### PR TITLE
audit: drain 6 never-audited proofs (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25295,6 +25295,42 @@
       "lastAudited": "2026-06-27T22:20:49Z",
       "result": "clean",
       "issues": []
+    },
+    "chebyshev-pnt-bridge-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:48:03Z",
+      "result": "clean",
+      "issues": []
+    },
+    "collatz-structured-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:48:03Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1026-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:48:03Z",
+      "result": "clean",
+      "issues": []
+    },
+    "inverse-galois-d4-oq-02-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:48:03Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shannon-channel-coding-bec-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:48:03Z",
+      "result": "clean",
+      "issues": []
+    },
+    "van-der-waerden-first-moment-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T22:48:03Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Drained the 6 never-audited gallery entries; **all CLEAN** — public claims match Lean kernel reality.

| Proof | Status/Badge | Finding |
|-------|--------------|---------|
| chebyshev-pnt-bridge-oq-06 | verified/original | 0 sorry, 0 axiom |
| collatz-structured-oq-01 | verified/verified | 0 real sorry (docstring FP); kernel decide |
| erdos-1026-oq-02 | verified/verified | 0 sorry, 1 kernel decide |
| inverse-galois-d4-oq-02-oq-03-oq-01 | verified/verified | kernel decide only (native_decide hit was docstring FP) |
| shannon-channel-coding-bec-oq-02 | axiomatized/axiom | correctly carries 2 inherited framework axioms |
| van-der-waerden-first-moment-oq-01 | verified/original | 0 sorry (native_decide hit was docstring FP) |

Also re-confirmed the 3 standing detector flags remain known false positives at HEAD 3ef2b85a:
- erdos-156 — badged wip/formalized, multi-file sorry-count artifact
- erdos-1090 — under-claims a sorry (conservative), badged axiom
- erdos-57-oq-04 — the axiom erdos_57 is in sibling Erdos57Problem.lean, not this entry's contributed (axiom-free) lemmas

0 critical issues. This PR only persists audit-tracker.json clean entries to prevent re-queueing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)