### PR TITLE
Enrich Total/Mean Number of Parts of a Composition (composition-parts-choose-oq-01-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/composition-parts-choose-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-01/annotations.json
@@ -3,13 +3,14 @@
     "id": "ann-gap-bridge",
     "proofId": "composition-parts-choose-oq-01-oq-01",
     "range": {
-      "startLine": 61,
+      "startLine": 75,
       "endLine": 138
     },
     "type": "theorem",
     "title": "The Gap Bijection and the Part-Count Bridge (gapsEquiv, boundaries_eq, length_eq_card_gaps)",
     "content": "gapsEquiv n composes Mathlib's compositionEquiv : Composition n ≃ CompositionAsSet n with compositionAsSetEquiv : CompositionAsSet n ≃ Finset (Fin (n−1)), identifying a composition with the subset of the n−1 internal gaps it cuts. The part-count bridge is built up from the boundary set: boundaries_eq exhibits d.boundaries (a Finset of Fin (n+1)) as insert 0 (insert (Fin.last n) (gap-subset.map shiftEmb)), where shiftEmb : Fin (n−1) ↪ Fin (n+1) is the shift i ↦ i+1 onto the internal points {1, …, n−1}. boundaries_card counts this as gap-subset.card + 2, since the two endpoints 0 and n are distinct (n ≥ 1) and neither is a shift of a gap; casLength_bridge then divides by the definition length = boundaries.card − 1 to get the CompositionAsSet form, and length_eq_card_gaps transports it to Composition n via Composition.toCompositionAsSet_length, giving the headline bridge length c = (gaps of c).card + 1. A composition with k parts cuts exactly k−1 of the n−1 gaps.",
     "mathContext": "$c.\\mathrm{length} = \\#(\\mathrm{gapsEquiv}\\ n\\ c) + 1$.",
+    "significance": "key",
     "prerequisites": [
       "Compositions and the boundary-set model CompositionAsSet n with length = boundaries.card − 1",
       "The bijections compositionEquiv and compositionAsSetEquiv : CompositionAsSet n ≃ Finset (Fin (n−1))",
@@ -26,13 +27,14 @@
     "id": "ann-binomial-sums",
     "proofId": "composition-parts-choose-oq-01-oq-01",
     "range": {
-      "startLine": 137,
+      "startLine": 141,
       "endLine": 164
     },
     "type": "theorem",
     "title": "Two Binomial Sums (sum_choose_mul, sum_finset_card)",
     "content": "sum_choose_mul proves the absorption identity ∑_{k=0}^{m} k·C(m,k) = m·2^(m−1): the k = 0 term vanishes, and the absorption rule (k+1)·C(m,k+1) = m·C(m,k) (Nat.add_one_mul_choose_eq) rewrites each remaining term to m·C(m−1,k), whose sum is m·2^(m−1) by Nat.sum_range_choose. sum_finset_card turns this into the geometric statement that the subsets of an m-element type have total size m·2^(m−1): Finset.powerset_univ identifies the universal Finset of subsets with univ.powerset, and Finset.sum_powerset_apply_card reduces ∑_{s ⊆ Fin m} s.card to ∑_k C(m,k)·k. This is the 'every element lies in exactly half the subsets' count, the engine of the mean computation.",
     "mathContext": "$\\sum_{k} k\\binom{m}{k} = m\\,2^{m-1} = \\sum_{s \\subseteq \\mathrm{Fin}\\,m} \\#s$.",
+    "significance": "supporting",
     "prerequisites": [
       "The absorption rule Nat.add_one_mul_choose_eq",
       "The binomial sum ∑_{j} C(m, j) = 2^m (Nat.sum_range_choose)",
@@ -49,13 +51,14 @@
     "id": "ann-first-moment",
     "proofId": "composition-parts-choose-oq-01-oq-01",
     "range": {
-      "startLine": 162,
+      "startLine": 166,
       "endLine": 201
     },
     "type": "theorem",
     "title": "The Total and Mean Number of Parts (total_parts, two_mul_total_parts, mean_parts)",
     "content": "total_parts is the headline: for n ≥ 2 the total number of parts over all compositions is (n+1)·2^(n−2). The proof rewrites ∑_{c} c.length via the bridge as ∑_{c} ((gapsEquiv n c).card + 1), splits with Finset.sum_add_distrib into (∑_c (gapsEquiv n c).card) + card(Composition n), reindexes the first summand to ∑_{s : Finset (Fin (n−1))} s.card by Equiv.sum_comp, and evaluates with sum_finset_card ((n−1)·2^(n−2)) and composition_card (2^(n−1)); substituting n = M + 2 closes (n−1)·2^(n−2) + 2^(n−1) = (n+1)·2^(n−2) by ring. The two summands are 'one extra part per cut' and 'one base part per composition'. two_mul_total_parts repackages this as the mean (n+1)/2 multiplicatively (2·total = (n+1)·card), and mean_parts as the rational average (∑_c length)/card = (n+1)/2 — the midpoint of the range [1, n] of possible part-counts, reflecting the symmetry C(n−1,k−1) = C(n−1,n−k) of the distribution.",
     "mathContext": "$\\sum_{c} c.\\mathrm{length} = (n+1)\\,2^{n-2}$, mean $= \\tfrac{n+1}{2}$ for $n \\ge 2$.",
+    "significance": "key",
     "prerequisites": [
       "The part-count bridge length_eq_card_gaps and the subset-sum sum_finset_card",
       "Finset.sum_add_distrib and Equiv.sum_comp for reindexing along the gap bijection",
@@ -72,13 +75,14 @@
     "id": "ann-worked-totals",
     "proofId": "composition-parts-choose-oq-01-oq-01",
     "range": {
-      "startLine": 201,
+      "startLine": 203,
       "endLine": 205
     },
     "type": "example",
     "title": "Worked Totals: n = 2, 3, 4 Give 3, 8, 20",
     "content": "The examples specialise total_parts. The compositions of 2 are 2 (one part) and 1+1 (two parts), total 1 + 2 = 3 = 3·2^0. The compositions of 3 are 3, 1+2, 2+1, 1+1+1 with 1+2+2+3 = 8 = 4·2^1 parts. The compositions of 4 total 20 = 5·2^2 parts. Each matches (n+1)·2^(n−2); the residual closed Nat arithmetic is discharged by the kernel's decide, introducing no Lean.ofReduceBool.",
     "mathContext": "$(n+1)\\,2^{n-2} = 3, 8, 20$ for $n = 2, 3, 4$.",
+    "significance": "context",
     "prerequisites": [
       "The headline total_parts",
       "Kernel decision procedure decide on closed Nat arithmetic"


### PR DESCRIPTION
## Enrichment pass (pass 0)

Axiom-free entry (`verified` / `original` / axiomCount 0; meta 15.2 KB, under cap). These 4 annotations already had `relatedConcepts`/`prerequisites` but were missing `significance`.

### Changes
- Added the missing `significance` field to all 4 annotations (key: gap-bijection bridge and first-moment headline; supporting: binomial sums; context: worked examples).
- Aligned 4 annotation startLines to their Lean constructs (theorem/example lines) — clears build warnings.

### Verification
- JSON valid; `annotations/build.ts`: zero warnings for this target.
- Axiom integrity unchanged: `verified` / `original` / axiomCount 0.