### PR TITLE
Enrich Dirichlet OQ-04 (Kronecker density): finer-grained proof annotations

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04/annotations.json
@@ -67,5 +67,76 @@
       "fractional parts accumulating at 0"
     ],
     "significance": "Converts the abstract density statement into the recognizable homogeneous Diophantine bound — the existence of arbitrarily good integer multiples near 0 — by reading the circle norm as distance to ℤ."
+  },
+  {
+    "id": "ann-small-circle-point",
+    "proofId": "dirichlet-approximation-theorem-oq-04",
+    "range": {
+      "startLine": 63,
+      "endLine": 73
+    },
+    "type": "technique",
+    "title": "Building a Nonzero Circle Point of Known Norm",
+    "content": "Before invoking density we manufacture an explicit nonzero target inside the ball: δ = min(ε,1)/2, so 0 < δ ≤ 1/2 and δ < ε. The cap at 1/2 is the crucial detail. The characterisation AddCircle.norm_coe_eq_abs_iff says ‖(↑x : AddCircle 1)‖ = |x| only while |x| ≤ 1/2 — i.e. within the fundamental domain (−1/2, 1/2] where the quotient map ℝ → ℝ/ℤ is an isometry. Capping δ at 1/2 (the role of the min with 1) keeps us there, so the abstract circle norm of ↑δ coincides exactly with the concrete real number δ. Without the cap a large ε could push δ past 1/2, where the norm wraps back toward 0 and ‖↑δ‖ ≠ δ. Knowing the norm exactly then gives both ↑δ ≠ 0 (positive norm) and ‖↑δ‖ < ε.",
+    "mathContext": "$\\delta = \\tfrac12\\min(\\varepsilon,1) \\in (0, \\tfrac12]$, and on $|x| \\le \\tfrac12$ the quotient is isometric: $\\|(\\,\\uparrow\\! x : \\mathbb{R}/\\mathbb{Z})\\| = |x|$, so $\\|\\uparrow\\!\\delta\\| = \\delta < \\varepsilon$.",
+    "prerequisites": [
+      "AddCircle.norm_coe_eq_abs_iff and the fundamental domain (−1/2, 1/2] of ℝ/ℤ",
+      "The quotient map ℝ → ℝ/ℤ is a local isometry near 0"
+    ],
+    "relatedConcepts": [
+      "fundamental domain",
+      "quotient norm",
+      "local isometry",
+      "circle metric"
+    ],
+    "significance": "Pins the circle norm of the auxiliary point to an exact real value, which is what certifies the point is simultaneously nonzero and within ε of 0 — the seed the density extraction needs."
+  },
+  {
+    "id": "ann-punctured-ball",
+    "proofId": "dirichlet-approximation-theorem-oq-04",
+    "range": {
+      "startLine": 74,
+      "endLine": 90
+    },
+    "type": "technique",
+    "title": "Why the Ball Must Be Punctured",
+    "content": "The set fed to density is the open punctured ball B(0,ε) ∖ {0}: open as an open ball minus a closed singleton (isOpen_ball.sdiff isClosed_singleton), and nonempty because the point ↑δ built above lives in it. DenseRange.exists_mem_open then returns a multiplier k with ↑(k·a) in the set, giving both ‖↑(k·a)‖ < ε and ↑(k·a) ≠ 0. The puncture is not cosmetic: removing 0 is exactly what forces k ≠ 0. With the full ball B(0,ε), density would be trivially satisfied by k = 0 (since 0·a maps to 0), yielding the vacuous approximation n = 0. By insisting the orbit point be nonzero, the argument (rintro rfl on k = 0 contradicts ↑(0·a) ≠ 0) guarantees a genuine positive-integer witness.",
+    "mathContext": "Open punctured ball $B(0,\\varepsilon)\\setminus\\{0\\}$; density meets it at $\\uparrow\\!(k\\cdot a)$ with $0 < \\|\\uparrow\\!(k\\cdot a)\\| < \\varepsilon$, hence $k \\ne 0$.",
+    "prerequisites": [
+      "DenseRange.exists_mem_open: a dense range meets every nonempty open set",
+      "isOpen_ball, isClosed_singleton and IsOpen.sdiff",
+      "An open ball minus a point is still open"
+    ],
+    "relatedConcepts": [
+      "dense range",
+      "punctured neighbourhood",
+      "nontrivial approximation",
+      "open set"
+    ],
+    "significance": "Isolates the single most important design choice in the proof — puncturing the ball — which upgrades a vacuous density hit at 0 into a genuine nonzero approximation."
+  },
+  {
+    "id": "ann-sign-normalisation",
+    "proofId": "dirichlet-approximation-theorem-oq-04",
+    "range": {
+      "startLine": 91,
+      "endLine": 105
+    },
+    "type": "technique",
+    "title": "From an Integer Witness to a Positive-Natural One",
+    "content": "Density supplied an integer multiplier k, but the theorem asks for a positive natural n. Set n = |k| = k.natAbs, positive because k ≠ 0 (Int.natAbs_pos). The goal |n·a − round(n·a)| is rewritten as a circle norm by AddCircle.norm_eq at period 1: with p = 1 the formula ‖(x : AddCircle p)‖ = |x − round(p⁻¹·x)·p| collapses (inv_one, one_mul, mul_one) to ‖(x : AddCircle 1)‖ = |x − round x|. It then remains to match ‖↑(n·a)‖ to the known bound ‖↑(k·a)‖. Since n = |k| equals either k or −k (abs_choice), a two-case split handles the sign: in the negative case neg_mul, AddCircle.coe_neg and norm_neg use that the circle norm is symmetric under negation, ‖−x‖ = ‖x‖, so the two norms agree and hbound finishes the proof.",
+    "mathContext": "$n = |k|$; $\\|(x:\\mathbb{R}/\\mathbb{Z})\\| = |x - \\operatorname{round} x|$ (period 1), and $\\|-x\\| = \\|x\\|$ aligns $n\\cdot a$ with $k\\cdot a$.",
+    "prerequisites": [
+      "Int.natAbs, Int.natAbs_pos and abs_choice for the sign case-split",
+      "AddCircle.norm_eq specialised to period 1, and norm_neg / AddCircle.coe_neg",
+      "round as the nearest-integer function"
+    ],
+    "relatedConcepts": [
+      "natAbs",
+      "norm symmetry under negation",
+      "nearest-integer distance",
+      "period-1 normalisation"
+    ],
+    "significance": "Closes the gap between the abstract circle statement and the requested elementary form — a positive integer and the explicit distance |n·a − round(n·a)| — via the symmetry of the circle norm."
   }
 ]


### PR DESCRIPTION
Enrichment pass for `dirichlet-approximation-theorem-oq-04` (quality 81, pass 0).

> Note: this re-submits the Dirichlet enrichment originally opened as #31113. That PR's branch was reused and force-pushed for the next target (erdos-1204), so #31113 ended up squash-merging the erdos commit instead. This PR restores the Dirichlet work on a dedicated per-target branch.

The entry's meta.json is already rich (16.6 KB, within all caps; full overview, conclusion, 4 cross-references, sections covering the whole file), so no meta deepening was warranted. The one genuine gap was **annotation granularity**: the 52-line corollary proof (lines 54–106) was covered by a single broad annotation.

## Changes
- Added 3 **technique** annotations on the corollary's distinct phases, raising coverage from 3 → 6 annotations:
  1. **Building a nonzero circle point of known norm** (63–73) — why δ is capped at 1/2 (the fundamental-domain isometry where ‖↑x‖ = |x|).
  2. **Why the ball must be punctured** (74–90) — removing 0 forces the multiplier k ≠ 0, turning a vacuous density hit into a genuine nonzero approximation.
  3. **From an integer witness to a positive-natural one** (91–105) — natAbs, the period-1 AddCircle.norm_eq read-back, and the sign case-split using ‖−x‖ = ‖x‖.
- Each carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- meta.json unchanged.

## Verification
- `annotations.json` valid JSON, 6 annotations
- `pnpm build` — ✓ built

🤖 Generated with [Claude Code](https://claude.com/claude-code)