### PR TITLE
Enrich Knight's Tour Oblique OQ-03: fix invalid annotation significance

### DIFF
--- a/src/data/proofs/knights-tour-oblique-oq-03/annotations.json
+++ b/src/data/proofs/knights-tour-oblique-oq-03/annotations.json
@@ -57,7 +57,7 @@
     "title": "Invertibility, faithfulness, and orbit action",
     "content": "d4_reverse_leftInverse: the composite symmetry t ↦ reverseTour (applyD4Tour g t) is undone by t ↦ reverseTour (applyD4Tour (d4Inv g) t). The proof rewrites reverseTour (applyD4Tour (d4Inv g) (reverseTour (applyD4Tour g t))) by pulling the inner D₄ element through the reversal (reverseTour_applyD4Tour), collapsing the resulting double reversal (reverseTour_involutive), and cancelling the D₄ pair (applyD4Tour_inv_left) — three rewrites, no induction. d4_reverse_injective then gets injectivity from the left inverse via Function.LeftInverse.injective, establishing that D₄ together with reversal acts faithfully on the finite type ClosedTour (an order-16 D₄ × ℤ/2 symmetry). reverseTour_applyD4Tour_orbit records the orbit-level reading: reversal maps the D₄-orbit of t onto the D₄-orbit of reverseTour t (witnessed by the same group element g), which is the form relevant to the histogram's orbit-divisibility.",
     "mathContext": "Composite $R \\circ \\sigma_g$ has inverse $R \\circ \\sigma_{g^{-1}}$ (commutation + involution + $D_4$ inverse), hence is injective; reversal permutes $D_4$-orbits.",
-    "significance": "important",
+    "significance": "key",
     "relatedConcepts": [
       "left inverse implies injective",
       "faithful group action",


### PR DESCRIPTION
Enrichment pass for `knights-tour-oblique-oq-03`.

## Fix: invalid significance (render bug)
`ann-ktoq03-inverse-injective` had `significance: "important"`, not a valid `AnnotationSignificance` value (`critical|key|supporting`), so `AnnotationPanel.tsx` rendered a blank badge and `ProofLine.tsx` used the default marker color. Set `key` — it establishes the faithful order-16 D₄×ℤ/2 action on closed tours.

## Axiom integrity (verified, unchanged)
`status: axiomatized`, `badge: axiom`, `axiomCount: 0` is appropriately conservative: this file's own theorems are assumption-free (the commute lemma is pure `List.map_reverse` through `closedTour_eq_iff`), but the entry sits in the knights-tour-oblique lineage that uses `native_decide` (`Lean.ofReduceBool`) and accepts `unique_four_oblique` as an axiom (Knuth's ~1.3×10¹³-tour enumeration). The header annotation already documents this honestly. Left as-is per the "when in doubt, axiomatized" policy.

## Already strong (left as-is)
overview (keyInsights + prerequisites), conclusion, 3 sections, 3 properly-schema'd crossReferences, 2 references, and 3 full-depth annotations covering the file. meta.json ~14 KB.

## Verification
- `scripts/annotations/resolver.ts validate` → **Valid: 3, Misaligned: 0**; significance values all valid enums; `pnpm build` passes.
- No `index.ts` change.