### PR TITLE
research(cauchy-schwarz-oq-01-oq-03-oq-02): equality case of the maximum-entropy bound

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean
@@ -19,6 +19,9 @@
   nonnegativity, and the **maximum-entropy bound** `H(p) ≤ log n` (Jensen on the concavity
   of `negMulLog`; equality at the uniform distribution). This is the "entropy half" of an
   entropic uncertainty relation, and a reusable building block for the eventual proof.
+
+  This revision adds the **equality case** of the maximum-entropy bound:
+  `H(p) = log n ↔ p` uniform, the strict-concavity refinement of the Jensen inequality.
 -/
 
 import Mathlib
@@ -87,5 +90,63 @@ theorem shannonEntropy_uniform [Nonempty ι] :
   simp only [shannonEntropy, Real.negMulLog, Real.log_inv, Finset.sum_const,
     Finset.card_univ, ← hn, nsmul_eq_mul]
   field_simp
+
+/-- **Equality case of the maximum-entropy bound.** For a probability vector on
+`n = card ι` outcomes, `H(p) = log n` *if and only if* `p` is the uniform distribution.
+
+The reverse implication is `shannonEntropy_uniform`. The forward implication is the
+strict-concavity (uniqueness) refinement of Jensen's inequality: because `negMulLog` is
+*strictly* concave on `[0,∞)`, equality in the maximum-entropy bound forces all the
+weighted points to coincide (`Real.strictConcaveOn_negMulLog.eq_of_map_sum_eq`), and the
+normalization `∑ pᵢ = 1` then pins each entry to `1/n`. This upgrades the inequality
+`shannonEntropy_le_log_card` to a full characterization of the maximizer (and, with it,
+the equality case in any entropic uncertainty relation built on this infrastructure). -/
+theorem shannonEntropy_eq_log_card_iff [Nonempty ι] {p : ι → ℝ}
+    (h0 : ∀ i, 0 ≤ p i) (hsum : ∑ i, p i = 1) :
+    shannonEntropy p = Real.log (Fintype.card ι)
+      ↔ ∀ i, p i = (Fintype.card ι : ℝ)⁻¹ := by
+  set n : ℕ := Fintype.card ι with hn
+  have hnpos : 0 < n := Fintype.card_pos
+  have hnR : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hnpos
+  constructor
+  · intro hH
+    -- Uniform weights `1/n` sum to `1`.
+    have hwsum : (∑ _i : ι, ((n : ℝ)⁻¹)) = 1 := by
+      rw [Finset.sum_const, Finset.card_univ, ← hn, nsmul_eq_mul]
+      field_simp
+    -- The weighted mean of `p` is `1/n` (since `∑ pᵢ = 1`).
+    have hmean : (∑ i : ι, ((n : ℝ)⁻¹) • p i) = (n : ℝ)⁻¹ := by
+      simp only [smul_eq_mul, ← Finset.mul_sum, hsum, mul_one]
+    -- `negMulLog (1/n) = (1/n) * log n`.
+    have hval : Real.negMulLog ((n : ℝ)⁻¹) = (n : ℝ)⁻¹ * Real.log n := by
+      rw [Real.negMulLog, Real.log_inv]; ring
+    -- Equality in Jensen: `negMulLog(mean) = ∑ (1/n)·negMulLog(pᵢ)`.
+    have h_eq : Real.negMulLog (∑ i : ι, ((n : ℝ)⁻¹) • p i)
+        = ∑ i : ι, ((n : ℝ)⁻¹) • Real.negMulLog (p i) := by
+      have hlhs : (∑ i : ι, ((n : ℝ)⁻¹) • Real.negMulLog (p i))
+          = (n : ℝ)⁻¹ * shannonEntropy p := by
+        simp only [smul_eq_mul, shannonEntropy, Finset.mul_sum]
+      rw [hmean, hval, hlhs, hH]
+    -- Strict concavity ⇒ all entries of `p` are equal.
+    have hall : ∀ ⦃j⦄, j ∈ (Finset.univ : Finset ι) → ∀ ⦃k⦄,
+        k ∈ (Finset.univ : Finset ι) → p j = p k :=
+      Real.strictConcaveOn_negMulLog.eq_of_map_sum_eq
+        (t := Finset.univ) (w := fun _ => (n : ℝ)⁻¹) (p := p)
+        (fun i _ => by positivity) hwsum
+        (fun i _ => Set.mem_Ici.mpr (h0 i)) h_eq.le
+    -- All entries equal + normalization ⇒ each equals `1/n`.
+    intro i
+    have hconst : ∀ j, p j = p i := fun j =>
+      hall (Finset.mem_univ j) (Finset.mem_univ i)
+    have hni : (n : ℝ) * p i = 1 := by
+      calc (n : ℝ) * p i = ∑ _j : ι, p i := by
+              rw [Finset.sum_const, Finset.card_univ, ← hn, nsmul_eq_mul]
+        _ = ∑ j : ι, p j := Finset.sum_congr rfl (fun j _ => (hconst j).symm)
+        _ = 1 := hsum
+    exact eq_inv_of_mul_eq_one_right hni
+  · intro hp
+    have hpu : p = (fun _ : ι => (Fintype.card ι : ℝ)⁻¹) := funext hp
+    rw [hpu, hn]
+    exact shannonEntropy_uniform
 
 end CauchySchwarzOQ01OQ03OQ02

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-oq-01-oq-03-oq-02",
   "title": "Shannon Entropy: Maximum-Entropy Bound (toward Entropic Uncertainty)",
   "slug": "cauchy-schwarz-oq-01-oq-03-oq-02",
-  "description": "Builds the finite-dimensional Shannon-entropy infrastructure needed for an entropic uncertainty relation: entropy of a probability vector via Mathlib's negMulLog, its nonnegativity, and the maximum-entropy bound H(p) ≤ log n via Jensen's inequality (with equality at the uniform distribution). The full Maassen–Uffink entropic uncertainty principle remains blocked on Mathlib's missing interpolation theory.",
+  "description": "Builds the finite-dimensional Shannon-entropy infrastructure needed for an entropic uncertainty relation: entropy of a probability vector via Mathlib's negMulLog, its nonnegativity, the maximum-entropy bound H(p) ≤ log n via Jensen's inequality, and the equality case H(p) = log n ↔ p uniform via the strict-concavity refinement of Jensen. The full Maassen–Uffink entropic uncertainty principle remains blocked on Mathlib's missing interpolation theory.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -18,9 +18,9 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 91,
-    "assumptions": "Uses Mathlib's Real.negMulLog (Shannon entropy term) with its concavity (concaveOn_negMulLog) and the finite Jensen inequality (ConcaveOn.le_map_sum). No additional axioms or assumptions.",
-    "theoremCount": 3,
+    "lineCount": 152,
+    "assumptions": "Uses Mathlib's Real.negMulLog (Shannon entropy term) with its concavity (concaveOn_negMulLog), strict concavity (strictConcaveOn_negMulLog), the finite Jensen inequality (ConcaveOn.le_map_sum), and its equality case (StrictConcaveOn.eq_of_map_sum_eq). No additional axioms or assumptions.",
+    "theoremCount": 4,
     "mathlib_version": "4.26.0",
     "definitionCount": 1
   },
@@ -32,7 +32,8 @@
       "The maximum-entropy bound H(p) ≤ log n is precisely the concavity of negMulLog plus Jensen with uniform weights — no information-theoretic machinery beyond Mathlib's Real.negMulLog is required.",
       "This is the 'entropy ceiling' that bounds either marginal in an entropic uncertainty relation; the genuinely hard content of Maassen–Uffink is the lower bound on the sum H(p) + H(q).",
       "The sharp Maassen–Uffink constant -2 ln c follows from the Hausdorff–Young inequality (a (2→∞) operator-norm / Riesz–Thorin interpolation argument), which Mathlib v4.26.0 does not yet provide — making the full theorem genuinely blocked rather than merely unattempted.",
-      "Deutsch's interpolation-free precursor H(p) + H(q) ≥ -2 ln((1+c)/2) is the natural next target once finite-dimensional entropy infrastructure (this entry) is in place."
+      "Deutsch's interpolation-free precursor H(p) + H(q) ≥ -2 ln((1+c)/2) is the natural next target once finite-dimensional entropy infrastructure (this entry) is in place.",
+      "The maximizer is unique: H(p) = log n forces p to be the uniform distribution. This is the equality case of Jensen for the strictly concave negMulLog (StrictConcaveOn.eq_of_map_sum_eq) — strict concavity collapses the inequality to an equality only when all sampled points coincide, and ∑ pᵢ = 1 then pins each entry to 1/n."
     ]
   },
   "sections": [
@@ -67,26 +68,32 @@
     {
       "id": "uniform",
       "title": "Uniform Distribution Attains the Bound",
-      "startLine": 82,
-      "endLine": 91,
+      "startLine": 84,
+      "endLine": 92,
       "summary": "The uniform distribution has entropy exactly log n, confirming the bound is sharp."
+    },
+    {
+      "id": "equality",
+      "title": "Equality Case: the Maximizer is Unique",
+      "startLine": 94,
+      "endLine": 151,
+      "summary": "H(p) = log n ↔ p is uniform. The forward direction is the strict-concavity refinement of Jensen (StrictConcaveOn.eq_of_map_sum_eq): equality forces all sampled points to coincide, and ∑ pᵢ = 1 pins each entry to 1/n; the reverse is shannonEntropy_uniform."
     }
   ],
   "conclusion": {
-    "summary": "The finite-dimensional Shannon-entropy framework and the maximum-entropy bound H(p) ≤ log n are formalized and fully machine-checked (0 axioms, 0 sorries), built directly on Mathlib's negMulLog concavity and Jensen's inequality. This is the provable entropy half of an entropic uncertainty relation.",
-    "implications": "Provides reusable infrastructure for any future formalization of the entropic uncertainty principle. The full Maassen–Uffink bound is documented as blocked on Mathlib's absent interpolation theory (Hausdorff–Young / Riesz–Thorin); Deutsch's interpolation-free bound is the recommended next step once this infrastructure is extended.",
+    "summary": "The finite-dimensional Shannon-entropy framework, the maximum-entropy bound H(p) ≤ log n, and its equality case (H(p) = log n ↔ p uniform) are formalized and fully machine-checked (0 axioms, 0 sorries), built directly on Mathlib's negMulLog concavity / strict concavity and the Jensen inequality with its equality case. This is the provable entropy half of an entropic uncertainty relation, now including a full characterization of the maximizer.",
+    "implications": "Provides reusable infrastructure for any future formalization of the entropic uncertainty principle. The equality case identifies the unique maximizer, which is the equality condition for either marginal of an eventual entropic uncertainty relation. The full Maassen–Uffink bound is documented as blocked on Mathlib's absent interpolation theory (Hausdorff–Young / Riesz–Thorin); Deutsch's interpolation-free bound is the recommended next step once this infrastructure is extended.",
     "openQuestions": [
       "Can Deutsch's entropic uncertainty bound H(p) + H(q) ≥ -2 ln((1+c)/2) — which avoids interpolation — be formalized on top of this entropy infrastructure?",
-      "Formalize the equality case of the maximum-entropy bound: prove that H(p) = log n forces p to be the uniform distribution (strict concavity of negMulLog), upgrading the ≤ to a characterization.",
       "Once Mathlib gains Riesz–Thorin / Hausdorff–Young interpolation, complete the sharp Maassen–Uffink constant -2 ln c, closing the parent's full open question.",
       "Relate this entropic ceiling to the parent's variance-based Robertson/Heisenberg bound: derive the qubit (n=2) entropic uncertainty relation explicitly and compare its strength to the variance product bound."
     ]
   },
   "leanFile": {
     "namespace": "CauchySchwarzOQ01OQ03OQ02",
-    "lineCount": 91,
+    "lineCount": 152,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 1,
     "path": "Proofs/CauchySchwarzOQ01OQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the verified Shannon-entropy entry `cauchy-schwarz-oq-01-oq-03-oq-02` with the **equality case** of the maximum-entropy bound — the strict-concavity refinement of Jensen's inequality:

```
H(p) = log n  ↔  p is the uniform distribution
```

This was the top open question listed in the entry's own conclusion ("prove that H(p) = log n forces p to be the uniform distribution"). It upgrades the existing inequality `shannonEntropy_le_log_card` (`H(p) ≤ log n`) to a full characterization of the maximizer.

## What's new

- `shannonEntropy_eq_log_card_iff` — `H(p) = log n ↔ ∀ i, p i = (card ι)⁻¹` for a probability vector (`∀ i, 0 ≤ p i`, `∑ p i = 1`).

## Proof

- **Forward**: `Real.negMulLog` is *strictly* concave on `[0,∞)` (`Real.strictConcaveOn_negMulLog`). Equality in the Jensen step therefore forces all the weighted sample points to coincide — Mathlib's `StrictConcaveOn.eq_of_map_sum_eq` with uniform weights `1/n`. The normalization `∑ pᵢ = 1` then pins each entry to `1/n`.
- **Reverse**: the existing `shannonEntropy_uniform`.

## Verification

- Compiles clean against Mathlib v4.26.0 (Lean `leanprover/lean4:v4.26.0`).
- `#print axioms shannonEntropy_eq_log_card_iff` → `[propext, Classical.choice, Quot.sound]` only. **0 axioms** (no `sorryAx`, no `Lean.ofReduceBool`), `status: verified`.
- Gallery `meta.json` updated: theoremCount 3→4, lineCount 91→152, new `equality` section, key insight, refreshed open questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)