### PR TITLE
Enrich Galois group of Xⁿ−p: coprime sharpness & exact cubic order

### DIFF
--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-03/annotations.json
@@ -1,0 +1,130 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "inverse-galois-d4-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "context",
+    "title": "The metacyclic bracket and its coprime sharpness",
+    "content": "The parent entry bounds the order of Gal(Xⁿ−p/ℚ) by three divisibilities: n ∣ |Gal| (the radical kernel Cₙ from ⁿ√p ↦ ζₙᵃ·ⁿ√p), φ(n) ∣ |Gal| (the cyclotomic quotient (ℤ/n)ˣ from ζₙ ↦ ζₙᵇ), and |Gal| ∣ n! (the faithful action on the n roots, Gal ↪ Sₙ). The conjectured order under genericity is the holomorph order n·φ(n). This file asks: how tightly do the two lower factors combine, and when does that combination already reach n·φ(n) with no genericity hypothesis? The answer is the least common multiple — and equality with the product is exactly the coprime case.",
+    "mathContext": "$n \\mid |\\mathrm{Gal}|,\\ \\varphi(n) \\mid |\\mathrm{Gal}|,\\ |\\mathrm{Gal}| \\mid n! \\ \\Longrightarrow\\ \\mathrm{lcm}(n,\\varphi(n)) \\mid |\\mathrm{Gal}| \\le n!$",
+    "significance": "context",
+    "relatedConcepts": [
+      "metacyclic group",
+      "holomorph ℤ/n ⋊ (ℤ/n)ˣ",
+      "Kummer theory",
+      "cyclotomic extension",
+      "split exact sequence",
+      "least common multiple"
+    ],
+    "prerequisites": [
+      "Galois theory",
+      "group theory",
+      "cyclotomic fields",
+      "elementary number theory"
+    ]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "inverse-galois-d4-oq-02-oq-03",
+    "range": { "startLine": 42, "endLine": 47 },
+    "type": "technique",
+    "title": "Building on the verified parent lemmas",
+    "content": "The file imports the parent module Proofs.InverseGaloisD4OQ02, which supplies the three structural divisibilities as named, fully verified lemmas (n_dvd_gal_card, totient_dvd_gal_card, gal_card_dvd_factorial). Every result here is purely number-theoretic plumbing on top of those three inputs: no new Galois-theoretic content is introduced, only the arithmetic of combining and squeezing the divisibility bounds. The `open Polynomial` brings the X, C, and .Gal notation for the polynomial Xⁿ − C p into scope.",
+    "mathContext": "$\\texttt{Fintype.card}\\,(X^n - C(p:\\mathbb{Q}):\\mathbb{Q}[X]).\\mathrm{Gal} = |\\mathrm{Gal}(X^n - p/\\mathbb{Q})|$",
+    "significance": "technical",
+    "relatedConcepts": [
+      "splitting field",
+      "Polynomial.Gal",
+      "modular proof architecture"
+    ],
+    "prerequisites": [
+      "Lean 4",
+      "Mathlib",
+      "Galois group of a polynomial"
+    ]
+  },
+  {
+    "id": "ann-lcm-bound",
+    "proofId": "inverse-galois-d4-oq-02-oq-03",
+    "range": { "startLine": 49, "endLine": 59 },
+    "type": "insight",
+    "title": "lcm, not product: the sharp combination of two divisibilities",
+    "content": "Two independent statements a ∣ N and b ∣ N do not give ab ∣ N — they give lcm(a, b) ∣ N, the smallest number both divide that must therefore divide N. The whole proof is a one-line application of Nat.lcm_dvd to the parent's n ∣ |Gal| and φ(n) ∣ |Gal|. The lcm is genuinely weaker than the product whenever n and φ(n) share a prime: for n = 4, φ(4) = 2, lcm(4, 2) = 4, so the bracket gives only 4 ∣ |Gal| even though the true order is 8. Recognising that the correct merge is lcm — not the optimistic product — is the conceptual heart of the entry.",
+    "mathContext": "$a \\mid N \\wedge b \\mid N \\Rightarrow \\mathrm{lcm}(a,b) \\mid N;\\quad \\mathrm{lcm}(4,2)=4 \\neq 8 = 4\\cdot 2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "least common multiple",
+      "divisibility lattice",
+      "Nat.lcm_dvd",
+      "greatest common divisor"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "lcm and gcd"
+    ]
+  },
+  {
+    "id": "ann-coprime",
+    "proofId": "inverse-galois-d4-oq-02-oq-03",
+    "range": { "startLine": 61, "endLine": 74 },
+    "type": "insight",
+    "title": "Coprimality forces the full metacyclic order for free",
+    "content": "When gcd(n, φ(n)) = 1 the identity lcm(n, φ(n)) = n·φ(n) holds (Nat.Coprime.lcm_eq_mul), so the lcm bound upgrades instantly to the full holomorph order n·φ(n) ∣ |Gal|. The striking point is that this lower bound needs NO genericity / linear-disjointness assumption — the assumption is only required for the matching upper bound |Gal| ≤ n·φ(n). So under coprimality the conjectured order is at least half-confirmed unconditionally: the bracket already certifies the full metacyclic order divides |Gal|.",
+    "mathContext": "$\\gcd(n,\\varphi(n))=1 \\Rightarrow \\mathrm{lcm}(n,\\varphi(n)) = n\\,\\varphi(n) \\Rightarrow n\\,\\varphi(n) \\mid |\\mathrm{Gal}|$",
+    "significance": "key",
+    "relatedConcepts": [
+      "coprime integers",
+      "Nat.Coprime.lcm_eq_mul",
+      "Euler totient",
+      "metacyclic order",
+      "unconditional lower bound"
+    ],
+    "prerequisites": [
+      "coprimality",
+      "Euler's totient function",
+      "lcm = product / gcd"
+    ]
+  },
+  {
+    "id": "ann-six-dvd-cubic",
+    "proofId": "inverse-galois-d4-oq-02-oq-03",
+    "range": { "startLine": 76, "endLine": 87 },
+    "type": "technique",
+    "title": "The cubic instance: 6 ∣ |Gal(X³−p)| for every prime p",
+    "content": "Specialising the coprime theorem to n = 3 needs only the decidable facts gcd(3, φ(3)) = gcd(3, 2) = 1 and 3·φ(3) = 6, both discharged by kernel `decide` (not native_decide — so no Lean.ofReduceBool, and the result stays axiom-free). The conclusion 6 ∣ |Gal(X³−p/ℚ)| is uniform in p: it holds for X³−2, X³−3, X³−5, and every other prime, because the coprime lower bound is a structural feature of n = 3, independent of which prime sits inside the radical.",
+    "mathContext": "$\\gcd(3,\\varphi(3))=\\gcd(3,2)=1,\\ 3\\cdot\\varphi(3)=6 \\ \\Rightarrow\\ 6 \\mid |\\mathrm{Gal}(X^3-p/\\mathbb{Q})|$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "kernel decide",
+      "totient of a prime",
+      "uniformity in p",
+      "axiom-free verification"
+    ],
+    "prerequisites": [
+      "Euler's totient",
+      "decidable propositions in Lean"
+    ]
+  },
+  {
+    "id": "ann-cubic-exact",
+    "proofId": "inverse-galois-d4-oq-02-oq-03",
+    "range": { "startLine": 89, "endLine": 102 },
+    "type": "insight",
+    "title": "The squeeze: |Gal(X³−p)| = 6 = |S₃| exactly",
+    "content": "Because 3·φ(3) = 6 happens to equal 3! = 6, the coprime lower bound 6 ∣ |Gal| meets the parent's upper bound |Gal| ∣ 3! head-on. Nat.dvd_antisymm (mutual divisibility forces equality) then pins |Gal(X³−p/ℚ)| = 6 = |S₃| for every prime p — the cubic Galois group is always the full symmetric group S₃. This is the cubic analogue of the base entry's |Gal(X⁴−2)| = 8, but where the quartic needed a bespoke ℝ-embedding argument, the cubic falls out of pure divisibility: the squeeze closes precisely because n = 3 is one of the few n with n·φ(n) = n!.",
+    "mathContext": "$6 \\mid |\\mathrm{Gal}| \\ \\wedge\\ |\\mathrm{Gal}| \\mid 3! = 6 \\ \\Rightarrow\\ |\\mathrm{Gal}(X^3-p/\\mathbb{Q})| = 6 = |S_3|$",
+    "significance": "key",
+    "relatedConcepts": [
+      "antisymmetry of divisibility",
+      "Nat.dvd_antisymm",
+      "symmetric group S₃",
+      "squeeze / sandwich argument",
+      "factorial"
+    ],
+    "prerequisites": [
+      "divisibility antisymmetry",
+      "symmetric groups",
+      "order of a finite group"
+    ]
+  }
+]

--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-03/meta.json
@@ -74,6 +74,43 @@
       "**Why n = 4 needed extra work**: For n = 4 the factors overlap (gcd(4, 2) = 2 ≠ 1, lcm = 4), so the divisibility bracket alone gives only 4 ∣ |Gal| ∣ 24 — it cannot distinguish |Gal| = 8 from other multiples of 4. This is precisely why the base D₄ entry required a separate ℝ-embedding argument that the cubic case avoids."
     ]
   },
+  "sections": [
+    {
+      "id": "overview-docstring",
+      "title": "Overview: combining and sharpening the divisibility bracket",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring recalling the parent's three divisibilities (n ∣ |Gal|, φ(n) ∣ |Gal|, |Gal| ∣ n!) and stating the goal: merge the two lower factors into lcm(n, φ(n)), upgrade to the full product n·φ(n) under coprimality, and pin the cubic order |Gal(X³−p)| = 6 exactly."
+    },
+    {
+      "id": "imports-setup",
+      "title": "Imports and namespace",
+      "startLine": 42,
+      "endLine": 47,
+      "summary": "Imports Mathlib and the parent module Proofs.InverseGaloisD4OQ02 (source of the three verified divisibility lemmas), opens the InverseGaloisExtensions namespace and Polynomial notation."
+    },
+    {
+      "id": "part-i-lcm",
+      "title": "Part I — the combined lower bound lcm(n, φ(n)) ∣ |Gal|",
+      "startLine": 49,
+      "endLine": 59,
+      "summary": "lcm_dvd_gal_card: a one-line Nat.lcm_dvd over the parent's n ∣ |Gal| and φ(n) ∣ |Gal|. The sharp common consequence is the lcm, not the product, since n and φ(n) may share prime factors."
+    },
+    {
+      "id": "part-ii-coprime",
+      "title": "Part II — coprime sharpness forces n·φ(n) ∣ |Gal|",
+      "startLine": 61,
+      "endLine": 74,
+      "summary": "mul_totient_dvd_gal_card_of_coprime: when gcd(n, φ(n)) = 1, Nat.Coprime.lcm_eq_mul rewrites lcm(n, φ(n)) to n·φ(n), so the full metacyclic order divides |Gal| with no genericity hypothesis."
+    },
+    {
+      "id": "part-iii-cubic",
+      "title": "Part III — the sharp cubic witness |Gal(X³−p)| = 6",
+      "startLine": 76,
+      "endLine": 102,
+      "summary": "six_dvd_gal_card_cubic specialises the coprime theorem to n = 3 (gcd(3, 2) = 1, 3·φ(3) = 6 by decide); gal_card_cubic_eq_six squeezes 6 ∣ |Gal| against |Gal| ∣ 3! = 6 via Nat.dvd_antisymm to pin |Gal(X³−p/ℚ)| = 6 = |S₃| for every prime p."
+    }
+  ],
   "conclusion": {
     "summary": "Combined the parent's two lower divisibilities into lcm(n, φ(n)) ∣ |Gal(Xⁿ−p/ℚ)|, and proved that gcd(n, φ(n)) = 1 forces the full metacyclic order n·φ(n) ∣ |Gal| with no genericity hypothesis. The cubic case is sharp: |Gal(X³−p/ℚ)| = 6 = |S₃| for every prime p, squeezed between the coprime lower bound 6 ∣ |Gal| and the parent's upper bound |Gal| ∣ 3! = 6. 4 theorems, 0 sorries, 0 axioms.",
     "implications": "Identifies the exact regime in which the verified divisibility bracket already determines the Galois order without the unproven genericity/linear-disjointness hypothesis: precisely when gcd(n, φ(n)) = 1 and n·φ(n) = n! (the cubic). It also explains structurally why n = 4 fell outside that regime and needed the base entry's separate argument, sharpening the picture of what the metacyclic bracket can and cannot decide on its own.",


### PR DESCRIPTION
Enrichment pass for `inverse-galois-d4-oq-02-oq-03` (quality 33, pass 0). The entry had a rich meta overview but was **missing both `annotations.json` and a `sections` array**.

## Changes
- **`annotations.json` (new, 6 annotations)** — each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: overview, imports, the lcm bound (*lcm, not product*: lcm(4,2)=4≠8), coprime sharpness (full metacyclic order with no genericity), the cubic 6 ∣ |Gal(X³−p)| (kernel `decide`, axiom-free), and the squeeze |Gal(X³−p)| = 6 = |S₃|.
- **`sections` array (new, 5 sections)** covering the full 102-line Lean file.

## Integrity
No mathematical claims, `status`, `badge`, or `axiomCount` altered — remains `verified`, 0 axioms (kernel `decide`, no `Lean.ofReduceBool`). meta.json 11.9 KB, under all caps. JSON validated; gallery enrichment phase of `pnpm build` reads the entry without error.