### PR TITLE
Enrich Complex Gaussian Integral (area-of-circle-oq-07-oq-01): deepen annotations + conclusion

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-01/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "area-of-circle-oq-07-oq-01",
     "range": {
       "startLine": 4,
-      "endLine": 28
+      "endLine": 18
     },
     "type": "concept",
     "title": "From the Real Gaussian to the Complex Right Half-Plane",
@@ -21,6 +21,28 @@
       "complex-valued Lebesgue integral over ℝ",
       "Mathlib integral_gaussian_complex",
       "parent area-of-circle-oq-07 (real Gaussian)"
+    ]
+  },
+  {
+    "id": "ann-aoc07oq01-principal-power",
+    "proofId": "area-of-circle-oq-07-oq-01",
+    "range": {
+      "startLine": 19,
+      "endLine": 28
+    },
+    "type": "insight",
+    "title": "Why the Value Is a Principal (1/2)-Power, Not a Square Root",
+    "content": "For complex `b` the result is `(π/b)^{1/2}` interpreted as the principal `Complex.cpow`, not `√(π/b)` — there is no canonical real square root of a complex number. The principal branch is the one continuous on the slit plane `ℂ ∖ ℝ₋`, and the whole right half-plane `re b > 0` maps `π/b` into that domain, so the value is unambiguous exactly on the locus where the integral converges. The header flags that the parent's `√π` is recovered only because at `b = 1` the argument `π/1` lands on the positive real axis, where the principal power and the real square root agree. This branch-tracking is the subtlety that a naive real-to-complex generalization would miss.",
+    "mathContext": "Principal power: $z^{1/2} = e^{\\tfrac12 \\operatorname{Log} z}$ with $\\operatorname{Log}$ the principal logarithm (branch cut on $\\mathbb R_{\\le 0}$). On $z = \\pi/b$ with $\\operatorname{re} b > 0$ this is single-valued; it coincides with $\\sqrt{\\cdot}$ only when $z \\in \\mathbb R_{>0}$, i.e. $b \\in \\mathbb R_{>0}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "principal branch of cpow",
+      "complex logarithm branch cut",
+      "slit plane ℂ ∖ ℝ₋"
+    ],
+    "prerequisites": [
+      "Complex.cpow and the principal logarithm",
+      "branch cuts"
     ]
   },
   {
@@ -49,12 +71,33 @@
     "proofId": "area-of-circle-oq-07-oq-01",
     "range": {
       "startLine": 40,
-      "endLine": 60
+      "endLine": 44
     },
     "type": "technique",
     "title": "Recovering √π as the b = 1 Case",
-    "content": "`gaussian_integral_eq_sqrt_pi_via_complex` derives the parent's real value `∫_ℝ e^{-x²} dx = √π` from the complex result at `b = 1`. The proof has two casting steps. `hLcast` identifies the real integral with its complex image: since the integrand is real-valued, `integral_complex_ofReal` moves the `ℂ`-coercion outside the integral, and pointwise `↑(e^{-x²}) = e^{-1·(↑x)²}` by `Complex.ofReal_exp` plus `push_cast; ring` on the exponent. `hRcast` collapses the principal power: `Real.sqrt_eq_rpow` writes `√π = π^{1/2}` (real rpow), `Complex.ofReal_cpow π_nonneg` turns `↑(π^{1/2})` into `(↑π)^{(1/2 : ℂ)}`, matching `(π/1)^{1/2}`. Rewriting both sides of the specialized hypothesis and `exact_mod_cast` finishes.",
-    "mathContext": "The non-trivial part of relating a complex statement to a real one is precisely the two identifications performed here: that a real-valued integral equals the real part of (here, the `ℂ`-coercion of) its complex form, and that a complex principal `(1/2)`-power of a positive real equals that real's square root. Both are exactly where a careless 'just set b = 1' would go wrong.",
+    "content": "`gaussian_integral_eq_sqrt_pi_via_complex` derives the parent's real value `∫_ℝ e^{-x²} dx = √π` from the complex result specialized at `b = 1` (the hypothesis `0 < re 1` discharged by `simp`). The recovery is not a syntactic substitution: the complex theorem speaks about a `ℂ`-valued integrand and a `Complex.cpow` value, while the parent is a statement about a real integral and a real `Real.sqrt`. Two genuine identifications bridge the gap, performed in the `hLcast` and `hRcast` steps.",
+    "mathContext": "$\\int_{\\mathbb R} e^{-x^2}\\,dx = \\sqrt{\\pi}$ is the $b = 1$ slice of $\\int_{\\mathbb R} e^{-b x^2}\\,dx = (\\pi/b)^{1/2}$, reached by pushing the real integral through $\\mathbb C$ and reducing $(\\pi/1)^{1/2}$ to $(\\sqrt\\pi : \\mathbb C)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "specialization b = 1",
+      "real vs complex statement",
+      "parent recovery"
+    ],
+    "prerequisites": [
+      "gaussian_integral_complex"
+    ]
+  },
+  {
+    "id": "ann-aoc07oq01-casting",
+    "proofId": "area-of-circle-oq-07-oq-01",
+    "range": {
+      "startLine": 45,
+      "endLine": 60
+    },
+    "type": "technique",
+    "title": "The Two Casting Steps",
+    "content": "The proof's substance is two casts. `hLcast` identifies the real integral with its complex image: since the integrand is real-valued, `integral_complex_ofReal` moves the `ℂ`-coercion outside the integral, and pointwise `↑(e^{-x²}) = e^{-1·(↑x)²}` follows from `Complex.ofReal_exp` plus `push_cast; ring` on the exponent. `hRcast` collapses the principal power: `Real.sqrt_eq_rpow` writes `√π = π^{1/2}` (real rpow), then `Complex.ofReal_cpow π_nonneg` turns `↑(π^{1/2})` into `(↑π)^{(1/2 : ℂ)}`, matching `(π/1)^{1/2}`. Rewriting both sides of the specialized hypothesis and `exact_mod_cast` finishes — and these are exactly the places a careless 'just set b = 1' would silently go wrong.",
+    "mathContext": "Coercion-pushing: $\\big(\\!\\int_{\\mathbb R} e^{-x^2}\\big)_{\\mathbb C} = \\int_{\\mathbb R}\\big(e^{-x^2}\\big)_{\\mathbb C}$ via `integral_complex_ofReal`. Power-collapse: $\\big(\\sqrt\\pi\\big)_{\\mathbb C} = (\\pi)^{1/2}_{\\mathbb C}$ via `Real.sqrt_eq_rpow` + `Complex.ofReal_cpow`.",
     "significance": "supporting",
     "relatedConcepts": [
       "integral_complex_ofReal",
@@ -63,9 +106,9 @@
       "exact_mod_cast"
     ],
     "prerequisites": [
-      "gaussian_integral_complex",
       "Complex.ofReal_exp",
-      "Complex.ofReal_cpow"
+      "Complex.ofReal_cpow",
+      "push_cast / exact_mod_cast"
     ]
   }
 ]

--- a/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
@@ -34,6 +34,13 @@
   },
   "sections": [
     {
+      "id": "open-question-context",
+      "title": "Open Question & Analytic-Continuation Context",
+      "startLine": 4,
+      "endLine": 28,
+      "summary": "The module docstring states the open question — extend the real Gaussian ∫_ℝ e^{-x²} = √π (the b = 1 parent) to complex b with 0 < re b — and answers YES via Mathlib's integral_gaussian_complex. It frames the move to complex b as the analytic continuation into the right half-plane {re b > 0} underlying the Fresnel oscillatory integrals, and notes the value is now a principal (1/2)-power rather than a real square root."
+    },
+    {
       "id": "complex-gaussian",
       "title": "The Complex Gaussian Integral",
       "startLine": 32,
@@ -141,7 +148,9 @@
     "summary": "The Gaussian integral extends from the real line to the complex right half-plane: for every b : ℂ with 0 < re b, ∫_ℝ e^{-b x²} dx = (π/b)^{1/2}. This is Mathlib's integral_gaussian_complex, restated as gaussian_integral_complex. The parent's real value ∫_ℝ e^{-x²} dx = √π is recovered as the b = 1 specialization in gaussian_integral_eq_sqrt_pi_via_complex: the integrand is real-valued, so the real integral pushes through ℂ via integral_complex_ofReal, and the complex principal power (π/1)^{1/2} collapses to (√π : ℂ) via Complex.ofReal_cpow and Real.sqrt_eq_rpow. 60 lines, 2 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
     "implications": "The genuine content is the move to complex b: the value (π/b)^{1/2} is a complex principal power, not a real square root, and it is the analytic continuation that connects the (absolutely convergent) Gaussian regime re b > 0 to the conditionally convergent Fresnel oscillatory integrals on the boundary re b = 0. The bridge theorem shows this complex result strictly subsumes the parent, with the real √π emerging as the on-axis b = 1 value. The hard analytic work — differentiating under the integral and the polar-coordinate evaluation — lives inside Mathlib's integral_gaussian_complex; this entry's contribution is the explicit parent-recovery cast, which is the non-trivial part of connecting the complex statement to the real one.",
     "openQuestions": [
-      "Take re b → 0⁺ along b = a + i t to recover the Fresnel integrals ∫ cos(t x²), ∫ sin(t x²) from gaussian_integral_complex."
+      "Take re b → 0⁺ along b = a + i t to recover the Fresnel integrals ∫ cos(t x²), ∫ sin(t x²) from gaussian_integral_complex.",
+      "Generalize to the shifted (completing-the-square) Gaussian ∫_ℝ e^{-b x² + c x} dx = (π/b)^{1/2} e^{c²/(4b)} for b, c : ℂ with 0 < re b, and identify it with the relevant Mathlib lemma — this is the form that directly yields the Fourier transform of the Gaussian.",
+      "Specialize c = -2π i ξ in the shifted Gaussian to formalize that the Gaussian e^{-π x²} is its own Fourier transform (the eigenfunction property), connecting this entry to the Fourier-analytic side of the gallery."
     ]
   }
 }


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-01` (The Complex Gaussian Integral $(\pi/b)^{1/2}$).

Already a solid entry (structured overview, full conclusion, 2 crossRefs) but light on annotation coverage (3) and open questions (1). This pass deepens both without padding — the 60-line / 2-theorem file genuinely subdivides into 5 distinct ideas.

## Changes
- **Annotations 3 → 5**, tiling the file by distinct purpose (all with mathContext/significance/relatedConcepts/prerequisites; resolver **Valid 5, Misaligned 0**):
  - NEW *Why the Value Is a Principal (1/2)-Power, Not a Square Root* — the `Complex.cpow` branch-cut subtlety on the slit plane, and why $b=1$ is where it meets $\sqrt{\cdot}$
  - NEW *The Two Casting Steps* — the `integral_complex_ofReal` coercion-push and the `Real.sqrt_eq_rpow`/`Complex.ofReal_cpow` power-collapse that bridge the complex statement to the real parent
  - existing three refocused (complex right half-plane generalization, `integral_gaussian_complex` restatement, $b=1$ recovery strategy)
- **Sections 2 → 3**: added a context section covering the docstring open-question / analytic-continuation framing
- **Open questions 1 → 3**: added the shifted/completing-the-square Gaussian $\to$ Fourier transform, and the Gaussian-as-Fourier-eigenfunction direction

## Verification
- JSON valid; resolver Valid 5 / Misaligned 0; `meta.json` within the 60 KB cap
- No status/badge/axiomCount change (entry remains `verified`, 0 axioms)
- Pre-PR freshness re-check passed (new content absent on origin/main at push)