### PR TITLE
Enrich The Derived-Length Gap: A₄ vs A₅ (abel-ruffini-oq-04-oq-02-oq-02-oq-06)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-06/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-06/annotations.json
@@ -93,5 +93,29 @@
       "solvable and perfect groups",
       "alternating groups Aₙ"
     ]
+  },
+  {
+    "id": "ann-verification-method",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-06",
+    "range": { "startLine": 203, "endLine": 230 },
+    "type": "technique",
+    "title": "Verification: One Logical Bridge, Genuine 0-Axiom Status",
+    "content": "All three parts of the proof turn on a single Mathlib lemma, `commutatorElement_eq_one_iff_commute` ($\\lbrack a, b\\rbrack = 1 \\iff \\text{Commute } a\\, b$), used in two opposite directions. To prove a derived subgroup is **non-trivial** ($A_4$ lower bound), it converts a known non-commuting pair into a non-identity commutator; to prove one is **trivial** ($A_3$ abelian, and inside the parent's $V_4$ computation), it converts universal commutativity into $\\lbrack G, G\\rbrack = \\bot$. The $A_5$ side adds the contrapositive of `isSolvable_of_comm` (all-commute $\\Rightarrow$ solvable) to manufacture non-commuting elements from non-solvability.\n\nEvery finite check — `a4_non_abelian`, the $A_3$ all-commute fact, and the parent's order-dividing-2 computation identifying $V_4$ — uses **kernel `decide`**, not `native_decide`. This matters for axiom integrity: `native_decide` would inject `Lean.ofReduceBool` and forfeit the 0-axiom claim. Because the heaviest decidable instance ranges over the 12-element group $A_4$ (not the 60-element $A_5$), kernel reduction stays tractable. `#print axioms` on the headline theorems reports only `propext`, `Classical.choice`, `Quot.sound` — the standard foundational triple, with no `sorryAx` and no `Lean.ofReduceBool`.",
+    "mathContext": "Kernel `decide` reduces a `Decidable` instance to `isTrue`/`isFalse` inside Lean's trusted kernel, so the resulting proof term carries no extra axiom. `native_decide` instead compiles the instance to native code and trusts its output via `Lean.ofReduceBool`, which counts as an assumption. For a 12-element group the kernel computation of `∀ a b : A₄, a * b = b * a → False`-style predicates is feasible; pushing the same approach to $A_5$ ($|A_5| = 60$, $3600$ pairs) is where one would be tempted to reach for `native_decide` — avoided here by using the simplicity/perfection argument instead of brute force.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "commutatorElement_eq_one_iff_commute",
+      "isSolvable_of_comm",
+      "kernel decide vs native_decide",
+      "Lean.ofReduceBool",
+      "axiom integrity",
+      "decidable instances on finite groups"
+    ],
+    "prerequisites": [
+      "decidability and the decide tactic",
+      "Lean kernel reduction",
+      "commutator subgroups",
+      "axiom tracking with #print axioms"
+    ]
   }
 ]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-06/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniOq04Oq02Oq02Oq06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniOq04Oq02Oq02Oq06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOq04Oq02Oq02Oq06Data: ProofData = {
+  proof: abelRuffiniOq04Oq02Oq02Oq06Proof,
+  annotations: abelRuffiniOq04Oq02Oq02Oq06Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-02-oq-06` (quality 73, pass 0).

## Changes
- **Created missing `index.ts`** — the proof page previously showed "proof not found" on the live site because Vite's `import.meta.glob` could not discover the entry. Uses the verbatim sibling pattern with camelCase `abelRuffiniOq04Oq02Oq02Oq06`.
- **Added a 5th annotation** (`ann-verification-method`, lines 203–230, previously uncovered) on the single `commutatorElement_eq_one_iff_commute` bridge used in both directions across all three parts, and the genuine 0-axiom (kernel `decide`, no `native_decide`/`Lean.ofReduceBool`) verification story.

## Notes
- meta.json already rich and well under the 60 KB cap (17 KB) — left its curated content intact, no inflation.
- All 4 cross-reference targets verified to exist.
- JSON validated; gallery data-generation stage links the entry (57 lean files, 45 related proofs). The `tsc` stage of `pnpm build` cannot run in this worktree (no `node_modules`), an environmental limitation; `index.ts` is a verbatim copy of a building sibling's pattern.