### PR TITLE
research(inverse-galois-oq-06-oq-02): mod-7 irreducible factorization — the Dedekind input [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3408,6 +3408,7 @@ import Proofs.InverseGaloisOQ02
 import Proofs.InverseGaloisOQ02Aristotle
 import Proofs.InverseGaloisOQ03
 import Proofs.InverseGaloisOQ06OQ01
+import Proofs.InverseGaloisOQ06OQ02
 import Proofs.IsoperimetricTheorem
 import Proofs.IsoperimetricTheoremOQ01
 import Proofs.IsoperimetricTheoremOQ02

--- a/proofs/Proofs/InverseGaloisOQ06OQ02.lean
+++ b/proofs/Proofs/InverseGaloisOQ06OQ02.lean
@@ -1,0 +1,212 @@
+import Mathlib
+import Proofs.InverseGaloisOQ06OQ01
+
+/-
+# The mod-7 Irreducible Factorization of `q` (OQ-06 → OQ-02)
+
+This file completes the *algebraic* half of the mod-7 Dedekind route toward the
+last remaining axiom in `InverseGaloisA5.lean`:
+
+  `axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal`
+
+where `q = X⁵ - 5X⁴ + 10X³ - 10X² + 25X - 5`.
+
+## What Dedekind's theorem needs as input
+
+Dedekind's theorem says: if a prime `p` does **not** divide the discriminant of
+`q` (equivalently `q mod p` is *squarefree*), and `q mod p` factors into
+irreducibles of degrees `d₁, …, dₖ`, then `Gal(q)` — viewed as a subgroup of the
+symmetric group on the roots — contains a permutation of cycle type
+`(d₁, …, dₖ)`.
+
+The sibling file `InverseGaloisOQ06OQ01.lean` established the *factorization
+shape* mod 7:
+
+  `q ≡ (X - 5)(X - 6) · (X³ + 6X² + 4X + 1)   (mod 7)`
+
+and that the cubic factor `cubicMod7` has **no roots** in `𝔽₇`.
+
+This file upgrades that to the full **irreducible-factorization** statement that
+Dedekind consumes:
+
+1. `cubicMod7_irreducible`      : the cubic factor is **irreducible** over `𝔽₇`
+                                  (degree 3 + no roots ⟹ irreducible).
+2. `linFactor5_irreducible`,
+   `linFactor6_irreducible`     : the two monic linear factors are irreducible.
+3. pairwise **non-association**  : the three factors are distinct primes,
+   so the factorization type is genuinely `(1, 1, 3)`.
+4. `q_mod7_squarefree`          : the product is squarefree (`p = 7`
+   **unramified**), discharging Dedekind's hypothesis on the discriminant.
+5. `q_mod7_factor_type`         : the packaged "(1,1,3) into distinct
+   irreducibles" statement — exactly the Dedekind input.
+
+## Honest scope
+
+This file does **NOT** eliminate `three_dvd_gal_card`. The remaining gap is
+Dedekind's theorem itself (factorization type ⟹ Frobenius cycle type ⟹
+`3 ∣ |Gal|`), which is absent from Mathlib 4.26 and is the subject of the
+sibling Frobenius track (`inverse-galois-a5-oq-01`). What we add here is the
+verified, 0-axiom *algebraic input* to that theorem: the factorization is into
+distinct irreducibles of degrees `(1,1,3)`, and 7 is unramified.
+
+## Key Mathlib API
+
+- `Polynomial.irreducible_of_degree_le_three_of_not_isRoot`
+    (hdeg : p.natDegree ∈ Finset.Icc 1 3) (hnot : ∀ x, ¬ IsRoot p x) : Irreducible p
+- `Polynomial.isCoprime_X_sub_C_of_isUnit_sub` : `IsUnit (a-b) → IsCoprime (X-C a) (X-C b)`
+- `Irreducible.isRelPrime_iff_not_dvd`, `Polynomial.dvd_iff_isRoot`
+- `squarefree_mul_iff` : `Squarefree (x*y) ↔ IsRelPrime x y ∧ Squarefree x ∧ Squarefree y`
+- `Polynomial.eq_of_monic_of_associated`, `Polynomial.natDegree_le_of_dvd`
+-/
+
+set_option linter.unusedVariables false
+set_option linter.unusedSimpArgs false
+
+open scoped Classical
+
+namespace InverseGaloisOQ06OQ02
+
+open InverseGaloisOQ06OQ01 Polynomial
+
+/-- `7` is prime, so `ZMod 7` is a field (and `(ZMod 7)[X]` a Euclidean domain).
+This instance powers the field/domain typeclass resolution used throughout. -/
+instance fact_prime_seven : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+
+-- ============================================================================
+-- § 1. The three factors and their degrees
+-- ============================================================================
+
+/-- The first linear factor `X - 5` over `𝔽₇`. -/
+noncomputable def linFactor5 : (ZMod 7)[X] := X - C 5
+
+/-- The second linear factor `X - 6` over `𝔽₇`. -/
+noncomputable def linFactor6 : (ZMod 7)[X] := X - C 6
+
+theorem cubicMod7_natDegree : cubicMod7.natDegree = 3 := by
+  unfold cubicMod7; compute_degree!
+
+theorem linFactor5_natDegree : linFactor5.natDegree = 1 := by
+  unfold linFactor5; compute_degree!
+
+theorem linFactor6_natDegree : linFactor6.natDegree = 1 := by
+  unfold linFactor6; compute_degree!
+
+theorem linFactor5_ne_zero : linFactor5 ≠ 0 := (monic_X_sub_C 5).ne_zero
+theorem linFactor6_ne_zero : linFactor6 ≠ 0 := (monic_X_sub_C 6).ne_zero
+
+theorem cubicMod7_ne_zero : cubicMod7 ≠ 0 := by
+  intro h0
+  have hd := cubicMod7_natDegree
+  rw [h0, natDegree_zero] at hd
+  exact absurd hd (by decide)
+
+-- ============================================================================
+-- § 2. Irreducibility
+-- ============================================================================
+
+/-- **The cubic factor is irreducible over `𝔽₇`.**
+A degree-3 polynomial over a field with no root is irreducible; the no-root fact
+is `InverseGaloisOQ06OQ01.cubicMod7_no_roots`. -/
+theorem cubicMod7_irreducible : Irreducible cubicMod7 := by
+  apply Polynomial.irreducible_of_degree_le_three_of_not_isRoot
+  · rw [cubicMod7_natDegree]; decide
+  · intro x; exact cubicMod7_no_roots x
+
+theorem linFactor5_irreducible : Irreducible linFactor5 := irreducible_X_sub_C 5
+theorem linFactor6_irreducible : Irreducible linFactor6 := irreducible_X_sub_C 6
+
+-- ============================================================================
+-- § 3. The three factors are pairwise non-associated (distinct primes)
+-- ============================================================================
+
+/-- The two linear factors are not associated: associated monic linears are
+equal, forcing `5 = 6` in `𝔽₇`, which is false. -/
+theorem linFactors_not_associated : ¬ Associated linFactor5 linFactor6 := by
+  intro h
+  have heq : linFactor5 = linFactor6 :=
+    eq_of_monic_of_associated (monic_X_sub_C 5) (monic_X_sub_C 6) h
+  have h0 := congrArg (eval (0 : ZMod 7)) heq
+  simp only [linFactor5, linFactor6, eval_sub, eval_X, eval_C] at h0
+  revert h0; decide
+
+/-- A degree-1 factor cannot be associated to the degree-3 cubic. -/
+theorem linFactor5_not_associated_cubic : ¬ Associated linFactor5 cubicMod7 := by
+  intro h
+  have h1 := natDegree_le_of_dvd h.dvd cubicMod7_ne_zero
+  have h2 := natDegree_le_of_dvd h.symm.dvd linFactor5_ne_zero
+  rw [linFactor5_natDegree, cubicMod7_natDegree] at h1 h2
+  omega
+
+/-- A degree-1 factor cannot be associated to the degree-3 cubic. -/
+theorem linFactor6_not_associated_cubic : ¬ Associated linFactor6 cubicMod7 := by
+  intro h
+  have h1 := natDegree_le_of_dvd h.dvd cubicMod7_ne_zero
+  have h2 := natDegree_le_of_dvd h.symm.dvd linFactor6_ne_zero
+  rw [linFactor6_natDegree, cubicMod7_natDegree] at h1 h2
+  omega
+
+-- ============================================================================
+-- § 4. Pairwise coprimality and squarefreeness (7 is unramified)
+-- ============================================================================
+
+/-- `X - 5` and `X - 6` are coprime: their difference `5 - 6 = -1` is a unit. -/
+theorem linFactors_isCoprime : IsCoprime linFactor5 linFactor6 := by
+  show IsCoprime (X - C (5 : ZMod 7)) (X - C 6)
+  exact isCoprime_X_sub_C_of_isUnit_sub (isUnit_iff_ne_zero.mpr (by decide))
+
+/-- `X - 5` is coprime to the cubic: `5` is not a root of the cubic. -/
+theorem linFactor5_cubic_isCoprime : IsCoprime linFactor5 cubicMod7 := by
+  have h : IsRelPrime linFactor5 cubicMod7 := by
+    show IsRelPrime (X - C (5 : ZMod 7)) cubicMod7
+    rw [(irreducible_X_sub_C (5 : ZMod 7)).isRelPrime_iff_not_dvd, dvd_iff_isRoot]
+    exact cubicMod7_no_roots 5
+  exact h.isCoprime
+
+/-- `X - 6` is coprime to the cubic: `6` is not a root of the cubic. -/
+theorem linFactor6_cubic_isCoprime : IsCoprime linFactor6 cubicMod7 := by
+  have h : IsRelPrime linFactor6 cubicMod7 := by
+    show IsRelPrime (X - C (6 : ZMod 7)) cubicMod7
+    rw [(irreducible_X_sub_C (6 : ZMod 7)).isRelPrime_iff_not_dvd, dvd_iff_isRoot]
+    exact cubicMod7_no_roots 6
+  exact h.isCoprime
+
+/-- **`q mod 7` is squarefree** — equivalently, 7 does not divide the
+discriminant of `q`, so 7 is unramified. This discharges the hypothesis of
+Dedekind's theorem. Built from the explicit factorization `(X-5)(X-6)·cubic`
+into pairwise-coprime irreducibles. -/
+theorem q_mod7_squarefree :
+    Squarefree (linFactor5 * linFactor6 * cubicMod7) := by
+  rw [squarefree_mul_iff]
+  refine ⟨?_, ?_, cubicMod7_irreducible.squarefree⟩
+  · exact (linFactor5_cubic_isCoprime.mul_left linFactor6_cubic_isCoprime).isRelPrime
+  · rw [squarefree_mul_iff]
+    exact ⟨linFactors_isCoprime.isRelPrime, linFactor5_irreducible.squarefree,
+           linFactor6_irreducible.squarefree⟩
+
+-- ============================================================================
+-- § 5. Packaged Dedekind input
+-- ============================================================================
+
+/-- **The mod-7 factor type of `q` is `(1, 1, 3)` into distinct irreducibles.**
+
+This bundles everything Dedekind's theorem consumes at `p = 7`:
+* three irreducible factors,
+* of degrees `1, 1, 3`,
+* pairwise non-associated (distinct primes),
+* with squarefree product (`p = 7` unramified).
+
+Combined with Dedekind's theorem (still a Mathlib gap; sibling track), this
+forces `Gal(q)` to contain a 3-cycle, hence `3 ∣ |Gal(q)|`. -/
+theorem q_mod7_factor_type :
+    Irreducible linFactor5 ∧ Irreducible linFactor6 ∧ Irreducible cubicMod7 ∧
+    linFactor5.natDegree = 1 ∧ linFactor6.natDegree = 1 ∧ cubicMod7.natDegree = 3 ∧
+    (¬ Associated linFactor5 linFactor6) ∧
+    (¬ Associated linFactor5 cubicMod7) ∧
+    (¬ Associated linFactor6 cubicMod7) ∧
+    Squarefree (linFactor5 * linFactor6 * cubicMod7) :=
+  ⟨linFactor5_irreducible, linFactor6_irreducible, cubicMod7_irreducible,
+   linFactor5_natDegree, linFactor6_natDegree, cubicMod7_natDegree,
+   linFactors_not_associated, linFactor5_not_associated_cubic,
+   linFactor6_not_associated_cubic, q_mod7_squarefree⟩
+
+end InverseGaloisOQ06OQ02

--- a/research/problems/inverse-galois-oq-06-oq-02/knowledge.md
+++ b/research/problems/inverse-galois-oq-06-oq-02/knowledge.md
@@ -1,0 +1,48 @@
+# Knowledge Base: inverse-galois-oq-06-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+The A₅ realizability entry rests on a single axiom `three_dvd_gal_card`. The
+mod-7 Dedekind route to eliminate it has two halves:
+
+1. **Algebraic input** (THIS slug): `q mod 7` = distinct irreducibles of degree
+   `(1,1,3)`, squarefree (7 unramified).
+2. **Dedekind implication** (sibling `inverse-galois-a5-oq-01`): factor type ⟹
+   Frobenius cycle type ⟹ `3 ∣ |Gal|`. Mathlib gap.
+
+Sibling `inverse-galois-oq-06-oq-01` had established only the *shape* of the
+factorization and that the cubic has no roots — not irreducibility/squarefree.
+
+---
+
+## Insights
+
+- A degree-3 polynomial over a field with no root is irreducible:
+  `Polynomial.irreducible_of_degree_le_three_of_not_isRoot`
+  `(hdeg : p.natDegree ∈ Finset.Icc 1 3) (hnot : ∀ x, ¬ IsRoot p x)`.
+  First goal closes by `rw [natDegree_eq]; decide`; second is exactly the
+  no-roots fact reused from the sibling.
+- Coprimality of distinct linear factors: `isCoprime_X_sub_C_of_isUnit_sub`
+  needs `IsUnit (a - b)`; over a field use `isUnit_iff_ne_zero.mpr (by decide)`.
+- Coprimality of linear vs cubic: `Irreducible.isRelPrime_iff_not_dvd` +
+  `Polynomial.dvd_iff_isRoot` reduces `¬ (X - C a) ∣ cubic` to `eval a cubic ≠ 0`.
+- Squarefree of a product of pairwise-coprime squarefrees:
+  `squarefree_mul_iff : Squarefree (x*y) ↔ IsRelPrime x y ∧ Squarefree x ∧ Squarefree y`
+  (note: `IsRelPrime`, not `IsCoprime`; convert with `IsCoprime.isRelPrime`).
+  `IsCoprime.mul_left` builds `IsCoprime (a*b) c` from the two coprimalities.
+- Non-association of equal-degree monic factors: `eq_of_monic_of_associated`
+  forces equality, then evaluate at 0 (`congrArg (eval 0)`) and `decide`.
+  Different degrees: `natDegree_le_of_dvd` both ways + `omega`.
+
+---
+
+## Dead Ends
+
+- `isCoprime_of_irreducible_of_not_associated` does NOT exist in Mathlib 4.26.
+  Use the `Irreducible.isRelPrime_iff_not_dvd` / `dvd_iff_isRoot` route instead.
+- `squarefree_mul_iff` is phrased with `IsRelPrime`, not `IsCoprime` — calling
+  `IsCoprime.squarefree_mul_iff` fails; convert first.

--- a/research/problems/inverse-galois-oq-06-oq-02/problem.md
+++ b/research/problems/inverse-galois-oq-06-oq-02/problem.md
@@ -1,0 +1,48 @@
+# Problem: mod-7 Irreducible Factorization of q (the Dedekind input)
+
+**Slug**: inverse-galois-oq-06-oq-02
+**Created**: 2026-06-27
+**Status**: Active
+**Source**: inverse-galois-oq-06 <!-- gallery-gap -->
+
+## Problem Statement
+
+The A₅-realizability entry (`InverseGaloisA5.lean`) is fully proved **except** for
+one axiom:
+
+```lean
+axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal
+```
+
+where `q = X⁵ - 5X⁴ + 10X³ - 10X² + 25X - 5`. The intended elimination route is
+**Dedekind's theorem at p = 7**: `q mod 7` factors into irreducibles of degrees
+`(1,1,3)`, so `Gal(q)` contains a 3-cycle, hence `3 ∣ |Gal(q)|`.
+
+Dedekind's theorem itself is a Mathlib gap (sibling Frobenius track
+`inverse-galois-a5-oq-01` / `inverse-galois-oq-06-oq-01`). This sub-problem
+isolates and **fully verifies the algebraic *input*** to that theorem at p = 7,
+which the sibling track had only partially established (factorization shape +
+no-roots, but not irreducibility or squarefreeness).
+
+### Goal (this slug)
+
+A verified, 0-axiom statement that, mod 7, `q` factors as
+
+  `(X - 5)(X - 6) · (X³ + 6X² + 4X + 1)`
+
+into **distinct irreducibles** of degrees `(1, 1, 3)` with **squarefree product**
+(so 7 is unramified). This is exactly the hypothesis Dedekind's theorem consumes.
+
+## Scope / Honesty
+
+This does **NOT** close `three_dvd_gal_card`. It supplies the verified algebraic
+half of the mod-7 route. The remaining "(1,1,3) factor type ⟹ Frobenius 3-cycle
+⟹ 3 ∣ |Gal|" implication is the sibling track and stays axiomatized.
+
+## First Steps (done)
+
+1. `cubicMod7` (from `InverseGaloisOQ06OQ01`) has no roots in 𝔽₇ — upgrade to
+   irreducibility via `irreducible_of_degree_le_three_of_not_isRoot`.
+2. Linear factors irreducible (`irreducible_X_sub_C`) and pairwise non-associated.
+3. Pairwise coprime (`isCoprime_X_sub_C_of_isUnit_sub`, `dvd_iff_isRoot`) ⟹
+   squarefree via `squarefree_mul_iff`.

--- a/research/problems/inverse-galois-oq-06-oq-02/state.md
+++ b/research/problems/inverse-galois-oq-06-oq-02/state.md
@@ -1,0 +1,41 @@
+# Research State: inverse-galois-oq-06-oq-02
+
+## Current State
+
+**Phase**: ACT (new verified file shipped)
+**Path**: full
+**Since**: 2026-06-27
+**Iteration**: 1
+
+## Iteration 1 (researcher-3, 2026-06-27) — ACT: verified mod-7 irreducible factorization
+
+**Outcome**: Created `Proofs/InverseGaloisOQ06OQ02.lean` — a 0-axiom file proving
+the complete **Dedekind input** for the mod-7 route to `three_dvd_gal_card`.
+
+### What was proved (all 0-axiom, 0-sorry)
+
+- `cubicMod7_irreducible` : the cubic factor `X³+6X²+4X+1` is irreducible over 𝔽₇
+  (degree 3 + no roots — upgrades the sibling's no-roots fact).
+- `linFactor5_irreducible`, `linFactor6_irreducible` : the two linear factors.
+- `linFactors_not_associated`, `linFactor5_not_associated_cubic`,
+  `linFactor6_not_associated_cubic` : the three factors are distinct primes.
+- `q_mod7_squarefree` : `(X-5)(X-6)·cubic` is squarefree (7 unramified).
+- `q_mod7_factor_type` : packaged "(1,1,3) into distinct irreducibles + squarefree"
+  — exactly the hypothesis Dedekind's theorem consumes.
+
+### Scope / honesty
+
+Does NOT eliminate `three_dvd_gal_card`. Supplies the verified algebraic input;
+the "(1,1,3) ⟹ Frobenius 3-cycle ⟹ 3 ∣ |Gal|" implication (Dedekind's theorem)
+remains a Mathlib gap owned by the sibling Frobenius track.
+
+### Relation to siblings
+
+- Builds on `InverseGaloisOQ06OQ01.cubicMod7` and `cubicMod7_no_roots`.
+- Complementary to `inverse-galois-a5-oq-01` (Frobenius bridge) — no overlap:
+  this slug owns the algebraic factorization, the sibling owns the group theory.
+
+## Next Action
+
+If Dedekind's theorem lands in Mathlib (or the sibling Frobenius bridge
+completes), `q_mod7_factor_type` plugs in directly to discharge the axiom.

--- a/src/data/research/problems/inverse-galois-oq-06-oq-02.json
+++ b/src/data/research/problems/inverse-galois-oq-06-oq-02.json
@@ -1,0 +1,124 @@
+{
+  "slug": "inverse-galois-oq-06-oq-02",
+  "title": "mod-7 Irreducible Factorization of q (the Dedekind input)",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "q \\bmod 7 = (X-5)(X-6)(X^3+6X^2+4X+1) \\text{ into distinct irreducibles of degrees } (1,1,3), \\text{ squarefree}",
+    "plain": "Verify, with no axioms, the algebraic input that Dedekind's theorem consumes at p=7 to force 3 | |Gal(q)|: namely that q reduces mod 7 to a product of distinct irreducible factors of degrees (1,1,3) and that this product is squarefree (so 7 is unramified). q = X^5 - 5X^4 + 10X^3 - 10X^2 + 25X - 5.",
+    "whyMatters": [
+      "The A5-realizability entry (InverseGaloisA5.lean) is fully proved except the single axiom three_dvd_gal_card; the mod-7 Dedekind route is the intended elimination.",
+      "The sibling track established only the factorization shape and that the cubic has no roots; it did not prove the cubic irreducible or the reduction squarefree.",
+      "Isolating and verifying the algebraic input cleanly separates what is machine-checked (this slug) from the remaining Mathlib gap (Dedekind's theorem itself)."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "cubicMod7 (X^3+6X^2+4X+1) is irreducible over F_7 (degree 3 with no roots).",
+      "The two linear factors X-5, X-6 are irreducible and pairwise non-associated to each other and to the cubic (distinct primes).",
+      "q mod 7 = (X-5)(X-6)*cubicMod7 is squarefree, so 7 does not divide disc(q) and 7 is unramified.",
+      "Packaged statement q_mod7_factor_type bundles the full (1,1,3) distinct-irreducible-plus-squarefree Dedekind input."
+    ],
+    "open": [
+      "Dedekind's theorem itself (factor type (1,1,3) => Frobenius 3-cycle => 3 | |Gal|) remains a Mathlib 4.26 gap.",
+      "Eliminating axiom three_dvd_gal_card still requires the sibling Frobenius bridge or an upstream Dedekind formalization."
+    ],
+    "goal": "Provide a verified, 0-axiom, 0-sorry algebraic input to the mod-7 Dedekind route without overclaiming that the axiom is eliminated."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-27",
+    "iteration": 1,
+    "focus": "Created Proofs/InverseGaloisOQ06OQ02.lean (0-axiom, 0-sorry): cubicMod7 irreducible + linear factors irreducible + pairwise non-associated + squarefree product => packaged Dedekind input q_mod7_factor_type. Complementary to sibling Frobenius track (inverse-galois-a5-oq-01); no overlap.",
+    "blockers": [
+      "Dedekind's theorem is not in Mathlib 4.26; the (1,1,3) => 3-cycle => 3 | |Gal| implication stays axiomatized (sibling track)."
+    ],
+    "nextAction": "When Dedekind's theorem (or the sibling Frobenius bridge) lands, q_mod7_factor_type plugs in to discharge three_dvd_gal_card.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ACT: shipped 0-axiom file upgrading the sibling's no-roots fact to full irreducibility + squarefreeness, packaged as the Dedekind input for the mod-7 route.",
+    "builtItems": [
+      "cubicMod7_irreducible via irreducible_of_degree_le_three_of_not_isRoot",
+      "pairwise non-association of the three factors (eq_of_monic_of_associated + degree bounds)",
+      "q_mod7_squarefree via squarefree_mul_iff and pairwise coprimality",
+      "q_mod7_factor_type packaged Dedekind input"
+    ],
+    "insights": [
+      "A degree-3 poly over a field with no root is irreducible: irreducible_of_degree_le_three_of_not_isRoot.",
+      "squarefree_mul_iff is phrased with IsRelPrime (not IsCoprime); convert via IsCoprime.isRelPrime.",
+      "Linear-vs-cubic coprimality: Irreducible.isRelPrime_iff_not_dvd + dvd_iff_isRoot reduces to eval a cubic != 0.",
+      "isCoprime_of_irreducible_of_not_associated does not exist in Mathlib 4.26."
+    ],
+    "mathlibGaps": [
+      "Dedekind's theorem: mod-p factorization type => Frobenius cycle type for number fields (not in Mathlib 4.26).",
+      "Frobenius element / inertia degree machinery for number field extensions."
+    ],
+    "nextSteps": [
+      "Plug q_mod7_factor_type into Dedekind's theorem once available to eliminate three_dvd_gal_card.",
+      "Optionally corroborate at a second unramified prime (e.g. p=11) for an independent (1,1,3) witness."
+    ],
+    "markdown": "See research/problems/inverse-galois-oq-06-oq-02/knowledge.md"
+  },
+  "tags": [
+    "galois-theory",
+    "algebraic-number-theory",
+    "inverse-galois-problem",
+    "dedekind-theorem"
+  ],
+  "relatedProofs": [
+    "inverse-galois",
+    "inverse-galois-a5",
+    "inverse-galois-a5-oq-01",
+    "inverse-galois-oq-06",
+    "inverse-galois-oq-06-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-27",
+  "lastUpdate": "2026-06-27",
+  "leanFiles": [
+    {
+      "path": "Proofs/InverseGaloisOQ06OQ02.lean",
+      "filename": "InverseGaloisOQ06OQ02.lean",
+      "lineCount": 208,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ06OQ02.lean"
+    },
+    {
+      "path": "Proofs/InverseGaloisOQ06OQ01.lean",
+      "filename": "InverseGaloisOQ06OQ01.lean",
+      "lineCount": 256,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ06OQ01.lean"
+    },
+    {
+      "path": "Proofs/InverseGaloisA5.lean",
+      "filename": "InverseGaloisA5.lean",
+      "lineCount": 2068,
+      "theoremCount": 65,
+      "axiomCount": 1,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisA5.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New file `Proofs/InverseGaloisOQ06OQ02.lean` (17 theorems, **0 axioms, 0 sorries**) verifying the algebraic *input* that Dedekind's theorem consumes at `p = 7` to force `3 ∣ |Gal(q)|`, where `q = X⁵ - 5X⁴ + 10X³ - 10X² + 25X - 5`.

This is the last open piece toward eliminating the single remaining axiom of the A₅-realizability entry:
```lean
axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal   -- InverseGaloisA5.lean
```

## What is proved (all 0-axiom)

Mod 7, `q` reduces to
```
q ≡ (X - 5)(X - 6) · (X³ + 6X² + 4X + 1)   (mod 7)
```
and this PR verifies that this is a factorization into **distinct irreducibles** of degrees `(1, 1, 3)` with **squarefree product**:

- `cubicMod7_irreducible` — the cubic factor is irreducible over `𝔽₇` (degree 3 + no roots ⟹ irreducible). Upgrades the sibling `OQ06OQ01`'s *no-roots* evidence to full irreducibility.
- `linFactor5_irreducible`, `linFactor6_irreducible` — the two linear factors.
- `linFactors_not_associated`, `linFactor{5,6}_not_associated_cubic` — the three factors are distinct primes.
- `q_mod7_squarefree` — `(X-5)(X-6)·cubic` is squarefree, i.e. `7 ∤ disc(q)` so 7 is **unramified**.
- `q_mod7_factor_type` — packaged "(1,1,3) into distinct irreducibles + squarefree" — exactly the Dedekind hypothesis.

## Honest scope

This does **NOT** eliminate `three_dvd_gal_card`. The remaining implication "(1,1,3) factor type ⟹ Frobenius 3-cycle ⟹ `3 ∣ |Gal|`" **is** Dedekind's theorem, a Mathlib 4.26 gap owned by the sibling Frobenius track (`inverse-galois-a5-oq-01` / `inverse-galois-oq-06-oq-01`). This PR supplies the verified, 0-axiom *algebraic half* and is complementary — no overlap with the group-theoretic bridge.

## Verification

- `lake env lean Proofs/InverseGaloisOQ06OQ02.lean` → exit 0, no errors/warnings (Mathlib oleans prebuilt; Docker wrapper unavailable in this sandbox, single-file host elaboration used as the documented fallback).
- `#print axioms q_mod7_factor_type` → `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool` (`decide`, not `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)