### PR TITLE
Enrich Abel–Ruffini obstruction (OQ-04-01-04-01): annotations 3→5

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04-oq-01/annotations.json
@@ -1,13 +1,37 @@
 [
   {
+    "id": "ann-module-overview",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "context",
+    "title": "From the Key Lemma to the Abel–Ruffini Obstruction",
+    "content": "The module docstring situates this file in the concrete-quintic branch of the Abel–Ruffini formalization. The parent entry proved the Key Group Theory Lemma — a transitive subgroup `G ≤ S_p` (`p` prime) containing a transposition is all of `S_p`. This file draws the payoff: for `p ≥ 5` that group is the full symmetric group, hence not solvable, which via the Galois correspondence (`Polynomial.solvableByRad`: a polynomial is solvable by radicals iff its Galois group is solvable) is the obstruction blocking the general quintic. The file is deliberately self-contained — it re-proves the Key Lemma rather than importing it — so it compiles standalone, and it cites the original sources (Ruffini 1799, Abel 1824, Galois 1831).",
+    "mathContext": "Galois's solvability criterion: a polynomial $f$ is solvable by radicals $\\iff \\mathrm{Gal}(f)$ is a solvable group. Since $S_p$ ($p \\ge 5$) is unsolvable and occurs as a Galois group, no general radical formula exists in degree $\\ge 5$.",
+    "significance": "context",
+    "relatedConcepts": ["Abel–Ruffini theorem", "Galois correspondence", "solvable group", "Polynomial.solvableByRad"],
+    "prerequisites": ["Galois theory", "solvability by radicals", "symmetric groups"]
+  },
+  {
+    "id": "ann-setup",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-04-oq-01",
+    "range": { "startLine": 36, "endLine": 42 },
+    "type": "technique",
+    "title": "Imports and Permutation-Group Setup",
+    "content": "A single `import Mathlib` pulls in the entire library; the `open Equiv Equiv.Perm Subgroup MulAction` line brings the permutation-group and group-action vocabulary into scope (cycle structure, `IsSwap`, `topEquiv`, `orbit`, `stabilizer`). The carrier `α` is an arbitrary finite type with decidable equality — abstracting away from any concrete set of roots, so the obstruction theorem applies uniformly to `S_n` for every `n`. The `MulAction` import is what lets a subgroup `G ≤ S_α` act on `α` and makes orbit–stabilizer available in the Key Lemma.",
+    "mathContext": "Working over an abstract finite type $\\alpha$ with $|\\alpha| = p$ means the results hold for the symmetric group $S_\\alpha \\cong S_p$ on any $p$-element set, not a fixed model.",
+    "significance": "technical",
+    "relatedConcepts": ["MulAction", "Equiv.Perm", "Fintype", "DecidableEq"],
+    "prerequisites": ["Lean namespaces and open", "group actions"]
+  },
+  {
     "id": "ann-key-lemma",
     "proofId": "abel-ruffini-oq-04-oq-01-oq-04-oq-01",
     "range": { "startLine": 47, "endLine": 81 },
     "type": "insight",
     "title": "The Key Group Theory Lemma (re-proved self-contained)",
     "content": "`eq_top_of_isPretransitive_of_mem_isSwap`: a transitive subgroup `G ≤ S_p` (`p = card α` prime) containing a transposition `τ` equals `⊤`. Orbit–stabilizer plus transitivity give `p ∣ |G|`; Cauchy (`exists_prime_orderOf_dvd_card`) produces an element of order `p`; on a `p`-element set such an element is a `p`-cycle with full support (`isCycle_of_prime_order`, `IsCycle.orderOf`); and a `p`-cycle together with any transposition generates `S_p` (`closure_prime_cycle_swap`). Since both generators lie in `G`, `⊤ = ⟨σ,τ⟩ ≤ G`. Re-proved here so the file is self-contained.",
-    "mathContext": "For prime $p$, a transitive $G\\le S_p$ containing a transposition satisfies $G=S_p$ — the classical bridge from 'transitive + a transposition' to the full symmetric group.",
-    "significance": "foundational",
+    "mathContext": "For prime $p$, a transitive $G\\le S_p$ containing a transposition satisfies $G=S_p$ — the classical bridge from 'transitive + a transposition' to the full symmetric group. Primality is essential: it forces the order-$p$ element to be a single $p$-cycle (full support), not a product of shorter cycles.",
+    "significance": "key",
     "relatedConcepts": ["closure_prime_cycle_swap", "exists_prime_orderOf_dvd_card", "isCycle_of_prime_order", "orbit_eq_univ"],
     "prerequisites": ["Orbit–stabilizer theorem", "Cauchy's theorem", "Cycle structure of permutations"]
   },
@@ -18,7 +42,7 @@
     "type": "insight",
     "title": "Non-Solvability Transported Across topEquiv",
     "content": "`not_isSolvable_top`: `S_α` is not solvable for `5 ≤ card α`. If `⊤ : Subgroup (Perm α)` were solvable, then `solvable_of_surjective` applied to the surjective monoid hom underlying `Subgroup.topEquiv : ⊤ ≃* Perm α` would make `Perm α` solvable — contradicting Mathlib's `Equiv.Perm.not_solvable α` (whose hypothesis `5 ≤ Cardinal.mk α` comes from `5 ≤ Fintype.card α` via `Cardinal.mk_fintype`). This is the clean bridge from 'G is everything' to 'G is unsolvable'.",
-    "mathContext": "$S_n$ is not solvable for $n\\ge 5$; equivalently the top subgroup of $\\mathrm{Perm}(\\alpha)$ is not solvable when $|\\alpha|\\ge 5$.",
+    "mathContext": "$S_n$ is not solvable for $n\\ge 5$; equivalently the top subgroup of $\\mathrm{Perm}(\\alpha)$ is not solvable when $|\\alpha|\\ge 5$. Solvability passes to quotients and subgroups and is preserved by surjections, so transporting it across the isomorphism $\\top \\cong \\mathrm{Perm}(\\alpha)$ is valid.",
     "significance": "key",
     "relatedConcepts": ["Equiv.Perm.not_solvable", "solvable_of_surjective", "Subgroup.topEquiv", "Cardinal.mk_fintype"],
     "prerequisites": ["Solvable groups", "MulEquiv and surjective homomorphisms"]
@@ -30,7 +54,7 @@
     "type": "insight",
     "title": "The Abel–Ruffini Obstruction",
     "content": "`not_isSolvable_of_isPretransitive_of_mem_isSwap`: a transitive subgroup of `S_p` (`p` prime, `p ≥ 5`) containing a transposition is NOT solvable — the Key Lemma forces `G = ⊤`, then `not_isSolvable_top` applies. Via the Galois correspondence (a polynomial is solvable by radicals iff its Galois group is solvable), this is exactly the obstruction making the general quintic unsolvable: any polynomial of prime degree `p ≥ 5` whose Galois group is transitive and contains a transposition (e.g. an irreducible quintic with two non-real roots, where complex conjugation is the transposition) is unsolvable by radicals.",
-    "mathContext": "Abel–Ruffini: degree-$\\ge 5$ polynomials have no general radical formula because $S_p$ ($p\\ge 5$) is unsolvable and arises as a Galois group.",
+    "mathContext": "Abel–Ruffini: degree-$\\ge 5$ polynomials have no general radical formula because $S_p$ ($p\\ge 5$) is unsolvable and arises as a Galois group. The transposition typically comes from complex conjugation acting on an irreducible polynomial with exactly two non-real roots.",
     "significance": "key",
     "relatedConcepts": ["eq_top_of_isPretransitive_of_mem_isSwap", "not_isSolvable_top", "Polynomial.solvableByRad"],
     "prerequisites": ["Galois solvability criterion"]


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-01-oq-04-oq-01` (quality 79, passes 0).

## Gap addressed
Three solid annotations existed, but the module docstring and setup (lines 1–42) were unannotated, and the Key Lemma annotation used a non-standard `significance: "foundational"` (the schema allows only key/supporting/technical/context).

## Changes
- **Added** module-overview annotation (lines 1–34): Galois correspondence framing, `Polynomial.solvableByRad`, original sources.
- **Added** imports/setup annotation (lines 36–42): abstract finite type $\alpha$, `MulAction`/orbit–stabilizer vocabulary, why the result is model-independent.
- **Deepened** `mathContext` on the three existing annotations: primality forcing a full-support $p$-cycle; solvability preserved under surjections; the transposition arising from complex conjugation on an irreducible quintic with two non-real roots.
- **Fixed** `significance`: "foundational" → "key".

## Verification
- annotations.json parses; 5 annotations, all with schema-valid `significance`, `mathContext`, `relatedConcepts`, `prerequisites`.
- No change to meta.json; axiom integrity untouched (status verified, 0 axioms — consistent with the Lean file's `#print axioms` reporting only propext/Classical.choice/Quot.sound).