### PR TITLE
research(abel-ruffini-oq-06-oq-01): A₄ solvable (V₄ ⊳ A₄) closes the threshold — Sₙ solvable ⟺ n ≤ 4 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ06OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ06OQ01.lean
@@ -1,0 +1,105 @@
+import Mathlib
+import Proofs.AbelRuffiniOQ06
+
+/-
+# Abel–Ruffini: closing the threshold at S₄ — the full equivalence Sₙ solvable ⟺ n ≤ 4
+  (abel-ruffini-oq-06-oq-01)
+
+The parent entry `Proofs.AbelRuffiniOQ06` supplies the *solvable side* of the
+symmetric-group threshold for every degree except the last open case, `S₄`:
+
+  * `permSolvable_of_alternatingSolvable` — the reduction `Aₙ solvable ⟹ Sₙ solvable`
+    (the short exact sequence `1 → Aₙ → Sₙ → ℤˣ` with abelian quotient);
+  * `permFinTwo_isSolvable`, `permFinThree_isSolvable` — `S₂`, `S₃` solvable, via the
+    prime-order (cyclic, hence abelian) alternating groups `A₂`, `A₃`.
+
+It left two open questions, both resolved here:
+
+  * **A₄ solvable.** `alternatingFinFour_isSolvable` proves `IsSolvable (A₄)`. The group
+    `A₄` of order 12 is the one case the prime-order argument cannot reach. Its commutator
+    subgroup is the Klein-four group `V₄ ⊴ A₄` (Mathlib's `alternatingGroup.kleinFour`,
+    `kleinFour_eq_commutator`), which has exponent two hence is abelian
+    (`mul_comm_of_exponent_two`), so it is solvable; and the quotient `A₄ / V₄` is abelian
+    because `V₄` *is* the commutator (`quotient_commutative_iff_commutator_le`), hence
+    solvable. The short exact sequence `1 → V₄ → A₄ → A₄/V₄ → 1` then gives `IsSolvable A₄`
+    via `solvable_of_ker_le_range` — i.e. the metabelian derived series `A₄ ⊳ V₄ ⊳ 1`.
+    Through the parent reduction this yields `permFinFour_isSolvable : IsSolvable (S₄)`.
+
+  * **The full equivalence.** With `S₄` closed, `isSolvable_perm_fin_iff` packages the
+    whole dichotomy as a single biconditional
+
+        IsSolvable (Equiv.Perm (Fin n))  ↔  n ≤ 4.
+
+    The forward direction is the non-solvability half: for `n ≥ 5` the alternating group
+    `A₅ ↪ Aₙ` is simple and non-abelian, so `Sₙ` is not solvable
+    (Mathlib's `Equiv.Perm.not_solvable`). The backward direction collects the solvable
+    cases `n ∈ {0,1,2,3,4}` — the trivial groups `S₀, S₁`, the parent's `S₂, S₃`, and the
+    new `S₄`.
+
+This is the exact group-theoretic threshold underlying the Abel–Ruffini theorem: the
+general polynomial of degree `n` is solvable by radicals iff its Galois group `Sₙ` is
+solvable, iff `n ≤ 4`.
+
+Status: 0 sorries, 0 axioms, no `native_decide`. `#print axioms` on the headline theorems
+reports only `propext, Classical.choice, Quot.sound`.
+-/
+
+namespace AbelRuffiniOQ06OQ01
+
+open Equiv
+
+/-- **`A₄ = alternatingGroup (Fin 4)` is solvable.** The single case the prime-order
+argument cannot reach (`|A₄| = 12`). The commutator subgroup of `A₄` is the Klein-four
+group `V₄` (abelian, exponent two), and the quotient `A₄ / V₄ ≅ ℤ/3` is abelian since `V₄`
+is exactly the commutator. Hence the derived series `A₄ ⊳ V₄ ⊳ 1` terminates: `A₄` is
+metabelian, so solvable. -/
+theorem alternatingFinFour_isSolvable : IsSolvable (alternatingGroup (Fin 4)) := by
+  have hα4 : Nat.card (Fin 4) = 4 := Nat.card_eq_fintype_card.trans (Fintype.card_fin 4)
+  set N := alternatingGroup.kleinFour (Fin 4) with hN
+  haveI hNnormal : N.Normal := alternatingGroup.normal_kleinFour hα4
+  -- V₄ has exponent two, hence is abelian, hence solvable.
+  have hexp : Monoid.exponent N = 2 := by
+    rw [hN]; exact alternatingGroup.exponent_kleinFour_of_card_eq_four hα4
+  haveI hNsolv : IsSolvable N :=
+    isSolvable_of_comm (fun a b => mul_comm_of_exponent_two hexp a b)
+  -- A₄ / V₄ is abelian because V₄ is the commutator subgroup of A₄.
+  have hcomm_le : commutator (alternatingGroup (Fin 4)) ≤ N :=
+    le_of_eq (alternatingGroup.kleinFour_eq_commutator hα4).symm
+  have hQcomm : Std.Commutative (· * · : (alternatingGroup (Fin 4) ⧸ N) → _ → _) :=
+    Subgroup.Normal.quotient_commutative_iff_commutator_le.mpr hcomm_le
+  haveI hQsolv : IsSolvable (alternatingGroup (Fin 4) ⧸ N) :=
+    isSolvable_of_comm (fun a b => hQcomm.comm a b)
+  -- The short exact sequence  1 → V₄ → A₄ → A₄/V₄ → 1.
+  exact solvable_of_ker_le_range N.subtype (QuotientGroup.mk' N)
+    (le_of_eq (by rw [QuotientGroup.ker_mk', Subgroup.range_subtype]))
+
+/-- **`S₄ = Equiv.Perm (Fin 4)` is solvable.** Lifts `A₄` solvable through the parent
+reduction `permSolvable_of_alternatingSolvable`. This closes the last open case of the
+solvable side of the threshold. -/
+theorem permFinFour_isSolvable : IsSolvable (Equiv.Perm (Fin 4)) :=
+  haveI := alternatingFinFour_isSolvable
+  AbelRuffiniOQ06.permSolvable_of_alternatingSolvable 4
+
+/-- **The Abel–Ruffini threshold, packaged:** `Sₙ = Equiv.Perm (Fin n)` is solvable **iff**
+`n ≤ 4`. The forward direction is non-solvability for `n ≥ 5` (`Equiv.Perm.not_solvable`,
+rooted in the simplicity of `A₅`); the backward direction collects the solvable cases
+`n ∈ {0,1,2,3,4}` — the trivial `S₀, S₁`, the parent's `S₂, S₃`, and `S₄`. -/
+theorem isSolvable_perm_fin_iff (n : ℕ) :
+    IsSolvable (Equiv.Perm (Fin n)) ↔ n ≤ 4 := by
+  constructor
+  · -- solvable ⟹ n ≤ 4, by contraposition through Aₙ non-solvable for n ≥ 5
+    intro hsolv
+    by_contra hn
+    push_neg at hn
+    exact Equiv.Perm.not_solvable (Fin n)
+      (by rw [Cardinal.mk_fin]; exact_mod_cast hn) hsolv
+  · -- n ≤ 4 ⟹ solvable, case by case
+    intro hn
+    interval_cases n
+    · infer_instance
+    · infer_instance
+    · exact AbelRuffiniOQ06.permFinTwo_isSolvable
+    · exact AbelRuffiniOQ06.permFinThree_isSolvable
+    · exact permFinFour_isSolvable
+
+end AbelRuffiniOQ06OQ01

--- a/src/data/proofs/abel-ruffini-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-06-oq-01/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "abel-ruffini-oq-06-oq-01",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "context",
+    "title": "Closing the threshold at the last open case S₄",
+    "content": "The Abel–Ruffini dichotomy 'Sₙ solvable ⟺ n ≤ 4' has its negative half (n ≥ 5) in Mathlib, via the simplicity of A₅. The parent entry supplied the easy solvable cases S₂, S₃ (their alternating groups A₂, A₃ have prime order, so are cyclic and abelian). The hard remaining case is S₄: its alternating group A₄ has order 12 — neither prime-order nor simple — so a new argument is needed. This file proves A₄ solvable via its metabelian structure, lifts that to S₄, and packages the complete equivalence."
+  },
+  {
+    "id": "ann-v4-solvable",
+    "proofId": "abel-ruffini-oq-06-oq-01",
+    "range": { "startLine": 58, "endLine": 67 },
+    "type": "key-step",
+    "title": "The Klein-four commutator subgroup V₄ is abelian, hence solvable",
+    "content": "The commutator subgroup of A₄ is the Klein-four group V₄ = alternatingGroup.kleinFour (Fin 4). Its defining feature is exponent two — every non-identity element is an involution — so for any a, b: ab = (ab)⁻¹ = b⁻¹a⁻¹ = ba. Mathlib packages this as mul_comm_of_exponent_two, turning Monoid.exponent V₄ = 2 into commutativity, and isSolvable_of_comm then makes V₄ solvable. This is the bottom step of the derived series A₄ ⊳ V₄ ⊳ 1."
+  },
+  {
+    "id": "ann-quotient-abelian",
+    "proofId": "abel-ruffini-oq-06-oq-01",
+    "range": { "startLine": 68, "endLine": 76 },
+    "type": "key-step",
+    "title": "A₄/V₄ is abelian because V₄ IS the commutator subgroup",
+    "content": "The same subgroup that serves as the solvable kernel also certifies the quotient is abelian: since V₄ = commutator A₄ (kleinFour_eq_commutator), the criterion quotient_commutative_iff_commutator_le gives that A₄/V₄ (≅ ℤ/3) is commutative, hence solvable. The short exact sequence 1 → V₄ → A₄ → A₄/V₄ → 1 — with ker(quotient map) = V₄ = range(inclusion) — then yields IsSolvable A₄ through solvable_of_ker_le_range. This is the metabelian core: solvable kernel + solvable quotient ⟹ solvable extension."
+  },
+  {
+    "id": "ann-s4",
+    "proofId": "abel-ruffini-oq-06-oq-01",
+    "range": { "startLine": 82, "endLine": 89 },
+    "type": "result",
+    "title": "S₄ is solvable",
+    "content": "Feeding the new IsSolvable A₄ instance into the parent reduction permSolvable_of_alternatingSolvable 4 (the short exact sequence 1 → A₄ → S₄ → ℤˣ with abelian quotient ℤˣ ≅ ℤ/2) yields permFinFour_isSolvable: IsSolvable (Equiv.Perm (Fin 4)). This closes the final open case of the solvable side of the threshold."
+  },
+  {
+    "id": "ann-equivalence",
+    "proofId": "abel-ruffini-oq-06-oq-01",
+    "range": { "startLine": 90, "endLine": 105 },
+    "type": "result",
+    "title": "The packaged threshold: Sₙ solvable ⟺ n ≤ 4",
+    "content": "isSolvable_perm_fin_iff packages the whole Abel–Ruffini dichotomy. Forward (solvable ⟹ n ≤ 4): contraposition — for n ≥ 5, Equiv.Perm.not_solvable (using #(Fin n) = n ≥ 5) shows Sₙ is non-solvable. Backward (n ≤ 4 ⟹ solvable): interval_cases on n discharges S₀, S₁ as subsingletons (infer_instance), S₂, S₃ from the parent theorems, and S₄ from permFinFour_isSolvable. This single biconditional is the exact group-theoretic boundary between radical-solvable degrees (n ≤ 4) and the rest."
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-06-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-06-oq-01/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "abel-ruffini-oq-06-oq-01",
+  "title": "Closing the Abel–Ruffini Threshold at S₄: A₄ is Solvable (V₄ ⊳ A₄) and the Full Equivalence Sₙ Solvable ⟺ n ≤ 4",
+  "slug": "abel-ruffini-oq-06-oq-01",
+  "description": "Resolves both open questions of the parent solvable-side entry by closing the last case S₄ and packaging the complete symmetric-group threshold. (1) A₄ solvable: the alternating group A₄ of order 12 is the one degree the parent's prime-order (cyclic) argument cannot reach. Its commutator subgroup is the Klein-four group V₄ ⊴ A₄ (Mathlib's alternatingGroup.kleinFour, kleinFour_eq_commutator), which has exponent two hence is abelian (mul_comm_of_exponent_two), so V₄ is solvable; and the quotient A₄/V₄ ≅ ℤ/3 is abelian precisely because V₄ IS the commutator subgroup (Subgroup.Normal.quotient_commutative_iff_commutator_le), so it too is solvable. The short exact sequence 1 → V₄ → A₄ → A₄/V₄ → 1 then gives IsSolvable A₄ via solvable_of_ker_le_range — the metabelian derived series A₄ ⊳ V₄ ⊳ 1. Through the parent reduction permSolvable_of_alternatingSolvable this lifts to permFinFour_isSolvable: IsSolvable (S₄). (2) The full equivalence: with S₄ closed, isSolvable_perm_fin_iff packages the whole dichotomy as the single biconditional IsSolvable (Equiv.Perm (Fin n)) ⟺ n ≤ 4. The forward direction is the non-solvability half — for n ≥ 5 the simple non-abelian A₅ ↪ Aₙ makes Sₙ non-solvable (Equiv.Perm.not_solvable) — and the backward direction collects the solvable cases n ∈ {0,1,2,3,4}: the trivial S₀, S₁, the parent's S₂, S₃, and the new S₄. This is the exact group-theoretic threshold underlying the Abel–Ruffini theorem: the general degree-n polynomial is solvable by radicals iff its Galois group Sₙ is solvable iff n ≤ 4. 3 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher (researcher-6)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ06OQ01.lean",
+    "parentProof": "abel-ruffini-oq-06",
+    "openQuestionId": "abel-ruffini-oq-06-oq-01",
+    "tags": [
+      "abel-ruffini",
+      "galois-theory",
+      "group-theory",
+      "solvable-group",
+      "symmetric-group",
+      "alternating-group",
+      "klein-four-group",
+      "derived-series",
+      "metabelian",
+      "solvability-by-radicals"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 105,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "None beyond the foundational propext / Classical.choice / Quot.sound. #print axioms on all three theorems (alternatingFinFour_isSolvable, permFinFour_isSolvable, isSolvable_perm_fin_iff) reports exactly [propext, Classical.choice, Quot.sound]. No native_decide, no Lean.ofReduceBool.",
+    "buildStatus": "Verified via `lake env lean Proofs/AbelRuffiniOQ06OQ01.lean` against pinned Mathlib v4.26.0 (single-file elaboration against prebuilt parent oleans; the host Docker daemon was unresponsive during this session, so the standard docker wrapper was bypassed for a direct toolchain elaboration, the accepted fallback). 0 errors; olean produced. #print axioms confirms 0 non-foundational axioms.",
+    "mathlibDependencies": [
+      {
+        "theorem": "alternatingGroup.kleinFour_eq_commutator",
+        "description": "For Nat.card α = 4, the Klein-four subgroup V₄ equals the commutator subgroup of A₄. This identification is what makes both V₄ abelian (it is Klein four) and the quotient A₄/V₄ abelian (quotient by the commutator).",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Alternating.KleinFour"
+      },
+      {
+        "theorem": "alternatingGroup.exponent_kleinFour_of_card_eq_four",
+        "description": "Monoid.exponent V₄ = 2; every element of the Klein-four group is an involution, which (mul_comm_of_exponent_two) forces commutativity, hence solvability of V₄.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Alternating.KleinFour"
+      },
+      {
+        "theorem": "alternatingGroup.normal_kleinFour",
+        "description": "V₄ ⊴ A₄ (it is even characteristic); supplies the normality needed for the quotient A₄/V₄ and the short exact sequence.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Alternating.KleinFour"
+      },
+      {
+        "theorem": "mul_comm_of_exponent_two",
+        "description": "A cancellative monoid of exponent two is abelian; converts V₄'s exponent-two property into the commutativity that gives isSolvable_of_comm.",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "Subgroup.Normal.quotient_commutative_iff_commutator_le",
+        "description": "G ⧸ N is commutative iff commutator G ≤ N. Applied with N = V₄ = commutator A₄, it yields the abelianness (hence solvability) of A₄/V₄ ≅ ℤ/3.",
+        "module": "Mathlib.GroupTheory.Commutator.Basic"
+      },
+      {
+        "theorem": "solvable_of_ker_le_range",
+        "description": "Solvability of a group extension: with ker(quotient map) ≤ range(inclusion) and both V₄ and A₄/V₄ solvable, the middle group A₄ is solvable. Encodes 1 → V₄ → A₄ → A₄/V₄ → 1.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "Equiv.Perm.not_solvable",
+        "description": "For 5 ≤ #X, Equiv.Perm X is not solvable (rooted in the simplicity of A₅). Supplies the forward direction of the equivalence: n ≥ 5 ⟹ Sₙ not solvable.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "AbelRuffiniOQ06.permSolvable_of_alternatingSolvable",
+        "description": "Parent reduction: Aₙ solvable ⟹ Sₙ solvable (via the SES 1 → Aₙ → Sₙ → ℤˣ). Lifts the new A₄ solvability to S₄ solvability.",
+        "module": "Proofs.AbelRuffiniOQ06"
+      }
+    ],
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Abel–Ruffini theorem says the general polynomial of degree $n \\ge 5$ is not solvable by radicals, because its Galois group $S_n$ is not solvable. The group-theoretic core is the sharp dichotomy: $S_n$ is solvable iff $n \\le 4$. Mathlib provides the negative half ($n \\ge 5$, via the simplicity of $A_5$) but not the positive half. The parent entry supplied $S_2, S_3$ solvable through the prime-order (cyclic) alternating groups $A_2, A_3$, leaving the single hard case $S_4$ — whose alternating group $A_4$ of order 12 is neither prime-order nor simple — and the packaging of the full equivalence as open.",
+    "problemStatement": "Prove $A_4 = \\mathrm{alternatingGroup}(\\mathrm{Fin}\\ 4)$ is solvable (the last open case of the solvable side), thereby obtaining $S_4$ solvable, and package the complete threshold as a single biconditional $\\mathrm{IsSolvable}(\\mathrm{Equiv.Perm}(\\mathrm{Fin}\\ n)) \\iff n \\le 4$.",
+    "proofStrategy": "(1) A₄ solvable via its metabelian structure. The commutator subgroup of $A_4$ is the Klein-four group $V_4$ (Mathlib's kleinFour_eq_commutator). $V_4$ has exponent two, so mul_comm_of_exponent_two makes it abelian and isSolvable_of_comm makes it solvable. The quotient $A_4/V_4 \\cong \\mathbb{Z}/3$ is abelian precisely because $V_4$ is the commutator (quotient_commutative_iff_commutator_le), hence solvable. The short exact sequence $1 \\to V_4 \\to A_4 \\to A_4/V_4 \\to 1$ then gives $\\mathrm{IsSolvable}(A_4)$ through solvable_of_ker_le_range, with the inclusion's range and the quotient map's kernel both equal to $V_4$. (2) $S_4$ solvable by feeding $A_4$ into the parent reduction permSolvable_of_alternatingSolvable. (3) The equivalence: forward by contraposition ($n \\ge 5 \\Rightarrow$ Equiv.Perm.not_solvable, using $\\#(\\mathrm{Fin}\\ n) = n \\ge 5$); backward by interval_cases on $n \\le 4$, discharging $n = 0, 1$ as subsingletons, $n = 2, 3$ by the parent theorems, and $n = 4$ by the new result.",
+    "keyInsights": [
+      "**A₄ is metabelian, not simple**: unlike $A_5$ (simple, non-solvable), $A_4$ sits in a two-step derived series $A_4 \\rhd V_4 \\rhd 1$. The Klein-four subgroup $V_4$ is exactly the commutator subgroup, so it is both abelian (Klein four) and yields an abelian quotient (quotient by the commutator) — the two ingredients solvability needs.",
+      "**Exponent two does all the work for V₄**: the Klein-four group's defining property — every non-identity element has order 2 — means $a b = (ab)^{-1} = b^{-1}a^{-1} = ba$, so $V_4$ is abelian and trivially solvable. Mathlib packages this as mul_comm_of_exponent_two.",
+      "**The same subgroup gives both extension factors**: because $V_4 = \\mathrm{commutator}(A_4)$, one subgroup simultaneously serves as the solvable normal kernel AND certifies the quotient is abelian. The short exact sequence $1 \\to V_4 \\to A_4 \\to A_4/V_4 \\to 1$ closes solvability through solvable_of_ker_le_range.",
+      "**The threshold is exactly n ≤ 4**: combining this positive half with Mathlib's negative half ($n \\ge 5$) packages the full Abel–Ruffini dichotomy $\\mathrm{IsSolvable}(S_n) \\iff n \\le 4$ as a single theorem. This is the precise group-theoretic boundary between degrees solvable by radicals ($n \\le 4$: the quadratic, cubic, quartic formulas) and those that are not ($n \\ge 5$)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: closing the last case S₄",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Header docstring and imports. Recalls the parent's solvable-side results (the reduction Aₙ⟹Sₙ and S₂, S₃ via prime-order alternating groups) and frames the two open questions resolved here: A₄ solvable (the one case order 12 leaves open) and the packaged equivalence Sₙ solvable ⟺ n ≤ 4. Imports the parent Proofs.AbelRuffiniOQ06."
+    },
+    {
+      "id": "a4-solvable",
+      "title": "Part I — A₄ is solvable (the metabelian core)",
+      "startLine": 52,
+      "endLine": 80,
+      "summary": "Proves alternatingFinFour_isSolvable. Takes V₄ = alternatingGroup.kleinFour (Fin 4): normal (normal_kleinFour), solvable because exponent two ⟹ abelian (exponent_kleinFour + mul_comm_of_exponent_two + isSolvable_of_comm). The quotient A₄/V₄ is abelian since V₄ = commutator A₄ (kleinFour_eq_commutator + quotient_commutative_iff_commutator_le), hence solvable. solvable_of_ker_le_range on the SES 1 → V₄ → A₄ → A₄/V₄ → 1 (ker of mk' = V₄ = range of subtype) concludes IsSolvable A₄."
+    },
+    {
+      "id": "s4-solvable",
+      "title": "Part II — S₄ is solvable",
+      "startLine": 82,
+      "endLine": 89,
+      "summary": "Proves permFinFour_isSolvable by feeding the new A₄ solvability instance into the parent reduction permSolvable_of_alternatingSolvable 4 (the short exact sequence 1 → A₄ → S₄ → ℤˣ with abelian quotient). Closes the last open case of the solvable side."
+    },
+    {
+      "id": "full-equivalence",
+      "title": "Part III — The packaged threshold Sₙ solvable ⟺ n ≤ 4",
+      "startLine": 90,
+      "endLine": 105,
+      "summary": "Proves isSolvable_perm_fin_iff. Forward: contraposition through Equiv.Perm.not_solvable for n ≥ 5 (using #(Fin n) = n). Backward: interval_cases on n ≤ 4 — S₀, S₁ subsingleton (infer_instance), S₂, S₃ from the parent, S₄ from permFinFour_isSolvable. Packages the full Abel–Ruffini group-theoretic dichotomy as one biconditional."
+    }
+  ],
+  "conclusion": {
+    "summary": "Closed the last open case of the symmetric-group threshold by proving A₄ solvable through its metabelian structure A₄ ⊳ V₄ ⊳ 1 (Klein-four commutator subgroup, abelian quotient), lifted it to S₄ solvable via the parent reduction, and packaged the complete dichotomy IsSolvable (Equiv.Perm (Fin n)) ⟺ n ≤ 4 as a single biconditional. This is the exact group-theoretic threshold underlying Abel–Ruffini: the general degree-n polynomial is solvable by radicals iff Sₙ is solvable iff n ≤ 4. 3 theorems, 0 sorries, 0 axioms.",
+    "implications": "Completes the solvable-side program of the parent chain: every degree's solvability status is now decided, and the full equivalence is a reusable single theorem. The A₄ argument is a clean, self-contained model of how solvability flows through a short exact sequence with abelian kernel and abelian quotient — directly reusable for other metabelian extensions. Together with Mathlib's n ≥ 5 non-solvability, this gives the formal group-theoretic foundation for the radical-solvability dichotomy of the general polynomial.",
+    "openQuestions": [
+      "Upgrade the order/solvability facts to explicit structure: identify Gal of the general quartic with the holomorph/wreath structure of S₄ (S₄ ≅ V₄ ⋊ S₃) and exhibit the radical tower realizing the resolvent cubic, connecting this abstract solvability to the classical quartic formula.",
+      "Combine isSolvable_perm_fin_iff with a Galois-correspondence statement to conclude the field-theoretic Abel–Ruffini: the general polynomial of degree n is solvable by radicals iff n ≤ 4, as a theorem about splitting fields rather than abstract permutation groups.",
+      "Generalize the metabelian SES argument into a reusable lemma `IsSolvable G` from `[N.Normal]`, `IsSolvable N`, `IsSolvable (G ⧸ N)` (the standard extension-closure of solvable groups), of which the A₄ proof here is the prototypical instance."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "abel-ruffini-oq-06",
+      "relationship": "parent — supplies the reduction permSolvable_of_alternatingSolvable (Aₙ ⟹ Sₙ) and the solvable cases S₂, S₃. This entry answers both of its open questions: A₄ (hence S₄) solvable, and the packaged equivalence Sₙ solvable ⟺ n ≤ 4."
+    },
+    {
+      "proofId": "abel-ruffini-oq-04-oq-01-oq-04-oq-01",
+      "relationship": "sibling — the non-solvable side (a transitive subgroup of S_p with a transposition is unsolvable for p ≥ 5). Together with this entry's positive cases, the two sides bracket the threshold from both directions."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves **both open questions** of the parent entry `abel-ruffini-oq-06` by closing the last open case `S₄` and packaging the complete symmetric-group threshold.

### A₄ is solvable (the case order 12 leaves open)
The parent reached `S₂`, `S₃` via prime-order (cyclic) alternating groups, but `A₄` (order 12) is neither prime-order nor simple. It is, however, **metabelian**:

```
A₄ ⊳ V₄ ⊳ 1
```

- Its commutator subgroup is the **Klein-four group `V₄`** (Mathlib's `alternatingGroup.kleinFour`, `kleinFour_eq_commutator`), which has **exponent two** hence is abelian (`mul_comm_of_exponent_two`) — so `V₄` is solvable.
- The quotient `A₄/V₄ ≅ ℤ/3` is abelian **precisely because `V₄` is the commutator subgroup** (`quotient_commutative_iff_commutator_le`) — so it too is solvable.
- The short exact sequence `1 → V₄ → A₄ → A₄/V₄ → 1` gives `IsSolvable A₄` via `solvable_of_ker_le_range`.

Through the parent reduction `permSolvable_of_alternatingSolvable`, this lifts to `IsSolvable (S₄)`.

### The full equivalence
With `S₄` closed, the whole dichotomy packages as one biconditional:

> `IsSolvable (Equiv.Perm (Fin n)) ↔ n ≤ 4`

Forward: `n ≥ 5 ⟹` non-solvable (`Equiv.Perm.not_solvable`, rooted in the simplicity of `A₅`). Backward: `n ∈ {0,1,2,3,4}` — trivial `S₀,S₁`, the parent's `S₂,S₃`, and the new `S₄`.

This is the exact group-theoretic threshold underlying **Abel–Ruffini**: the general degree-`n` polynomial is solvable by radicals iff its Galois group `Sₙ` is solvable iff `n ≤ 4`.

## Theorems (3, 0 sorries, 0 axioms)

| Theorem | Statement |
|---|---|
| `alternatingFinFour_isSolvable` | `IsSolvable (alternatingGroup (Fin 4))` |
| `permFinFour_isSolvable` | `IsSolvable (Equiv.Perm (Fin 4))` |
| `isSolvable_perm_fin_iff` | `IsSolvable (Equiv.Perm (Fin n)) ↔ n ≤ 4` |

## Verification

- `lake env lean Proofs/AbelRuffiniOQ06OQ01.lean` against pinned **Mathlib v4.26.0** — 0 errors, olean produced.
- `#print axioms` on all three theorems reports exactly `[propext, Classical.choice, Quot.sound]` — **0 non-foundational axioms**, no `native_decide`.

(Host Docker daemon was unresponsive this session; standard docker wrapper bypassed for direct single-file elaboration against prebuilt parent oleans — the accepted fallback.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)