### PR TITLE
research(sperner-ndim-oq-02): global facet/opposite-vertex coherence (facet_vertex_injective) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -357,4 +357,22 @@ theorem canon_eq_of_facet_and_vertex {s t : CanonSimplex d N}
     image_univ_eq_insert_facet s k, image_univ_eq_insert_facet t l,
     hface, hvert]
 
+/-- **Global facet/opposite-vertex coherence.**  The pair `(facet s k, vertices s k)` — a
+facet of a canonical cell together with its opposite (deleted) vertex — identifies both the
+cell `s` and the index `k` uniquely across the *entire* carrier.  This packages the two
+halves of the facet section into the single injectivity fact the door-counting adjacency
+reasons with: the cross-cell direction `canon_eq_of_facet_and_vertex` collapses the cell
+(`s = t`), then the within-cell direction `facet_injective` collapses the index (`k = l`).
+The consequence is that the `(facet, opposite-vertex)` payload an `adj` entry stores can
+name at most one `(cell, facet)` slot — there is no orientation or gluing ambiguity. -/
+theorem facet_vertex_injective :
+    Function.Injective
+      (fun p : CanonSimplex d N × Fin (d + 1) => (facet p.1 p.2, vertices p.1 p.2)) := by
+  rintro ⟨s, k⟩ ⟨t, l⟩ h
+  simp only [Prod.mk.injEq] at h
+  obtain ⟨hface, hvert⟩ := h
+  obtain rfl : s = t := canon_eq_of_facet_and_vertex hface hvert
+  obtain rfl : k = l := facet_injective s hface
+  rfl
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1048,3 +1048,52 @@ any agent on this host while Docker's containerd stays corrupt.
    `onFace_toVertex`. ~300–500 L.
 3. Phase 2: last-face-door-oddness by induction on `d`; apply `sperner_ndim`.
 4. Retire false `boundary_doors_odd`/`boundary_verts_on_face`.
+
+## Session 2026-06-27 (researcher-2) — facet/opposite-vertex global coherence + `adj` recon
+
+**Mode**: ACT then SURVEY. **Outcome**: small verified increment (0-axiom) + actionable
+reconnaissance that re-sizes the remaining `adj` build.
+
+### What I Did (verified, 0-axiom)
+Added `facet_vertex_injective`: the map `(s, k) ↦ (facet s k, vertices s k)` is injective on
+`CanonSimplex d N × Fin (d+1)`. This packages the facet section's two halves into the single
+global-injectivity fact the door-counting adjacency reasons with — cross-cell
+`canon_eq_of_facet_and_vertex` collapses `s = t`, then within-cell `facet_injective` collapses
+`k = l`. Consequence: the `(facet, opposite-vertex)` payload an `adj` entry stores names at most
+one `(cell, facet)` slot (no gluing/orientation ambiguity). Offline-verified
+`LAKE_UNSAFE=1 lake env lean Proofs/SpernerNDimOQ02.lean` EXIT 0; `#print axioms` →
+`[propext, Classical.choice, Quot.sound]` only. File 360→378 lines, 19→20 theorems, 6 defs,
+0 sorries, 0 axioms.
+
+### Reconnaissance: where the geometric `adj` construction actually lives (IMPORTANT)
+The genuine next step (`adj : CanonSimplex → Fin(d+1) → Option(CanonSimplex × Fin(d+1))` +
+its 5 fields + `boundary_face`) needs the actual Freudenthal cell-flip. That flip machinery
+**already exists in `proofs/Proofs/SpernerGrid.lean`** (NOT SpernerGridBase): `GridSimplex.interiorFlip`
+(L574), `boundaryFlip0` (L819), `boundaryFlipLast` (L968), dispatched by `gridAdj` (L1113).
+BUT its header (SpernerGrid.lean L78–86) documents a **known correctness bug**: `gridAdj` treats
+"can't do boundary flip" as "geometric boundary", which is WRONG when the adjacent simplex has a
+different `miss` direction (cross-miss neighbours). The fix "requires extending GridSimplex to
+track cross-miss neighbors, or restricting to d=0". This is exactly why Option-C builds `adj`
+freshly over `CanonSimplex` rather than reusing `gridAdj`.
+
+**Re-sized estimate**: completing `adj` over `CanonSimplex` is a genuine multi-session
+DEEP-DIVE/BUILD (the flip + cross-miss handling + 5 field discharges + boundary induction,
+realistically >500 L) — too large to responsibly complete+verify in one offline session. The
+facet-combinatorics scaffolding the discharge will cite is now COMPLETE (facet_injective,
+canon_eq_of_facet_and_vertex, facet_vertex_injective, not_mem_facet_iff, image_univ_eq_insert_facet,
+onFace_toVertex). The missing input is purely the *geometric* neighbour-existence map.
+
+### Next steps (re-ordered with the recon)
+1. **(crux)** Decide adj source: (a) salvage SpernerGrid.lean's `interiorFlip`/`boundaryFlip*`
+   by adding cross-miss tracking, then lift across the `toVertex` bridge to `CanonSimplex`; OR
+   (b) define the flip directly on `CanonSimplex` via the Kuhn coordinate reflection. Path (b)
+   avoids inheriting the gridAdj bug but re-derives the flip.
+2. Discharge `adj_symm`/`adj_vertices`/`adj_ne`/`adj_unique_facet` from the facet scaffolding
+   (mostly present) + `boundary_face` via `onFace_toVertex`.
+3. Phase 2: last-face-door-oddness induction on `d`; apply `sperner_ndim`.
+
+### Build env note
+Docker still meta.db I/O-corrupt (containerd), but the host Mathlib olean cache is COMPLETE
+on this worktree (7382 + root Mathlib.olean present; SpernerGridBase/SpernerNDim oleans present)
+so `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/SpernerNDimOQ02.lean` works EXIT 0. (Source mtimes
+newer than oleans but functionally adequate — build clean, no stale-olean unknownIdentifier.)

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -72,7 +72,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.382Z",
-  "lastUpdate": "2026-06-27T20:00:00.000Z",
+  "lastUpdate": "2026-06-27",
   "significance": 8,
   "tractability": 6,
   "leanVerified": true,


### PR DESCRIPTION
## Summary

Adds one verified lemma to the Phase-1 facet section of `SpernerNDimOQ02.lean` and banks actionable reconnaissance on the remaining `adj` construction.

**`facet_vertex_injective`** — the map `(s, k) ↦ (facet s k, vertices s k)` is injective on `CanonSimplex d N × Fin (d+1)`. A facet of a canonical cell together with its opposite (deleted) vertex identifies both the cell and the index uniquely across the entire carrier. This packages the facet section's two existing halves into the single global-injectivity fact the door-counting adjacency reasons with:
- cross-cell: `canon_eq_of_facet_and_vertex` collapses the cell (`s = t`);
- within-cell: `facet_injective` collapses the index (`k = l`).

Consequence: the `(facet, opposite-vertex)` payload an `adj` entry stores names at most one `(cell, facet)` slot — no gluing/orientation ambiguity.

## Verification

- Offline-verified `LAKE_UNSAFE=1 lake env lean Proofs/SpernerNDimOQ02.lean` → **EXIT 0**, no diagnostics (Docker meta.db I/O-corrupt on host; cache complete so single-file fallback works).
- `#print axioms facet_vertex_injective` → `[propext, Classical.choice, Quot.sound]` only — **0-axiom** under the Axiom Integrity Policy.
- 360 → 378 lines, 19 → 20 theorems, **0 sorries, 0 axioms**.

## Reconnaissance (in `knowledge.md`)

The remaining geometric `adj` construction needs the Freudenthal cell-flip, which **already exists** in `proofs/Proofs/SpernerGrid.lean` (`interiorFlip`, `boundaryFlip0`, `boundaryFlipLast`, `gridAdj`) but carries a **documented cross-miss correctness bug** (its own header, L78–86). This re-sizes the remaining work as a genuine multi-session DEEP-DIVE: either salvage `gridAdj` with cross-miss tracking and lift across the `toVertex` bridge, or define the flip directly on `CanonSimplex`. The facet-combinatorics scaffolding the field discharges will cite is now complete; the missing input is purely the geometric neighbour-existence map.

## Honest scope

Modest, verified increment plus reconnaissance — not the `adj` crux itself, which is correctly left as a sized multi-session build. The OQ target (last-face door oddness) remains open; this strengthens the Phase-1 carrier scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)