### PR TITLE
Enrich: Shannon–Hartley AWGN capacity — structured annotation fields

### DIFF
--- a/src/data/proofs/shannon-channel-coding-awgn-oq-03/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-awgn-oq-03/annotations.json
@@ -5,7 +5,21 @@
     "range": { "startLine": 1, "endLine": 56 },
     "type": "concept",
     "title": "From Per-Use Nats to Bandlimited Bits/Second",
-    "content": "OQ-03 asks to extend the parent AWGN capacity to the bandlimited Shannon–Hartley form. The parent proves $\\operatorname{awgnCapacity}(P,N) = \\tfrac12\\log(1+P/N)$ nats per channel use. Two textbook conversions produce the bits-per-second formula $C = B\\log_2(1+P/N)$: a change of base (one nat $= 1/\\log 2$ bits) and the Nyquist rate (a bandwidth-$B$ channel supports $2B$ independent dimensions per second). Their product gives the bridge $C = (2B/\\log 2)\\cdot\\operatorname{awgnCapacity}(P,N)$. The scalar bandlimited form is formalised exactly; the vector water-filling problem is left open."
+    "content": "OQ-03 asks to extend the parent AWGN capacity to the bandlimited Shannon–Hartley form. The parent proves $\\operatorname{awgnCapacity}(P,N) = \\tfrac12\\log(1+P/N)$ nats per channel use. Two textbook conversions produce the bits-per-second formula $C = B\\log_2(1+P/N)$: a change of base (one nat $= 1/\\log 2$ bits) and the Nyquist rate (a bandwidth-$B$ channel supports $2B$ independent dimensions per second). Their product gives the bridge $C = (2B/\\log 2)\\cdot\\operatorname{awgnCapacity}(P,N)$. The scalar bandlimited form is formalised exactly; the vector water-filling problem is left open.",
+    "mathContext": "$C = B\\log_2\\!\\left(1+\\dfrac{P}{N}\\right) = \\dfrac{2B}{\\log 2}\\cdot\\underbrace{\\tfrac12\\log\\!\\left(1+\\dfrac{P}{N}\\right)}_{\\operatorname{awgnCapacity}(P,N)\\ \\text{[nats/use]}}$, combining the $1\\,\\text{nat} = 1/\\log 2\\,\\text{bits}$ change of base with the Nyquist $2B$ dimensions/second.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Shannon–Hartley theorem",
+      "AWGN channel capacity",
+      "Nyquist rate / sampling theorem",
+      "nats vs bits (change of base)",
+      "water-filling (open vector case)"
+    ],
+    "prerequisites": [
+      "information theory",
+      "channel capacity",
+      "logarithms and base change"
+    ]
   },
   {
     "id": "ann-definition",
@@ -13,7 +27,19 @@
     "range": { "startLine": 63, "endLine": 67 },
     "type": "definition",
     "title": "The Shannon–Hartley Capacity",
-    "content": "$\\operatorname{shannonHartleyCapacity}(B,P,N) := B\\cdot\\log_2(1+P/N)$, the bandlimited AWGN capacity in bits per second as a function of bandwidth $B$ (Hz), signal power $P$, and noise power $N$. Here $\\log_2 = \\operatorname{Real.logb} 2$ and $\\operatorname{Real.logb} b\\,x = \\log x / \\log b$."
+    "content": "$\\operatorname{shannonHartleyCapacity}(B,P,N) := B\\cdot\\log_2(1+P/N)$, the bandlimited AWGN capacity in bits per second as a function of bandwidth $B$ (Hz), signal power $P$, and noise power $N$. Here $\\log_2 = \\operatorname{Real.logb} 2$ and $\\operatorname{Real.logb} b\\,x = \\log x / \\log b$.",
+    "mathContext": "$\\operatorname{shannonHartleyCapacity}(B,P,N) = B\\,\\log_2\\!\\left(1+\\dfrac{P}{N}\\right),\\qquad \\log_2 x = \\operatorname{Real.logb} 2\\,x = \\dfrac{\\log x}{\\log 2}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "bandlimited channel capacity",
+      "signal-to-noise ratio P/N",
+      "Real.logb",
+      "bits per second"
+    ],
+    "prerequisites": [
+      "real logarithm",
+      "Lean definitions"
+    ]
   },
   {
     "id": "ann-bridge",
@@ -21,7 +47,20 @@
     "range": { "startLine": 69, "endLine": 92 },
     "type": "key-step",
     "title": "The Bridge Identity (Nyquist + Change of Base)",
-    "content": "`shannonHartley_eq_awgn`: $C(B,P,N) = (2B/\\log 2)\\cdot\\operatorname{awgnCapacity}(P,N)$. Rewriting $\\log_2 x = \\log x/\\log 2$ turns the goal into a pure ring identity: $B\\cdot\\tfrac{\\log(1+P/N)}{\\log 2} = \\tfrac{2B}{\\log 2}\\cdot\\tfrac12\\log(1+P/N)$. This ties the bandlimited formula directly to the parent's verified per-use quantity. The companion `shannonHartley_eq_two_B_bits_per_use` rewrites the same fact as $C = 2B\\cdot(\\tfrac12\\log_2(1+P/N))$ — $2B$ copies of the per-use bit capacity."
+    "content": "`shannonHartley_eq_awgn`: $C(B,P,N) = (2B/\\log 2)\\cdot\\operatorname{awgnCapacity}(P,N)$. Rewriting $\\log_2 x = \\log x/\\log 2$ turns the goal into a pure ring identity: $B\\cdot\\tfrac{\\log(1+P/N)}{\\log 2} = \\tfrac{2B}{\\log 2}\\cdot\\tfrac12\\log(1+P/N)$. This ties the bandlimited formula directly to the parent's verified per-use quantity. The companion `shannonHartley_eq_two_B_bits_per_use` rewrites the same fact as $C = 2B\\cdot(\\tfrac12\\log_2(1+P/N))$ — $2B$ copies of the per-use bit capacity.",
+    "mathContext": "$B\\cdot\\dfrac{\\log(1+P/N)}{\\log 2} = \\dfrac{2B}{\\log 2}\\cdot\\tfrac12\\log(1+P/N)$ — a ring identity once $\\log_2$ is unfolded, linking $C$ to $\\operatorname{awgnCapacity}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "change of logarithm base",
+      "Nyquist factor 2B",
+      "ring normalization",
+      "per-use vs per-second capacity"
+    ],
+    "prerequisites": [
+      "logb_def (log x / log b)",
+      "field arithmetic",
+      "parent awgnCapacity"
+    ]
   },
   {
     "id": "ann-sign",
@@ -29,7 +68,19 @@
     "range": { "startLine": 94, "endLine": 130 },
     "type": "key-step",
     "title": "Sign: Non-negative, Vanishing, Strictly Positive",
-    "content": "Because $1+P/N \\ge 1$ for $P\\ge 0,\\,N>0$, $\\operatorname{logb} 2$ is non-negative there (`logb_nonneg`), so $C\\ge 0$ (`shannonHartley_nonneg`). It vanishes exactly when there is nothing to transmit over: $C(B,0,N)=0$ and $C(0,P,N)=0$ since $\\log_2 1 = 0$ (`shannonHartley_zero_power`, `shannonHartley_zero_bandwidth`). When $B,P,N>0$ the argument exceeds $1$, so `logb_pos` gives $C>0$ (`shannonHartley_pos`)."
+    "content": "Because $1+P/N \\ge 1$ for $P\\ge 0,\\,N>0$, $\\operatorname{logb} 2$ is non-negative there (`logb_nonneg`), so $C\\ge 0$ (`shannonHartley_nonneg`). It vanishes exactly when there is nothing to transmit over: $C(B,0,N)=0$ and $C(0,P,N)=0$ since $\\log_2 1 = 0$ (`shannonHartley_zero_power`, `shannonHartley_zero_bandwidth`). When $B,P,N>0$ the argument exceeds $1$, so `logb_pos` gives $C>0$ (`shannonHartley_pos`).",
+    "mathContext": "$P\\ge0,\\,N>0 \\Rightarrow 1+\\tfrac{P}{N}\\ge1 \\Rightarrow \\log_2(1+\\tfrac{P}{N})\\ge0 \\Rightarrow C\\ge0$; $C=0$ iff $B=0$ or $P=0$; $B,P,N>0 \\Rightarrow C>0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.logb_nonneg",
+      "Real.logb_pos",
+      "boundary / degenerate cases",
+      "positivity"
+    ],
+    "prerequisites": [
+      "monotonicity of log",
+      "ordered field inequalities"
+    ]
   },
   {
     "id": "ann-monotonicity",
@@ -37,7 +88,19 @@
     "range": { "startLine": 131, "endLine": 199 },
     "type": "key-step",
     "title": "Monotonicity in the Three Resources",
-    "content": "Capacity rises with bandwidth — a non-negative multiplier on a non-negative log (`shannonHartley_mono_bandwidth`, strict when $P,N>0$ in `shannonHartley_strictMono_bandwidth`). It rises with signal power because $P\\mapsto 1+P/N$ is increasing and $\\operatorname{logb} 2$ is monotone for base $2>1$ (`shannonHartley_mono_power` via `logb_le_logb_of_le`). It falls with noise power because $N\\mapsto 1+P/N$ is decreasing (`shannonHartley_antitone_noise`). The power and noise steps reuse the parent's $(P_2-P_1)/N$ and $P(N_2-N_1)/(N_1N_2)$ difference identities."
+    "content": "Capacity rises with bandwidth — a non-negative multiplier on a non-negative log (`shannonHartley_mono_bandwidth`, strict when $P,N>0$ in `shannonHartley_strictMono_bandwidth`). It rises with signal power because $P\\mapsto 1+P/N$ is increasing and $\\operatorname{logb} 2$ is monotone for base $2>1$ (`shannonHartley_mono_power` via `logb_le_logb_of_le`). It falls with noise power because $N\\mapsto 1+P/N$ is decreasing (`shannonHartley_antitone_noise`). The power and noise steps reuse the parent's $(P_2-P_1)/N$ and $P(N_2-N_1)/(N_1N_2)$ difference identities.",
+    "mathContext": "$\\dfrac{\\partial C}{\\partial B}\\ge0,\\ \\dfrac{\\partial C}{\\partial P}\\ge0,\\ \\dfrac{\\partial C}{\\partial N}\\le0$: $C$ is monotone up in $B$ and $P$ and down in $N$, via $1+\\tfrac{P}{N}$ increasing in $P$, decreasing in $N$, and $\\log_2$ increasing.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotone / antitone functions",
+      "Real.logb_le_logb_of_le",
+      "signal-to-noise ratio",
+      "comparative statics"
+    ],
+    "prerequisites": [
+      "monotonicity proofs",
+      "fraction inequalities"
+    ]
   },
   {
     "id": "ann-linear-bound",
@@ -45,6 +108,18 @@
     "range": { "startLine": 200, "endLine": 220 },
     "type": "key-step",
     "title": "The Low-SNR / Wideband Linear Bound",
-    "content": "`shannonHartley_le_snr_linear`: $C(B,P,N) \\le B\\cdot(P/N)/\\log 2$. The concavity inequality $\\log(1+x)\\le x$ (`Real.log_le_sub_one_of_pos` at $x=P/N$) gives $\\log(1+P/N)\\le P/N$; dividing by the positive constant $\\log 2$ (`div_le_div_iff_of_pos_right`) and multiplying by $B\\ge 0$ yields the bound. This is the formal statement that capacity grows at most linearly in SNR — the wideband regime where bandwidth, not power, is the efficient lever — with equality approached as $P/N\\to 0$."
+    "content": "`shannonHartley_le_snr_linear`: $C(B,P,N) \\le B\\cdot(P/N)/\\log 2$. The concavity inequality $\\log(1+x)\\le x$ (`Real.log_le_sub_one_of_pos` at $x=P/N$) gives $\\log(1+P/N)\\le P/N$; dividing by the positive constant $\\log 2$ (`div_le_div_iff_of_pos_right`) and multiplying by $B\\ge 0$ yields the bound. This is the formal statement that capacity grows at most linearly in SNR — the wideband regime where bandwidth, not power, is the efficient lever — with equality approached as $P/N\\to 0$.",
+    "mathContext": "$\\log(1+x)\\le x$ at $x=\\tfrac{P}{N}$ gives $C = B\\log_2(1+\\tfrac{P}{N}) \\le \\dfrac{B\\,(P/N)}{\\log 2}$, with the gap $\\to 0$ as $\\tfrac{P}{N}\\to 0$ (wideband / low-SNR regime).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "concavity bound log(1+x) ≤ x",
+      "Real.log_le_sub_one_of_pos",
+      "low-SNR / wideband regime",
+      "linear capacity scaling"
+    ],
+    "prerequisites": [
+      "concavity of log",
+      "inequality manipulation"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `shannon-channel-coding-awgn-oq-03` (passes: 0, quality: 70).

## Gap
All 6 annotations had detailed LaTeX-rich `content` but were **missing every structured field** — no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`. These are exactly the fields the gallery renders separately and that the enrichment quality score rewards, so this was the single highest-impact gap.

## Changes
Added all four fields to each of the 6 annotations (content left unchanged — no padding, no new annotations):
- **docstring** — the nats→bits change-of-base + Nyquist $2B$ bridge to $C = B\log_2(1+P/N)$;
- **definition** — `shannonHartleyCapacity` and the `Real.logb` unfolding;
- **bridge** — the ring identity linking $C$ to the parent `awgnCapacity`;
- **sign** — non-negativity / vanishing / strict positivity;
- **monotonicity** — up in $B,P$, down in $N$;
- **linear bound** — the $\log(1+x)\le x$ low-SNR/wideband bound.

## Verification
- `scripts/annotations/build.ts`: entry resolves with **0 errors**; all 6 annotations now carry mathContext + significance + relatedConcepts + prerequisites (verified programmatically).
- `check-meta-size.ts`: within all caps. meta.json untouched.
- Axiom integrity unchanged.