### PR TITLE
research(van-der-waerden-first-moment-oq-01): exact AP count + factor-2 sharpening [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/VanDerWaerdenFirstMomentOQ01.lean
+++ b/proofs/Proofs/VanDerWaerdenFirstMomentOQ01.lean
@@ -1,0 +1,152 @@
+/-
+  Exact count of fitting APs and a factor-2 sharpening of the van der Waerden
+  first-moment lower bound (open question van-der-waerden-first-moment-oq-01)
+
+  The base entry `Proofs.VanDerWaerdenFirstMoment` bounds the number of length-`k`
+  arithmetic progressions that fit in `[n]` by the deliberately loose count `n²`
+  (`card_vdwFamily_le`): it allows every pair `(a, d)` of first term and step.
+  That gives the union-bound threshold `n² < 2^(k-1)`, i.e. `W(k) ≳ 2^((k-1)/2)`.
+
+  The open question asks to sharpen this to `~ n²/(k-1)` by bounding the AP step.
+  We go further and compute the family's parameter count *exactly*, then extract a
+  bound that beats the requested `n²/(k-1)` by a further factor of `2`.
+
+  For a length-`k` AP with step `d` to fit we need `a + (k-1)d < n` with `a ≥ 0`,
+  so for each `d` exactly `n - (k-1)d` first terms `a` are admissible (and `0`
+  once `(k-1)d ≥ n` — handled automatically by truncated ℕ-subtraction).  Summing
+  over `d` gives the exact parameter count
+
+        |{(a,d) fitting}|  =  ∑_{d=1}^{n} (n - (k-1)·d)        (vdwFilter_card_eq_sum)
+
+  a triangular sum.  A telescoping-of-squares argument
+  (`2(k-1)(n - (k-1)d) ≤ (n-(k-1)(d-1))² - (n-(k-1)d)²`) collapses it to
+
+        2·(k-1)·|family|  ≤  n²                               (card_vdwFamily_two_mul_le)
+
+  i.e. at most `n²/(2(k-1))` length-`k` APs fit in `[n]` — twice as sharp as the
+  `n²/(k-1)` the question asked for, and a factor `(2(k-1))` improvement on the
+  base `n²` count.  Feeding this back through the verified Property-B engine widens
+  the admissible range of `n` from `n² < 2^(k-1)` to
+
+        n² < 2·(k-1)·2^(k-1)                                  (vdw_lower_bound_sharp)
+
+  a factor-`√(2(k-1))` improvement, giving `W(k) ≳ √(2(k-1))·2^((k-1)/2)`.
+
+  Everything here is elementary counting layered on top of the base entry's
+  verified `vdwAP` / `vdwFamily` / `vdw_two_coloring_exists`; the probabilistic
+  core remains the gallery's Property-B engine consumed as a black box.
+
+  Status: 0 sorries, 0 axioms, no `native_decide`.  #print axioms reports only
+  `propext, Classical.choice, Quot.sound`.
+-/
+import Mathlib
+import Proofs.VanDerWaerdenFirstMoment
+
+namespace ProbMethod.VanDerWaerden
+
+open Finset
+open ProbMethod.PropertyB (Mono property_b_two_colorable)
+open scoped Fin.NatCast
+
+variable {n : ℕ} [NeZero n]
+
+/-- **Fiber count.** Of the `n` first terms `a ∈ {0,…,n-1}`, exactly `n - c` satisfy
+`a + c < n` (and none once `c ≥ n`, via truncated ℕ-subtraction). -/
+theorem card_filter_lt (N c : ℕ) :
+    ((Finset.range N).filter (fun a => a + c < N)).card = N - c := by
+  have : (Finset.range N).filter (fun a => a + c < N) = Finset.range (N - c) := by
+    ext a; simp only [Finset.mem_filter, Finset.mem_range]; omega
+  rw [this, Finset.card_range]
+
+/-- **Exact parameter count of the fitting `(a, d)` box.**
+Grouping the fitting pairs by their step `d` and counting admissible first terms
+`a` fiberwise (`card_filter_lt`) yields the triangular sum `∑_{d=1}^{n} (n-(k-1)d)`
+— the precise number of `(a, d)` parameters, sharpening the base entry's loose
+`n²` overcount. -/
+theorem vdwFilter_card_eq_sum (N k : ℕ) :
+    (((Finset.range N) ×ˢ (Finset.Icc 1 N)).filter
+        (fun p => p.1 + (k - 1) * p.2 < N)).card
+      = ∑ d ∈ Finset.Icc 1 N, (N - (k - 1) * d) := by
+  rw [Finset.card_filter, Finset.sum_product, Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro d _hd
+  rw [← Finset.card_filter]
+  exact card_filter_lt N ((k - 1) * d)
+
+/-- **Family bounded by the exact parameter sum.** The AP family is the image of
+the fitting `(a, d)` box, so its cardinality is at most the exact box count. -/
+theorem card_vdwFamily_le_sum (k : ℕ) :
+    (vdwFamily n k).card ≤ ∑ d ∈ Finset.Icc 1 n, (n - (k - 1) * d) := by
+  refine le_trans ?_ (le_of_eq (vdwFilter_card_eq_sum n k))
+  rw [vdwFamily]
+  exact Finset.card_image_le
+
+/-- **Telescoping-of-squares bound on the triangular sum.**
+For every cutoff `m` and step `c`,
+`2c·∑_{d=1}^{m}(N - c·d) + (N - c·m)² ≤ N²`.
+The square slack telescopes: `2c(N-cd) ≤ (N-c(d-1))² - (N-cd)²`, so the partial
+sums stay below `N²`.  Specialising `m = c = ` the relevant values gives the family
+bound. -/
+theorem two_mul_sum_sq_le (N c m : ℕ) :
+    2 * c * (∑ d ∈ Finset.Icc 1 m, (N - c * d)) + (N - c * m) ^ 2 ≤ N ^ 2 := by
+  induction m with
+  | zero => simp
+  | succ m ih =>
+    rw [Finset.sum_Icc_succ_top (by omega : 1 ≤ m + 1)]
+    -- Per-step square slack: `2c·(N - c(m+1)) + (N - c(m+1))² ≤ (N - c·m)²`.
+    have hcm : c * (m + 1) = c * m + c := by ring
+    have key : 2 * c * (N - c * (m + 1)) + (N - c * (m + 1)) ^ 2 ≤ (N - c * m) ^ 2 := by
+      rcases le_or_gt N (c * (m + 1)) with h | h
+      · have hz : N - c * (m + 1) = 0 := by omega
+        rw [hz]; simp
+      · have hw : N - c * m = (N - c * (m + 1)) + c := by omega
+        rw [hw]; nlinarith [sq_nonneg c]
+    have hexp : 2 * c * ((∑ d ∈ Finset.Icc 1 m, (N - c * d)) + (N - c * (m + 1)))
+              = 2 * c * (∑ d ∈ Finset.Icc 1 m, (N - c * d)) + 2 * c * (N - c * (m + 1)) := by
+      rw [Nat.mul_add]
+    rw [hexp]
+    linarith [ih, key]
+
+/-- **Factor-2 sharpened AP-family bound.** `2·(k-1)·|family| ≤ n²`, i.e. at most
+`n²/(2(k-1))` length-`k` APs fit in `[n]`.  This beats the open question's requested
+`n²/(k-1)` by a further factor of `2`, and improves the base entry's loose `n²`
+count by a factor `2(k-1)`.  (No hypothesis on `k` is needed: for `k ≤ 1` the
+factor `2(k-1)` is `0` and the bound is vacuous.) -/
+theorem card_vdwFamily_two_mul_le (k : ℕ) :
+    2 * (k - 1) * (vdwFamily n k).card ≤ n ^ 2 := by
+  calc 2 * (k - 1) * (vdwFamily n k).card
+      ≤ 2 * (k - 1) * (∑ d ∈ Finset.Icc 1 n, (n - (k - 1) * d)) := by
+        gcongr
+        exact card_vdwFamily_le_sum k
+    _ ≤ n ^ 2 := by
+        have h := two_mul_sum_sq_le n (k - 1) n
+        omega
+
+/-- **Sharpened first-moment van der Waerden lower bound.**
+If `n² < 2·(k-1)·2^(k-1)` then there is a 2-colouring of `[n]` under which every
+length-`k` arithmetic progression with positive step contains both colours.
+
+This widens the admissible range of `n` by a factor `√(2(k-1))` over the base
+`vdw_lower_bound` (which requires `n² < 2^(k-1)`): the factor-2 family count
+`2(k-1)·|family| ≤ n²` lets a single cancellation of `2(k-1)` turn the hypothesis
+into `|family| < 2^(k-1)`.  The resulting witness is `W(k) ≳ √(2(k-1))·2^((k-1)/2)`. -/
+theorem vdw_lower_bound_sharp {k : ℕ} (hk : 2 ≤ k)
+    (hnk : n ^ 2 < 2 * (k - 1) * 2 ^ (k - 1)) :
+    ∃ c : Fin n → Bool, ∀ a d : ℕ, 1 ≤ d → a + (k - 1) * d < n →
+      ¬ Mono (vdwAP n a d k) c := by
+  -- Cancel `2(k-1)` from `2(k-1)·|family| ≤ n² < 2(k-1)·2^(k-1)`.
+  have hcard : (vdwFamily n k).card < 2 ^ (k - 1) := by
+    have h2 : 2 * (k - 1) * (vdwFamily n k).card < 2 * (k - 1) * 2 ^ (k - 1) :=
+      lt_of_le_of_lt (card_vdwFamily_two_mul_le k) hnk
+    exact lt_of_mul_lt_mul_left h2 (Nat.zero_le _)
+  obtain ⟨c, hc⟩ := vdw_two_coloring_exists (by omega) hcard
+  refine ⟨c, fun a d hd hb => ?_⟩
+  apply hc
+  -- The AP `vdwAP n a d k` belongs to the family (same membership as the base).
+  rw [vdwFamily, Finset.mem_image]
+  refine ⟨(a, d), ?_, rfl⟩
+  rw [Finset.mem_filter, Finset.mem_product, Finset.mem_Icc, Finset.mem_range]
+  have hdn : d ≤ (k - 1) * d := Nat.le_mul_of_pos_left d (by omega)
+  exact ⟨⟨by omega, hd, by omega⟩, hb⟩
+
+end ProbMethod.VanDerWaerden

--- a/src/data/proofs/van-der-waerden-first-moment-oq-01/annotations.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "vdw-oq01-ann-header",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "context",
+    "title": "Goal: Sharpen the Loose n² AP Count",
+    "content": "The base entry van-der-waerden-first-moment bounds the number of fitting length-k APs by the loose total n² — it allows every (a, d) pair. Its open question oq-01 asks to sharpen this to ~n²/(k-1) using that a fitting AP has step d ≤ (n-1)/(k-1). This file answers oq-01 and goes a factor of 2 further by computing the parameter count EXACTLY as a triangular sum, then collapsing it to 2(k-1)·|family| ≤ n². The probabilistic core (Property B) is reused verbatim from the base entry as a black box.",
+    "mathContext": "Base bound: $|\\mathrm{family}| \\le n^2$. Open question target: $|\\mathrm{family}| \\lesssim n^2/(k-1)$. This entry: $2(k-1)\\,|\\mathrm{family}| \\le n^2$, i.e. $|\\mathrm{family}| \\le n^2/(2(k-1))$.",
+    "significance": "context",
+    "relatedConcepts": ["first-moment method", "union bound", "AP counting", "Property B"],
+    "prerequisites": ["the base entry van-der-waerden-first-moment", "Finset cardinality"]
+  },
+  {
+    "id": "vdw-oq01-ann-fiber",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 53, "endLine": 59 },
+    "type": "technique",
+    "title": "The Fiber Count: n − c Admissible First Terms",
+    "content": "card_filter_lt is the per-step building block. For a fixed step the admissible first terms are {a < n : a + c < n} where c = (k-1)d. The filter equals range (n - c) — the equivalence a + c < n ↔ a < n - c is pure ℕ-arithmetic discharged by omega — so its cardinality is exactly n - c. Crucially, ℕ-subtraction truncates: when c ≥ n there are zero admissible terms and n - c = 0, so the same formula covers the degenerate steps with no case split.",
+    "mathContext": "$|\\{\\, a \\in \\{0,\\dots,n-1\\} : a + c < n \\,\\}| = n - c$ (truncated subtraction: $= 0$ when $c \\ge n$).",
+    "significance": "key",
+    "relatedConcepts": ["Finset.filter", "Finset.range", "truncated ℕ-subtraction", "fiber counting"],
+    "prerequisites": ["Finset.card_range", "omega"]
+  },
+  {
+    "id": "vdw-oq01-ann-exactsum",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 61, "endLine": 74 },
+    "type": "technique",
+    "title": "Exact Triangular Count by Summing Fibers",
+    "content": "vdwFilter_card_eq_sum computes the fitting (a,d) box exactly. Finset.card_filter rewrites the cardinality as a double sum of indicators; Finset.sum_product splits it over the (a,d) product; Finset.sum_comm swaps the order so the outer sum is over the step d. The inner sum over a is then exactly the fiber count n - (k-1)d (via card_filter_lt). The result is the exact triangular sum ∑_{d=1}^{n}(n - (k-1)d), replacing the base entry's loose n² overcount with an equality.",
+    "mathContext": "$\\bigl|\\{(a,d) : a < n,\\ 1 \\le d \\le n,\\ a + (k-1)d < n\\}\\bigr| = \\sum_{d=1}^{n} (n - (k-1)d)$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_product", "Finset.sum_comm", "fiberwise counting", "triangular number"],
+    "prerequisites": ["big operators over Finsets", "swapping summation order"]
+  },
+  {
+    "id": "vdw-oq01-ann-familyle",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 76, "endLine": 82 },
+    "type": "context",
+    "title": "Family ≤ Exact Box Count",
+    "content": "card_vdwFamily_le_sum transfers the exact box count to the AP family. The family vdwFamily n k is the image of the fitting (a,d) box under (a,d) ↦ vdwAP n a d k, and Finset.card_image_le gives that an image is no larger than its domain. So the family is bounded by the exact triangular sum just computed.",
+    "mathContext": "$|\\mathrm{vdwFamily}(n,k)| \\le \\sum_{d=1}^{n}(n - (k-1)d)$ because the family is an image of the parameter box.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.card_image_le", "image of a parameter set"],
+    "prerequisites": ["images of Finsets"]
+  },
+  {
+    "id": "vdw-oq01-ann-telescope",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 84, "endLine": 108 },
+    "type": "technique",
+    "title": "Telescoping-of-Squares Collapses the Triangular Sum",
+    "content": "two_mul_sum_sq_le is the elementary heart of the sharpening. Rather than a Gauss formula (which would entangle the floor (n-1)/(k-1)), it proves the strengthened invariant 2c·∑_{d=1}^{m}(N-c·d) + (N-c·m)² ≤ N² by induction on m. The induction step rests on a per-step square completion: 2c·(N-c(m+1)) + (N-c(m+1))² ≤ (N-c·m)², proved by cases on whether (m+1)c exceeds N (when it does, the new term is 0; otherwise it is a clean (w-c)(w+c) = w² - c² ≤ w² inequality, nlinarith with sq_nonneg c). The running square slack (N-c·m)² absorbs each new term, keeping the partial sum below N² for every cutoff m.",
+    "mathContext": "Per-step: with $w = N - cm$, $u = N - c(m+1)$, one has $2cu + u^2 \\le w^2$ since $w = u + c$ gives $w^2 - (2cu + u^2) = c^2 \\ge 0$. Summed: $2c\\sum_{d=1}^{m}(N - cd) + (N-cm)^2 \\le N^2$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping sum", "completing the square", "induction", "Finset.sum_Icc_succ_top", "nlinarith"],
+    "prerequisites": ["induction on ℕ", "nlinarith", "ℕ-subtraction case analysis"]
+  },
+  {
+    "id": "vdw-oq01-ann-factor2",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 110, "endLine": 123 },
+    "type": "technique",
+    "title": "The Factor-2 Family Bound 2(k−1)|family| ≤ n²",
+    "content": "card_vdwFamily_two_mul_le specialises the telescoping bound (N = n, c = k-1, m = n) and drops the nonnegative remainder (n-(k-1)n)² ≥ 0 (omega closes it over ℕ). The result, 2(k-1)·|family| ≤ n², means at most n²/(2(k-1)) length-k APs fit in [n] — twice as sharp as the open question's requested n²/(k-1), and a factor 2(k-1) improvement on the base entry's loose n². Notably it needs NO hypothesis on k: for k ≤ 1 the factor 2(k-1) is 0 and the bound is vacuously true, so one statement covers all k.",
+    "mathContext": "$2(k-1)\\,|\\mathrm{vdwFamily}(n,k)| \\le n^2$, hence $|\\mathrm{family}| \\le \\dfrac{n^2}{2(k-1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["AP family bound", "factor-2 improvement", "gcongr", "no hypothesis on k"],
+    "prerequisites": ["monotonicity of multiplication", "omega over ℕ"]
+  },
+  {
+    "id": "vdw-oq01-ann-lowerbound",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 125, "endLine": 152 },
+    "type": "technique",
+    "title": "The Sharpened van der Waerden Lower Bound",
+    "content": "vdw_lower_bound_sharp re-derives the lower bound with the wider admissible range. From the hypothesis n² < 2(k-1)·2^(k-1) and the factor-2 family bound, 2(k-1)·|family| ≤ n² < 2(k-1)·2^(k-1); cancelling the common factor 2(k-1) (lt_of_mul_lt_mul_left) yields |family| < 2^(k-1) — exactly the smallness the base entry's Property B engine vdw_two_coloring_exists consumes. The resulting 2-colouring leaves no member of the family monochromatic; a membership check (each fitting positive-step AP lies in the family) completes the AP-form statement. The admissible n now satisfies n² < 2(k-1)·2^(k-1), a factor √(2(k-1)) wider than the base bound n² < 2^(k-1), so W(k) ≳ √(2(k-1))·2^((k-1)/2).",
+    "mathContext": "If $n^2 < 2(k-1)\\,2^{k-1}$ then some 2-colouring of $[n]$ has no monochromatic length-$k$ positive-step AP, so $W(k) > n$; optimising $n$ gives $W(k) \\gtrsim \\sqrt{2(k-1)}\\,2^{(k-1)/2}$.",
+    "significance": "key",
+    "relatedConcepts": ["Property B", "union bound threshold", "van der Waerden number lower bound", "lt_of_mul_lt_mul_left"],
+    "prerequisites": ["the base entry's vdw_two_coloring_exists", "cancelling a common factor in an inequality"]
+  }
+]

--- a/src/data/proofs/van-der-waerden-first-moment-oq-01/meta.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-01/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "van-der-waerden-first-moment-oq-01",
+  "title": "Exact AP Count and a Factor-2 Sharpening of the van der Waerden First-Moment Bound",
+  "slug": "van-der-waerden-first-moment-oq-01",
+  "description": "The gallery's first-moment lower bound for van der Waerden numbers (van-der-waerden-first-moment) counts the length-k arithmetic progressions fitting in [n] by the deliberately loose total n² — it allows every pair (a, d) of first term and step. Its open question oq-01 asks to sharpen this to ~n²/(k-1) by exploiting that a fitting AP must have step d ≤ (n-1)/(k-1). This entry answers oq-01 and goes a factor of 2 further by computing the family's parameter count EXACTLY. For each step d, a fitting AP needs a + (k-1)d < n with a ≥ 0, so exactly n - (k-1)d first terms a are admissible (and 0 once (k-1)d ≥ n — handled automatically by truncated ℕ-subtraction). Summing over d gives the exact triangular count |{(a,d) fitting}| = ∑_{d=1}^{n} (n - (k-1)d) (vdwFilter_card_eq_sum), proved by a fiberwise count (group the product filter by d, count admissible a fiberwise via card_filter_lt). A telescoping-of-squares argument — 2(k-1)(n-(k-1)d) ≤ (n-(k-1)(d-1))² - (n-(k-1)d)², so the partial sums stay below n² — collapses the triangular sum to 2·(k-1)·|family| ≤ n² (card_vdwFamily_two_mul_le), needing NO hypothesis on k. This is at most n²/(2(k-1)) fitting APs: twice as sharp as the n²/(k-1) the open question requested, and a factor 2(k-1) improvement on the base entry's loose n² count. Feeding it back through the same verified Property-B engine (vdw_two_coloring_exists, consumed as a black box) widens the admissible range from n² < 2^(k-1) to n² < 2·(k-1)·2^(k-1) (vdw_lower_bound_sharp), a factor √(2(k-1)) improvement giving W(k) ≳ √(2(k-1))·2^((k-1)/2). HONESTY: this is elementary lattice-point counting on top of the base entry's verified AP combinatorics and probabilistic core; the improvement is to the constant/threshold, not to the union-bound method itself (the Lovász Local Lemma form W(k) ≳ 2^k/(ek) remains out of reach here). #print axioms reports only propext, Classical.choice, Quot.sound for all theorems; 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Lean Genius researcher-5",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VanDerWaerdenFirstMomentOQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 152,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The hypotheses (k ≥ 2 in the final lower bound, and the smallness bound n² < 2(k-1)·2^(k-1)) are inputs to the statements, not standing assumptions; the core sharpened count card_vdwFamily_two_mul_le needs no hypothesis on k at all. #print axioms reports only propext, Classical.choice, Quot.sound for vdw_lower_bound_sharp, card_vdwFamily_two_mul_le, and vdwFilter_card_eq_sum. The probabilistic core is the gallery's verified entry property-b-first-moment (via vdw_two_coloring_exists from the base van-der-waerden-first-moment entry), consumed as a black box; this entry contributes the exact triangular parameter count and the telescoping-of-squares bound on top of it. Badged 'original' because the exact-count and factor-2 sharpening are new content layered on a verified base entry, not a Mathlib headline theorem.",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "first-moment-method",
+      "van-der-waerden",
+      "arithmetic-progressions",
+      "lattice-point-counting",
+      "open-question"
+    ],
+    "dateAdded": "2026-06-27",
+    "originalContributions": [
+      "vdwFilter_card_eq_sum: the EXACT parameter count of fitting length-k APs equals the triangular sum ∑_{d=1}^{n} (n - (k-1)d) — fiberwise counting of admissible first terms a for each step d, with truncated ℕ-subtraction handling the d > (n-1)/(k-1) tail automatically; replaces the base entry's loose n² overcount with an equality",
+      "card_vdwFamily_two_mul_le: 2·(k-1)·|family| ≤ n² with NO hypothesis on k — at most n²/(2(k-1)) length-k APs fit in [n], twice as sharp as the open question's requested n²/(k-1) and a factor 2(k-1) improvement on the base n² bound",
+      "two_mul_sum_sq_le: the telescoping-of-squares engine 2c·∑_{d=1}^{m}(N - c·d) + (N - c·m)² ≤ N², the per-step bound 2c(N-cd) ≤ (N-c(d-1))² - (N-cd)² summed by induction — the elementary heart of the sharpening",
+      "vdw_lower_bound_sharp: if n² < 2·(k-1)·2^(k-1) then there is a 2-colouring of [n] with no monochromatic length-k positive-step AP — a factor √(2(k-1)) widening of the admissible n over the base bound n² < 2^(k-1), giving W(k) ≳ √(2(k-1))·2^((k-1)/2)",
+      "card_filter_lt: of the n first terms a ∈ {0,…,n-1}, exactly n - c satisfy a + c < n (the fiber count underlying the exact triangular sum), a clean ℕ-subtraction cardinality identity"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_filter / Finset.sum_product / Finset.sum_comm",
+        "description": "rewrite the product-filter cardinality as a double sum and swap the order of summation, so the fitting (a,d) box is counted fiberwise by step d.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_Icc_succ_top",
+        "description": "peels the top term off ∑_{d ∈ Icc 1 (m+1)}, driving the induction in the telescoping-of-squares bound.",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.card_image_le",
+        "description": "the AP family is the image of the fitting (a,d) box, so its cardinality is at most the exact box count.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "lt_of_mul_lt_mul_left",
+        "description": "cancels the common factor 2(k-1) from 2(k-1)·|family| < 2(k-1)·2^(k-1) to extract |family| < 2^(k-1), the hypothesis the Property B engine consumes.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/VanDerWaerdenFirstMomentOQ01.lean",
+    "namespace": "ProbMethod.VanDerWaerden",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 152,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The classical first-moment (union-bound) lower bound on van der Waerden numbers W(k) counts the length-k arithmetic progressions in [n] and asks for that count to fall below 2^(k-1). The base gallery entry van-der-waerden-first-moment proves this with the deliberately loose count n² (every (a,d) pair allowed), giving W(k) ≳ 2^((k-1)/2). Sharpening the AP count tightens the threshold constant: the step d of a fitting length-k AP is at most (n-1)/(k-1), so far fewer than n² pairs actually fit. The base entry's open question oq-01 asks for the resulting ~n²/(k-1) bound; the exact triangular count gives the sharper n²/(2(k-1)).",
+    "problemStatement": "Sharpen the base entry's loose n² count of fitting length-k APs (card_vdwFamily_le) using the step constraint a + (k-1)d < n, and feed the sharper count back through the verified Property B engine to widen the admissible range of n in the van der Waerden lower bound.",
+    "proofStrategy": "Count the fitting (a,d) parameter box exactly. Rewrite its cardinality (Finset.card_filter, Finset.sum_product, Finset.sum_comm) as a sum over the step d of the number of admissible first terms a; for fixed d that fiber is {a < n : a + (k-1)d < n}, which has exactly n - (k-1)d elements (card_filter_lt, with ℕ-subtraction truncating to 0 once (k-1)d ≥ n). This yields the exact triangular count ∑_{d=1}^{n}(n - (k-1)d) (vdwFilter_card_eq_sum), and the AP family — an image of this box — is bounded by it (card_vdwFamily_le_sum). To collapse the triangular sum, prove the strengthened invariant 2c·∑_{d=1}^{m}(N - c·d) + (N - c·m)² ≤ N² by induction on m (two_mul_sum_sq_le): the per-step increment satisfies 2c(N-c(m+1)) + (N-c(m+1))² ≤ (N-cm)² (a square completion, by cases on whether (m+1)c exceeds N), so the running square slack absorbs each new term. Specialising N = n, c = k-1, m = n gives 2(k-1)·|family| ≤ n² (card_vdwFamily_two_mul_le). Finally, if n² < 2(k-1)·2^(k-1), cancel 2(k-1) to get |family| < 2^(k-1) and invoke the base entry's vdw_two_coloring_exists, then verify each fitting AP lies in the family (vdw_lower_bound_sharp).",
+    "keyInsights": [
+      "The number of fitting length-k APs is not n² but a triangular sum: for each step d there are exactly n - (k-1)d admissible first terms, and ℕ-subtraction truncates the tail d > (n-1)/(k-1) to 0 for free — so ∑_{d=1}^{n}(n - (k-1)d) is the exact parameter count without any case split on the cutoff.",
+      "The triangular sum is collapsed not by a Gauss formula (which would entangle the floor (n-1)/(k-1)) but by a telescoping-of-squares: 2c(N-cd) ≤ (N-c(d-1))² - (N-cd)², so partial sums stay under N². This sidesteps the floor entirely and keeps the proof inside ℕ.",
+      "The sharpened bound 2(k-1)·|family| ≤ n² needs NO hypothesis on k — for k ≤ 1 the factor 2(k-1) is 0 and the bound is vacuous, so the same statement covers all k.",
+      "The improvement is to the constant, by a factor of 2 over the open question's target: n²/(2(k-1)) vs n²/(k-1). Through the union bound this is a factor √(2(k-1)) widening of the admissible n, i.e. W(k) ≳ √(2(k-1))·2^((k-1)/2) instead of 2^((k-1)/2).",
+      "Honesty about ceiling: this sharpens the COUNT and hence the union-bound constant, not the method. The exponential base of W(k) is untouched; reaching W(k) ≳ 2^k/(ek) needs the Lovász Local Lemma, not a tighter first-moment count."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview and Scope",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "States the goal: sharpen the base entry's loose n² AP count to the exact triangular sum and beyond, then re-derive the van der Waerden lower bound with a wider admissible range. Explicit that the probabilistic core remains the verified Property B engine and the improvement is to the constant, not the method."
+    },
+    {
+      "id": "fiber-count",
+      "title": "The Fiber Count and the Exact Triangular Sum",
+      "startLine": 53,
+      "endLine": 75,
+      "summary": "card_filter_lt: exactly n - c of the first terms a < n satisfy a + c < n. vdwFilter_card_eq_sum: grouping the fitting (a,d) box by step d and counting fiberwise gives the exact triangular count ∑_{d=1}^{n}(n - (k-1)d)."
+    },
+    {
+      "id": "family-bound",
+      "title": "Family Bounded by the Exact Sum",
+      "startLine": 76,
+      "endLine": 83,
+      "summary": "card_vdwFamily_le_sum: the AP family is the image of the fitting (a,d) box, so its cardinality is at most the exact triangular sum."
+    },
+    {
+      "id": "telescoping",
+      "title": "Telescoping-of-Squares and the Factor-2 Bound",
+      "startLine": 84,
+      "endLine": 123,
+      "summary": "two_mul_sum_sq_le: the strengthened invariant 2c·∑(N-c·d) + (N-c·m)² ≤ N², proved by induction with a per-step square completion. card_vdwFamily_two_mul_le: specialising gives 2(k-1)·|family| ≤ n², twice as sharp as the requested n²/(k-1), with no hypothesis on k."
+    },
+    {
+      "id": "lower-bound",
+      "title": "The Sharpened Lower Bound",
+      "startLine": 125,
+      "endLine": 152,
+      "summary": "vdw_lower_bound_sharp: if n² < 2(k-1)·2^(k-1), cancel 2(k-1) to get |family| < 2^(k-1), invoke the base entry's Property B engine, and verify each fitting AP is in the family — giving W(k) ≳ √(2(k-1))·2^((k-1)/2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "6 theorems, 0 definitions, 0 sorries, 0 axioms, no native_decide. The number of length-k arithmetic progressions fitting in [n] is computed exactly as the triangular sum ∑_{d=1}^{n}(n - (k-1)d), and a telescoping-of-squares bound collapses it to 2(k-1)·|family| ≤ n² — at most n²/(2(k-1)) APs, twice as sharp as the base entry's open question asked. Feeding this through the verified Property B engine widens the van der Waerden lower bound's admissible range to n² < 2(k-1)·2^(k-1), giving W(k) ≳ √(2(k-1))·2^((k-1)/2).",
+    "implications": "Resolves the base entry's open question oq-01 (sharpen the AP count to ~n²/(k-1)) and improves on it by a factor of 2 with an exact count. Demonstrates that the loose n² in the first-moment van der Waerden bound is genuinely improvable inside Lean by elementary lattice-point counting, and that the verified Property B engine accepts the sharper count unchanged.",
+    "openQuestions": [
+      "Track the lower-order term: vdwFilter_card_eq_sum is an equality, so the exact threshold (including the (N-cm)² remainder dropped in two_mul_sum_sq_le) could be stated, pinning the optimal constant rather than the ≤ n² bound.",
+      "Replace the union bound by the Lovász Local Lemma form W(k) ≳ 2^k/(ek), which requires a verified symmetric-LLL statement and a bound on the overlap degree of the AP-hypergraph — the genuine next jump, beyond constant-sharpening.",
+      "Generalise the exact count to length-k APs in higher-dimensional grids [n]^d, where the fitting region is a polytope and the fiberwise count becomes a multidimensional Ehrhart-type sum."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "van-der-waerden-first-moment",
+      "relationship": "parent — this entry sharpens that entry's loose n² AP count (card_vdwFamily_le) to the exact triangular sum and a factor-2 bound, answering its open question oq-01, and reuses its vdwAP/vdwFamily/vdw_two_coloring_exists"
+    },
+    {
+      "targetId": "property-b-first-moment",
+      "relationship": "engine — the probabilistic core (property_b_two_colorable, Erdős 1963 Property B via the first moment method) is consumed as a black box through the base entry's vdw_two_coloring_exists"
+    },
+    {
+      "targetId": "erdos-138",
+      "relationship": "related — the gallery's van der Waerden entry, which axiomatizes growth/lower-bound statements; this entry sharpens the elementary first-moment lower bound"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the base entry **van-der-waerden-first-moment**'s open question **oq-01** — *sharpen the loose `n²` count of fitting length-`k` arithmetic progressions to `~n²/(k-1)`* — and **goes a factor of 2 further** by computing the parameter count **exactly**.

The base entry bounds the number of fitting APs by the deliberately loose `n²` (every `(a,d)` pair allowed). For each step `d`, a fitting AP needs `a + (k-1)d < n` with `a ≥ 0`, so exactly `n - (k-1)d` first terms are admissible. Summing over `d` gives the **exact triangular count**, which a **telescoping-of-squares** argument collapses to a factor-`2(k-1)` bound.

## Results (all verified, 0-axiom)

| Theorem | Statement |
|---|---|
| `vdwFilter_card_eq_sum` | Exact parameter count `= ∑_{d=1}^{n} (n - (k-1)d)` (truncated ℕ-subtraction handles the tail) |
| `card_vdwFamily_le_sum` | `\|family\| ≤` that exact triangular sum |
| `two_mul_sum_sq_le` | Telescoping engine `2c·∑(N-c·d) + (N-c·m)² ≤ N²` |
| `card_vdwFamily_two_mul_le` | **`2·(k-1)·\|family\| ≤ n²`** — i.e. `≤ n²/(2(k-1))`, twice as sharp as oq-01 asked, **no hypothesis on `k`** |
| `vdw_lower_bound_sharp` | `n² < 2·(k-1)·2^(k-1)` ⟹ a 2-colouring with no monochromatic length-`k` AP |

The lower bound widens the admissible `n` by a factor `√(2(k-1))` over the base `n² < 2^(k-1)`, giving **`W(k) ≳ √(2(k-1))·2^((k-1)/2)`**.

## Honesty

Elementary lattice-point counting on top of the base entry's verified AP combinatorics and the Property-B engine (consumed as a black box via `vdw_two_coloring_exists`). The improvement is to the **constant/threshold**, not the union-bound method — the Lovász-Local-Lemma form `W(k) ≳ 2^k/(ek)` remains out of reach here.

## Verification

- `#print axioms` on `vdw_lower_bound_sharp`, `card_vdwFamily_two_mul_le`, `vdwFilter_card_eq_sum` → only `propext, Classical.choice, Quot.sound`.
- 0 sorries, no `native_decide`. Builds against pinned Mathlib v4.26.0.
- Gallery entry (`meta.json` + 8 annotations) added; `meta.json` 13 KB (cap 60 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)