### PR TITLE
research(sperner-ndim-oq-02): cell recovery from (facet, opposite-vertex) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -307,4 +307,54 @@ theorem not_mem_facet_iff (s : CanonSimplex d N) (k j : Fin (d + 1)) :
   · rintro rfl
     exact vertices_not_mem_facet s _
 
+-- ============================================================
+-- SECTION: Facet reconstruction of a canonical cell
+-- ============================================================
+-- `adj` records, for each interior facet of a cell, the neighbouring
+-- cell glued across it together with that neighbour's opposite vertex
+-- index.  For this stored data to be coherent the *cell* must be
+-- recoverable from a single (facet, opposite-vertex) pair.  These
+-- lemmas pin that down: the full vertex set of a canonical cell is its
+-- `k`-facet plus the deleted vertex `vertices s k`, and consequently a
+-- canonical cell is determined by any one facet together with its
+-- opposite vertex (`canon_eq_of_facet_and_vertex`).  This is the
+-- cross-cell companion of `facet_injective` (which handled the
+-- within-cell direction) and the precise statement that makes the
+-- (facet, opposite-vertex) payload of `adj` well defined.  All
+-- 0-sorry, 0-axiom.
+
+/-- The full vertex set of a canonical cell is its `k`-th facet
+together with the deleted vertex `vertices s k`.  Splitting `univ` as
+`insert k (univ.erase k)` and pushing through `vertices s` recovers the
+cell's `d + 1` vertices from the `d`-vertex facet and the one removed
+vertex. -/
+theorem image_univ_eq_insert_facet (s : CanonSimplex d N) (k : Fin (d + 1)) :
+    Finset.univ.image (vertices s) = insert (vertices s k) (facet s k) := by
+  rw [facet, ← Finset.image_insert, Finset.insert_erase (Finset.mem_univ k)]
+
+/-- The Finset vertex set of a canonical cell coerces to the range of
+its vertex map.  Bridges the Finset-level facet algebra above to the
+`Set.range` interface of `canon_eq_of_vertices_range`. -/
+theorem coe_image_univ_vertices (s : CanonSimplex d N) :
+    (↑(Finset.univ.image (vertices s)) : Set (SpernerNDim.Vertex d N))
+      = Set.range (vertices s) := by
+  rw [Finset.coe_image, Finset.coe_univ, Set.image_univ]
+
+/-- **A canonical cell is determined by one facet and its opposite
+vertex.**  If two canonical cells share a facet (`facet s k = facet t l`)
+together with the matching deleted vertex (`vertices s k = vertices t l`),
+then they are equal.  Both cells then have the same full vertex set
+(facet ∪ {opposite vertex}), and `canon_eq_of_vertices_range` collapses
+that to cell equality.  This is the coherence underlying `adj`: the
+(facet, opposite-vertex) pair the adjacency stores pins down the cell
+uniquely, so a glued neighbour cannot be ambiguous. -/
+theorem canon_eq_of_facet_and_vertex {s t : CanonSimplex d N}
+    {k l : Fin (d + 1)}
+    (hface : facet s k = facet t l)
+    (hvert : vertices s k = vertices t l) : s = t := by
+  apply canon_eq_of_vertices_range
+  rw [← coe_image_univ_vertices s, ← coe_image_univ_vertices t,
+    image_univ_eq_insert_facet s k, image_univ_eq_insert_facet t l,
+    hface, hvert]
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1,5 +1,71 @@
 # sperner-ndim-oq-02: Boundary-Door Oddness by Dimensional Induction
 
+## Session 2026-06-27 (Session 11, researcher-3) — Cell recovery from (facet, opposite-vertex)
+
+**Mode**: ACT (CONTINUE Phase-1). **Outcome**: PROGRESS — added the
+"Facet reconstruction of a canonical cell" section to
+`SpernerNDimOQ02.lean` (+3 theorems, ~50 L). **Type-check VERIFIED via
+`lake env lean` against the main-repo olean cache (EXIT 0, clean)**;
+**`#print axioms` obtained** — all three new theorems depend only on
+`[propext, Classical.choice, Quot.sound]`, i.e. **genuinely 0-axiom**
+(no `sorryAx`/`Lean.ofReduceBool`/`native_decide`). Docker host was DOWN
+again (containerd `meta.db` I/O error) so verified via the `lake env lean`
+single-file channel.
+
+### What was delivered (`SpernerNDimOQ02.lean`, new section)
+
+The within-cell facet algebra (`facet_injective`, `facet_card`,
+`not_mem_facet_iff`) was already closed in Session ≤10. This session adds
+the **cross-cell** coherence that makes the `adj` payload well defined —
+`adj` stores, per interior facet, the neighbour cell *and its opposite
+vertex index*, so a cell must be recoverable from one `(facet, opposite
+vertex)` pair:
+
+- `image_univ_eq_insert_facet s k : univ.image (vertices s)
+  = insert (vertices s k) (facet s k)`. The full `d+1`-vertex set is the
+  `d`-vertex facet plus the deleted vertex. Proof: `univ = insert k
+  (univ.erase k)` (`Finset.insert_erase`) pushed through `vertices s`
+  (`Finset.image_insert`). One-liner.
+- `coe_image_univ_vertices s : ↑(univ.image (vertices s)) =
+  Set.range (vertices s)`. Finset→Set bridge (`Finset.coe_image`,
+  `coe_univ`, `Set.image_univ`) so the facet algebra can feed
+  `canon_eq_of_vertices_range`.
+- `canon_eq_of_facet_and_vertex (hface : facet s k = facet t l)
+  (hvert : vertices s k = vertices t l) : s = t`. **Capstone.** A canonical
+  cell is determined by any ONE facet together with its opposite vertex:
+  both cells then have the same full vertex set (facet ∪ {opposite}), and
+  `canon_eq_of_vertices_range` (Session ≤10) collapses that to cell
+  equality. This is the cross-cell companion of `facet_injective` and the
+  exact statement showing the `(facet, opposite-vertex)` data `adj` keeps
+  is unambiguous.
+
+### Why this matters (Phase-1)
+
+The vertex/geometry half of the `SpernerTriangulation` carrier is now
+essentially complete: carrier (`CanonSimplex`), `vertices`,
+`vertices_injective`, per-geometry uniqueness (`canon_eq_of_vertices_range`),
+full facet combinatorics, AND cell-recovery-from-facet. The ONLY remaining
+obligations for a full instance are the adjacency field `adj` itself (the
+Freudenthal facet-pivot / neighbour construction) and its compatibility
+fields `adj_symm`/`adj_vertices`/`adj_ne`/`adj_unique_facet`/`boundary_face`.
+`canon_eq_of_facet_and_vertex` + `facet_injective` are precisely the
+uniqueness lemmas the eventual `adj` discharge will cite.
+
+### Next steps (unchanged ordering; cell-recovery now DONE)
+1. ~~`CanonSimplex` carrier + `vertices` + `vertices_injective`~~ DONE.
+2. ~~facet combinatorics + cross-cell cell-recovery~~ **DONE this session.**
+3. **(next)** Define `adj` via finite facet-search: for cell `s`, facet `k`,
+   search `univ : Finset (CanonSimplex)` for a `t ≠ s` with a facet equal to
+   `facet s k`; return `some (t, l)` with `l` the (unique, by
+   `facet_injective`) matching index, else `none`. Then discharge the 5
+   compatibility fields — `adj_unique_facet` falls out of `facet_injective`,
+   `adj_ne`/`adj_vertices` are immediate from the search predicate, `adj_symm`
+   needs the search to be symmetric, and `boundary_face` is the genuinely
+   geometric obligation (a facet with no neighbour lies on `∂Δ_N`).
+4. Phase 2: last-face-door-oddness by induction; apply `sperner_ndim`.
+
+---
+
 ## Session 2026-06-27 (Session 10, researcher-3) — Per-geometry uniqueness COMPLETE
 
 **Mode**: ACT (CONTINUE Phase-1; execute the Session-9 "next deliverable").


### PR DESCRIPTION
## Summary

Advances the Phase-1 Freudenthal `SpernerTriangulation` carrier for **sperner-ndim-oq-02** by closing the **cross-cell** facet-reconstruction coherence in `SpernerNDimOQ02.lean` (+3 theorems, ~50 L).

The abstract `adj` field stores, per interior facet, the neighbouring cell *and its opposite vertex index*. For that payload to be coherent a canonical cell must be recoverable from a single `(facet, opposite-vertex)` pair. The within-cell direction (`facet_injective`) was already done; this PR adds the cross-cell capstone.

## What's new (`SpernerNDimOQ02.lean`, new section)

- `image_univ_eq_insert_facet`: the full `d+1`-vertex set of a cell is its `k`-facet plus the deleted vertex — `univ.image (vertices s) = insert (vertices s k) (facet s k)`.
- `coe_image_univ_vertices`: Finset→Set bridge so the facet algebra feeds `canon_eq_of_vertices_range`.
- `canon_eq_of_facet_and_vertex`: **a canonical cell is determined by any one facet together with its opposite vertex** (`facet s k = facet t l` ∧ `vertices s k = vertices t l` ⟹ `s = t`). The cross-cell companion of `facet_injective`; the exact uniqueness lemma the eventual `adj` discharge cites.

## Verification

Docker containerd host was down (`meta.db` I/O error), so verified via the `lake env lean` single-file channel against the main-repo olean cache:

- Type-check: **EXIT 0, clean**.
- `#print axioms` on all three new theorems: `[propext, Classical.choice, Quot.sound]` only — **genuinely 0-axiom** (no `sorryAx`/`Lean.ofReduceBool`/`native_decide`).

## Status

PROGRESS, not complete. The vertex/geometry half of the carrier is now essentially closed; the remaining obligations for a full instance are the `adj` field (Freudenthal facet-pivot search) and its 5 compatibility fields, with `boundary_face` the genuinely geometric one. See `research/problems/sperner-ndim-oq-02/knowledge.md` (Session 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)