### PR TITLE
research(sperner-mathlib4-oq-02): n=2 Tucker instance + abstract path-following parity engine [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -146,10 +146,10 @@ import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01OQ01
 import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05
 import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02
 import Proofs.AngleTrisectionOQ02OQ01OQ02
-import Proofs.AngleTrisectionOQ02OQ01OQ02OQ02
 import Proofs.AngleTrisectionOQ02OQ01OQ02Aristotle
 import Proofs.AngleTrisectionOQ02OQ01OQ02Incomplete01
 import Proofs.AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle
+import Proofs.AngleTrisectionOQ02OQ01OQ02OQ02
 import Proofs.AngleTrisectionOQ02OQ02
 import Proofs.AngleTrisectionOQ02OQ02OQ02
 import Proofs.AngleTrisectionOQ02OQ02OQ03
@@ -524,9 +524,9 @@ import Proofs.BorsukUlamOQ03OQ04
 import Proofs.BorsukUlamOQ04
 import Proofs.BoundedPrimeGaps
 import Proofs.BoundedPrimeGapsOQ01
-import Proofs.BoundedPrimeGapsOQ02
 import Proofs.BoundedPrimeGapsOQ01OQ02
 import Proofs.BoundedPrimeGapsOQ01OQ03
+import Proofs.BoundedPrimeGapsOQ02
 import Proofs.BoundedPrimeGapsOQ03
 import Proofs.BoundedPrimeGapsOQ03OQ01
 import Proofs.BoundedPrimeGapsOQ03OQ01ChebyshevLower
@@ -3255,6 +3255,8 @@ import Proofs.HallsTheoremOQ01
 import Proofs.HallsTheoremOQ01OQ01
 import Proofs.HallsTheoremOQ01OQ03
 import Proofs.HallsTheoremOQ02
+import Proofs.HaltingApproximation
+import Proofs.HaltingArithmeticalHierarchy
 import Proofs.HaltingProblem
 import Proofs.HappyNumberOQ01
 import Proofs.HarmonicDivergence
@@ -3880,8 +3882,6 @@ import Proofs.RearrangementChebyshevEqOQ01
 import Proofs.RearrangementChebyshevEqOQ01OQ02
 import Proofs.RearrangementChebyshevStrictOQ01OQ02
 import Proofs.RearrangementChebyshevStrictOQ01OQ02OQ01
-import Proofs.HaltingApproximation
-import Proofs.HaltingArithmeticalHierarchy
 import Proofs.RelativizedHalting
 import Proofs.RelativizedHaltingBridge
 import Proofs.RepunitDivisibilityOQ01
@@ -4009,9 +4009,10 @@ import Proofs.SpernerSimplicialInstanceOQ03Tower
 import Proofs.SpernerSimplicialInstanceOQ04
 import Proofs.SpernerSimplicialInstanceOQ05
 import Proofs.SpernerSimplicialInstanceOQ05Scarf1d
-import Proofs.SpernerTuckerOneDim
 import Proofs.SpernerTuckerBorsukUlamOneDim
 import Proofs.SpernerTuckerBoundaryParity
+import Proofs.SpernerTuckerOneDim
+import Proofs.SpernerTuckerPathFollowing
 import Proofs.SphericalExcessGirard
 import Proofs.SphericalLawOfCosines
 import Proofs.SphericalLawOfCosinesOQ03

--- a/proofs/Proofs/SpernerTuckerHexagon.lean
+++ b/proofs/Proofs/SpernerTuckerHexagon.lean
@@ -1,0 +1,98 @@
+import Mathlib
+
+/-!
+# n = 2 Tucker on the hexagon: the first machine-checked n ≥ 2 instance
+
+`sperner-mathlib4-oq-02` asks whether the parent door-counting engine extends to
+**Tucker's lemma** / Borsuk–Ulam.  The n = 1 case is settled
+(`SpernerTuckerOneDim.lean`, `SpernerTuckerBorsukUlamOneDim.lean`) by a direct
+sign-change parity, and the abstract path-following engine for general `n` is in
+`SpernerTuckerPathFollowing.lean`.
+
+This file gives the **first fully machine-checked `n = 2` instance** of Tucker's
+conclusion, on the standard small antipodally symmetric triangulation of `B²`
+(a hexagon with its centre), entirely by kernel `decide` (0 axioms).  It serves two
+purposes that the Python verification artifact (`verify_tucker.py`) could only
+assert informally:
+
+1. **Tucker holds** (`hexagon_tucker`): *every* antipodal labelling has a
+   complementary edge — the conclusion is true for `n = 2`.
+2. **The direct-parity route provably does not lift**
+   (`count_even_witness`, `count_odd_witness`): the complementary-edge *count* is
+   **not** a parity invariant for `n = 2` — there are antipodal labellings with an
+   even count and others with an odd count.  This is the Lean confirmation of the
+   knowledge-base "Insight 3": the n = 1 discrete-FTC parity argument cannot be
+   ported to `n ≥ 2`, which is exactly why the path-following engine is needed.
+
+## Model
+
+Boundary of the hexagon: six vertices `0,…,5` in antipodal pairs, `v(i+3) = -v(i)`,
+plus an interior centre.  The triangulation has six triangles `(centre, v i, v (i+1))`;
+its edges are the boundary edges `v i — v (i+1)` and the spokes `centre — v i`.
+
+Labels lie in `{+1, +2, -1, -2}`, encoded as `Fin 4` via `0↦+1, 1↦+2, 2↦-1, 3↦-2`;
+`negL` is the label negation, an involution.  A boundary labelling is **antipodal**
+when `v(i+3) = -v(i)`, which we build in by setting the second triple of vertices to
+the negations of the first.  An edge is **complementary** when its two labels are
+negatives of each other.
+-/
+
+namespace SpernerTuckerHexagon
+
+/-- Label negation on `{+1,+2,-1,-2}` encoded as `Fin 4` (`0↦+1,1↦+2,2↦-1,3↦-2`):
+`+1 ↔ -1`, `+2 ↔ -2`.  It is an involution. -/
+def negL : Fin 4 → Fin 4 := ![2, 3, 0, 1]
+
+/-- `negL` is an involution: negating twice is the identity. -/
+theorem negL_involutive : Function.Involutive negL := by
+  intro x; fin_cases x <;> decide
+
+/-- Two labels are **complementary** when one is the negation of the other. -/
+def Compl (x y : Fin 4) : Prop := x = negL y
+
+instance (x y : Fin 4) : Decidable (Compl x y) := inferInstanceAs (Decidable (x = negL y))
+
+/-- The six boundary labels from three free labels `a, b, c` of `v 0, v 1, v 2`,
+with the antipodal condition `v(i+3) = -v(i)` built in for `v 3, v 4, v 5`. -/
+def V (a b c : Fin 4) : Fin 6 → Fin 4 := ![a, b, c, negL a, negL b, negL c]
+
+/-- The next boundary vertex around the hexagon (cyclic successor). -/
+def rot (i : Fin 6) : Fin 6 := i + 1
+
+/-- The boundary labelling really is **antipodal**: `v(i+3) = -v(i)` for all `i`. -/
+theorem V_antipodal : ∀ (a b c : Fin 4) (i : Fin 6), V a b c (i + 3) = negL (V a b c i) := by
+  decide
+
+/-- **n = 2 Tucker on the hexagon.**  For every antipodal boundary labelling (free
+labels `a, b, c` on `v 0, v 1, v 2`, the rest forced antipodally) and every centre
+label `d`, the triangulation has a complementary edge: either a boundary edge
+`v i — v (i+1)` or a spoke `centre — v i`.  Checked exhaustively over all `4⁴ = 256`
+antipodal labellings. -/
+theorem hexagon_tucker :
+    ∀ a b c d : Fin 4,
+      (∃ i : Fin 6, Compl (V a b c i) (V a b c (rot i))) ∨
+      (∃ i : Fin 6, Compl d (V a b c i)) := by
+  decide
+
+/-- The number of complementary edges of the triangulation under a given labelling:
+complementary boundary edges plus complementary spokes. -/
+def countCompl (a b c d : Fin 4) : ℕ :=
+  ((List.finRange 6).filter (fun i => decide (Compl (V a b c i) (V a b c (rot i))))).length
+  + ((List.finRange 6).filter (fun i => decide (Compl d (V a b c i)))).length
+
+/-- There is an antipodal labelling whose complementary-edge count is **even**. -/
+theorem count_even_witness : ∃ a b c d : Fin 4, Even (countCompl a b c d) := by decide
+
+/-- There is an antipodal labelling whose complementary-edge count is **odd**. -/
+theorem count_odd_witness : ∃ a b c d : Fin 4, Odd (countCompl a b c d) := by decide
+
+/-- **The complementary-edge count is not a parity invariant for `n = 2`.**
+Some antipodal labelling has an even count and some has an odd count, so no
+"count the target object, show it is odd" argument (the n = 1 route) can prove
+Tucker here — the path-following engine is genuinely required. -/
+theorem count_parity_not_invariant :
+    (∃ a b c d : Fin 4, Even (countCompl a b c d)) ∧
+    (∃ a b c d : Fin 4, Odd (countCompl a b c d)) :=
+  ⟨count_even_witness, count_odd_witness⟩
+
+end SpernerTuckerHexagon

--- a/proofs/Proofs/SpernerTuckerPathFollowing.lean
+++ b/proofs/Proofs/SpernerTuckerPathFollowing.lean
@@ -1,0 +1,127 @@
+/-
+# Abstract path-following parity engine for Tucker's lemma (n ≥ 2)
+
+Research artifact for `sperner-mathlib4-oq-02` ("Tucker's Lemma and Borsuk–Ulam
+from abstract door-counting").
+
+## Background
+
+Sperner's lemma is proved by a *door-counting* parity argument: a certain target
+object (a panchromatic cell) is counted modulo 2 and shown to be odd, hence
+non-empty.  The companion file `SpernerTuckerOneDim.lean` shows that **n = 1
+Tucker** (the combinatorial core of 1-D Borsuk–Ulam) is exactly such a direct
+parity statement: the number of *complementary edges* of a sign labelling that is
+antipodal on the boundary is always odd.
+
+That direct route **provably does not lift to n ≥ 2**: `SpernerTuckerHexagon.lean`
+exhibits, in Lean, antipodal labellings of the hexagon+centre triangulation of
+`B²` whose complementary-edge counts have *both* parities
+(`count_parity_not_invariant`).  So one cannot "count the complementary simplices
+and show the total is odd."
+
+The standard remedy (Freund–Todd 1981; Prescott–Su) is **path-following**.  One
+builds a graph `G` on the *almost-complementary* simplices, where two such
+simplices are adjacent when they share a complementary facet (a "door").  Every
+almost-complementary simplex has at most two such doors, so **`G` has maximum
+degree ≤ 2** — it is a disjoint union of paths and cycles.  The *endpoints* of
+these paths (degree-1 vertices) are exactly:
+
+* the genuinely **complementary** simplices (the interior target), and
+* the almost-complementary simplices lying on the **boundary**.
+
+The antipodal boundary condition forces the number of boundary endpoints to be
+**odd** (this is the lower-dimensional Tucker statement, used as an induction
+hypothesis).  Since the *total* number of endpoints is **even** (handshaking
+lemma), an **odd**, hence non-zero, number of endpoints must be interior — a
+complementary simplex exists.
+
+## What this file proves
+
+This file isolates and machine-checks the **combinatorial heart** of that
+argument, fully abstractly over an arbitrary finite simple graph:
+
+* `even_card_degree_one` — in any finite simple graph of maximum degree ≤ 2, the
+  number of degree-1 vertices is even (the handshaking lemma specialised to
+  paths-and-cycles graphs).
+* `exists_interior_degree_one` — the **path-following step**: if a "boundary"
+  predicate `B` marks an *odd* number of the degree-1 vertices, then some degree-1
+  vertex is *interior* (`¬ B`).
+
+Instantiating `G` with the almost-complementary-simplex graph and `B` with "lies
+on the antipodal boundary" turns `exists_interior_degree_one` into the existence
+of an interior complementary simplex, i.e. Tucker's lemma.  The geometric
+construction of that graph (and the proof that boundary endpoints are odd) is the
+remaining, dimension-specific work; the parity bookkeeping that *drives* it is
+verified here, 0 sorries, 0 axioms.
+-/
+import Mathlib.Combinatorics.SimpleGraph.DegreeSum
+import Mathlib.Tactic
+
+namespace SpernerTuckerPathFollowing
+
+open Finset SimpleGraph
+
+variable {V : Type*} (G : SimpleGraph V) [Fintype V] [DecidableRel G.Adj]
+
+/-- In a graph where every vertex has degree at most `2`, having odd degree is the
+same as having degree exactly `1`.  (Degrees lie in `{0, 1, 2}`; the odd one is
+`1`.) -/
+theorem odd_degree_iff_eq_one (h : ∀ v, G.degree v ≤ 2) (v : V) :
+    Odd (G.degree v) ↔ G.degree v = 1 := by
+  rw [Nat.odd_iff]
+  have := h v
+  omega
+
+/-- **Path-following parity engine.**  In a finite simple graph in which every
+vertex has degree at most `2` — equivalently, a disjoint union of paths and
+cycles — the number of degree-1 vertices is **even**.
+
+These degree-1 vertices are the endpoints of the constituent paths; this is the
+handshaking lemma specialised to the almost-complementary-simplex graph used in
+the Freund–Todd / Prescott–Su proof of Tucker's lemma. -/
+theorem even_card_degree_one (h : ∀ v, G.degree v ≤ 2) :
+    Even #{v | G.degree v = 1} := by
+  have hset : ({v | G.degree v = 1} : Finset V) = ({v | Odd (G.degree v)} : Finset V) := by
+    apply Finset.filter_congr
+    intro v _
+    exact (odd_degree_iff_eq_one G h v).symm
+  rw [hset]
+  exact G.even_card_odd_degree_vertices
+
+/-- **Tucker path-following step.**  Let `B` be a "boundary" predicate on the
+vertices of a maximum-degree-≤2 graph.  If an **odd** number of degree-1 vertices
+are boundary vertices, then there is a degree-1 vertex that is **not** a boundary
+vertex (an *interior* endpoint).
+
+In the path-following proof of Tucker's lemma, `G` is the graph of
+almost-complementary simplices, the degree-1 vertices are the path endpoints, and
+`B v` says "`v` lies on the antipodal boundary".  The antipodal boundary
+condition makes the number of boundary endpoints odd, so this lemma yields an
+interior endpoint, i.e. a complementary simplex. -/
+theorem exists_interior_degree_one {B : V → Prop} [DecidablePred B]
+    (h : ∀ v, G.degree v ≤ 2)
+    (hbdry : Odd #{v | G.degree v = 1 ∧ B v}) :
+    ∃ v, G.degree v = 1 ∧ ¬ B v := by
+  classical
+  have heven : Even #{v | G.degree v = 1} := even_card_degree_one G h
+  -- Split the degree-1 vertices according to the boundary predicate `B`:
+  -- the boundary part `s.filter B` is the boundary-endpoint count, and the
+  -- complementary part is the interior-endpoint count.
+  have e1 : #(({v | G.degree v = 1} : Finset V).filter B)
+      = #{v | G.degree v = 1 ∧ B v} := by
+    rw [Finset.filter_filter]
+  have e2 : #(({v | G.degree v = 1} : Finset V).filter (fun a => ¬ B a))
+      = #{v | G.degree v = 1 ∧ ¬ B v} := by
+    rw [Finset.filter_filter]
+  have hsplit := Finset.filter_card_add_filter_neg_card_eq_card
+    (s := ({v | G.degree v = 1} : Finset V)) (p := B)
+  rw [e1, e2] at hsplit
+  -- Total endpoints is even; boundary endpoints odd ⟹ interior endpoints odd > 0.
+  rw [Nat.even_iff] at heven
+  rw [Nat.odd_iff] at hbdry
+  have hpos : 0 < #{v | G.degree v = 1 ∧ ¬ B v} := by omega
+  obtain ⟨v, hv⟩ := Finset.card_pos.mp hpos
+  rw [Finset.mem_filter] at hv
+  exact ⟨v, hv.2⟩
+
+end SpernerTuckerPathFollowing


### PR DESCRIPTION
## sperner-mathlib4-oq-02 — Tucker's Lemma / Borsuk–Ulam from abstract door-counting

Two verified n≥2 artifacts, both 0-axiom (`#print axioms` = propext/Classical.choice/Quot.sound only).

### 1. `SpernerTuckerHexagon.lean` — first machine-checked n=2 Tucker instance
On the antipodally symmetric hexagon+centre triangulation of B² (labels {±1,±2} as Fin 4):
- `hexagon_tucker` — **n=2 Tucker holds**: all 256 antipodal labellings have a complementary edge (kernel `decide`).
- `count_parity_not_invariant` — the complementary-edge **count is not a parity invariant** for n=2 (even- and odd-count witnesses). Confirms knowledge-base Insight 3 *in Lean*: the n=1 direct-parity route provably cannot lift to n≥2, while the conclusion still holds.

### 2. `SpernerTuckerPathFollowing.lean` — abstract path-following parity engine for n≥2
The combinatorial heart of the Freund–Todd / Prescott–Su path-following proof, isolated fully abstractly over an arbitrary finite `SimpleGraph`:
- `odd_degree_iff_eq_one` — in a max-degree-≤2 graph, `Odd (degree v) ↔ degree v = 1`.
- `even_card_degree_one` — in a finite simple graph of max degree ≤ 2 (disjoint union of paths and cycles), the number of degree-1 vertices (path endpoints) is **even** — the handshaking lemma (`SimpleGraph.even_card_odd_degree_vertices`) specialised to the almost-complementary-simplex graph.
- `exists_interior_degree_one` — the **path-following step**: if an odd number of degree-1 vertices satisfy a boundary predicate `B`, some degree-1 vertex is interior (`¬ B`). Instantiating `B` = "on the antipodal boundary" yields an interior complementary simplex, i.e. Tucker's lemma.

This is the reusable engine the knowledge base has been pointing at for n≥2. What remains is the dimension-specific geometric construction of the almost-complementary-simplex graph and the odd-boundary-count (lower-dim Tucker induction) step.

### Verification
Verified via `lake env lean` against the main-repo Mathlib olean cache (Docker image build is broken — containerd meta.db I/O error). 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)