### PR TITLE
Enrich Prime Reciprocal Products Disjointness (erdos-307-oq-02-oq-01): add annotations

### DIFF
--- a/src/data/proofs/erdos-307-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-307-oq-02-oq-01/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-e307oq0201-header",
+    "proofId": "erdos-307-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "concept",
+    "title": "Discharging a p-adic Sorry Without p-adic Machinery",
+    "content": "This file proves prime_sets_disjoint, a lemma the parent Erdős 307 OQ-02 file left as a sorry with the note that it needs 'Mathlib's p-adic valuation theory'. The claim: if finite prime sets P, Q satisfy (Σ_{p∈P} 1/p)(Σ_{q∈Q} 1/q) = 1 then P ∩ Q = ∅. The whole proof is engineered around one observation — the only p-adic fact required is v_{p₀}(Σ_{p∈P} 1/p) = -1, and that single fact can be expressed elementarily as 'p₀ does not divide the integer numerator NP', provable by one reduction modulo p₀ in the finite field 𝔽_{p₀}. No padicValRat, and the result is 0-axiom (propext / Classical.choice / Quot.sound only).",
+    "summary": "Proves the parent's prime_sets_disjoint sorry elementarily, avoiding p-adic valuation machinery.",
+    "mathContext": "Goal: $(\\sum_{p\\in P} 1/p)(\\sum_{q\\in Q} 1/q) = 1 \\Rightarrow P\\cap Q = \\emptyset$. The p-adic content $v_{p_0}\\!\\left(\\sum_{p\\in P}1/p\\right) = -1$ is recast as $p_0 \\nmid N_P$ where $N_P$ is the cleared-denominator numerator.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős problem 307",
+      "p-adic valuation",
+      "Egyptian fractions",
+      "prime reciprocal sums",
+      "elementary vs. valuation-theoretic proof"
+    ],
+    "prerequisites": [
+      "rational arithmetic of unit fractions",
+      "p-adic valuation (conceptual)",
+      "finite fields 𝔽_p"
+    ]
+  },
+  {
+    "id": "ann-e307oq0201-setup",
+    "proofId": "erdos-307-oq-02-oq-01",
+    "range": { "startLine": 40, "endLine": 58 },
+    "type": "definition",
+    "title": "Numerator and Denominator of a Prime Reciprocal Sum",
+    "content": "Five definitions set the stage. reciprocalSum S = Σ_{n∈S} n⁻¹ over ℚ and reciprocalProduct P Q = reciprocalSum P · reciprocalSum Q mirror the parent file, and IsSetOfPrimes S asserts every element is prime. The two new integer definitions are the engine of the proof: primeDenom P = ∏_{p∈P} p is the squarefree common denominator, and primeNumer P = Σ_{p∈P} ∏_{q∈P.erase p} q is the matching integer numerator obtained by placing Σ 1/p over that common denominator. Keeping NP and DP as honest natural numbers (not rationals) is what lets the later argument run in ℤ/ℕ and ultimately in 𝔽_{p₀}.",
+    "summary": "Defines reciprocalSum/product, IsSetOfPrimes, and the integer numerator NP and denominator DP.",
+    "mathContext": "$D_P = \\prod_{p\\in P} p$ (squarefree); $N_P = \\sum_{p\\in P}\\prod_{q\\in P\\setminus\\{p\\}} q$. By construction $\\sum_{p\\in P} 1/p = N_P/D_P$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "common denominator",
+      "squarefree integer",
+      "Finset.erase",
+      "Finset.prod"
+    ],
+    "prerequisites": [
+      "finite sums and products over Finset",
+      "primes are nonzero"
+    ]
+  },
+  {
+    "id": "ann-e307oq0201-identity",
+    "proofId": "erdos-307-oq-02-oq-01",
+    "range": { "startLine": 64, "endLine": 92 },
+    "type": "technique",
+    "title": "Clearing Denominators to the Integer Identity NP·NQ = DP·DQ",
+    "content": "Two lemmas turn the rational hypothesis into an integer one. reciprocalSum_mul_denom proves (Σ 1/p)·(∏ p) = Σ_p ∏_{q≠p} q over ℚ: after push_cast and Finset.sum_mul, each term 1/p · ∏_{q∈P} q collapses to ∏_{q≠p} q via Finset.mul_prod_erase and inv_mul_cancel_left₀ (valid since each prime p ≠ 0). primeNumer_mul_eq then multiplies the two factors of (Σ1/P)(Σ1/Q) = 1 by DP·DQ: the rational identity (NP)(NQ) = (Σ1/P · Σ1/Q)(DP·DQ) = 1·(DP·DQ) follows by ring and the hypothesis, and exact_mod_cast transports it to the natural-number identity NP·NQ = DP·DQ via Nat.cast injectivity.",
+    "summary": "Proves NP·NQ = DP·DQ in ℕ by clearing denominators from the product-equals-1 hypothesis.",
+    "mathContext": "$\\frac1p\\prod_{q\\in P} q = \\prod_{q\\neq p} q$ gives $(\\sum 1/p)D_P = N_P$; applying to both factors of $(\\Sigma_{1/P})(\\Sigma_{1/Q})=1$ yields $N_P N_Q = D_P D_Q$ over $\\mathbb{Q}$, then over $\\mathbb{N}$ by cast injectivity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "clearing denominators",
+      "Finset.mul_prod_erase",
+      "inv_mul_cancel_left₀",
+      "Nat.cast injectivity",
+      "exact_mod_cast"
+    ],
+    "prerequisites": [
+      "field arithmetic over ℚ",
+      "casting ℕ → ℚ",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-e307oq0201-padic-core",
+    "proofId": "erdos-307-oq-02-oq-01",
+    "range": { "startLine": 98, "endLine": 127 },
+    "type": "insight",
+    "title": "The p-adic Core: p₀ ∤ NP via Reduction in 𝔽_{p₀}",
+    "content": "prime_not_dvd_primeNumer is the heart of the file: for a prime p₀ ∈ P, p₀ ∤ NP. The proof reduces NP modulo p₀ in ZMod p₀ = 𝔽_{p₀} (a field, registered via Fact (Nat.Prime p₀)). In hcast, Finset.sum_eq_single_of_mem isolates the p = p₀ summand because every other summand ∏_{q∈P.erase p} q contains the factor p₀ (since p₀ ∈ P.erase p), which is 0 in 𝔽_{p₀} by ZMod.natCast_self. The survivor ∏_{q∈P.erase p₀} q is a product of primes q ≠ p₀; in hne, Finset.prod_ne_zero_iff plus ZMod.natCast_eq_zero_iff and Nat.prime_dvd_prime_iff_eq show each factor is a nonzero unit, so the product is nonzero. A nonzero image mod p₀ means p₀ ∤ NP — exactly the statement v_{p₀}(Σ 1/p) = -1, with no valuation API.",
+    "summary": "For prime p₀ ∈ P, reducing NP mod p₀ leaves one nonzero unit-product term, so p₀ ∤ NP.",
+    "mathContext": "In $\\mathbb{F}_{p_0}$: $\\overline{N_P} = \\sum_p \\prod_{q\\neq p}\\bar q$; all terms with $p\\neq p_0$ vanish (they contain $\\bar p_0 = 0$), leaving $\\prod_{q\\in P\\setminus\\{p_0\\}}\\bar q \\neq 0$ since each $q\\neq p_0$ is a unit. Hence $\\overline{N_P}\\neq 0$, i.e. $p_0\\nmid N_P$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "reduction modulo p",
+      "ZMod p as a field",
+      "Finset.sum_eq_single_of_mem",
+      "Finset.prod_ne_zero_iff",
+      "Nat.prime_dvd_prime_iff_eq",
+      "p-adic valuation = -1"
+    ],
+    "prerequisites": [
+      "finite fields and ZMod p",
+      "integral domain (no zero divisors)",
+      "divisibility of primes"
+    ]
+  },
+  {
+    "id": "ann-e307oq0201-main",
+    "proofId": "erdos-307-oq-02-oq-01",
+    "range": { "startLine": 133, "endLine": 157 },
+    "type": "theorem",
+    "title": "Disjointness: A Shared Prime Breaks the Identity",
+    "content": "prime_sets_disjoint assembles the contradiction. Suppose p₀ ∈ P ∩ Q. The core lemma gives p₀ ∤ NP and p₀ ∤ NQ; since p₀ is prime, Nat.Prime.dvd_mul yields p₀ ∤ NP·NQ. On the other side, p₀ ∈ P gives p₀ ∣ DP = ∏ p (Finset.dvd_prod_of_mem), so p₀ ∣ DP·DQ. But primeNumer_mul_eq says NP·NQ = DP·DQ, so p₀ ∣ NP·NQ after all — contradicting p₀ ∤ NP·NQ. Hence no shared prime exists and P ∩ Q = ∅. The argument uses nothing about the primes beyond primality, so it holds for arbitrary finite prime sets, independent of any size bound.",
+    "summary": "A shared prime divides DP·DQ but neither numerator, contradicting NP·NQ = DP·DQ; so P ∩ Q = ∅.",
+    "mathContext": "$p_0\\in P\\cap Q \\Rightarrow p_0\\nmid N_P N_Q$ (core lemma + primality) yet $p_0\\mid D_P D_Q = N_P N_Q$ (divides both denominators) — contradiction, forcing $P\\cap Q = \\emptyset$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "proof by contradiction",
+      "Nat.Prime.dvd_mul",
+      "Finset.dvd_prod_of_mem",
+      "disjoint finite sets"
+    ],
+    "prerequisites": [
+      "Euclid's lemma (prime divides a product)",
+      "Finset.eq_empty_iff_forall_notMem"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-307-oq-02-oq-01` (passes: 0).

## Change
The entry had a mature `meta.json` (full overview with 6 keyInsights, sections with mathContext, conclusion, crossReferences) but **no `annotations.json`** — there were no inline annotations on the proof page.

Created `annotations.json` with **5 annotations**, each carrying mathContext (LaTeX), significance, relatedConcepts, and prerequisites:
1. **Header** — the strategy of discharging a 'p-adic' sorry without p-adic machinery.
2. **Setup** — the integer numerator NP and denominator DP definitions.
3. **Identity** — clearing denominators to NP·NQ = DP·DQ.
4. **p-adic core** — p₀ ∤ NP via reduction in 𝔽_{p₀} (the elementary form of v_{p₀} = -1).
5. **Disjointness** — the shared-prime contradiction.

Ranges align with the `sections` line ranges and stay within the 171-line file. Content verified against `proofs/Proofs/Erdos307OQ02OQ01.lean` (4 theorems, 5 defs, 0 sorries, 0 axioms).