### PR TITLE
audit(schroeder-bernstein-oq-03): sync meta.json sorries 4→1 after lemma proofs merged

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13039,10 +13039,10 @@
       "result": "clean"
     },
     "schroeder-bernstein-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-08T03:08:33Z",
-      "result": "clean"
+      "lastAudited": "2026-06-27T23:15:54Z",
+      "result": "issues-fixed"
     },
     "schroeder-bernstein-oq-04": {
       "auditCount": 4,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11919,6 +11919,12 @@
       "lastAudited": "2026-05-03T23:02:01Z",
       "result": "clean"
     },
+    "hilbert-3-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T23:19:12Z",
+      "result": "clean",
+      "issues": []
+    },
     "hilbert-4": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -17,9 +17,9 @@
       "open-question"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 257,
+    "lineCount": 269,
     "mathlibDependencies": [
       {
         "theorem": "OneOneReducible",
@@ -43,7 +43,7 @@
       }
     ],
     "originalContributions": [
-      "Partial formalization of Myhill's Isomorphism Theorem: easy direction fully proved, hard direction sorry'd (4 sorries)",
+      "Partial formalization of Myhill's Isomorphism Theorem: easy direction fully proved, hard direction sorry'd (1 sorry)",
       "Clean proof of the easy direction: computable bijection implies one-one equivalence",
       "Infrastructure for partial inverse via Nat.rfind (computable preimage search)",
       "Proof that computable isomorphism is an equivalence relation (reflexive, symmetric, transitive)",
@@ -101,30 +101,30 @@
       "title": "Section 3: Infrastructure — Partial Inverses and Orbits",
       "startLine": 97,
       "endLine": 134,
-      "summary": "Defines the partial inverse g⁻¹(m) = Nat.rfind(n ↦ g(n) = m) and states three key lemmas: partial inverse is Partrec (sorry'd), recovers the input under injection (sorry'd), and is defined on elements in range(g) (sorry'd). Also defines the forward orbit (g∘f)^k(n) and the isGFree predicate for orbit classification.",
+      "summary": "Defines the partial inverse g⁻¹(m) = Nat.rfind(n ↦ g(n) = m) and proves three key lemmas (all fully proved, no sorries): partial inverse is Partrec (via Partrec.rfind), recovers the input under injection (via Nat.rfind_spec), and is defined on elements in range(g) (via Nat.rfind_dom'). Also defines the forward orbit (g∘f)^k(n) and the isGFree predicate for orbit classification.",
       "mathContext": "$g^{-1}(m) := \\mu n[g(n) = m]$ (partial recursive unbounded search). By `Partrec.rfind`, since $(m, n) \\mapsto \\text{decide}(g(n) = m)$ is computable (as $g$ is computable), $g^{-1}$ is partial recursive. For injective $g$: $n \\in g^{-1}(m) \\Rightarrow g(n) = m$. Forward orbit: $\\text{fwdOrbit}(f, g, n, k) = (g \\circ f)^k(n)$. isGFree: $n$ is not in $\\text{range}(g)$."
     },
     {
       "id": "myhill-main",
       "title": "Section 4–5: Myhill's Isomorphism Theorem",
       "startLine": 136,
-      "endLine": 183,
+      "endLine": 194,
       "summary": "States and partially proves Myhill's theorem. The easy direction (←) follows immediately from myhill_easy. The hard direction (→) has a sorry covering the back-and-forth priority construction: classify orbits, define σ using f or g⁻¹ according to orbit type, prove σ is total, bijective, computable, and maps p to q.",
       "mathContext": "Hard direction plan: given $f: p \\leq_1 q$ and $g: q \\leq_1 p$, for each $n$ trace backward: $n \\leftarrow g^{-1}(n) \\leftarrow f^{-1}(g^{-1}(n)) \\leftarrow \\cdots$. Type A (terminates not in range($g$)): $\\sigma(n) := f(n)$. Type B (terminates not in range($f$)): $\\sigma(n) := g^{-1}(n)$. Type C (infinite): $\\sigma(n) := f(n)$. Each stage terminates by injectivity; the construction is computable by `partialInverse_partrec`."
     },
     {
       "id": "corollaries",
       "title": "Sections 6–7: Corollaries — Equivalence Relation",
-      "startLine": 186,
-      "endLine": 234,
+      "startLine": 196,
+      "endLine": 246,
       "summary": "Proves that computable isomorphism is an equivalence relation: reflexivity (identity permutation), symmetry (inverse permutation), transitivity (composition). Also exposes the two directions of Myhill's theorem as standalone lemmas and packages all three properties as an Equivalence instance.",
       "mathContext": "Reflexivity: $p \\simeq_c p$ via $\\text{id} : \\mathbb{N} \\simeq \\mathbb{N}$ (identity is computable, trivially $p(n) \\leftrightarrow p(n)$). Symmetry: if $p \\simeq_c q$ via $e$, then $q \\simeq_c p$ via $e^{-1}$ (computable by hypothesis; $q(n) \\leftrightarrow p(e^{-1}(n))$ by applying $e^{-1}$ to the correspondence). Transitivity: if $p \\simeq_c q$ via $e_1$ and $q \\simeq_c r$ via $e_2$, then $p \\simeq_c r$ via $e_1 \\circ e_2$."
     },
     {
       "id": "special-cases",
       "title": "Section 8: Key Special Cases",
-      "startLine": 238,
-      "endLine": 257,
+      "startLine": 248,
+      "endLine": 269,
       "summary": "Proves that ∅ and ℕ (the empty and universal predicates) are fixed points of computable isomorphism: any computable permutation maps ∅ to ∅ and ℕ to ℕ. These are the extreme cases in the one-one degree hierarchy.",
       "mathContext": "For the empty predicate $p = \\bot$: if $e$ maps $\\bot$ to $q$ (meaning $\\bot(n) \\leftrightarrow q(e(n))$), then $q(m) = \\bot$ for all $m$ (surjectivity of $e$). Dually for $p = \\top$. These facts follow from surjectivity of $e$ as a bijection."
     }
@@ -147,7 +147,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization proves the easy direction of Myhill's 1955 Isomorphism Theorem and the full equivalence-relation structure of computable isomorphism. The hard direction — constructing a computable bijection from two computable injections via the back-and-forth priority argument — has 4 sorries covering the partial inverse computability proof and the main construction. All infrastructure (partial inverses via `Nat.rfind`, forward orbits, `isGFree` predicate) is in place for completing the hard direction.",
+    "summary": "This formalization proves the easy direction of Myhill's 1955 Isomorphism Theorem and the full equivalence-relation structure of computable isomorphism. The hard direction — constructing a computable bijection from two computable injections via the back-and-forth priority argument — has 1 remaining sorry covering the main back-and-forth construction. The partial inverse computability lemmas are now fully proved, and all infrastructure (partial inverses via `Nat.rfind`, forward orbits, `isGFree` predicate) is in place for completing the hard direction.",
     "implications": "Myhill's theorem is a cornerstone of classical recursion theory: it shows that the one-one degrees have a finer structure than many-one degrees, and that 'computable isomorphism' is the right equivalence relation on decidable sets. Formalizing it in Lean 4 validates that Mathlib's computability library (`Partrec`, `Computable`, `OneOneReducible`) is expressive enough for serious recursion theory. The equivalence-relation proof has immediate applications: it enables quotient constructions over the one-one degrees, and the computable isomorphism type forms the basis for studying creative sets, simple sets, and other index-set hierarchies in effective mathematics.",
     "openQuestions": [
       "Can the hard direction be completed by formalizing the back-and-forth priority construction in Lean 4, using `Partrec` throughout and avoiding the oracle-computation machinery of Turing reducibility?",
@@ -180,7 +180,7 @@
       "note": "Chapter 3 — modern treatment"
     }
   ],
-  "sorries": 4,
+  "sorries": 1,
   "parentId": "schroeder-bernstein",
   "openQuestionId": "oq-03",
   "theorems": [
@@ -241,11 +241,11 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 257,
+    "lineCount": 269,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 4,
-    "sorries": 4,
+    "sorries": 1,
     "path": "Proofs/SchroederBernsteinOQ03.lean",
     "additionalFiles": [
       "Proofs/SchroederBernsteinOQ03Aristotle.lean"


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: schroeder-bernstein-oq-03 (Myhill's Isomorphism Theorem)
**Problem**: meta.json overstated remaining sorries (claimed 4, actual 1) after PR #30997 proved 3 lemmas.

## Evidence

PR #30997 (`bd0ff043ce2`) proved the three `partialInverse` computability lemmas
(`partialInverse_partrec`, `partialInverse_spec`, `partialInverse_dom`), removing 3 sorries — but meta.json was not synced.

Verified against `proofs/Proofs/SchroederBernsteinOQ03.lean`:
- **actual sorries: 1** (line 192 — hard-direction back-and-forth construction); meta claimed **4**
- **actual lineCount: 269**; meta claimed **257**
- axiomCount 0, theoremCount 14, definitionCount 4 — all match; no True stubs

## Fixes

- `meta.sorries` / top-level `sorries` / `leanFile.sorries`: 4 → 1
- `meta.lineCount` / `leanFile.lineCount`: 257 → 269
- `originalContributions[0]`: "(4 sorries)" → "(1 sorry)"
- `partial-inverse` section summary: 3 lemmas described as "(sorry'd)" → now fully proved
- `conclusion.summary`: "4 sorries" → "1 remaining sorry covering the main construction"
- Section line anchors (myhill-main, corollaries, special-cases) re-synced to current line numbers

Status `formalized` / badge `wip` unchanged — 1 sorry remains in the hard direction, so the entry is correctly still WIP.

---
Discovered during gallery integrity audit. Conservative-direction mismatch (underclaiming completeness), corrected for accuracy.