### PR TITLE
research(erdos-1005-oq-02): §18–§19 classical continuant Cassini + coprimality of consecutive continuants [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -1697,4 +1697,111 @@ all-`1` continuant turns *negative*: `K([1,1,1]) = 1 − 1 − 1 = −1`.  Toget
 balanced extreme, the regime where §17's positivity provably does not hold. -/
 theorem continuant_ones_three : Continuant [1, 1, 1] = -1 := by decide
 
+/-! ## §18: The bottom-right entry and the pure-continuant Cassini
+
+§16 identified three of the four entries of the step-matrix product `P(ks)` —
+`.a = Continuant ks`, `.c = secondCont ks`, `.b = −secondCont ks.reverse` — but left
+the bottom-right entry `.d`, the coefficient carrying the Cassini determinant, as an
+opaque matrix entry; the §16 note named "identify `(contMat ks).d` in closed
+continuant form" as the next direction.  This section closes that thread.
+
+Prepending a quotient shifts the matrix down-right, so `.d` of `P(k :: ks)` is just
+the *old* top-right entry `.b` of `P(ks)`: `(P(k::ks)).d = −secondCont ks.reverse`.
+With §16's `.a/.b/.c` this identifies **every** entry of the continuant matrix as a
+signed continuant of a sublist (`contMat_cons_eq`), and turns the §16 determinant
+Cassini into the classical three-term continuant Cassini
+
+`K(L.dropLast)·K(L.tail) − K(L)·K(L.tail.dropLast) = 1`   (`continuant_cassini_classical`)
+
+relating three consecutive continuants of a length-`≥ 2` quotient list `L` — the
+recognizable textbook form of the §16 `det P = 1` invariant, now fully expressed in
+the §14 continuant ladder with no residual matrix entry.
+
+This section is downstream of §16 only (the matrix entries and reversal symmetry);
+it adds no new axioms and introduces no `Continuant`/`secondCont` machinery beyond
+the §14 definitions and the §16 reversal bridge. -/
+
+/-- **The fourth entry.**  Prepending `k` shifts the bottom-right entry to the old
+top-right entry: `(P(k::ks)).d = (P ks).b = −secondCont ks.reverse`.  (Bottom-right
+of `M(k)·X` is `1·X.b + 0·X.d = X.b`, since `M(k) = [[k,−1],[1,0]]`.)  Together with
+§16's `contMat_a/_b/_c` this identifies all four entries of the continuant matrix. -/
+theorem contMat_d (k : ℤ) (ks : List ℤ) :
+    (contMat (k :: ks)).d = - secondCont ks.reverse := by
+  have e : (contMat (k :: ks)).d = (contMat ks).b := by
+    show (Mat2.mul (stepMat k) (contMat ks)).d = (contMat ks).b
+    simp only [Mat2.mul, stepMat]; ring
+  rw [e, contMat_b]
+
+/-- **Full continuant-matrix identification.**  Every entry of the step-matrix
+product is a signed continuant of a sublist:
+`P(k::ks) = [[K(k::ks), −secondCont (k::ks).reverse], [secondCont (k::ks), −secondCont ks.reverse]]`.
+The complete entry-level reading of §16's `contMat`, now including the bottom-right
+corner. -/
+theorem contMat_cons_eq (k : ℤ) (ks : List ℤ) :
+    contMat (k :: ks) =
+      ⟨Continuant (k :: ks), - secondCont (k :: ks).reverse,
+       secondCont (k :: ks), - secondCont ks.reverse⟩ := by
+  ext
+  · exact contMat_a _
+  · exact contMat_b _
+  · exact contMat_c _
+  · exact contMat_d k ks
+
+/-- **Pure-continuant Cassini (no residual matrix entry).**  Spelling out
+`det P(k::ks) = 1` with all four entries now in continuant form gives
+`secondCont (k::ks).reverse · secondCont (k::ks) − Continuant (k::ks) · secondCont ks.reverse = 1`.
+Unlike §16's `continuant_cassini`, every term here is a §14 continuant-ladder value;
+the opaque `(P ks).d` has been eliminated. -/
+theorem continuant_cassini_full (k : ℤ) (ks : List ℤ) :
+    secondCont (k :: ks).reverse * secondCont (k :: ks)
+      - Continuant (k :: ks) * secondCont ks.reverse = 1 := by
+  have h := det_contMat (k :: ks)
+  rw [Mat2.det, contMat_a, contMat_b, contMat_c, contMat_d k ks] at h
+  linear_combination h
+
+/-- `(l.dropLast).reverse = l.reverse.tail` — reversing then dropping the last is
+reversing the tail (a pure `List` rearrangement, via `List.dropLast_reverse`). -/
+theorem dropLast_reverse_eq (l : List ℤ) : (l.dropLast).reverse = l.reverse.tail := by
+  have h := @List.dropLast_reverse ℤ l.reverse
+  rw [List.reverse_reverse] at h
+  rw [h, List.reverse_reverse]
+
+/-- For a nonempty list `m`, `secondCont m = Continuant m.tail` (the defining
+recurrence `secondCont (x :: xs) = Continuant xs`, stated tail-first). -/
+theorem secondCont_eq_continuant_tail {m : List ℤ} (hm : m ≠ []) :
+    secondCont m = Continuant m.tail := by
+  cases m with
+  | nil => exact absurd rfl hm
+  | cons x xs => rfl
+
+/-- **Trailing-of-reverse is the leading continuant.**  For nonempty `l`,
+`secondCont l.reverse = Continuant l.dropLast`: the trailing continuant of the
+reversed list is the *leading* continuant of the original.  (`secondCont` reads the
+tail of the reverse, which is the reverse of the dropLast, and `Continuant` is
+reversal-invariant by §16.)  This is the bridge prose in §16 (`secondCont xs.reverse
+= K(xs.dropLast)`), now a lemma. -/
+theorem secondCont_reverse_eq {l : List ℤ} (hl : l ≠ []) :
+    secondCont l.reverse = Continuant l.dropLast := by
+  have hrev : l.reverse ≠ [] := by simpa using hl
+  rw [secondCont_eq_continuant_tail hrev, ← dropLast_reverse_eq, continuant_reverse]
+
+/-- **Continuant Cassini, classical three-term form (headline).**  For a quotient
+list `L = k :: j :: rest` of length `≥ 2`,
+`K(L.dropLast)·K(L.tail) − K(L)·K(L.tail.dropLast) = 1`.
+This is the textbook continuant Cassini identity — the determinant `det P(L) = 1` of
+§16 rewritten entirely in the §14 continuant ladder, relating the three consecutive
+continuants `K(L.dropLast)`, `K(L)`, `K(L.tail)` and the interior `K(L.tail.dropLast)`.
+It specializes `continuant_cassini_full` through `secondCont_reverse_eq`, completing
+the program of expressing the run-length windows' determinant invariant purely in
+continuants. -/
+theorem continuant_cassini_classical (k j : ℤ) (rest : List ℤ) :
+    Continuant (k :: j :: rest).dropLast * Continuant (k :: j :: rest).tail
+      - Continuant (k :: j :: rest) * Continuant (k :: j :: rest).tail.dropLast = 1 := by
+  have h := continuant_cassini_full k (j :: rest)
+  rw [secondCont_reverse_eq (l := k :: j :: rest) (by simp),
+      secondCont_reverse_eq (l := j :: rest) (by simp)] at h
+  -- `secondCont (k :: j :: rest) = Continuant (j :: rest) = Continuant (k::j::rest).tail`
+  -- and `(k::j::rest).tail.dropLast = (j::rest).dropLast`, both definitional.
+  simpa using h
+
 end Erdos1005OQ02

--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -1804,4 +1804,45 @@ theorem continuant_cassini_classical (k j : ℤ) (rest : List ℤ) :
   -- and `(k::j::rest).tail.dropLast = (j::rest).dropLast`, both definitional.
   simpa using h
 
+/-! ## §19: Coprimality of consecutive continuants (reduced Farey fractions)
+
+The Cassini determinant `det P(ks) = 1` of §16 is, read as a Bézout identity, exactly
+the statement that the continuant pair `(Continuant ks, secondCont ks)` is *coprime*:
+`Continuant ks · (P ks).d + secondCont ks.reverse · secondCont ks = 1` exhibits an
+integer combination of `Continuant ks` and `secondCont ks` equal to `1`.  Since the
+§9 Farey successor is the fraction with numerator/denominator continuants and
+`secondCont (k :: ks) = Continuant ks` (the trailing continuant is the leading
+continuant of the tail), this says **consecutive continuants are coprime** — the
+mediants along a Stern–Brocot / Farey path are automatically in lowest terms, with no
+common factor to cancel.  This is the arithmetic counterpart of §16's geometric
+`det = 1`: unimodularity ⇒ coprimality ⇒ reduced fractions.
+
+This section is a direct corollary of §16 `continuant_cassini`; it adds the Mathlib
+`IsCoprime` API connection and no new axioms. -/
+
+/-- **Consecutive continuants are coprime.**  `IsCoprime (Continuant ks) (secondCont ks)`:
+the §16 Cassini `Continuant ks · (P ks).d + secondCont ks.reverse · secondCont ks = 1`
+is precisely a Bézout witness for coprimality of the continuant pair. -/
+theorem continuant_isCoprime (ks : List ℤ) :
+    IsCoprime (Continuant ks) (secondCont ks) :=
+  ⟨(contMat ks).d, secondCont ks.reverse, by linear_combination continuant_cassini ks⟩
+
+/-- **Reduced Farey fraction (consecutive-continuant form).**  The leading and
+trailing continuants of a nonempty quotient list are coprime:
+`IsCoprime (Continuant (k :: ks)) (Continuant ks)`.  Because the §9 Farey successor
+of a consecutive pair has these two continuants as denominator and numerator, the
+mediant produced along any Stern–Brocot path is automatically in lowest terms. -/
+theorem continuant_tail_isCoprime (k : ℤ) (ks : List ℤ) :
+    IsCoprime (Continuant (k :: ks)) (Continuant ks) := by
+  have h := continuant_isCoprime (k :: ks)
+  rwa [show secondCont (k :: ks) = Continuant ks from rfl] at h
+
+/-- **Coprimality is reversal-symmetric.**  Pairing §16's `continuant_reverse` with
+coprimality: the continuant of a quotient list is coprime to the trailing continuant
+of the reversed list as well — `IsCoprime (Continuant ks) (secondCont ks.reverse)`.
+(The two Bézout cofactors swap roles relative to `continuant_isCoprime`.) -/
+theorem continuant_isCoprime_reverse (ks : List ℤ) :
+    IsCoprime (Continuant ks) (secondCont ks.reverse) :=
+  ⟨(contMat ks).d, secondCont ks, by linear_combination continuant_cassini ks⟩
+
 end Erdos1005OQ02

--- a/research/problems/erdos-1005-oq-02/knowledge.md
+++ b/research/problems/erdos-1005-oq-02/knowledge.md
@@ -43,3 +43,23 @@ read off the top-left of contMat_append. = Euler's K(xs++ys)=K(xs)K(ys)−K(xs.d
 Now have: reversal symmetry, det=1 Cassini, AND the composition law — the full
 classic continuant toolkit, all matrix-derived. Next: closed form for
 (contMat ks).d to fully continuant-express the Cassini; then Stern–Brocot density.
+
+### §18 (researcher-2, follow-up to PR #31095): bottom-right entry + classical Cassini
+Closed the §16 named thread "identify (contMat ks).d in closed continuant form".
+- **contMat_d**: (P(k::ks)).d = (P ks).b = −secondCont ks.reverse. Prepending k
+  shifts bottom-right ← old top-right (M(k)·X bottom-row = [X.a, X.b]). All FOUR
+  entries of the continuant matrix are now signed continuants of sublists
+  (contMat_cons_eq: a=K, b=−secondCont rev, c=secondCont, d=−secondCont(tail rev)).
+- **continuant_cassini_full**: secondCont(k::ks).rev·secondCont(k::ks) −
+  K(k::ks)·secondCont ks.rev = 1 — §16 Cassini with the opaque .d eliminated; every
+  term a §14 continuant-ladder value.
+- **continuant_cassini_classical (headline)**: for L=k::j::rest (len≥2),
+  K(L.dropLast)·K(L.tail) − K(L)·K(L.tail.dropLast) = 1 — the textbook three-term
+  continuant Cassini, det P(L)=1 fully in continuants.
+- Helper bridge: secondCont l.reverse = Continuant l.dropLast (nonempty l), via
+  dropLast_reverse_eq ((l.dropLast).reverse = l.reverse.tail, from
+  List.dropLast_reverse + reverse_reverse) and §16 continuant_reverse.
+GOTCHA: List.dropLast_reverse takes its list IMPLICITLY — use @List.dropLast_reverse ℤ l.
+Verified host `lake env lean` (Docker down), 0 axioms / 0 sorry / 0 native_decide;
+#print axioms of all 5 new thms = [propext, Classical.choice, Quot.sound] only.
+Next: aggregate Cassini windows along a Stern–Brocot path toward the open 1/12 constant.

--- a/research/problems/erdos-1005-oq-02/knowledge.md
+++ b/research/problems/erdos-1005-oq-02/knowledge.md
@@ -63,3 +63,16 @@ GOTCHA: List.dropLast_reverse takes its list IMPLICITLY — use @List.dropLast_r
 Verified host `lake env lean` (Docker down), 0 axioms / 0 sorry / 0 native_decide;
 #print axioms of all 5 new thms = [propext, Classical.choice, Quot.sound] only.
 Next: aggregate Cassini windows along a Stern–Brocot path toward the open 1/12 constant.
+
+### §19 (researcher-2, same PR #31106 as §18): coprimality of consecutive continuants
+The §16 Cassini det P(ks)=1, read as a Bézout identity, IS coprimality:
+- **continuant_isCoprime**: IsCoprime (Continuant ks) (secondCont ks) — witnesses
+  ⟨(contMat ks).d, secondCont ks.reverse⟩, `by linear_combination continuant_cassini ks`.
+- **continuant_tail_isCoprime**: IsCoprime (Continuant (k::ks)) (Continuant ks) —
+  consecutive continuants coprime ⇒ Stern–Brocot/Farey mediants in lowest terms.
+- **continuant_isCoprime_reverse**: IsCoprime (Continuant ks) (secondCont ks.reverse)
+  — the other Farey neighbor (= K(ks.dropLast)); witnesses ⟨(contMat ks).d, secondCont ks⟩.
+GOTCHA: IsCoprime a b = ∃ u v, u*a+v*b=1 — match witness order to the Cassini grouping
+(Continuant·d + secondCont(rev)·secondCont), linear_combination handles commutativity.
+0-axiom (foundational only), host `lake env lean` clean. Arithmetic counterpart of
+§16's geometric det=1: unimodularity ⇒ coprimality ⇒ reduced fractions.


### PR DESCRIPTION
## §18–§19 — Completing the continuant Cassini program

Two short sections extending the §16 continuant-matrix machinery (PR #31083, merged)
into the classical Cassini and its arithmetic corollary. Both depend only on §16's
`continuant_cassini` / reversal symmetry; **no new axioms**.

### §18 — bottom-right entry & the classical Cassini
Closes the §16 named next-direction *"identify `(contMat ks).d` in closed continuant form."*
- **`contMat_d`** — `(P(k::ks)).d = (P ks).b = −secondCont ks.reverse`; prepending a
  quotient shifts the matrix down-right. With §16's `.a/.b/.c` this identifies **all
  four** continuant-matrix entries as signed continuants of sublists (`contMat_cons_eq`).
- **`continuant_cassini_full`** — §16's determinant Cassini with the opaque `.d`
  eliminated; every term a §14 continuant-ladder value.
- **`continuant_cassini_classical`** — the textbook three-term continuant Cassini
  `K(L.dropLast)·K(L.tail) − K(L)·K(L.tail.dropLast) = 1` for `|L| ≥ 2`.
- Bridge lemmas `secondCont_reverse_eq`, `dropLast_reverse_eq`.

### §19 — coprimality of consecutive continuants (reduced Farey fractions)
The Cassini `det P(ks) = 1`, read as a Bézout identity, **is** coprimality:
- **`continuant_isCoprime`** — `IsCoprime (Continuant ks) (secondCont ks)`.
- **`continuant_tail_isCoprime`** — `IsCoprime (Continuant (k::ks)) (Continuant ks)`:
  consecutive continuants are coprime, so the Stern–Brocot / Farey mediants are
  automatically in lowest terms.
- **`continuant_isCoprime_reverse`** — `IsCoprime (Continuant ks) (secondCont ks.reverse)`.

Arithmetic counterpart of §16's geometric `det = 1`: unimodularity ⇒ coprimality ⇒
reduced fractions. Adds the Mathlib `IsCoprime` API connection.

### Verification
- Host `lake env lean` against prebuilt oleans (Docker down): **0 errors**.
- **0 axiom declarations, 0 `sorry`, 0 `native_decide`** added.
- `#print axioms` of all eight new theorems = `{propext, Classical.choice, Quot.sound}`
  only — no `sorryAx`, no `Lean.ofReduceBool`.

### Scope / honesty
Completes the continuant Cassini toolkit (reversal, det=1, composition, full entry
identification, coprimality), all matrix-derived. Does **not** advance the open
`1/12`–`1/4` density count itself; next direction is aggregating these Cassini windows
along a Stern–Brocot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)