### PR TITLE
Enrich Adjugate Behind Cramer's Rule & Cayley-Hamilton (cramers-oq-04-01): cover the header

### DIFF
--- a/src/data/proofs/cramers-rule-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "cramers-rule-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "context",
+    "title": "Cramer's Rule and Cayley–Hamilton Share One Identity",
+    "content": "The unifying theme of the file: the single universal adjugate identity adjugate B · B = (det B)·I specializes to both classical theorems. Feed it the scalar matrix B = A and it becomes A·(adj A · b) = (det A)·b — the determinant form of Cramer's rule, solving Ax = b up to a factor of det A. Feed it instead the characteristic matrix B = xI − A over the polynomial ring R[X], where det(xI − A) = χ_A(x), and it becomes adj(xI − A)·(xI − A) = χ_A(x)·I; evaluating this polynomial-matrix identity at A makes the right side χ_A(A) and the left side vanish, yielding the Cayley–Hamilton theorem χ_A(A) = 0. (This is why Cayley–Hamilton is NOT the naive 'substitute A for x in det(xI − A)' — that substitution is ill-typed; the rigorous route goes through the adjugate identity and an algebra evaluation.) A corollary is that the minimal polynomial divides the characteristic polynomial. Mathlib proves Cayley–Hamilton this way (aeval_self_charpoly); this entry packages the underlying adjugate identities and ties both theorems to their common source.",
+    "mathContext": "$\\operatorname{adj}(B)\\,B = (\\det B)\\,I$: scalar $B=A$ gives Cramer; characteristic $B = xI-A$ over $R[X]$ gives $\\operatorname{adj}(xI-A)(xI-A) = \\chi_A(x)I$, then $x \\mapsto A$ gives $\\chi_A(A)=0$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "adjugate / classical adjoint",
+      "Cramer's rule",
+      "Cayley–Hamilton theorem",
+      "characteristic polynomial",
+      "minimal polynomial"
+    ],
+    "prerequisites": [
+      "determinants and the adjugate identity adj(B)·B = (det B)·I",
+      "the characteristic matrix xI − A over R[X]",
+      "polynomial evaluation of matrices (aeval)"
+    ]
+  },
+  {
     "id": "ann-adjugate-identity",
     "proofId": "cramers-rule-oq-04-oq-01",
     "range": {

--- a/src/data/proofs/cramers-rule-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01/meta.json
@@ -94,6 +94,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview: One Adjugate Identity Behind Two Theorems",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Imports and module docstring. States the parent chain's open question (formalize the algebraic Cayley–Hamilton proof via the adjugate-reflexive property adj(xI−A)·(xI−A) = χ_A(x)·I) and the unifying observation: both Cramer's rule and Cayley–Hamilton are instances of the single adjugate identity adjugate B · B = (det B)·I — Cramer's rule with the scalar matrix B = A, Cayley–Hamilton with the characteristic matrix B = xI−A over R[X], where det(xI−A) = χ_A(x). Lists the main results and sets up a commutative ring R with a finite index type n.",
+      "mathContext": "Common source: $\\operatorname{adj}(B)\\,B = (\\det B)\\,I$. Cramer: $B = A$. Cayley–Hamilton: $B = xI - A$, $\\det(xI-A) = \\chi_A(x)$, then evaluate at $A$."
+    },
+    {
       "id": "adjugate-identity",
       "title": "Section I: The Adjugate-Reflexive Identity",
       "startLine": 37,


### PR DESCRIPTION
Enrichment pass for `cramers-rule-oq-04-oq-01` (The Adjugate Behind Cramer's Rule and Cayley–Hamilton; quality 83, pass 0).

Sections/annotations started at line 37, leaving the 36-line docstring uncovered.

## Changes
- **Added a header section (1–36) and a context annotation** for the docstring — frames the unifying theme: the single universal identity adj(B)·B = (det B)·I yields Cramer's rule (B = A) and Cayley–Hamilton (B = xI−A over R[X], then evaluate at A), and clarifies why Cayley–Hamilton is *not* the naive 'substitute A for x' (ill-typed).
- sections 3 → 4, annotations 3 → 4; full-file coverage.
- Structural gap fill only.

## Verification
- meta.json + annotations.json valid JSON; `check-meta-size.ts` within caps
- `pnpm build` — ✓ built

🤖 Generated with [Claude Code](https://claude.com/claude-code)