### PR TITLE
Enrich: σ Values from Mathlib, Axiom-Free (Erdős #823) — add index.ts

### DIFF
--- a/src/data/proofs/erdos-823-oq-05/index.ts
+++ b/src/data/proofs/erdos-823-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos823SigmaValues.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos823Oq05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos823Oq05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos823Oq05Data: ProofData = {
+  proof: erdos823Oq05Proof,
+  annotations: erdos823Oq05Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-823-oq-05` (priority 64 — highest in the queue).

## Critical fix
- **Created missing `index.ts`** — without it Vite's `import.meta.glob` could not discover the proof, so the page showed *'proof not found'* on the live site. Built from the standard template (Lean source `Erdos823SigmaValues.lean`, namespace `Erdos823SigmaValues`).

## Assessment
The `meta.json` and `annotations.json` are already comprehensive and schema-complete: the `overview` carries `historicalContext`, `problemStatement`, `proofStrategy`, and 5 `keyInsights`; there are 5 rich annotations with `mathContext`/`significance`/`relatedConcepts`; `sections`, `conclusion`, `references`, and `crossReferences` are all present and accurate. Per the enrichment size guardrails, an entry that already meets the quality targets should not be further deepened — so the missing `index.ts` was the one real defect (it was blocking the page from loading entirely).

## Verification
- `pnpm build` passes (✓ built in ~20s).
- Cross-checked against the 132-line Lean source: 12 theorems (`sigma_one_prime`, `sigma_6/14/15/28/957/958`, `sigma_pair_14_15`, `sigma_pair_957_958`, `six_perfect`, `twentyeight_perfect`, `fiber_24`), the 0-axiom claim (kernel `decide`/`norm_num` only, no `native_decide`), and the documented false-parent-claim note (σ206=312 ≠ σ210=576) all accurate.
- index.ts only; no JSON content changed.