### PR TITLE
Enrich: Poincaré Separation (self-contained compression)

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-setup-imports-seam",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 55 },
+    "type": "context",
+    "title": "Setup: Joining the Two Gallery Files Across a Deliberate Seam",
+    "content": "The two imports are the load-bearing ones: `Proofs.CauchyInterlacingPoincare` supplies the abstract codimension-m separation inequality `poincare_separation` (which takes the compression and its Rayleigh-agreement hypothesis as inputs), and `Proofs.CauchyInterlacingCompression` supplies the explicit orthogonal compression `compress T H := P_H ∘ T ∘ ι_H` together with `isSymmetric_compress` and `rayleigh_compress_eq` (which discharge that hypothesis). Opening both namespaces brings every ingredient into scope so the join is a single application with no new spectral lemmas. The `variable` block fixes an arbitrary finite-dimensional inner product space `V` over `𝕜 : RCLike` (real or complex); the dimension split `finrank V = n + m` and `finrank H = n` is introduced per-theorem rather than globally, since the codimension `m` is what varies across the three results.",
+    "mathContext": "Abstract Poincaré (compression abstracted away) + explicit compression (codimension abstracted away) ⟹ both the Rayleigh hypothesis and the codimension restriction vanish.",
+    "significance": "context",
+    "relatedConcepts": ["module imports", "namespace composition", "RCLike inner product space", "abstraction boundary"],
+    "prerequisites": ["finite-dimensional inner product spaces", "the abstract Poincaré separation file", "the orthogonal compression file"]
+  },
+  {
     "id": "ann-poincare-separation-compression",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
     "range": { "startLine": 73, "endLine": 104 },

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -86,7 +86,8 @@
       "The explicit-compression construction is codimension-agnostic: nothing in compress, isSymmetric_compress, or rayleigh_compress_eq uses that H is a hyperplane, so the same machinery that yields the codimension-one corollary yields the arbitrary-codimension theorem with zero additional spectral work",
       "Joining the abstract Poincaré inequality (which abstracts away the compression) with the explicit compression (which abstracts away the codimension) removes BOTH the Rayleigh hypothesis and the codimension restriction simultaneously",
       "The main theorem differs from the merged codimension-one compression corollary only in calling poincare_separation rather than the codimension-one assembly — the surrounding spectral plumbing is identical, evidence the abstraction boundaries were drawn at the right place",
-      "Proof-irrelevance of the Fin.mk bounds lets the abstract theorem's ⟨k+m⟩ / ⟨k⟩ conclusion discharge the corollary's goal directly by exact, with no index-coercion rewriting in the main theorem"
+      "Proof-irrelevance of the Fin.mk bounds lets the abstract theorem's ⟨k+m⟩ / ⟨k⟩ conclusion discharge the corollary's goal directly by exact, with no index-coercion rewriting in the main theorem",
+      "The reason no Rayleigh side condition survives is geometric: the orthogonal projection is self-adjoint (P_H = P_H*), so for x in H one has ⟨(compress T H) x, x⟩ = ⟨P_H T x, x⟩ = ⟨T x, P_H x⟩ = ⟨T x, x⟩ — the Rayleigh quotient of the compression agrees with that of T on H by construction. rayleigh_compress_eq packages exactly this identity, which is precisely the hypothesis the abstract Poincaré theorem demanded, so the variational max–min argument applies verbatim to μ"
     ],
     "prerequisites": [
       "The spectral theorem: orthonormal eigenbases and antitone descending eigenvalue families for symmetric operators on finite-dimensional inner product spaces",


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-02` (pass 0, quality 81).

## Changes
- **Annotation coverage**: added a `context` annotation for the previously-unannotated setup region (lines 49–55), explaining the two load-bearing imports (`CauchyInterlacingPoincare` → abstract separation; `CauchyInterlacingCompression` → explicit compression + Rayleigh discharge) and the deliberate codimension-agnostic seam this entry joins.
- **keyInsights**: added a 5th insight on the *geometric* reason no Rayleigh side condition survives — self-adjointness of the orthogonal projection ($P_H = P_H^*$) forces $\langle (\mathrm{compress}\,T\,H)x, x\rangle = \langle Tx, x\rangle$ for $x \in H$, which is exactly the hypothesis the abstract Poincaré theorem consumes.

## Verification
- JSON valid; meta.json 15.8 KB (well under 60 KB cap, all collections under caps).
- `pnpm build` passes.

Additive only; no existing content removed.