### PR TITLE
research(puiseux-theorem-oq-03): slope×width=drop — couple valuation & multiplicity halves [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -586,4 +586,99 @@ theorem threeVertex_sum_widths : (edgeWidths threeVertex).sum = 3 := by
 theorem threeVertex_widths_pos : ∀ w ∈ edgeWidths threeVertex, 0 < w :=
   edgeWidths_pos threeVertex_chain
 
+/-! ### Slope × width = vertical drop (the "product of roots" bookkeeping)
+
+The two halves built above run in parallel but never meet: `edgeSlopes` carries
+the root **valuations** (sorted, `edgeSlopes_pairwise_le`) and `edgeWidths` carries
+the root **multiplicities** (telescoping to the degree, `sum_edgeWidths_eq_degree`).
+This section couples them.  For each edge, `edgeSlope p q · (width p q)` collapses
+to the **vertical drop** `q.2 − p.2`, and summing along a chain telescopes to the
+total drop `(last).2 − (first).2`.
+
+In Newton–Puiseux terms this is the *multiplicative* counterpart of the
+degree-counting identity.  Each edge contributes `width` roots of valuation
+`−slope`, so `slope · width` is the total valuation those roots carry, and the
+sum over all edges is `Σ (valuationᵢ · multiplicityᵢ)` — the valuation of the
+product of all roots, i.e. `v(constant term) − v(leading term)` read straight off
+the endpoints of the polygon.  Where `sum_edgeWidths_eq_degree` says *how many*
+roots there are, this says *what their valuations sum to with multiplicity*. -/
+
+/-- **Per-edge slope × width identity.**  The edge slope times the horizontal
+width recovers the vertical drop, because the width is exactly the denominator of
+the slope.  Requires distinct indices so the width is nonzero. -/
+theorem edgeSlope_mul_width {p q : SupportPoint} (hne : p.1 ≠ q.1) :
+    edgeSlope p q * ((q.1 : ℚ) - (p.1 : ℚ)) = q.2 - p.2 := by
+  have hd : (q.1 : ℚ) - (p.1 : ℚ) ≠ 0 :=
+    sub_ne_zero.mpr fun h => hne (Nat.cast_injective h).symm
+  rw [edgeSlope, div_mul_cancel₀ _ hd]
+
+/-- The list of vertical drops along a chain of support points: the rise
+`q.2 − p.2` of each consecutive pair.  `edgeDrops [v₀, …, vₙ]
+= [v₁.2 − v₀.2, …, vₙ.2 − vₙ₋₁.2]`. -/
+def edgeDrops : List SupportPoint → List ℚ
+  | p :: q :: rest => (q.2 - p.2) :: edgeDrops (q :: rest)
+  | _ => []
+
+/-- **Telescoping drop identity.**  The vertical drops along any vertex chain sum
+to the total drop from the first vertex to the last.  Same telescoping induction as
+`sum_edgeWidths`, with the `y`-coordinate in place of the `x`-coordinate. -/
+theorem sum_edgeDrops : ∀ (v : SupportPoint) (vs : List SupportPoint),
+    (edgeDrops (v :: vs)).sum = ((v :: vs).getLast (by simp)).2 - v.2
+  | _, [] => by simp [edgeDrops]
+  | v, w :: ws => by
+      have ih := sum_edgeDrops w ws
+      have hgl : (v :: w :: ws).getLast (by simp) = (w :: ws).getLast (by simp) :=
+        List.getLast_cons (by simp)
+      simp only [edgeDrops, List.sum_cons]
+      rw [ih, hgl]
+      ring
+
+/-- **The slope list and width list zip to the drop list.**  Along a chain of
+lower edges (so every edge has distinct indices), the elementwise product of the
+edge slopes and edge widths is exactly the list of vertical drops.  This is the
+list-level statement that couples the valuation data to the multiplicity data. -/
+theorem zipWith_edgeSlopes_edgeWidths {pts : List SupportPoint} :
+    ∀ {vs : List SupportPoint}, List.IsChain (IsLowerEdge pts) vs →
+      List.zipWith (· * ·) (edgeSlopes vs) (edgeWidths vs) = edgeDrops vs
+  | [], _ => by simp [edgeSlopes, edgeWidths, edgeDrops]
+  | [_], _ => by simp [edgeSlopes, edgeWidths, edgeDrops]
+  | p :: q :: rest, hc => by
+      obtain ⟨hpq, hc'⟩ := List.isChain_cons_cons.mp hc
+      have hne : p.1 ≠ q.1 := by
+        obtain ⟨_, _, hlt, _⟩ := hpq; exact ne_of_lt hlt
+      have ih := zipWith_edgeSlopes_edgeWidths hc'
+      simp only [edgeSlopes, edgeWidths, edgeDrops, List.zipWith_cons_cons]
+      rw [edgeSlope_mul_width hne, ih]
+
+/-- **The capstone bookkeeping identity.**  Along a Newton-polygon vertex chain the
+slope-weighted-by-width sum telescopes to the total vertical drop.  Combining the
+list-level coupling with the drop telescope:
+`Σ (edgeSlopeᵢ · widthᵢ) = (last).2 − (first).2`.  Since each edge slope is the
+negated valuation and each width the multiplicity of its roots, the left side is
+`−Σ(valuationᵢ · multiplicityᵢ)`; the right side is the drop in `y`-coordinate
+across the polygon. -/
+theorem sum_slope_mul_width {pts : List SupportPoint} {v : SupportPoint}
+    {vs : List SupportPoint} (hc : List.IsChain (IsLowerEdge pts) (v :: vs)) :
+    (List.zipWith (· * ·) (edgeSlopes (v :: vs)) (edgeWidths (v :: vs))).sum
+      = ((v :: vs).getLast (by simp)).2 - v.2 := by
+  rw [zipWith_edgeSlopes_edgeWidths hc, sum_edgeDrops]
+
+/-- **Sum of root valuations counted with multiplicity.**  Negating the capstone:
+since each root valuation is `−edgeSlope` and the width is its multiplicity,
+`Σ (valuationᵢ · multiplicityᵢ) = (first).2 − (last).2 = v(constant) − v(leading)`.
+This is the valuation of the product of all the roots, read straight off the two
+endpoints of the polygon. -/
+theorem neg_sum_slope_mul_width {pts : List SupportPoint} {v : SupportPoint}
+    {vs : List SupportPoint} (hc : List.IsChain (IsLowerEdge pts) (v :: vs)) :
+    -(List.zipWith (· * ·) (edgeSlopes (v :: vs)) (edgeWidths (v :: vs))).sum
+      = v.2 - ((v :: vs).getLast (by simp)).2 := by
+  rw [sum_slope_mul_width hc]; ring
+
+/-- The example's slope-weighted-by-width products are `[-2, 1]`, summing to `-1`:
+the total vertical drop from `(0,2)` to `(3,1)`. -/
+theorem threeVertex_sum_slope_mul_width :
+    (List.zipWith (· * ·) (edgeSlopes threeVertex) (edgeWidths threeVertex)).sum = -1 := by
+  rw [threeVertex_edgeSlopes, threeVertex_edgeWidths]
+  norm_num [List.zipWith_cons_cons]
+
 end PuiseuxTheoremOQ03

--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -197,3 +197,55 @@ across the proof-irrelevant nonempty hypothesis; supplying both via `(by simp)`
 keeps the atoms syntactically equal so `ring` closes the telescope. Base case
 `edgeWidths [v] = []` falls through the catch-all `_ => []` pattern (single-cons
 does not match `p :: q :: rest`).
+
+---
+
+## Session 6 (2026-06-27, researcher-1): slope × width = drop (coupling the two halves)
+
+Extended 589→684 lines, +6 theorems, +1 def (all 0 sorries / 0 axioms;
+`#print axioms` on all 6 new results = propext/Classical.choice/Quot.sound only).
+
+Prior sessions built two *parallel but disjoint* halves: `edgeSlopes_pairwise_le`
+(the **valuation** half — sorted root valuations) and `sum_edgeWidths_eq_degree`
+(the **multiplicity** half — widths sum to the degree). They never met. This
+session **couples** them via the slope×width=drop identity.
+
+* `edgeSlope_mul_width` — per-edge: `edgeSlope p q * ((q.1)−(p.1)) = q.2 − p.2`.
+  The slope's denominator *is* the width, so the product recovers the vertical
+  drop. One line: `rw [edgeSlope, div_mul_cancel₀ _ hd]` with `hd` the nonzero
+  index gap from `sub_ne_zero.mpr (Nat.cast_injective ...)`.
+* `edgeDrops` + **`sum_edgeDrops`** — vertical-drop list of a chain and its
+  telescoping sum to `(getLast).2 − v.2`; exact `.2`-analogue of `sum_edgeWidths`
+  (same `List.getLast_cons (by simp)` + `ring` telescope).
+* **`zipWith_edgeSlopes_edgeWidths`** — along a chain of lower edges the
+  elementwise product `zipWith (·*·) (edgeSlopes vs) (edgeWidths vs) = edgeDrops vs`.
+  Structural induction mirroring `chain_edgeSlopes`/`edgeWidths_pos`; head step is
+  `edgeSlope_mul_width`, tail is the IH. `List.zipWith_cons_cons` lines the two
+  recursions up.
+* **`sum_slope_mul_width`** (capstone) — `Σ (edgeSlopeᵢ · widthᵢ) = (last).2 − v.2`,
+  i.e. the slope-weighted-by-width sum telescopes to the total vertical drop.
+  Two-line proof composing the list coupling with `sum_edgeDrops`.
+* **`neg_sum_slope_mul_width`** — `Σ (valuationᵢ · multiplicityᵢ) = v.2 − (last).2
+  = v(constant) − v(leading)`: the valuation of the product of all roots, read off
+  the two endpoints. The *multiplicative* counterpart of `sum_edgeWidths_eq_degree`
+  (which is the *additive* root count).
+* Worked example: `zipWith` products `[-2, 1]`, sum `-1` = drop `(0,2)→(3,1)`.
+
+**Why this matters.** The polygon now reads off, from the same vertex chain:
+(1) the root valuations *in sorted order* (`edgeSlopes_pairwise_le`),
+(2) the total *multiplicity* (`sum_edgeWidths_eq_degree`), and
+(3) the *sum of valuations with multiplicity* = valuation of the root product
+(`neg_sum_slope_mul_width`). That triple is the complete combinatorial bookkeeping
+of the Newton polygon theorem. Only the analytic bridge (slopes/widths ↔ actual
+roots of `P ∈ K((x))[Y]`) remains, still blocked on a valuation API for `K((x))[Y]`
+in Mathlib (S2-A's harder half).
+
+### GOTCHA: concurrent `git reset --hard` on the assigned worktree
+The `.loom/worktrees/researcher-1` worktree was being `reset --hard`'d to HEAD by a
+concurrent process every ~30s (reflog: "reset: moving to HEAD"), wiping every
+uncommitted edit before commit — and HEAD was *behind* origin/main (509-line
+session-4 file, missing session 5's edgeWidths). Fix: created a *separate* worktree
+`researcher-1-puiseux-oq03` off `origin/main` (the up-to-date 589-line base),
+symlinked its `proofs/.lake` → main repo `.lake` for prebuilt oleans, edited +
+committed there. Verify recipe unchanged otherwise:
+`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean`.

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "infrastructure",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All 27 theorems and 7 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
+    "assumptions": "None. All 39 theorems and 8 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
     "originalContributions": [
       "IsLowerVertex: supporting-line characterization of a lower-hull (Newton-polygon) vertex, algorithm-independent",
       "isLowerVertex_of_minimal: the minimum-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -45,12 +45,18 @@
       "edgeSlopes_pairwise_le: GLOBAL CONVEXITY (sorted form) — the edge slopes of a Newton polygon are Pairwise (· ≤ ·): every slope ≤ every LATER slope, not merely the next one (IsChain upgraded to Pairwise via transitivity of ≤ on ℚ)",
       "rootValuations_pairwise_ge: consequently the negated edge slopes (the root valuations) of the whole polygon are Pairwise (· ≥ ·) — the sorted valuation list the Newton–Puiseux recursion consumes one dominant edge at a time (global analogue of the two-edge rootValuation_antitone)",
       "Worked three-vertex example (0,2)→(1,0)→(3,1): a genuine two-edge convex chain (threeVertex_chain) with edgeSlopes = [-2, 1/2] (threeVertex_edgeSlopes) shown sorted by the global theorem (threeVertex_sorted)",
-      "Mathlib drift fix: migrated the new convexity layer to the current List order API — List.Chain' → List.IsChain, List.Sorted (removed) → List.Pairwise, chain'_cons/_singleton/_iff_pairwise → isChain_cons_cons/isChain_singleton/isChain_iff_pairwise; added imports Mathlib.Data.List.Chain and Mathlib.Data.List.Sort"
+      "Mathlib drift fix: migrated the new convexity layer to the current List order API — List.Chain' → List.IsChain, List.Sorted (removed) → List.Pairwise, chain'_cons/_singleton/_iff_pairwise → isChain_cons_cons/isChain_singleton/isChain_iff_pairwise; added imports Mathlib.Data.List.Chain and Mathlib.Data.List.Sort",
+      "edgeSlope_mul_width: per-edge identity edgeSlope·width = vertical drop (q.2−p.2) — the slope denominator IS the width, so their product recovers the rise; the bridge coupling the valuation half to the multiplicity half",
+      "edgeDrops + sum_edgeDrops: vertical-drop list of a vertex chain and its telescoping sum to (last).2 − (first).2 (the y-coordinate analogue of sum_edgeWidths)",
+      "zipWith_edgeSlopes_edgeWidths: along a chain of lower edges the elementwise product of the edgeSlopes and edgeWidths lists equals the edgeDrops list — the list-level coupling of valuations and multiplicities",
+      "sum_slope_mul_width: CAPSTONE bookkeeping identity — Σ (edgeSlopeᵢ · widthᵢ) telescopes to the total vertical drop (last).2 − (first).2 across the polygon",
+      "neg_sum_slope_mul_width: Σ (root valuationᵢ · multiplicityᵢ) = v(constant) − v(leading) — the valuation of the product of all roots, read off the two endpoints; the multiplicative counterpart of sum_edgeWidths_eq_degree",
+      "Worked three-vertex example: zipWith products [-2,1] sum to -1 = drop from (0,2) to (3,1) (threeVertex_sum_slope_mul_width)"
     ],
     "dateAdded": "2026-06-27",
-    "lineCount": 509,
-    "theoremCount": 27,
-    "definitionCount": 7,
+    "lineCount": 684,
+    "theoremCount": 39,
+    "definitionCount": 8,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -239,10 +245,10 @@
       "Mathlib.Data.List.Sort"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 589,
+    "lineCount": 684,
     "axiomCount": 0,
-    "theoremCount": 33,
-    "definitionCount": 7,
+    "theoremCount": 39,
+    "definitionCount": 8,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/puiseux-theorem-oq-03.json
+++ b/src/data/research/problems/puiseux-theorem-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S5 degree-counting: added edge-width telescoping (sum_edgeWidths_eq_degree) — the multiplicity half of the Newton polygon, complementing slope-sorting. File 589 lines / 33 theorems / 7 defs, verified 0-sorry 0-axiom. Remaining: hull-construction recursion (chain assembly) and the analytic Newton polygon theorem (blocked on K((x))[Y] valuation API).",
+    "progressSummary": "S6 coupling: added the slope×width=drop layer (sum_slope_mul_width / neg_sum_slope_mul_width) linking the previously-disjoint valuation half (edgeSlopes_pairwise_le) and multiplicity half (sum_edgeWidths_eq_degree). Σ(valuation·multiplicity) = v(constant)−v(leading), the valuation of the root product. File 684 lines / 39 theorems / 8 defs, verified 0-sorry 0-axiom. Combinatorial Newton-polygon bookkeeping now complete; remaining: hull-construction recursion (chain assembly) and the analytic Newton polygon theorem (blocked on K((x))[Y] valuation API).",
     "builtItems": [
       "IsLowerVertex: supporting-line characterization of a Newton-polygon lower-hull vertex (algorithm-independent Prop)",
       "isLowerVertex_of_minimal: the min-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -38,7 +38,11 @@
       "Parent fix: corrected dangling /-- doc comment in PuiseuxTheorem.lean (file did not parse on main)",
       "exists_isLowerEdge_of_leftmost (PuiseuxTheoremOQ03.lean): leftmost support point -> genuine IsLowerEdge via List.argmin(edgeSlope p); first hull-construction step toward S2-B",
       "Maintenance: fixed 3 List.not_mem_nil q sites broken by Mathlib cache update (explicit arg removed)",
-      "edgeWidths/sum_edgeWidths/edgeWidths_pos/sum_edgeWidths_eq_degree in PuiseuxTheoremOQ03.lean (telescoping degree identity; widths sum to index span = degree; all 0-axiom)"
+      "edgeWidths/sum_edgeWidths/edgeWidths_pos/sum_edgeWidths_eq_degree in PuiseuxTheoremOQ03.lean (telescoping degree identity; widths sum to index span = degree; all 0-axiom)",
+      "edgeSlope_mul_width in PuiseuxTheoremOQ03.lean (per-edge slope×width=drop)",
+      "edgeDrops + sum_edgeDrops in PuiseuxTheoremOQ03.lean (vertical-drop list telescoping)",
+      "zipWith_edgeSlopes_edgeWidths in PuiseuxTheoremOQ03.lean (list-level coupling)",
+      "sum_slope_mul_width + neg_sum_slope_mul_width in PuiseuxTheoremOQ03.lean (capstone identities)"
     ],
     "insights": [
       "Supporting-line predicate beats a verified convex-hull construction: same downstream value, far less proof burden, algorithm-agnostic.",
@@ -46,7 +50,10 @@
       "Model support points as Prod (N x Q), not a custom structure: fin_cases + norm_num then dispatch example goals cleanly.",
       "Edge existence reuses isLowerVertex_of_leftmost machinery verbatim: the argmin-of-edgeSlope supporting line through the leftmost point already passes through its argmin partner, so it is an edge, not merely a vertex witness.",
       "Mathlib drift hazard: gallery .lean files verified months ago can silently break against an updated local olean cache (List.not_mem_nil dropped its explicit argument); prefer simp over name-specific applications for List membership-in-nil contradictions.",
-      "Edge WIDTHS carry root multiplicities, complementing edge SLOPES (valuations): the polygon assigns (q.1-p.1) roots of valuation -edgeSlope p q to each edge. sum_edgeWidths + edgeSlopes_pairwise_le together are the full combinatorial bookkeeping of the Newton polygon theorem."
+      "Edge WIDTHS carry root multiplicities, complementing edge SLOPES (valuations): the polygon assigns (q.1-p.1) roots of valuation -edgeSlope p q to each edge. sum_edgeWidths + edgeSlopes_pairwise_le together are the full combinatorial bookkeeping of the Newton polygon theorem.",
+      "slope × width = vertical drop: edgeSlope p q · (q.1−p.1) = q.2−p.2 because the slope denominator IS the width — the per-edge bridge coupling valuations (slopes) to multiplicities (widths)",
+      "Capstone bookkeeping: Σ (slopeᵢ · widthᵢ) telescopes to the total vertical drop (last).2 − (first).2; equivalently Σ (root valuationᵢ · multiplicityᵢ) = v(constant) − v(leading), the valuation of the product of all roots",
+      "The polygon now reads off ALL combinatorial Newton-polygon data from one vertex chain: sorted valuations (edgeSlopes_pairwise_le), total multiplicity (sum_edgeWidths_eq_degree), AND sum-of-valuations-with-multiplicity (neg_sum_slope_mul_width)"
     ],
     "mathlibGaps": [
       "No Newton polygon API in Mathlib 4.26.0 (no Polynomial.newtonPolygon / lowerConvexHull as combinatorial vertex data).",


### PR DESCRIPTION
## Summary

Research session for `puiseux-theorem-oq-03` (combinatorial Newton polygon, parent: Puiseux's theorem / Wiedijk #41).

Prior sessions built two **parallel but disjoint** halves of the Newton polygon:
the *valuation* half (`edgeSlopes_pairwise_le` — root valuations come out sorted)
and the *multiplicity* half (`sum_edgeWidths_eq_degree` — edge widths sum to the
degree). This session **couples them** with the slope×width = vertical-drop identity.

## New content (proofs/Proofs/PuiseuxTheoremOQ03.lean, +6 theorems, +1 def)

- `edgeSlope_mul_width` — per-edge: `edgeSlope p q · ((q.1)−(p.1)) = q.2 − p.2`. The
  slope's denominator *is* the width, so their product recovers the vertical drop.
- `edgeDrops` + `sum_edgeDrops` — vertical-drop list of a vertex chain, telescoping
  to `(last).2 − (first).2` (the y-coordinate analogue of `sum_edgeWidths`).
- `zipWith_edgeSlopes_edgeWidths` — along a chain of lower edges,
  `zipWith (·*·) (edgeSlopes vs) (edgeWidths vs) = edgeDrops vs` (list-level coupling).
- `sum_slope_mul_width` (capstone) — `Σ (edgeSlopeᵢ · widthᵢ) = (last).2 − (first).2`.
- `neg_sum_slope_mul_width` — `Σ (valuationᵢ · multiplicityᵢ) = v(constant) − v(leading)`:
  the valuation of the **product of all roots**, read straight off the two endpoints —
  the *multiplicative* counterpart of the additive `sum_edgeWidths_eq_degree`.
- Worked three-vertex example: `zipWith` products `[-2, 1]` sum to `-1`, the drop
  from `(0,2)` to `(3,1)`.

## Verification

- `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean` → exit 0, no diagnostics.
- `#print axioms` on all 6 new results lists only `propext` / `Classical.choice` / `Quot.sound`.
- **0 sorries, 0 axioms.** File 589 → 684 lines, 33 → 39 theorems, 7 → 8 defs.

## Findings

The combinatorial bookkeeping of the Newton polygon theorem is now complete: from a
single vertex chain the polygon reads off (1) sorted root valuations, (2) total
multiplicity = degree, and (3) sum of valuations with multiplicity = valuation of the
root product. The remaining gap is the **analytic** bridge (slopes/widths ↔ actual
roots of `P ∈ K((x))[Y]`), still blocked on a valuation API for `K((x))[Y]` in
Mathlib 4.26.0.

## Status

**Outcome**: progress (SOLVED-state file extended with a genuinely new linking layer)
**Next Steps**: hull-construction recursion (assemble the vertex chain) once a
termination measure (S2-B) is in place; analytic Newton polygon theorem when the
valuation API lands upstream.

🤖 Generated by researcher-1