### PR TITLE
research(erdos-1034-oq-02): book-lemma lower-bound mechanism, made exact [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1034OQ02.lean
+++ b/proofs/Proofs/Erdos1034OQ02.lean
@@ -1,0 +1,194 @@
+/-
+Erdős Problem #1034 — OQ-02: The book-lemma lower-bound mechanism, made exact
+
+Erdős #1034 asks: if `G` has `n` vertices and `> n²/4` edges, must there exist a
+triangle `T` and `> (1/2 - o(1))n` vertices each adjacent to at least two vertices
+of `T`?  This was **disproved** by Ma–Tang, who give a construction with at most
+`(2 - √(5/2) + o(1))n ≈ 0.419n` such "good neighbours".  The current bounds on the
+threshold function `h(n)` are
+
+        (1/6 - o(1))·n  ≤  h(n)  ≤  (2 - √(5/2) + o(1))·n.
+
+The lower bound `n/6` comes from the **book lemma**: a graph with `> n²/4` edges
+contains an edge lying in many common-neighbour triangles (a "book"), and the pages
+of that book are automatically good neighbours of any triangle on the spine.
+
+OQ-02 asks whether `n/6` can be improved *beyond* the book lemma.  This file does
+not resolve that (genuinely open) question.  Instead it **formalizes the engine of
+the lower bound exactly**:
+
+  * `book_le_goodNeighborCount` — the general structural theorem.  If `{a,b}` is an
+    edge and `P` is a set of common neighbours of `a` and `b` (a book with spine
+    `{a,b}` and pages `P`), then the triangle `{a, b, p₀}` on the spine has at least
+    `|P| - 1` good neighbours.  This is the precise mechanism translating "book of
+    size `k`" into "triangle with `k - 1` good neighbours".
+
+  * `book_goodNeighborCount_eq` — for the *pure* book graph (spine plus independent
+    pages) the count is **exactly** `|P| - 1`: the book method delivers neither more
+    nor fewer good neighbours than its page count.  Verified with a concrete witness
+    on `Fin 5` by `decide` (no `native_decide`, so the result is axiom-free).
+
+Every result is fully machine-checked with no `sorry`, no `axiom`, and no
+`native_decide`.
+
+Reference: https://erdosproblems.com/1034
+-/
+import Mathlib
+
+open Finset
+
+namespace Erdos1034OQ02
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- A triangle in `G`: three mutually adjacent distinct vertices. -/
+structure Triangle (G : SimpleGraph V) where
+  v1 : V
+  v2 : V
+  v3 : V
+  ne12 : v1 ≠ v2
+  ne23 : v2 ≠ v3
+  ne13 : v1 ≠ v3
+  adj12 : G.Adj v1 v2
+  adj23 : G.Adj v2 v3
+  adj13 : G.Adj v1 v3
+
+namespace Triangle
+variable {G : SimpleGraph V}
+
+/-- The three vertices of a triangle. -/
+def vertices (T : Triangle G) : Finset V := {T.v1, T.v2, T.v3}
+
+omit [Fintype V] in
+@[simp] lemma mem_vertices {T : Triangle G} {y : V} :
+    y ∈ T.vertices ↔ y = T.v1 ∨ y = T.v2 ∨ y = T.v3 := by
+  simp [vertices]
+
+end Triangle
+
+/-- Number of triangle vertices adjacent to `y`. -/
+def adjacentCount (G : SimpleGraph V) [DecidableRel G.Adj] (T : Triangle G) (y : V) : ℕ :=
+  (T.vertices.filter (fun v => G.Adj y v)).card
+
+/-- The set of **good neighbours** of `T`: vertices outside `T` adjacent to at least
+two of `T`'s vertices. -/
+def goodNeighbors (G : SimpleGraph V) [DecidableRel G.Adj] (T : Triangle G) : Finset V :=
+  univ.filter (fun y => 2 ≤ adjacentCount G T y ∧ y ∉ T.vertices)
+
+/-- The number of good neighbours of `T`. -/
+def goodNeighborCount (G : SimpleGraph V) [DecidableRel G.Adj] (T : Triangle G) : ℕ :=
+  (goodNeighbors G T).card
+
+/-!
+## The book bridge (general lower bound)
+
+If `{a, b}` is an edge and `P` is a finset of common neighbours of `a` and `b`
+(disjoint from `{a, b}`), then any triangle `{a, b, p₀}` on the spine has at least
+`|P| - 1` good neighbours: every page other than `p₀` is adjacent to both `a` and
+`b`, hence to two vertices of the triangle.
+-/
+
+theorem book_le_goodNeighborCount (G : SimpleGraph V) [DecidableRel G.Adj]
+    {a b p0 : V} (P : Finset V)
+    (hp0 : p0 ∈ P) (haP : a ∉ P) (hbP : b ∉ P)
+    (hab : G.Adj a b)
+    (hPa : ∀ p ∈ P, G.Adj p a) (hPb : ∀ p ∈ P, G.Adj p b) :
+    ∃ T : Triangle G, T.v1 = a ∧ T.v2 = b ∧ T.v3 = p0 ∧
+      P.card - 1 ≤ goodNeighborCount G T := by
+  -- assemble the spine triangle `{a, b, p0}`
+  have hap0 : a ≠ p0 := fun h => haP (h ▸ hp0)
+  have hbp0 : b ≠ p0 := fun h => hbP (h ▸ hp0)
+  refine ⟨{ v1 := a, v2 := b, v3 := p0,
+            ne12 := hab.ne, ne23 := hbp0, ne13 := hap0,
+            adj12 := hab, adj23 := (hPb p0 hp0).symm, adj13 := (hPa p0 hp0).symm },
+          rfl, rfl, rfl, ?_⟩
+  set T : Triangle G :=
+    { v1 := a, v2 := b, v3 := p0,
+      ne12 := hab.ne, ne23 := hbp0, ne13 := hap0,
+      adj12 := hab, adj23 := (hPb p0 hp0).symm, adj13 := (hPa p0 hp0).symm } with hT
+  -- every page other than `p0` is a good neighbour
+  have hsub : P.erase p0 ⊆ goodNeighbors G T := by
+    intro q hq
+    obtain ⟨hqp0, hqP⟩ := Finset.mem_erase.mp hq
+    have hqa : G.Adj q a := hPa q hqP
+    have hqb : G.Adj q b := hPb q hqP
+    -- `{a, b}` sits inside the adjacency filter, giving count ≥ 2
+    have hpair : ({a, b} : Finset V) ⊆ T.vertices.filter (fun v => G.Adj q v) := by
+      intro x hx
+      rcases Finset.mem_insert.mp hx with rfl | hx
+      · exact Finset.mem_filter.mpr ⟨by simp [T, Triangle.vertices], hqa⟩
+      · rw [Finset.mem_singleton] at hx; subst hx
+        exact Finset.mem_filter.mpr ⟨by simp [T, Triangle.vertices], hqb⟩
+    have hcount : 2 ≤ adjacentCount G T q := by
+      show 2 ≤ (T.vertices.filter (fun v => G.Adj q v)).card
+      have hle := Finset.card_le_card hpair
+      rwa [Finset.card_pair hab.ne] at hle
+    -- `q` is outside the triangle
+    have hqnot : q ∉ T.vertices := by
+      simp only [Triangle.mem_vertices, hT]
+      push_neg
+      refine ⟨?_, ?_, hqp0⟩
+      · exact fun h => haP (h ▸ hqP)
+      · exact fun h => hbP (h ▸ hqP)
+    exact Finset.mem_filter.mpr ⟨Finset.mem_univ q, hcount, hqnot⟩
+  calc P.card - 1 = (P.erase p0).card := (Finset.card_erase_of_mem hp0).symm
+    _ ≤ (goodNeighbors G T).card := Finset.card_le_card hsub
+    _ = goodNeighborCount G T := rfl
+
+/-!
+## Sharpness: the pure book graph realizes the bound exactly
+
+For the **pure** book graph — spine edge `{a, b}` together with pages that are
+pairwise non-adjacent and joined only to `a` and `b` — the spine triangle has
+*exactly* `|P| - 1` good neighbours.  Concretely, take spine `{0, 1}` and pages
+`{2, 3, 4}` on `Fin 5`; the triangle `{0, 1, 2}` has good neighbours exactly
+`{3, 4}`, i.e. `|P| - 1 = 2`.  So the book lemma's output equals its page count:
+no good neighbours are gained or lost beyond the pages themselves.
+-/
+
+namespace Book
+
+/-- Spine edge `{0,1}` plus pages `2,3,4`, each joined only to the spine. -/
+def baseEdges : List (Fin 5 × Fin 5) :=
+  [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4)]
+
+/-- The (symmetric) adjacency relation of the pure book graph on `Fin 5`. -/
+def isEdge (i j : Fin 5) : Prop := (i, j) ∈ baseEdges ∨ (j, i) ∈ baseEdges
+
+instance : DecidableRel isEdge := fun _ _ => inferInstanceAs (Decidable (_ ∨ _))
+
+/-- The pure book graph on `Fin 5`. -/
+def bookG : SimpleGraph (Fin 5) where
+  Adj := isEdge
+  symm := by intro i j h; exact h.symm
+  loopless := by intro i; fin_cases i <;> decide
+
+instance : DecidableRel bookG.Adj := fun i j => inferInstanceAs (Decidable (isEdge i j))
+
+/-- The spine triangle `{0, 1, 2}` of the book graph. -/
+def bookT : Triangle bookG where
+  v1 := 0
+  v2 := 1
+  v3 := 2
+  ne12 := by decide
+  ne23 := by decide
+  ne13 := by decide
+  adj12 := by decide
+  adj23 := by decide
+  adj13 := by decide
+
+/-- The pages of the book. -/
+def pages : Finset (Fin 5) := {2, 3, 4}
+
+/-- The spine triangle has exactly `|pages| - 1 = 2` good neighbours: the book
+mechanism delivers precisely its page count. -/
+theorem book_goodNeighborCount_eq : goodNeighborCount bookG bookT = pages.card - 1 := by
+  decide
+
+/-- Spelled out: the good neighbours are exactly the two pages `{3, 4}`. -/
+theorem book_goodNeighbors_eq : goodNeighbors bookG bookT = {3, 4} := by
+  decide
+
+end Book
+
+end Erdos1034OQ02

--- a/research/problems/erdos-1034-oq-02/knowledge.md
+++ b/research/problems/erdos-1034-oq-02/knowledge.md
@@ -1,0 +1,73 @@
+# erdos-1034-oq-02 — Beyond the Book Lemma (Erdős #1034)
+
+## Problem
+
+Erdős #1034: a graph on `n` vertices with `> n²/4` edges — must it contain a
+triangle `T` with `> (1/2 - o(1))n` vertices each adjacent to ≥2 vertices of `T`?
+**No** (Ma–Tang). Bounds on the threshold `h(n)`:
+
+        (1/6 - o(1))·n  ≤  h(n)  ≤  (2 - √(5/2) + o(1))·n ≈ 0.419n.
+
+**OQ-02:** can the `n/6` lower bound — which comes from the **book lemma** — be
+improved beyond the book method (e.g. via flag algebras or regularity)? Genuinely open.
+
+## What this entry does (does NOT resolve OQ-02)
+
+Formalizes the lower-bound *mechanism* exactly, axiom-free:
+
+- **`book_le_goodNeighborCount` (general):** if `{a,b}` is an edge and `P` a set of
+  common neighbours of `a,b` (disjoint from `{a,b}`), the spine triangle `{a,b,p₀}`
+  has `≥ |P| - 1` good neighbours. Proof: every page `q ≠ p₀` is adjacent to both
+  `a` and `b` (two of the triangle's vertices), so `P.erase p₀ ⊆ goodNeighbors`;
+  `card_erase_of_mem` finishes.
+- **`book_goodNeighborCount_eq` / `book_goodNeighbors_eq` (sharp):** for the pure
+  book graph on `Fin 5` (spine `{0,1}`, pages `{2,3,4}`, pages pairwise
+  non-adjacent), the spine triangle `{0,1,2}` has good neighbours *exactly* `{3,4}`,
+  i.e. `= |P| - 1 = 2`. By ordinary `decide` (not `native_decide`), so axiom-free.
+
+**Interpretation:** the book method converts page count into good-neighbour count
+one-for-one. `n/6` is exactly the largest book the Turán count guarantees, so any
+improvement to `h(n)` must exploit structure the book argument ignores — which is
+precisely why OQ-02 is "beyond the book lemma".
+
+## Verification
+
+- File: `proofs/Proofs/Erdos1034OQ02.lean` (194 lines, 4 theorems/lemmas, 10 defs).
+- Host-verified against pinned Mathlib 4.26 oleans: 0 errors, 0 warnings, 0 sorries.
+- `#print axioms` on all three theorems: only `propext, Classical.choice, Quot.sound`.
+  No `sorryAx`, no `Lean.ofReduceBool`. Status **verified**, badge **verified**.
+
+## Lean gotchas captured
+
+- `Symmetric`/`Irreflexive` over a `Fintype` with strict-implicit binders (`⦃⦄`)
+  has **no auto `Decidable` instance** — `symm := by decide` fails to synthesize.
+  Use `symm := by intro i j h; exact h.symm` (the relation is `Or`-symmetric by
+  construction) and `loopless := by intro i; fin_cases i <;> decide`.
+- `rw [adjacentCount]` fails ("Failed to rewrite using equation theorems for a
+  def"). Use `show 2 ≤ (T.vertices.filter …).card` to unfold the `def` definitionally.
+- `Finset.card_pair (h : a ≠ b) : ({a,b}).card = 2`; `a ≠ b` from `hab.ne`
+  (`SimpleGraph.Adj.ne`). `(h : G.Adj p a).symm : G.Adj a p`.
+- A `SimpleGraph (Fin n)` built from a symmetric edge `List (Fin n × Fin n)` with
+  `isEdge i j := (i,j) ∈ base ∨ (j,i) ∈ base` is fully `decide`-friendly for
+  `goodNeighbors`/`goodNeighborCount` equalities — keeps the witness 0-axiom.
+
+## Session log
+
+### 2026-06-28 (Session 1) — FRESH
+
+**Mode:** FRESH. **Outcome:** completed (verified, 0-axiom).
+
+- Selected from EMPTY-tier available pool by tractability/value; chose the
+  structural-theorem angle over chasing the (open) asymptotic improvement.
+- Wrote `Erdos1034OQ02.lean` fresh and self-contained (the existing
+  `Erdos1034Problem.lean` is an Aristotle file littered with "failed to load").
+- Proved the general book bridge + matching finite sharpness witness; verified
+  0-axiom on host.
+- Added gallery entry `src/data/proofs/erdos-1034-oq-02/{meta,annotations}.json`.
+
+**Next steps (future sessions, optional):**
+- Generalize the sharpness `= |P| - 1` from the `Fin 5` witness to an *abstract*
+  pure book graph on any `V` (characterize all good neighbours: isolated vertices
+  contribute 0, pages see only the spine).
+- Formalize the Turán-count step "(> n²/4 edges) ⟹ (∃ book of size ≥ n/6)" to
+  connect this mechanism to the actual `h(n) ≥ n/6` bound.

--- a/src/data/proofs/erdos-1034-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1034-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "erdos-1034-oq-02-good-neighbor",
+    "proofId": "erdos-1034-oq-02",
+    "range": { "startLine": 75, "endLine": 79 },
+    "type": "definition",
+    "title": "Good Neighbours: Adjacent to Two of Three",
+    "content": "A vertex y is a 'good neighbour' of triangle T when it is adjacent to at least two of T's three vertices. goodNeighbors collects all such y lying outside T itself; goodNeighborCount is their number. This is the quantity Erdős #1034 maximizes: h(n) is the largest k such that every n-vertex graph with > n²/4 edges has a triangle with ≥ k good neighbours.",
+    "mathContext": "$$y \\text{ good for } T \\iff |\\{v \\in T : y \\sim v\\}| \\geq 2.$$",
+    "significance": "supporting",
+    "relatedConcepts": ["triangle neighbours", "good neighbour", "Erdős problem 1034"],
+    "prerequisites": ["Finset.filter", "Finset.card"]
+  },
+  {
+    "id": "erdos-1034-oq-02-book-bridge",
+    "proofId": "erdos-1034-oq-02",
+    "range": { "startLine": 91, "endLine": 145 },
+    "type": "insight",
+    "title": "The Book Bridge: |P| Pages Give |P|−1 Good Neighbours",
+    "content": "This is the engine of the n/6 lower bound. A 'book' has a spine edge {a,b} and pages P — vertices each adjacent to both a and b. For the spine triangle {a,b,p₀}, every other page q is adjacent to both a and b, which are two of the triangle's three vertices, so q is a good neighbour. Thus P.erase p₀ ⊆ goodNeighbors, and card_erase_of_mem gives goodNeighborCount ≥ |P| − 1. A book of size k therefore guarantees a triangle with k−1 good neighbours, and the Turán count guaranteeing a book of size ≥ n/6 yields h(n) ≥ n/6.",
+    "mathContext": "$$\\text{book of size } |P| \\implies \\text{goodNeighborCount} \\geq |P| - 1.$$",
+    "significance": "central",
+    "relatedConcepts": ["book lemma", "common neighbours", "Turán threshold", "lower bound"],
+    "prerequisites": ["Finset.card_le_card", "Finset.card_erase_of_mem", "SimpleGraph.Adj.symm"]
+  },
+  {
+    "id": "erdos-1034-oq-02-book-graph",
+    "proofId": "erdos-1034-oq-02",
+    "range": { "startLine": 161, "endLine": 179 },
+    "type": "definition",
+    "title": "The Pure Book Graph on Fin 5",
+    "content": "An explicit pure book: spine {0,1} and pages {2,3,4}, where pages are joined only to the spine and never to each other. Built as a SimpleGraph from a symmetric edge list with a DecidableRel instance, so all counts are computable by `decide`. The spine triangle {0,1,2} is bookT.",
+    "mathContext": "Spine $\\{0,1\\}$; pages $\\{2,3,4\\}$, each adjacent to $0$ and $1$ only.",
+    "significance": "supporting",
+    "relatedConcepts": ["pure book graph", "SimpleGraph", "DecidableRel", "decide"],
+    "prerequisites": ["SimpleGraph on Fin n", "symmetric edge relation"]
+  },
+  {
+    "id": "erdos-1034-oq-02-sharpness",
+    "proofId": "erdos-1034-oq-02",
+    "range": { "startLine": 185, "endLine": 189 },
+    "type": "insight",
+    "title": "Sharpness: The Bound Is Met With Equality",
+    "content": "For the pure book graph the spine triangle {0,1,2} has good neighbours exactly {3,4}, so goodNeighborCount = |pages| − 1 = 2. The general lower bound is therefore attained with equality: the book method delivers neither more nor fewer good neighbours than its page count. This is the precise sense in which improving h(n) beyond n/6 requires techniques *beyond* the book lemma — verified axiom-free by `decide` (not `native_decide`).",
+    "mathContext": "$$\\text{goodNeighborCount}(\\text{book}) = |P| - 1 \\quad (\\text{equality}).$$",
+    "significance": "central",
+    "relatedConcepts": ["sharpness", "barrier", "equality case", "axiom-free decide"],
+    "prerequisites": ["Finset equality by decide"]
+  }
+]

--- a/src/data/proofs/erdos-1034-oq-02/meta.json
+++ b/src/data/proofs/erdos-1034-oq-02/meta.json
@@ -1,0 +1,78 @@
+{
+  "id": "erdos-1034-oq-02",
+  "title": "The Book-Lemma Lower-Bound Mechanism for Erdős #1034, Made Exact",
+  "slug": "erdos-1034-oq-02",
+  "description": "Addresses OQ-02 of Erdős Problem #1034 (triangle neighbours in dense graphs): can the lower bound h(n) ≥ (1/6 - o(1))n, which comes from the book lemma, be improved beyond the book method? This entry does not resolve that open question; instead it formalizes the engine of the lower bound exactly, axiom-free. The main structural theorem book_le_goodNeighborCount shows that if {a,b} is an edge and P is a set of common neighbours of a and b (a 'book' with spine {a,b} and pages P), then the spine triangle {a,b,p₀} has at least |P|-1 'good neighbours' (vertices adjacent to ≥2 of the triangle's vertices) — the precise mechanism translating 'edge in many triangles' into 'triangle with many good neighbours'. A matching sharpness result (book_goodNeighborCount_eq, book_goodNeighbors_eq) shows that for the pure book graph (spine plus pairwise-nonadjacent pages) the count is exactly |P|-1: the book method delivers neither more nor fewer good neighbours than its page count, verified on an explicit Fin 5 witness by decide (no native_decide). Fully machine-checked: 0 sorries, 0 axioms beyond the foundational propext / Classical.choice / Quot.sound.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://erdosproblems.com/1034",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1034OQ02.lean",
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "triangles",
+      "extremal-combinatorics",
+      "book-lemma",
+      "good-neighbours",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 194,
+    "assumptions": "None. Every result is fully machine-checked and depends only on the standard foundational axioms propext / Classical.choice / Quot.sound. No `axiom` declarations, no structure-encoded assumptions, and no `native_decide` (the finite sharpness witness is discharged by ordinary `decide`, so `Lean.ofReduceBool` is not used).",
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 10,
+    "erdosNumber": 1034,
+    "erdosUrl": "https://erdosproblems.com/1034",
+    "erdosProblemStatus": "open"
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1034",
+      "relationship": "extends",
+      "description": "The parent problem: a graph with > n²/4 edges need NOT contain a triangle with > (1/2 - o(1))n good neighbours (disproved by Ma–Tang). The known bounds are (1/6 - o(1))n ≤ h(n) ≤ (2 - √(5/2) + o(1))n. OQ-02 asks whether the n/6 lower bound — which comes from the book lemma — can be improved."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**The book lemma and the n/6 floor**\n\nErdős Problem #1034 asks, for a graph G on n vertices with more than n²/4 edges, whether there must exist a triangle T together with more than (1/2 - o(1))n vertices each adjacent to at least two vertices of T. Ma and Tang disproved this, constructing dense graphs in which the best triangle has at most (2 - √(5/2) + o(1))n ≈ 0.419n such 'good neighbours'. The resulting threshold function h(n) is squeezed into (1/6 - o(1))n ≤ h(n) ≤ (2 - √(5/2) + o(1))n.\n\nThe lower bound n/6 is produced by the **book lemma**: a graph with more than n²/4 edges contains an edge {a,b} lying in many common-neighbour triangles — a 'book' with spine {a,b} whose 'pages' are the common neighbours — and every page is automatically adjacent to a and b, hence to two vertices of any triangle on the spine. So a book of size k yields a triangle with at least k-1 good neighbours, and a Turán-type count guarantees a book of size ≥ n/6.\n\nOQ-02 asks whether this n/6 floor can be pushed higher using techniques beyond the book lemma (flag algebras, regularity, etc.). That question is genuinely open. This entry does not answer it; it instead pins down the book mechanism itself as an exact, verified statement, isolating precisely what the book argument can and cannot deliver.",
+    "problemStatement": "**Open Question OQ-02: Beyond the book lemma**\n\nThe lower bound $h(n) \\geq (1/6 - o(1))n$ is obtained from the book lemma. Can it be improved — is there a construction or argument giving $h(n) \\geq (1/6 + \\varepsilon)n$ for some fixed $\\varepsilon > 0$, or is $n/6$ a genuine barrier for book-style methods?\n\nThis formalization makes the book mechanism precise: a book with spine $\\{a,b\\}$ and page set $P$ forces a triangle with at least $|P|-1$ good neighbours (general lower bound), and for the pure book graph this is met with equality (sharpness). The book method therefore converts page count into good-neighbour count one-for-one — clarifying that any improvement past $n/6$ must come from outside the book argument.",
+    "proofStrategy": "**Formalization approach (axiom-free)**\n\n1. Define a `Triangle G` as three mutually adjacent distinct vertices, with `vertices`, `adjacentCount` (number of triangle vertices adjacent to a given y), `goodNeighbors` (vertices outside T adjacent to ≥2 of T's vertices), and `goodNeighborCount`.\n2. Prove the general bridge `book_le_goodNeighborCount`: given an edge {a,b} and a page set P of common neighbours (disjoint from {a,b}), construct the spine triangle {a,b,p₀} and show every page q ≠ p₀ is a good neighbour — q is adjacent to both a and b, so {a,b} ⊆ the adjacency filter, giving adjacentCount ≥ 2, while q lies outside the triangle. Hence `P.erase p₀ ⊆ goodNeighbors`, and `card_erase_of_mem` gives goodNeighborCount ≥ |P| - 1.\n3. Build an explicit pure book graph on `Fin 5` (spine {0,1}, pages {2,3,4}, pages pairwise non-adjacent) as a `SimpleGraph` from a symmetric edge list, with a `DecidableRel` instance.\n4. Prove sharpness by `decide` (not `native_decide`): the spine triangle {0,1,2} has good-neighbour set exactly {3,4}, so goodNeighborCount = |pages| - 1 = 2. This shows the general lower bound is attained with equality by books.\n5. Confirm via `#print axioms` that all results depend only on propext / Classical.choice / Quot.sound.",
+    "keyInsights": [
+      "**The book-to-good-neighbour bridge is a clean subset inclusion**: every page other than the chosen spine vertex p₀ lands in `goodNeighbors`, because a page is adjacent to both spine endpoints a and b — two of the triangle's three vertices. The lower bound |P|-1 is then just `card (P.erase p₀)`.",
+      "**The bound is sharp for pure books**: in the pure book graph (pages joined only to the spine, never to each other), the spine triangle {a,b,p₀} has good neighbours that are *exactly* the remaining pages — no vertex outside P∪{a,b} is adjacent to anything, and pages see only the spine. So goodNeighborCount = |P| - 1 with equality, not merely ≥.",
+      "**Equality is the point for OQ-02**: because the book method converts page count into good-neighbour count one-for-one, the n/6 floor is precisely the largest book the Turán count guarantees. Any improvement to h(n) beyond n/6 must therefore exploit structure the book lemma ignores — this is what makes the open question 'beyond the book lemma'.",
+      "**Axiom-free finite verification**: the sharpness witness is discharged by ordinary `decide` over `Fin 5`, so the entry avoids the `Lean.ofReduceBool` axiom that `native_decide` would introduce. The whole file is verified with only the three foundational axioms."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Triangles and Good Neighbours",
+      "startLine": 43,
+      "endLine": 80,
+      "summary": "Defines the Triangle structure (three mutually adjacent distinct vertices), its vertex set, adjacentCount (triangle vertices adjacent to y), goodNeighbors (vertices outside T adjacent to ≥2 of T's vertices), and goodNeighborCount.",
+      "mathContext": "A vertex y is a 'good neighbour' of triangle T when it is adjacent to at least two of T's three vertices: $|\\{v \\in T : y \\sim v\\}| \\geq 2$."
+    },
+    {
+      "id": "book-bridge",
+      "title": "The Book Bridge (General Lower Bound)",
+      "startLine": 81,
+      "endLine": 145,
+      "summary": "book_le_goodNeighborCount: if {a,b} is an edge and P is a set of common neighbours of a,b disjoint from {a,b}, the spine triangle {a,b,p₀} has at least |P|-1 good neighbours. Proven by showing P.erase p₀ ⊆ goodNeighbors.",
+      "mathContext": "A book of size $|P|$ with spine $\\{a,b\\}$ forces a triangle with $\\geq |P|-1$ good neighbours: every page $q \\neq p_0$ is adjacent to both $a$ and $b$, hence to two vertices of $\\{a,b,p_0\\}$."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness: The Pure Book Graph",
+      "startLine": 146,
+      "endLine": 194,
+      "summary": "An explicit pure book graph on Fin 5 (spine {0,1}, pages {2,3,4}). book_goodNeighbors_eq: the spine triangle {0,1,2} has good neighbours exactly {3,4}. book_goodNeighborCount_eq: goodNeighborCount = |pages| - 1 = 2. Both by decide (no native_decide).",
+      "mathContext": "For the pure book graph the lower bound is met with equality — the book method delivers exactly its page count, $|P|-1$ good neighbours, neither more nor fewer."
+    }
+  ]
+}


### PR DESCRIPTION
## Erdős #1034 OQ-02 — beyond the book lemma

**Problem.** A graph on `n` vertices with `> n²/4` edges need not contain a triangle with `> (1/2-o(1))n` "good neighbours" (vertices adjacent to ≥2 of the triangle's vertices) — disproved by Ma–Tang. The threshold satisfies `(1/6-o(1))n ≤ h(n) ≤ (2-√(5/2)+o(1))n ≈ 0.419n`. **OQ-02** asks whether the `n/6` lower bound, which comes from the *book lemma*, can be improved beyond the book method.

This PR **does not resolve** that (open) question. It formalizes the lower-bound *mechanism* exactly, axiom-free.

### Results (all 0-axiom, host-verified vs pinned Mathlib 4.26)
- **`book_le_goodNeighborCount` (general):** if `{a,b}` is an edge and `P` is a set of common neighbours of `a,b` disjoint from `{a,b}`, the spine triangle `{a,b,p₀}` has `≥ |P|-1` good neighbours. Every page `q ≠ p₀` is adjacent to both `a` and `b` (two of the triangle's vertices), so `P.erase p₀ ⊆ goodNeighbors`.
- **`book_goodNeighbors_eq` / `book_goodNeighborCount_eq` (sharp):** for the pure book graph on `Fin 5` (spine `{0,1}`, pages `{2,3,4}`, pages pairwise non-adjacent) the spine triangle `{0,1,2}` has good neighbours *exactly* `{3,4}`, i.e. `= |P|-1 = 2`. Discharged by ordinary `decide` (**not** `native_decide`), so no `Lean.ofReduceBool`.

**Interpretation.** The book method converts page count into good-neighbour count one-for-one; `n/6` is exactly the largest book the Turán count guarantees, so improving `h(n)` past `n/6` requires structure the book lemma ignores — which is precisely what "beyond the book lemma" means.

### Verification
- `proofs/Proofs/Erdos1034OQ02.lean` — 194 lines, 4 theorems/lemmas, 10 defs. 0 sorries, 0 warnings.
- `#print axioms` on all three theorems: only `propext, Classical.choice, Quot.sound`. Status **verified**, badge **verified**.

### Files
- `proofs/Proofs/Erdos1034OQ02.lean`
- `src/data/proofs/erdos-1034-oq-02/{meta,annotations}.json`
- `research/problems/erdos-1034-oq-02/knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)