### PR TITLE
research(shannon-channel-coding-bec-oq-02): operational coding theorem for the BEC [axiomatized]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingBECOQ02.lean
+++ b/proofs/Proofs/ShannonChannelCodingBECOQ02.lean
@@ -1,0 +1,134 @@
+/-
+  Operational coding theorem for the Binary Erasure Channel
+  (open question shannon-channel-coding-bec-oq-02)
+
+  The base entry `Proofs.ShannonChannelCodingBEC` establishes the
+  *information-theoretic* capacity of the binary erasure channel from first
+  principles, axiom-free:
+
+        channelCapacity (bec p) = (1 - p) · log 2 nats   (= 1 - p bits).
+
+  That is a statement about a supremum of mutual informations over input
+  distributions — it says nothing yet about *codes*.  The open question asks to
+  bridge that information-theoretic supremum to the *operational* layer: rates
+  that are actually achievable by block codes with vanishing error, and a
+  matching converse forbidding reliable communication above capacity.
+
+  The gallery's discrete-memoryless channel framework already provides Shannon's
+  two operational theorems as the named results
+  `InformationTheory.ChannelCoding.channel_coding_achievability` and
+  `…channel_coding_converse` (both stated for an arbitrary `DMChannel` in terms
+  of its `channelCapacity`).  In this gallery those two theorems are *axioms* —
+  the deep random-coding / Fano arguments are taken as given at the abstract
+  level — so any operational statement derived from them is, honestly,
+  axiomatized.  What this file contributes is the *specialisation* to the
+  concrete BEC: feeding the proved capacity value `(1 - p)·log 2` through the
+  abstract operational theorems gives the BEC's operational coding theorem with
+  an explicit numerical threshold.
+
+  Results (all by substituting `bec_capacity` into the abstract operational
+  theorems):
+
+    * `bec_coding_achievability`       — any rate `0 < R < (1-p)·log 2` (nats) is
+                                         achievable: for every `ε > 0`, all long
+                                         enough block lengths admit a code of rate
+                                         `≥ R` with average error `< ε`.
+    * `bec_coding_achievability_bits`  — the textbook form: any bit-rate
+                                         `0 < R₂ < 1 - p` is achievable.
+    * `bec_coding_converse`            — any rate `R > (1-p)·log 2` is *not*
+                                         achievable: the average error is bounded
+                                         below by a fixed `δ > 0` for every code.
+    * `bec_coding_converse_bits`       — bit-rate form of the converse.
+
+  Together these pin the BEC's *operational* capacity to exactly the
+  information-theoretic value `(1-p)·log 2`, closing the loop the open question
+  asks for.
+
+  Status: 0 sorries.  Honestly *axiomatized*: every result here inherits
+  `channel_coding_achievability` and/or `channel_coding_converse` from the base
+  channel-coding framework (plus the ordinary `propext / Classical.choice /
+  Quot.sound`).  The BEC capacity value itself (`bec_capacity`) is axiom-free.
+-/
+import Mathlib
+import Proofs.ShannonChannelCodingBEC
+
+namespace InformationTheory.ChannelCoding.BEC
+
+open Filter
+
+variable {p : ℝ}
+
+/-- **Operational achievability for the BEC.**
+For any rate `0 < R < (1 - p)·log 2` (in nats), reliable communication is
+possible: for every target error `ε > 0`, all sufficiently long block lengths
+`n` admit a block code of rate `≥ R` together with a decoder whose average error
+probability is `< ε`.
+
+This is the gallery's abstract `channel_coding_achievability` applied to the
+binary erasure channel, with the capacity hypothesis discharged by the proved
+value `bec_capacity : channelCapacity (bec p) = (1 - p)·log 2`. -/
+theorem bec_coding_achievability (hp0 : 0 < p) (hp1 : p < 1)
+    {R : ℝ} (hR : 0 < R) (hR_cap : R < (1 - p) * Real.log 2) :
+    ∀ ε : ℝ, 0 < ε → ∀ᶠ (n : ℕ) in Filter.atTop, ∀ (hn : 0 < n),
+      ∃ (code : BlockCode Bool n) (decoder : (Fin n → Option Bool) → Fin code.M),
+        R ≤ rate_of_code hn code ∧
+        (∑ i : Fin code.M, (1 - ∑ y : Fin n → Option Bool,
+          (∏ j : Fin n, (bec p hp0.le hp1.le).W (code.encode i j) (y j)) *
+            if decoder y = i then (1 : ℝ) else 0)) / code.M < ε :=
+  channel_coding_achievability (bec p hp0.le hp1.le) hR
+    (by rw [bec_capacity hp0 hp1]; exact hR_cap)
+
+/-- **Operational converse for the BEC.**
+For any rate `R > (1 - p)·log 2` (in nats), reliable communication is impossible:
+there is a fixed `δ > 0` such that *every* block code of rate `≥ R` (at every
+length) has average error probability `≥ δ`.
+
+This is the gallery's abstract `channel_coding_converse` applied to the BEC, with
+the capacity hypothesis discharged by `bec_capacity`. -/
+theorem bec_coding_converse (hp0 : 0 < p) (hp1 : p < 1)
+    {R : ℝ} (hR : 0 < R) (hR_cap : (1 - p) * Real.log 2 < R) :
+    ∃ δ : ℝ, 0 < δ ∧ ∀ (n : ℕ) (hn : 0 < n)
+      (code : BlockCode Bool n) (decoder : (Fin n → Option Bool) → Fin code.M),
+        R ≤ rate_of_code hn code →
+        δ ≤ (∑ i : Fin code.M, (1 - ∑ y : Fin n → Option Bool,
+          (∏ j : Fin n, (bec p hp0.le hp1.le).W (code.encode i j) (y j)) *
+            if decoder y = i then (1 : ℝ) else 0)) / code.M :=
+  channel_coding_converse (bec p hp0.le hp1.le) hR
+    (by rw [bec_capacity hp0 hp1]; exact hR_cap)
+
+/-- **Achievability in bits — the textbook headline.**
+Any bit-rate `0 < R₂ < 1 - p` is achievable on the BEC.  Equivalent to
+`bec_coding_achievability` with the nat-rate `R = R₂ · log 2`; the rate guarantee
+`R₂ · log 2 ≤ rate_of_code` says exactly that the code's bit-rate
+`rate_of_code / log 2` is at least `R₂`. -/
+theorem bec_coding_achievability_bits (hp0 : 0 < p) (hp1 : p < 1)
+    {R₂ : ℝ} (hR : 0 < R₂) (hR_cap : R₂ < 1 - p) :
+    ∀ ε : ℝ, 0 < ε → ∀ᶠ (n : ℕ) in Filter.atTop, ∀ (hn : 0 < n),
+      ∃ (code : BlockCode Bool n) (decoder : (Fin n → Option Bool) → Fin code.M),
+        R₂ * Real.log 2 ≤ rate_of_code hn code ∧
+        (∑ i : Fin code.M, (1 - ∑ y : Fin n → Option Bool,
+          (∏ j : Fin n, (bec p hp0.le hp1.le).W (code.encode i j) (y j)) *
+            if decoder y = i then (1 : ℝ) else 0)) / code.M < ε := by
+  have hlog2 : 0 < Real.log 2 := Real.log_pos (by norm_num)
+  refine bec_coding_achievability hp0 hp1 (by positivity) ?_
+  -- R₂ · log 2 < (1 - p) · log 2 since R₂ < 1 - p and log 2 > 0.
+  exact mul_lt_mul_of_pos_right hR_cap hlog2
+
+/-- **Converse in bits.**
+No bit-rate `R₂ > 1 - p` is achievable on the BEC: a fixed `δ > 0` lower-bounds
+the average error of every code whose nat-rate is `≥ R₂ · log 2` (i.e. whose
+bit-rate is `≥ R₂`). -/
+theorem bec_coding_converse_bits (hp0 : 0 < p) (hp1 : p < 1)
+    {R₂ : ℝ} (hR : 0 < R₂) (hR_cap : 1 - p < R₂) :
+    ∃ δ : ℝ, 0 < δ ∧ ∀ (n : ℕ) (hn : 0 < n)
+      (code : BlockCode Bool n) (decoder : (Fin n → Option Bool) → Fin code.M),
+        R₂ * Real.log 2 ≤ rate_of_code hn code →
+        δ ≤ (∑ i : Fin code.M, (1 - ∑ y : Fin n → Option Bool,
+          (∏ j : Fin n, (bec p hp0.le hp1.le).W (code.encode i j) (y j)) *
+            if decoder y = i then (1 : ℝ) else 0)) / code.M := by
+  have hlog2 : 0 < Real.log 2 := Real.log_pos (by norm_num)
+  refine bec_coding_converse hp0 hp1 (by positivity) ?_
+  -- (1 - p) · log 2 < R₂ · log 2 since 1 - p < R₂ and log 2 > 0.
+  exact mul_lt_mul_of_pos_right hR_cap hlog2
+
+end InformationTheory.ChannelCoding.BEC

--- a/research/problems/shannon-channel-coding-bec-oq-02/knowledge.md
+++ b/research/problems/shannon-channel-coding-bec-oq-02/knowledge.md
@@ -1,0 +1,77 @@
+# shannon-channel-coding-bec-oq-02 — Operational Coding Theorem for the BEC
+
+**Parent gallery proof:** `shannon-channel-coding-bec` (BEC information capacity `C = (1-p)·log 2`, axiom-free).
+**Open question:** Establish an operational coding theorem for the BEC, connecting the
+information-theoretic supremum proved in the parent to achievable communication rates
+through the framework's `channel_coding_achievability`.
+
+## Summary
+
+The gallery's discrete-memoryless-channel framework (`ShannonChannelCoding.lean`) already
+states Shannon's two operational theorems for an *arbitrary* `DMChannel`, in terms of its
+`channelCapacity`:
+
+- `channel_coding_achievability` — rates below capacity are achievable (random coding);
+- `channel_coding_converse` — rates above capacity are not (Fano).
+
+Both are **axioms** of that framework (the deep arguments are taken as given at the abstract
+level). The BEC parent supplies, axiom-free, the concrete channel `bec : DMChannel Bool
+(Option Bool)` together with the capacity value `bec_capacity : channelCapacity (bec p) =
+(1-p)·log 2`. Specialising the two abstract theorems to `bec` and rewriting their capacity
+hypothesis with `bec_capacity` produces the BEC operational coding theorem with an explicit
+numerical threshold — exactly the bridge the open question asks for, via the route it itself
+suggests ("through the parent's channel_coding_achievability").
+
+This is an *instantiation*, not a from-scratch operational proof; it is therefore honestly
+**axiomatized** (2 inherited axioms), not verified.
+
+## Session 2026-06-27 (Session 1) — FRESH
+
+**Mode:** FRESH · **Outcome:** completed (axiomatized, 0 sorries)
+
+### What I did
+- Surveyed the parent and framework: confirmed `bec` is packaged as a `DMChannel Bool
+  (Option Bool)` and that `bec_capacity` gives `channelCapacity (bec p) = (1-p)·log 2`.
+- Confirmed `channel_coding_achievability` / `channel_coding_converse` are the framework's
+  abstract operational theorems, stated in terms of `channelCapacity ch` (and are axioms).
+- Wrote `proofs/Proofs/ShannonChannelCodingBECOQ02.lean` (134 lines, 4 theorems):
+  - `bec_coding_achievability` — every nat-rate `0 < R < (1-p)·log 2` achievable.
+  - `bec_coding_converse` — every nat-rate `R > (1-p)·log 2` unachievable.
+  - `bec_coding_achievability_bits` / `bec_coding_converse_bits` — bit-rate forms
+    (threshold `1-p` bits), via `mul_lt_mul_of_pos_right` and `Real.log_pos`.
+- Built the file axiom-checked: `#print axioms` shows achievability ← `channel_coding_achievability`,
+  converse ← `channel_coding_converse`, each plus only `propext / Classical.choice / Quot.sound`.
+- Authored gallery data (`meta.json`, `annotations.json`); verified the generator accepts
+  the entry (appears in `listings.json` as status `axiomatized`, badge `axiom`, 4 annotations).
+
+### Key findings
+- The framework was already channel-agnostic: the *only* channel-specific input needed to
+  instantiate the operational theorems is the numerical capacity value.
+- The nat↔bit conversion is a single multiplication by the positive constant `log 2`; the
+  rate guarantee `R₂·log 2 ≤ rate_of_code` is exactly "bit-rate `≥ R₂`".
+- Honest status is `axiomatized` (2 axioms on the critical path). `leanFile.axiomCount = 0`
+  (no literal `axiom` decl); `meta.axiomCount = 2` (inherited framework axioms).
+
+### Gotchas
+- Docker build wrapper is down (host disk ~95% full → containerd I/O error). Built via the
+  `LAKE_UNSAFE=1 lake env lean -o .lake/build/lib/lean/Proofs/X.olean` fallback, compiling
+  the Shannon dependency chain (OQ04, Entropy, OQ04OQ01, OQ03, OQ02OQ01, ChannelCoding, OQ02,
+  BEC) one file at a time (each fast — Mathlib oleans are cached; the worktree `.lake` is a
+  symlink to the main repo's shared cache).
+- `mul_lt_mul_right` resolved to the wrong typeclass form (`MulLeftStrictMono ℝ` synth
+  failure); use `mul_lt_mul_of_pos_right` instead.
+- Worktree gotcha: an absolute-path `Write` landed the file in the MAIN repo, not the
+  worktree — copied into the worktree and removed the stray.
+- `node_modules` absent in the worktree; ran `scripts/annotations/build.ts` with the MAIN
+  repo's `tsx` binary to validate the entry generates.
+
+### Files
+- `proofs/Proofs/ShannonChannelCodingBECOQ02.lean`
+- `src/data/proofs/shannon-channel-coding-bec-oq-02/{meta.json,annotations.json}`
+
+### Next steps
+- Discharge `channel_coding_achievability` / `channel_coding_converse` themselves (random
+  coding + Fano) to upgrade this and the sibling BSC/AWGN operational statements to verified.
+- A BEC-specific constructive achievability (random linear codes + peeling decoder, threshold
+  `1-p`) would replace the abstract achievability axiom with an explicit code family.
+- Strong converse (error → 1 above capacity) and finite-blocklength dispersion for the BEC.

--- a/src/data/proofs/shannon-channel-coding-bec-oq-02/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-02/annotations.json
@@ -1,0 +1,95 @@
+[
+    {
+        "id": "ann-bec-achievability",
+        "proofId": "shannon-channel-coding-bec-oq-02",
+        "range": {
+            "startLine": 61,
+            "endLine": 79
+        },
+        "type": "theorem",
+        "title": "Operational Achievability for the BEC",
+        "content": "States and proves that every nat-rate 0 < R < (1 - p) · log 2 is achievable on the binary erasure channel: for each target error ε > 0, all sufficiently long block lengths n admit a block code of rate ≥ R together with a decoder whose average error probability is below ε. The proof is a one-step specialisation of the framework's abstract channel_coding_achievability to ch := bec p; its capacity hypothesis R < channelCapacity (bec p) is rewritten by bec_capacity to the explicit threshold R < (1 - p) · log 2, which is exactly the stated hypothesis. The 'for all sufficiently long n' is the Filter.atTop eventually-quantifier inherited verbatim from the abstract theorem.",
+        "mathContext": "$0 < R < (1-p)\\log 2 \\ \\Rightarrow\\ \\forall \\varepsilon>0,\\ \\exists\\text{ codes of rate} \\ge R \\text{ with } P_e < \\varepsilon \\text{ for all large } n$",
+        "significance": "core",
+        "relatedConcepts": [
+            "channel coding theorem",
+            "achievability",
+            "block code",
+            "code rate",
+            "random coding"
+        ],
+        "prerequisites": [
+            "channel_coding_achievability",
+            "bec_capacity"
+        ]
+    },
+    {
+        "id": "ann-bec-converse",
+        "proofId": "shannon-channel-coding-bec-oq-02",
+        "range": {
+            "startLine": 81,
+            "endLine": 97
+        },
+        "type": "theorem",
+        "title": "Operational Converse for the BEC",
+        "content": "States and proves that every nat-rate R > (1 - p) · log 2 is unachievable: there is a fixed δ > 0 such that every block code of rate ≥ R, at every length, has average error probability at least δ. The proof specialises the framework's abstract channel_coding_converse to bec p and discharges its capacity hypothesis channelCapacity (bec p) < R with bec_capacity. Together with the achievability theorem this pins the BEC's operational capacity to exactly its information-theoretic capacity (1 - p) log 2.",
+        "mathContext": "$R > (1-p)\\log 2 \\ \\Rightarrow\\ \\exists\\,\\delta>0,\\ \\forall\\text{ codes of rate}\\ge R,\\ P_e \\ge \\delta$",
+        "significance": "core",
+        "relatedConcepts": [
+            "channel coding theorem",
+            "converse",
+            "Fano inequality",
+            "capacity threshold"
+        ],
+        "prerequisites": [
+            "channel_coding_converse",
+            "bec_capacity"
+        ]
+    },
+    {
+        "id": "ann-bec-achievability-bits",
+        "proofId": "shannon-channel-coding-bec-oq-02",
+        "range": {
+            "startLine": 99,
+            "endLine": 115
+        },
+        "type": "theorem",
+        "title": "Achievability in Bits — the Textbook Headline",
+        "content": "The headline form 'the BEC achieves rate 1 - p bits': every bit-rate 0 < R₂ < 1 - p is achievable. Derived from the nat-rate achievability theorem by the log-2 change of units — from R₂ < 1 - p and log 2 > 0, mul_lt_mul_of_pos_right gives the nat-rate hypothesis R₂ · log 2 < (1 - p) · log 2. The conclusion's rate guarantee R₂ · log 2 ≤ rate_of_code means the code's bit-rate rate_of_code / log 2 is at least R₂.",
+        "mathContext": "$0 < R_2 < 1-p \\ \\Rightarrow\\ R_2 \\text{ bits/use achievable on } \\mathrm{BEC}(p)$",
+        "significance": "supporting",
+        "relatedConcepts": [
+            "capacity in bits",
+            "nat-to-bit conversion",
+            "code rate"
+        ],
+        "prerequisites": [
+            "bec_coding_achievability",
+            "Real.log_pos",
+            "mul_lt_mul_of_pos_right"
+        ]
+    },
+    {
+        "id": "ann-bec-converse-bits",
+        "proofId": "shannon-channel-coding-bec-oq-02",
+        "range": {
+            "startLine": 117,
+            "endLine": 132
+        },
+        "type": "theorem",
+        "title": "Converse in Bits",
+        "content": "The bit-rate form of the converse: no bit-rate R₂ > 1 - p is achievable on the BEC. From 1 - p < R₂ and log 2 > 0, mul_lt_mul_of_pos_right gives (1 - p) · log 2 < R₂ · log 2, and the nat-rate converse applies. With the bit achievability theorem this establishes 1 - p bits as the exact operational bit-capacity of the BEC.",
+        "mathContext": "$R_2 > 1-p \\ \\Rightarrow\\ R_2 \\text{ bits/use unachievable on } \\mathrm{BEC}(p)$",
+        "significance": "supporting",
+        "relatedConcepts": [
+            "capacity in bits",
+            "converse",
+            "operational capacity"
+        ],
+        "prerequisites": [
+            "bec_coding_converse",
+            "Real.log_pos",
+            "mul_lt_mul_of_pos_right"
+        ]
+    }
+]

--- a/src/data/proofs/shannon-channel-coding-bec-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-02/meta.json
@@ -1,0 +1,139 @@
+{
+    "id": "shannon-channel-coding-bec-oq-02",
+    "title": "Operational Coding Theorem for the Binary Erasure Channel",
+    "slug": "shannon-channel-coding-bec-oq-02",
+    "description": "Bridges the binary erasure channel's information-theoretic capacity C(BEC(p)) = (1 - p) · log 2 (proved axiom-free in the parent entry) to the operational coding layer. Specialising the gallery's abstract channel-coding theorems channel_coding_achievability and channel_coding_converse to the concrete bec : DMChannel Bool (Option Bool), and discharging the capacity hypothesis with the proved value via bec_capacity, yields the BEC operational coding theorem with an explicit numerical threshold: every rate 0 < R < (1 - p) log 2 nats (equivalently every bit-rate 0 < R₂ < 1 - p) is achievable by block codes whose average error vanishes, while every rate above the threshold is bounded away from zero error. The two abstract operational theorems are axioms of the channel-coding framework, so the BEC operational theorem is honestly axiomatized (2 inherited axioms); no new axioms or sorries are introduced.",
+    "leanFile": {
+        "axiomCount": 0,
+        "lineCount": 134,
+        "path": "Proofs/ShannonChannelCodingBECOQ02.lean",
+        "sorries": 0,
+        "definitionCount": 0,
+        "theoremCount": 4
+    },
+    "sorries": 0,
+    "meta": {
+        "author": "Claude Shannon (1948), formalized in Lean 4",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Binary_erasure_channel",
+        "date": "1948",
+        "status": "axiomatized",
+        "proofRepoPath": "Proofs/ShannonChannelCodingBECOQ02.lean",
+        "tags": [
+            "information-theory",
+            "probability",
+            "coding-theory",
+            "channel-capacity",
+            "erasure-channel",
+            "channel-coding-theorem",
+            "advanced"
+        ],
+        "badge": "axiom",
+        "sorries": 0,
+        "mathlibDependencies": [
+            {
+                "theorem": "Real.log_pos",
+                "description": "log 2 > 0, used to transport the rate threshold between nats and bits (R₂ < 1 - p ⟺ R₂ · log 2 < (1 - p) · log 2)",
+                "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+            },
+            {
+                "theorem": "mul_lt_mul_of_pos_right",
+                "description": "Monotonicity of multiplication by the positive constant log 2, the single algebraic step in the bit-rate forms",
+                "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+            },
+            {
+                "theorem": "Filter.Eventually / Filter.atTop",
+                "description": "The 'for all sufficiently long block lengths' quantifier in the achievability statement, inherited verbatim from the abstract channel_coding_achievability",
+                "module": "Mathlib.Order.Filter.AtTopBot"
+            }
+        ],
+        "originalContributions": [
+            "bec_coding_achievability: every nat-rate 0 < R < (1 - p) · log 2 is achievable on the BEC — for each ε > 0, all sufficiently long block lengths admit a code of rate ≥ R with average error < ε. The abstract channel_coding_achievability applied to bec, with the capacity hypothesis discharged by the proved value bec_capacity.",
+            "bec_coding_converse: every nat-rate R > (1 - p) · log 2 is unachievable — a fixed δ > 0 lower-bounds the average error of every code of rate ≥ R, at every length. The abstract channel_coding_converse specialised to bec.",
+            "bec_coding_achievability_bits: the textbook headline 'the BEC achieves rate 1 - p bits' — every bit-rate 0 < R₂ < 1 - p is achievable, obtained from the nat-rate form by the log-2 change of units.",
+            "bec_coding_converse_bits: the bit-rate converse — no bit-rate R₂ > 1 - p is achievable.",
+            "Together these pin the BEC's operational capacity to exactly its information-theoretic capacity (1 - p) log 2, answering the open question raised by the sibling entry shannon-channel-coding-bec-oq-01 ('connecting the information capacity proved here to achievable communication rates')."
+        ],
+        "assumptions": "2 axioms, on the critical path: channel_coding_achievability and channel_coding_converse, the gallery's abstract statements of Shannon's two operational coding theorems for an arbitrary DMChannel (the deep random-coding and Fano arguments are taken as given at the abstract level in ShannonChannelCoding.lean). #print axioms confirms the achievability results depend on channel_coding_achievability and the converse results on channel_coding_converse, in each case plus only the ordinary propext / Classical.choice / Quot.sound. The BEC capacity value itself, bec_capacity : channelCapacity (bec p) = (1 - p) · log 2, is proved axiom-free in the parent and supplies the explicit numerical threshold. 0 sorries, no native_decide. leanFile.axiomCount is 0 because the file declares no literal 'axiom'; the assumptions are the two inherited framework axioms, hence meta axiomCount = 2 and status = axiomatized. SCOPE: this entry takes the abstract operational theorems as black boxes and specialises them to the concrete BEC; it does not reprove Shannon's random-coding achievability or Fano converse from scratch (those remain the framework's axioms).",
+        "dateAdded": "2026-06-27",
+        "axiomCount": 2,
+        "lineCount": 134,
+        "prerequisites": [
+            "The binary erasure channel capacity C(BEC(p)) = (1 - p) log 2 (ShannonChannelCodingBEC.lean), supplying the threshold via bec_capacity",
+            "Discrete memoryless channels, block codes, code rate, and channel capacity (ShannonChannelCoding.lean)",
+            "The abstract operational coding theorems channel_coding_achievability / channel_coding_converse (ShannonChannelCoding.lean)"
+        ],
+        "mathlib_version": "4.26.0",
+        "theoremCount": 4,
+        "definitionCount": 0
+    },
+    "overview": {
+        "historicalContext": "Shannon's 1948 channel coding theorem is the foundational result of information theory: it identifies the channel capacity C — an information-theoretic quantity defined as a supremum of mutual informations — with the operational threshold separating achievable from unachievable communication rates. Achievability (rates below C admit codes with vanishing error) is proved by the random-coding method; the converse (rates above C cannot be reliable) is proved via Fano's inequality. For the binary erasure channel, where each transmitted bit is either received correctly or replaced by a known erasure, the capacity is the especially transparent C = 1 - p bits: the surviving fraction of transmissions, each carrying one bit.\n\nThe parent gallery entry proves the BEC's *information* capacity (1 - p) log 2 from first principles. This entry closes the loop to the *operational* meaning by feeding that capacity value through the framework's abstract achievability and converse theorems, producing the BEC operational coding theorem with an explicit numerical threshold.",
+        "problemStatement": "**BEC Operational Coding Theorem**: For a binary erasure channel with erasure probability $0 < p < 1$, the operational capacity equals the information capacity $(1-p)\\log 2$ nats $= 1 - p$ bits. Concretely:\n- **Achievability**: for every rate $0 < R < (1-p)\\log 2$ and every $\\varepsilon > 0$, all sufficiently long block lengths $n$ admit a code of rate $\\ge R$ with average error probability $< \\varepsilon$.\n- **Converse**: for every rate $R > (1-p)\\log 2$ there is a fixed $\\delta > 0$ lower-bounding the average error of every code of rate $\\ge R$.",
+        "text": "Specialises the abstract channel-coding theorems to the BEC, pinning its operational capacity to the proved value (1 - p) log 2.",
+        "proofStrategy": "Each result is a one-step specialisation:\n\n1. **Achievability** (`bec_coding_achievability`): apply `channel_coding_achievability` to `ch := bec p`. Its capacity hypothesis `R < channelCapacity (bec p)` is rewritten by `bec_capacity hp0 hp1` to the explicit `R < (1 - p) · log 2`, which is the stated hypothesis.\n\n2. **Converse** (`bec_coding_converse`): identically, apply `channel_coding_converse` to `bec p` and rewrite the capacity hypothesis with `bec_capacity`.\n\n3. **Bit-rate forms** (`*_bits`): from a bit-rate hypothesis `R₂ < 1 - p` (resp. `1 - p < R₂`) and `log 2 > 0`, `mul_lt_mul_of_pos_right` gives the nat-rate hypothesis `R₂ · log 2 < (1 - p) · log 2`, and the nat-rate theorem applies. The conclusion's rate guarantee `R₂ · log 2 ≤ rate_of_code` says the code's bit-rate `rate_of_code / log 2` is at least `R₂`.",
+        "keyInsights": [
+            "The capacity proved by the parent is an information-theoretic supremum; on its own it says nothing about codes. The operational theorem is what turns it into a statement about achievable communication, and that is precisely Shannon's channel coding theorem.",
+            "The gallery already states the abstract operational theorems (for any DMChannel, in terms of channelCapacity); the only channel-specific input needed to instantiate them for the BEC is the numerical capacity value (1 - p) log 2 — supplied axiom-free by bec_capacity.",
+            "Honesty: because the abstract operational theorems are axioms here, the BEC operational theorem is axiomatized, not verified. #print axioms confirms exactly the two intended axioms are on the critical path (achievability ← channel_coding_achievability, converse ← channel_coding_converse).",
+            "The bit-rate forms are the textbook headline 'the BEC achieves rate 1 - p': the nat/bit conversion is a single multiplication by the positive constant log 2.",
+            "This directly answers an open question logged by the sibling entry bec-oq-01, which asked to connect the proved information capacity to achievable communication rates via the operational coding theorem."
+        ]
+    },
+    "conclusion": {
+        "summary": "Specialises the gallery's abstract channel-coding theorems to the binary erasure channel, establishing the BEC operational coding theorem: every rate below the capacity (1 - p) log 2 nats (every bit-rate below 1 - p) is achievable by block codes with vanishing average error, and every rate above is bounded away from zero error. The capacity value is supplied by the parent's axiom-free bec_capacity, so the threshold is explicit and numerical; the achievability and converse content are inherited from the framework's abstract operational theorems, which are axioms, making this entry honestly axiomatized (2 axioms, 0 sorries).",
+        "implications": "Completes the BEC strand of the Shannon channel-coding development from information capacity to operational capacity, the form in which capacity is actually used in coding theory. The specialisation pattern is reusable: any concrete DMChannel with a proved channelCapacity value (the BSC and AWGN entries also have one) can be turned into an operational coding theorem with an explicit threshold by the same two-line instantiation, so this entry doubles as a template for the sibling channels.",
+        "openQuestions": [
+            "Discharge the framework axioms channel_coding_achievability and channel_coding_converse themselves — formalize Shannon's random-coding achievability and the Fano-inequality converse for general discrete memoryless channels — which would upgrade this entry (and the BSC/AWGN operational statements) from axiomatized to verified.",
+            "Give a BEC-specific constructive achievability via random linear codes and the peeling (belief-propagation) decoder, whose erasure-correction threshold matches 1 - p, replacing the abstract random-coding axiom with an explicit code family for this channel.",
+            "Strengthen the converse to the strong converse (error → 1, not merely bounded below, above capacity) and quantify the finite-blocklength rate penalty (dispersion) for the BEC."
+        ]
+    },
+    "crossReferences": [
+        {
+            "targetId": "shannon-channel-coding-bec",
+            "relationship": "extends",
+            "description": "The parent: the binary erasure channel information capacity C(BEC(p)) = (1 - p) log 2, proved axiom-free. This entry feeds that value through the abstract operational theorems to obtain the BEC operational coding theorem."
+        },
+        {
+            "targetId": "shannon-channel-coding-bec-oq-01",
+            "relationship": "sibling",
+            "description": "The q-ary erasure channel capacity generalization, whose logged open question — 'connecting the information capacity proved here to achievable communication rates' via the operational coding theorem — this entry answers for the binary case."
+        },
+        {
+            "targetId": "shannon-channel-coding",
+            "relationship": "uses",
+            "description": "Supplies the abstract operational coding theorems channel_coding_achievability and channel_coding_converse (specialised here to the BEC) together with the BlockCode / rate_of_code / channelCapacity scaffold."
+        },
+        {
+            "targetId": "shannon-channel-coding-awgn",
+            "relationship": "sibling",
+            "description": "Companion concrete-capacity channel C = ½ log(1 + P/N); the same instantiation pattern would yield its operational coding theorem from its proved capacity value."
+        }
+    ],
+    "mainTheorems": [
+        {
+            "name": "bec_coding_achievability",
+            "type": "core",
+            "description": "Every nat-rate 0 < R < (1 - p) · log 2 is achievable on the BEC: for each ε > 0, all sufficiently long block lengths admit a code of rate ≥ R with average error < ε. The abstract achievability theorem specialised to bec, with the capacity hypothesis discharged by bec_capacity.",
+            "leanType": "R < (1 - p) * Real.log 2 → ∀ ε, 0 < ε → ∀ᶠ n in Filter.atTop, ∀ (hn : 0 < n), ∃ code decoder, R ≤ rate_of_code hn code ∧ (avg error) < ε"
+        },
+        {
+            "name": "bec_coding_converse",
+            "type": "core",
+            "description": "Every nat-rate R > (1 - p) · log 2 is unachievable: a fixed δ > 0 lower-bounds the average error of every code of rate ≥ R. The abstract converse specialised to bec.",
+            "leanType": "(1 - p) * Real.log 2 < R → ∃ δ, 0 < δ ∧ ∀ n hn code decoder, R ≤ rate_of_code hn code → δ ≤ (avg error)"
+        },
+        {
+            "name": "bec_coding_achievability_bits",
+            "type": "corollary",
+            "description": "Bit-rate headline form: every bit-rate 0 < R₂ < 1 - p is achievable on the BEC, via the log-2 change of units from the nat-rate achievability theorem.",
+            "leanType": "R₂ < 1 - p → ∀ ε, 0 < ε → ∀ᶠ n in Filter.atTop, ∀ (hn : 0 < n), ∃ code decoder, R₂ * Real.log 2 ≤ rate_of_code hn code ∧ (avg error) < ε"
+        },
+        {
+            "name": "bec_coding_converse_bits",
+            "type": "corollary",
+            "description": "Bit-rate converse: no bit-rate R₂ > 1 - p is achievable on the BEC.",
+            "leanType": "1 - p < R₂ → ∃ δ, 0 < δ ∧ ∀ n hn code decoder, R₂ * Real.log 2 ≤ rate_of_code hn code → δ ≤ (avg error)"
+        }
+    ]
+}


### PR DESCRIPTION
## Open question

`shannon-channel-coding-bec-oq-02` — *Establish an operational coding theorem for the BEC, connecting the information-theoretic supremum proved in the parent to achievable communication rates through the parent's `channel_coding_achievability`.*

## What this does

The parent `shannon-channel-coding-bec` proves the BEC's **information** capacity `C(BEC(p)) = (1-p)·log 2` axiom-free. That is a supremum of mutual informations — it says nothing about codes. This entry bridges it to the **operational** layer.

The gallery's channel framework already states Shannon's two operational theorems for an arbitrary `DMChannel` in terms of its `channelCapacity` (`channel_coding_achievability`, `channel_coding_converse` — both **axioms** of the framework). Specialising them to the concrete `bec : DMChannel Bool (Option Bool)` and discharging the capacity hypothesis with `bec_capacity` yields the BEC operational coding theorem with an explicit numerical threshold.

### New (`proofs/Proofs/ShannonChannelCodingBECOQ02.lean`, 4 theorems, 0 sorries)

| Theorem | Statement |
|---|---|
| `bec_coding_achievability` | every nat-rate `0 < R < (1-p)·log 2` is achievable (codes with vanishing avg error) |
| `bec_coding_converse` | every nat-rate `R > (1-p)·log 2` is unachievable (avg error `≥ δ > 0`) |
| `bec_coding_achievability_bits` | textbook form: every bit-rate `0 < R₂ < 1-p` achievable |
| `bec_coding_converse_bits` | bit-rate converse |

Together these pin the BEC's **operational** capacity to exactly `(1-p)·log 2`, answering the open question logged by the sibling entry `shannon-channel-coding-bec-oq-01`.

## Honesty / axiom status

**Status: `axiomatized` (badge `axiom`), 0 sorries, no `native_decide`.** `#print axioms` confirms the achievability results depend on `channel_coding_achievability` and the converse results on `channel_coding_converse`, in each case plus only `propext / Classical.choice / Quot.sound`. No new axioms are introduced; the BEC capacity value itself is proved axiom-free in the parent.

- `leanFile.axiomCount = 0` (no literal `axiom` declaration in the file)
- `meta.axiomCount = 2` (the two inherited framework axioms, which are on the critical path)

This is an *instantiation* of the abstract operational theorems, not a from-scratch random-coding/Fano proof (those remain the framework's axioms) — the route the open question itself suggests.

## Verification

Built via the `lake env lean` fallback (docker wrapper down — host disk pressure) against the cached Mathlib + Shannon dependency chain; compiles with 0 errors / 0 sorries. Gallery data validated through `scripts/annotations/build.ts` (entry generates into `listings.json` as `axiomatized`/`axiom`, 4 annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)