### PR TITLE
research(sperner-mathlib4-oq-02): exact door-counting identity — parity bridge → equation [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerTuckerDoorIncidenceParity.lean
+++ b/proofs/Proofs/SpernerTuckerDoorIncidenceParity.lean
@@ -202,10 +202,71 @@ theorem even_card_odd_doorCount_of_all_interior
   rw [hbdry] at hmod
   rw [Nat.even_iff, hmod]
 
+/-! ## The exact door-counting identity
+
+The parity bridge above is a mod-2 shadow of an exact integer identity.  In a door
+complex where every door touches one or two cells, summing the door-count over the
+cells counts each boundary door **once** and each interior door **twice**.  This
+upgrades the congruence to an equation and exposes the interior-door count. -/
+
+/-- An **interior door** is incident to exactly two cells — a facet shared by two
+cells (geometrically, in the interior of the region). -/
+def IsInteriorDoor (d : Door) : Prop := cellCount inc d = 2
+
+instance : DecidablePred (IsInteriorDoor inc) := fun d => by
+  unfold IsInteriorDoor; infer_instance
+
+/-- **Exact door-counting identity.**  When every door is incident to one or two
+cells, the total door-count (summed over cells) equals the number of boundary doors
+plus *twice* the number of interior doors: a boundary door is counted by its single
+cell, an interior door by both of its cells.  Reducing mod 2 (the `2 * …` term
+vanishes) gives the parity bridge `card_odd_doorCount_modEq_card_boundaryDoor`. -/
+theorem sum_doorCount_eq_boundary_add_two_interior
+    (h1 : ∀ d, 1 ≤ cellCount inc d) (h2 : ∀ d, cellCount inc d ≤ 2) :
+    (∑ c, doorCount inc c)
+      = (univ.filter (IsBoundaryDoor inc)).card
+        + 2 * (univ.filter (IsInteriorDoor inc)).card := by
+  rw [sum_doorCount_eq_sum_cellCount]
+  -- Each door's `cellCount` is `1` (boundary) or `2` (interior); rewrite the
+  -- summand as that case split, then sum the two constant pieces.
+  have hcong : ∀ d ∈ univ, cellCount inc d
+      = (if IsBoundaryDoor inc d then 1 else 2) := by
+    intro d _
+    by_cases hb : IsBoundaryDoor inc d
+    · rw [if_pos hb]; exact hb
+    · rw [if_neg hb]
+      have := h1 d; have := h2 d
+      unfold IsBoundaryDoor at hb
+      omega
+  rw [Finset.sum_congr rfl hcong, Finset.sum_ite, Finset.sum_const, Finset.sum_const,
+      smul_eq_mul, smul_eq_mul, mul_one]
+  -- the `¬ IsBoundaryDoor` doors are exactly the interior doors
+  have hfilt : univ.filter (fun d => ¬ IsBoundaryDoor inc d)
+      = univ.filter (IsInteriorDoor inc) := by
+    apply Finset.filter_congr
+    intro d _
+    have := h1 d; have := h2 d
+    unfold IsBoundaryDoor IsInteriorDoor
+    omega
+  rw [hfilt]
+  ring
+
+/-- **Interior-door count.**  Solving the exact identity for the interior doors:
+the number of interior doors is half the surplus of the total door-count over the
+boundary doors. -/
+theorem card_interior_eq
+    (h1 : ∀ d, 1 ≤ cellCount inc d) (h2 : ∀ d, cellCount inc d ≤ 2) :
+    2 * (univ.filter (IsInteriorDoor inc)).card
+      = (∑ c, doorCount inc c) - (univ.filter (IsBoundaryDoor inc)).card := by
+  rw [sum_doorCount_eq_boundary_add_two_interior inc h1 h2]
+  omega
+
 #check @incidence_parity_duality
 #check @card_odd_doorCount_modEq_card_boundaryDoor
 #check @exists_odd_doorCount_of_odd_boundary
 #check @even_card_odd_doorCount_of_all_interior
+#check @sum_doorCount_eq_boundary_add_two_interior
+#check @card_interior_eq
 
 -- Axiom audit: the results depend only on the foundational axioms
 -- (propext / Classical.choice / Quot.sound); no `sorryAx`, no `Lean.ofReduceBool`.
@@ -213,5 +274,7 @@ theorem even_card_odd_doorCount_of_all_interior
 #print axioms card_odd_doorCount_modEq_card_boundaryDoor
 #print axioms exists_odd_doorCount_of_odd_boundary
 #print axioms even_card_odd_doorCount_of_all_interior
+#print axioms sum_doorCount_eq_boundary_add_two_interior
+#print axioms card_interior_eq
 
 end SpernerTuckerDoorIncidenceParity

--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -318,3 +318,55 @@ invariant for n≥2), and complements PR #30917's `count_parity_not_invariant`
   graph, degree ≤ 2, and `Odd #{boundary ends}` via inductive (n−1)-Tucker
   (NOT raw ring parity).
 - Continuous n≥2 Tucker ⟹ Borsuk–Ulam (mesh→0 + compactness): separate analytic phase.
+
+## Session 2026-06-27 (researcher-3) — ACT: exact door-counting identity (parity → equation)
+
+**Mode**: REVISIT (RICH; n=1 line + abstract n≥2 engines already verified). 
+**Outcome**: progress (ACT) — strengthened `SpernerTuckerDoorIncidenceParity.lean`,
+0 sorries, 0 axioms (propext/Classical.choice/Quot.sound; plain `decide`/`omega`, no
+`native_decide`/`ofReduceBool`). Offline `LAKE_UNSAFE=1 ./bin/lake env lean` EXIT 0.
+
+### What I Did
+The incidence engine proved only the **mod-2** bridge
+`#{odd-door cells} ≡ #{boundary doors}`. Upgraded it to the **exact integer identity**
+underneath:
+- `IsInteriorDoor d := cellCount d = 2` (+ Decidable instance).
+- `sum_doorCount_eq_boundary_add_two_interior` : when every door touches one or two
+  cells (`1 ≤ cellCount d ≤ 2`),
+  `∑_c doorCount c = #{boundary doors} + 2·#{interior doors}` — each boundary door
+  counted once (its single cell), each interior door twice (both cells). Reducing
+  mod 2 kills the `2·…` term and recovers `card_odd_doorCount_modEq_card_boundaryDoor`.
+- `card_interior_eq` : solving for interior doors,
+  `2·#{interior} = ∑ doorCount − #{boundary}`.
+
+### Key Findings / why it's the right strengthening
+- The pre-existing results were all *parity* (`% 2` / `Odd` / `Even`) shadows of one
+  exact count. The identity is the door-complex analogue of the handshaking *equation*
+  `∑ deg = 2·#edges` generalised to allow degree-1 (boundary) doors: boundary doors are
+  precisely the "odd" defect that the pure handshaking lemma cannot see.
+- Makes the interior-door count a derived quantity, useful for the n≥2 Euler-type
+  bookkeeping (boundary doors come from inductive (n−1)-Tucker; interior doors are then
+  pinned by this equation).
+
+### GOTCHAs
+- `Finset.sum_ite` after rewriting the summand as `if IsBoundaryDoor … then 1 else 2`
+  yields the boundary card via the *eta-expanded* predicate `fun d => IsBoundaryDoor inc d`
+  whereas the goal's RHS uses `IsBoundaryDoor inc`; `ring` (not `omega`) closes the final
+  `A + B*2 = A + 2*B` because it unifies the eta-differing card atoms up to defeq.
+- The `¬ IsBoundaryDoor` filter equals the `IsInteriorDoor` filter only under
+  `1 ≤ cellCount ≤ 2` (`Finset.filter_congr` + `omega`).
+
+### Honest status
+- Infrastructure / sharpening, NOT new Tucker mathematics: the n≥2 geometric
+  instantiation (building the almost-complementary door complex and getting
+  `Odd #{boundary doors}` from inductive (n−1)-Tucker) remains the genuine open lever,
+  as flagged by every prior session. Value: turns the engine's parity output into an exact
+  count and exposes the interior-door quantity.
+
+### Files Modified
+- proofs/Proofs/SpernerTuckerDoorIncidenceParity.lean (+2 theorems 8→10, +1 def 3→4, 217→280 lines; 0 axioms, 0 sorries)
+- src/data/research/problems/sperner-mathlib4-oq-02.json (registered the file in leanFiles + currentState)
+
+### Next Steps (unchanged genuine lever)
+- n≥2 geometric door complex + `Odd #{boundary doors}` via inductive (n−1)-Tucker, then
+  feed `exists_odd_doorCount_of_odd_boundary` → `SpernerTuckerPathFollowing`.

--- a/src/data/research/problems/sperner-mathlib4-oq-02.json
+++ b/src/data/research/problems/sperner-mathlib4-oq-02.json
@@ -15,7 +15,7 @@
     "open": [],
     "goal": ""
   },
-  "currentState": "n=1 Tucker line COMPLETE end-to-end: discrete combinatorial core (SpernerTuckerOneDim, merged) + continuous capstone (SpernerTuckerBorsukUlamOneDim, this session) deriving the genuine 1-D Borsuk-Ulam theorem from IVT. A continuous 1-periodic f:R->R takes equal values at some antipodal pair c, c+1/2. n>=2 Tucker still needs the Freund-Todd / Prescott-Su path-following engine (complementary-edge count is not a parity invariant for n>=2).",
+  "currentState": "ACT: strengthened the door-incidence engine from the mod-2 parity bridge to the EXACT door-counting identity sum_doorCount = #boundary_doors + 2*#interior_doors (sum_doorCount_eq_boundary_add_two_interior) plus the interior-door count corollary card_interior_eq. 0-axiom (propext/Classical.choice/Quot.sound), offline EXIT 0. The n>=2 geometric instantiation (inductive (n-1)-Tucker -> odd boundary doors) remains the open lever.",
   "knowledge": {
     "progressSummary": "PROGRESS: n=1 line complete (combinatorial + continuous 1-D Borsuk-Ulam, merged). For n>=2 the abstract path-following engine (PR #30911) + interior-parity refinement are done. This session closes the door-counting→engine gap: SpernerTuckerDoorGraph derives the engine's max-degree-≤2 hypothesis from the door-incidence structure (≤2 doors/simplex, ≤2 simplices/door) via a clean counting injection, and chains it to the quantitative Tucker conclusion (odd boundary endpoints ⟹ odd interior complementary simplices). Verified, 0-axiom. Remaining for n>=2: supply the odd-boundary-endpoint input (inductive (n-1)-Tucker) and the geometric construction of the door-incidence relation for a concrete triangulation.",
     "builtItems": [
@@ -130,6 +130,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerTuckerDoorGraph.lean"
+    },
+    {
+      "path": "Proofs/SpernerTuckerDoorIncidenceParity.lean",
+      "filename": "SpernerTuckerDoorIncidenceParity.lean",
+      "lineCount": 280,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerTuckerDoorIncidenceParity.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Strengthens the abstract door-incidence engine in `SpernerTuckerDoorIncidenceParity.lean`. That file already proves the **mod-2 parity bridge** `#{cells with odd door-count} ≡ #{boundary doors}`. This PR adds the **exact integer identity** it is a shadow of:

- **`IsInteriorDoor d := cellCount d = 2`** (a door incident to exactly two cells), with a `DecidablePred` instance.
- **`sum_doorCount_eq_boundary_add_two_interior`** — when every door touches one or two cells (`1 ≤ cellCount d ≤ 2`):

  `∑_c doorCount c  =  #{boundary doors}  +  2 · #{interior doors}`

  Each boundary door is counted once (by its single cell), each interior door twice (by both). Reducing mod 2 kills the `2·…` term and recovers the existing `card_odd_doorCount_modEq_card_boundaryDoor` as a corollary.
- **`card_interior_eq`** — solving for the interior doors: `2·#{interior} = ∑ doorCount − #{boundary}`.

This is the door-complex analogue of the handshaking **equation** `∑ deg = 2·#edges`, generalised to allow degree-1 (boundary) doors — exactly the "odd defect" the pure handshaking lemma cannot see. It turns the engine's parity output into an exact count and exposes the interior-door quantity for the n≥2 Euler-type bookkeeping.

## Verification

- Offline build (`LAKE_UNSAFE=1 ./bin/lake env lean Proofs/SpernerTuckerDoorIncidenceParity.lean`, Docker host down): **EXIT 0, 0 errors**.
- `#print axioms` on both new theorems → `[propext, Classical.choice, Quot.sound]` only. Uses plain `omega`/`decide` — **no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`**. Genuinely 0-axiom.

File: 217→280 lines, theorems 8→10, defs 3→4; 0 axioms, 0 sorries. Also registered the file in the problem's `leanFiles` (it was previously unregistered).

## Honest status

Infrastructure / sharpening — **not new Tucker mathematics**. The n≥2 geometric instantiation (constructing the almost-complementary door complex and deriving `Odd #{boundary doors}` from the inductive `(n−1)`-Tucker statement) remains the genuine open lever, as flagged by every prior session on this problem. The abstract parity engine, the path-following engine, and now the exact count are all in place to receive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)