### PR TITLE
Enrich: Inductive CRT list certificate (crossRefs + references + setup annotation)

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-setup-imports-seam",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 55 },
+    "type": "context",
+    "title": "Setup: Joining the Two Gallery Files Across a Deliberate Seam",
+    "content": "The two imports are the load-bearing ones: `Proofs.CauchyInterlacingPoincare` supplies the abstract codimension-m separation inequality `poincare_separation` (which takes the compression and its Rayleigh-agreement hypothesis as inputs), and `Proofs.CauchyInterlacingCompression` supplies the explicit orthogonal compression `compress T H := P_H ∘ T ∘ ι_H` together with `isSymmetric_compress` and `rayleigh_compress_eq` (which discharge that hypothesis). Opening both namespaces brings every ingredient into scope so the join is a single application with no new spectral lemmas. The `variable` block fixes an arbitrary finite-dimensional inner product space `V` over `𝕜 : RCLike` (real or complex); the dimension split `finrank V = n + m` and `finrank H = n` is introduced per-theorem rather than globally, since the codimension `m` is what varies across the three results.",
+    "mathContext": "Abstract Poincaré (compression abstracted away) + explicit compression (codimension abstracted away) ⟹ both the Rayleigh hypothesis and the codimension restriction vanish.",
+    "significance": "context",
+    "relatedConcepts": ["module imports", "namespace composition", "RCLike inner product space", "abstraction boundary"],
+    "prerequisites": ["finite-dimensional inner product spaces", "the abstract Poincaré separation file", "the orthogonal compression file"]
+  },
+  {
     "id": "ann-poincare-separation-compression",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
     "range": { "startLine": 73, "endLine": 104 },

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -86,7 +86,8 @@
       "The explicit-compression construction is codimension-agnostic: nothing in compress, isSymmetric_compress, or rayleigh_compress_eq uses that H is a hyperplane, so the same machinery that yields the codimension-one corollary yields the arbitrary-codimension theorem with zero additional spectral work",
       "Joining the abstract Poincaré inequality (which abstracts away the compression) with the explicit compression (which abstracts away the codimension) removes BOTH the Rayleigh hypothesis and the codimension restriction simultaneously",
       "The main theorem differs from the merged codimension-one compression corollary only in calling poincare_separation rather than the codimension-one assembly — the surrounding spectral plumbing is identical, evidence the abstraction boundaries were drawn at the right place",
-      "Proof-irrelevance of the Fin.mk bounds lets the abstract theorem's ⟨k+m⟩ / ⟨k⟩ conclusion discharge the corollary's goal directly by exact, with no index-coercion rewriting in the main theorem"
+      "Proof-irrelevance of the Fin.mk bounds lets the abstract theorem's ⟨k+m⟩ / ⟨k⟩ conclusion discharge the corollary's goal directly by exact, with no index-coercion rewriting in the main theorem",
+      "The reason no Rayleigh side condition survives is geometric: the orthogonal projection is self-adjoint (P_H = P_H*), so for x in H one has ⟨(compress T H) x, x⟩ = ⟨P_H T x, x⟩ = ⟨T x, P_H x⟩ = ⟨T x, x⟩ — the Rayleigh quotient of the compression agrees with that of T on H by construction. rayleigh_compress_eq packages exactly this identity, which is precisely the hypothesis the abstract Poincaré theorem demanded, so the variational max–min argument applies verbatim to μ"
     ],
     "prerequisites": [
       "The spectral theorem: orthonormal eigenbases and antitone descending eigenvalue families for symmetric operators on finite-dimensional inner product spaces",

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-stability-oq0301-setup",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01",
+    "range": { "startLine": 44, "endLine": 50 },
+    "type": "context",
+    "title": "Setup: A Corollary File over the Weyl Keystone",
+    "content": "The single non-Mathlib import is `Proofs.CauchyInterlacingWeyl`, which supplies `weyl_monotone` (re⟪Tx,x⟫ ≤ re⟪Ux,x⟫ for all x ⟹ μ(k) ≤ ν(k)) — itself a 0-axiom/0-sorry corollary of the Courant–Fischer keystone. Opening `CauchyInterlacing.Weyl` brings that monotonicity theorem into scope so the whole stability bound is assembled from it without re-deriving any spectral theory. The `variable` block fixes an inner product space `E` over `𝕜 : RCLike` (real or complex); crucially the operators below are presented as CONTINUOUS linear maps `E →L[𝕜] E`, so that `‖T − U‖` is the genuine operator norm with the Lipschitz constant 1 the theorem claims — the eigen-presentation is carried to the bare `LinearMap` coercion only where `weyl_monotone` is applied.",
+    "mathContext": "Imports `weyl_monotone : (∀ x, \\mathrm{re}\\langle Tx,x\\rangle \\le \\mathrm{re}\\langle Ux,x\\rangle) \\Rightarrow \\mu_k \\le \\nu_k$; operators are continuous so $\\|T-U\\|$ is the true operator norm.",
+    "significance": "context",
+    "relatedConcepts": ["Weyl monotonicity", "operator norm", "continuous linear map", "module import"],
+    "prerequisites": ["the parent Weyl monotonicity entry", "operator norm on E →L[𝕜] E", "RCLike inner product spaces"]
+  },
+  {
     "id": "ann-stability-oq0301-rayleigh-bound",
     "proofId": "cauchy-interlacing-theorem-oq-03-oq-01",
     "range": { "startLine": 59, "endLine": 71 },

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/meta.json
@@ -117,12 +117,14 @@
   },
   "crossReferences": [
     {
-      "slug": "cauchy-interlacing-theorem-oq-03",
-      "relation": "Parent entry — proves Weyl monotonicity (weyl_monotone) and the additive inequality from the Courant–Fischer keystone, and lists this operator-norm stability bound as its lead open question. This entry closes that question, reusing weyl_monotone verbatim via the Loewner sandwich."
+      "proofId": "cauchy-interlacing-theorem-oq-03",
+      "relationship": "child-of",
+      "description": "Parent entry — proves Weyl monotonicity (weyl_monotone) and the additive inequality from the Courant–Fischer keystone, and lists this operator-norm stability bound as its lead open question. This entry closes that question, reusing weyl_monotone verbatim via the Loewner sandwich."
     },
     {
-      "slug": "cauchy-interlacing-theorem",
-      "relation": "Grandparent entry — proves the Courant–Fischer max–min keystone (eigenvalue_maxmin_lower / eigenvalue_maxmin_upper) on which Weyl monotonicity, and hence this stability bound, ultimately rest."
+      "proofId": "cauchy-interlacing-theorem",
+      "relationship": "builds-on",
+      "description": "Grandparent entry — proves the Courant–Fischer max–min keystone (eigenvalue_maxmin_lower / eigenvalue_maxmin_upper) on which Weyl monotonicity, and hence this stability bound, ultimately rest."
     }
   ],
   "references": [

--- a/src/data/proofs/cayley-hamilton-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-04-oq-01/meta.json
@@ -39,7 +39,8 @@
       "The trace/principal-minor/determinant Cayley–Hamilton identity is NOT what Mathlib's `Matrix.aeval_self_charpoly` provides — that theorem is phrased via the abstract `charpoly` polynomial — so the bare 3×3 identity must be proved from scratch, exactly as in the parent's 2×2 case.",
       "The middle coefficient c₂ is the sum of the three 2×2 principal minors, i.e. the second elementary symmetric function of the eigenvalues; naming it as a definition makes the identity read like the textbook characteristic polynomial X³ − (tr A)X² + c₂X − det A.",
       "Once reduced to entries by `fin_cases` over Fin 3, each of the nine matrix-entry equations is a polynomial identity of degree 3 in the nine entries that `ring` closes, keeping the file self-contained down to the ring axioms.",
-      "The cube reduction A³ = (tr A)·A² − c₂·A + (det A)·1 is the degree-3 linear recurrence underlying closed forms for Aⁿ, matrix exponentials, and resolvents of 3×3 matrices."
+      "The cube reduction A³ = (tr A)·A² − c₂·A + (det A)·1 is the degree-3 linear recurrence underlying closed forms for Aⁿ, matrix exponentials, and resolvents of 3×3 matrices.",
+      "The identity is a polynomial identity over an ARBITRARY commutative ring — no field, no division, no actual eigenvalues are required. The eigenvalue language (tr, c₂, det as e₁, e₂, e₃ of the spectrum) is only heuristic motivation; the entrywise `ring` proof certifies the far more general ring-theoretic statement, which is precisely why it holds for integer, modular, or polynomial-entry matrices that may have no eigenvalues in the base ring at all."
     ],
     "prerequisites": [
       "3×3 matrix arithmetic: trace, determinant, matrix multiplication",
@@ -74,6 +75,22 @@
       "targetId": "cayley-hamilton",
       "relationship": "extends",
       "description": "The 3×3 case of the Cayley–Hamilton theorem, proved explicitly in trace/principal-minor/determinant form."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Cayley, A.",
+      "title": "A Memoir on the Theory of Matrices",
+      "year": "1858",
+      "venue": "Philosophical Transactions of the Royal Society of London, vol. 148, pp. 17–37",
+      "note": "Introduces the theorem now called Cayley–Hamilton and verifies it explicitly for 2×2 and 3×3 matrices by direct computation, declining 'the labour of a formal proof' in general — exactly the 3×3 computation this file formalizes."
+    },
+    {
+      "authors": "Horn, R. A. and Johnson, C. R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "§2.4 (the Cayley–Hamilton theorem) and §1.2 (characteristic polynomial, trace, and the elementary symmetric functions of the eigenvalues as its coefficients)."
     }
   ],
   "sections": [

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-setup-imports",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-01",
+    "range": { "startLine": 30, "endLine": 33 },
+    "type": "context",
+    "title": "Setup: Assembling θ Bounds from Two Project Files",
+    "content": "The two non-Mathlib imports are the load-bearing ones and `open` brings them into scope. `ChebyshevBoundsOQ02OQ01` supplies the substantive lower estimate `chebyshevPsi_lower_linear` ($(\\log 2/3)m \\le \\psi(m)$, from the central binomial coefficient) that Mathlib lacks; `ChebyshevBoundsOQ02OQ02` supplies the closeness bridge `abs_psi_sub_theta_le` ($|\\psi - \\theta| \\le 2\\sqrt{m}\\log m$) and the identification `chebyshevTheta_eq_mathlib` that lets the file reuse Mathlib's upper bound. With both namespaces open the whole entry is pure assembly — no new analytic estimate is proved here; the only work is the linear bookkeeping of subtracting a lower-order term from the $\\psi$ bound.",
+    "mathContext": "$\\theta(m) = \\psi(m) - (\\psi(m) - \\theta(m))$: a strong lower bound on $\\psi$ minus a small upper bound on the gap yields a lower bound on $\\theta$.",
+    "significance": "context",
+    "relatedConcepts": ["module imports", "Chebyshev psi function", "central binomial coefficient", "proof assembly"],
+    "prerequisites": ["the project's ψ lower-bound file", "the ψ−θ closeness file"]
+  },
+  {
     "id": "ann-theta-lower",
     "proofId": "chebyshev-bounds-oq-02-oq-01-oq-01",
     "range": { "startLine": 46, "endLine": 60 },

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-01/meta.json
@@ -117,8 +117,31 @@
     },
     {
       "targetId": "chebyshev-bounds-oq-02",
-      "relationship": "relatedTo",
+      "relationship": "related-to",
       "description": "The parent strand: the second Chebyshev function ψ and Legendre's identity log(n!) = ∑ Λ(d)⌊n/d⌋, the foundation on which the ψ — and now θ — bounds are built."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Chebyshev, P. L.",
+      "title": "Mémoire sur les nombres premiers",
+      "year": "1852",
+      "venue": "Journal de mathématiques pures et appliquées, 1re série, tome 17, pp. 366–390",
+      "note": "The original elementary bounds c₁·n/log n ≤ π(n) ≤ c₂·n/log n, equivalently θ(n), ψ(n) = Θ(n), via the prime factorization of the central binomial coefficient — the method this entry's lower bound descends from."
+    },
+    {
+      "authors": "Apostol, T. M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer, Undergraduate Texts in Mathematics, ch. 4",
+      "note": "The Chebyshev functions θ and ψ, the relation 0 ≤ ψ(x) − θ(x) and its O(√x·log x) size, and Chebyshev-type bounds (Theorems 4.5–4.7)."
+    },
+    {
+      "authors": "Tenenbaum, G.",
+      "title": "Introduction to Analytic and Probabilistic Number Theory",
+      "year": "2015",
+      "venue": "AMS, Graduate Studies in Mathematics 163, 3rd ed., §I.1–I.2",
+      "note": "Modern treatment of Chebyshev's elementary estimates and the passage between θ, ψ, and π."
     }
   ]
 }

--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-setup",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-02",
+    "range": { "startLine": 29, "endLine": 33 },
+    "type": "context",
+    "title": "Setup: Plain Mathlib, No Extra Project Imports",
+    "content": "Unlike the assembly-style siblings, this file imports only `Mathlib` — the generalisation is genuinely self-contained, needing nothing from the two/three-modulus entry it answers. `open Nat` brings the coprime/list-product API (`coprime_list_prod_right_iff`, `Coprime.mul_dvd_of_dvd_of_dvd`, `modEq_iff_dvd'`, `eq_zero_of_dvd_of_lt`) into scope. The whole entry rests on a single list induction over the moduli; the inputs are a `List ℕ` of moduli carrying a `List.Pairwise Nat.Coprime` hypothesis (pairwise, not setwise, coprimality), which the induction consumes one head-relation at a time.",
+    "mathContext": "Inputs: a list $ms : \\mathrm{List}\\,\\mathbb{N}$ with $\\mathrm{List.Pairwise\\ Nat.Coprime}\\ ms$; the goal is divisibility/uniqueness against $ms.\\mathrm{prod} = \\prod_{m \\in ms} m$.",
+    "significance": "context",
+    "relatedConcepts": ["List.Pairwise", "Nat.Coprime", "list induction", "Mathlib Nat namespace"],
+    "prerequisites": ["lists and List.prod", "pairwise relations", "coprimality in ℕ"]
+  },
+  {
     "id": "ann-engine",
     "proofId": "chinese-remainder-constructive-oq-05-oq-02",
     "range": { "startLine": 33, "endLine": 53 },

--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
@@ -107,5 +107,50 @@
       "Pair this uniqueness certificate with an explicit inductive *construction* (folding Nat.chineseRemainder along the list) to obtain full existence-and-uniqueness over an arbitrary list.",
       "Generalise to a Finset or Multiset of moduli, and to the non-coprime case via the lcm in place of the product."
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "chinese-remainder-constructive-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "The sibling whose open question this entry answers: it proves the two- and three-modulus uniqueness certificates (crt_pair_iff, crt_triple_iff); this entry generalises them by list induction to an arbitrary pairwise-coprime list (crt_list_unique)."
+    },
+    {
+      "targetId": "chinese-remainder-constructive-oq-04",
+      "relationship": "related-to",
+      "description": "The list thread the sibling's open question points to; the worked [3,4,5] instance here is included in that thread's example style."
+    },
+    {
+      "targetId": "chinese-remainder-constructive",
+      "relationship": "child-of",
+      "description": "The base constructive CRT entry: existence and uniqueness of a solution modulo the product of pairwise-coprime moduli, of which this is the n-modulus uniqueness half via an inductive certificate."
+    },
+    {
+      "targetId": "chinese-remainder-non-coprime",
+      "relationship": "related-to",
+      "description": "Pursues this entry's second open question — the non-coprime generalisation, where the lcm of the moduli replaces the product."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Sunzi (孫子)",
+      "title": "Sunzi Suanjing (孫子算經, The Mathematical Classic of Sun Zi)",
+      "year": "c. 3rd–5th century CE",
+      "venue": "Chinese mathematical classic",
+      "note": "Earliest known statement of a simultaneous-congruence problem ('there are an unknown number of things; counted by threes, 2 remain…'), the origin of the theorem's name."
+    },
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed., §5.3–5.4",
+      "note": "The Chinese Remainder Theorem for pairwise-coprime moduli, existence and uniqueness modulo the product."
+    },
+    {
+      "authors": "Apostol, T. M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer, Undergraduate Texts in Mathematics, §5.6",
+      "note": "CRT statement and proof, and the structure of residue systems modulo a product of coprime moduli."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `chinese-remainder-constructive-oq-05-oq-02` (pass 0, quality 81).

## Changes
- **crossReferences (new)**: the entry had none. Added four — the sibling `oq-05-oq-01` whose open question this answers (two/three-modulus → arbitrary list), the `oq-04` list thread, the base `chinese-remainder-constructive` entry, and `chinese-remainder-non-coprime` (which pursues this entry's lcm/non-coprime open question). All targets verified to exist in the gallery.
- **references (new)**: the entry had none. Added the *Sunzi Suanjing* (origin of the theorem's name), Hardy & Wright, and Apostol.
- **Annotation coverage**: added a `context` annotation for the previously-unannotated setup region (lines 29–33) — this file imports only Mathlib (self-contained, unlike the assembly-style siblings) and consumes *pairwise* (not setwise) coprimality one head-relation per induction step.

## Verification
- JSON valid; meta.json 12.0 KB (well under caps).
- `pnpm build` passes.

Additive only.