### PR TITLE
Enrich: metacyclic bracket sharp degree boundary (annotations + sections)

### DIFF
--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01/annotations.json
@@ -1,0 +1,149 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "context",
+    "title": "The boundary question the cubic leaves open",
+    "content": "The parent chain bounds |Gal(Xⁿ−p/ℚ)| by a divisibility bracket: the coprime lower bound n·φ(n) ∣ |Gal| (valid when gcd(n, φ(n)) = 1) and the symmetric-group upper bound |Gal| ∣ n! (from the faithful action Gal ↪ Sₙ on the n roots). The squeeze pins |Gal| exactly only when its two ends coincide, i.e. when n·φ(n) = n!. At the cubic n = 3 this happens — 3·φ(3) = 6 = 3! — pinning |Gal(X³−p)| = 6. This file resolves the boundary completely: it characterizes every degree n for which the elementary bracket pins the order on its own, and the answer is exactly n ∈ {2, 3}.",
+    "mathContext": "$n\\,\\varphi(n) \\mid |\\mathrm{Gal}(X^n-p/\\mathbb{Q})| \\mid n! \\ \\text{ pins }|\\mathrm{Gal}|\\ \\Longleftrightarrow\\ n\\,\\varphi(n) = n!$",
+    "significance": "context",
+    "relatedConcepts": [
+      "metacyclic group",
+      "holomorph ℤ/n ⋊ (ℤ/n)ˣ",
+      "divisibility squeeze",
+      "totient",
+      "factorial",
+      "symmetric group Sₙ"
+    ],
+    "prerequisites": [
+      "Galois theory",
+      "elementary number theory",
+      "Euler totient function",
+      "divisibility"
+    ]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01",
+    "range": { "startLine": 42, "endLine": 47 },
+    "type": "technique",
+    "title": "Building on the verified parent bracket lemmas",
+    "content": "The file imports the parent module Proofs.InverseGaloisD4OQ02OQ03, which supplies the two bracket bounds as fully verified lemmas: mul_totient_dvd_gal_card_of_coprime (the coprime lower bound n·φ(n) ∣ |Gal|) and gal_card_dvd_factorial (the upper bound |Gal| ∣ n!). No new Galois-theoretic content is introduced here — every result is elementary arithmetic of the totient and factorial layered on top of those two inputs. The `open Polynomial` brings the X, C, and .Gal notation for Xⁿ − C p into scope.",
+    "mathContext": "$\\texttt{Fintype.card}\\,(X^n - C(p:\\mathbb{Q}):\\mathbb{Q}[X]).\\mathrm{Gal} = |\\mathrm{Gal}(X^n - p/\\mathbb{Q})|$",
+    "significance": "technical",
+    "relatedConcepts": [
+      "splitting field",
+      "Polynomial.Gal",
+      "modular proof architecture"
+    ],
+    "prerequisites": [
+      "Lean 4",
+      "Mathlib",
+      "Galois group of a polynomial"
+    ]
+  },
+  {
+    "id": "ann-boundary-statement",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01",
+    "range": { "startLine": 53, "endLine": 63 },
+    "type": "insight",
+    "title": "The boundary identity n·φ(n) = n! ⟺ n ∈ {2,3}",
+    "content": "The headline lemma totient_mul_eq_factorial_iff turns the algebraic 'when is the Galois order pinned?' into a purely arithmetic identity. The reverse direction is a finite check (`decide` on n = 2 and n = 3). The forward direction is the substance: assuming n·φ(n) = n! with n ≥ 2, it argues by contradiction that n cannot exceed 3. The reframing is the conceptual payoff — pinning is governed by an elementary totient/factorial equation with exactly two solutions, independent of any Galois machinery.",
+    "mathContext": "$\\text{for } n \\ge 2:\\quad n\\,\\varphi(n) = n! \\ \\Longleftrightarrow\\ n = 2 \\ \\vee\\ n = 3$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler totient",
+      "factorial",
+      "proof by contradiction",
+      "Diophantine characterization"
+    ],
+    "prerequisites": [
+      "totient function",
+      "factorial",
+      "natural-number arithmetic"
+    ]
+  },
+  {
+    "id": "ann-degree-bounds",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01",
+    "range": { "startLine": 64, "endLine": 78 },
+    "type": "technique",
+    "title": "Why n ≥ 4 cannot close the squeeze",
+    "content": "For the contradiction, write n = m + 2 with m ≥ 2. Two opposing estimates collide. The totient is small: φ(n) < n (Nat.totient_lt), so φ(m+2) ≤ m+1 and the metacyclic order satisfies n·φ(n) ≤ (m+2)(m+1) — at most n(n−1). The factorial is large: (m+2)! = (m+2)(m+1)·m! with m! ≥ 2! = 2 (Nat.factorial_le), so n! ≥ 2·n(n−1). The factor of m! ≥ 2 is precisely the slack: once n ≥ 4, the (n−2)! tail of n! exceeds 1, so n! strictly overshoots the metacyclic ceiling and the bracket can no longer pin the order.",
+    "mathContext": "$\\varphi(n) \\le n-1 \\ \\Rightarrow\\ n\\,\\varphi(n) \\le n(n-1); \\qquad n! = n(n-1)\\,(n-2)! \\ge 2\\,n(n-1) \\ \\text{ for } n \\ge 4$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.totient_lt",
+      "Nat.factorial_succ",
+      "Nat.factorial_le",
+      "monotonicity bounds"
+    ],
+    "prerequisites": [
+      "inequalities on naturals",
+      "totient bound φ(n) < n",
+      "factorial growth"
+    ]
+  },
+  {
+    "id": "ann-nlinarith",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01",
+    "range": { "startLine": 80, "endLine": 86 },
+    "type": "technique",
+    "title": "Closing the contradiction with nlinarith",
+    "content": "The two estimates are fed to nlinarith together with the hypothesis h : n·φ(n) = n!. Substituting the metacyclic upper bound into the factorial lower bound gives 2·(m+2)(m+1) ≤ (m+2)! = n·φ(n) ≤ (m+2)(m+1), forcing (m+2)(m+1) ≤ 0 against (m+2)(m+1) > 0 — a contradiction. nlinarith handles the nonlinear product term (m+2)(m+1) that plain linarith cannot, with the positivity fact hApos supplied as a hint so the solver can divide through.",
+    "mathContext": "$2A \\le n! = n\\,\\varphi(n) \\le A \\ \\text{ with } A = (m+2)(m+1) > 0 \\ \\Rightarrow\\ \\bot$",
+    "significance": "technical",
+    "relatedConcepts": [
+      "nlinarith",
+      "nonlinear arithmetic",
+      "positivity hints",
+      "proof by contradiction"
+    ],
+    "prerequisites": [
+      "Lean tactics",
+      "linear/nonlinear arithmetic over ℕ"
+    ]
+  },
+  {
+    "id": "ann-pin-theorem",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01",
+    "range": { "startLine": 92, "endLine": 104 },
+    "type": "insight",
+    "title": "The pin theorem — coprimality comes for free",
+    "content": "gal_card_eq_factorial_of_pin states that the squeeze condition n·φ(n) = n! alone forces |Gal(Xⁿ−p)| = n!, with NO separate coprimality hypothesis. The reason is structural: by the boundary identity the only solutions are n ∈ {2,3}, and both are coprime to their totient (gcd(2,1) = gcd(3,2) = 1, checked by `decide`). So the parent's coprime lower bound mul_totient_dvd_gal_card_of_coprime applies automatically, giving n! ∣ |Gal|; combined with |Gal| ∣ n! (gal_card_dvd_factorial), Nat.dvd_antisymm squeezes equality. The arithmetic boundary condition silently supplies the algebraic coprimality the lower bound needs.",
+    "mathContext": "$n\\,\\varphi(n) = n! \\ \\Rightarrow\\ \\gcd(n,\\varphi(n)) = 1 \\ \\Rightarrow\\ n! \\mid |\\mathrm{Gal}| \\ \\wedge\\ |\\mathrm{Gal}| \\mid n! \\ \\Rightarrow\\ |\\mathrm{Gal}| = n!$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.dvd_antisymm",
+      "coprimality",
+      "antisymmetry of divisibility",
+      "hypothesis elimination"
+    ],
+    "prerequisites": [
+      "divisibility antisymmetry",
+      "coprimality",
+      "Galois order bounds"
+    ]
+  },
+  {
+    "id": "ann-quadratic-witness",
+    "proofId": "inverse-galois-d4-oq-02-oq-03-oq-01",
+    "range": { "startLine": 110, "endLine": 116 },
+    "type": "concept",
+    "title": "The quadratic companion |Gal(X²−p)| = 2",
+    "content": "gal_card_quadratic_eq_two instantiates the pin theorem at n = 2: since 2·φ(2) = 2·1 = 2 = 2!, the squeeze pins |Gal(X²−p/ℚ)| = 2 for every prime p — the Galois group C₂ of the quadratic field ℚ(√p). It is the quadratic companion of the parent's cubic witness |Gal(X³−p)| = 6 = |S₃|. Together n = 2 and n = 3 are the ONLY argument-free, prime-uniform pins the bracket provides; n = 4 already escapes it (4·φ(4) = 8 ≠ 24 = 4!), which is exactly why the base D₄ entry |Gal(X⁴−2)| = 8 needed a separate resolvent/ℝ-embedding argument.",
+    "mathContext": "$2\\,\\varphi(2) = 2 = 2! \\ \\Rightarrow\\ |\\mathrm{Gal}(X^2-p/\\mathbb{Q})| = 2 = |C_2| = [\\mathbb{Q}(\\sqrt{p}):\\mathbb{Q}]$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "quadratic field ℚ(√p)",
+      "cyclic group C₂",
+      "symmetric group S₃",
+      "instantiation"
+    ],
+    "prerequisites": [
+      "quadratic extensions",
+      "Galois group of a quadratic"
+    ]
+  }
+]

--- a/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01/meta.json
@@ -75,6 +75,36 @@
       "**Quadratic and cubic are the only argument-free pins**: $|\\mathrm{Gal}(X^2-p)| = 2 = |C_2|$ and $|\\mathrm{Gal}(X^3-p)| = 6 = |S_3|$ fall straight out of the bracket, uniform in the prime $p$. For $n = 4$ the bracket gives only $4 \\mid |\\mathrm{Gal}| \\mid 24$ (here $4\\varphi(4) = 8 \\ne 24$), which is exactly why the base $D_4$ entry $|\\mathrm{Gal}(X^4-2)| = 8$ required a separate $\\mathbb{R}$-embedding/resolvent argument."
     ]
   },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: the bracket squeeze and the boundary question",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Header docstring and imports. Recalls the parent's divisibility bracket n·φ(n) ∣ |Gal(Xⁿ−p)| ∣ n! and frames the boundary question: for which degrees n does the squeeze close (n·φ(n) = n!) and pin the Galois order exactly? Imports the verified parent lemmas mul_totient_dvd_gal_card_of_coprime and gal_card_dvd_factorial."
+    },
+    {
+      "id": "boundary-count",
+      "title": "Part I — The sharp degree boundary n·φ(n) = n! ⟺ n ∈ {2,3}",
+      "startLine": 49,
+      "endLine": 86,
+      "summary": "Proves totient_mul_eq_factorial_iff. Reverse direction by decide; forward direction by contradiction: writing n = m+2 (m ≥ 2), the totient bound φ(n) ≤ n−1 caps n·φ(n) ≤ n(n−1) while (m+2)! = (m+2)(m+1)·m! with m! ≥ 2 gives n! ≥ 2n(n−1), and nlinarith closes the gap."
+    },
+    {
+      "id": "pin-theorem",
+      "title": "Part II — The pin theorem with automatic coprimality",
+      "startLine": 88,
+      "endLine": 104,
+      "summary": "Proves gal_card_eq_factorial_of_pin: n·φ(n) = n! forces |Gal(Xⁿ−p)| = n! with no coprimality hypothesis. The boundary solutions n ∈ {2,3} are automatically coprime to their totient, so the parent coprime lower bound applies and Nat.dvd_antisymm squeezes equality against |Gal| ∣ n!."
+    },
+    {
+      "id": "quadratic-witness",
+      "title": "Part III — The quadratic companion |Gal(X²−p)| = 2",
+      "startLine": 106,
+      "endLine": 118,
+      "summary": "Proves gal_card_quadratic_eq_two by instantiating the pin theorem at n = 2 (2·φ(2) = 2 = 2!), yielding |Gal(X²−p/ℚ)| = 2 = |C₂| for every prime p — the quadratic companion of the parent's cubic witness |Gal(X³−p)| = 6."
+    }
+  ],
   "conclusion": {
     "summary": "Pinned the sharp degree boundary of the metacyclic divisibility bracket: for n ≥ 2 the squeeze n·φ(n) ∣ |Gal(Xⁿ−p/ℚ)| ∣ n! determines the order exactly iff n·φ(n) = n!, which holds precisely for n ∈ {2,3}. The pin theorem requires no coprimality hypothesis (the boundary degrees are automatically coprime), and the quadratic companion |Gal(X²−p/ℚ)| = 2 joins the parent's cubic |Gal(X³−p/ℚ)| = 6 as the only two argument-free, prime-uniform pins. 3 theorems, 0 sorries, 0 axioms.",
     "implications": "Delimits exactly what the verified elementary bracket can decide on its own: it pins the Galois order of Xⁿ−p in exactly two degrees (n = 2, 3) and never for n ≥ 4. This both completes the small-degree picture (X²−p and X³−p have Galois group C₂ and S₃ uniformly in p) and explains structurally why every larger radical degree — starting with the base entry's own n = 4 — requires genericity/linear-disjointness or an explicit resolvent beyond the bracket.",


### PR DESCRIPTION
Enrichment pass for `inverse-galois-d4-oq-02-oq-03-oq-01` (passes: 0, quality: 33). This entry previously had **only** `meta.json` — no annotations and no sections — so the gallery page rendered without inline commentary or a navigable structure.

## Changes
- **`annotations.json` (new)** — 7 line-based annotations covering the full 118-line proof, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  - the bracket-squeeze framing and parent imports,
  - the boundary identity $n\varphi(n)=n! \Leftrightarrow n\in\{2,3\}$,
  - the $n\ge4$ degree bounds ($\varphi(n)\le n-1$ vs $n!\ge2n(n-1)$) and the `nlinarith` contradiction,
  - the pin theorem where coprimality is automatic at the boundary,
  - the quadratic companion $|\mathrm{Gal}(X^2-p)|=2$.
- **`sections` array (new in meta.json)** — 4 sections spanning lines 1–118 (overview/imports, boundary count, pin theorem, quadratic witness).
- Removed a never-needed `index.ts` shim (gallery now loads via build-generated `listings.json`/`data-manifest.json` per #20993; per-proof shims are legacy and the parent entries have none).

## Verification
- `scripts/annotations/build.ts`: my entry resolves with **0 errors**; static assets generated under `public/data/proofs/inverse-galois-d4-oq-02-oq-03-oq-01/`.
- Size guardrail: `check-meta-size.ts` — within all caps (meta.json ~12 KB ≪ 60 KB).
- Axiom integrity unchanged: `status: verified`, `axiomCount: 0` already match the Lean source (kernel `decide`, no `native_decide`).