### PR TITLE
research(erdos-340-greedy-sidon-oq-05): B_h sequences + sharp B_h upper bound [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos340GreedySidonOQ05.lean
+++ b/proofs/Proofs/Erdos340GreedySidonOQ05.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 LeanGenius Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: LeanGenius AI Research
+-/
+-- Full Mathlib: the `B_h` counting bound below combines `Finset.sym`, `Finset.powersetCard`,
+-- `Finset.card_image_of_injOn`, `Finset.sum_le_card_nsmul`, and `Nat.card_Icc`, which span
+-- several Mathlib namespaces; a single import keeps the development robust.
+import Mathlib
+
+/-
+# Erdős Problem #340, Open Question OQ-05: B_h Sequences
+
+## The Open Question
+
+The gallery proof `erdos-340-greedy-sidon` develops the theory of **Sidon sets**
+(also called `B_2` sequences): finite sets `A ⊆ ℕ` in which all pairwise sums
+`a + b` (`a ≤ b`, `a, b ∈ A`) are distinct.  A central quantitative fact is the
+*upper bound*: a Sidon set inside `{1, …, N}` has at most `O(√N)` elements,
+because the `card·(card+1)/2` pairwise sums are distinct and confined to `[1, 2N]`.
+
+OQ-05 asks: **does this theory extend to `B_h` sequences** — sets in which all
+`h`-fold sums (with repetition) are distinct?  This file provides the
+foundational `B_h` theory together with the sharp generalization of the Sidon
+upper bound.
+
+## What is formalized here
+
+* `IsBh h A` — the `B_h` property, phrased as injectivity of the multiset-sum map
+  on the `h`-element multisets `A.sym h`.  For `h = 2` this is exactly the Sidon
+  property (every set is `B_1`, and `B_0` is vacuous).
+
+* `IsBh.subset` — the `B_h` property is inherited by subsets.
+
+* `IsBh.sum_injOn_powersetCard` — a `B_h` set has *distinct subset-sums* across its
+  `h`-element subsets.  This is the combinatorial engine behind the counting bound.
+
+* `IsBh.choose_card_le` — **the main theorem**.  If `A ⊆ {1, …, N}` is `B_h`
+  (`h ≥ 1`), then
+  `Nat.choose A.card h ≤ h * N`.
+  For `h = 2` this is `A.card·(A.card-1)/2 ≤ 2N`, recovering the classical Sidon
+  bound `|A| = O(√N)`.  For general `h` it yields `|A| = O(N^{1/h})`, the trivial
+  `B_h` upper bound that is the starting point for the `B_h` analogue of #340.
+
+* `IsBh.two_card_mul_pred_le` — the explicit `h = 2` specialization
+  `A.card * (A.card - 1) ≤ 4 * N`, demonstrating concretely that the `B_h`
+  bound recovers the Sidon bound.
+
+## Mathematical note
+
+The bound is *sharp in order*: Singer difference sets give `B_2` sets of size
+`(1-o(1))√N`, and Bose–Chowla constructions give `B_h` sets of size
+`(1-o(1)) N^{1/h}`.  Closing the gap between the greedy lower bound and these
+algebraic constructions is the `B_h` form of the open problem #340.
+
+## References
+
+* [erdosproblems.com/340](https://www.erdosproblems.com/340)
+* Bose, Chowla (1962): "Theorems in the additive theory of numbers" — `B_h` sets
+  of size `~ N^{1/h}`.
+* Singer (1938): perfect difference sets, `B_2` sets of size `~ √N`.
+-/
+
+open Finset
+
+namespace Erdos340Bh
+
+/-! ## Part 1: The `B_h` property -/
+
+/-- A finite set `A ⊆ ℕ` is a **`B_h` set** if all `h`-fold sums with repetition are
+distinct.  We phrase this as injectivity of the *multiset-sum* map on the finset
+`A.sym h` of `h`-element multisets drawn from `A`.
+
+For `h = 2` an element of `A.sym 2` is an unordered pair `{a, b}` (with `a, b ∈ A`,
+repetition allowed) and its multiset sum is `a + b`; injectivity is exactly the
+Sidon property.  Every set is `B_1` (the multiset-sum of a singleton is the element
+itself), and `B_0` is vacuous (`A.sym 0 = {∅}`). -/
+def IsBh (h : ℕ) (A : Finset ℕ) : Prop :=
+  Set.InjOn (fun s : Sym ℕ h => (s : Multiset ℕ).sum) (A.sym h)
+
+/-- The `B_h` property is inherited by subsets: a sub-collection of a `B_h` set is
+again `B_h`, since its `h`-multisets form a subfamily of those of the larger set. -/
+theorem IsBh.subset {h : ℕ} {A B : Finset ℕ} (hA : IsBh h A) (hBA : B ⊆ A) :
+    IsBh h B :=
+  hA.mono (Finset.coe_subset.mpr (Finset.sym_mono hBA h))
+
+/-- Every finite set is `B_1`: the multiset-sum of a singleton multiset is the
+element itself, so the sum map is the identity on `A.sym 1` up to the canonical
+identification, hence injective. -/
+theorem isBh_one (A : Finset ℕ) : IsBh 1 A := by
+  intro s _ t _ hst
+  -- An element of `Sym ℕ 1` is determined by its multiset, which has card 1.
+  have hs : Multiset.card (s : Multiset ℕ) = 1 := s.2
+  have ht : Multiset.card (t : Multiset ℕ) = 1 := t.2
+  obtain ⟨a, ha⟩ := Multiset.card_eq_one.mp hs
+  obtain ⟨b, hb⟩ := Multiset.card_eq_one.mp ht
+  -- The sums are just `a` and `b`; equality of sums forces `a = b`, hence equal multisets.
+  apply Sym.coe_injective
+  simp only [ha, hb, Multiset.sum_singleton] at hst ⊢
+  rw [hst]
+
+/-! ## Part 2: From `B_h` to distinct subset-sums -/
+
+/-- A small bridge lemma: for a finset `U`, the `Finset.sum` over `id` equals the
+plain multiset sum of its underlying multiset. -/
+private theorem finset_sum_id_eq_val_sum (U : Finset ℕ) : U.sum id = U.1.sum := by
+  rw [← Finset.sum_map_val, Multiset.map_id]
+
+/-- **Distinct subset-sums.**  In a `B_h` set, the `h`-element *subsets* all have
+distinct sums.  (A subset is a special multiset — one with no repetition — so this
+is an immediate consequence of the `B_h` injectivity, restricted to the
+repetition-free multisets.)  This is the combinatorial core of the counting bound:
+it injects the `Nat.choose A.card h` many `h`-subsets into a bounded interval. -/
+theorem IsBh.sum_injOn_powersetCard {h : ℕ} {A : Finset ℕ} (hA : IsBh h A) :
+    Set.InjOn (fun S : Finset ℕ => S.sum id) (A.powersetCard h) := by
+  intro S hS T hT hST
+  rw [Finset.mem_coe, Finset.mem_powersetCard] at hS hT
+  obtain ⟨hSA, hSc⟩ := hS
+  obtain ⟨hTA, hTc⟩ := hT
+  -- View `S` and `T` as `h`-element multisets (elements distinct, so genuine subsets).
+  have hScard : Multiset.card S.1 = h := by rw [← Finset.card_def]; exact hSc
+  have hTcard : Multiset.card T.1 = h := by rw [← Finset.card_def]; exact hTc
+  set σS : Sym ℕ h := ⟨S.1, hScard⟩ with hσS
+  set σT : Sym ℕ h := ⟨T.1, hTcard⟩ with hσT
+  -- Both lie in `A.sym h`.
+  have hσSmem : σS ∈ A.sym h := by
+    rw [Finset.mem_sym_iff]
+    intro a ha
+    exact hSA ha
+  have hσTmem : σT ∈ A.sym h := by
+    rw [Finset.mem_sym_iff]
+    intro a ha
+    exact hTA ha
+  -- Equal subset-sums ⟹ equal multiset-sums.
+  have hsum : (σS : Multiset ℕ).sum = (σT : Multiset ℕ).sum := by
+    show S.1.sum = T.1.sum
+    rw [← finset_sum_id_eq_val_sum, ← finset_sum_id_eq_val_sum]
+    exact hST
+  -- Apply `B_h` injectivity, then strip the `Sym`/`Finset` wrappers.
+  have heq : σS = σT := hA hσSmem hσTmem hsum
+  have hval : S.1 = T.1 := congrArg (fun s : Sym ℕ h => (s : Multiset ℕ)) heq
+  exact Finset.val_injective hval
+
+/-! ## Part 3: The `B_h` upper bound -/
+
+/-- **Main theorem: the `B_h` counting bound.**  If `A` is a `B_h` set contained in
+`{1, …, N}` (with `h ≥ 1`), then
+`Nat.choose A.card h ≤ h * N`.
+
+*Proof.*  The `Nat.choose A.card h` many `h`-element subsets of `A` have pairwise
+distinct sums (`IsBh.sum_injOn_powersetCard`).  Each such sum lies in the interval
+`[1, h·N]` (an `h`-subset of `{1,…,N}` sums to at least `h ≥ 1` and at most `h·N`).
+An injection into `[1, h·N]` forces `Nat.choose A.card h ≤ |[1, h·N]| = h·N`. ∎
+
+At `h = 2` this is `A.card·(A.card-1)/2 ≤ 2N`, the classical Sidon bound; at general
+`h` it gives `|A| = O(N^{1/h})`. -/
+theorem IsBh.choose_card_le {h N : ℕ} {A : Finset ℕ} (hh : 1 ≤ h)
+    (hAN : A ⊆ Finset.Icc 1 N) (hA : IsBh h A) :
+    Nat.choose A.card h ≤ h * N := by
+  -- The image of the subset-sum map.
+  set img := (A.powersetCard h).image (fun S => S.sum id) with himg
+  -- `|image| = |powersetCard| = choose A.card h`, by injectivity.
+  have hcard_img : img.card = Nat.choose A.card h := by
+    rw [himg, Finset.card_image_of_injOn hA.sum_injOn_powersetCard,
+      Finset.card_powersetCard]
+  -- Every subset-sum lies in `Icc 1 (h * N)`.
+  have hsub : img ⊆ Finset.Icc 1 (h * N) := by
+    intro x hx
+    rw [himg, Finset.mem_image] at hx
+    obtain ⟨S, hS, rfl⟩ := hx
+    rw [Finset.mem_powersetCard] at hS
+    obtain ⟨hSA, hSc⟩ := hS
+    -- Each element of `S` is in `[1, N]`.
+    have hmem : ∀ a ∈ S, 1 ≤ a ∧ a ≤ N := by
+      intro a ha
+      exact Finset.mem_Icc.mp (hAN (hSA ha))
+    rw [Finset.mem_Icc]
+    constructor
+    · -- lower bound: `1 ≤ S.card • 1 ≤ S.sum id` since `S` is nonempty (`card = h ≥ 1`).
+      have hge : S.card • 1 ≤ S.sum id :=
+        Finset.card_nsmul_le_sum S id 1 (fun a ha => (hmem a ha).1)
+      simp only [smul_eq_mul, mul_one] at hge
+      omega
+    · -- upper bound: `S.sum id ≤ S.card • N = h * N`.
+      have hle : S.sum id ≤ S.card • N :=
+        Finset.sum_le_card_nsmul S id N (fun a ha => (hmem a ha).2)
+      rw [hSc, smul_eq_mul] at hle
+      exact hle
+  -- Combine: `choose ≤ |Icc 1 (h*N)| = h*N`.
+  calc Nat.choose A.card h = img.card := hcard_img.symm
+    _ ≤ (Finset.Icc 1 (h * N)).card := Finset.card_le_card hsub
+    _ = h * N := by rw [Nat.card_Icc, Nat.add_sub_cancel]
+
+/-- **Sidon-bound recovery.**  Specializing the `B_h` bound to `h = 2` recovers the
+classical Sidon upper bound in the explicit form `A.card·(A.card-1) ≤ 4N`, i.e.
+`|A| = O(√N)`.  This shows the `B_h` theory genuinely generalizes #340's `B_2` case. -/
+theorem IsBh.two_card_mul_pred_le {N : ℕ} {A : Finset ℕ}
+    (hAN : A ⊆ Finset.Icc 1 N) (hA : IsBh 2 A) :
+    A.card * (A.card - 1) ≤ 4 * N := by
+  have h := hA.choose_card_le (by norm_num) hAN
+  -- `Nat.choose k 2 = k*(k-1)/2`, and `k*(k-1)` is even, so `k*(k-1) = 2·⌊k(k-1)/2⌋ ≤ 4N`.
+  rw [Nat.choose_two_right] at h
+  have hev : 2 ∣ A.card * (A.card - 1) := (Nat.even_mul_pred_self A.card).two_dvd
+  omega
+
+end Erdos340Bh

--- a/research/knowledge/technique-index.json
+++ b/research/knowledge/technique-index.json
@@ -62,6 +62,14 @@
       ],
       "outcome": "success",
       "date": "2026-06-27"
+    },
+    {
+      "name": "B_h subset-sum counting (powersetCard injection into bounded interval)",
+      "used_in_problems": [
+        "erdos-340-greedy-sidon-oq-05"
+      ],
+      "outcome": "success",
+      "date": "2026-06-27"
     }
   ]
 }

--- a/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
@@ -1,0 +1,72 @@
+# Erdős #340 OQ-05: B_h Sequences
+
+**Open question (generalization) from gallery proof `erdos-340-greedy-sidon`.**
+
+The parent entry develops the theory of Sidon sets (= B_2 sequences: all pairwise
+sums distinct) and proves the upper bound `|A| = O(√N)` for `A ⊆ {1,…,N}`. OQ-05
+asks whether this extends to **B_h sequences**: sets in which all `h`-fold sums
+(with repetition) are distinct.
+
+## Summary
+
+`Erdos340GreedySidonOQ05.lean` formalizes the foundational B_h theory and the sharp
+B_h analogue of the Sidon upper bound, fully verified (0 sorries, 0 axioms beyond
+`propext`/`Classical.choice`/`Quot.sound`).
+
+| Result | Statement |
+|--------|-----------|
+| `IsBh h A` | `A` is B_h: the multiset-sum map is injective on `A.sym h` |
+| `IsBh.subset` | B_h is inherited by subsets |
+| `isBh_one` | every finite set is B_1 |
+| `IsBh.sum_injOn_powersetCard` | the `h`-element **subsets** of a B_h set have distinct sums |
+| `IsBh.choose_card_le` | **main:** `A ⊆ [1,N]`, B_h, `h ≥ 1` ⟹ `Nat.choose |A| h ≤ h·N` |
+| `IsBh.two_card_mul_pred_le` | Sidon recovery: `|A|·(|A|-1) ≤ 4N` (i.e. `|A| = O(√N)`) |
+
+The bound `Nat.choose |A| h ≤ h·N` gives `|A| = O(N^{1/h})`, the trivial B_h
+ceiling that Bose–Chowla constructions meet to within `(1-o(1))`.
+
+## Sessions
+
+### Session 2026-06-27 (Session 1) — FRESH
+
+**Mode**: FRESH · **Outcome**: progress (verified increment)
+
+#### What I Did
+- Defined `IsBh h A` as injectivity of the multiset-sum map `s ↦ (s : Multiset ℕ).sum`
+  on the finset `A.sym h` of `h`-element multisets — the clean generalization of the
+  parent `IsSidon` (B_2).
+- Proved the structural lemmas `IsBh.subset` and `isBh_one`.
+- Proved `IsBh.sum_injOn_powersetCard`: the `h`-element subsets of a B_h set have
+  pairwise distinct sums (a subset is a repetition-free multiset, so distinctness is
+  inherited from the B_h injectivity).
+- Proved the **main theorem** `IsBh.choose_card_le`: `Nat.choose |A| h ≤ h·N` for a
+  B_h set `A ⊆ {1,…,N}` with `h ≥ 1`, by injecting the `choose(|A|,h)` distinct
+  subset-sums into the interval `[1, h·N]`.
+- Proved `IsBh.two_card_mul_pred_le`, the explicit `h = 2` specialization, recovering
+  the classical Sidon bound.
+
+#### Key Findings
+- **Route through `h`-subsets, not all `h`-multisets.** `Finset.sym s n` has no direct
+  multichoose cardinality lemma in Mathlib (only the Fintype-level
+  `Sym.card_sym_eq_choose`). Using `Finset.powersetCard` (with `Finset.card_powersetCard
+  = Nat.choose`) for the counting, while keeping `A.sym h` only for the *definition*,
+  makes the bound clean: `card_image_of_injOn` + `Nat.card_Icc` finish it.
+- **Evenness needed at `h = 2`.** From `choose(k,2) = k(k-1)/2 ≤ 2N`, deriving
+  `k(k-1) ≤ 4N` needs `2 ∣ k(k-1)` (`(Nat.even_mul_pred_self k).two_dvd`); without it
+  `omega` finds the spurious counterexample `k(k-1) = 4N+1`.
+- **Build infra gotcha.** The host disk was at 100% with ~10 concurrent Docker Lean
+  builds thrashing the shared mathlib build dir (disk-I/O / permission-denied errors).
+  The worktree's `.lake/packages` is an absolute symlink that breaks inside the
+  container. Verified instead by invoking the host `v4.26.0` toolchain `lean` directly
+  on the single file with a hand-built `LEAN_PATH` over the existing package oleans —
+  no mathlib rebuild, low memory. `#print axioms` confirms 0-axiom.
+
+#### Files Modified
+- `proofs/Proofs/Erdos340GreedySidonOQ05.lean` (new, 206 lines, verified)
+- `src/data/research/problems/erdos-340-greedy-sidon-oq-05.json` (new)
+
+#### Next Steps
+- `B_h ⟹ B_{h-1}` downward closure (append a fixed element to (h−1)-multisets).
+- B_h greedy extension + the `N^{1/(2h-1)}` greedy lower bound — the genuine open
+  direction, matching the still-open parent #340.
+- Optional exact bridge `IsBh 2 A ↔ Erdos340.IsSidon A`.

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -1,0 +1,64 @@
+{
+  "slug": "erdos-340-greedy-sidon-oq-05",
+  "title": "Erdős #340 OQ-05: B_h sequences and the B_h upper bound",
+  "status": "in-progress",
+  "phase": "ACT",
+  "tier": "B",
+  "tractability": "medium — the foundational B_h theory and the sharp B_h counting upper bound are now formalized and verified (0-axiom). The deep open direction (improving the greedy B_h lower bound toward the N^{1/h} ceiling) remains open, exactly as for the parent #340.",
+  "started": "2026-06-27",
+  "lastUpdate": "2026-06-27",
+  "path": "research/problems/erdos-340-greedy-sidon-oq-05",
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos340GreedySidonOQ05.lean",
+      "filename": "Erdos340GreedySidonOQ05.lean",
+      "lineCount": 206,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos340GreedySidonOQ05.lean"
+    }
+  ],
+  "tags": [
+    "combinatorics",
+    "additive-combinatorics",
+    "sidon-sets",
+    "Bh-sets",
+    "extremal"
+  ],
+  "relatedProofs": [
+    "erdos-340",
+    "erdos-340-greedy-sidon",
+    "erdos-44"
+  ],
+  "problemStatement": "Open question (generalization) from the gallery proof 'erdos-340-greedy-sidon': does the Sidon (B_2) theory of #340 extend to B_h sequences — sets in which all h-fold sums with repetition are distinct? Formalize the B_h property and the B_h analogue of the Sidon upper bound.",
+  "references": [
+    "S. Chowla and R. C. Bose, Theorems in the additive theory of numbers, Comment. Math. Helv. 37 (1962/63), 141-147.",
+    "J. Singer, A theorem in finite projective geometry and some applications to number theory, Trans. AMS 43 (1938), 377-385.",
+    "https://www.erdosproblems.com/340"
+  ],
+  "knowledge": {
+    "insights": [
+      "B_h sets generalize Sidon (= B_2) sets: A is B_h iff all h-fold sums with repetition are distinct. The clean formalization is injectivity of the multiset-sum map s ↦ (s : Multiset ℕ).sum on the finset A.sym h of h-element multisets drawn from A (def IsBh in Erdos340GreedySidonOQ05.lean).",
+      "The sharp B_h upper bound is provable by an h-SUBSET counting argument rather than the full multiset count: the Nat.choose A.card h many h-element SUBSETS of A have pairwise distinct sums (a subset is a repetition-free multiset, so distinctness is inherited from the B_h injectivity), and each such sum lies in [1, h·N]. This injects choose(|A|,h) into an interval of length h·N, giving Nat.choose A.card h ≤ h·N (theorem IsBh.choose_card_le, 0-axiom verified).",
+      "At h = 2 the bound reads choose(|A|,2) = |A|·(|A|-1)/2 ≤ 2N, i.e. |A|·(|A|-1) ≤ 4N (theorem IsBh.two_card_mul_pred_le) — exactly the classical Sidon bound |A| = O(√N), confirming B_h genuinely generalizes #340's B_2 case. For general h it gives |A| = O(N^{1/h}), the trivial B_h ceiling that Bose-Chowla constructions meet to within (1-o(1)).",
+      "Using h-subsets (powersetCard, card = Nat.choose) instead of all h-multisets (Finset.sym, whose Finset-level cardinality is NOT directly available in Mathlib as a multichoose lemma) is what makes the counting bound clean: Finset.card_powersetCard gives the exact choose count, and Finset.card_image_of_injOn + Nat.card_Icc finish it.",
+      "h=2 omega gotcha: from choose(k,2) = k(k-1)/2 ≤ 2N, deriving k(k-1) ≤ 4N requires the EVENNESS of k(k-1) (else k(k-1)=4N+1 is a spurious omega counterexample). Supply 2 ∣ k(k-1) via (Nat.even_mul_pred_self k).two_dvd before omega."
+    ],
+    "builtItems": [
+      "Erdos340GreedySidonOQ05.lean: def IsBh (h-fold-sum-distinctness via multiset-sum InjOn on A.sym h); IsBh.subset; isBh_one (every set is B_1); IsBh.sum_injOn_powersetCard (distinct h-subset sums); IsBh.choose_card_le (MAIN: Nat.choose |A| h ≤ h·N for B_h A ⊆ [1,N]); IsBh.two_card_mul_pred_le (Sidon recovery |A|(|A|-1) ≤ 4N). 206 lines, 6 theorems, 1 def, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only)."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no B_h-set theory and no Sidon/B_h upper bound; the whole development is original relative to Mathlib.",
+      "Finset.sym s n has no direct cardinality (multichoose) lemma in Mathlib — only the Fintype-level Sym.card_sym_eq_choose. This is why the counting bound is routed through h-subsets (powersetCard, which DOES have card_powersetCard) rather than the full multiset family."
+    ],
+    "nextSteps": [
+      "Prove the explicit B_h ⟹ B_{h-1} downward closure (for nonempty A) by appending a fixed element to (h-1)-multisets — a clean structural theorem now that the multiset-sum formulation is in place.",
+      "Formalize a B_h analogue of the greedy extension lemma (parent file's sidon_exists_extension / nextSidon) to build a greedy B_h sequence and prove its N^{1/(2h-1)} lower bound — the genuine open direction matching the parent #340.",
+      "Optionally prove the exact bridge IsBh 2 A ↔ Erdos340.IsSidon A (Sym ℕ 2 ↔ ordered-pair sums) to formally link the new B_h def to the parent gallery's IsSidon."
+    ],
+    "progressSummary": "PROGRESS: Foundational B_h theory + sharp B_h upper bound Nat.choose |A| h ≤ h·N formalized and verified 0-axiom (Erdos340GreedySidonOQ05.lean). Recovers the classical Sidon bound at h=2. The deep open direction (greedy B_h lower bound) remains, as for the parent #340."
+  }
+}


### PR DESCRIPTION
## Erdős #340 OQ-05 — B_h sequences

Open question (generalization) from the gallery proof `erdos-340-greedy-sidon`: the parent develops Sidon (= B_2) set theory and the `|A| = O(√N)` upper bound. OQ-05 asks whether this extends to **B_h sequences** — sets in which all `h`-fold sums with repetition are distinct.

### What's formalized (`proofs/Proofs/Erdos340GreedySidonOQ05.lean`)

| Result | Statement |
|--------|-----------|
| `IsBh h A` | `A` is B_h: the multiset-sum map is injective on `A.sym h` (the `h`-element multisets) |
| `IsBh.subset` | B_h is inherited by subsets |
| `isBh_one` | every finite set is B_1 |
| `IsBh.sum_injOn_powersetCard` | the `h`-element **subsets** of a B_h set have distinct sums |
| **`IsBh.choose_card_le`** | **main:** `A ⊆ [1,N]`, B_h, `h ≥ 1` ⟹ `Nat.choose |A| h ≤ h·N` |
| `IsBh.two_card_mul_pred_le` | Sidon recovery: `|A|·(|A|-1) ≤ 4N` (i.e. `|A| = O(√N)`) |

The main bound gives `|A| = O(N^{1/h})`, the trivial B_h ceiling that Bose–Chowla constructions meet to within `(1-o(1))`. At `h = 2` it specializes to exactly the classical Sidon bound, confirming B_h genuinely generalizes #340's B_2 case.

### Proof idea
The `choose(|A|,h)` many `h`-element subsets of `A` have pairwise distinct sums (a subset is a repetition-free multiset, so distinctness is inherited from the B_h injectivity), and each sum lies in `[1, h·N]`. Injecting `choose(|A|,h)` distinct values into an interval of length `h·N` gives the bound. Routing the count through `Finset.powersetCard` (which has `card_powersetCard = Nat.choose`) rather than `Finset.sym` (no Finset-level multichoose lemma in Mathlib) keeps it clean.

### Verification
206 lines · 6 theorems · 1 def · **0 sorries · 0 axioms**. `#print axioms` lists only `propext`/`Classical.choice`/`Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.

> Note: verified via the host `lean v4.26.0` toolchain on the single file against the existing package oleans (the Docker build host was disk-full / overloaded with concurrent builds at the time). Re-run `./proofs/scripts/docker-build.sh Proofs.Erdos340GreedySidonOQ05` once the build host recovers.

### Status
`in-progress` / phase `ACT` — the foundational B_h theory and sharp upper bound are done; the deep open direction (greedy B_h lower bound toward the `N^{1/(2h-1)}` rate) remains, exactly as the parent #340 is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)