### PR TITLE
research(erdos-837-oq-05): prove zero_is_jump supersaturation, eliminate sorry [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos837Problem.lean
+++ b/proofs/Proofs/Erdos837Problem.lean
@@ -47,19 +47,19 @@ def densityJumpSet (k : ℕ) : Set ℝ :=
 
 /- ## Known Results -/
 
-/-- **Erdős–Stone–Simonovits (graphs)**: For k = 2,
+/- **Erdős–Stone–Simonovits (graphs)**: For k = 2,
     A_2 = {1 − 1/m : m ≥ 1} = {0, 1/2, 2/3, 3/4, ...}.
     Each jump value corresponds to a Turán density. -/
 
-/-- **Turán connection**: The jumps in A_2 correspond exactly to
+/- **Turán connection**: The jumps in A_2 correspond exactly to
     the Turán densities π(K_{m+1}) = 1 − 1/m. -/
 
 /- ## Main Question -/
 
-/-- **Erdős Problem #837**: What is A_3? Determine the set of
+/- **Erdős Problem #837**: What is A_3? Determine the set of
     density jump values for 3-uniform hypergraphs. -/
 
-/-- **Is 0 a jump for 3-uniform hypergraphs?** This is related
+/- **Is 0 a jump for 3-uniform hypergraphs?** This is related
     to the hypergraph Turán problem. -/
 
 /- ## Observations -/

--- a/proofs/Proofs/Erdos837ProblemOQ05.lean
+++ b/proofs/Proofs/Erdos837ProblemOQ05.lean
@@ -1,7 +1,4 @@
-import Mathlib.Order.LiminfLimsup
-import Mathlib.Topology.Instances.Real
-import Mathlib.Data.Nat.Choose.Basic
-import Mathlib.Tactic
+import Mathlib
 import Proofs.Erdos837Problem
 
 /-
@@ -24,6 +21,17 @@ diverging vertex count.
 - Encodes the "subhypergraph" condition via vertex/edge count bounds
 - States A_2 membership for Turán densities (axiomatized)
 
+## Status of zero_is_jump
+The supersaturation lemma `zero_is_jump` (0 ∈ A_k for k ≥ 2) is now
+**fully proved** in the counting model, with no `sorry`. The construction
+is the natural one: given any sequence Gₙ whose liminf edge-density is
+positive and whose vertex count diverges, one extracts subhypergraphs Hₙ
+of density exactly 1 by taking the largest admissible vertex set
+(`Nat.findGreatest`) on which a complete k-uniform hypergraph fits inside
+the edge budget e(Gₙ). Positivity of the liminf density forces
+e(Gₙ) → ∞, which makes the extracted vertex count diverge. Thus β = 1
+witnesses the jump for every such sequence, uniformly.
+
 ## Limitations
 The `KUniformHypergraph` type from the parent is a simple record of counts,
 not a full hypergraph structure. A proper formalization would use
@@ -31,6 +39,8 @@ not a full hypergraph structure. A proper formalization would use
 correct for the counting model.
 
 ## Axiom Count: 1
+The single remaining assumption is `erdos_stone_simonovits`, the deep
+Erdős–Stone–Simonovits characterization A_2 = {1 − 1/m : m ≥ 1}.
 -/
 
 open Filter Set
@@ -91,9 +101,13 @@ noncomputable def turanDensity (m : ℕ) : ℝ := 1 - 1 / (m : ℝ)
 /-- Turán densities are in [0, 1). -/
 theorem turanDensity_mem_Ico (m : ℕ) (hm : m ≥ 1) :
     turanDensity m ∈ Ico (0 : ℝ) 1 := by
-  constructor
-  · simp [turanDensity]; positivity
-  · simp [turanDensity]; positivity
+  have hm1 : (1:ℝ) ≤ (m:ℝ) := by exact_mod_cast hm
+  have hmpos : (0:ℝ) < (m:ℝ) := by linarith
+  unfold turanDensity
+  refine ⟨?_, ?_⟩
+  · rw [sub_nonneg, div_le_one hmpos]; exact hm1
+  · have : 0 < 1 / (m:ℝ) := by positivity
+    linarith
 
 /-- **Erdős-Stone-Simonovits theorem** (axiomatized):
     A_2 = {1 - 1/m : m ≥ 1} = {0, 1/2, 2/3, 3/4, ...}
@@ -104,15 +118,145 @@ axiom erdos_stone_simonovits :
     densityJumpSetLiminf 2 = {α : ℝ | ∃ m : ℕ, m ≥ 1 ∧ α = turanDensity m}
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION IV: Properties of A_k
+-- SECTION IV: Supersaturation infrastructure
 -- ═══════════════════════════════════════════════════════════════
 
-/-- 0 is always a density jump (for k ≥ 2): any positive density forces
-    denser subhypergraphs. This is the "supersaturation" phenomenon. -/
+/-- For a fixed arity `k ≥ 1`, the binomial coefficient `m.choose k`
+    diverges to infinity as `m → ∞`. This is the quantitative engine
+    behind supersaturation: a positive edge density on a growing vertex
+    set forces the raw edge count to diverge. -/
+theorem choose_tendsto_atTop {k : ℕ} (hk : 1 ≤ k) :
+    Tendsto (fun m : ℕ => (m.choose k : ℝ)) atTop atTop := by
+  apply tendsto_atTop_mono' atTop
+    (f₁ := fun m : ℕ => ((m + 1 - k : ℕ) : ℝ) ^ k / (k.factorial : ℝ))
+  · filter_upwards with m
+    have := Nat.pow_le_choose (α := ℝ) k m
+    simpa using this
+  · have h1 : Tendsto (fun m : ℕ => (m + 1 - k : ℕ)) atTop atTop := by
+      rw [tendsto_atTop]; intro b
+      filter_upwards [eventually_ge_atTop (b + k)] with m hm; omega
+    have h2 : Tendsto (fun m : ℕ => ((m + 1 - k : ℕ) : ℝ)) atTop atTop :=
+      tendsto_natCast_atTop_atTop.comp h1
+    have h3 : Tendsto (fun m : ℕ => ((m + 1 - k : ℕ) : ℝ) ^ k) atTop atTop :=
+      (tendsto_pow_atTop (Nat.one_le_iff_ne_zero.mp hk)).comp h2
+    exact h3.atTop_div_const (by positivity)
+
+/-- Edge density is always nonnegative. -/
+theorem edgeDensity_nonneg (G : KUniformHypergraph) : 0 ≤ edgeDensity G := by
+  unfold edgeDensity; split_ifs with h
+  · exact le_refl 0
+  · positivity
+
+-- ═══════════════════════════════════════════════════════════════
+-- SECTION V: Properties of A_k
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **0 is always a density jump (for k ≥ 2)**: any sequence of
+    k-uniform hypergraphs with positive liminf density and diverging
+    vertex count admits subhypergraphs of liminf density exactly 1.
+
+    This is the "supersaturation" phenomenon, here proved in full for
+    the counting model. The witness jump value is β = 1.
+
+    Construction: from a positive liminf density `0 < L` and diverging
+    vertex count we obtain `e(Gₙ) → ∞`. We then set `Hₙ` to be the
+    complete k-uniform hypergraph on the largest vertex count
+    `vₙ ≤ |Gₙ|` for which `C(vₙ, k) ≤ e(Gₙ)`; this has density 1, fits
+    inside `Gₙ`, and `vₙ → ∞`. -/
 theorem zero_is_jump (k : ℕ) (hk : k ≥ 2) :
     0 ∈ densityJumpSetLiminf k := by
-  refine ⟨le_refl 0, by linarith, ?_⟩
-  sorry -- Supersaturation: any positive density forces β > 0
+  classical
+  have hk1 : 1 ≤ k := by omega
+  refine ⟨le_refl 0, by norm_num, ?_⟩
+  -- Witness jump value β = 1.
+  refine ⟨1, by norm_num, le_refl 1, ?_⟩
+  intro G hunif hverts hdens
+  -- Positive liminf density, and a strictly smaller positive threshold c.
+  set L := liminf (fun n => edgeDensity (G n)) atTop with hL
+  have hLpos : 0 < L := hdens
+  set c : ℝ := L / 2 with hc
+  have hc0 : 0 < c := by rw [hc]; linarith
+  have hbdd : IsBoundedUnder (· ≥ ·) atTop (fun n => edgeDensity (G n)) :=
+    isBoundedUnder_of ⟨0, fun n => edgeDensity_nonneg (G n)⟩
+  -- Eventually the density exceeds c.
+  have hev_dens : ∀ᶠ n in atTop, c < edgeDensity (G n) := by
+    have hlt : c < L := by rw [hc]; linarith
+    exact eventually_lt_of_lt_liminf (by rw [← hL]; exact hlt) hbdd
+  -- Eventually `c · C(|Gₙ|, k) < e(Gₙ)`.
+  have hev_edges : ∀ᶠ n in atTop,
+      c * ((G n).vertices.choose k : ℝ) < ((G n).edges : ℝ) := by
+    filter_upwards [hev_dens] with n hn
+    have hun := hunif n
+    unfold edgeDensity at hn
+    simp only [binom, hun] at hn
+    by_cases hb : (G n).vertices.choose k = 0
+    · rw [if_pos hb] at hn; linarith
+    · rw [if_neg hb] at hn
+      have hcpos : (0:ℝ) < ((G n).vertices.choose k : ℝ) := by
+        exact_mod_cast Nat.pos_of_ne_zero hb
+      rw [lt_div_iff₀ hcpos] at hn
+      exact hn
+  -- Vertex count diverges as a ℕ-sequence.
+  have hvN : Tendsto (fun n => (G n).vertices) atTop atTop := by
+    rw [tendsto_atTop]; intro b
+    filter_upwards [hverts.eventually (eventually_ge_atTop (b:ℝ))] with n hn
+    exact_mod_cast hn
+  -- Hence `C(|Gₙ|, k) → ∞`, so `c · C(|Gₙ|, k) → ∞`, so `e(Gₙ) → ∞`.
+  have hverts_choose : Tendsto (fun n => ((G n).vertices.choose k : ℝ)) atTop atTop :=
+    (choose_tendsto_atTop hk1).comp hvN
+  have hc_choose : Tendsto (fun n => c * ((G n).vertices.choose k : ℝ)) atTop atTop :=
+    hverts_choose.const_mul_atTop hc0
+  have hedges : Tendsto (fun n => ((G n).edges : ℝ)) atTop atTop := by
+    apply tendsto_atTop_mono' atTop _ hc_choose
+    filter_upwards [hev_edges] with n hn using le_of_lt hn
+  -- Construct Hₙ: the complete k-uniform hypergraph on the largest
+  -- admissible vertex count.
+  set v : ℕ → ℕ :=
+    fun n => Nat.findGreatest (fun w => w.choose k ≤ (G n).edges) (G n).vertices with hv
+  refine ⟨fun n => ⟨v n, (v n).choose k, k⟩, fun n => rfl, ?_, ?_, ?_, ?_⟩
+  · -- vertices of H ≤ vertices of G
+    intro n; exact Nat.findGreatest_le _
+  · -- edges of H ≤ edges of G (the empty hypergraph w = 0 witnesses admissibility)
+    intro n
+    show (v n).choose k ≤ (G n).edges
+    rw [hv]
+    refine Nat.findGreatest_spec (P := fun w => w.choose k ≤ (G n).edges)
+      (m := 0) (Nat.zero_le _) ?_
+    simp [Nat.choose_eq_zero_of_lt (show 0 < k by omega)]
+  · -- vertices of H diverge
+    have hvdiv : Tendsto v atTop atTop := by
+      rw [tendsto_atTop]; intro M
+      have e1 : ∀ᶠ n in atTop, M ≤ (G n).vertices := by
+        filter_upwards [hvN.eventually (eventually_ge_atTop M)] with n hn; exact hn
+      have e2 : ∀ᶠ n in atTop, (M.choose k : ℝ) ≤ ((G n).edges : ℝ) :=
+        hedges.eventually (eventually_ge_atTop (M.choose k : ℝ))
+      filter_upwards [e1, e2] with n hn1 hn2
+      have hn2' : M.choose k ≤ (G n).edges := by exact_mod_cast hn2
+      exact Nat.le_findGreatest hn1 hn2'
+    exact tendsto_natCast_atTop_atTop.comp hvdiv
+  · -- liminf density of H equals 1 (≥ β = 1)
+    have hev1 : ∀ᶠ n in atTop,
+        edgeDensity (⟨v n, (v n).choose k, k⟩ : KUniformHypergraph) = 1 := by
+      have hk_le : ∀ᶠ n in atTop, k ≤ v n := by
+        have hvdiv : Tendsto v atTop atTop := by
+          rw [tendsto_atTop]; intro M
+          have e1 : ∀ᶠ n in atTop, M ≤ (G n).vertices := by
+            filter_upwards [hvN.eventually (eventually_ge_atTop M)] with n hn; exact hn
+          have e2 : ∀ᶠ n in atTop, (M.choose k : ℝ) ≤ ((G n).edges : ℝ) :=
+            hedges.eventually (eventually_ge_atTop (M.choose k : ℝ))
+          filter_upwards [e1, e2] with n hn1 hn2
+          have hn2' : M.choose k ≤ (G n).edges := by exact_mod_cast hn2
+          exact Nat.le_findGreatest hn1 hn2'
+        exact hvdiv.eventually (eventually_ge_atTop k)
+      filter_upwards [hk_le] with n hn
+      have hcne : (v n).choose k ≠ 0 := by
+        have := Nat.choose_pos hn; omega
+      show edgeDensity (⟨v n, (v n).choose k, k⟩ : KUniformHypergraph) = 1
+      unfold edgeDensity
+      simp only [binom]
+      rw [if_neg hcne]
+      rw [div_self (by exact_mod_cast hcne)]
+    rw [liminf_congr hev1, liminf_const]
 
 /-- The density jump set is contained in [0, 1). -/
 theorem densityJumpSet_subset_Ico (k : ℕ) :
@@ -121,7 +265,7 @@ theorem densityJumpSet_subset_Ico (k : ℕ) :
   exact ⟨hα_nn, hα_lt⟩
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION V: The Open Problem
+-- SECTION VI: The Open Problem
 -- ═══════════════════════════════════════════════════════════════
 
 /-- **Erdős Problem #837**: What is A_3?
@@ -145,5 +289,6 @@ theorem erdos_837_open :
 #check liminf_implies_original
 #check erdos_stone_simonovits
 #check turanDensity
+#check zero_is_jump
 
 end Erdos837OQ05

--- a/research/problems/erdos-837-oq-05-incomplete-01/knowledge.md
+++ b/research/problems/erdos-837-oq-05-incomplete-01/knowledge.md
@@ -1,0 +1,53 @@
+# erdos-837-oq-05-incomplete-01 — Complete proof of Hypergraph Density Jumps: Liminf Formulation
+
+## Status: COMPLETED (sorry eliminated)
+
+The task was to complete the proof in `Erdos837ProblemOQ05.lean`, which carried
+1 `sorry` (`zero_is_jump`) and 1 axiom (`erdos_stone_simonovits`).
+
+## What was done (session 2026-06-28, researcher-1)
+
+1. **Eliminated the `sorry` in `zero_is_jump`** — `0 ∈ A_k` for `k ≥ 2` is now
+   fully proved (counting model), no `sorry`. `#print axioms zero_is_jump`
+   reports only `propext / Classical.choice / Quot.sound`. The result is
+   independent of the `erdos_stone_simonovits` axiom.
+
+2. **Construction (β = 1 witness).** Given a sequence `Gₙ` with `(Gₙ).uniformity = k`,
+   diverging vertex count, and `0 < L = liminf (edgeDensity ∘ G)`:
+   - `eventually_lt_of_lt_liminf` (with `IsBoundedUnder (·≥·)` from
+     `edgeDensity ≥ 0`) gives eventually `c < edgeDensity (Gₙ)` for `c = L/2 > 0`.
+   - On those `n`, `c · C(|Gₙ|,k) < e(Gₙ)` (unfold `edgeDensity`, kill the
+     `if`-branch via positivity).
+   - `choose_tendsto_atTop`: `C(m,k) → ∞` (proved via `Nat.pow_le_choose`
+     lower bound `(m+1-k)^k/k! ≤ C(m,k)` squeezed by `tendsto_atTop_mono'`).
+   - Hence `c · C(|Gₙ|,k) → ∞`, so by `tendsto_atTop_mono'`, `e(Gₙ) → ∞`.
+   - Take `Hₙ = ⟨vₙ, C(vₙ,k), k⟩` with
+     `vₙ = Nat.findGreatest (fun w => C(w,k) ≤ e(Gₙ)) |Gₙ|`. Then
+     `C(vₙ,k) ≤ e(Gₙ)` (`findGreatest_spec` with witness `w=0`, since
+     `C(0,k)=0` for `k≥1`), `vₙ ≤ |Gₙ|` (`findGreatest_le`), `vₙ → ∞`
+     (`le_findGreatest`, needing both `|Gₙ| ≥ M` and `e(Gₙ) ≥ C(M,k)`), and
+     `edgeDensity Hₙ = 1` once `vₙ ≥ k` (so `C(vₙ,k) ≠ 0`, `div_self`).
+     `liminf_congr + liminf_const` finishes `1 ≤ liminf (edgeDensity ∘ H)`.
+
+3. **Fixed a parse-error bug in the parent `Erdos837Problem.lean`.** Four
+   floating `/-- … -/` doc comments (not attached to any declaration) were
+   parse errors in Lean v4.26 — the parent (and therefore the whole entry)
+   did NOT compile. Converted them to plain `/- … -/` block comments. This
+   was identical on `origin/main`, so the "verified" parent was silently broken.
+
+4. **Import fix.** `Mathlib.Topology.Instances.Real` is no longer a module
+   olean in Mathlib v4.26 (it became a directory). Switched the child's import
+   block to `import Mathlib` (+ `Proofs.Erdos837Problem`).
+
+## Remaining
+- 1 axiom: `erdos_stone_simonovits` (deep ESS A_2 characterization) — left as a
+  legitimate axiomatized input; not provable from current Mathlib.
+- The counting model (`KUniformHypergraph` = vertex/edge counts) is a toy model;
+  `zero_is_jump` is real supersaturation only relative to it. A genuine
+  formalization would use typed hypergraph structures.
+
+## Key Mathlib API used
+`Nat.findGreatest_spec`, `Nat.le_findGreatest`, `Nat.findGreatest_le`,
+`Nat.pow_le_choose`, `tendsto_pow_atTop`, `Tendsto.atTop_div_const`,
+`Tendsto.const_mul_atTop`, `tendsto_atTop_mono'`, `eventually_lt_of_lt_liminf`,
+`isBoundedUnder_of`, `liminf_congr`, `liminf_const`, `tendsto_natCast_atTop_atTop`.

--- a/src/data/proofs/erdos-837-oq-05/annotations.json
+++ b/src/data/proofs/erdos-837-oq-05/annotations.json
@@ -78,24 +78,24 @@
     "id": "ann-zero-is-jump",
     "proofId": "erdos-837-oq-05",
     "range": {
-      "startLine": 110,
-      "endLine": 121
+      "startLine": 166,
+      "endLine": 265
     },
     "type": "concept",
-    "title": "Zero is a Density Jump: The Supersaturation Phenomenon (Sorry)",
-    "content": "The theorem `zero_is_jump` claims that 0 ∈ A_k for all k ≥ 2: any k-uniform hypergraph with positive edge density contains dense subhypergraphs. This is proved with `sorry` because the full argument requires the Kruskal-Katona supersaturation theorem. The density jump set satisfies `densityJumpSet_subset_Ico`: A_k ⊆ [0,1), proved trivially by destructuring the set definition.",
+    "title": "Zero is a Density Jump: The Supersaturation Phenomenon (Proved)",
+    "content": "The theorem `zero_is_jump` proves that 0 ∈ A_k for all k ≥ 2: in the counting model, any sequence of k-uniform hypergraphs with positive liminf edge density and diverging vertex count admits subhypergraphs of liminf density exactly 1. The proof is now complete (no `sorry`). The witness jump value is β = 1. The key steps: (1) a positive liminf density 0 < L gives, via `eventually_lt_of_lt_liminf`, an eventual lower bound c = L/2 on the density; (2) since C(|Gₙ|,k) → ∞ (lemma `choose_tendsto_atTop`), the raw edge count e(Gₙ) → ∞; (3) Hₙ is taken to be the complete k-uniform hypergraph on the largest vertex count vₙ ≤ |Gₙ| with C(vₙ,k) ≤ e(Gₙ) (via `Nat.findGreatest`), which has density 1, fits inside Gₙ, and has vₙ → ∞. `#print axioms zero_is_jump` reports only propext / Classical.choice / Quot.sound. The set bound `densityJumpSet_subset_Ico`: A_k ⊆ [0,1) is proved trivially by destructuring the set definition.",
     "mathContext": "Supersaturation (Erdős-Simonovits, 1984): If a $k$-uniform hypergraph $H$ on $n$ vertices has at least $\\epsilon\\binom{n}{k}$ edges, then $H$ contains at least $c(\\epsilon)\\binom{n}{k}^t$ copies of any fixed $k$-uniform hypergraph $F$ on $t$ vertices. In particular, any positive density forces subhypergraphs with density bounded away from 0. For the density jump framework, this shows every $\\alpha \\in [0, \\pi(F))$ (below the Turán density of some $F$) is a density jump. Formalizing this requires full hypergraph theory not yet available in Mathlib.",
-    "significance": "supporting",
+    "significance": "core",
     "relatedConcepts": [
-      "supersaturation theorem",
-      "Kruskal-Katona theorem",
-      "sorry placeholder",
+      "supersaturation phenomenon",
+      "Nat.findGreatest extraction",
+      "Filter.liminf",
       "A_k density jump set"
     ],
     "prerequisites": [
-      "Erdős-Simonovits supersaturation 1984",
-      "Kruskal-Katona theorem",
-      "Lean sorry as incomplete proof"
+      "Filter.liminf and eventually_lt_of_lt_liminf",
+      "Nat.findGreatest API",
+      "binomial growth C(m,k) → ∞"
     ]
   },
   {

--- a/src/data/proofs/erdos-837-oq-05/meta.json
+++ b/src/data/proofs/erdos-837-oq-05/meta.json
@@ -16,9 +16,9 @@
     ],
     "proofRepoPath": "Proofs/Erdos837ProblemOQ05.lean",
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "1 axiom (erdos_stone_simonovits): A_2 = {1-1/m : m ≥ 1}. 1 sorry (zero_is_jump): 0 ∈ A_k requires supersaturation argument.",
+    "assumptions": "1 axiom (erdos_stone_simonovits): the deep Erdős-Stone-Simonovits characterization A_2 = {1-1/m : m ≥ 1}. 0 sorries: zero_is_jump (0 ∈ A_k for k ≥ 2) is now fully proved in the counting model via a Nat.findGreatest density-1 extraction, depending only on propext/Classical.choice/Quot.sound.",
     "axioms": [
       "erdos_stone_simonovits: densityJumpSetLiminf 2 = {1-1/m : m ≥ 1} (Erdős-Stone-Simonovits theorem)"
     ],
@@ -26,11 +26,14 @@
       "IsDensityJumpLiminf: proper formulation using Filter.liminf",
       "Relationship to parent's placeholder definition",
       "Turán density definition and basic properties",
-      "Formal statement of A_2 characterization"
+      "Formal statement of A_2 characterization",
+      "zero_is_jump: complete sorry-free proof that 0 is a density jump for k ≥ 2 (counting-model supersaturation), witnessed by β = 1 via a Nat.findGreatest density-1 subhypergraph extraction",
+      "choose_tendsto_atTop: C(m,k) → ∞ as m → ∞ for fixed k ≥ 1, the quantitative engine for supersaturation",
+      "Fixed a parse error in the parent Erdos837Problem.lean (floating /-- doc comments) that prevented the entry from compiling"
     ],
     "dateAdded": "2026-04-13",
-    "lineCount": 149,
-    "theoremCount": 5,
+    "lineCount": 294,
+    "theoremCount": 7,
     "definitionCount": 3,
     "mathlib_version": "4.26.0"
   },
@@ -74,10 +77,10 @@
     },
     {
       "id": "properties",
-      "title": "Section IV: Properties",
-      "startLine": 106,
-      "endLine": 122,
-      "summary": "States 0 ∈ A_k (sorry: needs supersaturation) and A_k ⊆ [0,1)."
+      "title": "Section IV: Supersaturation infrastructure and Properties",
+      "startLine": 119,
+      "endLine": 245,
+      "summary": "Proves choose_tendsto_atTop (C(m,k) → ∞) and edgeDensity_nonneg, then proves 0 ∈ A_k for k ≥ 2 fully (no sorry) and A_k ⊆ [0,1)."
     },
     {
       "id": "open-problem",
@@ -91,7 +94,7 @@
   "conclusion": {
     "summary": "Answers OQ-05 affirmatively: IsDensityJump can be strengthened using Filter.liminf to encode the full sequence-based formulation from the combinatorics literature.",
     "openQuestions": [
-      "Prove zero_is_jump using a supersaturation argument — requires formalizing the Kruskal-Katona theorem or Erdős-Simonovits supersaturation in Mathlib",
+      "Replace the counting model with typed hypergraph structures (e.g., extending Mathlib's SimpleGraph) so that zero_is_jump reflects genuine combinatorial supersaturation rather than the count-only model",
       "Formalize the subhypergraph relation properly using typed hypergraph structures (e.g., extending Mathlib's SimpleGraph)",
       "What is A_3? Is A_3 countable? Does A_3 contain non-Turán values? (Erdős #837, open since 1974)",
       "Does the Frankl-Füredi non-jump result (A_3 ∩ (0, 2/9) = ∅) have a Lean formalization?"
@@ -107,19 +110,16 @@
   ],
   "leanFile": {
     "imports": [
-      "Mathlib.Order.LiminfLimsup",
-      "Mathlib.Topology.Instances.Real",
-      "Mathlib.Data.Nat.Choose.Basic",
-      "Mathlib.Tactic",
+      "Mathlib",
       "Proofs.Erdos837Problem"
     ],
     "namespace": "Erdos837OQ05",
-    "lineCount": 149,
+    "lineCount": 294,
     "axiomCount": 1,
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 3,
     "path": "Proofs/Erdos837ProblemOQ05.lean",
-    "sorries": 1
+    "sorries": 0
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Completes the **Hypergraph Density Jumps: Liminf Formulation** entry (Erdős #837 OQ-05), the target of the `erdos-837-oq-05-incomplete-01` completion task.

- **Eliminated the `sorry` in `zero_is_jump`.** `0 ∈ A_k` for `k ≥ 2` is now fully proved in the counting model. `#print axioms zero_is_jump` reports only `propext / Classical.choice / Quot.sound` — it does **not** depend on the `erdos_stone_simonovits` axiom or `sorryAx`.
- **Construction** (witness jump value `β = 1`): from `0 < L = liminf (edgeDensity ∘ G)` and diverging vertex count, `eventually_lt_of_lt_liminf` yields an eventual density floor `c = L/2`; since `C(|Gₙ|,k) → ∞` (new lemma `choose_tendsto_atTop`) this forces `e(Gₙ) → ∞`. Then `Hₙ` is the complete k-uniform hypergraph on the largest `vₙ ≤ |Gₙ|` with `C(vₙ,k) ≤ e(Gₙ)` (via `Nat.findGreatest`): density exactly 1, fits inside `Gₙ`, and `vₙ → ∞`.
- **Added supporting lemmas**: `choose_tendsto_atTop` (`C(m,k) → ∞` for fixed `k ≥ 1`, via `Nat.pow_le_choose`) and `edgeDensity_nonneg`.

## Bug fix in the parent file

`Erdos837Problem.lean` had **four floating `/-- … -/` doc comments** (not attached to any declaration), which are parse errors in Lean v4.26 — the parent, and therefore the whole entry, did **not** compile. This is identical on `origin/main`, so the "verified" parent was silently broken. Converted them to plain `/- … -/` block comments (no semantic change).

Also updated the child's imports to `import Mathlib` (`Mathlib.Topology.Instances.Real` is no longer a module olean in v4.26).

## Status

| | before | after |
|---|---|---|
| sorries | 1 | **0** |
| axioms | 1 (`erdos_stone_simonovits`) | 1 (unchanged, deep ESS) |

Entry remains `axiomatized` with the single deep Erdős–Stone–Simonovits axiom. `meta.json` and `annotations.json` updated accordingly.

## Verification

Compiled locally with `lake env lean` against the prebuilt Mathlib oleans (host fallback; Docker not used). Both parent and child compile with no errors/sorries; axiom audit via `#print axioms` confirms the foundational-only footprint.

> Note: the `KUniformHypergraph` counting model (vertex/edge counts only) is a toy model; `zero_is_jump` is genuine supersaturation only relative to it. A typed-hypergraph formalization remains future work.