### PR TITLE
audit(cycleAL): drain queue — 15 never-audited proofs all CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25205,6 +25205,96 @@
       "lastAudited": "2026-06-27T19:03:40Z",
       "result": "clean",
       "issues": []
+    },
+    "arithmetic-series-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1012-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-307-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-564-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-634-medial-congruence-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "four-square-distribution-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fourth-root-2-degree4-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fourth-root-2-irrational-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "furstenberg-correspondence-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inverse-galois-d4-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inverse-galois-d4-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lebesgue-measure-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "legendre-partial-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "prob-method-applications-wip-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ramsey-r4k-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:20:49Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — cycleAL

Drained the audit queue: 15 never-audited gallery entries verified clean. Records the completions in `audit-tracker.json`.

## Results (15/15 clean)

| Slug | Verdict |
|------|---------|
| arithmetic-series-oq-02-oq-01-oq-01-oq-01 | clean (verified/mathlib, kernel `decide`, no nd) |
| erdos-1012-oq-02-oq-01 | clean ('sorry' only in docstring) |
| erdos-307-oq-02-oq-01 | clean ('sorry' only in docstrings, discharges prior sorry) |
| erdos-564-incomplete-01 | clean (infrastructure) |
| erdos-634-medial-congruence-oq-01 | clean (verified/original) |
| four-square-distribution-oq-07 | clean (nd hits are docstrings disclaiming nd) |
| fourth-root-2-degree4-oq-02 | clean |
| fourth-root-2-irrational-oq-02 | clean |
| furstenberg-correspondence-oq-03 | clean |
| inverse-galois-d4-oq-02 | clean |
| inverse-galois-d4-oq-02-oq-03 | clean |
| lebesgue-measure-oq-01-oq-02 | clean |
| legendre-partial-oq-04 | clean (axiomatized/axiom, axiomCount=2 = oppermann axiom + Lean.ofReduceBool) — **exemplary** |
| prob-method-applications-wip-01-oq-01 | clean |
| ramsey-r4k-oq-02 | clean |

## Verification performed

- **True-stub scan**: 0 across all 15 files; all have substantive theorem content.
- **Sorry check**: all `sorry` regex hits are inside docstrings; 0 real sorries.
- **native_decide check**: all `native_decide` regex hits are docstring mentions explicitly stating files use kernel `decide` (no `Lean.ofReduceBool`). Exception: legendre-partial-oq-04 genuinely uses native_decide and correctly accounts for it (axiomatized, axiomCount=2).
- **Status/badge/axiom consistency**: all match the Lean source.

Note: `inverse-galois-d4-oq-02-oq-03-oq-01` is an empty untracked directory with no `meta.json` — makes no public claims, so not a gallery integrity concern.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)