### PR TITLE
Enrich Gaussian integral = √π (area-of-circle-oq-07)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07/meta.json
@@ -33,6 +33,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: the Gaussian integral and the circle-area link",
+      "startLine": 4,
+      "endLine": 29,
+      "summary": "Header docstring stating the open question ∫_{-∞}^{∞} e^{-x²} dx = √π and its answer: the b = 1 specialization of Mathlib's integral_gaussian b = √(π/b). It also recalls the classical evaluation — square the integral and pass to polar coordinates, where the circle-area Jacobian of the parent entry area-of-circle appears — which the squared corollary records algebraically.",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$, the $b=1$ case of $\\int e^{-bx^2} = \\sqrt{\\pi/b}$."
+    },
+    {
       "id": "main",
       "title": "The Gaussian Integral Equals √π",
       "startLine": 31,


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07` (passes: 0, quality: 79 → 81).

## Gap addressed
The `sections` array covered only the two one-line theorems, omitting the header docstring.

- **Added an overview section** (lines 4–29) covering the problem statement (∫ e^{-x²} = √π as the b=1 case of Mathlib's `integral_gaussian`) and the classical polar-coordinate evaluation that links back to the parent `area-of-circle` Jacobian.

This is a deliberately small change: the file is a 2-theorem, 41-line specialization, and the annotations already fully cover it. Splitting the one-line theorems into more sections would be padding, which the size guardrails warn against.

## Verification
- `meta.json` within the 60 KB cap.
- `pnpm build` passes (✓ built).
- No axiom/status changes.