### PR TITLE
Enrich Class Equation in Index Form: fix crossReference schema, add sibling link

### DIFF
--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-01/meta.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-01/meta.json
@@ -119,8 +119,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "conjugacy-class-equation-oq-01",
-      "relationship": "Parent entry: supplies the per-class identity |class(g)| = [G : C_G(g)] that is summed here into the index form."
+      "targetId": "conjugacy-class-equation-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: supplies the per-class identity |class(g)| = [G : C_G(g)] that is summed here into the index form."
+    },
+    {
+      "targetId": "conjugacy-class-equation-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling: uses this index form's central application — a nontrivial finite p-group has nontrivial center, because every noncentral term [G : C_G(gᵢ)] is divisible by p, forcing p ∣ |Z(G)|. This entry's first open question is exactly that sibling's result."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `conjugacy-class-equation-oq-01-oq-01`.

## Fix: broken crossReference schema
The single cross-reference used `{ slug, relationship: "<full sentence>" }`. `slug` is not a recognized `CrossReference` field (the type uses `proofId`/`targetId`), and the long description was stuffed into `relationship` — so the parent link did not resolve and rendered a sentence where a relation label belongs. Converted to `{ targetId, relationship: "extends", description }`.

## Enrichment: sibling cross-reference
Added a link to `conjugacy-class-equation-oq-01-oq-02` ("Finite p-Groups Have Nontrivial Center, via the Class Equation") — that sibling is exactly this entry's **first open question** realized (every noncentral `[G : C_G(gᵢ)]` divisible by p ⟹ p ∣ |Z(G)|). Connects the index form to its central application.

## Already strong (left as-is)
overview (with keyInsights + prerequisites), conclusion, 3 full-coverage annotations, references, sections with mathContext, and mathlibDependencies are all complete. No duplicate keys; meta.json ~15 KB, within caps.

## Verification
- JSON parses; `pnpm build` passes.
- Axiom integrity accurate: `status: verified`, `badge: mathlib`, `axiomCount: 0` (#print axioms: propext/Classical.choice/Quot.sound only).