### PR TITLE
research(fourth-root-2-irrational-oq-02): exact degree [ℚ(p^{1/n}):ℚ]=n for every prime radical [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FourthRoot2IrrationalOQ02.lean
+++ b/proofs/Proofs/FourthRoot2IrrationalOQ02.lean
@@ -1,0 +1,127 @@
+/-
+# The exact algebraic degree of every prime radical: [ℚ(p^{1/n}) : ℚ] = n
+  (fourth-root-2-irrational OQ-02)
+
+The parent gallery entry **fourth-root-2-irrational** (`FourthRoot2Degree4.lean`)
+proves that `⁴√2` has degree exactly 4 over ℚ, via Eisenstein's criterion at the
+prime 2 on `X⁴ − 2` followed by Gauss's lemma. Its open question OQ-02 asks
+whether that Eisenstein-then-Gauss route can be **packaged as a reusable lemma**
+for `X^{2^k} − 2` (or `X^{p^k} − p`), filling the even-exponent / prime-power gap
+that Mathlib's Kummer lemmas (`X_pow_sub_C_irreducible_of_prime_pow`, which needs
+`p ≠ 2`, and `…_of_odd`, which needs odd exponent) mark with explicit `TODO`s.
+
+The *irreducibility* half of that packaging already exists in the gallery:
+`CubeRoot3IrrationalOQ01.irreducible_X_pow_sub_C_prime_{int,rat}` proves `Xⁿ − p`
+irreducible over ℤ and ℚ for **every** prime `p` and **every** `n ≥ 1` — with no
+parity or prime-power restriction — and `NthRootIrrationalOQ01` uses it to prove
+`p^{1/n}` *irrational*. But irrationality only certifies algebraic degree `≥ 2`.
+No file pins the degree of the real radical at *exactly* `n`.
+
+This file closes that gap. Building directly on the existing irreducibility
+lemma, it identifies the **minimal polynomial of the real radical** and computes
+the **exact field degree**, uniformly in `p` and `n`:
+
+  * `minpoly_primeRoot`          — `minpoly ℚ (p^{1/n}) = Xⁿ − p`;
+  * `finrank_adjoin_primeRoot`   — `[ℚ(p^{1/n}) : ℚ] = n`;
+  * `linearIndependent_primeRoot_powers` — `{1, r, …, rⁿ⁻¹}` are ℚ-independent.
+
+The headline specializations are exactly the cases OQ-02 names:
+
+  * `finrank_adjoin_two_pow_k` — `[ℚ(2^{1/2^k}) : ℚ] = 2^k`   (the even / prime-power exponent `2^k`);
+  * `finrank_adjoin_prime_pow` — `[ℚ(p^{1/p^k}) : ℚ] = p^k`   (the general `X^{p^k} − p` case);
+  * `finrank_adjoin_fourthRoot_two` — `[ℚ(2^{1/4}) : ℚ] = 4`, recovering the parent.
+
+The real radical is modeled as `(p : ℝ) ^ ((1 : ℝ) / n)` (`Real.rpow`), matching
+`NthRootIrrationalOQ01`, so the present degree results sit on top of that file's
+irrationality results for the *same* term.
+
+Zero axioms; reuses only Mathlib and the sibling irreducibility lemma.
+-/
+import Mathlib
+import Proofs.CubeRoot3IrrationalOQ01
+
+open Polynomial IntermediateField
+
+namespace FourthRoot2IrrationalOQ02
+
+/-! ### The real radical and its defining power relation -/
+
+/-- `(p^{1/n})ⁿ = p` for `p > 0`, `n ≥ 1`: the real `n`-th root of `p`, modeled as
+`Real.rpow`, raised back to the `n`-th power returns `p`. -/
+theorem rpow_inv_natCast_pow {p n : ℕ} (hp : 0 < p) (hn : 0 < n) :
+    ((p : ℝ) ^ ((1 : ℝ) / n)) ^ n = (p : ℝ) := by
+  rw [← Real.rpow_natCast ((p : ℝ) ^ ((1 : ℝ) / n)) n,
+      ← Real.rpow_mul (by positivity : (0 : ℝ) ≤ p)]
+  have hn' : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  rw [one_div, inv_mul_cancel₀ hn', Real.rpow_one]
+
+/-- The real radical `p^{1/n}` is a root of `Xⁿ − p` over ℚ. -/
+theorem aeval_primeRoot {p n : ℕ} (hp : 0 < p) (hn : 0 < n) :
+    (Polynomial.aeval ((p : ℝ) ^ ((1 : ℝ) / n))) (X ^ n - C (p : ℚ)) = 0 := by
+  simp only [map_sub, map_pow, aeval_X, rpow_inv_natCast_pow hp hn,
+    map_natCast, sub_self]
+
+/-- `p^{1/n}` is integral over ℚ: a root of the monic `Xⁿ − p`. -/
+theorem primeRoot_isIntegral {p n : ℕ} (hp : 0 < p) (hn : 0 < n) :
+    IsIntegral ℚ ((p : ℝ) ^ ((1 : ℝ) / n)) :=
+  ⟨X ^ n - C (p : ℚ), monic_X_pow_sub_C _ hn.ne', aeval_primeRoot hp hn⟩
+
+/-! ### The minimal polynomial and the exact degree -/
+
+/-- **The minimal polynomial of `p^{1/n}` over ℚ is `Xⁿ − p`.** This uses the
+sibling irreducibility lemma (Eisenstein at `p` + Gauss) and the fact that the
+radical is a root of the monic `Xⁿ − p`. It is the sharp statement: the radical's
+minimal polynomial is *the* full Eisenstein polynomial, not a proper factor. -/
+theorem minpoly_primeRoot {p n : ℕ} (hp : p.Prime) (hn : 0 < n) :
+    minpoly ℚ ((p : ℝ) ^ ((1 : ℝ) / n)) = X ^ n - C (p : ℚ) :=
+  (minpoly.eq_of_irreducible_of_monic
+    (CubeRoot3IrrationalOQ01.irreducible_X_pow_sub_C_prime_rat hp hn)
+    (aeval_primeRoot hp.pos hn)
+    (monic_X_pow_sub_C _ hn.ne')).symm
+
+/-- The minimal polynomial of `p^{1/n}` has degree exactly `n`. -/
+theorem minpoly_natDegree_primeRoot {p n : ℕ} (hp : p.Prime) (hn : 0 < n) :
+    (minpoly ℚ ((p : ℝ) ^ ((1 : ℝ) / n))).natDegree = n := by
+  rw [minpoly_primeRoot hp hn, natDegree_X_pow_sub_C]
+
+/-- **The exact field degree `[ℚ(p^{1/n}) : ℚ] = n`** for every prime `p` and
+every `n ≥ 1`. This is strictly stronger than irrationality (degree `≥ 2`): it
+pins the algebraic degree of the real radical at exactly `n`, with no parity or
+prime-power restriction on the exponent. -/
+theorem finrank_adjoin_primeRoot {p n : ℕ} (hp : p.Prime) (hn : 0 < n) :
+    Module.finrank ℚ ℚ⟮((p : ℝ) ^ ((1 : ℝ) / n))⟯ = n := by
+  rw [IntermediateField.adjoin.finrank (primeRoot_isIntegral hp.pos hn),
+      minpoly_natDegree_primeRoot hp hn]
+
+/-- **The power basis `{1, r, r², …, rⁿ⁻¹}` of `r = p^{1/n}` is ℚ-linearly
+independent.** Immediate from `[ℚ(r):ℚ] = n`: the powers below the minimal-
+polynomial degree are independent. Generalizes the parent's
+`linearIndependent_fr2_powers` (the `Fin 4` case for `⁴√2`). -/
+theorem linearIndependent_primeRoot_powers {p n : ℕ} (hp : p.Prime) (hn : 0 < n) :
+    LinearIndependent ℚ (fun i : Fin n => ((p : ℝ) ^ ((1 : ℝ) / n)) ^ (i : ℕ)) := by
+  have h := linearIndependent_pow (K := ℚ) ((p : ℝ) ^ ((1 : ℝ) / n))
+  rw [minpoly_natDegree_primeRoot hp hn] at h
+  exact h
+
+/-! ### The headline specializations named by OQ-02 -/
+
+/-- **`[ℚ(2^{1/2^k}) : ℚ] = 2^k`** — the even / prime-power exponent `2^k`. This is
+precisely the case Mathlib's Kummer API cannot reach (it requires `p ≠ 2` or odd
+exponent); Eisenstein at 2 is exponent-agnostic and handles it uniformly. -/
+theorem finrank_adjoin_two_pow_k (k : ℕ) :
+    Module.finrank ℚ ℚ⟮(((2 : ℕ) : ℝ) ^ ((1 : ℝ) / ((2 ^ k : ℕ) : ℝ)))⟯ = 2 ^ k :=
+  finrank_adjoin_primeRoot (p := 2) (n := 2 ^ k) (by norm_num) (by positivity)
+
+/-- **`[ℚ(p^{1/p^k}) : ℚ] = p^k`** — the general `X^{p^k} − p` case named by OQ-02,
+for an arbitrary prime `p`. -/
+theorem finrank_adjoin_prime_pow {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    Module.finrank ℚ ℚ⟮((p : ℝ) ^ ((1 : ℝ) / ((p ^ k : ℕ) : ℝ)))⟯ = p ^ k :=
+  finrank_adjoin_primeRoot hp (pow_pos hp.pos k)
+
+/-- **`[ℚ(2^{1/4}) : ℚ] = 4`** — recovering the parent entry's `finrank_adjoin_fr2`
+as the `k = 2` instance of `finrank_adjoin_two_pow_k` (note `2^{1/4} = ⁴√2`). -/
+theorem finrank_adjoin_fourthRoot_two :
+    Module.finrank ℚ ℚ⟮(((2 : ℕ) : ℝ) ^ ((1 : ℝ) / ((4 : ℕ) : ℝ)))⟯ = 4 :=
+  finrank_adjoin_primeRoot (p := 2) (n := 4) (by norm_num) (by norm_num)
+
+end FourthRoot2IrrationalOQ02

--- a/research/problems/fourth-root-2-irrational-oq-02/sessions/2026-06-27-s1-exact-degree-of-prime-radicals.md
+++ b/research/problems/fourth-root-2-irrational-oq-02/sessions/2026-06-27-s1-exact-degree-of-prime-radicals.md
@@ -1,0 +1,81 @@
+# S1 (researcher-1, 2026-06-27) — ACT: exact field degree of prime radicals [VERIFIED, 0-axiom]
+
+## Problem
+
+`fourth-root-2-irrational-oq-02`: can the Eisenstein-then-Gauss route be packaged
+as a reusable lemma for `X^{2^k} − 2` (or `X^{p^k} − p`), filling the
+even-exponent / prime-power gap that Mathlib's Kummer lemmas
+(`X_pow_sub_C_irreducible_of_prime_pow` needs `p ≠ 2`; `…_of_odd` needs odd `n`)
+mark with explicit `TODO`s?
+
+## Assessment of prior gallery state (avoid duplication)
+
+The *irreducibility* half of OQ-02 is **already in the gallery**:
+
+- `CubeRoot3IrrationalOQ01.irreducible_X_pow_sub_C_prime_{int,rat}` — `Xⁿ − p`
+  irreducible over ℤ and ℚ for **every** prime `p` and **every** `n ≥ 1`
+  (Eisenstein at `(p)` + Gauss). No parity / prime-power restriction. This already
+  subsumes `X^{2^k} − 2` and `X^{p^k} − p`.
+- `NthRootIrrationalOQ01.irrational_nthRoot_of_prime` — uses it to prove
+  `(p:ℝ)^(1/n)` irrational, but only via *degree ≥ 2*.
+
+So the literal "reusable irreducibility lemma" already exists. The **genuine
+remaining gap** is the sharp consequence for the *real* radical: nobody had
+identified `minpoly ℚ ((p:ℝ)^(1/n))` or computed the *exact* degree
+`[ℚ(p^{1/n}):ℚ] = n`. (The sibling `cube-root-3-irrational-oq-01` even lists
+exactly this — "connect to `minpoly ℚ (p^{1/n} : ℝ)`" and "exhibit the ℚ-basis" —
+as its own open questions.) The parent `FourthRoot2Degree4` proved it only for
+`n = 4`.
+
+## What this session added (`FourthRoot2IrrationalOQ02.lean`, 127 L, 0 sorry / 0 axiom)
+
+Imports `Mathlib` + `Proofs.CubeRoot3IrrationalOQ01` (reuses the irreducibility
+lemma rather than re-deriving it).
+
+- `rpow_inv_natCast_pow` — `((p:ℝ)^(1/n))ⁿ = p` (`Real.rpow` bookkeeping).
+- `aeval_primeRoot` / `primeRoot_isIntegral` — the radical is an integral root of
+  the monic `Xⁿ − C p` over ℚ.
+- `minpoly_primeRoot` — **`minpoly ℚ ((p:ℝ)^(1/n)) = Xⁿ − C p`** via
+  `minpoly.eq_of_irreducible_of_monic` + the sibling irreducibility lemma.
+- `finrank_adjoin_primeRoot` — **`[ℚ(p^{1/n}):ℚ] = n`**, every prime `p`, `n ≥ 1`.
+  Strictly stronger than irrationality. Generalizes parent's `finrank_adjoin_fr2`.
+- `linearIndependent_primeRoot_powers` — power basis `{1,…,rⁿ⁻¹}` ℚ-independent
+  (generalizes parent's `Fin 4` statement to `Fin n`).
+- Specializations named by OQ-02:
+  - `finrank_adjoin_two_pow_k` — `[ℚ(2^{1/2^k}):ℚ] = 2^k` (the Kummer-API gap).
+  - `finrank_adjoin_prime_pow` — `[ℚ(p^{1/p^k}):ℚ] = p^k`.
+  - `finrank_adjoin_fourthRoot_two` — `[ℚ(2^{1/4}):ℚ] = 4` (recovers the parent).
+
+## Gotchas
+
+- **Wrote the file to the MAIN repo path first** (`/…/lean-genius/proofs/…`)
+  instead of the worktree — the `Write` absolute path didn't include
+  `.loom/worktrees/researcher-1`. Docker build mounts the *worktree* (REPO_ROOT
+  derived from the script's own location) → "no such file". Moved it into the
+  worktree (and out of main, where an untracked scratch `.lean` can block the
+  deployer's `git pull`).
+- **Concrete-numeral specializations timed out** (`isDefEq`/`whnf`, 200k
+  heartbeats). Writing `ℚ⟮(2:ℝ)^((1:ℝ)/4)⟯` makes the radical `(2:ℝ)=OfNat 2`,
+  `4`, which don't *syntactically* match the general lemma's `↑(2:ℕ)`,
+  `↑(4:ℕ)`; the unifier ground on `Nat.cast_pow`/numeral whnf. Fix: write the
+  specialization terms with explicit `ℕ→ℝ` casts (`((2:ℕ):ℝ)`,
+  `((2^k:ℕ):ℝ)`) so they are *definitionally* the general lemma's conclusion.
+  (The all-variable `finrank_adjoin_prime_pow` did not time out — only the
+  concrete-numeral ones.)
+- Dropped `aeval_C` from one `simp only` (unusedSimpArgs lint flagged it).
+
+## Build
+
+`docker-build.sh Proofs.FourthRoot2IrrationalOQ02` → **Build succeeded
+(7744 jobs)**. 0 sorries, 0 `axiom`, no `native_decide`.
+
+## Status → progress (OQ-02 answered at the exact-degree level)
+
+The packaging OQ-02 requested is complete: exact algebraic degree of any prime
+radical, uniform across all exponents incl. the even / prime-power cases.
+
+## Follow-ups (depth guard: slug at `-oq-02`, depth 1 — follow-ups allowed)
+
+1. Exhibit an explicit `PowerBasis ℚ ℚ(p^{1/n})` (not just linear independence).
+2. The tower `ℚ ⊂ ℚ(p^{1/d}) ⊂ ℚ(p^{1/n})` for `d ∣ n` (generalizes
+   parent's `ℚ ⊂ ℚ(√2) ⊂ ℚ(⁴√2)`).

--- a/research/problems/fourth-root-2-irrational-oq-02/state.md
+++ b/research/problems/fourth-root-2-irrational-oq-02/state.md
@@ -1,0 +1,33 @@
+# State: fourth-root-2-irrational-oq-02
+
+## Current Phase: ACT (OQ-02 answered at the exact-degree level) — VERIFIED, 0-axiom
+## Iteration: 1
+
+## Status (S1, researcher-1, 2026-06-27) — VERIFIED
+
+Added `proofs/Proofs/FourthRoot2IrrationalOQ02.lean` (127 L, 0 sorry / 0 axiom,
+no `native_decide`; `docker-build` succeeded, 7744 jobs) + gallery entry
+`src/data/proofs/fourth-root-2-irrational-oq-02/` (meta.json + annotations.json).
+
+OQ-02's *irreducibility* packaging already existed
+(`CubeRoot3IrrationalOQ01.irreducible_X_pow_sub_C_prime_{int,rat}` — `Xⁿ − p`
+irreducible for all primes and all `n ≥ 1`). This session closes the genuine
+remaining gap: the **exact field degree of the real radical**.
+
+- `minpoly_primeRoot` — `minpoly ℚ ((p:ℝ)^(1/n)) = Xⁿ − C p`.
+- `finrank_adjoin_primeRoot` — `[ℚ(p^{1/n}):ℚ] = n` (every prime `p`, `n ≥ 1`).
+- `linearIndependent_primeRoot_powers` — power basis ℚ-independent.
+- Specializations: `[ℚ(2^{1/2^k}):ℚ]=2^k` (the Kummer-API gap),
+  `[ℚ(p^{1/p^k}):ℚ]=p^k`, `[ℚ(2^{1/4}):ℚ]=4` (recovers parent).
+
+Reuses the sibling irreducibility lemma via `import Proofs.CubeRoot3IrrationalOQ01`.
+Full notes: `sessions/2026-06-27-s1-exact-degree-of-prime-radicals.md`.
+
+## Next Action
+
+Optional follow-ups (not one-session-blocking): explicit `PowerBasis`; the
+divisor tower `ℚ ⊂ ℚ(p^{1/d}) ⊂ ℚ(p^{1/n})` for `d ∣ n`.
+
+## Out of scope
+
+Nothing blocking — the OQ-02 question is answered at the exact-degree level.

--- a/src/data/proofs/fourth-root-2-irrational-oq-02/annotations.json
+++ b/src/data/proofs/fourth-root-2-irrational-oq-02/annotations.json
@@ -1,0 +1,91 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "fourth-root-2-irrational-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "context",
+    "title": "Packaging the Eisenstein route: from irreducibility to exact degree",
+    "content": "The docstring frames the entry against the parent fourth-root-2-irrational (⁴√2 has degree 4 via Eisenstein on X⁴ − 2) and its open question OQ-02: package the route reusably for X^{2^k} − 2 / X^{p^k} − p, the even-exponent / prime-power cases Mathlib's Kummer API marks TODO. The irreducibility half already exists (CubeRoot3IrrationalOQ01 proves Xⁿ − p irreducible for all primes p and n ≥ 1); NthRootIrrationalOQ01 uses it for irrationality. The remaining gap — which this file closes — is the SHARP consequence for the real radical: its minimal polynomial and exact field degree, where irrationality only gives degree ≥ 2.",
+    "mathContext": "Eisenstein's criterion at a prime p is insensitive to the exponent's parity, so it covers exactly the cases the Kummer-theory lemmas leave open.",
+    "prerequisites": [
+      "Eisenstein's irreducibility criterion and Gauss's lemma",
+      "Minimal polynomial and degree of a simple algebraic extension"
+    ],
+    "relatedConcepts": [
+      "Eisenstein's criterion",
+      "Kummer theory",
+      "algebraic degree"
+    ],
+    "significance": "context"
+  },
+  {
+    "id": "ann-radical-power",
+    "proofId": "fourth-root-2-irrational-oq-02",
+    "range": {
+      "startLine": 49,
+      "endLine": 67
+    },
+    "type": "concept",
+    "title": "Bridging the analytic radical to the algebraic minimal polynomial",
+    "content": "The real radical is modeled as r = (p:ℝ)^(1/n) via Real.rpow, matching NthRootIrrationalOQ01 so the degree results sit on the same term as that file's irrationality results. rpow_inv_natCast_pow proves rⁿ = p^{(1/n)·n} = p^1 = p (Real.rpow_natCast, then Real.rpow_mul, then inv_mul_cancel₀ on the exponent). aeval_primeRoot evaluates Xⁿ − C p at r to rⁿ − p = 0, and primeRoot_isIntegral packages r as integral over ℚ with the monic witness Xⁿ − C p. This single power identity is the only bridge needed between the analytic and algebraic worlds.",
+    "mathContext": "An analytic object (a real n-th root) is certified as a root of a rational polynomial, making the field-theory machinery applicable.",
+    "prerequisites": [
+      "Real.rpow and its power laws",
+      "aeval and IsIntegral over a field"
+    ],
+    "relatedConcepts": [
+      "Real power function",
+      "integral element",
+      "monic polynomial"
+    ],
+    "significance": "key"
+  },
+  {
+    "id": "ann-minpoly-degree",
+    "proofId": "fourth-root-2-irrational-oq-02",
+    "range": {
+      "startLine": 69,
+      "endLine": 104
+    },
+    "type": "insight",
+    "title": "Irreducibility ⟹ exact degree, not merely irrationality",
+    "content": "minpoly_primeRoot identifies the minimal polynomial of r = p^{1/n} as EXACTLY Xⁿ − p, via minpoly.eq_of_irreducible_of_monic fed the sibling's irreducible_X_pow_sub_C_prime_rat together with monic-ness and the root fact. Then finrank_adjoin_primeRoot turns [ℚ(r):ℚ] into (minpoly ℚ r).natDegree = n through IntermediateField.adjoin.finrank. This is strictly stronger than irrationality (degree ≥ 2): it pins the algebraic degree at exactly n, with no parity or prime-power restriction. linearIndependent_primeRoot_powers then gives the ℚ-independent power basis {1, r, …, rⁿ⁻¹}, generalizing the parent's Fin 4 statement to Fin n.",
+    "mathContext": "Knowing the full minimal polynomial — not just that one exists of degree ≥ 2 — is what pins the extension degree and produces a basis.",
+    "prerequisites": [
+      "minpoly.eq_of_irreducible_of_monic",
+      "IntermediateField.adjoin.finrank",
+      "linearIndependent_pow"
+    ],
+    "relatedConcepts": [
+      "minimal polynomial",
+      "field degree",
+      "power basis"
+    ],
+    "significance": "key"
+  },
+  {
+    "id": "ann-specializations",
+    "proofId": "fourth-root-2-irrational-oq-02",
+    "range": {
+      "startLine": 106,
+      "endLine": 125
+    },
+    "type": "concept",
+    "title": "The exponents named by OQ-02, including the Kummer-API gap",
+    "content": "finrank_adjoin_two_pow_k gives [ℚ(2^{1/2^k}):ℚ] = 2^k — precisely the even / prime-power exponent Mathlib's X_pow_sub_C_irreducible_of_prime_pow (needs p ≠ 2) and …_of_odd (needs odd exponent) cannot reach. finrank_adjoin_prime_pow gives the general [ℚ(p^{1/p^k}):ℚ] = p^k. finrank_adjoin_fourthRoot_two recovers the parent's [ℚ(⁴√2):ℚ] = 4 as the k=2 instance. The concrete radical terms are written with explicit ℕ→ℝ casts so they are definitionally the general lemma's conclusion — writing them as real numerals instead triggers an isDefEq/whnf timeout.",
+    "mathContext": "Instantiating one general theorem at the named exponents is the 'reusable lemma' OQ-02 asked for, and it covers the Kummer-API TODO cases for free.",
+    "prerequisites": [
+      "Instantiating universally-quantified lemmas",
+      "Nat-to-Real cast normalization"
+    ],
+    "relatedConcepts": [
+      "prime-power exponent",
+      "Kummer theory TODO",
+      "definitional equality"
+    ],
+    "significance": "supporting"
+  }
+]

--- a/src/data/proofs/fourth-root-2-irrational-oq-02/meta.json
+++ b/src/data/proofs/fourth-root-2-irrational-oq-02/meta.json
@@ -1,0 +1,202 @@
+{
+  "id": "fourth-root-2-irrational-oq-02",
+  "title": "The Exact Algebraic Degree of Every Prime Radical: [ℚ(p^{1/n}) : ℚ] = n",
+  "slug": "fourth-root-2-irrational-oq-02",
+  "description": "Answers the parent ⁴√2 entry's open question OQ-02: package the Eisenstein-then-Gauss route as a reusable lemma for X^{2^k} − 2 and X^{p^k} − p, the even-exponent / prime-power cases Mathlib's Kummer API marks TODO. The irreducibility half already exists in the gallery (CubeRoot3IrrationalOQ01); this entry supplies the missing sharp consequence: it identifies the minimal polynomial of the REAL radical p^{1/n} as exactly Xⁿ − p and computes the exact field degree [ℚ(p^{1/n}):ℚ] = n for every prime p and every n ≥ 1, with the ℚ-linear independence of the power basis {1, r, …, rⁿ⁻¹}. This is strictly stronger than irrationality (degree ≥ 2): it pins the algebraic degree at exactly n. Headline specializations are the cases OQ-02 names: [ℚ(2^{1/2^k}):ℚ] = 2^k, [ℚ(p^{1/p^k}):ℚ] = p^k, and [ℚ(2^{1/4}):ℚ] = 4 (recovering the parent's finrank_adjoin_fr2). Zero axioms, zero sorries, no native_decide.",
+  "meta": {
+    "author": "Gotthold Eisenstein (1850); Carl Friedrich Gauss; formalized in Lean 4",
+    "date": "2026-06-27",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FourthRoot2IrrationalOQ02.lean",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "field-theory",
+      "minimal-polynomial",
+      "algebraic-degree",
+      "eisenstein-criterion",
+      "intermediate-field"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 127,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "originalContributions": [
+      "minpoly_primeRoot: the minimal polynomial of the real radical (p:ℝ)^(1/n) over ℚ is exactly Xⁿ − p, for every prime p and n ≥ 1. Built on the sibling irreducibility lemma (Eisenstein + Gauss) plus the fact that the radical is a root of the monic Xⁿ − p.",
+      "finrank_adjoin_primeRoot: the EXACT field degree [ℚ(p^{1/n}):ℚ] = n — strictly stronger than irrationality (degree ≥ 2), pinning the algebraic degree of the real radical at exactly n with no parity or prime-power restriction. Generalizes the parent's finrank_adjoin_fr2 (the n=4 case) to all primes and exponents.",
+      "linearIndependent_primeRoot_powers: the power basis {1, r, r², …, rⁿ⁻¹} of r = p^{1/n} is ℚ-linearly independent, generalizing the parent's linearIndependent_fr2_powers (Fin 4) to Fin n.",
+      "finrank_adjoin_two_pow_k: [ℚ(2^{1/2^k}):ℚ] = 2^k — the even / prime-power exponent case that Mathlib's Kummer lemmas (which need p ≠ 2 or odd exponent) cannot reach; Eisenstein at 2 is exponent-agnostic.",
+      "finrank_adjoin_prime_pow: [ℚ(p^{1/p^k}):ℚ] = p^k — the general X^{p^k} − p case explicitly named by the parent's OQ-02.",
+      "rpow_inv_natCast_pow / aeval_primeRoot / primeRoot_isIntegral: the Real.rpow bookkeeping showing (p^{1/n})ⁿ = p and that p^{1/n} is an integral root of Xⁿ − p over ℚ."
+    ],
+    "prerequisites": [
+      "The sibling general irreducibility lemma CubeRoot3IrrationalOQ01.irreducible_X_pow_sub_C_prime_rat (Eisenstein + Gauss for Xⁿ − p over ℚ)",
+      "minpoly.eq_of_irreducible_of_monic: a monic irreducible polynomial with a given root is the minimal polynomial",
+      "IntermediateField.adjoin.finrank: [K(x):K] equals the degree of the minimal polynomial of an integral x",
+      "Real.rpow arithmetic: (p^{1/n})ⁿ = p^{(1/n)·n} = p for p > 0, n ≥ 1"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "minpoly.eq_of_irreducible_of_monic",
+        "description": "If p is monic irreducible over a field and aeval x p = 0, then p = minpoly K x.",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "IntermediateField.adjoin.finrank",
+        "description": "For x integral over K, the field degree [K(x):K] equals (minpoly K x).natDegree.",
+        "module": "Mathlib.FieldTheory.Adjoin"
+      },
+      {
+        "theorem": "linearIndependent_pow",
+        "description": "For x with minimal polynomial of degree d, the powers x^0,…,x^{d-1} are linearly independent.",
+        "module": "Mathlib.FieldTheory.Minpoly.Field"
+      },
+      {
+        "theorem": "Real.rpow_natCast / Real.rpow_mul",
+        "description": "Real power identities used to show (p^{1/n})ⁿ = p.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry fourth-root-2-irrational proves that ⁴√2 has degree exactly 4 over ℚ, by Eisenstein's criterion at the prime 2 on X⁴ − 2 followed by Gauss's lemma. Its open question OQ-02 asks whether that Eisenstein-then-Gauss route can be packaged as a reusable lemma for X^{2^k} − 2 (or X^{p^k} − p), the cases Mathlib's Kummer-theory API explicitly cannot reach: X_pow_sub_C_irreducible_of_prime_pow requires p ≠ 2 and …_of_odd requires odd exponent, both leaving the even / prime-power case as a TODO.\n\nThe irreducibility half of that packaging is already in the gallery: CubeRoot3IrrationalOQ01 proves Xⁿ − p irreducible over ℤ and ℚ for every prime p and every n ≥ 1, and NthRootIrrationalOQ01 uses it to prove p^{1/n} irrational. But irrationality only certifies algebraic degree ≥ 2. This entry closes the remaining gap, the sharp statement the sibling entries leave open: the minimal polynomial of the REAL radical, and hence its EXACT field degree, uniformly in p and n.",
+    "problemStatement": "**Open Question (parent fourth-root-2-irrational, OQ-02)**: can the Eisenstein-then-Gauss route be packaged as a reusable lemma for X^{2^k} − 2 (or X^{p^k} − p), filling the even-exponent gap that Mathlib's Kummer lemmas mark with TODO comments?\n\n**This entry**: for every prime p and every n ≥ 1, minpoly ℚ ((p:ℝ)^{1/n}) = Xⁿ − p and [ℚ(p^{1/n}):ℚ] = n, with the power basis {1,…,rⁿ⁻¹} ℚ-independent; specialized to the even / prime-power exponents 2^k and p^k.",
+    "text": "A 127-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing Mathlib and the sibling irreducibility lemma. minpoly_primeRoot identifies the minimal polynomial; finrank_adjoin_primeRoot computes the exact degree; linearIndependent_primeRoot_powers gives the power basis; three specializations instantiate the 2^k, p^k, and n=4 cases named by OQ-02.",
+    "proofStrategy": "Model the real radical as r = (p:ℝ)^{1/n} via Real.rpow. (1) rpow_inv_natCast_pow shows rⁿ = p^{(1/n)·n} = p^1 = p (Real.rpow_natCast then Real.rpow_mul, then inv_mul_cancel₀). (2) aeval_primeRoot: aeval r (Xⁿ − C p) = rⁿ − p = 0, so r is integral over ℚ (primeRoot_isIntegral, witness the monic Xⁿ − C p). (3) minpoly_primeRoot: by minpoly.eq_of_irreducible_of_monic applied to the sibling's irreducible_X_pow_sub_C_prime_rat and the monic/root facts, the minimal polynomial is exactly Xⁿ − C p. (4) finrank_adjoin_primeRoot: IntermediateField.adjoin.finrank turns [ℚ(r):ℚ] into (minpoly ℚ r).natDegree = (Xⁿ − C p).natDegree = n. (5) linearIndependent_pow gives the power-basis independence at the known degree n. The specializations instantiate p and n; the radical terms are written with explicit ℕ→ℝ casts so they match the general lemma's conclusion definitionally (avoiding a whnf blow-up on concrete numerals).",
+    "keyInsights": [
+      "Eisenstein at p is exponent-agnostic: it cares only that p divides every lower coefficient once, never about the parity or prime-power structure of n — exactly why it fills the gap Mathlib's Kummer API leaves at p = 2 and even exponents.",
+      "Irreducibility ⟹ exact degree, not just irrationality: identifying Xⁿ − p as the FULL minimal polynomial (a monic irreducible the radical satisfies) pins [ℚ(p^{1/n}):ℚ] at exactly n, where irrationality alone only gives degree ≥ 2.",
+      "The real radical p^{1/n} (an analytic object via Real.rpow) and the algebraic minimal polynomial Xⁿ − p (a polynomial object) are bridged by a single power identity rⁿ = p; everything else is field-theory bookkeeping.",
+      "Stating concrete specializations with explicit ℕ→ℝ casts (rather than real numerals) keeps the radical syntactically equal to the general lemma's conclusion, dodging an isDefEq/whnf timeout that real numerals would trigger.",
+      "This generalizes the parent's three n=4 results (minpoly, finrank, power basis) to a single family parameterized by p and n, recovering ⁴√2 as the k=2 instance of the 2^k specialization."
+    ]
+  },
+  "sections": [
+    {
+      "id": "radical-power",
+      "title": "The Real Radical and Its Power Relation",
+      "startLine": 49,
+      "endLine": 67,
+      "summary": "rpow_inv_natCast_pow ((p^{1/n})ⁿ = p), aeval_primeRoot (root of Xⁿ − p), and primeRoot_isIntegral (integral over ℚ).",
+      "mathContext": "Bridges the analytic Real.rpow radical to the algebraic minimal-polynomial setting."
+    },
+    {
+      "id": "minpoly-degree",
+      "title": "Minimal Polynomial and Exact Degree",
+      "startLine": 69,
+      "endLine": 104,
+      "summary": "minpoly_primeRoot (minpoly = Xⁿ − p), minpoly_natDegree_primeRoot (degree n), finrank_adjoin_primeRoot ([ℚ(p^{1/n}):ℚ] = n), and linearIndependent_primeRoot_powers (power basis).",
+      "mathContext": "The core sharp results: exact algebraic degree and a ℚ-basis."
+    },
+    {
+      "id": "specializations",
+      "title": "The Exponents Named by OQ-02",
+      "startLine": 106,
+      "endLine": 125,
+      "summary": "finrank_adjoin_two_pow_k ([ℚ(2^{1/2^k}):ℚ] = 2^k), finrank_adjoin_prime_pow ([ℚ(p^{1/p^k}):ℚ] = p^k), finrank_adjoin_fourthRoot_two ([ℚ(2^{1/4}):ℚ] = 4).",
+      "mathContext": "Instantiates the even / prime-power cases Mathlib's Kummer API marks TODO, and recovers the parent."
+    }
+  ],
+  "conclusion": {
+    "summary": "Building on the gallery's existing general Eisenstein+Gauss irreducibility lemma, this entry proves the sharp consequence for the real radical: minpoly ℚ ((p:ℝ)^{1/n}) = Xⁿ − p and [ℚ(p^{1/n}):ℚ] = n for every prime p and n ≥ 1, with the power basis {1,…,rⁿ⁻¹} ℚ-independent. It specializes to the even / prime-power exponents 2^k and p^k that Mathlib's Kummer API marks TODO, and recovers the parent's [ℚ(⁴√2):ℚ] = 4 as the k=2 case.",
+    "implications": "The packaging requested by OQ-02 is complete: a single family of lemmas yields the exact algebraic degree of any prime radical, uniformly across all exponents including the even and prime-power cases. This is the field-degree refinement of the irrationality results in NthRootIrrationalOQ01 (same real term p^{1/n}), and generalizes the parent's degree-4 computation for ⁴√2.",
+    "openQuestions": [
+      "Exhibit an explicit ℚ-basis {1, r, …, rⁿ⁻¹} as a PowerBasis ℚ ℚ(r) (not just linear independence), giving the integral structure.",
+      "Extend from Xⁿ − p to Xⁿ − a for a squarefree-at-some-prime a, where Eisenstein still applies after a prime-factor analysis.",
+      "Build the quadratic/abelian tower ℚ ⊂ ℚ(p^{1/d}) ⊂ ℚ(p^{1/n}) for d ∣ n, generalizing the parent's ℚ ⊂ ℚ(√2) ⊂ ℚ(⁴√2)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fourth-root-2-irrational",
+      "relationship": "extends",
+      "description": "Parent: proves ⁴√2 has degree exactly 4 via Eisenstein on X⁴ − 2 and asks (OQ-02) for a reusable lemma covering X^{2^k} − 2 / X^{p^k} − p. This entry supplies the exact-degree statement for all primes and exponents."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-01",
+      "relationship": "builds-on",
+      "description": "Reuses irreducible_X_pow_sub_C_prime_rat (the general Eisenstein+Gauss irreducibility of Xⁿ − p) and supplies the minimal-polynomial / field-degree consequence that entry listed as its own open question."
+    },
+    {
+      "targetId": "nth-root-irrational-oq-01",
+      "relationship": "related",
+      "description": "That entry proves p^{1/n} irrational (degree ≥ 2) for the same Real.rpow term; this entry sharpens it to the exact degree n."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CubeRoot3IrrationalOQ01"
+    ],
+    "opens": [
+      "Polynomial",
+      "IntermediateField"
+    ],
+    "namespace": "FourthRoot2IrrationalOQ02",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "finrank_adjoin_primeRoot",
+        "type": "core",
+        "description": "The exact field degree [ℚ(p^{1/n}):ℚ] = n for every prime p and n ≥ 1.",
+        "leanType": "{p n : ℕ} → p.Prime → 0 < n → Module.finrank ℚ ℚ⟮(p : ℝ) ^ ((1 : ℝ) / n)⟯ = n"
+      },
+      {
+        "name": "minpoly_primeRoot",
+        "type": "key",
+        "description": "The minimal polynomial of the real radical p^{1/n} over ℚ is exactly Xⁿ − p.",
+        "leanType": "{p n : ℕ} → p.Prime → 0 < n → minpoly ℚ ((p : ℝ) ^ ((1 : ℝ) / n)) = X ^ n - C (p : ℚ)"
+      },
+      {
+        "name": "finrank_adjoin_two_pow_k",
+        "type": "key",
+        "description": "[ℚ(2^{1/2^k}):ℚ] = 2^k — the even / prime-power exponent case Mathlib's Kummer API cannot reach.",
+        "leanType": "(k : ℕ) → Module.finrank ℚ ℚ⟮((2 : ℕ) : ℝ) ^ ((1 : ℝ) / ((2 ^ k : ℕ) : ℝ))⟯ = 2 ^ k"
+      }
+    ],
+    "path": "Proofs/FourthRoot2IrrationalOQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "finrank_adjoin_primeRoot",
+      "type": "core",
+      "description": "Exact field degree [ℚ(p^{1/n}):ℚ] = n for every prime p, n ≥ 1.",
+      "leanType": "{p n : ℕ} → p.Prime → 0 < n → Module.finrank ℚ ℚ⟮(p : ℝ) ^ ((1 : ℝ) / n)⟯ = n"
+    },
+    {
+      "name": "minpoly_primeRoot",
+      "type": "key",
+      "description": "minpoly ℚ ((p:ℝ)^{1/n}) = Xⁿ − p.",
+      "leanType": "{p n : ℕ} → p.Prime → 0 < n → minpoly ℚ ((p : ℝ) ^ ((1 : ℝ) / n)) = X ^ n - C (p : ℚ)"
+    },
+    {
+      "name": "finrank_adjoin_prime_pow",
+      "type": "supporting",
+      "description": "[ℚ(p^{1/p^k}):ℚ] = p^k — the general X^{p^k} − p case named by OQ-02.",
+      "leanType": "{p : ℕ} → p.Prime → (k : ℕ) → Module.finrank ℚ ℚ⟮(p : ℝ) ^ ((1 : ℝ) / ((p ^ k : ℕ) : ℝ))⟯ = p ^ k"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Eisenstein, Gotthold",
+      "title": "Über die Irreductibilität und einige andere Eigenschaften der Gleichung...",
+      "year": "1850",
+      "venue": "Journal für die reine und angewandte Mathematik 39, 160–179",
+      "note": "Original irreducibility criterion"
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, 3rd ed., §13.2 (Algebraic Extensions), §9.4 (Irreducibility)",
+      "note": "Degree of a simple algebraic extension equals the degree of the minimal polynomial"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent **fourth-root-2-irrational** entry's open question **OQ-02** — *"package the Eisenstein-then-Gauss route as a reusable lemma for `X^{2^k} − 2` (or `X^{p^k} − p`), filling the even-exponent gap Mathlib's Kummer lemmas mark with TODO"* — at the **sharp, exact-degree level**.

The *irreducibility* half of OQ-02 already exists in the gallery: `CubeRoot3IrrationalOQ01.irreducible_X_pow_sub_C_prime_{int,rat}` proves `Xⁿ − p` irreducible over ℤ and ℚ for **every** prime `p` and **every** `n ≥ 1` (no parity / prime-power restriction). `NthRootIrrationalOQ01` uses it for *irrationality* — but only via degree ≥ 2. **The genuine remaining gap** (listed as an open question by the sibling entry itself) is the consequence for the *real* radical: nobody had identified `minpoly ℚ ((p:ℝ)^(1/n))` or computed the **exact** degree. The parent did it only for `n = 4`.

This PR closes that gap. New file `proofs/Proofs/FourthRoot2IrrationalOQ02.lean` (127 L, **0 sorry / 0 axiom**, no `native_decide`), reusing the sibling irreducibility lemma via `import Proofs.CubeRoot3IrrationalOQ01`:

- `minpoly_primeRoot` — `minpoly ℚ ((p:ℝ)^(1/n)) = Xⁿ − p`.
- `finrank_adjoin_primeRoot` — **`[ℚ(p^{1/n}):ℚ] = n`** for every prime `p`, `n ≥ 1`. Strictly stronger than irrationality; generalizes the parent's `finrank_adjoin_fr2` (n=4) to all primes/exponents.
- `linearIndependent_primeRoot_powers` — the power basis `{1, r, …, rⁿ⁻¹}` is ℚ-independent (parent's `Fin 4` → `Fin n`).
- Specializations named by OQ-02: `finrank_adjoin_two_pow_k` (`[ℚ(2^{1/2^k}):ℚ]=2^k`, the even / prime-power case the Kummer API can't reach), `finrank_adjoin_prime_pow` (`[ℚ(p^{1/p^k}):ℚ]=p^k`), `finrank_adjoin_fourthRoot_two` (`[ℚ(2^{1/4}):ℚ]=4`, recovering the parent).

## Verification

`./proofs/scripts/docker-build.sh Proofs.FourthRoot2IrrationalOQ02` → **Build succeeded (7744 jobs)**. 0 sorries, 0 `axiom` declarations, no `native_decide`, no structure-encoded assumptions → `status: verified`.

## Gallery

Adds `src/data/proofs/fourth-root-2-irrational-oq-02/` (meta.json + annotations.json) and research session notes/state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)