### PR TITLE
research(erdos-340-greedy-sidon-oq-05): greedy B_h extension + explicit greedy family [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos340GreedySidonOQ05.lean
+++ b/proofs/Proofs/Erdos340GreedySidonOQ05.lean
@@ -61,6 +61,11 @@ upper bound.
   bound: it shows `B_h` sets of unbounded size exist, leaving only the *rate*
   (`N^{1/(2h-1)}` inside `{1,…,N}`) open.
 
+* `greedyBhSet` / `exists_isBh_card` — **explicit greedy family**.  Iterating the
+  extension gives, for every `h ≥ 1` and every `n`, a concrete `B_h` set of
+  cardinality exactly `n`.  This isolates the open content: the *count* of a `B_h`
+  set is unbounded for free; only the size of its *largest element* is hard.
+
 ## Mathematical note
 
 The bound is *sharp in order*: Singer difference sets give `B_2` sets of size
@@ -554,5 +559,52 @@ theorem IsBh.exists_insert {h : ℕ} {A : Finset ℕ} (hh : 1 ≤ h) (hA : IsBh 
   have hle : (h * A.sup id + 1) ≤ A.sup id := Finset.le_sup (f := id) hmem
   have hpos : A.sup id ≤ h * A.sup id := Nat.le_mul_of_pos_left _ hh
   omega
+
+/-! ## Part 6: An explicit greedy `B_h` family
+
+Iterating `IsBh.exists_insert` realises the qualitative consequence of the extension
+lemma: `B_h` sets of *every* cardinality exist (the parent's `greedySidonSeq` does the
+same for `B_2`).  This pins down precisely what is — and is not — open: the *count*
+of a `B_h` set is unbounded for free; the hard quantitative question is how small its
+*largest element* can be, i.e. the `N^{1/(2h-1)}` greedy lower bound inside `{1,…,N}`. -/
+
+/-- The empty set is `B_h` for every `h`. -/
+theorem isBh_empty {h : ℕ} : IsBh h (∅ : Finset ℕ) := by
+  intro s hs t _ _
+  rcases Nat.eq_zero_or_pos h with rfl | hpos
+  · exact Subsingleton.elim s t
+  · rw [Finset.mem_coe] at hs
+    obtain ⟨k, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hpos.ne'
+    rw [Finset.sym_empty] at hs
+    exact absurd hs (Finset.notMem_empty s)
+
+/-- Greedy construction bundled with its invariants.  Starting from `∅`, repeatedly
+adjoin a witness of `IsBh.exists_insert`; stage `n` is a `B_h` set of cardinality `n`. -/
+noncomputable def greedyBhAux (h : ℕ) (hh : 1 ≤ h) :
+    (n : ℕ) → {A : Finset ℕ // IsBh h A ∧ A.card = n}
+  | 0 => ⟨∅, isBh_empty, Finset.card_empty⟩
+  | n + 1 =>
+      let prev := greedyBhAux h hh n
+      let m := Classical.choose (prev.2.1.exists_insert hh)
+      have hm := Classical.choose_spec (prev.2.1.exists_insert hh)
+      ⟨insert m prev.1, hm.2, by rw [Finset.card_insert_of_notMem hm.1, prev.2.2]⟩
+
+/-- The greedy `B_h` set at stage `n` (cardinality `n`). -/
+noncomputable def greedyBhSet (h : ℕ) (hh : 1 ≤ h) (n : ℕ) : Finset ℕ :=
+  (greedyBhAux h hh n).1
+
+theorem greedyBhSet_isBh {h : ℕ} (hh : 1 ≤ h) (n : ℕ) :
+    IsBh h (greedyBhSet h hh n) := (greedyBhAux h hh n).2.1
+
+theorem greedyBhSet_card {h : ℕ} (hh : 1 ≤ h) (n : ℕ) :
+    (greedyBhSet h hh n).card = n := (greedyBhAux h hh n).2.2
+
+/-- **`B_h` sets of every cardinality exist.**  For each `h ≥ 1` and each `n`, the
+greedy construction yields a `B_h` set with exactly `n` elements; in particular the
+cardinality of a `B_h` set is a-priori unbounded.  The open quantitative question is
+how small the largest element can be — the `N^{1/(2h-1)}` greedy lower bound. -/
+theorem exists_isBh_card (h : ℕ) (hh : 1 ≤ h) (n : ℕ) :
+    ∃ A : Finset ℕ, IsBh h A ∧ A.card = n :=
+  ⟨greedyBhSet h hh n, greedyBhSet_isBh hh n, greedyBhSet_card hh n⟩
 
 end Erdos340Bh

--- a/proofs/Proofs/Erdos340GreedySidonOQ05.lean
+++ b/proofs/Proofs/Erdos340GreedySidonOQ05.lean
@@ -53,6 +53,14 @@ upper bound.
   `B_h` property, since every `h`-fold sum increases by the same `h·c`.  This
   justifies normalising a `B_h` set by a translation without loss of generality.
 
+* `IsBh.insert_of_large` / `IsBh.exists_insert` — **greedy extension**.  If `A` is
+  `B_h` and `m > h·(max A)` then `insert m A` is `B_h`; consequently every `B_h` set
+  can be extended by a new element (the explicit witness `m = h·(max A) + 1`).  This
+  is the `B_h` analogue of the parent file's `sidon_insert_of_large` /
+  `sidon_exists_extension`, and the constructive seed for the (open) `B_h` lower
+  bound: it shows `B_h` sets of unbounded size exist, leaving only the *rate*
+  (`N^{1/(2h-1)}` inside `{1,…,N}`) open.
+
 ## Mathematical note
 
 The bound is *sharp in order*: Singer difference sets give `B_2` sets of size
@@ -418,5 +426,133 @@ theorem IsBh.map_add_right {h c : ℕ} {A : Finset ℕ} (hA : IsBh h A) :
   calc s = (s.map (· - c)).map (· + c) := (hrec hs).symm
     _ = (t.map (· - c)).map (· + c) := by rw [hpeq]
     _ = t := hrec ht
+
+/-! ## Part 5: The greedy `B_h` extension
+
+The deep open direction for #340 (and its `B_h` generalization) is the *lower*
+bound: how large a `B_h` set can the greedy algorithm guarantee inside `{1, …, N}`?
+The first ingredient is that a `B_h` set can *always* be extended by one new, very
+large, element.  This is the `B_h` analogue of the parent file's
+`sidon_insert_of_large` / `sidon_exists_extension`. -/
+
+/-- **Decomposition of an `h`-multiset over `insert m A`.**  Every entry of an
+`h`-multiset `s` over `insert m A` is either the new point `m` or lies in `A`, so `s`
+splits as `j` copies of `m` plus a multiset `sA` drawn entirely from `A`, where `j`
+is the multiplicity of `m`.  Records the cardinality and sum bookkeeping used by the
+extension argument. -/
+private theorem bh_split {h m : ℕ} {A : Finset ℕ} {s : Sym ℕ h}
+    (hs : ∀ x ∈ (s : Multiset ℕ), x ∈ insert m A) :
+    ∃ j sA, (s : Multiset ℕ) = Multiset.replicate j m + sA ∧
+      (∀ x ∈ sA, x ∈ A) ∧ Multiset.card sA = h - j ∧ j ≤ h ∧
+      (s : Multiset ℕ).sum = j * m + sA.sum := by
+  classical
+  set j := (s : Multiset ℕ).count m with hj
+  set sA := (s : Multiset ℕ).filter (· ≠ m) with hsA
+  have hcard : Multiset.card (s : Multiset ℕ) = h := s.2
+  -- `s` is its `m`-part (a replicate block) plus its `A`-part.
+  have hsplit : (s : Multiset ℕ) = Multiset.replicate j m + sA := by
+    rw [hj, hsA]
+    conv_lhs => rw [← Multiset.filter_add_not (· = m) (s : Multiset ℕ)]
+    rw [Multiset.filter_eq']
+  refine ⟨j, sA, hsplit, ?_, ?_, ?_, ?_⟩
+  · -- every entry of the `A`-part lies in `A`
+    intro x hx
+    rw [hsA] at hx
+    have hx' : x ∈ (s : Multiset ℕ) := (Multiset.mem_filter.mp hx).1
+    have hxne : x ≠ m := (Multiset.mem_filter.mp hx).2
+    rcases Finset.mem_insert.mp (hs x hx') with h1 | h1
+    · exact absurd h1 hxne
+    · exact h1
+  · -- `card sA = h - j`
+    have hcc := congrArg Multiset.card hsplit
+    rw [Multiset.card_add, Multiset.card_replicate] at hcc
+    omega
+  · -- `j ≤ h`
+    have hle : j ≤ Multiset.card (s : Multiset ℕ) := hj ▸ Multiset.count_le_card m _
+    omega
+  · -- the sum splits as `j·m + (A-part sum)`
+    have hsum := congrArg Multiset.sum hsplit
+    rw [Multiset.sum_add, Multiset.sum_replicate, smul_eq_mul] at hsum
+    exact hsum
+
+/-- **Greedy extension of a `B_h` set.**  If `A` is `B_h` (`h ≥ 1`) and the new point
+`m` exceeds `h · (max A)`, then `insert m A` is again `B_h`.
+
+*Proof.*  Decompose two colliding `h`-multisets over `insert m A` by their
+multiplicity of `m`: `s = j·{m} + s_A`, `t = k·{m} + t_A` with `s_A, t_A ⊆ A`.  Each
+`A`-part has sum at most `h · (max A) < m`, so the collision `j·m + s_A = k·m + t_A`
+forces `j = k` (otherwise the two sides differ by at least `m`).  Then `s_A` and `t_A`
+have equal sums and lie in `A.sym (h-j)`; as `A` is `B_{h-j}` (downward closure) they
+coincide, whence `s = t`. ∎ -/
+theorem IsBh.insert_of_large {h m : ℕ} {A : Finset ℕ}
+    (hA : IsBh h A) (hbig : h * A.sup id < m) : IsBh h (insert m A) := by
+  intro s hs t ht hsum
+  rw [Finset.mem_coe, Finset.mem_sym_iff] at hs ht
+  have hsM : ∀ x ∈ (s : Multiset ℕ), x ∈ insert m A := hs
+  have htM : ∀ x ∈ (t : Multiset ℕ), x ∈ insert m A := ht
+  obtain ⟨j, sA, hsplitS, hmemS, hcardS, hjh, hsumS⟩ := bh_split hsM
+  obtain ⟨k, tA, hsplitT, hmemT, hcardT, hkh, hsumT⟩ := bh_split htM
+  -- The `A`-part sums are bounded by `h · (max A) < m`.
+  have hSbound : sA.sum ≤ h * A.sup id := by
+    have h1 : sA.sum ≤ Multiset.card sA • A.sup id :=
+      Multiset.sum_le_card_nsmul sA (A.sup id)
+        (fun x hx => (Finset.le_sup (f := id) (hmemS x hx)))
+    rw [smul_eq_mul] at h1
+    have h2 : Multiset.card sA * A.sup id ≤ h * A.sup id := by
+      have : Multiset.card sA ≤ h := by omega
+      gcongr
+    omega
+  have hTbound : tA.sum ≤ h * A.sup id := by
+    have h1 : tA.sum ≤ Multiset.card tA • A.sup id :=
+      Multiset.sum_le_card_nsmul tA (A.sup id)
+        (fun x hx => (Finset.le_sup (f := id) (hmemT x hx)))
+    rw [smul_eq_mul] at h1
+    have h2 : Multiset.card tA * A.sup id ≤ h * A.sup id := by
+      have : Multiset.card tA ≤ h := by omega
+      gcongr
+    omega
+  have hsum0 : (s : Multiset ℕ).sum = (t : Multiset ℕ).sum := hsum
+  rw [hsumS, hsumT] at hsum0
+  -- `j = k`: a strict inequality would make the two `m`-blocks differ by ≥ m.
+  have hjk : j = k := by
+    rcases lt_trichotomy j k with hlt | heq | hgt
+    · exfalso
+      have hexp : (j + 1) * m = j * m + m := by ring
+      have hkm : (j + 1) * m ≤ k * m := by
+        have : j + 1 ≤ k := by omega
+        gcongr
+      omega
+    · exact heq
+    · exfalso
+      have hexp : (k + 1) * m = k * m + m := by ring
+      have hkm : (k + 1) * m ≤ j * m := by
+        have : k + 1 ≤ j := by omega
+        gcongr
+      omega
+  subst hjk
+  have hABsum : sA.sum = tA.sum := by omega
+  -- The `A`-parts are equal `(h-j)`-multisets by the `B_{h-j}` property.
+  have hbh : IsBh (h - j) A := hA.of_le (Nat.sub_le h j)
+  let sS : Sym ℕ (h - j) := ⟨sA, hcardS⟩
+  let tS : Sym ℕ (h - j) := ⟨tA, hcardT⟩
+  have memS : sS ∈ A.sym (h - j) := Finset.mem_sym_iff.mpr hmemS
+  have memT : tS ∈ A.sym (h - j) := Finset.mem_sym_iff.mpr hmemT
+  have hsymeq : sS = tS :=
+    hbh (Finset.mem_coe.mpr memS) (Finset.mem_coe.mpr memT) hABsum
+  have hAB : sA = tA := congrArg Subtype.val hsymeq
+  apply Sym.coe_injective
+  rw [hsplitS, hsplitT, hAB]
+
+/-- **Existence of a greedy extension.**  Every `B_h` set (`h ≥ 1`) can be extended
+by a new element: there is some `m ∉ A` with `insert m A` still `B_h`; concretely
+`m = h · (max A) + 1` works.  Iterating produces `B_h` sets of unbounded size — the
+constructive starting point for the `B_h` analogue of #340's greedy lower bound. -/
+theorem IsBh.exists_insert {h : ℕ} {A : Finset ℕ} (hh : 1 ≤ h) (hA : IsBh h A) :
+    ∃ m, m ∉ A ∧ IsBh h (insert m A) := by
+  refine ⟨h * A.sup id + 1, ?_, hA.insert_of_large (by omega)⟩
+  intro hmem
+  have hle : (h * A.sup id + 1) ≤ A.sup id := Finset.le_sup (f := id) hmem
+  have hpos : A.sup id ≤ h * A.sup id := Nat.le_mul_of_pos_left _ hh
+  omega
 
 end Erdos340Bh

--- a/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
@@ -193,3 +193,38 @@ to its olean (`lake env lean -o`), then `lake env lean Proofs/Erdos340GreedySido
   insertion breaks B_h) by `O(|A|^{2h-1})`, giving the greedy `N^{1/(2h-1)}` lower
   bound — the remaining open core, matching the still-open parent #340.
 - Iterate `exists_insert` into an explicit greedy B_h sequence à la `greedySidonSeq`.
+
+### Session 2026-06-27 (Session 4 cont., researcher-2) — explicit greedy B_h family
+
+**Mode**: ACT · **Outcome**: progress (verified increment, 0 sorries / 0 axioms).
+Added to the same PR (#30985) as the greedy extension.
+
+#### What I Did
+- Iterated `IsBh.exists_insert` into an **explicit greedy family** realizing the
+  qualitative payoff of extendability:
+  - `isBh_empty`: `∅` is B_h (h=0 domain `∅.sym 0` is a `Sym`-subsingleton; h≥1
+    domain `∅.sym (k+1) = ∅`).
+  - `greedyBhAux h hh : (n:ℕ) → {A : Finset ℕ // IsBh h A ∧ A.card = n}` — a
+    subtype-bundled structural recursion that carries the B_h proof *alongside* the
+    set, so `exists_insert`'s `IsBh` hypothesis is available at each step. Witness via
+    `Classical.choose (prev.2.1.exists_insert hh)`; `choose_spec` gives
+    `m∉prev ∧ B_h (insert m prev)`. card step: `Finset.card_insert_of_notMem`.
+  - Projections `greedyBhSet` / `greedyBhSet_isBh` / `greedyBhSet_card`.
+  - `exists_isBh_card`: for every h≥1 and n, a B_h set of cardinality exactly n exists.
+
+#### Why it matters
+SEPARATES the open question cleanly: a B_h set's *count* is unbounded for free
+(this result); the genuinely open core is how small the *largest element* can be —
+the N^{1/(2h-1)} greedy lower bound inside {1,…,N}.
+
+#### Gotchas
+- Bundle the invariant in a subtype and recurse on it — you cannot define the set by
+  plain `Nat.rec` and prove B_h separately, because the next witness *depends on* the
+  current B_h proof. The `{A // IsBh h A ∧ A.card = n}` carrier solves this.
+- `Finset.card_insert_of_not_mem` is deprecated → `Finset.card_insert_of_notMem`.
+- `noncomputable` required (Classical.choose). #print axioms = propext /
+  Classical.choice / Quot.sound only (0-axiom in the policy sense).
+
+#### Verification
+`lake env lean` exit 0, no warnings. `#print axioms exists_isBh_card / greedyBhSet_card`
+= 3 foundational only. 558 → 610 lines, 19 → 24 theorems, 2 → 4 defs.

--- a/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
@@ -140,3 +140,56 @@ theorems 8 → 14 (incl. 3 private helpers + `pair_eq_of_sidon`).
 #### Next Steps
 - The genuine open direction: greedy `B_h` extension + `N^{1/(2h-1)}` lower bound.
 - Transport a concrete gallery Sidon result through `isBh_two_iff_isSidon` as a corollary.
+
+### Session 2026-06-27 (Session 4, researcher-2) — greedy B_h extension
+
+**Mode**: ACT · **Outcome**: progress (verified increment, 0 sorries / 0 axioms).
+
+#### What I Did
+- Closed the first listed next-step's *constructive seed*: the **greedy B_h
+  extension**, the B_h analogue of the parent's `sidon_insert_of_large` /
+  `sidon_exists_extension`.
+  - `IsBh.insert_of_large`: if `A` is B_h and `m > h·(A.sup id)` then `insert m A`
+    is B_h. (No `h ≥ 1` needed — `h = 0` is the trivial singleton-domain case.)
+  - `IsBh.exists_insert`: every B_h set has *some* extension `m ∉ A` keeping it B_h;
+    explicit witness `m = h·(A.sup id) + 1`. Iterating ⟹ B_h sets of unbounded size.
+  - Private engine `bh_split`: any `h`-multiset `s` over `insert m A` decomposes as
+    `j•{m} + s_A` where `j = (s:Multiset).count m` and `s_A = filter (·≠m)` lies in
+    `A`; records `card s_A = h-j`, `j ≤ h`, and `sum s = j·m + sum s_A`.
+
+#### Proof idea
+Two colliding multisets give `j·m + Σs_A = k·m + Σt_A`. Each A-part sum is
+`≤ (h-j)·(max A) ≤ h·(max A) < m`, so a strict `j ≠ k` forces one side to exceed
+the other by `≥ m` — contradiction; hence `j = k`, then `Σs_A = Σt_A`, and the
+`(h-j)`-multiset A-parts coincide by downward closure (`of_le` to `B_{h-j}`),
+giving `s = t`.
+
+#### Key Findings / gotchas
+- `Multiset.filter_add_not` has `p` as the FIRST explicit arg (re-`variable (p)`
+  before it in Mathlib): call `Multiset.filter_add_not (· = m) (s : Multiset ℕ)`.
+- `Multiset.filter_eq' s b : s.filter (· = b) = replicate (count b s) b` (the primed
+  version uses `(· = b)`; unprimed uses `(b = ·)`). `filter (·≠m)` is defeq to
+  `filter (fun a => ¬ (·=m) a)`, so `rw` closes the split by `rfl` despite the
+  un-beta-reduced form.
+- For `x ∈ filter p s`, use `Multiset.mem_filter.mp hx` (gives `⟨x∈s, p x⟩`) — the
+  bare `Multiset.of_mem_filter`/`mem_of_mem_filter` mis-unified the predicate here.
+- `mul_le_mul_right'` is deprecated → replaced monotonicity steps with `gcongr`
+  (discharges the `a ≤ b` side goal from a local `have`).
+- The nonlinear `j*m` vs `k*m` comparison is fed to `omega` as atoms: supply
+  `hexp : (j+1)*m = j*m + m` (by `ring`) and `hkm : (j+1)*m ≤ k*m` (by `gcongr`),
+  then `omega` treats `j*m, k*m` as opaque and finishes linearly.
+- Sum bound via `Multiset.sum_le_card_nsmul s (A.sup id) (…) : s.sum ≤ card s • sup`
+  + `smul_eq_mul`; per-element `x ≤ A.sup id` from `Finset.le_sup (f := id)`.
+
+#### Verification
+Docker host build path unavailable; built the imported `Proofs.Erdos340GreedySidon`
+to its olean (`lake env lean -o`), then `lake env lean Proofs/Erdos340GreedySidonOQ05.lean`
+→ exit 0, no warnings. `#print axioms IsBh.insert_of_large / IsBh.exists_insert`
+= only `propext / Classical.choice / Quot.sound` (0-axiom). 422 → 558 lines,
+14 → 19 theorems (incl. private `bh_split`), 1 → 2 defs (counting `symPair`).
+
+#### Next Steps
+- Turn extendability into a *rate*: bound the FORBIDDEN set (values in `[1,N]` whose
+  insertion breaks B_h) by `O(|A|^{2h-1})`, giving the greedy `N^{1/(2h-1)}` lower
+  bound — the remaining open core, matching the still-open parent #340.
+- Iterate `exists_insert` into an explicit greedy B_h sequence à la `greedySidonSeq`.

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -6,16 +6,16 @@
   "tier": "B",
   "tractability": "medium — the foundational B_h theory and the sharp B_h counting upper bound are now formalized and verified (0-axiom). The deep open direction (improving the greedy B_h lower bound toward the N^{1/h} ceiling) remains open, exactly as for the parent #340.",
   "started": "2026-06-27",
-  "lastUpdate": "2026-06-27T16:30:00.000Z",
+  "lastUpdate": "2026-06-27T16:55:00.000Z",
   "path": "research/problems/erdos-340-greedy-sidon-oq-05",
   "leanFiles": [
     {
       "path": "Proofs/Erdos340GreedySidonOQ05.lean",
       "filename": "Erdos340GreedySidonOQ05.lean",
-      "lineCount": 558,
-      "theoremCount": 19,
+      "lineCount": 610,
+      "theoremCount": 24,
       "axiomCount": 0,
-      "defCount": 2,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos340GreedySidonOQ05.lean"
@@ -48,7 +48,8 @@
       "h=2 omega gotcha: from choose(k,2) = k(k-1)/2 ≤ 2N, deriving k(k-1) ≤ 4N requires the EVENNESS of k(k-1) (else k(k-1)=4N+1 is a spurious omega counterexample). Supply 2 ∣ k(k-1) via (Nat.even_mul_pred_self k).two_dvd before omega.",
       "The h=2 case of IsBh is provably IDENTICAL to the gallery IsSidon (isBh_two_iff_isSidon, 0-axiom). This upgrades the \"B_h generalizes #340\" claim from informal to a machine-checked equivalence: every Erdos340 Sidon result is literally the h=2 instance of the new B_h theory. Bridge API: Multiset.card_eq_two, Multiset.pair_comm, Sym.coe_injective, Sym.mem_coe; the symPair a b := ⟨{a,b}, by simp⟩ helper packages an unordered pair as Sym ℕ 2 with coe/sum/mem lemmas.",
       "GREEDY EXTENSION (the constructive seed for the lower-bound direction): a B_h set A can ALWAYS be extended by one new very-large element. IsBh.insert_of_large: if A is B_h and m > h·(max A) (m > h * A.sup id), then insert m A is B_h. Proof engine (private bh_split): any h-multiset s over insert m A splits as s = j•{m} + s_A with j = (s:Multiset).count m and s_A = filter(·≠m) drawn entirely from A; sum s = j·m + sum s_A, card s_A = h-j. For two colliding multisets j·m + Σs_A = k·m + Σt_A: since each A-part sum ≤ (h-j)·(max A) ≤ h·(max A) < m, a strict j≠k would make one side exceed the other by ≥ m, so j=k; then Σs_A = Σt_A and the (h-j)-multiset A-parts coincide by downward closure (of_le to B_{h-j}), giving s=t. Note h≥1 is NOT needed (h=0 is the trivial singleton-domain case).",
-      "IsBh.exists_insert: every B_h set has SOME extension m∉A with insert m A still B_h; the explicit witness m = h·(max A) + 1 works (m∉A because any a∈A has a ≤ max A ≤ h·max A < m via Nat.le_mul_of_pos_left, needs h≥1). Iterating yields B_h sets of unbounded size — the constructive starting point for the B_h greedy lower bound. This is the B_h analogue of the parent's sidon_insert_of_large / sidon_exists_extension."
+      "IsBh.exists_insert: every B_h set has SOME extension m∉A with insert m A still B_h; the explicit witness m = h·(max A) + 1 works (m∉A because any a∈A has a ≤ max A ≤ h·max A < m via Nat.le_mul_of_pos_left, needs h≥1). Iterating yields B_h sets of unbounded size — the constructive starting point for the B_h greedy lower bound. This is the B_h analogue of the parent's sidon_insert_of_large / sidon_exists_extension.",
+      "EXPLICIT GREEDY FAMILY: iterating exists_insert gives, for every h≥1 and every n, a concrete B_h set of cardinality EXACTLY n (exists_isBh_card). Built via greedyBhAux : (n:ℕ) → {A : Finset ℕ // IsBh h A ∧ A.card = n} — a subtype-bundled structural recursion that carries the B_h proof alongside the set so that exists_insert's hypothesis is available at each definition step (Classical.choose the witness; choose_spec gives m∉A ∧ B_h(insert m A)). Projections greedyBhSet/_isBh/_card. Needs isBh_empty (∅ is B_h: h=0 domain is a Sym-subsingleton, h≥1 domain is empty). This SEPARATES the open question: a B_h set's COUNT is unbounded for free; the open core is how small its LARGEST ELEMENT can be (the N^{1/(2h-1)} bound). 0-axiom (Classical.choice only)."
     ],
     "builtItems": [
       "Erdos340GreedySidonOQ05.lean: def IsBh (h-fold-sum-distinctness via multiset-sum InjOn on A.sym h); IsBh.subset; isBh_one (every set is B_1); IsBh.sum_injOn_powersetCard (distinct h-subset sums); IsBh.choose_card_le (MAIN: Nat.choose |A| h ≤ h·N for B_h A ⊆ [1,N]); IsBh.two_card_mul_pred_le (Sidon recovery |A|(|A|-1) ≤ 4N). 206 lines, 6 theorems, 1 def, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only).",
@@ -56,7 +57,8 @@
       "IsBh.of_le: B_h ⟹ B_k for all k ≤ h (iterates of_succ via Nat.le_induction)",
       "IsBh.isSidon / IsSidon.isBh_two / isBh_two_iff_isSidon: the EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A (gallery classical Sidon def). Forward: unordered pairs {a,b},{c,d} ∈ A.sym 2 with equal multiset-sums ⟹ {a,b}={c,d} by B_2 injectivity ⟹ a=c,b=d via orderings. Reverse: Multiset.card_eq_two writes each Sym ℕ 2 elt as {a,b}; pair_eq_of_sidon feeds the correctly-ordered quadruple (4 le_total cases) to IsSidon, giving {a,b}={c,d} ⟹ s=t via Sym.coe_injective. 0-axiom verified.",
       "IsBh.map_add_right: translation invariance — shifting every element of a B_h set by a fixed c preserves B_h (each h-fold sum increases by h·c).",
-      "bh_split (private), IsBh.insert_of_large, IsBh.exists_insert: the greedy B_h extension. insert_of_large: A B_h, m > h·(A.sup id) ⟹ insert m A B_h (via the count-m/filter split + downward closure). exists_insert: explicit always-available extension m = h·A.sup id + 1. 0-axiom verified. Key API: Multiset.filter_add_not, Multiset.filter_eq', Multiset.sum_replicate, Multiset.sum_le_card_nsmul, Finset.le_sup, Nat.le_mul_of_pos_left."
+      "bh_split (private), IsBh.insert_of_large, IsBh.exists_insert: the greedy B_h extension. insert_of_large: A B_h, m > h·(A.sup id) ⟹ insert m A B_h (via the count-m/filter split + downward closure). exists_insert: explicit always-available extension m = h·A.sup id + 1. 0-axiom verified. Key API: Multiset.filter_add_not, Multiset.filter_eq', Multiset.sum_replicate, Multiset.sum_le_card_nsmul, Finset.le_sup, Nat.le_mul_of_pos_left.",
+      "isBh_empty (∅ is B_h); greedyBhAux (subtype-bundled {A // IsBh h A ∧ A.card = n} recursion iterating exists_insert via Classical.choose); greedyBhSet/greedyBhSet_isBh/greedyBhSet_card projections; exists_isBh_card (for every h≥1, n: ∃ B_h set of card exactly n). The explicit greedy family. 0-axiom (Classical.choice only)."
     ],
     "mathlibGaps": [
       "Mathlib has no B_h-set theory and no Sidon/B_h upper bound; the whole development is original relative to Mathlib.",
@@ -67,6 +69,6 @@
       "Prove the maximal-set lower bound directly: if A ⊆ [1,N] is B_h and maximal (no n ∈ [1,N] extends it), then N ≤ |A| + (number of values blocked by a collision), and bound the blocked count by |A|^{2h-1}.",
       "With the bridge in hand, transport a concrete gallery Sidon result (e.g. sidon_upper_bound_weak or an explicit small Sidon set) through isBh_two_iff_isSidon as a sanity corollary."
     ],
-    "progressSummary": "PROGRESS: Foundational B_h theory + sharp upper bound Nat.choose |A| h ≤ h·N + downward closure (of_succ/of_le) + EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A + translation invariance + GREEDY EXTENSION (insert_of_large: m > h·max A ⟹ insert m A B_h; exists_insert: explicit always-available extension), all verified 0-axiom (Erdos340GreedySidonOQ05.lean, 550 lines, 19 theorems). The lower-bound direction now has its constructive seed (B_h sets are arbitrarily extendable); the remaining open core is the forbidden-set counting that turns extendability into the N^{1/(2h-1)} growth rate — matching the still-open parent #340."
+    "progressSummary": "PROGRESS: Foundational B_h theory + sharp upper bound Nat.choose |A| h ≤ h·N + downward closure (of_succ/of_le) + EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A + translation invariance + GREEDY EXTENSION (insert_of_large, exists_insert) + EXPLICIT GREEDY FAMILY (greedyBhAux/greedyBhSet; exists_isBh_card: a B_h set of every cardinality n exists for each h≥1), all verified 0-axiom (Erdos340GreedySidonOQ05.lean, 605 lines, 24 theorems). The construction cleanly SEPARATES the open question: a B_h set's count is unbounded for free; the remaining open core is the forbidden-set counting bounding the LARGEST element, i.e. the N^{1/(2h-1)} growth rate inside {1,…,N} — matching the still-open parent #340."
   }
 }

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -6,16 +6,16 @@
   "tier": "B",
   "tractability": "medium — the foundational B_h theory and the sharp B_h counting upper bound are now formalized and verified (0-axiom). The deep open direction (improving the greedy B_h lower bound toward the N^{1/h} ceiling) remains open, exactly as for the parent #340.",
   "started": "2026-06-27",
-  "lastUpdate": "2026-06-27T13:30:00.000Z",
+  "lastUpdate": "2026-06-27T16:30:00.000Z",
   "path": "research/problems/erdos-340-greedy-sidon-oq-05",
   "leanFiles": [
     {
       "path": "Proofs/Erdos340GreedySidonOQ05.lean",
       "filename": "Erdos340GreedySidonOQ05.lean",
-      "lineCount": 258,
-      "theoremCount": 8,
+      "lineCount": 558,
+      "theoremCount": 19,
       "axiomCount": 0,
-      "defCount": 1,
+      "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos340GreedySidonOQ05.lean"
@@ -46,22 +46,27 @@
       "At h = 2 the bound reads choose(|A|,2) = |A|·(|A|-1)/2 ≤ 2N, i.e. |A|·(|A|-1) ≤ 4N (theorem IsBh.two_card_mul_pred_le) — exactly the classical Sidon bound |A| = O(√N), confirming B_h genuinely generalizes #340's B_2 case. For general h it gives |A| = O(N^{1/h}), the trivial B_h ceiling that Bose-Chowla constructions meet to within (1-o(1)).",
       "Using h-subsets (powersetCard, card = Nat.choose) instead of all h-multisets (Finset.sym, whose Finset-level cardinality is NOT directly available in Mathlib as a multichoose lemma) is what makes the counting bound clean: Finset.card_powersetCard gives the exact choose count, and Finset.card_image_of_injOn + Nat.card_Icc finish it.",
       "h=2 omega gotcha: from choose(k,2) = k(k-1)/2 ≤ 2N, deriving k(k-1) ≤ 4N requires the EVENNESS of k(k-1) (else k(k-1)=4N+1 is a spurious omega counterexample). Supply 2 ∣ k(k-1) via (Nat.even_mul_pred_self k).two_dvd before omega.",
-      "The h=2 case of IsBh is provably IDENTICAL to the gallery IsSidon (isBh_two_iff_isSidon, 0-axiom). This upgrades the \"B_h generalizes #340\" claim from informal to a machine-checked equivalence: every Erdos340 Sidon result is literally the h=2 instance of the new B_h theory. Bridge API: Multiset.card_eq_two, Multiset.pair_comm, Sym.coe_injective, Sym.mem_coe; the symPair a b := ⟨{a,b}, by simp⟩ helper packages an unordered pair as Sym ℕ 2 with coe/sum/mem lemmas."
+      "The h=2 case of IsBh is provably IDENTICAL to the gallery IsSidon (isBh_two_iff_isSidon, 0-axiom). This upgrades the \"B_h generalizes #340\" claim from informal to a machine-checked equivalence: every Erdos340 Sidon result is literally the h=2 instance of the new B_h theory. Bridge API: Multiset.card_eq_two, Multiset.pair_comm, Sym.coe_injective, Sym.mem_coe; the symPair a b := ⟨{a,b}, by simp⟩ helper packages an unordered pair as Sym ℕ 2 with coe/sum/mem lemmas.",
+      "GREEDY EXTENSION (the constructive seed for the lower-bound direction): a B_h set A can ALWAYS be extended by one new very-large element. IsBh.insert_of_large: if A is B_h and m > h·(max A) (m > h * A.sup id), then insert m A is B_h. Proof engine (private bh_split): any h-multiset s over insert m A splits as s = j•{m} + s_A with j = (s:Multiset).count m and s_A = filter(·≠m) drawn entirely from A; sum s = j·m + sum s_A, card s_A = h-j. For two colliding multisets j·m + Σs_A = k·m + Σt_A: since each A-part sum ≤ (h-j)·(max A) ≤ h·(max A) < m, a strict j≠k would make one side exceed the other by ≥ m, so j=k; then Σs_A = Σt_A and the (h-j)-multiset A-parts coincide by downward closure (of_le to B_{h-j}), giving s=t. Note h≥1 is NOT needed (h=0 is the trivial singleton-domain case).",
+      "IsBh.exists_insert: every B_h set has SOME extension m∉A with insert m A still B_h; the explicit witness m = h·(max A) + 1 works (m∉A because any a∈A has a ≤ max A ≤ h·max A < m via Nat.le_mul_of_pos_left, needs h≥1). Iterating yields B_h sets of unbounded size — the constructive starting point for the B_h greedy lower bound. This is the B_h analogue of the parent's sidon_insert_of_large / sidon_exists_extension."
     ],
     "builtItems": [
       "Erdos340GreedySidonOQ05.lean: def IsBh (h-fold-sum-distinctness via multiset-sum InjOn on A.sym h); IsBh.subset; isBh_one (every set is B_1); IsBh.sum_injOn_powersetCard (distinct h-subset sums); IsBh.choose_card_le (MAIN: Nat.choose |A| h ≤ h·N for B_h A ⊆ [1,N]); IsBh.two_card_mul_pred_le (Sidon recovery |A|(|A|-1) ≤ 4N). 206 lines, 6 theorems, 1 def, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only).",
       "IsBh.of_succ: B_{h+1} ⟹ B_h downward closure (append a fixed element, cancel head via Sym.cons_inj_right)",
       "IsBh.of_le: B_h ⟹ B_k for all k ≤ h (iterates of_succ via Nat.le_induction)",
-      "IsBh.isSidon / IsSidon.isBh_two / isBh_two_iff_isSidon: the EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A (gallery classical Sidon def). Forward: unordered pairs {a,b},{c,d} ∈ A.sym 2 with equal multiset-sums ⟹ {a,b}={c,d} by B_2 injectivity ⟹ a=c,b=d via orderings. Reverse: Multiset.card_eq_two writes each Sym ℕ 2 elt as {a,b}; pair_eq_of_sidon feeds the correctly-ordered quadruple (4 le_total cases) to IsSidon, giving {a,b}={c,d} ⟹ s=t via Sym.coe_injective. 0-axiom verified."
+      "IsBh.isSidon / IsSidon.isBh_two / isBh_two_iff_isSidon: the EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A (gallery classical Sidon def). Forward: unordered pairs {a,b},{c,d} ∈ A.sym 2 with equal multiset-sums ⟹ {a,b}={c,d} by B_2 injectivity ⟹ a=c,b=d via orderings. Reverse: Multiset.card_eq_two writes each Sym ℕ 2 elt as {a,b}; pair_eq_of_sidon feeds the correctly-ordered quadruple (4 le_total cases) to IsSidon, giving {a,b}={c,d} ⟹ s=t via Sym.coe_injective. 0-axiom verified.",
+      "IsBh.map_add_right: translation invariance — shifting every element of a B_h set by a fixed c preserves B_h (each h-fold sum increases by h·c).",
+      "bh_split (private), IsBh.insert_of_large, IsBh.exists_insert: the greedy B_h extension. insert_of_large: A B_h, m > h·(A.sup id) ⟹ insert m A B_h (via the count-m/filter split + downward closure). exists_insert: explicit always-available extension m = h·A.sup id + 1. 0-axiom verified. Key API: Multiset.filter_add_not, Multiset.filter_eq', Multiset.sum_replicate, Multiset.sum_le_card_nsmul, Finset.le_sup, Nat.le_mul_of_pos_left."
     ],
     "mathlibGaps": [
       "Mathlib has no B_h-set theory and no Sidon/B_h upper bound; the whole development is original relative to Mathlib.",
       "Finset.sym s n has no direct cardinality (multichoose) lemma in Mathlib — only the Fintype-level Sym.card_sym_eq_choose. This is why the counting bound is routed through h-subsets (powersetCard, which DOES have card_powersetCard) rather than the full multiset family."
     ],
     "nextSteps": [
-      "Formalize a B_h analogue of the greedy extension lemma (parent file sidon_exists_extension / nextSidon) to build a greedy B_h sequence and prove its N^{1/(2h-1)} lower bound — the genuine open direction matching the parent #340.",
+      "Iterate IsBh.exists_insert into an explicit greedy B_h sequence (Nat-indexed recursion picking the next valid element, as the parent's greedySidonSeq does), then quantify the growth rate. The current insert_of_large uses the crude witness m > h·(max A); to get the N^{1/(2h-1)} lower bound one must instead show the FORBIDDEN set (values whose insertion breaks B_h) inside [1,N] has size O(|A|^{2h-1}), so some m ≤ N is always available until |A| ~ N^{1/(2h-1)}. This forbidden-set counting is the remaining open core.",
+      "Prove the maximal-set lower bound directly: if A ⊆ [1,N] is B_h and maximal (no n ∈ [1,N] extends it), then N ≤ |A| + (number of values blocked by a collision), and bound the blocked count by |A|^{2h-1}.",
       "With the bridge in hand, transport a concrete gallery Sidon result (e.g. sidon_upper_bound_weak or an explicit small Sidon set) through isBh_two_iff_isSidon as a sanity corollary."
     ],
-    "progressSummary": "PROGRESS: Foundational B_h theory + sharp upper bound Nat.choose |A| h ≤ h·N + downward closure (of_succ/of_le) + EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A, all verified 0-axiom (Erdos340GreedySidonOQ05.lean, 346 lines). The B_h def is now machine-certified to coincide with the gallery Sidon def at h=2. Deep open direction (greedy B_h N^{1/(2h-1)} lower bound) remains, as for parent #340."
+    "progressSummary": "PROGRESS: Foundational B_h theory + sharp upper bound Nat.choose |A| h ≤ h·N + downward closure (of_succ/of_le) + EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A + translation invariance + GREEDY EXTENSION (insert_of_large: m > h·max A ⟹ insert m A B_h; exists_insert: explicit always-available extension), all verified 0-axiom (Erdos340GreedySidonOQ05.lean, 550 lines, 19 theorems). The lower-bound direction now has its constructive seed (B_h sets are arbitrarily extendable); the remaining open core is the forbidden-set counting that turns extendability into the N^{1/(2h-1)} growth rate — matching the still-open parent #340."
   }
 }


### PR DESCRIPTION
## Summary

Extends the verified B_h theory for Erdős #340 OQ-05 with the **greedy extension** and an **explicit greedy family** — the constructive side of the (still-open) B_h lower-bound direction, mirroring the parent file's `sidon_insert_of_large` / `sidon_exists_extension` / `greedySidonSeq`.

| Result | Statement |
|--------|-----------|
| `IsBh.insert_of_large` | `A` is B_h and `m > h·(max A)` ⟹ `insert m A` is B_h |
| `IsBh.exists_insert` | every B_h set extends by some `m ∉ A` (witness `h·(max A)+1`) |
| `bh_split` (private) | decompose an `h`-multiset over `insert m A` into `j·{m}` + an `A`-part |
| `isBh_empty` | `∅` is B_h |
| `greedyBhAux` / `greedyBhSet` | subtype-bundled greedy recursion carrying the B_h invariant |
| `exists_isBh_card` | for every `h ≥ 1`, `n`: a B_h set of cardinality exactly `n` exists |

### Proof idea (extension)
Two colliding `h`-multisets over `insert m A` split by the multiplicity of `m`: `j·{m} + s_A` and `k·{m} + t_A` with `s_A, t_A ⊆ A`. Each A-part sum is `≤ h·(max A) < m`, so a strict `j ≠ k` forces the two sides to differ by `≥ m` — hence `j = k`; then `s_A, t_A` have equal sums and coincide by downward closure (`of_le` to B_{h-j}), giving `s = t`.

### Why the family matters
It isolates the open content: a B_h set's **count** is unbounded for free; the genuinely open core is how small its **largest element** can be — the `N^{1/(2h-1)}` greedy lower bound inside `{1,…,N}`, exactly as for parent #340.

### Verification
- Compiled offline with `lake env lean` (Docker host build path unavailable); exit 0, no warnings.
- `#print axioms` on all new results: only `propext`, `Classical.choice`, `Quot.sound` → **0-axiom**.
- `Erdos340GreedySidonOQ05.lean`: 422 → 610 lines, 14 → 24 theorems, 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)