### PR TITLE
research(inverse-galois-d4-oq-02-oq-03): coprime sharpness of the metacyclic bracket + exact cubic |Gal(X³−p)| = 6 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/InverseGaloisD4OQ02OQ03.lean
+++ b/proofs/Proofs/InverseGaloisD4OQ02OQ03.lean
@@ -1,0 +1,102 @@
+/-
+# Inverse Galois: the coprime sharpness of the metacyclic bracket (inverse-galois-d4-oq-02-oq-03)
+
+The parent entry `Proofs.InverseGaloisD4OQ02` establishes, for a prime `p` and `n ≥ 2`,
+the two independent lower divisibilities of the order of `Gal(Xⁿ - p / ℚ)`
+
+      n ∣ |Gal|        (`n_dvd_gal_card`,      the radical/kernel factor `Cₙ`)
+      φ(n) ∣ |Gal|     (`totient_dvd_gal_card`, the cyclotomic/quotient factor `(ℤ/n)ˣ`)
+
+together with the upper bound `|Gal| ∣ n!` (`gal_card_dvd_factorial`).  The metacyclic
+order conjectured under genericity is `n·φ(n)`, the order of the holomorph
+`ℤ/n ⋊ (ℤ/n)ˣ`.
+
+This file resolves the third open question of the parent: it *combines* the two lower
+factors into a single lower bound and characterizes when that bound already reaches the
+full metacyclic order without any genericity hypothesis.
+
+  * `lcm_dvd_gal_card`            : `lcm(n, φ(n)) ∣ |Gal|`, the sharp combination of the
+                                     two independent factors (`lcm`, not the product,
+                                     because `n` and `φ(n)` may share factors — e.g.
+                                     `n = 4`, `φ(4) = 2`, `lcm = 4`).
+  * `mul_totient_dvd_gal_card_of_coprime`
+                                   : when `gcd(n, φ(n)) = 1` the lcm *is* the product,
+                                     so the full metacyclic order `n·φ(n) ∣ |Gal|`
+                                     drops out for free — a lower bound with no
+                                     linear-disjointness assumption.
+
+The cubic case `n = 3` is the sharp witness.  There `gcd(3, φ(3)) = gcd(3, 2) = 1`, so
+`3·φ(3) = 6 ∣ |Gal(X³-p)|`; combined with `|Gal| ∣ 3! = 6` this *pins the order exactly*:
+
+      |Gal(X³ - p / ℚ)| = 6  =  |S₃|   for EVERY prime p   (`gal_card_cubic_eq_six`).
+
+This is the cubic analogue of the base entry's `|Gal(X⁴-2/ℚ)| = 8`, but it is uniform in
+the prime `p` and falls straight out of the divisibility bracket plus coprimality — no
+separate ℝ-embedding or resolvent argument is needed.  (For `n = 4` the two factors
+overlap, `lcm(4, 2) = 4 ≠ 8`, so coprimality fails and the bracket alone does not pin the
+order — exactly why the base entry needed an extra argument for `|Gal| = 8`.)
+
+Status: 0 sorries, 0 axioms, no `native_decide`.  `#print axioms` on the headline
+theorems reports only `propext, Classical.choice, Quot.sound`.
+-/
+import Mathlib
+import Proofs.InverseGaloisD4OQ02
+
+namespace InverseGaloisExtensions
+
+open Polynomial
+
+-- ============================================================================
+-- Part I: The combined lower bound  lcm(n, φ(n)) ∣ |Gal|
+-- ============================================================================
+
+/-- **`lcm(n, φ(n)) ∣ |Gal(Xⁿ-p/ℚ)|`.** The two independent lower factors
+`n ∣ |Gal|` (kernel `Cₙ`) and `φ(n) ∣ |Gal|` (quotient `(ℤ/n)ˣ`) combine to their least
+common multiple — the sharp common consequence, since `n` and `φ(n)` may share prime
+factors (e.g. `n = 4`, `φ(4) = 2`, `lcm = 4`). -/
+theorem lcm_dvd_gal_card (n p : ℕ) (hn : 2 ≤ n) (hp : p.Prime) :
+    Nat.lcm n n.totient ∣ Fintype.card (X ^ n - C (p : ℚ) : ℚ[X]).Gal :=
+  Nat.lcm_dvd (n_dvd_gal_card n p hn hp) (totient_dvd_gal_card n p hn hp)
+
+-- ============================================================================
+-- Part II: Coprime sharpness — the full metacyclic order is forced
+-- ============================================================================
+
+/-- **`gcd(n, φ(n)) = 1 ⟹ n·φ(n) ∣ |Gal(Xⁿ-p/ℚ)|`.** When the radical degree `n` and
+the cyclotomic degree `φ(n)` are coprime, their lcm equals their product, so the full
+metacyclic order `n·φ(n)` divides `|Gal|` — a lower bound obtained with no
+linear-disjointness / genericity hypothesis.  Combined with the upper bound `|Gal| ∣ n!`,
+whenever `n·φ(n) = n!` (e.g. `n = 3`) this pins `|Gal|` exactly. -/
+theorem mul_totient_dvd_gal_card_of_coprime (n p : ℕ) (hn : 2 ≤ n) (hp : p.Prime)
+    (hcop : Nat.Coprime n n.totient) :
+    n * n.totient ∣ Fintype.card (X ^ n - C (p : ℚ) : ℚ[X]).Gal := by
+  rw [← Nat.Coprime.lcm_eq_mul hcop]
+  exact lcm_dvd_gal_card n p hn hp
+
+-- ============================================================================
+-- Part III: The sharp cubic witness  |Gal(X³-p/ℚ)| = 6  for every prime p
+-- ============================================================================
+
+/-- **`6 ∣ |Gal(X³-p/ℚ)|`.** For `n = 3` the factors are coprime,
+`gcd(3, φ(3)) = gcd(3, 2) = 1`, so the full metacyclic order `3·φ(3) = 6` divides the
+order of the cubic Galois group for every prime `p`. -/
+theorem six_dvd_gal_card_cubic (p : ℕ) (hp : p.Prime) :
+    6 ∣ Fintype.card (X ^ 3 - C (p : ℚ) : ℚ[X]).Gal := by
+  have h := mul_totient_dvd_gal_card_of_coprime 3 p (by norm_num) hp (by decide)
+  have h6 : (3 : ℕ) * Nat.totient 3 = 6 := by decide
+  rwa [h6] at h
+
+/-- **`|Gal(X³-p/ℚ)| = 6`** for every prime `p`.  The coprime lower bound `6 ∣ |Gal|`
+and the symmetric-group upper bound `|Gal| ∣ 3! = 6` squeeze the order to exactly `6`,
+identifying the cubic Galois group with `S₃` uniformly in `p`.  This is the cubic
+analogue of the base entry's `|Gal(X⁴-2/ℚ)| = 8`, here uniform in the prime and derived
+purely from the divisibility bracket. -/
+theorem gal_card_cubic_eq_six (p : ℕ) (hp : p.Prime) :
+    Fintype.card (X ^ 3 - C (p : ℚ) : ℚ[X]).Gal = 6 := by
+  have hlow := six_dvd_gal_card_cubic p hp
+  have hhigh := gal_card_dvd_factorial 3 p (by norm_num) hp
+  have h6 : Nat.factorial 3 = 6 := by decide
+  rw [h6] at hhigh
+  exact Nat.dvd_antisymm hhigh hlow
+
+end InverseGaloisExtensions

--- a/research/problems/inverse-galois-d4-oq-02/knowledge.md
+++ b/research/problems/inverse-galois-d4-oq-02/knowledge.md
@@ -55,10 +55,29 @@ Gallery entry `src/data/proofs/inverse-galois-d4-oq-02/`.
 
 ---
 
+## Child entry: coprime sharpness (inverse-galois-d4-oq-02-oq-03)
+
+`Proofs/InverseGaloisD4OQ02OQ03.lean` (4 theorems, 0 sorries, 0 axioms; `#print axioms` =
+propext/Classical.choice/Quot.sound only) completes the "lcm + sharpness" next step below:
+
+- `lcm_dvd_gal_card : lcm(n, φ(n)) ∣ |Gal(Xⁿ−p)|` — combines the two lower factors via `Nat.lcm_dvd`.
+  Must be the **lcm, not the product**, since `n` and `φ(n)` may overlap (n=4: lcm(4,2)=4).
+- `mul_totient_dvd_gal_card_of_coprime : gcd(n,φ(n))=1 ⟹ n·φ(n) ∣ |Gal|` — `Nat.Coprime.lcm_eq_mul`
+  upgrades the lcm to the full metacyclic order, with **no genericity hypothesis** on the lower half.
+- `gal_card_cubic_eq_six : |Gal(X³−p/ℚ)| = 6` for every prime `p`. Coprime (gcd(3,2)=1) gives 6 ∣ |Gal|;
+  parent's `gal_card_dvd_factorial` gives |Gal| ∣ 3! = 6; `Nat.dvd_antisymm` squeezes. Cubic analogue of
+  the base |Gal(X⁴−2)| = 8, but uniform in `p` and argument-free.
+
+**Why n=4 is outside this regime**: gcd(4, φ(4)=2) = 2 ≠ 1, so lcm(4,2) = 4 ≠ 8 — the bracket alone
+cannot pin |Gal| = 8; that's exactly why the base D₄ entry needed a separate ℝ-embedding argument.
+
+Gallery entry `src/data/proofs/inverse-galois-d4-oq-02-oq-03/`. Same single-file `lake env lean` recipe.
+
 ## Next Steps
 
 - Exact order `|Gal| = n·φ(n)` under genericity: prove the upper bound `|Gal| ≤ n·φ(n)` via the tower
   `SF = ℚ(ζₙ)(ⁿ√p)`, i.e. `[SF:ℚ(ζₙ)] ≤ n` (root of `Xⁿ−p` over `ℚ(ζₙ)`) and `[ℚ(ζₙ):ℚ] = φ(n)`.
   The hard formalization step is `splittingField (Xⁿ−p) = ℚ(ζₙ, ⁿ√p)` (all roots are `ⁿ√p · ζₙᵏ`).
-- `lcm(n, φ(n)) ∣ |Gal|` by combining the two lower factors; sharp when `gcd(n, φ(n)) = 1`.
+- Non-coprime case (n=4): recover the full `n·φ(n)` beyond `lcm(n,φ(n))` via an independent kernel×quotient
+  product witness.
 - Identify the semidirect-product structure `Gal ≅ ℤ/n ⋊ (ℤ/n)ˣ` explicitly.

--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-03/meta.json
@@ -1,0 +1,100 @@
+{
+  "id": "inverse-galois-d4-oq-02-oq-03",
+  "title": "Galois Group of Xⁿ−p: Coprime Sharpness lcm(n,φ(n)) ∣ |Gal| and the Exact Cubic |Gal(X³−p)| = 6",
+  "slug": "inverse-galois-d4-oq-02-oq-03",
+  "description": "Resolves the third open question of the parent metacyclic-bracket entry: combine the two independent lower divisibilities n ∣ |Gal| (radical kernel Cₙ) and φ(n) ∣ |Gal| (cyclotomic quotient (ℤ/n)ˣ) of |Gal(Xⁿ−p/ℚ)| into their least common multiple lcm(n,φ(n)) ∣ |Gal| (lcm_dvd_gal_card), and characterize when that bound is sharp. When gcd(n,φ(n)) = 1 the lcm equals the product, so the full metacyclic order n·φ(n) ∣ |Gal| follows with no genericity/linear-disjointness hypothesis (mul_totient_dvd_gal_card_of_coprime). The cubic case n = 3 is the sharp witness: gcd(3,φ(3)) = gcd(3,2) = 1 gives 6 ∣ |Gal(X³−p)|, and combined with the parent's upper bound |Gal| ∣ 3! = 6 this pins the order exactly — |Gal(X³−p/ℚ)| = 6 = |S₃| for EVERY prime p (gal_card_cubic_eq_six). This is the cubic analogue of the base entry's |Gal(X⁴−2/ℚ)| = 8, but uniform in the prime p and obtained purely from the divisibility bracket plus coprimality; no ℝ-embedding or resolvent argument is needed. For n = 4 the two factors overlap (lcm(4,2) = 4 ≠ 8), so coprimality fails and the bracket alone cannot pin the order — exactly why the base D₄ entry needed an extra argument. 4 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher (researcher-7)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InverseGaloisD4OQ02OQ03.lean",
+    "parentProof": "inverse-galois-d4-oq-02",
+    "openQuestionId": "inverse-galois-d4-oq-02-oq-03",
+    "tags": [
+      "galois-theory",
+      "inverse-galois",
+      "number-theory",
+      "metacyclic-group",
+      "cyclotomic",
+      "totient",
+      "symmetric-group",
+      "field-extensions",
+      "polynomial"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 102,
+    "theoremCount": 4,
+    "assumptions": "None beyond the foundational propext / Classical.choice / Quot.sound. #print axioms on all four theorems (lcm_dvd_gal_card, mul_totient_dvd_gal_card_of_coprime, six_dvd_gal_card_cubic, gal_card_cubic_eq_six) reports only those three. The `decide` calls (Nat.Coprime 3 (φ 3), 3·φ(3) = 6, 3! = 6) are kernel decide, not native_decide — no Lean.ofReduceBool.",
+    "buildStatus": "Verified via `LAKE_UNSAFE=1 lake env lean Proofs/InverseGaloisD4OQ02OQ03.lean` against pinned Mathlib v4.26.0 (single-file elaboration against prebuilt parent oleans; host docker image build skipped due to host disk at 97%). 0 errors. #print axioms confirms 0 non-foundational axioms.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.lcm_dvd",
+        "description": "If a ∣ c and b ∣ c then lcm a b ∣ c; combines the two independent lower factors n and φ(n) into lcm(n, φ(n)).",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.Coprime.lcm_eq_mul",
+        "description": "For coprime a, b the lcm equals the product; turns lcm(n, φ(n)) ∣ |Gal| into n·φ(n) ∣ |Gal| under gcd(n, φ(n)) = 1.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_antisymm",
+        "description": "Mutual divisibility forces equality; squeezes |Gal(X³−p)| between 6 ∣ |Gal| and |Gal| ∣ 6.",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "InverseGaloisExtensions.n_dvd_gal_card",
+        "description": "Parent lemma: n ∣ |Gal(Xⁿ−p/ℚ)| (irreducible degree divides the splitting-field degree).",
+        "module": "Proofs.InverseGaloisD4OQ02"
+      },
+      {
+        "theorem": "InverseGaloisExtensions.totient_dvd_gal_card",
+        "description": "Parent lemma: φ(n) ∣ |Gal(Xⁿ−p/ℚ)| (cyclotomic subfield ℚ(ζₙ) of degree φ(n)).",
+        "module": "Proofs.InverseGaloisD4OQ02"
+      },
+      {
+        "theorem": "InverseGaloisExtensions.gal_card_dvd_factorial",
+        "description": "Parent lemma: |Gal(Xⁿ−p/ℚ)| ∣ n! (faithful action on the n roots embeds Gal ↪ Sₙ); supplies the upper bound for the cubic squeeze.",
+        "module": "Proofs.InverseGaloisD4OQ02"
+      }
+    ],
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Galois group of $X^n - p$ over $\\mathbb{Q}$ (prime $p$) is metacyclic, sitting in $1 \\to C_n \\to \\mathrm{Gal} \\to (\\mathbb{Z}/n)^\\times \\to 1$ with conjectured order $n\\,\\varphi(n)$ (the holomorph $\\mathbb{Z}/n \\rtimes (\\mathbb{Z}/n)^\\times$) under genericity. The parent entry proves the divisibility bracket $n \\mid |\\mathrm{Gal}|$, $\\varphi(n) \\mid |\\mathrm{Gal}|$, $|\\mathrm{Gal}| \\mid n!$. A natural question is whether the two lower factors can be merged and when the merge already reaches the full order. Because $n$ and $\\varphi(n)$ can share prime factors (e.g. $n = 4$, $\\varphi(4) = 2$), the correct merge is the lcm, not the product; the product is forced exactly when the two are coprime.",
+    "problemStatement": "Combine $n \\mid |\\mathrm{Gal}(X^n-p/\\mathbb{Q})|$ and $\\varphi(n) \\mid |\\mathrm{Gal}|$ into a single lower bound $\\mathrm{lcm}(n, \\varphi(n)) \\mid |\\mathrm{Gal}|$, and characterize when it is sharp — in particular show that $\\gcd(n, \\varphi(n)) = 1$ forces the full metacyclic order $n\\,\\varphi(n) \\mid |\\mathrm{Gal}|$ with no genericity hypothesis, and use the cubic case to pin $|\\mathrm{Gal}(X^3-p/\\mathbb{Q})|$ exactly.",
+    "proofStrategy": "(1) lcm bound: apply Nat.lcm_dvd to the two parent divisibilities. (2) Coprime sharpness: when gcd(n, φ(n)) = 1, Nat.Coprime.lcm_eq_mul rewrites lcm(n, φ(n)) to n·φ(n), so n·φ(n) ∣ |Gal| follows immediately. (3) Cubic witness: for n = 3, gcd(3, φ(3)) = gcd(3, 2) = 1 (kernel decide) gives 3·φ(3) = 6 ∣ |Gal(X³−p)|; the parent's upper bound |Gal| ∣ 3! = 6 plus Nat.dvd_antisymm forces |Gal| = 6 for every prime p.",
+    "keyInsights": [
+      "**lcm, not product**: The two lower factors n (kernel Cₙ) and φ(n) (quotient (ℤ/n)ˣ) are independent divisibilities, so their common consequence is lcm(n, φ(n)), not n·φ(n). The product divides |Gal| only when the factors are coprime — e.g. for n = 4, lcm(4, φ(4)=2) = 4, far short of the true |Gal| = 8.",
+      "**Coprimality buys the full order for free**: When gcd(n, φ(n)) = 1 the metacyclic order n·φ(n) divides |Gal| with NO linear-disjointness hypothesis. The genericity assumption is only needed for the matching upper bound |Gal| ≤ n·φ(n); the lower half is unconditional under coprimality.",
+      "**The cubic is pinned uniformly in p**: For n = 3 coprimality holds and n·φ(n) = 6 = 3!, so the lower bound 6 ∣ |Gal| meets the upper bound |Gal| ∣ 6 exactly. Hence |Gal(X³−p/ℚ)| = 6 = S₃ for every prime p, derived purely from the bracket — the cubic analogue of |Gal(X⁴−2)| = 8, but uniform and argument-free.",
+      "**Why n = 4 needed extra work**: For n = 4 the factors overlap (gcd(4, 2) = 2 ≠ 1, lcm = 4), so the divisibility bracket alone gives only 4 ∣ |Gal| ∣ 24 — it cannot distinguish |Gal| = 8 from other multiples of 4. This is precisely why the base D₄ entry required a separate ℝ-embedding argument that the cubic case avoids."
+    ]
+  },
+  "conclusion": {
+    "summary": "Combined the parent's two lower divisibilities into lcm(n, φ(n)) ∣ |Gal(Xⁿ−p/ℚ)|, and proved that gcd(n, φ(n)) = 1 forces the full metacyclic order n·φ(n) ∣ |Gal| with no genericity hypothesis. The cubic case is sharp: |Gal(X³−p/ℚ)| = 6 = |S₃| for every prime p, squeezed between the coprime lower bound 6 ∣ |Gal| and the parent's upper bound |Gal| ∣ 3! = 6. 4 theorems, 0 sorries, 0 axioms.",
+    "implications": "Identifies the exact regime in which the verified divisibility bracket already determines the Galois order without the unproven genericity/linear-disjointness hypothesis: precisely when gcd(n, φ(n)) = 1 and n·φ(n) = n! (the cubic). It also explains structurally why n = 4 fell outside that regime and needed the base entry's separate argument, sharpening the picture of what the metacyclic bracket can and cannot decide on its own.",
+    "openQuestions": [
+      "Characterize all n with n·φ(n) = n! (so that coprimality alone pins |Gal| = n·φ(n) = n!): n = 1, 2, 3 give equality; for n ≥ 4 the holomorph is a proper subgroup of Sₙ.",
+      "For coprime gcd(n, φ(n)) = 1 with n·φ(n) < n!, supply the matching upper bound |Gal| ≤ n·φ(n) (linear disjointness of ℚ(ⁿ√p) and ℚ(ζₙ)) to pin |Gal| = n·φ(n) even when the Sₙ bound is not tight.",
+      "Handle the non-coprime case gcd(n, φ(n)) > 1 (e.g. n = 4): the bracket gives only lcm(n, φ(n)) ∣ |Gal|, so an independent witness of the kernel × quotient product is needed to recover the full n·φ(n)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "inverse-galois-d4-oq-02",
+      "relationship": "parent — supplies the three divisibilities n ∣ |Gal|, φ(n) ∣ |Gal|, |Gal| ∣ n! that this entry combines (lcm) and sharpens (coprime ⟹ n·φ(n) ∣ |Gal|; exact cubic order)."
+    },
+    {
+      "proofId": "inverse-galois-d4",
+      "relationship": "grandparent — the n = 4, p = 2 case (|Gal| = 8). This entry explains why n = 4 falls outside the coprime regime (gcd(4, φ(4)) = 2) and so required that entry's separate ℝ-embedding argument."
+    },
+    {
+      "proofId": "inverse-galois-f20",
+      "relationship": "sibling — the n = 5, p = 2 case (F₂₀, gcd(5, φ(5)=4) = 1, so 20 = 5·φ(5) ∣ |Gal| by the coprime theorem here; |Gal| = 20 < 5! = 120 needs the genericity upper bound, outside the cubic squeeze)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves the **third open question** of the parent metacyclic-bracket entry [`inverse-galois-d4-oq-02`]: combine the two independent lower divisibilities of `|Gal(Xⁿ−p/ℚ)|` into a single bound and characterize when it is sharp.

The parent established `n ∣ |Gal|` (radical kernel `Cₙ`), `φ(n) ∣ |Gal|` (cyclotomic quotient `(ℤ/n)ˣ`), and `|Gal| ∣ n!`. This entry combines and sharpens them.

## New theorems (`Proofs/InverseGaloisD4OQ02OQ03.lean`, 4 theorems, 0 sorries, 0 axioms)

- **`lcm_dvd_gal_card`** — `lcm(n, φ(n)) ∣ |Gal(Xⁿ−p/ℚ)|`. The sharp common consequence of the two lower factors. Must be the *lcm, not the product*, since `n` and `φ(n)` may share prime factors (e.g. `n=4`: `lcm(4,2)=4`).
- **`mul_totient_dvd_gal_card_of_coprime`** — `gcd(n, φ(n)) = 1 ⟹ n·φ(n) ∣ |Gal|`. Under coprimality the full metacyclic order `n·φ(n)` divides `|Gal|` with **no genericity / linear-disjointness hypothesis** on the lower half.
- **`gal_card_cubic_eq_six`** — `|Gal(X³−p/ℚ)| = 6 = |S₃|` for **every prime `p`**. Coprimality (`gcd(3,2)=1`) gives `6 ∣ |Gal|`; the parent's `|Gal| ∣ 3! = 6` plus `Nat.dvd_antisymm` pins the order exactly. The cubic analogue of the base `|Gal(X⁴−2)| = 8`, but uniform in `p` and derived purely from the divisibility bracket — no ℝ-embedding or resolvent argument.

## Structural payoff

`n=4` has `gcd(4, φ(4)=2) = 2 ≠ 1`, so `lcm(4,2) = 4 ≠ 8` — the bracket alone *cannot* pin `|Gal| = 8`. This is exactly why the base D₄ entry required a separate ℝ-embedding argument that the cubic case avoids.

## Verification

`LAKE_UNSAFE=1 lake env lean Proofs/InverseGaloisD4OQ02OQ03.lean` against pinned Mathlib v4.26.0 (single-file elaboration against prebuilt parent oleans; docker image build skipped, host disk at 97%). **EXIT 0, clean.** `#print axioms` on all four theorems reports only `[propext, Classical.choice, Quot.sound]` — the `decide` calls are kernel decide, not `native_decide`. Genuinely 0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)