### PR TITLE
research(cauchy-schwarz-oq-01-oq-03-oq-02): discrete Gibbs' inequality (KL divergence ≥ 0) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean
@@ -149,4 +149,63 @@ theorem shannonEntropy_eq_log_card_iff [Nonempty ι] {p : ι → ℝ}
     rw [hpu, hn]
     exact shannonEntropy_uniform
 
+/-- Relative entropy (Kullback–Leibler divergence) of two finite probability vectors,
+`D(p ‖ q) = ∑ᵢ pᵢ (log pᵢ − log qᵢ)`. This is the discrete counterpart of the continuous
+KL divergence; it measures the information lost when `q` is used to approximate `p`. -/
+noncomputable def klDivergence (p q : ι → ℝ) : ℝ :=
+  ∑ i, p i * (Real.log (p i) - Real.log (q i))
+
+/-- **Gibbs' inequality** (discrete relative-entropy nonnegativity). For probability
+vectors `p, q` with `q` absolutely continuous with respect to `p` (`qᵢ > 0` whenever
+`pᵢ > 0`), the Kullback–Leibler divergence is nonnegative: `D(p ‖ q) ≥ 0`.
+
+Proof: it suffices to bound `−D(p ‖ q) = ∑ᵢ pᵢ (log qᵢ − log pᵢ)` above by `0`. Termwise,
+`pᵢ log(qᵢ/pᵢ) ≤ pᵢ (qᵢ/pᵢ − 1) = qᵢ − pᵢ` using the elementary inequality
+`log x ≤ x − 1` (`Real.log_le_sub_one_of_pos`); the degenerate terms `pᵢ = 0` give
+`0 ≤ qᵢ`. Summing, `−D ≤ ∑ᵢ (qᵢ − pᵢ) = 1 − 1 = 0`.
+
+Gibbs' inequality is the engine behind the maximum-entropy bound (`q` uniform recovers
+`H(p) ≤ log n`) and is the foundational positivity statement underlying any
+information-theoretic uncertainty relation. -/
+theorem klDivergence_nonneg {p q : ι → ℝ}
+    (hp0 : ∀ i, 0 ≤ p i) (hq0 : ∀ i, 0 ≤ q i)
+    (hpsum : ∑ i, p i = 1) (hqsum : ∑ i, q i = 1)
+    (hac : ∀ i, 0 < p i → 0 < q i) :
+    0 ≤ klDivergence p q := by
+  -- Termwise bound on the *negated* summand: `pᵢ (log qᵢ − log pᵢ) ≤ qᵢ − pᵢ`.
+  have hkey : ∀ i, p i * (Real.log (q i) - Real.log (p i)) ≤ q i - p i := by
+    intro i
+    rcases eq_or_lt_of_le (hp0 i) with hpi | hpi
+    · -- `pᵢ = 0`: the summand is `0`, and `qᵢ − 0 = qᵢ ≥ 0`.
+      rw [← hpi]; simpa using hq0 i
+    · -- `0 < pᵢ`, hence `0 < qᵢ` by absolute continuity.
+      have hqi : 0 < q i := hac i hpi
+      have hlog : Real.log (q i) - Real.log (p i) = Real.log (q i / p i) := by
+        rw [Real.log_div (ne_of_gt hqi) (ne_of_gt hpi)]
+      rw [hlog]
+      have hbound : Real.log (q i / p i) ≤ q i / p i - 1 :=
+        Real.log_le_sub_one_of_pos (div_pos hqi hpi)
+      calc p i * Real.log (q i / p i)
+          ≤ p i * (q i / p i - 1) := mul_le_mul_of_nonneg_left hbound (le_of_lt hpi)
+        _ = q i - p i := by field_simp
+  -- Sum the bound: `∑ pᵢ (log qᵢ − log pᵢ) ≤ ∑ (qᵢ − pᵢ) = 0`.
+  have hsum_le : (∑ i, p i * (Real.log (q i) - Real.log (p i))) ≤ ∑ i, (q i - p i) :=
+    Finset.sum_le_sum (fun i _ => hkey i)
+  have hsum_zero : (∑ i, (q i - p i)) = 0 := by
+    rw [Finset.sum_sub_distrib, hqsum, hpsum, sub_self]
+  -- The negated sum and `D(p ‖ q)` cancel termwise.
+  have hcancel :
+      klDivergence p q + (∑ i, p i * (Real.log (q i) - Real.log (p i))) = 0 := by
+    unfold klDivergence
+    rw [← Finset.sum_add_distrib]
+    exact Finset.sum_eq_zero (fun i _ => by ring)
+  linarith [hsum_le.trans hsum_zero.le]
+
+/-- `D(p ‖ p) = 0`: the relative entropy of a probability vector with itself vanishes
+(no information is lost). Combined with `klDivergence_nonneg`, `p` is the unique
+minimizer of `D(· ‖ p)`. -/
+theorem klDivergence_self (p : ι → ℝ) : klDivergence p p = 0 := by
+  unfold klDivergence
+  exact Finset.sum_eq_zero (fun i _ => by ring)
+
 end CauchySchwarzOQ01OQ03OQ02

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-oq-01-oq-03-oq-02",
   "title": "Shannon Entropy: Maximum-Entropy Bound (toward Entropic Uncertainty)",
   "slug": "cauchy-schwarz-oq-01-oq-03-oq-02",
-  "description": "Builds the finite-dimensional Shannon-entropy infrastructure needed for an entropic uncertainty relation: entropy of a probability vector via Mathlib's negMulLog, its nonnegativity, the maximum-entropy bound H(p) ≤ log n via Jensen's inequality, and the equality case H(p) = log n ↔ p uniform via the strict-concavity refinement of Jensen. The full Maassen–Uffink entropic uncertainty principle remains blocked on Mathlib's missing interpolation theory.",
+  "description": "Builds the finite-dimensional Shannon-entropy infrastructure needed for an entropic uncertainty relation: entropy of a probability vector via Mathlib's negMulLog, its nonnegativity, the maximum-entropy bound H(p) ≤ log n via Jensen's inequality, the equality case H(p) = log n ↔ p uniform via the strict-concavity refinement of Jensen, and the discrete relative entropy (Kullback–Leibler divergence) together with Gibbs' inequality D(p‖q) ≥ 0 — the positivity statement that underlies the maximum-entropy bound and any entropic uncertainty relation. The full Maassen–Uffink entropic uncertainty principle remains blocked on Mathlib's missing interpolation theory.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -18,11 +18,11 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 152,
-    "assumptions": "Uses Mathlib's Real.negMulLog (Shannon entropy term) with its concavity (concaveOn_negMulLog), strict concavity (strictConcaveOn_negMulLog), the finite Jensen inequality (ConcaveOn.le_map_sum), and its equality case (StrictConcaveOn.eq_of_map_sum_eq). No additional axioms or assumptions.",
-    "theoremCount": 4,
+    "lineCount": 211,
+    "assumptions": "Uses Mathlib's Real.negMulLog (Shannon entropy term) with its concavity (concaveOn_negMulLog), strict concavity (strictConcaveOn_negMulLog), the finite Jensen inequality (ConcaveOn.le_map_sum), and its equality case (StrictConcaveOn.eq_of_map_sum_eq); Gibbs' inequality uses the elementary log bound Real.log_le_sub_one_of_pos. No additional axioms or assumptions.",
+    "theoremCount": 6,
     "mathlib_version": "4.26.0",
-    "definitionCount": 1
+    "definitionCount": 2
   },
   "overview": {
     "problemStatement": "Parent open question: can the entropic uncertainty principle (Maassen–Uffink 1988), $H(p) + H(q) \\geq -2\\ln c$ for the outcome distributions of two orthonormal bases with maximal overlap $c$, be formalized in Lean 4? This entry establishes the provable entropy half of that relation — the maximum-entropy bound $H(p) \\leq \\log n$ — and documents the precise obstruction to the full theorem.",
@@ -33,7 +33,8 @@
       "This is the 'entropy ceiling' that bounds either marginal in an entropic uncertainty relation; the genuinely hard content of Maassen–Uffink is the lower bound on the sum H(p) + H(q).",
       "The sharp Maassen–Uffink constant -2 ln c follows from the Hausdorff–Young inequality (a (2→∞) operator-norm / Riesz–Thorin interpolation argument), which Mathlib v4.26.0 does not yet provide — making the full theorem genuinely blocked rather than merely unattempted.",
       "Deutsch's interpolation-free precursor H(p) + H(q) ≥ -2 ln((1+c)/2) is the natural next target once finite-dimensional entropy infrastructure (this entry) is in place.",
-      "The maximizer is unique: H(p) = log n forces p to be the uniform distribution. This is the equality case of Jensen for the strictly concave negMulLog (StrictConcaveOn.eq_of_map_sum_eq) — strict concavity collapses the inequality to an equality only when all sampled points coincide, and ∑ pᵢ = 1 then pins each entry to 1/n."
+      "The maximizer is unique: H(p) = log n forces p to be the uniform distribution. This is the equality case of Jensen for the strictly concave negMulLog (StrictConcaveOn.eq_of_map_sum_eq) — strict concavity collapses the inequality to an equality only when all sampled points coincide, and ∑ pᵢ = 1 then pins each entry to 1/n.",
+      "Gibbs' inequality D(p‖q) = ∑ᵢ pᵢ(log pᵢ − log qᵢ) ≥ 0 is the single positivity statement from which the entropy ceiling follows: it reduces termwise to log(qᵢ/pᵢ) ≤ qᵢ/pᵢ − 1 (the elementary log x ≤ x − 1), summing to ∑(qᵢ − pᵢ) = 0. Taking q uniform recovers H(p) ≤ log n, so the maximum-entropy bound and Gibbs positivity are two faces of the same inequality."
     ]
   },
   "sections": [
@@ -78,11 +79,18 @@
       "startLine": 94,
       "endLine": 151,
       "summary": "H(p) = log n ↔ p is uniform. The forward direction is the strict-concavity refinement of Jensen (StrictConcaveOn.eq_of_map_sum_eq): equality forces all sampled points to coincide, and ∑ pᵢ = 1 pins each entry to 1/n; the reverse is shannonEntropy_uniform."
+    },
+    {
+      "id": "kl-gibbs",
+      "title": "Relative Entropy and Gibbs' Inequality",
+      "startLine": 153,
+      "endLine": 210,
+      "summary": "Defines the discrete Kullback–Leibler divergence D(p‖q) = ∑ᵢ pᵢ(log pᵢ − log qᵢ) and proves Gibbs' inequality D(p‖q) ≥ 0 for probability vectors with q absolutely continuous w.r.t. p, via the termwise bound pᵢ log(qᵢ/pᵢ) ≤ qᵢ − pᵢ from Real.log_le_sub_one_of_pos. Also records D(p‖p) = 0. Gibbs positivity is the engine behind the maximum-entropy bound (q uniform) and the foundational positivity statement for entropic uncertainty."
     }
   ],
   "conclusion": {
-    "summary": "The finite-dimensional Shannon-entropy framework, the maximum-entropy bound H(p) ≤ log n, and its equality case (H(p) = log n ↔ p uniform) are formalized and fully machine-checked (0 axioms, 0 sorries), built directly on Mathlib's negMulLog concavity / strict concavity and the Jensen inequality with its equality case. This is the provable entropy half of an entropic uncertainty relation, now including a full characterization of the maximizer.",
-    "implications": "Provides reusable infrastructure for any future formalization of the entropic uncertainty principle. The equality case identifies the unique maximizer, which is the equality condition for either marginal of an eventual entropic uncertainty relation. The full Maassen–Uffink bound is documented as blocked on Mathlib's absent interpolation theory (Hausdorff–Young / Riesz–Thorin); Deutsch's interpolation-free bound is the recommended next step once this infrastructure is extended.",
+    "summary": "The finite-dimensional Shannon-entropy framework, the maximum-entropy bound H(p) ≤ log n, its equality case (H(p) = log n ↔ p uniform), and the discrete relative entropy with Gibbs' inequality (D(p‖q) ≥ 0, D(p‖p) = 0) are formalized and fully machine-checked (0 axioms, 0 sorries), built directly on Mathlib's negMulLog concavity / strict concavity, the Jensen inequality with its equality case, and the elementary log bound log x ≤ x − 1. This is the provable entropy half of an entropic uncertainty relation, including a full characterization of the maximizer and the underlying Gibbs positivity statement.",
+    "implications": "Provides reusable infrastructure for any future formalization of the entropic uncertainty principle. Gibbs' inequality D(p‖q) ≥ 0 is the foundational positivity result of information theory: it implies the maximum-entropy bound (take q uniform) and is the natural building block for the entropic uncertainty lower bound on H(p) + H(q). The equality case identifies the unique maximizer, which is the equality condition for either marginal of an eventual entropic uncertainty relation. The full Maassen–Uffink bound is documented as blocked on Mathlib's absent interpolation theory (Hausdorff–Young / Riesz–Thorin); Deutsch's interpolation-free bound is the recommended next step once this infrastructure is extended.",
     "openQuestions": [
       "Can Deutsch's entropic uncertainty bound H(p) + H(q) ≥ -2 ln((1+c)/2) — which avoids interpolation — be formalized on top of this entropy infrastructure?",
       "Once Mathlib gains Riesz–Thorin / Hausdorff–Young interpolation, complete the sharp Maassen–Uffink constant -2 ln c, closing the parent's full open question.",
@@ -91,10 +99,10 @@
   },
   "leanFile": {
     "namespace": "CauchySchwarzOQ01OQ03OQ02",
-    "lineCount": 152,
+    "lineCount": 211,
     "axiomCount": 0,
-    "theoremCount": 4,
-    "definitionCount": 1,
+    "theoremCount": 6,
+    "definitionCount": 2,
     "path": "Proofs/CauchySchwarzOQ01OQ03OQ02.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03-oq-02.json
@@ -1,0 +1,71 @@
+{
+  "slug": "cauchy-schwarz-oq-01-oq-03-oq-02",
+  "title": "Maassen-Uffink Entropic Uncertainty Principle",
+  "status": "active",
+  "phase": "PROVE",
+  "tier": "B",
+  "path": "full",
+  "started": "2026-06-27T22:38:00Z",
+  "lastUpdate": "2026-06-27T22:38:00Z",
+  "problemStatement": {
+    "formal": "For outcome distributions p, q of measuring a state in two orthonormal bases with maximal overlap c, H(p) + H(q) >= -2 ln c (Maassen-Uffink 1988).",
+    "plain": "Formalize the entropic uncertainty principle: the Shannon entropies of measurement outcomes in two complementary bases cannot both be small.",
+    "whyMatters": [
+      "Basis-independent strengthening of the Heisenberg/Robertson variance uncertainty bound (the parent entry cauchy-schwarz-oq-01-oq-03).",
+      "Foundational in quantum information theory (entropic uncertainty underlies security proofs in QKD)."
+    ]
+  },
+  "currentState": {
+    "phase": "PROVE",
+    "since": "2026-06-27T22:38:00Z",
+    "iteration": 2,
+    "focus": "Finite-dimensional Shannon-entropy + relative-entropy infrastructure; full Maassen-Uffink blocked on Mathlib interpolation theory.",
+    "blockers": [
+      "Sharp Maassen-Uffink constant -2 ln c needs Hausdorff-Young / Riesz-Thorin interpolation, absent in Mathlib v4.26.0."
+    ],
+    "nextAction": "Attempt Deutsch's interpolation-free bound H(p)+H(q) >= -2 ln((1+c)/2) on top of the entropy + Gibbs infrastructure.",
+    "attemptCounts": { "total": 2, "currentApproach": 1, "approachesTried": 1 }
+  },
+  "knowledge": {
+    "progressSummary": "Gallery entry verified, 0-axiom. Built finite Shannon entropy H(p)=sum negMulLog(p_i): nonnegativity, maximum-entropy bound H(p)<=log n (Jensen on concave negMulLog), equality case H(p)=log n iff p uniform (strict-concavity refinement), and discrete relative entropy D(p||q)=sum p_i(log p_i - log q_i) with Gibbs' inequality D(p||q)>=0 and D(p||p)=0. Full Maassen-Uffink remains blocked on Mathlib interpolation theory.",
+    "builtItems": [
+      "shannonEntropy (def) and shannonEntropy_nonneg",
+      "shannonEntropy_le_log_card (maximum-entropy bound via ConcaveOn.le_map_sum)",
+      "shannonEntropy_uniform and shannonEntropy_eq_log_card_iff (equality case via StrictConcaveOn.eq_of_map_sum_eq)",
+      "klDivergence (def) — discrete KL/relative entropy",
+      "klDivergence_nonneg — discrete Gibbs' inequality D(p||q)>=0",
+      "klDivergence_self — D(p||p)=0"
+    ],
+    "insights": [
+      "Gibbs' inequality D(p||q)>=0 and the maximum-entropy bound H(p)<=log n are the same inequality: take q uniform and D = log n - H(p).",
+      "Discrete Gibbs reduces termwise to log(q_i/p_i) <= q_i/p_i - 1 (Real.log_le_sub_one_of_pos); degenerate p_i=0 terms give 0<=q_i; summing yields sum(q_i-p_i)=0.",
+      "negMulLog strict concavity (StrictConcaveOn.eq_of_map_sum_eq) gives the unique maximizer (uniform) for the entropy ceiling.",
+      "Sibling ShannonEntropyOQ01 has the CONTINUOUS Gibbs inequality (integral form); this entry now supplies the finite-vector counterpart."
+    ],
+    "mathlibGaps": [
+      "No Hausdorff-Young / Riesz-Thorin interpolation in Mathlib v4.26.0 — blocks the sharp Maassen-Uffink constant -2 ln c."
+    ],
+    "nextSteps": [
+      "Formalize Deutsch's interpolation-free bound H(p)+H(q) >= -2 ln((1+c)/2).",
+      "Derive the explicit qubit (n=2) entropic uncertainty relation and compare to the parent's variance product bound.",
+      "Add data-processing / monotonicity of KL divergence once a channel/coarse-graining def is available."
+    ],
+    "markdown": "# Knowledge Base: cauchy-schwarz-oq-01-oq-03-oq-02 (Maassen-Uffink Entropic Uncertainty)\n\n## Status\nGallery entry VERIFIED, 0-axiom. Provable entropy + relative-entropy infrastructure in place; full Maassen-Uffink blocked on Mathlib interpolation.\n\n## Built (Proofs/CauchySchwarzOQ01OQ03OQ02.lean)\n- shannonEntropy, shannonEntropy_nonneg\n- shannonEntropy_le_log_card (maximum-entropy bound)\n- shannonEntropy_uniform, shannonEntropy_eq_log_card_iff (equality case)\n- klDivergence, klDivergence_nonneg (discrete Gibbs), klDivergence_self\n\n## Key insight\nGibbs D(p||q)>=0 with q uniform IS the maximum-entropy bound (D = log n - H(p)).\n\n## Blocker\nSharp constant -2 ln c needs Hausdorff-Young/Riesz-Thorin interpolation (absent in Mathlib v4.26.0).\n\n## Next\nDeutsch's interpolation-free bound H(p)+H(q) >= -2 ln((1+c)/2); qubit n=2 case.\n"
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/CauchySchwarzOQ01OQ03OQ02.lean",
+      "filename": "CauchySchwarzOQ01OQ03OQ02.lean",
+      "lineCount": 211,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean"
+    }
+  ],
+  "tags": ["information-theory", "quantum", "entropy", "seeker-selected"],
+  "relatedProofs": ["cauchy-schwarz-oq-01-oq-03", "shannon-entropy-oq-01"],
+  "references": []
+}


### PR DESCRIPTION
## Summary

Extends the entropic-uncertainty Shannon-entropy entry (`cauchy-schwarz-oq-01-oq-03-oq-02`, *Maassen–Uffink Entropic Uncertainty Principle*) with the **discrete relative entropy** and **Gibbs' inequality** — the foundational positivity statement of information theory and the inequality from which the existing maximum-entropy bound `H(p) ≤ log n` descends.

New content in `Proofs/CauchySchwarzOQ01OQ03OQ02.lean`:

- `klDivergence p q := ∑ᵢ pᵢ (log pᵢ − log qᵢ)` — discrete Kullback–Leibler divergence
- `klDivergence_nonneg` — **Gibbs' inequality** `D(p‖q) ≥ 0` for probability vectors with `q` absolutely continuous w.r.t. `p`
- `klDivergence_self` — `D(p‖p) = 0`

## Proof

Termwise bound on the negated summand: `pᵢ log(qᵢ/pᵢ) ≤ pᵢ(qᵢ/pᵢ − 1) = qᵢ − pᵢ` using the elementary inequality `log x ≤ x − 1` (`Real.log_le_sub_one_of_pos`); the degenerate `pᵢ = 0` terms give `0 ≤ qᵢ`. Summing gives `−D ≤ ∑(qᵢ − pᵢ) = 1 − 1 = 0`, hence `D ≥ 0`. Taking `q` uniform recovers the maximum-entropy bound already in the entry — Gibbs positivity and the entropy ceiling are two faces of the same inequality.

This complements the **continuous** Gibbs inequality in the sibling entry `ShannonEntropyOQ01` (integral form) with the finite-vector form needed by entropic uncertainty relations.

## Verification

Docker was unavailable this session; verified with the documented single-file fallback `lake env lean Proofs/CauchySchwarzOQ01OQ03OQ02.lean` (does **not** trigger a runaway `lake build`):

- Compiles clean, 0 errors, 0 sorries.
- `#print axioms` on both new theorems lists only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms** (no `Lean.ofReduceBool`, no `sorryAx`).

`meta.json` updated: `theoremCount` 4→6, `definitionCount` 1→2, `lineCount` 152→211; description, sections, key insights, and conclusion refreshed. Status remains `verified` / `mathlib` badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)