### PR TITLE
research(erdos-340-greedy-sidon-oq-05): end-to-end greedy B_h lower bound inside {1,…,N} [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos340GreedySidonOQ05.lean
+++ b/proofs/Proofs/Erdos340GreedySidonOQ05.lean
@@ -73,6 +73,19 @@ upper bound.
   The positive-slope affine group is thus the symmetry group of the `B_h` upper bound,
   letting one normalise a `B_h` set by an affine change of variable before counting.
 
+* `IsBh.card_forbidden_poly` — **the forbidden-value count**.  At most
+  `2·h·(|A|+1)^{2h-1}` small values `m` break the `B_h` property when inserted (an
+  explicit degree-`(2h-1)` polynomial in `|A|`), via `card_sym_le_pow` / `card_pool_le`.
+
+* `IsBh.exists_insert_le` / `exists_isBh_subset_Icc` / `exists_isBh_subset_Icc_card` —
+  **the end-to-end greedy lower bound inside `{1, …, N}`**.  Feeding the forbidden count
+  into a counting argument, a `B_h` set with `|A| + 2·h·(|A|+1)^{2h-1} < N` admits a
+  fresh element of `{1, …, N}` (`exists_insert_le`); iterating from `∅` builds a `B_h`
+  subset of `{1, …, N}` of cardinality `k` whenever `k + 2·h·k^{2h-1} ≤ N`
+  (`exists_isBh_subset_Icc_card`).  This is the combinatorial half of the
+  `|A| = Ω(N^{1/(2h-1)})` greedy rate; only the real-power inversion of the count
+  condition remains open.
+
 ## Mathematical note
 
 The bound is *sharp in order*: Singer difference sets give `B_2` sets of size
@@ -1018,5 +1031,116 @@ theorem IsBh.card_forbidden_poly {h : ℕ} {A : Finset ℕ} (hh : 1 ≤ h) (hA :
     _ = 2 * (h' + 1) * (A.card + 1) ^ (2 * (h' + 1) - 1) := by
         rw [mul_assoc (2 * (h' + 1)), ← pow_add,
           show h' + (h' + 1) = 2 * (h' + 1) - 1 from by omega]
+
+/-! ## Part 9: The end-to-end greedy lower bound inside `{1, …, N}`
+
+Parts 5–8 reduced the open `B_h` lower bound to a *counting* statement:
+`card_forbidden_poly` shows that at most `2·h·(|A|+1)^{2h-1}` small values are
+forbidden.  This part runs the greedy algorithm to completion **inside the interval**
+`{1, …, N}`, with no remaining counting.  A `B_h` set whose size and forbidden count
+together stay below `N` admits a fresh element of `{1, …, N}` (`exists_insert_le`), and
+iterating from `∅` builds a `B_h` subset of `{1, …, N}` of any cardinality `k` for which
+the count condition holds (`exists_isBh_subset_Icc` / `exists_isBh_subset_Icc_card`).
+
+The only piece left genuinely open is the *real-power arithmetic* converting the count
+condition `k + 2·h·k^{2h-1} ≤ N` into an explicit rate `k ≥ c·N^{1/(2h-1)}`; the
+combinatorial greedy iteration itself is now complete and verified. -/
+
+/-- **One greedy step inside `{1, …, N}`.**  If `A` is a `B_h` set (`h ≥ 1`) and the sum
+of `|A|` with the forbidden-value bound `2·h·(|A|+1)^{2h-1}` is still below `N`, then
+there is a fresh element `m ∈ {1, …, N}` (so `1 ≤ m ≤ N` and `m ∉ A`) whose insertion
+keeps `A` a `B_h` set.
+
+*Proof.*  Call `m ∈ {1, …, N}` *bad* if `m ∈ A` or `insert m A` is not `B_h`.  The bad
+values number at most `|A|` (those in `A`) plus the forbidden ones; every forbidden value
+is `≤ h·max A` (by `insert_of_large`, any larger `m` is automatically fine), so the
+forbidden values among `{1, …, N}` inject into those counted by `card_forbidden_poly`,
+giving `≤ 2·h·(|A|+1)^{2h-1}`.  Hence fewer than `N` of the `N` values in `{1, …, N}` are
+bad, so a good one remains. ∎ -/
+theorem IsBh.exists_insert_le {h N : ℕ} {A : Finset ℕ}
+    (hh : 1 ≤ h) (hA : IsBh h A)
+    (hN : A.card + 2 * h * (A.card + 1) ^ (2 * h - 1) < N) :
+    ∃ m, 1 ≤ m ∧ m ≤ N ∧ m ∉ A ∧ IsBh h (insert m A) := by
+  classical
+  -- The set of "bad" values in `{1, …, N}`.
+  set Bad : Finset ℕ :=
+    (Finset.Icc 1 N).filter (fun m => m ∈ A ∨ ¬ IsBh h (insert m A)) with hBad
+  -- Bound its cardinality by `|A|` plus the forbidden count.
+  have hBadcard : Bad.card ≤ A.card + 2 * h * (A.card + 1) ^ (2 * h - 1) := by
+    have hsplit :
+        Bad = (Finset.Icc 1 N).filter (fun m => m ∈ A)
+            ∪ (Finset.Icc 1 N).filter (fun m => ¬ IsBh h (insert m A)) := by
+      rw [hBad, Finset.filter_or]
+    rw [hsplit]
+    refine (Finset.card_union_le _ _).trans ?_
+    have hAcount : ((Finset.Icc 1 N).filter (fun m => m ∈ A)).card ≤ A.card := by
+      apply Finset.card_le_card
+      intro x hx
+      exact (Finset.mem_filter.mp hx).2
+    have hForb :
+        ((Finset.Icc 1 N).filter (fun m => ¬ IsBh h (insert m A))).card
+          ≤ 2 * h * (A.card + 1) ^ (2 * h - 1) := by
+      refine le_trans (Finset.card_le_card ?_) (hA.card_forbidden_poly hh)
+      intro m hm
+      rw [Finset.mem_filter] at hm ⊢
+      refine ⟨Finset.mem_range.mpr ?_, hm.2⟩
+      by_contra hlt
+      push_neg at hlt          -- `h * A.sup id + 1 ≤ m`
+      exact hm.2 (hA.insert_of_large (by omega))
+    omega
+  -- `{1, …, N}` has `N` elements, strictly more than `Bad`, so a good value remains.
+  have hIcc : (Finset.Icc 1 N).card = N := by rw [Nat.card_Icc]; omega
+  have hexists : ∃ m ∈ Finset.Icc 1 N, m ∉ Bad := by
+    by_contra hcon
+    push_neg at hcon
+    have hss : Finset.Icc 1 N ⊆ Bad := fun x hx => hcon x hx
+    have hle := Finset.card_le_card hss
+    omega
+  obtain ⟨m, hmIcc, hmnBad⟩ := hexists
+  have hpred : ¬ (m ∈ A ∨ ¬ IsBh h (insert m A)) := fun hp =>
+    hmnBad (by rw [hBad]; exact Finset.mem_filter.mpr ⟨hmIcc, hp⟩)
+  push_neg at hpred
+  rw [Finset.mem_Icc] at hmIcc
+  exact ⟨m, hmIcc.1, hmIcc.2, hpred.1, hpred.2⟩
+
+/-- **The greedy `B_h` set inside `{1, …, N}`.**  For every target cardinality `k` such
+that the count condition `j + 2·h·(j+1)^{2h-1} < N` holds at each intermediate size
+`j < k`, there is a `B_h` subset of `{1, …, N}` with exactly `k` elements.  This is the
+end-to-end greedy lower bound — the existence of a large `B_h` set inside an interval,
+obtained by iterating `exists_insert_le` from `∅`. -/
+theorem exists_isBh_subset_Icc {h : ℕ} (hh : 1 ≤ h) (N : ℕ) :
+    ∀ k, (∀ j, j < k → j + 2 * h * (j + 1) ^ (2 * h - 1) < N) →
+      ∃ A : Finset ℕ, A ⊆ Finset.Icc 1 N ∧ IsBh h A ∧ A.card = k := by
+  intro k
+  induction k with
+  | zero =>
+      intro _
+      exact ⟨∅, Finset.empty_subset _, isBh_empty, Finset.card_empty⟩
+  | succ k ih =>
+      intro hcond
+      obtain ⟨A, hsub, hbh, hcard⟩ := ih (fun j hj => hcond j (by omega))
+      obtain ⟨m, hm1, hmN, hmA, hins⟩ :=
+        hbh.exists_insert_le hh (by rw [hcard]; exact hcond k (by omega))
+      refine ⟨insert m A, ?_, hins, ?_⟩
+      · intro x hx
+        rw [Finset.mem_insert] at hx
+        rcases hx with rfl | hx
+        · exact Finset.mem_Icc.mpr ⟨hm1, hmN⟩
+        · exact hsub hx
+      · rw [Finset.card_insert_of_notMem hmA, hcard]
+
+/-- **Greedy lower bound, closed-form sufficient condition.**  If `k + 2·h·k^{2h-1} ≤ N`
+then `{1, …, N}` contains a `B_h` set of cardinality `k`: the greedy algorithm reaches
+size `k` whenever the degree-`(2h-1)` polynomial budget fits inside `N`.  This is the
+combinatorial half of the `B_h` greedy lower bound `|A| = Ω(N^{1/(2h-1)})`; only the
+real-power inversion of `k + 2·h·k^{2h-1} ≤ N` into `k ≥ c·N^{1/(2h-1)}` remains open. -/
+theorem exists_isBh_subset_Icc_card {h k N : ℕ} (hh : 1 ≤ h)
+    (hkN : k + 2 * h * k ^ (2 * h - 1) ≤ N) :
+    ∃ A : Finset ℕ, A ⊆ Finset.Icc 1 N ∧ IsBh h A ∧ A.card = k := by
+  refine exists_isBh_subset_Icc hh N k (fun j hj => ?_)
+  have hmono : 2 * h * (j + 1) ^ (2 * h - 1) ≤ 2 * h * k ^ (2 * h - 1) := by
+    gcongr
+    omega
+  omega
 
 end Erdos340Bh

--- a/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
@@ -410,3 +410,62 @@ card_pool_le` = `[propext, Classical.choice, Quot.sound]` (0-axiom). 923 → 102
   iterate "forbidden count `< N` ⟹ a small extension exists" inside `{1,…,N}`, then the
   real-power inequality `2h(k+1)^{2h−1} < N` ⟹ `k ≥ (N/(2h))^{1/(2h−1)} − 1`. Only
   remaining open piece; no further counting needed.
+
+### Session 2026-06-27 (researcher-2) — end-to-end greedy lower bound inside {1,…,N}
+
+**Mode**: CONTINUE (RICH) · **Outcome**: progress (verified increment, 0 sorries / 0 axioms).
+
+Closed the long-standing "end-to-end greedy iteration" next-step (Part 9, 3 new theorems).
+Turns the abstract forbidden-count polynomial `card_forbidden_poly` into an actual greedy
+**existence** statement: a large `B_h` set lives inside the interval `{1,…,N}`.
+
+#### What I Did
+- `IsBh.exists_insert_le` (`h≥1`): if `|A| + 2h(|A|+1)^{2h-1} < N` then there is a fresh
+  `m ∈ {1,…,N}` (`1 ≤ m ≤ N`, `m ∉ A`) with `insert m A` still `B_h`. Proof: the *bad*
+  values in `{1,…,N}` (`m∈A` or insertion breaks `B_h`) split as `filter_or` into the
+  `A`-part (`≤ |A|`) and the forbidden part; the forbidden part injects into the
+  `card_forbidden_poly` count because any `m > h·max A` is automatically insertable
+  (`insert_of_large`), so only `m ≤ h·max A` can be forbidden. Hence `|Bad| < N = |Icc 1 N|`,
+  so a good value survives.
+- `exists_isBh_subset_Icc` (`h≥1`): induction on target size `k` — if the per-step count
+  condition `j + 2h(j+1)^{2h-1} < N` holds for every `j<k`, then `{1,…,N}` has a `B_h`
+  subset of size exactly `k`. Base `∅`; step applies `exists_insert_le` to the size-`k`
+  set from the IH.
+- `exists_isBh_subset_Icc_card` (`h≥1`): clean closed-form consumer — `k + 2h·k^{2h-1} ≤ N`
+  ⟹ a `B_h` subset of `{1,…,N}` of size `k` exists. Derives the per-step `∀ j<k` condition
+  from the single bound via `gcongr` (pow monotonicity `(j+1)^{2h-1} ≤ k^{2h-1}`) + `omega`.
+
+#### Why it matters
+This is the **combinatorial half** of the `B_h` greedy lower bound `|A| = Ω(N^{1/(2h-1)})`,
+now a verified existence theorem. The ONLY remaining open piece is the real-power inversion
+of `k + 2h·k^{2h-1} ≤ N` into an explicit `k ≥ c·N^{1/(2h-1)}` — pure analysis, no more
+combinatorics. The whole Parts 5–9 arc (forbidden structure → orientation bound → sharp
+count → explicit polynomial → greedy iteration) is now closed end-to-end.
+
+#### Key Findings / gotchas
+- `Finset.card_sdiff` in this Mathlib (v4.26.0) is NOT the subset-hypothesis form
+  `(h:s⊆t)→(t\s).card = t.card - s.card`; it resolved to the unconditional
+  `#(s\t) = #s - #(s∩t)`. Avoided it entirely: proved a good value exists by
+  contradiction — if every `m ∈ Icc 1 N` were bad then `Icc 1 N ⊆ Bad`, so
+  `card_le_card` gives `N ≤ |Bad|`, contradicting `|Bad| < N` (`omega`).
+- `Nat.card_Icc 1 N` leaves the goal `N + 1 - 1 = N`; close with `omega` (not `rfl`).
+- The existence goal `∃ m, …` needs the witness `m` as the FIRST tuple component:
+  `⟨m, hm1, hmN, hmA, hins⟩`, not `⟨hm1, …⟩` (an easy off-by-one in the anonymous ctor).
+- `Finset.filter_or` splits `filter (p ∨ q)` into `filter p ∪ filter q`; `card_union_le`
+  + `card_le_card` then bound each part. `omega` abstracts the nonlinear
+  `2*h*(…)^(2h-1)` product as a consistent atom across the hypotheses.
+- The per-step → closed-form reduction: `gcongr` proves
+  `2h(j+1)^{2h-1} ≤ 2h·k^{2h-1}` leaving the base goal `j+1 ≤ k` (closed by `omega`).
+
+#### Verification
+Docker host down (`docker info` unavailable). Verified via host `v4.26.0`
+`lake env lean`: built the imported `Proofs.Erdos340GreedySidon` olean, then
+`lake env lean Proofs/Erdos340GreedySidonOQ05.lean` → exit 0, no warnings.
+`#print axioms IsBh.exists_insert_le / exists_isBh_subset_Icc / exists_isBh_subset_Icc_card`
+= `[propext, Classical.choice, Quot.sound]` (0-axiom). 1022 → 1146 lines, 34 → 37 theorems.
+
+#### Next Steps
+- Real-power closure: convert `k + 2h·k^{2h-1} ≤ N` into an explicit `Ω(N^{1/(2h-1)})`
+  rate (the last open piece, pure analysis).
+- Optional `h=2` specialization recovering an explicit `|A| ≥ c√N` Sidon lower bound
+  inside `{1,…,N}`, bridging to the parent `greedySidonSeq`.

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -6,14 +6,14 @@
   "tier": "B",
   "tractability": "medium — the foundational B_h theory and the sharp B_h counting upper bound are now formalized and verified (0-axiom). The deep open direction (improving the greedy B_h lower bound toward the N^{1/h} ceiling) remains open, exactly as for the parent #340.",
   "started": "2026-06-27",
-  "lastUpdate": "2026-06-27T20:00:00.000Z",
+  "lastUpdate": "2026-06-27T21:00:00.000Z",
   "path": "research/problems/erdos-340-greedy-sidon-oq-05",
   "leanFiles": [
     {
       "path": "Proofs/Erdos340GreedySidonOQ05.lean",
       "filename": "Erdos340GreedySidonOQ05.lean",
-      "lineCount": 1022,
-      "theoremCount": 34,
+      "lineCount": 1146,
+      "theoremCount": 37,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,
@@ -52,7 +52,8 @@
       "IsBh.exists_insert: every B_h set has SOME extension m∉A with insert m A still B_h; the explicit witness m = h·(max A) + 1 works (m∉A because any a∈A has a ≤ max A ≤ h·max A < m via Nat.le_mul_of_pos_left, needs h≥1). Iterating yields B_h sets of unbounded size — the constructive starting point for the B_h greedy lower bound. This is the B_h analogue of the parent's sidon_insert_of_large / sidon_exists_extension.",
       "EXPLICIT GREEDY FAMILY: iterating exists_insert gives, for every h≥1 and every n, a concrete B_h set of cardinality EXACTLY n (exists_isBh_card). Built via greedyBhAux : (n:ℕ) → {A : Finset ℕ // IsBh h A ∧ A.card = n} — a subtype-bundled structural recursion that carries the B_h proof alongside the set so that exists_insert's hypothesis is available at each definition step (Classical.choose the witness; choose_spec gives m∉A ∧ B_h(insert m A)). Projections greedyBhSet/_isBh/_card. Needs isBh_empty (∅ is B_h: h=0 domain is a Sym-subsingleton, h≥1 domain is empty). This SEPARATES the open question: a B_h set's COUNT is unbounded for free; the open core is how small its LARGEST ELEMENT can be (the N^{1/(2h-1)} bound). 0-axiom (Classical.choice only).",
       "ORIENTATION REFINEMENT closes the open forbidden-count gap. exists_diff_eq_of_not_insert now also yields card sA + card tA + d ≤ 2·h: the multiplicity gap d = |j−k| is paid out of the 2h slots of the two h-multisets, so the A-parts together carry ≤ 2h − d ≤ 2h − 1 elements. Hence at least one of sA, tA has size < h. card_forbidden_le' uses this to bound the forbidden set by 2·h·T₋·T₊ where T₋ = #multisets over A of size < h (degree h−1) and T₊ = #multisets of size ≤ h (degree h) — total degree 1+(h−1)+h = 2h−1 in |A|, one degree below the prior trivial T² bound. This is the count realising the SHARP N^{1/(2h-1)} greedy lower bound, the open quantitative core of #340's B_h generalisation. Proof: no parity/tagging bijection — just case-split on which side is short, union of two products, card_union_le + card_product. 0-axiom verified.",
-      "Part 8 (explicit closed form): card_forbidden_poly bounds the forbidden set by 2*h*(|A|+1)^(2h-1) — an explicit degree-(2h-1) polynomial in |A|, the form the greedy lower bound consumes. Built on card_sym_le_pow (|A.sym n| <= |A|^n, a Finset.sym cardinality bound Mathlib lacks) and geom_sum_le_pow (sum_{i<=k} n^i <= (n+1)^k)."
+      "Part 8 (explicit closed form): card_forbidden_poly bounds the forbidden set by 2*h*(|A|+1)^(2h-1) — an explicit degree-(2h-1) polynomial in |A|, the form the greedy lower bound consumes. Built on card_sym_le_pow (|A.sym n| <= |A|^n, a Finset.sym cardinality bound Mathlib lacks) and geom_sum_le_pow (sum_{i<=k} n^i <= (n+1)^k).",
+      "The greedy lower bound is now formalized end-to-end as an EXISTENCE statement inside an interval: exists_isBh_subset_Icc_card says {1,...,N} contains a B_h set of size k whenever k + 2h*k^(2h-1) <= N. This is exactly the combinatorial half of |A| = Omega(N^(1/(2h-1))); the ONLY remaining gap is the real-power arithmetic inverting 'k + 2h*k^(2h-1) <= N' into 'k >= c*N^(1/(2h-1))', which is analysis, not combinatorics. Key step: forbidden values in {1,...,N} inject into the card_forbidden_poly count because any m > h*max A is always insertable (insert_of_large), so only m <= h*max A can be forbidden."
     ],
     "builtItems": [
       "Erdos340GreedySidonOQ05.lean: def IsBh (h-fold-sum-distinctness via multiset-sum InjOn on A.sym h); IsBh.subset; isBh_one (every set is B_1); IsBh.sum_injOn_powersetCard (distinct h-subset sums); IsBh.choose_card_le (MAIN: Nat.choose |A| h ≤ h·N for B_h A ⊆ [1,N]); IsBh.two_card_mul_pred_le (Sidon recovery |A|(|A|-1) ≤ 4N). 206 lines, 6 theorems, 1 def, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only).",
@@ -67,15 +68,17 @@
       "card_sym_le_pow: (A.sym n).card <= A.card^n (Finset.sym cardinality bound, missing from Mathlib)",
       "geom_sum_le_pow: sum_{i<=k} n^i <= (n+1)^k",
       "card_pool_le: multiset pool of size <=k over A has card <= (|A|+1)^k",
-      "IsBh.card_forbidden_poly (h>=1): #forbidden <= 2*h*(|A|+1)^(2h-1), explicit closed form"
+      "IsBh.card_forbidden_poly (h>=1): #forbidden <= 2*h*(|A|+1)^(2h-1), explicit closed form",
+      "Erdos340GreedySidonOQ05.lean Part 9 (end-to-end greedy lower bound inside {1,...,N}): IsBh.exists_insert_le (B_h set with |A|+2h(|A|+1)^(2h-1) < N admits a fresh m in {1,...,N} keeping B_h, via card_forbidden_poly + a |Bad| < N counting argument); exists_isBh_subset_Icc (iterate from empty: a B_h subset of {1,...,N} of size k exists when the per-step count condition holds at each j<k); exists_isBh_subset_Icc_card (clean closed-form sufficient condition k + 2h*k^(2h-1) <= N => such a set of size k exists). All 0-axiom."
     ],
     "mathlibGaps": [
       "Mathlib has no B_h-set theory and no Sidon/B_h upper bound; the whole development is original relative to Mathlib.",
       "Finset.sym s n has no direct cardinality (multichoose) lemma in Mathlib — only the Fintype-level Sym.card_sym_eq_choose. This is why the counting bound is routed through h-subsets (powersetCard, which DOES have card_powersetCard) rather than the full multiset family."
     ],
     "nextSteps": [
-      "End-to-end greedy lower bound: iterate 'forbidden count < N => a small extension exists' inside {1,...,N}, then the real-power inequality 2h(k+1)^(2h-1) < N => k >= (N/(2h))^(1/(2h-1)) - 1. Only remaining open piece; no further counting needed."
+      "Real-power closure: turn exists_isBh_subset_Icc_card's condition 'k + 2h*k^(2h-1) <= N' into an explicit rate 'exists A subset {1,...,N}, IsBh h A and |A| >= floor((N/(4h))^(1/(2h-1)))' or similar, using Nat/real power monotonicity. This is the last open piece and is pure analysis (no more combinatorics).",
+      "Optional: specialize exists_isBh_subset_Icc_card at h=2 to recover an explicit Sidon lower bound |A| >= c*sqrt(N) inside {1,...,N}, bridging to the parent gallery's greedySidonSeq."
     ],
-    "progressSummary": "Foundational B_h theory + sharp upper bound (choose(|A|,h) <= h*N), Sidon bridge (IsBh 2 <-> IsSidon), affine invariance, greedy extension + explicit greedy family, and the forbidden-set structure/counting chain: card_forbidden_le (trivial T^2), card_forbidden_le' (sharp orientation 2h*T-*T+), and now card_forbidden_poly (explicit closed form 2h*(|A|+1)^(2h-1), degree 2h-1 in |A|). Remaining open: the [1,N]-bounded greedy iteration realising |A| = Omega(N^{1/(2h-1)})."
+    "progressSummary": "Foundational B_h theory + sharp upper bound (choose(|A|,h) <= h*N), Sidon bridge (IsBh 2 <-> IsSidon), affine invariance, greedy extension/family, and the sharp degree-(2h-1) forbidden-value polynomial (card_forbidden_poly). NEW: the end-to-end greedy LOWER bound inside {1,...,N} -- exists_isBh_subset_Icc_card gives a B_h subset of {1,...,N} of size k whenever k + 2h*k^(2h-1) <= N. Only the real-power inversion to an explicit N^(1/(2h-1)) rate remains open. 37 theorems, 0 sorries, 0 axioms."
   }
 }


### PR DESCRIPTION
## Summary

Closes the long-standing **end-to-end greedy iteration** next-step for Erdős #340 OQ-05 (B_h sequences). Parts 5–8 reduced the open B_h lower bound to a counting statement (`card_forbidden_poly`: at most `2h(|A|+1)^(2h-1)` small values are forbidden). **Part 9** runs the greedy algorithm to completion *inside the interval* `{1,…,N}`, turning that count into an actual existence theorem.

## New theorems (Part 9, all 0-axiom)

| Theorem | Statement |
|---------|-----------|
| `IsBh.exists_insert_le` | `h≥1`, `B_h A`, `|A| + 2h(|A|+1)^(2h-1) < N` ⟹ ∃ `m ∈ {1,…,N}`, `m ∉ A`, `B_h (insert m A)` |
| `exists_isBh_subset_Icc` | iterate from `∅`: a `B_h` subset of `{1,…,N}` of size `k` exists when the per-step count condition holds at each `j<k` |
| `exists_isBh_subset_Icc_card` | **clean closed form:** `k + 2h·k^(2h-1) ≤ N` ⟹ `{1,…,N}` contains a `B_h` set of size `k` |

## Proof idea

A value `m ∈ {1,…,N}` is *bad* if `m ∈ A` or inserting it breaks `B_h`. Splitting (`filter_or`), the bad set is `≤ |A|` (the `A`-part) plus the forbidden part. Crucially, every forbidden `m` satisfies `m ≤ h·max A` — any larger `m` is automatically insertable (`insert_of_large`) — so the forbidden part injects into the `card_forbidden_poly` count `≤ 2h(|A|+1)^(2h-1)`. Hence `|Bad| < N = |Icc 1 N|`, leaving a good value. Iterating gives the subset of any admissible size.

## Honest scope

This is the **combinatorial half** of the greedy lower bound `|A| = Ω(N^(1/(2h-1)))`, now a fully verified existence statement. The **only** remaining open piece is the real-power inversion of `k + 2h·k^(2h-1) ≤ N` into an explicit rate `k ≥ c·N^(1/(2h-1))` — pure analysis, no further combinatorics.

## Verification

Docker host unavailable; verified via host Lean **v4.26.0** `lake env lean Proofs/Erdos340GreedySidonOQ05.lean` → exit 0, no warnings. `#print axioms` on all three new theorems = `[propext, Classical.choice, Quot.sound]` (**0-axiom**). 1022 → 1146 lines, 34 → 37 theorems, 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)