### PR TITLE
Enrich Transcendental Numbers Exist (sqrt2-irrational-oq-02): deepen annotations

### DIFF
--- a/src/data/proofs/sqrt2-irrational-oq-02/annotations.json
+++ b/src/data/proofs/sqrt2-irrational-oq-02/annotations.json
@@ -19,29 +19,59 @@
     "proofId": "sqrt2-irrational-oq-02",
     "range": {
       "startLine": 31,
-      "endLine": 45
+      "endLine": 36
     },
     "type": "definition",
-    "title": "Liouville's constant: a Liouville number, irrational and transcendental",
-    "content": "liouvilleConst := liouvilleNumber 2 = ∑_k 2^{-k!}, the canonical concrete transcendental. Three facts are read off Mathlib's Liouville theory: liouvilleConst_liouville (it is a Liouville number, liouville_liouvilleNumber), liouvilleConst_irrational (Liouville numbers are irrational, .irrational), and liouvilleConst_transcendental (transcendental over ℤ, transcendental_liouvilleNumber). The defining feature of a Liouville number is that it is approximable by rationals far better than any algebraic number can be — which forces transcendence.",
-    "mathContext": "$L=\\sum_{k\\ge 1} 2^{-k!}$. A Liouville number $x$ admits, for every $n$, a rational $p/q$ with $0<|x-p/q|<q^{-n}$ — impossible for an algebraic irrational by Liouville's inequality, hence $x$ is transcendental.",
+    "title": "Liouville's Constant and Liouville Numbers",
+    "content": "liouvilleConst := liouvilleNumber 2 = ∑_k 2^{-k!}, the canonical concrete transcendental (Liouville, 1844 — the first numbers ever proved transcendental). liouvilleConst_liouville records that it is a Liouville number, via Mathlib's `liouville_liouvilleNumber` (the side goal `2 > 1` is `norm_num`). The defining feature: a Liouville number is approximable by rationals far better than any algebraic number can be — the factorial gaps in the exponents make the partial sums extraordinarily close rational approximations.",
+    "mathContext": "$L=\\sum_{k\\ge 1} 2^{-k!}$. A Liouville number $x$ admits, for every $n$, a rational $p/q$ with $0<|x-p/q|<q^{-n}$ — the factorial spacing of $L$'s digits supplies exactly such super-good approximations.",
     "significance": "key",
-    "relatedConcepts": ["Liouville number", "liouvilleNumber", "rational approximation", "transcendence"],
-    "prerequisites": ["Liouville's theorem on approximation", "series"]
+    "relatedConcepts": ["Liouville number", "liouvilleNumber", "rational approximation", "factorial series"],
+    "prerequisites": ["Liouville's approximation theorem", "infinite series"]
+  },
+  {
+    "id": "ann-sqrt2oq02-irrational-transcendental",
+    "proofId": "sqrt2-irrational-oq-02",
+    "range": {
+      "startLine": 38,
+      "endLine": 45
+    },
+    "type": "technique",
+    "title": "Irrational, Then Transcendental",
+    "content": "Two facts are read off the Liouville property. liouvilleConst_irrational uses `Liouville.irrational` — any Liouville number is irrational, because a rational would violate the super-approximability. liouvilleConst_transcendental uses `transcendental_liouvilleNumber`: Liouville's inequality says an algebraic irrational of degree d cannot be approximated to order better than d, so a number approximable to *every* order is transcendental over ℤ. The logical chain is Liouville number ⟹ irrational ⟹ (strictly more) transcendental.",
+    "mathContext": "Liouville's inequality: for $\\alpha$ algebraic of degree $d\\ge 2$ there is $c>0$ with $|\\alpha - p/q| > c\\,q^{-d}$ for all $p/q$. A number beating $q^{-n}$ for every $n$ violates this for every $d$, hence is transcendental.",
+    "significance": "key",
+    "relatedConcepts": ["Liouville's inequality", "irrationality", "transcendence over ℤ", "Transcendental"],
+    "prerequisites": ["Liouville's theorem on Diophantine approximation", "algebraic degree"]
   },
   {
     "id": "ann-sqrt2oq02-existence",
     "proofId": "sqrt2-irrational-oq-02",
     "range": {
       "startLine": 47,
+      "endLine": 52
+    },
+    "type": "insight",
+    "title": "Answer to OQ-02: An Irrational Transcendental Exists",
+    "content": "exists_irrational_transcendental bundles liouvilleConst with its irrationality and transcendence to witness `∃ x, Irrational x ∧ Transcendental ℤ x` — the direct answer to the parent's second open question. Crucially this is settled by a single *explicit* construction (Liouville's constant), not by Cantor's counting argument that transcendentals exist because the algebraics are countable while ℝ is not. The explicit witness is constructive and axiom-free.",
+    "mathContext": "$\\exists x\\in\\mathbb{R},\\ \\text{Irrational }x \\wedge \\text{Transcendental}_{\\mathbb{Z}}\\,x$, witnessed by $L = \\sum_k 2^{-k!}$.",
+    "significance": "key",
+    "relatedConcepts": ["existence statement", "explicit vs counting construction", "Cantor's argument", "Transcendental"],
+    "prerequisites": ["existential statements", "transcendental numbers"]
+  },
+  {
+    "id": "ann-sqrt2oq02-non-exhaustion",
+    "proofId": "sqrt2-irrational-oq-02",
+    "range": {
+      "startLine": 54,
       "endLine": 59
     },
     "type": "insight",
-    "title": "Answer to OQ-02: irrational transcendentals exist",
-    "content": "exists_irrational_transcendental bundles liouvilleConst with its irrationality and transcendence to witness ∃ x, Irrational x ∧ Transcendental ℤ x. not_forall_irrational_isAlgebraic restates this as ∃ x, Irrational x ∧ ¬IsAlgebraic ℤ x — using that Transcendental ℤ x is definitionally ¬IsAlgebraic ℤ x — so the algebraic irrationals (the parent's √n) do NOT exhaust the irrationals. A single explicit construction settles the existence question without invoking Cantor's counting argument.",
-    "mathContext": "$\\exists x\\in\\mathbb{R},\\ \\text{Irrational }x\\wedge\\neg\\text{IsAlgebraic}_{\\mathbb{Z}}x$. Transcendence is strictly stronger than irrationality.",
-    "significance": "key",
-    "relatedConcepts": ["existence statement", "Transcendental", "IsAlgebraic", "non-exhaustion"],
-    "prerequisites": ["existential statements", "algebraic vs transcendental"]
+    "title": "Transcendence Is Strictly Stronger Than Irrationality",
+    "content": "not_forall_irrational_isAlgebraic restates the existence result as `∃ x, Irrational x ∧ ¬ IsAlgebraic ℤ x`, using that `Transcendental ℤ x` is *definitionally* `¬ IsAlgebraic ℤ x` — so the same witness proves it with no extra work. The point this makes precise: the algebraic irrationals (the parent's `√n` family) do NOT exhaust the irrational numbers. Irrationality and algebraicity are independent — `√2` is irrational+algebraic, `L` is irrational+transcendental — so the parent entry captured only part of the irrational landscape.",
+    "mathContext": "$\\text{Transcendental}_{\\mathbb{Z}}\\,x \\equiv \\neg\\,\\text{IsAlgebraic}_{\\mathbb{Z}}\\,x$; hence $\\exists x,\\ \\text{Irrational }x \\wedge \\neg\\,\\text{IsAlgebraic}_{\\mathbb{Z}}\\,x$.",
+    "significance": "supporting",
+    "relatedConcepts": ["IsAlgebraic", "definitional equality", "non-exhaustion", "irrational vs algebraic"],
+    "prerequisites": ["algebraic vs transcendental", "negation as definition"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `sqrt2-irrational-oq-02` (Beyond Irrationality: Transcendental Numbers Exist).

Already had 3 sections and 3 open questions, but only 3 annotations. The 61-line file has 5 named results forming a clear logical chain, so it genuinely tiles into 5 annotations (not padding).

## Changes
- **Annotations 3 → 5** (all with mathContext/significance/relatedConcepts/prerequisites; resolver **Valid 5, Misaligned 0**), splitting the lumped blocks along the logical chain:
  1. Context — algebraic irrationals → transcendence
  2. NEW *Liouville's Constant and Liouville Numbers* — the definition + Liouville-number fact, with the 1844 first-transcendentals history
  3. NEW *Irrational, Then Transcendental* — the `Liouville.irrational` and `transcendental_liouvilleNumber` steps via Liouville's inequality
  4. *An Irrational Transcendental Exists* — the explicit answer to OQ-02 (vs Cantor's counting argument)
  5. NEW *Transcendence Is Strictly Stronger Than Irrationality* — the `Transcendental ≡ ¬IsAlgebraic` definitional restatement and non-exhaustion of the irrationals

## Verification
- JSON valid; resolver Valid 5 / Misaligned 0; within the 60 KB cap
- No meta/status/badge/axiomCount change (entry remains `verified`, 0 axioms)
- Confirmed origin/main still has 3 annotations at push time (not raced)