### PR TITLE
research(cauchy-schwarz-oq-01-oq-03-oq-02): Gibbs ⇒ max-entropy bridge — D(p‖uniform) = log n − H(p) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean
@@ -208,4 +208,43 @@ theorem klDivergence_self (p : ι → ℝ) : klDivergence p p = 0 := by
   unfold klDivergence
   exact Finset.sum_eq_zero (fun i _ => by ring)
 
+/-- **KL-to-uniform is the entropy gap.** For any probability vector `p` on `n = card ι`
+outcomes, the relative entropy to the *uniform* distribution equals the shortfall of the
+entropy from its ceiling:
+`D(p ‖ uniform) = log n − H(p)`.
+
+This is a pure algebraic identity (only `∑ pᵢ = 1` is needed): writing the uniform entry
+`1/n`, each KL summand `pᵢ (log pᵢ − log(1/n)) = pᵢ log n − negMulLog pᵢ`, and summing uses
+`∑ pᵢ = 1` on the first piece and the definition of `shannonEntropy` on the second. -/
+theorem klDivergence_uniform {p : ι → ℝ} (hsum : ∑ i, p i = 1) :
+    klDivergence p (fun _ : ι => (Fintype.card ι : ℝ)⁻¹)
+      = Real.log (Fintype.card ι) - shannonEntropy p := by
+  have hexpand : ∀ i : ι,
+      p i * (Real.log (p i) - Real.log ((Fintype.card ι : ℝ)⁻¹))
+        = p i * Real.log (Fintype.card ι) - Real.negMulLog (p i) := by
+    intro i; rw [Real.log_inv, Real.negMulLog]; ring
+  unfold klDivergence
+  rw [Finset.sum_congr rfl (fun i _ => hexpand i), Finset.sum_sub_distrib,
+    ← Finset.sum_mul, hsum, one_mul]
+  rfl
+
+/-- **Maximum-entropy bound, re-derived from Gibbs' inequality.** Applying
+`klDivergence_nonneg` with `q` the uniform distribution and rewriting through
+`klDivergence_uniform` gives `0 ≤ log n − H(p)`, i.e. `H(p) ≤ log n`.
+
+This makes precise the claim (in the `klDivergence_nonneg` docstring) that Gibbs'
+inequality is the *engine* behind the maximum-entropy bound `shannonEntropy_le_log_card`:
+the two are the same statement, viewed through `D(p ‖ uniform) = log n − H(p)`. -/
+theorem shannonEntropy_le_log_card_of_gibbs [Nonempty ι] {p : ι → ℝ}
+    (h0 : ∀ i, 0 ≤ p i) (hsum : ∑ i, p i = 1) :
+    shannonEntropy p ≤ Real.log (Fintype.card ι) := by
+  have hnR : (0 : ℝ) < (Fintype.card ι : ℝ) := by exact_mod_cast Fintype.card_pos
+  have hu0 : ∀ i : ι, (0 : ℝ) ≤ (Fintype.card ι : ℝ)⁻¹ := fun _ => by positivity
+  have husum : (∑ _i : ι, (Fintype.card ι : ℝ)⁻¹) = 1 := by
+    rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]; field_simp
+  have hac : ∀ i, 0 < p i → 0 < (Fintype.card ι : ℝ)⁻¹ := fun _ _ => by positivity
+  have hgibbs := klDivergence_nonneg h0 hu0 hsum husum hac
+  rw [klDivergence_uniform hsum] at hgibbs
+  linarith
+
 end CauchySchwarzOQ01OQ03OQ02

--- a/research/problems/cauchy-schwarz-oq-01-oq-03-oq-02/knowledge.md
+++ b/research/problems/cauchy-schwarz-oq-01-oq-03-oq-02/knowledge.md
@@ -77,3 +77,39 @@ Only after that does Deutsch/Maassen–Uffink become approachable.
 - Either: upstream/await Hausdorff–Young in Mathlib, then formalize sharp Maassen–Uffink.
 - Or: a future session builds the finite-dim `shannonEntropy` + max-entropy bound
   (provable now) as a sibling gallery entry, then attempts Deutsch's bound.
+
+## Session 2026-06-27 (Session 3, researcher-9) — Gibbs ⇒ max-entropy bridge [VERIFIED, 0-axiom]
+
+**Outcome**: BUILD. Added two theorems unifying the file's two halves (entropy ceiling
+and Gibbs positivity), making the "Gibbs is the engine" docstring claim an actual proof.
+
+### Built (added to `Proofs/CauchySchwarzOQ01OQ03OQ02.lean`, now 250L, 8 theorems)
+- `klDivergence_uniform {p} (hsum : ∑ p i = 1) : D(p ‖ uniform) = log n − H(p)`.
+  Pure algebra (no positivity needed): each KL summand
+  `pᵢ(log pᵢ − log(1/n)) = pᵢ·log n − negMulLog pᵢ` (`Real.log_inv` + `Real.negMulLog`,
+  `ring`); sum via `Finset.sum_sub_distrib`, `← Finset.sum_mul`, `hsum`, then `rfl`
+  recognizes `∑ negMulLog (p i) = shannonEntropy p`.
+- `shannonEntropy_le_log_card_of_gibbs [Nonempty ι] {p} (h0) (hsum)` : H(p) ≤ log n,
+  **re-derived from Gibbs**: instantiate `klDivergence_nonneg` with `q = uniform`
+  (hac trivial since `1/n > 0`), `rw [klDivergence_uniform hsum]`, `linarith`.
+  Independent of the Jensen-based `shannonEntropy_le_log_card` — same bound, two routes.
+
+### Verification
+`lake env lean` on the worktree file: EXIT 0, no errors. `#print axioms` on both new
+theorems = `[propext, Classical.choice, Quot.sound]` only (0 counting-axioms, no
+`sorryAx`/`Lean.ofReduceBool`). meta.json bumped theoremCount 6→8, lineCount 211→250,
+added `gibbs-bridge` section (211–249). status stays `verified`/`mathlib`/axiomCount 0.
+
+### GOTCHA (cost me several build cycles)
+Build commands MUST `cd` into the **worktree** proofs dir
+(`.loom/worktrees/researcher-9/proofs`), NOT `/Users/rwalters/GitHub/lean-genius/proofs`
+(the MAIN repo). I mistakenly built/`cp`-restored the main copy — which other agents were
+concurrently editing — so my edits appeared to "vanish" and `#print axioms` reported the
+new constants as *unknown* (it was checking a stale 211-line main file). The worktree
+`proofs/.lake` is a symlink to main's `.lake`, so oleans resolve fine from the worktree.
+Use a uniquely-named throwaway check file (`R9CSGibbsCheck.lean`) for `#print axioms`
+rather than append/restore on the real file (avoids races with concurrent agents).
+
+### Next Steps (unchanged)
+- Deutsch's interpolation-free bound `H(p)+H(q) ≥ −2 ln((1+c)/2)` on top of this infra.
+- Await Mathlib Hausdorff–Young/Riesz–Thorin for sharp Maassen–Uffink.

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json
@@ -18,9 +18,9 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 211,
+    "lineCount": 250,
     "assumptions": "Uses Mathlib's Real.negMulLog (Shannon entropy term) with its concavity (concaveOn_negMulLog), strict concavity (strictConcaveOn_negMulLog), the finite Jensen inequality (ConcaveOn.le_map_sum), and its equality case (StrictConcaveOn.eq_of_map_sum_eq); Gibbs' inequality uses the elementary log bound Real.log_le_sub_one_of_pos. No additional axioms or assumptions.",
-    "theoremCount": 6,
+    "theoremCount": 8,
     "mathlib_version": "4.26.0",
     "definitionCount": 2
   },
@@ -86,6 +86,13 @@
       "startLine": 153,
       "endLine": 210,
       "summary": "Defines the discrete Kullback–Leibler divergence D(p‖q) = ∑ᵢ pᵢ(log pᵢ − log qᵢ) and proves Gibbs' inequality D(p‖q) ≥ 0 for probability vectors with q absolutely continuous w.r.t. p, via the termwise bound pᵢ log(qᵢ/pᵢ) ≤ qᵢ − pᵢ from Real.log_le_sub_one_of_pos. Also records D(p‖p) = 0. Gibbs positivity is the engine behind the maximum-entropy bound (q uniform) and the foundational positivity statement for entropic uncertainty."
+    },
+    {
+      "id": "gibbs-bridge",
+      "title": "Gibbs ⇒ Maximum-Entropy: D(p‖uniform) = log n − H(p)",
+      "startLine": 211,
+      "endLine": 249,
+      "summary": "Proves the algebraic identity klDivergence_uniform: D(p‖uniform) = log n − H(p), the exact entropy gap to the uniform distribution (needs only ∑ pᵢ = 1). Combined with Gibbs' inequality this re-derives the maximum-entropy bound shannonEntropy_le_log_card_of_gibbs: H(p) ≤ log n, making rigorous the claim that Gibbs positivity and the entropy ceiling are two views of one inequality."
     }
   ],
   "conclusion": {
@@ -99,9 +106,9 @@
   },
   "leanFile": {
     "namespace": "CauchySchwarzOQ01OQ03OQ02",
-    "lineCount": 211,
+    "lineCount": 250,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 2,
     "path": "Proofs/CauchySchwarzOQ01OQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the **Shannon Entropy / Entropic Uncertainty** entry (`cauchy-schwarz-oq-01-oq-03-oq-02`) with two theorems that unify its two existing halves — the maximum-entropy bound and Gibbs' inequality — making rigorous the existing docstring claim that *Gibbs positivity is the engine behind the maximum-entropy bound*.

Builds on the discrete Gibbs' inequality merged in #30981.

## New theorems (`proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean`)

- **`klDivergence_uniform`** — `D(p ‖ uniform) = log n − H(p)`. The KL divergence to the uniform distribution is exactly the shortfall of the entropy from its ceiling. Pure algebraic identity (only `∑ pᵢ = 1` needed): each summand `pᵢ(log pᵢ − log(1/n)) = pᵢ·log n − negMulLog pᵢ` via `Real.log_inv`/`Real.negMulLog`, summed with `Finset.sum_sub_distrib` + `← Finset.sum_mul`.
- **`shannonEntropy_le_log_card_of_gibbs`** — `H(p) ≤ log n`, re-derived by instantiating `klDivergence_nonneg` at `q = uniform` and rewriting through `klDivergence_uniform`. An independent route to the bound already proved via Jensen (`shannonEntropy_le_log_card`): the max-entropy ceiling and Gibbs positivity are two views of one inequality.

## Verification

- `lake env lean` on the file: **EXIT 0**, no errors/sorries.
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only — **0 counting-axioms** (no `sorryAx`, no `Lean.ofReduceBool`).
- meta.json: `theoremCount` 6→8, `lineCount` 211→250, new `gibbs-bridge` section; status stays `verified` / `mathlib` / `axiomCount` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)