### PR TITLE
research(erdos-1005-oq-02): §6–8 iterated insertion + similar-ordering bridge [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -30,6 +30,13 @@ which any such argument is built:
   rational `p/q` with `a/b < p/q < c/d` has `q ≥ b + d`, with equality forcing
   `p/q = (a+c)/(b+d)`.  Thus *no* refinement of a Farey gap can do better than
   mediant insertion — the denominator `b + d` is a hard lower bound.
+* **Depth dichotomy (§ 6–7).** Iterating insertion shows the two extreme descent
+  regimes differ exponentially: a *one-sided* chain grows denominators linearly
+  (`(k+1)·b + d`), admitting `Θ(n)` levels under the order cap, while a
+  *balanced* (alternating) chain follows the Fibonacci recurrence — denominators
+  `F_{2k+3}` doubling every two levels — admitting only `O(log n)` levels.
+  Cassini's identity certifies the balanced bounding pairs as genuine Farey
+  neighbours.
 
 Every theorem below is fully machine-checked: 0 sorries, 0 axioms (the file is
 self-contained and does **not** import the `axiom longestSimilarRun` of the
@@ -385,5 +392,126 @@ identity is the witness that one-sided descent grows denominators *linearly*, so
 the number of admissible refinement levels under `q ≤ n` is `Θ(n)`. -/
 theorem iterate_left_denom_linear (k b d : ℕ) :
     b + (k * b + d) = (k + 1) * b + d := by ring
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 7: Balanced (alternating) insertion — exponential denominator growth
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+This section establishes the **other extreme** of the dichotomy announced in § 6.
+Where the one-sided chain grows denominators *linearly* (`(k+1)·b + d`), the
+*balanced* chain — the path through the Stern–Brocot tree that alternates left
+and right at every level — grows them *exponentially*.
+
+The balanced path from the root gap `0/1 < 1/1` produces the mediants
+`1/2, 2/3, 3/5, 5/8, 8/13, …`: consecutive ratios of Fibonacci numbers.  The
+bounding pairs along this path are exactly the consecutive Fibonacci fractions
+`F_{2k}/F_{2k+1} < F_{2k+1}/F_{2k+2}`, which we show below are genuine unimodular
+(adjacent Farey) pairs, so they really do arise from mediant insertion.  Their
+mediant has denominator `F_{2k+1} + F_{2k+2} = F_{2k+3}`, so the denominator
+obeys the Fibonacci recurrence and therefore **at least doubles every two
+levels**.  Consequently only `O(log n)` balanced levels fit under the cap
+`q ≤ n`, versus the `Θ(n)` one-sided levels of § 6 — an exponential separation
+between the two descent strategies, and the precise content of the heuristic
+that § 6 warned must *not* be applied to the worst case.
+-/
+
+/-- **Cassini's identity** (over `ℤ`).  `F_{n+1}² − F_n·F_{n+2} = (−1)ⁿ`.
+This is the signed version of unimodularity for consecutive Fibonacci fractions:
+the determinant of `[[F_n, F_{n+1}], [F_{n+1}, F_{n+2}]]` is `(−1)ⁿ`.  The proof
+is a one-step induction: expanding `F_{n+3}` and `F_{n+2}` via the recurrence
+turns the successor determinant into the negative of its predecessor. -/
+theorem fib_cassini (n : ℕ) :
+    (Nat.fib (n + 1) : ℤ) ^ 2 - Nat.fib n * Nat.fib (n + 2) = (-1) ^ n := by
+  induction n with
+  | zero => norm_num [Nat.fib_zero, Nat.fib_one, Nat.fib_two]
+  | succ k ih =>
+    have e2 : (Nat.fib (k + 2) : ℤ) = Nat.fib k + Nat.fib (k + 1) := by
+      exact_mod_cast Nat.fib_add_two
+    have e3 : (Nat.fib (k + 3) : ℤ) = Nat.fib (k + 1) + Nat.fib (k + 2) := by
+      exact_mod_cast Nat.fib_add_two
+    have hkey :
+        (Nat.fib (k + 1 + 1) : ℤ) ^ 2 - Nat.fib (k + 1) * Nat.fib (k + 1 + 2)
+          = -((Nat.fib (k + 1) : ℤ) ^ 2 - Nat.fib k * Nat.fib (k + 2)) := by
+      have i1 : k + 1 + 1 = k + 2 := rfl
+      have i2 : k + 1 + 2 = k + 3 := rfl
+      rw [i1, i2, e3, e2]; ring
+    rw [hkey, ih, pow_succ]; ring
+
+/-- **Consecutive Fibonacci fractions are a unimodular (Farey) pair.**  Reading
+Cassini at the *even* index `n = 2k` gives `F_{2k+1}² = F_{2k}·F_{2k+2} + 1`,
+which is exactly `Unimodular F_{2k} F_{2k+1} F_{2k+1} F_{2k+2}`.  Thus the
+balanced Stern–Brocot path consists of genuine adjacent Farey pairs, and the
+minimal-denominator machinery of § 4 applies to it verbatim. -/
+theorem unimodular_fib_even (k : ℕ) :
+    Unimodular (Nat.fib (2 * k)) (Nat.fib (2 * k + 1))
+               (Nat.fib (2 * k + 1)) (Nat.fib (2 * k + 2)) := by
+  unfold Unimodular
+  have hc := fib_cassini (2 * k)
+  have hsign : ((-1 : ℤ)) ^ (2 * k) = 1 := by rw [pow_mul]; norm_num
+  rw [hsign] at hc
+  have h2 : (Nat.fib (2 * k + 1) : ℤ) * Nat.fib (2 * k + 1)
+      = Nat.fib (2 * k) * Nat.fib (2 * k + 2) + 1 := by linear_combination hc
+  exact_mod_cast h2
+
+/-- **Two levels at least double the denominator.**  `2·F_k ≤ F_{k+2}`, because
+`F_{k+2} = F_k + F_{k+1} ≥ F_k + F_k`.  This is the engine of exponential
+growth: each pair of balanced refinement levels multiplies the denominator by at
+least `2`, in sharp contrast to the additive `+b` cost of a one-sided level. -/
+theorem fib_two_step_double (k : ℕ) : 2 * Nat.fib k ≤ Nat.fib (k + 2) := by
+  rw [Nat.fib_add_two]
+  have := Nat.fib_le_fib_succ (n := k)
+  omega
+
+/-- **Exponential lower bound on the balanced denominator.**  `2ʲ ≤ F_{2j+1}`.
+The depth-`2j` balanced bounding fraction already has denominator at least `2ʲ`,
+so it grows at least as fast as `2^{depth/2} = (√2)^{depth}`.  (The true rate is
+`φ^{depth}`; `√2` is the clean integer floor.) -/
+theorem fib_pow_lower (j : ℕ) : 2 ^ j ≤ Nat.fib (2 * j + 1) := by
+  induction j with
+  | zero => simp
+  | succ k ih =>
+    have h2 : 2 * 2 ^ k ≤ 2 * Nat.fib (2 * k + 1) := by omega
+    have hd : 2 * Nat.fib (2 * k + 1) ≤ Nat.fib (2 * k + 1 + 2) :=
+      fib_two_step_double (2 * k + 1)
+    have hpow : 2 ^ (k + 1) = 2 * 2 ^ k := by ring
+    have hidx : 2 * (k + 1) + 1 = 2 * k + 1 + 2 := by ring
+    rw [hpow, hidx]
+    omega
+
+/-- **The balanced mediant obeys the Fibonacci recurrence.**  The mediant of the
+unimodular pair `F_{2k}/F_{2k+1} < F_{2k+1}/F_{2k+2}` has denominator
+`F_{2k+1} + F_{2k+2} = F_{2k+3}`: the next Fibonacci number.  So one balanced
+refinement step advances the denominator index by two — the exponential
+counterpart of `iterate_left_denom_linear`. -/
+theorem balanced_mediant_denom (k : ℕ) :
+    Nat.fib (2 * k + 1) + Nat.fib (2 * k + 2) = Nat.fib (2 * k + 3) := by
+  have h : Nat.fib (2 * k + 1 + 2) = Nat.fib (2 * k + 1) + Nat.fib (2 * k + 1 + 1) :=
+    Nat.fib_add_two
+  simpa [show 2 * k + 1 + 2 = 2 * k + 3 from rfl,
+         show 2 * k + 1 + 1 = 2 * k + 2 from rfl] using h.symm
+
+/-- **Minimal denominator in a balanced gap.**  Specialising `denom_ge_of_between`
+to the Fibonacci pair: every fraction strictly between `F_{2k}/F_{2k+1}` and
+`F_{2k+1}/F_{2k+2}` has denominator `q ≥ F_{2k+3}`.  Combined with
+`fib_pow_lower` this forces `q` to grow exponentially with the balanced depth. -/
+theorem denom_ge_balanced (k : ℕ) {p q : ℕ} (hq : 0 < q)
+    (hlo : (Nat.fib (2 * k) : ℚ) / Nat.fib (2 * k + 1) < (p : ℚ) / q)
+    (hhi : (p : ℚ) / q < (Nat.fib (2 * k + 1) : ℚ) / Nat.fib (2 * k + 2)) :
+    Nat.fib (2 * k + 3) ≤ q := by
+  have hb : 0 < Nat.fib (2 * k + 1) := by rw [Nat.fib_pos]; omega
+  have hd : 0 < Nat.fib (2 * k + 2) := by rw [Nat.fib_pos]; omega
+  have hge := denom_ge_of_between hb hd hq (unimodular_fib_even k) hlo hhi
+  rwa [balanced_mediant_denom] at hge
+
+/-- **The dichotomy, quantified.**  If the depth-`2j` balanced bounding fraction
+`F_{2j+1}` fits under the order cap `n` (i.e. `F_{2j+1} ≤ n`), then `2ʲ ≤ n`, so
+`j ≤ log₂ n`.  Only `O(log n)` balanced levels are admissible — an *exponential*
+separation from § 6, where `iterate_left_denom_linear` admits `Θ(n)` one-sided
+levels under the same cap.  Any honest run-length count for `f(n)` must therefore
+distinguish these two descent regimes. -/
+theorem balanced_depth_log (j n : ℕ) (hcap : Nat.fib (2 * j + 1) ≤ n) :
+    2 ^ j ≤ n :=
+  le_trans (fib_pow_lower j) hcap
 
 end Erdos1005OQ02

--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -314,4 +314,76 @@ theorem denom_ge_of_between_ne_mediant {a b c d p q : ℕ} (hb : 0 < b) (hd : 0 
     have hsub := denom_ge_right_subgap hb hd hq h hM hhi
     omega
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 6: Iterated one-sided insertion — exact linear denominator growth
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+This section generalises the depth-two bounds of § 5 to arbitrary depth and, in
+doing so, **corrects a tempting but false heuristic**: that the order-`n`
+denominator cap forces only `O(log n)` mediant-refinement levels (a "Fibonacci /
+golden-ratio" depth bound).  Exponential `φ^k` denominator growth is special to
+*balanced* (alternating left/right) chains.  The *worst case* is the one-sided
+chain `a/b, (a+c)/(b+d), (2a+c)/(2b+d), …`, whose `k`-th mediant has denominator
+exactly `(k+1)·b + d` — **linear** in the depth `k`.  Concretely, the all-left
+chain from the root gap `0/1 < 1/1` is `0/1, 1/2, 1/3, …, 1/n`, giving `Θ(n)`
+refinement levels under the cap `q ≤ n`, not `O(log n)`.  Any genuine run-length
+count must therefore distinguish balanced from one-sided descent — the two
+extremes differ by an exponential factor in admissible depth.
+-/
+
+/-- **Iterated left insertion stays unimodular.**  Inserting the mediant into the
+*left* sub-gap `k` times turns the unimodular pair `a/b < c/d` into
+`a/b < (k·a + c)/(k·b + d)`, which is again unimodular.  No induction is needed:
+the relation `b·c = a·d + 1` is invariant under `c ↦ k·a + c`, `d ↦ k·b + d`
+(the added `k·a·b` cancels). -/
+theorem unimodular_iterate_left (k : ℕ) {a b c d : ℕ} (h : Unimodular a b c d) :
+    Unimodular a b (k * a + c) (k * b + d) := by
+  unfold Unimodular at h ⊢
+  have h' : (b : ℤ) * c = a * d + 1 := by exact_mod_cast h
+  have : (b : ℤ) * (k * a + c) = a * (k * b + d) + 1 := by linear_combination h'
+  exact_mod_cast this
+
+/-- **Iterated right insertion stays unimodular.**  Symmetrically, inserting the
+mediant into the *right* sub-gap `k` times turns `a/b < c/d` into
+`(a + k·c)/(b + k·d) < c/d`, again unimodular. -/
+theorem unimodular_iterate_right (k : ℕ) {a b c d : ℕ} (h : Unimodular a b c d) :
+    Unimodular (a + k * c) (b + k * d) c d := by
+  unfold Unimodular at h ⊢
+  have h' : (b : ℤ) * c = a * d + 1 := by exact_mod_cast h
+  have : ((b : ℤ) + k * d) * c = (a + k * c) * d + 1 := by linear_combination h'
+  exact_mod_cast this
+
+/-- **Depth-`k` denominator bound, left chain.**  The `k`-fold left sub-gap
+`(a/b, (k·a+c)/(k·b+d))` is unimodular, so every fraction strictly inside it has
+denominator `q ≥ b + (k·b + d) = (k+1)·b + d`.  The bound is **linear** in `k`:
+each extra refinement level along a one-sided chain costs only `b` in
+denominator, so up to `Θ(n)` such levels fit under the order-`n` cap. -/
+theorem denom_ge_iterate_left (k : ℕ) {a b c d p q : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (hq : 0 < q) (h : Unimodular a b c d)
+    (hlo : (a : ℚ) / b < (p : ℚ) / q)
+    (hhi : (p : ℚ) / q < (↑(k * a + c) : ℚ) / ↑(k * b + d)) :
+    b + (k * b + d) ≤ q := by
+  have hbd : 0 < k * b + d := by omega
+  exact denom_ge_of_between hb hbd hq (unimodular_iterate_left k h) hlo hhi
+
+/-- **Depth-`k` denominator bound, right chain.**  Symmetric to
+`denom_ge_iterate_left`: every fraction strictly inside the `k`-fold right
+sub-gap `((a+k·c)/(b+k·d), c/d)` has denominator `q ≥ (b + k·d) + d`. -/
+theorem denom_ge_iterate_right (k : ℕ) {a b c d p q : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (hq : 0 < q) (h : Unimodular a b c d)
+    (hlo : (↑(a + k * c) : ℚ) / ↑(b + k * d) < (p : ℚ) / q)
+    (hhi : (p : ℚ) / q < (c : ℚ) / d) :
+    (b + k * d) + d ≤ q := by
+  have hbd : 0 < b + k * d := by omega
+  exact denom_ge_of_between hbd hd hq (unimodular_iterate_right k h) hlo hhi
+
+/-- **The one-sided mediant denominator is exactly linear in depth.**  Reading
+`denom_ge_iterate_left` at the successor depth, the mediant produced by `k+1`
+left insertions sits at denominator `b + (k·b + d) = (k+1)·b + d`.  This exact
+identity is the witness that one-sided descent grows denominators *linearly*, so
+the number of admissible refinement levels under `q ≤ n` is `Θ(n)`. -/
+theorem iterate_left_denom_linear (k b d : ℕ) :
+    b + (k * b + d) = (k + 1) * b + d := by ring
+
 end Erdos1005OQ02

--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -514,4 +514,125 @@ theorem balanced_depth_log (j n : ℕ) (hcap : Nat.fib (2 * j + 1) ≤ n) :
     2 ^ j ≤ n :=
   le_trans (fib_pow_lower j) hcap
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 8: Mediant chains are similarly ordered — the bridge to f(n)
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+Sections 1–7 develop the *metric* side of mediant insertion (gap sizes,
+denominators, depth). The open problem, however, is about the *ordering* side:
+`f(n)` counts the longest run of consecutive **similarly ordered** Farey
+fractions, where `a/b` and `c/d` are similarly ordered iff
+`(a − c)·(b − d) ≥ 0` (numerator and denominator move the same way).  This
+section is the first link in the file between the two: it shows that mediant
+insertion *automatically produces* similarly ordered families.
+
+The headline is `simOrd_iterate_left_chain` / `_right_chain`: the entire
+one-sided mediant chain of § 6 — of length `Θ(n)` under the order cap (§ 6) —
+is **pairwise** similarly ordered.  This is exactly the combinatorial engine
+behind the linear lower bound `f(n) ≥ c·n`: monotone mediant descent never
+breaks similar ordering.
+
+What this does **not** do — and the honest gap to the open constant — is supply
+*consecutiveness*.  The chain `0/1, 1/2, 1/3, …, 1/n` is similarly ordered but
+its members are **not** adjacent in `F_n` (e.g. `1/2, 1/3` are separated in
+`F_5`).  Turning a similarly ordered mediant chain into a similarly ordered run
+of *consecutive* Farey fractions is precisely where the `1/12`–`1/4` optimization
+lives.  The predicate `SimOrd` below matches `similarlyOrdered` of
+`Erdos1005ProblemProvable.lean` verbatim, so these lemmas plug directly into the
+run definition there.
+-/
+
+/-- **Similar ordering** of `a/b` and `c/d`, as a predicate on the raw integer
+data: the numerator and denominator differences have the same (weak) sign.  This
+is definitionally the `similarlyOrdered` relation of
+`Erdos1005ProblemProvable.lean`. -/
+def SimOrd (a b c d : ℕ) : Prop :=
+  ((a : ℤ) - c ≥ 0 ∧ (b : ℤ) - d ≥ 0) ∨ ((a : ℤ) - c ≤ 0 ∧ (b : ℤ) - d ≤ 0)
+
+/-- Similar ordering is symmetric (swap the two fractions). -/
+theorem simOrd_symm {a b c d : ℕ} (h : SimOrd a b c d) : SimOrd c d a b := by
+  rcases h with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · exact Or.inr ⟨by linarith, by linarith⟩
+  · exact Or.inl ⟨by linarith, by linarith⟩
+
+/-- Similar ordering is reflexive. -/
+theorem simOrd_refl (a b : ℕ) : SimOrd a b a b := Or.inl ⟨by simp, by simp⟩
+
+/-- **Product characterization.**  `SimOrd` holds iff the product of the two
+differences is nonnegative, `(a − c)·(b − d) ≥ 0`.  This is the form most
+convenient for arithmetic and shows `SimOrd` is exactly "same sign". -/
+theorem simOrd_iff_prod {a b c d : ℕ} :
+    SimOrd a b c d ↔ ((a : ℤ) - c) * ((b : ℤ) - d) ≥ 0 := by
+  constructor
+  · rintro (⟨h1, h2⟩ | ⟨h1, h2⟩)
+    · exact mul_nonneg h1 h2
+    · nlinarith [h1, h2]
+  · intro h
+    rcases le_or_gt 0 ((a : ℤ) - c) with ha | ha
+    · rcases le_or_gt 0 ((b : ℤ) - d) with hb | hb
+      · exact Or.inl ⟨ha, hb⟩
+      · -- `(a-c) ≥ 0` and `(b-d) < 0` force `(a-c) = 0` (else product < 0)
+        have : (a : ℤ) - c ≤ 0 := by nlinarith
+        exact Or.inr ⟨this, by linarith⟩
+    · rcases le_or_gt 0 ((b : ℤ) - d) with hb | hb
+      · have : (b : ℤ) - d ≤ 0 := by nlinarith
+        exact Or.inr ⟨by linarith, this⟩
+      · exact Or.inr ⟨by linarith, by linarith⟩
+
+/-- **The mediant is similarly ordered with its left parent.**  Going from `a/b`
+to its mediant `(a+c)/(b+d)` increases both numerator (by `c`) and denominator
+(by `d`), so the two are similarly ordered. -/
+theorem simOrd_mediant_left (a b c d : ℕ) : SimOrd (a + c) (b + d) a b :=
+  Or.inl ⟨by push_cast; linarith, by push_cast; linarith⟩
+
+/-- **The mediant is similarly ordered with its right parent.**  Going from the
+mediant `(a+c)/(b+d)` to `c/d` decreases both numerator (by `a`) and denominator
+(by `b`), so the two are similarly ordered. -/
+theorem simOrd_mediant_right (a b c d : ℕ) : SimOrd (a + c) (b + d) c d :=
+  Or.inl ⟨by push_cast; linarith, by push_cast; linarith⟩
+
+/-- **The one-sided (left) mediant chain is pairwise similarly ordered.**  Along
+the § 6 left chain `eₖ = (k·a + c)/(k·b + d)`, deeper terms have larger numerator
+*and* larger denominator (both grow linearly in the depth `k`), so any two terms
+`eₖ` (`j ≤ k`) are similarly ordered.  Hence the **whole chain is a similarly
+ordered family** — the order-side counterpart of the metric depth bounds of § 6,
+and the engine of the linear lower bound on `f(n)`. -/
+theorem simOrd_iterate_left_chain (a b c d j k : ℕ) (hjk : j ≤ k) :
+    SimOrd (k * a + c) (k * b + d) (j * a + c) (j * b + d) := by
+  have hk : (j : ℤ) ≤ k := by exact_mod_cast hjk
+  refine Or.inl ⟨?_, ?_⟩
+  · have : ((k : ℤ) - j) * a ≥ 0 := mul_nonneg (by linarith) (by positivity)
+    push_cast; nlinarith
+  · have : ((k : ℤ) - j) * b ≥ 0 := mul_nonneg (by linarith) (by positivity)
+    push_cast; nlinarith
+
+/-- **The one-sided (right) mediant chain is pairwise similarly ordered.**
+Symmetric to `simOrd_iterate_left_chain` for the § 6 right chain
+`eₖ = (a + k·c)/(b + k·d)`. -/
+theorem simOrd_iterate_right_chain (a b c d j k : ℕ) (hjk : j ≤ k) :
+    SimOrd (a + k * c) (b + k * d) (a + j * c) (b + j * d) := by
+  have hk : (j : ℤ) ≤ k := by exact_mod_cast hjk
+  refine Or.inl ⟨?_, ?_⟩
+  · have : ((k : ℤ) - j) * c ≥ 0 := mul_nonneg (by linarith) (by positivity)
+    push_cast; nlinarith
+  · have : ((k : ℤ) - j) * d ≥ 0 := mul_nonneg (by linarith) (by positivity)
+    push_cast; nlinarith
+
+/-- **Similarly ordered chain under the order cap.**  Combining the order-side
+fact (`simOrd_iterate_left_chain`) with the metric admissibility from § 6: every
+term `eⱼ = (j·a + c)/(j·b + d)` of the left chain with depth `j ≤ k` has
+denominator `≤ k·b + d`, and all such terms are pairwise similarly ordered.  So
+if `k·b + d ≤ n`, the chain supplies `k + 1` pairwise similarly ordered fractions
+all of order `≤ n`.  Since `k` can be taken `≈ (n − d)/b = Θ(n)`, mediant descent
+produces *linearly long* similarly ordered families under the order-`n` cap.
+(That these are not yet *consecutive* in `F_n` is the remaining open step — see
+the section preamble.) -/
+theorem simOrd_chain_admissible (a b c d k n : ℕ) (hcap : k * b + d ≤ n)
+    {i j : ℕ} (hij : i ≤ j) (hjk : j ≤ k) :
+    SimOrd (j * a + c) (j * b + d) (i * a + c) (i * b + d) ∧ j * b + d ≤ n := by
+  refine ⟨simOrd_iterate_left_chain a b c d i j hij, ?_⟩
+  have : j * b ≤ k * b := Nat.mul_le_mul_right b hjk
+  omega
+
 end Erdos1005OQ02

--- a/research/problems/erdos-1005-oq-02/sessions/2026-06-27-s4-counting-roadmap-and-literature.md
+++ b/research/problems/erdos-1005-oq-02/sessions/2026-06-27-s4-counting-roadmap-and-literature.md
@@ -1,0 +1,108 @@
+# Session 2026-06-27 (s4) — Counting-argument roadmap + literature grounding
+
+**Researcher**: researcher-10
+**Mode**: DESIGN / KNOWLEDGE (build host unavailable — see Blocker)
+**Phase**: FORMALIZED (verified mediant calculus; open constant remains open)
+**Outcome**: progress (no Lean change; roadmap + literature recorded)
+
+## Goal
+
+Connect the already-verified mediant / minimal-denominator calculus in
+`proofs/Proofs/Erdos1005ProblemOQ02.lean` (19 theorems, 0 sorries, 0 axioms)
+to the genuinely open question — the Mayer–Erdős run constant
+`c ∈ [1/12, 1/4]` for `f(n)`, the longest run of *similarly ordered* Farey
+fractions — and pin down the precise next Lean lemma.
+
+## Literature grounding (corrects the bound recorded in the parent knowledge.md)
+
+The sharp current bounds are due to **Wouter van Doorn (2025)**,
+*"Improved bounds for the Mayer–Erdős phenomenon on similarly ordered Farey
+fractions"*, arXiv:**2509.00121**:
+
+- **Lower bound.** For all `k` and `l > k` with `l − k ≤ (1/12 − o(1)) n`,
+  the similar-ordering inequality `(a_l − a_k)(b_l − b_k) ≥ 0` holds. Hence
+  `f(n) ≥ (1/12 − o(1)) n`.
+- **Upper bound.** For every `n ≥ 4` there exist `k < l < k + n/4 + 5` with
+  `(a_l − a_k)(b_l − b_k) < 0`. Hence `f(n) ≤ n/4 + 5` (the parent
+  `knowledge.md` recorded the looser `n/4 + O(1)`; `+5` is the explicit
+  constant).
+
+So the open question is exactly the value of `c` in `f(n) = (c + o(1)) n`,
+known only to lie in `[1/12, 1/4]`.
+
+Two fractions `a/b`, `a'/b'` are *similarly ordered* iff
+`(a' − a)(b' − b) ≥ 0`. The file's `similarlyOrdered_iff_monotone` already
+records the equivalent "the two coordinate orderings agree" form.
+
+## How the verified lemmas feed a counting argument
+
+The verified results in `Erdos1005ProblemOQ02.lean` are exactly the
+Stern–Brocot / Farey *local* facts a run-length count rests on:
+
+1. **Minimal-denominator theorem** (`denom_ge_of_between`,
+   `eq_mediant_of_denom_eq`, `mediant_is_min_denominator`): every fraction
+   strictly inside a unimodular gap `a/b < c/d` has denominator `q ≥ b + d`,
+   with equality only at the mediant `(a+c)/(b+d)`. This is the engine that
+   converts "order `n`" (a denominator cap `q ≤ n`) into a *bound on how many
+   refinement levels fit*, hence on how long a monotone block can be.
+
+2. **Strict denominator growth** (`interior_denom_gt_max`,
+   `denom_ge_of_between_ne_mediant`): refining past the mediant forces the
+   smallest available denominator up by `≥ min(b, d)`. Iterating, the
+   admissible denominators along a path down the Stern–Brocot tree grow at
+   least like the partial sums of a continued-fraction expansion.
+
+3. **Sub-gap unimodularity + depth-two bounds** (`unimodular_left/right`,
+   `mediant_gap_left/right`, `denom_ge_left_subgap` giving `q ≥ 2b + d`,
+   `denom_ge_right_subgap` giving `q ≥ b + 2d`): each sub-gap is again
+   unimodular, so the whole calculus recurses. Depth-two already exhibits the
+   Fibonacci recurrence `F_{k+1} = F_k + F_{k-1}` on denominators.
+
+**Roadmap to the run bound.** A run of similarly ordered consecutive Farey
+fractions of order `n` corresponds to a monotone path in the Stern–Brocot
+tree along which both numerator and denominator move monotonically. The
+denominator cap `q ≤ n` plus the strict-growth lemma (2) bounds the depth of
+such a path; the minimal-denominator lemma (1) converts depth into a count of
+intermediate fractions. The constant `1/12` arises from optimizing the
+trade-off between path depth and branching (van Doorn's contribution); the
+verified lemmas here supply the *exact* per-step arithmetic that any such
+optimization must respect. They do **not** yet assemble into the asymptotic
+count — that assembly is the open work.
+
+## Precise next Lean target
+
+The natural next verified lemma, generalizing the depth-two bounds (3) to
+arbitrary depth:
+
+> **Depth-`k` Fibonacci denominator bound.** Along any length-`k` chain of
+> nested mediant insertions starting from a unimodular gap `a/b < c/d`, every
+> interior fraction has denominator `q ≥ F_{k+1} · min(b,d) + F_k · …`
+> (precise Fibonacci coefficients to be fixed by the induction), so a chain of
+> depth `k` requires denominator `≳ φ^k`. Equivalently: at most
+> `O(log_φ n)` mediant-refinement levels fit under the order-`n` cap.
+
+This is a clean induction over `k` using `unimodular_left/right` and
+`denom_ge_of_between` as the inductive step — entirely within the existing
+0-axiom toolkit, no new Mathlib dependencies. It is the bridge from the
+verified *local* calculus to a *global* count.
+
+## Blocker (why no Lean this cycle)
+
+The Docker build host is unusable: the data volume (`/System/Volumes/Data`)
+is **100% full** (≈6.9 GiB free of 926 GiB). `docker ps` responds but image
+builds die with `containerd … meta.db: input/output error`, and
+`docker-build.sh` exits 0 on this failure (false success — its output tail
+must be read). No Lean image is cached and the local Mathlib `.olean` set is
+incomplete (`Mathlib.olean` absent), so `lake env lean` cannot
+`import Mathlib` either. Adding an *unverified* inductive proof to a currently
+clean 0-axiom file risks silently breaking its verified status, so the
+depth-`k` lemma is deferred until the build host is restored (operator action:
+free disk space). This session therefore records the design + literature so
+the next verified-capable session can implement the depth-`k` bound directly.
+
+## Next Action
+
+When the build host is back: implement the **depth-`k` Fibonacci denominator
+bound** above as a 0-axiom induction in `Erdos1005ProblemOQ02.lean`, then use
+it to state the `O(log n)` refinement-depth corollary — the first global
+consequence of the local calculus.

--- a/research/problems/erdos-1005-oq-02/sessions/2026-06-27-s5-iterated-insertion-linear-bound.md
+++ b/research/problems/erdos-1005-oq-02/sessions/2026-06-27-s5-iterated-insertion-linear-bound.md
@@ -1,0 +1,71 @@
+# Session 2026-06-27 (s5) — Iterated insertion: verified linear depth bound + correction
+
+**Researcher**: researcher-10
+**Mode**: REVISIT (continue erdos-1005-oq-02)
+**Phase**: FORMALIZED → ORIENT (verified §6 added; open constant remains open)
+**Outcome**: progress (verified Lean, 0-axiom; corrected a false roadmap claim)
+
+## What I did
+
+- Found Docker still unusable (data volume 100% full; containerd blob I/O
+  error) — but the main-repo Mathlib `.olean` cache
+  (`proofs/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean`) is
+  present, so `lake env lean <file>` typechecks the worktree file directly
+  (EXIT=0, no errors). This restores a verified-capable loop without Docker.
+- Implemented **§6 of `Erdos1005ProblemOQ02.lean`** (5 new theorems, 0 sorries,
+  0 axioms — `#print axioms` shows only propext / Classical.choice / Quot.sound):
+  - `unimodular_iterate_left (k)` / `unimodular_iterate_right (k)`: iterating
+    one-sided mediant insertion `k` times stays unimodular,
+    `a/b < (k·a+c)/(k·b+d)` (and symmetric). Proof is one `linear_combination`
+    — `bc = ad+1` is invariant under `c ↦ k·a+c`, `d ↦ k·b+d`; no induction.
+  - `denom_ge_iterate_left (k)` / `_right (k)`: every fraction strictly inside
+    the `k`-fold one-sided sub-gap has denominator `q ≥ (k+1)·b+d` (resp.
+    `b+(k+1)·d`) — composes `unimodular_iterate_*` with `denom_ge_of_between`.
+  - `iterate_left_denom_linear`: the exact one-sided mediant denominator is
+    `(k+1)·b+d`.
+
+## Key finding — correction of the Iteration-4 target
+
+The s4 "next target" was a **depth-`k` Fibonacci denominator bound ⇒ `O(log n)`
+refinement depth**. That universal claim is **false**:
+
+- One-sided descent `(b,d) → (b, b+d) → (b, 2b+d) → …` gives denominators
+  `(k+1)·b+d` — **linear** in depth `k`. The concrete chain
+  `0/1, 1/2, 1/3, …, 1/n` fits `Θ(n)` refinement levels under the order-`n`
+  cap, not `O(log n)`.
+- Fibonacci / `φ^k` (exponential) denominator growth — and hence the
+  `O(log_φ n)` depth bound — is special to **balanced (alternating)** chains,
+  the opposite extreme.
+
+So §6 formalizes the *linear worst case* and the file docstring + gallery meta
+now state the correction explicitly. The honest picture: admissible
+mediant-refinement depth under `q ≤ n` ranges from `O(log n)` (balanced) up to
+`Θ(n)` (one-sided); any sharp run-length count toward the `1/12` constant must
+navigate this gap.
+
+## Literature (unchanged from s4)
+
+van Doorn 2025, arXiv:2509.00121: `f(n) ≥ (1/12−o(1))n`, `f(n) ≤ n/4+5`;
+constant `c ∈ [1/12, 1/4]` open.
+
+## Files modified
+
+- `proofs/Proofs/Erdos1005ProblemOQ02.lean` (+§6: 317→389 lines, 19→24 theorems)
+- `src/data/proofs/erdos-1005-oq-02/meta.json` (counts, §6 section, contribution,
+  corrected open question)
+- `src/data/research/problems/erdos-1005-oq-02.json` (knowledge: 0→8 items;
+  phase NEW→ORIENT; OQ02 leanFile counts)
+- `research/problems/erdos-1005-oq-02/state.md`
+
+## Verification
+
+`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean <worktree>/…/Erdos1005ProblemOQ02.lean`
+→ EXIT=0, no errors. `#print axioms` on all 5 new theorems → only
+propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool).
+File remains **verified, 0-axiom**.
+
+## Next action
+
+Formalize the balanced/alternating extreme (`Nat.fib`-tracked alternating
+mediant chain ⇒ `φ^k` growth ⇒ `O(log_φ n)` depth), then bridge depth to run
+length.

--- a/research/problems/erdos-1005-oq-02/sessions/2026-06-27-s6-similar-ordering-bridge.md
+++ b/research/problems/erdos-1005-oq-02/sessions/2026-06-27-s6-similar-ordering-bridge.md
@@ -1,0 +1,61 @@
+# Session 2026-06-27 (s6) — §8: mediant chains are similarly ordered (the bridge to f(n))
+
+**Researcher**: researcher-10
+**Mode**: REVISIT (continuing depth on erdos-1005-oq-02)
+**Phase**: FORMALIZED (verified bridge lemmas; open constant remains open)
+**Outcome**: progress (verified, 0-axiom — added §8, +8 theorems / +1 def)
+
+## What I Did
+
+- Observed that §1–7 of `Erdos1005ProblemOQ02.lean` developed only the *metric*
+  side of mediant insertion (gap sizes, denominators, depth) and never touched
+  the *ordering* relation that actually defines `f(n)`. Closed that gap with §8.
+- Defined `SimOrd a b c d` matching `similarlyOrdered` of
+  `Erdos1005ProblemProvable.lean` verbatim (numerator/denominator differences
+  share a weak sign), and proved `simOrd_iff_prod : SimOrd ↔ (a−c)(b−d) ≥ 0`,
+  plus `simOrd_symm`, `simOrd_refl`.
+- Proved the mediant is similarly ordered with both parents
+  (`simOrd_mediant_left`, `simOrd_mediant_right`).
+- Proved the **whole one-sided §6 chain is pairwise similarly ordered**
+  (`simOrd_iterate_left_chain`, `simOrd_iterate_right_chain`): for `j ≤ k`,
+  `eₖ = (k·a+c)/(k·b+d)` has both larger numerator and larger denominator than
+  `eⱼ`, so the chain — of length Θ(n) under the order cap (§6) — is a similarly
+  ordered family.
+- `simOrd_chain_admissible` packages this with the §6 cap `k·b+d ≤ n`.
+- Verified the whole file with `lake env lean` against the main-repo Mathlib
+  `.olean` cache (Docker image build still dies on the containerd `meta.db` I/O
+  error). Clean compile, exit 0, no warnings, 0 sorry / 0 axiom / no
+  native_decide.
+- Updated `meta.json` (lineCount 638, theoremCount 39, def 2, new §8 section,
+  originalContributions, conclusion, cross-ref to the parent's similarlyOrdered).
+
+## Key Findings
+
+- **Mediant insertion never breaks similar ordering.** Moving from a parent to
+  the mediant changes numerator and denominator in the same direction (+c,+d on
+  the left; −a,−b on the right). So similar ordering is *automatic* along any
+  monotone mediant descent — this is the order-side engine behind the linear
+  lower bound `f(n) ≥ c·n`.
+- **The honest gap to the open constant is consecutiveness, not ordering.** The
+  one-sided chain `0/1, 1/2, 1/3, …, 1/n` is similarly ordered and Θ(n) long but
+  its members are not adjacent in `F_n` (e.g. `1/2, 1/3` separated in `F_5`).
+  The `1/12`–`1/4` optimization lives entirely in converting such a chain into a
+  run of *consecutive* Farey fractions.
+- `nlinarith` cleanly discharges the "same sign ⇒ product ≥ 0" direction and the
+  degenerate `(a−c)=0` case in `simOrd_iff_prod`; `mul_nonneg_of_nonpos_nonpos`
+  does **not** exist in this Mathlib (v4.26.0) — use `nlinarith [h1, h2]`.
+  `le_or_lt` is deprecated in favour of `le_or_gt`.
+
+## Files Modified
+
+- `proofs/Proofs/Erdos1005ProblemOQ02.lean` (517 → 638 lines, +§8)
+- `src/data/proofs/erdos-1005-oq-02/meta.json`
+- `research/problems/erdos-1005-oq-02/state.md`
+
+## Next Steps
+
+Bridge similar ordering to consecutiveness: formalize the three-term Farey
+denominator recurrence `b_{k+1} = ⌊(n+b_{k−1})/b_k⌋·b_k − b_{k−1}` and analyse
+the sign of `(a_{k+1}−a_k)(b_{k+1}−b_k)` over a consecutive block — the concrete
+route toward van Doorn's `(1/12−o(1))n` lower bound. Assess whether to build a
+Farey indexing layer or reuse `fareyList`.

--- a/research/problems/erdos-1005-oq-02/state.md
+++ b/research/problems/erdos-1005-oq-02/state.md
@@ -75,16 +75,44 @@ extreme from this linear worst case. §6 formalizes the linear extreme and the
 file/meta now record the correction. A sharp run-length count toward `1/12` must
 distinguish the two extremes.
 
+## Iteration 6 addition (verified, 0-axiom — Docker still down, used `lake env lean`)
+
+Added **§8 (mediant chains are similarly ordered — the bridge to f(n))**,
+0-sorry / 0-axiom (verified via `lake env lean` against the main-repo Mathlib
+`.olean` cache; Docker image build still fails with the containerd `meta.db`
+I/O error). This is the **first link in the file between the metric mediant
+calculus (§1–7) and the ordering relation that defines the problem.** Eight
+theorems + one definition:
+
+- `SimOrd a b c d` — raw-integer form of `similarlyOrdered`
+  (`Erdos1005ProblemProvable.lean`): numerator and denominator differences share
+  a weak sign. `simOrd_iff_prod` proves it `↔ (a−c)(b−d) ≥ 0`; `simOrd_symm`,
+  `simOrd_refl`.
+- `simOrd_mediant_left` / `_right` — the mediant `(a+c)/(b+d)` is similarly
+  ordered with **both** parents (insertion never breaks similar ordering).
+- `simOrd_iterate_left_chain` / `_right_chain` (headline) — the **entire**
+  one-sided §6 chain `eₖ = (k·a+c)/(k·b+d)` is **pairwise** similarly ordered.
+  So the Θ(n)-long one-sided chain is a similarly ordered family — the order-side
+  engine of the linear lower bound on `f(n)`.
+- `simOrd_chain_admissible` — packages the above with the §6 cap: under
+  `k·b+d ≤ n` the depth-≤k terms are pairwise similarly ordered and of order ≤ n.
+
+**Honest boundary recorded in the section preamble:** chain members are *not*
+consecutive in `F_n` (e.g. `1/2, 1/3` separated in `F_5`), so this does **not**
+prove `f(n) ≳ n`. Supplying consecutiveness is exactly the open `1/12`–`1/4`
+step.
+
 ## Next Action
 
-Formalize the complementary **balanced/alternating** extreme: track the
-alternating mediant chain's denominators against `Nat.fib`, proving the `φ^k`
-growth and the `O(log_φ n)` depth bound for balanced descent. Then bridge depth
-to run length (monotone Stern–Brocot paths under the order-`n` cap ↔ runs of
-similarly ordered fractions).
+Bridge similar ordering to **consecutiveness**: formalize the three-term Farey
+denominator recurrence `b_{k+1} = ⌊(n+b_{k−1})/b_k⌋·b_k − b_{k−1}` and analyse
+when `(a_{k+1}−a_k)(b_{k+1}−b_k) ≥ 0` over a consecutive block — the concrete
+route to van Doorn's `(1/12−o(1))n` lower bound. (Likely needs a Farey-sequence
+indexing layer; assess buildability vs. reuse of `fareyList` in
+`Erdos1005ProblemProvable.lean`.)
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 2
+- Total attempts: 3
+- Current approach attempts: 3
 - Approaches tried: 1

--- a/research/problems/erdos-1005-oq-02/state.md
+++ b/research/problems/erdos-1005-oq-02/state.md
@@ -2,12 +2,12 @@
 
 **Phase**: FORMALIZED (verified infrastructure; open problem itself remains open)
 **Since**: 2026-06-25
-**Iteration**: 3
+**Iteration**: 5
 
 ## Current Focus
 
 Formalized the exact arithmetic of mediant insertion on Farey gaps:
-`proofs/Proofs/Erdos1005ProblemOQ02.lean` (317 lines, 19 theorems, 1 def,
+`proofs/Proofs/Erdos1005ProblemOQ02.lean` (389 lines, 24 theorems, 1 def,
 0 sorries, 0 axioms; #print axioms reports only propext / Classical.choice /
 Quot.sound).
 
@@ -43,14 +43,48 @@ point, and the next admissible denominator jumps by ≥ min(b,d). This is the
 strict-growth step the counting argument rests on; the 1/12 run constant itself
 remains open.
 
+## Iteration 4 addition (design/knowledge — build host down)
+
+Recorded `sessions/2026-06-27-s4-counting-roadmap-and-literature.md`: pins the
+literature to **van Doorn 2025, arXiv:2509.00121** (lower `(1/12−o(1))n`,
+explicit upper `n/4 + 5`, sharpening the parent knowledge.md's `n/4 + O(1)`),
+maps each verified lemma (minimal-denominator `q ≥ b+d`, strict growth, depth-
+two `q ≥ 2b+d` / `b+2d`) onto a counting-argument roadmap, and fixes the precise
+next Lean target: a **depth-`k` Fibonacci denominator bound** (0-axiom
+induction over nested mediant insertions ⇒ `O(log_φ n)` refinement depth under
+the order-`n` cap). No Lean change this cycle: Docker build host data volume is
+100% full (containerd meta.db I/O error; `docker-build.sh` false-exits 0), so
+an unverified inductive proof would risk the file's clean 0-axiom status.
+
+## Iteration 5 addition (verified, 0-axiom — build host still down, used `lake env lean`)
+
+Added **§6 (iterated one-sided insertion — exact linear denominator growth)**,
+0-sorry / 0-axiom (verified by `lake env lean` against the main-repo Mathlib
+`.olean` cache; Docker still unusable). Five theorems:
+`unimodular_iterate_left`/`_right` (k-fold one-sided insertion stays unimodular,
+`a/b < (k·a+c)/(k·b+d)`, by scale-invariance of `bc=ad+1` — no induction);
+`denom_ge_iterate_left`/`_right` (depth-`k` interior denominator bound
+`q ≥ (k+1)·b+d`); `iterate_left_denom_linear` (the exact `(k+1)·b+d`).
+
+**Key correction.** The Iteration-4 "depth-`k` Fibonacci ⇒ `O(log n)` refinement
+depth" target was **mathematically wrong as a universal claim**: the one-sided
+chain `0/1, 1/2, 1/3, …, 1/n` has only LINEAR denominator growth and fits
+`Θ(n)` refinement levels under the order-`n` cap. Exponential `φ^k` growth (hence
+`O(log n)` depth) is special to *balanced/alternating* chains — the opposite
+extreme from this linear worst case. §6 formalizes the linear extreme and the
+file/meta now record the correction. A sharp run-length count toward `1/12` must
+distinguish the two extremes.
+
 ## Next Action
 
-A counting argument over consecutive mediant insertions, combined with the
-gap-splitting and minimal-denominator results here, is the natural route
-toward recovering (or improving) the `1/12` run lower bound.
+Formalize the complementary **balanced/alternating** extreme: track the
+alternating mediant chain's denominators against `Nat.fib`, proving the `φ^k`
+growth and the `O(log_φ n)` depth bound for balanced descent. Then bridge depth
+to run length (monotone Stern–Brocot paths under the order-`n` cap ↔ runs of
+similarly ordered fractions).
 
 ## Attempt Counts
 
-- Total attempts: 1
-- Current approach attempts: 1
+- Total attempts: 2
+- Current approach attempts: 2
 - Approaches tried: 1

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -5,12 +5,12 @@
   "title": "Mediant Insertion and the Farey Gap Calculus: The Mediant Is the Unique Smallest-Denominator Fraction in a Gap",
   "description": "A self-contained, axiom-free formalization of the exact arithmetic of mediant insertion — the operation that refines the Farey sequence F_n into F_{n+1} by inserting, between adjacent fractions a/b < c/d, their mediant (a+c)/(b+d). Two threads are proved. First, the gap-splitting calculus: a unimodular gap of size 1/(bd) is split by its mediant into a left sub-gap 1/(b(b+d)) and a right sub-gap 1/(d(b+d)); these sum back to 1/(bd), stand in ratio d:b, and each is strictly smaller than the whole. Second, the headline minimal-denominator theorem: any fraction p/q strictly between two unimodular neighbours has denominator q ≥ b+d, and equality forces p/q = (a+c)/(b+d) exactly. Hence the mediant is the unique fraction of smallest denominator inside any Farey gap, and b+d is a hard lower bound on refining it — no construction can introduce a fraction of smaller denominator. The parent entry (Erdős #1005) records the open lower bound f(n) ≥ (1/12−o(1))n on runs of similarly ordered Farey fractions; that constant remains open and is NOT addressed here. This entry formalizes the verified mediant calculus on which such lower-bound constructions are built.",
   "leanFile": {
-    "lineCount": 517,
+    "lineCount": 638,
     "axiomCount": 0,
     "path": "Proofs/Erdos1005ProblemOQ02.lean",
     "sorries": 0,
-    "definitionCount": 1,
-    "theoremCount": 31
+    "definitionCount": 2,
+    "theoremCount": 39
   },
   "meta": {
     "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot mediant theory)",
@@ -41,11 +41,15 @@
       "denom_identity: the algebraic kernel over ℤ — q = b·(cq − pd) + d·(pb − aq), an unconditional identity once bc − ad = 1, verified by linear_combination",
       "mediant_is_min_denominator: a packaged statement — the mediant lies strictly inside the gap and every in-gap fraction has denominator ≥ b + d",
       "unimodular_iterate_left / unimodular_iterate_right: iterating one-sided insertion k times stays unimodular — a/b < c/d becomes a/b < (k·a+c)/(k·b+d) (and symmetrically on the right), with no induction needed since b·c = a·d+1 is invariant under c ↦ k·a+c, d ↦ k·b+d",
-      "denom_ge_iterate_left / denom_ge_iterate_right: the depth-k denominator bound — every fraction inside the k-fold one-sided sub-gap has q ≥ (k+1)·b+d (resp. b+(k+1)·d), LINEAR in the depth k. This corrects a tempting false heuristic: the order-n cap does NOT force O(log n) refinement depth; the one-sided chain 0/1, 1/2, 1/3, …, 1/n already fits Θ(n) levels. Exponential φ^k growth (hence O(log n) depth) is special to balanced/alternating chains, the opposite extreme from this linear worst case"
+      "denom_ge_iterate_left / denom_ge_iterate_right: the depth-k denominator bound — every fraction inside the k-fold one-sided sub-gap has q ≥ (k+1)·b+d (resp. b+(k+1)·d), LINEAR in the depth k. This corrects a tempting false heuristic: the order-n cap does NOT force O(log n) refinement depth; the one-sided chain 0/1, 1/2, 1/3, …, 1/n already fits Θ(n) levels. Exponential φ^k growth (hence O(log n) depth) is special to balanced/alternating chains, the opposite extreme from this linear worst case",
+      "§8 SimOrd + simOrd_iff_prod: the first bridge in the file from the metric mediant calculus to the ORDERING relation that defines f(n). SimOrd a b c d is the raw-integer form of the parent's similarlyOrdered (numerator and denominator differences have the same weak sign), proved equivalent to the product form (a−c)(b−d) ≥ 0",
+      "simOrd_mediant_left / simOrd_mediant_right: the mediant (a+c)/(b+d) is similarly ordered with BOTH parents a/b and c/d — inserting a mediant never breaks similar ordering (numerator and denominator move together by +c,+d on the left and −a,−b on the right)",
+      "simOrd_iterate_left_chain / simOrd_iterate_right_chain: the entire one-sided §6 mediant chain eₖ = (k·a+c)/(k·b+d) is PAIRWISE similarly ordered (deeper terms have larger numerator and larger denominator), so the Θ(n)-long one-sided chain is a similarly ordered family — the order-side engine behind the linear lower bound on f(n). The honest gap to the open constant: chain members are not yet CONSECUTIVE in F_n (e.g. 1/2, 1/3 are separated in F_5); supplying consecutiveness is where the 1/12–1/4 optimization lives",
+      "simOrd_chain_admissible: combines the order-side and metric sides — under the cap k·b+d ≤ n the depth-≤k left-chain terms are pairwise similarly ordered AND all of order ≤ n, so mediant descent yields linearly long similarly ordered families admissible at order n"
     ],
-    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for the headline theorems (denom_ge_of_between, eq_mediant_of_denom_eq, mediant_is_min_denominator). No native_decide is used (so no Lean.ofReduceBool). This entry does NOT resolve the open Erdős #1005 lower bound f(n) ≥ (1/12 − o(1))n on runs of similarly ordered Farey fractions; that constant remains open.",
-    "theoremCount": 24,
-    "definitionCount": 1
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for the headline theorems (denom_ge_of_between, eq_mediant_of_denom_eq, mediant_is_min_denominator). No native_decide is used (so no Lean.ofReduceBool). This entry does NOT resolve the open Erdős #1005 lower bound f(n) ≥ (1/12 − o(1))n on runs of similarly ordered Farey fractions; that constant remains open. §8 connects the calculus to the similarlyOrdered relation but explicitly does NOT supply consecutiveness in F_n, which is the open step.",
+    "theoremCount": 38,
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "The Farey sequence F_n — the reduced fractions in [0,1] with denominator ≤ n, in increasing order — is built recursively by mediant insertion: F_{n+1} is obtained from F_n by inserting between each adjacent pair a/b < c/d their mediant (a+c)/(b+d), which appears precisely when b+d = n+1. The mediant and the unimodular relation bc − ad = 1 organize the entire Stern–Brocot tree. Erdős Problem #1005 asks for the longest run of consecutive 'similarly ordered' Farey fractions, with known bounds (1/12 − o(1))n ≤ f(n) ≤ n/4 + O(1) and the leading constant open. Every lower-bound construction proceeds by tracking how mediant insertion subdivides gaps; this entry makes that subdivision exact and proves the optimality of the mediant.",
@@ -60,12 +64,13 @@
     ]
   },
   "conclusion": {
-    "summary": "A self-contained, 0-axiom, 0-sorry formalization (389 lines, 24 theorems, 1 definition) of mediant insertion on Farey gaps. The mediant splits a unimodular gap 1/(bd) into 1/(b(b+d)) and 1/(d(b+d)) — summing back to the whole, in ratio d:b, each strictly smaller — and, as the headline result, is the unique fraction of smallest denominator b + d inside the gap: every strictly-in-between p/q has q ≥ b + d, with equality forcing p/q = (a+c)/(b+d). A final section iterates one-sided insertion to arbitrary depth (unimodular_iterate_left/right, denom_ge_iterate_left/right), proving the depth-k interior denominator bound is LINEAR, (k+1)·b+d, which corrects a tempting false heuristic: the order-n cap admits Θ(n) one-sided refinement levels (e.g. 0/1, 1/2, …, 1/n), not O(log n) — exponential growth is special to balanced chains.",
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (638 lines, 39 theorems, 2 definitions) of mediant insertion on Farey gaps. The mediant splits a unimodular gap 1/(bd) into 1/(b(b+d)) and 1/(d(b+d)) — summing back to the whole, in ratio d:b, each strictly smaller — and, as the headline result, is the unique fraction of smallest denominator b + d inside the gap: every strictly-in-between p/q has q ≥ b + d, with equality forcing p/q = (a+c)/(b+d). §6–7 iterate insertion to arbitrary depth and prove a depth dichotomy: one-sided chains grow denominators linearly ((k+1)·b+d, Θ(n) admissible levels), balanced chains follow the Fibonacci recurrence and grow exponentially (O(log n) levels, certified by Cassini's identity). §8 finally bridges this metric calculus to the ORDERING relation defining f(n): the mediant is similarly ordered with both parents, and the entire one-sided chain is pairwise similarly ordered — the order-side engine of the linear lower bound — while honestly flagging that consecutiveness in F_n (the open 1/12–1/4 step) is not supplied.",
     "implications": "The minimal-denominator theorem (denom_ge_of_between together with eq_mediant_of_denom_eq) is the exact optimality statement behind Stern–Brocot/continued-fraction best approximation: the same q ≥ b + d bound governs convergent denominators and the 'no better approximation with smaller denominator' property. The gap-splitting identities are reusable infrastructure for any quantitative Farey argument, including the constructions that establish the known lower bound on runs in Erdős #1005.",
     "openQuestions": [
       "Erdős #1005 itself: can iterated mediant insertion plus a counting argument recover, or improve, the known lower bound (1/12 − o(1))n on the longest run of similarly ordered Farey fractions? The constant in [1/12, 1/4] is open and is not addressed by this entry.",
       "Best-approximation corollary: formalize that two consecutive continued-fraction convergents form a unimodular pair, so the minimal-denominator theorem yields the classical statement that no fraction with smaller denominator approximates better — connecting this entry to Diophantine approximation.",
-      "Refinement depth, balanced case: §6 settles the one-sided extreme (linear denominator growth, Θ(n) admissible levels). The complementary balanced/alternating extreme — where denominators follow the Fibonacci recurrence and grow like φ^k, giving O(log n) depth — remains to be formalized (track the alternating mediant chain against Nat.fib). The gap between these two extremes is exactly what a sharp run-length count toward the 1/12 constant must navigate."
+      "Refinement depth, balanced case: §6 settles the one-sided extreme (linear denominator growth, Θ(n) admissible levels) and §7 the balanced extreme (Fibonacci/φ^k growth, O(log n) depth, Cassini-certified). The gap between these two extremes is exactly what a sharp run-length count toward the 1/12 constant must navigate.",
+      "Consecutiveness, the open step (§8): §8 shows mediant chains are similarly ordered families of size Θ(n) under the order cap, but their members are not adjacent in F_n. The missing bridge is to turn a similarly ordered mediant chain into a run of CONSECUTIVE Farey fractions (or to bound how similar ordering can persist across consecutive fractions). Formalizing the three-term Farey recurrence b_{k+1} = ⌊(n+b_{k−1})/b_k⌋·b_k − b_{k−1} and analysing when (a_{k+1}−a_k)(b_{k+1}−b_k) ≥ 0 over a consecutive block is the concrete next target toward van Doorn's (1/12−o(1))n lower bound."
     ]
   },
   "sections": [
@@ -122,8 +127,15 @@
       "id": "balanced-insertion",
       "title": "§7 Balanced (alternating) insertion — exponential denominator growth",
       "startLine": 390,
-      "endLine": 517,
+      "endLine": 515,
       "summary": "Establishes the OTHER extreme of the §6 dichotomy: the balanced Stern–Brocot path (alternating left/right) grows denominators EXPONENTIALLY, not linearly. fib_cassini proves Cassini's identity F_{n+1}² − F_n·F_{n+2} = (−1)ⁿ over ℤ by one-step induction. unimodular_fib_even reads it at even index to certify the consecutive Fibonacci fractions F_{2k}/F_{2k+1} < F_{2k+1}/F_{2k+2} as genuine unimodular (adjacent Farey) pairs, so the minimal-denominator machinery of §4 applies. fib_two_step_double: 2·F_k ≤ F_{k+2} (two levels at least double the denominator). fib_pow_lower: 2ʲ ≤ F_{2j+1} (exponential lower bound). balanced_mediant_denom: the balanced mediant has denominator F_{2k+1}+F_{2k+2} = F_{2k+3}, the Fibonacci recurrence. denom_ge_balanced specialises denom_ge_of_between to the Fibonacci pair. balanced_depth_log: if F_{2j+1} ≤ n then 2ʲ ≤ n, so only O(log n) balanced levels fit under the order cap — an EXPONENTIAL separation from the Θ(n) one-sided levels of §6. Any run-length count toward the 1/12 constant must distinguish the two descent regimes."
+    },
+    {
+      "id": "similar-ordering-bridge",
+      "title": "§8 Mediant chains are similarly ordered — the bridge to f(n)",
+      "startLine": 517,
+      "endLine": 638,
+      "summary": "The first link in the file between the metric mediant calculus (§1–7) and the ORDERING relation that defines f(n). SimOrd a b c d is the raw-integer form of the parent's similarlyOrdered (numerator and denominator differences share a weak sign); simOrd_iff_prod proves it equivalent to (a−c)(b−d) ≥ 0, with simOrd_symm/simOrd_refl. simOrd_mediant_left/_right: the mediant is similarly ordered with BOTH parents — insertion never breaks similar ordering. simOrd_iterate_left_chain/_right_chain (headline): the entire one-sided §6 chain eₖ = (k·a+c)/(k·b+d) is PAIRWISE similarly ordered, so the Θ(n)-long one-sided chain is a similarly ordered family — the order-side engine of the linear lower bound on f(n). simOrd_chain_admissible packages this with the §6 cap: under k·b+d ≤ n the depth-≤k terms are pairwise similarly ordered and all of order ≤ n. Honest boundary: chain members are NOT yet consecutive in F_n (e.g. 1/2, 1/3 separated in F_5); supplying consecutiveness is exactly where the open 1/12–1/4 optimization lives."
     }
   ],
   "crossReferences": [
@@ -136,6 +148,11 @@
       "targetId": "erdos-1005-oq-03",
       "relationship": "complements",
       "description": "The sibling adjacency entry proves a unimodular pair is F_n-adjacent iff b + d > n, using q ≥ b + d for in-between fractions. This entry sharpens the same bound into an optimality-and-uniqueness statement (the mediant is THE minimal-denominator fraction) and adds the quantitative gap-splitting calculus (sub-gap sizes 1/(b(b+d)), 1/(d(b+d)), ratio d:b, strict refinement)."
+    },
+    {
+      "targetId": "erdos-1005",
+      "relationship": "extends",
+      "description": "§8 connects directly to the parent's similarlyOrdered relation and isSimOrdered/mayerErdosF run definitions (Erdos1005ProblemProvable.lean): the file's SimOrd predicate matches similarlyOrdered verbatim, and the mediant-chain similar-ordering lemmas supply the order-side combinatorics underlying the (1/12−o(1))n lower bound, modulo the open consecutiveness step."
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -5,12 +5,12 @@
   "title": "Mediant Insertion and the Farey Gap Calculus: The Mediant Is the Unique Smallest-Denominator Fraction in a Gap",
   "description": "A self-contained, axiom-free formalization of the exact arithmetic of mediant insertion — the operation that refines the Farey sequence F_n into F_{n+1} by inserting, between adjacent fractions a/b < c/d, their mediant (a+c)/(b+d). Two threads are proved. First, the gap-splitting calculus: a unimodular gap of size 1/(bd) is split by its mediant into a left sub-gap 1/(b(b+d)) and a right sub-gap 1/(d(b+d)); these sum back to 1/(bd), stand in ratio d:b, and each is strictly smaller than the whole. Second, the headline minimal-denominator theorem: any fraction p/q strictly between two unimodular neighbours has denominator q ≥ b+d, and equality forces p/q = (a+c)/(b+d) exactly. Hence the mediant is the unique fraction of smallest denominator inside any Farey gap, and b+d is a hard lower bound on refining it — no construction can introduce a fraction of smaller denominator. The parent entry (Erdős #1005) records the open lower bound f(n) ≥ (1/12−o(1))n on runs of similarly ordered Farey fractions; that constant remains open and is NOT addressed here. This entry formalizes the verified mediant calculus on which such lower-bound constructions are built.",
   "leanFile": {
-    "lineCount": 389,
+    "lineCount": 517,
     "axiomCount": 0,
     "path": "Proofs/Erdos1005ProblemOQ02.lean",
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 24
+    "theoremCount": 31
   },
   "meta": {
     "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot mediant theory)",
@@ -117,6 +117,13 @@
       "startLine": 317,
       "endLine": 388,
       "summary": "Generalises §5 to arbitrary depth and corrects a false heuristic. unimodular_iterate_left/_right: iterating mediant insertion into one sub-gap k times keeps the pair unimodular, a/b < (k·a+c)/(k·b+d). denom_ge_iterate_left/_right: every interior fraction of the k-fold one-sided sub-gap has q ≥ (k+1)·b+d — LINEAR in depth k. iterate_left_denom_linear records the exact denominator (k+1)·b+d. Consequence: a one-sided chain (e.g. 0/1, 1/2, 1/3, …, 1/n) fits Θ(n) refinement levels under the order-n cap, NOT O(log n); exponential φ^k growth and the O(log n) depth bound are special to balanced/alternating chains. Any run-length count toward the 1/12 constant must distinguish these two extremes."
+    },
+    {
+      "id": "balanced-insertion",
+      "title": "§7 Balanced (alternating) insertion — exponential denominator growth",
+      "startLine": 390,
+      "endLine": 517,
+      "summary": "Establishes the OTHER extreme of the §6 dichotomy: the balanced Stern–Brocot path (alternating left/right) grows denominators EXPONENTIALLY, not linearly. fib_cassini proves Cassini's identity F_{n+1}² − F_n·F_{n+2} = (−1)ⁿ over ℤ by one-step induction. unimodular_fib_even reads it at even index to certify the consecutive Fibonacci fractions F_{2k}/F_{2k+1} < F_{2k+1}/F_{2k+2} as genuine unimodular (adjacent Farey) pairs, so the minimal-denominator machinery of §4 applies. fib_two_step_double: 2·F_k ≤ F_{k+2} (two levels at least double the denominator). fib_pow_lower: 2ʲ ≤ F_{2j+1} (exponential lower bound). balanced_mediant_denom: the balanced mediant has denominator F_{2k+1}+F_{2k+2} = F_{2k+3}, the Fibonacci recurrence. denom_ge_balanced specialises denom_ge_of_between to the Fibonacci pair. balanced_depth_log: if F_{2j+1} ≤ n then 2ʲ ≤ n, so only O(log n) balanced levels fit under the order cap — an EXPONENTIAL separation from the Θ(n) one-sided levels of §6. Any run-length count toward the 1/12 constant must distinguish the two descent regimes."
     }
   ],
   "crossReferences": [
@@ -167,6 +174,12 @@
       "type": "headline",
       "description": "Second-smallest interior denominator: every fraction p/q strictly inside a unimodular gap a/b < c/d that is NOT the mediant (a+c)/(b+d) lies in one of the two (again unimodular) sub-gaps, hence has q ≥ (b+d)+min b d. So the mediant is the unique fraction of denominator b+d in the gap, and the next admissible denominator is at least min b d larger — the strict-growth step underlying any depth/counting argument toward the 1/12 run bound.",
       "leanType": "∀ {a b c d p q : ℕ}, 0 < b → 0 < d → 0 < q → Unimodular a b c d → (a:ℚ)/b < (p:ℚ)/q → (p:ℚ)/q < (c:ℚ)/d → (p:ℚ)/q ≠ (↑(a+c):ℚ)/↑(b+d) → (b+d)+min b d ≤ q"
+    },
+    {
+      "name": "balanced_depth_log",
+      "type": "headline",
+      "description": "Quantified depth dichotomy. If the depth-2j balanced bounding fraction F_{2j+1} fits under the order-n cap (F_{2j+1} ≤ n) then 2ʲ ≤ n, i.e. j ≤ log₂ n. Combined with the §6 linear bound (one-sided chains admit Θ(n) levels), this is an EXPONENTIAL separation between the two extreme mediant-descent strategies: balanced chains exhaust the order cap in O(log n) levels, one-sided chains in Θ(n). Cassini's identity (fib_cassini) certifies the balanced bounding pairs as genuine Farey neighbours, so both bounds live in the same unimodular gap calculus.",
+      "leanType": "∀ (j n : ℕ), Nat.fib (2*j+1) ≤ n → 2^j ≤ n"
     }
   ]
 }

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -5,12 +5,12 @@
   "title": "Mediant Insertion and the Farey Gap Calculus: The Mediant Is the Unique Smallest-Denominator Fraction in a Gap",
   "description": "A self-contained, axiom-free formalization of the exact arithmetic of mediant insertion — the operation that refines the Farey sequence F_n into F_{n+1} by inserting, between adjacent fractions a/b < c/d, their mediant (a+c)/(b+d). Two threads are proved. First, the gap-splitting calculus: a unimodular gap of size 1/(bd) is split by its mediant into a left sub-gap 1/(b(b+d)) and a right sub-gap 1/(d(b+d)); these sum back to 1/(bd), stand in ratio d:b, and each is strictly smaller than the whole. Second, the headline minimal-denominator theorem: any fraction p/q strictly between two unimodular neighbours has denominator q ≥ b+d, and equality forces p/q = (a+c)/(b+d) exactly. Hence the mediant is the unique fraction of smallest denominator inside any Farey gap, and b+d is a hard lower bound on refining it — no construction can introduce a fraction of smaller denominator. The parent entry (Erdős #1005) records the open lower bound f(n) ≥ (1/12−o(1))n on runs of similarly ordered Farey fractions; that constant remains open and is NOT addressed here. This entry formalizes the verified mediant calculus on which such lower-bound constructions are built.",
   "leanFile": {
-    "lineCount": 317,
+    "lineCount": 389,
     "axiomCount": 0,
     "path": "Proofs/Erdos1005ProblemOQ02.lean",
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 19
+    "theoremCount": 24
   },
   "meta": {
     "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot mediant theory)",
@@ -29,7 +29,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-25",
-    "lineCount": 256,
+    "lineCount": 389,
     "originalContributions": [
       "denom_ge_of_between: the headline lower bound — if a/b < p/q < c/d and the outer pair is unimodular (bc − ad = 1), then q ≥ b + d. Proved from the identity q = b·(cq − pd) + d·(pb − aq) by reading off pb − aq ≥ 1 and cq − pd ≥ 1 from the strict orders, with no Farey enumeration. The mediant therefore has the smallest denominator of any fraction in the open gap (a/b, c/d)",
       "eq_mediant_of_denom_eq: uniqueness — a strictly-in-gap fraction p/q that attains the minimal denominator q = b + d must be the mediant itself, p = a + c. The two cross-differences pb − aq and cq − pd are each pinned to exactly 1, forcing p·b = (a+c)·b and cancelling b",
@@ -39,10 +39,12 @@
       "mediant_gap_left_lt: strict refinement — each sub-gap 1/(b(b+d)) is strictly smaller than the full gap 1/(bd), so mediant insertion genuinely refines the partition",
       "unimodular_left / unimodular_right: the mediant forms a unimodular pair with each endpoint (b(a+c) − a(b+d) = 1 and (b+d)c − (a+c)d = 1), so the two halves of a split gap are themselves Farey-adjacent and can be split again — the recursive engine of the Stern–Brocot tree",
       "denom_identity: the algebraic kernel over ℤ — q = b·(cq − pd) + d·(pb − aq), an unconditional identity once bc − ad = 1, verified by linear_combination",
-      "mediant_is_min_denominator: a packaged statement — the mediant lies strictly inside the gap and every in-gap fraction has denominator ≥ b + d"
+      "mediant_is_min_denominator: a packaged statement — the mediant lies strictly inside the gap and every in-gap fraction has denominator ≥ b + d",
+      "unimodular_iterate_left / unimodular_iterate_right: iterating one-sided insertion k times stays unimodular — a/b < c/d becomes a/b < (k·a+c)/(k·b+d) (and symmetrically on the right), with no induction needed since b·c = a·d+1 is invariant under c ↦ k·a+c, d ↦ k·b+d",
+      "denom_ge_iterate_left / denom_ge_iterate_right: the depth-k denominator bound — every fraction inside the k-fold one-sided sub-gap has q ≥ (k+1)·b+d (resp. b+(k+1)·d), LINEAR in the depth k. This corrects a tempting false heuristic: the order-n cap does NOT force O(log n) refinement depth; the one-sided chain 0/1, 1/2, 1/3, …, 1/n already fits Θ(n) levels. Exponential φ^k growth (hence O(log n) depth) is special to balanced/alternating chains, the opposite extreme from this linear worst case"
     ],
     "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for the headline theorems (denom_ge_of_between, eq_mediant_of_denom_eq, mediant_is_min_denominator). No native_decide is used (so no Lean.ofReduceBool). This entry does NOT resolve the open Erdős #1005 lower bound f(n) ≥ (1/12 − o(1))n on runs of similarly ordered Farey fractions; that constant remains open.",
-    "theoremCount": 13,
+    "theoremCount": 24,
     "definitionCount": 1
   },
   "overview": {
@@ -58,12 +60,12 @@
     ]
   },
   "conclusion": {
-    "summary": "A self-contained, 0-axiom, 0-sorry formalization (256 lines, 13 theorems, 1 definition) of mediant insertion on Farey gaps. The mediant splits a unimodular gap 1/(bd) into 1/(b(b+d)) and 1/(d(b+d)) — summing back to the whole, in ratio d:b, each strictly smaller — and, as the headline result, is the unique fraction of smallest denominator b + d inside the gap: every strictly-in-between p/q has q ≥ b + d, with equality forcing p/q = (a+c)/(b+d).",
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (389 lines, 24 theorems, 1 definition) of mediant insertion on Farey gaps. The mediant splits a unimodular gap 1/(bd) into 1/(b(b+d)) and 1/(d(b+d)) — summing back to the whole, in ratio d:b, each strictly smaller — and, as the headline result, is the unique fraction of smallest denominator b + d inside the gap: every strictly-in-between p/q has q ≥ b + d, with equality forcing p/q = (a+c)/(b+d). A final section iterates one-sided insertion to arbitrary depth (unimodular_iterate_left/right, denom_ge_iterate_left/right), proving the depth-k interior denominator bound is LINEAR, (k+1)·b+d, which corrects a tempting false heuristic: the order-n cap admits Θ(n) one-sided refinement levels (e.g. 0/1, 1/2, …, 1/n), not O(log n) — exponential growth is special to balanced chains.",
     "implications": "The minimal-denominator theorem (denom_ge_of_between together with eq_mediant_of_denom_eq) is the exact optimality statement behind Stern–Brocot/continued-fraction best approximation: the same q ≥ b + d bound governs convergent denominators and the 'no better approximation with smaller denominator' property. The gap-splitting identities are reusable infrastructure for any quantitative Farey argument, including the constructions that establish the known lower bound on runs in Erdős #1005.",
     "openQuestions": [
       "Erdős #1005 itself: can iterated mediant insertion plus a counting argument recover, or improve, the known lower bound (1/12 − o(1))n on the longest run of similarly ordered Farey fractions? The constant in [1/12, 1/4] is open and is not addressed by this entry.",
       "Best-approximation corollary: formalize that two consecutive continued-fraction convergents form a unimodular pair, so the minimal-denominator theorem yields the classical statement that no fraction with smaller denominator approximates better — connecting this entry to Diophantine approximation.",
-      "Quantitative refinement depth: bound how many mediant insertions are needed to drive every gap of F_n below a target size, using the strict-refinement and ratio identities proved here."
+      "Refinement depth, balanced case: §6 settles the one-sided extreme (linear denominator growth, Θ(n) admissible levels). The complementary balanced/alternating extreme — where denominators follow the Fibonacci recurrence and grow like φ^k, giving O(log n) depth — remains to be formalized (track the alternating mediant chain against Nat.fib). The gap between these two extremes is exactly what a sharp run-length count toward the 1/12 constant must navigate."
     ]
   },
   "sections": [
@@ -108,6 +110,13 @@
       "startLine": 255,
       "endLine": 316,
       "summary": "mediant_denom_gt_left/_right (b < b+d, d < b+d); interior_denom_gt_max (every in-gap fraction has q > max b d, so refinement strictly raises the smallest denominator); denom_ge_left_subgap/denom_ge_right_subgap (the two sub-gaps are themselves unimodular, giving depth-two bounds q ≥ 2b+d and q ≥ b+2d); denom_ge_of_between_ne_mediant (every in-gap fraction other than the mediant has q ≥ (b+d)+min b d — the mediant is the unique denominator-(b+d) point, and the next admissible denominator jumps by at least min b d)."
+    },
+    {
+      "id": "iterated-insertion",
+      "title": "§6 Iterated one-sided insertion — exact linear denominator growth",
+      "startLine": 317,
+      "endLine": 388,
+      "summary": "Generalises §5 to arbitrary depth and corrects a false heuristic. unimodular_iterate_left/_right: iterating mediant insertion into one sub-gap k times keeps the pair unimodular, a/b < (k·a+c)/(k·b+d). denom_ge_iterate_left/_right: every interior fraction of the k-fold one-sided sub-gap has q ≥ (k+1)·b+d — LINEAR in depth k. iterate_left_denom_linear records the exact denominator (k+1)·b+d. Consequence: a one-sided chain (e.g. 0/1, 1/2, 1/3, …, 1/n) fits Θ(n) refinement levels under the order-n cap, NOT O(log n); exponential φ^k growth and the O(log n) depth bound are special to balanced/alternating chains. Any run-length count toward the 1/12 constant must distinguish these two extremes."
     }
   ],
   "crossReferences": [

--- a/src/data/research/problems/erdos-1005-oq-02.json
+++ b/src/data/research/problems/erdos-1005-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1005-oq-02",
   "title": "Improve lower bound 1/12 for Farey fraction gap using mediant insertion",
-  "phase": "NEW",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-03-30T21:46:38.105Z",
-    "iteration": 1,
+    "iteration": 5,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,11 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: §6 added (verified, 0-axiom) — iterated one-sided insertion + linear depth-k denominator bound; corrected a false O(log n)-depth heuristic. Open 1/12 constant untouched.",
+    "builtItems": [
+      "unimodular_iterate_left/right (Erdos1005ProblemOQ02.lean §6): k-fold one-sided mediant insertion stays unimodular, a/b<(k·a+c)/(k·b+d); proved by scale-invariance of bc=ad+1 (no induction)",
+      "denom_ge_iterate_left/right (Erdos1005ProblemOQ02.lean §6): depth-k interior denominator bound q ≥ (k+1)·b+d, LINEAR in depth",
+      "iterate_left_denom_linear (§6): exact one-sided mediant denominator (k+1)·b+d"
+    ],
+    "insights": [
+      "CORRECTION: the roadmap heuristic that the order-n cap forces O(log n) refinement depth is FALSE for arbitrary mediant chains. The one-sided chain 0/1,1/2,1/3,…,1/n fits Θ(n) levels under q≤n with only LINEAR denominator growth (k+1)·b+d.",
+      "Exponential φ^k denominator growth (and hence O(log n) depth) is special to BALANCED/alternating chains; one-sided chains are the linear worst case. A sharp run-length count toward the 1/12 constant must distinguish the two extremes.",
+      "Literature pin (van Doorn 2025, arXiv:2509.00121): f(n) ≥ (1/12−o(1))n and f(n) ≤ n/4+5; constant c∈[1/12,1/4] open."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Formalize the balanced/alternating extreme: track the alternating mediant chain denominators against Nat.fib, proving φ^k growth ⇒ O(log_φ n) depth for balanced descent (the complement of §6 linear bound).",
+      "Bridge depth bounds to a run-length statement: relate monotone Stern–Brocot paths under the order-n cap to runs of similarly ordered fractions."
+    ]
   },
   "tags": [
     "seeker-selected",
@@ -55,7 +66,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T21:46:38.105Z",
-  "lastUpdate": "2026-03-30T21:46:38.105Z",
+  "lastUpdate": "2026-06-27",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -73,8 +84,8 @@
     {
       "path": "Proofs/Erdos1005ProblemOQ02.lean",
       "filename": "Erdos1005ProblemOQ02.lean",
-      "lineCount": 318,
-      "theoremCount": 19,
+      "lineCount": 389,
+      "theoremCount": 24,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
Extends the verified mediant / Farey-gap calculus in `Erdos1005ProblemOQ02.lean` (Erdős #1005 OQ-02) with three new sections, all 0-sorry / 0-axiom (verified via `lake env lean` against the main-repo Mathlib `.olean` cache; Docker image build is down — containerd `meta.db` I/O error).

## §6 — Iterated one-sided insertion (linear growth)
`unimodular_iterate_left/_right`, `denom_ge_iterate_left/_right`, `iterate_left_denom_linear`: the depth-`k` one-sided mediant chain stays unimodular and its interior denominator bound is **linear**, `(k+1)·b+d`. Corrects a tempting false heuristic — the order-`n` cap admits **Θ(n)** one-sided refinement levels (e.g. `0/1, 1/2, …, 1/n`), not `O(log n)`.

## §7 — Balanced (alternating) insertion (exponential growth)
`fib_cassini` (Cassini's identity over ℤ), `unimodular_fib_even` (consecutive Fibonacci fractions are genuine Farey neighbours), `fib_two_step_double`, `fib_pow_lower`, `balanced_mediant_denom`, `denom_ge_balanced`, `balanced_depth_log`: the balanced Stern–Brocot path follows the Fibonacci recurrence, so denominators grow **exponentially** and only **O(log n)** balanced levels fit the cap. An exponential separation from §6 — any sharp run-length count must distinguish the two regimes.

## §8 — Mediant chains are similarly ordered (the bridge to f(n))
The first link in the file between the *metric* calculus (§1–7) and the *ordering* relation that defines `f(n)`:
- `SimOrd` matches `similarlyOrdered` of `Erdos1005ProblemProvable.lean`; `simOrd_iff_prod` proves `SimOrd ↔ (a−c)(b−d) ≥ 0` (with `simOrd_symm`, `simOrd_refl`).
- `simOrd_mediant_left/_right`: the mediant is similarly ordered with **both** parents — insertion never breaks similar ordering.
- `simOrd_iterate_left_chain/_right_chain` (headline): the **entire** one-sided §6 chain is **pairwise** similarly ordered, so the Θ(n)-long chain is a similarly ordered family — the order-side engine of the linear lower bound on `f(n)`.
- `simOrd_chain_admissible`: packages the above with the §6 order cap.

**Honest boundary.** §8 does **not** prove `f(n) ≳ n`: the chain members are not *consecutive* in `F_n` (e.g. `1/2, 1/3` separated in `F_5`). Supplying consecutiveness is exactly the open `1/12`–`1/4` step (van Doorn 2025, arXiv:2509.00121). No section resolves the open leading constant.

Totals now: 638 lines, 39 theorems, 2 defs, 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)