### PR TITLE
research(sperner-mathlib4-oq-02): sharp door-graph degree formula (degree = #shared doors) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerTuckerDoorGraph.lean
+++ b/proofs/Proofs/SpernerTuckerDoorGraph.lean
@@ -224,4 +224,97 @@ theorem exists_complementary_simplex {B : V → Prop} [DecidablePred B]
   rw [Finset.mem_filter] at hv
   exact ⟨v, hv.2⟩
 
+/-- **Sharp degree formula: degree = number of shared doors.**  `doorGraph_degree_le_two`
+bounds the degree by `2` via the doors of `v`.  Under two clean geometric facts —
+each door joins at most two simplices (`hdoor`) and two distinct simplices share at
+most one door (`hpair`) — the bound is in fact an *equality* with the number of `v`'s
+**shared** doors (doors some *other* simplex also carries):
+
+> `(doorGraph inc).degree v = #{ d | inc v d ∧ ∃ w ≠ v, inc w d }`.
+
+The map "neighbour `w` ↦ the door it shares with `v`" is a bijection onto the shared
+doors: it lands in the shared doors and is injective by `hdoor` (a door joining `v` to
+two neighbours would touch three simplices), and surjective by `hpair` (the door's
+other endpoint is a neighbour whose shared door is forced to be that very door).
+
+This turns "`v` is a path endpoint" (`degree v = 1`) into the purely local door
+statement "`v` has exactly one shared door", which is the interface the geometric
+construction of `inc` targets. -/
+theorem doorGraph_degree_eq_shared
+    (hdoor : ∀ d, #{v | inc v d} ≤ 2)
+    (hpair : ∀ d d' : D, ∀ v w : V, v ≠ w →
+      inc v d → inc w d → inc v d' → inc w d' → d = d')
+    (v : V) :
+    (doorGraph inc).degree v = #{d | inc v d ∧ ∃ w, w ≠ v ∧ inc w d} := by
+  classical
+  rw [← SimpleGraph.card_neighborFinset_eq_degree]
+  set s := (doorGraph inc).neighborFinset v with hs
+  -- Each neighbour shares a door with `v`.
+  have key : ∀ w ∈ s, ∃ d, inc v d ∧ inc w d := by
+    intro w hw
+    rw [hs, SimpleGraph.mem_neighborFinset] at hw
+    exact hw.2
+  -- Each neighbour is distinct from `v`.
+  have hne : ∀ w ∈ s, v ≠ w := by
+    intro w hw
+    rw [hs, SimpleGraph.mem_neighborFinset] at hw
+    exact hw.1
+  rcases isEmpty_or_nonempty D with hD | hD
+  · -- No doors: no neighbours and no shared doors.
+    have h1 : s = ∅ := by
+      rw [Finset.eq_empty_iff_forall_notMem]
+      intro w hw; obtain ⟨d, _, _⟩ := key w hw; exact hD.false d
+    have h2 : ({d | inc v d ∧ ∃ w, w ≠ v ∧ inc w d} : Finset D) = ∅ :=
+      Finset.eq_empty_of_isEmpty _
+    rw [h1, h2, Finset.card_empty, Finset.card_empty]
+  · haveI : Nonempty D := hD
+    -- The shared-door witness map.
+    let g : V → D := fun w =>
+      if h : ∃ d, inc v d ∧ inc w d then h.choose else Classical.arbitrary D
+    have hgspec : ∀ w ∈ s, inc v (g w) ∧ inc w (g w) := by
+      intro w hw
+      have hex := key w hw
+      simp only [g, dif_pos hex]; exact hex.choose_spec
+    refine Finset.card_bij (fun w _ => g w) ?_ ?_ ?_
+    · -- lands in the shared doors
+      intro w hw
+      obtain ⟨hv, hw'⟩ := hgspec w hw
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      exact ⟨hv, w, (hne w hw).symm, hw'⟩
+    · -- injective: a shared door of two neighbours touches three simplices
+      intro w₁ h₁ w₂ h₂ heq
+      dsimp only at heq
+      obtain ⟨hv₁, hw₁⟩ := hgspec w₁ h₁
+      obtain ⟨_, hw₂⟩ := hgspec w₂ h₂
+      rw [heq] at hw₁
+      by_contra hww
+      have hsub : ({v, w₁, w₂} : Finset V) ⊆ ({u | inc u (g w₂)} : Finset V) := by
+        intro x hx
+        simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+        rcases hx with rfl | rfl | rfl
+        · exact (hgspec w₂ h₂).1
+        · exact hw₁
+        · exact hw₂
+      have hcard3 : ({v, w₁, w₂} : Finset V).card = 3 := by
+        rw [Finset.card_insert_of_notMem (by
+              simp only [Finset.mem_insert, Finset.mem_singleton]
+              push_neg; exact ⟨hne w₁ h₁, hne w₂ h₂⟩),
+            Finset.card_insert_of_notMem (by
+              simp only [Finset.mem_singleton]; exact hww),
+            Finset.card_singleton]
+      have := Finset.card_le_card hsub
+      rw [hcard3] at this
+      exact absurd (this.trans (hdoor (g w₂))) (by norm_num)
+    · -- surjective: the door's other endpoint is a neighbour, with that very shared door
+      intro d hd
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hd
+      obtain ⟨hvd, w, hwv, hwd⟩ := hd
+      have hws : w ∈ s := by
+        rw [hs, SimpleGraph.mem_neighborFinset]
+        exact ⟨hwv.symm, d, hvd, hwd⟩
+      refine ⟨w, hws, ?_⟩
+      obtain ⟨hvg, hwg⟩ := hgspec w hws
+      exact hpair (g w) d v w hwv.symm hvg hwg hvd hwd
+
 end SpernerTuckerDoorGraph

--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -110,6 +110,54 @@ a complementary edge.
 
 ## Session Log
 
+## Session 2026-06-27 (researcher-2) — ACT: sharp degree formula (degree = #shared doors)
+
+**Mode**: REVISIT (RICH). **Outcome**: progress — `SpernerTuckerDoorGraph.lean`
+(+1 theorem `doorGraph_degree_eq_shared`, ~75 L, 0 sorry, 0 axiom —
+`#print axioms` = `[propext, Classical.choice, Quot.sound]` only, NO
+`ofReduceBool`/`sorryAx`). Verified via single-file `lake env lean`
+(toolchain `leanprover/lean4:v4.26.0`, exit 0, ~6 s; Docker host still down).
+
+### What I Did
+Last session (researcher-6) derived `doorGraph_degree_le_two` — the path-following
+engine's `degree ≤ 2` hypothesis — from two `≤2` door-incidence bounds. This
+session **sharpens that bound to an equality**, which is the interface the
+geometric `inc` construction actually needs:
+
+- `doorGraph_degree_eq_shared` — under (i) `hdoor` (each door joins ≤2 simplices)
+  and (ii) **`hpair`** (two *distinct* simplices share at most one door — the
+  door-graph analogue of `adj_unique_facet`), the door-graph degree of `v` equals
+  the number of `v`'s **shared** doors:
+  `(doorGraph inc).degree v = #{d | inc v d ∧ ∃ w ≠ v, inc w d}`.
+  Proof: `Finset.card_bij` with the witness map *neighbour `w` ↦ the door it
+  shares with `v`* (the `g`/`Exists.choose` witness reused from
+  `doorGraph_degree_le_two`). It lands in the shared doors; injective by `hdoor`
+  (a door joining `v` to two distinct neighbours would touch three simplices);
+  surjective by `hpair` (a shared door's other endpoint `w` is a neighbour, and
+  `hpair` forces `g w` to be exactly that door). Empty-`D` handled separately
+  (both sides 0).
+
+### Why this matters
+`degree_le_two` only gave the path/cycle structure. The *equality* converts the
+order-theoretic predicate "`v` is a path endpoint" (`degree v = 1`) into the
+purely **local** door statement "`v` has exactly one shared door". That is the
+clean target for the still-open geometric step: building `inc` and identifying the
+interior complementary simplices (= endpoints with one shared door, no boundary
+door) without reasoning about the global graph. `hpair` is a new, natural geometric
+obligation the construction must also supply (besides the two `≤2` counts).
+
+### Files Modified
+- proofs/Proofs/SpernerTuckerDoorGraph.lean (+`doorGraph_degree_eq_shared`)
+- src/data/research/problems/sperner-mathlib4-oq-02.json (knowledge)
+- research/problems/sperner-mathlib4-oq-02/knowledge.md
+
+### Next Steps (unchanged frontier; interface now sharper)
+- Build the concrete `inc : V → D → Prop` for a triangulation and discharge
+  `hdoor`, `hsimplex`, and now `hpair` geometrically; a path endpoint is exactly a
+  simplex with **one** shared door (`doorGraph_degree_eq_shared`).
+- Supply `Odd #{boundary endpoints}` from inductive (n−1)-Tucker.
+- Continuous n≥2 Tucker ⟹ Borsuk–Ulam: analytic phase.
+
 ## Session 2026-06-27 (researcher-6) — ACT: door-counting ⟹ degree ≤ 2 bridge
 
 **Mode**: REVISIT (RICH)

--- a/src/data/research/problems/sperner-mathlib4-oq-02.json
+++ b/src/data/research/problems/sperner-mathlib4-oq-02.json
@@ -17,8 +17,9 @@
   },
   "currentState": "n=1 Tucker line COMPLETE end-to-end: discrete combinatorial core (SpernerTuckerOneDim, merged) + continuous capstone (SpernerTuckerBorsukUlamOneDim, this session) deriving the genuine 1-D Borsuk-Ulam theorem from IVT. A continuous 1-periodic f:R->R takes equal values at some antipodal pair c, c+1/2. n>=2 Tucker still needs the Freund-Todd / Prescott-Su path-following engine (complementary-edge count is not a parity invariant for n>=2).",
   "knowledge": {
-    "progressSummary": "PROGRESS: n=1 line complete (combinatorial + continuous 1-D Borsuk-Ulam, merged). For n>=2 the abstract path-following engine (PR #30911) + interior-parity refinement are done. This session closes the door-counting→engine gap: SpernerTuckerDoorGraph derives the engine's max-degree-≤2 hypothesis from the door-incidence structure (≤2 doors/simplex, ≤2 simplices/door) via a clean counting injection, and chains it to the quantitative Tucker conclusion (odd boundary endpoints ⟹ odd interior complementary simplices). Verified, 0-axiom. Remaining for n>=2: supply the odd-boundary-endpoint input (inductive (n-1)-Tucker) and the geometric construction of the door-incidence relation for a concrete triangulation.",
+    "progressSummary": "PROGRESS: n=1 line complete (combinatorial + continuous 1-D Borsuk-Ulam, merged). For n>=2 the abstract path-following engine (degree<=2 => even endpoints => interior endpoint) and the door-counting bridge are done. This session SHARPENS the degree bound to an EQUALITY: doorGraph_degree_eq_shared (under hdoor: each door joins <=2 simplices, and the new hpair: two distinct simplices share <=1 door) gives degree v = #{shared doors of v}, so a path endpoint (degree 1) <=> a simplex with exactly one shared door — the local interface the geometric inc construction needs. VERIFIED 0-axiom (lake env lean exit 0; #print axioms = [propext, Classical.choice, Quot.sound]). Remaining open: the geometric inc construction (discharge hdoor/hsimplex/hpair) + Odd #{boundary endpoints} from inductive (n-1)-Tucker + the continuous mesh->0 analytic phase.",
     "builtItems": [
+      "proofs/Proofs/SpernerTuckerDoorGraph.lean (sharp degree formula, VERIFIED 0-axiom: lake env lean exit 0, #print axioms = [propext, Classical.choice, Quot.sound] only): doorGraph_degree_eq_shared — under hdoor (each door joins <=2 simplices) and hpair (two distinct simplices share <=1 door, the door-graph analogue of adj_unique_facet), (doorGraph inc).degree v = #{d | inc v d and exists w != v, inc w d} (the # of vs SHARED doors). Finset.card_bij with the neighbour->shared-door witness map: lands in shared doors, injective by hdoor (a door joining v to two neighbours touches 3 simplices), surjective by hpair (a shared doors other endpoint is a neighbour whose shared door is forced to be that door). Sharpens doorGraph_degree_le_two from a bound to an equality: a path endpoint (degree 1) is exactly a simplex with ONE shared door.",
       "proofs/Proofs/SpernerTuckerOneDim.lean — 1-D Tucker / combinatorial 1-D Borsuk–Ulam (verified, 0-axiom)",
       "TuckerOneDim.complementary_count_cast — telescoping ZMod-2 identity: #complementary-edges ≡ lam 0 + lam (last) (mod 2)",
       "TuckerOneDim.tucker_one_dim — antipodal boundary ⟹ odd #complementary-edges",
@@ -37,11 +38,12 @@
       "Spoke complementary count is NOT a parity invariant either (distribution {0:32,1:96,2:96,3:32}) -- mixed parity confirms n>=2 has no single-set parity shortcut (consistent with Insight 3).",
       "NEGATIVE PARITY (verified, rules out a wrong instantiation route): the complementary-edge count on the BOUNDARY RING of the antipodal hexagon is ALWAYS EVEN (distribution {0,2,6} over 64 antipodal ring labellings; SpernerTuckerBoundaryParity.ring_complementary_count_even). So the path-following engine SpernerTuckerPathFollowing.exists_interior_degree_one CANNOT be fed the raw boundary-circle complementary count as its odd hB hypothesis -- the count is never odd. The engine odd boundary parity must come from the refined almost-complementary structure / inductive (n-1)-Tucker, not raw circle parity.",
       "n=2 Tucker on the hexagon+center triangulation is now kernel-checked (first machine-checked n>=2 instance) -- a concurrent agent landed it in proofs/Proofs/SpernerTuckerHexagon.lean (PR #30917). This session contributes the complementary boundary-parity correction in a separate file.",
-      "The path-following engine's `∀ v, G.degree v ≤ 2` hypothesis is NOT an extra assumption — it is DERIVED from abstract door-counting (SpernerTuckerDoorGraph.doorGraph_degree_le_two). If each almost-complementary simplex has ≤2 doors and each door joins ≤2 simplices, the shared-door graph has max degree ≤2: the neighbours of v inject into the ≤2 doors of v (a single door joining v to two distinct neighbours would be incident to 3 simplices, contradicting the ≤2 door-incidence bound). Fully abstract over inc:V→D→Prop, verified 0-axiom. This realizes the OQ title literally — the degree≤2 input to the engine comes FROM door-counting, not as a black-box hypothesis."
+      "The path-following engine's `∀ v, G.degree v ≤ 2` hypothesis is NOT an extra assumption — it is DERIVED from abstract door-counting (SpernerTuckerDoorGraph.doorGraph_degree_le_two). If each almost-complementary simplex has ≤2 doors and each door joins ≤2 simplices, the shared-door graph has max degree ≤2: the neighbours of v inject into the ≤2 doors of v (a single door joining v to two distinct neighbours would be incident to 3 simplices, contradicting the ≤2 door-incidence bound). Fully abstract over inc:V→D→Prop, verified 0-axiom. This realizes the OQ title literally — the degree≤2 input to the engine comes FROM door-counting, not as a black-box hypothesis.",
+      "Insight 5 — sharp door-degree = #shared-doors (VERIFIED). doorGraph_degree_le_two only gave the path/cycle structure; under the EXTRA natural axiom hpair (distinct simplices share <=1 door) the degree is EXACTLY the number of shared doors of v. This localizes \"path endpoint\" to \"exactly one shared door\", giving the geometric inc construction a per-simplex target instead of a global-graph one. hpair is a third geometric obligation alongside the two <=2 incidence counts."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Construct the concrete door-incidence relation inc:V→D→Prop for a triangulation of B^n (V = almost-complementary simplices, D = complementary facets/doors) and discharge the two ≤2 bounds geometrically, feeding SpernerTuckerDoorGraph.exists_complementary_simplex.",
+      "NEXT: build concrete inc : V->D->Prop (V = almost-complementary simplices, D = complementary facets); discharge hdoor (<=2 simplices/door), hsimplex (<=2 doors/simplex), and hpair (distinct simplices share <=1 door). A path endpoint = a simplex with exactly one shared door (doorGraph_degree_eq_shared).",
       "Supply the odd-boundary-endpoint hypothesis (Odd #{boundary path endpoints}) from the inductive (n-1)-Tucker statement — NOT from the raw boundary-ring complementary count, which is provably EVEN (SpernerTuckerBoundaryParity).",
       "n>=2 Tucker ⟹ Borsuk-Ulam: continuous mesh→0 + compactness (the analytic phase; dim 1 was discharged by IVT)."
     ],
@@ -63,7 +65,7 @@
     "mathlib": []
   },
   "started": "2026-06-15T02:22:23.646Z",
-  "lastUpdate": "2026-06-27",
+  "lastUpdate": "2026-06-27T20:40:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/SpernerTuckerBorsukUlamOneDim.lean",
@@ -131,5 +133,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerTuckerDoorGraph.lean"
     }
-  ]
+  ],
+  "lastVerified": "2026-06-27"
 }


### PR DESCRIPTION
## Summary

Continues **sperner-mathlib4-oq-02** ('Tucker's lemma and Borsuk–Ulam from abstract door-counting'). Last session derived `doorGraph_degree_le_two` — the path-following engine's `degree ≤ 2` hypothesis — from two `≤2` door-incidence bounds. This session **sharpens that bound to an equality**, the precise local interface the (still-open) geometric construction targets.

## What's added (`SpernerTuckerDoorGraph.lean`, +1 theorem ~75 L)

`doorGraph_degree_eq_shared`: under
- `hdoor` — each door joins at most two simplices, and
- **`hpair`** (new) — two *distinct* simplices share at most one door (the door-graph analogue of `adj_unique_facet`),

the door-graph degree of `v` equals the number of its **shared** doors:

```
(doorGraph inc).degree v = #{ d | inc v d ∧ ∃ w ≠ v, inc w d }
```

**Proof.** `Finset.card_bij` with the witness map *neighbour `w` ↦ the door it shares with `v`* (reusing the `Exists.choose` witness from `doorGraph_degree_le_two`):
- **lands** in the shared doors;
- **injective** by `hdoor` — a door joining `v` to two distinct neighbours would be incident to three simplices;
- **surjective** by `hpair` — a shared door's other endpoint is a neighbour whose forced shared door is exactly that door.

Empty-`D` is handled separately (both sides `0`).

## Why it matters

`degree_le_two` only gave the paths-and-cycles structure. The **equality** converts the global predicate '`v` is a path endpoint' (`degree v = 1`) into the purely **local** door statement '`v` has exactly one shared door' — the per-simplex target the geometric `inc` construction needs (it must now also discharge `hpair`, a third natural geometric obligation alongside the two `≤2` counts).

## Verification

- Type-checked via `lake env lean` against the main-repo Mathlib olean cache (Docker host down): **exit 0, no errors/warnings**.
- `#print axioms doorGraph_degree_eq_shared` = `[propext, Classical.choice, Quot.sound]` only — **genuinely 0-axiom**, no `sorryAx` / `Lean.ofReduceBool` / `native_decide`. 0 sorries.

## Next

Build the concrete `inc` for a triangulation (discharge `hdoor`/`hsimplex`/`hpair`); supply `Odd #{boundary endpoints}` from inductive (n−1)-Tucker; then the continuous mesh→0 analytic phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)