### PR TITLE
research(egorov-theorem-oq-01-oq-03): the finite-measure hypothesis of Egorov's theorem is essential [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/EgorovTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/EgorovTheoremOQ01OQ03.lean
@@ -1,0 +1,134 @@
+import Mathlib.MeasureTheory.Function.Egorov
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.Tactic
+
+/-
+# Sharpness of Egorov's Theorem: the Finite-Measure Hypothesis is Essential
+
+## What This Proves
+
+**Egorov's theorem** says: on a measure space of *finite* measure, if
+`fₙ → g` almost everywhere then for every `ε > 0` there is a set of measure `≤ ε`
+off which `fₙ → g` *uniformly*. The parent gallery proof (`egorov-theorem-oq-01`)
+formalizes the theorem, a worked example (`xⁿ` on `[0,1]`), and the sharpness of
+the *removed null set* (`xⁿ` is non-uniform on all of `[0,1)`).
+
+This file establishes a different, complementary sharpness: the **finiteness of
+the ambient measure** cannot be dropped. On the infinite-measure space `(ℝ, vol)`
+there is a sequence converging to `0` *everywhere* yet admitting **no**
+finite-measure set off which the convergence is uniform — so the Egorov
+conclusion fails outright.
+
+The witnesses are the **marching indicators**
+
+  `fₙ = 𝟙_{[n, n+1]}`     (`marching n = (Icc n (n+1)).indicator 1`).
+
+* `marching_tendsto_zero` — for every `x : ℝ`, `fₙ(x) → 0`. (For a fixed `x`,
+  once `n > x` the bump `[n, n+1]` has marched past `x`, so `fₙ(x) = 0`.)
+  Convergence holds at *every* point, not merely almost everywhere.
+
+* `marching_not_tendstoUniformlyOn_of_volume_lt_top` — for **any** set `s` of
+  finite Lebesgue measure, `fₙ` does *not* converge uniformly to `0` on `sᶜ`.
+  Indeed uniformity on `sᶜ` (with `ε = 1/2`) would force `[n, n+1] ⊆ s` for all
+  large `n`, hence `[N, ∞) ⊆ s`, contradicting `vol s < ∞`.
+
+* `volume_finite_hypothesis_essential` — packaging: there is no finite-measure
+  set off which `fₙ → 0` uniformly.
+
+* `marching_not_tendstoUniformlyOn_univ` — the `s = ∅` special case: `fₙ` is
+  non-uniform even on all of `ℝ`.
+
+## Why It Is Not in Mathlib
+
+Mathlib has the abstract Egorov theorem but no formalized counterexample showing
+the finite-measure hypothesis is necessary. The marching-indicator construction,
+its everywhere-pointwise convergence, and the no-finite-exceptional-set
+obstruction are the new content.
+
+## Axiom Status
+
+Fully verified: 0 sorries, 0 `axiom` declarations, no `native_decide`. Relies
+only on Mathlib's measure theory and the foundational axioms `propext`,
+`Classical.choice`, `Quot.sound`.
+-/
+
+open MeasureTheory Filter Set Topology
+open scoped ENNReal
+
+namespace EgorovTheoremOQ01OQ03
+
+/-- The **marching indicators** `fₙ = 𝟙_{[n, n+1]}` on `ℝ`: a unit bump on the
+interval `[n, n+1]` that marches off to `+∞` as `n → ∞`. -/
+noncomputable def marching (n : ℕ) : ℝ → ℝ :=
+  Set.indicator (Set.Icc (n : ℝ) (n + 1)) 1
+
+/-- The marching indicators converge to `0` at **every** point of `ℝ`: for a
+fixed `x`, once `n > x` the bump `[n, n+1]` lies entirely to the right of `x`, so
+`fₙ(x) = 0` from then on. -/
+theorem marching_tendsto_zero (x : ℝ) :
+    Tendsto (fun n => marching n x) atTop (𝓝 (0 : ℝ)) := by
+  obtain ⟨N, hN⟩ := exists_nat_gt x
+  have hev : ∀ᶠ n in atTop, marching n x = 0 := by
+    rw [eventually_atTop]
+    refine ⟨N, fun n hn => ?_⟩
+    apply Set.indicator_of_notMem
+    rw [Set.mem_Icc]
+    rintro ⟨hle, _⟩
+    have hxn : x < (n : ℝ) := lt_of_lt_of_le hN (by exact_mod_cast hn)
+    linarith
+  exact (tendsto_congr' hev).mpr tendsto_const_nhds
+
+/-- **Sharpness of Egorov: the finite-measure hypothesis is essential.** For
+*any* set `s ⊆ ℝ` of finite Lebesgue measure, the marching indicators do not
+converge uniformly to `0` on the complement `sᶜ`. Hence no finite-measure
+exceptional set can rescue uniform convergence on the infinite-measure space `ℝ`,
+even though `fₙ → 0` everywhere pointwise. -/
+theorem marching_not_tendstoUniformlyOn_of_volume_lt_top
+    {s : Set ℝ} (hs : volume s < ⊤) :
+    ¬ TendstoUniformlyOn marching (fun _ => (0 : ℝ)) atTop sᶜ := by
+  intro h
+  rw [Metric.tendstoUniformlyOn_iff] at h
+  obtain ⟨N, hN⟩ := eventually_atTop.mp (h (1 / 2) (by norm_num))
+  -- Uniformity with `ε = 1/2` forces every `[n, n+1]` with `n ≥ N` into `s`,
+  -- so `[N, ∞) ⊆ s`.
+  have hsub : Set.Ici (N : ℝ) ⊆ s := by
+    intro x hx
+    have hx0 : (0 : ℝ) ≤ x := le_trans (Nat.cast_nonneg N) hx
+    by_contra hxs
+    -- `x ∈ sᶜ`; let `n = ⌊x⌋₊ ≥ N`, so `x ∈ [n, n+1]` and `fₙ(x) = 1`.
+    set n := ⌊x⌋₊ with hn_def
+    have hnN : N ≤ n := Nat.le_floor hx
+    have hmem : x ∈ Set.Icc (n : ℝ) (n + 1) := by
+      constructor
+      · exact Nat.floor_le hx0
+      · exact (Nat.lt_floor_add_one x).le
+    have hval : marching n x = 1 := by
+      unfold marching
+      rw [Set.indicator_of_mem hmem, Pi.one_apply]
+    have hdist := hN n hnN x hxs
+    rw [hval] at hdist
+    simp only [Real.dist_eq] at hdist
+    norm_num at hdist
+  -- But `[N, ∞)` has infinite measure, contradicting `vol s < ∞`.
+  have hle : volume (Set.Ici (N : ℝ)) ≤ volume s := measure_mono hsub
+  rw [Real.volume_Ici] at hle
+  exact hs.ne (top_le_iff.mp hle)
+
+/-- **The finite-measure hypothesis of Egorov's theorem cannot be dropped.**
+There is no finite-measure set `s` such that `fₙ → 0` uniformly off `s`, despite
+`fₙ → 0` everywhere on `ℝ`. -/
+theorem volume_finite_hypothesis_essential :
+    ¬ ∃ s : Set ℝ, volume s < ⊤ ∧
+      TendstoUniformlyOn marching (fun _ => (0 : ℝ)) atTop sᶜ := by
+  rintro ⟨s, hs, h⟩
+  exact marching_not_tendstoUniformlyOn_of_volume_lt_top hs h
+
+/-- The `s = ∅` special case: the marching indicators do not converge uniformly
+to `0` on all of `ℝ`, even though they converge to `0` at every point. -/
+theorem marching_not_tendstoUniformlyOn_univ :
+    ¬ TendstoUniformlyOn marching (fun _ => (0 : ℝ)) atTop Set.univ := by
+  have h := marching_not_tendstoUniformlyOn_of_volume_lt_top
+    (s := (∅ : Set ℝ)) (by simp)
+  rwa [Set.compl_empty] at h
+
+end EgorovTheoremOQ01OQ03

--- a/research/problems/egorov-theorem-oq-01-oq-03/knowledge.md
+++ b/research/problems/egorov-theorem-oq-01-oq-03/knowledge.md
@@ -1,0 +1,65 @@
+# Knowledge Base: egorov-theorem-oq-01-oq-03
+
+Sharpness of Egorov's theorem: the **finite-measure hypothesis is essential**.
+
+---
+
+## Problem Summary
+
+Egorov's theorem upgrades a.e. convergence to uniform convergence off a set of
+arbitrarily small measure — but only on a measure space of **finite** measure.
+This problem asks to formalize that the finiteness hypothesis cannot be dropped:
+on `(ℝ, Lebesgue)` exhibit a sequence converging to `0` everywhere pointwise that
+admits no finite-measure set off which the convergence is uniform.
+
+**Witness:** the marching indicators `fₙ = 𝟙_[n,n+1]`.
+
+---
+
+## Status: COMPLETED (verified, 0-axiom)
+
+Proved in `proofs/Proofs/EgorovTheoremOQ01OQ03.lean` (134 lines, 4 theorems,
+1 definition, 0 sorries, 0 axioms — only `propext`/`Classical.choice`/`Quot.sound`).
+
+---
+
+## Session 2026-06-27 (Session 1) - Construct and prove
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+- Defined `marching n = (Set.Icc n (n+1)).indicator 1`, the unit bump on `[n,n+1]`.
+- Proved `marching_tendsto_zero`: `fₙ(x) → 0` at **every** `x ∈ ℝ` (eventually-0
+  via `exists_nat_gt` + `Set.indicator_of_notMem`, then `tendsto_congr'`).
+- Proved the headline `marching_not_tendstoUniformlyOn_of_volume_lt_top`: for any
+  `s` with `vol s < ⊤`, `fₙ` is not uniform on `sᶜ`.
+- Packaged `volume_finite_hypothesis_essential` (no finite-measure exceptional set
+  exists) and `marching_not_tendstoUniformlyOn_univ` (`s = ∅` corollary).
+
+### Key Findings
+- The negation of `TendstoUniformlyOn` is clean via `Metric.tendstoUniformlyOn_iff`
+  at `ε = 1/2`: since the indicator is `{0,1}`-valued, `dist(0, fₙ x) < 1/2` forces
+  `fₙ x = 0`, i.e. `[n,n+1] ⊆ s` for all large `n`.
+- The contradiction is purely measure-monotone: `[N,∞) ⊆ s` ⇒ `vol s ≥ vol[N,∞) = ∞`
+  via `Real.volume_Ici` + `measure_mono`. **No measurability of `s` is needed**, so
+  the statement is slightly stronger than the textbook (measurable-`s`) version.
+- This is genuinely distinct from the parent `egorov-theorem-oq-01`, which proves
+  the *removed null set* cannot be omitted on a finite-measure example (`xⁿ` on
+  `[0,1]`). Here the *ambient finiteness* itself is what fails. Together they bound
+  Egorov from both sides.
+
+### Mathlib notes
+- `Real.volume_Ici : volume (Set.Ici a) = ∞` — exactly the infinite-tail fact needed.
+- `Set.indicator_of_not_mem` is deprecated → use `Set.indicator_of_notMem`.
+- Floor placement of `x ≥ N` into a bump: `Nat.le_floor`, `Nat.floor_le`,
+  `Nat.lt_floor_add_one`.
+
+### Files Modified
+- `proofs/Proofs/EgorovTheoremOQ01OQ03.lean` (new)
+- `src/data/proofs/egorov-theorem-oq-01-oq-03/{meta,annotations}.json` (new)
+
+### Next Steps
+- None required; problem resolved. Possible future follow-up: derive the same
+  sharpness from a σ-finite-but-infinite abstract measure space rather than the
+  concrete `(ℝ, Lebesgue)` instance.

--- a/src/data/proofs/egorov-theorem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/egorov-theorem-oq-01-oq-03/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-egorov-oq0103-docstring",
+    "proofId": "egorov-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 5,
+      "endLine": 53
+    },
+    "type": "context",
+    "title": "Sharpness of Egorov: Finiteness is Essential",
+    "content": "The docstring frames the goal: Egorov's theorem upgrades a.e. convergence to uniform convergence off a small set ONLY when the ambient measure is finite. This file proves that hypothesis is sharp on (ℝ, Lebesgue) using the marching indicators fₙ = 𝟙_[n,n+1]. It contrasts with the parent entry egorov-theorem-oq-01, which proves the orthogonal sharpness (the removed null set cannot be omitted on the finite-measure example xⁿ on [0,1]). Fully verified: 0 sorries, 0 axioms, no native_decide.",
+    "mathContext": "On an infinite-measure space Egorov fails: a sequence can converge to 0 everywhere yet never uniformly off any finite-measure set.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Egorov's theorem",
+      "essential hypotheses",
+      "infinite measure spaces",
+      "marching indicators",
+      "uniform vs pointwise convergence"
+    ],
+    "prerequisites": [
+      "measure theory",
+      "Lebesgue measure on ℝ",
+      "uniform convergence"
+    ]
+  },
+  {
+    "id": "ann-egorov-oq0103-marching",
+    "proofId": "egorov-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 60,
+      "endLine": 66
+    },
+    "type": "definition",
+    "title": "The Marching Indicators 𝟙_[n,n+1]",
+    "content": "marching n = (Set.Icc n (n+1)).indicator 1 is the unit bump supported on [n, n+1]. As n grows the bump marches off to +∞, never settling on any bounded region. This escape to infinity is exactly what makes finiteness of the ambient measure necessary: to suppress the bump uniformly past some index you must absorb the entire infinite tail [N, ∞) into the exceptional set.",
+    "mathContext": "fₙ(x) = 1 if x ∈ [n, n+1], else 0. The canonical textbook counterexample to Egorov on infinite measure.",
+    "significance": "core",
+    "relatedConcepts": [
+      "indicator function",
+      "bump functions",
+      "escape to infinity"
+    ],
+    "prerequisites": [
+      "Set.indicator"
+    ]
+  },
+  {
+    "id": "ann-egorov-oq0103-pointwise",
+    "proofId": "egorov-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 68,
+      "endLine": 84
+    },
+    "type": "theorem",
+    "title": "Everywhere-Pointwise Convergence to 0",
+    "content": "marching_tendsto_zero proves fₙ(x) → 0 for EVERY x ∈ ℝ, not merely almost everywhere. Fix x and pick a natural N > x (exists_nat_gt); for all n ≥ N one has x < n, so x ∉ [n, n+1] and the indicator vanishes. Thus the sequence is eventually 0 and converges to 0. This everywhere convergence is what makes the subsequent failure of uniformity so stark — there is no pointwise pathology at all.",
+    "mathContext": "For fixed x, the bump [n,n+1] eventually lies entirely to the right of x, so fₙ(x) = 0 for all large n.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pointwise convergence",
+      "eventually constant sequences",
+      "Filter.Tendsto"
+    ],
+    "prerequisites": [
+      "exists_nat_gt",
+      "tendsto_congr'",
+      "Set.indicator_of_notMem"
+    ]
+  },
+  {
+    "id": "ann-egorov-oq0103-sharpness",
+    "proofId": "egorov-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 86,
+      "endLine": 133
+    },
+    "type": "theorem",
+    "title": "No Finite-Measure Exceptional Set",
+    "content": "marching_not_tendstoUniformlyOn_of_volume_lt_top is the headline result: for any s with vol s < ∞, fₙ does not converge uniformly to 0 on sᶜ. Assume it does; Metric.tendstoUniformlyOn_iff at ε = 1/2 gives an index N past which dist(0, fₙ x) < 1/2 for all x ∈ sᶜ. Since fₙ takes only values 0 and 1, this forces fₙ x = 0 on sᶜ, i.e. [n,n+1] ⊆ s for all n ≥ N. For any real x ≥ N the floor index ⌊x⌋ ≥ N gives x ∈ [⌊x⌋, ⌊x⌋+1] ⊆ s, so [N,∞) ⊆ s and vol s ≥ vol[N,∞) = ∞ (Real.volume_Ici) — contradicting finiteness. Only monotonicity of measure is used, so s need not be measurable. Packaged as volume_finite_hypothesis_essential and specialized to s = ∅ in marching_not_tendstoUniformlyOn_univ.",
+    "mathContext": "Uniform 1/2-control off s past index N ⇒ the infinite-measure tail [N,∞) ⊆ s ⇒ vol s = ∞, contradicting vol s < ∞.",
+    "significance": "core",
+    "relatedConcepts": [
+      "uniform convergence",
+      "proof by contradiction",
+      "sharpness / essential hypothesis",
+      "monotonicity of measure"
+    ],
+    "prerequisites": [
+      "Metric.tendstoUniformlyOn_iff",
+      "Real.volume_Ici",
+      "measure_mono",
+      "Nat.floor bounds"
+    ]
+  }
+]

--- a/src/data/proofs/egorov-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/egorov-theorem-oq-01-oq-03/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "egorov-theorem-oq-01-oq-03",
+  "slug": "egorov-theorem-oq-01-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib.MeasureTheory.Function.Egorov",
+      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Filter",
+      "Set",
+      "Topology"
+    ],
+    "namespace": "EgorovTheoremOQ01OQ03",
+    "lineCount": 134,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/EgorovTheoremOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "title": "Sharpness of Egorov: the Finite-Measure Hypothesis is Essential",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EgorovTheoremOQ01OQ03.lean",
+    "tags": [
+      "analysis",
+      "measure-theory",
+      "convergence",
+      "uniform-convergence",
+      "real-analysis",
+      "egorov",
+      "counterexample",
+      "sharpness",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 134,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "badge": "verified",
+    "originalContributions": [
+      "marching_not_tendstoUniformlyOn_of_volume_lt_top: the headline sharpness result — for ANY set s ⊆ ℝ of finite Lebesgue measure, the marching indicators fₙ = 𝟙_[n,n+1] do NOT converge uniformly to 0 on the complement sᶜ. This establishes that Egorov's finite-(total-)measure hypothesis is essential: on the infinite-measure space ℝ no finite-measure exceptional set can be removed to obtain uniform convergence. Mathlib has the abstract Egorov theorem but no counterexample witnessing the necessity of finiteness.",
+      "marching_tendsto_zero: the marching indicators fₙ = 𝟙_[n,n+1] converge to 0 at EVERY point of ℝ (not merely a.e.) — for a fixed x, once n > x the bump [n,n+1] has marched past x, so fₙ(x) = 0 eventually. This is the everywhere-pointwise convergence that makes the failure of uniformity striking.",
+      "volume_finite_hypothesis_essential: packaging the obstruction as a single non-existence statement — there is no finite-measure set s with fₙ → 0 uniformly off s, despite everywhere-pointwise convergence.",
+      "marching_not_tendstoUniformlyOn_univ: the s = ∅ corollary — fₙ does not converge uniformly to 0 on all of ℝ, the cleanest one-line statement of non-uniformity on the infinite-measure space.",
+      "marching: the marching-indicator construction 𝟙_[n,n+1] on ℝ as a Set.indicator, the unit bump that marches to +∞."
+    ],
+    "prerequisites": [
+      "Metric.tendstoUniformlyOn_iff: the ε-characterization of uniform convergence on a set, used to refute uniformity at ε = 1/2",
+      "Set.indicator_of_mem / Set.indicator_of_notMem: evaluation of an indicator function inside and outside its support",
+      "Real.volume_Ici: the Lebesgue measure of a closed ray [a, ∞) is ∞",
+      "Nat.le_floor, Nat.floor_le, Nat.lt_floor_add_one: floor bounds placing a real x ≥ N inside some bump [⌊x⌋, ⌊x⌋+1]",
+      "measure_mono: monotonicity of measure (no measurability of s required)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Metric.tendstoUniformlyOn_iff",
+        "description": "Uniform convergence of Fₙ → g on a set s is equivalent to: for every ε > 0, eventually dist (g x) (Fₙ x) < ε for all x ∈ s. Instantiated at ε = 1/2 to refute uniform convergence of the marching indicators off any finite-measure set.",
+        "module": "Mathlib.Topology.MetricSpace.Pseudo.Basic"
+      },
+      {
+        "theorem": "Real.volume_Ici",
+        "description": "The Lebesgue measure of a closed ray [a, ∞) ⊆ ℝ is ∞. Supplies the contradiction: uniformity off s would force [N, ∞) ⊆ s, giving vol s = ∞ against the finite-measure assumption.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
+      },
+      {
+        "theorem": "Set.indicator_of_notMem",
+        "description": "For a ∉ s, the indicator (s.indicator f) a = 0. Drives the everywhere-pointwise convergence fₙ(x) → 0: once n > x, x ∉ [n,n+1] so fₙ(x) = 0.",
+        "module": "Mathlib.Algebra.Order.Group.Indicator"
+      },
+      {
+        "theorem": "measure_mono",
+        "description": "Monotonicity of an (outer) measure: s ⊆ t ⇒ μ s ≤ μ t, with no measurability hypothesis on s. Lets the obstruction hold for arbitrary finite-measure s, not just measurable ones.",
+        "module": "Mathlib.MeasureTheory.Measure.MeasureSpace"
+      }
+    ]
+  },
+  "openQuestions": [],
+  "crossReferences": [
+    {
+      "targetId": "egorov-theorem-oq-01",
+      "relationship": "parent",
+      "description": "Resolves the parent entry's open question egorov-theorem-oq-01-oq-01: it formalizes the failure of Egorov's theorem on an infinite (σ-finite) measure space via the marching indicators 1_[n,n+1], establishing that the finite-measure hypothesis μ s ≠ ∞ is essential. The parent proves the complementary sharpness (the removed null set cannot be omitted on the finite-measure example xⁿ on [0,1]); this entry proves the ambient finiteness itself cannot be dropped."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: MeasureTheory.Function.Egorov",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the abstract Egorov theorem MeasureTheory.tendstoUniformlyOn_of_ae_tendsto, whose finite-measure hypothesis this entry shows is necessary."
+    },
+    {
+      "title": "Real Analysis: Modern Techniques and Their Applications",
+      "author": "Folland",
+      "year": "1999",
+      "venue": "Wiley",
+      "description": "Standard reference for Egorov's theorem (Thm 2.33) and the standard remark that the finite-measure hypothesis is essential, illustrated by the marching-bump sequence 1_[n,n+1] on ℝ."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Egorov's theorem (Dmitri Egorov 1911; independently Carlo Severini 1910) — the second of Littlewood's three principles — upgrades almost-everywhere convergence to uniform convergence off an arbitrarily small set, PROVIDED the ambient measure is finite. Every textbook treatment immediately flags that finiteness is indispensable, and the canonical counterexample is the marching-bump sequence 1_[n,n+1] on ℝ with Lebesgue measure: it converges to 0 at every point yet never converges uniformly off any finite-measure set, because the unit bump keeps reappearing arbitrarily far out where no finite-measure exceptional set can catch it. The parent gallery entry formalizes Egorov plus the sharpness of the removed null set on the finite-measure example xⁿ on [0,1]; this entry formalizes the orthogonal sharpness — that the FINITENESS of the total measure cannot be dropped — which Mathlib does not record.",
+    "problemStatement": "Show that the finite-measure hypothesis in Egorov's theorem is essential. Concretely, on (ℝ, Lebesgue) exhibit a sequence converging to 0 everywhere pointwise that admits no finite-measure set off which the convergence is uniform. The witnesses are the marching indicators fₙ = 𝟙_[n,n+1]: marching_tendsto_zero proves fₙ(x) → 0 for every x, and marching_not_tendstoUniformlyOn_of_volume_lt_top proves that for any s with vol s < ∞, fₙ does not converge uniformly to 0 on sᶜ.",
+    "proofStrategy": "Pointwise convergence (marching_tendsto_zero): fix x and choose a natural N > x (exists_nat_gt); for n ≥ N one has x < n, so x ∉ [n,n+1] and the indicator vanishes, hence fₙ(x) = 0 eventually and the limit is 0. Sharpness (marching_not_tendstoUniformlyOn_of_volume_lt_top): assume uniform convergence on sᶜ and apply Metric.tendstoUniformlyOn_iff at ε = 1/2 to get an index N past which dist(0, fₙ x) < 1/2 for all x ∈ sᶜ; since fₙ takes only values 0 and 1, this forces fₙ x = 0 on sᶜ for all n ≥ N, i.e. [n,n+1] ⊆ s for every n ≥ N. For any real x ≥ N, the bump index ⌊x⌋ ≥ N places x ∈ [⌊x⌋, ⌊x⌋+1] ⊆ s (floor bounds), so [N, ∞) ⊆ s. Monotonicity then gives vol s ≥ vol[N,∞) = ∞ (Real.volume_Ici), contradicting vol s < ∞. The argument needs no measurability of s — pure monotonicity suffices.",
+    "keyInsights": [
+      "The two sharpness phenomena are genuinely different. The parent shows that on a FINITE-measure space the removed exceptional set must be nonempty (you cannot take ε = 0). This entry shows that on an INFINITE-measure space the theorem collapses entirely — no finite-measure exceptional set works at all. Both are needed to delimit exactly when Egorov holds.",
+      "Everywhere convergence makes the failure maximally stark: fₙ → 0 not just a.e. but at literally every point of ℝ, yet uniformity fails off every finite-measure set. The obstruction is the non-compactness / infinite measure of ℝ, not any pointwise pathology.",
+      "The mechanism is that the unit bump 𝟙_[n,n+1] escapes to infinity: to kill it uniformly past index N you would have to swallow the entire tail [N,∞) into the exceptional set, which has infinite measure. This is the quantitative content of 'finiteness is essential'.",
+      "The result holds for arbitrary (not necessarily measurable) finite-measure s, because only measure_mono — monotonicity of the outer measure — is used. This is slightly stronger than the textbook statement, which usually restricts to measurable exceptional sets.",
+      "The badge is verified/original: unlike the parent (which wraps Mathlib's abstract Egorov theorem and carries a mathlib badge), every theorem here is new content with no Mathlib analogue — Mathlib formalizes Egorov but not the counterexample establishing its hypothesis is sharp."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Finiteness is Essential",
+      "startLine": 5,
+      "endLine": 53,
+      "summary": "States the goal — the finite-measure hypothesis of Egorov's theorem cannot be dropped — and contrasts it with the parent entry's sharpness of the removed null set. Introduces the marching indicators 𝟙_[n,n+1], lists the four results, and records the axiom status (0 sorries, 0 axioms, no native_decide).",
+      "mathContext": "On infinite measure, a.e. (indeed everywhere) convergence does NOT yield uniform convergence off a small set: the marching bumps converge to 0 everywhere yet never uniformly off any finite-measure set."
+    },
+    {
+      "id": "marching-def",
+      "title": "The Marching Indicators",
+      "startLine": 60,
+      "endLine": 66,
+      "summary": "marching n = (Icc n (n+1)).indicator 1: a unit bump on [n, n+1] that marches off to +∞ as n grows. The construction is the canonical witness for sharpness of Egorov on infinite measure.",
+      "mathContext": "fₙ = 𝟙_[n,n+1] : ℝ → ℝ, equal to 1 on [n, n+1] and 0 elsewhere."
+    },
+    {
+      "id": "pointwise",
+      "title": "Everywhere-Pointwise Convergence to 0",
+      "startLine": 68,
+      "endLine": 84,
+      "summary": "marching_tendsto_zero: for every x ∈ ℝ, fₙ(x) → 0. Choosing N > x, for all n ≥ N one has x < n so x ∉ [n,n+1] and fₙ(x) = 0; the sequence is eventually 0, hence converges to 0.",
+      "mathContext": "For fixed x, the bump [n,n+1] eventually lies entirely to the right of x, so fₙ(x) = 0 for all large n."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness: No Finite-Measure Exceptional Set",
+      "startLine": 86,
+      "endLine": 133,
+      "summary": "marching_not_tendstoUniformlyOn_of_volume_lt_top: for any s with vol s < ∞, fₙ is not uniform on sᶜ. Uniformity at ε = 1/2 forces [n,n+1] ⊆ s for all n ≥ N, hence [N,∞) ⊆ s (via floor bounds), so vol s ≥ vol[N,∞) = ∞ — contradiction. Packaged as volume_finite_hypothesis_essential and specialized to s = ∅ in marching_not_tendstoUniformlyOn_univ.",
+      "mathContext": "Uniform 1/2-control off s past index N ⇒ the tail [N,∞) ⊆ s ⇒ vol s = ∞, contradicting finiteness. Only monotonicity of measure is used; s need not be measurable."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The finite-measure hypothesis in Egorov's theorem is essential. On (ℝ, Lebesgue) the marching indicators fₙ = 𝟙_[n,n+1] converge to 0 at every point (marching_tendsto_zero), yet for any set s of finite Lebesgue measure they fail to converge uniformly to 0 on sᶜ (marching_not_tendstoUniformlyOn_of_volume_lt_top): uniform 1/2-control off s would force the infinite-measure tail [N,∞) into s. Packaged as volume_finite_hypothesis_essential (no finite-measure exceptional set exists) and marching_not_tendstoUniformlyOn_univ (non-uniformity on all of ℝ). 134 lines, 4 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "Together with the parent entry — which shows the removed exceptional set cannot be taken null on a finite-measure example — this delimits Egorov's theorem from both sides: the conclusion needs a genuinely positive exceptional set, and the hypothesis needs genuinely finite total measure. The counterexample is original to the gallery; Mathlib has the theorem but not the sharpness witness.",
+    "openQuestions": []
+  }
+}


### PR DESCRIPTION
## Summary

Resolves the parent open question **egorov-theorem-oq-01-oq-01**: formalizes that the **finite-measure hypothesis of Egorov's theorem cannot be dropped**.

On `(ℝ, Lebesgue)` the **marching indicators** `fₙ = 𝟙_[n,n+1]` converge to `0` at *every* point, yet for **any** set `s` of finite Lebesgue measure they fail to converge uniformly to `0` on `sᶜ`. Uniform `1/2`-control off `s` past some index `N` would force the infinite-measure tail `[N,∞) ⊆ s`, contradicting `vol s < ∞`.

This is **complementary** to the parent entry (egorov-theorem-oq-01), which proves the *removed null set* cannot be omitted on a finite-measure example (`xⁿ` on `[0,1]`). Together they delimit Egorov from both sides.

## Theorems (`Proofs/EgorovTheoremOQ01OQ03.lean`)
- `marching_tendsto_zero` — `fₙ(x) → 0` at every `x ∈ ℝ` (everywhere, not just a.e.).
- `marching_not_tendstoUniformlyOn_of_volume_lt_top` — for any `vol s < ∞`, not uniform on `sᶜ`.
- `volume_finite_hypothesis_essential` — no finite-measure exceptional set exists.
- `marching_not_tendstoUniformlyOn_univ` — the `s = ∅` corollary (non-uniform on all of ℝ).

## Notes
- The obstruction uses only `measure_mono` (monotonicity), so **`s` need not be measurable** — slightly stronger than the textbook (measurable-`s`) statement.
- **134 lines, 4 theorems, 1 definition, 0 sorries, 0 `axiom` declarations**, no `native_decide`. `#print axioms` reports only `propext`/`Classical.choice`/`Quot.sound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)