### PR TITLE
Enrich Explicit Factorization over 𝔽_p and ℚ (bezout-oq-02-01-01-02): cover the header

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "ann-bezout-fp-header",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "context",
+    "title": "Making Abstract Factorization Explicit over 𝔽_p and ℚ",
+    "content": "The parent (BezoutIdentityOQ02OQ01OQ01) establishes unique factorization in polynomial rings abstractly and advertises two concrete settings — ℚ and 𝔽_p — leaving the explicit factorizations as an open question. This file fills it with five results that together exhibit a sharp dichotomy. Over a finite field the polynomial X^|K| − X is maximally SEPARABLE: it splits into |K| distinct linear factors, one per field element (fermat_factorization, the polynomial form of Fermat's little theorem a^|K| = a). Over 𝔽_p the binomial X^p − a is maximally INSEPARABLE: the Frobenius endomorphism collapses it to a single root of multiplicity p, X^p − a = (X − a)^p (frobenius_factorization). And over ℚ (characteristic 0) Fermat factorization fails entirely — witnessed by 2, a root of X^5 − X over 𝔽_5 but evaluating to 30 over ℚ. The new content beyond Mathlib is the equational product form (Mathlib has only the root multiset); the rest is a sub_pow_char + ZMod.pow_card computation.",
+    "mathContext": "Separable extreme $X^{|K|}-X=\\prod_{a}(X-a)$ vs. inseparable extreme $X^p-a=(X-a)^p$; characteristic $0$ (ℚ) admits neither.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Fermat's little theorem",
+      "Frobenius endomorphism",
+      "separable vs inseparable polynomials",
+      "splitting fields",
+      "characteristic p"
+    ],
+    "prerequisites": [
+      "finite fields and 𝔽_p = ZMod p",
+      "polynomial roots and factorization",
+      "the Frobenius map x ↦ xᵖ in characteristic p"
+    ]
+  },
+  {
     "id": "ann-bezout-fp-fermat",
     "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
     "range": { "startLine": 51, "endLine": 73 },


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-01-oq-01-oq-02` (Explicit Factorization over Finite Fields and ℚ; quality 83, pass 0).

Sections already cover the full 128-line file, but annotation coverage was only ~39% — notably the docstring (lines 1–50) had no annotation.

## Changes
- **Added a context annotation for the module docstring (1–50)**, framing the inherited open question and the central separable/inseparable dichotomy the file exhibits: X^|K|−X splits into |K| distinct linear factors over a finite field (Fermat), X^p−a collapses to (X−a)^p over 𝔽_p (Frobenius), and Fermat factorization fails over ℚ (char 0, witnessed by 2).
- annotations 3 → 4; header now covered.
- Structural gap fill only — no deepening of already-complete fields.

## Verification
- annotations.json valid JSON (4 annotations); `check-meta-size.ts` within caps
- `pnpm build` — ✓ built

🤖 Generated with [Claude Code](https://claude.com/claude-code)