### PR TITLE
research(puiseux-theorem-oq-03): Newton's valuation relation — slope×width synthesis [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -586,4 +586,93 @@ theorem threeVertex_sum_widths : (edgeWidths threeVertex).sum = 3 := by
 theorem threeVertex_widths_pos : ∀ w ∈ edgeWidths threeVertex, 0 < w :=
   edgeWidths_pos threeVertex_chain
 
+/-! ### Newton's valuation relation: width × slope telescopes to the valuation drop
+
+The two preceding sections isolate the two halves of the Newton polygon theorem:
+`edgeSlopes` carries the *valuations* of the roots (sorted, by convexity), and
+`edgeWidths` carries their *multiplicities* (summing to the `Y`-degree).  This
+section multiplies them together.
+
+On an edge from `p` to `q` the polygon contributes `q.1 − p.1` roots (the width),
+each of valuation `−edgeSlope p q`.  The valuation those roots contribute to the
+total is therefore `(q.1 − p.1) · edgeSlope p q`, which — because the slope is the
+rise over the run — is exactly the *vertical drop* `q.2 − p.2`.  Summing across a
+vertex chain telescopes to `(last vertex).2 − (first vertex).2`.
+
+Negating gives the classical relation: the sum of the valuations of all roots
+(with multiplicity) equals `v(a₀) − v(a_d)`, the valuation of the constant term
+minus that of the leading term — i.e. the valuation of `±a₀/a_d`, the product of
+the roots.  This is the synthesis the slope-sorting and width-counting results
+were each only half of. -/
+
+/-- On a non-degenerate edge the product width × slope is the vertical drop:
+`(q.1 − p.1) · edgeSlope p q = q.2 − p.2`.  This is just `edgeSlope`'s definition
+(rise over run) cancelled against the run, valid whenever the indices differ. -/
+theorem width_mul_edgeSlope {p q : SupportPoint} (h : (p.1 : ℚ) ≠ (q.1 : ℚ)) :
+    ((q.1 : ℚ) - (p.1 : ℚ)) * edgeSlope p q = q.2 - p.2 := by
+  have hne : (q.1 : ℚ) - (p.1 : ℚ) ≠ 0 := sub_ne_zero.mpr (Ne.symm h)
+  rw [edgeSlope, mul_div_cancel₀ _ hne]
+
+/-- The list of per-edge valuation drops along a chain of support points: the
+product width × slope `(q.1 − p.1) · edgeSlope p q` of each consecutive pair.
+On a genuine vertex chain each entry equals the vertical drop `q.2 − p.2`
+(`width_mul_edgeSlope`). -/
+def edgeDrops : List SupportPoint → List ℚ
+  | p :: q :: rest => ((q.1 : ℚ) - (p.1 : ℚ)) * edgeSlope p q :: edgeDrops (q :: rest)
+  | _ => []
+
+/-- **Telescoping valuation identity.**  Along any vertex chain the per-edge
+valuation drops (width × slope) sum to the total vertical drop from the first
+vertex to the last, `(last).2 − (first).2`.  The chain hypothesis is what makes
+each edge non-degenerate (`p.1 < q.1`), so `width_mul_edgeSlope` turns every term
+into a genuine drop `q.2 − p.2` and the sum telescopes. -/
+theorem sum_edgeDrops {pts : List SupportPoint} :
+    ∀ {v : SupportPoint} {vs : List SupportPoint},
+      List.IsChain (IsLowerEdge pts) (v :: vs) →
+      (edgeDrops (v :: vs)).sum = (((v :: vs).getLast (by simp)).2) - v.2
+  | _, [], _ => by simp [edgeDrops]
+  | v, w :: ws, hc => by
+      obtain ⟨hvw, hc'⟩ := List.isChain_cons_cons.mp hc
+      have ih := sum_edgeDrops hc'
+      obtain ⟨_, _, hlt, _⟩ := hvw
+      have hne : (v.1 : ℚ) ≠ (w.1 : ℚ) := by exact_mod_cast Nat.ne_of_lt hlt
+      have hdrop : ((w.1 : ℚ) - (v.1 : ℚ)) * edgeSlope v w = w.2 - v.2 :=
+        width_mul_edgeSlope hne
+      have hgl : (v :: w :: ws).getLast (by simp) = (w :: ws).getLast (by simp) :=
+        List.getLast_cons (by simp)
+      simp only [edgeDrops, List.sum_cons]
+      rw [ih, hdrop, hgl]
+      ring
+
+/-- **Newton's valuation relation.**  The sum of the valuations of all roots
+(counted with multiplicity) equals `v(a₀) − v(a_d)`: the valuation of the constant
+term minus that of the leading term.  Each edge contributes `width` roots of
+valuation `−slope`, so the total root-valuation sum is `−∑ (width · slope)`, which
+by `sum_edgeDrops` collapses to `(first).2 − (last).2`.  For a hull running from
+index `0` (constant term) to index `d` (leading term) the right-hand side is
+`v(a₀) − v(a_d)` — the valuation of the product of the roots. -/
+theorem sum_rootValuations {pts : List SupportPoint} {v : SupportPoint}
+    {vs : List SupportPoint} (hc : List.IsChain (IsLowerEdge pts) (v :: vs)) :
+    -((edgeDrops (v :: vs)).sum) = v.2 - (((v :: vs).getLast (by simp)).2) := by
+  rw [sum_edgeDrops hc]
+  ring
+
+/-- The per-edge valuation drops of the worked three-vertex example are
+`[-2, 1]`: edge `(0,2)→(1,0)` drops by `−2` (width `1`, slope `−2`) and edge
+`(1,0)→(3,1)` rises by `1` (width `2`, slope `1/2`). -/
+theorem threeVertex_edgeDrops : edgeDrops threeVertex = [-2, 1] := by
+  norm_num [edgeDrops, threeVertex, edgeSlope]
+
+/-- The drops of the example telescope to `1 − 2 = −1`, the vertical drop from the
+first vertex `(0,2)` to the last `(3,1)`. -/
+theorem threeVertex_sum_drops : (edgeDrops threeVertex).sum = -1 := by
+  norm_num [edgeDrops, threeVertex, edgeSlope]
+
+/-- The example's root valuations sum to `2 − 1 = 1 = v(a₀) − v(a_d)`: one root of
+valuation `2` (from the width-`1` edge) plus two roots of valuation `−1/2` (from
+the width-`2` edge) give `2 + 2·(−1/2) = 1`, matching `v(a₀) − v(a_d) = 2 − 1`. -/
+theorem threeVertex_sum_rootValuations :
+    -((edgeDrops threeVertex).sum) = 1 := by
+  norm_num [edgeDrops, threeVertex, edgeSlope]
+
 end PuiseuxTheoremOQ03

--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -197,3 +197,55 @@ across the proof-irrelevant nonempty hypothesis; supplying both via `(by simp)`
 keeps the atoms syntactically equal so `ring` closes the telescope. Base case
 `edgeWidths [v] = []` falls through the catch-all `_ => []` pattern (single-cons
 does not match `p :: q :: rest`).
+
+## Session 6 (2026-06-27, researcher-3): Newton's valuation relation (slope×width synthesis)
+
+Extended the file 589→678 lines, 33→39 theorems, 7→8 defs (all still 0 sorries /
+0 axioms; `#print axioms` on the new results lists only
+propext/Classical.choice/Quot.sound).
+
+The two prior layers were complementary but never combined:
+`edgeSlopes_pairwise_le` (slopes = root **valuations**, sorted) and
+`sum_edgeWidths_eq_degree` (widths = root **multiplicities**, summing to degree).
+This session multiplies them.
+
+New content:
+* `width_mul_edgeSlope`: on a non-degenerate edge `(q.1−p.1)·edgeSlope p q =
+  q.2−p.2` — the per-edge bridge. Just `edgeSlope`'s rise/run cancelled against
+  the run via `mul_div_cancel₀` (needs `(q.1−p.1) ≠ 0`, i.e. distinct indices).
+* `edgeDrops`: list of per-edge products width×slope along a chain (pointwise
+  product of `edgeSlopes` and `edgeWidths`; each entry = vertical drop on a real
+  edge). Same two-step structural-recursion shape as `edgeSlopes`/`edgeWidths`.
+* `sum_edgeDrops`: **telescoping valuation identity** — along any
+  `IsChain (IsLowerEdge pts)` the drops sum to `(last).2 − (first).2`. The chain
+  hypothesis is essential here (unlike `sum_edgeWidths`, which needs none):
+  width×slope only collapses to the drop when the indices differ, and the chain's
+  `p.1 < q.1` per edge supplies that. Induction mirrors `sum_edgeWidths` plus a
+  `width_mul_edgeSlope` rewrite of the head term.
+* `sum_rootValuations`: **Newton's valuation relation** — sum of all root
+  valuations (with multiplicity) = `v(a₀) − v(a_d)`. Each edge contributes `width`
+  roots of valuation `−slope`, so the total is `−∑(width·slope) = −(sum_edgeDrops)
+  = (first).2 − (last).2`. For a hull from index 0 (constant) to index d
+  (leading) this is `v(a₀) − v(a_d)` = valuation of `±a₀/a_d`, the product of the
+  roots.
+* Three-vertex worked synthesis: `edgeDrops = [-2, 1]` (`threeVertex_edgeDrops`),
+  sum `−1` (`threeVertex_sum_drops`), root-valuation sum `2 + 2·(−1/2) = 1`
+  (`threeVertex_sum_rootValuations`) = `v(a₀) − v(a_d) = 2 − 1`.
+
+**Why this matters.** This is the capstone tying both halves of the Newton
+polygon theorem together: once a valuation API on `K((x))[Y]` lands, the analytic
+Newton polygon theorem (slopes = root valuations) composed with `sum_rootValuations`
+recovers the classical relation `∑ v(roots) = v(a₀/a_d)` — the valuation analogue
+of Vieta's product formula. The combinatorial bookkeeping is now complete:
+valuations sorted (slopes), multiplicities counted (widths), and their product
+(total valuation) pinned to the coefficient valuations.
+
+GOTCHAs (session 6):
+* Stale prebuilt olean: `import Proofs.PuiseuxTheoremOQ03` in a separate
+  `#print axioms` file resolves to main's OLD olean, not your edits → "unknown
+  constant". Append the `#print axioms` lines to the file itself and run
+  `LAKE_UNSAFE=1 ./bin/lake env lean` directly, then restore.
+* Verification recipe unchanged: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean
+  Proofs/PuiseuxTheoremOQ03.lean` exits 0 (docker host build path unused).
+* `List.sum_map_neg` (map-then-sum-of-negs) is not reliably present — phrase the
+  root-valuation sum as `-(edgeDrops ...).sum` instead of `(... .map Neg.neg).sum`.

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "puiseux-theorem-oq-03",
   "title": "Puiseux Theorem OQ-03: A Combinatorial Newton Polygon",
   "slug": "puiseux-theorem-oq-03",
-  "description": "Lean deliverable for the computational sub-question of Puiseux's theorem (\"Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?\"). Introduces the Newton polygon of a polynomial over a valued field via the supporting-line characterization of lower-hull vertices (IsLowerVertex), proves the minimum-valuation point is always a vertex (isLowerVertex_of_minimal) and that every nonempty support set has one (exists_lowerVertex via List.argmin). It then builds the edge layer: a lower-edge predicate (IsLowerEdge), the fact that a supporting line through two distinct-index points has the forced edge slope (slope_eq_edgeSlope), that edge endpoints are vertices, and — the combinatorial heart — convexity of the Newton polygon (edgeSlope_mono): adjacent edge slopes are non-decreasing, hence the root valuations come sorted (rootValuation_antitone). Validated on the canonical Y²−x example: both support points are vertices, the single segment is a genuine lower edge of slope −1/2, and the leading exponent 1/2 matches the parent's leadingExponentFromSlope. Also fixes a parse error in the parent file (a dangling /-- doc comment).",
+  "description": "Lean deliverable for the computational sub-question of Puiseux's theorem (\"Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?\"). Introduces the Newton polygon of a polynomial over a valued field via the supporting-line characterization of lower-hull vertices (IsLowerVertex), proves the minimum-valuation point is always a vertex (isLowerVertex_of_minimal) and that every nonempty support set has one (exists_lowerVertex via List.argmin). It then builds the edge layer: a lower-edge predicate (IsLowerEdge), the fact that a supporting line through two distinct-index points has the forced edge slope (slope_eq_edgeSlope), that edge endpoints are vertices, and — the combinatorial heart — convexity of the Newton polygon (edgeSlope_mono): adjacent edge slopes are non-decreasing, hence the root valuations come sorted (rootValuation_antitone). Validated on the canonical Y²−x example: both support points are vertices, the single segment is a genuine lower edge of slope −1/2, and the leading exponent 1/2 matches the parent's leadingExponentFromSlope. The latest layer synthesizes the two halves of the Newton polygon theorem — slopes (valuations) and widths (multiplicities) — via Newton's valuation relation: along any vertex chain the per-edge products width×slope (edgeDrops) telescope to the total vertical drop (sum_edgeDrops), so the sum of all root valuations equals v(a₀)−v(a_d), the valuation of the constant minus the leading coefficient (sum_rootValuations). Also fixes a parse error in the parent file (a dangling /-- doc comment).",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Newton_polygon",
@@ -21,7 +21,7 @@
     "badge": "infrastructure",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All 27 theorems and 7 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
+    "assumptions": "None. All 39 theorems and 8 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
     "originalContributions": [
       "IsLowerVertex: supporting-line characterization of a lower-hull (Newton-polygon) vertex, algorithm-independent",
       "isLowerVertex_of_minimal: the minimum-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -45,18 +45,23 @@
       "edgeSlopes_pairwise_le: GLOBAL CONVEXITY (sorted form) — the edge slopes of a Newton polygon are Pairwise (· ≤ ·): every slope ≤ every LATER slope, not merely the next one (IsChain upgraded to Pairwise via transitivity of ≤ on ℚ)",
       "rootValuations_pairwise_ge: consequently the negated edge slopes (the root valuations) of the whole polygon are Pairwise (· ≥ ·) — the sorted valuation list the Newton–Puiseux recursion consumes one dominant edge at a time (global analogue of the two-edge rootValuation_antitone)",
       "Worked three-vertex example (0,2)→(1,0)→(3,1): a genuine two-edge convex chain (threeVertex_chain) with edgeSlopes = [-2, 1/2] (threeVertex_edgeSlopes) shown sorted by the global theorem (threeVertex_sorted)",
-      "Mathlib drift fix: migrated the new convexity layer to the current List order API — List.Chain' → List.IsChain, List.Sorted (removed) → List.Pairwise, chain'_cons/_singleton/_iff_pairwise → isChain_cons_cons/isChain_singleton/isChain_iff_pairwise; added imports Mathlib.Data.List.Chain and Mathlib.Data.List.Sort"
+      "Mathlib drift fix: migrated the new convexity layer to the current List order API — List.Chain' → List.IsChain, List.Sorted (removed) → List.Pairwise, chain'_cons/_singleton/_iff_pairwise → isChain_cons_cons/isChain_singleton/isChain_iff_pairwise; added imports Mathlib.Data.List.Chain and Mathlib.Data.List.Sort",
+      "width_mul_edgeSlope: on any non-degenerate edge the product width × slope equals the vertical drop q.2 − p.2 (edgeSlope's rise-over-run cancelled against the run via mul_div_cancel₀) — the per-edge bridge between the slope layer and the width layer",
+      "edgeDrops: the list of per-edge valuation drops (width × slope) along a chain — the pointwise product of the edgeSlopes and edgeWidths lists, each entry equal to the vertical drop on a genuine edge",
+      "sum_edgeDrops: TELESCOPING VALUATION IDENTITY — along any vertex chain the per-edge products width × slope sum to the total vertical drop (last).2 − (first).2; the chain hypothesis makes every edge non-degenerate so width_mul_edgeSlope turns each term into a drop and the sum telescopes",
+      "sum_rootValuations: NEWTON'S VALUATION RELATION — the sum of the valuations of all roots (with multiplicity) equals v(a₀) − v(a_d), the valuation of the constant term minus the leading term (= valuation of ±a₀/a_d, the product of the roots); this is the synthesis the slope-sorting (edgeSlopes_pairwise_le) and width-counting (sum_edgeWidths_eq_degree) results were each only half of",
+      "Worked three-vertex example (synthesis): edgeDrops = [-2, 1] telescope to -1 (threeVertex_sum_drops), and the root valuations sum to 2 + 2·(−1/2) = 1 = v(a₀) − v(a_d) (threeVertex_sum_rootValuations)"
     ],
     "dateAdded": "2026-06-27",
-    "lineCount": 509,
-    "theoremCount": 27,
-    "definitionCount": 7,
+    "lineCount": 678,
+    "theoremCount": 39,
+    "definitionCount": 8,
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Newton (1676) introduced the fractional-exponent root-finding procedure that bears his name; Puiseux (1850) gave the first rigorous proof that it produces all roots. The central combinatorial object is the Newton polygon: for a polynomial P(Y) = Σ aᵢ Yⁱ with coefficients in a valued field K((x)), it is the lower convex hull of the support points (i, v(aᵢ)). The Newton polygon theorem states that the negatives of its edge slopes are exactly the valuations of the roots of P in any algebraically closed valued extension — the fact that feeds the parent's leadingExponentFromSlope.\n\nThe computational story (Chudnovsky–Chudnovsky 1986, Duval 1989, Walsh 2000, Poteaux–Rybowicz 2008–15, Poteaux–Weimann 2021) tightens the cost of computing Puiseux expansions to quasi-linear Õ(d·δ) in the discriminant valuation δ. Every such bound is phrased on the Newton polygon as a data structure, so a computable combinatorial Newton polygon is the natural first formal step.",
     "problemStatement": "**Open Question (OQ-03 from Puiseux's Theorem)**: Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?\n\n**This deliverable**: Mathlib 4.26.0 has no Newton polygon API. This file supplies the combinatorial core — the lower-hull vertex predicate and its basic structure theory, validated on the canonical Y²−x example — as the foundation on which termination and complexity bounds can later be stated.",
-    "text": "A 224-line, fully-verified Lean file. The Newton polygon is captured not by a hull-construction algorithm but by the standard supporting-line predicates: a support point p is a lower vertex (IsLowerVertex) when some line y = m·i + b lies weakly below every support point and passes through p, and a pair (p,q) with p strictly left of q is a lower edge (IsLowerEdge) when one supporting line passes through both. General lemmas (minimum-valuation point is a vertex; existence of a vertex; edge endpoints are vertices; a supporting line's slope is forced by its two distinct points) build up to convexity (edgeSlope_mono): adjacent edge slopes are non-decreasing, so the root valuations come sorted (rootValuation_antitone). The worked Y²−x example (both endpoints are vertices, the segment is a genuine lower edge of slope −1/2, leading exponent 1/2) connects the construction to the parent's leadingExponentFromSlope. The file also repairs a parse error in the parent PuiseuxTheorem.lean.",
+    "text": "A 678-line, fully-verified Lean file. The Newton polygon is captured not by a hull-construction algorithm but by the standard supporting-line predicates: a support point p is a lower vertex (IsLowerVertex) when some line y = m·i + b lies weakly below every support point and passes through p, and a pair (p,q) with p strictly left of q is a lower edge (IsLowerEdge) when one supporting line passes through both. General lemmas (minimum-valuation point is a vertex; existence of a vertex; edge endpoints are vertices; a supporting line's slope is forced by its two distinct points) build up to convexity (edgeSlope_mono): adjacent edge slopes are non-decreasing, so the root valuations come sorted (rootValuation_antitone). The worked Y²−x example (both endpoints are vertices, the segment is a genuine lower edge of slope −1/2, leading exponent 1/2) connects the construction to the parent's leadingExponentFromSlope. The file also repairs a parse error in the parent PuiseuxTheorem.lean.",
     "proofStrategy": "**Predicate, not algorithm**: IsLowerVertex states existence of a supporting line through p below all support points. This is the math definition of a lower-hull vertex and keeps the API independent of any verified convex-hull routine.\n\n**General structure**: isLowerVertex_of_minimal uses the horizontal line y = v(p) — the lowest support point is always a vertex. exists_lowerVertex extracts the argmin of the valuations from a nonempty support list (Mathlib List.argmin + le_of_mem_argmin).\n\n**Example**: For Y²−x the support is {(0,1),(2,0)}; the line y = −½i + 1 passes through both and lies (with equality) below them, so both are vertices. edgeSlope (0,1) (2,0) = −1/2 by norm_num, and −(−1/2) = 1/2 = leadingExponentFromSlope 1 2.",
     "keyInsights": [
       "**Supporting lines beat algorithms**: Phrasing a Newton-polygon vertex as 'some line lies below all points and touches this one' captures the exact mathematical content without forcing a verified convex-hull construction — the API stays honest and small.",
@@ -115,6 +120,14 @@
       "endLine": 509,
       "summary": "edgeSlopes reads the edge-slope list off a List.IsChain of lower edges. chain_edgeSlopes proves it IsChain (· ≤ ·) by two-step structural induction (head = edgeSlope_mono, tail = IH); edgeSlopes_pairwise_le upgrades to Pairwise (· ≤ ·) via transitivity, and rootValuations_pairwise_ge negates to Pairwise (· ≥ ·) for the root valuations. A genuine three-vertex convex chain (0,2)→(1,0)→(3,1) with edge slopes [-2, 1/2] exercises the theorems.",
       "mathContext": "$\\text{IsChain}(\\text{IsLowerEdge})\\,vs \\Rightarrow (\\text{edgeSlopes}\\,vs)\\ \\text{sorted } \\le$; lifting adjacent-pair convexity $\\text{edgeSlope}(v_{i-1},v_i)\\le\\text{edgeSlope}(v_i,v_{i+1})$ to all pairs."
+    },
+    {
+      "id": "valuation-relation",
+      "title": "Newton's Valuation Relation: width × slope telescopes to the valuation drop",
+      "startLine": 589,
+      "endLine": 678,
+      "summary": "The synthesis of the slope and width layers. width_mul_edgeSlope: on a non-degenerate edge (q.1−p.1)·edgeSlope p q = q.2−p.2 (rise/run cancelled). edgeDrops lists these per-edge products along a chain, and sum_edgeDrops telescopes them to (last).2−(first).2 (the chain hypothesis makes every edge non-degenerate). sum_rootValuations negates: since each edge contributes width roots of valuation −slope, the sum of all root valuations is −∑(width·slope) = (first).2−(last).2 = v(a₀)−v(a_d). Exercised on the three-vertex example: drops [-2, 1] sum to −1, root valuations sum to 2 + 2·(−1/2) = 1 = 2 − 1.",
+      "mathContext": "$\\sum_{\\text{edges}}(\\Delta i)\\cdot\\text{slope}=v_{\\text{last}}-v_{\\text{first}}$, hence $\\sum_{\\text{roots}}v(\\rho)=v(a_0)-v(a_d)=v(\\pm a_0/a_d)$."
     }
   ],
   "mainTheorems": [
@@ -166,6 +179,20 @@
       "statement": "$\\text{IsChain}(\\text{IsLowerEdge}\\,\\text{pts})\\,vs \\Rightarrow (\\text{edgeSlopes}\\,vs).\\text{Pairwise}(\\le)$",
       "significance": "GLOBAL convexity of the Newton polygon: along any chain of lower edges, EVERY edge slope is ≤ every later edge slope — not merely the adjacent one (edgeSlope_mono). This is the whole-polygon statement that the lower hull is convex, and it is what makes a polynomial's root valuations come out as a fully sorted list (rootValuations_pairwise_ge), the structural backbone of the Newton–Puiseux recursion processing dominant edges in order.",
       "description": "chain_edgeSlopes proves the consecutive form (List.IsChain (· ≤ ·) on the edge-slope list) by a two-step structural induction whose head step is edgeSlope_mono and whose tail is the IH; List.isChain_iff_pairwise then upgrades it to Pairwise because ≤ on ℚ is transitive."
+    },
+    {
+      "name": "sum_edgeDrops",
+      "type": "theorem",
+      "statement": "$\\text{IsChain}(\\text{IsLowerEdge}\\,\\text{pts})\\,(v::vs) \\Rightarrow (\\text{edgeDrops}\\,(v::vs)).\\text{sum} = (\\text{last}\\,(v::vs))_2 - v_2$",
+      "significance": "TELESCOPING VALUATION IDENTITY. The per-edge products width × slope sum to the total vertical drop across the polygon. Combines the slope and width layers pointwise: on a chain every edge is non-degenerate, so width_mul_edgeSlope makes each term a genuine drop q.2 − p.2 and the sum telescopes to (last).2 − (first).2.",
+      "description": "Structural induction on the vertex list. The head term (w.1 − v.1)·edgeSlope v w rewrites to w.2 − v.2 via width_mul_edgeSlope (indices distinct from the chain's p.1 < q.1); the tail is the IH; List.getLast_cons and ring close it."
+    },
+    {
+      "name": "sum_rootValuations",
+      "type": "theorem",
+      "statement": "$\\text{IsChain}(\\text{IsLowerEdge}\\,\\text{pts})\\,(v::vs) \\Rightarrow -((\\text{edgeDrops}\\,(v::vs)).\\text{sum}) = v_2 - (\\text{last}\\,(v::vs))_2$",
+      "significance": "NEWTON'S VALUATION RELATION. Each edge contributes width roots of valuation −slope, so the sum of all root valuations is −∑(width·slope), which by sum_edgeDrops equals (first).2 − (last).2 = v(a₀) − v(a_d): the valuation of the constant term minus the leading term — equivalently the valuation of ±a₀/a_d, the product of the roots. This is the synthesis that the slope-sorting (edgeSlopes_pairwise_le) and width-counting (sum_edgeWidths_eq_degree) results were each only half of.",
+      "description": "Negate sum_edgeDrops and ring. Validated on the three-vertex example: one root of valuation 2 plus two of valuation −1/2 give 2 + 2·(−1/2) = 1 = 2 − 1 = v(a₀) − v(a_d)."
     },
     {
       "name": "ysqMinusX_isLowerEdge",
@@ -239,15 +266,15 @@
       "Mathlib.Data.List.Sort"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 589,
+    "lineCount": 678,
     "axiomCount": 0,
-    "theoremCount": 33,
-    "definitionCount": 7,
+    "theoremCount": 39,
+    "definitionCount": 8,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0
   },
   "conclusion": {
-    "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, the lower-edge predicate IsLowerEdge with the edge↔vertex bridge and the slope-determination lemma slope_eq_edgeSlope, and — the combinatorial heart — convexity of the polygon (edgeSlope_mono) yielding sorted root valuations (rootValuation_antitone). The latest layer lifts convexity from adjacent pairs to the whole polygon: edgeSlopes reads off the edge-slope list of a chain of lower edges, and edgeSlopes_pairwise_le proves it Pairwise (· ≤ ·) — every slope ≤ every later one — so the root valuations of the entire polygon are sorted (rootValuations_pairwise_ge), demonstrated on a genuine three-vertex convex chain. All validated on the Y²−x example whose single segment is a genuine lower edge tying the slope to the parent's leadingExponentFromSlope. All 27 theorems and 7 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
+    "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, the lower-edge predicate IsLowerEdge with the edge↔vertex bridge and the slope-determination lemma slope_eq_edgeSlope, and — the combinatorial heart — convexity of the polygon (edgeSlope_mono) yielding sorted root valuations (rootValuation_antitone). The latest layer lifts convexity from adjacent pairs to the whole polygon: edgeSlopes reads off the edge-slope list of a chain of lower edges, and edgeSlopes_pairwise_le proves it Pairwise (· ≤ ·) — every slope ≤ every later one — so the root valuations of the entire polygon are sorted (rootValuations_pairwise_ge), demonstrated on a genuine three-vertex convex chain. The newest layer fuses the slope and width data via Newton's valuation relation: width_mul_edgeSlope shows each per-edge product width × slope is the vertical drop, sum_edgeDrops telescopes those across a vertex chain, and sum_rootValuations concludes that the sum of all root valuations equals v(a₀) − v(a_d) — the constant-over-leading valuation, i.e. the valuation of the product of the roots. All validated on the Y²−x example whose single segment is a genuine lower edge tying the slope to the parent's leadingExponentFromSlope, and a three-vertex example exercising the slope-sorting, width-counting, and valuation-relation theorems. All 39 theorems and 8 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
     "implications": "This is the algorithm-independent data layer on which Newton–Puiseux termination measures and the Poteaux–Weimann complexity bounds can later be phrased. With a valuation API on K((x))[Y], the Newton polygon theorem (slopes = root valuations) becomes the next provable target.",
     "openQuestions": [
       "Prove the Newton polygon theorem: the negatives of the lower-hull edge slopes equal the valuations of the roots in an algebraically closed valued extension (needs a valuation API on K((x))[Y]) — the edge layer and its convexity (edgeSlope_mono) are now in place, so the valuations would automatically come out sorted",

--- a/src/data/research/problems/puiseux-theorem-oq-03.json
+++ b/src/data/research/problems/puiseux-theorem-oq-03.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-12T13:53:16-07:00",
-    "iteration": 2,
-    "focus": "Shipped combinatorial Newton polygon (S2-A): IsLowerVertex predicate + structure lemmas + Y^2-x example, verified 0-sorry 0-axiom.",
+    "iteration": 3,
+    "focus": "S6 synthesis: Newton's valuation relation — width_mul_edgeSlope + edgeDrops + sum_edgeDrops (telescoping) + sum_rootValuations (sum of root valuations = v(a0)-v(ad)), fusing the slope (valuation) and width (multiplicity) layers. 678 lines / 39 theorems / 8 defs, 0-sorry 0-axiom.",
     "blockers": [],
-    "nextAction": "S2-A harder half: Newton polygon theorem (edge slopes = root valuations) once a valuation API on K((x))[Y] exists; then S2-B termination measure.",
+    "nextAction": "Hull-construction recursion (assemble the IsChain vertex list by peeling edges) and the analytic Newton polygon theorem (edge slopes = root valuations), the latter blocked on a valuation API on K((x))[Y] in Mathlib.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S5 degree-counting: added edge-width telescoping (sum_edgeWidths_eq_degree) — the multiplicity half of the Newton polygon, complementing slope-sorting. File 589 lines / 33 theorems / 7 defs, verified 0-sorry 0-axiom. Remaining: hull-construction recursion (chain assembly) and the analytic Newton polygon theorem (blocked on K((x))[Y] valuation API).",
+    "progressSummary": "S6 synthesis: Newton's valuation relation — fused the slope (valuation) and width (multiplicity) layers. width_mul_edgeSlope (width*slope = vertical drop), edgeDrops, sum_edgeDrops (telescoping to (last).2-(first).2), sum_rootValuations (sum of all root valuations = v(a0)-v(ad), the constant-over-leading valuation = valuation of the product of roots). File 678 lines / 39 theorems / 8 defs, verified 0-sorry 0-axiom. Remaining: hull-construction recursion (chain assembly) and the analytic Newton polygon theorem (blocked on K((x))[Y] valuation API).",
     "builtItems": [
       "IsLowerVertex: supporting-line characterization of a Newton-polygon lower-hull vertex (algorithm-independent Prop)",
       "isLowerVertex_of_minimal: the min-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -38,7 +38,8 @@
       "Parent fix: corrected dangling /-- doc comment in PuiseuxTheorem.lean (file did not parse on main)",
       "exists_isLowerEdge_of_leftmost (PuiseuxTheoremOQ03.lean): leftmost support point -> genuine IsLowerEdge via List.argmin(edgeSlope p); first hull-construction step toward S2-B",
       "Maintenance: fixed 3 List.not_mem_nil q sites broken by Mathlib cache update (explicit arg removed)",
-      "edgeWidths/sum_edgeWidths/edgeWidths_pos/sum_edgeWidths_eq_degree in PuiseuxTheoremOQ03.lean (telescoping degree identity; widths sum to index span = degree; all 0-axiom)"
+      "edgeWidths/sum_edgeWidths/edgeWidths_pos/sum_edgeWidths_eq_degree in PuiseuxTheoremOQ03.lean (telescoping degree identity; widths sum to index span = degree; all 0-axiom)",
+      "width_mul_edgeSlope/edgeDrops/sum_edgeDrops/sum_rootValuations in PuiseuxTheoremOQ03.lean (Newton's valuation relation: width*slope = vertical drop, telescoping to (last).2-(first).2; sum of root valuations = v(a0)-v(ad); all 0-axiom)"
     ],
     "insights": [
       "Supporting-line predicate beats a verified convex-hull construction: same downstream value, far less proof burden, algorithm-agnostic.",
@@ -46,7 +47,9 @@
       "Model support points as Prod (N x Q), not a custom structure: fin_cases + norm_num then dispatch example goals cleanly.",
       "Edge existence reuses isLowerVertex_of_leftmost machinery verbatim: the argmin-of-edgeSlope supporting line through the leftmost point already passes through its argmin partner, so it is an edge, not merely a vertex witness.",
       "Mathlib drift hazard: gallery .lean files verified months ago can silently break against an updated local olean cache (List.not_mem_nil dropped its explicit argument); prefer simp over name-specific applications for List membership-in-nil contradictions.",
-      "Edge WIDTHS carry root multiplicities, complementing edge SLOPES (valuations): the polygon assigns (q.1-p.1) roots of valuation -edgeSlope p q to each edge. sum_edgeWidths + edgeSlopes_pairwise_le together are the full combinatorial bookkeeping of the Newton polygon theorem."
+      "Edge WIDTHS carry root multiplicities, complementing edge SLOPES (valuations): the polygon assigns (q.1-p.1) roots of valuation -edgeSlope p q to each edge. sum_edgeWidths + edgeSlopes_pairwise_le together are the full combinatorial bookkeeping of the Newton polygon theorem.",
+      "Multiplying the two layers gives Newton's valuation relation: width*slope per edge = the vertical drop q.2-p.2 (width_mul_edgeSlope), so the per-edge valuation contributions telescope (sum_edgeDrops) and the sum of all root valuations = v(a0)-v(ad). Note sum_edgeDrops NEEDS the chain hypothesis (unlike sum_edgeWidths) because width*slope only collapses to the drop on a non-degenerate edge (distinct indices).",
+      "Stale-olean gotcha: a separate file importing PuiseuxTheoremOQ03 to run #print axioms picks up main's OLD olean, not in-worktree edits (unknown-constant errors). Append #print axioms to the file itself and run lake env lean directly. Also: List.sum_map_neg is unreliable; phrase root-valuation sum as -(edgeDrops).sum."
     ],
     "mathlibGaps": [
       "No Newton polygon API in Mathlib 4.26.0 (no Polynomial.newtonPolygon / lowerConvexHull as combinatorial vertex data).",


### PR DESCRIPTION
## Summary

Adds the **synthesis layer** of the combinatorial Newton polygon in `PuiseuxTheoremOQ03.lean`, fusing the two halves that prior sessions built separately:

- **slopes** (`edgeSlopes_pairwise_le`) — root *valuations*, sorted by convexity
- **widths** (`sum_edgeWidths_eq_degree`) — root *multiplicities*, summing to the degree

Multiplying them gives **Newton's valuation relation**: the sum of the valuations of all roots equals `v(a₀) − v(a_d)`.

## New results (all 0-sorry / 0-axiom)

| Theorem | Statement |
|---|---|
| `width_mul_edgeSlope` | on a non-degenerate edge, `(q.1−p.1)·edgeSlope p q = q.2−p.2` (rise/run cancelled) |
| `edgeDrops` (def) | list of per-edge products width×slope along a chain |
| `sum_edgeDrops` | **telescoping valuation identity**: drops sum to `(last).2 − (first).2` |
| `sum_rootValuations` | **Newton's valuation relation**: `∑ root valuations = v(a₀) − v(a_d)` (= valuation of `±a₀/a_d`, the product of the roots) |

Plus a three-vertex worked synthesis (`threeVertex_edgeDrops = [-2,1]`, root-valuation sum `2 − 1 = 1`).

`sum_edgeDrops` requires the `IsChain (IsLowerEdge pts)` hypothesis (unlike `sum_edgeWidths`) because `width×slope` only collapses to the vertical drop on a non-degenerate edge — the chain's `p.1 < q.1` supplies that.

## Verification

`#print axioms` on every new theorem lists only `propext` / `Classical.choice` / `Quot.sound`. Built with `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean` (exit 0, no diagnostics).

File: 589→678 lines, 33→39 theorems, 7→8 defs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)