### PR TITLE
research(lovasz-local-lemma-oq-01): threshold monotonicity T(d+1) ≤ T(d) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LovaszLocalLemma.lean
+++ b/proofs/Proofs/LovaszLocalLemma.lean
@@ -361,4 +361,111 @@ theorem symmetric_lll_complete (n d : ℕ) (hd : 0 < d)
   ⟨threshold_satisfies_lll n d hd prob adj hdeg hprob,
    symmetric_lll_avoidance n d hd⟩
 
+-- ═══════════════════════════════════════════════════════════════════
+-- PART XI: THRESHOLD MONOTONICITY
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Bridge identity: (d+1)·T(d) = (d/(d+1))ᵈ, the symmetric avoidance
+    factor for the assignment xᵢ = 1/(d+1). This rescales the threshold
+    into the textbook avoidance-product form and is an immediate
+    consequence of `lllThreshold_eq_product`. -/
+theorem lllThreshold_mul_succ (d : ℕ) (hd : 0 < d) :
+    (↑d + 1) * lllThreshold d = (↑d / (↑d + 1 : ℚ)) ^ d := by
+  rw [lllThreshold_eq_product d hd]
+  have h : (↑d + 1 : ℚ) ≠ 0 := by positivity
+  field_simp
+
+/-- The arithmetic kernel of threshold monotonicity, written after
+    cross-multiplication: for `a = d ≥ 1`,
+    `(a+1)^{d+1}·(a+1)^{d+1} ≤ aᵈ·(a+2)^{d+2}`.
+
+    Proof idea: factor both sides as `((a+1)²)ᵈ·(a+1)²` and
+    `(a(a+2))ᵈ·(a+2)²`. Bernoulli's inequality applied to
+    `(1 - 1/(a+1)²)ᵈ ≥ 1 - d/(a+1)²` (note `a(a+2) = (a+1)² - 1`) gives
+    `(a(a+2))ᵈ·(a+1)² ≥ ((a+1)²)ᵈ·(a²+a+1)`, and the residual polynomial
+    inequality `(a²+a+1)(a+2)² ≥ (a+1)⁴` closes the gap. -/
+private theorem threshold_mono_key (d : ℕ) (hd : 1 ≤ d) :
+    ((↑d : ℚ) + 1) ^ (d + 1) * ((↑d : ℚ) + 1) ^ (d + 1) ≤
+      (↑d : ℚ) ^ d * ((↑d : ℚ) + 2) ^ (d + 2) := by
+  set a : ℚ := (↑d : ℚ) with ha
+  have ha1 : (1 : ℚ) ≤ a := by rw [ha]; exact_mod_cast hd
+  have ha0 : (0 : ℚ) < a := by linarith
+  have hane : (a + 1 : ℚ) ≠ 0 := by positivity
+  have hA : (0 : ℚ) < (a + 1) ^ 2 := by positivity
+  have hYnn : (0 : ℚ) ≤ ((a + 1) ^ 2) ^ d := by positivity
+  have hXnn : (0 : ℚ) ≤ (a * (a + 2)) ^ d := by positivity
+  -- Bernoulli: (1 - 1/(a+1)²)ᵈ ≥ 1 - a/(a+1)², with base = a(a+2)/(a+1)².
+  have hx : (-1 : ℚ) ≤ -(1 / (a + 1) ^ 2) := by
+    have h1 : (1 : ℚ) / (a + 1) ^ 2 ≤ 1 := by
+      rw [div_le_one hA]; nlinarith [ha1]
+    linarith
+  have hbern : 1 - a / (a + 1) ^ 2 ≤ (a * (a + 2) / (a + 1) ^ 2) ^ d := by
+    have hb := bernoulli_ineq d hx
+    rw [← ha] at hb
+    have hbase : (1 : ℚ) + -(1 / (a + 1) ^ 2) = a * (a + 2) / (a + 1) ^ 2 := by
+      field_simp; ring
+    rw [hbase] at hb
+    have hlhs : (1 : ℚ) + a * -(1 / (a + 1) ^ 2) = 1 - a / (a + 1) ^ 2 := by ring
+    rw [hlhs] at hb
+    exact hb
+  -- Clear the d-th power: ((a+1)²)ᵈ·(a²+a+1) ≤ (a(a+2))ᵈ·(a+1)².
+  have hYpos : (0 : ℚ) < ((a + 1) ^ 2) ^ d := by positivity
+  have ediv : (a * (a + 2) / (a + 1) ^ 2) ^ d
+      = (a * (a + 2)) ^ d / ((a + 1) ^ 2) ^ d := by rw [div_pow]
+  rw [ediv, le_div_iff₀ hYpos] at hbern
+  have h2 := mul_le_mul_of_nonneg_right hbern (le_of_lt hA)
+  have hsimp : (1 - a / (a + 1) ^ 2) * ((a + 1) ^ 2) ^ d * (a + 1) ^ 2
+      = ((a + 1) ^ 2) ^ d * (a ^ 2 + a + 1) := by
+    field_simp; ring
+  rw [hsimp] at h2
+  -- h2 : ((a+1)²)ᵈ·(a²+a+1) ≤ (a(a+2))ᵈ·(a+1)²
+  -- Residual polynomial inequality.
+  have hpoly : (a + 1) ^ 4 ≤ (a ^ 2 + a + 1) * (a + 2) ^ 2 := by
+    nlinarith [ha0, mul_pos ha0 ha0, mul_pos (mul_pos ha0 ha0) ha0]
+  -- Combine into the factored target ((a+1)²)ᵈ·(a+1)² ≤ (a(a+2))ᵈ·(a+2)².
+  have hgoal : ((a + 1) ^ 2) ^ d * (a + 1) ^ 2
+      ≤ (a * (a + 2)) ^ d * (a + 2) ^ 2 := by
+    have hbig : (((a + 1) ^ 2) ^ d * (a + 1) ^ 2) * (a + 1) ^ 2
+        ≤ ((a * (a + 2)) ^ d * (a + 2) ^ 2) * (a + 1) ^ 2 := by
+      nlinarith [mul_le_mul_of_nonneg_right h2 (sq_nonneg (a + 2)),
+                 mul_le_mul_of_nonneg_left hpoly hYnn, hXnn, hYnn]
+    exact le_of_mul_le_mul_right hbig hA
+  -- Refold the factored forms back to the original power expressions.
+  have hL : (a + 1) ^ (d + 1) * (a + 1) ^ (d + 1)
+      = ((a + 1) ^ 2) ^ d * (a + 1) ^ 2 := by
+    rw [← pow_add, ← pow_mul, ← pow_add]; congr 1; ring
+  have hR : a ^ d * (a + 2) ^ (d + 2)
+      = (a * (a + 2)) ^ d * (a + 2) ^ 2 := by
+    rw [pow_add, ← mul_assoc, ← mul_pow]
+  rw [hL, hR]
+  exact hgoal
+
+/-- **Threshold monotonicity**: the symmetric LLL threshold
+    `T(d) = dᵈ/(d+1)^{d+1}` is decreasing in the dependency degree —
+    `T(d+1) ≤ T(d)` for every `d ≥ 1`. Higher-degree dependency graphs
+    admit a smaller per-event probability budget. This subsumes
+    `lllThreshold_le_quarter`, since iterating from `T(1) = 1/4` bounds
+    every `T(d) ≤ 1/4`. -/
+theorem lllThreshold_succ_le (d : ℕ) (hd : 1 ≤ d) :
+    lllThreshold (d + 1) ≤ lllThreshold d := by
+  have hd0 : d ≠ 0 := by omega
+  have hd1 : d + 1 ≠ 0 := by omega
+  simp only [lllThreshold, if_neg hd0, if_neg hd1]
+  have e : (↑(d + 1) : ℚ) = ↑d + 1 := by push_cast; ring
+  rw [e, div_le_div_iff₀ (by positivity) (by positivity)]
+  have e2 : (↑d + 1 + 1 : ℚ) = ↑d + 2 := by ring
+  rw [e2]
+  exact threshold_mono_key d hd
+
+/-- Threshold monotonicity in `≤`-chain form for arbitrary degrees
+    `1 ≤ c ≤ d`: `T(d) ≤ T(c)`. Proved by induction on the gap using
+    `lllThreshold_succ_le`. -/
+theorem lllThreshold_antitone {c d : ℕ} (hc : 1 ≤ c) (hcd : c ≤ d) :
+    lllThreshold d ≤ lllThreshold c := by
+  induction d, hcd using Nat.le_induction with
+  | base => exact le_refl _
+  | succ n hn ih =>
+    have hn1 : 1 ≤ n := le_trans hc hn
+    exact le_trans (lllThreshold_succ_le n hn1) ih
+
 end ProbMethod.LovaszLocal

--- a/research/problems/lovasz-local-lemma-oq-01/knowledge.md
+++ b/research/problems/lovasz-local-lemma-oq-01/knowledge.md
@@ -6,16 +6,43 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+- The research-pool *title* "Finite Symmetric Thresholds" is a misnomer: that
+  rational/combinatorial surrogate is already fully complete in
+  `Proofs/LovaszLocalLemma.lean` (0 sorries, 0 axioms). The authoritative goal
+  (problem.md) is the **measure-theoretic** probabilistic LLL, which is still
+  open and research-grade.
+- `lllThreshold d = dᵈ/(d+1)^{d+1}` is the exact maximum of `x(1-x)ᵈ` over
+  `x ∈ [0,1)`, attained at `x = 1/(d+1)`. It equals `(1/(d+1))·(d/(d+1))ᵈ`
+  (`lllThreshold_eq_product`).
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **Threshold monotonicity** `T(d+1) ≤ T(d)` (and the chain `T(d) ≤ T(c)` for
+  `1 ≤ c ≤ d`) holds and is now formalized. It subsumes the universal bound
+  `T(d) ≤ 1/4` because `T(1) = 1/4`.
+- Monotonicity reduces (after cross-multiplication) to the elementary
+  polynomial inequality `(a+1)^{2d+2} ≤ aᵈ(a+2)^{d+2}`, which yields to a single
+  application of Bernoulli `(1-1/(a+1)²)ᵈ ≥ 1 - d/(a+1)²` plus the residual
+  `(a²+a+1)(a+2)² ≥ (a+1)⁴` (difference `a³+3a²+4a+3`). No real analysis / `exp`
+  needed — stays entirely in ℚ.
+- Reusable Lean pattern: to clear an `xᵈ`-power inequality of the form
+  `c ≤ (p/q)ᵈ`, rewrite with `div_pow` then `le_div_iff₀ (0 < qᵈ)`, multiply
+  through by the residual denominator with `mul_le_mul_of_nonneg_right`, and
+  hand the opaque `pᵈ`, `qᵈ` factors to `nlinarith` as atoms.
+- `div_le_div_iff` is gone in this Mathlib; use **`div_le_div_iff₀`**
+  `(hb : 0<b) (hd : 0<d) : a/b ≤ c/d ↔ a*d ≤ c*b`. Likewise `le_div_iff` →
+  `le_div_iff₀`.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Trying to prove `(a+1)^{2d+2} ≤ aᵈ(a+2)^{d+2}` term-by-term fails: the
+  base-power factor `((a+1)²)ᵈ ≥ (a(a+2))ᵈ` points the *wrong* way; the
+  `(a+2)²` vs `(a+1)²` factor is what compensates, so the Bernoulli/ratio
+  argument is required rather than monotonicity of `xⁿ`.
+- The measure-theoretic LLL is NOT a quick increment: Mathlib supplies
+  `iIndepSet`, `ProbabilityMeasure`, `cond`, but no LLL, and a real proof spans
+  multiple sessions.

--- a/research/problems/lovasz-local-lemma-oq-01/state.md
+++ b/research/problems/lovasz-local-lemma-oq-01/state.md
@@ -1,67 +1,51 @@
 # Research State: lovasz-local-lemma-oq-01
 
 ## Current State
-**Phase**: ORIENT → SURVEYED (true goal scoped; rational surrogate already complete)
+**Phase**: ACT (new verified results landed; measure-theoretic core still open)
 **Path**: full
-**Since**: 2026-06-26
-**Iteration**: 2
+**Since**: 2026-06-27
+**Iteration**: 3
 
-## Current Focus
+## This session (researcher-9, 2026-06-27)
 
-Authoritative goal (problem.md): **formalize the full probabilistic LLL with
-measure-theoretic probability spaces in Lean 4**. (The research-pool *title*
-"Finite Symmetric Thresholds" is a misnomer — that scope is already done; see
-below.)
+Landed three new **verified, 0-axiom** theorems in
+`Proofs/LovaszLocalLemma.lean` (Part XI), advancing roadmap items 2 and 3 from
+the prior session. Verified via `lake env lean` against the main-repo Mathlib
+`.olean` cache (Docker image build still broken — containerd meta.db I/O
+error). `#print axioms` on all three: only `[propext, Classical.choice,
+Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
 
-## Key finding 1: the rational/combinatorial surrogate is already complete
+1. **`lllThreshold_succ_le (d) (hd : 1 ≤ d) : T(d+1) ≤ T(d)`** — threshold
+   monotonicity. The symmetric LLL probability budget `T(d) = dᵈ/(d+1)^{d+1}`
+   shrinks as dependency degree grows. *This is the flagship new result*; it
+   subsumes the existing `lllThreshold_le_quarter` (iterate down to T(1)=1/4).
+2. **`lllThreshold_antitone {c d} (1 ≤ c) (c ≤ d) : T(d) ≤ T(c)`** — chain form,
+   by `Nat.le_induction` on the gap.
+3. **`lllThreshold_mul_succ (d) (hd : 0 < d) : (d+1)·T(d) = (d/(d+1))ᵈ`** —
+   bridge identity (roadmap item 2), immediate from `lllThreshold_eq_product`.
 
-`Proofs/LovaszLocalLemma.lean` (364 lines, **0 sorries, 0 axioms**) already
-proves the symmetric/general bounds, K-SAT (`ksat_lll`), Moser–Tardos
-(`moser_tardos_termination`, `symmetric_moser_tardos_bound`), and the full
-threshold theory: `lllThreshold d = d^d/(d+1)^(d+1)`, `lllThreshold_pos`, and
-`lllThreshold_le_quarter (d) (hd : 1 ≤ d)` for ALL d ≥ 1. There is no
-`LovaszLocalLemmaOQ01.lean` and no gallery dir; re-proving any of the above
-would be duplication.
+### Proof technique for monotonicity (reusable)
+Cross-multiply `T(d+1) ≤ T(d)` (via `div_le_div_iff₀`) to the polynomial
+target `(a+1)^{2d+2} ≤ aᵈ(a+2)^{d+2}` with `a = ↑d`. Factor both sides as
+`((a+1)²)ᵈ·(a+1)²` and `(a(a+2))ᵈ·(a+2)²` (`pow_add`/`pow_mul`/`mul_pow`).
+Apply the file's own `bernoulli_ineq` to `(1 - 1/(a+1)²)ᵈ ≥ 1 - d/(a+1)²`
+(note `a(a+2) = (a+1)²-1`), clear the `d`-th power with `le_div_iff₀`, then
+finish with the residual polynomial inequality `(a²+a+1)(a+2)² ≥ (a+1)⁴`
+(difference `= a³+3a²+4a+3 ≥ 0`) via `nlinarith` plus a multiply-out by `(a+1)²`
+(`le_of_mul_le_mul_right`).
 
-These are stated over `ℚ` with probabilities as rationals and dependency
-encoded combinatorially (`IsValidDepGraph`, `HasMaxDegree`) — a faithful
-*surrogate*, but NOT a measure-theoretic probability space.
+## Still open (the genuine OQ-01 deliverable)
 
-## Key finding 2: the genuine gap is measure-theoretic
-
-The true OQ-01 deliverable is the LLL over an actual probability space:
-events as measurable sets `A_i : Set Ω` in a `MeasureTheory.ProbabilityMeasure`,
-a real dependency/independence relation, and the conclusion
-`μ (⋂ i, (A_i)ᶜ) > 0`. Mathlib provides the needed primitives —
-`ProbabilityTheory.iIndepSet`, `MeasureTheory.Measure`, `condProb`/`cond`,
-`ProbabilityTheory.cond` — but no LLL. A full proof (the Spencer / cluster-
-expansion or the Moser–Tardos entropy-compression argument over a real measure
-space) is research-grade and spans multiple sessions.
-
-## Concrete tractable first increment (for a build-enabled session)
-
-1. State the measure-theoretic symmetric LLL as a Lean theorem (events in a
-   `ProbabilityMeasure`, `iIndepSet` for the non-neighbours, `μ Aᵢ ≤ p`,
-   `e·p·(d+1) ≤ 1` ⟹ `μ (⋂ Aᵢᶜ) > 0`) — a precise specification, even before
-   the proof.
-2. Bridge identity (low-risk, pure ℚ algebra) linking the surrogate to the
-   classical form: `(d+1) * lllThreshold d = (d/(d+1))^d ↗ 1/e`, i.e. the MT
-   threshold dominates the textbook `1/(e(d+1))` bound. The base file uses the
-   `d^d/(d+1)^(d+1)` form but never states this.
-3. General-d threshold monotonicity `lllThreshold (d+1) ≤ lllThreshold d`
-   (reduces to `(d+1)^(2d+2) ≤ d^d·(d+2)^(d+2)`), which would subsume
-   `lllThreshold_le_quarter`.
-
-## Blockers
-
-The measure-theoretic formalization is a large effort (Mathlib has the
-probability primitives but no LLL). Docker was down this session, so even the
-low-risk increments (items 2–3) could not be build-verified; landing
-unverified non-trivial inequalities is unsafe.
+The measure-theoretic probability-space LLL remains unformalized: events as
+measurable sets `Aᵢ : Set Ω` in a `ProbabilityMeasure`, real
+dependency/independence (`ProbabilityTheory.iIndepSet`), and the conclusion
+`μ (⋂ Aᵢᶜ) > 0`. Mathlib has the primitives but no LLL. This is the
+multi-session research-grade target (Spencer/cluster-expansion or Moser–Tardos
+entropy-compression over a real measure space).
 
 ## Next Action
 
-In a session with a working build: start with item 1 (state the
-measure-theoretic symmetric LLL precisely, as a Prop / sorried theorem) and
-item 2 (the `(d+1)·lllThreshold d = (d/(d+1))^d` bridge). Do NOT re-prove the
-rational surrogate — it is already complete in `LovaszLocalLemma.lean`.
+Roadmap item 1: state the measure-theoretic symmetric LLL precisely as a
+`Prop`/theorem statement (with `sorry`) in a *separate* file so the clean
+`LovaszLocalLemma.lean` stays 0-sorry. Do NOT re-prove the rational surrogate.
+The monotonicity/bridge increments are now done.

--- a/src/data/proofs/lovasz-local-lemma/meta.json
+++ b/src/data/proofs/lovasz-local-lemma/meta.json
@@ -20,8 +20,8 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 364,
-    "theoremCount": 25,
+    "lineCount": 471,
+    "theoremCount": 29,
     "definitionCount": 3,
     "originalContributions": [
       "Ten-part algebraic formalization of the Lovász Local Lemma covering symmetric and general cases",
@@ -31,7 +31,9 @@
       "Moser-Tardos constructive LLL bound: nonnegative expected resampling count Σ x_i/(1-x_i)",
       "Dependency graph structure: IsValidDepGraph and HasMaxDegree predicates",
       "threshold_satisfies_lll bridging symmetric threshold to the general LLL framework",
-      "Bernoulli's inequality proved by induction; (1+1/d)^d ≥ 2 and (d+1)^d ≥ 2·d^d as corollaries"
+      "Bernoulli's inequality proved by induction; (1+1/d)^d ≥ 2 and (d+1)^d ≥ 2·d^d as corollaries",
+      "Threshold monotonicity lllThreshold_succ_le: T(d+1) ≤ T(d) for all d ≥ 1, and lllThreshold_antitone: T(d) ≤ T(c) for 1 ≤ c ≤ d — the LLL probability budget shrinks as dependency degree grows; subsumes lllThreshold_le_quarter via T(1) = 1/4",
+      "Bridge identity lllThreshold_mul_succ: (d+1)·T(d) = (d/(d+1))^d, rescaling the threshold into the symmetric avoidance-product form"
     ]
   },
   "overview": {
@@ -305,12 +307,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 364,
+    "lineCount": 471,
     "path": "Proofs/LovaszLocalLemma.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 25
+    "theoremCount": 29
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Advances the **Lovász Local Lemma** gallery proof (`lovasz-local-lemma`, research problem `lovasz-local-lemma-oq-01`) with three new **verified, axiom-free** theorems in `Proofs/LovaszLocalLemma.lean` (Part XI). These discharge roadmap items 2–3 left by the prior research session.

### New results
- **`lllThreshold_succ_le (d) (hd : 1 ≤ d) : T(d+1) ≤ T(d)`** — *threshold monotonicity*. The symmetric LLL threshold `T(d) = dᵈ/(d+1)^{d+1}` (the max per-event probability the symmetric LLL tolerates at dependency degree `d`) is decreasing in `d`: a denser dependency graph permits a smaller probability budget. Flagship new result; **subsumes** the existing `lllThreshold_le_quarter` since `T(1) = 1/4`.
- **`lllThreshold_antitone {c d} (1 ≤ c) (c ≤ d) : T(d) ≤ T(c)`** — chain form, by `Nat.le_induction`.
- **`lllThreshold_mul_succ (d) (hd : 0 < d) : (d+1)·T(d) = (d/(d+1))ᵈ`** — bridge identity rescaling the threshold to the symmetric avoidance-product form.

### Proof
Entirely in ℚ — no real-analytic `exp`. Cross-multiply `T(d+1) ≤ T(d)` to the polynomial target `(a+1)^{2d+2} ≤ aᵈ(a+2)^{d+2}` (`a = ↑d`), factor both sides, apply the file's own `bernoulli_ineq` to `(1 - 1/(a+1)²)ᵈ ≥ 1 - d/(a+1)²` (using `a(a+2) = (a+1)²-1`), and close with the residual `(a²+a+1)(a+2)² ≥ (a+1)⁴` (difference `a³+3a²+4a+3 ≥ 0`).

## Verification
- `lake env lean Proofs/LovaszLocalLemma.lean` → **exit 0**, no errors, against the main-repo Mathlib `.olean` cache. (Docker image build is currently broken: containerd `meta.db` I/O error.)
- `#print axioms` on all three theorems → only `[propext, Classical.choice, Quot.sound]`. No `sorryAx`, no `Lean.ofReduceBool`. **0-axiom / verified.**
- `meta.json` `leanFile` stats updated: 364→471 lines, 25→29 theorems; status remains `verified` / `original`, axiomCount 0.

## Scope
The full measure-theoretic probability-space LLL (`μ (⋂ Aᵢᶜ) > 0` over a `ProbabilityMeasure` with `iIndepSet`) remains the open OQ-01 deliverable; this PR extends only the complete rational/combinatorial slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)