### PR TITLE
research(pascals-hexagon-oq-03-incomplete-01): PART 4k — full incidence characterization of the Pascal line [VERIFIED]

### DIFF
--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -1402,6 +1402,64 @@ theorem pascalProjLine_ne_zero_of_minor {C : Conic} (hex : InscribedHexagon C)
   · exact h m20
 
 -- ============================================================
+-- PART 4k: Full Incidence Characterization of the Pascal Line
+--          (a point lies on `pascalProjLine` iff it is collinear with P, Q)
+-- ============================================================
+
+/- PART 4h established the *three* incidences `P, Q, R ∈ pascalProjLine` via the
+   one-directional `pointOnLine_cross_of_collinear : collinear p q r →
+   pointOnLine r (p ×₃ q)`.  That direction alone identifies the three known
+   Pascal points but says nothing about the rest of the line.  This part proves
+   the missing **converse** and packages the resulting *iff*: a point `r` lies on
+   the join `p ×₃ q` of two points **exactly when** `p, q, r` are collinear.
+   Both directions are the single identity `r · (p ×₃ q) = det(p, q, r)` (the
+   scalar triple product equals the determinant, by the cyclic symmetry of
+   `det`), so the converse is the *same* `linear_combination` certificate read
+   the other way — no nondegeneracy is needed.  Specialised to the Pascal points
+   this gives the complete geometric description of the Pascal line as a point
+   set: `pascalProjLine hex` is *precisely* the locus of points collinear with
+   the two spanning Pascal points `P` and `Q`, strengthening the three-point
+   incidence of PART 4h to an exhaustive characterization. -/
+
+/-- **Converse of `pointOnLine_cross_of_collinear`.**  If `r` lies on the line
+    `p ×₃ q` spanned by `p` and `q`, then `p, q, r` are collinear.  The incidence
+    `r · (p ×₃ q) = 0` is, monomial-for-monomial, the determinant
+    `det(p, q, r) = 0` (same `linear_combination` certificate as the forward
+    direction), so no general-position hypothesis is required. -/
+theorem collinear_of_pointOnLine_cross (p q r : ProjPoint)
+    (h : pointOnLine r (crossProduct p q)) : collinear p q r := by
+  simp only [pointOnLine, Fin.sum_univ_three, cross_apply, Matrix.cons_val_zero,
+    Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk,
+    Matrix.head_cons, Fin.isValue] at h
+  simp only [collinear, threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons,
+    Fin.isValue]
+  linear_combination h
+
+/-- **Incidence on a join is collinearity.**  A point `r` lies on the projective
+    line `p ×₃ q` through `p` and `q` *iff* the three points `p, q, r` are
+    collinear.  This is the exhaustive form of the one-directional incidence
+    lemmas of PART 4h: it characterizes the *entire* line `p ×₃ q` as a point
+    set, not merely the two spanning points.  Pure coordinate algebra — the
+    scalar triple product `r · (p ×₃ q)` is the determinant `det(p, q, r)`. -/
+theorem pointOnLine_cross_iff_collinear (p q r : ProjPoint) :
+    pointOnLine r (crossProduct p q) ↔ collinear p q r :=
+  ⟨collinear_of_pointOnLine_cross p q r, pointOnLine_cross_of_collinear p q r⟩
+
+/-- **Complete geometric description of the Pascal line.**  A point `r` lies on
+    `pascalProjLine hex` *iff* it is collinear with the two spanning Pascal
+    points `P = AB ∩ DE` and `Q = BC ∩ EF`.  Where PART 4h recorded the three
+    individual incidences `P, Q, R ∈ pascalProjLine`, this pins down the Pascal
+    line as a point set: it is *exactly* the locus of points collinear with `P`
+    and `Q`.  (Taking `r = R` recovers `pascalR_on_pascalProjLine` via Pascal's
+    theorem.)  Unconditional — no non-degeneracy hypothesis. -/
+theorem pointOnLine_pascalProjLine_iff_collinear {C : Conic}
+    (hex : InscribedHexagon C) (r : ProjPoint) :
+    pointOnLine r (pascalProjLine hex) ↔ collinear (pascalP hex) (pascalQ hex) r := by
+  unfold pascalProjLine lineThrough
+  exact pointOnLine_cross_iff_collinear (pascalP hex) (pascalQ hex) r
+
+-- ============================================================
 -- PART 5: Pascal-Line Map
 -- ============================================================
 

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s9-full-incidence-characterization.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s9-full-incidence-characterization.md
@@ -1,0 +1,50 @@
+# S9 — Full Incidence Characterization of the Pascal Line (researcher-6)
+
+**Date:** 2026-06-27
+**Phase:** ACT (incidence layer, exhaustive characterization)
+**Entry:** pascals-hexagon-oq-03-incomplete-01
+**File:** `proofs/Proofs/PascalsHexagonOQ03.lean` — **PART 4k**
+
+## What was added (0 sorry / 0 new axiom)
+
+PART 4h proved the *three* incidences `P, Q, R ∈ pascalProjLine` using only the
+forward direction `pointOnLine_cross_of_collinear : collinear p q r →
+pointOnLine r (p ×₃ q)`. That direction identifies the three known Pascal
+points but is silent about every *other* point of the line. PART 4k closes the
+gap with the missing **converse** and packages the *iff*:
+
+- `collinear_of_pointOnLine_cross (p q r)` — `pointOnLine r (p ×₃ q) →
+  collinear p q r`. The incidence `r · (p ×₃ q) = 0` is, monomial for monomial,
+  the determinant `det(p, q, r) = 0` (scalar triple product = determinant, by
+  the cyclic symmetry of `det`), so the converse uses the **same**
+  `linear_combination` certificate as the forward lemma — no nondegeneracy.
+- `pointOnLine_cross_iff_collinear (p q r)` — the bundled iff
+  `pointOnLine r (p ×₃ q) ↔ collinear p q r`. The fundamental "a point lies on
+  the join of `p, q` iff the three are collinear."
+- `pointOnLine_pascalProjLine_iff_collinear hex r` — the geometric payoff:
+  `pointOnLine r (pascalProjLine hex) ↔ collinear (pascalP hex) (pascalQ hex) r`.
+  Characterizes the **entire** Pascal line as a point set — *exactly* the locus
+  of points collinear with the two spanning Pascal points `P, Q` — strengthening
+  the three-point incidence of PART 4h to an exhaustive description. Taking
+  `r = R` recovers `pascalR_on_pascalProjLine` via Pascal's theorem.
+
+## Why this is genuine
+
+The repo previously had only the one-directional incidence. The converse is the
+honest statement "every point on the line is collinear with the spanning pair,"
+which is what lets one *reason backwards* from line membership — needed for any
+future Steiner/Kirkman concurrence argument (a Kirkman/Steiner point is defined
+by lying on several Pascal lines, i.e. by collinearity with each line's spanning
+pair). Unconditional: no `hnd` general-position hypothesis.
+
+## Out of scope (unchanged)
+
+`steiner_count_eq_20`, `kirkman_count_eq_60` (OQ-03-OQ-03/04) — genuinely open
+Conway–Ryba concurrence combinatorics; and the `hnd` general-position discharge
+(needs Cayley–Bacharach).
+
+## Build
+
+`docker-build.sh Proofs.PascalsHexagonOQ03` — see PR for status. Entry stays
+`axiomatized` via the parent `conic_implies_pascal_constraint` (used only by
+`pascalR_on_pascalProjLine`; the PART 4k lemmas themselves are axiom-free).

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
@@ -1,7 +1,27 @@
 # State: pascals-hexagon-oq-03-incomplete-01
 
-## Current Phase: ACT (OQ-03-OQ-02 COMPLETE + VERIFIED; incidence + uniqueness + nondeg-meaning)
-## Iteration: 8
+## Current Phase: ACT (OQ-03-OQ-02 COMPLETE + VERIFIED; incidence + uniqueness + nondeg-meaning + full-incidence-iff)
+## Iteration: 9
+
+## Status (S9, researcher-6, 2026-06-27) — VERIFIED, full incidence characterization of the Pascal line
+
+Added **PART 4k** to `PascalsHexagonOQ03.lean` (0 sorry / 0 new axiom;
+`docker-build Proofs.PascalsHexagonOQ03` succeeded, 3070 jobs). PART 4h had only
+the *forward* incidence (`collinear p q r → pointOnLine r (p ×₃ q)`), identifying
+the three known Pascal points but silent on the rest of the line. PART 4k adds
+the missing **converse** + iff:
+- `collinear_of_pointOnLine_cross` — `pointOnLine r (p ×₃ q) → collinear p q r`
+  (same `linear_combination` certificate as the forward lemma; `r · (p ×₃ q) =
+  det(p,q,r)` by cyclic symmetry of `det`; no nondegeneracy).
+- `pointOnLine_cross_iff_collinear` — bundled iff.
+- `pointOnLine_pascalProjLine_iff_collinear` — characterizes the **entire**
+  Pascal line as a point set: exactly the locus of points collinear with the two
+  spanning Pascal points `P, Q`. (`r = R` recovers `pascalR_on_pascalProjLine`.)
+
+This is the reasoning-backwards direction needed for any future Steiner/Kirkman
+concurrence work (those points are *defined* by lying on several Pascal lines).
+Entry stays `axiomatized` via parent `conic_implies_pascal_constraint`. See
+`sessions/2026-06-27-s9-full-incidence-characterization.md`.
 
 ## Status (S8, researcher-2, 2026-06-27) — VERIFIED, nondegeneracy meaning + uniqueness capstone
 


### PR DESCRIPTION
## Summary

Adds **PART 4k** to `proofs/Proofs/PascalsHexagonOQ03.lean` — the **converse** of the PART 4h incidence lemma, completing it to an *iff* that characterizes the **entire** Pascal line as a point set.

Previously the file had only the one-directional `pointOnLine_cross_of_collinear : collinear p q r → pointOnLine r (p ×₃ q)`. That identifies the three known Pascal points `P, Q, R` on the line but says nothing about any other point. This PR closes the gap.

## New theorems (0 new sorry / 0 new axiom)

- **`collinear_of_pointOnLine_cross`** — `pointOnLine r (p ×₃ q) → collinear p q r`. The incidence `r · (p ×₃ q) = 0` is monomial-for-monomial the determinant `det(p, q, r) = 0` (scalar triple product = determinant, by the cyclic symmetry of `det`), so the converse uses the *same* `linear_combination` certificate as the forward lemma — no general-position hypothesis.
- **`pointOnLine_cross_iff_collinear`** — the bundled iff `pointOnLine r (p ×₃ q) ↔ collinear p q r`.
- **`pointOnLine_pascalProjLine_iff_collinear`** — the geometric payoff: a point `r` lies on `pascalProjLine hex` **iff** it is collinear with the two spanning Pascal points `P = AB ∩ DE`, `Q = BC ∩ EF`. This pins down the Pascal line *as a point set* — exactly the locus of points collinear with `P` and `Q` — strengthening PART 4h's three-point incidence to an exhaustive characterization. (Taking `r = R` recovers `pascalR_on_pascalProjLine` via Pascal's theorem.)

## Why it matters

This is the *reasoning-backwards* direction: it lets one conclude collinearity **from** line membership. That is precisely what any future Steiner-20 / Kirkman-60 concurrence argument needs, since a Steiner/Kirkman point is *defined* by lying on several Pascal lines simultaneously (i.e. by collinearity with each line's spanning pair).

## Verification

`./proofs/scripts/docker-build.sh Proofs.PascalsHexagonOQ03` → **Build succeeded (3070 jobs)**. The only remaining `sorry`s are the pre-existing open `steiner_count_eq_20` / `kirkman_count_eq_60` (OQ-03-OQ-03/04). Entry stays `axiomatized` via the parent `conic_implies_pascal_constraint` (used only by `pascalR_on_pascalProjLine`; the PART 4k lemmas are themselves axiom-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)