### PR TITLE
research(erdos-1005-oq-02): §14 continuant — one run-length criterion for every length [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -1143,4 +1143,175 @@ theorem simOrd_quint {a b c d e f g h i j k₁ k₂ k₃ : ℕ}
            (simOrd_long_iff hg hhd hi hjf).mpr c5,
            (simOrd_long3_iff he hfb hg hhd hi hjf).mpr c6⟩
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 14: The continuant — the run-length criterion for *every* length
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+§ 11–§ 13 computed the long-range obstruction of runs of length 3, 4, 5 one at a
+time, and each was governed by a rung of the same ladder of polynomials in the
+successor quotients:
+
+  `K() = 1`,  `K(k) = k`,  `K(k₁,k₂) = k₁k₂ − 1`,  `K(k₁,k₂,k₃) = k₁k₂k₃ − k₁ − k₃`.
+
+These are the **continuant** polynomials — the order-side shadow of the §9
+numerator/denominator recurrence `xₘ₊₁ = kₘ·xₘ − xₘ₋₁` (`x` runs over the Farey
+numerators or denominators).  This section replaces the per-length lemmas by ONE
+statement valid for runs of arbitrary length, by
+
+1. defining `Continuant : List ℤ → ℤ` with the head-recurrence
+   `K(k₁ :: k₂ :: ks) = k₁·K(k₂ :: ks) − K(ks)`;
+2. defining the iterated successor `stepSeq a c ks`, which applies the §9
+   recurrence once per quotient in `ks` to the consecutive pair `(a, c)`;
+3. proving the **closed form** `stepSeq a c ks = K(ks)·c − secondCont(ks)·a`
+   (`stepSeq_eq_continuant`) by induction on `ks`; and
+4. reading off the general endpoint window
+   `(a − pₘ)·(b − qₘ) = ((1+secondCont ks)·a − K·c)·((1+secondCont ks)·b − K·d)`
+   (`endpoint_window`), so a run's endpoints are similarly ordered iff that
+   single continuant-controlled product is `≥ 0` (`simOrd_run_iff`).
+
+The §11/§12/§13 windows `(2a−kc)`, `((k₂+1)a−(k₁k₂−1)c)`,
+`(k₂k₃·a−(k₁k₂k₃−k₁−k₃)c)` are exactly the cases `|ks| = 1, 2, 3` — verified by
+`continuant_two`, `continuant_three` and `secondCont_*` below.  This is the
+structural form (run-length criterion as a continuant positivity condition) that
+a density argument toward the `1/12` constant would have to control; the constant
+itself remains open.
+-/
+
+/-- The (minus-sign) **continuant** of a list of quotients, with the
+head-two-element recurrence `K(k₁ :: k₂ :: ks) = k₁·K(k₂ :: ks) − K(ks)` and
+bases `K([]) = 1`, `K([k]) = k`.  This is the polynomial governing the §9
+recurrence `xₘ₊₁ = kₘ·xₘ − xₘ₋₁`; its first rungs are the §11/§12/§13 controlling
+constants `1, k, k₁k₂−1, k₁k₂k₃−k₁−k₃`. -/
+def Continuant : List ℤ → ℤ
+  | [] => 1
+  | [k] => k
+  | k₁ :: k₂ :: ks => k₁ * Continuant (k₂ :: ks) - Continuant ks
+
+/-- The **trailing continuant** — the coefficient of `a` in the closed form for
+the iterated successor.  `secondCont (k :: ks) = K(ks)`, and `secondCont [] = 0`
+(the empty list is the base term `c`, carrying no `a`-contribution).  This
+`0`-base is what fixes the one-element edge case of the continuant recurrence. -/
+def secondCont : List ℤ → ℤ
+  | [] => 0
+  | _ :: ks => Continuant ks
+
+/-- `Continuant` obeys the single-step recurrence
+`K(k :: ks) = k·K(ks) − secondCont ks` in *every* case.  For `ks = []` this reads
+`K([k]) = k·1 − 0 = k`; the `secondCont [] = 0` convention is exactly what makes
+the one-element case agree with the general recurrence (a naive "two shorter
+tails" form would wrongly give `k − 1`). -/
+theorem continuant_cons (k : ℤ) (ks : List ℤ) :
+    Continuant (k :: ks) = k * Continuant ks - secondCont ks := by
+  cases ks with
+  | nil => simp [Continuant, secondCont]
+  | cons r rs => simp [Continuant, secondCont]
+
+/-- The **iterated successor term**.  Starting from consecutive numerators (or
+denominators) `t₀ = a`, `t₁ = c`, `stepSeq a c ks` applies the §9 recurrence
+`tₘ₊₁ = kₘ·tₘ − tₘ₋₁` once per quotient in `ks`, returning the final term
+`t_{|ks|+1}`.  (E.g. `stepSeq a c [k] = k·c − a` is the §9/§11 successor `e`.) -/
+def stepSeq (a c : ℤ) : List ℤ → ℤ
+  | [] => c
+  | k :: ks => stepSeq c (k * c - a) ks
+
+/-- **Continuant closed form for the iterated successor (headline).**  The term
+reached after applying the quotient list `ks` to a consecutive pair `(a, c)` is
+`stepSeq a c ks = K(ks)·c − secondCont(ks)·a`.  This collapses the per-length
+explicit formulas of §11/§12/§13 — `e = k·c − a`, `g = (k₁k₂−1)·c − k₂·a`,
+`i = (k₁k₂k₃−k₁−k₃)·c − (k₂k₃−1)·a` — into a single statement, valid for runs of
+*every* length, with the controlling coefficients reading off the continuant
+ladder. -/
+theorem stepSeq_eq_continuant (ks : List ℤ) (a c : ℤ) :
+    stepSeq a c ks = Continuant ks * c - secondCont ks * a := by
+  induction ks generalizing a c with
+  | nil => simp [stepSeq, Continuant, secondCont]
+  | cons k rest ih =>
+    rw [stepSeq, ih c (k * c - a), continuant_cons k rest]
+    simp only [secondCont]
+    ring
+
+/-- **General endpoint window (run of arbitrary length).**  Running `|ks|`
+successor steps from the consecutive numerator pair `(a, c)` and denominator pair
+`(b, d)` reaches endpoint numerator `pₘ = stepSeq a c ks` and denominator
+`qₘ = stepSeq b d ks`, and the §10/§11 product `(a − pₘ)·(b − qₘ)` factors as
+`((1+secondCont ks)·a − K·c)·((1+secondCont ks)·b − K·d)` with `K = Continuant ks`.
+So the endpoints of a length-`(|ks|+1)` run are similarly ordered iff this one
+continuant-controlled product is nonnegative — the §11/§12/§13 windows being
+`|ks| = 1, 2, 3`. -/
+theorem endpoint_window (ks : List ℤ) (a b c d : ℤ) :
+    (a - stepSeq a c ks) * (b - stepSeq b d ks)
+      = ((1 + secondCont ks) * a - Continuant ks * c)
+        * ((1 + secondCont ks) * b - Continuant ks * d) := by
+  rw [stepSeq_eq_continuant, stepSeq_eq_continuant]; ring
+
+/-- **General run endpoint criterion.**  If a `|ks|`-step run from `a/b, c/d`
+reaches endpoint `p/q` with `(p : ℤ) = stepSeq a c ks` and `(q : ℤ) = stepSeq b d ks`,
+then the endpoints `a/b, p/q` are similarly ordered **iff** the continuant window
+`((1+secondCont ks)·a − K·c)·((1+secondCont ks)·b − K·d) ≥ 0` holds, where
+`K = Continuant ks`.  Specializing `ks = [k]`, `[k₁,k₂]`, `[k₁,k₂,k₃]` recovers
+`simOrd_outer_iff`, `simOrd_long_iff`, `simOrd_long3_iff` respectively. -/
+theorem simOrd_run_iff {a b c d p q : ℕ} {ks : List ℤ}
+    (hp : (p : ℤ) = stepSeq (a : ℤ) (c : ℤ) ks)
+    (hq : (q : ℤ) = stepSeq (b : ℤ) (d : ℤ) ks) :
+    SimOrd a b p q ↔
+      ((1 + secondCont ks) * (a : ℤ) - Continuant ks * (c : ℤ))
+        * ((1 + secondCont ks) * (b : ℤ) - Continuant ks * (d : ℤ)) ≥ 0 := by
+  rw [simOrd_iff_prod, hp, hq, endpoint_window]
+
+-- The continuant ladder: rungs 0–3 are the §11/§12/§13 controlling constants.
+
+/-- Rung 0: `K([]) = 1`. -/
+theorem continuant_nil : Continuant [] = 1 := rfl
+
+/-- Rung 1: `K([k]) = k` — the §11 single-step depth. -/
+theorem continuant_one (k : ℤ) : Continuant [k] = k := rfl
+
+/-- Rung 2: `K([k₁,k₂]) = k₁k₂ − 1` — the §12 Stern–Brocot product. -/
+theorem continuant_two (k₁ k₂ : ℤ) : Continuant [k₁, k₂] = k₁ * k₂ - 1 := by
+  simp [continuant_cons, continuant_nil, secondCont]
+
+/-- Rung 3: `K([k₁,k₂,k₃]) = k₁k₂k₃ − k₁ − k₃` — the §13 continuant. -/
+theorem continuant_three (k₁ k₂ k₃ : ℤ) :
+    Continuant [k₁, k₂, k₃] = k₁ * k₂ * k₃ - k₁ - k₃ := by
+  rw [continuant_cons, continuant_two]; simp [secondCont, continuant_one]; ring
+
+/-- Trailing continuant, rung 1: `secondCont [k] = 1` — the §11 coefficient of `a`
+(`e = k·c − 1·a`). -/
+theorem secondCont_one (k : ℤ) : secondCont [k] = 1 := rfl
+
+/-- Trailing continuant, rung 2: `secondCont [k₁,k₂] = k₂` — the §12 coefficient of
+`a` (`g = (k₁k₂−1)·c − k₂·a`). -/
+theorem secondCont_two (k₁ k₂ : ℤ) : secondCont [k₁, k₂] = k₂ := rfl
+
+/-- Trailing continuant, rung 3: `secondCont [k₁,k₂,k₃] = k₂k₃ − 1` — the §13
+coefficient of `a` (`i = (k₁k₂k₃−k₁−k₃)·c − (k₂k₃−1)·a`). -/
+theorem secondCont_three (k₁ k₂ k₃ : ℤ) : secondCont [k₁, k₂, k₃] = k₂ * k₃ - 1 := by
+  simp [secondCont, continuant_two]
+
+/-- **Subsumption check (length-3 / §11).**  The general endpoint window at
+`ks = [k]` is exactly the §11 outer window `(2a − k·c)·(2b − k·d)`: with one step
+`p = stepSeq a c [k] = k·c − a`, so `a − p = 2a − k·c`. -/
+theorem endpoint_window_one (k a b c d : ℤ) :
+    (a - stepSeq a c [k]) * (b - stepSeq b d [k])
+      = (2 * a - k * c) * (2 * b - k * d) := by
+  rw [endpoint_window, secondCont_one, continuant_one]; ring
+
+/-- **Subsumption check (length-4 / §12).**  At `ks = [k₁,k₂]` the general window
+is the §12 long window `((k₂+1)a − (k₁k₂−1)c)·((k₂+1)b − (k₁k₂−1)d)`. -/
+theorem endpoint_window_two (k₁ k₂ a b c d : ℤ) :
+    (a - stepSeq a c [k₁, k₂]) * (b - stepSeq b d [k₁, k₂])
+      = ((k₂ + 1) * a - (k₁ * k₂ - 1) * c)
+        * ((k₂ + 1) * b - (k₁ * k₂ - 1) * d) := by
+  rw [endpoint_window, secondCont_two, continuant_two]; ring
+
+/-- **Subsumption check (length-5 / §13).**  At `ks = [k₁,k₂,k₃]` the general
+window is the §13 continuant window
+`(k₂k₃·a − (k₁k₂k₃−k₁−k₃)c)·(k₂k₃·b − (k₁k₂k₃−k₁−k₃)d)`. -/
+theorem endpoint_window_three (k₁ k₂ k₃ a b c d : ℤ) :
+    (a - stepSeq a c [k₁, k₂, k₃]) * (b - stepSeq b d [k₁, k₂, k₃])
+      = ((k₂ * k₃) * a - (k₁ * k₂ * k₃ - k₁ - k₃) * c)
+        * ((k₂ * k₃) * b - (k₁ * k₂ * k₃ - k₁ - k₃) * d) := by
+  rw [endpoint_window, secondCont_three, continuant_three]; ring
+
 end Erdos1005OQ02

--- a/research/problems/erdos-1005-oq-02/sessions/2026-06-27-s14-continuant-general-run-criterion.md
+++ b/research/problems/erdos-1005-oq-02/sessions/2026-06-27-s14-continuant-general-run-criterion.md
@@ -1,0 +1,71 @@
+# Session s14 — The continuant: a run-length criterion for *every* length
+
+**Date**: 2026-06-27
+**Researcher**: researcher-4
+**Phase**: FORMALIZED (verified infrastructure; the open `1/12` constant remains open)
+**Build**: `lake env lean` against the shared main-repo Mathlib `.olean` cache
+(worktree `proofs/.lake` symlinks to `proofs/.lake`); Docker still down.
+
+## Goal
+
+Execute the iteration-13 "Next Action": replace the per-length §11/§12/§13 run
+windows by ONE statement valid for arbitrary run length, via a `Continuant`
+definition and a closed form for the iterated §9 Farey successor.
+
+## What was added (§14, 0-sorry / 0-axiom)
+
+Three definitions + ten theorems. `#print axioms` reports only
+`propext / Classical.choice / Quot.sound` on every new theorem.
+
+### Definitions
+- `Continuant : List ℤ → ℤ` — minus-sign continuant, head-two-element recurrence
+  `K(k₁ :: k₂ :: ks) = k₁·K(k₂ :: ks) − K(ks)`, bases `K([])=1`, `K([k])=k`.
+- `secondCont : List ℤ → ℤ` — trailing continuant (coefficient of `a`):
+  `secondCont (k::ks) = K(ks)`, `secondCont [] = 0`.
+- `stepSeq a c ks` — the iterated successor: applies `tₘ₊₁ = kₘ·tₘ − tₘ₋₁` once
+  per quotient in `ks` to the consecutive pair `(a,c)`, returning `t_{|ks|+1}`.
+
+### Theorems
+- `continuant_cons` — the **unified** single-step recurrence
+  `K(k::ks) = k·K(ks) − secondCont ks`, valid in *every* case. Key subtlety: the
+  naive "two shorter tails" recurrence `K(k::ks) = k·K(ks) − K(ks.tail)` is WRONG
+  at `ks = []` (it gives `k·1 − K([]) = k−1` instead of `k`). The `secondCont []
+  = 0` convention is exactly the `K₋₁ = 0` index convention of classical
+  continuants, and repairs the edge case.
+- `stepSeq_eq_continuant` (**headline**) — closed form
+  `stepSeq a c ks = K(ks)·c − secondCont(ks)·a`, by induction on `ks` (generalizing
+  `a c`), one `continuant_cons` rewrite + `ring` in the step.
+- `endpoint_window` — `(a − pₘ)(b − qₘ)` factors as the continuant window
+  `((1+secondCont ks)a − K·c)·((1+secondCont ks)b − K·d)` (pure `ring` after the
+  closed form).
+- `simOrd_run_iff` (**headline**) — endpoints of a length-`(|ks|+1)` run are
+  `SimOrd` **iff** that single window is `≥ 0`. Proof is `rw [simOrd_iff_prod, hp,
+  hq, endpoint_window]`.
+- Ladder checks `continuant_two/_three`, `secondCont_one/_two/_three`: reproduce
+  the §11/§12/§13 constants `1, k, k₁k₂−1, k₁k₂k₃−k₁−k₃` and `a`-coefficients
+  `1, k₂, k₂k₃−1`.
+- Subsumption checks `endpoint_window_one/_two/_three`: the general window
+  *literally specializes* (by `ring`) to the §11 `(2a−kc)`, §12
+  `((k₂+1)a−(k₁k₂−1)c)`, §13 `(k₂k₃·a−(k₁k₂k₃−k₁−k₃)c)` windows at `|ks|=1,2,3`.
+
+## File delta
+
+`Erdos1005ProblemOQ02.lean`: 1146 → 1317 lines, 57 → 71 theorems, 2 → 5 defs.
+
+## Honest boundary
+
+This is the *structural* run criterion. It does NOT bound the density of
+quotient values for which the windows hold — that density count is the actual
+`1/12`–`1/4` optimization and remains open. The gain is that the optimization is
+now a single quantified statement (continuant positivity over a quotient list)
+rather than an unbounded family of per-length inequalities.
+
+## Next action
+
+Density side. With `simOrd_run_iff` reducing runs to continuant positivity:
+(1) prove `K(ks) ≥ 1`, `secondCont ks ≥ 0` for all-`≥1` quotient lists (induction
+on `continuant_cons`) to certify the windows' sign structure; (2) characterize,
+via the continuant, which quotient lists keep ALL non-adjacent windows
+nonnegative — isolating the extremal configurations a density count toward
+`1/12` must sum over. The continuant matrix `[[k,−1],[1,0]]` product gives `K` a
+determinant/Cassini handle.

--- a/research/problems/erdos-1005-oq-02/state.md
+++ b/research/problems/erdos-1005-oq-02/state.md
@@ -2,7 +2,7 @@
 
 **Phase**: FORMALIZED (verified infrastructure; open problem itself remains open)
 **Since**: 2026-06-25
-**Iteration**: 7
+**Iteration**: 14
 
 ## Current Focus
 
@@ -165,19 +165,65 @@ worktree Mathlib `.olean` cache — Docker `docker info` hangs). Two theorems:
 
 File: 1017 → 1146 lines, 55 → 57 theorems, 2 defs (no new def).
 
+## Iteration 14 addition (verified, 0-axiom — `lake env lean`, Docker down)
+
+Added **§14 (the continuant — the run-length criterion for *every* length)**,
+0-sorry / 0-axiom (verified by `lake env lean` against the shared main-repo
+Mathlib `.olean` cache — the worktree `proofs/.lake` symlinks to it; `#print
+axioms` reports only propext / Classical.choice / Quot.sound on every new
+theorem). **This delivers the §13 "Next Action" exactly: the per-length §11/§12/
+§13 windows are now ONE statement valid for arbitrary run length.** Three defs +
+ten theorems:
+
+- `Continuant : List ℤ → ℤ` — the minus-sign continuant with the head-two-element
+  recurrence `K(k₁ :: k₂ :: ks) = k₁·K(k₂ :: ks) − K(ks)`, bases `K([])=1`,
+  `K([k])=k`. `secondCont : List ℤ → ℤ` — the trailing continuant (coefficient of
+  `a`), `secondCont (k::ks)=K(ks)`, `secondCont []=0`. The `0`-base is the precise
+  fix for the one-element continuant edge case.
+- `continuant_cons` — the UNIFIED single-step recurrence
+  `K(k::ks) = k·K(ks) − secondCont ks`, holding in *every* case (the naive "two
+  shorter tails" form wrongly gives `k−1` at `ks=[]`; `secondCont []=0` repairs it).
+- `stepSeq a c ks` — the iterated §9 successor, applying `tₘ₊₁=kₘ·tₘ−tₘ₋₁` once
+  per quotient in `ks`.
+- `stepSeq_eq_continuant` (**headline**) — the closed form
+  `stepSeq a c ks = K(ks)·c − secondCont(ks)·a`, proved by induction on `ks`
+  (the §13-targeted general term formula). Collapses `e=k·c−a`,
+  `g=(k₁k₂−1)·c−k₂·a`, `i=(k₁k₂k₃−k₁−k₃)·c−(k₂k₃−1)·a` into one line.
+- `endpoint_window` — the general endpoint product factors as
+  `(a−pₘ)(b−qₘ) = ((1+secondCont ks)a − K·c)·((1+secondCont ks)b − K·d)`.
+- `simOrd_run_iff` (**headline**) — a length-`(|ks|+1)` run's endpoints `a/b, p/q`
+  (`p=stepSeq a c ks`, `q=stepSeq b d ks`) are similarly ordered **iff** that one
+  continuant-controlled window is `≥ 0`. The run-length criterion as a continuant
+  positivity condition — the structural form the §13 Next Action called for.
+- Ladder/subsumption checks: `continuant_two/_three`, `secondCont_one/_two/_three`
+  reproduce the §11/§12/§13 constants `1,k,k₁k₂−1,k₁k₂k₃−k₁−k₃` and coefficients
+  `1,k₂,k₂k₃−1`; `endpoint_window_one/_two/_three` prove the general window
+  *literally specializes* to the §11 `(2a−kc)`, §12 `((k₂+1)a−(k₁k₂−1)c)`, §13
+  `(k₂k₃·a−(k₁k₂k₃−k₁−k₃)c)` windows at `|ks|=1,2,3`.
+
+File: 1146 → 1317 lines, 57 → 71 theorems, 2 → 5 defs.
+
+**Honest boundary (unchanged).** This is the structural run criterion; it does
+*not* bound the density of `k`-values for which the windows hold, which is the
+actual `1/12`–`1/4` optimization. What §14 buys is that the optimization is now a
+single quantified statement (continuant positivity over a quotient list) rather
+than an unbounded family of per-length inequalities.
+
 ## Next Action
 
-Generalize the continuant pattern to arbitrary run length by induction over a
-list of quotients `[k₁,…,kₘ]`: the §11/§12/§13 ladder shows the m-th term is
-`tₘ = K(k₁,…,k_{m−1})·c − K(k₂,…,k_{m−1})·a` (continuant coefficients), so the
-endpoint window is `((1+K(k₂..))·a − K(k₁..)·c)·(…) ≥ 0`. A Lean `Continuant`
-definition with the recurrence `K(k :: ks) = k·K(ks) − K(ks.tail)` plus the
-matrix-product identity would convert the per-length explicit lemmas into ONE
-general statement — the run-length criterion as a continuant positivity
-condition, the structural form needed before bounding the `1/12` density.
+Bound the *density* side. With `simOrd_run_iff` the run-length criterion is a
+continuant positivity condition `((1+secondCont ks)a − K(ks)c)·(…) ≥ 0` over a
+quotient list `ks`. Two concrete next Lean targets: (1) **continuant positivity /
+monotonicity** — prove `K(ks) ≥ 1` (and `secondCont ks ≥ 0`) for all-`≥1`
+quotient lists by induction on `continuant_cons`, certifying the windows' sign
+structure; (2) **a "no long all-`k=1` run" or "break forced by a large quotient"
+lemma** — characterize, via the continuant, which quotient lists keep ALL
+non-adjacent windows nonnegative, isolating the extremal configurations that a
+density count toward `1/12` must sum over. The continuant matrix identity
+`[[k,−1],[1,0]]` product would give `K` a determinant/Cassini handle.
 
 ## Attempt Counts
 
-- Total attempts: 4
-- Current approach attempts: 4
+- Total attempts: 5
+- Current approach attempts: 5
 - Approaches tried: 1

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -5,12 +5,12 @@
   "title": "Mediant Insertion and the Farey Gap Calculus: The Mediant Is the Unique Smallest-Denominator Fraction in a Gap",
   "description": "A self-contained, axiom-free formalization of the exact arithmetic of mediant insertion — the operation that refines the Farey sequence F_n into F_{n+1} by inserting, between adjacent fractions a/b < c/d, their mediant (a+c)/(b+d). Two threads are proved. First, the gap-splitting calculus: a unimodular gap of size 1/(bd) is split by its mediant into a left sub-gap 1/(b(b+d)) and a right sub-gap 1/(d(b+d)); these sum back to 1/(bd), stand in ratio d:b, and each is strictly smaller than the whole. Second, the headline minimal-denominator theorem: any fraction p/q strictly between two unimodular neighbours has denominator q ≥ b+d, and equality forces p/q = (a+c)/(b+d) exactly. Hence the mediant is the unique fraction of smallest denominator inside any Farey gap, and b+d is a hard lower bound on refining it — no construction can introduce a fraction of smaller denominator. The parent entry (Erdős #1005) records the open lower bound f(n) ≥ (1/12−o(1))n on runs of similarly ordered Farey fractions; that constant remains open and is NOT addressed here. This entry formalizes the verified mediant calculus on which such lower-bound constructions are built.",
   "leanFile": {
-    "lineCount": 1146,
+    "lineCount": 1317,
     "axiomCount": 0,
     "path": "Proofs/Erdos1005ProblemOQ02.lean",
     "sorries": 0,
-    "definitionCount": 2,
-    "theoremCount": 57
+    "definitionCount": 5,
+    "theoremCount": 71
   },
   "meta": {
     "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot mediant theory)",


### PR DESCRIPTION
## Summary

Executes the iteration-13 **Next Action** for Erdős #1005 (OQ-02): replaces the per-length §11/§12/§13 *similar-ordering run* windows with a **single statement valid for arbitrary run length**, via a `Continuant : List ℤ → ℤ` and a closed form for the iterated §9 Farey successor.

All new content is **0-sorry / 0-axiom** — `#print axioms` reports only `propext / Classical.choice / Quot.sound` on every new theorem (verified by `lake env lean` against the shared Mathlib `.olean` cache; Docker build host is down).

## New (§14): 3 defs + 10 theorems

- **`Continuant`** — the minus-sign continuant, recurrence `K(k₁ :: k₂ :: ks) = k₁·K(k₂ :: ks) − K(ks)`, bases `K([])=1`, `K([k])=k`. **`secondCont`** — trailing continuant (`a`-coefficient), `secondCont (k::ks)=K(ks)`, `secondCont []=0`.
- **`continuant_cons`** — the unified single-step recurrence `K(k::ks) = k·K(ks) − secondCont ks`, valid in *every* case. (The naive "two shorter tails" form gives `k−1` at `ks=[]`; the `secondCont []=0` convention — the classical `K₋₁=0` index — repairs it.)
- **`stepSeq`** — the iterated successor `tₘ₊₁ = kₘ·tₘ − tₘ₋₁`, one step per quotient.
- **`stepSeq_eq_continuant`** (headline) — closed form `stepSeq a c ks = K(ks)·c − secondCont(ks)·a`, by induction on `ks`. Collapses `e=k·c−a`, `g=(k₁k₂−1)·c−k₂·a`, `i=(k₁k₂k₃−k₁−k₃)·c−(k₂k₃−1)·a` into one line.
- **`endpoint_window`** + **`simOrd_run_iff`** (headline) — a length-`(|ks|+1)` run's endpoints are similarly ordered **iff** one continuant-controlled window is `≥ 0`. The run-length criterion as a continuant positivity condition.
- **Subsumption checks** `endpoint_window_one/_two/_three` prove the general window *literally specializes* to the §11 `(2a−kc)`, §12 `((k₂+1)a−(k₁k₂−1)c)`, §13 `(k₂k₃·a−(k₁k₂k₃−k₁−k₃)c)` windows at `|ks|=1,2,3`; `continuant_two/_three`, `secondCont_one/_two/_three` reproduce the ladder constants.

## File delta

`Erdos1005ProblemOQ02.lean`: 1146 → 1317 lines, 57 → 71 theorems, 2 → 5 defs.

## Honest boundary

This is the **structural** run criterion; it does **not** bound the density of quotient values for which the windows hold — that density count is the actual `1/12`–`1/4` optimization and **remains open**. The gain is that the optimization is now a single quantified statement (continuant positivity over a quotient list) rather than an unbounded family of per-length inequalities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)