### PR TITLE
audit(erdos-214): meta sorries 1→0 — unit_square_from_stronger now proved

### DIFF
--- a/src/data/proofs/erdos-214/meta.json
+++ b/src/data/proofs/erdos-214/meta.json
@@ -16,7 +16,7 @@
       "combinatorial-geometry"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 214,
     "erdosUrl": "https://erdosproblems.com/214",
     "erdosProblemStatus": "solved",
@@ -78,8 +78,8 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 197,
-    "assumptions": "2 axioms: juhasz_1979 (Juhász 1979 — unit-distance free sets contain unit squares in complement), juhasz_stronger (stronger: unit-distance free sets contain any 4-point configuration in complement). 1 sorry in unit_square_from_stronger.",
+    "lineCount": 226,
+    "assumptions": "2 axioms: juhasz_1979 (Juhász 1979 — unit-distance free sets contain unit squares in complement), juhasz_stronger (stronger: unit-distance free sets contain any 4-point configuration in complement). 0 sorries: unit_square_from_stronger is now fully proved (the standard unit square is transported into the complement by Juhász's isometry).",
     "theoremCount": 5,
     "definitionCount": 13,
     "additionalFiles": [
@@ -90,7 +90,7 @@
     "historicalContext": "**Unit Distance Free Sets: Geometric Ramsey Theory in the Plane**\n\nErdős posed Problem #214 in 1983, asking about the geometric consequences of avoiding a single distance. The question lies at the heart of combinatorial geometry: what structure must the complement of a 'sparse' set possess?\n\n**The Unit Distance Graph**\n\nThe unit distance graph G₁(ℝ²) has all points of ℝ² as vertices and edges connecting pairs at distance 1. A unit-distance-free set is an independent set in this graph. The chromatic number χ(ℝ²) — the minimum colors needed so each color class is unit-distance-free — is the Hadwiger-Nelson problem: 5 ≤ χ(ℝ²) ≤ 7 (de Grey 2018 for the lower bound, hexagonal tiling for the upper).\n\n**Juhász's Resolution (1979)**\n\nRóbert Juhász proved a much stronger result than Erdős asked for: if S avoids unit distances, then Sᶜ contains a congruent copy of ANY 4-point configuration — not just unit squares. The proof uses the key observation that for each p ∈ S, the entire unit circle centered at p lies in Sᶜ, providing an abundance of points to build configurations from.\n\n**The Proof Strategy**\n\nFor any 4-point configuration P = {p₁, p₂, p₃, p₄}: Choose any point in S. Its unit circle (in Sᶜ) provides a 1-parameter family of candidate locations. The configuration has 8 degrees of freedom (4 points in ℝ²) minus 3 for rigid motions = 5 intrinsic degrees. The unit circles in Sᶜ provide enough flexibility (continuous families of points) to realize any 4-point configuration.\n\n**Limitations and Open Questions**\n\nThe result breaks down for large n-point configurations: there exist unit-distance-free sets whose complements miss certain n-point patterns. The critical threshold n is unknown. The 5-point case — whether ALL 5-point configurations must appear in Sᶜ — remains open since 1979.",
     "problemStatement": "Let S ⊂ ℝ² be such that no two points in S are distance 1 apart. Must the complement of S contain four points which form a unit square?\n\n**Answer:** YES (Juhász, 1979). More generally, Sᶜ contains a congruent copy of any 4-point configuration.",
     "text": "If S ⊂ ℝ² has no two points at distance 1 apart, must the complement contain four points forming a unit square? YES (Juhász, 1979). More generally, the complement contains a congruent copy of any 4-point set.",
-    "proofStrategy": "**Formalization Structure**\n\nThe Lean file (197 lines) is organized into ten labelled parts; several are prose section headers that carry no formal content in the current trimmed file.\n\n1. **Basic definitions**: Plane (EuclideanSpace ℝ (Fin 2)), dist (‖p-q‖), IsUnitDistanceFree, IsUnitSquare, ContainsUnitSquare\n\n2. **Main statement**: Erdos214Statement; axiomatized via juhasz_1979; erdos_214_solved := juhasz_1979\n\n3. **Stronger version**: PointSet n = Fin n → Plane, ContainsCongruentCopy via isometry, JuhaszStrongerTheorem (axiom juhasz_stronger) for n=4, unit_square_from_stronger (sorry: needs an explicit unit square encoded as PointSet 4)\n\n4. **Limitations**: HoldsFor5Points (open question, stated as a Prop only)\n\n5. **Graph connection**: UnitDistanceGraph definition, unit_distance_free_iff_no_edges (FULLY PROVED via ext/simp)\n\n6. **Proof techniques**: section header only — the geometric argument is described in prose, not formalized\n\n7. **Examples**: ScaledLattice = √2·ℤ² is defined as a candidate unit-distance-free set (the unit-free property is not formally proved)\n\n8–9. **Related problems / Geometric intuition**: section headers only\n\n10. **Summary**: erdos_214_status := juhasz_1979 and erdos_214_summary := ⟨juhasz_1979, juhasz_stronger⟩ (reductions to the two axioms)\n\n**What is Proved vs Axiomatized**\n\n- **Proved (sorry-free)**: unit_distance_free_iff_no_edges (graph characterization), erdos_214_solved, erdos_214_status, erdos_214_summary — the latter three are reductions to the two axioms\n- **Axiomatized (2 axioms)**: juhasz_1979, juhasz_stronger\n- **Sorry (1)**: unit_square_from_stronger (derives Erdos214Statement from JuhaszStrongerTheorem). The headline does not depend on this lemma — erdos_214_solved invokes juhasz_1979 directly.",
+    "proofStrategy": "**Formalization Structure**\n\nThe Lean file (226 lines) is organized into ten labelled parts; several are prose section headers that carry no formal content in the current trimmed file.\n\n1. **Basic definitions**: Plane (EuclideanSpace ℝ (Fin 2)), dist (‖p-q‖), IsUnitDistanceFree, IsUnitSquare, ContainsUnitSquare\n\n2. **Main statement**: Erdos214Statement; axiomatized via juhasz_1979; erdos_214_solved := juhasz_1979\n\n3. **Stronger version**: PointSet n = Fin n → Plane, ContainsCongruentCopy via isometry, JuhaszStrongerTheorem (axiom juhasz_stronger) for n=4, unit_square_from_stronger (FULLY PROVED: the standard unit square, encoded as PointSet 4, is transported into the complement by Juhász's isometry)\n\n4. **Limitations**: HoldsFor5Points (open question, stated as a Prop only)\n\n5. **Graph connection**: UnitDistanceGraph definition, unit_distance_free_iff_no_edges (FULLY PROVED via ext/simp)\n\n6. **Proof techniques**: section header only — the geometric argument is described in prose, not formalized\n\n7. **Examples**: ScaledLattice = √2·ℤ² is defined as a candidate unit-distance-free set (the unit-free property is not formally proved)\n\n8–9. **Related problems / Geometric intuition**: section headers only\n\n10. **Summary**: erdos_214_status := juhasz_1979 and erdos_214_summary := ⟨juhasz_1979, juhasz_stronger⟩ (reductions to the two axioms)\n\n**What is Proved vs Axiomatized**\n\n- **Proved (sorry-free)**: unit_distance_free_iff_no_edges (graph characterization), unit_square_from_stronger (derives Erdos214Statement from JuhaszStrongerTheorem via the standard unit square and Juhász's isometry), erdos_214_solved, erdos_214_status, erdos_214_summary — the latter three are reductions to the two axioms\n- **Axiomatized (2 axioms)**: juhasz_1979, juhasz_stronger\n\nThe file is now sorry-free (0 sorries); the only assumptions are the two Juhász axioms.",
     "keyInsights": [
       "For any p ∈ S (unit-distance-free), the entire unit circle {q : ‖p-q‖ = 1} lies in Sᶜ — this provides continuous families of complement points to build configurations from",
       "Juhász's result is much stronger than the original question: ALL 4-point configurations appear in Sᶜ, not just unit squares. The 4-point threshold is sharp — the result fails for large n",
@@ -131,10 +131,10 @@
     {
       "id": "stronger-version",
       "title": "Stronger Version: Any 4-Point Set",
-      "summary": "Defines PointSet n = Fin n → Plane and ContainsCongruentCopy (via distance-preserving map f with image in S). JuhaszStrongerTheorem: ∀ S unit-free, ∀ P : PointSet 4, Sᶜ contains congruent copy. unit_square_from_stronger has sorry (needs explicit unit square encoding as PointSet 4).",
+      "summary": "Defines PointSet n = Fin n → Plane and ContainsCongruentCopy (via distance-preserving map f with image in S). JuhaszStrongerTheorem: ∀ S unit-free, ∀ P : PointSet 4, Sᶜ contains congruent copy. unit_square_from_stronger is fully proved (explicit standard unit square as PointSet 4, transported by Juhász's isometry).",
       "startLine": 77,
       "endLine": 106,
-      "mathContext": "Defines PointSet n = Fin n → Plane and ContainsCongruentCopy (via distance-preserving map f with image in S). JuhaszStrongerTheorem: ∀ S unit-free, ∀ P : PointSet 4, Sᶜ contains congruent copy. unit_square_from_stronger has sorry (needs explicit unit square encoding as PointSet 4)."
+      "mathContext": "Defines PointSet n = Fin n → Plane and ContainsCongruentCopy (via distance-preserving map f with image in S). JuhaszStrongerTheorem: ∀ S unit-free, ∀ P : PointSet 4, Sᶜ contains congruent copy. unit_square_from_stronger is fully proved (explicit standard unit square as PointSet 4, transported by Juhász's isometry)."
     },
     {
       "id": "limitations",
@@ -191,7 +191,7 @@
       "Real"
     ],
     "namespace": "Erdos214",
-    "lineCount": 197,
+    "lineCount": 226,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 13,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-214 (Erdős #214 — unit-distance-free sets contain unit squares in complement)
**Severity**: LOW (sorry count off by 1, in the credibility-safe direction)

## Problem

meta.json was internally inconsistent on sorry count:
- `meta.sorries` = **1** (and `assumptions`, `proofStrategy`, section text all described "1 sorry in unit_square_from_stronger")
- `leanFile.sorries` and top-level `sorries` already = **0**

The source `Proofs/Erdos214Problem.lean` on `main` is **sorry-free**. PR #31128 proved `unit_square_from_stronger` (the standard unit square, encoded as `PointSet 4`, is transported into the complement by Juhász's isometry). The meta was only partially updated afterward.

## Evidence

```
$ grep -nE "^axiom |\bsorry\b" proofs/Proofs/Erdos214Problem.lean
72:axiom juhasz_1979 : Erdos214Statement
98:axiom juhasz_stronger : JuhaszStrongerTheorem
(no sorry)
```

Host compile (`lake env lean`) produces no `sorry` warnings and no errors.

## Fix

- `meta.sorries` 1 → 0
- `assumptions` / `proofStrategy` / section `summary`+`mathContext`: drop stale "1 sorry" language, record `unit_square_from_stronger` as fully proved
- `lineCount` 197 → 226 (matches current file)

Status stays **axiomatized / axiom**: the 2 Juhász axioms (`juhasz_1979`, `juhasz_stronger`) remain the only assumptions.

---
Discovered during gallery integrity audit.