### PR TITLE
Enrich Erdős #12 local obstruction: fix invalid significance, +prerequisites, +2 annotations

### DIFF
--- a/src/data/proofs/erdos-12-wip-01/annotations.json
+++ b/src/data/proofs/erdos-12-wip-01/annotations.json
@@ -31,8 +31,32 @@
     "title": "Residue-Level Obstruction: No Antipodal Pair mod a",
     "content": "Rephrasing a ∣ (b + c) as (b + c) % a = 0, no two distinct larger elements are antipodal mod a. This is the residue picture: around each a ∈ A, the larger elements avoid complementary residue pairs mod a — the local reason these sets are sparse.",
     "mathContext": "No distinct $b, c > a$ in $A$ with $b + c \\equiv 0 \\pmod a$.",
-    "significance": "important",
+    "significance": "key",
     "relatedConcepts": ["residues mod a", "additive combinatorics", "complementary residue pairs"],
     "prerequisites": ["Nat.dvd_of_mod_eq_zero"]
+  },
+  {
+    "id": "ann-unique-larger-multiple",
+    "proofId": "erdos-12-wip-01",
+    "range": { "startLine": 57, "endLine": 70 },
+    "type": "theorem",
+    "title": "At Most One Larger Multiple per Element",
+    "content": "Specializing the core obstruction at the residue 0 gives the cleanest structural consequence. `unique_larger_multiple` proves that any two larger multiples of `a` in `A` must coincide (b = c): assuming b ≠ c contradicts `no_two_larger_multiples`. `largerMultiples_subsingleton` packages this as a set statement — `{b ∈ A : a < b ∧ a ∣ b}` is a Subsingleton (at most one element). So every element `a ∈ A` admits at most one larger multiple in the set, the first quantitative bite of the sparsity obstruction.",
+    "mathContext": "$\\#\\{b \\in A : a < b \\wedge a \\mid b\\} \\le 1$ for each $a \\in A$.",
+    "significance": "key",
+    "relatedConcepts": ["subsingleton", "uniqueness", "local density obstruction"],
+    "prerequisites": ["by_contra", "Set.Subsingleton"]
+  },
+  {
+    "id": "ann-witness-456",
+    "proofId": "erdos-12-wip-01",
+    "range": { "startLine": 81, "endLine": 88 },
+    "type": "theorem",
+    "title": "A Concrete Witness: {4, 5, 6} Is Divisibility-Free",
+    "content": "`divFree_456` certifies that the predicate is non-vacuously satisfiable: the set {4, 5, 6} is divisibility-free. The proof is a finite case bash — `rcases` over the three membership disjunctions for a, b, c, then `omega` — and the only genuinely nontrivial constraint is 4 ∤ (5 + 6) = 11. Without such a witness the local-obstruction theorems could be vacuously true; this anchors them to a real example.",
+    "mathContext": "$\\{4,5,6\\}$ is divisibility-free; the sole nontrivial check is $4 \\nmid 5+6 = 11$.",
+    "significance": "supporting",
+    "relatedConcepts": ["non-vacuous satisfiability", "finite case analysis", "omega"],
+    "prerequisites": ["Set membership in finite sets", "the omega decision procedure"]
   }
 ]

--- a/src/data/proofs/erdos-12-wip-01/meta.json
+++ b/src/data/proofs/erdos-12-wip-01/meta.json
@@ -56,6 +56,12 @@
       "Specializing antipodality to the residue 0 gives the cleanest consequence: at most one larger element of A is a multiple of a.",
       "This is the local reason divisibility-free sets are sparse — each element forbids a positive fraction of residues for its larger neighbours — and is the elementary core beneath the (hard) global density theorems.",
       "The obstruction is purely a one-line application of dvd_add; the value is in naming and packaging the structure, not in proof depth."
+    ],
+    "prerequisites": [
+      "Divisibility on ℕ and dvd_add (a ∣ b, a ∣ c ⟹ a ∣ b+c)",
+      "The Erdős #12 divisibility-free predicate (see the gallery entry erdos-12)",
+      "Residues mod a and Nat.dvd_of_mod_eq_zero",
+      "Subsingleton sets and subset monotonicity of the predicate"
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `erdos-12-wip-01`.

## Fixes
- **Invalid significance (render bug)**: `ann-no-antipodal-pair` had `significance: "important"`, which is not an `AnnotationSignificance` enum value (`critical|key|supporting`) — `AnnotationPanel.tsx` renders a blank badge for it. Set `key`.
- **Missing overview `prerequisites`**: added 4 (divisibility/`dvd_add`, the Erdős #12 predicate, residues/`Nat.dvd_of_mod_eq_zero`, subsingletons/monotonicity).

## Annotation depth (3 → 5)
Covered two previously-unannotated parts of the file:
- **At Most One Larger Multiple per Element** (`unique_larger_multiple` / `largerMultiples_subsingleton`, lines 57–70) — the subsingleton consequence of the core obstruction.
- **A Concrete Witness: {4,5,6}** (`divFree_456`, lines 81–88) — non-vacuous satisfiability (sole nontrivial check 4 ∤ 11).

Both carry full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

## Verification
- `scripts/annotations/resolver.ts validate` → **Valid: 5, Misaligned: 0**; all significance values valid enums; `pnpm build` passes.
- No `index.ts` change; axiom integrity unchanged (`status: verified`, `badge: original`, `axiomCount: 0`).