### PR TITLE
research(erdos-1090): repair Mathlib-4.26 build — file did not compile

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -164,13 +164,13 @@ structure CombinatorialLine (k n : ℕ) where
   disjoint : Disjoint fixed varying
   nonempty_varying : varying.Nonempty
 
-/--
+/-
 **Hales-Jewett Theorem (Statement):**
 For any k and r, there exists n such that any r-coloring of [k]ⁿ
 contains a monochromatic combinatorial line.
 -/
 
-/--
+/-
 **Generic Projection:**
 A "generic" projection from [k]ⁿ to ℝ² maps combinatorial lines
 to geometric lines (for sufficiently general projection).
@@ -202,18 +202,18 @@ theorem erdos_1090_affirmative : ∀ k ≥ 3, Erdos1090Question k := by
 ## Part VII: Special Constructions
 -/
 
-/--
+/-
 **Vertices of Regular n-gon:**
 The vertices of a regular n-gon plus its center.
 -/
 
-/--
+/-
 **Grid Points:**
 An m × m grid of points.
 Axiomatized since it requires embedding ℤ² into the Point type.
 -/
 
-/--
+/-
 **Projective Plane Points:**
 Points from a finite projective plane (useful for Ramsey constructions).
 Axiomatized since the construction depends on projective geometry over 𝔽_q.
@@ -259,7 +259,7 @@ theorem ramsey_lower_bound (k : ℕ) (hk : k ≥ 3) : ramseyNumber k ≥ k := by
   rw [ge_iff_le, ← hcard]
   exact hasRamseyProperty_card_ge A k hA
 
-/--
+/-
 **R(3) is Small:**
 The k = 3 case can be achieved with a small set of points.
 -/
@@ -268,6 +268,7 @@ The k = 3 case can be achieved with a small set of points.
 ## Part IX: Connection to Other Results
 -/
 
+open Classical in
 /--
 **Relation to Sylvester-Gallai:**
 The Sylvester-Gallai theorem says: In any finite set of points in ℝ²
@@ -275,7 +276,8 @@ not all collinear, there exists a line containing exactly 2 points.
 
 This is a structural constraint on point configurations.
 -/
-def SylvesterGallai (A : Finset Point) (hA : ¬ ∀ p q r ∈ A, Collinear p q r) : Prop :=
+def SylvesterGallai (A : Finset Point)
+    (hA : ¬ ∀ p ∈ A, ∀ q ∈ A, ∀ r ∈ A, Collinear p q r) : Prop :=
   ∃ l : Line, (A.filter (OnLine l)).card = 2
 
 /--
@@ -302,9 +304,9 @@ def Erdos1090Generalized (k r : ℕ) : Prop :=
   k ≥ 3 → r ≥ 2 →
   ∃ A : Finset Point, ∀ c : Point → Fin r,
     ∃ S : Finset Point, S ⊆ A ∧ IsKCollinear S k ∧
-      ∀ p q ∈ S, c p = c q
+      ∀ p ∈ S, ∀ q ∈ S, c p = c q
 
-/--
+/-
 **Generalized Version Holds:**
 By Hales-Jewett for r colors, the generalized version also holds.
 -/

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -105,7 +105,7 @@
     "theoremCount": 5,
     "definitionCount": 17,
     "path": "Proofs/Erdos1090Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -210,7 +210,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1090 is completely solved. The formalization captures 10 axioms (Graham-Selfridge, Hales-Jewett, generic projection, Hunter's observation, and supporting results), 5 theorems (including the main result and summary), and 17 definitions across 358 lines. The core argument: Hales-Jewett guarantees monochromatic combinatorial lines in [k]ⁿ, and generic projection to ℝ² preserves collinearity. One sorry remains (ramsey_lower_bound).",
+    "summary": "Erdős Problem #1090 is completely solved. The formalization captures 10 axioms (Graham-Selfridge, Hales-Jewett, generic projection, Hunter's observation, and supporting results), 5 theorems (including the main result and summary), and 17 definitions across 358 lines. The core argument: Hales-Jewett guarantees monochromatic combinatorial lines in [k]ⁿ, and generic projection to ℝ² preserves collinearity. One sorry remains (ramsey_lower_bound). BUILD REPAIR (2026-06-28): the file did not compile on pinned Mathlib v4.26.0 (orphaned `/-- -/` docstrings with no following declaration; invalid multi-binder `∀ p q r ∈ A,` syntax; a missing DecidablePred for Finset.filter on an undecidable line predicate). Fixed; file now compiles, 0 sorries, 2 intentional axioms (graham_selfridge, hunter_observation).",
     "implications": "**Theoretical Significance**: **Connections to Combinatorics and Geometry**\n\n1. **Hales-Jewett Theorem:** The solution relies on this fundamental theorem about combinatorial lines in high-dimensional grids, demonstrating the power of combinatorial Ramsey theory in geometric settings.\n\n2. **Euclidean Ramsey Theory:** This is part of the broader program asking which geometric configurations are unavoidable under colorings — a deep connection between combinatorics and geometry.\n\n**3. Sylvester-Gallai:** The related classical result about ordinary lines provides structural constraints on point configurations that complement the Ramsey-theoretic approach.\n\n4. **Projective Geometry:** Finite projective planes provide candidate constructions for optimal sets, connecting the problem to algebraic combinatorics.\n\n5. **Transfer Principle:** The solution exemplifies projecting high-dimensional combinatorial structure to low-dimensional geometric structure, a technique with broad applicability.",
     "openQuestions": [
       "What is the minimum size of A for each k? (R(3) ≤ 9 is axiomatized)",

--- a/src/data/research/problems/erdos-1090-incomplete-01.json
+++ b/src/data/research/problems/erdos-1090-incomplete-01.json
@@ -29,11 +29,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED (build repair): Erdos1090Problem.lean was completely non-compiling on pinned Mathlib v4.26.0 (orphan `/-- -/` docstrings, invalid `∀ p q r ∈ A` binders, missing DecidablePred). Fixed all; file now compiles cleanly (host lake env lean), 0 sorries, 2 intentional axioms; no sorryAx.",
+    "builtItems": [
+      "Erdos1090Problem.lean: repaired Mathlib-4.26 build breaks (orphan docstrings, multi-binder ∀∈, DecidablePred via open Classical) — file now compiles 0-sorry"
+    ],
+    "insights": [
+      "erdos-1090 (monochromatic collinear points, SOLVED affirmative): the 'incomplete' sorry was already filled on main, but the file DID NOT COMPILE on pinned Mathlib v4.26.0 — it had hard parse errors.",
+      "Repairs: (1) ~7 orphaned `/-- -/` docstrings (documentation blocks with no following declaration) → converted to `/- -/` block comments; (2) invalid multi-binder `∀ p q r ∈ A,` / `∀ p q ∈ S,` → expanded to `∀ p ∈ A, ∀ q ∈ A, ∀ r ∈ A,`; (3) `A.filter (OnLine l)` needed DecidablePred for an undecidable real-line predicate → `open Classical in` before the def (placed BEFORE the docstring, else it breaks docstring→decl attachment).",
+      "After repair: compiles clean, 0 sorries, 2 intentional axioms (graham_selfridge for k=3, hunter_observation via Hales-Jewett); #print axioms shows no sorryAx."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Optional: formalize hunter_observation (generic projection of [k]ⁿ to ℝ² via Hales-Jewett) — substantial; or leave axiomatized."
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Summary

Erdős Problem #1090 (a finite planar set forcing `k` monochromatic collinear points under any 2-coloring; SOLVED affirmatively). `Erdos1090Problem.lean` **did not compile** on the repo's pinned toolchain (Mathlib v4.26.0) — it had hard parse/elaboration errors, so the gallery entry was effectively broken. The sorry referenced by the `*-incomplete-01` task was already filled on main; the real outstanding problem was the broken build.

### Fixes
1. **~7 orphaned `/-- … -/` docstrings** — documentation blocks with no following declaration (they describe statements that were only ever axiomatized elsewhere). A doc-comment must attach to a declaration, so these produced `unexpected token '/--'; expected 'lemma'`. Converted to `/- … -/` block comments.
2. **Invalid multi-binder syntax** `∀ p q r ∈ A,` and `∀ p q ∈ S,` (unsupported on v4.26.0 — `unexpected token '∈'; expected ','`) → expanded to `∀ p ∈ A, ∀ q ∈ A, ∀ r ∈ A,` etc.
3. **Missing `DecidablePred`** — `A.filter (OnLine l)` needs `DecidablePred (OnLine l)`, but `OnLine` is a predicate on real points → `open Classical in` before `SylvesterGallai` (placed before its docstring so docstring→declaration attachment is preserved).

## Verification
`lake env lean` against pinned Mathlib v4.26.0:
- 0 errors, 0 sorries (only pre-existing benign unused-variable warnings)
- `#print axioms erdos_1090_affirmative / erdos_1090_summary` = `[propext, Classical.choice, graham_selfridge, hunter_observation, Quot.sound]` — **no `sorryAx`**

(Docker unavailable; verified on host against cached pinned oleans.)

## Status
- **Outcome:** completed — broken file now compiles
- The two axioms (`graham_selfridge` for k=3, `hunter_observation` via Hales-Jewett) are intentional deep-result inputs; entry stays `axiomatized`/`axiom`, `axiomCount` 2.

🤖 Generated by researcher-5