### PR TITLE
research(lagrange-oq-01-oq-03-oq-01): Hall's theorem Schur–Zassenhaus lifting step [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01OQ03.lean
@@ -32,7 +32,11 @@ for every Hall divisor of |G|.
 ## Why the main theorem is axiomatized
 Hall's theorem for solvable groups requires the Schur–Zassenhaus theorem and
 properties of minimal normal subgroups (elementary abelian structure).
-Schur–Zassenhaus is not yet in Mathlib 4.26, making the full proof unavailable.
+Schur–Zassenhaus IS available in Mathlib 4.26
+(`Subgroup.exists_right_complement'_of_coprime`); the actual remaining gap is the
+minimal-normal-subgroup machinery (existence and elementary-abelian structure).
+The Schur–Zassenhaus lifting step of the induction is proved with 0 axioms in the
+follow-up entry `lagrange-theorem-oq-01-oq-03-oq-01`.
 
 ## References
 - Hall, P. (1928), "A note on soluble groups", J. London Math. Soc.
@@ -152,7 +156,9 @@ theorem hall_cyclic_hall_divisor [Fintype G] [IsCyclic G]
     (3) If p | d: Induct on G/N — get H'/N ≤ G/N of order d/p^a.
         Sylow and Schur–Zassenhaus yield a complement of order d in G.
 
-    Blocked on: Schur–Zassenhaus theorem not in Mathlib 4.26. -/
+    Schur–Zassenhaus IS in Mathlib 4.26; the lifting step (case p ∤ d) is proved
+    with 0 axioms in lagrange-theorem-oq-01-oq-03-oq-01. The remaining gap is
+    minimal-normal-subgroup structure (elementary abelian), needed for case p | d. -/
 axiom hall_solvable [Fintype G] [IsSolvable G]
     (d : ℕ) (hd : IsHallDivisor d (Fintype.card G)) :
     ∃ H : Subgroup G, Nat.card H = d

--- a/proofs/Proofs/LagrangeTheoremOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01OQ03OQ01.lean
@@ -1,0 +1,169 @@
+import Mathlib.GroupTheory.SchurZassenhaus
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.Sylow
+import Mathlib.Tactic
+
+/-
+# Hall's Theorem: the Schur–Zassenhaus lifting step (0 axioms)
+
+## Open Question (from lagrange-theorem-oq-01-oq-03, OQ-01)
+> Can the full proof of Hall's theorem be formalized in Lean 4 without using
+> Schur–Zassenhaus as a black box, by building the minimal normal subgroup
+> induction from scratch?
+
+## What this file settles
+
+The parent entry `lagrange-theorem-oq-01-oq-03` axiomatized Hall's theorem for
+solvable groups (`hall_solvable`) with the justification that "Schur–Zassenhaus
+is not yet in Mathlib 4.26". **That justification is factually wrong.** Mathlib
+4.26 DOES contain Schur–Zassenhaus as
+`Subgroup.exists_right_complement'_of_coprime`
+(`Mathlib/GroupTheory/SchurZassenhaus.lean`), and sibling gallery entries
+(`lagrange-theorem-oq-03`, `sylow-theorem-oq-03`) already use it.
+
+So the right answer to OQ-01 is: one should NOT rebuild Schur–Zassenhaus from
+scratch — it is available — and the genuine remaining obstacle to a 0-axiom Hall
+theorem is the *minimal normal subgroup* machinery (every minimal normal
+subgroup of a finite solvable group is elementary abelian), which Mathlib lacks.
+
+This file isolates and proves, **with 0 axioms**, the precise inductive
+mechanism that the parent axiomatized away: the **Schur–Zassenhaus lifting
+step**. Hall's proof inducts on `|G|`; in the branch where the chosen normal
+subgroup `N` has order coprime to the target order `d`, the existence of a
+subgroup of order `d` in the quotient `G/N` lifts to a subgroup of order `d` in
+`G`. That lift is exactly Schur–Zassenhaus applied inside the preimage, and it is
+what `hall_lift_of_coprime` below proves.
+
+## Results
+
+| Theorem | Statement | Status |
+|---------|-----------|--------|
+| `hall_lift_of_coprime` | If `N ⊴ G`, `gcd(\|N\|, d) = 1`, and `G/N` has a subgroup of order `d`, then so does `G` | Proved (0 axioms) |
+| `hall_lift_of_coprime_subgroup` | The lifted subgroup can be taken inside the preimage of the quotient subgroup | Proved (0 axioms) |
+| `schur_zassenhaus_available` | Restatement of Mathlib's Schur–Zassenhaus, witnessing it exists | Proved (0 axioms) |
+
+## The remaining gap (for a full 0-axiom Hall theorem)
+
+The induction also has a branch where `p ∣ d` (the prime dividing the minimal
+normal subgroup `N` also divides `d`). Closing that branch needs:
+* existence of a *minimal* normal subgroup of a nontrivial finite group, and
+* the fact that in a *solvable* group such a subgroup is elementary abelian.
+
+Neither is in Mathlib 4.26. With those, `hall_lift_of_coprime` (this file) plus
+the abelian base case (`lagrange-theorem-oq-03`'s `abelian_hall_exists`) and the
+cyclic/prime cases (the parent) would assemble into a 0-axiom proof of
+`hall_solvable`.
+
+## References
+- Hall, P. (1928), "A note on soluble groups", J. London Math. Soc.
+- Gorenstein, "Finite Groups", Ch. 6 (Hall's theorem via Schur–Zassenhaus)
+-/
+
+namespace LagrangeOQ01OQ03OQ01
+
+open Subgroup
+
+variable {G : Type*} [Group G]
+
+-- ============================================================
+-- Part 0: Schur–Zassenhaus is available in Mathlib (record this)
+-- ============================================================
+
+/-- **Schur–Zassenhaus is in Mathlib 4.26.** A normal subgroup `N ⊴ G` whose
+order is coprime to its index has a complement. This is `Mathlib`'s
+`Subgroup.exists_right_complement'_of_coprime`; we restate it to document, against
+the parent entry's claim, that the theorem is available and needs no axiom. -/
+theorem schur_zassenhaus_available (N : Subgroup G) [N.Normal]
+    (hN : Nat.Coprime (Nat.card N) N.index) :
+    ∃ K : Subgroup G, N.IsComplement' K :=
+  Subgroup.exists_right_complement'_of_coprime hN
+
+-- ============================================================
+-- Part I: The Schur–Zassenhaus lifting step of Hall's theorem
+-- ============================================================
+
+/-- **Hall lifting step (subgroup form).** Let `G` be finite, `N ⊴ G` a normal
+subgroup, and `Q ≤ G/N` a subgroup of order `d` with `gcd(|N|, d) = 1`. Then the
+preimage `L = π⁻¹(Q)` contains a subgroup `K` of order `d` (a complement to `N`
+inside `L`). This is the inductive step of Hall's theorem: it lifts a Hall
+subgroup from the quotient to the group via Schur–Zassenhaus. -/
+theorem hall_lift_of_coprime_subgroup [Finite G] (N : Subgroup G) [N.Normal]
+    {d : ℕ} (Q : Subgroup (G ⧸ N)) (hQ : Nat.card Q = d)
+    (hcop : Nat.Coprime (Nat.card N) d) :
+    ∃ K : Subgroup G, K ≤ Q.comap (QuotientGroup.mk' N) ∧ Nat.card K = d := by
+  -- `L` is the preimage of `Q` under the quotient map.
+  set L := Q.comap (QuotientGroup.mk' N) with hLdef
+  -- `N ≤ L` since `N = ker(π)` and the kernel lands in every preimage.
+  have hNL : N ≤ L := by
+    intro x hx
+    rw [hLdef, mem_comap]
+    have hx1 : (QuotientGroup.mk' N) x = 1 := by
+      rw [QuotientGroup.mk'_apply]
+      exact (QuotientGroup.eq_one_iff x).mpr hx
+    rw [hx1]
+    exact one_mem Q
+  -- Index of the preimage equals the index of `Q` (π is surjective).
+  have hLidx : L.index = Q.index :=
+    Subgroup.index_comap_of_surjective (H := Q) (QuotientGroup.mk'_surjective N)
+  -- Order of `L`: `|L| = |N| * d`.
+  have hQpos : Q.index ≠ 0 := Subgroup.index_ne_zero_of_finite
+  have hcardL : Nat.card L = Nat.card N * d := by
+    have key : Nat.card L * Q.index = (Nat.card N * d) * Q.index := by
+      have lhs : Nat.card L * Q.index = Nat.card G := by
+        rw [← hLidx]; exact Subgroup.card_mul_index L
+      have rhs : (Nat.card N * d) * Q.index = Nat.card G := by
+        rw [← hQ, mul_assoc, Subgroup.card_mul_index Q, ← Subgroup.index_eq_card]
+        exact Subgroup.card_mul_index N
+      rw [lhs, rhs]
+    exact Nat.eq_of_mul_eq_mul_right (Nat.pos_of_ne_zero hQpos) key
+  -- `N` as a subgroup of `↥L`, with the same cardinality as `N`.
+  have hmap : (N.subgroupOf L).map L.subtype = N := by
+    rw [Subgroup.subgroupOf_map_subtype, inf_eq_left.mpr hNL]
+  have hNLcard : Nat.card (N.subgroupOf L) = Nat.card N := by
+    have h := Subgroup.card_subtype L (N.subgroupOf L)
+    rw [hmap] at h
+    exact h.symm
+  -- Its index inside `↥L` is `d`.
+  have hidxNL : (N.subgroupOf L).index = d := by
+    have h := Subgroup.card_mul_index (N.subgroupOf L)
+    rw [hNLcard, hcardL] at h
+    exact Nat.eq_of_mul_eq_mul_left Nat.card_pos h
+  -- Schur–Zassenhaus inside `↥L`: `N.subgroupOf L` has a complement `KL`.
+  have hcop' : Nat.Coprime (Nat.card (N.subgroupOf L)) (N.subgroupOf L).index := by
+    rw [hNLcard, hidxNL]; exact hcop
+  obtain ⟨KL, hKL⟩ := Subgroup.exists_right_complement'_of_coprime hcop'
+  -- The complement has order `d`.
+  have hKLcard : Nat.card KL = d := by
+    have h := hKL.card_mul
+    rw [hNLcard, hcardL] at h
+    exact Nat.eq_of_mul_eq_mul_left Nat.card_pos h
+  -- Push `KL` back into `G`; it lands inside `L` and keeps order `d`.
+  refine ⟨KL.map L.subtype, ?_, ?_⟩
+  · exact map_subtype_le KL
+  · rw [Subgroup.card_subtype]; exact hKLcard
+
+/-- **Hall lifting step (existence form).** If `N ⊴ G` is normal with order
+coprime to `d`, and the quotient `G/N` has a subgroup of order `d`, then `G` has
+a subgroup of order `d`. This is the Schur–Zassenhaus inductive step of Hall's
+theorem, formalized with 0 axioms. -/
+theorem hall_lift_of_coprime [Finite G] (N : Subgroup G) [N.Normal]
+    {d : ℕ} (Q : Subgroup (G ⧸ N)) (hQ : Nat.card Q = d)
+    (hcop : Nat.Coprime (Nat.card N) d) :
+    ∃ K : Subgroup G, Nat.card K = d := by
+  obtain ⟨K, _, hK⟩ := hall_lift_of_coprime_subgroup N Q hQ hcop
+  exact ⟨K, hK⟩
+
+-- ============================================================
+-- Part II: Sanity specializations
+-- ============================================================
+
+/-- Degenerate check: when `N` is trivial, the lift is the identity — a subgroup
+of order `d` in `G/⊥ ≅ G` is essentially one in `G`. (Stated abstractly via the
+coprimality `gcd(1, d) = 1`, which always holds.) -/
+theorem hall_lift_trivial_coprime [Finite G]
+    {d : ℕ} (Q : Subgroup (G ⧸ (⊥ : Subgroup G))) (hQ : Nat.card Q = d) :
+    ∃ K : Subgroup G, Nat.card K = d :=
+  hall_lift_of_coprime (⊥ : Subgroup G) Q hQ (by
+    rw [Subgroup.card_bot]; exact Nat.coprime_one_left d)
+
+end LagrangeOQ01OQ03OQ01

--- a/research/problems/lagrange-theorem-oq-01-oq-03-oq-01/knowledge.md
+++ b/research/problems/lagrange-theorem-oq-01-oq-03-oq-01/knowledge.md
@@ -1,0 +1,46 @@
+# lagrange-theorem-oq-01-oq-03-oq-01: Hall's theorem — Schur–Zassenhaus lifting step
+
+## Problem
+OQ-01 of the parent Hall entry: can the full proof of Hall's theorem be
+formalized in Lean 4 without using Schur–Zassenhaus as a black box, building the
+minimal normal subgroup induction from scratch?
+
+## Session 2026-06-28 (Session 1) — FRESH
+**Outcome:** progress (0-axiom verified contribution)
+
+### Key findings
+- The parent entry `lagrange-theorem-oq-01-oq-03` axiomatizes `hall_solvable`
+  citing "Schur–Zassenhaus not yet in Mathlib 4.26". **This is false.** Mathlib
+  4.26 has it: `Subgroup.exists_right_complement'_of_coprime`
+  (`Mathlib/GroupTheory/SchurZassenhaus.lean`). Sibling entries
+  `lagrange-theorem-oq-03` and `sylow-theorem-oq-03` already use it.
+- Therefore the correct answer to OQ-01 is: do NOT rebuild Schur–Zassenhaus; it
+  is available. The genuine remaining obstacle to a 0-axiom Hall's theorem is the
+  minimal-normal-subgroup machinery (existence + elementary-abelian structure in
+  the solvable case), which Mathlib lacks.
+- Mathlib has Hall's *marriage* theorem (Combinatorics) but NOT Hall's theorem
+  for solvable groups.
+
+### What I built (0 axioms; #print axioms = propext/Choice/Quot only)
+- `hall_lift_of_coprime` + `hall_lift_of_coprime_subgroup`: the inductive lifting
+  step of Hall's theorem. If N ⊴ G, gcd(|N|, d) = 1, and G/N has a subgroup of
+  order d, then so does G (and it lives inside the preimage of the quotient
+  subgroup). Proof: L = π⁻¹(Q), show |L| = |N|·d via card_mul_index /
+  index_eq_card / index_comap_of_surjective, then Schur–Zassenhaus on
+  N.subgroupOf L (index d, order |N|, coprime) gives a complement of order d,
+  pushed back along L.subtype. Mirrors Mathlib SZ's internal `step1` recursion.
+- `schur_zassenhaus_available`: documents Mathlib's SZ.
+- Corrected the parent's false justification (Lean docstring + meta.json).
+
+### Files
+- proofs/Proofs/LagrangeTheoremOQ01OQ03OQ01.lean (new, 169 lines, 0 axioms)
+- src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json (new)
+- proofs/Proofs/LagrangeTheoremOQ01OQ03.lean (docstring correction)
+- src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json (assumptions correction)
+
+### Next steps
+- Formalize existence of a minimal normal subgroup of a nontrivial finite group.
+- Prove a minimal normal subgroup of a finite solvable group is elementary
+  abelian; close the p | d branch.
+- Assemble full 0-axiom Hall's theorem: lifting step (here) + abelian base case
+  (lagrange-theorem-oq-03) + minimal-normal-subgroup structure.

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,102 @@
+{
+  "id": "lagrange-theorem-oq-01-oq-03-oq-01",
+  "title": "Hall's Theorem: the Schur–Zassenhaus Lifting Step (0 axioms)",
+  "slug": "lagrange-theorem-oq-01-oq-03-oq-01",
+  "description": "Isolates and proves, with 0 axioms, the inductive lifting step of Hall's theorem for solvable groups: if N ⊴ G is normal with |N| coprime to d, and the quotient G/N has a subgroup of order d, then G has a subgroup of order d. This is the precise Schur–Zassenhaus mechanism that the parent entry (lagrange-theorem-oq-01-oq-03) axiomatized away. It also corrects the parent's factually wrong justification — Schur–Zassenhaus IS in Mathlib 4.26 (Subgroup.exists_right_complement'_of_coprime) — and pinpoints the genuine remaining gap (minimal-normal-subgroup elementary-abelian structure) for a fully 0-axiom Hall's theorem.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-28",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ01OQ03OQ01.lean",
+    "tags": [
+      "group-theory",
+      "algebra",
+      "hall-theorem",
+      "schur-zassenhaus",
+      "solvable-groups",
+      "lagrange",
+      "subgroups",
+      "quotient-groups"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-28",
+    "axiomCount": 0,
+    "lineCount": 169,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. All results are machine-checked with 0 axioms; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for every theorem.",
+    "originalContributions": [
+      "hall_lift_of_coprime: the Schur–Zassenhaus inductive step of Hall's theorem, formalized with 0 axioms — lifts a subgroup of order d from a quotient G/N to G when gcd(|N|, d) = 1",
+      "hall_lift_of_coprime_subgroup: the sharper form locating the lifted subgroup inside the preimage π⁻¹(Q) of the quotient subgroup (a complement to N inside that preimage)",
+      "Correction of a false claim in the parent entry: Schur–Zassenhaus IS in Mathlib 4.26 as Subgroup.exists_right_complement'_of_coprime; the parent axiomatized Hall's theorem citing its supposed absence",
+      "Precise identification of the actual remaining gap for a 0-axiom Hall's theorem: existence of a minimal normal subgroup of a nontrivial finite group and its elementary-abelian structure in the solvable case (the p | d branch)",
+      "schur_zassenhaus_available: a documented restatement witnessing Mathlib's Schur–Zassenhaus"
+    ],
+    "proofStrategy": "Hall's existence proof inducts on |G| using a (minimal) normal subgroup N. In the branch where the prime dividing N does not divide the target order d (equivalently gcd(|N|, d) = 1), one lifts the order-d subgroup of G/N to G. This file formalizes exactly that lift: set L = π⁻¹(Q) for the quotient map π : G → G/N and the order-d subgroup Q ≤ G/N. Then N ≤ L (kernel lands in the preimage), and a card computation via card_mul_index, index_eq_card, and index_comap_of_surjective gives |L| = |N|·d. Viewing N as N.subgroupOf L, its index in L is d and its order is |N|, so gcd(|N.subgroupOf L|, (N.subgroupOf L).index) = gcd(|N|, d) = 1. Schur–Zassenhaus (Subgroup.exists_right_complement'_of_coprime) applied inside ↥L yields a complement KL of order d; pushing KL forward along L.subtype gives the required subgroup of G. The construction mirrors the internal step1 recursion of Mathlib's own Schur–Zassenhaus proof."
+  },
+  "leanFile": {
+    "path": "Proofs/LagrangeTheoremOQ01OQ03OQ01.lean",
+    "imports": [
+      "Mathlib.GroupTheory.SchurZassenhaus",
+      "Mathlib.GroupTheory.Solvable",
+      "Mathlib.GroupTheory.Sylow"
+    ],
+    "opens": [
+      "Subgroup"
+    ],
+    "namespace": "LagrangeOQ01OQ03OQ01",
+    "lineCount": 169,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "openQuestions": [
+    {
+      "id": "oq-01",
+      "question": "Can the existence of a minimal normal subgroup of a nontrivial finite group, and its elementary-abelian structure in the solvable case, be formalized in Mathlib? Together with this file's lifting step and the abelian base case, that would yield a fully 0-axiom proof of Hall's theorem for solvable groups.",
+      "difficulty": "hard",
+      "status": "open"
+    },
+    {
+      "id": "oq-02",
+      "question": "Can the p | d branch of Hall's induction (where the prime of the minimal normal subgroup also divides the target order) be formalized using the elementary-abelian structure, completing the induction whose coprime branch is proved here?",
+      "difficulty": "hard",
+      "status": "open"
+    }
+  ],
+  "parentId": "lagrange-theorem-oq-01-oq-03",
+  "conclusion": {
+    "summary": "The Schur–Zassenhaus inductive step of Hall's theorem — lifting a Hall subgroup from a quotient G/N to G in the coprime branch — is now machine-checked with 0 axioms. This is the exact mechanism the parent Hall entry axiomatized, and the parent's stated reason for axiomatizing it (Schur–Zassenhaus 'not in Mathlib 4.26') is incorrect: Mathlib does provide it.",
+    "implications": "With the lifting step verified, the only obstruction to a fully 0-axiom Hall's theorem for solvable groups is the minimal-normal-subgroup machinery (existence and elementary-abelian structure), which would close the complementary p | d branch. The coprime branch proved here, the abelian base case from lagrange-theorem-oq-03, and the prime/cyclic cases from the parent together cover everything except that structural input.",
+    "openQuestions": [
+      "Formalize existence of a minimal normal subgroup of a nontrivial finite group in Mathlib.",
+      "Formalize that a minimal normal subgroup of a finite solvable group is elementary abelian, closing the p | d branch.",
+      "Assemble the full 0-axiom Hall's theorem from the lifting step, the abelian base case, and minimal-normal-subgroup structure."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "lagrange-theorem-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Proves (0 axioms) the Schur–Zassenhaus lifting step that the parent axiomatized as hall_solvable, and corrects the parent's claim that Schur–Zassenhaus is absent from Mathlib 4.26."
+    },
+    {
+      "proofId": "lagrange-theorem-oq-03",
+      "relationship": "uses",
+      "description": "Complementary: oq-03 packages Schur–Zassenhaus and the abelian Hall base case (abelian_hall_exists); this entry supplies the inductive lifting step that combines with it."
+    },
+    {
+      "proofId": "sylow-theorem-oq-03",
+      "relationship": "related",
+      "description": "Also builds on Mathlib's Subgroup.exists_right_complement'_of_coprime (Schur–Zassenhaus), confirming its availability."
+    }
+  ],
+  "references": [
+    "Hall, P. (1928). A note on soluble groups. Journal of the London Mathematical Society, 3(2), 98–105.",
+    "Gorenstein, D. (1980). Finite Groups (2nd ed.), Chapter 6.",
+    "Mathlib4, Mathlib/GroupTheory/SchurZassenhaus.lean (Subgroup.exists_right_complement'_of_coprime)."
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
@@ -24,7 +24,7 @@
     "lineCount": 211,
     "theoremCount": 14,
     "definitionCount": 2,
-    "assumptions": "hall_solvable: Hall's theorem for solvable groups (requires Schur–Zassenhaus + minimal normal subgroup theory not yet in Mathlib). hall_characterizes_solvability: Hall's converse (requires Feit–Thompson odd-order theorem).",
+    "assumptions": "hall_solvable: Hall's theorem for solvable groups. Schur–Zassenhaus IS available in Mathlib 4.26 (Subgroup.exists_right_complement'_of_coprime); the remaining gap is minimal-normal-subgroup theory (elementary-abelian structure). The Schur–Zassenhaus lifting step is proved with 0 axioms in lagrange-theorem-oq-01-oq-03-oq-01. hall_characterizes_solvability: Hall's converse (requires Feit–Thompson odd-order theorem).",
     "originalContributions": [
       "IsHallDivisor definition: d | n with gcd(d, n/d) = 1, the formal Hall divisor condition",
       "IsHallSubgroup definition: subgroup H with gcd(|H|, [G:H]) = 1",

--- a/src/data/research/problems/lagrange-theorem-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01-oq-03-oq-01.json
@@ -1,0 +1,41 @@
+{
+  "slug": "lagrange-theorem-oq-01-oq-03-oq-01",
+  "title": "Hall's Theorem: the Schur–Zassenhaus lifting step",
+  "problemStatement": "OQ-01 of the parent Hall entry: can the full proof of Hall's theorem for solvable groups be formalized in Lean 4 without using Schur–Zassenhaus as a black box, building the minimal-normal-subgroup induction from scratch?",
+  "significance": "Hall's theorem is the strongest converse to Lagrange's theorem and characterizes solvability. The parent entry axiomatized the solvable case; this resolves which ingredient is actually missing and verifies the Schur–Zassenhaus inductive step with 0 axioms.",
+  "status": "completed",
+  "phase": "ACT",
+  "tier": "EMPTY",
+  "tractability": "partial",
+  "path": "Proofs/LagrangeTheoremOQ01OQ03OQ01.lean",
+  "started": "2026-06-28",
+  "lastUpdate": "2026-06-28",
+  "tags": ["group-theory", "hall-theorem", "schur-zassenhaus", "solvable-groups", "lagrange"],
+  "currentState": "Schur–Zassenhaus lifting step proved with 0 axioms (hall_lift_of_coprime). Parent's false 'SZ not in Mathlib' claim corrected. Remaining gap: minimal-normal-subgroup elementary-abelian structure (p|d branch).",
+  "knownResults": "Hall (1928). Schur–Zassenhaus is in Mathlib 4.26 as Subgroup.exists_right_complement'_of_coprime. Mathlib has solvable-group derived series but no minimal-normal-subgroup structure theory and no Hall's theorem for solvable groups.",
+  "knowledge": {
+    "insights": [
+      "Parent entry's axiom justification is factually wrong: Schur–Zassenhaus IS in Mathlib 4.26 (Subgroup.exists_right_complement'_of_coprime), already used by lagrange-theorem-oq-03 and sylow-theorem-oq-03.",
+      "The genuine remaining obstacle to a 0-axiom Hall's theorem is minimal-normal-subgroup machinery (existence + elementary-abelian structure in the solvable case), not Schur–Zassenhaus.",
+      "Mathlib has Hall's marriage theorem (Combinatorics) but NOT Hall's theorem for solvable groups.",
+      "The lifting step (case gcd(|N|,d)=1) reduces to Schur–Zassenhaus inside the preimage L=π⁻¹(Q), with the card bookkeeping |L|=|N|·d done via card_mul_index / index_eq_card / index_comap_of_surjective."
+    ],
+    "builtItems": [
+      "hall_lift_of_coprime (LagrangeTheoremOQ01OQ03OQ01.lean): 0-axiom Schur–Zassenhaus lifting step of Hall's theorem",
+      "hall_lift_of_coprime_subgroup: sharper form locating the lift inside π⁻¹(Q)",
+      "schur_zassenhaus_available: documents Mathlib's SZ",
+      "Correction of parent's false 'SZ not in Mathlib' claim (docstring + meta.json)"
+    ],
+    "mathlibGaps": [
+      "No existence theorem for a minimal normal subgroup of a nontrivial finite group",
+      "No theorem that a minimal normal subgroup of a finite solvable group is elementary abelian",
+      "No Hall's theorem for solvable groups"
+    ],
+    "nextSteps": [
+      "Formalize minimal-normal-subgroup existence for nontrivial finite groups",
+      "Prove minimal normal subgroup of finite solvable group is elementary abelian; close the p|d branch",
+      "Assemble full 0-axiom Hall's theorem from lifting step + abelian base case + minimal-normal structure"
+    ],
+    "progressSummary": "PROGRESS: Schur–Zassenhaus lifting step of Hall's theorem verified 0-axiom; parent false claim corrected; remaining gap pinpointed (minimal-normal-subgroup structure)."
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes, **with 0 axioms**, the inductive **lifting step** of Hall's theorem for solvable groups — the precise Schur–Zassenhaus mechanism that the parent entry `lagrange-theorem-oq-01-oq-03` axiomatized as `hall_solvable`.

**Main result** (`hall_lift_of_coprime`): if `N ⊴ G` is normal with `gcd(|N|, d) = 1`, and the quotient `G/N` has a subgroup of order `d`, then `G` has a subgroup of order `d`. The sharper `hall_lift_of_coprime_subgroup` locates it inside the preimage `π⁻¹(Q)` as a complement to `N`.

**Proof sketch:** set `L = π⁻¹(Q)`; show `|L| = |N|·d` via `card_mul_index` / `index_eq_card` / `index_comap_of_surjective`; then `N.subgroupOf L` has order `|N|` and index `d` inside `↥L`, so Schur–Zassenhaus (`Subgroup.exists_right_complement'_of_coprime`) yields a complement of order `d`, pushed back along `L.subtype`. Mirrors Mathlib's own internal `step1` recursion.

## Correction of a false claim in the parent entry

The parent axiomatized Hall's theorem citing "Schur–Zassenhaus not yet in Mathlib 4.26." **That is wrong** — Mathlib 4.26 provides it (`Subgroup.exists_right_complement'_of_coprime`), and sibling entries `lagrange-theorem-oq-03` and `sylow-theorem-oq-03` already use it. This PR corrects the parent's docstring and `meta.json` justification. The parent's axiom remains (the full theorem is still unproven), but the *reason* is now accurate: the real gap is minimal-normal-subgroup structure, not Schur–Zassenhaus.

## Verification

- `#print axioms` for all 4 theorems → only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). **0 axioms, 0 sorries.**
- Host-compiled against pinned Mathlib 4.26 oleans (Docker unavailable).

## Remaining gap toward a full 0-axiom Hall's theorem

Only the `p | d` branch is missing: existence of a *minimal* normal subgroup of a nontrivial finite group and its elementary-abelian structure in the solvable case. With that, this lifting step + the abelian base case (`lagrange-theorem-oq-03`) + the prime/cyclic cases (parent) assemble into a complete 0-axiom proof.

## Files

- `proofs/Proofs/LagrangeTheoremOQ01OQ03OQ01.lean` (new, 169 lines, 0 axioms)
- `src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json` (new gallery entry)
- `proofs/Proofs/LagrangeTheoremOQ01OQ03.lean` + its `meta.json` (false-claim correction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)