### PR TITLE
research(erdos-1020-oq-02): small-n/large-n regime transition of the Erdős Matching Conjecture [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1020OQ02.lean
+++ b/proofs/Proofs/Erdos1020OQ02.lean
@@ -1,0 +1,165 @@
+/-
+  Erdős Problem #1020 — OQ-02: The small-n / large-n regime transition
+  for the Erdős Matching Conjecture.
+
+  Parent: Erdős Matching Conjecture (erdosproblems.com/1020).
+  Status of the conjecture: OPEN for r ≥ 4.
+
+  Context.
+  The conjectured extremal value of f(n; r, k) — the maximum number of edges
+  in an r-uniform hypergraph on n vertices with no k pairwise-disjoint edges —
+  is the maximum of two explicit constructions:
+
+    construction1 r k     = C(r·k − 1, r)              (all r-edges on r·k−1 vertices)
+    construction2 n r k   = C(n, r) − C(n − k + 1, r)  (all edges meeting a fixed (k−1)-set)
+    conjecturedValue      = max(construction1, construction2)
+
+  The conjecture is KNOWN in two opposite regimes:
+    • small n   — Frankl: n ≤ kr + kr/(2 r^{2r+1})
+    • large n   — Huang–Loh–Sudakov: n ≥ 3 k r²
+  and OPEN in the gap between them (for r ≥ 4).
+
+  The two constructions are extremal in opposite regimes:
+  `construction1` is the maximiser for small n, `construction2` for large n.
+  This file does NOT resolve the open gap. Instead it pins down, fully and
+  axiom-free, the *shape* of the transition between the two regimes:
+
+    1. `construction1` is constant in n;
+    2. `construction2` is monotonically nondecreasing in n (for n ≥ k);
+    3. hence the set of n on which `construction2` dominates `construction1`
+       is upward-closed — there is a single threshold separating the
+       "small-n regime" (extremal value = construction1) from the
+       "large-n regime" (extremal value = construction2);
+    4. consequently `conjecturedValue` is itself monotone nondecreasing in n;
+    5. on each side of the threshold `conjecturedValue` collapses to the
+       relevant construction (`max_eq_left`/`max_eq_right`).
+
+  The monotonicity (2) is a Pascal-telescoping identity:
+    construction2 (n+1) − construction2 n  =  C(n, r−1) − C(n−k+1, r−1)  ≥ 0.
+
+  A worked instance (r = 4, k = 2) exhibits the crossover concretely at n = 8.
+
+  All results are machine-checked with `decide` / `omega` only — no axioms,
+  no `native_decide`, no `sorry`.
+
+  Tags: hypergraph-theory, matching, extremal-combinatorics, regime-transition
+-/
+
+import Mathlib
+
+open Finset Nat
+
+namespace Erdos1020OQ02
+
+/-- Construction 1: all r-edges on `r·k − 1` vertices. Independent of `n`. -/
+def construction1 (r k : ℕ) : ℕ := Nat.choose (r * k - 1) r
+
+/-- Construction 2: all edges meeting a fixed `(k−1)`-set, on `n` vertices. -/
+def construction2 (n r k : ℕ) : ℕ := Nat.choose n r - Nat.choose (n - k + 1) r
+
+/-- The conjectured extremal value `f(n; r, k)`. -/
+def conjecturedValue (n r k : ℕ) : ℕ := max (construction1 r k) (construction2 n r k)
+
+/-! ### 1. `construction2` is monotone nondecreasing in `n`.
+
+(`construction1 r k` is independent of `n` by construction — it has no `n`
+argument — so all of the regime structure below is carried by `construction2`.)
+
+The single-step inequality is the heart of the file: it is the nonnegativity
+of `C(n, r−1) − C(n−k+1, r−1)`, exposed via two Pascal identities. -/
+
+/-- One step of monotonicity in `n`. -/
+theorem construction2_mono_step (n r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 1) (hn : n ≥ k) :
+    construction2 n r k ≤ construction2 (n + 1) r k := by
+  unfold construction2
+  -- Normalise the shifted index of the upper construction.
+  have hidx : n + 1 - k + 1 = n - k + 2 := by omega
+  rw [hidx]
+  have hr1 : r - 1 + 1 = r := Nat.sub_add_cancel hr
+  -- Pascal at the top: C(n+1, r) = C(n, r-1) + C(n, r).
+  have eq1 : Nat.choose (n + 1) r = Nat.choose n (r - 1) + Nat.choose n r := by
+    have h := Nat.choose_succ_succ n (r - 1)
+    simp only [Nat.succ_eq_add_one] at h
+    rw [hr1] at h
+    omega
+  -- Pascal at the shifted index: C(n-k+2, r) = C(n-k+1, r-1) + C(n-k+1, r).
+  have eq2 : Nat.choose (n - k + 2) r
+      = Nat.choose (n - k + 1) (r - 1) + Nat.choose (n - k + 1) r := by
+    have h := Nat.choose_succ_succ (n - k + 1) (r - 1)
+    simp only [Nat.succ_eq_add_one] at h
+    rw [hr1, show n - k + 1 + 1 = n - k + 2 from by omega] at h
+    omega
+  -- Monotonicity of `choose` in its first argument (since k ≥ 1 ⇒ n-k+1 ≤ n).
+  have ineq1 : Nat.choose (n - k + 1) (r - 1) ≤ Nat.choose n (r - 1) :=
+    Nat.choose_le_choose (r - 1) (by omega)
+  have ineq2 : Nat.choose (n - k + 1) r ≤ Nat.choose n r :=
+    Nat.choose_le_choose r (by omega)
+  omega
+
+/-- Monotonicity of `construction2` in `n` over the relevant range `k ≤ n ≤ m`. -/
+theorem construction2_mono (n m r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 1)
+    (hkn : k ≤ n) (hnm : n ≤ m) :
+    construction2 n r k ≤ construction2 m r k := by
+  induction m, hnm using Nat.le_induction with
+  | base => exact le_refl _
+  | succ m hm ih =>
+    exact le_trans ih (construction2_mono_step m r k hr hk (le_trans hkn hm))
+
+/-! ### 2. The "construction2 dominates" region is upward-closed.
+
+This is the precise statement that the small-n and large-n regimes are
+separated by a *single* threshold: once `construction2` has caught up to
+`construction1` it never falls behind again. -/
+
+theorem construction2_dominant_up (n m r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 1)
+    (hkn : k ≤ n) (hnm : n ≤ m)
+    (hdom : construction1 r k ≤ construction2 n r k) :
+    construction1 r k ≤ construction2 m r k :=
+  le_trans hdom (construction2_mono n m r k hr hk hkn hnm)
+
+/-! ### 3. `conjecturedValue` is monotone nondecreasing in `n`. -/
+
+theorem conjecturedValue_mono (n m r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 1)
+    (hkn : k ≤ n) (hnm : n ≤ m) :
+    conjecturedValue n r k ≤ conjecturedValue m r k := by
+  unfold conjecturedValue
+  exact max_le_max (le_refl _) (construction2_mono n m r k hr hk hkn hnm)
+
+/-! ### 4. On each side of the threshold the extremal value collapses. -/
+
+/-- Large-n regime: when `construction2` dominates, it *is* the conjectured value. -/
+theorem conjecturedValue_large (n r k : ℕ)
+    (h : construction1 r k ≤ construction2 n r k) :
+    conjecturedValue n r k = construction2 n r k :=
+  max_eq_right h
+
+/-- Small-n regime: when `construction1` dominates, it *is* the conjectured value. -/
+theorem conjecturedValue_small (n r k : ℕ)
+    (h : construction2 n r k ≤ construction1 r k) :
+    conjecturedValue n r k = construction1 r k :=
+  max_eq_left h
+
+/-! ### A worked instance of the transition: r = 4, k = 2.
+
+Here `construction1 = C(7,4) = 35`, and
+`construction2 n 4 2 = C(n,4) − C(n−1,4) = C(n−1,3)`,
+which first reaches 35 at `n = 8`. So the regime boundary sits between
+`n = 7` (construction1 strictly larger) and `n = 8` (construction2 catches up).
+Both facts are kernel-decidable, hence axiom-free. -/
+
+/-- At `n = 7` the small-n construction is strictly larger. -/
+example : construction2 7 4 2 < construction1 4 2 := by decide
+
+/-- At `n = 8` the large-n construction has caught up. -/
+example : construction1 4 2 ≤ construction2 8 4 2 := by decide
+
+/-- The conjectured value is `construction1` just below the threshold … -/
+example : conjecturedValue 7 4 2 = construction1 4 2 := by decide
+
+/-- … and equals `construction2` at and above it. -/
+example : conjecturedValue 8 4 2 = construction2 8 4 2 := by decide
+
+/-- Monotonicity of `conjecturedValue` across the crossover, concretely. -/
+example : conjecturedValue 7 4 2 ≤ conjecturedValue 8 4 2 := by decide
+
+end Erdos1020OQ02

--- a/src/data/proofs/erdos-1020-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1020-oq-02/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "constructions-def",
+    "proofId": "erdos-1020-oq-02",
+    "range": {
+      "startLine": 54,
+      "endLine": 61
+    },
+    "type": "definition",
+    "title": "The Two Extremal Constructions and the Conjectured Value",
+    "content": "construction1 r k = C(rk-1,r) counts all r-edges on a set of rk-1 vertices — too few for k disjoint r-edges — and does not depend on n. construction2 n r k = C(n,r) - C(n-k+1,r) counts all r-edges meeting a fixed (k-1)-set (any k of them share a vertex). The conjectured extremal value of f(n;r,k) is their max. The two terms are extremal in opposite regimes: construction1 for small n, construction2 for large n. Restated self-contained over Mathlib's Nat.choose rather than imported, so the file is axiom-free.",
+    "mathContext": "$$\\mathrm{construction1}=\\binom{rk-1}{r},\\quad \\mathrm{construction2}=\\binom{n}{r}-\\binom{n-k+1}{r},\\quad \\mathrm{conjecturedValue}=\\max(\\cdot,\\cdot).$$",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Erdős Matching Conjecture",
+      "extremal constructions",
+      "binomial coefficients"
+    ],
+    "prerequisites": [
+      "r-uniform hypergraphs",
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "construction2-mono-step",
+    "proofId": "erdos-1020-oq-02",
+    "range": {
+      "startLine": 72,
+      "endLine": 95
+    },
+    "type": "insight",
+    "title": "Pascal Telescoping: The Large-n Construction Never Decreases",
+    "content": "The single-step monotonicity is the mathematical heart of the file. Unfolding construction2 and normalising the shifted index, the increment construction2(n+1) - construction2(n) equals C(n,r-1) - C(n-k+1,r-1) after two applications of Pascal's identity (Nat.choose_succ_succ): C(n+1,r) = C(n,r-1)+C(n,r) and C(n-k+2,r) = C(n-k+1,r-1)+C(n-k+1,r). Since k ≥ 1 gives n-k+1 ≤ n, monotonicity of the binomial coefficient in its top argument (Nat.choose_le_choose) makes this difference nonnegative, and omega discharges the nat-subtraction bookkeeping. So the large-n construction is monotonically nondecreasing in n.",
+    "mathContext": "$$\\Big(\\binom{n+1}{r}-\\binom{n-k+2}{r}\\Big)-\\Big(\\binom{n}{r}-\\binom{n-k+1}{r}\\Big)=\\binom{n}{r-1}-\\binom{n-k+1}{r-1}\\ge 0.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pascal's identity",
+      "binomial monotonicity",
+      "telescoping"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_succ",
+      "Nat.choose_le_choose",
+      "natural-number subtraction"
+    ]
+  },
+  {
+    "id": "dominance-upward-closed",
+    "proofId": "erdos-1020-oq-02",
+    "range": {
+      "startLine": 112,
+      "endLine": 116
+    },
+    "type": "insight",
+    "title": "A Single Threshold Separates the Two Regimes",
+    "content": "Because construction1 is constant in n and construction2 is monotone nondecreasing, the set of n on which construction2 dominates construction1 is upward-closed: if it dominates at some n, it dominates at every m ≥ n (construction2_dominant_up, a one-line le_trans through the monotonicity). This is the precise sense in which the 'small-n regime' and 'large-n regime' are genuinely separated — by a single crossover threshold, with no interleaving. It frames OQ-02 sharply: the regime boundary is well-defined; the open difficulty is whether f equals the conjectured value across it.",
+    "mathContext": "$$\\mathrm{construction1}\\le\\mathrm{construction2}\\,n \\ \\wedge\\ n\\le m \\ \\Rightarrow\\ \\mathrm{construction1}\\le\\mathrm{construction2}\\,m.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "upward-closed set",
+      "phase transition",
+      "monotonicity"
+    ],
+    "prerequisites": [
+      "transitivity of ≤",
+      "monotone functions"
+    ]
+  },
+  {
+    "id": "conjectured-value-mono",
+    "proofId": "erdos-1020-oq-02",
+    "range": {
+      "startLine": 120,
+      "endLine": 124
+    },
+    "type": "insight",
+    "title": "The Conjectured Value Is Monotone in n",
+    "content": "Since conjecturedValue is the max of the constant construction1 and the nondecreasing construction2, it is itself monotone nondecreasing in n (conjecturedValue_mono, via max_le_max with le_refl on the constant side). Together with conjecturedValue_small / conjecturedValue_large — which collapse the max to construction1 below the threshold and to construction2 at and above it (max_eq_left / max_eq_right) — this gives the complete unconditional shape of the conjectured value as n grows: flat-then-rising, switching maximiser exactly once.",
+    "mathContext": "$$k\\le n\\le m\\ \\Rightarrow\\ \\mathrm{conjecturedValue}\\,n\\le\\mathrm{conjecturedValue}\\,m.$$",
+    "significance": "standard",
+    "relatedConcepts": [
+      "max of monotone functions",
+      "Erdős Matching Conjecture"
+    ],
+    "prerequisites": [
+      "max_le_max",
+      "max_eq_left / max_eq_right"
+    ]
+  },
+  {
+    "id": "worked-instance-crossover",
+    "proofId": "erdos-1020-oq-02",
+    "range": {
+      "startLine": 140,
+      "endLine": 163
+    },
+    "type": "insight",
+    "title": "Crossover at n = 8 for r = 4, k = 2",
+    "content": "A concrete instance makes the transition tangible. For r=4, k=2: construction1 = C(7,4) = 35 (constant), and construction2 n 4 2 = C(n,4) - C(n-1,4) = C(n-1,3). At n=7 this is C(6,3) = 20 < 35, so the small-n construction wins and conjecturedValue = 35. At n=8 it is C(7,3) = 35, so the large-n construction has caught up. The crossover sits exactly between n=7 and n=8. All four checks are kernel-decidable (`by decide`, not `native_decide`), so they add no axioms.",
+    "mathContext": "$$\\binom{6}{3}=20<35=\\binom{7}{4}\\quad\\text{but}\\quad \\binom{7}{3}=35:\\ \\text{crossover at } n=8.$$",
+    "significance": "standard",
+    "relatedConcepts": [
+      "binomial crossover",
+      "kernel decidability",
+      "regime threshold"
+    ],
+    "prerequisites": [
+      "binomial coefficient evaluation",
+      "decide"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1020-oq-02/meta.json
+++ b/src/data/proofs/erdos-1020-oq-02/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "erdos-1020-oq-02",
+  "title": "Erdős #1020 OQ-02: The Small-n / Large-n Regime Transition",
+  "slug": "erdos-1020-oq-02",
+  "description": "Open question OQ-02 of Erdős Problem #1020 (the Erdős Matching Conjecture) asks whether the gap between the two regimes in which the conjecture is known — Frankl's small-n result and Huang–Loh–Sudakov's large-n result — can be closed for general r. The conjectured extremal value of f(n;r,k) is max(construction1, construction2) where construction1 r k = C(rk-1,r) (independent of n) and construction2 n r k = C(n,r) - C(n-k+1,r); construction1 is the maximiser for small n and construction2 for large n. This entry does NOT resolve the open gap (OPEN for r≥4). Instead it pins down, axiom-free, the structure of the transition between the two regimes: construction2 is monotonically nondecreasing in n (construction2_mono, via a Pascal-telescoping identity construction2(n+1)-construction2(n) = C(n,r-1)-C(n-k+1,r-1) ≥ 0); hence the set of n on which construction2 dominates construction1 is upward-closed (construction2_dominant_up), so a single threshold separates the small-n regime (extremal value = construction1, conjecturedValue_small) from the large-n regime (extremal value = construction2, conjecturedValue_large); consequently conjecturedValue is itself monotone nondecreasing in n (conjecturedValue_mono). A worked instance (r=4, k=2) exhibits the crossover concretely at n=8 via kernel-decidable checks. No axioms, no native_decide, no sorries.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://www.erdosproblems.com/1020",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1020OQ02.lean",
+    "tags": [
+      "hypergraph-theory",
+      "matching",
+      "extremal-combinatorics",
+      "erdos-matching-conjecture",
+      "regime-transition",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 165,
+    "assumptions": "None. The file introduces no axioms and no sorries; every theorem depends only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms). The concrete crossover examples use kernel `decide` (not `native_decide`), so they introduce no Lean.ofReduceBool dependency. The open content of OQ-02 — whether the small-n/large-n gap can be closed for general r, i.e. the Erdős Matching Conjecture itself for r≥4 — is left unproved and unaxiomatized; only the regime-transition structure of the conjectured extremal value is established.",
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The Erdős Matching Conjecture (Erdős, 1965) predicts that f(n;r,k) — the maximum number of edges in an r-uniform hypergraph on n vertices with no k pairwise-disjoint edges — equals max(C(rk-1,r), C(n,r)-C(n-k+1,r)) for all r≥3. The two terms come from two natural extremal constructions, and they win in opposite regimes: for small n the first (all edges on rk-1 vertices) is larger, while for large n the second (all edges meeting a fixed (k-1)-set) dominates. The conjecture is proven in both extremes — Frankl established it for small n (n ≤ kr + kr/(2r^{2r+1})), and Huang–Loh–Sudakov (2012) for large n (n ≥ 3kr²) — leaving a gap in the middle range that is open for r≥4. OQ-02 asks whether this gap can be closed. The present entry isolates the part of the picture that is unconditionally true: the shape of the transition between the two regimes at the level of the conjectured value.",
+    "problemStatement": "**OQ-02**: Can the gap between the small-n regime (Frankl) and the large-n regime (Huang–Loh–Sudakov), in which the Erdős Matching Conjecture is known, be closed for general r?",
+    "text": "We re-state the two extremal constructions and their max (the conjectured value of f(n;r,k)) self-contained over Mathlib, and prove axiom-free the structure of the regime transition: construction2 is monotone nondecreasing in n, so the region where it overtakes the constant construction1 is upward-closed — a single threshold separates the small-n and large-n regimes — and the conjectured value is therefore monotone in n. The open gap (the conjecture for r≥4) is stated, not assumed.",
+    "proofStrategy": "Self-contained over Mathlib's Nat.choose. The single-step monotonicity construction2_mono_step unfolds construction2, normalises the shifted index (n+1-k+1 = n-k+2), and applies two Pascal identities (Nat.choose_succ_succ) — C(n+1,r) = C(n,r-1)+C(n,r) and C(n-k+2,r) = C(n-k+1,r-1)+C(n-k+1,r) — together with monotonicity of choose in its first argument (Nat.choose_le_choose, valid since k≥1 ⇒ n-k+1≤n); omega then discharges the nat-subtraction inequality, exposing the difference as C(n,r-1)-C(n-k+1,r-1) ≥ 0. construction2_mono lifts this across k≤n≤m by Nat.le_induction. construction2_dominant_up is le_trans through the monotonicity, giving the upward-closed dominance region. conjecturedValue_mono follows from max_le_max, and conjecturedValue_large / conjecturedValue_small are max_eq_right / max_eq_left. A worked r=4,k=2 instance pins the crossover at n=8 (construction2 7 4 2 = 20 < 35 = construction1; construction2 8 4 2 = 35) by kernel decide.",
+    "keyInsights": [
+      "The two extremal constructions are extremal in opposite regimes: construction1 r k = C(rk-1,r) is independent of n (a constant), while construction2 n r k = C(n,r)-C(n-k+1,r) grows with n. The 'gap between small n and large n' is precisely the band around their crossover.",
+      "construction2 is monotonically nondecreasing in n, because its one-step increment is a Pascal telescoping difference construction2(n+1)-construction2(n) = C(n,r-1)-C(n-k+1,r-1), nonnegative since n ≥ n-k+1 for k≥1.",
+      "Monotonicity forces the regimes to be cleanly separated: the set of n on which construction2 dominates the constant construction1 is upward-closed (construction2_dominant_up), so there is a single threshold, not an interleaving — once the large-n construction catches up it never falls behind.",
+      "Consequently the conjectured extremal value is monotone nondecreasing in n (conjecturedValue_mono) and collapses to construction1 below the threshold (conjecturedValue_small) and to construction2 at and above it (conjecturedValue_large).",
+      "This is unconditional structure of the conjectured value — it does NOT close the open gap (the conjecture for r≥4 is left stated, not axiomatized). It frames the open question precisely: the unknown is whether f equals this value throughout the middle band, not where the two constructions cross."
+    ],
+    "prerequisites": [
+      "The Erdős Matching Conjecture and its two extremal constructions",
+      "Binomial coefficients and Pascal's identity (Nat.choose_succ_succ)",
+      "Monotonicity of binomial coefficients (Nat.choose_le_choose)",
+      "Natural-number subtraction reasoning (omega) and induction on an inequality (Nat.le_induction)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "constructions",
+      "title": "The Two Extremal Constructions",
+      "startLine": 54,
+      "endLine": 61,
+      "summary": "construction1 r k = C(rk-1,r) (no n dependence), construction2 n r k = C(n,r)-C(n-k+1,r), and their max conjecturedValue n r k — the conjectured value of f(n;r,k), restated self-contained over Mathlib.",
+      "mathContext": "$\\mathrm{conjecturedValue}=\\max\\!\\big(\\binom{rk-1}{r},\\,\\binom{n}{r}-\\binom{n-k+1}{r}\\big)$."
+    },
+    {
+      "id": "monotonicity-in-n",
+      "title": "construction2 Is Monotone in n",
+      "startLine": 63,
+      "endLine": 105,
+      "summary": "construction2_mono_step (one step, via two Pascal identities and choose-monotonicity) and construction2_mono (k≤n≤m, by Nat.le_induction): the large-n construction never decreases as n grows.",
+      "mathContext": "$\\binom{n+1}{r}-\\binom{n-k+2}{r}-\\big(\\binom{n}{r}-\\binom{n-k+1}{r}\\big)=\\binom{n}{r-1}-\\binom{n-k+1}{r-1}\\ge 0$."
+    },
+    {
+      "id": "upward-closed",
+      "title": "The Dominance Region Is Upward-Closed",
+      "startLine": 108,
+      "endLine": 116,
+      "summary": "construction2_dominant_up: once construction2 catches up to construction1 at some n, it dominates for every m ≥ n. The two regimes are separated by a single threshold.",
+      "mathContext": "$\\{n : \\mathrm{construction1}\\le\\mathrm{construction2}\\,n\\}$ is an up-set in $n$."
+    },
+    {
+      "id": "conjectured-value-monotone",
+      "title": "The Conjectured Value Is Monotone in n",
+      "startLine": 118,
+      "endLine": 124,
+      "summary": "conjecturedValue_mono: max of a constant and a nondecreasing function is nondecreasing (max_le_max).",
+      "mathContext": "$\\mathrm{conjecturedValue}\\,n\\le\\mathrm{conjecturedValue}\\,m$ for $k\\le n\\le m$."
+    },
+    {
+      "id": "regime-collapse",
+      "title": "Collapse on Each Side of the Threshold",
+      "startLine": 126,
+      "endLine": 138,
+      "summary": "conjecturedValue_large (construction2 dominant ⇒ value = construction2) and conjecturedValue_small (construction1 dominant ⇒ value = construction1): max_eq_right / max_eq_left.",
+      "mathContext": "Below threshold the value is $\\binom{rk-1}{r}$; at/above it is $\\binom{n}{r}-\\binom{n-k+1}{r}$."
+    },
+    {
+      "id": "worked-instance",
+      "title": "A Worked Instance: r = 4, k = 2",
+      "startLine": 140,
+      "endLine": 163,
+      "summary": "Kernel-decidable checks locating the crossover at n=8: construction2 7 4 2 = 20 < 35 = construction1 4 2, while construction2 8 4 2 = 35; conjecturedValue switches from construction1 to construction2 across n=7→8 and is monotone there.",
+      "mathContext": "$\\binom{7}{4}-\\binom{6}{4}=20<35=\\binom{7}{4}$ but $\\binom{8}{4}-\\binom{7}{4}=35$: crossover at $n=8$."
+    }
+  ],
+  "conclusion": {
+    "summary": "OQ-02 of Erdős #1020 — closing the gap between the known small-n (Frankl) and large-n (Huang–Loh–Sudakov) regimes of the Erdős Matching Conjecture — is given a precise framing, and the unconditional structure of the regime transition is established axiom-free. The large-n construction C(n,r)-C(n-k+1,r) is monotone nondecreasing in n (a Pascal telescoping fact), so it overtakes the constant small-n construction C(rk-1,r) at a single threshold; the conjectured extremal value is therefore monotone in n and collapses to the relevant construction on each side. This does not resolve the open conjecture (r≥4), which is left stated, but it pins the geometry of the two regimes the open question concerns.",
+    "implications": "Separating what is unconditionally true (the crossover geometry of the conjectured value) from what is open (whether f attains that value throughout the middle band) sharpens OQ-02: the difficulty is not in locating the regime boundary — it is a single, well-defined threshold — but in proving the conjecture holds across it. The Pascal-telescoping monotonicity also gives a clean, reusable lemma about the second construction independent of the conjecture's status.",
+    "openQuestions": [
+      "Can the Erdős Matching Conjecture be proven throughout the middle band kr + O(kr·r^{-2r}) < n < 3kr² for r ≥ 4, closing the gap between the Frankl and Huang–Loh–Sudakov regimes?",
+      "Is the exact crossover threshold n₀(r,k) — the least n with construction2 ≥ construction1 — expressible in closed form, and how does the conjectured value behave in a neighbourhood of it?",
+      "Do the extremal hypergraphs interpolate between the two canonical constructions inside the gap, or is one of the two always extremal?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1020",
+      "relationship": "extends",
+      "description": "Parent gallery proof: Erdős Problem #1020 (the Erdős Matching Conjecture), whose two extremal constructions and small-n/large-n regimes this entry analyses. The parent's large_n_construction2_dominates establishes only ∃N; this entry strengthens the picture to full monotonicity and a single-threshold separation."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, P.",
+      "title": "A problem on independent r-tuples",
+      "year": "1965",
+      "venue": "Annales Universitatis Scientiarum Budapestinensis 8, 93–95",
+      "note": "Original formulation of the Erdős Matching Conjecture."
+    },
+    {
+      "authors": "Huang, H., Loh, P.-S., Sudakov, B.",
+      "title": "The size of a hypergraph and its matching number",
+      "year": "2012",
+      "venue": "Combinatorics, Probability and Computing 21, 442–450",
+      "note": "Proof of the conjecture in the large-n regime (n ≥ 3kr²) — the upper end of the gap OQ-02 concerns."
+    },
+    {
+      "authors": "Frankl, P.",
+      "title": "The shifting technique in extremal set theory",
+      "year": "1987",
+      "venue": "Surveys in Combinatorics, LMS Lecture Note Series 123, 81–110",
+      "note": "Frankl's upper bound and the small-n regime — the lower end of the gap."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "Erdos1020OQ02",
+    "lineCount": 165,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "path": "Proofs/Erdos1020OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 3
+  },
+  "sorries": 0,
+  "highlights": [
+    "construction2 n r k = C(n,r)-C(n-k+1,r) is monotonically nondecreasing in n (construction2_mono), proved axiom-free from a Pascal telescoping identity: its one-step increment is C(n,r-1)-C(n-k+1,r-1) ≥ 0.",
+    "The region where the large-n construction dominates the constant small-n construction is upward-closed (construction2_dominant_up): the small-n and large-n regimes are separated by a single threshold, never interleaved.",
+    "The conjectured extremal value max(construction1, construction2) is therefore monotone nondecreasing in n (conjecturedValue_mono) and collapses to the relevant construction on each side of the threshold (conjecturedValue_small / conjecturedValue_large).",
+    "The open content of OQ-02 — closing the gap between the Frankl and Huang–Loh–Sudakov regimes, i.e. the Erdős Matching Conjecture for r≥4 — is stated, not axiomatized; the file is fully verified (0 axioms, 0 sorries, kernel decide only)."
+  ]
+}

--- a/src/data/research/problems/erdos-1020-oq-02.json
+++ b/src/data/research/problems/erdos-1020-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1020-oq-02",
   "title": "Close gap between small n and large n regimes for hypergraph matching",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-03-30T21:46:38.106Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Regime-transition structure formalized & verified; open gap closure remains.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "VERIFIED (0-axiom). Created gallery entry erdos-1020-oq-02 + Proofs/Erdos1020OQ02.lean. Did NOT resolve the open gap (Erdős Matching Conjecture, OPEN r≥4); instead formalized the unconditional structure of the small-n/large-n regime transition of the conjectured value max(construction1, construction2): construction2 monotone in n (Pascal telescoping), dominance region upward-closed (single threshold), conjecturedValue monotone, collapse on each side. Worked instance r=4,k=2 crossover at n=8 by kernel decide.",
+    "builtItems": [
+      "Proofs/Erdos1020OQ02.lean (165 lines, 0 axioms, 0 sorries, verified): construction2_mono_step, construction2_mono, construction2_dominant_up, conjecturedValue_mono, conjecturedValue_large, conjecturedValue_small + 5 kernel-decide crossover examples.",
+      "Gallery entry src/data/proofs/erdos-1020-oq-02/ (meta.json + annotations.json)."
+    ],
+    "insights": [
+      "construction1 r k = C(rk-1,r) is constant in n; construction2 n r k = C(n,r)-C(n-k+1,r) is monotone nondecreasing in n. The gap is the band around their crossover.",
+      "construction2(n+1)-construction2(n) = C(n,r-1)-C(n-k+1,r-1) ≥ 0 (two Pascal identities + Nat.choose_le_choose); this is the heart of the monotonicity.",
+      "Monotonicity ⇒ the construction2-dominant region is upward-closed: a SINGLE threshold separates small-n and large-n regimes (no interleaving).",
+      "conjecturedValue = max(const, monotone) is monotone in n; collapses to construction1 below threshold, construction2 at/above (max_eq_left/right).",
+      "OQ-02 framed: regime boundary is a well-defined single threshold; the open difficulty is whether f attains the conjectured value across the gap band kr+... < n < 3kr² for r≥4."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Open: prove the Erdős Matching Conjecture across the middle band (r≥4) — the actual gap closure.",
+      "Characterize the exact crossover threshold n₀(r,k) in closed form.",
+      "Decide whether extremal hypergraphs interpolate between the two constructions inside the gap."
+    ]
   },
   "tags": [
     "seeker-selected",
@@ -52,7 +65,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T21:46:38.106Z",
-  "lastUpdate": "2026-03-30T21:46:38.106Z",
+  "lastUpdate": "2026-06-27",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

New gallery entry **erdos-1020-oq-02** for OQ-02 of Erdős Problem #1020 (the Erdős Matching Conjecture): *"close the gap between the small-n and large-n regimes for hypergraph matching."*

The conjectured extremal value of `f(n;r,k)` is `max(construction1, construction2)` where
`construction1 r k = C(rk-1, r)` (independent of `n`) and `construction2 n r k = C(n,r) - C(n-k+1,r)`.
The conjecture is known at both extremes — Frankl (small `n`) and Huang–Loh–Sudakov (large `n`) — and is **OPEN for r ≥ 4** in the gap between.

This PR does **not** close the open gap. It formalizes, axiom-free, the *unconditional structure* of the transition between the two regimes.

## What is proved (`Proofs/Erdos1020OQ02.lean`, 165 lines, 0 axioms, 0 sorries)

- `construction2_mono_step` / `construction2_mono` — `construction2` is monotone nondecreasing in `n`, via the Pascal telescoping identity
  `construction2(n+1) - construction2(n) = C(n,r-1) - C(n-k+1,r-1) ≥ 0`.
- `construction2_dominant_up` — the region where `construction2` dominates the constant `construction1` is **upward-closed**: a *single threshold* separates the small-n regime (extremal value = construction1) from the large-n regime (extremal value = construction2).
- `conjecturedValue_mono` — `max(construction1, construction2)` is therefore monotone nondecreasing in `n`.
- `conjecturedValue_small` / `conjecturedValue_large` — the conjectured value collapses to the relevant construction on each side of the threshold.
- Worked instance `r=4, k=2`: crossover at `n=8` (`construction2 7 4 2 = 20 < 35 = construction1`; `construction2 8 4 2 = 35`), by kernel `decide` (not `native_decide`).

## Verification

- Compiles via `lake env lean` (docker down this cycle); exit 0, no warnings.
- `#print axioms` on every theorem: only `propext` / `Classical.choice` / `Quot.sound` — **no `Lean.ofReduceBool`, no `sorryAx`**. Concrete examples use kernel `decide`.
- Annotations build runs clean for this entry (no anchor errors).
- `status: verified`, `badge: verified`, `axiomCount: 0`.

## Files

- `proofs/Proofs/Erdos1020OQ02.lean` (new)
- `src/data/proofs/erdos-1020-oq-02/{meta.json,annotations.json}` (new gallery entry)
- `src/data/research/problems/erdos-1020-oq-02.json` (knowledge update)

## Status

**Outcome**: completed (verified, 0-axiom). The open content — closing the gap / the Erdős Matching Conjecture for r ≥ 4 — is stated, not axiomatized.
**Next steps**: prove the conjecture across the middle band `kr+… < n < 3kr²`; characterize the exact crossover threshold `n₀(r,k)`.

🤖 Generated by researcher-7