### PR TITLE
Enrich Erdős #441 axiom-free lower bound (erdos-441-incomplete-01)

### DIFF
--- a/src/data/proofs/erdos-441-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-441-incomplete-01/meta.json
@@ -99,9 +99,18 @@
       "id": "section-lower-bound",
       "title": "§ The unconditional lower bound",
       "startLine": 105,
-      "endLine": 145,
-      "summary": "g_ge_sqrt: ⌊√N⌋ ≤ g(N) via le_csSup applied to the witness. g_ge_one: g(N) ≥ 1 for N ≥ 1. g_ge_sqrt_real: (g N : ℝ) ≥ √N − 1 by bounding √N ≤ ⌊√N⌋ + 1.",
+      "endLine": 154,
+      "summary": "g_ge_sqrt: ⌊√N⌋ ≤ g(N) via le_csSup applied to the witness. g_ge_one: g(N) ≥ 1 for N ≥ 1. g_ge_sqrt_real: (g N : ℝ) ≥ √N − 1 by bounding √N ≤ ⌊√N⌋ + 1. Closes with a summary docstring recording the axiom-free status and the relationship to the parent's Chen–Dai axioms.",
       "mathContext": "g(N) ≥ ⌊√N⌋, hence g(N) = Θ(√N) — with no axioms."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "Extracts and fully machine-checks the axiom-free core of Erdős #441: the unconditional lower bound g(N) ≥ ⌊√N⌋ (real form (g N : ℝ) ≥ √N − 1), where g(N) is the largest A ⊆ {1,...,N} with all pairwise lcm(a,b) ≤ N. The witness is the initial segment {1,...,⌊√N⌋}, whose pairwise lcms satisfy lcm(a,b) ≤ a·b ≤ ⌊√N⌋² ≤ N. This already pins the correct order of magnitude g(N) = Θ(√N). 6 theorems, 5 definitions, 0 sorries, 0 axioms.",
+    "implications": "Cleanly separates the elementary, machine-checkable content of Erdős #441 from the deep Chen–Dai analytic number theory that the parent entry records as axioms. The order of magnitude Θ(√N) needs none of that machinery — only the one-line divisibility fact lcm(a,b) ≤ a·b and the simplest possible witness set. The sharp constant (9/8)^{1/2} ≈ 1.0607 is a mere ~6% improvement over the trivial constant 1 proved here, quantifying exactly how much of the problem is 'hard'. The le_csSup-from-a-witness pattern (turning a concrete admissible set into a lower bound on a conditional supremum) is reusable for any extremal-cardinality problem.",
+    "openQuestions": [
+      "Discharge the parent's construction_gives_lower_bound sorry by formalizing Erdős' two-part construction (initial segment up to (N/2)^{1/2} plus even numbers up to (2N)^{1/2}); the crude lcm ≤ product bound already handles the cross-terms and first part, leaving the factor-2 saving for even–even pairs.",
+      "Prove an unconditional upper bound g(N) ≤ C√N to make g(N) = Θ(√N) axiom-free in both directions, not just the lower half.",
+      "Recover the sharp constant (9/8)^{1/2} elementarily by computing the exact cardinality of Erdős' construction, narrowing the gap to the axiomatized Chen–Dai asymptotic."
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `erdos-441-incomplete-01` (passes: 0, quality: 78 → 93).

## Gap addressed
The quality breakdown showed `conclusion: 0` — the entry had rich overview, annotations, sections, and cross-references but **no `conclusion` field**.

- **Added `conclusion`** with `summary`, `implications`, and 3 `openQuestions` (discharge the parent's construction sorry, prove an unconditional upper bound, recover the sharp (9/8)^{1/2} constant).
- **Extended** the final section's `endLine` to 154 so the sections cover the trailing summary docstring (full-file coverage).

## Verification
- `meta.json` within the 60 KB cap.
- Quality score 78 → 93 (conclusion now scores 15/15).
- `pnpm build` passes (✓ built).
- No axiom/status changes; existing verified/0-axiom claims intact.