### PR TITLE
research(erdos-1005-oq-04): consecutive vs pairwise similar ordering are provably distinct [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ04.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ04.lean
@@ -1,0 +1,283 @@
+import Mathlib.Tactic
+import Mathlib.Data.Rat.Defs
+import Mathlib.Data.List.Chain
+
+/-
+# Erdős Problem #1005 (OQ-04): Consecutive vs. Pairwise Similar Ordering
+
+## Parent
+
+Erdős #1005 studies the longest run `f(n)` of **consecutive similarly ordered**
+Farey fractions of order `n`. Two fractions `a/b`, `c/d` are *similarly ordered*
+when `(a - c)(b - d) ≥ 0` (numerator and denominator move the same way). In the
+parent formalization (`Erdos1005ProblemProvable.lean`) a run of `k` consecutive
+fractions counts only when **every pair** in the run is similarly ordered
+(`isSimOrdered`): the relation is symmetric and reflexive but, crucially, **not
+transitive**, so the pairwise condition is genuinely stronger than checking only
+adjacent pairs.
+
+This raises the open question (OQ-04):
+
+> Does the answer change if one considers *consecutive* similarly ordered runs
+> (adjacent pairs only) rather than *pairwise* similarly ordered runs? The
+> non-transitivity gap could make these differ significantly.
+
+## This file
+
+We separate the two notions cleanly, using Mathlib's two standard list
+predicates as the exact formal counterparts:
+
+* `List.Chain' R l`    — the **consecutive** (adjacent-pairs-only) condition;
+* `List.Pairwise R l`  — the **pairwise** (all-pairs) condition.
+
+Results, all fully machine-checked (0 sorries, 0 axioms, no `native_decide`):
+
+* `simOrdered_refl`, `simOrdered_symm` — the relation is reflexive and symmetric.
+* `simOrdered_not_transitive` — it is **not** transitive: an explicit triple of
+  order-4 Farey fractions `1/4, 1/2, 2/3` witnesses the failure.
+* `pairwise_imp_consecutive` — pairwise ⟹ consecutive (the trivial direction).
+* `farey4_block_chain'` — the genuine length-5 consecutive block of `F₄`,
+  `1/4, 1/3, 1/2, 2/3, 3/4`, **is** consecutively similarly ordered.
+* `farey4_block_not_pairwise` — yet that same block is **not** pairwise similarly
+  ordered (`1/4` and `2/3` clash).
+* `consecutive_strictly_weaker` — combining the two: there is a list that is
+  consecutively but not pairwise similarly ordered, so the consecutive notion is
+  strictly weaker. Hence the consecutive run length dominates the pairwise one,
+  `f_consec(n) ≥ f(n)`, and can strictly exceed it locally.
+* `farey4_block_consecutive_in_F4` — certification that the five witnesses really
+  are *consecutive* in `F₄` (each adjacent pair is unimodular with denominator
+  sum `> 4`, so no order-4 fraction lies between them). This makes the separation
+  a statement about a real run of the Farey sequence, not cherry-picked
+  non-adjacent fractions.
+
+**Scope.** This resolves the *qualitative* form of OQ-04: the two run notions are
+provably distinct, with `f_consec ≥ f`. Whether the two **asymptotic constants**
+differ (i.e. whether `f_consec(n)/n` and `f(n)/n` have different limits) remains
+open, as does the parent constant itself.
+
+Reference: https://erdosproblems.com/1005
+-/
+
+namespace Erdos1005OQ04
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 1: Farey fractions (mirrors the parent scaffold)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- A Farey fraction of order `n`: a pair `(p, q)` with `0 ≤ p ≤ q`,
+    `1 ≤ q ≤ n`, and `gcd(p, q) = 1`. -/
+structure FareyFraction (n : ℕ) where
+  p : ℕ
+  q : ℕ
+  hq_pos : 1 ≤ q
+  hq_le : q ≤ n
+  hp_le : p ≤ q
+  hcoprime : Nat.Coprime p q
+
+/-- The rational value of a Farey fraction. -/
+def FareyFraction.toRat {n : ℕ} (f : FareyFraction n) : ℚ :=
+  f.p / f.q
+
+/-- Two unimodular neighbours satisfy `bc - ad = 1`. -/
+def IsConsecutiveFarey {n : ℕ} (f g : FareyFraction n) : Prop :=
+  g.p * f.q - f.p * g.q = 1
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 2: The "similarly ordered" relation
+-- ══════════════════════════════════════════════════════════════════
+
+/-- Two Farey fractions `a/b`, `c/d` are **similarly ordered** when
+    `(a - c)(b - d) ≥ 0`: numerator and denominator change in the same
+    direction. This is the relation studied in Erdős #1005, written here in
+    its native product form over `ℤ`. -/
+def SimOrdered {n : ℕ} (f g : FareyFraction n) : Prop :=
+  (0 : ℤ) ≤ ((f.p : ℤ) - g.p) * ((f.q : ℤ) - g.q)
+
+instance {n : ℕ} : DecidableRel (SimOrdered (n := n)) :=
+  fun f g => by unfold SimOrdered; infer_instance
+
+/-- `SimOrdered` is reflexive: `(a-a)(b-b) = 0 ≥ 0`. -/
+lemma simOrdered_refl {n : ℕ} (f : FareyFraction n) : SimOrdered f f := by
+  unfold SimOrdered; simp
+
+/-- `SimOrdered` is symmetric: `(a-c)(b-d) = (c-a)(d-b)`. -/
+lemma simOrdered_symm {n : ℕ} (f g : FareyFraction n) :
+    SimOrdered f g ↔ SimOrdered g f := by
+  unfold SimOrdered
+  constructor <;> intro h <;> nlinarith [h]
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 3: Non-transitivity — the source of the gap
+-- ══════════════════════════════════════════════════════════════════
+
+/-- `1/4` as an order-4 Farey fraction. -/
+def f14 : FareyFraction 4 := ⟨1, 4, by decide, by decide, by decide, by decide⟩
+/-- `1/3` as an order-4 Farey fraction. -/
+def f13 : FareyFraction 4 := ⟨1, 3, by decide, by decide, by decide, by decide⟩
+/-- `1/2` as an order-4 Farey fraction. -/
+def f12 : FareyFraction 4 := ⟨1, 2, by decide, by decide, by decide, by decide⟩
+/-- `2/3` as an order-4 Farey fraction. -/
+def f23 : FareyFraction 4 := ⟨2, 3, by decide, by decide, by decide, by decide⟩
+/-- `3/4` as an order-4 Farey fraction. -/
+def f34 : FareyFraction 4 := ⟨3, 4, by decide, by decide, by decide, by decide⟩
+
+/-- `SimOrdered` is **not transitive**. Witness: `1/4 ~ 1/2` (numerators tie),
+    `1/2 ~ 2/3` (both increase), but `1/4 ̸~ 2/3` — going from `1/4` to `2/3` the
+    numerator rises while the denominator falls, `(1-2)(4-3) = -1 < 0`. This is
+    exactly the obstruction that forces the pairwise condition in the parent and
+    that OQ-04 asks about. -/
+theorem simOrdered_not_transitive :
+    ¬ ∀ f g h : FareyFraction 4, SimOrdered f g → SimOrdered g h → SimOrdered f h := by
+  intro H
+  have hbad : SimOrdered f14 f23 :=
+    H f14 f12 f23 (by decide) (by decide)
+  revert hbad; decide
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 4: Consecutive vs. pairwise as list predicates
+-- ══════════════════════════════════════════════════════════════════
+
+/-- A list of fractions is **consecutively** similarly ordered when every
+    *adjacent* pair is similarly ordered (`List.IsChain`). This is the run notion
+    OQ-04 proposes: it inspects only neighbours `(xᵢ, xᵢ₊₁)`. -/
+def ConsecutivelySimOrdered {n : ℕ} (l : List (FareyFraction n)) : Prop :=
+  l.IsChain SimOrdered
+
+/-- A list of fractions is **pairwise** similarly ordered when *every* pair is
+    similarly ordered (`List.Pairwise`). This is the parent's run notion
+    (`isSimOrdered`): it inspects all pairs `(xᵢ, xⱼ)`, `i < j`. -/
+def PairwiseSimOrdered {n : ℕ} (l : List (FareyFraction n)) : Prop :=
+  l.Pairwise SimOrdered
+
+/-- **Trivial direction.** Every pairwise similarly ordered run is, in
+    particular, consecutively similarly ordered. So `f(n) ≤ f_consec(n)`. -/
+theorem pairwise_imp_consecutive {n : ℕ} (l : List (FareyFraction n)) :
+    PairwiseSimOrdered l → ConsecutivelySimOrdered l :=
+  List.Pairwise.isChain
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 5: The separating witness — a real length-5 block of F₄
+-- ══════════════════════════════════════════════════════════════════
+
+/-- The consecutive block `1/4, 1/3, 1/2, 2/3, 3/4` of the Farey sequence `F₄`
+    (in increasing order). -/
+def farey4Block : List (FareyFraction 4) := [f14, f13, f12, f23, f34]
+
+/-- Every **adjacent** pair of `farey4Block` is similarly ordered: the block is
+    consecutively similarly ordered. (Along the block the numerators go
+    `1,1,1,2,3` and denominators `4,3,2,3,4`; each step moves both coordinates the
+    same way or holds one fixed.) -/
+theorem farey4_block_chain' : ConsecutivelySimOrdered farey4Block := by
+  unfold ConsecutivelySimOrdered farey4Block
+  rw [List.isChain_cons_cons, List.isChain_cons_cons, List.isChain_cons_cons,
+      List.isChain_cons_cons]
+  exact ⟨by decide, by decide, by decide, by decide, List.isChain_singleton _⟩
+
+/-- The same block is **not** pairwise similarly ordered: the non-adjacent pair
+    `1/4` (head) and `2/3` clashes, `(1-2)(4-3) = -1 < 0`. -/
+theorem farey4_block_not_pairwise : ¬ PairwiseSimOrdered farey4Block := by
+  unfold PairwiseSimOrdered farey4Block
+  rw [List.pairwise_cons]
+  rintro ⟨hhead, -⟩
+  have hbad : SimOrdered f14 f23 := hhead f23 (by simp)
+  revert hbad; decide
+
+/-- **Main separation.** There is a list of Farey fractions that is
+    consecutively but *not* pairwise similarly ordered. Together with
+    `pairwise_imp_consecutive`, the consecutive notion is therefore **strictly
+    weaker** than the pairwise notion: the implication of §4 has no converse.
+
+    Consequence for the run-length functions: the longest consecutive run
+    dominates the longest pairwise run, `f_consec(n) ≥ f(n)`, and the inequality
+    is strict at the level of individual runs — the length-5 block above is a
+    single consecutive run that no pairwise run can contain. -/
+theorem consecutive_strictly_weaker :
+    (∃ l : List (FareyFraction 4),
+        ConsecutivelySimOrdered l ∧ ¬ PairwiseSimOrdered l) ∧
+    (∀ l : List (FareyFraction 4), PairwiseSimOrdered l → ConsecutivelySimOrdered l) :=
+  ⟨⟨farey4Block, farey4_block_chain', farey4_block_not_pairwise⟩,
+   pairwise_imp_consecutive⟩
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 6: The witnesses really are consecutive in F₄
+-- ══════════════════════════════════════════════════════════════════
+--
+-- To make §5 a statement about a genuine run of the Farey sequence (and not
+-- merely about an arbitrary list), we certify that `1/4, 1/3, 1/2, 2/3, 3/4`
+-- are pairwise *adjacent* in `F₄`: each consecutive pair is unimodular and its
+-- denominators sum past `4`, so no order-4 fraction lies strictly between them.
+-- The adjacency engine below mirrors the sibling file `Erdos1005ProblemOQ03`.
+
+/-- Strict order of two Farey fractions is cross-multiplication. -/
+theorem toRat_lt_iff {n : ℕ} (f g : FareyFraction n) :
+    f.toRat < g.toRat ↔ f.p * g.q < g.p * f.q := by
+  unfold FareyFraction.toRat
+  have hf : (0 : ℚ) < f.q := Nat.cast_pos.mpr f.hq_pos
+  have hg : (0 : ℚ) < g.q := Nat.cast_pos.mpr g.hq_pos
+  rw [div_lt_div_iff₀ hf hg]
+  constructor <;> intro h <;> exact_mod_cast h
+
+/-- **Key lemma** (denominator-sum bound). If `a/b < p/q < c/d` and the outer
+    pair is unimodular (`bc - ad = 1`), then `q ≥ b + d`. -/
+theorem intermediate_denom_ge {n : ℕ} (f g h : FareyFraction n)
+    (huni : IsConsecutiveFarey f g)
+    (h1 : f.toRat < h.toRat) (h2 : h.toRat < g.toRat) :
+    f.q + g.q ≤ h.q := by
+  have hcb : g.p * f.q = f.p * g.q + 1 := by
+    have := huni; unfold IsConsecutiveFarey at this; omega
+  have hfh : f.p * h.q < h.p * f.q := (toRat_lt_iff f h).mp h1
+  have hhg : h.p * g.q < g.p * h.q := (toRat_lt_iff h g).mp h2
+  have hcbZ : (g.p : ℤ) * f.q = (f.p : ℤ) * g.q + 1 := by exact_mod_cast hcb
+  have h1Z : (f.p : ℤ) * h.q + 1 ≤ (h.p : ℤ) * f.q := by exact_mod_cast hfh
+  have h2Z : (h.p : ℤ) * g.q + 1 ≤ (g.p : ℤ) * h.q := by exact_mod_cast hhg
+  have key : (h.q : ℤ)
+      = (g.q : ℤ) * ((h.p : ℤ) * f.q - (f.p : ℤ) * h.q)
+        + (f.q : ℤ) * ((g.p : ℤ) * h.q - (h.p : ℤ) * g.q) := by
+    linear_combination (-(h.q : ℤ)) * hcbZ
+  have t1 : (1 : ℤ) ≤ (h.p : ℤ) * f.q - (f.p : ℤ) * h.q := by linarith
+  have t2 : (1 : ℤ) ≤ (g.p : ℤ) * h.q - (h.p : ℤ) * g.q := by linarith
+  have bound : (f.q : ℤ) + g.q ≤ h.q := by
+    nlinarith [mul_le_mul_of_nonneg_left t1 (by linarith : (0:ℤ) ≤ (g.q : ℤ)),
+               mul_le_mul_of_nonneg_left t2 (by linarith : (0:ℤ) ≤ (f.q : ℤ)), key]
+  exact_mod_cast bound
+
+/-- **Adjacency (sufficiency).** A unimodular pair with `b + d > n` is adjacent
+    in `F_n`: no Farey fraction of order `n` lies strictly between them. -/
+theorem farey_adjacent_of_denom_sum_gt {n : ℕ} (f g : FareyFraction n)
+    (huni : IsConsecutiveFarey f g) (hsum : n < f.q + g.q) :
+    ∀ h : FareyFraction n, ¬ (f.toRat < h.toRat ∧ h.toRat < g.toRat) := by
+  rintro h ⟨h1, h2⟩
+  have hge : f.q + g.q ≤ h.q := intermediate_denom_ge f g h huni h1 h2
+  exact absurd (le_trans hge h.hq_le) (by omega)
+
+/-- Each consecutive pair of `farey4Block` is unimodular (`bc - ad = 1`). -/
+theorem farey4_block_unimodular :
+    IsConsecutiveFarey f14 f13 ∧ IsConsecutiveFarey f13 f12 ∧
+    IsConsecutiveFarey f12 f23 ∧ IsConsecutiveFarey f23 f34 := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> (unfold IsConsecutiveFarey; decide)
+
+/-- Each consecutive pair of `farey4Block` is strictly increasing in value. -/
+theorem farey4_block_increasing :
+    f14.toRat < f13.toRat ∧ f13.toRat < f12.toRat ∧
+    f12.toRat < f23.toRat ∧ f23.toRat < f34.toRat := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;>
+    · rw [toRat_lt_iff]; decide
+
+/-- **Certification.** The five fractions `1/4, 1/3, 1/2, 2/3, 3/4` are genuinely
+    *consecutive* in `F₄`: every adjacent pair is strictly increasing and
+    adjacent (no order-4 fraction lies strictly between). So `farey4Block` is a
+    real contiguous block of the Farey sequence — the separation of §5 concerns
+    an honest consecutive run, not an arbitrary list. -/
+theorem farey4_block_consecutive_in_F4 :
+    (∀ h : FareyFraction 4, ¬ (f14.toRat < h.toRat ∧ h.toRat < f13.toRat)) ∧
+    (∀ h : FareyFraction 4, ¬ (f13.toRat < h.toRat ∧ h.toRat < f12.toRat)) ∧
+    (∀ h : FareyFraction 4, ¬ (f12.toRat < h.toRat ∧ h.toRat < f23.toRat)) ∧
+    (∀ h : FareyFraction 4, ¬ (f23.toRat < h.toRat ∧ h.toRat < f34.toRat)) := by
+  obtain ⟨u1, u2, u3, u4⟩ := farey4_block_unimodular
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · exact farey_adjacent_of_denom_sum_gt f14 f13 u1 (by decide)
+  · exact farey_adjacent_of_denom_sum_gt f13 f12 u2 (by decide)
+  · exact farey_adjacent_of_denom_sum_gt f12 f23 u3 (by decide)
+  · exact farey_adjacent_of_denom_sum_gt f23 f34 u4 (by decide)
+
+end Erdos1005OQ04

--- a/proofs/Proofs/Erdos1042OQ02.lean
+++ b/proofs/Proofs/Erdos1042OQ02.lean
@@ -1,0 +1,185 @@
+/-
+Erdős Problem #1042 — open question oq-02:
+"Can the result be extended to higher dimensions?"
+
+The parent entry (#1042, resolved by Ghosh–Ramachandran 2024) studies polynomial
+lemniscates {z : |f(z)| < 1} of one complex variable and records the
+component-count answers as axioms. The sibling companion oq-03
+(`Erdos1042OQ03.lean`) PROVES the elementary mechanism underneath every
+component-count bound in ONE variable: the lemniscate is CONFINED to the union
+of the open unit balls about the roots of `f`, hence is bounded, and each
+bounded connected component must trap a root — the source of the classical
+"at most n components" bound.
+
+This companion addresses oq-02 by isolating *what survives* and *what fails*
+when one passes from ℂ = ℂ¹ to ℂⁿ. We work with the natural multivariate
+analogue of a monic factored polynomial: a finite product
+
+    f(z) = ∏ⱼ (z (coordⱼ) − rootⱼ),    z ∈ ℂⁿ,
+
+each factor reading off one coordinate and subtracting a root. When n = 1 this
+is exactly the one-variable monic polynomial of oq-03 (`eval_one_dim`).
+
+SURVIVES into higher dimensions (proved generally for ℂⁿ):
+  • `continuous_eval` — the polynomial map is continuous;
+  • `isOpen_lem`     — the lemniscate is open;
+  • `mem_lem_of_eval_zero` — the zero locus of `f` lies inside the lemniscate.
+
+FAILS in higher dimensions — the new phenomenon answering oq-02:
+  • `cyl_unbounded` — in ℂ² the lemniscate of f(z₀,z₁) = z₀ is **unbounded**.
+    The free second coordinate turns each would-be isolated "island" into an
+    infinite tube, so the oq-03 confinement/boundedness (`isBounded_lem`) and
+    the resulting finite-component bound have NO direct ℂⁿ analogue.
+  • `isConnected_cyl` — that same lemniscate is moreover **connected**: the n
+    separate components of the one-variable picture can merge into a single
+    unbounded set.
+
+So the answer to oq-02 is, in this precise sense, NEGATIVE for the confinement
+mechanism: openness and the root-containment generalise verbatim, but the
+geometric features (boundedness, component counting) that drive the #1042 story
+are special to one complex variable.
+
+All results below are axiom-free and self-contained; the structures are
+re-declared locally so that nothing depends on the parent's axioms
+(`transfiniteDiameter`, `ghosh_ramachandran_*`).
+-/
+
+import Mathlib
+
+open BigOperators Metric
+
+namespace Erdos1042OQ02
+
+variable {n : ℕ}
+
+/-- A multivariate "coordinate-factored" polynomial on `ℂⁿ`: a finite product of
+affine factors, each factor reading off one coordinate (`coord j`) and
+subtracting a root (`root j`):  `f(z) = ∏ⱼ (z (coord j) - root j)`.
+When `n = 1` this is the one-variable monic polynomial of oq-03. -/
+structure CoordPoly (n : ℕ) where
+  degree : ℕ
+  coord : Fin degree → Fin n
+  root : Fin degree → ℂ
+
+/-- Evaluation of the coordinate-factored polynomial at a point `z ∈ ℂⁿ`. -/
+noncomputable def CoordPoly.eval (p : CoordPoly n) (z : Fin n → ℂ) : ℂ :=
+  ∏ j : Fin p.degree, (z (p.coord j) - p.root j)
+
+/-- The lemniscate of `p`, the open sublevel set `{z ∈ ℂⁿ : |f(z)| < 1}`. -/
+def lem (p : CoordPoly n) : Set (Fin n → ℂ) :=
+  {z | ‖p.eval z‖ < 1}
+
+/-- **Reduction to one variable.** For a coordinate-factored polynomial on `ℂ¹`,
+every factor reads off the unique coordinate `0`, so `eval` is exactly the
+one-variable monic product `∏ⱼ (z 0 - rootⱼ)` of Erdős #1042 oq-03. The
+multivariate framework therefore genuinely generalises the one-variable one. -/
+theorem eval_one_dim (p : CoordPoly 1) (z : Fin 1 → ℂ) :
+    p.eval z = ∏ j : Fin p.degree, (z 0 - p.root j) := by
+  unfold CoordPoly.eval
+  refine Finset.prod_congr rfl (fun j _ => ?_)
+  rw [Subsingleton.elim (p.coord j) (0 : Fin 1)]
+
+/-- The polynomial map `z ↦ f(z)` is continuous (a finite product of the
+continuous coordinate-evaluation maps `z ↦ z (coord j) - root j`). Survives to ℂⁿ. -/
+theorem continuous_eval (p : CoordPoly n) : Continuous p.eval := by
+  unfold CoordPoly.eval
+  exact continuous_finset_prod _ fun j _ => (continuous_apply (p.coord j)).sub continuous_const
+
+/-- The lemniscate is open: the preimage of `(-∞, 1)` under the continuous map
+`z ↦ |f(z)|`. Survives to ℂⁿ. -/
+theorem isOpen_lem (p : CoordPoly n) : IsOpen (lem p) := by
+  have h : Continuous fun z => ‖p.eval z‖ := (continuous_eval p).norm
+  show IsOpen ((fun z => ‖p.eval z‖) ⁻¹' Set.Iio 1)
+  exact h.isOpen_preimage (Set.Iio 1) isOpen_Iio
+
+/-- The zero locus of `f` lies in the lemniscate: if some factor vanishes at `z`
+(`z (coord j) = root j`) then `f(z) = 0` and `|0| = 0 < 1`. Survives to ℂⁿ.
+(In one variable the zero locus is the finite set of roots; in ℂⁿ it is a union
+of hyperplanes — already a hint that the higher-dimensional geometry differs.) -/
+theorem mem_lem_of_eval_zero (p : CoordPoly n) {z : Fin n → ℂ}
+    (h : ∃ j : Fin p.degree, z (p.coord j) = p.root j) : z ∈ lem p := by
+  obtain ⟨j, hj⟩ := h
+  have h0 : p.eval z = 0 := by
+    unfold CoordPoly.eval
+    exact Finset.prod_eq_zero (Finset.mem_univ j) (sub_eq_zero.mpr hj)
+  show ‖p.eval z‖ < 1
+  rw [h0]; simp
+
+/-! ### The higher-dimensional phenomenon (ℂ²)
+
+We exhibit, in two variables, a lemniscate that is open and connected but
+*unbounded* — the qualitative failure of the oq-03 confinement result. -/
+
+/-- The two-variable example `f(z₀, z₁) = z₀`: a single factor in the first
+coordinate only. Its lemniscate `{z : |z₀| < 1}` is an infinite "cylinder". -/
+def cylExample : CoordPoly 2 where
+  degree := 1
+  coord := fun _ => 0
+  root := fun _ => 0
+
+/-- `cylExample` evaluates to the first coordinate: `f(z) = z₀`. -/
+theorem cyl_eval (z : Fin 2 → ℂ) : cylExample.eval z = z 0 := by
+  simp [CoordPoly.eval, cylExample]
+
+/-- The lemniscate of `cylExample` is exactly the cylinder `{z : |z₀| < 1}`. -/
+theorem lem_cyl_eq : lem cylExample = {z : Fin 2 → ℂ | ‖z 0‖ < 1} := by
+  ext z
+  simp only [lem, Set.mem_setOf_eq, cyl_eval]
+
+/-- **Nonemptiness:** the cylinder contains the origin. -/
+theorem cyl_nonempty : (lem cylExample).Nonempty := by
+  refine ⟨0, ?_⟩
+  rw [lem_cyl_eq]
+  simp only [Set.mem_setOf_eq, Pi.zero_apply, norm_zero]
+  norm_num
+
+/-- **The new phenomenon (boundedness fails).** In ℂ² the lemniscate of
+`f(z₀,z₁) = z₀` is UNBOUNDED: the second coordinate is free, so the points
+`(0, t)` lie in the lemniscate for every `t ∈ ℝ` yet have norm `≥ |t| → ∞`.
+Contrast oq-03's `isBounded_lem`, which holds for *every* one-variable
+lemniscate. This is the core obstruction to extending #1042 to higher
+dimensions: there is no confinement to balls about the roots. -/
+theorem cyl_unbounded : ¬ Bornology.IsBounded (lem cylExample) := by
+  rw [isBounded_iff_forall_norm_le]
+  push_neg
+  intro C
+  refine ⟨![0, ((|C| + 1 : ℝ) : ℂ)], ?_, ?_⟩
+  · rw [lem_cyl_eq, Set.mem_setOf_eq, Matrix.cons_val_zero, norm_zero]
+    norm_num
+  · have hle : ‖(![0, ((|C| + 1 : ℝ) : ℂ)] : Fin 2 → ℂ) 1‖
+        ≤ ‖(![0, ((|C| + 1 : ℝ) : ℂ)] : Fin 2 → ℂ)‖ := norm_le_pi_norm _ 1
+    have hval : (![0, ((|C| + 1 : ℝ) : ℂ)] : Fin 2 → ℂ) 1 = ((|C| + 1 : ℝ) : ℂ) := by
+      simp [Matrix.cons_val_one]
+    rw [hval, Complex.norm_of_nonneg (by positivity : (0:ℝ) ≤ |C| + 1)] at hle
+    have hC : C < |C| + 1 := by have := le_abs_self C; linarith
+    linarith
+
+/-- The cylinder is convex (the preimage of the open unit ball in ℂ under the
+ℝ-linear first-coordinate projection). -/
+theorem convex_cyl : Convex ℝ (lem cylExample) := by
+  have h : lem cylExample
+      = (LinearMap.proj (0 : Fin 2) : (Fin 2 → ℂ) →ₗ[ℝ] ℂ) ⁻¹' Metric.ball (0 : ℂ) 1 := by
+    rw [lem_cyl_eq]
+    ext z
+    simp only [Set.mem_setOf_eq, Set.mem_preimage, mem_ball_zero_iff, LinearMap.proj_apply]
+  rw [h]
+  exact (convex_ball (0 : ℂ) 1).linear_preimage _
+
+/-- **Components merge.** The same ℂ² lemniscate is CONNECTED. Where the
+one-variable `zⁿ + 1` has `n` disjoint island components, the free coordinate
+fuses them into a single connected (indeed convex) unbounded set, so the
+component-counting question of #1042 has no naive higher-dimensional analogue. -/
+theorem isConnected_cyl : IsConnected (lem cylExample) :=
+  convex_cyl.isConnected cyl_nonempty
+
+/-- **Capstone (answer to oq-02).** Openness and root-containment extend verbatim
+to ℂⁿ, but the geometric heart of #1042 does not: in ℂ² the lemniscate of
+`f(z₀,z₁) = z₀` is open and connected yet UNBOUNDED, in direct contrast to the
+one-variable confinement/boundedness theorem of oq-03. Hence the #1042
+component-count results are genuinely a one-complex-variable phenomenon. -/
+theorem higher_dim_confinement_fails :
+    IsOpen (lem cylExample) ∧ IsConnected (lem cylExample) ∧
+      ¬ Bornology.IsBounded (lem cylExample) :=
+  ⟨isOpen_lem cylExample, isConnected_cyl, cyl_unbounded⟩
+
+end Erdos1042OQ02

--- a/src/data/proofs/erdos-1005-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1005-oq-04/annotations.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "ann-erdos1005oq04-header",
+    "proofId": "erdos-1005-oq-04",
+    "range": { "startLine": 5, "endLine": 59 },
+    "type": "context",
+    "title": "Does adjacent-only counting differ from all-pairs counting?",
+    "content": "The header frames OQ-04 of Erdős #1005. The parent counts a run of similarly ordered Farey fractions only when EVERY pair in the run satisfies (a_k − a_l)(b_k − b_l) ≥ 0 — a pairwise condition. The natural lighter alternative checks only neighbouring pairs. The header's key claim is that these genuinely differ because the similarly-ordered relation, though reflexive and symmetric, is not transitive. It previews the clean formal counterparts — List.IsChain for consecutive, List.Pairwise for pairwise — the explicit F_4 witness, and the honest scope: the separation proved here is exact and local, while whether the two asymptotic constants differ stays open.",
+    "mathContext": "Farey sequence $F_n$: reduced $a/b \\in [0,1]$ with $b \\le n$, increasing. Similarly ordered: $(a_k - a_l)(b_k - b_l) \\ge 0$. Pairwise run condition vs. adjacent-only run condition.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Farey sequence",
+      "similar ordering",
+      "non-transitivity",
+      "runs and chains"
+    ],
+    "prerequisites": [
+      "rational numbers",
+      "order relations"
+    ]
+  },
+  {
+    "id": "ann-erdos1005oq04-scaffold",
+    "proofId": "erdos-1005-oq-04",
+    "range": { "startLine": 64, "endLine": 84 },
+    "type": "definition",
+    "title": "Farey fraction scaffold",
+    "content": "The FareyFraction n structure packages a reduced fraction p/q with 0 ≤ p ≤ q, 1 ≤ q ≤ n and gcd(p,q)=1, together with its rational value toRat = p/q and the unimodular adjacency predicate IsConsecutiveFarey (g.p·f.q − f.p·g.q = 1). This mirrors the parent and the sibling OQ-03 exactly, so the witnesses below are bona fide order-n Farey fractions and the adjacency engine of §6 applies verbatim.",
+    "mathContext": "A Farey fraction of order $n$ is a reduced $p/q$ with $1 \\le q \\le n$; adjacent neighbours satisfy the unimodular relation $g_p f_q - f_p g_q = 1$.",
+    "significance": "Provides the concrete carrier on which both run notions and the adjacency certification are stated.",
+    "relatedConcepts": [
+      "Farey fractions",
+      "unimodular relation",
+      "coprimality"
+    ],
+    "prerequisites": [
+      "number theory",
+      "structures in Lean"
+    ]
+  },
+  {
+    "id": "ann-erdos1005oq04-relation",
+    "proofId": "erdos-1005-oq-04",
+    "range": { "startLine": 86, "endLine": 108 },
+    "type": "definition",
+    "title": "The similarly-ordered relation: reflexive, symmetric",
+    "content": "SimOrdered f g is defined in its native product form 0 ≤ (f.p − g.p)(f.q − g.q) over ℤ, with a DecidableRel instance so concrete instances reduce by decide. simOrdered_refl ((a−a)(b−b)=0) and simOrdered_symm ((a−c)(b−d)=(c−a)(d−b)) record the two properties the relation does have. The conspicuous omission — transitivity — is the subject of §3 and the whole engine of the separation.",
+    "mathContext": "$\\mathrm{SimOrdered}(f,g) \\iff 0 \\le (f_p - g_p)(f_q - g_q)$, i.e. the two coordinates move in the same direction (comparability in the product order on $\\mathbb{Z}^2$).",
+    "significance": "Fixes the relation and isolates exactly which algebraic properties hold, setting up the failure of transitivity as the crux.",
+    "relatedConcepts": [
+      "product order",
+      "comparability",
+      "reflexivity",
+      "symmetry"
+    ],
+    "prerequisites": [
+      "integer arithmetic",
+      "decidability"
+    ]
+  },
+  {
+    "id": "ann-erdos1005oq04-nontransitive",
+    "proofId": "erdos-1005-oq-04",
+    "range": { "startLine": 110, "endLine": 135 },
+    "type": "insight",
+    "title": "Non-transitivity is the whole content of OQ-04",
+    "content": "simOrdered_not_transitive exhibits the failure directly with three order-4 fractions: 1/4 ~ 1/2 (numerators tie, so the product is 0 ≥ 0), 1/2 ~ 2/3 (both numerator and denominator rise), yet 1/4 ̸~ 2/3 because the numerator rises while the denominator falls, (1−2)(4−3) = −1 < 0. This is precisely why requiring all pairs of a run to be similarly ordered (pairwise) is strictly stronger than requiring only neighbours (consecutive): a chain of locally-monotone steps can bend back on itself globally.",
+    "mathContext": "Comparability in a partial order is generally not transitive; here $1/4 \\le_{\\mathrm{prod}} 1/2$ and $1/2 \\le_{\\mathrm{prod}} 2/3$ fail to give $1/4, 2/3$ comparable since $(1-2)(4-3) = -1 < 0$.",
+    "significance": "The single fact that makes the consecutive and pairwise run notions diverge — every later result is a consequence of this non-transitivity.",
+    "relatedConcepts": [
+      "non-transitivity",
+      "partial order comparability",
+      "Erdős–Szekeres",
+      "monotone chains"
+    ],
+    "prerequisites": [
+      "order theory"
+    ]
+  },
+  {
+    "id": "ann-erdos1005oq04-two-notions",
+    "proofId": "erdos-1005-oq-04",
+    "range": { "startLine": 137, "endLine": 156 },
+    "type": "definition",
+    "title": "Consecutive = IsChain, pairwise = Pairwise",
+    "content": "The two run notions are identified with Mathlib's standard list predicates: ConsecutivelySimOrdered l := l.IsChain SimOrdered inspects only adjacent pairs (xᵢ, xᵢ₊₁), while PairwiseSimOrdered l := l.Pairwise SimOrdered inspects all pairs (xᵢ, xⱼ), i < j. This makes the easy direction a one-liner — pairwise_imp_consecutive is exactly List.Pairwise.isChain — and reduces the whole problem to producing a witness where the converse fails.",
+    "mathContext": "$\\mathrm{IsChain}\\,R\\,l$: $R$ holds on consecutive elements. $\\mathrm{Pairwise}\\,R\\,l$: $R$ holds on every pair $i<j$. Always $\\mathrm{Pairwise} \\Rightarrow \\mathrm{IsChain}$.",
+    "significance": "Casts the parent's run condition and OQ-04's alternative as two off-the-shelf predicates, so the separation is a clean statement and the trivial implication comes for free.",
+    "relatedConcepts": [
+      "List.IsChain",
+      "List.Pairwise",
+      "chains vs antichains"
+    ],
+    "prerequisites": [
+      "lists in Lean",
+      "Mathlib list predicates"
+    ]
+  },
+  {
+    "id": "ann-erdos1005oq04-witness",
+    "proofId": "erdos-1005-oq-04",
+    "range": { "startLine": 159, "endLine": 200 },
+    "type": "insight",
+    "title": "A real length-5 F₄ block that is consecutive but not pairwise",
+    "content": "The block farey4Block = [1/4, 1/3, 1/2, 2/3, 3/4] is the separating witness. farey4_block_chain' verifies it is consecutively similarly ordered — numerators 1,1,1,2,3 and denominators 4,3,2,3,4 keep every adjacent step monotone in both coordinates (or tied). farey4_block_not_pairwise shows it is not pairwise: the non-adjacent endpoints 1/4 and 2/3 reverse direction, (1−2)(4−3) = −1 < 0. consecutive_strictly_weaker packages this with the trivial direction into the headline — consecutive is strictly weaker than pairwise, so f_consec(n) ≥ f(n) with the gap already nonzero on a single length-5 run.",
+    "mathContext": "Along $1/4, 1/3, 1/2, 2/3, 3/4$ each neighbour pair is comparable in the product order, but the endpoints $1/4 = (1,4)$ and $2/3 = (2,3)$ are not — a length-5 IsChain that is not Pairwise.",
+    "significance": "The concrete heart of the result: a genuine Farey run on which the two notions provably disagree, pinning the direction and reality of the separation.",
+    "relatedConcepts": [
+      "explicit witness",
+      "monotone run",
+      "mediant insertion"
+    ],
+    "prerequisites": [
+      "Farey fractions",
+      "decidable evaluation"
+    ]
+  },
+  {
+    "id": "ann-erdos1005oq04-adjacency",
+    "proofId": "erdos-1005-oq-04",
+    "range": { "startLine": 202, "endLine": 282 },
+    "type": "proof",
+    "title": "Certifying the witnesses are truly consecutive in F₄",
+    "content": "To ensure the separation concerns an honest contiguous block of the Farey sequence rather than an arbitrary list, §6 certifies adjacency. The reused engine — toRat_lt_iff (order is cross-multiplication), intermediate_denom_ge (any fraction strictly between a unimodular pair has denominator ≥ b + d), farey_adjacent_of_denom_sum_gt (b + d > n forces adjacency) — combines with farey4_block_unimodular and farey4_block_increasing in farey4_block_consecutive_in_F4: for each adjacent pair of the block the denominators sum past 4, so no order-4 fraction lies strictly between them. The block is therefore exactly five consecutive entries of F_4.",
+    "mathContext": "Denominator-sum criterion: for a unimodular pair $a/b < c/d$ ($bc - ad = 1$), any in-between fraction has denominator $\\ge b + d$; hence $b + d > n$ means the pair is adjacent in $F_n$. Here every adjacent pair has $b + d \\ge 5 > 4$.",
+    "significance": "Upgrades the witness from 'some list of Farey fractions' to 'a genuine consecutive run of F_4', making the answer to OQ-04 a statement about the Farey sequence itself.",
+    "relatedConcepts": [
+      "Farey adjacency",
+      "Stern–Brocot tree",
+      "unimodular relation",
+      "denominator-sum criterion"
+    ],
+    "prerequisites": [
+      "integer arithmetic",
+      "Farey adjacency criterion"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1005-oq-04/meta.json
+++ b/src/data/proofs/erdos-1005-oq-04/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "erdos-1005-oq-04",
+  "slug": "erdos-1005-oq-04",
+  "sorries": 0,
+  "title": "Consecutive vs. Pairwise Similar Ordering: The Two Run Notions Are Provably Distinct",
+  "description": "A self-contained, axiom-free separation answering OQ-04 of Erdős #1005: does counting runs of 'similarly ordered' Farey fractions by adjacent pairs only (consecutive) differ from counting by all pairs (pairwise)? The parent counts a run only when EVERY pair a_k/b_k, a_l/b_l in it is similarly ordered, (a_k − a_l)(b_k − b_l) ≥ 0; the natural lighter alternative checks only neighbours. Because the similarly-ordered relation is symmetric and reflexive but NOT transitive, the two notions genuinely differ. We formalize them as Mathlib's List.IsChain (adjacent pairs) versus List.Pairwise (all pairs), prove the easy implication pairwise ⟹ consecutive, and exhibit an explicit witness that the converse fails: the genuine length-5 consecutive block 1/4, 1/3, 1/2, 2/3, 3/4 of the Farey sequence F_4 is consecutively similarly ordered yet not pairwise (1/4 and 2/3 clash, (1−2)(4−3) = −1 < 0). The five fractions are certified to be truly consecutive in F_4 (each adjacent pair is unimodular with denominator sum > 4, so no order-4 fraction lies between them), making the separation a statement about a real Farey run. Conclusion: the consecutive run length dominates the pairwise one, f_consec(n) ≥ f(n), and strictly exceeds it locally. Whether the two ASYMPTOTIC constants differ remains open.",
+  "leanFile": {
+    "lineCount": 283,
+    "axiomCount": 0,
+    "path": "Proofs/Erdos1005ProblemOQ04.lean",
+    "sorries": 0,
+    "definitionCount": 11,
+    "theoremCount": 13
+  },
+  "meta": {
+    "author": "Formalization original to Lean Genius (classical Farey theory; non-transitivity of similar ordering)",
+    "date": "1942",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1005ProblemOQ04.lean",
+    "tags": [
+      "number-theory",
+      "farey-fractions",
+      "combinatorics-on-words",
+      "order-theory",
+      "non-transitivity",
+      "list-chain"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-27",
+    "lineCount": 283,
+    "originalContributions": [
+      "consecutive_strictly_weaker: the headline — there is a list of order-4 Farey fractions that is consecutively (List.IsChain) but not pairwise (List.Pairwise) similarly ordered, while pairwise always implies consecutive. So the consecutive run notion proposed by OQ-04 is strictly weaker than the parent's pairwise notion; the two run-length functions satisfy f_consec(n) ≥ f(n) and differ at the level of individual runs",
+      "simOrdered_not_transitive: the root cause, made explicit — the similarly-ordered relation (a−c)(b−d) ≥ 0 is NOT transitive, witnessed by 1/4 ~ 1/2 (numerators tie), 1/2 ~ 2/3 (both rise), yet 1/4 ̸~ 2/3 (numerator rises while denominator falls). This single non-transitivity is exactly what makes consecutive and pairwise diverge",
+      "farey4_block_chain' / farey4_block_not_pairwise: the explicit separating witness — the block 1/4, 1/3, 1/2, 2/3, 3/4 of F_4 is consecutively similarly ordered (every adjacent step moves both coordinates the same way or holds one fixed) but fails pairwise on the non-adjacent endpoints 1/4 and 2/3",
+      "farey4_block_consecutive_in_F4: certification that the five witnesses are genuinely consecutive in F_4 — each adjacent pair is unimodular (bc − ad = 1) with denominator sum > 4, so by the denominator-sum criterion no order-4 fraction lies strictly between them. This makes the separation concern an honest contiguous block of the Farey sequence rather than an arbitrary list",
+      "pairwise_imp_consecutive: the trivial direction packaged as the inequality f(n) ≤ f_consec(n) (List.Pairwise.isChain), establishing that consecutive is a relaxation of pairwise and fixing the direction of the strictness",
+      "intermediate_denom_ge / farey_adjacent_of_denom_sum_gt: the reused adjacency engine (mirrored from the sibling OQ-03) — any fraction strictly between a unimodular pair has denominator ≥ b + d, so a unimodular pair with b + d > n is adjacent in F_n; this is what certifies the witnesses are consecutive"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound. No native_decide is used (so no Lean.ofReduceBool); the only `decide` calls are on concrete decidable integer/coprimality facts about fixed small fractions.",
+    "theoremCount": 13,
+    "definitionCount": 11
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1005 asks for the longest run f(n) of consecutive 'similarly ordered' Farey fractions of order n, where a_k/b_k and a_l/b_l are similarly ordered when (a_k − a_l)(b_k − b_l) ≥ 0. Mayer (1942) first observed that consecutive Farey fractions tend to be similarly ordered and proved f(n) → ∞; Erdős (1943) strengthened this to linear growth, and van Doorn (2025) established (1/12 − o(1))n ≤ f(n) ≤ n/4 + O(1). A recurring subtlety in the definition is that 'a run of length k is similarly ordered' is read as a PAIRWISE condition over all pairs in the run — because the relation, while symmetric and reflexive, is not transitive, so requiring only adjacent pairs would be a different and weaker condition. OQ-04 asks exactly whether this distinction matters.",
+    "problemStatement": "Does the answer change if one considers consecutive (adjacent-pairs-only) similarly ordered runs rather than pairwise (all-pairs) similarly ordered runs? Formally: is the run notion based on List.IsChain similarlyOrdered strictly weaker than the parent notion based on List.Pairwise similarlyOrdered, and does this distinction reflect a real phenomenon in the Farey sequence?",
+    "proofStrategy": "The entire separation is driven by non-transitivity. First the similarly-ordered relation (a−c)(b−d) ≥ 0 is shown reflexive and symmetric but not transitive, with the explicit triple 1/4, 1/2, 2/3 from F_4. The two run notions are then identified with Mathlib's standard list predicates — List.IsChain R (adjacent pairs) for the consecutive notion and List.Pairwise R (all pairs) for the pairwise notion — so that pairwise ⟹ consecutive is exactly List.Pairwise.isChain. To show the converse fails on a real Farey run, the contiguous block 1/4, 1/3, 1/2, 2/3, 3/4 of F_4 is exhibited: it is List.IsChain (each adjacent pair verified by decide on the product (a−c)(b−d)) but not List.Pairwise (the endpoints 1/4 and 2/3 give product −1). Finally the block is certified consecutive in F_4 by the denominator-sum adjacency criterion (each adjacent pair is unimodular with b + d > 4), reusing the integer-arithmetic engine intermediate_denom_ge. No Farey sequence is enumerated; the witnesses are explicit order-4 fractions.",
+    "keyInsights": [
+      "Non-transitivity is not a technicality but the whole content of OQ-04: the moment (a−c)(b−d) ≥ 0 fails to be transitive, requiring all pairs of a run to be similarly ordered (pairwise) becomes strictly stronger than requiring only neighbours (consecutive), so the two run-length functions need not agree.",
+      "The two run notions have exact Mathlib counterparts: consecutive = List.IsChain (adjacent relation), pairwise = List.Pairwise (all-pairs relation). The general fact List.Pairwise.isChain gives pairwise ⟹ consecutive for free, and the only mathematical work is exhibiting a witness where the converse fails.",
+      "The failure is realized by a genuine Farey run, not a contrived list: 1/4, 1/3, 1/2, 2/3, 3/4 are five CONSECUTIVE fractions of F_4 (certified via the unimodular + denominator-sum criterion). Along this block the numerators 1,1,1,2,3 and denominators 4,3,2,3,4 keep every adjacent step monotone, but the endpoints 1/4 and 2/3 reverse direction — so a length-5 consecutive run contains no length-5 pairwise run.",
+      "Direction of strictness is pinned: consecutive is a relaxation of pairwise, hence f_consec(n) ≥ f(n) always, and the F_4 block shows the gap is already nonzero at the level of individual runs. The qualitative answer to OQ-04 is therefore YES — the notions differ — with the consecutive count the larger one.",
+      "What remains open is quantitative: whether the asymptotic constants of f_consec(n)/n and f(n)/n differ (the parent constant itself is unknown, lying somewhere in [1/12, 1/4]). The separation here is exact and local, not asymptotic."
+    ]
+  },
+  "conclusion": {
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (283 lines, 13 theorems, 11 definitions) separating the two ways one might count runs of similarly ordered Farey fractions. The similarly-ordered relation is reflexive and symmetric but not transitive; consequently the consecutive (adjacent-pairs, List.IsChain) run notion is strictly weaker than the pairwise (all-pairs, List.Pairwise) notion used by the parent. The explicit witness is the genuine length-5 consecutive block 1/4, 1/3, 1/2, 2/3, 3/4 of F_4, which is consecutively but not pairwise similarly ordered, with its consecutiveness in F_4 certified by the unimodular denominator-sum adjacency criterion.",
+    "implications": "OQ-04 is answered qualitatively: the two run notions are provably distinct, with f_consec(n) ≥ f(n) and strict inequality realized locally. This clarifies why the parent's f(n) is defined by the pairwise condition — the lighter consecutive condition counts a strictly different (larger) quantity. The List.IsChain vs List.Pairwise framing and the non-transitivity witness are reusable for any 'similarly ordered'/comparability-chain analysis, and the adjacency engine intermediate_denom_ge is shared infrastructure with the sibling entry OQ-03.",
+    "openQuestions": [
+      "Asymptotic gap: do the two run-length functions have different leading constants — is lim f_consec(n)/n strictly greater than lim f(n)/n, or do they coincide despite the local separation? This is the quantitative form of OQ-04 and is open (even the pairwise constant is unknown in [1/12, 1/4]).",
+      "Maximal consecutive runs: characterize the longest List.IsChain blocks of F_n directly. Since consecutive Farey neighbours are unimodular, a consecutive similarly ordered run is a maximal monotone-direction chain of mediants; bounding its length may be more tractable than the pairwise problem and could bracket f_consec(n) explicitly."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Background: consecutive vs. pairwise",
+      "startLine": 6,
+      "endLine": 56,
+      "summary": "Module docstring framing OQ-04: the parent counts runs by the pairwise condition (all pairs similarly ordered), and OQ-04 asks whether the adjacent-pairs-only (consecutive) condition gives something different. Previews the List.IsChain vs List.Pairwise framing and the F_4 witness, and states the scope (qualitative separation; asymptotic constants remain open)."
+    },
+    {
+      "id": "scaffold",
+      "title": "§1 Farey fractions",
+      "startLine": 58,
+      "endLine": 84,
+      "summary": "The FareyFraction n structure (reduced p/q with q ≤ n), its rational value toRat, and the unimodular adjacency predicate IsConsecutiveFarey — the scaffold mirrored from the parent and sibling OQ-03."
+    },
+    {
+      "id": "relation",
+      "title": "§2 The similarly ordered relation",
+      "startLine": 86,
+      "endLine": 112,
+      "summary": "SimOrdered f g := 0 ≤ (f.p − g.p)(f.q − g.q), the relation in its native product form over ℤ, with a DecidableRel instance and proofs that it is reflexive (simOrdered_refl) and symmetric (simOrdered_symm)."
+    },
+    {
+      "id": "nontransitive",
+      "title": "§3 Non-transitivity",
+      "startLine": 114,
+      "endLine": 137,
+      "summary": "The five explicit order-4 fractions 1/4, 1/3, 1/2, 2/3, 3/4, and simOrdered_not_transitive: the relation is not transitive, witnessed by 1/4 ~ 1/2, 1/2 ~ 2/3, but 1/4 ̸~ 2/3. This is the obstruction that forces the pairwise condition and that OQ-04 probes."
+    },
+    {
+      "id": "two-notions",
+      "title": "§4 Consecutive vs. pairwise as list predicates",
+      "startLine": 138,
+      "endLine": 156,
+      "summary": "ConsecutivelySimOrdered := List.IsChain SimOrdered (adjacent pairs) and PairwiseSimOrdered := List.Pairwise SimOrdered (all pairs), with pairwise_imp_consecutive (List.Pairwise.isChain) giving the trivial direction f(n) ≤ f_consec(n)."
+    },
+    {
+      "id": "witness",
+      "title": "§5 The separating witness",
+      "startLine": 158,
+      "endLine": 207,
+      "summary": "The length-5 block farey4Block = [1/4, 1/3, 1/2, 2/3, 3/4]: farey4_block_chain' (it is consecutively similarly ordered), farey4_block_not_pairwise (it is not pairwise — endpoints 1/4 and 2/3 clash), and consecutive_strictly_weaker (the headline: consecutive is strictly weaker than pairwise)."
+    },
+    {
+      "id": "adjacency",
+      "title": "§6 The witnesses are consecutive in F₄",
+      "startLine": 208,
+      "endLine": 282,
+      "summary": "The adjacency engine (toRat_lt_iff, intermediate_denom_ge, farey_adjacent_of_denom_sum_gt, mirrored from OQ-03) plus farey4_block_unimodular and farey4_block_increasing, assembled in farey4_block_consecutive_in_F4: no order-4 fraction lies strictly between any adjacent pair of the block, so it is a genuine contiguous run of F_4."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-1005",
+      "relationship": "extends",
+      "description": "Answers OQ-04 of the parent: whether counting similarly ordered runs by adjacent pairs (consecutive) rather than all pairs (pairwise) changes the problem. The parent defines f(n) via the pairwise condition; this entry shows the consecutive condition is strictly weaker, so f_consec(n) ≥ f(n), with a real F_4 run witnessing the gap."
+    },
+    {
+      "targetId": "erdos-1005-oq-03",
+      "relationship": "uses",
+      "description": "Reuses the Farey adjacency engine (intermediate_denom_ge: any fraction between a unimodular pair has denominator ≥ b + d; farey_adjacent_of_denom_sum_gt: b + d > n implies adjacency) to certify that the five witness fractions are genuinely consecutive in F_4."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "consecutive_strictly_weaker",
+      "type": "headline",
+      "description": "The two run notions are provably distinct: there is a list of order-4 Farey fractions that is consecutively (List.IsChain) but not pairwise (List.Pairwise) similarly ordered, while pairwise always implies consecutive. Hence the consecutive run length dominates the pairwise one, f_consec(n) ≥ f(n), with strict inequality realized at the level of individual runs.",
+      "leanType": "(∃ l : List (FareyFraction 4), ConsecutivelySimOrdered l ∧ ¬ PairwiseSimOrdered l) ∧ (∀ l : List (FareyFraction 4), PairwiseSimOrdered l → ConsecutivelySimOrdered l)"
+    },
+    {
+      "name": "simOrdered_not_transitive",
+      "type": "core",
+      "description": "The root cause: the similarly-ordered relation (a−c)(b−d) ≥ 0 is not transitive. Witnessed by 1/4 ~ 1/2 (numerators tie), 1/2 ~ 2/3 (both rise), but 1/4 ̸~ 2/3 (numerator rises while denominator falls, product −1). This is exactly what forces the pairwise condition in the parent and separates the two run notions.",
+      "leanType": "¬ ∀ f g h : FareyFraction 4, SimOrdered f g → SimOrdered g h → SimOrdered f h"
+    },
+    {
+      "name": "farey4_block_chain'",
+      "type": "core",
+      "description": "The genuine length-5 consecutive block 1/4, 1/3, 1/2, 2/3, 3/4 of F_4 is consecutively similarly ordered: every adjacent pair satisfies (a−c)(b−d) ≥ 0.",
+      "leanType": "ConsecutivelySimOrdered farey4Block"
+    },
+    {
+      "name": "farey4_block_not_pairwise",
+      "type": "core",
+      "description": "The same block is not pairwise similarly ordered: the non-adjacent endpoints 1/4 and 2/3 clash, (1−2)(4−3) = −1 < 0. So a length-5 consecutive run contains no length-5 pairwise run.",
+      "leanType": "¬ PairwiseSimOrdered farey4Block"
+    },
+    {
+      "name": "farey4_block_consecutive_in_F4",
+      "type": "core",
+      "description": "Certification that the five witnesses are genuinely consecutive in F_4: each adjacent pair is unimodular with denominator sum > 4, so by the denominator-sum criterion no order-4 fraction lies strictly between them. The separation thus concerns an honest contiguous block of the Farey sequence.",
+      "leanType": "(∀ h, ¬ (f14.toRat < h.toRat ∧ h.toRat < f13.toRat)) ∧ ... ∧ (∀ h, ¬ (f23.toRat < h.toRat ∧ h.toRat < f34.toRat))"
+    },
+    {
+      "name": "pairwise_imp_consecutive",
+      "type": "supporting",
+      "description": "The trivial direction: every pairwise similarly ordered run is consecutively similarly ordered (List.Pairwise.isChain). Fixes the direction of strictness, f(n) ≤ f_consec(n).",
+      "leanType": "∀ {n : ℕ} (l : List (FareyFraction n)), PairwiseSimOrdered l → ConsecutivelySimOrdered l"
+    }
+  ]
+}

--- a/src/data/proofs/erdos-1042-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1042-oq-02/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "ann-erdos1042oq02-header",
+    "proofId": "erdos-1042-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
+    "type": "concept",
+    "title": "Do the Lemniscate Component Bounds Survive in Several Variables?",
+    "content": "Erdős Problem #1042 concerns connected components of one-variable polynomial lemniscates {z : |f(z)| < 1}; Ghosh–Ramachandran (2024) tied the answer to the transfinite diameter of the root set, and sibling oq-03 proves the underlying confinement of the lemniscate to unit balls about the roots. Open question oq-02 asks whether any of this extends to higher dimensions ℂⁿ. This file gives a precise partial answer: the soft analytic facts survive, but the geometry that drives the component count fails already in ℂ².",
+    "mathContext": "Multivariate model $f(z) = \\prod_j (z_{\\,c_j} - r_j)$ on $\\mathbb{C}^n$ with lemniscate $\\{z : |f(z)| < 1\\}$. When $n = 1$ this is the one-variable monic polynomial of oq-03.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polynomial lemniscate",
+      "several complex variables",
+      "connected components",
+      "transfinite diameter",
+      "higher-dimensional generalisation"
+    ]
+  },
+  {
+    "id": "ann-erdos1042oq02-reduction",
+    "proofId": "erdos-1042-oq-02",
+    "range": {
+      "startLine": 71,
+      "endLine": 82
+    },
+    "type": "key-step",
+    "title": "Faithful Reduction to One Variable",
+    "content": "On ℂ¹ every coordinate index lives in Fin 1, so by Subsingleton.elim each factor's coordinate is the unique coordinate 0. Thus eval reduces to ∏ⱼ(z 0 - rootⱼ), exactly the one-variable monic polynomial of sibling oq-03. This certifies that the multivariate framework genuinely generalises the one-variable theory, so the failure exhibited later is a true higher-dimensional effect rather than an artefact of a different definition.",
+    "mathContext": "$\\mathrm{Fin}\\ 1$ is a subsingleton, so $z_{\\,c_j} = z_0$ and $f(z) = \\prod_j (z_0 - r_j)$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Subsingleton.elim",
+      "Fin 1",
+      "definitional consistency"
+    ]
+  },
+  {
+    "id": "ann-erdos1042oq02-survives",
+    "proofId": "erdos-1042-oq-02",
+    "range": {
+      "startLine": 84,
+      "endLine": 106
+    },
+    "type": "technique",
+    "title": "What Survives: Continuity, Openness, Root-Containment",
+    "content": "The multivariate polynomial is a finite product of the continuous coordinate-evaluation maps z ↦ z(coordⱼ) - rootⱼ (continuous_apply composed with subtraction), so it is continuous and the lemniscate is the open preimage of (-∞,1). Wherever a single factor vanishes f = 0, so the zero locus lies inside the lemniscate. None of these arguments uses the dimension, so they hold verbatim in ℂⁿ — in particular the zero locus, a union of hyperplanes, is contained in the lemniscate.",
+    "mathContext": "$z \\mapsto f(z)$ continuous $\\Rightarrow \\{|f|<1\\}$ open; $f$ vanishes on $\\bigcup_j \\{z_{\\,c_j} = r_j\\} \\subseteq \\{|f|<1\\}$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "continuous_apply",
+      "continuous_finset_prod",
+      "open preimage",
+      "Finset.prod_eq_zero",
+      "hyperplane zero locus"
+    ]
+  },
+  {
+    "id": "ann-erdos1042oq02-unbounded",
+    "proofId": "erdos-1042-oq-02",
+    "range": {
+      "startLine": 108,
+      "endLine": 157
+    },
+    "type": "key-step",
+    "title": "The New Phenomenon: An Unbounded Lemniscate in ℂ²",
+    "content": "The crux. Take f(z₀,z₁) = z₀ on ℂ²; its lemniscate is the cylinder {z : |z₀| < 1}. For every real t the point (0,t) satisfies |z₀| = 0 < 1, so it lies in the lemniscate, yet its sup-norm is ≥ |z₁| = |t|, which is unbounded. Via isBounded_iff_forall_norm_le and norm_le_pi_norm this proves the lemniscate is unbounded — the exact failure of oq-03's isBounded_lem, which confines every one-variable lemniscate to a finite union of unit balls. The free coordinate direction is the obstruction.",
+    "mathContext": "$(0,t) \\in \\{|z_0|<1\\}$ and $\\|(0,t)\\| \\ge |t| \\to \\infty$, so the lemniscate escapes every ball; confinement to root-balls has no $\\mathbb{C}^n$ analogue.",
+    "significance": "key",
+    "relatedConcepts": [
+      "isBounded_iff_forall_norm_le",
+      "norm_le_pi_norm",
+      "sup norm on a product",
+      "confinement failure"
+    ]
+  },
+  {
+    "id": "ann-erdos1042oq02-connected",
+    "proofId": "erdos-1042-oq-02",
+    "range": {
+      "startLine": 159,
+      "endLine": 183
+    },
+    "type": "key-step",
+    "title": "Components Merge: The Cylinder Is Connected",
+    "content": "The cylinder {z : |z₀| < 1} is the preimage of the open unit ball B(0,1) ⊆ ℂ under the ℝ-linear first-coordinate projection z ↦ z₀. Since the ball is convex (convex_ball) and preimages of convex sets under linear maps are convex (Convex.linear_preimage), the cylinder is convex, hence connected (Convex.isConnected). Where the one-variable zⁿ + 1 produces n disjoint island components, the higher-dimensional lemniscate fuses them into a single connected unbounded set — so the component-counting question of #1042 has no naive ℂⁿ analogue. The capstone packages open + connected + unbounded.",
+    "mathContext": "$\\{|z_0|<1\\} = (\\,z \\mapsto z_0\\,)^{-1} B(0,1)$ is convex, hence connected; one connected component, not $n$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "convex_ball",
+      "Convex.linear_preimage",
+      "Convex.isConnected",
+      "LinearMap.proj",
+      "component merging"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1042-oq-02/meta.json
+++ b/src/data/proofs/erdos-1042-oq-02/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "erdos-1042-oq-02",
+  "title": "Polynomial Lemniscate Confinement Fails in Higher Dimensions",
+  "slug": "erdos-1042-oq-02",
+  "description": "Addresses open question oq-02 of Erdős Problem #1042 (can the component-count results be extended to higher dimensions?) by isolating exactly what survives and what fails when one passes from one complex variable ℂ to several, ℂⁿ. Using the natural multivariate analogue of a monic factored polynomial, f(z) = ∏ⱼ(z(coordⱼ) - rootⱼ) on ℂⁿ — which reduces to the one-variable monic polynomial of sibling oq-03 when n = 1 — the entry proves that openness, continuity, and root-containment generalise verbatim to ℂⁿ, but the geometric heart of #1042 does not. Concretely, in ℂ² the lemniscate of f(z₀,z₁) = z₀ is open and connected yet UNBOUNDED: the free second coordinate turns each would-be isolated island into an infinite tube. This is the precise obstruction — oq-03's confinement-to-unit-balls and the resulting 'at most n components' bound have no naive higher-dimensional analogue, so the #1042 answer is a genuinely one-complex-variable phenomenon. Fully axiom-free, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1042OQ02.lean",
+    "tags": [
+      "complex-analysis",
+      "potential-theory",
+      "polynomials",
+      "lemniscates",
+      "several-complex-variables",
+      "geometry",
+      "erdos",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 185,
+    "assumptions": "None. All eleven theorems are axiom-free and self-contained: the multivariate polynomial/lemniscate structures are re-declared locally so that nothing depends on the parent entry's axioms (transfiniteDiameter, ghosh_ramachandran_small_diameter, ghosh_ramachandran_diameter_one_examples) nor on sibling oq-03. No native_decide is used. Kernel-verified against Mathlib v4.26.0 (`lake env lean`, exit 0); `#print axioms higher_dim_confinement_fails` reports only `[propext, Classical.choice, Quot.sound]`. Mathlib lemmas used: continuous_finset_prod, continuous_apply, Finset.prod_eq_zero, sub_eq_zero, Continuous.norm, Fin.prod_univ_one, norm_le_pi_norm, isBounded_iff_forall_norm_le, Complex.norm_of_nonneg, Matrix.cons_val_zero/cons_val_one, LinearMap.proj, convex_ball, Convex.linear_preimage, Convex.isConnected. Uses the modern norm ‖·‖ throughout (Complex.abs was removed in v4.26.0).",
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "CoordPoly: a self-contained, axiom-free model of a multivariate coordinate-factored polynomial f(z) = ∏ⱼ(z(coordⱼ) - rootⱼ) on ℂⁿ, with eval and lemniscate sublevel set lem",
+      "eval_one_dim: REDUCTION — on ℂ¹ the model is exactly the one-variable monic polynomial ∏ⱼ(z 0 - rootⱼ) of sibling oq-03, so the framework genuinely generalises one variable",
+      "continuous_eval: z ↦ f(z) is continuous on ℂⁿ (finite product of coordinate-evaluation maps) — SURVIVES to higher dimensions",
+      "isOpen_lem: the lemniscate is open on ℂⁿ — SURVIVES",
+      "mem_lem_of_eval_zero: the zero locus of f lies inside the lemniscate (a union of hyperplanes in ℂⁿ, not a finite set) — SURVIVES",
+      "cylExample: the ℂ² polynomial f(z₀,z₁) = z₀ whose lemniscate is the infinite cylinder {|z₀| < 1}",
+      "cyl_eval / lem_cyl_eq: the example evaluates to the first coordinate and its lemniscate is exactly {z : |z₀| < 1}",
+      "cyl_unbounded: THE NEW PHENOMENON — in ℂ² this lemniscate is UNBOUNDED (points (0,t) lie in it for all real t with norm ≥ |t| → ∞), in direct contrast to oq-03's isBounded_lem which holds for every one-variable lemniscate",
+      "convex_cyl: the cylinder is convex (preimage of the open unit ball under the ℝ-linear first-coordinate projection)",
+      "isConnected_cyl: COMPONENTS MERGE — the same ℂ² lemniscate is connected; the n disjoint islands of the one-variable picture fuse into one set",
+      "higher_dim_confinement_fails: capstone — open + connected + unbounded, so the #1042 confinement/component-count results do not extend naively to ℂⁿ"
+    ],
+    "theoremCount": 11,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1042 asks how many connected components the lemniscate {z : |f(z)| < 1} of a degree-n monic polynomial with roots in a closed set F ⊆ ℂ can have. Erdős–Herzog–Piranian (1958) showed the unit disc allows n components (f(z) = zⁿ + 1). Ghosh–Ramachandran (2024) resolved the one-variable problem in terms of the transfinite diameter of F. A natural follow-up (open question oq-02) asks whether any of this survives in several complex variables, where 'lemniscate' becomes the sublevel set {z ∈ ℂⁿ : |f(z)| < 1} of a multivariate polynomial and the zero locus of f is a hypersurface rather than a finite set of points.",
+    "problemStatement": "Open question oq-02: can the result be extended to higher dimensions? This entry isolates, in the precise setting of coordinate-factored polynomials on ℂⁿ, which structural facts of the one-variable theory survive and which fail.",
+    "proofStrategy": "Work with a self-contained model CoordPoly of a multivariate polynomial f(z) = ∏ⱼ(z(coordⱼ) - rootⱼ) and its lemniscate lem = {|f| < 1} on ℂⁿ. (1) eval_one_dim shows that for n = 1 the model is exactly the one-variable monic polynomial of oq-03. (2) continuity, openness, and zero-locus-membership are proved for general ℂⁿ exactly as in one variable — these survive. (3) The crux is a single ℂ² example f(z₀,z₁) = z₀: its lemniscate equals the cylinder {|z₀| < 1}; the free second coordinate makes it unbounded (witnesses (0,t) with norm ≥ |t|) and, via convexity of the preimage of a ball under the ℝ-linear coordinate projection, connected. This exhibits the qualitative failure of oq-03's confinement/boundedness in higher dimensions.",
+    "keyInsights": [
+      "Openness and the root-containment of a lemniscate are 'soft' facts that depend only on continuity of f and the product structure, so they generalise verbatim from ℂ to ℂⁿ.",
+      "The geometric engine of #1042 — confinement of the lemniscate to the union of unit balls about the (finitely many) roots — relies on the zero set being a finite set of points. In ℂⁿ (n ≥ 2) the zero set of a single factor is a whole hyperplane, so there is no confinement: a free coordinate direction makes the lemniscate unbounded.",
+      "Unboundedness forces a different topology: where zⁿ + 1 produces n disjoint bounded islands in ℂ, the higher-dimensional cylinder is a single connected (indeed convex) unbounded set. The component-counting question therefore has no naive ℂⁿ analogue.",
+      "Re-declaring the structures locally keeps the contribution axiom-free, and giving an explicit reduction (eval_one_dim) to sibling oq-03 makes precise the sense in which this is a faithful higher-dimensional generalisation that nonetheless breaks."
+    ],
+    "prerequisites": [
+      "Finite products over Finset (Finset.prod_eq_zero, Fin.prod_univ_one) and continuity of finite products (continuous_finset_prod, continuous_apply)",
+      "The sup-norm on the product space Fin n → ℂ (norm_le_pi_norm) and boundedness in normed groups (isBounded_iff_forall_norm_le)",
+      "Convexity of preimages of balls under linear maps (convex_ball, Convex.linear_preimage) and convex ⟹ connected (Convex.isConnected)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "§I: Coordinate-Factored Polynomials and the One-Variable Reduction",
+      "startLine": 59,
+      "endLine": 82,
+      "summary": "Self-contained multivariate model f(z) = ∏ⱼ(z(coordⱼ) - rootⱼ) on ℂⁿ with its lemniscate, and a proof that for n = 1 it is exactly the one-variable monic polynomial of sibling oq-03.",
+      "mathContext": "On $\\mathbb{C}^1$ every factor reads off the unique coordinate $0$, so $f(z) = \\prod_j (z_0 - r_j)$, recovering oq-03."
+    },
+    {
+      "id": "survives",
+      "title": "§II: What Survives — Continuity, Openness, Root-Containment in ℂⁿ",
+      "startLine": 84,
+      "endLine": 106,
+      "summary": "The polynomial map is continuous, the lemniscate is open, and the zero locus of f lies inside the lemniscate — all proved for general ℂⁿ exactly as in one variable.",
+      "mathContext": "$z \\mapsto f(z)$ is a finite product of continuous coordinate maps, so $\\{|f| < 1\\}$ is open in $\\mathbb{C}^n$; wherever a factor vanishes, $f = 0 \\in \\{|f|<1\\}$."
+    },
+    {
+      "id": "unbounded",
+      "title": "§III: What Fails — An Unbounded Lemniscate in ℂ²",
+      "startLine": 108,
+      "endLine": 157,
+      "summary": "The example f(z₀,z₁) = z₀ has lemniscate the cylinder {|z₀| < 1}; the free coordinate makes it unbounded, contradicting oq-03's confinement/boundedness.",
+      "mathContext": "$(0, t) \\in \\{|z_0| < 1\\}$ for every $t \\in \\mathbb{R}$, yet $\\|(0,t)\\| \\geq |t| \\to \\infty$, so the lemniscate is unbounded."
+    },
+    {
+      "id": "capstone",
+      "title": "§IV: Connectedness and Capstone",
+      "startLine": 159,
+      "endLine": 183,
+      "summary": "The cylinder is convex, hence connected: the would-be separate components merge. The capstone packages open + connected + unbounded.",
+      "mathContext": "$\\{|z_0| < 1\\}$ is the preimage of the convex ball $B(0,1)$ under the $\\mathbb{R}$-linear projection $z \\mapsto z_0$, so it is convex and connected."
+    }
+  ],
+  "conclusion": {
+    "summary": "The answer to oq-02 is made precise and proved axiom-free: passing from one complex variable to several, the 'soft' facts of a polynomial lemniscate (continuity of f, openness, containment of the zero locus) generalise verbatim to ℂⁿ, but the geometric mechanism behind Erdős #1042 does not. In ℂ² the lemniscate of f(z₀,z₁) = z₀ is open and connected yet unbounded, in direct contrast to sibling oq-03's confinement of every one-variable lemniscate to a finite union of unit balls. The component-count results of #1042 are therefore a genuinely one-complex-variable phenomenon. 0 sorries, 0 axioms.",
+    "openQuestions": [
+      "Is there a correct higher-dimensional substitute for the component count — e.g. counting unbounded components, or bounding components of {|f| < 1} ∩ K for a fixed compact K ⊆ ℂⁿ — that does generalise the #1042 bounds?",
+      "For a multivariate polynomial whose zero locus is a compact (rather than affine) variety, is the lemniscate bounded, and does a confinement-to-tubular-neighbourhood analogue of oq-03 hold?"
+    ],
+    "implications": "Pins down exactly where the one-variable theory of polynomial lemniscates is special: the finiteness of the root set. This guides any genuine higher-dimensional extension of #1042 toward pluripotential-theoretic or compactness hypotheses that restore confinement, rather than a naive transcription of the planar component count."
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1042",
+      "relationship": "parent-problem",
+      "description": "Erdős Problem #1042 (Ghosh–Ramachandran 2024): component counts of one-variable polynomial lemniscates; records the transfinite-diameter answers as axioms"
+    },
+    {
+      "targetId": "erdos-1042-oq-03",
+      "relationship": "related-problem",
+      "description": "Sibling open question oq-03: proves the one-variable confinement of a lemniscate to unit balls about its roots — exactly the property this entry shows fails in ℂⁿ"
+    },
+    {
+      "targetId": "erdos-1039",
+      "relationship": "related-problem",
+      "description": "Polynomial lemniscate disc radius — companion lemniscate problem in the same cluster"
+    }
+  ],
+  "references": [
+    {
+      "author": "Erdős, P., Herzog, F. and Piranian, G.",
+      "title": "Metric properties of polynomials",
+      "year": 1958,
+      "note": "Unit disc gives n components via f(z) = zⁿ + 1"
+    },
+    {
+      "author": "Ghosh, S. and Ramachandran, K.",
+      "title": "On the number of components of polynomial lemniscates",
+      "year": 2024,
+      "note": "Resolves the one-variable #1042: component count depends on geometry, not transfinite diameter alone"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos1042OQ02",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1042OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős #1005 — Open Question oq-04

**Question:** *Does the answer change if one considers consecutive similarly ordered (adjacent pairs only) rather than pairwise similarly ordered runs? The non-transitivity gap could make these differ significantly.*

**Answer (qualitative): Yes — the two run notions are provably distinct, and the consecutive count is the larger one.**

### What's proved (`Proofs/Erdos1005ProblemOQ04.lean`, 283 lines, 13 theorems, 11 defs, 0 sorries, 0 axioms)

The parent counts a run of similarly ordered Farey fractions only when **every** pair satisfies `(a_k − a_l)(b_k − b_l) ≥ 0` (pairwise). oq-04 asks about the lighter **adjacent-pairs-only** (consecutive) condition. Since the relation is reflexive and symmetric but **not transitive**, the two diverge:

- `simOrdered_not_transitive` — the root cause: `1/4 ~ 1/2` (numerators tie), `1/2 ~ 2/3` (both rise), yet `1/4 ̸~ 2/3` (numerator rises, denominator falls; product `−1`).
- The two notions are cast as Mathlib's standard predicates: **consecutive = `List.IsChain`**, **pairwise = `List.Pairwise`**. `pairwise_imp_consecutive` is exactly `List.Pairwise.isChain`, giving `f_consec(n) ≥ f(n)` for free.
- **`consecutive_strictly_weaker` (headline)** — the genuine length-5 consecutive block `1/4, 1/3, 1/2, 2/3, 3/4` of `F₄` is consecutively similarly ordered (`farey4_block_chain'`) but **not** pairwise (`farey4_block_not_pairwise` — the endpoints `1/4` and `2/3` clash). So a length-5 consecutive run contains no length-5 pairwise run.
- **`farey4_block_consecutive_in_F4`** — certifies the five witnesses are *truly consecutive* in `F₄`: each adjacent pair is unimodular with denominator sum `> 4`, so the denominator-sum adjacency engine (reused from sibling oq-03) forbids any order-4 fraction between them. The separation concerns an honest Farey run, not an arbitrary list.

### Scope / honesty

This resolves the **qualitative** form of oq-04 (the notions differ; consecutive ≥ pairwise, strict locally). Whether the two **asymptotic constants** `lim f_consec(n)/n` and `lim f(n)/n` differ remains **open** — the parent constant itself is unknown in `[1/12, 1/4]`.

### Verification

Kernel-verified against Mathlib v4.26.0 via `lake env lean` (Docker daemon was down; used the documented host single-file fallback), exit 0, no errors/warnings. `#print axioms` reports only `propext / Classical.choice / Quot.sound` for all key theorems — no `sorryAx`, no `Lean.ofReduceBool` (no `native_decide`). Hence **`status: verified`, `badge: original`, `axiomCount: 0`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)