### PR TITLE
research(chebyshev-pnt-bridge-oq-06): real-log UPPER bound on π(n) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChebyshevPNTBridgeOQ06.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ06.lean
@@ -1,0 +1,160 @@
+/-
+# Chebyshev–PNT Bridge OQ-06: Real-Logarithmic UPPER Bound on π(n)
+
+The parent (`ChebyshevPNTBridge.lean`) proves the Chebyshev *upper* bound only in
+its `ℕ`-power form
+
+    (Nat.sqrt n) ^ (π(n) − π(√n)) ≤ 4^n          (`pow_sqrt_primeCounting_diff_le`),
+
+stating the real-logarithmic consequence "π(n) ≤ √n + n·log 4 / log √n" only as a
+comment in its header.  Its sibling `ChebyshevPNTBridgeOQ05.lean` carried the
+*lower* bound into real-logarithmic form (`primeCounting_mul_log_lower`,
+`primeCounting_ge_div_log`).  This file supplies the missing *upper* counterpart,
+so both Chebyshev densities are now available in matching `Real.log` form.
+
+The key content:
+
+* **`primeCounting_diff_mul_log_sqrt_le`** — taking `Real.log` of the parent's
+  power inequality, for every n ≥ 4,
+
+      (π(n) − π(√n)) · log(√n) ≤ n · log 4
+
+  (here `√n = Nat.sqrt n`, the integer square root).
+
+* **`primeCounting_mul_log_sqrt_le`** — collapsing the `π(√n)` correction with the
+  trivial bound `π(√n) ≤ √n` gives a clean upper bound on `π(n)·log(√n)`:
+
+      π(n) · log(√n) ≤ n · log 4 + √n · log(√n).
+
+* **`primeCounting_le_div_log_sqrt`** — dividing by `log(√n) > 0` records the
+  Chebyshev *upper* density directly:
+
+      π(n) ≤ n · log 4 / log(√n) + √n.
+
+  Since `log(√n) ≈ ½ log n`, the leading term is `≈ 2 n log 4 / log n`, giving
+  `limsup π(x)·log(x)/x ≤ 2 log 4` — the upper half of Chebyshev's 1852 theorem,
+  matching the lower half from OQ-05.
+
+Everything is derived from the parent results plus `Real.log` monotonicity and
+`Nat.monotone_primeCounting`; no new axioms.  `0 sorries, 0 axioms`.
+-/
+
+import Mathlib.NumberTheory.PrimeCounting
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Tactic
+import Proofs.ChebyshevPNTBridge
+
+namespace ChebyshevPNTBridgeOQ06
+
+open Nat
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART I: REAL-LOGARITHMIC FORM OF THE PARENT'S POWER UPPER BOUND
+
+`Real.log` is monotone and turns `a^k ≤ b^m` into `k·log a ≤ m·log b`.  Applied to
+the parent's `(√n)^(π(n)−π(√n)) ≤ 4^n` this is the upper-density counterpart of
+OQ-05's lower-density `primeCounting_mul_log_lower`.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Real-logarithmic upper bound (difference form), all n ≥ 4.**
+
+    (π(n) − π(√n)) · log(√n) ≤ n · log 4,
+
+with `√n = Nat.sqrt n`.  This is `Real.log` applied to the parent's
+`pow_sqrt_primeCounting_diff_le`. -/
+theorem primeCounting_diff_mul_log_sqrt_le (n : ℕ) (hn : 4 ≤ n) :
+    ((Nat.primeCounting n - Nat.primeCounting (Nat.sqrt n) : ℕ) : ℝ)
+        * Real.log (Nat.sqrt n)
+      ≤ (n : ℝ) * Real.log 4 := by
+  have hnat := ChebyshevPNTBridge.pow_sqrt_primeCounting_diff_le n hn
+  have hsqrt_ge2 : 2 ≤ Nat.sqrt n := by rw [Nat.le_sqrt]; omega
+  -- Cast the Nat inequality into ℝ.
+  have hcast : (Nat.sqrt n : ℝ) ^ (Nat.primeCounting n - Nat.primeCounting (Nat.sqrt n))
+      ≤ (4 : ℝ) ^ n := by
+    have hl : (((Nat.sqrt n) ^ (Nat.primeCounting n - Nat.primeCounting (Nat.sqrt n)) : ℕ) : ℝ)
+        = (Nat.sqrt n : ℝ) ^ (Nat.primeCounting n - Nat.primeCounting (Nat.sqrt n)) := by
+      push_cast; ring
+    have hr : ((4 ^ n : ℕ) : ℝ) = (4 : ℝ) ^ n := by push_cast; ring
+    calc (Nat.sqrt n : ℝ) ^ (Nat.primeCounting n - Nat.primeCounting (Nat.sqrt n))
+        = (((Nat.sqrt n) ^ (Nat.primeCounting n - Nat.primeCounting (Nat.sqrt n)) : ℕ) : ℝ) :=
+          hl.symm
+      _ ≤ ((4 ^ n : ℕ) : ℝ) := by exact_mod_cast hnat
+      _ = (4 : ℝ) ^ n := hr
+  have hlhs_pos : (0 : ℝ) <
+      (Nat.sqrt n : ℝ) ^ (Nat.primeCounting n - Nat.primeCounting (Nat.sqrt n)) := by
+    apply pow_pos; exact_mod_cast (by omega : 0 < Nat.sqrt n)
+  have hlog := Real.log_le_log hlhs_pos hcast
+  rw [Real.log_pow, Real.log_pow] at hlog
+  exact hlog
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART II: CLEAN UPPER BOUND ON π(n) (absorbing the π(√n) correction)
+
+`π(√n) ≤ √n` (the parent's `primeCounting_le`) lets us drop the small-prime
+correction term, turning the difference bound into a bound on `π(n)` itself.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Real-logarithmic upper bound, π(n) form, all n ≥ 4.**
+
+    π(n) · log(√n) ≤ n · log 4 + √n · log(√n).
+
+Obtained from `primeCounting_diff_mul_log_sqrt_le` by writing
+`π(n) = (π(n) − π(√n)) + π(√n)` (valid since `π` is monotone and `√n ≤ n`) and
+bounding the correction `π(√n) · log(√n) ≤ √n · log(√n)`. -/
+theorem primeCounting_mul_log_sqrt_le (n : ℕ) (hn : 4 ≤ n) :
+    (Nat.primeCounting n : ℝ) * Real.log (Nat.sqrt n)
+      ≤ (n : ℝ) * Real.log 4 + (Nat.sqrt n : ℝ) * Real.log (Nat.sqrt n) := by
+  have hmono : Nat.primeCounting (Nat.sqrt n) ≤ Nat.primeCounting n :=
+    Nat.monotone_primeCounting (Nat.sqrt_le_self n)
+  have hsqrt_ge2 : 2 ≤ Nat.sqrt n := by rw [Nat.le_sqrt]; omega
+  have hLnn : 0 ≤ Real.log (Nat.sqrt n) :=
+    Real.log_nonneg (by exact_mod_cast (by omega : 1 ≤ Nat.sqrt n))
+  have hpi_sqrt_le : (Nat.primeCounting (Nat.sqrt n) : ℝ) ≤ (Nat.sqrt n : ℝ) := by
+    exact_mod_cast ChebyshevPNTBridge.primeCounting_le (Nat.sqrt n)
+  have hth1 := primeCounting_diff_mul_log_sqrt_le n hn
+  have hcsub : ((Nat.primeCounting n - Nat.primeCounting (Nat.sqrt n) : ℕ) : ℝ)
+      = (Nat.primeCounting n : ℝ) - (Nat.primeCounting (Nat.sqrt n) : ℝ) := by
+    rw [Nat.cast_sub hmono]
+  rw [hcsub] at hth1
+  have hterm : (Nat.primeCounting (Nat.sqrt n) : ℝ) * Real.log (Nat.sqrt n)
+      ≤ (Nat.sqrt n : ℝ) * Real.log (Nat.sqrt n) :=
+    mul_le_mul_of_nonneg_right hpi_sqrt_le hLnn
+  nlinarith [hth1, hterm]
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART III: EXPLICIT CHEBYSHEV UPPER DENSITY (quotient form)
+
+Dividing by `log(√n) > 0` (positive for n ≥ 4, since √n ≥ 2) records the upper
+density directly — the mirror of OQ-05's `primeCounting_ge_div_log`.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **The Chebyshev upper density in quotient form: for n ≥ 4,
+
+    π(n) ≤ n · log 4 / log(√n) + √n.**
+
+Dividing `primeCounting_mul_log_sqrt_le` by `log(√n) > 0`.  As `log(√n) ≈ ½ log n`,
+the leading term is `≈ 2 n log 4 / log n`, so `limsup π(x)·log x / x ≤ 2 log 4`. -/
+theorem primeCounting_le_div_log_sqrt (n : ℕ) (hn : 4 ≤ n) :
+    (Nat.primeCounting n : ℝ)
+      ≤ (n : ℝ) * Real.log 4 / Real.log (Nat.sqrt n) + (Nat.sqrt n : ℝ) := by
+  have hsqrt_ge2 : 2 ≤ Nat.sqrt n := by rw [Nat.le_sqrt]; omega
+  have hL : 0 < Real.log (Nat.sqrt n) :=
+    Real.log_pos (by exact_mod_cast (by omega : 1 < Nat.sqrt n))
+  have h2 := primeCounting_mul_log_sqrt_le n hn
+  -- Multiply the RHS template by log(√n) and compare.
+  have key : ((n : ℝ) * Real.log 4 / Real.log (Nat.sqrt n) + (Nat.sqrt n : ℝ))
+        * Real.log (Nat.sqrt n)
+      = (n : ℝ) * Real.log 4 + (Nat.sqrt n : ℝ) * Real.log (Nat.sqrt n) := by
+    field_simp
+  have hmul : (Nat.primeCounting n : ℝ) * Real.log (Nat.sqrt n)
+      ≤ ((n : ℝ) * Real.log 4 / Real.log (Nat.sqrt n) + (Nat.sqrt n : ℝ))
+          * Real.log (Nat.sqrt n) := by
+    rw [key]; exact h2
+  exact le_of_mul_le_mul_right hmul hL
+
+#check primeCounting_diff_mul_log_sqrt_le   -- real-log difference form
+#check primeCounting_mul_log_sqrt_le        -- real-log π(n) form
+#check primeCounting_le_div_log_sqrt        -- quotient (upper density) form
+#check ChebyshevPNTBridgeOQ06.primeCounting_le_div_log_sqrt
+
+end ChebyshevPNTBridgeOQ06

--- a/research/problems/chebyshev-pnt-bridge-oq-06/knowledge.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-06/knowledge.md
@@ -1,0 +1,46 @@
+# Knowledge Base: chebyshev-pnt-bridge-oq-06
+
+Parent: ChebyshevPNTBridge.lean (Chebyshev's 1852 bounds on π(x)).
+Sibling: OQ-05 carried the LOWER bound into real-log form. This OQ-06 is the
+UPPER-bound mirror.
+
+---
+
+## Session 1 (2026-06-27, researcher-3): real-log upper bound
+
+**Deliverable:** `proofs/Proofs/ChebyshevPNTBridgeOQ06.lean` (160 lines, 3 theorems,
+**verified 0-sorry 0-axiom** — `#print axioms` lists only
+propext/Classical.choice/Quot.sound).
+
+The parent proves the upper bound only in ℕ-power form
+`(Nat.sqrt n)^(π(n)−π(√n)) ≤ 4^n` (`pow_sqrt_primeCounting_diff_le`), stating the
+real-log consequence only as a header comment. OQ-05 had done the lower bound in
+real-log form but no upper counterpart existed. Added:
+
+* `primeCounting_diff_mul_log_sqrt_le`: `(π(n)−π(√n))·log(√n) ≤ n·log 4` for n ≥ 4
+  — Real.log of the parent's power inequality (Real.log_le_log + Real.log_pow).
+* `primeCounting_mul_log_sqrt_le`: `π(n)·log(√n) ≤ n·log 4 + √n·log(√n)` — split
+  π(n) = (π(n)−π(√n)) + π(√n) via `Nat.cast_sub` (using `Nat.monotone_primeCounting`),
+  absorb correction via parent's `primeCounting_le` (π(√n) ≤ √n) and log(√n) ≥ 0.
+* `primeCounting_le_div_log_sqrt`: `π(n) ≤ n·log 4/log(√n) + √n` — divide by
+  log(√n) > 0 (√n ≥ 2 for n ≥ 4) via `le_of_mul_le_mul_right` + a `field_simp`
+  identity. Gives `limsup π(x)·log x/x ≤ 2 log 4` (since log(√n) ≈ ½ log n).
+
+Together with OQ-05's `primeCounting_ge_div_log` (lower density ≥ log 2 − o(1)),
+both halves of Chebyshev's theorem are now in matching Real.log form.
+
+GOTCHAs / reusable facts:
+* Proof skeleton is identical to OQ-05's lower-bound log transcription — copy its
+  `Real.log_le_log h_pos h_cast; rw [Real.log_pow, Real.log_pow]` pattern; the only
+  change is which parent Nat inequality is fed in.
+* `Nat.monotone_primeCounting (h : a ≤ b) : π a ≤ π b` exists in Mathlib (no reprove).
+* `Nat.le_sqrt` rewrites `2 ≤ Nat.sqrt n` to `2*2 ≤ n`; `omega` closes with `4 ≤ n`.
+* Keep `Nat.sqrt n` (integer sqrt) throughout → inequalities are EXACT, not
+  asymptotic; the 2 log 4 constant is read off in prose via log(√n) ≈ ½ log n.
+* Verify: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/ChebyshevPNTBridgeOQ06.lean`
+  (parent + ChebyshevBounds oleans already present in build/lib/lean/Proofs).
+
+## Dead ends / deferred
+* Tighter constants (Chebyshev's 0.921/1.106) need sharper primorial/central-binomial
+  estimates — deferred.
+* Full PNT π(x) ~ x/log x needs analytic ζ machinery — out of reach here.

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "chebyshev-pnt-bridge-oq-06",
+  "title": "Chebyshev–PNT Bridge OQ-06: Real-Logarithmic Upper Bound on π(n)",
+  "slug": "chebyshev-pnt-bridge-oq-06",
+  "description": "Completes the real-logarithmic packaging of Chebyshev's 1852 bounds on the prime-counting function π(n). The parent ChebyshevPNTBridge.lean proves the upper bound only in ℕ-power form ((Nat.sqrt n)^(π(n)−π(√n)) ≤ 4^n), stating its real-log consequence only as a header comment, while sibling OQ-05 carried the lower bound into real-log form. This file (ChebyshevPNTBridgeOQ06.lean) supplies the missing upper counterpart: taking Real.log of the parent's power inequality gives (π(n)−π(√n))·log(√n) ≤ n·log 4 (primeCounting_diff_mul_log_sqrt_le); absorbing the π(√n) correction via the trivial π(√n) ≤ √n gives π(n)·log(√n) ≤ n·log 4 + √n·log(√n) (primeCounting_mul_log_sqrt_le); and dividing by log(√n) > 0 records the upper density π(n) ≤ n·log 4/log(√n) + √n (primeCounting_le_div_log_sqrt). Since log(√n) ≈ ½ log n the leading term is ≈ 2n·log 4/log n, giving limsup π(x)·log x/x ≤ 2 log 4 — the upper half of Chebyshev's theorem, now in the same form as OQ-05's lower half. Fully verified, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_function",
+    "date": "Chebyshev 1852; formalized 2026",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "prime-counting",
+      "chebyshev",
+      "analytic-number-theory",
+      "prime-number-theorem",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ06.lean",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 3 theorems are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The bound uses the integer square root Nat.sqrt n throughout (so it is exact, not asymptotic); the asymptotic statement limsup π(x)·log x/x ≤ 2 log 4 is described in prose, not separately formalized.",
+    "originalContributions": [
+      "primeCounting_diff_mul_log_sqrt_le: the real-logarithmic upper bound in difference form, (π(n)−π(√n))·log(√n) ≤ n·log 4 for n ≥ 4 — Real.log applied to the parent's pow_sqrt_primeCounting_diff_le; the upper-density mirror of OQ-05's primeCounting_mul_log_lower",
+      "primeCounting_mul_log_sqrt_le: the clean π(n) form, π(n)·log(√n) ≤ n·log 4 + √n·log(√n), absorbing the small-prime correction via π(√n) ≤ √n and π monotone",
+      "primeCounting_le_div_log_sqrt: the Chebyshev upper density in quotient form, π(n) ≤ n·log 4/log(√n) + √n — dividing by log(√n) > 0; gives limsup π(x)·log x/x ≤ 2 log 4",
+      "Completes the symmetric real-log packaging: OQ-05 gave the lower density (≥ log 2 − o(1)) and OQ-06 gives the upper density (≤ 2 log 4 + o(1)), the two halves of Chebyshev's 1852 theorem now in matching Real.log form"
+    ],
+    "dateAdded": "2026-06-27",
+    "lineCount": 160,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Chebyshev (1852) proved the first rigorous bounds of the right order of magnitude for the prime-counting function: c₁·x/log x ≤ π(x) ≤ c₂·x/log x with explicit constants (his 0.921 and 1.106), half a century before the Prime Number Theorem (Hadamard, de la Vallée Poussin, 1896) showed π(x) ∼ x/log x. The Lean parent ChebyshevPNTBridge.lean reproves Chebyshev-type bounds with weaker constants (log 2 and 2 log 4) using the primorial bound primorial(n) ≤ 4^n for the upper bound and the central binomial coefficient C(2n,n) for the lower bound. OQ-05 packaged the lower bound in real-logarithmic form for all m; this OQ-06 packages the upper bound, completing the pair.",
+    "problemStatement": "**Open question (OQ-06 from the Chebyshev–PNT bridge)**: package the parent's ℕ-power upper bound (Nat.sqrt n)^(π(n)−π(√n)) ≤ 4^n into real-logarithmic and quotient (density) form, matching the lower bound already done in OQ-05, so that both halves of Chebyshev's theorem appear in the same Real.log shape.\n\n**This deliverable**: the three real-log upper-bound theorems and the resulting limsup π(x)·log x/x ≤ 2 log 4.",
+    "text": "A 160-line, fully-verified, 0-axiom Lean file. Real.log is monotone and additive on positive reals and satisfies log(a^k) = k·log a, so taking logs of the parent's power inequality (Nat.sqrt n)^(π(n)−π(√n)) ≤ 4^n turns it into (π(n)−π(√n))·log(√n) ≤ n·log 4 (primeCounting_diff_mul_log_sqrt_le). Writing π(n) = (π(n)−π(√n)) + π(√n) — valid because Nat.monotone_primeCounting gives π(√n) ≤ π(n) — and bounding the correction with the parent's π(√n) ≤ √n yields π(n)·log(√n) ≤ n·log 4 + √n·log(√n) (primeCounting_mul_log_sqrt_le). Dividing by log(√n) > 0 (positive since √n ≥ 2 for n ≥ 4) gives the density form π(n) ≤ n·log 4/log(√n) + √n (primeCounting_le_div_log_sqrt). The integer square root is kept throughout, so the inequalities are exact.",
+    "proofStrategy": "Mirror OQ-05's lower-bound log transcription exactly. (1) Cast the parent's Nat power inequality into ℝ (push_cast + exact_mod_cast). (2) Apply Real.log_le_log (monotone on positives) and Real.log_pow to both sides to get the difference form. (3) Use Nat.cast_sub with π(√n) ≤ π(n) to split π(n), and mul_le_mul_of_nonneg_right with π(√n) ≤ √n (and log(√n) ≥ 0) to absorb the correction. (4) Divide by log(√n) > 0 via le_of_mul_le_mul_right and a field_simp identity.",
+    "keyInsights": [
+      "**The upper bound was the missing sibling.** The parent stated 'π(n) ≤ √n + n·log 4/log √n' only as a header comment; OQ-05 formalized the lower density but not the upper. OQ-06 closes that asymmetry so limsup and liminf bounds are now both available in Real.log form.",
+      "**The integer square root is harmless.** Keeping Nat.sqrt n rather than the real √n makes every inequality exact (no asymptotic slack), at the cost of carrying log(Nat.sqrt n) ≈ ½ log n; the asymptotic constant 2 log 4 is read off afterwards.",
+      "**π(√n) ≤ √n turns a difference bound into an absolute bound.** The trivial prime-counting bound from the parent is exactly what lets the small-prime correction term be dropped into the explicit √n summand.",
+      "**Same proof skeleton as OQ-05.** Reusing Real.log_le_log / Real.log_pow / Nat.cast_sub keeps the upper and lower developments structurally identical — the only difference is which parent inequality is fed in."
+    ],
+    "prerequisites": [
+      "Chebyshev's bounds on π(x) and the parent gallery entry chebyshev-pnt-bridge",
+      "The sibling OQ-05 (real-log lower bound) whose structure this mirrors",
+      "Real.log monotonicity/additivity and Real.log_pow",
+      "Nat.monotone_primeCounting and Nat.sqrt basics",
+      "The prime number theorem context (π(x) ∼ x/log x)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "real-log-difference",
+      "title": "Real-Logarithmic Difference Form",
+      "startLine": 44,
+      "endLine": 88,
+      "summary": "primeCounting_diff_mul_log_sqrt_le takes Real.log of the parent's (Nat.sqrt n)^(π(n)−π(√n)) ≤ 4^n: cast to ℝ, apply Real.log_le_log (monotone on positives) and Real.log_pow on both sides, yielding (π(n)−π(√n))·log(√n) ≤ n·log 4 for n ≥ 4.",
+      "mathContext": "$(\\pi(n)-\\pi(\\sqrt n))\\log\\sqrt n \\le n\\log 4$, from $(\\sqrt n)^{\\pi(n)-\\pi(\\sqrt n)} \\le 4^n$."
+    },
+    {
+      "id": "clean-upper",
+      "title": "Clean Upper Bound on π(n)",
+      "startLine": 89,
+      "endLine": 130,
+      "summary": "primeCounting_mul_log_sqrt_le splits π(n) = (π(n)−π(√n)) + π(√n) via Nat.cast_sub (using Nat.monotone_primeCounting) and absorbs the correction with π(√n) ≤ √n (parent's primeCounting_le) and log(√n) ≥ 0, giving π(n)·log(√n) ≤ n·log 4 + √n·log(√n).",
+      "mathContext": "$\\pi(n)\\log\\sqrt n \\le n\\log 4 + \\sqrt n\\,\\log\\sqrt n$."
+    },
+    {
+      "id": "upper-density",
+      "title": "Chebyshev Upper Density (Quotient Form)",
+      "startLine": 131,
+      "endLine": 160,
+      "summary": "primeCounting_le_div_log_sqrt divides by log(√n) > 0 (positive since √n ≥ 2 for n ≥ 4) via le_of_mul_le_mul_right and a field_simp identity, giving π(n) ≤ n·log 4/log(√n) + √n. As log(√n) ≈ ½ log n, this yields limsup π(x)·log x/x ≤ 2 log 4.",
+      "mathContext": "$\\pi(n) \\le \\dfrac{n\\log 4}{\\log\\sqrt n} + \\sqrt n$, hence $\\limsup \\dfrac{\\pi(x)\\log x}{x} \\le 2\\log 4$."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "primeCounting_diff_mul_log_sqrt_le",
+      "type": "theorem",
+      "statement": "$n \\ge 4 \\Rightarrow (\\pi(n) - \\pi(\\sqrt n))\\cdot\\log\\sqrt n \\le n\\cdot\\log 4$",
+      "significance": "The real-logarithmic form of Chebyshev's upper bound, the direct upper-density mirror of OQ-05's primeCounting_mul_log_lower. Obtained by taking Real.log of the parent's purely combinatorial power inequality.",
+      "description": "Cast (Nat.sqrt n)^(π(n)−π(√n)) ≤ 4^n into ℝ; apply Real.log_le_log and Real.log_pow on both sides."
+    },
+    {
+      "name": "primeCounting_mul_log_sqrt_le",
+      "type": "theorem",
+      "statement": "$n \\ge 4 \\Rightarrow \\pi(n)\\cdot\\log\\sqrt n \\le n\\cdot\\log 4 + \\sqrt n\\cdot\\log\\sqrt n$",
+      "significance": "A bound on π(n) itself (not just the difference π(n)−π(√n)), obtained by absorbing the small-prime correction via the trivial π(√n) ≤ √n. This is the clean form from which the density bound follows.",
+      "description": "Split π(n) = (π(n)−π(√n)) + π(√n) with Nat.cast_sub (Nat.monotone_primeCounting) and bound π(√n)·log(√n) ≤ √n·log(√n)."
+    },
+    {
+      "name": "primeCounting_le_div_log_sqrt",
+      "type": "theorem",
+      "statement": "$n \\ge 4 \\Rightarrow \\pi(n) \\le \\dfrac{n\\cdot\\log 4}{\\log\\sqrt n} + \\sqrt n$",
+      "significance": "The Chebyshev UPPER density in explicit quotient form — the mirror of OQ-05's primeCounting_ge_div_log. With log(√n) ≈ ½ log n it gives limsup π(x)·log x/x ≤ 2 log 4, the upper half of Chebyshev's 1852 theorem, completing the pair with OQ-05's lower half.",
+      "description": "Divide primeCounting_mul_log_sqrt_le by log(√n) > 0 via le_of_mul_le_mul_right and a field_simp identity."
+    }
+  ],
+  "references": [
+    {
+      "author": "Chebyshev, P. L.",
+      "year": 1852,
+      "title": "Mémoire sur les nombres premiers",
+      "venue": "Journal de mathématiques pures et appliquées 17: 366–390",
+      "note": "First rigorous bounds c₁·x/log x ≤ π(x) ≤ c₂·x/log x; this file reproves the upper half with constant 2 log 4."
+    },
+    {
+      "author": "The Mathlib Community",
+      "year": 2026,
+      "title": "Mathlib.NumberTheory.PrimeCounting",
+      "venue": "Mathlib4 (accessed 2026)",
+      "note": "Provides Nat.primeCounting and Nat.monotone_primeCounting used here."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "chebyshev-pnt-bridge",
+      "relationship": "extends",
+      "description": "Parent formalization of Chebyshev's bounds. This file takes Real.log of the parent's ℕ-power upper bound pow_sqrt_primeCounting_diff_le and uses its primeCounting_le."
+    },
+    {
+      "proofId": "chebyshev-pnt-bridge-oq-05",
+      "relationship": "sibling",
+      "description": "OQ-05 packaged the LOWER bound in real-log form (primeCounting_mul_log_lower, primeCounting_ge_div_log); OQ-06 is its UPPER-bound mirror, completing the symmetric pair of Chebyshev densities."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.PrimeCounting",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Tactic",
+      "Proofs.ChebyshevPNTBridge"
+    ],
+    "namespace": "ChebyshevPNTBridgeOQ06",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/ChebyshevPNTBridgeOQ06.lean",
+    "sorries": 0
+  },
+  "conclusion": {
+    "summary": "Supplies the real-logarithmic UPPER bound on π(n) that the parent left as a header comment and that OQ-05's lower-bound work lacked a counterpart for: the difference form (π(n)−π(√n))·log(√n) ≤ n·log 4, the clean π(n) form π(n)·log(√n) ≤ n·log 4 + √n·log(√n), and the density quotient π(n) ≤ n·log 4/log(√n) + √n giving limsup π(x)·log x/x ≤ 2 log 4. All 3 theorems verify with 0 sorries and 0 axioms, structurally mirroring OQ-05.",
+    "implications": "Both halves of Chebyshev's 1852 theorem are now available in matching Real.log form (OQ-05 lower density ≥ log 2 − o(1), OQ-06 upper density ≤ 2 log 4 + o(1)). The natural next step is tightening the constants toward Chebyshev's sharper 0.921/1.106, and ultimately the asymptotic π(x) ∼ x/log x (PNT), which needs the analytic machinery (ζ non-vanishing on Re s = 1) not yet in this development.",
+    "openQuestions": [
+      "Tighten the constants from (log 2, 2 log 4) toward Chebyshev's (0.921, 1.106) via sharper primorial / central-binomial estimates.",
+      "Combine OQ-05 and OQ-06 into a single two-sided sandwich theorem with a common normalisation.",
+      "Bridge to the full Prime Number Theorem π(x) ∼ x/log x (requires analytic continuation and ζ non-vanishing)."
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/chebyshev-pnt-bridge-oq-06.json
+++ b/src/data/research/problems/chebyshev-pnt-bridge-oq-06.json
@@ -1,0 +1,56 @@
+{
+  "slug": "chebyshev-pnt-bridge-oq-06",
+  "title": "Chebyshev–PNT Bridge OQ-06: real-log upper bound on π(n)",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "Package the parent's ℕ-power Chebyshev upper bound (Nat.sqrt n)^(π(n)−π(√n)) ≤ 4^n into real-logarithmic and density form, mirroring the lower bound done in OQ-05.",
+    "plain": "The parent proves Chebyshev's upper bound on the prime-counting function π(n) only in power form; OQ-05 carried the lower bound into log form. This delivers the matching upper-bound log/density form, giving limsup π(x)·log x/x ≤ 2 log 4.",
+    "whyMatters": ["Completes the symmetric real-log packaging of both halves of Chebyshev's 1852 theorem", "Upper density mirror of OQ-05's lower density"]
+  },
+  "knownResults": {
+    "proven": ["(π(n)−π(√n))·log(√n) ≤ n·log 4", "π(n)·log(√n) ≤ n·log 4 + √n·log(√n)", "π(n) ≤ n·log 4/log(√n) + √n"],
+    "open": ["tighter constants toward Chebyshev's 0.921/1.106", "full PNT π(x) ~ x/log x"],
+    "goal": "Real-log upper bound on π(n) matching OQ-05's lower bound."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-27T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Delivered ChebyshevPNTBridgeOQ06.lean (3 thms, 0-sorry 0-axiom): real-log upper bound on π(n) by taking Real.log of the parent's power inequality, absorbing the π(√n) correction, and dividing by log(√n). Mirrors OQ-05's lower-bound development.",
+    "blockers": [],
+    "nextAction": "Combine OQ-05 + OQ-06 into a single two-sided sandwich; tighten constants; the full PNT is out of reach (needs analytic ζ machinery).",
+    "attemptCounts": { "total": 1, "currentApproach": 1, "approachesTried": 1 }
+  },
+  "knowledge": {
+    "progressSummary": "S1 ACT: real-log UPPER bound on π(n) for Chebyshev–PNT bridge (ChebyshevPNTBridgeOQ06.lean, 160 lines, 3 theorems, 0-sorry 0-axiom). primeCounting_diff_mul_log_sqrt_le, primeCounting_mul_log_sqrt_le, primeCounting_le_div_log_sqrt — the upper-density mirror of OQ-05's lower density, giving limsup π(x)·log x/x ≤ 2 log 4.",
+    "builtItems": [
+      "primeCounting_diff_mul_log_sqrt_le: (π(n)−π(√n))·log(√n) ≤ n·log 4 (Real.log of parent's pow_sqrt_primeCounting_diff_le)",
+      "primeCounting_mul_log_sqrt_le: π(n)·log(√n) ≤ n·log 4 + √n·log(√n) (absorb π(√n) ≤ √n)",
+      "primeCounting_le_div_log_sqrt: π(n) ≤ n·log 4/log(√n) + √n (divide by log(√n) > 0)"
+    ],
+    "insights": [
+      "Mirrors OQ-05's lower-bound log transcription exactly (Real.log_le_log + Real.log_pow + Nat.cast_sub); only the parent inequality fed in differs.",
+      "Keeping Nat.sqrt n makes inequalities exact; the asymptotic 2 log 4 is read off via log(√n) ≈ ½ log n afterward.",
+      "Nat.monotone_primeCounting exists in Mathlib — no need to reprove π monotonicity.",
+      "π(√n) ≤ √n (parent's primeCounting_le) is exactly what turns the difference bound into an absolute π(n) bound."
+    ],
+    "mathlibGaps": [
+      "No real-log Chebyshev bounds in Mathlib (only the combinatorial primorial / central-binomial pieces).",
+      "No PNT (π(x) ~ x/log x) — needs ζ non-vanishing on Re s = 1."
+    ],
+    "nextSteps": [
+      "Combine OQ-05 (lower) and OQ-06 (upper) into one two-sided sandwich theorem with a common normalisation.",
+      "Tighten constants toward Chebyshev's 0.921/1.106 via sharper estimates.",
+      "Full PNT is out of reach in this elementary development."
+    ],
+    "markdown": "# Knowledge: chebyshev-pnt-bridge-oq-06\nSee research/problems/chebyshev-pnt-bridge-oq-06/knowledge.md for session notes.\n"
+  },
+  "tags": ["number-theory", "prime-counting", "chebyshev", "analytic-number-theory"],
+  "relatedProofs": ["chebyshev-pnt-bridge", "chebyshev-pnt-bridge-oq-05"],
+  "references": { "papers": [], "urls": ["https://en.wikipedia.org/wiki/Chebyshev_function"], "mathlib": ["Mathlib.NumberTheory.PrimeCounting"] },
+  "started": "2026-06-27T00:00:00.000Z",
+  "lastUpdate": "2026-06-27T00:00:00.000Z"
+}


### PR DESCRIPTION
## Summary

Completes the symmetric real-logarithmic packaging of **Chebyshev's 1852 bounds** on the prime-counting function π(n).

The parent `ChebyshevPNTBridge.lean` proves the upper bound only in `ℕ`-power form `(Nat.sqrt n)^(π(n)−π(√n)) ≤ 4^n`, stating its real-log consequence only as a header comment. The sibling **OQ-05** carried the *lower* bound into real-log form (`primeCounting_mul_log_lower`, `primeCounting_ge_div_log`). This PR adds the missing *upper* counterpart.

## New theorems (`ChebyshevPNTBridgeOQ06.lean`, 3 theorems, 0-sorry / 0-axiom)

| Theorem | Statement |
|---|---|
| `primeCounting_diff_mul_log_sqrt_le` | `(π(n)−π(√n))·log(√n) ≤ n·log 4` |
| `primeCounting_mul_log_sqrt_le` | `π(n)·log(√n) ≤ n·log 4 + √n·log(√n)` |
| `primeCounting_le_div_log_sqrt` | `π(n) ≤ n·log 4/log(√n) + √n` |

The last gives `limsup π(x)·log x / x ≤ 2 log 4`, the **upper half** of Chebyshev's theorem — now in the same `Real.log` form as OQ-05's lower half (`≥ log 2 − o(1)`).

## Method

Mirrors OQ-05's lower-bound transcription exactly: cast the parent's `ℕ` power inequality to `ℝ`, apply `Real.log_le_log` + `Real.log_pow`, split `π(n) = (π(n)−π(√n)) + π(√n)` via `Nat.cast_sub` (using `Nat.monotone_primeCounting`), absorb the correction with the parent's `π(√n) ≤ √n`, and divide by `log(√n) > 0`. The integer square root `Nat.sqrt n` is kept throughout, so every inequality is **exact** (the asymptotic constant `2 log 4` is read off via `log(√n) ≈ ½ log n`).

`#print axioms` on all three results lists only `propext`/`Classical.choice`/`Quot.sound`. Built with `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/ChebyshevPNTBridgeOQ06.lean` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)