### PR TITLE
Enrich Hurwitz Theorem OQ-02: add annotations.json (7 annotations)

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-02/annotations.json
+++ b/src/data/proofs/hurwitz-theorem-oq-02/annotations.json
@@ -1,0 +1,172 @@
+[
+  {
+    "id": "ann-hurwitz-oq02-module-doc",
+    "proofId": "hurwitz-theorem-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 67
+    },
+    "type": "context",
+    "title": "The Open Question and the Division-Algebra Dictionary",
+    "content": "The module docstring frames a genuine coincidence in mathematical physics: Hurwitz's theorem (1898) gives exactly four normed division algebras over ℝ (ℝ, ℂ, ℍ, 𝕆, of dimensions 1, 2, 4, 8), and physics recognises exactly four fundamental interactions (gravity, electromagnetism, weak, strong). A research programme spanning Günaydin–Gürsey, Dixon, Baez–Huerta, and Furey builds a canonical dictionary matching each force's internal gauge group to one of the algebras. The docstring is explicit about scope: only the numerical and group-theoretic skeleton is machine-checked, while the physical interpretation — which algebra 'is' which force and why — lives entirely in commentary. This honesty matters: the file does not claim to derive physics from algebra, only to make the well-known 'four ↔ four' correspondence mathematically well-posed.",
+    "mathContext": "The dictionary table pairs each algebra $A$ with a force whose gauge group has dimension equal to either $\\dim_{\\mathbb{R}} \\mathrm{Im}(A)$ (for $\\mathbb{R}, \\mathbb{C}, \\mathbb{H}$) or $\\dim_{\\mathbb{R}} A$ (for $\\mathbb{O}$): $U(1)=1=\\dim \\mathrm{Im}\\,\\mathbb{C}$, $SU(2)=3=\\dim \\mathrm{Im}\\,\\mathbb{H}$, $SU(3)=8=\\dim \\mathbb{O}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Hurwitz's theorem",
+      "normed division algebras",
+      "Standard Model gauge group",
+      "Dixon–Furey–Baez–Huerta programme"
+    ],
+    "prerequisites": [
+      "composition algebras",
+      "gauge theory",
+      "Standard Model of particle physics"
+    ]
+  },
+  {
+    "id": "ann-hurwitz-oq02-nda",
+    "proofId": "hurwitz-theorem-oq-02",
+    "range": {
+      "startLine": 73,
+      "endLine": 107
+    },
+    "type": "definition",
+    "title": "The Four Normed Division Algebras as a Finite Type",
+    "content": "The four algebras are encoded as a 4-constructor inductive type `NDA` deriving `Fintype`, equipped with three functions: `dim` (1, 2, 4, 8), `imagDim` (0, 1, 3, 7), and `level` (0, 1, 2, 3). The structural facts are proved by case analysis: `dim_eq_imagDim_succ` (the imaginary subspace is one dimension smaller than the algebra, since the real axis is one-dimensional), `dim_eq_two_pow` (each dimension is a power of two), and `card_eq_four` (there are exactly four, by `decide`). Encoding Hurwitz's classification as a Fintype rather than a list of theorems is what makes the later bijection `decide`-checkable: bijectivity of a function between Fintypes is a decidable proposition.",
+    "mathContext": "$\\dim a = \\mathrm{imagDim}(a) + 1$ because $A = \\mathbb{R} \\cdot 1 \\oplus \\mathrm{Im}(A)$; and $\\dim a = 2^{\\mathrm{level}(a)}$ with $\\mathrm{level} \\in \\{0,1,2,3\\}$, giving dimensions $\\{2^0, 2^1, 2^2, 2^3\\} = \\{1,2,4,8\\}$. The Cayley–Dickson construction would give a 5th algebra (the 16-dimensional sedenions $2^4$), but it has zero divisors, so the chain of *normed division* algebras stops at four.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fintype",
+      "Cayley–Dickson construction",
+      "imaginary subspace",
+      "powers of two"
+    ],
+    "prerequisites": [
+      "inductive types",
+      "dimension of an algebra",
+      "decidable equality"
+    ]
+  },
+  {
+    "id": "ann-hurwitz-oq02-forces",
+    "proofId": "hurwitz-theorem-oq-02",
+    "range": {
+      "startLine": 111,
+      "endLine": 130
+    },
+    "type": "definition",
+    "title": "The Four Fundamental Forces and Their Gauge Dimensions",
+    "content": "The four interactions are a second 4-constructor Fintype `Force`, with `gaugeDim` recording the real dimension of each internal gauge group: gravity 0 (no internal gauge group — it is the geometry of spacetime via general covariance), electromagnetism 1 (the abelian $U(1)$), weak 3 (the non-abelian $SU(2)$), strong 8 (the non-abelian $SU(3)$). `card_eq_four` confirms there are four, and `standard_model_gauge_dim` computes the dimension of the full internal symmetry group $U(1) \\times SU(2) \\times SU(3)$ as $1 + 3 + 8 = 12$. These dimensions are not arbitrary: $\\dim SU(n) = n^2 - 1$, so $\\dim SU(2) = 3$ and $\\dim SU(3) = 8$.",
+    "mathContext": "For the special unitary groups $\\dim_{\\mathbb{R}} SU(n) = n^2 - 1$: $SU(2)$ has dimension $3$, $SU(3)$ has dimension $8$. The abelian $U(1)$ has dimension $1$. The Standard-Model internal gauge group $G_{SM} = U(1) \\times SU(2) \\times SU(3)$ therefore has $\\dim G_{SM} = 1 + 3 + 8 = 12$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "gauge group",
+      "special unitary group",
+      "Standard Model",
+      "Lie group dimension"
+    ],
+    "prerequisites": [
+      "Lie groups",
+      "U(1), SU(2), SU(3)",
+      "gauge symmetry"
+    ]
+  },
+  {
+    "id": "ann-hurwitz-oq02-dictionary",
+    "proofId": "hurwitz-theorem-oq-02",
+    "range": {
+      "startLine": 134,
+      "endLine": 161
+    },
+    "type": "insight",
+    "title": "The Canonical Bijection: Four Algebras ↔ Four Forces",
+    "content": "This is the heart of the formalization. `forceOf : NDA → Force` sends ℝ↦gravity, ℂ↦electromagnetism, ℍ↦weak, 𝕆↦strong, and `forceOf_bijective` proves it is a bijection — by `decide`, which is legitimate because both sides are Fintypes and bijectivity is decidable. `forceEquiv` packages this as an honest `NDA ≃ Force`. The precise content of the slogan 'the four connect to the four' is exactly this equivalence: a canonical correspondence, not a loose analogy. The dimension-matching theorems then verify the correspondence is meaningful: `gauge_dim_matches_imag` shows the gauge dimensions of gravity, EM, and weak equal the *imaginary* dimensions 0, 1, 3 of ℝ, ℂ, ℍ; `strong_gauge_dim` shows the strong gauge dimension 8 equals the *full* dimension of 𝕆. The asymmetry — imaginary dimension for three algebras, full dimension for the octonions — mirrors that $SU(3)$ sits inside $G_2 = \\mathrm{Aut}(\\mathbb{O})$ rather than acting on an imaginary subspace.",
+    "mathContext": "$\\mathrm{forceOf}: \\mathbb{R}\\mapsto\\text{gravity},\\ \\mathbb{C}\\mapsto\\text{EM},\\ \\mathbb{H}\\mapsto\\text{weak},\\ \\mathbb{O}\\mapsto\\text{strong}$ is a bijection of 4-element sets. Along it, $\\mathrm{gaugeDim}(\\mathrm{forceOf}\\,A) = \\dim \\mathrm{Im}(A)$ for $A \\in \\{\\mathbb{R},\\mathbb{C},\\mathbb{H}\\}$ (values $0,1,3$) and $\\mathrm{gaugeDim}(\\mathrm{forceOf}\\,\\mathbb{O}) = \\dim \\mathbb{O} = 8$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "bijection",
+      "Equiv.ofBijective",
+      "decidability over Fintypes",
+      "G₂ = Aut(𝕆)"
+    ],
+    "prerequisites": [
+      "bijective functions",
+      "type equivalences (≃)",
+      "decision procedures in Lean"
+    ]
+  },
+  {
+    "id": "ann-hurwitz-oq02-unit-quaternions",
+    "proofId": "hurwitz-theorem-oq-02",
+    "range": {
+      "startLine": 163,
+      "endLine": 198
+    },
+    "type": "technique",
+    "title": "Weak Force: The Unit Quaternions as a Subgroup of ℍˣ",
+    "content": "The genuinely group-theoretic core, and the cleanest algebra↔force link. The weak gauge group $SU(2)$ is isomorphic to $Sp(1)$, the unit quaternions $\\{q \\in \\mathbb{H} : |q| = 1\\}$. The file proves these form a subgroup of the units $\\mathbb{H}^\\times$ by establishing three closure facts directly from multiplicativity of the quaternion norm: `unitQuat_mul_closed` (via `map_mul`: $|pq| = |p||q| = 1$), `unitQuat_one` (via `map_one`), and `unitQuat_inv_closed` (via `map_inv₀`). The bundled `unitQuaternions : Subgroup (Quaternion ℝ)ˣ` carries these as its `mul_mem'`, `one_mem'`, `inv_mem'` fields. The inversion step is subtle: working in the unit group $\\mathbb{H}^\\times$ rather than $\\mathbb{H}$, it derives $|a^{-1}| = 1$ from $a \\cdot a^{-1} = 1$ (`Units.mul_inv`) and applying `normSq` to both sides. The key mathlib fact is that `Quaternion.normSq` is a `MonoidWithZeroHom`, i.e. multiplicative — which is precisely the composition-algebra property $N(xy) = N(x)N(y)$ that makes ℍ a *normed* division algebra in the first place.",
+    "mathContext": "$\\mathrm{normSq}: \\mathbb{H} \\to \\mathbb{R}$ is a monoid-with-zero homomorphism, so $N(pq) = N(p)N(q)$, $N(1) = 1$, $N(p^{-1}) = N(p)^{-1}$. The norm-one set $Sp(1) = N^{-1}(1)$ is therefore closed under product, identity, and inverse — a subgroup of $\\mathbb{H}^\\times$, isomorphic to $SU(2)$. Concretely $Sp(1) \\cong S^3$, the unit 3-sphere.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Sp(1) ≅ SU(2)",
+      "MonoidWithZeroHom",
+      "composition algebra",
+      "subgroup criterion",
+      "unit 3-sphere"
+    ],
+    "prerequisites": [
+      "quaternions",
+      "multiplicative norms",
+      "subgroups",
+      "group of units"
+    ]
+  },
+  {
+    "id": "ann-hurwitz-oq02-unit-complex",
+    "proofId": "hurwitz-theorem-oq-02",
+    "range": {
+      "startLine": 200,
+      "endLine": 212
+    },
+    "type": "technique",
+    "title": "Electromagnetism: The Unit Complex Numbers U(1)",
+    "content": "The electromagnetic gauge group $U(1)$ is literally the unit circle in ℂ — Mathlib's `Circle`. `unitComplex_mul_closed` proves the unit complex numbers are closed under multiplication by exactly the same argument as the quaternion case: `Complex.normSq` is multiplicative (`map_mul`), so $|zw| = |z||w| = 1$ when $|z| = |w| = 1$. `unitComplex_one` records that $1$ lies on the circle. That the same one-line `map_mul` proof works for both ℂ and ℍ exposes the unifying theme: closure of the norm-one elements is a *composition-algebra* phenomenon, not special to either algebra. The difference from the quaternion case is only that $U(1)$ is abelian (ℂ is commutative) whereas $SU(2) \\cong Sp(1)$ is not (ℍ is non-commutative) — mirroring that electromagnetism is an abelian gauge theory and the weak force is not.",
+    "mathContext": "$U(1) = \\{z \\in \\mathbb{C} : |z| = 1\\} = S^1$, the unit circle. Multiplicativity $\\mathrm{normSq}(zw) = \\mathrm{normSq}(z)\\,\\mathrm{normSq}(w)$ gives closure. Unlike $Sp(1)$, $U(1)$ is abelian since $\\mathbb{C}$ is commutative.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "U(1) gauge group",
+      "unit circle",
+      "Complex.normSq",
+      "abelian group"
+    ],
+    "prerequisites": [
+      "complex numbers",
+      "modulus of a complex number",
+      "multiplicative norms"
+    ]
+  },
+  {
+    "id": "ann-hurwitz-oq02-summary",
+    "proofId": "hurwitz-theorem-oq-02",
+    "range": {
+      "startLine": 214,
+      "endLine": 232
+    },
+    "type": "insight",
+    "title": "The Assembled Four-to-Four Dictionary",
+    "content": "The capstone theorem `four_to_four_dictionary` collects the backbone into a single statement: there are four algebras and four forces ($|NDA| = |Force| = 4$), `forceOf` is a bijection, and along it every gauge dimension matches an algebra dimension — the imaginary dimension for ℝ, ℂ, ℍ and the full dimension for 𝕆. The proof reuses the component lemmas (`card_eq_four`, `forceOf_bijective`) and finishes the dimension claim by case analysis, using `first | rfl | exact absurd rfl ha` to dispatch the three non-octonion algebras by `rfl` while ruling out the octonion case against the hypothesis `a ≠ octonion`. The single packaged statement is what answers the open question precisely: the 'four ↔ four' coincidence is, machine-checked, a dimension-respecting bijection — no more, no less.",
+    "mathContext": "The conjunction: $|NDA| = 4 \\wedge |Force| = 4 \\wedge \\mathrm{Bijective}(\\mathrm{forceOf}) \\wedge (\\forall a \\neq \\mathbb{O},\\ \\mathrm{gaugeDim}(\\mathrm{forceOf}\\,a) = \\dim\\mathrm{Im}(a)) \\wedge \\mathrm{gaugeDim}(\\mathrm{forceOf}\\,\\mathbb{O}) = \\dim\\mathbb{O}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "case analysis",
+      "bijection",
+      "dimension matching",
+      "proof assembly"
+    ],
+    "prerequisites": [
+      "logical conjunction",
+      "proof by cases",
+      "Function.Bijective"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `hurwitz-theorem-oq-02` (quality 45, passes 0).

## Gap addressed
The entry had a comprehensive `meta.json` (14 KB, well under caps) but **no `annotations.json` at all** — the proof page showed zero inline annotations. (`index.ts` is no longer needed; proofs load from `public/data/` at runtime since #20992.)

## What was added
7 section-aligned annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. **Module docstring** — the open question and the division-algebra/forces dictionary; explicit about scope (physics interpretation stays in commentary)
2. **NDA** — four normed division algebras as a Fintype; powers of two, Cayley–Dickson (sedenions fail), `dim = imagDim + 1`
3. **Force** — four interactions and $\dim SU(n) = n^2-1$ gauge dimensions; SM total 12
4. **forceOf bijection** — the canonical four↔four correspondence, decidable over Fintypes; imaginary-vs-full dimension matching
5. **Unit quaternions** — $Sp(1)\cong SU(2)$ as a subgroup of $\mathbb{H}^\times$ via `normSq` multiplicativity (composition-algebra property)
6. **Unit complex numbers** — $U(1)$ closure by the same `map_mul` argument; abelian vs non-abelian contrast
7. **four_to_four_dictionary** — the assembled dimension-respecting bijection

## Verification
- Both JSON files parse; `pnpm build` data-generation phase enriched the entry successfully (the `tsc` step can't run in this worktree — `node_modules` absent — but the change is pure data JSON validated by the data pipeline).
- Axiom integrity unchanged: `status: verified`, `axiomCount: 0`, `badge: original` — consistent with the Lean file (0 sorries, 0 axioms, plain `decide`/`rfl`, no `native_decide`).