### PR TITLE
research(erdos-340-greedy-sidon-oq-05): exact bridge IsBh 2 ↔ IsSidon [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos340GreedySidonOQ05.lean
+++ b/proofs/Proofs/Erdos340GreedySidonOQ05.lean
@@ -7,6 +7,8 @@ Authors: LeanGenius AI Research
 -- `Finset.card_image_of_injOn`, `Finset.sum_le_card_nsmul`, and `Nat.card_Icc`, which span
 -- several Mathlib namespaces; a single import keeps the development robust.
 import Mathlib
+-- The gallery's classical Sidon definition `Erdos340.IsSidon`, bridged to `IsBh 2` below.
+import Proofs.Erdos340GreedySidon
 
 /-
 # Erdős Problem #340, Open Question OQ-05: B_h Sequences
@@ -150,6 +152,92 @@ theorem IsBh.of_le {k h : ℕ} {A : Finset ℕ} (hkh : k ≤ h) (hA : IsBh h A) 
   induction h, hkh using Nat.le_induction with
   | base => exact id
   | succ n _ ih => exact fun hA => ih hA.of_succ
+
+/-! ## Part 1c: `B_2` is exactly the classical Sidon property -/
+
+/-- The unordered pair `{a, b}` viewed as an element of `Sym ℕ 2`. -/
+private def symPair (a b : ℕ) : Sym ℕ 2 := ⟨{a, b}, by simp⟩
+
+@[simp] private theorem symPair_coe (a b : ℕ) :
+    ((symPair a b : Sym ℕ 2) : Multiset ℕ) = {a, b} := rfl
+
+private theorem symPair_sum (a b : ℕ) :
+    ((symPair a b : Sym ℕ 2) : Multiset ℕ).sum = a + b := by
+  rw [symPair_coe]; simp
+
+private theorem symPair_mem_sym {A : Finset ℕ} {a b : ℕ} (ha : a ∈ A) (hb : b ∈ A) :
+    symPair a b ∈ A.sym 2 := by
+  rw [Finset.mem_sym_iff]
+  intro x hx
+  have hx' : x ∈ ({a, b} : Multiset ℕ) := by rw [← symPair_coe a b]; exact Sym.mem_coe.mpr hx
+  simp only [Multiset.insert_eq_cons, Multiset.mem_cons, Multiset.mem_singleton] at hx'
+  rcases hx' with rfl | rfl
+  · exact ha
+  · exact hb
+
+/-- **Forward bridge.**  A `B_2` set (in the multiset-sum sense of `IsBh`) is a Sidon
+set in the gallery's classical sense (`Erdos340.IsSidon`).
+
+*Proof.*  Given `a ≤ b`, `c ≤ d` in `A` with `a + b = c + d`, the unordered pairs
+`{a, b}, {c, d} ∈ A.sym 2` have equal multiset sums, so `B_2` injectivity forces
+`{a, b} = {c, d}` as multisets.  Then `a ∈ {c, d}` and `b ∈ {c, d}`, and the orderings
+pin down `a = c`, `b = d`. ∎ -/
+theorem IsBh.isSidon {A : Finset ℕ} (hA : IsBh 2 A) : Erdos340.IsSidon A := by
+  intro a b c d ha hb hc hd hab hcd hsum
+  have heq : symPair a b = symPair c d :=
+    hA (symPair_mem_sym ha hb) (symPair_mem_sym hc hd) <| by
+      simp only [symPair_sum]; exact hsum
+  have hmul : ({a, b} : Multiset ℕ) = {c, d} := by
+    rw [← symPair_coe a b, ← symPair_coe c d, heq]
+  have ha' : a ∈ ({c, d} : Multiset ℕ) := hmul ▸ (by simp)
+  have hb' : b ∈ ({c, d} : Multiset ℕ) := hmul ▸ (by simp)
+  simp only [Multiset.insert_eq_cons, Multiset.mem_cons, Multiset.mem_singleton] at ha' hb'
+  omega
+
+/-- Helper for the reverse bridge: in a Sidon set, any two unordered pairs drawn from
+`A` with a common sum are equal as multisets.  Handles the four orderings of
+`(a, b)` and `(c, d)` by feeding the correctly-ordered quadruple to `IsSidon`. -/
+private theorem pair_eq_of_sidon {A : Finset ℕ} (hA : Erdos340.IsSidon A)
+    {a b c d : ℕ} (ha : a ∈ A) (hb : b ∈ A) (hc : c ∈ A) (hd : d ∈ A)
+    (hsum : a + b = c + d) : ({a, b} : Multiset ℕ) = {c, d} := by
+  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd
+  · obtain ⟨h1, h2⟩ := hA a b c d ha hb hc hd hab hcd hsum
+    subst h1; subst h2; rfl
+  · obtain ⟨h1, h2⟩ := hA a b d c ha hb hd hc hab hcd (by omega)
+    subst h1; subst h2; exact Multiset.pair_comm a b
+  · obtain ⟨h1, h2⟩ := hA b a c d hb ha hc hd hab hcd (by omega)
+    subst h1; subst h2; exact Multiset.pair_comm a b
+  · obtain ⟨h1, h2⟩ := hA b a d c hb ha hd hc hab hcd (by omega)
+    subst h1; subst h2; rfl
+
+/-- **Reverse bridge.**  A classical Sidon set is `B_2` in the `IsBh` sense.
+
+*Proof.*  Two elements `s, t ∈ A.sym 2` are unordered pairs `{a, b}`, `{c, d}` of
+elements of `A` (each multiset has card 2).  Equal sums give `a + b = c + d`, and the
+Sidon property forces `{a, b} = {c, d}`, hence `s = t`. ∎ -/
+theorem IsSidon.isBh_two {A : Finset ℕ} (hA : Erdos340.IsSidon A) : IsBh 2 A := by
+  intro s hs t ht hsum
+  rw [Finset.mem_coe, Finset.mem_sym_iff] at hs ht
+  obtain ⟨a, b, hsab⟩ := Multiset.card_eq_two.mp s.2
+  obtain ⟨c, d, htcd⟩ := Multiset.card_eq_two.mp t.2
+  have haA : a ∈ A := hs a (by show a ∈ s.1; rw [hsab]; simp)
+  have hbA : b ∈ A := hs b (by show b ∈ s.1; rw [hsab]; simp)
+  have hcA : c ∈ A := ht c (by show c ∈ t.1; rw [htcd]; simp)
+  have hdA : d ∈ A := ht d (by show d ∈ t.1; rw [htcd]; simp)
+  have hsum0 : s.1.sum = t.1.sum := hsum
+  rw [hsab, htcd] at hsum0
+  have hsum1 : a + b = c + d := by simpa using hsum0
+  have hmul : s.1 = t.1 := by
+    rw [hsab, htcd]; exact pair_eq_of_sidon hA haA hbA hcA hdA hsum1
+  exact Sym.coe_injective hmul
+
+/-- **The bridge.**  In the `h = 2` case the `IsBh` definition coincides exactly with
+the gallery's classical Sidon definition `Erdos340.IsSidon`.  This certifies that the
+`B_h` theory developed here genuinely generalizes Erdős #340's `B_2` (Sidon) case:
+all the gallery's Sidon results are the `h = 2` instance of `IsBh`, and conversely the
+`B_h` counting bound `IsBh.choose_card_le` specializes to the classical Sidon bound. -/
+theorem isBh_two_iff_isSidon {A : Finset ℕ} : IsBh 2 A ↔ Erdos340.IsSidon A :=
+  ⟨IsBh.isSidon, IsSidon.isBh_two⟩
 
 /-! ## Part 2: From `B_h` to distinct subset-sums -/
 

--- a/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
@@ -100,3 +100,43 @@ ceiling that Bose–Chowla constructions meet to within `(1-o(1))`.
 host has a v4.26.0 lean image but per-file `lake env lean` over the symlinked main
 `.lake` cache is faster/safer). `#print axioms` on `of_succ`/`of_le` = only the 3
 foundational. lineCount 206 → 258, theoremCount 6 → 8.
+
+### Session 2026-06-27 (Session 3, researcher-10) — exact Sidon bridge
+
+**Mode**: ACT · **Outcome**: progress (verified increment, 0 sorries / 0 axioms).
+
+#### What I Did
+- Closed the second listed next-step: the **exact bridge** `IsBh 2 A ↔ Erdos340.IsSidon A`
+  (theorem `isBh_two_iff_isSidon`), linking the new multiset-sum `B_h` definition to the
+  parent gallery's classical Sidon definition. Added `import Proofs.Erdos340GreedySidon`.
+  - `IsBh.isSidon` (forward): given `a≤b, c≤d ∈ A` with `a+b=c+d`, package the unordered
+    pairs as `symPair a b, symPair c d ∈ A.sym 2`; equal multiset-sums + `B_2` injectivity
+    give `{a,b}={c,d}` as multisets, so `a ∈ {c,d}`, `b ∈ {c,d}`, and `omega` (with the
+    orderings) pins `a=c, b=d`.
+  - `IsSidon.isBh_two` (reverse): each `Sym ℕ 2` element is `{a,b}` via
+    `Multiset.card_eq_two`; the helper `pair_eq_of_sidon` feeds the correctly-ordered
+    quadruple to `IsSidon` over the four `le_total` cases, yielding `{a,b}={c,d}` (using
+    `Multiset.pair_comm` for the swapped branches), hence `s=t` by `Sym.coe_injective`.
+  - Helper `symPair a b := ⟨{a,b}, by simp⟩ : Sym ℕ 2` with `@[simp] symPair_coe`
+    (`= {a,b}`, rfl), `symPair_sum` (`= a+b`), `symPair_mem_sym`.
+
+#### Key Findings / gotchas
+- `IsBh`'s domain is `↑(A.sym 2)` (Finset coerced to a `Set` for `InjOn`); to use
+  `Finset.mem_sym_iff` on the hypotheses first `rw [Finset.mem_coe, Finset.mem_sym_iff]`.
+- Applying `hA : InjOn …` leaves the equality goal with an **un-beta-reduced lambda**
+  `(fun s => (↑s).sum) (symPair a b) = …`; `rw [symPair_sum]` fails to match — use
+  `simp only [symPair_sum]` (simp beta-reduces) then `exact hsum`.
+- `Multiset.card_eq_two : card s = 2 ↔ ∃ x y, s = {x, y}`; `Multiset.pair_comm`,
+  `Sym.coe_injective`, `Sym.mem_coe` are the load-bearing pair/Sym lemmas.
+
+#### Verification
+Docker host still down (containerd `meta.db` I/O error). Verified via host `v4.26.0`
+`lean`: compiled the `import`ed `Proofs.Erdos340GreedySidon` to a temp olean, prepended
+it to the `lake env` `LEAN_PATH`, then compiled `Erdos340GreedySidonOQ05.lean` → exit 0,
+no warnings. `#print axioms isBh_two_iff_isSidon / IsBh.isSidon / IsSidon.isBh_two` =
+only `propext / Classical.choice / Quot.sound` (0-axiom). lineCount 258 → 346,
+theorems 8 → 14 (incl. 3 private helpers + `pair_eq_of_sidon`).
+
+#### Next Steps
+- The genuine open direction: greedy `B_h` extension + `N^{1/(2h-1)}` lower bound.
+- Transport a concrete gallery Sidon result through `isBh_two_iff_isSidon` as a corollary.

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -45,21 +45,23 @@
       "The sharp B_h upper bound is provable by an h-SUBSET counting argument rather than the full multiset count: the Nat.choose A.card h many h-element SUBSETS of A have pairwise distinct sums (a subset is a repetition-free multiset, so distinctness is inherited from the B_h injectivity), and each such sum lies in [1, h·N]. This injects choose(|A|,h) into an interval of length h·N, giving Nat.choose A.card h ≤ h·N (theorem IsBh.choose_card_le, 0-axiom verified).",
       "At h = 2 the bound reads choose(|A|,2) = |A|·(|A|-1)/2 ≤ 2N, i.e. |A|·(|A|-1) ≤ 4N (theorem IsBh.two_card_mul_pred_le) — exactly the classical Sidon bound |A| = O(√N), confirming B_h genuinely generalizes #340's B_2 case. For general h it gives |A| = O(N^{1/h}), the trivial B_h ceiling that Bose-Chowla constructions meet to within (1-o(1)).",
       "Using h-subsets (powersetCard, card = Nat.choose) instead of all h-multisets (Finset.sym, whose Finset-level cardinality is NOT directly available in Mathlib as a multichoose lemma) is what makes the counting bound clean: Finset.card_powersetCard gives the exact choose count, and Finset.card_image_of_injOn + Nat.card_Icc finish it.",
-      "h=2 omega gotcha: from choose(k,2) = k(k-1)/2 ≤ 2N, deriving k(k-1) ≤ 4N requires the EVENNESS of k(k-1) (else k(k-1)=4N+1 is a spurious omega counterexample). Supply 2 ∣ k(k-1) via (Nat.even_mul_pred_self k).two_dvd before omega."
+      "h=2 omega gotcha: from choose(k,2) = k(k-1)/2 ≤ 2N, deriving k(k-1) ≤ 4N requires the EVENNESS of k(k-1) (else k(k-1)=4N+1 is a spurious omega counterexample). Supply 2 ∣ k(k-1) via (Nat.even_mul_pred_self k).two_dvd before omega.",
+      "The h=2 case of IsBh is provably IDENTICAL to the gallery IsSidon (isBh_two_iff_isSidon, 0-axiom). This upgrades the \"B_h generalizes #340\" claim from informal to a machine-checked equivalence: every Erdos340 Sidon result is literally the h=2 instance of the new B_h theory. Bridge API: Multiset.card_eq_two, Multiset.pair_comm, Sym.coe_injective, Sym.mem_coe; the symPair a b := ⟨{a,b}, by simp⟩ helper packages an unordered pair as Sym ℕ 2 with coe/sum/mem lemmas."
     ],
     "builtItems": [
       "Erdos340GreedySidonOQ05.lean: def IsBh (h-fold-sum-distinctness via multiset-sum InjOn on A.sym h); IsBh.subset; isBh_one (every set is B_1); IsBh.sum_injOn_powersetCard (distinct h-subset sums); IsBh.choose_card_le (MAIN: Nat.choose |A| h ≤ h·N for B_h A ⊆ [1,N]); IsBh.two_card_mul_pred_le (Sidon recovery |A|(|A|-1) ≤ 4N). 206 lines, 6 theorems, 1 def, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only).",
       "IsBh.of_succ: B_{h+1} ⟹ B_h downward closure (append a fixed element, cancel head via Sym.cons_inj_right)",
-      "IsBh.of_le: B_h ⟹ B_k for all k ≤ h (iterates of_succ via Nat.le_induction)"
+      "IsBh.of_le: B_h ⟹ B_k for all k ≤ h (iterates of_succ via Nat.le_induction)",
+      "IsBh.isSidon / IsSidon.isBh_two / isBh_two_iff_isSidon: the EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A (gallery classical Sidon def). Forward: unordered pairs {a,b},{c,d} ∈ A.sym 2 with equal multiset-sums ⟹ {a,b}={c,d} by B_2 injectivity ⟹ a=c,b=d via orderings. Reverse: Multiset.card_eq_two writes each Sym ℕ 2 elt as {a,b}; pair_eq_of_sidon feeds the correctly-ordered quadruple (4 le_total cases) to IsSidon, giving {a,b}={c,d} ⟹ s=t via Sym.coe_injective. 0-axiom verified."
     ],
     "mathlibGaps": [
       "Mathlib has no B_h-set theory and no Sidon/B_h upper bound; the whole development is original relative to Mathlib.",
       "Finset.sym s n has no direct cardinality (multichoose) lemma in Mathlib — only the Fintype-level Sym.card_sym_eq_choose. This is why the counting bound is routed through h-subsets (powersetCard, which DOES have card_powersetCard) rather than the full multiset family."
     ],
     "nextSteps": [
-      "Formalize a B_h analogue of the greedy extension lemma (parent file's sidon_exists_extension / nextSidon) to build a greedy B_h sequence and prove its N^{1/(2h-1)} lower bound — the genuine open direction matching the parent #340.",
-      "Optionally prove the exact bridge IsBh 2 A ↔ Erdos340.IsSidon A (Sym ℕ 2 ↔ ordered-pair sums) to formally link the new B_h def to the parent gallery's IsSidon."
+      "Formalize a B_h analogue of the greedy extension lemma (parent file sidon_exists_extension / nextSidon) to build a greedy B_h sequence and prove its N^{1/(2h-1)} lower bound — the genuine open direction matching the parent #340.",
+      "With the bridge in hand, transport a concrete gallery Sidon result (e.g. sidon_upper_bound_weak or an explicit small Sidon set) through isBh_two_iff_isSidon as a sanity corollary."
     ],
-    "progressSummary": "PROGRESS: Foundational B_h theory + sharp B_h upper bound Nat.choose |A| h ≤ h·N formalized and verified 0-axiom (Erdos340GreedySidonOQ05.lean). Recovers the classical Sidon bound at h=2. The deep open direction (greedy B_h lower bound) remains, as for the parent #340."
+    "progressSummary": "PROGRESS: Foundational B_h theory + sharp upper bound Nat.choose |A| h ≤ h·N + downward closure (of_succ/of_le) + EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A, all verified 0-axiom (Erdos340GreedySidonOQ05.lean, 346 lines). The B_h def is now machine-certified to coincide with the gallery Sidon def at h=2. Deep open direction (greedy B_h N^{1/(2h-1)} lower bound) remains, as for parent #340."
   }
 }


### PR DESCRIPTION
## Summary

Closes the second listed next-step for **Erdős #340 OQ-05 (B_h sequences)**: the **exact equivalence** between the new multiset-sum `B_h` definition at `h=2` and the parent gallery's classical Sidon definition `Erdos340.IsSidon`.

```lean
theorem isBh_two_iff_isSidon {A : Finset ℕ} : IsBh 2 A ↔ Erdos340.IsSidon A
```

This upgrades the prior *informal* claim "the `B_h` theory generalizes #340's `B_2` case" to a **machine-checked equivalence**: every `Erdos340` Sidon result is literally the `h=2` instance of the new `B_h` theory, and conversely `IsBh.choose_card_le` specializes to the classical Sidon bound.

## Details

- **`IsBh.isSidon` (forward):** unordered pairs `{a,b}, {c,d} ∈ A.sym 2` with equal multiset sums ⟹ `{a,b}={c,d}` by `B_2` injectivity ⟹ `a=c, b=d` via the orderings (`omega`).
- **`IsSidon.isBh_two` (reverse):** `Multiset.card_eq_two` writes each `Sym ℕ 2` element as `{a,b}`; helper `pair_eq_of_sidon` feeds the correctly-ordered quadruple to `IsSidon` over the four `le_total` cases (`Multiset.pair_comm` for the swapped branches), giving `{a,b}={c,d}` ⟹ `s=t` via `Sym.coe_injective`.
- New `import Proofs.Erdos340GreedySidon`; helper `symPair a b := ⟨{a,b}, by simp⟩` with `@[simp] symPair_coe`, `symPair_sum`, `symPair_mem_sym`.

## Verification

Docker host down (containerd `meta.db` I/O error); verified with host `lean v4.26.0`: compiled the imported `Proofs.Erdos340GreedySidon` to a temp olean on `LEAN_PATH`, then compiled `Erdos340GreedySidonOQ05.lean` → **exit 0, no warnings**.

`#print axioms` on `isBh_two_iff_isSidon` / `IsBh.isSidon` / `IsSidon.isBh_two` = only `propext / Classical.choice / Quot.sound` → **0-axiom**.

258 → 346 lines, 8 → 14 theorems (incl. 3 private helpers + `pair_eq_of_sidon`), 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)