### PR TITLE
audit(erdos-1011-oq-01): badge original→mathlib (Tier B Mathlib bridge)

### DIFF
--- a/src/data/proofs/erdos-1011-oq-01/meta.json
+++ b/src/data/proofs/erdos-1011-oq-01/meta.json
@@ -19,7 +19,7 @@
       "axiom-elimination",
       "open-question-resolved"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 105,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `erdos-1011-oq-01` — "Mantel's Theorem — the Triangle Case, Axiom-Free"
**Severity**: MEDIUM (Mathlib wrapper claimed as `original`)

## Problem

The entry was badged `verified/**original**`, but it is a **Tier B Mathlib bridge**. Its core result is a one-line specialization of Mathlib's Turán theorem:

```lean
theorem triangleFree_card_edgeFinset_le (hG : G.CliqueFree 3) :
    G.edgeFinset.card ≤ Fintype.card V ^ 2 / 4 := by
  have h := hG.card_edgeFinset_le (r := 2)   -- Mathlib's Turán bound does the work
  ...
```

The file's own docstring is honest about this:
> "The hard work — Turán's theorem itself — lives in Mathlib. The contribution of this file is to *connect* that machinery to the exact triangle statement…"

Per the auditor skill (Failure Mode #5: "0 sorries with hidden imports" + Tier B rules), a 0-sorry proof whose **core** result comes from a deep Mathlib theorem must use badge `mathlib`, not `original`.

## Evidence

- `meta.badge`: `original` → should be `mathlib`
- `meta.mathlibDependencies` already lists `SimpleGraph.CliqueFree.card_edgeFinset_le` (= the Turán bound) and `card_edgeFinset_turanGraph`.
- `originalContributions`: none.
- Precedent: sibling `frobenius-endomorphism-oq-01-oq-03` (also a Mathlib bridge) is correctly `verified/mathlib`.

## Fix

`meta.badge`: `original` → `mathlib`. Nothing else changes.

- `status` stays `verified` — the entry is genuinely 0-axiom / 0-sorry (matching the `verified/mathlib` frobenius precedent).
- The description, `mathlibDependencies`, and honest-scope prose already credit Mathlib correctly; only the badge field overstated independence.

---
Discovered during gallery integrity audit (auditor cycleV38, main @12712241b0c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)