### PR TITLE
Enrich Carmichael Function on Prime Powers (euler-totient-oq-01-02): cover the header

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-02/annotations.json
@@ -1,5 +1,27 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "euler-totient-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 30 },
+    "type": "context",
+    "title": "Why λ Can Be Strictly Smaller Than φ",
+    "content": "Euler's theorem says a^φ(n) ≡ 1 (mod n) for every unit a, but φ(n) need not be the SMALLEST such exponent. The Carmichael function λ(n) — the exponent of the unit group (ℤ/nℤ)ˣ — is: a^k ≡ 1 (mod n) for all units a iff λ(n) ∣ k. The gap between λ and φ is governed entirely by the group structure. When (ℤ/nℤ)ˣ is cyclic its exponent equals its order, so λ(n) = φ(n) — this is the case for odd prime powers pᵏ. When it is not cyclic, λ is a proper divisor of φ. The headline example is the 2-power case: for k ≥ 3 the group (ℤ/2ᵏℤ)ˣ ≅ ℤ/2 × ℤ/2ᵏ⁻² has exponent lcm(2, 2ᵏ⁻²) = 2ᵏ⁻², exactly half of φ(2ᵏ) = 2ᵏ⁻¹. So λ(2ᵏ) = 2ᵏ⁻² = φ(2ᵏ)/2. The file packages these from Mathlib's ArithmeticFunction.Carmichael, answering the parent's request for λ(2ᵏ) = 2ᵏ⁻² and the odd-prime-power identity, with concrete values λ(8) = 2, λ(16) = 4.",
+    "mathContext": "$\\lambda \\mid \\varphi$ always; $\\lambda = \\varphi \\iff (\\mathbb{Z}/n)^\\times$ cyclic. Non-cyclic $2^k$ ($k\\ge3$): $(\\mathbb{Z}/2^k)^\\times \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2^{k-2}$, exponent $2^{k-2} = \\varphi/2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Carmichael function (reduced totient)",
+      "Euler's totient φ",
+      "exponent of a group",
+      "unit group (ℤ/nℤ)ˣ",
+      "cyclic vs non-cyclic groups"
+    ],
+    "prerequisites": [
+      "Euler's theorem and the totient φ",
+      "the structure of (ℤ/2ᵏℤ)ˣ",
+      "exponent of a finite abelian group"
+    ]
+  },
+  {
     "id": "ann-two-powers",
     "proofId": "euler-totient-oq-01-oq-02",
     "range": {

--- a/src/data/proofs/euler-totient-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-02/meta.json
@@ -90,6 +90,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview: The Carmichael Function as the Smallest Universal Exponent",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Imports and module docstring. States the parent chain's open question (prove λ(2ᵏ) = 2ᵏ⁻² for k ≥ 3 and related Carmichael identities) and explains what λ is: the exponent of the unit group (ℤ/nℤ)ˣ — the SMALLEST k with aᵏ ≡ 1 (mod n) for every unit a, characterized by λ(n) ∣ k. The key structural fact: for n = 2ᵏ (k ≥ 3) the unit group is ℤ/2 × ℤ/2ᵏ⁻² (NOT cyclic), so λ(2ᵏ) = 2ᵏ⁻² = φ(2ᵏ)/2 is strictly below φ; for odd prime powers the group is cyclic so λ(pᵏ) = φ(pᵏ). Lists the main results, all packaged from Mathlib's ArithmeticFunction.Carmichael.",
+      "mathContext": "$\\lambda(n) = \\exp((\\mathbb{Z}/n\\mathbb{Z})^\\times)$, the least $k$ with $a^k \\equiv 1\\ (\\mathrm{mod}\\ n)$ for all units; $\\lambda(2^k) = 2^{k-2} = \\varphi(2^k)/2$ ($k\\ge3$), $\\lambda(p^k)=\\varphi(p^k)$ for odd $p$."
+    },
+    {
       "id": "two-powers",
       "title": "Section I: Powers of Two",
       "startLine": 31,


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-01-oq-02` (The Carmichael Function on Prime Powers: λ(2ᵏ) = 2ᵏ⁻²; quality 83, pass 0).

Sections/annotations started at line 31, leaving the 30-line docstring uncovered.

## Changes
- **Added a header section (1–30) and a context annotation** for the docstring — explains why the Carmichael function λ (the exponent of (ℤ/nℤ)ˣ) can be strictly smaller than φ: λ = φ exactly when the unit group is cyclic (odd prime powers), while the non-cyclic 2ᵏ group ℤ/2 × ℤ/2ᵏ⁻² (k ≥ 3) gives λ(2ᵏ) = 2ᵏ⁻² = φ/2.
- sections 3 → 4, annotations 3 → 4; full-file coverage.
- Structural gap fill only.

## Verification
- meta.json + annotations.json valid JSON; `check-meta-size.ts` within caps
- `pnpm build` — ✓ built

🤖 Generated with [Claude Code](https://claude.com/claude-code)