### PR TITLE
research(sperner-mathlib4-oq-02): pairwise door lemma — distinct simplices share ≤1 facet discharges hpair [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4028,6 +4028,7 @@ import Proofs.SpernerTuckerDoorLemma
 import Proofs.SpernerTuckerInductiveTower
 import Proofs.SpernerTuckerOneDim
 import Proofs.SpernerTuckerPathFollowing
+import Proofs.SpernerTuckerSimplexFacetPair
 import Proofs.SphericalExcessGirard
 import Proofs.SphericalLawOfCosines
 import Proofs.SphericalLawOfCosinesOQ03

--- a/proofs/Proofs/SpernerTuckerSimplexFacetPair.lean
+++ b/proofs/Proofs/SpernerTuckerSimplexFacetPair.lean
@@ -1,0 +1,143 @@
+/-
+# The pairwise facet lemma: two distinct simplices share ≤ 1 facet (discharging `hpair`)
+
+Research artifact for `sperner-mathlib4-oq-02` ("Tucker's Lemma and Borsuk–Ulam from
+abstract door-counting").
+
+## Where this sits
+
+The abstract door-counting engine (`SpernerTuckerDoorGraph.lean`) derives the
+path-following structure of Tucker's lemma from a finite *door-incidence relation*
+`inc : V → D → Prop` satisfying three geometric hypotheses:
+
+* `hdoor`    — each door is shared by `≤ 2` simplices (a *pseudomanifold* property);
+* `hsimplex` — each almost-complementary simplex has `≤ 2` doors;
+* `hpair`    — two distinct simplices share `≤ 1` door.
+
+`hsimplex` was turned into a theorem (for the canonical Sperner colouring) in
+`SpernerTuckerDoorLemma.lean`.  **This file discharges `hpair`** for the natural
+*subset incidence* — the incidence that any simplicial complex actually carries: a
+simplex is an `(n+1)`-element vertex set, a door/facet is one of its `n`-element
+subsets, and `inc v d` means "the facet `d` is a face of the simplex `v`".
+
+## What this file proves
+
+For finsets over any vertex type with decidable equality:
+
+* `card_inter_le_of_ne` — two *distinct* simplices of the same size `n+1` meet in at
+  most `n` vertices (else the intersection, being a same-card subset of each, would
+  equal both, forcing them equal).
+* `facet_eq_inter` — an `n`-facet shared by two distinct `(n+1)`-simplices is **exactly**
+  their intersection (it lies in the intersection, which already has `≤ n` elements, so
+  the inclusion is an equality of cardinality `n`).
+* `facets_pairwise` — **the pairwise door lemma**: two distinct simplices share at most
+  one facet (both shared facets equal the intersection, hence each other).
+* `subset_incidence_hpair` — `facets_pairwise` packaged in the **exact logical shape** of
+  the engine's `hpair` hypothesis, for the subset incidence `inc n`.  Combined with the
+  engine wiring example below, this shows `hpair` is no longer an assumption: only `hdoor`
+  (the genuine pseudomanifold property) and the geometric `bridge` remain open.
+
+The wiring example `degree_eq_shared_subset` feeds `subset_incidence_hpair` into the
+engine's sharp degree formula `doorGraph_degree_eq_shared`, leaving `hdoor` as the sole
+remaining incidence hypothesis there.
+
+## Honest status
+
+This is a genuine, dimension-free combinatorial theorem — the classical "two top-cells
+of a complex share at most one codimension-1 face" fact underlying every pseudomanifold /
+door-counting argument — proved from scratch (Mathlib lacks it in reusable form).  It
+converts the second of the engine's three abstract door hypotheses into a proof.  It is
+*not* the geometric `bridge`, and `hdoor` (the pseudomanifold property, which is genuinely
+false for arbitrary complexes and so cannot be proved abstractly) remains the geometric
+input, exactly as prior sessions flagged.
+
+Self-contained.  0 sorries, 0 axioms (propext / Classical.choice / Quot.sound only).
+-/
+import Mathlib.Tactic
+import Proofs.SpernerTuckerDoorGraph
+
+namespace SpernerTuckerSimplexFacetPair
+
+open Finset
+
+variable {α : Type*} [DecidableEq α]
+
+/-! ## The intersection bound for distinct equicardinal simplices -/
+
+/-- **Distinct simplices of size `n+1` meet in at most `n` vertices.**  If the
+intersection had `≥ n+1` elements then, being a subset of each `(n+1)`-element set with
+cardinality `≥` theirs, it would equal both — forcing `v = w`. -/
+theorem card_inter_le_of_ne {v w : Finset α} {n : ℕ}
+    (hv : v.card = n + 1) (hw : w.card = n + 1) (hvw : v ≠ w) :
+    (v ∩ w).card ≤ n := by
+  by_contra h
+  push_neg at h
+  have e1 : v ∩ w = v := eq_of_subset_of_card_le inter_subset_left (by omega)
+  have e2 : v ∩ w = w := eq_of_subset_of_card_le inter_subset_right (by omega)
+  exact hvw (e1.symm.trans e2)
+
+/-! ## A shared facet is the intersection -/
+
+/-- **An `n`-facet shared by two distinct `(n+1)`-simplices is their intersection.**
+The facet lies in `v ∩ w`, whose cardinality is already `≤ n`; an `n`-element subset of an
+`(≤ n)`-element set fills it, so the inclusion is an equality. -/
+theorem facet_eq_inter {v w d : Finset α} {n : ℕ}
+    (hv : v.card = n + 1) (hw : w.card = n + 1) (hvw : v ≠ w)
+    (hd : d.card = n) (hdv : d ⊆ v) (hdw : d ⊆ w) :
+    d = v ∩ w := by
+  have hsub : d ⊆ v ∩ w := subset_inter hdv hdw
+  have hle : (v ∩ w).card ≤ n := card_inter_le_of_ne hv hw hvw
+  exact eq_of_subset_of_card_le hsub (by omega)
+
+/-- **The pairwise door lemma.**  Two distinct `(n+1)`-simplices share **at most one**
+`n`-facet: both shared facets equal the intersection `v ∩ w`, hence each other. -/
+theorem facets_pairwise {v w d d' : Finset α} {n : ℕ}
+    (hv : v.card = n + 1) (hw : w.card = n + 1) (hvw : v ≠ w)
+    (hd : d.card = n) (hd' : d'.card = n)
+    (hdv : d ⊆ v) (hdw : d ⊆ w) (hd'v : d' ⊆ v) (hd'w : d' ⊆ w) :
+    d = d' := by
+  rw [facet_eq_inter hv hw hvw hd hdv hdw, facet_eq_inter hv hw hvw hd' hd'v hd'w]
+
+/-! ## Subset incidence and the engine's `hpair` -/
+
+/-- **Subset incidence.**  `inc n v d` holds when `v` is an `(n+1)`-simplex and `d` is one
+of its `n`-element facets.  This is the incidence any simplicial complex carries. -/
+def inc (n : ℕ) (v d : Finset α) : Prop := v.card = n + 1 ∧ d.card = n ∧ d ⊆ v
+
+instance (n : ℕ) : DecidableRel (inc (α := α) n) := fun _ _ => by unfold inc; infer_instance
+
+/-- **`hpair`, discharged.**  For the subset incidence, two distinct simplices carrying a
+common pair of facets `d, d'` must have `d = d'`.  This is exactly the engine's `hpair`
+hypothesis `∀ d d' v w, v ≠ w → inc v d → inc w d → inc v d' → inc w d' → d = d'`, now
+proved rather than assumed. -/
+theorem subset_incidence_hpair (n : ℕ) :
+    ∀ d d' v w : Finset α, v ≠ w →
+      inc n v d → inc n w d → inc n v d' → inc n w d' → d = d' := by
+  rintro d d' v w hvw ⟨hv, hd, hdv⟩ ⟨hw, -, hdw⟩ ⟨-, hd', hd'v⟩ ⟨-, -, hd'w⟩
+  exact facets_pairwise hv hw hvw hd hd' hdv hdw hd'v hd'w
+
+/-! ## Wiring: the engine's sharp degree formula needs only `hdoor` now
+
+`SpernerTuckerDoorGraph.doorGraph_degree_eq_shared` takes both `hdoor` and `hpair`.  With
+`hpair` supplied by `subset_incidence_hpair`, the *only* remaining incidence hypothesis is
+`hdoor` — the pseudomanifold "each facet borders ≤ 2 simplices" property, which is
+genuinely geometric (false for arbitrary complexes) and is the open input. -/
+
+/-- For the canonical subset incidence, the door-graph degree equals the number of shared
+facets — assuming only `hdoor` (`hpair` is now the proved `subset_incidence_hpair`). -/
+example [Fintype α] (n : ℕ)
+    (hdoor : ∀ d : Finset α, #{v | inc n v d} ≤ 2) (v : Finset α) :
+    (SpernerTuckerDoorGraph.doorGraph (inc n)).degree v
+      = #{d | inc n v d ∧ ∃ w, w ≠ v ∧ inc n w d} :=
+  SpernerTuckerDoorGraph.doorGraph_degree_eq_shared (inc n) hdoor
+    (subset_incidence_hpair n) v
+
+#check @facets_pairwise
+#check @subset_incidence_hpair
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
+-- no `sorryAx`, no `Lean.ofReduceBool`.
+#print axioms facets_pairwise
+#print axioms subset_incidence_hpair
+
+end SpernerTuckerSimplexFacetPair

--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -653,3 +653,52 @@ reduces the projection definitionally (ofGraphs is semireducible).
 This narrows the open surface from {step, bridge, base} to {bridge} (base verified at
 n=1). Frontier for next session is STILL the single geometric `bridge` construction —
 unchanged; this is organizing infrastructure, not new Tucker mathematics.
+
+## Session 2026-06-28 (researcher-10) — discharge `hpair` (pairwise door lemma)
+
+**Mode**: REVISIT (RICH). Frontier = the geometric `bridge` + the two remaining
+*incidence* hypotheses of the abstract engine (`SpernerTuckerDoorGraph`).
+**Outcome**: progress (ACT) — new `proofs/Proofs/SpernerTuckerSimplexFacetPair.lean`
+(143 LOC, 4 thm + 1 def + 1 instance + 1 wiring example, 0 sorry, 0 axiom). Verified
+offline via host `LAKE_UNSAFE=1 ./bin/lake env lean` against the Mathlib `.olean` cache
+(Docker down). `#print axioms` of `facets_pairwise` and `subset_incidence_hpair`:
+`[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.
+
+### What I Did
+The engine carries three black-box geometric hypotheses on the incidence
+`inc : V → D → Prop`: `hdoor` (each door borders ≤2 simplices), `hsimplex` (each simplex
+has ≤2 doors), `hpair` (two distinct simplices share ≤1 door). Last session
+(`SpernerTuckerDoorLemma`) turned `hsimplex` into a theorem for the canonical Sperner
+colouring. **This session discharges `hpair`** for the *subset incidence* — the incidence
+any simplicial complex actually carries (`inc n v d := v.card = n+1 ∧ d.card = n ∧ d ⊆ v`):
+
+- `card_inter_le_of_ne` — two distinct `(n+1)`-simplices meet in ≤ `n` vertices (else the
+  intersection, a same-card subset of each, equals both, forcing `v = w`).
+- `facet_eq_inter` — an `n`-facet shared by two distinct simplices is *exactly* `v ∩ w`
+  (it lies in the intersection, which already has ≤ `n` elements, so the inclusion fills).
+- `facets_pairwise` — the pairwise door lemma: both shared facets equal `v ∩ w`, hence
+  each other. Dimension-free, pure finset combinatorics.
+- `subset_incidence_hpair` — `facets_pairwise` packaged in the *exact* logical shape of the
+  engine's `hpair`. A `#check`-verified wiring `example` feeds it into
+  `doorGraph_degree_eq_shared`, leaving `hdoor` as that lemma's sole incidence input.
+
+### Why this matters / honest status
+Genuine, reusable, dimension-free combinatorics — the classical "two top-cells of a
+complex share ≤1 codim-1 face" fact underlying every pseudomanifold/door argument, which
+Mathlib lacks in reusable form. It converts the **second** of the engine's three abstract
+door hypotheses into a proof. Crucially, `hdoor` (each facet borders ≤2 simplices) is the
+*pseudomanifold* property — genuinely FALSE for arbitrary complexes — so it cannot be
+proved abstractly and remains the geometric input, alongside the still-open geometric
+`bridge` and the analytic mesh→0 phase. This is infrastructure/sharpening, NOT new Tucker
+geometry.
+
+### Files Modified
+- proofs/Proofs/SpernerTuckerSimplexFacetPair.lean (new)
+- proofs/Proofs.lean (registered the module)
+- src/data/research/problems/sperner-mathlib4-oq-02.json (leanFiles + knowledge)
+
+### Next Steps
+- `hdoor` is now the only remaining engine incidence hypothesis. Discharging it requires a
+  concrete triangulation model (the pseudomanifold structure), which is essentially the
+  geometric `bridge` construction — the genuine open lever every prior session flagged.
+- Continuous n≥2 Tucker ⟹ Borsuk–Ulam (mesh→0 + compactness): separate analytic phase.

--- a/src/data/research/problems/sperner-mathlib4-oq-02.json
+++ b/src/data/research/problems/sperner-mathlib4-oq-02.json
@@ -17,7 +17,7 @@
   },
   "currentState": "ACT: formalized the DIMENSION RECURSION of the Tucker door-counting proof (SpernerTuckerInductiveTower.lean, 0 sorries/0 axioms — propext/Classical.choice/Quot.sound only, no sorryAx/ofReduceBool). (1) odd_boundary_iff_odd_interior STRENGTHENS the path-following engine from mere existence of an interior endpoint to the parity EQUIVALENCE Odd #boundary <-> Odd #interior (the two endpoint classes partition the even-cardinality degree-1 set), the quantitative form the induction needs. (2) TuckerTower bundles per-level interior/boundary counts with step (the engine, discharged by (1)), bridge (the geometric boundary bijection: level-(n+1) boundary doors = level-n interior simplices — the SOLE remaining open input), and base (verified 1-D Tucker); tower_interior_odd : forall n, Odd (interior n) closes the induction in one line, and tower_exists_interior gives a complementary simplex in EVERY dimension. An inhabited trivialTower witnesses non-vacuity. This makes precise that, once the geometric bridge is supplied, full-dimensional Tucker is a two-hypothesis induction. Infrastructure/organizing-skeleton, not new Tucker mathematics; the geometric bridge remains the genuine frontier.",
   "knowledge": {
-    "progressSummary": "PROGRESS: hsimplex DISCHARGED. The abstract door-counting engine took three black-box geometric hypotheses (hdoor/hsimplex/hpair); SpernerTuckerDoorLemma now PROVES hsimplex (≤2 doors per simplex) for the canonical Sperner colouring — the classical door lemma, dimension-free, 0-axiom. Panchromatic⟹exactly 1 door also proved. Remaining open: hdoor + hpair (pseudomanifold facet-sharing of the global B^n complex), the geometric bridge (boundary(n+1)=interior(n)), and the analytic mesh→0 phase for n≥2.",
+    "progressSummary": "PROGRESS: hpair discharged. The abstract door-counting engine had 3 black-box incidence hypotheses (hdoor, hsimplex, hpair). hsimplex was proved last session (SpernerTuckerDoorLemma, canonical Sperner colouring); THIS session proves hpair (SpernerTuckerSimplexFacetPair, subset incidence) as clean dimension-free finset combinatorics — both shared facets equal v∩w. Only hdoor (the pseudomanifold property, genuinely geometric) + the geometric bridge + the analytic mesh→0 phase remain open. VERIFIED 0-axiom (lake env lean exit 0; #print axioms = [propext, Classical.choice, Quot.sound]).",
     "builtItems": [
       "proofs/Proofs/SpernerTuckerDoorGraph.lean (sharp degree formula, VERIFIED 0-axiom: lake env lean exit 0, #print axioms = [propext, Classical.choice, Quot.sound] only): doorGraph_degree_eq_shared — under hdoor (each door joins <=2 simplices) and hpair (two distinct simplices share <=1 door, the door-graph analogue of adj_unique_facet), (doorGraph inc).degree v = #{d | inc v d and exists w != v, inc w d} (the # of vs SHARED doors). Finset.card_bij with the neighbour->shared-door witness map: lands in shared doors, injective by hdoor (a door joining v to two neighbours touches 3 simplices), surjective by hpair (a shared doors other endpoint is a neighbour whose shared door is forced to be that door). Sharpens doorGraph_degree_le_two from a bound to an equality: a path endpoint (degree 1) is exactly a simplex with ONE shared door.",
       "proofs/Proofs/SpernerTuckerOneDim.lean — 1-D Tucker / combinatorial 1-D Borsuk–Ulam (verified, 0-axiom)",
@@ -32,7 +32,8 @@
       "even_card_antipodal_boundary: dimension-free generalization of the hexagon-only raw-boundary-even fact.",
       "towerOfCountEq + bridge_of_card_eq: build a TuckerTower from per-level count EQUALITIES boundary(n+1)=interior(n) (the cardinality shape of the geometric bijection), strictly stronger input than the bare parity-iff bridge.",
       "growingTower: first NON-TRIVIAL TuckerTower (interior n = 2n+1, growing) replacing the constant-1 trivialTower, demonstrating the recursion on substantive data.",
-      "proofs/Proofs/SpernerTuckerDoorLemma.lean (VERIFIED 0-axiom, lake env lean exit 0, #print axioms = propext/Classical.choice/Quot.sound only): card_doors_le_two (the hsimplex ≤2 bound, now a theorem), card_doors_eq_one_of_bijective, doors_same_color, door_image/door_no_top/door_injOn helpers."
+      "proofs/Proofs/SpernerTuckerDoorLemma.lean (VERIFIED 0-axiom, lake env lean exit 0, #print axioms = propext/Classical.choice/Quot.sound only): card_doors_le_two (the hsimplex ≤2 bound, now a theorem), card_doors_eq_one_of_bijective, doors_same_color, door_image/door_no_top/door_injOn helpers.",
+      "SpernerTuckerSimplexFacetPair.lean: card_inter_le_of_ne, facet_eq_inter, facets_pairwise (the pairwise door lemma), subset_incidence_hpair (engine-shaped hpair), + wiring example feeding it to doorGraph_degree_eq_shared. 0 sorries, 0 axioms (propext/Choice/Quot)."
     ],
     "insights": [
       "n=1 Tucker is provable directly as a discrete fundamental-theorem-of-calculus / sign-change-parity statement over ZMod 2 — cleaner than instantiating the abstract CellComplex (whose panchromatic conclusion genuinely diverges from the complementary-edge target, Insight 1).",
@@ -47,12 +48,15 @@
       "Insight 5 — sharp door-degree = #shared-doors (VERIFIED). doorGraph_degree_le_two only gave the path/cycle structure; under the EXTRA natural axiom hpair (distinct simplices share <=1 door) the degree is EXACTLY the number of shared doors of v. This localizes \"path endpoint\" to \"exactly one shared door\", giving the geometric inc construction a per-simplex target instead of a global-graph one. hpair is a third geometric obligation alongside the two <=2 incidence counts.",
       "The antipodal map is a FREE involution on the boundary doors, so the raw boundary-door count is EVEN in EVERY dimension (even_card_of_free_involution + even_card_antipodal_boundary). This generalizes SpernerTuckerBoundaryParity.ring_complementary_count_even (proved only for the n=2 hexagon by 64-case decide) to all n abstractly, and is the dimension-free reason the bridge must draw oddness from the lower-dim interior count, not the raw boundary ring.",
       "DOOR LEMMA (hsimplex discharged): for a Sperner colouring c:Fin(n+1)→Fin(n+1), a facet (drop vertex i) is a door iff its n other vertices realise all n low colours (≠ top = Fin.last n). Then #{doors} ≤ 2 ALWAYS — proved, not assumed. Key: a door facet is a BIJECTION of its n vertices onto the n low colours (door_image, via eq_of_subset_of_card_le on two n-element finsets); hence no other vertex is top-coloured (door_no_top) and c is injective off i (door_injOn). All doors share one colour (doors_same_color) realised by ≤2 vertices (card_color_le_two).",
-      "Panchromatic simplex (c bijective) has EXACTLY ONE door — the facet opposite the unique top-coloured vertex (card_doors_eq_one_of_bijective / isDoor_iff_eq_top_vertex). These are the cells the path-following engine treats as endpoints."
+      "Panchromatic simplex (c bijective) has EXACTLY ONE door — the facet opposite the unique top-coloured vertex (card_doors_eq_one_of_bijective / isDoor_iff_eq_top_vertex). These are the cells the path-following engine treats as endpoints.",
+      "hpair (two distinct simplices share <=1 facet) is provable as dimension-free finset combinatorics for SUBSET incidence: both shared facets equal v ∩ w (facet_eq_inter), hence are equal. Distinct equicardinal (n+1)-sets meet in <=n vertices (card_inter_le_of_ne). Discharges the 2nd of 3 abstract door hypotheses; with hsimplex (SpernerTuckerDoorLemma) only hdoor (pseudomanifold, genuinely geometric) + the bridge remain."
     ],
     "mathlibGaps": [
-      "Mathlib lacks a direct free-involution => even-cardinality lemma (only the p-group card_modEq_card_fixedPoints). Proved here from Finset.sum_ninvolution + ZMod.natCast_eq_zero_iff_even."
+      "Mathlib lacks a direct free-involution => even-cardinality lemma (only the p-group card_modEq_card_fixedPoints). Proved here from Finset.sum_ninvolution + ZMod.natCast_eq_zero_iff_even.",
+      "Mathlib lacks the reusable pseudomanifold fact: two distinct n-cells of a simplicial complex share at most one codimension-1 facet (facets_pairwise here proves it from scratch for the finset/subset model)."
     ],
     "nextSteps": [
+      "Discharge hdoor (each facet borders <=2 simplices) — the PSEUDOMANIFOLD property, genuinely geometric (false for arbitrary complexes), so it needs an actual triangulation model, not abstract combinatorics. This is now the SOLE remaining engine incidence hypothesis.",
       "Discharge hdoor (each door/facet shared by ≤2 simplices) — pseudomanifold property of the global B^n triangulation; and hpair (two distinct n-simplices share ≤1 facet — near-trivial for simplices). With hsimplex now PROVED (SpernerTuckerDoorLemma.card_doors_le_two), these two are the remaining door-incidence bounds before the abstract engine fires on a concrete inc.",
       "Supply Odd #{boundary doors} from the inductive (n-1)-Tucker statement (NOT the raw boundary ring, provably EVEN per SpernerTuckerAntipodalParity.even_card_antipodal_boundary).",
       "n>=2 Tucker ⟹ Borsuk–Ulam: continuous mesh→0 + compactness (analytic phase; dim 1 done by IVT)."
@@ -175,6 +179,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerTuckerAntipodalParity.lean"
+    },
+    {
+      "path": "Proofs/SpernerTuckerSimplexFacetPair.lean",
+      "filename": "SpernerTuckerSimplexFacetPair.lean",
+      "lineCount": 143,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerTuckerSimplexFacetPair.lean"
     }
   ],
   "lastVerified": "2026-06-27"


### PR DESCRIPTION
## Summary

Turns the **second** of the abstract door-counting engine's three black-box geometric incidence hypotheses into a theorem.

The engine `SpernerTuckerDoorGraph` derives Tucker's path-following structure from an incidence `inc : V → D → Prop` satisfying three hypotheses: `hdoor` (each door borders ≤2 simplices), `hsimplex` (each simplex has ≤2 doors), `hpair` (two distinct simplices share ≤1 door). The previous PR (#31120) proved `hsimplex` for the canonical Sperner colouring. **This PR proves `hpair`** for the *subset incidence* `inc n v d := v.card = n+1 ∧ d.card = n ∧ d ⊆ v` — the incidence any simplicial complex carries.

## New file: `SpernerTuckerSimplexFacetPair.lean` (143 LOC, 4 thm + 1 def, 0 sorry, 0 axiom)

- `card_inter_le_of_ne` — two distinct `(n+1)`-simplices meet in ≤ `n` vertices (else the intersection, a same-card subset of each, equals both, forcing `v = w`).
- `facet_eq_inter` — an `n`-facet shared by two distinct simplices is **exactly** `v ∩ w`.
- `facets_pairwise` — the pairwise door lemma: both shared facets equal `v ∩ w`, hence each other. Dimension-free, pure finset combinatorics.
- `subset_incidence_hpair` — `facets_pairwise` in the **exact logical shape** of the engine's `hpair`, with a `#check`-verified wiring `example` feeding it into `doorGraph_degree_eq_shared` (leaving `hdoor` as that lemma's sole incidence input).

## Honest status

Genuine reusable combinatorics — the classical "two top-cells of a complex share ≤1 codim-1 face" pseudomanifold fact, absent from Mathlib in reusable form. This is **infrastructure / sharpening, not new Tucker geometry**. `hdoor` (each facet borders ≤2 simplices) is the *pseudomanifold* property — genuinely false for arbitrary complexes, so it cannot be proved abstractly — and remains the geometric input alongside the still-open geometric `bridge` and the analytic mesh→0 phase.

## Verification

Host `lake env lean` (Docker down), exit 0. `#print axioms` of `facets_pairwise` and `subset_incidence_hpair` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)