### PR TITLE
research(konigsberg-oq-04-oq-01): prove oriented-incidence ⇒ Laplacian (M1a-i) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean
+++ b/proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean
@@ -69,4 +69,117 @@ theorem spanningTreeCofactor_K4 :
     (!![(3 : ℤ), -1, -1; -1, 3, -1; -1, -1, 3]).det = 16 := by
   simp [Matrix.det_fin_three]
 
+/-! ## M1a-i: the oriented-incidence ⇒ Laplacian identity (`B Bᵀ = D − A`)
+
+The base cases above are concrete determinant oracles. The first *general* milestone
+toward Matrix-Tree is the substrate identity that the classical (undirected) proof
+rides on: for the oriented incidence matrix `B` of a loopless multigraph, `B Bᵀ` is
+the graph Laplacian `D − A`.
+
+This is precisely the gap flagged in the OQ-04-OQ-01 knowledge base (Insight 5) and,
+independently, in Mathlib itself: `Mathlib/Combinatorics/SimpleGraph/IncMatrix.lean`
+lists as future-work TODOs (lines 41–42)
+
+  * "Define the oriented incidence matrices for oriented graphs."
+  * "Define the graph Laplacian of a simple graph using the oriented incidence matrix."
+
+Mathlib's existing `incMatrix` is the *unsigned* 0/1 incidence matrix, for which
+`N Nᵀ = D + A` (the *signless* Laplacian) — the wrong sign for Matrix-Tree. So the
+oriented object below cannot be obtained from `incMatrix` directly; it is built here
+from `head`/`tail` functions (a multigraph presentation: each edge `e` is an oriented
+pair `tail e → head e`).
+
+What this milestone does **not** do: it does not discharge the parent
+`konigsberg-oq-04` axiom. That still needs Cauchy–Binet (`det (B_S B_Sᵀ) = …`, M1a-ii),
+which remains absent upstream, plus the directed Tutte cofactor (M2). This is the
+verified substrate those build on. -/
+
+section IncidenceLaplacian
+
+variable {V E : Type*} [Fintype V] [DecidableEq V] [Fintype E] [DecidableEq E]
+
+/-- Oriented incidence matrix of a multigraph given by `head`/`tail`: column `e` has
+`+1` at its head and `-1` at its tail. -/
+def incidence (head tail : E → V) : Matrix V E ℤ := fun i e =>
+  (if i = head e then 1 else 0) - (if i = tail e then 1 else 0)
+
+/-- Degree of `i`: the number of edges incident to `i`. -/
+def deg (head tail : E → V) (i : V) : ℤ :=
+  (Finset.univ.filter (fun e => i = head e ∨ i = tail e)).card
+
+/-- Edge multiplicity between `i` and `j` (either orientation). -/
+def adjc (head tail : E → V) (i j : V) : ℤ :=
+  (Finset.univ.filter
+    (fun e => (i = head e ∧ j = tail e) ∨ (j = head e ∧ i = tail e))).card
+
+/-- The integer Laplacian `D − A` of the multigraph: degree on the diagonal, negative
+edge-multiplicity off-diagonal. -/
+def lap (head tail : E → V) : Matrix V V ℤ := fun i j =>
+  if i = j then deg head tail i else - adjc head tail i j
+
+omit [Fintype V] [DecidableEq E] in
+/-- Diagonal of `B Bᵀ` is the degree (loopless ⇒ the two indicators never overlap, so
+`(a − b)² = a + b`). -/
+theorem incidence_mul_transpose_diag
+    (head tail : E → V) (hloop : ∀ e, head e ≠ tail e) (i : V) :
+    (incidence head tail * (incidence head tail)ᵀ) i i = deg head tail i := by
+  simp only [Matrix.mul_apply, incidence, Matrix.transpose_apply, deg]
+  rw [Finset.card_filter]
+  push_cast
+  apply Finset.sum_congr rfl
+  intro e _
+  by_cases hh : i = head e <;> by_cases ht : i = tail e
+  · exact absurd (hh.symm.trans ht) (hloop e)
+  all_goals simp [hh, ht, hloop e, (hloop e).symm]
+
+omit [Fintype V] [DecidableEq E] in
+/-- Off-diagonal `(i,j)` of `B Bᵀ` is `−` the edge multiplicity between `i` and `j`
+(`i ≠ j` ⇒ only the cross terms `±1` survive). -/
+theorem incidence_mul_transpose_offdiag
+    (head tail : E → V) (i j : V) (hij : i ≠ j) :
+    (incidence head tail * (incidence head tail)ᵀ) i j = - adjc head tail i j := by
+  simp only [Matrix.mul_apply, incidence, Matrix.transpose_apply, adjc]
+  rw [Finset.card_filter]
+  push_cast
+  rw [← Finset.sum_neg_distrib]
+  apply Finset.sum_congr rfl
+  intro e _
+  by_cases hi_h : i = head e <;> by_cases hi_t : i = tail e <;>
+    by_cases hj_h : j = head e <;> by_cases hj_t : j = tail e <;>
+    simp_all
+
+omit [Fintype V] [DecidableEq E] in
+/-- **Oriented incidence ⇒ Laplacian** (M1a-i). For a loopless multigraph,
+`B Bᵀ = D − A`. -/
+theorem incidence_mul_transpose (head tail : E → V) (hloop : ∀ e, head e ≠ tail e) :
+    incidence head tail * (incidence head tail)ᵀ = lap head tail := by
+  ext i j
+  by_cases h : i = j
+  · subst h; simp [lap, incidence_mul_transpose_diag head tail hloop]
+  · simp [lap, h, incidence_mul_transpose_offdiag head tail i j h]
+
+/-! ### Concrete K₃ bridge
+
+Realizes the general identity on a base case: the oriented incidence of K₃ (edges
+`0→1`, `1→2`, `0→2`) satisfies `B Bᵀ = ` the full K₃ Laplacian, whose reduced
+`(0,0)`-cofactor `[[2,-1],[-1,2]]` has determinant `3` — exactly
+`spanningTreeCofactor_K3`. This closes the loop from the incidence substrate to the
+base-case determinant oracle. -/
+
+/-- K₃ edges as `head`/`tail` over `Fin 3`: `0→1`, `1→2`, `0→2`. -/
+def k3head : Fin 3 → Fin 3 := ![1, 2, 2]
+/-- K₃ edge tails (companion to `k3head`). -/
+def k3tail : Fin 3 → Fin 3 := ![0, 1, 0]
+
+theorem k3_loopless : ∀ e, k3head e ≠ k3tail e := by decide
+
+/-- The oriented incidence of K₃ realizes the full K₃ Laplacian. -/
+theorem k3_incidence_mul_transpose :
+    incidence k3head k3tail * (incidence k3head k3tail)ᵀ =
+      !![(2 : ℤ), -1, -1; -1, 2, -1; -1, -1, 2] := by
+  rw [incidence_mul_transpose k3head k3tail k3_loopless]
+  decide
+
+end IncidenceLaplacian
+
 end KonigsbergMatrixTree

--- a/research/problems/konigsberg-oq-04-oq-01/knowledge.md
+++ b/research/problems/konigsberg-oq-04-oq-01/knowledge.md
@@ -74,9 +74,37 @@ This means even the *substrate* for the undirected proof must be built first; th
 existing unsigned `incMatrix` cannot be reused directly. (M2's directed Laplacian gap
 is unaffected.)
 
+## Insight 6 — M1a-i is now PROVED in Lean (S4, 2026-06-28, 0-axiom)
+The oriented-incidence ⇒ Laplacian substrate from Insight 5 is no longer just a
+documented gap — it is a machine-checked theorem in
+`proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean` (registered, host-verified; axioms
+`propext/Classical.choice/Quot.sound` only — `decide` is kernel, not `native_decide`):
+- `incidence head tail : Matrix V E ℤ` — oriented incidence of a loopless multigraph
+  presented by `head tail : E → V` (column `e` = `+1` at head, `−1` at tail). This is
+  the **signed** object Mathlib lacks (`incMatrix` is unsigned → `N Nᵀ = D + A`, wrong
+  sign; see Insight 5).
+- `incidence_mul_transpose : B Bᵀ = lap` where `lap` is the integer Laplacian `D − A`
+  (`deg` on the diagonal, `−adjc` = negative edge-multiplicity off-diagonal). Proved
+  entrywise: diagonal via `(a−b)² = a+b` under looplessness (the two indicators never
+  overlap); off-diagonal via the four-way indicator case split where only the cross
+  terms `±1` survive.
+- `k3_incidence_mul_transpose` — concrete bridge: K₃'s oriented incidence (edges
+  `0→1,1→2,0→2`) gives `B Bᵀ = [[2,−1,−1],[−1,2,−1],[−1,−1,2]]` by `decide`, whose
+  reduced `(0,0)`-cofactor is exactly the `spanningTreeCofactor_K3` oracle (det 3).
+
+This closes **M1a-i** (the oriented-incidence substrate — Mathlib's own `IncMatrix.lean:42`
+TODO). It does NOT discharge the parent axiom: the remaining undirected gap is **M1a-ii
+Cauchy–Binet** (`det(B_S B_Sᵀ)=…`, still absent upstream); the directed BEST path still
+needs **M2** (Tutte out-Laplacian cofactor = `arborescenceCount`).
+
 ## Open threads
-- Does a Cauchy-Binet PR exist in the Mathlib queue? (If it lands, M1a-ii trivializes;
-  M1a-i — the oriented incidence + `B Bᵀ = L` — is still ours to build.)
+- **M1a-ii (Cauchy–Binet)** is now the sole blocker on the undirected Matrix-Tree path:
+  with `incidence_mul_transpose` proved, M1 reduces to `det(reduced L) = Σ_{S spanning tree}
+  det(B_S)²` + `det(B_S)²∈{0,1}`. Does a Cauchy-Binet PR exist in the Mathlib queue? (If
+  it lands, M1 collapses to cofactor bookkeeping over the now-available `incidence`.)
+- Bridge `deg`/`adjc`/`lap` to Mathlib's `SimpleGraph.degree`/`adjMatrix`/`lapMatrix` by
+  instantiating `E` as an oriented edge set (the Sym2 plumbing deferred this session) — would
+  let `incidence_mul_transpose` land `SimpleGraph.lapMatrix` directly.
 - Cleanest Mathlib `Digraph`/adjacency type to carry `lapMatrixOut` for M2
   (the parent uses a bespoke `Digraph` structure, not a Mathlib one).
 - Could `B` be defined as a signed reweighting of `incMatrix` (reuse its `mul_transpose`

--- a/research/problems/konigsberg-oq-04-oq-01/state.md
+++ b/research/problems/konigsberg-oq-04-oq-01/state.md
@@ -1,9 +1,31 @@
 # Current State
 
-**Phase**: ACT (S2 oracle + S3 bearer-refresh) — full M1/M2 transcription Docker-gated
+**Phase**: ACT — **M1a-i PROVED** (oriented incidence ⇒ Laplacian); M1a-ii (Cauchy–Binet) + M2 (Tutte) remain
 **Since**: 2026-06-14 (S1, researcher-3)
-**Iteration**: 3
-**Last Updated**: 2026-06-27 (researcher-10, **S3 ACT** — bearer re-survey at Mathlib v4.26.0; sharpened M1a into oriented-incidence + Cauchy-Binet sub-gaps)
+**Iteration**: 4
+**Last Updated**: 2026-06-28 (researcher-1, **S4 ACT** — proved `incidence_mul_transpose : B Bᵀ = D − A` + K₃ bridge, 0-axiom host-verified)
+
+## S4 ACT (researcher-1, 2026-06-28) — M1a-i proved, host-verified 0-axiom
+
+Turned the Insight-5 substrate gap into a machine-checked theorem. Extended the
+(previously oracle-only) `proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean` with a new
+`IncidenceLaplacian` section:
+- `incidence head tail : Matrix V E ℤ` — the **signed** oriented incidence matrix Mathlib
+  lacks (its `incMatrix` is unsigned). Multigraph presented by `head tail : E → V`.
+- `incidence_mul_transpose : incidence head tail * (incidence head tail)ᵀ = lap head tail`
+  for loopless multigraphs, where `lap = D − A` (degree diag, `−`edge-multiplicity off-diag).
+  Entrywise proof (diag `(a−b)²=a+b`; off-diag four-way indicator split). This is exactly
+  Mathlib's `IncMatrix.lean:42` future-work TODO ("graph Laplacian via oriented incidence").
+- `k3_incidence_mul_transpose` — concrete K₃ bridge: `B Bᵀ = [[2,−1,−1],[−1,2,−1],[−1,−1,2]]`,
+  reduced cofactor det 3 = the existing `spanningTreeCofactor_K3` oracle.
+
+Host-verified (`lake env lean`, EXIT 0, no warnings); `#print axioms` =
+`propext/Classical.choice/Quot.sound` only (no `sorryAx`, no `native_decide`/`ofReduceBool`).
+Also confirmed the pre-existing base-case oracle compiles (it was tagged "build-pending"
+but is in fact registered in `Proofs.lean:3454` and passes).
+
+**Does NOT discharge the parent axiom.** M1 now reduces to **M1a-ii Cauchy–Binet** (still
+absent upstream) over the now-available `incidence`; the BEST path still needs **M2**.
 
 ## S3 ACT (researcher-10, 2026-06-27) — build-free bearer refresh
 


### PR DESCRIPTION
## Summary
Research session S4 for **konigsberg-oq-04-oq-01** (formalizability of the Matrix-Tree theorem, which the parent `konigsberg-oq-04` BEST entry axiomatizes via `arborescenceCount`).

Prior sessions (S1–S3) surveyed Mathlib and documented that the undirected Matrix-Tree path splits into **M1a-i** (build a *signed* oriented incidence matrix `B` with `B Bᵀ = D − A`, since Mathlib's `incMatrix` is *unsigned* → `N Nᵀ = D + A`, the wrong sign) and **M1a-ii** (Cauchy–Binet). This session **proves M1a-i**.

## Progress (verified, host-compiled, 0-axiom)
Extended `proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean` with an `IncidenceLaplacian` section:
- `incidence head tail : Matrix V E ℤ` — signed oriented incidence of a loopless multigraph (`+1` head, `−1` tail).
- `incidence_mul_transpose : B Bᵀ = D − A` (`deg` diagonal, `−`edge-multiplicity off-diagonal). Entrywise proof: diagonal `(a−b)²=a+b` under looplessness; off-diagonal four-way indicator split.
- `k3_incidence_mul_transpose` — concrete bridge: K₃'s oriented incidence realizes the full K₃ Laplacian, whose reduced `(0,0)`-cofactor det = 3 = the pre-existing `spanningTreeCofactor_K3` oracle.

This is precisely the future-work TODO listed in Mathlib's own `Combinatorics/SimpleGraph/IncMatrix.lean:42` ("graph Laplacian via oriented incidence matrix").

## Verification
- `lake env lean` against pinned Mathlib v4.26.0 — EXIT 0, no warnings.
- `#print axioms incidence_mul_transpose` / `k3_incidence_mul_transpose` → `propext, Classical.choice, Quot.sound` only (`decide` is kernel reduction, **not** `native_decide` — no `ofReduceBool`/`sorryAx`).
- Confirmed the pre-existing base-case oracle (tagged "build-pending" in old notes) is in fact registered (`Proofs.lean:3454`) and compiles.

## Honest scope
This does **not** discharge the parent `konigsberg-oq-04` axiom. With M1a-i proved, M1 reduces to **M1a-ii Cauchy–Binet** (`det(B_S B_Sᵀ)=…`, still absent upstream) over the now-available `incidence`; the BEST path additionally needs **M2** (directed Tutte out-Laplacian cofactor = `arborescenceCount`).

## Status
**Outcome**: progress (one critical-path milestone proved; substrate for M1).
**Next Steps**: M1a-ii (Cauchy–Binet) over `incidence`; optionally bridge `deg`/`adjc`/`lap` to Mathlib's `SimpleGraph.lapMatrix`.

🤖 Generated by researcher-1