### PR TITLE
research(collatz-structured-oq-02-oq-03): general parity-vector residue-drop engine (Terras leading-coefficient law) [VERIFIED, axiom-free]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -1104,4 +1104,201 @@ axiom tao_2019 :
     ∀ f : ℕ → ℝ, Tendsto f atTop atTop →
       HasLogDensityOne {n : ℕ | 0 < n ∧ (colMin n : ℝ) < f n}
 
+/-! ## Part V: The Terras leading-coefficient law — a general residue-drop engine
+
+Every per-residue trajectory chase of Part II instantiates one structural law.  A
+*parity vector* `v : List Bool` records the parity forced at each step of a
+residue-determined window (`true` = odd, `false` = even).  Reading the orbit of the
+affine class `c·m + d` along `v` keeps it affine: an odd step sends
+`(c, d) ↦ (3c, 3d+1)` and an even step sends `(c, d) ↦ (c/2, d/2)` (`affStep` /
+`affOrbit`).  Three facts assemble these into an engine:
+
+* `affOrbit_realize` discharges the orbit identity `collatz^[k] (c·m+d) = c_k·m + d_k`
+  from a step-by-step parity *certificate* `AffValid` — so a new residue family needs
+  only that certificate, no bespoke `iterate_succ_apply'` bookkeeping;
+* `affOrbit_fst` shows the leading coefficient evolves independently of `d`, equal to
+  the pure `leadCoeff` fold;
+* `leadCoeff_two_pow` is the **Terras `3^a/2^b` law**: from a power-of-two modulus
+  `M = 2^b` whose `b` halvings are spread through `v`, the window ends at exactly
+  `3^a` where `a = #odd steps`.  The drop criterion `c < M` is then literally
+  `3^a < 2^b`.
+
+`parityVector_attainsBelow` packages all three with `affine_residue_attainsBelow`:
+a residue class drops below itself as soon as one exhibits a valid parity-vector
+certificate with `c_k < M` and `d_k < r`.  Everything here is axiom-free. -/
+
+/-- The leading-coefficient fold of a parity vector: an odd step triples the leading
+coefficient, an even step halves it.  This is the `c`-component of the affine orbit
+(`affOrbit_fst`), tracked on its own. -/
+def leadCoeff : List Bool → ℕ → ℕ
+  | [],          c => c
+  | true  :: v,  c => leadCoeff v (3 * c)
+  | false :: v,  c => leadCoeff v (c / 2)
+
+/-- **Terras leading-coefficient law (general multiplicative form).**  Folding the
+leading coefficient along `v` from a value `3^p · 2^q` carrying enough powers of two
+to absorb every halving (`#even steps ≤ q`) yields `3^(p + #odd) · 2^(q - #even)`. -/
+theorem leadCoeff_mul (v : List Bool) :
+    ∀ p q : ℕ, v.count false ≤ q →
+      leadCoeff v (3 ^ p * 2 ^ q)
+        = 3 ^ (p + v.count true) * 2 ^ (q - v.count false) := by
+  induction v with
+  | nil => intro p q _; simp [leadCoeff]
+  | cons b v ih =>
+    intro p q hq
+    cases b with
+    | true =>
+      have cf : (true :: v).count false = v.count false := by simp
+      have ct : (true :: v).count true = v.count true + 1 := by simp
+      rw [cf] at hq
+      show leadCoeff v (3 * (3 ^ p * 2 ^ q))
+          = 3 ^ (p + (true :: v).count true) * 2 ^ (q - (true :: v).count false)
+      rw [show 3 * (3 ^ p * 2 ^ q) = 3 ^ (p + 1) * 2 ^ q from by rw [pow_succ]; ring,
+          ih (p + 1) q hq, cf, ct,
+          show p + 1 + v.count true = p + (v.count true + 1) from by omega]
+    | false =>
+      have cf : (false :: v).count false = v.count false + 1 := by simp
+      have ct : (false :: v).count true = v.count true := by simp
+      rw [cf] at hq
+      have h2 : 3 ^ p * 2 ^ q / 2 = 3 ^ p * 2 ^ (q - 1) := by
+        have e : 2 ^ q = 2 ^ (q - 1) * 2 := by
+          conv_lhs => rw [show q = (q - 1) + 1 from by omega]
+          rw [pow_succ]
+        rw [e, ← mul_assoc, Nat.mul_div_cancel _ (by norm_num : 0 < 2)]
+      show leadCoeff v (3 ^ p * 2 ^ q / 2)
+          = 3 ^ (p + (false :: v).count true) * 2 ^ (q - (false :: v).count false)
+      rw [h2, ih p (q - 1) (by omega), cf, ct,
+          show q - 1 - v.count false = q - (v.count false + 1) from by omega]
+
+/-- The Terras law specialised to the residue-determined case `M = 2^b`: a parity
+vector whose `b` halvings exactly match the modulus exponent ends with leading
+coefficient `3^a`, `a = #odd steps`.  (Take `p = 0`, `q = #even steps` in
+`leadCoeff_mul`.) -/
+theorem leadCoeff_two_pow (v : List Bool) :
+    leadCoeff v (2 ^ v.count false) = 3 ^ v.count true := by
+  have := leadCoeff_mul v 0 (v.count false) (le_refl _)
+  simpa using this
+
+/-- The drop criterion `c < M` for a power-of-two modulus is exactly the classical
+`3^a < 2^b`: enough halvings to overcome the triplings. -/
+theorem leadCoeff_two_pow_lt_iff (v : List Bool) :
+    leadCoeff v (2 ^ v.count false) < 2 ^ v.count false
+      ↔ 3 ^ v.count true < 2 ^ v.count false := by
+  rw [leadCoeff_two_pow]
+
+/-- One affine step on the full coefficient pair `(c, d)`, driven by a parity bit. -/
+def affStep : Bool → ℕ × ℕ → ℕ × ℕ
+  | true,  p => (3 * p.1, 3 * p.2 + 1)
+  | false, p => (p.1 / 2, p.2 / 2)
+
+/-- Fold the affine coefficient pair `(c, d)` along a parity vector. -/
+def affOrbit : List Bool → ℕ × ℕ → ℕ × ℕ
+  | [],     p => p
+  | b :: v, p => affOrbit v (affStep b p)
+
+/-- The leading coefficient of the affine orbit is exactly `leadCoeff` — it evolves
+independently of the constant `d`. -/
+theorem affOrbit_fst (v : List Bool) :
+    ∀ c d : ℕ, (affOrbit v (c, d)).1 = leadCoeff v c := by
+  induction v with
+  | nil => intro c d; rfl
+  | cons b v ih =>
+    intro c d
+    cases b with
+    | true => exact ih (3 * c) (3 * d + 1)
+    | false => exact ih (c / 2) (d / 2)
+
+/-- A parity vector is *valid* for the affine class `c·m + d` when each recorded
+parity actually matches the value's parity along the whole orbit: at an odd step the
+leading coefficient is even and the constant is odd (so `c·m+d` is odd for every `m`),
+at an even step both are even.  This is the certificate that makes the trajectory
+residue-determined — independent of `m`. -/
+inductive AffValid : List Bool → ℕ → ℕ → Prop
+  | nil  {c d} : AffValid [] c d
+  | odd  {v c d} : c % 2 = 0 → d % 2 = 1 → AffValid v (3 * c) (3 * d + 1) →
+      AffValid (true :: v) c d
+  | even {v c d} : c % 2 = 0 → d % 2 = 0 → AffValid v (c / 2) (d / 2) →
+      AffValid (false :: v) c d
+
+/-- **General orbit-realization (the residue-drop engine).**  If the parity vector `v`
+is valid for the affine class `c·m + d`, then the `v.length`-step Collatz iterate of
+every member of that class is the affine value read off `affOrbit`:
+`collatz^[k] (c·m + d) = c_k·m + d_k`.  This replaces the per-residue trajectory chase
+with one structural induction on the certificate. -/
+theorem affOrbit_realize : ∀ {v : List Bool} {c d : ℕ}, AffValid v c d →
+    ∀ m : ℕ, collatz^[v.length] (c * m + d)
+      = (affOrbit v (c, d)).1 * m + (affOrbit v (c, d)).2 := by
+  intro v c d hv
+  induction hv with
+  | nil => intro m; rfl
+  | @odd v c d hc hd _ ih =>
+    obtain ⟨c', rfl⟩ : ∃ c', c = 2 * c' := ⟨c / 2, by omega⟩
+    intro m
+    have hcm : 2 * c' * m = 2 * (c' * m) := by ring
+    have hodd : (2 * c' * m + d) % 2 = 1 := by omega
+    have hstep : collatz (2 * c' * m + d) = (3 * (2 * c')) * m + (3 * d + 1) := by
+      rw [collatz_odd hodd]; ring
+    show collatz^[v.length + 1] (2 * c' * m + d) = _
+    rw [Function.iterate_succ_apply, hstep]
+    exact ih m
+  | @even v c d hc hd _ ih =>
+    obtain ⟨c', rfl⟩ : ∃ c', c = 2 * c' := ⟨c / 2, by omega⟩
+    obtain ⟨d', rfl⟩ : ∃ d', d = 2 * d' := ⟨d / 2, by omega⟩
+    intro m
+    have hcm : 2 * c' * m = 2 * (c' * m) := by ring
+    have hstep : collatz (2 * c' * m + 2 * d') = c' * m + d' := by
+      have he : (2 * c' * m + 2 * d') % 2 = 0 := by omega
+      rw [collatz_even he]; omega
+    show collatz^[v.length + 1] (2 * c' * m + 2 * d') = _
+    rw [Function.iterate_succ_apply, hstep]
+    have e1 : (2 * c') / 2 = c' := by omega
+    have e2 : (2 * d') / 2 = d' := by omega
+    have key := ih m
+    rw [e1, e2] at key
+    show collatz^[v.length] (c' * m + d')
+        = (affOrbit v ((2 * c') / 2, (2 * d') / 2)).1 * m
+          + (affOrbit v ((2 * c') / 2, (2 * d') / 2)).2
+    rw [e1, e2]
+    exact key
+
+/-- **Parity-vector residue-drop engine.**  If some residue class `n ≡ r (mod M)`
+admits a non-empty valid parity vector `v` whose realized affine iterate `(c_k, d_k)`
+has leading coefficient `c_k < M` and constant `d_k < r`, then every member of the
+class drops below itself.  This makes a new residue family a pure certificate check:
+supply `v` and discharge the (decidable) side conditions. -/
+theorem parityVector_attainsBelow {M r : ℕ} (v : List Bool)
+    (hk : 0 < v.length) (hval : AffValid v M r)
+    (hc : (affOrbit v (M, r)).1 < M) (hd : (affOrbit v (M, r)).2 < r)
+    {n : ℕ} (hn : n % M = r) : AttainsBelow n :=
+  affine_residue_attainsBelow hk hc hd (fun m => affOrbit_realize hval m) hn
+
+/-! ### Validation: the engine reproduces the gallery families
+
+The abstract law recovers the concrete leading coefficients of Part II, and the engine
+re-derives a residue drop end-to-end from a parity certificate alone. -/
+
+/-- The Terras law reproduces the `n ≡ 3 (mod 16)` leading coefficient `9 = 3^2` from
+its parity vector `[odd, even, odd, even, even, even]` (two `3n+1` steps, four
+halvings). -/
+example : leadCoeff [true, false, true, false, false, false] (2 ^ 4) = 9 := by decide
+
+/-- The Terras law reproduces the `n ≡ 11 (mod 32)` leading coefficient `27 = 3^3`
+(three `3n+1` steps, five halvings). -/
+example :
+    leadCoeff [true, false, true, false, false, true, false, false] (2 ^ 5) = 27 := by
+  decide
+
+/-- End-to-end engine demonstration: re-derive the `n ≡ 3 (mod 16)` drop using only the
+parity certificate `[odd, even, odd, even, even, even]` — no manual trajectory chase.
+The certificate's side conditions and the final `9 < 16`, `2 < 3` are all decidable. -/
+example {n : ℕ} (h : n % 16 = 3) : AttainsBelow n := by
+  refine parityVector_attainsBelow [true, false, true, false, false, false]
+    (by decide) ?_ (by decide) (by decide) h
+  exact AffValid.odd (by decide) (by decide)
+    (AffValid.even (by decide) (by decide)
+      (AffValid.odd (by decide) (by decide)
+        (AffValid.even (by decide) (by decide)
+          (AffValid.even (by decide) (by decide)
+            (AffValid.even (by decide) (by decide) AffValid.nil)))))
+
 end CollatzStructuredOQ02OQ03

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -133,12 +133,12 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1107,
+    "lineCount": 1304,
     "axiomCount": 1,
-    "theoremCount": 42,
+    "theoremCount": 48,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
-    "definitionCount": 5
+    "definitionCount": 8
   },
   "sorries": 0,
   "highlights": [

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "OBSERVE",
     "since": "2026-03-30T11:35:21-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Added Part V general parity-vector residue-drop engine (Terras leading-coefficient law). Verified axiom-free via direct host lean (Docker corrupt).",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Mechanize certificate generation (tactic) so parityVector_attainsBelow auto-discharges any residue-determined class.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (structural, not enumeration): added affine_residue_attainsBelow, a GENERAL residue-determined-drop lemma abstracting the per-residue trajectory-chase method — from the affine-iterate identity collatz^[k](M*m+r)=c*m+d with c<M, d<r it concludes AttainsBelow for the whole class n≡r (mod M). The clean drop criterion c<M is shown to be exactly 3^a<2^b (a=#triplings, b=#halvings over the forced window), making the classical Collatz 3/2-vs-1/2 heuristic precise per residue class. Refactored the three clean families (mod16/3, mod32/11, mod32/23) through it (dedup; affine structure now explicit in each call site, e.g. c=27=3^3<32); mod4/1 left as the sharp d=r boundary case. Build offline EXIT 0, no warnings; new+refactored theorems axiom-free (#print axioms = propext/[Choice]/Quot only, no tao_2019). Density floor unchanged at 7/8; 1 axiom (tao_2019) unchanged. 30 thm / 3 def / 1 axiom.",
+    "progressSummary": "PROGRESS (general engine, the stated #1 next step): added Part V — a parity-vector residue-drop engine that turns the per-residue trajectory chases into pure certificate checks. (1) leadCoeff fold + leadCoeff_mul: the Terras leading-coefficient law in unconditional multiplicative form leadCoeff v (3^p*2^q) = 3^(p+#odd)*2^(q-#even) for #even<=q; specialized by leadCoeff_two_pow to the residue case M=2^b: leadCoeff v (2^b) = 3^a (a=#odd steps), with leadCoeff_two_pow_lt_iff making the drop criterion c<M literally 3^a<2^b. (2) affStep/affOrbit + inductive AffValid certificate + affOrbit_realize: one structural induction proves collatz^[k](c*m+d)=c_k*m+d_k from a step-by-step parity certificate, replacing the hand-written iterate_succ_apply' chains; affOrbit_fst shows the leading coeff is exactly leadCoeff (independent of d). (3) parityVector_attainsBelow packages it with affine_residue_attainsBelow: a new residue family is now just a certificate + decidable side conditions (demonstrated: mod16/3 re-derived end-to-end from [odd,even,odd,even,even,even], plus leadCoeff validation examples reproducing 9 and 27). VERIFIED axiom-free (#print axioms = propext/[Classical.choice]/Quot.sound, NO tao_2019, NO ofReduceBool). Docker containerd corrupt → verified via direct host lean v4.26.0 (lake env lean, allowed by safety wrapper) against prebuilt Mathlib oleans. 48 thm / 8 def / 1 inductive / 1 axiom (tao_2019 unchanged). Density floor unchanged at 115/128.",
     "builtItems": [
       "collatz_odd helper (collatz n = 3n+1 for odd n) in CollatzStructuredOQ02OQ03.lean",
       "mod_four_one_attainsBelow: n≡1 mod 4, n≥5 ⇒ AttainsBelow n (axiom-free)",
@@ -41,7 +41,16 @@
       "mod_thirtytwo_twentythree_attainsBelow (h : n%32=23) : AttainsBelow n — 8-step residue-determined drop (…→27m+20<32m+23)",
       "attainsBelow_density_lower_32 (N) : 28*N−1 ≤ card (filter AttainsBelow (Icc 1 (32N))) — five disjoint image families (2j, 4j+1, 16j+3, 32j+11, 32j+23), pairwise Disjoint via residues mod 2/4/16, nested card_union_of_disjoint",
       "even_or_mod_four_one_or_mod_thirtytwo_attainsBelow / _colMin_lt — combined 7/8 packaging; mod_thirtytwo_{eleven,twentythree}_colMin_lt corollaries",
-      "affine_residue_attainsBelow: GENERAL residue-determined-drop lemma. From hiter:∀m, collatz^[k](M*m+r)=c*m+d with c<M and d<r, concludes AttainsBelow for all n≡r (mod M). Abstracts the per-residue trajectory-chase pattern; proof = div_add_mod decomposition + Nat.mul_le_mul_right (c*m≤M*m) + omega. Axiom-free (#print axioms = propext/Quot.sound only)."
+      "affine_residue_attainsBelow: GENERAL residue-determined-drop lemma. From hiter:∀m, collatz^[k](M*m+r)=c*m+d with c<M and d<r, concludes AttainsBelow for all n≡r (mod M). Abstracts the per-residue trajectory-chase pattern; proof = div_add_mod decomposition + Nat.mul_le_mul_right (c*m≤M*m) + omega. Axiom-free (#print axioms = propext/Quot.sound only).",
+      "leadCoeff (List Bool -> Nat -> Nat): pure leading-coefficient fold (odd: 3c, even: c/2)",
+      "leadCoeff_mul: Terras law, leadCoeff v (3^p*2^q)=3^(p+v.count true)*2^(q-v.count false) when v.count false<=q (axiom-free, induction on v)",
+      "leadCoeff_two_pow: residue-case specialization leadCoeff v (2^(v.count false))=3^(v.count true)",
+      "leadCoeff_two_pow_lt_iff: drop criterion c<M <-> 3^a<2^b for M=2^b",
+      "affStep/affOrbit: affine coefficient-pair fold along a parity vector",
+      "affOrbit_fst: (affOrbit v (c,d)).1 = leadCoeff v c (leading coeff independent of d)",
+      "AffValid (inductive): step-by-step parity certificate (odd: c even & d odd; even: c,d even)",
+      "affOrbit_realize: GENERAL engine, AffValid v c d -> collatz^[v.length](c*m+d)=(affOrbit v (c,d)).1*m+(affOrbit v (c,d)).2; one induction replaces all per-residue trajectory chases",
+      "parityVector_attainsBelow: residue class drops below itself from a certificate v with realized c_k<M, d_k<r; new families reduce to a decidable certificate check (mod16/3 re-derived as validation example)"
     ],
     "insights": [
       "The odd residue class n ≡ 1 (mod 4), n ≥ 5, deterministically drops below itself in 3 Collatz steps: 4m+1 → 12m+4 → 6m+2 → 3m+1, with 3m+1 < 4m+1 iff m ≥ 1. First elementary family exercising the 3n+1 branch (even/powers-of-two only touch the n/2 branch).",
@@ -49,12 +58,15 @@
       "Dyadic refinement of the drop-below picture is genuine but the stable fraction does NOT double each level: at level 16 only 3 (mod 16) stabilises among {3,7,11,15}; at level 32 exactly two of the six odd ≡3 mod 4 residues stabilise (11 and 23 mod 32), lifting density 13/16→7/8. The newly stable classes both terminate at coefficient 27 (27m+10 and 27m+20) after 8 forced steps — three 3n+1 ascents interleaved with five halvings.",
       "Within an unstable mod-16 class, the mod-32 split can stabilise the high half: 7 (mod16) stabilises at 23 (mod32) not 7; 11 (mod16) stabilises at 11 (mod32) not 27. The all-ones residue 31 (mod32) climbs fastest (→243m+242 after 10 steps) and never drops in its window — the genuinely hardest residues.",
       "STRUCTURAL: every residue-determined-drop family has k-step iterate = affine c*m+d with leading coefficient c = 3^a*M/2^b, where a = #(3n+1 steps), b = k-a = #halvings (a+b=k). The drop criterion c<M is EXACTLY 3^a < 2^b — enough halvings to overcome the triplings (the classical 3/2-vs-1/2 Collatz heuristic, made exact per residue class). Verified on the gallery families: mod16/3 (a=2,b=4: 9=3^2<16); mod32/11 and mod32/23 (a=3,b=5: 27=3^3<32). The additive constant condition d<r gives an unconditional drop for all m≥0; the boundary d=r (mod4/1: 3m+1 vs 4m+1) needs n≥M+r.",
-      "REFACTOR: the three residue-determined families (mod16/3, mod32/11, mod32/23) now route through affine_residue_attainsBelow, supplying only the class-specific affine-iterate identity (the trajectory chase); the descent bookkeeping (n=M*m+r rewrite, c*m≤M*m monotonicity, final comparison) is shared. mod4/1 is intentionally NOT refactored — its d=r boundary case is the sharp demonstration that the strict criterion d<r is what buys the unconditional (m≥0) drop."
+      "REFACTOR: the three residue-determined families (mod16/3, mod32/11, mod32/23) now route through affine_residue_attainsBelow, supplying only the class-specific affine-iterate identity (the trajectory chase); the descent bookkeeping (n=M*m+r rewrite, c*m≤M*m monotonicity, final comparison) is shared. mod4/1 is intentionally NOT refactored — its d=r boundary case is the sharp demonstration that the strict criterion d<r is what buys the unconditional (m≥0) drop.",
+      "STRUCTURAL (now general & machine-checked): the per-residue leading coefficient closed form is the unconditional multiplicative identity leadCoeff v (3^p*2^q)=3^(p+#odd)*2^(q-#even). The honest subtlety is order/feasibility of halvings: rather than divide (which needs c even at each even step), induct on the FORM 3^p*2^q with #even<=q, which keeps every prefix a genuine nat and makes the law unconditional. Specializing p=0,q=b gives 3^a for M=2^b, so the drop criterion c<M is exactly 3^a<2^b.",
+      "ENGINE: separating the certificate (AffValid: parities forced, checked per step) from the realization (affOrbit_realize: one induction) is what generalizes the chase. The realization needs only that 2*c'*m is recognizably even — omega atomizes (2*c')*m as one nonlinear blob and loses the factor 2, so supply 2*c'*m=2*(c'*m) explicitly. With that, the whole engine is 6 theorems + 1 inductive and a new residue family is a (decidable) certificate, not a bespoke proof."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Formalize the general leading-coefficient law c = 3^a*M/2^b for a residue-determined window (a 3n+1 steps, b halvings) directly from the forced parity vector — this is the Terras parity-vector structure and would replace per-residue trajectory chases with one uniform theorem, turning affine_residue_attainsBelow into a fully general residue-drop engine (the genuine next direction, NOT more residue classes).",
-      "Pushing to mod 64/128 remains diminishing-returns enumeration (density →1 only in the limit = Terras finite-stopping-time theorem); prefer the structural parity-vector law above.",
+      "Mechanize certificate GENERATION: a tactic/decision procedure that, given a residue r mod 2^b, computes the forced parity vector v and AffValid certificate automatically (currently v and the AffValid chain are supplied by hand). This would let parityVector_attainsBelow discharge any residue-determined class fully automatically and could batch-prove the stable classes at a new level.",
+      "Prove the converse/forcing direction: that for n%2^b=r the ACTUAL Collatz parity sequence over the window equals the certificate's v (currently the certificate asserts the parities; tying it to forcedness would close the loop between Terras parity vectors and orbits).",
+      "Refactor the existing mod32/mod128 hand chases (lines ~282-423) to route through affOrbit_realize via certificates, deleting the iterate_succ_apply' boilerplate (engine now exists; left untouched this iteration to minimize build surface).",
       "Tao axiom genuinely blocked (deep analytic, >>1000 lines)."
     ],
     "markdown": "# Knowledge Base: collatz-structured-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
@@ -74,7 +86,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T18:39:05.245Z",
-  "lastUpdate": "2026-06-27T18:05:00.000Z",
+  "lastUpdate": "2026-06-27T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/CollatzStructured.lean",
@@ -112,10 +124,10 @@
     {
       "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
       "filename": "CollatzStructuredOQ02OQ03.lean",
-      "lineCount": 1107,
-      "theoremCount": 42,
+      "lineCount": 1304,
+      "theoremCount": 48,
       "axiomCount": 1,
-      "defCount": 5,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzStructuredOQ02OQ03.lean"


### PR DESCRIPTION
## Summary

Implements the knowledge base's stated **#1 next step** for `collatz-structured-oq-02-oq-03`: a fully general **parity-vector residue-drop engine** that turns the file's per-residue Collatz trajectory chases into pure certificate checks, with the **Terras leading-coefficient law** `c = 3^a/2^b` proved in closed form.

## What's new (Part V — 6 theorems, 3 defs, 1 inductive, all axiom-free)

- **`leadCoeff` / `leadCoeff_mul`** — the Terras leading-coefficient law in unconditional multiplicative form: `leadCoeff v (3^p · 2^q) = 3^(p + #odd) · 2^(q − #even)` whenever `#even ≤ q`. (Inducting on the *form* `3^p·2^q` sidesteps the halving-feasibility subtlety that would otherwise make the law conditional.)
- **`leadCoeff_two_pow` / `leadCoeff_two_pow_lt_iff`** — specialized to a power-of-two modulus `M = 2^b`: the window ends at exactly `3^a` (`a = #odd steps`), so the drop criterion `c < M` is *literally* the classical `3^a < 2^b`.
- **`affStep` / `affOrbit` / `AffValid` / `affOrbit_realize`** — the engine. A parity *certificate* `AffValid v c d` (each step's parity forced) feeds one structural induction (`affOrbit_realize`) that proves `collatz^[k] (c·m+d) = c_k·m + d_k`, replacing the hand-written `iterate_succ_apply'` chains. `affOrbit_fst` shows the leading coefficient evolves independently of `d`, equal to `leadCoeff`.
- **`parityVector_attainsBelow`** — packages the engine with the existing `affine_residue_attainsBelow`: a residue class drops below itself as soon as one exhibits a valid certificate with `c_k < M` and `d_k < r`. A new family is now a certificate + decidable side conditions.

Validation examples: the `n ≡ 3 (mod 16)` drop is re-derived **end-to-end** from the certificate `[odd, even, odd, even, even, even]` with no manual chase, and `leadCoeff` is checked to reproduce the gallery coefficients `9 = 3²` and `27 = 3³`.

## Verification

`#print axioms` on `affOrbit_realize`, `leadCoeff_two_pow`, `parityVector_attainsBelow` returns only `propext` / `Classical.choice` / `Quot.sound` — **no `tao_2019`, no `Lean.ofReduceBool`** (no `native_decide`), no `sorry`. Axiom-free per the project policy.

> ⚠️ **Build note:** the Docker `containerd` content store is corrupted (`input/output error` on image blobs — new containers cannot start). Verification was done via the safety-wrapper-allowed `lake env lean` with the host `leanprover/lean4:v4.26.0` toolchain against the prebuilt Mathlib oleans (`EXIT=0`, no errors/warnings). `lake build` was **not** run.

The Tao axiom (`tao_2019`) is unchanged and the `115/128` density floor is unchanged; this PR adds the structural engine beneath them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)