### PR TITLE
research(sperner-mathlib4-oq-02): abstract door-counting parity engine [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerDoorCountingParity.lean
+++ b/proofs/Proofs/SpernerDoorCountingParity.lean
@@ -1,0 +1,149 @@
+/-
+# Sperner / Tucker OQ-02: The Abstract Door-Counting Parity Engine
+
+## Context
+
+The parent problem ("Tucker's Lemma and Borsuk–Ulam from Abstract Door-Counting")
+shipped the `n = 1` milestone (`SpernerTuckerOneDim.lean`): a telescoping ℤ/2
+identity producing a complementary edge on an antipodally-labelled path. The open
+frontier is `n ≥ 2`, where the complementary-edge count is *no longer* a direct
+parity invariant, so the 1-D telescoping argument does not lift.
+
+This file isolates the part of the machinery that **does** lift to every
+dimension: the *abstract door-counting parity engine*. In every flavour of
+combinatorial fixed-point theorem (Sperner, Tucker, Scarf), one builds a "door
+graph" whose vertices are cells and whose edges join cells sharing a marked facet
+("door"). A cell is a *door-terminal* (a place a path can end) exactly when it has
+odd door-degree, and the path-following argument is powered entirely by one fact:
+
+  **the number of odd-degree vertices of a finite graph is even** (handshake).
+
+Hence a *known* boundary terminal forces a *second*, distinct terminal — the
+sought solution. This file states that engine cleanly over an arbitrary finite
+`SimpleGraph`, specializes it to degree-≤2 "path/cycle" graphs (where door-terminal
+⇔ degree 1, the literal endpoints of paths), and packages the boundary/interior
+door-counting conclusion. Everything is **0 axioms, 0 sorries**.
+
+## What lifts and what does not
+
+- **Lifts (here):** the handshake parity engine and the "odd boundary ⇒ interior
+  door" pigeonhole. Dimension-independent.
+- **Does not lift (the `n ≥ 2` obstruction):** the labelling that makes the door
+  graph have all degrees ≤ 2 *and* makes boundary doors odd in count. At `n ≥ 2`
+  one needs Freund–Todd / Prescott–Su path-following on almost-complementary
+  simplices, not a single global parity count.
+
+## References
+
+- Mathlib, `Mathlib.Combinatorics.SimpleGraph.DegreeSum` (handshake lemma).
+- Freund & Todd, "A constructive proof of Tucker's combinatorial lemma" (1981).
+- Prescott & Su, "A constructive proof of Ky Fan's combinatorial lemma" (2005).
+-/
+import Mathlib
+
+namespace SpernerDoorCountingParity
+
+open Finset SimpleGraph
+
+variable {V : Type*} [Fintype V]
+variable (G : SimpleGraph V) [DecidableRel G.Adj]
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART I: THE ABSTRACT DOOR-COUNTING ENGINE (any degree)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- A *door-terminal* of the door graph: a cell with an odd number of doors. These
+are the only cells at which a path-following argument can terminate. -/
+def IsDoorTerminal (v : V) : Prop := Odd (G.degree v)
+
+instance : DecidablePred (IsDoorTerminal G) := fun v => by
+  unfold IsDoorTerminal; infer_instance
+
+/-- **The door-counting parity engine.** The number of door-terminals is even.
+This is precisely the handshake lemma, and it is the dimension-independent heart
+of every Sperner/Tucker/Scarf path-following argument. -/
+theorem even_card_doorTerminals :
+    Even (univ.filter (IsDoorTerminal G)).card :=
+  G.even_card_odd_degree_vertices
+
+/-- **A known door forces a second door.** If one cell is a door-terminal, there is
+another distinct one. In the geometric setting the first is a boundary door placed
+by hand; the second is the interior solution. -/
+theorem doorTerminal_forces_another {v : V} (hv : IsDoorTerminal G v) :
+    ∃ w, w ≠ v ∧ IsDoorTerminal G w :=
+  G.exists_ne_odd_degree_of_exists_odd_degree v hv
+
+/-- **Boundary/interior door counting.** If the door-terminals lying on a designated
+boundary set `B` are odd in number, then there is a door-terminal off `B` — the
+interior solution the constructive argument seeks. -/
+theorem exists_interior_doorTerminal [DecidableEq V] (B : Finset V)
+    (hB : Odd ((univ.filter (IsDoorTerminal G)) ∩ B).card) :
+    ∃ w, IsDoorTerminal G w ∧ w ∉ B := by
+  set D := univ.filter (IsDoorTerminal G) with hD
+  have hsplit : (D ∩ B).card + (D \ B).card = D.card := card_inter_add_card_sdiff D B
+  have hEven : Even D.card := even_card_doorTerminals G
+  -- total even, boundary part odd ⇒ interior part odd ⇒ nonempty
+  have hOddSdiff : Odd (D \ B).card := by
+    rcases hEven with ⟨k, hk⟩
+    rcases hB with ⟨j, hj⟩
+    refine ⟨k - j - 1, ?_⟩
+    omega
+  have hne : (D \ B).Nonempty := by
+    rw [← Finset.card_pos]; rcases hOddSdiff with ⟨t, ht⟩; omega
+  obtain ⟨w, hw⟩ := hne
+  rw [Finset.mem_sdiff, hD, Finset.mem_filter] at hw
+  exact ⟨w, hw.1.2, hw.2⟩
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART II: PATH/CYCLE SPECIALIZATION (degree ≤ 2)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-! When the door graph has maximum degree `2` — the situation engineered by
+path-following on almost-complementary simplices — door-terminals are exactly the
+degree-`1` cells, i.e. the literal endpoints of the disjoint paths. -/
+
+/-- Under degree `≤ 2`, a cell is a door-terminal iff its door-degree is exactly 1. -/
+theorem doorTerminal_iff_degree_one {v : V} (hdeg : G.degree v ≤ 2) :
+    IsDoorTerminal G v ↔ G.degree v = 1 := by
+  unfold IsDoorTerminal
+  rw [Nat.odd_iff]
+  omega
+
+/-- In a degree-`≤2` door graph the number of path endpoints (degree-1 cells) is
+even — paths pair up their two ends. -/
+theorem even_card_pathEnds (hG : ∀ v, G.degree v ≤ 2) :
+    Even (univ.filter (fun v => G.degree v = 1)).card := by
+  have h := even_card_doorTerminals G
+  rwa [Finset.filter_congr (fun v _ => doorTerminal_iff_degree_one G (hG v))] at h
+
+/-- A known path endpoint forces a second, distinct one. -/
+theorem pathEnd_forces_pathEnd (hG : ∀ v, G.degree v ≤ 2) {v : V}
+    (hv : G.degree v = 1) : ∃ w, w ≠ v ∧ G.degree w = 1 := by
+  obtain ⟨w, hwv, hw⟩ :=
+    doorTerminal_forces_another G ((doorTerminal_iff_degree_one G (hG v)).mpr hv)
+  exact ⟨w, hwv, (doorTerminal_iff_degree_one G (hG w)).mp hw⟩
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+SUMMARY
+═══════════════════════════════════════════════════════════════════════════════
+
+**Verified (0 axioms, 0 sorries):**
+1. `even_card_doorTerminals` — the handshake parity engine: the number of
+   door-terminals (odd-degree cells) is even.
+2. `doorTerminal_forces_another` — a known door forces a distinct second door.
+3. `exists_interior_doorTerminal` — odd boundary door count ⇒ an interior door.
+4. Degree-`≤2` specialization: door-terminals ⇔ degree-1 endpoints, their count is
+   even, and one endpoint forces another (`pathEnd_forces_pathEnd`).
+
+This pins down the dimension-independent engine of door-counting; the `n ≥ 2`
+work that remains is the construction of the degree-`≤2` door graph with an odd
+boundary-door count (Freund–Todd / Prescott–Su path-following), not the parity
+principle itself.
+-/
+
+#check @even_card_doorTerminals
+#check @doorTerminal_forces_another
+#check @exists_interior_doorTerminal
+#check @pathEnd_forces_pathEnd
+
+end SpernerDoorCountingParity

--- a/src/data/research/problems/sperner-mathlib4-oq-02.json
+++ b/src/data/research/problems/sperner-mathlib4-oq-02.json
@@ -24,7 +24,8 @@
       "TuckerOneDim.tucker_one_dim — antipodal boundary ⟹ odd #complementary-edges",
       "TuckerOneDim.exists_complementary_edge — 1-D Tucker existence statement",
       "Proofs/SpernerTuckerHexagon.lean (114 LOC, 0 sorries, 0 axioms; decide/kernel only -- propext/Classical.choice/Quot.sound, NO ofReduceBool): tucker_hexagon, ring_complementary_count_even, tucker_hexagon_exists.",
-      "Proofs/SpernerTuckerBoundaryParity.lean (84 LOC, 0 sorries, 0 axioms; decide/kernel -- propext/Classical.choice/Quot.sound, NO ofReduceBool): ring_complementary_count_even, ring_complementary_count_not_odd, lneg_involutive."
+      "Proofs/SpernerTuckerBoundaryParity.lean (84 LOC, 0 sorries, 0 axioms; decide/kernel -- propext/Classical.choice/Quot.sound, NO ofReduceBool): ring_complementary_count_even, ring_complementary_count_not_odd, lneg_involutive.",
+      "proofs/Proofs/SpernerDoorCountingParity.lean (149 LOC, 6 thm, 0 sorry, 0 axiom): dimension-independent abstract door-counting parity engine (handshake ⇒ even door-terminals; a known door forces another; odd boundary door count ⇒ interior door; degree-≤2 path specialization). Separates the transferable engine from the n≥2-specific labelling obstruction."
     ],
     "insights": [
       "n=1 Tucker is provable directly as a discrete fundamental-theorem-of-calculus / sign-change-parity statement over ZMod 2 — cleaner than instantiating the abstract CellComplex (whose panchromatic conclusion genuinely diverges from the complementary-edge target, Insight 1).",


### PR DESCRIPTION
## Summary

Continues **sperner-mathlib4-oq-02** ("Tucker's Lemma and Borsuk–Ulam from Abstract Door-Counting") after the merged `n=1` milestone (#30907). This PR isolates the part of the path-following machinery that lifts to **every dimension**: the abstract door-counting parity engine, formalized over an arbitrary finite `SimpleGraph`.

**Status: `verified` — 0 axioms, 0 sorries** (`#print axioms` → `propext`/`Classical.choice`/`Quot.sound` only).

## What's proved (`proofs/Proofs/SpernerDoorCountingParity.lean`)

A "door graph" has cells as vertices and edges joining cells sharing a marked facet ("door"); a *door-terminal* is a cell of odd door-degree — the only place a path can end.

- **`even_card_doorTerminals`** — the handshake lemma: the number of door-terminals is even. The dimension-independent heart of all Sperner/Tucker/Scarf path-following.
- **`doorTerminal_forces_another`** — a known door-terminal forces a distinct second one.
- **`exists_interior_doorTerminal`** — if the door-terminals on a boundary set `B` are odd in number, there is an interior door-terminal (the constructive solution). Via `card_inter_add_card_sdiff` + parity.
- **Degree-≤2 specialization** (the path/cycle case engineered by path-following): `doorTerminal_iff_degree_one`, `even_card_pathEnds`, and `pathEnd_forces_pathEnd` (one endpoint forces another).

## Why this advances the problem

The merged `n=1` proof used a telescoping ℤ/2 identity that does **not** lift to `n ≥ 2` (the complementary-edge count stops being a global parity invariant). This PR cleanly separates the **transferable engine** (handshake parity, proved here for all dimensions) from the **`n ≥ 2`-specific obstruction**: constructing the degree-≤2 door graph with an odd boundary-door count, which requires Freund–Todd / Prescott–Su path-following on almost-complementary simplices. That construction is the documented next frontier.

## Metrics
- 6 theorems, 1 def, 149 lines, 0 axioms, 0 sorries.
- Verified with `lake env lean` against Mathlib 4.26.0 (Docker unavailable — containerd corruption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)