### PR TITLE
Enrich Keith Numbers in Arbitrary Bases: annotation depth + fix invalid significance/type

### DIFF
--- a/src/data/proofs/keith-number-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/keith-number-oq-01-oq-02/annotations.json
@@ -11,6 +11,12 @@
     "content": "The parent entry defines a **Keith number** through a sliding-window recurrence over its *decimal* digits and proves the smallest one is $14$. The recurrence itself — drop the oldest window term, append the window sum, stop when you hit the target — never mentions a base; only the seed digits do. So a base-$b$ Keith number is an $N$ with at least two base-$b$ digits whose base-$b$ digit recurrence reaches $N$.\n\nThis follow-up reparametrizes only the digit extraction: $\\texttt{lsdDigitsB}\\ b$ peels base-$b$ digits ($n \\bmod b$, $n / b$) while the window dynamics $\\texttt{step}/\\texttt{reaches}$ are inherited verbatim from the parent.",
     "mathContext": "The parent (`keith-number-oq-01`) explicitly raised generalizing `IsKeith` to an arbitrary base as an open question; this entry answers it.",
     "significance": "key",
+    "relatedConcepts": [
+      "Keith numbers",
+      "positional numeral systems",
+      "Fibonacci-like recurrences",
+      "generalizing a definition across bases"
+    ],
     "prerequisites": [
       "positional (base-b) digit representations",
       "Fibonacci-like linear recurrences",
@@ -29,7 +35,16 @@
     "content": "$\\texttt{lsdDigitsB}\\ b\\ \\textit{fuel}\\ n$ extracts base-$b$ digits least-significant first by structural recursion on $\\textit{fuel}$, and $\\texttt{msdDigitsB}\\ b\\ n = (\\texttt{lsdDigitsB}\\ b\\ n\\ n).\\texttt{reverse}$. The predicate is\n$$\\texttt{IsKeithBase}\\ b\\ n \\;:=\\; b \\le n \\;\\wedge\\; \\texttt{reaches}\\ n\\ 40\\ (\\texttt{msdDigitsB}\\ b\\ n) = \\texttt{true},$$\nwhere $b \\le n$ is the 'at least two base-$b$ digits' condition. A `DecidablePred (IsKeithBase b)` instance is supplied so concrete claims reduce under `decide`.",
     "mathContext": "Keeping `lsdDigitsB` fuel-bounded (rather than using Mathlib's well-founded `Nat.digits`) is what keeps the base-b decision procedure kernel-reducible and the result axiom-free.",
     "significance": "key",
-    "prerequisites": []
+    "relatedConcepts": [
+      "base-b digit extraction",
+      "fuel-bounded structural recursion",
+      "DecidablePred",
+      "kernel reduction (decide)"
+    ],
+    "prerequisites": [
+      "structural recursion with a fuel parameter",
+      "Decidable instances and the decide tactic"
+    ]
   },
   {
     "id": "keithb-ann-recovery",
@@ -43,6 +58,12 @@
     "content": "`lsdDigitsB 10` and the parent's `lsdDigits` are different recursive definitions, so their agreement is *proved*, not assumed: $\\texttt{lsdDigitsB\\_ten}$ shows $\\texttt{lsdDigitsB}\\ 10\\ \\textit{fuel}\\ n = \\texttt{lsdDigits}\\ \\textit{fuel}\\ n$ by induction on $\\textit{fuel}$. Lifting through the reverse gives $\\texttt{msdDigitsB\\_ten}$ and then the bridge $\\texttt{isKeithBase\\_ten} : \\texttt{IsKeithBase}\\ 10\\ n \\leftrightarrow \\texttt{IsKeith}\\ n$. The set equality $\\{n \\mid \\texttt{IsKeithBase}\\ 10\\ n\\} = \\{n \\mid \\texttt{IsKeith}\\ n\\}$ then transports the parent's theorem to $\\texttt{smallest\\_keithBase10} : \\texttt{IsLeast}\\ \\{n \\mid \\texttt{IsKeithBase}\\ 10\\ n\\}\\ 14$.",
     "mathContext": "Confirms the generalization specializes correctly: the base-10 instance is exactly the classical Keith predicate.",
     "significance": "key",
+    "relatedConcepts": [
+      "definitional agreement proof",
+      "induction on a fuel parameter",
+      "IsLeast",
+      "transporting a theorem along an iff"
+    ],
     "prerequisites": [
       "induction on a fuel parameter",
       "set-builder equality and `IsLeast`"
@@ -55,11 +76,20 @@
       "startLine": 98,
       "endLine": 116
     },
-    "type": "observation",
+    "type": "insight",
     "title": "Small Keith Numbers in Other Bases",
     "content": "Other bases admit their own small Keith numbers, confirmed directly by `decide`: $5 = (11)_4$ runs the window $1,1,2,3,5$ and is Keith in base $4$ ($\\texttt{keithBase4\\_five}$), and $13 = (11)_{12}$ is Keith in base $12$. With $\\texttt{not\\_keithBase4\\_below\\_five}$ this yields $\\texttt{smallest\\_keithBase4} : \\texttt{IsLeast}\\ \\{n \\mid \\texttt{IsKeithBase}\\ 4\\ n\\}\\ 5$ — the base-4 analogue of $14$ in base $10$. The two-digit $(11)_b$ window is the Fibonacci sequence $1,1,2,3,5,8,\\dots$, so $(11)_b$ is Keith exactly when $b+1$ is a Fibonacci number (e.g. $4+1=5$, $12+1=13$).",
     "mathContext": "The smallest base-b Keith number depends on b and can be far below the decimal minimum 14.",
-    "significance": "standard",
-    "prerequisites": []
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fibonacci numbers",
+      "repunit (11)_b",
+      "base-dependent extremal values",
+      "the decide tactic"
+    ],
+    "prerequisites": [
+      "the Fibonacci sequence",
+      "decision procedures via decide"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `keith-number-oq-01-oq-02`.

## Annotation depth (the role's #1 mission)
All 4 annotations had `content`/`mathContext` but were **missing `relatedConcepts` entirely** (the relatedConcepts quality component was 0), and two had empty `prerequisites`. Added `relatedConcepts` to all 4 and filled the 2 empty `prerequisites` arrays. All four are now depth-complete.

## Render/validity fixes
- `keithb-ann-otherbases` had `significance: "standard"` — not a valid `AnnotationSignificance` enum (`critical|key|supporting`), so `AnnotationPanel.tsx` rendered a blank badge. Set `supporting`.
- Changed its `type` from `observation` to the valid `insight`.

## Already strong (left as-is)
overview (with keyInsights + prerequisites), conclusion, 4 sections, and properly-schema'd crossReferences were complete. meta.json ~15 KB, within caps.

## Verification
- `scripts/annotations/resolver.ts validate` → **Valid: 4, Misaligned: 0**; all significance values valid enums; `pnpm build` passes.
- No `index.ts` change; axiom integrity unchanged (`status: verified`, `badge: original`, `axiomCount: 0`).