### PR TITLE
Enrich Class-Number/Siegel-Zero Equivalence (dirichlets-theorem-oq-01-oq-01-oq-04): annotation depth

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-01-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/dirichlets-theorem-oq-01-oq-01-oq-04/annotations.json
@@ -9,7 +9,10 @@
     "type": "concept",
     "title": "Making the Class-Number / Siegel-Zero Equivalence Tight: Strategy",
     "content": "The parent's open question asks whether the Goldfeld-Gross-Zagier class-number / Siegel-zero equivalence can be made tight, yielding an unconditional polynomial-log lower bound on h(-D). The genuinely open content is supplying that unconditional bound. This file formalizes the structural skeleton honestly: Dirichlet's class number formula h(-D) = κ√D·L(1,χ) is carried as an explicit hypothesis (not a global axiom), and we prove that class-number lower bounds, L-value lower bounds, and Siegel-zero depth bounds are all equivalent with explicit, matching constants. The file is 0-axiom and 0-sorry; it claims the equivalence, not the resolution.",
-    "mathContext": "$h(-D) = (w/2\\pi)\\sqrt{D}\\,L(1,\\chi_{-D})$; a Siegel zero $\\beta \\to 1$ makes $L(1,\\chi)$ small, hence $h(-D)/\\sqrt D$ small."
+    "mathContext": "$h(-D) = (w/2\\pi)\\sqrt{D}\\,L(1,\\chi_{-D})$; a Siegel zero $\\beta \\to 1$ makes $L(1,\\chi)$ small, hence $h(-D)/\\sqrt D$ small.",
+    "significance": "context",
+    "relatedConcepts": ["Dirichlet class number formula", "Siegel zero", "Goldfeld-Gross-Zagier theorem", "L(1,χ) for a quadratic character", "hypothesis vs global axiom"],
+    "prerequisites": ["imaginary quadratic class number h(-D)", "Dirichlet L-functions and Siegel zeros", "the class number formula h = κ√D·L(1,χ)"]
   },
   {
     "id": "ann-02-tight-equiv",
@@ -21,7 +24,10 @@
     "type": "theorem",
     "title": "classNumber_ge_iff_Lvalue_ge: the tight equivalence",
     "content": "Under the class number formula h = κ√D·L with κ, D > 0, the class-number lower bound κ√D·B ≤ h is equivalent to the L-value lower bound B ≤ L — with the IDENTICAL constant κ√D on both sides. This is the precise sense of 'tight': multiplication by the positive scalar κ√D is an order isomorphism on ℝ, so no information (in particular no logarithmic factor) is lost. The forward direction cancels via le_of_mul_le_mul_left; the reverse multiplies via mul_le_mul_of_nonneg_left. classNumber_gt_iff_Lvalue_gt is the strict analogue.",
-    "mathContext": "$\\kappa\\sqrt D \\cdot B \\le h \\iff B \\le L$ because $\\kappa\\sqrt D > 0$."
+    "mathContext": "$\\kappa\\sqrt D \\cdot B \\le h \\iff B \\le L$ because $\\kappa\\sqrt D > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["order isomorphism by a positive scalar", "le_of_mul_le_mul_left", "mul_le_mul_of_nonneg_left", "lossless (tight) equivalence"],
+    "prerequisites": ["multiplication by a positive real preserves ≤", "iff proofs in both directions", "the class number formula as a hypothesis"]
   },
   {
     "id": "ann-03-mvt-bridge",
@@ -33,7 +39,10 @@
     "type": "theorem",
     "title": "The mean-value bridge to Siegel-zero depth",
     "content": "The MVT comparison L ≤ M(1-β) connects the L-value to the depth (1-β) of a Siegel zero. Lvalue_le_of_deep_zero: a deep zero (1-β ≤ δ) forces a small L-value (L ≤ Mδ). zero_depth_ge_of_Lvalue_ge: an L-value floor B ≤ L pushes the zero to be shallow (B ≤ M(1-β)), stated division-free. zero_depth_lower_explicit gives the rearranged form B/M ≤ 1-β via div_le_iff₀ (note the ₀ suffix in Mathlib v4.26).",
-    "mathContext": "By MVT on $[\\beta,1]$, $m(1-\\beta) \\le L(1,\\chi) \\le M(1-\\beta)$; depth and L-value are comparable up to $m, M$."
+    "mathContext": "By MVT on $[\\beta,1]$, $m(1-\\beta) \\le L(1,\\chi) \\le M(1-\\beta)$; depth and L-value are comparable up to $m, M$.",
+    "significance": "key",
+    "relatedConcepts": ["mean value theorem comparison", "Siegel-zero depth (1-β)", "div_le_iff₀ (Mathlib v4.26 naming)", "two-sided linear bracketing"],
+    "prerequisites": ["L(1,χ) bounded between m(1-β) and M(1-β)", "division-free inequality manipulation", "what the depth of a real zero means"]
   },
   {
     "id": "ann-04-two-way",
@@ -45,7 +54,10 @@
     "type": "theorem",
     "title": "The two-way class-number ⇔ Siegel-depth bridge",
     "content": "Composing the tight equivalence with the MVT comparisons gives a genuine two-way bridge. classNumber_lower_bounds_zero_depth: a class-number floor κ√D·B ≤ h forces the zero to be shallow (B ≤ M(1-β)). zero_depth_lower_bounds_classNumber: a depth bound B ≤ m(1-β) yields a class-number floor κ√D·B ≤ h. So resolving the depth of Siegel zeros and proving an unconditional class-number lower bound are interchangeable — the heart of the equivalence.",
-    "mathContext": "Class-number floor $\\Leftrightarrow$ L-value floor $\\Leftrightarrow$ Siegel-zero shallowness, up to the explicit constants."
+    "mathContext": "Class-number floor $\\Leftrightarrow$ L-value floor $\\Leftrightarrow$ Siegel-zero shallowness, up to the explicit constants.",
+    "significance": "key",
+    "relatedConcepts": ["composition of equivalences", "interchangeable open problems", "class number lower bound", "Siegel-zero repulsion"],
+    "prerequisites": ["chaining the tight equivalence with the MVT bridge", "transitivity of the bounds", "the role of explicit constants m, M, κ"]
   },
   {
     "id": "ann-05-ggz",
@@ -57,6 +69,9 @@
     "type": "theorem",
     "title": "Goldfeld–Gross–Zagier, transported",
     "content": "ggz_lower_bound_transported is literally the class number formula applied to the effective bound c·g ≤ h, giving c·g ≤ κ√D·L. ggz_bounds_zero_depth composes with the MVT to get c·g ≤ κ√D·M(1-β). The content of the open problem is improving the shape g(D) — from a power of log D (what GGZ gives) to a power of √D — which by this bridge directly lower-bounds the Siegel-zero depth (1-β).",
-    "mathContext": "GGZ: $h(-D) \\gtrsim \\log D$ effectively; the open step is sharpening $g(D)$ to a $\\sqrt D$-power."
+    "mathContext": "GGZ: $h(-D) \\gtrsim \\log D$ effectively; the open step is sharpening $g(D)$ to a $\\sqrt D$-power.",
+    "significance": "supporting",
+    "relatedConcepts": ["Goldfeld-Gross-Zagier effective bound", "effective lower bound on h(-D)", "log D vs √D growth shapes", "transporting a bound through the class number formula"],
+    "prerequisites": ["the GGZ effective class-number bound", "the shape g(D) of a lower bound", "applying the class number formula to an inequality"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass (pass 0)

Axiom-free entry (status `verified`, badge `original`, axiomCount 0; class number formula carried as a hypothesis, not an axiom; meta 15.2 KB, under cap). Quality gap was annotation depth.

### Changes
- Added `significance`, `relatedConcepts`, `prerequisites` to all 5 annotations (key/supporting/context tiers; tight order-iso equivalence, MVT Siegel-depth bridge, two-way interchangeability, Goldfeld-Gross-Zagier transport).

### Verification
- JSON valid; `annotations/build.ts`: zero warnings for this target.
- Axiom integrity unchanged: `verified` / `original` / axiomCount 0.