### PR TITLE
Enrich Squared Complex Gaussian (area-of-circle-oq-07-oq-04): deepen annotations + conclusion

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-04/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04/annotations.json
@@ -4,23 +4,46 @@
     "proofId": "area-of-circle-oq-07-oq-04",
     "range": {
       "startLine": 4,
-      "endLine": 30
+      "endLine": 19
     },
     "type": "concept",
     "title": "Squaring Removes the Branch Cut",
-    "content": "The sibling `area-of-circle-oq-07-oq-01` evaluates the complex Gaussian `∫_ℝ e^{-b x²} dx = (π/b)^{1/2}`, a genuine complex principal `(1/2)`-power. This entry observes that its **square** is far simpler: `(∫_ℝ e^{-b x²} dx)² = π/b`, with no fractional power. Over the right half-plane `{b : ℂ | re b > 0}` the base `π/b` is nonzero, so the two half-powers add cleanly. This is the complex-parameter form of the classical two-dimensional identity `(∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} = π` that computes the Gaussian (and, in the parent, the area of a circle).",
+    "content": "The sibling `area-of-circle-oq-07-oq-01` evaluates the complex Gaussian `∫_ℝ e^{-b x²} dx = (π/b)^{1/2}`, a genuine complex principal `(1/2)`-power. This entry observes that its **square** is far simpler: `(∫_ℝ e^{-b x²} dx)² = π/b`, with no fractional power. Over the right half-plane `{b : ℂ | re b > 0}` the base `π/b` is nonzero, so the two half-powers add cleanly to a single-valued rational function of `b`, free of the branch subtlety that the lone integral carries.",
     "mathContext": "The one-dimensional value $(\\pi/b)^{1/2}$ is single-valued only after fixing the principal branch of the complex power, and on the boundary $\\operatorname{re} b = 0$ that branch governs the Fresnel phase. Its square $\\pi/b$ is a single-valued rational function of $b$ on the half-plane, which is why downstream normalization constants are stated in terms of the square.",
     "significance": "key",
     "relatedConcepts": [
       "complex Gaussian integral",
       "principal complex power",
-      "two-dimensional squaring trick",
-      "branch cut"
+      "branch cut",
+      "single-valued rational function"
     ],
     "prerequisites": [
       "complex-valued Lebesgue integral over ℝ",
       "Mathlib integral_gaussian_complex",
       "sibling area-of-circle-oq-07-oq-01 (the complex Gaussian value)"
+    ]
+  },
+  {
+    "id": "ann-aoc07oq04-2dtrick",
+    "proofId": "area-of-circle-oq-07-oq-04",
+    "range": {
+      "startLine": 20,
+      "endLine": 30
+    },
+    "type": "insight",
+    "title": "The Classical 2-D Gaussian Trick, Complexified",
+    "content": "The clean value `π/b` is the complex-parameter form of the most famous trick in elementary analysis: `(∫_ℝ e^{-x²} dx)² = ∫∫_{ℝ²} e^{-(x²+y²)} dx dy = π`, evaluated by switching to polar coordinates — the very computation that links the Gaussian to the *area of a circle* in the parent `area-of-circle-oq-07`. Here the square is obtained algebraically (squaring the known 1-D value via `Complex.cpow_add`) rather than by a 2-D Fubini/polar argument, but it lands on the same rational answer, now tracked uniformly across the whole right half-plane. The parent's real `(∫ e^{-x²})² = π` is the on-axis `b = 1` slice.",
+    "mathContext": "$\\Big(\\int_{\\mathbb R} e^{-bx^2}dx\\Big)^2 = \\int_{\\mathbb R^2} e^{-b(x^2+y^2)}\\,dx\\,dy = \\int_0^{2\\pi}\\!\\!\\int_0^\\infty e^{-br^2} r\\,dr\\,d\\theta = \\frac{\\pi}{b}$, the polar evaluation whose $b=1$ case gives $\\pi$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "two-dimensional squaring trick",
+      "polar coordinates",
+      "Fubini's theorem",
+      "area of a circle"
+    ],
+    "prerequisites": [
+      "double integrals and polar coordinates",
+      "parent area-of-circle-oq-07"
     ]
   },
   {
@@ -51,22 +74,43 @@
     "proofId": "area-of-circle-oq-07-oq-04",
     "range": {
       "startLine": 47,
-      "endLine": 64
+      "endLine": 49
     },
     "type": "technique",
     "title": "Recovering π as the b = 1 Case",
-    "content": "`gaussian_integral_sq_eq_pi` derives the parent's real value `(∫_ℝ e^{-x²} dx)² = π` from the complex result at `b = 1`. The cast `hLcast` identifies the real integral with its complex image: since the integrand is real-valued, `integral_complex_ofReal` moves the `ℂ`-coercion outside the integral, and pointwise `↑(e^{-x²}) = e^{-1·(↑x)²}` by `Complex.ofReal_exp` plus `push_cast; ring`. With `π/1` simplified to `π` by `div_one`, rewriting the hypothesis and `exact_mod_cast` finishes.",
-    "mathContext": "The squared statement is what the parent `area-of-circle-oq-07` actually computes en route to `√π`: the two-dimensional Gaussian integral equals `π` directly, and the square root is extracted afterward. Recovering `π` (rather than `√π`) at `b = 1` makes this entry the faithful complex lift of the parent's central computation.",
+    "content": "`gaussian_integral_sq_eq_pi` derives the parent's real value `(∫_ℝ e^{-x²} dx)² = π` from the complex result specialized at `b = 1`. Because the squared statement evaluates to `π` (not `√π`), recovering it at `b = 1` makes this entry the faithful complex lift of the parent's *central* computation — the one the parent then takes a square root of. The hypothesis `0 < re 1` is discharged by `simp` and `π/1` simplifies to `π` via `div_one`.",
+    "mathContext": "The squared statement is what the parent `area-of-circle-oq-07` actually computes en route to `√π`: the two-dimensional Gaussian integral equals `π` directly, and the square root is extracted afterward.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "specialization b = 1",
+      "div_one",
+      "parent central computation"
+    ],
+    "prerequisites": [
+      "gaussian_integral_complex_sq"
+    ]
+  },
+  {
+    "id": "ann-aoc07oq04-casting",
+    "proofId": "area-of-circle-oq-07-oq-04",
+    "range": {
+      "startLine": 50,
+      "endLine": 64
+    },
+    "type": "technique",
+    "title": "The Real-to-Complex Cast",
+    "content": "The recovery's substance is the `hLcast` step identifying the real integral with its complex image: since the integrand is real-valued, `integral_complex_ofReal` moves the `ℂ`-coercion outside the integral, and pointwise `↑(e^{-x²}) = e^{-1·(↑x)²}` follows from `Complex.ofReal_exp` plus `push_cast; ring` on the exponent. After `div_one` simplifies `π/1` to `π`, rewriting the specialized hypothesis with `← hLcast` and `exact_mod_cast` transfers the complex equality back to ℝ. This is the same coercion-pushing pattern as the sibling oq-07-oq-01, minus the principal-power collapse (already handled by the squaring).",
+    "mathContext": "Coercion-pushing: $\\big(\\!\\int_{\\mathbb R} e^{-x^2}\\big)_{\\mathbb C} = \\int_{\\mathbb R}\\big(e^{-x^2}\\big)_{\\mathbb C}$ via `integral_complex_ofReal`, then $\\exact\\_mod\\_cast$ on $(\\,\\cdot\\,)^2 = \\pi$.",
     "significance": "supporting",
     "relatedConcepts": [
       "integral_complex_ofReal",
       "Complex.ofReal_exp",
-      "div_one",
-      "exact_mod_cast"
+      "exact_mod_cast",
+      "push_cast"
     ],
     "prerequisites": [
-      "gaussian_integral_complex_sq",
-      "Complex.ofReal_exp"
+      "Complex.ofReal_exp",
+      "push_cast / exact_mod_cast"
     ]
   }
 ]

--- a/src/data/proofs/area-of-circle-oq-07-oq-04/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04/meta.json
@@ -34,6 +34,13 @@
   },
   "sections": [
     {
+      "id": "open-question-context",
+      "title": "Open Question & the Two-Dimensional Trick",
+      "startLine": 4,
+      "endLine": 30,
+      "summary": "The module docstring poses the open question — formalize that the square of the complex Gaussian (∫_ℝ e^{-b x²})² is the clean rational value π/b for 0 < re b — and answers YES. It explains that squaring removes the principal-(1/2)-power branch subtlety and identifies π/b as the complex-parameter form of the classical 2-D trick (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} = π underlying the parent area-of-circle-oq-07."
+    },
+    {
       "id": "squared-complex",
       "title": "The Squared Complex Gaussian Integral",
       "startLine": 34,
@@ -140,7 +147,9 @@
     "summary": "Squaring the complex Gaussian removes the branch-cut subtlety of the principal (1/2)-power: for every b : ℂ with 0 < re b, (∫_ℝ e^{-b x²} dx)² = π/b. The integral itself is (π/b)^{1/2} (sibling area-of-circle-oq-07-oq-01, Mathlib's integral_gaussian_complex), and because π/b is nonzero on the right half-plane, Complex.cpow_add collapses (π/b)^{1/2} · (π/b)^{1/2} = (π/b)^{1/2+1/2} = (π/b)^1 = π/b. The parent's real value (∫_ℝ e^{-x²})² = π is the b = 1 case, recorded in gaussian_integral_sq_eq_pi via integral_complex_ofReal and π/1 = π. 64 lines, 2 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
     "implications": "The clean value π/b — with no fractional power — is the complex-parameter analogue of the classical two-dimensional trick (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} = π that underlies the area-of-a-circle computation. Where the one-dimensional integral carries a genuine complex (1/2)-power that must be tracked through its branch cut, the square is single-valued and rational in b. This makes the squared form the natural object for downstream identities (normalization constants of complex Gaussians, Fresnel-integral products on the boundary re b → 0).",
     "openQuestions": [
-      "Prove (∫_ℝ e^{-b x²})² = ∫_{ℝ²} e^{-b(x²+y²)} by Fubini and polar coordinates, exhibiting π/b as the literal two-dimensional area integral."
+      "Prove (∫_ℝ e^{-b x²})² = ∫_{ℝ²} e^{-b(x²+y²)} by Fubini and polar coordinates, exhibiting π/b as the literal two-dimensional area integral.",
+      "Generalize to n dimensions: (∫_ℝ e^{-b x²})ⁿ = ∫_{ℝⁿ} e^{-b|x|²} = (π/b)^{n/2}, where the n-fold product of half-powers again collapses cleanly only on the right half-plane — and connect the n = 2 case back to the area-of-circle computation.",
+      "Use the squared identity as a normalization to formalize the complex Gaussian probability density and its second moment ∫ x² e^{-b x²} = (1/2b)(π/b)^{1/2}, obtained by differentiating gaussian_integral_complex in the parameter b."
     ]
   }
 }


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-04` (The Squared Complex Gaussian Integral $(\int e^{-bx^2})^2 = \pi/b$).

Sibling of oq-07-oq-01 with the same shape: solid meta, but light annotation coverage (3) and a single open question. Deepened without padding — the file's distinct ideas support 5 annotations.

## Changes
- **Annotations 3 → 5** (all with mathContext/significance/relatedConcepts/prerequisites; resolver **Valid 5, Misaligned 0**):
  - NEW *The Classical 2-D Gaussian Trick, Complexified* — $\pi/b$ as the complex-parameter form of $(\int e^{-x^2})^2 = \iint e^{-(x^2+y^2)} = \pi$, the polar computation underlying the parent's area-of-circle link
  - NEW *The Real-to-Complex Cast* — the `integral_complex_ofReal` coercion-push in the $b=1$ recovery
  - existing three refocused (branch-cut removal, `Complex.cpow_add` collapse, $b=1$ recovery strategy)
- **Sections 2 → 3**: added the docstring open-question / 2-D-trick context section
- **Open questions 1 → 3**: added the $n$-dimensional $(\pi/b)^{n/2}$ generalization and the second-moment-by-differentiation direction

## Verification
- JSON valid; resolver Valid 5 / Misaligned 0; within the 60 KB cap; no status/axiom change (remains `verified`/badge `mathlib`, 0 axioms)
- Pre-PR freshness re-check passed