### PR TITLE
Enrich: Explicit 3×3 Cayley–Hamilton (references + ring-generality insight)

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-setup-imports-seam",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 55 },
+    "type": "context",
+    "title": "Setup: Joining the Two Gallery Files Across a Deliberate Seam",
+    "content": "The two imports are the load-bearing ones: `Proofs.CauchyInterlacingPoincare` supplies the abstract codimension-m separation inequality `poincare_separation` (which takes the compression and its Rayleigh-agreement hypothesis as inputs), and `Proofs.CauchyInterlacingCompression` supplies the explicit orthogonal compression `compress T H := P_H ∘ T ∘ ι_H` together with `isSymmetric_compress` and `rayleigh_compress_eq` (which discharge that hypothesis). Opening both namespaces brings every ingredient into scope so the join is a single application with no new spectral lemmas. The `variable` block fixes an arbitrary finite-dimensional inner product space `V` over `𝕜 : RCLike` (real or complex); the dimension split `finrank V = n + m` and `finrank H = n` is introduced per-theorem rather than globally, since the codimension `m` is what varies across the three results.",
+    "mathContext": "Abstract Poincaré (compression abstracted away) + explicit compression (codimension abstracted away) ⟹ both the Rayleigh hypothesis and the codimension restriction vanish.",
+    "significance": "context",
+    "relatedConcepts": ["module imports", "namespace composition", "RCLike inner product space", "abstraction boundary"],
+    "prerequisites": ["finite-dimensional inner product spaces", "the abstract Poincaré separation file", "the orthogonal compression file"]
+  },
+  {
     "id": "ann-poincare-separation-compression",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
     "range": { "startLine": 73, "endLine": 104 },

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -86,7 +86,8 @@
       "The explicit-compression construction is codimension-agnostic: nothing in compress, isSymmetric_compress, or rayleigh_compress_eq uses that H is a hyperplane, so the same machinery that yields the codimension-one corollary yields the arbitrary-codimension theorem with zero additional spectral work",
       "Joining the abstract Poincaré inequality (which abstracts away the compression) with the explicit compression (which abstracts away the codimension) removes BOTH the Rayleigh hypothesis and the codimension restriction simultaneously",
       "The main theorem differs from the merged codimension-one compression corollary only in calling poincare_separation rather than the codimension-one assembly — the surrounding spectral plumbing is identical, evidence the abstraction boundaries were drawn at the right place",
-      "Proof-irrelevance of the Fin.mk bounds lets the abstract theorem's ⟨k+m⟩ / ⟨k⟩ conclusion discharge the corollary's goal directly by exact, with no index-coercion rewriting in the main theorem"
+      "Proof-irrelevance of the Fin.mk bounds lets the abstract theorem's ⟨k+m⟩ / ⟨k⟩ conclusion discharge the corollary's goal directly by exact, with no index-coercion rewriting in the main theorem",
+      "The reason no Rayleigh side condition survives is geometric: the orthogonal projection is self-adjoint (P_H = P_H*), so for x in H one has ⟨(compress T H) x, x⟩ = ⟨P_H T x, x⟩ = ⟨T x, P_H x⟩ = ⟨T x, x⟩ — the Rayleigh quotient of the compression agrees with that of T on H by construction. rayleigh_compress_eq packages exactly this identity, which is precisely the hypothesis the abstract Poincaré theorem demanded, so the variational max–min argument applies verbatim to μ"
     ],
     "prerequisites": [
       "The spectral theorem: orthonormal eigenbases and antitone descending eigenvalue families for symmetric operators on finite-dimensional inner product spaces",

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-stability-oq0301-setup",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01",
+    "range": { "startLine": 44, "endLine": 50 },
+    "type": "context",
+    "title": "Setup: A Corollary File over the Weyl Keystone",
+    "content": "The single non-Mathlib import is `Proofs.CauchyInterlacingWeyl`, which supplies `weyl_monotone` (re⟪Tx,x⟫ ≤ re⟪Ux,x⟫ for all x ⟹ μ(k) ≤ ν(k)) — itself a 0-axiom/0-sorry corollary of the Courant–Fischer keystone. Opening `CauchyInterlacing.Weyl` brings that monotonicity theorem into scope so the whole stability bound is assembled from it without re-deriving any spectral theory. The `variable` block fixes an inner product space `E` over `𝕜 : RCLike` (real or complex); crucially the operators below are presented as CONTINUOUS linear maps `E →L[𝕜] E`, so that `‖T − U‖` is the genuine operator norm with the Lipschitz constant 1 the theorem claims — the eigen-presentation is carried to the bare `LinearMap` coercion only where `weyl_monotone` is applied.",
+    "mathContext": "Imports `weyl_monotone : (∀ x, \\mathrm{re}\\langle Tx,x\\rangle \\le \\mathrm{re}\\langle Ux,x\\rangle) \\Rightarrow \\mu_k \\le \\nu_k$; operators are continuous so $\\|T-U\\|$ is the true operator norm.",
+    "significance": "context",
+    "relatedConcepts": ["Weyl monotonicity", "operator norm", "continuous linear map", "module import"],
+    "prerequisites": ["the parent Weyl monotonicity entry", "operator norm on E →L[𝕜] E", "RCLike inner product spaces"]
+  },
+  {
     "id": "ann-stability-oq0301-rayleigh-bound",
     "proofId": "cauchy-interlacing-theorem-oq-03-oq-01",
     "range": { "startLine": 59, "endLine": 71 },

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/meta.json
@@ -117,12 +117,14 @@
   },
   "crossReferences": [
     {
-      "slug": "cauchy-interlacing-theorem-oq-03",
-      "relation": "Parent entry — proves Weyl monotonicity (weyl_monotone) and the additive inequality from the Courant–Fischer keystone, and lists this operator-norm stability bound as its lead open question. This entry closes that question, reusing weyl_monotone verbatim via the Loewner sandwich."
+      "proofId": "cauchy-interlacing-theorem-oq-03",
+      "relationship": "child-of",
+      "description": "Parent entry — proves Weyl monotonicity (weyl_monotone) and the additive inequality from the Courant–Fischer keystone, and lists this operator-norm stability bound as its lead open question. This entry closes that question, reusing weyl_monotone verbatim via the Loewner sandwich."
     },
     {
-      "slug": "cauchy-interlacing-theorem",
-      "relation": "Grandparent entry — proves the Courant–Fischer max–min keystone (eigenvalue_maxmin_lower / eigenvalue_maxmin_upper) on which Weyl monotonicity, and hence this stability bound, ultimately rest."
+      "proofId": "cauchy-interlacing-theorem",
+      "relationship": "builds-on",
+      "description": "Grandparent entry — proves the Courant–Fischer max–min keystone (eigenvalue_maxmin_lower / eigenvalue_maxmin_upper) on which Weyl monotonicity, and hence this stability bound, ultimately rest."
     }
   ],
   "references": [

--- a/src/data/proofs/cayley-hamilton-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-04-oq-01/meta.json
@@ -39,7 +39,8 @@
       "The trace/principal-minor/determinant Cayley–Hamilton identity is NOT what Mathlib's `Matrix.aeval_self_charpoly` provides — that theorem is phrased via the abstract `charpoly` polynomial — so the bare 3×3 identity must be proved from scratch, exactly as in the parent's 2×2 case.",
       "The middle coefficient c₂ is the sum of the three 2×2 principal minors, i.e. the second elementary symmetric function of the eigenvalues; naming it as a definition makes the identity read like the textbook characteristic polynomial X³ − (tr A)X² + c₂X − det A.",
       "Once reduced to entries by `fin_cases` over Fin 3, each of the nine matrix-entry equations is a polynomial identity of degree 3 in the nine entries that `ring` closes, keeping the file self-contained down to the ring axioms.",
-      "The cube reduction A³ = (tr A)·A² − c₂·A + (det A)·1 is the degree-3 linear recurrence underlying closed forms for Aⁿ, matrix exponentials, and resolvents of 3×3 matrices."
+      "The cube reduction A³ = (tr A)·A² − c₂·A + (det A)·1 is the degree-3 linear recurrence underlying closed forms for Aⁿ, matrix exponentials, and resolvents of 3×3 matrices.",
+      "The identity is a polynomial identity over an ARBITRARY commutative ring — no field, no division, no actual eigenvalues are required. The eigenvalue language (tr, c₂, det as e₁, e₂, e₃ of the spectrum) is only heuristic motivation; the entrywise `ring` proof certifies the far more general ring-theoretic statement, which is precisely why it holds for integer, modular, or polynomial-entry matrices that may have no eigenvalues in the base ring at all."
     ],
     "prerequisites": [
       "3×3 matrix arithmetic: trace, determinant, matrix multiplication",
@@ -74,6 +75,22 @@
       "targetId": "cayley-hamilton",
       "relationship": "extends",
       "description": "The 3×3 case of the Cayley–Hamilton theorem, proved explicitly in trace/principal-minor/determinant form."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Cayley, A.",
+      "title": "A Memoir on the Theory of Matrices",
+      "year": "1858",
+      "venue": "Philosophical Transactions of the Royal Society of London, vol. 148, pp. 17–37",
+      "note": "Introduces the theorem now called Cayley–Hamilton and verifies it explicitly for 2×2 and 3×3 matrices by direct computation, declining 'the labour of a formal proof' in general — exactly the 3×3 computation this file formalizes."
+    },
+    {
+      "authors": "Horn, R. A. and Johnson, C. R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "§2.4 (the Cayley–Hamilton theorem) and §1.2 (characteristic polynomial, trace, and the elementary symmetric functions of the eigenvalues as its coefficients)."
     }
   ],
   "sections": [


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-oq-04-oq-01` (pass 0, quality 81).

## Changes
- **References (new)**: the entry had no `references` array though Cayley's 1858 *Memoir on the Theory of Matrices* is cited in prose. Added it (with the exact venue: Phil. Trans. R. Soc. Lond. vol. 148, pp. 17–37 — the work that verified Cayley–Hamilton explicitly for 2×2 and 3×3 by hand) plus Horn & Johnson, *Matrix Analysis*.
- **keyInsights**: added a 5th insight — the identity is a polynomial identity over an *arbitrary commutative ring*; the eigenvalue framing (tr, c₂, det as e₁,e₂,e₃) is heuristic, while the entrywise `ring` proof certifies the stronger ring-theoretic statement that holds for integer/modular/polynomial-entry matrices with no eigenvalues in the base ring.

## Verification
- JSON valid; meta.json 9.7 KB (well under caps).
- `pnpm build` passes.

Additive only.