### PR TITLE
research(inverse-galois-oq-06-oq-02): mod-7 factorization identity in q_mod7_factor_type [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/InverseGaloisOQ06OQ01.lean
+++ b/proofs/Proofs/InverseGaloisOQ06OQ01.lean
@@ -187,7 +187,11 @@ theorem gal_card_ne_5 : Fintype.card q.Gal ≠ 5 := by
 -- § 5. Factorization mod 7
 -- ============================================================================
 
-private noncomputable def q_ℤ : ℤ[X] :=
+/-- The degree-5 integer polynomial `q` whose splitting field realises `A₅`.
+Made public (mirroring the sibling `InverseGaloisOQ06OQ02P11.q_ℤ`) so the
+mod-7 factorization identity can be carried in the packaged Dedekind input
+`InverseGaloisOQ06OQ02.q_mod7_factor_type`. -/
+noncomputable def q_ℤ : ℤ[X] :=
   X ^ 5 - C 5 * X ^ 4 + C 10 * X ^ 3 - C 10 * X ^ 2 + C 25 * X - C 5
 
 /-- The cubic factor X³ + 6X² + 4X + 1 over 𝔽₇. -/

--- a/proofs/Proofs/InverseGaloisOQ06OQ02.lean
+++ b/proofs/Proofs/InverseGaloisOQ06OQ02.lean
@@ -187,13 +187,25 @@ theorem q_mod7_squarefree :
 -- § 5. Packaged Dedekind input
 -- ============================================================================
 
+/-- **`q ≡ (X-5)(X-6)·cubicMod7  (mod 7)`**, restated with the named factors
+`linFactor5`, `linFactor6`. This is `InverseGaloisOQ06OQ01.q_ℤ_mod7_factorization`
+re-expressed through the local factor definitions, so the packaged
+`q_mod7_factor_type` below can carry the identity tying the three irreducibles
+to `q` itself — exactly as the sibling `p = 11` packaging does
+(`InverseGaloisOQ06OQ02P11.q_ℤ_mod11_factorization`). -/
+theorem q_mod7_factorization :
+    q_ℤ.map (Int.castRingHom (ZMod 7)) = linFactor5 * linFactor6 * cubicMod7 := by
+  show q_ℤ.map (Int.castRingHom (ZMod 7)) = (X - C 5) * (X - C 6) * cubicMod7
+  exact q_ℤ_mod7_factorization
+
 /-- **The mod-7 factor type of `q` is `(1, 1, 3)` into distinct irreducibles.**
 
 This bundles everything Dedekind's theorem consumes at `p = 7`:
 * three irreducible factors,
 * of degrees `1, 1, 3`,
 * pairwise non-associated (distinct primes),
-* with squarefree product (`p = 7` unramified).
+* with squarefree product (`p = 7` unramified),
+* whose product is genuinely `q mod 7` (`q_mod7_factorization`).
 
 Combined with Dedekind's theorem (still a Mathlib gap; sibling track), this
 forces `Gal(q)` to contain a 3-cycle, hence `3 ∣ |Gal(q)|`. -/
@@ -203,10 +215,11 @@ theorem q_mod7_factor_type :
     (¬ Associated linFactor5 linFactor6) ∧
     (¬ Associated linFactor5 cubicMod7) ∧
     (¬ Associated linFactor6 cubicMod7) ∧
-    Squarefree (linFactor5 * linFactor6 * cubicMod7) :=
+    Squarefree (linFactor5 * linFactor6 * cubicMod7) ∧
+    q_ℤ.map (Int.castRingHom (ZMod 7)) = linFactor5 * linFactor6 * cubicMod7 :=
   ⟨linFactor5_irreducible, linFactor6_irreducible, cubicMod7_irreducible,
    linFactor5_natDegree, linFactor6_natDegree, cubicMod7_natDegree,
    linFactors_not_associated, linFactor5_not_associated_cubic,
-   linFactor6_not_associated_cubic, q_mod7_squarefree⟩
+   linFactor6_not_associated_cubic, q_mod7_squarefree, q_mod7_factorization⟩
 
 end InverseGaloisOQ06OQ02

--- a/research/problems/inverse-galois-oq-06-oq-02/knowledge.md
+++ b/research/problems/inverse-galois-oq-06-oq-02/knowledge.md
@@ -40,6 +40,21 @@ factorization and that the cubic has no roots — not irreducibility/squarefree.
 
 ---
 
+## Packaging completeness (iter 3)
+
+- A "factor type" theorem that lists irreducibles + degrees + distinctness +
+  squarefreeness is **incomplete** unless it ALSO carries the factorization
+  identity `q.map(ℤ→𝔽ₚ) = f₁·f₂·f₃`. Without it the statement is about an
+  arbitrary product, not about `q mod p`. The mod-11 packaging already had this
+  conjunct; the mod-7 one did not — fixed by re-exporting
+  `q_ℤ_mod7_factorization` through the local factor defs.
+- Restating an identity proved with `(X - C 5)` in terms of a `noncomputable def
+  linFactor5 := X - C 5`: use `show <goal with X - C 5>; exact <lemma>`. The
+  `show` succeeds by defeq (regular defs unfold during `isDefEq`); no `rw`/`simp`
+  unfolding of the def is needed.
+
+---
+
 ## Dead Ends
 
 - `isCoprime_of_irreducible_of_not_associated` does NOT exist in Mathlib 4.26.

--- a/research/problems/inverse-galois-oq-06-oq-02/state.md
+++ b/research/problems/inverse-galois-oq-06-oq-02/state.md
@@ -57,8 +57,39 @@ factor type, so once Dedekind's theorem is available the Frobenius elements at
 both primes are 3-cycles — strengthening the evidence that `3 ∣ |Gal(q)|` and
 ruling out a prime-specific accident.
 
+## Iteration 3 (researcher-1, 2026-06-27) — ACT: close mod-7/mod-11 packaging asymmetry
+
+**Outcome**: Strengthened `q_mod7_factor_type` in `Proofs/InverseGaloisOQ06OQ02.lean`
+(still 0-axiom, 0-sorry).
+
+Audit found a genuine gap: the mod-11 packaging `q_mod11_factor_type` carries the
+full factorization **identity** `q.map(ℤ→𝔽₁₁) = linFactor4·linFactor3·cubicMod11`
+as a final conjunct, but the mod-7 `q_mod7_factor_type` did **not** — it asserted
+three distinct irreducibles of degrees (1,1,3) with squarefree product, without
+asserting they are the factors **of `q`**. As stated it was a fact about an
+arbitrary product, not about `q mod 7`.
+
+Fix:
+- Added `q_mod7_factorization : q.map(ℤ→𝔽₇) = linFactor5·linFactor6·cubicMod7`,
+  a thin restatement of `InverseGaloisOQ06OQ01.q_ℤ_mod7_factorization` through the
+  local `linFactor5 = X-5`, `linFactor6 = X-6` definitions (defeq `show` + `exact`).
+- Appended that identity as the final conjunct of `q_mod7_factor_type`, so it is
+  now symmetric with (and as complete as) `q_mod11_factor_type` — the packaged
+  Dedekind input genuinely says "these are the factors of `q mod 7`".
+- Required making `q_ℤ` public in `Proofs/InverseGaloisOQ06OQ01.lean` (it was
+  `private`, so its name could not appear in the new conjunct's *type* from
+  OQ02). This mirrors the sibling `InverseGaloisOQ06OQ02P11.q_ℤ`, which is
+  already public for the same reason. Visibility-only change; OQ01's own proofs
+  are unaffected (re-verified, 0-axiom, 0-sorry).
+
+No new mathematics; this tightens the existing statement so it actually entails
+what Dedekind's theorem consumes. The remaining gap is unchanged (Frobenius
+bridge, sibling track).
+
 ## Next Action
 
 If Dedekind's theorem lands in Mathlib (or the sibling Frobenius bridge
 completes), `q_mod7_factor_type` / `q_mod11_factor_type` plug in directly to
-discharge the axiom.
+discharge the axiom. The algebraic input is now complete and symmetric at both
+unramified primes (7, 11): irreducible factors + degrees + distinctness +
+squarefreeness + factorization identity.


### PR DESCRIPTION
## Summary

Closes a packaging asymmetry between the two unramified primes (7, 11) in the A₅ Dedekind-input track. The mod-11 bundle `q_mod11_factor_type` already carried the full factorization **identity** as a final conjunct; the mod-7 bundle `q_mod7_factor_type` did not — it asserted three distinct irreducibles of degrees (1,1,3) with squarefree product, but never that they are the factors **of `q`**. As stated it was a fact about an arbitrary product, not about `q mod 7`.

## Changes

- **`q_mod7_factorization`** (new): `q.map(ℤ→𝔽₇) = linFactor5·linFactor6·cubicMod7`, a thin restatement of `InverseGaloisOQ06OQ01.q_ℤ_mod7_factorization` through the local `linFactor5 = X−5`, `linFactor6 = X−6` definitions (defeq `show` + `exact`).
- **`q_mod7_factor_type`** (strengthened): appends the factorization identity as a final conjunct, making it symmetric with `q_mod11_factor_type`. The packaged Dedekind input now genuinely says "these are the factors of `q mod 7`".
- **`q_ℤ` made public** in `InverseGaloisOQ06OQ01.lean` (was `private`, so its name could not appear in the new conjunct's *type* from OQ02). Mirrors the sibling `InverseGaloisOQ06OQ02P11.q_ℤ`, public for the same reason. Visibility-only change; OQ01's own proofs are unaffected.

## Verification

- `lake env lean Proofs/InverseGaloisOQ06OQ02.lean` → exit 0 (Mathlib v4.26.0); OQ01 re-verified exit 0.
- `#print axioms q_mod7_factor_type` → only `propext / Classical.choice / Quot.sound` (foundational). **Still 0-sorry, 0-axiom.**

## Status

**Outcome**: progress (algebraic Dedekind input now complete and symmetric at both unramified primes). No new mathematics — this tightens an existing statement so it entails what Dedekind's theorem consumes. The remaining gap (Frobenius/Dedekind bridge) is unchanged, sibling track.

🤖 Generated by researcher-1