### PR TITLE
research(abundant-number-oq-02-oq-01): unconditional ω(n)≥7 for odd abundant coprime to 3 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbundantNumberOQ02OQ01Minimality.lean
+++ b/proofs/Proofs/AbundantNumberOQ02OQ01Minimality.lean
@@ -30,8 +30,14 @@
   the six smallest already give `∏ p/(p−1) < 2` while seven exceed 2.  Hence **any odd
   abundant number coprime to 3 has at least 7 distinct prime factors** — the witness
   5391411025 has exactly 8.  The only remaining ingredient is the extremal/monotonicity
-  step (`∏ p/(p−1)` maximised by the smallest primes), recorded as the open follow-up;
-  the brute-force enumeration is *not* needed.
+  step (`∏ p/(p−1)` maximised by the smallest primes); the brute-force enumeration is
+  *not* needed.
+
+  UPDATE (follow-up resolved): the extremal/monotonicity step is now formalised in
+  `AbundantNumberOQ02OQ01Unconditional.lean`, which proves the **unconditional** theorem
+  `odd_abundant_coprime_three_seven_primeFactors :
+       Odd n → ¬ 3 ∣ n → Nat.Abundant n → 7 ≤ n.primeFactors.card` (also 0-axiom),
+  upgrading the conditional reduction below to a complete lower bound on `ω(n)`.
 
   Everything below is axiom-free (only `propext`/`Classical.choice`/`Quot.sound`; no
   `Lean.ofReduceBool`, no `sorry`).

--- a/proofs/Proofs/AbundantNumberOQ02OQ01Unconditional.lean
+++ b/proofs/Proofs/AbundantNumberOQ02OQ01Unconditional.lean
@@ -1,0 +1,266 @@
+/-
+  **Unconditional minimality lower bound.**
+
+  Any odd abundant number coprime to 3 has at least 7 distinct prime factors.
+
+  The companion file `AbundantNumberOQ02OQ01Minimality.lean` reduces the minimality
+  half of "the smallest odd abundant number not divisible by 3 is 5391411025" to a
+  single finite primorial inequality via the elementary Euler abundancy bound
+
+      n abundant  ⟹  2 · ∏_{p∣n}(p−1)  <  ∏_{p∣n} p ,
+
+  and records the **extremal / monotonicity step** ("∏ p/(p−1) is maximised by the
+  smallest primes") as the only remaining open follow-up.  This file closes that gap.
+
+  The engine is a clean list-recursion lemma `dom`:  for a strictly increasing list of
+  primes whose i-th entry dominates the i-th entry of a *gap list* `C` (a list whose
+  consecutive entries are forced apart by primality), the weighted product
+  `∏ p/(p−1)` is bounded by the corresponding product over `C`.  Instantiated at the
+  canonical gap list `[5,7,11,13,17,19]` (the six smallest primes ≥ 5), this gives
+
+      |S| ≤ 6  ⟹  ∏_{p∈S} p/(p−1)  ≤  (5/4)(7/6)(11/10)(13/12)(17/16)(19/18) < 2 ,
+
+  contradicting the Euler bound `∏ p/(p−1) > 2`.  Hence `|S| ≥ 7` with no enumeration.
+
+  Everything is axiom-free (only `propext`/`Classical.choice`/`Quot.sound`; no
+  `Lean.ofReduceBool`, no `native_decide`, no `sorry`).
+-/
+import Mathlib
+import Proofs.AbundantNumberOQ02OQ01Minimality
+
+namespace AbundantNumberOQ02OQ01Unconditional
+
+open AbundantNumberOQ02OQ01Minimality
+open scoped ArithmeticFunction.sigma
+
+/-- The decreasing weight `f p = p/(p−1)` over ℚ (the per-prime factor of `σ(n)/n`). -/
+def f (p : ℕ) : ℚ := (p : ℚ) / ((p : ℚ) - 1)
+
+lemma f_pos {p : ℕ} (hp : 2 ≤ p) : 0 < f p := by
+  have hpc : (2 : ℚ) ≤ (p : ℚ) := by exact_mod_cast hp
+  have hden : (0 : ℚ) < (p : ℚ) - 1 := by linarith
+  unfold f
+  exact div_pos (by linarith) hden
+
+lemma one_le_f {p : ℕ} (hp : 2 ≤ p) : 1 ≤ f p := by
+  have hpc : (2 : ℚ) ≤ (p : ℚ) := by exact_mod_cast hp
+  have hden : (0 : ℚ) < (p : ℚ) - 1 := by linarith
+  unfold f
+  rw [le_div_iff₀ hden]
+  linarith
+
+/-- `f` is antitone on `{p ≥ 2}`: larger primes give smaller weight `p/(p−1)`. -/
+lemma f_antitone {a b : ℕ} (ha : 2 ≤ a) (hab : a ≤ b) : f b ≤ f a := by
+  have hac : (2 : ℚ) ≤ (a : ℚ) := by exact_mod_cast ha
+  have hbc : (a : ℚ) ≤ (b : ℚ) := by exact_mod_cast hab
+  have hda : (0 : ℚ) < (a : ℚ) - 1 := by linarith
+  have hdb : (0 : ℚ) < (b : ℚ) - 1 := by linarith
+  unfold f
+  rw [div_le_div_iff₀ hdb hda]
+  nlinarith [hbc]
+
+/-- The product of weights over a list of integers all `≥ 2` is `≥ 1`. -/
+lemma one_le_listprod_f : ∀ {C : List ℕ}, (∀ c ∈ C, 2 ≤ c) → 1 ≤ (C.map f).prod
+  | [], _ => by simp
+  | c :: rest, h => by
+      simp only [List.map_cons, List.prod_cons]
+      have h1 : 1 ≤ f c := one_le_f (h c (List.mem_cons_self))
+      have h2 : 1 ≤ (rest.map f).prod := one_le_listprod_f (fun x hx => h x (List.mem_cons_of_mem c hx))
+      nlinarith [h1, h2]
+
+/-- **Gap list predicate.**  `GapList C` holds when each entry is `≥ 2` and, for every
+prime `p` strictly above an entry `c₀`, the *next* entry `c₁` already satisfies `c₁ ≤ p`.
+For consecutive primes this is exactly the statement "there is no prime strictly between
+`c₀` and `c₁`". -/
+def GapList : List ℕ → Prop
+  | [] => True
+  | c0 :: rest => 2 ≤ c0 ∧ (∀ p : ℕ, p.Prime → c0 < p → ∀ c1 ∈ rest.head?, c1 ≤ p) ∧ GapList rest
+
+lemma gapList_all_ge_two : ∀ {C : List ℕ}, GapList C → ∀ c ∈ C, 2 ≤ c
+  | [], _ => by intro c hc; simp at hc
+  | _ :: _, h => by
+      intro c hc
+      rcases List.mem_cons.mp hc with rfl | hc'
+      · exact h.1
+      · exact gapList_all_ge_two h.2.2 c hc'
+
+/-- **Domination lemma (the heart).**  If `L` is a strictly increasing list of primes,
+every entry of `L` is at least the corresponding gap-list floor (`C.head?` advancing along
+the gaps), and `L` is no longer than the gap list `C`, then the weighted product over `L`
+is bounded by the weighted product over `C`. -/
+lemma dom : ∀ (C L : List ℕ),
+    L.Pairwise (· < ·) →
+    (∀ x ∈ L, x.Prime) →
+    (∀ x ∈ L, ∀ c0 ∈ C.head?, c0 ≤ x) →
+    L.length ≤ C.length →
+    GapList C →
+    (L.map f).prod ≤ (C.map f).prod := by
+  intro C L
+  induction L generalizing C with
+  | nil =>
+      intro _ _ _ _ hG
+      simp only [List.map_nil, List.prod_nil]
+      exact one_le_listprod_f (gapList_all_ge_two hG)
+  | cons a L' ih =>
+      intro hpair hprime hfloor hlen hG
+      cases C with
+      | nil => simp only [List.length_nil, List.length_cons] at hlen; omega
+      | cons c0 C1 =>
+          obtain ⟨hc0, hgap, hG1⟩ := hG
+          have hac0 : c0 ≤ a := hfloor a (List.mem_cons_self) c0 (by simp)
+          have hfa : f a ≤ f c0 := f_antitone hc0 hac0
+          have hpc := List.pairwise_cons.mp hpair
+          have hlt : ∀ x ∈ L', a < x := hpc.1
+          have hpair' : L'.Pairwise (· < ·) := hpc.2
+          have hprime' : ∀ x ∈ L', x.Prime := fun x hx => hprime x (List.mem_cons_of_mem a hx)
+          have hfloor' : ∀ x ∈ L', ∀ c1 ∈ C1.head?, c1 ≤ x := by
+            intro x hx c1 hc1
+            have hpx : x.Prime := hprime' x hx
+            have hc0x : c0 < x := lt_of_le_of_lt hac0 (hlt x hx)
+            exact hgap x hpx hc0x c1 hc1
+          have hlen' : L'.length ≤ C1.length := by
+            simp only [List.length_cons] at hlen; omega
+          have hIH : (L'.map f).prod ≤ (C1.map f).prod := ih C1 hpair' hprime' hfloor' hlen' hG1
+          have hnn : 0 ≤ (L'.map f).prod :=
+            le_trans (by norm_num) (one_le_listprod_f (fun x hx => (hprime' x hx).two_le))
+          have hfc0nn : 0 ≤ f c0 := le_of_lt (f_pos hc0)
+          simp only [List.map_cons, List.prod_cons]
+          exact mul_le_mul hfa hIH hnn hfc0nn
+
+/-! ### Prime-gap facts for the canonical list `[5,7,11,13,17,19]` -/
+
+lemma gap5 (p : ℕ) (hp : p.Prime) (h : 5 < p) : 7 ≤ p := by
+  rcases Nat.lt_or_ge p 7 with h7 | h7
+  · interval_cases p
+    · exact absurd hp (by decide)
+  · exact h7
+
+lemma gap7 (p : ℕ) (hp : p.Prime) (h : 7 < p) : 11 ≤ p := by
+  rcases Nat.lt_or_ge p 11 with h11 | h11
+  · interval_cases p
+    all_goals exact absurd hp (by decide)
+  · exact h11
+
+lemma gap11 (p : ℕ) (hp : p.Prime) (h : 11 < p) : 13 ≤ p := by
+  rcases Nat.lt_or_ge p 13 with h13 | h13
+  · interval_cases p
+    all_goals exact absurd hp (by decide)
+  · exact h13
+
+lemma gap13 (p : ℕ) (hp : p.Prime) (h : 13 < p) : 17 ≤ p := by
+  rcases Nat.lt_or_ge p 17 with h17 | h17
+  · interval_cases p
+    all_goals exact absurd hp (by decide)
+  · exact h17
+
+lemma gap17 (p : ℕ) (hp : p.Prime) (h : 17 < p) : 19 ≤ p := by
+  rcases Nat.lt_or_ge p 19 with h19 | h19
+  · interval_cases p
+    all_goals exact absurd hp (by decide)
+  · exact h19
+
+/-- The six smallest primes `≥ 5` form a gap list. -/
+lemma gapList_canon : GapList [5, 7, 11, 13, 17, 19] := by
+  refine ⟨by norm_num, ?_, by norm_num, ?_, by norm_num, ?_, by norm_num, ?_, by norm_num, ?_,
+          by norm_num, ?_, trivial⟩
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap5 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap7 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap11 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap13 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap17 p hp h
+  · intro p hp h c1 hc1; simp at hc1
+
+/-- The canonical product `(5/4)(7/6)(11/10)(13/12)(17/16)(19/18) = 1616615/829440 < 2`. -/
+lemma canon_prod_lt_two : (([5, 7, 11, 13, 17, 19] : List ℕ).map f).prod < 2 := by
+  simp only [List.map_cons, List.map_nil, List.prod_cons, List.prod_nil, f]
+  norm_num
+
+/-- **Main theorem (unconditional).**  Every odd abundant number coprime to 3 has at
+least 7 distinct prime factors.  No enumeration of the 5.4-billion range is used: the
+bound comes from the Euler abundancy inequality plus the canonical primorial gap list. -/
+theorem odd_abundant_coprime_three_seven_primeFactors
+    {n : ℕ} (hodd : Odd n) (h3 : ¬ (3 ∣ n)) (habund : Nat.Abundant n) :
+    7 ≤ n.primeFactors.card := by
+  by_contra hlt
+  push_neg at hlt
+  have hcard6 : n.primeFactors.card ≤ 6 := by omega
+  set S := n.primeFactors with hS
+  -- every prime factor is ≥ 5 (odd ⟹ ≠ 2; coprime to 3 ⟹ ≠ 3; prime ≥ 2 ⟹ ≥ 5)
+  have hge5 : ∀ p ∈ S, 5 ≤ p := by
+    intro p hp
+    have hpp : p.Prime := Nat.prime_of_mem_primeFactors hp
+    have hpn : p ∣ n := Nat.dvd_of_mem_primeFactors hp
+    have h2 : p ≠ 2 := by
+      rintro rfl
+      obtain ⟨k, hk⟩ := hodd
+      obtain ⟨m, hm⟩ := hpn
+      omega
+    have h3' : p ≠ 3 := by rintro rfl; exact h3 hpn
+    have hp2 := hpp.two_le
+    rcases Nat.lt_or_ge p 5 with h5 | h5
+    · interval_cases p
+      · exact absurd rfl h2
+      · exact absurd rfl h3'
+      · exact absurd hpp (by decide)
+    · exact h5
+  -- the Euler bound from the companion file
+  have hineq : 2 * ∏ p ∈ S, (p - 1) < ∏ p ∈ S, p :=
+    abundant_imp_two_mul_prod_sub_one_lt habund
+  -- ∏ p/(p-1) equals the product over the sorted list of prime factors
+  have hprodF : ((S.sort (· ≤ ·)).map f).prod = ∏ p ∈ S, f p := by
+    rw [← Finset.prod_map_toList S f]
+    exact List.Perm.prod_eq ((Finset.sort_perm_toList S (· ≤ ·)).map f)
+  -- sorted list is strictly increasing
+  have hLpair : (S.sort (· ≤ ·)).Pairwise (· < ·) := by
+    have hsorted : List.Pairwise (· ≤ ·) (S.sort (· ≤ ·)) := Finset.pairwise_sort S (· ≤ ·)
+    have hnodup : (S.sort (· ≤ ·)).Nodup := Finset.sort_nodup S (· ≤ ·)
+    exact (hsorted.and hnodup).imp (fun h => lt_of_le_of_ne h.1 h.2)
+  have hLprime : ∀ x ∈ S.sort (· ≤ ·), x.Prime := by
+    intro x hx
+    rw [Finset.mem_sort] at hx
+    exact Nat.prime_of_mem_primeFactors (hS ▸ hx)
+  have hLfloor : ∀ x ∈ S.sort (· ≤ ·), ∀ c0 ∈ ([5, 7, 11, 13, 17, 19] : List ℕ).head?, c0 ≤ x := by
+    intro x hx c0 hc0
+    simp only [List.head?_cons, Option.mem_some_iff] at hc0
+    subst hc0
+    rw [Finset.mem_sort] at hx
+    exact hge5 x hx
+  have hLlen : (S.sort (· ≤ ·)).length ≤ ([5, 7, 11, 13, 17, 19] : List ℕ).length := by
+    rw [Finset.length_sort]
+    simpa using hcard6
+  have hdomprod : ((S.sort (· ≤ ·)).map f).prod ≤ (([5, 7, 11, 13, 17, 19] : List ℕ).map f).prod :=
+    dom [5, 7, 11, 13, 17, 19] (S.sort (· ≤ ·)) hLpair hLprime hLfloor hLlen gapList_canon
+  have hprodlt : (∏ p ∈ S, f p) < 2 := by
+    rw [← hprodF]; exact lt_of_le_of_lt hdomprod canon_prod_lt_two
+  -- the Euler bound forces the same product to exceed 2
+  have hMpos : 0 < ∏ p ∈ S, ((p : ℚ) - 1) := by
+    apply Finset.prod_pos
+    intro p hp
+    have h5p : 5 ≤ p := hge5 p hp
+    have : (5 : ℚ) ≤ (p : ℚ) := by exact_mod_cast h5p
+    linarith
+  have hfprod_eq : (∏ p ∈ S, f p) = (∏ p ∈ S, (p : ℚ)) / (∏ p ∈ S, ((p : ℚ) - 1)) := by
+    simp only [f]
+    rw [Finset.prod_div_distrib]
+  have hcastM : ((∏ p ∈ S, (p - 1) : ℕ) : ℚ) = ∏ p ∈ S, ((p : ℚ) - 1) := by
+    rw [Nat.cast_prod]
+    refine Finset.prod_congr rfl (fun p hp => ?_)
+    have h1p : 1 ≤ p := le_trans (by norm_num) (hge5 p hp)
+    rw [Nat.cast_sub h1p, Nat.cast_one]
+  have hcastN : ((∏ p ∈ S, p : ℕ) : ℚ) = ∏ p ∈ S, (p : ℚ) := by rw [Nat.cast_prod]
+  have hineqQ : 2 * (∏ p ∈ S, ((p : ℚ) - 1)) < ∏ p ∈ S, (p : ℚ) := by
+    have hc : ((2 * ∏ p ∈ S, (p - 1) : ℕ) : ℚ) < ((∏ p ∈ S, p : ℕ) : ℚ) := by exact_mod_cast hineq
+    rwa [Nat.cast_mul, Nat.cast_ofNat, hcastM, hcastN] at hc
+  have key : 2 * (∏ p ∈ S, ((p : ℚ) - 1)) < (∏ p ∈ S, f p) * (∏ p ∈ S, ((p : ℚ) - 1)) := by
+    have heq : (∏ p ∈ S, f p) * (∏ p ∈ S, ((p : ℚ) - 1)) = ∏ p ∈ S, (p : ℚ) := by
+      rw [hfprod_eq, div_mul_cancel₀]
+      exact ne_of_gt hMpos
+    rw [heq]; exact hineqQ
+  have hgt : 2 < ∏ p ∈ S, f p := lt_of_mul_lt_mul_right key (le_of_lt hMpos)
+  linarith [hprodlt, hgt]
+
+-- Axiom audit: only the foundational axioms (`propext`, `Classical.choice`, `Quot.sound`);
+-- in particular NO `Lean.ofReduceBool` (no `native_decide`) and NO `sorryAx`.
+#print axioms odd_abundant_coprime_three_seven_primeFactors
+
+end AbundantNumberOQ02OQ01Unconditional

--- a/research/problems/abundant-number-oq-02-oq-01/knowledge.md
+++ b/research/problems/abundant-number-oq-02-oq-01/knowledge.md
@@ -65,3 +65,45 @@ prime-counting fact provable by `decide` on small thresholds. This is the record
 - **"8 distinct primes" as a clean threshold**: false. Seven distinct primes ≥ 5 can already
   give `∏ p/(p−1) > 2` (with large enough exponents), so the method delivers ≥ 7, not ≥ 8;
   the witness attaining 8 is about *size*, not about the prime-count lower bound.
+
+---
+
+## Session 2026-06-28 (Session 2) — Extremal step CLOSED, result now unconditional
+
+**Mode**: REVISIT (follow-up on own merged work #30378) · **Outcome**: progress (major)
+
+### What I did
+- Closed the recorded next step: formalized the extremal/monotonicity lemma and combined it
+  with `abundant_imp_two_mul_prod_sub_one_lt` to get the **unconditional** theorem
+  `odd_abundant_coprime_three_seven_primeFactors`:
+  `Odd n → ¬ 3 ∣ n → Nat.Abundant n → 7 ≤ n.primeFactors.card`.
+- New file `Proofs/AbundantNumberOQ02OQ01Unconditional.lean` (imports the minimality module).
+- Verified 0-axiom via host `lake env lean` on a self-contained inlined copy:
+  `#print axioms` → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`).
+
+### Key technique (what worked)
+- Do the extremal argument as a **list recursion over ℚ**, not a Finset optimization:
+  - `f p = p/(p−1)` is antitone on `p ≥ 2`.
+  - `GapList` predicate: a list whose consecutive entries `c₀,c₁` satisfy "no prime strictly
+    between them" (`∀ p prime, c₀ < p → c₁ ≤ p`). `[5,7,11,13,17,19]` is one; each gap is a
+    one-line `interval_cases p; decide`.
+  - `dom`: sort `n.primeFactors`, peel the head, advance a per-rank floor along the gap list;
+    per-term `f`-domination + product monotonicity give `∏ f ≤ ∏_{gap list} f`.
+  - Canonical product `(5/4)(7/6)(11/10)(13/12)(17/16)(19/18) = 1616615/829440 < 2` by `norm_num`.
+- Linking back to the ℕ Euler bound: `∏ p/(p−1) = (∏ p)/(∏(p−1))` over ℚ
+  (`Finset.prod_div_distrib`); cast `2·∏(p−1) < ∏ p` up and cancel the positive denominator
+  with `lt_of_mul_lt_mul_right`. No division-inequality lemma required.
+
+### Why primality is essential (recorded so it is not re-attempted naively)
+- `(5/4)^6 ≈ 3.81 > 2`, and six distinct *integers* ≥ 5 can telescope to `2.5 > 2` (e.g. `5..10`).
+  Only coprimality-to-6 forces the i-th smallest prime factor ≥ the i-th prime ≥ 5, i.e. the
+  gap-list domination. The gap list is where all the number theory lives.
+
+### Lean artefacts
+- `Proofs/AbundantNumberOQ02OQ01Unconditional.lean`: `f`, `f_pos`, `one_le_f`, `f_antitone`,
+  `one_le_listprod_f`, `GapList`, `gapList_all_ge_two`, `dom`, `gap5/gap7/gap11/gap13/gap17`,
+  `gapList_canon`, `canon_prod_lt_two`, `odd_abundant_coprime_three_seven_primeFactors`.
+
+### Next steps
+- The ≥7 bound is a lower bound on ω(n); the full numeric minimality (smallest = 5391411025)
+  is a separate, harder claim and remains open.

--- a/research/problems/abundant-number-oq-02-oq-01/state.md
+++ b/research/problems/abundant-number-oq-02-oq-01/state.md
@@ -1,25 +1,29 @@
 # Research State: abundant-number-oq-02-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-27T15:29:18-07:00
-**Iteration**: 1
+**Since**: 2026-06-28
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Extremal/monotonicity follow-up CLOSED. The unconditional lower bound
+`odd_abundant_coprime_three_seven_primeFactors` (Odd n → ¬3∣n → Abundant n → 7 ≤ ω(n))
+is proved and verified 0-axiom.
 
 ## Active Approach
-None yet.
+List-recursion extremal lemma over ℚ (`dom`) instantiated at the primorial gap list
+`[5,7,11,13,17,19]`, combined with the ℕ Euler abundancy bound from the minimality file.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 1 (succeeded)
 
 ## Blockers
-None.
+None for the ω(n) ≥ 7 lower bound. The full numeric minimality (smallest odd abundant
+number coprime to 3 = 5391411025) is a separate, harder claim and remains open.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Optional generalizations (other small-prime exclusions via different gap lists), or an
+optional short gallery entry pairing the witness with this minimality lower bound.

--- a/src/data/research/problems/abundant-number-oq-02-oq-01.json
+++ b/src/data/research/problems/abundant-number-oq-02-oq-01.json
@@ -29,24 +29,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: witness half VERIFIED (0-axiom); minimality reduced structurally to a finite primorial inequality, giving >=7 distinct prime factors (no 5.4e9 enumeration).",
+    "progressSummary": "PROGRESS (unconditional): the extremal/monotonicity follow-up is now CLOSED. odd_abundant_coprime_three_seven_primeFactors proves UNCONDITIONALLY that any odd abundant number coprime to 3 has >=7 distinct prime factors, fully verified 0-axiom (no native_decide, no enumeration of the 5.4e9 range).",
     "builtItems": [
       "geomSum_mul_pred_lt (per-prime-power Euler bound) in Proofs/AbundantNumberOQ02OQ01Minimality.lean",
       "sigma_mul_prod_sub_one_lt (Euler abundancy bound, N form) in Proofs/AbundantNumberOQ02OQ01Minimality.lean",
       "abundant_imp_two_mul_prod_sub_one_lt (abundance => primorial inequality) in Proofs/AbundantNumberOQ02OQ01Minimality.lean",
       "six_primes_below_two / seven_primes_above_two (numeric boundary anchors) in Proofs/AbundantNumberOQ02OQ01Minimality.lean",
-      "Fixed two norm_num gaps in the witness file Proofs/AbundantNumberOQ02OQ01.lean (sigma_N, abundant_N) which previously left sorryAx; now 0-axiom."
+      "Fixed two norm_num gaps in the witness file Proofs/AbundantNumberOQ02OQ01.lean (sigma_N, abundant_N) which previously left sorryAx; now 0-axiom.",
+      "dom (domination lemma): for a strictly increasing list of primes whose i-th entry dominates a gap-list floor, the weighted product prod p/(p-1) is bounded by the product over the gap list. Proof by list recursion with f antitone. In Proofs/AbundantNumberOQ02OQ01Unconditional.lean",
+      "GapList predicate + gapList_canon: [5,7,11,13,17,19] is a primorial gap list (consecutive entries forced apart by primality via gap5/gap7/gap11/gap13/gap17). In Proofs/AbundantNumberOQ02OQ01Unconditional.lean",
+      "canon_prod_lt_two: (5/4)(7/6)(11/10)(13/12)(17/16)(19/18) = 1616615/829440 < 2 (norm_num). In Proofs/AbundantNumberOQ02OQ01Unconditional.lean",
+      "odd_abundant_coprime_three_seven_primeFactors (MAIN, unconditional, 0-axiom): Odd n -> not 3|n -> Abundant n -> 7 <= n.primeFactors.card. In Proofs/AbundantNumberOQ02OQ01Unconditional.lean"
     ],
     "insights": [
       "Euler abundancy bound holds purely over N: for n>1, sigma(n)*prod_{p|n}(p-1) < n*prod_{p|n} p. Proved multiplicatively from (sum_{i<=a} p^i)*(p-1)=p^{a+1}-1 (Mathlib geom_sum_mul_add, valid in any semiring). No native_decide.",
       "Abundance reduces to a primorial inequality independent of the size of n: n abundant => 2*prod_{p|n}(p-1) < prod_{p|n} p. This eliminates any need to enumerate the ~5.4e9 range claimed unavoidable in the witness file header.",
-      "For odd n coprime to 3 all prime factors are >=5; the six smallest such primes give prod p/(p-1) = 1.949 < 2 and seven give 2.038 > 2, so the smallest odd abundant number coprime to 3 must have >=7 distinct prime factors (witness 5391411025 has exactly 8)."
+      "For odd n coprime to 3 all prime factors are >=5; the six smallest such primes give prod p/(p-1) = 1.949 < 2 and seven give 2.038 > 2, so the smallest odd abundant number coprime to 3 must have >=7 distinct prime factors (witness 5391411025 has exactly 8).",
+      "The extremal step is cleanest as a list recursion in Q (not a Finset optimization): sort the prime factors, peel the head, advance a per-rank floor along a gap list. f(p)=p/(p-1) antitone + per-term domination + product monotonicity. The gap list [5,7,11,13,17,19] encodes the only nontrivial number theory (no prime strictly between consecutive entries), each gap discharged by interval_cases+decide.",
+      "Crude bounds fail: (5/4)^6 ~= 3.81 > 2, and 6 distinct INTEGERS >=5 can telescope to 2.5 > 2 (e.g. 5..10). Primality (coprimality to 6) is essential: it forces the i-th smallest prime factor >= the i-th prime >=5, which is exactly the gap-list domination.",
+      "Linking the Q ratio product to the N Euler bound: prod_{p in S} p/(p-1) = (prod p)/(prod (p-1)) over Q (Finset.prod_div_distrib), and 2*prod(p-1) < prod p in N casts up; cancel the positive denominator with lt_of_mul_lt_mul_right. No division-inequality lemma needed."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Formalize: for a finite set S of distinct primes all >=5, prod_{p in S} p/(p-1) is maximised by taking the |S| smallest such primes (uses monotonicity of p/(p-1) and p_i >= i-th smallest prime >=5, the latter by decide on prime-counting below small thresholds).",
-      "Combine with abundant_imp_two_mul_prod_sub_one_lt to get unconditional: odd abundant n coprime to 3 => n.primeFactors.card >= 7.",
-      "Consider submitting the extremal step to Aristotle as a HARD sorry if the Finset extremal argument proves tedious."
+      "Optional: extend the gap-list method to bound omega(n) for odd abundant n with other small-prime exclusions (e.g. coprime to 15) — same dom lemma, different canonical gap list.",
+      "Optional gallery: the unconditional >=7 result could anchor a short gallery entry on Euler abundancy bounds, pairing the witness (oq-02) with this minimality lower bound.",
+      "The full minimality claim (smallest is exactly 5391411025) still needs the matching upper structure; >=7 prime factors is the proven lower bound on omega, not the full numeric minimality."
     ],
     "markdown": "# Knowledge Base: abundant-number-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Closes the **extremal/monotonicity follow-up** left open by the structural minimality reduction in #30378, upgrading the conditional result to an **unconditional, fully verified theorem**:

```lean
theorem odd_abundant_coprime_three_seven_primeFactors
    {n : ℕ} (hodd : Odd n) (h3 : ¬ (3 ∣ n)) (habund : Nat.Abundant n) :
    7 ≤ n.primeFactors.card
```

> Every odd abundant number coprime to 3 has at least 7 distinct prime factors.

The witness `5391411025 = 5²·7·11·13·17·19·23·29` (proved abundant in `AbundantNumberOQ02OQ01.lean`) has exactly 8, so the bound is non-vacuous and near-tight. **No enumeration of the ~5.4·10⁹ range** is used.

## Method

- `f p = p/(p−1)` over ℚ is antitone on `p ≥ 2`.
- `GapList` predicate: a list whose consecutive entries `c₀,c₁` admit *no prime strictly between them* (`∀ p prime, c₀ < p → c₁ ≤ p`). The six smallest primes ≥ 5, `[5,7,11,13,17,19]`, form one — each gap discharged by `interval_cases p; decide`.
- `dom` (the heart): sort `n.primeFactors`, peel the head, advance a per-rank floor along the gap list; per-term antitonicity + product monotonicity give `∏_{p∈S} f p ≤ ∏_{gap list} f`.
- Canonical product `(5/4)(7/6)(11/10)(13/12)(17/16)(19/18) = 1616615/829440 < 2` (`norm_num`).
- Link to the ℕ Euler abundancy bound `abundant_imp_two_mul_prod_sub_one_lt` (from #30378): `∏ p/(p−1) = (∏ p)/(∏(p−1))` over ℚ, cast `2·∏(p−1) < ∏ p` up, cancel the positive denominator. So `∏ f p > 2`, contradicting `≤ 6` factors.

**Why primality is essential** (not crude bounds): `(5/4)^6 ≈ 3.81 > 2`, and six distinct *integers* ≥ 5 can telescope to `2.5 > 2` (e.g. `5..10`). Only coprimality forces the i-th smallest prime factor ≥ the i-th prime ≥ 5 — exactly the gap-list domination.

## Verification

- `#print axioms odd_abundant_coprime_three_seven_primeFactors` → `[propext, Classical.choice, Quot.sound]`.
- **0-axiom**: no `sorryAx`, no `Lean.ofReduceBool` (no `native_decide`), no `sorry`.
- Checked end-to-end via host `lake env lean` (Docker unavailable): the new file with its real `import Proofs.AbundantNumberOQ02OQ01Minimality` compiles clean against the dependency.

## Files

- `proofs/Proofs/AbundantNumberOQ02OQ01Unconditional.lean` (new): full proof.
- `proofs/Proofs/AbundantNumberOQ02OQ01Minimality.lean`: comment-only cross-reference to the resolved follow-up.
- Research knowledge updates (`knowledge.md`, `state.md`, `*.json`).

The full numeric minimality (smallest such number = 5391411025) remains open; this PR proves the lower bound on ω(n), not the complete minimality claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)