### PR TITLE
research(erdos-1005-oq-02): §12 length-4 two-quotient run — long-range obstruction via Stern–Brocot product k₁·k₂−1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -918,4 +918,100 @@ theorem simOrd_triple {a b c d e f k : ℕ} (hb : 0 < b) (hd : 0 < d) (hf_pos : 
       ↔ (2 * (a : ℤ) - k * c) * (2 * (b : ℤ) - k * d) ≥ 0 := by
   rw [simOrd_triple_iff_outer hb hd hf_pos hcd he hfb, simOrd_outer_iff he hfb]
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 12: Length-4 runs — two quotients, and the long-range obstruction
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+§ 11 settled the smallest run that can break, a length-3 block governed by a
+*single* successor quotient `k`.  A length-4 block `a/b, c/d, e/f, g/h` is the
+first run driven by **two** quotients: writing the §9 recurrence twice,
+
+  `e = k₁·c − a`,  `f = k₁·d − b`      (first step, quotient `k₁`)
+  `g = k₂·e − c`,  `h = k₂·f − d`      (second step, quotient `k₂`)
+
+Of the six pairs, the three *adjacent* ones are free (§10).  The three
+non-adjacent obstructions split into the two length-3 outer criteria of §11
+(one per consecutive triple) **plus a genuinely new long-range pair** `a/b, g/h`
+spanning the whole block.  Substituting the recurrences collapses the fourth
+term to a closed form in the *first* pair,
+
+  `g = (k₁·k₂ − 1)·c − k₂·a`,   `h = (k₁·k₂ − 1)·d − k₂·b`,
+
+so the long pair is similarly ordered **iff**
+`((k₂+1)·a − (k₁·k₂−1)·c)·((k₂+1)·b − (k₁·k₂−1)·d) ≥ 0` (`simOrd_long_iff`).
+This is the order-side shadow of the Stern–Brocot product `k₁·k₂ − 1`: the
+combined "depth" of the two steps, not either one alone, controls whether the
+endpoints of a length-4 run stay similarly ordered.  The headline `simOrd_quad`
+assembles the run criterion as the conjunction of the two §11 windows and this
+new long-range window.
+-/
+
+/-- **Long-range criterion for a length-4 run.**  Iterating the successor
+recurrence twice (`e + a = k₁·c`, `f + b = k₁·d`, then `g + c = k₂·e`,
+`h + d = k₂·f`) expresses the fourth term as `g = (k₁·k₂−1)·c − k₂·a`,
+`h = (k₁·k₂−1)·d − k₂·b`, so the *endpoints* `a/b, g/h` are similarly ordered
+**iff** `((k₂+1)·a − (k₁·k₂−1)·c)·((k₂+1)·b − (k₁·k₂−1)·d) ≥ 0`.  The controlling
+quantity is the Stern–Brocot product `k₁·k₂ − 1`, the combined depth of the two
+steps. -/
+theorem simOrd_long_iff {a b c d e f g h k₁ k₂ : ℕ}
+    (he : e + a = k₁ * c) (hf : f + b = k₁ * d)
+    (hg : g + c = k₂ * e) (hh : h + d = k₂ * f) :
+    SimOrd a b g h ↔
+      (((k₂ : ℤ) + 1) * a - ((k₁ : ℤ) * k₂ - 1) * c)
+        * (((k₂ : ℤ) + 1) * b - ((k₁ : ℤ) * k₂ - 1) * d) ≥ 0 := by
+  have He : (e : ℤ) = k₁ * c - a := by
+    have : (e : ℤ) + a = k₁ * c := by exact_mod_cast he
+    linarith
+  have Hf : (f : ℤ) = k₁ * d - b := by
+    have : (f : ℤ) + b = k₁ * d := by exact_mod_cast hf
+    linarith
+  have Hg : (g : ℤ) = k₂ * e - c := by
+    have : (g : ℤ) + c = k₂ * e := by exact_mod_cast hg
+    linarith
+  have Hh : (h : ℤ) = k₂ * f - d := by
+    have : (h : ℤ) + d = k₂ * f := by exact_mod_cast hh
+    linarith
+  have key : ((a : ℤ) - g) * ((b : ℤ) - h)
+      = (((k₂ : ℤ) + 1) * a - ((k₁ : ℤ) * k₂ - 1) * c)
+          * (((k₂ : ℤ) + 1) * b - ((k₁ : ℤ) * k₂ - 1) * d) := by
+    rw [Hg, Hh, He, Hf]; ring
+  rw [simOrd_iff_prod, key]
+
+/-- **Length-4 run criterion (headline).**  Four consecutive Farey neighbours
+`a/b, c/d, e/f, g/h` produced by two successor steps (`e + a = k₁·c`,
+`f + b = k₁·d`, `g + c = k₂·e`, `h + d = k₂·f`) form a pairwise similarly ordered
+run **iff** all three non-adjacent windows are nonnegative: the two length-3
+windows of §11 (one per consecutive triple) and the new long-range window of
+`simOrd_long_iff`.  The three adjacent pairs are automatically free (§10), so the
+two quotients `k₁, k₂` interact *only* through these three explicit inequalities —
+and the long-range one is controlled by the combined depth `k₁·k₂ − 1`, the first
+place a run can break for reasons invisible to either single step. -/
+theorem simOrd_quad {a b c d e f g h k₁ k₂ : ℕ}
+    (hb : 0 < b) (hd : 0 < d) (hf_pos : 0 < f) (hh_pos : 0 < h)
+    (hcd : Unimodular a b c d)
+    (he : e + a = k₁ * c) (hfb : f + b = k₁ * d)
+    (hg : g + c = k₂ * e) (hhd : h + d = k₂ * f) :
+    (SimOrd a b c d ∧ SimOrd c d e f ∧ SimOrd e f g h
+        ∧ SimOrd a b e f ∧ SimOrd c d g h ∧ SimOrd a b g h)
+      ↔ ((2 * (a : ℤ) - k₁ * c) * (2 * (b : ℤ) - k₁ * d) ≥ 0
+          ∧ (2 * (c : ℤ) - k₂ * e) * (2 * (d : ℤ) - k₂ * f) ≥ 0
+          ∧ (((k₂ : ℤ) + 1) * a - ((k₁ : ℤ) * k₂ - 1) * c)
+              * (((k₂ : ℤ) + 1) * b - ((k₁ : ℤ) * k₂ - 1) * d) ≥ 0) := by
+  have hcdef : Unimodular c d e f := farey_succ_unimodular hcd he hfb
+  have hefgh : Unimodular e f g h := farey_succ_unimodular hcdef hg hhd
+  have s1 : SimOrd a b c d := unimodular_simOrd hb hd hcd
+  have s2 : SimOrd c d e f := unimodular_simOrd hd hf_pos hcdef
+  have s3 : SimOrd e f g h := unimodular_simOrd hf_pos hh_pos hefgh
+  constructor
+  · rintro ⟨_, _, _, h4, h5, h6⟩
+    exact ⟨(simOrd_outer_iff he hfb).mp h4,
+           (simOrd_outer_iff hg hhd).mp h5,
+           (simOrd_long_iff he hfb hg hhd).mp h6⟩
+  · rintro ⟨c1, c2, c3⟩
+    exact ⟨s1, s2, s3,
+           (simOrd_outer_iff he hfb).mpr c1,
+           (simOrd_outer_iff hg hhd).mpr c2,
+           (simOrd_long_iff he hfb hg hhd).mpr c3⟩
+
 end Erdos1005OQ02

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -5,12 +5,12 @@
   "title": "Mediant Insertion and the Farey Gap Calculus: The Mediant Is the Unique Smallest-Denominator Fraction in a Gap",
   "description": "A self-contained, axiom-free formalization of the exact arithmetic of mediant insertion — the operation that refines the Farey sequence F_n into F_{n+1} by inserting, between adjacent fractions a/b < c/d, their mediant (a+c)/(b+d). Two threads are proved. First, the gap-splitting calculus: a unimodular gap of size 1/(bd) is split by its mediant into a left sub-gap 1/(b(b+d)) and a right sub-gap 1/(d(b+d)); these sum back to 1/(bd), stand in ratio d:b, and each is strictly smaller than the whole. Second, the headline minimal-denominator theorem: any fraction p/q strictly between two unimodular neighbours has denominator q ≥ b+d, and equality forces p/q = (a+c)/(b+d) exactly. Hence the mediant is the unique fraction of smallest denominator inside any Farey gap, and b+d is a hard lower bound on refining it — no construction can introduce a fraction of smaller denominator. The parent entry (Erdős #1005) records the open lower bound f(n) ≥ (1/12−o(1))n on runs of similarly ordered Farey fractions; that constant remains open and is NOT addressed here. This entry formalizes the verified mediant calculus on which such lower-bound constructions are built.",
   "leanFile": {
-    "lineCount": 921,
+    "lineCount": 1017,
     "axiomCount": 0,
     "path": "Proofs/Erdos1005ProblemOQ02.lean",
     "sorries": 0,
     "definitionCount": 2,
-    "theoremCount": 53
+    "theoremCount": 55
   },
   "meta": {
     "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot mediant theory)",
@@ -29,7 +29,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-25",
-    "lineCount": 921,
+    "lineCount": 1017,
     "originalContributions": [
       "denom_ge_of_between: the headline lower bound — if a/b < p/q < c/d and the outer pair is unimodular (bc − ad = 1), then q ≥ b + d. Proved from the identity q = b·(cq − pd) + d·(pb − aq) by reading off pb − aq ≥ 1 and cq − pd ≥ 1 from the strict orders, with no Farey enumeration. The mediant therefore has the smallest denominator of any fraction in the open gap (a/b, c/d)",
       "eq_mediant_of_denom_eq: uniqueness — a strictly-in-gap fraction p/q that attains the minimal denominator q = b + d must be the mediant itself, p = a + c. The two cross-differences pb − aq and cq − pd are each pinned to exactly 1, forcing p·b = (a+c)·b and cancelling b",
@@ -54,10 +54,12 @@
       "§10 farey_succ_simOrd + succ_controlling_nonneg: a consecutive Farey step c/d→e/f is similarly ordered for EVERY quotient k (the successor is again unimodular, and adjacent pairs are always similarly ordered), so the §9 controlling product (a+c−k·c)(b+d−k·d) is UNCONDITIONALLY ≥ 0. This corrects the §9 framing: a single Farey step never breaks a similarly ordered run; the 1/12–1/4 run-length obstruction is entirely a NON-ADJACENT phenomenon (failures occur only among pairs j₁<j₂ with j₂>j₁+1 in a window, never the adjacent j₂=j₁+1 pairs)",
       "§11 simOrd_outer_iff: the NON-adjacent (outer) pair a/b,e/f of three consecutive Farey neighbours is similarly ordered iff (2a−k·c)(2b−k·d)≥0 — the §9 adjacent product (a−(k−1)c)(b−(k−1)d) with the (k−1)·shift replaced by a doubling, which is what lets it go negative",
       "§11 simOrd_triple_iff_outer: a length-3 run a/b,c/d,e/f reduces to its outer pair — both adjacent pairs are free by §10, so the block is pairwise similarly ordered iff a/b,e/f is. First point where non-adjacency can break a run",
-      "§11 simOrd_triple (headline): three consecutive Farey neighbours form a similarly ordered run iff (2a−k·c)(2b−k·d)≥0. The break interval for the successor quotient k is (2a/c,2b/d) of width 2/(c·d) — the first explicit METRIC criterion for a run to break, directly realizing the non-adjacent obstruction §10 identified"
+      "§11 simOrd_triple (headline): three consecutive Farey neighbours form a similarly ordered run iff (2a−k·c)(2b−k·d)≥0. The break interval for the successor quotient k is (2a/c,2b/d) of width 2/(c·d) — the first explicit METRIC criterion for a run to break, directly realizing the non-adjacent obstruction §10 identified",
+      "§12 simOrd_long_iff: the LONG-RANGE obstruction of a length-4 run. Iterating the §9 successor twice (e+a=k₁·c, f+b=k₁·d, then g+c=k₂·e, h+d=k₂·f) collapses the fourth term to g=(k₁·k₂−1)·c−k₂·a, h=(k₁·k₂−1)·d−k₂·b, so the ENDPOINTS a/b,g/h are similarly ordered iff ((k₂+1)·a−(k₁·k₂−1)·c)·((k₂+1)·b−(k₁·k₂−1)·d)≥0. The controlling quantity is the Stern–Brocot product k₁·k₂−1 — the COMBINED depth of the two steps, not either single quotient",
+      "§12 simOrd_quad (headline): four consecutive Farey neighbours a/b,c/d,e/f,g/h from two successor steps (quotients k₁,k₂) form a pairwise similarly ordered run IFF all three non-adjacent windows are ≥0 — the two length-3 windows of §11 (one per consecutive triple: (2a−k₁c)(2b−k₁d)≥0 and (2c−k₂e)(2d−k₂f)≥0) AND the new long-range window ((k₂+1)a−(k₁k₂−1)c)((k₂+1)b−(k₁k₂−1)d)≥0. The three adjacent pairs are automatically free (§10), so the two quotients interact ONLY through these three explicit inequalities; the first run whose break is invisible to either single step, governed by the combined depth k₁·k₂−1. All 0-axiom (propext/Classical.choice/Quot.sound only)"
     ],
-    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for the headline theorems (denom_ge_of_between, eq_mediant_of_denom_eq, mediant_is_min_denominator). No native_decide is used (so no Lean.ofReduceBool). This entry does NOT resolve the open Erdős #1005 lower bound f(n) ≥ (1/12 − o(1))n on runs of similarly ordered Farey fractions; that constant remains open. §8 connects the calculus to the similarlyOrdered relation but explicitly does NOT supply consecutiveness in F_n, which is the open step.",
-    "theoremCount": 38,
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for the headline theorems (denom_ge_of_between, simOrd_triple, simOrd_quad, simOrd_long_iff). No native_decide is used (so no Lean.ofReduceBool). This entry does NOT resolve the open Erdős #1005 lower bound f(n) ≥ (1/12 − o(1))n on runs of similarly ordered Farey fractions; that constant remains open. The §8–§12 ordering theory builds explicit metric break-criteria (length-3 window of width 2/(c·d); length-4 long-range window in the combined depth k₁·k₂−1) but does NOT yet aggregate them into a bound on the run-length constant, which is the open step.",
+    "theoremCount": 40,
     "definitionCount": 2
   },
   "overview": {
@@ -152,6 +154,13 @@
       "startLine": 640,
       "endLine": 745,
       "summary": "Replaces §8's NON-consecutive mediant chains with the genuine Farey successor: if a/b<c/d are consecutive in F_n, the next fraction e/f is e=k·c−a, f=k·d−b with k=⌊(n+b)/d⌋ (Hardy–Wright Thm 28–30), carried in addition form e+a=k·c, f+b=k·d to avoid ℕ subtraction. farey_succ_unimodular: the recurrence preserves unimodularity, so c/d,e/f are again consecutive (iterating walks along genuinely adjacent fractions). farey_succ_lt: c·f<d·e (successor lies to the right). farey_three_term: the symmetric law d·(a+e)=c·(b+f) — the middle term is the exact k-section, the Farey form of bₖ₋₁+bₖ₊₁=k·bₖ. farey_succ_denom_le_iff: order-n cap f≤n ↔ k·d≤n+b, selecting k=⌊(n+b)/d⌋ as the largest admissible step. Headline simOrd_succ_controlling: a CONSECUTIVE step c/d→e/f is similarly ordered IFF (a+c−k·c)·(b+d−k·d)≥0 — the controlling quantity is now an explicit arithmetic condition on the successive quotient k. Corollary simOrd_succ_k_eq_one: the k=1 step is ALWAYS similarly ordered (product collapses to a·b≥0), so runs can only break at quotients k≥2 — isolating exactly where the 1/12–1/4 optimization lives. All 0-axiom (propext/Classical.choice/Quot.sound only)."
+    },
+    {
+      "id": "length-4-two-quotient-runs",
+      "title": "§12 Length-4 runs — two quotients and the long-range obstruction",
+      "startLine": 922,
+      "endLine": 1017,
+      "summary": "The first run driven by TWO successor quotients. A length-4 block a/b,c/d,e/f,g/h applies the §9 recurrence twice: e=k₁·c−a, f=k₁·d−b then g=k₂·e−c, h=k₂·f−d. Of its six pairs the three adjacent ones are free (§10); the three non-adjacent obstructions are the two §11 length-3 windows (one per consecutive triple) PLUS a genuinely new long-range pair a/b,g/h spanning the whole block. simOrd_long_iff: substituting the recurrences collapses the fourth term to g=(k₁·k₂−1)·c−k₂·a, h=(k₁·k₂−1)·d−k₂·b, so a/b,g/h is similarly ordered iff ((k₂+1)a−(k₁k₂−1)c)((k₂+1)b−(k₁k₂−1)d)≥0 — controlled by the Stern–Brocot product k₁·k₂−1, the combined depth of the two steps. simOrd_quad (headline): the length-4 run is pairwise similarly ordered iff all three windows are ≥0, so the two quotients interact only through these explicit inequalities and the first non-single-step break is governed by k₁·k₂−1. All 0-axiom (propext/Classical.choice/Quot.sound only)."
     }
   ],
   "crossReferences": [

--- a/src/data/research/problems/erdos-1005-oq-02.json
+++ b/src/data/research/problems/erdos-1005-oq-02.json
@@ -40,7 +40,9 @@
       "succ_controlling_nonneg (§10): the §9 controlling product (a+c−kc)(b+d−kd) is unconditionally ≥0",
       "simOrd_outer_iff (§11): non-adjacent outer pair similarly ordered iff (2a−kc)(2b−kd)≥0",
       "simOrd_triple_iff_outer (§11): length-3 run reduces to outer pair (adjacent pairs free by §10)",
-      "simOrd_triple (§11): length-3 run similarly ordered iff (2a−kc)(2b−kd)≥0; break interval (2a/c,2b/d) width 2/(cd)"
+      "simOrd_triple (§11): length-3 run similarly ordered iff (2a−kc)(2b−kd)≥0; break interval (2a/c,2b/d) width 2/(cd)",
+      "simOrd_long_iff: SimOrd a b g h ↔ ((k₂+1)a−(k₁k₂−1)c)((k₂+1)b−(k₁k₂−1)d) ≥ 0, the long-range criterion for the endpoints of a two-step (length-4) Farey run. [verified, 0-axiom]",
+      "simOrd_quad: length-4 run a/b,c/d,e/f,g/h pairwise similarly ordered ↔ conjunction of the two §11 length-3 windows and the simOrd_long_iff long-range window. [verified, 0-axiom]"
     ],
     "insights": [
       "CORRECTION: the roadmap heuristic that the order-n cap forces O(log n) refinement depth is FALSE for arbitrary mediant chains. The one-sided chain 0/1,1/2,1/3,…,1/n fits Θ(n) levels under q≤n with only LINEAR denominator growth (k+1)·b+d.",
@@ -48,12 +50,14 @@
       "Literature pin (van Doorn 2025, arXiv:2509.00121): f(n) ≥ (1/12−o(1))n and f(n) ≤ n/4+5; constant c∈[1/12,1/4] open.",
       "CORRECTION to §9 framing: a single Farey step NEVER breaks a similarly ordered run (any quotient k). Reason: c/d,e/f are again unimodular (farey_succ_unimodular) and adjacent unimodular pairs are always similarly ordered. The per-step controlling product is therefore always ≥0.",
       "Structural reframing: since adjacency alone never breaks similar ordering, the f(n) ≤ n/4 upper bound is purely a NON-ADJACENT effect — isSimOrdered demands similar ordering for every pair j₁<j₂ in a window, and only the j₂>j₁+1 pairs can fail. The open 1/12–1/4 gap lives in controlling long-range (non-adjacent) similar ordering, not per-step quotients.",
-      "The first non-adjacent break is METRIC: a length-3 Farey run breaks iff the successor quotient k falls in (2a/c,2b/d), an interval of width 2(bc−ad)/(cd)=2/(cd). Small cd (large gaps) ⇒ wider break window. This is the bridge from the per-step quotient to the run-length obstruction behind 1/12–1/4."
+      "The first non-adjacent break is METRIC: a length-3 Farey run breaks iff the successor quotient k falls in (2a/c,2b/d), an interval of width 2(bc−ad)/(cd)=2/(cd). Small cd (large gaps) ⇒ wider break window. This is the bridge from the per-step quotient to the run-length obstruction behind 1/12–1/4.",
+      "§12: a length-4 Farey run (two quotients k₁,k₂) breaks ONLY through three explicit non-adjacent windows — the two §11 length-3 windows plus a NEW long-range endpoint window. The three adjacent pairs are always free (§10).",
+      "§12: the long-range endpoint pair a/b,g/h of a length-4 run is controlled by the Stern–Brocot PRODUCT k₁·k₂−1 (combined depth of both steps), not by either quotient alone — the first break invisible to any single Farey step. Closed form g=(k₁k₂−1)c−k₂a, h=(k₁k₂−1)d−k₂b."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Extend to length-4: with two successive quotients k₁,k₂, characterize which of the 3 non-adjacent pairs (skip-1 ×2, skip-2 ×1) can break, in terms of (k₁,k₂).",
-      "Aggregate the width-2/(cd) break windows along a Stern–Brocot path to bound expected run length — the quantitative route toward the 1/12 constant."
+      "Generalize simOrd_quad to length-(m+1) runs: prove the run is similarly ordered iff ALL C(m,2)−m non-adjacent windows are ≥0 (adjacent ones free by §10), with the skip-j window controlled by a Stern–Brocot continuant in the quotients k₁,…,k_{m−1}.",
+      "Aggregate the explicit break windows (length-3 width 2/(cd); length-4 long-range product k₁k₂−1) along a Stern–Brocot path to bound expected run length — the quantitative route toward the open 1/12 constant."
     ]
   },
   "tags": [


### PR DESCRIPTION
## §12 — Length-4 runs, two quotients, and the long-range obstruction

Builds on §10 (every adjacent Farey pair is similarly ordered) and §11 (length-3 single-quotient criterion). This is the first run driven by **two** successor quotients.

### Result
A length-4 Farey run `a/b, c/d, e/f, g/h`, produced by two §9 successor steps
`e=k₁·c−a, f=k₁·d−b` then `g=k₂·e−c, h=k₂·f−d`, is **pairwise similarly ordered iff** its three non-adjacent windows are all ≥ 0:

1. `(2a − k₁c)(2b − k₁d) ≥ 0` — first length-3 window (§11)
2. `(2c − k₂e)(2d − k₂f) ≥ 0` — second length-3 window (§11)
3. `((k₂+1)a − (k₁k₂−1)c)·((k₂+1)b − (k₁k₂−1)d) ≥ 0` — **new long-range endpoint window**

The three adjacent pairs are automatically free (§10), so the two quotients interact *only* through these three explicit inequalities.

### What's new
Substituting both recurrences collapses the fourth term to the closed form
`g = (k₁k₂−1)c − k₂a`, `h = (k₁k₂−1)d − k₂b`. The endpoint pair `a/b, g/h` is therefore controlled by the **Stern–Brocot product `k₁·k₂ − 1`** — the *combined depth* of the two steps, not either quotient alone. This is the first place a run can break for a reason invisible to any single Farey step.

### Theorems (both verified, 0-axiom)
- `simOrd_long_iff` — the long-range endpoint criterion
- `simOrd_quad` (headline) — the full length-4 run criterion as the conjunction of the three windows

### Verification
- Compiled clean via `lake env lean` (Lean v4.26.0, prebuilt Mathlib oleans; docker-build infeasible — host docker down / disk constrained).
- `#print axioms simOrd_quad` / `simOrd_long_iff` → `[propext, Classical.choice, Quot.sound]` only. No `sorry`, no `axiom`, no `native_decide`.

### Scope
This is verified structural infrastructure. It does **not** resolve the open Erdős #1005 `1/12` lower-bound constant — that remains open. Next step: generalize to length-(m+1) runs (skip-j windows as Stern–Brocot continuants) and aggregate the windows along a Stern–Brocot path toward the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)