### PR TITLE
research(sperner-ndim-oq-02): interior Freudenthal pivot — chain-interior facet neighbour exists [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -375,4 +375,297 @@ theorem facet_vertex_injective :
   obtain rfl : k = l := facet_injective s hface
   rfl
 
+-- ============================================================
+-- SECTION: Interior Freudenthal pivot (neighbour existence)
+-- ============================================================
+-- The search-based `adj` reads off, for each facet of a canonical
+-- cell, the unique *other* canonical cell glued across it (or
+-- `none` on the geometric boundary).  Its `boundary_face` field is
+-- the contrapositive obligation: an *interior* facet must actually
+-- have a neighbour.  This section supplies the geometric heart of
+-- that existence for the chain-interior facets — the **Freudenthal
+-- pivot**: deleting an interior vertex `a.succ` of a Kuhn cell, the
+-- neighbour glued across the remaining `d`-vertex facet is obtained
+-- by swapping the two consecutive increment steps `a` and `b`
+-- (`b.castSucc = a.succ`).  Only the pivoted vertex changes; it
+-- moves along the "other diagonal" of the local square
+-- `verts a.castSucc → verts a.succ → verts b.succ`.
+--
+-- We build that neighbour as an honest `GridSimplex`
+-- (`pivotSimplex`, all five Kuhn axioms discharged), and prove it
+-- (i) keeps the deleted-vertex facet fixed (`pivot_facet_eq`) and
+-- (ii) genuinely moves the opposite vertex (`pivot_opposite_ne`),
+-- hence is a *different* cell (`pivot_ne`).  This is the
+-- `GridSimplex`-level existence statement; canonicalising the
+-- pivot (re-selecting the lex-min base) to land it back in
+-- `CanonSimplex`, and the two boundary-chain pivots `a.succ ∈ {0,d}`,
+-- remain for the full `adj`.  Everything here is 0-sorry, 0-axiom.
+
+open SpernerGrid
+
+/-- A `Fin` index never equals the successor it casts up to: `x.castSucc ≠ x.succ`. -/
+theorem Fin_castSucc_ne_succ {d : ℕ} (x : Fin d) : x.castSucc ≠ x.succ := by
+  intro h
+  have hv := congrArg Fin.val h
+  simp only [Fin.coe_castSucc, Fin.val_succ] at hv
+  omega
+
+/-- Two consecutive Kuhn steps are distinct: if `a.succ = b.castSucc`
+then `a ≠ b` (else `a.succ = a.castSucc`, impossible). -/
+theorem pivot_ab_ne {a b : Fin d} (hb : a.succ = b.castSucc) : a ≠ b := by
+  rintro rfl
+  exact absurd hb.symm (Fin_castSucc_ne_succ a)
+
+/-- The **pivoted vertex**.  Relative to the deleted vertex
+`s.verts a.succ`, it decrements the coordinate raised at step `a`
+(`incDir a`) and increments the coordinate raised at step `b`
+(`incDir b`) — i.e. it is `verts a.castSucc + e_{incDir b} - e_miss`,
+the opposite corner of the local square.  The total mass is
+preserved (`incDir a` falls by 1, `incDir b` rises by 1), and the
+`incDir a` coordinate is `≥ 1` (step `a` raised it), so the nat
+subtraction is exact. -/
+def pivotPoint (s : SpernerGrid.GridSimplex d N) (a b : Fin d) (hab : a ≠ b) :
+    SpernerGrid.BaryPoint d N where
+  coords := fun j =>
+    if j = s.incDir a then (s.verts a.succ).coords j - 1
+    else if j = s.incDir b then (s.verts a.succ).coords j + 1
+    else (s.verts a.succ).coords j
+  sum_eq := by
+    have hpos : 1 ≤ (s.verts a.succ).coords (s.incDir a) := by
+      have := s.step_inc a; omega
+    have hne : s.incDir a ≠ s.incDir b := fun h => hab (s.inc_injective h)
+    -- Move-one-unit identity: "+[=incDir a]" on the pivot balances "+[=incDir b]" on the original.
+    have key : ∀ j : Fin (d + 1),
+        (if j = s.incDir a then (s.verts a.succ).coords j - 1
+          else if j = s.incDir b then (s.verts a.succ).coords j + 1
+          else (s.verts a.succ).coords j)
+        + (if j = s.incDir a then 1 else 0)
+        = (s.verts a.succ).coords j + (if j = s.incDir b then 1 else 0) := by
+      intro j
+      by_cases h1 : j = s.incDir a
+      · subst h1
+        rw [if_pos rfl, if_pos rfl, if_neg hne]
+        omega
+      · by_cases h2 : j = s.incDir b
+        · subst h2
+          rw [if_neg h1, if_pos rfl, if_neg h1, if_pos rfl]
+        · rw [if_neg h1, if_neg h2, if_neg h1, if_neg h2]
+    have hone_a : (∑ j : Fin (d + 1), (if j = s.incDir a then (1 : ℕ) else 0)) = 1 := by simp
+    have hone_b : (∑ j : Fin (d + 1), (if j = s.incDir b then (1 : ℕ) else 0)) = 1 := by simp
+    have hsum :
+        (∑ j : Fin (d + 1),
+            (if j = s.incDir a then (s.verts a.succ).coords j - 1
+              else if j = s.incDir b then (s.verts a.succ).coords j + 1
+              else (s.verts a.succ).coords j)) + 1
+          = (∑ j : Fin (d + 1), (s.verts a.succ).coords j) + 1 := by
+      calc
+        (∑ j : Fin (d + 1),
+            (if j = s.incDir a then (s.verts a.succ).coords j - 1
+              else if j = s.incDir b then (s.verts a.succ).coords j + 1
+              else (s.verts a.succ).coords j)) + 1
+            = (∑ j : Fin (d + 1),
+                (if j = s.incDir a then (s.verts a.succ).coords j - 1
+                  else if j = s.incDir b then (s.verts a.succ).coords j + 1
+                  else (s.verts a.succ).coords j))
+              + (∑ j : Fin (d + 1), (if j = s.incDir a then (1 : ℕ) else 0)) := by rw [hone_a]
+          _ = ∑ j : Fin (d + 1),
+                ((if j = s.incDir a then (s.verts a.succ).coords j - 1
+                    else if j = s.incDir b then (s.verts a.succ).coords j + 1
+                    else (s.verts a.succ).coords j)
+                  + (if j = s.incDir a then (1 : ℕ) else 0)) := by rw [Finset.sum_add_distrib]
+          _ = ∑ j : Fin (d + 1),
+                ((s.verts a.succ).coords j + (if j = s.incDir b then (1 : ℕ) else 0)) :=
+                Finset.sum_congr rfl (fun j _ => key j)
+          _ = (∑ j : Fin (d + 1), (s.verts a.succ).coords j)
+                + (∑ j : Fin (d + 1), (if j = s.incDir b then (1 : ℕ) else 0)) := by
+                rw [Finset.sum_add_distrib]
+          _ = (∑ j : Fin (d + 1), (s.verts a.succ).coords j) + 1 := by rw [hone_b]
+    rw [(s.verts a.succ).sum_eq] at hsum
+    omega
+
+theorem pivotPoint_coords_eq_incA (s : SpernerGrid.GridSimplex d N)
+    (a b : Fin d) (hab : a ≠ b) :
+    (pivotPoint s a b hab).coords (s.incDir a)
+      = (s.verts a.succ).coords (s.incDir a) - 1 := by
+  have h : (pivotPoint s a b hab).coords (s.incDir a)
+      = if s.incDir a = s.incDir a then (s.verts a.succ).coords (s.incDir a) - 1
+        else if s.incDir a = s.incDir b then (s.verts a.succ).coords (s.incDir a) + 1
+        else (s.verts a.succ).coords (s.incDir a) := rfl
+  rw [h, if_pos rfl]
+
+theorem pivotPoint_coords_eq_incB (s : SpernerGrid.GridSimplex d N)
+    (a b : Fin d) (hab : a ≠ b) :
+    (pivotPoint s a b hab).coords (s.incDir b)
+      = (s.verts a.succ).coords (s.incDir b) + 1 := by
+  have hne : s.incDir b ≠ s.incDir a := fun h => hab (s.inc_injective h).symm
+  have h : (pivotPoint s a b hab).coords (s.incDir b)
+      = if s.incDir b = s.incDir a then (s.verts a.succ).coords (s.incDir b) - 1
+        else if s.incDir b = s.incDir b then (s.verts a.succ).coords (s.incDir b) + 1
+        else (s.verts a.succ).coords (s.incDir b) := rfl
+  rw [h, if_neg hne, if_pos rfl]
+
+theorem pivotPoint_coords_eq_other (s : SpernerGrid.GridSimplex d N)
+    (a b : Fin d) (hab : a ≠ b) (j : Fin (d + 1))
+    (hja : j ≠ s.incDir a) (hjb : j ≠ s.incDir b) :
+    (pivotPoint s a b hab).coords j = (s.verts a.succ).coords j := by
+  have h : (pivotPoint s a b hab).coords j
+      = if j = s.incDir a then (s.verts a.succ).coords j - 1
+        else if j = s.incDir b then (s.verts a.succ).coords j + 1
+        else (s.verts a.succ).coords j := rfl
+  rw [h, if_neg hja, if_neg hjb]
+
+/-- The **interior Freudenthal pivot**.  For consecutive steps `a`, `b`
+(`a.succ = b.castSucc`), the neighbour of `s` glued across the facet
+opposite vertex `a.succ`: same base/`miss`, the two increment steps
+`a`, `b` swapped (`incDir ∘ swap a b`), and the single vertex `a.succ`
+replaced by `pivotPoint`.  All five Kuhn axioms are discharged: the
+`miss` coordinate is untouched everywhere (so `step_dec` is inherited);
+the only steps whose endpoints move are `a` and `b`, handled by the
+local-square computation. -/
+def pivotSimplex (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) : SpernerGrid.GridSimplex d N where
+  verts := Function.update s.verts a.succ (pivotPoint s a b (pivot_ab_ne hb))
+  incDir := s.incDir ∘ Equiv.swap a b
+  miss := s.miss
+  miss_ne_inc := fun k => s.miss_ne_inc (Equiv.swap a b k)
+  inc_injective := s.inc_injective.comp (Equiv.swap a b).injective
+  step_dec := by
+    have hab : a ≠ b := pivot_ab_ne hb
+    -- The `miss` coordinate is unchanged at every vertex.
+    have hconst : ∀ v : Fin (d + 1),
+        (Function.update s.verts a.succ (pivotPoint s a b hab) v).coords s.miss
+          = (s.verts v).coords s.miss := by
+      intro v
+      by_cases hv : v = a.succ
+      · subst hv
+        rw [Function.update_self]
+        exact pivotPoint_coords_eq_other s a b hab s.miss
+          (fun h => s.miss_ne_inc a h.symm) (fun h => s.miss_ne_inc b h.symm)
+      · rw [Function.update_of_ne hv]
+    intro k
+    rw [hconst, hconst]
+    exact s.step_dec k
+  step_inc := by
+    have hab : a ≠ b := pivot_ab_ne hb
+    intro k
+    by_cases hka : k = a
+    · rw [hka]
+      have hIa : (s.incDir ∘ ⇑(Equiv.swap a b)) a = s.incDir b := by
+        simp [Equiv.swap_apply_left]
+      rw [hIa, Function.update_self,
+        Function.update_of_ne (Fin_castSucc_ne_succ a),
+        pivotPoint_coords_eq_incB s a b hab]
+      have hstep : (s.verts a.succ).coords (s.incDir b)
+          = (s.verts a.castSucc).coords (s.incDir b) :=
+        s.step_same a (s.incDir b) (fun h => hab (s.inc_injective h).symm) (s.miss_ne_inc b)
+      omega
+    · by_cases hkb : k = b
+      · rw [hkb]
+        have hIb : (s.incDir ∘ ⇑(Equiv.swap a b)) b = s.incDir a := by
+          simp [Equiv.swap_apply_right]
+        have hbc : b.castSucc = a.succ := hb.symm
+        have hsucc_ne : b.succ ≠ a.succ := fun h => hab (Fin.succ_inj.mp h).symm
+        rw [hIb, Function.update_of_ne hsucc_ne, hbc, Function.update_self,
+          pivotPoint_coords_eq_incA s a b hab]
+        have hpos : 1 ≤ (s.verts a.succ).coords (s.incDir a) := by
+          have := s.step_inc a; omega
+        have hstep : (s.verts b.succ).coords (s.incDir a)
+            = (s.verts a.succ).coords (s.incDir a) := by
+          have h := s.step_same b (s.incDir a) (fun h => hab (s.inc_injective h)) (s.miss_ne_inc a)
+          rwa [hbc] at h
+        omega
+      · have hIk : (s.incDir ∘ ⇑(Equiv.swap a b)) k = s.incDir k := by
+          simp [Equiv.swap_apply_of_ne_of_ne hka hkb]
+        have hcs_ne : k.castSucc ≠ a.succ := by
+          rw [hb]; exact fun h => hkb (Fin.castSucc_inj.mp h)
+        have hsc_ne : k.succ ≠ a.succ := fun h => hka (Fin.succ_inj.mp h)
+        rw [hIk, Function.update_of_ne hsc_ne, Function.update_of_ne hcs_ne]
+        exact s.step_inc k
+  step_same := by
+    have hab : a ≠ b := pivot_ab_ne hb
+    intro k j hjI hjm
+    by_cases hka : k = a
+    · rw [hka] at hjI ⊢
+      have hIa : (s.incDir ∘ ⇑(Equiv.swap a b)) a = s.incDir b := by
+        simp [Equiv.swap_apply_left]
+      rw [hIa] at hjI
+      rw [Function.update_self, Function.update_of_ne (Fin_castSucc_ne_succ a)]
+      by_cases hja : j = s.incDir a
+      · subst hja
+        rw [pivotPoint_coords_eq_incA s a b hab]
+        have := s.step_inc a
+        omega
+      · rw [pivotPoint_coords_eq_other s a b hab j hja hjI]
+        exact s.step_same a j hja hjm
+    · by_cases hkb : k = b
+      · rw [hkb] at hjI ⊢
+        have hIb : (s.incDir ∘ ⇑(Equiv.swap a b)) b = s.incDir a := by
+          simp [Equiv.swap_apply_right]
+        rw [hIb] at hjI
+        have hbc : b.castSucc = a.succ := hb.symm
+        have hsucc_ne : b.succ ≠ a.succ := fun h => hab (Fin.succ_inj.mp h).symm
+        rw [Function.update_of_ne hsucc_ne, hbc, Function.update_self]
+        by_cases hjb : j = s.incDir b
+        · subst hjb
+          rw [pivotPoint_coords_eq_incB s a b hab]
+          have hss := s.step_inc b
+          rw [hbc] at hss
+          omega
+        · rw [pivotPoint_coords_eq_other s a b hab j hjI hjb]
+          have hss := s.step_same b j hjb hjm
+          rw [hbc] at hss
+          exact hss
+      · have hIk : (s.incDir ∘ ⇑(Equiv.swap a b)) k = s.incDir k := by
+          simp [Equiv.swap_apply_of_ne_of_ne hka hkb]
+        rw [hIk] at hjI
+        have hcs_ne : k.castSucc ≠ a.succ := by
+          rw [hb]; exact fun h => hkb (Fin.castSucc_inj.mp h)
+        have hsc_ne : k.succ ≠ a.succ := fun h => hka (Fin.succ_inj.mp h)
+        rw [Function.update_of_ne hsc_ne, Function.update_of_ne hcs_ne]
+        exact s.step_same k j hjI hjm
+
+/-- **The pivot keeps the facet fixed.**  The `d` vertices off the
+deleted vertex `a.succ` are untouched by the pivot, so `s` and its
+pivot share the facet opposite `a.succ` as vertex sets.  This is the
+`adj_vertices`-style common-face equality for the interior pivot. -/
+theorem pivot_facet_eq (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    (Finset.univ.erase a.succ).image (pivotSimplex s a b hb).verts
+      = (Finset.univ.erase a.succ).image s.verts := by
+  apply Finset.image_congr
+  intro j hj
+  have hjne : j ≠ a.succ := by simpa using hj
+  show Function.update s.verts a.succ (pivotPoint s a b (pivot_ab_ne hb)) j = s.verts j
+  rw [Function.update_of_ne hjne]
+
+/-- **The pivot moves the opposite vertex.**  The pivoted vertex
+differs from the deleted vertex at coordinate `incDir a` (it drops by
+one, from a value `≥ 1`).  So the pivot is a genuinely different
+filling of the shared facet. -/
+theorem pivot_opposite_ne (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    (pivotSimplex s a b hb).verts a.succ ≠ s.verts a.succ := by
+  have hab : a ≠ b := pivot_ab_ne hb
+  intro h
+  have hpos : 1 ≤ (s.verts a.succ).coords (s.incDir a) := by
+    have := s.step_inc a; omega
+  have hcoord : ((pivotSimplex s a b hb).verts a.succ).coords (s.incDir a)
+      = (s.verts a.succ).coords (s.incDir a) := by rw [h]
+  have hval : (pivotSimplex s a b hb).verts a.succ = pivotPoint s a b hab := by
+    show Function.update s.verts a.succ (pivotPoint s a b hab) a.succ = _
+    rw [Function.update_self]
+  rw [hval, pivotPoint_coords_eq_incA s a b hab] at hcoord
+  omega
+
+/-- **The interior pivot is a different cell.**  Immediate from
+`pivot_opposite_ne`: equal simplices would have equal vertex
+functions, hence equal opposite vertices.  Together with
+`pivot_facet_eq` this is exactly the `GridSimplex`-level neighbour
+existence the search-based `adj` needs at chain-interior facets. -/
+theorem pivot_ne (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    pivotSimplex s a b hb ≠ s := by
+  intro h
+  exact pivot_opposite_ne s a b hb (by rw [h])
+
 end SpernerNDimOQ02

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -32,12 +32,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Phase-1 carrier + facet combinatorics VERIFIED 0-axiom, Session 11): CanonSimplex now has its full facet combinatorics (facet sets, card=d, facet_injective, not_mem_facet_iff), machine-checked 0-axiom on top of the BaryPoint≃Vertex bridge and geometry-uniqueness. Only the adj pivot function + its 5 compatibility fields + boundary_face remain for a full SpernerTriangulation instance. The open OQ target (boundary_doors_odd / last-face door oddness) is still unsolved.",
+    "progressSummary": "PROGRESS (interior Freudenthal pivot VERIFIED 0-axiom): the chain-interior facet neighbour now EXISTS as an honest GridSimplex (pivotSimplex) that shares the facet (pivot_facet_eq) and is a different cell (pivot_ne/pivot_opposite_ne) — the existence half boundary_face needs. Remaining for full adj: canonicalisation of the pivot into CanonSimplex, the two boundary-chain pivots, and the adj search itself. OQ target (last-face door oddness) still open.",
     "builtItems": [
       "proofs/Proofs/SpernerNDimOQ02.lean (facet combinatorics, VERIFIED 0-axiom Session 11: clean lake env lean build, #print axioms = [propext, Classical.choice, Quot.sound] only): facet s k := (univ.erase k).image (vertices s); mem_facet_iff; vertices_not_mem_facet (deleted vertex is the unique vertex absent from its facet); facet_card (each facet has exactly d vertices); facet_injective (the d+1 facets of a cell are distinct = within-cell half of adj_unique_facet); not_mem_facet_iff (facet+cell determine the removed index). Building blocks for the abstract adj_vertices/adj_unique_facet fields.",
       "proofs/Proofs/SpernerNDimOQ02.lean (Session 3, VERIFIED): baryEquivVertex d N : BaryPoint d N ≃ Vertex d N (toVertex drops last bary coord, toBary appends slack N-∑); coord simp lemmas; onFace_toVertex (face correspondence); isSperner_iff (transports Sperner condition). 0 sorries, 0 new axioms. This is Option C step 0.",
       "SpernerGridBase.lean: factored GridSimplex foundation (structure+DecidableEq+Fintype+verts_injective+coord trackers, SpernerGrid lines 241-513) into clean base — verified 0-axiom",
-      "SpernerGridBase.GridSimplex.incDir_const_before / last_coord_non_miss / last_coord_miss: every vertex = explicit fn of (verts 0, miss, incDir) — verified 0-axiom"
+      "SpernerGridBase.GridSimplex.incDir_const_before / last_coord_non_miss / last_coord_miss: every vertex = explicit fn of (verts 0, miss, incDir) — verified 0-axiom",
+      "proofs/Proofs/SpernerNDimOQ02.lean (VERIFIED 0-axiom): interior Freudenthal pivot — pivotPoint (opposite-corner vertex), pivotSimplex (full GridSimplex with all 5 Kuhn axioms via incDir∘swap a b + Function.update of the one moved vertex), pivot_facet_eq (deleted-vertex facet preserved), pivot_opposite_ne (moved vertex differs at incDir a), pivot_ne (different cell). #print axioms = [propext, Classical.choice, Quot.sound]."
     ],
     "insights": [
       "SpernerNDim.lean is complete (669 lines, 0 sorries): structure SpernerTriangulation (8 fields) + theorem sperner_ndim (line 654) which yields a fully-colored simplex from an odd count of last-face boundary doors. This is the exact finish line for sperner_grid.",
@@ -45,15 +46,17 @@
       "Coordinate bridge: abstract framework uses Vertex d N (Fin d -> N, sum<=N, Kuhn coords); SpernerGrid uses BaryPoint d N (Fin (d+1) -> N, sum=N). They are canonically isomorphic; proving BaryPoint d N ≃ Vertex d N (~30-50 lines, no adjacency) is the cleanest standalone first deliverable and unlocks reuse of the whole framework.",
       "Phase-1 instance must use unoriented Kuhn cells (base point + permutation of increment order, one representative per geometric cell). The Session-1 orientation-doubling bug came from carrying a free miss/orientation flag in GridSimplex; the instance must NOT.",
       "Session 5: representation A (GridSimplex subtype) preferred over Finset for the Phase-1 Simplex type — Finset does not dodge the canonical vertex-ordering obligation; IsCanon s := forall k, lex (s.verts 0) <= s.verts k is a simpler computable canonicality predicate (step_dec fixes chain direction from lex-min base).",
-      "Phase-1 GridSimplex-rep REQUIRES canonicalization: a facet-sharing dual graph over all GridSimplices breaks adj_unique_facet (a cell and its reverse share the same vertex set/facets). Cube-Kuhn lex-min-base uniqueness does NOT transfer (corner-simplex is not a union of full Kuhn cubes), so a separate IsCanon predicate is mandatory."
+      "Phase-1 GridSimplex-rep REQUIRES canonicalization: a facet-sharing dual graph over all GridSimplices breaks adj_unique_facet (a cell and its reverse share the same vertex set/facets). Cube-Kuhn lex-min-base uniqueness does NOT transfer (corner-simplex is not a union of full Kuhn cubes), so a separate IsCanon predicate is mandatory.",
+      "The chain-interior facet (delete vertex a.succ, 0<a.succ<d) always has a neighbour: swap the two consecutive increment steps a,b (b.castSucc=a.succ). Only the middle vertex moves to the opposite corner verts(a.castSucc)+e_{incDir b}-e_miss; the miss coordinate is untouched at every vertex (so step_dec is inherited verbatim), and only steps a,b have a moved endpoint. This is the GridSimplex-level EXISTENCE half of the search-based adj boundary_face obligation (an interior facet must have a partner).",
+      "Pitfall: subst hka with hka:k=a eliminates a (replacing a by k), not k — breaks references to the def binder a. Use rw [hka] (and rw [hka] at hjI ⊢) instead to keep a.",
+      "Pitfall: nat (x+1)+0 is defeq x+1, so rw/simp auto-closes such goals by rfl — a trailing omega then errors with No goals."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "DONE (#30819): CanonSimplex carrier + IsCanon (decidable) + per-geometry uniqueness (canon_eq_of_vertices_range)",
-      "DONE (#30873, VERIFIED 0-axiom Session 11): vertices := toVertex∘verts + vertices_injective; facet combinatorics (facet/facet_card/facet_injective/not_mem_facet_iff)",
-      "adj via finite facet-search over CanonSimplex; discharge 5 adjacency fields + boundary_face (adj_unique_facet from facet_injective+canon_eq_of_vertices_range; boundary_face via onFace_toVertex)",
-      "Phase 2: last-face-door-oddness by induction on d; apply sperner_ndim",
-      "Retire false boundary_doors_odd/boundary_verts_on_face"
+      "Canonicalise the pivot: build a CanonSimplex from any GridSimplex with the same vertex set (re-select lex-min base + reorder chain), so the interior neighbour lands back in the carrier; combine with pivot_facet_eq to get a canonical partner sharing facet (CanonSimplex level).",
+      "Boundary-chain pivots: handle deleted vertex a.succ = 0 (vertex index 0) and = d (Fin.last) — these change the base/miss and are the genuine boundary vs interior dichotomy.",
+      "Define adj by finite facet-search over CanonSimplex; discharge adj_symm/adj_vertices/adj_ne via facet_vertex_injective + pivot existence, boundary_face via (contrapositive) interior⟹pivot-partner.",
+      "Phase 2: last-face door oddness by induction on d; apply sperner_ndim."
     ]
   },
   "tags": [
@@ -72,7 +75,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.382Z",
-  "lastUpdate": "2026-06-27",
+  "lastUpdate": "2026-06-27T22:10:00.000Z",
   "significance": 8,
   "tractability": 6,
   "leanVerified": true,


### PR DESCRIPTION
## Summary

Advances **sperner-ndim-oq-02** (n-Dimensional Sperner: Boundary-Door Oddness by Dimensional Induction). The frontier is the abstract `SpernerTriangulation.adj` facet-adjacency field over the canonical Freudenthal carrier `CanonSimplex`. Its `boundary_face` obligation is, contrapositively, that an **interior facet must actually have a neighbouring cell**. This PR builds the geometric heart of that existence for the chain-interior facets — the **Freudenthal pivot**.

For a Kuhn cell `s` and two consecutive increment steps `a, b` (`a.succ = b.castSucc`), deleting the middle vertex `a.succ` leaves a `d`-vertex facet; the neighbour across it is obtained by swapping steps `a` and `b`, which moves only that one vertex to the opposite corner of the local square `verts(a.castSucc) → verts(a.succ) → verts(b.succ)`.

## What's proved (all 0-axiom)

- **`pivotSimplex`** — the neighbour as an honest `GridSimplex`: same base/`miss`, increment steps swapped (`incDir ∘ Equiv.swap a b`), the single vertex `a.succ` replaced by `pivotPoint` via `Function.update`. All five Kuhn axioms (`miss_ne_inc`, `step_inc`, `step_dec`, `step_same`, `inc_injective`) discharged. The `miss` coordinate is untouched at every vertex, so `step_dec` is inherited verbatim; only steps `a, b` have a moved endpoint.
- **`pivot_facet_eq`** — the `d` vertices off `a.succ` are untouched, so `s` and its pivot share the facet opposite `a.succ` (the `adj_vertices`-style common-face equality).
- **`pivot_opposite_ne`** — the pivoted vertex differs from the deleted one at coordinate `incDir a` (drops by one from a value `≥ 1`).
- **`pivot_ne`** — hence a genuinely different cell.

Supporting: `pivotPoint` + its three coordinate-evaluation lemmas, `Fin_castSucc_ne_succ`, `pivot_ab_ne`.

## Verification

`lake env lean Proofs/SpernerNDimOQ02.lean` builds clean (Docker build host is currently broken — meta.db I/O error — so the single-file `lake env lean` fallback was used over the cached Mathlib oleans).

```
'SpernerNDimOQ02.pivotSimplex'      depends on axioms: [propext, Classical.choice, Quot.sound]
'SpernerNDimOQ02.pivot_facet_eq'    depends on axioms: [propext, Classical.choice, Quot.sound]
'SpernerNDimOQ02.pivot_opposite_ne' depends on axioms: [propext, Classical.choice, Quot.sound]
'SpernerNDimOQ02.pivot_ne'          depends on axioms: [propext, Classical.choice, Quot.sound]
```

No `sorry`, no new `axiom`, no `native_decide`/`ofReduceBool`.

## Remaining for the full `adj`

- Canonicalise the pivot back into `CanonSimplex` (re-select lex-min base), combining with `pivot_facet_eq` to get a *canonical* partner sharing the facet.
- The two boundary-chain pivots (deleted vertex index `0` or `Fin.last d`).
- Define `adj` by finite facet-search and discharge its compatibility fields (`facet_vertex_injective` already supplies cross-cell/within-cell uniqueness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)