### PR TITLE
audit(erdos-1090): correct sorry count 1 → 0

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3772,9 +3772,9 @@
     },
     "erdos-1090": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-06-27T12:57:40Z",
-      "result": "clean"
+      "auditCount": 6,
+      "lastAudited": "2026-06-28T00:09:07Z",
+      "result": "issues-fixed"
     },
     "erdos-1091": {
       "auditCount": 6,

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1090,
     "erdosUrl": "https://erdosproblems.com/1090",
     "erdosProblemStatus": "solved",
@@ -247,5 +247,5 @@
       "note": "Geometric Ramsey results on monochromatic configurations"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Gallery Integrity Fix — sorry count mismatch

**Proof**: `erdos-1090`
**Severity**: HIGH (sorry-count mismatch), but conservative direction (under-claim)

### Evidence
- `proofs/Proofs/Erdos1090Problem.lean`: **0** `sorry` tokens
- `src/data/proofs/erdos-1090/meta.json`: claimed `sorries: 1` (both top-level and `meta.sorries`)

### Fix
- `sorries` → `0` in both locations.
- `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 2` are all **correct and unchanged** — the file has 2 `axiom` declarations (verified: `grep -c '^axiom '` = 2). This entry is genuinely axiomatized; only the sorry bookkeeping was wrong.
- Tracker updated (`erdos-1090` → issues-fixed).

Supersedes the now-CONFLICTING #30966 with a clean rebase on current `main`. Please close #30966 in favor of this.

---
Discovered during gallery integrity audit.