### PR TITLE
research(cauchy-schwarz-oq-01-oq-03-oq-02-oq-01): entropic uncertainty — min-entropy bound + eigenstate Maassen–Uffink [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ01OQ03OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ03OQ02OQ01.lean
@@ -1,0 +1,126 @@
+/-
+  Entropic Uncertainty — OQ-01-OQ-03-OQ-02-OQ-01:
+  The min-entropy lower bound and the EIGENSTATE case of Maassen–Uffink.
+
+  ## Question
+  The parent entry (`cauchy-schwarz-oq-01-oq-03-oq-02`) builds the finite Shannon-
+  entropy infrastructure for the entropic uncertainty principle (Maassen–Uffink
+  1988): for outcome distributions `p, q` of measuring a state in two orthonormal
+  bases of maximal overlap `c`, `H(p) + H(q) ≥ -2 ln c`. It proves the entropy
+  *ceiling* `H ≤ log n` but notes the *lower* bound on `H(p) + H(q)` is gated on
+  Riesz–Thorin / Hausdorff–Young interpolation, absent from Mathlib.
+
+  This file supplies what IS provable elementarily: the **min-entropy lower bound**
+  `H(p) ≥ -log(max_i p_i)` (equivalently `H(p) ≥ -log M` whenever every `p_i ≤ M`),
+  and the resulting **eigenstate case** of the Maassen–Uffink relation. When the
+  measured state is a basis vector of the first basis, `H(p) = 0` and every outcome
+  probability in the second basis is bounded by the squared overlap `q_k ≤ c²`,
+  so `H(p) + H(q) ≥ 0 + (-log c²) = -2 log c`. This is a genuine special case of
+  the full theorem, proved with no interpolation theory.
+
+  ## What this file delivers (0 axioms, 0 sorries)
+  * `negMulLog_ge_mul_neg_log` — pointwise: `x·(-log M) ≤ negMulLog x` for `0 ≤ x ≤ M`.
+  * `shannonEntropy_ge_neg_log_of_max` — the min-entropy bound: if every `p_i ≤ M`
+    (`M > 0`) and `∑ p_i = 1`, then `H(p) ≥ -log M`.
+  * `shannonEntropy_point_mass` — a deterministic distribution has `H = 0`.
+  * `maassen_uffink_eigenstate` — the EUP lower bound `-2 log c ≤ H(p) + H(q)` in the
+    eigenstate case (`p` a point mass, `q_k ≤ c²`).
+
+  ## References
+  - H. Maassen, J. Uffink, *Generalized entropic uncertainty relations*,
+    Phys. Rev. Lett. 60 (1988).
+  - D. Deutsch, *Uncertainty in quantum measurements*, Phys. Rev. Lett. 50 (1983).
+
+  Tags: information-theory, entropy, uncertainty-principle, quantum-information, cauchy-schwarz
+-/
+
+import Mathlib
+
+open Finset
+
+namespace CauchySchwarzOQ01OQ03OQ02OQ01
+
+variable {ι : Type*} [Fintype ι]
+
+/-- Shannon entropy of a finite probability vector `p` (in nats):
+`H(p) = ∑ᵢ negMulLog(pᵢ) = -∑ᵢ pᵢ log pᵢ`, via Mathlib's `Real.negMulLog`. -/
+noncomputable def shannonEntropy (p : ι → ℝ) : ℝ :=
+  ∑ i, Real.negMulLog (p i)
+
+-- ============================================================
+-- SECTION I: The pointwise min-entropy inequality
+-- ============================================================
+
+/-- **Pointwise bound.** For `0 ≤ x ≤ M` with `0 < M`, `x·(-log M) ≤ negMulLog x`.
+This is the term that, summed against a probability vector, yields the min-entropy
+bound `H(p) ≥ -log M`. -/
+theorem negMulLog_ge_mul_neg_log (M x : ℝ) (_hM : 0 < M) (hx0 : 0 ≤ x) (hxM : x ≤ M) :
+    x * (-Real.log M) ≤ Real.negMulLog x := by
+  rcases eq_or_lt_of_le hx0 with hx | hpos
+  · simp [← hx, Real.negMulLog]
+  · have hlog : Real.log x ≤ Real.log M := Real.log_le_log hpos hxM
+    rw [Real.negMulLog]
+    nlinarith [mul_le_mul_of_nonneg_left hlog hx0]
+
+-- ============================================================
+-- SECTION II: The min-entropy lower bound on Shannon entropy
+-- ============================================================
+
+/-- **Min-entropy bound.** If every outcome probability satisfies `p_i ≤ M` for some
+`M > 0` and `∑ p_i = 1`, then `H(p) ≥ -log M`. Instantiated with `M = max_i p_i`
+this is the standard fact `H(p) ≥ H_∞(p) = -log(max_i p_i)`: Shannon entropy is at
+least the min-entropy. -/
+theorem shannonEntropy_ge_neg_log_of_max {p : ι → ℝ} (M : ℝ) (hM : 0 < M)
+    (h0 : ∀ i, 0 ≤ p i) (hub : ∀ i, p i ≤ M) (hsum : ∑ i, p i = 1) :
+    -Real.log M ≤ shannonEntropy p := by
+  have hterm : ∑ i, p i * (-Real.log M) ≤ ∑ i, Real.negMulLog (p i) :=
+    Finset.sum_le_sum (fun i _ => negMulLog_ge_mul_neg_log M (p i) hM (h0 i) (hub i))
+  calc -Real.log M = (∑ i, p i) * (-Real.log M) := by rw [hsum]; ring
+    _ = ∑ i, p i * (-Real.log M) := by rw [Finset.sum_mul]
+    _ ≤ shannonEntropy p := hterm
+
+-- ============================================================
+-- SECTION III: Deterministic distributions have zero entropy
+-- ============================================================
+
+/-- **Point mass.** A deterministic distribution (each entry `0` or `1`) has zero
+Shannon entropy: `negMulLog 0 = negMulLog 1 = 0`. -/
+theorem shannonEntropy_point_mass {p : ι → ℝ} (h : ∀ i, p i = 0 ∨ p i = 1) :
+    shannonEntropy p = 0 := by
+  apply Finset.sum_eq_zero
+  intro i _
+  rcases h i with h0 | h1
+  · rw [h0]; simp [Real.negMulLog]
+  · rw [h1]; simp [Real.negMulLog]
+
+-- ============================================================
+-- SECTION IV: The eigenstate case of Maassen–Uffink
+-- ============================================================
+
+/-- **Eigenstate Maassen–Uffink.** Measuring a basis vector of the first basis gives
+a deterministic distribution `p` (`H(p) = 0`); in the second basis every outcome
+probability is bounded by the squared maximal overlap, `q_k ≤ c²`. Then the entropic
+uncertainty lower bound holds: `-2 log c ≤ H(p) + H(q)`.
+
+This is the genuine `H(p) = 0` special case of the full Maassen–Uffink relation,
+proved from the min-entropy bound alone — no Hausdorff–Young / Riesz–Thorin
+interpolation, which the general case requires and Mathlib lacks. -/
+theorem maassen_uffink_eigenstate {p q : ι → ℝ} (c : ℝ) (hc0 : 0 < c)
+    (hp : ∀ i, p i = 0 ∨ p i = 1)
+    (hq0 : ∀ i, 0 ≤ q i) (hqsum : ∑ i, q i = 1) (hqub : ∀ i, q i ≤ c ^ 2) :
+    -2 * Real.log c ≤ shannonEntropy p + shannonEntropy q := by
+  have hc2 : (0 : ℝ) < c ^ 2 := by positivity
+  have hHq : -Real.log (c ^ 2) ≤ shannonEntropy q :=
+    shannonEntropy_ge_neg_log_of_max (c ^ 2) hc2 hq0 hqub hqsum
+  have hlog : Real.log (c ^ 2) = 2 * Real.log c := by
+    rw [Real.log_pow]; push_cast; ring
+  rw [hlog] at hHq
+  rw [shannonEntropy_point_mass hp]
+  linarith [hHq]
+
+#check @negMulLog_ge_mul_neg_log
+#check @shannonEntropy_ge_neg_log_of_max
+#check @shannonEntropy_point_mass
+#check @maassen_uffink_eigenstate
+
+end CauchySchwarzOQ01OQ03OQ02OQ01

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-pointwise",
+    "proofId": "cauchy-schwarz-oq-01-oq-03-oq-02-oq-01",
+    "range": { "startLine": 57, "endLine": 63 },
+    "type": "insight",
+    "title": "The Pointwise Atom of the Min-Entropy Bound",
+    "content": "`negMulLog_ge_mul_neg_log`: for `0 ≤ x ≤ M` with `M > 0`, `x·(-log M) ≤ negMulLog x = -x log x`. For `x = 0` both sides are `0` (`negMulLog 0 = 0`). For `x > 0`, monotonicity of `log` (`Real.log_le_log`) gives `log x ≤ log M`, and `nlinarith` with the scaled inequality `x·log x ≤ x·log M` finishes. Summed against a probability vector this single term yields the min-entropy bound.",
+    "mathContext": "Since $-t\\log t$ is increasing in the sense relevant here, replacing $p_i$ by its upper bound $M$ inside $\\log$ underestimates $-p_i\\log p_i$ by $-p_i\\log M$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.negMulLog", "Real.log_le_log", "nlinarith"],
+    "prerequisites": ["Monotonicity of the real logarithm"]
+  },
+  {
+    "id": "ann-min-entropy",
+    "proofId": "cauchy-schwarz-oq-01-oq-03-oq-02-oq-01",
+    "range": { "startLine": 73, "endLine": 80 },
+    "type": "insight",
+    "title": "Shannon Entropy ≥ Min-Entropy",
+    "content": "`shannonEntropy_ge_neg_log_of_max`: if every `p_i ≤ M` (`M > 0`) and `∑ p_i = 1`, then `H(p) ≥ -log M`. Summing the pointwise bound (`Finset.sum_le_sum`) gives `∑ p_i·(-log M) ≤ H(p)`, and `∑ p_i·(-log M) = (∑ p_i)·(-log M) = -log M` by `∑ p_i = 1`. Instantiating `M = max_i p_i` recovers the textbook fact `H(p) ≥ H_∞(p) = -log(max_i p_i)`: Shannon entropy dominates the min-entropy. This is the elementary half of every entropic uncertainty relation.",
+    "mathContext": "$H(p)=-\\sum_i p_i\\log p_i \\ge -\\log\\max_i p_i = H_\\infty(p)$, the min-entropy, for any probability vector $p$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_le_sum", "Finset.sum_mul", "min-entropy"],
+    "prerequisites": ["Finite sums of inequalities"]
+  },
+  {
+    "id": "ann-point-mass",
+    "proofId": "cauchy-schwarz-oq-01-oq-03-oq-02-oq-01",
+    "range": { "startLine": 88, "endLine": 94 },
+    "type": "insight",
+    "title": "A Certain Outcome Carries Zero Entropy",
+    "content": "`shannonEntropy_point_mass`: a deterministic distribution (each entry `0` or `1`) has `H = 0`, because `negMulLog 0 = 0` and `negMulLog 1 = -1·log 1 = 0`, so every summand vanishes (`Finset.sum_eq_zero`). This is the `H(p) = 0` input to the eigenstate uncertainty bound.",
+    "mathContext": "Measuring a basis vector in its own basis gives a point-mass distribution with zero Shannon entropy.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.negMulLog", "Finset.sum_eq_zero"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-eigenstate-eup",
+    "proofId": "cauchy-schwarz-oq-01-oq-03-oq-02-oq-01",
+    "range": { "startLine": 108, "endLine": 122 },
+    "type": "insight",
+    "title": "The Eigenstate Case of Maassen–Uffink",
+    "content": "`maassen_uffink_eigenstate`: if `p` is a point mass and every conjugate probability satisfies `q_k ≤ c²` (`0 < c`), then `-2 log c ≤ H(p) + H(q)`. The point-mass lemma gives `H(p) = 0`; the min-entropy bound with `M = c²` gives `H(q) ≥ -log(c²)`; and `Real.log_pow` rewrites `-log(c²) = -2 log c`, the textbook Maassen–Uffink constant. This is the genuine `H(p) = 0` special case — the only case provable without the Hausdorff–Young / Riesz–Thorin interpolation that the general bound needs and that Mathlib lacks.",
+    "mathContext": "For a state equal to a basis vector $a_{j_0}$: $p$ is deterministic ($H(p)=0$) and $q_k=|\\langle b_k|a_{j_0}\\rangle|^2\\le c^2$, so $H(p)+H(q)\\ge -\\log c^2 = -2\\log c$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.log_pow", "shannonEntropy_ge_neg_log_of_max", "shannonEntropy_point_mass"],
+    "prerequisites": ["Born rule (for the q_k ≤ c² hypothesis)", "Maximal basis overlap c"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02-oq-01/meta.json
@@ -1,0 +1,100 @@
+{
+  "id": "cauchy-schwarz-oq-01-oq-03-oq-02-oq-01",
+  "title": "Entropic Uncertainty: the Min-Entropy Bound and the Eigenstate Case of Maassen–Uffink",
+  "slug": "cauchy-schwarz-oq-01-oq-03-oq-02-oq-01",
+  "description": "The parent entry builds the finite Shannon-entropy infrastructure for the Maassen–Uffink entropic uncertainty principle H(p) + H(q) ≥ -2 ln c, but notes the lower bound on the sum is gated on Riesz–Thorin / Hausdorff–Young interpolation, which Mathlib lacks. This entry proves what IS elementary: the min-entropy lower bound H(p) ≥ -log(max_i p_i) (equivalently H(p) ≥ -log M whenever every p_i ≤ M), that a deterministic distribution has zero entropy, and the resulting eigenstate case of Maassen–Uffink — when the measured state is a basis vector of the first basis (H(p) = 0) and every outcome probability in the second basis is bounded by the squared maximal overlap (q_k ≤ c²), the entropic uncertainty bound -2 log c ≤ H(p) + H(q) holds. A genuine special case of the full theorem, with no interpolation theory. Fully verified, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ03OQ02OQ01.lean",
+    "tags": [
+      "information-theory",
+      "entropy",
+      "uncertainty-principle",
+      "quantum-information",
+      "cauchy-schwarz"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 126,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. VERIFIED: compiles clean against Mathlib 4.26.0 via `lake env lean Proofs/CauchySchwarzOQ01OQ03OQ02OQ01.lean` (no errors, no warnings); `#print axioms` on maassen_uffink_eigenstate and shannonEntropy_ge_neg_log_of_max reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no Lean.ofReduceBool. Uses Mathlib's Real.negMulLog, Real.log_le_log, Real.log_pow, Finset.sum_le_sum, and nlinarith. SCOPE: this is the eigenstate (H(p) = 0) special case of Maassen–Uffink, proved from the min-entropy bound; the general-state lower bound needs Hausdorff–Young / Riesz–Thorin interpolation, which is not in Mathlib (recorded in openQuestions, as in the parent).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "dateAdded": "2026-06-27",
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Heisenberg's uncertainty principle in its variance form (Robertson 1929) is basis-dependent and degenerate for some states. Deutsch (1983) proposed an entropic formulation, H(p) + H(q) ≥ -2 ln((1+c)/2), later sharpened by Maassen and Uffink (1988) to the optimal H(p) + H(q) ≥ -2 ln c, where c = max_{j,k} |⟨a_j | b_k⟩| is the maximal overlap of the two measurement bases. The sharp constant follows from the Riesz–Thorin interpolation / Hausdorff–Young inequality. Entropic uncertainty relations are foundational in quantum information theory, underlying security proofs for quantum key distribution. The parent gallery entry formalizes the entropy ceiling H ≤ log n and notes the lower bound is interpolation-gated; this entry isolates the elementary eigenstate case, which needs only the min-entropy bound.",
+    "problemStatement": "Within the finite Shannon-entropy framework H(p) = ∑_i negMulLog(p_i), prove (i) the min-entropy lower bound: if every outcome probability satisfies p_i ≤ M (M > 0) and ∑ p_i = 1, then H(p) ≥ -log M (so in particular H(p) ≥ -log(max_i p_i)); (ii) a deterministic distribution has H = 0; and (iii) the eigenstate case of Maassen–Uffink: if p is a point mass and every q_k ≤ c² (0 < c), then -2 log c ≤ H(p) + H(q).",
+    "proofStrategy": "The pointwise inequality negMulLog_ge_mul_neg_log: for 0 ≤ x ≤ M, x·(-log M) ≤ negMulLog x = -x log x. For x = 0 both sides are 0; for x > 0, monotonicity of log (Real.log_le_log) gives log x ≤ log M, and nlinarith with the scaled inequality x·log x ≤ x·log M closes it. Summing against a probability vector and using ∑ p_i = 1 gives the min-entropy bound shannonEntropy_ge_neg_log_of_max via Finset.sum_le_sum and Finset.sum_mul. shannonEntropy_point_mass: each entry is 0 or 1, and negMulLog 0 = negMulLog 1 = 0, so the sum vanishes (Finset.sum_eq_zero). The eigenstate theorem maassen_uffink_eigenstate combines them: H(p) = 0 by the point-mass lemma, and H(q) ≥ -log(c²) = -2 log c by the min-entropy bound with M = c² (Real.log_pow turns log(c²) into 2 log c); linarith assembles -2 log c ≤ 0 + H(q).",
+    "keyInsights": [
+      "Shannon entropy is always at least the min-entropy: H(p) ≥ -log(max_i p_i). This single inequality is the elementary half of every entropic uncertainty relation and needs no interpolation theory.",
+      "The eigenstate case of Maassen–Uffink is genuinely provable now: when the state is a basis vector, H(p) = 0 and the conjugate distribution is spread out (q_k ≤ c²), so H(q) ≥ -2 log c carries the whole bound. The hard, interpolation-gated content is precisely the trade-off for non-eigenstates.",
+      "The overlap c enters only through the bound q_k ≤ c² on the conjugate outcome probabilities; squaring corresponds to Born-rule probabilities |⟨b_k | a_j⟩|², and Real.log_pow converts -log(c²) into the textbook constant -2 log c.",
+      "The pointwise lemma x·(-log M) ≤ negMulLog x is the reusable atom: summed against any sub-probability vector it yields min-entropy-type bounds, independent of the uncertainty-principle application."
+    ]
+  },
+  "sections": [
+    {
+      "id": "pointwise",
+      "title": "The Pointwise Min-Entropy Inequality",
+      "startLine": 50,
+      "endLine": 63,
+      "summary": "negMulLog_ge_mul_neg_log: for 0 ≤ x ≤ M (M > 0), x·(-log M) ≤ negMulLog x. The x = 0 case is trivial; x > 0 uses monotonicity of log and nlinarith."
+    },
+    {
+      "id": "min-entropy",
+      "title": "The Min-Entropy Lower Bound",
+      "startLine": 65,
+      "endLine": 80,
+      "summary": "shannonEntropy_ge_neg_log_of_max: if every p_i ≤ M (M > 0) and ∑ p_i = 1, then H(p) ≥ -log M. Sum the pointwise bound and use ∑ p_i = 1. With M = max p_i this is H(p) ≥ H_∞(p)."
+    },
+    {
+      "id": "point-mass",
+      "title": "Deterministic Distributions Have Zero Entropy",
+      "startLine": 82,
+      "endLine": 94,
+      "summary": "shannonEntropy_point_mass: a distribution with each entry 0 or 1 has H = 0, since negMulLog 0 = negMulLog 1 = 0."
+    },
+    {
+      "id": "eigenstate-eup",
+      "title": "The Eigenstate Case of Maassen–Uffink",
+      "startLine": 96,
+      "endLine": 122,
+      "summary": "maassen_uffink_eigenstate: p a point mass and q_k ≤ c² (0 < c) ⟹ -2 log c ≤ H(p) + H(q). Combines the point-mass and min-entropy lemmas with Real.log_pow."
+    }
+  ],
+  "conclusion": {
+    "summary": "The eigenstate case of the Maassen–Uffink entropic uncertainty principle is formalized and verified: when the measured state is a basis vector (H(p) = 0) and the conjugate outcome probabilities are bounded by the squared maximal overlap (q_k ≤ c²), the bound -2 log c ≤ H(p) + H(q) holds. The engine is the elementary min-entropy lower bound H(p) ≥ -log(max_i p_i). Fully machine-checked, 0 axioms, 0 sorries.",
+    "implications": "This converts the parent entry's entropy infrastructure into a genuine instance of the entropic uncertainty relation, isolating exactly the part that is provable without interpolation theory. The min-entropy bound is a reusable lemma for information-theoretic estimates throughout the gallery.",
+    "openQuestions": [
+      "Prove the general-state Maassen–Uffink bound H(p) + H(q) ≥ -2 ln c, which requires the Hausdorff–Young inequality / Riesz–Thorin interpolation — absent from Mathlib v4.26.0.",
+      "Formalize Deutsch's interpolation-free precursor H(p) + H(q) ≥ -2 ln((1+c)/2), a substantial but self-contained development.",
+      "Connect q_k ≤ c² to the genuine quantum setup: derive it from |⟨b_k | a_j⟩| ≤ c and the Born rule for a basis-vector state in a finite-dimensional Hilbert space."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry builds the Shannon-entropy infrastructure and the ceiling H ≤ log n, noting the lower bound is interpolation-gated. This entry proves the elementary min-entropy bound and the eigenstate case of the Maassen–Uffink lower bound."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Grandparent entry derives the Heisenberg/Robertson variance uncertainty bound from complex Cauchy–Schwarz; the entropic uncertainty principle is its basis-independent strengthening."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 126,
+    "path": "Proofs/CauchySchwarzOQ01OQ03OQ02OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 4
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry turning the parent's Shannon-entropy infrastructure into a **genuine instance of the entropic uncertainty principle**.

The parent (`cauchy-schwarz-oq-01-oq-03-oq-02`) proves the entropy ceiling `H ≤ log n` but notes the Maassen–Uffink lower bound `H(p)+H(q) ≥ -2 ln c` is gated on Riesz–Thorin / Hausdorff–Young interpolation, which Mathlib lacks. This file proves what **is** elementary.

## Theorems (4, 1 def; 0 sorries, 0 axioms)

| Name | Statement |
|---|---|
| `negMulLog_ge_mul_neg_log` | pointwise `x·(-log M) ≤ negMulLog x` for `0 ≤ x ≤ M` |
| `shannonEntropy_ge_neg_log_of_max` | min-entropy bound `H(p) ≥ -log(max_i p_i)` (Shannon ≥ min-entropy) |
| `shannonEntropy_point_mass` | a deterministic distribution has `H = 0` |
| `maassen_uffink_eigenstate` | eigenstate case `-2 log c ≤ H(p)+H(q)` when `p` is a point mass and `q_k ≤ c²` |

## Key insight

Shannon entropy always dominates the **min-entropy**: `H(p) ≥ -log(max_i p_i)`. That single elementary inequality carries the whole eigenstate uncertainty bound — when the measured state is a basis vector, `H(p) = 0` and the conjugate distribution is spread out (`q_k ≤ c²`), so `H(q) ≥ -log(c²) = -2 log c`. The hard, interpolation-gated content is exactly the trade-off for **non-eigenstates**.

## Scope

Eigenstate (`H(p) = 0`) case only. The general-state bound needs Hausdorff–Young / Riesz–Thorin interpolation (absent from Mathlib v4.26.0) and is recorded in `openQuestions`, as in the parent.

## Verification

Compiles clean against **Mathlib 4.26.0** via `lake env lean Proofs/CauchySchwarzOQ01OQ03OQ02OQ01.lean` (no errors, no warnings). `#print axioms` on `maassen_uffink_eigenstate` and `shannonEntropy_ge_neg_log_of_max` reports only `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)