### PR TITLE
research(collatz-structured-oq-01): backward Collatz — preimage structure & infinitude of the basin of 1 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -917,6 +917,7 @@ import Proofs.CollatzCyclesOQ02
 import Proofs.CollatzCyclesOQ03
 import Proofs.CollatzCyclesOQ04
 import Proofs.CollatzStructured
+import Proofs.CollatzStructuredOQ01
 import Proofs.CollatzStructuredOQ02OQ01
 import Proofs.CollatzStructuredOQ02OQ02
 import Proofs.CollatzStructuredOQ03

--- a/proofs/Proofs/CollatzStructuredOQ01.lean
+++ b/proofs/Proofs/CollatzStructuredOQ01.lean
@@ -1,0 +1,195 @@
+/-
+# OQ-01: Backward Collatz — Preimage Structure and Infinitude of the Basin of 1
+
+Parent: `collatz-structured` (CollatzStructured.lean) proves *forward* facts —
+powers of two reach 1, closure of "reaches 1" under doubling, and specific small
+values. This file studies the **backward** dynamics: the preimage (predecessor)
+structure of the Collatz map and what it implies about the set of numbers that
+reach 1 (the *basin* of 1).
+
+We prove, with **no axioms and no `sorry`**:
+
+1. **Exact preimage characterization.** For every `a m : ℕ`,
+   `collatz a = m ↔ a = 2 * m ∨ (a % 2 = 1 ∧ 3 * a + 1 = m)`.
+   Every predecessor of `m` is either the *even predecessor* `2m` or an
+   *odd predecessor* `a` with `3a + 1 = m`.
+
+2. **Branching law.** An odd predecessor exists iff `m ≡ 4 (mod 6)`:
+   `(∃ a, a % 2 = 1 ∧ 3 * a + 1 = m) ↔ m % 6 = 4`.
+   Hence in the Collatz graph every vertex `m ≡ 4 (mod 6)` has two predecessors
+   and every other vertex has exactly one (the even predecessor `2m`).
+
+3. **Backward closure of the basin.** If `collatz a = m` and `m` reaches 1, then
+   `a` reaches 1. The basin of 1 is closed under taking predecessors.
+
+4. **The basin of 1 is infinite** — it contains every power of two.
+
+These are *unconditional* structural facts about the Collatz graph: they do not
+assume the Collatz conjecture, but describe the shape of the component containing
+1, independently of whether that component is all of `ℕ`.
+
+Tags: number-theory, collatz, predecessor, preimage, dynamical-systems
+-/
+
+import Mathlib.Tactic
+import Proofs.CollatzStructured
+
+namespace CollatzBackward
+
+open Collatz
+
+/-!
+## Part I: Exact Preimage Characterization
+
+The Collatz map `collatz n = if n even then n/2 else 3n+1` is two-to-one onto its
+image in a controlled way. A predecessor `a` of `m` (i.e. `collatz a = m`) is
+either even — in which case `a/2 = m`, forcing `a = 2m` — or odd, in which case
+`3a + 1 = m`.
+-/
+
+/-- **Exact preimage characterization.** `a` maps to `m` under the Collatz map iff
+`a` is the even predecessor `2m` or an odd number with `3a + 1 = m`. -/
+theorem collatz_eq_iff (a m : ℕ) :
+    collatz a = m ↔ a = 2 * m ∨ (a % 2 = 1 ∧ 3 * a + 1 = m) := by
+  unfold collatz
+  split_ifs with h
+  · -- a is even
+    constructor
+    · intro hm; exact Or.inl (by omega)
+    · rintro (rfl | ⟨h1, _⟩) <;> omega
+  · -- a is odd
+    have h1 : a % 2 = 1 := by omega
+    constructor
+    · intro hm; exact Or.inr ⟨h1, hm⟩
+    · rintro (rfl | ⟨_, h2⟩)
+      · omega
+      · exact h2
+
+/-- The preimage of `{m}` under the Collatz map, described explicitly. -/
+theorem preimage_collatz (m : ℕ) :
+    collatz ⁻¹' {m} = {a | a = 2 * m ∨ (a % 2 = 1 ∧ 3 * a + 1 = m)} := by
+  ext a
+  simp [Set.mem_preimage, collatz_eq_iff]
+
+/-- The **even predecessor**: `2m` always maps to `m`. -/
+theorem even_pred (m : ℕ) : collatz (2 * m) = m := collatz_two_mul m
+
+/-!
+## Part II: The Branching Law
+
+An *odd* predecessor of `m` exists exactly when `m ≡ 4 (mod 6)`. Combined with the
+always-present even predecessor `2m`, this says: vertices congruent to `4 mod 6`
+have in-degree 2 in the Collatz graph; all others have in-degree 1.
+-/
+
+/-- **Branching law.** `m` has an odd predecessor iff `m ≡ 4 (mod 6)`. -/
+theorem odd_pred_exists_iff (m : ℕ) :
+    (∃ a, a % 2 = 1 ∧ 3 * a + 1 = m) ↔ m % 6 = 4 := by
+  constructor
+  · rintro ⟨a, ha, rfl⟩
+    omega
+  · intro hm
+    exact ⟨2 * (m / 6) + 1, by omega, by omega⟩
+
+/-- When `m ≡ 4 (mod 6)` there are (at least) two distinct predecessors: the even
+predecessor `2m` and a distinct odd predecessor. The Collatz graph branches here. -/
+theorem two_preds_of_mod {m : ℕ} (hm : m % 6 = 4) :
+    ∃ a b, a ≠ b ∧ collatz a = m ∧ collatz b = m := by
+  obtain ⟨c, hc, hcm⟩ := (odd_pred_exists_iff m).mpr hm
+  refine ⟨2 * m, c, ?_, even_pred m, ?_⟩
+  · omega
+  · rw [collatz_eq_iff]; exact Or.inr ⟨hc, hcm⟩
+
+/-- When `m % 6 ≠ 4`, the *only* predecessor of `m` is the even predecessor `2m`. -/
+theorem unique_pred_of_not_mod {m : ℕ} (hm : m % 6 ≠ 4) {a : ℕ}
+    (ha : collatz a = m) : a = 2 * m := by
+  rcases (collatz_eq_iff a m).mp ha with h | ⟨hodd, h3⟩
+  · exact h
+  · exact absurd ((odd_pred_exists_iff m).mp ⟨a, hodd, h3⟩) hm
+
+/-!
+## Part III: Backward Closure of the Basin
+
+If `a` maps to `m` in one step and `m` reaches 1, then `a` reaches 1 (in one more
+step). Thus the basin of 1 is closed under taking predecessors — its preimage
+under `collatz` is contained in itself.
+-/
+
+/-- **Backward closure.** If `collatz a = m` and `m` reaches 1, then `a` reaches 1. -/
+theorem reaches_one_of_collatz {a m : ℕ} (h : collatz a = m) (hm : ReachesOne m) :
+    ReachesOne a := by
+  obtain ⟨k, hk⟩ := hm
+  refine ⟨k + 1, ?_⟩
+  simp only [collatzIter] at hk ⊢
+  rw [Function.iterate_succ_apply, h]
+  exact hk
+
+/-- Backward closure via the odd predecessor: if `a` is odd and `3a + 1` reaches 1,
+then `a` reaches 1. -/
+theorem reaches_one_odd_pred {a : ℕ} (ha : a % 2 = 1) (h : ReachesOne (3 * a + 1)) :
+    ReachesOne a :=
+  reaches_one_of_collatz ((collatz_eq_iff a (3 * a + 1)).mpr (Or.inr ⟨ha, rfl⟩)) h
+
+/-- The basin of 1 is closed under `collatz`-preimages: every predecessor of a
+basin element is again a basin element. -/
+theorem basin_closed_under_pred :
+    collatz ⁻¹' {n | ReachesOne n} ⊆ {n | ReachesOne n} := by
+  intro a ha
+  exact reaches_one_of_collatz (rfl : collatz a = collatz a) ha
+
+/-!
+## Part IV: The Basin of 1 is Infinite
+
+The set of numbers reaching 1 contains every power of two (parent file:
+`pow_two_reaches_one`), and `k ↦ 2^(k+1)` is an injection into it, so the basin is
+infinite. This is unconditional — it does not need the Collatz conjecture.
+-/
+
+/-- **The basin of 1 is infinite.** -/
+theorem basin_infinite : {n : ℕ | ReachesOne n}.Infinite := by
+  apply Set.infinite_of_injective_forall_mem (f := fun k : ℕ => 2 ^ (k + 1))
+  · intro x y hxy
+    have hxy' : 2 ^ (x + 1) = 2 ^ (y + 1) := hxy
+    have : x + 1 = y + 1 := Nat.pow_right_injective (le_refl 2) hxy'
+    omega
+  · intro k
+    simp only [Set.mem_setOf_eq]
+    exact pow_two_reaches_one (k + 1) (by omega)
+
+/-!
+## Part V: Computed Examples of the Branching Structure
+
+Concrete instances of the preimage law for small `m`.
+-/
+
+-- 16 ≡ 4 (mod 6): two predecessors, 32 (even) and 5 (odd, 3·5+1 = 16).
+example : collatz 32 = 16 := by decide
+example : collatz 5 = 16 := by decide
+example : (16 : ℕ) % 6 = 4 := by decide
+
+-- 10 ≡ 4 (mod 6): two predecessors, 20 (even) and 3 (odd, 3·3+1 = 10).
+example : collatz 20 = 10 := by decide
+example : collatz 3 = 10 := by decide
+
+-- 8 ≢ 4 (mod 6): only the even predecessor 16.
+example : (8 : ℕ) % 6 ≠ 4 := by decide
+example : collatz 16 = 8 := by decide
+
+/-!
+## Summary
+
+**Proved (no axioms, no `sorry`)**:
+1. ✓ Exact preimage characterization `collatz_eq_iff`
+2. ✓ Branching law `odd_pred_exists_iff` (odd predecessor ⟺ `m ≡ 4 mod 6`)
+3. ✓ In-degree dichotomy: `two_preds_of_mod` / `unique_pred_of_not_mod`
+4. ✓ Backward closure of the basin `reaches_one_of_collatz`, `basin_closed_under_pred`
+5. ✓ The basin of 1 is infinite `basin_infinite`
+
+**Unconditional**: none of these assume the Collatz conjecture. They describe the
+backward dynamics (the Collatz graph) regardless of whether every `n` reaches 1.
+
+**What remains open**: whether the basin of 1 is *all* of `ℕ ≥ 1` — i.e. the
+Collatz conjecture itself (axiomatized in the parent file).
+-/
+
+end CollatzBackward

--- a/src/data/proofs/collatz-structured-oq-01/annotations.json
+++ b/src/data/proofs/collatz-structured-oq-01/annotations.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "ann-collatz-oq01-header",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 39
+    },
+    "type": "concept",
+    "title": "Module Header: Backward Collatz Dynamics",
+    "content": "The header (lines 1-32) states the four verified results and stresses that they are unconditional — independent of the Collatz conjecture. Lines 34-39 set up the module: `import Mathlib.Tactic`, `import Proofs.CollatzStructured` (to reuse the parent's `collatz`, `collatzIter`, and `ReachesOne`), `namespace CollatzBackward`, and `open Collatz`. By importing the parent rather than redefining the map, this entry adds genuinely new content (the backward structure) on top of the existing forward formalization.",
+    "mathContext": "The Collatz graph has vertices ℕ and edges n → collatz(n). Reading edges backwards makes the conjecture a reachability question: it holds iff every vertex lies in the basin of 1. The backward map is set-valued — each m has the even predecessor 2m and, conditionally, an odd predecessor.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Collatz conjecture",
+      "backward dynamics",
+      "Collatz graph",
+      "basin of attraction"
+    ],
+    "prerequisites": [
+      "Collatz map background",
+      "Lean 4 imports and namespaces"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq01-preimage",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 75
+    },
+    "type": "theorem",
+    "title": "Exact Preimage Characterization (collatz_eq_iff)",
+    "content": "`collatz_eq_iff` states `collatz a = m ↔ a = 2*m ∨ (a % 2 = 1 ∧ 3*a + 1 = m)`. The proof unfolds `collatz` and uses `split_ifs` on the parity test `a % 2 = 0`. In the even branch, `collatz a = a/2`, so `a/2 = m` together with `a` even forces `a = 2m` — discharged by `omega`, which reasons about `/2` and `%2` natively. In the odd branch, `collatz a = 3a+1`, giving the right disjunct directly. `preimage_collatz` restates this as the set equality `collatz ⁻¹' {m} = {a | a = 2*m ∨ (a%2=1 ∧ 3a+1=m)}`, and `even_pred` records the always-present even predecessor `collatz (2m) = m`.",
+    "mathContext": "A predecessor a of m is even (then a = 2m, the 'even predecessor') or odd (then 3a+1 = m, the 'odd predecessor'). These cases are exhaustive and exclusive, so the fiber of collatz over m is completely described. Phrasing oddness as `a % 2 = 1` (rather than `Odd a`) keeps the whole argument inside omega's linear-arithmetic-with-mod fragment.",
+    "significance": "key",
+    "relatedConcepts": [
+      "preimage",
+      "parity case analysis",
+      "omega tactic",
+      "Collatz map"
+    ],
+    "prerequisites": [
+      "Lean split_ifs and omega",
+      "natural number division and modulo"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq01-branching",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 108
+    },
+    "type": "theorem",
+    "title": "The Branching Law (odd_pred_exists_iff) and In-degree Dichotomy",
+    "content": "`odd_pred_exists_iff` proves `(∃ a, a%2=1 ∧ 3a+1=m) ↔ m % 6 = 4`. Forward: substituting an odd a and applying omega gives (3a+1) % 6 = 4. Backward: from m % 6 = 4 the explicit witness `2*(m/6)+1` is odd and satisfies 3a+1 = m. `two_preds_of_mod` then exhibits two distinct predecessors when m ≡ 4 (mod 6): the even 2m and the odd witness, distinct by parity (omega). `unique_pred_of_not_mod` shows that otherwise 2m is the sole predecessor — the odd disjunct of `collatz_eq_iff` is impossible by the branching law.",
+    "mathContext": "Writing an odd a = 2t+1 gives 3a+1 = 6t+4, so odd predecessors exist exactly for m ≡ 4 (mod 6), and the odd predecessor is (m-1)/3 = 2(m/6)+1. Combined with the universal even predecessor 2m, the Collatz graph has in-degree 2 precisely on residue 4 mod 6 and in-degree 1 elsewhere — one residue in six branches.",
+    "significance": "key",
+    "relatedConcepts": [
+      "modular arithmetic",
+      "in-degree",
+      "Collatz tree branching",
+      "explicit witness"
+    ],
+    "prerequisites": [
+      "residues mod 6",
+      "existential witnesses in Lean"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq01-closure",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 138
+    },
+    "type": "theorem",
+    "title": "Backward Closure of the Basin (reaches_one_of_collatz)",
+    "content": "`reaches_one_of_collatz` shows that if `collatz a = m` and `m` reaches 1 in k steps, then `a` reaches 1 in k+1 steps. After `simp only [collatzIter]`, `Function.iterate_succ_apply` rewrites `collatz^[k+1] a` to `collatz^[k] (collatz a)`, then `rw [h]` replaces `collatz a` with `m`, reducing to the hypothesis `collatz^[k] m = 1`. `reaches_one_odd_pred` is the odd-predecessor specialization, and `basin_closed_under_pred` packages the result as the set inclusion `collatz ⁻¹' {n | ReachesOne n} ⊆ {n | ReachesOne n}`.",
+    "mathContext": "Reaching 1 is preserved backwards along edges: a → m and m → 1 implies a → 1. Hence the basin of 1 is closed under the (set-valued) predecessor map and equals the set generated from 1 by repeatedly taking predecessors — the Collatz tree rooted at 1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "function iteration",
+      "basin of attraction",
+      "closure under preimage",
+      "Collatz tree"
+    ],
+    "prerequisites": [
+      "Function.iterate lemmas",
+      "ReachesOne predicate"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq01-infinite",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 148,
+      "endLine": 157
+    },
+    "type": "theorem",
+    "title": "The Basin of 1 is Infinite (basin_infinite)",
+    "content": "`basin_infinite` proves `{n : ℕ | ReachesOne n}.Infinite`. It applies `Set.infinite_of_injective_forall_mem` with the map `k ↦ 2^(k+1)`. Injectivity follows from `Nat.pow_right_injective (le_refl 2)` (base ≥ 2), reducing `2^(x+1) = 2^(y+1)` to `x+1 = y+1` and then omega. Membership is `pow_two_reaches_one (k+1)` from the parent file: every power of two reaches 1.",
+    "mathContext": "The component of 1 contains 2, 4, 8, 16, …, an infinite family, so it is infinite — unconditionally. This is a provable sub-statement strictly weaker than the Collatz conjecture (which would assert the component is all of ℕ≥1).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Set.Infinite",
+      "injectivity of exponentials",
+      "powers of two",
+      "unconditional result"
+    ],
+    "prerequisites": [
+      "Set.infinite_of_injective_forall_mem",
+      "Nat.pow_right_injective"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq01-examples",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 159,
+      "endLine": 176
+    },
+    "type": "concept",
+    "title": "Computed Examples of the Branching Structure",
+    "content": "Small instances verified by `decide` (kernel-checked, axiom-free): 16 ≡ 4 (mod 6) has predecessors 32 (even) and 5 (odd, 3·5+1 = 16); 10 ≡ 4 (mod 6) has predecessors 20 and 3; 8 ≢ 4 (mod 6) has only the even predecessor 16. These confirm the branching law on concrete numbers.",
+    "mathContext": "Illustrates the in-degree dichotomy: vertices congruent to 4 mod 6 branch (two predecessors), all others do not (the even predecessor alone). Using `decide` rather than `native_decide` keeps these checks within the kernel and free of the Lean.ofReduceBool axiom.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide tactic",
+      "branching examples",
+      "residue 4 mod 6"
+    ],
+    "prerequisites": [
+      "decidable equality on ℕ"
+    ]
+  }
+]

--- a/src/data/proofs/collatz-structured-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-01/meta.json
@@ -1,0 +1,238 @@
+{
+  "id": "collatz-structured-oq-01",
+  "title": "Backward Collatz: Preimage Structure and Infinitude of the Basin of 1",
+  "slug": "collatz-structured-oq-01",
+  "description": "Studies the backward dynamics of the Collatz map. Proves the exact preimage characterization (every predecessor of m is either the even predecessor 2m or an odd a with 3a+1=m), the mod-6 branching law (an odd predecessor exists iff m ≡ 4 mod 6), the resulting in-degree dichotomy (2 if m ≡ 4 mod 6, else 1), backward closure of the basin of 1 under predecessors, and that the basin of 1 is infinite. All results are unconditional (independent of the Collatz conjecture) and fully verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "status": "verified",
+    "proofRepoPath": "Proofs/CollatzStructuredOQ01.lean",
+    "tags": [
+      "number-theory",
+      "collatz",
+      "predecessor",
+      "preimage",
+      "dynamical-systems",
+      "graph-theory",
+      "research",
+      "verified"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 195,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "assumptions": "None. All theorems depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound); none use sorry, native_decide, or any added axiom. The results are unconditional — they do not assume the Collatz conjecture.",
+    "dateAdded": "2026-06-27",
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Collatz_conjecture",
+    "date": "Classical backward-Collatz folklore; formalized 2026",
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.infinite_of_injective_forall_mem",
+        "description": "A set is infinite if there is an injection from an infinite type into it — used to prove the basin of 1 is infinite via k ↦ 2^(k+1).",
+        "module": "Mathlib.Data.Set.Finite"
+      },
+      {
+        "theorem": "Nat.pow_right_injective",
+        "description": "For base ≥ 2, the exponential map is injective — used to show k ↦ 2^(k+1) is injective.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Function.iterate_succ_apply",
+        "description": "f^[k+1] a = f^[k] (f a) — used in the backward-closure step to peel one Collatz iteration.",
+        "module": "Mathlib.Logic.Function.Iterate"
+      }
+    ],
+    "originalContributions": [
+      "collatz_eq_iff: an exact characterization of the Collatz preimage — collatz a = m ↔ a = 2m ∨ (a odd ∧ 3a+1 = m) — proved by parity case split and omega, with no division artifacts.",
+      "odd_pred_exists_iff: the mod-6 branching law — m has an odd predecessor iff m ≡ 4 (mod 6) — with an explicit witness 2·(m/6)+1.",
+      "two_preds_of_mod / unique_pred_of_not_mod: the in-degree dichotomy of the Collatz graph (in-degree 2 exactly on residue 4 mod 6, otherwise 1).",
+      "reaches_one_of_collatz: backward closure of the basin of 1 — predecessors of basin elements are basin elements — and the set-level corollary basin_closed_under_pred.",
+      "basin_infinite: an unconditional proof that the set of numbers reaching 1 is infinite, via the injection k ↦ 2^(k+1)."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Collatz conjecture asks whether every positive integer reaches 1 under the map $n \\mapsto n/2$ ($n$ even) or $n \\mapsto 3n+1$ ($n$ odd). The conjecture concerns the *forward* orbit of each starting value. A complementary viewpoint studies the *backward* orbit: the Collatz graph, whose vertices are the positive integers and whose edges point from $n$ to $\\mathrm{collatz}(n)$. Reading these edges backwards turns the conjecture into a reachability statement — the conjecture holds iff every vertex lies in the *basin* of 1, the set of vertices from which 1 is reachable. The backward map is set-valued: a vertex $m$ has the always-present even predecessor $2m$ and, conditionally, an odd predecessor. Terras's 1976 density argument and the classical 'Collatz tree' both exploit this backward branching structure. This entry isolates and fully verifies the elementary combinatorial core of that structure.",
+    "problemStatement": "Describe the backward dynamics of the Collatz map: (1) characterize exactly the preimage $\\{a : \\mathrm{collatz}(a) = m\\}$ of each $m$; (2) determine when $m$ has more than one predecessor (the branching of the Collatz graph); (3) show the basin of 1 is closed under taking predecessors; and (4) show the basin of 1 is infinite — all unconditionally, without assuming the Collatz conjecture.",
+    "proofStrategy": "Reuse the parent file's `collatz`, `collatzIter`, and `ReachesOne` definitions. The preimage characterization is a parity case split on $a$ closed by `omega` (which handles the `/2` and `%2` reasoning natively). The branching law reduces, via the characterization, to the arithmetic fact that $\\{3a+1 : a\\text{ odd}\\} = \\{m : m \\equiv 4 \\pmod 6\\}$, again discharged by `omega` with an explicit witness. Backward closure peels one Collatz step with `Function.iterate_succ_apply`. Infinitude uses `Set.infinite_of_injective_forall_mem` with the injection $k \\mapsto 2^{k+1}$, whose image lies in the basin by the parent's `pow_two_reaches_one`.",
+    "prerequisites": [
+      "Collatz map and iteration",
+      "Modular arithmetic (residues mod 6)",
+      "Preimages and set-valued inverse maps",
+      "Lean 4 omega tactic and Set.Infinite API"
+    ],
+    "keyInsights": [
+      "The Collatz preimage is cleanly two-valued. Splitting on the parity of a predecessor $a$: if $a$ is even then $\\mathrm{collatz}(a) = a/2 = m$ forces $a = 2m$; if $a$ is odd then $\\mathrm{collatz}(a) = 3a+1 = m$. There are no other cases, giving the exact characterization `collatz a = m ↔ a = 2m ∨ (a odd ∧ 3a+1 = m)`. Stating it with `a % 2 = 1` rather than `Odd a` keeps the whole proof inside `omega`.",
+      "The odd predecessor is governed entirely by a residue. Writing an odd $a = 2t+1$ gives $3a+1 = 6t+4$, so the odd predecessors of $m$ exist iff $m \\equiv 4 \\pmod 6$, and then the unique odd predecessor is $(m-1)/3 = 2(m/6)+1$. This is the precise branching rule of the Collatz tree.",
+      "In-degree dichotomy: every vertex has the even predecessor $2m$, so vertices with $m \\equiv 4 \\pmod 6$ have in-degree (at least) 2 and all others have in-degree exactly 1. The branching is sparse and completely explicit — one in every six residues branches.",
+      "Backward closure is the engine behind 'building the Collatz tree from 1 outward'. If $\\mathrm{collatz}(a) = m$ and $m$ reaches 1 in $k$ steps, then $a$ reaches 1 in $k+1$ steps: $\\mathrm{collatz}^{[k+1]}(a) = \\mathrm{collatz}^{[k]}(\\mathrm{collatz}(a)) = \\mathrm{collatz}^{[k]}(m) = 1$. Hence the basin of 1 is exactly the set generated from 1 by repeatedly applying the (set-valued) predecessor map.",
+      "Infinitude of the basin is unconditional and elementary: $2, 4, 8, 16, \\dots$ all reach 1, and $k \\mapsto 2^{k+1}$ is an injection into the basin. This needs nothing about whether *every* integer reaches 1 — it only asserts the component of 1 is infinite, which is a far weaker (and provable) statement than the Collatz conjecture.",
+      "These results frame the Collatz conjecture as a single clean question about the structure already proved here: the basin of 1 is an explicitly branching, backward-closed, infinite set — the conjecture is exactly the assertion that this set is *all* of $\\mathbb{N}_{\\geq 1}$."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Docstring stating the four verified results (preimage characterization, branching law, backward closure, infinitude of the basin), the imports (Mathlib.Tactic and the parent CollatzStructured), the namespace CollatzBackward, and `open Collatz` to reuse the parent's collatz / collatzIter / ReachesOne definitions.",
+      "mathContext": "Sets up the backward-dynamics viewpoint: the Collatz graph with edges n → collatz(n), read in reverse. All results are unconditional structural facts about the component of 1."
+    },
+    {
+      "id": "part-i-preimage",
+      "title": "Part I: Exact Preimage Characterization",
+      "startLine": 41,
+      "endLine": 75,
+      "summary": "`collatz_eq_iff`: collatz a = m ↔ a = 2m ∨ (a%2=1 ∧ 3a+1=m), proved by `split_ifs` on the parity of a and `omega`. `preimage_collatz` re-expresses this as the explicit set collatz⁻¹'{m}. `even_pred` records that 2m always maps to m.",
+      "mathContext": "A predecessor a of m is even (then a = 2m) or odd (then 3a+1 = m). These two cases are exhaustive and mutually exclusive, giving the complete fiber of the Collatz map over m."
+    },
+    {
+      "id": "part-ii-branching",
+      "title": "Part II: The Branching Law",
+      "startLine": 77,
+      "endLine": 108,
+      "summary": "`odd_pred_exists_iff`: m has an odd predecessor iff m ≡ 4 (mod 6), with explicit witness 2·(m/6)+1. `two_preds_of_mod`: when m ≡ 4 (mod 6) there are two distinct predecessors (even 2m and the odd one). `unique_pred_of_not_mod`: otherwise 2m is the only predecessor.",
+      "mathContext": "The Collatz graph branches exactly at residue 4 mod 6: in-degree 2 there, in-degree 1 elsewhere. This is the precise combinatorial shape of the backward Collatz tree."
+    },
+    {
+      "id": "part-iii-closure",
+      "title": "Part III: Backward Closure of the Basin",
+      "startLine": 110,
+      "endLine": 138,
+      "summary": "`reaches_one_of_collatz`: if collatz a = m and m reaches 1, so does a (one extra step via Function.iterate_succ_apply). `reaches_one_odd_pred`: the odd-predecessor specialization. `basin_closed_under_pred`: collatz⁻¹'(basin) ⊆ basin.",
+      "mathContext": "The basin of 1 is closed under taking predecessors, so it is exactly the set generated from 1 by the set-valued backward map — the Collatz tree rooted at 1."
+    },
+    {
+      "id": "part-iv-infinite",
+      "title": "Part IV: The Basin of 1 is Infinite",
+      "startLine": 140,
+      "endLine": 157,
+      "summary": "`basin_infinite`: {n | ReachesOne n}.Infinite, via Set.infinite_of_injective_forall_mem with the injection k ↦ 2^(k+1) (injective by Nat.pow_right_injective; image in the basin by the parent's pow_two_reaches_one).",
+      "mathContext": "The component of 1 is infinite unconditionally: all powers of two reach 1. This is a provable lower bound on the basin, far weaker than the (open) claim that the basin is all of ℕ≥1."
+    },
+    {
+      "id": "part-v-examples",
+      "title": "Part V: Computed Examples",
+      "startLine": 159,
+      "endLine": 176,
+      "summary": "Small concrete instances verified by `decide`: predecessors of 16 (32 and 5, since 16 ≡ 4 mod 6), of 10 (20 and 3), and the single predecessor 16 of 8 (8 ≢ 4 mod 6).",
+      "mathContext": "Illustrates the branching law on small numbers: 16 and 10 branch (two predecessors each), 8 does not (only its even predecessor)."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 178,
+      "endLine": 195,
+      "summary": "Recapitulates the five proved results, emphasizes their unconditional nature, and frames the open Collatz conjecture as the single remaining question of whether the basin of 1 is all of ℕ≥1.",
+      "mathContext": "The entry reduces the conjecture to a statement about the explicitly-described basin: branching, backward-closed, infinite — is it everything?"
+    }
+  ],
+  "conclusion": {
+    "summary": "The file gives a complete, axiom-free description of the backward Collatz dynamics: the exact preimage of each m (even predecessor 2m plus an odd predecessor iff m ≡ 4 mod 6), the in-degree dichotomy of the Collatz graph, backward closure of the basin of 1, and infinitude of that basin. Every theorem is verified with 0 axioms and 0 sorries and is independent of the Collatz conjecture.",
+    "implications": "**1. Reformulation of the conjecture.** Together the results describe the basin of 1 as an explicitly branching (in-degree 2 exactly on residue 4 mod 6), backward-closed, infinite subset of ℕ. The Collatz conjecture is precisely the assertion that this subset equals ℕ≥1 — a single set-equality question about a fully characterized object.\n\n**2. The Collatz tree, made precise.** `reaches_one_of_collatz` plus the preimage law give the standard 'grow the tree from 1' construction a verified foundation: starting from 1, repeatedly adjoin the even predecessor 2m of every node and, when m ≡ 4 mod 6, the odd predecessor too. Every node so produced provably reaches 1.\n\n**3. Density beachhead.** The branching law is the elementary input to Terras-style density arguments (cf. the sibling entry collatz-structured-oq-03): one residue class in six branches, so the backward tree grows, and counting tree nodes up to N lower-bounds the density of the basin. This entry supplies the exact branching rule those arguments rely on.\n\n**4. Unconditional infinitude.** `basin_infinite` is a clean example of separating a provable sub-statement (the component of 1 is infinite) from the full open problem (the component is everything). It needs only powers of two.",
+    "openQuestions": [
+      "Can one prove an unconditional lower bound on |{n ≤ N : ReachesOne n}| by counting nodes of the backward Collatz tree using the mod-6 branching law? This would be a verified density result strictly weaker than the conjecture.",
+      "Is the basin of 1 closed under any *forward* operation beyond the trivial ones — e.g. can the preimage characterization be iterated to describe the 2-step predecessor structure (preimage of preimage) in closed residue-class form?",
+      "Does the in-degree dichotomy extend to a verified description of the Collatz graph as a tree (acyclicity of the basin minus the {1,4,2} cycle), connecting this entry to the cycle-exclusion results in the collatz-cycles family?"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "collatz_eq_iff",
+      "type": "core",
+      "description": "Exact Collatz preimage: a maps to m iff a is the even predecessor 2m or an odd number with 3a+1 = m.",
+      "leanType": "∀ a m : ℕ, collatz a = m ↔ a = 2 * m ∨ (a % 2 = 1 ∧ 3 * a + 1 = m)"
+    },
+    {
+      "name": "odd_pred_exists_iff",
+      "type": "core",
+      "description": "Branching law: m has an odd predecessor iff m ≡ 4 (mod 6).",
+      "leanType": "∀ m : ℕ, (∃ a, a % 2 = 1 ∧ 3 * a + 1 = m) ↔ m % 6 = 4"
+    },
+    {
+      "name": "two_preds_of_mod",
+      "type": "core",
+      "description": "When m ≡ 4 (mod 6), m has two distinct predecessors (the even 2m and an odd one).",
+      "leanType": "m % 6 = 4 → ∃ a b, a ≠ b ∧ collatz a = m ∧ collatz b = m"
+    },
+    {
+      "name": "unique_pred_of_not_mod",
+      "type": "supporting",
+      "description": "When m ≢ 4 (mod 6), the only predecessor of m is the even predecessor 2m.",
+      "leanType": "m % 6 ≠ 4 → collatz a = m → a = 2 * m"
+    },
+    {
+      "name": "reaches_one_of_collatz",
+      "type": "core",
+      "description": "Backward closure: if collatz a = m and m reaches 1, then a reaches 1.",
+      "leanType": "collatz a = m → ReachesOne m → ReachesOne a"
+    },
+    {
+      "name": "basin_closed_under_pred",
+      "type": "supporting",
+      "description": "The basin of 1 is closed under taking collatz-preimages.",
+      "leanType": "collatz ⁻¹' {n | ReachesOne n} ⊆ {n | ReachesOne n}"
+    },
+    {
+      "name": "basin_infinite",
+      "type": "core",
+      "description": "The set of numbers reaching 1 is infinite (contains every power of two).",
+      "leanType": "{n : ℕ | ReachesOne n}.Infinite"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "collatz-structured",
+      "relationship": "extends",
+      "description": "Parent proof establishes the forward Collatz facts (powers of two reach 1, closure under doubling) and the definitions collatz / collatzIter / ReachesOne reused here. This entry develops the complementary backward (preimage) structure."
+    },
+    {
+      "targetId": "collatz-structured-oq-03",
+      "relationship": "related",
+      "description": "Studies the average stopping time and Terras's density-1 result. The mod-6 branching law proved here is the elementary combinatorial input to counting backward-tree nodes that underlies such density arguments."
+    },
+    {
+      "targetId": "collatz-cycles",
+      "relationship": "related",
+      "description": "Proves structural constraints on Collatz cycles (no fixed points, unique cycle {1,4,2}). The backward-closure and preimage structure here describe the acyclic tree part of the Collatz graph that complements the cycle analysis."
+    },
+    {
+      "targetId": "collatz-structured-oq-02",
+      "relationship": "related",
+      "description": "Derives algebraic constraints on cycle length via the halving inequality 2^M > 3^j. Both entries dissect the elementary arithmetic of the 3n+1 step from complementary angles (cycles vs. preimages)."
+    }
+  ],
+  "references": [
+    {
+      "text": "Lagarias, J. C. (1985). The 3x+1 problem and its generalizations. American Mathematical Monthly, 92(1), 3-23.",
+      "url": "https://en.wikipedia.org/wiki/Collatz_conjecture"
+    },
+    {
+      "text": "Terras, R. (1976). A stopping time problem on the positive integers. Acta Arithmetica, 30(3), 241-252.",
+      "url": "https://en.wikipedia.org/wiki/Collatz_conjecture#Stopping_time"
+    },
+    {
+      "text": "Lagarias, J. C. (ed.) (2010). The Ultimate Challenge: The 3x+1 Problem. American Mathematical Society.",
+      "url": "https://en.wikipedia.org/wiki/Collatz_conjecture"
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/CollatzStructuredOQ01.lean",
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.CollatzStructured"
+    ],
+    "opens": [
+      "Collatz"
+    ],
+    "namespace": "CollatzBackward",
+    "lineCount": 195,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/collatz-structured-oq-01.json
+++ b/src/data/research/problems/collatz-structured-oq-01.json
@@ -29,11 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "S1 (researcher-12, 2026-06-27, PR #30960, VERIFIED 0-axiom): Created Proofs/CollatzStructuredOQ01.lean (195 lines, 10 theorems, 0 axioms, 0 sorries) formalizing the BACKWARD dynamics of the Collatz map, all unconditional (independent of the Collatz conjecture). Proved: (1) exact preimage characterization collatz_eq_iff: collatz a = m ↔ a = 2m ∨ (a odd ∧ 3a+1 = m); (2) branching law odd_pred_exists_iff: odd predecessor exists iff m ≡ 4 (mod 6); (3) in-degree dichotomy two_preds_of_mod / unique_pred_of_not_mod (in-degree 2 on residue 4 mod 6, else 1); (4) backward closure reaches_one_of_collatz / basin_closed_under_pred; (5) basin_infinite: the basin of 1 is infinite (contains every power of two). Reuses parent CollatzStructured definitions. #print axioms confirms only propext/Classical.choice/Quot.sound. Built via lake env lean fallback (Docker meta.db I/O-corrupt on host). Gallery entry added.",
+    "builtItems": [
+      "collatz_eq_iff: exact Collatz preimage characterization, proved by parity split + omega",
+      "odd_pred_exists_iff: mod-6 branching law with explicit witness 2*(m/6)+1",
+      "two_preds_of_mod / unique_pred_of_not_mod: in-degree dichotomy of the Collatz graph",
+      "reaches_one_of_collatz / basin_closed_under_pred: backward closure of the basin of 1",
+      "basin_infinite: unconditional proof the basin of 1 is infinite via k ↦ 2^(k+1)"
+    ],
+    "insights": [
+      "The Collatz preimage is cleanly two-valued: splitting on the parity of a predecessor a gives a = 2m (even) or 3a+1 = m (odd); stating oddness as a % 2 = 1 keeps the whole proof inside omega.",
+      "Odd predecessors are governed by a single residue: an odd a = 2t+1 gives 3a+1 = 6t+4, so odd predecessors of m exist exactly when m ≡ 4 (mod 6), and the unique odd predecessor is 2*(m/6)+1.",
+      "In-degree dichotomy: every m has the even predecessor 2m, so vertices with m ≡ 4 (mod 6) have in-degree 2 and all others in-degree 1 — one residue in six branches.",
+      "Backward closure (collatz a = m, m reaches 1 ⟹ a reaches 1) makes the basin of 1 exactly the set generated from 1 by the set-valued predecessor map — the Collatz tree rooted at 1.",
+      "Infinitude of the basin is unconditional and elementary (powers of two), far weaker than the conjecture; it cleanly separates a provable sub-statement from the open problem."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Count backward-tree nodes via the mod-6 branching law to obtain an unconditional lower bound on |{n ≤ N : ReachesOne n}| (a verified density result weaker than the conjecture).",
+      "Describe the 2-step predecessor structure (preimage of preimage) in closed residue-class form by iterating collatz_eq_iff.",
+      "Connect backward closure + cycle-exclusion (collatz-cycles family) toward a verified tree (acyclicity of the basin minus the {1,4,2} cycle)."
+    ]
   },
   "tags": [
     "number-theory",


### PR DESCRIPTION
## Summary

New verified Lean file `proofs/Proofs/CollatzStructuredOQ01.lean` plus gallery entry for `collatz-structured-oq-01`. Studies the **backward** dynamics of the Collatz map — the preimage/predecessor structure — complementing the parent `collatz-structured` (which proves forward facts about powers of two and small values).

**All results are unconditional** (they do not assume the Collatz conjecture) and fully machine-checked: **0 axioms, 0 sorries**. `#print axioms` reports only `propext`/`Classical.choice`/`Quot.sound` — no `sorry`, no `native_decide`, no added axiom.

## Theorems (10 total)

| Theorem | Statement |
|---|---|
| `collatz_eq_iff` | `collatz a = m ↔ a = 2m ∨ (a%2=1 ∧ 3a+1=m)` — exact preimage |
| `preimage_collatz` | explicit description of `collatz ⁻¹' {m}` |
| `even_pred` | `collatz (2m) = m` (universal even predecessor) |
| `odd_pred_exists_iff` | odd predecessor exists ↔ `m ≡ 4 (mod 6)` (branching law) |
| `two_preds_of_mod` | `m ≡ 4 (mod 6)` ⟹ two distinct predecessors |
| `unique_pred_of_not_mod` | otherwise `2m` is the only predecessor |
| `reaches_one_of_collatz` | backward closure: `collatz a = m`, `m` reaches 1 ⟹ `a` reaches 1 |
| `reaches_one_odd_pred` | odd-predecessor specialization |
| `basin_closed_under_pred` | `collatz ⁻¹' (basin) ⊆ basin` |
| `basin_infinite` | the basin of 1 is infinite (contains every power of two) |

## Significance

Together these describe the basin of 1 as an explicitly branching (in-degree 2 exactly on residue 4 mod 6), backward-closed, infinite subset of ℕ. The Collatz conjecture is exactly the statement that this fully-characterized set is *all* of ℕ≥1. The mod-6 branching law is also the elementary input to Terras-style backward-tree density counting (cf. sibling `collatz-structured-oq-03`).

## Verification

Built via `lake env lean` (Docker wrapper's containerd `meta.db` is I/O-corrupt on this host). Dependency `Proofs.CollatzStructured` olean built first, then the new file typechecks with exit 0. `#print axioms` on all eight named results confirms 0 added axioms. Gallery data validated: `gallery:check-size` passes (18KB, well under cap) and the entry is discovered by `annotations:build` (4069 proofs).

## Files
- `proofs/Proofs/CollatzStructuredOQ01.lean` (new, 195 lines)
- `proofs/Proofs.lean` (register import)
- `src/data/proofs/collatz-structured-oq-01/{meta.json,annotations.json}` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)