### PR TITLE
Enrich Galois group of Xⁿ−p divisibility bracket (inverse-galois-d4-oq-02)

### DIFF
--- a/src/data/proofs/inverse-galois-d4-oq-02/annotations.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "inverse-galois-d4-oq-02",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "context",
+    "title": "Metacyclic structure of Gal(Xⁿ−p/ℚ)",
+    "content": "The splitting field of Xⁿ−p over ℚ is ℚ(ⁿ√p, ζₙ). An automorphism is pinned by where it sends the radical ⁿ√p ↦ ζₙᵃ·ⁿ√p and the root of unity ζₙ ↦ ζₙᵇ with gcd(b,n)=1. These data give the split exact sequence 1 → Cₙ → Gal → (ℤ/nℤ)ˣ → 1: the kernel Cₙ (translating the exponent a) and the quotient (ℤ/nℤ)ˣ ≅ Gal(ℚ(ζₙ)/ℚ) (acting on b). Under genericity (ℚ(ⁿ√p) and ℚ(ζₙ) linearly disjoint) the order is exactly n·φ(n). This file proves the verified shadows of both factors plus the Sₙ ceiling.",
+    "mathContext": "$1 \\to C_n \\to \\mathrm{Gal}(X^n-p/\\mathbb{Q}) \\to (\\mathbb{Z}/n\\mathbb{Z})^\\times \\to 1, \\qquad |\\mathrm{Gal}| = n\\,\\varphi(n)$",
+    "significance": "context",
+    "relatedConcepts": ["metacyclic group", "Kummer theory", "affine group", "holomorph", "semidirect product", "split exact sequence"],
+    "prerequisites": ["Galois theory", "group theory", "cyclotomic fields"]
+  },
+  {
+    "id": "ann-irreducible",
+    "proofId": "inverse-galois-d4-oq-02",
+    "range": { "startLine": 48, "endLine": 51 },
+    "type": "technique",
+    "title": "Irreducibility via Eisenstein at p",
+    "content": "Xⁿ−p is irreducible over ℚ for every n ≥ 2 and prime p by Eisenstein's criterion at the prime p: the prime p divides the constant coefficient −p but p² does not, and p divides no other coefficient (they are 0) and not the leading coefficient 1. This uniformity across all n is what makes the lower factor n ∣ |Gal| clean — unlike general Xⁿ−a, where irreducibility for even n needs the extra condition a ∉ −4ℚⁿ. The lemma is imported from the gallery's nth-root-irrational entry.",
+    "mathContext": "Eisenstein at $p$: $p \\mid p$, $p^2 \\nmid p$, $p \\nmid 1 \\Rightarrow X^n - p$ irreducible over $\\mathbb{Q}$.",
+    "significance": "key",
+    "relatedConcepts": ["Eisenstein's criterion", "Gauss's lemma", "irreducible polynomial"],
+    "prerequisites": ["polynomial rings", "unique factorization"]
+  },
+  {
+    "id": "ann-basic-facts",
+    "proofId": "inverse-galois-d4-oq-02",
+    "range": { "startLine": 53, "endLine": 66 },
+    "type": "definition",
+    "title": "Degree n, monic, and separable",
+    "content": "Three supporting facts that turn |Gal| into a clean degree count. The polynomial has natDegree n and is monic (leading term Xⁿ). Crucially it is separable: in characteristic 0 every irreducible polynomial is separable, so Xⁿ−p has n distinct roots in its splitting field. Separability is the hypothesis that lets card_of_separable identify |Gal| with the splitting-field degree, and lets card_rootSet_eq_natDegree count exactly n roots for the Sₙ embedding.",
+    "mathContext": "$\\deg(X^n-p)=n$, monic, separable (char $0$) $\\Rightarrow$ exactly $n$ distinct roots.",
+    "significance": "supporting",
+    "relatedConcepts": ["separable polynomial", "characteristic zero", "splitting field"],
+    "prerequisites": ["field theory", "polynomial degree"]
+  },
+  {
+    "id": "ann-n-dvd-gal",
+    "proofId": "inverse-galois-d4-oq-02",
+    "range": { "startLine": 72, "endLine": 84 },
+    "type": "insight",
+    "title": "n ∣ |Gal| — the radical lower factor",
+    "content": "For a separable polynomial, |Gal| equals the degree [SF:ℚ] of the splitting field (card_of_separable). Adjoining a single root ⁿ√p of the irreducible degree-n polynomial gives an intermediate field ℚ(ⁿ√p) of degree exactly n. By the tower law n = [ℚ(ⁿ√p):ℚ] divides [SF:ℚ] = |Gal|. This is the verified shadow of the kernel Cₙ in the metacyclic sequence, and it generalizes the parent entry's four_dvd_x4_sub_2_gal_card (n=4: 4 ∣ 8).",
+    "mathContext": "$n = [\\mathbb{Q}(\\sqrt[n]{p}):\\mathbb{Q}] \\mid [\\mathrm{SF}:\\mathbb{Q}] = |\\mathrm{Gal}|$",
+    "significance": "key",
+    "relatedConcepts": ["tower law", "primitive element", "radical extension", "Lagrange's theorem"],
+    "prerequisites": ["field extension degree", "Galois correspondence"]
+  },
+  {
+    "id": "ann-factorial",
+    "proofId": "inverse-galois-d4-oq-02",
+    "range": { "startLine": 90, "endLine": 108 },
+    "type": "insight",
+    "title": "|Gal| ∣ n! — the Sₙ ceiling",
+    "content": "A Galois automorphism is determined by its action on the n roots, and that action is faithful (galActionHom_injective): the only automorphism fixing all roots is the identity. This injects Gal into the symmetric group Sₙ on the root set, whose order is n!. By Lagrange |Gal| ∣ n!. The exact root count n comes from card_rootSet_eq_natDegree (separable, splits). This is the universal upper bound for any degree-n polynomial; it generalizes the parent's x4_sub_2_gal_card_dvd_24 (24 = 4!).",
+    "mathContext": "$\\mathrm{Gal} \\hookrightarrow S_n \\Rightarrow |\\mathrm{Gal}| \\mid |S_n| = n!$",
+    "significance": "key",
+    "relatedConcepts": ["symmetric group", "faithful action", "Galois group as permutation group", "Lagrange's theorem"],
+    "prerequisites": ["group actions", "permutation groups"]
+  },
+  {
+    "id": "ann-roots-of-unity",
+    "proofId": "inverse-galois-d4-oq-02",
+    "range": { "startLine": 142, "endLine": 171 },
+    "type": "insight",
+    "title": "Roots of unity manufactured from the roots themselves",
+    "content": "The heart of the cyclotomic factor. Every root β of Xⁿ−p satisfies βⁿ = p, the same value for all n roots. So for a fixed nonzero root α, each ratio β/α satisfies (β/α)ⁿ = p/p = 1 — it is an n-th root of unity. The map β ↦ β/α is injective (α is cancellable), so the n distinct roots produce n distinct n-th roots of unity already living in the splitting field. HasEnoughRootsOfUnity.of_card_le then upgrades 'at least n n-th roots of unity' to 'contains a primitive n-th root ζₙ'. No separate cyclotomic construction is needed.",
+    "mathContext": "$\\beta^n = p = \\alpha^n \\Rightarrow (\\beta/\\alpha)^n = 1$; the $n$ distinct $\\beta/\\alpha$ are the $n$-th roots of unity, forcing a primitive $\\zeta_n \\in \\mathrm{SF}$.",
+    "significance": "key",
+    "relatedConcepts": ["roots of unity", "primitive root of unity", "HasEnoughRootsOfUnity", "Kummer theory"],
+    "prerequisites": ["roots of unity", "injective maps", "field arithmetic"]
+  },
+  {
+    "id": "ann-cyclotomic-tower",
+    "proofId": "inverse-galois-d4-oq-02",
+    "range": { "startLine": 172, "endLine": 183 },
+    "type": "insight",
+    "title": "φ(n) ∣ |Gal| — the cyclotomic quotient witness",
+    "content": "Given the primitive root ζₙ in the splitting field, its minimal polynomial over ℚ is the n-th cyclotomic polynomial Φₙ (irreducible over ℚ by cyclotomic.irreducible_rat), which has degree φ(n). So the intermediate field ℚ(ζₙ) has degree [ℚ(ζₙ):ℚ] = φ(n), and the tower law gives φ(n) ∣ [SF:ℚ] = |Gal|. This is the verified shadow of the quotient Gal ↠ Gal(ℚ(ζₙ)/ℚ) ≅ (ℤ/nℤ)ˣ — the metacyclic ingredient absent from the parent entry. Together with n ∣ |Gal| it pins both factors of n·φ(n) from below.",
+    "mathContext": "$[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}] = \\deg \\Phi_n = \\varphi(n) \\mid [\\mathrm{SF}:\\mathbb{Q}] = |\\mathrm{Gal}|$",
+    "significance": "key",
+    "relatedConcepts": ["cyclotomic polynomial", "Euler totient", "minimal polynomial", "tower law", "(ℤ/nℤ)ˣ"],
+    "prerequisites": ["cyclotomic fields", "minimal polynomials", "field extension degree"]
+  }
+]

--- a/src/data/proofs/inverse-galois-d4-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02/meta.json
@@ -89,6 +89,43 @@
       "**Sharp at n = 4**: For n=4, p=2 the bracket gives 4 ∣ |Gal|, φ(4)=2 ∣ |Gal|, |Gal| ∣ 24. The parent entry's independent ℝ-embedding argument pins |Gal| = 8 inside this bracket — both factors 4 and 2 are achieved, and 8 ∣ 24."
     ]
   },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: the metacyclic divisibility bracket",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Frames the open question: Gal(Xⁿ−p/ℚ) is metacyclic of order n·φ(n), sitting in the split exact sequence 1 → Cₙ → Gal → (ℤ/nℤ)ˣ → 1. This file proves the verified two-sided bracket n ∣ |Gal| ∣ n! plus the cyclotomic lower factor φ(n) ∣ |Gal|, generalizing the parent n=4 lemmas and adding the (ℤ/nℤ)ˣ-quotient witness."
+    },
+    {
+      "id": "part-i-basic-facts",
+      "title": "Part I — Basic facts about Xⁿ − p",
+      "startLine": 44,
+      "endLine": 66,
+      "summary": "Four foundational lemmas about the polynomial Xⁿ − p over ℚ for prime p: irreducibility (Eisenstein at p, reusing the gallery lemma eisenstein_X_pow_sub_prime), degree n, monicity, and separability (irreducible in characteristic 0). These feed all three divisibility results."
+    },
+    {
+      "id": "part-ii-lower-factor",
+      "title": "Part II — The lower factor n ∣ |Gal|",
+      "startLine": 68,
+      "endLine": 84,
+      "summary": "Proves n ∣ |Gal(Xⁿ−p/ℚ)|: card_of_separable turns |Gal| into the splitting-field degree, and the irreducible degree n = [ℚ(ⁿ√p):ℚ] divides that degree via irred_monic_degree_dvd_splitting_finrank. Generalizes the parent's four_dvd_x4_sub_2_gal_card."
+    },
+    {
+      "id": "part-iii-upper-bound",
+      "title": "Part III — The upper bound |Gal| ∣ n!",
+      "startLine": 86,
+      "endLine": 108,
+      "summary": "Proves |Gal| ∣ n!: the Galois action on the n roots is faithful (galActionHom_injective), embedding Gal ↪ Sₙ, whose order is n!. card_rootSet_eq_natDegree supplies the exact root count n. Generalizes the parent's x4_sub_2_gal_card_dvd_24."
+    },
+    {
+      "id": "part-iv-cyclotomic",
+      "title": "Part IV — The cyclotomic factor φ(n) ∣ |Gal|",
+      "startLine": 110,
+      "endLine": 185,
+      "summary": "The new metacyclic ingredient. A primitive n-th root of unity is built from the roots of Xⁿ−p themselves (the ratios β/α of the n roots are the n distinct n-th roots of unity), so ℚ(ζₙ) ⊆ splitting field with [ℚ(ζₙ):ℚ] = φ(n); the tower law forces φ(n) ∣ |Gal|. Witnesses the quotient Gal ↠ (ℤ/nℤ)ˣ."
+    }
+  ],
   "conclusion": {
     "summary": "Verified divisibility skeleton for Gal(Xⁿ−p/ℚ): n ∣ |Gal|, φ(n) ∣ |Gal|, and |Gal| ∣ n!, for every n ≥ 2 and prime p. 7 theorems, 0 sorries, 0 axioms. The cyclotomic factor φ(n) ∣ |Gal| (via a primitive n-th root of unity built from the roots of Xⁿ−p) is the new metacyclic ingredient beyond the parent D₄ entry.",
     "implications": "Generalizes the parent's n=4 divisibility lemmas (four_dvd_x4_sub_2_gal_card, x4_sub_2_gal_card_dvd_24) to all degrees and supplies the cyclotomic-quotient factor, narrowing the order of Gal(Xⁿ−p/ℚ) to a multiple of lcm(n, φ(n)) dividing n!. This is the verified scaffold on which the exact metacyclic computation |Gal| = n·φ(n) can be assembled.",


### PR DESCRIPTION
Enrichment pass for `inverse-galois-d4-oq-02` (passes: 0, quality: 33).

## Gaps addressed
This entry had a rich `meta.json` overview/conclusion but was missing a `sections` array and had **no `annotations.json`** at all.

- **Added `sections`** (5 sections) covering the full 185-line Lean file: overview/metacyclic framing, Part I basic facts (Eisenstein/degree/monic/separable), Part II `n ∣ |Gal|`, Part III `|Gal| ∣ n!`, Part IV `φ(n) ∣ |Gal|`.
- **Created `annotations.json`** with 7 substantive annotations, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  - the metacyclic exact sequence framing
  - Eisenstein irreducibility (uniform in n)
  - degree/monic/separable supporting facts
  - the radical lower factor n ∣ |Gal| (tower law)
  - the Sₙ ceiling |Gal| ∣ n! (faithful root action)
  - roots of unity manufactured from the roots themselves (β/α)
  - the cyclotomic quotient witness φ(n) ∣ |Gal|

## Verification
- `meta.json` 12.6 KB — well under the 60 KB cap; all collections under their caps.
- `pnpm build` passes (JSON validation + tsc + vite).
- No axiom/status changes; existing `verified`/0-axiom claims left intact.