### PR TITLE
Enrich Closure of a (Pre)connected Set (connected-space-oq-01): header + cross-refs

### DIFF
--- a/src/data/proofs/connected-space-oq-01/annotations.json
+++ b/src/data/proofs/connected-space-oq-01/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "connected-space-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
+    "type": "context",
+    "title": "Why Limit Points Cannot Break Connectedness",
+    "content": "The intuition behind the whole file: preconnectedness is the impossibility of splitting a set across two disjoint open sets that both meet it. Adding limit points (passing to the closure) cannot create such a split, because any open separation of closure s would already separate the dense original s — contradiction. This gives three results of increasing strength. (1) closure of a (pre)connected set is (pre)connected. (2) 'Bark and tree': ANY set t with s ⊆ t ⊆ closure s is preconnected, not just the closure itself — the tree (s) plus any amount of its bark (limit points) stays in one piece. (3) The density corollary: if a connected subset is dense (closure = univ), the whole space is connected. The core lemmas are Mathlib's (IsPreconnected.closure, IsPreconnected.subset_closure); the gallery packaging and the dense-subset corollary are the contribution.",
+    "mathContext": "An open separation of $\\overline{s}$ restricts to an open separation of the dense $s$; hence $\\overline{s}$ — and any $t$ with $s \\subseteq t \\subseteq \\overline{s}$ — stays preconnected.",
+    "significance": "context",
+    "relatedConcepts": [
+      "preconnected vs connected",
+      "closure and limit points",
+      "dense subset",
+      "open separation",
+      "bark and tree"
+    ],
+    "prerequisites": [
+      "topological closure",
+      "the definition of (pre)connectedness via open separations",
+      "dense sets (closure = univ)"
+    ]
+  },
+  {
     "id": "ann-closure",
     "proofId": "connected-space-oq-01",
     "range": {

--- a/src/data/proofs/connected-space-oq-01/meta.json
+++ b/src/data/proofs/connected-space-oq-01/meta.json
@@ -82,6 +82,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview: Connectedness Is Stable Under Closure",
+      "startLine": 1,
+      "endLine": 34,
+      "summary": "Imports and module docstring. States the topological fact that the closure of a (pre)connected set is (pre)connected, its sharper 'bark and tree' generalization (any set wedged between s and closure s is preconnected), and the corollary that a dense connected subset forces the whole space to be connected. Notes the core results live in Mathlib (IsPreconnected.closure, IsConnected.closure, IsPreconnected.subset_closure) and are packaged here in gallery form with the density corollary added. Sets up a topological space α and opens Set, Topology.",
+      "mathContext": "$s$ preconnected $\\Rightarrow \\overline{s}$ preconnected; more sharply $s \\subseteq t \\subseteq \\overline{s} \\Rightarrow t$ preconnected; and a dense connected subset $\\Rightarrow$ the space is connected."
+    },
+    {
       "id": "closure",
       "title": "Section I: Closure Preserves (Pre)connectedness",
       "startLine": 35,
@@ -133,7 +141,18 @@
     "path": "Proofs/ConnectedSpaceOQ01.lean",
     "sorries": 0
   },
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "connected-space-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Sibling that probes the limits of this entry's closure-stability: path-connectedness is NOT closure-stable in general (the 'connected salvage' and path-component rigidity), exactly the open question flagged here."
+    },
+    {
+      "targetId": "connected-space-oq-01-oq-02",
+      "relationship": "related",
+      "description": "The topologist's sine curve is the canonical example where this entry's theorem bites: a connected set whose closure is connected but not path-connected — concretely realizing 'closure preserves connectedness'."
+    }
+  ],
   "references": [
     {
       "key": "Munkres",


### PR DESCRIPTION
Enrichment pass for `connected-space-oq-01` (The Closure of a (Pre)connected Set Is (Pre)connected; quality 83, pass 0).

Two genuine gaps: sections/annotations started at line 35 (the 34-line docstring was uncovered), and the entry had **zero cross-references**.

## Changes
- **Added a header section (1–34) and a context annotation** for the docstring — explains why limit points cannot break connectedness and the increasing-strength chain: closure-stability → 'bark and tree' (any t with s ⊆ t ⊆ closure s) → the dense-connected ⟹ connected-space corollary.
- **Added 2 cross-references** (was empty): to sibling `connected-space-oq-01-oq-01` (path-connectedness is NOT closure-stable — exactly the open question this entry flags) and `connected-space-oq-01-oq-02` (the topologist's sine curve, the canonical realizing example).
- sections 3 → 4, annotations 3 → 4, crossReferences 0 → 2.

## Verification
- meta.json + annotations.json valid JSON; `check-meta-size.ts` within caps
- `pnpm build` — ✓ built

🤖 Generated with [Claude Code](https://claude.com/claude-code)