### PR TITLE
research(catalan-numbers-oq-05-oq-01): Catalan as a difference of central binomials (ballot number) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CatalanNumbersOQ05OQ01.lean
+++ b/proofs/Proofs/CatalanNumbersOQ05OQ01.lean
@@ -1,0 +1,88 @@
+/-
+# The Catalan Number as a Difference of Central Binomial Coefficients (Ballot Number)
+
+## Open question (`catalan-numbers-oq-05-oq-01`)
+
+The parent entry `catalan-numbers-oq-05` works with the Catalan numbers via Mathlib's
+explicit formula `catalan n = C(2n,n)/(n+1)`. Its open question asks for the
+*row-difference* form: `catalan n` as a reflected difference of binomial coefficients —
+the **ballot numbers** `C(2n,n−k) − C(2n,n−k−1)` — exhibiting the Catalan triangle as
+successive differences.
+
+## Result
+
+The base ballot number (`k = 0`) is the clean closed identity
+
+    catalan n = C(2n, n) − C(2n, n+1),
+
+i.e. each Catalan number is the *gap* between the central binomial coefficient and its
+immediate neighbour. Mathlib has the division form `catalan n = centralBinom n / (n+1)`
+(`Nat.catalan_eq_centralBinom_div`) but not this subtraction-free-of-division form.
+
+* `choose_two_mul_succ` — the neighbour coefficient is `C(2n,n+1) = n · catalan n`,
+  obtained from the Pascal recurrence `choose_succ_right_eq` and
+  `succ_mul_catalan_eq_centralBinom`.
+* `catalan_eq_choose_sub` — the headline `catalan n = C(2n,n) − C(2n,n+1)`, since
+  `C(2n,n) = (n+1)·catalan n` and `C(2n,n+1) = n·catalan n`, whose difference is
+  `catalan n` (a genuine ℕ subtraction, never truncated).
+* `catalan_eq_choose_sub_symm` — the reflected form `catalan (n+1) = C(2(n+1),n+1) −
+  C(2(n+1),n)`, using the symmetry `C(2(n+1),n+2) = C(2(n+1),n)`; this is the ballot-number
+  reading the open question asks for.
+
+0 sorries, 0 axioms.
+-/
+
+import Mathlib
+
+namespace CatalanNumbersOQ05OQ01
+
+open Nat
+
+/-- The off-centre central-binomial neighbour is `C(2n, n+1) = n · catalan n`. Derived
+from the Pascal step `C(2n,n+1)·(n+1) = C(2n,n)·n` together with
+`C(2n,n) = (n+1)·catalan n`. -/
+theorem choose_two_mul_succ (n : ℕ) : (2 * n).choose (n + 1) = n * catalan n := by
+  -- Pascal: C(2n, n+1)·(n+1) = C(2n, n)·(2n − n) = C(2n, n)·n.
+  have hkey : (2 * n).choose (n + 1) * (n + 1) = (2 * n).choose n * n := by
+    have h := Nat.choose_succ_right_eq (2 * n) n
+    simpa [two_mul, Nat.add_sub_cancel] using h
+  -- Central binomial in terms of the Catalan number.
+  have hcb : (2 * n).choose n = (n + 1) * catalan n := by
+    have h := succ_mul_catalan_eq_centralBinom n
+    rw [Nat.centralBinom_eq_two_mul_choose] at h
+    omega
+  -- Cancel the common factor (n+1).
+  have heq : (2 * n).choose (n + 1) * (n + 1) = (n * catalan n) * (n + 1) := by
+    rw [hkey, hcb]; ring
+  exact Nat.eq_of_mul_eq_mul_right (Nat.succ_pos n) heq
+
+/-- **Catalan number as a difference of central binomial coefficients.**
+`catalan n = C(2n, n) − C(2n, n+1)`: each Catalan number is the gap between the central
+binomial coefficient and its neighbour (the base, `k = 0`, ballot number). -/
+theorem catalan_eq_choose_sub (n : ℕ) :
+    catalan n = (2 * n).choose n - (2 * n).choose (n + 1) := by
+  have hcb : (2 * n).choose n = (n + 1) * catalan n := by
+    have h := succ_mul_catalan_eq_centralBinom n
+    rw [Nat.centralBinom_eq_two_mul_choose] at h
+    omega
+  rw [hcb, choose_two_mul_succ]
+  have h : (n + 1) * catalan n = n * catalan n + catalan n := by ring
+  omega
+
+/-- **Reflected (ballot-number) form.** For `n ≥ 1` (here written `n+1`),
+`catalan (n+1) = C(2(n+1), n+1) − C(2(n+1), n)`, using the binomial symmetry
+`C(2(n+1), n+2) = C(2(n+1), n)`. This is the row-difference reading of the open question:
+the Catalan number is the difference of two adjacent entries in row `2(n+1)` of Pascal's
+triangle, read symmetrically about the centre. (The index `n+1` avoids the spurious ℕ
+truncation `n−1` at `n=0`, where the unshifted reflected form would fail.) -/
+theorem catalan_eq_choose_sub_symm (n : ℕ) :
+    catalan (n + 1) = (2 * (n + 1)).choose (n + 1) - (2 * (n + 1)).choose n := by
+  have hsymm : (2 * (n + 1)).choose ((n + 1) + 1) = (2 * (n + 1)).choose n := by
+    have hle : (n + 1) + 1 ≤ 2 * (n + 1) := by omega
+    have h := Nat.choose_symm hle
+    have he : 2 * (n + 1) - ((n + 1) + 1) = n := by omega
+    rw [he] at h
+    exact h.symm
+  rw [catalan_eq_choose_sub, hsymm]
+
+end CatalanNumbersOQ05OQ01

--- a/research/problems/catalan-numbers-oq-05-oq-01/knowledge.md
+++ b/research/problems/catalan-numbers-oq-05-oq-01/knowledge.md
@@ -1,0 +1,54 @@
+# Knowledge Base: catalan-numbers-oq-05-oq-01
+
+Catalan number as a difference of central binomial coefficients (ballot number).
+
+---
+
+## Problem Understanding
+
+Parent `catalan-numbers-oq-05` uses Mathlib's `catalan n = centralBinom n / (n+1)`. Its OQ:
+express `catalan n` as a reflected difference of binomial coefficients — the ballot
+numbers `C(2n,n−k) − C(2n,n−k−1)` — exhibiting the Catalan triangle as successive
+differences.
+
+---
+
+## Session 2026-06-27 (researcher-9) — SOLVED (base ballot number) [VERIFIED, 0-axiom]
+
+**Outcome**: BUILD + new gallery entry. The base ballot number `catalan n = C(2n,n) −
+C(2n,n+1)` (not in Mathlib) plus the reflected form.
+
+### The mathematics
+`C(2n,n) = (n+1)·catalan n` (Mathlib `succ_mul_catalan_eq_centralBinom`).
+`C(2n,n+1) = n·catalan n` (Pascal step + cancellation). Difference = catalan n.
+
+### Built `Proofs/CatalanNumbersOQ05OQ01.lean` (88 LOC, 3 theorems, no def)
+- `choose_two_mul_succ (n) : (2*n).choose (n+1) = n * catalan n`. Pascal:
+  `Nat.choose_succ_right_eq (2*n) n` → `C(2n,n+1)*(n+1) = C(2n,n)*(2n−n)`, simp
+  `[two_mul, Nat.add_sub_cancel]` → `= C(2n,n)*n`; sub `C(2n,n)=(n+1)*catalan n`; cancel
+  `(n+1)` via `Nat.eq_of_mul_eq_mul_right (Nat.succ_pos n)`.
+- `catalan_eq_choose_sub (n) : catalan n = (2*n).choose n − (2*n).choose (n+1)`. rw the two
+  coefficient identities, then `omega` (with `(n+1)*c = n*c + c` by ring).
+- `catalan_eq_choose_sub_symm (n) : catalan (n+1) = (2*(n+1)).choose (n+1) −
+  (2*(n+1)).choose n`. Binomial symmetry `Nat.choose_symm` reflects `C(2(n+1),n+2)` to
+  `C(2(n+1),n)`. Indexed at n+1 to avoid the FALSE n=0 case of the unshifted n−1 form.
+
+### Verification
+`lake env lean` (worktree): EXIT 0, no warnings. `#print axioms` all three =
+`[propext, Classical.choice, Quot.sound]` — 0 counting-axioms. Gallery meta+annotations
+created (verified/original/axiomCount 0), JSON validated.
+
+### GOTCHAs
+- `catalan` and `succ_mul_catalan_eq_centralBinom` are ROOT namespace (NOT `Nat.`); but
+  `Nat.centralBinom`, `Nat.centralBinom_eq_two_mul_choose`, `Nat.choose_*` are `Nat.`.
+- **ℕ-truncation trap**: the reflected form `catalan n = C(2n,n) − C(2n,n−1)` is FALSE at
+  n=0 (n−1 truncates to 0 → C(0,0)−C(0,0)=0 ≠ catalan 0 = 1). State it at n+1.
+- Build in the WORKTREE proofs dir, not main.
+
+### Files
+- `proofs/Proofs/CatalanNumbersOQ05OQ01.lean` (new, verified 0-axiom)
+- `src/data/proofs/catalan-numbers-oq-05-oq-01/{meta.json,annotations.json}` (new)
+
+### Next Steps
+- Full Catalan triangle B(2n,k) = C(2n,n+k) − C(2n,n+k+1) uniformly.
+- Convolution identities from reflected sums of ballot numbers.

--- a/src/data/proofs/catalan-numbers-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-05-oq-01/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-neighbour",
+    "proofId": "catalan-numbers-oq-05-oq-01",
+    "range": { "startLine": 41, "endLine": 57 },
+    "type": "theorem",
+    "title": "The Neighbour Coefficient C(2n,n+1) = n·catalan n",
+    "content": "`choose_two_mul_succ`: $\\binom{2n}{n+1} = n\\,C_n$. The Pascal step `choose_succ_right_eq` gives $\\binom{2n}{n+1}(n+1) = \\binom{2n}{n}(2n-n) = \\binom{2n}{n}\\,n$; substituting $\\binom{2n}{n} = (n+1)C_n$ (`succ_mul_catalan_eq_centralBinom`) and cancelling the common factor $(n+1)$ via `Nat.eq_of_mul_eq_mul_right` yields the result.",
+    "mathContext": "$\\binom{2n}{n+1} = n\\,C_n$.",
+    "significance": "critical",
+    "prerequisites": ["Nat.choose_succ_right_eq", "succ_mul_catalan_eq_centralBinom", "Cancellation"],
+    "relatedConcepts": ["Pascal's recurrence", "Central binomial coefficient"]
+  },
+  {
+    "id": "ann-difference",
+    "proofId": "catalan-numbers-oq-05-oq-01",
+    "range": { "startLine": 59, "endLine": 70 },
+    "type": "theorem",
+    "title": "Catalan as a Difference of Central Binomial Coefficients",
+    "content": "`catalan_eq_choose_sub`: $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$, the base ballot number. With $\\binom{2n}{n} = (n+1)C_n$ and $\\binom{2n}{n+1} = nC_n$, the difference is $(n+1)C_n - nC_n = C_n$ — a genuine ℕ subtraction (the minuend dominates), discharged by `omega` given the ring identity $(n+1)C_n = nC_n + C_n$.",
+    "mathContext": "$C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$.",
+    "significance": "critical",
+    "prerequisites": ["choose_two_mul_succ", "succ_mul_catalan_eq_centralBinom", "omega"],
+    "relatedConcepts": ["Ballot numbers", "Catalan triangle", "Natural-number subtraction"]
+  },
+  {
+    "id": "ann-reflected",
+    "proofId": "catalan-numbers-oq-05-oq-01",
+    "range": { "startLine": 72, "endLine": 87 },
+    "type": "theorem",
+    "title": "The Reflected (Ballot-Number) Form",
+    "content": "`catalan_eq_choose_sub_symm`: $C_{n+1} = \\binom{2(n+1)}{n+1} - \\binom{2(n+1)}{n}$, using the binomial symmetry $\\binom{2(n+1)}{n+2} = \\binom{2(n+1)}{n}$ (`choose_symm`). This is the row-difference reading of the Catalan triangle. The statement is indexed at $n+1$ because the unshifted form with $n-1$ is false at $n=0$, where $n-1$ truncates to $0$ in ℕ.",
+    "mathContext": "$C_{n+1} = \\binom{2(n+1)}{n+1} - \\binom{2(n+1)}{n}$.",
+    "significance": "key",
+    "prerequisites": ["Nat.choose_symm", "catalan_eq_choose_sub"],
+    "relatedConcepts": ["Binomial symmetry", "Ballot numbers", "ℕ truncation"]
+  }
+]

--- a/src/data/proofs/catalan-numbers-oq-05-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-05-oq-01/meta.json
@@ -1,0 +1,110 @@
+{
+  "id": "catalan-numbers-oq-05-oq-01",
+  "title": "The Catalan Number as a Difference of Central Binomial Coefficients (Ballot Number)",
+  "slug": "catalan-numbers-oq-05-oq-01",
+  "description": "Answers the parent entry's open question (catalan-numbers-oq-05) for the base ballot number: the Catalan number is the difference of the central binomial coefficient and its neighbour, catalan n = C(2n,n) − C(2n,n+1). Mathlib records the division form catalan n = centralBinom n / (n+1) but not this difference form. The proof identifies both coefficients in terms of the Catalan number — C(2n,n) = (n+1)·catalan n (Mathlib's succ_mul_catalan_eq_centralBinom) and C(2n,n+1) = n·catalan n (from the Pascal step choose_succ_right_eq) — whose difference is exactly catalan n, a genuine ℕ subtraction. A reflected form catalan (n+1) = C(2(n+1),n+1) − C(2(n+1),n) is derived from binomial symmetry, giving the row-difference (ballot-number) reading the open question asks for. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Ballot numbers / Catalan triangle (classical); difference identity formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "ballot-numbers",
+      "binomial-coefficients",
+      "central-binomial",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CatalanNumbersOQ05OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "succ_mul_catalan_eq_centralBinom",
+        "description": "(n+1)·catalan n = centralBinom n. Gives C(2n,n) = (n+1)·catalan n, the larger of the two coefficients in the difference.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "choose n (k+1) · (k+1) = choose n k · (n−k). With n = 2n, k = n it gives C(2n,n+1)·(n+1) = C(2n,n)·n, from which C(2n,n+1) = n·catalan n after cancelling (n+1).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "choose n (n−k) = choose n k for k ≤ n. Supplies the reflection C(2(n+1),n+2) = C(2(n+1),n) for the symmetric ballot-number form.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "centralBinom n = (2n).choose n, connecting Mathlib's centralBinom to the explicit binomial coefficient used throughout.",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      }
+    ],
+    "originalContributions": [
+      "The difference identity catalan n = C(2n,n) − C(2n,n+1) — the base ballot number — which Mathlib does not record (it has only the division form catalan n = centralBinom n / (n+1))",
+      "The neighbour-coefficient lemma C(2n,n+1) = n·catalan n, obtained by cancelling (n+1) in the Pascal step choose_succ_right_eq against C(2n,n) = (n+1)·catalan n",
+      "The reflected ballot-number form catalan (n+1) = C(2(n+1),n+1) − C(2(n+1),n) via binomial symmetry, the row-difference reading of the Catalan triangle the open question asks for",
+      "A note on the ℕ truncation pitfall: the unshifted reflected form catalan n = C(2n,n) − C(2n,n−1) is false at n=0 (where n−1 truncates to 0), which is why the symmetric statement is indexed at n+1"
+    ],
+    "dateAdded": "2026-06-27",
+    "axiomCount": 0,
+    "lineCount": 88,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Uses only structural Mathlib lemmas (succ_mul_catalan_eq_centralBinom, Nat.choose_succ_right_eq, Nat.choose_symm, Nat.centralBinom_eq_two_mul_choose) with omega and ring; no native_decide and no structure-encoded hypotheses. #print axioms reports only the foundational propext, Classical.choice, Quot.sound, none of which count as assumptions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "neighbour",
+      "title": "The Neighbour Coefficient C(2n,n+1) = n·catalan n",
+      "startLine": 41,
+      "endLine": 57,
+      "summary": "From the Pascal step choose_succ_right_eq, C(2n,n+1)·(n+1) = C(2n,n)·n; combined with C(2n,n) = (n+1)·catalan n and cancelling (n+1) gives C(2n,n+1) = n·catalan n."
+    },
+    {
+      "id": "difference",
+      "title": "Catalan as a Difference of Central Binomial Coefficients",
+      "startLine": 59,
+      "endLine": 70,
+      "summary": "catalan n = C(2n,n) − C(2n,n+1): since C(2n,n) = (n+1)·catalan n and C(2n,n+1) = n·catalan n, the difference is (n+1)·catalan n − n·catalan n = catalan n, a genuine ℕ subtraction closed by omega."
+    },
+    {
+      "id": "reflected",
+      "title": "The Reflected (Ballot-Number) Form",
+      "startLine": 72,
+      "endLine": 87,
+      "summary": "catalan (n+1) = C(2(n+1),n+1) − C(2(n+1),n), from binomial symmetry C(2(n+1),n+2) = C(2(n+1),n). Indexing at n+1 avoids the spurious ℕ truncation n−1 at n=0."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Ballot numbers and the Catalan triangle**\n\nThe Catalan number $C_n$ counts Dyck paths, balanced parenthesisations, and binary trees. Beyond the explicit formula $C_n = \\tfrac{1}{n+1}\\binom{2n}{n}$, the Catalan numbers sit at the edge of the *ballot number* triangle $B(m,k) = \\binom{m}{k} - \\binom{m}{k-1}$, where successive differences of binomial coefficients in a fixed row count constrained lattice paths. The base entry of row $2n$ is $\\binom{2n}{n} - \\binom{2n}{n+1} = C_n$. The parent entry `catalan-numbers-oq-05` uses the division form; its open question asks for this row-difference reading.",
+    "problemStatement": "**Catalan as a difference of binomials**\n\nFor every $n$,\n$$C_n = \\binom{2n}{n} - \\binom{2n}{n+1},$$\nand, symmetrically (for $n \\ge 1$), $C_n = \\binom{2n}{n} - \\binom{2n}{n-1}$. The goal is a fully machine-checked proof of this difference (ballot-number) form, complementing Mathlib's division formula.",
+    "proofStrategy": "**Pin both coefficients to the Catalan number, then subtract.** Mathlib's `succ_mul_catalan_eq_centralBinom` gives $\\binom{2n}{n} = (n+1)C_n$. For the neighbour, the Pascal recurrence `choose_succ_right_eq` gives $\\binom{2n}{n+1}(n+1) = \\binom{2n}{n}\\,n = (n+1)C_n\\,n$; cancelling $(n+1)$ yields $\\binom{2n}{n+1} = n\\,C_n$. Their difference is $(n+1)C_n - nC_n = C_n$ — a genuine ℕ subtraction (the minuend dominates), discharged by `omega`. The reflected form follows from the symmetry $\\binom{2(n+1)}{n+2} = \\binom{2(n+1)}{n}$ (`choose_symm`), indexed at $n+1$ to avoid the truncated $n-1$ at $n=0$.",
+    "keyInsights": [
+      "**Both coefficients are Catalan multiples.** $\\binom{2n}{n} = (n+1)C_n$ and $\\binom{2n}{n+1} = nC_n$, so their difference collapses to $C_n$ with no binomial arithmetic left over.",
+      "**The neighbour comes from one Pascal step.** `choose_succ_right_eq` relates $\\binom{2n}{n+1}$ to $\\binom{2n}{n}$; cancelling the common factor $(n+1)$ is the whole content of the neighbour lemma.",
+      "**Subtraction-free of division.** Mathlib stores $C_n = \\binom{2n}{n}/(n+1)$; the difference form $\\binom{2n}{n} - \\binom{2n}{n+1}$ avoids division entirely and is a genuine (non-truncated) ℕ subtraction.",
+      "**Mind the ℕ truncation.** The reflected form using $n-1$ is false at $n=0$ (where $n-1=0$ in ℕ), so it must be stated at $n+1$."
+    ],
+    "prerequisites": [
+      "Binomial coefficients and Pascal's recurrence",
+      "Catalan numbers and the central binomial coefficient",
+      "Binomial symmetry",
+      "Natural-number subtraction"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Catalan number is the difference of the central binomial coefficient and its neighbour, $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$ (the base ballot number), proved by pinning $\\binom{2n}{n} = (n+1)C_n$ and $\\binom{2n}{n+1} = nC_n$ and subtracting. A reflected form $C_{n+1} = \\binom{2(n+1)}{n+1} - \\binom{2(n+1)}{n}$ follows from binomial symmetry. 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the difference (ballot-number) form of the Catalan number that Mathlib lacks, complementing its division formula.",
+      "Exhibits the Catalan number as a base entry of the ballot/Catalan triangle, the row-difference structure requested by the open question.",
+      "Records the ℕ-truncation caveat that forces the symmetric statement to be indexed at n+1."
+    ],
+    "openQuestions": [
+      "Does the full Catalan triangle B(2n,k) = C(2n,n+k) − C(2n,n+k+1) admit a uniform Lean treatment, with each row entry counting the constrained lattice paths?",
+      "Can the reflected sums of several ballot numbers be packaged to recover convolution identities for the Catalan numbers?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry **`catalan-numbers-oq-05-oq-01`** answering the parent `catalan-numbers-oq-05`'s open question for the base ballot number: each Catalan number is the difference of the central binomial coefficient and its neighbour,

> `catalan n = C(2n,n) − C(2n,n+1)`.

Mathlib records the division form `catalan n = centralBinom n / (n+1)` (`Nat.catalan_eq_centralBinom_div`) but **not** this difference form.

## New file `proofs/Proofs/CatalanNumbersOQ05OQ01.lean` (3 theorems)

- **`choose_two_mul_succ`** — `C(2n,n+1) = n·catalan n`, from the Pascal step `choose_succ_right_eq` and cancellation of `(n+1)`.
- **`catalan_eq_choose_sub`** — `catalan n = C(2n,n) − C(2n,n+1)`, since `C(2n,n) = (n+1)·catalan n` and `C(2n,n+1) = n·catalan n`, whose difference is `catalan n` (a genuine ℕ subtraction).
- **`catalan_eq_choose_sub_symm`** — the reflected ballot-number form `catalan (n+1) = C(2(n+1),n+1) − C(2(n+1),n)` via binomial symmetry. Indexed at `n+1` because the unshifted `n−1` form is false at `n=0` (ℕ truncation).

## Verification

- `lake env lean`: **EXIT 0**, no warnings/sorries.
- `#print axioms` on all three theorems: `[propext, Classical.choice, Quot.sound]` only — **0 counting-axioms**.
- New gallery entry: `meta.json` + `annotations.json`, status `verified`, badge `original`, `axiomCount` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)