### PR TITLE
research(erdos-574-oq-01): honest extremal-number definition + numeric lower-bound transfer [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos574Problem.lean
+++ b/proofs/Proofs/Erdos574Problem.lean
@@ -40,12 +40,7 @@ Reference: https://erdosproblems.com/574
 Source: [ErSi82] Erdős–Simonovits
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Algebra.Ring.Parity
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.Logic.Function.Iterate
-import Mathlib.Tactic
+import Mathlib
 
 /- ## Definitions -/
 
@@ -70,13 +65,13 @@ def HasCycle {n : ℕ} (G : SimpleGraph' n) (ℓ : ℕ) : Prop :=
 def IsConsecutiveCycleFree {n : ℕ} (G : SimpleGraph' n) (k : ℕ) : Prop :=
   ¬HasCycle G (2 * k - 1) ∧ ¬HasCycle G (2 * k)
 
-/-- ex(n; {C_{2k−1}, C_{2k}}): the maximum number of edges in a
-    {C_{2k−1}, C_{2k}}-free graph on n vertices. -/
+/-- `ex(n; {C_{2k−1}, C_{2k}})`: the maximum number of edges in a
+    `{C_{2k−1}, C_{2k}}`-free graph on `n` vertices, as the supremum of the
+    achievable edge counts. The defining set is bounded above by `n * n`
+    (`edgeCount'_le`) and nonempty (the empty graph is cycle-free), so the
+    supremum is attained. -/
 noncomputable def exConsecutiveCycles (n k : ℕ) : ℕ :=
-  Finset.sup (Finset.filter
-    (fun _ => True)  -- axiomatized
-    (Finset.range 1))
-    id
+  sSup {m : ℕ | ∃ G : SimpleGraph' n, IsConsecutiveCycleFree G k ∧ edgeCount' G = m}
 
 /-- A graph is **bipartite**: its vertices admit a 2-colouring with no
     monochromatic edge. -/
@@ -164,6 +159,43 @@ theorem bipartite_evenFree_consecutiveFree {n : ℕ} (G : SimpleGraph' n)
     (hG : IsBipartite G) (k : ℕ) (hk : 1 ≤ k)
     (hev : ¬ HasCycle G (2 * k)) : IsConsecutiveCycleFree G k :=
   ⟨bipartite_no_odd_consecutive G hG k hk, hev⟩
+
+/- ## The lower-bound transfer at the level of the extremal function -/
+
+/-- Every graph on `Fin n` has at most `n * n` edges (the edge set is a subset
+    of `Fin n × Fin n`). A crude bound, but enough to make the supremum
+    defining `exConsecutiveCycles` well-behaved. -/
+lemma edgeCount'_le {n : ℕ} (G : SimpleGraph' n) : edgeCount' G ≤ n * n := by
+  classical
+  calc edgeCount' G
+      ≤ (Finset.univ : Finset (Fin n × Fin n)).card := Finset.card_filter_le _ _
+    _ = n * n := by rw [Finset.card_univ, Fintype.card_prod, Fintype.card_fin]
+
+/-- The set of edge counts achievable by `{C_{2k−1}, C_{2k}}`-free graphs is
+    bounded above (by `n * n`), so `exConsecutiveCycles` is a genuine maximum. -/
+lemma bddAbove_consecutiveFree_edgeCounts (n k : ℕ) :
+    BddAbove {m : ℕ | ∃ G : SimpleGraph' n, IsConsecutiveCycleFree G k ∧ edgeCount' G = m} := by
+  refine ⟨n * n, ?_⟩
+  rintro m ⟨G, _, rfl⟩
+  exact edgeCount'_le G
+
+/-- **The extremal function dominates every admissible graph.** Any
+    `{C_{2k−1}, C_{2k}}`-free graph's edge count is at most
+    `exConsecutiveCycles n k`. -/
+theorem edgeCount_le_exConsecutive {n k : ℕ} (G : SimpleGraph' n)
+    (h : IsConsecutiveCycleFree G k) : edgeCount' G ≤ exConsecutiveCycles n k :=
+  le_csSup (bddAbove_consecutiveFree_edgeCounts n k) ⟨G, h, rfl⟩
+
+/-- **Numeric form of the lower-bound transfer.** A bipartite, `C_{2k}`-free
+    graph contributes its full edge count to the extremal number
+    `exConsecutiveCycles n k` — forbidding the odd cycle `C_{2k−1}` costs nothing
+    even at the level of the extremal *function*, not merely cycle-freeness.
+    This is the formal bridge from `ex(n; C_{2k})` lower bounds (realised by
+    bipartite incidence graphs) to `ex(n; {C_{2k−1}, C_{2k}})`. -/
+theorem bipartite_evenFree_le_ex {n k : ℕ} (G : SimpleGraph' n)
+    (hG : IsBipartite G) (hk : 1 ≤ k) (hev : ¬ HasCycle G (2 * k)) :
+    edgeCount' G ≤ exConsecutiveCycles n k :=
+  edgeCount_le_exConsecutive G (bipartite_evenFree_consecutiveFree G hG k hk hev)
 
 /- ## Main Conjecture (OPEN) -/
 

--- a/src/data/proofs/erdos-574/annotations.json
+++ b/src/data/proofs/erdos-574/annotations.json
@@ -96,12 +96,12 @@
     "id": "extremal-number",
     "proofId": "erdos-574",
     "range": {
-      "startLine": 46,
-      "endLine": 52
+      "startLine": 68,
+      "endLine": 74
     },
     "type": "definition",
     "title": "Extremal Number for Consecutive Cycle Pairs",
-    "content": "The extremal number $\\text{ex}(n; \\{C_{2k-1}, C_{2k}\\})$ is the maximum number of edges in a graph on $n$ vertices that is $\\{C_{2k-1}, C_{2k}\\}$-free. The formalization uses an axiomatized supremum since computing the exact extremal number requires solving the open problem.",
+    "content": "The extremal number $\\text{ex}(n; \\{C_{2k-1}, C_{2k}\\})$ is the maximum number of edges in a graph on $n$ vertices that is $\\{C_{2k-1}, C_{2k}\\}$-free. The formalization defines it as a genuine (non-axiomatized) supremum over the achievable edge counts; this set is bounded above by $n^2$ (`edgeCount'_le`) and nonempty, so the supremum is attained. Computing its exact *value* requires solving the open problem, but the definition itself is well-posed, and `edgeCount_le_exConsecutive` shows every admissible graph's edge count lies below it.",
     "mathContext": "$\\text{ex}(n; \\{C_{2k-1}, C_{2k}\\}) = \\max\\{|E(G)| : G \\text{ on } n \\text{ vertices, } G \\not\\supseteq C_{2k-1}, C_{2k}\\}$",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-574/meta.json
+++ b/src/data/proofs/erdos-574/meta.json
@@ -101,18 +101,13 @@
     "https://erdosproblems.com/574"
   ],
   "leanFile": {
-    "lineCount": 188,
+    "lineCount": 220,
     "structureCount": 1,
     "axiomCount": 0,
-    "theoremCount": 3,
-    "lemmaCount": 1,
+    "theoremCount": 5,
+    "lemmaCount": 3,
     "imports": [
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Algebra.Ring.Parity",
-      "Mathlib.Data.Real.Basic",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Logic.Function.Iterate",
-      "Mathlib.Tactic"
+      "Mathlib"
     ],
     "opens": [
       "Classical"


### PR DESCRIPTION
## Summary

Two improvements to `Proofs/Erdos574Problem.lean` (Erdős #574 — the Turán number for consecutive cycle pairs, $\text{ex}(n; \{C_{2k-1}, C_{2k}\})$).

The file's **structural** lower-bound transfer was already proven 0-axiom: a bipartite $C_{2k}$-free graph is automatically $\{C_{2k-1}, C_{2k}\}$-free, because *bipartite ⟹ no odd cycle*, so forbidding the odd cycle $C_{2k-1}$ is "free" on the standard incidence-geometry lower-bound witnesses.

### 1. Honest definition (was a deceptive stub)

`exConsecutiveCycles n k` was a vacuous placeholder:
```lean
Finset.sup (Finset.filter (fun _ => True) (Finset.range 1)) id   -- axiomatized
```
which **ignores both `n` and `k`** (two unused-variable warnings) and always returns `0`, while claiming to be the extremal number. Replaced with the genuine supremum
```lean
sSup {m : ℕ | ∃ G : SimpleGraph' n, IsConsecutiveCycleFree G k ∧ edgeCount' G = m}
```
The defining set is bounded above by $n^2$ (`edgeCount'_le`) and nonempty (the empty graph is cycle-free), so the supremum is a genuine, attained maximum — **not** an axiom.

### 2. Numeric lower-bound transfer (new, 0-axiom)

New results lift the structural transfer to the extremal *function*:
- `edgeCount'_le` — any graph on `Fin n` has at most $n^2$ edges.
- `bddAbove_consecutiveFree_edgeCounts` — the achievable edge counts are bounded.
- `edgeCount_le_exConsecutive` — every admissible graph's edge count is $\le$ `exConsecutiveCycles n k` (via `le_csSup`).
- `bipartite_evenFree_le_ex` — a bipartite $C_{2k}$-free graph contributes its **full** edge count to $\text{ex}(n; \{C_{2k-1}, C_{2k}\})$. This is the formal bridge from $\text{ex}(n; C_{2k})$ lower bounds to the consecutive-pair extremal number, at the numeric level rather than just cycle-freeness.

Also corrected the `extremal-number` annotation, which described the definition as an "axiomatized supremum" — no longer accurate.

## Verification

Host-verified against pinned Mathlib 4.26: `lake env lean` exit 0, **no warnings**, no sorries. `#print axioms` on the new results shows only `propext / Classical.choice / Quot.sound`. File total: **0 axioms, 0 sorries**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
