### PR TITLE
research(sperner-ndim-oq-02): the interior Freudenthal pivot is an involution [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -668,6 +668,71 @@ theorem pivot_ne (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
   intro h
   exact pivot_opposite_ne s a b hb (by rw [h])
 
+/-- `GridSimplex` extensionality on the three data fields (the structure carries no
+`@[ext]`; the proof fields are discharged by definitional proof irrelevance). -/
+private theorem gridSimplex_ext {s t : SpernerGrid.GridSimplex d N}
+    (hv : s.verts = t.verts) (hi : s.incDir = t.incDir) (hm : s.miss = t.miss) :
+    s = t := by
+  cases s; cases t; cases hv; cases hi; cases hm; rfl
+
+/-- **The interior pivot is an involution.**  Pivoting twice across the *same* facet
+(opposite `a.succ`, with the same consecutive step pair `a, b`) returns the original
+cell.  Two ingredients combine: the direction permutation `Equiv.swap a b` is its own
+inverse (`incDir` returns to `s.incDir`), and the second `pivotPoint` exactly undoes
+the first — in the pivoted cell `t` the roles of the two move directions are swapped
+(`t.incDir a = s.incDir b`, `t.incDir b = s.incDir a`), so the second pivot moves
+`incDir a` *up* and `incDir b` *down*, reversing the original move and restoring
+`s.verts a.succ`.  This is the geometric heart of the adjacency symmetry `adj_symm`
+for chain-interior facets: the neighbour relation built from `pivotSimplex` is
+symmetric, with each facet-flip its own reverse. -/
+theorem pivot_involutive (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    pivotSimplex (pivotSimplex s a b hb) a b hb = s := by
+  have hab : a ≠ b := pivot_ab_ne hb
+  set t := pivotSimplex s a b hb with ht
+  -- Roles of the move directions are swapped in `t`.
+  have hia : t.incDir a = s.incDir b := by
+    show (s.incDir ∘ ⇑(Equiv.swap a b)) a = s.incDir b
+    simp [Equiv.swap_apply_left]
+  have hib : t.incDir b = s.incDir a := by
+    show (s.incDir ∘ ⇑(Equiv.swap a b)) b = s.incDir a
+    simp [Equiv.swap_apply_right]
+  have hva : t.verts a.succ = pivotPoint s a b hab := by
+    show Function.update s.verts a.succ (pivotPoint s a b hab) a.succ = _
+    rw [Function.update_self]
+  have hne : s.incDir a ≠ s.incDir b := fun h => hab (s.inc_injective h)
+  have hpos : 1 ≤ (s.verts a.succ).coords (s.incDir a) := by
+    have := s.step_inc a; omega
+  -- The doubly-pivoted vertex returns to the original deleted vertex.
+  have hpt : pivotPoint t a b hab = s.verts a.succ := by
+    ext j
+    by_cases h1 : j = s.incDir a
+    · subst h1
+      have hL : (pivotPoint t a b hab).coords (s.incDir a)
+          = (t.verts a.succ).coords (t.incDir b) + 1 := by
+        rw [← hib]; exact pivotPoint_coords_eq_incB t a b hab
+      rw [hL, hva, hib, pivotPoint_coords_eq_incA s a b hab]
+      omega
+    · by_cases h2 : j = s.incDir b
+      · subst h2
+        have hL : (pivotPoint t a b hab).coords (s.incDir b)
+            = (t.verts a.succ).coords (t.incDir a) - 1 := by
+          rw [← hia]; exact pivotPoint_coords_eq_incA t a b hab
+        rw [hL, hva, hia, pivotPoint_coords_eq_incB s a b hab]
+        omega
+      · have hja : j ≠ t.incDir a := by rw [hia]; exact h2
+        have hjb : j ≠ t.incDir b := by rw [hib]; exact h1
+        rw [pivotPoint_coords_eq_other t a b hab j hja hjb, hva,
+          pivotPoint_coords_eq_other s a b hab j h1 h2]
+  -- Assemble the three field equalities.
+  refine gridSimplex_ext ?_ ?_ rfl
+  · show Function.update t.verts a.succ (pivotPoint t a b hab) = s.verts
+    have htv : t.verts = Function.update s.verts a.succ (pivotPoint s a b hab) := rfl
+    rw [hpt, htv, Function.update_idem, Function.update_eq_self]
+  · show (s.incDir ∘ ⇑(Equiv.swap a b)) ∘ ⇑(Equiv.swap a b) = s.incDir
+    funext k
+    simp [Equiv.swap_apply_self]
+
 /-- **The interior pivot fixes the base vertex.**  The pivot only updates the
 vertex `a.succ`, and `a.succ ≠ 0`, so the lex-base `verts 0` is untouched. -/
 theorem pivot_base_eq (s : SpernerGrid.GridSimplex d N) (a b : Fin d)

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1311,3 +1311,49 @@ and `pivot_base_eq` = `[propext, Classical.choice, Quot.sound]` only. File 738�
    the existing facet scaffolding (facet_unique_neighbor / facet_injective /
    facet_vertex_injective) + `pivot_facet_eq`/`pivot_opposite_ne`.
 2. Phase 2: last-face-door oddness induction on `d`; apply `sperner_ndim`.
+
+## Session 2026-06-27 (researcher-2) — the interior pivot is an involution
+
+**Mode**: ACT. **Outcome**: verified increment (0-axiom) toward CanonSimplex `adj` / `adj_symm`.
+
+### What I Did (verified, 0-axiom)
+`pivot_involutive`: the interior Freudenthal pivot is an **involution** —
+`pivotSimplex (pivotSimplex s a b hb) a b hb = s`, with the *same* `(a, b, hb)`. This is
+the geometric heart of the adjacency symmetry `adj_symm` for chain-interior facets: the
+pivot-based neighbour relation is symmetric, each facet-flip its own reverse.
+
+### Proof idea
+Two facts combine. (1) The direction permutation `Equiv.swap a b` is its own inverse, so
+the doubly-pivoted `incDir` returns to `s.incDir` (`Equiv.swap_apply_self`). (2) The second
+`pivotPoint` exactly undoes the first: in the pivoted cell `t` the move directions are
+*swapped* (`t.incDir a = s.incDir b`, `t.incDir b = s.incDir a` via `swap_apply_left/right`),
+so the back-pivot moves `incDir a` *up* and `incDir b` *down*, reversing the original move.
+The whole proof reduces to `pivotPoint t a b = s.verts a.succ` (3-way `by_cases` on `j` vs
+`s.incDir a` / `s.incDir b`, each closed by the `pivotPoint_coords_eq_inc{A,B,other}` lemmas
++ `omega` for the `x+1-1=x` natural-subtraction step), then `GridSimplex` field extensionality.
+
+### Gotchas / API
+- `GridSimplex` carries no `@[ext]` (only `BaryPoint` does, `SpernerGridBase.lean:38`). Added a
+  local `gridSimplex_ext` (`cases s; cases t; cases hv; cases hi; cases hm; rfl` — the Prop
+  fields collapse by definitional proof irrelevance). The vertex field uses
+  `Function.update_idem` (`update (update f a x) a y = update f a y`) then
+  `Function.update_eq_self` (`update f a (f a) = f`).
+- `set t := pivotSimplex s a b hb with ht` keeps `t` definitionally transparent: the `show`
+  unfoldings of `t.incDir` (`= s.incDir ∘ ⇑(Equiv.swap a b)`) and `t.verts` work, and
+  `have htv : t.verts = … := rfl` succeeds.
+- To rewrite a `pivotPoint_coords_eq_incB t …` (stated at `t.incDir b`) into a goal indexed by
+  `s.incDir a`, first `rw [← hib]` (`hib : t.incDir b = s.incDir a`) to align the coord index.
+
+### Verification
+Docker host down; host `v4.26.0` `lake env lean Proofs/SpernerNDimOQ02.lean` → exit 0, no
+warnings (dep oleans `SpernerNDim`/`SpernerGridBase` present in the symlinked `.lake`).
+`#print axioms SpernerNDimOQ02.pivot_involutive` = `[propext, Classical.choice, Quot.sound]`
+(0-axiom). File 775 → 840 lines, 33 → 35 theorems (+ private `gridSimplex_ext`).
+
+### Next steps
+1. Lift the involution across recanonicalization (`pivot_isCanon_iff`): when the pivot is not
+   canonical, re-sort to the lex-min base (lex linear-order infra) so the symmetric partner
+   lives in `CanonSimplex`.
+2. Boundary-chain pivots (deleted vertex `0` or `Fin.last`) — the interior/boundary dichotomy.
+3. Assemble `adj` over `CanonSimplex`; discharge `adj_symm` via `pivot_involutive` + recanon.
+4. Phase 2: last-face door oddness induction on `d`; apply `sperner_ndim`.


### PR DESCRIPTION
## Summary

Adds `pivot_involutive` to the n-dimensional Sperner formalization (Erdős-related OQ-02): the interior Freudenthal pivot is an **involution**,

```
pivotSimplex (pivotSimplex s a b hb) a b hb = s
```

with the *same* step pair `(a, b, hb)`. This is the geometric heart of the adjacency symmetry `adj_symm` for chain-interior facets — the pivot-based neighbour relation is symmetric, with each facet-flip its own reverse.

## Proof idea

Two facts combine:
1. The direction permutation `Equiv.swap a b` is its own inverse, so the doubly-pivoted `incDir` returns to `s.incDir`.
2. The second `pivotPoint` exactly undoes the first: in the pivoted cell `t` the move directions are *swapped* (`t.incDir a = s.incDir b`, `t.incDir b = s.incDir a`), so the back-pivot moves `incDir a` up and `incDir b` down — reversing the original move.

The proof reduces to `pivotPoint t a b = s.verts a.succ` (a 3-way case split on the coordinate `j`, each branch closed by the existing `pivotPoint_coords_eq_inc{A,B,other}` lemmas plus `omega` for the `x+1-1=x` natural-subtraction step), followed by `GridSimplex` field extensionality (a local `gridSimplex_ext` via definitional proof irrelevance, since `GridSimplex` carries no `@[ext]`).

## Scope

This advances the long-running `adj`-over-`CanonSimplex` construction by grounding `adj_symm` geometrically. Still open: lifting the involution across recanonicalization (`pivot_isCanon_iff`) so the symmetric partner lands in `CanonSimplex`, the boundary-chain pivots, and Phase 2 (last-face door oddness). The main OQ target remains open.

## Verification

Docker host unavailable; verified via host Lean **v4.26.0** `lake env lean Proofs/SpernerNDimOQ02.lean` → exit 0, no warnings. `#print axioms SpernerNDimOQ02.pivot_involutive` = `[propext, Classical.choice, Quot.sound]` (**0-axiom**). 775 → 840 lines, 33 → 35 theorems, 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)