### PR TITLE
research(schroeder-bernstein-oq-03): prove 3 partialInverse computability lemmas [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -109,17 +109,29 @@ def partialInverse (g : ℕ → ℕ) : ℕ →. ℕ :=
     [Detailed proof requires Computable₂ API — see Mathlib.Computability.Partrec] -/
 theorem partialInverse_partrec {g : ℕ → ℕ} (hg : Computable g) :
     Partrec (partialInverse g) := by
-  sorry
+  unfold partialInverse
+  apply Partrec.rfind
+  apply Computable₂.partrec₂
+  -- (m, n) ↦ decide (g n = m) is computable: equality of naturals is primitive
+  -- recursive, and g is computable.
+  have heq0 : Primrec₂ (fun a b : ℕ => decide (a = b)) := Primrec.eq.decide
+  have heq : Computable₂ (fun a b : ℕ => decide (a = b)) := heq0.to_comp
+  exact heq.comp (hg.comp Computable.snd) Computable.fst
 
-/-- The partial inverse recovers the input under a computable injection. -/
-theorem partialInverse_spec {g : ℕ → ℕ} (hg_inj : Injective g)
+/-- The partial inverse recovers the input under a computable injection.
+    (Injectivity is not needed: `rfind` returns a witness `n` with `g n = m`.) -/
+theorem partialInverse_spec {g : ℕ → ℕ} (_hg_inj : Injective g)
     {m n : ℕ} (h : n ∈ partialInverse g m) : g n = m := by
-  sorry
+  have hspec := Nat.rfind_spec h
+  simpa using hspec
 
-/-- Elements in range(g) have a partial inverse defined. -/
+/-- Elements in range(g) have a partial inverse defined.
+    A witness `g k = m` makes the bounded `rfind` search terminate. -/
 theorem partialInverse_dom {g : ℕ → ℕ} {m : ℕ} (hm : ∃ k, g k = m) :
     (partialInverse g m).Dom := by
-  sorry
+  obtain ⟨k, hk⟩ := hm
+  rw [partialInverse, Nat.rfind_dom']
+  exact ⟨k, by simp [hk], fun _ => trivial⟩
 
 /-!
 ## Section 4: Orbit Structure for the Back-and-Forth


### PR DESCRIPTION
## Schröder–Bernstein OQ-03 — Myhill Isomorphism Theorem (computable CBS)

**Question.** *Myhill's isomorphism theorem (1955): computable injections yield a computable bijection. Can this be formalized using Lean's `Computable` typeclasses?*

`SchroederBernsteinOQ03.lean` formalizes the theorem in the `Primcodable` setting. The easy direction and the equivalence-relation corollaries were already proved; the file carried sorries in the partial-inverse infrastructure plus the deep back-and-forth construction.

### What this PR proves (3 sorries discharged: 4 → 1 tactic sorries)
The three self-contained partial-inverse lemmas, via Mathlib's `Nat.rfind` / `Primrec` API:

| Lemma | Statement | Key API |
|-------|-----------|---------|
| `partialInverse_partrec` | `Partrec (partialInverse g)` from `Computable g` | `Partrec.rfind`, `Computable₂.partrec₂`, `Primrec.eq.decide` + `.to_comp` |
| `partialInverse_spec` | `n ∈ partialInverse g m → g n = m` | `Nat.rfind_spec` |
| `partialInverse_dom` | `(∃ k, g k = m) → (partialInverse g m).Dom` | `Nat.rfind_dom'` |

These are exactly the computability facts the hard direction relies on (`g⁻¹` is partial-recursive and recovers preimages), so they are reusable scaffolding for completing the priority construction.

### Verification
- Built with `lake env lean Proofs/SchroederBernsteinOQ03.lean` (Lean v4.26.0, Mathlib) — compiles with no errors.
- `#print axioms` on all three new proofs: `[propext, Classical.choice, Quot.sound]` only — **0 counted axioms**, no `native_decide`, no `sorry`.
- Docker unavailable in this environment; used the `lake env lean` fallback against the populated Mathlib oleans.

### Remaining
The one open sorry is `myhill_isomorphism` (→ direction): the ~200-line back-and-forth priority construction (Rogers §7.4). Left for future work; this PR completes its computability prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)