### PR TITLE
Enrich Separability = No Repeated Linear Factor (factor-rem-oq-01-02-01): cover the header

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-02-oq-01/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "factor-remainder-theorem-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 68
+    },
+    "type": "context",
+    "title": "Does the Ordinary Derivative Still Detect Repeated Roots in Characteristic p?",
+    "content": "Mathlib defines separability through the ordinary derivative — Separable p :↔ IsCoprime p (derivative p). The parent entry's hasseDeriv_detects_char_p shows the ordinary derivative can be deceptive in positive characteristic: over 𝔽₂ the derivative of X² is identically 0, so the naive 'p and p′ share a root' test looks blind. This leaf resolves the worry. The key distinction is multiplicity: separability is a squarefreeness (multiplicity ≤ 1) condition, and double roots — multiplicity exactly 2 — ARE detected by the ordinary derivative in every characteristic, because hasseDeriv 1 = derivative and the divided-power correction only matters at multiplicity ≥ p. Building on the parent's characteristic-free double_root_iff, the file makes the link explicit and computable: for a nonzero split polynomial over a field, p.Separable ↔ ∀ a, ¬(X−a)² ∣ p — separability is exactly the absence of a repeated linear factor — and confirms it with explicit char-2 witnesses (X²+X separable, X² not).",
+    "mathContext": "Worry: $\\operatorname{char} = 2 \\Rightarrow (X^2)' = 0$. Resolution: double roots (mult. $2$) are caught by the ordinary derivative in all characteristics; only mult. $\\ge p$ needs the Hasse/divided-power correction.",
+    "significance": "context",
+    "relatedConcepts": [
+      "separability",
+      "ordinary vs Hasse derivative",
+      "squarefree polynomials",
+      "characteristic p",
+      "repeated roots and multiplicity"
+    ],
+    "prerequisites": [
+      "parent: factor-remainder-theorem-oq-01-oq-02 (Hasse multiplicity factor theorem)",
+      "Polynomial.Separable and IsCoprime",
+      "the ordinary derivative on polynomials"
+    ]
+  },
+  {
     "id": "ann-repeated-root",
     "proofId": "factor-remainder-theorem-oq-01-oq-02-oq-01",
     "range": {

--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-02-oq-01/meta.json
@@ -106,6 +106,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview: Separability as the Absence of a Repeated Linear Factor",
+      "startLine": 1,
+      "endLine": 68,
+      "summary": "Imports and module docstring. Recalls the parent (factor-remainder-theorem-oq-01-oq-02), which proves the characteristic-free Hasse multiplicity factor theorem and its k=2 instance double_root_iff via the ordinary derivative. Mathlib defines Separable p :↔ IsCoprime p (derivative p), again through the ordinary derivative — raising the worry that in positive characteristic (where the ordinary derivative of X² vanishes) the criterion might miss repeated roots. The docstring explains why it does not: squarefreeness is a multiplicity-≤-1 condition, and double roots are detected by the ordinary derivative in every characteristic (the divided-power correction is only needed at multiplicity ≥ p). Lists the main results — the (X−a)²-divisibility characterization of separability and explicit char-2 witnesses — and sets up the namespace.",
+      "mathContext": "$p\\text{ Separable} \\iff \\forall a,\\ \\neg\\,(X-a)^2 \\mid p$ (for nonzero split $p$ over a field), in every characteristic; squarefreeness is detected by the ordinary derivative."
+    },
+    {
       "id": "repeated-root",
       "title": "Section I: Repeated Linear Factor via the Ordinary Derivative",
       "startLine": 69,


### PR DESCRIPTION
Enrichment pass for `factor-remainder-theorem-oq-01-oq-02-oq-01` (Separability Is the Absence of a Repeated Linear Factor, in Every Characteristic; quality 83, pass 0).

Sections and annotations both started at line 69 on a 154-line file, leaving the 68-line docstring + setup uncovered.

## Changes
- **Added a header section (1–68) and a context annotation** for the module docstring — frames the central question (Mathlib defines separability via the *ordinary* derivative; does that still detect repeated roots in characteristic p, where (X²)′ = 0 over 𝔽₂?) and its resolution (double roots = multiplicity 2 are caught by the ordinary derivative in every characteristic; only multiplicity ≥ p needs the parent's Hasse/divided-power correction).
- sections 3 → 4, annotations 3 → 4; full-file coverage.
- Structural gap fill only — no deepening of already-complete fields.

## Verification
- meta.json + annotations.json valid JSON; `check-meta-size.ts` within caps
- `pnpm build` — ✓ built

🤖 Generated with [Claude Code](https://claude.com/claude-code)