### PR TITLE
research(erdos-490-incomplete-01): repair build + reduce sorries 6→2 [0-axiom eliminations]

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -28,10 +28,12 @@
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
+import Mathlib.Order.Interval.Finset.Nat
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.NumberTheory.Primorial
 
 open Finset Real
+open scoped Classical
 
 namespace Erdos490
 
@@ -56,7 +58,7 @@ def ProductMapInjective (A B : Finset ℕ) : Prop :=
   ∀ a₁ a₂ b₁ b₂, a₁ ∈ A → a₂ ∈ A → b₁ ∈ B → b₂ ∈ B →
     a₁ * b₁ = a₂ * b₂ → (a₁ = a₂ ∧ b₁ = b₂)
 
-/-- The two definitions are equivalent. -/
+/- The two definitions `HasDistinctProducts` and `ProductMapInjective` are equivalent. -/
 /-
 ## Part II: The Erdős Question
 -/
@@ -75,13 +77,13 @@ where
       have hsub : A ⊆ Finset.Icc 1 N :=
         fun a ha => Finset.mem_Icc.mpr (hA a ha)
       calc A.card ≤ (Finset.Icc 1 N).card := Finset.card_le_card hsub
-        _ = N + 1 - 1 := by simp [Finset.card_Icc]
+        _ = N + 1 - 1 := by rw [Nat.card_Icc]
         _ = N := by omega
     have hBcard : B.card ≤ N := by
       have hsub : B ⊆ Finset.Icc 1 N :=
         fun b hb => Finset.mem_Icc.mpr (hB b hb)
       calc B.card ≤ (Finset.Icc 1 N).card := Finset.card_le_card hsub
-        _ = N + 1 - 1 := by simp [Finset.card_Icc]
+        _ = N + 1 - 1 := by rw [Nat.card_Icc]
         _ = N := by omega
     calc A.card * B.card ≤ N * N := Nat.mul_le_mul hAcard hBcard
       _ = N ^ 2 := by ring
@@ -126,17 +128,34 @@ def optimalB (N : ℕ) : Finset ℕ :=
 axiom optimal_has_distinct_products (N : ℕ) (hN : N ≥ 4) :
   HasDistinctProducts (optimalA N) (optimalB N)
 
-/-- The optimal example achieves |A||B| ~ N²/(2 log N). -/
-/-- Why it works: products a·p are distinct because primes are coprime to smaller numbers. -/
+/- The optimal example achieves |A||B| ~ N²/(2 log N). -/
+/-- Why it works: products `a·p` are distinct because each prime `p > N/2` exceeds
+every `a ≤ N/2`, so `p` cannot divide a nonzero `a`.  Positivity `1 ≤ aᵢ` (which holds
+for the elements of `optimalA`) is needed: without it `a₁ = a₂ = 0` gives `0 = 0` for
+any distinct primes. -/
 theorem optimal_works_because_primes (a₁ a₂ : ℕ) (p₁ p₂ : ℕ)
+    (ha₁_pos : 1 ≤ a₁) (ha₂_pos : 1 ≤ a₂)
     (ha₁ : a₁ ≤ N / 2) (ha₂ : a₂ ≤ N / 2)
     (hp₁ : Nat.Prime p₁) (hp₂ : Nat.Prime p₂)
     (hp₁_large : N / 2 < p₁) (hp₂_large : N / 2 < p₂)
     (heq : a₁ * p₁ = a₂ * p₂) : a₁ = a₂ ∧ p₁ = p₂ := by
-  -- If a₁p₁ = a₂p₂ with p₁, p₂ > N/2 and a₁, a₂ ≤ N/2, then p₁ | a₂p₂ = a₁p₁
-  -- Since p₁ > a₂, we must have p₁ | p₂, so p₁ = p₂ (both prime)
-  -- Then a₁ = a₂.
-  sorry
+  -- `p₁ ∣ a₂ * p₂ = a₁ * p₁`.  As `p₁` is prime, `p₁ ∣ a₂` or `p₁ ∣ p₂`.
+  -- `p₁ > N/2 ≥ a₂ ≥ 1`, so `p₁ ∣ a₂` is impossible (a positive multiple of `p₁`
+  -- is `≥ p₁ > a₂`).  Hence `p₁ ∣ p₂`, and both prime gives `p₁ = p₂`; cancelling
+  -- the nonzero `p₁` yields `a₁ = a₂`.
+  have ha₂_lt : a₂ < p₁ := lt_of_le_of_lt ha₂ hp₁_large
+  have hdvd : p₁ ∣ a₂ * p₂ := ⟨a₁, by rw [← heq]; ring⟩
+  have hp₁p₂ : p₁ = p₂ := by
+    rcases (hp₁.prime.dvd_mul.mp hdvd) with hda | hdp
+    · -- p₁ ∣ a₂ with 0 < a₂ < p₁ is impossible
+      have : p₁ ≤ a₂ := Nat.le_of_dvd (by omega) hda
+      omega
+    · exact (Nat.prime_dvd_prime_iff_eq hp₁ hp₂).mp hdp
+  refine ⟨?_, hp₁p₂⟩
+  -- cancel p₁ = p₂ (nonzero) from a₁ * p₁ = a₂ * p₂
+  have hp₁_pos : 0 < p₁ := hp₁.pos
+  have : a₁ * p₁ = a₂ * p₁ := by rw [heq, hp₁p₂]
+  exact Nat.eq_of_mul_eq_mul_right hp₁_pos this
 
 /-
 ## Part V: The Limit Question (Open)
@@ -150,7 +169,7 @@ noncomputable def productRatio (N : ℕ) : ℝ :=
 def LimitQuestion : Prop :=
   ∃ L : ℝ, Filter.Tendsto productRatio Filter.atTop (nhds L)
 
-/-- Van Doorn observed: If the limit exists, it must be ≥ 1. -/
+/- Van Doorn observed: If the limit exists, it must be ≥ 1. -/
 /-- The limit question is OPEN. -/
 def LimitQuestionOpen : Prop :=
   -- We don't know if the limit exists
@@ -164,14 +183,31 @@ def LimitQuestionOpen : Prop :=
 def IsMultiplicativeSidon (A : Finset ℕ) : Prop :=
   HasDistinctProducts A A
 
-/-- For A = B, the bound is |A|² ≪ N²/log N, so |A| ≪ N/√(log N). -/
-/-- Primes are a multiplicative Sidon set. -/
-theorem primes_sidon (N : ℕ) :
-    let P := Finset.filter Nat.Prime (Finset.range (N + 1))
-    IsMultiplicativeSidon P := by
-  intro P
-  unfold IsMultiplicativeSidon HasDistinctProducts
-  sorry -- Unique factorization implies distinct products
+/- For A = B, the bound is |A|² ≪ N²/log N, so |A| ≪ N/√(log N). -/
+/-- The genuine multiplicative-Sidon property of the primes.  Note that the *ordered*
+notion `IsMultiplicativeSidon P = HasDistinctProducts P P` (`(productSet P P).card =
+|P|²`) is **false** for `|P| ≥ 2`, because commutativity collapses `p·q` and `q·p` to a
+single element of the product set (e.g. `P = {2,3}` gives `productSet = {4,6,9}` of card
+`3 ≠ 4 = |P|²`).  The correct statement is that a product of two primes determines the
+unordered pair: if `p₁·q₁ = p₂·q₂` with all four prime then `{p₁,q₁} = {p₂,q₂}`.  This is
+the honest "multiplicative Sidon" content, a direct consequence of prime divisibility. -/
+theorem primes_products_determine_pair {p₁ q₁ p₂ q₂ : ℕ}
+    (hp₁ : Nat.Prime p₁) (hq₁ : Nat.Prime q₁) (hp₂ : Nat.Prime p₂) (hq₂ : Nat.Prime q₂)
+    (h : p₁ * q₁ = p₂ * q₂) :
+    (p₁ = p₂ ∧ q₁ = q₂) ∨ (p₁ = q₂ ∧ q₁ = p₂) := by
+  -- `p₁ ∣ p₂ * q₂`, and `p₁` prime, so `p₁ = p₂` or `p₁ = q₂`; cancel and finish.
+  have hdvd : p₁ ∣ p₂ * q₂ := ⟨q₁, by rw [← h]⟩
+  rcases (hp₁.prime.dvd_mul.mp hdvd) with hd | hd
+  · -- p₁ = p₂
+    have hp₁p₂ : p₁ = p₂ := (Nat.prime_dvd_prime_iff_eq hp₁ hp₂).mp hd
+    refine Or.inl ⟨hp₁p₂, ?_⟩
+    rw [← hp₁p₂] at h
+    exact Nat.eq_of_mul_eq_mul_left hp₁.pos h
+  · -- p₁ = q₂
+    have hp₁q₂ : p₁ = q₂ := (Nat.prime_dvd_prime_iff_eq hp₁ hq₂).mp hd
+    refine Or.inr ⟨hp₁q₂, ?_⟩
+    rw [← hp₁q₂, Nat.mul_comm p₂ p₁] at h
+    exact Nat.eq_of_mul_eq_mul_left hp₁.pos h
 
 /-
 ## Part VII: Related Problems
@@ -193,7 +229,14 @@ noncomputable def multiplicativeEnergy (A B : Finset ℕ) : ℕ :=
     (fun ((a₁, a₂), (b₁, b₂)) => a₁ * b₁ = a₂ * b₂)
     |>.card
 
-/-- Distinct products means minimal energy. -/
+/-- Distinct products means minimal energy.  DEFERRED (genuine fiber-counting
+combinatorics, ~50–80 lines): the multiplicative energy is `∑_{p} r(p)²` where
+`r(p) = #{(a,b) ∈ A×B : ab = p}`, while `|A||B| = ∑_p r(p)` and
+`(productSet A B).card = #{p : r(p) > 0}`.  The diagonal already contributes `|A||B|`
+to the energy, so `energy = |A||B| ↔ every fiber has size ≤ 1 ↔ the product map is
+injective ↔ HasDistinctProducts`.  Formalizing requires `Finset.card_eq_sum_card_fiberwise`
+on the product map and a per-fiber `r(p)² = r(p) ↔ r(p) ≤ 1` argument; left for a
+follow-up session. -/
 theorem distinct_minimal_energy (A B : Finset ℕ) :
     HasDistinctProducts A B ↔ multiplicativeEnergy A B = A.card * B.card := by
   sorry
@@ -208,10 +251,10 @@ theorem trivial_bound (N : ℕ) (A B : Finset ℕ)
     A.card * B.card ≤ N^2 := by
   have hAN : A.card ≤ N :=
     (Finset.card_le_card (fun a ha => Finset.mem_Icc.mpr (hA a ha))).trans
-      (by simp [Finset.card_Icc]; omega)
+      (by rw [Nat.card_Icc]; omega)
   have hBN : B.card ≤ N :=
     (Finset.card_le_card (fun b hb => Finset.mem_Icc.mpr (hB b hb))).trans
-      (by simp [Finset.card_Icc]; omega)
+      (by rw [Nat.card_Icc]; omega)
   calc A.card * B.card ≤ N * N := Nat.mul_le_mul hAN hBN
     _ = N ^ 2 := (sq N).symm
 
@@ -272,11 +315,25 @@ theorem bound_is_optimal :
   · intro N hN
     use optimalA N, optimalB N
     constructor
-    · sorry  -- IsSubsetUpTo (optimalA N) N
+    · -- IsSubsetUpTo (optimalA N) N : elements satisfy 1 ≤ n ≤ N/2 ≤ N
+      intro a ha
+      simp only [optimalA, Finset.mem_filter, Finset.mem_range] at ha
+      obtain ⟨_, ha1, ha2⟩ := ha
+      exact ⟨ha1, le_trans ha2 (Nat.div_le_self N 2)⟩
     constructor
-    · sorry  -- IsSubsetUpTo (optimalB N) N
+    · -- IsSubsetUpTo (optimalB N) N : primes p with N/2 < p ≤ N satisfy 1 ≤ p ≤ N
+      intro b hb
+      simp only [optimalB, Finset.mem_filter, Finset.mem_range] at hb
+      obtain ⟨_, hbprime, _, hbN⟩ := hb
+      exact ⟨hbprime.one_lt.le, hbN⟩
     constructor
     · exact optimal_has_distinct_products N (by linarith)
-    · sorry  -- Lower bound
+    · -- Lower bound. DEFERRED (requires prime-counting / PNT-level input): one needs
+      -- |optimalA N| = ⌊N/2⌋ and |optimalB N| = π(N) − π(N/2) ~ N/(2 log N), so the
+      -- product is ~ N²/(4 log N).  The lower bound on π(N) − π(N/2) is a Chebyshev /
+      -- Bertrand-type estimate not yet wired in here; left for a follow-up session.
+      -- (Note: the constant 1/3 chosen above is only attainable asymptotically and
+      -- with the sharper N²/(4 log N) main term would need adjusting to ≤ 1/4.)
+      sorry
 
 end Erdos490

--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -1,0 +1,51 @@
+# erdos-490-incomplete-01 — knowledge
+
+## Problem
+Completion task for `proofs/Proofs/Erdos490Problem.lean` (Erdős #490: distinct products
+of two sets, |A||B| ≪ N²/log N, Szemerédi 1976). The file was committed BROKEN against
+the current Mathlib pin and carried 6 sorries.
+
+## Session 2026-06-28 (researcher-8) — build repair + 4 sorries eliminated (6 → 2)
+**Build repair** (file did not compile against pinned Mathlib 4.26):
+- 4 orphan `/--` doc-comments before block comments / other doc-comments caused
+  `unexpected token '/--'; expected 'lemma'` → changed the leading ones to plain `/- -/`.
+- `Finset.card_Icc` renamed → `Nat.card_Icc` (4 sites); the `simp [Finset.card_Icc]; omega`
+  calls became `rw [Nat.card_Icc]; omega` (avoids "No goals" after simp closes it).
+- `maxProductSize` uses `Nat.find` over a ∀-quantified (undecidable) predicate →
+  added `open scoped Classical` for the `DecidablePred` instance.
+- Added `import Mathlib.Order.Interval.Finset.Nat` for `Nat.card_Icc`.
+
+**Sorries eliminated (4), all 0-axiom (propext/Classical.choice/Quot.sound):**
+- `optimal_works_because_primes` was FALSE as stated (a₁=a₂=0 gives 0=0 for distinct
+  primes). Added hypotheses `1 ≤ a₁, 1 ≤ a₂` (true for elements of optimalA) and proved
+  it: p₁ ∣ a₂·p₂ = a₁·p₁, p₁ prime + p₁ > N/2 ≥ a₂ rules out p₁∣a₂, so p₁∣p₂ ⇒ p₁=p₂,
+  then cancel (`Nat.eq_of_mul_eq_mul_right`).
+- The two `IsSubsetUpTo (optimalA/optimalB N) N` subgoals in `bound_is_optimal`:
+  unfold the filter membership, `Nat.div_le_self` / `Nat.Prime.one_lt.le`.
+- `primes_sidon` was FALSE as stated (ordered `HasDistinctProducts P P` = card P² fails
+  since p·q = q·p collapses in the product SET; P={2,3} → card 3 ≠ 4). Replaced with the
+  correct `primes_products_determine_pair`: p₁q₁=p₂q₂ all prime ⇒ {p₁,q₁}={p₂,q₂}
+  (prime divisibility, `Nat.prime_dvd_prime_iff_eq` + cancel).
+
+**Remaining 2 sorries (genuinely hard, documented in-file):**
+- `distinct_minimal_energy`: HasDistinctProducts ↔ energy = |A||B|. Fiber-counting
+  (energy = ∑ r(p)², |A||B| = ∑ r(p)); ~50–80 lines via card_eq_sum_card_fiberwise.
+- `bound_is_optimal` lower bound: needs |optimalB| = π(N)−π(N/2) ~ N/(2 log N), a
+  Chebyshev/PNT prime-count estimate not wired in. (Constant 1/3 likely needs ≤1/4.)
+
+**2 axioms remain** (deep, correctly axiomatized): `szemeredi_theorem` (Szemerédi 1976),
+`optimal_has_distinct_products`.
+
+Build: host `lake env lean` exit 0. Gallery meta `src/data/proofs/erdos-490/meta.json`
+updated: sorries 6→2, lineCount 282→339.
+
+### Gotchas
+- `rw [← hp₁p₂] at h` (not in the goal) to substitute the RHS prime, then
+  `Nat.eq_of_mul_eq_mul_left p.pos h` to cancel.
+- A committed gallery file marked complete may be both build-broken AND carry
+  sorries on FALSE statements — verify each "sorry" is actually provable before
+  attempting; restate (don't `sorry`) mis-stated lemmas.
+
+## Still open (NOT done here)
+- distinct_minimal_energy fiber-counting; bound_is_optimal PNT lower bound.
+- Erdos490OQ01.lean carries 3 axioms (separate, untouched).

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 2,
     "erdosNumber": 490,
     "erdosUrl": "https://erdosproblems.com/490",
     "erdosProblemStatus": "solved",
@@ -68,8 +68,8 @@
       "bound_is_optimal: matching lower bound (partially proved)"
     ],
     "axiomCount": 2,
-    "lineCount": 282,
-    "assumptions": "2 axiom(s) and 6 sorry(s). See the Lean source for details.",
+    "lineCount": 339,
+    "assumptions": "2 axioms (szemeredi_theorem — Szemerédi 1976, deep; optimal_has_distinct_products — the optimal example has distinct products, deep) and 2 sorries (distinct_minimal_energy — multiplicative-energy fiber-counting; bound_is_optimal lower bound — needs a Chebyshev/PNT prime-count estimate). Reduced from 6 sorries (2026-06-28, researcher-8): repaired the build against the current Mathlib pin (orphan doc-comments, Finset.card_Icc → Nat.card_Icc, DecidablePred via open scoped Classical) and eliminated 4 sorries with 0-axiom proofs — optimal_works_because_primes (positivity-corrected and proved), the two IsSubsetUpTo subgoals, and a false primes_sidon claim replaced by the correct primes_products_determine_pair (product of two primes determines the unordered pair).",
     "theoremCount": 10,
     "definitionCount": 15,
     "additionalFiles": [
@@ -202,12 +202,12 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 282,
+    "lineCount": 339,
     "axiomCount": 2,
     "theoremCount": 10,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
-    "sorries": 6,
+    "sorries": 2,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
       "Proofs/Erdos490Aristotle.lean"

--- a/src/data/research/problems/erdos-490-incomplete-01.json
+++ b/src/data/research/problems/erdos-490-incomplete-01.json
@@ -1,0 +1,83 @@
+{
+  "slug": "erdos-490-incomplete-01",
+  "title": "Erdős #490 (distinct products): build repair + sorry reduction",
+  "status": "progress",
+  "phase": "ACT",
+  "path": "fast",
+  "tier": "B",
+  "significance": 5,
+  "tractability": 6,
+  "started": "2026-06-28T00:00:00.000Z",
+  "lastUpdate": "2026-06-28T00:00:00.000Z",
+  "tags": [
+    "number-theory",
+    "combinatorics",
+    "erdos",
+    "multiplicative-energy",
+    "szemeredi",
+    "completion"
+  ],
+  "problemStatement": {
+    "formal": "A,B \\subseteq \\{1,\\dots,N\\} \\text{ with all products } ab \\text{ distinct} \\Rightarrow |A||B| \\ll N^2/\\log N \\text{ (Szemerédi 1976).}",
+    "plain": "Erdős #490: if A, B ⊆ {1,...,N} have all products ab distinct, then |A||B| ≪ N²/log N. The Lean file formalizes the statement, the optimal example, and supporting lemmas; Szemerédi's theorem itself and the optimal-example distinct-products fact are axiomatized. This task repairs the build and discharges tractable sorries.",
+    "whyMatters": [
+      "Keeps a committed gallery file building against the current Mathlib pin.",
+      "Eliminates sorries that were tractable (and corrects two mis-stated lemmas), improving the file's integrity."
+    ]
+  },
+  "currentState": {
+    "summary": "IN PROGRESS. Repaired the build (orphan doc-comments, Finset.card_Icc → Nat.card_Icc, DecidablePred via open scoped Classical) and reduced sorries 6 → 2 with 0-axiom proofs (optimal_works_because_primes fixed+proved, two IsSubsetUpTo subgoals, false primes_sidon replaced by correct primes_products_determine_pair). 2 deep axioms and 2 hard sorries remain.",
+    "outcome": "progress"
+  },
+  "knowledge": {
+    "insights": [
+      "optimal_works_because_primes was false without positivity (a₁=a₂=0 ⇒ 0=0 for distinct primes); fixed by requiring 1 ≤ aᵢ.",
+      "primes_sidon was false: ordered HasDistinctProducts P P (card = |P|²) fails because p·q = q·p collapses in the product set; the correct statement is primes_products_determine_pair.",
+      "distinct_minimal_energy is a real iff but needs fiber-counting (energy = ∑ r(p)², |A||B| = ∑ r(p)); deferred.",
+      "the lower bound in bound_is_optimal needs π(N) − π(N/2) ~ N/(2 log N), a Chebyshev/PNT estimate; deferred."
+    ],
+    "builtItems": [
+      "Build repair: Nat.card_Icc, open scoped Classical, orphan-comment fixes (Erdos490Problem.lean)",
+      "optimal_works_because_primes: proved (Erdos490Problem.lean)",
+      "two IsSubsetUpTo subgoals in bound_is_optimal: proved",
+      "primes_products_determine_pair: new correct lemma replacing false primes_sidon"
+    ],
+    "mathlibGaps": [
+      "No prime-counting lower bound (π(N) − π(N/2)) readily available for the optimal-example lower bound."
+    ],
+    "nextSteps": [
+      "Prove distinct_minimal_energy via Finset.card_eq_sum_card_fiberwise on the product map.",
+      "Prove the bound_is_optimal lower bound using a Chebyshev-type prime count."
+    ],
+    "progressSummary": "PROGRESS 2026-06-28 (researcher-8): repaired build + reduced Erdos490Problem.lean sorries 6 → 2 (all eliminations 0-axiom), corrected two false lemma statements. 2 deep axioms + 2 hard sorries remain."
+  },
+  "knownResults": {
+    "established": [
+      "Szemerédi (1976): |A||B| ≪ N²/log N for distinct-product sets.",
+      "Optimal example A = [1,N/2], B = primes in (N/2,N] achieves ~ N²/(2 log N)."
+    ]
+  },
+  "references": {
+    "papers": [
+      "Erdős problem #490: https://www.erdosproblems.com/490",
+      "Szemerédi, On a problem of P. Erdős, J. Number Theory (1976)."
+    ]
+  },
+  "relatedProofs": [
+    "erdos-490",
+    "erdos-490-oq-01"
+  ],
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos490Problem.lean",
+      "filename": "Erdos490Problem.lean",
+      "lineCount": 339,
+      "theoremCount": 10,
+      "axiomCount": 2,
+      "defCount": 15,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos490Problem.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Completion session for **erdos-490-incomplete-01** (Erdős #490 — distinct products of
two sets, |A||B| ≪ N²/log N). `proofs/Proofs/Erdos490Problem.lean` was committed
**broken against the current Mathlib 4.26 pin** and carried **6 sorries**. This PR
repairs the build and eliminates **4 sorries** with axiom-free proofs (6 → 2), correcting
two mis-stated lemmas in the process.

## Build repair
- 4 orphan `/--` doc-comments (placed before block comments / other doc-comments) caused
  `unexpected token '/--'` → changed the leading ones to plain `/- -/`.
- `Finset.card_Icc` renamed → `Nat.card_Icc` (4 sites); the `simp [...]; omega` calls
  became `rw [Nat.card_Icc]; omega`.
- `maxProductSize`'s `Nat.find` over a ∀-quantified (undecidable) predicate needs a
  `DecidablePred` instance → `open scoped Classical`; added
  `import Mathlib.Order.Interval.Finset.Nat`.

## Sorries eliminated (4, all 0-axiom)
- **`optimal_works_because_primes`** was **false** as stated (a₁=a₂=0 gives 0=0 for
  distinct primes). Added the positivity hypotheses `1 ≤ a₁, 1 ≤ a₂` (true for elements
  of `optimalA`) and proved it via prime divisibility + cancellation.
- The two **`IsSubsetUpTo (optimalA/optimalB N) N`** subgoals in `bound_is_optimal`.
- **`primes_sidon`** was **false** (the *ordered* `HasDistinctProducts P P` = `|P|²`
  fails because `p·q = q·p` collapse to one element of the product set; `P={2,3}` gives
  card 3 ≠ 4). Replaced by the correct **`primes_products_determine_pair`**: a product of
  two primes determines the unordered pair.

## Remaining (documented in-file)
- **2 axioms** (deep, correctly axiomatized): `szemeredi_theorem` (Szemerédi 1976),
  `optimal_has_distinct_products`.
- **2 sorries**: `distinct_minimal_energy` (multiplicative-energy fiber-counting),
  `bound_is_optimal` lower bound (needs a Chebyshev/PNT prime-count estimate).

## Verification
`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos490Problem.lean` → exit 0.
`#print axioms` on the new proofs → `propext, Classical.choice, Quot.sound` only.
Gallery `src/data/proofs/erdos-490/meta.json` updated: sorries 6 → 2, lineCount 282 → 339.

## Status
**Outcome**: progress (build repaired, 4/6 sorries eliminated, 2 false lemmas corrected).
**Next steps**: `distinct_minimal_energy` fiber-counting; the PNT-level lower bound.

🤖 Generated by researcher-8