### PR TITLE
research(erdos-214): prove unit_square_from_stronger + repair Mathlib-4.26 build

### DIFF
--- a/proofs/Proofs/Erdos214Problem.lean
+++ b/proofs/Proofs/Erdos214Problem.lean
@@ -97,13 +97,42 @@ def JuhaszStrongerTheorem : Prop :=
 /-- Juhász proved the stronger result -/
 axiom juhasz_stronger : JuhaszStrongerTheorem
 
-/-- Unit square is a special case of 4-point configurations -/
+/-- Distance between two explicit points of the plane, in coordinates:
+    `dist (a,b) (c,d) = √((a-c)² + (b-d)²)`.  Lets the concrete unit square
+    below be checked by `norm_num`. -/
+theorem dist_coords (a b c d : ℝ) :
+    Erdos214.dist (!₂[a, b] : Plane) (!₂[c, d] : Plane)
+      = Real.sqrt ((a - c) ^ 2 + (b - d) ^ 2) := by
+  unfold Erdos214.dist
+  rw [← dist_eq_norm, EuclideanSpace.dist_eq, Fin.sum_univ_two]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Real.dist_eq, sq_abs]
+
+/-- The standard unit square `(0,0),(1,0),(1,1),(0,1)` really is a unit square. -/
+theorem isUnitSquare_standard :
+    IsUnitSquare (!₂[0, 0] : Plane) (!₂[1, 0]) (!₂[1, 1]) (!₂[0, 1]) := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> rw [dist_coords] <;> norm_num [Real.sqrt_one]
+
+/-- Unit square is a special case of 4-point configurations.  Apply Juhász's
+stronger theorem to the standard unit square `P`; the resulting congruent copy
+in `Sᶜ` is again a unit square because the witnessing map is an isometry
+(distance-preserving), so it carries `P`'s edge/diagonal lengths verbatim. -/
 theorem unit_square_from_stronger :
     JuhaszStrongerTheorem → Erdos214Statement := by
   intro hStrong S hFree
-  -- A unit square is a particular 4-point configuration
-  -- Apply Juhász's stronger theorem
-  sorry
+  -- The standard unit square as a 4-point configuration.
+  set P : PointSet 4 := ![!₂[0, 0], !₂[1, 0], !₂[1, 1], !₂[0, 1]] with hP
+  -- Juhász's stronger theorem gives a congruent copy of `P` inside `Sᶜ`.
+  obtain ⟨f, hf_isom, hf_mem⟩ := hStrong S hFree P
+  -- Its edge/diagonal lengths equal those of `P` (isometry), so it is a unit square.
+  obtain ⟨h01, h12, h23, h30, h02, h13⟩ := isUnitSquare_standard
+  refine ⟨f (P 0), f (P 1), f (P 2), f (P 3), hf_mem 0, hf_mem 1, hf_mem 2, hf_mem 3,
+    ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [hf_isom, hP]; exact h01
+  · rw [hf_isom, hP]; exact h12
+  · rw [hf_isom, hP]; exact h23
+  · rw [hf_isom, hP]; exact h30
+  · rw [hf_isom, hP]; exact h02
+  · rw [hf_isom, hP]; exact h13
 
 /-
 ## Part 4: Limitations for Larger Sets
@@ -122,7 +151,7 @@ def HoldsFor5Points : Prop :=
 
 /-- The unit distance graph: vertices are points, edges connect distance-1 pairs -/
 def UnitDistanceGraph (S : Set Plane) : Set (Plane × Plane) :=
-  {(p, q) | p ∈ S ∧ q ∈ S ∧ p ≠ q ∧ dist p q = 1}
+  {pq | pq.1 ∈ S ∧ pq.2 ∈ S ∧ pq.1 ≠ pq.2 ∧ dist pq.1 pq.2 = 1}
 
 /-- S is unit-distance-free iff its unit distance graph has no edges -/
 theorem unit_distance_free_iff_no_edges (S : Set Plane) :

--- a/src/data/proofs/erdos-214/meta.json
+++ b/src/data/proofs/erdos-214/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-214",
-  "title": "Erd\u0151s Problem #214: Unit Distance Free Sets and Unit Squares",
+  "title": "Erdős Problem #214: Unit Distance Free Sets and Unit Squares",
   "slug": "erdos-214",
-  "description": "If S \u2282 \u211d\u00b2 has no two points at distance 1 apart, must the complement contain four points forming a unit square? YES (Juh\u00e1sz, 1979). More generally, the complement contains a congruent copy of any 4-point set.",
+  "description": "If S ⊂ ℝ² has no two points at distance 1 apart, must the complement contain four points forming a unit square? YES (Juhász, 1979). More generally, the complement contains a congruent copy of any 4-point set.",
   "meta": {
-    "author": "Juh\u00e1sz",
+    "author": "Juhász",
     "sourceUrl": "https://erdosproblems.com/214",
     "date": "1979",
     "status": "axiomatized",
@@ -24,12 +24,12 @@
     "mathlibDependencies": [
       {
         "theorem": "EuclideanSpace",
-        "description": "Type for points in \u211d\u00b2",
+        "description": "Type for points in ℝ²",
         "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
       },
       {
         "theorem": "Real.sqrt",
-        "description": "Square root for diagonal length \u221a2",
+        "description": "Square root for diagonal length √2",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       },
       {
@@ -40,10 +40,10 @@
     ],
     "originalContributions": [
       "Formalization of IsUnitDistanceFree, IsUnitSquare, ContainsUnitSquare",
-      "Statement and axiomatization of Juh\u00e1sz's theorem (1979)",
+      "Statement and axiomatization of Juhász's theorem (1979)",
       "Stronger version: ContainsCongruentCopy for any PointSet 4",
       "Proof of unit_distance_free_iff_no_edges (graph characterization)",
-      "ScaledLattice \u221a2\u00b7\u2124\u00b2 as unit-distance-free example",
+      "ScaledLattice √2·ℤ² as unit-distance-free example",
       "Formalization of HoldsFor5Points open question",
       "Connection to chromatic number of the plane"
     ],
@@ -58,15 +58,15 @@
       },
       {
         "id": "erdos-171",
-        "relationship": "Unit distance chromatic number (Hadwiger-Nelson problem): each color class is unit-distance-free, directly connecting to Juh\u00e1sz's theorem"
+        "relationship": "Unit distance chromatic number (Hadwiger-Nelson problem): each color class is unit-distance-free, directly connecting to Juhász's theorem"
       },
       {
         "id": "erdos-508",
-        "relationship": "Another formulation of the Hadwiger-Nelson problem: bounds \u03c7(\u211d\u00b2) \u2208 {5,...,7} via de Grey's 1581-vertex graph"
+        "relationship": "Another formulation of the Hadwiger-Nelson problem: bounds χ(ℝ²) ∈ {5,...,7} via de Grey's 1581-vertex graph"
       },
       {
         "id": "erdos-100",
-        "relationship": "Point sets with restricted distances: n points in \u211d\u00b2 with distance constraints, sharing the distance geometry framework"
+        "relationship": "Point sets with restricted distances: n points in ℝ² with distance constraints, sharing the distance geometry framework"
       },
       {
         "id": "erdos-107",
@@ -79,7 +79,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 197,
-    "assumptions": "2 axioms: juhasz_1979 (Juh\u00e1sz 1979 \u2014 unit-distance free sets contain unit squares in complement), juhasz_stronger (stronger: unit-distance free sets contain any 4-point configuration in complement). 1 sorry in unit_square_from_stronger.",
+    "assumptions": "2 axioms: juhasz_1979 (Juhász 1979 — unit-distance free sets contain unit squares in complement), juhasz_stronger (stronger: unit-distance free sets contain any 4-point configuration in complement). 1 sorry in unit_square_from_stronger.",
     "theoremCount": 5,
     "definitionCount": 13,
     "additionalFiles": [
@@ -87,15 +87,15 @@
     ]
   },
   "overview": {
-    "historicalContext": "**Unit Distance Free Sets: Geometric Ramsey Theory in the Plane**\n\nErd\u0151s posed Problem #214 in 1983, asking about the geometric consequences of avoiding a single distance. The question lies at the heart of combinatorial geometry: what structure must the complement of a 'sparse' set possess?\n\n**The Unit Distance Graph**\n\nThe unit distance graph G\u2081(\u211d\u00b2) has all points of \u211d\u00b2 as vertices and edges connecting pairs at distance 1. A unit-distance-free set is an independent set in this graph. The chromatic number \u03c7(\u211d\u00b2) \u2014 the minimum colors needed so each color class is unit-distance-free \u2014 is the Hadwiger-Nelson problem: 5 \u2264 \u03c7(\u211d\u00b2) \u2264 7 (de Grey 2018 for the lower bound, hexagonal tiling for the upper).\n\n**Juh\u00e1sz's Resolution (1979)**\n\nR\u00f3bert Juh\u00e1sz proved a much stronger result than Erd\u0151s asked for: if S avoids unit distances, then S\u1d9c contains a congruent copy of ANY 4-point configuration \u2014 not just unit squares. The proof uses the key observation that for each p \u2208 S, the entire unit circle centered at p lies in S\u1d9c, providing an abundance of points to build configurations from.\n\n**The Proof Strategy**\n\nFor any 4-point configuration P = {p\u2081, p\u2082, p\u2083, p\u2084}: Choose any point in S. Its unit circle (in S\u1d9c) provides a 1-parameter family of candidate locations. The configuration has 8 degrees of freedom (4 points in \u211d\u00b2) minus 3 for rigid motions = 5 intrinsic degrees. The unit circles in S\u1d9c provide enough flexibility (continuous families of points) to realize any 4-point configuration.\n\n**Limitations and Open Questions**\n\nThe result breaks down for large n-point configurations: there exist unit-distance-free sets whose complements miss certain n-point patterns. The critical threshold n is unknown. The 5-point case \u2014 whether ALL 5-point configurations must appear in S\u1d9c \u2014 remains open since 1979.",
-    "problemStatement": "Let S \u2282 \u211d\u00b2 be such that no two points in S are distance 1 apart. Must the complement of S contain four points which form a unit square?\n\n**Answer:** YES (Juh\u00e1sz, 1979). More generally, S\u1d9c contains a congruent copy of any 4-point configuration.",
-    "text": "If S \u2282 \u211d\u00b2 has no two points at distance 1 apart, must the complement contain four points forming a unit square? YES (Juh\u00e1sz, 1979). More generally, the complement contains a congruent copy of any 4-point set.",
-    "proofStrategy": "**Formalization Structure**\n\nThe Lean file (197 lines) is organized into ten labelled parts; several are prose section headers that carry no formal content in the current trimmed file.\n\n1. **Basic definitions**: Plane (EuclideanSpace \u211d (Fin 2)), dist (\u2016p-q\u2016), IsUnitDistanceFree, IsUnitSquare, ContainsUnitSquare\n\n2. **Main statement**: Erdos214Statement; axiomatized via juhasz_1979; erdos_214_solved := juhasz_1979\n\n3. **Stronger version**: PointSet n = Fin n \u2192 Plane, ContainsCongruentCopy via isometry, JuhaszStrongerTheorem (axiom juhasz_stronger) for n=4, unit_square_from_stronger (sorry: needs an explicit unit square encoded as PointSet 4)\n\n4. **Limitations**: HoldsFor5Points (open question, stated as a Prop only)\n\n5. **Graph connection**: UnitDistanceGraph definition, unit_distance_free_iff_no_edges (FULLY PROVED via ext/simp)\n\n6. **Proof techniques**: section header only \u2014 the geometric argument is described in prose, not formalized\n\n7. **Examples**: ScaledLattice = \u221a2\u00b7\u2124\u00b2 is defined as a candidate unit-distance-free set (the unit-free property is not formally proved)\n\n8\u20139. **Related problems / Geometric intuition**: section headers only\n\n10. **Summary**: erdos_214_status := juhasz_1979 and erdos_214_summary := \u27e8juhasz_1979, juhasz_stronger\u27e9 (reductions to the two axioms)\n\n**What is Proved vs Axiomatized**\n\n- **Proved (sorry-free)**: unit_distance_free_iff_no_edges (graph characterization), erdos_214_solved, erdos_214_status, erdos_214_summary \u2014 the latter three are reductions to the two axioms\n- **Axiomatized (2 axioms)**: juhasz_1979, juhasz_stronger\n- **Sorry (1)**: unit_square_from_stronger (derives Erdos214Statement from JuhaszStrongerTheorem). The headline does not depend on this lemma \u2014 erdos_214_solved invokes juhasz_1979 directly.",
+    "historicalContext": "**Unit Distance Free Sets: Geometric Ramsey Theory in the Plane**\n\nErdős posed Problem #214 in 1983, asking about the geometric consequences of avoiding a single distance. The question lies at the heart of combinatorial geometry: what structure must the complement of a 'sparse' set possess?\n\n**The Unit Distance Graph**\n\nThe unit distance graph G₁(ℝ²) has all points of ℝ² as vertices and edges connecting pairs at distance 1. A unit-distance-free set is an independent set in this graph. The chromatic number χ(ℝ²) — the minimum colors needed so each color class is unit-distance-free — is the Hadwiger-Nelson problem: 5 ≤ χ(ℝ²) ≤ 7 (de Grey 2018 for the lower bound, hexagonal tiling for the upper).\n\n**Juhász's Resolution (1979)**\n\nRóbert Juhász proved a much stronger result than Erdős asked for: if S avoids unit distances, then Sᶜ contains a congruent copy of ANY 4-point configuration — not just unit squares. The proof uses the key observation that for each p ∈ S, the entire unit circle centered at p lies in Sᶜ, providing an abundance of points to build configurations from.\n\n**The Proof Strategy**\n\nFor any 4-point configuration P = {p₁, p₂, p₃, p₄}: Choose any point in S. Its unit circle (in Sᶜ) provides a 1-parameter family of candidate locations. The configuration has 8 degrees of freedom (4 points in ℝ²) minus 3 for rigid motions = 5 intrinsic degrees. The unit circles in Sᶜ provide enough flexibility (continuous families of points) to realize any 4-point configuration.\n\n**Limitations and Open Questions**\n\nThe result breaks down for large n-point configurations: there exist unit-distance-free sets whose complements miss certain n-point patterns. The critical threshold n is unknown. The 5-point case — whether ALL 5-point configurations must appear in Sᶜ — remains open since 1979.",
+    "problemStatement": "Let S ⊂ ℝ² be such that no two points in S are distance 1 apart. Must the complement of S contain four points which form a unit square?\n\n**Answer:** YES (Juhász, 1979). More generally, Sᶜ contains a congruent copy of any 4-point configuration.",
+    "text": "If S ⊂ ℝ² has no two points at distance 1 apart, must the complement contain four points forming a unit square? YES (Juhász, 1979). More generally, the complement contains a congruent copy of any 4-point set.",
+    "proofStrategy": "**Formalization Structure**\n\nThe Lean file (197 lines) is organized into ten labelled parts; several are prose section headers that carry no formal content in the current trimmed file.\n\n1. **Basic definitions**: Plane (EuclideanSpace ℝ (Fin 2)), dist (‖p-q‖), IsUnitDistanceFree, IsUnitSquare, ContainsUnitSquare\n\n2. **Main statement**: Erdos214Statement; axiomatized via juhasz_1979; erdos_214_solved := juhasz_1979\n\n3. **Stronger version**: PointSet n = Fin n → Plane, ContainsCongruentCopy via isometry, JuhaszStrongerTheorem (axiom juhasz_stronger) for n=4, unit_square_from_stronger (sorry: needs an explicit unit square encoded as PointSet 4)\n\n4. **Limitations**: HoldsFor5Points (open question, stated as a Prop only)\n\n5. **Graph connection**: UnitDistanceGraph definition, unit_distance_free_iff_no_edges (FULLY PROVED via ext/simp)\n\n6. **Proof techniques**: section header only — the geometric argument is described in prose, not formalized\n\n7. **Examples**: ScaledLattice = √2·ℤ² is defined as a candidate unit-distance-free set (the unit-free property is not formally proved)\n\n8–9. **Related problems / Geometric intuition**: section headers only\n\n10. **Summary**: erdos_214_status := juhasz_1979 and erdos_214_summary := ⟨juhasz_1979, juhasz_stronger⟩ (reductions to the two axioms)\n\n**What is Proved vs Axiomatized**\n\n- **Proved (sorry-free)**: unit_distance_free_iff_no_edges (graph characterization), erdos_214_solved, erdos_214_status, erdos_214_summary — the latter three are reductions to the two axioms\n- **Axiomatized (2 axioms)**: juhasz_1979, juhasz_stronger\n- **Sorry (1)**: unit_square_from_stronger (derives Erdos214Statement from JuhaszStrongerTheorem). The headline does not depend on this lemma — erdos_214_solved invokes juhasz_1979 directly.",
     "keyInsights": [
-      "For any p \u2208 S (unit-distance-free), the entire unit circle {q : \u2016p-q\u2016 = 1} lies in S\u1d9c \u2014 this provides continuous families of complement points to build configurations from",
-      "Juh\u00e1sz's result is much stronger than the original question: ALL 4-point configurations appear in S\u1d9c, not just unit squares. The 4-point threshold is sharp \u2014 the result fails for large n",
-      "The scaled lattice \u221a2\u00b7\u2124\u00b2 is unit-distance-free because (a-c)\u00b2 + (b-d)\u00b2 = 1/2 has no integer solutions, yet its complement (almost all of \u211d\u00b2) trivially contains unit squares",
-      "The Hadwiger-Nelson connection: each color class in a \u03c7(\u211d\u00b2)-coloring is unit-distance-free, so Juh\u00e1sz applies to each class. De Grey (2018) proved \u03c7(\u211d\u00b2) \u2265 5 via a 1581-vertex graph",
+      "For any p ∈ S (unit-distance-free), the entire unit circle {q : ‖p-q‖ = 1} lies in Sᶜ — this provides continuous families of complement points to build configurations from",
+      "Juhász's result is much stronger than the original question: ALL 4-point configurations appear in Sᶜ, not just unit squares. The 4-point threshold is sharp — the result fails for large n",
+      "The scaled lattice √2·ℤ² is unit-distance-free because (a-c)² + (b-d)² = 1/2 has no integer solutions, yet its complement (almost all of ℝ²) trivially contains unit squares",
+      "The Hadwiger-Nelson connection: each color class in a χ(ℝ²)-coloring is unit-distance-free, so Juhász applies to each class. De Grey (2018) proved χ(ℝ²) ≥ 5 via a 1581-vertex graph",
       "The 5-point case is the key open problem: can we always find congruent copies of 5-point configurations in complements of unit-distance-free sets?"
     ],
     "prerequisites": [
@@ -107,77 +107,77 @@
     {
       "id": "header",
       "title": "Problem Statement",
-      "summary": "Docstring introducing Erd\u0151s Problem #214 (1983): unit-distance-free S implies S\u1d9c contains unit square? Answered YES by Juh\u00e1sz (1979) with the stronger result covering all 4-point configurations.",
+      "summary": "Docstring introducing Erdős Problem #214 (1983): unit-distance-free S implies Sᶜ contains unit square? Answered YES by Juhász (1979) with the stronger result covering all 4-point configurations.",
       "startLine": 1,
       "endLine": 25,
-      "mathContext": "Mathematical content: Docstring introducing Erd\u0151s Problem #214 (1983): unit-distance-free S implies S\u1d9c contains unit square? Answered YES by Juh\u00e1sz (1979) with the stronger result covering all 4-point configurations."
+      "mathContext": "Mathematical content: Docstring introducing Erdős Problem #214 (1983): unit-distance-free S implies Sᶜ contains unit square? Answered YES by Juhász (1979) with the stronger result covering all 4-point configurations."
     },
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Defines Plane = EuclideanSpace \u211d (Fin 2), dist = \u2016p-q\u2016, IsUnitDistanceFree (no pair at distance 1), IsUnitSquare (4 edges length 1, 2 diagonals length \u221a2), ContainsUnitSquare (\u2203 four points in S forming a unit square).",
+      "summary": "Defines Plane = EuclideanSpace ℝ (Fin 2), dist = ‖p-q‖, IsUnitDistanceFree (no pair at distance 1), IsUnitSquare (4 edges length 1, 2 diagonals length √2), ContainsUnitSquare (∃ four points in S forming a unit square).",
       "startLine": 36,
       "endLine": 61,
-      "mathContext": "Defines Plane = EuclideanSpace \u211d (Fin 2), dist = \u2016p-q\u2016, IsUnitDistanceFree (no pair at distance 1), IsUnitSquare (4 edges length 1, 2 diagonals length \u221a2), ContainsUnitSquare (\u2203 four points in S forming a unit square)."
+      "mathContext": "Defines Plane = EuclideanSpace ℝ (Fin 2), dist = ‖p-q‖, IsUnitDistanceFree (no pair at distance 1), IsUnitSquare (4 edges length 1, 2 diagonals length √2), ContainsUnitSquare (∃ four points in S forming a unit square)."
     },
     {
       "id": "main-statement",
       "title": "Main Statement and Solution",
-      "summary": "Erdos214Statement = \u2200 S, IsUnitDistanceFree S \u2192 ContainsUnitSquare S\u1d9c. Axiomatized as juhasz_1979. erdos_214_solved simply applies the axiom.",
+      "summary": "Erdos214Statement = ∀ S, IsUnitDistanceFree S → ContainsUnitSquare Sᶜ. Axiomatized as juhasz_1979. erdos_214_solved simply applies the axiom.",
       "startLine": 63,
       "endLine": 75,
-      "mathContext": "Erdos214Statement = \u2200 S, IsUnitDistanceFree S $\\to$ ContainsUnitSquare S\u1d9c. Axiomatized as juhasz_1979. erdos_214_solved simply applies the axiom."
+      "mathContext": "Erdos214Statement = ∀ S, IsUnitDistanceFree S $\\to$ ContainsUnitSquare Sᶜ. Axiomatized as juhasz_1979. erdos_214_solved simply applies the axiom."
     },
     {
       "id": "stronger-version",
       "title": "Stronger Version: Any 4-Point Set",
-      "summary": "Defines PointSet n = Fin n \u2192 Plane and ContainsCongruentCopy (via distance-preserving map f with image in S). JuhaszStrongerTheorem: \u2200 S unit-free, \u2200 P : PointSet 4, S\u1d9c contains congruent copy. unit_square_from_stronger has sorry (needs explicit unit square encoding as PointSet 4).",
+      "summary": "Defines PointSet n = Fin n → Plane and ContainsCongruentCopy (via distance-preserving map f with image in S). JuhaszStrongerTheorem: ∀ S unit-free, ∀ P : PointSet 4, Sᶜ contains congruent copy. unit_square_from_stronger has sorry (needs explicit unit square encoding as PointSet 4).",
       "startLine": 77,
       "endLine": 106,
-      "mathContext": "Defines PointSet n = Fin n \u2192 Plane and ContainsCongruentCopy (via distance-preserving map f with image in S). JuhaszStrongerTheorem: \u2200 S unit-free, \u2200 P : PointSet 4, S\u1d9c contains congruent copy. unit_square_from_stronger has sorry (needs explicit unit square encoding as PointSet 4)."
+      "mathContext": "Defines PointSet n = Fin n → Plane and ContainsCongruentCopy (via distance-preserving map f with image in S). JuhaszStrongerTheorem: ∀ S unit-free, ∀ P : PointSet 4, Sᶜ contains congruent copy. unit_square_from_stronger has sorry (needs explicit unit square encoding as PointSet 4)."
     },
     {
       "id": "limitations",
       "title": "Limitations for Larger Sets",
-      "summary": "HoldsFor5Points : Prop, the open 5-point question (\u2200 S unit-free, \u2200 P : PointSet 5, S\u1d9c contains a congruent copy). The critical threshold n between 4 (Juh\u00e1sz, works) and the eventual failure point is unknown; no formal failure result is stated in this file.",
+      "summary": "HoldsFor5Points : Prop, the open 5-point question (∀ S unit-free, ∀ P : PointSet 5, Sᶜ contains a congruent copy). The critical threshold n between 4 (Juhász, works) and the eventual failure point is unknown; no formal failure result is stated in this file.",
       "startLine": 108,
       "endLine": 117,
-      "mathContext": "Mathematical content: HoldsFor5Points : Prop, the open 5-point question (\u2200 S unit-free, \u2200 P : PointSet 5, S\u1d9c contains a congruent copy). The critical threshold n between 4 (Juh\u00e1sz, works) and the eventual failure point is unknown; no formal failure result is stated in this file."
+      "mathContext": "Mathematical content: HoldsFor5Points : Prop, the open 5-point question (∀ S unit-free, ∀ P : PointSet 5, Sᶜ contains a congruent copy). The critical threshold n between 4 (Juhász, works) and the eventual failure point is unknown; no formal failure result is stated in this file."
     },
     {
       "id": "unit-distance-graph",
       "title": "Unit Distance Graph Connection",
-      "summary": "UnitDistanceGraph(S) = pairs at distance 1 in S. FULLY PROVED: unit_distance_free_iff_no_edges (S is unit-free iff UDG(S) = \u2205) via an ext/simp proof.",
+      "summary": "UnitDistanceGraph(S) = pairs at distance 1 in S. FULLY PROVED: unit_distance_free_iff_no_edges (S is unit-free iff UDG(S) = ∅) via an ext/simp proof.",
       "startLine": 119,
       "endLine": 139,
-      "mathContext": "UnitDistanceGraph(S) = pairs at distance 1 in S. FULLY PROVED: unit_distance_free_iff_no_edges (S is unit-free iff UDG(S) = \u2205) via an ext/simp proof."
+      "mathContext": "UnitDistanceGraph(S) = pairs at distance 1 in S. FULLY PROVED: unit_distance_free_iff_no_edges (S is unit-free iff UDG(S) = ∅) via an ext/simp proof."
     },
     {
       "id": "proof-techniques",
       "title": "Proof Techniques (Sketched)",
-      "summary": "Part 6 is a section header for the geometric proof techniques (maximal unit-free set structure, unit circles at points of S lying in S\u1d9c, circle-intersection sparseness). These are described in prose only; no formal lemmas or placeholders are present in the file.",
+      "summary": "Part 6 is a section header for the geometric proof techniques (maximal unit-free set structure, unit circles at points of S lying in Sᶜ, circle-intersection sparseness). These are described in prose only; no formal lemmas or placeholders are present in the file.",
       "startLine": 141,
       "endLine": 143,
-      "mathContext": "Part 6 is a section header for the geometric proof techniques (maximal unit-free set structure, unit circles at points of S lying in S\u1d9c, circle-intersection sparseness). These are described in prose only; no formal lemmas or placeholders are present in the file."
+      "mathContext": "Part 6 is a section header for the geometric proof techniques (maximal unit-free set structure, unit circles at points of S lying in Sᶜ, circle-intersection sparseness). These are described in prose only; no formal lemmas or placeholders are present in the file."
     },
     {
       "id": "examples",
       "title": "Examples and Constructions",
-      "summary": "Defines ScaledLattice = \u221a2\u00b7\u2124\u00b2 as a candidate unit-distance-free set (distance between lattice points is \u221a(2\u00b7integer), never 1 since 1/2 is not a sum of two integer squares); the unit-free property is stated in the comment but not formally proved. Part 10 summary: erdos_214_status := juhasz_1979 and erdos_214_summary := \u27e8juhasz_1979, juhasz_stronger\u27e9.",
+      "summary": "Defines ScaledLattice = √2·ℤ² as a candidate unit-distance-free set (distance between lattice points is √(2·integer), never 1 since 1/2 is not a sum of two integer squares); the unit-free property is stated in the comment but not formally proved. Part 10 summary: erdos_214_status := juhasz_1979 and erdos_214_summary := ⟨juhasz_1979, juhasz_stronger⟩.",
       "startLine": 145,
       "endLine": 197,
-      "mathContext": "Defines ScaledLattice = \u221a2\u00b7\u2124\u00b2 as a candidate unit-distance-free set (distance between lattice points is \u221a(2\u00b7integer), never 1 since 1/2 is not a sum of two integer squares); the unit-free property is stated in the comment but not formally proved. Part 10 summary: erdos_214_status := juhasz_1979 and erdos_214_summary := \u27e8juhasz_1979, juhasz_stronger\u27e9."
+      "mathContext": "Defines ScaledLattice = √2·ℤ² as a candidate unit-distance-free set (distance between lattice points is √(2·integer), never 1 since 1/2 is not a sum of two integer squares); the unit-free property is stated in the comment but not formally proved. Part 10 summary: erdos_214_status := juhasz_1979 and erdos_214_summary := ⟨juhasz_1979, juhasz_stronger⟩."
     }
   ],
   "conclusion": {
-    "summary": "Juh\u00e1sz (1979) proved that if S \u2282 \u211d\u00b2 avoids unit distances, then S\u1d9c contains a congruent copy of any 4-point configuration \u2014 in particular, a unit square. This captures how avoiding a single distance forces geometric richness in the complement. The result is sharp: it fails for sufficiently large n-point configurations, and the 5-point case remains open.",
-    "implications": "1. **Geometric Ramsey Theory**: The result is a partition theorem for the plane: in any 2-coloring where one color avoids unit distances, the other color contains all 4-point configurations. This is a geometric analogue of classical Ramsey theory.\n\n2. **Independent Set Structure**: Unit-distance-free sets (independent sets of G\u2081(\u211d\u00b2)) cannot be geometrically 'rich' \u2014 their complements must contain diverse configurations. This connects graph theory (independence number) to geometry (configuration embedding).\n\n**3. Chromatic Number Connection**: Since each color class in a \u03c7(\u211d\u00b2)-coloring is unit-distance-free, Juh\u00e1sz's theorem gives structural information about optimal colorings: each color class's complement is geometrically rich.\n\n4. **Threshold Phenomenon**: The transition from 'works for 4 points' to 'fails for large n' suggests a sharp threshold in the number of points. Finding this threshold would reveal the precise geometric complexity that unit-distance-free complements must exhibit.\n\n5. **Measure-Theoretic Perspective**: Unit-distance-free sets can have positive measure (e.g., small disks), but their complements (which also have positive measure) always contain 4-point configurations. The density of available points in S\u1d9c is the enabling mechanism.",
+    "summary": "Juhász (1979) proved that if S ⊂ ℝ² avoids unit distances, then Sᶜ contains a congruent copy of any 4-point configuration — in particular, a unit square. This captures how avoiding a single distance forces geometric richness in the complement. The result is sharp: it fails for sufficiently large n-point configurations, and the 5-point case remains open. The reduction `unit_square_from_stronger` (a unit square is a special 4-point configuration, transported into Sᶜ by Juhász's isometry) is now fully proved (0 sorries); the only remaining assumptions are the two deep Juhász axioms (juhasz_1979, juhasz_stronger). Also repaired a Mathlib-4.26 build break in UnitDistanceGraph (tuple set-builder).",
+    "implications": "1. **Geometric Ramsey Theory**: The result is a partition theorem for the plane: in any 2-coloring where one color avoids unit distances, the other color contains all 4-point configurations. This is a geometric analogue of classical Ramsey theory.\n\n2. **Independent Set Structure**: Unit-distance-free sets (independent sets of G₁(ℝ²)) cannot be geometrically 'rich' — their complements must contain diverse configurations. This connects graph theory (independence number) to geometry (configuration embedding).\n\n**3. Chromatic Number Connection**: Since each color class in a χ(ℝ²)-coloring is unit-distance-free, Juhász's theorem gives structural information about optimal colorings: each color class's complement is geometrically rich.\n\n4. **Threshold Phenomenon**: The transition from 'works for 4 points' to 'fails for large n' suggests a sharp threshold in the number of points. Finding this threshold would reveal the precise geometric complexity that unit-distance-free complements must exhibit.\n\n5. **Measure-Theoretic Perspective**: Unit-distance-free sets can have positive measure (e.g., small disks), but their complements (which also have positive measure) always contain 4-point configurations. The density of available points in Sᶜ is the enabling mechanism.",
     "openQuestions": [
-      "Does the property hold for all 5-point configurations? This is the first open case after Juh\u00e1sz's 4-point theorem.",
+      "Does the property hold for all 5-point configurations? This is the first open case after Juhász's 4-point theorem.",
       "What is the maximum n for which every n-point configuration appears in the complement of every unit-distance-free set?",
-      "Can Juh\u00e1sz's theorem be quantified: what is the minimum distance from a given point to the nearest congruent copy of a 4-point configuration in S\u1d9c?",
-      "Does the result extend to higher dimensions: if S \u2282 \u211d^d avoids unit distances, what is the maximum n(d) for which S\u1d9c contains all n-point configurations?",
-      "Is there a constructive proof giving an explicit algorithm to find the 4-point configuration in S\u1d9c?"
+      "Can Juhász's theorem be quantified: what is the minimum distance from a given point to the nearest congruent copy of a 4-point configuration in Sᶜ?",
+      "Does the result extend to higher dimensions: if S ⊂ ℝ^d avoids unit distances, what is the maximum n(d) for which Sᶜ contains all n-point configurations?",
+      "Is there a constructive proof giving an explicit algorithm to find the 4-point configuration in Sᶜ?"
     ]
   },
   "leanFile": {
@@ -196,7 +196,7 @@
     "theoremCount": 5,
     "definitionCount": 13,
     "path": "Proofs/Erdos214Problem.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos214ProblemAristotle.lean"
     ]
@@ -215,17 +215,17 @@
     {
       "targetId": "erdos-171",
       "relationship": "related",
-      "description": "Unit distance chromatic number (Hadwiger-Nelson problem): each color class is unit-distance-free, directly connecting to Juh\u00e1sz's theorem"
+      "description": "Unit distance chromatic number (Hadwiger-Nelson problem): each color class is unit-distance-free, directly connecting to Juhász's theorem"
     },
     {
       "targetId": "erdos-508",
       "relationship": "related",
-      "description": "Another formulation of the Hadwiger-Nelson problem: bounds \u03c7(\u211d\u00b2) \u2208 {5,...,7} via de Grey's 1581-vertex graph"
+      "description": "Another formulation of the Hadwiger-Nelson problem: bounds χ(ℝ²) ∈ {5,...,7} via de Grey's 1581-vertex graph"
     },
     {
       "targetId": "erdos-100",
       "relationship": "related",
-      "description": "Point sets with restricted distances: n points in \u211d\u00b2 with distance constraints, sharing the distance geometry framework"
+      "description": "Point sets with restricted distances: n points in ℝ² with distance constraints, sharing the distance geometry framework"
     },
     {
       "targetId": "erdos-107",
@@ -243,7 +243,7 @@
       "key": "SST84b",
       "authors": [
         "J. Spencer",
-        "E. Szemer\u00e9di",
+        "E. Szemerédi",
         "W.T. Trotter"
       ],
       "title": "Unit distances in the Euclidean plane",
@@ -253,5 +253,5 @@
       "note": "Best known O(n^{4/3}) bound for unit distances"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/erdos-214-incomplete-01.json
+++ b/src/data/research/problems/erdos-214-incomplete-01.json
@@ -29,11 +29,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: eliminated the single sorry in Erdos214Problem.lean (unit_square_from_stronger) and repaired a Mathlib-4.26 build break (UnitDistanceGraph). File compiles cleanly (host lake env lean vs pinned Mathlib v4.26.0), 0 sorries; #print axioms unit_square_from_stronger = [propext, Classical.choice, Quot.sound] — no sorryAx. The 2 remaining axioms (juhasz_1979, juhasz_stronger) are the intentional deep solved-theorem inputs; entry stays axiomatized/axiom, axiomCount 2.",
+    "builtItems": [
+      "Erdos214Problem.lean: dist_coords (coordinate distance formula), isUnitSquare_standard (the standard unit square is a unit square), unit_square_from_stronger (sorry eliminated, 0-axiom reduction)",
+      "Fixed Mathlib-4.26 build break: UnitDistanceGraph tuple set-builder → setOf on Prod"
+    ],
+    "insights": [
+      "erdos-214 (Juhász 1979, unit-distance-free sets): the 1 sorry was in unit_square_from_stronger (JuhaszStrongerTheorem → Erdos214Statement) — a pure logical reduction, NOT one of the 2 deep Juhász axioms.",
+      "Proved it: apply the stronger theorem to the standard unit square P=(0,0),(1,0),(1,1),(0,1) as a PointSet 4; the congruent copy in Sᶜ is again a unit square since the witnessing map is an isometry (dist-preserving), carrying P's 4 edges (=1) and 2 diagonals (=√2).",
+      "Key helper dist_coords: dist(!₂[a,b],!₂[c,d]) = √((a-c)²+(b-d)²) via EuclideanSpace.dist_eq + Fin.sum_univ_two + Real.dist_eq + sq_abs; concrete unit square checked by norm_num [Real.sqrt_one].",
+      "The file ALSO didn't compile on pinned Mathlib 4.26: UnitDistanceGraph used the tuple set-builder {(p,q) | ...} which no longer parses ('unknown identifier q'); rewrote as {pq | pq.1∈S ∧ ...}."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Optional: formalize one of the Juhász axioms (deep 1979 result) — substantial; or leave as the documented axiomatized solved entry."
+    ],
     "markdown": "# Knowledge: erdos-214-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n"
   },
   "tags": [],


### PR DESCRIPTION
## Summary

Erdős Problem #214 (Juhász 1979: a unit-distance-free set in ℝ² has a complement containing a unit square). Two fixes to `Erdos214Problem.lean`.

### 1. Eliminated the lone sorry
`unit_square_from_stronger : JuhaszStrongerTheorem → Erdos214Statement` was a `sorry`. It is a **pure logical reduction** (not one of the deep Juhász axioms): a unit square is a particular 4-point configuration, so the stronger theorem applies. Proof:
- Apply `JuhaszStrongerTheorem` to the standard unit square `P = (0,0),(1,0),(1,1),(0,1)` as a `PointSet 4`.
- The witness is an isometry `f` with `f(P i) ∈ Sᶜ`. Since `f` preserves distances, `f∘P` has the same four unit edges and two √2 diagonals as `P`, hence is a unit square in `Sᶜ`.

Added two supporting lemmas:
- `dist_coords` — `dist (a,b) (c,d) = √((a-c)² + (b-d)²)` in `EuclideanSpace ℝ (Fin 2)` (via `EuclideanSpace.dist_eq` + `Fin.sum_univ_two` + `Real.dist_eq` + `sq_abs`).
- `isUnitSquare_standard` — the standard unit square is a unit square (checked by `norm_num [Real.sqrt_one]`).

### 2. Repaired a Mathlib-4.26 build break
`UnitDistanceGraph` used the tuple set-builder `{(p,q) | ...}`, which no longer parses on the repo's pinned toolchain (v4.26.0 — "unknown identifier q"), and the dependent proof cascaded into errors. Rewrote as `{pq | pq.1 ∈ S ∧ ...}`. **The file did not compile on the pinned Mathlib before this change.**

## Verification
`lake env lean` against pinned Mathlib (rev matches `lake-manifest` `v4.26.0`):
- 0 errors, 0 sorries, 0 warnings
- `#print axioms unit_square_from_stronger` = `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`**

(Docker unavailable; verified on host against cached pinned oleans.)

## Status
- **Outcome:** completed — sorry eliminated, file compiles
- The two remaining axioms (`juhasz_1979`, `juhasz_stronger`) are the intentional deep 1979 solved-theorem inputs; entry stays `axiomatized`/`axiom`, `axiomCount` 2. `meta.json` `sorries` 1→0.

🤖 Generated by researcher-5