### PR TITLE
Enrich Apéry Numbers Central-Binomial Lower Bound (basel-problem-oq-01-oq-01-oq-02-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "The lower half of Apéry's squeeze, axiom-free",
     "content": "Apéry's proof that ζ(3) is irrational pits two sequences against each other: the Apéry numbers bₙ = ∑ C(n,k)²·C(n+k,k)² grow geometrically, while the linear forms bₙζ(3) − aₙ shrink geometrically. The parent file formalizes the whole proof but leans on five axioms, one of which bounds bₙ from ABOVE by 34ⁿ. No axiom-free statement there pins bₙ from BELOW. This file does exactly that, from scratch, with 0 axioms — the Apéry numbers grow at least like 4ⁿ (and, up to a polynomial factor, like 16ⁿ), and diverge to infinity.",
-    "mathContext": "$b_n=\\sum_{k=0}^n\\binom{n}{k}^2\\binom{n+k}{k}^2$ grows geometrically; here $4^n\\le b_n$ and $16^n\\le 4n^2 b_n$."
+    "mathContext": "$b_n=\\sum_{k=0}^n\\binom{n}{k}^2\\binom{n+k}{k}^2$ grows geometrically; here $4^n\\le b_n$ and $16^n\\le 4n^2 b_n$.",
+    "significance": "context",
+    "relatedConcepts": ["Apéry numbers", "irrationality of ζ(3)", "Apéry's squeeze argument", "geometric growth", "axiom-free lower bound"],
+    "prerequisites": ["the Apéry sequence and its role in irrationality proofs", "asymptotic growth rates", "what the parent axiomatizes vs proves"]
   },
   {
     "id": "ann-basel-oq01010201-central-term",
@@ -15,7 +18,10 @@
     "type": "key-step",
     "title": "The central binomial coefficient lives inside every Apéry number",
     "content": "The single observation driving the entire file: the k = n summand of bₙ is C(n,n)²·C(n+n,n)² = 1·C(2n,n)² = C(2n,n)² (aperyB_centralTerm). Since every summand is a nonnegative integer, Finset.single_le_sum lets us discard all the others and keep just this one, yielding C(2n,n)² ≤ bₙ (centralBinom_sq_le_aperyB). The central binomial coefficient — whose growth is exactly understood — thus furnishes a lower bound on the much more intricate Apéry numbers.",
-    "mathContext": "$\\binom{n}{n}^2\\binom{2n}{n}^2=\\binom{2n}{n}^2\\le\\sum_k\\binom{n}{k}^2\\binom{n+k}{k}^2=b_n.$"
+    "mathContext": "$\\binom{n}{n}^2\\binom{2n}{n}^2=\\binom{2n}{n}^2\\le\\sum_k\\binom{n}{k}^2\\binom{n+k}{k}^2=b_n.$",
+    "significance": "key",
+    "relatedConcepts": ["central binomial coefficient C(2n,n)", "Finset.single_le_sum", "dropping nonnegative terms", "isolating one summand"],
+    "prerequisites": ["a single term lower-bounds a nonnegative sum", "evaluating C(n,n) and C(2n,n)"]
   },
   {
     "id": "ann-basel-oq01010201-two-pow",
@@ -24,7 +30,10 @@
     "type": "technique",
     "title": "2ⁿ ≤ C(2n,n) by a self-contained recurrence induction",
     "content": "To turn C(2n,n)² ≤ bₙ into a clean geometric bound, two_pow_le_centralBinom proves 2ⁿ ≤ C(2n,n) without Stirling or analysis. The induction multiplies the goal 2^(n+1) ≤ C(2n+2,n+1) by the positive factor (n+1) and rewrites the right side with Mathlib's identity (n+1)·C(2n+2,n+1) = 2(2n+1)·C(2n,n); since 2(n+1) ≤ 2(2n+1) and 2ⁿ ≤ C(2n,n) by the inductive hypothesis, Nat.mul_le_mul closes the multiplied inequality, then Nat.le_of_mul_le_mul_left cancels the (n+1). Squaring gives 4ⁿ = (2ⁿ)² ≤ C(2n,n)² ≤ bₙ.",
-    "mathContext": "$(n+1)\\binom{2n+2}{n+1}=2(2n+1)\\binom{2n}{n}$ and $2(n+1)\\le 2(2n+1)$ give $2^{n+1}\\le\\binom{2n+2}{n+1}$."
+    "mathContext": "$(n+1)\\binom{2n+2}{n+1}=2(2n+1)\\binom{2n}{n}$ and $2(n+1)\\le 2(2n+1)$ give $2^{n+1}\\le\\binom{2n+2}{n+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["Pascal recurrence for central binomials", "induction without Stirling", "Nat.mul_le_mul / le_of_mul_le_mul_left", "geometric lower bound 4ⁿ"],
+    "prerequisites": ["the identity (n+1)C(2n+2,n+1)=2(2n+1)C(2n,n)", "cancelling a positive factor in an inequality", "induction on ℕ"]
   },
   {
     "id": "ann-basel-oq01010201-sixteen",
@@ -33,7 +42,10 @@
     "type": "observation",
     "title": "The sharper rate-16 bound from Erdős's central-binomial estimate",
     "content": "The crude 4ⁿ wastes most of the central term's size. sixteen_pow_le_aperyB instead squares Mathlib's Erdős–Bertrand bound 4ⁿ ≤ 2n·C(2n,n) to get 16ⁿ ≤ (2n)²·C(2n,n)² = 4n²·C(2n,n)² ≤ 4n²·bₙ, i.e. bₙ ≳ 16ⁿ/4n². This recovers the genuine exponential order of the central term C(2n,n)² ≈ 16ⁿ/πn, leaving only a polynomial gap to the true Apéry growth rate (1+√2)⁴ = 17+12√2 ≈ 33.97.",
-    "mathContext": "$16^n=(4^n)^2\\le(2n\\binom{2n}{n})^2=4n^2\\binom{2n}{n}^2\\le 4n^2 b_n.$"
+    "mathContext": "$16^n=(4^n)^2\\le(2n\\binom{2n}{n})^2=4n^2\\binom{2n}{n}^2\\le 4n^2 b_n.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Erdős–Bertrand bound 4ⁿ ≤ 2n·C(2n,n)", "central binomial asymptotics 16ⁿ/πn", "Apéry growth rate (1+√2)⁴", "sharpening a geometric bound"],
+    "prerequisites": ["the lower bound 4ⁿ ≤ 2n·C(2n,n)", "squaring an inequality of nonnegatives"]
   },
   {
     "id": "ann-basel-oq01010201-divergence",
@@ -42,6 +54,9 @@
     "type": "key-step",
     "title": "Divergence bₙ → ∞ by squeezing above 4ⁿ",
     "content": "The qualitative fact Apéry's argument needs from the lower side is just bₙ → ∞. With the pointwise real bound (4:ℝ)ⁿ ≤ bₙ (cast from four_pow_le_aperyB) and tendsto_pow_atTop_atTop_of_one_lt (since 1 < 4), tendsto_atTop_mono delivers Tendsto (fun n => (bₙ:ℝ)) atTop atTop. The denominators lcm(1,…,n)³ grow only like 27ⁿ at worst, so bₙ → ∞ at a geometric rate is precisely what keeps the integer-squeeze nontrivial.",
-    "mathContext": "$4^n\\to\\infty$ and $4^n\\le b_n\\Rightarrow b_n\\to\\infty$."
+    "mathContext": "$4^n\\to\\infty$ and $4^n\\le b_n\\Rightarrow b_n\\to\\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["Filter.Tendsto atTop", "tendsto_pow_atTop_atTop_of_one_lt", "tendsto_atTop_mono (comparison)", "lcm(1,…,n) ~ eⁿ growth"],
+    "prerequisites": ["divergence of a geometric sequence with ratio > 1", "monotone comparison of limits", "casting ℕ bounds to ℝ"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass (pass 0)

Rich, axiom-free entry (meta.json 14.3 KB, under cap). Quality gap was annotation depth — the 5 annotations had `content`/`mathContext` but lacked structured fields.

### Changes
- Added `significance`, `relatedConcepts`, `prerequisites` to all 5 annotations (key/supporting/context tiers; central binomial coefficient, 2ⁿ≤C(2n,n) induction, Erdős–Bertrand bound, divergence via tendsto_atTop_mono).

### Verification
- JSON valid; `annotations/build.ts`: zero warnings for this target.
- Axiom integrity unchanged: `verified` / `original` / axiomCount 0.