### PR TITLE
Enrich Catalan as a difference of central binomials (ballot number)

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-05-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-ballot-reflection",
+    "proofId": "catalan-numbers-oq-05-oq-01",
+    "range": { "startLine": 1, "endLine": 11 },
+    "type": "concept",
+    "title": "Ballot Numbers and the Reflection Principle",
+    "content": "The differences $\\binom{2n}{n-k} - \\binom{2n}{n-k-1}$ are the **ballot numbers**, the entries of the Catalan triangle. Their combinatorial meaning comes from André's *reflection principle*: among the $\\binom{2n}{n-k}$ lattice paths to a given endpoint, the ones that touch a forbidden boundary are in bijection with paths to the reflected endpoint, counted by $\\binom{2n}{n-k-1}$; subtracting leaves exactly the paths that stay on the legal side. The base case $k=0$ proved here, $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$, is the statement that the Catalan number counts Dyck paths (balanced parenthesizations). So the purely algebraic identity in this file is the arithmetic shadow of a counting bijection.",
+    "mathContext": "Ballot number $\\binom{2n}{n-k} - \\binom{2n}{n-k-1}$; reflection principle: #(good paths) = #(all) − #(reflected bad).",
+    "significance": "supporting",
+    "relatedConcepts": ["ballot problem", "reflection principle", "Dyck paths", "Catalan triangle"],
+    "prerequisites": ["binomial coefficients", "lattice paths"]
+  },
+  {
+    "id": "ann-centralbinom-bridge",
+    "proofId": "catalan-numbers-oq-05-oq-01",
+    "range": { "startLine": 12, "endLine": 33 },
+    "type": "technique",
+    "title": "The Central-Binomial–Catalan Bridge",
+    "content": "The load-bearing sublemma reused by both `choose_two_mul_succ` and `catalan_eq_choose_sub` is the bridge $\\binom{2n}{n} = (n+1)\\,C_n$, assembled from Mathlib's `succ_mul_catalan_eq_centralBinom` and `Nat.centralBinom_eq_two_mul_choose`. With the Pascal step it pins down both central-row entries — $\\binom{2n}{n} = (n+1)C_n$ and $\\binom{2n}{n+1} = n\\,C_n$ — so their difference collapses to $C_n$. This division-free packaging complements the only form Mathlib stores, $C_n = \\binom{2n}{n}/(n+1)$ (`Nat.catalan_eq_centralBinom_div`), trading an exact division for an honest ℕ subtraction.",
+    "mathContext": "Bridge: $\\binom{2n}{n} = (n+1)\\,C_n$, versus Mathlib's $C_n = \\binom{2n}{n}/(n+1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["central binomial coefficient", "Nat.catalan_eq_centralBinom_div", "division-free identity"],
+    "prerequisites": ["succ_mul_catalan_eq_centralBinom", "Nat.centralBinom_eq_two_mul_choose"]
+  },
+  {
     "id": "ann-neighbour",
     "proofId": "catalan-numbers-oq-05-oq-01",
     "range": { "startLine": 41, "endLine": 57 },

--- a/src/data/proofs/catalan-numbers-oq-05-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-05-oq-01/meta.json
@@ -106,5 +106,27 @@
       "Does the full Catalan triangle B(2n,k) = C(2n,n+k) − C(2n,n+k+1) admit a uniform Lean treatment, with each row entry counting the constrained lattice paths?",
       "Can the reflected sums of several ballot numbers be packaged to recover convolution identities for the Catalan numbers?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "catalan-numbers-oq-05",
+      "relationship": "extends",
+      "description": "Parent entry: works with the Catalan numbers via Mathlib's division formula catalan n = C(2n,n)/(n+1). This entry answers its open question by giving the division-free ballot-number difference form C(2n,n) − C(2n,n+1)."
+    },
+    {
+      "targetId": "ballot-problem",
+      "relationship": "related",
+      "description": "The ballot problem and André's reflection principle supply the combinatorial meaning of the binomial differences proved here as ballot numbers (the base case being the Catalan / Dyck-path count)."
+    },
+    {
+      "targetId": "catalan-numbers-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Companion Catalan-number arithmetic in the gallery; shares the central-binomial-coefficient toolkit (succ_mul_catalan_eq_centralBinom, centralBinom) used to derive this difference identity."
+    },
+    {
+      "targetId": "combinations-formula-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Another Pascal's-triangle binomial-identity entry (the Fibonacci shallow-diagonal sum); both read a named integer sequence off a structured combination of binomial coefficients."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-05-oq-01` (the Catalan number as a difference of central binomial coefficients / base ballot number).

The entry already had a full structured overview, conclusion, and 3 deep annotations. Two gaps remained:

**annotations.json (3 → 5)** — added two genuinely additive, header-anchored annotations (existing 3 already cover the three theorems):
- **ann-ballot-reflection** — the ballot-number / André reflection-principle combinatorial meaning behind the binomial differences (the base case is exactly the Dyck-path / Catalan count), i.e. the counting bijection whose arithmetic shadow the file proves.
- **ann-centralbinom-bridge** — the C(2n,n) = (n+1)·catalan n bridge lemma reused across both theorems, and how the resulting division-free difference form contrasts with Mathlib's stored division formula.

**crossReferences (absent → 4)** — populated using the renderer's `targetId`/`relationship`/`description` schema, all verified to exist on origin/main: the parent `catalan-numbers-oq-05`, `ballot-problem`, `catalan-numbers-oq-01-oq-02`, and `combinations-formula-oq-01-oq-01`.

All 5 annotations align to Lean constructs (resolver Misaligned: 0). meta.json 8496 → 9656 B, well under the 60 KB cap. `annotations:build` and `gallery:check-size` pass with no errors for this entry; the full `tsc -b && vite build` does not run in this fresh worktree due to an environmental better-sqlite3 native-build failure under node v26, unrelated to this JSON-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)