### PR TITLE
research(erdos-728-factorial-divisibility-oq-04): formalize the classical logarithmic barrier (toward Erdős #729) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos728FactorialDivisibilityOQ04.lean
+++ b/proofs/Proofs/Erdos728FactorialDivisibilityOQ04.lean
@@ -1,0 +1,102 @@
+/-
+# Erdős #728 → #729: the elementary logarithmic barrier (prime-2 / Legendre form)
+
+Research artifact for `erdos-728-factorial-divisibility-oq-04`:
+"How do the techniques of the #728 resolution extend to related problems like #729?"
+
+Erdős #728 (resolved affirmatively, Jan 2026, GPT-5.2 + Aristotle; see
+`Erdos728FactorialDivisibility.lean` and arXiv:2601.07421) and Erdős #729 (resolved
+by Barreto–Leeham with a modification of the same argument) are both about how far
+the *near*-divisibility of `a! b!` into `n!` can push `a + b` beyond `n`.
+
+The classical baseline both results break "beyond" is Erdős's elementary bound:
+
+  if `a! b! ∣ n!` then `a + b ≤ n + O(log n)`.
+
+Erdős's proof needs only the prime `2`.  By Legendre's formula
+`v₂(m!) = m − s₂(m)` (with `s₂ m = (Nat.digits 2 m).sum` the binary digit sum),
+the divisibility `a! b! ∣ n!` forces `v₂(a!) + v₂(b!) ≤ v₂(n!)`, i.e.
+`(a − s₂ a) + (b − s₂ b) ≤ n − s₂ n`, hence `a + b ≤ n + s₂ a + s₂ b`, and each
+binary digit sum is at most the binary length `= O(log)`.
+
+This file formalizes that barrier exactly over `ℕ`, 0-sorry / 0-axiom, as the
+verified starting point for the #729 generalization.  #729 asks for infinitely many
+`a, b, n` with `a + b > n + C log n` for which the denominator of `n!/(a! b!)`
+contains only primes bounded in terms of `C` — equivalently, the large-prime
+valuations already satisfy `v_p(a!) + v_p(b!) ≤ v_p(n!)`, while small primes (like
+the `2` used here) may fail it.  The barrier proved here is precisely the `O(log n)`
+statement that #728/#729 must — and do — defeat; the technique that defeats it is
+the large-prime carry analysis carried out in `Erdos728FactorialDivisibility.lean`.
+
+This is foundational infrastructure, not a resolution of #729: it is the lower bound
+the resolution surpasses, formalized in the same `padicValNat`/Legendre vocabulary
+the #728 file already uses (`kappa`, `W`, Kummer carries).
+-/
+import Mathlib
+
+namespace Erdos728FactorialDivisibilityOQ04
+
+open Nat
+
+/-- **Legendre's formula at `p = 2`, additive `ℕ` form.**  Every `m` splits as the
+2-adic valuation of `m!` plus the binary digit sum of `m`:
+`m = v₂(m!) + s₂(m)`.  This is `v₂(m!) = m − s₂(m)` rearranged to avoid truncated
+subtraction, read off from Mathlib's `sub_one_mul_padicValNat_factorial` at `p = 2`
+(where the `(p − 1)` factor is `1`). -/
+theorem factorial_val_add_digitsum (m : ℕ) :
+    m = padicValNat 2 (m !) + (Nat.digits 2 m).sum := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have hleg := sub_one_mul_padicValNat_factorial (p := 2) m
+  have hs : (Nat.digits 2 m).sum ≤ m := Nat.digit_sum_le 2 m
+  omega
+
+/-- **The logarithmic barrier (exact Legendre/popcount form).**  If `a! · b! ∣ n!`
+then `a + b ≤ n + s₂(a) + s₂(b)`, where `s₂` is the binary digit sum.  Proof: the
+divisibility gives `v₂(a!) + v₂(b!) ≤ v₂(n!)`; substituting Legendre's
+`m = v₂(m!) + s₂(m)` for `a`, `b`, `n` and clearing the valuations yields the bound.
+Only the prime `2` is used — this is Erdős's original elementary argument. -/
+theorem log_barrier {a b n : ℕ} (h : a ! * b ! ∣ n !) :
+    a + b ≤ n + (Nat.digits 2 a).sum + (Nat.digits 2 b).sum := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have hmono : padicValNat 2 (a ! * b !) ≤ padicValNat 2 (n !) :=
+    (padicValNat_dvd_iff_le (Nat.factorial_ne_zero n)).mp
+      (dvd_trans (pow_padicValNat_dvd (p := 2) (n := a ! * b !)) h)
+  rw [padicValNat.mul (Nat.factorial_ne_zero a) (Nat.factorial_ne_zero b)] at hmono
+  have ha := factorial_val_add_digitsum a
+  have hb := factorial_val_add_digitsum b
+  have hn := factorial_val_add_digitsum n
+  omega
+
+/-- The binary digit sum is at most the binary length: each base-2 digit is `< 2`,
+hence `≤ 1`, so the sum is bounded by the number of digits. -/
+theorem digitsum_two_le_length (m : ℕ) :
+    (Nat.digits 2 m).sum ≤ (Nat.digits 2 m).length := by
+  have h : (Nat.digits 2 m).sum ≤ (Nat.digits 2 m).length • 1 :=
+    List.sum_le_card_nsmul (Nat.digits 2 m) 1
+      (fun x hx => by have := Nat.digits_lt_base (by norm_num) hx; omega)
+  simpa using h
+
+/-- **The logarithmic barrier (explicit `O(log)` form).**  If `a! · b! ∣ n!` then
+`a + b ≤ n + len₂(a) + len₂(b)`, where `len₂ m = (Nat.digits 2 m).length` is the
+number of binary digits of `m` (`= ⌊log₂ m⌋ + 1` for `m > 0`).  This is the
+`a + b ≤ n + O(log n)` barrier in fully explicit form; #728/#729 exhibit triples
+violating it once small primes are excluded. -/
+theorem log_barrier_length {a b n : ℕ} (h : a ! * b ! ∣ n !) :
+    a + b ≤ n + (Nat.digits 2 a).length + (Nat.digits 2 b).length := by
+  have hbar := log_barrier h
+  have ha := digitsum_two_le_length a
+  have hb := digitsum_two_le_length b
+  omega
+
+#check @factorial_val_add_digitsum
+#check @log_barrier
+#check @log_barrier_length
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
+-- no sorryAx, no Lean.ofReduceBool.
+#print axioms factorial_val_add_digitsum
+#print axioms log_barrier
+#print axioms digitsum_two_le_length
+#print axioms log_barrier_length
+
+end Erdos728FactorialDivisibilityOQ04

--- a/research/problems/erdos-728-factorial-divisibility-oq-04/problem.md
+++ b/research/problems/erdos-728-factorial-divisibility-oq-04/problem.md
@@ -1,0 +1,57 @@
+# Problem: erdos-728-factorial-divisibility-oq-04 — extending the #728 techniques to Erdős #729
+
+## Statement
+
+### Plain Language
+Open question (generalization) spawned from the gallery proof
+`erdos-728-factorial-divisibility`: **how do the techniques of the #728 resolution
+extend to related problems like Erdős #729?**
+
+### The two problems
+- **Erdős #728** (resolved affirmatively, Jan 2026, GPT-5.2 + Aristotle): for any
+  fixed `0 < ε < 1/2` and `C > 0` there are infinitely many triples `(a,b,n)` with
+  range constraints and `a + b > n + C log n` satisfying `a! b! ∣ n! (a+b−n)!`.
+- **Erdős #729** (resolved by Barreto–Leeham, with a *modification* of the #728
+  argument): are there infinitely many `a, b, n` with `a + b > n + C log n` such
+  that the denominator of `n! / (a! b!)` contains only primes `≪_C 1`?  Equivalently:
+  `a! b! ∣ n!` "ignoring small primes" — for every prime `p ≫_C 1`,
+  `v_p(a!) + v_p(b!) ≤ v_p(n!)`.
+
+### The baseline both break
+Erdős's elementary theorem: if `a! b! ∣ n!` then `a + b ≤ n + O(log n)`.  Proof uses
+the prime `2` alone via Legendre's formula `v₂(m!) = m − s₂(m)`.  #728/#729 show this
+`O(log n)` barrier is sharp only because of *small* primes; restricting to large
+primes (the carry analysis) lets `a + b` exceed `n + C log n`.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 5
+tags:
+  - number-theory
+  - combinatorics
+  - erdos
+  - factorial
+  - p-adic
+  - ai-solved
+```
+
+**Significance**: 6/10
+**Tractability**: 5/10
+
+## Why This Matters
+Reuses the verified Kummer/Legendre carry-counting infrastructure of the #728
+resolution; #729 is the closest cousin and was solved by an explicit modification of
+the same method, so it is the most tractable generalization target.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| erdos-728-factorial-divisibility | Parent: the resolved #728, supplies `kappa`/`W`/Kummer-carry infrastructure |
+
+## References
+- arXiv:2601.07421 — write-up of Aristotle's Lean proof of #728.
+- erdosproblems.com/728, /729.

--- a/research/problems/erdos-728-factorial-divisibility-oq-04/state.md
+++ b/research/problems/erdos-728-factorial-divisibility-oq-04/state.md
@@ -1,0 +1,67 @@
+# Research State: erdos-728-factorial-divisibility-oq-04
+
+## Current State
+**Phase**: ORIENT (fresh problem; first iteration grounds the generalization target)
+**Since**: 2026-06-27
+**Iteration**: 1
+
+## Current Focus
+Extending the #728 factorial-divisibility techniques to Erdős #729. First iteration:
+fixed the precise statements of #728 vs #729 (the latter from a fresh web survey),
+identified the shared technique stack, and formalized the **classical logarithmic
+barrier** that both results break — the verified foundation for the generalization.
+
+## Iteration 1 addition (verified, 0-axiom — researcher-1, `lake env lean`, Docker down)
+
+Created `proofs/Proofs/Erdos728FactorialDivisibilityOQ04.lean` (108 lines, 4
+theorems, 0 sorries, 0 axioms; `#print axioms` = only propext / Classical.choice /
+Quot.sound on every theorem; verified by host `lean v4.26.0` over the shared
+main-repo Mathlib `.olean` cache, Docker image build down with the containerd
+`meta.db` I/O error).
+
+Formalizes the **elementary Erdős logarithmic barrier** — the `a + b ≤ n + O(log n)`
+bound that #728 and #729 are precisely about surpassing — in the same
+`padicValNat`/Legendre vocabulary the parent #728 file uses:
+
+- `factorial_val_add_digitsum` — Legendre at `p = 2` in additive ℕ form:
+  `m = v₂(m!) + s₂(m)` (binary digit sum), from Mathlib's
+  `sub_one_mul_padicValNat_factorial` (the `(p−1)` factor is `1` at `p = 2`).
+- `log_barrier` (**headline**) — `a! · b! ∣ n! → a + b ≤ n + s₂(a) + s₂(b)`.
+  Divisibility gives `v₂(a!) + v₂(b!) ≤ v₂(n!)` (`padicValNat.mul` +
+  `padicValNat_dvd_iff_le` + `pow_padicValNat_dvd`); substituting the Legendre split
+  and clearing the valuations (`omega`) yields the bound.  Only the prime `2` is
+  used — Erdős's original argument.
+- `digitsum_two_le_length` — `s₂(m) ≤ len₂(m)` (each binary digit `< 2`).
+- `log_barrier_length` — `a! · b! ∣ n! → a + b ≤ n + len₂(a) + len₂(b)`, the
+  explicit `O(log)` form (`len₂ m = ⌊log₂ m⌋ + 1` for `m > 0`).
+
+## Why this is the right foundation
+#729 asks for infinitely many `a, b, n` with `a + b > n + C log n` whose `n!/(a! b!)`
+denominator has only bounded primes — i.e. the LARGE-prime valuations satisfy
+`v_p(a!)+v_p(b!) ≤ v_p(n!)` while small primes (the `2` above) may fail it.  The
+barrier formalized here is exactly the obstruction at `p = 2`; #729's resolution
+shows it is defeated once one passes to large primes, where the #728 carry analysis
+(`kappa`, `lemma_forced_carries_largep`, the Chernoff bound on carries) applies.
+
+## Next Action
+- **Legendre at a general prime `p`**: lift `factorial_val_add_digitsum` to
+  `(p−1)·v_p(m!) = m − s_p(m)` for arbitrary prime `p` (it is literally
+  `sub_one_mul_padicValNat_factorial`) and restate the divisibility criterion
+  `v_p(a!)+v_p(b!) ≤ v_p(n!)` per-prime — the exact quantity #729 controls for large `p`.
+- **The "ignoring small primes" predicate**: define
+  `DivisibleIgnoringSmall a b n B := ∀ p, p.Prime → B < p → v_p(a!)+v_p(b!) ≤ v_p(n!)`
+  and prove the trivial direction (genuine divisibility ⟹ holds for all `B`), setting
+  up #729's existence target as the negation of an `O(log)` bound under this predicate.
+- **Reuse `kappa`/Kummer**: connect `v_p(n!/(a!b!))` to the central-binomial carry
+  count `kappa` from the parent file, the bridge by which #728's large-prime machine
+  transfers to #729.
+
+## Attempt Counts
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (barrier-first grounding)
+
+## Blockers
+- A full formalized resolution of #729 is a large undertaking (the #728 file is
+  1416 lines of probabilistic carry analysis); this iteration delivers the verified
+  baseline + a concrete per-prime roadmap, not the resolution.


### PR DESCRIPTION
## First iteration on the #728 → #729 generalization

This open question (spawned from the `erdos-728-factorial-divisibility` gallery proof) asks **how the techniques of the resolved #728 extend to Erdős #729**. This first iteration grounds the target: it fixes the precise statements, maps the shared technique stack, and formalizes the **verified baseline both results break beyond**.

### Background (from a fresh survey)
- **#728** (resolved Jan 2026, GPT-5.2 + Aristotle; arXiv:2601.07421): infinitely many `(a,b,n)` with `a+b > n + C log n` and `a! b! ∣ n!(a+b−n)!`.
- **#729** (resolved by Barreto–Leeham via a *modification* of the #728 argument): infinitely many `a,b,n` with `a+b > n + C log n` such that the denominator of `n!/(a! b!)` has only primes `≪_C 1` — i.e. the **large**-prime valuations satisfy `v_p(a!)+v_p(b!) ≤ v_p(n!)`, while small primes may fail it.
- **The shared baseline**: Erdős's elementary `a! b! ∣ n! → a+b ≤ n + O(log n)`, provable with the prime `2` alone via Legendre `v₂(m!) = m − s₂(m)`. #728/#729 surpass it precisely by excluding small primes.

### What this PR proves (`Erdos728FactorialDivisibilityOQ04.lean`, 4 theorems, 0-axiom)
| Theorem | Statement |
|---|---|
| `factorial_val_add_digitsum` | `m = v₂(m!) + s₂(m)` (Legendre at `p=2`, additive ℕ form) |
| `log_barrier` | `a!·b! ∣ n! → a + b ≤ n + s₂(a) + s₂(b)` (exact popcount barrier) |
| `digitsum_two_le_length` | `s₂(m) ≤ len₂(m)` |
| `log_barrier_length` | `a!·b! ∣ n! → a + b ≤ n + len₂(a) + len₂(b)` (explicit `O(log)`) |

Built on Mathlib's `sub_one_mul_padicValNat_factorial` (Legendre), `padicValNat.mul`, `padicValNat_dvd_iff_le`, `pow_padicValNat_dvd`. Stated in the same `padicValNat`/Legendre vocabulary the parent #728 file (`kappa`, `W`, Kummer carries) already uses, so it plugs into that machinery.

### Verification
- `lean v4.26.0` over the shared main-repo Mathlib `.olean` cache (Docker image build down — containerd `meta.db` I/O error). Clean compile.
- `#print axioms` on all four theorems: only `propext` / `Classical.choice` / `Quot.sound`. 0 sorries, 0 `axiom` declarations.
- Also initializes the problem's research dir (`problem.md` with both statements, `state.md` with a concrete per-prime next-step roadmap).

### Honest boundary
This is the verified *lower bound* (the `O(log n)` barrier) that #729's resolution surpasses — **not** a resolution of #729. A full formalized extension is a large undertaking (the #728 file is 1416 lines of probabilistic carry analysis). The `state.md` roadmap fixes the concrete next Lean targets (general-prime Legendre split; the "divisibility ignoring small primes" predicate; reusing `kappa`/Kummer for the large-prime transfer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)