### PR TITLE
research(erdos-1005-oq-02): §15 depth-m unimodularity of the iterated Farey walk [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -1314,4 +1314,78 @@ theorem endpoint_window_three (k₁ k₂ k₃ a b c d : ℤ) :
         * ((k₂ * k₃) * b - (k₁ * k₂ * k₃ - k₁ - k₃) * d) := by
   rw [endpoint_window, secondCont_three, continuant_three]; ring
 
+/-! ## §15: Depth-`m` unimodularity of the iterated Farey walk
+
+§9's `farey_succ_unimodular` shows a *single* Farey-successor step preserves
+unimodularity (`b·c = a·d + 1`).  The §14 `stepSeq` recurrence walks along
+arbitrarily many successive Farey neighbours by applying that step once per
+quotient in a list `ks`.  This section proves that the walk's
+**cross-determinant `nₘ·dₘ₊₁ − nₘ₊₁·dₘ` is invariant under every step**, so a
+unimodular start stays unimodular at *every* depth.
+
+This is the depth-uniform form of §9's consecutiveness bridge: it certifies that
+the entire §14 quotient-list walk consists of genuinely *consecutive* Farey
+fractions (each adjacent pair unimodular), not merely similarly-ordered ones.
+Concretely it is the order-`m` Stern–Brocot invariant, the determinant shadow of
+the step matrix `[[k, −1], [1, 0]]` (which has determinant `1`).
+
+The bookkeeping uses `stepPair`, returning the final consecutive *pair*
+`(t_{|ks|}, t_{|ks|+1})` of the §14 recurrence; its second component is exactly
+`stepSeq a c ks` (the §14 final term), and its first is the penultimate term,
+which the determinant invariant needs. -/
+
+/-- The iterated §9/§14 successor returning the final consecutive **pair**
+`(t_{|ks|}, t_{|ks|+1})` (for a numerator seed `(a, c)`, or a denominator seed
+`(b, d)`).  Its second component is `stepSeq a c ks`; the first is the penultimate
+term, needed to state the walk's unimodular invariant. -/
+def stepPair (a c : ℤ) : List ℤ → ℤ × ℤ
+  | [] => (a, c)
+  | k :: ks => stepPair c (k * c - a) ks
+
+/-- `stepPair`'s second component is exactly `stepSeq` — the §14 final term. -/
+theorem stepPair_snd (ks : List ℤ) (a c : ℤ) :
+    (stepPair a c ks).2 = stepSeq a c ks := by
+  induction ks generalizing a c with
+  | nil => rfl
+  | cons k ks ih => simp only [stepPair, stepSeq]; exact ih c (k * c - a)
+
+/-- **Depth-`m` unimodularity (the headline).**  Running the §14 recurrence on a
+numerator seed `(a, c)` and a denominator seed `(b, d)` through the *same* quotient
+list `ks`, the cross-determinant of the final consecutive pairs equals the seed
+cross-determinant:
+`nₘ·dₘ₊₁ − nₘ₊₁·dₘ = a·d − b·c`.
+Each step's matrix `[[k, −1], [1, 0]]` has determinant `1`, so the invariant is
+preserved exactly — proved by list induction with the seed pair threaded through
+the recurrence `(a, c) ↦ (c, k·c − a)`. -/
+theorem stepPair_cross (ks : List ℤ) (a b c d : ℤ) :
+    (stepPair a c ks).1 * (stepPair b d ks).2
+        - (stepPair a c ks).2 * (stepPair b d ks).1
+      = a * d - b * c := by
+  induction ks generalizing a b c d with
+  | nil => simp only [stepPair]; ring
+  | cons k ks ih =>
+      simp only [stepPair]
+      rw [ih c d (k * c - a) (k * d - b)]; ring
+
+/-- **Unimodularity is preserved at every depth.**  If the seed consecutive pair
+`a/b < c/d` is unimodular (`b·c = a·d + 1`, the §1 `Unimodular` convention), then
+so is the final consecutive pair of the depth-`|ks|` walk: its cross-determinant
+is `−1`.  Hence iterating the §14 recurrence from a Farey-adjacent pair lands on a
+Farey-adjacent pair at every depth — the consecutiveness §9 supplies one step at a
+time, now uniform in the run length. -/
+theorem stepPair_cross_unimodular (ks : List ℤ) {a b c d : ℤ}
+    (h : b * c = a * d + 1) :
+    (stepPair a c ks).1 * (stepPair b d ks).2
+        - (stepPair a c ks).2 * (stepPair b d ks).1 = -1 := by
+  rw [stepPair_cross]; omega
+
+/-- **Subsumption check (§9).**  At `ks = [k]` the walk's consecutive pair is
+`(c, k·c − a)` for numerators and `(d, k·d − b)` for denominators, and the
+depth-`m` invariant reduces to the §9 single-step determinant
+`c·(k·d − b) − (k·c − a)·d = a·d − b·c`. -/
+theorem stepPair_cross_one (k a b c d : ℤ) :
+    (stepPair a c [k]).1 * (stepPair b d [k]).2
+        - (stepPair a c [k]).2 * (stepPair b d [k]).1 = a * d - b * c :=
+  stepPair_cross [k] a b c d
+
 end Erdos1005OQ02

--- a/research/problems/erdos-1005-oq-02/state.md
+++ b/research/problems/erdos-1005-oq-02/state.md
@@ -227,3 +227,51 @@ density count toward `1/12` must sum over. The continuant matrix identity
 - Total attempts: 5
 - Current approach attempts: 5
 - Approaches tried: 1
+
+## Iteration 15 addition (verified, 0-axiom — researcher-3, `lake env lean`)
+
+Added **§15 (depth-`m` unimodularity of the iterated Farey walk)**, 0-sorry /
+0-axiom (verified by host `lean v4.26.0` over the shared main-repo Mathlib
+`.olean` cache; `#print axioms` reports only propext / Quot.sound — `stepPair_snd`
+is axiom-free). One def + four theorems:
+
+- `stepPair a c ks` — the iterated §9/§14 successor returning the final
+  *consecutive pair* `(t_{|ks|}, t_{|ks|+1})`; `stepPair_snd`: its second
+  component is exactly `stepSeq a c ks`.
+- `stepPair_cross` (**headline**) — the walk's cross-determinant
+  `nₘ·dₘ₊₁ − nₘ₊₁·dₘ = a·d − b·c` is **invariant under every step**. Proof: list
+  induction threading the seed pair `(a,c) ↦ (c, k·c−a)`; each step's matrix
+  `[[k,−1],[1,0]]` has determinant 1. The arbitrary-depth generalisation of §9's
+  single-step `farey_succ_unimodular`.
+- `stepPair_cross_unimodular` — a unimodular seed (`b·c = a·d + 1`) stays
+  unimodular (cross `= −1`) at *every* depth: the depth-uniform consecutiveness
+  §9 supplied one step at a time.
+- `stepPair_cross_one` — §9 subsumption at `ks = [k]`.
+
+**IMPORTANT CORRECTION to Iteration 14's "Next Action (1)".** The proposed target
+`K(ks) ≥ 1` for all-`≥1` quotient lists is **mathematically false** for the
+minus-sign continuant: `K([1,1]) = 0`, `K([1,1,1]) = −1` (all-1's continuant is
+period-6 `1,1,0,−1,−1,0,…`, the rotation-by-60° orbit of `[[1,−1],[1,0]]`). Blanket
+continuant positivity is therefore unavailable. The correct sign handle is the
+**determinant (Cassini) invariant**, which §15 establishes: each step matrix has
+det 1, so the walk's cross-determinant is invariant. A future Cassini/continuant
+determinant identity `K(ks)·sc(ks') − K(ks')·sc(ks) = ±1` (for `ks = ks' ++ [k]`)
+follows the same det-1 reasoning and would let `stepPair_cross` be re-expressed
+purely in continuant terms.
+
+File: 1317 → 1391 lines, 71 → 75 theorems, 5 → 6 defs.
+
+**Honest boundary (unchanged).** This is the structural consecutiveness invariant,
+not a bound on the density of admissible quotient lists — the open `1/12`–`1/4`
+constant remains open.
+
+## Next Action (revised)
+
+- **Continuant Cassini identity** (replaces the false positivity target): prove
+  `Continuant ks · m11 − m01 · secondCont ks = 1` where `(m01, m11)` is the
+  companion second column of the step-matrix product (base `(0,1)`), or the
+  equivalent consecutive-list form `K(ks ++ [k])·sc(ks) − K(ks)·sc(ks ++ [k]) = ±1`.
+  This re-expresses `stepPair_cross` purely in continuant terms and certifies the
+  windows' sign structure.
+- **Continuant reversal symmetry** `Continuant ks.reverse = Continuant ks` (true;
+  verified by hand at rungs 2,3) — the palindrome structure a density count exploits.

--- a/src/data/research/problems/erdos-1005-oq-02.json
+++ b/src/data/research/problems/erdos-1005-oq-02.json
@@ -42,7 +42,9 @@
       "simOrd_triple_iff_outer (§11): length-3 run reduces to outer pair (adjacent pairs free by §10)",
       "simOrd_triple (§11): length-3 run similarly ordered iff (2a−kc)(2b−kd)≥0; break interval (2a/c,2b/d) width 2/(cd)",
       "simOrd_long_iff: SimOrd a b g h ↔ ((k₂+1)a−(k₁k₂−1)c)((k₂+1)b−(k₁k₂−1)d) ≥ 0, the long-range criterion for the endpoints of a two-step (length-4) Farey run. [verified, 0-axiom]",
-      "simOrd_quad: length-4 run a/b,c/d,e/f,g/h pairwise similarly ordered ↔ conjunction of the two §11 length-3 windows and the simOrd_long_iff long-range window. [verified, 0-axiom]"
+      "simOrd_quad: length-4 run a/b,c/d,e/f,g/h pairwise similarly ordered ↔ conjunction of the two §11 length-3 windows and the simOrd_long_iff long-range window. [verified, 0-axiom]",
+      "§13/§14 (merged PRs #31014/#31072): the continuant K(ks) = (minus-sign) continuant of a quotient list governs the run-length criterion at every length; simOrd_run_iff states a length-(|ks|+1) run is similarly ordered iff the single continuant window ((1+secondCont ks)a − K·c)((1+secondCont ks)b − K·d) ≥ 0. defs Continuant, secondCont, stepSeq; continuant_cons unified recurrence; stepSeq_eq_continuant closed form.",
+      "§15 (THIS SESSION): stepPair a c ks — the iterated §9/§14 successor returning the final consecutive PAIR (t_{|ks|}, t_{|ks|+1}); stepPair_snd: its 2nd component is stepSeq a c ks. stepPair_cross (HEADLINE): the walk's cross-determinant (stepPair a c ks).1·(stepPair b d ks).2 − (stepPair a c ks).2·(stepPair b d ks).1 = a·d − b·c — INVARIANT under every step (det of [[k,−1],[1,0]] is 1), proved by list induction threading the seed pair. stepPair_cross_unimodular: a unimodular seed (b·c=a·d+1) stays unimodular (cross = −1) at EVERY depth. stepPair_cross_one: §9 subsumption. The depth-uniform form of §9's single-step consecutiveness bridge. [verified, 0-axiom]"
     ],
     "insights": [
       "CORRECTION: the roadmap heuristic that the order-n cap forces O(log n) refinement depth is FALSE for arbitrary mediant chains. The one-sided chain 0/1,1/2,1/3,…,1/n fits Θ(n) levels under q≤n with only LINEAR denominator growth (k+1)·b+d.",
@@ -52,12 +54,15 @@
       "Structural reframing: since adjacency alone never breaks similar ordering, the f(n) ≤ n/4 upper bound is purely a NON-ADJACENT effect — isSimOrdered demands similar ordering for every pair j₁<j₂ in a window, and only the j₂>j₁+1 pairs can fail. The open 1/12–1/4 gap lives in controlling long-range (non-adjacent) similar ordering, not per-step quotients.",
       "The first non-adjacent break is METRIC: a length-3 Farey run breaks iff the successor quotient k falls in (2a/c,2b/d), an interval of width 2(bc−ad)/(cd)=2/(cd). Small cd (large gaps) ⇒ wider break window. This is the bridge from the per-step quotient to the run-length obstruction behind 1/12–1/4.",
       "§12: a length-4 Farey run (two quotients k₁,k₂) breaks ONLY through three explicit non-adjacent windows — the two §11 length-3 windows plus a NEW long-range endpoint window. The three adjacent pairs are always free (§10).",
-      "§12: the long-range endpoint pair a/b,g/h of a length-4 run is controlled by the Stern–Brocot PRODUCT k₁·k₂−1 (combined depth of both steps), not by either quotient alone — the first break invisible to any single Farey step. Closed form g=(k₁k₂−1)c−k₂a, h=(k₁k₂−1)d−k₂b."
+      "§12: the long-range endpoint pair a/b,g/h of a length-4 run is controlled by the Stern–Brocot PRODUCT k₁·k₂−1 (combined depth of both steps), not by either quotient alone — the first break invisible to any single Farey step. Closed form g=(k₁k₂−1)c−k₂a, h=(k₁k₂−1)d−k₂b.",
+      "CORRECTION to the §14 state.md 'Next Action (1)': the proposed target 'K(ks) ≥ 1 for all-≥1 quotient lists' is mathematically FALSE for the minus-sign continuant. Counterexamples: K([1,1]) = 1·1−1 = 0, K([1,1,1]) = 1−1−1 = −1. With all quotients = 1 the continuant is periodic (period 6: 1,1,0,−1,−1,0,…), the rotation-by-60° orbit of [[1,−1],[1,0]]. So blanket continuant positivity is unavailable; the windows' sign structure must be analysed via the DETERMINANT (Cassini) invariant instead — which is what §15 supplies (det of each step matrix is 1, so the walk's cross-determinant is invariant).",
+      "§15: the iterated Farey walk's cross-determinant nₘ·dₘ₊₁ − nₘ₊₁·dₘ is INVARIANT = a·d − b·c at every depth (stepPair_cross), because each §14 step is the unimodular matrix [[k,−1],[1,0]] (det 1). Hence a Farey-adjacent (unimodular) seed walks along genuinely consecutive Farey fractions at EVERY depth — the depth-uniform consecutiveness §9 gave one step at a time. This is the correct structural invariant of the quotient-list walk (replacing the false continuant-positivity target), and the right handle for a Cassini/continuant determinant identity."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Generalize simOrd_quad to length-(m+1) runs: prove the run is similarly ordered iff ALL C(m,2)−m non-adjacent windows are ≥0 (adjacent ones free by §10), with the skip-j window controlled by a Stern–Brocot continuant in the quotients k₁,…,k_{m−1}.",
-      "Aggregate the explicit break windows (length-3 width 2/(cd); length-4 long-range product k₁k₂−1) along a Stern–Brocot path to bound expected run length — the quantitative route toward the open 1/12 constant."
+      "Continuant Cassini identity (REPLACES the false §14 'K(ks)≥1' target): prove K(ks)·m11 − m01·secondCont ks = 1 where (m01,m11) is the companion second column of the step-matrix product (base (0,1)), or the consecutive-list form K(ks++[k])·sc(ks) − K(ks)·sc(ks++[k]) = ±1. Re-expresses §15 stepPair_cross purely in continuant terms; same det-1 reasoning.",
+      "Continuant reversal symmetry K(ks.reverse) = K(ks) (true; holds at rungs 2,3) — the palindrome structure of the run windows a density count exploits.",
+      "Aggregate the explicit break windows (length-3 width 2/(cd); length-4 long-range product k₁k₂−1; general continuant window simOrd_run_iff) along a Stern–Brocot path to bound expected run length — the quantitative route toward the open 1/12 constant."
     ]
   },
   "tags": [
@@ -80,7 +85,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T21:46:38.105Z",
-  "lastUpdate": "2026-06-27",
+  "lastUpdate": "2026-06-27T22:15:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -98,10 +103,10 @@
     {
       "path": "Proofs/Erdos1005ProblemOQ02.lean",
       "filename": "Erdos1005ProblemOQ02.lean",
-      "lineCount": 389,
-      "theoremCount": 24,
+      "lineCount": 1391,
+      "theoremCount": 76,
       "axiomCount": 0,
-      "defCount": 1,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1005ProblemOQ02.lean"


### PR DESCRIPTION
## Summary

Adds **§15** to `Erdos1005ProblemOQ02.lean`: the **depth-`m` unimodularity invariant** of the §14 iterated Farey/Stern–Brocot walk, generalizing §9's single-step `farey_succ_unimodular` to arbitrary run length.

The §14 `stepSeq` recurrence walks along successive Farey neighbours by applying `tₘ₊₁ = kₘ·tₘ − tₘ₋₁` once per quotient in a list `ks`. §15 proves the walk's cross-determinant is invariant:

```
nₘ·dₘ₊₁ − nₘ₊₁·dₘ  =  a·d − b·c    (for every quotient list ks)
```

because each step is the matrix `[[k, −1], [1, 0]]`, which has determinant `1`. Hence a Farey-adjacent (unimodular) seed walks along **genuinely consecutive** Farey fractions at *every* depth — the depth-uniform form of §9's consecutiveness bridge (§9 supplied it one step at a time).

## New declarations (1 def + 4 theorems, all 0-axiom)

- `stepPair a c ks` — iterated successor returning the final consecutive **pair** `(t_{|ks|}, t_{|ks|+1})`; `stepPair_snd` ties its 2nd component to the §14 `stepSeq`.
- `stepPair_cross` *(headline)* — cross-determinant invariance, by list induction threading the seed pair `(a,c) ↦ (c, k·c−a)` + `ring`.
- `stepPair_cross_unimodular` — a unimodular seed (`b·c = a·d + 1`) stays unimodular (cross `= −1`) at every depth.
- `stepPair_cross_one` — §9 subsumption at `ks = [k]`.

## Correction to the prior "Next Action"

The §14 `state.md` Next Action proposed proving `K(ks) ≥ 1` for all-`≥1` quotient lists. This is **mathematically false** for the minus-sign continuant: `K([1,1]) = 1·1−1 = 0` and `K([1,1,1]) = 1−1−1 = −1` (the all-1's continuant is period-6 `1,1,0,−1,−1,0,…`, the rotation-by-60° orbit of `[[1,−1],[1,0]]`). Blanket continuant positivity is unavailable; the correct sign handle is the **determinant (Cassini) invariant**, which §15 establishes. `state.md` / metadata `nextSteps` are revised accordingly (pointing at the continuant Cassini identity and reversal symmetry instead).

## Verification

Host `lean v4.26.0` → exit 0, no errors/warnings. `#print axioms` = `[propext, Quot.sound]` on the three theorems (`stepPair_snd` is axiom-free). File `Erdos1005ProblemOQ02.lean` 1317 → 1391 lines, +1 def +4 theorems, 0 sorries, 0 axioms. (Stale meta counts for this file — last recorded 389/24 — also corrected to 1391/76/6.)

**Honest boundary:** this is the structural consecutiveness invariant, not a density bound on admissible quotient lists; the open `1/12`–`1/4` constant (van Doorn 2025, arXiv:2509.00121) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)