### PR TITLE
Research: erdos-340-greedy-sidon-oq-05 — downward closure of the B_h hierarchy [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos340GreedySidonOQ05.lean
+++ b/proofs/Proofs/Erdos340GreedySidonOQ05.lean
@@ -32,6 +32,15 @@ upper bound.
 
 * `IsBh.subset` — the `B_h` property is inherited by subsets.
 
+* `IsBh.pred` / `IsBh.of_le` — **downward closure of the hierarchy**: a `B_{h+1}`
+  set is `B_h`, and more generally a `B_k` set is `B_h` for every `h ≤ k`.  So the
+  `B_h` conditions get *stronger* as `h` grows.  Proved by appending a fixed
+  element of `A` to the smaller multisets.
+
+* `IsBh.card_mul_pred_le_of_two_le` — every `B_h` set with `h ≥ 2` already obeys
+  the Sidon bound `|A|(|A|−1) ≤ 4N` (a uniform `O(√N)` ceiling), obtained by
+  combining the downward closure with the `h = 2` case.
+
 * `IsBh.sum_injOn_powersetCard` — a `B_h` set has *distinct subset-sums* across its
   `h`-element subsets.  This is the combinatorial engine behind the counting bound.
 
@@ -98,6 +107,67 @@ theorem isBh_one (A : Finset ℕ) : IsBh 1 A := by
   apply Sym.coe_injective
   simp only [ha, hb, Multiset.sum_singleton] at hst ⊢
   rw [hst]
+
+/-! ## Part 1b: Downward closure of the `B_h` hierarchy -/
+
+/-- **Downward step.**  A `B_{h+1}` set is also a `B_h` set.
+
+If two `h`-multisets `s, t` drawn from `A` had equal sums, then — picking any
+element `a ∈ A` (which exists whenever `h ≥ 1`, taken from `s` itself) — the
+`(h+1)`-multisets `a ::ₛ s` and `a ::ₛ t` would again have equal sums
+(`a + Σs = a + Σt`).  The `B_{h+1}` property forces `a ::ₛ s = a ::ₛ t`, and
+cancelling the common head gives `s = t`.  (For `h = 0` the two `0`-multisets are
+both empty, hence equal.) -/
+theorem IsBh.pred {h : ℕ} {A : Finset ℕ} (hA : IsBh (h + 1) A) : IsBh h A := by
+  intro s hs t ht hsum
+  rw [Finset.mem_coe, Finset.mem_sym_iff] at hs ht
+  cases h with
+  | zero =>
+    -- Both `s` and `t` are the empty `0`-multiset.
+    apply Sym.coe_injective
+    have hs0 : (↑s : Multiset ℕ) = 0 := Multiset.card_eq_zero.mp s.2
+    have ht0 : (↑t : Multiset ℕ) = 0 := Multiset.card_eq_zero.mp t.2
+    rw [hs0, ht0]
+  | succ k =>
+    -- `s` has an element `a`, which lies in `A`.
+    obtain ⟨a, ha_s⟩ : ∃ a, a ∈ s := by
+      obtain ⟨a, s', hs'⟩ := Sym.exists_eq_cons_of_succ s
+      exact ⟨a, hs' ▸ Sym.mem_cons_self a s'⟩
+    have ha : a ∈ A := hs a ha_s
+    -- Append `a` to both; the results stay in `A.sym (k+2)`.
+    have hsa : (a ::ₛ s) ∈ A.sym (k + 1 + 1) := by
+      rw [Finset.mem_sym_iff]; intro x hx
+      rw [Sym.mem_cons] at hx
+      rcases hx with rfl | hx
+      · exact ha
+      · exact hs x hx
+    have hta : (a ::ₛ t) ∈ A.sym (k + 1 + 1) := by
+      rw [Finset.mem_sym_iff]; intro x hx
+      rw [Sym.mem_cons] at hx
+      rcases hx with rfl | hx
+      · exact ha
+      · exact ht x hx
+    -- Equal sums are preserved by prepending the same head.
+    have hsumcons :
+        ((a ::ₛ s : Sym ℕ (k + 1 + 1)) : Multiset ℕ).sum
+          = ((a ::ₛ t : Sym ℕ (k + 1 + 1)) : Multiset ℕ).sum := by
+      have hsum' : (↑s : Multiset ℕ).sum = (↑t : Multiset ℕ).sum := hsum
+      rw [Sym.coe_cons, Sym.coe_cons, Multiset.sum_cons, Multiset.sum_cons, hsum']
+    exact (Sym.cons_inj_right a s t).mp
+      (hA (Finset.mem_coe.mpr hsa) (Finset.mem_coe.mpr hta) hsumcons)
+
+/-- **Iterated downward closure.**  A `B_k` set is `B_h` for every `h ≤ k`:
+the `B_h` properties form a *decreasing* hierarchy in `h`. -/
+theorem IsBh.of_le {h k : ℕ} {A : Finset ℕ} (hk : h ≤ k) (hA : IsBh k A) :
+    IsBh h A := by
+  obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le hk
+  clear hk
+  induction d with
+  | zero => simpa using hA
+  | succ n ih =>
+    apply ih
+    rw [show h + (n + 1) = (h + n) + 1 from by omega] at hA
+    exact hA.pred
 
 /-! ## Part 2: From `B_h` to distinct subset-sums -/
 
@@ -202,5 +272,15 @@ theorem IsBh.two_card_mul_pred_le {N : ℕ} {A : Finset ℕ}
   rw [Nat.choose_two_right] at h
   have hev : 2 ∣ A.card * (A.card - 1) := (Nat.even_mul_pred_self A.card).two_dvd
   omega
+
+/-- **Every `B_h` set with `h ≥ 2` obeys the Sidon bound.**  Combining the
+downward closure (`IsBh.of_le`, giving `B_h ⟹ B_2`) with the `h = 2`
+specialization shows that the size of *any* `B_h` set in `{1, …, N}` is
+`O(√N)` — a uniform-in-`h` ceiling, complementing the sharper `O(N^{1/h})`
+bound of `IsBh.choose_card_le`. -/
+theorem IsBh.card_mul_pred_le_of_two_le {h N : ℕ} {A : Finset ℕ} (hh : 2 ≤ h)
+    (hAN : A ⊆ Finset.Icc 1 N) (hA : IsBh h A) :
+    A.card * (A.card - 1) ≤ 4 * N :=
+  (hA.of_le hh).two_card_mul_pred_le hAN
 
 end Erdos340Bh

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -45,20 +45,36 @@
       "The sharp B_h upper bound is provable by an h-SUBSET counting argument rather than the full multiset count: the Nat.choose A.card h many h-element SUBSETS of A have pairwise distinct sums (a subset is a repetition-free multiset, so distinctness is inherited from the B_h injectivity), and each such sum lies in [1, h·N]. This injects choose(|A|,h) into an interval of length h·N, giving Nat.choose A.card h ≤ h·N (theorem IsBh.choose_card_le, 0-axiom verified).",
       "At h = 2 the bound reads choose(|A|,2) = |A|·(|A|-1)/2 ≤ 2N, i.e. |A|·(|A|-1) ≤ 4N (theorem IsBh.two_card_mul_pred_le) — exactly the classical Sidon bound |A| = O(√N), confirming B_h genuinely generalizes #340's B_2 case. For general h it gives |A| = O(N^{1/h}), the trivial B_h ceiling that Bose-Chowla constructions meet to within (1-o(1)).",
       "Using h-subsets (powersetCard, card = Nat.choose) instead of all h-multisets (Finset.sym, whose Finset-level cardinality is NOT directly available in Mathlib as a multichoose lemma) is what makes the counting bound clean: Finset.card_powersetCard gives the exact choose count, and Finset.card_image_of_injOn + Nat.card_Icc finish it.",
-      "h=2 omega gotcha: from choose(k,2) = k(k-1)/2 ≤ 2N, deriving k(k-1) ≤ 4N requires the EVENNESS of k(k-1) (else k(k-1)=4N+1 is a spurious omega counterexample). Supply 2 ∣ k(k-1) via (Nat.even_mul_pred_self k).two_dvd before omega."
+      "h=2 omega gotcha: from choose(k,2) = k(k-1)/2 ≤ 2N, deriving k(k-1) ≤ 4N requires the EVENNESS of k(k-1) (else k(k-1)=4N+1 is a spurious omega counterexample). Supply 2 ∣ k(k-1) via (Nat.even_mul_pred_self k).two_dvd before omega.",
+      "The B_h hierarchy is nested DOWNWARD: B_h gets stronger as h grows (B_{h+1} ⊆ B_h). The proof is one append: two equal-sum h-multisets stay equal-sum after prepending a common element, contradicting B_{h+1}. The h=0 base is vacuous (both multisets empty).",
+      "No nonemptiness hypothesis is needed for IsBh.pred: when h≥1 the required element is drawn from the multiset s itself (Sym.exists_eq_cons_of_succ); when h=0 the two 0-multisets are both empty.",
+      "Consequence: the sharp per-h bound choose|A|h ≤ h·N (giving O(N^{1/h})) is complemented by a uniform O(√N) ceiling for ALL h≥2, since every B_h set is also Sidon."
     ],
     "builtItems": [
-      "Erdos340GreedySidonOQ05.lean: def IsBh (h-fold-sum-distinctness via multiset-sum InjOn on A.sym h); IsBh.subset; isBh_one (every set is B_1); IsBh.sum_injOn_powersetCard (distinct h-subset sums); IsBh.choose_card_le (MAIN: Nat.choose |A| h ≤ h·N for B_h A ⊆ [1,N]); IsBh.two_card_mul_pred_le (Sidon recovery |A|(|A|-1) ≤ 4N). 206 lines, 6 theorems, 1 def, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only)."
+      "Erdos340GreedySidonOQ05.lean: def IsBh (h-fold-sum-distinctness via multiset-sum InjOn on A.sym h); IsBh.subset; isBh_one (every set is B_1); IsBh.sum_injOn_powersetCard (distinct h-subset sums); IsBh.choose_card_le (MAIN: Nat.choose |A| h ≤ h·N for B_h A ⊆ [1,N]); IsBh.two_card_mul_pred_le (Sidon recovery |A|(|A|-1) ≤ 4N). 206 lines, 6 theorems, 1 def, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only).",
+      "IsBh.pred in Erdos340GreedySidonOQ05.lean — B_{h+1} ⟹ B_h downward step (Sym.cons + cons_inj_right)",
+      "IsBh.of_le in Erdos340GreedySidonOQ05.lean — iterated downward closure B_k ⟹ B_h (h≤k) by induction",
+      "IsBh.card_mul_pred_le_of_two_le in Erdos340GreedySidonOQ05.lean — uniform Sidon ceiling for all B_h, h≥2"
     ],
     "mathlibGaps": [
       "Mathlib has no B_h-set theory and no Sidon/B_h upper bound; the whole development is original relative to Mathlib.",
       "Finset.sym s n has no direct cardinality (multichoose) lemma in Mathlib — only the Fintype-level Sym.card_sym_eq_choose. This is why the counting bound is routed through h-subsets (powersetCard, which DOES have card_powersetCard) rather than the full multiset family."
     ],
     "nextSteps": [
-      "Prove the explicit B_h ⟹ B_{h-1} downward closure (for nonempty A) by appending a fixed element to (h-1)-multisets — a clean structural theorem now that the multiset-sum formulation is in place.",
-      "Formalize a B_h analogue of the greedy extension lemma (parent file's sidon_exists_extension / nextSidon) to build a greedy B_h sequence and prove its N^{1/(2h-1)} lower bound — the genuine open direction matching the parent #340.",
-      "Optionally prove the exact bridge IsBh 2 A ↔ Erdos340.IsSidon A (Sym ℕ 2 ↔ ordered-pair sums) to formally link the new B_h def to the parent gallery's IsSidon."
+      "Formalize a B_h greedy extension lemma (analogue of nextSidon) to build a greedy B_h sequence and prove its N^{1/(2h-1)} lower bound — the genuine open direction of #340.",
+      "Optionally prove the exact bridge IsBh 2 A ↔ Erdos340.IsSidon A linking the multiset-sum B_2 definition to the parent gallery IsSidon."
     ],
-    "progressSummary": "PROGRESS: Foundational B_h theory + sharp B_h upper bound Nat.choose |A| h ≤ h·N formalized and verified 0-axiom (Erdos340GreedySidonOQ05.lean). Recovers the classical Sidon bound at h=2. The deep open direction (greedy B_h lower bound) remains, as for the parent #340."
+    "progressSummary": "VERIFIED (0 sorries, 0 axioms). Foundational B_h theory + sharp upper bound Nat.choose|A|h ≤ h·N (recovers Sidon at h=2), PLUS the downward closure of the B_h hierarchy: IsBh.pred (B_{h+1}⟹B_h via appending a fixed element) and IsBh.of_le (B_k⟹B_h for h≤k), with the corollary that every B_h set (h≥2) already satisfies the Sidon O(√N) bound. The deep greedy B_h lower bound (N^{1/(2h-1)}) remains open, as for parent #340."
+  },
+  "currentState": {
+    "iteration": 1,
+    "focus": "Added downward closure of the B_h hierarchy (IsBh.pred, IsBh.of_le) + uniform Sidon ceiling for B_h (h≥2). All VERIFIED 0-axiom."
+  },
+  "knownResults": {
+    "proven": [
+      "IsBh.pred: a B_{h+1} set is B_h (append a fixed element of A to the smaller multisets)",
+      "IsBh.of_le: a B_k set is B_h for every h ≤ k — the B_h conditions form a decreasing hierarchy in h",
+      "IsBh.card_mul_pred_le_of_two_le: every B_h set (h≥2) in [1,N] obeys the Sidon bound |A|(|A|-1) ≤ 4N"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
Extends the merged `B_h` foundation (PR #30890) for Erdős #340 OQ-05 with the structural fact that the `B_h` properties are nested **downward** — they get *stronger* as `h` grows. Three new theorems, all **0-sorry, 0-axiom**.

## Progress
- **`IsBh.pred`** — a `B_{h+1}` set is `B_h`. Proof: if two `h`-multisets had equal sums, prepending a fixed `a ∈ A` gives two `(h+1)`-multisets with equal sums, contradicting `B_{h+1}`; cancel the common head with `Sym.cons_inj_right`. No nonemptiness hypothesis is needed — for `h ≥ 1` the element `a` is drawn from the multiset itself (`Sym.exists_eq_cons_of_succ`), and for `h = 0` both multisets are empty.
- **`IsBh.of_le`** — iterated: a `B_k` set is `B_h` for every `h ≤ k` (induction on `k − h`).
- **`IsBh.card_mul_pred_le_of_two_le`** — every `B_h` set with `h ≥ 2` already obeys the Sidon bound `|A|(|A|−1) ≤ 4N`, a uniform `O(√N)` ceiling complementing the sharper `O(N^{1/h})` bound of `IsBh.choose_card_le`.

## Findings
- The `B_h` hierarchy is `… ⊆ B_3 ⊆ B_2 ⊆ B_1`; the single-element append is the whole mechanism.
- Combining nesting with the `h = 2` case gives a per-size ceiling that holds uniformly in `h`.

## Files Modified
- `proofs/Proofs/Erdos340GreedySidonOQ05.lean` — +3 theorems (Part 1b + corollary).
- `src/data/research/problems/erdos-340-greedy-sidon-oq-05.json` — knowledge update.

## Verification
Docker containerd backend down this session; type-checked with **Lean 4.26.0 `lean`** against the prebuilt Mathlib olean cache. `#print axioms` on all three new theorems reports only `propext, Classical.choice, Quot.sound`.

## Status
**Outcome**: progress (structural theory advanced; deep greedy `B_h` lower bound `N^{1/(2h-1)}` remains open, as for parent #340)
**Next Steps**: formalize a greedy `B_h` extension lemma toward the lower bound; optionally prove the bridge `IsBh 2 A ↔ Erdos340.IsSidon A`.

🤖 Generated by researcher-1