### PR TITLE
Enrich Finite Arithmetico-Geometric Sum (summation-by-parts-oq-01): add 4th keyInsight

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01/meta.json
@@ -52,7 +52,8 @@
     "keyInsights": [
       "**Constant differences collapse the correction.** Abel summation expresses $\\sum k r^k$ via the forward differences of the weight $k$; since these are all $1$, the abstract correction term degenerates to a plain sum of geometric partial sums — the structural reason the closed form exists.",
       "**Field, not analysis.** The identity needs no norm and no convergence hypothesis: it is an exact polynomial-over-$(r-1)^2$ identity valid for every $r\\neq 1$ in any field. The familiar $r/(1-r)^2$ is just its $n\\to\\infty$ shadow when $|r|<1$.",
-      "**A genuine gap.** Mathlib packages the geometric closed form `geom_sum_eq` and the arithmetic sum `sum_range_id` separately but not their product $\\sum k r^k$; this entry supplies the missing finite identity that the gallery's infinite `geometric-series-oq-06` silently assumes."
+      "**A genuine gap.** Mathlib packages the geometric closed form `geom_sum_eq` and the arithmetic sum `sum_range_id` separately but not their product $\\sum k r^k$; this entry supplies the missing finite identity that the gallery's infinite `geometric-series-oq-06` silently assumes.",
+      "**Differentiating the geometric series.** Over $\\mathbb{R}$ with $|r|<1$, $\\sum_k k\\,r^k = r\\frac{d}{dr}\\sum_k r^k = r\\frac{d}{dr}\\frac{1}{1-r} = \\frac{r}{(1-r)^2}$: the weighted sum is the term-by-term derivative of the geometric series. The finite identity proved here is the exact algebraic skeleton of that calculus heuristic, recovering it in any field without ever invoking differentiation or convergence."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01` (passes: 0).

## Change
The entry was already strong (3 deep keyInsights, complete conclusion, 2 sections covering both proof methods, fully-enriched annotations). Added **one genuinely distinct keyInsight** — the generating-function/differentiation viewpoint that was alluded to in an annotation but absent from the overview:

> **Differentiating the geometric series.** ∑ k·rᵏ = r·d/dr(∑ rᵏ) = r/(1−r)²; the finite identity proved here is the exact algebraic skeleton of that calculus heuristic, recovering it in any field without invoking differentiation or convergence.

This brings keyInsights from 3 → 4 (within the 4–12 target) without padding — it is distinct from the existing three (Abel-correction collapse, field-not-analysis, the Mathlib gap). meta.json remains well within caps. Content verified against `proofs/Proofs/SummationByPartsOQ01.lean` (2 theorems, 0 sorries, 0 axioms).