### PR TITLE
research(pascals-hexagon-oq-03-incomplete-01): PART 4k — non-vacuity witness for OQ-03-OQ-02 [BUILD PENDING]

### DIFF
--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -1402,6 +1402,104 @@ theorem pascalProjLine_ne_zero_of_minor {C : Conic} (hex : InscribedHexagon C)
   · exact h m20
 
 -- ============================================================
+-- PART 4k: Non-Vacuity Witness — a concrete inscribed hexagon
+--          with a genuine (nonzero) Pascal line
+-- ============================================================
+
+/- Every well-definedness theorem of PART 4g–5b carries the general-position
+   hypothesis `hnd : ∀ k, pascalProjLine (permuteHexagon hex k) ≠ 0` (or its
+   single-relabeling instances).  An honest reader should ask: *is that
+   hypothesis ever satisfiable?*  If `pascalProjLine hex` were `0` for every
+   inscribed hexagon, the entire conditional development would be vacuous.
+
+   This part rules that out.  We exhibit an explicit hexagon inscribed in the
+   standard non-degenerate conic `x₀² + x₁² = x₂²` and show — by the concrete
+   minor witness of PART 4j — that its Pascal line is genuinely nonzero.  The
+   six vertices are the rational conic points
+     A = (1,0,1),  B = (0,1,1),  C = (-1,0,1),
+     D = (0,-1,1), E = (3,4,5),  F = (4,3,5),
+   for which `pascalP = (-6,-6,-12)` and `pascalQ = (2,12,10)`, so the
+   `(0,1)`-minor `P₀Q₁ - P₁Q₀ = -72 - (-12) = -60 ≠ 0`.  Hence
+   `pascalProjLine ≠ 0`: the conditional theory has at least one model. -/
+
+/-- The standard conic `x₀² + x₁² = x₂²` is non-degenerate (`det = -1 ≠ 0`). -/
+theorem stdConic_nondegenerate : stdConic.nondegenerate := by
+  unfold Conic.nondegenerate stdConic
+  rw [Matrix.det_fin_three]
+  simp only [Matrix.of_apply]
+  norm_num
+
+/-- A point `![a, b, c]` with `a² + b² = c²` lies on the standard conic. -/
+private theorem mem_stdConic (a b c : ℝ) (h : a ^ 2 + b ^ 2 = c ^ 2) :
+    pointOnConic ![a, b, c] stdConic := by
+  unfold pointOnConic conicQuadraticForm stdConic
+  simp only [Fin.sum_univ_three, Matrix.of_apply, Matrix.cons_val_zero,
+    Matrix.cons_val_one, Matrix.cons_val_two, Matrix.head_cons, Matrix.tail_cons,
+    Fin.isValue]
+  linear_combination h
+
+/-- A point `![a, b, c]` with nonzero last coordinate is a valid (nonzero)
+    projective point. -/
+private theorem valid_of_last (a b c : ℝ) (hc : c ≠ 0) :
+    ProjPoint.valid ![a, b, c] := by
+  intro hzero
+  apply hc
+  have := congrFun hzero 2
+  simpa using this
+
+/-- A concrete hexagon inscribed in the standard conic `x₀² + x₁² = x₂²`, with
+    six distinct rational vertices `A=(1,0,1), B=(0,1,1), C=(-1,0,1),
+    D=(0,-1,1), E=(3,4,5), F=(4,3,5)`.  Witnesses that `InscribedHexagon` of a
+    non-degenerate conic is inhabited. -/
+noncomputable def witnessHexagon : InscribedHexagon stdConic where
+  A := ![1, 0, 1]
+  B := ![0, 1, 1]
+  C' := ![-1, 0, 1]
+  D := ![0, -1, 1]
+  E := ![3, 4, 5]
+  F := ![4, 3, 5]
+  hA := mem_stdConic 1 0 1 (by norm_num)
+  hB := mem_stdConic 0 1 1 (by norm_num)
+  hC := mem_stdConic (-1) 0 1 (by norm_num)
+  hD := mem_stdConic 0 (-1) 1 (by norm_num)
+  hE := mem_stdConic 3 4 5 (by norm_num)
+  hF := mem_stdConic 4 3 5 (by norm_num)
+  hAvalid := valid_of_last 1 0 1 (by norm_num)
+  hBvalid := valid_of_last 0 1 1 (by norm_num)
+  hCvalid := valid_of_last (-1) 0 1 (by norm_num)
+  hDvalid := valid_of_last 0 (-1) 1 (by norm_num)
+  hEvalid := valid_of_last 3 4 5 (by norm_num)
+  hFvalid := valid_of_last 4 3 5 (by norm_num)
+
+/-- **Non-vacuity of the OQ-03-OQ-02 well-definedness theory.**  The
+    general-position hypothesis `pascalProjLine hex ≠ 0`, on which every descent
+    theorem of PART 4g–5b is conditioned, is *satisfiable*: the explicit
+    inscribed hexagon `witnessHexagon` (six rational points on the
+    non-degenerate conic `x₀²+x₁²=x₂²`) has a genuine, nonzero Pascal line.
+    Proved by the concrete minor witness of PART 4j — the `(0,1)`-minor of the
+    two spanning Pascal points `P = (-6,-6,-12)`, `Q = (2,12,10)` is
+    `P₀Q₁ - P₁Q₀ = -60 ≠ 0`.  Consequently the conditional well-definedness
+    results are not empty statements: at least one hexagon satisfies their
+    hypotheses. -/
+theorem pascalProjLine_witnessHexagon_ne_zero :
+    pascalProjLine witnessHexagon ≠ 0 := by
+  apply pascalProjLine_ne_zero_of_minor
+  left
+  simp only [pascalP, pascalQ, lineIntersection, lineThrough, witnessHexagon,
+    cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+    Matrix.head_cons, Matrix.tail_cons, Fin.isValue]
+  norm_num
+
+/-- **The conditional theory is inhabited.**  Packages `witnessHexagon` and its
+    non-degeneracy: there exists a non-degenerate conic carrying an inscribed
+    hexagon whose Pascal line is genuine.  This is the existence statement
+    underlying the well-definedness results of PART 4g–5b. -/
+theorem exists_inscribedHexagon_pascalProjLine_ne_zero :
+    ∃ (C : Conic), C.nondegenerate ∧
+      ∃ (hex : InscribedHexagon C), pascalProjLine hex ≠ 0 :=
+  ⟨stdConic, stdConic_nondegenerate, witnessHexagon, pascalProjLine_witnessHexagon_ne_zero⟩
+
+-- ============================================================
 -- PART 5: Pascal-Line Map
 -- ============================================================
 

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s9-nonvacuity-witness.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s9-nonvacuity-witness.md
@@ -1,0 +1,85 @@
+# S9 — Non-Vacuity Witness for the OQ-03-OQ-02 Well-Definedness Theory
+
+**Date:** 2026-06-27
+**Agent:** researcher-1
+**Phase:** ACT (addendum — non-vacuity of the conditional development)
+**Build status:** PENDING (host blocker, see below) — hand-verified by compiled precedent.
+
+## Motivation
+
+Every well-definedness theorem of PART 4g–5b carries a general-position
+hypothesis of the form `pascalProjLine (permuteHexagon hex k) ≠ 0` (the `hnd`
+family). PART 4j (S8) gave that hypothesis its exact geometric meaning ("the two
+spanning Pascal points are projectively distinct") and a checkable sufficient
+condition `pascalProjLine_ne_zero_of_minor` (one nonvanishing `2×2` minor ⟹ the
+line is genuine). But a sceptical reader should ask the **vacuity question**: is
+`hnd` ever satisfiable at all? If `pascalProjLine hex = 0` for *every* inscribed
+hexagon, the whole conditional theory would be empty.
+
+S9 rules that out with an explicit witness.
+
+## What was added (PART 4k)
+
+Appended **PART 4k** to `proofs/Proofs/PascalsHexagonOQ03.lean`
+(0 sorry / 0 new axiom):
+
+- `stdConic_nondegenerate` — the standard conic `x₀²+x₁²=x₂²` (matrix
+  `diag(1,1,-1)`) has `det = -1 ≠ 0`. (`Matrix.det_fin_three` + `norm_num`,
+  same pattern as parent line 403.)
+- `mem_stdConic` (private) — `![a,b,c]` with `a²+b²=c²` lies on `stdConic`.
+  (`Fin.sum_univ_three` + `Matrix.of_apply` + `linear_combination h`, mirroring
+  parent `stdConicPoint_on_conic` at line 349.)
+- `valid_of_last` (private) — `![a,b,c]` with `c ≠ 0` is a valid (nonzero)
+  projective point (`congrFun … 2` + `simpa`).
+- `witnessHexagon : InscribedHexagon stdConic` — the explicit hexagon with the
+  six rational conic points
+  `A=(1,0,1), B=(0,1,1), C=(-1,0,1), D=(0,-1,1), E=(3,4,5), F=(4,3,5)`.
+- `pascalProjLine_witnessHexagon_ne_zero` — **main result**: the witness's
+  Pascal line is genuinely nonzero. Discharged via `pascalProjLine_ne_zero_of_minor`
+  on the `(0,1)`-minor: `pascalP = (-6,-6,-12)`, `pascalQ = (2,12,10)`, so
+  `P₀Q₁ − P₁Q₀ = -72 − (-12) = -60 ≠ 0`. (`cross_apply` + `cons_val` simp set
+  + `norm_num`, the pattern of `crossProduct_eq_zero_iff` / `pascal_std_conic_parametrized`.)
+- `exists_inscribedHexagon_pascalProjLine_ne_zero` — packaged existence:
+  ∃ a non-degenerate conic carrying an inscribed hexagon with a genuine Pascal
+  line. The existence statement underlying PART 4g–5b.
+
+## Numerical check (Python, before encoding)
+
+```
+A=(1,0,1) B=(0,1,1) C=(-1,0,1) D=(0,-1,1) E=(3,4,5) F=(4,3,5)  on x²+y²=z²
+pascalP = cross(cross A B, cross D E) = (-6,-6,-12)
+pascalQ = cross(cross B C, cross E F) = ( 2,12, 10)
+pascalProjLine = cross(P,Q) = (84,36,-60) ≠ 0   (minor P₀Q₁−P₁Q₀ = -60)
+```
+
+## Significance (honest assessment)
+
+Modest but genuine. The core OQ-03-OQ-02 (`pascalLine` well-definedness) was
+already complete and verified through S8. S9 does **not** discharge the full
+`hnd` (all 720 relabelings) for any hexagon — that is the deep conic
+general-position theory, still open — and does **not** touch the open
+Steiner-20 / Kirkman-60 counts. What it does is close the *vacuity* gap: it
+proves the conditional well-definedness results are not empty statements by
+exhibiting one concrete model, and demonstrates `pascalProjLine_ne_zero_of_minor`
+firing on real data. This is the natural capstone to the PART 4j non-degeneracy
+analysis.
+
+## Build blocker (unchanged from S3–S5)
+
+`docker-build.sh` fails: host Data volume 100% full (8.2 GiB free) and the
+containerd blob store is I/O-corrupt (`docker system df` errors on a missing
+blob); no `lean4-arm64:v4.26.0` image present. Local single-file `lean`
+typecheck also impossible — the worktree's olean cache is partial
+(`Aesop.olean`, `Mathlib/Tactic.olean` absent), and refetching needs network +
+disk on a full volume. Direct `lake build` is prohibited by policy.
+
+All PART 4k proofs reuse tactic patterns with **compiled precedent in the same
+two files**: `simp only [Matrix.det_fin_three, Matrix.of_apply]` + `norm_num`
+(parent 403), `simp only [Fin.sum_univ_three, Matrix.of_apply]` for the
+`stdConic` match reduction (parent 351), `linear_combination h` (OQ03 1224/1439),
+the `cross_apply`/`cons_val` simp set + `norm_num` (OQ03 `crossProduct_eq_zero_iff`),
+and `congrFun`-at-index validity (OQ03 896–951). Same hand-verification status as
+S3–S5 (which S6 later build-confirmed once the host recovered).
+
+**Next (unchanged):** Steiner-20 / Kirkman-60 (OQ-03-OQ-03/04, genuinely open)
+and the full `hnd` general-position discharge remain the only open directions.

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
@@ -1,7 +1,34 @@
 # State: pascals-hexagon-oq-03-incomplete-01
 
-## Current Phase: ACT (OQ-03-OQ-02 COMPLETE + VERIFIED; incidence + uniqueness + nondeg-meaning)
-## Iteration: 8
+## Current Phase: ACT (OQ-03-OQ-02 COMPLETE; + non-vacuity witness)
+## Iteration: 9
+
+## Status (S9, researcher-1, 2026-06-27) — non-vacuity witness (BUILD PENDING)
+
+Added **PART 4k** to `PascalsHexagonOQ03.lean` (0 sorry / 0 new axiom): a
+concrete witness closing the *vacuity* gap in the OQ-03-OQ-02 well-definedness
+theory. Every descent theorem of PART 4g–5b is conditioned on
+`pascalProjLine … ≠ 0` (the `hnd` family); S9 proves that hypothesis is
+satisfiable.
+
+- `witnessHexagon : InscribedHexagon stdConic` — explicit hexagon on the
+  standard non-degenerate conic `x₀²+x₁²=x₂²` with six rational points
+  `A=(1,0,1), B=(0,1,1), C=(-1,0,1), D=(0,-1,1), E=(3,4,5), F=(4,3,5)`.
+- `pascalProjLine_witnessHexagon_ne_zero` — its Pascal line is genuinely
+  nonzero, via `pascalProjLine_ne_zero_of_minor` on the `(0,1)`-minor
+  (`P=(-6,-6,-12)`, `Q=(2,12,10)`, `P₀Q₁−P₁Q₀ = -60 ≠ 0`).
+- `stdConic_nondegenerate` (`det = -1 ≠ 0`), `mem_stdConic`, `valid_of_last`
+  helpers, and `exists_inscribedHexagon_pascalProjLine_ne_zero` (packaged
+  existence).
+
+Does NOT discharge full `hnd` (all 720 relabelings — deep general-position
+theory) and does NOT touch open Steiner-20/Kirkman-60 (2 remaining sorries).
+
+**BUILD PENDING**: same host blocker as S3–S5 (Docker disk 100% full +
+containerd blob corruption; local olean cache partial — `Aesop.olean` absent).
+All proofs reuse tactic patterns with compiled precedent in the same two files
+(parent 351/403, OQ03 1224/1439, `crossProduct_eq_zero_iff`, congrFun 896–951).
+See `sessions/2026-06-27-s9-nonvacuity-witness.md`.
 
 ## Status (S8, researcher-2, 2026-06-27) — VERIFIED, nondegeneracy meaning + uniqueness capstone
 


### PR DESCRIPTION
## Summary

Adds **PART 4k** to `proofs/Proofs/PascalsHexagonOQ03.lean`: a concrete
witness closing the **vacuity gap** in the Hexagrammum Mysticum Pascal-line
well-definedness theory (OQ-03-OQ-02).

Every descent theorem of PART 4g–5b carries a general-position hypothesis of
the form `pascalProjLine (permuteHexagon hex k) ≠ 0` (the `hnd` family). PART 4j
(S8) gave that hypothesis its exact geometric meaning and a checkable sufficient
condition `pascalProjLine_ne_zero_of_minor`. PART 4k answers the natural
follow-up — *is `hnd` ever satisfiable?* — by exhibiting an explicit model.

## What's added (0 sorry / 0 new axiom)

- `stdConic_nondegenerate` — standard conic `x₀²+x₁²=x₂²` has `det = -1 ≠ 0`.
- `mem_stdConic`, `valid_of_last` — point-on-conic / validity helpers for `![a,b,c]`.
- `witnessHexagon : InscribedHexagon stdConic` — explicit hexagon with six
  rational conic points `A=(1,0,1), B=(0,1,1), C=(-1,0,1), D=(0,-1,1),
  E=(3,4,5), F=(4,3,5)`.
- `pascalProjLine_witnessHexagon_ne_zero` — **main result**: the witness's
  Pascal line is genuinely nonzero, discharged via the `(0,1)`-minor
  (`pascalP = (-6,-6,-12)`, `pascalQ = (2,12,10)`, `P₀Q₁−P₁Q₀ = -60 ≠ 0`).
- `exists_inscribedHexagon_pascalProjLine_ne_zero` — packaged existence: a
  non-degenerate conic carrying an inscribed hexagon with a genuine Pascal line.

## Scope (honest)

Modest, incremental capstone to the PART 4j non-degeneracy analysis. Does **not**
discharge the full `hnd` (all 720 relabelings — deep conic general-position
theory) and does **not** touch the open Steiner-20 / Kirkman-60 counts
(OQ-03-OQ-03/04). It proves the conditional well-definedness results are not
empty statements.

## ⚠️ Build status: PENDING

`docker-build.sh` is blocked by a host issue (Data volume 100% full +
containerd blob-store I/O corruption; no `lean4-arm64:v4.26.0` image), and a
local single-file `lean` typecheck is impossible because the worktree olean
cache is partial (`Aesop.olean` / `Mathlib/Tactic.olean` absent). Direct
`lake build` is prohibited by policy. This is the same blocker documented in
sessions S3–S5 (which S6 later build-confirmed once the host recovered).

All PART 4k proofs reuse tactic patterns with **compiled precedent in the same
two files**:
- `simp only [Matrix.det_fin_three, Matrix.of_apply]` + `norm_num` (parent line 403)
- `simp only [Fin.sum_univ_three, Matrix.of_apply]` `stdConic` match reduction (parent line 351)
- `linear_combination h` (OQ03 lines 1224/1439)
- `cross_apply`/`cons_val` simp set + `norm_num` (`crossProduct_eq_zero_iff`)
- `congrFun`-at-index validity (OQ03 lines 896–951)

The non-degeneracy was numerically verified before encoding. **Please
build-verify with `./proofs/scripts/docker-build.sh Proofs.PascalsHexagonOQ03`
once the host recovers.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)