### PR TITLE
research(collatz-structured-oq-02-oq-03): decidable parity-vector certificate — residue-drop families collapse to one `by decide` [VERIFIED, axiom-free]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -1272,6 +1272,61 @@ theorem parityVector_attainsBelow {M r : ℕ} (v : List Bool)
     {n : ℕ} (hn : n % M = r) : AttainsBelow n :=
   affine_residue_attainsBelow hk hc hd (fun m => affOrbit_realize hval m) hn
 
+/-! ### Decidable certificates: the engine as a one-shot `by decide`
+
+`AffValid` is a `Prop`-valued inductive, so supplying a certificate still means writing
+a nested `AffValid.odd …/AffValid.even …` term by hand (one constructor per step).  The
+validity condition is, however, a finite computation on the residue data alone, so it
+reflects into a `Bool`.  `affValidB` is that decision procedure and `affValidB_sound`
+transports a `true` result back to the `Prop`.  Bundling it with the two drop
+inequalities and non-emptiness gives `dropCert`, a single `Bool` whose truth — checked by
+`decide` — certifies that a whole residue class drops below itself.  Adding a new
+residue family is then literally one `by decide`, with no trajectory chase and no
+hand-built certificate term. -/
+
+/-- Computable Boolean validity checker mirroring `AffValid`: an odd bit needs the
+leading coefficient even and the constant odd (then recurse on the tripled pair); an
+even bit needs both even (then recurse on the halved pair). -/
+def affValidB : List Bool → ℕ → ℕ → Bool
+  | [],          _, _ => true
+  | true  :: v,  c, d => (c % 2 == 0) && (d % 2 == 1) && affValidB v (3 * c) (3 * d + 1)
+  | false :: v,  c, d => (c % 2 == 0) && (d % 2 == 0) && affValidB v (c / 2) (d / 2)
+
+/-- The Boolean checker is sound for the `Prop`-valued certificate: a `true` evaluation
+of `affValidB` produces an `AffValid` derivation.  This is what lets `decide` discharge a
+parity certificate. -/
+theorem affValidB_sound : ∀ {v : List Bool} {c d : ℕ},
+    affValidB v c d = true → AffValid v c d := by
+  intro v
+  induction v with
+  | nil => intro c d _; exact AffValid.nil
+  | cons b v ih =>
+    intro c d h
+    cases b with
+    | true =>
+      simp only [affValidB, Bool.and_eq_true, beq_iff_eq] at h
+      exact AffValid.odd h.1.1 h.1.2 (ih h.2)
+    | false =>
+      simp only [affValidB, Bool.and_eq_true, beq_iff_eq] at h
+      exact AffValid.even h.1.1 h.1.2 (ih h.2)
+
+/-- A single Boolean drop-certificate for the residue class `r (mod M)` along the parity
+vector `v`: non-empty, valid for `(M, r)`, and the realized affine iterate `(c_k, d_k)`
+satisfies the drop conditions `c_k < M` and `d_k < r`.  Each conjunct is a finite
+computation, so `dropCert M r v` evaluates by `decide`. -/
+def dropCert (M r : ℕ) (v : List Bool) : Bool :=
+  decide (0 < v.length) && affValidB v M r &&
+    decide ((affOrbit v (M, r)).1 < M) && decide ((affOrbit v (M, r)).2 < r)
+
+/-- **One-shot residue-drop engine.**  A `true` drop-certificate for `(M, r, v)` makes
+every `n ≡ r (mod M)` attain a value below itself.  Combined with `decide` this reduces a
+new residue family to a single line: `dropCert_attainsBelow v (by decide) h`. -/
+theorem dropCert_attainsBelow {M r : ℕ} (v : List Bool)
+    (h : dropCert M r v = true) {n : ℕ} (hn : n % M = r) : AttainsBelow n := by
+  simp only [dropCert, Bool.and_eq_true, decide_eq_true_eq] at h
+  obtain ⟨⟨⟨hk, hval⟩, hc⟩, hd⟩ := h
+  exact parityVector_attainsBelow v hk (affValidB_sound hval) hc hd hn
+
 /-! ### Validation: the engine reproduces the gallery families
 
 The abstract law recovers the concrete leading coefficients of Part II, and the engine
@@ -1289,16 +1344,17 @@ example :
   decide
 
 /-- End-to-end engine demonstration: re-derive the `n ≡ 3 (mod 16)` drop using only the
-parity certificate `[odd, even, odd, even, even, even]` — no manual trajectory chase.
-The certificate's side conditions and the final `9 < 16`, `2 < 3` are all decidable. -/
-example {n : ℕ} (h : n % 16 = 3) : AttainsBelow n := by
-  refine parityVector_attainsBelow [true, false, true, false, false, false]
-    (by decide) ?_ (by decide) (by decide) h
-  exact AffValid.odd (by decide) (by decide)
-    (AffValid.even (by decide) (by decide)
-      (AffValid.odd (by decide) (by decide)
-        (AffValid.even (by decide) (by decide)
-          (AffValid.even (by decide) (by decide)
-            (AffValid.even (by decide) (by decide) AffValid.nil)))))
+parity certificate `[odd, even, odd, even, even, even]` and a single `by decide` — no
+manual trajectory chase and no hand-built `AffValid` term.  The whole drop-certificate
+(validity, `9 < 16`, `2 < 3`, non-emptiness) collapses to one decidable check. -/
+example {n : ℕ} (h : n % 16 = 3) : AttainsBelow n :=
+  dropCert_attainsBelow [true, false, true, false, false, false] (by decide) h
+
+/-- The one-shot certificate scales to longer windows with no extra proof effort: the
+`n ≡ 11 (mod 32)` drop (eight steps, parity vector `[odd,even,odd,even,even,odd,even,even]`,
+final affine coefficient `27 = 3^3 < 32`) is the *same* single `by decide`. -/
+example {n : ℕ} (h : n % 32 = 11) : AttainsBelow n :=
+  dropCert_attainsBelow
+    [true, false, true, false, false, true, false, false] (by decide) h
 
 end CollatzStructuredOQ02OQ03

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -305,3 +305,55 @@ as two reusable lemmas, replacing the per-residue `collatz_odd …; ring` /
 - de-risk component (1): `paritySteps n b : Fin b → Bool` + proof that `n mod 2^b`
   forces it, turning per-residue lemmas into corollaries of one inductive theorem.
 - Then re-attack Terras/Korec natural-density-1 stopping time (Tao axiom stays BLOCKED).
+
+## Session 2026-06-27 (researcher-2) — ACT: decidable certificate for the parity-vector engine
+
+**Mode**: BUILD (Docker meta.db I/O-corrupt again → offline `LAKE_UNSAFE=1 ./bin/lake env lean`, EXIT 0).
+**Outcome**: progress — axiom-free, build-verified, completes the engine's "turnkey" promise.
+
+### What I Did
+The parity-vector residue-drop engine (`affOrbit_realize` / `parityVector_attainsBelow`,
+merged #30903) was complete but every certificate was a hand-built nested
+`AffValid.odd …/AffValid.even …` term (one constructor per step). Closed that gap with a
+reflection layer:
+- `affValidB : List Bool → ℕ → ℕ → Bool` — computable validity checker mirroring the
+  `AffValid` inductive (odd bit: `c%2==0 && d%2==1 && rec (3c)(3d+1)`; even bit: both even,
+  recurse halved).
+- `affValidB_sound : affValidB v c d = true → AffValid v c d` — induction on `v`, `simp`
+  with `Bool.and_eq_true, beq_iff_eq`. Transports the Bool back to the Prop certificate.
+- `dropCert M r v : Bool` — bundles `0 < v.length`, `affValidB v M r`, and the two drop
+  bounds `(affOrbit v (M,r)).1 < M`, `.2 < r` into a single decidable Boolean.
+- `dropCert_attainsBelow v (h : dropCert M r v = true) (hn : n%M=r) : AttainsBelow n` —
+  the one-shot engine. A new residue family is now literally `dropCert_attainsBelow v (by decide) h`.
+- Replaced the verbose 9-line end-to-end `AffValid` example with the one-liner, and added a
+  second example (`n ≡ 11 (mod 32)`, 8-step vector) showing the SAME single `by decide`
+  scales to longer windows.
+
+### Key Findings
+- `decide` (not `native_decide`) evaluates `affValidB`/`affOrbit`/`leadCoeff` by kernel
+  reduction on small Nats (M ≤ 128, products ≤ few thousand) — fast, and **axiom-free**:
+  `#print axioms affValidB_sound`/`dropCert_attainsBelow` → `[propext, Quot.sound]` only.
+  No `Lean.ofReduceBool` (that would require `native_decide`), no `tao_2019`.
+- `dropCert` uses `decide (0 < v.length)` rather than `!v.isEmpty` so the soundness `simp`
+  unfolds cleanly via `Bool.and_eq_true, decide_eq_true_eq` to a 4-tuple — avoids fragile
+  `List.isEmpty_eq_*` lemma-name guessing.
+
+### Honest status
+- This is the **completion of the engine's usability**, not new Collatz mathematics: the
+  density floor is unchanged (115/128) and the Tao axiom remains BLOCKED. Value: adding any
+  future residue family (mod 256/512/…) is now a one-line decidable certificate instead of a
+  hand-written 8–11-constructor `AffValid` term — the engine is genuinely turnkey for the
+  vector-supplied case.
+
+### Files Modified
+- proofs/Proofs/CollatzStructuredOQ02OQ03.lean (+2 theorems 48→50, +2 defs 8→10, 1304→1360 lines; 1 axiom unchanged, 0 sorries)
+- src/data/proofs/collatz-structured-oq-02-oq-03/meta.json (counts synced + highlight; meta block counts were stale at 39/5/1107)
+- src/data/research/problems/collatz-structured-oq-02-oq-03.json (leanFiles counts 1304/48/8 → 1360/50/10)
+
+### Next Steps (genuine remaining lever, unchanged)
+- de-risk component (1): auto-DERIVE the parity vector from `(M, r)` so the caller supplies
+  only the modulus and residue, not the vector. Blocker: termination of "simulate while the
+  leading coefficient stays even" is not a clean structural recursion (odd steps don't
+  decrease v2(c)); this is the same difficulty as the drop-below conjecture itself for the
+  m-dependent classes. The decidable certificate here is the right primitive to build that on.
+- Then re-attack Terras/Korec natural-density-1 stopping time (Tao axiom stays BLOCKED).

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,12 +20,12 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1107,
+    "lineCount": 1360,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
-    "theoremCount": 39,
-    "definitionCount": 5
+    "theoremCount": 50,
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "The Collatz conjecture asserts every positive integer's orbit reaches 1. Short of the full conjecture, 'almost all' results bound the orbit for density-one sets of starting values. Terras (1976) and Korec (1994) showed almost all n (in natural density) have finite stopping time — their orbit drops below the starting value. Tao (2019, Forum Math. Pi) gave a dramatically stronger statement: for any f → ∞, almost all n (in the finer logarithmic density) have orbit minimum below f(n), i.e. orbits attain almost bounded values. OQ-03 asks whether this analytic landmark can be formalized in Lean.",
@@ -133,15 +133,16 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1304,
+    "lineCount": 1360,
     "axiomCount": 1,
-    "theoremCount": 48,
+    "theoremCount": 50,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
-    "definitionCount": 8
+    "definitionCount": 10
   },
   "sorries": 0,
   "highlights": [
+    "Decidable parity-vector certificate: affValidB reflects the AffValid validity predicate into a computable Bool, affValidB_sound transports a true result back to the Prop, and dropCert M r v bundles validity + the drop bounds c_k<M, d_k<r into one Boolean. dropCert_attainsBelow then makes a whole residue family a single `by decide` (no trajectory chase, no hand-built certificate term) — e.g. the n≡3 (mod 16) and n≡11 (mod 32) drops each collapse to one line. Axiom-free (propext, Quot.sound only)",
     "Reusable affine step-composition lemmas (Terras leading-coefficient law): affine_step_even (c,d)↦(c/2,d/2) and affine_step_odd (c,d)↦(3c,3d+1) track a residue class M·m+r as an affine map c·m+d, reading each parity off the even leading coefficient — replacing the per-step ring/omega trajectory boilerplate. mod_sixteen_three_attainsBelow now uses them for a one-line hiter; axiom-free",
     "Machine-checked density floor raised 7/8 → 115/128: attainsBelow_density_lower_128 shows ≥ 115N−1 of [1,128N] drop below themselves (64N evens + (32N−1) of 1+4ℕ + 8N of 3+16ℕ + 4N of 11+32ℕ + 4N of 23+32ℕ + N each of 7,15,59 (mod 128), eight pairwise-disjoint residue families)",
     "Three new odd classes n ≡ 7, 15, 59 (mod 128) each drop below themselves in exactly 11 residue-determined steps to 81m+d (81 = 3^4 < 2^7 = 128), axiom-free",

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -124,10 +124,10 @@
     {
       "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
       "filename": "CollatzStructuredOQ02OQ03.lean",
-      "lineCount": 1304,
-      "theoremCount": 48,
+      "lineCount": 1360,
+      "theoremCount": 50,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 10,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzStructuredOQ02OQ03.lean"


### PR DESCRIPTION
## Summary

Completes the **parity-vector residue-drop engine** (merged in #30903) by adding a decidability/reflection layer. Previously, certifying that a residue class `n ≡ r (mod M)` drops below itself required hand-building a nested `AffValid.odd …/AffValid.even …` term — one constructor per Collatz step (8–11 lines for the mod-32/128 families). This PR makes any residue family a **single `by decide`**.

## What's new

- **`affValidB : List Bool → ℕ → ℕ → Bool`** — computable validity checker mirroring the `AffValid` inductive (odd bit ⇒ `c%2==0 && d%2==1 && rec (3c)(3d+1)`; even bit ⇒ both even, recurse halved).
- **`affValidB_sound`** — `affValidB v c d = true → AffValid v c d`. Induction on `v`; transports the Bool decision back to the `Prop` certificate.
- **`dropCert M r v : Bool`** — bundles non-emptiness, `affValidB v M r`, and the two drop bounds `(affOrbit v (M,r)).1 < M`, `.2 < r` into one decidable Boolean.
- **`dropCert_attainsBelow v (by decide) h`** — the one-shot engine. A new residue family is now one line, with no trajectory chase and no hand-built certificate term.

The two validation examples (`n ≡ 3 (mod 16)`, `n ≡ 11 (mod 32)`) each collapse to a single `by decide`, demonstrating the engine scales to longer windows at zero extra proof cost.

## Verification

- Uses `decide` (kernel reduction on small Nats, M ≤ 128), **not** `native_decide`.
- `#print axioms affValidB_sound` / `dropCert_attainsBelow` → `[propext, Quot.sound]` only — **axiom-free** (no `Lean.ofReduceBool`, no `tao_2019`).
- Offline-verified `LAKE_UNSAFE=1 lake env lean Proofs/CollatzStructuredOQ02OQ03.lean` → **EXIT 0**, no warnings (Docker meta.db is I/O-corrupt on the host, the documented fallback).
- +2 theorems (48→50), +2 defs (8→10), 1360 lines. **1 axiom (`tao_2019`) unchanged, 0 sorries.**

## Honest scope

This is the **completion of the engine's usability**, not new Collatz mathematics. The unconditional density floor is unchanged (115/128) and the deep `tao_2019` axiom remains BLOCKED. Value: adding any future residue family (mod 256/512/…) is now a one-line decidable certificate. The remaining genuine lever — auto-*deriving* the parity vector from `(M, r)` — is blocked on a non-structural termination argument (documented in `knowledge.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)