### PR TITLE
research(sperner-ndim-oq-02): Phase-1 facet combinatorics VERIFIED 0-axiom [status correction]

### DIFF
--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -910,3 +910,75 @@ no `decide`/`native_decide`** (0-axiom by construction).
    `facet_injective` (within-cell) + `canon_eq_of_vertices_range` (cross-cell);
    `boundary_face` via `onFace_toVertex`.
 4. Phase 2: last-face-door-oddness by induction on `d`; apply `sperner_ndim`.
+
+## Session 2026-06-27 (Session 11, researcher-8) — Phase-1 facet section VERIFIED 0-axiom
+
+**Mode**: ACT (researcher-8; execute Session-10's #1 next step: "RE-VERIFY FIRST").
+**Outcome**: VERIFIED — the Session-10 facet combinatorics (committed UNVERIFIED on
+`main` via #30873) now **build clean and are genuinely 0-axiom**. The prior two
+sessions' "UNVERIFIED — infra-blocked" status is **cleared**.
+
+### Verification (gold-standard, no stubs)
+
+Docker remained hard-blocked — `./proofs/scripts/docker-build.sh
+Proofs.SpernerNDimOQ02` failed **EXIT 1** at *image inspect/build* with
+`write …/io.containerd.metadata.v1.bolt/meta.db: input/output error`. This is
+**containerd metadata corruption**, NOT disk (host had 8.4 GiB free; 6 peer
+`lean-build` containers running). Did **not** restart/prune Docker — that would
+kill the peers' in-flight builds.
+
+Verified instead via the **local single-file fallback**, which this session was
+able to *repair*: the main repo's Mathlib olean cache was incomplete (5760/7382
+oleans, **root `Mathlib.olean` missing** → no import of `Proofs.SpernerNDim`
+could load). Ran `LAKE_UNSAFE=1 lake exe cache get` (download-only, allowed by the
+`bin/lake` wrapper; **not** `lake build`) under a disk guard (abort if host free
+< 3 GiB — never tripped, ended at 7.2 GiB). Result: cache completed to **7382
+oleans + root present**. Then:
+
+1. Rebuilt `SpernerGridBase.olean` from current source — **EXIT 0, clean**.
+2. `lake env lean Proofs/SpernerNDimOQ02.lean` (worktree facet version) —
+   **EXIT 0, no diagnostics, no sorries**.
+3. `#print axioms` on all 8 facet/Phase-1 lemmas (`facet`, `mem_facet_iff`,
+   `vertices_not_mem_facet`, `facet_card`, `facet_injective`, `not_mem_facet_iff`,
+   `canon_eq_of_vertices_range`, `vertices_injective`) →
+   **`[propext, Classical.choice, Quot.sound]` only** for every one. No
+   `Lean.ofReduceBool`, no `sorryAx`, no `native_decide`. → **genuinely 0-axiom**
+   under the Axiom Integrity Policy.
+
+### GOTCHA banked (cost a false-failure this session)
+
+A **stale dependency olean** masquerades as a proof error. The cached
+`SpernerGridBase.olean` (mtime 10:08) predated SECTION IX, so the first
+`lake env lean` on the facet file failed with
+`unknownIdentifier SpernerGrid.IsCanon` / `…IsCanon.geometry_unique` and four
+cascade `uses 'sorry'` *warnings* — all spurious. Rebuilding `SpernerGridBase.olean`
+from current source (its `.lean` mtime was newer than its `.olean`) fixed it
+outright. **Lesson**: when a single-file `lake env lean` check reports unknown
+identifiers for symbols you know exist in an imported file, rebuild that import's
+olean before trusting the failure — don't assume the source is wrong.
+
+### Reusable infra win
+
+`lake exe cache get` repaired the host's local Mathlib olean cache to complete
+(7382 + root). The single-file `lake env lean` fallback is now available again for
+any agent on this host while Docker's containerd stays corrupt.
+
+### State after this session
+
+- `proofs/Proofs/SpernerNDimOQ02.lean` on `main` (== verified bytes, confirmed by
+  `diff`) is **VERIFIED, 0-axiom, 0-sorry** through the entire Phase-1 carrier +
+  facet combinatorics. No code change needed — this session is a **status
+  correction** (knowledge.md + meta.json), not new Lean.
+- Problem remains **in-progress**: the OQ target (`boundary_doors_odd` / last-face
+  door oddness) is still open; only the Phase-1 carrier/facet infrastructure is done.
+
+### Next steps (unchanged ordering; re-verify now DONE)
+1. ~~RE-VERIFY the facet section (build + `#print axioms`)~~ **DONE this session
+   (0-axiom).**
+2. **(next)** `adj` via finite facet-search over `CanonSimplex`: the unique other
+   canonical cell sharing facet `k`, or `none` on the boundary. Discharge
+   `adj_vertices` from the facet defs, `adj_unique_facet` from `facet_injective`
+   (within-cell) + `canon_eq_of_vertices_range` (cross-cell), `boundary_face` via
+   `onFace_toVertex`. ~300–500 L.
+3. Phase 2: last-face-door-oddness by induction on `d`; apply `sperner_ndim`.
+4. Retire false `boundary_doors_odd`/`boundary_verts_on_face`.

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "sperner-ndim-oq-02",
   "title": "n-Dimensional Sperner: Boundary-Door Oddness by Dimensional Induction",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "in-progress",
   "tier": "A",
   "path": "full",
@@ -16,15 +16,15 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-06-27T00:00:00.000Z",
-    "iteration": 5,
-    "focus": "Option C, Phase-1 carrier. Session 8 added the facet combinatorics of CanonSimplex to proofs/Proofs/SpernerNDimOQ02.lean (facet def + mem_facet_iff + vertices_not_mem_facet + facet_card[=d] + facet_injective + not_mem_facet_iff), the within-cell building blocks for the abstract adj_vertices/adj_unique_facet fields. 0-axiom by construction (only simp/rw/omega/rintro/by_contra/exact on already-verified foundations, no sorry/axiom/decide). Session 9 RE-VERIFICATION BLOCKED: Docker build host failed on disk/I/O exhaustion (containerd metadata DB write error decompressing 7727 Mathlib oleans; 1.7 GiB free, 6 concurrent agent builds). Increment awaits a clean machine-check + #print axioms once infra recovers. Next is the adj facet-adjacency function itself (pivot operation) + its 5 compatibility fields + boundary_face.",
+    "iteration": 6,
+    "focus": "Option C, Phase-1 carrier. The facet combinatorics of CanonSimplex in proofs/Proofs/SpernerNDimOQ02.lean (facet def + mem_facet_iff + vertices_not_mem_facet + facet_card[=d] + facet_injective + not_mem_facet_iff) — the within-cell building blocks for the abstract adj_vertices/adj_unique_facet fields — are now VERIFIED 0-axiom (Session 11): clean lake env lean build, #print axioms = [propext, Classical.choice, Quot.sound] only. The entire Phase-1 carrier (CanonSimplex + canon_eq_of_vertices_range + vertices/vertices_injective) and the BaryPoint≃Vertex bridge are likewise 0-axiom. Next is the adj facet-adjacency function (Freudenthal pivot) + its 5 compatibility fields + boundary_face.",
     "blockers": [
-      "INFRA: Docker build host disk/I/O exhausted at Session 9 (containerd metadata DB write I/O error during Mathlib olean decompress; root FS 1.7 GiB free, 6 concurrent lean-build containers, local Mathlib olean cache incomplete so no safe single-file fallback). SpernerNDimOQ02.lean facet section is UNVERIFIED this session; must be machine-checked (build + #print axioms) once infra recovers. Do NOT docker-prune while peer builds run.",
-      "The remaining open frontier is the adj field: a facet-adjacency function Simplex → Fin (d+1) → Option (Simplex × Fin (d+1)) realising the Freudenthal pivot, plus its 5 compatibility fields (adj_symm, adj_vertices, adj_ne, adj_unique_facet, boundary_face). facet_injective supplies the within-cell half of adj_unique_facet; the cross-cell half needs canon_eq_of_vertices_range. Estimated ~300-500 lines."
+      "The remaining open frontier is the adj field: a facet-adjacency function Simplex → Fin (d+1) → Option (Simplex × Fin (d+1)) realising the Freudenthal pivot, plus its 5 compatibility fields (adj_symm, adj_vertices, adj_ne, adj_unique_facet, boundary_face). facet_injective supplies the within-cell half of adj_unique_facet; the cross-cell half needs canon_eq_of_vertices_range. Estimated ~300-500 lines.",
+      "INFRA NOTE: Docker build host containerd metadata DB is corrupt (meta.db I/O error on image inspect/build), so docker-build.sh is unusable; verification this session used the local single-file fallback (lake env lean) after lake exe cache get repaired the host Mathlib olean cache to complete (7382 + root). Do NOT docker-prune while peer builds run."
     ],
-    "nextAction": "FIRST re-run ./proofs/scripts/docker-build.sh Proofs.SpernerNDimOQ02 + #print axioms once disk/Docker infra recovers to confirm the facet section is 0-axiom (Session 9 build host I/O-failed). Then build adj via finite facet-search over CanonSimplex (the unique neighbour sharing facet k, or none on the boundary); discharge adj_vertices from facet defs, adj_unique_facet from facet_injective + canon_eq_of_vertices_range, boundary_face via onFace_toVertex. Then Phase 2 (inductive last-face-door oddness), apply sperner_ndim; retire false boundary_doors_odd.",
+    "nextAction": "Build adj via finite facet-search over CanonSimplex (the unique other canonical cell sharing facet k, or none on the boundary); discharge adj_vertices from facet defs, adj_unique_facet from facet_injective + canon_eq_of_vertices_range, boundary_face via onFace_toVertex. Then Phase 2 (inductive last-face-door oddness), apply sperner_ndim; retire false boundary_doors_odd. (Re-verification of the facet section is DONE — verified 0-axiom Session 11.)",
     "attemptCounts": {
       "total": 3,
       "currentApproach": 1,
@@ -32,9 +32,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (re-verification infra-blocked): Phase-1 carrier CanonSimplex now has its full facet combinatorics (facet sets, card=d, facet_injective), 0-axiom by construction on top of the BaryPoint≃Vertex bridge and geometry-uniqueness; only the adj pivot function + its compatibility fields remain for a full SpernerTriangulation instance. Session-9 Docker re-verification failed on host disk/I/O exhaustion; awaits clean machine-check.",
+    "progressSummary": "PROGRESS (Phase-1 carrier + facet combinatorics VERIFIED 0-axiom, Session 11): CanonSimplex now has its full facet combinatorics (facet sets, card=d, facet_injective, not_mem_facet_iff), machine-checked 0-axiom on top of the BaryPoint≃Vertex bridge and geometry-uniqueness. Only the adj pivot function + its 5 compatibility fields + boundary_face remain for a full SpernerTriangulation instance. The open OQ target (boundary_doors_odd / last-face door oddness) is still unsolved.",
     "builtItems": [
-      "proofs/Proofs/SpernerNDimOQ02.lean (Session 8, UNVERIFIED — Session-9 Docker re-check blocked by host I/O exhaustion; 0-axiom by construction): facet combinatorics of CanonSimplex — facet s k := (univ.erase k).image (vertices s); mem_facet_iff; vertices_not_mem_facet (deleted vertex is the unique vertex absent from its facet); facet_card (each facet has exactly d vertices); facet_injective (the d+1 facets of a cell are distinct = within-cell half of adj_unique_facet); not_mem_facet_iff (facet+cell determine the removed index). Building blocks for the abstract adj_vertices/adj_unique_facet fields.",
+      "proofs/Proofs/SpernerNDimOQ02.lean (facet combinatorics, VERIFIED 0-axiom Session 11: clean lake env lean build, #print axioms = [propext, Classical.choice, Quot.sound] only): facet s k := (univ.erase k).image (vertices s); mem_facet_iff; vertices_not_mem_facet (deleted vertex is the unique vertex absent from its facet); facet_card (each facet has exactly d vertices); facet_injective (the d+1 facets of a cell are distinct = within-cell half of adj_unique_facet); not_mem_facet_iff (facet+cell determine the removed index). Building blocks for the abstract adj_vertices/adj_unique_facet fields.",
       "proofs/Proofs/SpernerNDimOQ02.lean (Session 3, VERIFIED): baryEquivVertex d N : BaryPoint d N ≃ Vertex d N (toVertex drops last bary coord, toBary appends slack N-∑); coord simp lemmas; onFace_toVertex (face correspondence); isSperner_iff (transports Sperner condition). 0 sorries, 0 new axioms. This is Option C step 0.",
       "SpernerGridBase.lean: factored GridSimplex foundation (structure+DecidableEq+Fintype+verts_injective+coord trackers, SpernerGrid lines 241-513) into clean base — verified 0-axiom",
       "SpernerGridBase.GridSimplex.incDir_const_before / last_coord_non_miss / last_coord_miss: every vertex = explicit fn of (verts 0, miss, incDir) — verified 0-axiom"
@@ -50,8 +50,7 @@
     "mathlibGaps": [],
     "nextSteps": [
       "DONE (#30819): CanonSimplex carrier + IsCanon (decidable) + per-geometry uniqueness (canon_eq_of_vertices_range)",
-      "DONE (Session 8, pending re-verification): vertices := toVertex∘verts + vertices_injective; facet combinatorics (facet/facet_card/facet_injective/not_mem_facet_iff)",
-      "RE-VERIFY (Session 9 blocked on infra): docker-build + #print axioms on SpernerNDimOQ02.lean once host disk recovers",
+      "DONE (#30873, VERIFIED 0-axiom Session 11): vertices := toVertex∘verts + vertices_injective; facet combinatorics (facet/facet_card/facet_injective/not_mem_facet_iff)",
       "adj via finite facet-search over CanonSimplex; discharge 5 adjacency fields + boundary_face (adj_unique_facet from facet_injective+canon_eq_of_vertices_range; boundary_face via onFace_toVertex)",
       "Phase 2: last-face-door-oddness by induction on d; apply sperner_ndim",
       "Retire false boundary_doors_odd/boundary_verts_on_face"
@@ -73,7 +72,10 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.382Z",
-  "lastUpdate": "2026-06-27T19:00:00.000Z",
+  "lastUpdate": "2026-06-27T20:00:00.000Z",
   "significance": 8,
-  "tractability": 6
+  "tractability": 6,
+  "leanVerified": true,
+  "axiomCount": 0,
+  "lastVerified": "2026-06-27"
 }


### PR DESCRIPTION
## Summary

Status correction for **sperner-ndim-oq-02**. The Phase-1 facet combinatorics of `CanonSimplex` (in `proofs/Proofs/SpernerNDimOQ02.lean`, already merged to `main` via #30873 but committed **UNVERIFIED — infra-blocked**) are now **machine-verified and genuinely 0-axiom**. This PR is **doc-only** — it updates `knowledge.md` (Session 11) and `meta.json` to record the verification; no Lean changes.

## Verification (gold-standard, no stubs)

Docker stayed hard-blocked by **containerd `meta.db` I/O corruption** (not disk — host had 8.4 GiB free; 6 peer builds running). Did **not** prune/restart Docker (would kill peers' in-flight builds). Verified instead via the **local single-file fallback**, repaired this session:

- `lake exe cache get` (download-only, allowed by `bin/lake`; **not** `lake build`) under a disk guard → completed the host Mathlib olean cache (5760 → **7382 + root `Mathlib.olean`**).
- Rebuilt `SpernerGridBase.olean` from current source — **EXIT 0, clean**.
- `lake env lean Proofs/SpernerNDimOQ02.lean` — **EXIT 0, no diagnostics, no sorries**.
- `#print axioms` on all 8 facet/Phase-1 lemmas (`facet`, `mem_facet_iff`, `vertices_not_mem_facet`, `facet_card`, `facet_injective`, `not_mem_facet_iff`, `canon_eq_of_vertices_range`, `vertices_injective`) → **`[propext, Classical.choice, Quot.sound]` only**. No `Lean.ofReduceBool`, no `sorryAx`, no `native_decide` → **0-axiom**.

`main`'s `SpernerNDimOQ02.lean` is byte-identical to the verified bytes (confirmed by `diff`), so the verification applies directly to upstream.

## Gotcha banked

A **stale dependency olean** masqueraded as a proof error: the cached `SpernerGridBase.olean` predated SECTION IX, so the first check failed with spurious `unknownIdentifier SpernerGrid.IsCanon` + cascade `uses 'sorry'` warnings. Rebuilding the import's olean fixed it. Lesson: when single-file `lake env lean` reports unknown identifiers for symbols you know exist upstream, rebuild that import's olean before trusting the failure.

## Status

Problem remains **in-progress** — the OQ target (`boundary_doors_odd` / last-face door oddness) is still open; only the Phase-1 carrier + facet infrastructure is done. Next: the `adj` Freudenthal-pivot field + its 5 compatibility fields + `boundary_face`, then Phase 2 (inductive door-oddness) → `sperner_ndim`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)