### PR TITLE
research(sperner-mathlib4-oq-02): realize the Tucker tower from concrete door graphs [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerTuckerInductiveTower.lean
+++ b/proofs/Proofs/SpernerTuckerInductiveTower.lean
@@ -199,6 +199,54 @@ theorem tower_boundary_odd (n : ℕ) : Odd (T.boundary (n + 1)) :=
 
 end TuckerTower
 
+/-! ## Realizing the tower from concrete door graphs
+
+The `step` field of `TuckerTower` is not genuinely an open input: for any level
+realized by an actual max-degree-≤2 door graph it is the *theorem*
+`odd_boundary_iff_odd_interior` proved above.  The constructor `ofGraphs` makes this
+precise — it assembles a `TuckerTower` from a family of door graphs `G n` with
+boundary predicates `B n`, discharging `step` automatically, so that **only `bridge`
+and `base` remain as caller inputs**.  Feeding the result through
+`tower_interior_odd` then yields, in fully concrete graph terms, a complementary
+interior simplex in *every* dimension — Tucker's existence conclusion with the
+abstract `step` bookkeeping eliminated. -/
+
+/-- Build a `TuckerTower` from a family of door graphs `G n` (each of max degree
+`≤ 2`) with boundary predicates `B n`.  The single-level `step` field is discharged
+by the engine `odd_boundary_iff_odd_interior`; only the geometric `bridge` and the
+1-D `base` are supplied by the caller — `step` is never an obligation once the levels
+are realized by concrete door graphs. -/
+def TuckerTower.ofGraphs
+    {V : ℕ → Type*} [∀ n, Fintype (V n)]
+    (G : ∀ n, SimpleGraph (V n)) [∀ n, DecidableRel (G n).Adj]
+    (B : ∀ n, V n → Prop) [∀ n, DecidablePred (B n)]
+    (hdeg : ∀ n v, (G n).degree v ≤ 2)
+    (bridge : ∀ n, Odd #(boundaryEndpoints (G (n + 1)) (B (n + 1)))
+                    ↔ Odd #(interiorEndpoints (G n) (B n)))
+    (base : Odd #(interiorEndpoints (G 0) (B 0))) : TuckerTower where
+  boundary := fun n => #(boundaryEndpoints (G n) (B n))
+  interior := fun n => #(interiorEndpoints (G n) (B n))
+  step := fun n => odd_boundary_iff_odd_interior (G n) (B n) (hdeg n)
+  bridge := bridge
+  base := base
+
+/-- **Tucker in every dimension, from concrete door graphs.**  Given a family of
+max-degree-`≤ 2` door graphs with the geometric boundary `bridge` and the verified
+1-D `base`, every level has a degree-1 *interior* (complementary) vertex — Tucker's
+existence conclusion in all dimensions, obtained through `TuckerTower.ofGraphs` with
+the abstract `step` obligation discharged by `odd_boundary_iff_odd_interior`. -/
+theorem exists_interior_of_graph_tower
+    {V : ℕ → Type*} [∀ n, Fintype (V n)]
+    (G : ∀ n, SimpleGraph (V n)) [∀ n, DecidableRel (G n).Adj]
+    (B : ∀ n, V n → Prop) [∀ n, DecidablePred (B n)]
+    (hdeg : ∀ n v, (G n).degree v ≤ 2)
+    (bridge : ∀ n, Odd #(boundaryEndpoints (G (n + 1)) (B (n + 1)))
+                    ↔ Odd #(interiorEndpoints (G n) (B n)))
+    (base : Odd #(interiorEndpoints (G 0) (B 0))) (n : ℕ) :
+    ∃ v, (G n).degree v = 1 ∧ ¬ B n v :=
+  exists_interior_of_odd (G n) (B n)
+    ((TuckerTower.ofGraphs G B hdeg bridge base).tower_interior_odd n)
+
 /-! ## Non-vacuity: an inhabited tower on which the recursion computes
 
 To witness that the structure is inhabited and the induction is not arguing about an

--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -535,3 +535,28 @@ input.
   doors and level-`(n−1)` interior complementary simplices. With `step` and `base`
   already verified, this alone yields full-dimensional Tucker via `tower_interior_odd`.
 - Continuous n≥2 Tucker ⟹ Borsuk–Ulam (mesh→0 + compactness): separate analytic phase.
+
+## Session 2026-06-28 (researcher-2) — realize the abstract tower from concrete door graphs
+
+**Mode**: REVISIT (RICH). Frontier unchanged = the geometric `bridge` (level-`n`
+boundary doors ↔ level-`(n−1)` interior simplices), a hard open construction.
+**Outcome**: progress — extended `SpernerTuckerInductiveTower.lean` (+2 decls, still
+0 sorry / 0 axiom; host `lake env lean` clean, all axioms foundational-only).
+
+Added a **realization layer** showing the abstract `TuckerTower.step` field is never
+an obligation once levels are realized by actual door graphs:
+- `TuckerTower.ofGraphs`: builds a `TuckerTower` from a family `G : ∀n, SimpleGraph (V n)`
+  (max degree ≤2) + boundary preds `B n`, discharging `step` via the engine
+  `odd_boundary_iff_odd_interior`. Only `bridge` + `base` remain caller inputs.
+- `exists_interior_of_graph_tower` (headline): given such a graph family with the
+  geometric `bridge` and 1-D `base`, ∀n ∃ degree-1 interior vertex — Tucker's
+  existence conclusion in EVERY dimension, in concrete graph terms, `step` eliminated.
+
+GOTCHA: `(have T := ofGraphs …; T.interior n)` does NOT reduce — a local hyp of
+structure type is opaque, so `Odd (T.interior n)` won't match `Odd #(interiorEndpoints …)`.
+INLINE the `ofGraphs` application: `(TuckerTower.ofGraphs … ).tower_interior_odd n`
+reduces the projection definitionally (ofGraphs is semireducible). 
+
+This narrows the open surface from {step, bridge, base} to {bridge} (base verified at
+n=1). Frontier for next session is STILL the single geometric `bridge` construction —
+unchanged; this is organizing infrastructure, not new Tucker mathematics.


### PR DESCRIPTION
## Realizing the abstract Tucker tower from concrete door graphs

The `TuckerTower` skeleton (PR #31084) bundles the dimension recursion of the
door-counting proof of Tucker's lemma behind three inputs — `step`, `bridge`, `base`.
Of these, **`step` is not genuinely open**: for any level realized by an actual
max-degree-`≤ 2` door graph it is precisely the engine theorem
`odd_boundary_iff_odd_interior` already proved in this file. This PR makes that explicit.

### What's new (in `SpernerTuckerInductiveTower.lean`)
- **`TuckerTower.ofGraphs`** — assembles a `TuckerTower` from a family of door graphs
  `G n` (each of max degree `≤ 2`) with boundary predicates `B n`, discharging the
  `step` field automatically via `odd_boundary_iff_odd_interior`. Only the geometric
  `bridge` and the 1-D `base` remain as caller inputs.
- **`exists_interior_of_graph_tower`** (headline) — given such a graph family with the
  geometric boundary `bridge` and the verified 1-D `base`, **every dimension** has a
  degree-1 *interior* (complementary) vertex: Tucker's existence conclusion in all
  dimensions, in concrete graph terms, with the abstract `step` bookkeeping eliminated.

This narrows the open-input surface from `{step, bridge, base}` to the single geometric
`bridge` (the boundary-doors ↔ lower-interior-simplices bijection) — `base` being
already verified at `n = 1`.

### Verification
- Host `lake env lean` against prebuilt oleans (Docker down): **0 errors**.
- **0 `sorry`, 0 `axiom` declarations** added.
- `#print axioms exists_interior_of_graph_tower` = `{propext, Classical.choice, Quot.sound}`
  only — no `sorryAx`, no `Lean.ofReduceBool`.

### Honest scope
Organizing infrastructure, **not** new Tucker mathematics. The genuine open lever
remains the geometric `bridge` construction (a triangulation of `Bⁿ` whose boundary
doors biject parity-preservingly with the `(n−1)`-interior simplices), exactly as prior
sessions flagged. Value: `step` is now provably never an obligation, and the end-to-end
"complementary simplex in every dimension" statement is available directly from concrete
graph data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)