### PR TITLE
audit(gallery): drain 6 unaudited proofs — all CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25349,6 +25349,42 @@
       "lastAudited": "2026-06-27T23:10:02Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-01-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T23:58:18Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T23:58:18Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cassini-identity-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T23:58:19Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-01-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T23:58:19Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-10": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T23:58:19Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-3-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T23:58:19Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 6 unaudited proofs drained

All 6 previously-unaudited gallery entries audited; **all CLEAN**. No meta.json overclaims found.

| slug | status/badge | sorry | axiom | verdict |
|------|--------------|-------|-------|---------|
| abel-ruffini-oq-04-oq-01-oq-04-oq-01 | verified/original | 0 | 0 | clean — Sₙ unsolvable side, real theorems |
| abel-ruffini-oq-06 | verified/**mathlib** | 0 | 0 | clean — badge correctly `mathlib`, deep deps disclosed |
| cassini-identity-oq-01-oq-02 | verified/original | 0 | 0 | clean — Cassini via Q-matrix powers |
| cauchy-schwarz-oq-01-oq-03-oq-02-oq-01 | verified/original | 0 | 0 | clean — Maassen–Uffink entropic uncertainty |
| combinations-formula-oq-10 | verified/original | 0 | 0 | clean — Σ C(n,k)²=C(2n,n); `decide×4` is plain kernel-decide (not `ofReduceBool`) |
| hilbert-3-oq-01 | verified/original | 0 | 0 | clean — graded Dehn invariant |

### Checks applied
- **True-stub**: 0 across all files (no vacuous `: True` / `:= trivial` theorems)
- **Sorry count**: meta `sorries: 0` matches actual (0 in all files)
- **Axiom count**: meta `axiomCount: 0` matches (0 `axiom` declarations; no `native_decide`/`sorryAx`)
- **Mathlib-wrapper honesty**: `abel-ruffini-oq-06` correctly badged `mathlib` and lists its 5 deep `mathlibDependencies`. The `original`-badged files build on Mathlib *primitives* (matrix multiplication, Fibonacci recurrence) rather than a single deep theorem doing the core work — `original` is defensible.

### Queue state after this PR
- 0 unaudited remaining
- 3 standing false-positives (re-confirmed safe, no action): `erdos-156` (wip, honest), `erdos-1090` (under-claim), `erdos-57-oq-04` (host-file `axiom erdos_57` is the parent conjecture used only in `infinite_odd_cycle_lengths`; the oq-04 theorems `exists_odd_cycle_*` are axiom-free)

Only `src/data/proofs/audit-tracker.json` changes (6 clean entries appended).

---
Discovered during gallery integrity audit.