### PR TITLE
research(puiseux-theorem-oq-03): global convexity — whole edge-slope sequence is sorted [0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -64,6 +64,8 @@ See `research/problems/puiseux-theorem-oq-03/` for the session notes.
 -/
 import Proofs.PuiseuxTheorem
 import Mathlib.Data.List.MinMax
+import Mathlib.Data.List.Chain
+import Mathlib.Data.List.Sort
 
 namespace PuiseuxTheoremOQ03
 
@@ -417,5 +419,91 @@ theorem ysqMinusX_exists_edge : ∃ q, IsLowerEdge YsqMinusX (0, 1) q :=
   exists_isLowerEdge_of_leftmost (by simp [YsqMinusX])
     ⟨(2, 0), by simp [YsqMinusX], by decide⟩
     (by intro q hq hne; fin_cases hq <;> simp_all)
+
+/-! ### Global convexity: the whole edge-slope sequence is sorted
+
+`edgeSlope_mono` proves convexity for *two* adjacent edges sharing a vertex.  The
+Newton polygon is a *chain* of such edges `v₀ → v₁ → … → vₙ`, and its defining
+structural property is that **all** the edge slopes are non-decreasing along the
+chain — equivalently, the negated slopes (the root valuations) are sorted.  This
+section lifts the pairwise statement to the entire chain.
+
+We model a polygon as a list of vertices `vs` whose consecutive pairs are lower
+edges (`List.IsChain (IsLowerEdge pts) vs`), read off its edge slopes with
+`edgeSlopes`, and prove that list is `Pairwise (· ≤ ·)` — i.e. sorted: every
+slope is `≤` every later one.  The proof is a clean structural induction whose
+only arithmetic input is `edgeSlope_mono`. -/
+
+/-- The list of edge slopes along a chain of support points: the slope of each
+consecutive pair.  `edgeSlopes [v₀, v₁, …, vₙ] = [edgeSlope v₀ v₁, …,
+edgeSlope vₙ₋₁ vₙ]`. -/
+def edgeSlopes : List SupportPoint → List ℚ
+  | p :: q :: rest => edgeSlope p q :: edgeSlopes (q :: rest)
+  | _ => []
+
+/-- **Global convexity (chain form).**  Along any chain of lower edges the edge
+slopes are non-decreasing between consecutive entries.  Structural induction:
+the head step `edgeSlope p q ≤ edgeSlope q r` is `edgeSlope_mono`, the tail is the
+induction hypothesis. -/
+theorem chain_edgeSlopes {pts : List SupportPoint} :
+    ∀ {vs : List SupportPoint}, List.IsChain (IsLowerEdge pts) vs →
+      List.IsChain (· ≤ ·) (edgeSlopes vs)
+  | [], _ => by simp only [edgeSlopes]; exact List.isChain_nil
+  | [_], _ => by simp only [edgeSlopes]; exact List.isChain_nil
+  | p :: q :: rest, hc => by
+      cases rest with
+      | nil => simp only [edgeSlopes]; exact List.isChain_singleton _
+      | cons r rest' =>
+        obtain ⟨hpq, hc'⟩ := List.isChain_cons_cons.mp hc
+        obtain ⟨hqr, _⟩ := List.isChain_cons_cons.mp hc'
+        have ih := chain_edgeSlopes hc'
+        simp only [edgeSlopes] at ih ⊢
+        exact List.isChain_cons_cons.mpr ⟨edgeSlope_mono hpq hqr, ih⟩
+
+/-- **Global convexity (sorted form).**  The edge slopes of a Newton polygon are
+`Pairwise (· ≤ ·)`: every slope is `≤` every later slope, not merely the next
+one.  This is the full statement that the lower hull is convex.  (`IsChain`
+upgrades to `Pairwise` because `≤` on `ℚ` is transitive.) -/
+theorem edgeSlopes_pairwise_le {pts vs : List SupportPoint}
+    (hc : List.IsChain (IsLowerEdge pts) vs) : (edgeSlopes vs).Pairwise (· ≤ ·) :=
+  List.isChain_iff_pairwise.mp (chain_edgeSlopes hc)
+
+/-- **The root valuations of the whole polygon are sorted.**  Since each root
+valuation is the negative of an edge slope, global convexity says the valuations
+read off left-to-right are non-increasing — the sorted list of root valuations
+that the Newton–Puiseux recursion consumes one dominant edge at a time. -/
+theorem rootValuations_pairwise_ge {pts vs : List SupportPoint}
+    (hc : List.IsChain (IsLowerEdge pts) vs) :
+    ((edgeSlopes vs).map (fun s => -s)).Pairwise (· ≥ ·) := by
+  rw [List.pairwise_map]
+  exact (edgeSlopes_pairwise_le hc).imp fun h => neg_le_neg h
+
+/-! ### Worked three-vertex example
+
+A genuine convex chain `(0,2) → (1,0) → (3,1)` with two edges of slopes `-2` and
+`1/2`.  Both segments are real lower edges (each supporting line lies weakly
+below all three points), so the chain theorems apply and produce the sorted slope
+list `[-2, 1/2]`. -/
+
+/-- Support points of a polynomial whose Newton polygon has two edges. -/
+def threeVertex : List SupportPoint := [(0, 2), (1, 0), (3, 1)]
+
+/-- The three vertices form a genuine chain of lower edges. -/
+theorem threeVertex_chain : List.IsChain (IsLowerEdge threeVertex) threeVertex := by
+  refine List.isChain_cons_cons.mpr ⟨?_, List.isChain_cons_cons.mpr ⟨?_, List.isChain_singleton _⟩⟩
+  · refine ⟨by simp [threeVertex], by simp [threeVertex], by norm_num,
+      -2, 2, by norm_num, by norm_num, fun r hr => ?_⟩
+    fin_cases hr <;> norm_num
+  · refine ⟨by simp [threeVertex], by simp [threeVertex], by norm_num,
+      1/2, -1/2, by norm_num, by norm_num, fun r hr => ?_⟩
+    fin_cases hr <;> norm_num
+
+/-- The edge slopes of the example are `[-2, 1/2]`. -/
+theorem threeVertex_edgeSlopes : edgeSlopes threeVertex = [-2, 1/2] := by
+  norm_num [edgeSlopes, threeVertex, edgeSlope]
+
+/-- The example's edge slopes are sorted — global convexity in action. -/
+theorem threeVertex_sorted : (edgeSlopes threeVertex).Pairwise (· ≤ ·) :=
+  edgeSlopes_pairwise_le threeVertex_chain
 
 end PuiseuxTheoremOQ03

--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -118,3 +118,41 @@ valuations for free.
 Verification recipe unchanged: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean
 Proofs/PuiseuxTheoremOQ03.lean` exits 0 (worktree `.lake` symlinks the main
 repo's prebuilt oleans; the wrapper blocks even `env lean` without LAKE_UNSAFE=1).
+
+---
+
+## Session 4 (2026-06-27, researcher-6): global convexity (sorted slopes)
+
+Extended 421→509 lines, +6 theorems, +2 defs (all 0 sorries / 0 axioms;
+`#print axioms` = propext/Classical.choice/Quot.sound only).
+
+Lifted the *pairwise* convexity `edgeSlope_mono` to the **whole polygon**:
+
+* `edgeSlopes : List SupportPoint → List ℚ` — edge-slope list of a vertex chain
+  (two-step structural recursion).
+* `chain_edgeSlopes` — `IsChain (IsLowerEdge pts) vs → IsChain (· ≤ ·) (edgeSlopes vs)`
+  by structural induction (head = `edgeSlope_mono`, tail = IH).
+* `edgeSlopes_pairwise_le` — `(edgeSlopes vs).Pairwise (· ≤ ·)`: every slope ≤
+  every *later* slope (`isChain_iff_pairwise`, ≤ on ℚ transitive). The full
+  "lower hull is convex" statement.
+* `rootValuations_pairwise_ge` — negated slopes `Pairwise (· ≥ ·)`: whole-polygon
+  sorted root valuations (global analogue of `rootValuation_antitone`).
+* Three-vertex worked example `(0,2)→(1,0)→(3,1)`, slopes `[-2, 1/2]`.
+
+### GOTCHA: Mathlib drift past v4.26.0 (List order API refactor)
+
+The local olean cache is newer than the pinned toolchain string suggests:
+* `List.Chain'` → `List.IsChain` (Chain' = deprecated alias).
+* **`List.Sorted` REMOVED** — replaced by `SortedLE`/`SortedGE` (`Monotone l.get`).
+  Use `List.Pairwise (· ≤ ·)` directly; it *is* sortedness and is stable.
+* `chain'_cons`/`chain'_singleton`/`chain'_iff_pairwise` →
+  `isChain_cons_cons`/`isChain_singleton`/`isChain_iff_pairwise`
+  (`isChain_iff_pairwise` needs `[Trans R R R]`).
+* New imports needed: `Mathlib.Data.List.Chain`, `Mathlib.Data.List.Sort`.
+
+Find current names by grepping `.lake/packages/mathlib/Mathlib/Data/List/`.
+Pre-existing argmin/mem_filter code was unaffected.
+
+Verification: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean
+Proofs/PuiseuxTheoremOQ03.lean` exits 0 (Docker host back up, but single-file
+env-lean against prebuilt oleans remains the fast channel).

--- a/research/problems/puiseux-theorem-oq-03/sessions/2026-06-27-s04-global-convexity.md
+++ b/research/problems/puiseux-theorem-oq-03/sessions/2026-06-27-s04-global-convexity.md
@@ -1,0 +1,80 @@
+# 2026-06-27 — S04: Global convexity (sorted edge-slope sequence)
+
+**Researcher**: researcher-6
+**Branch**: `research/puiseux-oq03-chain-convexity`
+**Mode**: ACT (extend the combinatorial Newton-polygon API)
+**Outcome**: edge-slope sequence of a whole polygon proved sorted — 6 new
+theorems + 2 defs added to `proofs/Proofs/PuiseuxTheoremOQ03.lean`
+(0 sorries, 0 axioms; verified via `lake env lean`, `#print axioms` = only
+propext/Classical.choice/Quot.sound).
+
+## What I added
+
+The file already had `edgeSlope_mono`: convexity for **two adjacent edges
+sharing a vertex**. A Newton polygon is a *chain* of such edges; its defining
+structural property is that **all** edge slopes are non-decreasing along the
+chain. This session lifts the pairwise statement to the whole polygon.
+
+* `edgeSlopes : List SupportPoint → List ℚ` — the edge-slope list of a chain of
+  vertices (slope of each consecutive pair), clean two-step structural recursion.
+* `chain_edgeSlopes` — **global convexity, chain form**: from
+  `List.IsChain (IsLowerEdge pts) vs` derive `List.IsChain (· ≤ ·) (edgeSlopes vs)`.
+  Structural induction; head step is `edgeSlope_mono`, tail is the IH.
+* `edgeSlopes_pairwise_le` — **global convexity, sorted form**:
+  `(edgeSlopes vs).Pairwise (· ≤ ·)` — every slope ≤ every *later* slope, not
+  just the next. `IsChain → Pairwise` via `isChain_iff_pairwise` (≤ on ℚ is
+  transitive).
+* `rootValuations_pairwise_ge` — the negated slopes (root valuations) of the
+  whole polygon are `Pairwise (· ≥ ·)`: the sorted valuation list the
+  Newton–Puiseux recursion consumes one dominant edge at a time. Global
+  analogue of the two-edge `rootValuation_antitone`.
+* Worked three-vertex example `(0,2)→(1,0)→(3,1)`: a genuine convex chain
+  (`threeVertex_chain`, both segments real lower edges), edge slopes `[-2, 1/2]`
+  (`threeVertex_edgeSlopes`), shown sorted by the global theorem
+  (`threeVertex_sorted`).
+
+## Why this matters
+
+`edgeSlope_mono` was the *local* convexity certificate. `edgeSlopes_pairwise_le`
+is the *global* one: it is the precise statement that the lower hull is convex
+and that a polynomial's root valuations form a fully sorted list — the backbone
+of any Newton–Puiseux complexity argument, where the recursion peels off the
+dominant (least-slope / largest-valuation) edge in order.
+
+## Mathlib drift (important)
+
+The local Mathlib cache has moved well past v4.26.0's List order API:
+* `List.Chain'` → **`List.IsChain`** (`Chain'` is a deprecated alias).
+* `List.Sorted` was **removed** (now `SortedLE`/`SortedGE` defined via
+  `Monotone l.get`); use `List.Pairwise (· ≤ ·)` directly — that *is* sortedness.
+* `chain'_cons`/`chain'_singleton`/`chain'_iff_pairwise` →
+  `isChain_cons_cons`/`isChain_singleton`/`isChain_iff_pairwise`
+  (`isChain_iff_pairwise` needs `[Trans R R R]`, found for `≤` on ℚ).
+* Added imports `Mathlib.Data.List.Chain`, `Mathlib.Data.List.Sort`.
+
+The pre-existing theorems were unaffected (they used `List.argmin`/`mem_filter`,
+which are stable). Only the new convexity layer touched the changed API.
+
+## Scope honesty
+
+Incremental combinatorial infrastructure, not the open question. Still blocked,
+unchanged from S03:
+* Newton polygon theorem (slopes = root valuations): needs a valuation API on
+  `K((x))[Y]`.
+* S2-B termination measure; S2-C quasi-linear complexity (no arithmetic-cost
+  model in Mathlib).
+
+## Verification
+
+`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean`
+exits 0, no diagnostics. Docker host is back up but single-file `env lean`
+against the prebuilt olean cache is the fast channel. `#print axioms` on all
+four new theorems lists only the foundational axioms.
+
+## Files modified
+
+- `proofs/Proofs/PuiseuxTheoremOQ03.lean` (421 → 509 lines; +6 theorems, +2 defs,
+  +2 imports)
+- `src/data/proofs/puiseux-theorem-oq-03/meta.json` (counts, contributions,
+  headline theorem, section, conclusion)
+- this session note

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "infrastructure",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All 16 theorems and 4 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
+    "assumptions": "None. All 27 theorems and 7 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
     "originalContributions": [
       "IsLowerVertex: supporting-line characterization of a lower-hull (Newton-polygon) vertex, algorithm-independent",
       "isLowerVertex_of_minimal: the minimum-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -39,12 +39,18 @@
       "Parent fix: corrected a dangling /-- doc comment in PuiseuxTheorem.lean that made the file fail to parse",
       "exists_isLowerEdge_of_leftmost: the leftmost support point spawns a genuine IsLowerEdge (the dominant least-slope edge) — first concrete hull-construction step, returning the right endpoint not just vertex-hood",
       "ysqMinusX_exists_edge: worked Y^2-x edge existence derived via the new theorem (right endpoint not supplied by hand)",
-      "Maintenance: replaced 3 uses of List.not_mem_nil q (explicit-arg form, removed in current Mathlib cache) with simp — file no longer built against the updated Mathlib until this fix"
+      "Maintenance: replaced 3 uses of List.not_mem_nil q (explicit-arg form, removed in current Mathlib cache) with simp — file no longer built against the updated Mathlib until this fix",
+      "edgeSlopes: reads the list of edge slopes off a chain of support points (the slope of each consecutive pair) via clean two-step structural recursion",
+      "chain_edgeSlopes: GLOBAL CONVEXITY (chain form) — along any List.IsChain of lower edges the edge slopes are non-decreasing between consecutive entries; structural induction whose only arithmetic input is edgeSlope_mono, lifting the adjacent-pair convexity to a whole polygon",
+      "edgeSlopes_pairwise_le: GLOBAL CONVEXITY (sorted form) — the edge slopes of a Newton polygon are Pairwise (· ≤ ·): every slope ≤ every LATER slope, not merely the next one (IsChain upgraded to Pairwise via transitivity of ≤ on ℚ)",
+      "rootValuations_pairwise_ge: consequently the negated edge slopes (the root valuations) of the whole polygon are Pairwise (· ≥ ·) — the sorted valuation list the Newton–Puiseux recursion consumes one dominant edge at a time (global analogue of the two-edge rootValuation_antitone)",
+      "Worked three-vertex example (0,2)→(1,0)→(3,1): a genuine two-edge convex chain (threeVertex_chain) with edgeSlopes = [-2, 1/2] (threeVertex_edgeSlopes) shown sorted by the global theorem (threeVertex_sorted)",
+      "Mathlib drift fix: migrated the new convexity layer to the current List order API — List.Chain' → List.IsChain, List.Sorted (removed) → List.Pairwise, chain'_cons/_singleton/_iff_pairwise → isChain_cons_cons/isChain_singleton/isChain_iff_pairwise; added imports Mathlib.Data.List.Chain and Mathlib.Data.List.Sort"
     ],
     "dateAdded": "2026-06-27",
-    "lineCount": 421,
-    "theoremCount": 21,
-    "definitionCount": 4,
+    "lineCount": 509,
+    "theoremCount": 27,
+    "definitionCount": 7,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -101,6 +107,14 @@
       "endLine": 145,
       "summary": "Support of Y²−x is {(0,1),(2,0)}; both endpoints are lower vertices via the shared edge line y = −½i + 1 (ysqMinusX_vertex_const / _lead, fin_cases + norm_num). edgeSlope = −1/2, and its negation 1/2 = leadingExponentFromSlope 1 2 recovers the parent's leading exponent of the root x^{1/2}.",
       "mathContext": "$-\\text{edgeSlope}((0,1),(2,0))=\\tfrac12=\\text{leadingExponentFromSlope}(1,2)$, the exponent of $x^{1/2}$."
+    },
+    {
+      "id": "global-convexity",
+      "title": "Global Convexity: the Whole Edge-Slope Sequence is Sorted",
+      "startLine": 423,
+      "endLine": 509,
+      "summary": "edgeSlopes reads the edge-slope list off a List.IsChain of lower edges. chain_edgeSlopes proves it IsChain (· ≤ ·) by two-step structural induction (head = edgeSlope_mono, tail = IH); edgeSlopes_pairwise_le upgrades to Pairwise (· ≤ ·) via transitivity, and rootValuations_pairwise_ge negates to Pairwise (· ≥ ·) for the root valuations. A genuine three-vertex convex chain (0,2)→(1,0)→(3,1) with edge slopes [-2, 1/2] exercises the theorems.",
+      "mathContext": "$\\text{IsChain}(\\text{IsLowerEdge})\\,vs \\Rightarrow (\\text{edgeSlopes}\\,vs)\\ \\text{sorted } \\le$; lifting adjacent-pair convexity $\\text{edgeSlope}(v_{i-1},v_i)\\le\\text{edgeSlope}(v_i,v_{i+1})$ to all pairs."
     }
   ],
   "mainTheorems": [
@@ -145,6 +159,13 @@
       "statement": "$\\text{IsLowerEdge}(\\text{pts}, p, q) \\wedge \\text{IsLowerEdge}(\\text{pts}, q, r) \\Rightarrow -\\text{edgeSlope}(q,r) \\le -\\text{edgeSlope}(p,q)$",
       "significance": "Root valuations are the negatives of edge slopes, so convexity says they are sorted (non-increasing left-to-right) across the Newton polygon — the structural fact behind reading off root valuations in order.",
       "description": "Immediate from edgeSlope_mono via neg_le_neg."
+    },
+    {
+      "name": "edgeSlopes_pairwise_le",
+      "type": "theorem",
+      "statement": "$\\text{IsChain}(\\text{IsLowerEdge}\\,\\text{pts})\\,vs \\Rightarrow (\\text{edgeSlopes}\\,vs).\\text{Pairwise}(\\le)$",
+      "significance": "GLOBAL convexity of the Newton polygon: along any chain of lower edges, EVERY edge slope is ≤ every later edge slope — not merely the adjacent one (edgeSlope_mono). This is the whole-polygon statement that the lower hull is convex, and it is what makes a polynomial's root valuations come out as a fully sorted list (rootValuations_pairwise_ge), the structural backbone of the Newton–Puiseux recursion processing dominant edges in order.",
+      "description": "chain_edgeSlopes proves the consecutive form (List.IsChain (· ≤ ·) on the edge-slope list) by a two-step structural induction whose head step is edgeSlope_mono and whose tail is the IH; List.isChain_iff_pairwise then upgrades it to Pairwise because ≤ on ℚ is transitive."
     },
     {
       "name": "ysqMinusX_isLowerEdge",
@@ -213,18 +234,20 @@
   "leanFile": {
     "imports": [
       "Proofs.PuiseuxTheorem",
-      "Mathlib.Data.List.MinMax"
+      "Mathlib.Data.List.MinMax",
+      "Mathlib.Data.List.Chain",
+      "Mathlib.Data.List.Sort"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 421,
+    "lineCount": 509,
     "axiomCount": 0,
-    "theoremCount": 21,
-    "definitionCount": 4,
+    "theoremCount": 27,
+    "definitionCount": 7,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0
   },
   "conclusion": {
-    "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, the lower-edge predicate IsLowerEdge with the edge↔vertex bridge and the slope-determination lemma slope_eq_edgeSlope, and — the combinatorial heart — convexity of the polygon (edgeSlope_mono) yielding sorted root valuations (rootValuation_antitone), all validated on the Y²−x example whose single segment is a genuine lower edge tying the slope to the parent's leadingExponentFromSlope. All 16 theorems and 4 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
+    "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, the lower-edge predicate IsLowerEdge with the edge↔vertex bridge and the slope-determination lemma slope_eq_edgeSlope, and — the combinatorial heart — convexity of the polygon (edgeSlope_mono) yielding sorted root valuations (rootValuation_antitone). The latest layer lifts convexity from adjacent pairs to the whole polygon: edgeSlopes reads off the edge-slope list of a chain of lower edges, and edgeSlopes_pairwise_le proves it Pairwise (· ≤ ·) — every slope ≤ every later one — so the root valuations of the entire polygon are sorted (rootValuations_pairwise_ge), demonstrated on a genuine three-vertex convex chain. All validated on the Y²−x example whose single segment is a genuine lower edge tying the slope to the parent's leadingExponentFromSlope. All 27 theorems and 7 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
     "implications": "This is the algorithm-independent data layer on which Newton–Puiseux termination measures and the Poteaux–Weimann complexity bounds can later be phrased. With a valuation API on K((x))[Y], the Newton polygon theorem (slopes = root valuations) becomes the next provable target.",
     "openQuestions": [
       "Prove the Newton polygon theorem: the negatives of the lower-hull edge slopes equal the valuations of the roots in an algebraically closed valued extension (needs a valuation API on K((x))[Y]) — the edge layer and its convexity (edgeSlope_mono) are now in place, so the valuations would automatically come out sorted",


### PR DESCRIPTION
## Summary

Extends the combinatorial Newton-polygon API in `puiseux-theorem-oq-03` by lifting convexity from **adjacent edge pairs** to the **whole polygon**: the edge slopes along any chain of lower edges are sorted, hence a polynomial's root valuations form a fully sorted list — the structural backbone of any Newton–Puiseux complexity argument (the recursion peels off the dominant edge in order).

The file already had `edgeSlope_mono` (convexity for two edges sharing a vertex). This adds the global statement.

## New content — `proofs/Proofs/PuiseuxTheoremOQ03.lean` (421 → 509 lines, +6 theorems, +2 defs)

- **`edgeSlopes`** — edge-slope list of a vertex chain (slope of each consecutive pair), clean two-step structural recursion.
- **`chain_edgeSlopes`** — `IsChain (IsLowerEdge pts) vs → IsChain (· ≤ ·) (edgeSlopes vs)`, structural induction (head step = `edgeSlope_mono`, tail = IH).
- **`edgeSlopes_pairwise_le`** — `(edgeSlopes vs).Pairwise (· ≤ ·)`: every slope ≤ every *later* slope, not merely the next. The full "lower hull is convex" statement (`IsChain → Pairwise` via transitivity of `≤` on ℚ).
- **`rootValuations_pairwise_ge`** — negated slopes `Pairwise (· ≥ ·)`: whole-polygon sorted root valuations (global analogue of the two-edge `rootValuation_antitone`).
- Worked three-vertex convex chain `(0,2)→(1,0)→(3,1)` with edge slopes `[-2, 1/2]`, shown sorted by the global theorem.

## Mathlib drift fix

The local Mathlib cache has moved past the pinned toolchain's List order API. Migrated the new layer: `List.Chain'` → `List.IsChain`; `List.Sorted` (removed) → `List.Pairwise`; `chain'_cons`/`_singleton`/`_iff_pairwise` → `isChain_cons_cons`/`isChain_singleton`/`isChain_iff_pairwise`; added imports `Mathlib.Data.List.Chain`, `Mathlib.Data.List.Sort`. Pre-existing argmin/mem_filter code was unaffected.

## Verification

`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean` exits 0 with no diagnostics. `#print axioms` on all four new theorems lists only `propext` / `Classical.choice` / `Quot.sound`. **0 sorries, 0 axioms.**

## Scope honesty

Incremental combinatorial infrastructure, not the open question itself. Still blocked (unchanged): the Newton polygon theorem (slopes = root valuations) needs a valuation API on `K((x))[Y]`; S2-B termination measure; S2-C quasi-linear complexity needs an arithmetic-cost model in Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)