### PR TITLE
research(ramsey-r4k-oq-02): exact Ramsey lower bound R(4,3) ≥ 9 via Wagner coloring [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/RamseyR4kOQ02.lean
+++ b/proofs/Proofs/RamseyR4kOQ02.lean
@@ -1,0 +1,107 @@
+/-
+  RamseyR4kOQ02.lean
+
+  Exact Ramsey number lower bound: R(4,3) ≥ 9.
+
+  Open question OQ-02 from the `ramsey-r4k` gallery proof asks whether the exact
+  off-diagonal Ramsey numbers R(4,3) = 9, R(4,4) = 18, R(4,5) = 25 can be verified
+  in Lean 4. The parent proof `ramsey-r4k` establishes only the classical
+  Erdős–Szekeres *upper* bounds (R(4,k) ≤ C(k+2,3), giving R(4,3) ≤ 10), not the
+  exact values.
+
+  This file contributes the *lower* half of the smallest case:
+
+        R(4,3) ≥ 9,   i.e.   ¬ RamseyProp 8 4 3,
+
+  the "exhibit an extremal coloring on n-1 = 8 vertices" direction mentioned in the
+  open question. We give the explicit extremal 2-coloring of K₈ and verify by finite
+  decision that it contains no red 4-clique and no blue 3-clique.
+
+  The extremal coloring is the **Wagner graph** V₈ (the Möbius–Kantor 8-cycle with the
+  four long diagonals), the unique triangle-free graph on 8 vertices with independence
+  number 3. Encoding the Wagner edges as the *blue* color and all other edges as *red*:
+
+    * blue is triangle-free   ⟹  no blue K₃,
+    * α(Wagner) = 3           ⟹  the red graph (its complement) has clique number 3,
+                                   hence no red K₄.
+
+  Combined with the parent proof's machinery the exact value R(4,3) = 9 is bracketed
+  from below; the matching exact upper bound R(4,3) ≤ 9 (sharpening the binomial
+  bound of 10) remains open here.
+
+  The clique-freeness facts are finite checks over all subsets of Fin 8, discharged by
+  `decide`, so they are fully kernel-verified (no `native_decide`, no extra axioms).
+
+  Source: Open question OQ-02 from the ramsey-r4k gallery proof.
+  Tags: combinatorics, ramsey-theory, graph-theory, exact-ramsey-numbers, lower-bounds
+-/
+
+import Mathlib
+import Proofs.RamseyR4k
+
+namespace RamseyR4kOQ02
+
+open Finset
+
+/-! ## The extremal coloring of K₈ (the Wagner graph)
+
+We work on the vertex set `Fin 8 ≅ ℤ/8ℤ`. The Wagner graph has an edge between
+`i` and `j` exactly when their cyclic distance is `1` or `4` (equivalently the
+circular difference `(i - j) mod 8 ∈ {1, 4, 7}`). We color these edges **blue**
+(`false`) and every other edge **red** (`true`). Loops are colored blue to satisfy
+the irreflexivity convention `f x x = false`.
+-/
+
+/-- The circular difference `(i - j) mod 8`, computed without subtraction underflow. -/
+def cdiff (i j : Fin 8) : ℕ := (i.val + 8 - j.val) % 8
+
+/-- The extremal 2-coloring of `K₈`: `false` (blue) on Wagner edges and loops,
+    `true` (red) elsewhere. -/
+def wagnerColor (i j : Fin 8) : Bool :=
+  let d := cdiff i j
+  !(d == 0 || d == 1 || d == 4 || d == 7)
+
+/-- The coloring is symmetric (an undirected edge coloring). -/
+theorem wagner_symm : ∀ x y, wagnerColor x y = wagnerColor y x := by decide
+
+/-- The coloring is irreflexive: loops are blue. -/
+theorem wagner_irrefl : ∀ x, wagnerColor x x = false := by decide
+
+set_option maxRecDepth 4000 in
+/-- No red 4-clique: the red graph (complement of the Wagner graph) has clique
+    number 3, so there is no set of 4 vertices that are pairwise red. -/
+theorem wagner_no_red_K4 :
+    ¬ ∃ S : Finset (Fin 8), S.card ≥ 4 ∧
+        ∀ x y, x ∈ S → y ∈ S → x ≠ y → wagnerColor x y = true := by decide
+
+set_option maxRecDepth 4000 in
+/-- No blue 3-clique: the Wagner (blue) graph is triangle-free. -/
+theorem wagner_no_blue_K3 :
+    ¬ ∃ S : Finset (Fin 8), S.card ≥ 3 ∧
+        ∀ x y, x ∈ S → y ∈ S → x ≠ y → wagnerColor x y = false := by decide
+
+/-! ## The lower bound R(4,3) ≥ 9 -/
+
+/-- **R(4,3) ≥ 9.** There is a 2-coloring of `K₈` with no red 4-clique and no blue
+    3-clique, so `K₈` does *not* have the Ramsey property `RamseyProp 8 4 3`. This is
+    the lower-bound half of the exact value R(4,3) = 9. -/
+theorem r43_lower : ¬ RamseyR4k.RamseyProp 8 4 3 := by
+  intro h
+  rcases h wagnerColor wagner_symm wagner_irrefl with hred | hblue
+  · exact wagner_no_red_K4 hred
+  · exact wagner_no_blue_K3 hblue
+
+/-- Restated in the conventional Ramsey direction: every 2-coloring of `K₈`
+    *can* avoid both a red 4-clique and a blue 3-clique. Concretely, the Wagner
+    coloring witnesses this. -/
+theorem r43_lower_witness :
+    ∃ f : Fin 8 → Fin 8 → Bool,
+      (∀ x y, f x y = f y x) ∧
+      (∀ x, f x x = false) ∧
+      (¬ ∃ S : Finset (Fin 8), S.card ≥ 4 ∧
+          ∀ x y, x ∈ S → y ∈ S → x ≠ y → f x y = true) ∧
+      (¬ ∃ S : Finset (Fin 8), S.card ≥ 3 ∧
+          ∀ x y, x ∈ S → y ∈ S → x ≠ y → f x y = false) :=
+  ⟨wagnerColor, wagner_symm, wagner_irrefl, wagner_no_red_K4, wagner_no_blue_K3⟩
+
+end RamseyR4kOQ02

--- a/research/problems/ramsey-r4k-oq-02/knowledge.md
+++ b/research/problems/ramsey-r4k-oq-02/knowledge.md
@@ -2,16 +2,36 @@
 
 ## Established Facts
 
-(None yet — populated during OBSERVE.)
+- **R(4,3) ≥ 9** is now formalized: `RamseyR4kOQ02.r43_lower : ¬ RamseyR4k.RamseyProp 8 4 3`
+  (file `proofs/Proofs/RamseyR4kOQ02.lean`). VERIFIED, 0-axiom (only
+  propext/Classical.choice/Quot.sound; `decide`, not `native_decide`).
+- The extremal witness is the **Wagner graph V₈** taken as the blue color:
+  `wagnerColor i j = false` iff (i−j) mod 8 ∈ {0,1,4,7}. It is triangle-free
+  (no blue K₃) and has independence number 3 (so its complement, the red graph,
+  has no K₄).
+- Both clique-freeness facts are decidable finite checks over subsets of Fin 8
+  (`set_option maxRecDepth 4000` required for the kernel `decide`).
 
 ## Open Questions Within This Problem
 
-- The main open question (see `problem.md`).
+- **Exact upper bound R(4,3) ≤ 9** (every 2-coloring of K₉ has a red K₄ or blue K₃).
+  The parent only gives the binomial bound ≤ 10. This needs either an exhaustive/SAT
+  argument over K₉ or a degree/parity combinatorial argument — not yet attempted.
+- **R(4,4) = 18** and **R(4,5) = 25** — both halves still open; the lower bounds need
+  17- and 24-vertex extremal colorings (Paley graph on 17 vertices for R(4,4)>17).
 
 ## Failed Approaches
 
-(None yet.)
+- Plain `decide` on the clique-freeness existentials hits "maximum recursion depth";
+  fixed by `set_option maxRecDepth 4000`.
+- `native_decide` would also work but introduces the `Lean.ofReduceBool` axiom;
+  avoided in favor of axiom-free `decide`.
 
 ## Promising Leads
 
-(None yet.)
+- For R(4,3) ≤ 9: the standard combinatorial proof pivots on a vertex of K₉ — among
+  its 8 edges, ≥6 red forces a red K₄ analysis, ≥3 blue forces a blue triangle unless
+  the blue neighbors are mutually red; a degree/parity count finishes it. Formalizable
+  without exhaustive search.
+- For R(4,4) > 17: the Paley graph on F₁₇ (quadratic-residue connection set) is the
+  extremal coloring; its clique/independence checks are larger but still decidable.

--- a/research/problems/ramsey-r4k-oq-02/state.md
+++ b/research/problems/ramsey-r4k-oq-02/state.md
@@ -1,17 +1,24 @@
 # State: ramsey-r4k-oq-02
 
-**Phase**: OBSERVE
-**Since**: 2026-06-09
+**Phase**: PROGRESS
+**Since**: 2026-06-27
 **Path**: full
 
 ## Phase History
 
 - 2026-06-09: Initialized in OBSERVE phase by Seeker.
+- 2026-06-27: researcher-9 proved the lower bound R(4,3) ≥ 9 (¬ RamseyProp 8 4 3) via the explicit Wagner extremal coloring of K₈. VERIFIED, 0-axiom.
 
 ## Current Focus
 
-Reading the source gallery proof `ramsey-r4k` and translating the open question into a precise Lean statement.
+Lower-bound half of R(4,3) = 9 complete. Remaining: the exact upper bound R(4,3) ≤ 9
+(sharpening the parent binomial bound of 10), and the harder cases R(4,4) = 18,
+R(4,5) = 25.
 
 ## Notes
 
-Selected by Seeker on 2026-06-09 from candidate pool. Significance/tractability scores recorded in `research/db/knowledge.db`.
+- Lean file: `proofs/Proofs/RamseyR4kOQ02.lean` (imports parent `Proofs.RamseyR4k`).
+- The lower bound is `decide`-verified (kernel enumeration over subsets of Fin 8),
+  so it depends only on propext/Classical.choice/Quot.sound — no `Lean.ofReduceBool`.
+- The Wagner graph V₈ (cyclic connection set {±1, 4}) is the unique triangle-free
+  8-vertex graph with independence number 3, exactly the (3,4)-extremal graph.

--- a/src/data/proofs/ramsey-r4k-oq-02/meta.json
+++ b/src/data/proofs/ramsey-r4k-oq-02/meta.json
@@ -1,0 +1,61 @@
+{
+  "id": "ramsey-r4k-oq-02",
+  "title": "Exact Ramsey Number Lower Bound R(4,3) ≥ 9 via the Wagner Coloring",
+  "slug": "ramsey-r4k-oq-02",
+  "description": "Verifies the lower-bound half of the exact off-diagonal Ramsey number R(4,3) = 9: there is a 2-coloring of K₈ with no red 4-clique and no blue 3-clique, hence R(4,3) > 8. The extremal coloring is the Wagner graph V₈ (the 8-cycle with its four long diagonals), the unique triangle-free graph on 8 vertices with independence number 3, taken as the blue color. The two clique-freeness facts are finite decisions over all subsets of Fin 8 discharged by `decide`, so the result is fully kernel-verified with no extra axioms (only propext/Classical.choice/Quot.sound). This is the 'exhibit an extremal coloring on n-1 vertices' direction raised by the parent's OQ-02; the matching exact upper bound R(4,3) ≤ 9 (sharpening the binomial bound 10) remains open.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RamseyR4kOQ02.lean",
+    "tags": [
+      "combinatorics",
+      "ramsey-theory",
+      "graph-theory",
+      "exact-ramsey-numbers",
+      "lower-bounds"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 107,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "assumptions": "None. The two clique-freeness lemmas (`wagner_no_red_K4`, `wagner_no_blue_K3`) and the symmetry/irreflexivity facts are proved by `decide` — kernel-checked finite enumeration, not `native_decide` — so `#print axioms r43_lower` lists only the foundational axioms propext, Classical.choice, Quot.sound. No `Lean.ofReduceBool`, no `sorryAx`. `set_option maxRecDepth 4000` is needed for the two existential-over-Finset (Fin 8) decisions.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.decidableBAll",
+        "description": "Decidability of bounded ∀ over a Finset, used so the no-clique existentials over Finset (Fin 8) reduce by `decide`",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Fintype.decidableExistsFintype",
+        "description": "Decidability of ∃ S : Finset (Fin 8), enabling kernel enumeration of all 2^8 candidate cliques",
+        "module": "Mathlib.Data.Fintype.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Explicit Wagner-graph 2-coloring of K₈ (`wagnerColor`) encoded by cyclic difference (i−j) mod 8 ∈ {1,4,7}",
+      "Fully kernel-verified (0-axiom) proof that this coloring has no red 4-clique (`wagner_no_red_K4`) and no blue 3-clique (`wagner_no_blue_K3`)",
+      "The lower bound R(4,3) ≥ 9 as ¬ RamseyProp 8 4 3 (`r43_lower`), reusing the parent gallery proof's RamseyProp encoding",
+      "A self-contained witness form `r43_lower_witness` packaging the extremal coloring and its two clique-freeness certificates"
+    ],
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "The Ramsey property RamseyProp (from the parent ramsey-r4k proof)",
+      "Wagner graph / Möbius–Kantor structure on 8 vertices",
+      "Decidability of finite Finset quantifiers in Lean 4"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The exact value R(4,3) = R(3,4) = 9 is due to Greenwood and Gleason (1955). Establishing it has two halves: the upper bound R(4,3) ≤ 9 (every 2-coloring of K₉ has a red K₄ or blue K₃) and the lower bound R(4,3) ≥ 9 (some 2-coloring of K₈ avoids both). The lower bound is witnessed by the Wagner graph V₈ — the cycle C₈ together with its four main diagonals — which is the unique triangle-free graph on 8 vertices with independence number 3. The parent gallery proof `ramsey-r4k` formalizes only the classical Erdős–Szekeres binomial upper bounds (R(4,k) ≤ C(k+2,3), giving R(4,3) ≤ 10), never the exact values; the open question OQ-02 asks specifically whether the exact numbers R(4,3)=9, R(4,4)=18, R(4,5)=25 can be verified in Lean 4, noting this needs either SAT-style verification of extremal colorings or an inductive combinatorial argument. This entry settles the smallest case's lower bound by directly exhibiting and checking the extremal coloring.",
+    "problemStatement": "Using the parent encoding `RamseyProp n r s` (every symmetric irreflexive Bool 2-coloring of Fin n × Fin n has a red r-clique or blue s-clique), prove ¬ RamseyProp 8 4 3, i.e. R(4,3) > 8, by exhibiting an explicit coloring of K₈ with no red 4-clique and no blue 3-clique.",
+    "proofStrategy": "Define `wagnerColor i j` to be blue (`false`) exactly when the circular difference (i−j) mod 8 lies in {1,4,7} (the Wagner edges) or i = j (loops), and red (`true`) otherwise. Then: (1) `decide` checks symmetry and irreflexivity over the 64 vertex pairs; (2) since the blue (Wagner) graph is triangle-free, `decide` (with maxRecDepth raised) verifies there is no blue 3-clique by enumerating all subsets of Fin 8; (3) since the Wagner graph has independence number 3, its complement (the red graph) has clique number 3, so `decide` verifies no red 4-clique. Feeding `wagnerColor` together with these certificates into any hypothetical `RamseyProp 8 4 3` yields a contradiction, proving `r43_lower`.",
+    "keyInsights": [
+      "**Extremal coloring as a finite certificate.** Unlike the upper bound (which would require ruling out all 2^36 colorings of K₉), the lower bound only needs one witness coloring of K₈ whose two clique-freeness properties are individually decidable — turning a Ramsey lower bound into a kernel-checkable `decide`.",
+      "**Wagner graph = unique (3,4)-extremal graph on 8 vertices.** Encoding it via the cyclic connection set {±1, 4} makes both triangle-freeness (no blue K₃) and independence number 3 (no red K₄) hold simultaneously, exactly the two conditions a R(4,3)>8 witness must satisfy.",
+      "**0-axiom via `decide` not `native_decide`.** The enumeration is small enough (2^8 subsets, 64 pairs) that the kernel can reduce it directly once `maxRecDepth` is raised, so the proof avoids `Lean.ofReduceBool` and remains genuinely axiom-free — stronger than the parent's numeric bounds, which use `native_decide`.",
+      "**Reuses the gallery's RamseyProp.** By importing the parent file's `RamseyProp`, the lower bound is stated against the exact same definition the gallery uses for upper bounds, so the two results compose into a clean bracket 8 < R(4,3) ≤ 10 with the exact upper bound R(4,3) ≤ 9 left as the remaining open step."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Open question **OQ-02** of the `ramsey-r4k` gallery proof asks whether the exact off-diagonal Ramsey numbers $R(4,3)=9$, $R(4,4)=18$, $R(4,5)=25$ can be verified in Lean 4. The parent proof formalizes only the classical Erdős–Szekeres **upper** bounds ($R(4,k)\le\binom{k+2}{3}$, giving $R(4,3)\le 10$), never the exact values.

This PR settles the **lower-bound half of the smallest case**:
$$R(4,3) \ge 9, \qquad\text{i.e.}\qquad \neg\,\mathrm{RamseyProp}\;8\;4\;3.$$

## Approach

The extremal witness is the **Wagner graph $V_8$** (the $8$-cycle plus its four long diagonals; cyclic connection set $\{\pm1,4\}$), the *unique* triangle-free graph on $8$ vertices with independence number $3$. Coloring its edges **blue** and all others **red**:

- blue is triangle-free $\Rightarrow$ no blue $K_3$;
- $\alpha(V_8)=3 \Rightarrow$ the red graph (its complement) has clique number $3 \Rightarrow$ no red $K_4$.

Feeding this coloring into any hypothetical `RamseyProp 8 4 3` yields a contradiction.

## What's verified

| Theorem | Statement |
|---|---|
| `wagner_symm` / `wagner_irrefl` | the coloring is a valid symmetric, irreflexive edge coloring |
| `wagner_no_red_K4` | no set of 4 pairwise-red vertices |
| `wagner_no_blue_K3` | no set of 3 pairwise-blue vertices |
| `r43_lower` | `¬ RamseyR4k.RamseyProp 8 4 3` (reuses the parent's `RamseyProp`) |
| `r43_lower_witness` | self-contained packaging of the coloring + both certificates |

The clique-freeness facts are finite decisions over subsets of `Fin 8`, discharged by **`decide`** (kernel enumeration, `maxRecDepth` raised) — **not** `native_decide`.

```
#print axioms r43_lower
  → [propext, Classical.choice, Quot.sound]
```

No `Lean.ofReduceBool`, no `sorryAx` ⇒ **VERIFIED, 0-axiom** (stronger than the parent's numeric bounds, which use `native_decide`). 0 sorries.

## Verification

Verified with `lake env lean` (Lean v4.26.0) against the Mathlib `.olean` cache — the Docker build channel was down (containerd `meta.db` I/O error). `RamseyR4k` dependency compiled and `RamseyR4kOQ02.lean` type-checks with exit 0.

## Scope / what remains open

- Exact **upper** bound $R(4,3)\le 9$ (sharpening the binomial $10$) — needs a degree/parity combinatorial argument or exhaustive check over $K_9$.
- $R(4,4)=18$, $R(4,5)=25$ — both halves still open (lower bounds need 17- and 24-vertex extremal colorings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)