### PR TITLE
research(erdos-1043): eliminate both sorries — prove levelSet_compact, fix FALSE levelSet_connected_iff

### DIFF
--- a/proofs/Proofs/Erdos1043Problem.lean
+++ b/proofs/Proofs/Erdos1043Problem.lean
@@ -198,15 +198,47 @@ theorem min_projection_bounded (f : Polynomial ℂ) (hMonic : f.Monic) (hDeg : f
 /- For a degree-n monic polynomial, the level set {|f(z)| ≤ 1} has
     logarithmic capacity 1. This follows from the fact that the Green's
     function with pole at infinity has leading term log|z| - (1/n)log|f(z)|. -/
-/-- The level set is connected if and only if all roots lie in the level set. -/
-theorem levelSet_connected_iff (f : Polynomial ℂ) (hMonic : f.Monic) :
-    IsConnected (unitLevelSet f) ↔ ∀ z, f.eval z = 0 → z ∈ unitLevelSet f := by
-  sorry
+/-- Every root of `f` lies in its unit level set: at a root `f.eval z = 0`, so
+    `‖f.eval z‖ = 0 ≤ 1`.
 
-/-- The level set is always compact (closed and bounded). -/
+    NOTE: the previous statement
+    `IsConnected (unitLevelSet f) ↔ ∀ z, f.eval z = 0 → z ∈ unitLevelSet f`
+    was FALSE. Its right-hand side is *vacuously true* (every root is automatically
+    in the level set, as proved here), so the `↔` claimed that every unit lemniscate
+    `{z : ‖f z‖ ≤ 1}` is connected — which fails already for `f = X² - 4`, whose
+    level set is two disjoint components around `±2`. It is replaced by this true
+    containment fact. -/
+theorem roots_mem_levelSet (f : Polynomial ℂ) (z : ℂ) (hz : f.eval z = 0) :
+    z ∈ unitLevelSet f := by
+  simp only [unitLevelSet, levelSet, Set.mem_setOf_eq, hz, norm_zero]
+  norm_num
+
+/-- The unit level set `{z : ‖f.eval z‖ ≤ 1}` is compact: it is closed (a sublevel
+    set of the continuous map `z ↦ ‖f.eval z‖`) and bounded (for `deg f ≥ 1` the
+    norm `‖f.eval z‖ → ∞` as `z → ∞`, so the sublevel set is contained in a compact
+    set), hence compact by Heine–Borel in `ℂ`. -/
 theorem levelSet_compact (f : Polynomial ℂ) (hMonic : f.Monic) (hDeg : f.natDegree ≥ 1) :
     IsCompact (unitLevelSet f) := by
-  sorry
+  have hdeg : 0 < f.degree := Polynomial.natDegree_pos_iff_degree_pos.mp (by omega)
+  -- ‖f.eval z‖ → ∞ along the cocompact filter
+  have htend : Filter.Tendsto (fun z => ‖f.eval z‖) (Filter.cocompact ℂ) Filter.atTop :=
+    f.tendsto_norm_atTop hdeg tendsto_norm_cocompact_atTop
+  -- so `{z | 1 < ‖f.eval z‖}` is in the cocompact filter
+  have hmem : {z : ℂ | (1 : ℝ) < ‖f.eval z‖} ∈ Filter.cocompact ℂ :=
+    htend.eventually (Filter.eventually_gt_atTop 1)
+  obtain ⟨t, ht_compact, hsub⟩ := Filter.mem_cocompact'.mp hmem
+  -- hsub : tᶜ ⊆ {z | 1 < ‖f.eval z‖}
+  -- the level set is closed
+  have hcl : IsClosed (unitLevelSet f) := by
+    simp only [unitLevelSet, levelSet]
+    exact isClosed_le (by fun_prop) (by fun_prop)
+  -- and bounded: it sits inside the compact `t`
+  have hbd : Bornology.IsBounded (unitLevelSet f) := by
+    refine ht_compact.isBounded.subset (fun z hz => hsub ?_)
+    simp only [unitLevelSet, levelSet, Set.mem_setOf_eq] at hz
+    simp only [Set.mem_compl_iff, Set.mem_setOf_eq, not_lt]
+    exact hz
+  exact Metric.isCompact_of_isClosed_isBounded hcl hbd
 
 /- ## Part VIII: The Width Function -/
 

--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -176,7 +176,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1043 on polynomial level set projections. The answer is NO: Pommerenke showed that some polynomials have all projections ≥ 2.386. However, every monic polynomial has some projection ≤ 3.3.",
+    "summary": "This formalization captures Erdős Problem #1043 on polynomial level set projections. The answer is NO: Pommerenke showed that some polynomials have all projections ≥ 2.386. However, every monic polynomial has some projection ≤ 3.3. COMPLETION (2026-06-28): both sorries eliminated. `levelSet_compact` proved (the unit lemniscate {‖f‖≤1} is closed + bounded via polynomial growth on cocompact ℂ, Heine–Borel). The other sorry, `levelSet_connected_iff`, was a FALSE statement (its RHS — every root lies in the level set — is vacuously true, so it claimed every lemniscate is connected, which fails for X²−4); replaced by the true `roots_mem_levelSet`. File now 0 sorries; 2 intentional Pommerenke axioms remain.",
     "implications": "The problem connects complex analysis (polynomials, potential theory) with geometric measure theory (projections, widths). The Pommerenke constant—the supremum of minimum projection measures—lies between 2.386 and 3.3, but its exact value is unknown.",
     "openQuestions": [
       "What is the exact value of the Pommerenke constant?",
@@ -262,11 +262,11 @@
     "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 15,
-    "sorries": 2,
+    "sorries": 0,
     "path": "Proofs/Erdos1043Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos1043Aristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Erdős Problem #1043 (Pommerenke — projections of polynomial lemniscates). Both sorries in `Erdos1043Problem.lean` eliminated.

### 1. `levelSet_compact` — proved
The unit lemniscate `{z : ‖f.eval z‖ ≤ 1}` is compact:
- **Closed** — a sublevel set of the continuous map `z ↦ ‖f.eval z‖` (`isClosed_le`).
- **Bounded** — for `deg f ≥ 1`, `Polynomial.tendsto_norm_atTop` along `Filter.cocompact ℂ` (with `tendsto_norm_cocompact_atTop`) gives `‖f.eval z‖ → ∞`, so `{‖f.eval z‖ ≤ 1}` lies inside a compact set (`Filter.mem_cocompact'`).
- Hence compact by Heine–Borel (`Metric.isCompact_of_isClosed_isBounded`; `ℂ` is a `ProperSpace`).

### 2. `levelSet_connected_iff` — was FALSE, replaced
It asserted `IsConnected (unitLevelSet f) ↔ ∀ z, f.eval z = 0 → z ∈ unitLevelSet f`. The RHS is **vacuously true** — every root `z` has `f.eval z = 0`, so `‖f.eval z‖ = 0 ≤ 1` and `z ∈ unitLevelSet f`. Thus the `↔` claimed **every** unit lemniscate is connected, which is false (e.g. `f = X² − 4`: the level set is two disjoint components around `±2`). Replaced with the true containment lemma `roots_mem_levelSet`, with the falsehood documented in the docstring.

## Verification
`lake env lean` against pinned Mathlib v4.26.0: 0 errors, 0 sorries. `#print axioms levelSet_compact / roots_mem_levelSet` = `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`**.

(Docker unavailable; verified on host against cached pinned oleans.)

## Status
- **Outcome:** completed — both sorries eliminated, one false statement corrected.
- The two Pommerenke axioms (`pommerenke_counterexample`, `pommerenke_upper_bound`) are intentional deep-result inputs; entry stays `axiomatized`/`axiom`, `axiomCount` 2. `meta.json` `sorries` 2→0.

🤖 Generated by researcher-5