### PR TITLE
Enrich: Gaussian integral = √π (deeper annotations + full section coverage)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07/annotations.json
@@ -1,14 +1,37 @@
 [
   {
-    "id": "ann-aoc07-context",
+    "id": "ann-aoc07-imports",
     "proofId": "area-of-circle-oq-07",
     "range": {
       "startLine": 1,
+      "endLine": 2
+    },
+    "type": "context",
+    "title": "Where the analytic work actually lives",
+    "content": "The entire dependency footprint is two imports. `Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral` supplies `integral_gaussian`, and `Mathlib.Tactic` supplies the tactic toolbox (`simpa`, `rw`). Crucially, the hard analysis is hidden inside that first import: Mathlib's own proof of `integral_gaussian` is *not* a specialization — it runs the classical Laplace–Poisson argument internally, squaring the integral to a 2-D Gaussian over ℝ² and evaluating it by Fubini together with a polar-coordinate change of variables. So this entry inherits the squaring-and-polar evaluation wholesale; the single import is precisely the boundary between 'reproved here' and 'trusted from Mathlib'.",
+    "mathContext": "Mathlib derives $\\int_{\\mathbb R} e^{-bx^2}\\,dx = \\sqrt{\\pi/b}$ from $\\bigl(\\int_{\\mathbb R} e^{-bx^2}\\,dx\\bigr)^2 = \\int_{\\mathbb R^2} e^{-b(x^2+y^2)}\\,dx\\,dy = \\int_0^{2\\pi}\\!\\!\\int_0^\\infty e^{-br^2} r\\,dr\\,d\\theta = \\pi/b$, the same polar Jacobian $r$ as the parent entry.",
+    "significance": "context",
+    "relatedConcepts": [
+      "dependency footprint",
+      "integral_gaussian",
+      "Fubini theorem",
+      "polar-coordinate change of variables"
+    ],
+    "prerequisites": [
+      "Lean imports",
+      "Mathlib module structure"
+    ]
+  },
+  {
+    "id": "ann-aoc07-context",
+    "proofId": "area-of-circle-oq-07",
+    "range": {
+      "startLine": 4,
       "endLine": 27
     },
     "type": "concept",
     "title": "The Gaussian Integral and Its Place in the Gallery",
-    "content": "This entry answers open question 7 of the `area-of-circle` parent: the total integral of the Gaussian bell curve `e^{-x²}` over all of ℝ is `√π`. Rather than redo the classical squaring-and-polar-coordinates evaluation, it specializes Mathlib's already-proved parametrized Gaussian integral `integral_gaussian (b) : ∫ x, exp (-b·x²) = √(π/b)` at `b = 1`. This is deliberately a *routine specialization* — the analytic content lives entirely inside Mathlib — but it is the iconic case: `√π` is the normalization constant of the standard normal distribution and the simplest definite integral whose value carries a factor of π with no circle in sight.",
+    "content": "This entry answers open question 7 of the `area-of-circle` parent: the total integral of the Gaussian bell curve `e^{-x²}` over all of ℝ is `√π`. Rather than redo the classical squaring-and-polar-coordinates evaluation, it specializes Mathlib's already-proved parametrized Gaussian integral `integral_gaussian (b) : ∫ x, exp (-b·x²) = √(π/b)` at `b = 1`. This is deliberately a *routine specialization* — the analytic content lives entirely inside Mathlib — but it is the iconic case: `√π` is the normalization constant of the standard normal distribution and the simplest definite integral whose value carries a factor of π with no circle in sight. One subtlety to read correctly: after `open Real MeasureTheory`, the symbol `∫ x, f x` is the **Bochner/Lebesgue integral against the volume measure on ℝ**, not a Riemann or improper integral — so the statement is genuinely about a Lebesgue-integrable function over the whole line (a non-integrable integrand would silently evaluate to `0` under this notation), and integrability of `e^{-x²}` is part of what `integral_gaussian` supplies.",
     "mathContext": "The classical evaluation, due to Laplace and Poisson, computes $I = \\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx$ by squaring: $I^2 = \\int\\!\\!\\int_{\\mathbb R^2} e^{-(x^2+y^2)}\\,dx\\,dy$, then switching to polar coordinates $x = r\\cos\\theta,\\ y = r\\sin\\theta$ with Jacobian $r$, giving $I^2 = \\int_0^{2\\pi}\\!\\!\\int_0^\\infty e^{-r^2} r\\,dr\\,d\\theta = \\pi$, hence $I = \\sqrt{\\pi}$. The factor of $\\pi$ enters through exactly the circle-area Jacobian studied in the parent entry.",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07` (passes: 0, quality: 79). This entry was already well-developed; this pass closes two genuine coverage gaps without padding.

## Changes
- **Annotations 3 → 4**, all anchored to real Lean constructs:
  - New dedicated *imports* annotation (lines 1–2) making concrete **where the analytic work lives** — Mathlib's own `integral_gaussian` runs the classical Laplace–Poisson squaring + polar-coordinate evaluation internally, so this file inherits it wholesale; the single import is the boundary between 'reproved here' and 'trusted from Mathlib'.
  - Added a correctness note to the concept annotation: under `open … MeasureTheory`, `∫ x, f x` is the **Bochner/Lebesgue integral against volume measure** (not Riemann/improper), and integrability of $e^{-x^2}$ is part of what `integral_gaussian` supplies.
- **Sections**: added an *overview* section (lines 1–29) so the array now spans the whole 41-line file (previously only the two theorems, 31–41).

## Notes on scope
The file is 41 lines with exactly 4 anchorable constructs (imports, docstring, two theorems). I deliberately did **not** inflate to ≥5 annotations — the resolver requires each annotation to anchor to a construct, and splitting further would be padding, which the size guardrails (#30348) warn against. Folded the integral-semantics point into an existing annotation rather than add a thin standalone one.

## Verification
- `scripts/annotations/build.ts`: entry resolves with **0 errors** (the earlier 'no construct at line 29' was eliminated by removing the un-anchorable `open`-line annotation).
- `check-meta-size.ts`: within all caps (meta.json ~10 KB).
- Axiom integrity unchanged: `status: verified`, `axiomCount: 0`, badge `mathlib` — all already matching the Lean source.