### PR TITLE
research(sperner-mathlib4-oq-02): path-endpoint form of the boundary-door parity bridge [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerTuckerDoorIncidenceParity.lean
+++ b/proofs/Proofs/SpernerTuckerDoorIncidenceParity.lean
@@ -261,12 +261,54 @@ theorem card_interior_eq
   rw [sum_doorCount_eq_boundary_add_two_interior inc h1 h2]
   omega
 
+/-! ## Path-endpoint form: stating the bridge in the degree-1 vocabulary
+
+The parity bridge above produces a cell of *odd* door-count.  The path-following
+engine (`SpernerTuckerPathFollowing`) consumes its seed as a **degree-1** vertex —
+a cell touching *exactly one* door, the endpoint of a path.  In the door-graph
+regime where every cell, like every door, touches at most two of the other kind,
+"odd door-count" collapses to "exactly one door", so the parity bridge can be stated
+directly in the vocabulary the engine expects, without an intervening `Odd`. -/
+
+/-- In the door-graph regime (every cell touches at most two doors), a cell has an
+odd door-count iff it touches *exactly one* door — a path endpoint.  Hence the number
+of path-endpoint cells is congruent mod 2 to the number of boundary doors. -/
+theorem card_endpoint_cells_modEq_card_boundaryDoor
+    (hc2 : ∀ c, doorCount inc c ≤ 2) (h2 : ∀ d, cellCount inc d ≤ 2) :
+    (univ.filter (fun c => doorCount inc c = 1)).card % 2
+      = (univ.filter (IsBoundaryDoor inc)).card % 2 := by
+  have hfilt : (univ.filter (fun c => doorCount inc c = 1))
+      = univ.filter (fun c => Odd (doorCount inc c)) := by
+    apply Finset.filter_congr
+    intro c _
+    rw [Nat.odd_iff]
+    have := hc2 c
+    omega
+  rw [hfilt, card_odd_doorCount_modEq_card_boundaryDoor inc h2]
+
+/-- **Odd boundary doors force a path-endpoint cell.**  In the door-graph regime
+(cells and doors of incidence ≤ 2), an odd number of boundary doors forces a cell
+touching *exactly one* door — a degree-1 path endpoint, the precise seed the
+path-following engine follows to a complementary simplex.  This refines
+`exists_odd_doorCount_of_odd_boundary` from "odd door-count" to "exactly one door". -/
+theorem exists_endpoint_cell_of_odd_boundary
+    (hc2 : ∀ c, doorCount inc c ≤ 2) (h2 : ∀ d, cellCount inc d ≤ 2)
+    (hbdry : Odd (univ.filter (IsBoundaryDoor inc)).card) :
+    ∃ c, doorCount inc c = 1 := by
+  obtain ⟨c, hc⟩ := exists_odd_doorCount_of_odd_boundary inc h2 hbdry
+  refine ⟨c, ?_⟩
+  rw [Nat.odd_iff] at hc
+  have := hc2 c
+  omega
+
 #check @incidence_parity_duality
 #check @card_odd_doorCount_modEq_card_boundaryDoor
 #check @exists_odd_doorCount_of_odd_boundary
 #check @even_card_odd_doorCount_of_all_interior
 #check @sum_doorCount_eq_boundary_add_two_interior
 #check @card_interior_eq
+#check @card_endpoint_cells_modEq_card_boundaryDoor
+#check @exists_endpoint_cell_of_odd_boundary
 
 -- Axiom audit: the results depend only on the foundational axioms
 -- (propext / Classical.choice / Quot.sound); no `sorryAx`, no `Lean.ofReduceBool`.
@@ -276,5 +318,7 @@ theorem card_interior_eq
 #print axioms even_card_odd_doorCount_of_all_interior
 #print axioms sum_doorCount_eq_boundary_add_two_interior
 #print axioms card_interior_eq
+#print axioms card_endpoint_cells_modEq_card_boundaryDoor
+#print axioms exists_endpoint_cell_of_odd_boundary
 
 end SpernerTuckerDoorIncidenceParity

--- a/research/problems/sperner-mathlib4-oq-02/state.md
+++ b/research/problems/sperner-mathlib4-oq-02/state.md
@@ -4,7 +4,7 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-06-27T16:10:00-07:00
-**Iteration**: 8
+**Iteration**: 9
 
 ## Iteration 8 addition (researcher-1, verified 0-axiom — `lake env lean`, Docker down)
 Added `proofs/Proofs/SpernerTuckerInductiveTower.lean` (0 sorries, 0 axioms;
@@ -109,3 +109,32 @@ The n≥2 abstract pipeline now has parity engines at both the **graph** level
   (`SpernerTuckerBoundaryParity`). The incidence engine consumes this directly.
 - n>=2 Tucker ⟹ Borsuk–Ulam: continuous mesh→0 + compactness (analytic phase;
   dim 1 was discharged by IVT).
+
+## Iteration 9 addition (verified, 0-axiom — researcher-1, `lake env lean`, Docker down)
+
+Extended `SpernerTuckerDoorIncidenceParity.lean` (264 → 324 lines) with the
+**path-endpoint form** of the boundary-door parity bridge — stating the existing
+incidence-level result in the exact degree-1 vocabulary the path-following engine
+(`SpernerTuckerPathFollowing.lean`) consumes. Two theorems, 0-sorry / 0-axiom
+(`#print axioms` = only propext / Classical.choice / Quot.sound; verified via host
+`lean v4.26.0` over the shared main-repo Mathlib `.olean` cache, Docker image build
+down with the containerd `meta.db` I/O error):
+
+- `card_endpoint_cells_modEq_card_boundaryDoor` — in the door-graph regime where
+  every CELL touches ≤ 2 doors (as well as every door ≤ 2 cells), a cell has odd
+  door-count **iff** it touches *exactly one* door (a path endpoint). Hence
+  `#{endpoint cells} ≡ #{boundary doors} (mod 2)`. Collapses the `Odd`-quantified
+  bridge `card_odd_doorCount_modEq_card_boundaryDoor` to the `= 1` (degree-1) form.
+- `exists_endpoint_cell_of_odd_boundary` — an **odd** number of boundary doors forces
+  a cell of **exactly one** door, i.e. a genuine degree-1 path endpoint — the precise
+  seed `SpernerTuckerPathFollowing` follows to a complementary simplex. Refines
+  `exists_odd_doorCount_of_odd_boundary` ("odd door-count") to the engine's input shape.
+
+This closes a small vocabulary gap the file's own docstring flagged: the incidence
+bridge produced an *odd-door-count* cell, but the path-following engine is seeded by a
+*degree-1* vertex; in the door-graph regime (`doorCount ≤ 2`) these coincide, and the
+two new lemmas make that explicit. Independent of the open path-following PR #30911
+(different file) — purely additive at the end of the incidence namespace.
+
+The n≥2 geometric instantiation (concrete `inc` for a B^n triangulation, and supplying
+`Odd #{boundary doors}` from the inductive (n−1)-Tucker statement) remains the open step.


### PR DESCRIPTION
## Path-endpoint form of the boundary-door parity bridge

Extends `SpernerTuckerDoorIncidenceParity.lean` (the abstract door-counting incidence layer for **sperner-mathlib4-oq-02**, "Tucker's Lemma and Borsuk–Ulam from abstract door-counting") with the boundary-door parity bridge restated in the **degree-1 / path-endpoint** vocabulary that the path-following engine consumes.

### The gap this closes
The file's existing bridge produces a cell of **odd door-count**:
```
exists_odd_doorCount_of_odd_boundary : Odd #{boundary doors} → ∃ c, Odd (doorCount inc c)
```
But `SpernerTuckerPathFollowing` seeds path-following from a **degree-1 vertex** — a cell touching *exactly one* door. The file's own docstring names this consumer but states the bridge only up to `Odd`. In the door-graph regime where every cell, like every door, touches at most two of the other kind, "odd door-count" collapses to "exactly one door", so the bridge can be stated directly in the engine's vocabulary.

### Theorems (2, both 0-axiom)
| Theorem | Statement |
|---|---|
| `card_endpoint_cells_modEq_card_boundaryDoor` | `(∀c, doorCount ≤ 2) → (∀d, cellCount ≤ 2) → #{c \| doorCount c = 1} ≡ #{boundary doors} (mod 2)` |
| `exists_endpoint_cell_of_odd_boundary` | same hyps `→ Odd #{boundary doors} → ∃ c, doorCount inc c = 1` |

Both reduce to the existing `card_odd_doorCount_modEq_card_boundaryDoor` / `exists_odd_doorCount_of_odd_boundary` via the regime fact `doorCount c ≤ 2 → (doorCount c = 1 ↔ Odd (doorCount c))`.

### Verification
- `lean v4.26.0` over the shared main-repo Mathlib `.olean` cache (Docker image build down — containerd `meta.db` I/O error, as in prior iterations). Clean compile.
- `#print axioms` on both new theorems: only `propext` / `Classical.choice` / `Quot.sound`. 0 sorries, 0 `axiom` declarations.
- File `264 → 324` lines. Purely additive at the end of the namespace; independent of the open path-following PR #30911 (a different file).

### Honest boundary
This is a vocabulary refinement of an existing abstract bridge, not new geometry. The n≥2 geometric instantiation (a concrete `inc` for a Bⁿ triangulation, and supplying `Odd #{boundary doors}` from the inductive (n−1)-Tucker statement) remains the open step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)