### PR TITLE
research(inverse-galois-d4-oq-02): metacyclic divisibility bracket for Gal(Xⁿ−p/ℚ) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/InverseGaloisD4OQ02.lean
+++ b/proofs/Proofs/InverseGaloisD4OQ02.lean
@@ -1,0 +1,185 @@
+/-
+# Inverse Galois Problem: Generalizing X⁴-2 to Xⁿ-p (open question inverse-galois-d4-oq-02)
+
+The base entry `Proofs.InverseGaloisD4` computes `|Gal(X⁴-2/ℚ)| = 8`, identifying the
+Galois group with the dihedral group `D₄`.  The open question asks for the general
+picture: for a prime `p`, the Galois group of `Xⁿ - p` over `ℚ` is *metacyclic* of order
+`n·φ(n)` under genericity — it sits in a split exact sequence
+
+      1 → Cₙ → Gal(Xⁿ-p/ℚ) → (ℤ/nℤ)ˣ → 1,
+
+the kernel `Cₙ` permuting the roots `α·ζⁱ` by translating `i`, and the quotient
+`(ℤ/nℤ)ˣ ≅ Gal(ℚ(ζₙ)/ℚ)` acting on the roots of unity.
+
+This file establishes the two-sided divisibility bracket that pins the order of this group:
+
+      n  ∣  |Gal(Xⁿ-p/ℚ)|  ∣  n!         (`n_dvd_gal_card`, `gal_card_dvd_factorial`)
+
+and, on the metacyclic side, the cyclotomic lower factor
+
+      φ(n)  ∣  |Gal(Xⁿ-p/ℚ)|             (`totient_dvd_gal_card`)
+
+obtained from the cyclotomic subfield `ℚ(ζₙ) ⊆ ℚ(roots)`, of degree `φ(n)`.  These three
+divisibilities directly generalize the base entry's `four_dvd_x4_sub_2_gal_card`
+(`n = 4`: `4 ∣ |Gal|`) and `x4_sub_2_gal_card_dvd_24` (`|Gal| ∣ 24 = 4!`), and add the
+new `(ℤ/nℤ)ˣ`-quotient witness `φ(n) ∣ |Gal|`.  For `n = 4` they read
+`4 ∣ |Gal|`, `|Gal| ∣ 24`, `φ(4)=2 ∣ |Gal|`, consistent with the known `|Gal| = 8`.
+
+Irreducibility of `Xⁿ - p` over `ℚ` is Eisenstein at `p` (valid for every `n ≥ 1`,
+prime `p`), reusing `NthRootIrrationalOQ01.eisenstein_X_pow_sub_prime`.  The two outer
+bounds reuse the base entry's `irred_monic_degree_dvd_splitting_finrank` and the
+`galActionHom` embedding into `Sₙ`; the cyclotomic factor uses that `ℚ(ζₙ)` is a
+subfield of the splitting field with `[ℚ(ζₙ):ℚ] = φ(n)`.
+
+Status: 0 sorries, 0 axioms, no `native_decide`.  `#print axioms` reports only
+`propext, Classical.choice, Quot.sound`.
+-/
+import Mathlib
+import Proofs.InverseGaloisD4
+
+namespace InverseGaloisExtensions
+
+open Polynomial
+
+-- ============================================================================
+-- Part I: Basic facts about Xⁿ - p for prime p
+-- ============================================================================
+
+/-- `Xⁿ - p` is irreducible over `ℚ` for prime `p` and `n ≥ 2`, via Eisenstein at `p`. -/
+theorem x_pow_sub_prime_irreducible (n p : ℕ) (hn : 2 ≤ n) (hp : p.Prime) :
+    Irreducible (X ^ n - C (p : ℚ) : ℚ[X]) :=
+  NthRootIrrationalOQ01.eisenstein_X_pow_sub_prime n p hn hp
+
+/-- `Xⁿ - p` has degree `n`. -/
+theorem x_pow_sub_prime_natDegree (n p : ℕ) (hn : 1 ≤ n) (hp : p.Prime) :
+    (X ^ n - C (p : ℚ) : ℚ[X]).natDegree = n :=
+  NthRootIrrationalOQ01.natDegree_X_pow_sub_C_eq hn (by exact_mod_cast hp.ne_zero)
+
+/-- `Xⁿ - p` is monic. -/
+theorem x_pow_sub_prime_monic (n p : ℕ) (hn : 1 ≤ n) :
+    (X ^ n - C (p : ℚ) : ℚ[X]).Monic :=
+  monic_X_pow_sub_C _ (by omega)
+
+/-- `Xⁿ - p` is separable (irreducible in characteristic 0). -/
+theorem x_pow_sub_prime_separable (n p : ℕ) (hn : 2 ≤ n) (hp : p.Prime) :
+    (X ^ n - C (p : ℚ) : ℚ[X]).Separable :=
+  (x_pow_sub_prime_irreducible n p hn hp).separable
+
+-- ============================================================================
+-- Part II: The lower factor n ∣ |Gal| (irreducible degree divides the order)
+-- ============================================================================
+
+/-- **`n ∣ |Gal(Xⁿ-p/ℚ)|`.** The degree of the irreducible polynomial `Xⁿ - p`
+divides the order of its Galois group: adjoining a single root gives an intermediate
+field of degree `n`, which divides the full splitting-field degree `= |Gal|`.
+
+Generalizes the base entry's `four_dvd_x4_sub_2_gal_card` (`n = 4`). -/
+theorem n_dvd_gal_card (n p : ℕ) (hn : 2 ≤ n) (hp : p.Prime) :
+    n ∣ Fintype.card (X ^ n - C (p : ℚ) : ℚ[X]).Gal := by
+  have hcard := Polynomial.Gal.card_of_separable (x_pow_sub_prime_separable n p hn hp)
+  rw [Nat.card_eq_fintype_card] at hcard
+  rw [hcard]
+  have hdvd := irred_monic_degree_dvd_splitting_finrank
+    (x_pow_sub_prime_irreducible n p hn hp) (x_pow_sub_prime_monic n p (by omega))
+  rwa [x_pow_sub_prime_natDegree n p (by omega) hp] at hdvd
+
+-- ============================================================================
+-- Part III: The upper bound |Gal| ∣ n! (embedding into Sₙ via the root action)
+-- ============================================================================
+
+/-- **`|Gal(Xⁿ-p/ℚ)| ∣ n!`.** The Galois group embeds into the symmetric group `Sₙ`
+on the `n` roots, so its order divides `n!`.
+
+Generalizes the base entry's `x4_sub_2_gal_card_dvd_24` (`n = 4`, `24 = 4!`). -/
+theorem gal_card_dvd_factorial (n p : ℕ) (hn : 2 ≤ n) (hp : p.Prime) :
+    Fintype.card (X ^ n - C (p : ℚ) : ℚ[X]).Gal ∣ n.factorial := by
+  set q := (X ^ n - C (p : ℚ) : ℚ[X]) with hq
+  haveI : Fact (map (algebraMap ℚ q.SplittingField) q).Splits :=
+    ⟨Polynomial.SplittingField.splits q⟩
+  haveI : DecidableEq (↥(q.rootSet q.SplittingField)) := Classical.typeDecidableEq _
+  have hinj := Polynomial.Gal.galActionHom_injective q q.SplittingField
+  have hdvd : Nat.card q.Gal ∣ Nat.card (Equiv.Perm (q.rootSet q.SplittingField)) :=
+    Subgroup.card_dvd_of_injective _ hinj
+  rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, Fintype.card_perm] at hdvd
+  have hcard : Fintype.card (q.rootSet q.SplittingField) = n := by
+    rw [Polynomial.card_rootSet_eq_natDegree (x_pow_sub_prime_separable n p hn hp)
+        (Polynomial.SplittingField.splits q)]
+    exact x_pow_sub_prime_natDegree n p (by omega) hp
+  rwa [hcard] at hdvd
+
+-- ============================================================================
+-- Part IV: The cyclotomic factor φ(n) ∣ |Gal|  (the metacyclic quotient witness)
+-- ============================================================================
+
+/-- **`φ(n) ∣ |Gal(Xⁿ-p/ℚ)|`.** The splitting field `L` of `Xⁿ - p` contains a
+primitive `n`-th root of unity: the `n` distinct roots `β` all satisfy `βⁿ = p`, so
+their ratios `β/α` (for a fixed root `α`) give `n` distinct `n`-th roots of unity in
+`L`.  Hence `ℚ(ζₙ) ⊆ L` with `[ℚ(ζₙ):ℚ] = φ(n)`, and the tower law forces
+`φ(n) ∣ [L:ℚ] = |Gal|`.
+
+This is the cyclotomic lower factor of the metacyclic order `n·φ(n)`: it witnesses the
+quotient `Gal(Xⁿ-p/ℚ) ↠ Gal(ℚ(ζₙ)/ℚ) ≅ (ℤ/nℤ)ˣ`.  Together with `n_dvd_gal_card` it
+pins both factors of `n·φ(n)` from below.  For `n = 4`: `φ(4) = 2 ∣ 8 = |Gal(X⁴-2)|`. -/
+theorem totient_dvd_gal_card (n p : ℕ) (hn : 2 ≤ n) (hp : p.Prime) :
+    n.totient ∣ Fintype.card (X ^ n - C (p : ℚ) : ℚ[X]).Gal := by
+  classical
+  haveI : NeZero n := ⟨by omega⟩
+  set q := (X ^ n - C (p : ℚ) : ℚ[X]) with hq
+  have hsep := x_pow_sub_prime_separable n p hn hp
+  have hsplit := Polynomial.SplittingField.splits q
+  -- |Gal| = [L:ℚ]
+  have hgal : Fintype.card q.Gal = Module.finrank ℚ q.SplittingField := by
+    have h := Polynomial.Gal.card_of_separable hsep
+    rwa [Nat.card_eq_fintype_card] at h
+  rw [hgal]
+  haveI : CharZero q.SplittingField := inferInstance
+  have hp_ne : (p : q.SplittingField) ≠ 0 := by
+    exact_mod_cast hp.ne_zero
+  -- the n roots of q in L
+  have hcardroot : Fintype.card (q.rootSet q.SplittingField) = n := by
+    rw [Polynomial.card_rootSet_eq_natDegree hsep hsplit,
+      x_pow_sub_prime_natDegree n p (by omega) hp]
+  -- every root β has βⁿ = p
+  have root_pow : ∀ β ∈ q.rootSet q.SplittingField, β ^ n = (p : q.SplittingField) := by
+    intro β hβ
+    have h0 := (Polynomial.mem_rootSet.mp hβ).2
+    simp only [hq, map_sub, map_pow, aeval_X, aeval_C] at h0
+    rw [map_natCast] at h0
+    exact sub_eq_zero.mp h0
+  -- fix a root α; it is nonzero since αⁿ = p ≠ 0
+  obtain ⟨⟨α, hα_mem⟩⟩ := Fintype.card_pos_iff.mp (by rw [hcardroot]; omega)
+  have hαpow : α ^ n = (p : q.SplittingField) := root_pow α hα_mem
+  have hα0 : α ≠ 0 := by
+    intro h; apply hp_ne; rw [← hαpow, h, zero_pow (by omega : n ≠ 0)]
+  -- the map β ↦ β/α injects the n roots into the n-th roots of unity in L
+  have hge : n ≤ Fintype.card (rootsOfUnity n q.SplittingField) := by
+    have hle : Fintype.card (q.rootSet q.SplittingField)
+        ≤ Fintype.card (rootsOfUnity n q.SplittingField) := by
+      refine Fintype.card_le_of_injective
+        (fun β : q.rootSet q.SplittingField =>
+          rootsOfUnity.mkOfPowEq (β.1 / α) (by
+            rw [div_pow, root_pow β.1 β.2, hαpow, div_self hp_ne])) ?_
+      intro β₁ β₂ h
+      have hcoe := congrArg
+        (fun u : rootsOfUnity n q.SplittingField =>
+          ((u : (q.SplittingField)ˣ) : q.SplittingField)) h
+      simp only [rootsOfUnity.coe_mkOfPowEq] at hcoe
+      rw [div_eq_div_iff hα0 hα0] at hcoe
+      exact Subtype.ext (mul_right_cancel₀ hα0 hcoe)
+    rwa [hcardroot] at hle
+  -- so L has enough roots of unity: a primitive n-th root ζ exists
+  haveI : HasEnoughRootsOfUnity q.SplittingField n := HasEnoughRootsOfUnity.of_card_le hge
+  obtain ⟨ζ, hζ⟩ := HasEnoughRootsOfUnity.exists_primitiveRoot q.SplittingField n
+  -- ℚ(ζ) has degree φ(n) and sits inside L; tower law gives φ(n) ∣ [L:ℚ]
+  have hζ_int : IsIntegral ℚ ζ := .of_finite ℚ ζ
+  haveI : NeZero ((n : ℕ) : ℚ) := ⟨Nat.cast_ne_zero.mpr (by omega)⟩
+  have hmin : cyclotomic n ℚ = minpoly ℚ ζ :=
+    hζ.minpoly_eq_cyclotomic_of_irreducible (cyclotomic.irreducible_rat (by omega))
+  set F := IntermediateField.adjoin ℚ ({ζ} : Set q.SplittingField) with hF
+  have hF_finrank : Module.finrank ℚ F = n.totient := by
+    rw [IntermediateField.adjoin.finrank hζ_int, ← hmin, natDegree_cyclotomic]
+  have htower := Module.finrank_mul_finrank ℚ F q.SplittingField
+  rw [hF_finrank] at htower
+  exact ⟨_, htower.symm⟩
+
+end InverseGaloisExtensions

--- a/research/problems/inverse-galois-d4-oq-02/knowledge.md
+++ b/research/problems/inverse-galois-d4-oq-02/knowledge.md
@@ -1,21 +1,64 @@
 # Knowledge Base: inverse-galois-d4-oq-02
 
-Insights accumulated during research on this problem.
+Generalize Gal(X⁴−2/ℚ) = D₄ to Gal(Xⁿ−p/ℚ): metacyclic of order n·φ(n) under genericity.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The splitting field of `Xⁿ − p` (prime `p`) over ℚ is `ℚ(ⁿ√p, ζₙ)`. The Galois group is
+metacyclic: `1 → Cₙ → Gal → (ℤ/n)ˣ → 1`, of order dividing `n·φ(n)`, with equality under the
+genericity hypothesis `ℚ(ⁿ√p) ∩ ℚ(ζₙ) = ℚ`. Parent case `n=4, p=2` gives `D₄`, order `8 = 4·φ(4)`.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **Eisenstein is uniform in `n`.** `Xⁿ − p` is Eisenstein at `p` for every `n ≥ 1`, so it is
+  irreducible over ℚ with no case analysis. Reuses `NthRootIrrationalOQ01.eisenstein_X_pow_sub_prime`.
+- **The two divisibility factors of `n·φ(n)` are independently provable and cheap.**
+  - `n ∣ |Gal|` from `irred_monic_degree_dvd_splitting_finrank` (parent lemma) — the kernel `Cₙ`.
+  - `φ(n) ∣ |Gal|` from a primitive `n`-th root of unity living in the splitting field — the quotient `(ℤ/n)ˣ`.
+- **Manufacture the primitive root from the roots themselves.** Every root `β` of `Xⁿ−p` has `βⁿ = p`,
+  so for a fixed root `α ≠ 0` the `n` ratios `β/α` are exactly the `n` distinct `n`-th roots of unity in
+  the splitting field. `HasEnoughRootsOfUnity.of_card_le` then yields a primitive `ζₙ` with no separate
+  cyclotomic splitting-field construction. `rootsOfUnity.mkOfPowEq` packages each ratio as a unit.
+- **`[ℚ(ζₙ):ℚ] = φ(n)`** via `IsPrimitiveRoot.minpoly_eq_cyclotomic_of_irreducible` (note: the lemma
+  returns `cyclotomic n ℚ = minpoly ℚ ζ`, the REVERSED direction — rewrite with `←`) + `natDegree_cyclotomic`.
+  Needs the instance `[NeZero ((n:ℕ):ℚ)]` (supply via `Nat.cast_ne_zero.mpr`).
+- **Upper bound `|Gal| ∣ n!`** from the faithful action on roots (`galActionHom_injective`), generalizing
+  the parent's `x4_sub_2_gal_card_dvd_24`.
+
+## Session 2026-06-27 (Session 1) — FRESH, outcome: progress (verified)
+
+**Built** `proofs/Proofs/InverseGaloisD4OQ02.lean` (185 lines, 7 theorems, 0 sorries, 0 axioms;
+`#print axioms` = propext/Classical.choice/Quot.sound only):
+- `x_pow_sub_prime_irreducible / natDegree / monic / separable` — basic facts for all `n ≥ 2`.
+- `n_dvd_gal_card : n ∣ |Gal(Xⁿ−p)|`.
+- `gal_card_dvd_factorial : |Gal(Xⁿ−p)| ∣ n!`.
+- `totient_dvd_gal_card : φ(n) ∣ |Gal(Xⁿ−p)|` — the new metacyclic ingredient.
+
+Gallery entry `src/data/proofs/inverse-galois-d4-oq-02/`.
+
+**Verification recipe** (docker image build was down — host disk I/O error): single-file elaboration
+`LAKE_UNSAFE=1 lake env lean Proofs/InverseGaloisD4OQ02.lean`; dependency oleans on LEAN_PATH live under
+`.lake/build/lib/lean/Proofs/` (NOT `.lake/build/lib/Proofs/`).
 
 ---
 
-## Dead Ends
+## Dead Ends / Gotchas
 
-[Approaches known not to work will be documented here]
+- `rw [← hcardroot]` on the goal `n ≤ card (rootsOfUnity n L)` fails: motive not type-correct because
+  `rootsOfUnity n` carries a `NeZero n` instance and rewriting every `n` breaks it. Fix: prove the
+  `card rootSet ≤ card rootsOfUnity` inequality first, then `rwa [hcardroot] at hle` (only rewrites the LHS).
+- `minpoly_eq_cyclotomic_of_irreducible` is stated `cyclotomic n K = minpoly K μ` (reversed); use `← hmin`.
+
+---
+
+## Next Steps
+
+- Exact order `|Gal| = n·φ(n)` under genericity: prove the upper bound `|Gal| ≤ n·φ(n)` via the tower
+  `SF = ℚ(ζₙ)(ⁿ√p)`, i.e. `[SF:ℚ(ζₙ)] ≤ n` (root of `Xⁿ−p` over `ℚ(ζₙ)`) and `[ℚ(ζₙ):ℚ] = φ(n)`.
+  The hard formalization step is `splittingField (Xⁿ−p) = ℚ(ζₙ, ⁿ√p)` (all roots are `ⁿ√p · ζₙᵏ`).
+- `lcm(n, φ(n)) ∣ |Gal|` by combining the two lower factors; sharp when `gcd(n, φ(n)) = 1`.
+- Identify the semidirect-product structure `Gal ≅ ℤ/n ⋊ (ℤ/n)ˣ` explicitly.

--- a/src/data/proofs/inverse-galois-d4-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02/meta.json
@@ -1,0 +1,115 @@
+{
+  "id": "inverse-galois-d4-oq-02",
+  "title": "Galois Group of Xⁿ−p: The Metacyclic Divisibility Bracket n ∣ |Gal| ∣ n! and φ(n) ∣ |Gal|",
+  "slug": "inverse-galois-d4-oq-02",
+  "description": "Generalizes the parent entry's D₄ = Gal(X⁴−2/ℚ) computation toward the metacyclic structure of Gal(Xⁿ−p/ℚ) for an arbitrary degree n ≥ 2 and prime p. The full open question asks for |Gal(Xⁿ−p/ℚ)| = n·φ(n) (the affine/holomorph group ℤ/n ⋊ (ℤ/n)ˣ) under genericity. This entry establishes the verified divisibility skeleton that pins that order from both sides: the lower factor n ∣ |Gal| (the irreducible degree divides the splitting-field degree, generalizing the parent's four_dvd_x4_sub_2_gal_card), the cyclotomic lower factor φ(n) ∣ |Gal| (the splitting field contains a primitive n-th root of unity, so ℚ(ζₙ) ⊆ ℚ(roots) of degree φ(n) — the new metacyclic quotient witness Gal ↠ (ℤ/n)ˣ), and the upper bound |Gal| ∣ n! (embedding into Sₙ via the root action, generalizing the parent's x4_sub_2_gal_card_dvd_24). For n = 4, p = 2 these read 4 ∣ |Gal|, 2 = φ(4) ∣ |Gal|, |Gal| ∣ 24, consistent with the known |Gal| = 8. Irreducibility of Xⁿ−p is Eisenstein at p. 7 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher (researcher-9)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InverseGaloisD4OQ02.lean",
+    "parentProof": "inverse-galois-d4",
+    "openQuestionId": "inverse-galois-d4-oq-02",
+    "tags": [
+      "galois-theory",
+      "inverse-galois",
+      "number-theory",
+      "metacyclic-group",
+      "kummer-extension",
+      "cyclotomic",
+      "roots-of-unity",
+      "field-extensions",
+      "polynomial"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 185,
+    "theoremCount": 7,
+    "assumptions": "None beyond the foundational propext / Classical.choice / Quot.sound. #print axioms on all three headline theorems (n_dvd_gal_card, totient_dvd_gal_card, gal_card_dvd_factorial) reports only those three. No native_decide.",
+    "buildStatus": "Verified via `lake env lean Proofs/InverseGaloisD4OQ02.lean` against pinned Mathlib v4.26.0 (LAKE_UNSAFE single-file elaboration; host docker image build was unavailable due to a transient disk I/O error). 0 errors. #print axioms confirms 0 non-foundational axioms.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.Gal.card_of_separable",
+        "description": "For a separable polynomial, Nat.card of the Galois group equals the finrank of the splitting field; turns |Gal| into a degree.",
+        "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
+      },
+      {
+        "theorem": "Polynomial.Gal.galActionHom_injective",
+        "description": "The action of the Galois group on the root set is faithful; gives the embedding Gal ↪ Sₙ used for |Gal| ∣ n!.",
+        "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
+      },
+      {
+        "theorem": "Polynomial.card_rootSet_eq_natDegree",
+        "description": "A separable polynomial that splits has exactly natDegree-many distinct roots; gives the n distinct roots used to build the n-th roots of unity.",
+        "module": "Mathlib.FieldTheory.Separable"
+      },
+      {
+        "theorem": "HasEnoughRootsOfUnity.of_card_le",
+        "description": "If a domain has at least n n-th roots of unity, it contains a primitive n-th root of unity (HasEnoughRootsOfUnity).",
+        "module": "Mathlib.RingTheory.RootsOfUnity.EnoughRootsOfUnity"
+      },
+      {
+        "theorem": "rootsOfUnity.mkOfPowEq",
+        "description": "Packages an element ζ with ζⁿ = 1 as a member of the rootsOfUnity n subgroup; used for the injection β ↦ β/α from roots to roots of unity.",
+        "module": "Mathlib.RingTheory.RootsOfUnity.Basic"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.minpoly_eq_cyclotomic_of_irreducible",
+        "description": "For a primitive n-th root of unity over ℚ, the minimal polynomial is the n-th cyclotomic polynomial; with natDegree_cyclotomic gives [ℚ(ζₙ):ℚ] = φ(n).",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Roots"
+      },
+      {
+        "theorem": "Polynomial.cyclotomic.irreducible_rat",
+        "description": "The n-th cyclotomic polynomial is irreducible over ℚ; supplies the irreducibility hypothesis for the minimal-polynomial identification.",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic"
+      },
+      {
+        "theorem": "Module.finrank_mul_finrank",
+        "description": "The tower law finrank ℚ F · finrank F L = finrank ℚ L, used for both n ∣ |Gal| and φ(n) ∣ |Gal|.",
+        "module": "Mathlib.LinearAlgebra.Dimension.Free"
+      },
+      {
+        "theorem": "NthRootIrrationalOQ01.eisenstein_X_pow_sub_prime",
+        "description": "Xⁿ − p is irreducible over ℚ for prime p (Eisenstein + Gauss); reused gallery lemma.",
+        "module": "Proofs.NthRootIrrationalOQ01"
+      }
+    ],
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Galois group of $X^n - p$ over $\\mathbb{Q}$ (for a prime $p$) is a classical example of a **metacyclic** group. Its splitting field is $\\mathbb{Q}(\\sqrt[n]{p}, \\zeta_n)$, and an automorphism is determined by $\\sqrt[n]{p} \\mapsto \\zeta_n^a \\sqrt[n]{p}$ and $\\zeta_n \\mapsto \\zeta_n^b$ with $\\gcd(b,n)=1$. This realizes the group as a subgroup of the affine/holomorph group $\\mathbb{Z}/n \\rtimes (\\mathbb{Z}/n)^\\times$, of order $n\\,\\varphi(n)$, with equality exactly when the radical extension $\\mathbb{Q}(\\sqrt[n]{p})$ and the cyclotomic extension $\\mathbb{Q}(\\zeta_n)$ are linearly disjoint over $\\mathbb{Q}$. The parent gallery entry handles $n=4$, $p=2$: there $\\mathbb{Z}/4 \\rtimes (\\mathbb{Z}/4)^\\times \\cong D_4$ of order $4 \\cdot 2 = 8$.",
+    "problemStatement": "Generalize Gal(X⁴−2/ℚ) = D₄ to Gal(Xⁿ−p/ℚ): show the group is metacyclic of order n·φ(n) under genericity. This entry proves the verified divisibility bracket n ∣ |Gal| ∣ n! together with the cyclotomic factor φ(n) ∣ |Gal|, which pin both factors of n·φ(n) from below and bound the order from above.",
+    "proofStrategy": "Three independent divisibilities, each generalizing or extending a parent lemma. (1) Lower factor n ∣ |Gal|: Xⁿ−p is irreducible (Eisenstein at p), so adjoining one root gives a degree-n intermediate field, and n = [ℚ(ⁿ√p):ℚ] divides [SF:ℚ] = |Gal| (separable). (2) Cyclotomic factor φ(n) ∣ |Gal|: the n distinct roots β all satisfy βⁿ = p, so the ratios β/α (for a fixed root α ≠ 0) give n distinct n-th roots of unity in the splitting field; hence it contains a primitive ζₙ (HasEnoughRootsOfUnity.of_card_le), ℚ(ζₙ) is an intermediate field of degree φ(n) (minpoly = cyclotomic), and the tower law gives φ(n) ∣ |Gal|. (3) Upper bound |Gal| ∣ n!: the Galois action on the n roots is faithful, embedding Gal ↪ Sₙ.",
+    "keyInsights": [
+      "**Metacyclic, not cyclic**: Over ℚ (which lacks the n-th roots of unity for n ≥ 3) the group of Xⁿ−p is NOT the cyclic Kummer group; it sits in 1 → Cₙ → Gal → (ℤ/n)ˣ → 1. The two divisibilities n ∣ |Gal| and φ(n) ∣ |Gal| are the verified shadows of the kernel Cₙ and the quotient (ℤ/n)ˣ respectively.",
+      "**Roots of unity for free**: A primitive n-th root of unity is manufactured from the roots of Xⁿ−p themselves — every root has the same n-th power p, so the n ratios β/α are exactly the n distinct n-th roots of unity. No separate cyclotomic splitting-field construction is needed; HasEnoughRootsOfUnity.of_card_le converts the count into a primitive root.",
+      "**Eisenstein is uniform in n**: Xⁿ−p is Eisenstein at p for every n, so irreducibility (and hence the clean n ∣ |Gal| factor) holds across all degrees with no case analysis — unlike the harder even-n irreducibility criteria for general Xⁿ−a.",
+      "**Sharp at n = 4**: For n=4, p=2 the bracket gives 4 ∣ |Gal|, φ(4)=2 ∣ |Gal|, |Gal| ∣ 24. The parent entry's independent ℝ-embedding argument pins |Gal| = 8 inside this bracket — both factors 4 and 2 are achieved, and 8 ∣ 24."
+    ]
+  },
+  "conclusion": {
+    "summary": "Verified divisibility skeleton for Gal(Xⁿ−p/ℚ): n ∣ |Gal|, φ(n) ∣ |Gal|, and |Gal| ∣ n!, for every n ≥ 2 and prime p. 7 theorems, 0 sorries, 0 axioms. The cyclotomic factor φ(n) ∣ |Gal| (via a primitive n-th root of unity built from the roots of Xⁿ−p) is the new metacyclic ingredient beyond the parent D₄ entry.",
+    "implications": "Generalizes the parent's n=4 divisibility lemmas (four_dvd_x4_sub_2_gal_card, x4_sub_2_gal_card_dvd_24) to all degrees and supplies the cyclotomic-quotient factor, narrowing the order of Gal(Xⁿ−p/ℚ) to a multiple of lcm(n, φ(n)) dividing n!. This is the verified scaffold on which the exact metacyclic computation |Gal| = n·φ(n) can be assembled.",
+    "openQuestions": [
+      "Prove the exact metacyclic order |Gal(Xⁿ−p/ℚ)| = n·φ(n) under the genericity hypothesis ℚ(ⁿ√p) ∩ ℚ(ζₙ) = ℚ (equivalently, the upper bound |Gal| ≤ n·φ(n) via the tower SF = ℚ(ζₙ)(ⁿ√p)).",
+      "Identify the semidirect-product structure Gal ≅ ℤ/n ⋊ (ℤ/n)ˣ explicitly, not just the order.",
+      "Combine n ∣ |Gal| and φ(n) ∣ |Gal| into lcm(n, φ(n)) ∣ |Gal|, and characterize when this lower bound is sharp (e.g. gcd(n, φ(n)) = 1)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "inverse-galois-d4",
+      "relationship": "parent — the n=4, p=2 case (|Gal(X⁴−2/ℚ)| = 8 = D₄); this entry generalizes its degree-divisibility and Sₙ-embedding lemmas to all n and adds the cyclotomic factor."
+    },
+    {
+      "proofId": "inverse-galois-f20",
+      "relationship": "sibling — the n=5, p=2 case (F₂₀ = ℤ/5 ⋊ (ℤ/5)ˣ via X⁵−2/ℚ), an instance of the metacyclic family treated here."
+    },
+    {
+      "proofId": "nth-root-irrational-oq-01",
+      "relationship": "dependency — supplies eisenstein_X_pow_sub_prime, the irreducibility of Xⁿ−p over ℚ."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Open question **inverse-galois-d4-oq-02** asks to generalize the parent gallery entry's `D₄ = Gal(X⁴−2/ℚ)` computation to `Gal(Xⁿ−p/ℚ)` for arbitrary `n ≥ 2` and prime `p` — conjecturally **metacyclic of order `n·φ(n)`** (the affine group `ℤ/n ⋊ (ℤ/n)ˣ`) under genericity.

This PR establishes the **verified divisibility skeleton** that pins that order from both sides, for every `n ≥ 2` and prime `p`:

| Theorem | Statement | Role |
|---|---|---|
| `n_dvd_gal_card` | `n ∣ \|Gal(Xⁿ−p)\|` | kernel `Cₙ` — generalizes parent `four_dvd_x4_sub_2_gal_card` |
| `totient_dvd_gal_card` | `φ(n) ∣ \|Gal(Xⁿ−p)\|` | quotient `(ℤ/n)ˣ` — **new metacyclic ingredient** |
| `gal_card_dvd_factorial` | `\|Gal(Xⁿ−p)\| ∣ n!` | `Sₙ` embedding — generalizes parent `x4_sub_2_gal_card_dvd_24` |

plus the basic facts (`x_pow_sub_prime_irreducible/natDegree/monic/separable`) for all `n`.

For `n=4, p=2`: `4 ∣ |Gal|`, `φ(4)=2 ∣ |Gal|`, `|Gal| ∣ 24` — consistent with the parent's `|Gal| = 8`.

## The new ingredient: φ(n) ∣ |Gal|

The cyclotomic factor is obtained without a separate cyclotomic splitting-field construction: the `n` roots of `Xⁿ−p` all have the same `n`-th power `p`, so their pairwise ratios `β/α` are exactly the `n` distinct `n`-th roots of unity in the splitting field. `HasEnoughRootsOfUnity.of_card_le` converts that count into a primitive `ζₙ`, so `ℚ(ζₙ)` is an intermediate field of degree `φ(n)` (`minpoly = cyclotomic`), and the tower law gives `φ(n) ∣ |Gal|`.

## Verification

- **185 lines, 7 theorems, 0 sorries, 0 axioms.**
- `#print axioms` on `n_dvd_gal_card`, `totient_dvd_gal_card`, `gal_card_dvd_factorial` reports only `propext / Classical.choice / Quot.sound`. No `native_decide`.
- Verified via `LAKE_UNSAFE=1 lake env lean Proofs/InverseGaloisD4OQ02.lean` (0 errors) against pinned Mathlib v4.26.0. The host docker image build was transiently unavailable (disk I/O error), so verification used single-file elaboration; every cited declaration is present in the pinned Mathlib.

## Still open (documented in the entry)

The exact equality `|Gal| = n·φ(n)` under genericity (i.e. the upper bound `|Gal| ≤ n·φ(n)` via the tower `SF = ℚ(ζₙ)(ⁿ√p)`) remains for future work — the hard step being `splittingField(Xⁿ−p) = ℚ(ζₙ, ⁿ√p)`.

## Files

- `proofs/Proofs/InverseGaloisD4OQ02.lean` — the verified extension.
- `src/data/proofs/inverse-galois-d4-oq-02/meta.json` — gallery entry.
- `research/problems/inverse-galois-d4-oq-02/knowledge.md` — session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)