### PR TITLE
research(sperner-mathlib4-oq-02): door-conservation identity (degree + boundary doors = total doors)

### DIFF
--- a/proofs/Proofs/SpernerTuckerDoorGraph.lean
+++ b/proofs/Proofs/SpernerTuckerDoorGraph.lean
@@ -317,4 +317,70 @@ theorem doorGraph_degree_eq_shared
       obtain ⟨hvg, hwg⟩ := hgspec w hws
       exact hpair (g w) d v w hwv.symm hvg hwg hvd hwd
 
+/-- **Door conservation: total doors = shared doors + boundary doors.**  Every
+door of `v` is either *shared* (some other simplex also carries it) or a *boundary
+door* (`v` is its only simplex).  Combined with the sharp degree formula
+(`doorGraph_degree_eq_shared`, which identifies the shared doors with the graph
+degree), this gives the local door-balance identity
+
+> `degree v + #(boundary doors of v) = #(all doors of v)`.
+
+This is the abstract analogue of "interior facets are shared, boundary facets are
+not": it converts the global graph-degree of a simplex into a purely local count of
+its boundary doors.  It is exactly the conservation law the inductive
+lower-dimensional Tucker count plugs into — the boundary doors of the top-dimensional
+simplices are the facets the `(n−1)`-dimensional argument enumerates. -/
+theorem doorGraph_degree_add_boundaryDoors
+    (hdoor : ∀ d, #{v | inc v d} ≤ 2)
+    (hpair : ∀ d d' : D, ∀ v w : V, v ≠ w →
+      inc v d → inc w d → inc v d' → inc w d' → d = d')
+    (v : V) :
+    (doorGraph inc).degree v + #{d | inc v d ∧ ∀ w, w ≠ v → ¬ inc w d}
+      = #{d | inc v d} := by
+  classical
+  rw [doorGraph_degree_eq_shared inc hdoor hpair v]
+  -- Rewrite the boundary doors `∀ w ≠ v, ¬ inc w d` as the negation of "shared".
+  have hbdry : ({d | inc v d ∧ ∀ w, w ≠ v → ¬ inc w d} : Finset D)
+      = ({d | inc v d ∧ ¬ ∃ w, w ≠ v ∧ inc w d} : Finset D) := by
+    apply Finset.filter_congr
+    intro d _
+    constructor
+    · rintro ⟨h1, h2⟩
+      exact ⟨h1, by push_neg; exact h2⟩
+    · rintro ⟨h1, h2⟩
+      push_neg at h2
+      exact ⟨h1, h2⟩
+  rw [hbdry]
+  -- Shared and boundary doors partition the doors of `v`.
+  have e1 : #(({d | inc v d} : Finset D).filter (fun d => ∃ w, w ≠ v ∧ inc w d))
+      = #{d | inc v d ∧ ∃ w, w ≠ v ∧ inc w d} := by rw [Finset.filter_filter]
+  have e2 : #(({d | inc v d} : Finset D).filter (fun d => ¬ ∃ w, w ≠ v ∧ inc w d))
+      = #{d | inc v d ∧ ¬ ∃ w, w ≠ v ∧ inc w d} := by rw [Finset.filter_filter]
+  have hsplit := Finset.filter_card_add_filter_neg_card_eq_card
+    (s := ({d | inc v d} : Finset D)) (p := fun d => ∃ w, w ≠ v ∧ inc w d)
+  rw [e1, e2] at hsplit
+  exact hsplit
+
+/-- **A path endpoint with a full door complement has exactly one boundary door.**
+By door conservation, a degree-1 simplex (`degree v = 1`, the path-following
+*endpoint* condition) that carries the maximal two doors has `1 + b = 2`, i.e.
+exactly one boundary door `b = 1`.
+
+This is the clean local fingerprint of a complementary simplex on the boundary:
+of its two facets, one is shared with an interior neighbour (the unique graph edge)
+and the other lies on the boundary — the facet the inductive `(n−1)`-Tucker count
+pairs.  It turns the order-theoretic "endpoint" predicate into a single boundary
+door, with no reference to the global graph. -/
+theorem boundaryDoor_of_endpoint
+    (hdoor : ∀ d, #{v | inc v d} ≤ 2)
+    (hpair : ∀ d d' : D, ∀ v w : V, v ≠ w →
+      inc v d → inc w d → inc v d' → inc w d' → d = d')
+    (v : V)
+    (hdeg : (doorGraph inc).degree v = 1)
+    (htwo : #{d | inc v d} = 2) :
+    #{d | inc v d ∧ ∀ w, w ≠ v → ¬ inc w d} = 1 := by
+  have hcons := doorGraph_degree_add_boundaryDoors inc hdoor hpair v
+  rw [hdeg, htwo] at hcons
+  omega
+
 end SpernerTuckerDoorGraph

--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -88,6 +88,19 @@ compactness argument is the real (still-open) analytic phase.
 - **Tucker ⟹ Borsuk–Ulam** (continuous, mesh→0 + compactness) is a separate
   analytic phase, out of scope for the combinatorial engine.
 
+### Insight 5 — door conservation localizes the boundary (PORTABLE, DONE)
+With the sharp degree formula `degree v = #(shared doors of v)` in hand, the doors
+of a simplex split as shared (= graph degree) ⊕ boundary (carried by no other
+simplex), giving `degree v + #(boundary doors v) = #(all doors v)`
+(`doorGraph_degree_add_boundaryDoors`, 0-axiom). Consequence: a degree-1 *endpoint*
+with the maximal two doors has exactly one boundary door (`boundaryDoor_of_endpoint`).
+This makes "is a path endpoint" a **purely local** statement about a simplex's own
+boundary doors, with no reference to the global graph — the precise hook for the
+still-open `Odd #{boundary endpoints}` step, which becomes a count of boundary doors
+supplied by inductive (n−1)-Tucker. The abstract door-counting engine
+(`SpernerTuckerDoorGraph.lean`) is now closed end-to-end up to that one geometric/
+inductive boundary input.
+
 ---
 
 ## Dead Ends
@@ -109,6 +122,49 @@ a complementary edge.
 ---
 
 ## Session Log
+
+## Session 2026-06-27 (researcher-2) — ACT: door-conservation identity (degree + boundary doors = total doors)
+
+**Mode**: REVISIT (RICH). **Outcome**: progress — `SpernerTuckerDoorGraph.lean`
+(+2 theorems, ~60 L, 0 sorry, `#print axioms` = `[propext, Classical.choice,
+Quot.sound]` only, NO `ofReduceBool`/`sorryAx`). Verified via single-file
+`lake env lean` against the main-repo Mathlib olean cache (Docker host still down).
+
+### What I Did
+The prior session sharpened the degree bound to an *equality* `degree v =
+#(shared doors of v)` (`doorGraph_degree_eq_shared`). This session uses that to
+prove the **door-conservation law** and read off the local boundary fingerprint:
+
+- `doorGraph_degree_add_boundaryDoors` — under `hdoor` (≤2 simplices/door) and
+  `hpair` (distinct simplices share ≤1 door),
+  `degree v + #{d | inc v d ∧ ∀ w ≠ v, ¬ inc w d} = #{d | inc v d}`.
+  Proof: rewrite `degree` as `#shared` (the sharp formula); the shared doors
+  (`∃ w ≠ v, inc w d`) and the boundary doors (its negation, `push_neg`) partition
+  the doors of `v` via `Finset.filter_card_add_filter_neg_card_eq_card`.
+- `boundaryDoor_of_endpoint` — a degree-1 endpoint carrying the maximal two doors
+  has **exactly one** boundary door (`1 + b = 2`, `omega`).
+
+### Why this matters
+Conservation converts the *global* graph degree of a simplex into a *purely local*
+count of its boundary doors — the abstract analogue of "interior facets are shared,
+boundary facets are not". The endpoint corollary is the clean local fingerprint of
+a boundary complementary simplex: one shared facet (its unique graph edge) + one
+boundary facet (the facet the inductive `(n−1)`-Tucker count enumerates). This is
+the conservation law that the still-open `Odd #{boundary endpoints}` step plugs into:
+boundary endpoints ↔ simplices with an odd number of boundary doors.
+
+### Files Modified
+- proofs/Proofs/SpernerTuckerDoorGraph.lean (+`doorGraph_degree_add_boundaryDoors`,
+  +`boundaryDoor_of_endpoint`)
+- research/problems/sperner-mathlib4-oq-02/knowledge.md
+
+### Next Steps (frontier unchanged; boundary interface now local)
+- Supply `Odd #{boundary endpoints}` for a concrete antipodal triangulation by
+  counting **boundary doors** (now a local per-simplex quantity) via inductive
+  (n−1)-Tucker — feeds `exists_complementary_simplex`.
+- Build the concrete `inc : V → D → Prop` and discharge `hdoor`/`hsimplex`/`hpair`
+  geometrically; a boundary endpoint is a two-door simplex with one boundary door.
+- Continuous n≥2 Tucker ⟹ Borsuk–Ulam: analytic phase.
 
 ## Session 2026-06-27 (researcher-2) — ACT: sharp degree formula (degree = #shared doors)
 


### PR DESCRIPTION
## Summary

Extends the abstract door-counting engine for n≥2 Tucker
(`proofs/Proofs/SpernerTuckerDoorGraph.lean`) with the **door-conservation
identity** and its endpoint corollary. Builds directly on the prior session's
sharp degree formula `degree v = #(shared doors of v)`
(`doorGraph_degree_eq_shared`).

Two new theorems (0 sorry, 0 axiom):

- **`doorGraph_degree_add_boundaryDoors`** — under `hdoor` (each door joins ≤2
  simplices) and `hpair` (distinct simplices share ≤1 door):

  > `degree v + #{d | inc v d ∧ ∀ w ≠ v, ¬ inc w d} = #{d | inc v d}`

  i.e. every door of a simplex is either *shared* (= a graph edge, by the sharp
  degree formula) or a *boundary door* (carried by no other simplex), and these
  two partition the simplex's doors. Proof rewrites `degree` as `#shared`, then
  splits via `Finset.filter_card_add_filter_neg_card_eq_card`.

- **`boundaryDoor_of_endpoint`** — a degree-1 path *endpoint* carrying the maximal
  two doors has **exactly one** boundary door (`1 + b = 2`).

## Why it matters

Conservation converts the *global* graph degree of a simplex into a *purely local*
count of its boundary doors — the abstract analogue of "interior facets are shared,
boundary facets are not". The endpoint corollary is the clean local fingerprint of
a boundary complementary simplex: one shared facet (its unique graph edge) + one
boundary facet (the facet the inductive (n−1)-Tucker count enumerates). This is the
conservation law the still-open `Odd #{boundary endpoints}` step plugs into. The
abstract door-counting engine is now closed end-to-end up to that one
geometric/inductive boundary input.

## Verification

- `#print axioms` for both new theorems = `[propext, Classical.choice, Quot.sound]`
  — **no `ofReduceBool`, no `sorryAx`**.
- Built via single-file `lake env lean Proofs/SpernerTuckerDoorGraph.lean` against
  the main-repo Mathlib olean cache (toolchain `leanprover/lean4:v4.26.0`, exit 0).
  Docker host build is currently down; this is the standard single-file fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)