### PR TITLE
Enrich Erdős #211 extremal 1/6 constant (erdos-211-incomplete-01)

### DIFF
--- a/src/data/proofs/erdos-211-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-211-incomplete-01/annotations.json
@@ -52,5 +52,17 @@
     "significance": "critical",
     "relatedConcepts": ["Steiner triple system", "necessary divisibility condition", "Kirkman's condition", "Fano plane", "affine plane AG(2,3)"],
     "prerequisites": ["Nat.choose_two_right", "binomial coefficients"]
+  },
+  {
+    "id": "erdos211-inc01-ann-islinecover",
+    "proofId": "erdos-211-incomplete-01",
+    "range": { "startLine": 43, "endLine": 53 },
+    "type": "definition",
+    "title": "IsLineCover: An Honest Antecedent, Not an Assumed Configuration",
+    "content": "The whole entry turns on what IsLineCover is — and is not. It is a three-part Prop bundling the axioms of a Steiner triple system S(2,3,n): every line has exactly three points (hcard), every line sits inside the point set V (hsub), and every 2-element subset of V lies on exactly one line (hcover, the ∃! cover condition). This is a *hypothesis*, quantified universally: every theorem below reads 'for all V and L, if IsLineCover V L then …'. Crucially it is **not** an axiom asserting such an L exists. That distinction is the 'incomplete-01' framing: the entry rigorously proves the combinatorial consequence (the n(n-1)/6 line count) of being such a system, while the geometric question — for which n and via which planar point sets such a system is *realised* — is deliberately left to the classical Kirkman/Steiner existence theory. Trading existence for an honest antecedent is exactly what keeps the file 0-axiom while still extracting the rigorous heart of Erdős's 1/6.",
+    "mathContext": "$\\mathrm{IsLineCover}\\,V\\,L \\;:=\\; \\bigl(\\forall l\\in L,\\,|l|=3\\bigr)\\;\\wedge\\;\\bigl(\\forall l\\in L,\\,l\\subseteq V\\bigr)\\;\\wedge\\;\\bigl(\\forall p\\in \\binom{V}{2},\\,\\exists!\\,l\\in L,\\ p\\subseteq l\\bigr)$. The $\\exists!$ ('exactly one') is the $\\lambda=1$ of a $2$-design $S(2,3,n)$; weakening it to $\\exists$ would break the per-pair fiber count of $1$ that the double count needs.",
+    "significance": "key",
+    "relatedConcepts": ["Steiner triple system S(2,3,n)", "2-design", "ExistsUnique", "honest antecedent vs. axiom", "conditional theorem", "design realizability"],
+    "prerequisites": ["Prop and predicates in Lean", "Finset.powersetCard", "ExistsUnique (∃!)"]
   }
 ]

--- a/src/data/proofs/erdos-211-incomplete-01/index.ts
+++ b/src/data/proofs/erdos-211-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos211SteinerLineCount.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos211Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos211Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos211Incomplete01Data: ProofData = {
+  proof: erdos211Incomplete01Proof,
+  annotations: erdos211Incomplete01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-211-incomplete-01` (quality 73, pass 0).

## Changes
- **Created missing `index.ts`** — the proof page previously failed to load (Vite `import.meta.glob` could not discover the entry). camelCase `erdos211Incomplete01`, source `Erdos211SteinerLineCount.lean`.
- **Added a 5th annotation** (`ann-islinecover`, lines 43–53) on the `IsLineCover` definition: the honest-antecedent-vs-assumed-existence distinction that underpins the entry's 0-axiom, 'combinatorial core not geometric realizability' framing — the conceptual key to the *incomplete-01* scoping. Validates cleanly against the Lean source.

## Notes
- meta.json already rich and well under cap (10.5 KB); content left intact, no inflation.
- Cross-reference target `erdos-211` verified to exist.
- JSON validated; gallery data-generation links the entry. The two pre-existing soft validation warnings on the older display-partition annotations are fleet-wide (non-strict mode) and untouched here. `tsc` stage can't run in this worktree (no `node_modules`); `index.ts` follows a verbatim building-sibling pattern.

Branch named distinctly to avoid colliding with the still-open PR #30902 on `feature/enricher-5`.