### PR TITLE
research(sperner-mathlib4-oq-02): incidence-level generalized handshake — boundary doors force an odd-door cell [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4017,6 +4017,7 @@ import Proofs.SpernerSimplicialInstanceOQ05Scarf1d
 import Proofs.SpernerTuckerBorsukUlamOneDim
 import Proofs.SpernerTuckerBoundaryParity
 import Proofs.SpernerTuckerDoorGraph
+import Proofs.SpernerTuckerDoorIncidenceParity
 import Proofs.SpernerTuckerOneDim
 import Proofs.SpernerTuckerPathFollowing
 import Proofs.SphericalExcessGirard

--- a/proofs/Proofs/SpernerTuckerDoorIncidenceParity.lean
+++ b/proofs/Proofs/SpernerTuckerDoorIncidenceParity.lean
@@ -1,0 +1,217 @@
+/-
+# The generalized handshake bridge: boundary doors force an odd-door cell (n ≥ 2 Tucker)
+
+Research artifact for `sperner-mathlib4-oq-02` ("Tucker's Lemma and Borsuk–Ulam
+from abstract door-counting").
+
+## Where this sits
+
+The door-counting program for Sperner/Tucker/Scarf is driven by a single parity
+principle.  The companion files isolate its *graph* form:
+
+* `SpernerDoorCountingParity.lean` / `SpernerTuckerPathFollowing.lean` — the
+  handshaking lemma `even_card_odd_degree_vertices`: in any finite simple graph the
+  number of odd-degree vertices is even, specialised to degree-≤2 "path/cycle" door
+  graphs where door-terminals are the degree-1 path endpoints.
+* `SpernerTuckerInteriorParity.lean` — given an **odd** number of *boundary*
+  endpoints, the **interior** endpoints (the complementary simplices) are odd too.
+
+All of those start from a `SimpleGraph`, i.e. they presuppose every "door" joins
+**exactly two** cells.  The geometric door structure of Tucker is *not* like that:
+a complementary facet on the **boundary** of the region belongs to **one** cell,
+while an interior facet belongs to **two**.  `SpernerTuckerBoundaryParity.lean`
+records the consequence of ignoring this — the raw boundary ring's complementary
+count is *always even*, so the odd parity the engine needs cannot come from a plain
+graph handshake; it must come from the **boundary doors** themselves.
+
+## What this file proves (the missing bridge)
+
+This file states and verifies the door-counting principle **at the incidence
+level**, before any graph is built, where doors are allowed to touch one *or* two
+cells.  Model an abstract **door complex** as a bipartite incidence
+`inc : Cell → Door → Bool`.  Write
+
+* `doorCount c` = number of doors incident to cell `c`,
+* `cellCount d` = number of cells incident to door `d`.
+
+Double counting the incident pairs two ways gives `∑ doorCount = ∑ cellCount`, and
+reducing mod 2 yields the **incidence-duality parity law**
+
+  `#{cells with odd door-count}  ≡  #{doors with odd cell-count}   (mod 2)`,
+
+with *no hypotheses whatsoever* (`incidence_parity_duality`).  This is the genuine
+generalisation of the handshaking lemma: when every door touches exactly two cells
+the right-hand side is empty and one recovers "the number of odd-degree vertices is
+even".
+
+Specialising to the geometric regime — every door touches **at most two** cells —
+an odd cell-count means *exactly one* cell, i.e. a **boundary door**.  So
+
+  `#{cells with odd door-count}  ≡  #{boundary doors}   (mod 2)`
+
+(`card_odd_doorCount_modEq_card_boundaryDoor`), and therefore an **odd** number of
+boundary doors forces a cell with an **odd** number of doors
+(`exists_odd_doorCount_of_odd_boundary`).  In the Freund–Todd / Prescott–Su
+instantiation the boundary doors are the antipodally-paired boundary facets (whose
+odd count is the inductive `(n−1)`-Tucker input) and the odd-door cells are exactly
+the degree-1 path endpoints fed to `SpernerTuckerPathFollowing`.  This file is the
+clean combinatorial converter between the two — the step the graph-level files
+assumed rather than proved.
+
+Self-contained over arbitrary finite `Cell`, `Door`.  0 sorries, 0 axioms.
+-/
+import Mathlib
+
+namespace SpernerTuckerDoorIncidenceParity
+
+open Finset
+
+variable {Cell Door : Type*} [Fintype Cell] [Fintype Door]
+variable (inc : Cell → Door → Bool)
+
+/-- Number of doors incident to a cell. -/
+def doorCount (c : Cell) : ℕ := (univ.filter (fun d => inc c d)).card
+
+/-- Number of cells incident to a door. -/
+def cellCount (d : Door) : ℕ := (univ.filter (fun c => inc c d)).card
+
+/-- A **boundary door** of the complex is one incident to exactly one cell;
+geometrically a facet on the boundary of the region. -/
+def IsBoundaryDoor (d : Door) : Prop := cellCount inc d = 1
+
+instance : DecidablePred (IsBoundaryDoor inc) := fun d => by
+  unfold IsBoundaryDoor; infer_instance
+
+/-! ## A reusable parity helper
+
+For any `ℕ`-valued statistic on a finite type, the sum is congruent mod 2 to the
+number of indices on which the statistic is odd. -/
+
+/-- `(∑ i, a i)` and `#{i | Odd (a i)}` have the same parity. -/
+theorem card_odd_mod_two {ι : Type*} [Fintype ι] (a : ι → ℕ) :
+    (univ.filter (fun i => Odd (a i))).card % 2 = (∑ i, a i) % 2 := by
+  rw [Finset.sum_nat_mod, Finset.card_filter]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro i _
+  rcases Nat.even_or_odd (a i) with h | h
+  · rw [if_neg (by simpa [Nat.not_odd_iff_even] using h), Nat.even_iff.mp h]
+  · rw [if_pos h, Nat.odd_iff.mp h]
+
+/-! ## Double counting the incident pairs -/
+
+/-- **Double counting.** Summing the door-counts over cells and the cell-counts over
+doors count the same set of incident `(cell, door)` pairs, hence are equal. -/
+theorem sum_doorCount_eq_sum_cellCount :
+    (∑ c, doorCount inc c) = ∑ d, cellCount inc d := by
+  unfold doorCount cellCount
+  simp only [Finset.card_filter]
+  rw [Finset.sum_comm]
+
+/-! ## The incidence-duality parity law (no hypotheses) -/
+
+/-- **Generalized handshaking lemma / incidence-duality parity law.**  For an
+arbitrary bipartite incidence `inc : Cell → Door → Bool`, the number of cells whose
+door-count is odd is congruent mod 2 to the number of doors whose cell-count is odd.
+
+When every door is incident to exactly two cells (a graph), the right-hand side is
+empty and this is exactly `SimpleGraph.even_card_odd_degree_vertices`. -/
+theorem incidence_parity_duality :
+    (univ.filter (fun c => Odd (doorCount inc c))).card % 2
+      = (univ.filter (fun d => Odd (cellCount inc d))).card % 2 := by
+  rw [card_odd_mod_two, card_odd_mod_two, sum_doorCount_eq_sum_cellCount]
+
+/-! ## Geometric specialization: doors touch at most two cells -/
+
+omit [Fintype Door] in
+/-- When a door touches at most two cells, "odd cell-count" means *exactly one*
+cell, i.e. the door is a boundary door. -/
+theorem odd_cellCount_iff_boundary {d : Door} (h : cellCount inc d ≤ 2) :
+    Odd (cellCount inc d) ↔ IsBoundaryDoor inc d := by
+  unfold IsBoundaryDoor
+  rw [Nat.odd_iff]
+  omega
+
+/-- **The boundary-door parity bridge.**  In a door complex where every door is
+incident to at most two cells, the number of cells with an odd door-count is
+congruent mod 2 to the number of boundary doors.
+
+This converts the antipodal boundary condition (an *odd* number of boundary doors,
+supplied by the inductive `(n−1)`-Tucker statement) into an *odd* number of cells
+that are path endpoints, the input to the path-following engine. -/
+theorem card_odd_doorCount_modEq_card_boundaryDoor
+    (h2 : ∀ d, cellCount inc d ≤ 2) :
+    (univ.filter (fun c => Odd (doorCount inc c))).card % 2
+      = (univ.filter (IsBoundaryDoor inc)).card % 2 := by
+  rw [incidence_parity_duality]
+  have hfilt : (univ.filter (fun d => Odd (cellCount inc d)))
+      = univ.filter (IsBoundaryDoor inc) :=
+    Finset.filter_congr (fun d _ => odd_cellCount_iff_boundary inc (h2 d))
+  rw [hfilt]
+
+/-- **Odd boundary doors force an odd-door cell.**  If a door complex with doors of
+incidence ≤ 2 has an *odd* number of boundary doors, then some cell has an *odd*
+number of doors.  Geometrically: the antipodal boundary condition forces a
+path-endpoint cell — the seed from which path-following reaches a complementary
+simplex. -/
+theorem exists_odd_doorCount_of_odd_boundary
+    (h2 : ∀ d, cellCount inc d ≤ 2)
+    (hbdry : Odd (univ.filter (IsBoundaryDoor inc)).card) :
+    ∃ c, Odd (doorCount inc c) := by
+  have hmod := card_odd_doorCount_modEq_card_boundaryDoor inc h2
+  rw [Nat.odd_iff] at hbdry
+  rw [hbdry] at hmod
+  have hpos : 0 < (univ.filter (fun c => Odd (doorCount inc c))).card := by
+    rcases Nat.eq_zero_or_pos (univ.filter (fun c => Odd (doorCount inc c))).card with h0 | hp
+    · rw [h0] at hmod; simp at hmod
+    · exact hp
+  obtain ⟨c, hc⟩ := Finset.card_pos.mp hpos
+  rw [Finset.mem_filter] at hc
+  exact ⟨c, hc.2⟩
+
+/-! ## Parity-refined form
+
+For direct use alongside `SpernerTuckerInteriorParity`, the boundary-door count and
+the odd-door-cell count have the *same* parity. -/
+
+/-- The number of boundary doors and the number of odd-door cells have the same
+parity. -/
+theorem odd_boundary_iff_odd_doorCount_cell
+    (h2 : ∀ d, cellCount inc d ≤ 2) :
+    Odd (univ.filter (IsBoundaryDoor inc)).card
+      ↔ Odd (univ.filter (fun c => Odd (doorCount inc c))).card := by
+  have hmod := card_odd_doorCount_modEq_card_boundaryDoor inc h2
+  rw [Nat.odd_iff, Nat.odd_iff, hmod]
+
+/-! ## Sanity check: the pure-graph case recovers the handshaking lemma
+
+If every door is incident to *exactly* two cells there are no boundary doors, so the
+duality law degenerates to "the number of odd-door-count cells is even". -/
+
+/-- With every door incident to exactly two cells, the number of cells of odd
+door-count is even — the handshaking lemma recovered from the incidence law. -/
+theorem even_card_odd_doorCount_of_all_interior
+    (h2 : ∀ d, cellCount inc d = 2) :
+    Even (univ.filter (fun c => Odd (doorCount inc c))).card := by
+  have hbdry : (univ.filter (IsBoundaryDoor inc)).card = 0 := by
+    rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+    intro d _
+    unfold IsBoundaryDoor
+    rw [h2 d]; decide
+  have hmod := card_odd_doorCount_modEq_card_boundaryDoor inc (fun d => by rw [h2 d])
+  rw [hbdry] at hmod
+  rw [Nat.even_iff, hmod]
+
+#check @incidence_parity_duality
+#check @card_odd_doorCount_modEq_card_boundaryDoor
+#check @exists_odd_doorCount_of_odd_boundary
+#check @even_card_odd_doorCount_of_all_interior
+
+-- Axiom audit: the results depend only on the foundational axioms
+-- (propext / Classical.choice / Quot.sound); no `sorryAx`, no `Lean.ofReduceBool`.
+#print axioms incidence_parity_duality
+#print axioms card_odd_doorCount_modEq_card_boundaryDoor
+#print axioms exists_odd_doorCount_of_odd_boundary
+#print axioms even_card_odd_doorCount_of_all_interior
+
+end SpernerTuckerDoorIncidenceParity

--- a/research/problems/sperner-mathlib4-oq-02/state.md
+++ b/research/problems/sperner-mathlib4-oq-02/state.md
@@ -3,25 +3,38 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-06-27T15:30:00-07:00
-**Iteration**: 5
+**Since**: 2026-06-27T16:10:00-07:00
+**Iteration**: 6
 
 ## Current Focus
 The **n=1 line is COMPLETE end-to-end** (combinatorial + continuous 1-D
 Borsuk–Ulam, merged). Current work is the **n≥2 path-following engine**.
 
-This session (researcher-6) closes the **door-counting ⟹ max-degree-≤2 gap**:
-`proofs/Proofs/SpernerTuckerDoorGraph.lean` (227 LOC, 0 sorries, 0 axioms). The
-path-following engine (`SpernerTuckerPathFollowing.lean`) assumed
-`∀ v, G.degree v ≤ 2` as a black box; this file **derives** it from the abstract
-door-incidence structure `inc : V → D → Prop`: if each almost-complementary
-simplex has ≤2 doors and each door joins ≤2 simplices, the shared-door graph
-`doorGraph` has max degree ≤2 (`doorGraph_degree_le_two`, proved by a counting
-injection — the neighbours of `v` inject into the ≤2 doors of `v`). Chained to
-the quantitative Tucker conclusion `tucker_door_count` (odd boundary endpoints ⟹
-odd interior complementary simplices) and `exists_complementary_simplex`. This
-realizes the OQ title literally — the engine's degree bound comes *from*
-door-counting, not as an assumption.
+This session (researcher-12) adds the **incidence-level generalized handshake**:
+`proofs/Proofs/SpernerTuckerDoorIncidenceParity.lean` (0 sorries, 0 axioms —
+`#print axioms` = only propext/Classical.choice/Quot.sound). All prior parity
+machinery (`SpernerTuckerPathFollowing`, `SpernerDoorCountingParity`,
+`SpernerTuckerDoorGraph`) is built on a `SimpleGraph`, which structurally forces
+every "door" to join **exactly two** cells — but the geometric door structure has
+**boundary doors** that touch only **one** cell. `SpernerTuckerBoundaryParity`
+already recorded the cost of ignoring this (the raw boundary ring is always EVEN);
+the odd parity the engine needs must come from the boundary doors themselves.
+
+This file supplies that, working directly on the bipartite incidence
+`inc : Cell → Door → Bool` *before any graph is built*:
+- `incidence_parity_duality` — **with no hypotheses**, `#{cells of odd door-count}
+  ≡ #{doors of odd cell-count}  (mod 2)`, by double-counting incident pairs and
+  reducing mod 2. This is the genuine generalisation of the handshaking lemma:
+  the all-interior case (`even_card_odd_doorCount_of_all_interior`) recovers
+  "the number of odd-degree vertices is even".
+- `card_odd_doorCount_modEq_card_boundaryDoor` — when every door touches ≤2 cells,
+  odd cell-count ⇔ *boundary door*, so `#{odd-door cells} ≡ #{boundary doors}`.
+- `exists_odd_doorCount_of_odd_boundary` — an **odd** number of boundary doors
+  forces a cell of **odd** door-count (the path-endpoint seed).
+
+This complements `SpernerTuckerDoorGraph` (which builds the graph and bounds its
+degree from the same `inc`); together they pin the dimension-independent core of
+the door-counting program at both the incidence and graph levels.
 
 ## Verification note
 Docker IMAGE build is currently broken (containerd `meta.db` I/O error), but
@@ -37,9 +50,10 @@ panchromatic conclusion diverges from the complementary-edge target — Insight 
 - `exists_complementary_edge`: 1-D Tucker existence.
 
 ## Attempt Count
-- Total attempts: 2
+- Total attempts: 3
 - Current approach attempts: 1
-- Approaches tried: 2 (engine-reusability assessment → direct-parity port)
+- Approaches tried: 3 (engine-reusability assessment → direct-parity port →
+  incidence-level generalized handshake with native boundary doors)
 
 ## Blockers
 - None for n=1 (done).
@@ -47,14 +61,16 @@ panchromatic conclusion diverges from the complementary-edge target — Insight 
   almost-complementary simplices, antipodal pairing of boundary path-endpoints).
 
 ## Next Action
-The n≥2 abstract pipeline is now complete: door-incidence ⟹ degree≤2
-(`doorGraph_degree_le_two`) ⟹ handshaking ⟹ `exists_complementary_simplex`. Two
+The n≥2 abstract pipeline now has parity engines at both the **graph** level
+(`doorGraph_degree_le_two` ⟹ handshaking ⟹ `exists_complementary_simplex`) and the
+**incidence** level (`incidence_parity_duality` ⟹
+`exists_odd_doorCount_of_odd_boundary`, natively handling boundary doors). Two
 *geometric* inputs remain to instantiate it:
-- Build the concrete `inc : V → D → Prop` for a triangulation of B^n
-  (V = almost-complementary simplices, D = complementary facets/doors) and
-  discharge the two ≤2 bounds geometrically.
-- Supply `Odd #{boundary endpoints}` from the inductive (n−1)-Tucker statement —
+- Build the concrete `inc : Cell → Door → Bool` for a triangulation of B^n
+  (cells = almost-complementary simplices, doors = complementary facets) and
+  discharge the ≤2 bounds geometrically; this makes both engines fire.
+- Supply `Odd #{boundary doors}` from the inductive (n−1)-Tucker statement —
   NOT the raw boundary-ring count, which is provably EVEN
-  (`SpernerTuckerBoundaryParity`).
+  (`SpernerTuckerBoundaryParity`). The incidence engine consumes this directly.
 - n>=2 Tucker ⟹ Borsuk–Ulam: continuous mesh→0 + compactness (analytic phase;
   dim 1 was discharged by IVT).


### PR DESCRIPTION
## Summary

Adds `proofs/Proofs/SpernerTuckerDoorIncidenceParity.lean` to the `sperner-mathlib4-oq-02` program ("Tucker's Lemma and Borsuk–Ulam from abstract door-counting").

The door-counting program is driven by a parity principle. Every existing parity engine in this program — `SpernerTuckerPathFollowing`, `SpernerDoorCountingParity`, `SpernerTuckerDoorGraph` — is built on a `SimpleGraph`, which **structurally forces every "door" to join exactly two cells**. But the geometric door structure of Tucker has **boundary doors** that touch only **one** cell. `SpernerTuckerBoundaryParity` already recorded the cost of ignoring this (the raw boundary ring's complementary count is *always even*), concluding the odd parity the engine needs must come from the boundary doors themselves — but no file supplied it.

This file does, working directly on the bipartite incidence `inc : Cell → Door → Bool` **before any graph is built**:

- **`incidence_parity_duality`** — with **no hypotheses**: `#{cells of odd door-count} ≡ #{doors of odd cell-count} (mod 2)`, by double-counting incident `(cell, door)` pairs and reducing mod 2. This is the genuine generalization of the handshaking lemma — the all-interior special case (`even_card_odd_doorCount_of_all_interior`) recovers "the number of odd-degree vertices is even".
- **`card_odd_doorCount_modEq_card_boundaryDoor`** — when every door touches ≤2 cells, odd cell-count ⇔ *boundary door*, so `#{odd-door cells} ≡ #{boundary doors} (mod 2)`.
- **`exists_odd_doorCount_of_odd_boundary`** — an **odd** number of boundary doors forces a cell of **odd** door-count (the path-endpoint seed for path-following).
- **`odd_boundary_iff_odd_doorCount_cell`** — parity-refined `↔` form for use alongside `SpernerTuckerInteriorParity`.

This complements `SpernerTuckerDoorGraph` (which builds the door graph and bounds its degree from the same `inc`); together they pin the dimension-independent core of the door-counting program at **both** the incidence and graph levels. It converts the antipodal boundary condition (odd boundary doors, the inductive `(n−1)`-Tucker input) into the odd-door cell the path-following engine consumes.

## Verification

- 0 sorries, 0 `axiom` declarations.
- `#print axioms` for all four headline theorems = `{propext, Classical.choice, Quot.sound}` only — no `sorryAx`, no `Lean.ofReduceBool`. **Genuinely 0-axiom / verified.**
- Compiled via `lake env lean` against the Mathlib `.olean` cache (the docker *image* build is currently broken — containerd `meta.db` I/O error — but `docker ps` works; this is the established fallback for this repo). 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)