### PR TITLE
research(stirling-formula-oq-02-oq-01): continuous Stirling for Γ via log-convexity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4077,6 +4077,7 @@ import Proofs.StirlingFirstKindOQ02OQ01
 import Proofs.StirlingFormula
 import Proofs.StirlingFormulaOQ01OQ01
 import Proofs.StirlingFormulaOQ02
+import Proofs.StirlingFormulaOQ02OQ01
 import Proofs.StirlingFormulaOQ03
 import Proofs.StirlingFormulaOQ03OQ01
 import Proofs.StirlingFormulaOQ03OQ02

--- a/proofs/Proofs/StirlingFormulaOQ02OQ01.lean
+++ b/proofs/Proofs/StirlingFormulaOQ02OQ01.lean
@@ -1,0 +1,394 @@
+import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
+import Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup
+import Mathlib.Analysis.SpecialFunctions.Stirling
+import Mathlib.Analysis.Asymptotics.AsymptoticEquivalent
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Tactic
+
+/-
+# The Continuous Stirling Formula for the Gamma Function
+
+## What This Proves
+The full **continuous** Stirling asymptotic for the real Gamma function:
+
+  Γ(x+1) ~ √(2πx) · (x/e)^x   as  x → ∞   (x ∈ ℝ),
+
+together with its logarithmic form
+
+  log Γ(x+1) − (½·log(2πx) + x·log x − x) → 0.
+
+The sibling entry `stirling-formula-oq-02` (StirlingFormulaOQ02.lean) established the
+Stirling formula for Γ only at **integer** points (via Γ(n+1) = n!), and explicitly
+left the continuous real-variable statement as an open question, noting it "requires
+the Laplace method (~500 lines of integral analysis not yet in Mathlib)".
+
+## Key Insight — no Laplace method needed
+The continuous formula follows from **two ingredients already in Mathlib**:
+
+  1. the discrete Stirling formula `Stirling.factorial_isEquivalent_stirling`, and
+  2. **log-convexity of Γ** (`Real.convexOn_log_Gamma`).
+
+Write n = ⌊x⌋.  Log-convexity of Γ gives the two-sided "slope sandwich"
+
+  (x−n)·log n  ≤  log Γ(x+1) − log Γ(n+1)  ≤  (x−n)·log(n+1),
+
+so log Γ(x+1) is pinned to the discrete value log Γ(n+1) up to an error that an
+elementary estimate (using only `Real.log_le_sub_one_of_pos`) shows tends to 0.
+This is the classical Artin/Bohr–Mollerup route and is far shorter than a Laplace
+integral analysis.
+
+## Status
+- [x] Discrete → continuous log form (fully verified, 0 sorries, 0 axioms)
+- [x] Asymptotic equivalence `~` form
+- [x] Slope sandwich from `convexOn_log_Gamma`
+- [x] Elementary error estimate `x·log(n/x) + (x−n) → 0`
+
+## Mathlib Dependencies
+- `Real.convexOn_log_Gamma`           : log ∘ Γ is convex on (0, ∞)
+- `Stirling.factorial_isEquivalent_stirling` : n! ~ √(2πn)·(n/e)^n
+- `Real.Gamma_add_one`, `Real.Gamma_pos_of_pos`, `Real.Gamma_nat_eq_factorial`
+- `Real.log_le_sub_one_of_pos`        : log y ≤ y − 1
+- `tendsto_nat_floor_div_atTop`       : ⌊x⌋/x → 1
+-/
+
+namespace StirlingGammaCont
+
+open Real Filter Asymptotics Topology
+
+/-- The logarithm of the Stirling approximation `√(2πy)·(y/e)^y`. -/
+noncomputable def logApprox (y : ℝ) : ℝ :=
+  (1 / 2) * Real.log (2 * π * y) + y * Real.log y - y
+
+-- ============================================================
+-- PART 1: Elementary error estimate
+--   −1/⌊x⌋ ≤ x·log(⌊x⌋/x) + (x − ⌊x⌋) ≤ 0
+-- ============================================================
+
+/-- Upper bound: `x·log(⌊x⌋/x) + (x − ⌊x⌋) ≤ 0`, from `log y ≤ y − 1`. -/
+theorem error_le_zero (x : ℝ) (hx : 1 ≤ x) :
+    x * Real.log ((⌊x⌋₊ : ℝ) / x) + (x - (⌊x⌋₊ : ℝ)) ≤ 0 := by
+  have hx0 : (0 : ℝ) < x := by linarith
+  have hn1 : 1 ≤ (⌊x⌋₊ : ℝ) := by
+    have : 1 ≤ ⌊x⌋₊ := Nat.one_le_floor_iff x |>.mpr hx
+    exact_mod_cast this
+  have hnx : (0 : ℝ) < (⌊x⌋₊ : ℝ) / x := by positivity
+  have hlog : Real.log ((⌊x⌋₊ : ℝ) / x) ≤ (⌊x⌋₊ : ℝ) / x - 1 := log_le_sub_one_of_pos hnx
+  have hmul : x * Real.log ((⌊x⌋₊ : ℝ) / x) ≤ x * ((⌊x⌋₊ : ℝ) / x - 1) :=
+    mul_le_mul_of_nonneg_left hlog hx0.le
+  have heq : x * ((⌊x⌋₊ : ℝ) / x - 1) = (⌊x⌋₊ : ℝ) - x := by field_simp
+  nlinarith [hmul, heq]
+
+/-- Lower bound: `−1/⌊x⌋ ≤ x·log(⌊x⌋/x) + (x − ⌊x⌋)`. -/
+theorem error_ge (x : ℝ) (hx : 1 ≤ x) :
+    -(1 / (⌊x⌋₊ : ℝ)) ≤ x * Real.log ((⌊x⌋₊ : ℝ) / x) + (x - (⌊x⌋₊ : ℝ)) := by
+  have hx0 : (0 : ℝ) < x := by linarith
+  have hn1 : 1 ≤ (⌊x⌋₊ : ℝ) := by
+    have : 1 ≤ ⌊x⌋₊ := Nat.one_le_floor_iff x |>.mpr hx
+    exact_mod_cast this
+  have hnpos : (0 : ℝ) < (⌊x⌋₊ : ℝ) := by linarith
+  have hxn0 : (0 : ℝ) < x / (⌊x⌋₊ : ℝ) := by positivity
+  have hlog : Real.log (x / (⌊x⌋₊ : ℝ)) ≤ x / (⌊x⌋₊ : ℝ) - 1 := log_le_sub_one_of_pos hxn0
+  have hinv : Real.log (x / (⌊x⌋₊ : ℝ)) = -Real.log ((⌊x⌋₊ : ℝ) / x) := by
+    rw [← Real.log_inv]; congr 1; field_simp
+  rw [hinv] at hlog
+  have h2 : x * (1 - x / (⌊x⌋₊ : ℝ)) ≤ x * Real.log ((⌊x⌋₊ : ℝ) / x) :=
+    mul_le_mul_of_nonneg_left (by linarith) hx0.le
+  have hfract : x - (⌊x⌋₊ : ℝ) < 1 := by
+    have := Nat.lt_floor_add_one x; linarith
+  have hfract0 : 0 ≤ x - (⌊x⌋₊ : ℝ) := by
+    have := Nat.floor_le hx0.le; linarith
+  have key : x * (1 - x / (⌊x⌋₊ : ℝ)) + (x - (⌊x⌋₊ : ℝ))
+      = -((x - (⌊x⌋₊ : ℝ)) ^ 2 / (⌊x⌋₊ : ℝ)) := by field_simp; ring
+  have hsq : (x - (⌊x⌋₊ : ℝ)) ^ 2 ≤ 1 := by nlinarith [hfract, hfract0]
+  have hfin : -(1 / (⌊x⌋₊ : ℝ)) ≤ -((x - (⌊x⌋₊ : ℝ)) ^ 2 / (⌊x⌋₊ : ℝ)) := by
+    rw [neg_le_neg_iff, div_le_div_iff_of_pos_right hnpos]; exact hsq
+  linarith [h2, key, hfin]
+
+-- ============================================================
+-- PART 2: Log-convexity slope sandwich
+--   log Γ(n+1) + (x−n)·log n ≤ log Γ(x+1) ≤ log Γ(n+1) + (x−n)·log(n+1)
+-- ============================================================
+
+/-- Lower sandwich from convexity (slope monotonicity). -/
+theorem sandwich_lower (x : ℝ) (hx : 1 ≤ x) :
+    Real.log (Real.Gamma ((⌊x⌋₊ : ℝ) + 1)) + (x - (⌊x⌋₊ : ℝ)) * Real.log (⌊x⌋₊ : ℝ)
+      ≤ Real.log (Real.Gamma (x + 1)) := by
+  set n : ℝ := (⌊x⌋₊ : ℝ) with hn
+  have hn1 : 1 ≤ n := by
+    have : 1 ≤ ⌊x⌋₊ := Nat.one_le_floor_iff x |>.mpr hx
+    rw [hn]; exact_mod_cast this
+  have hnle : n ≤ x := by rw [hn]; exact Nat.floor_le (by linarith)
+  rcases eq_or_lt_of_le hnle with hxe | hxlt
+  · rw [← hxe]; simp
+  · have hconv := convexOn_log_Gamma
+    have hmemn : n ∈ Set.Ioi (0 : ℝ) := Set.mem_Ioi.mpr (by linarith)
+    have hmemx1 : x + 1 ∈ Set.Ioi (0 : ℝ) := Set.mem_Ioi.mpr (by linarith)
+    have hslope := hconv.slope_mono_adjacent hmemn hmemx1
+      (by linarith : n < n + 1) (by linarith : n + 1 < x + 1)
+    have hGn : Real.Gamma (n + 1) = n * Real.Gamma n :=
+      Real.Gamma_add_one (by linarith : n ≠ 0)
+    have hGnpos : 0 < Real.Gamma n := Real.Gamma_pos_of_pos (by linarith)
+    have hslopeLeft :
+        ((Real.log ∘ Real.Gamma) (n + 1) - (Real.log ∘ Real.Gamma) n) / (n + 1 - n)
+          = Real.log n := by
+      simp only [Function.comp_apply]
+      rw [hGn, Real.log_mul (by linarith : n ≠ 0) (ne_of_gt hGnpos),
+          show n + 1 - n = 1 by ring, div_one]
+      ring
+    have hxn : (0 : ℝ) < x - n := by linarith
+    rw [hslopeLeft, show x + 1 - (n + 1) = x - n by ring, le_div_iff₀ hxn] at hslope
+    simp only [Function.comp_apply] at hslope
+    nlinarith [hslope]
+
+/-- Upper sandwich from convexity (chord above the graph). -/
+theorem sandwich_upper (x : ℝ) (hx : 1 ≤ x) :
+    Real.log (Real.Gamma (x + 1)) ≤
+      Real.log (Real.Gamma ((⌊x⌋₊ : ℝ) + 1)) + (x - (⌊x⌋₊ : ℝ)) * Real.log ((⌊x⌋₊ : ℝ) + 1) := by
+  set n : ℝ := (⌊x⌋₊ : ℝ) with hn
+  have hn1 : 1 ≤ n := by
+    have : 1 ≤ ⌊x⌋₊ := Nat.one_le_floor_iff x |>.mpr hx
+    rw [hn]; exact_mod_cast this
+  have hnle : n ≤ x := by rw [hn]; exact Nat.floor_le (by linarith)
+  have hlt : x < n + 1 := by rw [hn]; exact_mod_cast Nat.lt_floor_add_one x
+  have hconv := convexOn_log_Gamma
+  have hmemn1 : n + 1 ∈ Set.Ioi (0 : ℝ) := Set.mem_Ioi.mpr (by linarith)
+  have hmemn2 : n + 2 ∈ Set.Ioi (0 : ℝ) := Set.mem_Ioi.mpr (by linarith)
+  have ha : (0 : ℝ) ≤ (n + 1) - x := by linarith
+  have hb : (0 : ℝ) ≤ x - n := by linarith
+  have hab : ((n + 1) - x) + (x - n) = 1 := by ring
+  have hchord := hconv.2 hmemn1 hmemn2 ha hb hab
+  have hpt : ((n + 1) - x) • (n + 1) + (x - n) • (n + 2) = x + 1 := by
+    simp only [smul_eq_mul]; ring
+  rw [hpt] at hchord
+  simp only [Function.comp_apply, smul_eq_mul] at hchord
+  have hGn2 : Real.Gamma (n + 2) = (n + 1) * Real.Gamma (n + 1) := by
+    have h : (n + 1) + 1 = n + 2 := by ring
+    rw [← h, Real.Gamma_add_one (by linarith : n + 1 ≠ 0)]
+  have hGn1pos : 0 < Real.Gamma (n + 1) := Real.Gamma_pos_of_pos (by linarith)
+  have hL2 : Real.log (Real.Gamma (n + 2))
+      = Real.log (n + 1) + Real.log (Real.Gamma (n + 1)) := by
+    rw [hGn2, Real.log_mul (by linarith : n + 1 ≠ 0) (ne_of_gt hGn1pos)]
+  rw [hL2] at hchord
+  nlinarith [hchord]
+
+-- ============================================================
+-- PART 3: Algebraic identity linking the discrete and continuous error
+-- ============================================================
+
+/-- The combined error term equals the elementary expression of Part 1
+(plus a `½·log(n/x)` correction that also vanishes). -/
+theorem error_identity (x : ℝ) (hx : 1 ≤ x) :
+    (x - (⌊x⌋₊ : ℝ)) * Real.log (⌊x⌋₊ : ℝ) + logApprox (⌊x⌋₊ : ℝ) - logApprox x
+      = (1 / 2) * Real.log ((⌊x⌋₊ : ℝ) / x)
+          + (x * Real.log ((⌊x⌋₊ : ℝ) / x) + (x - (⌊x⌋₊ : ℝ))) := by
+  set n : ℝ := (⌊x⌋₊ : ℝ) with hn
+  have hx0 : (0 : ℝ) < x := by linarith
+  have hn1 : 1 ≤ n := by
+    have : 1 ≤ ⌊x⌋₊ := Nat.one_le_floor_iff x |>.mpr hx
+    rw [hn]; exact_mod_cast this
+  have hnpos : (0 : ℝ) < n := by linarith
+  have hpi : (0 : ℝ) < π := Real.pi_pos
+  have e1 : Real.log (2 * π * n) - Real.log (2 * π * x) = Real.log (n / x) := by
+    rw [← Real.log_div (by positivity) (by positivity)]
+    congr 1
+    field_simp
+  have e2 : Real.log n - Real.log x = Real.log (n / x) :=
+    (Real.log_div (ne_of_gt hnpos) (ne_of_gt hx0)).symm
+  simp only [logApprox]
+  linear_combination (1 / 2) * e1 + x * e2
+
+-- ============================================================
+-- PART 4: Discrete Stirling in log form
+-- ============================================================
+
+/-- The discrete Stirling formula, in the form `log Γ(n+1) − logApprox n → 0`. -/
+theorem discrete_log_stirling :
+    Tendsto (fun n : ℕ => Real.log (Real.Gamma ((n : ℝ) + 1)) - logApprox (n : ℝ))
+      atTop (𝓝 0) := by
+  have hequiv := Stirling.factorial_isEquivalent_stirling
+  have hne : ∀ᶠ n : ℕ in atTop,
+      Real.sqrt (2 * (n : ℝ) * π) * ((n : ℝ) / Real.exp 1) ^ n ≠ 0 := by
+    filter_upwards [eventually_gt_atTop 0] with n hn
+    have hn' : (0 : ℝ) < n := by exact_mod_cast hn
+    positivity
+  have htend1 : Tendsto
+      (fun n : ℕ => (Nat.factorial n : ℝ) / (Real.sqrt (2 * (n : ℝ) * π) * ((n : ℝ) / Real.exp 1) ^ n))
+      atTop (𝓝 1) := (isEquivalent_iff_tendsto_one hne).mp hequiv
+  have htendlog : Tendsto
+      (fun n : ℕ =>
+        Real.log ((Nat.factorial n : ℝ) / (Real.sqrt (2 * (n : ℝ) * π) * ((n : ℝ) / Real.exp 1) ^ n)))
+      atTop (𝓝 0) := by
+    have h := (Real.continuousAt_log (one_ne_zero)).tendsto.comp htend1
+    simpa using h
+  refine Filter.Tendsto.congr' ?_ htendlog
+  filter_upwards [eventually_gt_atTop 0] with n hn
+  have hn' : (0 : ℝ) < n := by exact_mod_cast hn
+  have hfac : (0 : ℝ) < (Nat.factorial n : ℝ) := by positivity
+  have hden : (0 : ℝ) < Real.sqrt (2 * (n : ℝ) * π) * ((n : ℝ) / Real.exp 1) ^ n := by positivity
+  rw [Real.log_div (ne_of_gt hfac) (ne_of_gt hden),
+      Real.log_mul (by positivity) (by positivity),
+      Real.log_pow, Real.sqrt_eq_rpow, Real.log_rpow (by positivity)]
+  -- log Γ(n+1) = log n!
+  rw [Real.Gamma_nat_eq_factorial]
+  -- expand logApprox and n·log(n/e) = n·log n − n
+  rw [logApprox, Real.log_div (ne_of_gt hn') (Real.exp_ne_zero 1), Real.log_exp]
+  have h2pi : Real.log (2 * π * (n : ℝ)) = Real.log (2 * (n : ℝ) * π) := by
+    congr 1; ring
+  rw [h2pi]
+  ring
+
+-- ============================================================
+-- PART 5: The vanishing of the error terms
+-- ============================================================
+
+/-- `1/⌊x⌋ → 0`. -/
+theorem inv_floor_tendsto : Tendsto (fun x : ℝ => ((⌊x⌋₊ : ℝ))⁻¹) atTop (𝓝 0) := by
+  have hfl : Tendsto (fun x : ℝ => (⌊x⌋₊ : ℝ)) atTop atTop :=
+    tendsto_natCast_atTop_atTop.comp (tendsto_nat_floor_atTop (α := ℝ))
+  exact hfl.inv_tendsto_atTop
+
+/-- `½·log(⌊x⌋/x) → 0`. -/
+theorem half_log_floor_div_tendsto :
+    Tendsto (fun x : ℝ => (1 / 2) * Real.log ((⌊x⌋₊ : ℝ) / x)) atTop (𝓝 0) := by
+  have hdiv : Tendsto (fun x : ℝ => (⌊x⌋₊ : ℝ) / x) atTop (𝓝 1) := tendsto_nat_floor_div_atTop
+  have hlog : Tendsto (fun x : ℝ => Real.log ((⌊x⌋₊ : ℝ) / x)) atTop (𝓝 0) := by
+    have h := (Real.continuousAt_log (one_ne_zero)).tendsto.comp hdiv
+    simpa using h
+  have := hlog.const_mul (1 / 2 : ℝ)
+  simpa using this
+
+/-- The elementary error `x·log(⌊x⌋/x) + (x − ⌊x⌋) → 0` (squeeze). -/
+theorem error_tendsto :
+    Tendsto (fun x : ℝ => x * Real.log ((⌊x⌋₊ : ℝ) / x) + (x - (⌊x⌋₊ : ℝ)))
+      atTop (𝓝 0) := by
+  have hlo : Tendsto (fun x : ℝ => -((⌊x⌋₊ : ℝ))⁻¹) atTop (𝓝 0) := by
+    have := inv_floor_tendsto.neg; simpa using this
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le' hlo tendsto_const_nhds ?_ ?_
+  · filter_upwards [eventually_ge_atTop (1 : ℝ)] with x hx
+    have := error_ge x hx
+    rwa [one_div] at this
+  · filter_upwards [eventually_ge_atTop (1 : ℝ)] with x hx
+    exact error_le_zero x hx
+
+/-- The upper-sandwich correction `(x − ⌊x⌋)·(log(⌊x⌋+1) − log ⌊x⌋) → 0` (squeeze). -/
+theorem correction_tendsto :
+    Tendsto (fun x : ℝ =>
+      (x - (⌊x⌋₊ : ℝ)) * (Real.log ((⌊x⌋₊ : ℝ) + 1) - Real.log (⌊x⌋₊ : ℝ)))
+      atTop (𝓝 0) := by
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds inv_floor_tendsto ?_ ?_
+  · filter_upwards [eventually_ge_atTop (1 : ℝ)] with x hx
+    have hn1 : 1 ≤ (⌊x⌋₊ : ℝ) := by
+      have : 1 ≤ ⌊x⌋₊ := Nat.one_le_floor_iff x |>.mpr hx
+      exact_mod_cast this
+    have hfract0 : 0 ≤ x - (⌊x⌋₊ : ℝ) := by
+      have := Nat.floor_le (by linarith : (0:ℝ) ≤ x); linarith
+    have hmono : Real.log (⌊x⌋₊ : ℝ) ≤ Real.log ((⌊x⌋₊ : ℝ) + 1) :=
+      Real.log_le_log (by linarith) (by linarith)
+    exact mul_nonneg hfract0 (by linarith [hmono])
+  · filter_upwards [eventually_ge_atTop (1 : ℝ)] with x hx
+    have hx0 : (0 : ℝ) < x := by linarith
+    have hn1 : 1 ≤ (⌊x⌋₊ : ℝ) := by
+      have : 1 ≤ ⌊x⌋₊ := Nat.one_le_floor_iff x |>.mpr hx
+      exact_mod_cast this
+    have hnpos : (0 : ℝ) < (⌊x⌋₊ : ℝ) := by linarith
+    have hfract0 : 0 ≤ x - (⌊x⌋₊ : ℝ) := by
+      have := Nat.floor_le hx0.le; linarith
+    have hfract1 : x - (⌊x⌋₊ : ℝ) ≤ 1 := by
+      have := Nat.lt_floor_add_one x; linarith
+    -- log(n+1) − log n = log((n+1)/n) ≤ (n+1)/n − 1 = 1/n
+    have hd : Real.log ((⌊x⌋₊ : ℝ) + 1) - Real.log (⌊x⌋₊ : ℝ) ≤ ((⌊x⌋₊ : ℝ))⁻¹ := by
+      have hdiv : (0 : ℝ) < ((⌊x⌋₊ : ℝ) + 1) / (⌊x⌋₊ : ℝ) := by positivity
+      have hl := log_le_sub_one_of_pos hdiv
+      rw [Real.log_div (by linarith) (ne_of_gt hnpos)] at hl
+      have hsub : ((⌊x⌋₊ : ℝ) + 1) / (⌊x⌋₊ : ℝ) - 1 = ((⌊x⌋₊ : ℝ))⁻¹ := by
+        field_simp; ring
+      rw [hsub] at hl; exact hl
+    have hmono0 : 0 ≤ Real.log ((⌊x⌋₊ : ℝ) + 1) - Real.log (⌊x⌋₊ : ℝ) := by
+      have : Real.log (⌊x⌋₊ : ℝ) ≤ Real.log ((⌊x⌋₊ : ℝ) + 1) :=
+        Real.log_le_log hnpos (by linarith)
+      linarith
+    calc (x - (⌊x⌋₊ : ℝ)) * (Real.log ((⌊x⌋₊ : ℝ) + 1) - Real.log (⌊x⌋₊ : ℝ))
+        ≤ 1 * (Real.log ((⌊x⌋₊ : ℝ) + 1) - Real.log (⌊x⌋₊ : ℝ)) := by
+          apply mul_le_mul_of_nonneg_right hfract1 hmono0
+      _ = Real.log ((⌊x⌋₊ : ℝ) + 1) - Real.log (⌊x⌋₊ : ℝ) := by ring
+      _ ≤ ((⌊x⌋₊ : ℝ))⁻¹ := hd
+
+-- ============================================================
+-- PART 6: Main result — log form
+-- ============================================================
+
+/-- **Continuous Stirling formula (logarithmic form).**
+`log Γ(x+1) − (½·log(2πx) + x·log x − x) → 0` as `x → ∞`. -/
+theorem log_gamma_continuous_stirling :
+    Tendsto (fun x : ℝ => Real.log (Real.Gamma (x + 1)) - logApprox x) atTop (𝓝 0) := by
+  -- D(x) := log Γ(⌊x⌋+1) − logApprox ⌊x⌋ → 0
+  have hD : Tendsto (fun x : ℝ =>
+      Real.log (Real.Gamma ((⌊x⌋₊ : ℝ) + 1)) - logApprox (⌊x⌋₊ : ℝ)) atTop (𝓝 0) :=
+    discrete_log_stirling.comp (tendsto_nat_floor_atTop (α := ℝ))
+  -- lower bounding function
+  have hlo : Tendsto (fun x : ℝ =>
+      (Real.log (Real.Gamma ((⌊x⌋₊ : ℝ) + 1)) - logApprox (⌊x⌋₊ : ℝ))
+        + ((1 / 2) * Real.log ((⌊x⌋₊ : ℝ) / x)
+            + (x * Real.log ((⌊x⌋₊ : ℝ) / x) + (x - (⌊x⌋₊ : ℝ))))) atTop (𝓝 0) := by
+    have := hD.add (half_log_floor_div_tendsto.add error_tendsto)
+    simpa using this
+  -- upper bounding function = lower + correction
+  have hhi : Tendsto (fun x : ℝ =>
+      ((Real.log (Real.Gamma ((⌊x⌋₊ : ℝ) + 1)) - logApprox (⌊x⌋₊ : ℝ))
+        + ((1 / 2) * Real.log ((⌊x⌋₊ : ℝ) / x)
+            + (x * Real.log ((⌊x⌋₊ : ℝ) / x) + (x - (⌊x⌋₊ : ℝ)))))
+        + (x - (⌊x⌋₊ : ℝ)) * (Real.log ((⌊x⌋₊ : ℝ) + 1) - Real.log (⌊x⌋₊ : ℝ)))
+      atTop (𝓝 0) := by
+    have := hlo.add correction_tendsto
+    simpa using this
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le' hlo hhi ?_ ?_
+  · -- lower ≤ target
+    filter_upwards [eventually_ge_atTop (1 : ℝ)] with x hx
+    have hid := error_identity x hx
+    have hsw := sandwich_lower x hx
+    -- target − lower = (log Γ(x+1)) − (log Γ(n+1) + (x−n) log n)  ≥ 0
+    nlinarith [hid, hsw]
+  · -- target ≤ upper
+    filter_upwards [eventually_ge_atTop (1 : ℝ)] with x hx
+    have hid := error_identity x hx
+    have hsw := sandwich_upper x hx
+    nlinarith [hid, hsw]
+
+-- ============================================================
+-- PART 7: Main result — asymptotic equivalence
+-- ============================================================
+
+/-- `exp(logApprox x) = √(2πx)·(x/e)^x` for `x > 0`. -/
+theorem exp_logApprox (x : ℝ) (hx : 0 < x) :
+    Real.exp (logApprox x) = Real.sqrt (2 * π * x) * (x / Real.exp 1) ^ x := by
+  have h1 : Real.sqrt (2 * π * x) = Real.exp ((1 / 2) * Real.log (2 * π * x)) := by
+    rw [Real.sqrt_eq_rpow, Real.rpow_def_of_pos (by positivity)]; ring_nf
+  have h2 : (x / Real.exp 1) ^ x = Real.exp (x * Real.log x - x) := by
+    rw [Real.rpow_def_of_pos (by positivity)]
+    congr 1
+    rw [Real.log_div (ne_of_gt hx) (Real.exp_ne_zero 1), Real.log_exp]; ring
+  rw [h1, h2, ← Real.exp_add, logApprox]
+  congr 1; ring
+
+/-- **Continuous Stirling formula (asymptotic equivalence).**
+`Γ(x+1) ~ √(2πx)·(x/e)^x` as `x → ∞`. This is the headline result; the sibling
+entry `stirling-formula-oq-02` proved it only at integer points. -/
+theorem gamma_continuous_isEquivalent_stirling :
+    (fun x : ℝ => Real.Gamma (x + 1)) ~[atTop]
+      fun x : ℝ => Real.sqrt (2 * π * x) * (x / Real.exp 1) ^ x := by
+  refine (isEquivalent_iff_tendsto_one ?_).mpr ?_
+  · filter_upwards [eventually_gt_atTop (0 : ℝ)] with x hx
+    have : 0 < Real.sqrt (2 * π * x) * (x / Real.exp 1) ^ x := by positivity
+    exact ne_of_gt this
+  · have hexp : Tendsto
+        (fun x : ℝ => Real.exp (Real.log (Real.Gamma (x + 1)) - logApprox x))
+        atTop (𝓝 1) := by
+      have h := (Real.continuous_exp.tendsto 0).comp log_gamma_continuous_stirling
+      simpa using h
+    refine hexp.congr' ?_
+    filter_upwards [eventually_gt_atTop (0 : ℝ)] with x hx
+    have hΓ : 0 < Real.Gamma (x + 1) := Real.Gamma_pos_of_pos (by linarith)
+    rw [Real.exp_sub, Real.exp_log hΓ, exp_logApprox x hx]
+    simp [Pi.div_apply]
+
+end StirlingGammaCont

--- a/research/problems/stirling-formula-oq-02-oq-01/knowledge.md
+++ b/research/problems/stirling-formula-oq-02-oq-01/knowledge.md
@@ -1,0 +1,80 @@
+# Knowledge: Continuous Stirling Formula for the Gamma Function
+
+**Problem**: Prove the full continuous Stirling formula Γ(x+1) ~ √(2πx)·(x/e)^x for all real x > 0.
+
+**Slug**: `stirling-formula-oq-02-oq-01` (child of `stirling-formula-oq-02`).
+
+## Status: SOLVED (continuous form), 0 axioms, 0 sorries
+
+Lean file: `proofs/Proofs/StirlingFormulaOQ02OQ01.lean`, namespace `StirlingGammaCont`.
+
+Main results:
+- `gamma_continuous_isEquivalent_stirling` : `(fun x => Γ(x+1)) ~[atTop] (fun x => √(2πx)·(x/e)^x)` — the headline `~` form.
+- `log_gamma_continuous_stirling` : `log Γ(x+1) − (½·log(2πx) + x·log x − x) → 0` — the log form.
+
+## Key insight (corrects the parent's assessment)
+
+The parent entry `stirling-formula-oq-02` proved Stirling for Γ **only at integer
+points** (via Γ(n+1)=n!) and stated the continuous version as an open question,
+asserting it "requires the Laplace method (~500 lines of integral analysis not yet
+in Mathlib)".
+
+**This is overly pessimistic.** The continuous formula follows from two facts already
+in Mathlib, with NO Laplace integral analysis:
+
+1. `Stirling.factorial_isEquivalent_stirling` — the discrete formula n! ~ √(2πn)(n/e)^n.
+2. `Real.convexOn_log_Gamma` — log-convexity of Γ on (0,∞).
+
+This is the classical **Artin / Bohr–Mollerup** route.
+
+## Proof architecture
+
+Write n = ⌊x⌋. Log-convexity of Γ gives a two-sided **slope sandwich**:
+
+    (x−n)·log n  ≤  log Γ(x+1) − log Γ(n+1)  ≤  (x−n)·log(n+1).
+
+- Lower bound: `ConvexOn.slope_mono_adjacent` on the triple n < n+1 < x+1, using
+  slope(n,n+1) = log Γ(n+1)/Γ(n) = log n.
+- Upper bound: the chord/convex-combination inequality (`ConvexOn.2`) with
+  x+1 = a(n+1)+b(n+2), a=(n+1)−x, b=x−n, using log Γ(n+2)/Γ(n+1) = log(n+1).
+
+Combining with the discrete log-Stirling `log Γ(n+1) − logApprox n → 0` and the
+algebraic identity (`error_identity`)
+
+    (x−n)·log n + logApprox n − logApprox x
+        = ½·log(n/x) + (x·log(n/x) + (x−n)),
+
+the target log Γ(x+1) − logApprox x is squeezed between two functions both → 0.
+
+## The crux estimate (`error_le_zero` / `error_ge`)
+
+For x ≥ 1, n = ⌊x⌋:
+
+    −1/n  ≤  x·log(n/x) + (x−n)  ≤  0.
+
+- Upper: `log y ≤ y−1` (`Real.log_le_sub_one_of_pos`) at y=n/x gives
+  x·log(n/x) ≤ x(n/x−1) = n−x, i.e. the bracket ≤ 0.
+- Lower: same lemma at y=x/n gives log(n/x) ≥ 1−x/n, hence the bracket ≥
+  −(x−n)²/n ≥ −1/n (since (x−n)² < 1).
+
+Both bounds → 0: `½·log(n/x) → 0` (since ⌊x⌋/x → 1, `tendsto_nat_floor_div_atTop`),
+the bracket → 0 by squeeze against ±1/⌊x⌋ → 0, and the upper-sandwich correction
+(x−n)(log(n+1)−log n) → 0 (bounded by 1/⌊x⌋ via `log_le_sub_one_of_pos`).
+
+## Mathlib lemmas that made it short
+- `Real.convexOn_log_Gamma`, `ConvexOn.slope_mono_adjacent`, `ConvexOn.2` (chord).
+- `Stirling.factorial_isEquivalent_stirling`, `isEquivalent_iff_tendsto_one`.
+- `Real.log_le_sub_one_of_pos`, `tendsto_nat_floor_div_atTop`, `tendsto_nat_floor_atTop`.
+- `Real.Gamma_add_one`, `Real.Gamma_pos_of_pos`, `Real.Gamma_nat_eq_factorial`.
+
+## Verification
+Type-checked with `lake env lean Proofs/StirlingFormulaOQ02OQ01.lean` (host Lean
+4.26.0 against prebuilt Mathlib v4.26.0). Docker build wrapper was unavailable this
+session; single-file host check used as the fallback. 0 sorries, 0 axioms,
+`#print axioms` clean (only the foundational propext/Classical.choice/Quot.sound).
+
+## Follow-up directions (not pursued)
+- Ramanujan/Stirling series next term: log Γ(x+1) = … + 1/(12x) − … (needs error
+  control beyond the leading log term).
+- Bernoulli-number asymptotic expansion.
+These are genuinely harder (real error estimates), distinct from this entry.

--- a/src/data/proofs/stirling-formula-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/stirling-formula-oq-02-oq-01/annotations.json
@@ -1,0 +1,108 @@
+[
+  {
+    "id": "ann-sfoq0201-header",
+    "proofId": "stirling-formula-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 60 },
+    "type": "concept",
+    "title": "Goal: continuous Stirling without the Laplace method",
+    "content": "The sibling entry stirling-formula-oq-02 proved Stirling's formula for the Gamma function only at integer arguments (via Γ(n+1)=n!) and left the continuous real-variable statement Γ(x+1) ~ √(2πx)·(x/e)^x as an open question, estimating it would need '~500 lines of integral analysis (Laplace method) not yet in Mathlib'. This file proves the continuous formula in full, with 0 axioms and 0 sorries, using a completely different and far shorter route: Mathlib's discrete Stirling formula together with the log-convexity of Γ. The logApprox definition packages the target log-asymptotic ½·log(2πy) + y·log y − y.",
+    "mathContext": "$\\Gamma(x+1) \\sim \\sqrt{2\\pi x}\\,(x/e)^x$ as $x\\to\\infty$, $x\\in\\mathbb{R}$ — proved from log-convexity, not the Laplace integral.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gamma function",
+      "Stirling's formula",
+      "log-convexity",
+      "Bohr–Mollerup theorem",
+      "asymptotic equivalence"
+    ],
+    "prerequisites": [
+      "Gamma function and Γ(s+1)=s·Γ(s)",
+      "convex functions",
+      "asymptotic equivalence and squeeze theorem"
+    ]
+  },
+  {
+    "id": "ann-sfoq0201-error-estimate",
+    "proofId": "stirling-formula-oq-02-oq-01",
+    "range": { "startLine": 62, "endLine": 105 },
+    "type": "technique",
+    "title": "The one elementary estimate the whole proof needs",
+    "content": "error_le_zero and error_ge establish −1/⌊x⌋ ≤ x·log(⌊x⌋/x) + (x−⌊x⌋) ≤ 0. Both directions use a single Mathlib lemma, log y ≤ y−1 (Real.log_le_sub_one_of_pos): applied at y=⌊x⌋/x it gives the upper bound x·log(⌊x⌋/x) ≤ ⌊x⌋−x; applied at y=x/⌊x⌋ it gives log(⌊x⌋/x) ≥ 1−x/⌊x⌋, so the bracket ≥ −(x−⌊x⌋)²/⌊x⌋ ≥ −1/⌊x⌋ since the fractional part squared is < 1.",
+    "mathContext": "$-\\tfrac{1}{n} \\le x\\log\\tfrac{n}{x} + (x-n) \\le 0,\\quad n=\\lfloor x\\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": ["logarithm inequalities", "floor function", "squeeze theorem"],
+    "prerequisites": ["log y ≤ y−1", "elementary algebra"]
+  },
+  {
+    "id": "ann-sfoq0201-sandwich",
+    "proofId": "stirling-formula-oq-02-oq-01",
+    "range": { "startLine": 107, "endLine": 173 },
+    "type": "technique",
+    "title": "Log-convexity pins log Γ(x+1) to its integer neighbours",
+    "content": "sandwich_lower uses ConvexOn.slope_mono_adjacent on n < n+1 < x+1: the slope between n and n+1 is log Γ(n+1)/Γ(n) = log n, so log Γ(x+1) − log Γ(n+1) ≥ (x−n)·log n. sandwich_upper uses the chord (convex-combination) inequality on [n+1,n+2], with endpoint slope log Γ(n+2)/Γ(n+1) = log(n+1), giving the matching upper bound. Both reductions of Γ-ratios use the functional equation Γ(s+1)=s·Γ(s).",
+    "mathContext": "$(x{-}n)\\log n \\le \\log\\Gamma(x{+}1) - \\log\\Gamma(n{+}1) \\le (x{-}n)\\log(n{+}1)$.",
+    "significance": "key",
+    "relatedConcepts": ["convexity", "slope monotonicity", "Gamma functional equation"],
+    "prerequisites": ["ConvexOn.slope_mono_adjacent", "chord inequality"]
+  },
+  {
+    "id": "ann-sfoq0201-error-identity",
+    "proofId": "stirling-formula-oq-02-oq-01",
+    "range": { "startLine": 175, "endLine": 199 },
+    "type": "insight",
+    "title": "Bridging the discrete and continuous error",
+    "content": "error_identity shows the combined error (x−n)·log n + logApprox(n) − logApprox(x) equals ½·log(n/x) + (x·log(n/x) + (x−n)). This is the algebraic glue that connects the sandwich (which references log Γ(n+1)) to the discrete Stirling limit (which references logApprox(n)). It is proved by linear_combination over the two logarithm-of-quotient identities log(2πn)−log(2πx)=log(n/x) and log n − log x = log(n/x).",
+    "mathContext": "$(x{-}n)\\log n + \\log A(n) - \\log A(x) = \\tfrac12\\log\\tfrac{n}{x} + \\big(x\\log\\tfrac{n}{x} + (x{-}n)\\big)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["logarithm laws", "linear_combination tactic"],
+    "prerequisites": ["log of a quotient"]
+  },
+  {
+    "id": "ann-sfoq0201-discrete",
+    "proofId": "stirling-formula-oq-02-oq-01",
+    "range": { "startLine": 201, "endLine": 239 },
+    "type": "technique",
+    "title": "Recasting Mathlib's factorial Stirling in log form",
+    "content": "discrete_log_stirling converts Stirling.factorial_isEquivalent_stirling (n! ~ √(2πn)(n/e)^n) into the additive log statement log Γ(n+1) − logApprox(n) → 0. The equivalence gives the ratio n!/(√(2πn)(n/e)^n) → 1; taking logs (continuity of log at 1) and rewriting via Γ(n+1)=n! and log of the product/power yields the result.",
+    "mathContext": "$\\log\\Gamma(n{+}1) - \\big(\\tfrac12\\log(2\\pi n) + n\\log n - n\\big) \\to 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["asymptotic equivalence", "continuity of log"],
+    "prerequisites": ["isEquivalent_iff_tendsto_one", "Γ(n+1)=n!"]
+  },
+  {
+    "id": "ann-sfoq0201-vanishing",
+    "proofId": "stirling-formula-oq-02-oq-01",
+    "range": { "startLine": 241, "endLine": 316 },
+    "type": "technique",
+    "title": "Squeezing the error terms to zero",
+    "content": "Four limit lemmas finish the analytic bookkeeping: inv_floor_tendsto (1/⌊x⌋ → 0), half_log_floor_div_tendsto (½·log(⌊x⌋/x) → 0, since ⌊x⌋/x → 1 by tendsto_nat_floor_div_atTop), error_tendsto (the bracket → 0 by squeezing against ±1/⌊x⌋ from Part 1), and correction_tendsto ((x−⌊x⌋)(log(⌊x⌋+1)−log ⌊x⌋) → 0, bounded above by 1/⌊x⌋ again via log y ≤ y−1).",
+    "mathContext": "$\\tfrac12\\log\\tfrac{\\lfloor x\\rfloor}{x}\\to 0,\\quad x\\log\\tfrac{\\lfloor x\\rfloor}{x} + (x-\\lfloor x\\rfloor)\\to 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["squeeze theorem", "floor asymptotics"],
+    "prerequisites": ["tendsto_nat_floor_div_atTop", "squeeze"]
+  },
+  {
+    "id": "ann-sfoq0201-log-form",
+    "proofId": "stirling-formula-oq-02-oq-01",
+    "range": { "startLine": 317, "endLine": 357 },
+    "type": "result",
+    "title": "Main result (logarithmic form)",
+    "content": "log_gamma_continuous_stirling assembles everything: the target log Γ(x+1) − logApprox(x) is squeezed between a lower function (discrete error + ½·log(⌊x⌋/x) + bracket) and an upper function (the same plus the (x−⌊x⌋)·(log(⌊x⌋+1)−log ⌊x⌋) correction). Both bounds → 0 by Parts 3–5, and the pointwise inequalities come from the sandwich plus error_identity.",
+    "mathContext": "$\\log\\Gamma(x{+}1) - \\big(\\tfrac12\\log(2\\pi x) + x\\log x - x\\big) \\to 0$.",
+    "significance": "key",
+    "relatedConcepts": ["squeeze theorem", "Stirling's formula"],
+    "prerequisites": ["all preceding parts"]
+  },
+  {
+    "id": "ann-sfoq0201-equivalence",
+    "proofId": "stirling-formula-oq-02-oq-01",
+    "range": { "startLine": 358, "endLine": 394 },
+    "type": "result",
+    "title": "Headline result: the asymptotic equivalence",
+    "content": "exp_logApprox proves exp(logApprox x) = √(2πx)·(x/e)^x, the bridge between additive and multiplicative forms. gamma_continuous_isEquivalent_stirling then states Γ(x+1) ~ √(2πx)·(x/e)^x: exponentiating the log-form limit gives Γ(x+1)/(√(2πx)(x/e)^x) → 1, which is the equivalence by isEquivalent_iff_tendsto_one. Both headline theorems depend only on propext, Classical.choice, Quot.sound.",
+    "mathContext": "$\\Gamma(x{+}1) \\sim \\sqrt{2\\pi x}\\,(x/e)^x \\quad (x\\to\\infty,\\ x\\in\\mathbb{R})$.",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic equivalence", "exponential/logarithm bridge"],
+    "prerequisites": ["isEquivalent_iff_tendsto_one", "rpow identities"]
+  }
+]

--- a/src/data/proofs/stirling-formula-oq-02-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-02-oq-01/meta.json
@@ -1,0 +1,208 @@
+{
+  "id": "stirling-formula-oq-02-oq-01",
+  "title": "The Continuous Stirling Formula for the Gamma Function",
+  "slug": "stirling-formula-oq-02-oq-01",
+  "description": "Answers the parent's open question by proving the full continuous Stirling asymptotic Γ(x+1) ~ √(2πx)·(x/e)^x for all real x → ∞ (not just integer points). The key insight is that NO Laplace method is needed: the result follows from Mathlib's discrete Stirling formula plus log-convexity of Γ, via a two-sided slope sandwich and an elementary error estimate. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Researcher (lean-genius)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StirlingFormulaOQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "gamma-function",
+      "stirling-formula",
+      "asymptotics",
+      "special-functions",
+      "log-convexity",
+      "bohr-mollerup"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.convexOn_log_Gamma",
+        "description": "log ∘ Γ is convex on (0, ∞); the source of the two-sided slope sandwich",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup"
+      },
+      {
+        "theorem": "Stirling.factorial_isEquivalent_stirling",
+        "description": "The discrete Stirling formula n! ~ √(2πn)·(n/e)^n, bridged to log Γ at integers",
+        "module": "Mathlib.Analysis.SpecialFunctions.Stirling"
+      },
+      {
+        "theorem": "ConvexOn.slope_mono_adjacent",
+        "description": "Monotonicity of adjacent slopes of a convex function; gives the lower sandwich",
+        "module": "Mathlib.Analysis.Convex.Slope"
+      },
+      {
+        "theorem": "Real.log_le_sub_one_of_pos",
+        "description": "log y ≤ y − 1; the only analytic input for the elementary O(1/n) error estimate",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "tendsto_nat_floor_div_atTop",
+        "description": "⌊x⌋/x → 1, used to vanish the ½·log(⌊x⌋/x) correction",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "Real.Gamma_add_one",
+        "description": "Γ(s+1) = s·Γ(s); turns adjacent log-Γ slopes into log n and log(n+1)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "isEquivalent_iff_tendsto_one",
+        "description": "f ~ g ↔ f/g → 1; packages the log-form limit into the asymptotic equivalence",
+        "module": "Mathlib.Analysis.Asymptotics.AsymptoticEquivalent"
+      }
+    ],
+    "originalContributions": [
+      "gamma_continuous_isEquivalent_stirling: the headline result Γ(x+1) ~ √(2πx)·(x/e)^x for real x → ∞, which the parent entry left open (it proved only integer points)",
+      "log_gamma_continuous_stirling: the logarithmic form log Γ(x+1) − (½·log(2πx) + x·log x − x) → 0",
+      "sandwich_lower / sandwich_upper: the two-sided log-convexity slope sandwich (x−n)·log n ≤ log Γ(x+1) − log Γ(n+1) ≤ (x−n)·log(n+1), n = ⌊x⌋",
+      "error_le_zero / error_ge: the elementary two-sided bound −1/⌊x⌋ ≤ x·log(⌊x⌋/x) + (x−⌊x⌋) ≤ 0, proved using only log y ≤ y−1",
+      "error_identity: the algebraic bridge linking the discrete error log Γ(n+1) − logApprox n to the continuous error log Γ(x+1) − logApprox x",
+      "discrete_log_stirling: Mathlib's factorial Stirling formula recast in the log form log Γ(n+1) − logApprox n → 0",
+      "exp_logApprox: exp(logApprox x) = √(2πx)·(x/e)^x, the bridge between the log and equivalence forms"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Both headline theorems (gamma_continuous_isEquivalent_stirling, log_gamma_continuous_stirling) depend only on propext, Classical.choice, Quot.sound.",
+    "lineCount": 394,
+    "theoremCount": 13,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Stirling's formula n! ~ √(2πn)·(n/e)^n (de Moivre 1721, Stirling 1730) extends to the Gamma function Γ(x+1) ~ √(2πx)·(x/e)^x for real x. The classical analytic proof (Laplace 1812) goes through the integral representation Γ(x+1) = ∫₀^∞ t^x e^{−t} dt via the Laplace/saddle-point method. The sibling gallery entry stirling-formula-oq-02 proved the formula only at integer points (using Γ(n+1)=n!) and stated the continuous real-variable version as an open question, estimating it would need '~500 lines of integral analysis not yet in Mathlib'. This entry shows that estimate to be far too pessimistic: the continuous formula follows from the discrete one plus log-convexity of Γ — the route Emil Artin used in his 1931 monograph 'The Gamma Function', and the same convexity that underlies the Bohr–Mollerup theorem (already in Mathlib).",
+    "problemStatement": "Prove the full continuous Stirling formula Γ(x+1) ~ √(2πx)·(x/e)^x as x → ∞ over the reals, not merely at integer arguments.\n\n**Answer:** Proved, with 0 axioms and 0 sorries, WITHOUT the Laplace method — from Mathlib's discrete Stirling formula and the log-convexity of Γ.",
+    "text": "A short, fully elementary derivation of the continuous Gamma Stirling asymptotic from the factorial case, using log-convexity instead of integral asymptotics.",
+    "proofStrategy": "Let n = ⌊x⌋. (1) Log-convexity of Γ (Real.convexOn_log_Gamma) gives a two-sided slope sandwich: the lower bound from ConvexOn.slope_mono_adjacent on n < n+1 < x+1 (whose left slope is log Γ(n+1)/Γ(n) = log n), the upper bound from the chord inequality on [n+1, n+2] (whose endpoint slope is log Γ(n+2)/Γ(n+1) = log(n+1)). (2) The discrete Stirling formula gives log Γ(n+1) − logApprox(n) → 0. (3) An algebraic identity reduces the residual error to ½·log(n/x) + (x·log(n/x) + (x−n)). (4) The elementary bound −1/n ≤ x·log(n/x) + (x−n) ≤ 0, proved from log y ≤ y−1 alone, plus ⌊x⌋/x → 1, squeezes everything to 0. (5) Exponentiating converts the log-form limit into the asymptotic equivalence via isEquivalent_iff_tendsto_one.",
+    "keyInsights": [
+      "**No Laplace method is needed.** The parent entry estimated the continuous formula at ~500 lines of integral analysis. Log-convexity of Γ — already in Mathlib via Bohr–Mollerup — collapses it to a slope sandwich plus an elementary squeeze.",
+      "**Log-convexity pins the continuous value to the discrete one.** For n = ⌊x⌋, convexity forces (x−n)·log n ≤ log Γ(x+1) − log Γ(n+1) ≤ (x−n)·log(n+1); since log(n+1) − log n → 0, the continuous value tracks the discrete Stirling value.",
+      "**The whole error reduces to one elementary estimate.** After algebra, the gap is ½·log(⌊x⌋/x) + (x·log(⌊x⌋/x) + (x−⌊x⌋)), and the bracket is squeezed between −1/⌊x⌋ and 0 using only log y ≤ y−1 (applied at both n/x and x/n).",
+      "**This is Artin's route.** The same convexity argument Emil Artin used to characterize Γ yields its asymptotics for free, reusing exactly the Mathlib API built for the Bohr–Mollerup uniqueness theorem."
+    ],
+    "prerequisites": [
+      "The Gamma function and its functional equation Γ(s+1) = s·Γ(s)",
+      "Convex functions and slope monotonicity",
+      "Asymptotic equivalence (IsEquivalent), filters and the squeeze theorem",
+      "The factorial Stirling formula (Wiedijk #90)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part-1-error-estimate",
+      "title": "PART 1: Elementary Error Estimate",
+      "startLine": 62,
+      "endLine": 105,
+      "summary": "error_le_zero and error_ge prove the two-sided bound −1/⌊x⌋ ≤ x·log(⌊x⌋/x) + (x−⌊x⌋) ≤ 0. The upper bound applies log y ≤ y−1 at y = ⌊x⌋/x; the lower bound applies it at y = x/⌊x⌋ and uses (x−⌊x⌋)² < 1.",
+      "mathContext": "-\\tfrac{1}{n} \\le x\\log\\tfrac{n}{x} + (x-n) \\le 0, \\quad n = \\lfloor x\\rfloor"
+    },
+    {
+      "id": "part-2-sandwich",
+      "title": "PART 2: Log-Convexity Slope Sandwich",
+      "startLine": 107,
+      "endLine": 173,
+      "summary": "sandwich_lower (via ConvexOn.slope_mono_adjacent) and sandwich_upper (via the chord/convex-combination inequality) bound log Γ(x+1) between log Γ(n+1) + (x−n)·log n and log Γ(n+1) + (x−n)·log(n+1), using Γ(n+1)=n·Γ(n) and Γ(n+2)=(n+1)·Γ(n+1).",
+      "mathContext": "\\log\\Gamma(n{+}1) + (x{-}n)\\log n \\le \\log\\Gamma(x{+}1) \\le \\log\\Gamma(n{+}1) + (x{-}n)\\log(n{+}1)"
+    },
+    {
+      "id": "part-3-error-identity",
+      "title": "PART 3: Discrete–Continuous Error Identity",
+      "startLine": 175,
+      "endLine": 199,
+      "summary": "error_identity: (x−n)·log n + logApprox n − logApprox x = ½·log(n/x) + (x·log(n/x) + (x−n)), proved by linear_combination over the log-addition identities for 2πn/2πx and n/x.",
+      "mathContext": "(x{-}n)\\log n + \\log\\!A(n) - \\log\\!A(x) = \\tfrac12\\log\\tfrac{n}{x} + \\big(x\\log\\tfrac{n}{x} + (x{-}n)\\big)"
+    },
+    {
+      "id": "part-4-discrete",
+      "title": "PART 4: Discrete Stirling in Log Form",
+      "startLine": 201,
+      "endLine": 239,
+      "summary": "discrete_log_stirling: recasts Stirling.factorial_isEquivalent_stirling as log Γ(n+1) − logApprox(n) → 0, by taking logs of the ratio n!/(√(2πn)(n/e)^n) → 1 and rewriting via Γ(n+1)=n!.",
+      "mathContext": "\\log\\Gamma(n{+}1) - \\big(\\tfrac12\\log(2\\pi n) + n\\log n - n\\big) \\to 0"
+    },
+    {
+      "id": "part-5-vanishing",
+      "title": "PART 5: Vanishing of the Error Terms",
+      "startLine": 241,
+      "endLine": 316,
+      "summary": "inv_floor_tendsto (1/⌊x⌋ → 0), half_log_floor_div_tendsto (½·log(⌊x⌋/x) → 0 via ⌊x⌋/x → 1), error_tendsto (the bracket → 0 by squeezing against ±1/⌊x⌋), and correction_tendsto ((x−⌊x⌋)(log(⌊x⌋+1)−log ⌊x⌋) → 0, bounded by 1/⌊x⌋).",
+      "mathContext": "\\tfrac12\\log\\tfrac{\\lfloor x\\rfloor}{x} \\to 0,\\quad x\\log\\tfrac{\\lfloor x\\rfloor}{x} + (x-\\lfloor x\\rfloor) \\to 0"
+    },
+    {
+      "id": "part-6-log-form",
+      "title": "PART 6: Main Result — Logarithmic Form",
+      "startLine": 317,
+      "endLine": 357,
+      "summary": "log_gamma_continuous_stirling: log Γ(x+1) − logApprox x → 0, by squeezing the target between the lower and upper sandwich combinations (each → 0 by Parts 3–5).",
+      "mathContext": "\\log\\Gamma(x{+}1) - \\big(\\tfrac12\\log(2\\pi x) + x\\log x - x\\big) \\to 0"
+    },
+    {
+      "id": "part-7-equivalence",
+      "title": "PART 7: Main Result — Asymptotic Equivalence",
+      "startLine": 358,
+      "endLine": 394,
+      "summary": "exp_logApprox (exp(logApprox x) = √(2πx)(x/e)^x) and gamma_continuous_isEquivalent_stirling (Γ(x+1) ~ √(2πx)(x/e)^x), obtained by exponentiating the log-form limit and applying isEquivalent_iff_tendsto_one.",
+      "mathContext": "\\Gamma(x{+}1) \\sim \\sqrt{2\\pi x}\\,(x/e)^x \\quad (x\\to\\infty,\\ x\\in\\mathbb{R})"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1931",
+      "note": "Log-convexity characterization of Γ; the convexity route used here"
+    },
+    {
+      "authors": "Stirling, James",
+      "title": "Methodus Differentialis",
+      "year": "1730",
+      "note": "The factorial asymptotic with the sharp constant √(2π)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "stirling-formula-oq-02",
+      "relationship": "answers",
+      "description": "Directly answers OQ-02's stated open question — the full continuous Stirling formula for Γ at real arguments — and shows it does not require the Laplace method."
+    },
+    {
+      "targetId": "stirling-formula",
+      "relationship": "extends",
+      "description": "Extends the factorial Stirling formula (Wiedijk #90) from ℕ to the continuous real Gamma function."
+    }
+  ],
+  "conclusion": {
+    "summary": "The continuous Stirling formula Γ(x+1) ~ √(2πx)·(x/e)^x is proved for all real x → ∞, with 0 axioms and 0 sorries, from Mathlib's discrete Stirling formula and the log-convexity of Γ. A two-sided slope sandwich pins log Γ(x+1) to the discrete log-Stirling value, and an elementary estimate (using only log y ≤ y−1) squeezes the residual error to 0.",
+    "implications": "Upgrades the parent's integer-point result to the full real-variable asymptotic, and demonstrates that log-convexity — not the Laplace method — is the economical route. The continuous Gamma Stirling formula underpins large-parameter asymptotics throughout probability and statistical mechanics.",
+    "openQuestions": [
+      "Prove the next term of the Stirling series: log Γ(x+1) = x log x − x + ½ log(2πx) + 1/(12x) + O(1/x³), which needs error control beyond the leading log term.",
+      "Connect the higher-order corrections to the Bernoulli numbers in the asymptotic expansion."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gamma.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup",
+      "Mathlib.Analysis.SpecialFunctions.Stirling",
+      "Mathlib.Analysis.Asymptotics.AsymptoticEquivalent",
+      "Mathlib.Analysis.SpecificLimits.Basic"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Asymptotics",
+      "Topology"
+    ],
+    "namespace": "StirlingGammaCont",
+    "lineCount": 394,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "path": "Proofs/StirlingFormulaOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/stirling-formula-oq-02-oq-01.json
+++ b/src/data/research/problems/stirling-formula-oq-02-oq-01.json
@@ -1,0 +1,100 @@
+{
+  "slug": "stirling-formula-oq-02-oq-01",
+  "title": "The Continuous Stirling Formula for the Gamma Function",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\Gamma(x+1) \\sim \\sqrt{2\\pi x}\\,(x/e)^x \\text{ as } x \\to \\infty,\\ x \\in \\mathbb{R}.",
+    "plain": "Prove the full continuous Stirling formula Γ(x+1) ~ √(2πx)·(x/e)^x for all real x → ∞, generalizing the parent entry's integer-point result.",
+    "whyMatters": [
+      "Completes the Gamma-Stirling development from integer arguments to the full real line.",
+      "Shows the continuous formula needs only log-convexity (Bohr–Mollerup), not the Laplace method, correcting the parent's ~500-line estimate."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "`gamma_continuous_isEquivalent_stirling`: Γ(x+1) ~ √(2πx)·(x/e)^x for real x → ∞ (headline).",
+      "`log_gamma_continuous_stirling`: log Γ(x+1) − (½·log(2πx) + x·log x − x) → 0.",
+      "`sandwich_lower` / `sandwich_upper`: the two-sided log-convexity slope sandwich.",
+      "`error_le_zero` / `error_ge`: the elementary bound −1/⌊x⌋ ≤ x·log(⌊x⌋/x) + (x−⌊x⌋) ≤ 0.",
+      "`error_identity`, `discrete_log_stirling`, `exp_logApprox`: the bridging infrastructure."
+    ],
+    "open": [
+      "Next-order Stirling series term log Γ(x+1) = x log x − x + ½ log(2πx) + 1/(12x) + O(1/x³).",
+      "Connection of higher corrections to Bernoulli numbers."
+    ],
+    "goal": "Use log-convexity of Γ plus the discrete Stirling formula to obtain the continuous asymptotic."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-27T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Continuous Stirling for Γ via the log-convexity (Artin/Bohr–Mollerup) route.",
+    "blockers": [],
+    "nextAction": "Done. Optional follow-up: the 1/(12x) correction term.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED. Proved the continuous Stirling formula Γ(x+1) ~ √(2πx)·(x/e)^x (and its log form) with 0 axioms and 0 sorries, from Mathlib's Stirling.factorial_isEquivalent_stirling and Real.convexOn_log_Gamma. Key device: a two-sided slope sandwich from log-convexity pins log Γ(x+1) to the discrete log-Stirling value, and a single elementary estimate (log y ≤ y−1) squeezes the residual error to 0. No Laplace method.",
+    "builtItems": [
+      "Lean file Proofs/StirlingFormulaOQ02OQ01.lean (namespace StirlingGammaCont, 13 theorems, 1 def, 394 lines, 0 axioms, 0 sorries).",
+      "Gallery entry src/data/proofs/stirling-formula-oq-02-oq-01/ (meta.json + annotations.json)."
+    ],
+    "insights": [
+      "The continuous Gamma Stirling formula follows from log-convexity of Γ — already in Mathlib via Bohr–Mollerup — without any integral/Laplace analysis; the parent's ~500-line estimate was far too pessimistic.",
+      "ConvexOn.slope_mono_adjacent (lower) and the chord inequality ConvexOn.2 (upper) give a clean (x−⌊x⌋)-scaled sandwich around the integer Stirling value.",
+      "The entire residual error reduces to x·log(⌊x⌋/x) + (x−⌊x⌋), bounded between −1/⌊x⌋ and 0 using only Real.log_le_sub_one_of_pos."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the discrete Stirling formula and Γ log-convexity but not the continuous Gamma Stirling asymptotic; this file supplies it (candidate for upstreaming)."
+    ],
+    "nextSteps": [
+      "Optionally formalize the 1/(12x) correction term and the Bernoulli-number expansion (genuinely harder; separate entry)."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "analysis",
+    "gamma-function",
+    "stirling-formula",
+    "asymptotics",
+    "log-convexity"
+  ],
+  "relatedProofs": [
+    "stirling-formula-oq-02",
+    "stirling-formula",
+    "stirling-formula-oq-03-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup",
+      "Mathlib.Analysis.SpecialFunctions.Stirling"
+    ]
+  },
+  "started": "2026-06-27T00:00:00.000Z",
+  "lastUpdate": "2026-06-27T00:00:00.000Z",
+  "completed": "2026-06-27T00:00:00.000Z",
+  "significance": 7,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/StirlingFormulaOQ02OQ01.lean",
+      "filename": "StirlingFormulaOQ02OQ01.lean",
+      "lineCount": 394,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/StirlingFormulaOQ02OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **full continuous Stirling formula** for the Gamma function:

> Γ(x+1) ~ √(2πx)·(x/e)^x   as x → ∞   (x ∈ ℝ)

together with its logarithmic form `log Γ(x+1) − (½·log(2πx) + x·log x − x) → 0`.

This is exactly the open question the parent entry **`stirling-formula-oq-02`** left
unanswered. That entry proved Stirling for Γ only at **integer** points (via Γ(n+1)=n!)
and stated the continuous real-variable version as open, estimating it would require
"the Laplace method (~500 lines of integral analysis not yet in Mathlib)".

## Key insight: no Laplace method needed

The continuous formula follows from **two facts already in Mathlib**:

1. `Stirling.factorial_isEquivalent_stirling` — the discrete formula n! ~ √(2πn)(n/e)^n;
2. `Real.convexOn_log_Gamma` — log-convexity of Γ.

This is the classical **Artin / Bohr–Mollerup** route. With n = ⌊x⌋:

- **Slope sandwich** (from `ConvexOn.slope_mono_adjacent` + the chord inequality):
  `(x−n)·log n ≤ log Γ(x+1) − log Γ(n+1) ≤ (x−n)·log(n+1)`.
- **Elementary error estimate** (using only `Real.log_le_sub_one_of_pos`):
  `−1/⌊x⌋ ≤ x·log(⌊x⌋/x) + (x−⌊x⌋) ≤ 0`.

The discrete log-Stirling value plus these bounds squeeze the residual error to 0.

## Verification

- `proofs/Proofs/StirlingFormulaOQ02OQ01.lean` — 13 theorems, 1 def, 394 lines.
- **0 axioms, 0 sorries.** Both headline theorems
  (`gamma_continuous_isEquivalent_stirling`, `log_gamma_continuous_stirling`)
  depend only on `propext, Classical.choice, Quot.sound` (checked via `#print axioms`;
  no `sorryAx`, no `Lean.ofReduceBool`).
- Registered in `proofs/Proofs.lean`.
- Type-checked with host `lake env lean` (Lean 4.26.0) against prebuilt Mathlib v4.26.0.
  The Docker build wrapper was unavailable this session, so a CI/deployer Docker build
  is the remaining confirmation gate before any `verified` flip is final.

## Gallery

- `src/data/proofs/stirling-formula-oq-02-oq-01/{meta.json, annotations.json}`
- `src/data/research/problems/stirling-formula-oq-02-oq-01.json` (status: completed)
- `research/problems/stirling-formula-oq-02-oq-01/knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)