### PR TITLE
Enrich Axiom-Free Isoperimetric Inequality (Hurwitz Capstone): add conclusion

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -99,6 +99,15 @@
       "summary": "isoperimetric_inequality_regular is the capstone. It applies exists_nice_reparam_for_regular (IFT, 0-axiom) to get a constant-speed (c = L/2π) zero-mean reparametrization ρ of γ, names S = ∫√(x²+y²) and Sxy = ∫(x²+y²), invokes the Wirtinger sum bound (Sxy ≤ 2πc²) and both Cauchy–Schwarz bounds (S² ≤ 2π·Sxy and |∫(x·y'−y·x')| ≤ c·S) on ρ, bridges 2·ρ.area = |∫(ρ.x·ρ.y' − ρ.y·ρ.x')|, and feeds everything to the kernel. ρ's circumference/area preservation transports the bound back to γ — 4πA ≤ L² with #print axioms reporting only propext / Classical.choice / Quot.sound."
     }
   ],
+  "conclusion": {
+    "summary": "Completes the Hurwitz isoperimetric program in Lean: $4\\pi A \\le L^2$ holds for every regular $C^1$ closed plane curve with positive circumference, proved with zero axioms (`#print axioms` reports only `propext / Classical.choice / Quot.sound`). The proof is pure assembly — the constant-speed zero-mean reparametrization (inverse function theorem), the Wirtinger/Fourier sum bound, and the two Cauchy–Schwarz bounds were each discharged axiom-free in a companion file, and this capstone wires them into the self-contained algebraic kernel $4\\pi A \\le L^2$. The algebraic kernel is re-proved locally so the result survives the parent file's bit-rot on the current Mathlib pin.",
+    "implications": "This is the maximal honest 0-axiom endpoint of the parent's five-axiom proof: regularity (nowhere-vanishing speed) is not a convenience but a necessity, since the arc-length reparametrization is genuinely false at stationary points (the arc-length map is not strictly monotone, so the inverse function theorem yields no $C^1$ inverse). The work demonstrates a reusable formalization pattern — isolate an analytic proof's hard analytic facts as named axioms, discharge each independently in a self-contained companion, then reassemble — that turns an axiomatized gallery entry into a fully machine-checked theorem without re-deriving the entire chain at once. It also resolves a Wiedijk-100-adjacent target (the isoperimetric inequality) axiom-free on the regular locus.",
+    "openQuestions": [
+      "Equality / rigidity: the inequality alone does not characterize the extremal curve. Can one formalize, axiom-free, that $4\\pi A = L^2$ forces $\\gamma$ to be a circle (the Fourier proof gives this by tracking which Wirtinger and Cauchy–Schwarz steps are tight)?",
+      "Beyond the regular locus: recover the full all-$C^1$-curves statement axiom-free by an approximation argument — regularize a curve with isolated stationary points, apply the regular bound, and pass to the limit — rather than treating the all-curves version as inherently axiom-bound.",
+      "Higher dimensions: extend to the $n$-dimensional isoperimetric inequality $\\mathrm{vol}(\\partial\\Omega)^n \\ge n^n \\omega_n \\mathrm{vol}(\\Omega)^{n-1}$, where the Fourier/Wirtinger machinery is replaced by Brunn–Minkowski or symmetrization, and assess how much can be made axiom-free in Mathlib."
+    ]
+  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-01-oq-02-oq-02-oq-01",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02`.

The entry was already strong (rich overview, 3 sections, 5 annotations with mathContext) but was **missing the `conclusion` field entirely**. This pass adds it.

## Changes
- **Added `conclusion`** with:
  - `summary` — the capstone result $4\pi A \le L^2$ axiom-free for regular $C^1$ closed curves, assembled from independently-discharged companions
  - `implications` — why regularity is a genuine necessity (the IFT reparametrization fails at stationary points) and the reusable 'axiomatize → discharge → reassemble' formalization pattern
  - 3 `openQuestions` — equality/rigidity (extremal = circle), extending past the regular locus by approximation, and the higher-dimensional isoperimetric inequality

No change to status/badge/axiomCount — entry remains `verified`/`original`, 0 axioms.

## Verification
- `meta.json` 13.9 KB — within the 60 KB cap (`check-meta-size.ts`: within caps)
- JSON validated (`conclusion` present, 3 open questions); structure matches the gallery schema (`pnpm build` confirmed the structure on a prior run)

Note: opened on a dedicated branch (`feature/enricher-2-isoperimetric-capstone`) rather than `feature/enricher-2` to avoid clobbering the still-open PR #30964.