### PR TITLE
research(sperner-ndim-oq-02): lex order is a linear order — transitivity, totality, finite-set lex-min [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerGridBase.lean
+++ b/proofs/Proofs/SpernerGridBase.lean
@@ -601,6 +601,101 @@ theorem BaryPoint.lexLE_antisymm {d N : ℕ} {a b : BaryPoint d N}
     · exact h'.symm
     · exact (BaryPoint.lexLT_asymm h h').elim
 
+/-- **Transitivity of the strict lex order.**  If `a < b` at first-differing
+coordinate `i` and `b < c` at first-differing coordinate `j`, then `a < c`,
+with the witness being `min i j`. -/
+theorem BaryPoint.lexLT_trans {d N : ℕ} {a b c : BaryPoint d N}
+    (hab : a.lexLT b) (hbc : b.lexLT c) : a.lexLT c := by
+  obtain ⟨i, hi_eq, hi_lt⟩ := hab
+  obtain ⟨j, hj_eq, hj_lt⟩ := hbc
+  rcases lt_trichotomy i j with h | h | h
+  · -- i < j: the cells still differ first at `i` (where `b i = c i`).
+    refine ⟨i, fun k hk => ?_, ?_⟩
+    · rw [hi_eq k hk, hj_eq k (hk.trans h)]
+    · rw [← hj_eq i h]; exact hi_lt
+  · -- i = j: a i < b i < c i at the common index.
+    subst h
+    exact ⟨i, fun k hk => (hi_eq k hk).trans (hj_eq k hk), hi_lt.trans hj_lt⟩
+  · -- j < i: the cells differ first at `j` (where `a j = b j`).
+    refine ⟨j, fun k hk => ?_, ?_⟩
+    · rw [hi_eq k (hk.trans h), hj_eq k hk]
+    · rw [hi_eq j h]; exact hj_lt
+
+/-- **Transitivity of the non-strict lex order.** -/
+theorem BaryPoint.lexLE_trans {d N : ℕ} {a b c : BaryPoint d N}
+    (hab : a.lexLE b) (hbc : b.lexLE c) : a.lexLE c := by
+  rcases hab with rfl | hab
+  · exact hbc
+  · rcases hbc with rfl | hbc
+    · exact Or.inr hab
+    · exact Or.inr (BaryPoint.lexLT_trans hab hbc)
+
+/-- **Trichotomy (totality) of the lex order.**  Any two barycentric points are
+lex-comparable: either `a < b`, `a = b`, or `b < a`.  The witness is the
+lex-minimal coordinate at which they differ (the minimum of the nonempty finset
+of differing coordinates); below it the two points agree. -/
+theorem BaryPoint.lexLT_trichotomy {d N : ℕ} (a b : BaryPoint d N) :
+    a.lexLT b ∨ a = b ∨ b.lexLT a := by
+  classical
+  by_cases hab : a = b
+  · exact Or.inr (Or.inl hab)
+  · -- The set of differing coordinates is nonempty (else `a = b` by `ext`).
+    have hne : (Finset.univ.filter (fun i => a.coords i ≠ b.coords i)).Nonempty := by
+      rw [Finset.filter_nonempty_iff]
+      by_contra h
+      push_neg at h
+      exact hab (BaryPoint.ext (funext fun i => h i (Finset.mem_univ i)))
+    obtain ⟨i, hiS, hi_min⟩ :
+        ∃ i ∈ Finset.univ.filter (fun i => a.coords i ≠ b.coords i),
+          ∀ j ∈ Finset.univ.filter (fun i => a.coords i ≠ b.coords i), i ≤ j :=
+      ⟨_, (Finset.univ.filter _).min'_mem hne, fun j hj => (Finset.univ.filter _).min'_le j hj⟩
+    have hdiff : a.coords i ≠ b.coords i := (Finset.mem_filter.mp hiS).2
+    have hbefore : ∀ j : Fin (d + 1), j < i → a.coords j = b.coords j := by
+      intro j hj
+      by_contra hjne
+      exact absurd (hi_min j (Finset.mem_filter.mpr ⟨Finset.mem_univ j, hjne⟩)) (not_le.mpr hj)
+    rcases lt_trichotomy (a.coords i) (b.coords i) with h | h | h
+    · exact Or.inl ⟨i, hbefore, h⟩
+    · exact absurd h hdiff
+    · exact Or.inr (Or.inr ⟨i, fun j hj => (hbefore j hj).symm, h⟩)
+
+/-- **Totality of the non-strict lex order.** -/
+theorem BaryPoint.lexLE_total {d N : ℕ} (a b : BaryPoint d N) :
+    a.lexLE b ∨ b.lexLE a := by
+  rcases BaryPoint.lexLT_trichotomy a b with h | h | h
+  · exact Or.inl (Or.inr h)
+  · exact Or.inl (Or.inl h)
+  · exact Or.inr (Or.inr h)
+
+/-- **Lex-minimum of a nonempty finite vertex set.**  Any nonempty finite set of
+barycentric points has an element that is lex-`≤` every element of the set.  This
+is the order-theoretic core of canonicalization: it is what lets a
+recanonicalization step select the (unique, by `lexLE_antisymm`) lex-minimal base
+of a given geometric cell.  Proved by induction on the set, using totality and
+transitivity to fold in each new point. -/
+theorem BaryPoint.exists_lex_min {d N : ℕ} (S : Finset (BaryPoint d N)) :
+    S.Nonempty → ∃ m ∈ S, ∀ x ∈ S, m.lexLE x := by
+  classical
+  induction S using Finset.induction_on with
+  | empty => intro h; exact absurd h Finset.not_nonempty_empty
+  | insert a s ha ih =>
+    intro _
+    rcases s.eq_empty_or_nonempty with rfl | hs
+    · refine ⟨a, Finset.mem_insert_self a ∅, fun x hx => ?_⟩
+      rcases Finset.mem_insert.mp hx with hxa | hx
+      · rw [hxa]; exact BaryPoint.lexLE_refl a
+      · exact absurd hx (Finset.notMem_empty x)
+    · obtain ⟨m, hm, hmin⟩ := ih hs
+      rcases BaryPoint.lexLE_total a m with hle | hle
+      · refine ⟨a, Finset.mem_insert_self a s, fun x hx => ?_⟩
+        rcases Finset.mem_insert.mp hx with hxa | hx
+        · rw [hxa]; exact BaryPoint.lexLE_refl a
+        · exact BaryPoint.lexLE_trans hle (hmin x hx)
+      · refine ⟨m, Finset.mem_insert_of_mem hm, fun x hx => ?_⟩
+        rcases Finset.mem_insert.mp hx with hxa | hx
+        · rw [hxa]; exact hle
+        · exact hmin x hx
+
 /-- A `GridSimplex` is *canonical* when its base vertex `verts 0`
 is lexicographically minimal among its `d+1` vertices. Each
 geometric Freudenthal cell has exactly one canonical encoding (the

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1,5 +1,62 @@
 # sperner-ndim-oq-02: Boundary-Door Oddness by Dimensional Induction
 
+## Session 2026-06-27 (researcher-2) — Lex order is a linear order + lex-min existence (`exists_lex_min`)
+
+**Mode**: ACT (CONTINUE Phase-1). **Outcome**: PROGRESS — completed the
+**linear-order structure** of the barycentric lex order in `SpernerGridBase.lean`
+(+5 theorems, ~95 L), supplying the missing transitivity + totality and a
+finite-set lex-minimum existence lemma. **Type-check VERIFIED via `lake env lean`
+against the main-repo olean cache (EXIT 0, no errors/warnings)**; **`#print axioms`
+obtained** — all five new theorems depend only on `[propext, Classical.choice,
+Quot.sound]`, i.e. **genuinely 0-axiom** (no `sorryAx`/`Lean.ofReduceBool`/
+`native_decide`). Downstream `SpernerNDimOQ02.lean` re-verified clean against the
+updated base. Docker host still down (containerd) → single-file `lake env lean`
+channel; `Finset.induction` is **not** `@[elab_as_elim]` (its `with`-arm binders
+are inaccessible) — use `Finset.induction_on` instead.
+
+### What was delivered (`SpernerGridBase.lean`, after `lexLE_antisymm`)
+
+`BaryPoint.lexLE` previously had only refl / irrefl / asymm / antisymm — enough for
+`IsCanon.base_unique` (lex-min is *unique*) but **not** to *select* a lex-min. This
+session closes the linear-order gap, which the next-step canonicalization
+("re-select lex-min base") needs:
+
+- `BaryPoint.lexLT_trans` — strict-lex transitivity. First-differing coordinate of
+  `a < c` is `min i j` (where `i`/`j` are the witnesses of `a<b`, `b<c`); three-way
+  case split on `i`-vs-`j`, each closed by `rw` chaining the prefix-equalities.
+- `BaryPoint.lexLE_trans` — non-strict corollary.
+- `BaryPoint.lexLT_trichotomy` — **totality**: `a<b ∨ a=b ∨ b<a`. Witness = the
+  lex-minimal coordinate at which `a,b` differ (`Finset.min'` of the nonempty
+  `filter (a.coords · ≠ b.coords ·)`); below it they agree by minimality, at it
+  `Nat.lt_trichotomy` resolves the direction.
+- `BaryPoint.lexLE_total` — non-strict corollary.
+- `BaryPoint.exists_lex_min` — **payoff**: any nonempty `Finset (BaryPoint d N)`
+  has an element lex-`≤` all others. `Finset.induction_on`; totality picks the
+  smaller of the new point and the inductive min, transitivity propagates it.
+  This is the order-theoretic core of canonicalization — it lets a
+  recanonicalization step *select* the (unique, by `lexLE_antisymm`) lex-min base
+  of a geometric cell's vertex set.
+
+### Why this matters (Phase-1)
+
+The remaining obstacle to a full `SpernerTriangulation` instance is the `adj`
+search, whose interior pivot may land on a *non-canonical* `GridSimplex`
+(`pivot_isCanon_iff`, prev. session, reduces that test to one lex comparison). To
+return the neighbour into the `CanonSimplex` carrier we must re-pick the lex-min
+base and re-sort — and "re-pick the lex-min base" is precisely `exists_lex_min`
+(existence) + `lexLE_antisymm` (uniqueness). The lex order is now a full linear
+order on `BaryPoint`, so the canonicalization map is well-defined; what remains is
+the *construction* of the re-sorted `GridSimplex` (verts/incDir/miss + 5 Kuhn
+axioms) realizing that base.
+
+### Next steps (unchanged ordering; lex linear-order now DONE)
+1. **(next)** Canonicalize a `GridSimplex`: build the `CanonSimplex` with the same
+   `Set.range verts`, taking base `= exists_lex_min` of the vertex set and
+   re-sorting the chain; uniqueness is `IsCanon.geometry_unique`.
+2. Define `adj` via finite facet-search over `CanonSimplex` (recanonicalize the
+   interior pivot); discharge `adj_symm`/`adj_vertices`/`adj_ne`/`boundary_face`.
+3. Phase 2: last-face door oddness by induction on `d`; apply `sperner_ndim`.
+
 ## Session 2026-06-27 (researcher-1) — At-most-one-neighbour across a facet (`adj_unique_facet`)
 
 **Mode**: ACT (CONTINUE Phase-1). **Outcome**: PROGRESS — added the


### PR DESCRIPTION
## Summary

Completes the **linear-order structure** of the barycentric lexicographic order in `SpernerGridBase.lean`, adding the transitivity and totality that were missing, plus a finite-set lex-minimum existence lemma. This is the order-theoretic core the next-step **canonicalization** ("re-select the lex-min base") requires.

Previously `BaryPoint.lexLE` had only `refl` / `irrefl` / `asymm` / `antisymm` — enough for `IsCanon.base_unique` (the lex-min is *unique*) but **not** enough to *select* a lex-min. The five new theorems close that gap:

| Theorem | Content |
|---|---|
| `BaryPoint.lexLT_trans` | strict-lex transitivity (witness `= min i j`) |
| `BaryPoint.lexLE_trans` | non-strict corollary |
| `BaryPoint.lexLT_trichotomy` | **totality** `a<b ∨ a=b ∨ b<a` (witness = lex-min differing coordinate, via `Finset.min'`) |
| `BaryPoint.lexLE_total` | non-strict corollary |
| `BaryPoint.exists_lex_min` | any nonempty `Finset (BaryPoint d N)` has a lex-`≤`-minimal element |

## Why this matters (Phase-1)

The remaining obstacle to a full `SpernerTriangulation` instance is the `adj` search, whose interior Freudenthal pivot may land on a **non-canonical** `GridSimplex` (last session's `pivot_isCanon_iff` reduced that test to one lex comparison). Returning the neighbour into the `CanonSimplex` carrier requires re-picking the lex-min base and re-sorting the chain. "Re-pick the lex-min base" is exactly `exists_lex_min` (existence) + `lexLE_antisymm` (uniqueness). The lex order is now a full linear order on `BaryPoint`, so the canonicalization map is well-defined; the remaining work is the *construction* of the re-sorted `GridSimplex`.

## Verification

- **Type-check**: `lake env lean Proofs/SpernerGridBase.lean` → exit 0, no errors/warnings.
- **Axioms**: `#print axioms` for all five theorems = `[propext, Classical.choice, Quot.sound]` — **genuinely 0-axiom** (no `sorryAx` / `Lean.ofReduceBool` / `native_decide`).
- **Downstream**: `Proofs/SpernerNDimOQ02.lean` re-verified clean against the updated base.

0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions added. Docker host down → verified via the single-file `lake env lean` channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)