### PR TITLE
Enrich Hyperoctahedral Contribution Formula (four-square-distribution-oq-07)

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-07/annotations.json
+++ b/src/data/proofs/four-square-distribution-oq-07/annotations.json
@@ -6,42 +6,75 @@
     "type": "concept",
     "title": "Type Contributions for Sums of 2k Squares, via Orbit-Stabilizer",
     "content": "A representation type of n as a sum of d squares is the sorted multiset of absolute values |aᵢ|. The signed-permutation (hyperoctahedral) group B_d = S_d ⋉ (ℤ/2)^d acts on the d-tuples, and the number of representations sharing a type is the size of its orbit. This file proves the orbit size is 2^z · d!/∏(m v)! for every dimension d, where z is the number of nonzero coordinates and m the multiplicities — confirming the parent entry's prediction for sums of 2k squares. Everything is machine-checked with 0 axioms; concrete values use `decide`, not `native_decide`.",
-    "summary": "The type-contribution formula 2^z · d!/∏ mᵢ! as a B_d orbit, proved for all dimensions."
+    "summary": "The type-contribution formula 2^z · d!/∏ mᵢ! as a B_d orbit, proved for all dimensions.",
+    "mathContext": "$|\\mathrm{orbit}(\\text{type})| = \\dfrac{|B_d|}{|\\mathrm{Stab}|} = \\dfrac{2^d\\, d!}{2^{d-z}\\prod_v (m_v)!} = 2^z\\,\\dfrac{d!}{\\prod_v (m_v)!} = 2^z\\binom{d}{m}$, the multinomial scaled by the sign freedom on the $z$ nonzero coordinates.",
+    "significance": "key",
+    "relatedConcepts": ["orbit-stabilizer theorem", "hyperoctahedral group B_d", "signed permutations", "Jacobi four-square theorem", "representation type", "group action orbit"],
+    "prerequisites": ["group actions", "orbit-stabilizer theorem", "sums of squares", "multinomial coefficients"]
   },
   {
     "id": "ann-fsq-oq07-orders",
     "proofId": "four-square-distribution-oq-07",
-    "range": { "startLine": 65, "endLine": 79 },
+    "range": { "startLine": 64, "endLine": 79 },
     "type": "definition",
     "title": "Group Order, Stabilizer Order, Contribution",
-    "content": "hyperoctahedralOrder d = 2^d · d! is |B_d|: each of the d coordinates may flip sign (2^d), then the coordinates are permuted (d!). stabilizerOrder fixes a type: sign flips are free only on the d − z zero coordinates (2^(d−z)), and equal absolute values may be permuted within their blocks (∏(m v)!). contribution = 2^z · multinomial is the orbit size to be derived.",
-    "summary": "|B_d| = 2^d·d!, stabilizer = 2^(d−z)·∏(m v)!, contribution = 2^z·multinomial."
+    "content": "hyperoctahedralOrder d = 2^d · d! is |B_d|: each of the d coordinates may flip sign (2^d), then the coordinates are permuted (d!). stabilizerOrder fixes a type: sign flips are free only on the d − z zero coordinates (2^(d−z)), and equal absolute values may be permuted within their blocks (∏(m v)!). contribution = 2^z · multinomial is the orbit size to be derived. Encoding these as three separate `def`s lets the central identity be stated as a clean equation between them.",
+    "summary": "|B_d| = 2^d·d!, stabilizer = 2^(d−z)·∏(m v)!, contribution = 2^z·multinomial.",
+    "mathContext": "$|B_d| = 2^d\\, d!$; $\\ |\\mathrm{Stab}| = 2^{d-z}\\prod_{v\\in s}(m_v)!$; $\\ \\mathrm{contribution} = 2^z\\cdot\\mathrm{multinomial}(s,m) = 2^z\\dfrac{(\\sum_v m_v)!}{\\prod_v (m_v)!}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["wreath product S_d ≀ ℤ/2", "stabilizer subgroup", "Young subgroup", "multinomial coefficient", "factorial"],
+    "prerequisites": ["semidirect product", "stabilizer subgroups", "Finset products in Lean"]
   },
   {
     "id": "ann-fsq-oq07-orbit-stabilizer",
     "proofId": "four-square-distribution-oq-07",
-    "range": { "startLine": 88, "endLine": 110 },
+    "range": { "startLine": 84, "endLine": 104 },
     "type": "insight",
     "title": "The Orbit-Stabilizer Identity contribution · stabilizer = 2^d · d!",
-    "content": "The decisive theorem: contribution · stabilizerOrder = 2^d · d! for every dimension d and every multiplicity function summing to d. The proof regroups 2^z · 2^(d−z) = 2^d (via Nat.add_sub_cancel' since z ≤ d) and uses Nat.multinomial_spec, which says (∏(m v)!) · multinomial = (∑ m v)! = d!. No division is needed and there is no native_decide, so the identity is symbolic and axiom-free for all dimensions at once.",
-    "summary": "contribution · stabilizer = 2^d · d!, from Nat.multinomial_spec and 2^z·2^(d−z) = 2^d."
+    "content": "The decisive theorem: contribution · stabilizerOrder = 2^d · d! for every dimension d and every multiplicity function summing to d. The proof regroups 2^z · 2^(d−z) = 2^d (via Nat.add_sub_cancel' since z ≤ d) and uses Nat.multinomial_spec, which says (∏(m v)!) · multinomial = (∑ m v)! = d!. No division is needed and there is no native_decide, so the identity is symbolic and axiom-free for all dimensions at once. The `calc` block makes the three rewrites explicit: `ring` regroups the powers and factorials, `pow_add` + `add_sub_cancel'` collapses the sign factors, and `multinomial_spec` discharges the multinomial.",
+    "summary": "contribution · stabilizer = 2^d · d!, from Nat.multinomial_spec and 2^z·2^(d−z) = 2^d.",
+    "mathContext": "$\\underbrace{(2^z\\,\\mathrm{multinomial})}_{\\mathrm{contribution}}\\cdot\\underbrace{(2^{d-z}\\textstyle\\prod (m_v)!)}_{\\mathrm{stabilizer}} = 2^z 2^{d-z}\\cdot\\Big(\\textstyle\\prod (m_v)!\\cdot\\mathrm{multinomial}\\Big) = 2^d\\cdot d!$ using $2^z 2^{d-z}=2^d$ (since $z\\le d$) and $\\prod(m_v)!\\cdot\\mathrm{multinomial}=(\\sum m_v)!=d!$.",
+    "significance": "key",
+    "relatedConcepts": ["orbit-stabilizer theorem", "multinomial theorem", "Nat.multinomial_spec", "Lagrange's theorem", "exponent arithmetic"],
+    "prerequisites": ["orbit-stabilizer theorem", "multinomial identity", "Lean calc and ring tactics"]
+  },
+  {
+    "id": "ann-fsq-oq07-div-quotient",
+    "proofId": "four-square-distribution-oq-07",
+    "range": { "startLine": 106, "endLine": 124 },
+    "type": "technique",
+    "title": "Divisibility and the Quotient Form of the Contribution",
+    "content": "Two corollaries package the multiplicative identity in the shapes a reader expects from Lagrange/orbit-stabilizer. `stabilizerOrder_dvd_order` exhibits the contribution itself as the cofactor, so stab ∣ |B_d| — orbits have integer size. `contribution_eq_order_div_stabilizer` then rewrites contribution = |B_d| / |stab| using `Nat.div_eq_iff_eq_mul_left`, which is valid precisely because the stabilizer order is positive (a product of a power of two and nonzero factorials) and divides the group order. Doing it this way keeps the development inside ℕ with no truncated division.",
+    "summary": "stab ∣ |B_d| via the contribution as cofactor; contribution = |B_d|/|stab| over ℕ with no truncation.",
+    "mathContext": "$|\\mathrm{Stab}| \\mid |B_d|$ with cofactor exactly $\\mathrm{contribution}$, hence $\\mathrm{contribution} = |B_d| / |\\mathrm{Stab}|$. Natural-number division is exact here because $|\\mathrm{Stab}| = 2^{d-z}\\prod(m_v)! > 0$ divides $|B_d|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lagrange's theorem", "divisibility in ℕ", "exact division", "cofactor"],
+    "prerequisites": ["natural-number division", "divisibility", "Nat.div_eq_iff_eq_mul_left"]
   },
   {
     "id": "ann-fsq-oq07-nonzero",
     "proofId": "four-square-distribution-oq-07",
-    "range": { "startLine": 131, "endLine": 138 },
+    "range": { "startLine": 130, "endLine": 138 },
     "type": "insight",
     "title": "The Nonzero-Coordinate Count z = d − m 0",
-    "content": "In the sum-of-squares reading, m 0 is the multiplicity of the value 0, and the nonzero coordinates number z = d − m 0. Equivalently m 0 + z = d (proved via Finset.sum_erase_add), so the stabilizer's sign-flip factor 2^(d−z) = 2^(m 0) counts exactly the sign freedom on the zero coordinates — flipping a 0 changes nothing.",
-    "summary": "z = d − m 0; the 2^(d−z) sign factor is the freedom on the zero coordinates."
+    "content": "In the sum-of-squares reading, m 0 is the multiplicity of the value 0, and the nonzero coordinates number z = d − m 0. Equivalently m 0 + z = d (proved via Finset.sum_erase_add), so the stabilizer's sign-flip factor 2^(d−z) = 2^(m 0) counts exactly the sign freedom on the zero coordinates — flipping a 0 changes nothing. This is the bridge that ties the abstract parameter z to the concrete arithmetic of which coordinates of a representation are actually zero.",
+    "summary": "z = d − m 0; the 2^(d−z) sign factor is the freedom on the zero coordinates.",
+    "mathContext": "$z = d - m_0$, equivalently $m_0 + \\sum_{v\\in s\\setminus\\{0\\}} m_v = d$. Then $2^{d-z} = 2^{m_0}$: a sign flip on a coordinate equal to $0$ is the identity, so those $m_0$ flips stabilize the type.",
+    "significance": "key",
+    "relatedConcepts": ["sums of squares", "sign symmetry of zero", "Finset.sum_erase_add", "stabilizer factorization"],
+    "prerequisites": ["Finset sums", "multiplicity functions"]
   },
   {
     "id": "ann-fsq-oq07-instances",
     "proofId": "four-square-distribution-oq-07",
-    "range": { "startLine": 146, "endLine": 182 },
+    "range": { "startLine": 143, "endLine": 181 },
     "type": "example",
     "title": "d = 4 (Jacobi) and the d = 8 Generalization",
-    "content": "Instantiating the general formula: the four-square type (0,0,0,1) has z=1 and contribution 8, while an all-distinct type (a,b,c,d) has z=4 and the maximal contribution 384 = |B₄|. For eight squares the group order is 2^8·8! = 10321920, and the type (0,…,0,1) contributes 16 with 16·645120 = |B₈| — exactly the parent entry's predicted B₈ data. All concrete numbers are checked by `decide` (kernel reduction), so no Lean.ofReduceBool enters.",
-    "summary": "Verified instances: 8 and 384 for four squares; order 10321920 and contribution 16 for eight squares."
+    "content": "Instantiating the general formula via the helper `twoValueMult` (a two-value type {0, w} with a zeros and b copies of w): the four-square type (0,0,0,1) has z=1 and contribution 8, while an all-distinct type (a,b,c,d) has z=4 and the maximal contribution 384 = |B₄|. For eight squares the group order is 2^8·8! = 10321920, and the type (0,…,0,1) contributes 16 with 16·645120 = |B₈| — exactly the parent entry's predicted B₈ data. All concrete numbers are checked by `decide` (kernel reduction), so no Lean.ofReduceBool enters; the orbit-stabilizer half of each `∧` is closed by specializing the general theorem rather than recomputing.",
+    "summary": "Verified instances: 8 and 384 for four squares; order 10321920 and contribution 16 for eight squares.",
+    "mathContext": "Four squares: $(0,0,0,1)\\to 2^1\\binom{4}{3,1}=2\\cdot 4=8$; all-distinct $\\to 2^4\\binom{4}{1,1,1,1}=16\\cdot 24=384=|B_4|$. Eight squares: $|B_8|=2^8\\,8!=10321920$, and $(0^7,1)\\to 2^1\\binom{8}{7,1}=2\\cdot 8=16$ with $16\\cdot 645120=|B_8|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Jacobi four-square theorem", "decide vs native_decide", "kernel reduction", "eight-square (Jacobi) formula", "representation count r_d(n)"],
+    "prerequisites": ["decide tactic", "evaluating multinomials", "sums of squares representations"]
   }
 ]

--- a/src/data/proofs/four-square-distribution-oq-07/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-07/meta.json
@@ -139,6 +139,34 @@
       "targetId": "four-square-distribution-oq-06"
     }
   ],
+  "references": [
+    {
+      "authors": ["C. G. J. Jacobi"],
+      "title": "Fundamenta nova theoriae functionum ellipticarum",
+      "year": 1829,
+      "note": "Origin of the four-square formula r₄(n) = 8·Σ_{4∤d|n} d (1834 in published form), the d = 4 base case generalized here to sums of 2k squares."
+    },
+    {
+      "authors": ["M. Bhargava", "J. Hanke"],
+      "title": "Universal quaternary quadratic forms and the 290-theorem",
+      "year": 2005,
+      "note": "Broader quaternary-form context for the open question on extending the hyperoctahedral symmetry beyond x²+y²+z²+w², where the symmetry group is no longer the full B_d."
+    },
+    {
+      "authors": ["G. E. Andrews", "R. Askey", "R. Roy"],
+      "title": "Special Functions",
+      "venue": "Cambridge University Press, Encyclopedia of Mathematics and its Applications 71",
+      "year": 1999,
+      "note": "Standard reference for sums-of-squares representation functions r_k(n) and the underlying theta-function identities (Jacobi, Liouville, Glaisher)."
+    },
+    {
+      "authors": ["N. Bourbaki"],
+      "title": "Groupes et algèbres de Lie, Chapitres 4–6 (Coxeter group B_d / type C_d)",
+      "venue": "Hermann / Springer",
+      "year": 1968,
+      "note": "Structure of the hyperoctahedral group B_d = S_d ⋉ (ℤ/2)^d as the Weyl group of type B_d/C_d, the symmetry group acting on the d signed coordinates."
+    }
+  ],
   "sorries": 0,
   "leanFile": {
     "imports": [


### PR DESCRIPTION
Enrichment pass for `four-square-distribution-oq-07` (0 prior passes, quality 66). The entry already had a rich meta.json (overview, sections, conclusion, cross-references) and 5 annotations, but the annotations were missing the depth fields the gallery uses, and meta.json had no bibliography.

## Changes
- **annotations.json:** added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all annotations (previously `content` + `summary` only). The math contexts spell out the orbit-stabilizer arithmetic — e.g. $2^z 2^{d-z}=2^d$ and $\prod(m_v)!\cdot\mathrm{multinomial}=d!$ — and the concrete $d=4,8$ evaluations.
- **New annotation** covering the divisibility / quotient-form theorems (`stabilizerOrder_dvd_order`, `contribution_eq_order_div_stabilizer`) at lines 106–124, which previously had no coverage.
- **meta.json references (new):** Jacobi (1829), Bhargava–Hanke 290-theorem (2005), Andrews–Askey–Roy *Special Functions*, Bourbaki on the type-B Weyl group.

## Size / guardrails
meta.json is **12.2 KB**, well under the 60 KB cap; keyInsights 4/12, crossRefs 2/20, references 4/25 — all under caps. No existing content removed.

## Axiom integrity
Confirmed `status: verified`, `badge: original`, `axiomCount: 0` are accurate: the file uses `decide` (kernel-checked), not `native_decide`, and the general theorems depend only on propext/Classical.choice/Quot.sound. No structure-encoded assumptions.

## Validation
`scripts/gallery/check-meta-size.ts` passes; `scripts/annotations/build.ts` reports **0 errors for this entry** (annotation line ranges align with Lean constructs); JSON confirmed via `json.load`. Full `pnpm build` not runnable in this worktree (no local node_modules — environmental, unrelated to these data-only changes).