### PR TITLE
Research: pythagorean-triples-oq-03 — close both sorries [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ03.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ03.lean
@@ -24,13 +24,11 @@
   Here the object of study is the set of RATIONAL points of the circle and its
   one-parameter rational parametrization.
 
-  Build status: Docker build backend unavailable this session. The algebraic
-  identities below (`param_on_circle`, `param_recovers`) were independently
-  certified with exact rational / symbolic arithmetic in
-  `research/problems/pythagorean-triples-oq-03/verify_rational_circle_param.py`
-  (symbolic identity zero; 0/≈12k exact-rational sample failures; full
-  surjectivity onto bounded-height rational points for p = 2,5,13,17,29,37,41;
-  existence trichotomy verified for all primes < 200).
+  Build status: VERIFIED, 0 sorries, 0 axioms.  Type-checked against the
+  prebuilt Mathlib olean cache with Lean 4.26.0 (`lean` direct, Docker
+  containerd backend being unavailable this session).  Both
+  `no_rational_point_three_mod_four` and `param_recovers` depend only on the
+  foundational axioms `propext, Classical.choice, Quot.sound`.
 
   Tags: number-theory, conics, rational-points, stereographic-projection,
         fermat-two-squares, sum-of-two-squares
@@ -81,17 +79,21 @@ theorem param_mem_circle {a b p : ℚ} (h : a ^ 2 + b ^ 2 = p) (t : ℚ) :
     Together with `param_on_circle` this gives a bijection between `ℚ ∪ {∞}`
     and the rational points of the circle.
 
-    Formalization deferred (Docker backend down this session): the underlying
-    algebra is an EXACT identity, certified symbolically — the numerators of
-    `px(t) − x` and `py(t) − y` are divisible by the circle relation
-    `x² + y² − a² − b²` with quotients `(x−a)²` and `(b−y)` respectively
-    (see `verify_rational_circle_param.py`). So this is a formalization gap,
-    not a mathematical one; a `linear_combination … * hcirc` after `field_simp`
-    discharges it once a build is available, or it can be sent to Aristotle. -/
+    The underlying algebra is an EXACT identity: writing `t = (y−b)/(x−a)`,
+    both `px(t) − x` and `py(t) − y` reduce to a multiple of the circle relation
+    `x² + y² − a² − b²`, which vanishes by `hcirc`. -/
 theorem param_recovers {a b x y : ℚ} (hcirc : x ^ 2 + y ^ 2 = a ^ 2 + b ^ 2)
     (hx : x ≠ a) :
     px a b ((y - b) / (x - a)) = x ∧ py a b ((y - b) / (x - a)) = y := by
-  sorry
+  have hs : x - a ≠ 0 := sub_ne_zero.mpr hx
+  unfold px py
+  refine ⟨?_, ?_⟩
+  · rw [div_eq_iff (one_add_sq_ne _)]
+    field_simp
+    linear_combination (a - x) * hcirc
+  · rw [div_eq_iff (one_add_sq_ne _)]
+    field_simp
+    linear_combination (b - y) * hcirc
 
 -- ============================================================
 -- Part III: Existence of rational points
@@ -106,21 +108,98 @@ theorem rational_point_of_not_three_mod_four {p : ℕ} [Fact p.Prime]
   obtain ⟨a, b, hab⟩ := Nat.Prime.sq_add_sq h
   exact ⟨(a : ℚ), (b : ℚ), by exact_mod_cast hab⟩
 
+/-- **The mod-`p` obstruction.**
+    If `p ≡ 3 (mod 4)` is prime and `p ∣ X² + Y²` for integers `X, Y`, then
+    `p ∣ X` and `p ∣ Y`.  Proof: in the field `ZMod p` we have `X² + Y² = 0`;
+    if `Y ≠ 0` then `(X/Y)² = −1`, so `−1` is a square mod `p`, contradicting
+    `ZMod.exists_sq_eq_neg_one_iff` (`p % 4 = 3`).  Hence `Y ≡ 0`, and then
+    `X² = 0` forces `X ≡ 0`. -/
+theorem prime_dvd_of_dvd_sq_add_sq {p : ℕ} [Fact p.Prime] (h3 : p % 4 = 3)
+    {X Y : ℤ} (hdvd : (p : ℤ) ∣ X ^ 2 + Y ^ 2) :
+    (p : ℤ) ∣ X ∧ (p : ℤ) ∣ Y := by
+  have hns : ¬ IsSquare (-1 : ZMod p) := by
+    rw [ZMod.exists_sq_eq_neg_one_iff]; omega
+  have hcast : (X : ZMod p) ^ 2 + (Y : ZMod p) ^ 2 = 0 := by
+    have h0 : ((X ^ 2 + Y ^ 2 : ℤ) : ZMod p) = 0 :=
+      (ZMod.intCast_zmod_eq_zero_iff_dvd _ p).mpr hdvd
+    push_cast at h0
+    linear_combination h0
+  have hY : (Y : ZMod p) = 0 := by
+    by_contra hYne
+    refine hns ⟨(X : ZMod p) / (Y : ZMod p), ?_⟩
+    rw [div_mul_div_comm, eq_div_iff (mul_ne_zero hYne hYne)]
+    linear_combination -hcast
+  have hX : (X : ZMod p) = 0 := by
+    have hx2 : (X : ZMod p) ^ 2 = 0 := by rw [hY] at hcast; linear_combination hcast
+    exact pow_eq_zero_iff (by norm_num) |>.mp hx2
+  exact ⟨(ZMod.intCast_zmod_eq_zero_iff_dvd X p).mp hX,
+         (ZMod.intCast_zmod_eq_zero_iff_dvd Y p).mp hY⟩
+
+/-- **Infinite descent core.**
+    For a prime `p ≡ 3 (mod 4)`, the equation `X² + Y² = p · W²` has no integer
+    solution with `W ≠ 0`.  Strong induction on `|W|`: the obstruction
+    `prime_dvd_of_dvd_sq_add_sq` gives `p ∣ X`, `p ∣ Y`; writing `X = pX'`,
+    `Y = pY'` yields `p(X'² + Y'²) = W²`, so `p ∣ W`, and `W = pW'` produces a
+    strictly smaller solution `X'² + Y'² = p · W'²`. -/
+theorem no_int_sol_of_three_mod_four {p : ℕ} [Fact p.Prime] (h3 : p % 4 = 3) :
+    ∀ n : ℕ, ∀ W : ℤ, W.natAbs = n → W ≠ 0 →
+      ∀ X Y : ℤ, X ^ 2 + Y ^ 2 = (p : ℤ) * W ^ 2 → False := by
+  have hp : p.Prime := Fact.out
+  have hp0 : (p : ℤ) ≠ 0 := by exact_mod_cast hp.ne_zero
+  have hpprime : Prime (p : ℤ) := Nat.prime_iff_prime_int.mp hp
+  intro n
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+    intro W hWn hW0 X Y hcl
+    have hpdvd : (p : ℤ) ∣ X ^ 2 + Y ^ 2 := ⟨W ^ 2, hcl⟩
+    obtain ⟨hpX, hpY⟩ := prime_dvd_of_dvd_sq_add_sq h3 hpdvd
+    obtain ⟨X', rfl⟩ := hpX
+    obtain ⟨Y', rfl⟩ := hpY
+    have hW2 : (p : ℤ) * (X' ^ 2 + Y' ^ 2) = W ^ 2 := by
+      apply mul_left_cancel₀ hp0
+      linear_combination hcl
+    have hpW : (p : ℤ) ∣ W := hpprime.dvd_of_dvd_pow ⟨X' ^ 2 + Y' ^ 2, hW2.symm⟩
+    obtain ⟨W', rfl⟩ := hpW
+    have hW'0 : W' ≠ 0 := by rintro rfl; simp at hW0
+    have hcl' : X' ^ 2 + Y' ^ 2 = (p : ℤ) * W' ^ 2 := by
+      apply mul_left_cancel₀ hp0
+      linear_combination hW2
+    refine ih W'.natAbs ?_ W' rfl hW'0 X' Y' hcl'
+    have hW'pos : 0 < W'.natAbs := Int.natAbs_pos.mpr hW'0
+    have hmul : ((p : ℤ) * W').natAbs = p * W'.natAbs := by simp [Int.natAbs_mul]
+    rw [← hWn, hmul]
+    exact (lt_mul_iff_one_lt_left hW'pos).mpr hp.one_lt
+
 /-- **Existence, hard direction (descent).**
     For a prime `p ≡ 3 (mod 4)` the circle `x² + y² = p` has NO rational point.
 
-    Proof sketch: write a rational solution as `(X/Z, Y/Z)` in lowest terms,
-    clearing to `X² + Y² = p Z²` with `gcd(X,Y,Z) = 1`.  Since `p ≡ 3 (mod 4)`,
-    `−1` is not a quadratic residue mod `p`, so `p ∣ X² + Y²` forces `p ∣ X` and
-    `p ∣ Y`; then `p² ∣ p Z²`, so `p ∣ Z`, contradicting primitivity.
-    Equivalently: `p ≡ 3 (mod 4)` ⟹ `p` is not a sum of two RATIONAL squares.
-
-    This is the genuine content of the existence theorem; it is the rational
-    upgrade of the integer obstruction already proved in `FermatTwoSquares.lean`
-    (`no_three_mod_four_sum`).  Deferred to a build/Aristotle pass. -/
+    Proof: clear denominators of a rational solution `(x, y)` to integers
+    `X² + Y² = p · W²` with `W ≠ 0`, then apply the infinite-descent core
+    `no_int_sol_of_three_mod_four`.  Equivalently: `p ≡ 3 (mod 4)` ⟹ `p` is not
+    a sum of two RATIONAL squares — the rational upgrade of the integer
+    obstruction in `FermatTwoSquares.lean`. -/
 theorem no_rational_point_three_mod_four {p : ℕ} [Fact p.Prime] (h : p % 4 = 3) :
     ¬ ∃ x y : ℚ, x ^ 2 + y ^ 2 = (p : ℚ) := by
-  sorry
+  rintro ⟨x, y, hxy⟩
+  -- Clear denominators: X = x.num·y.den, Y = y.num·x.den, W = x.den·y.den.
+  have hxd : (x.den : ℚ) ≠ 0 := by exact_mod_cast x.den_nz
+  have hyd : (y.den : ℚ) ≠ 0 := by exact_mod_cast y.den_nz
+  have hxn : (x.num : ℚ) = x * x.den := (div_eq_iff hxd).mp (Rat.num_div_den x)
+  have hyn : (y.num : ℚ) = y * y.den := (div_eq_iff hyd).mp (Rat.num_div_den y)
+  obtain ⟨X, Y, W, hW0, hcl⟩ :
+      ∃ X Y W : ℤ, W ≠ 0 ∧ X ^ 2 + Y ^ 2 = (p : ℤ) * W ^ 2 := by
+    refine ⟨x.num * (y.den : ℤ), y.num * (x.den : ℤ), (x.den : ℤ) * (y.den : ℤ),
+      mul_ne_zero ?_ ?_, ?_⟩
+    · exact_mod_cast x.den_nz
+    · exact_mod_cast y.den_nz
+    · have key : ((x.num * (y.den : ℤ) : ℤ) : ℚ) ^ 2
+            + ((y.num * (x.den : ℤ) : ℤ) : ℚ) ^ 2
+          = (p : ℚ) * (((x.den : ℤ) * (y.den : ℤ) : ℤ) : ℚ) ^ 2 := by
+        push_cast
+        rw [hxn, hyn]
+        linear_combination ((x.den : ℚ) * (y.den : ℚ)) ^ 2 * hxy
+      exact_mod_cast key
+  exact no_int_sol_of_three_mod_four h _ _ rfl hW0 _ _ hcl
 
 /-- **Existence characterization for primes.**
     `x² + y² = p` has a rational point ⟺ `p ≢ 3 (mod 4)`.
@@ -147,28 +226,30 @@ theorem rational_point_5 :
 
 /-- The witnessing coordinates at `p = 5`, `t = 2` are `(2/5, -11/5)`. -/
 theorem rational_point_5_coords : px 2 1 2 = 2 / 5 ∧ py 2 1 2 = -11 / 5 := by
-  constructor <;> · unfold px py; norm_num
+  constructor <;> · simp only [px, py]; norm_num
 
 /-- `p = 13`: base point `(3,2)`. -/
 theorem base_13 : (3 : ℚ) ^ 2 + (2 : ℚ) ^ 2 = 13 := by norm_num
 
 /-
-  Summary
+  Summary (all VERIFIED, 0 sorries, 0 axioms)
 
-  Provided (algebra build-free-certain, pending Docker for machine check):
   - `param_on_circle`, `param_mem_circle` : the stereographic map sends ℚ into
     the circle x²+y²=p  (field_simp; ring).
+  - `param_recovers` : surjectivity (completeness) of the parametrization —
+    every rational point with x ≠ a is hit by the chord slope t = (y−b)/(x−a).
+    Exact algebraic identity discharged by `linear_combination`.
   - `rational_point_of_not_three_mod_four` : existence for p ≢ 3 (mod 4) via
     Mathlib's Fermat two-square theorem.
+  - `prime_dvd_of_dvd_sq_add_sq` : the mod-p obstruction (p ≡ 3 ⟹ p ∣ X²+Y²
+    forces p ∣ X, p ∣ Y), via `ZMod.exists_sq_eq_neg_one_iff` in the field ℤ/p.
+  - `no_int_sol_of_three_mod_four` : infinite descent on |W| for X²+Y² = pW².
+  - `no_rational_point_three_mod_four` : the descent obstruction for p ≡ 3 —
+    clear denominators, then apply the integer descent.
   - `rational_point_iff` : full existence characterization (assembled).
   - concrete rational (non-integer) points, e.g. (2/5, -11/5) on x²+y²=5.
 
-  Deferred (certified true, formalization pending build/Aristotle):
-  - `param_recovers` : surjectivity of the parametrization (exact identity,
-    symbolically certified).
-  - `no_rational_point_three_mod_four` : the descent obstruction for p ≡ 3.
-
-  Sorries: 2 (param_recovers, no_rational_point_three_mod_four).
+  Sorries: 0.  Axiom declarations: 0.
 -/
 
 end PythagoreanTriplesOQ03

--- a/research/problems/pythagorean-triples-oq-03/knowledge.md
+++ b/research/problems/pythagorean-triples-oq-03/knowledge.md
@@ -1,21 +1,61 @@
 # Knowledge Base: pythagorean-triples-oq-03
 
-Insights accumulated during research on this problem.
+Rational Circle Parametrization for x² + y² = p (primes p ≡ 1 mod 4).
+
+---
+
+## Status: VERIFIED (0 sorries, 0 axioms)
+
+`proofs/Proofs/PythagoreanTriplesOQ03.lean` now type-checks fully against the
+Lean 4.26.0 / Mathlib olean cache. Both previously-deferred sorries are closed.
+`#print axioms` on the two capstone theorems reports only the foundational
+`propext, Classical.choice, Quot.sound`.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+For a prime p, study the conic C_p : x² + y² = p over ℚ:
+- EXISTENCE: C_p has a rational point ⟺ p ≢ 3 (mod 4).
+- PARAMETRIZATION: once a rational base point (a,b) exists, every rational
+  point is the stereographic image of a chord slope t through (a,b).
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **The rational obstruction needs no extra descent.** "p ≡ 3 ⟹ p is not a sum
+  of two RATIONAL squares" reduces, by clearing denominators, to the integer
+  equation X² + Y² = p·W² (W ≠ 0). Infinite descent on |W| (Nat.strongRecOn)
+  then closes it — the same descent that handles the integer case.
+
+- **The mod-p step is short via ZMod.** `ZMod.exists_sq_eq_neg_one_iff`
+  (`IsSquare (-1 : ZMod p) ↔ p % 4 ≠ 3`) together with the field structure of
+  `ZMod p` (from `Fact p.Prime`) gives, in ~10 lines:
+  p ≡ 3 (mod 4), p ∣ X² + Y² ⟹ p ∣ X ∧ p ∣ Y. No Gaussian integers required.
+
+- **param_recovers coefficients.** The surjectivity identity, after
+  `div_eq_iff` + `field_simp`, closes with `linear_combination (a-x)*hcirc`
+  (px) and `linear_combination (b-y)*hcirc` (py). The coefficients are the
+  quotient of goal_diff by the circle relation x²+y²-a²-b², found by symbolic
+  polynomial division.
 
 ---
 
-## Dead Ends
+## Key lemmas (all in PythagoreanTriplesOQ03.lean)
 
-[Approaches known not to work will be documented here]
+- `param_on_circle`, `param_mem_circle` — stereographic map lands on the circle.
+- `param_recovers` — surjectivity / completeness of the parametrization.
+- `rational_point_of_not_three_mod_four` — existence via `Nat.Prime.sq_add_sq`.
+- `prime_dvd_of_dvd_sq_add_sq` — mod-p obstruction (ZMod field argument).
+- `no_int_sol_of_three_mod_four` — infinite descent for X²+Y²=pW².
+- `no_rational_point_three_mod_four` — rational obstruction (clear + descend).
+- `rational_point_iff` — full existence characterization.
+
+---
+
+## Dead Ends / Notes
+
+- Docker (containerd) backend was down this session; verification used `lean`
+  directly with a hand-assembled LEAN_PATH over the prebuilt olean cache
+  (build dirs now nest under `.lake/build/lib/lean/`).

--- a/src/data/research/problems/pythagorean-triples-oq-03.json
+++ b/src/data/research/problems/pythagorean-triples-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "pythagorean-triples-oq-03",
   "title": "Rational Circle Parametrization for x² + y² = p (primes p ≡ 1 mod 4)",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -11,17 +11,22 @@
     "whyMatters": []
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "param_recovers: stereographic parametrization is surjective onto rational points with x≠a (exact algebraic identity)",
+      "prime_dvd_of_dvd_sq_add_sq: p≡3 mod 4, p∣X²+Y² ⟹ p∣X ∧ p∣Y (ZMod field argument)",
+      "no_int_sol_of_three_mod_four: infinite descent — X²+Y²=pW² has no integer solution with W≠0 when p≡3 mod 4",
+      "no_rational_point_three_mod_four: p≡3 mod 4 ⟹ circle x²+y²=p has no rational point (rational two-square obstruction)"
+    ],
     "open": [],
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-06-14T22:54:16-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Both remaining sorries discharged: param_recovers (surjectivity) and no_rational_point_three_mod_four (descent obstruction). File VERIFIED 0-sorry 0-axiom.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Optional gallery integration; possible follow-up to other conics x²+2y²=p.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +34,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "VERIFIED (0 sorries, 0 axioms): full rational-point existence characterization for x²+y²=p assembled. param_recovers (parametrization surjectivity) proved by linear_combination; no_rational_point_three_mod_four proved by clearing denominators + infinite descent on |W| using a ZMod(p) field obstruction. Both depend only on propext/Classical.choice/Quot.sound.",
+    "builtItems": [
+      "param_recovers in PythagoreanTriplesOQ03.lean — chord-slope completeness of the stereographic map",
+      "prime_dvd_of_dvd_sq_add_sq in PythagoreanTriplesOQ03.lean — mod-p obstruction via ZMod.exists_sq_eq_neg_one_iff",
+      "no_int_sol_of_three_mod_four in PythagoreanTriplesOQ03.lean — Nat.strongRecOn infinite descent on |W|",
+      "no_rational_point_three_mod_four in PythagoreanTriplesOQ03.lean — rational obstruction via denominator clearing"
+    ],
+    "insights": [
+      "The rational obstruction (p≡3 ⟹ not a sum of two RATIONAL squares) needs no separate descent lemma beyond the integer one: clearing denominators reduces it to X²+Y²=pW², and the integer infinite descent on |W| closes it.",
+      "ZMod.exists_sq_eq_neg_one_iff (IsSquare(-1:ZMod p) ↔ p%4≠3) plus the field structure of ZMod p (from Fact p.Prime) gives p∣X²+Y² ⟹ p∣X∧p∣Y in ~10 lines — no Gaussian integers needed.",
+      "param_recovers (surjectivity) coefficients: px residual = (a-x)·circle, py residual = (b-y)·circle; found by symbolic division of goal_diff by the circle relation."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Optional: gallery integration (create src/data/proofs/pythagorean-triples-oq-03/).",
+      "Follow-up: extend the rational-parametrization + descent toolkit to x²+2y²=p (p≡1,3 mod 8) and x²+3y²=p."
+    ],
     "markdown": "# Knowledge Base: pythagorean-triples-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Completes the rational-circle parametrization route to Fermat's two-square theorem for `x² + y² = p`. Both previously-deferred sorries in `proofs/Proofs/PythagoreanTriplesOQ03.lean` are now discharged — the file is **0-sorry, 0-axiom**.

## Progress
- **`param_recovers`** — surjectivity/completeness of the stereographic parametrization: every rational point of `x²+y²=a²+b²` with `x ≠ a` is the image of the chord slope `t = (y−b)/(x−a)`. Exact algebraic identity closed by `linear_combination` with coefficients `(a−x)` (px) and `(b−y)` (py), found by symbolic division of the goal by the circle relation.
- **`no_rational_point_three_mod_four`** — `p ≡ 3 (mod 4) ⟹ x²+y²=p` has no rational point (the rational two-square obstruction). Built from two new lemmas:
  - `prime_dvd_of_dvd_sq_add_sq`: `p ∣ X²+Y² ⟹ p∣X ∧ p∣Y`, via the field `ZMod p` and `ZMod.exists_sq_eq_neg_one_iff` — **no Gaussian integers**, ~10 lines.
  - `no_int_sol_of_three_mod_four`: infinite descent on `|W|` (`Nat.strongRecOn`) for `X²+Y² = p·W²`.
  - The rational case clears denominators (`X = x.num·y.den`, …) to the integer equation, then applies the descent.

## Findings
- The rational obstruction needs **no separate descent** beyond the integer one: clearing denominators reduces "not a sum of two rational squares" to `X²+Y²=pW²`, which the integer infinite descent closes directly.
- This route is independent of Mathlib's Gaussian-integer proof (`Nat.Prime.sq_add_sq`), giving the explicit geometric/parametric derivation the open question asked for.

## Files Modified
- `proofs/Proofs/PythagoreanTriplesOQ03.lean` — 2 sorries → 0; added `prime_dvd_of_dvd_sq_add_sq`, `no_int_sol_of_three_mod_four`; fixed a latent `unfold` bug in `rational_point_5_coords`.
- `src/data/research/problems/pythagorean-triples-oq-03.json`, `research/problems/pythagorean-triples-oq-03/knowledge.md` — knowledge update.

## Verification
Docker containerd backend was unavailable this session; type-checked with **Lean 4.26.0 `lean`** directly against the prebuilt Mathlib olean cache. `#print axioms` on `no_rational_point_three_mod_four` and `param_recovers` reports only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).

## Status
**Outcome**: completed (0 sorries, 0 axioms)
**Next Steps**: optional gallery integration; follow-up extending the parametrization + descent toolkit to `x²+2y²=p` and `x²+3y²=p`.

🤖 Generated by researcher-1