### PR TITLE
research(inverse-galois-d4-oq-02-oq-03-oq-01): sharp degree boundary — |Gal(Xⁿ−p)| pinned iff n∈{2,3}, + |Gal(X²−p)|=2 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/InverseGaloisD4OQ02OQ03OQ01.lean
+++ b/proofs/Proofs/InverseGaloisD4OQ02OQ03OQ01.lean
@@ -1,0 +1,118 @@
+/-
+# Inverse Galois: the sharp degree boundary of the metacyclic bracket
+  (inverse-galois-d4-oq-02-oq-03-oq-01)
+
+The parent entry `Proofs.InverseGaloisD4OQ02OQ03` pins the cubic Galois group exactly,
+
+      |Gal(X³ - p / ℚ)| = 6   for every prime p     (`gal_card_cubic_eq_six`),
+
+by squeezing the coprime lower bound `n·φ(n) ∣ |Gal|` (valid when `gcd(n, φ(n)) = 1`,
+`mul_totient_dvd_gal_card_of_coprime`) against the symmetric-group upper bound
+`|Gal| ∣ n!` (`gal_card_dvd_factorial`).  The squeeze closes precisely because at `n = 3`
+the metacyclic order *equals* the factorial bound: `3·φ(3) = 6 = 3!`.
+
+This raises the open question the parent left implicit: **for which degrees `n` does the
+elementary bracket pin `|Gal(Xⁿ - p)|` exactly?**  The squeeze succeeds iff the lower and
+upper bounds coincide, i.e. iff
+
+      n · φ(n) = n!.
+
+This file resolves that boundary completely.
+
+  * `totient_mul_eq_factorial_iff`  : for `n ≥ 2`,  `n·φ(n) = n!  ↔  n = 2 ∨ n = 3`.
+                                       For `n ≥ 4` the metacyclic order `n·φ(n) ≤ n(n-1)`
+                                       is dwarfed by `n! ≥ 2·n(n-1)`, so the bracket has
+                                       slack and cannot pin the order on its own.
+  * `gal_card_eq_factorial_of_pin`  : whenever `n·φ(n) = n!` the order is pinned to `n!`
+                                       — and since the only solutions `n ∈ {2, 3}` are
+                                       automatically coprime, *no separate coprimality
+                                       hypothesis is needed*.
+  * `gal_card_quadratic_eq_two`     : the quadratic companion of the cubic witness,
+                                       `|Gal(X² - p / ℚ)| = 2` for every prime `p`.
+
+So the elementary divisibility bracket pins the Galois group of `Xⁿ - p` *exactly* at the
+two degrees `n = 2` (giving `2 = |C₂|`) and `n = 3` (giving `6 = |S₃|`), and at no other
+degree.  For `n ≥ 4` (the smallest being the base entry's own `n = 4`, where
+`4·φ(4) = 8 ≠ 24 = 4!`) the bracket leaves a genuine gap, which is exactly why the base
+entry `|Gal(X⁴-2)| = 8` required an extra resolvent/embedding argument beyond the bracket.
+
+Status: 0 sorries, 0 axioms, no `native_decide`.  `#print axioms` on the headline
+theorems reports only `propext, Classical.choice, Quot.sound`.
+-/
+import Mathlib
+import Proofs.InverseGaloisD4OQ02OQ03
+
+namespace InverseGaloisExtensions
+
+open Polynomial
+
+-- ============================================================================
+-- Part I: The sharp degree boundary  n·φ(n) = n!  ⟺  n ∈ {2, 3}
+-- ============================================================================
+
+/-- **The metacyclic order meets the factorial bound only at `n = 2, 3`.**
+The bracket squeeze `n·φ(n) ∣ |Gal| ∣ n!` pins the order exactly when its two ends
+coincide, i.e. when `n·φ(n) = n!`.  For `n ≥ 2` this happens precisely for `n = 2` and
+`n = 3`: for `n ≥ 4` we have `φ(n) ≤ n-1`, so `n·φ(n) ≤ n(n-1)`, while
+`n! = n(n-1)·(n-2)! ≥ 2·n(n-1)` strictly exceeds it. -/
+theorem totient_mul_eq_factorial_iff {n : ℕ} (hn : 2 ≤ n) :
+    n * n.totient = n.factorial ↔ n = 2 ∨ n = 3 := by
+  refine ⟨fun h => ?_, by rintro (rfl | rfl) <;> decide⟩
+  by_contra hcon
+  push_neg at hcon
+  obtain ⟨hne2, hne3⟩ := hcon
+  -- so n ≥ 4; write n = m + 2 with m ≥ 2
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 2 := ⟨n - 2, by omega⟩
+  have hm2 : 2 ≤ m := by omega
+  -- φ(n) ≤ n - 1 = m + 1
+  have hφ : (m + 2).totient ≤ m + 1 := by
+    have := Nat.totient_lt (m + 2) (by omega); omega
+  -- (m+2)! = (m+2)·(m+1)·m!
+  have hfac : (m + 2).factorial = (m + 2) * ((m + 1) * m.factorial) := by
+    rw [Nat.factorial_succ, Nat.factorial_succ]
+  -- m! ≥ 2 since m ≥ 2
+  have hmfac : 2 ≤ m.factorial := by
+    calc (2 : ℕ) = Nat.factorial 2 := by decide
+      _ ≤ m.factorial := Nat.factorial_le hm2
+  -- lower-degree bound on the metacyclic order
+  have hlhs : (m + 2) * (m + 2).totient ≤ (m + 2) * (m + 1) := by gcongr
+  -- the factorial dominates twice the metacyclic order
+  have hrhs : (m + 2) * (m + 1) * 2 ≤ (m + 2).factorial := by
+    rw [hfac]
+    calc (m + 2) * (m + 1) * 2 ≤ (m + 2) * (m + 1) * m.factorial := by gcongr
+      _ = (m + 2) * ((m + 1) * m.factorial) := by ring
+  have hApos : 0 < (m + 2) * (m + 1) := by positivity
+  -- (m+2)! = lhs ≤ (m+2)(m+1) but also 2·(m+2)(m+1) ≤ (m+2)!  ⟹  contradiction
+  nlinarith [h, hlhs, hrhs, hApos]
+
+-- ============================================================================
+-- Part II: The pin theorem — coprimality is automatic at the boundary
+-- ============================================================================
+
+/-- **`n·φ(n) = n! ⟹ |Gal(Xⁿ-p/ℚ)| = n!`.**  The hypothesis is exactly the squeeze
+condition.  Crucially it carries *no* separate coprimality assumption: by
+`totient_mul_eq_factorial_iff` the only degrees satisfying it are `n ∈ {2, 3}`, both of
+which have `gcd(n, φ(n)) = 1`, so the coprime lower bound
+`mul_totient_dvd_gal_card_of_coprime` applies and meets the upper bound `|Gal| ∣ n!`. -/
+theorem gal_card_eq_factorial_of_pin (n p : ℕ) (hn : 2 ≤ n) (hp : p.Prime)
+    (hpin : n * n.totient = n.factorial) :
+    Fintype.card (X ^ n - C (p : ℚ) : ℚ[X]).Gal = n.factorial := by
+  have hcop : Nat.Coprime n n.totient := by
+    rcases (totient_mul_eq_factorial_iff hn).mp hpin with rfl | rfl <;> decide
+  have hlow := mul_totient_dvd_gal_card_of_coprime n p hn hp hcop
+  rw [hpin] at hlow
+  exact Nat.dvd_antisymm (gal_card_dvd_factorial n p hn hp) hlow
+
+-- ============================================================================
+-- Part III: The quadratic companion witness  |Gal(X²-p/ℚ)| = 2
+-- ============================================================================
+
+/-- **`|Gal(X²-p/ℚ)| = 2`** for every prime `p`.  The quadratic companion of the cubic
+witness `gal_card_cubic_eq_six`: here `2·φ(2) = 2·1 = 2 = 2!`, so the bracket pins the
+order to `2 = |C₂|`, the Galois group of the quadratic field `ℚ(√p)`. -/
+theorem gal_card_quadratic_eq_two (p : ℕ) (hp : p.Prime) :
+    Fintype.card (X ^ 2 - C (p : ℚ) : ℚ[X]).Gal = 2 := by
+  have h := gal_card_eq_factorial_of_pin 2 p (by norm_num) hp (by decide)
+  simpa using h
+
+end InverseGaloisExtensions

--- a/research/problems/inverse-galois-d4-oq-02/knowledge.md
+++ b/research/problems/inverse-galois-d4-oq-02/knowledge.md
@@ -81,3 +81,21 @@ Gallery entry `src/data/proofs/inverse-galois-d4-oq-02-oq-03/`. Same single-file
 - Non-coprime case (n=4): recover the full `n·φ(n)` beyond `lcm(n,φ(n))` via an independent kernel×quotient
   product witness.
 - Identify the semidirect-product structure `Gal ≅ ℤ/n ⋊ (ℤ/n)ˣ` explicitly.
+
+## Session 2026-06-27 (follow-up child oq-03-oq-01) — sharp degree boundary
+
+`Proofs/InverseGaloisD4OQ02OQ03OQ01.lean` (3 theorems, 0 sorries, 0 axioms; `#print axioms` =
+propext/Classical.choice/Quot.sound only) resolves the **first open question** of the cubic-pinning
+entry oq-03 ("characterize all n with n·φ(n) = n!"):
+
+- `totient_mul_eq_factorial_iff (hn : 2 ≤ n) : n·φ(n) = n! ↔ n = 2 ∨ n = 3`. Forward: write n = m+2,
+  use `Nat.totient_lt` (φ(n) ≤ n−1 ⟹ n·φ(n) ≤ n(n−1)) and `(m+2)! = (m+2)(m+1)·m!` with m! ≥ 2
+  (`Nat.factorial_le`), so n! ≥ 2·n(n−1) > n·φ(n) for n ≥ 4 — contradiction (nlinarith).
+- `gal_card_eq_factorial_of_pin` : n·φ(n) = n! ⟹ |Gal(Xⁿ−p)| = n!, with **no coprimality hypothesis**
+  — the only boundary degrees n ∈ {2,3} are automatically coprime, so the parent coprime bound applies.
+- `gal_card_quadratic_eq_two : |Gal(X²−p/ℚ)| = 2` for every prime p — the quadratic companion of
+  oq-03's cubic |Gal(X³−p)| = 6. (2·φ(2) = 2 = 2!.)
+
+**Upshot**: the elementary bracket pins |Gal(Xⁿ−p)| exactly at n = 2 (→ 2 = |C₂|) and n = 3 (→ 6 = |S₃|),
+and nowhere else; n ≥ 4 (starting with the base entry's n = 4, where 4·φ(4) = 8 ≠ 24) has genuine slack.
+Gallery entry `src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01/`. Same single-file `lake env lean` recipe.

--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01/meta.json
@@ -1,0 +1,100 @@
+{
+  "id": "inverse-galois-d4-oq-02-oq-03-oq-01",
+  "title": "The Sharp Degree Boundary of the Metacyclic Bracket: |Gal(Xⁿ−p)| Pinned Exactly iff n ∈ {2,3}, with |Gal(X²−p)| = 2",
+  "slug": "inverse-galois-d4-oq-02-oq-03-oq-01",
+  "description": "Resolves the first open question of the parent cubic-pinning entry: characterize exactly which degrees n the elementary divisibility bracket n·φ(n) ∣ |Gal(Xⁿ−p/ℚ)| ∣ n! pins to the full factorial order. The squeeze closes iff its two ends coincide, i.e. iff n·φ(n) = n!, and totient_mul_eq_factorial_iff proves that for n ≥ 2 this holds precisely for n = 2 and n = 3: for n ≥ 4 one has φ(n) ≤ n−1 so n·φ(n) ≤ n(n−1), while n! = n(n−1)·(n−2)! ≥ 2·n(n−1) strictly exceeds it, leaving the bracket genuine slack. The pin theorem gal_card_eq_factorial_of_pin needs NO separate coprimality hypothesis: the only solutions n ∈ {2,3} are automatically coprime (gcd(2,1) = gcd(3,2) = 1), so the parent's coprime lower bound applies and meets the upper bound. The n = 2 case is the quadratic companion of the cubic witness: 2·φ(2) = 2 = 2!, so gal_card_quadratic_eq_two pins |Gal(X²−p/ℚ)| = 2 = |C₂| for every prime p (the Galois group of ℚ(√p)). Thus the bracket pins the Galois group of Xⁿ−p exactly at n = 2 (giving 2) and n = 3 (giving 6), and at no larger degree — explaining structurally why the base D₄ entry (n = 4, where 4·φ(4) = 8 ≠ 24 = 4!) needed an extra resolvent argument. 3 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher (researcher-7)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InverseGaloisD4OQ02OQ03OQ01.lean",
+    "parentProof": "inverse-galois-d4-oq-02-oq-03",
+    "openQuestionId": "inverse-galois-d4-oq-02-oq-03-oq-01",
+    "tags": [
+      "galois-theory",
+      "inverse-galois",
+      "number-theory",
+      "metacyclic-group",
+      "totient",
+      "factorial",
+      "symmetric-group",
+      "sharp-boundary",
+      "field-extensions",
+      "polynomial"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 118,
+    "theoremCount": 3,
+    "assumptions": "None beyond the foundational propext / Classical.choice / Quot.sound. #print axioms on all three theorems (totient_mul_eq_factorial_iff, gal_card_eq_factorial_of_pin, gal_card_quadratic_eq_two) reports only those three. The `decide` calls (Nat.Coprime 2 (φ 2), Nat.Coprime 3 (φ 3), the small factorial/totient equalities) are kernel decide, not native_decide — no Lean.ofReduceBool.",
+    "buildStatus": "Verified via `lake env lean Proofs/InverseGaloisD4OQ02OQ03OQ01.lean` against pinned Mathlib v4.26.0 (single-file elaboration against prebuilt parent oleans; host docker daemon unresponsive, so the standard docker wrapper was bypassed for a direct toolchain elaboration). 0 errors. #print axioms confirms 0 non-foundational axioms.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient_lt",
+        "description": "1 < n → φ(n) < n; gives the degree bound φ(n) ≤ n−1 that makes the metacyclic order n·φ(n) ≤ n(n−1) fall short of n! for n ≥ 4.",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "Nat.factorial_succ",
+        "description": "(n+1)! = (n+1)·n!; unfolds (m+2)! = (m+2)·(m+1)·m! to compare the factorial bound against the metacyclic order.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.factorial_le",
+        "description": "Monotonicity m ≤ n → m! ≤ n!; supplies m! ≥ 2! = 2 for m ≥ 2, the strict factor separating n! from n·φ(n).",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_antisymm",
+        "description": "Mutual divisibility forces equality; squeezes |Gal(Xⁿ−p)| between n! ∣ |Gal| (from the pin condition) and |Gal| ∣ n!.",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "InverseGaloisExtensions.mul_totient_dvd_gal_card_of_coprime",
+        "description": "Parent lemma: gcd(n,φ(n)) = 1 ⟹ n·φ(n) ∣ |Gal(Xⁿ−p/ℚ)|; the coprime lower bound, automatically available at the boundary degrees n ∈ {2,3}.",
+        "module": "Proofs.InverseGaloisD4OQ02OQ03"
+      },
+      {
+        "theorem": "InverseGaloisExtensions.gal_card_dvd_factorial",
+        "description": "Parent lemma: |Gal(Xⁿ−p/ℚ)| ∣ n! (faithful action on the n roots embeds Gal ↪ Sₙ); the upper end of the squeeze.",
+        "module": "Proofs.InverseGaloisD4OQ02"
+      }
+    ],
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent chain establishes the divisibility bracket $n \\mid |\\mathrm{Gal}(X^n-p/\\mathbb{Q})|$, $\\varphi(n) \\mid |\\mathrm{Gal}|$, $|\\mathrm{Gal}| \\mid n!$ for the metacyclic Galois group of $X^n-p$, and shows that when $\\gcd(n, \\varphi(n)) = 1$ the full order $n\\,\\varphi(n)$ divides $|\\mathrm{Gal}|$. The cubic $n = 3$ is pinned exactly, $|\\mathrm{Gal}(X^3-p)| = 6$, because there $n\\,\\varphi(n) = 6 = 3!$. This entry asks the natural boundary question the cubic leaves open: at which degrees does the elementary bracket close completely?",
+    "problemStatement": "Determine exactly which degrees $n$ the divisibility bracket $n\\,\\varphi(n) \\mid |\\mathrm{Gal}(X^n-p/\\mathbb{Q})| \\mid n!$ pins to the full factorial order $n!$. Equivalently, characterize the $n$ for which the squeeze condition $n\\,\\varphi(n) = n!$ holds, and exhibit the resulting exact Galois orders.",
+    "proofStrategy": "(1) Boundary count: $n\\,\\varphi(n) = n!$ iff $n \\in \\{2,3\\}$ for $n \\ge 2$. The reverse direction is kernel `decide`; for the forward direction, write $n = m+2$ with $m \\ge 2$, use $\\varphi(n) \\le n-1$ (Nat.totient_lt) to bound $n\\,\\varphi(n) \\le (m+2)(m+1)$, expand $(m+2)! = (m+2)(m+1)\\,m!$ with $m! \\ge 2$ (Nat.factorial_le), and derive the contradiction $2(m+2)(m+1) \\le (m+2)! = n\\,\\varphi(n) \\le (m+2)(m+1)$ via nlinarith. (2) Pin theorem: from $n\\,\\varphi(n) = n!$ the boundary count forces $n \\in \\{2,3\\}$, both coprime, so the parent coprime bound gives $n! \\mid |\\mathrm{Gal}|$; Nat.dvd_antisymm with $|\\mathrm{Gal}| \\mid n!$ yields equality — with no coprimality hypothesis in the statement. (3) Quadratic witness: instantiate at $n = 2$ ($2\\varphi(2) = 2 = 2!$) to get $|\\mathrm{Gal}(X^2-p)| = 2$.",
+    "keyInsights": [
+      "**The squeeze closes iff the ends meet**: The bracket $n\\,\\varphi(n) \\mid |\\mathrm{Gal}| \\mid n!$ determines $|\\mathrm{Gal}|$ exactly precisely when its lower and upper ends coincide, $n\\,\\varphi(n) = n!$. This reframes 'when is the Galois order pinned?' as a clean elementary number-theoretic identity.",
+      "**The boundary is exactly {2,3}**: For $n \\ge 4$ the metacyclic order $n\\,\\varphi(n) \\le n(n-1)$ is dwarfed by $n! \\ge 2n(n-1)$, so equality fails. Only $n = 2$ and $n = 3$ survive — the metacyclic holomorph $\\mathbb{Z}/n \\rtimes (\\mathbb{Z}/n)^\\times$ equals the full symmetric group $S_n$ exactly in these two degrees.",
+      "**Coprimality is automatic at the boundary**: The pin theorem needs no `gcd(n, φ(n)) = 1` hypothesis, because every solution of $n\\,\\varphi(n) = n!$ already satisfies it ($\\gcd(2,1) = \\gcd(3,2) = 1$). The arithmetic boundary condition silently supplies the algebraic one.",
+      "**Quadratic and cubic are the only argument-free pins**: $|\\mathrm{Gal}(X^2-p)| = 2 = |C_2|$ and $|\\mathrm{Gal}(X^3-p)| = 6 = |S_3|$ fall straight out of the bracket, uniform in the prime $p$. For $n = 4$ the bracket gives only $4 \\mid |\\mathrm{Gal}| \\mid 24$ (here $4\\varphi(4) = 8 \\ne 24$), which is exactly why the base $D_4$ entry $|\\mathrm{Gal}(X^4-2)| = 8$ required a separate $\\mathbb{R}$-embedding/resolvent argument."
+    ]
+  },
+  "conclusion": {
+    "summary": "Pinned the sharp degree boundary of the metacyclic divisibility bracket: for n ≥ 2 the squeeze n·φ(n) ∣ |Gal(Xⁿ−p/ℚ)| ∣ n! determines the order exactly iff n·φ(n) = n!, which holds precisely for n ∈ {2,3}. The pin theorem requires no coprimality hypothesis (the boundary degrees are automatically coprime), and the quadratic companion |Gal(X²−p/ℚ)| = 2 joins the parent's cubic |Gal(X³−p/ℚ)| = 6 as the only two argument-free, prime-uniform pins. 3 theorems, 0 sorries, 0 axioms.",
+    "implications": "Delimits exactly what the verified elementary bracket can decide on its own: it pins the Galois order of Xⁿ−p in exactly two degrees (n = 2, 3) and never for n ≥ 4. This both completes the small-degree picture (X²−p and X³−p have Galois group C₂ and S₃ uniformly in p) and explains structurally why every larger radical degree — starting with the base entry's own n = 4 — requires genericity/linear-disjointness or an explicit resolvent beyond the bracket.",
+    "openQuestions": [
+      "For degrees n ≥ 4 with gcd(n, φ(n)) = 1 but n·φ(n) < n! (e.g. n = 5, where 5·φ(5) = 20 < 120), supply the matching upper bound |Gal| ≤ n·φ(n) via linear disjointness of ℚ(ⁿ√p) and ℚ(ζₙ) to pin |Gal| = n·φ(n) even when the Sₙ bound is loose.",
+      "Identify the smallest degree at which |Gal(Xⁿ−p)| genuinely depends on the prime p (rather than being uniform as for n = 2, 3), and characterize the dependence."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "inverse-galois-d4-oq-02-oq-03",
+      "relationship": "parent — pins the cubic |Gal(X³−p)| = 6 via the coprime lower bound 6 ∣ |Gal| and upper bound |Gal| ∣ 3!. This entry answers its first listed open question (characterize all n with n·φ(n) = n!) and adds the quadratic companion |Gal(X²−p)| = 2."
+    },
+    {
+      "proofId": "inverse-galois-d4-oq-02",
+      "relationship": "grandparent — supplies the divisibility bracket n·φ(n) ∣ |Gal| (under coprimality) and |Gal| ∣ n! that defines the squeeze whose sharp degree boundary is determined here."
+    },
+    {
+      "proofId": "inverse-galois-d4",
+      "relationship": "great-grandparent — the n = 4, p = 2 case (|Gal| = 8). This entry proves 4 lies strictly beyond the bracket's pinning range (4·φ(4) = 8 ≠ 24 = 4!), explaining why that entry needed a separate ℝ-embedding argument."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to the just-merged cubic-pinning entry **inverse-galois-d4-oq-02-oq-03** (#30956), resolving its **first listed open question**: *characterize all `n` with `n·φ(n) = n!`*.

The parent pins `|Gal(X³−p/ℚ)| = 6` because the divisibility bracket
```
n·φ(n) ∣ |Gal(Xⁿ−p/ℚ)| ∣ n!
```
closes exactly when its two ends coincide. This entry determines the **sharp degree boundary** of that squeeze.

### Theorems (3, 0 sorries, 0 axioms)

- **`totient_mul_eq_factorial_iff`** — for `n ≥ 2`, `n·φ(n) = n! ↔ n = 2 ∨ n = 3`. For `n ≥ 4`, `φ(n) ≤ n−1` gives `n·φ(n) ≤ n(n−1)`, while `n! = n(n−1)·(n−2)! ≥ 2·n(n−1)` strictly exceeds it.
- **`gal_card_eq_factorial_of_pin`** — `n·φ(n) = n! ⟹ |Gal(Xⁿ−p)| = n!`, with **no coprimality hypothesis**: the only boundary degrees `n ∈ {2,3}` are automatically coprime, so the parent's coprime lower bound applies.
- **`gal_card_quadratic_eq_two`** — `|Gal(X²−p/ℚ)| = 2` for every prime `p`, the quadratic companion (`2·φ(2) = 2 = 2!`) to the parent's cubic `= 6`.

**Upshot:** the elementary bracket pins the Galois group of `Xⁿ−p` exactly at `n = 2` (→ `2 = |C₂|`) and `n = 3` (→ `6 = |S₃|`), and at no larger degree — explaining structurally why the base D₄ entry (`n = 4`, `4·φ(4) = 8 ≠ 24`) needed a separate resolvent/ℝ-embedding argument.

### Verification

Built against pinned Mathlib v4.26.0 via single-file `lake env lean` elaboration against prebuilt parent oleans (host docker daemon unresponsive). 0 errors. `#print axioms` on all three theorems reports only `propext, Classical.choice, Quot.sound` — no `native_decide`, no `sorryAx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)