### PR TITLE
research(erdos-1005-oq-02): §16 continuant matrix — Cassini + reversal symmetry [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -1388,4 +1388,179 @@ theorem stepPair_cross_one (k a b c d : ℤ) :
         - (stepPair a c [k]).2 * (stepPair b d [k]).1 = a * d - b * c :=
   stepPair_cross [k] a b c d
 
+/-! ## §16: The continuant matrix — Cassini and reversal symmetry
+
+§14's `Continuant` and `secondCont` arose as the controlling coefficients of the
+§9 successor recurrence `tₘ₊₁ = kₘ·tₘ − tₘ₋₁`, equivalently the 2×2 step matrix
+`M(k) = [[k, −1], [1, 0]]` (determinant `1`).  This section makes that matrix
+representation explicit and reads two structural facts off it that the per-rung
+algebra of §11–§13 could only sample:
+
+* **Cassini / determinant invariant.**  Each step matrix has determinant `1`, so
+  the ordered product `P(ks) = M(k₁)·⋯·M(kₙ)` has determinant `1` at every depth.
+  Its top-left and bottom-left entries are exactly `Continuant ks` and
+  `secondCont ks`, giving the continuant Cassini identity
+  `K(ks)·(P ks).d − (P ks).b·secondCont(ks) = 1`.  This is the determinant route
+  the §15 note flagged as the correct replacement for the (false) blanket
+  "continuant positivity" target — the §14 windows' sign structure is governed by
+  a `det = 1` invariant, never by `K ≥ 1`.
+
+* **Reversal symmetry (headline).**  `K(ks.reverse) = K(ks)`.  The step matrix is
+  *not* symmetric, but it satisfies `M(k)ᵀ = J·M(k)·J` with `J = diag(1, −1)`
+  (`J² = I`), so the map `φ(X) = J·Xᵀ·J` fixes every `M(k)` while reversing
+  products (`φ(XY) = φ(Y)·φ(X)`).  Hence `P(ks.reverse) = φ(P ks)`, and the
+  top-left entry of `φ(X)` equals that of `X`, forcing `K(ks.reverse) = K(ks)`.
+  This is the palindrome structure of the run-length windows: a length-`(|ks|+1)`
+  run and its reverse are governed by the *same* continuant. -/
+
+/-- A 2×2 integer matrix `[[a, b], [c, d]]`, used as the step-matrix carrier for
+the §14 continuant.  A bespoke structure (rather than `Matrix (Fin 2) (Fin 2) ℤ`)
+keeps every entry-level proof a one-line `ext`/`ring`. -/
+@[ext] structure Mat2 where
+  a : ℤ
+  b : ℤ
+  c : ℤ
+  d : ℤ
+
+namespace Mat2
+
+/-- Matrix multiplication `[[a,b],[c,d]]·[[a',b'],[c',d']]`. -/
+def mul (X Y : Mat2) : Mat2 :=
+  ⟨X.a * Y.a + X.b * Y.c, X.a * Y.b + X.b * Y.d,
+   X.c * Y.a + X.d * Y.c, X.c * Y.b + X.d * Y.d⟩
+
+/-- The identity matrix. -/
+def one : Mat2 := ⟨1, 0, 0, 1⟩
+
+/-- The transpose `[[a,c],[b,d]]`. -/
+def transpose (X : Mat2) : Mat2 := ⟨X.a, X.c, X.b, X.d⟩
+
+/-- Conjugation by `J = diag(1, −1)`: `J·X·J = [[a,−b],[−c,d]]`. -/
+def conj (X : Mat2) : Mat2 := ⟨X.a, -X.b, -X.c, X.d⟩
+
+/-- The anti-automorphism `φ(X) = J·Xᵀ·J = [[a,−c],[−b,d]]`. -/
+def phi (X : Mat2) : Mat2 := ⟨X.a, -X.c, -X.b, X.d⟩
+
+/-- The determinant `a·d − b·c`. -/
+def det (X : Mat2) : ℤ := X.a * X.d - X.b * X.c
+
+theorem mul_assoc (X Y Z : Mat2) : mul (mul X Y) Z = mul X (mul Y Z) := by
+  ext <;> simp only [mul] <;> ring
+
+theorem one_mul (X : Mat2) : mul one X = X := by
+  ext <;> simp only [mul, one] <;> ring
+
+theorem mul_one (X : Mat2) : mul X one = X := by
+  ext <;> simp only [mul, one] <;> ring
+
+/-- `φ` reverses products: `φ(XY) = φ(Y)·φ(X)`. -/
+theorem phi_mul (X Y : Mat2) : phi (mul X Y) = mul (phi Y) (phi X) := by
+  ext <;> simp only [phi, mul] <;> ring
+
+theorem phi_one : phi one = one := by ext <;> simp [phi, one]
+
+/-- The determinant is multiplicative — the Cassini engine. -/
+theorem det_mul (X Y : Mat2) : det (mul X Y) = det X * det Y := by
+  simp only [det, mul]; ring
+
+theorem det_one : det one = 1 := by simp [det, one]
+
+end Mat2
+
+/-- The §9/§14 step matrix `M(k) = [[k, −1], [1, 0]]`, determinant `1`. -/
+def stepMat (k : ℤ) : Mat2 := ⟨k, -1, 1, 0⟩
+
+theorem det_stepMat (k : ℤ) : Mat2.det (stepMat k) = 1 := by
+  simp [Mat2.det, stepMat]
+
+/-- `φ` fixes every step matrix — the conjugation symmetry `M(k)ᵀ = J·M(k)·J`. -/
+theorem phi_stepMat (k : ℤ) : Mat2.phi (stepMat k) = stepMat k := by
+  simp [Mat2.phi, stepMat]
+
+/-- The ordered product `P(ks) = M(k₁)·⋯·M(kₙ)` of step matrices. -/
+def contMat : List ℤ → Mat2
+  | [] => Mat2.one
+  | k :: ks => Mat2.mul (stepMat k) (contMat ks)
+
+theorem contMat_singleton (k : ℤ) : contMat [k] = stepMat k := by
+  simp [contMat, Mat2.mul_one]
+
+/-- `contMat` is multiplicative on concatenation — the matrix product respects
+list append. -/
+theorem contMat_append (xs ys : List ℤ) :
+    contMat (xs ++ ys) = Mat2.mul (contMat xs) (contMat ys) := by
+  induction xs with
+  | nil => simp [contMat, Mat2.one_mul]
+  | cons k xs ih =>
+    simp only [List.cons_append, contMat, ih, Mat2.mul_assoc]
+
+/-- **Continuant entries.**  The top-left entry of the step-matrix product is the
+§14 `Continuant`, and the bottom-left entry is `secondCont` — the matrix
+representation of the §14 recurrence. -/
+theorem contMat_entries (ks : List ℤ) :
+    (contMat ks).a = Continuant ks ∧ (contMat ks).c = secondCont ks := by
+  induction ks with
+  | nil => exact ⟨rfl, rfl⟩
+  | cons k ks ih =>
+    refine ⟨?_, ?_⟩
+    · simp only [contMat, Mat2.mul, stepMat, ih.1, ih.2, continuant_cons]; ring
+    · simp only [contMat, Mat2.mul, stepMat, ih.1, secondCont]; ring
+
+theorem contMat_a (ks : List ℤ) : (contMat ks).a = Continuant ks :=
+  (contMat_entries ks).1
+
+theorem contMat_c (ks : List ℤ) : (contMat ks).c = secondCont ks :=
+  (contMat_entries ks).2
+
+/-- **The reversal bridge.**  Reversing the quotient list applies `φ` to the
+step-matrix product: `P(ks.reverse) = φ(P ks)`.  Proved by list induction using
+that `φ` reverses products and fixes each step matrix. -/
+theorem contMat_reverse (ks : List ℤ) :
+    contMat ks.reverse = Mat2.phi (contMat ks) := by
+  induction ks with
+  | nil => simp [contMat, Mat2.phi_one]
+  | cons k ks ih =>
+    rw [List.reverse_cons, contMat_append, contMat_singleton, ih,
+      show contMat (k :: ks) = Mat2.mul (stepMat k) (contMat ks) from rfl,
+      Mat2.phi_mul, phi_stepMat]
+
+/-- **Continuant reversal symmetry (headline).**  `K(ks.reverse) = K(ks)`: the
+continuant is invariant under reversing its quotient list.  Reading the top-left
+entry of the reversal bridge `P(ks.reverse) = φ(P ks)`, which `φ` leaves fixed.
+This is the palindrome symmetry of the §14 run-length windows. -/
+theorem continuant_reverse (ks : List ℤ) :
+    Continuant ks.reverse = Continuant ks := by
+  have h := congrArg Mat2.a (contMat_reverse ks)
+  simpa only [contMat_a, Mat2.phi] using h
+
+/-- The reversal symmetry also identifies the top-right entry of the product:
+`(P ks).b = −secondCont(ks.reverse)`.  (The bottom-left entry of `P(ks.reverse)`
+is `secondCont(ks.reverse)`, and the reversal bridge maps it to `−(P ks).b`.) -/
+theorem contMat_b (ks : List ℤ) : (contMat ks).b = - secondCont ks.reverse := by
+  have h := congrArg Mat2.c (contMat_reverse ks)
+  simp only [contMat_c, Mat2.phi] at h
+  linarith [h]
+
+/-- **Determinant invariant.**  `det P(ks) = 1` at every depth — each step matrix
+has determinant `1` and the determinant is multiplicative. -/
+theorem det_contMat (ks : List ℤ) : Mat2.det (contMat ks) = 1 := by
+  induction ks with
+  | nil => simp [contMat, Mat2.det_one]
+  | cons k ks ih => rw [contMat, Mat2.det_mul, det_stepMat, ih]; ring
+
+/-- **Continuant Cassini identity (headline).**  Spelling out `det P(ks) = 1` with
+the continuant entries gives
+`K(ks)·(P ks).d − (P ks).b·secondCont(ks) = 1`,
+and substituting `(P ks).b = −secondCont(ks.reverse)`,
+`K(ks)·(P ks).d + secondCont(ks.reverse)·secondCont(ks) = 1`.
+This is the `det = 1` invariant the §15 note named as the correct replacement for
+the false blanket "continuant positivity" target: the §14 windows are governed by
+a Cassini determinant, not by any sign condition on `K` itself. -/
+theorem continuant_cassini (ks : List ℤ) :
+    Continuant ks * (contMat ks).d
+        + secondCont ks.reverse * secondCont ks = 1 := by
+  have h := det_contMat ks
+  simp only [Mat2.det, contMat_a, contMat_c, contMat_b] at h
+  linear_combination h
+
 end Erdos1005OQ02

--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -1563,4 +1563,21 @@ theorem continuant_cassini (ks : List ℤ) :
   simp only [Mat2.det, contMat_a, contMat_c, contMat_b] at h
   linear_combination h
 
+/-- **Continuant addition formula (Euler's composition law).**  Reading the
+top-left entry of the matrix product `contMat (xs ++ ys) = contMat xs · contMat ys`
+gives the classic continuant composition identity
+`K(xs ++ ys) = K(xs)·K(ys) − secondCont(xs.reverse)·secondCont(ys)`.
+Since `secondCont(xs.reverse) = K(xs.dropLast)` (the *leading* continuant, by
+`continuant_reverse`) and `secondCont(ys) = K(ys.tail)`, this is exactly Euler's
+`K(xs ++ ys) = K(xs)·K(ys) − K(xs.dropLast)·K(ys.tail)`.  It splits the §14
+run-length window of a concatenated quotient list into the product of the two
+sub-walk continuants minus a single junction term — the algebraic engine behind
+both the reversal symmetry and any density count over a Stern–Brocot path. -/
+theorem continuant_append (xs ys : List ℤ) :
+    Continuant (xs ++ ys)
+      = Continuant xs * Continuant ys - secondCont xs.reverse * secondCont ys := by
+  have h := congrArg Mat2.a (contMat_append xs ys)
+  simp only [contMat_a, Mat2.mul, contMat_b, contMat_c] at h
+  linear_combination h
+
 end Erdos1005OQ02

--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -934,4 +934,78 @@ theorem isCanon_baseOf_eq {s : SpernerGrid.GridSimplex d N}
 theorem baseOf_canon (s : CanonSimplex d N) : baseOf s.1 = s.1.verts 0 :=
   isCanon_baseOf_eq s.2
 
+-- ============================================================
+-- The recanonicalization base of the interior pivot
+-- ============================================================
+-- `baseOf` names the lex-min base a recanonicalization step selects.
+-- For the interior pivot (`pivotSimplex`, the neighbour the `adj`
+-- search produces at a chain-interior facet) we can now pin that base
+-- down in *both* outcomes of the single canonicality test
+-- `pivot_isCanon_iff`:
+--
+--   * already canonical → `baseOf` is the untouched base `s.verts 0`
+--     (`pivot_base_eq`), so recanonicalization is the identity;
+--   * not canonical → the one moved vertex, the `pivotPoint`, has
+--     dropped lex-below `s.verts 0` and so becomes the new lex-min
+--     base of the neighbour's vertex set.
+--
+-- Together these say *exactly which vertex* the recanonicalization map
+-- must promote to the base in every interior-pivot case — the remaining
+-- input that step needs beyond the already-proven well-definedness
+-- (`baseOf_eq_of_range_eq`) and identity-on-canonical
+-- (`isCanon_baseOf_eq`) facts.
+
+/-- **Recanonicalization base of a canonical interior pivot.**  When the
+interior pivot already lands on the canonical representative, its lex-min
+base is the untouched base `s.verts 0` (the pivot fixes vertex `0`,
+`pivot_base_eq`).  So the recanonicalization map is the identity here. -/
+theorem baseOf_pivot_of_canon (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc)
+    (hcanon : SpernerGrid.IsCanon (pivotSimplex s a b hb)) :
+    baseOf (pivotSimplex s a b hb) = s.verts 0 := by
+  rw [isCanon_baseOf_eq hcanon, pivot_base_eq]
+
+/-- **Recanonicalization base of a non-canonical interior pivot.**  When the
+single lex test of `pivot_isCanon_iff` fails — i.e. the moved vertex
+`pivotPoint` is *not* lex-dominated by the base `s.verts 0` — the pivot is
+non-canonical, and the `pivotPoint` is precisely its new lex-min base.
+
+The pivot's vertices are the moved `pivotPoint` together with the `d`
+untouched vertices `s.verts j` (`j ≠ a.succ`).  Failure of the test makes
+`pivotPoint` lex-`≤` the old base `s.verts 0` (lex totality), which in turn
+is lex-`≤` every `s.verts j` (`s` is canonical); so `pivotPoint` dominates
+all vertices and, lying in the cell, is the unique lex-min base
+(`baseOf_unique`).  This identifies the vertex the recanonicalization map
+must promote to the base whenever the interior pivot leaves the carrier. -/
+theorem baseOf_pivot_of_not_canon (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) (hs : SpernerGrid.IsCanon s)
+    (hp : ¬ (s.verts 0).lexLE (pivotPoint s a b (pivot_ab_ne hb))) :
+    baseOf (pivotSimplex s a b hb) = pivotPoint s a b (pivot_ab_ne hb) := by
+  -- The moved vertex `a.succ` is the `pivotPoint`.
+  have hpiv : (pivotSimplex s a b hb).verts a.succ
+      = pivotPoint s a b (pivot_ab_ne hb) := by
+    show Function.update s.verts a.succ (pivotPoint s a b (pivot_ab_ne hb)) a.succ = _
+    rw [Function.update_self]
+  -- Test failure + lex totality: `pivotPoint` lex-≤ the old base.
+  have hple0 : (pivotPoint s a b (pivot_ab_ne hb)).lexLE (s.verts 0) := by
+    rcases SpernerGrid.BaryPoint.lexLE_total (s.verts 0)
+        (pivotPoint s a b (pivot_ab_ne hb)) with h | h
+    · exact absurd h hp
+    · exact h
+  symm
+  apply baseOf_unique (pivotSimplex s a b hb)
+  · -- `pivotPoint` is a vertex of the pivoted cell.
+    rw [← hpiv]; exact mem_vertexSet (pivotSimplex s a b hb) a.succ
+  · -- `pivotPoint` lex-dominates every vertex of the pivoted cell.
+    intro x hx
+    obtain ⟨j, _, rfl⟩ := Finset.mem_image.mp hx
+    by_cases hj : j = a.succ
+    · subst hj; rw [hpiv]; exact SpernerGrid.BaryPoint.lexLE_refl _
+    · have hxj : (pivotSimplex s a b hb).verts j = s.verts j := by
+        show Function.update s.verts a.succ
+          (pivotPoint s a b (pivot_ab_ne hb)) j = s.verts j
+        rw [Function.update_of_ne hj]
+      rw [hxj]
+      exact SpernerGrid.BaryPoint.lexLE_trans hple0 (hs j)
+
 end SpernerNDimOQ02

--- a/research/problems/erdos-1005-oq-02/knowledge.md
+++ b/research/problems/erdos-1005-oq-02/knowledge.md
@@ -1,0 +1,38 @@
+## Session 2026-06-27 (researcher-2): §16 continuant matrix — Cassini + reversal
+
+PR #31083 (VERIFIED, 0-axiom). Realised both named nextSteps targets via an
+explicit 2×2 step-matrix representation of the §14 continuant.
+
+- **Mat2** structure (4 fields a,b,c,d) with mul/one/transpose/conj/phi/det,
+  every entry-level lemma a one-line `ext <;> simp only [...] <;> ring`.
+  Deliberately NOT `Matrix (Fin 2)` — avoids all Fin-indexing pain.
+- **contMat ks** = ordered product M(k₁)·…·M(kₙ) of step matrices
+  M(k)=[[k,−1],[1,0]]. `contMat_entries`: top-left = Continuant ks,
+  bottom-left = secondCont ks (matrix form of the §14 recurrence).
+- **continuant_reverse (headline)**: K(ks.reverse) = K(ks). M(k) is NOT
+  symmetric, but M(k)ᵀ = J·M(k)·J with J=diag(1,−1); so φ(X)=J·Xᵀ·J fixes
+  each M(k) and reverses products ⇒ contMat(reverse ks)=φ(contMat ks), and
+  φ leaves the top-left entry fixed. Palindrome symmetry of the run windows.
+- **continuant_cassini**: det(contMat ks)=1 ⇒
+  K(ks)·(contMat ks).d + secondCont(ks.reverse)·secondCont(ks) = 1.
+  This is the det-route the §15 note named as the replacement for the FALSE
+  "continuant positivity" target.
+- **contMat_b**: (contMat ks).b = −secondCont(ks.reverse) (continuant-term
+  reading of the top-right entry, via the reversal bridge).
+
+KEY TECHNIQUE: when a step matrix is not symmetric, reversal symmetry of its
+continuant still follows from the conjugation M ᵀ = J·M·J (J an involution),
+via the anti-automorphism φ=conj∘transpose that fixes each generator. Generic
+trick for any second-order linear recurrence's continuant.
+
+REMAINING / next directions:
+- Identify (contMat ks).d in closed continuant form (it is reversal-symmetric;
+  conjecturally Continuant of the "interior" ks.tail.dropLast). Would make the
+  Cassini fully continuant-expressed.
+- Continuant addition/append formula K(xs++ys) = K(xs)K(ys) − (junction term)
+  — now within reach from contMat_append + contMat_entries.
+- Aggregate the explicit break windows along a Stern–Brocot path toward the
+  open 1/12 constant (unchanged long-range goal; still the hard part).
+
+Docker was DOWN; verified via host `lake env lean` single-file elaboration
+(clean, 0 errors). 0 axiom decls / 0 sorry / 0 native_decide file-wide.

--- a/research/problems/erdos-1005-oq-02/knowledge.md
+++ b/research/problems/erdos-1005-oq-02/knowledge.md
@@ -36,3 +36,10 @@ REMAINING / next directions:
 
 Docker was DOWN; verified via host `lake env lean` single-file elaboration
 (clean, 0 errors). 0 axiom decls / 0 sorry / 0 native_decide file-wide.
+
+### §17 (same session, same PR #31083): continuant addition formula
+continuant_append: K(xs++ys) = K(xs)·K(ys) − secondCont(xs.reverse)·secondCont(ys),
+read off the top-left of contMat_append. = Euler's K(xs++ys)=K(xs)K(ys)−K(xs.dropLast)K(ys.tail).
+Now have: reversal symmetry, det=1 Cassini, AND the composition law — the full
+classic continuant toolkit, all matrix-derived. Next: closed form for
+(contMat ks).d to fully continuant-express the Cassini; then Stern–Brocot density.


### PR DESCRIPTION
## Summary

Adds **§16** to `Erdos1005ProblemOQ02.lean`: an explicit 2×2 step-matrix representation of the §14 `Continuant`, from which two structural facts fall out that the per-rung §11–§13 algebra could only sample.

Erdős #1005 asks for the leading constant `c ∈ [1/12, 1/4]` of the longest run of "similarly ordered" Farey fractions (open). This file formalises the underlying gap calculus; §14 introduced the minus-sign **continuant** `K(ks)` governing the run-length window at every length. §16 supplies the two continuant identities the §15 note flagged as the right next handles.

## New results (both VERIFIED, 0-axiom)

- **`continuant_reverse` (headline):** `K(ks.reverse) = K(ks)`.
  The step matrix `M(k) = [[k,−1],[1,0]]` is *not* symmetric, but satisfies `M(k)ᵀ = J·M(k)·J` with `J = diag(1,−1)`. Hence the anti-automorphism `φ(X) = J·Xᵀ·J` fixes every `M(k)` and reverses products, giving `contMat(ks.reverse) = φ(contMat ks)`. The top-left entry (`= Continuant`) is `φ`-invariant, so the continuant is reversal-invariant — the **palindrome symmetry** of the §14 run-length windows.

- **`continuant_cassini`:** `det(contMat ks) = 1` at every depth, spelled out as
  `K(ks)·(contMat ks).d + secondCont(ks.reverse)·secondCont(ks) = 1`.
  This is the determinant route the §15 note named as the correct replacement for the **false** blanket "continuant positivity" target (`K([1,1,1]) = −1`): the §14 windows are governed by a `det = 1` Cassini invariant, never by any sign condition on `K`.

## Supporting infrastructure

- `Mat2` — bespoke 4-field 2×2 integer matrix structure (`mul`/`one`/`transpose`/`conj`/`phi`/`det`) with `ext`+`ring` lemmas, deliberately avoiding `Matrix (Fin 2)` indexing so every entry-level step is one line.
- `stepMat`, `contMat` (ordered step-matrix product), `contMat_append` (multiplicativity over `++`), `contMat_entries` (top-left `= Continuant`, bottom-left `= secondCont`), `contMat_reverse` (the reversal bridge), `contMat_b` (`(contMat ks).b = −secondCont ks.reverse`), `det_contMat`.

## Verification

Docker was down this session; verified via host `lake env lean` single-file elaboration against prebuilt Mathlib oleans — **clean, 0 errors, 0 warnings**. File-wide: 0 `axiom` declarations, 0 `sorry`, 0 `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)