### PR TITLE
Enrich Ramsey R(4,3) ≥ 9 lower bound (ramsey-r4k-oq-02)

### DIFF
--- a/src/data/proofs/ramsey-r4k-oq-02/annotations.json
+++ b/src/data/proofs/ramsey-r4k-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-cdiff",
+    "proofId": "ramsey-r4k-oq-02",
+    "range": { "startLine": 55, "endLine": 56 },
+    "type": "definition",
+    "title": "Circular Difference on ℤ/8ℤ",
+    "content": "`cdiff i j` computes the cyclic distance label `(i - j) mod 8`. The vertices of K₈ are identified with the cyclic group ℤ/8ℤ, and the entire coloring depends only on this difference, making the graph a circulant. The expression `(i.val + 8 - j.val) % 8` adds 8 before subtracting to avoid natural-number underflow, since `Fin 8` arithmetic on raw `.val` would otherwise truncate `i.val - j.val` to 0 whenever `j > i`.",
+    "mathContext": "$\\mathrm{cdiff}(i,j) = (i - j) \\bmod 8 \\in \\{0,1,\\dots,7\\}$, the canonical label of the chord between $i$ and $j$ in the circulant graph on $\\mathbb{Z}/8\\mathbb{Z}$.",
+    "significance": "technical",
+    "relatedConcepts": ["circulant graph", "cyclic group ℤ/nℤ", "modular arithmetic", "Cayley graph"],
+    "prerequisites": ["modular arithmetic", "Fin n in Lean 4"]
+  },
+  {
+    "id": "ann-wagner-color",
+    "proofId": "ramsey-r4k-oq-02",
+    "range": { "startLine": 58, "endLine": 62 },
+    "type": "definition",
+    "title": "The Wagner-Graph 2-Coloring",
+    "content": "`wagnerColor` paints an edge blue (`false`) exactly when its cyclic difference lies in the connection set {0,1,4,7} and red (`true`) otherwise. Differences 1 and 7 = −1 are the eight 8-cycle edges; difference 4 gives the four long diagonals; difference 0 is the loop (colored blue by the irreflexivity convention `f x x = false`). The blue graph is therefore the circulant C₈(1,4) — the Wagner graph V₈, also realizable as the Möbius–Kantor ladder M₈. Red is its complement, the circulant C₈(2,3).",
+    "mathContext": "Blue connection set $S = \\{\\pm 1, 4\\}$ gives the Wagner graph $V_8 = C_8(1,4)$; the red graph is the complementary circulant $C_8(2,3)$. An edge $ij$ is blue iff $(i-j)\\bmod 8 \\in \\{1,4,7\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["Wagner graph V₈", "Möbius ladder M₈", "circulant graph", "graph complement", "edge 2-coloring"],
+    "prerequisites": ["graph coloring", "circulant graphs", "Boolean functions in Lean"]
+  },
+  {
+    "id": "ann-symm-irrefl",
+    "proofId": "ramsey-r4k-oq-02",
+    "range": { "startLine": 64, "endLine": 68 },
+    "type": "technique",
+    "title": "Symmetry and Irreflexivity by Decision",
+    "content": "The two well-formedness conditions for an undirected edge coloring — symmetry `f x y = f y x` and irreflexivity `f x x = false` — are bounded statements over the 64 (resp. 8) vertex pairs of `Fin 8`. Each is `Decidable`, so `decide` discharges it by exhaustive kernel evaluation. These two facts are exactly the structural hypotheses the parent's `RamseyProp` demands of any candidate coloring, so proving them here lets `wagnerColor` be fed into `RamseyProp 8 4 3`.",
+    "mathContext": "Symmetry follows because $(i-j)\\bmod 8$ and $(j-i)\\bmod 8$ are both in $\\{1,4,7\\}$ together (the set is closed under negation mod 8: $-1\\equiv 7,\\ -4\\equiv 4$). Irreflexivity holds because $\\mathrm{cdiff}(i,i)=0$ is in the blue set.",
+    "significance": "supporting",
+    "relatedConcepts": ["undirected graph", "symmetric relation", "Decidable instances", "decide tactic"],
+    "prerequisites": ["decidability of finite quantifiers"]
+  },
+  {
+    "id": "ann-no-red-k4",
+    "proofId": "ramsey-r4k-oq-02",
+    "range": { "startLine": 70, "endLine": 75 },
+    "type": "insight",
+    "title": "No Red 4-Clique: ω(complement) = 3",
+    "content": "A red 4-clique would be four vertices pairwise joined by red edges, i.e. an independent set of size 4 in the blue Wagner graph. The Wagner graph V₈ has independence number α(V₈) = 3, so no such set exists and the red graph has clique number 3 < 4. The statement quantifies over all `Finset (Fin 8)` (every one of the 2⁸ = 256 subsets), and `decide` enumerates them; `set_option maxRecDepth 4000` is needed because the recursive kernel unfolding of the nested `Finset` decidability instance exceeds the default depth of 512.",
+    "mathContext": "$\\alpha(V_8) = 3 \\iff \\omega(\\overline{V_8}) = 3$, so $\\overline{V_8} = C_8(2,3)$ contains no $K_4$. Formally: $\\neg\\,\\exists S,\\ |S|\\ge 4 \\wedge \\forall x,y\\in S,\\ x\\ne y \\Rightarrow \\text{red}.$",
+    "significance": "key",
+    "relatedConcepts": ["independence number α(G)", "clique number ω(G)", "graph complement", "Ramsey extremal graph"],
+    "prerequisites": ["clique and independent set", "Finset decidability"]
+  },
+  {
+    "id": "ann-no-blue-k3",
+    "proofId": "ramsey-r4k-oq-02",
+    "range": { "startLine": 77, "endLine": 81 },
+    "type": "insight",
+    "title": "No Blue 3-Clique: V₈ Is Triangle-Free",
+    "content": "A blue 3-clique is a triangle in the Wagner graph. V₈ is triangle-free: it is bipartite-like enough that no three of the chord types {±1, 4} close up — e.g. 1+1 = 2, 1+4 = 5, 4+4 = 0 are never themselves in {1,4,7} in a way that forms a 3-cycle. Hence the blue graph has no K₃. As with the red case, the claim ranges over all 256 subsets of `Fin 8` and is closed by kernel `decide` under raised `maxRecDepth`. Triangle-freeness together with α = 3 is precisely the extremal pair a witness for R(4,3) > 8 must satisfy.",
+    "mathContext": "$V_8$ has girth 4, hence is triangle-free: $\\omega(V_8) = 2$. No three vertices have pairwise differences all in $\\{1,4,7\\}$. Formally $\\neg\\,\\exists S,\\ |S|\\ge 3 \\wedge \\forall x,y\\in S,\\ x\\ne y \\Rightarrow \\text{blue}.$",
+    "significance": "key",
+    "relatedConcepts": ["triangle-free graph", "girth", "Wagner graph", "Ramsey extremal coloring"],
+    "prerequisites": ["triangle-free graphs", "Finset decidability"]
+  },
+  {
+    "id": "ann-r43-lower",
+    "proofId": "ramsey-r4k-oq-02",
+    "range": { "startLine": 83, "endLine": 92 },
+    "type": "concept",
+    "title": "The Lower Bound R(4,3) ≥ 9",
+    "content": "`r43_lower` proves `¬ RamseyProp 8 4 3`, i.e. R(4,3) > 8. The argument is a one-line contradiction: assume K₈ does have the Ramsey property; apply it to `wagnerColor` (which is symmetric and irreflexive by the previous lemmas) to get either a red 4-clique or a blue 3-clique; both branches are refuted by `wagner_no_red_K4` and `wagner_no_blue_K3`. This reuses the *exact same* `RamseyProp` definition the parent gallery proof uses for its upper bounds, so the two results compose into a clean bracket on R(4,3).",
+    "mathContext": "$R(4,3) > 8 \\iff \\neg\\,\\mathrm{RamseyProp}(8,4,3)$. Combined with the parent's binomial bound $R(4,3)\\le\\binom{5}{3}=10$ this gives $9 \\le R(4,3) \\le 10$; the true value is $R(4,3)=9$ (Greenwood–Gleason 1955).",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey number R(s,t)", "off-diagonal Ramsey number", "proof by contradiction", "RamseyProp encoding"],
+    "prerequisites": ["Ramsey's theorem", "the parent ramsey-r4k RamseyProp definition"]
+  },
+  {
+    "id": "ann-witness",
+    "proofId": "ramsey-r4k-oq-02",
+    "range": { "startLine": 94, "endLine": 105 },
+    "type": "concept",
+    "title": "Self-Contained Witness Packaging",
+    "content": "`r43_lower_witness` restates the result as a positive existential: there *exists* a coloring of K₈ that is symmetric, irreflexive, free of red 4-cliques, and free of blue 3-cliques. The proof is just the anonymous constructor `⟨wagnerColor, …⟩` bundling the coloring with its four certificates. This form is self-contained — it does not mention `RamseyProp` — so a reader who has not loaded the parent file can still see the full extremal-coloring content of the lower bound in one statement.",
+    "mathContext": "Existential witness form: $\\exists f,\\ (\\text{symm})\\wedge(\\text{irrefl})\\wedge(\\text{no red }K_4)\\wedge(\\text{no blue }K_3)$. Equivalent to $R(4,3) > 8$ but stated without reference to the abstract Ramsey predicate.",
+    "significance": "supporting",
+    "relatedConcepts": ["existential witness", "anonymous constructor", "extremal coloring", "self-contained statement"],
+    "prerequisites": ["existential quantifiers in Lean", "anonymous constructor syntax"]
+  }
+]

--- a/src/data/proofs/ramsey-r4k-oq-02/meta.json
+++ b/src/data/proofs/ramsey-r4k-oq-02/meta.json
@@ -55,7 +55,121 @@
       "**Extremal coloring as a finite certificate.** Unlike the upper bound (which would require ruling out all 2^36 colorings of K₉), the lower bound only needs one witness coloring of K₈ whose two clique-freeness properties are individually decidable — turning a Ramsey lower bound into a kernel-checkable `decide`.",
       "**Wagner graph = unique (3,4)-extremal graph on 8 vertices.** Encoding it via the cyclic connection set {±1, 4} makes both triangle-freeness (no blue K₃) and independence number 3 (no red K₄) hold simultaneously, exactly the two conditions a R(4,3)>8 witness must satisfy.",
       "**0-axiom via `decide` not `native_decide`.** The enumeration is small enough (2^8 subsets, 64 pairs) that the kernel can reduce it directly once `maxRecDepth` is raised, so the proof avoids `Lean.ofReduceBool` and remains genuinely axiom-free — stronger than the parent's numeric bounds, which use `native_decide`.",
-      "**Reuses the gallery's RamseyProp.** By importing the parent file's `RamseyProp`, the lower bound is stated against the exact same definition the gallery uses for upper bounds, so the two results compose into a clean bracket 8 < R(4,3) ≤ 10 with the exact upper bound R(4,3) ≤ 9 left as the remaining open step."
+      "**Reuses the gallery's RamseyProp.** By importing the parent file's `RamseyProp`, the lower bound is stated against the exact same definition the gallery uses for upper bounds, so the two results compose into a clean bracket 8 < R(4,3) ≤ 10 with the exact upper bound R(4,3) ≤ 9 left as the remaining open step.",
+      "**A circulant graph trivializes both checks.** Because the whole coloring depends only on the cyclic difference (i−j) mod 8, the graph is vertex-transitive (a Cayley graph of ℤ/8ℤ with connection set {±1, 4}). Symmetry of the coloring then reduces to the connection set being closed under negation mod 8 (−1≡7, −4≡4), and the two clique checks inherit the high symmetry that makes the small enumeration feasible."
     ]
-  }
+  },
+  "sections": [
+    {
+      "id": "circular-difference",
+      "title": "Circular Difference on ℤ/8ℤ",
+      "startLine": 46,
+      "endLine": 56,
+      "summary": "Identifies the vertices of K₈ with the cyclic group ℤ/8ℤ and defines `cdiff i j = (i − j) mod 8`, the chord label that the entire circulant coloring depends on. The `+ 8` guards against natural-number subtraction underflow."
+    },
+    {
+      "id": "wagner-coloring",
+      "title": "The Wagner-Graph 2-Coloring",
+      "startLine": 58,
+      "endLine": 68,
+      "summary": "Defines `wagnerColor`: blue on the connection set {0,1,4,7} (the 8-cycle edges ±1, the long diagonals 4, and loops 0), red elsewhere. The blue graph is the Wagner circulant C₈(1,4); the red graph is its complement C₈(2,3). Two `decide` lemmas establish symmetry and irreflexivity."
+    },
+    {
+      "id": "no-red-k4",
+      "title": "No Red 4-Clique (α(V₈) = 3)",
+      "startLine": 70,
+      "endLine": 75,
+      "summary": "`wagner_no_red_K4`: a red 4-clique would be an independent 4-set in the Wagner graph, but α(V₈) = 3. Discharged by `decide` over all 256 subsets of Fin 8 with `maxRecDepth 4000`."
+    },
+    {
+      "id": "no-blue-k3",
+      "title": "No Blue 3-Clique (V₈ triangle-free)",
+      "startLine": 77,
+      "endLine": 81,
+      "summary": "`wagner_no_blue_K3`: the Wagner graph has girth 4 and is triangle-free, so there is no blue K₃. Discharged by `decide` over all subsets of Fin 8 with `maxRecDepth 4000`."
+    },
+    {
+      "id": "lower-bound",
+      "title": "The Lower Bound R(4,3) ≥ 9",
+      "startLine": 83,
+      "endLine": 105,
+      "summary": "`r43_lower` proves `¬ RamseyProp 8 4 3` by feeding the Wagner coloring into the parent's Ramsey predicate and refuting both resulting cliques. `r43_lower_witness` repackages the same content as a self-contained existential over colorings of K₈."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry settles the lower-bound half of the exact off-diagonal Ramsey number R(4,3) = 9 by exhibiting and kernel-verifying an explicit extremal 2-coloring of K₈. The coloring is the Wagner graph V₈ (the circulant C₈(1,4)), taken as the blue color: it is triangle-free (no blue K₃) and has independence number 3 (no red K₄). Both clique-freeness facts are finite decisions over all subsets of Fin 8, discharged by `decide` rather than `native_decide`, so `¬ RamseyProp 8 4 3` is proved with only the foundational axioms propext, Classical.choice, and Quot.sound — genuinely 0-axiom.",
+    "implications": [
+      "Combined with the parent proof's binomial upper bound R(4,3) ≤ C(5,3) = 10, this pins R(4,3) into the bracket 9 ≤ R(4,3) ≤ 10, one step away from the exact value 9.",
+      "It demonstrates the general principle that Ramsey *lower* bounds are far cheaper to formalize than *upper* bounds: a lower bound needs a single extremal witness whose two clique properties are individually decidable, whereas the matching upper bound must quantify over all 2^C(9,2) colorings of K₉.",
+      "Encoding the extremal graph as a circulant (a Cayley graph of ℤ/8ℤ) keeps the decision small enough for the *kernel* — not just the compiler — making the result strictly stronger than the parent's `native_decide` numeric bounds, which depend on `Lean.ofReduceBool`.",
+      "It provides a reusable template — define a circulant coloring, prove triangle-freeness and bounded independence by `decide`, contradict `RamseyProp` — for the larger extremal cases R(4,4) ≥ 18 (Paley graph on 17 vertices) and R(4,5) ≥ 25 raised in the same open question."
+    ],
+    "openQuestions": [
+      "The matching exact upper bound R(4,3) ≤ 9 — that every 2-coloring of K₉ contains a red K₄ or blue K₃ — remains unformalized here; it would sharpen the bracket to the exact value R(4,3) = 9.",
+      "Can the next lower bounds R(4,4) ≥ 18 (via the Paley graph on GF(17)) and R(4,5) ≥ 25 be verified by `decide` at all, or does the 2^17 / 2^24 subset enumeration force `native_decide` and reintroduce the `Lean.ofReduceBool` axiom?",
+      "Is there a uniform, parameterized Lean formalization that proves R(4,k) ≥ f(k) lower bounds from a description of the extremal circulant/Cayley graph, rather than a hand-built witness per case?",
+      "Can the uniqueness of V₈ as the extremal (triangle-free, α = 3) graph on 8 vertices be formalized, certifying not just that the bound holds but that the witness is essentially the only one?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "ramsey-r4k",
+      "relationship": "Parent proof — source of the open question OQ-02 and of the `RamseyProp` encoding reused here",
+      "description": "Establishes the classical Erdős–Szekeres binomial upper bounds R(4,k) ≤ C(k+2,3) (giving R(4,3) ≤ 10) but not the exact values. This entry supplies the lower-bound half of the smallest exact case, R(4,3) ≥ 9, completing the bracket to within one of the true value."
+    },
+    {
+      "proofId": "ramsey-r4k-oq-01",
+      "relationship": "Sibling open-question entry on the same parent",
+      "description": "Treats the asymptotic R(4,k) frontier (AKS upper bound O(k³/log²k) and the Mattheus–Verstraëte lower bound), complementing this entry's focus on an exact small-case value."
+    },
+    {
+      "proofId": "ramseys-theorem",
+      "relationship": "Foundational result that Ramsey numbers R(s,t) are well-defined and finite",
+      "description": "Ramsey's theorem guarantees R(4,3) exists; this entry computes a lower bound on its exact value by an extremal construction."
+    },
+    {
+      "proofId": "ramsey-r4k-extensions-oq-01",
+      "relationship": "Related lower-bound technique via the probabilistic method",
+      "description": "Erdős's probabilistic lower bound R(k,k) > 2^(k/2) gives non-constructive diagonal lower bounds; this entry instead gives a fully explicit, kernel-checked constructive lower bound for the off-diagonal case R(4,3)."
+    }
+  ],
+  "references": [
+    {
+      "authors": ["R. E. Greenwood", "A. M. Gleason"],
+      "title": "Combinatorial relations and chromatic graphs",
+      "venue": "Canadian Journal of Mathematics",
+      "volume": "7",
+      "pages": "1–7",
+      "year": 1955,
+      "doi": "10.4153/CJM-1955-001-4",
+      "note": "Determines the exact values R(3,3)=6, R(3,4)=9, R(3,5)=14, R(4,4)=18; the source of R(4,3)=9."
+    },
+    {
+      "authors": ["P. Erdős", "G. Szekeres"],
+      "title": "A combinatorial problem in geometry",
+      "venue": "Compositio Mathematica",
+      "volume": "2",
+      "pages": "463–470",
+      "year": 1935,
+      "note": "Origin of the binomial recurrence R(s,t) ≤ R(s−1,t) + R(s,t−1) underlying the parent proof's upper bounds."
+    },
+    {
+      "authors": ["K. Wagner"],
+      "title": "Über eine Eigenschaft der ebenen Komplexe",
+      "venue": "Mathematische Annalen",
+      "volume": "114",
+      "pages": "570–590",
+      "year": 1937,
+      "doi": "10.1007/BF01594196",
+      "note": "Introduces the Wagner graph V₈ used here as the extremal blue coloring."
+    },
+    {
+      "authors": ["S. P. Radziszowski"],
+      "title": "Small Ramsey Numbers",
+      "venue": "Electronic Journal of Combinatorics, Dynamic Survey DS1",
+      "year": 2021,
+      "url": "https://www.combinatorics.org/ojs/index.php/eljc/article/view/DS1",
+      "note": "Standard reference tabulating known small Ramsey numbers and their extremal colorings, including R(4,3)=9."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `ramsey-r4k-oq-02` (0 prior passes, quality 18). The entry previously had only a meta.json with overview; this adds the missing depth.

## Changes
- **annotations.json (new):** 7 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering the circular difference `cdiff`, the Wagner-graph coloring `wagnerColor`, the symmetry/irreflexivity well-formedness lemmas, both `decide` clique-freeness decisions (α(V₈)=3 ⟹ no red K₄; triangle-free ⟹ no blue K₃), and the two lower-bound theorems.
- **sections:** 5 sections covering the full 107-line Lean file.
- **conclusion:** summary + 4 implications + 4 open questions (matching exact upper bound R(4,3) ≤ 9, scaling to R(4,4)/R(4,5), uniform parameterized formalization, witness uniqueness).
- **crossReferences:** parent `ramsey-r4k`, sibling `ramsey-r4k-oq-01`, `ramseys-theorem`, and `ramsey-r4k-extensions-oq-01`.
- **references:** Greenwood–Gleason (1955), Erdős–Szekeres (1935), Wagner (1937), Radziszowski's *Small Ramsey Numbers* survey.
- **keyInsights:** +1 on the circulant/Cayley-graph structure (now 5).

## Size / guardrails
meta.json is **14.5 KB**, well under the 60 KB cap; all collections under their caps (keyInsights 5/12, crossRefs 4/20, refs 4/25, openQuestions 4/15).

## Axiom integrity
Verified `status: verified`, `badge: verified`, `axiomCount: 0` are accurate: both clique-freeness lemmas use `decide` (kernel-checked), **not** `native_decide`, so `#print axioms r43_lower` lists only propext/Classical.choice/Quot.sound — no `Lean.ofReduceBool`. No structure-encoded assumptions.

## Validation
`pnpm gallery:check-size` and `pnpm annotations:build` passed (JSON structure validated); both files also confirmed via `json.load`. The full `pnpm build` couldn't reach `tsc`/`vite` in this worktree (no local node_modules — environmental, unrelated to these data-only changes).