### PR TITLE
research(erdos-307-oq-02-oq-01): prove prime_sets_disjoint [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1887,6 +1887,7 @@ import Proofs.Erdos305Problem
 import Proofs.Erdos306Problem
 import Proofs.Erdos307Aristotle
 import Proofs.Erdos307OQ02
+import Proofs.Erdos307OQ02OQ01
 import Proofs.Erdos307Problem
 import Proofs.Erdos308OQ03
 import Proofs.Erdos308Problem

--- a/proofs/Proofs/Erdos307OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos307OQ02OQ01.lean
@@ -1,0 +1,171 @@
+import Mathlib
+
+/-
+# Erdős 307 — OQ-02-OQ-01: Disjointness of Prime Solution Sets
+
+## Research Problem: erdos-307-oq-02-oq-01
+
+Discharges the `prime_sets_disjoint` sorry documented in `Erdos307OQ02.lean`:
+
+  If P and Q are finite sets of primes with
+    (Σ_{p ∈ P} 1/p) · (Σ_{q ∈ Q} 1/q) = 1,
+  then P ∩ Q = ∅.
+
+The documented approach was "p-adic valuation theory". We give a fully
+elementary, axiom-free proof that captures exactly the p-adic content
+without invoking `padicValRat`:
+
+  * Write Σ_{p ∈ P} 1/p = NP / DP where
+      DP := ∏_{p ∈ P} p          (squarefree, the denominator)
+      NP := Σ_{p ∈ P} ∏_{q ≠ p} q (the numerator).
+  * The hypothesis (NP/DP)(NQ/DQ) = 1 clears denominators to the INTEGER
+    identity  NP · NQ = DP · DQ.
+  * For a prime p₀ ∈ P, reducing NP modulo p₀ kills every summand except
+    the q = p₀ term (which is a product of primes all ≠ p₀, hence a unit
+    in 𝔽_{p₀}). So p₀ ∤ NP. This is precisely v_{p₀}(Σ 1/p) = -1.
+  * If p₀ ∈ P ∩ Q then p₀ ∤ NP and p₀ ∤ NQ, so p₀ ∤ NP·NQ; but p₀ ∣ DP
+    and p₀ ∣ DQ give p₀ ∣ DP·DQ = NP·NQ. Contradiction.
+
+Tags: number-theory, primes, p-adic-valuation, egyptian-fractions
+-/
+
+open Finset BigOperators
+
+namespace Erdos307OQ02OQ01
+
+-- ============================================================
+-- Part I: Setup (mirrors the parent file)
+-- ============================================================
+
+/-- Sum of reciprocals of elements in a finite set. -/
+noncomputable def reciprocalSum (S : Finset ℕ) : ℚ :=
+  ∑ n ∈ S, (n : ℚ)⁻¹
+
+/-- Product of two reciprocal sums. -/
+noncomputable def reciprocalProduct (P Q : Finset ℕ) : ℚ :=
+  reciprocalSum P * reciprocalSum Q
+
+/-- A set of primes: every element is prime. -/
+def IsSetOfPrimes (S : Finset ℕ) : Prop :=
+  ∀ p ∈ S, Nat.Prime p
+
+/-- The integer numerator of `reciprocalSum`:  Σ_{p ∈ P} ∏_{q ∈ P\{p}} q. -/
+def primeNumer (P : Finset ℕ) : ℕ :=
+  ∑ p ∈ P, ∏ q ∈ P.erase p, q
+
+/-- The integer denominator of `reciprocalSum`:  ∏_{p ∈ P} p. -/
+def primeDenom (P : Finset ℕ) : ℕ :=
+  ∏ p ∈ P, p
+
+-- ============================================================
+-- Part II: The numerator / denominator identity over ℚ
+-- ============================================================
+
+/-- Clearing denominators:  (Σ 1/p) · (∏ p) = Σ_{p} ∏_{q ≠ p} q.
+    Requires only that no element is `0` (true for primes). -/
+lemma reciprocalSum_mul_denom (P : Finset ℕ) (hP : ∀ p ∈ P, p ≠ 0) :
+    reciprocalSum P * (primeDenom P : ℚ) = (primeNumer P : ℚ) := by
+  unfold reciprocalSum primeDenom primeNumer
+  push_cast
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro p hp
+  have hpne : (p : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (hP p hp)
+  rw [← Finset.mul_prod_erase P (fun q => (q : ℚ)) hp, inv_mul_cancel_left₀ hpne]
+
+/-- The cleared-denominator INTEGER identity.  From `(Σ1/p)(Σ1/q) = 1` we get
+    `NP · NQ = DP · DQ` in ℕ. -/
+lemma primeNumer_mul_eq (P Q : Finset ℕ)
+    (hP : ∀ p ∈ P, p ≠ 0) (hQ : ∀ q ∈ Q, q ≠ 0)
+    (h : reciprocalProduct P Q = 1) :
+    primeNumer P * primeNumer Q = primeDenom P * primeDenom Q := by
+  have hA := reciprocalSum_mul_denom P hP
+  have hB := reciprocalSum_mul_denom Q hQ
+  unfold reciprocalProduct at h
+  have key : (primeNumer P : ℚ) * (primeNumer Q : ℚ)
+      = (primeDenom P : ℚ) * (primeDenom Q : ℚ) := by
+    have e : (primeNumer P : ℚ) * (primeNumer Q : ℚ)
+        = (reciprocalSum P * reciprocalSum Q)
+            * ((primeDenom P : ℚ) * (primeDenom Q : ℚ)) := by
+      rw [← hA, ← hB]; ring
+    rw [e, h, one_mul]
+  exact_mod_cast key
+
+-- ============================================================
+-- Part III: The p-adic core — p₀ ∤ numerator
+-- ============================================================
+
+/-- For a prime `p₀ ∈ P` (with `P` a set of primes), `p₀` does NOT divide the
+    numerator `NP`.  Equivalently `v_{p₀}(Σ_{p∈P} 1/p) = -1`.
+
+    Proof: reduce `NP = Σ_p ∏_{q≠p} q` modulo `p₀` in the field `𝔽_{p₀}`.
+    Every summand with `p ≠ p₀` contains the factor `p₀`, hence vanishes; the
+    `p = p₀` summand is `∏_{q ≠ p₀} q`, a product of primes all distinct from
+    `p₀`, hence a nonzero product in the field. -/
+lemma prime_not_dvd_primeNumer (P : Finset ℕ) (hP : IsSetOfPrimes P)
+    {p₀ : ℕ} (hp₀ : p₀ ∈ P) : ¬ (p₀ ∣ primeNumer P) := by
+  have hp₀prime : Nat.Prime p₀ := hP p₀ hp₀
+  haveI : Fact (Nat.Prime p₀) := ⟨hp₀prime⟩
+  haveI : NeZero p₀ := ⟨hp₀prime.pos.ne'⟩
+  -- Reduce `NP` modulo `p₀`: only the `p = p₀` summand survives.
+  have hcast : ((primeNumer P : ℕ) : ZMod p₀) = ∏ q ∈ P.erase p₀, (q : ZMod p₀) := by
+    unfold primeNumer
+    push_cast
+    exact Finset.sum_eq_single_of_mem p₀ hp₀ (fun b _ hbne =>
+      Finset.prod_eq_zero (Finset.mem_erase.mpr ⟨Ne.symm hbne, hp₀⟩)
+        (ZMod.natCast_self p₀))
+  -- That surviving product is a nonempty product of nonzero units → nonzero.
+  have hne : ((primeNumer P : ℕ) : ZMod p₀) ≠ 0 := by
+    rw [hcast, Finset.prod_ne_zero_iff]
+    intro q hq
+    rw [Finset.mem_erase] at hq
+    have hqprime : Nat.Prime q := hP q hq.2
+    rw [Ne, ZMod.natCast_eq_zero_iff]
+    exact fun hdvdq => hq.1 ((Nat.prime_dvd_prime_iff_eq hp₀prime hqprime).mp hdvdq).symm
+  -- A divisor would force the cast to vanish.
+  intro hdvd
+  exact hne ((ZMod.natCast_eq_zero_iff _ _).mpr hdvd)
+
+-- ============================================================
+-- Part IV: Main theorem
+-- ============================================================
+
+/-- **prime_sets_disjoint** (was a documented sorry in `Erdos307OQ02.lean`).
+
+    If `P, Q` are finite sets of primes whose reciprocal sums multiply to `1`,
+    then `P ∩ Q = ∅`. -/
+theorem prime_sets_disjoint {P Q : Finset ℕ} (hP : IsSetOfPrimes P)
+    (hQ : IsSetOfPrimes Q) (hPQ : reciprocalProduct P Q = 1) :
+    P ∩ Q = ∅ := by
+  rw [Finset.eq_empty_iff_forall_notMem]
+  intro p₀ hmem
+  rw [Finset.mem_inter] at hmem
+  obtain ⟨hp₀P, hp₀Q⟩ := hmem
+  have hp₀prime : Nat.Prime p₀ := hP p₀ hp₀P
+  -- p₀ divides neither numerator.
+  have hnP : ¬ p₀ ∣ primeNumer P := prime_not_dvd_primeNumer P hP hp₀P
+  have hnQ : ¬ p₀ ∣ primeNumer Q := prime_not_dvd_primeNumer Q hQ hp₀Q
+  have hnPQ : ¬ p₀ ∣ primeNumer P * primeNumer Q := by
+    rw [hp₀prime.dvd_mul]; exact not_or.mpr ⟨hnP, hnQ⟩
+  -- but p₀ divides both denominators, hence their product.
+  have hdP : p₀ ∣ primeDenom P := by
+    unfold primeDenom; exact Finset.dvd_prod_of_mem (fun p => p) hp₀P
+  have heq := primeNumer_mul_eq P Q
+    (fun p hp => (hP p hp).pos.ne') (fun q hq => (hQ q hq).pos.ne') hPQ
+  have hdvd : p₀ ∣ primeNumer P * primeNumer Q := by
+    rw [heq]; exact hdP.mul_right _
+  exact hnPQ hdvd
+
+/-
+  Result: `prime_sets_disjoint` is fully proved — 0 sorries, 0 axioms.
+
+  This discharges item (1) of "Part VI: Documentation of Remaining Sorries"
+  in `Erdos307OQ02.lean`.  The p-adic valuation content (v_{p₀} = -1 for each
+  p₀ in a prime-reciprocal sum) is captured elementarily by a single mod-p₀
+  reduction in `prime_not_dvd_primeNumer`, avoiding any `padicValRat` machinery.
+
+  Remaining from the parent: `prime_set_size_lower_bound` (|P ∪ Q| ≥ 60), which
+  needs a verified Mertens-type computational bound and is independent of this.
+-/
+
+end Erdos307OQ02OQ01

--- a/research/problems/erdos-307-oq-02-oq-01/knowledge.md
+++ b/research/problems/erdos-307-oq-02-oq-01/knowledge.md
@@ -1,0 +1,51 @@
+# erdos-307-oq-02-oq-01 — Prove prime_sets_disjoint via p-adic valuation
+
+**Status:** COMPLETED (0 sorries, 0 axioms — verified via `lake env lean`, Docker down)
+
+## Problem
+
+Discharge the `prime_sets_disjoint` sorry documented in `Erdos307OQ02.lean`:
+if `P, Q` are finite sets of primes with `(Σ_{p∈P} 1/p)(Σ_{q∈Q} 1/q) = 1`,
+then `P ∩ Q = ∅`. Parent flagged it as "requires Mathlib's p-adic valuation theory".
+
+## Session 2026-06-27 (Session 1) — COMPLETED
+
+**Mode:** FRESH
+**Outcome:** completed (theorem fully proved, axiom-free)
+
+### What I Did
+- Recognized the p-adic content `v_{p₀}(Σ 1/p) = -1` can be captured elementarily
+  without `padicValRat`, as a single reduction mod `p₀` in the field `𝔽_{p₀}`.
+- Wrote `proofs/Proofs/Erdos307OQ02OQ01.lean` (171 lines, 5 defs, 4 lemmas/theorems):
+  - `reciprocalSum_mul_denom`: `(Σ 1/p)·(∏ p) = Σ_p ∏_{q≠p} q` over ℚ (via `Finset.mul_prod_erase`, `inv_mul_cancel_left₀`).
+  - `primeNumer_mul_eq`: clears denominators in the product-1 hypothesis to the
+    INTEGER identity `NP·NQ = DP·DQ` (cast down via `exact_mod_cast`).
+  - `prime_not_dvd_primeNumer`: the p-adic core — `p₀ ∤ NP` for prime `p₀ ∈ P`,
+    by reducing `NP` in `ZMod p₀`: non-`p₀` summands carry the factor `p₀` and
+    vanish (`Finset.prod_eq_zero` + `ZMod.natCast_self`); survivor `∏_{q≠p₀} q`
+    is a product of units (`Finset.prod_ne_zero_iff` + `ZMod.natCast_eq_zero_iff`
+    + `Nat.prime_dvd_prime_iff_eq`).
+  - `prime_sets_disjoint`: a shared prime `p₀` divides `DP·DQ` but neither `NP`
+    nor `NQ`, contradicting `NP·NQ = DP·DQ`.
+- Registered in `proofs/Proofs.lean`; added gallery entry `src/data/proofs/erdos-307-oq-02-oq-01/`.
+
+### Key Findings
+- The valuation fact `v_{p₀}(Σ_{p∈P} 1/p) = -1` ⟺ "`p₀ ∤ NP`", a one-line modular reduction.
+- Clearing denominators turns the ℚ-hypothesis into a clean ℕ-identity, sidestepping
+  rational arithmetic entirely for the divisibility contradiction.
+- The argument needs no size/structure assumptions beyond primality — works for all finite prime sets.
+
+### Files Modified
+- `proofs/Proofs/Erdos307OQ02OQ01.lean` (new)
+- `proofs/Proofs.lean` (import)
+- `src/data/proofs/erdos-307-oq-02-oq-01/meta.json` (new)
+
+### Verification
+- Docker build blocked (containerd `meta.db` I/O error). Verified via main-repo
+  Mathlib `.olean` cache: `lake env lean` EXIT 0, no warnings.
+- `#print axioms prime_sets_disjoint` → `[propext, Classical.choice, Quot.sound]`
+  (no `sorryAx`, no `Lean.ofReduceBool`).
+
+### Next Steps
+- Remaining parent sorry `prime_set_size_lower_bound` (|P ∪ Q| ≥ 60) needs a
+  verified Mertens-type bound on `Σ_{p≤281} 1/p ≈ 2.009` — independent of this work.

--- a/src/data/proofs/erdos-307-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-307-oq-02-oq-01/meta.json
@@ -1,0 +1,117 @@
+{
+  "id": "erdos-307-oq-02-oq-01",
+  "title": "Prime Reciprocal Products: Disjointness of Solution Sets",
+  "slug": "erdos-307-oq-02-oq-01",
+  "description": "Discharges the prime_sets_disjoint sorry from Erdős 307 OQ-02: if P, Q are finite sets of primes with (Σ 1/p)(Σ 1/q) = 1 then P ∩ Q = ∅. The documented p-adic valuation argument is captured elementarily via a single mod-p₀ reduction in 𝔽_{p₀}.",
+  "meta": {
+    "author": "Research (prime_sets_disjoint for Erdős 307)",
+    "sourceUrl": "https://erdosproblems.com/307",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos307OQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "p-adic",
+      "egyptian-fractions",
+      "erdos",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 171,
+    "assumptions": "0 sorries, 0 axioms (depends only on propext, Classical.choice, Quot.sound). Fully verified.",
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "prime_sets_disjoint proved (was a documented sorry in OQ-02)",
+      "Integer numerator/denominator identity for prime-reciprocal sums (reciprocalSum_mul_denom)",
+      "Cleared-denominator integer identity NP·NQ = DP·DQ from the product-1 hypothesis (primeNumer_mul_eq)",
+      "Elementary p-adic core: p₀ ∤ NP via mod-p₀ reduction in 𝔽_{p₀} (prime_not_dvd_primeNumer)"
+    ],
+    "theoremCount": 4,
+    "definitionCount": 5
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #307 asks whether two finite sets of primes $P, Q$ can satisfy $(\\sum_{p \\in P} 1/p)(\\sum_{q \\in Q} 1/q) = 1$. A natural structural constraint on any hypothetical solution is that $P$ and $Q$ must be disjoint: a shared prime would appear with reciprocal in both factors and break the rationality budget. The parent OQ-02 file documented this as `prime_sets_disjoint` but left it as a sorry, citing a need for 'Mathlib's p-adic valuation theory'.\n\nThis file discharges that sorry with a fully elementary, axiom-free proof. The key realization is that the entire p-adic content — namely $v_{p_0}(\\sum_{p \\in P} 1/p) = -1$ for each prime $p_0 \\in P$ — can be expressed without any `padicValRat` machinery, as a single reduction modulo $p_0$ in the finite field $\\mathbb{F}_{p_0}$.",
+    "problemStatement": "If P and Q are finite sets of primes with (Σ_{p∈P} 1/p)(Σ_{q∈Q} 1/q) = 1, then P ∩ Q = ∅.",
+    "text": "Writes each reciprocal sum as a fraction NP/DP with DP = ∏ p the squarefree denominator and NP = Σ_p ∏_{q≠p} q the numerator. The product-equals-1 hypothesis clears denominators to the integer identity NP·NQ = DP·DQ. A shared prime p₀ divides DP·DQ twice but divides neither numerator, a contradiction.",
+    "proofStrategy": "Clear denominators to get the integer identity NP·NQ = DP·DQ. Then show p₀ ∤ NP for any prime p₀ ∈ P by reducing NP modulo p₀ in 𝔽_{p₀}: every summand except the p=p₀ term contains the factor p₀ and vanishes, while the surviving term ∏_{q≠p₀} q is a product of units. If p₀ ∈ P ∩ Q then p₀ divides neither NP nor NQ, hence not NP·NQ — but p₀ divides both DP and DQ, hence DP·DQ = NP·NQ. Contradiction.",
+    "keyInsights": [
+      "The p-adic valuation v_{p₀}(Σ_{p∈P} 1/p) = -1 is captured elementarily as 'p₀ ∤ NP' — no padicValRat needed",
+      "Writing Σ_{p∈P} 1/p = NP/DP with DP = ∏_{p∈P} p (squarefree) and NP = Σ_p ∏_{q≠p} q clears denominators cleanly",
+      "The product-equals-1 hypothesis over ℚ casts down to the integer identity NP·NQ = DP·DQ via Nat.cast injectivity",
+      "Reducing NP modulo p₀ in the field 𝔽_{p₀} kills every summand except the p=p₀ term; that survivor ∏_{q≠p₀} q is a product of nonzero units, so p₀ ∤ NP",
+      "A shared prime p₀ ∈ P ∩ Q divides DP·DQ (twice) but neither numerator, so it cannot divide the equal product NP·NQ — the contradiction",
+      "The argument needs no special structure beyond the elements being prime: it works for any finite prime sets, independent of the size bound"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup",
+      "summary": "Defines reciprocalSum, reciprocalProduct, IsSetOfPrimes (mirroring the parent), plus the integer numerator primeNumer = Σ_p ∏_{q≠p} q and denominator primeDenom = ∏ p.",
+      "startLine": 36,
+      "endLine": 58,
+      "mathContext": "For a finite prime set $P$, $\\sum_{p \\in P} 1/p = N_P / D_P$ where $D_P = \\prod_{p \\in P} p$ is squarefree and $N_P = \\sum_{p \\in P} \\prod_{q \\in P \\setminus \\{p\\}} q$. These are exactly the numerator and denominator one obtains by placing the reciprocal sum over a common denominator."
+    },
+    {
+      "id": "identity",
+      "title": "Numerator/Denominator Identity",
+      "summary": "Proves reciprocalSum_mul_denom: (Σ 1/p)·(∏ p) = Σ_p ∏_{q≠p} q over ℚ, then primeNumer_mul_eq: clearing denominators in the product-1 hypothesis yields the integer identity NP·NQ = DP·DQ.",
+      "startLine": 60,
+      "endLine": 92,
+      "mathContext": "Multiplying $\\sum_{p \\in P} 1/p$ by $D_P = \\prod_{p \\in P} p$ and using $\\frac{1}{p}\\prod_{q \\in P} q = \\prod_{q \\neq p} q$ (via Finset.mul_prod_erase) gives $N_P$. Applying this to both factors of $(\\Sigma_{1/P})(\\Sigma_{1/Q}) = 1$ and multiplying through by $D_P D_Q$ produces $N_P N_Q = D_P D_Q$ over $\\mathbb{Q}$; Nat.cast injectivity transports it to $\\mathbb{N}$."
+    },
+    {
+      "id": "padic-core",
+      "title": "The p-adic Core: p₀ ∤ Numerator",
+      "summary": "Proves prime_not_dvd_primeNumer: for a prime p₀ ∈ P, p₀ does not divide NP. This is the elementary form of v_{p₀}(Σ 1/p) = -1, proved by reduction modulo p₀ in 𝔽_{p₀}.",
+      "startLine": 94,
+      "endLine": 127,
+      "mathContext": "Reduce $N_P = \\sum_{p} \\prod_{q \\neq p} q$ in $\\mathbb{F}_{p_0}$. Every summand with $p \\neq p_0$ contains the factor $p_0$ (since $p_0 \\in P \\setminus \\{p\\}$) and so vanishes. The surviving $p = p_0$ summand is $\\prod_{q \\in P \\setminus \\{p_0\\}} q$, a product of primes all distinct from $p_0$, hence a product of nonzero elements of the field $\\mathbb{F}_{p_0}$ — nonzero. Therefore $\\bar{N_P} \\neq 0$, i.e. $p_0 \\nmid N_P$."
+    },
+    {
+      "id": "main",
+      "title": "Disjointness",
+      "summary": "Proves prime_sets_disjoint: P ∩ Q = ∅. A shared prime p₀ would divide DP·DQ but neither NP nor NQ, contradicting NP·NQ = DP·DQ.",
+      "startLine": 129,
+      "endLine": 157,
+      "mathContext": "Suppose $p_0 \\in P \\cap Q$. By the core lemma $p_0 \\nmid N_P$ and $p_0 \\nmid N_Q$, so $p_0 \\nmid N_P N_Q$ (as $p_0$ is prime). But $p_0 \\mid D_P$ (since $p_0 \\in P$) and $p_0 \\mid D_Q$, so $p_0 \\mid D_P D_Q = N_P N_Q$. Contradiction, so $P \\cap Q = \\emptyset$."
+    }
+  ],
+  "conclusion": {
+    "summary": "prime_sets_disjoint is fully proved, axiom-free. The p-adic valuation argument the parent file flagged as needing 'Mathlib's p-adic theory' reduces to a single mod-p₀ computation in a finite field.",
+    "openQuestions": [
+      "Prove the remaining parent sorry prime_set_size_lower_bound (|P ∪ Q| ≥ 60) via a verified Mertens-type bound on Σ_{p≤281} 1/p",
+      "Does disjointness combined with the size bound rule out all small prime solutions, narrowing the search for Erdős 307?"
+    ],
+    "implications": "Discharges item (1) of the parent's 'Remaining Sorries'. It demonstrates a recurring pattern: results posed as requiring heavy p-adic valuation machinery often have elementary finite-field formulations. The valuation fact v_{p₀}(Σ 1/p) = -1 becomes a one-line modular reduction, keeping the proof axiom-free and self-contained."
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-307-oq-02",
+      "relationship": "parent-problem",
+      "description": "Parent: discharges the prime_sets_disjoint sorry documented in OQ-02"
+    },
+    {
+      "targetId": "erdos-307",
+      "relationship": "ancestor-problem",
+      "description": "Root: Erdős Problem #307 on prime reciprocal products"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos307OQ02OQ01",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 5,
+    "path": "Proofs/Erdos307OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-307-oq-02-oq-01.json
+++ b/src/data/research/problems/erdos-307-oq-02-oq-01.json
@@ -1,0 +1,47 @@
+{
+  "id": "erdos-307-oq-02-oq-01",
+  "name": "Erdős 307: prove prime_sets_disjoint via p-adic valuation",
+  "parentId": "erdos-307-oq-02",
+  "status": "completed",
+  "knowledge": {
+    "score": 7,
+    "insights": [
+      "The p-adic fact v_{p₀}(Σ_{p∈P} 1/p) = -1 is equivalent to 'p₀ ∤ NP' where NP = Σ_p ∏_{q≠p} q — no padicValRat needed",
+      "Writing Σ_{p∈P} 1/p = NP/DP with DP = ∏ p (squarefree) and NP = Σ_p ∏_{q≠p} q clears denominators cleanly",
+      "(Σ1/P)(Σ1/Q) = 1 over ℚ casts down to the integer identity NP·NQ = DP·DQ via Nat.cast injectivity",
+      "Reducing NP mod p₀ in the field 𝔽_{p₀} kills every summand except p=p₀; the survivor ∏_{q≠p₀} q is a product of units, so p₀ ∤ NP",
+      "A shared prime p₀ ∈ P∩Q divides DP·DQ but neither numerator, contradicting NP·NQ = DP·DQ",
+      "The disjointness argument needs no size/structure beyond primality — works for all finite prime sets"
+    ],
+    "builtItems": [
+      "reciprocalSum_mul_denom: (Σ 1/p)·(∏ p) = Σ_p ∏_{q≠p} q over ℚ",
+      "primeNumer_mul_eq: integer identity NP·NQ = DP·DQ from the product-1 hypothesis",
+      "prime_not_dvd_primeNumer: p₀ ∤ NP via mod-p₀ reduction in ZMod p₀ (the p-adic core)",
+      "prime_sets_disjoint: P ∩ Q = ∅ — the parent's documented sorry, now fully proved (0 axioms)"
+    ],
+    "progressSummary": "COMPLETE: prime_sets_disjoint proved axiom-free (depends only on propext/Classical.choice/Quot.sound). Discharges item 1 of Erdos307OQ02 remaining sorries. Verified via lake env lean (Docker down).",
+    "nextSteps": [
+      "Remaining parent sorry prime_set_size_lower_bound (|P∪Q|≥60) needs a verified Mertens-type bound on Σ_{p≤281} 1/p ≈ 2.009",
+      "Combine disjointness with a size bound to constrain hypothetical Erdős 307 prime solutions"
+    ]
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos307OQ02OQ01.lean",
+      "filename": "Erdos307OQ02OQ01.lean",
+      "lineCount": 171,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos307OQ02OQ01.lean"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-307",
+    "erdos-307-oq-02",
+    "erdos-307-oq-02-oq-01"
+  ],
+  "lastUpdate": "2026-06-27T20:30:00.000Z"
+}


### PR DESCRIPTION
## Summary

Discharges the `prime_sets_disjoint` sorry documented in `Erdos307OQ02.lean` (item 1 of its "Remaining Sorries").

**Claim.** If `P, Q` are finite sets of primes with `(Σ_{p∈P} 1/p)(Σ_{q∈Q} 1/q) = 1`, then `P ∩ Q = ∅`.

The parent flagged this as requiring "Mathlib's p-adic valuation theory". This proof captures exactly the p-adic content — `v_{p₀}(Σ 1/p) = -1` for each prime `p₀ ∈ P` — **elementarily**, as a single reduction modulo `p₀` in the finite field `𝔽_{p₀}`, with **no `padicValRat` machinery**.

## Proof structure (`proofs/Proofs/Erdos307OQ02OQ01.lean`, 171 lines)

1. `reciprocalSum_mul_denom` — `(Σ 1/p)·(∏ p) = Σ_p ∏_{q≠p} q` over ℚ (clears denominators).
2. `primeNumer_mul_eq` — from `(Σ1/P)(Σ1/Q)=1`, casts down to the **integer identity** `NP·NQ = DP·DQ`.
3. `prime_not_dvd_primeNumer` — the core: `p₀ ∤ NP` for prime `p₀ ∈ P`. Reducing `NP = Σ_p ∏_{q≠p} q` in `ZMod p₀`, every summand except `p=p₀` carries the factor `p₀` and vanishes; the survivor `∏_{q≠p₀} q` is a product of nonzero units.
4. `prime_sets_disjoint` — a shared prime `p₀` divides `DP·DQ` (twice) but neither `NP` nor `NQ`, contradicting `NP·NQ = DP·DQ`.

## Verification

- **Docker storage is corrupt** (containerd `meta.db` I/O error) — verified instead via `lake env lean` against the main-repo Mathlib `.olean` cache (Lean 4.26.0): **EXIT 0, zero warnings**.
- `#print axioms prime_sets_disjoint` → `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `Lean.ofReduceBool`**.
- **0 sorries, 0 axioms.**

## Files
- `proofs/Proofs/Erdos307OQ02OQ01.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/erdos-307-oq-02-oq-01/meta.json` (new gallery entry)
- `research/problems/erdos-307-oq-02-oq-01/knowledge.md` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)