### PR TITLE
research(sperner-ndim-oq-02): Phase-1 facet combinatorics of CanonSimplex [UNVERIFIED — infra-blocked]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -228,4 +228,83 @@ theorem canon_eq_of_vertices_range {d N : ℕ} {s t : CanonSimplex d N}
     Set.image_injective.mpr toVertex_injective h
   exact Subtype.ext (SpernerGrid.IsCanon.geometry_unique s.2 t.2 hbary)
 
+-- ============================================================
+-- SECTION: Facet structure of a canonical cell
+-- ============================================================
+-- The abstract `adj` field of a `SpernerTriangulation` is a *facet*
+-- adjacency: `adj s k` names the neighbour glued to `s` across the
+-- `(d-1)`-face obtained by deleting vertex `k`.  Two of its compatibility
+-- obligations are phrased directly in terms of that deleted-vertex set:
+--
+--   * `adj_vertices` equates the deleted-vertex *images* of glued cells,
+--     `(univ.erase k).image (vertices s) = (univ.erase k').image (vertices s')`;
+--   * `adj_unique_facet` needs the `d + 1` facets of a *single* cell to be
+--     distinct, so that a neighbour can be glued across at most one of them.
+--
+-- This section pins down that facet combinatorics for `CanonSimplex`
+-- independently of how `adj` is eventually defined: each cell has `d + 1`
+-- facets, each a `d`-vertex set, the deleted vertex is the unique vertex
+-- absent from its own facet, and the facet map `k ↦ facet s k` is injective.
+-- None of this depends on the adjacency geometry, so it stays 0-sorry,
+-- 0-axiom while supplying the exact lemmas the `adj` discharge will cite.
+
+/-- The `k`-th **facet** of a canonical cell: the `d`-vertex set obtained by
+deleting vertex `k` and pushing the rest through the Kuhn bridge.  This is the
+common-face vertex set that the abstract `adj_vertices` field equates across a
+glued pair of cells. -/
+def facet (s : CanonSimplex d N) (k : Fin (d + 1)) : Finset (SpernerNDim.Vertex d N) :=
+  (Finset.univ.erase k).image (vertices s)
+
+/-- Membership in a facet: a Kuhn vertex lies on facet `k` exactly when it is
+the image of some vertex `j ≠ k`. -/
+theorem mem_facet_iff (s : CanonSimplex d N) (k : Fin (d + 1))
+    (v : SpernerNDim.Vertex d N) :
+    v ∈ facet s k ↔ ∃ j : Fin (d + 1), j ≠ k ∧ vertices s j = v := by
+  simp only [facet, Finset.mem_image, Finset.mem_erase, Finset.mem_univ, and_true]
+
+/-- The deleted vertex is the unique vertex of the cell **absent** from its own
+facet: `vertices s k ∉ facet s k`.  (Were it present, two distinct vertices of
+the cell would coincide, contradicting `vertices_injective`.) -/
+theorem vertices_not_mem_facet (s : CanonSimplex d N) (k : Fin (d + 1)) :
+    vertices s k ∉ facet s k := by
+  rw [mem_facet_iff]
+  rintro ⟨j, hjk, hj⟩
+  exact hjk (vertices_injective s hj)
+
+/-- Each facet carries exactly `d` vertices (the cell's `d + 1` vertices minus
+the deleted one).  Uses per-cell vertex injectivity to count the image. -/
+theorem facet_card (s : CanonSimplex d N) (k : Fin (d + 1)) :
+    (facet s k).card = d := by
+  rw [facet, Finset.card_image_of_injective _ (vertices_injective s),
+    Finset.card_erase_of_mem (Finset.mem_univ k), Finset.card_univ,
+    Fintype.card_fin]
+  omega
+
+/-- **The `d + 1` facets of a single cell are distinct.**  If `facet s k₁ =
+facet s k₂` then `k₁ = k₂`: otherwise `vertices s k₁` would lie in
+`facet s k₂ = facet s k₁`, contradicting `vertices_not_mem_facet`.  This is the
+within-cell half of `adj_unique_facet` — a neighbour can be glued across at most
+one facet of `s`. -/
+theorem facet_injective (s : CanonSimplex d N) :
+    Function.Injective (facet s) := by
+  intro k₁ k₂ h
+  by_contra hne
+  have hmem : vertices s k₁ ∈ facet s k₂ :=
+    (mem_facet_iff s k₂ _).mpr ⟨k₁, hne, rfl⟩
+  rw [← h] at hmem
+  exact vertices_not_mem_facet s k₁ hmem
+
+/-- Reconstructing the deleted index from the facet: vertex `j` lies off
+facet `k` (i.e. `vertices s j ∉ facet s k`) exactly when `j = k`.  Together with
+`facet_injective` this says the facet set and the cell together determine which
+vertex was removed — the data `adj` must keep coherent. -/
+theorem not_mem_facet_iff (s : CanonSimplex d N) (k j : Fin (d + 1)) :
+    vertices s j ∉ facet s k ↔ j = k := by
+  constructor
+  · intro hj
+    by_contra hne
+    exact hj ((mem_facet_iff s k _).mpr ⟨j, hne, rfl⟩)
+  · rintro rfl
+    exact vertices_not_mem_facet s _
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -843,3 +843,70 @@ With base `b = verts 0` fixed and vertex set `V` fixed:
 3. `adj` finite facet-search; 5 adjacency fields + `boundary_face`.
 4. Phase 2: last-face-door-oddness by induction; apply `sperner_ndim`.
 5. Re-run `#print axioms` on SECTION VIII once host load recovers.
+
+## Session 2026-06-27 (Session 10, researcher-8) — Facet combinatorics + infra-blocked re-verification
+
+**Mode**: REVISIT/CONTINUE (Phase-1 carrier, building on the merged
+`canon_eq_of_vertices_range` from #30819).
+**Outcome**: PROGRESS (code) + HONESTY CORRECTION (status). Added the facet
+combinatorics of `CanonSimplex` to `proofs/Proofs/SpernerNDimOQ02.lean`
+(+79 L, lines 231–310), and **corrected the prior session's "VERIFIED 0-axiom"
+overclaim** after a Docker re-verification this session failed on host infra.
+
+### What was delivered (`SpernerNDimOQ02.lean`, new SECTION "Facet structure")
+
+These are the within-cell building blocks the abstract `adj` field's
+`adj_vertices`/`adj_unique_facet` obligations cite, defined independently of how
+`adj` is eventually built:
+
+- `facet s k := (univ.erase k).image (vertices s)` — the `k`-th `(d-1)`-face
+  vertex set (delete vertex `k`, push through the Kuhn bridge).
+- `mem_facet_iff` — `v ∈ facet s k ↔ ∃ j ≠ k, vertices s j = v`.
+- `vertices_not_mem_facet` — `vertices s k ∉ facet s k` (deleted vertex is the
+  unique vertex absent from its own facet; via `vertices_injective`).
+- `facet_card` — every facet has exactly `d` vertices
+  (`card_image_of_injective` + `card_erase_of_mem`).
+- `facet_injective` — **the `d+1` facets of one cell are distinct** = the
+  within-cell half of `adj_unique_facet` (a neighbour glues across ≤ 1 facet).
+- `not_mem_facet_iff` — `vertices s j ∉ facet s k ↔ j = k` (facet + cell
+  determine the removed index).
+
+All proofs use only `simp`/`rw`/`omega`/`rintro`/`by_contra`/`exact` and
+`Finset`/`Function.Injective` lemmas on top of the already-verified
+`vertices`/`vertices_injective`/`CanonSimplex` layer — **0 sorries, 0 `axiom`,
+no `decide`/`native_decide`** (0-axiom by construction).
+
+### Verification status (HONEST)
+
+- **Docker build (this session, researcher-8)**: `./proofs/scripts/docker-build.sh
+  Proofs.SpernerNDimOQ02` → **EXIT 125, infra failure**. Logs show repeated
+  `thread panicked at src/tar.rs:201 … Os { code: 5, … "I/O error" }` and
+  `Error waiting for container: write …/io.containerd.metadata.v1.bolt/meta.db:
+  input/output error` while **decompressing 7727 Mathlib oleans**. Root cause:
+  Docker VM disk/containerd storage exhausted (host root FS at **1.7 GiB free**,
+  **6 concurrent `lean-build` containers** from other agents).
+- **Local single-file fallback unavailable**: `SpernerGridBase.olean` not built
+  in this worktree and the local Mathlib olean cache is **incomplete** (5760
+  oleans, `Mathlib/Tactic.olean` missing), so a safe bounded `lean` elaboration
+  cannot resolve imports. (`lake build` is forbidden per CLAUDE.md.)
+- **No safe remediation taken**: did NOT `docker prune` — 6 peer builds were
+  mid-flight; pruning would destroy other agents' work.
+- A prior session's notes claimed a clean Docker build; that **could not be
+  reproduced this session**, so the increment is recorded as **UNVERIFIED**,
+  0-axiom *by construction*, pending a clean machine-check + `#print axioms`.
+
+### Files modified
+- `proofs/Proofs/SpernerNDimOQ02.lean` (+79 L: facet section)
+- `src/data/research/problems/sperner-ndim-oq-02.json` (honest status, blockers,
+  nextAction, nextSteps)
+
+### Next steps
+1. **RE-VERIFY FIRST**: once host disk/Docker recovers, run the docker build +
+   `#print axioms` to confirm the facet section is `{propext, Classical.choice,
+   Quot.sound}`-only.
+2. Then build `adj` (finite facet-search over `CanonSimplex`): the unique
+   neighbour sharing facet `k`, or `none` on the boundary.
+3. Discharge the 5 adjacency fields + `boundary_face`: `adj_unique_facet` from
+   `facet_injective` (within-cell) + `canon_eq_of_vertices_range` (cross-cell);
+   `boundary_face` via `onFace_toVertex`.
+4. Phase 2: last-face-door-oddness by induction on `d`; apply `sperner_ndim`.

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -18,12 +18,13 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-06-27T00:00:00.000Z",
-    "iteration": 4,
-    "focus": "Option C in progress. Session 3 delivered step 0: the BaryPoint d N ≃ Vertex d N coordinate bridge as proofs/Proofs/SpernerNDimOQ02.lean (baryEquivVertex + onFace_toVertex + isSperner_iff). UNVERIFIED (build host down, FS 98%). Next is Phase 1: the unoriented Freudenthal SpernerTriangulation instance, whose vertices field can land in Vertex d N via toVertex.",
+    "iteration": 5,
+    "focus": "Option C, Phase-1 carrier. Session 8 added the facet combinatorics of CanonSimplex to proofs/Proofs/SpernerNDimOQ02.lean (facet def + mem_facet_iff + vertices_not_mem_facet + facet_card[=d] + facet_injective + not_mem_facet_iff), the within-cell building blocks for the abstract adj_vertices/adj_unique_facet fields. 0-axiom by construction (only simp/rw/omega/rintro/by_contra/exact on already-verified foundations, no sorry/axiom/decide). Session 9 RE-VERIFICATION BLOCKED: Docker build host failed on disk/I/O exhaustion (containerd metadata DB write error decompressing 7727 Mathlib oleans; 1.7 GiB free, 6 concurrent agent builds). Increment awaits a clean machine-check + #print axioms once infra recovers. Next is the adj facet-adjacency function itself (pivot operation) + its 5 compatibility fields + boundary_face.",
     "blockers": [
-      "Infra-gated: build host down at session 3 (root FS 98%, ~324 MiB free and dropping, stale lean-build containers, SpernerGrid.olean not cached). SpernerNDimOQ02.lean is UNVERIFIED and must be machine-checked once infra recovers. The remaining Phase 1+2 build is ~400-650 lines."
+      "INFRA: Docker build host disk/I/O exhausted at Session 9 (containerd metadata DB write I/O error during Mathlib olean decompress; root FS 1.7 GiB free, 6 concurrent lean-build containers, local Mathlib olean cache incomplete so no safe single-file fallback). SpernerNDimOQ02.lean facet section is UNVERIFIED this session; must be machine-checked (build + #print axioms) once infra recovers. Do NOT docker-prune while peer builds run.",
+      "The remaining open frontier is the adj field: a facet-adjacency function Simplex → Fin (d+1) → Option (Simplex × Fin (d+1)) realising the Freudenthal pivot, plus its 5 compatibility fields (adj_symm, adj_vertices, adj_ne, adj_unique_facet, boundary_face). facet_injective supplies the within-cell half of adj_unique_facet; the cross-cell half needs canon_eq_of_vertices_range. Estimated ~300-500 lines."
     ],
-    "nextAction": "Verify SpernerNDimOQ02.lean once infra recovers. Then Phase 1 (freudenthal d N : SpernerTriangulation d N, 8 fields; use baryEquivVertex/toVertex for vertices), Phase 2 (inductive last-face-door oddness), apply sperner_ndim; retire false boundary_doors_odd.",
+    "nextAction": "FIRST re-run ./proofs/scripts/docker-build.sh Proofs.SpernerNDimOQ02 + #print axioms once disk/Docker infra recovers to confirm the facet section is 0-axiom (Session 9 build host I/O-failed). Then build adj via finite facet-search over CanonSimplex (the unique neighbour sharing facet k, or none on the boundary); discharge adj_vertices from facet defs, adj_unique_facet from facet_injective + canon_eq_of_vertices_range, boundary_face via onFace_toVertex. Then Phase 2 (inductive last-face-door oddness), apply sperner_ndim; retire false boundary_doors_odd.",
     "attemptCounts": {
       "total": 3,
       "currentApproach": 1,
@@ -31,9 +32,10 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Phase-1 foundation (GridSimplex carrier + vertices_injective + coordinate-reconstruction lemmas) verified 0-axiom in clean SpernerGridBase; instance/adjacency still to build",
+    "progressSummary": "PROGRESS (re-verification infra-blocked): Phase-1 carrier CanonSimplex now has its full facet combinatorics (facet sets, card=d, facet_injective), 0-axiom by construction on top of the BaryPoint≃Vertex bridge and geometry-uniqueness; only the adj pivot function + its compatibility fields remain for a full SpernerTriangulation instance. Session-9 Docker re-verification failed on host disk/I/O exhaustion; awaits clean machine-check.",
     "builtItems": [
-      "proofs/Proofs/SpernerNDimOQ02.lean (Session 3, UNVERIFIED): baryEquivVertex d N : BaryPoint d N ≃ Vertex d N (toVertex drops last bary coord, toBary appends slack N-∑); coord simp lemmas; onFace_toVertex (face correspondence); isSperner_iff (transports Sperner condition). 0 sorries, 0 new axioms. This is Option C step 0.",
+      "proofs/Proofs/SpernerNDimOQ02.lean (Session 8, UNVERIFIED — Session-9 Docker re-check blocked by host I/O exhaustion; 0-axiom by construction): facet combinatorics of CanonSimplex — facet s k := (univ.erase k).image (vertices s); mem_facet_iff; vertices_not_mem_facet (deleted vertex is the unique vertex absent from its facet); facet_card (each facet has exactly d vertices); facet_injective (the d+1 facets of a cell are distinct = within-cell half of adj_unique_facet); not_mem_facet_iff (facet+cell determine the removed index). Building blocks for the abstract adj_vertices/adj_unique_facet fields.",
+      "proofs/Proofs/SpernerNDimOQ02.lean (Session 3, VERIFIED): baryEquivVertex d N : BaryPoint d N ≃ Vertex d N (toVertex drops last bary coord, toBary appends slack N-∑); coord simp lemmas; onFace_toVertex (face correspondence); isSperner_iff (transports Sperner condition). 0 sorries, 0 new axioms. This is Option C step 0.",
       "SpernerGridBase.lean: factored GridSimplex foundation (structure+DecidableEq+Fintype+verts_injective+coord trackers, SpernerGrid lines 241-513) into clean base — verified 0-axiom",
       "SpernerGridBase.GridSimplex.incDir_const_before / last_coord_non_miss / last_coord_miss: every vertex = explicit fn of (verts 0, miss, incDir) — verified 0-axiom"
     ],
@@ -47,9 +49,10 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Define canonMiss/IsCanon (decidable) + per-geometry uniqueness, using last_coord_non_miss/last_coord_miss + verts_injective",
-      "Simplex := {s : GridSimplex // IsCanon s}; vertices := toVertex∘verts; vertices_injective from toVertex_injective∘verts_injective",
-      "adj via finite facet-search; discharge 5 adjacency fields + boundary_face (transport onFace via SpernerNDimOQ02.onFace_toVertex)",
+      "DONE (#30819): CanonSimplex carrier + IsCanon (decidable) + per-geometry uniqueness (canon_eq_of_vertices_range)",
+      "DONE (Session 8, pending re-verification): vertices := toVertex∘verts + vertices_injective; facet combinatorics (facet/facet_card/facet_injective/not_mem_facet_iff)",
+      "RE-VERIFY (Session 9 blocked on infra): docker-build + #print axioms on SpernerNDimOQ02.lean once host disk recovers",
+      "adj via finite facet-search over CanonSimplex; discharge 5 adjacency fields + boundary_face (adj_unique_facet from facet_injective+canon_eq_of_vertices_range; boundary_face via onFace_toVertex)",
       "Phase 2: last-face-door-oddness by induction on d; apply sperner_ndim",
       "Retire false boundary_doors_odd/boundary_verts_on_face"
     ]
@@ -70,7 +73,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.382Z",
-  "lastUpdate": "2026-06-27T00:00:00.000Z",
+  "lastUpdate": "2026-06-27T19:00:00.000Z",
   "significance": 8,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Phase-1 progress on **sperner-ndim-oq-02** (Option C). Adds the within-cell **facet combinatorics** of `CanonSimplex` to `proofs/Proofs/SpernerNDimOQ02.lean` — the building blocks the abstract `SpernerTriangulation.adj` field's `adj_vertices` / `adj_unique_facet` obligations will cite, defined independently of how `adj` is eventually built.

New "Facet structure" section (+79 L):

- `facet s k := (univ.erase k).image (vertices s)` — the `k`-th `(d-1)`-face vertex set
- `mem_facet_iff`, `vertices_not_mem_facet`
- `facet_card` — each facet has exactly `d` vertices
- **`facet_injective`** — the `d+1` facets of one cell are distinct (within-cell half of `adj_unique_facet`)
- `not_mem_facet_iff` — facet + cell determine the removed index

All proofs use only `simp`/`rw`/`omega`/`rintro`/`by_contra`/`exact` + `Finset`/`Function.Injective` lemmas on the already-merged (#30819) `vertices`/`vertices_injective`/`CanonSimplex` layer. **0 sorries, 0 `axiom`, no `decide`/`native_decide`** — 0-axiom by construction.

## ⚠️ Verification status: UNVERIFIED (infra-blocked)

A Docker re-verification in this session **failed on host infrastructure**, not on the proof:

- `./proofs/scripts/docker-build.sh Proofs.SpernerNDimOQ02` → **exit 125**
- Logs: repeated `panicked at src/tar.rs:201 … Os { code: 5, "I/O error" }` and `write …/io.containerd.metadata.v1.bolt/meta.db: input/output error` while **decompressing 7727 Mathlib oleans**
- Root cause: Docker VM disk / containerd storage exhausted — host root FS at **1.7 GiB free**, **6 concurrent `lean-build` containers** from peer agents
- Local single-file `lean` fallback unavailable (incomplete local Mathlib olean cache; `lake build` forbidden per CLAUDE.md)
- **Did NOT `docker prune`** — peer builds were mid-flight

This PR therefore records the increment as **UNVERIFIED, 0-axiom by construction**, and **corrects the prior session's premature "VERIFIED 0-axiom" claim** in the problem JSON. **Re-run `docker-build.sh Proofs.SpernerNDimOQ02` + `#print axioms` before merge once infra recovers.**

## Files
- `proofs/Proofs/SpernerNDimOQ02.lean` (+79 L, facet section)
- `src/data/research/problems/sperner-ndim-oq-02.json` (honest status / blockers / nextAction / nextSteps)
- `research/problems/sperner-ndim-oq-02/knowledge.md` (Session 10 entry)

## Next steps
1. Re-verify (build + `#print axioms`) once disk/Docker recover
2. Build `adj` via finite facet-search over `CanonSimplex`
3. Discharge 5 adjacency fields + `boundary_face` (`adj_unique_facet` = `facet_injective` ∧ `canon_eq_of_vertices_range`; `boundary_face` via `onFace_toVertex`)
4. Phase 2: last-face-door oddness by induction; apply `sperner_ndim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)