### PR TITLE
research(cassini-identity-oq-01-oq-02): Fibonacci addition formula from Q^{m+n}=Q^m Q^n [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CassiniIdentityOQ01OQ02.lean
+++ b/proofs/Proofs/CassiniIdentityOQ01OQ02.lean
@@ -1,0 +1,121 @@
+/-
+  Fibonacci identities from the Q-matrix factorisation `Q^(m+n) = Q^m Q^n`
+  (open question `cassini-identity-oq-01-oq-02`)
+
+  Parent `cassini-identity-oq-01` establishes Cassini's identity
+  `F_{n+1} F_{n-1} − F_n² = (−1)ⁿ` from `det (Qⁿ) = (det Q)ⁿ`, where
+  `Q = !![1,1; 1,0]` is the Fibonacci companion ("Q-")matrix.
+
+  Its open question asks: can the **addition formula** be read off directly from the
+  entries of the matrix law `Q^{m+n} = Q^m Q^n` (which is just associativity of matrix
+  multiplication / `pow_add`), packaging several classical Fibonacci identities as
+  corollaries of a single factorisation, with no separate induction per identity?
+
+  This file does exactly that. The one inductive input is the closed form of the matrix
+  power (`Q_pow_succ`); every identity below is then a corollary obtained by reading off a
+  matrix entry of `Q^{(m+1)+(n+1)} = Q^{m+1} Q^{n+1}`, or by taking a determinant.
+
+  - `Q_pow_succ`     : `Q^(n+1) = !![F(n+2), F(n+1); F(n+1), F(n)]`  (the only induction).
+  - `fib_add_matrix` : `F(m+n+1) = F(m+1)F(n+1) + F(m)F(n)`  — the `(2,2)` entry
+                       (recovers Mathlib's `Nat.fib_add`).
+  - `fib_add_offdiag`: `F(m+n+2) = F(m+2)F(n+1) + F(m+1)F(n)`  — the `(1,2)` entry, the
+                       "addition formula" of the problem statement.
+  - `cassini_matrix` : `F(n+2)F(n) − F(n+1)² = (−1)^(n+1)`  — from `det (Q^(n+1))`, the
+                       Cassini identity recovered through the *same* factorisation.
+
+  Worked over `ℤ` (entries `(Nat.fib k : ℤ)`), 0 sorries, 0 axioms. Mathlib has no
+  Fibonacci Q-matrix of its own, so the closed form `Q_pow_succ` is a genuinely new
+  artifact.
+-/
+
+import Mathlib
+
+open Matrix
+
+namespace CassiniIdentityOQ01OQ02
+
+/-- The Fibonacci companion ("Q-")matrix over `ℤ`: `Q = !![1,1; 1,0]`. Its powers encode
+the Fibonacci numbers (`Q_pow_succ`), and `det Q = −1` drives Cassini's identity. -/
+def Q : Matrix (Fin 2) (Fin 2) ℤ := !![1, 1; 1, 0]
+
+/-- **Closed form of the Q-matrix power** (the single induction of this development):
+`Q^(n+1) = !![F(n+2), F(n+1); F(n+1), F(n)]`. The shifted exponent `n+1` keeps every
+Fibonacci index nonnegative, sidestepping the `F_{-1}` convention. -/
+theorem Q_pow_succ (n : ℕ) :
+    Q ^ (n + 1)
+      = !![(Nat.fib (n + 2) : ℤ), (Nat.fib (n + 1) : ℤ);
+            (Nat.fib (n + 1) : ℤ), (Nat.fib n : ℤ)] := by
+  induction n with
+  | zero =>
+      ext i j
+      fin_cases i <;> fin_cases j <;> simp [Q, pow_one]
+  | succ k ih =>
+      have F2 : (Nat.fib (k + 2) : ℤ) = (Nat.fib k : ℤ) + (Nat.fib (k + 1) : ℤ) := by
+        exact_mod_cast Nat.fib_add_two
+      have F3 : (Nat.fib (k + 3) : ℤ) = (Nat.fib (k + 1) : ℤ) + (Nat.fib (k + 2) : ℤ) := by
+        exact_mod_cast (Nat.fib_add_two (n := k + 1))
+      rw [pow_succ, ih, show Q = !![(1 : ℤ), 1; 1, 0] from rfl, Matrix.mul_fin_two]
+      ext i j
+      fin_cases i <;> fin_cases j <;>
+        simp only [Matrix.cons_val', Matrix.cons_val_fin_one, Matrix.of_apply,
+          Matrix.empty_val',
+          show (k + 1 + 2 : ℕ) = k + 3 from rfl, show (k + 1 + 1 : ℕ) = k + 2 from rfl] <;>
+        push_cast <;>
+        simp only [F2, F3, mul_one, mul_zero, add_zero] <;> ring
+
+/-- The matrix law `Q^{(m+1)+(n+1)} = Q^{m+1} · Q^{n+1}` with both sides put in closed
+form: the LHS is the closed power of `Q^{(m+n+1)+1}`, the RHS the product of the two
+closed powers. Every addition identity below is one entry of this single equation. -/
+private theorem Q_factor (m n : ℕ) :
+    (!![(Nat.fib (m + n + 3) : ℤ), (Nat.fib (m + n + 2) : ℤ);
+         (Nat.fib (m + n + 2) : ℤ), (Nat.fib (m + n + 1) : ℤ)]
+      : Matrix (Fin 2) (Fin 2) ℤ)
+      = !![(Nat.fib (m + 2) : ℤ), (Nat.fib (m + 1) : ℤ);
+            (Nat.fib (m + 1) : ℤ), (Nat.fib m : ℤ)]
+        * !![(Nat.fib (n + 2) : ℤ), (Nat.fib (n + 1) : ℤ);
+              (Nat.fib (n + 1) : ℤ), (Nat.fib n : ℤ)] := by
+  have hexp : (m + 1) + (n + 1) = (m + n + 1) + 1 := by ring
+  have hmat : Q ^ ((m + n + 1) + 1) = Q ^ (m + 1) * Q ^ (n + 1) := by
+    rw [← hexp, ← pow_add]
+  rw [Q_pow_succ, Q_pow_succ, Q_pow_succ] at hmat
+  -- normalise the LHS Fibonacci indices `(m+n+1)+2`, `(m+n+1)+1` to `m+n+3`, `m+n+2`
+  simpa only [show (m + n + 1 + 2 : ℕ) = m + n + 3 from rfl,
+    show (m + n + 1 + 1 : ℕ) = m + n + 2 from rfl] using hmat
+
+/-- **Addition formula, `(2,2)` entry.** `F(m+n+1) = F(m+1)F(n+1) + F(m)F(n)`.
+This is the bottom-right entry of `Q^{(m+1)+(n+1)} = Q^{m+1} Q^{n+1}`; it recovers
+Mathlib's `Nat.fib_add` as an entry of the matrix factorisation rather than by its own
+induction. -/
+theorem fib_add_matrix (m n : ℕ) :
+    Nat.fib (m + n + 1) = Nat.fib (m + 1) * Nat.fib (n + 1) + Nat.fib m * Nat.fib n := by
+  have h := congrFun (congrFun (Q_factor m n) 1) 1
+  simp only [Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.cons_val_fin_one, Matrix.of_apply, Matrix.empty_val',
+    Matrix.mul_apply, Fin.sum_univ_two] at h
+  exact_mod_cast h
+
+/-- **Addition formula, `(1,2)` entry** — the form in the problem statement.
+`F(m+n+2) = F(m+2)F(n+1) + F(m+1)F(n)`, read off the top-right entry of
+`Q^{(m+1)+(n+1)} = Q^{m+1} Q^{n+1}`. -/
+theorem fib_add_offdiag (m n : ℕ) :
+    Nat.fib (m + n + 2) = Nat.fib (m + 2) * Nat.fib (n + 1) + Nat.fib (m + 1) * Nat.fib n := by
+  have h := congrFun (congrFun (Q_factor m n) 0) 1
+  simp only [Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.cons_val_fin_one, Matrix.of_apply, Matrix.empty_val',
+    Matrix.mul_apply, Fin.sum_univ_two] at h
+  exact_mod_cast h
+
+/-- **Cassini's identity from the same factorisation.** `F(n+2)F(n) − F(n+1)² = (−1)^(n+1)`,
+obtained from `det (Q^(n+1)) = (det Q)^(n+1)` with `det Q = −1`. This is the parent
+entry's identity recovered through the Q-matrix used here for the addition formulas, so a
+single matrix `Q` packages both the addition law and Cassini. -/
+theorem cassini_matrix (n : ℕ) :
+    (Nat.fib (n + 2) : ℤ) * Nat.fib n - (Nat.fib (n + 1) : ℤ) ^ 2 = (-1) ^ (n + 1) := by
+  have hdet : (Q ^ (n + 1)).det = (Q.det) ^ (n + 1) := Matrix.det_pow _ _
+  rw [Q_pow_succ, Matrix.det_fin_two_of, show Q = !![(1 : ℤ), 1; 1, 0] from rfl,
+    Matrix.det_fin_two_of] at hdet
+  -- hdet : F(n+2)·F(n) − F(n+1)·F(n+1) = (1·0 − 1·1)^(n+1)
+  rw [sq, hdet]
+  norm_num
+
+end CassiniIdentityOQ01OQ02

--- a/research/problems/cassini-identity-oq-01-oq-02/knowledge.md
+++ b/research/problems/cassini-identity-oq-01-oq-02/knowledge.md
@@ -1,0 +1,72 @@
+# Knowledge Base: cassini-identity-oq-01-oq-02
+
+Fibonacci addition formula from the Q-matrix factorisation `Q^{m+n} = Q^m Q^n`.
+
+---
+
+## Problem Understanding
+
+Parent `cassini-identity-oq-01` (`Proofs/CassiniIdentityOQ01.lean`, verified) proves
+Cassini's identity from `det(Q^{n+1}) = (det Q)^{n+1}` with `Q = !![1,1;1,0]`. Its second
+open question: can the **addition formula** be read off directly from the entries of
+`Q^{m+n} = Q^m Q^n` (associativity of matrix multiplication), packaging several Fibonacci
+identities as corollaries of one factorisation, with no separate induction per identity?
+
+---
+
+## Session 2026-06-27 (researcher-9) — SOLVED the OQ [VERIFIED, 0-axiom]
+
+**Outcome**: BUILD + new gallery entry. The open question is answered: the addition
+formula is literally an entry of `Q^{(m+1)+(n+1)} = Q^{m+1} Q^{n+1}`.
+
+### Built `Proofs/CassiniIdentityOQ01OQ02.lean` (121 LOC, 1 def + 5 theorems)
+- `Q : Matrix (Fin 2) (Fin 2) ℤ := !![1,1;1,0]`.
+- `Q_pow_succ (n) : Q^(n+1) = !![F(n+2),F(n+1);F(n+1),F(n)]` — **the only induction**.
+  Shifted exponent `n+1` avoids the `F(-1)` index. Succ step: `rw [pow_succ, ih,
+  show Q = !![(1:ℤ),1;1,0] from rfl, Matrix.mul_fin_two]`, then per-entry
+  `simp only [cons_val', cons_val_fin_one, of_apply, empty_val',
+  show k+1+2 = k+3 from rfl, show k+1+1 = k+2 from rfl] <;> push_cast <;>
+  simp only [F2, F3, mul_one, mul_zero, add_zero] <;> ring`, where `F2,F3` are the cast
+  recurrences `(F(k+2):ℤ)=F k+F(k+1)` (`exact_mod_cast Nat.fib_add_two`) and
+  `(F(k+3):ℤ)=F(k+1)+F(k+2)` (`exact_mod_cast (Nat.fib_add_two (n:=k+1))`).
+- `Q_factor (m n)` (private): closed-form of `pow_add` — `!![F(m+n+3),..]= !![F(m+2),..]*
+  !![F(n+2),..]`. Built by `rw [← hexp, ← pow_add]` (hexp: (m+1)+(n+1)=(m+n+1)+1 by ring),
+  `rw [Q_pow_succ, Q_pow_succ, Q_pow_succ]`, then `simpa only [show ...=... from rfl]`
+  normalising the LHS indices.
+- `fib_add_matrix (m n) : F(m+n+1) = F(m+1)F(n+1) + F(m)F(n)` — the `(2,2)` entry
+  (recovers Mathlib `Nat.fib_add`). `congrFun (congrFun (Q_factor m n) 1) 1`, then
+  `simp only [cons_val', cons_val_zero, cons_val_one, cons_val_fin_one, of_apply,
+  empty_val', mul_apply, Fin.sum_univ_two] at h; exact_mod_cast h`.
+- `fib_add_offdiag (m n) : F(m+n+2) = F(m+2)F(n+1) + F(m+1)F(n)` — the `(1,2)` entry
+  (the problem's addition formula). Same recipe at index `(0,1)`.
+- `cassini_matrix (n) : (F(n+2):ℤ)*F(n) - (F(n+1):ℤ)^2 = (-1)^(n+1)` — `Matrix.det_pow`
+  + `det_fin_two_of` on `Q^(n+1)` and on `Q`; `rw [sq, hdet]; norm_num`.
+
+### Verification
+`lake env lean` (worktree proofs dir): EXIT 0, no warnings. `#print axioms` on all four
+public theorems = `[propext, Classical.choice, Quot.sound]` only — 0 counting-axioms, no
+`sorryAx`/`Lean.ofReduceBool`. Gallery `meta.json` + `annotations.json` created (status
+verified, badge original, axiomCount 0). meta/annotations JSON validated.
+
+### GOTCHAs
+- Build in the **worktree** proofs dir (`.loom/worktrees/researcher-9/proofs`), NOT the
+  main repo `proofs/` — concurrent agents edit there and clobber. Worktree `proofs/.lake`
+  symlinks to main's olean cache so `lake env lean` resolves Mathlib fine.
+- `rw [Q]` does NOT work for a plain `def`; use `rw [show Q = !![(1:ℤ),1;1,0] from rfl]`.
+- `Proofs.lean` is **auto-generated** (`.lean/scripts/generate-proofs-imports.sh`,
+  "do not edit manually") — ~495 proof files are unregistered; the generator picks up new
+  files. Do not hand-edit it (also avoids merge conflicts).
+- Index normalisation: `Nat.fib_add_two` matches `fib (?+2)` syntactically, so `fib(k+3)`
+  (numeral 3) is NOT rewritten by it — supply explicit cast `have`s (F2/F3) and normalise
+  `k+1+1→k+2`, `k+1+2→k+3` via `show ... from rfl` (they are defeq).
+- `congrFun (congrFun matEq i) j` reads off a matrix-equation entry (Matrix is a function
+  type synonym), then simp evaluates `!![..] i j`.
+
+### Files
+- `proofs/Proofs/CassiniIdentityOQ01OQ02.lean` (new, verified 0-axiom)
+- `src/data/proofs/cassini-identity-oq-01-oq-02/{meta.json,annotations.json}` (new entry)
+
+### Next Steps
+- d'Ocagne `F_m F_{n+1} - F_{m+1}F_n = (-1)^n F_{m-n}` from off-diagonal entries of a
+  product (needs `Q^{-n}` or a det-of-product argument).
+- Catalan identity via `det(Q^{n-r} Q^{2r})`.

--- a/src/data/proofs/cassini-identity-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-02/annotations.json
@@ -1,0 +1,61 @@
+[
+  {
+    "id": "ann-q-matrix",
+    "proofId": "cassini-identity-oq-01-oq-02",
+    "range": { "startLine": 37, "endLine": 39 },
+    "type": "definition",
+    "title": "The Fibonacci Companion Matrix Q",
+    "content": "The companion ('Q') matrix $Q = \\begin{psmallmatrix}1&1\\\\1&0\\end{psmallmatrix}$ over $\\mathbb{Z}$. Multiplying the column $(F_{k+1},F_k)$ by $Q$ produces $(F_{k+2},F_{k+1})$, so a single matrix carries the Fibonacci recurrence. The same $Q$ supplies both the addition formulas (through $Q^{m+n}=Q^mQ^n$) and Cassini's identity (through $\\det Q = -1$).",
+    "mathContext": "$Q = !![1,1;1,0]$ over $\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["Companion matrix", "Fibonacci recurrence", "Matrix powers"]
+  },
+  {
+    "id": "ann-matrix-power",
+    "proofId": "cassini-identity-oq-01-oq-02",
+    "range": { "startLine": 41, "endLine": 67 },
+    "type": "theorem",
+    "title": "Closed Form of the Q-Matrix Power (the only induction)",
+    "content": "The identity $Q^{n+1} = \\begin{psmallmatrix}F_{n+2}&F_{n+1}\\\\F_{n+1}&F_n\\end{psmallmatrix}$, proved by induction on $n$. The base case is $Q^1 = Q$. In the step $Q^{k+2} = Q^{k+1}\\cdot Q$ is expanded with `Matrix.mul_fin_two`; each of the four entries is a Fibonacci recurrence instance, closed by `push_cast` with the recurrence and `ring`. The shifted exponent $n+1$ keeps every index nonnegative, avoiding the $F_{-1}$ convention. This is the only induction in the file.",
+    "mathContext": "$Q^{n+1} = !![F_{n+2}, F_{n+1}; F_{n+1}, F_n]$.",
+    "significance": "critical",
+    "prerequisites": ["Matrix multiplication", "Mathematical induction", "Nat.fib_add_two"],
+    "relatedConcepts": ["Matrix powers", "Fibonacci recurrence", "Companion matrix"]
+  },
+  {
+    "id": "ann-factorisation",
+    "proofId": "cassini-identity-oq-01-oq-02",
+    "range": { "startLine": 69, "endLine": 87 },
+    "type": "theorem",
+    "title": "The Single Factorisation Q^{(m+1)+(n+1)} = Q^{m+1} Q^{n+1}",
+    "content": "Both sides of `pow_add` written in closed form: the left side is the closed power $Q^{(m+n+1)+1}$, the right the product of two closed powers (still unexpanded). This one matrix equation — true for the trivial reason that exponents add — is the source from which each addition identity is read off as an entry.",
+    "mathContext": "$!![F_{m+n+3},F_{m+n+2};F_{m+n+2},F_{m+n+1}] = !![F_{m+2},F_{m+1};F_{m+1},F_m]\\cdot!![F_{n+2},F_{n+1};F_{n+1},F_n]$.",
+    "significance": "critical",
+    "prerequisites": ["pow_add", "Matrix multiplication"],
+    "relatedConcepts": ["Associativity of matrix multiplication", "Matrix factorisation"]
+  },
+  {
+    "id": "ann-addition-formulas",
+    "proofId": "cassini-identity-oq-01-oq-02",
+    "range": { "startLine": 89, "endLine": 110 },
+    "type": "theorem",
+    "title": "Addition Formulas by Reading Off Entries",
+    "content": "Two corollaries extracted from the factorisation by `congrFun` and simplifying the matrix-product entry. The $(2,2)$ entry gives $F_{m+n+1} = F_{m+1}F_{n+1} + F_m F_n$, which is exactly Mathlib's `Nat.fib_add` — here recovered as a matrix entry rather than by its own induction. The $(1,2)$ entry gives the addition formula of the problem statement, $F_{m+n+2} = F_{m+2}F_{n+1} + F_{m+1}F_n$. Casting from $\\mathbb{Z}$ back to $\\mathbb{N}$ finishes each.",
+    "mathContext": "$(2,2)$: $F_{m+n+1} = F_{m+1}F_{n+1}+F_mF_n$; $(1,2)$: $F_{m+n+2} = F_{m+2}F_{n+1}+F_{m+1}F_n$.",
+    "significance": "critical",
+    "prerequisites": ["Matrix.mul_fin_two", "congrFun on a matrix equation", "exact_mod_cast"],
+    "relatedConcepts": ["Fibonacci addition formula", "Nat.fib_add", "Entry extraction"]
+  },
+  {
+    "id": "ann-cassini",
+    "proofId": "cassini-identity-oq-01-oq-02",
+    "range": { "startLine": 112, "endLine": 120 },
+    "type": "theorem",
+    "title": "Cassini's Identity from the Same Matrix",
+    "content": "The parent entry's identity $F_{n+2}F_n - F_{n+1}^2 = (-1)^{n+1}$, recovered here through the same $Q$: `Matrix.det_pow` gives $\\det(Q^{n+1}) = (\\det Q)^{n+1} = (-1)^{n+1}$, and `Matrix.det_fin_two_of` on the closed power gives $F_{n+2}F_n - F_{n+1}^2$. Equating the two closes the goal, showing a single companion matrix packages both the addition law and Cassini.",
+    "mathContext": "$F_{n+2}F_n - F_{n+1}^2 = (\\det Q)^{n+1} = (-1)^{n+1}$.",
+    "significance": "key",
+    "prerequisites": ["Matrix.det_pow", "Matrix.det_fin_two_of"],
+    "relatedConcepts": ["Cassini's identity", "Determinant multiplicativity", "Alternating sign"]
+  }
+]

--- a/src/data/proofs/cassini-identity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-02/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "cassini-identity-oq-01-oq-02",
+  "title": "Fibonacci Addition Formula from the Q-Matrix Factorisation Q^{m+n} = Q^m Q^n",
+  "slug": "cassini-identity-oq-01-oq-02",
+  "description": "Answers the open question of the parent entry (cassini-identity-oq-01): the Fibonacci addition formula is read off directly from the entries of the matrix law Q^{m+n} = Q^m Q^n, with Q = !![1,1;1,0] the Fibonacci companion matrix. A single induction establishes the closed power Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n]; every identity is then a corollary obtained by reading off one entry of Q^{(m+1)+(n+1)} = Q^{m+1}·Q^{n+1} or by taking a determinant. The (2,2) entry gives F_{m+n+1} = F_{m+1}F_{n+1} + F_m F_n (recovering Mathlib's Nat.fib_add), the (1,2) entry gives the addition formula F_{m+n+2} = F_{m+2}F_{n+1} + F_{m+1}F_n, and the determinant gives Cassini's identity F_{n+2}F_n − F_{n+1}² = (−1)^{n+1} — all packaged as corollaries of the one factorisation. Mathlib records no Fibonacci companion matrix, so the closed power form is a genuinely new artifact.",
+  "meta": {
+    "author": "Fibonacci addition formula (classical); Q-matrix factorisation proof formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Matrix_form",
+    "date": "1960",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "cassini",
+      "addition-formula",
+      "linear-algebra",
+      "companion-matrix",
+      "matrix-power",
+      "determinant",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CassiniIdentityOQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.mul_fin_two",
+        "description": "Closed form for the product of two 2×2 matrices given by !![..] literals. The four entries of Q^{m+1}·Q^{n+1} are exactly the bilinear Fibonacci sums that the addition identities assert.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Notation"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "The Fibonacci recurrence fib (n+2) = fib n + fib (n+1), the only arithmetic input to the inductive step identifying the entries of Q^{n+1} with consecutive Fibonacci numbers.",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Matrix.det_pow",
+        "description": "det (M^k) = (det M)^k. Applied with det Q = −1 it turns det(Q^{n+1}) into (−1)^{n+1}, supplying the alternating sign of Cassini's identity as a corollary of the same matrix.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_fin_two_of",
+        "description": "det !![a,b;c,d] = a·d − b·c, used to evaluate both det Q and det(Q^{n+1}) for the Cassini corollary.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "pow_add",
+        "description": "a^(m+n) = a^m · a^n in a monoid. Instantiated at the matrix Q it is the factorisation Q^{(m+1)+(n+1)} = Q^{m+1}·Q^{n+1} whose entries are the addition formulas — the associativity content the open question asks to exploit.",
+        "module": "Mathlib.Algebra.Group.Defs"
+      }
+    ],
+    "originalContributions": [
+      "Resolves the parent entry's open question: the Fibonacci addition formula is obtained by reading off a single entry of the matrix factorisation Q^{m+n} = Q^m Q^n, not by a dedicated induction",
+      "The closed Q-matrix power Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n] over ℤ proved by one induction on the Fibonacci recurrence — Mathlib records no Fibonacci companion matrix",
+      "Three classical identities packaged as corollaries of one factorisation: the (2,2) entry F_{m+n+1} = F_{m+1}F_{n+1} + F_m F_n (recovering Nat.fib_add), the (1,2) entry F_{m+n+2} = F_{m+2}F_{n+1} + F_{m+1}F_n, and Cassini's identity F_{n+2}F_n − F_{n+1}² = (−1)^{n+1} via the determinant",
+      "Demonstrates the 'one matrix identity, many corollaries' pattern: a family of bilinear Fibonacci identities becomes entry-reading on a single associativity equation"
+    ],
+    "dateAdded": "2026-06-27",
+    "axiomCount": 0,
+    "lineCount": 121,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The proof uses only structural Mathlib lemmas (Matrix.mul_fin_two, Matrix.det_pow, Matrix.det_fin_two_of, pow_add, Nat.fib_add_two) with induction, push_cast, ring, and exact_mod_cast; no native_decide and no structure-encoded hypotheses. #print axioms reports only the foundational propext, Classical.choice, Quot.sound, none of which count as assumptions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "sections": [
+    {
+      "id": "q-matrix",
+      "title": "The Fibonacci Q-Matrix",
+      "startLine": 37,
+      "endLine": 39,
+      "summary": "The companion matrix Q = !![1,1;1,0] over ℤ, whose powers carry the Fibonacci numbers and whose determinant −1 drives Cassini's identity."
+    },
+    {
+      "id": "matrix-power",
+      "title": "Closed Form of the Q-Matrix Power (the single induction)",
+      "startLine": 41,
+      "endLine": 67,
+      "summary": "Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n] by induction on n. The base case is Q^1 = Q; the step multiplies by Q (Matrix.mul_fin_two) and closes each of the four entries with the Fibonacci recurrence and ring. This is the only induction in the file."
+    },
+    {
+      "id": "factorisation",
+      "title": "The Single Factorisation Q^{(m+1)+(n+1)} = Q^{m+1} Q^{n+1}",
+      "startLine": 69,
+      "endLine": 87,
+      "summary": "Both sides of pow_add put in closed form: the left side is the closed power Q^{(m+n+1)+1}, the right the product of two closed powers. Every addition identity below is one entry of this single equation."
+    },
+    {
+      "id": "addition-formulas",
+      "title": "Addition Formulas by Reading Off Entries",
+      "startLine": 89,
+      "endLine": 110,
+      "summary": "The (2,2) entry gives F_{m+n+1} = F_{m+1}F_{n+1} + F_m F_n (recovering Mathlib's Nat.fib_add); the (1,2) entry gives the addition formula of the problem statement F_{m+n+2} = F_{m+2}F_{n+1} + F_{m+1}F_n. Each is extracted by congrFun on the matrix equation and simplifying the matrix-product entry."
+    },
+    {
+      "id": "cassini",
+      "title": "Cassini's Identity from the Same Matrix",
+      "startLine": 112,
+      "endLine": 120,
+      "summary": "F_{n+2}F_n − F_{n+1}² = (−1)^{n+1} from det(Q^{n+1}) = (det Q)^{n+1} = (−1)^{n+1}, recovering the parent entry's identity through the same Q used for the addition formulas."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**The Fibonacci Q-matrix**\n\nThe companion matrix $Q = \\begin{psmallmatrix}1&1\\\\1&0\\end{psmallmatrix}$ encodes the Fibonacci recurrence as a single linear map: its powers satisfy $Q^{n+1} = \\begin{psmallmatrix}F_{n+2}&F_{n+1}\\\\F_{n+1}&F_n\\end{psmallmatrix}$. This 'matrix form' of the Fibonacci numbers (popularised in the 20th century and underlying the $O(\\log n)$ fast-doubling algorithm) turns the whole zoo of bilinear Fibonacci identities into statements about products and determinants of $Q$. The parent entry cassini-identity-oq-01 used $\\det(Q^{n+1}) = (\\det Q)^{n+1}$ to prove Cassini's identity and asked, as an open question, whether the addition formula could likewise be read off the entries of $Q^{m+n} = Q^m Q^n$. This entry answers that question.",
+    "problemStatement": "**Addition formula from the matrix factorisation**\n\nThe law $Q^{m+n} = Q^m Q^n$ is just associativity of matrix multiplication (`pow_add`). Reading off an entry of both sides should yield the Fibonacci addition formula\n$$F_{m+n+2} = F_{m+2}F_{n+1} + F_{m+1}F_n,$$\nand, with the determinant, Cassini's identity — all as corollaries of one factorisation, with no separate induction per identity.",
+    "proofStrategy": "**One induction, then read off entries.** A single induction proves the closed power $Q^{n+1} = \\begin{psmallmatrix}F_{n+2}&F_{n+1}\\\\F_{n+1}&F_n\\end{psmallmatrix}$ over $\\mathbb{Z}$, the inductive step closing each of the four entries via $F_{k+2}=F_k+F_{k+1}$. Substituting this closed form into both sides of $Q^{(m+1)+(n+1)} = Q^{m+1}Q^{n+1}$ (an instance of `pow_add`) and expanding the right side with `Matrix.mul_fin_two` produces a matrix equation whose entries are exactly the bilinear Fibonacci identities. The $(2,2)$ entry is $F_{m+n+1} = F_{m+1}F_{n+1}+F_mF_n$; the $(1,2)$ entry is $F_{m+n+2} = F_{m+2}F_{n+1}+F_{m+1}F_n$. Casting back to $\\mathbb{N}$ gives the natural-number identities. Finally `Matrix.det_pow` against `Matrix.det_fin_two_of` recovers Cassini's identity from the same $Q$.",
+    "keyInsights": [
+      "**Associativity is the addition formula.** $Q^{m+n} = Q^m Q^n$ holds for the trivial reason that exponents add; reading off the $(1,2)$ entry turns this triviality into the Fibonacci addition law.",
+      "**One factorisation, many identities.** The same equation $Q^{(m+1)+(n+1)} = Q^{m+1}Q^{n+1}$ yields the $(2,2)$ identity (= Mathlib's `Nat.fib_add`), the $(1,2)$ addition formula, and — via the determinant — Cassini. No per-identity induction is needed.",
+      "**The closed power is the only induction.** All the combinatorial content is concentrated in $Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n]$; everything afterward is entry-reading and casting.",
+      "**Stay in ℤ.** Working with $(F_k : \\mathbb{Z})$ entries keeps matrix multiplication, the determinant, and the subtraction in Cassini genuine, with `ring` handling the entrywise algebra."
+    ],
+    "prerequisites": [
+      "Matrix multiplication, powers, and the determinant",
+      "a^(m+n) = a^m a^n in a monoid (pow_add)",
+      "Fibonacci numbers and their recurrence",
+      "Mathematical induction"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Fibonacci addition formula $F_{m+n+2} = F_{m+2}F_{n+1} + F_{m+1}F_n$ is read off the $(1,2)$ entry of the factorisation $Q^{(m+1)+(n+1)} = Q^{m+1}Q^{n+1}$, the $(2,2)$ entry gives $F_{m+n+1} = F_{m+1}F_{n+1}+F_mF_n$ (= Mathlib's `Nat.fib_add`), and the determinant gives Cassini's identity $F_{n+2}F_n - F_{n+1}^2 = (-1)^{n+1}$ — all corollaries of one matrix identity. The closed power $Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n]$ is the single induction. 0 axioms, 0 sorries.",
+    "implications": [
+      "Resolves the parent entry's second open question by exhibiting the Fibonacci addition formula as an entry of $Q^{m+n} = Q^m Q^n$.",
+      "Packages several classical Fibonacci identities (addition in two index forms, Cassini) as corollaries of a single associativity equation, demonstrating the 'one matrix identity, many corollaries' technique.",
+      "Reuses and extends the Fibonacci companion-matrix infrastructure (the closed power over ℤ) that Mathlib lacks, making it available for further identities (d'Ocagne, Catalan, convolution)."
+    ],
+    "openQuestions": [
+      "Can d'Ocagne's identity $F_m F_{n+1} - F_{m+1}F_n = (-1)^n F_{m-n}$ be obtained from the off-diagonal entries of $Q^m Q^{-n}$ or from a determinant of a product, completing the entry-reading programme for the standard identity list?",
+      "Does the Catalan identity $F_{n-r}F_{n+r} - F_n^2 = (-1)^{n-r+1}F_r^2$ follow from a determinant of $Q^{n-r}Q^{2r}$ as suggested in the parent entry, or does the off-diagonal mixing require a separate entry analysis?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry **`cassini-identity-oq-01-oq-02`** answering the second open question of the parent entry `cassini-identity-oq-01`: *can the Fibonacci addition formula be read off directly from the entries of `Q^{m+n} = Q^m Q^n`, packaging several identities as corollaries of one matrix factorisation?*

Yes. With the Fibonacci companion matrix `Q = !![1,1;1,0]` over ℤ, a single induction gives the closed power, and every identity below is one entry of the factorisation (an instance of `pow_add`) or a determinant.

## New file `proofs/Proofs/CassiniIdentityOQ01OQ02.lean` (1 def + 5 theorems)

- **`Q_pow_succ`** — `Q^(n+1) = !![F(n+2),F(n+1);F(n+1),F(n)]`. The only induction; the shifted exponent avoids the `F(-1)` convention.
- **`fib_add_matrix`** — `F(m+n+1) = F(m+1)F(n+1) + F(m)F(n)`, the `(2,2)` entry of `Q^{(m+1)+(n+1)} = Q^{m+1}Q^{n+1}` (recovers Mathlib's `Nat.fib_add` as a matrix entry).
- **`fib_add_offdiag`** — `F(m+n+2) = F(m+2)F(n+1) + F(m+1)F(n)`, the `(1,2)` entry: the addition formula of the problem statement.
- **`cassini_matrix`** — `F(n+2)F(n) − F(n+1)² = (−1)^(n+1)` via `det(Q^(n+1)) = (det Q)^(n+1)`: the parent's Cassini identity recovered through the *same* `Q`.

## Verification

- `lake env lean` on the file: **EXIT 0**, no warnings/sorries.
- `#print axioms` on all four public theorems: `[propext, Classical.choice, Quot.sound]` only — **0 counting-axioms** (no `sorryAx`, no `Lean.ofReduceBool`).
- New gallery entry: `meta.json` + `annotations.json`, status `verified`, badge `original`, `axiomCount` 0. (`Proofs.lean` is auto-generated and left untouched; the generator registers the new module.)

Mathlib records no Fibonacci companion matrix, so the closed power `Q^{n+1} = !![F(n+2),F(n+1);F(n+1),F(n)]` is a genuinely new artifact, reusable for further identities (d'Ocagne, Catalan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)