### PR TITLE
Enrich The Second Moment of the Gaussian ∫ x² e^{-x²} = √π/2

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05/annotations.json
@@ -59,5 +59,47 @@
       "HasDerivAt calculus for compositions",
       "integrability of Gaussian-weighted polynomials"
     ]
+  },
+  {
+    "id": "ann-aoc07oq05-derivatives",
+    "proofId": "area-of-circle-oq-07-oq-05",
+    "range": { "startLine": 60, "endLine": 71 },
+    "type": "technique",
+    "title": "Building the Two Derivatives u and v",
+    "content": "The integration-by-parts lemma is fed two `HasDerivAt` facts. The first, `hu`, says `u = x` has derivative `1` and is `hasDerivAt_id` with a cosmetic `simpa`. The second, `hv`, builds the antiderivative `v = -½ e^{-x²}` with derivative `v' = x e^{-x²}` by composing Mathlib's differentiation API in three steps: `(hasDerivAt_pow 2 x).neg` gives `d/dx(-x²) = -(2x)`; `.exp` chains it through the exponential to `d/dx e^{-x²} = -(2x)·e^{-x²}`; `.const_mul (-½)` scales to `d/dx(-½ e^{-x²}) = -½·(-(2x))·e^{-x²}`. A final `convert … using 1; ring` reconciles this with the clean target `x e^{-x²}`, since `-½·(-(2x)) = x`.",
+    "mathContext": "$\\frac{d}{dx}\\!\\left(-\\tfrac12 e^{-x^2}\\right) = -\\tfrac12 \\cdot (-2x)\\, e^{-x^2} = x\\,e^{-x^2}$, so $v' = x e^{-x^2}$ is exactly the inner factor of the integrand $x^2 e^{-x^2} = x \\cdot (x e^{-x^2}) = u\\,v'$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "HasDerivAt.exp",
+      "HasDerivAt.const_mul",
+      "hasDerivAt_pow",
+      "chain rule for compositions"
+    ],
+    "prerequisites": [
+      "differentiation API in Mathlib (HasDerivAt)",
+      "chain and product rules"
+    ]
+  },
+  {
+    "id": "ann-aoc07oq05-obligations",
+    "proofId": "area-of-circle-oq-07-oq-05",
+    "range": { "startLine": 72, "endLine": 98 },
+    "type": "technique",
+    "title": "Discharging the Integrability and Boundary Obligations",
+    "content": "Beyond the two derivatives, `integral_mul_deriv_eq_deriv_mul` requires that both products `u·v'` and `u'·v` be integrable and that the boundary product `u·v` converge at each end. Integrability of `u·v' = x² e^{-x²}` comes from `integrable_rpow_mul_exp_neg_mul_sq` at `s = 2`, after bridging the real power `x^(2:ℝ)` to the natural power `x²` with `Real.rpow_natCast`; integrability of `u'·v = -½ e^{-x²}` is `integrable_exp_neg_mul_sq` scaled by `const_mul`. The two boundary limits `hbot`/`htop` are both obtained from the single cocompact decay `tendsto_mul_gaussian_cocompact`: `cocompact_eq_atBot_atTop` gives `atBot ≤ cocompact ℝ` and `atTop ≤ cocompact ℝ`, so `mono_left` restricts the cocompact limit to each one-sided filter, and `const_mul (-½)` rescales it to the actual boundary factor.",
+    "mathContext": "The IBP lemma's hypotheses are: $u v', u' v \\in L^1(\\mathbb R)$ and $\\lim_{x\\to-\\infty} uv = \\lim_{x\\to+\\infty} uv = 0$. The two one-sided limits are specializations of one cocompact statement because $\\text{cocompact }\\mathbb R = \\text{atBot} \\sqcup \\text{atTop}$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "integrable_rpow_mul_exp_neg_mul_sq",
+      "integrable_exp_neg_mul_sq",
+      "cocompact_eq_atBot_atTop",
+      "Tendsto.mono_left",
+      "Real.rpow_natCast"
+    ],
+    "prerequisites": [
+      "Lebesgue integrability criteria",
+      "filter monotonicity (mono_left)",
+      "cocompact filter on ℝ"
+    ]
   }
 ]

--- a/src/data/proofs/area-of-circle-oq-07-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05/meta.json
@@ -1,7 +1,6 @@
 {
   "id": "area-of-circle-oq-07-oq-05",
   "slug": "area-of-circle-oq-07-oq-05",
-  "description": "The second moment of the standard Gaussian weight, ∫_ℝ x² e^{-x²} dx = √π/2, evaluated as a real Lebesgue integral. Integration by parts on the whole real line trades the x² weight for a derivative: writing the integrand as x·(x e^{-x²}) and recognizing x e^{-x²} = d/dx(-½ e^{-x²}), the boundary term vanishes by Gaussian decay and the second moment reduces to exactly half the parent's zeroth moment √π. This is the Γ(3/2) = √π/2 moment realized directly, the n = 1 base case of the even-moment double-factorial recursion ∫ x^{2n} e^{-x²} = (2n-1)!!·√π/2^n.",
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
@@ -25,33 +24,6 @@
   },
   "title": "The Second Moment of the Gaussian ∫ x² e^{-x²} = √π/2",
   "description": "Adds the first nontrivial weighted moment to the Gaussian family: ∫_ℝ x² e^{-x²} dx = √π/2, exactly half the parent's zeroth moment √π. The value is obtained by integration by parts on the whole line — writing x² e^{-x²} = x·(x e^{-x²}), where x e^{-x²} is the derivative of -½ e^{-x²}; the boundary term x·(-½ e^{-x²}) vanishes at ±∞ by Gaussian decay, leaving ½∫ e^{-x²} = ½√π. Equivalently ½·Γ(3/2)·2 = √π/2, the variance integral of the unnormalized Gaussian.",
-  "overview": {
-    "historicalContext": "The moments ∫_ℝ x^{2n} e^{-x²} dx = (2n−1)!!·√π/2ⁿ encode the variance and higher cumulants of the normal distribution and are foundational to probability, statistical mechanics (equipartition), and the Hermite-polynomial theory of the Gaussian. The second moment n = 1, giving √π/2, is the variance integral of the unnormalized standard Gaussian and the first case where a polynomial weight must be carried through the integral — naturally handled by integration by parts, the same recursion that generates all even moments.",
-    "problemStatement": "Evaluate the second moment of the Gaussian weight, $\\int_{-\\infty}^{\\infty} x^2 e^{-x^2}\\,dx = \\dfrac{\\sqrt{\\pi}}{2}$, building on the parent's zeroth moment $\\int_{\\mathbb{R}} e^{-x^2}\\,dx = \\sqrt{\\pi}$.",
-    "proofStrategy": "Integration by parts on (−∞, ∞) via MeasureTheory.integral_mul_deriv_eq_deriv_mul with u = x (u' = 1) and v = −½ e^{-x²} (v' = x e^{-x²}, built from hasDerivAt_pow, HasDerivAt.exp, HasDerivAt.const_mul). The integrand factors as u·v' = x² e^{-x²}, so the IBP formula gives ∫ x² e^{-x²} = 0 − 0 − ∫ 1·(−½ e^{-x²}) = ½∫ e^{-x²} = ½√π. The boundary term x e^{-x²} → 0 at ±∞ comes from tendsto_mul_gaussian_cocompact (repackaged from tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact); the two integrability side-conditions use integrable_rpow_mul_exp_neg_mul_sq and integrable_exp_neg_mul_sq; the residual ∫ e^{-x²} = √π is the parent value integral_gaussian 1.",
-    "keyInsights": [
-      "The value √π/2 being exactly half the zeroth moment √π is not a coincidence: integration by parts with u = x trades the x² weight for the antiderivative of x e^{-x²}, and because u' = 1 the residual is precisely the bare zeroth moment scaled by ½.",
-      "The boundary term vanishes because Gaussian decay e^{-x²} dominates the linear factor x; on ℝ the cocompact filter equals atBot ⊔ atTop, so a single cocompact limit packages both one-sided boundary terms the IBP lemma needs.",
-      "The same single IBP step, iterated, yields the double-factorial recursion ∫ x^{2n} e^{-x²} = (2n−1)!!·√π/2ⁿ for all even moments; here one application suffices because the polynomial weight is only x².",
-      "Equivalently the result is the Gamma special value ½·Γ(3/2)·2 = √π/2, exhibiting the moment as a shadow of the Gamma function — the analytic object that unifies all Gaussian moments."
-    ]
-  },
-  "sections": [
-    {
-      "id": "boundary-decay",
-      "title": "The Boundary Term Vanishes",
-      "startLine": 41,
-      "endLine": 52,
-      "summary": "tendsto_mul_gaussian_cocompact: x e^{-x²} → 0 at both ends of ℝ, repackaged from tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact via tendsto_zero_iff_norm_tendsto_zero — the boundary product that vanishes in the IBP computation."
-    },
-    {
-      "id": "integration-by-parts",
-      "title": "The Second Moment by Integration by Parts",
-      "startLine": 53,
-      "endLine": 118,
-      "summary": "gaussian_second_moment: ∫ x² e^{-x²} = √π/2 via integral_mul_deriv_eq_deriv_mul with u = x, v = −½ e^{-x²}, discharging the derivative, integrability, and boundary obligations, leaving ½∫ e^{-x²} = ½√π (integral_gaussian)."
-    }
-  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-05` (0 prior passes).

## Consolidation (size guardrails)
The `meta.json` had **duplicate top-level keys** — `description`, `overview`, and `sections` each appeared twice. JSON parsing keeps only the last occurrence, so the first copies were dead weight inflating the file and confusing future editors. Removed the dead first copies, keeping the richer rendered second copies verbatim.
- **17.1 KB → 13.2 KB** with **zero change to rendered content**.

## Annotation depth (3 → 5)
The 65-line integration-by-parts proof (lines 53–118) was a single annotation block. Split out two focused sub-step annotations:
- **Building the Two Derivatives u and v** (60–71): the `HasDerivAt` chain `hasDerivAt_pow → .neg → .exp → .const_mul` producing `v' = x e^{-x²}`.
- **Discharging the Integrability and Boundary Obligations** (72–98): `integrable_rpow_mul_exp_neg_mul_sq` (with `Real.rpow_natCast` bridge), and the `atBot`/`atTop` boundary limits from one cocompact statement via `cocompact_eq_atBot_atTop` + `mono_left`.

Both new annotations carry `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

## Verification
- Both JSON files parse; no duplicate keys remain.
- `pnpm build` passes.
- Axiom integrity unchanged: `status: verified`, `badge: mathlib`, `axiomCount: 0` — accurate for this 0-axiom Mathlib-assembled proof.