### PR TITLE
research(sum-of-divisors-oq-01): square-packaging half of Euler form [BUILD-PENDING]

### DIFF
--- a/proofs/Proofs/SumOfDivisorsOQ01SquarePacking.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ01SquarePacking.lean
@@ -1,0 +1,118 @@
+/-
+# Euler's Odd-Perfect Form — the square-packaging half (`m²`)
+
+This file extends the *local prime-power engine* of `SumOfDivisorsOQ01.lean`
+toward the **global** assembly of Euler's structural theorem.
+
+## The two halves of Euler's form
+
+Euler (1747): an odd perfect `N` has the form `N = p^a·m²` with `p` the special
+prime, `p ≡ a ≡ 1 (mod 4)`, `gcd(p, m) = 1`.  The classical proof has two halves:
+
+1. **Square-packaging (this file).**  Multiplicativity of `σ` spreads the
+   prime-power parity law L1 (`σ(p^a)` odd ⟺ `a` even) across the whole
+   factorization: for odd `N`, `σ(N)` is odd ⟺ *every* prime exponent is even
+   ⟺ `N` is a perfect square.  This is the `m²` half — the non-special primes,
+   each to an even power, assemble into a square.
+
+2. **Special-prime counting (deferred).**  The harder mod-4 *counting* that
+   `σ(N)=2N` forces *exactly one* odd-exponent prime, and that L2 pins it to
+   `p ≡ a ≡ 1 (mod 4)`.  Left for follow-up.
+
+## Contents
+
+* `isSquare_iff_even_factorization` — `N` (positive) is a square ⟺ every prime
+  exponent in `N.factorization` is even.  (Pure factorization fact.)
+* `odd_sigma_iff_even_factorization` — for odd `N`, `σ(N)` is odd ⟺ every prime
+  exponent is even.  (L1 spread by `isMultiplicative_sigma`.)
+* `odd_sigma_odd_iff_isSquare` — **headline**: for odd `N`, `σ(N)` is odd ⟺ `N`
+  is a perfect square.  (Odd case of "σ(n) odd ⟺ n is a square or twice a
+  square".)
+* `odd_perfect_not_isSquare` — corollary: an odd perfect number is never a
+  perfect square (its `σ = 2N` is even, so it cannot be a square).
+
+All results are conditional structure theorems and assume nothing about the
+existence of odd perfect numbers (open).
+-/
+import Mathlib
+import Proofs.SumOfDivisorsOQ01
+
+open ArithmeticFunction Finset
+open scoped ArithmeticFunction.sigma
+
+namespace SumOfDivisorsOQ01
+
+/-- A positive natural number is a perfect square iff every exponent in its prime
+factorization is even.  Pure factorization fact, independent of the
+perfect-number context. -/
+theorem isSquare_iff_even_factorization {N : ℕ} (hN : N ≠ 0) :
+    IsSquare N ↔ ∀ p, Even (N.factorization p) := by
+  constructor
+  · rintro ⟨r, rfl⟩ p
+    have hr : r ≠ 0 := by rintro rfl; simp at hN
+    rw [Nat.factorization_mul hr hr, Finsupp.add_apply]
+    exact ⟨r.factorization p, rfl⟩
+  · intro h
+    refine ⟨N.factorization.prod fun p e => p ^ (e / 2), ?_⟩
+    have key : (N.factorization.prod fun p e => p ^ (e / 2)) ^ 2 = N := by
+      conv_rhs => rw [← Nat.factorization_prod_pow_eq_self hN]
+      simp only [Finsupp.prod]
+      rw [← Finset.prod_pow]
+      refine Finset.prod_congr rfl fun p _ => ?_
+      rw [← pow_mul]
+      congr 1
+      obtain ⟨k, hk⟩ := h p
+      omega
+    rw [← key]; ring
+
+/-- For an odd `N`, `σ(N)` is odd iff every prime in its factorization appears to
+an even power.  Multiplicativity of `σ` (`isMultiplicative_sigma`) turns the
+prime-power parity law L1 (`sigma_prime_pow_odd_iff`) into a statement about the
+whole factorization. -/
+theorem odd_sigma_iff_even_factorization {N : ℕ} (hodd : Odd N) (hN : N ≠ 0) :
+    Odd (σ 1 N) ↔ ∀ p ∈ N.primeFactors, Even (N.factorization p) := by
+  rw [(σ 1).multiplicative_factorization isMultiplicative_sigma hN]
+  simp only [Finsupp.prod, Nat.support_factorization]
+  rw [← not_even_iff_odd, even_iff_two_dvd,
+    Nat.prime_two.prime.dvd_finset_prod_iff]
+  push_neg
+  refine forall_congr' fun p => imp_congr_right fun hp => ?_
+  have hp_prime : p.Prime := Nat.prime_of_mem_primeFactors hp
+  have hpd : p ∣ N := Nat.dvd_of_mem_primeFactors hp
+  have hp_odd : Odd p := by
+    rcases Nat.even_or_odd p with he | ho
+    · exact absurd (even_iff_two_dvd.mpr (he.two_dvd.trans hpd))
+        (not_even_iff_odd.mpr hodd)
+    · exact ho
+  rw [← even_iff_two_dvd, not_even_iff_odd]
+  exact sigma_prime_pow_odd_iff hp_prime hp_odd _
+
+/-- **σ-parity detects squares (odd case).**  For an odd `N`, `σ(N)` is odd ⟺ `N`
+is a perfect square.  This is the odd case of the classical "σ(n) is odd iff n is
+a square or twice a square", and the square-packaging half of Euler's odd-perfect
+form: the part of `N` on which `σ` stays odd (the even-exponent primes) is a
+square `m²`. -/
+theorem odd_sigma_odd_iff_isSquare {N : ℕ} (hodd : Odd N) (hN : N ≠ 0) :
+    Odd (σ 1 N) ↔ IsSquare N := by
+  rw [odd_sigma_iff_even_factorization hodd hN, isSquare_iff_even_factorization hN]
+  constructor
+  · intro h p
+    by_cases hp : p ∈ N.primeFactors
+    · exact h p hp
+    · have hz : N.factorization p = 0 := by
+        rw [← Nat.support_factorization] at hp
+        exact Finsupp.not_mem_support_iff.mp hp
+      rw [hz]; exact even_zero
+  · intro h p _; exact h p
+
+/-- **An odd perfect number is never a perfect square.**  From `σ(N) = 2N` the
+value `σ(N)` is even, so by the parity law `N` cannot be a square.  Equivalently:
+in `N = p^a·m²` the special prime's exponent `a` is odd, so `p^a` is a non-square
+factor and `N` itself is not a square. -/
+theorem odd_perfect_not_isSquare {N : ℕ} (hodd : Odd N) (hperf : Nat.Perfect N) :
+    ¬ IsSquare N := by
+  have hN : N ≠ 0 := hperf.2.ne'
+  rw [← odd_sigma_odd_iff_isSquare hodd hN, odd_perfect_sigma_eq_two_mul hperf]
+  exact not_odd_iff_even.mpr ⟨N, by ring⟩
+
+end SumOfDivisorsOQ01

--- a/research/problems/sum-of-divisors-oq-01/knowledge.md
+++ b/research/problems/sum-of-divisors-oq-01/knowledge.md
@@ -135,3 +135,46 @@ bulk; steps 2 and 4 are short congruence arguments).
   `p₀ ≡ a₀ ≡ 1 (mod 4)`.
 - Submit that assembly sorry to Aristotle as a HARD job once the MCP is back (known classical
   result — Hardy–Wright Thm 277).
+
+## Session 2026-06-27 (researcher-2) — square-packaging half drafted [BUILD-PENDING]
+
+**State on entry:** local prime-power engine (L1, L2, pairing, parity) merged &
+verified (PR #30852, 0-sorry/0-axiom). SOLVED-with-followup: the global assembly
+is the open gap. Picked the **square-packaging half** of that assembly.
+
+**New work** — `proofs/Proofs/SumOfDivisorsOQ01SquarePacking.lean` (4 theorems,
+isolated companion that `import Proofs.SumOfDivisorsOQ01` so it CANNOT regress the
+verified main entry):
+
+1. `isSquare_iff_even_factorization {N} (hN : N ≠ 0) : IsSquare N ↔ ∀ p, Even (N.factorization p)`
+   — pure factorization fact. Reverse builds the witness `∏ p^(e_p/2)` and shows
+   its square is `N` via `Nat.factorization_prod_pow_eq_self` + `Finset.prod_pow`.
+2. `odd_sigma_iff_even_factorization {N} (hodd) (hN) : Odd (σ 1 N) ↔ ∀ p ∈ N.primeFactors, Even (N.factorization p)`
+   — L1 spread by `isMultiplicative_sigma` over the factorization product; parity
+   of a product handled by `Nat.prime_two.prime.dvd_finset_prod_iff` + `push_neg`.
+3. `odd_sigma_odd_iff_isSquare {N} (hodd) (hN) : Odd (σ 1 N) ↔ IsSquare N`
+   — **headline**: odd case of "σ(n) odd ⟺ n is a square or twice a square".
+   This is exactly the `m²` packaging: the part of `N` where `σ` stays odd is a
+   square. Bridges (1)↔(2) via `factorization = 0` off `primeFactors`.
+4. `odd_perfect_not_isSquare {N} (hodd) (hperf) : ¬ IsSquare N`
+   — corollary: an odd perfect number is never a square (`σ N = 2N` is even).
+
+**Status: BUILD-PENDING (NOT machine-verified).** Docker was hard-down all
+session: host disk `/System/Volumes/Data` at 100% (≤8 GiB free of 926 GiB, ~6
+concurrent agent Mathlib builds) and `containerd` `meta.db` throwing
+`input/output error` on every new image/container build. 4 build attempts all
+failed at the Docker daemon layer (never reached Lean). Every Mathlib lemma name
+WAS statically checked against the local checkout `proofs/.lake/packages/mathlib`
+(e.g. `even_iff_two_dvd`, `not_even_iff_odd`, `Nat.factorization_mul`,
+`Prime.dvd_finset_prod_iff`, `Finset.prod_pow`, `multiplicative_factorization`),
+but tactic-level success is unconfirmed. **Do not promote to `verified` or update
+the gallery meta until a Docker-up build of `Proofs.SumOfDivisorsOQ01SquarePacking`
+returns `=== Build succeeded ===`.** Risk spots if it fails: the `simp only
+[Finsupp.prod]` unfolds, the `forall_congr'`/`imp_congr_right` shape after
+`push_neg`, and the `dvd_finset_prod_iff` rewrite unification.
+
+**Remaining gap (the harder half):** the mod-4 *counting* that `σ(N)=2N` forces
+*exactly one* odd-exponent prime (so the non-special part is the `m²` above), then
+L2 pins `p ≡ a ≡ 1 (mod 4)`. Approach: two even σ-factors would put `4 ∣ σ(N)`,
+contradicting `σ(N) = 2·odd ≡ 2 (mod 4)`; combine with theorem (2) "at least one"
+to get exactly one. Then `Nat.factorization_prod_pow_eq_self` packages the rest.


### PR DESCRIPTION
## Summary

Advances `sum-of-divisors-oq-01` (Euler's odd-perfect form) from the merged, verified **local prime-power engine** (PR #30852) toward the **global assembly**. This PR drafts the **square-packaging ($m^2$) half**: multiplicativity of $\sigma$ spreads the prime-power parity law L1 across the whole factorization, so for odd $N$, $\sigma(N)$ is odd $\iff$ every prime exponent is even $\iff N$ is a perfect square — exactly the non-special primes assembling into $m^2$.

New file `proofs/Proofs/SumOfDivisorsOQ01SquarePacking.lean` (isolated companion that `import Proofs.SumOfDivisorsOQ01`, so it **cannot regress** the verified main entry):

1. `isSquare_iff_even_factorization` — $N>0$ is a square $\iff$ all exponents in `N.factorization` are even (pure factorization fact).
2. `odd_sigma_iff_even_factorization` — for odd $N$, $\mathrm{Odd}(\sigma N) \iff$ all prime exponents even (L1 spread by `isMultiplicative_sigma`).
3. `odd_sigma_odd_iff_isSquare` — **headline**: for odd $N$, $\mathrm{Odd}(\sigma N) \iff \mathrm{IsSquare}\,N$ (odd case of "$\sigma(n)$ odd iff $n$ is a square or twice a square").
4. `odd_perfect_not_isSquare` — corollary: an odd perfect number is never a perfect square.

## ⚠️ BUILD-PENDING — NOT machine-verified

Docker was **hard-down** the entire session: host disk `/System/Volumes/Data` at 100% (≤8 GiB free of 926 GiB, ~6 concurrent agent Mathlib builds) with `containerd` `meta.db` returning `input/output error` on every new build. **4 build attempts all failed at the Docker daemon layer, never reaching Lean.**

Every Mathlib lemma name was statically checked against the local checkout (`proofs/.lake/packages/mathlib`), but tactic-level success is unconfirmed. **Do not promote to `verified` or update the gallery meta** until a Docker-up build of `Proofs.SumOfDivisorsOQ01SquarePacking` returns `=== Build succeeded ===`. The gallery `meta.json` is intentionally left untouched.

## Remaining gap (harder half)

The mod-4 *counting* that $\sigma(N)=2N$ forces *exactly one* odd-exponent prime, then L2 pins $p \equiv a \equiv 1 \pmod 4$. Documented in `knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)