### PR TITLE
Enrich Abel-Ruffini S₄ threshold: deepen annotations

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-06-oq-01/annotations.json
@@ -5,7 +5,21 @@
     "range": { "startLine": 1, "endLine": 50 },
     "type": "context",
     "title": "Closing the threshold at the last open case S₄",
-    "content": "The Abel–Ruffini dichotomy 'Sₙ solvable ⟺ n ≤ 4' has its negative half (n ≥ 5) in Mathlib, via the simplicity of A₅. The parent entry supplied the easy solvable cases S₂, S₃ (their alternating groups A₂, A₃ have prime order, so are cyclic and abelian). The hard remaining case is S₄: its alternating group A₄ has order 12 — neither prime-order nor simple — so a new argument is needed. This file proves A₄ solvable via its metabelian structure, lifts that to S₄, and packages the complete equivalence."
+    "content": "The Abel–Ruffini dichotomy 'Sₙ solvable ⟺ n ≤ 4' has its negative half (n ≥ 5) in Mathlib, via the simplicity of A₅. The parent entry supplied the easy solvable cases S₂, S₃ (their alternating groups A₂, A₃ have prime order, so are cyclic and abelian). The hard remaining case is S₄: its alternating group A₄ has order 12 — neither prime-order nor simple — so a new argument is needed. This file proves A₄ solvable via its metabelian structure, lifts that to S₄, and packages the complete equivalence.",
+    "mathContext": "The threshold is the group-theoretic content of the Abel–Ruffini theorem: the general degree-$n$ polynomial is solvable by radicals iff its Galois group $S_n$ is a solvable group, iff $n \\le 4$. The derived series $G \\rhd G' \\rhd G'' \\rhd \\cdots$ terminates at $1$ exactly for $S_2, S_3, S_4$; for $n \\ge 5$ it stabilizes at the non-trivial simple group $A_n$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Abel–Ruffini theorem",
+      "solvable group",
+      "symmetric group Sₙ",
+      "alternating group Aₙ",
+      "solvability by radicals"
+    ],
+    "prerequisites": [
+      "solvable groups",
+      "derived series",
+      "Galois theory of polynomials"
+    ]
   },
   {
     "id": "ann-v4-solvable",
@@ -13,7 +27,20 @@
     "range": { "startLine": 58, "endLine": 67 },
     "type": "key-step",
     "title": "The Klein-four commutator subgroup V₄ is abelian, hence solvable",
-    "content": "The commutator subgroup of A₄ is the Klein-four group V₄ = alternatingGroup.kleinFour (Fin 4). Its defining feature is exponent two — every non-identity element is an involution — so for any a, b: ab = (ab)⁻¹ = b⁻¹a⁻¹ = ba. Mathlib packages this as mul_comm_of_exponent_two, turning Monoid.exponent V₄ = 2 into commutativity, and isSolvable_of_comm then makes V₄ solvable. This is the bottom step of the derived series A₄ ⊳ V₄ ⊳ 1."
+    "content": "The commutator subgroup of A₄ is the Klein-four group V₄ = alternatingGroup.kleinFour (Fin 4). Its defining feature is exponent two — every non-identity element is an involution — so for any a, b: ab = (ab)⁻¹ = b⁻¹a⁻¹ = ba. Mathlib packages this as mul_comm_of_exponent_two, turning Monoid.exponent V₄ = 2 into commutativity, and isSolvable_of_comm then makes V₄ solvable. This is the bottom step of the derived series A₄ ⊳ V₄ ⊳ 1.",
+    "mathContext": "$V_4 = \\{e, (12)(34), (13)(24), (14)(23)\\} \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ has exponent $2$: every element satisfies $x^2 = e$, i.e. $x = x^{-1}$. Then $ab = (ab)^{-1} = b^{-1}a^{-1} = ba$, so $V_4$ is abelian, hence solvable (an abelian group has derived subgroup $\\{e\\}$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Klein four-group V₄",
+      "exponent two / involutions",
+      "commutator subgroup",
+      "abelian implies solvable"
+    ],
+    "prerequisites": [
+      "group exponent",
+      "abelian groups",
+      "commutator subgroup"
+    ]
   },
   {
     "id": "ann-quotient-abelian",
@@ -21,7 +48,21 @@
     "range": { "startLine": 68, "endLine": 76 },
     "type": "key-step",
     "title": "A₄/V₄ is abelian because V₄ IS the commutator subgroup",
-    "content": "The same subgroup that serves as the solvable kernel also certifies the quotient is abelian: since V₄ = commutator A₄ (kleinFour_eq_commutator), the criterion quotient_commutative_iff_commutator_le gives that A₄/V₄ (≅ ℤ/3) is commutative, hence solvable. The short exact sequence 1 → V₄ → A₄ → A₄/V₄ → 1 — with ker(quotient map) = V₄ = range(inclusion) — then yields IsSolvable A₄ through solvable_of_ker_le_range. This is the metabelian core: solvable kernel + solvable quotient ⟹ solvable extension."
+    "content": "The same subgroup that serves as the solvable kernel also certifies the quotient is abelian: since V₄ = commutator A₄ (kleinFour_eq_commutator), the criterion quotient_commutative_iff_commutator_le gives that A₄/V₄ (≅ ℤ/3) is commutative, hence solvable. The short exact sequence 1 → V₄ → A₄ → A₄/V₄ → 1 — with ker(quotient map) = V₄ = range(inclusion) — then yields IsSolvable A₄ through solvable_of_ker_le_range. This is the metabelian core: solvable kernel + solvable quotient ⟹ solvable extension.",
+    "mathContext": "$G/N$ is abelian iff $G' \\le N$ (the commutator subgroup lies in $N$). Here $N = V_4 = A_4' = \\mathrm{commutator}(A_4)$, so $G' \\le N$ holds with equality and $A_4/V_4 \\cong \\mathbb{Z}/3$ is abelian. Solvability is closed under extensions: $1 \\to N \\to G \\to G/N \\to 1$ with $N$ and $G/N$ solvable gives $G$ solvable — the derived series concatenates.",
+    "significance": "key",
+    "relatedConcepts": [
+      "abelianization",
+      "commutator subgroup",
+      "short exact sequence",
+      "extension of solvable groups",
+      "metabelian group"
+    ],
+    "prerequisites": [
+      "quotient groups",
+      "commutator subgroup",
+      "extensions of groups"
+    ]
   },
   {
     "id": "ann-s4",
@@ -29,7 +70,19 @@
     "range": { "startLine": 82, "endLine": 89 },
     "type": "result",
     "title": "S₄ is solvable",
-    "content": "Feeding the new IsSolvable A₄ instance into the parent reduction permSolvable_of_alternatingSolvable 4 (the short exact sequence 1 → A₄ → S₄ → ℤˣ with abelian quotient ℤˣ ≅ ℤ/2) yields permFinFour_isSolvable: IsSolvable (Equiv.Perm (Fin 4)). This closes the final open case of the solvable side of the threshold."
+    "content": "Feeding the new IsSolvable A₄ instance into the parent reduction permSolvable_of_alternatingSolvable 4 (the short exact sequence 1 → A₄ → S₄ → ℤˣ with abelian quotient ℤˣ ≅ ℤ/2) yields permFinFour_isSolvable: IsSolvable (Equiv.Perm (Fin 4)). This closes the final open case of the solvable side of the threshold.",
+    "mathContext": "The short exact sequence $1 \\to A_4 \\to S_4 \\to \\{\\pm 1\\} \\to 1$ (the sign homomorphism, with kernel $A_4$ and abelian quotient $\\mathbb{Z}/2$) extends a solvable normal subgroup by an abelian quotient, so $S_4$ is solvable. Its full derived series is $S_4 \\rhd A_4 \\rhd V_4 \\rhd 1$, of length $3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sign homomorphism",
+      "short exact sequence",
+      "derived series",
+      "S₄ structure"
+    ],
+    "prerequisites": [
+      "alternating subgroup",
+      "quotient by a normal subgroup"
+    ]
   },
   {
     "id": "ann-equivalence",
@@ -37,6 +90,20 @@
     "range": { "startLine": 90, "endLine": 105 },
     "type": "result",
     "title": "The packaged threshold: Sₙ solvable ⟺ n ≤ 4",
-    "content": "isSolvable_perm_fin_iff packages the whole Abel–Ruffini dichotomy. Forward (solvable ⟹ n ≤ 4): contraposition — for n ≥ 5, Equiv.Perm.not_solvable (using #(Fin n) = n ≥ 5) shows Sₙ is non-solvable. Backward (n ≤ 4 ⟹ solvable): interval_cases on n discharges S₀, S₁ as subsingletons (infer_instance), S₂, S₃ from the parent theorems, and S₄ from permFinFour_isSolvable. This single biconditional is the exact group-theoretic boundary between radical-solvable degrees (n ≤ 4) and the rest."
+    "content": "isSolvable_perm_fin_iff packages the whole Abel–Ruffini dichotomy. Forward (solvable ⟹ n ≤ 4): contraposition — for n ≥ 5, Equiv.Perm.not_solvable (using #(Fin n) = n ≥ 5) shows Sₙ is non-solvable. Backward (n ≤ 4 ⟹ solvable): interval_cases on n discharges S₀, S₁ as subsingletons (infer_instance), S₂, S₃ from the parent theorems, and S₄ from permFinFour_isSolvable. This single biconditional is the exact group-theoretic boundary between radical-solvable degrees (n ≤ 4) and the rest.",
+    "mathContext": "$\\mathrm{IsSolvable}(S_n) \\iff n \\le 4$. The non-solvable direction rests on the simplicity of $A_5$: for $n \\ge 5$, $A_5 \\le A_n$ is non-abelian simple, so the derived series of $S_n$ stabilizes at the perfect group $A_n$ ($A_n' = A_n$) and never reaches $1$. The solvable direction is a finite case split over $n \\in \\{0,1,2,3,4\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Abel–Ruffini threshold",
+      "simplicity of A₅",
+      "perfect group",
+      "proof by contraposition",
+      "interval_cases"
+    ],
+    "prerequisites": [
+      "simple groups",
+      "non-solvability of Sₙ for n ≥ 5",
+      "biconditional proofs"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-06-oq-01` (pass 0, quality 66).

## Gap addressed
The entry had 5 well-written annotations carrying only `title` + `content` — no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`.

## Changes
Added all four missing fields to every annotation:
- **Overview** — the derived series view of the Sₙ-solvable threshold
- **V₄ solvable** — exponent-two ⟹ involutions ⟹ abelian
- **Quotient abelian** — G/N abelian iff G' ≤ N, with V₄ = commutator(A₄)
- **S₄ solvable** — sign sequence 1 → A₄ → S₄ → ℤ/2 → 1, full series S₄ ⊳ A₄ ⊳ V₄ ⊳ 1
- **Equivalence** — non-solvability from simplicity of A₅ (perfect group)

`meta.json` left unchanged (already rich at 14.2KB, under all caps). All math drawn directly from the Lean source.

## Verification
JSON validates; all 5 annotations now carry the four enrichment fields.
