### PR TITLE
research(erdos-1007-oq-04): max graph dimension — monotonicity + edge-count bound [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1240,6 +1240,7 @@ import Proofs.Erdos1006Problem
 import Proofs.Erdos1007OQ01
 import Proofs.Erdos1007OQ01Aristotle
 import Proofs.Erdos1007OQ01OQ01
+import Proofs.Erdos1007OQ04
 import Proofs.Erdos1007OQ05
 import Proofs.Erdos1007OQ05OQ01
 import Proofs.Erdos1007Problem

--- a/proofs/Proofs/Erdos1007OQ04.lean
+++ b/proofs/Proofs/Erdos1007OQ04.lean
@@ -1,0 +1,265 @@
+import Mathlib
+
+/-!
+# Erdős #1007 OQ-04: The Maximum Dimension of a Graph on n Vertices and m Edges
+
+## Context
+
+`Erdos1007OQ05.lean` / `Erdos1007OQ01.lean` study the **graph dimension** — the least
+Euclidean dimension `d` in which a graph has a unit-distance embedding
+(`UnitDistanceEmbedding`). They pin down the dimension of the *complete* graph: the
+regular simplex gives `dim(Kₙ) = n − 1` (`Erdos1007OQ01.lean`), the sharp simplex bound.
+
+The parent's fourth open question looks past the complete graph:
+
+> *What is the maximum dimension of a graph on `n` vertices and `m` edges? The simplex
+> bound gives `dim(Kₙ) = n − 1`, but sparse graphs may also have high dimension.*
+
+So the relevant parameter is not just the vertex count `n` but the **edge count `m`**.
+This file supplies the structural facts that frame that question and proves the two
+clean, fully-verified bounds available without the deep extremal geometry of House (2013):
+
+* **Subgraph monotonicity** — deleting edges can only *decrease* the dimension. Hence the
+  maximum dimension over all graphs on `n` vertices is attained by `Kₙ` (so it equals
+  `n − 1`), and more edges never hurt.
+* **A vertex-support / edge-count upper bound** — the dimension is controlled by the set
+  of vertices that actually carry an edge: if a finite set `S` contains both endpoints of
+  every edge, the graph embeds in `ℝ^{|S|}`. In particular a graph with `m` edges has at
+  most `2m` non-isolated vertices, so its dimension is at most `2m` — *independent of the
+  total vertex count `n`*. This is the precise sense in which a sparse graph cannot have
+  dimension much larger than its edge count, even when it has many (isolated) vertices.
+
+The common engine is `hasUnitEmbedding_of_idx`: place vertex `v` at `(1/√2)·e_{idx v}`
+for any index map `idx : V → Fin N` that separates the endpoints of every edge. All
+distinct scaled basis vectors are at distance `1`, so every edge becomes a unit distance.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`. The
+`UnitDistanceEmbedding` structure and `hasUnitEmbedding` predicate mirror
+`Erdos1007OQ05.lean` (reproduced locally so the file stands alone; the parent's
+`Erdos1007Problem` is bit-rotted under the 4.26.0 toolchain and cannot be imported).
+The scaled-basis distance computation `scaled_basis_sq_dist` is reproduced verbatim from
+`Erdos1007OQ05.lean`. Everything else is new.
+-/
+
+namespace Erdos1007OQ04
+
+open Finset
+
+/-- A unit-distance embedding of a graph in `ℝⁿ` (mirrors
+    `Erdos1007OQ05.UnitDistanceEmbedding`). -/
+structure UnitDistanceEmbedding (V : Type*) (adj : V → V → Prop) (n : ℕ) where
+  embed : V → Fin n → ℝ
+  unit_edges : ∀ u v, adj u v →
+    Real.sqrt (Finset.univ.sum fun i => (embed u i - embed v i) ^ 2) = 1
+
+/-- A graph can be embedded as unit distances in `ℝⁿ`. -/
+def hasUnitEmbedding (V : Type*) (adj : V → V → Prop) (n : ℕ) : Prop :=
+  Nonempty (UnitDistanceEmbedding V adj n)
+
+/-! ## The scaled-basis distance computation
+
+`scaled_basis_sq_dist` is reproduced verbatim from `Erdos1007OQ05.lean`: the squared
+distance between two scaled standard basis vectors at distinct coordinates is `1`. -/
+
+/-- Helper: squared distance between scaled basis vectors at distinct positions. -/
+private lemma scaled_basis_sq_dist {n : ℕ} {i j : Fin n} (hij : i ≠ j) :
+    Finset.univ.sum (fun k : Fin n =>
+      ((if i = k then (1 : ℝ) / Real.sqrt 2 else 0) -
+       (if j = k then 1 / Real.sqrt 2 else 0)) ^ 2) = 1 := by
+  have hc : ((1 : ℝ) / Real.sqrt 2) ^ 2 = 1 / 2 := by
+    rw [div_pow, one_pow, Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
+  -- Each squared difference splits into a contribution at coordinate `i` and at `j`.
+  have key : ∀ k : Fin n,
+      ((if i = k then (1 : ℝ) / Real.sqrt 2 else 0) -
+       (if j = k then 1 / Real.sqrt 2 else 0)) ^ 2
+        = (if i = k then (1 : ℝ) / 2 else 0) + (if j = k then 1 / 2 else 0) := by
+    intro k
+    rcases eq_or_ne i k with hik | hik
+    · subst hik
+      rw [if_pos rfl, if_neg hij.symm, if_pos rfl, if_neg hij.symm, sub_zero, add_zero, hc]
+    · rcases eq_or_ne j k with hjk | hjk
+      · subst hjk
+        rw [if_neg hik, if_pos rfl, if_neg hik, if_pos rfl, zero_sub, neg_sq, zero_add, hc]
+      · rw [if_neg hik, if_neg hjk, if_neg hik, if_neg hjk, sub_zero]
+        simp
+  rw [Finset.sum_congr rfl (fun k _ => key k), Finset.sum_add_distrib,
+    Finset.sum_ite_eq, Finset.sum_ite_eq]
+  simp only [Finset.mem_univ, if_true]
+  norm_num
+
+/-! ## The index embedding
+
+The single construction underlying every bound below. -/
+
+/-- **Index embedding.** Place vertex `v` at the scaled basis vector `(1/√2)·e_{idx v}` in
+    `ℝ^N`. If `idx` sends the two endpoints of every edge to *distinct* coordinates, this
+    is a unit-distance embedding: distinct scaled basis vectors are at distance exactly
+    `1`. This packages the scaled-basis trick so that every bound below is a one-line
+    choice of an index map. -/
+theorem hasUnitEmbedding_of_idx {V : Type*} {adj : V → V → Prop} {N : ℕ}
+    (idx : V → Fin N) (hsep : ∀ u v, adj u v → idx u ≠ idx v) :
+    hasUnitEmbedding V adj N := by
+  refine ⟨⟨fun v k => if idx v = k then 1 / Real.sqrt 2 else 0, ?_⟩⟩
+  intro u v huv
+  rw [scaled_basis_sq_dist (hsep u v huv)]
+  exact Real.sqrt_one
+
+/-! ## Subgraph monotonicity
+
+Deleting edges never raises the dimension: the same embedding satisfies fewer
+constraints. -/
+
+/-- **Subgraph monotonicity.** If `adj₁` is a subgraph of `adj₂` (every `adj₁`-edge is an
+    `adj₂`-edge), any unit embedding of `adj₂` is also one of `adj₁`. So the dimension is
+    monotone under edge addition, and the maximum dimension over graphs on a fixed vertex
+    set is attained by the complete graph. -/
+theorem hasUnitEmbedding_restrict {V : Type*} {adj₁ adj₂ : V → V → Prop} {n : ℕ}
+    (hsub : ∀ u v, adj₁ u v → adj₂ u v) (h : hasUnitEmbedding V adj₂ n) :
+    hasUnitEmbedding V adj₁ n :=
+  h.elim fun e => ⟨⟨e.embed, fun u v huv => e.unit_edges u v (hsub u v huv)⟩⟩
+
+/-! ## Monotonicity in the ambient dimension
+
+Padding with zero coordinates extends an embedding to any higher dimension (reproduced
+from `Erdos1007OQ05OQ01.lean` so the edge-count bound can conclude `≤ 2m`). -/
+
+/-- Padding an embedding with zero coordinates extends it from `ℝⁿ` to `ℝᵐ` for `m ≥ n`. -/
+def embedding_mono {V : Type*} {adj : V → V → Prop} {n m : ℕ} (hnm : n ≤ m)
+    (e : UnitDistanceEmbedding V adj n) : UnitDistanceEmbedding V adj m := by
+  classical
+  refine ⟨fun v i => if h : (i : ℕ) < n then e.embed v ⟨i, h⟩ else 0, ?_⟩
+  intro u v huv
+  set G : ℕ → ℝ := fun j =>
+    ((if h : j < n then e.embed u ⟨j, h⟩ else 0) - (if h : j < n then e.embed v ⟨j, h⟩ else 0)) ^ 2
+    with hG
+  have hGzero : ∀ j ∈ range m, j ∉ range n → G j = 0 := by
+    intro j _ hj
+    simp only [mem_range, not_lt] at hj
+    simp only [hG, dif_neg (not_lt.mpr hj), sub_zero]
+    ring
+  have hsub : range n ⊆ range m := fun x hx =>
+    Finset.mem_range.mpr (lt_of_lt_of_le (Finset.mem_range.mp hx) hnm)
+  have hsum : (∑ i : Fin m, G (i : ℕ)) = ∑ i : Fin n, (e.embed u i - e.embed v i) ^ 2 := by
+    rw [Fin.sum_univ_eq_sum_range G m,
+      (Finset.sum_subset hsub hGzero).symm,
+      ← Fin.sum_univ_eq_sum_range G n]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    simp only [hG, dif_pos i.isLt, Fin.eta]
+  rw [hsum]
+  exact e.unit_edges u v huv
+
+/-- Monotonicity of `hasUnitEmbedding` in the ambient dimension. -/
+theorem hasUnitEmbedding_mono {V : Type*} {adj : V → V → Prop} {n m : ℕ} (hnm : n ≤ m)
+    (h : hasUnitEmbedding V adj n) : hasUnitEmbedding V adj m :=
+  h.elim fun e => ⟨embedding_mono hnm e⟩
+
+/-! ## The universal bound: dimension ≤ |V|
+
+Indexing all vertices injectively gives an embedding in `ℝ^{|V|}`. -/
+
+/-- **Universal upper bound.** Every loopless graph on a finite vertex set `V` embeds in
+    `ℝ^{|V|}` (place vertices at distinct scaled basis vectors). Combined with
+    `dim(Kₙ) = n − 1` (the simplex bound, `Erdos1007OQ01.lean`), the maximum dimension of
+    a graph on `n` vertices is between `n − 1` and `n`; the sharp value `n − 1` follows
+    from the regular-simplex embedding of `Kₙ`. -/
+theorem hasUnitEmbedding_card (V : Type*) [Fintype V] [DecidableEq V]
+    (adj : V → V → Prop) (hirr : ∀ v, ¬ adj v v) :
+    hasUnitEmbedding V adj (Fintype.card V) := by
+  refine hasUnitEmbedding_of_idx (Fintype.equivFin V) ?_
+  intro u v huv
+  have huv' : u ≠ v := fun h => hirr v (h ▸ huv)
+  exact fun h => huv' ((Fintype.equivFin V).injective h)
+
+/-! ## The edge-count bound: dimension ≤ |support| ≤ 2·(#edges)
+
+The dimension is controlled by the vertices that actually carry an edge. -/
+
+/-- **Edge-cover bound.** If a finite set `S` contains both endpoints of every edge, the
+    graph embeds in `ℝ^{|S|}`. Isolated vertices (those outside `S`) cost no dimension:
+    they are all placed at the origin. -/
+theorem hasUnitEmbedding_of_cover {V : Type*} [DecidableEq V] {adj : V → V → Prop}
+    (hirr : ∀ v, ¬ adj v v) (S : Finset V)
+    (hcover : ∀ u v, adj u v → u ∈ S ∧ v ∈ S) :
+    hasUnitEmbedding V adj S.card := by
+  classical
+  rcases Nat.eq_zero_or_pos S.card with h0 | hpos
+  · -- `S` empty ⟹ no edges ⟹ embed trivially in `ℝ⁰`.
+    have hSempty : S = ∅ := Finset.card_eq_zero.mp h0
+    have hempty : ∀ u v, ¬ adj u v := by
+      intro u v huv
+      have hu := (hcover u v huv).1
+      rw [hSempty] at hu
+      exact absurd hu (Finset.notMem_empty u)
+    rw [h0]
+    exact ⟨⟨fun _ i => i.elim0, fun u v huv => absurd huv (hempty u v)⟩⟩
+  · haveI : NeZero S.card := ⟨hpos.ne'⟩
+    refine hasUnitEmbedding_of_idx
+      (fun v => if h : v ∈ S then S.equivFin ⟨v, h⟩ else 0) ?_
+    intro u v huv
+    obtain ⟨huS, hvS⟩ := hcover u v huv
+    have hne : u ≠ v := fun h => hirr v (h ▸ huv)
+    simp only [dif_pos huS, dif_pos hvS, ne_eq]
+    intro hidx
+    exact hne (congrArg Subtype.val (S.equivFin.injective hidx))
+
+/-! ## Edge-count corollary for simple graphs
+
+For a finite simple graph, the incidence support has at most `2·(#edges)` vertices, so the
+dimension is at most `2·(#edges)` regardless of how many isolated vertices the graph has. -/
+
+/-- The set of vertices incident to at least one edge of a finite simple graph. -/
+noncomputable def support {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] : Finset V :=
+  Finset.univ.filter (fun v => ∃ w, G.Adj v w)
+
+/-- **Edge-count upper bound.** A finite simple graph with `m` edges embeds in `ℝ^{2m}`,
+    independent of the number of vertices. So a graph's dimension is at most twice its
+    edge count: a *sparse* graph has *low* dimension, no matter how large `n` is.
+
+    (The factor `2` is the trivial endpoint count; the sharp constant is the subtler part
+    of the open question.) -/
+theorem hasUnitEmbedding_two_mul_edges {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] :
+    hasUnitEmbedding V G.Adj (2 * G.edgeFinset.card) := by
+  classical
+  -- Every edge endpoint lies in the support `S`.
+  have hcover : ∀ u v, G.Adj u v → u ∈ support G ∧ v ∈ support G := by
+    intro u v huv
+    refine ⟨Finset.mem_filter.mpr ⟨Finset.mem_univ u, ⟨v, huv⟩⟩,
+            Finset.mem_filter.mpr ⟨Finset.mem_univ v, ⟨u, huv.symm⟩⟩⟩
+  have hbase : hasUnitEmbedding V G.Adj (support G).card :=
+    hasUnitEmbedding_of_cover (fun v => G.loopless v) (support G) hcover
+  -- The support has at most `2m` vertices: each non-isolated vertex has degree ≥ 1, and
+  -- the degrees sum to `2m` (handshake lemma).
+  have hle : (support G).card ≤ 2 * G.edgeFinset.card := by
+    rw [← SimpleGraph.sum_degrees_eq_twice_card_edges]
+    calc (support G).card
+        = ∑ _v ∈ support G, 1 := by rw [Finset.sum_const, smul_eq_mul, mul_one]
+      _ ≤ ∑ v ∈ support G, G.degree v := by
+          refine Finset.sum_le_sum fun v hv => ?_
+          rw [support, Finset.mem_filter] at hv
+          obtain ⟨w, hvw⟩ := hv.2
+          have : 0 < G.degree v := (G.degree_pos_iff_exists_adj v).mpr ⟨w, hvw⟩
+          omega
+      _ ≤ ∑ v, G.degree v := Finset.sum_le_sum_of_subset (Finset.subset_univ _)
+  exact hasUnitEmbedding_mono hle hbase
+
+end Erdos1007OQ04
+
+/-!
+## Summary
+
+For the dimension of a graph on `n` vertices and `m` edges:
+
+- `hasUnitEmbedding_restrict`: **monotone under edge addition** — fewer edges, lower (or
+  equal) dimension; the maximum over all graphs on `n` vertices is realized by `Kₙ`.
+- `hasUnitEmbedding_card`: **universal bound `dim ≤ n`** via distinct scaled basis vectors;
+  with `dim(Kₙ) = n − 1` (`Erdos1007OQ01.lean`) this places the maximum dimension on `n`
+  vertices at exactly `n − 1`.
+- `hasUnitEmbedding_of_cover` / `hasUnitEmbedding_two_mul_edges`: **edge-count bound
+  `dim ≤ 2m`** — only the non-isolated vertices matter, so a sparse graph has low dimension
+  irrespective of `n`. This is the rigorous form of "sparse graphs cannot have *arbitrarily*
+  high dimension": their dimension is tied to the edge count, not the vertex count.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/erdos-1007-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1007-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-context",
+    "proofId": "erdos-1007-oq-04",
+    "range": { "startLine": 3, "endLine": 47 },
+    "type": "context",
+    "title": "Maximum Graph Dimension as a Function of n and m",
+    "content": "The Euclidean dimension of a graph is the least n admitting a unit-distance embedding in ℝⁿ — adjacent vertices exactly distance 1 apart (Erdős–Harary–Tutte, 1965). The complete graph is extreme: dim(Kₙ)=n−1 via the regular simplex. The parent's fourth open question looks past Kₙ and asks for the maximum dimension at a given vertex count n and edge count m, noting that sparse graphs may also have high dimension. This file proves the two clean bounds framing that question: subgraph monotonicity and an edge-count bound. The UnitDistanceEmbedding structure and hasUnitEmbedding predicate are reproduced locally because Erdos1007Problem.lean is bit-rotted under toolchain 4.26.0.",
+    "mathContext": "Graph dimension $\\dim(G)=\\min\\{n : G \\hookrightarrow \\mathbb{R}^n \\text{ as unit distances}\\}$. Extremal question: maximize $\\dim(G)$ over graphs with $|V|=n$, $|E|=m$.",
+    "significance": "context",
+    "relatedConcepts": ["graph dimension", "unit-distance graph", "extremal graph theory", "Erdős problem #1007", "handshake lemma"],
+    "prerequisites": ["Euclidean embeddings of graphs", "metric geometry", "the handshake lemma"]
+  },
+  {
+    "id": "ann-idx-embedding",
+    "proofId": "erdos-1007-oq-04",
+    "range": { "startLine": 99, "endLine": 113 },
+    "type": "technique",
+    "title": "One Engine: the Scaled-Basis Index Embedding",
+    "content": "hasUnitEmbedding_of_idx packages the scaled-basis trick once. Place vertex v at (1/√2)·e_{idx v} ∈ ℝᴺ for an index map idx : V → Fin N. The squared distance between two such vectors at distinct coordinates is (1/2)+(1/2)=1 (scaled_basis_sq_dist, collapsed by Finset.sum_ite_eq). So if idx assigns distinct coordinates to the two endpoints of every edge, every edge becomes a unit distance and we have an embedding in ℝᴺ. Each upper bound below is then a one-line choice of idx.",
+    "mathContext": "$\\|\\tfrac{1}{\\sqrt2}e_a - \\tfrac{1}{\\sqrt2}e_b\\|^2 = \\tfrac12+\\tfrac12 = 1$ for $a \\neq b$.",
+    "significance": "core",
+    "relatedConcepts": ["standard basis", "unit-distance embedding", "indicator sums"],
+    "prerequisites": ["Finset.sum_ite_eq", "Real.sqrt"]
+  },
+  {
+    "id": "ann-monotonicity",
+    "proofId": "erdos-1007-oq-04",
+    "range": { "startLine": 116, "endLine": 124 },
+    "type": "insight",
+    "title": "Subgraph Monotonicity ⇒ the Maximum is Kₙ",
+    "content": "hasUnitEmbedding_restrict: a unit embedding of adj₂ is automatically one of any subgraph adj₁ ⊆ adj₂ — fewer edges, fewer constraints, same points. So dimension is monotone under edge addition, and the maximum dimension over all graphs on a fixed vertex set is attained by the complete graph. Combined with dim(Kₙ)=n−1 (Erdos1007OQ01), the maximum dimension on n vertices is exactly n−1.",
+    "mathContext": "$H \\subseteq G \\Rightarrow \\dim(H) \\le \\dim(G)$; hence $\\max_{|V|=n}\\dim = \\dim(K_n) = n-1$.",
+    "significance": "key",
+    "relatedConcepts": ["monotonicity", "complete graph", "simplex bound"],
+    "prerequisites": ["subgraph order on graphs"]
+  },
+  {
+    "id": "ann-card-bound",
+    "proofId": "erdos-1007-oq-04",
+    "range": { "startLine": 165, "endLine": 178 },
+    "type": "insight",
+    "title": "Universal Bound: dim(G) ≤ |V|",
+    "content": "hasUnitEmbedding_card: take idx to be a bijection V ≃ Fin |V|. Looplessness makes the endpoints of every edge distinct vertices, hence distinct indices, so the index embedding applies and every loopless graph on V embeds in ℝ^{|V|}. This is the vertex-count side of the bracket; the regular simplex sharpens it to n−1 for Kₙ.",
+    "mathContext": "$\\dim(G) \\le |V|$ for every loopless graph; sharpened to $n-1$ by the simplex.",
+    "significance": "key",
+    "relatedConcepts": ["Fintype.equivFin", "looplessness", "universal upper bound"],
+    "prerequisites": ["finite types and bijections to Fin n"]
+  },
+  {
+    "id": "ann-edge-bound",
+    "proofId": "erdos-1007-oq-04",
+    "range": { "startLine": 180, "endLine": 240 },
+    "type": "insight",
+    "title": "Edge-Count Bound: dim(G) ≤ 2·|E(G)|",
+    "content": "Only non-isolated vertices cost dimension. hasUnitEmbedding_of_cover embeds a graph in ℝ^{|S|} whenever a finite set S covers all edge endpoints (vertices outside S go to the origin; the empty cover is the edgeless graph in ℝ⁰). Taking S = the support (non-isolated vertices), the handshake lemma ∑_v deg(v) = 2|E| together with deg(v) ≥ 1 on the support gives |S| ≤ 2|E|; zero-padding monotonicity then yields hasUnitEmbedding_two_mul_edges: dim(G) ≤ 2·|E(G)|, independent of |V|. So a sparse graph cannot have arbitrarily high dimension — high dimension forces many edges.",
+    "mathContext": "$|\\mathrm{supp}(G)| \\le \\sum_v \\deg(v) = 2|E(G)|$, hence $\\dim(G) \\le 2|E(G)|$.",
+    "significance": "core",
+    "relatedConcepts": ["handshake lemma", "vertex support", "isolated vertices", "sparse graphs"],
+    "prerequisites": ["SimpleGraph.sum_degrees_eq_twice_card_edges", "degree positivity"]
+  },
+  {
+    "id": "ann-open",
+    "proofId": "erdos-1007-oq-04",
+    "range": { "startLine": 244, "endLine": 265 },
+    "type": "context",
+    "title": "What Remains Open",
+    "content": "The two bounds bracket the (n,m) extremal function: n−1 (sharp, via Kₙ) on the vertex-count side and 2m on the edge-count side. The sharp maximum dimension as a joint function of n and m — and whether the constant 2 in the edge-count bound can be improved, or sharpened for restricted graph classes — is the deep remaining content of the open question, tied to House (2013) and Chaffee–Noble (2016).",
+    "mathContext": "Sharp $\\max\\{\\dim(G) : |V|=n, |E|=m\\}$ is open; this entry gives matching-style brackets.",
+    "significance": "context",
+    "relatedConcepts": ["extremal graph theory", "House 2013", "Chaffee–Noble 2016"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/erdos-1007-oq-04/meta.json
+++ b/src/data/proofs/erdos-1007-oq-04/meta.json
@@ -1,0 +1,203 @@
+{
+  "id": "erdos-1007-oq-04",
+  "title": "The Maximum Dimension of a Graph on n Vertices and m Edges: Monotonicity and the Edge-Count Bound",
+  "slug": "erdos-1007-oq-04",
+  "description": "Toward the parent's fourth open question — the maximum graph (Euclidean) dimension as a function of both the vertex count n and the edge count m — this entry proves the two clean, fully-verified bounds available without the deep extremal geometry of House (2013): (1) subgraph monotonicity, so deleting edges never raises the dimension and the maximum over n-vertex graphs is attained by Kₙ (giving n−1 with the simplex bound); and (2) an edge-count upper bound, dim(G) ≤ 2·|E(G)|, proved via a vertex-support embedding and the handshake lemma — only non-isolated vertices cost dimension, so a sparse graph cannot have dimension much larger than its edge count regardless of how many isolated vertices it has.",
+  "meta": {
+    "author": "Paul Erdős (problem #1007); formalized in Lean 4",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1007OQ04.lean",
+    "tags": [
+      "graph-theory",
+      "metric-geometry",
+      "unit-distance",
+      "graph-dimension",
+      "erdos-problem",
+      "euclidean-embedding",
+      "extremal-graph-theory"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 265,
+    "theoremCount": 6,
+    "definitionCount": 3,
+    "originalContributions": [
+      "hasUnitEmbedding_of_idx: a single reusable engine — placing vertex v at the scaled basis vector (1/√2)·e_{idx v} gives a unit-distance embedding in ℝᴺ whenever the index map idx separates the endpoints of every edge (distinct scaled basis vectors are at distance exactly 1).",
+      "hasUnitEmbedding_restrict: subgraph monotonicity — any unit embedding of a graph restricts to every subgraph, so the dimension is monotone under edge addition and the maximum over a fixed vertex set is realized by the complete graph.",
+      "hasUnitEmbedding_card: the universal bound dim(G) ≤ |V| for every loopless graph (index all vertices injectively); with dim(Kₙ)=n−1 from Erdos1007OQ01 this pins the maximum dimension on n vertices at exactly n−1.",
+      "hasUnitEmbedding_of_cover: an edge-cover bound — if a finite set S contains both endpoints of every edge, the graph embeds in ℝ^{|S|}; isolated vertices are sent to the origin and cost nothing.",
+      "hasUnitEmbedding_two_mul_edges: the edge-count bound dim(G) ≤ 2·|E(G)| for finite simple graphs, via the handshake lemma (∑ degrees = 2m) bounding the support size, independent of |V| — the rigorous form of 'a sparse graph has low dimension'."
+    ],
+    "prerequisites": [
+      "Unit-distance embeddings of graphs and the graph (Euclidean) dimension",
+      "Finset sums, the handshake lemma, and scaled standard basis vectors in Lean 4/Mathlib"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.sum_degrees_eq_twice_card_edges",
+        "description": "∑_v deg(v) = 2·|E| — the handshake lemma, used to bound the non-isolated support by twice the edge count",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
+      },
+      {
+        "theorem": "SimpleGraph.degree_pos_iff_exists_adj",
+        "description": "0 < deg(v) ↔ v has a neighbour — identifies the non-isolated vertices contributing to the support",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      },
+      {
+        "theorem": "Finset.sum_ite_eq",
+        "description": "∑ k, (if a = k then f k else 0) = f a — collapses the two non-zero coordinates of the scaled-basis squared distance",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.equivFin",
+        "description": "s ≃ Fin s.card — supplies the injective index map for the edge-cover embedding",
+        "module": "Mathlib.Data.Fintype.Card"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The (Euclidean) dimension of a graph is the least n for which it has a unit-distance embedding in ℝⁿ — vertices placed so adjacent ones are exactly distance 1 apart (Erdős–Harary–Tutte, 1965). The complete graph is the extreme case: the regular simplex realizes Kₙ in ℝ^{n−1}, so dim(Kₙ)=n−1 (formalized in the gallery's Erdos1007OQ01). The parent's open questions then ask how dimension behaves for general graphs, where the relevant parameters are the vertex count n and the edge count m. Determining the exact maximum dimension at given (n,m) is a hard extremal problem — House (2013) proved a 4-dimensional graph has at least 9 edges, with K_{3,3} the unique minimizer, and Chaffee–Noble (2016) handled dimension 5; the gallery records these as axioms.",
+    "problemStatement": "**Open Question (parent erdos-1007, OQ-04)**: what is the maximum dimension of a graph on n vertices and m edges? The simplex bound gives dim(Kₙ)=n−1, but sparse graphs may also have high dimension.\n\n**This entry**: proves the two clean bounds framing the question — subgraph monotonicity (the maximum over n vertices is Kₙ, hence n−1) and an edge-count bound dim(G) ≤ 2m showing a sparse graph's dimension is tied to its edge count, not its vertex count.",
+    "text": "A 265-line, fully verified file (0 sorries, 0 axioms, no native_decide). It reproduces the UnitDistanceEmbedding structure and hasUnitEmbedding predicate locally (the parent Erdos1007Problem is bit-rotted under toolchain 4.26.0), reproduces the scaled-basis squared-distance computation, and then builds: the index-embedding engine hasUnitEmbedding_of_idx, subgraph monotonicity hasUnitEmbedding_restrict, ambient-dimension monotonicity hasUnitEmbedding_mono (zero-padding), the universal bound hasUnitEmbedding_card (dim ≤ |V|), the edge-cover bound hasUnitEmbedding_of_cover (dim ≤ |S|), and the edge-count bound hasUnitEmbedding_two_mul_edges (dim ≤ 2m).",
+    "proofStrategy": "Everything reduces to one construction: place vertex v at (1/√2)·e_{idx v}. Any two distinct scaled basis vectors are at squared distance (1/2)+(1/2)=1, so an index map idx that gives distinct coordinates to the two endpoints of every edge yields a unit embedding (hasUnitEmbedding_of_idx). The universal bound takes idx = a bijection V ≃ Fin |V| (loopless ⟹ endpoints distinct ⟹ distinct indices). The edge-cover bound takes idx = the canonical injection of the cover set S into Fin |S| (sending vertices outside S to a junk index, which is never compared because non-edges impose no constraint); the empty-cover case is the edgeless graph, embedded in ℝ⁰. Subgraph monotonicity is immediate: the same embedding satisfies a subset of the constraints. The edge-count bound takes S to be the non-isolated support; the handshake lemma ∑ deg = 2m together with deg(v) ≥ 1 for v in the support gives |S| ≤ 2m, and zero-padding monotonicity lifts the ℝ^{|S|} embedding to ℝ^{2m}.",
+    "keyInsights": [
+      "A single scaled-basis index embedding proves every upper bound here: distinct scaled basis vectors are unit distance apart, so any edge-separating index map works.",
+      "Dimension is monotone under edge addition — deleting edges only removes constraints — so the maximum dimension on a fixed vertex set is attained by the complete graph Kₙ, namely n−1.",
+      "Only non-isolated vertices cost dimension: isolated vertices all go to the origin, so a finite cover S of the edge endpoints bounds the dimension by |S|.",
+      "The handshake lemma turns the support bound into an edge-count bound: |support| ≤ ∑ deg = 2m, so dim(G) ≤ 2·|E(G)| independent of the vertex count — a sparse graph cannot have arbitrarily high dimension.",
+      "These bracket the open question from both sides: n−1 (sharp, via Kₙ) for the vertex-count dependence, and 2m for the edge-count dependence; the sharp constant in the edge-count regime is the subtler remaining problem."
+    ]
+  },
+  "sections": [
+    {
+      "id": "index-embedding",
+      "title": "The Scaled-Basis Index Embedding",
+      "startLine": 60,
+      "endLine": 113,
+      "summary": "scaled_basis_sq_dist (distinct scaled basis vectors are unit distance apart) and hasUnitEmbedding_of_idx (the reusable embedding engine).",
+      "mathContext": "Placing v at (1/√2)·e_{idx v} is a unit embedding whenever idx separates edge endpoints."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Subgraph and Dimension Monotonicity",
+      "startLine": 114,
+      "endLine": 163,
+      "summary": "hasUnitEmbedding_restrict (edge deletion never raises dimension) and hasUnitEmbedding_mono (zero-padding to higher ambient dimension).",
+      "mathContext": "The maximum dimension on n vertices is attained by Kₙ."
+    },
+    {
+      "id": "bounds",
+      "title": "The Universal and Edge-Count Bounds",
+      "startLine": 164,
+      "endLine": 240,
+      "summary": "hasUnitEmbedding_card (dim ≤ |V|), hasUnitEmbedding_of_cover (dim ≤ |S| for an edge cover), hasUnitEmbedding_two_mul_edges (dim ≤ 2m via the handshake lemma).",
+      "mathContext": "Dimension is bounded by the vertex count and, more finely, by twice the edge count."
+    }
+  ],
+  "conclusion": {
+    "summary": "For the dimension of a graph on n vertices and m edges, this entry proves subgraph monotonicity (so the maximum over n vertices is the complete graph's, n−1) and the edge-count bound dim(G) ≤ 2·|E(G)| (so a sparse graph has dimension tied to its edge count, not its vertex count).",
+    "implications": "Monotonicity makes 'maximum dimension on n vertices = n−1' rigorous once Kₙ's simplex dimension is known, and shows adding edges can only increase dimension. The edge-count bound formalizes the intuition behind the open question's remark that 'sparse graphs may also have high dimension' by capping that dimension at 2m: high dimension forces many edges. Together they bracket the (n,m) extremal function from both sides.",
+    "openQuestions": [
+      "Determine the sharp maximum dimension as a function of (n, m), beyond the n−1 and 2m brackets — the heart of the open question.",
+      "Improve the constant 2 in dim(G) ≤ 2·|E(G)| (e.g. to the support size, or sharper for triangle-free / bipartite graphs).",
+      "Formalize a specific sparse high-dimension family (such as complete bipartite graphs) to exhibit dimension well above any constant while m = o(n²)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1007-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Sibling: monotonicity and the edgeless base case of the graph dimension. This entry adds subgraph monotonicity and the edge-count bound, and its open questions list this exact direction (an upper bound from the scaled-basis embedding)."
+    },
+    {
+      "targetId": "erdos-1007-oq-01",
+      "relationship": "related",
+      "description": "Establishes dim(Kₙ)=n−1 via the regular simplex; combined with the universal bound here, the maximum dimension on n vertices is exactly n−1."
+    },
+    {
+      "targetId": "erdos-1007",
+      "relationship": "related",
+      "description": "Root: Erdős Problem #1007 on graph dimension."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1007OQ04",
+    "lineCount": 265,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 3,
+    "mainTheorems": [
+      {
+        "name": "hasUnitEmbedding_two_mul_edges",
+        "type": "core",
+        "description": "A finite simple graph with m edges embeds in ℝ^{2m}, independent of the vertex count",
+        "leanType": "{V : Type*} → [Fintype V] → [DecidableEq V] → (G : SimpleGraph V) → [DecidableRel G.Adj] → hasUnitEmbedding V G.Adj (2 * G.edgeFinset.card)"
+      },
+      {
+        "name": "hasUnitEmbedding_restrict",
+        "type": "key",
+        "description": "Subgraph monotonicity: a unit embedding of a graph restricts to every subgraph",
+        "leanType": "{V : Type*} → {adj₁ adj₂ : V → V → Prop} → {n : ℕ} → (∀ u v, adj₁ u v → adj₂ u v) → hasUnitEmbedding V adj₂ n → hasUnitEmbedding V adj₁ n"
+      },
+      {
+        "name": "hasUnitEmbedding_card",
+        "type": "key",
+        "description": "Universal upper bound: every loopless graph on V embeds in ℝ^{|V|}",
+        "leanType": "(V : Type*) → [Fintype V] → [DecidableEq V] → (adj : V → V → Prop) → (∀ v, ¬ adj v v) → hasUnitEmbedding V adj (Fintype.card V)"
+      },
+      {
+        "name": "hasUnitEmbedding_of_idx",
+        "type": "key",
+        "description": "The scaled-basis index embedding: an edge-separating index map yields a unit embedding",
+        "leanType": "{V : Type*} → {adj : V → V → Prop} → {N : ℕ} → (idx : V → Fin N) → (∀ u v, adj u v → idx u ≠ idx v) → hasUnitEmbedding V adj N"
+      }
+    ],
+    "path": "Proofs/Erdos1007OQ04.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "hasUnitEmbedding_two_mul_edges",
+      "type": "core",
+      "description": "dim(G) ≤ 2·|E(G)| for finite simple graphs, independent of |V|",
+      "leanType": "{V : Type*} → [Fintype V] → [DecidableEq V] → (G : SimpleGraph V) → [DecidableRel G.Adj] → hasUnitEmbedding V G.Adj (2 * G.edgeFinset.card)"
+    },
+    {
+      "name": "hasUnitEmbedding_restrict",
+      "type": "key",
+      "description": "Subgraph monotonicity of the dimension",
+      "leanType": "{V : Type*} → {adj₁ adj₂ : V → V → Prop} → {n : ℕ} → (∀ u v, adj₁ u v → adj₂ u v) → hasUnitEmbedding V adj₂ n → hasUnitEmbedding V adj₁ n"
+    },
+    {
+      "name": "hasUnitEmbedding_card",
+      "type": "key",
+      "description": "Universal bound dim ≤ |V| via distinct scaled basis vectors",
+      "leanType": "(V : Type*) → [Fintype V] → [DecidableEq V] → (adj : V → V → Prop) → (∀ v, ¬ adj v v) → hasUnitEmbedding V adj (Fintype.card V)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul; Harary, Frank; Tutte, William T.",
+      "title": "On the dimension of a graph",
+      "year": "1965",
+      "venue": "Mathematika 12, 118–122",
+      "note": "Introduces the Euclidean dimension of a graph"
+    },
+    {
+      "authors": "House, John",
+      "title": "A 4-dimensional graph has at least 9 edges",
+      "year": "2013",
+      "venue": "Discrete Mathematics 313(18), 1783–1789",
+      "note": "Sharp (n,m) extremal result the open question targets"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős #1007 OQ-04 — Maximum Dimension of a Graph on n Vertices and m Edges

The parent's fourth open question asks for the maximum (Euclidean) dimension of a graph as a function of both the vertex count `n` and the edge count `m`. The exact answer is a hard extremal problem (House 2013; Chaffee–Noble 2016). This PR proves the two clean, fully machine-checked bounds that bracket it.

### Results (`proofs/Proofs/Erdos1007OQ04.lean`, 0-axiom)
- **`hasUnitEmbedding_restrict`** — subgraph monotonicity: deleting edges never raises the dimension. ⇒ the maximum over `n`-vertex graphs is `dim(Kₙ) = n − 1` (with `dim(Kₙ)=n−1` from `Erdos1007OQ01`).
- **`hasUnitEmbedding_two_mul_edges`** — edge-count bound `dim(G) ≤ 2·|E(G)|`, independent of `|V|`, via the handshake lemma. ⇒ a *sparse* graph cannot have arbitrarily high dimension; high dimension forces many edges.
- Supporting: **`hasUnitEmbedding_of_idx`** (reusable scaled-basis engine), **`hasUnitEmbedding_card`** (`dim ≤ |V|`), **`hasUnitEmbedding_of_cover`** (`dim ≤ |S|` for an edge cover), `hasUnitEmbedding_mono` (zero-padding).

### Engine
Place vertex `v` at `(1/√2)·e_{idx v}`. Distinct scaled basis vectors are at distance exactly 1, so any index map separating edge endpoints yields a unit embedding. Each bound is then a one-line choice of `idx`.

### Verification
- 265 lines, 6 theorems, 3 defs, **0 sorries, 0 `axiom` declarations, no `native_decide`**.
- `#print axioms` on all main theorems: only `propext`, `Classical.choice`, `Quot.sound`.
- Host-verified with `lake env lean` against prebuilt Mathlib oleans (exit 0).

Self-contained: `UnitDistanceEmbedding`/`hasUnitEmbedding` reproduced locally (the parent `Erdos1007Problem` is bit-rotted under toolchain 4.26.0). Gallery entry added under `src/data/proofs/erdos-1007-oq-04/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)