### PR TITLE
Enrich Bertrand Series Threshold Σ1/(n(log n)^p) (harmonic-divergence-oq-02-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-02-oq-01/annotations.json
@@ -3,61 +3,76 @@
     "id": "ann-bertrand-def",
     "proofId": "harmonic-divergence-oq-02-oq-01",
     "range": {
-      "startLine": 49,
+      "startLine": 53,
       "endLine": 89
     },
     "type": "definition",
     "title": "The Real-Exponent Bertrand Term with a Repaired Small-Index Cap",
     "content": "bertrand p n is 1/(n·(log n)^p) for n ≥ 2, where (log n)^p is a genuine real power (Real.rpow). For n < 2 the value is capped at the n=2 term rather than set to 0. This cap matters: the parent's `if n < 2 then 0` makes f(1)=0 lie below f(2)>0, so the sequence is NOT non-increasing on the positives and the antitone hypothesis of the condensation test is unprovable at (m,n)=(1,2). Capping at the n=2 value changes only finitely many terms (so convergence is unaffected) while making the sequence genuinely antitone on all positive indices.",
-    "mathContext": "The exponent on $\\log n$ is real, so the family $\\{1/(n(\\log n)^p)\\}_{p\\in\\mathbb{R}}$ is parameterized continuously. `denom_pos` shows $n(\\log n)^p>0$ for $n\\ge 2$ via `Real.rpow_pos_of_pos` and $\\log n>0$, and `bertrand_nonneg` follows."
+    "mathContext": "The exponent on $\\log n$ is real, so the family $\\{1/(n(\\log n)^p)\\}_{p\\in\\mathbb{R}}$ is parameterized continuously. `denom_pos` shows $n(\\log n)^p>0$ for $n\\ge 2$ via `Real.rpow_pos_of_pos` and $\\log n>0$, and `bertrand_nonneg` follows.",
+    "significance": "key",
+    "relatedConcepts": ["Bertrand series 1/(n(log n)^p)", "Real.rpow real exponent", "repairing antitonicity at small indices", "finitely-many-terms invariance of convergence"],
+    "prerequisites": ["the Bertrand/logarithmic series", "real powers (rpow)", "why a small-index cap preserves convergence"]
   },
   {
     "id": "ann-bertrand-antitone",
     "proofId": "harmonic-divergence-oq-02-oq-01",
     "range": {
-      "startLine": 90,
+      "startLine": 92,
       "endLine": 117
     },
     "type": "theorem",
     "title": "Antitonicity for p ≥ 0",
     "content": "For p ≥ 0 the term is non-increasing on positive indices — exactly the hypothesis summable_condensed_iff_of_nonneg requires. The core fact is monotonicity of the denominator: m·(log m)^p ≤ n·(log n)^p for 2 ≤ m ≤ n, since m ≤ n and (log m)^p ≤ (log n)^p (Real.rpow_le_rpow, using p ≥ 0 and log m ≥ 0). The m=1 boundary is dispatched by the cap, which equals the n=2 value and therefore dominates every later term.",
-    "mathContext": "`one_div_le_one_div_of_le` converts the denominator inequality into $1/(n(\\log n)^p)\\le 1/(m(\\log m)^p)$. The p ≥ 0 hypothesis is essential and genuinely used (for p < 0 antitonicity is false)."
+    "mathContext": "`one_div_le_one_div_of_le` converts the denominator inequality into $1/(n(\\log n)^p)\\le 1/(m(\\log m)^p)$. The p ≥ 0 hypothesis is essential and genuinely used (for p < 0 antitonicity is false).",
+    "significance": "key",
+    "relatedConcepts": ["antitone sequence", "Real.rpow_le_rpow", "one_div_le_one_div_of_le", "denominator monotonicity", "hypothesis of the condensation test"],
+    "prerequisites": ["monotonicity of rpow in the base for nonneg exponent", "reciprocal reverses ≤", "p ≥ 0 is essential"]
   },
   {
     "id": "ann-bertrand-condensed",
     "proofId": "harmonic-divergence-oq-02-oq-01",
     "range": {
-      "startLine": 118,
+      "startLine": 119,
       "endLine": 139
     },
     "type": "theorem",
     "title": "Condensed Term = Rescaled Real p-Series",
     "content": "The Cauchy-condensed term at k ≥ 1 is 2^k · bertrand p (2^k) = (1/(log 2)^p)·(1/k^p). The 2^k factors cancel, log(2^k) = k·log 2, and Real.mul_rpow splits (k·log 2)^p = k^p·(log 2)^p. This exposes the condensed series as a constant multiple of the real p-series Σ 1/k^p — the single identity that drives the whole p ≥ 0 dichotomy.",
-    "mathContext": "After substituting $\\log(2^k)=k\\log 2$ and splitting the rpow, `field_simp` clears the denominators using the nonzero guards $2^k\\ne 0$, $k^p\\ne 0$, $(\\log 2)^p\\ne 0$ (each from `Real.rpow_pos_of_pos`)."
+    "mathContext": "After substituting $\\log(2^k)=k\\log 2$ and splitting the rpow, `field_simp` clears the denominators using the nonzero guards $2^k\\ne 0$, $k^p\\ne 0$, $(\\log 2)^p\\ne 0$ (each from `Real.rpow_pos_of_pos`).",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy condensation test", "real p-series Σ 1/k^p", "Real.mul_rpow", "log(2^k) = k·log 2", "reduction to a known series"],
+    "prerequisites": ["the condensation transform 2^k·a(2^k)", "splitting (xy)^p = x^p y^p", "field_simp with nonzero guards"]
   },
   {
     "id": "ann-bertrand-nonneg-dichotomy",
     "proofId": "harmonic-divergence-oq-02-oq-01",
     "range": {
-      "startLine": 140,
+      "startLine": 141,
       "endLine": 156
     },
     "type": "theorem",
     "title": "Convergence Dichotomy for p ≥ 0",
     "content": "For p ≥ 0, Σ bertrand p converges ⟺ p > 1. The proof is a clean iff-chain: summable_condensed_iff_of_nonneg reduces to the condensed series; summable_nat_add_iff drops the k=0 term; summable_mul_left_iff removes the constant 1/(log 2)^p; and Real.summable_one_div_nat_rpow says Σ 1/k^p converges ⟺ 1 < p. No case split on whether p is an integer is needed.",
-    "mathContext": "Each step is an `Iff` rewrite, so the whole statement is settled without ever constructing the sum, only transporting summability across condensation, shifting, and a nonzero scalar."
+    "mathContext": "Each step is an `Iff` rewrite, so the whole statement is settled without ever constructing the sum, only transporting summability across condensation, shifting, and a nonzero scalar.",
+    "significance": "key",
+    "relatedConcepts": ["iff-chain of summability rewrites", "Real.summable_one_div_nat_rpow", "summable_mul_left_iff", "summable_nat_add_iff", "p-series threshold"],
+    "prerequisites": ["transporting summability across reindexings", "the real p-series convergence criterion", "removing a nonzero scalar factor"]
   },
   {
     "id": "ann-bertrand-negative",
     "proofId": "harmonic-divergence-oq-02-oq-01",
     "range": {
-      "startLine": 157,
+      "startLine": 159,
       "endLine": 184
     },
     "type": "theorem",
     "title": "Divergence for p < 0 by Comparison",
     "content": "When p < 0 the term is not antitone, so condensation is unavailable. Instead it dominates the harmonic term: for n ≥ 3, log n > 1 and p ≤ 0 give (log n)^p ≤ 1 (Real.rpow_le_one_of_one_le_of_nonpos), hence bertrand 0 (n) ≤ bertrand p (n). Since the p=0 series diverges, Summable.of_nonneg_of_le on the tail n ≥ 3 forces the p < 0 series to diverge.",
-    "mathContext": "The bound $1\\le\\log(n+3)$ comes from `Real.le_log_iff_exp_le` together with $e<3$ (`Real.exp_one_lt_d9`). The tail is isolated with `summable_nat_add_iff 3`."
+    "mathContext": "The bound $1\\le\\log(n+3)$ comes from `Real.le_log_iff_exp_le` together with $e<3$ (`Real.exp_one_lt_d9`). The tail is isolated with `summable_nat_add_iff 3`.",
+    "significance": "supporting",
+    "relatedConcepts": ["comparison test", "Real.rpow_le_one_of_one_le_of_nonpos", "domination by the harmonic series", "non-antitone case handled separately"],
+    "prerequisites": ["(log n)^p ≤ 1 for p ≤ 0 and log n ≥ 1", "comparison with a divergent series", "isolating a tail of the series"]
   },
   {
     "id": "ann-bertrand-threshold",
@@ -69,6 +84,9 @@
     "type": "theorem",
     "title": "The Full Threshold and Parent Corollaries",
     "content": "Splitting at p = 0 combines the two analyses into the all-real-p theorem: Σ bertrand p converges ⟺ p > 1. The parent's two cases are now one-line corollaries: logHarmonic_diverges (p=1) = bertrand_not_summable_of_le_one le_rfl, and logHarmonicSq_converges (p=2) = bertrand_summable_of_one_lt (by norm_num). The general dichotomy strictly subsumes and re-derives the parent.",
-    "mathContext": "For $p<0$ both sides are false; for $p\\ge 0$ the condensation dichotomy applies. The corollaries `bertrand_not_summable_of_le_one` (covers $p=1$ and the strip $0<p<1$) and `bertrand_summable_of_one_lt` package the two regimes."
+    "mathContext": "For $p<0$ both sides are false; for $p\\ge 0$ the condensation dichotomy applies. The corollaries `bertrand_not_summable_of_le_one` (covers $p=1$ and the strip $0<p<1$) and `bertrand_summable_of_one_lt` package the two regimes.",
+    "significance": "key",
+    "relatedConcepts": ["Bertrand series threshold p > 1", "case split at p = 0", "subsuming the parent corollaries", "logarithmic harmonic series"],
+    "prerequisites": ["combining the p≥0 and p<0 analyses", "specializing the threshold to p=1 and p=2", "the parent's divergence/convergence statements"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass (pass 0)

Axiom-free entry (`verified` / `original` / axiomCount 0; meta 13.8 KB, under cap). Quality gap was annotation depth.

### Changes
- Added `significance`, `relatedConcepts`, `prerequisites` to all 6 annotations (key/supporting tiers; Cauchy condensation, reduction to the real p-series, antitonicity repair via small-index cap, p<0 comparison, full threshold + parent corollaries).
- Aligned 5 annotation startLines to their Lean constructs (def/theorem) — clears build warnings.

### Verification
- JSON valid; `annotations/build.ts`: zero warnings for this target.
- Axiom integrity unchanged: `verified` / `original` / axiomCount 0.