### PR TITLE
Enrich Reverse Minkowski from CS (cs-integral-oq-02-oq-03): cover the header

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "cauchy-schwarz-integral-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 59 },
+    "type": "context",
+    "title": "The Open Question: Reverse Minkowski from Cauchy–Schwarz?",
+    "content": "The parent entry (cauchy-schwarz-integral-oq-02) derived the FORWARD Minkowski inequality ‖f+g‖_p ≤ ‖f‖_p + ‖g‖_p from Cauchy–Schwarz and asked whether the REVERSE inequality |‖f‖_p − ‖g‖_p| ≤ ‖f+g‖_p admits the same CS-based derivation. This file answers YES via two complementary paths, both previewed in the docstring. Path 1 (p = 2 and any real inner-product space): use the CS LOWER bound ⟪f,g⟫ ≥ −‖f‖·‖g‖ in the norm-squared identity ‖f+g‖² = ‖f‖² + 2⟪f,g⟫ + ‖g‖² to get ‖f+g‖² ≥ (‖f‖−‖g‖)², then take square roots — the exact mirror of the parent's forward proof, which used the CS upper bound. Path 2 (general Lᵖ, no inner product): the reverse inequality is a formal consequence of the forward triangle inequality, valid in any normed group, so it holds for Lᵖ once forward Minkowski (a parent CS/Hölder corollary) is in hand. The imports bring in L²/inner-product structure, the mean inequalities, and the Lp normed-group instance; the setup opens MeasureTheory over a measure space (α, μ).",
+    "mathContext": "Forward and reverse Minkowski are the two halves of one estimate: $-\\|f\\|\\|g\\| \\le \\langle f,g\\rangle \\le \\|f\\|\\|g\\|$, each fed through $\\|f+g\\|^2 = \\|f\\|^2 + 2\\langle f,g\\rangle + \\|g\\|^2$.",
+    "significance": "context",
+    "relatedConcepts": ["reverse triangle inequality", "Minkowski inequality", "Cauchy–Schwarz upper vs lower bound", "Lᵖ spaces"],
+    "prerequisites": ["parent: cauchy-schwarz-integral-oq-02 (forward Minkowski from CS)", "inner-product and Lᵖ norm structure"]
+  },
+  {
     "id": "ann-cs-lower-bound",
     "proofId": "cauchy-schwarz-integral-oq-02-oq-03",
     "range": { "startLine": 64, "endLine": 72 },

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/meta.json
@@ -70,6 +70,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "The Open Question and Its Two-Path Answer",
+      "startLine": 1,
+      "endLine": 59,
+      "summary": "Imports and module docstring. States the open question inherited from the parent (cauchy-schwarz-integral-oq-02): can the REVERSE Minkowski inequality |‖f‖_p − ‖g‖_p| ≤ ‖f+g‖_p also be derived from Cauchy–Schwarz? The answer is YES, by two complementary routes set out here — Path 1 (p = 2 and abstract inner-product spaces) uses the CS LOWER bound ⟪f,g⟫ ≥ −‖f‖·‖g‖ directly, mirroring the parent's forward derivation from the CS upper bound; Path 2 (general Lᵖ) derives it from the forward triangle inequality, which the parent obtained from CS/Hölder. Sets up the measure-space context (noncomputable section, open MeasureTheory, namespace ReverseMinkowskiFromCS).",
+      "mathContext": "Open question: $\\big|\\,\\|f\\|_p - \\|g\\|_p\\,\\big| \\le \\|f+g\\|_p$ from Cauchy–Schwarz? Answer: yes — CS lower bound for $p=2$, forward triangle for general $p$."
+    },
+    {
       "id": "from-cs",
       "title": "Reverse Minkowski from the CS Lower Bound",
       "startLine": 60,


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-integral-oq-02-oq-03` (Reverse Minkowski Inequality from Cauchy–Schwarz; quality 83, pass 0).

The entry is already richly enriched (highlights, openQuestion, implications, 5 keyInsights, conclusion). The one genuine structural gap: sections and annotations both started at line 60, leaving the docstring + setup (lines 1–59) uncovered.

## Changes
- **Added a header section (1–59)** and a **context annotation** for the module docstring — frames the inherited open question (can the *reverse* Minkowski inequality also come from Cauchy–Schwarz?) and its two-path YES answer: the CS *lower* bound for p = 2 / inner-product spaces, and the forward triangle inequality for general Lᵖ.
- sections 3 → 4, annotations 3 → 4; full-file coverage.
- No deepening of already-complete fields — structural gap fill only.

## Verification
- meta.json + annotations.json valid JSON; `check-meta-size.ts` within caps
- `pnpm build` — ✓ built

🤖 Generated with [Claude Code](https://claude.com/claude-code)