### PR TITLE
research(sperner-ndim-oq-02): adj_unique_facet cross-cell uniqueness [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -668,4 +668,71 @@ theorem pivot_ne (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
   intro h
   exact pivot_opposite_ne s a b hb (by rw [h])
 
+-- ============================================================
+-- SECTION: At most one neighbour across a facet (adj_unique_facet)
+-- ============================================================
+-- The abstract `adj_unique_facet` field requires that two *distinct*
+-- facets of a cell `s` cannot both be glued to the *same* neighbour `t`
+-- — geometrically, two `d`-simplices share at most one common
+-- `(d-1)`-face.  This section proves exactly that, purely from the facet
+-- combinatorics and per-geometry uniqueness already established, so the
+-- eventual `adj` discharge can cite it directly.  The key step is that
+-- the union of two distinct facets of a cell is its *entire* vertex set;
+-- if both facets also lie in a second cell `t`, then `t`'s `d + 1`
+-- vertices contain `s`'s `d + 1` vertices, forcing equal vertex sets and
+-- hence `s = t`.  All 0-sorry, 0-axiom.
+
+/-- **The union of two distinct facets is the full vertex set.**  Facet
+`k₁` omits only vertex `k₁` and facet `k₂` omits only vertex `k₂`; when
+`k₁ ≠ k₂` each omitted vertex is supplied by the other facet, so the
+union recovers all `d + 1` vertices of the cell. -/
+theorem facet_union_facet (s : CanonSimplex d N) {k₁ k₂ : Fin (d + 1)}
+    (h : k₁ ≠ k₂) :
+    facet s k₁ ∪ facet s k₂ = Finset.univ.image (vertices s) := by
+  rw [facet, facet, ← Finset.image_union]
+  congr 1
+  apply Finset.eq_univ_of_forall
+  intro a
+  rw [Finset.mem_union, Finset.mem_erase, Finset.mem_erase]
+  by_cases ha : a = k₁
+  · exact Or.inr ⟨ha ▸ h, Finset.mem_univ _⟩
+  · exact Or.inl ⟨ha, Finset.mem_univ _⟩
+
+/-- A canonical cell has exactly `d + 1` distinct Kuhn vertices: the
+image of `univ` under the injective vertex map. -/
+theorem image_univ_card (s : CanonSimplex d N) :
+    (Finset.univ.image (vertices s)).card = d + 1 := by
+  rw [Finset.card_image_of_injective _ (vertices_injective s), Finset.card_univ,
+    Fintype.card_fin]
+
+/-- **At most one neighbour across a facet (`adj_unique_facet`).**  If a cell
+`s` shares two facets `k₁, k₂` with the *same* other cell `t`
+(`facet s k₁ = facet t l₁`, `facet s k₂ = facet t l₂`, `s ≠ t`), then in fact
+`k₁ = k₂`.  Otherwise the two distinct facets of `s` would union to all of `s`'s
+vertices while both lying inside `t`'s vertex set; equal cardinalities then force
+`s` and `t` to have the same vertex set, so `canon_eq_of_vertices_range` gives
+`s = t`, contradicting `s ≠ t`.  This is exactly the content of the abstract
+`adj_unique_facet` compatibility field: a neighbour is glued across at most one
+facet of `s`. -/
+theorem facet_unique_neighbor {s t : CanonSimplex d N}
+    {k₁ k₂ l₁ l₂ : Fin (d + 1)} (hne : s ≠ t)
+    (h₁ : facet s k₁ = facet t l₁) (h₂ : facet s k₂ = facet t l₂) :
+    k₁ = k₂ := by
+  by_contra hk
+  have hs : Finset.univ.image (vertices s) = facet s k₁ ∪ facet s k₂ :=
+    (facet_union_facet s hk).symm
+  have hsub : Finset.univ.image (vertices s) ⊆ Finset.univ.image (vertices t) := by
+    rw [hs, h₁, h₂]
+    apply Finset.union_subset
+    · rw [facet]; exact Finset.image_subset_image (Finset.erase_subset _ _)
+    · rw [facet]; exact Finset.image_subset_image (Finset.erase_subset _ _)
+  have hcard :
+      (Finset.univ.image (vertices t)).card ≤ (Finset.univ.image (vertices s)).card := by
+    rw [image_univ_card, image_univ_card]
+  have heq : Finset.univ.image (vertices s) = Finset.univ.image (vertices t) :=
+    Finset.eq_of_subset_of_card_le hsub hcard
+  apply hne
+  apply canon_eq_of_vertices_range
+  rw [← coe_image_univ_vertices s, ← coe_image_univ_vertices t, heq]
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1,5 +1,55 @@
 # sperner-ndim-oq-02: Boundary-Door Oddness by Dimensional Induction
 
+## Session 2026-06-27 (researcher-1) — At-most-one-neighbour across a facet (`adj_unique_facet`)
+
+**Mode**: ACT (CONTINUE Phase-1). **Outcome**: PROGRESS — added the
+"At most one neighbour across a facet" section to `SpernerNDimOQ02.lean`
+(+3 theorems), appended after the concurrently-merged interior-pivot
+section (`pivotSimplex`, the existence half). **Type-check VERIFIED via
+`lake env lean` against the main-repo olean cache (EXIT 0, no
+errors/warnings)**; **`#print axioms` obtained** — all three new theorems
+depend only on `[propext, Classical.choice, Quot.sound]`, i.e. **genuinely
+0-axiom** (no `sorryAx`/`Lean.ofReduceBool`/`native_decide`). Docker host
+still unusable (containerd meta.db I/O), so verified via the single-file
+`lake env lean` channel (worktree `.lake` symlinks to the main repo cache).
+Rebased onto a fresh branch off origin/main after a concurrent sperner PR
+(interior Freudenthal pivot) landed mid-session.
+
+### What was delivered (`SpernerNDimOQ02.lean`, new section)
+
+The cross-cell uniqueness underlying the abstract `adj_unique_facet` field —
+*two distinct facets of a cell cannot both be glued to the same neighbour*
+(equivalently, two `d`-simplices share at most one common `(d-1)`-face). Proven
+purely from the facet combinatorics + per-geometry uniqueness already in place:
+
+- `facet_union_facet s (h : k₁ ≠ k₂) : facet s k₁ ∪ facet s k₂ =
+  univ.image (vertices s)`. The union of two *distinct* facets is the cell's
+  full vertex set: facet `k₁` omits only `k₁`, facet `k₂` omits only `k₂`, and
+  when `k₁ ≠ k₂` each omitted vertex is supplied by the other. Proof:
+  `← Finset.image_union` + `univ.erase k₁ ∪ univ.erase k₂ = univ`.
+- `image_univ_card s : (univ.image (vertices s)).card = d + 1`. Cell has `d+1`
+  distinct Kuhn vertices (`card_image_of_injective` + `vertices_injective`).
+- `facet_unique_neighbor (hne : s ≠ t) (h₁ : facet s k₁ = facet t l₁)
+  (h₂ : facet s k₂ = facet t l₂) : k₁ = k₂`. **Capstone = `adj_unique_facet`
+  content.** If `k₁ ≠ k₂`, the union `facet s k₁ ∪ facet s k₂` is all of `s`'s
+  vertices, yet both facets lie inside `t`'s `d+1`-vertex set; equal cards force
+  `univ.image (vertices s) = univ.image (vertices t)`, so
+  `canon_eq_of_vertices_range` gives `s = t` — contradicting `s ≠ t`.
+
+### Why this matters (Phase-1)
+
+`adj_unique_facet` is one of the five `adj` compatibility fields. Its
+*cross-cell* direction (same neighbour `t`, two facets of `s`) needs the
+vertex-set/cardinality argument above, now closed and 0-axiom — `facet_injective`
+alone (within-cell) does not give it. Combined with `facet_injective` and
+`facet_vertex_injective` (global facet+vertex ↦ cell+index), the uniqueness
+scaffolding the eventual `adj` discharge cites for `adj_unique_facet` is
+complete. Remaining for a full instance: the `adj` *function* (Freudenthal
+facet-search — the interior pivot existence is now in place via `pivotSimplex`)
+plus `adj_symm`, `adj_vertices`, `adj_ne`, `boundary_face`.
+
+---
+
 ## Session 2026-06-27 (Session 11, researcher-3) — Cell recovery from (facet, opposite-vertex)
 
 **Mode**: ACT (CONTINUE Phase-1). **Outcome**: PROGRESS — added the

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-27T00:00:00.000Z",
-    "iteration": 6,
-    "focus": "Option C, Phase-1 carrier. The facet combinatorics of CanonSimplex in proofs/Proofs/SpernerNDimOQ02.lean (facet def + mem_facet_iff + vertices_not_mem_facet + facet_card[=d] + facet_injective + not_mem_facet_iff) — the within-cell building blocks for the abstract adj_vertices/adj_unique_facet fields — are now VERIFIED 0-axiom (Session 11): clean lake env lean build, #print axioms = [propext, Classical.choice, Quot.sound] only. The entire Phase-1 carrier (CanonSimplex + canon_eq_of_vertices_range + vertices/vertices_injective) and the BaryPoint≃Vertex bridge are likewise 0-axiom. Next is the adj facet-adjacency function (Freudenthal pivot) + its 5 compatibility fields + boundary_face.",
+    "iteration": 7,
+    "focus": "Option C, Phase-1 carrier. This session adds the cross-cell adj_unique_facet uniqueness lemma (facet_unique_neighbor: two distinct facets of a cell cannot both glue to the same neighbour) plus its supports facet_union_facet and image_univ_card, all VERIFIED 0-axiom (clean lake env lean build, #print axioms = [propext, Classical.choice, Quot.sound] only). Together with facet_injective (within-cell), facet_vertex_injective (global), and the concurrently-merged interior-pivot existence (pivotSimplex/pivot_facet_eq/pivot_ne), the adj_unique_facet scaffolding is complete. Remaining for a full SpernerTriangulation instance: the adj search function itself + adj_symm/adj_vertices/adj_ne/boundary_face.",
     "blockers": [
       "The remaining open frontier is the adj field: a facet-adjacency function Simplex → Fin (d+1) → Option (Simplex × Fin (d+1)) realising the Freudenthal pivot, plus its 5 compatibility fields (adj_symm, adj_vertices, adj_ne, adj_unique_facet, boundary_face). facet_injective supplies the within-cell half of adj_unique_facet; the cross-cell half needs canon_eq_of_vertices_range. Estimated ~300-500 lines.",
       "INFRA NOTE: Docker build host containerd metadata DB is corrupt (meta.db I/O error on image inspect/build), so docker-build.sh is unusable; verification this session used the local single-file fallback (lake env lean) after lake exe cache get repaired the host Mathlib olean cache to complete (7382 + root). Do NOT docker-prune while peer builds run."
     ],
-    "nextAction": "Build adj via finite facet-search over CanonSimplex (the unique other canonical cell sharing facet k, or none on the boundary); discharge adj_vertices from facet defs, adj_unique_facet from facet_injective + canon_eq_of_vertices_range, boundary_face via onFace_toVertex. Then Phase 2 (inductive last-face-door oddness), apply sperner_ndim; retire false boundary_doors_odd. (Re-verification of the facet section is DONE — verified 0-axiom Session 11.)",
+    "nextAction": "Build adj via finite facet-search over CanonSimplex; adj_unique_facet now cites facet_unique_neighbor directly (DONE this session), the interior pivot supplies neighbour existence (pivotSimplex), adj_vertices/adj_ne are immediate from the search predicate, adj_symm needs search symmetry, boundary_face via onFace_toVertex. Then Phase 2 (inductive last-face-door oddness), apply sperner_ndim; retire false boundary_doors_odd.",
     "attemptCounts": {
       "total": 3,
       "currentApproach": 1,
@@ -32,8 +32,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (interior Freudenthal pivot VERIFIED 0-axiom): the chain-interior facet neighbour now EXISTS as an honest GridSimplex (pivotSimplex) that shares the facet (pivot_facet_eq) and is a different cell (pivot_ne/pivot_opposite_ne) — the existence half boundary_face needs. Remaining for full adj: canonicalisation of the pivot into CanonSimplex, the two boundary-chain pivots, and the adj search itself. OQ target (last-face door oddness) still open.",
+    "progressSummary": "PROGRESS (adj_unique_facet cross-cell uniqueness VERIFIED 0-axiom): facet_unique_neighbor (two distinct facets of a cell cannot glue to one neighbour) + supports facet_union_facet and image_univ_card, all machine-checked 0-axiom on top of the facet combinatorics, BaryPoint≃Vertex bridge, and geometry-uniqueness. Combined with the concurrently-merged interior Freudenthal pivot (pivotSimplex, neighbour existence), only the adj search function + adj_symm/adj_vertices/adj_ne/boundary_face remain for a full SpernerTriangulation instance. The open OQ target (boundary_doors_odd / last-face door oddness) is still unsolved.",
     "builtItems": [
+      "proofs/Proofs/SpernerNDimOQ02.lean (adj_unique_facet uniqueness, VERIFIED 0-axiom: clean lake env lean build, #print axioms = [propext, Classical.choice, Quot.sound] only): facet_union_facet (union of two distinct facets = full vertex set); image_univ_card (cell has d+1 distinct Kuhn vertices); facet_unique_neighbor (two distinct facets of a cell cannot both glue to the same neighbour t — the cross-cell content of the abstract adj_unique_facet field, via vertex-set/cardinality + canon_eq_of_vertices_range).",
       "proofs/Proofs/SpernerNDimOQ02.lean (facet combinatorics, VERIFIED 0-axiom Session 11: clean lake env lean build, #print axioms = [propext, Classical.choice, Quot.sound] only): facet s k := (univ.erase k).image (vertices s); mem_facet_iff; vertices_not_mem_facet (deleted vertex is the unique vertex absent from its facet); facet_card (each facet has exactly d vertices); facet_injective (the d+1 facets of a cell are distinct = within-cell half of adj_unique_facet); not_mem_facet_iff (facet+cell determine the removed index). Building blocks for the abstract adj_vertices/adj_unique_facet fields.",
       "proofs/Proofs/SpernerNDimOQ02.lean (Session 3, VERIFIED): baryEquivVertex d N : BaryPoint d N ≃ Vertex d N (toVertex drops last bary coord, toBary appends slack N-∑); coord simp lemmas; onFace_toVertex (face correspondence); isSperner_iff (transports Sperner condition). 0 sorries, 0 new axioms. This is Option C step 0.",
       "SpernerGridBase.lean: factored GridSimplex foundation (structure+DecidableEq+Fintype+verts_injective+coord trackers, SpernerGrid lines 241-513) into clean base — verified 0-axiom",
@@ -53,6 +54,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "DONE (this session, VERIFIED 0-axiom): adj_unique_facet cross-cell uniqueness (facet_unique_neighbor + facet_union_facet + image_univ_card)",
       "Canonicalise the pivot: build a CanonSimplex from any GridSimplex with the same vertex set (re-select lex-min base + reorder chain), so the interior neighbour lands back in the carrier; combine with pivot_facet_eq to get a canonical partner sharing facet (CanonSimplex level).",
       "Boundary-chain pivots: handle deleted vertex a.succ = 0 (vertex index 0) and = d (Fin.last) — these change the base/miss and are the genuine boundary vs interior dichotomy.",
       "Define adj by finite facet-search over CanonSimplex; discharge adj_symm/adj_vertices/adj_ne via facet_vertex_injective + pivot existence, boundary_face via (contrapositive) interior⟹pivot-partner.",
@@ -75,7 +77,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.382Z",
-  "lastUpdate": "2026-06-27T22:10:00.000Z",
+  "lastUpdate": "2026-06-27",
   "significance": 8,
   "tractability": 6,
   "leanVerified": true,


### PR DESCRIPTION
## Summary

Advances the Phase-1 `CanonSimplex` carrier for `sperner-ndim-oq-02` (n-dimensional Sperner) by proving the **cross-cell content of the abstract `SpernerTriangulation.adj_unique_facet` field**: two distinct facets of a cell cannot both be glued to the same neighbour (equivalently, two `d`-simplices share at most one common `(d-1)`-face).

Three new theorems in `proofs/Proofs/SpernerNDimOQ02.lean`, appended after the concurrently-merged interior-pivot section:

- **`facet_union_facet`** — the union of two *distinct* facets of a cell is its entire vertex set (each omitted vertex is supplied by the other facet).
- **`image_univ_card`** — a canonical cell has exactly `d + 1` distinct Kuhn vertices.
- **`facet_unique_neighbor`** — if `facet s k₁ = facet t l₁`, `facet s k₂ = facet t l₂`, and `s ≠ t`, then `k₁ = k₂`. If the indices differed, the two facets would union to all of `s`'s vertices while both sitting inside `t`'s `d+1`-vertex set; equal cardinalities force equal vertex sets, so `canon_eq_of_vertices_range` gives `s = t`, contradicting `s ≠ t`.

This is exactly the uniqueness the eventual `adj` discharge cites for `adj_unique_facet`. `facet_injective` alone supplies only the within-cell direction; the cross-cell direction (same neighbour `t`) needs the vertex-set/cardinality argument here.

## Verification

- Type-checks via `lake env lean Proofs/SpernerNDimOQ02.lean` (EXIT 0, no errors/warnings) against the main-repo olean cache. Docker host is unusable (containerd `meta.db` I/O error), so the single-file channel was used.
- `#print axioms` on all three theorems: `[propext, Classical.choice, Quot.sound]` only — **genuinely 0-axiom** (no `sorryAx`/`Lean.ofReduceBool`/`native_decide`).

## Status

`sperner-ndim-oq-02` remains **in-progress / axiomCount 0**. The open OQ target (last-face door oddness) is still unsolved; remaining for a full `SpernerTriangulation` instance: the `adj` search function + `adj_symm`/`adj_vertices`/`adj_ne`/`boundary_face`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)