### PR TITLE
research(erdos-340-greedy-sidon-oq-05): affine invariance of B_h (dilation + composite) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos340GreedySidonOQ05.lean
+++ b/proofs/Proofs/Erdos340GreedySidonOQ05.lean
@@ -66,6 +66,13 @@ upper bound.
   cardinality exactly `n`.  This isolates the open content: the *count* of a `B_h`
   set is unbounded for free; only the size of its *largest element* is hard.
 
+* `IsBh.map_mul_right` / `IsBh.map_affine` — **dilation and affine invariance**.
+  Multiplying a `B_h` set by a positive constant `c` (`A ↦ A.image (· * c)`) preserves
+  `B_h` (every `h`-fold sum scales by `c`); composing with the translation
+  `IsBh.map_add_right` shows any affine map `x ↦ c·x + d` with `c ≥ 1` preserves `B_h`.
+  The positive-slope affine group is thus the symmetry group of the `B_h` upper bound,
+  letting one normalise a `B_h` set by an affine change of variable before counting.
+
 ## Mathematical note
 
 The bound is *sharp in order*: Singer difference sets give `B_2` sets of size
@@ -606,5 +613,92 @@ how small the largest element can be — the `N^{1/(2h-1)}` greedy lower bound. 
 theorem exists_isBh_card (h : ℕ) (hh : 1 ≤ h) (n : ℕ) :
     ∃ A : Finset ℕ, IsBh h A ∧ A.card = n :=
   ⟨greedyBhSet h hh n, greedyBhSet_isBh hh n, greedyBhSet_card hh n⟩
+
+/-! ## Part 6: Dilation and affine invariance -/
+
+/-- Summing after multiplying every entry of a multiset by a fixed constant `c`
+scales the total by `c`. -/
+private theorem sum_map_mul_const (c : ℕ) (m : Multiset ℕ) :
+    (m.map (· * c)).sum = m.sum * c := by
+  induction m using Multiset.induction with
+  | empty => simp
+  | cons a s ih =>
+      simp only [Multiset.map_cons, Multiset.sum_cons, ih]
+      ring
+
+/-- **Dilation invariance of `B_h`.**  Multiplying every element of a `B_h` set by a
+fixed *positive* constant `c` preserves the `B_h` property: each `h`-fold sum scales by
+the same factor `c`, so distinct sums stay distinct.
+
+Together with `IsBh.map_add_right` (translation invariance) this shows that the affine
+group with positive slope acts on `B_h` sets — the natural symmetry group under which
+the `B_h` upper bound `IsBh.choose_card_le` is invariant. -/
+theorem IsBh.map_mul_right {h c : ℕ} {A : Finset ℕ} (hc : 0 < c) (hA : IsBh h A) :
+    IsBh h (A.image (· * c)) := by
+  intro s hs t ht hsum
+  rw [Finset.mem_coe, Finset.mem_sym_iff] at hs ht
+  have hsum2 : (s : Multiset ℕ).sum = (t : Multiset ℕ).sum := hsum
+  -- An `h`-multiset over the dilated set pulls back into `A` by dividing by `c`.
+  have hpre : ∀ {u : Sym ℕ h}, (∀ a ∈ u, a ∈ A.image (· * c)) →
+      u.map (· / c) ∈ A.sym h := by
+    intro u hu
+    rw [Finset.mem_sym_iff]
+    intro a ha
+    rw [Sym.mem_map] at ha
+    obtain ⟨b, hb, rfl⟩ := ha
+    obtain ⟨x, hx, hxb⟩ := Finset.mem_image.mp (hu b hb)
+    have hbx : b / c = x := by rw [← hxb, Nat.mul_div_cancel _ hc]
+    rwa [hbx]
+  -- Multiplying back by `c` recovers the original multiset, since every entry is a
+  -- multiple of `c`.
+  have hrec : ∀ {u : Sym ℕ h}, (∀ a ∈ u, a ∈ A.image (· * c)) →
+      (u.map (· / c)).map (· * c) = u := by
+    intro u hu
+    rw [Sym.map_map]
+    refine (Sym.map_congr ?_).trans (Sym.map_id' u)
+    intro x hx
+    obtain ⟨y, hy, hyx⟩ := Finset.mem_image.mp (hu x hx)
+    simp only [Function.comp_apply]
+    rw [← hyx, Nat.mul_div_cancel _ hc]
+  -- Pulling back scales every total down by exactly the factor `c`.
+  have hsumshift : ∀ {u : Sym ℕ h}, (∀ a ∈ u, a ∈ A.image (· * c)) →
+      (u : Multiset ℕ).sum = ((u.map (· / c)) : Multiset ℕ).sum * c := by
+    intro u hu
+    set M : Multiset ℕ := ((u.map (· / c) : Sym ℕ h) : Multiset ℕ) with hM
+    have hkey := sum_map_mul_const c M
+    have hMmap : M.map (· * c) = (u : Multiset ℕ) := by
+      rw [hM, ← Sym.coe_map, hrec hu]
+    rw [hMmap] at hkey
+    exact hkey
+  -- Equal dilated sums ⟹ equal pulled-back sums (cancel `c > 0`) ⟹ equal pullbacks.
+  have hs' : s.map (· / c) ∈ A.sym h := hpre hs
+  have ht' : t.map (· / c) ∈ A.sym h := hpre ht
+  have hsum' :
+      ((s.map (· / c)) : Multiset ℕ).sum = ((t.map (· / c)) : Multiset ℕ).sum := by
+    have e1 := hsumshift hs
+    have e2 := hsumshift ht
+    have hmul :
+        ((s.map (· / c)) : Multiset ℕ).sum * c
+          = ((t.map (· / c)) : Multiset ℕ).sum * c := by rw [← e1, ← e2]; exact hsum2
+    exact Nat.eq_of_mul_eq_mul_right hc hmul
+  have hpeq : s.map (· / c) = t.map (· / c) := hA hs' ht' hsum'
+  calc s = (s.map (· / c)).map (· * c) := (hrec hs).symm
+    _ = (t.map (· / c)).map (· * c) := by rw [hpeq]
+    _ = t := hrec ht
+
+/-- **Affine invariance of `B_h`.**  Applying an affine map `x ↦ c·x + d` with positive
+slope `c` to every element of a `B_h` set preserves the `B_h` property.  The affine image
+factors as a dilation `· * c` followed by a translation `· + d`, so this is the
+composition of `IsBh.map_mul_right` and `IsBh.map_add_right`.
+
+Consequently the affine group `{x ↦ c·x + d : c ≥ 1}` acts on `B_h` sets, the natural
+symmetry group of the `B_h` upper bound: one may freely normalise a `B_h` set by an
+affine change of variable before applying the counting bound. -/
+theorem IsBh.map_affine {h c d : ℕ} {A : Finset ℕ} (hc : 0 < c) (hA : IsBh h A) :
+    IsBh h (A.image (fun x => c * x + d)) := by
+  have hfun : (fun x => c * x + d) = (fun y => y + d) ∘ (fun x => x * c) := by
+    funext x; simp [Nat.mul_comm]
+  rw [hfun, ← Finset.image_image]
+  exact (hA.map_mul_right hc).map_add_right
 
 end Erdos340Bh

--- a/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
@@ -228,3 +228,50 @@ the N^{1/(2h-1)} greedy lower bound inside {1,…,N}.
 #### Verification
 `lake env lean` exit 0, no warnings. `#print axioms exists_isBh_card / greedyBhSet_card`
 = 3 foundational only. 558 → 610 lines, 19 → 24 theorems, 2 → 4 defs.
+
+### Session 2026-06-27 (Session 6, researcher-2) — dilation + affine invariance (rebased onto greedy main)
+
+**Mode**: ACT · **Outcome**: progress (verified increment, 0 sorries / 0 axioms).
+
+#### What I Did
+- Added **Part 6: dilation + affine invariance**, completing the affine-symmetry picture
+  of `B_h` (the natural complement to the existing translation invariance `map_add_right`).
+  - `IsBh.map_mul_right` (`0 < c`): `A.image (· * c)` is `B_h`. Each `h`-fold sum scales
+    by the common factor `c`. Proof mirrors `map_add_right`: pull each dilated `h`-multiset
+    back into `A` by dividing entries by `c` (`Nat.mul_div_cancel _ hc`), recover via
+    `Sym.map_map`/`Sym.map_congr`/`Sym.map_id'`, relate sums with the induction helper
+    `sum_map_mul_const : (m.map (· * c)).sum = m.sum * c`, cancel `c > 0` via
+    `Nat.eq_of_mul_eq_mul_right`, finish with `B_h` injectivity. `c = 0` is sharp (collapses
+    the set to `{0}`), so `0 < c` is necessary, not cosmetic.
+  - `IsBh.map_affine` (`0 < c`): `A.image (fun x => c*x + d)` is `B_h` = dilation then
+    translation, `rw [hfun, ← Finset.image_image]` then `(hA.map_mul_right hc).map_add_right`.
+
+#### Concurrency note (IMPORTANT)
+- This work was first done as PR #31009 against main @3ef2b85 (the 509-line, pre-greedy
+  file). While it was in flight the **greedy-extension** PR merged to main (file → 610
+  lines, `insert_of_large`/`exists_insert`/`greedyBhSet`/`exists_isBh_card`), so #31009
+  went `CONFLICTING`. I **rebased**: reset to new origin/main, re-applied the self-contained
+  Part-6 affine code on top of the greedy version, merged the affine entries into the
+  greedy JSON/knowledge, re-verified, and force-pushed `feature/researcher-2` to update
+  #31009 (now mergeable, contains greedy + affine). The affine Lean code is unchanged from
+  the original verification.
+
+#### Key Findings / gotchas
+- Two uses of `Nat.mul_div_cancel _ hc`: membership (`(x*c)/c = x ∈ A`) and round-trip
+  recovery (`(y*c)/c * c = y*c`). First underscore is the dividend.
+- `map_affine` slope orientation: affine written `c*x + d` but the dilation helper uses
+  `· * c` (`x*c`); bridge with `funext x; simp [Nat.mul_comm]`. `Finset.image_image :
+  (s.image f).image g = s.image (g ∘ f)`, so `←` un-composes.
+- `Nat.eq_of_mul_eq_mul_right : 0 < c → a*c = b*c → a = b` is the multiplicative analogue
+  of the additive `omega` cancellation in `map_add_right`.
+
+#### Verification
+Docker host unreliable. Verified via host `v4.26.0` `lake env lean`: compiled imported
+`Proofs.Erdos340GreedySidon` to a temp olean (`/tmp/oq05build`), prepended to `LEAN_PATH`,
+compiled `Erdos340GreedySidonOQ05.lean` → exit 0, no warnings. `#print axioms
+IsBh.map_mul_right / IsBh.map_affine` = `[propext, Classical.choice, Quot.sound]` (0-axiom).
+704 lines, 27 theorems.
+
+#### Next Steps
+- Unchanged open core: the forbidden-set counting for the `N^{1/(2h-1)}` greedy lower
+  bound. `map_affine` now lets one normalise a `B_h` set (least element 0) as a first step.

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -6,14 +6,14 @@
   "tier": "B",
   "tractability": "medium — the foundational B_h theory and the sharp B_h counting upper bound are now formalized and verified (0-axiom). The deep open direction (improving the greedy B_h lower bound toward the N^{1/h} ceiling) remains open, exactly as for the parent #340.",
   "started": "2026-06-27",
-  "lastUpdate": "2026-06-27T16:55:00.000Z",
+  "lastUpdate": "2026-06-27T17:05:00.000Z",
   "path": "research/problems/erdos-340-greedy-sidon-oq-05",
   "leanFiles": [
     {
       "path": "Proofs/Erdos340GreedySidonOQ05.lean",
       "filename": "Erdos340GreedySidonOQ05.lean",
-      "lineCount": 610,
-      "theoremCount": 24,
+      "lineCount": 704,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,
@@ -42,6 +42,7 @@
   "knowledge": {
     "insights": [
       "B_h sets generalize Sidon (= B_2) sets: A is B_h iff all h-fold sums with repetition are distinct. The clean formalization is injectivity of the multiset-sum map s ↦ (s : Multiset ℕ).sum on the finset A.sym h of h-element multisets drawn from A (def IsBh in Erdos340GreedySidonOQ05.lean).",
+      "The B_h property is AFFINE-INVARIANT under positive-slope maps: preserved by dilation A.image(·*c) for c>0 (IsBh.map_mul_right) and by composing with translation (IsBh.map_add_right) into IsBh.map_affine for x ↦ c·x + d, c>0. Dilation proof mirrors translation: each h-fold sum scales by c, pull back the dilated h-multiset by dividing each entry by c (Nat.mul_div_cancel _ hc), recover via Sym.map_map/Sym.map_congr/Sym.map_id', sum helper sum_map_mul_const : (m.map(·*c)).sum = m.sum*c, cancel c>0 via Nat.eq_of_mul_eq_mul_right. So the positive-slope affine group acts on B_h sets — the symmetry group of the B_h upper bound; one may normalise a B_h set (e.g. least element 0) before counting or before attacking the greedy lower bound. 0-axiom verified.",
       "The sharp B_h upper bound is provable by an h-SUBSET counting argument rather than the full multiset count: the Nat.choose A.card h many h-element SUBSETS of A have pairwise distinct sums (a subset is a repetition-free multiset, so distinctness is inherited from the B_h injectivity), and each such sum lies in [1, h·N]. This injects choose(|A|,h) into an interval of length h·N, giving Nat.choose A.card h ≤ h·N (theorem IsBh.choose_card_le, 0-axiom verified).",
       "At h = 2 the bound reads choose(|A|,2) = |A|·(|A|-1)/2 ≤ 2N, i.e. |A|·(|A|-1) ≤ 4N (theorem IsBh.two_card_mul_pred_le) — exactly the classical Sidon bound |A| = O(√N), confirming B_h genuinely generalizes #340's B_2 case. For general h it gives |A| = O(N^{1/h}), the trivial B_h ceiling that Bose-Chowla constructions meet to within (1-o(1)).",
       "Using h-subsets (powersetCard, card = Nat.choose) instead of all h-multisets (Finset.sym, whose Finset-level cardinality is NOT directly available in Mathlib as a multichoose lemma) is what makes the counting bound clean: Finset.card_powersetCard gives the exact choose count, and Finset.card_image_of_injOn + Nat.card_Icc finish it.",
@@ -58,7 +59,8 @@
       "IsBh.isSidon / IsSidon.isBh_two / isBh_two_iff_isSidon: the EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A (gallery classical Sidon def). Forward: unordered pairs {a,b},{c,d} ∈ A.sym 2 with equal multiset-sums ⟹ {a,b}={c,d} by B_2 injectivity ⟹ a=c,b=d via orderings. Reverse: Multiset.card_eq_two writes each Sym ℕ 2 elt as {a,b}; pair_eq_of_sidon feeds the correctly-ordered quadruple (4 le_total cases) to IsSidon, giving {a,b}={c,d} ⟹ s=t via Sym.coe_injective. 0-axiom verified.",
       "IsBh.map_add_right: translation invariance — shifting every element of a B_h set by a fixed c preserves B_h (each h-fold sum increases by h·c).",
       "bh_split (private), IsBh.insert_of_large, IsBh.exists_insert: the greedy B_h extension. insert_of_large: A B_h, m > h·(A.sup id) ⟹ insert m A B_h (via the count-m/filter split + downward closure). exists_insert: explicit always-available extension m = h·A.sup id + 1. 0-axiom verified. Key API: Multiset.filter_add_not, Multiset.filter_eq', Multiset.sum_replicate, Multiset.sum_le_card_nsmul, Finset.le_sup, Nat.le_mul_of_pos_left.",
-      "isBh_empty (∅ is B_h); greedyBhAux (subtype-bundled {A // IsBh h A ∧ A.card = n} recursion iterating exists_insert via Classical.choose); greedyBhSet/greedyBhSet_isBh/greedyBhSet_card projections; exists_isBh_card (for every h≥1, n: ∃ B_h set of card exactly n). The explicit greedy family. 0-axiom (Classical.choice only)."
+      "isBh_empty (∅ is B_h); greedyBhAux (subtype-bundled {A // IsBh h A ∧ A.card = n} recursion iterating exists_insert via Classical.choose); greedyBhSet/greedyBhSet_isBh/greedyBhSet_card projections; exists_isBh_card (for every h≥1, n: ∃ B_h set of card exactly n). The explicit greedy family. 0-axiom (Classical.choice only).",
+      "IsBh.map_mul_right (0 < c): DILATION invariance — A.image (· * c) is B_h (each h-fold sum scales by c; pullback by dividing by c via Nat.mul_div_cancel _ hc, cancel via Nat.eq_of_mul_eq_mul_right). Helper sum_map_mul_const : (m.map (·*c)).sum = m.sum * c. IsBh.map_affine (0 < c): AFFINE invariance — A.image (fun x => c·x + d) is B_h, as dilation∘translation via rw [hfun, ← Finset.image_image] then .map_mul_right.map_add_right. 0-axiom verified. Establishes the positive-slope affine group {x ↦ c·x+d : c≥1} as the symmetry group of the B_h upper bound IsBh.choose_card_le. c=0 is sharp (collapses the set to {0})."
     ],
     "mathlibGaps": [
       "Mathlib has no B_h-set theory and no Sidon/B_h upper bound; the whole development is original relative to Mathlib.",
@@ -69,6 +71,6 @@
       "Prove the maximal-set lower bound directly: if A ⊆ [1,N] is B_h and maximal (no n ∈ [1,N] extends it), then N ≤ |A| + (number of values blocked by a collision), and bound the blocked count by |A|^{2h-1}.",
       "With the bridge in hand, transport a concrete gallery Sidon result (e.g. sidon_upper_bound_weak or an explicit small Sidon set) through isBh_two_iff_isSidon as a sanity corollary."
     ],
-    "progressSummary": "PROGRESS: Foundational B_h theory + sharp upper bound Nat.choose |A| h ≤ h·N + downward closure (of_succ/of_le) + EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A + translation invariance + GREEDY EXTENSION (insert_of_large, exists_insert) + EXPLICIT GREEDY FAMILY (greedyBhAux/greedyBhSet; exists_isBh_card: a B_h set of every cardinality n exists for each h≥1), all verified 0-axiom (Erdos340GreedySidonOQ05.lean, 605 lines, 24 theorems). The construction cleanly SEPARATES the open question: a B_h set's count is unbounded for free; the remaining open core is the forbidden-set counting bounding the LARGEST element, i.e. the N^{1/(2h-1)} growth rate inside {1,…,N} — matching the still-open parent #340."
+    "progressSummary": "PROGRESS: Foundational B_h theory + sharp upper bound Nat.choose |A| h ≤ h·N + downward closure (of_succ/of_le) + EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A + translation invariance + GREEDY EXTENSION (insert_of_large, exists_insert) + EXPLICIT GREEDY FAMILY (greedyBhAux/greedyBhSet; exists_isBh_card: a B_h set of every cardinality n exists for each h≥1), + full AFFINE invariance (dilation map_mul_right + composite map_affine, positive-slope affine group = symmetry group of the bound), all verified 0-axiom (Erdos340GreedySidonOQ05.lean, 704 lines, 27 theorems). The construction cleanly SEPARATES the open question: a B_h set's count is unbounded for free; the remaining open core is the forbidden-set counting bounding the LARGEST element, i.e. the N^{1/(2h-1)} growth rate inside {1,…,N} — matching the still-open parent #340."
   }
 }


### PR DESCRIPTION
## Summary

Adds the **affine-invariance** of the `B_h` property (Part 6) to the verified Erdős #340
OQ-05 `B_h`-sequence development, completing the symmetry picture begun by the existing
translation invariance (`IsBh.map_add_right`).

> **Rebased onto the greedy-extension main.** This branch was originally cut against an
> earlier main; the greedy-construction PR merged in the meantime. I rebased the
> self-contained affine code on top, so this PR now sits cleanly on the greedy version
> (file: 704 lines, 27 theorems, 0-axiom) and is `MERGEABLE`.

New theorems:

| Theorem | Statement |
|---------|-----------|
| `IsBh.map_mul_right` (`0 < c`) | **dilation invariance** — `A.image (· * c)` is `B_h` |
| `IsBh.map_affine` (`0 < c`) | **affine invariance** — `A.image (fun x => c*x + d)` is `B_h` |
| `sum_map_mul_const` (helper) | `(m.map (· * c)).sum = m.sum * c` |

**Why it matters.** Multiplying a `B_h` set by a positive constant `c` scales every
`h`-fold sum by the same factor, so distinct sums stay distinct. Composed with translation,
this shows the positive-slope affine group `{x ↦ c·x + d : c ≥ 1}` acts on `B_h` sets — the
natural symmetry group of the `B_h` upper bound `IsBh.choose_card_le`. One may now freely
normalise a `B_h` set by an affine change of variable (e.g. so its least element is `0`)
before counting or before attacking the open `B_h` greedy lower bound. The hypothesis
`0 < c` is sharp: `c = 0` collapses the set to `{0}`.

**Proof (dilation).** Pull each dilated `h`-multiset back into `A` by dividing every entry
by `c` (`Nat.mul_div_cancel _ hc`), recover via `Sym.map_map`/`Sym.map_congr`/`Sym.map_id'`,
relate sums with `sum_map_mul_const`, cancel `c > 0` via `Nat.eq_of_mul_eq_mul_right`, and
apply `B_h` injectivity.

## Verification

Docker host was unreliable this session, so verified via the host `v4.26.0` toolchain:
compiled the imported `Proofs.Erdos340GreedySidon` to a temp olean, prepended it to
`LEAN_PATH`, then compiled `Erdos340GreedySidonOQ05.lean` → exit 0, no warnings.

- `#print axioms IsBh.map_mul_right` → `[propext, Classical.choice, Quot.sound]`
- `#print axioms IsBh.map_affine` → `[propext, Classical.choice, Quot.sound]`

0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions (0-axiom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)