### PR TITLE
research(prob-method-applications-wip-01-oq-01): instantiate abstract ramsey_avoidance over K_n ⟹ R(k,k)>n [verified]

### DIFF
--- a/proofs/Proofs/ProbMethodApplicationsWIPOQ01.lean
+++ b/proofs/Proofs/ProbMethodApplicationsWIPOQ01.lean
@@ -1,0 +1,135 @@
+/-
+  Probabilistic Method Applications — WIP OQ-01
+
+  Open question (prob-method-applications-wip-01-oq-01):
+    "Instantiate `ramsey_avoidance` to `K_n`:
+       C(n,m)·2^(1-C(m,2)) < 1  ⟹  R(m,m) > n."
+
+  The companion file `ProbMethodApplicationsWIP.lean` proves the *abstract*
+  first-moment avoidance engine
+
+      ProbMethod.Core.ramsey_avoidance :
+        (cliques : Finset (Finset E)) (m : ℕ)
+        (∀ K ∈ cliques, K.card = m)
+        (cliques.card * 2^(|E| - m + 1) < 2^|E|)
+        ⟹ ∃ S : Finset E, ∀ K ∈ cliques, ¬ (K ⊆ S ∨ Disjoint K S),
+
+  over an arbitrary finite "edge" set `E`, where a block `K` is monochromatic
+  under the colouring `S` (= the set of `true`-coloured edges) exactly when
+  `K ⊆ S` (all `true`) or `Disjoint K S` (all `false`).  Its docstring *claims*
+  that instantiating `E` as the edge set of `K_n` recovers the Erdős (1947)
+  lower bound `R(m,m) > n`, but never carries out that instantiation.
+
+  This file supplies the missing bridge.  Taking
+    * `E := ` the edges of `K_n` (the 2-subsets of `Fin n`, from
+      `RamseyFirstMoment.Edges`), so `|E| = C(n,2)`;
+    * `blocks := ` the images `EdgesIn n K` of the vertex `k`-subsets `K`, each a
+      genuine `K_k`-clique of `C(k,2)` edges;
+  the abstract hypothesis `blocks.card · 2^(C(n,2)-C(k,2)+1) < 2^(C(n,2))`
+  follows from the classical criterion `2·C(n,k) < 2^(C(k,2))` (i.e.
+  `C(n,k)·2^(1-C(k,2)) < 1`), and `ramsey_avoidance` then yields a 2-colouring of
+  `K_n` with no monochromatic `K_k`.  Translating the abstract "`S`-membership"
+  colouring back into `RamseyFirstMoment.Coloring`, we obtain *exactly* the
+  conclusion of `RamseyFirstMoment.first_moment_ramsey` — but now derived from the
+  abstract engine rather than re-proved by a bespoke count.  This verifies the
+  WIP file's standing claim and unifies the two formalisations.
+
+  Status: 0 sorries, 0 axioms, no native_decide.
+-/
+import Mathlib
+import Proofs.ProbMethodApplicationsWIP
+import Proofs.RamseyFirstMoment
+
+open Finset
+
+namespace ProbMethod.ApplicationsWIPOQ01
+
+variable {n k : ℕ}
+
+/-- **K_n instantiation of the abstract avoidance engine.**
+    If `2·C(n,k) < 2^(C(k,2))` (equivalently `C(n,k)·2^(1-C(k,2)) < 1`), then
+    there is a 2-colouring of the edges of `K_n` with no monochromatic `K_k`,
+    i.e. `R(k,k) > n`.  The proof instantiates `ProbMethod.Core.ramsey_avoidance`
+    over the edge set of `K_n`; the family of "bad blocks" is the set of induced
+    clique-edge sets `EdgesIn n K` over vertex `k`-subsets `K`.
+
+    (The usual side condition `2 ≤ k` is omitted as redundant: the counting
+    hypothesis `2·C(n,k) < 2^(C(k,2))` already fails for `k ∈ {0,1}`, where the
+    right-hand side is `2^0 = 1`.) -/
+theorem ramsey_avoidance_Kn (hkn : k ≤ n)
+    (hbound : 2 * n.choose k < 2 ^ (k.choose 2)) :
+    ∃ c : RamseyFirstMoment.Coloring n,
+      ∀ K : Finset (Fin n), K.card = k → ¬ RamseyFirstMoment.Mono c K := by
+  classical
+  -- The clique-edge blocks: image of the vertex `k`-subsets under `EdgesIn n`.
+  set blocks :=
+    ((univ : Finset (Fin n)).powersetCard k).image (RamseyFirstMoment.EdgesIn n)
+    with hblocks
+  -- `|E| = C(n,2)` where `E` is the edge subtype.
+  have hcardE : Fintype.card (↥(RamseyFirstMoment.Edges n)) = n.choose 2 := by
+    rw [Fintype.card_coe, RamseyFirstMoment.card_Edges]
+  -- Every block is a `K_k`-clique, hence has exactly `C(k,2)` edges.
+  have hm : ∀ B ∈ blocks, B.card = k.choose 2 := by
+    intro B hB
+    rw [hblocks, mem_image] at hB
+    obtain ⟨K, hK, rfl⟩ := hB
+    rw [mem_powersetCard] at hK
+    rw [RamseyFirstMoment.card_EdgesIn, hK.2]
+  -- There are at most `C(n,k)` blocks (the image can only shrink the count).
+  have hblock_card : blocks.card ≤ n.choose k := by
+    rw [hblocks]
+    refine le_trans card_image_le ?_
+    rw [Finset.card_powersetCard, Finset.card_univ, Fintype.card_fin]
+  have hb_le_a : k.choose 2 ≤ n.choose 2 := Nat.choose_le_choose 2 hkn
+  -- Discharge the counting hypothesis of `ramsey_avoidance`.
+  have hcount : blocks.card *
+      (2 ^ (Fintype.card (↥(RamseyFirstMoment.Edges n)) - k.choose 2 + 1))
+        < 2 ^ (Fintype.card (↥(RamseyFirstMoment.Edges n))) := by
+    rw [hcardE]
+    have key : n.choose k * (2 ^ (n.choose 2 - k.choose 2 + 1)) < 2 ^ (n.choose 2) := by
+      have hsplit : (2 : ℕ) ^ n.choose 2
+          = 2 ^ k.choose 2 * 2 ^ (n.choose 2 - k.choose 2) := by
+        rw [← pow_add, Nat.add_sub_cancel' hb_le_a]
+      have hpos : 0 < 2 ^ (n.choose 2 - k.choose 2) := pow_pos (by norm_num) _
+      rw [hsplit]
+      calc n.choose k * (2 ^ (n.choose 2 - k.choose 2 + 1))
+          = (2 * n.choose k) * 2 ^ (n.choose 2 - k.choose 2) := by
+            rw [pow_succ]; ring
+        _ < 2 ^ k.choose 2 * 2 ^ (n.choose 2 - k.choose 2) :=
+            (Nat.mul_lt_mul_right hpos).mpr hbound
+    calc blocks.card * (2 ^ (n.choose 2 - k.choose 2 + 1))
+        ≤ n.choose k * (2 ^ (n.choose 2 - k.choose 2 + 1)) := by gcongr
+      _ < 2 ^ (n.choose 2) := key
+  -- Apply the abstract avoidance engine.
+  obtain ⟨S, hS⟩ :=
+    ProbMethod.Core.ramsey_avoidance blocks (k.choose 2) hm hcount
+  -- Translate the avoiding set `S` into an honest edge colouring.
+  refine ⟨fun e => decide (e ∈ S), ?_⟩
+  intro K hKcard hmono
+  -- `EdgesIn n K` is one of the blocks.
+  have hKblock : RamseyFirstMoment.EdgesIn n K ∈ blocks := by
+    rw [hblocks]
+    exact mem_image_of_mem _ (by rw [mem_powersetCard]; exact ⟨subset_univ K, hKcard⟩)
+  -- so it is not monochromatic for the abstract `Mono`.
+  have hnotmono :
+      ¬ ((RamseyFirstMoment.EdgesIn n K) ⊆ S ∨ Disjoint (RamseyFirstMoment.EdgesIn n K) S) :=
+    hS _ hKblock
+  rw [not_or] at hnotmono
+  obtain ⟨hnsub, hndisj⟩ := hnotmono
+  -- a `false` edge (not in `S`) and a `true` edge (in `S`) inside the same clique
+  obtain ⟨e, heB, heS⟩ := Finset.not_subset.mp hnsub
+  obtain ⟨f, hfB, hfS⟩ := Finset.not_disjoint_iff.mp hndisj
+  -- but `hmono` forces them to share a colour — contradiction.
+  have hcol : decide (e ∈ S) = decide (f ∈ S) := hmono e heB f hfB
+  rw [decide_eq_decide] at hcol
+  exact heS (hcol.mpr hfS)
+
+/-- **Concrete witness, via the abstract engine.** `2·C(6,4) = 30 < 64 = 2^(C(4,2))`,
+    so there is a 2-colouring of `K_6` with no monochromatic `K_4`, i.e.
+    `R(4,4) > 6` — recovered here purely from `ProbMethod.Core.ramsey_avoidance`. -/
+theorem ramsey_four_gt_six_via_avoidance :
+    ∃ c : RamseyFirstMoment.Coloring 6,
+      ∀ K : Finset (Fin 6), K.card = 4 → ¬ RamseyFirstMoment.Mono c K :=
+  ramsey_avoidance_Kn (by norm_num) (by decide)
+
+end ProbMethod.ApplicationsWIPOQ01

--- a/src/data/proofs/prob-method-applications-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/prob-method-applications-wip-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "wipoq01-blocks",
+    "proofId": "prob-method-applications-wip-01-oq-01",
+    "range": { "startLine": 64, "endLine": 82 },
+    "type": "definition",
+    "title": "The Clique-Edge Blocks",
+    "content": "The abstract engine ramsey_avoidance is fed a family blocks : Finset (Finset E) of 'bad blocks' over the edge type E = ↥(Edges n) of K_n. Here blocks is the image of every vertex k-subset K under K ↦ EdgesIn n K, the set of edges induced inside K. Two facts about this family are all the engine needs: each block has exactly C(k,2) edges (RamseyFirstMoment.card_EdgesIn, since K.card = k), and there are at most C(n,k) of them (Finset.card_image_le over univ.powersetCard k). The image may collapse distinct vertex sets to the same edge set, but because the engine's hypothesis is monotone in the block count, only the upper bound matters — no injectivity proof is required.",
+    "mathContext": "$\\mathrm{blocks} = \\{\\,\\mathrm{EdgesIn}\\,n\\,K : |K| = k\\,\\},\\quad |\\mathrm{block}| = \\binom{k}{2},\\quad |\\mathrm{blocks}| \\le \\binom{n}{k}$",
+    "significance": "key",
+    "prerequisites": ["Finset.image and card_image_le", "powersetCard for vertex k-subsets", "RamseyFirstMoment.card_EdgesIn"],
+    "relatedConcepts": ["induced clique edges", "uniform block size", "monotone counting hypothesis"]
+  },
+  {
+    "id": "wipoq01-counting",
+    "proofId": "prob-method-applications-wip-01-oq-01",
+    "range": { "startLine": 84, "endLine": 102 },
+    "type": "lemma",
+    "title": "Reducing the Abstract Count to the Erdős Criterion",
+    "content": "The engine requires blocks.card · 2^{|E|−C(k,2)+1} < 2^{|E|} with |E| = C(n,2). Using C(k,2) ≤ C(n,2) (Nat.choose_le_choose) we split 2^{C(n,2)} = 2^{C(k,2)} · 2^{C(n,2)−C(k,2)} via Nat.add_sub_cancel'. Cancelling the positive factor 2^{C(n,2)−C(k,2)}, the target becomes 2·C(n,k) < 2^{C(k,2)} — exactly the classical Erdős first-moment criterion C(n,k)·2^{1−C(k,2)} < 1. The block-count bound blocks.card ≤ C(n,k) is absorbed by gcongr, so the supplied hypothesis closes the inequality.",
+    "mathContext": "$\\binom{n}{k}\\cdot 2^{\\binom{n}{2}-\\binom{k}{2}+1} < 2^{\\binom{n}{2}} \\iff 2\\binom{n}{k} < 2^{\\binom{k}{2}}$",
+    "significance": "key",
+    "prerequisites": ["Nat.add_sub_cancel'", "Nat.choose_le_choose", "Nat.mul_lt_mul_right", "gcongr"],
+    "relatedConcepts": ["first-moment criterion", "union bound below the total count"]
+  },
+  {
+    "id": "wipoq01-translate",
+    "proofId": "prob-method-applications-wip-01-oq-01",
+    "range": { "startLine": 103, "endLine": 125 },
+    "type": "insight",
+    "title": "From Avoiding Set to Edge Colouring",
+    "content": "ramsey_avoidance returns S : Finset E with ¬(B ⊆ S ∨ Disjoint B S) for every block B. Define the colouring c e = decide (e ∈ S). For any K with K.card = k, its block EdgesIn n K is among blocks, so it is not contained in S and not disjoint from S. Finset.not_subset gives an edge e ∈ EdgesIn n K with e ∉ S (colour false); Finset.not_disjoint_iff gives an edge f ∈ EdgesIn n K with f ∈ S (colour true). If K were monochromatic then c e = c f, i.e. decide (e ∈ S) = decide (f ∈ S); decide_eq_decide turns this into e ∈ S ↔ f ∈ S, contradicting e ∉ S and f ∈ S. Hence ¬ RamseyFirstMoment.Mono c K — precisely the conclusion of first_moment_ramsey, now obtained from the abstract engine.",
+    "mathContext": "$c(e) := [\\,e \\in S\\,],\\qquad \\neg(B \\subseteq S \\lor B \\cap S = \\varnothing) \\Rightarrow K \\text{ is not monochromatic}$",
+    "significance": "key",
+    "prerequisites": ["Finset.not_subset", "Finset.not_disjoint_iff", "decide_eq_decide"],
+    "relatedConcepts": ["membership colouring", "monochromatic clique", "faithful instantiation"]
+  },
+  {
+    "id": "wipoq01-witness",
+    "proofId": "prob-method-applications-wip-01-oq-01",
+    "range": { "startLine": 127, "endLine": 133 },
+    "type": "lemma",
+    "title": "Concrete Witness R(4,4) > 6",
+    "content": "Instantiating ramsey_avoidance_Kn at n = 6, k = 4: the hypothesis 2·C(6,4) = 30 < 64 = 2^{C(4,2)} holds (checked by decide), so there is a 2-colouring of the 15 edges of K_6 with no monochromatic K_4 — the standard R(4,4) > 6 witness, here certified entirely through the abstract avoidance engine rather than the bespoke first-moment count.",
+    "mathContext": "$2\\binom{6}{4} = 30 < 64 = 2^{\\binom{4}{2}} \\Rightarrow R(4,4) > 6$",
+    "significance": "supporting",
+    "prerequisites": ["decide for a finite numeric inequality"],
+    "relatedConcepts": ["R(4,4) > 6", "non-vacuous instantiation"]
+  }
+]

--- a/src/data/proofs/prob-method-applications-wip-01-oq-01/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01-oq-01/meta.json
@@ -1,0 +1,180 @@
+{
+  "id": "prob-method-applications-wip-01-oq-01",
+  "title": "Instantiating the Abstract First-Moment Engine: Erdős Ramsey Bound R(k,k) > n",
+  "slug": "prob-method-applications-wip-01-oq-01",
+  "description": "The work-in-progress file ProbMethodApplicationsWIP.lean proves the abstract first-moment / union-bound avoidance engine ramsey_avoidance over an arbitrary finite edge set E: if the bad blocks are few enough (|cliques|·2^{|E|−m+1} < 2^{|E|}) then a colouring avoids them all. Its docstring claims that instantiating E as the edge set of K_n recovers the Erdős (1947) lower bound R(k,k) > n, but never carries out the instantiation. This entry supplies that bridge: taking E to be the C(n,2) edges of K_n and the blocks to be the induced clique-edge sets EdgesIn n K of the vertex k-subsets, the abstract hypothesis reduces to the classical criterion 2·C(n,k) < 2^{C(k,2)}, and ramsey_avoidance yields a 2-colouring of K_n with no monochromatic K_k. Translating the abstract S-membership colouring back into RamseyFirstMoment.Coloring reproduces exactly the conclusion of RamseyFirstMoment.first_moment_ramsey — now derived from the abstract engine rather than re-proved by a bespoke count. Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Paul Erdős (1947); abstract engine and instantiation formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Ramsey%27s_theorem#Lower_bound",
+    "date": "1947",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodApplicationsWIPOQ01.lean",
+    "tags": [
+      "probabilistic-method",
+      "ramsey-theory",
+      "combinatorics",
+      "first-moment-method",
+      "union-bound",
+      "erdos"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_image_le",
+        "description": "(s.image f).card ≤ s.card. Bounds the number of distinct clique-edge blocks by the number of vertex k-subsets C(n,k); the image map K ↦ EdgesIn n K may collapse, which only helps the counting hypothesis.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.not_disjoint_iff",
+        "description": "¬ Disjoint s t ↔ ∃ a, a ∈ s ∧ a ∈ t. Extracts a true-coloured edge (in S) inside a non-monochromatic block from the abstract engine's ¬(K ⊆ S ∨ Disjoint K S).",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.not_subset",
+        "description": "¬ s ⊆ t ↔ ∃ a ∈ s, a ∉ t. Extracts a false-coloured edge (not in S) inside the same block; together with the true edge this exhibits two differently-coloured edges, contradicting monochromaticity.",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.add_sub_cancel'",
+        "description": "a ≤ b → a + (b − a) = b. Splits 2^{C(n,2)} = 2^{C(k,2)} · 2^{C(n,2)−C(k,2)} using C(k,2) ≤ C(n,2), aligning the two sides of the counting inequality.",
+        "module": "Mathlib.Algebra.Order.Sub.Basic"
+      },
+      {
+        "theorem": "Nat.choose_le_choose",
+        "description": "k ≤ n → k.choose r ≤ n.choose r. Gives C(k,2) ≤ C(n,2), the exponent comparison needed to split the power of two.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "ramsey_avoidance_Kn: the K_n instantiation of the abstract avoidance engine. From 2·C(n,k) < 2^{C(k,2)} and k ≤ n it produces a 2-colouring of the edges of K_n with no monochromatic K_k (i.e. R(k,k) > n), by feeding ProbMethod.Core.ramsey_avoidance the family blocks = {EdgesIn n K : K a vertex k-subset} with block size m = C(k,2) and edge-set size |E| = C(n,2). This is the instantiation the WIP file's docstring asserted but did not carry out.",
+      "The block-counting reduction: each block EdgesIn n K has exactly C(k,2) edges (RamseyFirstMoment.card_EdgesIn), and there are at most C(n,k) distinct blocks (Finset.card_image_le over the vertex k-subsets). Crucially the engine's hypothesis only needs an upper bound on the block count, so no injectivity of K ↦ EdgesIn n K is required.",
+      "The colouring translation: the abstract avoiding set S : Finset E is turned into an honest edge colouring c e = decide (e ∈ S), and the abstract non-monochromaticity ¬(EdgesIn n K ⊆ S ∨ Disjoint (EdgesIn n K) S) is shown equivalent to the graph-theoretic statement that K is not monochromatic under c — yielding exactly the conclusion of RamseyFirstMoment.first_moment_ramsey.",
+      "Removal of the redundant side condition: unlike first_moment_ramsey, this statement omits the usual 2 ≤ k hypothesis, observing that the counting bound 2·C(n,k) < 2^{C(k,2)} already fails for k ∈ {0,1} (right-hand side 2^0 = 1).",
+      "ramsey_four_gt_six_via_avoidance: the concrete instance R(4,4) > 6 (2·C(6,4) = 30 < 64 = 2^{C(4,2)}), recovered purely from the abstract ramsey_avoidance engine, certifying the bridge is non-vacuous."
+    ],
+    "dateAdded": "2026-06-27",
+    "relatedProblems": [
+      {
+        "id": "prob-method-applications-wip-01",
+        "relationship": "Carries out the K_n instantiation that this parent file's abstract ramsey_avoidance engine claims in its docstring but leaves unproven, turning an asserted application into a machine-checked theorem."
+      },
+      {
+        "id": "prob-method-applications-oq-03",
+        "relationship": "Sibling Ramsey first-moment entry. There the bespoke RamseyFirstMoment.first_moment_ramsey is fed a closed-form counting bound to get the exponential family R(2m,2m) > 2^m; here the same R(k,k) > n conclusion is instead routed through the abstract avoidance engine, unifying the two formalisations of the first-moment Ramsey bound."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 135,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for ramsey_avoidance_Kn and ramsey_four_gt_six_via_avoidance — no sorryAx, no Lean.ofReduceBool. The result is a unification, not a new bound: its conclusion coincides with the existing RamseyFirstMoment.first_moment_ramsey; the contribution is deriving that conclusion as a genuine corollary of the abstract ProbMethod.Core.ramsey_avoidance engine, which the work-in-progress parent file had only asserted instantiates this way.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős's 1947 lower bound R(k,k) > 2^{k/2} is the founding application of the probabilistic method: colour the edges of K_n uniformly at random and bound the expected number of monochromatic k-cliques by C(n,k)·2^{1−C(k,2)}; if this is below 1 a clique-free colouring exists. The lean-genius gallery formalises the union-bound heart of this argument twice. RamseyFirstMoment.lean proves it directly over edge colourings of K_n (first_moment_ramsey: 2·C(n,k) < 2^{C(k,2)} ⟹ R(k,k) > n). Separately, ProbMethodApplicationsWIP.lean abstracts the same union bound into a self-contained engine ramsey_avoidance over an arbitrary finite 'edge' set E, where a block is monochromatic under a colouring S exactly when it is contained in S (all one colour) or disjoint from S (all the other). That abstract file's docstring announces — but never proves — that instantiating E as the edge set of K_n recovers R(k,k) > n. This entry closes that loop.",
+    "problemStatement": "Carry out the instantiation the abstract avoidance engine only claims: specialise ProbMethod.Core.ramsey_avoidance to E = the edge set of K_n, with the clique-edge blocks EdgesIn n K of the vertex k-subsets, and recover the Erdős criterion 2·C(n,k) < 2^{C(k,2)} ⟹ R(k,k) > n as a corollary — matching the conclusion of the bespoke RamseyFirstMoment.first_moment_ramsey.",
+    "text": "Take E to be the edge subtype of K_n, so |E| = C(n,2). For each vertex k-subset K let EdgesIn n K be its induced edges, a block of exactly C(k,2) edges. Let blocks be the image of all C(n,k) vertex k-subsets under K ↦ EdgesIn n K; the image has at most C(n,k) elements. The abstract engine ramsey_avoidance asks for blocks.card · 2^{|E|−C(k,2)+1} < 2^{|E|}. Bounding blocks.card by C(n,k) and writing 2^{C(n,2)} = 2^{C(k,2)}·2^{C(n,2)−C(k,2)} (using C(k,2) ≤ C(n,2)), this reduces to (2·C(n,k))·2^{C(n,2)−C(k,2)} < 2^{C(k,2)}·2^{C(n,2)−C(k,2)}, i.e. exactly the classical 2·C(n,k) < 2^{C(k,2)}. The engine returns an avoiding set S of edges; colouring an edge by its membership in S gives a 2-colouring of K_n, and the abstract 'block not monochromatic' (neither contained in nor disjoint from S) says precisely that the clique K has two differently-coloured edges. Hence no K_k is monochromatic: R(k,k) > n.",
+    "proofStrategy": "Everything is finite and over ℕ; the engine has already discharged the probability.\n\n1. **Edge-set size.** |E| = Fintype.card ↥(Edges n) = C(n,2), from RamseyFirstMoment.card_Edges.\n\n2. **Block size.** Each block in the image equals some EdgesIn n K with K.card = k, so by RamseyFirstMoment.card_EdgesIn it has C(k,2) edges. This supplies the engine's uniform block-size hypothesis with m = C(k,2).\n\n3. **Block count.** blocks = (univ.powersetCard k).image (EdgesIn n), so by Finset.card_image_le its cardinality is at most (univ.powersetCard k).card = C(n,k). Only an upper bound is needed; the map need not be injective.\n\n4. **Counting hypothesis.** From C(k,2) ≤ C(n,2) (Nat.choose_le_choose) split 2^{C(n,2)} = 2^{C(k,2)}·2^{C(n,2)−C(k,2)} (Nat.add_sub_cancel'); the strict inequality then follows from the supplied 2·C(n,k) < 2^{C(k,2)} multiplied by the positive 2^{C(n,2)−C(k,2)}, with the block-count bound from step 3 absorbed by gcongr.\n\n5. **Invoke the engine.** ProbMethod.Core.ramsey_avoidance blocks (C(k,2)) returns S : Finset E with ∀ B ∈ blocks, ¬(B ⊆ S ∨ Disjoint B S).\n\n6. **Translate to a colouring.** Set c e = decide (e ∈ S). For any K with K.card = k, EdgesIn n K ∈ blocks, so ¬(EdgesIn n K ⊆ S ∨ Disjoint (EdgesIn n K) S). By Finset.not_subset there is an edge e ∈ EdgesIn n K with e ∉ S (colour false), and by Finset.not_disjoint_iff an edge f ∈ EdgesIn n K with f ∈ S (colour true); decide_eq_decide turns monochromaticity c e = c f into the false equivalence e ∈ S ↔ f ∈ S, a contradiction. Hence ¬ Mono c K, exactly first_moment_ramsey's conclusion.",
+    "keyInsights": [
+      "**The abstract engine really does specialise.** The WIP file's ramsey_avoidance is stated over an opaque finite 'edge' set with a set-theoretic notion of monochromatic block (contained-or-disjoint). The work here is showing this abstraction is faithful: under E = edges of K_n and blocks = induced clique edges, it reproduces the graph-colouring Ramsey bound verbatim, validating a docstring claim that was previously only rhetorical.",
+      "**An upper bound on the block count suffices.** Because the engine's hypothesis is monotone in |cliques|, the family of blocks can be taken as a plain image with possible collapses (Finset.card_image_le), avoiding any need to prove the map vertex-set ↦ edge-set is injective — a small but real simplification over counting cliques exactly.",
+      "**Membership is the colouring.** The bridge from the abstract avoiding set S : Finset E to an honest Boolean edge colouring is just c e = decide (e ∈ S); the two faces of 'not monochromatic' (not all-in-S, not all-out-of-S) are exactly a false edge and a true edge, so decide_eq_decide closes the translation in one step.",
+      "**Two formalisations, one theorem.** The gallery now has the first-moment Ramsey bound both as a bespoke edge-colouring count (first_moment_ramsey) and as a corollary of an abstract reusable union-bound engine; this entry is the proof that they deliver the same conclusion, R(k,k) > n.",
+      "**The 2 ≤ k side condition is free.** The counting hypothesis 2·C(n,k) < 2^{C(k,2)} cannot hold for k ∈ {0,1} (the right side is 2^0 = 1), so the usual lower bound on k can be dropped from the statement without weakening it."
+    ],
+    "prerequisites": [
+      "The first-moment / union-bound existence principle (number of bad outcomes below the total ⟹ a good outcome exists)",
+      "Diagonal Ramsey numbers R(k,k) and monochromatic cliques in edge 2-colourings",
+      "Finset image cardinality bounds and powersetCard for the vertex k-subsets",
+      "The abstract ProbMethod.Core.ramsey_avoidance engine and the RamseyFirstMoment edge/clique model"
+    ]
+  },
+  "sections": [
+    {
+      "id": "instantiation",
+      "title": "Instantiating the Abstract Engine over K_n",
+      "startLine": 59,
+      "endLine": 125,
+      "mathContext": "$2\\binom{n}{k} < 2^{\\binom{k}{2}} \\ \\Rightarrow\\ R(k,k) > n$",
+      "summary": "ramsey_avoidance_Kn sets E = the C(n,2) edges of K_n and blocks = the induced clique-edge sets EdgesIn n K of the vertex k-subsets. It verifies the engine's uniform block-size (C(k,2)) and block-count (≤ C(n,k)) hypotheses, reduces the abstract counting inequality to 2·C(n,k) < 2^{C(k,2)}, invokes ProbMethod.Core.ramsey_avoidance, and translates the avoiding edge set S into the colouring c e = decide (e ∈ S) to obtain a K_n colouring with no monochromatic K_k."
+    },
+    {
+      "id": "witness",
+      "title": "Concrete Witness R(4,4) > 6",
+      "startLine": 127,
+      "endLine": 133,
+      "mathContext": "$2\\binom{6}{4} = 30 < 64 = 2^{\\binom{4}{2}}$",
+      "summary": "ramsey_four_gt_six_via_avoidance instantiates ramsey_avoidance_Kn at n = 6, k = 4, certifying via the abstract engine that there is a 2-colouring of K_6 with no monochromatic K_4 — the standard R(4,4) > 6 witness, here produced without the bespoke count."
+    }
+  ],
+  "conclusion": {
+    "summary": "The abstract first-moment avoidance engine ProbMethod.Core.ramsey_avoidance is instantiated over the edge set of K_n, recovering the Erdős criterion 2·C(n,k) < 2^{C(k,2)} ⟹ R(k,k) > n as a genuine corollary. The conclusion matches the gallery's bespoke RamseyFirstMoment.first_moment_ramsey; the value added is the verified bridge from the reusable abstract engine to the graph-colouring statement, fulfilling a claim the work-in-progress parent file had only asserted. Zero sorries, zero axioms, no native_decide.",
+    "implications": "Confirms the WIP abstraction is faithful and reusable: any family of finite 'edge' blocks satisfying the union-bound count yields an avoiding colouring, and the Ramsey case is one instance. Because the engine only needs an upper bound on the block count, the instantiation avoids proving injectivity of the clique-to-edge-set map. The translation pattern (avoiding Finset ↦ membership colouring) is reusable for other instantiations of the same engine (e.g. Property B, hypergraph 2-colouring).",
+    "openQuestions": [
+      "Instantiate the same abstract engine for Property B (2-colourability of k-uniform hypergraphs), reusing the membership-colouring translation, to unify it with property-b-first-moment.",
+      "State and prove that the clique-to-edge-set map K ↦ EdgesIn n K is injective for k ≥ 2, upgrading the block count from ≤ C(n,k) to = C(n,k) and giving the exact expected-value form of the criterion.",
+      "Combine with prob-method-applications-oq-03 to route the exponential family R(2m,2m) > 2^m through the abstract engine as well, retiring the bespoke first_moment_ramsey count entirely."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-applications-wip-01",
+      "relationship": "extends",
+      "description": "Proves the K_n instantiation that this file's abstract ramsey_avoidance engine claims in its docstring, turning the asserted application R(k,k) > n into a machine-checked corollary."
+    },
+    {
+      "targetId": "prob-method-applications-oq-03",
+      "relationship": "related",
+      "description": "Both formalise the first-moment Ramsey lower bound R(k,k) > n; that entry uses the bespoke RamseyFirstMoment count to reach the exponential family, this one routes the same conclusion through the abstract avoidance engine."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/ProbMethodApplicationsWIPOQ01.lean",
+    "imports": [
+      "Mathlib",
+      "Proofs.ProbMethodApplicationsWIP",
+      "Proofs.RamseyFirstMoment"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ProbMethod.ApplicationsWIPOQ01",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 2
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "Some remarks on the theory of graphs",
+      "year": "1947",
+      "venue": "Bulletin of the American Mathematical Society 53, 292–294",
+      "note": "Introduces the probabilistic lower bound R(k,k) > 2^{k/2}, the founding application of the first-moment / union-bound method instantiated here."
+    },
+    {
+      "authors": "Alon, Noga; Spencer, Joel H.",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition",
+      "note": "Chapter 1 presents the first-moment Ramsey lower bound; the abstract union-bound engine instantiated here is its combinatorial core."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "ramsey_avoidance_Kn",
+      "type": "core",
+      "description": "If 2·C(n,k) < 2^{C(k,2)} and k ≤ n then there is a 2-colouring of the edges of K_n with no monochromatic K_k (R(k,k) > n), obtained by instantiating the abstract ProbMethod.Core.ramsey_avoidance engine over the edge set of K_n.",
+      "leanType": "(k ≤ n) → (2 * n.choose k < 2 ^ (k.choose 2)) → ∃ c : RamseyFirstMoment.Coloring n, ∀ K : Finset (Fin n), K.card = k → ¬ RamseyFirstMoment.Mono c K"
+    },
+    {
+      "name": "ramsey_four_gt_six_via_avoidance",
+      "type": "core",
+      "description": "The concrete instance R(4,4) > 6: a 2-colouring of K_6 with no monochromatic K_4, recovered purely from the abstract avoidance engine.",
+      "leanType": "∃ c : RamseyFirstMoment.Coloring 6, ∀ K : Finset (Fin 6), K.card = 4 → ¬ RamseyFirstMoment.Mono c K"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/prob-method-applications-wip-01-oq-01.json
+++ b/src/data/research/problems/prob-method-applications-wip-01-oq-01.json
@@ -1,0 +1,73 @@
+{
+  "slug": "prob-method-applications-wip-01-oq-01",
+  "title": "Instantiating Ramsey Avoidance to a Numeric Diagonal Lower Bound R(m,m)>n",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\binom{n}{m}\\cdot 2^{\\,1-\\binom{m}{2}} < 1 \\;\\Longrightarrow\\; R(m,m) > n",
+    "plain": "The parent gallery proof establishes a general \"avoidance\" theorem: over any",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [
+      "ramsey_avoidance_Kn: R(k,k) > n from the abstract ProbMethod.Core.ramsey_avoidance engine",
+      "ramsey_four_gt_six_via_avoidance: concrete R(4,4) > 6 via the engine"
+    ],
+    "open": [],
+    "goal": "Carry out the K_n instantiation the parent abstract engine only claims, recovering 2*C(n,k) < 2^{C(k,2)} => R(k,k) > n as a corollary."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-27T13:50:00-07:00",
+    "iteration": 2,
+    "focus": "Solved: instantiated the abstract ramsey_avoidance engine over K_n, deriving R(k,k) > n. Verified 0-axiom.",
+    "blockers": [],
+    "nextAction": "Done. PR opened. Optional follow-ups recorded in nextSteps.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: verified 0-axiom instantiation of the abstract first-moment avoidance engine over the edge set of K_n, recovering the Erdos criterion 2*C(n,k) < 2^{C(k,2)} => R(k,k) > n. Conclusion matches RamseyFirstMoment.first_moment_ramsey but is derived from the abstract engine, fulfilling the WIP file docstring claim.",
+    "builtItems": [
+      "ramsey_avoidance_Kn in Proofs/ProbMethodApplicationsWIPOQ01.lean: K_n instantiation of ProbMethod.Core.ramsey_avoidance giving R(k,k) > n",
+      "ramsey_four_gt_six_via_avoidance: R(4,4) > 6 witness via the abstract engine",
+      "block-counting reduction: blocks = (univ.powersetCard k).image (EdgesIn n), card <= C(n,k) via card_image_le, each block size C(k,2)",
+      "colouring translation: c e = decide (e in S) turns the abstract avoiding set into an honest edge 2-colouring"
+    ],
+    "insights": [
+      "The abstract avoidance engine only needs an UPPER bound on the block count, so the clique-to-edge-set image map need not be proven injective (card_image_le suffices).",
+      "The set-theoretic monochromatic block (K subset S or Disjoint K S) translates faithfully to graph monochromaticity via membership colouring; decide_eq_decide closes the equivalence in one step.",
+      "The 2 <= k side condition of first_moment_ramsey is redundant: the bound 2*C(n,k) < 2^{C(k,2)} already fails for k in {0,1} (RHS 2^0 = 1).",
+      "The abstract counting hypothesis blocks.card * 2^{|E|-m+1} < 2^{|E|} reduces to the classical 2*C(n,k) < 2^{C(k,2)} after splitting 2^{C(n,2)} = 2^{C(k,2)} * 2^{C(n,2)-C(k,2)}."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Instantiate the same abstract engine for Property B (k-uniform hypergraph 2-colourability), reusing the membership-colouring translation.",
+      "Prove K -> EdgesIn n K injective for k >= 2 to upgrade block count from <= C(n,k) to = C(n,k) (exact expected-value form).",
+      "Route the exponential family R(2m,2m) > 2^m (oq-03) through the abstract engine to retire the bespoke count."
+    ],
+    "markdown": "# Knowledge Base: prob-method-applications-wip-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "probabilistic-method",
+    "ramsey-theory"
+  ],
+  "relatedProofs": [
+    "prob-method-applications",
+    "prob-method-applications-wip-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-27T11:33:01-07:00",
+  "significance": 5,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary

Closes open question `prob-method-applications-wip-01-oq-01`: *"Instantiate `ramsey_avoidance` to K_n: C(n,m)·2^(1−C(m,2)) < 1 ⟹ R(m,m) > n."*

The parent file `ProbMethodApplicationsWIP.lean` proves the **abstract** first-moment / union-bound avoidance engine `ProbMethod.Core.ramsey_avoidance` over an arbitrary finite "edge" set `E`, and its docstring *claims* that instantiating `E` as the edge set of `K_n` recovers the Erdős (1947) bound `R(k,k) > n` — but never carries out that instantiation. This PR supplies the missing bridge.

## What's proved

- **`ramsey_avoidance_Kn`** — taking `E` = the `C(n,2)` edges of `K_n` and the bad blocks = the induced clique-edge sets `EdgesIn n K` of the vertex `k`-subsets, the abstract hypothesis reduces to the classical criterion `2·C(n,k) < 2^(C(k,2))`, and `ramsey_avoidance` yields a 2-colouring of `K_n` with no monochromatic `K_k` (i.e. `R(k,k) > n`). The avoiding set `S` is translated into an honest edge colouring `c e = decide (e ∈ S)`; the result is **exactly the conclusion of `RamseyFirstMoment.first_moment_ramsey`**, now derived from the abstract engine rather than re-proved by a bespoke count.
- **`ramsey_four_gt_six_via_avoidance`** — the concrete witness `R(4,4) > 6` (`2·C(6,4)=30 < 64=2^(C(4,2))`), recovered purely through the abstract engine.

## Honesty note

This is a **unification / instantiation**, not a new bound: the conclusion coincides with the existing `first_moment_ramsey`. The value added is the verified bridge from the reusable abstract engine to the graph-colouring statement, fulfilling the parent file's standing docstring claim. Two small simplifications: the engine needs only an *upper* bound on the block count (no injectivity of the clique→edge-set map), and the redundant `2 ≤ k` side condition is dropped (the count already fails for `k ∈ {0,1}`).

## Verification

- `lake env lean` on host (Lean 4.26.0) — **0 errors, 0 warnings** (Docker image build currently blocked by a containerd `meta.db` I/O error on the host).
- `#print axioms` for both theorems = `propext, Classical.choice, Quot.sound` only — no `sorryAx`, no `Lean.ofReduceBool`.
- **Status: `verified`, 0 axioms, 0 sorries, no `native_decide`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)