### PR TITLE
Fix: erdos-156 meta — file does NOT compile, correct overclaim

### DIFF
--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -57,6 +57,7 @@
       }
     ],
     "originalContributions": [
+      "STATUS CAVEAT (2026-06-27): the '(proved)'/'fully proved' annotations below describe the INTENDED formalization, not current machine-verified status. The file does NOT compile against pinned Mathlib v4.26.0 (~30 errors, 5 sorry-emitting declarations); see `assumptions`. A reformalization is required before any of these contributions can be claimed as verified.",
       "Two equivalent formal definitions of Sidon sets (IsSidonSet with ≤, IsSidonSetAlt with <) with detailed equivalence proof (sidonSet_iff_alt) via four-case analysis",
       "Greedy Sidon construction (greedySidon) with proved Sidon-ness (greedySidon_is_sidon), interval containment (greedySidon_subset_interval), and maximality (greedySidon_maximal) — all fully proved",
       "Maximal Sidon set predicate (IsMaximalSidonSet), interval definition (Interval), and size function",
@@ -66,8 +67,8 @@
       "Three sorry lemmas forming the N^{1/3} lower bound: diffShadow_ncard_le (shadow union bound), midShadow_ncard_le (midpoint image bound), greedySidon_cube_lower_bound (N ≤ n + n·(n(n+1)/2) + n(n+1)/2)"
     ],
     "axiomCount": 0,
-    "lineCount": 652,
-    "assumptions": "0 axioms. 3 sorries: diffShadow_ncard_le, midShadow_ncard_le, greedySidon_cube_lower_bound (greedy Sidon N^{1/3} lower bound framework, added in #8603). Core theorems (sidon_sumset_size, greedySidon correctness, greedy step) fully proved.",
+    "lineCount": 741,
+    "assumptions": "0 axioms. NOT machine-verified: as of 2026-06-27 this file does NOT compile against the pinned Mathlib v4.26.0 — `lake env lean Proofs/Erdos156Problem.lean` reports ~30 errors and 5 declarations emitting `sorry`. The breakage is pre-existing and pervasive (not confined to the 3 shadow-bound lemmas): the greedy construction declarations (greedySidon and helpers, L121/131/152/157) elaborate to `sorry`, the Sidon-set equivalence (L55/66/73/79/80) and sumset characterization (L354/388/393/415/433/436/437/442, incl. sidon_sumset_size and sidon_of_sumset_size) have unsolved goals / type-mismatches, and several orphan `/-- -/` docstrings (L191/193/202/219/235/491) are parse errors. The 3 shadow-bound fills added UNVERIFIED in #30726 (diffShadow_ncard_le, midShadow_ncard_le, greedySidon_cube_lower_bound) also fail (greedySidon_cube_lower_bound still emits `sorry` at L688; unknown identifier `x` at L581/585). A full reformalization against pinned Mathlib v4.26.0 is required before any 'proved'/'verified' claim. No part of this file is currently kernel-checked.",
     "mathlib_version": "4.26.0",
     "theoremCount": 19,
     "definitionCount": 12,
@@ -185,7 +186,7 @@
     ],
     "opens": [],
     "namespace": "Erdos156",
-    "lineCount": 652,
+    "lineCount": 741,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 12,


### PR DESCRIPTION
## Fix

Resolves the meta/source drift in #30949 by **actually building** `Proofs/Erdos156Problem.lean`. The auditor issue assumed the source was sorry-free and merely needed a kernel check to upgrade the badge. The build shows the opposite: **the file does not compile at all** against the pinned Mathlib v4.26.0.

## Evidence

`LAKE_UNSAFE=1 lake env lean Proofs/Erdos156Problem.lean` (deps from main repo's populated `.lake`, Mathlib pinned at `v4.26.0`):

- **~30 error sites** spanning the whole file (not just the 3 filled lemmas)
- **5 declarations emit `sorry`**: the greedy construction `greedySidon` and helpers (L121/131/152/157) and `greedySidon_cube_lower_bound` (L688)
- Sidon-set equivalence: `tauto`/`linarith` failures (L55/66/73/79/80)
- Sumset characterization incl. `sidon_sumset_size`, `sidon_of_sumset_size`: unsolved goals / type-mismatches (L354/388/393/415/433/436/437/442)
- Orphan `/-- -/` docstrings are parse errors (L191/193/202/219/235/491)
- The 3 UNVERIFIED shadow-bound fills from #30726 also fail: unknown identifier `x` (L581/585), `greedySidon_cube_lower_bound` emits `sorry` (L688)

**Control**: a known-verified proof (`FourSquareDistributionOQ07.lean`) compiles **clean** in the exact same environment, confirming this is genuine breakage, not an env/toolchain artifact. Docker build was unavailable (containerd `meta.db` I/O error, host disk ~99% full), so the single-file `lake env lean` path was used.

**Before**: meta claimed `status: formalized`, `sorries: 3`, `lineCount: 652`, with the greedy construction "all fully proved" and the sumset characterization as "three proved theorems" — i.e. it overstated the file as mostly machine-verified.

**After** (kept conservative — badge stays `wip`, **not** upgraded):
- `lineCount` 652 → 741 (meta + leanFile)
- `assumptions` rewritten to state the file is **NOT machine-verified** and enumerate the failure classes
- `originalContributions` gains a status caveat so the "(proved)" annotations are not read as current verified claims

The file needs a full reformalization against pinned Mathlib v4.26.0 — research-tier work, tracked separately (out of mechanic scope).

Closes #30949

---
Automated fix by lean-mechanic agent.