### PR TITLE
Enrich Row-sum fractal dimension (lucas-theorem-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/lucas-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lucas-theorem-oq-01-oq-01-oq-01/meta.json
@@ -15,7 +15,15 @@
     "sorries": 0
   },
   "overview": {
-    "text": "Fine's theorem gives a per-row count of binomial coefficients not divisible by p as a product over base-p digits. Because the count is built from a multiplicative recursion in the row index, summing it over a full base-p block telescopes: each of the m digit positions contributes an independent factor ∑_{d<p}(d+1) = p(p+1)/2, so the block total is (p(p+1)/2)ᵐ. The formalization routes this through the recursion fineCount p (p·j+r) = (r+1)·fineCount p j rather than the digit-product form, partitioning the block by the last base-p digit and inducting on the number of digits m."
+    "text": "Fine's theorem gives a per-row count of binomial coefficients not divisible by p as a product over base-p digits. Because the count is built from a multiplicative recursion in the row index, summing it over a full base-p block telescopes: each of the m digit positions contributes an independent factor ∑_{d<p}(d+1) = p(p+1)/2, so the block total is (p(p+1)/2)ᵐ. The formalization routes this through the recursion fineCount p (p·j+r) = (r+1)·fineCount p j rather than the digit-product form, partitioning the block by the last base-p digit and inducting on the number of digits m.",
+    "keyInsights": [
+      "**Summation linearises the digit product.** Fine's per-row count is a product over base-p digits ∏(nᵢ+1), but summing it over a full pᵐ-block makes the digit positions independent, so the multiplicative-over-digits structure becomes a clean product of m identical per-digit factors (p(p+1)/2)ᵐ — a discrete Fubini over base-p expansions.",
+      "**The recursion, not the digit-product form, is the right engine.** Routing the proof through fineCount p (p·j+r) = (r+1)·fineCount p j (partition by last digit) rather than the closed digit product turns the whole argument into a single induction on the digit count m, avoiding any manipulation of variable-length base-p expansions.",
+      "**The per-digit factor is exactly Gauss's triangular number.** Summing the recursion's (r+1) over the last digit r < p yields ∑_{r<p}(r+1) = p(p+1)/2 — the same 1+2+⋯+p Gauss summed as a schoolboy. Its appearance per digit is what produces the m-th power.",
+      "**A division-free doubled identity dodges ℕ-truncation.** Because p(p+1)/2 involves natural-number division, the triangular sum is proved first in doubled form 2·∑(r+1) = p(p+1) (a pure polynomial identity closed by ring/induction) and then halved by omega — a robust pattern for division-laden ℕ identities.",
+      "**The growth rate is a fractal dimension.** The block total (p(p+1)/2)ᵐ over pᵐ rows has exponential rate log_p(p(p+1)/2), the box-counting dimension of the self-similar mod-p Pascal triangle; at p = 2 this is the Sierpiński total 3ᵐ and dimension log₂3 ≈ 1.585.",
+      "**The block-reindexing lemma is reusable infrastructure.** sum_range_mul_split (∑_{n<pM} f n = ∑_{j<M}∑_{r<p} f(pj+r)) is proved for an arbitrary f, decoupled from the binomial content, so it serves any base-p block computation, not just this one."
+    ]
   },
   "meta": {
     "author": "Classical (consequence of Fine 1947; the row-sum/box-dimension reading is folklore in the study of Pascal's triangle mod p). Lean formalization original",


### PR DESCRIPTION
Enrichment pass for `lucas-theorem-oq-01-oq-01-oq-01` (0 prior passes, quality 78). This entry is already excellent — rich meta, 6 annotations all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites` and full coverage, sections, cross-references, references, and a conclusion with 2 open questions. The single structural gap was that `overview` carried only a `text` blob and **no `keyInsights` array** (the quality bar asks for 4–12).

## Changes (meta.json only)
Added a **6-item `overview.keyInsights`** surfacing insights currently buried in prose, each tied to the actual proof:
1. summation linearises Fine's digit product — a discrete Fubini over base-p expansions giving $(p(p+1)/2)^m$;
2. why the multiplicative recursion $\mathrm{fineCount}\,p\,(pj+r)=(r+1)\,\mathrm{fineCount}\,p\,j$ (not the digit-product form) is the right engine — collapses to one induction on the digit count;
3. the per-digit factor as Gauss's triangular number $p(p+1)/2$;
4. the division-free doubled-identity trick $2\sum(r+1)=p(p+1)$ to dodge ℕ-truncation;
5. the growth rate $\log_p(p(p+1)/2)$ as the box-counting fractal dimension (Sierpiński $\log_2 3$ at $p=2$);
6. `sum_range_mul_split` as reusable base-p block infrastructure.

## Size / guardrails
meta.json **13.6 KB**, well under the 60 KB cap; keyInsights 6/12, openQuestions 2/15, crossRefs 2/20, refs 2/25. No existing content removed; annotations unchanged (already complete).

## Validation
`scripts/gallery/check-meta-size.ts` passes; JSON confirmed via `json.load`. Full `pnpm build` not runnable in this worktree (no local node_modules — environmental, unrelated to these data-only changes).