### PR TITLE
research(van-der-waerden-first-moment-oq-01): exact AP-family count — bijection upgrades the sharpened bound to an equality [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -917,6 +917,7 @@ import Proofs.CollatzCyclesOQ02
 import Proofs.CollatzCyclesOQ03
 import Proofs.CollatzCyclesOQ04
 import Proofs.CollatzStructured
+import Proofs.CollatzStructuredOQ01
 import Proofs.CollatzStructuredOQ02OQ01
 import Proofs.CollatzStructuredOQ02OQ02
 import Proofs.CollatzStructuredOQ03

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4302,6 +4302,7 @@ import Proofs.VandermondeInterpolationOQ01OQ01
 import Proofs.VandermondeInterpolationOQ01OQ02
 import Proofs.VandermondeInterpolationOQ01OQ02OQ01
 import Proofs.VanDerWaerdenFirstMoment
+import Proofs.VanDerWaerdenFirstMomentOQ01
 import Proofs.VarignonTheorem
 import Proofs.VarignonTheoremOQ01OQ01
 import Proofs.VietaGeneralOQ030505OQ01

--- a/proofs/Proofs/CollatzStructuredOQ01.lean
+++ b/proofs/Proofs/CollatzStructuredOQ01.lean
@@ -1,0 +1,195 @@
+/-
+# OQ-01: Backward Collatz — Preimage Structure and Infinitude of the Basin of 1
+
+Parent: `collatz-structured` (CollatzStructured.lean) proves *forward* facts —
+powers of two reach 1, closure of "reaches 1" under doubling, and specific small
+values. This file studies the **backward** dynamics: the preimage (predecessor)
+structure of the Collatz map and what it implies about the set of numbers that
+reach 1 (the *basin* of 1).
+
+We prove, with **no axioms and no `sorry`**:
+
+1. **Exact preimage characterization.** For every `a m : ℕ`,
+   `collatz a = m ↔ a = 2 * m ∨ (a % 2 = 1 ∧ 3 * a + 1 = m)`.
+   Every predecessor of `m` is either the *even predecessor* `2m` or an
+   *odd predecessor* `a` with `3a + 1 = m`.
+
+2. **Branching law.** An odd predecessor exists iff `m ≡ 4 (mod 6)`:
+   `(∃ a, a % 2 = 1 ∧ 3 * a + 1 = m) ↔ m % 6 = 4`.
+   Hence in the Collatz graph every vertex `m ≡ 4 (mod 6)` has two predecessors
+   and every other vertex has exactly one (the even predecessor `2m`).
+
+3. **Backward closure of the basin.** If `collatz a = m` and `m` reaches 1, then
+   `a` reaches 1. The basin of 1 is closed under taking predecessors.
+
+4. **The basin of 1 is infinite** — it contains every power of two.
+
+These are *unconditional* structural facts about the Collatz graph: they do not
+assume the Collatz conjecture, but describe the shape of the component containing
+1, independently of whether that component is all of `ℕ`.
+
+Tags: number-theory, collatz, predecessor, preimage, dynamical-systems
+-/
+
+import Mathlib.Tactic
+import Proofs.CollatzStructured
+
+namespace CollatzBackward
+
+open Collatz
+
+/-!
+## Part I: Exact Preimage Characterization
+
+The Collatz map `collatz n = if n even then n/2 else 3n+1` is two-to-one onto its
+image in a controlled way. A predecessor `a` of `m` (i.e. `collatz a = m`) is
+either even — in which case `a/2 = m`, forcing `a = 2m` — or odd, in which case
+`3a + 1 = m`.
+-/
+
+/-- **Exact preimage characterization.** `a` maps to `m` under the Collatz map iff
+`a` is the even predecessor `2m` or an odd number with `3a + 1 = m`. -/
+theorem collatz_eq_iff (a m : ℕ) :
+    collatz a = m ↔ a = 2 * m ∨ (a % 2 = 1 ∧ 3 * a + 1 = m) := by
+  unfold collatz
+  split_ifs with h
+  · -- a is even
+    constructor
+    · intro hm; exact Or.inl (by omega)
+    · rintro (rfl | ⟨h1, _⟩) <;> omega
+  · -- a is odd
+    have h1 : a % 2 = 1 := by omega
+    constructor
+    · intro hm; exact Or.inr ⟨h1, hm⟩
+    · rintro (rfl | ⟨_, h2⟩)
+      · omega
+      · exact h2
+
+/-- The preimage of `{m}` under the Collatz map, described explicitly. -/
+theorem preimage_collatz (m : ℕ) :
+    collatz ⁻¹' {m} = {a | a = 2 * m ∨ (a % 2 = 1 ∧ 3 * a + 1 = m)} := by
+  ext a
+  simp [Set.mem_preimage, collatz_eq_iff]
+
+/-- The **even predecessor**: `2m` always maps to `m`. -/
+theorem even_pred (m : ℕ) : collatz (2 * m) = m := collatz_two_mul m
+
+/-!
+## Part II: The Branching Law
+
+An *odd* predecessor of `m` exists exactly when `m ≡ 4 (mod 6)`. Combined with the
+always-present even predecessor `2m`, this says: vertices congruent to `4 mod 6`
+have in-degree 2 in the Collatz graph; all others have in-degree 1.
+-/
+
+/-- **Branching law.** `m` has an odd predecessor iff `m ≡ 4 (mod 6)`. -/
+theorem odd_pred_exists_iff (m : ℕ) :
+    (∃ a, a % 2 = 1 ∧ 3 * a + 1 = m) ↔ m % 6 = 4 := by
+  constructor
+  · rintro ⟨a, ha, rfl⟩
+    omega
+  · intro hm
+    exact ⟨2 * (m / 6) + 1, by omega, by omega⟩
+
+/-- When `m ≡ 4 (mod 6)` there are (at least) two distinct predecessors: the even
+predecessor `2m` and a distinct odd predecessor. The Collatz graph branches here. -/
+theorem two_preds_of_mod {m : ℕ} (hm : m % 6 = 4) :
+    ∃ a b, a ≠ b ∧ collatz a = m ∧ collatz b = m := by
+  obtain ⟨c, hc, hcm⟩ := (odd_pred_exists_iff m).mpr hm
+  refine ⟨2 * m, c, ?_, even_pred m, ?_⟩
+  · omega
+  · rw [collatz_eq_iff]; exact Or.inr ⟨hc, hcm⟩
+
+/-- When `m % 6 ≠ 4`, the *only* predecessor of `m` is the even predecessor `2m`. -/
+theorem unique_pred_of_not_mod {m : ℕ} (hm : m % 6 ≠ 4) {a : ℕ}
+    (ha : collatz a = m) : a = 2 * m := by
+  rcases (collatz_eq_iff a m).mp ha with h | ⟨hodd, h3⟩
+  · exact h
+  · exact absurd ((odd_pred_exists_iff m).mp ⟨a, hodd, h3⟩) hm
+
+/-!
+## Part III: Backward Closure of the Basin
+
+If `a` maps to `m` in one step and `m` reaches 1, then `a` reaches 1 (in one more
+step). Thus the basin of 1 is closed under taking predecessors — its preimage
+under `collatz` is contained in itself.
+-/
+
+/-- **Backward closure.** If `collatz a = m` and `m` reaches 1, then `a` reaches 1. -/
+theorem reaches_one_of_collatz {a m : ℕ} (h : collatz a = m) (hm : ReachesOne m) :
+    ReachesOne a := by
+  obtain ⟨k, hk⟩ := hm
+  refine ⟨k + 1, ?_⟩
+  simp only [collatzIter] at hk ⊢
+  rw [Function.iterate_succ_apply, h]
+  exact hk
+
+/-- Backward closure via the odd predecessor: if `a` is odd and `3a + 1` reaches 1,
+then `a` reaches 1. -/
+theorem reaches_one_odd_pred {a : ℕ} (ha : a % 2 = 1) (h : ReachesOne (3 * a + 1)) :
+    ReachesOne a :=
+  reaches_one_of_collatz ((collatz_eq_iff a (3 * a + 1)).mpr (Or.inr ⟨ha, rfl⟩)) h
+
+/-- The basin of 1 is closed under `collatz`-preimages: every predecessor of a
+basin element is again a basin element. -/
+theorem basin_closed_under_pred :
+    collatz ⁻¹' {n | ReachesOne n} ⊆ {n | ReachesOne n} := by
+  intro a ha
+  exact reaches_one_of_collatz (rfl : collatz a = collatz a) ha
+
+/-!
+## Part IV: The Basin of 1 is Infinite
+
+The set of numbers reaching 1 contains every power of two (parent file:
+`pow_two_reaches_one`), and `k ↦ 2^(k+1)` is an injection into it, so the basin is
+infinite. This is unconditional — it does not need the Collatz conjecture.
+-/
+
+/-- **The basin of 1 is infinite.** -/
+theorem basin_infinite : {n : ℕ | ReachesOne n}.Infinite := by
+  apply Set.infinite_of_injective_forall_mem (f := fun k : ℕ => 2 ^ (k + 1))
+  · intro x y hxy
+    have hxy' : 2 ^ (x + 1) = 2 ^ (y + 1) := hxy
+    have : x + 1 = y + 1 := Nat.pow_right_injective (le_refl 2) hxy'
+    omega
+  · intro k
+    simp only [Set.mem_setOf_eq]
+    exact pow_two_reaches_one (k + 1) (by omega)
+
+/-!
+## Part V: Computed Examples of the Branching Structure
+
+Concrete instances of the preimage law for small `m`.
+-/
+
+-- 16 ≡ 4 (mod 6): two predecessors, 32 (even) and 5 (odd, 3·5+1 = 16).
+example : collatz 32 = 16 := by decide
+example : collatz 5 = 16 := by decide
+example : (16 : ℕ) % 6 = 4 := by decide
+
+-- 10 ≡ 4 (mod 6): two predecessors, 20 (even) and 3 (odd, 3·3+1 = 10).
+example : collatz 20 = 10 := by decide
+example : collatz 3 = 10 := by decide
+
+-- 8 ≢ 4 (mod 6): only the even predecessor 16.
+example : (8 : ℕ) % 6 ≠ 4 := by decide
+example : collatz 16 = 8 := by decide
+
+/-!
+## Summary
+
+**Proved (no axioms, no `sorry`)**:
+1. ✓ Exact preimage characterization `collatz_eq_iff`
+2. ✓ Branching law `odd_pred_exists_iff` (odd predecessor ⟺ `m ≡ 4 mod 6`)
+3. ✓ In-degree dichotomy: `two_preds_of_mod` / `unique_pred_of_not_mod`
+4. ✓ Backward closure of the basin `reaches_one_of_collatz`, `basin_closed_under_pred`
+5. ✓ The basin of 1 is infinite `basin_infinite`
+
+**Unconditional**: none of these assume the Collatz conjecture. They describe the
+backward dynamics (the Collatz graph) regardless of whether every `n` reaches 1.
+
+**What remains open**: whether the basin of 1 is *all* of `ℕ ≥ 1` — i.e. the
+Collatz conjecture itself (axiomatized in the parent file).
+-/
+
+end CollatzBackward

--- a/proofs/Proofs/VanDerWaerdenFirstMomentOQ01.lean
+++ b/proofs/Proofs/VanDerWaerdenFirstMomentOQ01.lean
@@ -1,0 +1,281 @@
+/-
+  Sharpening the AP-family count in the van der Waerden first-moment lower bound
+  (open question van-der-waerden-first-moment-oq-01)
+
+  The base entry `Proofs.VanDerWaerdenFirstMoment` bounds the number of length-`k`
+  arithmetic progressions that fit in `[n]` by the deliberately loose count `n²`
+  (`card_vdwFamily_le`): it allows every pair `(a, d)` of first term and step.
+  That gives the clean union-bound threshold `n² < 2^(k-1)`, i.e.
+  `W(k) ≳ 2^((k-1)/2)`.
+
+  But the step `d` is heavily constrained.  For a length-`k` AP to fit we need
+  `a + (k-1)d < n`, and since `a ≥ 0` this already forces
+
+        (k-1)·d  <  n,      hence   d ≤ (n-1)/(k-1).
+
+  So the step ranges over only `(n-1)/(k-1)` values, not `n`.  Intersecting the
+  `(a, d)`-parameter box with this sharper step range improves the family bound by
+  a full factor of `(k-1)`:
+
+        |family|              ≤ n · ⌊(n-1)/(k-1)⌋          (card_vdwFamily_le_div)
+        |family| · (k-1)      ≤ n · (n-1)                  (card_vdwFamily_mul_le)
+
+  i.e. at most `n(n-1)/(k-1) < n²/(k-1)` APs fit — exactly the `~n²/(k-1)` count
+  the open question asks for.  Feeding this back through the verified Property-B
+  engine widens the admissible range of `n` from `n² < 2^(k-1)` to
+
+        n(n-1) < (k-1)·2^(k-1)        (vdw_lower_bound_sharp)
+
+  a factor-`√(k-1)` improvement, giving `W(k) ≳ √(k-1)·2^((k-1)/2)`.
+
+  Everything here is elementary counting layered on top of the base entry's
+  verified `vdwAP` / `vdwFamily` / `vdw_two_coloring_exists`; the probabilistic
+  core remains the gallery's Property-B engine consumed as a black box.
+
+  Status: 0 sorries, 0 axioms, no `native_decide`.  #print axioms reports only
+  `propext, Classical.choice, Quot.sound`.
+-/
+import Mathlib
+import Proofs.VanDerWaerdenFirstMoment
+
+namespace ProbMethod.VanDerWaerden
+
+open Finset
+open ProbMethod.PropertyB (Mono property_b_two_colorable)
+open scoped Fin.NatCast
+
+variable {n : ℕ} [NeZero n]
+
+/-- **Sharper AP-family bound via the step constraint.**
+A fitting length-`k` AP (`k ≥ 2`) has step `d ≤ (n-1)/(k-1)`: from
+`a + (k-1)d < n` and `a ≥ 0` we get `(k-1)d < n`, hence `d ≤ (n-1)/(k-1)`.
+Restricting the `(a, d)`-parameter box to this step range bounds the family by
+`n · ⌊(n-1)/(k-1)⌋`, a factor-`(k-1)` improvement on the base `n²` count. -/
+theorem card_vdwFamily_le_div {k : ℕ} (hk : 2 ≤ k) :
+    (vdwFamily n k).card ≤ n * ((n - 1) / (k - 1)) := by
+  have hk1 : 0 < k - 1 := by omega
+  calc (vdwFamily n k).card
+      ≤ (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+          (fun p => p.1 + (k - 1) * p.2 < n)).card := Finset.card_image_le
+    _ ≤ ((Finset.range n) ×ˢ (Finset.Icc 1 ((n - 1) / (k - 1)))).card := by
+        apply Finset.card_le_card
+        intro p hp
+        rw [Finset.mem_filter, Finset.mem_product, Finset.mem_Icc,
+          Finset.mem_range] at hp
+        obtain ⟨⟨ha, hd1, _hdn⟩, hbound⟩ := hp
+        have hX : (k - 1) * p.2 < n := by omega
+        rw [Finset.mem_product, Finset.mem_Icc, Finset.mem_range]
+        refine ⟨ha, hd1, ?_⟩
+        rw [Nat.le_div_iff_mul_le hk1, Nat.mul_comm]
+        omega
+    _ = n * ((n - 1) / (k - 1)) := by
+        rw [Finset.card_product, Finset.card_range, Nat.card_Icc,
+          Nat.add_sub_cancel]
+
+/-- **Division-free sharpened count.** `|family| · (k-1) ≤ n(n-1)`, i.e. at most
+`n(n-1)/(k-1) < n²/(k-1)` length-`k` APs fit in `[n]` — a factor-`(k-1)`
+improvement on the base entry's loose `n²` bound. -/
+theorem card_vdwFamily_mul_le {k : ℕ} (hk : 2 ≤ k) :
+    (vdwFamily n k).card * (k - 1) ≤ n * (n - 1) := by
+  calc (vdwFamily n k).card * (k - 1)
+      ≤ (n * ((n - 1) / (k - 1))) * (k - 1) := by
+        gcongr
+        exact card_vdwFamily_le_div hk
+    _ = n * (((n - 1) / (k - 1)) * (k - 1)) := by ring
+    _ ≤ n * (n - 1) := by
+        gcongr
+        exact Nat.div_mul_le_self _ _
+
+/-- **Sharpened first-moment van der Waerden lower bound.**
+If `n(n-1) < (k-1)·2^(k-1)` then there is a 2-colouring of `[n]` under which every
+length-`k` arithmetic progression with positive step contains both colours.
+
+This widens the admissible range of `n` by a factor `√(k-1)` over the base
+`vdw_lower_bound` (which requires `n² < 2^(k-1)`): the sharper family count
+`|family|·(k-1) ≤ n(n-1)` lets a single cancellation of `(k-1)` turn the
+hypothesis into `|family| < 2^(k-1)`.  The resulting witness is
+`W(k) ≳ √(k-1)·2^((k-1)/2)`. -/
+theorem vdw_lower_bound_sharp {k : ℕ} (hk : 2 ≤ k)
+    (hnk : n * (n - 1) < (k - 1) * 2 ^ (k - 1)) :
+    ∃ c : Fin n → Bool, ∀ a d : ℕ, 1 ≤ d → a + (k - 1) * d < n →
+      ¬ Mono (vdwAP n a d k) c := by
+  have hk1 : 0 < k - 1 := by omega
+  -- Cancel (k-1) from |family|·(k-1) ≤ n(n-1) < (k-1)·2^(k-1).
+  have hcard : (vdwFamily n k).card < 2 ^ (k - 1) := by
+    have h1 : (vdwFamily n k).card * (k - 1) < 2 ^ (k - 1) * (k - 1) := by
+      have := lt_of_le_of_lt (card_vdwFamily_mul_le hk) hnk
+      rwa [Nat.mul_comm (k - 1) (2 ^ (k - 1))] at this
+    exact lt_of_mul_lt_mul_right h1 (Nat.zero_le _)
+  obtain ⟨c, hc⟩ := vdw_two_coloring_exists (by omega) hcard
+  refine ⟨c, fun a d hd hb => ?_⟩
+  apply hc
+  -- The AP `vdwAP n a d k` belongs to the family (same membership as the base).
+  rw [vdwFamily, Finset.mem_image]
+  refine ⟨(a, d), ?_, rfl⟩
+  rw [Finset.mem_filter, Finset.mem_product, Finset.mem_Icc, Finset.mem_range]
+  have hdn : d ≤ (k - 1) * d := Nat.le_mul_of_pos_left d (by omega)
+  exact ⟨⟨by omega, hd, by omega⟩, hb⟩
+
+/-! ### The AP-family count is exact
+
+The bounds above (`card_vdwFamily_le_div`) are *inequalities*: they cap the family
+size by `n · ⌊(n-1)/(k-1)⌋`, which over-counts because for a fixed step `d` the
+first term `a` ranges only over `n - (k-1)d` values, not all of `n`.  We now show
+the `(a, d)`-parametrisation is in fact a **bijection** onto the family — distinct
+admissible pairs give distinct progressions — so the family count is *exactly* the
+number of fitting `(a, d)` pairs, which evaluates to the closed sum
+
+      |vdwFamily(n, k)|  =  ∑_{d=1}^{⌊(n-1)/(k-1)⌋} (n - (k-1)·d).
+
+This upgrades the open question's `≤ n²/(k-1)` to an equality and pins down the
+first-moment AP count precisely. -/
+
+/-- **Membership in `vdwAP`.** A point lies in the length-`k` AP exactly when it is
+`a + i·d` (cast into `Fin n`) for some index `i < k`. -/
+theorem mem_vdwAP {a d k : ℕ} {x : Fin n} :
+    x ∈ vdwAP n a d k ↔ ∃ i, i < k ∧ ((a + i * d : ℕ) : Fin n) = x := by
+  unfold vdwAP
+  simp only [Finset.mem_image, Finset.mem_range]
+
+/-- **The `(a, d)`-parametrisation is injective on fitting pairs (`k ≥ 2`).**
+A length-`≥ 2` arithmetic progression determines its first term (its least element,
+recovered at `i = 0`) and its step (the gap to the next element, recovered at
+`i = 1`): if two admissible pairs yield the same AP, comparing least elements forces
+`a = a'`, and then comparing the second elements forces `i·d' = d` and `j·d = d'` for
+indices `i, j < k`, whence `(i·j)·d = d`, so `i = j = 1` and `d = d'`. -/
+theorem vdwFamily_param_injOn {k : ℕ} (hk : 2 ≤ k) :
+    Set.InjOn (fun p : ℕ × ℕ => vdwAP n p.1 p.2 k)
+      (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+        (fun p => p.1 + (k - 1) * p.2 < n) : Finset (ℕ × ℕ)) := by
+  -- An in-range natural cast into `Fin n` is injective.
+  have castinj : ∀ x y : ℕ, x < n → y < n → ((x : Fin n) = (y : Fin n)) → x = y := by
+    intro x y hx hy h
+    have := congrArg Fin.val h
+    rwa [Fin.val_cast_of_lt hx, Fin.val_cast_of_lt hy] at this
+  -- Every term `a + i·d` of a fitting AP stays below `n`.
+  have hterm : ∀ b e : ℕ, b + (k - 1) * e < n → ∀ i, i < k → b + i * e < n := by
+    intro b e hbe i hi
+    have : i * e ≤ (k - 1) * e := Nat.mul_le_mul_right e (by omega)
+    omega
+  intro p hp q hq hpq
+  obtain ⟨a, d⟩ := p
+  obtain ⟨a', d'⟩ := q
+  simp only [Finset.coe_filter, Finset.mem_product, Finset.mem_range,
+    Finset.mem_Icc, Set.mem_setOf_eq] at hp hq
+  obtain ⟨⟨hpa, hpd1, _hpdn⟩, hpb⟩ := hp
+  obtain ⟨⟨hqa, hqd1, _hqdn⟩, hqb⟩ := hq
+  dsimp only at hpq
+  -- Step 1: `a = a'` by comparing least elements (index 0).
+  have ha_le : a ≤ a' := by
+    -- `a'` is the least element of `vdwAP n a' d' k = vdwAP n a d k`, so `a' = a + i·d`.
+    have hmem : ((a' : ℕ) : Fin n) ∈ vdwAP n a' d' k := by
+      rw [mem_vdwAP]; exact ⟨0, by omega, by simp⟩
+    rw [← hpq, mem_vdwAP] at hmem
+    obtain ⟨i, hi, hival⟩ := hmem
+    have hb : a + i * d < n := hterm a d hpb i hi
+    have := castinj _ _ hb hqa hival
+    omega
+  have ha_ge : a' ≤ a := by
+    -- `a` is the least element of `vdwAP n a d k = vdwAP n a' d' k`, so `a = a' + i·d'`.
+    have hmem : ((a : ℕ) : Fin n) ∈ vdwAP n a d k := by
+      rw [mem_vdwAP]; exact ⟨0, by omega, by simp⟩
+    rw [hpq, mem_vdwAP] at hmem
+    obtain ⟨i, hi, hival⟩ := hmem
+    have hb : a' + i * d' < n := hterm a' d' hqb i hi
+    have := castinj _ _ hb hpa hival
+    omega
+  have haa : a = a' := le_antisymm ha_le ha_ge
+  subst haa
+  -- Step 2: `d = d'` by comparing second elements (index 1).
+  have hkpos : (1 : ℕ) < k := by omega
+  have hi_eq : ∃ i, i < k ∧ a + i * d' = a + d := by
+    have hmem : ((a + 1 * d : ℕ) : Fin n) ∈ vdwAP n a d k := by
+      rw [mem_vdwAP]; exact ⟨1, hkpos, rfl⟩
+    rw [hpq, mem_vdwAP] at hmem
+    obtain ⟨i, hi, hival⟩ := hmem
+    have hb1 : a + i * d' < n := hterm a d' hqb i hi
+    have hb2 : a + 1 * d < n := by have := hterm a d hpb 1 hkpos; simpa using this
+    refine ⟨i, hi, ?_⟩
+    have := castinj _ _ hb1 hb2 hival
+    simpa using this
+  have hj_eq : ∃ j, j < k ∧ a + j * d = a + d' := by
+    have hmem : ((a + 1 * d' : ℕ) : Fin n) ∈ vdwAP n a d' k := by
+      rw [mem_vdwAP]; exact ⟨1, hkpos, rfl⟩
+    rw [← hpq, mem_vdwAP] at hmem
+    obtain ⟨j, hj, hjval⟩ := hmem
+    have hb1 : a + j * d < n := hterm a d hpb j hj
+    have hb2 : a + 1 * d' < n := by have := hterm a d' hqb 1 hkpos; simpa using this
+    refine ⟨j, hj, ?_⟩
+    have := castinj _ _ hb1 hb2 hjval
+    simpa using this
+  obtain ⟨i, _hi, hid⟩ := hi_eq
+  obtain ⟨j, _hj, hjd⟩ := hj_eq
+  have hid' : i * d' = d := by omega
+  have hjd' : j * d = d' := by omega
+  have hij : (i * j) * d = 1 * d := by
+    have : (i * j) * d = i * (j * d) := by ring
+    rw [this, hjd', hid', one_mul]
+  have hij1 : i * j = 1 := Nat.eq_of_mul_eq_mul_right (by omega) hij
+  have hi1 : i = 1 := Nat.dvd_one.mp ⟨j, hij1.symm⟩
+  have hdd : d = d' := by rw [← hid', hi1, one_mul]
+  rw [hdd]
+
+/-- **The AP family is in bijection with the fitting `(a, d)` pairs (`k ≥ 2`),**
+hence its cardinality equals the number of such pairs. -/
+theorem card_vdwFamily_eq {k : ℕ} (hk : 2 ≤ k) :
+    (vdwFamily n k).card =
+      (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+        (fun p => p.1 + (k - 1) * p.2 < n)).card := by
+  unfold vdwFamily
+  exact Finset.card_image_of_injOn (vdwFamily_param_injOn hk)
+
+omit [NeZero n] in
+/-- **The fitting-pair count is a closed sum over the step.** For each step `d` the
+first term ranges over the `n - (k-1)d` values with `a + (k-1)d < n`. -/
+theorem card_fitting_pairs (k : ℕ) :
+    (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+        (fun p => p.1 + (k - 1) * p.2 < n)).card
+      = ∑ d ∈ Finset.Icc 1 n, (n - (k - 1) * d) := by
+  rw [Finset.card_filter, Finset.sum_product, Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro d _
+  rw [← Finset.card_filter]
+  have hrw : (Finset.range n).filter (fun a => a + (k - 1) * d < n)
+        = Finset.range (n - (k - 1) * d) := by
+    ext a
+    simp only [Finset.mem_filter, Finset.mem_range]
+    omega
+  rw [hrw, Finset.card_range]
+
+/-- **Exact AP-family count (`k ≥ 2`).** Combining the bijection with the closed
+sum: the number of length-`k` arithmetic progressions fitting in `[n]` is exactly
+`∑_{d=1}^{n} (n - (k-1)d)` (terms with `(k-1)d ≥ n` contributing `0`). -/
+theorem card_vdwFamily_eq_sum {k : ℕ} (hk : 2 ≤ k) :
+    (vdwFamily n k).card = ∑ d ∈ Finset.Icc 1 n, (n - (k - 1) * d) := by
+  rw [card_vdwFamily_eq hk, card_fitting_pairs]
+
+/-- **Exact AP-family count over the admissible step range.** The same exact count,
+with the sum restricted to the genuinely admissible steps `1 ≤ d ≤ ⌊(n-1)/(k-1)⌋`
+(the only `d` for which any AP fits); beyond this range every term vanishes. -/
+theorem card_vdwFamily_eq_sum_div {k : ℕ} (hk : 2 ≤ k) :
+    (vdwFamily n k).card
+      = ∑ d ∈ Finset.Icc 1 ((n - 1) / (k - 1)), (n - (k - 1) * d) := by
+  have hk1 : 0 < k - 1 := by omega
+  rw [card_vdwFamily_eq_sum hk]
+  symm
+  apply Finset.sum_subset
+  · intro d hd
+    rw [Finset.mem_Icc] at hd ⊢
+    exact ⟨hd.1, le_trans hd.2 (le_trans (Nat.div_le_self _ _) (by omega))⟩
+  · intro d hd hdnot
+    rw [Finset.mem_Icc] at hd
+    rw [Finset.mem_Icc, not_and] at hdnot
+    have hdD : (n - 1) / (k - 1) < d := by
+      have := hdnot hd.1
+      omega
+    have : n - 1 < d * (k - 1) := (Nat.div_lt_iff_lt_mul hk1).mp hdD
+    have : n ≤ (k - 1) * d := by
+      rw [Nat.mul_comm]; omega
+    omega
+
+end ProbMethod.VanDerWaerden

--- a/src/data/proofs/collatz-structured-oq-01/annotations.json
+++ b/src/data/proofs/collatz-structured-oq-01/annotations.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "ann-collatz-oq01-header",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 39
+    },
+    "type": "concept",
+    "title": "Module Header: Backward Collatz Dynamics",
+    "content": "The header (lines 1-32) states the four verified results and stresses that they are unconditional — independent of the Collatz conjecture. Lines 34-39 set up the module: `import Mathlib.Tactic`, `import Proofs.CollatzStructured` (to reuse the parent's `collatz`, `collatzIter`, and `ReachesOne`), `namespace CollatzBackward`, and `open Collatz`. By importing the parent rather than redefining the map, this entry adds genuinely new content (the backward structure) on top of the existing forward formalization.",
+    "mathContext": "The Collatz graph has vertices ℕ and edges n → collatz(n). Reading edges backwards makes the conjecture a reachability question: it holds iff every vertex lies in the basin of 1. The backward map is set-valued — each m has the even predecessor 2m and, conditionally, an odd predecessor.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Collatz conjecture",
+      "backward dynamics",
+      "Collatz graph",
+      "basin of attraction"
+    ],
+    "prerequisites": [
+      "Collatz map background",
+      "Lean 4 imports and namespaces"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq01-preimage",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 75
+    },
+    "type": "theorem",
+    "title": "Exact Preimage Characterization (collatz_eq_iff)",
+    "content": "`collatz_eq_iff` states `collatz a = m ↔ a = 2*m ∨ (a % 2 = 1 ∧ 3*a + 1 = m)`. The proof unfolds `collatz` and uses `split_ifs` on the parity test `a % 2 = 0`. In the even branch, `collatz a = a/2`, so `a/2 = m` together with `a` even forces `a = 2m` — discharged by `omega`, which reasons about `/2` and `%2` natively. In the odd branch, `collatz a = 3a+1`, giving the right disjunct directly. `preimage_collatz` restates this as the set equality `collatz ⁻¹' {m} = {a | a = 2*m ∨ (a%2=1 ∧ 3a+1=m)}`, and `even_pred` records the always-present even predecessor `collatz (2m) = m`.",
+    "mathContext": "A predecessor a of m is even (then a = 2m, the 'even predecessor') or odd (then 3a+1 = m, the 'odd predecessor'). These cases are exhaustive and exclusive, so the fiber of collatz over m is completely described. Phrasing oddness as `a % 2 = 1` (rather than `Odd a`) keeps the whole argument inside omega's linear-arithmetic-with-mod fragment.",
+    "significance": "key",
+    "relatedConcepts": [
+      "preimage",
+      "parity case analysis",
+      "omega tactic",
+      "Collatz map"
+    ],
+    "prerequisites": [
+      "Lean split_ifs and omega",
+      "natural number division and modulo"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq01-branching",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 108
+    },
+    "type": "theorem",
+    "title": "The Branching Law (odd_pred_exists_iff) and In-degree Dichotomy",
+    "content": "`odd_pred_exists_iff` proves `(∃ a, a%2=1 ∧ 3a+1=m) ↔ m % 6 = 4`. Forward: substituting an odd a and applying omega gives (3a+1) % 6 = 4. Backward: from m % 6 = 4 the explicit witness `2*(m/6)+1` is odd and satisfies 3a+1 = m. `two_preds_of_mod` then exhibits two distinct predecessors when m ≡ 4 (mod 6): the even 2m and the odd witness, distinct by parity (omega). `unique_pred_of_not_mod` shows that otherwise 2m is the sole predecessor — the odd disjunct of `collatz_eq_iff` is impossible by the branching law.",
+    "mathContext": "Writing an odd a = 2t+1 gives 3a+1 = 6t+4, so odd predecessors exist exactly for m ≡ 4 (mod 6), and the odd predecessor is (m-1)/3 = 2(m/6)+1. Combined with the universal even predecessor 2m, the Collatz graph has in-degree 2 precisely on residue 4 mod 6 and in-degree 1 elsewhere — one residue in six branches.",
+    "significance": "key",
+    "relatedConcepts": [
+      "modular arithmetic",
+      "in-degree",
+      "Collatz tree branching",
+      "explicit witness"
+    ],
+    "prerequisites": [
+      "residues mod 6",
+      "existential witnesses in Lean"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq01-closure",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 138
+    },
+    "type": "theorem",
+    "title": "Backward Closure of the Basin (reaches_one_of_collatz)",
+    "content": "`reaches_one_of_collatz` shows that if `collatz a = m` and `m` reaches 1 in k steps, then `a` reaches 1 in k+1 steps. After `simp only [collatzIter]`, `Function.iterate_succ_apply` rewrites `collatz^[k+1] a` to `collatz^[k] (collatz a)`, then `rw [h]` replaces `collatz a` with `m`, reducing to the hypothesis `collatz^[k] m = 1`. `reaches_one_odd_pred` is the odd-predecessor specialization, and `basin_closed_under_pred` packages the result as the set inclusion `collatz ⁻¹' {n | ReachesOne n} ⊆ {n | ReachesOne n}`.",
+    "mathContext": "Reaching 1 is preserved backwards along edges: a → m and m → 1 implies a → 1. Hence the basin of 1 is closed under the (set-valued) predecessor map and equals the set generated from 1 by repeatedly taking predecessors — the Collatz tree rooted at 1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "function iteration",
+      "basin of attraction",
+      "closure under preimage",
+      "Collatz tree"
+    ],
+    "prerequisites": [
+      "Function.iterate lemmas",
+      "ReachesOne predicate"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq01-infinite",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 148,
+      "endLine": 157
+    },
+    "type": "theorem",
+    "title": "The Basin of 1 is Infinite (basin_infinite)",
+    "content": "`basin_infinite` proves `{n : ℕ | ReachesOne n}.Infinite`. It applies `Set.infinite_of_injective_forall_mem` with the map `k ↦ 2^(k+1)`. Injectivity follows from `Nat.pow_right_injective (le_refl 2)` (base ≥ 2), reducing `2^(x+1) = 2^(y+1)` to `x+1 = y+1` and then omega. Membership is `pow_two_reaches_one (k+1)` from the parent file: every power of two reaches 1.",
+    "mathContext": "The component of 1 contains 2, 4, 8, 16, …, an infinite family, so it is infinite — unconditionally. This is a provable sub-statement strictly weaker than the Collatz conjecture (which would assert the component is all of ℕ≥1).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Set.Infinite",
+      "injectivity of exponentials",
+      "powers of two",
+      "unconditional result"
+    ],
+    "prerequisites": [
+      "Set.infinite_of_injective_forall_mem",
+      "Nat.pow_right_injective"
+    ]
+  },
+  {
+    "id": "ann-collatz-oq01-examples",
+    "proofId": "collatz-structured-oq-01",
+    "range": {
+      "startLine": 159,
+      "endLine": 176
+    },
+    "type": "concept",
+    "title": "Computed Examples of the Branching Structure",
+    "content": "Small instances verified by `decide` (kernel-checked, axiom-free): 16 ≡ 4 (mod 6) has predecessors 32 (even) and 5 (odd, 3·5+1 = 16); 10 ≡ 4 (mod 6) has predecessors 20 and 3; 8 ≢ 4 (mod 6) has only the even predecessor 16. These confirm the branching law on concrete numbers.",
+    "mathContext": "Illustrates the in-degree dichotomy: vertices congruent to 4 mod 6 branch (two predecessors), all others do not (the even predecessor alone). Using `decide` rather than `native_decide` keeps these checks within the kernel and free of the Lean.ofReduceBool axiom.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide tactic",
+      "branching examples",
+      "residue 4 mod 6"
+    ],
+    "prerequisites": [
+      "decidable equality on ℕ"
+    ]
+  }
+]

--- a/src/data/proofs/collatz-structured-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-01/meta.json
@@ -1,0 +1,238 @@
+{
+  "id": "collatz-structured-oq-01",
+  "title": "Backward Collatz: Preimage Structure and Infinitude of the Basin of 1",
+  "slug": "collatz-structured-oq-01",
+  "description": "Studies the backward dynamics of the Collatz map. Proves the exact preimage characterization (every predecessor of m is either the even predecessor 2m or an odd a with 3a+1=m), the mod-6 branching law (an odd predecessor exists iff m ≡ 4 mod 6), the resulting in-degree dichotomy (2 if m ≡ 4 mod 6, else 1), backward closure of the basin of 1 under predecessors, and that the basin of 1 is infinite. All results are unconditional (independent of the Collatz conjecture) and fully verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "status": "verified",
+    "proofRepoPath": "Proofs/CollatzStructuredOQ01.lean",
+    "tags": [
+      "number-theory",
+      "collatz",
+      "predecessor",
+      "preimage",
+      "dynamical-systems",
+      "graph-theory",
+      "research",
+      "verified"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 195,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "assumptions": "None. All theorems depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound); none use sorry, native_decide, or any added axiom. The results are unconditional — they do not assume the Collatz conjecture.",
+    "dateAdded": "2026-06-27",
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Collatz_conjecture",
+    "date": "Classical backward-Collatz folklore; formalized 2026",
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.infinite_of_injective_forall_mem",
+        "description": "A set is infinite if there is an injection from an infinite type into it — used to prove the basin of 1 is infinite via k ↦ 2^(k+1).",
+        "module": "Mathlib.Data.Set.Finite"
+      },
+      {
+        "theorem": "Nat.pow_right_injective",
+        "description": "For base ≥ 2, the exponential map is injective — used to show k ↦ 2^(k+1) is injective.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Function.iterate_succ_apply",
+        "description": "f^[k+1] a = f^[k] (f a) — used in the backward-closure step to peel one Collatz iteration.",
+        "module": "Mathlib.Logic.Function.Iterate"
+      }
+    ],
+    "originalContributions": [
+      "collatz_eq_iff: an exact characterization of the Collatz preimage — collatz a = m ↔ a = 2m ∨ (a odd ∧ 3a+1 = m) — proved by parity case split and omega, with no division artifacts.",
+      "odd_pred_exists_iff: the mod-6 branching law — m has an odd predecessor iff m ≡ 4 (mod 6) — with an explicit witness 2·(m/6)+1.",
+      "two_preds_of_mod / unique_pred_of_not_mod: the in-degree dichotomy of the Collatz graph (in-degree 2 exactly on residue 4 mod 6, otherwise 1).",
+      "reaches_one_of_collatz: backward closure of the basin of 1 — predecessors of basin elements are basin elements — and the set-level corollary basin_closed_under_pred.",
+      "basin_infinite: an unconditional proof that the set of numbers reaching 1 is infinite, via the injection k ↦ 2^(k+1)."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Collatz conjecture asks whether every positive integer reaches 1 under the map $n \\mapsto n/2$ ($n$ even) or $n \\mapsto 3n+1$ ($n$ odd). The conjecture concerns the *forward* orbit of each starting value. A complementary viewpoint studies the *backward* orbit: the Collatz graph, whose vertices are the positive integers and whose edges point from $n$ to $\\mathrm{collatz}(n)$. Reading these edges backwards turns the conjecture into a reachability statement — the conjecture holds iff every vertex lies in the *basin* of 1, the set of vertices from which 1 is reachable. The backward map is set-valued: a vertex $m$ has the always-present even predecessor $2m$ and, conditionally, an odd predecessor. Terras's 1976 density argument and the classical 'Collatz tree' both exploit this backward branching structure. This entry isolates and fully verifies the elementary combinatorial core of that structure.",
+    "problemStatement": "Describe the backward dynamics of the Collatz map: (1) characterize exactly the preimage $\\{a : \\mathrm{collatz}(a) = m\\}$ of each $m$; (2) determine when $m$ has more than one predecessor (the branching of the Collatz graph); (3) show the basin of 1 is closed under taking predecessors; and (4) show the basin of 1 is infinite — all unconditionally, without assuming the Collatz conjecture.",
+    "proofStrategy": "Reuse the parent file's `collatz`, `collatzIter`, and `ReachesOne` definitions. The preimage characterization is a parity case split on $a$ closed by `omega` (which handles the `/2` and `%2` reasoning natively). The branching law reduces, via the characterization, to the arithmetic fact that $\\{3a+1 : a\\text{ odd}\\} = \\{m : m \\equiv 4 \\pmod 6\\}$, again discharged by `omega` with an explicit witness. Backward closure peels one Collatz step with `Function.iterate_succ_apply`. Infinitude uses `Set.infinite_of_injective_forall_mem` with the injection $k \\mapsto 2^{k+1}$, whose image lies in the basin by the parent's `pow_two_reaches_one`.",
+    "prerequisites": [
+      "Collatz map and iteration",
+      "Modular arithmetic (residues mod 6)",
+      "Preimages and set-valued inverse maps",
+      "Lean 4 omega tactic and Set.Infinite API"
+    ],
+    "keyInsights": [
+      "The Collatz preimage is cleanly two-valued. Splitting on the parity of a predecessor $a$: if $a$ is even then $\\mathrm{collatz}(a) = a/2 = m$ forces $a = 2m$; if $a$ is odd then $\\mathrm{collatz}(a) = 3a+1 = m$. There are no other cases, giving the exact characterization `collatz a = m ↔ a = 2m ∨ (a odd ∧ 3a+1 = m)`. Stating it with `a % 2 = 1` rather than `Odd a` keeps the whole proof inside `omega`.",
+      "The odd predecessor is governed entirely by a residue. Writing an odd $a = 2t+1$ gives $3a+1 = 6t+4$, so the odd predecessors of $m$ exist iff $m \\equiv 4 \\pmod 6$, and then the unique odd predecessor is $(m-1)/3 = 2(m/6)+1$. This is the precise branching rule of the Collatz tree.",
+      "In-degree dichotomy: every vertex has the even predecessor $2m$, so vertices with $m \\equiv 4 \\pmod 6$ have in-degree (at least) 2 and all others have in-degree exactly 1. The branching is sparse and completely explicit — one in every six residues branches.",
+      "Backward closure is the engine behind 'building the Collatz tree from 1 outward'. If $\\mathrm{collatz}(a) = m$ and $m$ reaches 1 in $k$ steps, then $a$ reaches 1 in $k+1$ steps: $\\mathrm{collatz}^{[k+1]}(a) = \\mathrm{collatz}^{[k]}(\\mathrm{collatz}(a)) = \\mathrm{collatz}^{[k]}(m) = 1$. Hence the basin of 1 is exactly the set generated from 1 by repeatedly applying the (set-valued) predecessor map.",
+      "Infinitude of the basin is unconditional and elementary: $2, 4, 8, 16, \\dots$ all reach 1, and $k \\mapsto 2^{k+1}$ is an injection into the basin. This needs nothing about whether *every* integer reaches 1 — it only asserts the component of 1 is infinite, which is a far weaker (and provable) statement than the Collatz conjecture.",
+      "These results frame the Collatz conjecture as a single clean question about the structure already proved here: the basin of 1 is an explicitly branching, backward-closed, infinite set — the conjecture is exactly the assertion that this set is *all* of $\\mathbb{N}_{\\geq 1}$."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Docstring stating the four verified results (preimage characterization, branching law, backward closure, infinitude of the basin), the imports (Mathlib.Tactic and the parent CollatzStructured), the namespace CollatzBackward, and `open Collatz` to reuse the parent's collatz / collatzIter / ReachesOne definitions.",
+      "mathContext": "Sets up the backward-dynamics viewpoint: the Collatz graph with edges n → collatz(n), read in reverse. All results are unconditional structural facts about the component of 1."
+    },
+    {
+      "id": "part-i-preimage",
+      "title": "Part I: Exact Preimage Characterization",
+      "startLine": 41,
+      "endLine": 75,
+      "summary": "`collatz_eq_iff`: collatz a = m ↔ a = 2m ∨ (a%2=1 ∧ 3a+1=m), proved by `split_ifs` on the parity of a and `omega`. `preimage_collatz` re-expresses this as the explicit set collatz⁻¹'{m}. `even_pred` records that 2m always maps to m.",
+      "mathContext": "A predecessor a of m is even (then a = 2m) or odd (then 3a+1 = m). These two cases are exhaustive and mutually exclusive, giving the complete fiber of the Collatz map over m."
+    },
+    {
+      "id": "part-ii-branching",
+      "title": "Part II: The Branching Law",
+      "startLine": 77,
+      "endLine": 108,
+      "summary": "`odd_pred_exists_iff`: m has an odd predecessor iff m ≡ 4 (mod 6), with explicit witness 2·(m/6)+1. `two_preds_of_mod`: when m ≡ 4 (mod 6) there are two distinct predecessors (even 2m and the odd one). `unique_pred_of_not_mod`: otherwise 2m is the only predecessor.",
+      "mathContext": "The Collatz graph branches exactly at residue 4 mod 6: in-degree 2 there, in-degree 1 elsewhere. This is the precise combinatorial shape of the backward Collatz tree."
+    },
+    {
+      "id": "part-iii-closure",
+      "title": "Part III: Backward Closure of the Basin",
+      "startLine": 110,
+      "endLine": 138,
+      "summary": "`reaches_one_of_collatz`: if collatz a = m and m reaches 1, so does a (one extra step via Function.iterate_succ_apply). `reaches_one_odd_pred`: the odd-predecessor specialization. `basin_closed_under_pred`: collatz⁻¹'(basin) ⊆ basin.",
+      "mathContext": "The basin of 1 is closed under taking predecessors, so it is exactly the set generated from 1 by the set-valued backward map — the Collatz tree rooted at 1."
+    },
+    {
+      "id": "part-iv-infinite",
+      "title": "Part IV: The Basin of 1 is Infinite",
+      "startLine": 140,
+      "endLine": 157,
+      "summary": "`basin_infinite`: {n | ReachesOne n}.Infinite, via Set.infinite_of_injective_forall_mem with the injection k ↦ 2^(k+1) (injective by Nat.pow_right_injective; image in the basin by the parent's pow_two_reaches_one).",
+      "mathContext": "The component of 1 is infinite unconditionally: all powers of two reach 1. This is a provable lower bound on the basin, far weaker than the (open) claim that the basin is all of ℕ≥1."
+    },
+    {
+      "id": "part-v-examples",
+      "title": "Part V: Computed Examples",
+      "startLine": 159,
+      "endLine": 176,
+      "summary": "Small concrete instances verified by `decide`: predecessors of 16 (32 and 5, since 16 ≡ 4 mod 6), of 10 (20 and 3), and the single predecessor 16 of 8 (8 ≢ 4 mod 6).",
+      "mathContext": "Illustrates the branching law on small numbers: 16 and 10 branch (two predecessors each), 8 does not (only its even predecessor)."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 178,
+      "endLine": 195,
+      "summary": "Recapitulates the five proved results, emphasizes their unconditional nature, and frames the open Collatz conjecture as the single remaining question of whether the basin of 1 is all of ℕ≥1.",
+      "mathContext": "The entry reduces the conjecture to a statement about the explicitly-described basin: branching, backward-closed, infinite — is it everything?"
+    }
+  ],
+  "conclusion": {
+    "summary": "The file gives a complete, axiom-free description of the backward Collatz dynamics: the exact preimage of each m (even predecessor 2m plus an odd predecessor iff m ≡ 4 mod 6), the in-degree dichotomy of the Collatz graph, backward closure of the basin of 1, and infinitude of that basin. Every theorem is verified with 0 axioms and 0 sorries and is independent of the Collatz conjecture.",
+    "implications": "**1. Reformulation of the conjecture.** Together the results describe the basin of 1 as an explicitly branching (in-degree 2 exactly on residue 4 mod 6), backward-closed, infinite subset of ℕ. The Collatz conjecture is precisely the assertion that this subset equals ℕ≥1 — a single set-equality question about a fully characterized object.\n\n**2. The Collatz tree, made precise.** `reaches_one_of_collatz` plus the preimage law give the standard 'grow the tree from 1' construction a verified foundation: starting from 1, repeatedly adjoin the even predecessor 2m of every node and, when m ≡ 4 mod 6, the odd predecessor too. Every node so produced provably reaches 1.\n\n**3. Density beachhead.** The branching law is the elementary input to Terras-style density arguments (cf. the sibling entry collatz-structured-oq-03): one residue class in six branches, so the backward tree grows, and counting tree nodes up to N lower-bounds the density of the basin. This entry supplies the exact branching rule those arguments rely on.\n\n**4. Unconditional infinitude.** `basin_infinite` is a clean example of separating a provable sub-statement (the component of 1 is infinite) from the full open problem (the component is everything). It needs only powers of two.",
+    "openQuestions": [
+      "Can one prove an unconditional lower bound on |{n ≤ N : ReachesOne n}| by counting nodes of the backward Collatz tree using the mod-6 branching law? This would be a verified density result strictly weaker than the conjecture.",
+      "Is the basin of 1 closed under any *forward* operation beyond the trivial ones — e.g. can the preimage characterization be iterated to describe the 2-step predecessor structure (preimage of preimage) in closed residue-class form?",
+      "Does the in-degree dichotomy extend to a verified description of the Collatz graph as a tree (acyclicity of the basin minus the {1,4,2} cycle), connecting this entry to the cycle-exclusion results in the collatz-cycles family?"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "collatz_eq_iff",
+      "type": "core",
+      "description": "Exact Collatz preimage: a maps to m iff a is the even predecessor 2m or an odd number with 3a+1 = m.",
+      "leanType": "∀ a m : ℕ, collatz a = m ↔ a = 2 * m ∨ (a % 2 = 1 ∧ 3 * a + 1 = m)"
+    },
+    {
+      "name": "odd_pred_exists_iff",
+      "type": "core",
+      "description": "Branching law: m has an odd predecessor iff m ≡ 4 (mod 6).",
+      "leanType": "∀ m : ℕ, (∃ a, a % 2 = 1 ∧ 3 * a + 1 = m) ↔ m % 6 = 4"
+    },
+    {
+      "name": "two_preds_of_mod",
+      "type": "core",
+      "description": "When m ≡ 4 (mod 6), m has two distinct predecessors (the even 2m and an odd one).",
+      "leanType": "m % 6 = 4 → ∃ a b, a ≠ b ∧ collatz a = m ∧ collatz b = m"
+    },
+    {
+      "name": "unique_pred_of_not_mod",
+      "type": "supporting",
+      "description": "When m ≢ 4 (mod 6), the only predecessor of m is the even predecessor 2m.",
+      "leanType": "m % 6 ≠ 4 → collatz a = m → a = 2 * m"
+    },
+    {
+      "name": "reaches_one_of_collatz",
+      "type": "core",
+      "description": "Backward closure: if collatz a = m and m reaches 1, then a reaches 1.",
+      "leanType": "collatz a = m → ReachesOne m → ReachesOne a"
+    },
+    {
+      "name": "basin_closed_under_pred",
+      "type": "supporting",
+      "description": "The basin of 1 is closed under taking collatz-preimages.",
+      "leanType": "collatz ⁻¹' {n | ReachesOne n} ⊆ {n | ReachesOne n}"
+    },
+    {
+      "name": "basin_infinite",
+      "type": "core",
+      "description": "The set of numbers reaching 1 is infinite (contains every power of two).",
+      "leanType": "{n : ℕ | ReachesOne n}.Infinite"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "collatz-structured",
+      "relationship": "extends",
+      "description": "Parent proof establishes the forward Collatz facts (powers of two reach 1, closure under doubling) and the definitions collatz / collatzIter / ReachesOne reused here. This entry develops the complementary backward (preimage) structure."
+    },
+    {
+      "targetId": "collatz-structured-oq-03",
+      "relationship": "related",
+      "description": "Studies the average stopping time and Terras's density-1 result. The mod-6 branching law proved here is the elementary combinatorial input to counting backward-tree nodes that underlies such density arguments."
+    },
+    {
+      "targetId": "collatz-cycles",
+      "relationship": "related",
+      "description": "Proves structural constraints on Collatz cycles (no fixed points, unique cycle {1,4,2}). The backward-closure and preimage structure here describe the acyclic tree part of the Collatz graph that complements the cycle analysis."
+    },
+    {
+      "targetId": "collatz-structured-oq-02",
+      "relationship": "related",
+      "description": "Derives algebraic constraints on cycle length via the halving inequality 2^M > 3^j. Both entries dissect the elementary arithmetic of the 3n+1 step from complementary angles (cycles vs. preimages)."
+    }
+  ],
+  "references": [
+    {
+      "text": "Lagarias, J. C. (1985). The 3x+1 problem and its generalizations. American Mathematical Monthly, 92(1), 3-23.",
+      "url": "https://en.wikipedia.org/wiki/Collatz_conjecture"
+    },
+    {
+      "text": "Terras, R. (1976). A stopping time problem on the positive integers. Acta Arithmetica, 30(3), 241-252.",
+      "url": "https://en.wikipedia.org/wiki/Collatz_conjecture#Stopping_time"
+    },
+    {
+      "text": "Lagarias, J. C. (ed.) (2010). The Ultimate Challenge: The 3x+1 Problem. American Mathematical Society.",
+      "url": "https://en.wikipedia.org/wiki/Collatz_conjecture"
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/CollatzStructuredOQ01.lean",
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.CollatzStructured"
+    ],
+    "opens": [
+      "Collatz"
+    ],
+    "namespace": "CollatzBackward",
+    "lineCount": 195,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/proofs/van-der-waerden-first-moment-oq-01/annotations.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "vdw-oq01-ann-header",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "From a Loose Bound to the Exact Count",
+    "content": "The base entry `van-der-waerden-first-moment` counts the length-`k` arithmetic progressions fitting in `[n]` by the loose `n²` (every `(a,d)` pair allowed). This file sharpens that count in two layers built on the base entry's `vdwAP` / `vdwFamily` / `vdw_two_coloring_exists`. First it proves the inequality the open question asks for — a factor-`(k-1)` improvement to `n·⌊(n-1)/(k-1)⌋ < n²/(k-1)` — and feeds it through the verified Property-B engine. Then it goes further: the `(a,d)`-parametrisation is shown to be a *bijection*, so the family count is computed *exactly*.",
+    "mathContext": "Base bound: $|\\mathrm{vdwFamily}(n,k)| \\le n^2$. Target: $|\\mathrm{vdwFamily}(n,k)| \\le n\\lfloor (n-1)/(k-1)\\rfloor \\le n^2/(k-1)$, and exactly $\\sum_{d=1}^{\\lfloor (n-1)/(k-1)\\rfloor} (n-(k-1)d)$.",
+    "significance": "context",
+    "relatedConcepts": ["first-moment method", "van der Waerden numbers", "enumerative combinatorics"],
+    "prerequisites": ["the base entry van-der-waerden-first-moment", "Property B"]
+  },
+  {
+    "id": "vdw-oq01-ann-le-div",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 54, "endLine": 96 },
+    "type": "technique",
+    "title": "The Forced Step Range Gives a Factor-(k-1)",
+    "content": "`card_vdwFamily_le_div` is the inequality the open question requests. The point is that the fitting constraint `a + (k-1)d < n` is secretly a constraint on the *step*: since `a ≥ 0`, it forces `(k-1)d < n`, i.e. `d ≤ ⌊(n-1)/(k-1)⌋`. Intersecting the `(a,d)`-parameter box `{0,…,n-1} × {1,…,n}` with this sharper step range and applying `Finset.card_le_card` bounds the family by `n·⌊(n-1)/(k-1)⌋`. `card_vdwFamily_mul_le` clears the floor division to the clean `|family|·(k-1) ≤ n(n-1)`, exhibiting the full factor-`(k-1)` improvement over the base `n²`.",
+    "mathContext": "$a + (k-1)d < n,\\ a \\ge 0 \\Rightarrow (k-1)d < n \\Rightarrow d \\le \\lfloor (n-1)/(k-1)\\rfloor$, so $|\\mathrm{vdwFamily}(n,k)|\\cdot(k-1) \\le n(n-1) < n^2$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_le_card", "Nat.le_div_iff_mul_le", "step constraint"],
+    "prerequisites": ["Finset cardinality monotonicity", "natural-number division"]
+  },
+  {
+    "id": "vdw-oq01-ann-lower-bound-sharp",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 98, "endLine": 117 },
+    "type": "technique",
+    "title": "Feeding the Sharper Count Back Through Property B",
+    "content": "`vdw_lower_bound_sharp` widens the admissible range of `n` from the base `n² < 2^(k-1)` to `n(n-1) < (k-1)·2^(k-1)`. The mechanism is a single cancellation: from `|family|·(k-1) ≤ n(n-1) < (k-1)·2^(k-1)` one divides by `(k-1)` to get `|family| < 2^(k-1)`, exactly the smallness hypothesis the verified `vdw_two_coloring_exists` (the Property-B engine on the AP-hypergraph) consumes. The resulting witness is `W(k) ≳ √(k-1)·2^((k-1)/2)`, a √(k-1) improvement on the base threshold.",
+    "mathContext": "$n(n-1) < (k-1)2^{k-1} \\Rightarrow |\\mathrm{vdwFamily}(n,k)| < 2^{k-1} \\Rightarrow \\exists$ a 2-colouring of $[n]$ with no monochromatic length-$k$ AP, so $W(k) > n$.",
+    "significance": "key",
+    "relatedConcepts": ["Property B", "first-moment threshold", "lt_of_mul_lt_mul_right"],
+    "prerequisites": ["the base entry's vdw_two_coloring_exists"]
+  },
+  {
+    "id": "vdw-oq01-ann-mem",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 119, "endLine": 144 },
+    "type": "definition",
+    "title": "Decoding Membership in an AP",
+    "content": "`mem_vdwAP` unfolds the image definition of `vdwAP` to the clean characterisation: `x ∈ vdwAP n a d k` iff `x = a + i·d` (cast into `Fin n`) for some index `i < k`. This is the workhorse for the bijection: it lets specific elements of the AP be named by their index — the first term sits at `i = 0`, the second at `i = 1` — which is exactly how the parameters `a` and `d` will be read back off the set.",
+    "mathContext": "$x \\in \\mathrm{vdwAP}(n,a,d,k) \\iff \\exists\\, i < k,\\ x = \\overline{a + i d}$ where $\\overline{(\\cdot)} : \\mathbb{N} \\to \\mathrm{Fin}\\,n$ is reduction mod $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.mem_image", "arithmetic progression", "indexing"],
+    "prerequisites": ["Finset.image membership"]
+  },
+  {
+    "id": "vdw-oq01-ann-injon",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 146, "endLine": 223 },
+    "type": "technique",
+    "title": "The Parametrisation is a Bijection",
+    "content": "`vdwFamily_param_injOn` is the mathematical heart of the entry: distinct fitting `(a,d)` pairs give distinct progressions, so the `(a,d)`-parametrisation is injective and `vdwFamily` is in bijection with the fitting pairs. The proof recovers the parameters from the set. Because every term `a+i·d` stays below `n` (no wraparound), `Fin.val_cast_of_lt` makes the `Fin n` cast injective, so set equality of two APs becomes natural-number equalities. Comparing *least* elements (index 0) forces `a = a'`; comparing *second* elements (index 1) yields `i·d' = d` and `j·d = d'` for some `i, j < k`, whence `(i·j)·d = d`, so `i·j = 1`, giving `i = j = 1` and `d = d'`.",
+    "mathContext": "An AP of length $\\ge 2$ is determined as a set by its minimum ($=a$) and the gap to its next element ($=d$). The relation $i d' = d,\\ j d = d'$ forces $ij = 1$ in $\\mathbb{N}$, hence $i = j = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Set.InjOn", "Fin.val_cast_of_lt", "Nat.dvd_one", "no wraparound", "bijection"],
+    "prerequisites": ["injective casts into Fin n", "natural-number divisibility"]
+  },
+  {
+    "id": "vdw-oq01-ann-card-eq",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 225, "endLine": 233 },
+    "type": "technique",
+    "title": "Cardinality Equals the Pair Count",
+    "content": "`card_vdwFamily_eq` is the immediate payoff of the bijection: since `vdwFamily` is the image of the fitting-pair set under an injective-on-its-domain map, `Finset.card_image_of_injOn` gives `|vdwFamily(n,k)| = (number of fitting (a,d) pairs)`. This is what upgrades every `≤` in the family count to an `=`.",
+    "mathContext": "$|\\mathrm{vdwFamily}(n,k)| = |\\{(a,d) : a<n,\\ 1\\le d\\le n,\\ a+(k-1)d<n\\}|$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_image_of_injOn", "bijection", "exact count"],
+    "prerequisites": ["image cardinality under injectivity"]
+  },
+  {
+    "id": "vdw-oq01-ann-sum",
+    "proofId": "van-der-waerden-first-moment-oq-01",
+    "range": { "startLine": 234, "endLine": 281 },
+    "type": "technique",
+    "title": "The Closed-Form Exact Count",
+    "content": "`card_fitting_pairs` evaluates the pair count by double counting: `Finset.card_filter` turns it into a double sum, `Finset.sum_product` and `Finset.sum_comm` put the step `d` on the outside, and for each fixed `d` the inner filter `{a < n : a+(k-1)d < n}` is exactly `range (n-(k-1)d)`, of size `n-(k-1)d`. So the count is `∑_{d=1}^{n} (n-(k-1)d)`. `card_vdwFamily_eq_sum` combines this with the bijection, and `card_vdwFamily_eq_sum_div` restricts the sum to the admissible range `1 ≤ d ≤ ⌊(n-1)/(k-1)⌋` (terms beyond it vanish, via `Nat.div_lt_iff_lt_mul`), giving the cleanest exact formula.",
+    "mathContext": "$|\\mathrm{vdwFamily}(n,k)| = \\sum_{d=1}^{\\lfloor (n-1)/(k-1)\\rfloor} (n - (k-1)d) \\approx \\frac{n^2}{2(k-1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_filter", "Finset.sum_product", "Finset.sum_comm", "Finset.sum_subset", "double counting"],
+    "prerequisites": ["big operators over Finsets", "natural-number division inequalities"]
+  }
+]

--- a/src/data/proofs/van-der-waerden-first-moment-oq-01/meta.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-01/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "van-der-waerden-first-moment-oq-01",
+  "title": "Sharpening the van der Waerden First-Moment AP Count: From a Bound to the Exact Cardinality",
+  "slug": "van-der-waerden-first-moment-oq-01",
+  "description": "The base entry van-der-waerden-first-moment bounds the number of length-k arithmetic progressions fitting in [n] by the deliberately loose count n² (every (a,d) pair allowed), giving the union-bound threshold n² < 2^(k-1), i.e. W(k) ≳ 2^((k-1)/2). Open question van-der-waerden-first-moment-oq-01 asks to sharpen this to ~n²/(k-1), since the fitting constraint a+(k-1)d < n already forces (k-1)d < n, so the step ranges over only ⌊(n-1)/(k-1)⌋ values rather than n. This entry resolves the open question in two layers. FIRST (the inequality the OQ literally asks for): card_vdwFamily_le_div bounds the family by n·⌊(n-1)/(k-1)⌋ and card_vdwFamily_mul_le gives the division-free |family|·(k-1) ≤ n(n-1) < n²/(k-1) — a factor-(k-1) improvement — which vdw_lower_bound_sharp feeds back through the verified Property-B engine to widen the admissible range from n² < 2^(k-1) to n(n-1) < (k-1)·2^(k-1), a √(k-1) improvement giving W(k) ≳ √(k-1)·2^((k-1)/2). SECOND (the genuinely new theory-level content): the bound is upgraded from an inequality to an EXACT count. vdwFamily_param_injOn proves the (a,d)-parametrisation is injective on fitting pairs — a length-≥2 AP determines its first term (least element, index 0) and its step (gap to the next, index 1) — so the family is in bijection with the fitting pairs. card_vdwFamily_eq then gives |family| = (number of fitting (a,d) pairs), and card_fitting_pairs evaluates that to the closed sum ∑_{d=1}^{n} (n-(k-1)d); card_vdwFamily_eq_sum and card_vdwFamily_eq_sum_div assemble the exact formula |vdwFamily(n,k)| = ∑_{d=1}^{⌊(n-1)/(k-1)⌋} (n-(k-1)d). This pins down the first-moment AP count precisely and shows the n·⌊(n-1)/(k-1)⌋ upper bound is tight up to the a-range. HONESTY: the upper-bound layer (card_vdwFamily_le_div, card_vdwFamily_mul_le, vdw_lower_bound_sharp) is elementary counting; the probabilistic core remains the gallery's verified property-b-first-moment engine, consumed as a black box. The exact-count layer is the new contribution of this session: an injectivity (bijection) argument and a Finset double-counting that turn the ≤ into =.",
+  "meta": {
+    "author": "Lean Genius researcher-12",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VanDerWaerdenFirstMomentOQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 281,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The hypotheses (k ≥ 2 and the smallness bounds) are inputs to the statements, not standing assumptions. #print axioms reports only propext, Classical.choice, Quot.sound for card_vdwFamily_eq_sum, card_vdwFamily_eq_sum_div, and vdwFamily_param_injOn (verified directly). Builds on the verified base entry van-der-waerden-first-moment (vdwAP / vdwFamily / vdw_two_coloring_exists), whose probabilistic core is the gallery's property-b-first-moment engine, consumed as a black box. Badged 'original' because the new content — the (a,d)→AP bijection (vdwFamily_param_injOn), the resulting exact cardinality (card_vdwFamily_eq, card_vdwFamily_eq_sum), and the sharpened lower bound (vdw_lower_bound_sharp) — is not a Mathlib headline theorem.",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "first-moment-method",
+      "van-der-waerden",
+      "arithmetic-progressions",
+      "ramsey-theory",
+      "enumerative-combinatorics"
+    ],
+    "dateAdded": "2026-06-27",
+    "originalContributions": [
+      "vdwFamily_param_injOn: the (a,d)-parametrisation (a,d) ↦ {a, a+d, …, a+(k-1)d} is injective on the set of fitting pairs for k ≥ 2 — a length-≥2 AP determines its first term (least element) and step (gap to the next), so distinct admissible pairs give distinct progressions. This is the bijection underlying the exact count.",
+      "card_vdwFamily_eq_sum: the EXACT number of length-k APs fitting in [n] is ∑_{d=1}^{n} (n-(k-1)d) (k ≥ 2), upgrading the open question's requested inequality |family| ≤ n²/(k-1) to an equality and pinning down the first-moment AP count precisely.",
+      "card_vdwFamily_eq_sum_div: the same exact count with the sum restricted to the genuinely admissible step range 1 ≤ d ≤ ⌊(n-1)/(k-1)⌋ (terms beyond which vanish), the cleanest closed form for the family cardinality.",
+      "card_vdwFamily_le_div / card_vdwFamily_mul_le: the inequality the OQ asks for — |family| ≤ n·⌊(n-1)/(k-1)⌋ and |family|·(k-1) ≤ n(n-1) < n²/(k-1) — a factor-(k-1) improvement on the base n² bound, obtained by intersecting the (a,d)-box with the forced step range (k-1)d < n.",
+      "vdw_lower_bound_sharp: feeding the sharpened count through the verified Property-B engine widens the admissible range from n² < 2^(k-1) to n(n-1) < (k-1)·2^(k-1), a √(k-1) improvement giving W(k) ≳ √(k-1)·2^((k-1)/2)."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "an injective-on-its-domain image preserves cardinality — turns vdwFamily_param_injOn into card_vdwFamily_eq (|family| = number of fitting pairs).",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Fin.val_cast_of_lt",
+        "description": "for a < n, the Fin n cast of a has value a — the no-wraparound fact letting cast equalities be decoded back to natural-number equalities in the injectivity proof.",
+        "module": "Mathlib.Data.Fin.Basic"
+      },
+      {
+        "theorem": "Finset.card_filter / Finset.sum_product / Finset.sum_comm",
+        "description": "the double-counting that rewrites the fitting-pair count as the iterated sum ∑_d ∑_a [a+(k-1)d<n], collapsing each inner sum to n-(k-1)d (card_fitting_pairs).",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.div_lt_iff_lt_mul / Nat.div_le_self",
+        "description": "the natural-number division facts reducing the exact sum to the admissible step range 1 ≤ d ≤ ⌊(n-1)/(k-1)⌋ (card_vdwFamily_eq_sum_div).",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/VanDerWaerdenFirstMomentOQ01.lean",
+    "namespace": "ProbMethod.VanDerWaerden",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 281,
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The growth of the van der Waerden numbers W(k) is governed from below by the probabilistic method: the elementary first-moment (union-bound) argument gives W(k) ≳ 2^((k-1)/2), and the Lovász Local Lemma improves this to W(k) ≳ 2^k/(ek). The first-moment threshold is n² < 2^(k-1), where n² over-counts the length-k arithmetic progressions fitting in [n]. The exact count of such APs is a classical enumerative fact: for each admissible common difference d the first term ranges over n-(k-1)d values, so the total is ∑_{d≥1, (k-1)d<n} (n-(k-1)d) ≈ n²/(2(k-1)). Replacing the crude n² by this exact count sharpens the constant in the first-moment lower bound (it does not change the exponential rate, which only the Local Lemma improves).",
+    "problemStatement": "Open question van-der-waerden-first-moment-oq-01: sharpen the base entry's loose family bound |vdwFamily(n,k)| ≤ n² to the true order ~n²/(k-1), using that the fitting constraint a+(k-1)d < n forces the step into the range 1 ≤ d ≤ ⌊(n-1)/(k-1)⌋. Determine the exact cardinality of the AP family and feed the improvement back through the verified Property-B engine.",
+    "proofStrategy": "Two layers on top of the verified base entry. (1) Inequality: intersect the (a,d)-parameter box {0,…,n-1}×{1,…,n} with the forced step range, since a≥0 and a+(k-1)d<n give (k-1)d<n, i.e. d ≤ ⌊(n-1)/(k-1)⌋; card monotonicity then yields |family| ≤ n·⌊(n-1)/(k-1)⌋ and, clearing the division, |family|·(k-1) ≤ n(n-1). Cancelling (k-1) inside the Property-B hypothesis turns n(n-1) < (k-1)·2^(k-1) into |family| < 2^(k-1), the sharpened lower bound. (2) Exactness: prove the parametrisation (a,d) ↦ vdwAP n a d k is injective on fitting pairs. From mem_vdwAP, the least element of the AP (index i=0) is a and the next (index i=1) is a+d, both recovered by decoding Fin n casts via Fin.val_cast_of_lt; comparing least elements forces a=a', and comparing second elements forces i·d'=d and j·d=d' for indices i,j<k, whence (i·j)·d=d, so i=j=1 and d=d'. Finset.card_image_of_injOn gives |family| = (fitting-pair count); a Finset double-count (card_filter, sum_product, sum_comm) evaluates the pair count to ∑_{d=1}^{n}(n-(k-1)d), and Finset.sum_subset restricts the sum to the admissible range 1 ≤ d ≤ ⌊(n-1)/(k-1)⌋.",
+    "keyInsights": [
+      "The fitting constraint a+(k-1)d < n is really a constraint on the step: with a ≥ 0 it forces (k-1)d < n, so only ⌊(n-1)/(k-1)⌋ of the n nominal step values are admissible. This single observation is the factor-(k-1) the open question asks for.",
+      "The (a,d)-parametrisation is a bijection, not just a surjection: a length-≥2 AP, viewed as a Finset (Fin n), determines its first term as its least element and its step as the gap to the second element. This upgrades every ≤ in the family count to an =.",
+      "Decoding the bijection in Lean is the crux: an element of vdwAP n a d k is a+i·d cast into Fin n, and because every term stays below n (no wraparound) the cast is injective (Fin.val_cast_of_lt), so set equality of two APs becomes natural-number equalities a+i·d' = a+d that omega and a divisibility step (i·j=1 ⟹ i=1) finish.",
+      "The exact count ∑_{d=1}^{⌊(n-1)/(k-1)⌋}(n-(k-1)d) ≈ n²/(2(k-1)) confirms the sharpened bound is the truth: the n·⌊(n-1)/(k-1)⌋ upper bound is tight up to the a-range, and the n² base bound was loose by a full factor of about 2(k-1).",
+      "Sharpening the count improves the constant in W(k) ≳ √(k-1)·2^((k-1)/2) but not the exponential rate; only a verified Lovász Local Lemma would lift the exponent, which remains the open frontier."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview and Scope",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "States the open question — sharpen the loose n² AP count — and the two layers of the answer: the factor-(k-1) inequality and the exact cardinality. Explicit that the probabilistic core remains the verified Property-B engine."
+    },
+    {
+      "id": "sharpened-bound",
+      "title": "The Factor-(k-1) Inequality",
+      "startLine": 54,
+      "endLine": 118,
+      "summary": "card_vdwFamily_le_div bounds the family by n·⌊(n-1)/(k-1)⌋ via the forced step range; card_vdwFamily_mul_le clears the division to |family|·(k-1) ≤ n(n-1); vdw_lower_bound_sharp feeds this through the Property-B engine to the sharpened threshold n(n-1) < (k-1)·2^(k-1)."
+    },
+    {
+      "id": "exact-count",
+      "title": "The AP-Family Count is Exact",
+      "startLine": 119,
+      "endLine": 233,
+      "summary": "mem_vdwAP characterises membership; vdwFamily_param_injOn proves the (a,d)-parametrisation is injective on fitting pairs (the AP determines its first term and step), giving the bijection card_vdwFamily_eq between the family and the fitting pairs."
+    },
+    {
+      "id": "closed-sum",
+      "title": "The Closed-Form Exact Cardinality",
+      "startLine": 234,
+      "endLine": 281,
+      "summary": "card_fitting_pairs double-counts the fitting pairs as ∑_d (n-(k-1)d); card_vdwFamily_eq_sum and card_vdwFamily_eq_sum_div assemble the exact family cardinality ∑_{d=1}^{⌊(n-1)/(k-1)⌋} (n-(k-1)d)."
+    }
+  ],
+  "conclusion": {
+    "summary": "9 theorems, 0 definitions, 0 sorries, 0 axioms, no native_decide. Open question van-der-waerden-first-moment-oq-01 is resolved on two levels. The inequality it asks for — |family| ≤ n·⌊(n-1)/(k-1)⌋ < n²/(k-1) — is proved and fed through the verified Property-B engine to the sharpened first-moment lower bound n(n-1) < (k-1)·2^(k-1), giving W(k) ≳ √(k-1)·2^((k-1)/2). Beyond the inequality, the count is made EXACT: the (a,d)-parametrisation is a bijection onto the family, so |vdwFamily(n,k)| = ∑_{d=1}^{⌊(n-1)/(k-1)⌋} (n-(k-1)d) precisely.",
+    "implications": "Pins down the exact number of length-k arithmetic progressions fitting in [n], confirming the sharpened bound is the truth up to the first-term range and that the base entry's n² count was loose by a factor of about 2(k-1). The exact cardinality and the (a,d)→AP bijection are reusable enumerative facts; the sharpened lower bound improves the constant in the first-moment threshold for van der Waerden numbers.",
+    "openQuestions": [
+      "Lift the improvement from the constant to the exponent: a verified symmetric Lovász Local Lemma would give W(k) ≳ 2^k/(ek), which the first-moment method (even with the exact count) cannot reach.",
+      "Express the exact count ∑_{d=1}^{D}(n-(k-1)d) in fully closed arithmetic form nD - (k-1)·D(D+1)/2 with D = ⌊(n-1)/(k-1)⌋, and derive matching upper and lower asymptotics ~n²/(2(k-1)).",
+      "Extend the exact-count and bijection method to multidimensional or polynomial progressions, where the fitting region and the parametrisation are higher-dimensional."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "van-der-waerden-first-moment",
+      "relationship": "base — this entry sharpens that entry's loose n² AP-family bound (card_vdwFamily_le) to the exact count and the factor-(k-1) lower bound, reusing its vdwAP / vdwFamily / vdw_two_coloring_exists verbatim"
+    },
+    {
+      "targetId": "property-b-first-moment",
+      "relationship": "engine — the probabilistic core consumed by vdw_lower_bound_sharp is property_b_two_colorable (Erdős 1963 Property B via the first moment method), instantiated on the arithmetic-progression hypergraph"
+    },
+    {
+      "targetId": "erdos-138",
+      "relationship": "related — the gallery's van der Waerden entry, which axiomatizes growth/lower-bound statements; this entry sharpens the elementary first-moment lower bound proved outright in the base entry"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/van-der-waerden-first-moment-oq-01.json
+++ b/src/data/research/problems/van-der-waerden-first-moment-oq-01.json
@@ -1,0 +1,96 @@
+{
+  "slug": "van-der-waerden-first-moment-oq-01",
+  "title": "Sharpening the van der Waerden First-Moment Family Bound to n²/(k-1)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\left| \\mathrm{vdwFamily}(n, k) \\right| \\;\\le\\; n \\cdot \\left\\lfloor \\frac{n-1}{k-1} \\right\\rfloor \\;\\le\\; \\frac{n^2}{k-1}, \\qquad k \\ge 2,",
+    "plain": "How many arithmetic progressions of length $k$ fit inside the interval $\\{0, 1, \\dots, n-1\\}$? Each such progression is fixed by its starting point $a$ and its common difference (step) $d \\ge 1$. There are $n$ choices for $a$, and the existing proof crudely bounds the number of steps by $n$ as well, giving $n^2$. But the fitting constraint $a + (k-1)d < n$ forces $(k-1)d < n$, so the step can be at most $\\lfloor (n-1)/(k-1) \\rfloor$ — there are roughly $n/(k-1)$ admissible steps, not $n$. Counting the $(a,d)$ pairs with this tighter step range gives $n \\cdot \\lfloor (n-1)/(k-1) \\rfloor \\approx n^2/(k-1)$ progressions, an improvement by a factor of $k-1$.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-27T11:33:01-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE (researcher-12, 2026-06-27, VERIFIED 0-axiom): The open question — sharpen the loose n² AP-family count to ~n²/(k-1) — is resolved on two levels in Proofs/VanDerWaerdenFirstMomentOQ01.lean (281 lines, 9 theorems, 0 axioms, 0 sorries). LEVEL 1 (the inequality asked for): card_vdwFamily_le_div gives |family| ≤ n·⌊(n-1)/(k-1)⌋, card_vdwFamily_mul_le gives |family|·(k-1) ≤ n(n-1) < n²/(k-1) (factor-(k-1) improvement), and vdw_lower_bound_sharp feeds this through the verified Property-B engine to widen the threshold from n² < 2^(k-1) to n(n-1) < (k-1)·2^(k-1), giving W(k) ≳ √(k-1)·2^((k-1)/2). LEVEL 2 (new, exact): vdwFamily_param_injOn proves the (a,d)-parametrisation is a bijection onto the family (an AP of length ≥2 determines its first term = least element and step = gap to next), so card_vdwFamily_eq gives |family| = (fitting-pair count) and card_vdwFamily_eq_sum / card_vdwFamily_eq_sum_div give the EXACT closed form |vdwFamily(n,k)| = ∑_{d=1}^{⌊(n-1)/(k-1)⌋} (n-(k-1)d). #print axioms: only propext/Classical.choice/Quot.sound. NOTE: an earlier dead agent had created the LEVEL-1 upper-bound file (untracked); this session rescued it and added the LEVEL-2 exact count + gallery entry.",
+    "builtItems": [
+      "vdwFamily_param_injOn: (a,d) ↦ vdwAP n a d k injective on fitting pairs (k≥2) — the bijection, via mem_vdwAP + Fin.val_cast_of_lt decoding + Nat.dvd_one",
+      "card_vdwFamily_eq: |vdwFamily(n,k)| = (fitting-pair count) via Finset.card_image_of_injOn",
+      "card_fitting_pairs: fitting-pair count = ∑_{d∈Icc 1 n} (n-(k-1)d) via card_filter + sum_product + sum_comm double counting",
+      "card_vdwFamily_eq_sum / card_vdwFamily_eq_sum_div: the EXACT family cardinality, the latter over the admissible step range 1 ≤ d ≤ ⌊(n-1)/(k-1)⌋",
+      "card_vdwFamily_le_div / card_vdwFamily_mul_le / vdw_lower_bound_sharp: the factor-(k-1) inequality and sharpened first-moment threshold (rescued upper-bound layer)"
+    ],
+    "insights": [
+      "The fitting constraint a+(k-1)d < n with a ≥ 0 forces (k-1)d < n, i.e. d ≤ ⌊(n-1)/(k-1)⌋ — the step ranges over only ~n/(k-1) values, which is the entire source of the factor-(k-1) improvement the OQ requests.",
+      "The (a,d)-parametrisation is a BIJECTION, not merely a surjection: a length-≥2 AP viewed as a Finset (Fin n) determines its first term as its least element (index 0) and its step as the gap to the next element (index 1). This upgrades every ≤ in the family count to an =.",
+      "Decoding the bijection in Lean hinges on no-wraparound: every term a+i·d stays below n, so Fin.val_cast_of_lt makes the cast injective and set equality of two APs becomes natural-number equalities a+i·d = a+d that omega + a divisibility step (i·j=1 ⟹ i=1) finish.",
+      "The exact count ∑_{d=1}^{⌊(n-1)/(k-1)⌋}(n-(k-1)d) ≈ n²/(2(k-1)) shows the n·⌊(n-1)/(k-1)⌋ upper bound is tight up to the first-term range, and the base n² bound was loose by a factor of about 2(k-1).",
+      "Sharpening the count improves only the CONSTANT in W(k) ≳ √(k-1)·2^((k-1)/2); the exponential rate is untouched and would require a verified Lovász Local Lemma to lift."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Express ∑_{d=1}^{D}(n-(k-1)d) in fully closed arithmetic form nD - (k-1)D(D+1)/2 with D=⌊(n-1)/(k-1)⌋ and derive matching ~n²/(2(k-1)) asymptotics.",
+      "A verified symmetric Lovász Local Lemma to lift W(k) from √(k-1)·2^((k-1)/2) toward 2^k/(ek) — the exponent, which the first-moment method cannot reach.",
+      "Extend the exact-count + bijection method to multidimensional or polynomial progressions."
+    ],
+    "markdown": "# Knowledge Base: van-der-waerden-first-moment-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "probabilistic-method",
+    "van-der-waerden",
+    "arithmetic-progressions"
+  ],
+  "relatedProofs": [
+    "van-der-waerden-first-moment"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-27T11:33:01-07:00",
+  "significance": 5,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/VanDerWaerdenFirstMoment.lean",
+      "filename": "VanDerWaerdenFirstMoment.lean",
+      "lineCount": 138,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/VanDerWaerdenFirstMoment.lean"
+    },
+    {
+      "path": "Proofs/VanDerWaerdenFirstMomentOQ01.lean",
+      "filename": "VanDerWaerdenFirstMomentOQ01.lean",
+      "lineCount": 120,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/VanDerWaerdenFirstMomentOQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Open question van-der-waerden-first-moment-oq-01

Sharpen the base entry's deliberately loose `n²` count of length-`k` arithmetic progressions fitting in `[n]` to the true order `~n²/(k-1)`. This PR resolves it on **two levels** in `Proofs/VanDerWaerdenFirstMomentOQ01.lean` (281 lines, 9 theorems, **0 axioms, 0 sorries, no native_decide**).

### Level 1 — the inequality the OQ asks for (factor-`(k-1)` improvement)
The fitting constraint `a + (k-1)d < n` with `a ≥ 0` forces `(k-1)d < n`, so the step ranges over only `⌊(n-1)/(k-1)⌋` values, not `n`.
- `card_vdwFamily_le_div` — `|family| ≤ n·⌊(n-1)/(k-1)⌋`
- `card_vdwFamily_mul_le` — `|family|·(k-1) ≤ n(n-1) < n²/(k-1)`
- `vdw_lower_bound_sharp` — feeds this through the verified Property-B engine to widen the admissible range from `n² < 2^(k-1)` to `n(n-1) < (k-1)·2^(k-1)`, giving `W(k) ≳ √(k-1)·2^((k-1)/2)`

### Level 2 — the new theory-level content: `≤` upgraded to `=`
- `vdwFamily_param_injOn` — the `(a,d)`-parametrisation is a **bijection** onto the family: a length-`≥2` AP, viewed as a `Finset (Fin n)`, determines its first term (least element, index 0) and its step (gap to the next, index 1). Proved by no-wraparound cast decoding (`Fin.val_cast_of_lt`) reducing set equality to natural-number equalities, finished by `i·j = 1 ⟹ i = 1`.
- `card_vdwFamily_eq` — `|family| = ` (number of fitting `(a,d)` pairs) via `Finset.card_image_of_injOn`
- `card_fitting_pairs` / `card_vdwFamily_eq_sum` / `card_vdwFamily_eq_sum_div` — the **exact** closed form
  `|vdwFamily(n,k)| = ∑_{d=1}^{⌊(n-1)/(k-1)⌋} (n - (k-1)d) ≈ n²/(2(k-1))`

This pins the first-moment AP count down precisely and shows the `n·⌊(n-1)/(k-1)⌋` upper bound is tight up to the first-term range (the base `n²` was loose by ~`2(k-1)`).

### Provenance / honesty
The Level-1 upper-bound layer was started by an earlier (dead) agent as an **untracked** file; this session rescues it, adds the Level-2 exact count, and adds the gallery entry. The probabilistic core remains the gallery's verified `property-b-first-moment` engine, consumed as a black box. `#print axioms` reports only `propext, Classical.choice, Quot.sound` for the new results.

### Verification
- `lake env lean Proofs/VanDerWaerdenFirstMomentOQ01.lean` — clean (0 errors)
- `#print axioms card_vdwFamily_eq_sum / card_vdwFamily_eq_sum_div / vdwFamily_param_injOn` → `[propext, Classical.choice, Quot.sound]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)