### PR TITLE
research(abel-ruffini-oq-04-oq-01-oq-04-oq-01): non-solvability obstruction — transitive subgroup of S_p with a transposition is unsolvable (p≥5) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ04OQ01OQ04OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ01OQ04OQ01.lean
@@ -1,0 +1,118 @@
+/-
+  Abel–Ruffini, concrete-quintic branch — OQ-04-OQ-01-OQ-04-OQ-01:
+  from the Key Group Theory Lemma to the NON-SOLVABILITY obstruction.
+
+  ## Question
+  The parent entry (`AbelRuffiniOQ04OQ01OQ04`) proves the Key Group Theory Lemma:
+  a transitive subgroup `G ≤ S_p` (`p` prime) containing a transposition is all of
+  `S_p`. Its open question is the payoff for Abel–Ruffini: such a `G` is the FULL
+  symmetric group, hence — for `p ≥ 5` — **not solvable**. Combined with the Galois
+  correspondence (a polynomial is solvable by radicals iff its Galois group is
+  solvable, `Polynomial.solvableByRad`), this is exactly the group-theoretic
+  obstruction that makes the general quintic unsolvable.
+
+  This file supplies that step, axiom-free: it re-proves the Key Lemma
+  self-contained (so the file stands alone) and then derives
+
+      a transitive subgroup of `S_p` with a transposition and `p ≥ 5` is not
+      solvable,
+
+  by transporting Mathlib's `Equiv.Perm.not_solvable` across `Subgroup.topEquiv`.
+
+  ## What this file delivers (0 axioms, 0 sorries)
+  * `eq_top_of_isPretransitive_of_mem_isSwap` — the Key Lemma (re-proved).
+  * `not_isSolvable_of_isPretransitive_of_mem_isSwap` — the obstruction: such a `G`
+    is not solvable when `5 ≤ card α`.
+  * `not_isSolvable_top` — corollary: `S_α` itself is not solvable for `5 ≤ card α`,
+    phrased for the top subgroup.
+
+  ## References
+  - N. H. Abel (1824); P. Ruffini (1799); É. Galois (1831).
+  - Mathlib: `Equiv.Perm.not_solvable`, `closure_prime_cycle_swap`.
+
+  Tags: algebra, galois-theory, abel-ruffini, solvability, symmetric-group
+-/
+
+import Mathlib
+
+open Equiv Equiv.Perm Subgroup MulAction
+
+namespace AbelRuffiniOQ04OQ01OQ04OQ01
+
+variable {α : Type*} [Fintype α] [DecidableEq α]
+
+/-- **Key Group Theory Lemma (transitive + a transposition ⟹ full symmetric group).**
+If `α` has a prime number of elements and `G ≤ S_α` acts transitively and contains
+a transposition, then `G = ⊤`. (Re-proved self-contained from the parent entry.) -/
+theorem eq_top_of_isPretransitive_of_mem_isSwap
+    (hp : (Fintype.card α).Prime)
+    (G : Subgroup (Equiv.Perm α)) [IsPretransitive G α]
+    {τ : Equiv.Perm α} (hτ : τ ∈ G) (hτswap : τ.IsSwap) :
+    G = ⊤ := by
+  classical
+  haveI : Fact (Fintype.card α).Prime := ⟨hp⟩
+  have hcard2 : 2 ≤ Fintype.card α := hp.two_le
+  obtain ⟨a⟩ : Nonempty α := Fintype.card_pos_iff.mp (by omega)
+  have horbit : Fintype.card (orbit G a) = Fintype.card α :=
+    Fintype.card_congr ((Equiv.setCongr (MulAction.orbit_eq_univ G a)).trans (Equiv.Set.univ α))
+  have hpdvd : Fintype.card α ∣ Fintype.card G := by
+    have hos := MulAction.card_orbit_mul_card_stabilizer_eq_card_group (α := G) a
+    refine ⟨Fintype.card (stabilizer G a), ?_⟩
+    rw [← hos, horbit]
+  obtain ⟨g, hg⟩ := exists_prime_orderOf_dvd_card (Fintype.card α) hpdvd
+  have hσord : orderOf (g : Equiv.Perm α) = Fintype.card α := by
+    rw [orderOf_coe]; exact hg
+  have hσcyc : (g : Equiv.Perm α).IsCycle := by
+    refine isCycle_of_prime_order (by rw [hσord]; exact hp) ?_
+    rw [hσord]
+    calc ((g : Equiv.Perm α).support.card) ≤ Fintype.card α := Finset.card_le_univ _
+      _ < 2 * Fintype.card α := by omega
+  have hσsupp : (g : Equiv.Perm α).support = Finset.univ := by
+    have h1 := hσcyc.orderOf
+    rw [hσord] at h1
+    exact Finset.eq_univ_of_card _ h1.symm
+  have hgen : Subgroup.closure (({(g : Equiv.Perm α), τ}) : Set (Equiv.Perm α)) = ⊤ :=
+    closure_prime_cycle_swap hp hσcyc hσsupp hτswap
+  rw [eq_top_iff, ← hgen, Subgroup.closure_le]
+  intro x hx
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+  rcases hx with rfl | rfl
+  · exact g.2
+  · exact hτ
+
+-- ============================================================
+-- The Abel–Ruffini obstruction: non-solvability for p ≥ 5
+-- ============================================================
+
+omit [DecidableEq α] in
+/-- The full symmetric group on `α` is not solvable when `5 ≤ card α`, phrased for
+the top subgroup (`Subgroup.topEquiv : ⊤ ≃* S_α`). -/
+theorem not_isSolvable_top (h5 : 5 ≤ Fintype.card α) :
+    ¬ IsSolvable (⊤ : Subgroup (Equiv.Perm α)) := by
+  intro hsolv
+  have hperm : IsSolvable (Equiv.Perm α) :=
+    solvable_of_surjective (f := (Subgroup.topEquiv : (⊤ : Subgroup (Equiv.Perm α)) ≃* _).toMonoidHom)
+      (Subgroup.topEquiv).surjective
+  refine Equiv.Perm.not_solvable α ?_ hperm
+  rw [Cardinal.mk_fintype]
+  exact_mod_cast h5
+
+/-- **The Abel–Ruffini obstruction.** A transitive subgroup of `S_p` (`p` prime,
+`p ≥ 5`) that contains a transposition is the full symmetric group and is therefore
+**not solvable**. Via the Galois correspondence this is exactly what blocks
+solvability by radicals: any polynomial whose Galois group is such a `G` is not
+solvable by radicals. -/
+theorem not_isSolvable_of_isPretransitive_of_mem_isSwap
+    (hp : (Fintype.card α).Prime) (h5 : 5 ≤ Fintype.card α)
+    (G : Subgroup (Equiv.Perm α)) [IsPretransitive G α]
+    {τ : Equiv.Perm α} (hτ : τ ∈ G) (hτswap : τ.IsSwap) :
+    ¬ IsSolvable G := by
+  have htop : G = ⊤ := eq_top_of_isPretransitive_of_mem_isSwap hp G hτ hτswap
+  subst htop
+  exact not_isSolvable_top h5
+
+#check @eq_top_of_isPretransitive_of_mem_isSwap
+#check @not_isSolvable_top
+#check @not_isSolvable_of_isPretransitive_of_mem_isSwap
+
+end AbelRuffiniOQ04OQ01OQ04OQ01

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04-oq-01/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-key-lemma",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-04-oq-01",
+    "range": { "startLine": 47, "endLine": 81 },
+    "type": "insight",
+    "title": "The Key Group Theory Lemma (re-proved self-contained)",
+    "content": "`eq_top_of_isPretransitive_of_mem_isSwap`: a transitive subgroup `G ≤ S_p` (`p = card α` prime) containing a transposition `τ` equals `⊤`. Orbit–stabilizer plus transitivity give `p ∣ |G|`; Cauchy (`exists_prime_orderOf_dvd_card`) produces an element of order `p`; on a `p`-element set such an element is a `p`-cycle with full support (`isCycle_of_prime_order`, `IsCycle.orderOf`); and a `p`-cycle together with any transposition generates `S_p` (`closure_prime_cycle_swap`). Since both generators lie in `G`, `⊤ = ⟨σ,τ⟩ ≤ G`. Re-proved here so the file is self-contained.",
+    "mathContext": "For prime $p$, a transitive $G\\le S_p$ containing a transposition satisfies $G=S_p$ — the classical bridge from 'transitive + a transposition' to the full symmetric group.",
+    "significance": "foundational",
+    "relatedConcepts": ["closure_prime_cycle_swap", "exists_prime_orderOf_dvd_card", "isCycle_of_prime_order", "orbit_eq_univ"],
+    "prerequisites": ["Orbit–stabilizer theorem", "Cauchy's theorem", "Cycle structure of permutations"]
+  },
+  {
+    "id": "ann-not-solvable-top",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-04-oq-01",
+    "range": { "startLine": 88, "endLine": 100 },
+    "type": "insight",
+    "title": "Non-Solvability Transported Across topEquiv",
+    "content": "`not_isSolvable_top`: `S_α` is not solvable for `5 ≤ card α`. If `⊤ : Subgroup (Perm α)` were solvable, then `solvable_of_surjective` applied to the surjective monoid hom underlying `Subgroup.topEquiv : ⊤ ≃* Perm α` would make `Perm α` solvable — contradicting Mathlib's `Equiv.Perm.not_solvable α` (whose hypothesis `5 ≤ Cardinal.mk α` comes from `5 ≤ Fintype.card α` via `Cardinal.mk_fintype`). This is the clean bridge from 'G is everything' to 'G is unsolvable'.",
+    "mathContext": "$S_n$ is not solvable for $n\\ge 5$; equivalently the top subgroup of $\\mathrm{Perm}(\\alpha)$ is not solvable when $|\\alpha|\\ge 5$.",
+    "significance": "key",
+    "relatedConcepts": ["Equiv.Perm.not_solvable", "solvable_of_surjective", "Subgroup.topEquiv", "Cardinal.mk_fintype"],
+    "prerequisites": ["Solvable groups", "MulEquiv and surjective homomorphisms"]
+  },
+  {
+    "id": "ann-obstruction",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-04-oq-01",
+    "range": { "startLine": 105, "endLine": 116 },
+    "type": "insight",
+    "title": "The Abel–Ruffini Obstruction",
+    "content": "`not_isSolvable_of_isPretransitive_of_mem_isSwap`: a transitive subgroup of `S_p` (`p` prime, `p ≥ 5`) containing a transposition is NOT solvable — the Key Lemma forces `G = ⊤`, then `not_isSolvable_top` applies. Via the Galois correspondence (a polynomial is solvable by radicals iff its Galois group is solvable), this is exactly the obstruction making the general quintic unsolvable: any polynomial of prime degree `p ≥ 5` whose Galois group is transitive and contains a transposition (e.g. an irreducible quintic with two non-real roots, where complex conjugation is the transposition) is unsolvable by radicals.",
+    "mathContext": "Abel–Ruffini: degree-$\\ge 5$ polynomials have no general radical formula because $S_p$ ($p\\ge 5$) is unsolvable and arises as a Galois group.",
+    "significance": "key",
+    "relatedConcepts": ["eq_top_of_isPretransitive_of_mem_isSwap", "not_isSolvable_top", "Polynomial.solvableByRad"],
+    "prerequisites": ["Galois solvability criterion"]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04-oq-01/meta.json
@@ -1,0 +1,86 @@
+{
+  "id": "abel-ruffini-oq-04-oq-01-oq-04-oq-01",
+  "title": "The Abel–Ruffini Obstruction: a Transitive Subgroup of S_p with a Transposition Is Not Solvable (p ≥ 5)",
+  "slug": "abel-ruffini-oq-04-oq-01-oq-04-oq-01",
+  "description": "The parent entry proves the Key Group Theory Lemma — a transitive subgroup G ≤ S_p (p prime) containing a transposition equals all of S_p. This entry draws the Abel–Ruffini payoff: for p ≥ 5 that group is the full symmetric group and hence NOT solvable, which via the Galois correspondence is exactly the obstruction that makes the general quintic unsolvable by radicals. It re-proves the Key Lemma self-contained, then transports Mathlib's Equiv.Perm.not_solvable across Subgroup.topEquiv to conclude non-solvability of the top subgroup, and assembles the two into the headline obstruction theorem. Fully verified, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ01OQ04OQ01.lean",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "abel-ruffini",
+      "solvability",
+      "symmetric-group"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 118,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. VERIFIED: compiles clean against Mathlib 4.26.0 via `lake env lean Proofs/AbelRuffiniOQ04OQ01OQ04OQ01.lean` (no errors, no warnings); `#print axioms` on not_isSolvable_of_isPretransitive_of_mem_isSwap and not_isSolvable_top reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no Lean.ofReduceBool. Assembles standard Mathlib results: orbit–stabilizer, Cauchy (exists_prime_orderOf_dvd_card), isCycle_of_prime_order, closure_prime_cycle_swap, Equiv.Perm.not_solvable, solvable_of_surjective, Subgroup.topEquiv. The Key Lemma is re-proved self-contained so the file stands alone.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "dateAdded": "2026-06-27",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Abel–Ruffini theorem (Ruffini 1799, Abel 1824) states there is no general algebraic formula in radicals for the roots of polynomials of degree ≥ 5. Galois (1831) explained why: a polynomial is solvable by radicals iff its Galois group is a solvable group. The general quintic has Galois group S_5, and S_n is not solvable for n ≥ 5, so no radical formula exists. Concretely exhibiting an unsolvable quintic reduces to showing a specific Galois group is S_5; the standard route is the Key Group Theory Lemma — a transitive subgroup of S_p (p prime) with a transposition is all of S_p — applied to an irreducible quintic with exactly two non-real roots (complex conjugation supplies the transposition). The parent entry formalized that lemma; this entry supplies the non-solvability conclusion that turns it into the Abel–Ruffini obstruction.",
+    "problemStatement": "Given the Key Group Theory Lemma (a transitive G ≤ S_p, p prime, containing a transposition equals ⊤), derive the Abel–Ruffini obstruction: for p ≥ 5 such a G is not solvable. Concretely, prove not_isSolvable_top (S_α is not solvable for 5 ≤ card α, phrased for the top subgroup) and not_isSolvable_of_isPretransitive_of_mem_isSwap (a transitive subgroup of S_p with a transposition and p ≥ 5 is not solvable).",
+    "proofStrategy": "The Key Lemma is re-proved verbatim from the parent (orbit–stabilizer gives p ∣ |G|; Cauchy gives an order-p element; on a p-element set that element is a p-cycle with full support; a p-cycle and a transposition generate S_p via closure_prime_cycle_swap; both generators lie in G, so G = ⊤). For non-solvability, not_isSolvable_top assumes IsSolvable (⊤ : Subgroup (Perm α)) and derives IsSolvable (Perm α) by solvable_of_surjective applied to the surjective monoid hom underlying Subgroup.topEquiv : ⊤ ≃* Perm α; this contradicts Equiv.Perm.not_solvable α (with 5 ≤ Cardinal.mk α obtained from 5 ≤ Fintype.card α via Cardinal.mk_fintype). The headline theorem combines the two: the Key Lemma forces G = ⊤, after which not_isSolvable_top applies.",
+    "keyInsights": [
+      "The Key Group Theory Lemma is not just a structural curiosity: for p ≥ 5 it immediately yields non-solvability, which is the entire group-theoretic content of Abel–Ruffini. G = ⊤ = S_p and S_p is unsolvable.",
+      "Non-solvability transports across Subgroup.topEquiv: a solvable ⊤ would force the whole symmetric group to be solvable (solvable_of_surjective), contradicting Equiv.Perm.not_solvable. This is the clean bridge from 'G is everything' to 'G is unsolvable'.",
+      "The cardinality hypothesis is exactly p ≥ 5: Equiv.Perm.not_solvable needs 5 ≤ #α, matching the historical degree threshold below which (degree ≤ 4) the symmetric groups S_2, S_3, S_4 ARE solvable and radical formulas exist.",
+      "Via the Galois correspondence (Polynomial.solvableByRad / the Galois solvability criterion) this obstruction says: any polynomial whose Galois group is a transitive subgroup of S_p (p ≥ 5) with a transposition is not solvable by radicals — the abstract template behind every concrete unsolvable quintic."
+    ]
+  },
+  "sections": [
+    {
+      "id": "key-lemma",
+      "title": "The Key Group Theory Lemma (re-proved)",
+      "startLine": 44,
+      "endLine": 81,
+      "summary": "eq_top_of_isPretransitive_of_mem_isSwap: a transitive G ≤ S_p (p prime) containing a transposition equals ⊤, via orbit–stabilizer, Cauchy, p-cycle structure, and closure_prime_cycle_swap."
+    },
+    {
+      "id": "obstruction",
+      "title": "The Non-Solvability Obstruction (p ≥ 5)",
+      "startLine": 83,
+      "endLine": 116,
+      "summary": "not_isSolvable_top: S_α is not solvable for 5 ≤ card α (transported across Subgroup.topEquiv from Equiv.Perm.not_solvable). not_isSolvable_of_isPretransitive_of_mem_isSwap: a transitive subgroup of S_p with a transposition and p ≥ 5 is not solvable."
+    }
+  ],
+  "conclusion": {
+    "summary": "A transitive subgroup of S_p (p prime, p ≥ 5) containing a transposition equals the full symmetric group and is therefore not solvable — the Abel–Ruffini obstruction. The Key Lemma forces G = ⊤; non-solvability of ⊤ follows from Mathlib's Equiv.Perm.not_solvable transported across Subgroup.topEquiv. Fully machine-checked, 0 axioms, 0 sorries.",
+    "implications": "This converts the parent's structural Key Lemma into the group-theoretic heart of Abel–Ruffini: via the Galois correspondence, any polynomial of prime degree p ≥ 5 whose Galois group is transitive and contains a transposition is unsolvable by radicals. It is the reusable abstract obstruction behind every concrete unsolvable quintic such as x⁵ − 4x + 2.",
+    "openQuestions": [
+      "Instantiate the obstruction on a concrete polynomial: combine with irreducibility (Eisenstein) and a real-root count to conclude Gal(x⁵ − 4x + 2) is not solvable, recovering the classical example fully formally.",
+      "Bridge to Polynomial.solvableByRad: state and prove 'Galois group a transitive subgroup of S_p (p ≥ 5) with a transposition ⟹ not solvable by radicals' using Mathlib's Galois solvability criterion.",
+      "Generalize from prime degree to the existence of a transposition plus an n-cycle (or other generation criteria) for non-prime degrees."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-04-oq-01-oq-04",
+      "relationship": "extends",
+      "description": "Parent entry proves the Key Group Theory Lemma (transitive + transposition ⟹ S_p). This entry derives its Abel–Ruffini payoff: for p ≥ 5 the group is not solvable."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Grandparent entry computes Gal(x⁵ − 4x + 2) ≅ S₅; this non-solvability obstruction is the abstract reason that computation implies unsolvability by radicals."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 118,
+    "path": "Proofs/AbelRuffiniOQ04OQ01OQ04OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 3
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry drawing the **Abel–Ruffini payoff** from the parent's Key Group Theory Lemma (`abel-ruffini-oq-04-oq-01-oq-04`: a transitive `G ≤ S_p` with a transposition equals `⊤`).

For `p ≥ 5` that group is the full symmetric group and hence **not solvable** — via the Galois correspondence, exactly the obstruction that makes the general quintic unsolvable by radicals.

## Theorems (3; 0 sorries, 0 axioms)

| Name | Statement |
|---|---|
| `eq_top_of_isPretransitive_of_mem_isSwap` | the Key Lemma, re-proved self-contained |
| `not_isSolvable_top` | `S_α` is not solvable for `5 ≤ card α` |
| `not_isSolvable_of_isPretransitive_of_mem_isSwap` | a transitive subgroup of `S_p` (`p` prime, `p ≥ 5`) with a transposition is not solvable |

## Key insight

The Key Lemma forces `G = ⊤`; non-solvability of `⊤` follows by transporting Mathlib's `Equiv.Perm.not_solvable` across `Subgroup.topEquiv` (`solvable_of_surjective`). The cardinality threshold is exactly `p ≥ 5`, matching the historical degree boundary below which `S_2, S_3, S_4` are solvable and radical formulas exist.

## Verification

Compiles clean against **Mathlib 4.26.0** via `lake env lean Proofs/AbelRuffiniOQ04OQ01OQ04OQ01.lean` (no errors, no warnings). `#print axioms` on `not_isSolvable_of_isPretransitive_of_mem_isSwap` and `not_isSolvable_top` reports only `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)