### PR TITLE
research(centered-hexagonal-sum-oq-01-oq-01): uniform centered-polygonal partial-sum closed form [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CenteredHexagonalSumOQ01OQ01.lean
+++ b/proofs/Proofs/CenteredHexagonalSumOQ01OQ01.lean
@@ -1,0 +1,96 @@
+/-
+# Centered Polygonal Partial Sums — a Uniform Closed Form
+
+## Open question (`centered-hexagonal-sum-oq-01-oq-01`)
+
+The parent entry `centered-hexagonal-sum-oq-01` proves the figurate identity that the
+first `n` *centered hexagonal* numbers sum to the perfect cube `n³`. Its open question
+asks whether the analogous **centered `k`-gonal** partial sums admit equally clean closed
+forms, and which reindexing keeps each computation inside the naturals.
+
+## Result
+
+For every `k`, the `n`-th centered `k`-gonal number is `C_{k,n} = k·n(n−1)/2 + 1`
+(the centre dot plus `k` triangular arms); `k = 6` is the centered hexagonal case
+`3n(n−1)+1`. The partial sums obey a single **uniform closed form**, valid for all `k`
+simultaneously and stated without any division or truncated subtraction:
+
+    6 · ∑_{i=1}^{n} C_{k,i}  =  k·n³ + (6−k)·n.
+
+* `six_mul_cgon_succ` — the per-term `/2` is eliminated once and for all: `n(n+1)` is
+  always even, so `6·C_{k,n+1} = 3·(k·n(n+1)) + 6` is a genuine ℕ identity.
+* `six_mul_sum_cgon` — the headline closed form `6·∑ C_{k,i} = k·n³ + (6−k)·n`, over ℤ
+  so the single coefficient `6−k` carries every centered-polygonal family at once
+  (k=3 centered triangular, k=4 centered square, k=5 centered pentagonal, …).
+* `cgon_six` / `sum_centeredHex_cube` — specialising to `k = 6` collapses `6−k` to `0`,
+  recovering the parent's cube identity `∑ C_{6,i} = n³` as a one-line corollary.
+
+The reindexing answer to the open question: scale by the denominator `6` and move the
+linear part to the other side (`+ (6−k)·n` rather than `− (k−6)·n`); then no division and
+no ℕ-subtraction ever appear, and `k = 6` is the unique value making the partial sums a
+pure power.
+
+0 sorries, 0 axioms.
+-/
+
+import Mathlib
+
+namespace CenteredHexagonalSumOQ01OQ01
+
+open Finset
+
+/-- The `n`-th **centered `k`-gonal number** `C_{k,n} = k·n(n−1)/2 + 1`: a central dot
+plus `k` triangular arms of `n−1` rings. `k = 6` gives the centered hexagonal numbers
+`3n(n−1)+1` of the parent entry; `k = 3, 4, 5` give the centered triangular, square, and
+pentagonal numbers. -/
+def cgon (k n : ℕ) : ℕ := k * (n * (n - 1)) / 2 + 1
+
+/-- For `k = 6` the definition is the parent entry's centered hexagonal number
+`C_{6,n} = 3·n(n−1) + 1`. -/
+theorem cgon_six (n : ℕ) : cgon 6 n = 3 * (n * (n - 1)) + 1 := by
+  unfold cgon
+  omega
+
+/-- **Eliminating the `/2`.** Because `n(n+1)` is always even, the reindexed term has the
+honest ℕ identity `6·C_{k,n+1} = 3·(k·n(n+1)) + 6` — no division survives. -/
+theorem six_mul_cgon_succ (k n : ℕ) :
+    6 * cgon k (n + 1) = 3 * (k * (n * (n + 1))) + 6 := by
+  have hdvd : 2 ∣ k * (n * (n + 1)) :=
+    (even_iff_two_dvd.mp (Nat.even_mul_succ_self n)).mul_left k
+  have hcgon : cgon k (n + 1) = k * (n * (n + 1)) / 2 + 1 := by
+    unfold cgon
+    rw [Nat.add_sub_cancel, Nat.mul_comm (n + 1) n]
+  rw [hcgon]
+  omega
+
+/-- **Uniform closed form for centered-polygonal partial sums.** Over ℤ, for every `k`,
+
+`6 · ∑_{i<n} C_{k,i+1} = k·n³ + (6−k)·n`,
+
+a single formula carrying every centered `k`-gonal family. The reindexed sum `∑_{i<n}
+C_{k,i+1}` is the `1`-indexed sum `∑_{i=1}^{n} C_{k,i}`. -/
+theorem six_mul_sum_cgon (k n : ℕ) :
+    6 * (∑ i ∈ range n, (cgon k (i + 1) : ℤ))
+      = (k : ℤ) * (n : ℤ) ^ 3 + (6 - (k : ℤ)) * (n : ℤ) := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+      rw [sum_range_succ, mul_add, ih]
+      have hC : (6 : ℤ) * (cgon k (m + 1) : ℤ) = 3 * ((k : ℤ) * ((m : ℤ) * (m + 1))) + 6 := by
+        exact_mod_cast six_mul_cgon_succ k m
+      rw [hC]
+      push_cast
+      ring
+
+/-- **Parent identity as a corollary** (`k = 6`). Centered hexagonal partial sums are
+cubes: `∑_{i=1}^{n} C_{6,i} = n³`. Specialising the uniform closed form to `k = 6` makes
+the linear coefficient `6 − k` vanish, leaving `6·∑ = 6·n³`. -/
+theorem sum_centeredHex_cube (n : ℕ) :
+    ∑ i ∈ range n, cgon 6 (i + 1) = n ^ 3 := by
+  have h := six_mul_sum_cgon 6 n
+  have h6 : (6 : ℤ) * (∑ i ∈ range n, (cgon 6 (i + 1) : ℤ)) = 6 * (n : ℤ) ^ 3 := by
+    rw [h]; ring
+  have hz : (∑ i ∈ range n, (cgon 6 (i + 1) : ℤ)) = (n : ℤ) ^ 3 := by linarith
+  exact_mod_cast hz
+
+end CenteredHexagonalSumOQ01OQ01

--- a/research/problems/centered-hexagonal-sum-oq-01-oq-01/knowledge.md
+++ b/research/problems/centered-hexagonal-sum-oq-01-oq-01/knowledge.md
@@ -1,0 +1,63 @@
+# Knowledge Base: centered-hexagonal-sum-oq-01-oq-01
+
+Uniform closed form for centered-polygonal partial sums.
+
+---
+
+## Problem Understanding
+
+Parent `centered-hexagonal-sum-oq-01` (`Proofs/CenteredHexagonalSum.lean`, verified)
+proves `∑_{i=1}^{n} C_{6,i} = n³` for centered hexagonal numbers `C_{6,n}=3n(n−1)+1`.
+Its OQ: do analogous centered k-gonal partial sums have equally clean closed forms, and
+which reindexing keeps each inside ℕ?
+
+---
+
+## Session 2026-06-27 (researcher-9) — SOLVED the OQ [VERIFIED, 0-axiom]
+
+**Outcome**: BUILD + new gallery entry. A single uniform closed form answers the OQ for
+all k at once.
+
+### The mathematics
+Centered k-gonal number `C_{k,n} = k·n(n−1)/2 + 1`. Partial sum
+`∑_{i=1}^{n} C_{k,i} = k·n(n²−1)/6 + n`. Cleared of division and ℕ-subtraction:
+
+  **6·∑_{i=1}^{n} C_{k,i} = k·n³ + (6−k)·n.**
+
+k=6 ⇒ coefficient (6−k)=0 ⇒ 6·∑ = 6n³ ⇒ ∑ = n³ (recovers parent). Hexagonal is the
+UNIQUE centered-polygonal family whose partial sums are a pure power.
+
+### Built `Proofs/CenteredHexagonalSumOQ01OQ01.lean` (96 LOC, 1 def + 4 theorems)
+- `cgon k n := k*(n*(n-1))/2 + 1`.
+- `cgon_six (n) : cgon 6 n = 3*(n*(n-1))+1` (= parent's centeredHex). Proof: `unfold; omega`
+  (omega clears `6*Y/2` for atom Y=n*(n-1)).
+- `six_mul_cgon_succ (k n) : 6 * cgon k (n+1) = 3*(k*(n*(n+1))) + 6`. The /2-elimination:
+  `hdvd : 2 ∣ k*(n*(n+1))` from `(even_iff_two_dvd.mp (Nat.even_mul_succ_self n)).mul_left k`,
+  then `rw [hcgon]; omega` (omega uses hdvd to discharge the division by literal 2).
+- `six_mul_sum_cgon (k n) : 6 * (∑ i ∈ range n, (cgon k (i+1):ℤ)) = k*n³ + (6−k)*n`.
+  Over ℤ so the single coeff (6−k) carries all families. Induction: `rw [sum_range_succ,
+  mul_add, ih]; rw [hC]; push_cast; ring` where `hC := exact_mod_cast six_mul_cgon_succ`.
+- `sum_centeredHex_cube (n) : ∑ i ∈ range n, cgon 6 (i+1) = n^3`. k=6 corollary: from
+  six_mul_sum_cgon, `(6−6)=0`, `6*∑ℤ = 6*n³`, `linarith` ⇒ ∑ℤ=n³, `exact_mod_cast`.
+
+### Verification
+`lake env lean` (worktree proofs dir): EXIT 0, no warnings. `#print axioms` on all four
+theorems = `[propext, Classical.choice, Quot.sound]` (cgon_six: only propext, Quot.sound) —
+0 counting-axioms. Gallery `meta.json` + `annotations.json` created (verified, original,
+axiomCount 0), JSON validated.
+
+### GOTCHAs
+- Build in the **worktree** proofs dir, NOT main (concurrent agents clobber).
+- `omega` clears division by a literal (`X/2`) when a `2 ∣ X` fact is in context and the
+  numerator is treated as a single atom — used to kill the centered-polygonal `/2` without
+  manual `Nat.div_mul_cancel` plumbing.
+- Keep the closed form division-free by stating it scaled (`6·∑ = …`) and ADDING `(6−k)·n`
+  rather than subtracting — answers the OQ's "stay inside ℕ" directly.
+
+### Files
+- `proofs/Proofs/CenteredHexagonalSumOQ01OQ01.lean` (new, verified 0-axiom)
+- `src/data/proofs/centered-hexagonal-sum-oq-01-oq-01/{meta.json,annotations.json}` (new)
+
+### Next Steps
+- Power sums `∑ C_{k,i}²` uniform in k.
+- Partial sums of ordinary (non-centered) k-gonal numbers and their pure-power value of k.

--- a/src/data/proofs/centered-hexagonal-sum-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/centered-hexagonal-sum-oq-01-oq-01/annotations.json
@@ -1,0 +1,49 @@
+[
+  {
+    "id": "ann-definition",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-01",
+    "range": { "startLine": 44, "endLine": 54 },
+    "type": "definition",
+    "title": "The Centered k-Gonal Number C_{k,n}",
+    "content": "$C_{k,n} = \\tfrac{k\\,n(n-1)}{2} + 1$: a central dot plus $k$ triangular arms of $n-1$ rings. The families $k=3,4,5,6$ are the centered triangular, square, pentagonal, and hexagonal numbers. The lemma `cgon_six` checks that $k=6$ reproduces the parent entry's centered hexagonal number $3n(n-1)+1$ (the $/2$ and the factor $6$ combine to $3$).",
+    "mathContext": "$C_{k,n} = k\\,n(n-1)/2 + 1$; $C_{6,n} = 3n(n-1)+1$.",
+    "significance": "key",
+    "relatedConcepts": ["Centered polygonal numbers", "Figurate numbers", "Triangular numbers"]
+  },
+  {
+    "id": "ann-denominator",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 70 },
+    "type": "theorem",
+    "title": "Eliminating the /2 via Parity",
+    "content": "`six_mul_cgon_succ`: $6\\,C_{k,n+1} = 3\\,(k\\,n(n+1)) + 6$. The centered $k$-gonal definition carries a division by $2$; because $n(n+1)$ is always even (`Nat.even_mul_succ_self`), we have $2 \\mid k\\,n(n+1)$, so multiplying by $6$ clears the division exactly and leaves a polynomial ℕ identity. With the divisibility fact in context, `omega` discharges the truncated division.",
+    "mathContext": "$6\\,C_{k,n+1} = 3\\,(k\\,n(n+1)) + 6$, using $2 \\mid n(n+1)$.",
+    "significance": "critical",
+    "prerequisites": ["Nat.even_mul_succ_self", "Divisibility", "omega"],
+    "relatedConcepts": ["Parity of consecutive integers", "Exact division"]
+  },
+  {
+    "id": "ann-closed-form",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-01",
+    "range": { "startLine": 72, "endLine": 86 },
+    "type": "theorem",
+    "title": "The Uniform Closed Form (all k at once)",
+    "content": "`six_mul_sum_cgon`: $6\\sum_{i<n} C_{k,i+1} = k\\,n^3 + (6-k)\\,n$ over $\\mathbb{Z}$. A single linear-in-$k$ formula carries every centered-polygonal family. The proof is a one-step induction: peel the top term (`Finset.sum_range_succ`), rewrite by the inductive hypothesis and the per-term lemma, and close with `ring`. Scaling by the denominator $6$ and writing $+(6-k)\\,n$ (rather than subtracting) is exactly the reindexing that keeps everything division- and subtraction-free.",
+    "mathContext": "$6\\sum_{i=1}^{n} C_{k,i} = k\\,n^3 + (6-k)\\,n$.",
+    "significance": "critical",
+    "prerequisites": ["Finset.sum_range_succ", "Mathematical induction", "ring over ℤ"],
+    "relatedConcepts": ["Closed-form partial sums", "Figurate number identities"]
+  },
+  {
+    "id": "ann-corollary",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-01",
+    "range": { "startLine": 88, "endLine": 95 },
+    "type": "theorem",
+    "title": "Parent Cube Identity (k = 6)",
+    "content": "`sum_centeredHex_cube`: $\\sum_{i=1}^{n} C_{6,i} = n^3$. Specialising the uniform formula to $k=6$ makes the linear coefficient $6-k$ vanish, leaving $6\\sum = 6\\,n^3$, hence $\\sum = n^3$ (divide by $6$, then cast ℤ→ℕ). Hexagonal is the unique centered-polygonal family whose partial sums are a perfect power, precisely because $6-k=0$ only at $k=6$.",
+    "mathContext": "$\\sum_{i=1}^{n} C_{6,i} = n^3$.",
+    "significance": "key",
+    "prerequisites": ["six_mul_sum_cgon", "linarith", "exact_mod_cast"],
+    "relatedConcepts": ["Centered hexagonal numbers", "Perfect cubes", "Specialisation"]
+  }
+]

--- a/src/data/proofs/centered-hexagonal-sum-oq-01-oq-01/meta.json
+++ b/src/data/proofs/centered-hexagonal-sum-oq-01-oq-01/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "centered-hexagonal-sum-oq-01-oq-01",
+  "title": "Centered Polygonal Partial Sums: a Uniform Closed Form",
+  "slug": "centered-hexagonal-sum-oq-01-oq-01",
+  "description": "Answers the parent entry's open question (centered-hexagonal-sum-oq-01): do the analogous centered k-gonal partial sums admit equally clean closed forms, and which reindexing keeps each inside the naturals? Yes — there is a single uniform closed form valid for all k at once: 6·∑_{i=1}^{n} C_{k,i} = k·n³ + (6−k)·n, where C_{k,n} = k·n(n−1)/2 + 1 is the n-th centered k-gonal number (k=6 is centered hexagonal, k=3 triangular, k=4 square, k=5 pentagonal). The reindexing answer: scale by the denominator 6 and add the linear term (6−k)·n to the right rather than subtracting, so no division or truncated ℕ-subtraction ever appears; the per-term /2 is eliminated once via the fact that n(n+1) is even. Specialising to k=6 makes the linear coefficient vanish, recovering the parent's cube identity ∑ C_{6,i} = n³ as a one-line corollary. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Centered polygonal figurate identities (classical); uniform closed form formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Centered_polygonal_number",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "figurate-numbers",
+      "centered-polygonal",
+      "finite-sums",
+      "closed-form",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CenteredHexagonalSumOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.even_mul_succ_self",
+        "description": "n(n+1) is always even. This is what eliminates the /2 in the centered k-gonal number: 2 ∣ k·n(n+1), so 6·C_{k,n+1} = 3·(k·n(n+1)) + 6 is an honest ℕ identity with no surviving division.",
+        "module": "Mathlib.Algebra.Group.Nat.Even"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the top term of ∑_{i<n+1} for the one-step induction proving the closed form.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.even_iff_two_dvd",
+        "description": "Converts the parity of n(n+1) to the divisibility 2 ∣ n(n+1) used by omega to discharge the /2.",
+        "module": "Mathlib.Algebra.Parity"
+      }
+    ],
+    "originalContributions": [
+      "A single uniform closed form 6·∑_{i=1}^{n} C_{k,i} = k·n³ + (6−k)·n carrying every centered k-gonal family at once (triangular, square, pentagonal, hexagonal, …), answering the parent entry's open question",
+      "The denominator-clearing reindexing: scaling by 6 and writing + (6−k)·n keeps the whole identity inside ℕ/ℤ with no division and no truncated subtraction — the requested 'stays inside the naturals' pattern",
+      "The per-term lemma 6·C_{k,n+1} = 3·(k·n(n+1)) + 6, removing the /2 in the centered-polygonal definition via the parity of n(n+1)",
+      "The parent's centered hexagonal cube identity ∑ C_{6,i} = n³ recovered as the k=6 corollary, where the linear coefficient 6−k vanishes — exhibiting hexagonal as the unique centered-polygonal family whose partial sums are a pure power"
+    ],
+    "dateAdded": "2026-06-27",
+    "axiomCount": 0,
+    "lineCount": 96,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Uses only structural Mathlib lemmas (Nat.even_mul_succ_self, Finset.sum_range_succ) with induction, omega, push_cast, ring, and exact_mod_cast; no native_decide and no structure-encoded hypotheses. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (cgon_six needs only propext, Quot.sound), none of which count as assumptions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The Centered k-Gonal Number",
+      "startLine": 44,
+      "endLine": 54,
+      "summary": "C_{k,n} = k·n(n−1)/2 + 1, a central dot plus k triangular arms. The lemma cgon_six identifies k=6 with the parent entry's centered hexagonal number 3n(n−1)+1."
+    },
+    {
+      "id": "denominator",
+      "title": "Eliminating the /2",
+      "startLine": 56,
+      "endLine": 70,
+      "summary": "six_mul_cgon_succ: because n(n+1) is even, 6·C_{k,n+1} = 3·(k·n(n+1)) + 6 holds in ℕ with no surviving division. The parity 2 ∣ k·n(n+1) lets omega discharge the truncated division."
+    },
+    {
+      "id": "closed-form",
+      "title": "The Uniform Closed Form",
+      "startLine": 72,
+      "endLine": 86,
+      "summary": "six_mul_sum_cgon: 6·∑_{i<n} C_{k,i+1} = k·n³ + (6−k)·n over ℤ, by one-step induction — a single coefficient (6−k) parameterises every centered-polygonal family. Scaling by 6 and adding (6−k)·n avoids all division and ℕ-subtraction."
+    },
+    {
+      "id": "corollary",
+      "title": "Parent Cube Identity as the k=6 Corollary",
+      "startLine": 88,
+      "endLine": 95,
+      "summary": "sum_centeredHex_cube: for k=6 the linear coefficient 6−k vanishes, so 6·∑ = 6·n³ and ∑ C_{6,i} = n³, recovering the parent entry's centered hexagonal cube identity."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Centered polygonal numbers**\n\nThe centered $k$-gonal numbers count dots in $k$-fold symmetric figures built from a central point surrounded by successive polygonal rings: $C_{k,n} = \\tfrac{k\\,n(n-1)}{2} + 1$. The centered hexagonal case $C_{6,n} = 3n(n-1)+1$ has the striking property (the parent entry, `centered-hexagonal-sum-oq-01`) that its partial sums are perfect cubes, $\\sum_{i=1}^{n} C_{6,i} = n^3$. A natural question — posed as that entry's open question — is whether the other centered-polygonal families enjoy comparably clean partial-sum formulas, and how to phrase them without leaving the natural numbers (the definition carries a $/2$).",
+    "problemStatement": "**Uniform centered-polygonal partial sum**\n\nFor every $k$ and $n$,\n$$6\\sum_{i=1}^{n} C_{k,i} = k\\,n^3 + (6-k)\\,n,$$\nstated so that no division or truncated subtraction appears. Specialising $k=6$ should recover the parent's cube identity.",
+    "proofStrategy": "**Clear the denominator, then one induction.** First eliminate the $/2$ in the definition: since $n(n+1)$ is even, $2 \\mid k\\,n(n+1)$, giving the honest ℕ identity $6\\,C_{k,n+1} = 3\\,(k\\,n(n+1)) + 6$ (`omega` discharges the division from the parity fact). Then a single induction on $n$ proves the closed form $6\\sum_{i<n} C_{k,i+1} = k\\,n^3 + (6-k)\\,n$ over ℤ: the step peels the top term with `Finset.sum_range_succ`, rewrites by the inductive hypothesis and the per-term lemma, and closes with `ring`. Working over ℤ lets the single coefficient $6-k$ carry every family; the reindexed sum $\\sum_{i<n} C_{k,i+1}$ is the $1$-indexed $\\sum_{i=1}^{n} C_{k,i}$.",
+    "keyInsights": [
+      "**One formula for all families.** Scaling by $6$ turns the family-dependent cubic into the single linear-in-$k$ identity $6\\sum C_{k,i} = k\\,n^3 + (6-k)\\,n$; centered triangular, square, pentagonal, hexagonal are just $k = 3,4,5,6$.",
+      "**Hexagonal is special because $6-k$ vanishes.** The partial sums are a pure power $n^3$ exactly when $k = 6$; for other $k$ a genuine linear term $(6-k)\\,n$ remains, so no other centered-polygonal family sums to a perfect power.",
+      "**Staying in ℕ is a phrasing choice.** Multiplying through by the denominator $6$ and moving the linear part to the right as $+(6-k)\\,n$ (rather than subtracting $(k-6)\\,n$) removes every division and every truncated subtraction.",
+      "**The $/2$ dies from parity.** $n(n+1)$ is always even, so the centered $k$-gonal number's division is exact and `omega` clears it once and for all."
+    ],
+    "prerequisites": [
+      "Centered polygonal (figurate) numbers",
+      "Finite sums over Finset.range",
+      "Parity of n(n+1)",
+      "Mathematical induction"
+    ]
+  },
+  "conclusion": {
+    "summary": "Every centered $k$-gonal partial sum obeys the single uniform closed form $6\\sum_{i=1}^{n} C_{k,i} = k\\,n^3 + (6-k)\\,n$, proved by clearing the $/2$ from the parity of $n(n+1)$ and a one-step induction over ℤ. Specialising $k=6$ makes $6-k$ vanish and recovers the parent entry's cube identity $\\sum C_{6,i} = n^3$. The formula is stated without division or truncated subtraction, answering the open question's 'stays inside the naturals' requirement. 0 axioms, 0 sorries.",
+    "implications": [
+      "Generalises the parent's centered hexagonal cube identity to all centered-polygonal families with a single linear-in-k formula.",
+      "Identifies hexagonal ($k=6$) as the unique centered-polygonal family whose partial sums are a perfect power, because that is precisely when the linear coefficient $6-k$ is zero.",
+      "Demonstrates the 'scale by the denominator, avoid subtraction' idiom for keeping figurate-sum identities inside ℕ/ℤ and ring-provable."
+    ],
+    "openQuestions": [
+      "Do the centered polygonal numbers themselves (not their partial sums) admit a clean closed form for ∑ C_{k,i}² or other power sums, again uniform in k?",
+      "Is there an analogous single formula for the partial sums of the ordinary (non-centered) k-gonal numbers, and how does the special value of k that yields a pure power shift?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry **`centered-hexagonal-sum-oq-01-oq-01`** answering the open question of the parent `centered-hexagonal-sum-oq-01`: *do the analogous centered k-gonal partial sums admit equally clean closed forms, and which reindexing keeps each inside the naturals?*

Yes — a single **uniform closed form** carries every centered-polygonal family at once, stated with no division and no truncated ℕ-subtraction:

> `6 · ∑_{i=1}^{n} C_{k,i} = k·n³ + (6−k)·n`,  where `C_{k,n} = k·n(n−1)/2 + 1`.

`k = 6` makes the linear coefficient `6−k` vanish, recovering the parent's cube identity `∑ C_{6,i} = n³` — and showing **hexagonal is the unique centered-polygonal family whose partial sums are a perfect power**.

## New file `proofs/Proofs/CenteredHexagonalSumOQ01OQ01.lean` (1 def + 4 theorems)

- **`cgon` / `cgon_six`** — the centered k-gonal number; `k=6` is the parent's `3n(n−1)+1`.
- **`six_mul_cgon_succ`** — `6·C_{k,n+1} = 3·(k·n(n+1)) + 6`, eliminating the `/2` via the parity of `n(n+1)` (`omega` + `2 ∣ k·n(n+1)`).
- **`six_mul_sum_cgon`** — the uniform closed form over ℤ, one coefficient `(6−k)` per family, by one-step induction.
- **`sum_centeredHex_cube`** — `∑ C_{6,i} = n³` as the `k=6` corollary.

## Verification

- `lake env lean`: **EXIT 0**, no warnings/sorries.
- `#print axioms` on all four theorems: `[propext, Classical.choice, Quot.sound]` only (`cgon_six` needs just `propext, Quot.sound`) — **0 counting-axioms**.
- New gallery entry: `meta.json` + `annotations.json`, status `verified`, badge `original`, `axiomCount` 0.

The reindexing answer to the open question: scale by the denominator `6` and **add** `(6−k)·n` (rather than subtract), so the whole identity stays inside ℕ/ℤ and is `ring`-provable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)