### PR TITLE
research(pythagorean-theorem-oq-01): close spherical_flat_limit + repair Mathlib drift [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1887,6 +1887,7 @@ import Proofs.Erdos305Problem
 import Proofs.Erdos306Problem
 import Proofs.Erdos307Aristotle
 import Proofs.Erdos307OQ02
+import Proofs.Erdos307OQ02OQ01
 import Proofs.Erdos307Problem
 import Proofs.Erdos308OQ03
 import Proofs.Erdos308Problem

--- a/proofs/Proofs/Erdos307OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos307OQ02OQ01.lean
@@ -1,0 +1,171 @@
+import Mathlib
+
+/-
+# Erdős 307 — OQ-02-OQ-01: Disjointness of Prime Solution Sets
+
+## Research Problem: erdos-307-oq-02-oq-01
+
+Discharges the `prime_sets_disjoint` sorry documented in `Erdos307OQ02.lean`:
+
+  If P and Q are finite sets of primes with
+    (Σ_{p ∈ P} 1/p) · (Σ_{q ∈ Q} 1/q) = 1,
+  then P ∩ Q = ∅.
+
+The documented approach was "p-adic valuation theory". We give a fully
+elementary, axiom-free proof that captures exactly the p-adic content
+without invoking `padicValRat`:
+
+  * Write Σ_{p ∈ P} 1/p = NP / DP where
+      DP := ∏_{p ∈ P} p          (squarefree, the denominator)
+      NP := Σ_{p ∈ P} ∏_{q ≠ p} q (the numerator).
+  * The hypothesis (NP/DP)(NQ/DQ) = 1 clears denominators to the INTEGER
+    identity  NP · NQ = DP · DQ.
+  * For a prime p₀ ∈ P, reducing NP modulo p₀ kills every summand except
+    the q = p₀ term (which is a product of primes all ≠ p₀, hence a unit
+    in 𝔽_{p₀}). So p₀ ∤ NP. This is precisely v_{p₀}(Σ 1/p) = -1.
+  * If p₀ ∈ P ∩ Q then p₀ ∤ NP and p₀ ∤ NQ, so p₀ ∤ NP·NQ; but p₀ ∣ DP
+    and p₀ ∣ DQ give p₀ ∣ DP·DQ = NP·NQ. Contradiction.
+
+Tags: number-theory, primes, p-adic-valuation, egyptian-fractions
+-/
+
+open Finset BigOperators
+
+namespace Erdos307OQ02OQ01
+
+-- ============================================================
+-- Part I: Setup (mirrors the parent file)
+-- ============================================================
+
+/-- Sum of reciprocals of elements in a finite set. -/
+noncomputable def reciprocalSum (S : Finset ℕ) : ℚ :=
+  ∑ n ∈ S, (n : ℚ)⁻¹
+
+/-- Product of two reciprocal sums. -/
+noncomputable def reciprocalProduct (P Q : Finset ℕ) : ℚ :=
+  reciprocalSum P * reciprocalSum Q
+
+/-- A set of primes: every element is prime. -/
+def IsSetOfPrimes (S : Finset ℕ) : Prop :=
+  ∀ p ∈ S, Nat.Prime p
+
+/-- The integer numerator of `reciprocalSum`:  Σ_{p ∈ P} ∏_{q ∈ P\{p}} q. -/
+def primeNumer (P : Finset ℕ) : ℕ :=
+  ∑ p ∈ P, ∏ q ∈ P.erase p, q
+
+/-- The integer denominator of `reciprocalSum`:  ∏_{p ∈ P} p. -/
+def primeDenom (P : Finset ℕ) : ℕ :=
+  ∏ p ∈ P, p
+
+-- ============================================================
+-- Part II: The numerator / denominator identity over ℚ
+-- ============================================================
+
+/-- Clearing denominators:  (Σ 1/p) · (∏ p) = Σ_{p} ∏_{q ≠ p} q.
+    Requires only that no element is `0` (true for primes). -/
+lemma reciprocalSum_mul_denom (P : Finset ℕ) (hP : ∀ p ∈ P, p ≠ 0) :
+    reciprocalSum P * (primeDenom P : ℚ) = (primeNumer P : ℚ) := by
+  unfold reciprocalSum primeDenom primeNumer
+  push_cast
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro p hp
+  have hpne : (p : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (hP p hp)
+  rw [← Finset.mul_prod_erase P (fun q => (q : ℚ)) hp, inv_mul_cancel_left₀ hpne]
+
+/-- The cleared-denominator INTEGER identity.  From `(Σ1/p)(Σ1/q) = 1` we get
+    `NP · NQ = DP · DQ` in ℕ. -/
+lemma primeNumer_mul_eq (P Q : Finset ℕ)
+    (hP : ∀ p ∈ P, p ≠ 0) (hQ : ∀ q ∈ Q, q ≠ 0)
+    (h : reciprocalProduct P Q = 1) :
+    primeNumer P * primeNumer Q = primeDenom P * primeDenom Q := by
+  have hA := reciprocalSum_mul_denom P hP
+  have hB := reciprocalSum_mul_denom Q hQ
+  unfold reciprocalProduct at h
+  have key : (primeNumer P : ℚ) * (primeNumer Q : ℚ)
+      = (primeDenom P : ℚ) * (primeDenom Q : ℚ) := by
+    have e : (primeNumer P : ℚ) * (primeNumer Q : ℚ)
+        = (reciprocalSum P * reciprocalSum Q)
+            * ((primeDenom P : ℚ) * (primeDenom Q : ℚ)) := by
+      rw [← hA, ← hB]; ring
+    rw [e, h, one_mul]
+  exact_mod_cast key
+
+-- ============================================================
+-- Part III: The p-adic core — p₀ ∤ numerator
+-- ============================================================
+
+/-- For a prime `p₀ ∈ P` (with `P` a set of primes), `p₀` does NOT divide the
+    numerator `NP`.  Equivalently `v_{p₀}(Σ_{p∈P} 1/p) = -1`.
+
+    Proof: reduce `NP = Σ_p ∏_{q≠p} q` modulo `p₀` in the field `𝔽_{p₀}`.
+    Every summand with `p ≠ p₀` contains the factor `p₀`, hence vanishes; the
+    `p = p₀` summand is `∏_{q ≠ p₀} q`, a product of primes all distinct from
+    `p₀`, hence a nonzero product in the field. -/
+lemma prime_not_dvd_primeNumer (P : Finset ℕ) (hP : IsSetOfPrimes P)
+    {p₀ : ℕ} (hp₀ : p₀ ∈ P) : ¬ (p₀ ∣ primeNumer P) := by
+  have hp₀prime : Nat.Prime p₀ := hP p₀ hp₀
+  haveI : Fact (Nat.Prime p₀) := ⟨hp₀prime⟩
+  haveI : NeZero p₀ := ⟨hp₀prime.pos.ne'⟩
+  -- Reduce `NP` modulo `p₀`: only the `p = p₀` summand survives.
+  have hcast : ((primeNumer P : ℕ) : ZMod p₀) = ∏ q ∈ P.erase p₀, (q : ZMod p₀) := by
+    unfold primeNumer
+    push_cast
+    exact Finset.sum_eq_single_of_mem p₀ hp₀ (fun b _ hbne =>
+      Finset.prod_eq_zero (Finset.mem_erase.mpr ⟨Ne.symm hbne, hp₀⟩)
+        (ZMod.natCast_self p₀))
+  -- That surviving product is a nonempty product of nonzero units → nonzero.
+  have hne : ((primeNumer P : ℕ) : ZMod p₀) ≠ 0 := by
+    rw [hcast, Finset.prod_ne_zero_iff]
+    intro q hq
+    rw [Finset.mem_erase] at hq
+    have hqprime : Nat.Prime q := hP q hq.2
+    rw [Ne, ZMod.natCast_eq_zero_iff]
+    exact fun hdvdq => hq.1 ((Nat.prime_dvd_prime_iff_eq hp₀prime hqprime).mp hdvdq).symm
+  -- A divisor would force the cast to vanish.
+  intro hdvd
+  exact hne ((ZMod.natCast_eq_zero_iff _ _).mpr hdvd)
+
+-- ============================================================
+-- Part IV: Main theorem
+-- ============================================================
+
+/-- **prime_sets_disjoint** (was a documented sorry in `Erdos307OQ02.lean`).
+
+    If `P, Q` are finite sets of primes whose reciprocal sums multiply to `1`,
+    then `P ∩ Q = ∅`. -/
+theorem prime_sets_disjoint {P Q : Finset ℕ} (hP : IsSetOfPrimes P)
+    (hQ : IsSetOfPrimes Q) (hPQ : reciprocalProduct P Q = 1) :
+    P ∩ Q = ∅ := by
+  rw [Finset.eq_empty_iff_forall_notMem]
+  intro p₀ hmem
+  rw [Finset.mem_inter] at hmem
+  obtain ⟨hp₀P, hp₀Q⟩ := hmem
+  have hp₀prime : Nat.Prime p₀ := hP p₀ hp₀P
+  -- p₀ divides neither numerator.
+  have hnP : ¬ p₀ ∣ primeNumer P := prime_not_dvd_primeNumer P hP hp₀P
+  have hnQ : ¬ p₀ ∣ primeNumer Q := prime_not_dvd_primeNumer Q hQ hp₀Q
+  have hnPQ : ¬ p₀ ∣ primeNumer P * primeNumer Q := by
+    rw [hp₀prime.dvd_mul]; exact not_or.mpr ⟨hnP, hnQ⟩
+  -- but p₀ divides both denominators, hence their product.
+  have hdP : p₀ ∣ primeDenom P := by
+    unfold primeDenom; exact Finset.dvd_prod_of_mem (fun p => p) hp₀P
+  have heq := primeNumer_mul_eq P Q
+    (fun p hp => (hP p hp).pos.ne') (fun q hq => (hQ q hq).pos.ne') hPQ
+  have hdvd : p₀ ∣ primeNumer P * primeNumer Q := by
+    rw [heq]; exact hdP.mul_right _
+  exact hnPQ hdvd
+
+/-
+  Result: `prime_sets_disjoint` is fully proved — 0 sorries, 0 axioms.
+
+  This discharges item (1) of "Part VI: Documentation of Remaining Sorries"
+  in `Erdos307OQ02.lean`.  The p-adic valuation content (v_{p₀} = -1 for each
+  p₀ in a prime-reciprocal sum) is captured elementarily by a single mod-p₀
+  reduction in `prime_not_dvd_primeNumer`, avoiding any `padicValRat` machinery.
+
+  Remaining from the parent: `prime_set_size_lower_bound` (|P ∪ Q| ≥ 60), which
+  needs a verified Mertens-type computational bound and is independent of this.
+-/
+
+end Erdos307OQ02OQ01

--- a/proofs/Proofs/PythagoreanTheoremOQ05.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ05.lean
@@ -26,7 +26,7 @@ The product limit (cosh(ta)·cosh(tb)-1)/t² → (a²+b²)/2 follows by decompos
   (cosh(ta)·cosh(tb) - 1)/t² = (cosh(ta)-1)/t² · cosh(tb) + (cosh(tb)-1)/t²
 and using continuity of cosh at 0.
 
-## Status: 0 sorries, 0 axioms (spherical case has 1 sorry — see note below)
+## Status: 0 sorries, 0 axioms (both hyperbolic and spherical cases fully proved)
 
 Tags: geometry, non-euclidean, flat-limit, taylor-approximation, squeeze-theorem
 -/
@@ -36,9 +36,11 @@ import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
 import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 import Mathlib.Analysis.Calculus.MeanValue
 import Mathlib.Topology.Algebra.Order.LiminfLimsup
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Sinc
 import Mathlib.Tactic
 
 open Real Filter Set
+open scoped Topology
 
 namespace PythagoreanFlatLimit
 
@@ -89,7 +91,7 @@ theorem cosh_ge_one' (x : ℝ) : 1 ≤ Real.cosh x := by
 theorem sinh_ge_id' (x : ℝ) (hx : 0 ≤ x) : x ≤ Real.sinh x := by
   suffices h : Real.sinh x - x ≥ 0 by linarith
   let f : ℝ → ℝ := fun y => Real.sinh y - y
-  have hf0 : f 0 = 0 := by simp [Real.sinh_zero]
+  have hf0 : f 0 = 0 := by show Real.sinh 0 - 0 = 0; norm_num [Real.sinh_zero]
   have hf_cont : ContinuousOn f (Icc 0 x) :=
     (Real.continuous_sinh.sub continuous_id).continuousOn
   have hf_diff : DifferentiableOn ℝ f (interior (Icc 0 x)) := by
@@ -109,7 +111,7 @@ theorem sinh_ge_id' (x : ℝ) (hx : 0 ≤ x) : x ≤ Real.sinh x := by
 theorem cosh_ge_one_add_sq_div_two' (x : ℝ) (hx : 0 ≤ x) : 1 + x ^ 2 / 2 ≤ Real.cosh x := by
   suffices h : Real.cosh x - 1 - x ^ 2 / 2 ≥ 0 by linarith
   let f : ℝ → ℝ := fun y => Real.cosh y - 1 - y ^ 2 / 2
-  have hf0 : f 0 = 0 := by simp [Real.cosh_zero]
+  have hf0 : f 0 = 0 := by show Real.cosh 0 - 1 - 0 ^ 2 / 2 = 0; norm_num [Real.cosh_zero]
   have hf_cont : ContinuousOn f (Icc 0 x) := by
     exact (Real.continuous_cosh.sub continuous_const |>.sub
       ((continuous_pow 2).div_const 2)).continuousOn
@@ -118,14 +120,18 @@ theorem cosh_ge_one_add_sq_div_two' (x : ℝ) (hx : 0 ≤ x) : 1 + x ^ 2 / 2 ≤
     have : HasDerivAt f (Real.sinh t - t) t := by
       have hd3 : HasDerivAt (fun y : ℝ => y ^ 2 / 2) t t := by
         convert (hasDerivAt_pow 2 t).div_const 2 using 1; ring
-      exact ((hasDerivAt_cosh' t).sub (hasDerivAt_const t 1)).sub hd3
+      have hcomb : HasDerivAt f (Real.sinh t - 0 - t) t :=
+        ((hasDerivAt_cosh' t).sub (hasDerivAt_const t 1)).sub hd3
+      simpa using hcomb
     exact this.differentiableAt.differentiableWithinAt
   have hf_deriv : ∀ t ∈ interior (Icc 0 x), 0 ≤ deriv f t := by
     intro t ht
     have hd3 : HasDerivAt (fun y : ℝ => y ^ 2 / 2) t t := by
       convert (hasDerivAt_pow 2 t).div_const 2 using 1; ring
-    have hd : HasDerivAt f (Real.sinh t - t) t :=
-      ((hasDerivAt_cosh' t).sub (hasDerivAt_const t 1)).sub hd3
+    have hd : HasDerivAt f (Real.sinh t - t) t := by
+      have hcomb : HasDerivAt f (Real.sinh t - 0 - t) t :=
+        ((hasDerivAt_cosh' t).sub (hasDerivAt_const t 1)).sub hd3
+      simpa using hcomb
     rw [hd.deriv]; linarith [sinh_ge_id' t (interior_subset ht).1]
   have hf_mono : MonotoneOn f (Icc 0 x) :=
     monotoneOn_of_deriv_nonneg (convex_Icc 0 x) hf_cont hf_diff hf_deriv
@@ -134,7 +140,7 @@ theorem cosh_ge_one_add_sq_div_two' (x : ℝ) (hx : 0 ≤ x) : 1 + x ^ 2 / 2 ≤
 
 /-- cosh(x) ≥ 1 + x²/2 for all real x (extend via evenness). -/
 theorem cosh_ge_one_add_sq_div_two_all (x : ℝ) : 1 + x ^ 2 / 2 ≤ Real.cosh x := by
-  rcases le_or_lt 0 x with hx | hx
+  rcases le_or_gt 0 x with hx | hx
   · exact cosh_ge_one_add_sq_div_two' x hx
   · have h := cosh_ge_one_add_sq_div_two' (-x) (by linarith)
     rwa [Real.cosh_neg, neg_sq] at h
@@ -181,14 +187,14 @@ private theorem hasDerivAt_gDeriv (u : ℝ) :
   -- d/du[2u·cosh u] = 2·cosh u + 2u·sinh u
   have h1 : HasDerivAt (fun u => 2 * u * Real.cosh u) (2 * Real.cosh u + 2 * u * Real.sinh u) u := by
     have := (hasDerivAt_id u |>.const_mul 2).mul hc
-    convert this using 1; ring
+    convert this using 1; simp only [id_eq]; ring
   -- d/du[(u²-2)·sinh u] = 2u·sinh u + (u²-2)·cosh u
   have h2 : HasDerivAt (fun u => (u ^ 2 - 2) * Real.sinh u)
       (2 * u * Real.sinh u + (u ^ 2 - 2) * Real.cosh u) u := by
     have hd : HasDerivAt (fun u : ℝ => u ^ 2 - 2) (2 * u) u := by
       convert ht2.sub (hasDerivAt_const u 2) using 1; ring
     have := hd.mul hs
-    convert this using 1; ring
+    convert this using 1
   have := h1.add h2
   convert this using 1; ring
 
@@ -202,7 +208,7 @@ private theorem gSecondDeriv_nonneg (u : ℝ) (hu : 0 ≤ u) :
 
 /-- gDeriv(u) ≥ 0 for u ≥ 0: apply monotoneOn to gDeriv itself. -/
 private theorem gDeriv_nonneg (x : ℝ) (hx : 0 ≤ x) : 0 ≤ gDeriv x := by
-  suffices hg : gDeriv 0 ≤ gDeriv x by rwa [gDeriv_zero, le_iff_eq_or_lt] at hg; exact hg.le
+  suffices hg : gDeriv 0 ≤ gDeriv x by rwa [gDeriv_zero] at hg
   apply monotoneOn_of_deriv_nonneg (convex_Icc 0 x)
   · -- ContinuousOn gDeriv [0, x]
     unfold gDeriv
@@ -222,9 +228,8 @@ private theorem gDeriv_nonneg (x : ℝ) (hx : 0 ≤ x) : 0 ≤ gDeriv x := by
 /-- Key upper bound: 2·(cosh u - 1) ≤ u²·cosh u for u ≥ 0. -/
 theorem cosh_sub_one_le_sq_mul_cosh (u : ℝ) (hu : 0 ≤ u) :
     2 * (Real.cosh u - 1) ≤ u ^ 2 * Real.cosh u := by
-  have key : 0 ≤ u ^ 2 * Real.cosh u - 2 * (Real.cosh u - 1) := by
+  have hmono : MonotoneOn (fun v => v ^ 2 * Real.cosh v - 2 * (Real.cosh v - 1)) (Icc 0 u) := by
     apply monotoneOn_of_deriv_nonneg (convex_Icc 0 u)
-          (f := fun v => v ^ 2 * Real.cosh v - 2 * (Real.cosh v - 1))
     · exact ((continuous_pow 2 |>.mul Real.continuous_cosh).sub
         (continuous_const.mul (Real.continuous_cosh.sub continuous_const))).continuousOn
     · intro v _
@@ -232,14 +237,13 @@ theorem cosh_sub_one_le_sq_mul_cosh (u : ℝ) (hu : 0 ≤ u) :
     · intro v hv
       rw [(hasDerivAt_gFun v).deriv]
       exact gDeriv_nonneg v (interior_subset hv).1
-    · exact Set.left_mem_Icc.mpr hu
-    · exact Set.right_mem_Icc.mpr hu
-    · simp [Real.cosh_zero]
-  linarith
+  have key := hmono (Set.left_mem_Icc.mpr hu) (Set.right_mem_Icc.mpr hu) hu
+  simp only [Real.cosh_zero] at key
+  nlinarith [key]
 
 /-- Upper bound for all real u (via evenness of cosh). -/
 theorem cosh_sub_one_le_sq_mul_cosh_all (u : ℝ) : 2 * (Real.cosh u - 1) ≤ u ^ 2 * Real.cosh u := by
-  rcases le_or_lt 0 u with hu | hu
+  rcases le_or_gt 0 u with hu | hu
   · exact cosh_sub_one_le_sq_mul_cosh u hu
   · have h := cosh_sub_one_le_sq_mul_cosh (-u) (by linarith)
     rwa [Real.cosh_neg, neg_sq] at h
@@ -255,32 +259,29 @@ theorem cosh_mul_sub_one_div_sq_bounds (x : ℝ) (t : ℝ) (ht : 0 < t) :
     (Real.cosh (t * x) - 1) / t ^ 2 ≤ x ^ 2 * Real.cosh (t * x) / 2 := by
   have ht2 : (0 : ℝ) < t ^ 2 := sq_pos_of_pos ht
   constructor
-  · rw [le_div_iff ht2]
+  · rw [le_div_iff₀ ht2]
     have h := cosh_ge_one_add_sq_div_two_all (t * x)
     nlinarith [sq_nonneg (t * x)]
-  · rw [div_le_div_iff ht2 two_pos]
+  · rw [div_le_div_iff₀ ht2 two_pos]
     have h := cosh_sub_one_le_sq_mul_cosh_all (t * x)
     nlinarith [sq_abs (t * x), sq_nonneg t, sq_nonneg x]
 
 /-- The flat-limit for scaled cosh: (cosh(tx)-1)/t² → x²/2 as t → 0⁺. -/
 theorem tendsto_cosh_mul_sub_one_div_sq (x : ℝ) :
     Tendsto (fun t : ℝ => (Real.cosh (t * x) - 1) / t ^ 2) (𝓝[Ioi 0] 0) (𝓝 (x ^ 2 / 2)) := by
-  apply tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds _
-  · -- Lower bound holds eventually
-    exact Filter.eventually_nhdsWithin_of_forall fun t ht =>
-      (cosh_mul_sub_one_div_sq_bounds x t ht).1
-  · -- Upper: x²·cosh(tx)/2 → x²·1/2 = x²/2
-    have hcont : Tendsto (fun t : ℝ => x ^ 2 * Real.cosh (t * x) / 2) (𝓝[Ioi 0] 0) (𝓝 (x ^ 2 / 2)) := by
-      have hcosh : Tendsto (fun t : ℝ => Real.cosh (t * x)) (𝓝 0) (𝓝 1) := by
-        have := Real.continuous_cosh.continuousAt (x := (0 : ℝ) * x)
-        simp only [zero_mul, Real.cosh_zero] at this
-        exact this.tendsto.comp (continuous_id.mul continuous_const).continuousAt
-      have := hcosh.mono_left nhdsWithin_le_nhds |>.const_mul (x ^ 2) |>.div_const 2
-      simp only [mul_one] at this; convert this using 1; ring
-    exact hcont
-  · -- Upper bound holds eventually
-    exact Filter.eventually_nhdsWithin_of_forall fun t ht =>
-      (cosh_mul_sub_one_div_sq_bounds x t ht).2
+  -- Upper bounding function x²·cosh(tx)/2 → x²/2 by continuity of cosh at 0
+  have hcont : Tendsto (fun t : ℝ => x ^ 2 * Real.cosh (t * x) / 2)
+      (𝓝[Ioi 0] 0) (𝓝 (x ^ 2 / 2)) := by
+    have hcosh : Tendsto (fun t : ℝ => Real.cosh (t * x)) (𝓝[Ioi 0] 0) (𝓝 1) := by
+      have : Tendsto (fun t : ℝ => Real.cosh (t * x)) (𝓝 0) (𝓝 (Real.cosh (0 * x))) :=
+        Real.continuous_cosh.continuousAt.comp (continuous_id.mul continuous_const).continuousAt
+      simp only [zero_mul, Real.cosh_zero] at this
+      exact this.mono_left nhdsWithin_le_nhds
+    have h := (hcosh.const_mul (x ^ 2)).div_const 2
+    simpa using h
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds hcont ?_ ?_
+  · exact eventually_nhdsWithin_of_forall fun t ht => (cosh_mul_sub_one_div_sq_bounds x t ht).1
+  · exact eventually_nhdsWithin_of_forall fun t ht => (cosh_mul_sub_one_div_sq_bounds x t ht).2
 
 -- ============================================================
 -- Part V: Product limit (cosh(ta)·cosh(tb)-1)/t² → (a²+b²)/2
@@ -309,9 +310,9 @@ theorem tendsto_cosh_prod_sub_one_div_sq (a b : ℝ) :
     field_simp; ring
   rw [show (a ^ 2 + b ^ 2) / 2 = a ^ 2 / 2 * 1 + b ^ 2 / 2 by ring]
   apply Tendsto.congr'
+  · exact eventually_nhdsWithin_of_forall fun t ht => (heq t ht).symm
   · exact ((tendsto_cosh_mul_sub_one_div_sq a).mul (tendsto_cosh_mul_one b)).add
       (tendsto_cosh_mul_sub_one_div_sq b)
-  · exact Filter.eventually_nhdsWithin_of_forall fun t ht => (heq t ht).symm
 
 -- ============================================================
 -- Part VI: Main Flat-Limit Theorems
@@ -334,41 +335,109 @@ theorem hyperbolic_flat_limit {a b c : ℝ}
   -- On (0,∞), the two functions agree (from hypothesis h)
   have hagree : ∀ᶠ t in 𝓝[Ioi 0] 0,
       (Real.cosh (t * c) - 1) / t ^ 2 = (Real.cosh (t * a) * Real.cosh (t * b) - 1) / t ^ 2 :=
-    Filter.eventually_nhdsWithin_of_forall fun t ht => by rw [h t ht]
+    eventually_nhdsWithin_of_forall fun t ht => by rw [h t ht]
   -- By uniqueness of limits: c²/2 = (a²+b²)/2
   have : c ^ 2 / 2 = (a ^ 2 + b ^ 2) / 2 :=
     tendsto_nhds_unique (hlhs.congr' hagree) hrhs
   linarith
 
-/-- **Spherical Flat Limit**: If cos(t·c) = cos(t·a)·cos(t·b) for all small t > 0,
+-- ============================================================
+-- Part Va: Spherical scaled limit (1 - cos(tx))/t² → x²/2
+-- Proved via the exact identity (1 - cos(tx))/t² = (x²/2)·sinc(tx/2)²
+-- ============================================================
+
+/-- `sin u = sinc u · u` for all real `u` (sinc absorbs the removable singularity). -/
+theorem sin_eq_sinc_mul (u : ℝ) : Real.sin u = Real.sinc u * u := by
+  rcases eq_or_ne u 0 with h | h
+  · simp [h]
+  · rw [Real.sinc_of_ne_zero h]; field_simp
+
+/-- The spherical flat-limit for scaled cos: `(1 - cos(tx))/t² → x²/2` as `t → 0⁺`.
+
+    The mechanism is the exact algebraic identity (for `t ≠ 0`)
+      `(1 - cos(tx))/t² = (x²/2)·sinc(tx/2)²`,
+    obtained from the half-angle identity `1 - cos(tx) = 2 sin(tx/2)²` and
+    `sin u = sinc u · u`. Since `sinc` is continuous with `sinc 0 = 1`, the
+    right-hand side tends to `x²/2`. This is the spherical analogue of
+    `tendsto_cosh_mul_sub_one_div_sq`. -/
+theorem tendsto_one_sub_cos_mul_div_sq (x : ℝ) :
+    Tendsto (fun t : ℝ => (1 - Real.cos (t * x)) / t ^ 2) (𝓝[Ioi 0] 0) (𝓝 (x ^ 2 / 2)) := by
+  -- Exact identity on (0,∞): (1-cos(tx))/t² = (x²/2)·sinc(tx/2)²
+  have heq : ∀ t : ℝ, t ∈ Ioi (0:ℝ) →
+      (1 - Real.cos (t * x)) / t ^ 2 = x ^ 2 / 2 * Real.sinc (t * x / 2) ^ 2 := by
+    intro t ht
+    have ht2 : t ^ 2 ≠ 0 := ne_of_gt (sq_pos_of_pos ht)
+    -- half-angle: 1 - cos(tx) = 2·sin(tx/2)²
+    have hcos2 := Real.cos_two_mul (t * x / 2)
+    rw [show (2:ℝ) * (t * x / 2) = t * x by ring] at hcos2
+    have hpyth := Real.sin_sq_add_cos_sq (t * x / 2)
+    have half : 1 - Real.cos (t * x) = 2 * Real.sin (t * x / 2) ^ 2 := by linarith
+    rw [half, sin_eq_sinc_mul (t * x / 2), div_eq_iff ht2]; ring
+  -- t·x/2 → 0, hence sinc(t·x/2) → sinc 0 = 1
+  have htto : Tendsto (fun t : ℝ => t * x / 2) (𝓝[Ioi 0] 0) (𝓝 0) := by
+    have h0 : Tendsto (fun t : ℝ => t * x / 2) (𝓝 0) (𝓝 (0 * x / 2)) :=
+      ((continuous_id.mul continuous_const).div_const 2).continuousAt.tendsto
+    simp only [zero_mul, zero_div] at h0
+    exact h0.mono_left nhdsWithin_le_nhds
+  have hsinc : Tendsto (fun t : ℝ => Real.sinc (t * x / 2)) (𝓝[Ioi 0] 0) (𝓝 1) := by
+    have hc : Tendsto Real.sinc (𝓝 (0:ℝ)) (𝓝 (Real.sinc 0)) := Real.continuous_sinc.continuousAt
+    rw [Real.sinc_zero] at hc
+    exact hc.comp htto
+  rw [show x ^ 2 / 2 = x ^ 2 / 2 * 1 ^ 2 by ring]
+  apply Tendsto.congr'
+  · exact eventually_nhdsWithin_of_forall fun t ht => (heq t ht).symm
+  · exact (hsinc.pow 2).const_mul (x ^ 2 / 2)
+
+/-- cos(tx) → 1 as t → 0⁺ (continuity). -/
+theorem tendsto_cos_mul_one (x : ℝ) :
+    Tendsto (fun t : ℝ => Real.cos (t * x)) (𝓝[Ioi 0] 0) (𝓝 1) := by
+  have : Tendsto (fun t : ℝ => Real.cos (t * x)) (𝓝 0) (𝓝 (Real.cos (0 * x))) :=
+    Real.continuous_cos.continuousAt.comp (continuous_id.mul continuous_const).continuousAt
+  simp only [zero_mul, Real.cos_zero] at this
+  exact this.mono_left nhdsWithin_le_nhds
+
+/-- The spherical product limit: `(1 - cos(ta)·cos(tb))/t² → (a²+b²)/2` as `t → 0⁺`.
+    Uses the decomposition
+      `(1 - cos(ta)·cos(tb))/t² = (1-cos(ta))/t²·cos(tb) + (1-cos(tb))/t²`. -/
+theorem tendsto_one_sub_cos_prod_div_sq (a b : ℝ) :
+    Tendsto (fun t : ℝ => (1 - Real.cos (t * a) * Real.cos (t * b)) / t ^ 2)
+    (𝓝[Ioi 0] 0) (𝓝 ((a ^ 2 + b ^ 2) / 2)) := by
+  have heq : ∀ t : ℝ, t ∈ Ioi (0:ℝ) →
+      (1 - Real.cos (t * a) * Real.cos (t * b)) / t ^ 2 =
+      (1 - Real.cos (t * a)) / t ^ 2 * Real.cos (t * b) + (1 - Real.cos (t * b)) / t ^ 2 := by
+    intro t ht
+    have htne : t ≠ 0 := ne_of_gt ht
+    field_simp; ring
+  rw [show (a ^ 2 + b ^ 2) / 2 = a ^ 2 / 2 * 1 + b ^ 2 / 2 by ring]
+  apply Tendsto.congr'
+  · exact eventually_nhdsWithin_of_forall fun t ht => (heq t ht).symm
+  · exact ((tendsto_one_sub_cos_mul_div_sq a).mul (tendsto_cos_mul_one b)).add
+      (tendsto_one_sub_cos_mul_div_sq b)
+
+/-- **Spherical Flat Limit**: If cos(t·c) = cos(t·a)·cos(t·b) for all t > 0,
     then c² = a² + b².
 
     The spherical Pythagorean theorem (positive curvature) also reduces to the Euclidean
-    theorem as curvature → 0.
-
-    Note: Requires 0 ≤ a, b, c ≤ π (to ensure cos is injective in the relevant range).
-    For the flat limit, we only need the second-order behavior. -/
+    theorem as curvature → 0. No range restriction on a, b, c is needed: the flat limit
+    extracts the second-order (t → 0⁺) behaviour, where the spherical law of cosines
+    `cos c = cos a · cos b` linearizes to `c² = a² + b²`. This mirrors `hyperbolic_flat_limit`. -/
 theorem spherical_flat_limit {a b c : ℝ}
     (h : ∀ t : ℝ, 0 < t → Real.cos (t * c) = Real.cos (t * a) * Real.cos (t * b)) :
     c ^ 2 = a ^ 2 + b ^ 2 := by
-  -- The analog of the cosh bound: (1-cos(tx))/t² → x²/2
-  -- Lower bound: 1-cos(x) ≥ x²/2 - x⁴/24 (from Taylor), but we use:
-  --   1 - cos(x) = 2·sin²(x/2) ≥ 2·(x/2)² (from |sin θ| ≥ |θ| - |θ|³/6 for small θ)
-  -- Upper bound: 1 - cos(x) ≤ x²/2 (from cos(x) ≥ 1 - x²/2)
-  -- This gives the squeeze (1-cos(tx))/t² → x²/2
-  -- We use this analogously to the hyperbolic case.
-  --
-  -- The full proof follows the same pattern but requires proving:
-  --   tendsto_cos_mul_one_sub_div_sq: (1-cos(tx))/t² → x²/2
-  -- via squeeze with 1-cos(x) ≤ x²/2 (from cos(x) ≥ 1-x²/2).
-  --
-  -- For the lower bound we use: 1-cos(x) ≥ x²/2-x⁴/24, which for small x is ≥ x²/3.
-  -- HOWEVER: the squeeze still works since upper bound x²·1/2 → x²/2
-  -- and lower bound x²/2 is constant.
-  -- The key: cos(x) ≤ 1 - x²/2 + x⁴/24 gives upper, cos(x) ≥ 1 - x²/2 gives lower.
-  -- With 1-cos(x) ≥ x²/2 - x⁴/24 and for small t, this gives the squeeze.
-  -- ADMITTED: This parallel proof follows identically to the hyperbolic case,
-  -- using cos inequalities (1-cos(x) ≤ x²/2 and 2(1-cos(x)) ≤ x²) instead of cosh.
-  sorry
+  have hlhs : Tendsto (fun t : ℝ => (1 - Real.cos (t * c)) / t ^ 2)
+      (𝓝[Ioi 0] 0) (𝓝 (c ^ 2 / 2)) :=
+    tendsto_one_sub_cos_mul_div_sq c
+  have hrhs : Tendsto (fun t : ℝ => (1 - Real.cos (t * a) * Real.cos (t * b)) / t ^ 2)
+      (𝓝[Ioi 0] 0) (𝓝 ((a ^ 2 + b ^ 2) / 2)) :=
+    tendsto_one_sub_cos_prod_div_sq a b
+  -- On (0,∞), the two functions agree (from hypothesis h)
+  have hagree : ∀ᶠ t in 𝓝[Ioi 0] 0,
+      (1 - Real.cos (t * c)) / t ^ 2 =
+      (1 - Real.cos (t * a) * Real.cos (t * b)) / t ^ 2 :=
+    eventually_nhdsWithin_of_forall fun t ht => by rw [h t ht]
+  -- By uniqueness of limits: c²/2 = (a²+b²)/2
+  have : c ^ 2 / 2 = (a ^ 2 + b ^ 2) / 2 :=
+    tendsto_nhds_unique (hlhs.congr' hagree) hrhs
+  linarith
 
 end PythagoreanFlatLimit

--- a/research/problems/erdos-307-oq-02-oq-01/knowledge.md
+++ b/research/problems/erdos-307-oq-02-oq-01/knowledge.md
@@ -1,0 +1,51 @@
+# erdos-307-oq-02-oq-01 — Prove prime_sets_disjoint via p-adic valuation
+
+**Status:** COMPLETED (0 sorries, 0 axioms — verified via `lake env lean`, Docker down)
+
+## Problem
+
+Discharge the `prime_sets_disjoint` sorry documented in `Erdos307OQ02.lean`:
+if `P, Q` are finite sets of primes with `(Σ_{p∈P} 1/p)(Σ_{q∈Q} 1/q) = 1`,
+then `P ∩ Q = ∅`. Parent flagged it as "requires Mathlib's p-adic valuation theory".
+
+## Session 2026-06-27 (Session 1) — COMPLETED
+
+**Mode:** FRESH
+**Outcome:** completed (theorem fully proved, axiom-free)
+
+### What I Did
+- Recognized the p-adic content `v_{p₀}(Σ 1/p) = -1` can be captured elementarily
+  without `padicValRat`, as a single reduction mod `p₀` in the field `𝔽_{p₀}`.
+- Wrote `proofs/Proofs/Erdos307OQ02OQ01.lean` (171 lines, 5 defs, 4 lemmas/theorems):
+  - `reciprocalSum_mul_denom`: `(Σ 1/p)·(∏ p) = Σ_p ∏_{q≠p} q` over ℚ (via `Finset.mul_prod_erase`, `inv_mul_cancel_left₀`).
+  - `primeNumer_mul_eq`: clears denominators in the product-1 hypothesis to the
+    INTEGER identity `NP·NQ = DP·DQ` (cast down via `exact_mod_cast`).
+  - `prime_not_dvd_primeNumer`: the p-adic core — `p₀ ∤ NP` for prime `p₀ ∈ P`,
+    by reducing `NP` in `ZMod p₀`: non-`p₀` summands carry the factor `p₀` and
+    vanish (`Finset.prod_eq_zero` + `ZMod.natCast_self`); survivor `∏_{q≠p₀} q`
+    is a product of units (`Finset.prod_ne_zero_iff` + `ZMod.natCast_eq_zero_iff`
+    + `Nat.prime_dvd_prime_iff_eq`).
+  - `prime_sets_disjoint`: a shared prime `p₀` divides `DP·DQ` but neither `NP`
+    nor `NQ`, contradicting `NP·NQ = DP·DQ`.
+- Registered in `proofs/Proofs.lean`; added gallery entry `src/data/proofs/erdos-307-oq-02-oq-01/`.
+
+### Key Findings
+- The valuation fact `v_{p₀}(Σ_{p∈P} 1/p) = -1` ⟺ "`p₀ ∤ NP`", a one-line modular reduction.
+- Clearing denominators turns the ℚ-hypothesis into a clean ℕ-identity, sidestepping
+  rational arithmetic entirely for the divisibility contradiction.
+- The argument needs no size/structure assumptions beyond primality — works for all finite prime sets.
+
+### Files Modified
+- `proofs/Proofs/Erdos307OQ02OQ01.lean` (new)
+- `proofs/Proofs.lean` (import)
+- `src/data/proofs/erdos-307-oq-02-oq-01/meta.json` (new)
+
+### Verification
+- Docker build blocked (containerd `meta.db` I/O error). Verified via main-repo
+  Mathlib `.olean` cache: `lake env lean` EXIT 0, no warnings.
+- `#print axioms prime_sets_disjoint` → `[propext, Classical.choice, Quot.sound]`
+  (no `sorryAx`, no `Lean.ofReduceBool`).
+
+### Next Steps
+- Remaining parent sorry `prime_set_size_lower_bound` (|P ∪ Q| ≥ 60) needs a
+  verified Mertens-type bound on `Σ_{p≤281} 1/p ≈ 2.009` — independent of this work.

--- a/research/problems/pythagorean-theorem-oq-01/knowledge.md
+++ b/research/problems/pythagorean-theorem-oq-01/knowledge.md
@@ -19,3 +19,35 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-06-27 (researcher-7) — Family follow-up: spherical flat limit + drift repair
+
+**Mode**: FRESH (claimed oq-01) · **Outcome**: progress (closed a real sorry; repaired build)
+
+### What I Did
+- Confirmed the claimed problem (base 2-D Pythagorean theorem, `PythagoreanTheorem.lean`) is fully SOLVED (8 thms, 0 sorry, 0 axioms): `pythagorean_theorem`, converse, `pythagorean_sum`, integer triples.
+- Found the only open sorry in the family in `PythagoreanTheoremOQ05.lean` (`spherical_flat_limit`) and closed it.
+- Discovered the file no longer built against the current Mathlib cache (pervasive drift) and repaired the whole file.
+
+### Key Findings
+- **Spherical flat limit** (`cos(tc)=cos(ta)cos(tb) ∀t>0 ⟹ c²=a²+b²`) proved via the *exact* identity
+  `(1-cos(tx))/t² = (x²/2)·sinc(tx/2)²` (half-angle `1-cos u = 2 sin(u/2)²` + `sin u = sinc u · u`),
+  then `Real.sinc` continuity (`sinc 0 = 1`). Cleaner than the hyperbolic squeeze — no derivative machinery.
+- No `0 ≤ a,b,c ≤ π` restriction is needed (the old docstring caveat was removed).
+- **Mathlib drift fixed**: `le_div_iff→le_div_iff₀`, `div_le_div_iff→div_le_div_iff₀`,
+  `Filter.eventually_nhdsWithin_of_forall→eventually_nhdsWithin_of_forall`, `Tendsto.congr'` arg order
+  (eventuallyEq first), pointwise squeeze → eventually squeeze `…_le_of_le'`, `HasDerivAt.sub` of a
+  constant now yields `… - 0` (needs `simpa`), bare `simp` no longer closes let-bound `f 0 = 0` (needs `show`),
+  `open scoped Topology` required for `𝓝`.
+
+### Files Modified
+- `proofs/Proofs/PythagoreanTheoremOQ05.lean` — spherical case complete; whole file builds (0 sorry, 0 axioms).
+
+### Verification
+- `lake env lean` (Lean 4.26.0) against main-repo Mathlib cache: EXIT 0, no errors/warnings, 0 sorries. Docker build unavailable (containerd meta.db I/O error).
+
+### Next Steps
+- Optionally add a gallery entry for the now-complete `PythagoreanTheoremOQ05`.
+- Audit sibling pythagorean files for the same drift.

--- a/src/data/proofs/erdos-307-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-307-oq-02-oq-01/meta.json
@@ -1,0 +1,117 @@
+{
+  "id": "erdos-307-oq-02-oq-01",
+  "title": "Prime Reciprocal Products: Disjointness of Solution Sets",
+  "slug": "erdos-307-oq-02-oq-01",
+  "description": "Discharges the prime_sets_disjoint sorry from Erdős 307 OQ-02: if P, Q are finite sets of primes with (Σ 1/p)(Σ 1/q) = 1 then P ∩ Q = ∅. The documented p-adic valuation argument is captured elementarily via a single mod-p₀ reduction in 𝔽_{p₀}.",
+  "meta": {
+    "author": "Research (prime_sets_disjoint for Erdős 307)",
+    "sourceUrl": "https://erdosproblems.com/307",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos307OQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "p-adic",
+      "egyptian-fractions",
+      "erdos",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 171,
+    "assumptions": "0 sorries, 0 axioms (depends only on propext, Classical.choice, Quot.sound). Fully verified.",
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "prime_sets_disjoint proved (was a documented sorry in OQ-02)",
+      "Integer numerator/denominator identity for prime-reciprocal sums (reciprocalSum_mul_denom)",
+      "Cleared-denominator integer identity NP·NQ = DP·DQ from the product-1 hypothesis (primeNumer_mul_eq)",
+      "Elementary p-adic core: p₀ ∤ NP via mod-p₀ reduction in 𝔽_{p₀} (prime_not_dvd_primeNumer)"
+    ],
+    "theoremCount": 4,
+    "definitionCount": 5
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #307 asks whether two finite sets of primes $P, Q$ can satisfy $(\\sum_{p \\in P} 1/p)(\\sum_{q \\in Q} 1/q) = 1$. A natural structural constraint on any hypothetical solution is that $P$ and $Q$ must be disjoint: a shared prime would appear with reciprocal in both factors and break the rationality budget. The parent OQ-02 file documented this as `prime_sets_disjoint` but left it as a sorry, citing a need for 'Mathlib's p-adic valuation theory'.\n\nThis file discharges that sorry with a fully elementary, axiom-free proof. The key realization is that the entire p-adic content — namely $v_{p_0}(\\sum_{p \\in P} 1/p) = -1$ for each prime $p_0 \\in P$ — can be expressed without any `padicValRat` machinery, as a single reduction modulo $p_0$ in the finite field $\\mathbb{F}_{p_0}$.",
+    "problemStatement": "If P and Q are finite sets of primes with (Σ_{p∈P} 1/p)(Σ_{q∈Q} 1/q) = 1, then P ∩ Q = ∅.",
+    "text": "Writes each reciprocal sum as a fraction NP/DP with DP = ∏ p the squarefree denominator and NP = Σ_p ∏_{q≠p} q the numerator. The product-equals-1 hypothesis clears denominators to the integer identity NP·NQ = DP·DQ. A shared prime p₀ divides DP·DQ twice but divides neither numerator, a contradiction.",
+    "proofStrategy": "Clear denominators to get the integer identity NP·NQ = DP·DQ. Then show p₀ ∤ NP for any prime p₀ ∈ P by reducing NP modulo p₀ in 𝔽_{p₀}: every summand except the p=p₀ term contains the factor p₀ and vanishes, while the surviving term ∏_{q≠p₀} q is a product of units. If p₀ ∈ P ∩ Q then p₀ divides neither NP nor NQ, hence not NP·NQ — but p₀ divides both DP and DQ, hence DP·DQ = NP·NQ. Contradiction.",
+    "keyInsights": [
+      "The p-adic valuation v_{p₀}(Σ_{p∈P} 1/p) = -1 is captured elementarily as 'p₀ ∤ NP' — no padicValRat needed",
+      "Writing Σ_{p∈P} 1/p = NP/DP with DP = ∏_{p∈P} p (squarefree) and NP = Σ_p ∏_{q≠p} q clears denominators cleanly",
+      "The product-equals-1 hypothesis over ℚ casts down to the integer identity NP·NQ = DP·DQ via Nat.cast injectivity",
+      "Reducing NP modulo p₀ in the field 𝔽_{p₀} kills every summand except the p=p₀ term; that survivor ∏_{q≠p₀} q is a product of nonzero units, so p₀ ∤ NP",
+      "A shared prime p₀ ∈ P ∩ Q divides DP·DQ (twice) but neither numerator, so it cannot divide the equal product NP·NQ — the contradiction",
+      "The argument needs no special structure beyond the elements being prime: it works for any finite prime sets, independent of the size bound"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup",
+      "summary": "Defines reciprocalSum, reciprocalProduct, IsSetOfPrimes (mirroring the parent), plus the integer numerator primeNumer = Σ_p ∏_{q≠p} q and denominator primeDenom = ∏ p.",
+      "startLine": 36,
+      "endLine": 58,
+      "mathContext": "For a finite prime set $P$, $\\sum_{p \\in P} 1/p = N_P / D_P$ where $D_P = \\prod_{p \\in P} p$ is squarefree and $N_P = \\sum_{p \\in P} \\prod_{q \\in P \\setminus \\{p\\}} q$. These are exactly the numerator and denominator one obtains by placing the reciprocal sum over a common denominator."
+    },
+    {
+      "id": "identity",
+      "title": "Numerator/Denominator Identity",
+      "summary": "Proves reciprocalSum_mul_denom: (Σ 1/p)·(∏ p) = Σ_p ∏_{q≠p} q over ℚ, then primeNumer_mul_eq: clearing denominators in the product-1 hypothesis yields the integer identity NP·NQ = DP·DQ.",
+      "startLine": 60,
+      "endLine": 92,
+      "mathContext": "Multiplying $\\sum_{p \\in P} 1/p$ by $D_P = \\prod_{p \\in P} p$ and using $\\frac{1}{p}\\prod_{q \\in P} q = \\prod_{q \\neq p} q$ (via Finset.mul_prod_erase) gives $N_P$. Applying this to both factors of $(\\Sigma_{1/P})(\\Sigma_{1/Q}) = 1$ and multiplying through by $D_P D_Q$ produces $N_P N_Q = D_P D_Q$ over $\\mathbb{Q}$; Nat.cast injectivity transports it to $\\mathbb{N}$."
+    },
+    {
+      "id": "padic-core",
+      "title": "The p-adic Core: p₀ ∤ Numerator",
+      "summary": "Proves prime_not_dvd_primeNumer: for a prime p₀ ∈ P, p₀ does not divide NP. This is the elementary form of v_{p₀}(Σ 1/p) = -1, proved by reduction modulo p₀ in 𝔽_{p₀}.",
+      "startLine": 94,
+      "endLine": 127,
+      "mathContext": "Reduce $N_P = \\sum_{p} \\prod_{q \\neq p} q$ in $\\mathbb{F}_{p_0}$. Every summand with $p \\neq p_0$ contains the factor $p_0$ (since $p_0 \\in P \\setminus \\{p\\}$) and so vanishes. The surviving $p = p_0$ summand is $\\prod_{q \\in P \\setminus \\{p_0\\}} q$, a product of primes all distinct from $p_0$, hence a product of nonzero elements of the field $\\mathbb{F}_{p_0}$ — nonzero. Therefore $\\bar{N_P} \\neq 0$, i.e. $p_0 \\nmid N_P$."
+    },
+    {
+      "id": "main",
+      "title": "Disjointness",
+      "summary": "Proves prime_sets_disjoint: P ∩ Q = ∅. A shared prime p₀ would divide DP·DQ but neither NP nor NQ, contradicting NP·NQ = DP·DQ.",
+      "startLine": 129,
+      "endLine": 157,
+      "mathContext": "Suppose $p_0 \\in P \\cap Q$. By the core lemma $p_0 \\nmid N_P$ and $p_0 \\nmid N_Q$, so $p_0 \\nmid N_P N_Q$ (as $p_0$ is prime). But $p_0 \\mid D_P$ (since $p_0 \\in P$) and $p_0 \\mid D_Q$, so $p_0 \\mid D_P D_Q = N_P N_Q$. Contradiction, so $P \\cap Q = \\emptyset$."
+    }
+  ],
+  "conclusion": {
+    "summary": "prime_sets_disjoint is fully proved, axiom-free. The p-adic valuation argument the parent file flagged as needing 'Mathlib's p-adic theory' reduces to a single mod-p₀ computation in a finite field.",
+    "openQuestions": [
+      "Prove the remaining parent sorry prime_set_size_lower_bound (|P ∪ Q| ≥ 60) via a verified Mertens-type bound on Σ_{p≤281} 1/p",
+      "Does disjointness combined with the size bound rule out all small prime solutions, narrowing the search for Erdős 307?"
+    ],
+    "implications": "Discharges item (1) of the parent's 'Remaining Sorries'. It demonstrates a recurring pattern: results posed as requiring heavy p-adic valuation machinery often have elementary finite-field formulations. The valuation fact v_{p₀}(Σ 1/p) = -1 becomes a one-line modular reduction, keeping the proof axiom-free and self-contained."
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-307-oq-02",
+      "relationship": "parent-problem",
+      "description": "Parent: discharges the prime_sets_disjoint sorry documented in OQ-02"
+    },
+    {
+      "targetId": "erdos-307",
+      "relationship": "ancestor-problem",
+      "description": "Root: Erdős Problem #307 on prime reciprocal products"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos307OQ02OQ01",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 5,
+    "path": "Proofs/Erdos307OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-307-oq-02-oq-01.json
+++ b/src/data/research/problems/erdos-307-oq-02-oq-01.json
@@ -1,0 +1,47 @@
+{
+  "id": "erdos-307-oq-02-oq-01",
+  "name": "Erdős 307: prove prime_sets_disjoint via p-adic valuation",
+  "parentId": "erdos-307-oq-02",
+  "status": "completed",
+  "knowledge": {
+    "score": 7,
+    "insights": [
+      "The p-adic fact v_{p₀}(Σ_{p∈P} 1/p) = -1 is equivalent to 'p₀ ∤ NP' where NP = Σ_p ∏_{q≠p} q — no padicValRat needed",
+      "Writing Σ_{p∈P} 1/p = NP/DP with DP = ∏ p (squarefree) and NP = Σ_p ∏_{q≠p} q clears denominators cleanly",
+      "(Σ1/P)(Σ1/Q) = 1 over ℚ casts down to the integer identity NP·NQ = DP·DQ via Nat.cast injectivity",
+      "Reducing NP mod p₀ in the field 𝔽_{p₀} kills every summand except p=p₀; the survivor ∏_{q≠p₀} q is a product of units, so p₀ ∤ NP",
+      "A shared prime p₀ ∈ P∩Q divides DP·DQ but neither numerator, contradicting NP·NQ = DP·DQ",
+      "The disjointness argument needs no size/structure beyond primality — works for all finite prime sets"
+    ],
+    "builtItems": [
+      "reciprocalSum_mul_denom: (Σ 1/p)·(∏ p) = Σ_p ∏_{q≠p} q over ℚ",
+      "primeNumer_mul_eq: integer identity NP·NQ = DP·DQ from the product-1 hypothesis",
+      "prime_not_dvd_primeNumer: p₀ ∤ NP via mod-p₀ reduction in ZMod p₀ (the p-adic core)",
+      "prime_sets_disjoint: P ∩ Q = ∅ — the parent's documented sorry, now fully proved (0 axioms)"
+    ],
+    "progressSummary": "COMPLETE: prime_sets_disjoint proved axiom-free (depends only on propext/Classical.choice/Quot.sound). Discharges item 1 of Erdos307OQ02 remaining sorries. Verified via lake env lean (Docker down).",
+    "nextSteps": [
+      "Remaining parent sorry prime_set_size_lower_bound (|P∪Q|≥60) needs a verified Mertens-type bound on Σ_{p≤281} 1/p ≈ 2.009",
+      "Combine disjointness with a size bound to constrain hypothetical Erdős 307 prime solutions"
+    ]
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos307OQ02OQ01.lean",
+      "filename": "Erdos307OQ02OQ01.lean",
+      "lineCount": 171,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos307OQ02OQ01.lean"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-307",
+    "erdos-307-oq-02",
+    "erdos-307-oq-02-oq-01"
+  ],
+  "lastUpdate": "2026-06-27T20:30:00.000Z"
+}

--- a/src/data/research/problems/pythagorean-theorem-oq-01.json
+++ b/src/data/research/problems/pythagorean-theorem-oq-01.json
@@ -39,11 +39,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "COMPLETE: base 2-D Pythagorean theorem solved (PythagoreanTheorem.lean, 0 sorry). As family follow-up, closed the only open sorry in the flat-limit file (PythagoreanTheoremOQ05.lean spherical_flat_limit) and repaired pervasive Mathlib-cache drift across that file.",
+    "builtItems": [
+      "sin_eq_sinc_mul, tendsto_one_sub_cos_mul_div_sq, tendsto_cos_mul_one, tendsto_one_sub_cos_prod_div_sq, spherical_flat_limit in Proofs/PythagoreanTheoremOQ05.lean (0 sorry, 0 axioms, verified via lake env lean 4.26.0)"
+    ],
+    "insights": [
+      "Spherical flat limit: from cos(tc)=cos(ta)cos(tb) ∀t>0, c²=a²+b² follows by the exact identity (1-cos(tx))/t² = (x²/2)·sinc(tx/2)², using half-angle 1-cos(tx)=2sin(tx/2)² and sin u = sinc u · u; sinc continuity (sinc 0 = 1) gives the limit. No range restriction on a,b,c needed.",
+      "This sinc-identity route is cleaner than the hyperbolic squeeze: it avoids all monotonicity/second-derivative machinery and reduces the limit to continuity of Real.sinc at 0."
+    ],
+    "mathlibGaps": [
+      "Mathlib cache drift broke the existing hyperbolic section: le_div_iff→le_div_iff₀, div_le_div_iff→div_le_div_iff₀, Filter.eventually_nhdsWithin_of_forall→eventually_nhdsWithin_of_forall, Tendsto.congr! argument order (eventuallyEq first), pointwise squeeze tendsto_of_tendsto_of_tendsto_of_le_of_le→eventually variant (prime), HasDerivAt.sub of a const now yields x-0 (needs simpa/convert), and let-bound f 0 = 0 no longer closes by bare simp (needs show)."
+    ],
+    "nextSteps": [
+      "Optionally create a gallery entry (src/data/proofs/pythagorean-theorem-oq-05) for the now-complete flat-limit file.",
+      "Audit sibling pythagorean files (OQ03 etc.) for the same Mathlib drift."
+    ],
     "markdown": "# Knowledge Base: pythagorean-theorem-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -63,7 +73,7 @@
     "mathlib": []
   },
   "started": "2026-04-06T06:37:41.264Z",
-  "lastUpdate": "2026-04-12T21:07:23.998Z",
+  "lastUpdate": "2026-06-27T13:30:00.000Z",
   "significance": 7,
   "tractability": 7,
   "leanFiles": [
@@ -107,7 +117,7 @@
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTheoremOQ05.lean"
     }


### PR DESCRIPTION
## Summary

The claimed problem **pythagorean-theorem-oq-01** (base 2-D Pythagorean theorem) is already fully solved (`PythagoreanTheorem.lean`, 8 theorems, 0 sorry, 0 axioms). As a family follow-up this PR:

1. **Closes the only open sorry in the family** — `spherical_flat_limit` in `PythagoreanTheoremOQ05.lean`.
2. **Repairs pervasive Mathlib-cache drift** that had silently broken the *entire* file against the current Mathlib.

## Spherical flat limit

`cos(t·c) = cos(t·a)·cos(t·b)  ∀ t>0  ⟹  c² = a² + b²`

Proved via the **exact** algebraic identity (for `t ≠ 0`)

```
(1 - cos(t·x)) / t²  =  (x²/2) · sinc(t·x/2)²
```

from the half-angle identity `1 - cos u = 2 sin(u/2)²` and `sin u = sinc u · u`, then continuity of `Real.sinc` at 0 (`sinc 0 = 1`). This is cleaner than the existing hyperbolic squeeze — it needs no monotonicity / second-derivative machinery. No range restriction on `a, b, c` is required (the old `0 ≤ a,b,c ≤ π` caveat was removed).

New lemmas: `sin_eq_sinc_mul`, `tendsto_one_sub_cos_mul_div_sq`, `tendsto_cos_mul_one`, `tendsto_one_sub_cos_prod_div_sq`, `spherical_flat_limit`.

## Mathlib drift repaired (whole file)

- `le_div_iff` → `le_div_iff₀`, `div_le_div_iff` → `div_le_div_iff₀`
- `Filter.eventually_nhdsWithin_of_forall` → `eventually_nhdsWithin_of_forall`
- `Tendsto.congr'` argument order (eventuallyEq first)
- pointwise squeeze `tendsto_of_tendsto_of_tendsto_of_le_of_le` → eventually variant `…_le_of_le'`
- `HasDerivAt.sub` of a constant now yields `… - 0` (closed via `simpa`)
- let-bound `f 0 = 0` no longer closes by bare `simp` (uses `show`)
- `open scoped Topology` now required for `𝓝`

## Verification

`lake env lean` (Lean 4.26.0) against the main-repo Mathlib cache: **EXIT 0, no errors, no warnings, 0 sorries, 0 axiom declarations** (no `native_decide`). Docker build was unavailable (containerd `meta.db` I/O error), so per-file verification was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)