### PR TITLE
Enrich Stark Units rank-one regulator (kroneckers-jugendtraum-oq-02): deepen annotations + sections

### DIFF
--- a/src/data/proofs/kroneckers-jugendtraum-oq-02/annotations.json
+++ b/src/data/proofs/kroneckers-jugendtraum-oq-02/annotations.json
@@ -2,14 +2,26 @@
   {
     "id": "ann-overview",
     "proofId": "kroneckers-jugendtraum-oq-02",
-    "range": { "startLine": 4, "endLine": 41 },
+    "range": { "startLine": 4, "endLine": 16 },
     "type": "concept",
-    "title": "Rank-One Stark Units: the Regulator is One Logarithm",
-    "content": "Hilbert's 12th problem seeks explicit generators of abelian extensions of a number field K. Beyond ℚ (roots of unity) and imaginary quadratic fields (complex multiplication), the conjectural answer is governed by the **Stark conjectures**. Their simplest instance — the *rank-one abelian Stark conjecture* — applies exactly when the relevant unit rank is 1, and predicts that L'(0, χ) is a rational multiple of a single logarithm log|ε| of one algebraic unit ε, the **Stark unit**.\n\nThis entry machine-checks the structural fact that makes that statement meaningful: in unit rank 1, the regulator of K collapses from a determinant to a single logarithm of the fundamental unit. It does not attempt the open problem of computing Stark units effectively.",
-    "mathContext": "Rank-one abelian Stark: $L'(0,\\chi) = \\tfrac{1}{w}\\sum_{\\sigma} \\chi(\\sigma)\\log|\\varepsilon^\\sigma|$ for a Stark unit $\\varepsilon$; this entry formalizes the regulator side, $R_K = \\mathrm{mult}(w)\\,|\\log w(\\varepsilon)|$ when $\\mathrm{rank}\\,K = 1$.",
+    "title": "Hilbert's 12th and the Rank-One Stark Conjecture",
+    "content": "Hilbert's 12th problem (Kronecker's *Jugendtraum*) seeks explicit generators of the abelian extensions of a number field K. It is solved for K = ℚ (Kronecker–Weber: roots of unity) and for imaginary quadratic K (complex multiplication: singular moduli and elliptic units), but the general case is open and conjecturally governed by the **Stark conjectures**. Their best-tested instance — the *rank-one abelian Stark conjecture* — applies exactly when the relevant unit rank is 1, and predicts that the leading Taylor coefficient L'(0, χ) of the Artin L-function is a rational multiple of a single logarithm log|ε| of one algebraic unit ε, the **Stark unit**, which generates an abelian extension.",
+    "mathContext": "Rank-one abelian Stark: $L'(0,\\chi) = -\\tfrac{1}{w}\\sum_{\\sigma \\in \\mathrm{Gal}} \\chi(\\sigma)\\log|\\varepsilon^\\sigma|$ for a Stark unit $\\varepsilon$ generating the predicted abelian extension.",
     "significance": "context",
-    "relatedConcepts": ["Hilbert's 12th problem", "Kronecker's Jugendtraum", "Stark conjectures", "Stark units", "abelian extensions"],
+    "relatedConcepts": ["Hilbert's 12th problem", "Kronecker's Jugendtraum", "Kronecker–Weber theorem", "complex multiplication", "Stark conjectures"],
     "prerequisites": ["algebraic number theory", "class field theory", "Artin L-functions"]
+  },
+  {
+    "id": "ann-isolated-fact",
+    "proofId": "kroneckers-jugendtraum-oq-02",
+    "range": { "startLine": 17, "endLine": 23 },
+    "type": "insight",
+    "title": "The Structural Fact Isolated (and What Is Left Open)",
+    "content": "The entry machine-checks the *structural* prerequisite that makes the rank-one Stark statement even well-posed: in unit rank 1, the regulator of K — in general an (r × r) determinant of logarithms of a fundamental system of units — collapses to a single archimedean logarithm of the fundamental (Stark) unit ε. This is the regulator side of the conjecture, the part that is pure linear algebra once Dirichlet's theorem is in hand. It deliberately does **not** address the deep open problem: computing Stark units effectively, or proving L'(0, χ) actually equals that logarithm. Separating the provable structural fact from the open analytic conjecture is the entry's honest scoping.",
+    "mathContext": "This entry formalizes only the regulator identity $R_K = \\mathrm{mult}(w)\\,|\\log w(\\varepsilon)|$ when $\\mathrm{rank}\\,K = 1$; the analytic Stark equality $L'(0,\\chi) \\sim R_K$ remains conjectural.",
+    "significance": "key",
+    "relatedConcepts": ["regulator", "Stark units", "effective computation (open)", "scope of formalization"],
+    "prerequisites": ["unit rank", "regulator of a number field"]
   },
   {
     "id": "ann-rank-characterization",
@@ -24,15 +36,27 @@
     "prerequisites": ["Dirichlet's unit theorem", "infinite places of a number field"]
   },
   {
+    "id": "ann-regulator-statement",
+    "proofId": "kroneckers-jugendtraum-oq-02",
+    "range": { "startLine": 58, "endLine": 65 },
+    "type": "concept",
+    "title": "The Rank-One Regulator Is a Single Logarithm",
+    "content": "`regulator_eq_single_log_of_rank_eq_one` states the headline collapse: assuming `rank K = 1`, there exist an infinite place w and a unit ε with `regulator K = mult w · |log (w ε)|`. The existential packages the fundamental (Stark) unit ε = `fundSystem K i` together with the single place w that indexes it. This is exactly the linear-algebra fact behind the rank-one abelian Stark conjecture's statement that L'(0, χ) is a rational multiple of one log|ε| — the regulator, normally a determinant, is now literally one archimedean logarithm.",
+    "mathContext": "$\\exists\\, w,\\ \\varepsilon:\\ R_K = \\mathrm{mult}(w)\\,|\\log w(\\varepsilon)|$, with $\\varepsilon$ the fundamental unit.",
+    "significance": "key",
+    "relatedConcepts": ["regulator", "Stark unit", "fundamental system of units", "infinite place", "archimedean logarithm"],
+    "prerequisites": ["regulator of a number field", "fundamental units"]
+  },
+  {
     "id": "ann-regulator-collapse",
     "proofId": "kroneckers-jugendtraum-oq-02",
-    "range": { "startLine": 58, "endLine": 77 },
+    "range": { "startLine": 66, "endLine": 77 },
     "type": "technique",
-    "title": "Collapsing the Regulator Determinant via Matrix.det_unique",
-    "content": "Mathlib defines the regulator as the covolume of the unit lattice, and `regOfFamily_eq_det` expresses it as the absolute value of the determinant of the (rank × rank) matrix (mult w · log w(uᵢ))_{i,w} of logarithms of a fundamental system of units, with rows/columns indexed by the infinite places other than the distinguished place w₀.\n\nWhen `rank K = 1`, both index types are singletons. Transporting the `Unique (Fin (rank K))` instance along `equivFinRank` gives `Unique {w // w ≠ w₀}`, so `Matrix.det_unique` reduces the determinant to its single diagonal entry `mult(w) · log(w ε)`. Factoring the absolute value over the product (abs_mul) and using that the multiplicity is a nonnegative cast (Nat.abs_cast) yields `regulator K = mult(w) · |log(w ε)|` — the regulator as a single archimedean logarithm of the fundamental (Stark) unit ε = fundSystem K.",
+    "title": "Collapsing the Determinant via Matrix.det_unique",
+    "content": "Mathlib expresses the regulator (covolume of the unit lattice) as the absolute value of the determinant of the (rank × rank) matrix (mult w · log w(uᵢ)) of logarithms, indexed by the infinite places other than the distinguished place w₀ (`regulator_eq_det`). When `rank K = 1`, both index types are singletons: transporting the `Unique (Fin (rank K))` instance along `equivFinRank` gives `Unique {w // w ≠ w₀}`, so `Matrix.det_unique` reduces the determinant to its single diagonal entry. Factoring the absolute value over the product (`abs_mul`) and using that the multiplicity is a nonnegative cast (`Nat.abs_cast`) yields the single-logarithm form.",
     "mathContext": "$R_K = \\bigl|\\det\\,(\\mathrm{mult}\\,w \\cdot \\log w(u_i))_{i,w}\\bigr| \\xrightarrow{\\;\\mathrm{rank}=1\\;} \\mathrm{mult}(w)\\,|\\log w(\\varepsilon)|$ via $\\det$ of a $1\\times1$ matrix.",
-    "significance": "key",
-    "relatedConcepts": ["regulator", "unit lattice covolume", "Matrix.det_unique", "equivFinRank", "fundamental system of units", "logarithmic embedding"],
+    "significance": "supporting",
+    "relatedConcepts": ["Matrix.det_unique", "equivFinRank", "Unique type instances", "unit lattice covolume", "logarithmic embedding"],
     "prerequisites": ["determinant of a 1×1 matrix", "the regulator as a determinant of logarithms", "Unique type instances"]
   }
 ]

--- a/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
@@ -74,6 +74,13 @@
   },
   "sections": [
     {
+      "id": "context-hilbert-12-stark",
+      "title": "Hilbert's 12th & the Rank-One Stark Setting",
+      "startLine": 4,
+      "endLine": 41,
+      "summary": "The module docstring frames Hilbert's 12th problem (Kronecker's Jugendtraum) — explicit generators of abelian extensions, solved for ℚ (Kronecker–Weber) and imaginary quadratic fields (complex multiplication) — and the Stark conjectures' rank-one instance, where L'(0, χ) is predicted to be a rational multiple of a single log|ε| of a Stark unit. It scopes the file to the provable structural regulator-collapse fact, explicitly excluding the open problem of computing Stark units effectively, and lists the two main theorems and the proof strategy (Dirichlet rank characterization + Matrix.det_unique)."
+    },
+    {
       "id": "rank-characterization",
       "title": "Rank One ⟺ Two Infinite Places",
       "startLine": 50,


### PR DESCRIPTION
Enrichment pass for `kroneckers-jugendtraum-oq-02` (Rank-One Regulator Collapses to a Single Logarithm).

Solid entry (structured overview, 3 open questions) but light annotation coverage (3) and only 2 sections. Deepened by tiling the file's genuinely distinct ideas — Hilbert's 12th / Stark context, the isolated structural fact, the rank characterization, and the regulator collapse (statement + proof).

## Changes
- **Annotations 3 → 5** (all with mathContext/significance/relatedConcepts/prerequisites; resolver **Valid 5, Misaligned 0**):
  - NEW *Hilbert's 12th and the Rank-One Stark Conjecture* — the Jugendtraum / Kronecker–Weber / CM / Stark context
  - NEW *The Structural Fact Isolated (and What Is Left Open)* — what the file proves vs. the open effective-computation problem
  - existing rank-characterization kept; the regulator annotation split into *statement* (the single-log existential) and *proof* (`Matrix.det_unique` collapse)
- **Sections 2 → 3**: added a context section for the Hilbert-12/Stark docstring framing

## Verification
- JSON valid; resolver Valid 5 / Misaligned 0; within the 60 KB cap
- No status/badge/axiomCount change (entry remains `verified`, 0 axioms)
- Pre-PR freshness re-check passed