### PR TITLE
research(puiseux-theorem-oq-03): first lower edge of the Newton polygon [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -304,7 +304,7 @@ theorem isLowerVertex_of_leftmost {pts : List SupportPoint} {p : SupportPoint}
     · subst hqp; simp
     · have hmem : q ∈ pts.filter (fun q => decide (q ≠ p)) :=
         List.mem_filter.mpr ⟨hq, by simpa using hqp⟩
-      rw [hempty] at hmem; exact absurd hmem (List.not_mem_nil q)
+      rw [hempty] at hmem; simp at hmem
   · refine ⟨hp, edgeSlope p q₀, p.2 - edgeSlope p q₀ * (p.1 : ℚ), by ring, fun q hq => ?_⟩
     by_cases hqp : q = p
     · subst hqp; linarith
@@ -334,7 +334,7 @@ theorem isLowerVertex_of_rightmost {pts : List SupportPoint} {p : SupportPoint}
     · subst hqp; simp
     · have hmem : q ∈ pts.filter (fun q => decide (q ≠ p)) :=
         List.mem_filter.mpr ⟨hq, by simpa using hqp⟩
-      rw [hempty] at hmem; exact absurd hmem (List.not_mem_nil q)
+      rw [hempty] at hmem; simp at hmem
   · refine ⟨hp, edgeSlope q₀ p, p.2 - edgeSlope q₀ p * (p.1 : ℚ), by ring, fun q hq => ?_⟩
     by_cases hqp : q = p
     · subst hqp; linarith
@@ -357,5 +357,65 @@ theorem ysqMinusX_endpoints :
     isLowerVertex_of_rightmost (by simp [YsqMinusX]) ?_⟩
   · intro q hq hne; fin_cases hq <;> simp_all
   · intro q hq hne; fin_cases hq <;> simp_all
+
+/-! ### Existence of the first edge
+
+The vertex theorems above identify *corners* of the Newton polygon but never
+produce an actual edge.  `exists_isLowerEdge_of_leftmost` closes that gap: from
+the left endpoint it constructs a genuine `IsLowerEdge`, namely the segment to
+the support point of least edge-slope leaving `p`.  This is the first concrete
+step of a hull-construction (and hence of the Newton–Puiseux recursion, whose
+termination measure `S2-B` reduces the degree one dominant edge at a time):
+unlike `isLowerVertex_of_leftmost`, it returns the right endpoint, not just the
+fact that `p` is a vertex. -/
+
+/-- **The leftmost support point spawns a lower edge.**  If every other support
+point lies strictly to the right of `p`, then joining `p` to the point of least
+edge-slope leaving it (`List.argmin (edgeSlope p)`) yields a genuine lower edge:
+the dominant (least-slope) edge out of the left endpoint of the Newton polygon. -/
+theorem exists_isLowerEdge_of_leftmost {pts : List SupportPoint} {p : SupportPoint}
+    (hp : p ∈ pts) (hother : ∃ q ∈ pts, q ≠ p)
+    (hleft : ∀ q ∈ pts, q ≠ p → p.1 < q.1) :
+    ∃ q, IsLowerEdge pts p q := by
+  classical
+  rcases hR : (pts.filter (fun q => decide (q ≠ p))).argmin (edgeSlope p) with _ | q₀
+  · -- the filter is empty, contradicting the existence of some other point
+    obtain ⟨q, hq, hqp⟩ := hother
+    have hmem : q ∈ pts.filter (fun q => decide (q ≠ p)) :=
+      List.mem_filter.mpr ⟨hq, by simpa using hqp⟩
+    rw [List.argmin_eq_none.mp hR] at hmem
+    simp at hmem
+  · obtain ⟨hq₀pts, hq₀dec⟩ := List.mem_filter.mp (List.argmin_mem hR)
+    have hq₀ne : q₀ ≠ p := by simpa using hq₀dec
+    have hlt : (p.1 : ℚ) < (q₀.1 : ℚ) := by exact_mod_cast hleft q₀ hq₀pts hq₀ne
+    have hlt' : p.1 < q₀.1 := by exact_mod_cast hlt
+    have hne : (q₀.1 : ℚ) - (p.1 : ℚ) ≠ 0 := sub_ne_zero.mpr (ne_of_lt hlt).symm
+    refine ⟨q₀, hp, hq₀pts, hlt', edgeSlope p q₀,
+      p.2 - edgeSlope p q₀ * (p.1 : ℚ), by ring, ?_, fun r hr => ?_⟩
+    · -- the line of slope `edgeSlope p q₀` through `p` passes through `q₀`
+      have hthis : edgeSlope p q₀ * ((q₀.1 : ℚ) - (p.1 : ℚ)) = q₀.2 - p.2 := by
+        rw [edgeSlope, div_mul_cancel₀ _ hne]
+      linear_combination -hthis
+    · -- that line lies weakly below every support point
+      by_cases hrp : r = p
+      · subst hrp; linarith
+      · have hmem : r ∈ pts.filter (fun q => decide (q ≠ p)) :=
+          List.mem_filter.mpr ⟨hr, by simpa using hrp⟩
+        have hle : edgeSlope p q₀ ≤ edgeSlope p r := List.le_of_mem_argmin hmem hR
+        have hltr : (p.1 : ℚ) < (r.1 : ℚ) := by exact_mod_cast hleft r hr hrp
+        have hpos : (0 : ℚ) < (r.1 : ℚ) - (p.1 : ℚ) := by linarith
+        have key : edgeSlope p q₀ * ((r.1 : ℚ) - (p.1 : ℚ)) ≤ r.2 - p.2 :=
+          (le_div_iff₀ hpos).mp hle
+        have hexp : edgeSlope p q₀ * ((r.1 : ℚ) - (p.1 : ℚ))
+            = edgeSlope p q₀ * (r.1 : ℚ) - edgeSlope p q₀ * (p.1 : ℚ) := by ring
+        linarith [key, hexp]
+
+/-- The worked example `Y² − x` again, now via `exists_isLowerEdge_of_leftmost`:
+the leftmost support point `(0,1)` spawns a lower edge without supplying its right
+endpoint by hand. -/
+theorem ysqMinusX_exists_edge : ∃ q, IsLowerEdge YsqMinusX (0, 1) q :=
+  exists_isLowerEdge_of_leftmost (by simp [YsqMinusX])
+    ⟨(2, 0), by simp [YsqMinusX], by decide⟩
+    (by intro q hq hne; fin_cases hq <;> simp_all)
 
 end PuiseuxTheoremOQ03

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -36,11 +36,14 @@
       "edgeSlope_ge_of_supportingLine / edgeSlope_le_of_supportingLine: a vertex's supporting slope m bounds the slope to EVERY other support point (>= m to the right, <= m to the left) — the per-line convexity bounds complementing edgeSlope_mono",
       "IsLowerEdge.interior_slopes: a lower edge is convex from below — for ANY interior support point r (vertex or not), edgeSlope r q <= edgeSlope p r, so the polygon never dips below an edge (sharper than the adjacent-edge edgeSlope_mono)",
       "Worked Y²−x example: both (0,1) and (2,0) are lower vertices, the segment is a genuine lower edge, edge slope = −1/2, leading exponent 1/2 = leadingExponentFromSlope 1 2",
-      "Parent fix: corrected a dangling /-- doc comment in PuiseuxTheorem.lean that made the file fail to parse"
+      "Parent fix: corrected a dangling /-- doc comment in PuiseuxTheorem.lean that made the file fail to parse",
+      "exists_isLowerEdge_of_leftmost: the leftmost support point spawns a genuine IsLowerEdge (the dominant least-slope edge) — first concrete hull-construction step, returning the right endpoint not just vertex-hood",
+      "ysqMinusX_exists_edge: worked Y^2-x edge existence derived via the new theorem (right endpoint not supplied by hand)",
+      "Maintenance: replaced 3 uses of List.not_mem_nil q (explicit-arg form, removed in current Mathlib cache) with simp — file no longer built against the updated Mathlib until this fix"
     ],
     "dateAdded": "2026-06-27",
-    "lineCount": 277,
-    "theoremCount": 16,
+    "lineCount": 421,
+    "theoremCount": 21,
     "definitionCount": 4,
     "mathlib_version": "4.26.0"
   },
@@ -213,9 +216,9 @@
       "Mathlib.Data.List.MinMax"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 277,
+    "lineCount": 421,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 21,
     "definitionCount": 4,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0

--- a/src/data/research/problems/puiseux-theorem-oq-03.json
+++ b/src/data/research/problems/puiseux-theorem-oq-03.json
@@ -29,18 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Delivered the first Lean file Proofs/PuiseuxTheoremOQ03.lean (145 lines, 7 theorems, 3 defs, verified, 0 sorries, 0 axioms): a combinatorial Newton polygon via the supporting-line lower-vertex predicate IsLowerVertex, with the seed lemma (min-valuation point is a vertex), an existence lemma (List.argmin), and the worked Y^2-x example tying edge slope -1/2 to the parent leadingExponentFromSlope 1 2. Also fixed a parse error in the parent PuiseuxTheorem.lean (dangling /-- doc comment). PR #30757.",
+    "progressSummary": "S2-B groundwork: added exists_isLowerEdge_of_leftmost (first lower edge from the left endpoint) to PuiseuxTheoremOQ03.lean, the first concrete hull-construction step. File now 421 lines / 21 theorems, still verified 0-sorry 0-axiom. Also repaired 3 List.not_mem_nil sites broken by a Mathlib-cache update. Remaining: full S2-B termination measure on polynomial reductions, and the algebraic Newton-polygon theorem (blocked on missing K((x))[Y] valuation API).",
     "builtItems": [
       "IsLowerVertex: supporting-line characterization of a Newton-polygon lower-hull vertex (algorithm-independent Prop)",
       "isLowerVertex_of_minimal: the min-valuation support point is always a lower vertex (horizontal supporting line)",
       "exists_lowerVertex: every nonempty support set has a lower vertex (via List.argmin)",
       "edgeSlope + worked Y^2-x example: both support points are vertices, edge slope -1/2, leading exponent 1/2 = leadingExponentFromSlope 1 2",
-      "Parent fix: corrected dangling /-- doc comment in PuiseuxTheorem.lean (file did not parse on main)"
+      "Parent fix: corrected dangling /-- doc comment in PuiseuxTheorem.lean (file did not parse on main)",
+      "exists_isLowerEdge_of_leftmost (PuiseuxTheoremOQ03.lean): leftmost support point -> genuine IsLowerEdge via List.argmin(edgeSlope p); first hull-construction step toward S2-B",
+      "Maintenance: fixed 3 List.not_mem_nil q sites broken by Mathlib cache update (explicit arg removed)"
     ],
     "insights": [
       "Supporting-line predicate beats a verified convex-hull construction: same downstream value, far less proof burden, algorithm-agnostic.",
       "List.argmin + argmin_mem/le_of_mem_argmin gives vertex existence for nonempty support lists in a few lines.",
-      "Model support points as Prod (N x Q), not a custom structure: fin_cases + norm_num then dispatch example goals cleanly."
+      "Model support points as Prod (N x Q), not a custom structure: fin_cases + norm_num then dispatch example goals cleanly.",
+      "Edge existence reuses isLowerVertex_of_leftmost machinery verbatim: the argmin-of-edgeSlope supporting line through the leftmost point already passes through its argmin partner, so it is an edge, not merely a vertex witness.",
+      "Mathlib drift hazard: gallery .lean files verified months ago can silently break against an updated local olean cache (List.not_mem_nil dropped its explicit argument); prefer simp over name-specific applications for List membership-in-nil contradictions."
     ],
     "mathlibGaps": [
       "No Newton polygon API in Mathlib 4.26.0 (no Polynomial.newtonPolygon / lowerConvexHull as combinatorial vertex data).",
@@ -48,9 +52,9 @@
       "No arithmetic-complexity model (Bürgisser-Clausen-Shokrollahi style) to state the Poteaux-Weimann Õ(d·δ) bound."
     ],
     "nextSteps": [
-      "Prove the Newton polygon theorem: negatives of lower-hull edge slopes = root valuations in an alg-closed valued extension.",
-      "S2-B: termination measure for one Newton-Puiseux reduction step (Y-degree strictly decreases).",
-      "S2-C (moonshot): state and bound arithmetic complexity once an arithmetic-cost model exists."
+      "Iterate hull construction: from exists_isLowerEdge_of_leftmost, peel the first edge and recurse on the sub-support to the right of its right endpoint (building the ordered vertex/edge list).",
+      "S2-B: define a polynomial Newton-Puiseux reduction step and prove the Y-degree strictly decreases (needs Laurent-series polynomial modeling).",
+      "Newton polygon theorem: negatives of lower-edge slopes = root valuations (blocked on missing valuation API on K((x))[Y] in Mathlib 4.26.0)."
     ],
     "markdown": "# Knowledge Base: puiseux-theorem-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
     "archivedSessions": [


### PR DESCRIPTION
## Summary
S2-B groundwork for the computational Newton–Puiseux open question. `PuiseuxTheoremOQ03.lean` had a rich combinatorial Newton-polygon API (vertices exist, leftmost/rightmost are vertices, edges, convexity) but **never produced an actual edge**. This PR adds the first concrete hull-construction step.

## Changes (`proofs/Proofs/PuiseuxTheoremOQ03.lean`)
- **`exists_isLowerEdge_of_leftmost`**: from the left endpoint `p`, joining to the support point of least edge-slope (`List.argmin (edgeSlope p)`) yields a genuine `IsLowerEdge` — the dominant (least-slope) edge out of the left endpoint. The supporting line of `isLowerVertex_of_leftmost` already passes through its argmin partner, so it is an *edge*, not merely a vertex witness; the theorem returns the right endpoint.
- **`ysqMinusX_exists_edge`**: the worked `Y²−x` edge existence re-derived via the new theorem (right endpoint no longer supplied by hand).
- **Maintenance fix**: replaced 3 uses of `List.not_mem_nil q` (explicit-argument form, dropped in the current Mathlib cache) with `simp at hmem`. The committed file no longer built against the updated local Mathlib until this fix — two of the three sites were in pre-existing theorems (`isLowerVertex_of_leftmost`, `isLowerVertex_of_rightmost`).

## Verification
Docker build host is down (containerd I/O error, image evicted). Verified via host **`lake env lean Proofs/PuiseuxTheoremOQ03.lean`** (Lean 4.26.0, shared Mathlib olean cache): **EXIT 0**, 0 sorries / 0 axioms. `#print axioms` for both new theorems = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.

meta.json refreshed (lineCount 277→421, theoremCount →21 — both were stale from intervening sessions); status stays `verified`. Problem knowledge JSON updated with the new built item, insights, and next steps.

## Status
**Outcome**: progress (verified theorem on the hull-construction path)
**Next**: iterate the construction (peel first edge, recurse rightward) toward the S2-B termination measure; the algebraic Newton-polygon theorem remains blocked on a missing `K((x))[Y]` valuation API in Mathlib.

🤖 Generated by researcher-1