### PR TITLE
research(erdos-728-factorial-divisibility-oq-04): integrate barrier file + prime-uniform sharpening [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2522,6 +2522,7 @@ import Proofs.Erdos725Problem
 import Proofs.Erdos726Problem
 import Proofs.Erdos727Problem
 import Proofs.Erdos728FactorialDivisibility
+import Proofs.Erdos728FactorialDivisibilityOQ04
 import Proofs.Erdos728Problem
 import Proofs.Erdos729LegendreGeneral
 import Proofs.Erdos729LegendrePrimeRecurrence

--- a/proofs/Proofs/Erdos728FactorialDivisibilityOQ04.lean
+++ b/proofs/Proofs/Erdos728FactorialDivisibilityOQ04.lean
@@ -88,14 +88,75 @@ theorem log_barrier_length {a b n : ℕ} (h : a ! * b ! ∣ n !) :
   have hb := digitsum_two_le_length b
   omega
 
+/-!
+## General-prime form of the barrier
+
+Erdős's argument uses only the prime `2` because Legendre's `(p−1)·v_p(m!) = m − s_p(m)`
+has the `(p−1)` factor equal to `1` there, so the valuation inequality reads off the
+digit-sum bound with no division.  But the *same* derivation goes through verbatim for
+**every** prime `p`: multiplying the valuation inequality `v_p(a!)+v_p(b!) ≤ v_p(n!)`
+by `(p−1)` and substituting Legendre gives
+
+  `(a − s_p a) + (b − s_p b) ≤ (n − s_p n)`,  i.e.  `a + b + s_p(n) ≤ n + s_p(a) + s_p(b)`.
+
+This is a strict sharpening of `log_barrier` in two ways: it adds the `+ s_p(n)` term on
+the small side (dropped in the classical statement), and it holds for an arbitrary prime,
+so one may take the prime giving the smallest right-hand side.  The prime `2` is the
+right choice for the *asymptotic* `O(log n)` bound because `s_2` is the slowest-growing
+digit sum, but the inequality itself is prime-uniform.
+-/
+
+/-- **Legendre's formula at a general prime `p`, additive `ℕ` form.**
+`m = (p − 1)·v_p(m!) + s_p(m)`, where `s_p m = (Nat.digits p m).sum`.  Rearranged from
+Mathlib's `sub_one_mul_padicValNat_factorial` to avoid truncated subtraction. -/
+theorem factorial_pval_add_digitsum (p m : ℕ) [Fact p.Prime] :
+    m = (p - 1) * padicValNat p (m !) + (Nat.digits p m).sum := by
+  have hleg := sub_one_mul_padicValNat_factorial (p := p) m
+  have hs : (Nat.digits p m).sum ≤ m := Nat.digit_sum_le p m
+  omega
+
+/-- **The logarithmic barrier at a general prime `p` (sharp form).**  If `a! · b! ∣ n!`
+then `a + b + s_p(n) ≤ n + s_p(a) + s_p(b)` for every prime `p`, where `s_p` is the
+base-`p` digit sum.  Only the single prime `p` is used.  Specializing to `p = 2` and
+dropping the `s_2(n)` term recovers `log_barrier`; keeping it gives a strictly stronger
+bound. -/
+theorem log_barrier_prime {a b n : ℕ} (p : ℕ) [Fact p.Prime] (h : a ! * b ! ∣ n !) :
+    a + b + (Nat.digits p n).sum ≤ n + (Nat.digits p a).sum + (Nat.digits p b).sum := by
+  have hmono : padicValNat p (a ! * b !) ≤ padicValNat p (n !) :=
+    (padicValNat_dvd_iff_le (Nat.factorial_ne_zero n)).mp
+      (dvd_trans (pow_padicValNat_dvd (p := p) (n := a ! * b !)) h)
+  rw [padicValNat.mul (Nat.factorial_ne_zero a) (Nat.factorial_ne_zero b)] at hmono
+  -- Scale the valuation inequality by `(p − 1)` so Legendre substitutes cleanly.
+  have hmul := Nat.mul_le_mul (le_refl (p - 1)) hmono
+  rw [Nat.mul_add] at hmul
+  have ha := factorial_pval_add_digitsum p a
+  have hb := factorial_pval_add_digitsum p b
+  have hn := factorial_pval_add_digitsum p n
+  -- omega atomizes the identical `(p−1)·v_p(·!)` subterms shared by hmul/ha/hb/hn.
+  omega
+
+/-- **The classical barrier is the `p = 2` specialization.**  Recovers `log_barrier`
+(`a + b ≤ n + s₂(a) + s₂(b)`) from the general-prime sharp form, discarding the
+`s₂(n)` slack. -/
+theorem log_barrier_of_prime {a b n : ℕ} (h : a ! * b ! ∣ n !) :
+    a + b ≤ n + (Nat.digits 2 a).sum + (Nat.digits 2 b).sum := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have := log_barrier_prime 2 h
+  omega
+
 #check @factorial_val_add_digitsum
+#check @factorial_pval_add_digitsum
 #check @log_barrier
+#check @log_barrier_prime
 #check @log_barrier_length
 
 -- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
 -- no sorryAx, no Lean.ofReduceBool.
 #print axioms factorial_val_add_digitsum
+#print axioms factorial_pval_add_digitsum
 #print axioms log_barrier
+#print axioms log_barrier_prime
+#print axioms log_barrier_of_prime
 #print axioms digitsum_two_le_length
 #print axioms log_barrier_length
 

--- a/research/problems/erdos-728-factorial-divisibility-oq-04/knowledge.md
+++ b/research/problems/erdos-728-factorial-divisibility-oq-04/knowledge.md
@@ -1,0 +1,41 @@
+# erdos-728-factorial-divisibility-oq-04 — knowledge
+
+## Problem
+"How do the #728 techniques extend to #729?" Concretely: formalize the elementary
+O(log n) barrier `a!·b! ∣ n! ⇒ a + b ≤ n + O(log n)` (the lower bound #728/#729
+surpass), in exact Legendre/popcount form.
+
+## Session 2026-06-28 (researcher-8) — SOLVED: integration + prime-uniform sharpening
+The Lean file `proofs/Proofs/Erdos728FactorialDivisibilityOQ04.lean` already existed
+(committed in PR #31101, 0-axiom/0-sorry, 4 theorems) but was **never integrated**:
+not in `Proofs.lean`, no gallery `meta.json`/`annotations.json`, no research json.
+
+This session:
+1. **Integrated** the file: added `import Proofs.Erdos728FactorialDivisibilityOQ04`
+   to the aggregator; created `src/data/proofs/erdos-728-factorial-divisibility-oq-04/
+   {meta,annotations}.json` and the research json. status=verified, badge=original.
+2. **Sharpened** the barrier to a prime-uniform form (3 new theorems):
+   - `factorial_pval_add_digitsum p m`: Legendre at general prime p,
+     `m = (p−1)·v_p(m!) + s_p(m)` (p=2 collapses to the existing p=2 lemma).
+   - `log_barrier_prime p`: `a!·b! ∣ n! ⇒ a + b + s_p(n) ≤ n + s_p(a) + s_p(b)` for
+     EVERY prime p. Strictly stronger than the classical statement: adds the +s_p(n)
+     term (dropped classically) AND holds for all primes (take the best p).
+   - `log_barrier_of_prime`: recovers the original `log_barrier` (p=2, drop s₂(n)).
+
+Now 7 theorems, 0 def, 0 axioms, 0 sorries. Host-verified exit 0; #print axioms →
+propext/Classical.choice/Quot.sound only.
+
+### Key technique / gotcha
+- For a VARIABLE prime p, the term `(p−1)·v_p(m!)` is nonlinear, but **omega
+  atomizes identical nonlinear subterms**. So: take `hmono : v_p(a!)+v_p(b!) ≤ v_p(n!)`,
+  scale by (p−1) via `Nat.mul_le_mul (le_refl (p-1)) hmono` then `rw [Nat.mul_add]`,
+  and feed ha/hb/hn (each containing the SAME `(p−1)·v_p(·!)` syntactic atom) to omega.
+- `Nat.digit_sum_le p m` and `sub_one_mul_padicValNat_factorial (p:=p) m` both work
+  for general prime p (need `[Fact p.Prime]`).
+
+## Still open (follow-ups, NOT done here)
+- Sharpness: infinite families achieving equality in log_barrier_prime at p=2
+  (central binomial / multinomial cases).
+- Multinomial barrier: a₁!·…·a_k! ∣ n! ⇒ ∑aᵢ + s_p(n) ≤ n + ∑s_p(aᵢ).
+- This is the barrier #728/#729 surpass; the actual #729 resolution (large-prime
+  carry analysis) is in `Erdos728FactorialDivisibility.lean`, not here.

--- a/src/data/proofs/erdos-728-factorial-divisibility-oq-04/annotations.json
+++ b/src/data/proofs/erdos-728-factorial-divisibility-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "erdos-728-factorial-divisibility-oq-04",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "concept",
+    "title": "The Elementary Barrier #728/#729 Surpass",
+    "content": "The classical baseline that Erdős #728 and #729 are built to break: if a!·b! ∣ n! then a + b ≤ n + O(log n). Erdős's proof needs only the prime 2. By Legendre's formula v₂(m!) = m − s₂(m) (with s₂ the binary digit sum), the divisibility forces v₂(a!) + v₂(b!) ≤ v₂(n!), i.e. (a − s₂a) + (b − s₂b) ≤ (n − s₂n), hence a + b ≤ n + s₂(a) + s₂(b), and each binary digit sum is O(log). This file formalizes that barrier exactly over ℕ — it is the lower bound the #728/#729 resolutions surpass, not a resolution of #729.",
+    "mathContext": "$a!\\,b! \\mid n! \\Rightarrow a+b \\le n + s_2(a) + s_2(b) \\le n + O(\\log n)$.",
+    "significance": "essential",
+    "relatedConcepts": ["Legendre's formula", "p-adic valuation", "binary digit sum", "Erdős #728", "Erdős #729"],
+    "prerequisites": ["factorial valuation", "base-2 expansion"]
+  },
+  {
+    "id": "ann-legendre-2",
+    "proofId": "erdos-728-factorial-divisibility-oq-04",
+    "range": { "startLine": 41, "endLine": 50 },
+    "type": "theorem",
+    "title": "Legendre's Formula at p = 2 (additive form)",
+    "content": "factorial_val_add_digitsum: every m splits as m = v₂(m!) + s₂(m). This is v₂(m!) = m − s₂(m) rearranged to avoid truncated subtraction, read off from Mathlib's sub_one_mul_padicValNat_factorial at p = 2 (where the (p−1) factor is 1). The bound s₂(m) ≤ m (Nat.digit_sum_le) lets omega close it.",
+    "mathContext": "$m = v_2(m!) + s_2(m)$, equivalently $v_2(m!) = m - s_2(m)$.",
+    "significance": "essential",
+    "relatedConcepts": ["Legendre's formula", "padicValNat", "digit sum"],
+    "prerequisites": ["sub_one_mul_padicValNat_factorial", "Nat.digit_sum_le"]
+  },
+  {
+    "id": "ann-log-barrier",
+    "proofId": "erdos-728-factorial-divisibility-oq-04",
+    "range": { "startLine": 53, "endLine": 68 },
+    "type": "theorem",
+    "title": "The Logarithmic Barrier (Legendre form)",
+    "content": "log_barrier: a!·b! ∣ n! ⇒ a + b ≤ n + s₂(a) + s₂(b). The divisibility gives v₂(a!) + v₂(b!) ≤ v₂(n!) (via padicValNat_dvd_iff_le on pow_padicValNat_dvd, then padicValNat.mul to split the product). Substituting Legendre's m = v₂(m!) + s₂(m) for a, b, n and clearing the valuations with omega yields the bound. Only the prime 2 is used — Erdős's original elementary argument.",
+    "mathContext": "$v_2(a!)+v_2(b!) \\le v_2(n!) \\Rightarrow a+b \\le n + s_2(a)+s_2(b)$.",
+    "significance": "essential",
+    "relatedConcepts": ["factorial divisibility", "p-adic valuation", "Legendre's formula"],
+    "prerequisites": ["factorial_val_add_digitsum", "padicValNat_dvd_iff_le", "padicValNat.mul"]
+  },
+  {
+    "id": "ann-log-barrier-length",
+    "proofId": "erdos-728-factorial-divisibility-oq-04",
+    "range": { "startLine": 70, "endLine": 89 },
+    "type": "theorem",
+    "title": "Explicit O(log) Form via Popcount ≤ Length",
+    "content": "digitsum_two_le_length bounds the binary digit sum by the binary length (each base-2 digit is ≤ 1, so the sum ≤ the number of digits, via List.sum_le_card_nsmul). log_barrier_length then gives a + b ≤ n + len₂(a) + len₂(b) with len₂(m) = ⌊log₂ m⌋ + 1 for m > 0 — the a + b ≤ n + O(log n) barrier in fully explicit form.",
+    "mathContext": "$s_2(m) \\le \\mathrm{len}_2(m)$, so $a+b \\le n + \\mathrm{len}_2(a) + \\mathrm{len}_2(b)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["popcount", "binary length", "logarithmic bound"],
+    "prerequisites": ["log_barrier", "List.sum_le_card_nsmul"]
+  },
+  {
+    "id": "ann-legendre-p",
+    "proofId": "erdos-728-factorial-divisibility-oq-04",
+    "range": { "startLine": 108, "endLine": 121 },
+    "type": "theorem",
+    "title": "Legendre at a General Prime p",
+    "content": "factorial_pval_add_digitsum: m = (p − 1)·v_p(m!) + s_p(m) for every prime p. This is the prime-uniform additive form of Legendre's formula; at p = 2 the (p−1) factor collapses to 1, recovering factorial_val_add_digitsum. The (p−1) factor is exactly why Erdős's argument is most elementary at p = 2.",
+    "mathContext": "$m = (p-1)\\,v_p(m!) + s_p(m)$, i.e. $v_p(m!) = \\dfrac{m - s_p(m)}{p-1}$.",
+    "significance": "essential",
+    "relatedConcepts": ["Legendre's formula", "general prime", "base-p digit sum"],
+    "prerequisites": ["sub_one_mul_padicValNat_factorial", "Nat.digit_sum_le"]
+  },
+  {
+    "id": "ann-log-barrier-prime",
+    "proofId": "erdos-728-factorial-divisibility-oq-04",
+    "range": { "startLine": 123, "endLine": 139 },
+    "type": "theorem",
+    "title": "Prime-Uniform Sharp Barrier",
+    "content": "log_barrier_prime: a!·b! ∣ n! ⇒ a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for EVERY prime p. Strictly stronger than the classical statement: it adds the s_p(n) term on the small side (dropped in log_barrier) and holds for an arbitrary prime, so one may take the prime minimizing the right-hand side. The valuation inequality v_p(a!) + v_p(b!) ≤ v_p(n!) is scaled by (p−1) (Nat.mul_le_mul + Nat.mul_add) and combined with Legendre via omega, which atomizes the shared (p−1)·v_p(·!) subterms. The prime 2 is optimal for the asymptotic O(log n) rate because s₂ grows slowest, but the inequality itself is prime-independent.",
+    "mathContext": "$\\forall p \\text{ prime}: a+b+s_p(n) \\le n + s_p(a) + s_p(b)$.",
+    "significance": "essential",
+    "relatedConcepts": ["prime-uniform bound", "sharpening", "Legendre's formula", "omega atomization"],
+    "prerequisites": ["factorial_pval_add_digitsum", "Nat.mul_le_mul"]
+  },
+  {
+    "id": "ann-log-barrier-of-prime",
+    "proofId": "erdos-728-factorial-divisibility-oq-04",
+    "range": { "startLine": 141, "endLine": 150 },
+    "type": "theorem",
+    "title": "Recovering the Classical Barrier (p = 2)",
+    "content": "log_barrier_of_prime: specializing the prime-uniform sharp form to p = 2 and discarding the s₂(n) slack recovers exactly log_barrier (a + b ≤ n + s₂(a) + s₂(b)). This makes the generalization precise — the classical barrier is the p = 2 corner of the prime-uniform family.",
+    "mathContext": "$p = 2$: drop $s_2(n) \\ge 0$ to get $a+b \\le n + s_2(a) + s_2(b)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization", "classical barrier"],
+    "prerequisites": ["log_barrier_prime"]
+  }
+]

--- a/src/data/proofs/erdos-728-factorial-divisibility-oq-04/meta.json
+++ b/src/data/proofs/erdos-728-factorial-divisibility-oq-04/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "erdos-728-factorial-divisibility-oq-04",
+  "slug": "erdos-728-factorial-divisibility-oq-04",
+  "title": "Erdős #728 → #729: the elementary logarithmic barrier (prime-uniform Legendre form)",
+  "overview": {
+    "text": "A verified formalization of the classical elementary barrier that Erdős #728 and #729 are built to surpass: if a!·b! ∣ n! then a + b ≤ n + O(log n). The proof needs only Legendre's formula for the p-adic valuation of a factorial. This file formalizes the barrier exactly over ℕ (0-sorry, 0-axiom) and sharpens it to a prime-uniform statement: the bound a + b + s_p(n) ≤ n + s_p(a) + s_p(b) holds for every prime p, not just p = 2.",
+    "historicalContext": "Erdős #728 (resolved affirmatively, January 2026, GPT-5.2 + Harmonic Aristotle; arXiv:2601.07421) and Erdős #729 (Barreto–Leeham, a modification of the same argument) both concern how far the near-divisibility of a!·b! into n! can push a + b beyond n. The classical baseline both results break beyond is Erdős's elementary bound a + b ≤ n + O(log n), whose proof uses only the prime 2: by Legendre's formula v₂(m!) = m − s₂(m), the divisibility forces (a − s₂a) + (b − s₂b) ≤ (n − s₂n), hence a + b ≤ n + s₂(a) + s₂(b), and each binary digit sum is O(log). This file is the verified starting point for the #729 generalization — the lower bound the resolution surpasses, in the same padicValNat/Legendre vocabulary the #728 file uses.",
+    "problemStatement": "How do the techniques of the #728 resolution extend to related problems like #729? Concretely: formalize the elementary O(log n) barrier a + b ≤ n + s₂(a) + s₂(b) (from a!·b! ∣ n!) that #728/#729 must defeat, in the exact Legendre/popcount form, and identify how prime-uniform it is.",
+    "proofStrategy": "Legendre's formula in additive ℕ form, m = (p−1)·v_p(m!) + s_p(m), read off from Mathlib's sub_one_mul_padicValNat_factorial. For p = 2 the (p−1) factor is 1, giving m = v₂(m!) + s₂(m) directly (factorial_val_add_digitsum). The divisibility a!·b! ∣ n! yields v_p(a!) + v_p(b!) ≤ v_p(n!) via padicValNat_dvd_iff_le and padicValNat.mul; scaling by (p−1) and substituting Legendre gives the barrier. omega discharges the final linear arithmetic (atomizing the shared (p−1)·v_p(·!) subterms). The digit-sum is bounded by the binary length via List.sum_le_card_nsmul to reach the explicit O(log) form.",
+    "keyInsights": [
+      "**Only the prime 2 is needed for O(log)** — Erdős's argument is elementary precisely because Legendre's (p−1)·v_p(m!) = m − s_p(m) has the (p−1) factor equal to 1 at p = 2, so the valuation inequality reads off the digit-sum bound with no division.",
+      "**The barrier is prime-uniform** — the same derivation holds verbatim for every prime p, giving a + b + s_p(n) ≤ n + s_p(a) + s_p(b). One may take the prime minimizing the right-hand side; p = 2 is optimal for the asymptotic O(log n) rate because s₂ is the slowest-growing digit sum.",
+      "**The +s_p(n) term is a free strengthening** — the classical statement drops s_p(n) from the small side; keeping it (log_barrier_prime) is strictly stronger than the textbook a + b ≤ n + s_p(a) + s_p(b).",
+      "**The barrier is what #728/#729 defeat** — both resolutions exhibit infinitely many triples violating a + b ≤ n + C log n once small primes are excluded; the large-prime carry analysis in the #728 file is the technique that surpasses this elementary lower bound.",
+      "**Binary digit sum = popcount = O(log)** — s₂(m) ≤ len₂(m) = ⌊log₂ m⌋ + 1, making the O(log n) rate fully explicit (log_barrier_length)."
+    ],
+    "prerequisites": [
+      "Legendre's formula for v_p(m!) (Mathlib: sub_one_mul_padicValNat_factorial)",
+      "p-adic valuation and divisibility (padicValNat_dvd_iff_le, padicValNat.mul)",
+      "base-p digit expansion and digit sums (Nat.digits, Nat.digit_sum_le)"
+    ],
+    "mainTheorems": [
+      "factorial_val_add_digitsum: m = v₂(m!) + s₂(m) (Legendre at p = 2, additive form)",
+      "factorial_pval_add_digitsum: m = (p−1)·v_p(m!) + s_p(m) (Legendre at general prime p)",
+      "log_barrier: a!·b! ∣ n! ⇒ a + b ≤ n + s₂(a) + s₂(b)",
+      "log_barrier_prime: a!·b! ∣ n! ⇒ a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for every prime p (sharp, prime-uniform)",
+      "log_barrier_length: a!·b! ∣ n! ⇒ a + b ≤ n + len₂(a) + len₂(b) (explicit O(log) form)"
+    ],
+    "references": [
+      "Erdős problem #728: https://www.erdosproblems.com/728",
+      "Erdős problem #729: https://www.erdosproblems.com/729",
+      "Resolution of #728 (GPT-5.2 + Harmonic Aristotle, Jan 2026): arXiv:2601.07421",
+      "Legendre, A.-M. *Théorie des nombres* (1830) — the formula v_p(m!) = (m − s_p(m))/(p − 1)."
+    ]
+  },
+  "description": "Verified (0-axiom, 0-sorry) formalization of the elementary logarithmic barrier underlying Erdős #728/#729: a!·b! ∣ n! ⇒ a + b ≤ n + O(log n), proved from Legendre's formula using only the prime 2. This research session integrates the file into the gallery (it was previously committed un-integrated: not in the aggregator, no gallery metadata) and adds a prime-uniform sharpening — log_barrier_prime: a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for every prime p — strictly stronger than the classical p = 2 statement, from which log_barrier is recovered. 7 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "conclusion": {
+    "summary": "Formalizes Erdős's elementary O(log n) barrier for factorial divisibility in exact Legendre/popcount form, and generalizes it to a prime-uniform bound holding for every prime p. All 7 theorems are machine-checked with only the foundational axioms (propext, Classical.choice, Quot.sound). This is foundational infrastructure — the lower bound that the #728/#729 resolutions surpass — not a resolution of #729 itself.",
+    "implications": "Provides a verified, reusable statement of the barrier in the same padicValNat/Legendre vocabulary used by the #728 resolution file, so future work on #729 (the large-prime carry analysis) can cite it directly. The prime-uniform form clarifies exactly why the prime 2 is the optimal elementary choice for the asymptotic rate while the inequality itself is prime-independent.",
+    "openQuestions": [
+      "Sharpness of the barrier: construct explicit infinite families of triples (a, b, n) with a!·b! ∣ n! achieving a + b = n + s₂(a) + s₂(b) − s₂(n) (equality in log_barrier_prime at p = 2), e.g. via the central binomial / multinomial cases, to show the popcount bound is attained.",
+      "Multi-factorial / multinomial barrier: extend to a₁!·…·a_k! ∣ n! ⇒ ∑ aᵢ + s_p(n) ≤ n + ∑ s_p(aᵢ), the natural generalization to multinomial coefficients, via the same Legendre argument."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-728-factorial-divisibility",
+      "relationship": "Parent. The resolved Erdős #728 (a + b can exceed n by Θ(log n) for factorial near-divisibility). This OQ-04 file formalizes the elementary barrier that #728 surpasses, in the same Legendre/padicValNat vocabulary."
+    }
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Nat"],
+    "namespace": "Erdos728FactorialDivisibilityOQ04",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos728FactorialDivisibilityOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "researcher-8",
+    "date": "2026",
+    "dateAdded": "2026-06-28",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/Erdos728FactorialDivisibilityOQ04.lean",
+    "erdosNumber": 728,
+    "erdosUrl": "https://www.erdosproblems.com/728",
+    "sourceUrl": "https://www.erdosproblems.com/728",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "erdos",
+      "factorial",
+      "p-adic",
+      "legendre-formula",
+      "digit-sum",
+      "research"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 163,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. All 7 theorems are machine-checked; #print axioms reports only propext, Classical.choice, Quot.sound (no sorryAx, no custom axioms, no Lean.ofReduceBool). This file proves the elementary barrier that Erdős #728/#729 surpass; it is not a resolution of #729.",
+    "mathlib_version": "4.26.0",
+    "relatedProblems": ["erdos-728-factorial-divisibility"],
+    "originalContributions": [
+      "factorial_val_add_digitsum: Legendre's formula at p = 2 in additive ℕ form m = v₂(m!) + s₂(m), avoiding truncated subtraction.",
+      "log_barrier: PROVEN formalization of Erdős's elementary barrier a!·b! ∣ n! ⇒ a + b ≤ n + s₂(a) + s₂(b) using only the prime 2.",
+      "digitsum_two_le_length / log_barrier_length: the explicit O(log) form a + b ≤ n + len₂(a) + len₂(b) via the popcount ≤ binary-length bound.",
+      "factorial_pval_add_digitsum (this session): Legendre at a general prime p, m = (p−1)·v_p(m!) + s_p(m).",
+      "log_barrier_prime (this session): PROVEN prime-uniform sharp barrier a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for every prime p — strictly stronger than the classical p = 2 statement (adds the s_p(n) term, holds for all primes).",
+      "log_barrier_of_prime (this session): recovers the classical log_barrier as the p = 2 specialization of the sharp prime-uniform form.",
+      "Gallery integration (this session): added the previously un-integrated file to Proofs.lean and created gallery metadata + annotations."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "sub_one_mul_padicValNat_factorial",
+        "description": "(p − 1) · v_p(m!) = m − s_p(m), Legendre's formula in Mathlib; the engine of both factorial_val_add_digitsum and factorial_pval_add_digitsum",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "padicValNat_dvd_iff_le",
+        "description": "p^k ∣ n ↔ k ≤ v_p(n) (n ≠ 0); turns the factorial divisibility into the valuation inequality",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "padicValNat.mul",
+        "description": "v_p(a·b) = v_p(a) + v_p(b) for a, b ≠ 0; splits v_p(a!·b!)",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.digit_sum_le",
+        "description": "(Nat.digits b m).sum ≤ m; bounds the digit sum for the Legendre rearrangement",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "List.sum_le_card_nsmul",
+        "description": "Sum of a list bounded by card times an upper bound on entries; gives popcount ≤ binary length",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.List"
+      }
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Header: the barrier and its role for #728/#729",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring framing the elementary O(log n) barrier a + b ≤ n + O(log n) as the baseline that Erdős #728/#729 surpass, derived from Legendre's formula at p = 2. Imports Mathlib; opens Nat.",
+      "mathContext": "$a!\\,b! \\mid n! \\Rightarrow a+b \\le n + O(\\log n)$, via $v_2(m!) = m - s_2(m)$."
+    },
+    {
+      "id": "legendre-2",
+      "title": "Legendre at p = 2 and the classical barrier",
+      "startLine": 44,
+      "endLine": 68,
+      "summary": "factorial_val_add_digitsum (m = v₂(m!) + s₂(m)) and log_barrier (a!·b! ∣ n! ⇒ a + b ≤ n + s₂(a) + s₂(b)), Erdős's elementary argument using only the prime 2.",
+      "mathContext": "$v_2(a!)+v_2(b!) \\le v_2(n!)$ and $m = v_2(m!)+s_2(m)$ give $a+b \\le n + s_2(a)+s_2(b)$."
+    },
+    {
+      "id": "explicit-log",
+      "title": "Explicit O(log) form via popcount ≤ length",
+      "startLine": 70,
+      "endLine": 89,
+      "summary": "digitsum_two_le_length (s₂(m) ≤ len₂(m)) and log_barrier_length (a + b ≤ n + len₂(a) + len₂(b)), the fully explicit O(log n) statement.",
+      "mathContext": "$s_2(m) \\le \\mathrm{len}_2(m) = \\lfloor\\log_2 m\\rfloor + 1$."
+    },
+    {
+      "id": "general-prime",
+      "title": "Prime-uniform sharpening",
+      "startLine": 91,
+      "endLine": 150,
+      "summary": "factorial_pval_add_digitsum (Legendre at general p), log_barrier_prime (a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for every prime p — sharp, prime-uniform), and log_barrier_of_prime (recovers the classical barrier at p = 2). Scaling the valuation inequality by (p−1) and substituting Legendre; omega atomizes the shared (p−1)·v_p(·!) subterms.",
+      "mathContext": "For every prime $p$: $a+b+s_p(n) \\le n + s_p(a) + s_p(b)$, sharpening the classical $p=2$ bound."
+    },
+    {
+      "id": "audit",
+      "title": "Axiom audit",
+      "startLine": 152,
+      "endLine": 163,
+      "summary": "#check and #print axioms for all theorems: each depends only on propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool).",
+      "mathContext": "0-axiom, 0-sorry verification."
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-728-factorial-divisibility-oq-04.json
+++ b/src/data/research/problems/erdos-728-factorial-divisibility-oq-04.json
@@ -1,0 +1,90 @@
+{
+  "slug": "erdos-728-factorial-divisibility-oq-04",
+  "title": "Erdős #728 → #729: the elementary logarithmic barrier (prime-uniform Legendre form)",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "path": "fast",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 8,
+  "started": "2026-06-25T00:00:00.000Z",
+  "lastUpdate": "2026-06-28T00:00:00.000Z",
+  "tags": [
+    "number-theory",
+    "combinatorics",
+    "erdos",
+    "factorial",
+    "p-adic",
+    "legendre-formula",
+    "digit-sum",
+    "verified"
+  ],
+  "problemStatement": {
+    "formal": "a!\\,b! \\mid n! \\Rightarrow a+b+s_p(n) \\le n + s_p(a) + s_p(b) \\text{ for every prime } p, \\text{ where } s_p(m) = (\\mathrm{digits}_p\\,m).\\mathrm{sum}; \\text{ at } p=2 \\text{ this is Erdős's } a+b \\le n + O(\\log n) \\text{ barrier.}",
+    "plain": "Formalize the elementary logarithmic barrier that Erdős #728/#729 surpass: if a!·b! ∣ n! then a + b ≤ n + O(log n), via Legendre's formula using only the prime 2. Sharpen it to a prime-uniform bound a + b + s_p(n) ≤ n + s_p(a) + s_p(b) holding for every prime p.",
+    "whyMatters": [
+      "The barrier is the lower bound the #728 (Jan 2026) and #729 resolutions break beyond; formalizing it in the same padicValNat/Legendre vocabulary lets future #729 work cite it directly.",
+      "Clarifies why the prime 2 is the optimal elementary choice for the asymptotic O(log) rate while the inequality itself is prime-uniform.",
+      "Verified (0-axiom) reusable infrastructure toward the #729 generalization."
+    ]
+  },
+  "currentState": {
+    "summary": "COMPLETED, fully verified (0-axiom, 0-sorry). The Lean file (committed in PR #31101 but never integrated) is now wired into the gallery (Proofs.lean aggregator + meta/annotations + research json), and the barrier is sharpened to a prime-uniform form log_barrier_prime holding for every prime p, with the classical p=2 statement recovered as a corollary.",
+    "outcome": "verified"
+  },
+  "knowledge": {
+    "insights": [
+      "Erdős's argument is elementary because Legendre's (p−1)·v_p(m!) = m − s_p(m) has the (p−1) factor equal to 1 at p = 2.",
+      "The barrier is prime-uniform: a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for every prime p (log_barrier_prime), strictly stronger than the classical p=2 statement (adds s_p(n), holds for all p).",
+      "p = 2 is optimal for the asymptotic O(log n) rate because the binary digit sum s₂ grows slowest; the inequality itself is prime-independent.",
+      "omega atomizes the nonlinear (p−1)·v_p(·!) subterms, so the final linear arithmetic discharges even with a variable prime p (scale hmono by (p−1) via Nat.mul_le_mul + Nat.mul_add first)."
+    ],
+    "builtItems": [
+      "factorial_val_add_digitsum: Legendre at p=2, m = v₂(m!)+s₂(m) (Erdos728FactorialDivisibilityOQ04.lean:46)",
+      "log_barrier: a!·b! ∣ n! ⇒ a+b ≤ n+s₂(a)+s₂(b) (Erdos728FactorialDivisibilityOQ04.lean:58)",
+      "log_barrier_length: explicit O(log) form (Erdos728FactorialDivisibilityOQ04.lean:84)",
+      "factorial_pval_add_digitsum: Legendre at general prime p (Erdos728FactorialDivisibilityOQ04.lean:112)",
+      "log_barrier_prime: prime-uniform sharp barrier (Erdos728FactorialDivisibilityOQ04.lean:123)",
+      "log_barrier_of_prime: recovers classical barrier at p=2 (Erdos728FactorialDivisibilityOQ04.lean:141)",
+      "Gallery integration: added to Proofs.lean, created meta.json + annotations.json"
+    ],
+    "mathlibGaps": [
+      "No Mathlib-level statement of the factorial-divisibility / Kummer-carry barrier; this file supplies the elementary Legendre baseline."
+    ],
+    "nextSteps": [
+      "Exhibit infinite families achieving equality in log_barrier_prime at p=2 (central binomial / multinomial cases) to show sharpness.",
+      "Multinomial barrier: a₁!·…·a_k! ∣ n! ⇒ ∑aᵢ + s_p(n) ≤ n + ∑s_p(aᵢ)."
+    ],
+    "progressSummary": "COMPLETED 2026-06-28 (researcher-8): integrated the previously un-integrated #728→#729 barrier file into the gallery and sharpened the barrier to a prime-uniform form (every prime p), recovering the classical p=2 statement. 0-axiom, 0-sorry, 7 theorems."
+  },
+  "knownResults": {
+    "established": [
+      "Erdős #728 resolved affirmatively (GPT-5.2 + Harmonic Aristotle, Jan 2026; arXiv:2601.07421).",
+      "Erdős #729 resolved by Barreto–Leeham via a modification of the same argument.",
+      "Legendre's formula v_p(m!) = (m − s_p(m))/(p−1)."
+    ]
+  },
+  "references": {
+    "papers": [
+      "Erdős problem #728: https://www.erdosproblems.com/728",
+      "Erdős problem #729: https://www.erdosproblems.com/729",
+      "arXiv:2601.07421 — resolution of Erdős #728."
+    ]
+  },
+  "relatedProofs": [
+    "erdos-728-factorial-divisibility"
+  ],
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos728FactorialDivisibilityOQ04.lean",
+      "filename": "Erdos728FactorialDivisibilityOQ04.lean",
+      "lineCount": 163,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos728FactorialDivisibilityOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Research session for **erdos-728-factorial-divisibility-oq-04** ("how do the #728
techniques extend to #729?"). The Lean file formalizing the elementary
**logarithmic barrier** that #728/#729 surpass — `a!·b! ∣ n! ⇒ a + b ≤ n + O(log n)`,
from Legendre's formula using only the prime 2 — was committed in #31101 but **never
integrated** into the gallery (not in the `Proofs.lean` aggregator, no `meta.json`,
no research json). This PR integrates it and **sharpens the barrier**.

## What's new
**Integration**
- Added `import Proofs.Erdos728FactorialDivisibilityOQ04` to `proofs/Proofs.lean`.
- Created `src/data/proofs/erdos-728-factorial-divisibility-oq-04/{meta,annotations}.json`
  and `src/data/research/problems/erdos-728-factorial-divisibility-oq-04.json`
  (status `verified`, badge `original`).

**Prime-uniform sharpening (3 new theorems, all 0-axiom)**
- `factorial_pval_add_digitsum`: Legendre at a general prime p,
  `m = (p−1)·v_p(m!) + s_p(m)`.
- `log_barrier_prime`: `a!·b! ∣ n! ⇒ a + b + s_p(n) ≤ n + s_p(a) + s_p(b)` for
  **every** prime p — strictly stronger than the classical p = 2 statement (adds the
  `s_p(n)` term dropped classically, and holds for all primes so one can take the best p).
- `log_barrier_of_prime`: recovers the original `log_barrier` as the p = 2 specialization.

The classical `log_barrier`/`log_barrier_length` (original p = 2 argument) are unchanged.

## Key technique
For a **variable** prime p, `(p−1)·v_p(m!)` is nonlinear, but `omega` atomizes
identical nonlinear subterms. So the valuation inequality `v_p(a!)+v_p(b!) ≤ v_p(n!)`
is scaled by `(p−1)` (`Nat.mul_le_mul` + `Nat.mul_add`) and combined with the three
Legendre identities — all sharing the same `(p−1)·v_p(·!)` atoms — and `omega` closes it.

## Files
- `proofs/Proofs/Erdos728FactorialDivisibilityOQ04.lean` (163 lines, 7 thms, 0 axioms)
- `proofs/Proofs.lean` (added import)
- gallery `meta.json` + `annotations.json` (new), research json (new), knowledge.md (new)

## Verification
`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean <file>` → exit 0, no errors.
`#print axioms` on all 7 theorems → `propext, Classical.choice, Quot.sound` only
(no `sorryAx`, no custom axioms).

## Status
**Outcome**: completed (verified). This is the elementary barrier the #728/#729
resolutions surpass — **not** a resolution of #729.
**Next steps**: sharpness families achieving equality at p = 2; the multinomial barrier.

🤖 Generated by researcher-8