### PR TITLE
research(erdos-1010-oq-01): triangle supersaturation bound fails exactly at t = ⌊n/2⌋ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1256,6 +1256,7 @@ import Proofs.Erdos100OQ02
 import Proofs.Erdos100OQ02OQ02
 import Proofs.Erdos100OQ03
 import Proofs.Erdos100Problem
+import Proofs.Erdos1010OQ01
 import Proofs.Erdos1010OQ02Problem
 import Proofs.Erdos1010Problem
 import Proofs.Erdos1011Problem

--- a/proofs/Proofs/Erdos1010OQ01.lean
+++ b/proofs/Proofs/Erdos1010OQ01.lean
@@ -1,0 +1,167 @@
+/-
+  Erdős Problem #1010 — Open Question 01:
+  What happens for t ≥ ⌊n/2⌋ ?
+
+  Source: https://erdosproblems.com/1010 (follow-up open question)
+  Parent: Proofs/Erdos1010Problem.lean
+
+  ## Background
+
+  Erdős Problem #1010 (Lovász–Simonovits 1976, Nikiforov–Khadzhiivanov 1981)
+  states the supersaturation bound:
+
+      For t < ⌊n/2⌋, every graph on n vertices with ⌊n²/4⌋ + t edges
+      contains at least  t · ⌊n/2⌋  triangles.
+
+  The hypothesis `t < ⌊n/2⌋` is essential. The natural follow-up question is:
+  does the same *linear* lower bound `t · ⌊n/2⌋` continue to hold once
+  `t ≥ ⌊n/2⌋`?  The answer is **NO**: the regime changes qualitatively exactly
+  at `t = ⌊n/2⌋`.
+
+  ## What this file proves (0-axiom, machine-checked)
+
+  We pin down *why* the bound breaks and *exactly where*.
+
+  1. `crossover` — the arithmetic heart. Writing `n = 2m`, the cheapest
+     triangle-free way to reach `⌊n²/4⌋ + t` edges is no longer "balanced
+     bipartite + t internal edges" (yielding `t·m` triangles) but the
+     **unbalanced** base `K_{m-1, m+1}` plus `t+1` triangle-free internal
+     edges, each of which spans only the smaller side and so creates only
+     `m-1` triangles — a total of `(t+1)·(m-1)`.  We prove
+
+         (t+1)·(m-1) < t·m   ↔   m ≤ t         (for m ≥ 1),
+
+     i.e. the unbalanced construction beats the linear bound *precisely* once
+     `t ≥ m = ⌊n/2⌋`.  This is the boundary the open question asks about.
+
+  2. A fully explicit witness at the first failing value `n = 6, t = 3 = ⌊n/2⌋`.
+     The graph `Gw = K_{2,4} + C₄(big part)` has exactly `⌊6²/4⌋ + 3 = 12`
+     edges and exactly `8` triangles, whereas the extrapolated linear bound
+     predicts `t · ⌊n/2⌋ = 3 · 3 = 9`.  Since `8 < 9`, the bound of #1010
+     fails at `t = ⌊n/2⌋`.  Equivalently: the hypothesis `t < ⌊n/2⌋` in
+     Erdős #1010 is **sharp**.
+
+  Everything is verified by `decide` / `omega` / `ring`; `#print axioms`
+  reports only `propext`, `Classical.choice`, `Quot.sound`.
+
+  Tags: graph-theory, extremal, triangles, turán, supersaturation, sharpness
+-/
+
+import Mathlib
+
+open SimpleGraph Finset
+
+/-
+## Shared definitions (mirroring the parent file `Erdos1010Problem.lean`)
+-/
+
+/-- The Turán threshold: maximum number of edges in a triangle-free graph
+    on `n` vertices, `ex(n, K₃) = ⌊n²/4⌋`. -/
+def turanThreshold (n : ℕ) : ℕ := n ^ 2 / 4
+
+/-- Number of triangles in a graph, counted as 3-element cliques. -/
+def triangleCount {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
+  (Finset.univ.filter (fun s : Finset V =>
+    s.card = 3 ∧ ∀ x ∈ s, ∀ y ∈ s, x ≠ y → G.Adj x y)).card
+
+/-
+## Part 1 — The arithmetic crossover
+
+The transition between the two extremal regimes happens at a single, exact
+value of `t`.  This is a statement of pure `ℕ`-arithmetic and is the reason the
+linear bound of #1010 cannot persist past `t = ⌊n/2⌋`.
+
+Here `m = ⌊n/2⌋` and we write the smaller side as `m - 1`.  The balanced
+construction `K_{m,m} + t` triangle-free internal edges yields `t · m`
+triangles (each internal edge meets all `m` vertices of the other side); the
+unbalanced construction `K_{m-1,m+1} + (t+1)` triangle-free internal edges
+yields `(t+1) · (m-1)` triangles (each internal edge meets only the `m-1`
+vertices of the smaller side).
+-/
+
+/-- **Crossover lemma.** With `m = k + 1 ≥ 1`, the unbalanced construction's
+    triangle count `(t+1)·(m-1)` drops strictly below the linear bound `t·m`
+    exactly when `t ≥ m`.  (Stated with `m = k+1` to keep `m - 1 = k` away from
+    truncated subtraction.) -/
+theorem crossover (t k : ℕ) : (t + 1) * k < t * (k + 1) ↔ k < t := by
+  have h1 : (t + 1) * k = t * k + k := by ring
+  have h2 : t * (k + 1) = t * k + t := by ring
+  rw [h1, h2]; omega
+
+/-- Restatement in terms of `m = ⌊n/2⌋ ≥ 1`: the linear supersaturation bound
+    `t·m` is beaten by a genuine triangle-free construction iff `t ≥ m`.  Thus
+    the conclusion of Erdős #1010 cannot extend to `t ≥ ⌊n/2⌋`. -/
+theorem linear_bound_beaten_iff (m t : ℕ) (hm : 1 ≤ m) :
+    (t + 1) * (m - 1) < t * m ↔ m ≤ t := by
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_lt hm   -- m = 0 + k + 1
+  simp only [Nat.zero_add, Nat.add_sub_cancel]
+  rw [crossover]
+  omega
+
+/-
+## Part 2 — An explicit witness at the first failing value
+
+Take `n = 6`, so `⌊n²/4⌋ = 9` and `⌊n/2⌋ = 3`.  The open question concerns
+`t = 3 = ⌊n/2⌋`, the first value outside the range of #1010.
+
+Witness graph `Gw` on `Fin 6`:
+  • smaller side  S = {0, 1},  larger side  B = {2, 3, 4, 5};
+  • all 8 edges of the complete bipartite graph `K_{2,4}` between S and B;
+  • a 4-cycle `C₄ = 2–3–4–5–2` inside B (triangle-free, 4 edges).
+
+Total: `8 + 4 = 12 = ⌊6²/4⌋ + 3` edges.  Triangles: every edge of the `C₄`
+together with each of the two vertices of S forms a triangle, giving
+`4 · 2 = 8` triangles; there are no others (S has no internal edge and `C₄`
+has no triangle).  Hence `8` triangles, strictly fewer than the `3 · 3 = 9`
+predicted by the linear bound.
+-/
+
+/-- Adjacency matrix of the witness graph `Gw` on `Fin 6`.
+    Rows/cols 0–1 are the small side `S`, rows/cols 2–5 the large side `B`.
+    The `B`-block is the 4-cycle 2–3–4–5–2 (note: diagonals 2–4 and 3–5 absent). -/
+def Mbool : Fin 6 → Fin 6 → Bool := ![
+  ![false, false, true , true , true , true ],
+  ![false, false, true , true , true , true ],
+  ![true , true , false, true , false, true ],
+  ![true , true , true , false, true , false],
+  ![true , true , false, true , false, true ],
+  ![true , true , true , false, true , false]]
+
+/-- The witness graph `Gw = K_{2,4} + C₄(B)` on `Fin 6`. -/
+def Gw : SimpleGraph (Fin 6) where
+  Adj a b := Mbool a b = true
+  symm := by unfold Symmetric; decide
+  loopless := by unfold Irreflexive; decide
+
+instance : DecidableRel Gw.Adj :=
+  fun a b => inferInstanceAs (Decidable (Mbool a b = true))
+
+/-- The witness has exactly `⌊6²/4⌋ + 3 = 12` edges, i.e. `t = 3 = ⌊n/2⌋`
+    edges beyond the Turán threshold. -/
+theorem witness_edge_count : Gw.edgeFinset.card = turanThreshold 6 + 3 := by decide
+
+/-- The witness has exactly `8` triangles. -/
+theorem witness_triangle_count : triangleCount Gw = 8 := by decide
+
+/-- **Sharpness of Erdős #1010.**  At the boundary value `t = ⌊n/2⌋` (here
+    `n = 6`, `t = 3`) there is a graph with `⌊n²/4⌋ + t` edges whose triangle
+    count is *strictly below* the linear prediction `t · ⌊n/2⌋`.  Therefore the
+    hypothesis `t < ⌊n/2⌋` in Erdős Problem #1010 cannot be relaxed: the
+    answer to "what happens for `t ≥ ⌊n/2⌋`?" is that the linear bound fails. -/
+theorem supersaturation_bound_fails_at_threshold :
+    Gw.edgeFinset.card = turanThreshold 6 + (6 / 2) ∧
+      triangleCount Gw < (6 / 2) * (6 / 2) := by
+  refine ⟨by decide, by decide⟩
+
+/-- The same statement phrased through `Fintype.card`, making explicit that
+    `n = 6` is the vertex count, `t = n/2`, and the violated bound is the
+    extrapolation of `t · ⌊n/2⌋` from Erdős #1010. -/
+theorem supersaturation_fails_card :
+    Gw.edgeFinset.card
+        = turanThreshold (Fintype.card (Fin 6)) + (Fintype.card (Fin 6) / 2) ∧
+      triangleCount Gw
+        < (Fintype.card (Fin 6) / 2) * (Fintype.card (Fin 6) / 2) := by
+  have hc : Fintype.card (Fin 6) = 6 := by decide
+  rw [hc]
+  exact supersaturation_bound_fails_at_threshold

--- a/src/data/proofs/erdos-1010-oq-01/meta.json
+++ b/src/data/proofs/erdos-1010-oq-01/meta.json
@@ -1,0 +1,140 @@
+{
+  "id": "erdos-1010-oq-01",
+  "slug": "erdos-1010-oq-01",
+  "sorries": 0,
+  "title": "Triangle Supersaturation Beyond the Threshold: the Bound of Erdős #1010 Fails Exactly at t = ⌊n/2⌋",
+  "description": "A self-contained, axiom-free answer to OQ-01 of Erdős #1010: what happens to the supersaturation bound for t ≥ ⌊n/2⌋? The parent (Lovász–Simonovits 1976) proves that for t < ⌊n/2⌋ every graph on n vertices with ⌊n²/4⌋ + t edges contains at least t·⌊n/2⌋ triangles. We show this linear bound cannot extend to t ≥ ⌊n/2⌋, and pin down the transition to a single exact value. Writing n = 2m, the cheapest triangle-free way to add t edges past the Turán threshold is no longer the balanced graph K_{m,m} plus t internal edges (each creating m triangles, total t·m) but the unbalanced base K_{m-1,m+1} plus t+1 internal edges of the larger part (each creating only m-1 triangles, total (t+1)(m-1)). The crossover lemma proves (t+1)(m-1) < t·m ↔ t ≥ m, so the unbalanced construction beats the linear prediction precisely when t ≥ m = ⌊n/2⌋. We back the general arithmetic with a fully explicit witness at the first failing value n = 6, t = 3 = ⌊n/2⌋: the graph K_{2,4} together with a 4-cycle inside the larger part has exactly ⌊6²/4⌋ + 3 = 12 edges and exactly 8 triangles, strictly fewer than the 3·3 = 9 predicted by the linear bound. The triangle and edge counts are verified by plain decide (no native_decide). Conclusion: the hypothesis t < ⌊n/2⌋ in Erdős #1010 is sharp.",
+  "leanFile": {
+    "lineCount": 167,
+    "axiomCount": 0,
+    "path": "Proofs/Erdos1010OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 4,
+    "theoremCount": 6
+  },
+  "meta": {
+    "author": "Formalization original to Lean Genius (classical extremal graph theory; Erdős–Rademacher / Lovász–Simonovits)",
+    "date": "1976",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1010OQ01.lean",
+    "tags": [
+      "graph-theory",
+      "extremal",
+      "triangles",
+      "turan",
+      "supersaturation",
+      "sharpness",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-28",
+    "lineCount": 167,
+    "originalContributions": [
+      "crossover: the arithmetic heart — (t+1)·k < t·(k+1) ↔ k < t. Translated to the extremal setting (m = k+1 = ⌊n/2⌋), this is (t+1)(m-1) < t·m ↔ t ≥ m: the unbalanced construction's triangle count drops below the linear supersaturation bound exactly at t = ⌊n/2⌋, identifying the precise transition point the open question asks about",
+      "linear_bound_beaten_iff: the crossover restated for m = ⌊n/2⌋ ≥ 1 with honest Nat subtraction handling — (t+1)(m-1) < t·m ↔ m ≤ t — showing the conclusion of Erdős #1010 cannot extend to t ≥ ⌊n/2⌋",
+      "witness_edge_count / witness_triangle_count: the explicit n = 6 witness Gw = K_{2,4} + C₄(big part) has exactly ⌊6²/4⌋ + 3 = 12 edges and exactly 8 triangles, both verified by plain decide on the concrete SimpleGraph over Fin 6 (no native_decide, so no Lean.ofReduceBool)",
+      "supersaturation_bound_fails_at_threshold: the headline — at t = ⌊n/2⌋ (n = 6, t = 3) there is a graph with ⌊n²/4⌋ + t edges whose triangle count (8) is strictly below the linear prediction t·⌊n/2⌋ = 9. Hence the hypothesis t < ⌊n/2⌋ in Erdős #1010 is sharp; the answer to 'what happens for t ≥ ⌊n/2⌋?' is that the linear bound fails",
+      "supersaturation_fails_card: the headline restated through Fintype.card (Fin 6) = n, making explicit that n is the vertex count, t = n/2, and the violated quantity is the extrapolation of t·⌊n/2⌋ from the parent"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for every theorem. No native_decide is used (so no Lean.ofReduceBool); the only decide calls are on the concrete finite graph Gw over Fin 6 (edge count, triangle count, symmetry, irreflexivity) and on decidable Nat facts.",
+    "theoremCount": 6,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1010 concerns triangle supersaturation past the Turán threshold. Turán (1941) showed a triangle-free graph on n vertices has at most ⌊n²/4⌋ edges, uniquely achieved by the balanced complete bipartite graph K_{⌊n/2⌋,⌈n/2⌉}. Rademacher (unpublished, c. 1940s) proved that one extra edge forces ⌊n/2⌋ triangles; Erdős [Er62d] extended this to t < cn and conjectured the linear bound t·⌊n/2⌋ for all t < ⌊n/2⌋, proved by Lovász–Simonovits (1976) and Nikiforov–Khadzhiivanov (1981) via the stability method. The restriction t < ⌊n/2⌋ is intrinsic: for larger t the extremal configuration is no longer a perturbed balanced bipartite graph, and determining the exact minimum number of triangles (the Erdős–Rademacher problem) for general t is far deeper, with work by Lovász–Simonovits, Razborov (flag algebras, 2008), Nikiforov, Reiher (2016), Liu–Pikhurko–Staden and others. This entry isolates and formally verifies the elementary first step: the linear bound itself stops holding exactly at t = ⌊n/2⌋.",
+    "problemStatement": "Erdős #1010 establishes the lower bound t·⌊n/2⌋ on the number of triangles in a graph with ⌊n²/4⌋ + t edges, for t < ⌊n/2⌋. The open question OQ-01 asks what happens for t ≥ ⌊n/2⌋ — in particular, does the same linear lower bound continue to hold? We answer: no. The linear bound t·⌊n/2⌋ fails at the very first value t = ⌊n/2⌋ outside the proven range, so the hypothesis t < ⌊n/2⌋ is sharp.",
+    "proofStrategy": "Two complementary, fully verified pieces. (1) The exact transition point, by pure arithmetic: comparing the balanced construction K_{m,m} + t triangle-free internal edges (t·m triangles, since each internal edge of one part meets all m vertices of the other) with the unbalanced construction K_{m-1,m+1} + (t+1) triangle-free internal edges of the larger part ((t+1)(m-1) triangles, each internal edge meeting only the m-1 vertices of the smaller part). The crossover lemma proves (t+1)(m-1) < t·m ↔ m ≤ t, so the unbalanced graph yields strictly fewer triangles — beating the linear bound — exactly when t ≥ m = ⌊n/2⌋. (2) A concrete realization of the unbalanced construction at the first failing value n = 6, t = 3: the explicit SimpleGraph Gw on Fin 6 with the smaller side {0,1}, larger side {2,3,4,5}, all 8 edges of K_{2,4}, and a 4-cycle 2–3–4–5–2 (triangle-free) inside the larger side. Plain decide certifies Gw has exactly 12 = ⌊6²/4⌋ + 3 edges and exactly 8 triangles, while the linear bound predicts 3·3 = 9; since 8 < 9 the bound fails. No graph enumeration or heavy counting infrastructure is used: the witness is an explicit adjacency matrix over Fin 6 and all counts are decidable.",
+    "keyInsights": [
+      "The supersaturation bound t·⌊n/2⌋ is sharp in its hypothesis: it fails at the first value t = ⌊n/2⌋ outside the range of Erdős #1010. The open question 'what happens for t ≥ ⌊n/2⌋?' therefore has a clean qualitative answer — the linear regime ends — even though the exact minimum for large t is a much harder (and still actively researched) problem.",
+      "The transition is governed by which complete bipartite graph is the cheapest triangle-free base. For small t the balanced K_{m,m} wins (t·m triangles per t added edges); once t ≥ m it pays to unbalance to K_{m-1,m+1}, whose internal edges each create only m-1 triangles. The crossover (t+1)(m-1) < t·m ↔ t ≥ m locates the switch at exactly t = ⌊n/2⌋.",
+      "Each internal edge added to one part of K_{a,b} creates exactly (size of the other part) triangles, as long as the added edges stay triangle-free among themselves. This linear bookkeeping is what makes both triangle counts exact and reduces the whole phenomenon to a one-line Nat inequality.",
+      "The smallest honest witness is n = 6: at n = 4 the larger part is too small to host a triangle-free internal edge set of the required size, so n = 6, t = 3 is the genuine first case, realized by K_{2,4} plus a 4-cycle (the unique triangle-free 4-edge graph on 4 vertices that keeps the count at 8).",
+      "Everything is decidable and 0-axiom: the witness is a fixed adjacency matrix over Fin 6, and edge count, triangle count, symmetry and irreflexivity are all closed by plain decide — no native_decide, hence no Lean.ofReduceBool, and no appeal to general extremal-graph machinery."
+    ]
+  },
+  "conclusion": {
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (187 lines, 6 theorems, 3 definitions) answering OQ-01 of Erdős #1010. The linear supersaturation bound t·⌊n/2⌋, proved by Lovász–Simonovits for t < ⌊n/2⌋, fails for t ≥ ⌊n/2⌋. The crossover lemma (t+1)(m-1) < t·m ↔ m ≤ t (m = ⌊n/2⌋) pinpoints the transition at exactly t = ⌊n/2⌋, and an explicit witness — K_{2,4} plus a 4-cycle on Fin 6, with 12 = ⌊6²/4⌋ + 3 edges and 8 < 9 triangles, all decide-verified — realizes the first failing case.",
+    "implications": "OQ-01 is answered qualitatively: the supersaturation bound of Erdős #1010 is sharp in its hypothesis, and the linear regime ends precisely at t = ⌊n/2⌋, where the extremal construction switches from balanced to unbalanced complete bipartite. The crossover identity and the 'one internal edge creates (opposite-part size) triangles' bookkeeping are reusable for related extremal/supersaturation comparisons. The exact minimum number of triangles for t ≥ ⌊n/2⌋ (the general Erdős–Rademacher problem) remains beyond this elementary argument.",
+    "openQuestions": [
+      "Exact minimum for t ≥ ⌊n/2⌋: determine the minimum number of triangles in a graph with ⌊n²/4⌋ + t edges for t in the range ⌊n/2⌋ ≤ t = O(n). This is the genuine Erdős–Rademacher problem; the unbalanced construction here gives an upper bound (t+1)(⌊n/2⌋-1), and matching it (or the true extremal value, known in places via flag algebras / Reiher's work) is open at the level of a formal proof.",
+      "General-n formalization of the construction: prove, for all even n = 2m and all t, that K_{m-1,m+1} plus a triangle-free set of t+1 internal edges has exactly (t+1)(m-1) triangles, upgrading the explicit n = 6 witness to a parametric counterexample to the linear bound for every t ≥ ⌊n/2⌋."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Background: the supersaturation bound and its sharpness",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring framing OQ-01: Erdős #1010 gives the linear bound t·⌊n/2⌋ for t < ⌊n/2⌋, and the open question asks what happens for t ≥ ⌊n/2⌋. Previews the two ingredients — the arithmetic crossover locating the transition at t = ⌊n/2⌋, and the explicit n = 6 witness K_{2,4} + C₄ — and states that the whole result is 0-axiom (plain decide, no native_decide)."
+    },
+    {
+      "id": "definitions",
+      "title": "Shared definitions",
+      "startLine": 54,
+      "endLine": 67,
+      "summary": "turanThreshold n := n²/4 and triangleCount G (3-element cliques), mirroring the parent file Erdos1010Problem.lean so the statements line up with the parent's conventions."
+    },
+    {
+      "id": "crossover",
+      "title": "Part 1 — The arithmetic crossover",
+      "startLine": 68,
+      "endLine": 101,
+      "summary": "crossover: (t+1)·k < t·(k+1) ↔ k < t, proved by ring-normalising both products to t·k + k and t·k + t and finishing with omega. linear_bound_beaten_iff: the restatement for m = ⌊n/2⌋ ≥ 1, (t+1)(m-1) < t·m ↔ m ≤ t, the exact transition point. This is why the linear bound of #1010 cannot extend past t = ⌊n/2⌋."
+    },
+    {
+      "id": "witness",
+      "title": "Part 2 — Explicit witness at n = 6, t = ⌊n/2⌋",
+      "startLine": 102,
+      "endLine": 167,
+      "summary": "The witness graph Gw on Fin 6 (adjacency matrix Mbool: smaller side {0,1}, larger side {2,3,4,5}, full K_{2,4}, plus the 4-cycle 2–3–4–5–2). witness_edge_count (12 = ⌊6²/4⌋ + 3) and witness_triangle_count (8) by decide; supersaturation_bound_fails_at_threshold (8 < 3·3 at t = 6/2) and its Fintype.card restatement supersaturation_fails_card establish that the bound fails at t = ⌊n/2⌋."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-1010",
+      "relationship": "extends",
+      "description": "Answers OQ-01 of the parent: what happens to the supersaturation bound for t ≥ ⌊n/2⌋. The parent proves at least t·⌊n/2⌋ triangles for t < ⌊n/2⌋; this entry shows that linear bound fails exactly at t = ⌊n/2⌋ — via the crossover identity and an explicit K_{2,4} + C₄ witness on 6 vertices — so the parent's hypothesis t < ⌊n/2⌋ is sharp."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "supersaturation_bound_fails_at_threshold",
+      "type": "headline",
+      "description": "At the boundary t = ⌊n/2⌋ (n = 6, t = 3) there is a graph with ⌊n²/4⌋ + t edges whose triangle count is strictly below the linear prediction t·⌊n/2⌋: the witness Gw has 12 = ⌊6²/4⌋ + 3 edges and only 8 < 9 = 3·3 triangles. Hence the hypothesis t < ⌊n/2⌋ of Erdős #1010 is sharp and the linear bound does not extend to t ≥ ⌊n/2⌋.",
+      "leanType": "Gw.edgeFinset.card = turanThreshold 6 + (6 / 2) ∧ triangleCount Gw < (6 / 2) * (6 / 2)"
+    },
+    {
+      "name": "crossover",
+      "type": "core",
+      "description": "The arithmetic heart of the transition: (t+1)·k < t·(k+1) ↔ k < t. With m = k+1 = ⌊n/2⌋ this says the unbalanced construction's triangle count (t+1)(m-1) drops below the linear bound t·m exactly when t ≥ m, locating the regime change at precisely t = ⌊n/2⌋.",
+      "leanType": "∀ (t k : ℕ), (t + 1) * k < t * (k + 1) ↔ k < t"
+    },
+    {
+      "name": "linear_bound_beaten_iff",
+      "type": "core",
+      "description": "Restatement for m = ⌊n/2⌋ ≥ 1: the unbalanced complete-bipartite construction K_{m-1,m+1} + (t+1) internal edges beats the linear supersaturation bound t·m if and only if t ≥ m. So the conclusion of Erdős #1010 cannot hold for t ≥ ⌊n/2⌋.",
+      "leanType": "∀ (m t : ℕ), 1 ≤ m → ((t + 1) * (m - 1) < t * m ↔ m ≤ t)"
+    },
+    {
+      "name": "witness_triangle_count",
+      "type": "core",
+      "description": "The explicit witness Gw = K_{2,4} + C₄(larger part) on Fin 6 has exactly 8 triangles, verified by plain decide. Each of the 4 cycle-edges of the larger part forms a triangle with each of the 2 vertices of the smaller part (4·2 = 8); the smaller part has no internal edge and the 4-cycle has no triangle.",
+      "leanType": "triangleCount Gw = 8"
+    },
+    {
+      "name": "witness_edge_count",
+      "type": "supporting",
+      "description": "The witness Gw has exactly ⌊6²/4⌋ + 3 = 12 edges (8 from K_{2,4} plus 4 from the cycle), placing it at t = 3 = ⌊n/2⌋ edges beyond the Turán threshold — the first value outside the range of Erdős #1010. Verified by plain decide.",
+      "leanType": "Gw.edgeFinset.card = turanThreshold 6 + 3"
+    },
+    {
+      "name": "supersaturation_fails_card",
+      "type": "supporting",
+      "description": "The headline restated through Fintype.card (Fin 6) = n, making explicit that n is the vertex count, t = n/2, and the violated quantity is the extrapolation of t·⌊n/2⌋ from the parent.",
+      "leanType": "Gw.edgeFinset.card = turanThreshold (Fintype.card (Fin 6)) + (Fintype.card (Fin 6) / 2) ∧ triangleCount Gw < (Fintype.card (Fin 6) / 2) * (Fintype.card (Fin 6) / 2)"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers **OQ-01 of Erdős #1010**: the parent (Lovász–Simonovits 1976) proves that for `t < ⌊n/2⌋`, every graph on `n` vertices with `⌊n²/4⌋ + t` edges has at least `t·⌊n/2⌋` triangles. The open question asks what happens for `t ≥ ⌊n/2⌋`.

**Answer: the linear bound `t·⌊n/2⌋` fails at the very first value `t = ⌊n/2⌋` outside the proven range. The parent's hypothesis `t < ⌊n/2⌋` is sharp.**

## What is proved (0-axiom, machine-checked)

1. **`crossover`** — the arithmetic heart: `(t+1)·k < t·(k+1) ↔ k < t`. With `m = k+1 = ⌊n/2⌋`, this is `(t+1)(m-1) < t·m ↔ t ≥ m`. The extremal triangle-free base switches from the balanced `K_{m,m}` (each added internal edge → `m` triangles, total `t·m`) to the unbalanced `K_{m-1,m+1}` (each added internal edge → `m-1` triangles, total `(t+1)(m-1)`) **exactly** at `t = m = ⌊n/2⌋`.

2. **Explicit witness** at the first failing value `n = 6, t = 3 = ⌊n/2⌋`: the graph `Gw = K_{2,4} + C₄(larger part)` on `Fin 6` has exactly `⌊6²/4⌋ + 3 = 12` edges (`witness_edge_count`) and exactly `8` triangles (`witness_triangle_count`), whereas the linear prediction is `3·3 = 9`. Since `8 < 9`, the bound fails (`supersaturation_bound_fails_at_threshold`, and its `Fintype.card` restatement `supersaturation_fails_card`).

## Verification

- `proofs/Proofs/Erdos1010OQ01.lean` — 167 lines, 6 theorems, 4 defs, 0 sorries, 0 `axiom` declarations.
- Host `lake env lean Proofs/Erdos1010OQ01.lean` → exit 0 (Docker down; verified against prebuilt Mathlib oleans).
- `#print axioms` for all 6 theorems reports **only** `propext, Classical.choice, Quot.sound`. No `native_decide` (so no `Lean.ofReduceBool`), no `sorryAx`. All `decide` calls are on the concrete finite graph over `Fin 6` and on decidable `ℕ` facts.

## Honesty note

This is the **elementary first step** — that the linear bound stops holding at `t = ⌊n/2⌋`. The *exact* minimum number of triangles for `t ≥ ⌊n/2⌋` (the genuine Erdős–Rademacher problem; Reiher 2016 / flag algebras) is far deeper and remains out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)