### PR TITLE
research(sperner-mathlib4-oq-02): continuous 1-D Borsuk–Ulam capstone [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4009,6 +4009,7 @@ import Proofs.SpernerSimplicialInstanceOQ04
 import Proofs.SpernerSimplicialInstanceOQ05
 import Proofs.SpernerSimplicialInstanceOQ05Scarf1d
 import Proofs.SpernerTuckerOneDim
+import Proofs.SpernerTuckerBorsukUlamOneDim
 import Proofs.SphericalExcessGirard
 import Proofs.SphericalLawOfCosines
 import Proofs.SphericalLawOfCosinesOQ03

--- a/proofs/Proofs/SpernerTuckerBorsukUlamOneDim.lean
+++ b/proofs/Proofs/SpernerTuckerBorsukUlamOneDim.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 RJ Walters. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: RJ Walters
+-/
+import Mathlib
+
+/-!
+# One-dimensional Borsuk–Ulam theorem (continuous capstone of `n = 1` Tucker)
+
+The companion file `SpernerTuckerOneDim.lean` proves the **combinatorial** core of
+the `n = 1` Borsuk–Ulam theorem: for a sign labelling of a path that is *antipodal
+on the boundary*, some edge is **complementary** (its endpoints carry opposite
+signs). That is the discrete statement
+`TuckerOneDim.exists_complementary_edge`.
+
+This file completes the `n = 1` line by carrying out the standard
+**Tucker ⟹ Borsuk–Ulam** reduction. In general that reduction is an analytic
+limit argument (refine the triangulation, mesh `→ 0`, extract a convergent
+subsequence by compactness). In **dimension one** the limit collapses entirely to
+the **Intermediate Value Theorem**: a continuous function whose two boundary
+values are *antipodal* (`f a = - f b`) must vanish somewhere in between, exactly
+as a discrete sign-change must occur across an antipodal boundary.
+
+## Main results
+
+* `BorsukUlamOneDim.exists_zero_of_antipodal`: the continuous analogue of
+  `exists_complementary_edge`. If `f` is continuous on the interval between `a`
+  and `b` with antipodal boundary values `f a = - f b`, then `f` has a zero in
+  that interval.
+* `BorsukUlamOneDim.borsuk_ulam_circle`: the **one-dimensional Borsuk–Ulam
+  theorem**. A continuous `1`-periodic function `f : ℝ → ℝ` (equivalently, a
+  continuous real function on the circle `S¹`) takes **equal values at some pair
+  of antipodal points** `c` and `c + 1/2`.
+
+## Relationship to the discrete result
+
+The dictionary between the discrete (`SpernerTuckerOneDim`) and continuous
+statements is:
+
+| discrete (Tucker, `n = 1`)            | continuous (Borsuk–Ulam, `n = 1`)         |
+|---------------------------------------|-------------------------------------------|
+| sign labelling `λ : Fin (N+1) → ZMod 2` | continuous `f : ℝ → ℝ`                   |
+| antipodal boundary `λ 0 ≠ λ (last N)` | antipodal boundary `f a = - f b`          |
+| complementary edge (`λ` changes sign) | zero of `f` (IVT)                         |
+| odd #complementary-edges (parity)     | nonempty zero set (connectedness/IVT)     |
+
+Both are instances of "an antipodal boundary forces an interior witness"; the
+discrete witness is counted by a `ZMod 2` parity, the continuous one by the
+intermediate value theorem.
+
+## References
+
+* A. W. Tucker, *Some topological properties of disk and sphere* (1946).
+* J. Matoušek, *Using the Borsuk–Ulam Theorem* (2003).
+
+## Tags
+
+Borsuk-Ulam, Tucker, antipodal, intermediate value theorem, circle
+-/
+
+open Set
+
+namespace BorsukUlamOneDim
+
+/-- `0` always lies in the (unordered) interval between `x` and `-x`. -/
+private lemma zero_mem_uIcc_neg (x : ℝ) : (0 : ℝ) ∈ Set.uIcc x (-x) := by
+  rw [Set.mem_uIcc]
+  rcases le_total x 0 with h | h
+  · exact Or.inl ⟨h, by linarith⟩
+  · exact Or.inr ⟨by linarith, h⟩
+
+/-- **One-dimensional Borsuk–Ulam, zero form** — the continuous analogue of the
+discrete `TuckerOneDim.exists_complementary_edge`.
+
+If `f` is continuous on the interval between `a` and `b` and its boundary values
+are **antipodal** (`f a = - f b`), then `f` has a zero somewhere in the interval.
+This is the intermediate value theorem applied at the value `0`, which always
+lies between `f a` and `f b = - f a`. -/
+theorem exists_zero_of_antipodal {a b : ℝ} (f : ℝ → ℝ)
+    (hf : ContinuousOn f (Set.uIcc a b)) (hanti : f a = - f b) :
+    ∃ c ∈ Set.uIcc a b, f c = 0 := by
+  have h0 : (0 : ℝ) ∈ Set.uIcc (f a) (f b) := by
+    rw [hanti, Set.uIcc_comm]; exact zero_mem_uIcc_neg (f b)
+  obtain ⟨c, hc, hfc⟩ := intermediate_value_uIcc hf h0
+  exact ⟨c, hc, hfc⟩
+
+/-- **One-dimensional Borsuk–Ulam theorem.** A continuous `1`-periodic function
+`f : ℝ → ℝ` — equivalently, a continuous real-valued function on the circle
+`S¹ = ℝ / ℤ` — takes **equal values at some pair of antipodal points**: there is
+a point `c` with `f c = f (c + 1/2)`.
+
+The proof is the textbook reduction to the one-variable case: the *antipodal
+difference* `g x = f x - f (x + 1/2)` satisfies `g 0 = - g (1/2)` (using
+`1`-periodicity, `f 1 = f 0`), so `g` has antipodal boundary values on
+`[0, 1/2]` and hence a zero there by `exists_zero_of_antipodal`. -/
+theorem borsuk_ulam_circle (f : ℝ → ℝ) (hf : Continuous f)
+    (hper : ∀ x, f (x + 1) = f x) :
+    ∃ c, f c = f (c + 1 / 2) := by
+  -- `f 1 = f 0` from `1`-periodicity (with `0 + 1 = 1`).
+  have hf1 : f 1 = f 0 := by simpa using hper 0
+  -- The antipodal difference `g x = f x - f (x + 1/2)` is continuous.
+  have hcont : Continuous (fun x => f x - f (x + 1 / 2)) := by fun_prop
+  -- Its boundary values on `[0, 1/2]` are antipodal: `g 0 = - g (1/2)`.
+  have hanti : (fun x => f x - f (x + 1 / 2)) 0
+      = -((fun x => f x - f (x + 1 / 2)) (1 / 2)) := by
+    simp only
+    rw [show (0 : ℝ) + 1 / 2 = 1 / 2 by norm_num,
+        show (1 : ℝ) / 2 + 1 / 2 = 1 by norm_num, hf1]
+    ring
+  -- IVT on the antipodal difference yields a coincident antipodal pair.
+  obtain ⟨c, _, hc⟩ :=
+    exists_zero_of_antipodal (fun x => f x - f (x + 1 / 2)) hcont.continuousOn hanti
+  have hc' : f c - f (c + 1 / 2) = 0 := hc
+  exact ⟨c, by linarith⟩
+
+end BorsukUlamOneDim

--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -62,6 +62,22 @@ boundary path-endpoints, forcing an interior complementary simplex. This is a
 genuinely different parity engine (parity of path endpoints, not of the target
 set itself).
 
+### Insight 4b — n=1 Tucker ⟹ Borsuk–Ulam collapses to IVT (PORTABLE, DONE)
+The general Tucker ⟹ Borsuk–Ulam reduction is an analytic limit (refine the
+triangulation, mesh → 0, extract a convergent subsequence by compactness). In
+**dimension 1** this limit *collapses entirely to the Intermediate Value
+Theorem*: a continuous function with antipodal boundary values (`f a = -f b`)
+has a zero between `a` and `b` — the exact continuous mirror of "an antipodal
+sign boundary forces a complementary edge". From this, the genuine continuous
+**1-D Borsuk–Ulam** follows: for continuous 1-periodic `f`, the antipodal
+difference `g x = f x - f (x + 1/2)` satisfies `g 0 = -g (1/2)` (periodicity),
+so `g` has a zero ⟹ `f c = f (c + 1/2)` for some `c`. Shipped as
+`SpernerTuckerBorsukUlamOneDim.lean` (`exists_zero_of_antipodal`,
+`borsuk_ulam_circle`), 117 LOC, 0 sorries, 0 axioms (IVT only). Mathlib has **no**
+Borsuk–Ulam theorem of its own, so this is a genuinely new artifact, not a
+re-export. NB: the analytic collapse is special to n=1; for n≥2 the mesh→0 /
+compactness argument is the real (still-open) analytic phase.
+
 ### Insight 4 — buildability split
 - **n=1 milestone**: small, self-contained `CellComplex`-style parity over
   `{+1,-1}`. Estimated < 200 LOC. BUILD when Docker is up.
@@ -163,3 +179,40 @@ a complementary edge.
   complementary-edge count is NOT a parity invariant for n≥2 — Insight 3). Or the
   Tucker-via-Sperner doubling/quotient reduction on RPⁿ.
 - Tucker ⟹ Borsuk–Ulam: continuous mesh→0 + compactness (separate analytic phase).
+
+## Session 2026-06-27 (Session 4) — ACT: continuous 1-D Borsuk–Ulam capstone (verified)
+
+**Mode**: BUILD (Docker IMAGE build broken — containerd `meta.db` I/O error; verified
+via `lake env lean` fallback against main-repo Mathlib `.olean` cache)
+**Outcome**: progress (ACT) — new verified file, 0 sorries, 0 axioms
+
+### What I Did
+- Completed the **n=1 line end-to-end** by adding the continuous capstone
+  `proofs/Proofs/SpernerTuckerBorsukUlamOneDim.lean` (117 LOC). It carries out the
+  **Tucker ⟹ Borsuk–Ulam** reduction in dimension 1, where the usual mesh→0 /
+  compactness limit collapses to the **Intermediate Value Theorem** (Insight 4b).
+
+### Theorems (all verified, 0-axiom: propext/Classical.choice/Quot.sound only)
+- `exists_zero_of_antipodal`: continuous `f` with antipodal boundary `f a = -f b`
+  has a zero in `uIcc a b` (continuous analogue of `exists_complementary_edge`).
+  Proof: `intermediate_value_uIcc` at the value `0`, which lies in `uIcc x (-x)`.
+- `borsuk_ulam_circle`: **1-D Borsuk–Ulam** — continuous 1-periodic `f : ℝ → ℝ`
+  has `f c = f (c + 1/2)` for some `c`. Proof: antipodal difference
+  `g x = f x - f (x + 1/2)` has `g 0 = -g (1/2)` by periodicity, then the above.
+
+### Gotchas
+- After `rw [hanti]` the IVT interval is `uIcc (-f b) (f b)`; needed
+  `Set.uIcc_comm` to match the helper `zero_mem_uIcc_neg : 0 ∈ uIcc x (-x)`.
+- Mathlib has NO Borsuk–Ulam theorem (only a passing mention in
+  `Topology/Homotopy/LocallyContractible.lean`) — this is a genuinely new artifact.
+
+### Files Modified
+- proofs/Proofs/SpernerTuckerBorsukUlamOneDim.lean (new)
+- proofs/Proofs.lean (registered the module)
+- src/data/research/problems/sperner-mathlib4-oq-02.json (leanFiles + currentState)
+- research/problems/sperner-mathlib4-oq-02/{knowledge.md, state.md}
+
+### Next Steps (n≥2 unchanged)
+- n≥2 Tucker: Freund–Todd / Prescott–Su path-following engine (Insight 3), or
+  Tucker-via-Sperner doubling on RPⁿ. The n≥2 Tucker ⟹ Borsuk–Ulam mesh→0 /
+  compactness analytic phase remains the genuine open analytic step.

--- a/research/problems/sperner-mathlib4-oq-02/state.md
+++ b/research/problems/sperner-mathlib4-oq-02/state.md
@@ -3,14 +3,26 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-06-27T10:30:00-07:00
-**Iteration**: 3
+**Since**: 2026-06-27T12:30:00-07:00
+**Iteration**: 4
 
 ## Current Focus
-n=1 Tucker milestone SHIPPED and verified (Docker is up — prior blocker cleared).
-New file `proofs/Proofs/SpernerTuckerOneDim.lean` (169 LOC, 0 sorries, 0 axioms)
-proves 1-D Tucker = the combinatorial core of 1-D Borsuk–Ulam via a direct
-sign-change parity (discrete fundamental theorem of calculus over `ZMod 2`).
+The **n=1 line is now COMPLETE end-to-end**. This session added the *continuous
+capstone*: `proofs/Proofs/SpernerTuckerBorsukUlamOneDim.lean` (117 LOC, 0 sorries,
+0 axioms) carries out the **Tucker ⟹ Borsuk–Ulam** reduction in dimension 1. In
+dim 1 the usual mesh→0/compactness limit collapses to the **Intermediate Value
+Theorem**, giving the genuine *continuous* **1-D Borsuk–Ulam theorem**:
+`borsuk_ulam_circle` — a continuous 1-periodic `f : ℝ → ℝ` (a function on the
+circle) takes **equal values at some antipodal pair** `c`, `c + 1/2`.
+
+Together with the prior `SpernerTuckerOneDim.lean` (discrete combinatorial core,
+merged PR #30823) this gives the full discrete→continuous n=1 story.
+
+## Verification note
+Docker IMAGE build is currently broken (containerd `meta.db` I/O error), but
+`docker ps` works. Verified the new file via the established fallback
+`lake env lean` against the main-repo Mathlib `.olean` cache (0 errors;
+`#print axioms` = only propext/Classical.choice/Quot.sound).
 
 ## Active Approach
 Direct sign-change parity, not a `CellComplex` instantiation (the engine's
@@ -33,4 +45,5 @@ panchromatic conclusion diverges from the complementary-edge target — Insight 
 - n>=2: scope/build the Freund-Todd / Prescott-Su path-following engine (the
   complementary-edge count is NOT a parity invariant for n>=2 — Insight 3), or the
   Tucker-via-Sperner doubling/quotient reduction on RP^n.
-- Tucker ⟹ Borsuk–Ulam: continuous mesh→0 + compactness (separate analytic phase).
+- n>=2 Tucker ⟹ Borsuk–Ulam: continuous mesh→0 + compactness (the genuine analytic
+  phase; in dim 1 this was discharged this session by IVT).

--- a/src/data/research/problems/sperner-mathlib4-oq-02.json
+++ b/src/data/research/problems/sperner-mathlib4-oq-02.json
@@ -15,20 +15,7 @@
     "open": [],
     "goal": ""
   },
-  "currentState": {
-    "phase": "ACT",
-    "since": "2026-06-27T10:30:00-07:00",
-    "iteration": 3,
-    "focus": "Delivered the n=1 Tucker milestone: 1-D Tucker / combinatorial 1-D Borsuk–Ulam, fully verified (0 sorries, 0 axioms).",
-    "activeApproach": "Direct sign-change parity (discrete FTC over ZMod 2): the count of complementary edges equals the boundary sign sum; antipodal boundary forces it odd, hence ≥ 1.",
-    "blockers": [],
-    "nextAction": "Scope the n≥2 engine: Freund–Todd / Prescott–Su path-following on almost-complementary simplices (the complementary-edge count is NOT a parity invariant for n≥2, so the direct route does not lift).",
-    "attemptCounts": {
-      "total": 2,
-      "currentApproach": 1,
-      "approachesTried": 2
-    }
-  },
+  "currentState": "n=1 Tucker line COMPLETE end-to-end: discrete combinatorial core (SpernerTuckerOneDim, merged) + continuous capstone (SpernerTuckerBorsukUlamOneDim, this session) deriving the genuine 1-D Borsuk-Ulam theorem from IVT. A continuous 1-periodic f:R->R takes equal values at some antipodal pair c, c+1/2. n>=2 Tucker still needs the Freund-Todd / Prescott-Su path-following engine (complementary-edge count is not a parity invariant for n>=2).",
   "knowledge": {
     "progressSummary": "n=1 Tucker milestone shipped as proofs/Proofs/SpernerTuckerOneDim.lean (169 LOC, 0 sorries, 0 axioms, kernel `decide` only). Proves the combinatorial core of 1-D Borsuk–Ulam: any sign labelling of a path that is antipodal on the boundary (endpoints differ) has a complementary edge. Method: a telescoping ZMod-2 identity (`complementary_count_cast`) shows the complementary-edge count ≡ boundary sign sum (mod 2); the antipodal condition pins that to 1, forcing an odd count (`tucker_one_dim`), hence existence (`exists_complementary_edge`). Confirms the OQ's positive direction for n=1 and the negative direction for the general engine: the direct parity route does NOT lift to n≥2.",
     "builtItems": [
@@ -65,8 +52,19 @@
     "mathlib": []
   },
   "started": "2026-06-15T02:22:23.646Z",
-  "lastUpdate": "2026-06-27T17:35:00.000Z",
+  "lastUpdate": "2026-06-27",
   "leanFiles": [
+    {
+      "path": "Proofs/SpernerTuckerBorsukUlamOneDim.lean",
+      "filename": "SpernerTuckerBorsukUlamOneDim.lean",
+      "lineCount": 117,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerTuckerBorsukUlamOneDim.lean"
+    },
     {
       "path": "Proofs/SpernerTuckerOneDim.lean",
       "filename": "SpernerTuckerOneDim.lean",


### PR DESCRIPTION
## Summary

Completes the **n=1 Tucker line end-to-end** for the open problem
`sperner-mathlib4-oq-02` (Tucker's lemma / Borsuk–Ulam from abstract
door-counting). The discrete combinatorial core (`SpernerTuckerOneDim.lean`,
merged in #30823) is now joined by the **continuous capstone**: the standard
**Tucker ⟹ Borsuk–Ulam** reduction, which in dimension 1 collapses entirely to
the **Intermediate Value Theorem**.

New file `proofs/Proofs/SpernerTuckerBorsukUlamOneDim.lean` (117 LOC, 0 sorries,
0 axioms):

- **`exists_zero_of_antipodal`** — continuous analogue of the discrete
  `exists_complementary_edge`: a continuous `f` with antipodal boundary values
  `f a = -f b` has a zero in `uIcc a b`. Proof: `intermediate_value_uIcc` at the
  value `0`, which always lies in `uIcc x (-x)`.
- **`borsuk_ulam_circle`** — the **1-D Borsuk–Ulam theorem**: a continuous
  `1`-periodic `f : ℝ → ℝ` (equivalently a continuous function on the circle
  `S¹`) takes **equal values at some antipodal pair** `c`, `c + 1/2`. Proof: the
  antipodal difference `g x = f x - f (x + 1/2)` satisfies `g 0 = -g (1/2)` by
  periodicity, then the lemma above.

The discrete↔continuous dictionary (antipodal boundary forces an interior
witness; counted by `ZMod 2` parity in the discrete case, by IVT in the
continuous case) is documented in the file's module docstring.

Mathlib has **no** Borsuk–Ulam theorem of its own (only a passing mention in
`Topology/Homotopy/LocallyContractible.lean`), so this is a genuinely new
artifact.

## Verification

`#print axioms` confirms both theorems depend only on
`propext`/`Classical.choice`/`Quot.sound` — **0-axiom, 0-sorry**.

Verified via `lake env lean` against the main-repo Mathlib `.olean` cache: the
Docker image build is currently broken (containerd `meta.db` I/O error), but
`lake env lean` typechecks the single file (which imports only `Mathlib`)
against the cached oleans with 0 errors.

## Scope note

The analytic collapse to IVT is special to `n = 1`. For `n ≥ 2`, Tucker's
complementary-edge count is not a parity invariant (verified computationally),
and the mesh→0 / compactness analytic phase of Tucker ⟹ Borsuk–Ulam remains the
genuine open step — tracked in the problem's `knowledge.md` (Insights 3, 4b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)