### PR TITLE
Enrich Sum of Reciprocal Odd Squares = π²/8 (basel-problem-oq-06-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/basel-problem-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-06-oq-01/annotations.json
@@ -9,7 +9,10 @@
     "type": "concept",
     "title": "basel_hasSum: The Basel Identity from Mathlib",
     "content": "**basel_hasSum** records the Basel identity in `HasSum` form: $\\sum_{n=1}^\\infty 1/n^2 = \\pi^2/6$, supplied by Mathlib's `hasSum_zeta_two`. The base summand is `f n = 1/n²`. Everything downstream is an elementary corollary of this one input — no new analytic content is introduced.",
-    "mathContext": "Mathlib proves $\\zeta(2) = \\pi^2/6$ via Bernoulli polynomials and Parseval's identity for the sawtooth Fourier series, a route quite different from Euler's original product argument."
+    "mathContext": "Mathlib proves $\\zeta(2) = \\pi^2/6$ via Bernoulli polynomials and Parseval's identity for the sawtooth Fourier series, a route quite different from Euler's original product argument.",
+    "significance": "key",
+    "relatedConcepts": ["Basel problem ζ(2)=π²/6", "HasSum vs tsum", "hasSum_zeta_two (Mathlib)", "Riemann zeta at 2"],
+    "prerequisites": ["the value of ζ(2)", "the HasSum predicate", "summand f n = 1/n²"]
   },
   {
     "id": "ann-bp0601-even",
@@ -21,7 +24,10 @@
     "type": "technique",
     "title": "hasSum_even: Even Squares Sum to π²/24 by Rescaling",
     "content": "**hasSum_even** proves $\\sum_{k\\ge 1} 1/(2k)^2 = \\pi^2/24$. The even-indexed term satisfies $1/(2k)^2 = (1/4)\\cdot 1/k^2$, so the even subsequence is the Basel series scaled by $1/4$. `HasSum.mul_left (1/4)` produces a `HasSum` with value $(1/4)(\\pi^2/6) = \\pi^2/24$, and `HasSum.congr_fun` reduces the goal to the pointwise identity, discharged by `push_cast`/`ring`.",
-    "mathContext": "Scaling a convergent series by a constant scales its sum by the same constant — the key tool is `HasSum.mul_left`."
+    "mathContext": "Scaling a convergent series by a constant scales its sum by the same constant — the key tool is `HasSum.mul_left`.",
+    "significance": "supporting",
+    "relatedConcepts": ["HasSum.mul_left (linearity)", "even subsequence as a rescaled series", "HasSum.congr_fun", "factor 1/4 = (1/2)²"],
+    "prerequisites": ["scaling a series scales its sum", "the identity 1/(2k)² = (1/4)/k²", "push_cast/ring for pointwise equalities"]
   },
   {
     "id": "ann-bp0601-summable",
@@ -33,7 +39,10 @@
     "type": "technique",
     "title": "summable_odd: The Odd Subsequence is Summable",
     "content": "**summable_odd** establishes that $k \\mapsto 1/(2k+1)^2$ is summable. Since $k \\mapsto 2k+1$ is injective (`omega`), the odd terms form a reindexed subseries of the summable Basel series, and `Summable.comp_injective` transfers summability. This summability is what lets `even_add_odd` recombine the two halves.",
-    "mathContext": "A subseries of a summable nonnegative series, taken along an injective index map, is itself summable."
+    "mathContext": "A subseries of a summable nonnegative series, taken along an injective index map, is itself summable.",
+    "significance": "supporting",
+    "relatedConcepts": ["Summable.comp_injective", "injective reindexing (k ↦ 2k+1)", "subseries of a summable series", "omega for arithmetic injectivity"],
+    "prerequisites": ["summability under injective reindexing", "the Basel series is summable", "injectivity of k ↦ 2k+1"]
   },
   {
     "id": "ann-bp0601-odd",
@@ -45,7 +54,10 @@
     "type": "key-step",
     "title": "hasSum_odd: Odd Squares Sum to π²/8 by Uniqueness",
     "content": "**hasSum_odd** is the main result: $\\sum_{k\\ge 0} 1/(2k+1)^2 = \\pi^2/8$. Let $b$ be the (a priori unknown) value of the odd sum. `HasSum.even_add_odd` combines the even part ($\\pi^2/24$) with the odd part to reconstruct the full Basel series, giving `HasSum f (π²/24 + b)`. Uniqueness of sums (`HasSum.unique`) against the Basel value forces $\\pi^2/6 = \\pi^2/24 + b$, so `linarith` yields $b = \\pi^2/8$.",
-    "mathContext": "The odd value is pinned not by computing it directly but by uniqueness: even + odd = whole, and the whole and even values are known. $\\pi^2/6 - \\pi^2/24 = \\pi^2/8$."
+    "mathContext": "The odd value is pinned not by computing it directly but by uniqueness: even + odd = whole, and the whole and even values are known. $\\pi^2/6 - \\pi^2/24 = \\pi^2/8$.",
+    "significance": "key",
+    "relatedConcepts": ["HasSum.even_add_odd", "uniqueness of sums (HasSum.unique)", "solving for an unknown sum", "even+odd decomposition of ℕ"],
+    "prerequisites": ["a series has at most one sum", "splitting ℕ into even and odd indices", "π²/6 − π²/24 = π²/8"]
   },
   {
     "id": "ann-bp0601-restate",
@@ -57,6 +69,9 @@
     "type": "concept",
     "title": "Natural-Form, tsum, and Consistency Restatements",
     "content": "**odd_squares_hasSum** restates the result with the explicit summand $1/(2k+1)^2$ (as a real), and **odd_squares_tsum** gives the `tsum` equality $\\sum'_k 1/(2k+1)^2 = \\pi^2/8$. **odd_squares_pos** and **even_add_odd_eq_basel** record the positivity of the value and the consistency check $\\pi^2/24 + \\pi^2/8 = \\pi^2/6$.",
-    "mathContext": "This identity is the $s=2$ value of the Dirichlet lambda function $\\lambda(s) = (1-2^{-s})\\zeta(s)$: $\\lambda(2) = (3/4)\\zeta(2) = \\pi^2/8$."
+    "mathContext": "This identity is the $s=2$ value of the Dirichlet lambda function $\\lambda(s) = (1-2^{-s})\\zeta(s)$: $\\lambda(2) = (3/4)\\zeta(2) = \\pi^2/8$.",
+    "significance": "context",
+    "relatedConcepts": ["Dirichlet lambda function λ(s)", "tsum restatement", "HasSum.tsum_eq", "positivity (positivity tactic)"],
+    "prerequisites": ["converting HasSum to tsum", "λ(2) = (3/4)ζ(2)", "consistency checks via ring"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass (pass 0)

Axiom-free entry (`verified` / badge `verified` / axiomCount 0; meta 9.7 KB, under cap). Quality gap was annotation depth.

### Changes
- Added `significance`, `relatedConcepts`, `prerequisites` to all 5 annotations (key/supporting/context tiers; HasSum.mul_left rescaling, Summable.comp_injective, even_add_odd + uniqueness to pin the odd sum, Dirichlet lambda λ(2)).

### Verification
- JSON valid; `annotations/build.ts`: zero warnings for this target.
- Axiom integrity unchanged: `verified` / axiomCount 0.