### PR TITLE
research(binomial-theorem-oq-05-oq-02): weighted AM–GM from Bernoulli via repeat-with-multiplicity

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -470,6 +470,7 @@ import Proofs.BinomialTheoremOQ04OQ03
 import Proofs.BinomialTheoremOQ04OQ04
 import Proofs.BinomialTheoremOQ05
 import Proofs.BinomialTheoremOQ05OQ01
+import Proofs.BinomialTheoremOQ05OQ02
 import Proofs.BirchSwinnertonDyer
 import Proofs.BirchSwinnertonDyerAristotle
 import Proofs.BirchSwinnertonDyerOQ01

--- a/proofs/Proofs/BinomialTheoremOQ05OQ02.lean
+++ b/proofs/Proofs/BinomialTheoremOQ05OQ02.lean
@@ -1,0 +1,294 @@
+/-
+# AM–GM from Bernoulli: the first-order-truncation route
+
+**Open Question (binomial-theorem-oq-05-oq-02).** The parent entry
+`binomial-theorem-oq-05` proved Bernoulli's inequality `1 + n·a ≤ (1 + a)ⁿ` as
+the *first-order truncation* of the binomial expansion. The follow-up asks:
+does that same viewpoint give a clean Lean proof of the AM–GM inequality, the
+way Bernoulli "applied termwise" classically yields it?
+
+**Answer: yes.** The unweighted AM–GM inequality
+
+  `∏ xᵢ ≤ (mean xᵢ)ⁿ`            (`amgm_list`)
+
+falls out of a single list induction whose *only* analytic input is the
+gallery's Bernoulli inequality in tangent-line form `1 + n·(r − 1) ≤ rⁿ`
+(`bernoulli_pow`, i.e. Mathlib's `one_add_mul_sub_le_pow`). There are **no
+logarithms, no convexity of `exp`, no Jensen inequality** — in pointed contrast
+to Mathlib's `Real.geom_mean_le_arith_mean_weighted`, whose proof routes through
+`convexOn_exp.map_sum_le`. The whole argument is the elementary
+"`A_{n+1}^{n+1} ≥ A_n^n · x_{n+1}` via Bernoulli" step.
+
+We then promote it to the **rational-weighted** AM–GM
+
+  `∏ xᵢ ^ kᵢ ≤ (mean) ^ (∑ kᵢ)`   (`amgm_weighted_nat`)
+
+by the classical *repeat-with-multiplicity* reduction (replace each `xᵢ` by `kᵢ`
+copies), so the weighted inequality the open question names is obtained from the
+Bernoulli proof with no further analytic input.
+
+**What this file proves.**
+- `bernoulli_pow` — tangent-line Bernoulli (the kernel), re-exported from the
+  parent's theme.
+- `amgm_step` — the inductive heart: `x · Aₜⁿ ≤ A^{n+1}` whenever
+  `(n+1)·A = x + n·Aₜ`. This is *pure* Bernoulli.
+- `amgm_list` — unweighted AM–GM for a list of nonnegative reals.
+- `amgm_prod_le` — the same with the product/sum written multiplicatively as a
+  clean `∏ ≤ (∑/n)ⁿ` over `Finset` indices.
+- `repList` and `repList_{prod,sum,length,nonneg}` — the repeat-with-multiplicity
+  bookkeeping: building, for a list of `(value, weight)` pairs, the flat list
+  containing each value with its multiplicity.
+- `amgm_weighted_list` / `amgm_weighted_nat` — rational/natural-weighted AM–GM via
+  the repetition reduction (list form and `Finset` form).
+- Numeric witnesses.
+
+All results are fully verified: 0 sorries, 0 axioms.
+-/
+import Mathlib
+
+namespace BinomialTheoremOQ05OQ02
+
+open scoped BigOperators
+
+/-! ## The kernel: tangent-line Bernoulli -/
+
+/-- **Bernoulli, tangent-line form** (the gallery's `bernoulli_pow`). For
+`r ≥ -1` and any `n : ℕ`, `1 + n·(r − 1) ≤ rⁿ`: the tangent line to `t ↦ tⁿ` at
+`t = 1` lies below the curve. This single inequality is the *only* analytic
+ingredient of the AM–GM proof below. -/
+theorem bernoulli_pow {r : ℝ} (hr : -1 ≤ r) (n : ℕ) : 1 + n * (r - 1) ≤ r ^ n :=
+  one_add_mul_sub_le_pow hr n
+
+/-! ## The inductive heart -/
+
+/-- **The Bernoulli step.** Splicing a new nonnegative term `x` into a sample
+whose previous mean was `Aₜ ≥ 0`, giving the new mean `A`, satisfies
+`x · Aₜⁿ ≤ A^{n+1}`, provided the means obey the bookkeeping identity
+`(n+1)·A = x + n·Aₜ`.
+
+This is exactly Bernoulli: dividing through by `Aₜ^{n+1}` (when `Aₜ > 0`) turns
+the claim into `(n+1)·r − n ≤ r^{n+1}` with `r = A/Aₜ`, which is
+`bernoulli_pow` rearranged. -/
+theorem amgm_step {n : ℕ} {x At A : ℝ} (hx : 0 ≤ x) (hAt : 0 ≤ At) (hA : 0 ≤ A)
+    (hrel : ((n : ℝ) + 1) * A = x + n * At) : x * At ^ n ≤ A ^ (n + 1) := by
+  rcases eq_or_lt_of_le hAt with hAt0 | hAtpos
+  · -- Degenerate case `Aₜ = 0`: the previous sample was all zeros.
+    rcases n with _ | m
+    · -- `n = 0`: then `A = x`, and both sides equal `x`.
+      simp only [Nat.cast_zero, zero_add, one_mul, Nat.zero_eq, pow_zero, mul_one,
+        pow_one] at *
+      linarith [hrel]
+    · -- `n = m+1 ≥ 1`: `Aₜⁿ = 0`, so the left side is `0 ≤ A^{n+1}`.
+      have : At ^ (m + 1) = 0 := by rw [← hAt0]; simp
+      rw [this, mul_zero]
+      positivity
+  · -- Main case `Aₜ > 0`: rescale by `r = A / Aₜ` and apply Bernoulli.
+    set r : ℝ := A / At with hr_def
+    have hAtne : At ≠ 0 := ne_of_gt hAtpos
+    have hr0 : 0 ≤ r := div_nonneg hA hAt
+    have hArAt : A = r * At := by field_simp [hr_def]
+    -- The bookkeeping identity in terms of `r`: `x = ((n+1)·r − n)·Aₜ`.
+    have hx_eq : x = (((n : ℝ) + 1) * r - n) * At := by
+      have : ((n : ℝ) + 1) * (r * At) = x + n * At := by rw [← hArAt]; exact hrel
+      nlinarith [this]
+    -- Bernoulli: `(n+1)·r − n ≤ r^{n+1}`.
+    have hb : ((n : ℝ) + 1) * r - n ≤ r ^ (n + 1) := by
+      have h := bernoulli_pow (by linarith : (-1 : ℝ) ≤ r) (n + 1)
+      have hcast : (1 : ℝ) + ((n : ℝ) + 1) * (r - 1) = ((n : ℝ) + 1) * r - n := by ring
+      have : (1 : ℝ) + ((n + 1 : ℕ) : ℝ) * (r - 1) ≤ r ^ (n + 1) := h
+      push_cast at this
+      linarith [this]
+    -- Assemble: both sides carry a common factor `Aₜ^{n+1} ≥ 0`.
+    have hpow : (0 : ℝ) ≤ At ^ (n + 1) := by positivity
+    calc x * At ^ n
+        = (((n : ℝ) + 1) * r - n) * At ^ (n + 1) := by
+          rw [hx_eq]; ring
+      _ ≤ r ^ (n + 1) * At ^ (n + 1) := by exact mul_le_mul_of_nonneg_right hb hpow
+      _ = A ^ (n + 1) := by rw [hArAt, mul_pow]
+
+/-! ## Unweighted AM–GM -/
+
+/-- **Unweighted AM–GM, list form.** For a list `l` of nonnegative reals,
+`∏ l ≤ (mean l)^(length l)`, where `mean l = (∑ l) / (length l)`. Proved by a
+single induction on `l`, the cons-step being `amgm_step` — i.e. pure Bernoulli.
+The empty list gives `1 ≤ (0/0)^0 = 1`. -/
+theorem amgm_list (l : List ℝ) (hl : ∀ x ∈ l, 0 ≤ x) :
+    l.prod ≤ (l.sum / l.length) ^ l.length := by
+  induction l with
+  | nil => simp
+  | cons x t ih =>
+    have hx : 0 ≤ x := hl x (List.mem_cons_self x t)
+    have ht : ∀ y ∈ t, 0 ≤ y := fun y hy => hl y (List.mem_cons_of_mem x hy)
+    have hts : 0 ≤ t.sum := List.sum_nonneg ht
+    set n : ℕ := t.length with hn
+    set At : ℝ := t.sum / n with hAt_def
+    set A : ℝ := (x + t.sum) / ((n : ℝ) + 1) with hA_def
+    have hAt : 0 ≤ At := div_nonneg hts (by positivity)
+    have hA : 0 ≤ A := by
+      apply div_nonneg (by linarith) (by positivity)
+    -- Bookkeeping `(n+1)·A = x + n·Aₜ`.
+    have hnAt : (n : ℝ) * At = t.sum := by
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · -- `n = 0` forces `t = []`, so `t.sum = 0`.
+        have : t = [] := List.length_eq_zero_iff.mp hn0
+        simp [this, hn0]
+      · have : (n : ℝ) ≠ 0 := by positivity
+        rw [hAt_def]; field_simp
+    have hrel : ((n : ℝ) + 1) * A = x + n * At := by
+      rw [hA_def]; field_simp; linarith [hnAt]
+    -- Apply the inductive hypothesis, then the Bernoulli step.
+    have ih' : t.prod ≤ At ^ n := ih ht
+    have step : x * At ^ n ≤ A ^ (n + 1) := amgm_step hx hAt hA hrel
+    calc (x :: t).prod
+        = x * t.prod := by rw [List.prod_cons]
+      _ ≤ x * At ^ n := by exact mul_le_mul_of_nonneg_left ih' hx
+      _ ≤ A ^ (n + 1) := step
+      _ = ((x :: t).sum / (x :: t).length) ^ (x :: t).length := by
+          rw [List.sum_cons, List.length_cons, hA_def]; push_cast; ring_nf
+
+/-! ## Multiplicative `Finset` form -/
+
+/-- **Unweighted AM–GM, `Finset` form.** For nonnegative reals `z i` indexed by
+a `Finset s` of size `n`, `∏ z ≤ (∑ z / n)ⁿ`. This is `amgm_list` transported
+along `s.toList`. -/
+theorem amgm_prod_le {ι : Type*} (s : Finset ι) (z : ι → ℝ)
+    (hz : ∀ i ∈ s, 0 ≤ z i) :
+    ∏ i ∈ s, z i ≤ ((∑ i ∈ s, z i) / s.card) ^ s.card := by
+  have hmap : ∀ x ∈ s.toList.map z, 0 ≤ x := by
+    intro x hx
+    simp only [List.mem_map, Finset.mem_toList] at hx
+    obtain ⟨i, hi, rfl⟩ := hx
+    exact hz i hi
+  have key := amgm_list (s.toList.map z) hmap
+  rwa [Finset.prod_map_toList, Finset.sum_map_toList,
+    List.length_map, Finset.length_toList] at key
+
+/-! ## Rational/natural-weighted AM–GM via repetition
+
+The classical promotion of unweighted AM–GM to natural-weighted AM–GM: replace
+each value `xᵢ` by `kᵢ` copies and apply the unweighted inequality to the
+resulting flat sample. No new analytic input — the only inequality used is still
+`amgm_list`, hence still pure Bernoulli. -/
+
+/-- The *repetition list* of a list of `(value, weight)` pairs: each pair
+`(v, k)` contributes `k` copies of `v`. -/
+def repList (p : List (ℝ × ℕ)) : List ℝ :=
+  p.flatMap (fun q => List.replicate q.2 q.1)
+
+@[simp] theorem repList_nil : repList [] = [] := rfl
+
+@[simp] theorem repList_cons (q : ℝ × ℕ) (p : List (ℝ × ℕ)) :
+    repList (q :: p) = List.replicate q.2 q.1 ++ repList p := by
+  simp [repList, List.flatMap_cons]
+
+/-- The product over the repetition list is `∏ vᵢ ^ kᵢ`. -/
+theorem repList_prod (p : List (ℝ × ℕ)) :
+    (repList p).prod = (p.map (fun q => q.1 ^ q.2)).prod := by
+  induction p with
+  | nil => simp
+  | cons q p ih => simp [repList_cons, List.prod_append, List.prod_replicate, ih]
+
+/-- The sum over the repetition list is `∑ kᵢ · vᵢ` (the weighted total). -/
+theorem repList_sum (p : List (ℝ × ℕ)) :
+    (repList p).sum = (p.map (fun q => (q.2 : ℝ) * q.1)).sum := by
+  induction p with
+  | nil => simp
+  | cons q p ih =>
+      simp [repList_cons, List.sum_append, List.sum_replicate, nsmul_eq_mul, ih]
+
+/-- The length of the repetition list is the total weight `∑ kᵢ`. -/
+theorem repList_length (p : List (ℝ × ℕ)) :
+    (repList p).length = (p.map (fun q => q.2)).sum := by
+  induction p with
+  | nil => simp
+  | cons q p ih => simp [repList_cons, List.length_append, List.length_replicate, ih]
+
+/-- Nonnegativity transfers from the values to every entry of the repetition
+list. -/
+theorem repList_nonneg (p : List (ℝ × ℕ)) (hp : ∀ q ∈ p, 0 ≤ q.1) :
+    ∀ x ∈ repList p, 0 ≤ x := by
+  intro x hx
+  rw [repList, List.mem_flatMap] at hx
+  obtain ⟨q, hq, hxq⟩ := hx
+  rw [List.eq_of_mem_replicate hxq]
+  exact hp q hq
+
+/-- **Natural-weighted AM–GM, list-of-pairs form.** For pairs `(vᵢ, kᵢ)` with
+`vᵢ ≥ 0`, the weighted geometric mean is bounded by the weighted arithmetic mean:
+`∏ vᵢ^{kᵢ} ≤ ((∑ kᵢ·vᵢ) / (∑ kᵢ))^{∑ kᵢ}`. Obtained from `amgm_list` applied to
+the repetition list — pure Bernoulli, no logarithms. -/
+theorem amgm_weighted_list (p : List (ℝ × ℕ)) (hp : ∀ q ∈ p, 0 ≤ q.1) :
+    (p.map (fun q => q.1 ^ q.2)).prod ≤
+      ((p.map (fun q => (q.2 : ℝ) * q.1)).sum / (p.map (fun q => q.2)).sum) ^
+        (p.map (fun q => q.2)).sum := by
+  have key := amgm_list (repList p) (repList_nonneg p hp)
+  rwa [repList_prod, repList_sum, repList_length] at key
+
+/-- **Natural-weighted AM–GM, `Finset` form.** For nonnegative reals `x i` with
+natural-number weights `k i` over a `Finset s`,
+`∏ x i ^ k i ≤ ((∑ k i · x i) / (∑ k i))^(∑ k i)`. This is the inequality the open
+question names, derived from the Bernoulli route by the repetition reduction. -/
+theorem amgm_weighted_nat {ι : Type*} (s : Finset ι) (x : ι → ℝ) (k : ι → ℕ)
+    (hx : ∀ i ∈ s, 0 ≤ x i) :
+    ∏ i ∈ s, x i ^ k i ≤
+      ((∑ i ∈ s, (k i : ℝ) * x i) / (∑ i ∈ s, k i)) ^ (∑ i ∈ s, k i) := by
+  set p : List (ℝ × ℕ) := s.toList.map (fun i => (x i, k i)) with hp_def
+  have hp : ∀ q ∈ p, 0 ≤ q.1 := by
+    intro q hq
+    rw [hp_def, List.mem_map] at hq
+    obtain ⟨i, hi, rfl⟩ := hq
+    exact hx i (Finset.mem_toList.mp hi)
+  have key := amgm_weighted_list p hp
+  have e1 : (p.map (fun q => q.1 ^ q.2)).prod = ∏ i ∈ s, x i ^ k i := by
+    rw [hp_def, List.map_map]
+    simp only [Function.comp_def]
+    exact Finset.prod_map_toList s (fun i => x i ^ k i)
+  have e2 : (p.map (fun q => (q.2 : ℝ) * q.1)).sum = ∑ i ∈ s, (k i : ℝ) * x i := by
+    rw [hp_def, List.map_map]
+    simp only [Function.comp_def]
+    exact Finset.sum_map_toList s (fun i => (k i : ℝ) * x i)
+  have e3 : (p.map (fun q => q.2)).sum = ∑ i ∈ s, k i := by
+    rw [hp_def, List.map_map]
+    simp only [Function.comp_def]
+    exact Finset.sum_map_toList s (fun i => k i)
+  rw [e1, e2, e3] at key
+  exact key
+
+/-! ## Numeric witnesses -/
+
+/-- Two-variable AM–GM `√(ab) ≤ (a+b)/2`, here as `ab ≤ ((a+b)/2)²`, falls out of
+`amgm_list [a, b]` — i.e. straight from Bernoulli with `n = 2`. -/
+example (a b : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) : a * b ≤ ((a + b) / 2) ^ 2 := by
+  have h := amgm_list [a, b] (by
+    intro x hx; simp only [List.mem_cons, List.mem_singleton, List.not_mem_nil,
+      or_false] at hx; rcases hx with rfl | rfl <;> assumption)
+  simpa using h
+
+/-- Three-variable AM–GM `abc ≤ ((a+b+c)/3)³`. -/
+example (a b c : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) :
+    a * b * c ≤ ((a + b + c) / 3) ^ 3 := by
+  have h := amgm_list [a, b, c] (by
+    intro x hx
+    simp only [List.mem_cons, List.mem_singleton, List.not_mem_nil, or_false] at hx
+    rcases hx with rfl | rfl | rfl <;> assumption)
+  simp only [List.prod_cons, List.prod_nil, mul_one, List.sum_cons, List.sum_nil,
+    add_zero, List.length_cons, List.length_nil] at h
+  norm_num at h ⊢
+  linarith [h]
+
+/-- A concrete instance: `2·4·8 = 64 ≤ ((2+4+8)/3)³ = (14/3)³ ≈ 101.6`. -/
+example : (2 : ℝ) * 4 * 8 ≤ ((2 + 4 + 8) / 3) ^ 3 := by norm_num
+
+/-- **Weighted** witness: with weights `(2, 1)` on `(a, b)`, the weighted AM–GM
+gives `a² · b ≤ ((2a + b)/3)³`. This is `amgm_weighted_list [(a,2), (b,1)]`. -/
+example (a b : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) :
+    a ^ 2 * b ^ 1 ≤ ((2 * a + b) / 3) ^ 3 := by
+  have h := amgm_weighted_list [(a, 2), (b, 1)] (by
+    intro q hq
+    simp only [List.mem_cons, List.mem_singleton, List.not_mem_nil, or_false] at hq
+    rcases hq with rfl | rfl
+    · exact ha
+    · exact hb)
+  simpa using h
+
+end BinomialTheoremOQ05OQ02

--- a/src/data/proofs/binomial-theorem-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-05-oq-02/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "amgm-bernoulli-context",
+    "proofId": "binomial-theorem-oq-05-oq-02",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "AM–GM is Bernoulli, Applied Termwise",
+    "content": "The parent entry proved Bernoulli's inequality 1 + n·(r−1) ≤ rⁿ as the first-order truncation of the binomial expansion. This file shows that the same inequality — with no further analytic input — proves AM–GM. A single list induction whose cons-step is Bernoulli gives the unweighted geometric-mean ≤ arithmetic-mean bound; the classical repeat-with-multiplicity reduction promotes it to the natural-weighted form. Contrast Mathlib's Real.geom_mean_le_arith_mean_weighted, which goes through convexity of exp and Jensen.",
+    "mathContext": "The geometric mean $\\left(\\prod x_i\\right)^{1/n}$ is bounded by the arithmetic mean $\\frac1n\\sum x_i$; equivalently $\\prod x_i \\le \\left(\\frac{\\sum x_i}{n}\\right)^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bernoulli's inequality",
+      "AM–GM inequality",
+      "first-order truncation",
+      "convexity of exp (the route this proof avoids)"
+    ],
+    "prerequisites": [
+      "Bernoulli's inequality in tangent-line form",
+      "arithmetic and geometric means"
+    ]
+  },
+  {
+    "id": "amgm-step-insight",
+    "proofId": "binomial-theorem-oq-05-oq-02",
+    "range": { "startLine": 62, "endLine": 107 },
+    "type": "insight",
+    "title": "The Inductive Step is Bernoulli, Rescaled",
+    "content": "Splicing a new nonnegative term x into a sample of mean Aₜ to form the new mean A satisfies x·Aₜⁿ ≤ A^{n+1}, given the bookkeeping (n+1)·A = x + n·Aₜ. When Aₜ > 0, set r = A/Aₜ: the claim becomes ((n+1)·r − n)·Aₜ^{n+1} ≤ r^{n+1}·Aₜ^{n+1}, and dividing by Aₜ^{n+1} leaves exactly Bernoulli (n+1)·r − n ≤ r^{n+1}. This single step is the only place an inequality (other than nonnegativity) is consumed.",
+    "mathContext": "With $r = A/A_t$, $x = ((n+1)r - n)A_t$, so $x A_t^n = ((n+1)r-n)A_t^{n+1} \\le r^{n+1} A_t^{n+1} = A^{n+1}$ by Bernoulli $1 + (n+1)(r-1) \\le r^{n+1}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Bernoulli's inequality",
+      "induction on sample size",
+      "homogeneous rescaling"
+    ],
+    "prerequisites": [
+      "Bernoulli's inequality",
+      "manipulating powers and means"
+    ]
+  },
+  {
+    "id": "amgm-list-theorem",
+    "proofId": "binomial-theorem-oq-05-oq-02",
+    "range": { "startLine": 109, "endLine": 164 },
+    "type": "theorem",
+    "title": "Unweighted AM–GM by Bernoulli Induction",
+    "content": "amgm_list proves ∏ l ≤ (l.sum / l.length)^l.length for a list of nonnegative reals by a single induction, the cons-step being amgm_step. Choosing At = t.sum/n and A = (x + t.sum)/(n+1) makes the step's hypothesis (n+1)·A = x + n·At a pure arithmetic identity. amgm_prod_le repackages the result over a Finset as ∏ z ≤ (∑ z / card)^card by transporting along s.toList.",
+    "mathContext": "$\\prod_{i} x_i \\le \\left(\\frac{1}{n}\\sum_i x_i\\right)^n$ for $x_i \\ge 0$, with $n$ the sample size.",
+    "significance": "key",
+    "relatedConcepts": [
+      "AM–GM inequality",
+      "list induction",
+      "Finset.toList transport"
+    ],
+    "prerequisites": [
+      "the inductive step amgm_step",
+      "sums and products over lists and Finsets"
+    ]
+  },
+  {
+    "id": "amgm-weighted-theorem",
+    "proofId": "binomial-theorem-oq-05-oq-02",
+    "range": { "startLine": 166, "endLine": 255 },
+    "type": "theorem",
+    "title": "Weighted AM–GM via Repeat-with-Multiplicity",
+    "content": "Natural weights are multiplicities. The repetition list repList sends a list of (value, weight) pairs to the flat list with each value repeated by its weight; repList_prod/sum/length compute its product ∏ vᵢ^{kᵢ}, sum ∑ kᵢ·vᵢ, and length ∑ kᵢ. Feeding it to amgm_list and rewriting gives amgm_weighted_list and its Finset form amgm_weighted_nat: ∏ xᵢ^{kᵢ} ≤ ((∑ kᵢ·xᵢ)/(∑ kᵢ))^{∑ kᵢ} — the inequality the open question names, with no analytic input beyond Bernoulli.",
+    "mathContext": "$\\prod_i x_i^{k_i} \\le \\left(\\frac{\\sum_i k_i x_i}{\\sum_i k_i}\\right)^{\\sum_i k_i}$ for $x_i \\ge 0$ and natural weights $k_i$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "weighted AM–GM inequality",
+      "repeat-with-multiplicity reduction",
+      "List.replicate / List.flatMap"
+    ],
+    "prerequisites": [
+      "unweighted AM–GM (amgm_list)",
+      "products and sums over replicated lists"
+    ]
+  },
+  {
+    "id": "amgm-numeric-witnesses",
+    "proofId": "binomial-theorem-oq-05-oq-02",
+    "range": { "startLine": 257, "endLine": 290 },
+    "type": "concept",
+    "title": "Numeric Witnesses",
+    "content": "Concrete instances anchor the abstract inequalities: the two-variable ab ≤ ((a+b)/2)² and three-variable abc ≤ ((a+b+c)/3)³ from amgm_list, the explicit 2·4·8 = 64 ≤ (14/3)³ ≈ 101.6, and the weighted a²·b ≤ ((2a+b)/3)³ from amgm_weighted_list [(a,2),(b,1)].",
+    "mathContext": "E.g. $2\\cdot 4\\cdot 8 = 64 \\le \\left(\\tfrac{14}{3}\\right)^3$ and the weighted $a^2 b \\le \\left(\\tfrac{2a+b}{3}\\right)^3$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "AM–GM inequality",
+      "weighted AM–GM inequality"
+    ],
+    "prerequisites": [
+      "the AM–GM theorems above"
+    ]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-05-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-05-oq-02/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "binomial-theorem-oq-05-oq-02",
+  "title": "Weighted AM–GM from Bernoulli: the First-Order-Truncation Route",
+  "slug": "binomial-theorem-oq-05-oq-02",
+  "description": "The parent entry proved Bernoulli's inequality 1 + n·a ≤ (1+a)ⁿ as the first-order truncation of the binomial expansion. This follow-up shows that the same elementary inequality — and nothing analytic beyond it — proves AM–GM. A single list induction whose cons-step is pure Bernoulli gives the unweighted ∏ xᵢ ≤ (mean)ⁿ; the classical repeat-with-multiplicity reduction then promotes it to the natural-weighted ∏ xᵢ^{kᵢ} ≤ (weighted mean)^{∑kᵢ}. No logarithms, no convexity of exp, no Jensen — in contrast to Mathlib's Real.geom_mean_le_arith_mean_weighted, which routes through convexOn_exp.",
+  "meta": {
+    "author": "Classical (AM–GM via Bernoulli, attributed to the Cauchy/Bernoulli tradition); formalized atop Mathlib's one_add_mul_sub_le_pow",
+    "sourceUrl": "https://en.wikipedia.org/wiki/AM%E2%80%93GM_inequality",
+    "date": "1821",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ05OQ02.lean",
+    "tags": [
+      "analysis",
+      "inequality",
+      "binomial-theorem",
+      "bernoulli-inequality",
+      "am-gm-inequality",
+      "induction",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "one_add_mul_sub_le_pow",
+        "description": "Bernoulli's inequality in tangent-line form: for r ≥ -1, 1 + n·(r−1) ≤ rⁿ. The single analytic ingredient of the whole development — every AM–GM result below reduces to this.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "List.prod_replicate",
+        "description": "(replicate n a).prod = aⁿ. Used (with its additive sum_replicate) to evaluate the product/sum/length of the repetition list in the weighted reduction.",
+        "module": "Mathlib.Algebra.BigOperators.Group.List.Defs"
+      },
+      {
+        "theorem": "Finset.prod_map_toList",
+        "description": "(s.toList.map f).prod = ∏ i ∈ s, f i. Transports the list-form AM–GM to the Finset form, both unweighted and weighted.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      }
+    ],
+    "originalContributions": [
+      "amgm_step: the inductive heart — x · Aₜⁿ ≤ A^{n+1} whenever (n+1)·A = x + n·Aₜ, proved by rescaling by r = A/Aₜ and applying Bernoulli. This is the one nontrivial step and it is pure Bernoulli.",
+      "amgm_list: unweighted AM–GM for a list of nonnegative reals, ∏ l ≤ (l.sum / l.length)^l.length, by a single induction with amgm_step as the cons-step — no logarithms, no exp-convexity, no Jensen",
+      "amgm_prod_le: the Finset packaging ∏ z ≤ (∑ z / card)^card",
+      "repList and repList_{prod,sum,length,nonneg}: the repeat-with-multiplicity bookkeeping (each (value,weight) pair contributes weight copies of value), realising the classical reduction of weighted to unweighted AM–GM",
+      "amgm_weighted_list / amgm_weighted_nat: the natural-weighted AM–GM ∏ xᵢ^{kᵢ} ≤ ((∑ kᵢ·xᵢ)/(∑ kᵢ))^{∑ kᵢ} (list and Finset forms) — the inequality the open question names, obtained from the Bernoulli route with no further analytic input",
+      "Numeric witnesses: two- and three-variable AM–GM, the concrete 2·4·8 ≤ (14/3)³, and the weighted a²·b ≤ ((2a+b)/3)³"
+    ],
+    "dateAdded": "2026-06-27",
+    "axioms": 0,
+    "axiomCount": 0,
+    "lineCount": 294,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound). The sole analytic input is Mathlib's Bernoulli inequality one_add_mul_sub_le_pow; the AM–GM development — unweighted list and Finset forms, the repetition reduction, and the natural-weighted inequality — is the original content and does not re-export Mathlib's logarithm/convexity-based geom_mean_le_arith_mean_weighted.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The arithmetic–geometric mean inequality is one of the oldest in analysis, with Cauchy's celebrated 1821 forward–backward induction proof among the most famous. Less often emphasised is that AM–GM is, at heart, *Bernoulli's inequality applied termwise*: the single tangent-line bound 1 + n·(r−1) ≤ rⁿ, iterated, forces the geometric mean below the arithmetic mean. Mathlib's general weighted AM–GM (Real.geom_mean_le_arith_mean_weighted) instead routes through the convexity of exp and Jensen's inequality — analytically heavier machinery. This entry follows the elementary Bernoulli route end to end, taking the gallery's parent Bernoulli entry as its only analytic input.",
+    "problemStatement": "**Open Question (binomial-theorem-oq-05-oq-02):** The parent entry binomial-theorem-oq-05 proved Bernoulli's inequality as the first-order truncation of the binomial expansion. Does that same viewpoint give a clean Lean proof of the (weighted) AM–GM inequality, which classically follows from Bernoulli applied termwise?\n\n**Answer: yes.** A single list induction whose only analytic input is the tangent-line Bernoulli inequality proves the unweighted AM–GM ∏ xᵢ ≤ (mean)ⁿ. The classical repeat-with-multiplicity reduction — replace each xᵢ by kᵢ copies — then promotes it to the natural-weighted AM–GM ∏ xᵢ^{kᵢ} ≤ ((∑ kᵢ·xᵢ)/(∑ kᵢ))^{∑ kᵢ} with no further analytic ingredient.",
+    "text": "The geometric mean of nonnegative reals never exceeds their arithmetic mean. Proved here by induction on the sample: splicing one new term into a sample of mean Aₜ to form the new mean A satisfies x·Aₜⁿ ≤ A^{n+1}, which after dividing by Aₜ^{n+1} is exactly Bernoulli for r = A/Aₜ. Iterating gives the unweighted inequality; replacing each value by an integer number of copies gives the weighted one.",
+    "proofStrategy": "1. **Bernoulli kernel** (`bernoulli_pow`): re-export the parent's tangent-line Bernoulli 1 + n·(r−1) ≤ rⁿ from Mathlib's one_add_mul_sub_le_pow.\n2. **Inductive step** (`amgm_step`): show x·Aₜⁿ ≤ A^{n+1} under the bookkeeping (n+1)·A = x + n·Aₜ. With Aₜ > 0, set r = A/Aₜ; the claim becomes ((n+1)·r − n)·Aₜ^{n+1} ≤ r^{n+1}·Aₜ^{n+1}, i.e. Bernoulli rescaled. The Aₜ = 0 degenerate case is handled separately.\n3. **Unweighted AM–GM** (`amgm_list`): induct on the list; the cons-step is amgm_step with At = t.sum/n and A = (x+t.sum)/(n+1), whose bookkeeping identity (n+1)·A = x + n·At is pure arithmetic.\n4. **Finset form** (`amgm_prod_le`): transport amgm_list along s.toList.\n5. **Repetition reduction** (`repList` + `repList_{prod,sum,length,nonneg}`): for a list of (value, weight) pairs, the flat list with each value repeated by its weight has product ∏ vᵢ^{kᵢ}, sum ∑ kᵢ·vᵢ, and length ∑ kᵢ.\n6. **Weighted AM–GM** (`amgm_weighted_list`, `amgm_weighted_nat`): apply amgm_list to the repetition list and rewrite the three quantities — yielding the natural-weighted inequality the open question names.",
+    "keyInsights": [
+      "**AM–GM is Bernoulli, iterated.** The whole proof rests on the single tangent-line inequality 1 + n·(r−1) ≤ rⁿ. Dividing the inductive step x·Aₜⁿ ≤ A^{n+1} by Aₜ^{n+1} with r = A/Aₜ turns it verbatim into Bernoulli — no logarithm or exponential ever appears.",
+      "**The bookkeeping identity carries the induction.** Writing the new mean as A = (x + n·Aₜ)/(n+1) makes the cons-step's hypothesis (n+1)·A = x + n·Aₜ an arithmetic triviality, so the only inequality consumed per step is Bernoulli.",
+      "**Weighted = unweighted on a repeated sample.** Natural weights kᵢ are exactly multiplicities: the repetition list, with vᵢ appearing kᵢ times, has product ∏ vᵢ^{kᵢ}, sum ∑ kᵢ·vᵢ, and length ∑ kᵢ, so the weighted inequality falls out of the unweighted one with zero extra analytic content.",
+      "**A genuinely lighter route than Mathlib's.** Mathlib's weighted AM–GM goes through convexity of exp and Jensen; this development needs only Bernoulli, illustrating that the binomial first-order-truncation viewpoint reaches AM–GM by elementary means."
+    ],
+    "prerequisites": [
+      "Bernoulli's inequality in tangent-line form 1 + n·(r−1) ≤ rⁿ (the parent entry)",
+      "Arithmetic and geometric means of finite samples",
+      "Induction on lists; transport between lists and Finsets via s.toList",
+      "The repeat-with-multiplicity reduction of weighted to unweighted means"
+    ]
+  },
+  "sections": [
+    {
+      "id": "kernel",
+      "title": "Bernoulli Kernel and the Inductive Step",
+      "startLine": 53,
+      "endLine": 107,
+      "summary": "Re-exports the tangent-line Bernoulli inequality (bernoulli_pow) and proves the inductive heart amgm_step: x·Aₜⁿ ≤ A^{n+1} whenever (n+1)·A = x + n·Aₜ, by rescaling to r = A/Aₜ and applying Bernoulli, with the Aₜ = 0 case handled separately.",
+      "mathContext": "The single analytic ingredient (Bernoulli) and the one nontrivial inequality step of the whole development."
+    },
+    {
+      "id": "unweighted",
+      "title": "Unweighted AM–GM (List and Finset Forms)",
+      "startLine": 109,
+      "endLine": 164,
+      "summary": "amgm_list: ∏ l ≤ (l.sum/l.length)^l.length for nonnegative reals, by induction with amgm_step as the cons-step. amgm_prod_le: the Finset packaging ∏ z ≤ (∑ z / card)^card, transported along s.toList.",
+      "mathContext": "Unweighted AM–GM with no logarithms or exp-convexity — pure Bernoulli induction."
+    },
+    {
+      "id": "weighted",
+      "title": "Natural-Weighted AM–GM via Repetition",
+      "startLine": 166,
+      "endLine": 255,
+      "summary": "The repetition list repList (each (value, weight) pair contributes weight copies) and its product/sum/length/nonneg lemmas, then amgm_weighted_list and amgm_weighted_nat: ∏ xᵢ^{kᵢ} ≤ ((∑ kᵢ·xᵢ)/(∑ kᵢ))^{∑ kᵢ}, the inequality the open question names.",
+      "mathContext": "Weighted AM–GM obtained from the unweighted form by the repeat-with-multiplicity reduction — no further analytic input."
+    },
+    {
+      "id": "numeric",
+      "title": "Numeric Witnesses",
+      "startLine": 257,
+      "endLine": 290,
+      "summary": "Two-variable ab ≤ ((a+b)/2)², three-variable abc ≤ ((a+b+c)/3)³, the concrete 2·4·8 = 64 ≤ (14/3)³, and the weighted witness a²·b ≤ ((2a+b)/3)³ from amgm_weighted_list [(a,2),(b,1)].",
+      "mathContext": "Concrete instances of the unweighted and weighted inequalities."
+    }
+  ],
+  "conclusion": {
+    "summary": "AM–GM is proved end to end from Bernoulli's inequality alone: a single list induction (cons-step amgm_step, which is Bernoulli rescaled) gives the unweighted ∏ xᵢ ≤ (mean)ⁿ, and the repeat-with-multiplicity reduction promotes it to the natural-weighted ∏ xᵢ^{kᵢ} ≤ ((∑ kᵢ·xᵢ)/(∑ kᵢ))^{∑ kᵢ}. Fully verified: 0 sorries, 0 axioms.",
+    "implications": "This answers the parent entry's open question affirmatively: the binomial first-order-truncation viewpoint does give a clean Lean proof of weighted AM–GM. The development is notably lighter than Mathlib's Real.geom_mean_le_arith_mean_weighted, which depends on convexity of exp and Jensen's inequality; here the only analytic input is Bernoulli. The repetition lemmas (repList and friends) are reusable bookkeeping for any 'weighted = unweighted on a repeated sample' argument.",
+    "openQuestions": [
+      "Does the same Bernoulli route reach the real-weighted AM–GM (arbitrary nonnegative real weights summing to 1) by a density/limit argument from the rational-weighted case, still avoiding exp-convexity?",
+      "Can the Bernoulli-only unweighted AM–GM amgm_list be sharpened to the equality-case characterisation (equality iff all entries equal) by tracking the strict Bernoulli inequality?"
+    ],
+    "crossReferences": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-05",
+      "relationship": "extends",
+      "description": "Answers OQ-05's open question: the parent proved Bernoulli as the first-order truncation of the binomial expansion; this entry uses exactly that inequality to prove (weighted) AM–GM termwise"
+    },
+    {
+      "targetId": "binomial-theorem-oq-05-oq-01",
+      "relationship": "sibling",
+      "description": "Both are follow-ups to the Bernoulli entry OQ-05; OQ-05-OQ-01 takes the multiplicative (Vandermonde) route, this entry the inequality (AM–GM) route"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "BinomialTheoremOQ05OQ02",
+    "lineCount": 294,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "path": "Proofs/BinomialTheoremOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "A.-L. Cauchy",
+      "title": "Cours d'analyse de l'École Royale Polytechnique",
+      "year": "1821",
+      "venue": "Paris",
+      "note": "Classic forward–backward induction proof of AM–GM; the inductive viewpoint underlies the Bernoulli route used here"
+    },
+    {
+      "authors": "G. H. Hardy, J. E. Littlewood, G. Pólya",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Standard reference deriving AM–GM and weighted AM–GM, including the reduction of weighted to unweighted means by multiplicities"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question of `binomial-theorem-oq-05`: does the *first-order-truncation* (tangent-line Bernoulli) viewpoint give a clean Lean proof of the (weighted) AM–GM inequality, the way Bernoulli classically yields it termwise?

**Yes.** A single list induction whose only analytic input is the gallery's Bernoulli inequality `one_add_mul_sub_le_pow` (`1 + n·(r−1) ≤ rⁿ`) proves the unweighted AM–GM `∏ xᵢ ≤ (mean)ⁿ`. The classical *repeat-with-multiplicity* reduction then promotes it to the natural-weighted `∏ xᵢ^{kᵢ} ≤ ((∑ kᵢ·xᵢ)/(∑ kᵢ))^{∑ kᵢ}` — **no logarithms, no convexity of exp, no Jensen**, in contrast to Mathlib's `Real.geom_mean_le_arith_mean_weighted`.

## Contents
- `proofs/Proofs/BinomialTheoremOQ05OQ02.lean` (12 theorems, 1 def, 294 lines) — `amgm_step` (Bernoulli-rescaled inductive heart), `amgm_list`/`amgm_prod_le` (unweighted, list + Finset), `repList` family (repetition bookkeeping), `amgm_weighted_list`/`amgm_weighted_nat` (weighted), numeric witnesses.
- Gallery data: `meta.json`, `annotations.json`; registered in `proofs/Proofs.lean`.

Claimed status: **verified, 0 sorries, 0 axioms** (sole dependency: `one_add_mul_sub_le_pow`).

## ⚠️ Build verification note
The host hit a **disk-full condition** (Data volume 100%, ~0 bytes free) during this session, so I could **not run `docker-build.sh` to re-verify locally**. The file was authored/verified in a prior session, but per the trust-but-verify policy I am flagging that **CI / deployer should confirm a clean build before merge**. If the build fails, do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)