### PR TITLE
research(inverse-galois-oq-06-oq-02): verify part (B) of mod-7 Dedekind — (1,1,3) cycle type ⟹ 3 | |Gal| [0-axiom]

### DIFF
--- a/proofs/Proofs/InverseGaloisOQ06OQ02Cycle.lean
+++ b/proofs/Proofs/InverseGaloisOQ06OQ02Cycle.lean
@@ -1,0 +1,111 @@
+import Mathlib
+
+/-
+# The permutation-group consequence of the mod-7 `(1,1,3)` factor type (OQ-06 → OQ-02)
+
+The sibling files `InverseGaloisOQ06OQ02.lean` (mod 7) and
+`InverseGaloisOQ06OQ02P11.lean` (mod 11) supply the *algebraic* input that
+Dedekind's theorem consumes toward the last axiom of `InverseGaloisA5.lean`:
+
+  `axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal`
+
+namely that `q = X⁵ - 5X⁴ + 10X³ - 10X² + 25X - 5` reduces, modulo the
+unramified prime `7`, to a product of distinct irreducibles of degrees
+`(1, 1, 3)`.
+
+Dedekind's theorem itself — the statement that this factorization type forces
+`Gal(q) ⊆ S₅` to contain a *Frobenius element of the same cycle type* — is the
+remaining Mathlib 4.26 gap. But Dedekind's conclusion splits into two parts:
+
+  (A) Frobenius ↔ factorization: the genuine number-theory gap, owned by the
+      sibling `inverse-galois-a5-oq-01` (`InverseGaloisA5Dedekind.lean`).
+  (B) cycle type ⟹ element order ⟹ divisibility of `|Gal|`: a *purely
+      group-theoretic*, fully machine-checkable consequence.
+
+This file isolates and verifies **part (B)** with **no axioms and no sorries**,
+so the only thing standing between the verified algebraic input and the axiom is
+part (A). Concretely we:
+
+* exhibit an explicit permutation of the five roots with cycle type `(1, 1, 3)`
+  (a 3-cycle that fixes two points — the two linear factors `X-5`, `X-6` mod 7),
+* prove it has order exactly `3`,
+* prove the abstract bridge: **any finite group with an order-3 element, and any
+  subgroup of `S₅` containing such a `(1,1,3)` permutation, has order divisible
+  by 3.**
+
+This is *not* a claim that `three_dvd_gal_card` is eliminated — it makes precise
+that the deterministic half of the mod-7 Dedekind route is verified, and the
+residual gap is exactly the Frobenius ↔ factorization correspondence (A).
+-/
+
+open Equiv Equiv.Perm
+
+namespace InverseGaloisOQ06OQ02Cycle
+
+/-! ## An explicit `(1,1,3)` permutation of the five roots -/
+
+/-- The cycle type `(1, 1, 3)` of `q mod 7` corresponds, in the symmetric group
+`S₅` on the five roots, to a permutation that 3-cycles the three roots of the
+irreducible cubic factor and fixes the two roots of the linear factors
+`X - 5`, `X - 6`.  We realise it concretely as `(2 3 4)`, fixing `0` and `1`. -/
+def frob113 : Perm (Fin 5) := swap 2 3 * swap 2 4
+
+/-- `frob113` is a three-cycle (matching the single degree-3 irreducible factor). -/
+theorem frob113_isThreeCycle : frob113.IsThreeCycle :=
+  isThreeCycle_swap_mul_swap_same (by decide) (by decide) (by decide)
+
+/-- Its cycle type is `{3}` — i.e. one 3-cycle plus two fixed points, exactly the
+`(1, 1, 3)` shape of the mod-7 factorization. -/
+theorem frob113_cycleType : frob113.cycleType = {3} :=
+  frob113_isThreeCycle.cycleType
+
+/-- The order of the `(1,1,3)` permutation is exactly `3`. -/
+theorem frob113_orderOf : orderOf frob113 = 3 :=
+  frob113_isThreeCycle.orderOf
+
+/-- The root of the linear factor `X - 5` (encoded as point `0`) is fixed. -/
+theorem frob113_fixes_zero : frob113 0 = 0 := by decide
+
+/-- The root of the linear factor `X - 6` (encoded as point `1`) is fixed. -/
+theorem frob113_fixes_one : frob113 1 = 1 := by decide
+
+/-! ## The abstract deterministic half of Dedekind: cycle type ⟹ `3 ∣ |G|` -/
+
+/-- **Group-level bridge.** In any finite group, a single order-3 element forces
+`3 ∣ |G|`.  This is the trivial-but-essential downstream step of Dedekind: once
+the Frobenius element of cycle type `(1,1,3)` is known to have order 3, its order
+divides the group order. -/
+theorem three_dvd_card_of_orderOf_three {G : Type*} [Group G] [Fintype G]
+    (g : G) (hg : orderOf g = 3) : 3 ∣ Fintype.card G := by
+  rw [← hg]; exact orderOf_dvd_card
+
+/-- **Subgroup-level bridge.** If a subgroup `H ⊆ S(α)` of a permutation group
+contains a three-cycle, then `3 ∣ |H|`.  Applied with `H = Gal(q) ↪ S₅` and the
+Frobenius `(1,1,3)` permutation, this is precisely the conclusion the mod-7
+Dedekind route needs — modulo the Frobenius ↔ factorization correspondence,
+which is the genuine remaining gap. -/
+theorem three_dvd_natCard_of_isThreeCycle_mem {α : Type*} [Fintype α] [DecidableEq α]
+    {H : Subgroup (Perm α)} {σ : Perm α} (hσ : σ.IsThreeCycle) (hmem : σ ∈ H) :
+    3 ∣ Nat.card H := by
+  rw [← hσ.orderOf]
+  exact H.orderOf_dvd_natCard hmem
+
+/-- **Instantiation at the explicit `(1,1,3)` witness.** Any subgroup of `S₅`
+containing `frob113` (the cycle type of `q mod 7`) has order divisible by 3. -/
+theorem three_dvd_natCard_of_frob113_mem {H : Subgroup (Perm (Fin 5))}
+    (hmem : frob113 ∈ H) : 3 ∣ Nat.card H :=
+  three_dvd_natCard_of_isThreeCycle_mem frob113_isThreeCycle hmem
+
+/-- **Packaged statement of part (B).** The `(1,1,3)` factor type, *once realised
+as a Frobenius permutation `σ ∈ Gal`* (the hypothesis `hmem` together with the
+cycle-type identity `hσ`), deterministically yields `3 ∣ |Gal|`.  Phrasing it
+with the cycle-type hypothesis explicit makes the residual Mathlib gap visible:
+supplying `σ` and `hmem` for the actual mod-7 Frobenius is part (A), Dedekind's
+theorem. -/
+theorem dedekind_consequence_113 {α : Type*} [Fintype α] [DecidableEq α]
+    {Gal : Subgroup (Perm α)} {σ : Perm α}
+    (hσ : σ.cycleType = {3}) (hmem : σ ∈ Gal) :
+    3 ∣ Nat.card Gal :=
+  three_dvd_natCard_of_isThreeCycle_mem hσ hmem
+
+end InverseGaloisOQ06OQ02Cycle

--- a/research/problems/inverse-galois-oq-06-oq-02/knowledge.md
+++ b/research/problems/inverse-galois-oq-06-oq-02/knowledge.md
@@ -55,6 +55,41 @@ factorization and that the cubic has no roots — not irreducibility/squarefree.
 
 ---
 
+## Part (B): the permutation-group consequence (iter 3 / Cycle file)
+
+Dedekind's conclusion at `p = 7` factors into two independent halves:
+
+- **(A) Frobenius ↔ factorization** — the genuine number-theory gap (Frobenius
+  at an unramified `𝔭 | 7` acts with cycle type equal to the factorization
+  degrees). Owned by sibling `inverse-galois-a5-oq-01`
+  (`InverseGaloisA5Dedekind.exists_gal_order_three`, still a sorry).
+- **(B) cycle type ⟹ order ⟹ divisibility** — pure group theory, now fully
+  machine-checked in `InverseGaloisOQ06OQ02Cycle.lean` (0-axiom/0-sorry).
+
+`InverseGaloisOQ06OQ02Cycle.lean` content:
+
+- `frob113 : Perm (Fin 5) := swap 2 3 * swap 2 4` — explicit `(1,1,3)`
+  permutation (3-cycles 2,3,4; fixes 0,1 = the two linear-factor roots).
+- `Equiv.Perm.isThreeCycle_swap_mul_swap_same (ab) (ac) (bc)` proves
+  `IsThreeCycle (swap a b * swap a c)`; the three distinctness args over
+  `Fin 5` close by `decide`. Fixed points `frob113 0 = 0`, `frob113 1 = 1`
+  also by `decide` (kernel `decide`, NOT `native_decide` — stays 0-axiom).
+- `Equiv.Perm.IsThreeCycle.orderOf : orderOf g = 3` (via `lcm_cycleType` +
+  `cycleType = {3}`).
+- Bridges:
+  - `three_dvd_card_of_orderOf_three` — finite group, order-3 elt ⟹ `3 ∣ card`
+    via `orderOf_dvd_card`.
+  - `three_dvd_natCard_of_isThreeCycle_mem` — `H ≤ Perm α` containing a 3-cycle
+    ⟹ `3 ∣ Nat.card H` via `Subgroup.orderOf_dvd_natCard` (no `Fintype` needed,
+    uses `Nat.card`).
+  - `dedekind_consequence_113` — the packaged part-(B) statement with the
+    cycle-type hypothesis explicit, making the residual gap (A) visible.
+
+This does **not** discharge `three_dvd_gal_card`; it verifies the deterministic
+half so the only remaining gap is the Frobenius ↔ factorization correspondence.
+
+---
+
 ## Dead Ends
 
 - `isCoprime_of_irreducible_of_not_associated` does NOT exist in Mathlib 4.26.

--- a/src/data/research/problems/inverse-galois-oq-06-oq-02.json
+++ b/src/data/research/problems/inverse-galois-oq-06-oq-02.json
@@ -30,12 +30,12 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-27",
-    "iteration": 2,
-    "focus": "Iteration 2: added Proofs/InverseGaloisOQ06OQ02P11.lean (0-axiom, 0-sorry) corroborating the mod-7 (1,1,3) factor type at a second unramified prime p=11 — q mod 11 = (X-4)(X-3)(X^3+2X^2+X-5) into distinct irreducibles, squarefree, with the full coefficient-by-coefficient factorization identity. Iteration 1 created Proofs/InverseGaloisOQ06OQ02.lean (mod-7 packaged Dedekind input q_mod7_factor_type).",
+    "iteration": 3,
+    "focus": "Iteration 3: added Proofs/InverseGaloisOQ06OQ02Cycle.lean (0-axiom, 0-sorry) isolating the PERMUTATION-GROUP half of Dedekind — part (B) cycle type => element order => 3 | |Gal|. Exhibits an explicit (1,1,3) permutation of the five roots (frob113 = (2 3 4), fixing the two linear-factor roots), proves IsThreeCycle/cycleType={3}/orderOf=3, and the abstract bridges three_dvd_card_of_orderOf_three, three_dvd_natCard_of_isThreeCycle_mem, dedekind_consequence_113. This makes precise that the ONLY remaining gap is part (A), the Frobenius<->factorization correspondence (sibling inverse-galois-a5-oq-01). Iteration 2 added P11 (mod-11 corroboration); iteration 1 created the mod-7 packaged input q_mod7_factor_type.",
     "blockers": [
       "Dedekind's theorem is not in Mathlib 4.26; the (1,1,3) => 3-cycle => 3 | |Gal| implication stays axiomatized (sibling track)."
     ],
-    "nextAction": "When Dedekind's theorem (or the sibling Frobenius bridge) lands, q_mod7_factor_type plugs in to discharge three_dvd_gal_card.",
+    "nextAction": "The remaining work is part (A) only: the Frobenius<->factorization correspondence (Dedekind's theorem) in the sibling track. q_mod7_factor_type (input) + dedekind_consequence_113 (consequence) then compose to discharge three_dvd_gal_card.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -43,19 +43,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT: shipped 0-axiom mod-7 Dedekind input (q_mod7_factor_type), then corroborated at a second unramified prime p=11 (q_mod11_factor_type, with full factorization identity) — two independent (1,1,3) witnesses, both 0-axiom/0-sorry.",
+    "progressSummary": "ACT: shipped 0-axiom mod-7 Dedekind input (q_mod7_factor_type), corroborated at p=11 (q_mod11_factor_type), then isolated and verified the permutation-group consequence (part B: cycle type (1,1,3) => order-3 element => 3 | |Gal|) in InverseGaloisOQ06OQ02Cycle.lean — explicit 3-cycle witness + abstract bridges, all 0-axiom/0-sorry. Residual gap is now precisely part (A), Frobenius<->factorization (Dedekind's theorem).",
     "builtItems": [
       "cubicMod7_irreducible via irreducible_of_degree_le_three_of_not_isRoot",
       "pairwise non-association of the three factors (eq_of_monic_of_associated + degree bounds)",
       "q_mod7_squarefree via squarefree_mul_iff and pairwise coprimality",
       "q_mod7_factor_type packaged Dedekind input",
-      "[p=11 corroboration] InverseGaloisOQ06OQ02P11.lean (0-axiom, 0-sorry): q mod 11 = (X-4)(X-3)(X^3+2X^2+X-5), cubicMod11 irreducible (no roots in F_11), pairwise non-associated, squarefree, AND the full coefficient-by-coefficient factorization identity q_ℤ.map = (X-4)(X-3)*cubicMod11 — an independent (1,1,3) witness at a second unramified prime"
+      "[p=11 corroboration] InverseGaloisOQ06OQ02P11.lean (0-axiom, 0-sorry): q mod 11 = (X-4)(X-3)(X^3+2X^2+X-5), cubicMod11 irreducible (no roots in F_11), pairwise non-associated, squarefree, AND the full coefficient-by-coefficient factorization identity q_ℤ.map = (X-4)(X-3)*cubicMod11 — an independent (1,1,3) witness at a second unramified prime",
+      "[part B: group-theory consequence] InverseGaloisOQ06OQ02Cycle.lean (0-axiom, 0-sorry): frob113 = swap 2 3 * swap 2 4 an explicit (1,1,3) permutation of the 5 roots (fixes 0,1 = the two linear-factor roots), frob113_isThreeCycle / frob113_cycleType={3} / frob113_orderOf=3; abstract bridges three_dvd_card_of_orderOf_three (finite group + order-3 elt => 3|card via orderOf_dvd_card), three_dvd_natCard_of_isThreeCycle_mem (subgroup of S(α) containing a 3-cycle => 3|Nat.card via Subgroup.orderOf_dvd_natCard), and dedekind_consequence_113. Verifies the deterministic half of Dedekind so the residual gap is exactly part (A)."
     ],
     "insights": [
       "A degree-3 poly over a field with no root is irreducible: irreducible_of_degree_le_three_of_not_isRoot.",
       "squarefree_mul_iff is phrased with IsRelPrime (not IsCoprime); convert via IsCoprime.isRelPrime.",
       "Linear-vs-cubic coprimality: Irreducible.isRelPrime_iff_not_dvd + dvd_iff_isRoot reduces to eval a cubic != 0.",
-      "isCoprime_of_irreducible_of_not_associated does not exist in Mathlib 4.26."
+      "isCoprime_of_irreducible_of_not_associated does not exist in Mathlib 4.26.",
+      "Equiv.Perm.isThreeCycle_swap_mul_swap_same (ab ac bc) builds IsThreeCycle (swap a b * swap a c) — cleanest concrete 3-cycle; distinctness over Fin 5 by decide.",
+      "Equiv.Perm.IsThreeCycle.orderOf : orderOf g = 3 (cycle type {3} => order 3 via lcm_cycleType).",
+      "Subgroup.orderOf_dvd_natCard (s) (hx : x ∈ s) : orderOf x ∣ Nat.card s — turns an element's order directly into a divisor of the subgroup order (no Fintype needed)."
     ],
     "mathlibGaps": [
       "Dedekind's theorem: mod-p factorization type => Frobenius cycle type for number fields (not in Mathlib 4.26).",
@@ -64,7 +68,8 @@
     "nextSteps": [
       "Plug q_mod7_factor_type (or q_mod11_factor_type) into Dedekind's theorem once available to eliminate three_dvd_gal_card.",
       "DONE: corroborated at the second unramified prime p=11 (q_mod11_factor_type, independent (1,1,3) witness) in InverseGaloisOQ06OQ02P11.lean.",
-      "Optionally add a third unramified prime, or pursue the sibling Frobenius bridge to actually discharge the axiom."
+      "DONE: isolated and verified part (B), the permutation-group consequence (cycle type (1,1,3) => order-3 element => 3 | |Gal|), in InverseGaloisOQ06OQ02Cycle.lean — 0-axiom/0-sorry.",
+      "Residual: part (A) only — the Frobenius<->factorization correspondence (Dedekind's theorem) in the sibling track inverse-galois-a5-oq-01 (exists_gal_order_three). Compose q_mod7_factor_type + dedekind_consequence_113 once part (A) lands."
     ],
     "markdown": "See research/problems/inverse-galois-oq-06-oq-02/knowledge.md"
   },
@@ -89,6 +94,17 @@
   "started": "2026-06-27",
   "lastUpdate": "2026-06-27",
   "leanFiles": [
+    {
+      "path": "Proofs/InverseGaloisOQ06OQ02Cycle.lean",
+      "filename": "InverseGaloisOQ06OQ02Cycle.lean",
+      "lineCount": 111,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ06OQ02Cycle.lean"
+    },
     {
       "path": "Proofs/InverseGaloisOQ06OQ02P11.lean",
       "filename": "InverseGaloisOQ06OQ02P11.lean",


### PR DESCRIPTION
## Summary

Advances **inverse-galois-oq-06-oq-02** (the algebraic input to the mod-7 Dedekind route toward the last axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` in `InverseGaloisA5.lean`).

Dedekind's conclusion at the unramified prime `p = 7` splits into two independent halves:

- **(A) Frobenius ↔ factorization** — the genuine number-theory gap (the Frobenius element at `𝔭 | 7` acts on the roots with cycle type equal to the factorization degrees). Owned by the sibling track `inverse-galois-a5-oq-01` (`InverseGaloisA5Dedekind.exists_gal_order_three`, still a `sorry`).
- **(B) cycle type ⟹ element order ⟹ divisibility of `|Gal|`** — a purely group-theoretic, fully machine-checkable consequence.

Prior iterations verified the **algebraic input** (the `(1,1,3)` factor type) at `p = 7` and `p = 11`, both 0-axiom/0-sorry. This PR isolates and verifies **part (B)**.

## New file: `Proofs/InverseGaloisOQ06OQ02Cycle.lean` (0-axiom, 0-sorry)

- `frob113 = swap 2 3 * swap 2 4` — an explicit `(1,1,3)` permutation of the five roots: 3-cycles the three roots of the irreducible cubic factor and **fixes** points `0, 1` (the roots of the two linear factors `X-5`, `X-6` mod 7).
- `frob113_isThreeCycle`, `frob113_cycleType = {3}`, `frob113_orderOf = 3` (kernel `decide`, **not** `native_decide` — stays genuinely 0-axiom).
- Abstract bridges:
  - `three_dvd_card_of_orderOf_three` — finite group + order-3 element ⟹ `3 ∣ card` (via `orderOf_dvd_card`).
  - `three_dvd_natCard_of_isThreeCycle_mem` — any subgroup of `S(α)` containing a 3-cycle has `3 ∣ Nat.card` (via `Subgroup.orderOf_dvd_natCard`).
  - `dedekind_consequence_113` — the packaged part-(B) statement, with the cycle-type hypothesis explicit so the residual gap (A) is visible.

## Honesty / scope

This does **not** discharge `three_dvd_gal_card`. It verifies the deterministic half of the mod-7 Dedekind route and pins the residual gap to *exactly* part (A), the Frobenius ↔ factorization correspondence (Dedekind's theorem, a Mathlib 4.26 gap). The axiom count of the A₅ entry is unchanged.

## Verification

`lake env lean Proofs/InverseGaloisOQ06OQ02Cycle.lean` → exit 0, no errors/warnings (Docker was unavailable; verified on host with the pinned Mathlib). 9 theorems, 1 def, 0 sorry, 0 `axiom`, 0 `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)