### PR TITLE
research(binomial-theorem-oq-05-oq-02): AM–GM via Bernoulli termwise — the first-order-truncation route [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ05OQ02.lean
+++ b/proofs/Proofs/BinomialTheoremOQ05OQ02.lean
@@ -1,0 +1,175 @@
+/-
+# AM–GM from Bernoulli: the first-order-truncation route
+
+**Open Question (binomial-theorem-oq-05-oq-02).** The parent entry
+`binomial-theorem-oq-05` proved Bernoulli's inequality `1 + n·a ≤ (1 + a)ⁿ` as
+the *first-order truncation* of the binomial expansion. The follow-up asks:
+does that same viewpoint give a clean Lean proof of the AM–GM inequality, the
+way Bernoulli "applied termwise" classically yields it?
+
+**Answer: yes.** The unweighted AM–GM inequality
+
+  `∏ xᵢ ≤ (mean xᵢ)ⁿ`            (`amgm_list`)
+
+falls out of a single list induction whose *only* analytic input is the
+gallery's Bernoulli inequality in tangent-line form `1 + n·(r − 1) ≤ rⁿ`
+(`bernoulli_pow`, i.e. Mathlib's `one_add_mul_sub_le_pow`). There are **no
+logarithms, no convexity of `exp`, no Jensen inequality** — in pointed contrast
+to Mathlib's `Real.geom_mean_le_arith_mean_weighted`, whose proof routes through
+`convexOn_exp.map_sum_le`. The whole argument is the elementary
+"`A_{n+1}^{n+1} ≥ A_n^n · x_{n+1}` via Bernoulli" induction step.
+
+**What this file proves.**
+- `bernoulli_pow` — tangent-line Bernoulli (the kernel), from the parent's theme.
+- `amgm_step` — the inductive heart: `x · Aₜⁿ ≤ A^{n+1}` whenever
+  `(n+1)·A = x + n·Aₜ`. This is *pure* Bernoulli.
+- `amgm_list` — unweighted AM–GM for a list of nonnegative reals.
+- `amgm_prod_le` — the same as a clean `∏ ≤ (∑/n)ⁿ` over `Finset` indices.
+- Numeric witnesses (two- and three-variable AM–GM as instant corollaries).
+
+All results are fully verified: 0 sorries, 0 axioms.
+-/
+import Mathlib
+
+namespace BinomialTheoremOQ05OQ02
+
+open scoped BigOperators
+
+/-! ## The kernel: tangent-line Bernoulli -/
+
+/-- **Bernoulli, tangent-line form** (the gallery's `bernoulli_pow`). For
+`r ≥ -1` and any `n : ℕ`, `1 + n·(r − 1) ≤ rⁿ`: the tangent line to `t ↦ tⁿ` at
+`t = 1` lies below the curve. This single inequality is the *only* analytic
+ingredient of the AM–GM proof below. -/
+theorem bernoulli_pow {r : ℝ} (hr : -1 ≤ r) (n : ℕ) : 1 + n * (r - 1) ≤ r ^ n :=
+  one_add_mul_sub_le_pow hr n
+
+/-! ## The inductive heart -/
+
+/-- **The Bernoulli step.** Splicing a new nonnegative term `x` into a sample
+whose previous mean was `Aₜ ≥ 0`, giving the new mean `A`, satisfies
+`x · Aₜⁿ ≤ A^{n+1}`, provided the means obey the bookkeeping identity
+`(n+1)·A = x + n·Aₜ`.
+
+This is exactly Bernoulli: dividing through by `Aₜ^{n+1}` (when `Aₜ > 0`) turns
+the claim into `(n+1)·r − n ≤ r^{n+1}` with `r = A/Aₜ`, which is
+`bernoulli_pow` rearranged. -/
+theorem amgm_step {n : ℕ} {x At A : ℝ} (_hx : 0 ≤ x) (hAt : 0 ≤ At) (hA : 0 ≤ A)
+    (hrel : ((n : ℝ) + 1) * A = x + n * At) : x * At ^ n ≤ A ^ (n + 1) := by
+  rcases eq_or_lt_of_le hAt with hAt0 | hAtpos
+  · -- Degenerate case `Aₜ = 0`: the previous sample was all zeros.
+    rcases n with _ | m
+    · -- `n = 0`: then `A = x`, and both sides equal `x`.
+      simp only [Nat.cast_zero, zero_add, one_mul, zero_mul, add_zero, pow_zero,
+        mul_one, pow_one] at hrel ⊢
+      linarith
+    · -- `n = m+1 ≥ 1`: `Aₜⁿ = 0`, so the left side is `0 ≤ A^{n+1}`.
+      have h0 : At ^ (m + 1) = 0 := by rw [← hAt0]; simp
+      rw [h0, mul_zero]
+      exact pow_nonneg hA _
+  · -- Main case `Aₜ > 0`: rescale by `r = A / Aₜ` and apply Bernoulli.
+    have hAtne : At ≠ 0 := ne_of_gt hAtpos
+    set r : ℝ := A / At with hr_def
+    have hr0 : 0 ≤ r := div_nonneg hA hAt
+    have hArAt : A = r * At := by rw [hr_def]; exact (div_mul_cancel₀ A hAtne).symm
+    -- The bookkeeping identity in terms of `r`: `x = ((n+1)·r − n)·Aₜ`.
+    have hx_eq : x = (((n : ℝ) + 1) * r - n) * At := by
+      have h : ((n : ℝ) + 1) * (r * At) = x + n * At := by rw [← hArAt]; exact hrel
+      nlinarith [h]
+    -- Bernoulli: `(n+1)·r − n ≤ r^{n+1}`.
+    have hb : ((n : ℝ) + 1) * r - n ≤ r ^ (n + 1) := by
+      have h := bernoulli_pow (by linarith : (-1 : ℝ) ≤ r) (n + 1)
+      push_cast at h
+      linarith [h]
+    -- Assemble: both sides carry the common factor `Aₜ^{n+1} ≥ 0`.
+    have hpow : (0 : ℝ) ≤ At ^ (n + 1) := by positivity
+    calc x * At ^ n
+        = (((n : ℝ) + 1) * r - n) * At ^ (n + 1) := by rw [hx_eq]; ring
+      _ ≤ r ^ (n + 1) * At ^ (n + 1) := mul_le_mul_of_nonneg_right hb hpow
+      _ = A ^ (n + 1) := by rw [hArAt, mul_pow]
+
+/-! ## Unweighted AM–GM -/
+
+/-- **Unweighted AM–GM, list form.** For a list `l` of nonnegative reals,
+`∏ l ≤ (mean l)^(length l)`, where `mean l = (∑ l) / (length l)`. Proved by a
+single induction on `l`, the cons-step being `amgm_step` — i.e. pure Bernoulli.
+The empty list gives `1 ≤ (0/0)^0 = 1`. -/
+theorem amgm_list (l : List ℝ) (hl : ∀ x ∈ l, 0 ≤ x) :
+    l.prod ≤ (l.sum / l.length) ^ l.length := by
+  induction l with
+  | nil => simp
+  | cons x t ih =>
+    have hx : 0 ≤ x := hl x (by simp)
+    have ht : ∀ y ∈ t, 0 ≤ y := fun y hy => hl y (by simp [hy])
+    have hts : 0 ≤ t.sum := List.sum_nonneg ht
+    have ih' : t.prod ≤ (t.sum / t.length) ^ t.length := ih ht
+    have hAt : (0 : ℝ) ≤ t.sum / t.length := div_nonneg hts (by positivity)
+    have hA : (0 : ℝ) ≤ (x + t.sum) / ((t.length : ℝ) + 1) :=
+      div_nonneg (by linarith) (by positivity)
+    -- `n·Aₜ = ∑ t`, handling the empty tail separately.
+    have hnAt : (t.length : ℝ) * (t.sum / t.length) = t.sum := by
+      rcases Nat.eq_zero_or_pos t.length with h0 | hpos
+      · have ht0 : t = [] := List.length_eq_zero_iff.mp h0
+        simp [ht0]
+      · have hne : (t.length : ℝ) ≠ 0 := by positivity
+        field_simp
+    -- Bookkeeping identity feeding `amgm_step`.
+    have hrel : ((t.length : ℝ) + 1) * ((x + t.sum) / ((t.length : ℝ) + 1))
+        = x + t.length * (t.sum / t.length) := by
+      rw [hnAt]
+      have hne : ((t.length : ℝ) + 1) ≠ 0 := by positivity
+      field_simp
+    have step : x * (t.sum / t.length) ^ t.length
+        ≤ ((x + t.sum) / ((t.length : ℝ) + 1)) ^ (t.length + 1) :=
+      amgm_step (n := t.length) hx hAt hA hrel
+    calc (x :: t).prod
+        = x * t.prod := List.prod_cons
+      _ ≤ x * (t.sum / t.length) ^ t.length := mul_le_mul_of_nonneg_left ih' hx
+      _ ≤ ((x + t.sum) / ((t.length : ℝ) + 1)) ^ (t.length + 1) := step
+      _ = ((x :: t).sum / (x :: t).length) ^ (x :: t).length := by
+          rw [List.sum_cons, List.length_cons]; push_cast; ring_nf
+
+/-! ## Multiplicative `Finset` form -/
+
+/-- **Unweighted AM–GM, `Finset` form.** For nonnegative reals `z i` indexed by
+a `Finset s` of size `n`, `∏ z ≤ (∑ z / n)ⁿ`. This is `amgm_list` transported
+along `s.toList`. -/
+theorem amgm_prod_le {ι : Type*} (s : Finset ι) (z : ι → ℝ)
+    (hz : ∀ i ∈ s, 0 ≤ z i) :
+    ∏ i ∈ s, z i ≤ ((∑ i ∈ s, z i) / s.card) ^ s.card := by
+  have hmap : ∀ x ∈ s.toList.map z, 0 ≤ x := by
+    intro x hx
+    simp only [List.mem_map, Finset.mem_toList] at hx
+    obtain ⟨i, hi, rfl⟩ := hx
+    exact hz i hi
+  have key := amgm_list (s.toList.map z) hmap
+  rwa [Finset.prod_map_toList, Finset.sum_map_toList,
+    List.length_map, Finset.length_toList] at key
+
+/-! ## Numeric witnesses -/
+
+/-- Two-variable AM–GM `√(ab) ≤ (a+b)/2`, here as `ab ≤ ((a+b)/2)²`, is just
+`amgm_list [a, b]` — i.e. straight from Bernoulli with `n = 2`. -/
+example (a b : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) : a * b ≤ ((a + b) / 2) ^ 2 := by
+  have h := amgm_list [a, b] (by
+    intro x hx
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hx
+    rcases hx with rfl | rfl <;> assumption)
+  simpa using h
+
+/-- Three-variable AM–GM `abc ≤ ((a+b+c)/3)³`. -/
+example (a b c : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) :
+    a * b * c ≤ ((a + b + c) / 3) ^ 3 := by
+  have h := amgm_list [a, b, c] (by
+    intro x hx
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hx
+    rcases hx with rfl | rfl | rfl <;> assumption)
+  simp only [List.prod_cons, List.prod_nil, mul_one, List.sum_cons, List.sum_nil,
+    add_zero, List.length_cons, List.length_nil] at h
+  norm_num at h ⊢
+  linarith [h]
+
+/-- A concrete instance: `2·4·8 = 64 ≤ ((2+4+8)/3)³ = (14/3)³ ≈ 101.6`. -/
+example : (2 : ℝ) * 4 * 8 ≤ ((2 + 4 + 8) / 3) ^ 3 := by norm_num
+
+end BinomialTheoremOQ05OQ02

--- a/src/data/proofs/binomial-theorem-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-05-oq-02/annotations.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "amgm-bernoulli-context",
+    "proofId": "binomial-theorem-oq-05-oq-02",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "concept",
+    "title": "AM–GM as Bernoulli Applied Termwise",
+    "content": "The parent entry proved Bernoulli's inequality as the first-order truncation of the binomial expansion and asked whether that viewpoint yields a clean Lean proof of AM–GM. It does. With Aₙ = (1/n)∑ xᵢ the running arithmetic mean, the only fact needed is that appending one term satisfies A_{n+1}^{n+1} ≥ Aₙⁿ·x_{n+1}, which is exactly Bernoulli at exponent n+1 with ratio r = A_{n+1}/Aₙ. A single induction then gives ∏ xᵢ ≤ Aₙⁿ — with no logarithms, convexity of exp, or Jensen inequality.",
+    "mathContext": "Mathlib proves AM–GM (`Real.geom_mean_le_arith_mean_weighted`) via Jensen's inequality for the convex exponential, $\\prod z_i^{w_i} = \\exp(\\sum w_i \\log z_i) \\le \\sum w_i z_i$. The Bernoulli route taken here is log-free: it uses only the tangent-line estimate $1 + n(r-1) \\le r^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "AM–GM inequality",
+      "Bernoulli's inequality",
+      "tangent-line method",
+      "convexity of exp (the route avoided)"
+    ],
+    "prerequisites": [
+      "Bernoulli's inequality",
+      "arithmetic and geometric means"
+    ]
+  },
+  {
+    "id": "kernel",
+    "proofId": "binomial-theorem-oq-05-oq-02",
+    "range": { "startLine": 38, "endLine": 45 },
+    "type": "theorem",
+    "title": "Tangent-Line Bernoulli (the Kernel)",
+    "content": "bernoulli_pow re-exports Mathlib's one_add_mul_sub_le_pow: for r ≥ -1, 1 + n·(r−1) ≤ rⁿ. This is the only analytic ingredient consumed by the entire AM–GM proof below.",
+    "mathContext": "Geometrically, the graph of $t \\mapsto t^n$ lies above its tangent line at $t = 1$. The slack $r^n - (1 + n(r-1))$ is the discarded binomial tail $\\binom{n}{2}(r-1)^2 + \\cdots$, which is the geometric-vs-arithmetic mean gap.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "one_add_mul_sub_le_pow",
+      "tangent line to tⁿ"
+    ],
+    "prerequisites": [
+      "Bernoulli's inequality, power form"
+    ]
+  },
+  {
+    "id": "amgm-step",
+    "proofId": "binomial-theorem-oq-05-oq-02",
+    "range": { "startLine": 47, "endLine": 89 },
+    "type": "theorem",
+    "title": "The Inductive Heart: x·Aₜⁿ ≤ A^{n+1}",
+    "content": "amgm_step proves x·Aₜⁿ ≤ A^{n+1} whenever (n+1)·A = x + n·Aₜ — the only place Bernoulli is used. Rescaling by r = A/Aₜ turns the bookkeeping identity into x = ((n+1)r − n)·Aₜ, so x·Aₜⁿ = ((n+1)r − n)·Aₜ^{n+1}; Bernoulli gives (n+1)r − n ≤ r^{n+1}, and multiplying by Aₜ^{n+1} ≥ 0 finishes. The degenerate Aₜ = 0 case is handled directly.",
+    "mathContext": "Dividing the target $x \\cdot A_t^n \\le A^{n+1}$ by $A_t^{n+1} > 0$ and setting $r = A/A_t$ reduces it to $(n+1)r - n \\le r^{n+1}$, i.e. $1 + (n+1)(r-1) \\le r^{n+1}$ — Bernoulli at exponent $n+1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bernoulli's inequality",
+      "arithmetic mean update",
+      "div_mul_cancel₀"
+    ],
+    "prerequisites": [
+      "ordered-field arithmetic",
+      "monotonicity of multiplication"
+    ]
+  },
+  {
+    "id": "amgm-list",
+    "proofId": "binomial-theorem-oq-05-oq-02",
+    "range": { "startLine": 91, "endLine": 130 },
+    "type": "theorem",
+    "title": "Unweighted AM–GM (List Form)",
+    "content": "amgm_list: for a list l of nonnegative reals, ∏ l ≤ (mean l)^(length l). One induction: the empty list gives 1 ≤ (0/0)⁰ = 1; the cons step multiplies the inductive hypothesis by x ≥ 0 and applies amgm_step, with the mean-bookkeeping identity (n+1)·A = x + n·Aₜ supplied by a short field_simp.",
+    "mathContext": "Phrasing the induction as 'append one term' keeps the bookkeeping to a single linear identity, avoiding the explicit weight renormalization a weighted statement would require. The running mean of the tail is $A_t = (\\sum t)/|t|$ and the new mean is $A = (x + \\sum t)/(|t|+1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "AM–GM inequality",
+      "list induction",
+      "List.sum_nonneg"
+    ],
+    "prerequisites": [
+      "induction over lists"
+    ]
+  },
+  {
+    "id": "amgm-prod-le",
+    "proofId": "binomial-theorem-oq-05-oq-02",
+    "range": { "startLine": 132, "endLine": 147 },
+    "type": "theorem",
+    "title": "Multiplicative Finset Form",
+    "content": "amgm_prod_le: ∏ i ∈ s, z i ≤ (∑ i ∈ s, z i / s.card)^s.card for nonnegative z, transported from amgm_list along s.toList via Finset.prod_map_toList and sum_map_toList. A drop-in elementary alternative to Mathlib's geom_mean inequality for unweighted AM–GM.",
+    "mathContext": "The transport identities $(s.\\mathrm{toList}.\\mathrm{map}\\ f).\\mathrm{prod} = \\prod_{i \\in s} f i$ and the analogous sum/length statements convert the list inequality into the indexed-product form.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.prod_map_toList",
+      "geom_mean_le_arith_mean_weighted (the Mathlib analogue)"
+    ],
+    "prerequisites": [
+      "Finset big operators"
+    ]
+  },
+  {
+    "id": "numeric-witnesses",
+    "proofId": "binomial-theorem-oq-05-oq-02",
+    "range": { "startLine": 149, "endLine": 175 },
+    "type": "example",
+    "title": "Two- and Three-Variable Corollaries",
+    "content": "The two-variable ab ≤ ((a+b)/2)² and three-variable abc ≤ ((a+b+c)/3)³ inequalities are instant specializations of amgm_list to [a,b] and [a,b,c], plus the concrete witness 2·4·8 = 64 ≤ (14/3)³ ≈ 101.6.",
+    "mathContext": "These recover the familiar low-arity AM–GM inequalities as corollaries of the general list statement, illustrating that the Bernoulli induction subsumes the classical cases.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "AM–GM for two/three variables"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-05-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-05-oq-02/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "binomial-theorem-oq-05-oq-02",
+  "title": "AM–GM from Bernoulli: the first-order-truncation route",
+  "slug": "binomial-theorem-oq-05-oq-02",
+  "description": "Answers the open question of binomial-theorem-oq-05: does the first-order-truncation (Bernoulli) viewpoint give a clean Lean proof of AM–GM? Yes — the unweighted AM–GM inequality ∏ xᵢ ≤ (mean)ⁿ falls out of a single list induction whose only analytic input is the tangent-line Bernoulli inequality 1 + n(r−1) ≤ rⁿ. No logarithms, no convexity of exp, no Jensen — in contrast to Mathlib's geom_mean_le_arith_mean_weighted, which routes through convexOn_exp.",
+  "meta": {
+    "author": "Classical (Bernoulli proof of AM–GM); formalized for lean-genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/AM%E2%80%93GM_inequality",
+    "date": "2026-06-27",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ05OQ02.lean",
+    "tags": [
+      "analysis",
+      "inequality",
+      "binomial-theorem",
+      "bernoulli-inequality",
+      "am-gm",
+      "induction",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "one_add_mul_sub_le_pow",
+        "description": "Tangent-line Bernoulli: -1 ≤ a ⟹ 1 + n·(a-1) ≤ aⁿ. The single analytic ingredient of the whole AM–GM proof, re-exported as bernoulli_pow.",
+        "module": "Mathlib.Algebra.Order.Ring.Pow"
+      },
+      {
+        "theorem": "div_mul_cancel₀",
+        "description": "a/b·b = a for b ≠ 0; used to write A = (A/Aₜ)·Aₜ in the rescaling step of amgm_step.",
+        "module": "Mathlib.Algebra.GroupWithZero.Units.Basic"
+      },
+      {
+        "theorem": "List.sum_nonneg",
+        "description": "A list of nonnegative reals has nonnegative sum; gives the nonnegativity of the running mean in the induction.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.List"
+      },
+      {
+        "theorem": "Finset.prod_map_toList",
+        "description": "(s.toList.map f).prod = ∏ i ∈ s, f i; transports the list AM–GM to the Finset form amgm_prod_le.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      },
+      {
+        "theorem": "mul_le_mul_of_nonneg_right",
+        "description": "Monotonicity of multiplication by a nonnegative factor; multiplies the Bernoulli inequality by the common factor Aₜ^{n+1} ≥ 0.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "amgm_step: the Bernoulli inductive step x·Aₜⁿ ≤ A^{n+1} under the mean-bookkeeping identity (n+1)·A = x + n·Aₜ, proved by rescaling to r = A/Aₜ and applying tangent-line Bernoulli — the entire analytic content of AM–GM in one lemma",
+      "amgm_list: unweighted AM–GM ∏ l ≤ (mean l)^(length l) for a list of nonnegative reals, by a single induction whose cons-step is amgm_step; no logarithms, exp-convexity, or Jensen",
+      "amgm_prod_le: the Finset form ∏ z ≤ (∑ z / n)ⁿ, transported along s.toList",
+      "Numeric witnesses: two-variable ab ≤ ((a+b)/2)² and three-variable abc ≤ ((a+b+c)/3)³ as instant corollaries, plus the concrete 64 ≤ (14/3)³",
+      "Methodological answer to OQ-05: the first-order-truncation/Bernoulli viewpoint does give a clean, fully elementary Lean proof of AM–GM, structurally different from Mathlib's convexity-of-exp route"
+    ],
+    "dateAdded": "2026-06-27",
+    "axioms": 0,
+    "axiomCount": 0,
+    "lineCount": 175,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries: #print axioms reports only propext, Classical.choice, Quot.sound for amgm_step, amgm_list, and amgm_prod_le. No sorryAx, no native_decide / Lean.ofReduceBool. Badge `original` reflects that the proof architecture (AM–GM via the tangent-line Bernoulli induction) is supplied here, not imported — Mathlib proves AM–GM only via convexity of exp.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The arithmetic–geometric mean inequality is one of the oldest inequalities in mathematics, with the two-variable case known to the Greeks. Among its many proofs, the *Bernoulli* (or tangent-line) proof is the most elementary: it uses nothing beyond Bernoulli's inequality $1 + n(r-1) \\le r^n$, itself the first-order truncation of the binomial expansion. This is the proof Pólya attributed to a dream, and it avoids the logarithm/exponential machinery used in the convexity (Jensen) proof. Mathlib's `Real.geom_mean_le_arith_mean_weighted` takes the convexity route through `convexOn_exp`; this entry supplies the Bernoulli route instead, directly answering the open question raised by the parent Bernoulli entry binomial-theorem-oq-05.",
+    "problemStatement": "**Open Question (OQ-05-OQ-02):** Does the same first-order-truncation (Bernoulli) viewpoint that yields Bernoulli's inequality give a clean Lean proof of the AM–GM inequality, the way Bernoulli \"applied termwise\" classically does?\n\n**Answer:** Yes. With $A_n = \\frac{1}{n}\\sum_{i\\le n} x_i$ the running arithmetic mean, the inductive step $A_{n+1}^{\\,n+1} \\ge A_n^{\\,n}\\, x_{n+1}$ is *exactly* Bernoulli $1 + (n+1)(r-1) \\le r^{n+1}$ with $r = A_{n+1}/A_n$. A single list induction then gives $\\prod x_i \\le A_n^{\\,n}$, with no logarithms, no convexity of $\\exp$, and no Jensen inequality.",
+    "text": "The geometric mean of nonnegative reals is at most their arithmetic mean. Equivalently, ∏ xᵢ ≤ ((∑ xᵢ)/n)ⁿ. The proof here is the Bernoulli/tangent-line induction: adding one new term to the sample multiplies the product bound by exactly the factor Bernoulli controls.",
+    "proofStrategy": "1. **Kernel** (`bernoulli_pow`): the tangent-line Bernoulli inequality 1 + n·(r−1) ≤ rⁿ for r ≥ -1 (Mathlib's `one_add_mul_sub_le_pow`).\n2. **Inductive step** (`amgm_step`): to show x·Aₜⁿ ≤ A^{n+1} given (n+1)·A = x + n·Aₜ, rescale by r = A/Aₜ. The identity becomes x = ((n+1)r − n)·Aₜ, so x·Aₜⁿ = ((n+1)r − n)·Aₜ^{n+1}; Bernoulli gives (n+1)r − n ≤ r^{n+1}, and multiplying by Aₜ^{n+1} ≥ 0 yields r^{n+1}·Aₜ^{n+1} = A^{n+1}. The degenerate Aₜ = 0 case is handled directly.\n3. **Induction** (`amgm_list`): induct on the list. The empty list gives 1 ≤ (0/0)⁰ = 1; the cons step combines the inductive hypothesis (multiplied by x ≥ 0) with `amgm_step`, the mean-bookkeeping identity (n+1)·A = x + n·Aₜ supplied by a short `field_simp` computation.\n4. **Finset form** (`amgm_prod_le`): transport `amgm_list` along `s.toList` using `Finset.prod_map_toList` / `sum_map_toList`.",
+    "keyInsights": [
+      "**The whole of AM–GM is one Bernoulli step.** The only inequality used is 1 + n(r−1) ≤ rⁿ. Everything else is bookkeeping about how the arithmetic mean updates when one term is appended.",
+      "**Mean update = Bernoulli.** Writing r = A_{n+1}/A_n for the ratio of successive arithmetic means, the required A_{n+1}^{n+1} ≥ A_n^n·x_{n+1} is literally Bernoulli at exponent n+1 — the discarded binomial tail is the slack between geometric and arithmetic mean.",
+      "**A genuinely different proof from Mathlib's.** Mathlib derives AM–GM from Jensen's inequality for the convex function exp (and the logarithm). The Bernoulli proof here is log-free and exp-free, and is arguably more elementary: it needs only ordered-field arithmetic and one tangent-line estimate.",
+      "**Cons-induction avoids weight renormalization.** Phrasing the induction over a list (append one term) keeps the bookkeeping to a single linear identity (n+1)·A = x + n·Aₜ, sidestepping the explicit weight-normalization that the weighted statement would require."
+    ],
+    "prerequisites": [
+      "Bernoulli's inequality in tangent-line form 1 + n·(a−1) ≤ aⁿ (binomial-theorem-oq-05)",
+      "Induction over lists",
+      "Monotonicity of multiplication by nonnegative factors",
+      "Basic ordered-field arithmetic (field_simp, division cancellation)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "kernel",
+      "title": "The Kernel: Tangent-Line Bernoulli",
+      "startLine": 38,
+      "endLine": 45,
+      "summary": "Re-exports Bernoulli in tangent-line form 1 + n·(r−1) ≤ rⁿ for r ≥ -1 — the single analytic ingredient of the AM–GM proof.",
+      "mathContext": "Re-exports Bernoulli in tangent-line form 1 + n·(r−1) ≤ rⁿ for r ≥ -1 — the single analytic ingredient of the AM–GM proof."
+    },
+    {
+      "id": "step",
+      "title": "The Inductive Heart",
+      "startLine": 47,
+      "endLine": 89,
+      "summary": "amgm_step: x·Aₜⁿ ≤ A^{n+1} whenever (n+1)·A = x + n·Aₜ, by rescaling to r = A/Aₜ and applying Bernoulli. This lemma carries all of the inequality's analytic content.",
+      "mathContext": "amgm_step: x·Aₜⁿ ≤ A^{n+1} whenever (n+1)·A = x + n·Aₜ, by rescaling to r = A/Aₜ and applying Bernoulli."
+    },
+    {
+      "id": "amgm",
+      "title": "Unweighted AM–GM",
+      "startLine": 91,
+      "endLine": 130,
+      "summary": "amgm_list: ∏ l ≤ (mean l)^(length l) for a list of nonnegative reals, by one induction whose cons-step is amgm_step.",
+      "mathContext": "amgm_list: ∏ l ≤ (mean l)^(length l) for a list of nonnegative reals, by one induction whose cons-step is amgm_step."
+    },
+    {
+      "id": "finset",
+      "title": "Multiplicative Finset Form",
+      "startLine": 132,
+      "endLine": 147,
+      "summary": "amgm_prod_le: ∏ z ≤ (∑ z / n)ⁿ over Finset indices, transported from amgm_list along s.toList.",
+      "mathContext": "amgm_prod_le: ∏ z ≤ (∑ z / n)ⁿ over Finset indices, transported from amgm_list along s.toList."
+    },
+    {
+      "id": "numeric",
+      "title": "Numeric Witnesses",
+      "startLine": 149,
+      "endLine": 175,
+      "summary": "Two-variable ab ≤ ((a+b)/2)² and three-variable abc ≤ ((a+b+c)/3)³ as instant corollaries, plus the concrete 64 ≤ (14/3)³.",
+      "mathContext": "Two-variable ab ≤ ((a+b)/2)² and three-variable abc ≤ ((a+b+c)/3)³ as instant corollaries."
+    }
+  ],
+  "conclusion": {
+    "summary": "The AM–GM inequality ∏ xᵢ ≤ (mean)ⁿ is proved by a single list induction whose only analytic input is the tangent-line Bernoulli inequality 1 + n(r−1) ≤ rⁿ, with no logarithms, convexity of exp, or Jensen inequality. This answers the open question of binomial-theorem-oq-05: the first-order-truncation viewpoint does give a clean Lean proof of AM–GM. Fully verified: 0 sorries, 0 axioms.",
+    "implications": "The entry records a fully elementary, log-free proof architecture for AM–GM that is structurally distinct from Mathlib's convexity-of-exp route. The single lemma amgm_step isolates the exact point where Bernoulli enters, making transparent the classical slogan that 'AM–GM is Bernoulli applied termwise'. The Finset form amgm_prod_le is directly usable as a drop-in elementary alternative to geom_mean wherever unweighted AM–GM is needed.",
+    "openQuestions": [
+      "Can the rational/natural-weighted AM–GM ∏ xᵢ^{kᵢ} ≤ (∑ kᵢ xᵢ / ∑ kᵢ)^{∑ kᵢ} be obtained from amgm_list by the repeat-with-multiplicity reduction, keeping the proof Bernoulli-only?",
+      "Does the same amgm_step bookkeeping yield the equality case (all xᵢ equal) by tracking when the Bernoulli inequality is strict?"
+    ],
+    "crossReferences": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-05",
+      "relationship": "extends",
+      "description": "Answers OQ-05's closing question — whether the first-order-truncation (Bernoulli) viewpoint gives a clean Lean proof of AM–GM — and reuses its tangent-line Bernoulli inequality as the kernel."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "related",
+      "description": "Bernoulli's inequality, the kernel here, is itself the first-order truncation of the binomial expansion."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators"
+    ],
+    "namespace": "BinomialTheoremOQ05OQ02",
+    "lineCount": 175,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "G. H. Hardy, J. E. Littlewood, G. Pólya",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Classic reference collecting proofs of AM–GM, including the elementary tangent-line/Bernoulli argument."
+    },
+    {
+      "authors": "D. S. Mitrinović",
+      "title": "Analytic Inequalities",
+      "year": "1970",
+      "venue": "Springer-Verlag",
+      "note": "Bernoulli's inequality and its role in deriving AM–GM and the power-mean inequalities."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question posed by the parent entry **binomial-theorem-oq-05** (Bernoulli's inequality): *does the first-order-truncation (Bernoulli) viewpoint give a clean Lean proof of AM–GM, the way Bernoulli "applied termwise" classically does?*

**Yes.** The unweighted AM–GM inequality `∏ xᵢ ≤ (mean)ⁿ` falls out of a **single list induction whose only analytic input is the tangent-line Bernoulli inequality** `1 + n(r−1) ≤ rⁿ`. No logarithms, no convexity of `exp`, no Jensen — in pointed contrast to Mathlib's `Real.geom_mean_le_arith_mean_weighted`, whose proof routes through `convexOn_exp.map_sum_le`.

## Theorems
- **`amgm_step`** — the inductive heart: `x·Aₜⁿ ≤ A^{n+1}` whenever `(n+1)·A = x + n·Aₜ`. Rescaling by `r = A/Aₜ` turns this into `(n+1)r − n ≤ r^{n+1}`, i.e. Bernoulli at exponent `n+1`. This single lemma carries **all** of the inequality's analytic content.
- **`amgm_list`** — unweighted AM–GM `∏ l ≤ (mean l)^(length l)` for a list of nonnegative reals, by one induction whose cons-step is `amgm_step`.
- **`amgm_prod_le`** — the `Finset` form `∏ z ≤ (∑ z / n)ⁿ`, transported along `s.toList`.
- Numeric witnesses: `ab ≤ ((a+b)/2)²`, `abc ≤ ((a+b+c)/3)³`, and `64 ≤ (14/3)³`.

## Verification
Docker daemon was down this session, so verified with host `lake env lean` against the prebuilt Mathlib oleans (single-file, type-checks only — **not** `lake build`):
- **0 sorries**, **0 `axiom` declarations**
- `#print axioms` for `amgm_step`, `amgm_list`, `amgm_prod_le` reports only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.

Status `verified`, badge `original` (the AM–GM-via-Bernoulli proof architecture is supplied here, not imported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)