### PR TITLE
Enrich Hall's theorem balanced one-sided criterion (halls-theorem-oq-02)

### DIFF
--- a/src/data/proofs/halls-theorem-oq-02/annotations.json
+++ b/src/data/proofs/halls-theorem-oq-02/annotations.json
@@ -12,16 +12,40 @@
     "prerequisites": ["bipartite graphs", "Hall's condition"]
   },
   {
-    "id": "ann-both-sides",
+    "id": "ann-setup",
     "proofId": "halls-theorem-oq-02",
-    "range": { "startLine": 44, "endLine": 89 },
+    "range": { "startLine": 33, "endLine": 42 },
+    "type": "context",
+    "title": "Imports and the Bipartite Setting",
+    "content": "The file imports Mathlib and the parent Proofs.HallsTheoremOQ01 (whose hall_marriage is the entire engine), opens Set/Function/SimpleGraph, and fixes the ambient data: a graph G on a vertex type V with parts p₁, p₂ : Set V. Every result is stated relative to G.IsBipartiteWith p₁ p₂ and the typeclass G.LocallyFinite (so neighbour sets are finite and Hall's ncard condition is meaningful). Reusing the parent rather than re-deriving the hard sufficiency direction is what keeps this entry short and 0-axiom.",
+    "mathContext": "$G : \\mathrm{SimpleGraph}\\,V$, $p_1, p_2 : \\mathrm{Set}\\,V$, $G.\\mathrm{IsBipartiteWith}\\,p_1\\,p_2$, $G.\\mathrm{LocallyFinite}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["IsBipartiteWith", "LocallyFinite", "dependency reuse"],
+    "prerequisites": ["bipartite graphs", "Lean typeclasses"]
+  },
+  {
+    "id": "ann-partner-map",
+    "proofId": "halls-theorem-oq-02",
+    "range": { "startLine": 44, "endLine": 76 },
     "type": "theorem",
-    "title": "One-Sided Hall Saturates Both Sides (Balanced Case)",
-    "content": "`isMatching_saturating_both_of_balanced`: in a locally finite bipartite graph with balanced parts (p₁.ncard = p₂.ncard, p₂ finite), the ONE-SIDED Hall condition on p₁ yields a matching M with both p₁ ⊆ M.verts and p₂ ⊆ M.verts. The proof starts from a p₁-saturating matching given by the parent's hall_marriage, then defines the matched-partner map φ v = the unique M-neighbour of v and shows: (a) φ v ∈ p₂ — M.Adj v (φ v) ⟹ G.Adj v (φ v), and bipartiteness sends neighbours of p₁ into p₂ (IsBipartiteWith.mem_of_mem_adj); (b) φ v ∈ M.verts — a partner is a matched endpoint (Subgraph.Adj.snd_mem); (c) φ is injective on p₁ — equal partners force equal vertices in a matching (IsMatching.eq_of_adj_right). Hence φ '' p₁ ⊆ p₂ with (φ '' p₁).ncard = p₁.ncard = p₂.ncard, and since p₂ is finite Set.eq_of_subset_of_ncard_le gives φ '' p₁ = p₂, so p₂ ⊆ M.verts. Neither Mathlib nor the parent has this one-sided form.",
-    "mathContext": "$|p_1|=|p_2|$, $p_2$ finite, Hall on $p_1$ $\\Rightarrow\\exists M$ with $p_1,p_2\\subseteq M.\\mathrm{verts}$; the partner map $\\varphi$ injects $p_1\\hookrightarrow p_2$, and $|\\varphi(p_1)|=|p_2|$ forces $\\varphi(p_1)=p_2$.",
+    "title": "The Matched-Partner Map and Its Injectivity",
+    "content": "Opening isMatching_saturating_both_of_balanced: hall_marriage supplies a p₁-saturating matching M. The matched-partner map φ v = the unique M-neighbour of v (defined by dependent if on v ∈ M.verts, using the matching's choose) is then shown to (a) map p₁ into p₂ — M.Adj v (φ v) ⟹ G.Adj v (φ v), and bipartiteness sends neighbours of p₁ into p₂ (IsBipartiteWith.mem_of_mem_adj); (b) land in M.verts — a partner is a matched endpoint (Subgraph.Adj.snd_mem); (c) be injective on p₁ — equal partners force equal vertices in a matching (IsMatching.eq_of_adj_right).",
+    "mathContext": "$\\varphi(v)$ = $M$-partner of $v$; $\\varphi(p_1) \\subseteq p_2 \\cap M.\\mathrm{verts}$ and $\\varphi$ injective on $p_1$.",
     "significance": "critical",
-    "relatedConcepts": ["Hall's marriage theorem", "matched-partner map", "injection-to-bijection", "Set.ncard", "bipartite saturation"],
-    "prerequisites": ["bipartite matchings", "Hall's condition", "set cardinality"]
+    "relatedConcepts": ["matched-partner map", "IsBipartiteWith.mem_of_mem_adj", "IsMatching.eq_of_adj_right", "injectivity on a set"],
+    "prerequisites": ["bipartite matchings", "Hall's condition"]
+  },
+  {
+    "id": "ann-cardinality-upgrade",
+    "proofId": "halls-theorem-oq-02",
+    "range": { "startLine": 77, "endLine": 89 },
+    "type": "insight",
+    "title": "Balance Upgrades the Injection to a Bijection",
+    "content": "The counting heart of the theorem. The image φ '' p₁ ⊆ p₂ has cardinality (φ '' p₁).ncard = p₁.ncard = p₂.ncard (Set.ncard_image_of_injOn using injectivity, then the balance hypothesis). Since p₂ is finite, a subset with ncard ≥ |p₂| must be all of p₂ (Set.eq_of_subset_of_ncard_le), so φ '' p₁ = p₂. As φ lands in M.verts, this gives p₂ ⊆ M.verts: the matching saturates the second side for free. This injection-to-bijection-via-equal-finite-cardinality move is exactly what the global Hall condition hides. Neither Mathlib nor the parent states this one-sided balanced form.",
+    "mathContext": "$|\\varphi(p_1)| = |p_1| = |p_2|$ with $p_2$ finite $\\Rightarrow \\varphi(p_1) = p_2$, so $p_2 \\subseteq M.\\mathrm{verts}$.",
+    "significance": "critical",
+    "relatedConcepts": ["injection-to-bijection", "Set.ncard", "Set.eq_of_subset_of_ncard_le", "pigeonhole", "bipartite saturation"],
+    "prerequisites": ["set cardinality", "finite sets"]
   },
   {
     "id": "ann-perfect-matching",

--- a/src/data/proofs/halls-theorem-oq-02/meta.json
+++ b/src/data/proofs/halls-theorem-oq-02/meta.json
@@ -101,20 +101,44 @@
   },
   "sections": [
     {
-      "id": "part-i",
-      "title": "Part I: Balanced One-Sided Hall Saturates Both Sides",
-      "startLine": 40,
-      "endLine": 89,
-      "summary": "isMatching_saturating_both_of_balanced: from hall_marriage's p₁-saturating matching, the matched-partner map φ injects p₁ into p₂ (bipartiteness) and into M.verts (partners are matched endpoints); injectivity comes from IsMatching.eq_of_adj_right. Balance (p₁.ncard = p₂.ncard) with p₂ finite upgrades the injection to φ '' p₁ = p₂ (Set.eq_of_subset_of_ncard_le), so p₂ ⊆ M.verts and the matching saturates both sides.",
-      "mathContext": "$\\varphi:p_1\\hookrightarrow p_2$ with $|\\varphi(p_1)|=|p_1|=|p_2|$ and $p_2$ finite $\\Rightarrow\\varphi(p_1)=p_2$, so $p_2\\subseteq M.\\mathrm{verts}$."
+      "id": "header",
+      "title": "Overview: Unbundling the Global Hall Condition",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Header docstring framing the contribution. The parent HallsTheoremOQ01 proves hall_marriage (Hall on p₁ ↔ a p₁-saturating matching) and hall_perfect (the global Hall condition ↔ a perfect matching); Mathlib's perfect-matching theorem also needs the global condition, which silently bundles p₁ ∪ p₂ = univ and p₁.ncard = p₂.ncard. This entry isolates the textbook balanced criterion: check Hall on one side, get both.",
+      "mathContext": "global Hall ≡ (one-sided Hall on p₁) ∧ (p₁ ∪ p₂ = V) ∧ (|p₁| = |p₂|)."
     },
     {
-      "id": "part-ii",
+      "id": "setup",
+      "title": "Imports and Bipartite Setup",
+      "startLine": 33,
+      "endLine": 42,
+      "summary": "Imports Mathlib and the parent Proofs.HallsTheoremOQ01, opens Set/Function/SimpleGraph, and fixes the ambient data: a graph G on V with parts p₁, p₂. All results are stated relative to G.IsBipartiteWith p₁ p₂ and G.LocallyFinite.",
+      "mathContext": "G : SimpleGraph V, parts p₁ p₂ : Set V, G.IsBipartiteWith p₁ p₂."
+    },
+    {
+      "id": "partner-map",
+      "title": "Part I·a: The Matched-Partner Map and Its Injectivity",
+      "startLine": 44,
+      "endLine": 76,
+      "summary": "Inside isMatching_saturating_both_of_balanced: hall_marriage supplies a p₁-saturating matching M; the matched-partner map φ v = the unique M-neighbour of v is shown to (a) map p₁ into p₂ via bipartiteness (IsBipartiteWith.mem_of_mem_adj), (b) land in M.verts (Subgraph.Adj.snd_mem), and (c) be injective on p₁ (IsMatching.eq_of_adj_right).",
+      "mathContext": "φ : p₁ → V, φ(v) the M-partner of v; φ(p₁) ⊆ p₂ ∩ M.verts and φ injective on p₁."
+    },
+    {
+      "id": "cardinality-upgrade",
+      "title": "Part I·b: Balance Upgrades the Injection to a Bijection",
+      "startLine": 77,
+      "endLine": 89,
+      "summary": "The image φ '' p₁ ⊆ p₂ has ncard = p₁.ncard = p₂.ncard (Set.ncard_image_of_injOn + balance), so with p₂ finite Set.eq_of_subset_of_ncard_le forces φ '' p₁ = p₂; hence p₂ ⊆ M.verts and the matching saturates both sides.",
+      "mathContext": "|φ(p₁)| = |p₁| = |p₂| with p₂ finite ⟹ φ(p₁) = p₂, so p₂ ⊆ M.verts."
+    },
+    {
+      "id": "perfect-matching",
       "title": "Part II: The Balanced Perfect-Matching Criterion",
       "startLine": 90,
       "endLine": 110,
-      "summary": "exists_isPerfectMatching_of_balanced: adding p₁ ∪ p₂ = univ to the balanced one-sided hypotheses makes the both-sides-saturating matching spanning (its vertex set ⊇ p₁ ∪ p₂ = univ, via Subgraph.isSpanning_iff), hence a SimpleGraph perfect matching — the practical bipartite criterion in its natural one-sided form, with the global Hall condition replaced by balance + covering + one-sided Hall.",
-      "mathContext": "$p_1\\subseteq M.\\mathrm{verts}\\wedge p_2\\subseteq M.\\mathrm{verts}\\wedge p_1\\cup p_2=V\\Rightarrow M.\\mathrm{verts}=V$, i.e. $M$ is a perfect matching."
+      "summary": "exists_isPerfectMatching_of_balanced: adding p₁ ∪ p₂ = univ to the balanced one-sided hypotheses makes the both-sides-saturating matching spanning (M.verts ⊇ p₁ ∪ p₂ = univ, via Subgraph.isSpanning_iff), hence a SimpleGraph perfect matching — the practical bipartite criterion with the global Hall condition replaced by balance + covering + one-sided Hall.",
+      "mathContext": "p₁ ⊆ M.verts ∧ p₂ ⊆ M.verts ∧ p₁ ∪ p₂ = V ⟹ M.verts = V, i.e. M is a perfect matching."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `halls-theorem-oq-02` (passes: 0, quality: 79 → 98).

## Gaps addressed
The quality breakdown showed `sections: 4` (only 2 coarse sections, missing the header) and `annotations: 15` (only 3).

- **Sections 2 → 5**: added an overview section (header docstring) and a setup section (imports + bipartite setting), and split the single proof section into the matched-partner-map/injectivity step and the cardinality-upgrade (injection→bijection) step.
- **Annotations 3 → 5**: added a setup annotation and split the large both-sides theorem annotation into a partner-map annotation and a cardinality-upgrade annotation — each with mathContext, significance, relatedConcepts, prerequisites.

## Verification
- `meta.json` within the 60 KB cap.
- Quality score 79 → 98 (sections 4→10, annotations 15→25).
- `pnpm build` passes (✓ built).
- No axiom/status changes; existing verified/0-axiom claims intact.