### PR TITLE
research(abel-ruffini-oq-06): solvable side of Sₙ threshold — Aₙ→Sₙ reduction + S₂, S₃ solvable [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ06.lean
+++ b/proofs/Proofs/AbelRuffiniOQ06.lean
@@ -1,0 +1,94 @@
+import Mathlib
+
+/-
+# Abel–Ruffini: the solvable side of the symmetric-group threshold
+
+The group-theoretic heart of the Abel–Ruffini theorem is the dichotomy
+
+> `Sₙ` is solvable **iff** `n ≤ 4`.
+
+The non-solvable half (`n ≥ 5`) is Mathlib's `Equiv.Perm.fin_5_not_solvable`,
+generalized to all `n ≥ 5` in `AbelRuffiniObstructionOQ06.lean`. This file
+supplies the **positive** half — the solvable cases — which Mathlib does *not*
+package: there is no Mathlib lemma asserting `IsSolvable (Equiv.Perm (Fin n))`
+for `n ∈ {3, 4}`.
+
+## What is proved here
+
+* `permSolvable_of_alternatingSolvable` — a reusable **reduction**: `Sₙ` is
+  solvable as soon as the alternating group `Aₙ` is, because `Aₙ = ker (sign)` is
+  a normal subgroup of `Sₙ` with abelian quotient (`Sₙ / Aₙ ↪ ℤˣ`). This is the
+  short exact sequence `1 → Aₙ → Sₙ → ℤˣ` packaged through
+  `solvable_of_ker_le_range`.
+* `permFinTwo_isSolvable`, `permFinThree_isSolvable` — `S₂` and `S₃` are solvable.
+  Both alternating groups here have prime order (`1` and `3`), hence are cyclic,
+  hence abelian, hence solvable; the reduction then lifts solvability to the full
+  symmetric group.
+
+Combined with the `n ≥ 5` non-solvability, these complete the threshold for every
+`n` except the single remaining case `S₄` (whose alternating group `A₄` of order
+12 needs the Klein-four normal subgroup `V₄ ⊴ A₄`); that case is isolated in the
+companion `AbelRuffiniOQ06Aristotle.lean`.
+
+## Scope
+
+This is the *characteristic-independent core*. The title's characteristic-`p` /
+Abhyankar angle (fundamental groups of curves in positive characteristic —
+Raynaud/Harbater) is deep, unformalized theory and out of scope.
+-/
+
+namespace AbelRuffiniOQ06
+
+open Equiv
+
+/-!
+## The reduction `Aₙ solvable ⟹ Sₙ solvable`
+-/
+
+/--
+**Reduction lemma.** If the alternating group `Aₙ = alternatingGroup (Fin n)` is
+solvable, then the full symmetric group `Sₙ = Equiv.Perm (Fin n)` is solvable.
+
+The alternating group is the kernel of the sign homomorphism
+`Equiv.Perm.sign : Sₙ →* ℤˣ`, so we have a short exact sequence
+`1 → Aₙ → Sₙ → ℤˣ` with abelian (hence solvable) quotient. Solvability of an
+extension of a solvable group by a solvable group is `solvable_of_ker_le_range`.
+-/
+theorem permSolvable_of_alternatingSolvable (n : ℕ)
+    [IsSolvable (alternatingGroup (Fin n))] :
+    IsSolvable (Equiv.Perm (Fin n)) :=
+  solvable_of_ker_le_range (alternatingGroup (Fin n)).subtype Equiv.Perm.sign
+    (by rw [Subgroup.range_subtype]; exact alternatingGroup_eq_sign_ker.ge)
+
+/-!
+## `A₂` and `A₃` are solvable (prime order ⟹ cyclic ⟹ abelian)
+-/
+
+/-- The alternating group `A₃` is cyclic of order `3`, hence solvable. -/
+instance alternatingFinThree_isSolvable : IsSolvable (alternatingGroup (Fin 3)) := by
+  haveI : Fact (Nat.Prime 3) := ⟨by norm_num⟩
+  have hcard : Nat.card (alternatingGroup (Fin 3)) = 3 := by
+    rw [nat_card_alternatingGroup, Nat.card_eq_fintype_card, Fintype.card_fin]; rfl
+  haveI : IsCyclic (alternatingGroup (Fin 3)) := isCyclic_of_prime_card hcard
+  exact isSolvable_of_comm fun a b => (IsCyclic.commutative).comm a b
+
+/-- The alternating group `A₂` is trivial of order `1`, hence solvable. -/
+instance alternatingFinTwo_isSolvable : IsSolvable (alternatingGroup (Fin 2)) := by
+  have hcard : Fintype.card (alternatingGroup (Fin 2)) = 1 := by
+    rw [card_alternatingGroup, Fintype.card_fin]; rfl
+  haveI : Subsingleton (alternatingGroup (Fin 2)) := Fintype.card_le_one_iff_subsingleton.mp hcard.le
+  infer_instance
+
+/-!
+## `S₂` and `S₃` are solvable
+-/
+
+/-- `S₂ = Equiv.Perm (Fin 2)` is solvable. -/
+theorem permFinTwo_isSolvable : IsSolvable (Equiv.Perm (Fin 2)) :=
+  permSolvable_of_alternatingSolvable 2
+
+/-- `S₃ = Equiv.Perm (Fin 3)` is solvable. -/
+theorem permFinThree_isSolvable : IsSolvable (Equiv.Perm (Fin 3)) :=
+  permSolvable_of_alternatingSolvable 3
+
+end AbelRuffiniOQ06

--- a/proofs/Proofs/AbelRuffiniOQ06Aristotle.lean
+++ b/proofs/Proofs/AbelRuffiniOQ06Aristotle.lean
@@ -1,0 +1,39 @@
+import Mathlib
+
+/-
+# Abel–Ruffini OQ-06 — companion: the remaining S₄ / A₄ case
+
+The verified file `AbelRuffiniOQ06.lean` proves the reduction
+`Aₙ solvable ⟹ Sₙ solvable` and settles `S₂`, `S₃`. The only symmetric group
+below the n ≥ 5 non-solvability threshold not yet closed is `S₄`, which by the
+reduction needs solvability of the alternating group `A₄` (order 12).
+
+`A₄` is solvable because it has the Klein-four normal subgroup
+`V₄ = {1, (12)(34), (13)(24), (14)(23)}` with abelian quotient `A₄ / V₄ ≅ ℤ/3`.
+Equivalently, its derived series is `A₄ ⊳ V₄ ⊳ 1`.
+
+This companion isolates that single fact for proof search.
+-/
+
+namespace AbelRuffiniOQ06Aristotle
+
+open Equiv
+
+/-- Reduction (proved in the verified file, restated here standalone): if the
+alternating group is solvable then the full symmetric group is solvable. -/
+theorem permSolvable_of_alternatingSolvable (n : ℕ)
+    [IsSolvable (alternatingGroup (Fin n))] :
+    IsSolvable (Equiv.Perm (Fin n)) :=
+  solvable_of_ker_le_range (alternatingGroup (Fin n)).subtype Equiv.Perm.sign
+    (by rw [Subgroup.range_subtype]; exact alternatingGroup_eq_sign_ker.ge)
+
+/-- The alternating group `A₄` is solvable (derived series `A₄ ⊳ V₄ ⊳ 1`). -/
+theorem alternatingFinFour_isSolvable : IsSolvable (alternatingGroup (Fin 4)) := by
+  sorry
+
+/-- `S₄ = Equiv.Perm (Fin 4)` is solvable. -/
+theorem permFinFour_isSolvable : IsSolvable (Equiv.Perm (Fin 4)) := by
+  haveI := alternatingFinFour_isSolvable
+  exact permSolvable_of_alternatingSolvable 4
+
+end AbelRuffiniOQ06Aristotle

--- a/research/problems/abel-ruffini-oq-06/knowledge.md
+++ b/research/problems/abel-ruffini-oq-06/knowledge.md
@@ -53,3 +53,47 @@ positive-characteristic theory of fundamental groups of curves
   machinery in Mathlib.
 - Settled on the uniform `n ≥ 5` non-solvability + abstract radical criterion,
   which are certain to compile and capture the genuine mathematical obstruction.
+
+## Session 2026-06-27 (researcher-8) — solvable side of the threshold
+
+**Mode**: FRESH · **Outcome**: progress (verified, 0-axiom)
+
+New file `proofs/Proofs/AbelRuffiniOQ06.lean`, namespace `AbelRuffiniOQ06`,
+0 axioms / 0 sorries (single-file checked with `lake env lean`; `#print axioms`
+shows only `propext`/`Classical.choice`/`Quot.sound`):
+
+| Theorem | Statement |
+|---|---|
+| `permSolvable_of_alternatingSolvable` | `[IsSolvable (alternatingGroup (Fin n))] → IsSolvable (Equiv.Perm (Fin n))` |
+| `alternatingFinThree_isSolvable` | `IsSolvable (alternatingGroup (Fin 3))` (order 3, cyclic) |
+| `alternatingFinTwo_isSolvable` | `IsSolvable (alternatingGroup (Fin 2))` (trivial) |
+| `permFinTwo_isSolvable` | `IsSolvable (Equiv.Perm (Fin 2))` |
+| `permFinThree_isSolvable` | `IsSolvable (Equiv.Perm (Fin 3))` |
+
+This **directly answers open question 2** of the sibling entry
+`abel-ruffini-obstruction-oq-06` ("formalize solvability of S₃ and S₄"),
+closing `n = 3` and reducing `n = 4` to a single fact.
+
+### Key Mathlib facts used
+- `solvable_of_ker_le_range` — solvability transfers across `1 → A → G → B` when
+  `ker(g) ≤ range(f)` and `A`, `B` solvable. Used with `f = (Aₙ).subtype`,
+  `g = Equiv.Perm.sign`, `B = ℤˣ` (abelian).
+- `alternatingGroup_eq_sign_ker` : `alternatingGroup α = sign.ker`. The kernel
+  hypothesis collapses to `Aₙ ≤ Aₙ` after `Subgroup.range_subtype`.
+- `nat_card_alternatingGroup` : `Nat.card (Aₙ) = (Nat.card α)!/2` (note the RHS
+  uses `Nat.card`, so chase with `Nat.card_eq_fintype_card, Fintype.card_fin`).
+- `isCyclic_of_prime_card` (wants `Nat.card`, not `Fintype.card`!),
+  `IsCyclic.commutative`, `isSolvable_of_comm`.
+
+### Remaining gap — S₄ / A₄
+`S₄ solvable ⟺ A₄ solvable` via the reduction. `A₄` (order 12) is solvable by
+`A₄ ⊳ V₄ ⊳ 1` (Klein-four normal subgroup, quotient `ℤ/3`). Mathlib has no
+`A₄`-solvable lemma and only a TODO toward `V₄ ⊴ A₄` in
+`SpecificGroups/KleinFour.lean`. Isolated as a `sorry` in companion
+`proofs/Proofs/AbelRuffiniOQ06Aristotle.lean` and submitted to Aristotle.
+
+### Environment notes
+- Docker build infeasible this session (daemon hung, `docker ps` → rc 124; disk
+  ~84%). Verified via `LAKE_UNSAFE=1 lake env lean Proofs/AbelRuffiniOQ06.lean`
+  (single-file elaboration against prebuilt Mathlib oleans — bounded memory,
+  NOT `lake build`).

--- a/src/data/proofs/abel-ruffini-oq-06/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-06/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-reduction",
+    "proofId": "abel-ruffini-oq-06",
+    "range": { "startLine": 57, "endLine": 61 },
+    "type": "theorem",
+    "title": "Reduction: Aₙ Solvable ⟹ Sₙ Solvable",
+    "content": "The reusable engine of this file. The sign homomorphism $\\mathrm{sign} : S_n \\to \\mathbb{Z}^\\times$ has kernel exactly the alternating group $A_n$ (`alternatingGroup_eq_sign_ker`) and abelian codomain $\\mathbb{Z}^\\times$. So $1 \\to A_n \\to S_n \\to \\mathbb{Z}^\\times$ is an extension of $A_n$ by an abelian group. Feeding the inclusion $A_n \\hookrightarrow S_n$ and $\\mathrm{sign}$ into `solvable_of_ker_le_range` — whose hypothesis $\\ker(\\mathrm{sign}) \\le \\mathrm{range}(\\text{inclusion})$ collapses to $A_n \\le A_n$ after `Subgroup.range_subtype` and the sign-kernel identity — yields $S_n$ solvable from $A_n$ solvable. Mathlib provides the sign-kernel identification but not this solvability transfer.",
+    "mathContext": "$\\mathrm{IsSolvable}(A_n) \\Rightarrow \\mathrm{IsSolvable}(S_n)$, via the short exact sequence $1 \\to A_n \\to S_n \\to \\mathbb{Z}^\\times$.",
+    "significance": "key",
+    "relatedConcepts": ["Solvable group", "Short exact sequence", "Sign homomorphism", "Alternating group", "Group extension"],
+    "prerequisites": ["solvability is closed under extensions", "ker(sign) = Aₙ", "solvable_of_ker_le_range"]
+  },
+  {
+    "id": "ann-a3-solvable",
+    "proofId": "abel-ruffini-oq-06",
+    "range": { "startLine": 67, "endLine": 73 },
+    "type": "theorem",
+    "title": "A₃ Solvable (Prime Order ⟹ Cyclic)",
+    "content": "The alternating group $A_3$ has order $|A_3| = 3!/2 = 3$ (`nat_card_alternatingGroup`). Since $3$ is prime, the group is cyclic (`isCyclic_of_prime_card`), hence commutative (`IsCyclic.commutative`), hence solvable (`isSolvable_of_comm`). No permutation-specific reasoning is needed once the order is computed — arithmetic alone forces solvability.",
+    "mathContext": "$|A_3| = 3$ prime $\\Rightarrow A_3$ cyclic $\\Rightarrow$ abelian $\\Rightarrow$ solvable.",
+    "significance": "important",
+    "relatedConcepts": ["Cyclic group", "Prime order group", "Alternating group A₃"],
+    "prerequisites": ["a group of prime order is cyclic", "cyclic ⟹ abelian", "card of alternating group"]
+  },
+  {
+    "id": "ann-a2-solvable",
+    "proofId": "abel-ruffini-oq-06",
+    "range": { "startLine": 75, "endLine": 80 },
+    "type": "theorem",
+    "title": "A₂ Solvable (Trivial Group)",
+    "content": "The alternating group $A_2$ has order $|A_2| = 2!/2 = 1$, so it is a subsingleton and therefore solvable by the subsingleton instance. This is the degenerate endpoint that the reduction lifts to $S_2$.",
+    "mathContext": "$|A_2| = 1 \\Rightarrow A_2$ trivial $\\Rightarrow$ solvable.",
+    "significance": "supporting",
+    "relatedConcepts": ["Trivial group", "Subsingleton", "Alternating group A₂"],
+    "prerequisites": ["subsingleton groups are solvable", "card of alternating group"]
+  },
+  {
+    "id": "ann-s3-solvable",
+    "proofId": "abel-ruffini-oq-06",
+    "range": { "startLine": 86, "endLine": 92 },
+    "type": "theorem",
+    "title": "S₂ and S₃ Solvable",
+    "content": "Applying the reduction to the base cases delivers the $n = 2$ and $n = 3$ solvable instances of the Abel–Ruffini threshold: `permFinTwo_isSolvable` and `permFinThree_isSolvable`. The $n = 3$ case is the one Mathlib does not provide; together with the $n \\ge 5$ non-solvability of `abel-ruffini-obstruction-oq-06`, the only symmetric group whose solvability is still open is $S_4$ — now reduced to the single fact that $A_4$ is solvable.",
+    "mathContext": "$\\mathrm{IsSolvable}(S_2)$ and $\\mathrm{IsSolvable}(S_3)$.",
+    "significance": "key",
+    "relatedConcepts": ["Symmetric group S₃", "Abel–Ruffini threshold", "Solvable group"],
+    "prerequisites": ["the Aₙ → Sₙ reduction", "solvability of A₂, A₃"]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-06/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-06/meta.json
@@ -1,0 +1,119 @@
+{
+  "id": "abel-ruffini-oq-06",
+  "title": "Abel–Ruffini Threshold, Solvable Side: S₂ and S₃ are Solvable via the Aₙ → Sₙ Reduction",
+  "slug": "abel-ruffini-oq-06",
+  "description": "The group-theoretic core of Abel–Ruffini is the dichotomy 'Sₙ is solvable ⟺ n ≤ 4'. The non-solvable half (n ≥ 5) is Mathlib's Equiv.Perm.fin_5_not_solvable (generalized in abel-ruffini-obstruction-oq-06); the positive half is not packaged by Mathlib at all. This file supplies the reusable reduction permSolvable_of_alternatingSolvable: Sₙ is solvable whenever the alternating group Aₙ is, because Aₙ = ker(sign) is normal in Sₙ with abelian quotient (Sₙ/Aₙ ↪ ℤˣ) — the short exact sequence 1 → Aₙ → Sₙ → ℤˣ routed through solvable_of_ker_le_range. It then closes the small cases: A₂ (order 1) and A₃ (order 3, prime ⟹ cyclic ⟹ abelian) are solvable, lifting to S₂ and S₃ via the reduction. This directly answers the second open question of abel-ruffini-obstruction-oq-06 (formalize solvability of S₃/S₄), closing n = 3 and isolating n = 4 to a single missing fact (A₄ solvable, A₄ ⊳ V₄ ⊳ 1). 0 axioms, 0 sorries. The characteristic-p / Abhyankar angle of the problem title is deep unformalized theory and out of scope.",
+  "meta": {
+    "author": "Abel (1824), Ruffini (1799), Galois (1830s); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abel%E2%80%93Ruffini_theorem",
+    "date": "1824",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "group-theory",
+      "solvability",
+      "symmetric-group",
+      "alternating-group",
+      "abel-ruffini",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/AbelRuffiniOQ06.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "solvable_of_ker_le_range",
+        "description": "If ker g ≤ range f with G' = dom f and G'' = cod g both solvable, then the middle group is solvable. The extension principle behind the Aₙ → Sₙ reduction (1 → Aₙ → Sₙ → ℤˣ).",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "alternatingGroup_eq_sign_ker",
+        "description": "alternatingGroup α = (Equiv.Perm.sign).ker. Identifies Aₙ as the kernel of the sign homomorphism, giving the normal subgroup with abelian quotient.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Alternating"
+      },
+      {
+        "theorem": "isCyclic_of_prime_card",
+        "description": "A finite group whose order is prime is cyclic. Applied to A₃ (order 3) to obtain cyclicity, hence commutativity, hence solvability.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "nat_card_alternatingGroup",
+        "description": "Nat.card (alternatingGroup α) = (Fintype.card α)! / 2. Computes |A₂| = 1 and |A₃| = 3.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Alternating"
+      },
+      {
+        "theorem": "isSolvable_of_comm",
+        "description": "A group in which every pair of elements commutes is solvable. Lifts commutativity of cyclic A₃ to solvability.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      }
+    ],
+    "originalContributions": [
+      "permSolvable_of_alternatingSolvable: a reusable reduction lemma proving Sₙ solvable from Aₙ solvable, by exhibiting Aₙ = ker(sign) as a normal subgroup of Sₙ with abelian quotient and invoking solvable_of_ker_le_range — Mathlib has the sign kernel identification but does not package this solvability transfer",
+      "permFinThree_isSolvable: S₃ = Equiv.Perm (Fin 3) is solvable, obtained by showing A₃ has prime order 3 (nat_card_alternatingGroup), hence is cyclic (isCyclic_of_prime_card), hence abelian, hence solvable, then applying the reduction — the n = 3 case of the Abel–Ruffini threshold's solvable side, which Mathlib does not provide",
+      "permFinTwo_isSolvable: S₂ re-derived through the same uniform reduction (A₂ is trivial), demonstrating the reduction subsumes the abelian endpoint that abel-ruffini-obstruction-oq-06 proved by an ad hoc commutativity decide",
+      "Reduces the remaining open threshold case to a single isolated fact: with the reduction in hand, S₄ solvable is equivalent to A₄ solvable (order 12, A₄ ⊳ V₄ ⊳ 1), which is split into the companion AbelRuffiniOQ06Aristotle.lean"
+    ],
+    "dateAdded": "2026-06-27",
+    "axiomCount": 0,
+    "lineCount": 94,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (single-file checked with `lake env lean`). #print axioms reports only the foundational propext / Classical.choice / Quot.sound (none of which count). No native_decide, so no Lean.ofReduceBool. No structure-encoded hypotheses. Scope note: this is the characteristic-independent core; the characteristic-p Abhyankar refinements are not formalized. The remaining threshold case S₄ (needing A₄ solvable) is deferred to a companion file and is NOT claimed here.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Abel–Ruffini (Ruffini 1799, Abel 1824, conceptualized by Galois c.1830) states the general quintic has no radical formula. Galois reduced radical solvability to solvability of the Galois group, and the obstruction for n ≥ 5 is purely group-theoretic: Sₙ is not a solvable group, ultimately because A₅ is a nonabelian simple group. The positive side — that S₂, S₃, S₄ ARE solvable, which is what makes the linear/quadratic/Cardano/Ferrari formulas possible — is classical but comparatively neglected in formalization: Mathlib ships only the non-solvability instance for Fin 5 and no positive instances. This file formalizes the solvable side at the structural level, with the alternating group entering as the kernel of the sign map.",
+    "problemStatement": "Formalize the solvable side of the Abel–Ruffini threshold: provide a reusable reduction from solvability of the alternating group Aₙ to solvability of the full symmetric group Sₙ, and use it to prove S₂ and S₃ solvable, thereby answering the standing open question of abel-ruffini-obstruction-oq-06 for n = 3 and isolating n = 4.",
+    "proofStrategy": "The reduction observes that the sign homomorphism sign : Sₙ →* ℤˣ has kernel exactly Aₙ (alternatingGroup_eq_sign_ker) and abelian codomain ℤˣ. Feeding the inclusion Aₙ ↪ Sₙ and sign into solvable_of_ker_le_range — whose hypothesis ker(sign) ≤ range(inclusion) is just Aₙ ≤ Aₙ after rewriting range_subtype and the sign-kernel identity — yields Sₙ solvable from Aₙ solvable and ℤˣ solvable (abelian). For the base cases, nat_card_alternatingGroup gives |A₂| = 1 (subsingleton, solvable) and |A₃| = 3; primality makes A₃ cyclic (isCyclic_of_prime_card), hence commutative (IsCyclic.commutative), hence solvable (isSolvable_of_comm). The reduction then lifts both to S₂ and S₃.",
+    "keyInsights": [
+      "The single short exact sequence 1 → Aₙ → Sₙ → ℤˣ → 1, with abelian right term, transfers solvability uniformly in n: every solvable symmetric group below the threshold is solvable for the *same* structural reason, not by case-specific computation.",
+      "The Mathlib gap is precise: Equiv.Perm.fin_5_not_solvable and Equiv.Perm.not_solvable give the negative side, but there is no lemma IsSolvable (Equiv.Perm (Fin n)) for n ∈ {3,4}; the reduction lemma is exactly the missing tool that makes those cases one-liners modulo solvability of Aₙ.",
+      "For A₃, solvability is forced by arithmetic alone: order 3 is prime, so the group is cyclic and therefore abelian — no permutation-specific reasoning is needed once the order is computed.",
+      "The reduction makes the remaining open case sharp: S₄ solvable ⟺ A₄ solvable, collapsing the whole 'complete the threshold' task to the single Klein-four fact A₄ ⊳ V₄ ⊳ 1."
+    ]
+  },
+  "sections": [
+    {
+      "id": "reduction",
+      "title": "The Aₙ → Sₙ Reduction",
+      "startLine": 57,
+      "endLine": 61,
+      "summary": "permSolvable_of_alternatingSolvable: Sₙ is solvable whenever Aₙ is, via solvable_of_ker_le_range applied to the inclusion Aₙ ↪ Sₙ and sign : Sₙ →* ℤˣ. The kernel hypothesis reduces to Aₙ ≤ Aₙ after Subgroup.range_subtype and alternatingGroup_eq_sign_ker."
+    },
+    {
+      "id": "base-cases",
+      "title": "A₂ and A₃ Solvable",
+      "startLine": 67,
+      "endLine": 80,
+      "summary": "alternatingFinTwo_isSolvable: |A₂| = 1, subsingleton, solvable. alternatingFinThree_isSolvable: |A₃| = 3 (nat_card_alternatingGroup); prime order ⟹ cyclic (isCyclic_of_prime_card) ⟹ abelian (IsCyclic.commutative) ⟹ solvable (isSolvable_of_comm)."
+    },
+    {
+      "id": "symmetric-cases",
+      "title": "S₂ and S₃ Solvable",
+      "startLine": 86,
+      "endLine": 92,
+      "summary": "permFinTwo_isSolvable and permFinThree_isSolvable apply the reduction to the base cases, delivering the n = 2 and n = 3 solvable instances of the Abel–Ruffini threshold."
+    }
+  ],
+  "conclusion": {
+    "summary": "This axiom-free, sorry-free file formalizes the solvable side of the Abel–Ruffini threshold at the structural level. Its centerpiece is the reduction permSolvable_of_alternatingSolvable, which transfers solvability from the alternating group to the symmetric group through the sign exact sequence. Using it, S₂ and S₃ are proved solvable (A₂ trivial, A₃ cyclic of prime order). Together with the n ≥ 5 non-solvability of abel-ruffini-obstruction-oq-06, this leaves only n = 4 open, now reduced to the single fact that A₄ is solvable.",
+    "implications": "The reduction is the reusable infrastructure for completing 'Sₙ solvable ⟺ n ≤ 4': any future proof of A₄ solvability immediately yields S₄ solvability, after which the full threshold equivalence follows. More broadly, the lemma applies to any subgroup-of-index-≤-2 situation and packages a standard solvability transfer that downstream Galois-theoretic formalizations can invoke directly.",
+    "openQuestions": [
+      "Formalize A₄ solvable (A₄ ⊳ V₄ ⊳ 1, with V₄ the Klein-four normal subgroup of order 4 and abelian quotient A₄/V₄ ≅ ℤ/3), thereby obtaining S₄ solvable through the reduction and completing the solvable side of the threshold for all n ≤ 4. This is isolated in the companion AbelRuffiniOQ06Aristotle.lean.",
+      "Package the full equivalence 'IsSolvable (Equiv.Perm (Fin n)) ⟺ n ≤ 4' as a single theorem once n = 4 is closed, combining this file's positive instances with the uniform n ≥ 5 non-solvability."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-obstruction-oq-06",
+      "relationship": "extends",
+      "description": "Directly answers that entry's second open question — 'formalize solvability of S₃ and S₄' — by supplying the Aₙ → Sₙ reduction and closing n = 2, 3. That entry proves the n ≥ 5 non-solvability and the radical criterion; together they pin the Abel–Ruffini threshold except for the single remaining case S₄."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "The base Abel–Ruffini gallery entry. This file develops the solvable (n ≤ 4) side of the symmetric-group threshold that makes the classical low-degree radical formulas possible."
+    }
+  ]
+}

--- a/src/data/research/problems/abel-ruffini-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-06.json
@@ -29,11 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: Formalized the solvable side of the Sₙ threshold — reduction Aₙ solvable ⟹ Sₙ solvable, plus S₂ and S₃ solvable (0 axioms, 0 sorries). Only S₄ (needs A₄ solvable) remains. Char-p Abhyankar angle out of scope.",
+    "builtItems": [
+      "permSolvable_of_alternatingSolvable in AbelRuffiniOQ06.lean:57 — Sₙ solvable from Aₙ solvable via solvable_of_ker_le_range on 1→Aₙ→Sₙ→ℤˣ",
+      "permFinThree_isSolvable in AbelRuffiniOQ06.lean:90 — S₃ solvable (A₃ prime-order cyclic)",
+      "permFinTwo_isSolvable in AbelRuffiniOQ06.lean:86 — S₂ solvable via same reduction",
+      "alternatingFinThree_isSolvable / alternatingFinTwo_isSolvable instances (A₃ order 3 cyclic, A₂ trivial)"
+    ],
+    "insights": [
+      "Mathlib has the negative side (Equiv.Perm.fin_5_not_solvable / not_solvable) and the sign-kernel identity (alternatingGroup_eq_sign_ker) but NOT the positive instances IsSolvable (Perm (Fin n)) for n∈{3,4}; the missing piece is purely the Aₙ→Sₙ solvability transfer, which solvable_of_ker_le_range supplies in one line",
+      "A₃ solvability needs no permutation reasoning: |A₃|=3 prime ⟹ cyclic ⟹ abelian ⟹ solvable",
+      "The reduction makes S₄ solvable ⟺ A₄ solvable, isolating the whole remaining task to the Klein-four fact A₄ ⊳ V₄ ⊳ 1"
+    ],
+    "mathlibGaps": [
+      "No Mathlib lemma IsSolvable (Equiv.Perm (Fin n)) for n∈{3,4}; no packaged Aₙ→Sₙ solvability transfer; no A₄-solvable / Klein-four-normal-in-A₄ result"
+    ],
+    "nextSteps": [
+      "Prove alternatingFinFour_isSolvable (A₄ ⊳ V₄ ⊳ 1) — submitted to Aristotle via AbelRuffiniOQ06Aristotle.lean — then permFinFour_isSolvable lands by the reduction",
+      "Package full equivalence IsSolvable (Equiv.Perm (Fin n)) ⟺ n ≤ 4 once n=4 closes"
+    ]
   },
   "tags": [
     "algebra",


### PR DESCRIPTION
## Summary

Formalizes the **positive half** of the Abel–Ruffini group-theoretic threshold `Sₙ solvable ⟺ n ≤ 4` — the side Mathlib does **not** package (it ships only the negative `Equiv.Perm.fin_5_not_solvable` and no `IsSolvable (Equiv.Perm (Fin n))` for n ∈ {3,4}).

New verified file `proofs/Proofs/AbelRuffiniOQ06.lean` (**0 axioms, 0 sorries**; `#print axioms` = `propext`/`Classical.choice`/`Quot.sound` only):

| Theorem | Statement |
|---|---|
| `permSolvable_of_alternatingSolvable` | reusable reduction: `IsSolvable (alternatingGroup (Fin n)) → IsSolvable (Equiv.Perm (Fin n))` |
| `alternatingFinThree_isSolvable` | `A₃` solvable (order 3, prime ⟹ cyclic ⟹ abelian) |
| `alternatingFinTwo_isSolvable` | `A₂` solvable (trivial) |
| `permFinTwo_isSolvable`, `permFinThree_isSolvable` | `S₂`, `S₃` solvable |

The reduction routes the short exact sequence `1 → Aₙ → Sₙ → ℤˣ` (with `Aₙ = ker(sign)`, abelian quotient) through Mathlib's `solvable_of_ker_le_range`; its kernel hypothesis collapses to `Aₙ ≤ Aₙ` after `Subgroup.range_subtype` and `alternatingGroup_eq_sign_ker`.

## Significance

Directly answers **open question 2** of the sibling entry `abel-ruffini-obstruction-oq-06` ("formalize solvability of S₃ and S₄"). Closes **n = 3** and reduces the only remaining case **n = 4** to the single fact `A₄` solvable (`A₄ ⊳ V₄ ⊳ 1`), isolated in companion `AbelRuffiniOQ06Aristotle.lean` (one `sorry`, for Aristotle).

## Verification

Single-file `lake env lean Proofs/AbelRuffiniOQ06.lean` (clean); docker daemon was unavailable this session (`docker ps` → rc 124). The deep characteristic-p / Abhyankar angle of the problem title is unformalized theory and explicitly out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)