### PR TITLE
research(puiseux-theorem-oq-03): dominant-edge-slope canonicity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -418,4 +418,48 @@ theorem ysqMinusX_exists_edge : ∃ q, IsLowerEdge YsqMinusX (0, 1) q :=
     ⟨(2, 0), by simp [YsqMinusX], by decide⟩
     (by intro q hq hne; fin_cases hq <;> simp_all)
 
+/-! ### The dominant edge slope is canonical
+
+`exists_isLowerEdge_of_leftmost` builds *a* lower edge out of the left endpoint by
+choosing the right endpoint of least slope.  The lemmas here show that this choice
+does not matter for the *slope*: every lower edge out of a fixed left endpoint `p`
+realizes the **same**, minimal, slope.  Consequently the leading root valuation the
+parent reads off the first edge (`leadingExponentFromSlope`) is well-defined — it is
+a property of the vertex `p`, not of the particular right endpoint used to name the
+edge.  This is the structural fact that makes "*the* dominant slope" meaningful and
+is a prerequisite for any hull-construction recursion: each recursion step is allowed
+to pick any valid right endpoint and still computes the canonical slope sequence. -/
+
+/-- **A lower edge realizes the least slope leaving its left endpoint.**  For a lower
+edge `(p, q)` and any support point `r` strictly to the right of `p`,
+`edgeSlope p q ≤ edgeSlope p r`.  The dominant edge out of `p` is the steepest
+descent of the lower hull. -/
+theorem IsLowerEdge.edgeSlope_le_right {pts : List SupportPoint} {p q r : SupportPoint}
+    (h : IsLowerEdge pts p q) (hr : r ∈ pts) (hpr : (p.1 : ℚ) < r.1) :
+    edgeSlope p q ≤ edgeSlope p r := by
+  obtain ⟨_, _, hlt, m, b, hpe, hqe, hsupp⟩ := h
+  have e1 : m = edgeSlope p q := slope_eq_edgeSlope hpe hqe (ne_of_lt hlt)
+  have hge := edgeSlope_ge_of_supportingLine hpe hr hsupp hpr
+  rwa [e1] at hge
+
+/-- **The dominant edge slope out of a vertex is well-defined.**  Any two lower edges
+sharing the same left endpoint `p` have equal slope: each is the minimal slope leaving
+`p`, so they bound each other. -/
+theorem lowerEdge_slope_unique {pts : List SupportPoint} {p q q' : SupportPoint}
+    (h : IsLowerEdge pts p q) (h' : IsLowerEdge pts p q') :
+    edgeSlope p q = edgeSlope p q' := by
+  have hpr : (p.1 : ℚ) < q.1 := by exact_mod_cast h.2.2.1
+  have hpr' : (p.1 : ℚ) < q'.1 := by exact_mod_cast h'.2.2.1
+  have le1 : edgeSlope p q ≤ edgeSlope p q' := h.edgeSlope_le_right h'.2.1 hpr'
+  have le2 : edgeSlope p q' ≤ edgeSlope p q := h'.edgeSlope_le_right h.2.1 hpr
+  linarith
+
+/-- **The leading root valuation is well-defined.**  Since the root valuation is the
+negative of the edge slope, `lowerEdge_slope_unique` says the valuation the parent
+reads off the dominant edge does not depend on the chosen right endpoint. -/
+theorem leadingRootValuation_well_defined {pts : List SupportPoint} {p q q' : SupportPoint}
+    (h : IsLowerEdge pts p q) (h' : IsLowerEdge pts p q') :
+    -edgeSlope p q = -edgeSlope p q' := by
+  rw [lowerEdge_slope_unique h h']
+
 end PuiseuxTheoremOQ03

--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -118,3 +118,20 @@ valuations for free.
 Verification recipe unchanged: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean
 Proofs/PuiseuxTheoremOQ03.lean` exits 0 (worktree `.lake` symlinks the main
 repo's prebuilt oleans; the wrapper blocks even `env lean` without LAKE_UNSAFE=1).
+
+## Session 2026-06-27 (researcher-3) — ACT: dominant-edge-slope canonicity (verified)
+
+**Mode**: BUILD (Docker containerd I/O error → `lake env lean`; 0-axiom).
+**Outcome**: progress (ACT) — +3 theorems, PuiseuxTheoremOQ03.lean now 465 LOC, 0 sorry, 0 axiom.
+
+- `IsLowerEdge.edgeSlope_le_right` — a lower edge realizes the **least** slope leaving its
+  left endpoint (`edgeSlope p q ≤ edgeSlope p r` for all support points `r` to the right).
+- `lowerEdge_slope_unique` — **the dominant edge slope out of a vertex is well-defined**: any
+  two lower edges sharing a left endpoint have equal slope.
+- `leadingRootValuation_well_defined` — the leading root valuation (−edge slope) is
+  independent of the chosen right endpoint.
+
+These make "the dominant slope" a property of the vertex, not of the named edge endpoint —
+the structural prerequisite for a hull-construction recursion. Next: peel-and-recurse hull
+builder + termination; algebraic Newton-polygon theorem still blocked on missing K((x))[Y]
+valuation API.

--- a/research/problems/puiseux-theorem-oq-03/state.md
+++ b/research/problems/puiseux-theorem-oq-03/state.md
@@ -1,25 +1,26 @@
 # Research State: puiseux-theorem-oq-03
 
 ## Current State
-**Phase**: OBSERVE
-**Path**: fast
-**Since**: 2026-05-12T13:53:16-07:00
-**Iteration**: 1
+**Phase**: ACT
+**Path**: full
+**Since**: 2026-06-27
+**Iteration**: continued (S2-B groundwork)
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Combinatorial Newton polygon (`PuiseuxTheoremOQ03.lean`, 465 LOC, 0 sorry, 0 axiom).
+This session added the **dominant-edge-slope canonicity** layer.
 
 ## Active Approach
-None yet.
-
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+Supporting-line predicate API for lower vertices/edges. New results:
+- `IsLowerEdge.edgeSlope_le_right`: an edge realizes the least slope leaving its left endpoint.
+- `lowerEdge_slope_unique`: any two lower edges from a fixed left endpoint have equal slope.
+- `leadingRootValuation_well_defined`: leading root valuation is endpoint-independent.
 
 ## Blockers
-None.
+- Docker containerd I/O error (verified via `lake env lean`).
+- Algebraic Newton-polygon theorem blocked on missing K((x))[Y] valuation API in Mathlib 4.26.0.
 
 ## Next Action
-Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.
-See FAST_PATH.md for protocol.
+- Peel-and-recurse hull builder: recurse on the sub-support right of the first edge's right
+  endpoint, certifying canonicity via `lowerEdge_slope_unique`; prove termination (support shrinks).
+- S2-B polynomial Newton–Puiseux reduction step + Y-degree-decrease termination measure.

--- a/src/data/research/problems/puiseux-theorem-oq-03.json
+++ b/src/data/research/problems/puiseux-theorem-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S2-B groundwork: added exists_isLowerEdge_of_leftmost (first lower edge from the left endpoint) to PuiseuxTheoremOQ03.lean, the first concrete hull-construction step. File now 421 lines / 21 theorems, still verified 0-sorry 0-axiom. Also repaired 3 List.not_mem_nil sites broken by a Mathlib-cache update. Remaining: full S2-B termination measure on polynomial reductions, and the algebraic Newton-polygon theorem (blocked on missing K((x))[Y] valuation API).",
+    "progressSummary": "S2-B groundwork continued. Newton-polygon file PuiseuxTheoremOQ03.lean now 465 lines / 24 theorems, still verified 0-sorry 0-axiom. Added the canonicity layer for the dominant edge: IsLowerEdge.edgeSlope_le_right (an edge realizes the minimal slope leaving its left endpoint), lowerEdge_slope_unique (any two lower edges from a fixed left endpoint have equal slope — 'the dominant slope' is well-defined), and leadingRootValuation_well_defined (the parent's leadingExponentFromSlope reads a canonical value independent of the chosen right endpoint). This is the structural prerequisite for a hull-construction recursion. Remaining: peel-and-recurse hull builder + S2-B polynomial reduction termination; algebraic Newton-polygon theorem still blocked on missing K((x))[Y] valuation API in Mathlib v4.26.0.",
     "builtItems": [
       "IsLowerVertex: supporting-line characterization of a Newton-polygon lower-hull vertex (algorithm-independent Prop)",
       "isLowerVertex_of_minimal: the min-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -37,14 +37,18 @@
       "edgeSlope + worked Y^2-x example: both support points are vertices, edge slope -1/2, leading exponent 1/2 = leadingExponentFromSlope 1 2",
       "Parent fix: corrected dangling /-- doc comment in PuiseuxTheorem.lean (file did not parse on main)",
       "exists_isLowerEdge_of_leftmost (PuiseuxTheoremOQ03.lean): leftmost support point -> genuine IsLowerEdge via List.argmin(edgeSlope p); first hull-construction step toward S2-B",
-      "Maintenance: fixed 3 List.not_mem_nil q sites broken by Mathlib cache update (explicit arg removed)"
+      "Maintenance: fixed 3 List.not_mem_nil q sites broken by Mathlib cache update (explicit arg removed)",
+      "PuiseuxTheoremOQ03.IsLowerEdge.edgeSlope_le_right — a lower edge realizes the least slope leaving its left endpoint",
+      "PuiseuxTheoremOQ03.lowerEdge_slope_unique — the dominant edge slope out of a vertex is well-defined (any two lower edges sharing a left endpoint have equal slope)",
+      "PuiseuxTheoremOQ03.leadingRootValuation_well_defined — the leading root valuation (−edge slope) is independent of the chosen right endpoint"
     ],
     "insights": [
       "Supporting-line predicate beats a verified convex-hull construction: same downstream value, far less proof burden, algorithm-agnostic.",
       "List.argmin + argmin_mem/le_of_mem_argmin gives vertex existence for nonempty support lists in a few lines.",
       "Model support points as Prod (N x Q), not a custom structure: fin_cases + norm_num then dispatch example goals cleanly.",
       "Edge existence reuses isLowerVertex_of_leftmost machinery verbatim: the argmin-of-edgeSlope supporting line through the leftmost point already passes through its argmin partner, so it is an edge, not merely a vertex witness.",
-      "Mathlib drift hazard: gallery .lean files verified months ago can silently break against an updated local olean cache (List.not_mem_nil dropped its explicit argument); prefer simp over name-specific applications for List membership-in-nil contradictions."
+      "Mathlib drift hazard: gallery .lean files verified months ago can silently break against an updated local olean cache (List.not_mem_nil dropped its explicit argument); prefer simp over name-specific applications for List membership-in-nil contradictions.",
+      "The dominant edge slope out of a vertex p is canonical: every lower edge from p realizes the SAME (minimal) slope, because the supporting line through p has the least slope leaving p (edgeSlope_ge_of_supportingLine). This means 'the dominant slope' / leading root valuation is a property of the vertex, not of the named right endpoint — a prerequisite for a hull-construction recursion that is free to pick any valid right endpoint."
     ],
     "mathlibGaps": [
       "No Newton polygon API in Mathlib 4.26.0 (no Polynomial.newtonPolygon / lowerConvexHull as combinatorial vertex data).",
@@ -52,11 +56,11 @@
       "No arithmetic-complexity model (Bürgisser-Clausen-Shokrollahi style) to state the Poteaux-Weimann Õ(d·δ) bound."
     ],
     "nextSteps": [
-      "Iterate hull construction: from exists_isLowerEdge_of_leftmost, peel the first edge and recurse on the sub-support to the right of its right endpoint (building the ordered vertex/edge list).",
-      "S2-B: define a polynomial Newton-Puiseux reduction step and prove the Y-degree strictly decreases (needs Laurent-series polynomial modeling).",
+      "Hull-construction recursion: from exists_isLowerEdge_of_leftmost peel the first edge and recurse on the sub-support right of its right endpoint, using lowerEdge_slope_unique to certify the slope sequence is canonical; prove the recursion terminates (support strictly shrinks).",
+      "S2-B: define a polynomial Newton–Puiseux reduction step and prove the Y-degree strictly decreases (needs Laurent-series polynomial modeling).",
       "Newton polygon theorem: negatives of lower-edge slopes = root valuations (blocked on missing valuation API on K((x))[Y] in Mathlib 4.26.0)."
     ],
-    "markdown": "# Knowledge Base: puiseux-theorem-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
+    "markdown": "# Knowledge Base: puiseux-theorem-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n\n\n## Session 2026-06-27 (researcher-3) — ACT: dominant-edge-slope canonicity (verified)\n\n**Mode**: BUILD (Docker containerd I/O error → verified via `lake env lean`; `#print axioms`\n= only propext/Classical.choice/Quot.sound, i.e. 0-axiom).\n**Outcome**: progress (ACT) — +3 theorems on PuiseuxTheoremOQ03.lean (465 LOC, 0 sorry, 0 axiom).\n\n### What I added\n- `IsLowerEdge.edgeSlope_le_right` — a lower edge `(p,q)` realizes the **least** slope\n  leaving `p`: `edgeSlope p q ≤ edgeSlope p r` for every support point `r` to the right.\n  (One line from `edgeSlope_ge_of_supportingLine` plus `slope_eq_edgeSlope`.)\n- `lowerEdge_slope_unique` — **the dominant edge slope out of a vertex is well-defined**:\n  any two lower edges sharing the left endpoint `p` have equal slope (each is minimal, so\n  they bound each other).\n- `leadingRootValuation_well_defined` — the leading root valuation `−edgeSlope` the parent\n  reads off the first edge is independent of the chosen right endpoint.\n\n### Why it matters\nMakes \"*the* dominant slope\" / leading exponent a property of the vertex rather than of the\narbitrarily-named edge endpoint — the structural prerequisite for a hull-construction\nrecursion that picks any valid right endpoint and still computes the canonical slope sequence.\n\n### Next\n- Peel-and-recurse hull builder (recurse on sub-support right of the edge's right endpoint),\n  using `lowerEdge_slope_unique` to certify canonicity; prove termination.\n",
     "archivedSessions": [
       {
         "filename": "2026-05-12-s01-galois-scoping.md",
@@ -117,6 +121,18 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PuiseuxTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/PuiseuxTheoremOQ03.lean",
+      "filename": "PuiseuxTheoremOQ03.lean",
+      "lineCount": 465,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PuiseuxTheoremOQ03.lean"
     }
-  ]
+  ],
+  "lastUpdate": "2026-06-27"
 }


### PR DESCRIPTION
## Summary

Continues the combinatorial Newton-polygon work for `puiseux-theorem-oq-03` (*"Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?"*). The existing `PuiseuxTheoremOQ03.lean` builds lower vertices/edges via a supporting-line predicate and constructs the dominant edge out of the left endpoint (`exists_isLowerEdge_of_leftmost`). This PR adds the **canonicity layer** showing that the dominant slope is intrinsic.

File is now 465 LOC, **0 sorries, 0 axioms**.

## New theorems (all verified, 0-axiom)

- `IsLowerEdge.edgeSlope_le_right` — a lower edge `(p, q)` realizes the **least** slope leaving its left endpoint: `edgeSlope p q ≤ edgeSlope p r` for every support point `r` strictly to the right of `p`. The dominant edge is the steepest descent of the lower hull.
- `lowerEdge_slope_unique` — **the dominant edge slope out of a vertex is well-defined**: any two lower edges sharing the left endpoint `p` have equal slope (each is the minimal slope leaving `p`, so they bound each other).
- `leadingRootValuation_well_defined` — the leading root valuation (`−edge slope`) the parent reads off the first edge is independent of the chosen right endpoint.

## Why it matters

The parent's `leadingExponentFromSlope` reads the leading Puiseux exponent off the first edge slope. These lemmas certify that this value is a property of the **vertex**, not of the arbitrarily-named right endpoint used to describe the edge — the structural prerequisite for a hull-construction recursion that is free to pick any valid right endpoint and still computes the canonical slope sequence.

## Verification

Docker's containerd is currently throwing an I/O error, so this was verified via `lake env lean` against the main-repo Mathlib olean cache. `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` for all three new theorems — 0-axiom by project policy (no `Lean.ofReduceBool`/`sorryAx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)