### PR TITLE
audit(frobenius-endomorphism-oq-01-oq-03): badge original → mathlib (Tier B wrapper)

### DIFF
--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-03/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/FrobeniusEndomorphismOQ01OQ03.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide, so no Lean.ofReduceBool is introduced. The automorphism frobeniusEquiv is noncomputable only because RingEquiv.ofBijective uses choice to extract the inverse — this introduces no extra axioms beyond the standard triple.",


### PR DESCRIPTION
## Gallery integrity fix

**Proof**: `frobenius-endomorphism-oq-01-oq-03` (landed in #28643)
**Problem**: Tier B Mathlib wrapper carries `badge: "original"` — an overclaim.

## Evidence

The three core results are one-line delegations to Mathlib:

```lean
theorem frobenius_injective : Function.Injective (frobenius R p) := frobenius_inj R p
theorem frobenius_bijective : Function.Bijective (frobenius K p) :=
  Finite.injective_iff_bijective.mp (frobenius_injective K p)
noncomputable def frobeniusEquiv : K ≃+* K :=
  RingEquiv.ofBijective (frobenius K p) (frobenius_bijective K p)
```

The Lean file's own docstring states: *"Everything is Mathlib-backed (`frobenius_inj`, `Finite.injective_iff_bijective`, `RingEquiv.ofBijective`)."* The meta's `mathlibDependencies` and `originalContributions` already disclose this honestly — only the **badge taxonomy** was wrong.

Per the auditor tier policy, a proof whose core result is obtained by calling a Mathlib theorem is **Tier B** and must use `badge: "mathlib"`, not `"original"` (failure mode #5: "0 sorries with hidden imports").

**Sibling convention confirms it**: the parent `frobenius-endomorphism-oq-01` and direct siblings `oq-01-oq-01`, `oq-01-oq-02` all use `badge: "mathlib"` with `status: "verified"`.

## Fix

`meta.badge`: `"original"` → `"mathlib"`. `status` stays `"verified"` (genuinely 0 sorries, 0 axioms). One-field change.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)