### PR TITLE
Enrich Ceva incenter: complete annotation fields

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-04/annotations.json
@@ -7,7 +7,9 @@
     "title": "Module Overview: Angle Bisectors via Mass Points",
     "content": "The parent entry cevas-theorem-oq-04 certifies cevian concurrency from positive vertex masses, with the centroid arising from equal masses. This file treats the angle-bisector case: masses equal to the opposite side lengths (a, b, c) reproduce the angle-bisector theorem ratios and make the three bisectors concurrent at the incenter.",
     "mathContext": "Masses (mA, mB, mC) = (a, b, c); ratios BD/DC = c/b, CE/EA = a/c, AF/FB = b/a; incenter I = (a·A + b·B + c·C)/(a+b+c).",
-    "significance": "Turns the textbook 'the three angle bisectors meet at the incenter' into a checked theorem, with an explicit affine-combination witness in any real vector space."
+    "significance": "Turns the textbook 'the three angle bisectors meet at the incenter' into a checked theorem, with an explicit affine-combination witness in any real vector space.",
+    "relatedConcepts": ["mass points / barycentric coordinates", "angle-bisector theorem", "incenter", "Ceva's theorem", "cevian concurrency"],
+    "prerequisites": ["triangle geometry", "barycentric coordinates", "the parent mass-point framework"]
   },
   {
     "id": "ann-ctoq0404-01-bisectorMass",
@@ -17,7 +19,9 @@
     "title": "The Angle-Bisector Mass Assignment",
     "content": "bisectorMass packages masses equal to the opposite side lengths a = |BC|, b = |CA|, c = |AB| as an instance of the parent's MassPoint structure. Positivity of the side lengths supplies the structure's positivity fields.",
     "mathContext": "bisectorMass a b c : MassPoint with mA = a, mB = b, mC = c.",
-    "significance": "Choosing masses = opposite sides is precisely what the angle-bisector theorem dictates; everything else follows from the parent framework."
+    "significance": "Choosing masses = opposite sides is precisely what the angle-bisector theorem dictates; everything else follows from the parent framework.",
+    "relatedConcepts": ["mass-point assignment", "side lengths a, b, c", "MassPoint structure", "positivity hypotheses"],
+    "prerequisites": ["triangle side lengths", "structures with positivity fields"]
   },
   {
     "id": "ann-ctoq0404-02-ratios",
@@ -27,7 +31,9 @@
     "title": "Angle-Bisector Theorem Ratios",
     "content": "The parent's lever-arm identity ratio_balance gives rD/(1-rD) = mC/mB, which for bisectorMass is c/b — exactly BD/DC for the internal bisector from A. The cyclic lemmas give CE/EA = a/c and AF/FB = b/a.",
     "mathContext": "BD/DC = c/b, CE/EA = a/c, AF/FB = b/a.",
-    "significance": "Certifies that the side-length masses encode the angle-bisector theorem ratios, the bridge between the abstract masses and genuine bisectors."
+    "significance": "Certifies that the side-length masses encode the angle-bisector theorem ratios, the bridge between the abstract masses and genuine bisectors.",
+    "relatedConcepts": ["angle-bisector theorem", "lever-arm / ratio_balance", "directed segment ratios", "cyclic symmetry"],
+    "prerequisites": ["ratios of divided segments", "the parent ratio_balance lemma"]
   },
   {
     "id": "ann-ctoq0404-03-ceva",
@@ -37,7 +43,9 @@
     "title": "Concurrency via Ceva",
     "content": "Reusing the parent's ceva_ratio_product_one, the three bisectors satisfy Ceva's concurrency criterion. The product of directed ratios telescopes: (c/b)·(a/c)·(b/a) = 1.",
     "mathContext": "(rD/(1-rD))·(rE/(1-rE))·(rF/(1-rF)) = 1 = (c/b)·(a/c)·(b/a).",
-    "significance": "Establishes concurrency at the criterion level before pinning down the actual meeting point."
+    "significance": "Establishes concurrency at the criterion level before pinning down the actual meeting point.",
+    "relatedConcepts": ["Ceva's theorem", "telescoping product of ratios", "cevian concurrency criterion"],
+    "prerequisites": ["Ceva's theorem", "product of directed ratios"]
   },
   {
     "id": "ann-ctoq0404-04-incenter-defs",
@@ -47,7 +55,9 @@
     "title": "Feet and Incenter in a Real Vector Space",
     "content": "Working in an arbitrary real vector space V, footD/footE/footF are the bisector division points and incenter is the barycentric point (a·A + b·B + c·C)/(a+b+c). footD_eq_division confirms footD is the parent's rD division point for the bisector masses.",
     "mathContext": "footD = (b/(b+c))·B + (c/(b+c))·C; incenter = Σ (side/perimeter)·vertex.",
-    "significance": "Realises the cevians as honest lines so that concurrency becomes a statement about a common point, not just a ratio identity."
+    "significance": "Realises the cevians as honest lines so that concurrency becomes a statement about a common point, not just a ratio identity.",
+    "relatedConcepts": ["real vector space", "barycentric / affine combination", "incenter", "division points (feet of cevians)"],
+    "prerequisites": ["real vector spaces", "affine combinations", "barycentric coordinates"]
   },
   {
     "id": "ann-ctoq0404-05-concurrency",
@@ -57,7 +67,9 @@
     "title": "The Incenter Lies on All Three Bisectors",
     "content": "incenter_on_bisector_A/B/C prove (via match_scalars + field_simp) that the incenter equals the affine combination of each vertex with the opposite foot. The weights_*_sum_one lemmas show the two weights sum to 1, so each is a genuine affine combination and I lies on each bisector.",
     "mathContext": "I = (a/(a+b+c))·A + ((b+c)/(a+b+c))·footD, with a/(a+b+c) + (b+c)/(a+b+c) = 1; cyclically for B, C.",
-    "significance": "The explicit geometric concurrency witness: a single point I incident to all three bisectors, with barycentric coordinates (a : b : c)."
+    "significance": "The explicit geometric concurrency witness: a single point I incident to all three bisectors, with barycentric coordinates (a : b : c).",
+    "relatedConcepts": ["concurrency witness", "affine combination (weights sum to 1)", "barycentric coordinates (a:b:c)", "match_scalars / field_simp"],
+    "prerequisites": ["affine combinations", "incidence of a point on a line", "Lean tactics match_scalars, field_simp"]
   },
   {
     "id": "ann-ctoq0404-06-linemap",
@@ -67,6 +79,8 @@
     "title": "Bisector as an Affine Line",
     "content": "incenter_lineMap_A recasts the A-bisector as AffineMap.lineMap A footD, locating the incenter at parameter (b+c)/(a+b+c) ∈ (0,1).",
     "mathContext": "I = AffineMap.lineMap A footD ((b+c)/(a+b+c)).",
-    "significance": "Phrases incidence in Mathlib's canonical 'point on a line' vocabulary, ready to connect with the affine Ceva theory."
+    "significance": "Phrases incidence in Mathlib's canonical 'point on a line' vocabulary, ready to connect with the affine Ceva theory.",
+    "relatedConcepts": ["AffineMap.lineMap", "interpolation parameter in (0,1)", "affine line", "Mathlib affine geometry"],
+    "prerequisites": ["affine maps", "line parametrization (lineMap)"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cevas-theorem-oq-04-oq-04` (incenter via angle-bisector mass points, pass 0, quality 80).

## Gap addressed
The meta was already complete (all rendered overview/conclusion fields present). The gap was in the **annotations**: all 7 had `mathContext` + `significance` but were missing `relatedConcepts` and `prerequisites`.

## Change (annotations.json only)
Added `relatedConcepts` and `prerequisites` to each of the 7 annotations, drawn from existing content — mass points/barycentric coords, the angle-bisector theorem ratios, Ceva's criterion, the incenter (a:b:c), affine combinations, and `AffineMap.lineMap`. `content`/`mathContext`/`significance` preserved verbatim. meta.json untouched (status `verified`, 0 axioms).

## Verification
JSON validates; all 7 annotations now carry the four enrichment fields.
