### PR TITLE
research(puiseux-theorem-oq-03): Newton polygon is a graph over the index axis [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -304,7 +304,7 @@ theorem isLowerVertex_of_leftmost {pts : List SupportPoint} {p : SupportPoint}
     · subst hqp; simp
     · have hmem : q ∈ pts.filter (fun q => decide (q ≠ p)) :=
         List.mem_filter.mpr ⟨hq, by simpa using hqp⟩
-      rw [hempty] at hmem; exact absurd hmem (List.not_mem_nil q)
+      rw [hempty] at hmem; simp at hmem
   · refine ⟨hp, edgeSlope p q₀, p.2 - edgeSlope p q₀ * (p.1 : ℚ), by ring, fun q hq => ?_⟩
     by_cases hqp : q = p
     · subst hqp; linarith
@@ -334,7 +334,7 @@ theorem isLowerVertex_of_rightmost {pts : List SupportPoint} {p : SupportPoint}
     · subst hqp; simp
     · have hmem : q ∈ pts.filter (fun q => decide (q ≠ p)) :=
         List.mem_filter.mpr ⟨hq, by simpa using hqp⟩
-      rw [hempty] at hmem; exact absurd hmem (List.not_mem_nil q)
+      rw [hempty] at hmem; simp at hmem
   · refine ⟨hp, edgeSlope q₀ p, p.2 - edgeSlope q₀ p * (p.1 : ℚ), by ring, fun q hq => ?_⟩
     by_cases hqp : q = p
     · subst hqp; linarith
@@ -357,5 +357,51 @@ theorem ysqMinusX_endpoints :
     isLowerVertex_of_rightmost (by simp [YsqMinusX]) ?_⟩
   · intro q hq hne; fin_cases hq <;> simp_all
   · intro q hq hne; fin_cases hq <;> simp_all
+
+/-! ### The Newton polygon is a graph over the index axis
+
+The vertex predicate identifies corners by a supporting line, so *a priori* two
+distinct support points could both qualify as vertices.  The lemmas here show
+this never happens at a shared index.  A lower vertex's valuation is the
+**minimum** over all support points sharing its index
+(`IsLowerVertex.le_of_sameIndex`): the supporting line, evaluated at the common
+index, sits at the vertex and weakly below every competitor.  Consequently at
+most one support point per index can be a vertex (`IsLowerVertex.eq_of_index`),
+so the lower hull is the graph of a well-defined function `i ↦ v`.  This is the
+combinatorial content of "*the* Newton polygon" being a single polygonal arc
+rather than an arbitrary point set, and it is what lets the Newton–Puiseux
+algorithm collapse each index-fiber to its lowest point before tracing edges. -/
+
+/-- **A lower vertex is lowest in its index-fiber.**  If `p` is a lower vertex and
+`q` is any support point with the same index `p.1 = q.1`, then `p.2 ≤ q.2`.  The
+supporting line through `p` agrees with `p` at that index and lies weakly below
+`q`, so `p` cannot be beaten there. -/
+theorem IsLowerVertex.le_of_sameIndex {pts : List SupportPoint} {p q : SupportPoint}
+    (hp : IsLowerVertex pts p) (hq : q ∈ pts) (hidx : p.1 = q.1) : p.2 ≤ q.2 := by
+  obtain ⟨_, m, b, hpe, hsup⟩ := hp
+  have h := hsup q hq
+  rw [← hidx] at h
+  linarith [hpe, h]
+
+/-- **Index-uniqueness of vertices.**  Two lower vertices with the same index are
+equal.  Together with `le_of_sameIndex` this says the lower hull is the graph of
+a function of the index: each `Y`-degree contributes at most one polygon vertex,
+namely the support point of least valuation there. -/
+theorem IsLowerVertex.eq_of_index {pts : List SupportPoint} {p q : SupportPoint}
+    (hp : IsLowerVertex pts p) (hq : IsLowerVertex pts q) (hidx : p.1 = q.1) :
+    p = q := by
+  have h1 : p.2 ≤ q.2 := hp.le_of_sameIndex hq.mem hidx
+  have h2 : q.2 ≤ p.2 := hq.le_of_sameIndex hp.mem hidx.symm
+  exact Prod.ext_iff.mpr ⟨hidx, le_antisymm h1 h2⟩
+
+/-- A support point that is **not lowest at its index** is not a lower vertex.
+Augmenting `Y² − x`'s support with a spurious high point `(0, 5)` directly above
+the constant term: `(0, 5)` fails to be a vertex because the genuine vertex
+`(0, 1)` sits below it at the same index `0`. -/
+theorem ysqMinusX_high_not_vertex :
+    ¬ IsLowerVertex [(0, 1), (2, 0), (0, 5)] (0, 5) := by
+  intro h
+  have hle : (5 : ℚ) ≤ 1 := h.le_of_sameIndex (q := (0, 1)) (by simp) rfl
+  norm_num at hle
 
 end PuiseuxTheoremOQ03

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -156,6 +156,13 @@
       "statement": "$-\\text{edgeSlope}((0,1),(2,0)) = \\text{leadingExponentFromSlope}(1,2) = 1/2$",
       "significance": "Closes the loop to the parent: the negative edge slope recovers the leading exponent 1/2 of the root x^{1/2} of Y²−x, exactly the parent's leadingExponentFromSlope definition.",
       "description": "Unfolds edgeSlope and the parent definition; both sides equal 1/2 by norm_num."
+    },
+    {
+      "name": "IsLowerVertex.eq_of_index",
+      "type": "theorem",
+      "statement": "$\\text{IsLowerVertex}(\\text{pts}, p) \\wedge \\text{IsLowerVertex}(\\text{pts}, q) \\wedge p_1 = q_1 \\implies p = q$",
+      "significance": "Well-definedness of the Newton polygon: at most one support point per Y-degree is a lower vertex, so the lower hull is the graph of a function i ↦ v. This is the combinatorial content of “the” Newton polygon being a single polygonal arc rather than an arbitrary point set, and it justifies the Newton–Puiseux step of collapsing each index-fibre to its lowest point before tracing edges.",
+      "description": "Two lower vertices with the same index are equal. Proved from IsLowerVertex.le_of_sameIndex, which shows a lower vertex is the minimum-valuation support point in its index-fibre (the supporting line, evaluated at the shared index, sits at the vertex and weakly below every competitor)."
     }
   ],
   "references": [
@@ -213,12 +220,13 @@
       "Mathlib.Data.List.MinMax"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 277,
+    "lineCount": 407,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 22,
     "definitionCount": 4,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sorryCount": 0
   },
   "conclusion": {
     "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, the lower-edge predicate IsLowerEdge with the edge↔vertex bridge and the slope-determination lemma slope_eq_edgeSlope, and — the combinatorial heart — convexity of the polygon (edgeSlope_mono) yielding sorted root valuations (rootValuation_antitone), all validated on the Y²−x example whose single segment is a genuine lower edge tying the slope to the parent's leadingExponentFromSlope. All 16 theorems and 4 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",


### PR DESCRIPTION
## Summary

One research iteration on **puiseux-theorem-oq-03** (combinatorial Newton polygon for the Newton–Puiseux algorithm). Two things:

1. **New result — the Newton polygon is well-defined as a function of the index.** Adds the layer showing that distinct support points can never both be lower vertices at the same `Y`-degree, so the lower hull is the graph of a function `i ↦ v` rather than an arbitrary point set.
2. **Drift repair.** The previous endpoint-theorem commit (#30874) shipped *build-unverified*. Its `isLowerVertex_of_leftmost/rightmost` proofs broke against the current Mathlib pin because `List.not_mem_nil` dropped its explicit argument. Fixed at both sites; the **whole file now type-checks**.

## New theorems (all 0-sorry, 0-axiom)

- `IsLowerVertex.le_of_sameIndex` — a lower vertex is the minimum-valuation support point in its index-fibre.
- `IsLowerVertex.eq_of_index` — two lower vertices with the same index are equal ⟹ lower hull = graph of `i ↦ v`. This is the combinatorial content of "*the*" Newton polygon being a single polygonal arc, and it justifies collapsing each index-fibre to its lowest point before tracing edges.
- `ysqMinusX_high_not_vertex` — worked counter-check: a spurious `(0,5)` above the constant term of `Y²−x` is not a vertex.

## Verification

- Docker build blocked by corrupted containerd storage (`meta.db` I/O error), so verified via `lake env lean` against the main-repo Mathlib olean cache (lean v4.26.0).
- File compiles **exit 0, no errors, no sorries** (only benign unused-variable linter warnings inherited from the parent).
- `#print axioms` on every new and repaired theorem: `[propext, Classical.choice, Quot.sound]` only — **0 mathematical axioms**, no `sorryAx`/`Lean.ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)