### PR TITLE
research(erdos-10-wip-01-oq-01): bounded-offset certification — 906 needs exactly 3 powers of 2 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1465,6 +1465,7 @@ import Proofs.Erdos10OQ02Popcount
 import Proofs.Erdos10PrimePlusPowers
 import Proofs.Erdos10Problem
 import Proofs.Erdos10WIP01
+import Proofs.Erdos10WIP01OQ01
 import Proofs.Erdos1100Incomplete01
 import Proofs.Erdos1100OQ01Aristotle
 import Proofs.Erdos1100Problem

--- a/proofs/Proofs/Erdos10WIP01OQ01.lean
+++ b/proofs/Proofs/Erdos10WIP01OQ01.lean
@@ -1,0 +1,203 @@
+import Proofs.Erdos10WIP01
+
+/-
+# Erdős #10 — WIP-01 / OQ-01: bounded-offset certification of Granville–Soundararajan witnesses
+
+## Context (parent Erdős Problem #10: sums of a prime and powers of 2)
+
+`Erdos10WIP01` proved the characterization
+
+> `IsPrimePlusKPowers k n ↔ ∃ p prime, p ≤ n ∧ popcount (n − p) ≤ k`     (`isPrimePlusKPowers_iff_popcount`)
+
+which still phrases membership as a search over **all primes `p ≤ n`** — an `O(n / log n)`
+sweep, far out of kernel reach for the 10-digit Granville–Soundararajan witnesses.
+
+This file supplies the dual, **bounded** form. Substituting `m = n − p` turns the prime sweep
+into a search over **offsets**:
+
+> `IsPrimePlusKPowers k n ↔ ∃ m ≤ n, popcount m ≤ k ∧ (n − m) prime`     (`isPrimePlusKPowers_iff_offset`)
+
+The offsets with `popcount m ≤ k` number only `∑_{j≤k} C(⌊log₂ n⌋+1, j) = O((log n)^k)` — a few
+thousand for `k = 3, n ≈ 2³⁰`, versus tens of millions of primes. **This is the reformulation that
+makes a witness checkable at all without enumerating primes.**
+
+## Concrete certification (no `native_decide`)
+
+We then *use* the bounded form to settle the smallest concrete witness of the Granville–
+Soundararajan phenomenon, the smallest even integer that genuinely needs three powers of two:
+
+> **`906` is a prime plus three powers of two, but not a prime plus at most two.**
+> (`need_exactly_three_906`)
+
+`906 = 887 + 2⁰ + 2¹ + 2⁴` gives the upper witness. For the lower bound, the bounded form
+collapses `¬ IsPrimePlusKPowers 2 906` to the finite statement "no offset `2^a` or `2^a + 2^b`
+(`a, b < 10`, since `2¹⁰ = 1024 > 906`) makes `906 − offset` prime" — `56` candidates, all
+composite — which the **kernel** decides (`decide`, not `native_decide`): the result is genuinely
+`0`-axiom (`propext / Quot.sound / Classical.choice` only, no `Lean.ofReduceBool`).
+
+The 10-digit witness `1117175146` is the same shape with `~4500` offsets; the kernel primality
+checks there are individually feasible but the aggregate is heavy, and the honest route to it is a
+covering-congruence certificate (a fixed finite set of primes dividing `n − 2^a − 2^b − 2^c` for
+every exponent triple). See the closing assessment.
+
+Tags: number-theory, primes, powers-of-two, binary, popcount, additive-combinatorics, erdos
+-/
+
+namespace Erdos10WIP01OQ01
+
+open Erdos10OQ02 Erdos10WIP01
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: THE BOUNDED-OFFSET REFORMULATION
+
+Substitute `m = n − p`: searching primes `p ≤ n` ⟺ searching offsets `m ≤ n`.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- **Bounded-offset form of the Erdős #10 predicate.** `n` is a prime plus at most `k` powers of
+    two iff some offset `m ≤ n` of binary popcount `≤ k` has `n − m` prime.
+
+    This is `isPrimePlusKPowers_iff_popcount` after the involution `p ↦ n − p`: the unbounded prime
+    sweep becomes a search over the `O((log n)^k)` offsets with `popcount ≤ k`. It is the form a
+    witness certificate actually consumes — only finitely many `m` need be inspected. -/
+theorem isPrimePlusKPowers_iff_offset (k n : ℕ) :
+    IsPrimePlusKPowers k n ↔ ∃ m, m ≤ n ∧ popcount m ≤ k ∧ (n - m).Prime := by
+  rw [isPrimePlusKPowers_iff_popcount]
+  constructor
+  · rintro ⟨p, hp, hpn, hpc⟩
+    exact ⟨n - p, Nat.sub_le _ _, hpc, by rwa [Nat.sub_sub_self hpn]⟩
+  · rintro ⟨m, hmn, hmc, hp⟩
+    exact ⟨n - m, hp, Nat.sub_le _ _, by rwa [Nat.sub_sub_self hmn]⟩
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: STRUCTURE OF `≤ 2`-POWER OFFSETS
+
+A sum of at most two powers of two is `0`, a single power, or a pair — read straight off the
+exponent multiset (card `≤ 2`). Exponents are bounded by the value.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- A sum of **at most two** powers of two is `0`, a single power `2^a`, or `2^a + 2^b`.
+    Direct from the exponent multiset `s` (`s.card ≤ 2`): split on `card ∈ {0, 1, 2}`. -/
+theorem repWithAtMost_two_shape {m : ℕ} (h : RepWithAtMost 2 m) :
+    m = 0 ∨ (∃ a, m = 2 ^ a) ∨ (∃ a b, m = 2 ^ a + 2 ^ b) := by
+  obtain ⟨s, hcard, hsum⟩ := h
+  subst hsum
+  interval_cases hc : s.card
+  · -- card 0
+    rw [Multiset.card_eq_zero] at hc; subst hc; simp
+  · -- card 1
+    obtain ⟨a, rfl⟩ := Multiset.card_eq_one.mp hc
+    refine Or.inr (Or.inl ⟨a, ?_⟩); simp [powSum]
+  · -- card 2
+    obtain ⟨a, b, rfl⟩ := Multiset.card_eq_two.mp hc
+    refine Or.inr (Or.inr ⟨a, b, ?_⟩)
+    simp [powSum, Multiset.insert_eq_cons]
+
+/-- If `2 ^ a ≤ 906` then `a < 10` (as `2¹⁰ = 1024 > 906`). -/
+theorem exp_lt_ten {a : ℕ} (h : 2 ^ a ≤ 906) : a < 10 := by
+  by_contra hge
+  push_neg at hge
+  have : (2 : ℕ) ^ 10 ≤ 2 ^ a := Nat.pow_le_pow_right (by norm_num) hge
+  norm_num at this
+  omega
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: CERTIFYING THE WITNESS `906` WITHOUT `native_decide`
+
+`906` is the smallest even integer needing three powers of two.
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- The finite, kernel-decidable search underlying `¬ IsPrimePlusKPowers 2 906`: `906` itself,
+    or some `906 − 2^a` (`a < 10`), or some `906 − 2^a − 2^b` (`a, b < 10`), is prime. All `56`
+    candidates are composite, so this is `False` — by the **kernel** `decide`, not `native_decide`. -/
+def search906 : Prop :=
+  (906 : ℕ).Prime ∨
+    (∃ a : Fin 10, ((906 - 2 ^ (a : ℕ)) : ℕ).Prime) ∨
+    (∃ a b : Fin 10, ((906 - 2 ^ (a : ℕ) - 2 ^ (b : ℕ)) : ℕ).Prime)
+
+/-- Membership of `906` in `prime + ≤ 2 powers` would force one of the finitely many bounded
+    offsets to land on a prime. -/
+theorem isPrimePlus2_906_imp_search (h : IsPrimePlusKPowers 2 906) : search906 := by
+  obtain ⟨p, hp, m, hm, hnm⟩ := h            -- 906 = p + m, p prime, RepWithAtMost 2 m
+  have hm906 : m ≤ 906 := by omega
+  rcases repWithAtMost_two_shape hm with h0 | ⟨a, ha⟩ | ⟨a, b, hab⟩
+  · -- m = 0 ⇒ 906 = p prime
+    refine Or.inl ?_
+    have : p = 906 := by omega
+    rwa [this] at hp
+  · -- m = 2^a ⇒ 906 − 2^a = p prime, a < 10
+    refine Or.inr (Or.inl ⟨⟨a, exp_lt_ten (ha ▸ hm906)⟩, ?_⟩)
+    have hpe : (906 : ℕ) - 2 ^ a = p := by omega
+    simpa [hpe] using hp
+  · -- m = 2^a + 2^b ⇒ 906 − 2^a − 2^b = p prime, a,b < 10
+    have hmle : 2 ^ a + 2 ^ b ≤ 906 := hab ▸ hm906
+    have h2a : 2 ^ a ≤ 906 := le_trans (Nat.le_add_right _ _) hmle
+    have h2b : 2 ^ b ≤ 906 := le_trans (Nat.le_add_left _ _) hmle
+    refine Or.inr (Or.inr ⟨⟨a, exp_lt_ten h2a⟩, ⟨b, exp_lt_ten h2b⟩, ?_⟩)
+    have hpe : (906 : ℕ) - 2 ^ a - 2 ^ b = p := by omega
+    simpa [hpe] using hp
+
+set_option maxRecDepth 100000 in
+/-- **Lower bound.** `906` is *not* a prime plus at most two powers of two.
+    The bounded search `search906` is refuted by the kernel `decide` (all `56` offsets composite);
+    `isPrimePlus2_906_imp_search` then closes the contrapositive. No `native_decide`. -/
+theorem not_isPrimePlusKPowers_two_906 : ¬ IsPrimePlusKPowers 2 906 := by
+  have hsearch : ¬ search906 := by
+    unfold search906
+    decide
+  exact fun h => hsearch (isPrimePlus2_906_imp_search h)
+
+/-- **Upper witness.** `906 = 887 + 2⁰ + 2¹ + 2⁴` is a prime plus three powers of two. -/
+theorem isPrimePlusKPowers_three_906 : IsPrimePlusKPowers 3 906 := by
+  refine ⟨887, by norm_num, 19, ⟨{0, 1, 4}, by decide, by decide⟩, by norm_num⟩
+
+/-- **`906` is a Granville–Soundararajan witness needing exactly three powers of two**: a prime
+    plus three powers of two, but not a prime plus at most two. Fully certified, `0`-axiom, with no
+    `native_decide` — the smallest even integer exhibiting the Erdős #10 "three powers" phenomenon. -/
+theorem need_exactly_three_906 :
+    IsPrimePlusKPowers 3 906 ∧ ¬ IsPrimePlusKPowers 2 906 :=
+  ⟨isPrimePlusKPowers_three_906, not_isPrimePlusKPowers_two_906⟩
+
+#check @isPrimePlusKPowers_iff_offset
+#check @need_exactly_three_906
+
+end Erdos10WIP01OQ01
+
+/-
+## Summary
+
+- `isPrimePlusKPowers_iff_offset`: the **bounded-offset reformulation** of the Erdős #10 predicate
+  — `IsPrimePlusKPowers k n ↔ ∃ m ≤ n, popcount m ≤ k ∧ (n − m) prime`. Converts the unbounded
+  "search all primes `p ≤ n`" of `isPrimePlusKPowers_iff_popcount` into a search over the
+  `O((log n)^k)` offsets of popcount `≤ k`. This is what makes any concrete witness checkable.
+- `repWithAtMost_two_shape`: a `≤ 2`-power sum is `0`, `2^a`, or `2^a + 2^b` (exponent multiset of
+  card `≤ 2`); `exp_lt_ten` bounds the exponents from the value.
+- `need_exactly_three_906`: **`906` needs exactly three powers of two** (`= 887 + 1 + 2 + 16`, and
+  not a prime plus `≤ 2`). The lower bound runs the bounded search `search906` through the **kernel**
+  `decide` over its `56` composite offsets — `0`-axiom, **no `native_decide`** (no `Lean.ofReduceBool`).
+
+## Infrastructure assessment: the 10-digit witness `1117175146`
+
+**Needed**: `¬ IsPrimePlusKPowers 3 1117175146`. Via `isPrimePlusKPowers_iff_offset` this is the finite
+claim "`1117175146 − m` is composite for every `m` with `popcount m ≤ 3`" — `≈ 4526` offsets
+(`m = 0, 2^a, 2^a+2^b, 2^a+2^b+2^c`, exponents `< 31` since `2³¹ > 1117175146`).
+
+**Size estimate / decision**: BUILD (offset reduction) done here; the *aggregate* compositeness check
+is the remaining work. Two honest routes, both substantial:
+- **Kernel `decide`**: each `Nat.Prime` test on a 10-digit number is kernel-feasible, but `~4526` of
+  them in one `decide` is heavy (minutes–hours, large memory) — and any `native_decide` shortcut would
+  forfeit the `0`-axiom status (it pulls in `Lean.ofReduceBool`).
+- **Covering certificate** (the mathematically faithful route): a fixed finite prime set
+  `{3, 5, 7, 13, 17, 241, …}` such that some member divides `1117175146 − 2^a − 2^b − 2^c` for *every*
+  exponent triple (a covering system on the exponents mod `lcm` of the orders of `2`). This replaces
+  `4526` primality tests by a finite residue computation, but formalizing the covering system is a
+  multi-session build. `need_exactly_three_906` is the same statement at a scale where the kernel can
+  close it directly — the working template for the covering build.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/erdos-10-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-01/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-offset-reformulation",
+    "proofId": "erdos-10-wip-01-oq-01",
+    "range": {
+      "startLine": 52,
+      "endLine": 78
+    },
+    "type": "insight",
+    "title": "Search Offsets, Not Primes",
+    "content": "isPrimePlusKPowers_iff_offset is the structural pivot of the file. The parent's isPrimePlusKPowers_iff_popcount phrases membership as 'some prime p ≤ n has popcount(n−p) ≤ k' — correct, but it ranges over all O(n/log n) primes below n. Substituting m = n − p (a self-inverse bijection on [0,n], since p ≤ n, justified by Nat.sub_sub_self) re-indexes the same search by the OFFSET m: now the condition is 'some m ≤ n with popcount m ≤ k has (n − m) prime'. Crucially the offsets with popcount ≤ k number only ∑_{j≤k} C(⌊log₂ n⌋+1, j) = O((log n)^k) — a few thousand at 10 digits, versus tens of millions of primes. The two directions of the iff are symmetric: forward sends p to m = n−p; backward sends m to p = n−m, with popcount and primality transported across the involution.",
+    "mathContext": "$\\mathrm{IsPrimePlusKPowers}\\,k\\,n \\iff \\exists m \\le n,\\ \\mathrm{popcount}\\,m \\le k \\wedge (n-m)\\ \\text{prime}$.",
+    "significance": "key",
+    "relatedConcepts": ["change of variable", "involution n − ·", "popcount", "bounded search", "Erdős–Graham problem"],
+    "prerequisites": ["isPrimePlusKPowers_iff_popcount (parent Erdos10WIP01)", "Nat.sub_sub_self", "binary popcount"]
+  },
+  {
+    "id": "ann-offset-shape",
+    "proofId": "erdos-10-wip-01-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 111
+    },
+    "type": "concept",
+    "title": "The Shape of a ≤2-Power Offset",
+    "content": "repWithAtMost_two_shape pins down exactly which offsets matter when k = 2: a sum of at most two powers of two is 0, a single power 2^a, or a pair 2^a + 2^b. The proof reads this straight off the exponent multiset s with s.card ≤ 2 — split on card ∈ {0,1,2} via Multiset.card_eq_zero / _one / _two and evaluate powSum on each shape, with no binary-representation API. exp_lt_ten supplies the second half of the finiteness: any power actually used satisfies 2^a ≤ 906, and since 2¹⁰ = 1024 > 906 (Nat.pow_le_pow_right), the exponent is below 10. Together these turn the offset search into a finite disjunction over Fin 10–indexed exponents.",
+    "mathContext": "$\\mathrm{RepWithAtMost}\\,2\\,m \\Rightarrow m \\in \\{0\\} \\cup \\{2^a\\} \\cup \\{2^a + 2^b\\}$, with $2^a \\le 906 \\Rightarrow a < 10$.",
+    "significance": "supporting",
+    "relatedConcepts": ["multiset cardinality", "exponent bounds", "finite enumeration", "powers of two"],
+    "prerequisites": ["Multiset.card_eq_two", "Nat.pow_le_pow_right", "the powSum definition"]
+  },
+  {
+    "id": "ann-certify-906",
+    "proofId": "erdos-10-wip-01-oq-01",
+    "range": {
+      "startLine": 112,
+      "endLine": 170
+    },
+    "type": "insight",
+    "title": "906 Needs Exactly Three Powers — by the Kernel, Not native_decide",
+    "content": "need_exactly_three_906 settles the smallest even integer genuinely needing three powers of two. The upper witness isPrimePlusKPowers_three_906 is immediate: 906 = 887 + 2⁰ + 2¹ + 2⁴ with 887 prime and 19 = powSum {0,1,4}. The lower bound not_isPrimePlusKPowers_two_906 is the substantive half: isPrimePlus2_906_imp_search threads a hypothetical 906 = p + m through repWithAtMost_two_shape, drops the (bounded) exponents into Fin 10, and lands in the decidable disjunction search906 — '906, or some 906−2^a, or some 906−2^a−2^b is prime' over the 56 offsets with popcount ≤ 2. All 56 values are composite, so `decide` refutes search906 and the contrapositive gives ¬IsPrimePlusKPowers 2 906. The certificate is closed by the KERNEL `decide` (with maxRecDepth 100000), not native_decide: `#print axioms` lists only propext / Classical.choice / Quot.sound, with no Lean.ofReduceBool — genuinely 0-axiom. The 10-digit witness 1117175146 is the same shape with ~4526 offsets; 906 is its working template, and the faithful scaling route is a covering-congruence certificate.",
+    "mathContext": "$\\mathrm{IsPrimePlusKPowers}\\,3\\,906 \\wedge \\neg\\,\\mathrm{IsPrimePlusKPowers}\\,2\\,906$; lower bound = 56 composite offsets, kernel-decided.",
+    "significance": "key",
+    "relatedConcepts": ["Granville–Soundararajan witness", "decide vs native_decide", "0-axiom certification", "covering congruences", "Erdős #10"],
+    "prerequisites": ["isPrimePlusKPowers_iff_offset", "repWithAtMost_two_shape", "kernel decidability of Nat.Prime"]
+  }
+]

--- a/src/data/proofs/erdos-10-wip-01-oq-01/index.ts
+++ b/src/data/proofs/erdos-10-wip-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos10WIP01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos10Wip01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos10Wip01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos10Wip01Oq01Data: ProofData = {
+  proof: erdos10Wip01Oq01Proof,
+  annotations: erdos10Wip01Oq01Annotations,
+}

--- a/src/data/proofs/erdos-10-wip-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-01/meta.json
@@ -1,0 +1,199 @@
+{
+  "id": "erdos-10-wip-01-oq-01",
+  "title": "Erdős #10: Bounded-Offset Certification — 906 Needs Exactly Three Powers of Two",
+  "slug": "erdos-10-wip-01-oq-01",
+  "description": "Answers the open question left by erdos-10-wip-01: certify a Granville–Soundararajan witness without native_decide. The key is the bounded-offset reformulation isPrimePlusKPowers_iff_offset — substituting m = n−p turns the prime-plus-popcount characterization's unbounded 'search all primes p ≤ n' into a search over the O((log n)^k) offsets m ≤ n with popcount m ≤ k. Applied to the smallest even integer that genuinely needs three powers of two, it gives need_exactly_three_906: 906 = 887 + 2⁰ + 2¹ + 2⁴ is a prime plus three powers, but not a prime plus at most two — the lower bound being the finite '56 offsets, all composite' claim discharged by the kernel `decide` (not native_decide). Genuinely 0-axiom (propext / Classical.choice / Quot.sound only; no Lean.ofReduceBool). Builds on the verified Erdos10WIP01 thread.",
+  "meta": {
+    "author": "Erdős & Graham (problem); Granville–Soundararajan (k=3 conjecture); formalized in Lean 4",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos10WIP01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "powers-of-two",
+      "binary",
+      "popcount",
+      "additive-combinatorics",
+      "erdos-problem"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 203,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, no `native_decide`. `#print axioms need_exactly_three_906` (and `isPrimePlusKPowers_iff_offset`, `not_isPrimePlusKPowers_two_906`) reports only the ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted under the project's axiom-integrity policy. The lower-bound search is closed by the *kernel* `decide` (with `set_option maxRecDepth 100000`), NOT `native_decide`, so the result does not depend on `Lean.ofReduceBool`. Imports the verified Erdos10WIP01 file and reuses isPrimePlusKPowers_iff_popcount, RepWithAtMost, powSum, IsPrimePlusKPowers; all new results are fully machine-checked.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Multiset.card_eq_two",
+        "description": "s.card = 2 ↔ ∃ x y, s = {x, y} — reads the two exponents off a ≤2-power offset multiset",
+        "module": "Mathlib.Data.Multiset.Basic"
+      },
+      {
+        "theorem": "Nat.sub_sub_self",
+        "description": "m ≤ n → n − (n − m) = m — the involution behind the offset reformulation",
+        "module": "Mathlib.Algebra.Order.Sub.Basic"
+      },
+      {
+        "theorem": "Nat.Prime (norm_num / Decidable)",
+        "description": "Kernel-checked primality of the offset values; the bounded search is decided by `decide`",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "dateAdded": "2026-06-28",
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "parentDependencies": [
+      "Erdos10WIP01"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #10 asks whether some fixed k makes every sufficiently large integer a prime plus at most k powers of 2 — Erdős and Graham conjectured no such k exists. Granville–Soundararajan (1998) conjectured k = 3 suffices for odd integers; the companion even part allows 4. The numerical evidence rests on deciding the predicate IsPrimePlusKPowers k n on concrete inputs: the smallest even integer that genuinely needs three powers of two is 906, and Grechuk found the 10-digit 1117175146 is not a prime plus at most three powers.\n\nThe parent file erdos-10-wip-01 phrased the predicate as 'IsPrimePlusKPowers k n ↔ ∃ prime p ≤ n with popcount(n−p) ≤ k' — an O(log) check *per prime*, but still a sweep over all O(n/log n) primes below n, hopeless for the kernel at 10 digits and left as an explicit open question (certify a witness without native_decide). This file removes the obstruction by dualizing the search.",
+    "problemStatement": "Open question from erdos-10-wip-01: use the prime-plus-popcount characterization with a verified (kernel) primality check to certify a concrete Granville–Soundararajan witness without `native_decide`. This file supplies the bounded-offset reformulation that makes such a certificate finite, and discharges the smallest even three-powers witness, 906, end to end.",
+    "text": "A 203-line, fully verified (0 sorries, 0 axioms, no native_decide) file. Part I proves isPrimePlusKPowers_iff_offset: the involution p ↦ n−p turns the prime sweep into a search over offsets m ≤ n with popcount m ≤ k (only O((log n)^k) of them). Part II reads the shape of ≤2-power offsets off their exponent multiset (repWithAtMost_two_shape: 0, 2^a, or 2^a+2^b) and bounds the exponents from the value (exp_lt_ten). Part III certifies 906: the upper witness 906 = 887 + 2⁰ + 2¹ + 2⁴, and the lower bound ¬IsPrimePlusKPowers 2 906 by reducing to the finite kernel-decidable search search906 over the 56 offsets (all composite).",
+    "proofStrategy": "isPrimePlusKPowers_iff_offset rewrites with the parent's isPrimePlusKPowers_iff_popcount and applies Nat.sub_sub_self in both directions (m = n − p forward, p = n − m backward), with popcount(n − p) = popcount m and (n − m) = p prime. repWithAtMost_two_shape splits on s.card ∈ {0,1,2} (Multiset.card_eq_{zero,one,two}) and evaluates powSum on each. exp_lt_ten derives a < 10 from 2^a ≤ 906 via Nat.pow_le_pow_right and 2¹⁰ = 1024 > 906. isPrimePlus2_906_imp_search threads a hypothetical representation 906 = p + m through the shape lemma, places the (bounded) exponents into Fin 10, and lands in the decidable disjunction search906; not_isPrimePlusKPowers_two_906 refutes search906 by the kernel `decide` and takes the contrapositive. The upper witness is a direct ⟨887, prime, 19 = powSum {0,1,4}, …⟩.",
+    "keyInsights": [
+      "Dualize the search: substituting m = n − p (an involution on [0,n], since p ≤ n) turns 'search all primes p ≤ n' into 'search all offsets m ≤ n with popcount m ≤ k'. The offsets number only ∑_{j≤k} C(⌊log₂ n⌋+1, j) = O((log n)^k) — a few thousand at 10 digits versus tens of millions of primes. This is what makes any concrete witness checkable without enumerating primes.",
+      "A sum of at most two powers of two is exactly 0, 2^a, or 2^a + 2^b — read straight off the exponent multiset of cardinality ≤ 2, with no binary-representation API.",
+      "Once the offset exponents are bounded by the value (2^a ≤ n ⟹ a < ⌈log₂ n⌉), the predicate becomes a finite disjunction over Fin-indexed exponents whose only atoms are primality tests on small numbers — decidable by the kernel.",
+      "906 needs exactly three powers: 906 = 887 + 1 + 2 + 16, while every one of the 56 offsets with popcount ≤ 2 leaves 906 − offset composite. The lower bound is closed by the *kernel* `decide` (maxRecDepth 100000), so the certificate is 0-axiom — no Lean.ofReduceBool, unlike native_decide.",
+      "The 10-digit witness 1117175146 is the identical shape with ~4526 offsets; 906 is the working template, and the honest scaling route is a covering-congruence certificate (a fixed finite prime set dividing n − 2^a − 2^b − 2^c for every exponent triple)."
+    ],
+    "prerequisites": [
+      "The Erdős #10 powers-of-two thread (erdos-10-wip-01: RepWithAtMost, powSum, isPrimePlusKPowers_iff_popcount)",
+      "Multisets and their cardinality in Lean 4/Mathlib",
+      "Kernel decidability of Nat.Prime and `decide` vs `native_decide`"
+    ]
+  },
+  "sections": [
+    {
+      "id": "offset-reformulation",
+      "title": "Part I: The Bounded-Offset Reformulation",
+      "startLine": 52,
+      "endLine": 78,
+      "summary": "isPrimePlusKPowers_iff_offset: IsPrimePlusKPowers k n ↔ ∃ m ≤ n, popcount m ≤ k ∧ (n − m) prime — the involution p ↦ n − m replaces the unbounded prime sweep with a search over O((log n)^k) offsets.",
+      "mathContext": "Nat.sub_sub_self makes m = n − p a self-inverse bijection on [0,n]; popcount and primality transport across it."
+    },
+    {
+      "id": "offset-structure",
+      "title": "Part II: Structure of ≤2-Power Offsets",
+      "startLine": 79,
+      "endLine": 111,
+      "summary": "repWithAtMost_two_shape: a ≤2-power sum is 0, 2^a, or 2^a + 2^b (card-≤2 exponent multiset). exp_lt_ten: 2^a ≤ 906 ⟹ a < 10.",
+      "mathContext": "Multiset.card_eq_{zero,one,two} enumerate the offset shapes; 2¹⁰ = 1024 > 906 bounds the exponents."
+    },
+    {
+      "id": "certify-906",
+      "title": "Part III: Certifying 906 Without native_decide",
+      "startLine": 112,
+      "endLine": 170,
+      "summary": "search906 (the 56-candidate kernel-decidable disjunction), isPrimePlus2_906_imp_search, not_isPrimePlusKPowers_two_906 (lower bound by kernel `decide`), isPrimePlusKPowers_three_906 (= 887 + 1 + 2 + 16), and need_exactly_three_906 combining them.",
+      "mathContext": "The smallest even integer needing three powers of two, certified 0-axiom; `decide` (not native_decide) refutes the finite offset search."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file closes the open question from erdos-10-wip-01 at the scale where the kernel can finish: the bounded-offset reformulation isPrimePlusKPowers_iff_offset replaces the unbounded prime sweep of the Erdős #10 predicate with a finite offset search, and need_exactly_three_906 certifies — 0-axiom, with the kernel `decide` rather than native_decide — that 906 is a prime plus three powers of two but not a prime plus at most two.",
+    "implications": "The reformulation is the missing structural step for any concrete Granville–Soundararajan witness: it bounds the search at O((log n)^k) offsets, finite and (for small n) kernel-decidable. 906 is the smallest even three-powers witness and the working template for the 10-digit 1117175146, whose ~4526 offsets push the aggregate kernel check into heavy territory and motivate a covering-congruence certificate as the faithful scaling route.",
+    "openQuestions": [
+      "Scale need_exactly_three_906 to Grechuk's 1117175146 via a covering-congruence certificate: a fixed finite prime set {3,5,7,13,17,241,…} such that some member divides 1117175146 − 2^a − 2^b − 2^c for every exponent triple, replacing ~4526 kernel primality tests by a finite residue computation.",
+      "Package isPrimePlusKPowers_iff_offset as a reusable Decidable instance for IsPrimePlusKPowers k n bounded by ⌈log₂ n⌉, so any small witness is settled by `decide` with no bespoke shape lemma."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-10-wip-01",
+      "relationship": "extends",
+      "description": "Parent: answers its open question (certify a witness without native_decide) by dualizing isPrimePlusKPowers_iff_popcount into a bounded offset search."
+    },
+    {
+      "targetId": "erdos-10-oq-02",
+      "relationship": "extends",
+      "description": "Builds on the reduction lemma and popcount decision procedure of the OQ-02 thread."
+    },
+    {
+      "targetId": "erdos-10",
+      "relationship": "extends",
+      "description": "Parent problem: Erdős #10, sums of a prime and powers of 2."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.Erdos10WIP01"
+    ],
+    "opens": [
+      "Erdos10OQ02",
+      "Erdos10WIP01"
+    ],
+    "namespace": "Erdos10WIP01OQ01",
+    "lineCount": 203,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "isPrimePlusKPowers_iff_offset",
+        "type": "core",
+        "description": "Bounded-offset reformulation: IsPrimePlusKPowers k n ↔ ∃ m ≤ n with popcount m ≤ k and (n − m) prime",
+        "leanType": "(k n : ℕ) → IsPrimePlusKPowers k n ↔ ∃ m, m ≤ n ∧ popcount m ≤ k ∧ (n - m).Prime"
+      },
+      {
+        "name": "need_exactly_three_906",
+        "type": "core",
+        "description": "906 is a prime plus three powers of two but not a prime plus at most two — certified 0-axiom, no native_decide",
+        "leanType": "IsPrimePlusKPowers 3 906 ∧ ¬ IsPrimePlusKPowers 2 906"
+      },
+      {
+        "name": "repWithAtMost_two_shape",
+        "type": "key",
+        "description": "A sum of at most two powers of two is 0, 2^a, or 2^a + 2^b",
+        "leanType": "RepWithAtMost 2 m → m = 0 ∨ (∃ a, m = 2 ^ a) ∨ (∃ a b, m = 2 ^ a + 2 ^ b)"
+      }
+    ],
+    "path": "Proofs/Erdos10WIP01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "isPrimePlusKPowers_iff_offset",
+      "type": "core",
+      "description": "Bounded-offset reformulation of the Erdős #10 predicate: search offsets, not primes",
+      "leanType": "(k n : ℕ) → IsPrimePlusKPowers k n ↔ ∃ m, m ≤ n ∧ popcount m ≤ k ∧ (n - m).Prime"
+    },
+    {
+      "name": "need_exactly_three_906",
+      "type": "core",
+      "description": "906 needs exactly three powers of two (= 887 + 1 + 2 + 16), certified without native_decide",
+      "leanType": "IsPrimePlusKPowers 3 906 ∧ ¬ IsPrimePlusKPowers 2 906"
+    },
+    {
+      "name": "repWithAtMost_two_shape",
+      "type": "key",
+      "description": "Shape of a ≤2-power offset: 0, 2^a, or 2^a + 2^b",
+      "leanType": "RepWithAtMost 2 m → m = 0 ∨ (∃ a, m = 2 ^ a) ∨ (∃ a b, m = 2 ^ a + 2 ^ b)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Granville, Andrew; Soundararajan, Kannan",
+      "title": "A binary additive problem of Erdős and the order of 2 mod p²",
+      "year": "1998",
+      "venue": "Ramanujan Journal 2, 283–298",
+      "note": "Conjectures k = 3 for odd integers; the concrete witness searches use the prime-plus-popcount predicate"
+    },
+    {
+      "authors": "Gallagher, Patrick X.",
+      "title": "Primes and powers of 2",
+      "year": "1975",
+      "venue": "Inventiones Mathematicae 29, 125–142",
+      "note": "Density of the representable set tends to 1"
+    },
+    {
+      "authors": "Erdős, Paul; Graham, Ronald",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "Monographies de L'Enseignement Mathématique 28",
+      "note": "The original 'prime plus k powers of 2' problem"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question left by **erdos-10-wip-01**: *certify a concrete Granville–Soundararajan witness without `native_decide`*.

The parent characterization `isPrimePlusKPowers_iff_popcount` phrased Erdős #10 membership as an **unbounded sweep over all primes `p ≤ n`**. The fix is to dualize the search.

### New results (`proofs/Proofs/Erdos10WIP01OQ01.lean`, 203 lines, 7 theorems, 1 def)

- **`isPrimePlusKPowers_iff_offset`** — the bounded-offset reformulation:
  > `IsPrimePlusKPowers k n ↔ ∃ m ≤ n, popcount m ≤ k ∧ (n − m).Prime`

  Substituting `m = n − p` (`Nat.sub_sub_self`, a self-inverse bijection on `[0,n]`) re-indexes the search by **offset**. Offsets with `popcount ≤ k` number only `O((log n)^k)` — finite and (for small `n`) kernel-decidable, with no prime sieve. This is what makes any concrete witness checkable.
- **`repWithAtMost_two_shape`** / **`exp_lt_ten`** — a `≤2`-power offset is `0`, `2^a`, or `2^a + 2^b`; exponents are bounded by the value (`2^a ≤ 906 ⟹ a < 10`).
- **`need_exactly_three_906`** — `906` is a prime plus three powers of two but **not** a prime plus at most two:
  - upper: `906 = 887 + 2⁰ + 2¹ + 2⁴` (887 prime, `19 = powSum {0,1,4}`);
  - lower: `¬IsPrimePlusKPowers 2 906` reduces to the finite disjunction `search906` over the **56** offsets with `popcount ≤ 2` (all composite), refuted by the **kernel** `decide` (`set_option maxRecDepth 100000`).

`906` is the smallest even integer that genuinely needs three powers of two.

## Axiom integrity

`#print axioms need_exactly_three_906` (and `isPrimePlusKPowers_iff_offset`, `not_isPrimePlusKPowers_two_906`) → **`[propext, Classical.choice, Quot.sound]` only**. No `Lean.ofReduceBool` (the lower bound uses kernel `decide`, **not** `native_decide`), no `sorryAx`. Genuinely **0-axiom / VERIFIED**.

- `status: verified`, `badge: verified`, `axiomCount: 0`, `sorries: 0`.
- Host-verified with `lake env lean` under pinned Mathlib **v4.26.0**.

## Scaling note

Grechuk's 10-digit witness `1117175146` is the identical shape with `~4526` offsets; `906` is the working template. The faithful scaling route is a **covering-congruence certificate** (a fixed finite prime set dividing `n − 2^a − 2^b − 2^c` for every exponent triple), replacing the aggregate kernel primality check — left as a documented follow-up.

## Files
- `proofs/Proofs/Erdos10WIP01OQ01.lean` (new), registered in `proofs/Proofs.lean`
- `src/data/proofs/erdos-10-wip-01-oq-01/` — `meta.json`, `annotations.json`, `index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)