### PR TITLE
Enrich Polynomial Szemerédi via Bergelson–Leibman (furstenberg-correspondence-oq-03): annotation depth

### DIFF
--- a/src/data/proofs/furstenberg-correspondence-oq-03/annotations.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-03/annotations.json
@@ -9,7 +9,21 @@
     "type": "concept",
     "title": "Polynomial Szemerédi: Statement and Verified Backbone",
     "content": "This file formalizes the Bergelson–Leibman polynomial Szemerédi theorem (1996), the polynomial extension of Szemerédi's theorem. It does NOT assert the deep theorem — that remains an open formalization target stated here as a Prop. Everything proved is machine-checked (0 axioms, 0 sorries): the configuration object, its algebraic constraints, the linear specialization to arithmetic progressions, a nonlinear square example, and Mathlib's recurrence base case. The combinatorial form: if A ⊆ ℤ has positive upper Banach density and p₁,…,p_k ∈ ℤ[X] have pᵢ(0)=0, then some x and d≠0 give x+pᵢ(d) ∈ A for all i.",
-    "summary": "Statement and verified backbone for the polynomial Szemerédi theorem."
+    "summary": "Statement and verified backbone for the polynomial Szemerédi theorem.",
+    "mathContext": "$A \\subseteq \\mathbb{Z}$ with $\\bar{d}(A) > 0$ and $p_i \\in \\mathbb{Z}[X]$, $p_i(0)=0$ $\\Rightarrow$ $\\exists\\, x,\\, d \\neq 0$ with $x + p_i(d) \\in A$ for all $i$. The ergodic form replaces this with $\\mu(\\bigcap_i T^{-p_i(n)}E) > 0$ for some $n \\neq 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Szemerédi's theorem",
+      "Furstenberg correspondence principle",
+      "polynomial multiple recurrence",
+      "upper Banach density",
+      "van der Waerden's theorem"
+    ],
+    "prerequisites": [
+      "additive combinatorics",
+      "ergodic theory",
+      "density of integer sets"
+    ]
   },
   {
     "id": "ann-furst-oq03-config",
@@ -21,7 +35,19 @@
     "type": "definition",
     "title": "The Polynomial Configuration and Its Collapse at d=0",
     "content": "configPoint p x d i := x + (p i).eval d is the i-th point of the configuration. The no-constant-term predicate NoConstantTerm p says every pᵢ(0)=0. The lemma config_collapses_at_zero verifies that under this hypothesis the configuration degenerates to the single point {x} when d=0. This is exactly why the theorem must demand a nontrivial d≠0: the d=0 solution is always present and carries no information.",
-    "summary": "Configuration object; collapse to {x} at d=0 motivates the d≠0 requirement."
+    "summary": "Configuration object; collapse to {x} at d=0 motivates the d≠0 requirement.",
+    "mathContext": "$\\mathrm{configPoint}(p, x, d, i) = x + p_i(d)$. Under $p_i(0)=0$, at $d=0$ every point equals $x + p_i(0) = x$, so the configuration collapses to the singleton $\\{x\\}$ — the trivial, information-free solution the theorem must exclude.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polynomial evaluation",
+      "nondegeneracy condition",
+      "arithmetic configurations",
+      "Fin k indexing"
+    ],
+    "prerequisites": [
+      "polynomial algebra over ℤ",
+      "polynomial evaluation maps"
+    ]
   },
   {
     "id": "ann-furst-oq03-divisibility",
@@ -33,7 +59,21 @@
     "type": "insight",
     "title": "No Constant Term = Divisibility by X = d ∣ pᵢ(d)",
     "content": "Three equivalent faces of the hypothesis. eval_zero_iff_X_dvd proves pᵢ(0)=0 ↔ X ∣ pᵢ via Mathlib's X_dvd_iff and coeff_zero_eq_eval_zero. dvd_eval_of_noConstantTerm then factors pᵢ = X·q and concludes d ∣ pᵢ(d) for every d. Consequently (configPoint_sub_dvd) every configuration point is congruent to the base point modulo d: the configuration always lives inside the residue-class structure determined by d. This elementary obstruction is one any proof of the full theorem must respect.",
-    "summary": "pᵢ(0)=0 ⇔ X∣pᵢ ⇒ d∣pᵢ(d): every configuration point ≡ x (mod d)."
+    "summary": "pᵢ(0)=0 ⇔ X∣pᵢ ⇒ d∣pᵢ(d): every configuration point ≡ x (mod d).",
+    "mathContext": "$p(0)=0 \\iff p_{[0]}=0 \\iff X \\mid p$. Writing $p = X \\cdot q$ gives $p(d) = d \\cdot q(d)$, so $d \\mid p(d)$ for all $d$. Hence $x + p_i(d) \\equiv x \\pmod{d}$: the whole configuration sits in one residue class mod $d$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polynomial divisibility",
+      "factorization X ∣ p",
+      "residue classes mod d",
+      "Polynomial.X_dvd_iff",
+      "constant coefficient"
+    ],
+    "prerequisites": [
+      "commutative ring theory",
+      "polynomial divisibility",
+      "modular arithmetic"
+    ]
   },
   {
     "id": "ann-furst-oq03-linear",
@@ -45,7 +85,19 @@
     "type": "insight",
     "title": "Szemerédi Is the Degree-One Case",
     "content": "Taking pᵢ = i·X (linearPoly), configPoint_linear shows the configuration is exactly x + i·d — the arithmetic progression x, x+d, …, x+(k-1)d. So Bergelson–Leibman applied to the linear family reproduces Szemerédi's theorem on length-k arithmetic progressions. This makes precise the sense in which the polynomial theorem is an extension: AP-Szemerédi is the degree-one instance.",
-    "summary": "Linear family pᵢ=i·X yields the AP x+i·d, recovering Szemerédi."
+    "summary": "Linear family pᵢ=i·X yields the AP x+i·d, recovering Szemerédi.",
+    "mathContext": "$p_i = i \\cdot X$ gives $p_i(d) = i \\cdot d$, so $\\mathrm{configPoint} = x + i \\cdot d$ — the length-$k$ arithmetic progression $x, x+d, \\dots, x+(k-1)d$. Bergelson–Leibman on $\\{i \\cdot X\\}$ is exactly Szemerédi's theorem; the polynomial theorem is its degree-$\\geq 2$ generalization.",
+    "significance": "key",
+    "relatedConcepts": [
+      "arithmetic progressions",
+      "Szemerédi's theorem",
+      "degree-one specialization",
+      "linear polynomials"
+    ],
+    "prerequisites": [
+      "arithmetic progressions",
+      "polynomial degree"
+    ]
   },
   {
     "id": "ann-furst-oq03-square",
@@ -57,7 +109,19 @@
     "type": "concept",
     "title": "A Genuinely Nonlinear Configuration: Squares",
     "content": "The square family p₀=0, p₁=X² gives the two-point configuration {x, x+d²}. squareConfig_gap_isSquare verifies the gap is a perfect square d². This is the simplest configuration outside the reach of Szemerédi's theorem — Bergelson–Leibman asserts every positive-density set contains such a pair with d≠0, a result with no linear analogue.",
-    "summary": "p₁=X² gives {x, x+d²} with verified perfect-square gap — a nonlinear pattern."
+    "summary": "p₁=X² gives {x, x+d²} with verified perfect-square gap — a nonlinear pattern.",
+    "mathContext": "$p_0 = 0,\\ p_1 = X^2$ gives the pair $\\{x,\\ x + d^2\\}$ with gap $d^2$, a perfect square. The $k=2$ instance asserts every positive-density set contains $x, x+d^2$ with $d \\neq 0$ — the polynomial Sárközy/Furstenberg square-difference phenomenon, with no arithmetic-progression analogue.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "perfect squares",
+      "nonlinear patterns",
+      "Sárközy–Furstenberg theorem",
+      "square differences"
+    ],
+    "prerequisites": [
+      "polynomial algebra over ℤ",
+      "perfect squares"
+    ]
   },
   {
     "id": "ann-furst-oq03-statement",
@@ -69,7 +133,20 @@
     "type": "definition",
     "title": "The Polynomial Szemerédi Property as a Formalization Target",
     "content": "PolynomialSzemerediProperty A packages the combinatorial conclusion as a Prop on A ⊆ ℤ. It is stated, not asserted: a future proof would derive it for every positive-density A via the Furstenberg correspondence and polynomial multiple recurrence. univ_polynomialSzemerediProperty certifies the statement is not vacuously false (ℤ satisfies it), and the .mono lemma shows it transfers up to supersets.",
-    "summary": "Prop-valued target for the combinatorial theorem, with sanity and monotonicity lemmas."
+    "summary": "Prop-valued target for the combinatorial theorem, with sanity and monotonicity lemmas.",
+    "mathContext": "$\\mathrm{PolynomialSzemerediProperty}(A) := \\forall k\\, p,\\ 0 < k \\to \\mathrm{NoConstantTerm}(p) \\to \\exists\\, x, d \\neq 0,\\ \\forall i,\\ \\mathrm{configPoint}(p,x,d,i) \\in A$. Stating it as a $\\mathrm{Prop}$ (not an axiom) makes it a target; $\\mathbb{Z}$ satisfies it via $x=0, d=1$, and $A \\subseteq B$ propagates it upward.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Prop-valued formalization target",
+      "monotonicity under inclusion",
+      "Furstenberg correspondence",
+      "vacuous-truth sanity check"
+    ],
+    "prerequisites": [
+      "predicate logic",
+      "set theory",
+      "Lean Prop encoding"
+    ]
   },
   {
     "id": "ann-furst-oq03-ergodic",
@@ -81,6 +158,21 @@
     "type": "insight",
     "title": "Poincaré Recurrence Is the k=1 Base Case",
     "content": "The ergodic proof proceeds through polynomial multiple recurrence. poincare_single_recurrence derives single recurrence from Mathlib's MeasurePreserving.conservative — this is k=1, p₁(n)=n. measurePreserving_iterate_eval verifies that polynomial-exponent iterates T^{p(n)} stay measure-preserving, the elementary fact underlying the averages (1/N)Σ μ(E ∩ T^{-p(n)}E). PolynomialMultipleRecurrence states the full k≥2 conclusion as a target. The gap to k≥2 is PET induction plus nilsystem characteristic-factor theory, neither in Mathlib.",
-    "summary": "Mathlib supplies the k=1 base case (Poincaré); k≥2 needs nilsystem machinery."
+    "summary": "Mathlib supplies the k=1 base case (Poincaré); k≥2 needs nilsystem machinery.",
+    "mathContext": "$k=1,\\ p_1(n)=n$: $\\exists n>0,\\ \\mu(E \\cap T^{-n}E) \\neq 0$ — Poincaré recurrence from $\\mathrm{MeasurePreserving.conservative}$. The general statement seeks $n \\neq 0$ with $\\mu\\!\\left(\\bigcap_i T^{-p_i(n)}E\\right) > 0$; $T^{[p(n)]}$ stays measure-preserving, but $k \\geq 2$ needs PET induction and characteristic-factor (nilsystem) theory.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Poincaré recurrence",
+      "measure-preserving systems",
+      "PET induction",
+      "nilsystems",
+      "characteristic factors",
+      "multiple recurrence"
+    ],
+    "prerequisites": [
+      "measure theory",
+      "ergodic theory",
+      "measure-preserving transformations"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `furstenberg-correspondence-oq-03` (passes: 0, quality: 70).

## Changes
Added the four annotation-depth fields to **all 7 annotations** (none had them previously):
- **mathContext**: LaTeX formulas — the combinatorial/ergodic statements, $\mathrm{configPoint}=x+p_i(d)$, the divisibility chain $p(0)=0 \iff X\mid p \iff d\mid p(d)$, the linear AP specialization, the square pair $\{x,x+d^2\}$, the Prop-target definition, and Poincaré k=1 recurrence.
- **significance**: key/supporting classification.
- **relatedConcepts**: e.g. Szemerédi, Furstenberg correspondence, PET induction, nilsystems, characteristic factors, Sárközy–Furstenberg.
- **prerequisites**: e.g. additive combinatorics, ergodic theory, polynomial divisibility, measure theory.

meta.json was already mature (12 KB, well under caps) — overview, conclusion, sections, and crossReferences left intact. No index.ts added (vestigial per #20993).

Content verified accurate against `proofs/Proofs/FurstenbergCorrespondenceOQ03.lean` (0 axioms, 0 sorries; deep theorem stated as Prop target, not asserted).