### PR TITLE
Enrich Maclaurin's Inequality Chain from Newton Log-Concavity (newton-inductive-step-oq-01-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/newton-inductive-step-oq-01-oq-02/annotations.json
@@ -9,7 +9,10 @@
     "type": "concept",
     "title": "Deriving Maclaurin's Chain from Newton: Strategy",
     "content": "Newton's inequality is the log-concavity ēₖ² ≥ ēₖ₋₁·ēₖ₊₁ of the elementary symmetric means; Maclaurin's inequality is the resulting chain ē₁ ≥ ē₂^{1/2} ≥ ... ≥ ēₙ^{1/n}. The parent file proved Newton only for k = 1 (the general k ≥ 2 case is still an open sorry). Rather than build on that sorry, this file proves the REDUCTION: for any abstract positive sequence a with a₀ = 1, log-concavity implies the Maclaurin chain. The whole development is 0-axiom and 0-sorry; Newton's inequalities are an explicit hypothesis, so instantiating a := ēₖ gives the full chain once the parent's Newton case is completed.",
-    "mathContext": "Log-concavity ⟹ non-increasing ratios ⟹ non-increasing running geometric mean ēₖ^{1/k}."
+    "mathContext": "Log-concavity ⟹ non-increasing ratios ⟹ non-increasing running geometric mean ēₖ^{1/k}.",
+    "significance": "context",
+    "relatedConcepts": ["Newton's inequalities", "Maclaurin's inequality", "log-concave sequences", "elementary symmetric means", "reduction proof avoiding a parent sorry"],
+    "prerequisites": ["elementary symmetric means ēₖ", "log-concavity ēₖ² ≥ ēₖ₋₁ēₖ₊₁", "the AM-GM / Maclaurin chain"]
   },
   {
     "id": "ann-02-ratios",
@@ -21,7 +24,10 @@
     "type": "theorem",
     "title": "Log-concavity ⇒ ratios non-increasing",
     "content": "Define ratioSeq a k = a k / a (k-1). ratioSeq_step_of_logConcave: the log-concavity a(k-1)·a(k+1) ≤ a k² cross-multiplies (div_le_div_iff₀, the v4.26 name) to r(k+1) ≤ r k. ratioSeq_antitone_of_logConcave: by induction on n, for 1 ≤ m ≤ n the ratio r n ≤ r m — the ratios are non-increasing from index 1 onward. This monotonicity of ratios is the entire content of Newton's inequality for the chain.",
-    "mathContext": "$a(k-1)a(k+1) \\le a(k)^2 \\iff \\tfrac{a(k+1)}{a(k)} \\le \\tfrac{a(k)}{a(k-1)}$."
+    "mathContext": "$a(k-1)a(k+1) \\le a(k)^2 \\iff \\tfrac{a(k+1)}{a(k)} \\le \\tfrac{a(k)}{a(k-1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["consecutive-ratio sequence", "antitone sequence", "div_le_div_iff₀ (Mathlib v4.26)", "log-concavity as ratio monotonicity"],
+    "prerequisites": ["cross-multiplying a ratio inequality", "induction to extend a one-step bound", "positivity of the sequence"]
   },
   {
     "id": "ann-03-telescope",
@@ -33,7 +39,10 @@
     "type": "theorem",
     "title": "Telescoping product",
     "content": "prod_ratioSeq: ∏_{j=1}^k (a j / a (j-1)) = a k. By induction with Finset.prod_Icc_succ_top, peeling the top factor a(k+1)/a k; mul_div_cancel₀ collapses a k · (a(k+1)/a k) = a(k+1), and a₀ = 1 seeds the empty product. This expresses a k as a product of the (non-increasing) ratios — the key to viewing ēₖ^{1/k} as a running geometric mean.",
-    "mathContext": "$\\prod_{j=1}^k r_j = a_k$ with $r_j = a_j/a_{j-1}$ and $a_0 = 1$."
+    "mathContext": "$\\prod_{j=1}^k r_j = a_k$ with $r_j = a_j/a_{j-1}$ and $a_0 = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping product", "Finset.prod_Icc_succ_top", "mul_div_cancel₀", "running geometric mean"],
+    "prerequisites": ["induction on a finite product", "peeling the top factor of an Icc product", "the normalization a₀ = 1"]
   },
   {
     "id": "ann-04-maclaurin-poly",
@@ -45,7 +54,10 @@
     "type": "theorem",
     "title": "Maclaurin's chain, polynomial form",
     "content": "lastRatio_pow_le: r(k+1)^k ≤ a k, because r(k+1)^k = ∏_{j≤k} r(k+1) ≤ ∏_{j≤k} r j = a k by Finset.prod_le_prod (each earlier ratio r j is ≥ r(k+1)) and prod_ratioSeq; the card of Icc 1 k is k (Nat.card_Icc). maclaurin_pow then writes a(k+1) = a k·r(k+1), so a(k+1)^k = a k^k·r(k+1)^k ≤ a k^k·a k = a k^{k+1}. This polynomial form avoids real powers entirely.",
-    "mathContext": "$a_{k+1}^k \\le a_k^{k+1}$, equivalent to $a_{k+1}^{1/(k+1)} \\le a_k^{1/k}$."
+    "mathContext": "$a_{k+1}^k \\le a_k^{k+1}$, equivalent to $a_{k+1}^{1/(k+1)} \\le a_k^{1/k}$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.prod_le_prod", "bounding a constant power by a product", "Nat.card_Icc", "natural-power form of Maclaurin"],
+    "prerequisites": ["smallest ratio bounds a product of ratios", "the telescoping identity ∏ r = a k", "natural-number exponent arithmetic"]
   },
   {
     "id": "ann-05-maclaurin-root",
@@ -57,6 +69,9 @@
     "type": "theorem",
     "title": "Maclaurin's chain, radical form",
     "content": "maclaurin_root: a(k+1)^{1/(k+1)} ≤ a k^{1/k} with genuine real powers (Real.rpow). The polynomial form is recast with real exponents via Real.rpow_natCast, then both sides are raised to the nonnegative power 1/(k(k+1)) by Real.rpow_le_rpow; Real.rpow_mul collapses the iterated powers and field_simp simplifies (k)·(1/(k(k+1))) = 1/(k+1) and (k+1)·(1/(k(k+1))) = 1/k. This is the Maclaurin chain ē₁ ≥ ē₂^{1/2} ≥ ... exactly as classically stated.",
-    "mathContext": "$\\bar e_1 \\ge \\bar e_2^{1/2} \\ge \\bar e_3^{1/3} \\ge \\cdots$"
+    "mathContext": "$\\bar e_1 \\ge \\bar e_2^{1/2} \\ge \\bar e_3^{1/3} \\ge \\cdots$",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.rpow and rpow_natCast", "raising an inequality to a fractional power", "Real.rpow_mul", "classical Maclaurin chain in radical form"],
+    "prerequisites": ["real (rpow) exponentiation and its monotonicity", "field_simp on rational exponents", "converting natural powers to real powers"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass (pass 0)

Axiom-free entry (`verified` / `original` / axiomCount 0; Newton's inequalities carried as a hypothesis; meta 13.6 KB, under cap). Quality gap was annotation depth.

### Changes
- Added `significance`, `relatedConcepts`, `prerequisites` to all 5 annotations (key/supporting/context tiers; ratio-sequence antitonicity, telescoping product, polynomial & radical Maclaurin forms, Real.rpow manipulation).

### Verification
- JSON valid; `annotations/build.ts`: zero warnings for this target.
- Axiom integrity unchanged: `verified` / `original` / axiomCount 0.