### PR TITLE
Enrich Chebyshev–PNT Bridge OQ-06: add annotations

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-cheb06-context",
+    "proofId": "chebyshev-pnt-bridge-oq-06",
+    "range": { "startLine": 2, "endLine": 13 },
+    "type": "context",
+    "title": "Completing the real-log Chebyshev bracket",
+    "content": "The parent `ChebyshevPNTBridge` proves the Chebyshev upper bound only in ℕ-power form, $(\\sqrt n)^{\\pi(n)-\\pi(\\sqrt n)} \\le 4^n$, leaving the real-logarithmic consequence as a header comment. The sibling OQ-05 carried the *lower* bound into $\\mathrm{Real.log}$ form. This file supplies the missing *upper* counterpart, so both Chebyshev densities are finally available in matching $\\mathrm{Real.log}$ form — closing the bracket $c_1\\,n/\\log n \\le \\pi(n) \\le c_2\\,n/\\log n$ in formalized real-analytic shape.",
+    "mathContext": "$(\\sqrt n)^{\\pi(n)-\\pi(\\sqrt n)} \\le 4^n \\ \\xrightarrow{\\ \\log\\ }\\ (\\pi(n)-\\pi(\\sqrt n))\\log\\sqrt n \\le n\\log 4$",
+    "significance": "context",
+    "relatedConcepts": ["prime counting function π(n)", "Chebyshev bounds", "prime number theorem"],
+    "prerequisites": ["analytic number theory", "logarithm monotonicity"]
+  },
+  {
+    "id": "ann-cheb06-chebyshev-1852",
+    "proofId": "chebyshev-pnt-bridge-oq-06",
+    "range": { "startLine": 15, "endLine": 36 },
+    "type": "insight",
+    "title": "Recovering Chebyshev's 1852 upper density 2 log 4",
+    "content": "Dividing the π(n) bound by $\\log(\\sqrt n) \\approx \\tfrac12\\log n$ makes the leading term $\\approx 2n\\log 4/\\log n$, hence $\\limsup_{x} \\pi(x)\\log x / x \\le 2\\log 4$. This is the upper half of Chebyshev's 1852 theorem (the first unconditional proof that $\\pi(x)$ has order $x/\\log x$, half a century before the Prime Number Theorem pinned the constant to exactly 1). The factor $\\log 4 = 2\\log 2$ traces directly to the central-binomial bound $\\binom{2n}{n} < 4^n$ underlying the parent.",
+    "mathContext": "$\\limsup_{x\\to\\infty}\\frac{\\pi(x)\\log x}{x} \\le 2\\log 4 = 4\\log 2 \\approx 2.77$",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev's theorem (1852)", "prime number theorem", "central binomial coefficient", "natural density"],
+    "prerequisites": ["asymptotic density", "Chebyshev's estimates"]
+  },
+  {
+    "id": "ann-cheb06-log-monotone",
+    "proofId": "chebyshev-pnt-bridge-oq-06",
+    "range": { "startLine": 51, "endLine": 57 },
+    "type": "technique",
+    "title": "Logarithm turns powers into products",
+    "content": "The whole upper-density argument rides on one fact: $\\mathrm{Real.log}$ is monotone and additive on powers, so $a^k \\le b^m$ becomes $k\\log a \\le m\\log b$ (via `Real.log_le_log` then `Real.log_pow`). Applied to the parent's power inequality this is the exact mirror of OQ-05's lower-density derivation `primeCounting_mul_log_lower` — the same transform run on the opposite inequality direction.",
+    "mathContext": "$0 < a^k \\le b^m \\ \\Rightarrow\\ k\\log a = \\log(a^k) \\le \\log(b^m) = m\\log b$",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.log_le_log", "Real.log_pow", "monotone transform"],
+    "prerequisites": ["properties of the real logarithm"]
+  },
+  {
+    "id": "ann-cheb06-difference-form",
+    "proofId": "chebyshev-pnt-bridge-oq-06",
+    "range": { "startLine": 59, "endLine": 88 },
+    "type": "theorem",
+    "title": "Part I — the real-log difference bound",
+    "content": "`primeCounting_diff_mul_log_sqrt_le`: for $n \\ge 4$, $(\\pi(n)-\\pi(\\sqrt n))\\log\\sqrt n \\le n\\log 4$. The proof casts the parent's ℕ-power inequality into ℝ (the `hcast` calc, using `push_cast` to move the cast through the power), checks the base is positive so the logarithm is monotone (`hlhs_pos` + `Real.log_le_log`), then `Real.log_pow` rewrites both sides into the product form. Here $\\sqrt n$ is the *integer* square root `Nat.sqrt n`.",
+    "mathContext": "$(\\pi(n)-\\pi(\\sqrt n))\\cdot\\log(\\sqrt n) \\le n\\cdot\\log 4 \\qquad (n \\ge 4)$",
+    "significance": "key",
+    "relatedConcepts": ["integer square root Nat.sqrt", "cast push_cast", "Real.log_pow"],
+    "prerequisites": ["casting ℕ→ℝ in Lean", "logarithm of a power"]
+  },
+  {
+    "id": "ann-cheb06-clean-bound",
+    "proofId": "chebyshev-pnt-bridge-oq-06",
+    "range": { "startLine": 97, "endLine": 122 },
+    "type": "theorem",
+    "title": "Part II — absorbing the π(√n) correction",
+    "content": "`primeCounting_mul_log_sqrt_le`: writing $\\pi(n) = (\\pi(n)-\\pi(\\sqrt n)) + \\pi(\\sqrt n)$ (valid since $\\pi$ is monotone and $\\sqrt n \\le n$, `Nat.monotone_primeCounting`) and bounding the small-prime correction by the trivial $\\pi(\\sqrt n) \\le \\sqrt n$ (the parent's `primeCounting_le`) turns the difference bound into a clean bound on $\\pi(n)\\log\\sqrt n$ itself. The ℕ-subtraction is converted to genuine ℝ-subtraction via `Nat.cast_sub hmono` before `nlinarith` combines the two inequalities.",
+    "mathContext": "$\\pi(n)\\cdot\\log(\\sqrt n) \\le n\\log 4 + \\sqrt n\\cdot\\log(\\sqrt n)$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.monotone_primeCounting", "truncated subtraction Nat.cast_sub", "trivial bound π(m) ≤ m"],
+    "prerequisites": ["monotonicity of π", "ℕ vs ℝ subtraction"]
+  },
+  {
+    "id": "ann-cheb06-density-quotient",
+    "proofId": "chebyshev-pnt-bridge-oq-06",
+    "range": { "startLine": 131, "endLine": 153 },
+    "type": "theorem",
+    "title": "Part III — the explicit upper density",
+    "content": "`primeCounting_le_div_log_sqrt`: dividing the Part II bound by $\\log(\\sqrt n) > 0$ (positive for $n \\ge 4$ since $\\sqrt n \\ge 2$, `Real.log_pos`) records the Chebyshev upper density directly, $\\pi(n) \\le n\\log 4/\\log\\sqrt n + \\sqrt n$. Rather than dividing symbolically, the proof multiplies the target template back through by $\\log\\sqrt n$ (the `key` `field_simp` identity) and cancels with `le_of_mul_le_mul_right`, sidestepping division lemmas. This is the explicit mirror of OQ-05's lower-density `primeCounting_ge_div_log`.",
+    "mathContext": "$\\pi(n) \\le \\dfrac{n\\,\\log 4}{\\log(\\sqrt n)} + \\sqrt n \\qquad (n \\ge 4)$",
+    "significance": "key",
+    "relatedConcepts": ["Real.log_pos", "field_simp", "le_of_mul_le_mul_right", "upper density"],
+    "prerequisites": ["positivity of log", "cancellation of a positive factor"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `chebyshev-pnt-bridge-oq-06` (Real-Logarithmic Upper Bound on π(n)).

The entry was meta-rich (full overview, 3 sections, conclusion, 2 crossRefs) but had **no `annotations.json`** — the dominant quality gap (quality score 39). This pass creates it.

## Changes
- **Created `annotations.json`** — 6 annotations, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`:
  1. Context — completing the real-log Chebyshev bracket (upper counterpart to OQ-05's lower bound)
  2. Insight — recovering Chebyshev's 1852 upper density $\limsup \pi(x)\log x/x \le 2\log 4$
  3. Technique — the log-monotonicity transform $a^k\le b^m \Rightarrow k\log a \le m\log b$
  4. Part I theorem — the real-log difference bound (cast + `Real.log_pow`)
  5. Part II theorem — absorbing the $\pi(\sqrt n)$ correction via `Nat.cast_sub` + `nlinarith`
  6. Part III theorem — the explicit quotient upper density

## Verification
- JSON valid; resolver alignment **Valid: 6, Misaligned: 0** against `ChebyshevPNTBridgeOQ06.lean`
- `meta.json` within the 60 KB cap; no meta/status/axiom change (entry remains `verified`, 0 axioms)
- Pre-PR freshness re-check: annotations.json still absent on origin/main at push time