### PR TITLE
Enrich Denumerability of ℚ[X]: +2 annotations, fix 3 misaligned ranges

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-06/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-06/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-imports-helper",
     "proofId": "denumerability-rationals-oq-06",
     "range": {
-      "startLine": 29,
-      "endLine": 31
+      "startLine": 31,
+      "endLine": 32
     },
     "type": "key-step",
     "title": "The Engine Lemma #ℚ = ℵ₀",
@@ -26,8 +26,8 @@
     "id": "ann-polynomial-cardinality",
     "proofId": "denumerability-rationals-oq-06",
     "range": {
-      "startLine": 33,
-      "endLine": 40
+      "startLine": 34,
+      "endLine": 41
     },
     "type": "theorem",
     "title": "#(ℚ[X]) = ℵ₀ via the Max Formula",
@@ -49,8 +49,8 @@
     "id": "ann-denumerable-witness",
     "proofId": "denumerability-rationals-oq-06",
     "range": {
-      "startLine": 46,
-      "endLine": 54
+      "startLine": 47,
+      "endLine": 55
     },
     "type": "theorem",
     "title": "An Explicit Bijection ℕ ≃ ℚ[X]",
@@ -66,6 +66,50 @@
     "prerequisites": [
       "equivalences between types",
       "extracting a witness from a Nonempty"
+    ]
+  },
+  {
+    "id": "ann-why-polynomial-ring",
+    "proofId": "denumerability-rationals-oq-06",
+    "range": {
+      "startLine": 3,
+      "endLine": 25
+    },
+    "type": "context",
+    "title": "Why the Polynomial Ring: From Countable ℚ to Countable Algebraic Numbers",
+    "content": "The base denumerability entry and OQ-05 push countability of ℚ through finite products, lists, and finite subsets (#(ℚ×ℚ), #(List ℚ), #(Finset ℚ) all stay ℵ₀), while the function space ℕ → ℚ already jumps to the continuum 𝔠. None of those reach the object that governs *algebraic* countability: the polynomial ring. This entry isolates #(ℚ[X]) = #(ℤ[X]) = ℵ₀ precisely because it is the cardinal fact behind the countability of the algebraic numbers — every algebraic number is a root of some polynomial in ℚ[X], and each polynomial has only finitely many roots, so the algebraic numbers form a countable union of finite sets, hence are countable. OQ-07 pursues that consequence explicitly.",
+    "mathContext": "$\\#(\\mathbb{Q}[X]) = \\aleph_0$, and each $p \\in \\mathbb{Q}[X]$ has finitely many roots, so $\\overline{\\mathbb{Q}} = \\bigcup_{p \\in \\mathbb{Q}[X]} \\{\\text{roots of } p\\}$ is a countable union of finite sets, hence countable.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "algebraic numbers",
+      "countable union of finite sets",
+      "continuum 𝔠",
+      "ℵ₀ stability"
+    ],
+    "prerequisites": [
+      "countability of a type",
+      "cardinal arithmetic"
+    ]
+  },
+  {
+    "id": "ann-rat-eq-int",
+    "proofId": "denumerability-rationals-oq-06",
+    "range": {
+      "startLine": 43,
+      "endLine": 45
+    },
+    "type": "theorem",
+    "title": "ℚ[X] and ℤ[X] Are Equinumerous",
+    "content": "cardinalMk_polynomial_rat_eq_int records #(ℚ[X]) = #(ℤ[X]) as an immediate corollary: both were shown equal to ℵ₀, so they equal each other by transitivity. Slight as it is, it makes explicit that enlarging the coefficient ring from ℤ to ℚ — adjoining all the fractions — does not change the cardinality of the polynomial ring; both remain countably infinite. The same collapse holds for any countably infinite coefficient ring, since the max formula #(R[X]) = max #R ℵ₀ only sees #R through its maximum with ℵ₀.",
+    "mathContext": "$\\#(\\mathbb{Q}[X]) = \\aleph_0 = \\#(\\mathbb{Z}[X])$; more generally $\\#(R[X]) = \\aleph_0$ for every countably infinite ring $R$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "transitivity of cardinal equality",
+      "coefficient ring",
+      "max formula"
+    ],
+    "prerequisites": [
+      "cardinal equality"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `denumerability-rationals-oq-06`.

## Annotation depth (3 → 5)
The entry's meta (overview with keyInsights+prerequisites, conclusion, sections, properly-schema'd crossReferences) was already complete; the gap was annotation coverage. Added two substantive annotations:
- **Why the Polynomial Ring** (module docstring, lines 3–25): motivates the entry — `#(ℚ[X]) = ℵ₀` is the cardinal fact behind the countability of the algebraic numbers (each algebraic number is a root of some `p ∈ ℚ[X]`, finitely many per polynomial ⟹ countable union of finite sets), the thread OQ-07 follows.
- **ℚ[X] and ℤ[X] Are Equinumerous** (lines 43–45): the `cardinalMk_polynomial_rat_eq_int` corollary, previously uncovered.

Both carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

## Accuracy fix: 3 misaligned ranges
The 3 pre-existing annotations had `startLine`s pointing at blank/`open` lines just before each construct's docstring — the resolver reported "No Lean construct found at line N" (a silent accuracy bug). Re-anchored each to its construct's docstring line. `scripts/annotations/resolver.ts validate` now reports **Valid: 5, Misaligned: 0**.

## Verification
- JSON parses; resolver clean; `pnpm build` passes.
- No `index.ts` added (the gallery loads via `listings.json`+`data-manifest.json`; the entry already loads).
- Axiom integrity unchanged: `status: verified`, `axiomCount: 0`.