### PR TITLE
audit: drain queue 4058/4058 — 2 never-audited targets clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25193,6 +25193,18 @@
       "lastAudited": "2026-06-27T15:47:27Z",
       "result": "clean",
       "issues": []
+    },
+    "sum-of-divisors-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T19:03:40Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pascals-hexagon-incomplete-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T19:03:40Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Drained the audit queue: 2 never-audited gallery proofs verified clean against their Lean sources.

### sum-of-divisors-oq-01 — `verified` / `mathlib` ✓
- 5 theorems, **0 sorries, 0 axioms, 0 native_decide**
- Tier B mathlib bridge, correctly labeled `mathlib`; mathlib dependencies disclosed in meta.
- No overclaiming.

### pascals-hexagon-incomplete-01-oq-03-oq-01 — `verified` / `original` ✓
- 8 main + helper theorems, **0 sorries, 0 axioms, 0 native_decide**
- The `sorry`/`native_decide` substrings grep surfaces (lines 24, 54, 275) are **docstring prose**, not code — false-positive tokens.
- Claims match source.

Queue: 4058/4058 audited, 0 unaudited.

> Note: `fourth-root-2-irrational-oq-02` appeared as an unaudited target in a stale worktree but is **not on origin/main** (phantom from an in-flight researcher worktree); excluded.

---
Discovered during autonomous gallery integrity audit.