### PR TITLE
Enrich Erdős #10 OQ-04 lower density of S₁ (erdos-10-oq-04): annotation depth

### DIFF
--- a/src/data/proofs/erdos-10-oq-04/annotations.json
+++ b/src/data/proofs/erdos-10-oq-04/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "OQ-04: the exact lower density of S₁ is open — what is and is not formalized",
     "content": "Erdős Problem #10 asks for a finite k with every large integer a prime plus at most k powers of 2. The k = 1 set is S₁ = {p} ∪ {p + 2ᵃ}. The fourth open question asks for the exact lower density d̲(S₁). This is genuinely unknown: Romanoff (1934) proved d̲(S₁) > 0 and Erdős (1950, covering congruences) gave d̲(S₁) < 1, but neither the exact value nor the sharpest explicit bounds are known. This file deliberately does NOT claim the open question. It supplies the verified, 0-axiom scaffolding the parent file was missing entirely (the parent has definitions and zero theorems): a clean membership characterization, monotonicity of the family Sₖ, and the order/analytic facts about lower density.",
-    "mathContext": "S₁ = { n : n = p or n = p + 2ᵃ, p prime }. Known: 0 < d̲(S₁) < 1. Open: the exact value of d̲(S₁)."
+    "mathContext": "S₁ = { n : n = p or n = p + 2ᵃ, p prime }. Known: 0 < d̲(S₁) < 1. Open: the exact value of d̲(S₁).",
+    "significance": "context",
+    "relatedConcepts": ["Erdős problem #10", "Romanoff's theorem", "covering congruences", "lower asymptotic density", "scope of a formalization"],
+    "prerequisites": ["asymptotic density of a set of integers", "powers of 2 and prime sums", "what an open question is vs a proved scaffold"]
   },
   {
     "id": "ann-def-sumprimepows-erdos10oq04",
@@ -15,7 +18,10 @@
     "type": "definition",
     "title": "The representable family Sₖ",
     "content": "`sumPrimeAndTwoPows k` is the set of n of the form p + Σ 2^{aᵢ} where p is prime and the exponents form a multiset of cardinality at most k. Using a multiset (rather than a finite set) of exponents allows repeated powers, matching the parent file's definition exactly so the two formalizations interoperate.",
-    "mathContext": "Sₖ = { n : ∃ p prime, ∃ pows : Multiset ℕ, |pows| ≤ k ∧ n = p + Σ 2^{aᵢ} }."
+    "mathContext": "Sₖ = { n : ∃ p prime, ∃ pows : Multiset ℕ, |pows| ≤ k ∧ n = p + Σ 2^{aᵢ} }.",
+    "significance": "key",
+    "relatedConcepts": ["multiset of exponents", "powers of two", "additive representation", "Multiset.card"],
+    "prerequisites": ["multisets vs finite sets", "sum over a mapped multiset", "primality predicate"]
   },
   {
     "id": "ann-def-lowerdensity-erdos10oq04",
@@ -24,7 +30,10 @@
     "type": "definition",
     "title": "Lower density via liminf of counting ratios",
     "content": "`densityFn S n = |S ∩ [0,n]| / (n+1)` is the finite counting ratio (factored out so its boundedness can be reused), and `lowerDensity S` is its liminf along `atTop`. The liminf — rather than a plain limit — is used because the limit need not exist; the lower density is exactly what Romanoff's and Gallagher's theorems bound.",
-    "mathContext": "d̲(S) = liminf_{n→∞} |S ∩ [0,n]| / (n+1)."
+    "mathContext": "d̲(S) = liminf_{n→∞} |S ∩ [0,n]| / (n+1).",
+    "significance": "key",
+    "relatedConcepts": ["lower asymptotic density", "liminf along atTop", "counting function", "Filter.liminf"],
+    "prerequisites": ["liminf of a real sequence", "the atTop filter on ℕ", "why density may have no limit"]
   },
   {
     "id": "ann-thm-memiff-erdos10oq04",
@@ -33,7 +42,10 @@
     "type": "theorem",
     "title": "Membership in S₁ collapses to 'prime or p + 2ᵃ'",
     "content": "For k = 1 the exponent multiset has cardinality 0 or 1. The cardinality-0 case (`Multiset.card_eq_zero`) gives n = p, a prime; the cardinality-1 case (`Multiset.card_eq_one`) gives a singleton {a}, whose mapped sum is 2ᵃ, so n = p + 2ᵃ. The proof unpacks both directions, turning the abstract multiset definition into a usable, quantifier-light disjunction.",
-    "mathContext": "n ∈ S₁ ⇔ n.Prime ∨ ∃ p a, p.Prime ∧ n = p + 2ᵃ."
+    "mathContext": "n ∈ S₁ ⇔ n.Prime ∨ ∃ p a, p.Prime ∧ n = p + 2ᵃ.",
+    "significance": "key",
+    "relatedConcepts": ["case split on cardinality", "Multiset.card_eq_zero / card_eq_one", "membership characterization", "specialization k = 1"],
+    "prerequisites": ["multisets of cardinality 0 or 1", "sum over a singleton multiset", "iff proofs by unpacking both directions"]
   },
   {
     "id": "ann-thm-mono-erdos10oq04",
@@ -42,7 +54,10 @@
     "type": "theorem",
     "title": "The family Sₖ is monotone in k",
     "content": "If j ≤ k then any witness for membership in Sⱼ (a prime and a multiset of ≤ j powers) is also a witness for Sₖ, since |pows| ≤ j ≤ k. Combined with monotonicity of lower density, this yields d̲(S₁) ≤ d̲(Sₖ) for every k ≥ 1 — the elementary lower edge of Gallagher's theorem d̲(Sₖ) → 1.",
-    "mathContext": "Monotone (fun k => Sₖ); hence j ≤ k ⇒ Sⱼ ⊆ Sₖ."
+    "mathContext": "Monotone (fun k => Sₖ); hence j ≤ k ⇒ Sⱼ ⊆ Sₖ.",
+    "significance": "supporting",
+    "relatedConcepts": ["monotone family of sets", "witness reuse", "set inclusion", "Gallagher's theorem"],
+    "prerequisites": ["Monotone predicate on ℕ", "transitivity of ≤ on cardinalities"]
   },
   {
     "id": "ann-thm-onenotmem-erdos10oq04",
@@ -51,7 +66,10 @@
     "type": "theorem",
     "title": "1 is never representable",
     "content": "Any element of Sₖ is at least the prime p ≥ 2 added to a nonnegative power sum, so it cannot equal 1. This is the smallest non-member and shows S₁ ≠ ℕ.",
-    "mathContext": "1 ∉ Sₖ for every k, since p ≥ 2 forces p + Σ2^{aᵢ} ≥ 2."
+    "mathContext": "1 ∉ Sₖ for every k, since p ≥ 2 forces p + Σ2^{aᵢ} ≥ 2.",
+    "significance": "supporting",
+    "relatedConcepts": ["lower bound from primality (p ≥ 2)", "non-membership", "proper subset of ℕ"],
+    "prerequisites": ["every prime is ≥ 2", "nonnegativity of a power sum"]
   },
   {
     "id": "ann-thm-densitymono-erdos10oq04",
@@ -60,7 +78,10 @@
     "type": "theorem",
     "title": "Lower density is monotone under inclusion",
     "content": "If A ⊆ B then on each window [0,n] the filtered count for A is at most that for B (`Finset.card_le_card` on the filtered subset), so densityFn A n ≤ densityFn B n pointwise. The result follows from `Filter.liminf_le_liminf`, discharging its boundedness side-conditions from the [0,1] bound on counting ratios.",
-    "mathContext": "A ⊆ B ⇒ d̲(A) ≤ d̲(B)."
+    "mathContext": "A ⊆ B ⇒ d̲(A) ≤ d̲(B).",
+    "significance": "key",
+    "relatedConcepts": ["monotonicity of liminf", "Filter.liminf_le_liminf", "Finset.card_le_card", "boundedness side-conditions"],
+    "prerequisites": ["liminf preserves pointwise ≤", "counting ratios bounded in [0,1]", "filtered Finset cardinalities"]
   },
   {
     "id": "ann-thm-s1le-erdos10oq04",
@@ -69,6 +90,9 @@
     "type": "theorem",
     "title": "Lower edge of Gallagher's theorem",
     "content": "Since S₁ ⊆ Sₖ for k ≥ 1, lower density's monotonicity gives d̲(S₁) ≤ d̲(Sₖ). Gallagher (1975) proved d̲(Sₖ) → 1; d̲(S₁) sits at the base of this increasing chain, and its exact value is the open question.",
-    "mathContext": "1 ≤ k ⇒ d̲(S₁) ≤ d̲(Sₖ)."
+    "mathContext": "1 ≤ k ⇒ d̲(S₁) ≤ d̲(Sₖ).",
+    "significance": "key",
+    "relatedConcepts": ["Gallagher's theorem (1975)", "increasing chain of densities", "Erdős problem #10 OQ-04", "open question framing"],
+    "prerequisites": ["combining set monotonicity with density monotonicity", "the limit d̲(Sₖ) → 1"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass (pass 0)

Axiom-free scaffolding entry (meta.json 9.7 KB, under cap). Quality gap was annotation depth — all 8 annotations had `content`/`mathContext` but lacked structured fields.

### Changes
- Added `significance`, `relatedConcepts`, `prerequisites` to all 8 annotations.
  - Tiers: `key` (Sₖ definition, lower density via liminf, S₁ membership characterization, density monotonicity, Gallagher lower edge), `supporting` (k-monotonicity, 1∉Sₖ), `context` (open-question scope header).
  - relatedConcepts link to Romanoff/Gallagher, lower asymptotic density, Filter.liminf_le_liminf, multiset representations.

### Verification
- JSON valid; `annotations/build.ts`: zero warnings for this target.
- Axiom integrity unchanged: `verified` / `original` / axiomCount 0; the open question (exact d̲(S₁)) is explicitly NOT claimed.