### PR TITLE
research(collatz-structured-oq-02-oq-03): auto-derive parity vector from (b,r) — turnkey residue-drop engine [VERIFIED, axiom-free]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -1465,4 +1465,104 @@ theorem attainsBelow_density_lower_16_general (N : ℕ) :
     N
   rwa [hcard] at key
 
+/-! ## Part VII: Fully auto-derived certificates — supply only the modulus and residue
+
+The decidable certificate `dropCert` of Part V still asks the caller for the parity
+vector `v`; only the *validity check* is automatic.  But for a power-of-two modulus
+`M = 2^b` the parity vector is itself residue-determined and so can be **computed**
+from `(b, r)` alone: starting the affine pair at `(2^b, r)`, the leading coefficient
+`c` stays even until exactly `b` halvings have happened, and while `c` is even the
+parity of `c·m + d` is just `d mod 2` — independent of `m`.  So each step's parity is
+forced, and `deriveVec` reads it straight off the running constant.
+
+`deriveVec` terminates by a fuel argument: two odd steps can never be consecutive (an
+odd step sends `d ↦ 3d+1`, which is even), and each even step strips one factor of two
+from `c`, so the residue-determined window closes after at most `2b` steps once `c`
+becomes odd.  Crucially `affValidB (deriveVec fuel c d) c d = true` holds
+**unconditionally** — the recursion branches on exactly the validity conditions — so no
+divisibility hypothesis is needed and soundness never depends on the fuel being large
+enough (an exhausted or non-dropping window simply fails the decidable drop check, it
+never produces a false `AttainsBelow`).
+
+This closes the last gap to a turnkey engine: a new residue family `r (mod 2^b)` is now
+literally `autoDropCert_attainsBelow (b := …) (r := …) (by decide) h` — the caller
+supplies neither a trajectory chase nor a hand-built parity vector, only the modulus
+exponent and residue.  Axiom-free (`decide`, not `native_decide`). -/
+
+/-- Auto-derive the residue-determined parity vector of the affine class `c·m + d`,
+reading each forced parity off the constant `d` (valid while the leading coefficient
+`c` stays even).  Stops when `c` becomes odd — at which point the window is closed and
+the leading coefficient `c` is final — or when the `fuel` is exhausted.  For a
+power-of-two start `c = 2^b` the closure always happens within `2b` steps. -/
+def deriveVec : ℕ → ℕ → ℕ → List Bool
+  | 0,         _, _ => []
+  | fuel + 1,  c, d =>
+      if c % 2 = 1 then []
+      else if d % 2 = 1 then true  :: deriveVec fuel (3 * c) (3 * d + 1)
+      else false :: deriveVec fuel (c / 2) (d / 2)
+
+/-- The auto-derived parity vector is always a valid `AffValid` certificate for its
+own starting pair, **with no hypothesis on `c, d`**: `deriveVec` branches on exactly the
+parity conditions `affValidB` checks, so every recorded bit is sound by construction. -/
+theorem affValidB_deriveVec :
+    ∀ (fuel c d : ℕ), affValidB (deriveVec fuel c d) c d = true := by
+  intro fuel
+  induction fuel with
+  | zero => intro c d; rfl
+  | succ fuel ih =>
+    intro c d
+    rw [deriveVec]
+    split_ifs with hc hd
+    · rfl
+    · have hce : c % 2 = 0 := by omega
+      simp only [affValidB, Bool.and_eq_true, beq_iff_eq]
+      exact ⟨⟨hce, hd⟩, ih (3 * c) (3 * d + 1)⟩
+    · have hce : c % 2 = 0 := by omega
+      have hde : d % 2 = 0 := by omega
+      simp only [affValidB, Bool.and_eq_true, beq_iff_eq]
+      exact ⟨⟨hce, hde⟩, ih (c / 2) (d / 2)⟩
+
+/-- A single decidable certificate for the residue class `r (mod 2^b)` that derives its
+own parity vector: non-empty derived window whose realized affine iterate drops
+(`c_k < 2^b`, `d_k < r`).  Each conjunct is a finite computation, so this evaluates by
+`decide`.  Unlike `dropCert`, the caller supplies **no** parity vector. -/
+def autoDropCert (b r : ℕ) : Bool :=
+  decide (0 < (deriveVec (2 * b + 1) (2 ^ b) r).length) &&
+    decide ((affOrbit (deriveVec (2 * b + 1) (2 ^ b) r) (2 ^ b, r)).1 < 2 ^ b) &&
+    decide ((affOrbit (deriveVec (2 * b + 1) (2 ^ b) r) (2 ^ b, r)).2 < r)
+
+/-- **Fully auto-derived residue-drop engine.**  A `true` `autoDropCert b r` makes every
+`n ≡ r (mod 2^b)` attain a value below itself — the parity vector is derived internally
+from `(b, r)`, so a new residue family is one line:
+`autoDropCert_attainsBelow (b := …) (r := …) (by decide) h`. -/
+theorem autoDropCert_attainsBelow {b r : ℕ} (h : autoDropCert b r = true)
+    {n : ℕ} (hn : n % 2 ^ b = r) : AttainsBelow n := by
+  simp only [autoDropCert, Bool.and_eq_true, decide_eq_true_eq] at h
+  obtain ⟨⟨hk, hc⟩, hd⟩ := h
+  exact parityVector_attainsBelow _ hk
+    (affValidB_sound (affValidB_deriveVec _ _ _)) hc hd hn
+
+/-! ### Validation: the auto-derived engine reproduces the gallery families
+
+Each call below supplies only the modulus exponent `b` and the residue `r`; the parity
+vector that the Part II/V lemmas wrote out by hand is now computed by `deriveVec` and
+certified by a single `by decide`. -/
+
+/-- `n ≡ 3 (mod 16 = 2^4)` drops below itself — derived end-to-end from `(b, r) = (4, 3)`,
+no parity vector supplied. -/
+example {n : ℕ} (h : n % 16 = 3) : AttainsBelow n :=
+  autoDropCert_attainsBelow (b := 4) (r := 3) (by decide)
+    (by rw [show (2 : ℕ) ^ 4 = 16 by norm_num]; exact h)
+
+/-- `n ≡ 11 (mod 32 = 2^5)` drops below itself — derived from `(b, r) = (5, 11)`. -/
+example {n : ℕ} (h : n % 32 = 11) : AttainsBelow n :=
+  autoDropCert_attainsBelow (b := 5) (r := 11) (by decide)
+    (by rw [show (2 : ℕ) ^ 5 = 32 by norm_num]; exact h)
+
+/-- `n ≡ 7 (mod 128 = 2^7)` drops below itself — derived from `(b, r) = (7, 7)`, an
+eleven-step residue-determined window, the *same* one `by decide`. -/
+example {n : ℕ} (h : n % 128 = 7) : AttainsBelow n :=
+  autoDropCert_attainsBelow (b := 7) (r := 7) (by decide)
+    (by rw [show (2 : ℕ) ^ 7 = 128 by norm_num]; exact h)
+
 end CollatzStructuredOQ02OQ03

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -357,3 +357,65 @@ reflection layer:
   decrease v2(c)); this is the same difficulty as the drop-below conjecture itself for the
   m-dependent classes. The decidable certificate here is the right primitive to build that on.
 - Then re-attack Terras/Korec natural-density-1 stopping time (Tao axiom stays BLOCKED).
+
+## Session 2026-06-27 (researcher-8) — ACT: parity vector AUTO-DERIVED from (b, r) — de-risk component (1)
+
+**Mode**: BUILD (Docker unresponsive — `docker info` hangs; built offline
+`LAKE_UNSAFE=1 ./bin/lake env lean Proofs/CollatzStructuredOQ02OQ03.lean` against the
+worktree's cached Mathlib oleans, REAL_EXIT=0, no errors/warnings).
+**Outcome**: progress — completes the long-documented "component (1)" lever; axiom-free.
+
+### What I Did
+Closed the last manual input in the residue-drop engine. Previously `dropCert M r v`
+auto-checked validity but the caller still hand-supplied the parity vector `v`. Added
+**Part VII**: `deriveVec` COMPUTES the residue-determined parity vector from `(b, r)`
+alone for a power-of-two modulus `2^b`.
+- `deriveVec : ℕ → ℕ → ℕ → List Bool` — fuel-bounded simulation starting the affine
+  pair at `(2^b, r)`; while the leading coefficient `c` is even the parity of `c·m+d`
+  is `d mod 2` (independent of `m`), so each step is forced and read off `d`. Stops when
+  `c` becomes odd (window closed) or fuel exhausted.
+- `affValidB_deriveVec : ∀ fuel c d, affValidB (deriveVec fuel c d) c d = true` —
+  **unconditional** (no divisibility hypothesis): the recursion branches on exactly the
+  conditions `affValidB` checks, so every derived bit is valid by construction.
+- `autoDropCert (b r : ℕ) : Bool` and `autoDropCert_attainsBelow` — a new residue family
+  `r (mod 2^b)` is now `autoDropCert_attainsBelow (b:=…) (r:=…) (by decide) h`, supplying
+  NO parity vector. Validated end-to-end by re-deriving `n≡3 (mod 16)`, `n≡11 (mod 32)`,
+  `n≡7 (mod 128)` — each a single `by decide`.
+
+### Key Findings
+- The termination/soundness split is the crux: **fuel bounds completeness, never
+  soundness.** An exhausted or non-dropping window just fails the decidable drop check
+  (`c_k < 2^b` / `d_k < r`); it can never emit a false `AttainsBelow`. So the messy
+  "simulate while c even" termination concern (flagged as equivalent to the drop-below
+  conjecture for m-dependent classes) is sidestepped: pick any fuel `≥ 2b` and the
+  determined classes certify; the rest correctly fail.
+- Two odd steps are never consecutive (odd sends `d ↦ 3d+1`, even), and each even step
+  strips one factor of two from `c = 2^b`, so the determined window closes within `2b`
+  steps — `fuel = 2b+1` always suffices for the determined classes.
+- `#print axioms autoDropCert_attainsBelow` / `affValidB_deriveVec` → `[propext,
+  Quot.sound]` only. Kernel `decide`, NOT `native_decide` — no `Lean.ofReduceBool`.
+
+### Honest status
+- This is **engine completion / usability**, not new Collatz mathematics: the density
+  floor is unchanged (115/128) and the Tao axiom remains BLOCKED. Value: the engine is
+  now genuinely turnkey for power-of-two moduli — caller supplies only `(b, r)`. This is
+  exactly de-risk **component (1)** documented by researcher-1/researcher-2 as the last
+  remaining lever (auto-DERIVE the vector from the modulus+residue).
+
+### GOTCHA / process note
+- **The worktree was hard-reset mid-session** (`git reflog` → `reset: moving to HEAD`),
+  silently wiping uncommitted edits — and an early "EXIT 0" build had actually run on the
+  *original* file. Lesson: in this worktree, **commit immediately after editing** (a
+  committed change survives `reset --hard HEAD`) and re-grep the file for your new
+  identifiers before trusting a build's exit code.
+
+### Files Modified
+- proofs/Proofs/CollatzStructuredOQ02OQ03.lean (+2 thm 52→54, +2 def 10→12, 1468→1568 lines; 1 axiom unchanged, 0 sorries)
+- src/data/proofs/collatz-structured-oq-02-oq-03/meta.json (counts synced + highlight)
+- src/data/research/problems/collatz-structured-oq-02-oq-03.json (leanFiles counts 1360/50/10 → 1568/54/12)
+
+### Next Steps
+- The remaining direction is unchanged and genuinely hard: a *uniform* drop theorem
+  (one inductive statement covering all determined classes via the `3^a < 2^b` criterion),
+  then Terras/Korec natural-density-1 stopping time. Tao axiom stays BLOCKED. Further
+  density-floor dyadic levels (mod 256+) remain diminishing returns.

--- a/research/problems/collatz-structured-oq-02-oq-03/state.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/state.md
@@ -3,42 +3,47 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-06-27T05:00:00-07:00
-**Iteration**: 5
+**Since**: 2026-06-27T19:00:00-07:00
+**Iteration**: 6
 
 ## Current Focus
-ORIENT/metadata-sync — no build capability this session (Docker down, no real lake/elan,
-no cached oleans), so authored no Lean. Confirmed from source that the 115/128 axiom-free
-floor (merged #30768) is intact (1051 L, 39 thm, 1 deep axiom `tao_2019`, 0 sorries) and
-the gallery meta is correct. Synced a grossly-stale `leanFiles` entry in the research JSON
-(146→1052 L, 7→39 thm). Documented a concrete Terras leading-coefficient (`c = 3^a/2^b`)
-formalization plan to de-risk the genuine next direction (design note only, unverified).
+ACT — completed de-risk **component (1)**: the residue-drop engine now AUTO-DERIVES the
+parity vector from `(b, r)` for power-of-two moduli (`deriveVec`/`autoDropCert`), so the
+caller supplies only the modulus exponent and residue, not a hand-built vector. Built
+offline (Docker unresponsive), REAL_EXIT=0, axiom-free (`propext, Quot.sound`; kernel
+`decide`, not `native_decide`).
 
 ## Active Approach
 Deep result stays a single documented axiom (`tao_2019`); the elementary residue-dynamics
-core is extended one dyadic level via the shared `affine_residue_attainsBelow` helper, then
-assembled into a disjoint-family counting bound (`attainsBelow_density_lower_128`).
+core is now a fully turnkey decidable engine. `deriveVec` simulates the affine pair from
+`(2^b, r)` reading each forced parity off the constant `d`; `affValidB_deriveVec` proves
+the derived vector is unconditionally valid; `autoDropCert_attainsBelow` certifies a
+residue family in one `by decide`.
 
 ## Attempt Count
-- Total attempts: 5
+- Total attempts: 6
 - Approaches tried: statement + explicit families; n≡1 mod 4 family; colMin bridge;
-  mod-16/mod-32 refinements; mod-128 refinement (committed broken); **mod-128 repair + verify (this session)**
+  mod-16/32/128 refinements; general density lemma + decidable `dropCert` (vector supplied);
+  **auto-derived parity vector `deriveVec`/`autoDropCert` (this session — no vector supplied)**
 
 ## Blockers
 - Full proof of Tao (2019) remains BLOCKED (3-adic transport/concentration + Fourier; >> 1000 lines).
-- Build host: Docker is back up but disk at 99% (~190Mi free). Verified offline via
-  `LAKE_UNSAFE=1 ./bin/lake env lean` against the worktree's cached Mathlib oleans (EXIT 0).
+- Build host: Docker `docker info` hangs (unresponsive). Verified offline via
+  `LAKE_UNSAFE=1 ./bin/lake env lean` against the worktree's cached Mathlib oleans (REAL_EXIT 0).
+- **Worktree hazard**: a hard reset (`git reset --hard HEAD`) ran mid-session and wiped
+  uncommitted edits. Commit immediately after editing in this worktree.
 
 ## Next Action
-The next dyadic improvement past 115/128 is at level 256 (density 237/256), but this is
-diminishing returns — each level adds only a handful of residue classes and the path to
-density 1 is the Terras/Korec finite-stopping-time theorem, not finite residue computation.
-Future milestone: formalize Terras/Korec natural-density stopping-time toward Tao's bound.
+Remaining genuine lever: a *uniform* drop theorem (one inductive statement covering all
+determined classes through the `3^a < 2^b` criterion), then Terras/Korec natural-density-1
+stopping time toward Tao's bound. Further dyadic density levels (mod 256+) are diminishing
+returns. Tao axiom stays BLOCKED.
 
 ## Deliverable (this session)
-`proofs/Proofs/CollatzStructuredOQ02OQ03.lean` — now COMPILES (was broken):
-- `mod_onetwentyeight_seven_attainsBelow`, `mod_onetwentyeight_fifteen_attainsBelow`,
-  `mod_onetwentyeight_fiftynine_attainsBelow` (the three missing 11-step drop theorems);
-- `even_or_mod_four_one_or_mod_onetwentyeight_attainsBelow` (8-way packaging).
-Verified EXIT 0 offline; all new theorems axiom-free (`propext/Classical.choice/Quot.sound`).
-Still 1 deep axiom (`tao_2019`), 0 sorries, 39 theorems. meta.json counts corrected.
+`proofs/Proofs/CollatzStructuredOQ02OQ03.lean` — Part VII added (1468→1568 lines, 52→54
+theorems, 10→12 defs, 1 axiom unchanged, 0 sorries):
+- `deriveVec` (auto-derives the residue-determined parity vector from `(b, r)`);
+- `affValidB_deriveVec` (the derived vector is unconditionally a valid `AffValid` certificate);
+- `autoDropCert` / `autoDropCert_attainsBelow` (one-line residue-family certification from
+  `(b, r)` alone), validated on `n≡3 (mod 16)`, `n≡11 (mod 32)`, `n≡7 (mod 128)`.
+Verified REAL_EXIT 0 offline; new theorems axiom-free (`propext, Quot.sound`).

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,12 +20,12 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1468,
+    "lineCount": 1568,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
-    "theoremCount": 52,
-    "definitionCount": 10
+    "theoremCount": 54,
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "The Collatz conjecture asserts every positive integer's orbit reaches 1. Short of the full conjecture, 'almost all' results bound the orbit for density-one sets of starting values. Terras (1976) and Korec (1994) showed almost all n (in natural density) have finite stopping time — their orbit drops below the starting value. Tao (2019, Forum Math. Pi) gave a dramatically stronger statement: for any f → ∞, almost all n (in the finer logarithmic density) have orbit minimum below f(n), i.e. orbits attain almost bounded values. OQ-03 asks whether this analytic landmark can be formalized in Lean.",
@@ -133,15 +133,16 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1468,
+    "lineCount": 1568,
     "axiomCount": 1,
-    "theoremCount": 52,
+    "theoremCount": 54,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
-    "definitionCount": 10
+    "definitionCount": 12
   },
   "sorries": 0,
   "highlights": [
+    "Fully auto-derived residue-drop certificate (autoDropCert / autoDropCert_attainsBelow): for a power-of-two modulus 2^b the parity vector is itself residue-determined, so deriveVec COMPUTES it from (b,r) alone (reading each forced parity off the affine constant d while the leading coefficient stays even) — the caller no longer supplies a parity vector at all, only the modulus exponent and residue. affValidB_deriveVec proves the derived vector is always a valid AffValid certificate unconditionally (the recursion branches on exactly the validity conditions), so soundness never depends on the fuel bound. A new residue family r (mod 2^b) is now one line: autoDropCert_attainsBelow (b:=…) (r:=…) (by decide) h — validated by re-deriving n≡3 (mod 16), n≡11 (mod 32), n≡7 (mod 128) end-to-end with no hand-built vector. Axiom-free (propext, Quot.sound only; kernel decide, not native_decide).",
     "General residue-class density floor (attainsBelow_density_of_residues): for ANY modulus M ≥ 1 and any finite set R of residues each certified to drop below itself, at least |R|·(N−1) of [1,M·N] attain a value below themselves — lower density ≥ |R|/M. One injectivity argument ((r,m) ↦ M·m+r, with r<M the remainder mod M) replaces all the per-level pairwise-disjointness bookkeeping; the four bespoke floors (3/4, 13/16, 7/8, 115/128) become one-line instantiations. Re-derived the 13/16 floor (attainsBelow_density_lower_16_general) from it with the residue count 13 discharged by a kernel `decide`. Axiom-free (propext, Classical.choice, Quot.sound).",
     "Decidable parity-vector certificate: affValidB reflects the AffValid validity predicate into a computable Bool, affValidB_sound transports a true result back to the Prop, and dropCert M r v bundles validity + the drop bounds c_k<M, d_k<r into one Boolean. dropCert_attainsBelow then makes a whole residue family a single `by decide` (no trajectory chase, no hand-built certificate term) — e.g. the n≡3 (mod 16) and n≡11 (mod 32) drops each collapse to one line. Axiom-free (propext, Quot.sound only)",
     "Reusable affine step-composition lemmas (Terras leading-coefficient law): affine_step_even (c,d)↦(c/2,d/2) and affine_step_odd (c,d)↦(3c,3d+1) track a residue class M·m+r as an affine map c·m+d, reading each parity off the even leading coefficient — replacing the per-step ring/omega trajectory boilerplate. mod_sixteen_three_attainsBelow now uses them for a one-line hiter; axiom-free",

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -130,10 +130,10 @@
     {
       "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
       "filename": "CollatzStructuredOQ02OQ03.lean",
-      "lineCount": 1360,
-      "theoremCount": 50,
+      "lineCount": 1568,
+      "theoremCount": 54,
       "axiomCount": 1,
-      "defCount": 10,
+      "defCount": 12,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzStructuredOQ02OQ03.lean"


### PR DESCRIPTION
## Summary

Completes the long-documented de-risk **component (1)** for the Collatz OQ-03 residue-drop engine: the parity vector is now **auto-derived from `(b, r)`** (modulus exponent + residue) instead of being hand-supplied by the caller.

Previously `dropCert M r v` auto-*checked* a parity vector but the caller still wrote `v` out by hand. For a power-of-two modulus `2^b` the vector is itself residue-determined — while the leading coefficient `c` stays even, the parity of `c·m + d` is just `d mod 2`, independent of `m` — so it can be **computed**.

## What's new (Part VII)

- **`deriveVec : ℕ → ℕ → ℕ → List Bool`** — fuel-bounded simulation from `(2^b, r)` that derives the residue-determined parity vector, reading each forced parity off the running affine constant `d`.
- **`affValidB_deriveVec`** — the derived vector is **unconditionally** a valid `AffValid` certificate (no divisibility hypothesis): the recursion branches on exactly the conditions `affValidB` checks. Fuel bounds *completeness*, never *soundness* — a non-dropping/exhausted window simply fails the decidable drop check, never emitting a false `AttainsBelow`.
- **`autoDropCert` / `autoDropCert_attainsBelow`** — a new residue family `r (mod 2^b)` is now one line: `autoDropCert_attainsBelow (b := …) (r := …) (by decide) h`, supplying **no** parity vector. Validated end-to-end by re-deriving `n ≡ 3 (mod 16)`, `n ≡ 11 (mod 32)`, `n ≡ 7 (mod 128)`.

## Honesty / scope

This is **engine completion / usability**, not new Collatz mathematics. The density floor is unchanged (115/128) and the deep `tao_2019` axiom remains **BLOCKED** (3-adic transport/concentration + Fourier, ≫ 1000 lines). Value: the engine is now genuinely turnkey for power-of-two moduli.

## Verification

- Built offline (`LAKE_UNSAFE=1 ./bin/lake env lean Proofs/CollatzStructuredOQ02OQ03.lean`, **REAL_EXIT 0**, no errors/warnings) — Docker host unresponsive this session.
- `#print axioms autoDropCert_attainsBelow` / `affValidB_deriveVec` → `[propext, Quot.sound]` only. Kernel `decide`, **not** `native_decide` — no `Lean.ofReduceBool`.
- Counts: 1468→1568 lines, 52→54 theorems, 10→12 defs, 1 axiom (`tao_2019`) unchanged, 0 sorries. Gallery `meta.json` and research JSON synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)