### PR TITLE
research(erdos-564-incomplete-01): verified tower-growth theory + parent parse fix [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos564Incomplete01.lean
+++ b/proofs/Proofs/Erdos564Incomplete01.lean
@@ -1,0 +1,110 @@
+/-
+  Erdős Problem #564 — verified tower-growth theory (erdos-564-incomplete-01)
+
+  **Parent problem (OPEN, $500).**  For the 3-uniform hypergraph Ramsey number
+  R₃(n) the known bounds (Erdős–Hajnal–Rado 1965) are
+      2^{cn²}  <  R₃(n)  <  2^{2^n},
+  i.e. a *singly* exponential lower bound and a *doubly* exponential upper bound.
+  Erdős asked whether the lower bound can be raised to `2^{2^{cn}}` — whether
+  R₃(n) reaches **tower height 2** from below.  `Erdos564Problem.lean` axiomatizes
+  the Ramsey number `R` and the two EHR bounds and defines the iterated-exponential
+  `tower` function, but develops almost no theory of `tower` (only the three
+  unfoldings `tower_zero/one/two` and positivity).
+
+  **This file.**  The phrase "tower height", on which the whole problem hinges, is
+  only meaningful once one knows the tower genuinely *grows* with its height and
+  with its base.  Here is that theory, fully verified and **0-axiom** (it touches
+  none of the parent's axioms — `#print axioms` on every result lists only
+  propext / Classical.choice / Quot.sound):
+
+    * `tower_lt_succ_height` : `tower k n < tower (k+1) n`              (height ↑)
+    * `tower_strictMono_height` : `StrictMono (k ↦ tower k n)`
+    * `tower_strictMono_base`   : `StrictMono (tower k)`               (base ↑)
+    * `self_le_tower`           : `n ≤ tower k n`
+    * `tower_one_lt_tower_two`  : `1 ≤ n → tower 1 n < tower 2 n`
+      — the *singly*-exponential known lower bound is strictly below the
+        *doubly*-exponential conjectured one: the exact gap Erdős #564 asks to close.
+
+  Nothing here resolves the open conjecture; this is the combinatorial scaffolding
+  that makes its statement ("can R₃ reach tower height 2?") precise.
+
+  Reference: https://erdosproblems.com/564
+-/
+
+import Mathlib
+import Proofs.Erdos564Problem
+
+open Erdos564
+
+namespace Erdos564.Incomplete01
+
+/-- One step of the tower is an exponential: `tower (k+1) n = 2 ^ tower k n`.
+This is the recursion `tower` is defined by, recorded as a rewrite lemma. -/
+theorem tower_succ (k n : ℕ) : tower (k + 1) n = 2 ^ tower k n := rfl
+
+/-- **Each extra level strictly increases the tower.**  `tower k n < tower (k+1) n`
+for every `k` and `n`, because `m < 2 ^ m` holds for every natural number `m`
+(including `m = 0`, where `0 < 1`).  No positivity hypothesis on `n` is needed. -/
+theorem tower_lt_succ_height (k n : ℕ) : tower k n < tower (k + 1) n := by
+  rw [tower_succ]
+  exact Nat.lt_two_pow_self
+
+/-- **The tower is strictly increasing in its height.**  For fixed base `n` the
+map `k ↦ tower k n` is strictly monotone — every additional `2^(·)` level makes
+the value strictly larger. -/
+theorem tower_strictMono_height (n : ℕ) : StrictMono (fun k => tower k n) :=
+  strictMono_nat_of_lt_succ (fun k => tower_lt_succ_height k n)
+
+/-- **The base is a lower bound for the whole tower.**  `n ≤ tower k n` for every
+height `k`: the tower never drops below its base.  Immediate from height-monotonicity
+applied to `0 ≤ k` together with `tower 0 n = n`. -/
+theorem self_le_tower (k n : ℕ) : n ≤ tower k n := by
+  have h := (tower_strictMono_height n).monotone (Nat.zero_le k)
+  rwa [tower_zero] at h
+
+/-- **The tower is strictly increasing in its base.**  For fixed height `k` the map
+`n ↦ tower k n` is strictly monotone.  Induction on `k`: the base case is the
+identity, and `2 ^ (·)` is strictly monotone on `ℕ`, so it preserves the inductive
+strict inequality. -/
+theorem tower_strictMono_base (k : ℕ) : StrictMono (tower k) := by
+  induction k with
+  | zero => intro a b h; simpa [tower_zero] using h
+  | succ k ih =>
+      intro a b h
+      simp only [tower_succ]
+      exact Nat.pow_lt_pow_right (by norm_num) (ih h)
+
+/-- The tower is (non-strictly) monotone in its base, for fixed height. -/
+theorem tower_mono_base (k : ℕ) : Monotone (tower k) :=
+  (tower_strictMono_base k).monotone
+
+/-- `tower 2 n = 2 ^ (2 ^ n)` — the doubly-exponential height appearing in both the
+EHR upper bound and the conjectured lower bound. -/
+theorem tower_two_eq (n : ℕ) : tower 2 n = 2 ^ (2 ^ n) := rfl
+
+/-- **The crux of Erdős #564, made precise.**  The known *singly*-exponential
+lower bound has tower height `1` (`tower 1 n = 2 ^ n`); the conjectured lower
+bound has tower height `2` (`tower 2 n = 2 ^ (2 ^ n)`).  For every `n` the
+former is strictly smaller than the latter:
+    `tower 1 n < tower 2 n`.
+So the conjecture genuinely asks to push R₃ up a whole tower level — closing the
+height gap between the EHR lower and upper bounds. -/
+theorem tower_one_lt_tower_two (n : ℕ) : tower 1 n < tower 2 n := by
+  have h1 : tower 1 n = 2 ^ n := tower_one n
+  have h2 : tower 2 n = 2 ^ (2 ^ n) := tower_two_eq n
+  rw [h1, h2]
+  -- 2 ^ n < 2 ^ (2 ^ n) since n < 2 ^ n for every n
+  exact Nat.pow_lt_pow_right (by norm_num) Nat.lt_two_pow_self
+
+/-! ### Concrete sanity checks -/
+
+/-- `tower 2 3 = 256`. -/
+theorem tower_two_three : tower 2 3 = 256 := by decide
+
+/-- `tower 3 1 = 16`: `tower 3 1 = 2 ^ tower 2 1 = 2 ^ (2 ^ (2 ^ 1)) = 2 ^ 4 = 16`. -/
+theorem tower_three_one : tower 3 1 = 16 := by decide
+
+/-- The base bound in action: `5 ≤ tower 4 5`. -/
+theorem self_le_tower_example : 5 ≤ tower 4 5 := self_le_tower 4 5
+
+end Erdos564.Incomplete01

--- a/proofs/Proofs/Erdos564Problem.lean
+++ b/proofs/Proofs/Erdos564Problem.lean
@@ -62,8 +62,8 @@ def HasHypergraphRamseyProperty (k m n : ℕ) : Prop :=
 /-- R_k(n) denotes the hypergraph Ramsey number (axiomatized). -/
 axiom R : ℕ → ℕ → ℕ
 
-/-- R_k(n) has the Ramsey property. -/
-/-- R_k(n) is minimal with the Ramsey property. -/
+/- R_k(n) has the Ramsey property. -/
+/- R_k(n) is minimal with the Ramsey property. -/
 /-
 ## Known Bounds (Erdős-Hajnal-Rado 1965)
 
@@ -147,11 +147,11 @@ theorem tower_pos (k n : ℕ) (hn : n ≥ 1) : tower k n ≥ 1 := by
 For very small cases, we can state known values of R₃(n).
 -/
 
-/-- R₃(3) is the smallest m where any 2-colouring of triples on m vertices
+/- R₃(3) is the smallest m where any 2-colouring of triples on m vertices
     yields a monochromatic triangle (3 vertices with all 3 triples same colour).
 
     It's known that R₃(3) = 4. -/
-/-- R₃(4) is known to be 13. -/
+/- R₃(4) is known to be 13. -/
 /-
 ## Comparison with Graph Ramsey Numbers
 
@@ -161,7 +161,7 @@ For graphs (k = 2), the Ramsey number R(n) = R₂(n,n) satisfies:
 This is singly exponential. For 3-uniform hypergraphs, growth is much faster.
 -/
 
-/-- Graph Ramsey numbers are exponential (Erdős-Szekeres bounds). -/
+/- Graph Ramsey numbers are exponential (Erdős-Szekeres bounds). -/
 /-- The known bounds can be restated using tower functions:
     For k = 2 (graphs): R₂(n) ~ tower(1, n)
     For k = 3: tower(1, n²) < R₃(n) < tower(2, n)
@@ -180,7 +180,7 @@ for the 4-colour version of this problem, suggesting the 2-colour case might
 also have such a bound.
 -/
 
-/-- For 4 colours, a doubly exponential lower bound is known.
+/- For 4 colours, a doubly exponential lower bound is known.
     (Erdős-Hajnal-Máté-Rado 1984)
 
     This is evidence that the 2-colour case might also have such a bound. -/

--- a/research/problems/erdos-564-incomplete-01/knowledge.md
+++ b/research/problems/erdos-564-incomplete-01/knowledge.md
@@ -1,2 +1,59 @@
-# Knowledge: erdos-564-incomplete-01
-*No research conducted yet*
+# Knowledge Base: erdos-564-incomplete-01
+
+Parent: Erdős Problem #564 — 3-uniform hypergraph Ramsey numbers R₃(n).
+**OPEN, $500 prize.** Known (Erdős–Hajnal–Rado 1965): 2^{cn²} < R₃(n) < 2^{2^n}.
+Erdős asks whether the lower bound can be raised to 2^{2^{cn}} (tower height 2).
+
+---
+
+## Session 1 (2026-06-27, researcher-3): verified tower-growth theory
+
+**Deliverable:** `proofs/Proofs/Erdos564Incomplete01.lean` (110 lines, 11 theorems,
+0 defs, **verified 0-sorry 0-axiom** — `#print axioms` lists only
+propext/Classical.choice/Quot.sound; the parent's R/EHR axioms and its sorry are
+NOT pulled in).
+
+The parent `Erdos564Problem.lean` defines `tower k n = 2↑↑k` from base n but proves
+almost no theory of it (only `tower_zero/one/two` and `tower_pos`). Since the whole
+problem is phrased in terms of "tower height", that growth theory was the missing
+scaffolding. Added:
+
+* `tower_succ`: `tower (k+1) n = 2 ^ tower k n` (rfl rewrite lemma).
+* `tower_lt_succ_height`: `tower k n < tower (k+1) n` for ALL k,n — from `m < 2^m`
+  (`Nat.lt_two_pow_self`); no positivity hypothesis needed (works at m=0: 0<1).
+* `tower_strictMono_height`: `StrictMono (k ↦ tower k n)` via
+  `strictMono_nat_of_lt_succ`.
+* `self_le_tower`: `n ≤ tower k n` (height-monotone at 0 ≤ k, tower 0 n = n).
+* `tower_strictMono_base`: `StrictMono (tower k)` — induction on k, successor step
+  composes IH with strict monotonicity of `2^(·)` (`Nat.pow_lt_pow_right`).
+* `tower_mono_base`: non-strict corollary.
+* `tower_two_eq`: `tower 2 n = 2 ^ (2 ^ n)`.
+* `tower_one_lt_tower_two`: **the crux** — `2^n < 2^{2^n}` for every n. This is the
+  formal statement that the singly-exponential known lower bound (height 1) sits
+  strictly below the doubly-exponential conjectured one (height 2): exactly the gap
+  Erdős #564 asks to close.
+* Concrete checks: `tower 2 3 = 256`, `tower 3 1 = 16`, `5 ≤ tower 4 5`.
+
+**Parent fix.** `Erdos564Problem.lean` did NOT parse on main: six dangling `/--`
+doc comments (lines 65, 66, 153, 154, 164, 186) sat before `/-` block comments /
+other doc comments with no intervening declaration → `unexpected token '/--';
+expected 'lemma'`. Converted those six to `/-`. Same bug class as the
+puiseux-theorem parent fix. (The parent still has its 3 axioms and 1 sorry
+`bounds_gap_enormous` — legitimate for an open problem; untouched.)
+
+GOTCHAs (session 1):
+* Parent olean was MISSING (file didn't parse, so never built). Had to build it
+  single-file AFTER the parse fix: `LAKE_UNSAFE=1 ./bin/lake env lean
+  Proofs/Erdos564Problem.lean -o .lake/build/lib/lean/Proofs/Erdos564Problem.olean`
+  — note the **extra `lean/` segment** in the dep-olean libdir (`build/lib/lean/Proofs`,
+  not `build/lib/Proofs`); `lake env lean` resolves imports against the former.
+* Importing a parent with axioms+sorry does not taint downstream `#print axioms`
+  unless the theorem transitively uses them — confirmed all 11 results 0-axiom.
+* `Nat.lt_two_pow_self` (m < 2^m) and `Nat.pow_lt_pow_right` (strict mono of b^·,
+  b>1) are the only nontrivial Mathlib lemmas used.
+
+## Dead ends / deferred
+* The open conjecture R₃(n) ≥ 2^{2^{cn}} is out of reach ($500 open problem).
+* Parent's `bounds_gap_enormous` (rpow inequality 2^{2^n}/2^{n²} > 10^100, n≥10)
+  left as the parent's sorry — provable via `2^n ≥ n²+924` induction + `rpow_sub`
+  + monotonicity + `norm_num` on `2^924 > 10^100`, but messy over rpow; deferred.

--- a/src/data/proofs/erdos-564-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-564-incomplete-01/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "erdos-564-incomplete-01",
+  "title": "Erdős #564: Verified Tower-Growth Theory",
+  "slug": "erdos-564-incomplete-01",
+  "description": "A standalone, fully-verified (0-sorry, 0-axiom) theory of the iterated-exponential tower function underlying Erdős Problem #564 (3-uniform hypergraph Ramsey numbers, OPEN, $500 prize). The parent file Erdos564Problem.lean axiomatizes the Ramsey number R and the Erdős–Hajnal–Rado bounds 2^{cn²} < R₃(n) < 2^{2^n} and defines the tower function tower(k,n) = 2↑↑k from base n, but proves almost no theory of it (only the unfoldings tower_zero/one/two and positivity). Since the entire problem is phrased in terms of 'tower height' — Erdős asks whether the singly-exponential lower bound (tower height 1) can be raised to the doubly-exponential 2^{2^{cn}} (tower height 2) — this file supplies the missing growth theory that makes that question precise: the tower is strictly increasing in its height (tower_lt_succ_height, tower_strictMono_height) and in its base (tower_strictMono_base), bounded below by its base (self_le_tower), and crucially the singly-exponential bound is strictly below the doubly-exponential one for every n (tower_one_lt_tower_two) — exactly the gap the open conjecture asks to close. Also repairs six dangling /-- doc comments in the parent Erdos564Problem.lean that made it fail to parse entirely.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://erdosproblems.com/564",
+    "date": "Erdős–Hajnal–Rado 1965; formalized 2026",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "ramsey-theory",
+      "hypergraph",
+      "erdos-problem",
+      "tower-function",
+      "infrastructure",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/Erdos564Incomplete01.lean",
+    "badge": "infrastructure",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 11 theorems are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms — the parent's R/EHR-bound axioms and its bounds_gap_enormous sorry are NOT pulled in). This file resolves none of the open conjecture; it is the verified combinatorial scaffolding making the 'tower height' framing of Erdős #564 precise. The parent Erdos564Problem.lean retains its 3 axioms (R, the two EHR bounds) and 1 sorry (bounds_gap_enormous), all legitimately so for an open problem.",
+    "originalContributions": [
+      "tower_succ: the defining recursion tower (k+1) n = 2 ^ tower k n recorded as a rewrite lemma",
+      "tower_lt_succ_height: each extra level strictly increases the tower — tower k n < tower (k+1) n for all k, n (via m < 2^m, no positivity hypothesis needed)",
+      "tower_strictMono_height: for fixed base, k ↦ tower k n is strictly monotone (the height genuinely grows)",
+      "self_le_tower: n ≤ tower k n for every height k (the tower never drops below its base)",
+      "tower_strictMono_base: for fixed height, n ↦ tower k n is strictly monotone (induction on k; 2^(·) is strictly monotone)",
+      "tower_mono_base: the non-strict base monotonicity corollary",
+      "tower_two_eq: tower 2 n = 2 ^ (2 ^ n), the doubly-exponential height in both the EHR upper bound and the conjectured lower bound",
+      "tower_one_lt_tower_two: THE CRUX of Erdős #564 made precise — the singly-exponential known lower bound (tower height 1) is strictly below the doubly-exponential conjectured lower bound (tower height 2) for every n; the exact height gap the open conjecture asks to close",
+      "Concrete sanity checks: tower 2 3 = 256, tower 3 1 = 16, 5 ≤ tower 4 5",
+      "Parent fix: repaired six dangling /-- doc comments (lines 65, 66, 153, 154, 164, 186) in Erdos564Problem.lean that caused 'unexpected token /--; expected lemma' parse errors — the parent file did not compile at all on main"
+    ],
+    "dateAdded": "2026-06-27",
+    "lineCount": 110,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #564 concerns the 3-uniform hypergraph Ramsey number R₃(n): the least m such that any 2-colouring of the triples on m vertices contains a monochromatic complete sub-hypergraph on n vertices. Erdős, Hajnal, and Rado (1965) proved 2^{cn²} < R₃(n) < 2^{2^n}: a singly-exponential lower bound and a doubly-exponential upper bound, leaving a gap of one full 'tower level'. Erdős offered $500 for deciding whether the lower bound can be raised to 2^{2^{cn}}, matching the tower height of the upper bound. For 4 colours such a doubly-exponential lower bound is known (Erdős–Hajnal–Máté–Rado 1984), which is the principal evidence for the 2-colour conjecture. The problem remains open.",
+    "problemStatement": "**Open Question (Erdős #564, $500)**: Is there a constant c > 0 such that R₃(n) ≥ 2^{2^{cn}} for all sufficiently large n? Equivalently, does the 3-uniform hypergraph Ramsey number reach tower height 2 from below, closing the gap with the EHR upper bound?\n\n**This deliverable**: not the conjecture (which is open), but the verified theory of the tower function in terms of which the conjecture is stated. The parent formalization defines tower(k,n) but proves no growth properties; without them 'tower height' is just notation. This file proves the tower strictly increases in height and base, and that the singly-exponential lower bound sits strictly below the doubly-exponential conjectured one — pinning down exactly what the open problem asks.",
+    "text": "A 110-line, fully-verified, 0-axiom Lean file building the growth theory of the iterated exponential tower(k,n) = 2↑↑k from base n. The central facts: tower_lt_succ_height (tower k n < tower (k+1) n, from the elementary m < 2^m, valid even at m = 0), which lifts to tower_strictMono_height (k ↦ tower k n strictly monotone); tower_strictMono_base (n ↦ tower k n strictly monotone, by induction on k using strict monotonicity of 2^(·)); self_le_tower (n ≤ tower k n); and the crux tower_one_lt_tower_two (2^n < 2^{2^n} for every n), which is the precise statement that the conjecture seeks to lift R₃ from tower height 1 to tower height 2. Concrete evaluations (tower 2 3 = 256, tower 3 1 = 16) anchor the definitions. The file also repairs six dangling /-- doc comments in the parent that made it fail to parse.",
+    "proofStrategy": "Everything reduces to two elementary facts about base-2 exponentiation on ℕ: m < 2^m (Nat.lt_two_pow_self) and strict monotonicity of 2^(·) (Nat.pow_lt_pow_right). Height growth is a single application of the first; height strict-monotonicity is strictMono_nat_of_lt_succ over it; base strict-monotonicity is an induction on the height where the successor step composes the inductive strict inequality with strict monotonicity of 2^(·). The base lower bound and the height-1-vs-2 crux are immediate corollaries.",
+    "keyInsights": [
+      "**'Tower height' needs a growth theorem to be meaningful.** The parent defines tower(k,n) but proves no monotonicity; this file supplies the strict growth in both arguments that turns 'tower height 2' from notation into a comparison the conjecture can be stated against.",
+      "**The height gap is the whole problem.** tower_one_lt_tower_two (2^n < 2^{2^n}) is the formal content of 'the EHR lower bound is one tower level below the upper bound' — Erdős #564 asks whether R₃ can be pushed across that gap.",
+      "**No positivity hypothesis is needed for height growth.** Because m < 2^m holds even at m = 0, tower k n < tower (k+1) n holds for all n including 0 — a small but clean strengthening over the parent's positivity-gated lemma.",
+      "**Honest scope.** The open conjecture is untouched and the parent's deep axioms (R, the EHR bounds) and its arithmetic sorry are deliberately not imported into any result here; #print axioms confirms 0-axiom status."
+    ],
+    "prerequisites": [
+      "Ramsey theory and hypergraph Ramsey numbers",
+      "Iterated exponentials / tower (Knuth up-arrow) functions",
+      "Strict monotonicity of exponentiation on ℕ",
+      "Mathlib Nat.lt_two_pow_self, Nat.pow_lt_pow_right, strictMono_nat_of_lt_succ",
+      "Parent gallery entry erdos-564 (the axiomatized formalization and tower definition)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "height-growth",
+      "title": "Growth in Tower Height",
+      "startLine": 41,
+      "endLine": 70,
+      "summary": "tower_succ records the recursion tower (k+1) n = 2 ^ tower k n. tower_lt_succ_height proves tower k n < tower (k+1) n from m < 2^m (Nat.lt_two_pow_self), with no positivity hypothesis. tower_strictMono_height upgrades this to strict monotonicity of k ↦ tower k n via strictMono_nat_of_lt_succ, and self_le_tower derives n ≤ tower k n from height-monotonicity at 0 ≤ k.",
+      "mathContext": "$\\text{tower}(k,n) < \\text{tower}(k+1,n) = 2^{\\text{tower}(k,n)}$ since $m < 2^m$; hence $n = \\text{tower}(0,n) \\le \\text{tower}(k,n)$."
+    },
+    {
+      "id": "base-growth",
+      "title": "Growth in Tower Base and the Height-1-vs-2 Crux",
+      "startLine": 71,
+      "endLine": 98,
+      "summary": "tower_strictMono_base proves n ↦ tower k n is strictly monotone by induction on k (successor step composes the IH with strict monotonicity of 2^(·)); tower_mono_base is the non-strict corollary. tower_two_eq gives tower 2 n = 2^(2^n). The crux tower_one_lt_tower_two shows 2^n < 2^(2^n) for every n — the singly-exponential known lower bound is strictly below the doubly-exponential conjectured one.",
+      "mathContext": "$\\text{tower}(1,n) = 2^n < 2^{2^n} = \\text{tower}(2,n)$: the EHR lower bound is one tower level below the upper bound."
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Sanity Checks",
+      "startLine": 99,
+      "endLine": 110,
+      "summary": "tower 2 3 = 256, tower 3 1 = 16 (both by decide), and 5 ≤ tower 4 5 instantiating self_le_tower.",
+      "mathContext": "$\\text{tower}(2,3)=2^{2^3}=2^8=256$; $\\text{tower}(3,1)=2^{2^{2}}=2^4=16$."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "tower_lt_succ_height",
+      "type": "theorem",
+      "statement": "$\\forall k\\, n,\\ \\text{tower}\\,k\\,n < \\text{tower}\\,(k+1)\\,n$",
+      "significance": "Each additional level of the tower strictly increases its value, with no positivity hypothesis on the base. The foundational growth fact from which height-monotonicity follows.",
+      "description": "Rewrite tower (k+1) n = 2 ^ tower k n and apply m < 2^m (Nat.lt_two_pow_self)."
+    },
+    {
+      "name": "tower_strictMono_height",
+      "type": "theorem",
+      "statement": "$\\forall n,\\ \\text{StrictMono}\\,(k \\mapsto \\text{tower}\\,k\\,n)$",
+      "significance": "For a fixed base the tower is strictly increasing in its height — the formal content of 'tower height' as a growth measure.",
+      "description": "strictMono_nat_of_lt_succ applied to tower_lt_succ_height."
+    },
+    {
+      "name": "tower_strictMono_base",
+      "type": "theorem",
+      "statement": "$\\forall k,\\ \\text{StrictMono}\\,(\\text{tower}\\,k)$",
+      "significance": "For a fixed height the tower is strictly increasing in its base. Combined with height-monotonicity, the tower grows strictly in both arguments.",
+      "description": "Induction on k: the base case is the identity; the successor step composes the inductive strict inequality with strict monotonicity of 2^(·) (Nat.pow_lt_pow_right)."
+    },
+    {
+      "name": "tower_one_lt_tower_two",
+      "type": "theorem",
+      "statement": "$\\forall n,\\ \\text{tower}\\,1\\,n < \\text{tower}\\,2\\,n$, i.e. $2^n < 2^{2^n}$",
+      "significance": "THE CRUX of Erdős #564 made precise: the singly-exponential known lower bound (tower height 1) is strictly below the doubly-exponential conjectured lower bound (tower height 2). The open conjecture asks whether R₃(n) can be lifted across exactly this gap.",
+      "description": "Rewrite to 2^n and 2^(2^n) and apply strict monotonicity of 2^(·) to n < 2^n."
+    },
+    {
+      "name": "self_le_tower",
+      "type": "theorem",
+      "statement": "$\\forall k\\, n,\\ n \\le \\text{tower}\\,k\\,n$",
+      "significance": "The base is a lower bound for the whole tower at any height — the tower never shrinks below where it starts.",
+      "description": "Height-monotonicity applied to 0 ≤ k, with tower 0 n = n."
+    }
+  ],
+  "references": [
+    {
+      "author": "Erdős, P. and Hajnal, A. and Rado, R.",
+      "year": 1965,
+      "title": "Partition relations for cardinal numbers",
+      "venue": "Acta Math. Acad. Sci. Hungar. 16: 93–196",
+      "note": "Proves 2^{cn²} < R₃(n) < 2^{2^n}, the bounds whose tower-height gap Erdős #564 asks to close."
+    },
+    {
+      "author": "Erdős, P. and Hajnal, A. and Máté, A. and Rado, R.",
+      "year": 1984,
+      "title": "Combinatorial set theory: partition relations for cardinals",
+      "venue": "Studies in Logic 106, North-Holland",
+      "note": "Doubly-exponential lower bound for the 4-colour version — the main evidence for the 2-colour conjecture."
+    },
+    {
+      "author": "Erdős Problems",
+      "year": 2026,
+      "title": "Problem #564",
+      "venue": "https://erdosproblems.com/564",
+      "note": "Statement of the open problem and its $500 prize."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "erdos-564",
+      "relationship": "extends",
+      "description": "Parent formalization of Erdős #564 (axiomatized R and EHR bounds, tower definition). This file supplies the verified growth theory of that tower and repairs six dangling /-- doc comments that made the parent fail to parse."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos564Problem"
+    ],
+    "namespace": "Erdos564.Incomplete01",
+    "lineCount": 110,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos564Incomplete01.lean",
+    "sorries": 0
+  },
+  "conclusion": {
+    "summary": "Supplies the verified, 0-axiom growth theory of the iterated-exponential tower function underlying Erdős #564: strict monotonicity in height (tower_lt_succ_height, tower_strictMono_height) and base (tower_strictMono_base), the base lower bound (self_le_tower), and the crux tower_one_lt_tower_two (2^n < 2^{2^n}) that makes precise the one-tower-level gap between the EHR lower and upper bounds. All 11 theorems verify with 0 sorries and 0 axioms (the parent's R/EHR axioms and its sorry are not imported). Also repairs six dangling /-- doc comments that made the parent Erdos564Problem.lean fail to parse.",
+    "implications": "With the tower's growth theory in place, 'tower height' is now a rigorous comparison rather than notation, and the open conjecture (R₃ reaching tower height 2) can be stated and reasoned about precisely. The next infrastructural targets are monotonicity/Ramsey-property lemmas for the hypergraph Ramsey number itself, and proving the parent's arithmetic sorry bounds_gap_enormous.",
+    "openQuestions": [
+      "The conjecture itself remains OPEN ($500): is there c > 0 with R₃(n) ≥ 2^{2^{cn}} for large n?",
+      "Prove the parent's bounds_gap_enormous (2^{2^n}/2^{n²} > 10^100 for n ≥ 10) — a pure arithmetic fact currently left as sorry.",
+      "Develop monotonicity of the hypergraph Ramsey property (more vertices preserve it) toward a verified definition of R₃ replacing the axiom."
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-564-incomplete-01.json
+++ b/src/data/research/problems/erdos-564-incomplete-01.json
@@ -1,40 +1,55 @@
 {
   "slug": "erdos-564-incomplete-01",
   "title": "erdos-564-incomplete-01",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "C",
   "path": "full",
   "problemStatement": {
-    "formal": "",
-    "plain": "",
-    "whyMatters": []
+    "formal": "Erdős #564 (OPEN, $500): is there c>0 with R₃(n) ≥ 2^{2^{cn}} for large n? This sub-task delivers the verified tower-growth theory underlying the 'tower height' framing.",
+    "plain": "For the 3-uniform hypergraph Ramsey number R₃(n), the known bounds are 2^{cn²} < R₃(n) < 2^{2^n}: singly-exponential lower, doubly-exponential upper. Erdős asks whether the lower bound can be raised to tower height 2 (2^{2^{cn}}). This file builds the verified theory of the tower function in which the question is phrased.",
+    "whyMatters": ["Makes 'tower height' rigorous (strict monotonicity in height and base)", "Pins down the exact one-tower-level gap (tower_one_lt_tower_two) the open conjecture asks to close"]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": ["tower strictly increasing in height and base", "n ≤ tower k n", "2^n < 2^{2^n} for all n (height-1 < height-2)"],
+    "open": ["the conjecture R₃(n) ≥ 2^{2^{cn}} itself", "parent's bounds_gap_enormous sorry"],
+    "goal": "Verified combinatorial scaffolding for the tower-height framing of Erdős #564 (not the open conjecture)."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-03T08:33:50.249Z",
+    "phase": "ACT",
+    "since": "2026-06-27T00:00:00.000Z",
     "iteration": 1,
-    "focus": "",
+    "focus": "Delivered standalone verified 0-axiom tower-growth theory (Erdos564Incomplete01.lean, 11 thms): strict monotonicity in height (tower_lt_succ_height/tower_strictMono_height) and base (tower_strictMono_base), self_le_tower, and the crux tower_one_lt_tower_two (2^n < 2^{2^n}). Also fixed 6 dangling /-- doc comments that made parent Erdos564Problem.lean fail to parse.",
     "blockers": [],
-    "nextAction": "",
+    "nextAction": "Ramsey-property monotonicity lemmas toward a verified R₃ definition (replacing the axiom); prove the parent's bounds_gap_enormous arithmetic sorry. The open conjecture itself is out of reach.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Knowledge: erdos-564-incomplete-01\n*No research conducted yet*\n"
+    "progressSummary": "S1 ACT: standalone verified tower-growth theory for Erdős #564 (Erdos564Incomplete01.lean, 110 lines, 11 theorems, 0-sorry 0-axiom). Strict monotonicity in height and base, base lower bound, and the crux 2^n < 2^{2^n} making precise the one-tower-level gap of the open conjecture. Fixed the parent's 6 dangling /-- doc comments (parent did not parse at all on main).",
+    "builtItems": [
+      "Erdos564Incomplete01.lean: tower_succ, tower_lt_succ_height, tower_strictMono_height, self_le_tower, tower_strictMono_base, tower_mono_base, tower_two_eq, tower_one_lt_tower_two, plus 3 concrete checks (all 0-axiom verified)",
+      "Parent fix: 6 dangling /-- doc comments in Erdos564Problem.lean (lines 65/66/153/154/164/186) converted to /- so the file parses"
+    ],
+    "insights": [
+      "Tower height growth needs no positivity hypothesis: m < 2^m holds even at m=0, so tower k n < tower (k+1) n for all n (strengthens the parent's positivity-gated tower_pos framing).",
+      "tower_one_lt_tower_two (2^n < 2^{2^n}) is the formal content of 'the EHR lower bound is one tower level below the upper bound' — the precise gap Erdős #564 asks to close.",
+      "Importing a parent file with axioms + a sorry does NOT taint #print axioms of theorems that don't transitively use them: all 11 results are 0-axiom despite importing Erdos564Problem (which has axiom R + 2 EHR axioms + 1 sorry).",
+      "The parent Erdos564Problem.lean did not parse on main (dangling /-- doc comments before /- blocks) — same bug class as the puiseux-theorem parent fix. Its olean was therefore missing; had to build it single-file to the lean/Proofs libdir (extra lean/ segment)."
+    ],
+    "mathlibGaps": [
+      "No hypergraph Ramsey number API in Mathlib (R₃ is axiomatized in the parent).",
+      "No formal Erdős–Hajnal–Rado bound proofs (axiomatized)."
+    ],
+    "nextSteps": [
+      "Prove monotonicity of HasHypergraphRamseyProperty (more vertices preserve a monochromatic clique) toward a verified R₃.",
+      "Prove the parent's bounds_gap_enormous (2^{2^n}/2^{n²} > 10^100 for n≥10): induction 2^n ≥ n²+924 for n≥10, then rpow_sub + monotonicity; norm_num on 2^924 > 10^100.",
+      "The conjecture R₃(n) ≥ 2^{2^{cn}} is open ($500) — out of reach."
+    ],
+    "markdown": "# Knowledge: erdos-564-incomplete-01\nSee research/problems/erdos-564-incomplete-01/knowledge.md for full session notes.\n"
   },
   "tags": [],
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Erdős Problem **#564** (3-uniform hypergraph Ramsey numbers, **OPEN, $500**) is entirely phrased in terms of **tower height**: the Erdős–Hajnal–Rado bounds `2^{cn²} < R₃(n) < 2^{2^n}` leave a one-tower-level gap, and Erdős asks whether the lower bound can be raised to `2^{2^{cn}}`. The parent `Erdos564Problem.lean` defines the `tower` function but proves no growth theory — so "tower height" was just notation.

This PR adds the missing **verified, 0-axiom** growth theory and fixes a parse error that prevented the parent from compiling at all.

## New file `Erdos564Incomplete01.lean` (110 lines, 11 theorems, 0-sorry / 0-axiom)

| Theorem | Statement |
|---|---|
| `tower_lt_succ_height` | `tower k n < tower (k+1) n` for all `k,n` (from `m < 2^m`, no positivity hypothesis) |
| `tower_strictMono_height` | `StrictMono (k ↦ tower k n)` |
| `tower_strictMono_base` | `StrictMono (tower k)` |
| `self_le_tower` | `n ≤ tower k n` |
| `tower_one_lt_tower_two` | **the crux**: `2^n < 2^{2^n}` — the precise height-1-vs-height-2 gap the open conjecture asks to close |

Plus concrete checks (`tower 2 3 = 256`, `tower 3 1 = 16`, `5 ≤ tower 4 5`).

`#print axioms` on every result lists only `propext` / `Classical.choice` / `Quot.sound` — despite importing the parent (which has `axiom R`, two EHR-bound axioms, and a `sorry`), none of those are transitively used.

## Parent parse fix

`Erdos564Problem.lean` **did not parse on `main`**: six dangling `/--` doc comments (lines 65, 66, 153, 154, 164, 186) sat before `/-` block comments with no intervening declaration → `unexpected token '/--'; expected 'lemma'`. Converted those six to `/-`. (Same bug class as the earlier puiseux-theorem parent fix.) The parent retains its 3 axioms and 1 `sorry` (`bounds_gap_enormous`), legitimate for an open problem.

## Scope

Resolves **none** of the open conjecture — this is verified combinatorial scaffolding that makes the "tower height" framing precise. Built with `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos564Incomplete01.lean` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)