### PR TITLE
research(erdos-340-greedy-sidon-oq-05): B_h downward closure in h [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos340GreedySidonOQ05.lean
+++ b/proofs/Proofs/Erdos340GreedySidonOQ05.lean
@@ -99,6 +99,58 @@ theorem isBh_one (A : Finset ℕ) : IsBh 1 A := by
   simp only [ha, hb, Multiset.sum_singleton] at hst ⊢
   rw [hst]
 
+/-! ## Part 1b: Downward closure in `h` -/
+
+/-- **Downward closure (one step).**  A `B_{h+1}` set is also `B_h`.
+
+*Proof.*  If `A` is empty the claim is degenerate (`A.sym h` is a subsingleton for
+`h = 0` and empty for `h ≥ 1`).  Otherwise fix any `a ∈ A`.  Given two `h`-multisets
+`s, t ∈ A.sym h` with equal sums, the `(h+1)`-multisets `a ::ₛ s` and `a ::ₛ t` lie
+in `A.sym (h+1)` and have equal sums (each is the common sum plus `a`); the `B_{h+1}`
+injectivity forces `a ::ₛ s = a ::ₛ t`, and cancelling the head `a`
+(`Sym.cons_inj_right`) gives `s = t`. ∎ -/
+theorem IsBh.of_succ {h : ℕ} {A : Finset ℕ} (hA : IsBh (h + 1) A) : IsBh h A := by
+  rcases A.eq_empty_or_nonempty with rfl | ⟨a, haA⟩
+  · -- `A = ∅`: the domain `∅.sym h` has at most one element.
+    intro s hs t ht _
+    rcases Nat.eq_zero_or_pos h with rfl | hpos
+    · exact Subsingleton.elim s t
+    · obtain ⟨k, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hpos.ne'
+      rw [Finset.sym_empty] at hs
+      exact absurd hs (Finset.notMem_empty s)
+  · -- Append a fixed `a ∈ A` to reduce to `B_{h+1}` injectivity.
+    intro s hs t ht hsum
+    have hsmem : ∀ x ∈ s, x ∈ A := Finset.mem_sym_iff.mp hs
+    have htmem : ∀ x ∈ t, x ∈ A := Finset.mem_sym_iff.mp ht
+    have hs' : a ::ₛ s ∈ A.sym (h + 1) := by
+      rw [Finset.mem_sym_iff]
+      intro x hx
+      rcases Sym.mem_cons.mp hx with rfl | hxs
+      · exact haA
+      · exact hsmem x hxs
+    have ht' : a ::ₛ t ∈ A.sym (h + 1) := by
+      rw [Finset.mem_sym_iff]
+      intro x hx
+      rcases Sym.mem_cons.mp hx with rfl | hxt
+      · exact haA
+      · exact htmem x hxt
+    have hsum0 : (s : Multiset ℕ).sum = (t : Multiset ℕ).sum := hsum
+    have hsum' :
+        ((a ::ₛ s : Sym ℕ (h + 1)) : Multiset ℕ).sum
+          = ((a ::ₛ t : Sym ℕ (h + 1)) : Multiset ℕ).sum := by
+      rw [Sym.coe_cons, Sym.coe_cons, Multiset.sum_cons, Multiset.sum_cons, hsum0]
+    have hcons : a ::ₛ s = a ::ₛ t := hA hs' ht' hsum'
+    exact (Sym.cons_inj_right a s t).mp hcons
+
+/-- **Downward closure (general).**  A `B_h` set is `B_k` for every `k ≤ h`: all
+shorter sums remain distinct.  Iterates `IsBh.of_succ`. -/
+theorem IsBh.of_le {k h : ℕ} {A : Finset ℕ} (hkh : k ≤ h) (hA : IsBh h A) :
+    IsBh k A := by
+  revert hA
+  induction h, hkh using Nat.le_induction with
+  | base => exact id
+  | succ n _ ih => exact fun hA => ih hA.of_succ
+
 /-! ## Part 2: From `B_h` to distinct subset-sums -/
 
 /-- A small bridge lemma: for a finset `U`, the `Finset.sum` over `id` equals the

--- a/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
@@ -18,6 +18,8 @@ B_h analogue of the Sidon upper bound, fully verified (0 sorries, 0 axioms beyon
 | `IsBh h A` | `A` is B_h: the multiset-sum map is injective on `A.sym h` |
 | `IsBh.subset` | B_h is inherited by subsets |
 | `isBh_one` | every finite set is B_1 |
+| `IsBh.of_succ` | downward closure: `B_{h+1}` ⟹ `B_h` |
+| `IsBh.of_le` | downward closure (general): `k ≤ h`, `B_h` ⟹ `B_k` |
 | `IsBh.sum_injOn_powersetCard` | the `h`-element **subsets** of a B_h set have distinct sums |
 | `IsBh.choose_card_le` | **main:** `A ⊆ [1,N]`, B_h, `h ≥ 1` ⟹ `Nat.choose |A| h ≤ h·N` |
 | `IsBh.two_card_mul_pred_le` | Sidon recovery: `|A|·(|A|-1) ≤ 4N` (i.e. `|A| = O(√N)`) |
@@ -66,7 +68,35 @@ ceiling that Bose–Chowla constructions meet to within `(1-o(1))`.
 - `src/data/research/problems/erdos-340-greedy-sidon-oq-05.json` (new)
 
 #### Next Steps
-- `B_h ⟹ B_{h-1}` downward closure (append a fixed element to (h−1)-multisets).
 - B_h greedy extension + the `N^{1/(2h-1)}` greedy lower bound — the genuine open
   direction, matching the still-open parent #340.
 - Optional exact bridge `IsBh 2 A ↔ Erdos340.IsSidon A`.
+
+### Session 2026-06-27 (Session 2, researcher-10) — downward closure
+
+**Mode**: ACT · **Outcome**: progress (verified increment, 0 sorries / 0 axioms).
+
+#### What I Did
+- Closed the first listed next-step: the **downward closure** in `h`.
+  - `IsBh.of_succ`: `B_{h+1} ⟹ B_h`. Append a fixed `a ∈ A` to two `h`-multisets
+    with equal sums; the consed `(h+1)`-multisets land in `A.sym (h+1)` with equal
+    sums (each is the common sum plus `a`), so `B_{h+1}` injectivity gives
+    `a ::ₛ s = a ::ₛ t`, and `Sym.cons_inj_right` cancels the head. The `A = ∅` case
+    is degenerate (`∅.sym 0` is a `Unique` subsingleton; `∅.sym (k+1) = ∅`).
+  - `IsBh.of_le`: `k ≤ h ⟹ B_h ⟹ B_k`, iterating `of_succ` via `Nat.le_induction`
+    (revert the `B_h` hypothesis so the motive stays type-correct).
+
+#### Key Findings / gotchas
+- `hsum : (fun s => (↑s).sum) s = …` arrives as an un-beta-reduced lambda app; bind
+  it to an explicitly-typed `have hsum0 : (s:Multiset).sum = (t:Multiset).sum := hsum`
+  (defeq) before `rw`, else `rw [hsum]` fails to find the pattern.
+- `Finset.not_mem_empty` is deprecated → `Finset.notMem_empty`.
+- API used: `Sym.cons` (`::ₛ`), `Sym.coe_cons`, `Multiset.sum_cons`,
+  `Sym.cons_inj_right`, `Sym.mem_cons`, `Finset.mem_sym_iff`, `Finset.sym_empty`,
+  `Sym.uniqueZero`/`Subsingleton.elim`.
+
+#### Verification
+`lake env lean Proofs/Erdos340GreedySidonOQ05.lean` → exit 0, no warnings (Docker
+host has a v4.26.0 lean image but per-file `lake env lean` over the symlinked main
+`.lake` cache is faster/safer). `#print axioms` on `of_succ`/`of_le` = only the 3
+foundational. lineCount 206 → 258, theoremCount 6 → 8.

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -6,14 +6,14 @@
   "tier": "B",
   "tractability": "medium — the foundational B_h theory and the sharp B_h counting upper bound are now formalized and verified (0-axiom). The deep open direction (improving the greedy B_h lower bound toward the N^{1/h} ceiling) remains open, exactly as for the parent #340.",
   "started": "2026-06-27",
-  "lastUpdate": "2026-06-27",
+  "lastUpdate": "2026-06-27T13:30:00.000Z",
   "path": "research/problems/erdos-340-greedy-sidon-oq-05",
   "leanFiles": [
     {
       "path": "Proofs/Erdos340GreedySidonOQ05.lean",
       "filename": "Erdos340GreedySidonOQ05.lean",
-      "lineCount": 206,
-      "theoremCount": 6,
+      "lineCount": 258,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -48,14 +48,15 @@
       "h=2 omega gotcha: from choose(k,2) = k(k-1)/2 ≤ 2N, deriving k(k-1) ≤ 4N requires the EVENNESS of k(k-1) (else k(k-1)=4N+1 is a spurious omega counterexample). Supply 2 ∣ k(k-1) via (Nat.even_mul_pred_self k).two_dvd before omega."
     ],
     "builtItems": [
-      "Erdos340GreedySidonOQ05.lean: def IsBh (h-fold-sum-distinctness via multiset-sum InjOn on A.sym h); IsBh.subset; isBh_one (every set is B_1); IsBh.sum_injOn_powersetCard (distinct h-subset sums); IsBh.choose_card_le (MAIN: Nat.choose |A| h ≤ h·N for B_h A ⊆ [1,N]); IsBh.two_card_mul_pred_le (Sidon recovery |A|(|A|-1) ≤ 4N). 206 lines, 6 theorems, 1 def, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only)."
+      "Erdos340GreedySidonOQ05.lean: def IsBh (h-fold-sum-distinctness via multiset-sum InjOn on A.sym h); IsBh.subset; isBh_one (every set is B_1); IsBh.sum_injOn_powersetCard (distinct h-subset sums); IsBh.choose_card_le (MAIN: Nat.choose |A| h ≤ h·N for B_h A ⊆ [1,N]); IsBh.two_card_mul_pred_le (Sidon recovery |A|(|A|-1) ≤ 4N). 206 lines, 6 theorems, 1 def, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only).",
+      "IsBh.of_succ: B_{h+1} ⟹ B_h downward closure (append a fixed element, cancel head via Sym.cons_inj_right)",
+      "IsBh.of_le: B_h ⟹ B_k for all k ≤ h (iterates of_succ via Nat.le_induction)"
     ],
     "mathlibGaps": [
       "Mathlib has no B_h-set theory and no Sidon/B_h upper bound; the whole development is original relative to Mathlib.",
       "Finset.sym s n has no direct cardinality (multichoose) lemma in Mathlib — only the Fintype-level Sym.card_sym_eq_choose. This is why the counting bound is routed through h-subsets (powersetCard, which DOES have card_powersetCard) rather than the full multiset family."
     ],
     "nextSteps": [
-      "Prove the explicit B_h ⟹ B_{h-1} downward closure (for nonempty A) by appending a fixed element to (h-1)-multisets — a clean structural theorem now that the multiset-sum formulation is in place.",
       "Formalize a B_h analogue of the greedy extension lemma (parent file's sidon_exists_extension / nextSidon) to build a greedy B_h sequence and prove its N^{1/(2h-1)} lower bound — the genuine open direction matching the parent #340.",
       "Optionally prove the exact bridge IsBh 2 A ↔ Erdos340.IsSidon A (Sym ℕ 2 ↔ ordered-pair sums) to formally link the new B_h def to the parent gallery's IsSidon."
     ],


### PR DESCRIPTION
## Summary

Extends the verified `B_h` theory in `Erdos340GreedySidonOQ05.lean` (Erdős #340, OQ-05) by closing its **first listed open next-step**: the downward closure of the `B_h` property in `h`.

A set is `B_h` if all `h`-fold sums (with repetition) are distinct. Intuitively, distinctness of longer sums should force distinctness of shorter ones; this PR proves it.

## New theorems (0 sorries, 0 axioms)

- **`IsBh.of_succ`** — `B_{h+1} ⟹ B_h`. Given two `h`-multisets `s, t ∈ A.sym h` with equal sums, append a fixed `a ∈ A`: the consed `(h+1)`-multisets `a ::ₛ s`, `a ::ₛ t` lie in `A.sym (h+1)` and have equal sums (each is the common sum plus `a`), so `B_{h+1}` injectivity gives `a ::ₛ s = a ::ₛ t`, and `Sym.cons_inj_right` cancels the head. The `A = ∅` case is degenerate (`∅.sym 0` is a `Unique` subsingleton; `∅.sym (k+1) = ∅`).
- **`IsBh.of_le`** — `k ≤ h ⟹ B_h ⟹ B_k`, iterating `of_succ` via `Nat.le_induction`.

## Verification

`lake env lean Proofs/Erdos340GreedySidonOQ05.lean` → exit 0, no warnings. `#print axioms` on `of_succ`/`of_le` lists only `propext, Classical.choice, Quot.sound` — **0 custom axioms, 0 sorries**. File: lineCount 206 → 258, theoremCount 6 → 8. No new imports (Mathlib only); the rest of the file is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)