### PR TITLE
Enrich Frobenius monomorphism/automorphism (oq-01-oq-03): structured annotations + cross-refs

### DIFF
--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-03/annotations.json
@@ -8,7 +8,21 @@
       "endLine": 27
     },
     "title": "Module Header: Monomorphism and Automorphism",
-    "content": "Building on the parent Frobenius entry (the map $x \\mapsto x^p$ as a ring homomorphism), this file records the two structural facts that pin down the kernel and image of the Frobenius. On an **integral domain** it is injective — a *monomorphism* — because a domain is reduced and $x^p = y^p \\Rightarrow (x-y)^p = 0 \\Rightarrow x = y$. On a **finite field** the injective Frobenius is automatically surjective (a finite injective self-map is bijective), hence an *automorphism*: every element is a $p$-th power and the map packages as a ring equivalence $K \\simeq_{+*} K$. Fully verified: 0 sorries, 0 axioms, no `native_decide`."
+    "content": "Building on the parent Frobenius entry (the map $x \\mapsto x^p$ as a ring homomorphism), this file records the two structural facts that pin down the kernel and image of the Frobenius. On an **integral domain** it is injective — a *monomorphism* — because a domain is reduced and $x^p = y^p \\Rightarrow (x-y)^p = 0 \\Rightarrow x = y$. On a **finite field** the injective Frobenius is automatically surjective (a finite injective self-map is bijective), hence an *automorphism*: every element is a $p$-th power and the map packages as a ring equivalence $K \\simeq_{+*} K$. Fully verified: 0 sorries, 0 axioms, no `native_decide`.",
+    "mathContext": "The dichotomy in one line: $\\operatorname{Frob}_p$ is always a monomorphism on a reduced ring, and on a finite field $K$ it is an automorphism whose set of fixed points is the prime subfield $\\mathbb{F}_p$. The two faces $x^p = 0 \\Rightarrow x = 0$ (trivial kernel) and $\\forall y\\,\\exists x,\\ x^p = y$ (surjectivity) bracket the structure of the map.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Frobenius endomorphism",
+      "characteristic p",
+      "monomorphism vs automorphism",
+      "perfect field",
+      "freshman's dream"
+    ],
+    "prerequisites": [
+      "ring homomorphisms",
+      "integral domains and reduced rings",
+      "finite fields"
+    ]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-03-injective",
@@ -19,7 +33,21 @@
       "endLine": 41
     },
     "title": "Frobenius is Injective on a Domain (Monomorphism)",
-    "content": "`frobenius_injective`: over an integral domain $R$ of characteristic $p$, the map $x \\mapsto x^p$ is injective. This is Mathlib's `frobenius_inj`, which asks only that $R$ be **reduced** (no nonzero nilpotents) — an integral domain qualifies. The mechanism: $x^p = y^p$ gives $(x-y)^p = x^p - y^p = 0$ (the freshman's dream), and in a reduced ring the only $p$-th root of $0$ is $0$, so $x = y$. The Frobenius is therefore a monomorphism."
+    "content": "`frobenius_injective`: over an integral domain $R$ of characteristic $p$, the map $x \\mapsto x^p$ is injective. This is Mathlib's `frobenius_inj`, which asks only that $R$ be **reduced** (no nonzero nilpotents) — an integral domain qualifies. The mechanism: $x^p = y^p$ gives $(x-y)^p = x^p - y^p = 0$ (the freshman's dream), and in a reduced ring the only $p$-th root of $0$ is $0$, so $x = y$. The Frobenius is therefore a monomorphism.",
+    "mathContext": "$\\operatorname{Frob}_p(x) = \\operatorname{Frob}_p(y) \\Rightarrow x^p = y^p \\Rightarrow (x-y)^p = \\sum_{k} \\binom{p}{k} x^k(-y)^{p-k} = x^p - y^p = 0$, where every middle binomial $\\binom{p}{k}$ ($0 < k < p$) is divisible by $p$ and hence vanishes in characteristic $p$. In a reduced ring $z^p = 0 \\Rightarrow z = 0$, so $x - y = 0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "injective ring homomorphism",
+      "reduced ring (IsReduced)",
+      "nilpotent elements",
+      "freshman's dream (x+y)^p = x^p + y^p",
+      "kernel of a ring map"
+    ],
+    "prerequisites": [
+      "integral domain implies reduced",
+      "binomial theorem mod p",
+      "frobenius_inj (Mathlib)"
+    ]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-03-cancellation",
@@ -30,7 +58,21 @@
       "endLine": 53
     },
     "title": "Cancellation and Trivial Kernel",
-    "content": "`pow_p_left_inj`: the injectivity as an explicit cancellation rule, $x^p = y^p \\iff x = y$ — the forward direction unfolds `frobenius_def` and applies `frobenius_injective`, the reverse is `rfl`.\n\n`pow_p_eq_zero_iff`: specializing $y = 0$ gives the trivial-kernel statement $x^p = 0 \\iff x = 0$, after rewriting $0^p = 0$ via `zero_pow (expChar_pos R p).ne'`. This 'no nonzero nilpotents' fact is the precise content that makes the Frobenius injective."
+    "content": "`pow_p_left_inj`: the injectivity as an explicit cancellation rule, $x^p = y^p \\iff x = y$ — the forward direction unfolds `frobenius_def` and applies `frobenius_injective`, the reverse is `rfl`.\n\n`pow_p_eq_zero_iff`: specializing $y = 0$ gives the trivial-kernel statement $x^p = 0 \\iff x = 0$, after rewriting $0^p = 0$ via `zero_pow (expChar_pos R p).ne'`. This 'no nonzero nilpotents' fact is the precise content that makes the Frobenius injective.",
+    "mathContext": "Cancellation: $x^p = y^p \\iff x = y$. Trivial kernel (the $y = 0$ instance): $x^p = 0 \\iff x = 0$, valid once $0^p = 0$, i.e. $p \\neq 0$ — supplied by `(expChar_pos R p).ne'`. The trivial kernel is exactly the reduced-ring axiom $\\operatorname{nil}(R) = 0$ specialized to $p$-th powers.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cancellation law",
+      "trivial kernel",
+      "exponential characteristic (ExpChar)",
+      "zero_pow",
+      "reduced ring"
+    ],
+    "prerequisites": [
+      "iff proofs in Lean",
+      "frobenius_def",
+      "expChar_pos"
+    ]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-03-bijective",
@@ -41,7 +83,21 @@
       "endLine": 68
     },
     "title": "Frobenius is Bijective on a Finite Field (Automorphism)",
-    "content": "`frobenius_bijective`: over a finite field $K$ the Frobenius is bijective. A finite field is a finite integral domain, so the injective Frobenius (`frobenius_injective`) is automatically surjective by the pigeonhole principle `Finite.injective_iff_bijective`. Finiteness is exactly what upgrades the monomorphism to an *automorphism* — on an infinite domain (e.g. $\\mathbb{F}_p(t)$) the Frobenius is injective but not surjective."
+    "content": "`frobenius_bijective`: over a finite field $K$ the Frobenius is bijective. A finite field is a finite integral domain, so the injective Frobenius (`frobenius_injective`) is automatically surjective by the pigeonhole principle `Finite.injective_iff_bijective`. Finiteness is exactly what upgrades the monomorphism to an *automorphism* — on an infinite domain (e.g. $\\mathbb{F}_p(t)$) the Frobenius is injective but not surjective.",
+    "mathContext": "For a self-map $f : K \\to K$ of a finite set, $f$ injective $\\iff f$ surjective $\\iff f$ bijective (pigeonhole). Combined with injectivity over the domain $K$, this yields bijectivity. The hypotheses `[Field K] [Finite K]` are precisely a finite field; the result fails the moment $K$ is infinite, e.g. $\\operatorname{Frob}_p$ on $\\mathbb{F}_p(t)$ misses $t$ since $t$ has no $p$-th root.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "finite field",
+      "bijection",
+      "automorphism",
+      "Finite.injective_iff_bijective"
+    ],
+    "prerequisites": [
+      "finite types (Finite)",
+      "injective iff surjective on a finite set",
+      "a finite field is a finite domain"
+    ]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-03-surjective",
@@ -52,7 +108,21 @@
       "endLine": 74
     },
     "title": "Every Element is a p-th Power",
-    "content": "`exists_pow_p`: surjectivity restated — over a finite field, $\\forall y, \\exists x,\\ x^p = y$. The witness comes from `frobenius_bijective.surjective`, with `frobenius_def` unfolded. This is the defining property of a **perfect field**, proved here for the finite case as a corollary of finite injective $\\Rightarrow$ surjective."
+    "content": "`exists_pow_p`: surjectivity restated — over a finite field, $\\forall y, \\exists x,\\ x^p = y$. The witness comes from `frobenius_bijective.surjective`, with `frobenius_def` unfolded. This is the defining property of a **perfect field**, proved here for the finite case as a corollary of finite injective $\\Rightarrow$ surjective.",
+    "mathContext": "$\\forall y \\in K,\\ \\exists x \\in K,\\ x^p = y$ — i.e. the $p$-power map $K \\to K$ is onto, so $K = K^p$. A field of characteristic $p$ with $K = K^p$ is by definition **perfect**; finite fields are the archetype. Equivalently the $p$-th root $y^{1/p} = y^{p^{n-1}}$ is single-valued, where $|K| = p^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "surjectivity",
+      "perfect field",
+      "p-th roots",
+      "K = K^p",
+      "separability"
+    ],
+    "prerequisites": [
+      "Function.Surjective",
+      "frobenius_bijective",
+      "definition of a perfect field"
+    ]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-03-equiv",
@@ -63,7 +133,21 @@
       "endLine": 83
     },
     "title": "The Frobenius Ring Automorphism",
-    "content": "`frobeniusEquiv`: the Frobenius of a finite field packaged as a genuine ring **automorphism** $K \\simeq_{+*} K$, via `RingEquiv.ofBijective` applied to the bijective Frobenius. `frobeniusEquiv_apply` ($\\mathrm{frobeniusEquiv}\\,x = x^p$) and `coe_frobeniusEquiv` (the coercion equals the underlying ring hom) are both `rfl`. This is the generator of $\\mathrm{Gal}(K / \\mathbb{F}_p)$. It is `noncomputable` only because the inverse is extracted via choice — no extra axioms are introduced."
+    "content": "`frobeniusEquiv`: the Frobenius of a finite field packaged as a genuine ring **automorphism** $K \\simeq_{+*} K$, via `RingEquiv.ofBijective` applied to the bijective Frobenius. `frobeniusEquiv_apply` ($\\mathrm{frobeniusEquiv}\\,x = x^p$) and `coe_frobeniusEquiv` (the coercion equals the underlying ring hom) are both `rfl`. This is the generator of $\\mathrm{Gal}(K / \\mathbb{F}_p)$. It is `noncomputable` only because the inverse is extracted via choice — no extra axioms are introduced.",
+    "mathContext": "`RingEquiv.ofBijective` upgrades a bijective ring hom $\\varphi$ to $\\varphi : K \\simeq_{+*} K$ by adjoining the (choice-extracted) inverse $\\varphi^{-1}$. Here $\\varphi = \\operatorname{Frob}_p$, so $\\mathrm{frobeniusEquiv}$ is the field automorphism $x \\mapsto x^p$ fixing $\\mathbb{F}_p$ pointwise; in $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p) \\cong \\mathbb{Z}/n$ it is the canonical generator of order $n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "ring equivalence (RingEquiv)",
+      "field automorphism",
+      "Galois group of a finite field",
+      "RingEquiv.ofBijective",
+      "noncomputable definitions"
+    ],
+    "prerequisites": [
+      "ring isomorphisms",
+      "RingEquiv.ofBijective",
+      "noncomputable and Classical.choice"
+    ]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-03-concrete",
@@ -74,6 +158,20 @@
       "endLine": 100
     },
     "title": "Concrete Checks over ZMod 5 and ZMod 7",
-    "content": "With `Fact (Nat.Prime 5)` / `Fact (Nat.Prime 7)` supplied, $\\mathbb{Z}/5$ and $\\mathbb{Z}/7$ are finite fields and `ExpChar` resolves from `CharP` plus the prime fact. `frobenius_bijective_zmod_five`: $x \\mapsto x^5$ is bijective on $\\mathbb{Z}/5$ (here the identity, by Fermat). `exists_pow_seven_zmod_seven`: every element of $\\mathbb{Z}/7$ is a $7$-th power. Both are direct instantiations of the general finite-field theorems."
+    "content": "With `Fact (Nat.Prime 5)` / `Fact (Nat.Prime 7)` supplied, $\\mathbb{Z}/5$ and $\\mathbb{Z}/7$ are finite fields and `ExpChar` resolves from `CharP` plus the prime fact. `frobenius_bijective_zmod_five`: $x \\mapsto x^5$ is bijective on $\\mathbb{Z}/5$ (here the identity, by Fermat). `exists_pow_seven_zmod_seven`: every element of $\\mathbb{Z}/7$ is a $7$-th power. Both are direct instantiations of the general finite-field theorems.",
+    "mathContext": "On the prime field $\\mathbb{Z}/p$ the Frobenius $x \\mapsto x^p$ is the **identity** by Fermat's little theorem ($a^p \\equiv a \\pmod p$), so $\\mathrm{frobeniusEquiv}$ is trivial there — the nontrivial automorphisms appear only over proper extensions $\\mathbb{F}_{p^n}$, $n > 1$. Thus $a = a^7$ for all $a \\in \\mathbb{Z}/7$ exhibits surjectivity concretely.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fermat's little theorem",
+      "ZMod p as a field",
+      "Fact and instance resolution",
+      "prime subfield",
+      "identity automorphism"
+    ],
+    "prerequisites": [
+      "ZMod p instances",
+      "Fact (Nat.Prime p)",
+      "Fermat's little theorem"
+    ]
   }
 ]

--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-03/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/FrobeniusEndomorphismOQ01OQ03.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide, so no Lean.ofReduceBool is introduced. The automorphism frobeniusEquiv is noncomputable only because RingEquiv.ofBijective uses choice to extract the inverse — this introduces no extra axioms beyond the standard triple.",
@@ -84,6 +84,21 @@
       "proofId": "frobenius-endomorphism-oq-01",
       "relationship": "extends",
       "description": "The parent packages the Frobenius x ↦ x^p as a ring homomorphism in prime characteristic and characterizes it as the identity on ZMod p and on finite fields. This entry answers its lead open question, supplying the two structural facts the parent left open: injectivity on a domain (monomorphism) and bijectivity on a finite field (automorphism)."
+    },
+    {
+      "proofId": "frobenius-endomorphism-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Takes the automorphism frobeniusEquiv : K ≃+* K built here and exhibits it as the generator of the cyclic Galois group Gal(𝔽_{p^n} / 𝔽_p) of order n — answering this entry's first open question."
+    },
+    {
+      "proofId": "frobenius-endomorphism-oq-01-oq-02-oq-02",
+      "relationship": "contrasts",
+      "description": "The exact counterpoint to the finite-field automorphism: on the infinite field 𝔽_p(X) the Frobenius is injective but NOT surjective (X has no p-th root), an explicit imperfect field — answering this entry's second open question about where surjectivity fails."
+    },
+    {
+      "proofId": "frobenius-endomorphism-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Identifies the fixed field of the Frobenius automorphism as the prime subfield 𝔽_p — the complementary structural fact: this entry shows the Frobenius is an automorphism, that entry pins down exactly which elements it fixes."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `frobenius-endomorphism-oq-01-oq-03` (passes: 0, quality: 60).

## Changes

**annotations.json** — all 7 annotations were missing the *required* `significance` field and the structured metadata. Added:
- `significance` (critical / key / supporting) to every annotation
- `mathContext` — LaTeX explaining the math at each section (freshman's dream binomial argument, pigeonhole injective⇒bijective, perfect-field K=Kᵖ, RingEquiv.ofBijective, Fermat identity on the prime field)
- `relatedConcepts` and `prerequisites` arrays

**meta.json**
- Added 3 cross-references that directly answer this entry's two open questions:
  - `frobenius-endomorphism-oq-01-oq-01` (Galois generator) — answers OQ #1
  - `frobenius-endomorphism-oq-01-oq-02-oq-02` (imperfect field 𝔽ₚ(X)) — answers OQ #2
  - `frobenius-endomorphism-oq-01-oq-02` (fixed field = prime subfield) — complementary
- Adopted the audit finding from open PR #31069: **badge `original` → `mathlib`**. The three core results (`frobenius_inj`, `Finite.injective_iff_bijective`, `RingEquiv.ofBijective`) are one-line Mathlib delegations, so `mathlib` is the honest badge. Status remains `verified` (0 sorries, 0 axioms, no native_decide — unchanged).

## Verification
- `pnpm build` passes (typecheck + gallery data-gen)
- meta.json 16.2 KB (well under 60 KB cap); all collections under caps
- Both JSON files valid

Note: supersedes the single-line badge change in PR #31069 by folding it into this enrichment.