### PR TITLE
research(shannon-channel-coding-awgn-oq-03): bandlimited Shannon–Hartley C = B·log₂(1+P/N) bits/s [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingAWGNOQ03.lean
+++ b/proofs/Proofs/ShannonChannelCodingAWGNOQ03.lean
@@ -1,0 +1,220 @@
+/-
+  The Bandlimited Shannon–Hartley Capacity:  C = B · log₂(1 + P/N)  bits/s
+
+  Open question (shannon-channel-coding-awgn-oq-03):
+  "Extend to the bandlimited Shannon–Hartley form C = B log₂(1 + P/N) bits/s
+   and to parallel Gaussian channels via water-filling (the capacity of a
+   vector AWGN channel)."
+
+  ## What this file does
+
+  The companion file `ShannonChannelCodingAWGN` proves, axiom-free, that the
+  capacity of a single use of the additive white Gaussian noise channel is
+
+        awgnCapacity P N = ½ · log(1 + P/N)           [nats per channel use]
+
+  where `log` is the natural logarithm and `P`, `N` are the signal and noise
+  powers.  This file turns that *per-use, nats* quantity into the classical
+  *bandlimited, bits-per-second* Shannon–Hartley formula
+
+        C(B, P, N) = B · log₂(1 + P/N)               [bits per second].
+
+  ## The bridge: Nyquist sampling + a change of logarithm base
+
+  Two textbook conversions assemble the bits/second formula from the per-use
+  nats formula, and both are exact algebraic identities:
+
+  1. **Change of base (nats → bits).**  One nat is `1 / log 2` bits, so the
+     per-use capacity in bits is
+            awgnCapacity P N / log 2 = ½ · log₂(1 + P/N)   [bits per use].
+
+  2. **Nyquist rate (uses → seconds).**  A strictly bandlimited channel of
+     bandwidth `B` Hz supports `2B` independent (orthogonal) signalling
+     dimensions per second.  Multiplying the per-use bit capacity by `2B`:
+            C = 2B · ½ · log₂(1 + P/N) = B · log₂(1 + P/N)  [bits per second].
+
+  Combining the two gives the single bridge identity proved below,
+  `shannonHartley_eq_awgn`:
+
+        C(B, P, N) = (2B / log 2) · awgnCapacity P N.
+
+  Everything downstream — non-negativity, the power/bandwidth monotonicities,
+  the vanishing of capacity at zero power or zero bandwidth, and the low-SNR
+  linear upper bound `log₂(1+x) ≤ x / log 2` — is then a structural consequence
+  of the corresponding fact about `Real.logb 2`.
+
+  ## Scope note
+
+  This file formalises the *bandlimited scalar* Shannon–Hartley form exactly.
+  The second half of the open question — the capacity of a *vector* (parallel)
+  Gaussian channel via water-filling, `C = Σᵢ ½ log(1 + Pᵢ/Nᵢ)` with
+  `Σ Pᵢ ≤ P` optimised by the water-filling power allocation — is a genuinely
+  separate optimisation problem and is left open here.  The per-use AWGN
+  capacity it builds on is exactly the `awgnCapacity` re-exported below.
+-/
+
+import Mathlib
+import Proofs.ShannonChannelCodingAWGN
+
+namespace ShannonHartley
+
+open Real ShannonAWGN
+
+/-- The **bandlimited Shannon–Hartley capacity** of an AWGN channel of
+    bandwidth `B` (Hz), signal power `P`, and noise power `N`, measured in
+    bits per second:  `C(B, P, N) = B · log₂(1 + P/N)`. -/
+noncomputable def shannonHartleyCapacity (B P N : ℝ) : ℝ :=
+  B * Real.logb 2 (1 + P / N)
+
+/-! ## The bridge to the per-use AWGN capacity -/
+
+/-- **Bridge identity.**  The bits-per-second Shannon–Hartley capacity is the
+    per-use AWGN capacity (in nats) rescaled by the Nyquist factor `2B` and the
+    nats→bits change of base `1 / log 2`:
+
+        `C(B, P, N) = (2B / log 2) · awgnCapacity P N`.
+
+    This is the precise content of "Nyquist sampling + change of logarithm
+    base": `awgnCapacity P N = ½ log(1 + P/N)` and `log₂ x = log x / log 2`. -/
+theorem shannonHartley_eq_awgn (B P N : ℝ) :
+    shannonHartleyCapacity B P N = (2 * B / Real.log 2) * awgnCapacity P N := by
+  unfold shannonHartleyCapacity awgnCapacity
+  rw [Real.logb]
+  ring
+
+/-- **Nyquist assembly.**  The capacity is `2B` times the per-use capacity in
+    bits, `½ log₂(1 + P/N)`.  This exposes the "`2B` independent uses per
+    second" reading directly. -/
+theorem shannonHartley_eq_two_B_bits_per_use (B P N : ℝ) :
+    shannonHartleyCapacity B P N =
+      2 * B * ((1 / 2) * Real.logb 2 (1 + P / N)) := by
+  unfold shannonHartleyCapacity
+  ring
+
+/-! ## Structural properties of the bandlimited capacity formula -/
+
+/-- The capacity is non-negative for any non-negative bandwidth and signal
+    power (with positive noise). -/
+theorem shannonHartley_nonneg {B P N : ℝ} (hB : 0 ≤ B) (hP : 0 ≤ P)
+    (hN : 0 < N) : 0 ≤ shannonHartleyCapacity B P N := by
+  unfold shannonHartleyCapacity
+  have hd : 0 ≤ P / N := div_nonneg hP hN.le
+  have h1 : (1 : ℝ) ≤ 1 + P / N := by linarith
+  have hlog : 0 ≤ Real.logb 2 (1 + P / N) :=
+    Real.logb_nonneg (by norm_num) h1
+  exact mul_nonneg hB hlog
+
+/-- With no signal power the capacity vanishes: `C(B, 0, N) = 0`. -/
+theorem shannonHartley_zero_power {B N : ℝ} :
+    shannonHartleyCapacity B 0 N = 0 := by
+  unfold shannonHartleyCapacity
+  simp
+
+/-- With no bandwidth there is no capacity: `C(0, P, N) = 0`. -/
+theorem shannonHartley_zero_bandwidth {P N : ℝ} :
+    shannonHartleyCapacity 0 P N = 0 := by
+  unfold shannonHartleyCapacity
+  simp
+
+/-- The capacity is strictly positive whenever there is bandwidth, signal
+    power, and noise. -/
+theorem shannonHartley_pos {B P N : ℝ} (hB : 0 < B) (hP : 0 < P) (hN : 0 < N) :
+    0 < shannonHartleyCapacity B P N := by
+  unfold shannonHartleyCapacity
+  have hd : 0 < P / N := div_pos hP hN
+  have h1 : (1 : ℝ) < 1 + P / N := by linarith
+  have hlog : 0 < Real.logb 2 (1 + P / N) :=
+    Real.logb_pos (by norm_num) h1
+  exact mul_pos hB hlog
+
+/-- The capacity is monotone increasing in the bandwidth. -/
+theorem shannonHartley_mono_bandwidth {B₁ B₂ P N : ℝ} (hP : 0 ≤ P) (hN : 0 < N)
+    (h : B₁ ≤ B₂) :
+    shannonHartleyCapacity B₁ P N ≤ shannonHartleyCapacity B₂ P N := by
+  unfold shannonHartleyCapacity
+  have hd : 0 ≤ P / N := div_nonneg hP hN.le
+  have h1 : (1 : ℝ) ≤ 1 + P / N := by linarith
+  have hlog : 0 ≤ Real.logb 2 (1 + P / N) :=
+    Real.logb_nonneg (by norm_num) h1
+  exact mul_le_mul_of_nonneg_right h hlog
+
+/-- The capacity is strictly increasing in the bandwidth (given signal and
+    noise power). -/
+theorem shannonHartley_strictMono_bandwidth {B₁ B₂ P N : ℝ} (hP : 0 < P)
+    (hN : 0 < N) (h : B₁ < B₂) :
+    shannonHartleyCapacity B₁ P N < shannonHartleyCapacity B₂ P N := by
+  unfold shannonHartleyCapacity
+  have hd : 0 < P / N := div_pos hP hN
+  have h1 : (1 : ℝ) < 1 + P / N := by linarith
+  have hlog : 0 < Real.logb 2 (1 + P / N) :=
+    Real.logb_pos (by norm_num) h1
+  exact mul_lt_mul_of_pos_right h hlog
+
+/-- The capacity is monotone increasing in the signal power. -/
+theorem shannonHartley_mono_power {B P₁ P₂ N : ℝ} (hB : 0 ≤ B) (hN : 0 < N)
+    (hP₁ : 0 ≤ P₁) (h : P₁ ≤ P₂) :
+    shannonHartleyCapacity B P₁ N ≤ shannonHartleyCapacity B P₂ N := by
+  unfold shannonHartleyCapacity
+  have hpos : (0 : ℝ) < 1 + P₁ / N := by
+    have : 0 ≤ P₁ / N := div_nonneg hP₁ hN.le
+    linarith
+  have hdiv : P₁ / N ≤ P₂ / N := by
+    have h0 : (0 : ℝ) ≤ (P₂ - P₁) / N := div_nonneg (by linarith) hN.le
+    have he : (P₂ - P₁) / N = P₂ / N - P₁ / N := by ring
+    linarith [he ▸ h0]
+  have hle : 1 + P₁ / N ≤ 1 + P₂ / N := by linarith
+  have hlog : Real.logb 2 (1 + P₁ / N) ≤ Real.logb 2 (1 + P₂ / N) :=
+    Real.logb_le_logb_of_le (by norm_num) hpos hle
+  exact mul_le_mul_of_nonneg_left hlog hB
+
+/-- The capacity is decreasing in the noise power: more noise, less capacity. -/
+theorem shannonHartley_antitone_noise {B P N₁ N₂ : ℝ} (hB : 0 ≤ B) (hP : 0 ≤ P)
+    (hN₁ : 0 < N₁) (h : N₁ ≤ N₂) :
+    shannonHartleyCapacity B P N₂ ≤ shannonHartleyCapacity B P N₁ := by
+  unfold shannonHartleyCapacity
+  have hN₂ : 0 < N₂ := lt_of_lt_of_le hN₁ h
+  have hpos : (0 : ℝ) < 1 + P / N₂ := by
+    have : 0 ≤ P / N₂ := div_nonneg hP hN₂.le
+    linarith
+  have hdiv : P / N₂ ≤ P / N₁ := by
+    have hden : (0 : ℝ) ≤ N₁ * N₂ := mul_nonneg hN₁.le hN₂.le
+    have h0 : (0 : ℝ) ≤ P * (N₂ - N₁) / (N₁ * N₂) :=
+      div_nonneg (mul_nonneg hP (by linarith)) hden
+    have he : P * (N₂ - N₁) / (N₁ * N₂) = P / N₁ - P / N₂ := by
+      rw [div_sub_div _ _ hN₁.ne' hN₂.ne']
+      ring
+    linarith [he ▸ h0]
+  have hle : 1 + P / N₂ ≤ 1 + P / N₁ := by linarith
+  have hlog : Real.logb 2 (1 + P / N₂) ≤ Real.logb 2 (1 + P / N₁) :=
+    Real.logb_le_logb_of_le (by norm_num) hpos hle
+  exact mul_le_mul_of_nonneg_left hlog hB
+
+/-! ## The low-SNR / wideband linear bound -/
+
+/-- **Linear (low-SNR) upper bound.**  Since `log(1 + x) ≤ x`, the capacity is
+    bounded by the bandwidth-scaled signal-to-noise ratio divided by `log 2`:
+
+        `C(B, P, N) ≤ B · (P/N) / log 2`.
+
+    This is the precise form behind the wideband statement that capacity grows
+    at most linearly in SNR; equality is approached as `P/N → 0`. -/
+theorem shannonHartley_le_snr_linear {B P N : ℝ} (hB : 0 ≤ B) (hP : 0 ≤ P)
+    (hN : 0 < N) :
+    shannonHartleyCapacity B P N ≤ B * (P / N) / Real.log 2 := by
+  unfold shannonHartleyCapacity
+  have hd : 0 ≤ P / N := div_nonneg hP hN.le
+  have hxpos : (0 : ℝ) < 1 + P / N := by linarith
+  -- log(1 + P/N) ≤ P/N
+  have hlog_le : Real.log (1 + P / N) ≤ P / N := by
+    have := Real.log_le_sub_one_of_pos hxpos
+    linarith
+  have hlog2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  -- logb 2 (1 + P/N) = log(1 + P/N) / log 2 ≤ (P/N) / log 2
+  have hlogb_le : Real.logb 2 (1 + P / N) ≤ (P / N) / Real.log 2 := by
+    rw [Real.logb, div_le_div_iff_of_pos_right hlog2]
+    exact hlog_le
+  calc B * Real.logb 2 (1 + P / N)
+      ≤ B * ((P / N) / Real.log 2) := mul_le_mul_of_nonneg_left hlogb_le hB
+    _ = B * (P / N) / Real.log 2 := by ring
+
+end ShannonHartley

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-03/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "shannon-channel-coding-awgn-oq-03",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "From Per-Use Nats to Bandlimited Bits/Second",
+    "content": "OQ-03 asks to extend the parent AWGN capacity to the bandlimited Shannon–Hartley form. The parent proves $\\operatorname{awgnCapacity}(P,N) = \\tfrac12\\log(1+P/N)$ nats per channel use. Two textbook conversions produce the bits-per-second formula $C = B\\log_2(1+P/N)$: a change of base (one nat $= 1/\\log 2$ bits) and the Nyquist rate (a bandwidth-$B$ channel supports $2B$ independent dimensions per second). Their product gives the bridge $C = (2B/\\log 2)\\cdot\\operatorname{awgnCapacity}(P,N)$. The scalar bandlimited form is formalised exactly; the vector water-filling problem is left open."
+  },
+  {
+    "id": "ann-definition",
+    "proofId": "shannon-channel-coding-awgn-oq-03",
+    "range": { "startLine": 63, "endLine": 67 },
+    "type": "definition",
+    "title": "The Shannon–Hartley Capacity",
+    "content": "$\\operatorname{shannonHartleyCapacity}(B,P,N) := B\\cdot\\log_2(1+P/N)$, the bandlimited AWGN capacity in bits per second as a function of bandwidth $B$ (Hz), signal power $P$, and noise power $N$. Here $\\log_2 = \\operatorname{Real.logb} 2$ and $\\operatorname{Real.logb} b\\,x = \\log x / \\log b$."
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "shannon-channel-coding-awgn-oq-03",
+    "range": { "startLine": 69, "endLine": 92 },
+    "type": "key-step",
+    "title": "The Bridge Identity (Nyquist + Change of Base)",
+    "content": "`shannonHartley_eq_awgn`: $C(B,P,N) = (2B/\\log 2)\\cdot\\operatorname{awgnCapacity}(P,N)$. Rewriting $\\log_2 x = \\log x/\\log 2$ turns the goal into a pure ring identity: $B\\cdot\\tfrac{\\log(1+P/N)}{\\log 2} = \\tfrac{2B}{\\log 2}\\cdot\\tfrac12\\log(1+P/N)$. This ties the bandlimited formula directly to the parent's verified per-use quantity. The companion `shannonHartley_eq_two_B_bits_per_use` rewrites the same fact as $C = 2B\\cdot(\\tfrac12\\log_2(1+P/N))$ — $2B$ copies of the per-use bit capacity."
+  },
+  {
+    "id": "ann-sign",
+    "proofId": "shannon-channel-coding-awgn-oq-03",
+    "range": { "startLine": 94, "endLine": 130 },
+    "type": "key-step",
+    "title": "Sign: Non-negative, Vanishing, Strictly Positive",
+    "content": "Because $1+P/N \\ge 1$ for $P\\ge 0,\\,N>0$, $\\operatorname{logb} 2$ is non-negative there (`logb_nonneg`), so $C\\ge 0$ (`shannonHartley_nonneg`). It vanishes exactly when there is nothing to transmit over: $C(B,0,N)=0$ and $C(0,P,N)=0$ since $\\log_2 1 = 0$ (`shannonHartley_zero_power`, `shannonHartley_zero_bandwidth`). When $B,P,N>0$ the argument exceeds $1$, so `logb_pos` gives $C>0$ (`shannonHartley_pos`)."
+  },
+  {
+    "id": "ann-monotonicity",
+    "proofId": "shannon-channel-coding-awgn-oq-03",
+    "range": { "startLine": 131, "endLine": 199 },
+    "type": "key-step",
+    "title": "Monotonicity in the Three Resources",
+    "content": "Capacity rises with bandwidth — a non-negative multiplier on a non-negative log (`shannonHartley_mono_bandwidth`, strict when $P,N>0$ in `shannonHartley_strictMono_bandwidth`). It rises with signal power because $P\\mapsto 1+P/N$ is increasing and $\\operatorname{logb} 2$ is monotone for base $2>1$ (`shannonHartley_mono_power` via `logb_le_logb_of_le`). It falls with noise power because $N\\mapsto 1+P/N$ is decreasing (`shannonHartley_antitone_noise`). The power and noise steps reuse the parent's $(P_2-P_1)/N$ and $P(N_2-N_1)/(N_1N_2)$ difference identities."
+  },
+  {
+    "id": "ann-linear-bound",
+    "proofId": "shannon-channel-coding-awgn-oq-03",
+    "range": { "startLine": 200, "endLine": 220 },
+    "type": "key-step",
+    "title": "The Low-SNR / Wideband Linear Bound",
+    "content": "`shannonHartley_le_snr_linear`: $C(B,P,N) \\le B\\cdot(P/N)/\\log 2$. The concavity inequality $\\log(1+x)\\le x$ (`Real.log_le_sub_one_of_pos` at $x=P/N$) gives $\\log(1+P/N)\\le P/N$; dividing by the positive constant $\\log 2$ (`div_le_div_iff_of_pos_right`) and multiplying by $B\\ge 0$ yields the bound. This is the formal statement that capacity grows at most linearly in SNR — the wideband regime where bandwidth, not power, is the efficient lever — with equality approached as $P/N\\to 0$."
+  }
+]

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-03/index.ts
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ShannonChannelCodingAWGNOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const shannonChannelCodingAwgnOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const shannonChannelCodingAwgnOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const shannonChannelCodingAwgnOq03Data: ProofData = {
+  proof: shannonChannelCodingAwgnOq03Proof,
+  annotations: shannonChannelCodingAwgnOq03Annotations,
+}

--- a/src/data/proofs/shannon-channel-coding-awgn-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-03/meta.json
@@ -1,0 +1,192 @@
+{
+  "id": "shannon-channel-coding-awgn-oq-03",
+  "slug": "shannon-channel-coding-awgn-oq-03",
+  "title": "The Bandlimited Shannon–Hartley Capacity C = B·log₂(1 + P/N) bits/s",
+  "description": "Turns the parent AWGN per-use capacity awgnCapacity P N = ½ log(1 + P/N) nats/use into the classical bandlimited Shannon–Hartley formula C(B, P, N) = B·log₂(1 + P/N) bits per second. The bridge is two exact textbook conversions: change of logarithm base (one nat = 1/log 2 bits) and the Nyquist rate (a bandwidth-B channel supports 2B independent signalling dimensions per second), giving the single identity C = (2B / log 2)·awgnCapacity P N. All structural properties follow: non-negativity, vanishing at zero power or zero bandwidth, strict positivity, monotonicity in bandwidth and power, antitonicity in noise, and the low-SNR linear bound C ≤ B·(P/N)/log 2 from log(1+x) ≤ x. 220 lines, 11 theorems, 1 definition, 0 axioms, 0 sorries. The vector/parallel Gaussian channel via water-filling is left open.",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ShannonChannelCodingAWGN"
+    ],
+    "opens": [
+      "Real",
+      "ShannonAWGN"
+    ],
+    "namespace": "ShannonHartley",
+    "lineCount": 220,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "path": "Proofs/ShannonChannelCodingAWGNOQ03.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonChannelCodingAWGNOQ03.lean",
+    "tags": [
+      "information-theory",
+      "channel-capacity",
+      "shannon-hartley",
+      "awgn",
+      "shannon",
+      "bandwidth",
+      "logarithm",
+      "analysis",
+      "coding-theory",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 220,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "badge": "verified",
+    "originalContributions": [
+      "shannonHartley_eq_awgn: the bridge identity C(B, P, N) = (2B / log 2)·awgnCapacity P N. This is the precise formal content of 'Nyquist sampling + change of logarithm base': the per-use AWGN capacity awgnCapacity P N = ½ log(1 + P/N) (nats per channel use, from the parent file) is multiplied by the Nyquist factor 2B (independent dimensions per second) and divided by log 2 (the nats→bits change of base), yielding the bits-per-second Shannon–Hartley value. It ties the bandlimited formula directly to the parent's verified per-use quantity rather than re-deriving it.",
+      "shannonHartleyCapacity / shannonHartley_eq_two_B_bits_per_use: the definition C(B, P, N) = B·log₂(1 + P/N) and its 'Nyquist reading' C = 2B·(½ log₂(1 + P/N)), exposing the capacity as 2B copies of the per-use bit capacity ½ log₂(1 + P/N).",
+      "shannonHartley_le_snr_linear: the low-SNR / wideband linear bound C ≤ B·(P/N)/log 2, the formal version of 'capacity grows at most linearly in SNR'. It follows from the elementary inequality log(1 + x) ≤ x (Real.log_le_sub_one_of_pos) after the change of base, and is approached with equality as P/N → 0.",
+      "Structural suite (shannonHartley_nonneg, shannonHartley_pos, shannonHartley_zero_power, shannonHartley_zero_bandwidth, shannonHartley_mono_bandwidth, shannonHartley_strictMono_bandwidth, shannonHartley_mono_power, shannonHartley_antitone_noise): the complete qualitative behaviour of the capacity surface — non-negative, zero exactly when bandwidth or signal power vanishes, strictly positive otherwise, increasing in bandwidth and power, decreasing in noise — each reduced to the corresponding monotonicity of Real.logb 2 on 1 + P/N."
+    ],
+    "prerequisites": [
+      "Parent: shannon-channel-coding-awgn (the per-use AWGN capacity awgnCapacity P N = ½ log(1 + P/N), proved axiom-free)",
+      "Real.logb b x = Real.log x / Real.log b (definition of the base-b logarithm)",
+      "Monotonicity of logb for base > 1: Real.logb_le_logb_of_le, Real.logb_pos, Real.logb_nonneg",
+      "The elementary bound Real.log_le_sub_one_of_pos: 0 < x → log x ≤ x − 1",
+      "Nyquist sampling theorem (informal justification for the 2B independent dimensions per second factor)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.logb_le_logb_of_le",
+        "description": "For base b > 1, logb b is monotone: 0 < x → x ≤ y → logb b x ≤ logb b y. Drives the monotonicity of the capacity in signal power and its antitonicity in noise power.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Base"
+      },
+      {
+        "theorem": "Real.logb_pos",
+        "description": "For base b > 1, 1 < x → 0 < logb b x. Gives strict positivity of the capacity when there is bandwidth, power and noise.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Base"
+      },
+      {
+        "theorem": "Real.logb_nonneg",
+        "description": "For base b > 1, 1 ≤ x → 0 ≤ logb b x. Gives non-negativity of the capacity and the non-strict bandwidth/power monotonicities.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Base"
+      },
+      {
+        "theorem": "Real.log_le_sub_one_of_pos",
+        "description": "0 < x → log x ≤ x − 1, the concavity bound on the logarithm. Applied at x = 1 + P/N it yields log(1 + P/N) ≤ P/N, the low-SNR linear upper bound on capacity.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Shannon–Hartley theorem, C = B·log₂(1 + S/N), is the most quoted formula in information theory: it states the maximum error-free data rate (bits per second) of a bandlimited analogue channel of bandwidth B (Hz) corrupted by additive white Gaussian noise of power N, with received signal power S. It is the continuous-time, engineering-units face of Shannon's AWGN capacity. The per-symbol result — capacity ½ log(1 + P/N) nats per channel use — and the rate at which a bandlimited channel offers independent uses (the Nyquist rate, 2B per second) combine to give the bits-per-second figure. The parent formalization established the per-use value axiom-free from the differential-entropy layer; this entry performs the two unit conversions that produce the textbook bandlimited formula.",
+    "problemStatement": "Extend the parent AWGN capacity (awgnCapacity P N = ½ log(1 + P/N) nats per channel use) to the bandlimited Shannon–Hartley form C(B, P, N) = B·log₂(1 + P/N) bits per second, and establish its qualitative properties (sign, monotonicities, the low-SNR linear bound). The open question's second half — the capacity of a vector (parallel) Gaussian channel obtained by water-filling the power budget across sub-channels — is a separate optimisation problem and is left open.",
+    "proofStrategy": "Define shannonHartleyCapacity B P N := B·log₂(1 + P/N). The central lemma shannonHartley_eq_awgn rewrites log₂ as log/log 2 and shows the capacity equals (2B/log 2)·awgnCapacity P N — the algebraic core of 'Nyquist sampling (×2B uses/s) + change of base (÷log 2 nats→bits)'. Every structural theorem then reduces to a known fact about Real.logb 2 on the argument 1 + P/N: non-negativity and positivity from logb_nonneg / logb_pos (since 1 + P/N ≥ 1, with strictness when P > 0), monotonicity in P and antitonicity in N from logb_le_logb_of_le applied to the monotone map P ↦ 1 + P/N (resp. N ↦ 1 + P/N), and monotonicity in B by multiplying the non-negative log factor. The low-SNR bound shannonHartley_le_snr_linear uses the concavity inequality log(1 + x) ≤ x at x = P/N, divided through by the positive constant log 2.",
+    "keyInsights": [
+      "The bandlimited formula is two unit conversions away from the per-use formula. Nothing new about Gaussian channels is needed: C = B·log₂(1 + P/N) is exactly the per-use nats capacity ½ log(1 + P/N) multiplied by 2B (Nyquist uses per second) and divided by log 2 (nats to bits). The bridge identity makes both factors explicit and ties the result to the parent's verified quantity.",
+      "Base change and sampling are independent scalars. The change of base contributes the fixed factor 1/log 2 and the Nyquist rate contributes the fixed factor 2B; their product 2B/log 2 multiplies the whole per-use capacity, so the entire qualitative shape of C is inherited from awgnCapacity (equivalently from log₂(1 + P/N)).",
+      "Monotonicity is entirely carried by the inner map. Capacity rises with bandwidth (a non-negative multiplier on a non-negative log), rises with signal power, and falls with noise power — all because P ↦ 1 + P/N is increasing, N ↦ 1 + P/N is decreasing, and logb 2 is increasing for base 2 > 1.",
+      "The linear bound is the wideband regime in disguise. C ≤ B·(P/N)/log 2 is the formal content of 'at low SNR, capacity is roughly proportional to SNR', the regime where adding bandwidth, not power, is the efficient way to buy rate; it is the single inequality log(1 + x) ≤ x scaled by B/log 2.",
+      "Honest 'verified' status: 0 axioms beyond the foundational propext / Classical.choice / Quot.sound, 0 sorries. The substantive analytic facts (logb monotonicity, log(1+x) ≤ x) are Mathlib's; the original content is the Nyquist-plus-base-change bridge to the parent capacity and the assembled structural theory of the bandlimited formula."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: From Per-Use Nats to Bandlimited Bits/Second",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "States OQ-03 and lays out the answer: the parent's awgnCapacity P N = ½ log(1 + P/N) nats/use becomes C = B·log₂(1 + P/N) bits/s via change of base (÷log 2) and the Nyquist rate (×2B uses/s), summarised in the bridge identity C = (2B/log 2)·awgnCapacity P N. Notes the scope: the scalar bandlimited form is formalised exactly; the vector water-filling problem is left open.",
+      "mathContext": "$C(B,P,N) = B\\,\\log_2\\!\\left(1 + \\tfrac{P}{N}\\right)\\ \\text{bits/s}$"
+    },
+    {
+      "id": "definition",
+      "title": "Definition: The Shannon–Hartley Capacity",
+      "startLine": 63,
+      "endLine": 67,
+      "summary": "noncomputable def shannonHartleyCapacity B P N := B·Real.logb 2 (1 + P/N), the bandlimited capacity in bits per second as a function of bandwidth B (Hz), signal power P, and noise power N.",
+      "mathContext": "$C(B,P,N) := B\\,\\log_2(1 + P/N)$"
+    },
+    {
+      "id": "bridge",
+      "title": "Part I: The Bridge to the Per-Use AWGN Capacity",
+      "startLine": 69,
+      "endLine": 92,
+      "summary": "theorem shannonHartley_eq_awgn: C(B, P, N) = (2B/log 2)·awgnCapacity P N, the algebraic core of Nyquist sampling plus the nats→bits change of base. theorem shannonHartley_eq_two_B_bits_per_use: C = 2B·(½ log₂(1 + P/N)), exposing capacity as 2B copies of the per-use bit capacity.",
+      "mathContext": "$C = \\dfrac{2B}{\\log 2}\\,\\operatorname{awgnCapacity}(P,N) = 2B\\cdot\\tfrac12\\log_2(1+P/N)$"
+    },
+    {
+      "id": "sign",
+      "title": "Part II: Non-negativity, Vanishing, and Strict Positivity",
+      "startLine": 94,
+      "endLine": 130,
+      "summary": "theorem shannonHartley_nonneg (0 ≤ C from 1 + P/N ≥ 1), theorem shannonHartley_zero_power and theorem shannonHartley_zero_bandwidth (C = 0 when P = 0 or B = 0, since log₂ 1 = 0), and theorem shannonHartley_pos (0 < C when B, P, N > 0, from logb_pos).",
+      "mathContext": "$0 \\le C,\\quad C(B,0,N)=C(0,P,N)=0,\\quad C>0\\ \\text{if}\\ B,P,N>0$"
+    },
+    {
+      "id": "monotonicity",
+      "title": "Part III: Monotonicity in Bandwidth, Power, and Noise",
+      "startLine": 131,
+      "endLine": 199,
+      "summary": "theorem shannonHartley_mono_bandwidth and theorem shannonHartley_strictMono_bandwidth (increasing, strictly when P, N > 0), theorem shannonHartley_mono_power (increasing in signal power via logb_le_logb_of_le on P ↦ 1 + P/N), and theorem shannonHartley_antitone_noise (decreasing in noise power via N ↦ 1 + P/N).",
+      "mathContext": "$B_1\\le B_2 \\Rightarrow C_1\\le C_2;\\ P_1\\le P_2 \\Rightarrow C_1\\le C_2;\\ N_1\\le N_2 \\Rightarrow C_2\\le C_1$"
+    },
+    {
+      "id": "linear-bound",
+      "title": "Part IV: The Low-SNR / Wideband Linear Bound",
+      "startLine": 200,
+      "endLine": 220,
+      "summary": "theorem shannonHartley_le_snr_linear: C ≤ B·(P/N)/log 2, the formal 'capacity grows at most linearly in SNR'. Uses log(1 + P/N) ≤ P/N (Real.log_le_sub_one_of_pos) divided by the positive constant log 2; equality is approached as P/N → 0.",
+      "mathContext": "$C(B,P,N) \\le \\dfrac{B\\,(P/N)}{\\log 2}$"
+    }
+  ],
+  "conclusion": {
+    "summary": "The bandlimited Shannon–Hartley capacity C(B, P, N) = B·log₂(1 + P/N) bits/s is assembled axiom-free from the parent's per-use AWGN capacity ½ log(1 + P/N) nats/use by the bridge identity C = (2B/log 2)·awgnCapacity P N (Nyquist rate × change of base). Its full qualitative theory follows: non-negative, zero exactly when bandwidth or signal power vanishes, strictly positive otherwise, increasing in bandwidth and signal power, decreasing in noise, and bounded above by the linear SNR form B·(P/N)/log 2. 220 lines, 11 theorems, 1 definition, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The entry completes the standard textbook chain from the per-symbol AWGN capacity to the engineering-units bandlimited formula, with the two unit conversions (sampling and base change) made fully explicit and verified. The structural suite gives a reusable formal account of how data rate responds to the three resources — bandwidth, signal power, and noise — and the linear bound isolates the low-SNR/wideband regime in which bandwidth, not power, is the efficient lever on rate.",
+    "openQuestions": [
+      "Vector / parallel Gaussian channel via water-filling: prove the capacity of n independent sub-channels with noise powers Nᵢ under a total power budget Σ Pᵢ ≤ P is Σ ½ log(1 + Pᵢ/Nᵢ) maximised by the water-filling allocation Pᵢ = (μ − Nᵢ)₊, and that the optimal level μ is fixed by Σ (μ − Nᵢ)₊ = P. This is the genuinely separate optimisation half of OQ-03.",
+      "Wideband limit: formalise lim_{B → ∞} C = P/(N₀ log 2) for a fixed noise spectral density N = N₀·B, the asymptotic capacity of the infinite-bandwidth AWGN channel, as the rigorous limit behind the linear bound shannonHartley_le_snr_linear."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-channel-coding-awgn",
+      "relationship": "extends",
+      "description": "Parent. Supplies the per-channel-use capacity awgnCapacity P N = ½ log(1 + P/N) nats; this entry rescales it by the Nyquist factor 2B and the nats→bits change of base to obtain the bandlimited bits-per-second formula."
+    },
+    {
+      "targetId": "shannon-channel-coding-awgn-oq-02",
+      "relationship": "related",
+      "description": "Sibling OQ on the same parent. OQ-02 discharges the converse's output-power hypothesis E[Y²] = P + N; OQ-03 (this entry) recasts the resulting per-use capacity in bandlimited bits-per-second units."
+    },
+    {
+      "targetId": "shannon-channel-coding-oq-01",
+      "relationship": "related",
+      "description": "Grandparent context: computing capacities for concrete channels (BSC, BEC, AWGN). The Shannon–Hartley formula is the bandlimited, bits-per-second presentation of the AWGN capacity computed there."
+    }
+  ],
+  "references": [
+    {
+      "title": "Communication in the Presence of Noise",
+      "author": "Claude E. Shannon",
+      "year": "1949",
+      "venue": "Proceedings of the IRE, 37(1):10–21",
+      "description": "Origin of the bandlimited capacity C = B·log₂(1 + S/N), combining the per-dimension Gaussian capacity with the 2B-dimensions-per-second sampling theorem."
+    },
+    {
+      "title": "Elements of Information Theory",
+      "author": "Thomas M. Cover and Joy A. Thomas",
+      "year": "2006",
+      "venue": "Wiley-Interscience",
+      "description": "Standard reference for the AWGN capacity ½ log(1 + P/N), the bandlimited Shannon–Hartley form, the parallel Gaussian channel and the water-filling power allocation."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Log.Base",
+      "author": "Mathlib Community",
+      "year": "2026",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the base-b logarithm Real.logb and its monotonicity/positivity lemmas (logb_le_logb_of_le, logb_pos, logb_nonneg) used throughout."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-03.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-03.json
@@ -1,0 +1,78 @@
+{
+  "slug": "shannon-channel-coding-awgn-oq-03",
+  "title": "Extend to the bandlimited Shannon–Hartley form C = B log₂(1 + P/N) bits/s and...",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Extend to the bandlimited Shannon–Hartley form C = B log₂(1 + P/N) bits/s and to parallel Gaussian channels via water-filling (the capacity of a vector AWGN channel).",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-06-27T17:44:11.367Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: bandlimited Shannon–Hartley C = B·log₂(1+P/N) bits/s formalized VERIFIED (0-axiom) via Nyquist+base-change bridge to parent AWGN capacity; full structural theory + low-SNR linear bound. Vector water-filling left open.",
+    "builtItems": [
+      "shannonHartleyCapacity (def) + 11 theorems in proofs/Proofs/ShannonChannelCodingAWGNOQ03.lean (220 lines, 0 axioms, 0 sorries, VERIFIED)",
+      "shannonHartley_eq_awgn: C = (2B/log 2)·awgnCapacity P N (bridge)",
+      "shannonHartley_le_snr_linear: C ≤ B·(P/N)/log 2 (low-SNR bound)",
+      "Structural suite: nonneg, pos, zero_power, zero_bandwidth, mono_bandwidth, strictMono_bandwidth, mono_power, antitone_noise, eq_two_B_bits_per_use"
+    ],
+    "insights": [
+      "The bandlimited Shannon–Hartley form C = B·log₂(1+P/N) bits/s is exactly two unit conversions away from the parent per-use AWGN capacity ½log(1+P/N) nats/use: a change of base (÷log 2, nats→bits) and the Nyquist rate (×2B independent dimensions/s).",
+      "Bridge identity C = (2B/log 2)·awgnCapacity P N ties the bits/s formula directly to the parent verified quantity; after rw [Real.logb] it is a pure ring identity (no need for log 2 ≠ 0).",
+      "All qualitative behaviour of C is inherited from Real.logb 2 on the inner map 1+P/N: nonneg/pos from logb_nonneg/logb_pos, monotone in P / antitone in N from logb_le_logb_of_le, monotone in B by multiplying a nonneg log factor.",
+      "Low-SNR/wideband linear bound C ≤ B·(P/N)/log 2 is the single inequality log(1+x) ≤ x (Real.log_le_sub_one_of_pos) scaled by B/log 2."
+    ],
+    "mathlibGaps": [
+      "v4.26.0: logb monotonicity lemma is Real.logb_le_logb_of_le (takes hb:1<b first); Real.logb_le_logb_right does NOT exist.",
+      "No Mathlib infrastructure for the parallel/vector Gaussian channel capacity or the water-filling power allocation (the open second half of OQ-03)."
+    ],
+    "nextSteps": [
+      "Vector/parallel Gaussian channel via water-filling: C = Σ ½log(1+Pᵢ/Nᵢ) maximised by Pᵢ=(μ−Nᵢ)₊ under ΣPᵢ≤P; the optimisation half left open.",
+      "Wideband limit lim_{B→∞} C = P/(N₀ log 2) for fixed noise spectral density N=N₀·B, as the rigorous limit behind the linear bound."
+    ]
+  },
+  "tags": [
+    "information-theory",
+    "analysis",
+    "probability",
+    "measure-theory",
+    "coding-theory",
+    "channel-capacity"
+  ],
+  "relatedProofs": [
+    "shannon-channel-coding",
+    "shannon-channel-coding-awgn"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-27T17:44:11.367Z",
+  "lastUpdate": "2026-06-27",
+  "significance": 6,
+  "tractability": 5,
+  "currentPhase": "COMPLETED"
+}


### PR DESCRIPTION
## Summary

New gallery entry **shannon-channel-coding-awgn-oq-03**, answering the first half of the open question

> *Extend to the bandlimited Shannon–Hartley form C = B·log₂(1 + P/N) bits/s and to parallel Gaussian channels via water-filling.*

It turns the parent AWGN per-use capacity `awgnCapacity P N = ½ log(1 + P/N)` (nats per channel use, proved axiom-free in `ShannonChannelCodingAWGN`) into the classical **bandlimited bits-per-second** Shannon–Hartley formula

```
C(B, P, N) = B · log₂(1 + P/N)   [bits per second]
```

via two exact textbook unit conversions, captured in one bridge identity:

```lean
theorem shannonHartley_eq_awgn (B P N : ℝ) :
    shannonHartleyCapacity B P N = (2 * B / Real.log 2) * awgnCapacity P N
```

- **change of base** (one nat = `1/log 2` bits, nats→bits), and
- **Nyquist rate** (a bandwidth-`B` channel offers `2B` independent dimensions per second).

## Contents

`proofs/Proofs/ShannonChannelCodingAWGNOQ03.lean` — **220 lines, 1 definition, 11 theorems, 0 sorries, 0 axioms.**

- `shannonHartleyCapacity` — `C = B · log₂(1 + P/N)`
- `shannonHartley_eq_awgn`, `shannonHartley_eq_two_B_bits_per_use` — the Nyquist + change-of-base bridge
- sign: `shannonHartley_nonneg`, `shannonHartley_pos`, `shannonHartley_zero_power`, `shannonHartley_zero_bandwidth`
- monotonicity: `shannonHartley_mono_bandwidth`, `shannonHartley_strictMono_bandwidth`, `shannonHartley_mono_power`, `shannonHartley_antitone_noise`
- `shannonHartley_le_snr_linear` — the low-SNR / wideband bound `C ≤ B·(P/N)/log 2`

## Verification

`#print axioms` on every theorem yields only `[propext, Classical.choice, Quot.sound]` — **genuinely 0-axiom, status `verified`**. No `sorryAx`, no `Lean.ofReduceBool`. Built against Mathlib `v4.26.0` (docker down → `lake env lean` per-dependency olean fallback).

## Scope / left open

The **vector / parallel Gaussian channel via water-filling** (the optimisation `C = Σ ½ log(1 + Pᵢ/Nᵢ)` maximised by `Pᵢ = (μ − Nᵢ)₊` under `Σ Pᵢ ≤ P`) is a genuinely separate optimisation problem and is documented as an open follow-up, not claimed here.

Includes gallery data (`meta.json`, `annotations.json`, `index.ts`) and the research problem record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)