### PR TITLE
Enrich Arithmetico-Geometric sum: field-generality annotation

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01/annotations.json
+++ b/src/data/proofs/summation-by-parts-oq-01/annotations.json
@@ -15,6 +15,21 @@
     "prerequisites": ["finite sums", "geometric series"]
   },
   {
+    "id": "ann-sbp-oq01-setup",
+    "proofId": "summation-by-parts-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 56
+    },
+    "type": "concept",
+    "title": "Purely algebraic: any field, one hypothesis r ≠ 1",
+    "content": "The whole development lives over an arbitrary field K (variable {K : Type*} [Field K]) — no order, no norm, no notion of convergence. The single hypothesis r ≠ 1 enters the proof exactly once, as hr1 : r − 1 ≠ 0 (sub_ne_zero.mpr hr), which is what licenses dividing by (r − 1)². This is the structural reason the result is sharper than the familiar analytic ∑ k·rᵏ = r/(1−r)²: that limit needs ‖r‖ < 1 in a normed field, whereas the finite identity is an exact element of K(r) valid at every r except the removable singularity r = 1. The casts (n : K) are the only bridge from the index set ℕ into the field.",
+    "mathContext": "The identity is an equation in the field of fractions $K(r)$: both sides are rational functions of $r$ with the single pole at $r=1$. The hypothesis $r\\neq 1 \\iff r-1\\neq 0$ is precisely what makes $(r-1)^{-2}$ defined.",
+    "significance": "supporting",
+    "relatedConcepts": ["field (no analytic structure)", "removable singularity at r = 1", "natural number cast ℕ → K", "rational function identity"],
+    "prerequisites": ["fields", "division and nonzero denominators"]
+  },
+  {
     "id": "ann-sbp-oq01-closed-form",
     "proofId": "summation-by-parts-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01` (pass 0, quality 79).

## Assessment
The entry was already well-enriched: rich `meta.json` (9.6 KB — overview, 4 keyInsights, 2 sections, conclusion, 2 crossReferences) and 3 annotations already carrying full `mathContext` / `significance` / `relatedConcepts` / `prerequisites`, covering the docstring and both theorems. The Lean file is only 83 lines with 2 theorems, so per the size guardrails I deliberately kept this a **light** pass rather than padding to an arbitrary annotation count.

## Change
Added one substantive annotation (`ann-sbp-oq01-setup`, lines 44–56) for the one genuinely uncovered, mathematically meaningful region — the field-generality setup:
- the identity is purely algebraic over **any** field (no order, norm, or convergence),
- the sole hypothesis `r ≠ 1` enters exactly once as `r − 1 ≠ 0`, licensing division by `(r − 1)²`,
- it is an exact rational-function identity in `K(r)` with a removable singularity at `r = 1`, sharper than the analytic `∑ k·rᵏ = r/(1−r)²` which needs `‖r‖ < 1`.

`meta.json` left unchanged (already meets all quality targets, under all caps).

## Verification
JSON validates; all 4 annotations carry the four enrichment fields.
