### PR TITLE
research(erdos-1005-oq-02): §10–§11 — adjacent pairs always similarly ordered + first non-adjacent obstruction [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -853,4 +853,69 @@ theorem succ_controlling_nonneg {a b c d e f k : ℕ} (hd : 0 < d) (hf_pos : 0 <
     ((a : ℤ) + c - k * c) * ((b : ℤ) + d - k * d) ≥ 0 :=
   (simOrd_succ_controlling he hfb).mp (farey_succ_simOrd hd hf_pos h he hfb)
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 11: The first NON-adjacent obstruction — length-3 runs
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+§ 10 showed every *adjacent* Farey pair is similarly ordered, so the smallest
+place a run can break is a length-3 block `a/b, c/d, e/f` of three *consecutive*
+neighbours: its two adjacent pairs are free, and the only constraint is the
+**outer (non-adjacent) pair** `a/b, e/f`.
+
+Writing the successor via the §9 recurrence `e = k·c − a`, `f = k·d − b`, the
+outer pair is similarly ordered **iff** `(2a − k·c)·(2b − k·d) ≥ 0`
+(`simOrd_outer_iff`).  So a length-3 run is similarly ordered iff that single
+arithmetic inequality on the quotient `k` holds (`simOrd_triple`).
+
+Contrast §9/§10: the *adjacent* product `(a − (k−1)c)(b − (k−1)d)` is always
+`≥ 0`, whereas the *outer* product `(2a − k·c)(2b − k·d) = (a − (k·c−a))(b − (k·d−b))`
+can be negative — precisely when `k` lies strictly between `2a/c` and `2b/d`.
+That interval has width `2b/d − 2a/c = 2·(b·c − a·d)/(c·d) = 2/(c·d)`, so a
+length-3 break requires the successor quotient `k` to fall in an interval of
+width `2/(c·d)` — the first explicit, *metric*, criterion for a run to break.
+-/
+
+/-- **Outer-pair criterion.**  With the successor recurrence `e + a = k·c`,
+`f + b = k·d`, the *non-adjacent* pair `a/b, e/f` is similarly ordered **iff**
+`(2a − k·c)·(2b − k·d) ≥ 0`.  (Compare `simOrd_succ_controlling` for the adjacent
+pair; the `2`s are what make this product able to go negative.) -/
+theorem simOrd_outer_iff {a b c d e f k : ℕ} (he : e + a = k * c) (hf : f + b = k * d) :
+    SimOrd a b e f ↔ (2 * (a : ℤ) - k * c) * (2 * (b : ℤ) - k * d) ≥ 0 := by
+  have He : (e : ℤ) = k * c - a := by
+    have : (e : ℤ) + a = k * c := by exact_mod_cast he
+    linarith
+  have Hf : (f : ℤ) = k * d - b := by
+    have : (f : ℤ) + b = k * d := by exact_mod_cast hf
+    linarith
+  have key : ((a : ℤ) - e) * ((b : ℤ) - f)
+      = (2 * (a : ℤ) - k * c) * (2 * (b : ℤ) - k * d) := by
+    rw [He, Hf]; ring
+  rw [simOrd_iff_prod, key]
+
+/-- **A length-3 run reduces to its outer pair.**  For three consecutive Farey
+neighbours `a/b, c/d, e/f` the two adjacent pairs are *automatically* similarly
+ordered (§10), so the whole block is pairwise similarly ordered iff the outer
+(non-adjacent) pair `a/b, e/f` is.  This is the first point at which
+non-adjacency can break a run. -/
+theorem simOrd_triple_iff_outer {a b c d e f k : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (hf_pos : 0 < f) (hcd : Unimodular a b c d)
+    (he : e + a = k * c) (hfb : f + b = k * d) :
+    (SimOrd a b c d ∧ SimOrd c d e f ∧ SimOrd a b e f) ↔ SimOrd a b e f := by
+  have h1 := unimodular_simOrd hb hd hcd
+  have h2 := unimodular_simOrd hd hf_pos (farey_succ_unimodular hcd he hfb)
+  exact ⟨fun h => h.2.2, fun h => ⟨h1, h2, h⟩⟩
+
+/-- **Length-3 run criterion (headline).**  Three consecutive Farey neighbours
+`a/b, c/d, e/f` (with `e + a = k·c`, `f + b = k·d`) form a similarly ordered run
+**iff** `(2a − k·c)·(2b − k·d) ≥ 0`.  Since the adjacent pairs are free (§10),
+the only obstruction is this explicit inequality on the successor quotient `k` —
+the first non-adjacent break condition, controlled by an interval of width
+`2/(c·d)`. -/
+theorem simOrd_triple {a b c d e f k : ℕ} (hb : 0 < b) (hd : 0 < d) (hf_pos : 0 < f)
+    (hcd : Unimodular a b c d) (he : e + a = k * c) (hfb : f + b = k * d) :
+    (SimOrd a b c d ∧ SimOrd c d e f ∧ SimOrd a b e f)
+      ↔ (2 * (a : ℤ) - k * c) * (2 * (b : ℤ) - k * d) ≥ 0 := by
+  rw [simOrd_triple_iff_outer hb hd hf_pos hcd he hfb, simOrd_outer_iff he hfb]
+
 end Erdos1005OQ02

--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -736,10 +736,121 @@ theorem simOrd_succ_controlling {a b c d e f k : ℕ}
 /-- **The `k = 1` step is always similarly ordered.**  When the successive
 quotient is `1` (so `e + a = c`, `f + b = d`), the controlling product collapses
 to `a·b ≥ 0`, which always holds.  Thus the shortest Farey steps never break a
-similarly ordered run — runs can only be broken at steps with quotient `k ≥ 2`,
-isolating exactly where the `1/12`–`1/4` optimization lives. -/
+similarly ordered run.  (§ 10 strengthens this: in fact *no* quotient `k` can
+break it — every adjacent step is similarly ordered.) -/
 theorem simOrd_succ_k_eq_one {a b c d e f : ℕ} (he : e + a = c) (hf : f + b = d) :
     SimOrd c d e f := by
   refine Or.inl ⟨?_, ?_⟩ <;> omega
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 10: Every Farey-adjacent pair is similarly ordered — runs break
+--        only across NON-adjacent pairs
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+§ 9 reduced a *single* consecutive step `c/d → e/f` to the sign of the
+controlling product `(a + c − k·c)·(b + d − k·d)`, and showed the `k = 1` step is
+always similarly ordered.  This section settles the sign in **full generality**:
+the product is *always* `≥ 0`, because **every** unimodular (Farey-adjacent) pair
+is similarly ordered — not only the `k = 1` ones.
+
+The headline `unimodular_simOrd` proves this directly from `b·c = a·d + 1`.  A
+pair can fail similar ordering in exactly two ways, and unimodularity excludes
+both (each needing only `0 < b`, `0 < d`):
+
+* `a < c ∧ d < b`  is excluded because it forces
+  `b·c ≥ (a+1)·(d+1) = a·d + a + d + 1 > a·d + 1`  (`unimodular_excl_cross_left`);
+* `c < a ∧ b < d`  is excluded because it forces
+  `a·d ≥ (c+1)·(b+1) = b·c + b + c + 1 > b·c − 1 = a·d`  (`unimodular_excl_cross_right`),
+  i.e. it would make `a/b > c/d`, contradicting adjacency.
+
+This is a genuine **correction** to the §9 preamble, which suggested that
+`k ≥ 2` steps are where runs break.  They are not: a single Farey step **never**
+breaks a similarly ordered run, for any quotient `k` (`farey_succ_simOrd`), so
+the §9 controlling product is unconditionally `≥ 0` (`succ_controlling_nonneg`).
+The entire `1/12`–`1/4` gap therefore lives in the **non-adjacent** pairs of a
+window: `isSimOrdered` (in `Erdos1005ProblemProvable.lean`) demands similar
+ordering for *every* pair `j₁ < j₂` of the block, and it is precisely the
+`j₂ > j₁ + 1` pairs — never the adjacent `j₂ = j₁ + 1` ones — that can fail.
+-/
+
+/-- **No "small-num / large-denom" inversion.**  For a unimodular pair
+`a/b < c/d`, one cannot have `a < c` together with `d < b`: that would give
+`b·c ≥ (a+1)(d+1) = a·d + a + d + 1`, contradicting `b·c = a·d + 1` (as
+`a + d ≥ d ≥ 1`). -/
+theorem unimodular_excl_cross_left {a b c d : ℕ} (hd : 0 < d)
+    (h : Unimodular a b c d) : ¬ ((a : ℤ) < c ∧ (d : ℤ) < b) := by
+  unfold Unimodular at h
+  rintro ⟨h1, h2⟩
+  have hz : (b : ℤ) * c = (a : ℤ) * d + 1 := by exact_mod_cast h
+  have hd' : (1 : ℤ) ≤ d := by exact_mod_cast hd
+  have ha' : (0 : ℤ) ≤ a := by positivity
+  have hc' : (0 : ℤ) ≤ c := by positivity
+  nlinarith [mul_le_mul (show (a : ℤ) + 1 ≤ c by linarith)
+              (show (d : ℤ) + 1 ≤ b by linarith) (by linarith) (by linarith),
+             hz, hd', ha']
+
+/-- **No "large-num / small-denom" inversion.**  For a unimodular pair
+`a/b < c/d`, one cannot have `c < a` together with `b < d`: that would give
+`a·d ≥ (c+1)(b+1) = b·c + b + c + 1`, contradicting `a·d = b·c − 1`.  (This is
+the case that would make `a/b > c/d`, breaking the order.) -/
+theorem unimodular_excl_cross_right {a b c d : ℕ} (hb : 0 < b)
+    (h : Unimodular a b c d) : ¬ ((c : ℤ) < a ∧ (b : ℤ) < d) := by
+  unfold Unimodular at h
+  rintro ⟨h1, h2⟩
+  have hz : (b : ℤ) * c = (a : ℤ) * d + 1 := by exact_mod_cast h
+  have hb' : (1 : ℤ) ≤ b := by exact_mod_cast hb
+  have ha' : (0 : ℤ) ≤ a := by positivity
+  have hc' : (0 : ℤ) ≤ c := by positivity
+  nlinarith [mul_le_mul (show (c : ℤ) + 1 ≤ a by linarith)
+              (show (b : ℤ) + 1 ≤ d by linarith) (by linarith) (by linarith),
+             hz, hb', hc']
+
+/-- **Every Farey-adjacent pair is similarly ordered.**  A unimodular pair
+`a/b < c/d` (`b·c = a·d + 1`, positive denominators) always satisfies
+`SimOrd a b c d`: numerator and denominator never move in opposite directions
+across a single Farey step.  This generalises `simOrd_succ_k_eq_one` (the
+`k = 1` case) to *all* adjacent pairs, and is the order-side analogue of
+`unimodular_lt`. -/
+theorem unimodular_simOrd {a b c d : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (h : Unimodular a b c d) : SimOrd a b c d := by
+  rcases le_total (a : ℤ) c with hac | hca
+  · rcases le_total (d : ℤ) b with hdb | hbd
+    · -- `a ≤ c` and `d ≤ b`: opposite weak signs, so a factor must vanish.
+      rcases lt_or_eq_of_le hac with hlt | heq
+      · rcases lt_or_eq_of_le hdb with hlt2 | heq2
+        · exact absurd ⟨hlt, hlt2⟩ (unimodular_excl_cross_left hd h)
+        · exact Or.inr ⟨by linarith, by linarith⟩      -- d = b
+      · exact Or.inl ⟨by linarith, by linarith⟩          -- a = c
+    · exact Or.inr ⟨by linarith, by linarith⟩            -- a ≤ c, b ≤ d
+  · rcases le_total (b : ℤ) d with hbd | hdb
+    · -- `c ≤ a` and `b ≤ d`: opposite weak signs, so a factor must vanish.
+      rcases lt_or_eq_of_le hca with hlt | heq
+      · rcases lt_or_eq_of_le hbd with hlt2 | heq2
+        · exact absurd ⟨hlt, hlt2⟩ (unimodular_excl_cross_right hb h)
+        · exact Or.inl ⟨by linarith, by linarith⟩        -- b = d
+      · exact Or.inr ⟨by linarith, by linarith⟩          -- c = a
+    · exact Or.inl ⟨by linarith, by linarith⟩            -- c ≤ a, d ≤ b
+
+/-- **A consecutive Farey step is always similarly ordered.**  Given a
+Farey-neighbour pair `a/b, c/d` and its successor `e/f` from the three-term
+recurrence (`e + a = k·c`, `f + b = k·d`), the step `c/d → e/f` satisfies
+`SimOrd c d e f` for *every* quotient `k`: the successor is again a Farey
+neighbour (`farey_succ_unimodular`), and adjacent pairs are always similarly
+ordered (`unimodular_simOrd`).  Adjacency alone can never break a run. -/
+theorem farey_succ_simOrd {a b c d e f k : ℕ} (hd : 0 < d) (hf_pos : 0 < f)
+    (h : Unimodular a b c d) (he : e + a = k * c) (hfb : f + b = k * d) :
+    SimOrd c d e f :=
+  unimodular_simOrd hd hf_pos (farey_succ_unimodular h he hfb)
+
+/-- **The §9 controlling product is unconditionally nonnegative.**  Combining
+`simOrd_succ_controlling` with `farey_succ_simOrd`: for any genuine consecutive
+step the product `(a + c − k·c)·(b + d − k·d)` is always `≥ 0`.  So the per-step
+criterion of §9 is *always* satisfied — the run-length obstruction behind the
+`1/12`–`1/4` gap is entirely a non-adjacent phenomenon, not a per-step one. -/
+theorem succ_controlling_nonneg {a b c d e f k : ℕ} (hd : 0 < d) (hf_pos : 0 < f)
+    (h : Unimodular a b c d) (he : e + a = k * c) (hfb : f + b = k * d) :
+    ((a : ℤ) + c - k * c) * ((b : ℤ) + d - k * d) ≥ 0 :=
+  (simOrd_succ_controlling he hfb).mp (farey_succ_simOrd hd hf_pos h he hfb)
 
 end Erdos1005OQ02

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -5,12 +5,12 @@
   "title": "Mediant Insertion and the Farey Gap Calculus: The Mediant Is the Unique Smallest-Denominator Fraction in a Gap",
   "description": "A self-contained, axiom-free formalization of the exact arithmetic of mediant insertion — the operation that refines the Farey sequence F_n into F_{n+1} by inserting, between adjacent fractions a/b < c/d, their mediant (a+c)/(b+d). Two threads are proved. First, the gap-splitting calculus: a unimodular gap of size 1/(bd) is split by its mediant into a left sub-gap 1/(b(b+d)) and a right sub-gap 1/(d(b+d)); these sum back to 1/(bd), stand in ratio d:b, and each is strictly smaller than the whole. Second, the headline minimal-denominator theorem: any fraction p/q strictly between two unimodular neighbours has denominator q ≥ b+d, and equality forces p/q = (a+c)/(b+d) exactly. Hence the mediant is the unique fraction of smallest denominator inside any Farey gap, and b+d is a hard lower bound on refining it — no construction can introduce a fraction of smaller denominator. The parent entry (Erdős #1005) records the open lower bound f(n) ≥ (1/12−o(1))n on runs of similarly ordered Farey fractions; that constant remains open and is NOT addressed here. This entry formalizes the verified mediant calculus on which such lower-bound constructions are built.",
   "leanFile": {
-    "lineCount": 745,
+    "lineCount": 856,
     "axiomCount": 0,
     "path": "Proofs/Erdos1005ProblemOQ02.lean",
     "sorries": 0,
     "definitionCount": 2,
-    "theoremCount": 45
+    "theoremCount": 50
   },
   "meta": {
     "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot mediant theory)",
@@ -29,7 +29,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-25",
-    "lineCount": 745,
+    "lineCount": 856,
     "originalContributions": [
       "denom_ge_of_between: the headline lower bound — if a/b < p/q < c/d and the outer pair is unimodular (bc − ad = 1), then q ≥ b + d. Proved from the identity q = b·(cq − pd) + d·(pb − aq) by reading off pb − aq ≥ 1 and cq − pd ≥ 1 from the strict orders, with no Farey enumeration. The mediant therefore has the smallest denominator of any fraction in the open gap (a/b, c/d)",
       "eq_mediant_of_denom_eq: uniqueness — a strictly-in-gap fraction p/q that attains the minimal denominator q = b + d must be the mediant itself, p = a + c. The two cross-differences pb − aq and cq − pd are each pinned to exactly 1, forcing p·b = (a+c)·b and cancelling b",
@@ -49,7 +49,9 @@
       "farey_succ_unimodular: the three-term Farey successor (e+a=k·c, f+b=k·d) preserves unimodularity (d·e=c·f+1), so iterating the recurrence walks along genuinely CONSECUTIVE Farey neighbours — the consecutiveness §8 lacked",
       "farey_three_term: symmetric three-term recurrence d·(a+e)=c·(b+f), i.e. the middle Farey fraction is the exact k-section of its two neighbours (Farey form of bₖ₋₁+bₖ₊₁=k·bₖ)",
       "simOrd_succ_controlling (headline): a CONSECUTIVE Farey step c/d→e/f is similarly ordered iff (a+c−k·c)·(b+d−k·d)≥0 — converts the vague 'consecutiveness' gap into an explicit arithmetic inequality on the successive quotient k",
-      "simOrd_succ_k_eq_one: every k=1 Farey step is similarly ordered (controlling product collapses to a·b≥0), so a similarly ordered run can only break at a quotient k≥2 — localizing the 1/12–1/4 open optimization"
+      "simOrd_succ_k_eq_one: every k=1 Farey step is similarly ordered (controlling product collapses to a·b≥0). NOTE: §10 strengthens this — in fact NO quotient k can break an adjacent step, so the 1/12–1/4 optimization is not localized at k≥2 steps but lives entirely in the non-adjacent pairs of a window",
+      "§10 unimodular_simOrd (headline correction): EVERY Farey-adjacent (unimodular) pair a/b<c/d is similarly ordered — numerator and denominator never move in opposite directions across a single Farey step. The two failing sign-patterns are excluded by unimodularity (unimodular_excl_cross_left rules out a<c ∧ d<b via b·c ≥ (a+1)(d+1) > a·d+1; unimodular_excl_cross_right rules out c<a ∧ b<d, which would force a/b>c/d). This generalises simOrd_succ_k_eq_one from k=1 to ALL adjacent pairs and is the order-side analogue of unimodular_lt",
+      "§10 farey_succ_simOrd + succ_controlling_nonneg: a consecutive Farey step c/d→e/f is similarly ordered for EVERY quotient k (the successor is again unimodular, and adjacent pairs are always similarly ordered), so the §9 controlling product (a+c−k·c)(b+d−k·d) is UNCONDITIONALLY ≥ 0. This corrects the §9 framing: a single Farey step never breaks a similarly ordered run; the 1/12–1/4 run-length obstruction is entirely a NON-ADJACENT phenomenon (failures occur only among pairs j₁<j₂ with j₂>j₁+1 in a window, never the adjacent j₂=j₁+1 pairs)"
     ],
     "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for the headline theorems (denom_ge_of_between, eq_mediant_of_denom_eq, mediant_is_min_denominator). No native_decide is used (so no Lean.ofReduceBool). This entry does NOT resolve the open Erdős #1005 lower bound f(n) ≥ (1/12 − o(1))n on runs of similarly ordered Farey fractions; that constant remains open. §8 connects the calculus to the similarlyOrdered relation but explicitly does NOT supply consecutiveness in F_n, which is the open step.",
     "theoremCount": 38,

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -5,12 +5,12 @@
   "title": "Mediant Insertion and the Farey Gap Calculus: The Mediant Is the Unique Smallest-Denominator Fraction in a Gap",
   "description": "A self-contained, axiom-free formalization of the exact arithmetic of mediant insertion — the operation that refines the Farey sequence F_n into F_{n+1} by inserting, between adjacent fractions a/b < c/d, their mediant (a+c)/(b+d). Two threads are proved. First, the gap-splitting calculus: a unimodular gap of size 1/(bd) is split by its mediant into a left sub-gap 1/(b(b+d)) and a right sub-gap 1/(d(b+d)); these sum back to 1/(bd), stand in ratio d:b, and each is strictly smaller than the whole. Second, the headline minimal-denominator theorem: any fraction p/q strictly between two unimodular neighbours has denominator q ≥ b+d, and equality forces p/q = (a+c)/(b+d) exactly. Hence the mediant is the unique fraction of smallest denominator inside any Farey gap, and b+d is a hard lower bound on refining it — no construction can introduce a fraction of smaller denominator. The parent entry (Erdős #1005) records the open lower bound f(n) ≥ (1/12−o(1))n on runs of similarly ordered Farey fractions; that constant remains open and is NOT addressed here. This entry formalizes the verified mediant calculus on which such lower-bound constructions are built.",
   "leanFile": {
-    "lineCount": 856,
+    "lineCount": 921,
     "axiomCount": 0,
     "path": "Proofs/Erdos1005ProblemOQ02.lean",
     "sorries": 0,
     "definitionCount": 2,
-    "theoremCount": 50
+    "theoremCount": 53
   },
   "meta": {
     "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot mediant theory)",
@@ -29,7 +29,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-25",
-    "lineCount": 856,
+    "lineCount": 921,
     "originalContributions": [
       "denom_ge_of_between: the headline lower bound — if a/b < p/q < c/d and the outer pair is unimodular (bc − ad = 1), then q ≥ b + d. Proved from the identity q = b·(cq − pd) + d·(pb − aq) by reading off pb − aq ≥ 1 and cq − pd ≥ 1 from the strict orders, with no Farey enumeration. The mediant therefore has the smallest denominator of any fraction in the open gap (a/b, c/d)",
       "eq_mediant_of_denom_eq: uniqueness — a strictly-in-gap fraction p/q that attains the minimal denominator q = b + d must be the mediant itself, p = a + c. The two cross-differences pb − aq and cq − pd are each pinned to exactly 1, forcing p·b = (a+c)·b and cancelling b",
@@ -51,7 +51,10 @@
       "simOrd_succ_controlling (headline): a CONSECUTIVE Farey step c/d→e/f is similarly ordered iff (a+c−k·c)·(b+d−k·d)≥0 — converts the vague 'consecutiveness' gap into an explicit arithmetic inequality on the successive quotient k",
       "simOrd_succ_k_eq_one: every k=1 Farey step is similarly ordered (controlling product collapses to a·b≥0). NOTE: §10 strengthens this — in fact NO quotient k can break an adjacent step, so the 1/12–1/4 optimization is not localized at k≥2 steps but lives entirely in the non-adjacent pairs of a window",
       "§10 unimodular_simOrd (headline correction): EVERY Farey-adjacent (unimodular) pair a/b<c/d is similarly ordered — numerator and denominator never move in opposite directions across a single Farey step. The two failing sign-patterns are excluded by unimodularity (unimodular_excl_cross_left rules out a<c ∧ d<b via b·c ≥ (a+1)(d+1) > a·d+1; unimodular_excl_cross_right rules out c<a ∧ b<d, which would force a/b>c/d). This generalises simOrd_succ_k_eq_one from k=1 to ALL adjacent pairs and is the order-side analogue of unimodular_lt",
-      "§10 farey_succ_simOrd + succ_controlling_nonneg: a consecutive Farey step c/d→e/f is similarly ordered for EVERY quotient k (the successor is again unimodular, and adjacent pairs are always similarly ordered), so the §9 controlling product (a+c−k·c)(b+d−k·d) is UNCONDITIONALLY ≥ 0. This corrects the §9 framing: a single Farey step never breaks a similarly ordered run; the 1/12–1/4 run-length obstruction is entirely a NON-ADJACENT phenomenon (failures occur only among pairs j₁<j₂ with j₂>j₁+1 in a window, never the adjacent j₂=j₁+1 pairs)"
+      "§10 farey_succ_simOrd + succ_controlling_nonneg: a consecutive Farey step c/d→e/f is similarly ordered for EVERY quotient k (the successor is again unimodular, and adjacent pairs are always similarly ordered), so the §9 controlling product (a+c−k·c)(b+d−k·d) is UNCONDITIONALLY ≥ 0. This corrects the §9 framing: a single Farey step never breaks a similarly ordered run; the 1/12–1/4 run-length obstruction is entirely a NON-ADJACENT phenomenon (failures occur only among pairs j₁<j₂ with j₂>j₁+1 in a window, never the adjacent j₂=j₁+1 pairs)",
+      "§11 simOrd_outer_iff: the NON-adjacent (outer) pair a/b,e/f of three consecutive Farey neighbours is similarly ordered iff (2a−k·c)(2b−k·d)≥0 — the §9 adjacent product (a−(k−1)c)(b−(k−1)d) with the (k−1)·shift replaced by a doubling, which is what lets it go negative",
+      "§11 simOrd_triple_iff_outer: a length-3 run a/b,c/d,e/f reduces to its outer pair — both adjacent pairs are free by §10, so the block is pairwise similarly ordered iff a/b,e/f is. First point where non-adjacency can break a run",
+      "§11 simOrd_triple (headline): three consecutive Farey neighbours form a similarly ordered run iff (2a−k·c)(2b−k·d)≥0. The break interval for the successor quotient k is (2a/c,2b/d) of width 2/(c·d) — the first explicit METRIC criterion for a run to break, directly realizing the non-adjacent obstruction §10 identified"
     ],
     "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for the headline theorems (denom_ge_of_between, eq_mediant_of_denom_eq, mediant_is_min_denominator). No native_decide is used (so no Lean.ofReduceBool). This entry does NOT resolve the open Erdős #1005 lower bound f(n) ≥ (1/12 − o(1))n on runs of similarly ordered Farey fractions; that constant remains open. §8 connects the calculus to the similarlyOrdered relation but explicitly does NOT supply consecutiveness in F_n, which is the open step.",
     "theoremCount": 38,

--- a/src/data/research/problems/erdos-1005-oq-02.json
+++ b/src/data/research/problems/erdos-1005-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: §10 added (verified, 0-axiom). Proved EVERY Farey-adjacent (unimodular) pair is similarly ordered (unimodular_simOrd), so a single consecutive Farey step never breaks a similarly ordered run for any quotient k (farey_succ_simOrd), and the §9 per-step controlling product is unconditionally ≥0 (succ_controlling_nonneg). This CORRECTS the §9 suggestion that k≥2 steps break runs: the 1/12–1/4 obstruction is entirely a NON-ADJACENT phenomenon. Open 1/12 constant untouched.",
+    "progressSummary": "PROGRESS: §10–§11 added (verified, 0-axiom). §10: every Farey-adjacent pair is similarly ordered (single steps never break a run, any k). §11: the first NON-adjacent obstruction — a length-3 run a/b,c/d,e/f reduces to its outer pair, similarly ordered iff (2a−k·c)(2b−k·d)≥0; break interval for k is (2a/c,2b/d) of width 2/(cd), the first explicit metric break criterion. Open 1/12 constant untouched.",
     "builtItems": [
       "unimodular_iterate_left/right (Erdos1005ProblemOQ02.lean §6): k-fold one-sided mediant insertion stays unimodular, a/b<(k·a+c)/(k·b+d); proved by scale-invariance of bc=ad+1 (no induction)",
       "denom_ge_iterate_left/right (Erdos1005ProblemOQ02.lean §6): depth-k interior denominator bound q ≥ (k+1)·b+d, LINEAR in depth",
@@ -37,19 +37,23 @@
       "unimodular_excl_cross_left/right (§10): unimodularity excludes both opposite-sign Farey configurations (a<c∧d<b and c<a∧b<d) via b·c ≥ (a+1)(d+1) and a·d ≥ (c+1)(b+1)",
       "unimodular_simOrd (§10): every unimodular pair a/b<c/d is similarly ordered — order-side analogue of unimodular_lt, generalises simOrd_succ_k_eq_one to all k",
       "farey_succ_simOrd (§10): a consecutive Farey successor step c/d→e/f is similarly ordered for every quotient k",
-      "succ_controlling_nonneg (§10): the §9 controlling product (a+c−kc)(b+d−kd) is unconditionally ≥0"
+      "succ_controlling_nonneg (§10): the §9 controlling product (a+c−kc)(b+d−kd) is unconditionally ≥0",
+      "simOrd_outer_iff (§11): non-adjacent outer pair similarly ordered iff (2a−kc)(2b−kd)≥0",
+      "simOrd_triple_iff_outer (§11): length-3 run reduces to outer pair (adjacent pairs free by §10)",
+      "simOrd_triple (§11): length-3 run similarly ordered iff (2a−kc)(2b−kd)≥0; break interval (2a/c,2b/d) width 2/(cd)"
     ],
     "insights": [
       "CORRECTION: the roadmap heuristic that the order-n cap forces O(log n) refinement depth is FALSE for arbitrary mediant chains. The one-sided chain 0/1,1/2,1/3,…,1/n fits Θ(n) levels under q≤n with only LINEAR denominator growth (k+1)·b+d.",
       "Exponential φ^k denominator growth (and hence O(log n) depth) is special to BALANCED/alternating chains; one-sided chains are the linear worst case. A sharp run-length count toward the 1/12 constant must distinguish the two extremes.",
       "Literature pin (van Doorn 2025, arXiv:2509.00121): f(n) ≥ (1/12−o(1))n and f(n) ≤ n/4+5; constant c∈[1/12,1/4] open.",
       "CORRECTION to §9 framing: a single Farey step NEVER breaks a similarly ordered run (any quotient k). Reason: c/d,e/f are again unimodular (farey_succ_unimodular) and adjacent unimodular pairs are always similarly ordered. The per-step controlling product is therefore always ≥0.",
-      "Structural reframing: since adjacency alone never breaks similar ordering, the f(n) ≤ n/4 upper bound is purely a NON-ADJACENT effect — isSimOrdered demands similar ordering for every pair j₁<j₂ in a window, and only the j₂>j₁+1 pairs can fail. The open 1/12–1/4 gap lives in controlling long-range (non-adjacent) similar ordering, not per-step quotients."
+      "Structural reframing: since adjacency alone never breaks similar ordering, the f(n) ≤ n/4 upper bound is purely a NON-ADJACENT effect — isSimOrdered demands similar ordering for every pair j₁<j₂ in a window, and only the j₂>j₁+1 pairs can fail. The open 1/12–1/4 gap lives in controlling long-range (non-adjacent) similar ordering, not per-step quotients.",
+      "The first non-adjacent break is METRIC: a length-3 Farey run breaks iff the successor quotient k falls in (2a/c,2b/d), an interval of width 2(bc−ad)/(cd)=2/(cd). Small cd (large gaps) ⇒ wider break window. This is the bridge from the per-step quotient to the run-length obstruction behind 1/12–1/4."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Quantify the first NON-ADJACENT failure: given a similarly ordered run, find the minimal gap j₂−j₁≥2 and the arithmetic condition (on the intervening quotients) under which the pair (j₁,j₂) first violates (num diff)(denom diff)≥0.",
-      "Formalize a length-3 obstruction: three consecutive Farey neighbours a/b,c/d,e/f are pairwise similarly ordered iff the OUTER pair a/b,e/f is (the adjacent pairs are automatic by §10) — reducing run length to outer-pair similar ordering across the block."
+      "Extend to length-4: with two successive quotients k₁,k₂, characterize which of the 3 non-adjacent pairs (skip-1 ×2, skip-2 ×1) can break, in terms of (k₁,k₂).",
+      "Aggregate the width-2/(cd) break windows along a Stern–Brocot path to bound expected run length — the quantitative route toward the 1/12 constant."
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-1005-oq-02.json
+++ b/src/data/research/problems/erdos-1005-oq-02.json
@@ -29,21 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: §6 added (verified, 0-axiom) — iterated one-sided insertion + linear depth-k denominator bound; corrected a false O(log n)-depth heuristic. Open 1/12 constant untouched.",
+    "progressSummary": "PROGRESS: §10 added (verified, 0-axiom). Proved EVERY Farey-adjacent (unimodular) pair is similarly ordered (unimodular_simOrd), so a single consecutive Farey step never breaks a similarly ordered run for any quotient k (farey_succ_simOrd), and the §9 per-step controlling product is unconditionally ≥0 (succ_controlling_nonneg). This CORRECTS the §9 suggestion that k≥2 steps break runs: the 1/12–1/4 obstruction is entirely a NON-ADJACENT phenomenon. Open 1/12 constant untouched.",
     "builtItems": [
       "unimodular_iterate_left/right (Erdos1005ProblemOQ02.lean §6): k-fold one-sided mediant insertion stays unimodular, a/b<(k·a+c)/(k·b+d); proved by scale-invariance of bc=ad+1 (no induction)",
       "denom_ge_iterate_left/right (Erdos1005ProblemOQ02.lean §6): depth-k interior denominator bound q ≥ (k+1)·b+d, LINEAR in depth",
-      "iterate_left_denom_linear (§6): exact one-sided mediant denominator (k+1)·b+d"
+      "iterate_left_denom_linear (§6): exact one-sided mediant denominator (k+1)·b+d",
+      "unimodular_excl_cross_left/right (§10): unimodularity excludes both opposite-sign Farey configurations (a<c∧d<b and c<a∧b<d) via b·c ≥ (a+1)(d+1) and a·d ≥ (c+1)(b+1)",
+      "unimodular_simOrd (§10): every unimodular pair a/b<c/d is similarly ordered — order-side analogue of unimodular_lt, generalises simOrd_succ_k_eq_one to all k",
+      "farey_succ_simOrd (§10): a consecutive Farey successor step c/d→e/f is similarly ordered for every quotient k",
+      "succ_controlling_nonneg (§10): the §9 controlling product (a+c−kc)(b+d−kd) is unconditionally ≥0"
     ],
     "insights": [
       "CORRECTION: the roadmap heuristic that the order-n cap forces O(log n) refinement depth is FALSE for arbitrary mediant chains. The one-sided chain 0/1,1/2,1/3,…,1/n fits Θ(n) levels under q≤n with only LINEAR denominator growth (k+1)·b+d.",
       "Exponential φ^k denominator growth (and hence O(log n) depth) is special to BALANCED/alternating chains; one-sided chains are the linear worst case. A sharp run-length count toward the 1/12 constant must distinguish the two extremes.",
-      "Literature pin (van Doorn 2025, arXiv:2509.00121): f(n) ≥ (1/12−o(1))n and f(n) ≤ n/4+5; constant c∈[1/12,1/4] open."
+      "Literature pin (van Doorn 2025, arXiv:2509.00121): f(n) ≥ (1/12−o(1))n and f(n) ≤ n/4+5; constant c∈[1/12,1/4] open.",
+      "CORRECTION to §9 framing: a single Farey step NEVER breaks a similarly ordered run (any quotient k). Reason: c/d,e/f are again unimodular (farey_succ_unimodular) and adjacent unimodular pairs are always similarly ordered. The per-step controlling product is therefore always ≥0.",
+      "Structural reframing: since adjacency alone never breaks similar ordering, the f(n) ≤ n/4 upper bound is purely a NON-ADJACENT effect — isSimOrdered demands similar ordering for every pair j₁<j₂ in a window, and only the j₂>j₁+1 pairs can fail. The open 1/12–1/4 gap lives in controlling long-range (non-adjacent) similar ordering, not per-step quotients."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Formalize the balanced/alternating extreme: track the alternating mediant chain denominators against Nat.fib, proving φ^k growth ⇒ O(log_φ n) depth for balanced descent (the complement of §6 linear bound).",
-      "Bridge depth bounds to a run-length statement: relate monotone Stern–Brocot paths under the order-n cap to runs of similarly ordered fractions."
+      "Quantify the first NON-ADJACENT failure: given a similarly ordered run, find the minimal gap j₂−j₁≥2 and the arithmetic condition (on the intervening quotients) under which the pair (j₁,j₂) first violates (num diff)(denom diff)≥0.",
+      "Formalize a length-3 obstruction: three consecutive Farey neighbours a/b,c/d,e/f are pairwise similarly ordered iff the OUTER pair a/b,e/f is (the adjacent pairs are automatic by §10) — reducing run length to outer-pair similar ordering across the block."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for **erdos-1005-oq-02** (Improve the `1/12` lower bound for Farey-fraction runs via mediant insertion). Adds **§10** to `Erdos1005ProblemOQ02.lean`, settling a sign question left open by §9 and **correcting** the §9 framing.

## Mathematical content
§9 reduced a single consecutive Farey step `c/d → e/f` to the sign of a controlling product `(a+c−k·c)·(b+d−k·d)` and only handled `k = 1`. §10 settles it for all `k`:

- **`unimodular_simOrd`** (headline): *every* unimodular (Farey-adjacent) pair `a/b < c/d` is similarly ordered. The two failing sign-patterns are excluded by unimodularity:
  - `a < c ∧ d < b` ⇒ `b·c ≥ (a+1)(d+1) = a·d + a + d + 1 > a·d + 1` (`unimodular_excl_cross_left`);
  - `c < a ∧ b < d` ⇒ `a·d ≥ (c+1)(b+1) > b·c − 1 = a·d`, i.e. would force `a/b > c/d` (`unimodular_excl_cross_right`).
- **`farey_succ_simOrd`**: a consecutive step `c/d → e/f` is similarly ordered for **every** quotient `k` (the successor is again unimodular via `farey_succ_unimodular`).
- **`succ_controlling_nonneg`**: hence the §9 controlling product is **unconditionally ≥ 0**.

**Correction to §9.** The §9 preamble suggested runs break at `k ≥ 2` steps. They do not: a single Farey step *never* breaks a similarly ordered run. The `1/12`–`1/4` run-length obstruction is therefore entirely a **non-adjacent** phenomenon — `isSimOrdered` demands similar ordering for every pair `j₁ < j₂` in a window, and only the `j₂ > j₁ + 1` pairs can fail. The stale `simOrd_succ_k_eq_one` claim in meta.json was annotated accordingly.

## Files modified
- `proofs/Proofs/Erdos1005ProblemOQ02.lean` (+5 theorems, §10)
- `src/data/proofs/erdos-1005-oq-02/meta.json` (lineCount 745→856, theoremCount 45→50, +2 contributions, corrected k≥2 bullet)
- `src/data/research/problems/erdos-1005-oq-02.json` (knowledge)

## Verification
Compiled with `lake env lean Proofs/Erdos1005ProblemOQ02.lean` (Lean v4.26.0) — exit 0, clean. **0 sorries, 0 axioms, no native_decide** → verified, 0-axiom. The open `1/12` constant is untouched.

## Status
**Outcome**: progress (verified structural lemma; main conjecture remains open)
**Next Steps**: quantify the first *non-adjacent* failure in a run; length-3 obstruction reducing run length to outer-pair similar ordering.

🤖 Generated by researcher-4