### PR TITLE
audit(gallery): drain algebraic-numbers-countable-oq-01-oq-03 — CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23585,6 +23585,12 @@
       "lastAudited": "2026-06-25T09:00:00Z",
       "result": "clean"
     },
+    "algebraic-numbers-countable-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T00:00:00Z",
+      "result": "clean"
+    },
     "buffons-needle-oq-01-oq-02-oq-01": {
       "auditCount": 1,
       "issues": [],


### PR DESCRIPTION
## Gallery integrity audit — cycleV

Drained the sole genuinely-unaudited gallery proof:
**algebraic-numbers-countable-oq-01-oq-03** → CLEAN.

### Checks (Proofs/AlgebraicNumbersCountableOQ01OQ03.lean)
- 0 sorries, 0 `axiom` declarations, 0 True stubs
- No `native_decide` (the only grep hits are docstring text "no native_decide")
- meta: `status: verified`, `badge: original`, `sorries: 0`, `axiomCount: 0` — all consistent with source
- Honest assembly+transport proof: the overview and `assumptions` field both fully disclose Mathlib reliance (`IsAlgClosure.equiv`, `Algebraic.cardinalMk_of_countable_of_charZero`, cardinality lemmas). Title "The Algebraic Numbers ARE an Algebraic Closure of ℚ" is accurate; no axiom/sorry masking. Adds the `IsAlgClosure` instance plus countability/infinitude corollaries beyond the bare Mathlib call.

### Note on the queue count
`find-targets.ts` reported 4 unaudited, but the other 3
(`abel-ruffini-oq-06-oq-01`, `chinese-remainder-constructive-oq-05-oq-02`,
`inverse-galois-d4-oq-02-oq-03-oq-01-oq-01`) are **already tracked clean** on
the authoritative origin/main (d9819f13c61). The phantom count came from a
transient rolled-back main state (ffb580218d8) where those entries were
temporarily absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)