### PR TITLE
Enrich Erdős #1012 OQ-02-OQ-01: bipartite exception necessity (add annotations)

### DIFF
--- a/src/data/proofs/erdos-1012-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1012-oq-02-oq-01/annotations.json
@@ -1,0 +1,143 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "erdos-1012-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "context",
+    "title": "Why the bipartite exception must be necessary",
+    "content": "Bondy's vertex-pancyclicity theorem (1971) says a graph on n vertices with ≥ n²/4 + 1 edges is either vertex-pancyclic or the balanced complete bipartite graph K_{⌊n/2⌋,⌈n/2⌉}. The parent entry axiomatizes this as bondy_vertex_pancyclic but never inhabits the exception branch — leaving open whether it is vacuous. If it were, Bondy's theorem would collapse to the cleaner 'enough edges ⟹ vertex-pancyclic'. This file forecloses that: it exhibits the complete bipartite graph as a concrete near-extremal graph that genuinely fails (vertex-)pancyclicity yet matches the exception predicate exactly. The balanced K_{m,m} on n = 2m vertices has exactly m² = ⌊n²/4⌋ edges — one short of the threshold — which is precisely why it survives as the extremal obstruction.",
+    "mathContext": "$|E| \\ge \\tfrac{n^2}{4} + 1 \\;\\Rightarrow\\; \\text{vertex-pancyclic} \\;\\vee\\; G \\cong K_{\\lfloor n/2\\rfloor,\\lceil n/2\\rceil}$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Bondy's pancyclicity theorem",
+      "extremal graph theory",
+      "complete bipartite graph",
+      "necessity of an exception",
+      "sharp edge threshold"
+    ],
+    "prerequisites": [
+      "graph theory",
+      "cycles and pancyclicity",
+      "extremal combinatorics"
+    ]
+  },
+  {
+    "id": "ann-self-containment",
+    "proofId": "erdos-1012-oq-02-oq-01",
+    "range": { "startLine": 42, "endLine": 52 },
+    "type": "context",
+    "title": "Self-containment against Mathlib drift",
+    "content": "The cycle/pancyclicity predicates are re-declared verbatim from the parent rather than imported, because the parent Erdos1012OQ02 does not compile against the pinned Mathlib v4.26.0 (it uses the renamed Finset.card_Icc and the deprecated Set.ncard_coe_Finset). Re-declaring keeps this contribution fully machine-checked and insulated from that drift, at the cost of a small duplication — a deliberate trade favoring verifiability. The parent's compile failure is flagged separately for repair.",
+    "mathContext": "Parent drift: `Finset.card_Icc` → `Nat.card_Icc`, `Set.ncard_coe_Finset` deprecated.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Mathlib version pinning",
+      "self-contained formalization",
+      "API drift"
+    ],
+    "prerequisites": [
+      "Lean 4",
+      "Mathlib"
+    ]
+  },
+  {
+    "id": "ann-predicates",
+    "proofId": "erdos-1012-oq-02-oq-01",
+    "range": { "startLine": 62, "endLine": 86 },
+    "type": "definition",
+    "title": "Pancyclicity predicates as a length window 3..m",
+    "content": "Five nested predicates build up the notion. hasCycleThroughVertex G v l asserts a cycle of length l through v; hasCycleOfLength G l existentially quantifies the vertex; isPancyclicUpTo G m requires a cycle of every length 3 ≤ l ≤ m; isVertexPancyclicUpTo G v m requires v to lie on cycles of every such length; and isVertexPancyclicGraphUpTo G m demands this of every vertex. The window deliberately starts at 3 — the shortest possible cycle — which is exactly the length where a triangle-free graph fails, so length 3 is the only case the obstruction needs to defeat.",
+    "mathContext": "$\\text{vertex-pancyclic}_{\\le m}(G) \\;\\equiv\\; \\forall v,\\ \\forall l \\in [3,m],\\ \\exists\\,\\text{cycle of length } l \\text{ through } v$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pancyclic graph",
+      "girth",
+      "cycle length spectrum",
+      "SimpleGraph.Walk.IsCycle"
+    ],
+    "prerequisites": [
+      "simple graphs",
+      "walks and cycles in Lean"
+    ]
+  },
+  {
+    "id": "ann-no-triangle",
+    "proofId": "erdos-1012-oq-02-oq-01",
+    "range": { "startLine": 87, "endLine": 102 },
+    "type": "technique",
+    "title": "Triangle-freeness by same-side pigeonhole",
+    "content": "The keystone lemma: no three vertices a, b, c of V ⊕ W are cyclically pairwise adjacent. Adjacency in completeBipartiteGraph holds only across sides, so a~b and b~c push a and c both to the side opposite b — the same side as each other — making c~a impossible. In Lean this is the entire proof: unfold completeBipartiteGraph_adj, then `cases a <;> cases b <;> cases c <;> simp_all` exhausts the 2³ = 8 side-assignments, all contradictory. This is the structural reason a bipartite graph has no odd cycle, specialized to length 3.",
+    "mathContext": "$\\mathrm{Adj}(a,b) \\Leftrightarrow \\mathrm{side}(a) \\ne \\mathrm{side}(b);\\ \\text{3 vertices, 2 sides} \\Rightarrow \\text{two share a side} \\Rightarrow \\text{non-adjacent}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "bipartite = no odd cycle",
+      "completeBipartiteGraph_adj",
+      "case exhaustion"
+    ],
+    "prerequisites": [
+      "bipartite graphs",
+      "Sum type case analysis"
+    ]
+  },
+  {
+    "id": "ann-no-3cycle",
+    "proofId": "erdos-1012-oq-02-oq-01",
+    "range": { "startLine": 104, "endLine": 124 },
+    "type": "technique",
+    "title": "Short closed walk ⟹ triangle, via getVert",
+    "content": "Lifting triangle-freeness to 'no vertex on a 3-cycle' avoids inducting on the Walk structure. A closed walk of length 3 has vertices getVert 0, 1, 2, 3 with getVert 0 = getVert 3 = v (getVert_zero and getVert_length). The three consecutive adjacencies come from adj_getVert_succ at i = 0, 1, 2; rewriting the endpoints back to v assembles exactly the triangle v~x, x~y, y~v that completeBipartite_no_triangle forbids. Notably the IsCycle hypothesis is discarded (`rintro ⟨w, -, hlen⟩`) — *any* closed walk of length 3 is already excluded, a stronger statement than just ruling out cycles.",
+    "mathContext": "$w(0)=w(3)=v,\\ w(i)\\sim w(i{+}1)\\ (i=0,1,2)\\ \\Rightarrow\\ v\\sim x\\sim y\\sim v$",
+    "significance": "key",
+    "relatedConcepts": [
+      "SimpleGraph.Walk.getVert",
+      "adj_getVert_succ",
+      "closed walk",
+      "avoiding structural induction"
+    ],
+    "prerequisites": [
+      "walks in SimpleGraph",
+      "Lean tactic rintro"
+    ]
+  },
+  {
+    "id": "ann-not-pancyclic",
+    "proofId": "erdos-1012-oq-02-oq-01",
+    "range": { "startLine": 126, "endLine": 146 },
+    "type": "insight",
+    "title": "Failure of pancyclicity at the first window step",
+    "content": "Both negative results follow immediately once the length window reaches 3. completeBipartite_not_pancyclic instantiates the pancyclicity hypothesis at l = 3 to extract a 3-cycle, contradicting completeBipartite_no_3cycle. completeBipartite_not_vertexPancyclic needs only a single witness — any left vertex Sum.inl v (using [Nonempty V]) lies on no 3-cycle, so the universal 'every vertex is vertex-pancyclic' fails. The graph fails at the very shortest length the window opens with, the sharpest possible failure.",
+    "mathContext": "$\\neg\\,\\mathrm{hasCycleOfLength}\\,3 \\;\\Rightarrow\\; \\neg\\,\\text{pancyclic}_{\\le m}\\ (m \\ge 3)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "proof by single counterexample",
+      "Nonempty typeclass",
+      "vertex-pancyclicity"
+    ],
+    "prerequisites": [
+      "logical negation of quantifiers",
+      "Lean instance arguments"
+    ]
+  },
+  {
+    "id": "ann-bondy-exception",
+    "proofId": "erdos-1012-oq-02-oq-01",
+    "range": { "startLine": 148, "endLine": 172 },
+    "type": "insight",
+    "title": "Realizing Bondy's exception predicate exactly",
+    "content": "The final theorem matches the *exact* structural predicate of the parent's axiom: ∃ A B, A ∪ B = univ ∧ Disjoint A B ∧ ∀ a∈A b∈B, Adj a b. Taking A = left vertices (isLeft) and B = right vertices (isRight), the three obligations are discharged by case analysis on the Sum tag: union is univ (every vertex is left or right), disjointness (none is both), and every cross pair adjacent (left–right is exactly the bipartite adjacency). Combined with the non-vertex-pancyclicity above, this proves branch (b) of Bondy's disjunction is genuinely inhabited by a non-vertex-pancyclic graph — so the exception is necessary and the n²/4 + 1 threshold is sharp.",
+    "mathContext": "$A = \\{x : x.\\mathrm{isLeft}\\},\\ B = \\{x : x.\\mathrm{isRight}\\}:\\ A \\cup B = \\mathrm{univ},\\ A \\cap B = \\varnothing,\\ \\forall a\\in A, b\\in B,\\ a \\sim b$",
+    "significance": "key",
+    "relatedConcepts": [
+      "bipartition",
+      "Finset.filter",
+      "Disjoint",
+      "matching an axiom's hypothesis",
+      "sharpness witness"
+    ],
+    "prerequisites": [
+      "Finset operations",
+      "Sum.isLeft / isRight"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-1012-oq-02-oq-01` (quality 33, pass 0). The entry already had 7 sections, 4 keyInsights, and a conclusion but was **missing `annotations.json`**.

## Changes
- **`annotations.json` (new, 7 annotations)** — each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. Why the bipartite exception must be necessary (Bondy 1971, the n²/4+1 threshold)
  2. Self-containment vs the parent's Mathlib-v4.26.0 drift
  3. The five pancyclicity predicates as a length window 3..m
  4. Triangle-freeness by same-side pigeonhole (the keystone lemma)
  5. Short closed walk ⟹ triangle via `getVert` / `adj_getVert_succ`
  6. Failure of (vertex-)pancyclicity at the first window step
  7. Realizing Bondy's exception predicate exactly (left/right bipartition)

## Integrity
No mathematical claims, `status`, `badge`, or `axiomCount` altered — remains `verified`, 0 axioms. JSON validated; gallery enrichment phase of `pnpm build` reads the entry without error.