### PR TITLE
Enrich Erdős #835 surjective-colouring consequence (erdos-835-incomplete-01)

### DIFF
--- a/src/data/proofs/erdos-835-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-835-incomplete-01/annotations.json
@@ -2,14 +2,26 @@
   {
     "id": "erdos835-inc01-ann-defs",
     "proofId": "erdos-835-incomplete-01",
-    "range": { "startLine": 1, "endLine": 76 },
+    "range": { "startLine": 53, "endLine": 71 },
     "type": "definition",
     "title": "The Erdős–Rosenfeld Property, Re-declared",
-    "content": "Erdős Problem #835 asks whether for some k > 2 the k-subsets of {1,…,2k} admit a (k+1)-colouring that is 'rainbow' on every (k+1)-subset — equivalently whether the Johnson graph J(2k,k) has chromatic number k+1 (answer: NO for 3 ≤ k ≤ 8). Because the scaffold Erdos835Problem.lean fails to parse on the pinned toolchain, this file re-declares the definitions verbatim: `baseSet n` = {1,…,n}, `kSubsets n k` = the subtype of k-element subsets, `hasErdosRosenfeldProperty` (every (k+1)-subset A sees all k+1 colours among its k-subsets), and `ErdosRosenfeldQuestion`. `baseSet_card` supplies the elementary count |{1,…,n}| = n via card_map + card_range.",
-    "mathContext": "$\\mathrm{baseSet}(n) = \\{1,\\dots,n\\}, \\quad |\\mathrm{baseSet}(n)| = n; \\quad \\chi(J(2k,k)) \\overset{?}{=} k+1.$",
+    "content": "Erdős Problem #835 asks whether for some k > 2 the k-subsets of {1,…,2k} admit a (k+1)-colouring that is 'rainbow' on every (k+1)-subset — equivalently whether the Johnson graph J(2k,k) has chromatic number k+1 (answer: NO for 3 ≤ k ≤ 8). Because the scaffold Erdos835Problem.lean fails to parse on the pinned toolchain, this file re-declares the definitions verbatim: `baseSet n` = {1,…,n} (the range {0,…,n−1} mapped by +1), `kSubsets n k` = the subtype of k-element subsets of baseSet n, `hasErdosRosenfeldProperty` (every (k+1)-subset A of {1,…,2k} sees all k+1 colours among its k-subsets), and `ErdosRosenfeldQuestion` (existence of such a colouring).",
+    "mathContext": "$\\text{property}: \\forall A \\subseteq \\{1,\\dots,2k\\},\\ |A|=k+1,\\ \\forall c,\\ \\exists S \\subseteq A,\\ |S|=k,\\ \\chi(S)=c.$",
     "significance": "key",
     "relatedConcepts": ["Johnson graph", "chromatic number", "k-subset colouring", "Erdős problems"],
     "prerequisites": ["Finset", "subtypes", "graph colouring"]
+  },
+  {
+    "id": "erdos835-inc01-ann-baseset-card",
+    "proofId": "erdos-835-incomplete-01",
+    "range": { "startLine": 73, "endLine": 76 },
+    "type": "technique",
+    "title": "The Base-Set Count |{1,…,n}| = n",
+    "content": "baseSet_card proves the elementary count |baseSet n| = n that the scaffold omitted. Since baseSet n is the range {0,…,n−1} mapped by the injective (· + 1), its cardinality is preserved (Finset.card_map) and equals card_range n = n. Trivial as it is, this count is load-bearing: it is exactly what lets the surjectivity proof exhibit a (k+1)-subset inside the 2k-element ground set when k+1 ≤ 2k.",
+    "mathContext": "$|\\mathrm{baseSet}(n)| = |\\mathrm{range}(n)| = n$ (card preserved under the injective $\\cdot+1$).",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.card_map", "Finset.card_range", "injective map"],
+    "prerequisites": ["Finset cardinality"]
   },
   {
     "id": "erdos835-inc01-ann-surjective",
@@ -26,13 +38,25 @@
   {
     "id": "erdos835-inc01-ann-corollaries",
     "proofId": "erdos-835-incomplete-01",
-    "range": { "startLine": 92, "endLine": 127 },
+    "range": { "startLine": 92, "endLine": 106 },
     "type": "theorem",
     "title": "Range and Question Corollaries",
-    "content": "Two corollaries package the consequence. `erdosRosenfeld_range_univ`: the range of an Erdős–Rosenfeld colouring is all of Fin(k+1) (via `Function.Surjective.range_eq`), so exactly k+1 colours are used. `erdosRosenfeldQuestion_surjective`: a positive answer to the question for k ≥ 1 yields a surjective (k+1)-colouring. Together these pin the 'lower side' of the equivalence property ⇔ χ(J(2k,k)) = k+1 — a valid colouring cannot waste any colour, which is exactly why the obstruction (χ > k+1 for k ≥ 3) is about packing all colours rainbow-style on every window rather than mere properness.",
+    "content": "Two corollaries package the consequence. `erdosRosenfeld_range_univ`: the range of an Erdős–Rosenfeld colouring is all of Fin(k+1) (via `Function.Surjective.range_eq`), so exactly k+1 colours are used. `erdosRosenfeldQuestion_surjective`: a positive answer to the question for k ≥ 1 yields a surjective (k+1)-colouring (destructure the existential, reuse the surjectivity theorem).",
     "mathContext": "$\\mathrm{range}\\,\\chi = \\mathrm{Fin}(k+1); \\qquad \\mathrm{ErdosRosenfeldQuestion}(k) \\implies \\exists \\chi\\ \\text{surjective}.$",
     "significance": "key",
     "relatedConcepts": ["range = univ", "equivalence to chromatic number", "Johnson graph colouring"],
     "prerequisites": ["surjectivity", "Function.Surjective.range_eq"]
+  },
+  {
+    "id": "erdos835-inc01-ann-significance",
+    "proofId": "erdos-835-incomplete-01",
+    "range": { "startLine": 108, "endLine": 125 },
+    "type": "context",
+    "title": "Why surjectivity is the 'lower side' of the equivalence",
+    "content": "The closing docstring frames the result against the full problem. The surjectivity consequence pins the lower side of the equivalence property ⇔ χ(J(2k,k)) = k+1: a valid colouring cannot waste any of the k+1 colours, since a single (k+1)-window already forces all of them. This is why the obstruction (χ > k+1 for k ≥ 3) is genuinely about packing all colours rainbow-style on every window, not mere properness. The open combinatorial heart — the existence (k=2) and non-existence (3 ≤ k ≤ 8) of such colourings — is exactly what the scaffold's two sorries stand in for.",
+    "mathContext": "$\\text{property} \\implies \\text{all } k+1 \\text{ colours used}$; obstruction is rainbow-packing, not properness.",
+    "significance": "context",
+    "relatedConcepts": ["chromatic number equivalence", "rainbow colouring", "open problem framing"],
+    "prerequisites": ["graph colouring", "chromatic number"]
   }
 ]

--- a/src/data/proofs/erdos-835-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-835-incomplete-01/meta.json
@@ -59,20 +59,52 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header: the Problem and Scope",
+      "summary": "Docstring stating Erdős #835 (does some k>2 admit a (k+1)-colouring of the k-subsets of {1,...,2k} rainbow on every (k+1)-subset; equivalently χ(J(2k,k))=k+1; answer NO for 3≤k≤8), the scaffold's two sorries, and the unconditional surjectivity result proved here.",
+      "startLine": 3,
+      "endLine": 45,
+      "mathContext": "Erdős #835: ∃ k>2, χ(J(2k,k)) = k+1?  (answer NO for 3 ≤ k ≤ 8)."
+    },
+    {
       "id": "definitions",
       "title": "The Erdős #835 Definitions (re-declared)",
-      "summary": "baseSet, kSubsets, hasErdosRosenfeldProperty, ErdosRosenfeldQuestion, re-declared because the scaffold fails to parse, plus baseSet_card.",
-      "startLine": 1,
-      "endLine": 75,
-      "mathContext": "The k-subsets of {1,...,n} as a subtype; the property quantifies all-colours-appear over every (k+1)-subset; |{1,...,n}| = n."
+      "summary": "baseSet n = {1,...,n} (range mapped by +1), kSubsets n k (the k-element subsets as a subtype), hasErdosRosenfeldProperty (every (k+1)-subset sees all k+1 colours among its k-subsets), and ErdosRosenfeldQuestion. Re-declared verbatim because the scaffold Erdos835Problem.lean fails to parse on the pinned toolchain.",
+      "startLine": 53,
+      "endLine": 71,
+      "mathContext": "hasErdosRosenfeldProperty: ∀ A ⊆ {1,...,2k}, |A| = k+1, ∀ c, ∃ S ⊆ A, |S| = k, χ(S) = c."
+    },
+    {
+      "id": "baseset-card",
+      "title": "The Base-Set Count",
+      "summary": "baseSet_card: |{1,...,n}| = n, via Finset.card_map and Finset.card_range — the elementary count the scaffold omitted, needed to exhibit a (k+1)-subset of the 2k-element ground set.",
+      "startLine": 73,
+      "endLine": 76,
+      "mathContext": "|baseSet(n)| = |range(n)| = n."
     },
     {
       "id": "surjectivity",
       "title": "The Property Forces a Surjective Colouring",
-      "summary": "erdosRosenfeld_surjective, erdosRosenfeld_range_univ, erdosRosenfeldQuestion_surjective — every colour is used.",
-      "startLine": 76,
-      "endLine": 127,
-      "mathContext": "A (k+1)-subset A of {1,...,2k} exists for k>=1; the property gives a k-subset of A of every colour, so the colouring is surjective."
+      "summary": "erdosRosenfeld_surjective: for k≥1, a colouring with the Erdős–Rosenfeld property is surjective onto Fin(k+1). Pick any (k+1)-subset A of {1,...,2k} (exists since k+1≤2k, via Finset.exists_subset_card_eq + baseSet_card + omega); the property hands back, for every colour c, a k-subset of A coloured c.",
+      "startLine": 78,
+      "endLine": 90,
+      "mathContext": "k ≥ 1, property ⟹ χ surjective onto Fin(k+1)."
+    },
+    {
+      "id": "corollaries",
+      "title": "Range and Question Corollaries",
+      "summary": "erdosRosenfeld_range_univ: the range of an Erdős–Rosenfeld colouring is all of Fin(k+1) (Function.Surjective.range_eq), so exactly k+1 colours are used. erdosRosenfeldQuestion_surjective: a positive answer to the question for k≥1 yields a surjective (k+1)-colouring.",
+      "startLine": 92,
+      "endLine": 106,
+      "mathContext": "range χ = Fin(k+1);  ErdosRosenfeldQuestion(k) ⟹ ∃ χ surjective."
+    },
+    {
+      "id": "significance",
+      "title": "Significance",
+      "summary": "Closing docstring: the surjectivity consequence pins the 'lower side' of the equivalence property ⇔ χ(J(2k,k))=k+1 — a valid colouring cannot waste a colour — leaving the existence/non-existence of such colourings (the scaffold's sorries) as the open combinatorial heart.",
+      "startLine": 108,
+      "endLine": 125,
+      "mathContext": "property ⟹ all k+1 colours used: the colour-exhausting lower half of the χ equivalence."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-835-incomplete-01` (passes: 0, quality: 79 → 98).

## Gaps addressed
The quality breakdown showed `sections: 4` (only 2 coarse sections) and `annotations: 15` (only 3).

- **Sections 2 → 6**: split the coarse definitions/surjectivity split into finer sections covering the full file — module header, re-declared definitions, the base-set count, the surjectivity theorem, range/question corollaries, and the significance docstring.
- **Annotations 3 → 5**: separated `baseSet_card` into its own annotation, added a closing annotation framing why surjectivity is the 'lower side' of the χ(J(2k,k))=k+1 equivalence, and realigned annotation ranges to the constructs they actually describe.

## Verification
- `meta.json` within the 60 KB cap.
- Quality score 79 → 98 (sections 4→10, annotations 15→25).
- `pnpm build` passes (✓ built).
- No axiom/status changes; existing verified/0-axiom claims intact.