### PR TITLE
Enrich Young's Inequality (amgm-oq-05): populate sections + header annotation

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-05/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-05/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-young-header",
+    "proofId": "amgm-inequality-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 32
+    },
+    "type": "context",
+    "title": "Young's Inequality as Weighted AM-GM, and the Gap This Fills",
+    "content": "Young's inequality for products, a·b ≤ aᵖ/p + b^q/q for Hölder-conjugate exponents (p⁻¹ + q⁻¹ = 1), is the conjugate-exponent root of Hölder's inequality and, at p = q = 2, of Cauchy–Schwarz. Conceptually it is weighted AM-GM with weights (1/p, 1/q): the weighted geometric mean a·b = (aᵖ)^{1/p}(b^q)^{1/q} is at most the weighted arithmetic mean aᵖ/p + b^q/q. Mathlib carries the inequality (Real.young_inequality_of_nonneg, used to bootstrap Hölder) but not the sharp equality case. This file supplies it: for a, b > 0, equality holds iff aᵖ = b^q. The whole file works over Real.rpow (all exponents real), and the proof's engine is the strict — not merely the ordinary — convexity of exp.",
+    "mathContext": "Weighted AM-GM form: $a^{1/p\\cdot p}b^{1/q\\cdot q}$-style $(a^p)^{1/p}(b^q)^{1/q} \\le \\tfrac1p a^p + \\tfrac1q b^q$, equality iff the two interpolated points coincide ($a^p = b^q$).",
+    "significance": "context",
+    "relatedConcepts": [
+      "weighted AM-GM",
+      "Hölder's inequality",
+      "Cauchy–Schwarz",
+      "Legendre/convex duality",
+      "equality case of a convexity bound"
+    ],
+    "prerequisites": [
+      "Hölder-conjugate exponents (Real.HolderConjugate)",
+      "convexity and strict convexity",
+      "real powers (Real.rpow)"
+    ]
+  },
+  {
     "id": "ann-young-inequality",
     "proofId": "amgm-inequality-oq-05",
     "range": {

--- a/src/data/proofs/amgm-inequality-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05/meta.json
@@ -46,6 +46,48 @@
       "Young's inequality (Real.young_inequality_of_nonneg)"
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: Young's Inequality and Its Equality Case",
+      "startLine": 1,
+      "endLine": 32,
+      "mathContext": "$ab \\le \\dfrac{a^p}{p} + \\dfrac{b^q}{q}$ for $\\tfrac1p+\\tfrac1q=1$, with equality (for $a,b>0$) iff $a^p = b^q$.",
+      "summary": "Module docstring. States Young's inequality for products at Hölder-conjugate exponents p, q > 1, notes Mathlib has the inequality (Real.young_inequality_of_nonneg) but not its equality case, and announces the headline contribution: a·b = aᵖ/p + b^q/q ⟺ aᵖ = b^q for a, b > 0, proved from strict convexity of exp by writing both sides as endpoints of a (p⁻¹, q⁻¹)-weighted exp combination. All exponents are real (Real.rpow). Imports Mathlib, opens Real."
+    },
+    {
+      "id": "inequality",
+      "title": "Young's Inequality (the inequality direction)",
+      "startLine": 34,
+      "endLine": 39,
+      "mathContext": "$ab \\le \\dfrac{a^p}{p} + \\dfrac{b^q}{q}$ for $a,b \\ge 0$ and $p.\\mathrm{HolderConjugate}\\,q$.",
+      "summary": "young_inequality: the nonnegative form a·b ≤ aᵖ/p + b^q/q, a thin wrapper around Mathlib's Real.young_inequality_of_nonneg. This is the inequality half against which the equality case is sharp."
+    },
+    {
+      "id": "factorization",
+      "title": "The Bridge Factorization a·b = (aᵖ)^{1/p}·(b^q)^{1/q}",
+      "startLine": 41,
+      "endLine": 52,
+      "mathContext": "$ab = (a^p)^{1/p}(b^q)^{1/q}$ since $(a^p)^{1/p} = a^{p\\cdot p^{-1}} = a^1 = a$.",
+      "summary": "mul_eq_rpow_inv_mul_rpow_inv (private helper): for a, b > 0, a·b = (aᵖ)^(p⁻¹)·(b^q)^(q⁻¹). Each factor collapses by rpow arithmetic (Real.rpow_mul + mul_inv_cancel₀ + rpow_one). This rewriting is what realizes a·b as the geometric-mean endpoint exp(p⁻¹·log(aᵖ) + q⁻¹·log(b^q)) on which strict convexity acts — the link used in both directions of the equality case."
+    },
+    {
+      "id": "equality-case",
+      "title": "The Equality Case (headline): equality ⟺ aᵖ = b^q",
+      "startLine": 54,
+      "endLine": 97,
+      "mathContext": "$ab = \\dfrac{a^p}{p}+\\dfrac{b^q}{q} \\iff a^p = b^q$ (for $a,b>0$), via $\\exp$ strict convexity.",
+      "summary": "young_inequality_eq_iff, the new content. Forward: by contradiction — if aᵖ ≠ b^q then log(aᵖ) ≠ log(b^q) (log injective on positives), and strictConvexOn_exp with weights (p⁻¹, q⁻¹) gives a STRICT inequality whose endpoints are exactly a·b and aᵖ/p + b^q/q, contradicting the assumed equality. Reverse: if aᵖ = b^q =: t, both sides equal t using p⁻¹ + q⁻¹ = 1. This is the sharp boundary of Young's inequality, absent from Mathlib."
+    },
+    {
+      "id": "two-square-case",
+      "title": "The p = q = 2 Specialization: 2ab ≤ a² + b²",
+      "startLine": 99,
+      "endLine": 110,
+      "mathContext": "$2ab \\le a^2 + b^2$, equality iff $a=b$; equivalently $(a-b)^2 \\ge 0$.",
+      "summary": "two_mul_le_sq_add_sq: the classical case (2 is its own Hölder conjugate), bundling 2ab ≤ a² + b² for all real a, b with the equality characterization a = b. Inequality via nlinarith [sq_nonneg (a−b)]; equality extracts (a−b)² = 0. This is two-term AM-GM and the inequality behind Cauchy–Schwarz."
+    }
+  ],
   "conclusion": {
     "summary": "Young's inequality and — the new content — its sharp equality case are fully verified: 4 theorems, 0 definitions, 0 axioms, 0 sorries. The inequality wraps Mathlib's Real.young_inequality_of_nonneg; the equality characterization aᵖ = b^q (for a, b > 0) is proved from the strict convexity of exp via a logarithmic change of coordinates, and the p = q = 2 corollary recovers 2ab ≤ a² + b² with equality iff a = b.",
     "implications": "The equality case sharpens every downstream use of Young's inequality: in Hölder's inequality it pins down when the Hölder estimate is tight (proportional power-normalized vectors), and in the Cauchy–Schwarz specialization it recovers the linear-dependence equality condition. The proof illustrates the standard route from a convexity inequality to its equality case: replace convexity by strict convexity, linearize the weights in logarithmic coordinates, and use injectivity to transport equality back.",


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-05` (Young's Inequality and Its Equality Case; quality 83, pass 0).

The entry had a rich overview, conclusion, keyInsights, cross-references and references, but two genuine structural gaps:

## Changes
- **Populated the empty `sections` array** with 5 sections covering the entire 111-line file: overview, the inequality wrapper (young_inequality), the rpow bridge factorization (mul_eq_rpow_inv_mul_rpow_inv), the headline equality case (young_inequality_eq_iff), and the p=q=2 specialization (two_mul_le_sq_add_sq). Each has `mathContext` and a substantive `summary`.
- **Added a context annotation for the docstring (lines 1–32)**, which the existing 4 theorem-level annotations skipped — frames Young's inequality as weighted AM-GM and situates it in the Hölder / Cauchy–Schwarz / Legendre-duality picture (4 → 5 annotations).
- meta.json 9.6 KB → 12.9 KB, within all caps.

No deepening of already-complete fields (keyInsights, conclusion left as-is) — this fills structural gaps only.

## Verification
- meta.json + annotations.json valid JSON; `check-meta-size.ts` within caps
- `pnpm build` — ✓ built

🤖 Generated with [Claude Code](https://claude.com/claude-code)