### PR TITLE
research(erdos-340-greedy-sidon-oq-05): count the forbidden values — explicit polynomial bound on the B_h greedy obstruction [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos340GreedySidonOQ05.lean
+++ b/proofs/Proofs/Erdos340GreedySidonOQ05.lean
@@ -773,4 +773,63 @@ theorem IsBh.map_affine {h c d : ℕ} {A : Finset ℕ} (hc : 0 < c) (hA : IsBh h
   rw [hfun, ← Finset.image_image]
   exact (hA.map_mul_right hc).map_add_right
 
+/-! ## Part 7: Counting the forbidden values
+
+§5b reduced the open lower bound to a *counting* question: how many values are
+forbidden for greedy `B_h` extension?  `IsBh.exists_diff_eq_of_not_insert` shows
+every forbidden `m` solves `d · m + sA.sum = tA.sum` for a triple `(d, sA, tA)`
+with `1 ≤ d ≤ h` and `sA, tA` short multisets over `A`.  Crucially the triple
+**determines** `m` (since `d ≥ 1`), so the forbidden values are the image of the
+finite triple-set under `(d, sA, tA) ↦ (tA.sum − sA.sum) / d`.  Counting the
+triples gives an explicit cardinality bound, polynomial in `|A|`. -/
+
+open scoped Classical in
+/-- **The forbidden set is polynomially bounded.**  For a `B_h` set `A`, the number
+of values `m` below the trivial ceiling `h · max A` whose insertion breaks `B_h` is
+at most `h · T²`, where `T` is the number of multisets over `A` of size `≤ h`
+(`T = ∑_{i ≤ h} multichoose(|A|, i)`, polynomial in `|A|` of degree `h`).
+
+This is the explicit form of the §5b counting milestone: it turns the (open)
+`B_h` greedy lower bound into a concrete bound on the forbidden set.  The rate it
+yields is the trivial `N^{1/2h}`; the sharp `N^{1/(2h-1)}` needs the finer count
+that exploits the orientation of the `d · m` block. -/
+theorem IsBh.card_forbidden_le {h : ℕ} {A : Finset ℕ} (hA : IsBh h A) :
+    ((Finset.range (h * A.sup id + 1)).filter
+        (fun m => ¬ IsBh h (insert m A))).card
+      ≤ h * (((Finset.range (h + 1)).biUnion
+              (fun i => (A.sym i).image Subtype.val)).card) ^ 2 := by
+  set T : Finset (Multiset ℕ) :=
+    (Finset.range (h + 1)).biUnion (fun i => (A.sym i).image Subtype.val) with hT
+  set F := (Finset.range (h * A.sup id + 1)).filter
+      (fun m => ¬ IsBh h (insert m A)) with hF
+  -- Every multiset over `A` of size `≤ h` lies in `T`.
+  have hmemT : ∀ u : Multiset ℕ, (∀ x ∈ u, x ∈ A) → Multiset.card u ≤ h → u ∈ T := by
+    intro u hu hcard
+    rw [hT, Finset.mem_biUnion]
+    refine ⟨Multiset.card u, Finset.mem_range.mpr (by omega), ?_⟩
+    rw [Finset.mem_image]
+    exact ⟨⟨u, rfl⟩, Finset.mem_sym_iff.mpr hu, rfl⟩
+  set P : Finset (ℕ × Multiset ℕ × Multiset ℕ) := (Finset.Icc 1 h) ×ˢ T ×ˢ T with hP
+  -- Every forbidden value is the image of its determining triple.
+  have hsub : F ⊆ P.image (fun p => (p.2.2.sum - p.2.1.sum) / p.1) := by
+    intro m hm
+    rw [hF, Finset.mem_filter, Finset.mem_range] at hm
+    obtain ⟨hmlt, hbad⟩ := hm
+    obtain ⟨d, sA, tA, hd1, hdh, hsA, htA, hcsA, hctA, heq⟩ :=
+      hA.exists_diff_eq_of_not_insert hbad
+    rw [Finset.mem_image]
+    refine ⟨(d, sA, tA), ?_, ?_⟩
+    · rw [hP, Finset.mem_product, Finset.mem_product]
+      exact ⟨Finset.mem_Icc.mpr ⟨hd1, hdh⟩, hmemT sA hsA hcsA, hmemT tA htA hctA⟩
+    · show (tA.sum - sA.sum) / d = m
+      rw [show tA.sum - sA.sum = d * m from by omega]
+      exact Nat.mul_div_cancel_left m (by omega)
+  calc F.card ≤ (P.image (fun p => (p.2.2.sum - p.2.1.sum) / p.1)).card :=
+        Finset.card_le_card hsub
+    _ ≤ P.card := Finset.card_image_le
+    _ = h * T.card ^ 2 := by
+        rw [hP, Finset.card_product, Finset.card_product, Nat.card_Icc,
+            Nat.add_sub_cancel]
+        ring
+
 end Erdos340Bh

--- a/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
@@ -275,3 +275,29 @@ IsBh.map_mul_right / IsBh.map_affine` = `[propext, Classical.choice, Quot.sound]
 #### Next Steps
 - Unchanged open core: the forbidden-set counting for the `N^{1/(2h-1)}` greedy lower
   bound. `map_affine` now lets one normalise a `B_h` set (least element 0) as a first step.
+
+### Session 2026-06-27 (researcher-3) — counting the forbidden values
+
+**Mode**: CONTINUE (RICH) · **Outcome**: progress (verified increment)
+
+Added `IsBh.card_forbidden_le` (Part 7): the §5b counting milestone made explicit.
+For a `B_h` set `A`, the number of values `m ≤ h·max A` whose insertion breaks `B_h`
+is `≤ h · T²`, where `T = #{multisets over A of size ≤ h}` (`= ∑_{i≤h} multichoose(|A|,i)`,
+polynomial in `|A|` of degree `h`).
+
+**Proof idea.** `exists_diff_eq_of_not_insert` gives each forbidden `m` a triple
+`(d, sA, tA)` with `1 ≤ d ≤ h`, `sA,tA` multisets over `A` of size `≤ h`, and
+`d·m + sA.sum = tA.sum`. Since `d ≥ 1`, the triple *determines* `m = (tA.sum−sA.sum)/d`.
+So the forbidden set is a *subset of the image* of the finite triple-set
+`Icc 1 h ×ˢ T ×ˢ T` under `(d,sA,tA) ↦ (tA.sum−sA.sum)/d` — no choice function needed,
+just `card_le_card` + `card_image_le` + `card_product`.
+
+**Key API.** `Finset.mem_sym_iff` (Sym carries card in its type → membership is just the
+`∀x∈u, x∈A` condition); short multiset `u` over `A` lands in
+`T := (range (h+1)).biUnion (i ↦ (A.sym i).image Subtype.val)` at index `card u`.
+`Nat.mul_div_cancel_left m (0<d) : d*m/d = m`. `Nat.card_Icc : #(Icc a b)=b+1-a`.
+
+**Honest scope.** The bound `h·T²` is degree `2h` in `|A|`, giving the *trivial*
+`N^{1/2h}` greedy rate. The sharp `N^{1/(2h-1)}` needs the finer count exploiting the
+orientation of the `d·m` block (the `d` and `(sA,tA)` are not independent). Still open.
+Verified 0-axiom (`lake env lean`, exit 0; `#print axioms` = propext/Classical.choice/Quot.sound).

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -12,8 +12,8 @@
     {
       "path": "Proofs/Erdos340GreedySidonOQ05.lean",
       "filename": "Erdos340GreedySidonOQ05.lean",
-      "lineCount": 704,
-      "theoremCount": 27,
+      "lineCount": 835,
+      "theoremCount": 28,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,
@@ -71,6 +71,6 @@
       "Prove the maximal-set lower bound directly: if A ⊆ [1,N] is B_h and maximal (no n ∈ [1,N] extends it), then N ≤ |A| + (number of values blocked by a collision), and bound the blocked count by |A|^{2h-1}.",
       "With the bridge in hand, transport a concrete gallery Sidon result (e.g. sidon_upper_bound_weak or an explicit small Sidon set) through isBh_two_iff_isSidon as a sanity corollary."
     ],
-    "progressSummary": "PROGRESS: Foundational B_h theory + sharp upper bound Nat.choose |A| h ≤ h·N + downward closure (of_succ/of_le) + EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A + translation invariance + GREEDY EXTENSION (insert_of_large, exists_insert) + EXPLICIT GREEDY FAMILY (greedyBhAux/greedyBhSet; exists_isBh_card: a B_h set of every cardinality n exists for each h≥1), + full AFFINE invariance (dilation map_mul_right + composite map_affine, positive-slope affine group = symmetry group of the bound), all verified 0-axiom (Erdos340GreedySidonOQ05.lean, 704 lines, 27 theorems). The construction cleanly SEPARATES the open question: a B_h set's count is unbounded for free; the remaining open core is the forbidden-set counting bounding the LARGEST element, i.e. the N^{1/(2h-1)} growth rate inside {1,…,N} — matching the still-open parent #340."
+    "progressSummary": "PROGRESS: Foundational B_h theory + sharp upper bound Nat.choose |A| h ≤ h·N + downward closure (of_succ/of_le) + EXACT bridge IsBh 2 A ↔ Erdos340.IsSidon A + translation invariance + GREEDY EXTENSION (insert_of_large, exists_insert) + EXPLICIT GREEDY FAMILY (greedyBhAux/greedyBhSet; exists_isBh_card: a B_h set of every cardinality n exists for each h≥1), + full AFFINE invariance (dilation map_mul_right + composite map_affine, positive-slope affine group = symmetry group of the bound), + EXPLICIT FORBIDDEN-SET COUNT (IsBh.card_forbidden_le: #forbidden m ≤ h·T² where T=#{multisets over A of size ≤h}, polynomial in |A| — the §5b counting milestone made explicit, via forbidden m ↦ determining triple (d,sA,tA)), all verified 0-axiom (Erdos340GreedySidonOQ05.lean, 835 lines, 28 theorems). The construction cleanly SEPARATES the open question: a B_h set's count is unbounded for free; card_forbidden_le now gives the trivial N^{1/2h} greedy rate, but the sharp N^{1/(2h-1)} growth inside {1,…,N} (needing the finer d·m-orientation count) remains open — matching the still-open parent #340."
   }
 }


### PR DESCRIPTION
## Summary

Advances the **RICH** open problem `erdos-340-greedy-sidon-oq-05` (the B_h generalization of Sidon-set theory) by realizing the counting milestone its own §5b documentation flags as the reduction of the open lower bound.

Adds one verified theorem `IsBh.card_forbidden_le` (Part 7, +59 lines) to `Erdos340GreedySidonOQ05.lean`.

## What it proves

For a B_h set `A`, the number of values `m ≤ h·max(A)` whose insertion breaks B_h is
```
≤ h · T²,   where T = #{ multisets over A of size ≤ h } = Σ_{i≤h} multichoose(|A|, i)
```
— **polynomial in `|A|`** (degree `2h`). This is exactly the "pure counting problem about multisets over A" that `IsBh.exists_diff_eq_of_not_insert` (the prior forbidden-value characterization) was set up to enable.

## Proof

`exists_diff_eq_of_not_insert` assigns each forbidden `m` a triple `(d, sA, tA)` with `1 ≤ d ≤ h`, `sA, tA` short multisets over `A`, and `d·m + sA.sum = tA.sum`. Since `d ≥ 1`, the triple **determines** `m = (tA.sum − sA.sum)/d`. So the forbidden set is a *subset of the image* of the finite triple-set `Icc 1 h ×ˢ T ×ˢ T` under `(d,sA,tA) ↦ (tA.sum−sA.sum)/d` — bounded by `card_le_card` + `card_image_le` + `card_product`. No choice function required.

## Honest scope

The degree-`2h` bound yields only the **trivial `N^{1/2h}` greedy rate**. The sharp `N^{1/(2h-1)}` requires the finer count that exploits the orientation of the `d·m` block (the gap `d` and the multiset pair `(sA, tA)` are not independent). The optimal rate **remains open**, matching the still-open parent Erdős #340.

## Verification

- `lake env lean Proofs/Erdos340GreedySidonOQ05.lean` → exit 0, no errors/warnings/sorries (Mathlib oleans prebuilt; Docker wrapper unavailable in sandbox, single-file host elaboration used).
- `#print axioms Erdos340Bh.IsBh.card_forbidden_le` → `[propext, Classical.choice, Quot.sound]` only.
- File: 835 lines, 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)