### PR TITLE
research(erdos-1110-oq-01): prove {2,3} Yu-Chen density-zero [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1110Problem.lean
+++ b/proofs/Proofs/Erdos1110Problem.lean
@@ -403,6 +403,39 @@ The non-representable numbers have density zero for many parameter choices:
 - q = 3 and p > 6, or
 - q = 2 and p > 10
 -/
+
+/-- A single point has natural density `0`: for `n ≥ N` the count
+`|{0} ∩ {0,…,n}| = 1`, so the ratio `1/n → 0`. (Helper for the `{2,3}` density-zero
+instance below.) -/
+theorem hasDensity_singleton_zero : HasDensity {0} 0 := by
+  intro ε hε
+  obtain ⟨N, hN⟩ := exists_nat_gt (1 / ε)
+  refine ⟨N + 1, fun n hn => ?_⟩
+  have h0mem : (0 : ℕ) ∈ Finset.range (n + 1) := Finset.mem_range.mpr (by omega)
+  simp only [Set.mem_singleton_iff, Finset.filter_eq', h0mem, if_true,
+    Finset.card_singleton, Nat.cast_one, sub_zero]
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast (by omega : 0 < n)
+  have hcast : (1 : ℝ) / ε < (n : ℝ) := by
+    have : (N : ℝ) < (n : ℝ) := by exact_mod_cast (by omega : N < n)
+    linarith
+  rw [abs_of_nonneg (by positivity), div_lt_iff₀ hnpos]
+  rw [div_lt_iff₀ hε] at hcast
+  linarith [mul_comm (n : ℝ) ε]
+
+/-- **Yu-Chen density zero, `{2,3}` case (unconditional, 0-axiom).** For the base
+pair `{2,3}` the non-representable set is the single point `{0}` (see
+`nonRepresentable_two_three`), hence has natural density `0` — the sharpest possible
+instance of the Yu-Chen density-zero phenomenon. No axiom needed. -/
+theorem nonRepresentable_two_three_density_zero :
+    HasDensity (NonRepresentable 2 3) 0 := by
+  rw [nonRepresentable_two_three]; exact hasDensity_singleton_zero
+
+/-- **Yu-Chen density zero, `{3,2}` case (unconditional, 0-axiom).** Same statement for
+the reversed base pair (`NonRepresentable 3 2 = {0}`). -/
+theorem nonRepresentable_three_two_density_zero :
+    HasDensity (NonRepresentable 3 2) 0 := by
+  rw [nonRepresentable_three_two]; exact hasDensity_singleton_zero
+
 /--
 **Yu-Chen Coprime Non-Representables:**
 There are infinitely many coprime non-representable numbers for most (p,q):

--- a/research/problems/erdos-1110-oq-01/state.md
+++ b/research/problems/erdos-1110-oq-01/state.md
@@ -1,24 +1,42 @@
 # Current State
 
-**Phase**: NEW
+**Phase**: ACT — {2,3} case fully solved + density-zero proved; 1 deep axiom remains
 **Since**: 2026-05-29T19:14:09.134Z
-**Iteration**: 1
+**Iteration**: 3
+**Last Updated**: 2026-06-28 (researcher-1, S4 ACT)
+
+## S4 ACT (researcher-1, 2026-06-28) — Yu-Chen density-zero for {2,3}, 0-axiom
+
+Gave content to the previously def-only `HasDensity` scaffolding by proving the
+{2,3} case of the Yu-Chen density-zero phenomenon, unconditionally (0-axiom):
+- `hasDensity_singleton_zero : HasDensity {0} 0` (count = 1, ratio 1/n → 0).
+- `nonRepresentable_two_three_density_zero : HasDensity (NonRepresentable 2 3) 0`
+  and the `3 2` companion — reduce to the singleton helper via the existing
+  `nonRepresentable_two_three`/`_three_two` (= {0}). The sharpest possible Yu-Chen
+  instance (density exactly 0, set = {0}).
+
+Host-verified (`lake env lean`, EXIT 0); `#print axioms` = propext/Choice/Quot only.
+The file's single deep axiom `erdos_lewin_infinite` (hard direction, {p,q}≠{2,3} ⇒
+infinite, not in Mathlib) is UNCHANGED — genuinely deep (Erdős–Lewin 1996), not the
+target this session.
 
 ## Current Focus
 
-Initial exploration of the problem.
+Reduce/eliminate the last deep axiom `erdos_lewin_infinite` (or a concrete special case).
 
 ## Active Approach
 
-None yet.
+The {2,3} elementary side is exhausted (representability + non-rep set + density all
+proved 0-axiom). Remaining work is the deep infinitude direction.
 
 ## Blockers
 
-None.
+`erdos_lewin_infinite` is a deep 1996 result absent from Mathlib 4.26.
 
 ## Next Action
 
-Begin problem exploration.
+Attempt a concrete special case of the infinitude direction, or clean up the
+remaining unused `minSummandBound`/`CoprimeNonRepresentable` scaffolding.
 
 ## Attempt Counts
 

--- a/src/data/research/problems/erdos-1110-oq-01.json
+++ b/src/data/research/problems/erdos-1110-oq-01.json
@@ -33,30 +33,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "The {2,3} case is fully solved 0-axiom (case_2_3_all_representable, strong induction). Iteration 2 proved the EASY direction of the Erdos-Lewin iff unconditionally and pinned the non-representable set exactly to {0} for both base orderings, weakening the former bundled-iff axiom to the single deep `erdos_lewin_infinite` (hard direction only). Also repaired ~10 pre-existing Mathlib-4.26 build breakages so the file compiles again. Residual assumption: the deep Erdos-Lewin direction (not in Mathlib).",
+    "progressSummary": "The {2,3} case is fully solved 0-axiom (representability + NonRepresentable={0}). Iter 2 proved the EASY Erdos-Lewin direction unconditionally, weakening the axiom to the deep hard direction only (erdos_lewin_infinite). Iter 3 (S4): proved the {2,3} Yu-Chen density-zero instance 0-axiom (HasDensity (NonRepresentable 2 3) 0), giving content to the formerly def-only HasDensity scaffolding. Residual assumption unchanged: the single deep axiom erdos_lewin_infinite (hard direction, not in Mathlib).",
     "builtItems": [
       "case_2_3_all_representable (pre-existing, 0-axiom): every n>=1 is an antichain sum of 3^a 2^b, by strong induction (even: double; odd: subtract 3^{floor log_3 n}).",
       "not_isRepresentable_zero (0-axiom): a nonempty antichain of positive power forms has positive sum, so 0 is never representable.",
       "isPowerForm_comm / isRepresentable_comm (0-axiom): representability is symmetric in the base pair (p^k q^l ranges over the same set as q^k p^l).",
       "nonRepresentable_three_two / nonRepresentable_two_three (0-axiom): NonRepresentable = {0} exactly for {2,3}.",
       "finite_nonRepresentable_of_two_three (0-axiom): the easy direction {2,3} => Finite, now proved not assumed (returns the singleton {0}).",
-      "erdos_lewin_theorem (now a THEOREM): full iff, backward from finite_nonRepresentable_of_two_three, forward from the weaker axiom erdos_lewin_infinite."
+      "erdos_lewin_theorem (now a THEOREM): full iff, backward from finite_nonRepresentable_of_two_three, forward from the weaker axiom erdos_lewin_infinite.",
+      "hasDensity_singleton_zero (0-axiom): a single point has natural density 0 (count=1, ratio 1/n -> 0).",
+      "nonRepresentable_two_three_density_zero / _three_two_density_zero (0-axiom): the {2,3} non-representable set {0} has density zero — the sharpest Yu-Chen density-zero instance, giving content to the previously def-only HasDensity scaffolding."
     ],
     "insights": [
       "The Erdos-Lewin 'iff' splits cleanly: the {2,3}=>finite half is elementary (it is exactly the proven case_2_3 induction), only ¬{2,3}=>infinite is deep. Axiomatising just the deep half (erdos_lewin_infinite) is strictly weaker than axiomatising the iff.",
       "For {2,3} the non-representable set is the single point {0}, not merely finite.",
       "Mathlib 4.26 renames hit this file: Nat.strong_rec_on -> Nat.strong_induction_on; Nat.pow_log_le_self now takes (b)(hn:n!=0) with n implicit; Nat.lt_pow_succ_log_self now takes (hb)(n) with n explicit.",
       "omega cannot see through an un-beta-reduced lambda ((fun x=>x*2) a) nor multiply two unknowns (3^k * c); dsimp/explicit c=1 substitution fixes both. ring fails on Nat truncated subtraction; rw [pow_succ] then omega works.",
-      "A subst is blocked when a `let`-bound local (k := Nat.log 3 n) depends on the variable; rewrite the goal with the equation instead of subst."
+      "A subst is blocked when a `let`-bound local (k := Nat.log 3 n) depends on the variable; rewrite the goal with the equation instead of subst.",
+      "The {2,3} case realizes Yu-Chen density-zero exactly: NonRepresentable={0} has density 0 (not just below some bound). Provable 0-axiom by reducing HasDensity {0} 0 to 1/n->0 via Finset.filter_eq' on the singleton.",
+      "Mathlib-4.26 gotcha: div_lt_iff renamed to div_lt_iff₀ (a/c<b iff a<b*c for 0<c); Finset.filter_eq' evaluates filter(.=a) to (if a in s then {a} else empty), sidestepping the Set-vs-Classical Decidable-instance mismatch that blocks rw on a hand-stated card lemma."
     ],
     "mathlibGaps": [
       "Erdos-Lewin deep direction: {p,q}!={2,3} (p>q>=2 coprime) => infinitely many non-representable numbers. Not in Mathlib 4.26.",
       "Yu-Chen density-zero and coprime-non-representable results (2022). Not in Mathlib."
     ],
     "nextSteps": [
-      "DONE (iter 2): proved the easy Erdos-Lewin direction unconditionally; weakened the iff axiom to the deep direction only; repaired Mathlib-4.26 build breakages.",
-      "Attempt the deep direction (or a special case) to reduce/eliminate erdos_lewin_infinite.",
-      "Either prove a concrete HasDensity / minSummandBound statement or remove the unused scaffolding."
+      "Attempt the deep direction erdos_lewin_infinite (or a concrete special case, e.g. a single (p,q)) to reduce/eliminate the last axiom — genuinely hard (Erdos-Lewin 1996, not in Mathlib).",
+      "Optionally prove a HasDensity statement for CoprimeNonRepresentable {2,3}, or remove the still-unused minSummandBound / CoprimeNonRepresentable scaffolding."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for **erdos-1110-oq-01** (density of non-representables for additive bases). The {2,3} base-pair case was already solved 0-axiom in prior sessions (`NonRepresentable 2 3 = {0}`), leaving exactly one deep axiom `erdos_lewin_infinite` (the hard direction of Erdős–Lewin 1996: `{p,q}≠{2,3} ⟹` infinitely many non-representable; not in Mathlib).

This session gives content to the previously **def-only** `HasDensity` scaffolding by proving the {2,3} case of the **Yu-Chen density-zero** phenomenon, unconditionally.

## Progress (verified, host-compiled, 0-axiom)
- `hasDensity_singleton_zero : HasDensity {0} 0` — a single point has natural density 0 (count = 1, ratio `1/n → 0`). Proved by evaluating the count via `Finset.filter_eq'` on the singleton (sidestepping the Set-vs-`Classical` `Decidable`-instance mismatch that blocks `rw` on a hand-stated card lemma).
- `nonRepresentable_two_three_density_zero : HasDensity (NonRepresentable 2 3) 0` and the `3 2` companion — reduce to the singleton helper via the existing `nonRepresentable_two_three`/`_three_two` (`= {0}`). The sharpest possible Yu-Chen instance: density exactly 0, set `= {0}`.

## Verification
- `lake env lean` against pinned Mathlib v4.26.0 — EXIT 0 (only a pre-existing unused-variable warning at line 98, unrelated).
- `#print axioms` of the new theorems → `propext, Classical.choice, Quot.sound` only (no `sorryAx`, no `native_decide`).

## Honest scope
The file's single deep axiom `erdos_lewin_infinite` is **unchanged** — it is genuinely deep (Erdős–Lewin 1996, absent from Mathlib) and was not the target. This session converts dead scaffolding into a proved, literature-aligned theorem; it does not reduce the assumption count.

## Status
**Outcome**: progress (new 0-axiom theorem; scaffolding given content). 1 deep axiom remains.
**Next Steps**: attempt a concrete special case of `erdos_lewin_infinite`, or clean up the still-unused `minSummandBound`/`CoprimeNonRepresentable` scaffolding.

🤖 Generated by researcher-1