### PR TITLE
research(gelfond-schneider-oq-01): Baker proves strictly more — log 2 + √2·log 3 transcendental [axiomatized, 1-axiom]

### DIFF
--- a/proofs/Proofs/GelfondSchneiderOQ01.lean
+++ b/proofs/Proofs/GelfondSchneiderOQ01.lean
@@ -1,0 +1,200 @@
+import Mathlib
+
+/-
+# Gelfond–Schneider — OQ-01: Baker's Theorem Proves Strictly More — Transcendence of Linear Forms in Two Logarithms
+
+## Research Problem: gelfond-schneider-oq-01
+
+> *Can Baker's theorem be used to prove more transcendence results?*
+
+The gallery parent (`gelfond-schneider`) records the Gelfond–Schneider theorem (Hilbert's 7th
+problem) as a stated assumption.  Gelfond–Schneider, and its sibling Hermite–Lindemann, are both
+**single-logarithm** statements: they control one quantity of the shape `b · log a` (equivalently
+one power `a ^ b = exp(b · log a)`).  In 1966 Alan Baker proved the decisive generalisation to
+**several** logarithms — *linear forms in logarithms* — for which he received the Fields Medal.
+
+This file answers OQ-01 in the affirmative by formalising the two-logarithm case of Baker's
+theorem and deriving a concrete transcendence result that the single-logarithm theory does
+**not** reach:
+
+> **`log 2 + √2 · log 3` is transcendental.**
+
+## Why this is genuinely beyond Gelfond–Schneider / Lindemann
+
+* Hermite–Lindemann gives transcendence of a *single* `log a` (e.g. `log 2`, `log 3` are each
+  transcendental), and an algebraic multiple of one transcendental is trivially transcendental.
+* The new phenomenon is the **sum** `β₁ log a₁ + β₂ log a₂` of two `ℚ`-linearly-independent
+  logarithms with algebraic coefficients: a priori the two transcendentals could cancel into an
+  algebraic number.  Baker's theorem is exactly the statement that they cannot — the form is
+  transcendental whenever the coefficients are not both zero.  Gelfond–Schneider (`n = 1`) says
+  nothing about this `n = 2` cancellation question.
+
+## Main results
+
+* `baker_linear_form_two` — Baker's theorem, two-logarithm homogeneous form, stated as an
+  `axiom` exactly as the parent entry states Gelfond–Schneider.  For algebraic bases `a₁, a₂ > 1`
+  with `ℚ`-linearly independent logarithms (`log a₁ / log a₂` irrational) and algebraic
+  coefficients `β₁, β₂` not both zero, the linear form `β₁ log a₁ + β₂ log a₂` is transcendental.
+* `irrational_log_three_div_log_two`, `irrational_log_two_div_log_three` — the independence input
+  for the bases `2, 3`, via the classical parity argument `2^p = 3^d ⇒ 2 ∣ 3`.
+* `sqrt_two_algebraic` — `√2` is algebraic (root of `X² − 2`), the algebraic-coefficient input.
+* `transcendental_log_two_add_sqrt_two_log_three` — the flagship consequence:
+  `log 2 + √2 · log 3` is transcendental.
+* `transcendental_log_six` — sanity sibling: the *collapsing* case `log 2 + log 3 = log 6`
+  recovered as a single-logarithm transcendence (here `n = 2` Baker agrees with Lindemann).
+
+## Assumption
+
+`baker_linear_form_two` is the sole non-foundational assumption, mirroring the parent's
+treatment of Gelfond–Schneider: the full proof of Baker's theorem (Baker's auxiliary functions,
+zero estimates, and the theory of linear forms in logarithms) is not formalised.  Every theorem
+below is otherwise fully machine-checked; `#print axioms` shows the only non-foundational
+dependency is this single Baker assumption.
+
+Tags: transcendental-number-theory, baker-theorem, linear-forms-in-logarithms, gelfond-schneider,
+hilbert-7, logarithm
+-/
+
+namespace GelfondSchneiderOQ01
+
+open Polynomial Real
+
+/-- **Baker's theorem** (linear forms in logarithms, two-logarithm homogeneous form), stated as
+    an assumption in the same spirit as the gallery parent states Gelfond–Schneider.
+
+    If `a₁, a₂ > 1` are algebraic and their logarithms are linearly independent over `ℚ` (encoded
+    as `log a₁ / log a₂ ∉ ℚ`), then for any algebraic coefficients `β₁, β₂` not both zero, the
+    linear form `β₁ · log a₁ + β₂ · log a₂` is transcendental.
+
+    This is the `n = 2` case of Baker's 1966 theorem; the `n = 1` analogue is Gelfond–Schneider /
+    Hermite–Lindemann. -/
+axiom baker_linear_form_two
+    (a₁ a₂ : ℝ) (ha₁ : 1 < a₁) (ha₂ : 1 < a₂)
+    (halg₁ : IsAlgebraic ℚ a₁) (halg₂ : IsAlgebraic ℚ a₂)
+    (hindep : Irrational (Real.log a₁ / Real.log a₂))
+    (β₁ β₂ : ℝ) (hβ₁ : IsAlgebraic ℚ β₁) (hβ₂ : IsAlgebraic ℚ β₂)
+    (hβ_ne : ¬ (β₁ = 0 ∧ β₂ = 0)) :
+    Transcendental ℚ (β₁ * Real.log a₁ + β₂ * Real.log a₂)
+
+/-- Every rational, viewed in `ℝ`, is algebraic — supplies the algebraic bases `2, 3`. -/
+private lemma rat_cast_algebraic (q : ℚ) : IsAlgebraic ℚ ((q : ℝ)) := by
+  refine ⟨X - C q, ?_, ?_⟩
+  · intro h
+    have hcoeff : (X - C q : ℚ[X]).coeff 1 = 0 := by rw [h]; simp
+    simp at hcoeff
+  · simp
+
+/-- `(2 : ℝ)` is algebraic over `ℚ`. -/
+private lemma two_algebraic : IsAlgebraic ℚ ((2 : ℝ)) := by
+  have := rat_cast_algebraic 2
+  simpa using this
+
+/-- `(3 : ℝ)` is algebraic over `ℚ`. -/
+private lemma three_algebraic : IsAlgebraic ℚ ((3 : ℝ)) := by
+  have := rat_cast_algebraic 3
+  simpa using this
+
+/-- `(1 : ℝ)` is algebraic over `ℚ`. -/
+private lemma one_algebraic : IsAlgebraic ℚ ((1 : ℝ)) := by
+  have := rat_cast_algebraic 1
+  simpa using this
+
+/-- `√2` is algebraic over `ℚ` (a root of `X² − 2`) — supplies the algebraic coefficient. -/
+lemma sqrt_two_algebraic : IsAlgebraic ℚ (Real.sqrt 2) := by
+  refine ⟨X ^ 2 - C 2, ?_, ?_⟩
+  · intro h
+    have hcoeff : (X ^ 2 - C 2 : ℚ[X]).coeff 2 = 0 := by rw [h]; simp
+    simp at hcoeff
+  · simp [sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
+
+/-- **`log 3 / log 2` is irrational.**  A rational value `p/d` exponentiates to `2^p = 3^d` for
+    positive integers `p, d`, impossible by parity (`2 ∣ 3^d ⇒ 2 ∣ 3`). -/
+theorem irrational_log_three_div_log_two : Irrational (Real.log 3 / Real.log 2) := by
+  rw [Irrational]
+  rintro ⟨q, hq⟩
+  have hl2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  have hl3 : (0 : ℝ) < Real.log 3 := Real.log_pos (by norm_num)
+  have hqpos : (0 : ℝ) < (q : ℝ) := by rw [hq]; positivity
+  have hqnum_pos : 0 < q.num := by
+    rwa [Rat.num_pos, ← Rat.cast_pos (K := ℝ)]
+  have hden : (0 : ℝ) < (q.den : ℝ) := by exact_mod_cast q.pos
+  have hcross : (q.num : ℝ) * Real.log 2 = (q.den : ℝ) * Real.log 3 := by
+    have hqeq : (q : ℝ) = (q.num : ℝ) / (q.den : ℝ) := by exact_mod_cast (Rat.num_div_den q).symm
+    rw [hqeq] at hq
+    field_simp at hq
+    nlinarith [hq, hl2, hl3]
+  set N : ℕ := q.num.toNat with hN
+  have hNcast : (N : ℝ) = (q.num : ℝ) := by
+    rw [hN]; exact_mod_cast Int.toNat_of_nonneg (le_of_lt hqnum_pos)
+  have hNpos : 0 < N := by rw [hN]; omega
+  have hlog : Real.log ((2 : ℝ) ^ N) = Real.log ((3 : ℝ) ^ q.den) := by
+    rw [Real.log_pow, Real.log_pow, hNcast]
+    linarith [hcross]
+  have hpow : (2 : ℝ) ^ N = (3 : ℝ) ^ q.den := by
+    have h2 : (0 : ℝ) < (2 : ℝ) ^ N := by positivity
+    have h3 : (0 : ℝ) < (3 : ℝ) ^ q.den := by positivity
+    have := congrArg Real.exp hlog
+    rwa [Real.exp_log h2, Real.exp_log h3] at this
+  have hnat : (2 : ℕ) ^ N = (3 : ℕ) ^ q.den := by
+    have : ((2 ^ N : ℕ) : ℝ) = ((3 ^ q.den : ℕ) : ℝ) := by push_cast; exact hpow
+    exact_mod_cast this
+  have hdvd : (2 : ℕ) ∣ 3 ^ q.den := by
+    rw [← hnat]; exact dvd_pow_self 2 hNpos.ne'
+  have : (2 : ℕ) ∣ 3 := Nat.Prime.dvd_of_dvd_pow Nat.prime_two hdvd
+  norm_num at this
+
+/-- **`log 2 / log 3` is irrational** — the reciprocal of an irrational nonzero real is
+    irrational.  This is the independence hypothesis Baker's theorem needs for the bases `2, 3`. -/
+theorem irrational_log_two_div_log_three : Irrational (Real.log 2 / Real.log 3) := by
+  have hl2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  have hl3 : (0 : ℝ) < Real.log 3 := Real.log_pos (by norm_num)
+  have hbase := irrational_log_three_div_log_two
+  -- log 2 / log 3 = (log 3 / log 2)⁻¹
+  have heq : Real.log 2 / Real.log 3 = (Real.log 3 / Real.log 2)⁻¹ := by
+    rw [inv_div]
+  rw [heq]
+  exact hbase.inv
+
+/-- **Flagship consequence of Baker's theorem (OQ-01).**  The linear form
+
+        `log 2 + √2 · log 3`
+
+    is transcendental.  Both summands are transcendental, but the new content — beyond
+    Hermite–Lindemann and Gelfond–Schneider — is that they cannot cancel into an algebraic
+    number, because `log 2` and `log 3` are `ℚ`-linearly independent and the coefficients
+    `1, √2` are algebraic and not both zero.  This is the two-logarithm (`n = 2`) regime that
+    single-logarithm transcendence theory does not reach. -/
+theorem transcendental_log_two_add_sqrt_two_log_three :
+    Transcendental ℚ (Real.log 2 + Real.sqrt 2 * Real.log 3) := by
+  have h := baker_linear_form_two 2 3 (by norm_num) (by norm_num)
+    two_algebraic three_algebraic irrational_log_two_div_log_three
+    1 (Real.sqrt 2)
+    one_algebraic sqrt_two_algebraic
+    (by
+      rintro ⟨h1, _⟩
+      norm_num at h1)
+  -- rewrite `1 * log 2 + √2 * log 3` to `log 2 + √2 * log 3`
+  simpa [one_mul] using h
+
+/-- **Collapsing sanity case.**  With both coefficients `1`, the two-logarithm form degenerates
+    to a *single* logarithm `log 2 + log 3 = log 6`, and Baker's `n = 2` conclusion agrees with
+    the single-logarithm Hermite–Lindemann fact that `log 6` is transcendental.  This contrasts
+    with the flagship: an algebraic-irrational coefficient genuinely prevents the collapse. -/
+theorem transcendental_log_six : Transcendental ℚ (Real.log 6) := by
+  have h := baker_linear_form_two 2 3 (by norm_num) (by norm_num)
+    two_algebraic three_algebraic irrational_log_two_div_log_three
+    1 1
+    one_algebraic one_algebraic
+    (by rintro ⟨h1, _⟩; norm_num at h1)
+  have hlog6 : Real.log 2 + Real.log 3 = Real.log 6 := by
+    rw [← Real.log_mul (by norm_num) (by norm_num)]; norm_num
+  simpa [one_mul, hlog6] using h
+
+#check @baker_linear_form_two
+#check @sqrt_two_algebraic
+#check @irrational_log_three_div_log_two
+#check @irrational_log_two_div_log_three
+#check @transcendental_log_two_add_sqrt_two_log_three
+#check @transcendental_log_six
+
+end GelfondSchneiderOQ01

--- a/research/problems/gelfond-schneider-oq-01/knowledge.md
+++ b/research/problems/gelfond-schneider-oq-01/knowledge.md
@@ -1,0 +1,57 @@
+# Knowledge Base: gelfond-schneider-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+OQ-01 is a genuinely open-ended "can technique X do more?" question. The honest
+formalization mirrors the parent: state the deep theorem (here Baker's `n = 2`
+linear-forms theorem) as an `axiom`, then prove a downstream consequence that is
+**not** reachable from the single-logarithm theory, fully machine-checked.
+
+The discriminating example must exhibit the `n ≥ 2` phenomenon — two
+ℚ-linearly-independent logarithms that could *a priori* cancel under algebraic
+coefficients. `log 2 + √2 · log 3` is the cleanest witness:
+- `log 2`, `log 3` are ℚ-linearly independent (⟺ `log 2 / log 3` irrational),
+- coefficients `1, √2` are algebraic, not both zero,
+- so Baker forbids the sum from being algebraic.
+
+## What worked
+
+- **Independence input is unconditional.** `Irrational (log 3 / log 2)` needs no
+  transcendence theory: a rational `p/d` cross-multiplies to `2^p = 3^d`, then
+  `2 ∣ 3^d ⇒ 2 ∣ 3` via `Nat.Prime.dvd_of_dvd_pow`. The reciprocal follows from
+  `Irrational.inv`. (Same parity argument the sibling `gelfond-schneider-oq-04`
+  uses.)
+- **Algebraic coefficient `√2`.** Witness polynomial `X² − 2`; non-triviality via
+  the degree-2 coefficient, root via `Real.sq_sqrt`.
+- **Rationals are algebraic.** `IsAlgebraic ℚ (q : ℝ)` from `X - C q`; specializes
+  to the bases `2, 3` and the coefficient `1`.
+- **Collapsing sanity check.** With both coefficients `1`, the form degenerates to
+  `log 2 + log 3 = log 6` (single logarithm), where Baker agrees with
+  Hermite–Lindemann. This contrast confirms the algebraic-irrational coefficient
+  is what supplies the new content.
+
+## Axiom status
+
+`baker_linear_form_two` is the sole non-foundational assumption. `#print axioms`
+on the flagship reports only `propext / Classical.choice / Quot.sound` plus
+`baker_linear_form_two`; the independence lemmas carry **no** Baker dependency.
+
+## Dead ends / cautions
+
+- Do NOT try to prove Baker's theorem — it is the open/deep input; that is out of
+  scope and would be `OPEN` per SORRY-CLASSIFICATION.
+- A single-logarithm example (e.g. `log 6`) does **not** answer OQ-01; it is
+  reachable from Hermite–Lindemann and so demonstrates nothing beyond the parent.
+
+---
+
+## OQ-chain depth guard
+
+Slug `gelfond-schneider-oq-01` has depth 1 (`-oq-` count = 1). Follow-ups are
+permitted but should broaden toward sibling questions on the parent rather than
+recurse on the same index. Candidate siblings (not auto-spawned here): the
+general `n`-logarithm form; effective/quantitative Baker bounds.

--- a/research/problems/gelfond-schneider-oq-01/problem.md
+++ b/research/problems/gelfond-schneider-oq-01/problem.md
@@ -1,0 +1,30 @@
+# Problem: Can Baker's theorem prove more transcendence results than Gelfond–Schneider?
+
+**Slug**: gelfond-schneider-oq-01
+**Created**: 2026-06-27
+**Status**: Active
+**Source**: gelfond-schneider <!-- gallery-gap -->
+
+## Problem Statement
+
+The gallery parent `gelfond-schneider` records the Gelfond–Schneider theorem
+(Hilbert's 7th problem) as a stated assumption and develops its single-logarithm
+consequences (transcendental constants, transcendence of `log a`). Gelfond–
+Schneider and Hermite–Lindemann are both **single-logarithm** statements: each
+controls one quantity of the shape `b · log a`.
+
+OQ-01 asks whether Baker's theorem — the 1966 generalization to **linear forms in
+several logarithms**, `β₁ log a₁ + ⋯ + βₙ log aₙ` (Fields Medal) — can prove
+transcendence results the single-logarithm theory cannot reach.
+
+## Target
+
+Formalize the two-logarithm (`n = 2`) homogeneous case of Baker's theorem and
+derive a concrete consequence beyond Gelfond–Schneider:
+
+> `log 2 + √2 · log 3` is transcendental.
+
+The new phenomenon is **non-cancellation**: a priori two ℚ-linearly-independent
+transcendentals `log 2`, `log 3` scaled by algebraic coefficients could cancel
+into an algebraic number. Baker's theorem forbids this; Gelfond–Schneider
+(`n = 1`) is silent about the `n = 2` cancellation question.

--- a/research/problems/gelfond-schneider-oq-01/state.md
+++ b/research/problems/gelfond-schneider-oq-01/state.md
@@ -1,0 +1,35 @@
+# State: gelfond-schneider-oq-01
+
+**Phase**: COMPLETED (axiomatized entry)
+**Last updated**: 2026-06-27 (researcher-1)
+
+## Summary
+
+Answered OQ-01 in the affirmative by formalizing the two-logarithm case of
+Baker's theorem (as a stated assumption, exactly as the parent records Gelfond–
+Schneider) and deriving `log 2 + √2 · log 3` transcendental — a result strictly
+beyond the single-logarithm Gelfond–Schneider / Hermite–Lindemann theory.
+
+## Iteration 1 (researcher-1, 2026-06-27) — ACT: formalize + gallery entry
+
+**Outcome**: `Proofs/GelfondSchneiderOQ01.lean` — 0 sorries, 1 axiom
+(`baker_linear_form_two`). Verified: `lake env lean Proofs/GelfondSchneiderOQ01.lean`
+exits 0 against pinned Mathlib v4.26.0; `#print axioms` on the flagship shows only
+foundational axioms + `baker_linear_form_two`.
+
+Deliverables:
+- Lean file with the Baker `n = 2` axiom, the algebraic inputs (`√2` algebraic,
+  rationals algebraic), the unconditional independence lemmas
+  (`irrational_log_three_div_log_two` and reciprocal), the flagship
+  `transcendental_log_two_add_sqrt_two_log_three`, and the collapsing sanity case
+  `transcendental_log_six`.
+- Gallery entry `src/data/proofs/gelfond-schneider-oq-01/` (meta.json, index.ts,
+  annotations.json), status `axiomatized`, badge `axiom`, axiomCount 1.
+
+## Next Action
+
+If `baker_linear_form_two` is ever discharged (formalizing Baker's method), this
+entry and the parent's Gelfond–Schneider axiom both become unconditional. A
+natural sibling is the general `n`-logarithm form, or the effective/quantitative
+Baker lower bounds (the feature distinguishing Baker's method from the
+ineffective Gelfond–Schneider proof).

--- a/src/data/proofs/gelfond-schneider-oq-01/annotations.json
+++ b/src/data/proofs/gelfond-schneider-oq-01/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "gelfond-schneider-oq-01",
+    "range": { "startLine": 3, "endLine": 56 },
+    "type": "context",
+    "title": "From One Logarithm to Several: Why Baker Proves More",
+    "content": "Gelfond-Schneider and Hermite-Lindemann are single-logarithm theorems — each controls one quantity b·log a. Baker's 1966 theorem generalizes to linear forms in several logarithms. The new phenomenon at n = 2 is cancellation: a priori two transcendentals β₁ log a₁ and β₂ log a₂ could sum to an algebraic number. Baker's theorem forbids this when log a₁, log a₂ are ℚ-linearly independent and β₁, β₂ are algebraic and not both zero. This file isolates that n = 2 input as an axiom (as the parent does for Gelfond-Schneider) and derives a transcendence result the n = 1 theory cannot reach.",
+    "mathContext": "$\\beta_1\\log a_1+\\beta_2\\log a_2\\ \\text{transcendental whenever}\\ \\tfrac{\\log a_1}{\\log a_2}\\notin\\mathbb{Q},\\ (\\beta_1,\\beta_2)\\neq(0,0)$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Baker's theorem",
+      "linear forms in logarithms",
+      "Gelfond-Schneider theorem",
+      "transcendence"
+    ],
+    "prerequisites": [
+      "algebraic and transcendental numbers",
+      "real logarithm",
+      "ℚ-linear independence"
+    ]
+  },
+  {
+    "id": "ann-baker-axiom",
+    "proofId": "gelfond-schneider-oq-01",
+    "range": { "startLine": 62, "endLine": 77 },
+    "type": "context",
+    "title": "Baker's Theorem, Two-Logarithm Form (Stated Assumption)",
+    "content": "baker_linear_form_two is the n = 2 homogeneous case of Baker's theorem, declared as a Lean axiom exactly as the parent entry declares Gelfond-Schneider. The full proof (Baker's auxiliary functions, zero estimates, the theory of linear forms in logarithms) is not formalized. Isolating precisely this hypothesis makes explicit what goes beyond the single-logarithm Gelfond-Schneider / Hermite-Lindemann theory: the ℚ-linear-independence hypothesis (log a₁ / log a₂ irrational) is meaningful only for n ≥ 2.",
+    "mathContext": "$a_1,a_2>1\\ \\text{alg.},\\ \\tfrac{\\log a_1}{\\log a_2}\\notin\\mathbb{Q},\\ \\beta_1,\\beta_2\\ \\text{alg.},\\ (\\beta_1,\\beta_2)\\neq 0\\ \\Rightarrow\\ \\beta_1\\log a_1+\\beta_2\\log a_2\\ \\text{transc.}$",
+    "significance": "high",
+    "relatedConcepts": [
+      "Baker's theorem",
+      "axiomatized assumption"
+    ],
+    "prerequisites": [
+      "Transcendental ℚ",
+      "IsAlgebraic ℚ",
+      "Irrational"
+    ]
+  },
+  {
+    "id": "ann-independence",
+    "proofId": "gelfond-schneider-oq-01",
+    "range": { "startLine": 110, "endLine": 144 },
+    "type": "lemma",
+    "title": "log 3 / log 2 is Irrational — Unconditionally",
+    "content": "irrational_log_three_div_log_two supplies the ℚ-linear-independence hypothesis Baker's theorem needs, and depends on NO Baker assumption. A rational value log 3 / log 2 = p/d would cross-multiply to N·log 2 = d·log 3 with N = p > 0, hence log(2^N) = log(3^d) and so 2^N = 3^d. Then 2 ∣ 3^d, and Nat.Prime.dvd_of_dvd_pow forces 2 ∣ 3 — false. The reciprocal irrational_log_two_div_log_three follows from Irrational.inv.",
+    "mathContext": "$\\tfrac{\\log 3}{\\log 2}=\\tfrac{p}{d}\\Rightarrow 2^{p}=3^{d}\\Rightarrow 2\\mid 3,\\ \\text{contradiction}$",
+    "significance": "high",
+    "relatedConcepts": [
+      "irrationality",
+      "unique factorization",
+      "parity argument"
+    ],
+    "prerequisites": [
+      "Real.log_pow",
+      "Real.exp_log",
+      "Nat.Prime.dvd_of_dvd_pow"
+    ]
+  },
+  {
+    "id": "ann-flagship",
+    "proofId": "gelfond-schneider-oq-01",
+    "range": { "startLine": 158, "endLine": 177 },
+    "type": "theorem",
+    "title": "log 2 + √2·log 3 is Transcendental",
+    "content": "The flagship consequence. Both log 2 and log 3 are transcendental, but the content beyond Hermite-Lindemann / Gelfond-Schneider is that they cannot cancel into an algebraic number: log 2, log 3 are ℚ-linearly independent and the coefficients 1, √2 are algebraic and not both zero. Instantiating Baker's theorem at a₁ = 2, a₂ = 3, β₁ = 1, β₂ = √2 (with √2 algebraic as a root of X² − 2) and simplifying 1·log 2 to log 2 gives the result. This is exactly the n = 2 cancellation question on which Gelfond-Schneider is silent.",
+    "mathContext": "$\\log 2+\\sqrt{2}\\,\\log 3\\ \\text{is transcendental}$",
+    "significance": "high",
+    "relatedConcepts": [
+      "Baker's theorem",
+      "non-cancellation of logarithms",
+      "algebraic coefficients"
+    ],
+    "prerequisites": [
+      "baker_linear_form_two",
+      "sqrt_two_algebraic",
+      "irrational_log_two_div_log_three"
+    ]
+  },
+  {
+    "id": "ann-collapse",
+    "proofId": "gelfond-schneider-oq-01",
+    "range": { "startLine": 179, "endLine": 191 },
+    "type": "theorem",
+    "title": "The Collapsing Sanity Case: log 6",
+    "content": "transcendental_log_six instantiates Baker's theorem at β₁ = β₂ = 1, where the two-logarithm form degenerates to a single logarithm log 2 + log 3 = log 6. Here Baker's n = 2 conclusion agrees with the single-logarithm Hermite-Lindemann fact that log 6 is transcendental. The contrast with the flagship is the point: an algebraic-irrational coefficient (√2) genuinely prevents the collapse, which is where the multi-logarithm regime adds new information.",
+    "mathContext": "$\\log 2+\\log 3=\\log 6\\ \\text{transcendental (Baker agrees with Hermite-Lindemann)}$",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Hermite-Lindemann theorem",
+      "degenerate case"
+    ],
+    "prerequisites": [
+      "Real.log_mul"
+    ]
+  }
+]

--- a/src/data/proofs/gelfond-schneider-oq-01/index.ts
+++ b/src/data/proofs/gelfond-schneider-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GelfondSchneiderOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const gelfondSchneiderOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const gelfondSchneiderOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const gelfondSchneiderOq01Data: ProofData = {
+  proof: gelfondSchneiderOq01Proof,
+  annotations: gelfondSchneiderOq01Annotations,
+}

--- a/src/data/proofs/gelfond-schneider-oq-01/meta.json
+++ b/src/data/proofs/gelfond-schneider-oq-01/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "gelfond-schneider-oq-01",
+  "title": "Baker's Theorem Proves Strictly More: log 2 + √2·log 3 is Transcendental",
+  "slug": "gelfond-schneider-oq-01",
+  "description": "Can Baker's theorem be used to prove more transcendence results than Gelfond-Schneider? Gelfond-Schneider and Hermite-Lindemann are single-logarithm statements; Baker's 1966 theorem (Fields Medal) controls linear forms in several logarithms. This entry formalizes the two-logarithm case of Baker's theorem (as a stated assumption, exactly as the parent records Gelfond-Schneider) and derives a result the single-logarithm theory cannot reach: log 2 + √2·log 3 is transcendental — the two ℚ-linearly-independent transcendentals log 2, log 3 cannot cancel into an algebraic number under the algebraic-irrational coefficient √2. Formalized in Lean 4 over Mathlib.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/GelfondSchneiderOQ01.lean",
+    "tags": [
+      "transcendental-number-theory",
+      "baker-theorem",
+      "linear-forms-in-logarithms",
+      "gelfond-schneider",
+      "hilbert-7",
+      "logarithm",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "lineCount": 200,
+    "assumptions": "One stated assumption: baker_linear_form_two, the two-logarithm homogeneous case of Baker's theorem (algebraic bases a₁, a₂ > 1 with ℚ-linearly-independent logarithms, algebraic coefficients β₁, β₂ not both zero ⟹ β₁·log a₁ + β₂·log a₂ transcendental), re-declared as an `axiom` exactly as the gallery parent `gelfond-schneider` records Gelfond-Schneider — the full proof of Baker's theorem (auxiliary functions, zero estimates, the theory of linear forms in logarithms) is not formalized. Every theorem in this file is otherwise fully machine-checked: `lake env lean` builds Proofs/GelfondSchneiderOQ01.lean to exit 0 against the pinned Mathlib (v4.26.0), and #print axioms reports, beyond the foundational propext / Classical.choice / Quot.sound, only the single GelfondSchneiderOQ01.baker_linear_form_two assumption (no sorryAx, no Lean.ofReduceBool). In particular irrational_log_three_div_log_two depends on NO Baker assumption — it is unconditional. The file imports only Mathlib.",
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.log_pow",
+        "description": "log(x^n) = n · log x — converts the cross-multiplied relation N · log 2 = d · log 3 into log(2^N) = log(3^d) in the independence proof.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.exp_log",
+        "description": "exp(log x) = x for x > 0 — recovers 2^N = 3^d from equality of logarithms.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.dvd_of_dvd_pow",
+        "description": "a prime dividing a power divides the base — delivers the parity contradiction 2 ∣ 3^d ⟹ 2 ∣ 3 establishing irrationality of log 3 / log 2.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Irrational.inv",
+        "description": "the inverse of an irrational is irrational — turns irrationality of log 3 / log 2 into that of log 2 / log 3, the ℚ-linear-independence input Baker's theorem consumes.",
+        "module": "Mathlib.RingTheory.Irrational"
+      },
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "(√x)² = x for x ≥ 0 — verifies √2 is a root of X² − 2, supplying the algebraic coefficient.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      }
+    ],
+    "originalContributions": [
+      "baker_linear_form_two: the two-logarithm homogeneous form of Baker's theorem, stated as a Lean `axiom` exactly as the parent entry states Gelfond-Schneider. This isolates the precise n = 2 input that goes beyond the single-logarithm (n = 1) Gelfond-Schneider / Hermite-Lindemann theory.",
+      "transcendental_log_two_add_sqrt_two_log_three: log 2 + √2·log 3 is transcendental — the flagship consequence. Both summands are transcendental, but the genuinely new content beyond Gelfond-Schneider is that two ℚ-linearly-independent logarithms cannot cancel into an algebraic number when scaled by algebraic coefficients not both zero. Gelfond-Schneider (n = 1) says nothing about this n = 2 cancellation question.",
+      "irrational_log_three_div_log_two / irrational_log_two_div_log_three: log 3 / log 2 (and its reciprocal) are irrational, proved unconditionally (no Baker assumption) — a rational value forces 2^p = 3^d for positive integers, impossible by parity. This supplies the ℚ-linear-independence hypothesis for the bases 2, 3.",
+      "transcendental_log_six: the collapsing sanity case — with both coefficients 1 the n = 2 form degenerates to the single logarithm log 2 + log 3 = log 6, where Baker's conclusion agrees with single-logarithm Hermite-Lindemann, contrasting with the flagship where the algebraic-irrational coefficient √2 prevents the collapse."
+    ],
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Gelfond-Schneider (1934, Hilbert's 7th problem) and Hermite-Lindemann are single-logarithm transcendence theorems: each controls one quantity of the shape b · log a. In 1966 Alan Baker proved the decisive generalization to linear forms in several logarithms, β₁ log a₁ + ⋯ + βₙ log aₙ, for which he received the Fields Medal. The gallery parent `gelfond-schneider` records the n = 1 theory; this entry isolates the n = 2 step and its new consequences.",
+    "problemStatement": "Can Baker's theorem be used to prove more transcendence results than Gelfond-Schneider? Concretely: is the sum log 2 + √2·log 3 of two ℚ-linearly-independent logarithms, scaled by the algebraic coefficients 1 and √2, transcendental — even though a priori two transcendentals could cancel into an algebraic number?",
+    "text": "Baker's theorem (n = 2) states that for algebraic bases a₁, a₂ > 1 whose logarithms are ℚ-linearly independent (encoded as log a₁ / log a₂ irrational) and algebraic coefficients β₁, β₂ not both zero, the form β₁ log a₁ + β₂ log a₂ is transcendental. Applied to a₁ = 2, a₂ = 3, β₁ = 1, β₂ = √2 — with the independence input log 2 / log 3 ∉ ℚ proved unconditionally via the parity of 2^p = 3^d, and √2 algebraic as a root of X² − 2 — it yields the transcendence of log 2 + √2·log 3. The same theorem at β₁ = β₂ = 1 recovers transcendence of log 6, where the n = 2 form collapses to a single logarithm and Baker agrees with Hermite-Lindemann."
+  },
+  "sections": [
+    {
+      "id": "baker-assumption",
+      "title": "Baker's Theorem (Two Logarithms) and the Algebraic Inputs",
+      "summary": "States the two-logarithm homogeneous form of Baker's theorem as an axiom (mirroring the parent's treatment of Gelfond-Schneider), and proves the algebraic-number inputs: every rational is algebraic (giving the bases 2, 3), and √2 is algebraic as a root of X² − 2 (the algebraic coefficient).",
+      "startLine": 62,
+      "endLine": 108
+    },
+    {
+      "id": "independence",
+      "title": "ℚ-Linear Independence of log 2 and log 3",
+      "summary": "irrational_log_three_div_log_two proves log 3 / log 2 ∉ ℚ unconditionally (a rational p/d forces 2^p = 3^d, impossible by parity); irrational_log_two_div_log_three derives the reciprocal as the independence hypothesis Baker's theorem needs for the bases 2, 3.",
+      "startLine": 110,
+      "endLine": 156
+    },
+    {
+      "id": "flagship",
+      "title": "log 2 + √2·log 3 is Transcendental, and the Collapsing Case",
+      "summary": "transcendental_log_two_add_sqrt_two_log_three feeds the algebraic and independence inputs into Baker's theorem for the flagship result. transcendental_log_six is the sanity sibling: with both coefficients 1 the form degenerates to log 6 and Baker agrees with single-logarithm Hermite-Lindemann.",
+      "startLine": 158,
+      "endLine": 191
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 sorries; the sole non-foundational assumption is the two-logarithm case of Baker's theorem, re-declared as an axiom as the parent does for Gelfond-Schneider): log 2 + √2·log 3 is transcendental, a result strictly beyond single-logarithm transcendence theory. The ℚ-linear independence of log 2 and log 3 is established unconditionally.",
+    "implications": "Answers OQ-01 affirmatively: Baker's theorem proves strictly more than Gelfond-Schneider. The new phenomenon is non-cancellation of ℚ-linearly-independent logarithms under algebraic coefficients — a genuine n ≥ 2 effect invisible to the n = 1 theory. The collapsing case log 6 marks the boundary where the two regimes agree. The same template gives transcendence of β₁ log p + β₂ log q for distinct primes p, q and any algebraic coefficients not both zero.",
+    "openQuestions": [
+      "Generalize from the two fixed bases 2, 3 to arbitrary multiplicatively independent positive algebraic a₁, a₂, or to the full n-logarithm form of Baker's theorem.",
+      "Discharge the baker_linear_form_two assumption by formalizing Baker's method (auxiliary functions, zero estimates), which would make this and the parent's Gelfond-Schneider axiom unconditional.",
+      "Formalize Baker's effective (quantitative) lower bounds on |β₁ log a₁ + β₂ log a₂|, the feature that distinguishes Baker's method from the ineffective Gelfond-Schneider proof."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "gelfond-schneider",
+      "relationship": "parent-problem",
+      "description": "Parent: the Gelfond-Schneider theorem (Hilbert's 7th) as a single-logarithm statement. This entry isolates the two-logarithm (Baker) generalization and a transcendence result — log 2 + √2·log 3 — that the single-logarithm theory cannot reach."
+    },
+    {
+      "targetId": "gelfond-schneider-oq-04",
+      "relationship": "related",
+      "description": "Sibling OQ on the same parent: oq-04 develops the single-logarithm dichotomy (log₂ 3 transcendental) reusing the same parity argument for independence; this entry (oq-01) moves to the multi-logarithm Baker regime."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Alan Baker"
+      ],
+      "title": "Linear forms in the logarithms of algebraic numbers I",
+      "year": "1966",
+      "venue": "Mathematika",
+      "note": "The theorem on linear forms in logarithms; Fields Medal 1970"
+    },
+    {
+      "authors": [
+        "Alan Baker"
+      ],
+      "title": "Transcendental Number Theory",
+      "year": "1975",
+      "venue": "Cambridge University Press",
+      "note": "Baker's method and its effective generalizations of Gelfond-Schneider"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Real"
+    ],
+    "namespace": "GelfondSchneiderOQ01",
+    "lineCount": 200,
+    "axiomCount": 1,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/GelfondSchneiderOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-01** — *can Baker's theorem be used to prove more transcendence results than Gelfond–Schneider?* — in the affirmative. Gelfond–Schneider and Hermite–Lindemann are **single-logarithm** statements (each controls one `b·log a`). Baker's 1966 theorem (Fields Medal) controls **linear forms in several logarithms**. This entry isolates the `n = 2` step and derives a result the single-logarithm theory cannot reach:

> **`log 2 + √2·log 3` is transcendental.**

The new phenomenon is **non-cancellation**: a priori two ℚ-linearly-independent transcendentals `log 2`, `log 3` scaled by algebraic coefficients could cancel into an algebraic number. Baker's theorem forbids this; Gelfond–Schneider (`n = 1`) is silent about it.

## New file `Proofs/GelfondSchneiderOQ01.lean` (0-sorry, 1-axiom)

- **`baker_linear_form_two`** — the `n = 2` homogeneous case of Baker's theorem, stated as an `axiom` exactly as the gallery parent records Gelfond–Schneider (the full proof — auxiliary functions, zero estimates — is not formalized).
- **`transcendental_log_two_add_sqrt_two_log_three`** — the flagship consequence.
- **`irrational_log_three_div_log_two`** (+ reciprocal) — the ℚ-independence input, proved **unconditionally** (no Baker assumption) via parity of `2^p = 3^d`.
- **`sqrt_two_algebraic`** + rationals-algebraic — the algebraic inputs.
- **`transcendental_log_six`** — collapsing sanity case (both coefficients `1` → single logarithm `log 6`, where Baker agrees with Hermite–Lindemann).

## Verification

- `lake env lean Proofs/GelfondSchneiderOQ01.lean` → exit 0 (Mathlib v4.26.0).
- `#print axioms` on the flagship → foundational axioms + `baker_linear_form_two` only (no `sorryAx`, no `Lean.ofReduceBool`); the independence lemmas carry **no** Baker dependency.
- Gallery entry `src/data/proofs/gelfond-schneider-oq-01/` (meta.json 11 KB < cap, index.ts, 5 annotations all line-validated via the annotation resolver). `pnpm annotations:build` → exit 0.

## Status

**Outcome**: completed (axiomatized, axiomCount 1). The sole non-foundational assumption is the `n = 2` Baker theorem, mirroring the parent's treatment of Gelfond–Schneider. Natural siblings: the general `n`-logarithm form; effective/quantitative Baker bounds.

🤖 Generated by researcher-1