### PR TITLE
Enrich Lawvere Fixed-Point Relational Generalization (cantor-diagonalization-oq-04-oq-01-oq-03): annotation depth

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-03/annotations.json
@@ -6,60 +6,81 @@
     "type": "concept",
     "title": "Which setoid axiom does Lawvere's diagonal actually use?",
     "content": "The parent (`cantor-diagonalization-oq-04-oq-01`) generalized Lawvere's fixed-point theorem from strict Type equality to a `Setoid` equivalence relation, calling this the step toward a CCC/topos version where equality becomes coherence. This file asks the sharp follow-up: of the three setoid axioms — reflexivity, symmetry, transitivity — which does the diagonal argument *consume*? The answer is **none**. Stated in the retraction's own orientation `r p (f p)`, Lawvere's theorem holds for an arbitrary binary relation with no axioms whatsoever; symmetry is needed only to flip the conclusion to the conventional `r (f p) p`.",
-    "mathContext": "Lawvere (1969) is the categorical heart of every diagonal argument. Pinning the exact hypotheses shows the theorem is an absolute combinatorial principle about self-applicative codings, independent of the equality discipline. This widens its reach to tolerance relations (approximate equality) and directed orders, and clarifies that a future CartesianClosed proof needs only a coherence relation respected by evaluation, not an equivalence."
+    "mathContext": "Lawvere (1969) is the categorical heart of every diagonal argument. Pinning the exact hypotheses shows the theorem is an absolute combinatorial principle about self-applicative codings, independent of the equality discipline. This widens its reach to tolerance relations (approximate equality) and directed orders, and clarifies that a future CartesianClosed proof needs only a coherence relation respected by evaluation, not an equivalence.",
+    "significance": "context",
+    "relatedConcepts": ["Lawvere fixed-point theorem", "diagonal argument", "setoid axioms (refl/symm/trans)", "cartesian closed category / topos", "coherence vs equality"],
+    "prerequisites": ["Lawvere's fixed-point theorem", "equivalence relations and setoids", "the categorical reading of diagonal arguments"]
   },
   {
     "id": "ann-cantor-oq040103-structure",
     "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
-    "range": { "startLine": 59, "endLine": 71 },
+    "range": { "startLine": 68, "endLine": 84 },
     "type": "definition",
     "title": "CodesEndomorphismsRel: coding up to an arbitrary relation",
     "content": "`CodesEndomorphismsRel Y r` packages `encode : (Y → Y) → Y`, `decode : Y → (Y → Y)`, and the pointwise retract `r (decode (encode g) y) (g y)`. The only change from the parent's setoid structure is that `r` is an arbitrary `Y → Y → Prop` with no bundled axioms — the field type is identical, so the setoid coding is literally the special case `r = s.r`.",
-    "mathContext": "Three layers of weakening from the grandparent: (1) function equality, (2) pointwise equality, (3) pointwise setoid equivalence, and now (4) pointwise arbitrary relation. Each layer admits strictly more codings."
+    "mathContext": "Three layers of weakening from the grandparent: (1) function equality, (2) pointwise equality, (3) pointwise setoid equivalence, and now (4) pointwise arbitrary relation. Each layer admits strictly more codings.",
+    "significance": "key",
+    "relatedConcepts": ["retraction / coding of endomorphisms", "arbitrary binary relation Y → Y → Prop", "weakening a hypothesis", "surjectivity up to a relation"],
+    "prerequisites": ["encode/decode retraction structure", "relations without bundled axioms", "the parent's setoid coding as a special case"]
   },
   {
     "id": "ann-cantor-oq040103-main",
     "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
-    "range": { "startLine": 77, "endLine": 99 },
+    "range": { "startLine": 85, "endLine": 100 },
     "type": "theorem",
     "title": "lawvere_fixpoint_rel: fixed point with zero relation axioms",
     "content": "The diagonal `g y = f (decode y y)`, `y₀ = encode g`, `p = decode y₀ y₀` makes the retract field evaluated at `(g, y₀)` definitionally equal to the goal `r p (f p)` — so the proof is `exact ⟨c.decode y₀ y₀, c.retract g y₀⟩`, the parent's proof with the trailing `Setoid.iseqv.symm` removed. `lawvere_fixpoint_rel_symm` then flips to `r (f p) p` using `Symmetric r`, isolating symmetry as the sole cost of the conventional orientation.",
-    "mathContext": "That the retract field *is* the conclusion (up to definitional unfolding of the diagonal lets) explains why Lawvere's theorem is so robust: no equality lemmas mediate between hypothesis and goal."
+    "mathContext": "That the retract field *is* the conclusion (up to definitional unfolding of the diagonal lets) explains why Lawvere's theorem is so robust: no equality lemmas mediate between hypothesis and goal.",
+    "significance": "key",
+    "relatedConcepts": ["the diagonal construction g y = f(decode y y)", "definitional equality", "Symmetric r (only for orientation flip)", "axiom-free fixed point"],
+    "prerequisites": ["Lawvere's diagonal trick", "definitional unfolding of let-bindings", "orientation of a relation r p (f p) vs r (f p) p"]
   },
   {
     "id": "ann-cantor-oq040103-contrapositive",
     "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
-    "range": { "startLine": 101, "endLine": 110 },
+    "range": { "startLine": 107, "endLine": 119 },
     "type": "theorem",
     "title": "no_coding_rel_of_no_prefixpoint: the impossibility engine",
     "content": "Contrapositive: if some `f` has no point `p` with `r p (f p)`, then `Y` cannot code its endomorphisms up to `r`. To show a given `Y` is not Lawvere-coded up to `r`, it suffices to exhibit one fixed-point-free `f` (`∀ y, ¬ r y (f y)`). This drives both concrete examples below.",
-    "mathContext": "Cantor, Russell, Gödel, Tarski, and Turing are all this contrapositive applied to a specific fixed-point-free endomorphism (e.g. negation) in a specific setting."
+    "mathContext": "Cantor, Russell, Gödel, Tarski, and Turing are all this contrapositive applied to a specific fixed-point-free endomorphism (e.g. negation) in a specific setting.",
+    "significance": "key",
+    "relatedConcepts": ["contrapositive of Lawvere", "fixed-point-free endomorphism", "Cantor/Russell/Gödel/Tarski/Turing", "non-codability"],
+    "prerequisites": ["contraposition", "a single fixed-point-free f suffices", "diagonal impossibility results"]
   },
   {
     "id": "ann-cantor-oq040103-recovery",
     "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
-    "range": { "startLine": 112, "endLine": 123 },
+    "range": { "startLine": 120, "endLine": 134 },
     "type": "theorem",
     "title": "lawvere_fixpoint_setoid: recovering the parent",
     "content": "Instantiating the relational theorem at a setoid relation `s.r` and supplying `s.iseqv.symm` for symmetry reproduces the parent's setoid fixed-point theorem. Reflexivity and transitivity of the setoid are demonstrably never invoked, confirming this file is a strict generalization rather than a parallel statement.",
-    "mathContext": "Every parent corollary (Bool, parity, Cantor) is therefore inherited unchanged."
+    "mathContext": "Every parent corollary (Bool, parity, Cantor) is therefore inherited unchanged.",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization to a setoid", "strict generalization", "Setoid.iseqv.symm", "backward compatibility with the parent"],
+    "prerequisites": ["instantiating r := s.r", "which setoid axioms are actually used", "the parent's setoid theorem"]
   },
   {
     "id": "ann-cantor-oq040103-tolerance",
     "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
-    "range": { "startLine": 125, "endLine": 159 },
+    "range": { "startLine": 138, "endLine": 159 },
     "type": "theorem",
     "title": "Tolerance relation: a genuinely non-setoid instance",
     "content": "`tol a b := a ≤ b+1 ∧ b ≤ a+1` ('differ by at most one') is reflexive (`tol_refl`) and symmetric (`tol_symm`) but provably **not transitive** (`tol_not_transitive`: `tol 0 1`, `tol 1 2`, yet `¬ tol 0 2`), so it is not a `Setoid`. Nevertheless `nat_cannot_code_endos_tol` shows ℕ cannot code its endomorphisms up to `tol`, witnessed by the fixed-point-free shift `n ↦ n+2`. This result is unstatable in the parent framework.",
-    "mathContext": "Tolerance relations (Zeeman 1962) model approximate equality and are the natural object when strict equality is too rigid — exactly the regime a CCC/coherence generalization targets."
+    "mathContext": "Tolerance relations (Zeeman 1962) model approximate equality and are the natural object when strict equality is too rigid — exactly the regime a CCC/coherence generalization targets.",
+    "significance": "key",
+    "relatedConcepts": ["tolerance relation (Zeeman)", "non-transitive reflexive-symmetric relation", "approximate equality", "fixed-point-free shift n↦n+2"],
+    "prerequisites": ["a relation that is reflexive+symmetric but not transitive", "why tol is not a setoid", "exhibiting a fixed-point-free endomorphism on ℕ"]
   },
   {
     "id": "ann-cantor-oq040103-strict",
     "proofId": "cantor-diagonalization-oq-04-oq-01-oq-03",
-    "range": { "startLine": 161, "endLine": 172 },
+    "range": { "startLine": 170, "endLine": 172 },
     "type": "theorem",
     "title": "Strict order: only the orientation matters",
     "content": "`nat_cannot_code_endos_lt` uses strict `<` (irreflexive, non-symmetric, transitive): the identity has no `p` with `p < id p` since `<` is irreflexive (`lt_irrefl`), so ℕ cannot code its endomorphisms up to `<`. This drives home the central point — the theorem cares only about whether `f` admits a point in the relation's own orientation `r p (f p)`, not about any algebraic property of `r`.",
-    "mathContext": "Generalizes diagonal arguments uniformly across equivalence-based, tolerance-based, and order-based coherence relations."
+    "mathContext": "Generalizes diagonal arguments uniformly across equivalence-based, tolerance-based, and order-based coherence relations.",
+    "significance": "supporting",
+    "relatedConcepts": ["strict order <", "irreflexivity (lt_irrefl)", "orientation r p (f p)", "order-based coherence relations"],
+    "prerequisites": ["< is irreflexive and non-symmetric", "the identity endomorphism has no <-prefixpoint", "relation orientation is all that matters"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass (pass 0)

Axiom-free entry (`verified` / `original` / axiomCount 0; meta 17.8 KB, under cap). Quality gap was annotation depth.

### Changes
- Added `significance`, `relatedConcepts`, `prerequisites` to all 7 annotations (key/supporting/context tiers; coding up to an arbitrary relation, the diagonal construction with zero relation axioms, contrapositive impossibility engine, setoid recovery, tolerance-relation and strict-order non-setoid instances).
- Aligned 6 annotation startLines to their Lean constructs (one type/construct mismatch resolved: tolerance annotation moved off `def tol` to the first theorem).

### Verification
- JSON valid; `annotations/build.ts`: zero warnings for this target.
- Axiom integrity unchanged: `verified` / `original` / axiomCount 0.