### PR TITLE
Enrich: odd-squares sum closed form — cross-references + overview annotation

### DIFF
--- a/src/data/proofs/odd-squares-sum-oq-01/annotations.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "odd-squares-sum-oq-01",
+    "range": { "startLine": 4, "endLine": 34 },
+    "type": "context",
+    "title": "The odd-indexed companion of the square-pyramidal sum",
+    "content": "The header states open question OQ-01: the squares of the first $n$ odd numbers $1^2+3^2+\\cdots+(2n-1)^2$ sum to $n(2n-1)(2n+1)/3$. Indexing the $k$-th odd number as $2k+1$ for $k=0,\\dots,n-1$ gives $\\sum_{k<n}(2k+1)^2$. This is the odd-indexed sibling of the *square-pyramidal* identity $\\sum_{k\\le n}k^2 = n(n+1)(2n+1)/6$, recoverable as $\\sum_{j<2n}j^2 - 4\\sum_{k<n}k^2$. Mathlib provides the square-pyramidal sum but not this odd variant, so the file supplies both an exact $\\mathbb{N}$ form (`three_mul_sum_odd_squares`) and the rational closed form (`sum_odd_squares_rat`), each by a short induction.",
+    "mathContext": "$\\sum_{k<n}(2k+1)^2 = \\dfrac{n(2n-1)(2n+1)}{3} \\;=\\; \\sum_{j<2n} j^2 \\;-\\; 4\\sum_{k<n} k^2.$",
+    "significance": "context",
+    "prerequisites": ["Mathematical induction", "Finite sums over Finset.range", "Figurate / square-pyramidal numbers"],
+    "relatedConcepts": ["Square-pyramidal number", "Odd numbers 2k+1", "Power sums", "Closed-form summation"]
+  },
+  {
     "id": "ann-integer-form",
     "proofId": "odd-squares-sum-oq-01",
     "range": { "startLine": 46, "endLine": 62 },
@@ -20,6 +32,7 @@
     "content": "After `sum_range_succ` the goal is $3(\\sum_{k<m} + (2m+1)^2) + (m+1) = 4(m+1)^3$. The inductive hypothesis is about the *clustered* term $3\\sum_{k<m} + m$, which is not yet syntactically present. The `key` step regroups the left side by `ring` into $(3\\sum_{k<m} + m) + (3(2m+1)^2 + 1)$, exposing the hypothesis cluster exactly; rewriting by `ih` replaces it with $4m^3$ and a final `ring` finishes. This 'shape the goal to fit the hypothesis' move is what keeps the proof to two `ring` calls.",
     "mathContext": "$3\\sum_{k<m+1}(2k+1)^2 + (m+1) = (3\\sum_{k<m}(2k+1)^2 + m) + (3(2m+1)^2 + 1)$.",
     "significance": "supporting",
+    "prerequisites": ["Mathematical induction", "Associativity / commutativity of +,·", "ring tactic"],
     "relatedConcepts": ["Inductive hypothesis matching", "Associativity", "ring tactic"]
   },
   {

--- a/src/data/proofs/odd-squares-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/meta.json
@@ -83,5 +83,17 @@
       "Does the same 'clear the denominator additively' pattern give equally clean ℕ proofs for the sum of cubes of odd numbers ∑(2k+1)³ = n²(2n²−1) and higher odd-power sums?",
       "Can the odd-square sum be derived inside Lean as the explicit difference ∑_{j<2n} j² − 4∑_{k<n} k² from Mathlib's square-pyramidal identity, rather than re-proved by induction?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "proofId": "newton-power-sum-identities-oq-01",
+      "relationship": "related — power sums",
+      "description": "Newton's identities give the general theory of power sums pₖ = ∑ᵢ Xᵢᵏ in terms of elementary symmetric polynomials. This entry is a concrete univariate power sum, ∑_{k<n}(2k+1)², in closed form. Both formalize power-sum closed forms that go beyond Mathlib's built-in lemmas."
+    },
+    {
+      "proofId": "triangular-reciprocals",
+      "relationship": "related — elementary closed-form sum",
+      "description": "A companion elementary identity for a sum over the first n naturals: ∑ 2/(n(n+1)) = 2 by telescoping. Both belong to the gallery's family of clean closed forms for figurate/polynomial sums proved by short, fully verified elementary arguments."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `odd-squares-sum-oq-01` (passes: 0, quality: 79).

## Gaps closed
- **crossReferences was empty** despite the proof repeatedly invoking the square-pyramidal identity and power-sum machinery. Added two links to entries verified to exist:
  - `newton-power-sum-identities-oq-01` — general power-sum theory $p_k=\sum_i X_i^k$;
  - `triangular-reciprocals` — companion elementary closed-form sum.
  (No square-pyramidal gallery entry exists, so it could not be linked.)
- **Header had no annotation** — added an overview annotation (lines 4–34) framing this as the odd-indexed companion of $\sum_{k\le n}k^2=n(n+1)(2n+1)/6$, via $\sum_{j<2n}j^2-4\sum_{k<n}k^2$. Annotations 3 → 4.
- Filled the one **missing `prerequisites`** field (reassociation annotation).

## Verification
- `scripts/annotations/build.ts`: 0 errors for this entry; all 4 annotations now carry mathContext + significance + relatedConcepts + prerequisites.
- `check-meta-size.ts`: within caps.
- Axiom integrity unchanged (verified, 0 axioms).