### PR TITLE
audit(gallery): drain 3 unaudited proofs — all CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25385,6 +25385,24 @@
       "lastAudited": "2026-06-27T23:58:19Z",
       "result": "clean",
       "issues": []
+    },
+    "catalan-numbers-oq-05-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T00:12:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "centered-hexagonal-sum-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T00:12:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hurwitz-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T00:12:49Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Drained the 3 remaining never-audited gallery entries. **All clean** — every meta.json claim matches the Lean source.

| Proof | status/badge | sorries | axioms | Verdict |
|-------|-------------|---------|--------|---------|
| `catalan-numbers-oq-05-oq-01` | verified/original | 0 | 0 | ✅ clean |
| `centered-hexagonal-sum-oq-01-oq-01` | verified/original | 0 | 0 | ✅ clean |
| `hurwitz-theorem-oq-02` | verified/original | 0 | 0 | ✅ clean |

### Checks
- **Sorries**: all 0, match meta.
- **Axioms**: 0 `axiom` declarations, no structure-encoded assumptions.
- **native_decide**: none. Hurwitz uses 4 plain `decide` on small Fintypes (`card NDA = 4` etc.) — kernel decide, **not** `native_decide`, so no `Lean.ofReduceBool`; 0-axiom claim holds.
- **True stubs**: none.
- **Narrative (Hurwitz)**: title names a famous theorem, but the file proves the *four↔four dictionary skeleton* (NDA/Force Fintypes, the `forceOf` bijection, gauge-dim matches, unit-quaternion subgroup), **not** Hurwitz's classification. The description and conclusion explicitly say "without overclaiming" and cite Hurwitz's classification as established fact rather than claiming to prove it. Acceptable.

Queue after this drain: **0 unaudited** (3 remaining "with issues" are known standing heuristic false positives: erdos-156 wip, erdos-1090 under-claim, erdos-57-oq-04 disclosed host axiom).

---
Discovered during gallery integrity audit. Tracker-only change.