### PR TITLE
Enrich: Galois group of irreducible polynomial as transitive subgroup of S_n

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-setup-galaction",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-02",
+    "range": {
+      "startLine": 40,
+      "endLine": 45
+    },
+    "type": "context",
+    "title": "Setup: the Permutation Representation of the Galois Group",
+    "content": "The file works over an arbitrary base field F and an arbitrary extension E (not just the concrete quintic), with p : F[X] a polynomial. The central object, supplied by Mathlib, is galActionHom p E : p.Gal →* Equiv.Perm (rootSet p E) — the permutation representation that records how each field automorphism permutes the finite root set. Everything below studies this single homomorphism: its image is the 'subgroup of S_n', its injectivity makes that image a faithful copy of Gal p, and its transitivity (for irreducible p) is the property the abel-ruffini chain depends on. Opening MulAction brings the action API (IsPretransitive, exists_smul_eq) into scope; the scoped IntermediateField notation F⟮α⟯ is used in the divisibility proof.",
+    "mathContext": "$\\mathrm{galActionHom}\\,p\\,E : \\mathrm{Gal}\\,p \\to \\mathrm{Perm}(\\mathrm{rootSet}\\,p\\,E)$, the action of field automorphisms on the roots.",
+    "significance": "context",
+    "relatedConcepts": [
+      "permutation representation",
+      "Galois group action on roots",
+      "splitting field",
+      "root set"
+    ],
+    "prerequisites": [
+      "Polynomial.Gal",
+      "Polynomial.Gal.galActionHom",
+      "MulAction"
+    ]
+  },
+  {
     "id": "ann-transitive-subgroup",
     "proofId": "abel-ruffini-oq-04-oq-01-oq-02",
     "range": {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/meta.json
@@ -75,7 +75,8 @@
       "Irreducibility is exactly transitivity of the Galois action: the roots of an irreducible polynomial are mutually conjugate, hence form a single orbit. This is the Galois-theoretic source of the 'transitive subgroup of S_n' hypothesis that the sibling lemma consumes abstractly.",
       "Transitivity transfers from the abstract group action to the realised permutation subgroup with no extra work, because the corestriction onto the range is a surjective equivariant map — the subgroup acts by the very same permutations.",
       "Mathlib's prime_degree_dvd_card is not really about prime degree: primality was used solely to know the degree is nonzero. Replacing that with Irreducible.natDegree_pos yields the divisibility n | |Gal| for all n, recovering the parent's '5 | |Gal|' as the prime instance.",
-      "The orbit–stabilizer divisibility n | |Gal| is the quantitative shadow of transitivity: a transitive action of Gal on the n roots forces n to divide |Gal|, which is precisely how one knows a degree-n irreducible polynomial has Galois group of order a multiple of n."
+      "The orbit–stabilizer divisibility n | |Gal| is the quantitative shadow of transitivity: a transitive action of Gal on the n roots forces n to divide |Gal|, which is precisely how one knows a degree-n irreducible polynomial has Galois group of order a multiple of n.",
+      "Faithfulness — not the homomorphism alone — is what makes 'subgroup' literal rather than figurative. galActionHom_injective promotes the permutation representation Gal p → Perm(rootSet p E) to an isomorphism onto its image (galMulEquivRange), so Gal p is realised as, not merely mapped to, a transitive subgroup of S_n. Without injectivity one would only have a quotient acting on the roots."
     ],
     "prerequisites": [
       "Galois theory of polynomials: splitting fields, p.Gal, the action on roots",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-01-oq-02` (pass 0, quality 81).

## Changes
- **Annotation coverage**: added a `context` annotation for the previously-unannotated setup section (lines 40–45), framing `galActionHom` as the central permutation representation and how it threads the abel-ruffini chain — its *image* is the subgroup of $S_n$, its *injectivity* makes that image faithful, and its *transitivity* (for irreducible $p$) is the hypothesis the sibling lemma consumes.
- **keyInsights**: added a 5th insight on faithfulness — `galActionHom_injective` (packaged as `galMulEquivRange`) is what makes 'subgroup of $S_n$' literal rather than a mere quotient mapping into the symmetric group.

## Verification
- JSON valid; meta.json 12.1 KB (well under 60 KB cap, all collections under caps).
- `pnpm build` passes.

No existing content removed; additive only.