### PR TITLE
research(chinese-remainder-constructive-oq-05-oq-02): inductive CRT certificate for a list of pairwise-coprime moduli [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChineseRemainderConstructiveOQ05OQ02.lean
+++ b/proofs/Proofs/ChineseRemainderConstructiveOQ05OQ02.lean
@@ -1,0 +1,89 @@
+/-
+# An Inductive CRT Certificate for an Arbitrary List of Pairwise-Coprime Moduli
+
+## Open question (`chinese-remainder-constructive-oq-05-oq-02`)
+
+The sibling `chinese-remainder-constructive-oq-05-oq-01` proves CRT *uniqueness*
+certificates for two moduli (`crt_pair_iff`) and three moduli (`crt_triple_iff`). Its open
+question asks to generalise these to an **arbitrary list of pairwise-coprime moduli** — an
+inductive CRT certificate — connecting to the list thread of `oq-04`.
+
+## Result
+
+* `prod_dvd_of_forall_dvd` — the combination engine: for any list `ms` of **pairwise**
+  coprime naturals, if every `m ∈ ms` divides `d` then `ms.prod` divides `d`. (One list
+  induction; the head is coprime to the tail product by `coprime_list_prod_right_iff`, and
+  `Nat.Coprime.mul_dvd_of_dvd_of_dvd` folds it in.)
+
+* `crt_list_unique` — the **n-modulus uniqueness certificate**: for pairwise-coprime `ms`,
+  any two residue solutions below `ms.prod` that agree modulo every `m ∈ ms` are equal.
+  This is the list generalisation of the sibling's `crt_pair_iff`/`crt_triple_iff`: a
+  solution found below the product is *the* solution.
+
+* `crt_345_unique` — a concrete instance over `[3,4,5]` (product `60`), in the style of the
+  sibling's worked examples, discharged through `crt_list_unique`.
+
+0 sorries, 0 axioms.
+-/
+
+import Mathlib
+
+namespace ChineseRemainderConstructiveOQ05OQ02
+
+open Nat
+
+/-- **Combination engine.** For a list `ms` of *pairwise*-coprime naturals, the product
+`ms.prod` divides any common multiple `d` of its entries. The inductive heart of the
+n-modulus Chinese Remainder Theorem: the head `a` is coprime to the tail product (so
+`a · t.prod ∣ d` once both factors divide `d`). -/
+theorem prod_dvd_of_forall_dvd {d : ℕ} :
+    ∀ {ms : List ℕ}, ms.Pairwise Nat.Coprime → (∀ m ∈ ms, m ∣ d) → ms.prod ∣ d := by
+  intro ms
+  induction ms with
+  | nil => intro _ _; simp
+  | cons a t ih =>
+      intro hpw hdvd
+      rw [List.pairwise_cons] at hpw
+      obtain ⟨ha, htail⟩ := hpw
+      have hda : a ∣ d := hdvd a (List.mem_cons.mpr (Or.inl rfl))
+      have hdt : t.prod ∣ d := ih htail (fun m hm => hdvd m (List.mem_cons.mpr (Or.inr hm)))
+      have hcop : Nat.Coprime a t.prod := Nat.coprime_list_prod_right_iff.mpr ha
+      rw [List.prod_cons]
+      exact Nat.Coprime.mul_dvd_of_dvd_of_dvd hcop hda hdt
+
+/-- **n-modulus CRT uniqueness certificate.** For a list `ms` of pairwise-coprime moduli,
+any two values below `ms.prod` that share all residues `· % m` (`m ∈ ms`) are equal. Hence
+a residue system has *at most one* solution in `[0, ms.prod)` — the certificate that a
+found solution is the unique one. Generalises the two- and three-modulus certificates of
+the sibling entry to arbitrarily many moduli. -/
+theorem crt_list_unique {ms : List ℕ} (hpw : ms.Pairwise Nat.Coprime)
+    {a b : ℕ} (ha : a < ms.prod) (hb : b < ms.prod)
+    (h : ∀ m ∈ ms, a % m = b % m) : a = b := by
+  rcases le_total a b with hab | hab
+  · -- a ≤ b: every m divides b − a, hence so does ms.prod; but b − a < ms.prod.
+    have hdvd : ∀ m ∈ ms, m ∣ b - a := fun m hm =>
+      (Nat.modEq_iff_dvd' hab).mp (h m hm)
+    have hpd : ms.prod ∣ b - a := prod_dvd_of_forall_dvd hpw hdvd
+    have hz : b - a = 0 := Nat.eq_zero_of_dvd_of_lt hpd (by omega)
+    omega
+  · -- b ≤ a, symmetric.
+    have hdvd : ∀ m ∈ ms, m ∣ a - b := fun m hm =>
+      (Nat.modEq_iff_dvd' hab).mp (h m hm).symm
+    have hpd : ms.prod ∣ a - b := prod_dvd_of_forall_dvd hpw hdvd
+    have hz : a - b = 0 := Nat.eq_zero_of_dvd_of_lt hpd (by omega)
+    omega
+
+/-- **Worked instance** over the pairwise-coprime moduli `[3, 4, 5]` (product `60`), in the
+style of the sibling entry's examples: any two values below `60` with the same residues
+mod `3`, `4`, and `5` coincide. -/
+theorem crt_345_unique {a b : ℕ} (ha : a < 60) (hb : b < 60)
+    (h3 : a % 3 = b % 3) (h4 : a % 4 = b % 4) (h5 : a % 5 = b % 5) : a = b := by
+  have hpw : ([3, 4, 5] : List ℕ).Pairwise Nat.Coprime := by decide
+  have hprod : ([3, 4, 5] : List ℕ).prod = 60 := by decide
+  refine crt_list_unique hpw (ms := [3, 4, 5]) ?_ ?_ ?_
+  · rw [hprod]; exact ha
+  · rw [hprod]; exact hb
+  · intro m hm
+    fin_cases hm <;> assumption
+
+end ChineseRemainderConstructiveOQ05OQ02

--- a/research/problems/chinese-remainder-constructive-oq-05-oq-02/knowledge.md
+++ b/research/problems/chinese-remainder-constructive-oq-05-oq-02/knowledge.md
@@ -1,0 +1,55 @@
+# Knowledge Base: chinese-remainder-constructive-oq-05-oq-02
+
+Inductive CRT certificate for an arbitrary list of pairwise-coprime moduli.
+
+---
+
+## Problem Understanding
+
+Sibling `chinese-remainder-constructive-oq-05-oq-01` has `crt_pair_iff` (2 moduli) and
+`crt_triple_iff` (3 moduli) uniqueness certificates. OQ: generalise to an arbitrary list
+of pairwise-coprime moduli (inductive certificate), connecting to the oq-04 list thread.
+
+---
+
+## Session 2026-06-27 (researcher-9) — SOLVED (uniqueness) [VERIFIED, 0-axiom]
+
+**Outcome**: BUILD + new gallery entry. The n-modulus uniqueness certificate via an
+inductive combination engine.
+
+### Built `Proofs/ChineseRemainderConstructiveOQ05OQ02.lean` (89 LOC, 3 theorems)
+- `prod_dvd_of_forall_dvd {d} : ∀ {ms}, ms.Pairwise Coprime → (∀ m ∈ ms, m ∣ d) →
+  ms.prod ∣ d`. List induction (`intro ms; induction ms`); cons step: head `a` coprime to
+  `t.prod` via `Nat.coprime_list_prod_right_iff.mpr ha` (ha from `List.pairwise_cons`),
+  then `Nat.Coprime.mul_dvd_of_dvd_of_dvd hcop hda hdt` after `List.prod_cons`. Membership
+  via `List.mem_cons.mpr (Or.inl rfl)` / `(Or.inr hm)`.
+- `crt_list_unique {ms} (hpw) {a b} (ha : a<ms.prod) (hb) (h : ∀ m∈ms, a%m=b%m) : a=b`.
+  `rcases le_total a b`; each branch: `(Nat.modEq_iff_dvd' hab).mp (h m hm)[.symm]` gives
+  `m ∣ (b−a)`, `prod_dvd_of_forall_dvd` lifts to `ms.prod ∣ (b−a)`,
+  `Nat.eq_zero_of_dvd_of_lt hpd (by omega)` → diff 0 → `omega`.
+- `crt_345_unique`: [3,4,5] product 60 instance. `hpw`/`hprod` by `decide`; residue ∀ via
+  `fin_cases hm <;> assumption`.
+
+### Verification
+`lake env lean` (worktree): EXIT 0, no warnings. `#print axioms` all 3 =
+`[propext, Classical.choice, Quot.sound]` (engine: only propext, Quot.sound) — 0
+counting-axioms, no native_decide (decide used only on the concrete [3,4,5] facts, kernel
+decide not native). Gallery meta+annotations created (verified/original/axiomCount 0).
+
+### GOTCHAs
+- `induction ms` needs ms generalized: state as `{d} : ∀ {ms}, ... ` and `intro ms;
+  induction ms` so the IH quantifies the tail correctly.
+- `Nat.coprime_list_prod_right_iff : Coprime k l.prod ↔ ∀ n ∈ l, Coprime k n` (in
+  Mathlib.Data.Nat.GCD.BigOperators) — the head-coprime-to-tail-product fact.
+- `Nat.Coprime.mul_dvd_of_dvd_of_dvd (hcop) (h1) (h2) : m*n ∣ d`.
+- decide (kernel) is fine for 0-axiom; native_decide would add ofReduceBool.
+- Build in WORKTREE proofs dir, not main.
+
+### Files
+- `proofs/Proofs/ChineseRemainderConstructiveOQ05OQ02.lean` (new, verified 0-axiom)
+- `src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/{meta.json,annotations.json}`
+
+### Next Steps
+- Pair with an explicit inductive CONSTRUCTION (fold Nat.chineseRemainder along the list)
+  for full existence+uniqueness.
+- Finset/Multiset version; non-coprime case via lcm.

--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-engine",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-02",
+    "range": { "startLine": 33, "endLine": 53 },
+    "type": "theorem",
+    "title": "Combination Engine: Product Divides Common Multiples",
+    "content": "`prod_dvd_of_forall_dvd`: for a list `ms` of pairwise-coprime naturals, if every `m ∈ ms` divides `d` then `ms.prod ∣ d`. List induction on `a :: t`: the head `a` is coprime to the tail product `t.prod` (from the head's pairwise relations via `coprime_list_prod_right_iff`), the tail product divides `d` by the inductive hypothesis, so `(a::t).prod = a · t.prod ∣ d` by `Nat.Coprime.mul_dvd_of_dvd_of_dvd`.",
+    "mathContext": "pairwise-coprime `ms`, `(∀ m ∈ ms, m ∣ d) → ms.prod ∣ d`.",
+    "significance": "critical",
+    "prerequisites": ["List.Pairwise", "Nat.coprime_list_prod_right_iff", "Nat.Coprime.mul_dvd_of_dvd_of_dvd"],
+    "relatedConcepts": ["Coprimality", "List products", "Divisibility"]
+  },
+  {
+    "id": "ann-uniqueness",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-02",
+    "range": { "startLine": 55, "endLine": 77 },
+    "type": "theorem",
+    "title": "The n-Modulus Uniqueness Certificate",
+    "content": "`crt_list_unique`: for pairwise-coprime `ms`, two values `a, b < ms.prod` with `a % m = b % m` for all `m ∈ ms` are equal. Equal residues give `m ∣ |a − b|` for every `m` (`Nat.modEq_iff_dvd'`), so `ms.prod ∣ |a − b|` by the combination engine; since `|a − b| < ms.prod`, `Nat.eq_zero_of_dvd_of_lt` forces the difference to be `0`. Generalises `crt_pair_iff` / `crt_triple_iff` to arbitrarily many moduli.",
+    "mathContext": "a residue system has at most one solution in `[0, ms.prod)`.",
+    "significance": "critical",
+    "prerequisites": ["prod_dvd_of_forall_dvd", "Nat.modEq_iff_dvd'", "Nat.eq_zero_of_dvd_of_lt"],
+    "relatedConcepts": ["Chinese Remainder Theorem", "Uniqueness", "Modular arithmetic"]
+  },
+  {
+    "id": "ann-example",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-02",
+    "range": { "startLine": 79, "endLine": 88 },
+    "type": "theorem",
+    "title": "Worked Instance over [3, 4, 5]",
+    "content": "`crt_345_unique`: any two values below `60` with the same residues mod `3`, `4`, `5` coincide. The pairwise coprimality of `[3,4,5]` and the product `60` are `decide`d; the per-modulus residue hypotheses are dispatched by `fin_cases` on the list membership, each matching one of the supplied equalities. A concrete bridge to the sibling entry's example style.",
+    "mathContext": "`[3,4,5].prod = 60`; unique solution below 60.",
+    "significance": "key",
+    "prerequisites": ["crt_list_unique", "fin_cases", "decide"],
+    "relatedConcepts": ["Concrete CRT", "Pairwise coprimality"]
+  }
+]

--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
@@ -1,0 +1,111 @@
+{
+  "id": "chinese-remainder-constructive-oq-05-oq-02",
+  "title": "An Inductive CRT Certificate for an Arbitrary List of Pairwise-Coprime Moduli",
+  "slug": "chinese-remainder-constructive-oq-05-oq-02",
+  "description": "Answers the sibling entry's open question (chinese-remainder-constructive-oq-05-oq-01) by generalising its two- and three-modulus CRT uniqueness certificates (crt_pair_iff, crt_triple_iff) to an arbitrary list of pairwise-coprime moduli. The combination engine prod_dvd_of_forall_dvd shows that for a pairwise-coprime list ms, the product ms.prod divides any common multiple of its entries, by list induction (the head is coprime to the tail product via coprime_list_prod_right_iff, folded in by Nat.Coprime.mul_dvd_of_dvd_of_dvd). From it, crt_list_unique gives the n-modulus uniqueness certificate: any two values below ms.prod that agree modulo every m ∈ ms are equal — a residue system has at most one solution in [0, ms.prod). A worked instance over [3,4,5] (product 60) is included in the sibling's example style. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Chinese Remainder Theorem (classical); inductive list certificate formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chinese_remainder_theorem",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "chinese-remainder-theorem",
+      "modular-arithmetic",
+      "coprime",
+      "induction",
+      "lists",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/ChineseRemainderConstructiveOQ05OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.coprime_list_prod_right_iff",
+        "description": "Coprime k l.prod ↔ ∀ n ∈ l, Coprime k n. Gives that the head modulus is coprime to the product of the tail, the inductive step's key fact.",
+        "module": "Mathlib.Data.Nat.GCD.BigOperators"
+      },
+      {
+        "theorem": "Nat.Coprime.mul_dvd_of_dvd_of_dvd",
+        "description": "Coprime m n → m ∣ d → n ∣ d → m·n ∣ d. Folds the head modulus and the tail product into the full product dividing the common multiple.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.modEq_iff_dvd'",
+        "description": "For a ≤ b, a ≡ b [MOD n] ↔ n ∣ b − a. Converts equal residues into divisibility of the difference, on which the product-divides lemma acts.",
+        "module": "Mathlib.Data.Nat.ModEq"
+      },
+      {
+        "theorem": "Nat.eq_zero_of_dvd_of_lt",
+        "description": "a ∣ b → b < a → b = 0. Forces the difference to vanish once ms.prod divides it and it is smaller than ms.prod, giving uniqueness.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "prod_dvd_of_forall_dvd: for a pairwise-coprime list ms, ms.prod divides any common multiple of its entries — the inductive combination engine of the n-modulus CRT, which the sibling entry only instantiated at two and three moduli",
+      "crt_list_unique: the n-modulus CRT uniqueness certificate over an arbitrary pairwise-coprime list, generalising crt_pair_iff and crt_triple_iff to arbitrarily many moduli",
+      "A worked [3,4,5] instance (product 60) discharged through the general theorem, matching the sibling entry's example style and connecting to the oq-04 list thread",
+      "Stays axiom-free and native_decide-free: list induction plus Mathlib's coprime/list-product API, with omega and decide on the concrete example only"
+    ],
+    "dateAdded": "2026-06-27",
+    "axiomCount": 0,
+    "lineCount": 89,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Uses only structural Mathlib lemmas (Nat.coprime_list_prod_right_iff, Nat.Coprime.mul_dvd_of_dvd_of_dvd, Nat.modEq_iff_dvd', Nat.eq_zero_of_dvd_of_lt) with list induction, omega, and a decide on the concrete [3,4,5] example. No native_decide and no structure-encoded hypotheses; #print axioms reports only propext, Classical.choice, Quot.sound (prod_dvd_of_forall_dvd needs only propext, Quot.sound), none of which count as assumptions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "engine",
+      "title": "The Combination Engine: Product Divides Common Multiples",
+      "startLine": 33,
+      "endLine": 53,
+      "summary": "prod_dvd_of_forall_dvd: for a pairwise-coprime list ms, if every m ∈ ms divides d then ms.prod ∣ d. List induction: the head a is coprime to t.prod (coprime_list_prod_right_iff), so a·t.prod ∣ d by Nat.Coprime.mul_dvd_of_dvd_of_dvd."
+    },
+    {
+      "id": "uniqueness",
+      "title": "The n-Modulus Uniqueness Certificate",
+      "startLine": 55,
+      "endLine": 77,
+      "summary": "crt_list_unique: any two values below ms.prod agreeing modulo every m ∈ ms are equal. Equal residues give m ∣ (difference) for all m, hence ms.prod ∣ (difference); but the difference is below ms.prod, so it vanishes."
+    },
+    {
+      "id": "example",
+      "title": "Worked Instance over [3, 4, 5]",
+      "startLine": 79,
+      "endLine": 88,
+      "summary": "crt_345_unique: two values below 60 with the same residues mod 3, 4, 5 coincide. Pairwise coprimality and the product 60 are decided; the residue hypotheses are dispatched by fin_cases on list membership."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**The Chinese Remainder Theorem**\n\nThe CRT states that a system of congruences with pairwise-coprime moduli $m_1,\\dots,m_k$ has a unique solution modulo the product $\\prod m_i$. The sibling entry `chinese-remainder-constructive-oq-05-oq-01` formalised *uniqueness certificates* for two moduli (`crt_pair_iff`) and three (`crt_triple_iff`), each a self-contained, axiom-free statement that a residue system pins a unique value below the product. Its open question asks for the inductive generalisation to an arbitrary list of moduli.",
+    "problemStatement": "**n-modulus uniqueness.** For a list `ms` of pairwise-coprime naturals, any two `a, b < ms.prod` with `a % m = b % m` for every `m ∈ ms` satisfy `a = b`. Equivalently, a residue system has at most one solution in `[0, ms.prod)`.",
+    "proofStrategy": "**Product divides the difference.** The engine `prod_dvd_of_forall_dvd` is a list induction: for `a :: t`, the head `a` is coprime to `t.prod` (`coprime_list_prod_right_iff` applied to the head's pairwise relations), so if `a ∣ d` and `t.prod ∣ d` (induction hypothesis) then `a · t.prod = (a::t).prod ∣ d` by `Nat.Coprime.mul_dvd_of_dvd_of_dvd`. For uniqueness, equal residues `a % m = b % m` give `m ∣ |a − b|` for every `m` (`Nat.modEq_iff_dvd'`), so `ms.prod ∣ |a − b|`; since `|a − b| < ms.prod`, the difference is `0` (`Nat.eq_zero_of_dvd_of_lt`), i.e. `a = b`.",
+    "keyInsights": [
+      "**Coprimality lifts to the product.** The head modulus being coprime to every tail modulus makes it coprime to the whole tail product (`coprime_list_prod_right_iff`), which is exactly what lets the products multiply into a single divisor.",
+      "**Uniqueness is one divisibility plus a bound.** Once `ms.prod` divides the difference of two solutions and that difference is smaller than `ms.prod`, it must be zero — no explicit construction is needed for the uniqueness half.",
+      "**The certificate is the practical content.** Knowing the solution below the product is unique means any candidate found (e.g. by search or by the pair/triple constructions) is *the* answer.",
+      "**Pairwise, not setwise.** The hypothesis is `List.Pairwise Nat.Coprime`; the induction consumes the head's pairwise relations exactly once per step."
+    ],
+    "prerequisites": [
+      "Modular arithmetic and Nat.ModEq",
+      "Coprimality and products",
+      "List induction and List.Pairwise",
+      "Divisibility bounds in ℕ"
+    ]
+  },
+  "conclusion": {
+    "summary": "For a pairwise-coprime list of moduli, the product divides any common multiple of the entries (`prod_dvd_of_forall_dvd`), and consequently any two values below the product that share all residues are equal (`crt_list_unique`) — the n-modulus CRT uniqueness certificate, generalising the sibling's two- and three-modulus versions. A worked `[3,4,5]` instance is included. 0 axioms, 0 sorries.",
+    "implications": [
+      "Provides the inductive, arbitrary-arity CRT uniqueness certificate the sibling entry's open question requested.",
+      "The combination engine prod_dvd_of_forall_dvd is reusable for any 'pairwise-coprime product divides a common multiple' argument.",
+      "Connects the pair/triple certificates to the list thread, with a concrete [3,4,5] example bridging the styles."
+    ],
+    "openQuestions": [
+      "Pair this uniqueness certificate with an explicit inductive *construction* (folding Nat.chineseRemainder along the list) to obtain full existence-and-uniqueness over an arbitrary list.",
+      "Generalise to a Finset or Multiset of moduli, and to the non-coprime case via the lcm in place of the product."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry **`chinese-remainder-constructive-oq-05-oq-02`** answering the sibling `chinese-remainder-constructive-oq-05-oq-01`'s open question: generalise its two- and three-modulus CRT uniqueness certificates (`crt_pair_iff`, `crt_triple_iff`) to an **arbitrary list of pairwise-coprime moduli**.

## New file `proofs/Proofs/ChineseRemainderConstructiveOQ05OQ02.lean` (3 theorems)

- **`prod_dvd_of_forall_dvd`** — the combination engine: for a pairwise-coprime list `ms`, `ms.prod` divides any common multiple of its entries. List induction; the head is coprime to the tail product (`coprime_list_prod_right_iff`), folded in by `Nat.Coprime.mul_dvd_of_dvd_of_dvd`.
- **`crt_list_unique`** — the n-modulus uniqueness certificate: any two values below `ms.prod` agreeing modulo every `m ∈ ms` are equal. (Equal residues ⇒ `ms.prod ∣ |a−b|`; but `|a−b| < ms.prod`, so it is `0`.)
- **`crt_345_unique`** — a worked `[3,4,5]` (product 60) instance in the sibling's example style.

## Verification

- `lake env lean`: **EXIT 0**, no warnings/sorries.
- `#print axioms` on all three theorems: `[propext, Classical.choice, Quot.sound]` only (`prod_dvd_of_forall_dvd` needs just `propext, Quot.sound`) — **0 counting-axioms**, kernel `decide` (not `native_decide`).
- New gallery entry: `meta.json` + `annotations.json`, status `verified`, badge `original`, `axiomCount` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)