### PR TITLE
research(algebraic-numbers-countable-oq-01-oq-03): the algebraic numbers ARE an algebraic closure of ℚ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ01OQ03.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ01OQ03.lean
@@ -1,0 +1,153 @@
+/-
+  # The Algebraic Numbers ARE an Algebraic Closure of ℚ
+
+  ## Lineage
+
+  * Grandparent (`AlgebraicNumbersCountable`): the algebraic numbers form a
+    *countable* subset of ℂ; in fact `#{z : ℂ | IsAlgebraic ℚ z} = ℵ₀`.
+  * Parent (`AlgebraicNumbersCountableOQ01`): the algebraic elements of a field
+    extension `L / K` are closed under `+, -, *, ⁻¹`, hence form a *subfield*.
+  * Sibling (`AlgebraicNumbersCountableOQ01OQ01`): that subfield is upgraded to an
+    `IntermediateField` `algebraicNumbersField : IntermediateField ℚ ℂ`, shown to be
+    *algebraically closed*, and identified with Mathlib's *relative* algebraic
+    closure `algebraicClosure ℚ ℂ`.
+
+  ## What this file adds (open question `oq-01-oq-03`)
+
+  The sibling identifies the algebraic numbers with the *relative* closure
+  `algebraicClosure ℚ ℂ` — an object that still lives inside `ℂ`. The open question
+  asks for the last structural step: identify the algebraic numbers with the
+  *abstract* algebraic closure `AlgebraicClosure ℚ`, the closure built by Mathlib
+  from `ℚ` alone with no ambient field.
+
+  The bridge is the universal "any two algebraic closures are isomorphic" principle.
+  Concretely:
+
+  1. **`algebraicNumbersField` is an algebraic closure of `ℚ`.** It is algebraically
+     closed (sibling) *and* algebraic over `ℚ` (every element is algebraic, by
+     definition), the two halves of Mathlib's `IsAlgClosure ℚ ·` predicate
+     (`instance : IsAlgClosure ℚ algebraicNumbersField`).
+
+  2. **The isomorphism.** Since `AlgebraicClosure ℚ` is also an `IsAlgClosure ℚ ·`,
+     Mathlib's `IsAlgClosure.equiv` yields a `ℚ`-algebra isomorphism
+     `algebraicNumbersEquivAlgebraicClosure : algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ`.
+     As a `ℚ`-algebra map it automatically fixes `ℚ` pointwise.
+
+  3. **Cardinality transport.** A `ℚ`-algebra isomorphism is in particular a
+     bijection, so the grandparent's count `#(algebraic numbers) = ℵ₀` transfers to
+     the abstract closure:
+     `#(AlgebraicClosure ℚ) = ℵ₀`  (`cardinalMk_algebraicClosure_rat`),
+     and hence `AlgebraicClosure ℚ` is a `Countable` type
+     (`countable_algebraicClosure_rat`). This realizes the classical fact that
+     "the field of algebraic numbers is countable" for the *intrinsically* defined
+     algebraic closure, not merely for its concrete copy inside `ℂ`.
+
+  All results are fully verified: 0 sorries, 0 `axiom` declarations, 0
+  structure-encoded assumptions (only the foundational `propext`,
+  `Classical.choice`, `Quot.sound`).
+
+  The mathematical content here is the *transport*: the sibling supplies the
+  algebraically-closed intermediate field, Mathlib supplies the uniqueness of
+  algebraic closures, and combining them pins the abstract `AlgebraicClosure ℚ`
+  down to the concrete algebraic numbers — including the transfer of countability.
+
+  Tags: field-theory, algebraic-numbers, algebraic-closure, cardinality, countable
+-/
+import Mathlib
+import Proofs.AlgebraicNumbersCountableOQ01OQ01
+
+open Cardinal
+
+namespace AlgebraicNumbersCountableOQ01OQ03
+
+open AlgebraicNumbersCountableOQ01OQ01
+
+/- ============================================================
+   § 1 : The algebraic numbers are an algebraic closure of ℚ
+   ============================================================ -/
+
+/-- **The algebraic numbers form an algebraic closure of `ℚ`.**
+
+`IsAlgClosure ℚ K` packages the two defining properties of an algebraic closure:
+`K` is algebraically closed and `K / ℚ` is an algebraic extension. The sibling file
+supplies the first (`IsAlgClosed algebraicNumbersField`) and the parent's
+construction supplies the second (every algebraic number is, by definition,
+algebraic over `ℚ`). -/
+instance instIsAlgClosure : IsAlgClosure ℚ algebraicNumbersField where
+  isAlgClosed := inferInstance
+  isAlgebraic := inferInstance
+
+/- ============================================================
+   § 2 : Identification with the abstract `AlgebraicClosure ℚ`
+   ============================================================ -/
+
+/-- **Main theorem (open question `oq-01-oq-03`).** The concrete field of algebraic
+numbers inside `ℂ` is `ℚ`-algebra isomorphic to Mathlib's abstractly-constructed
+`AlgebraicClosure ℚ`.
+
+Both are algebraic closures of `ℚ` (`instIsAlgClosure` and Mathlib's instance for
+`AlgebraicClosure ℚ`), and any two algebraic closures of the same field are
+isomorphic over it — Mathlib's `IsAlgClosure.equiv`. The isomorphism is a
+`ℚ`-algebra equivalence, so it is simultaneously a field isomorphism and fixes
+`ℚ` pointwise. -/
+noncomputable def algebraicNumbersEquivAlgebraicClosure :
+    algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ :=
+  IsAlgClosure.equiv ℚ algebraicNumbersField (AlgebraicClosure ℚ)
+
+/-- The identification is a `ℚ`-algebra map, hence fixes every rational: it sends
+`algebraMap ℚ algebraicNumbersField q` to `algebraMap ℚ (AlgebraicClosure ℚ) q`. -/
+@[simp] theorem algebraicNumbersEquivAlgebraicClosure_commutes (q : ℚ) :
+    algebraicNumbersEquivAlgebraicClosure (algebraMap ℚ algebraicNumbersField q)
+      = algebraMap ℚ (AlgebraicClosure ℚ) q :=
+  algebraicNumbersEquivAlgebraicClosure.commutes q
+
+/- ============================================================
+   § 3 : Cardinality transport — `AlgebraicClosure ℚ` is countable
+   ============================================================ -/
+
+/-- The underlying type of the algebraic-numbers field has cardinality `ℵ₀`.
+
+The carrier of `algebraicNumbersField` is the subtype `{z : ℂ // IsAlgebraic ℚ z}`,
+whose cardinality is `ℵ₀` by Mathlib's
+`Algebraic.cardinalMk_of_countable_of_charZero` (`ℚ` is countable of characteristic
+zero). -/
+theorem cardinalMk_algebraicNumbersField :
+    #(algebraicNumbersField) = ℵ₀ :=
+  -- the carrier `↥algebraicNumbersField` is *definitionally* `{z : ℂ // IsAlgebraic ℚ z}`,
+  -- since membership unfolds to `IsAlgebraic ℚ ·` (`mem_algebraicIntermediateField`).
+  Algebraic.cardinalMk_of_countable_of_charZero ℚ ℂ
+
+/-- **The abstract algebraic closure of `ℚ` is countably infinite:**
+`#(AlgebraicClosure ℚ) = ℵ₀`.
+
+This transports the grandparent's count of the algebraic numbers across the
+isomorphism `algebraicNumbersEquivAlgebraicClosure`. While "the algebraic numbers
+are countable" is classical, here it is established for the *intrinsic*
+`AlgebraicClosure ℚ`, which carries no a-priori embedding into `ℂ`. -/
+theorem cardinalMk_algebraicClosure_rat :
+    #(AlgebraicClosure ℚ) = ℵ₀ :=
+  (Cardinal.mk_congr algebraicNumbersEquivAlgebraicClosure.toEquiv).symm.trans
+    cardinalMk_algebraicNumbersField
+
+/-- The abstract algebraic closure `AlgebraicClosure ℚ` is a `Countable` type. -/
+theorem countable_algebraicClosure_rat : Countable (AlgebraicClosure ℚ) :=
+  Cardinal.mk_le_aleph0_iff.mp (le_of_eq cardinalMk_algebraicClosure_rat)
+
+/-- `AlgebraicClosure ℚ` is, moreover, infinite, so the count `ℵ₀` is genuine
+countable infinity rather than mere countability. -/
+theorem infinite_algebraicClosure_rat : Infinite (AlgebraicClosure ℚ) :=
+  Cardinal.infinite_iff.mpr (le_of_eq cardinalMk_algebraicClosure_rat.symm)
+
+section Examples
+
+-- The isomorphism is a bijection between the two carriers.
+example : Function.Bijective algebraicNumbersEquivAlgebraicClosure :=
+  algebraicNumbersEquivAlgebraicClosure.bijective
+
+-- `AlgebraicClosure ℚ` is countable and infinite — i.e. countably infinite.
+example : Countable (AlgebraicClosure ℚ) := countable_algebraicClosure_rat
+example : Infinite (AlgebraicClosure ℚ) := infinite_algebraicClosure_rat
+
+end Examples
+
+end AlgebraicNumbersCountableOQ01OQ03

--- a/src/data/proofs/algebraic-numbers-countable-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-01-oq-03/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "anoq03-ann-isalgclosure",
+    "proofId": "algebraic-numbers-countable-oq-01-oq-03",
+    "range": { "startLine": 73, "endLine": 88 },
+    "type": "definition",
+    "title": "The algebraic numbers are an algebraic closure of ℚ",
+    "content": "instIsAlgClosure certifies IsAlgClosure ℚ algebraicNumbersField. Mathlib's IsAlgClosure ℚ K class bundles two facts: K is algebraically closed and K/ℚ is an algebraic extension. The sibling entry already supplies the first as an instance (IsAlgClosed algebraicNumbersField); the parent's construction supplies the second (every algebraic number is, by definition, algebraic over ℚ). So the instance is the one-line assembly ⟨inferInstance, inferInstance⟩ — recognizing the concrete algebraic numbers as a formal algebraic closure.",
+    "mathContext": "An algebraic closure of $K$ is an algebraically closed field that is algebraic over $K$. Recognizing $\\overline{\\mathbb{Q}}$ as one is the prerequisite for invoking Steinitz uniqueness.",
+    "significance": "core",
+    "relatedConcepts": ["algebraic closure", "IsAlgClosure", "algebraically closed field", "algebraic extension"],
+    "prerequisites": ["field extensions", "algebraically closed fields"]
+  },
+  {
+    "id": "anoq03-ann-equiv",
+    "proofId": "algebraic-numbers-countable-oq-01-oq-03",
+    "range": { "startLine": 90, "endLine": 116 },
+    "type": "theorem",
+    "title": "Identification with the abstract AlgebraicClosure ℚ",
+    "content": "algebraicNumbersEquivAlgebraicClosure is the main result: a ℚ-algebra isomorphism algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ. It comes from IsAlgClosure.equiv ℚ _ _, the formalization of Steinitz's theorem that any two algebraic closures of a field are isomorphic over it. The concrete closure lives inside ℂ; the abstract AlgebraicClosure ℚ is built from ℚ alone, with no ambient field — the isomorphism is exactly what a formal library needs to identify them. Being a ℚ-algebra map, it fixes ℚ pointwise (algebraicNumbersEquivAlgebraicClosure_commutes).",
+    "mathContext": "Steinitz uniqueness: algebraic closures are unique up to (non-canonical) isomorphism over the base. The isomorphism is noncomputable — it depends on a choice of lift.",
+    "significance": "core",
+    "relatedConcepts": ["Steinitz uniqueness", "IsAlgClosure.equiv", "AlgEquiv", "AlgebraicClosure"],
+    "prerequisites": ["algebraic closures", "algebra isomorphisms"]
+  },
+  {
+    "id": "anoq03-ann-cardinality",
+    "proofId": "algebraic-numbers-countable-oq-01-oq-03",
+    "range": { "startLine": 118, "endLine": 153 },
+    "type": "theorem",
+    "title": "Cardinality transport — AlgebraicClosure ℚ is countably infinite",
+    "content": "cardinalMk_algebraicNumbersField reads off #algebraicNumbersField = ℵ₀ from Mathlib's Algebraic.cardinalMk_of_countable_of_charZero, using that the field's carrier is definitionally {z : ℂ // IsAlgebraic ℚ z} (membership is Iff.rfl). Because cardinality is an isomorphism invariant, Cardinal.mk_congr applied to the equiv transports this to cardinalMk_algebraicClosure_rat : #(AlgebraicClosure ℚ) = ℵ₀. Cardinal.mk_le_aleph0_iff and Cardinal.infinite_iff then give countable_algebraicClosure_rat and infinite_algebraicClosure_rat — the abstract closure is countably infinite, the classical countability of the algebraic numbers freed of any embedding into ℂ.",
+    "mathContext": "Cantor (1874): the algebraic numbers are countable. Transporting across the $\\mathbb{Q}$-algebra isomorphism shows the intrinsic $\\mathrm{AlgebraicClosure}\\,\\mathbb{Q}$ — uncoupled from $\\mathbb{C}$ — is itself countably infinite.",
+    "significance": "core",
+    "relatedConcepts": ["cardinality", "countable", "aleph-null", "isomorphism invariant"],
+    "prerequisites": ["cardinal arithmetic", "countable sets"]
+  }
+]

--- a/src/data/proofs/algebraic-numbers-countable-oq-01-oq-03/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-01-oq-03/meta.json
@@ -1,0 +1,224 @@
+{
+  "id": "algebraic-numbers-countable-oq-01-oq-03",
+  "title": "The Algebraic Numbers ARE an Algebraic Closure of ℚ",
+  "slug": "algebraic-numbers-countable-oq-01-oq-03",
+  "description": "Answers the open question of the sibling entry: identify the concrete field of algebraic numbers inside ℂ with Mathlib's abstractly-constructed AlgebraicClosure ℚ. The sibling proves algebraicNumbersField : IntermediateField ℚ ℂ is algebraically closed; here it is also (by definition) algebraic over ℚ, so it satisfies Mathlib's IsAlgClosure ℚ · predicate. Since AlgebraicClosure ℚ is also an IsAlgClosure ℚ ·, the uniqueness of algebraic closures (IsAlgClosure.equiv) yields a ℚ-algebra isomorphism algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ. Transporting the grandparent's cardinality count across this isomorphism establishes that the abstract AlgebraicClosure ℚ is countably infinite (#(AlgebraicClosure ℚ) = ℵ₀), hence a Countable type — realizing 'the algebraic numbers are countable' for the intrinsically-defined closure that carries no a-priori embedding into ℂ.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Algebraic_closure",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicNumbersCountableOQ01OQ03.lean",
+    "tags": [
+      "field-theory",
+      "algebraic-numbers",
+      "algebraic-closure",
+      "cardinality",
+      "countable",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 153,
+    "assumptions": "",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-27",
+    "originalContributions": [
+      "instIsAlgClosure: the concrete field of algebraic numbers algebraicNumbersField : IntermediateField ℚ ℂ is an algebraic closure of ℚ in Mathlib's sense (IsAlgClosure ℚ algebraicNumbersField) — assembling the sibling's IsAlgClosed instance with the parent's defining fact that every algebraic number is algebraic over ℚ",
+      "algebraicNumbersEquivAlgebraicClosure: the main result — a ℚ-algebra isomorphism algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ between the concrete algebraic numbers inside ℂ and Mathlib's abstractly-constructed algebraic closure of ℚ, obtained from the uniqueness of algebraic closures (IsAlgClosure.equiv)",
+      "algebraicNumbersEquivAlgebraicClosure_commutes: the identification fixes ℚ pointwise, sending algebraMap ℚ algebraicNumbersField q to algebraMap ℚ (AlgebraicClosure ℚ) q (it is a ℚ-algebra map)",
+      "cardinalMk_algebraicNumbersField: the carrier of algebraicNumbersField has cardinality ℵ₀, reading off Algebraic.cardinalMk_of_countable_of_charZero through the definitional identification of the carrier with {z : ℂ // IsAlgebraic ℚ z}",
+      "cardinalMk_algebraicClosure_rat: #(AlgebraicClosure ℚ) = ℵ₀ — the abstract algebraic closure of ℚ is countably infinite, established by transporting the cardinality across the isomorphism",
+      "countable_algebraicClosure_rat and infinite_algebraicClosure_rat: AlgebraicClosure ℚ is a Countable type and an Infinite type — i.e. countably infinite — both derived from the cardinality equality"
+    ],
+    "prerequisites": [
+      "AlgebraicNumbersCountableOQ01OQ01: supplies algebraicNumbersField : IntermediateField ℚ ℂ, its IsAlgClosed instance, and the algebraic-over-ℚ instance — the two halves of IsAlgClosure ℚ algebraicNumbersField",
+      "IsAlgClosure: Mathlib's predicate bundling 'K is algebraically closed' with 'K/R is algebraic'; the formal notion of an algebraic closure",
+      "IsAlgClosure.equiv: any two algebraic closures of the same base field are isomorphic over it — the uniqueness principle providing the identification",
+      "Algebraic.cardinalMk_of_countable_of_charZero: over a countable base of characteristic zero, the algebraic elements have cardinality ℵ₀ — the grandparent-style count used for transport",
+      "Cardinal.mk_congr, Cardinal.mk_le_aleph0_iff, Cardinal.infinite_iff: transport of cardinality across an equiv and the bridges to Countable / Infinite"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "IsAlgClosure.equiv",
+        "description": "A (noncomputable) ℚ-algebra isomorphism between any two algebraic closures of ℚ; instantiated at algebraicNumbersField and AlgebraicClosure ℚ to give the identification",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "IsAlgClosure",
+        "description": "The class bundling IsAlgClosed K and Algebra.IsAlgebraic R K; the formal definition of K being an algebraic closure of R, established here for algebraicNumbersField",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "Algebraic.cardinalMk_of_countable_of_charZero",
+        "description": "#{x : A // IsAlgebraic R x} = ℵ₀ for a countable base R of characteristic zero; supplies the cardinality of the algebraic numbers' carrier",
+        "module": "Mathlib.Algebra.AlgebraicCard"
+      },
+      {
+        "theorem": "Cardinal.mk_congr",
+        "description": "An equiv α ≃ β yields #α = #β; transports the cardinality count across the algebraic-closure isomorphism",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Cardinal.mk_le_aleph0_iff",
+        "description": "#α ≤ ℵ₀ ↔ Countable α; turns the cardinality bound into a Countable instance for AlgebraicClosure ℚ",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Cardinal.infinite_iff",
+        "description": "Infinite α ↔ ℵ₀ ≤ #α; yields that AlgebraicClosure ℚ is infinite from the cardinality equality",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      }
+    ],
+    "theoremCount": 5,
+    "relatedProblems": [
+      {
+        "id": "algebraic-numbers-countable-oq-01-oq-01",
+        "relationship": "Sibling/parent: builds algebraicNumbersField : IntermediateField ℚ ℂ, proves it algebraically closed, and identifies it with the relative closure algebraicClosure ℚ ℂ. This entry takes the final step to the abstract AlgebraicClosure ℚ."
+      },
+      {
+        "id": "algebraic-numbers-countable",
+        "relationship": "Grandparent: the algebraic numbers are countable (#= ℵ₀ inside ℂ). This entry transports that count to the intrinsic AlgebraicClosure ℚ."
+      }
+    ],
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Steinitz (1910) proved that every field has an algebraic closure, unique up to (non-canonical) isomorphism over the base. The algebraic numbers $\\overline{\\mathbb{Q}}$ — the complex numbers algebraic over $\\mathbb{Q}$ — are the most familiar example: a countable, algebraically closed field sitting inside the uncountable $\\mathbb{C}$. Formal libraries face a subtlety the classical statement hides: $\\mathbb{C}$ provides a *concrete* algebraic closure (the algebraic numbers), but a library also builds an *abstract* algebraic closure $\\mathrm{AlgebraicClosure}\\,\\mathbb{Q}$ from $\\mathbb{Q}$ alone, with no ambient field. Steinitz's uniqueness theorem says these must be isomorphic. This entry machine-checks that isomorphism and, through it, transports Cantor's (1874) countability of the algebraic numbers onto the intrinsic closure.",
+    "problemStatement": "Answer the sibling entry's open question. (1) Show the concrete field of algebraic numbers $\\mathrm{algebraicNumbersField} : \\mathrm{IntermediateField}\\,\\mathbb{Q}\\,\\mathbb{C}$ is an algebraic closure of $\\mathbb{Q}$ in Mathlib's sense, $\\mathrm{IsAlgClosure}\\,\\mathbb{Q}\\,\\cdot$. (2) Construct a $\\mathbb{Q}$-algebra isomorphism $\\mathrm{algebraicNumbersField} \\simeq_{alg[\\mathbb{Q}]} \\mathrm{AlgebraicClosure}\\,\\mathbb{Q}$ to the abstractly-built closure. (3) Transport cardinality: prove $\\#(\\mathrm{AlgebraicClosure}\\,\\mathbb{Q}) = \\aleph_0$, so the abstract closure is countably infinite.",
+    "proofStrategy": "**Algebraic closure predicate.** `IsAlgClosure ℚ K` unfolds to `IsAlgClosed K ∧ Algebra.IsAlgebraic ℚ K`. The sibling supplies `IsAlgClosed algebraicNumbersField`; the parent's construction makes the extension algebraic over ℚ (every element is by definition algebraic). Both are already instances, so `instIsAlgClosure` is `⟨inferInstance, inferInstance⟩`.\n\n**The isomorphism.** `AlgebraicClosure ℚ` carries Mathlib's own `IsAlgClosure ℚ ·` instance. With both fields algebraic closures of ℚ, `IsAlgClosure.equiv ℚ algebraicNumbersField (AlgebraicClosure ℚ)` is a `ℚ`-algebra isomorphism. Being a `ℚ`-algebra map, it fixes ℚ pointwise (`commutes`).\n\n**Cardinality transport.** The carrier of `algebraicNumbersField` is *definitionally* `{z : ℂ // IsAlgebraic ℚ z}` (membership is `Iff.rfl`), so `Algebraic.cardinalMk_of_countable_of_charZero ℚ ℂ` gives `#algebraicNumbersField = ℵ₀` directly. The isomorphism is in particular an `Equiv`, so `Cardinal.mk_congr` transfers the count to `#(AlgebraicClosure ℚ) = ℵ₀`; `Cardinal.mk_le_aleph0_iff` and `Cardinal.infinite_iff` then read off `Countable` and `Infinite`.",
+    "keyInsights": [
+      "**Concrete vs. abstract closure.** A formal library distinguishes the algebraic numbers realized inside $\\mathbb{C}$ from the closure $\\mathrm{AlgebraicClosure}\\,\\mathbb{Q}$ built from $\\mathbb{Q}$ alone. Steinitz uniqueness ($\\mathrm{IsAlgClosure.equiv}$) is exactly what pins them together — a step invisible in informal mathematics but required for a machine-checked identification.",
+      "**Being an algebraic closure = closed + algebraic.** The only content needed to invoke uniqueness is the two-field predicate $\\mathrm{IsAlgClosure}\\,\\mathbb{Q}\\,\\cdot$: the sibling's algebraic-closedness plus the construction's algebraicity over $\\mathbb{Q}$. Both are already typeclass instances, so the closure recognition is a one-line assembly.",
+      "**Cardinality is an isomorphism invariant, so countability is intrinsic.** $\\overline{\\mathbb{Q}}$'s countability is classically proved inside $\\mathbb{C}$; transporting it across the $\\mathbb{Q}$-algebra isomorphism shows the *abstract* $\\mathrm{AlgebraicClosure}\\,\\mathbb{Q}$ — which carries no embedding into $\\mathbb{C}$ — is itself countably infinite.",
+      "**The carrier is definitionally the right subtype.** Because membership in $\\mathrm{algebraicNumbersField}$ reduces (by $\\mathtt{Iff.rfl}$) to $\\mathrm{IsAlgebraic}\\,\\mathbb{Q}\\,\\cdot$, Mathlib's cardinality lemma for algebraic elements applies to the field's carrier with no coercion bookkeeping."
+    ]
+  },
+  "sections": [
+    {
+      "id": "isalgclosure",
+      "title": "§1: The algebraic numbers are an algebraic closure of ℚ",
+      "startLine": 73,
+      "endLine": 88,
+      "summary": "instIsAlgClosure : IsAlgClosure ℚ algebraicNumbersField, assembled from the sibling's IsAlgClosed instance and the parent construction's Algebra.IsAlgebraic ℚ instance — the two fields of Mathlib's algebraic-closure predicate.",
+      "mathContext": "An algebraic closure of a field K is an algebraically closed field that is algebraic over K. Mathlib packages exactly these two conditions as the class IsAlgClosure K ·."
+    },
+    {
+      "id": "equiv",
+      "title": "§2: Identification with the abstract AlgebraicClosure ℚ",
+      "startLine": 90,
+      "endLine": 116,
+      "summary": "algebraicNumbersEquivAlgebraicClosure : algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ from IsAlgClosure.equiv; algebraicNumbersEquivAlgebraicClosure_commutes records that it fixes ℚ pointwise.",
+      "mathContext": "Any two algebraic closures of the same field are isomorphic over it (Steinitz uniqueness). Here it bridges the concrete closure inside ℂ and Mathlib's abstract construction from ℚ."
+    },
+    {
+      "id": "cardinality",
+      "title": "§3: Cardinality transport — AlgebraicClosure ℚ is countable",
+      "startLine": 118,
+      "endLine": 153,
+      "summary": "cardinalMk_algebraicNumbersField (#= ℵ₀ for the concrete carrier), transported across the isomorphism to cardinalMk_algebraicClosure_rat : #(AlgebraicClosure ℚ) = ℵ₀, then countable_algebraicClosure_rat and infinite_algebraicClosure_rat.",
+      "mathContext": "Cardinality is an isomorphism invariant; transporting the count establishes that the intrinsically-defined AlgebraicClosure ℚ is countably infinite, the classical countability of the algebraic numbers freed of any embedding into ℂ."
+    }
+  ],
+  "conclusion": {
+    "summary": "The concrete field of algebraic numbers inside ℂ is shown to be an algebraic closure of ℚ in Mathlib's formal sense (IsAlgClosure ℚ ·), and Steinitz uniqueness (IsAlgClosure.equiv) then produces a ℚ-algebra isomorphism algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ identifying it with the abstractly-constructed closure. Transporting the grandparent's count across this isomorphism proves #(AlgebraicClosure ℚ) = ℵ₀, so the intrinsic algebraic closure of ℚ is countably infinite — Countable and Infinite. This closes the structural arc begun at the grandparent (algebraic numbers are countable) and continued at the sibling (they form an algebraically closed field).",
+    "implications": [
+      "Identifies the concrete algebraic numbers ⊆ ℂ with Mathlib's intrinsic AlgebraicClosure ℚ, so downstream work can move freely between the embedded and abstract presentations of ℚ̄.",
+      "Establishes that the abstract AlgebraicClosure ℚ is countably infinite — a fact not tied to any embedding into ℂ — by transporting cardinality across the isomorphism.",
+      "Demonstrates the formal-library pattern: recognize a concrete object as satisfying a uniqueness-bearing predicate (IsAlgClosure), then import all properties of the canonical model for free."
+    ],
+    "openQuestions": [
+      "Transport more than cardinality: carry the grandparent's explicit countable enumeration (stratification by degree) across the isomorphism to give an explicit countable basis/enumeration of AlgebraicClosure ℚ.",
+      "Identify algebraicNumbersField with the perfect closure / show AlgebraicClosure ℚ is the splitting field of the family of all ℚ[X] polynomials, packaging the isomorphism as compatibility of splitting data."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "algebraic-numbers-countable-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Builds algebraicNumbersField and proves it algebraically closed, identifying it with the relative closure algebraicClosure ℚ ℂ. This entry takes the final step to the abstract AlgebraicClosure ℚ."
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "ancestor",
+      "description": "Grandparent: the algebraic numbers are countable. This entry transports that count to the intrinsic AlgebraicClosure ℚ."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "algebraicNumbersEquivAlgebraicClosure",
+      "type": "definition",
+      "description": "The main result: a ℚ-algebra isomorphism between the concrete field of algebraic numbers inside ℂ and Mathlib's abstractly-constructed AlgebraicClosure ℚ, from the uniqueness of algebraic closures.",
+      "leanType": "algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ"
+    },
+    {
+      "name": "instIsAlgClosure",
+      "type": "core",
+      "description": "The algebraic numbers form an algebraic closure of ℚ: algebraically closed (sibling) and algebraic over ℚ (parent construction).",
+      "leanType": "IsAlgClosure ℚ algebraicNumbersField"
+    },
+    {
+      "name": "cardinalMk_algebraicClosure_rat",
+      "type": "core",
+      "description": "The abstract algebraic closure of ℚ is countably infinite: #(AlgebraicClosure ℚ) = ℵ₀, transported across the isomorphism.",
+      "leanType": "#(AlgebraicClosure ℚ) = ℵ₀"
+    },
+    {
+      "name": "countable_algebraicClosure_rat",
+      "type": "supporting",
+      "description": "AlgebraicClosure ℚ is a Countable type.",
+      "leanType": "Countable (AlgebraicClosure ℚ)"
+    },
+    {
+      "name": "infinite_algebraicClosure_rat",
+      "type": "supporting",
+      "description": "AlgebraicClosure ℚ is an Infinite type; with countability, countably infinite.",
+      "leanType": "Infinite (AlgebraicClosure ℚ)"
+    },
+    {
+      "name": "algebraicNumbersEquivAlgebraicClosure_commutes",
+      "type": "supporting",
+      "description": "The identification fixes ℚ pointwise — it is a ℚ-algebra map.",
+      "leanType": "∀ q : ℚ, equiv (algebraMap ℚ algebraicNumbersField q) = algebraMap ℚ (AlgebraicClosure ℚ) q"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Ernst Steinitz"
+      ],
+      "title": "Algebraische Theorie der Körper",
+      "year": "1910",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 137, pp. 167–309",
+      "note": "Existence and uniqueness (up to isomorphism over the base) of algebraic closures — the principle behind IsAlgClosure.equiv."
+    },
+    {
+      "authors": [
+        "Georg Cantor"
+      ],
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "Countability of the algebraic numbers, transported here onto the intrinsic AlgebraicClosure ℚ."
+    }
+  ],
+  "sorries": [],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AlgebraicNumbersCountableOQ01OQ01"
+    ],
+    "opens": [
+      "Cardinal",
+      "AlgebraicNumbersCountableOQ01OQ01"
+    ],
+    "namespace": "AlgebraicNumbersCountableOQ01OQ03",
+    "lineCount": 153,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/AlgebraicNumbersCountableOQ01OQ03.lean"
+  }
+}

--- a/src/data/research/problems/algebraic-numbers-countable-oq-01-oq-03.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-01-oq-03.json
@@ -1,0 +1,209 @@
+{
+  "slug": "algebraic-numbers-countable-oq-01-oq-03",
+  "title": "Algebraic Numbers as the Countable Algebraically Closed Field Q-bar",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "Algebraic numbers (roots of rational-coefficient polynomials) are closed under $+,-,\\times,\\div$,",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-27T15:29:18-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: ℚ-algebra isomorphism algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ (verified, 0-axiom); #(AlgebraicClosure ℚ)=ℵ₀, Countable+Infinite transported across it.",
+    "builtItems": [
+      "instIsAlgClosure : IsAlgClosure ℚ algebraicNumbersField (Proofs/AlgebraicNumbersCountableOQ01OQ03.lean §1)",
+      "algebraicNumbersEquivAlgebraicClosure : algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ via IsAlgClosure.equiv (§2)",
+      "cardinalMk_algebraicClosure_rat : #(AlgebraicClosure ℚ) = ℵ₀; countable_/infinite_algebraicClosure_rat (§3)"
+    ],
+    "insights": [
+      "Concrete closure (algebraic numbers ⊆ ℂ) and abstract AlgebraicClosure ℚ are linked only via Steinitz uniqueness (IsAlgClosure.equiv); both must first be recognized as IsAlgClosure ℚ ·.",
+      "Recognizing the concrete field as IsAlgClosure ℚ · is a one-line ⟨inferInstance, inferInstance⟩: IsAlgClosed (sibling) + Algebra.IsAlgebraic ℚ (parent construction).",
+      "algebraicNumbersField carrier is DEFINITIONALLY {z : ℂ // IsAlgebraic ℚ z} (mem is Iff.rfl), so Algebraic.cardinalMk_of_countable_of_charZero applies directly to the field carrier.",
+      "Cardinality transports across the AlgEquiv (Cardinal.mk_congr e.toEquiv), giving countability of the intrinsic AlgebraicClosure ℚ with no embedding into ℂ."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Transport an explicit degree-stratified enumeration across the iso for an explicit countable basis of AlgebraicClosure ℚ.",
+      "Package the iso as compatibility of splitting data: AlgebraicClosure ℚ as splitting field of all of ℚ[X]."
+    ],
+    "markdown": "# Knowledge Base: algebraic-numbers-countable-oq-01-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "field-theory",
+    "algebraic-closure",
+    "countability"
+  ],
+  "relatedProofs": [
+    "algebraic-numbers-countable",
+    "algebraic-numbers-countable-oq-01",
+    "algebraic-numbers-countable-oq-01-oq-01",
+    "algebraic-numbers-countable-oq-02",
+    "algebraic-numbers-countable-oq-02-oq-02",
+    "algebraic-numbers-countable-oq-02-oq-03",
+    "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+    "algebraic-numbers-countable-oq-02-oq-04",
+    "algebraic-numbers-countable-oq-04",
+    "algebraic-numbers-countable-oq-05"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-27T22:46:40.721Z",
+  "lastUpdate": "2026-06-27T22:46:40.774Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/AlgebraicNumbersCountable.lean",
+      "filename": "AlgebraicNumbersCountable.lean",
+      "lineCount": 255,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountable.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableAristotle.lean",
+      "filename": "AlgebraicNumbersCountableAristotle.lean",
+      "lineCount": 46,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableAristotle.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableOQ01.lean",
+      "filename": "AlgebraicNumbersCountableOQ01.lean",
+      "lineCount": 209,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ01.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableOQ01OQ01.lean",
+      "filename": "AlgebraicNumbersCountableOQ01OQ01.lean",
+      "lineCount": 178,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableOQ02.lean",
+      "filename": "AlgebraicNumbersCountableOQ02.lean",
+      "lineCount": 193,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ02.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableOQ02OQ02.lean",
+      "filename": "AlgebraicNumbersCountableOQ02OQ02.lean",
+      "lineCount": 286,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableOQ02OQ02OQ01.lean",
+      "filename": "AlgebraicNumbersCountableOQ02OQ02OQ01.lean",
+      "lineCount": 134,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableOQ02OQ03.lean",
+      "filename": "AlgebraicNumbersCountableOQ02OQ03.lean",
+      "lineCount": 194,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02.lean",
+      "filename": "AlgebraicNumbersCountableOQ02OQ03OQ02.lean",
+      "lineCount": 137,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableOQ02OQ04.lean",
+      "filename": "AlgebraicNumbersCountableOQ02OQ04.lean",
+      "lineCount": 1080,
+      "theoremCount": 42,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableOQ04.lean",
+      "filename": "AlgebraicNumbersCountableOQ04.lean",
+      "lineCount": 759,
+      "theoremCount": 13,
+      "axiomCount": 3,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ04.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableOQ05.lean",
+      "filename": "AlgebraicNumbersCountableOQ05.lean",
+      "lineCount": 306,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ05.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question of sibling entry **algebraic-numbers-countable-oq-01-oq-01**: identify the *concrete* field of algebraic numbers inside ℂ with Mathlib's *abstractly-constructed* `AlgebraicClosure ℚ`.

The sibling proved `algebraicNumbersField : IntermediateField ℚ ℂ` is algebraically closed and equal to the *relative* closure `algebraicClosure ℚ ℂ`. This entry takes the final structural step to the intrinsic `AlgebraicClosure ℚ` (built from ℚ alone, no ambient field).

## Results (`Proofs/AlgebraicNumbersCountableOQ01OQ03.lean`)

- **`instIsAlgClosure`** — `IsAlgClosure ℚ algebraicNumbersField`: the algebraic numbers form an algebraic closure of ℚ in Mathlib's sense, assembled from the sibling's `IsAlgClosed` instance + the parent construction's `Algebra.IsAlgebraic ℚ` instance.
- **`algebraicNumbersEquivAlgebraicClosure`** (main) — a ℚ-algebra isomorphism `algebraicNumbersField ≃ₐ[ℚ] AlgebraicClosure ℚ` from Steinitz uniqueness (`IsAlgClosure.equiv`); fixes ℚ pointwise (`…_commutes`).
- **`cardinalMk_algebraicClosure_rat`** — `#(AlgebraicClosure ℚ) = ℵ₀`, transporting the grandparent's count across the isomorphism; hence **`countable_algebraicClosure_rat`** and **`infinite_algebraicClosure_rat`** — the intrinsic closure is countably infinite, with no a-priori embedding into ℂ.

## Verification

- `lake env lean` compiles clean: **0 sorries, 0 warnings**.
- `#print axioms` on every result: only `propext, Classical.choice, Quot.sound` — **0-axiom, no `sorryAx`/`ofReduceBool`**.
- 153 lines, 5 theorems, 1 def, 1 instance.
- Gallery: `meta.json` (status `verified`, badge `original`, axiomCount 0) + `annotations.json`.

## Mathematical note

The content is the *transport*: the sibling supplies the algebraically-closed intermediate field, Mathlib supplies the uniqueness of algebraic closures, and combining them pins the abstract `AlgebraicClosure ℚ` down to the concrete algebraic numbers — including the transfer of countability (Cantor 1874) to the intrinsic object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)