### PR TITLE
Enrich Hall's Theorem: Schur–Zassenhaus lifting step (lagrange-theorem-oq-01-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "lagrange-oq010301-sz-available",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-01",
+    "range": { "startLine": 76, "endLine": 79 },
+    "type": "context",
+    "title": "Schur–Zassenhaus Is Already in Mathlib",
+    "content": "This restates Mathlib's Subgroup.exists_right_complement'_of_coprime: a normal subgroup N whose order is coprime to its index has a complement K (so N ∩ K = ⊥ and NK = G). The parent gallery entry axiomatized Hall's theorem on the premise that Schur–Zassenhaus was missing from Mathlib 4.26; exhibiting it here as a one-line proof refutes that premise and removes the supposed need for an axiom. Schur–Zassenhaus is the engine of the coprime branch of Hall's induction.",
+    "mathContext": "$$\\gcd(|N|, [G:N]) = 1 \\implies \\exists K,\\ N \\cap K = \\bot \\ \\wedge\\ N \\vee K = \\top.$$",
+    "significance": "key",
+    "relatedConcepts": ["Schur–Zassenhaus theorem", "complement of a subgroup", "coprime order and index"],
+    "prerequisites": ["normal subgroup", "subgroup complement", "Nat.Coprime"]
+  },
+  {
+    "id": "lagrange-oq010301-preimage",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-01",
+    "range": { "startLine": 95, "endLine": 104 },
+    "type": "technique",
+    "title": "The Preimage L = π⁻¹(Q) Contains N",
+    "content": "The lift works inside L, the preimage of the quotient subgroup Q under the quotient map π : G → G/N. Because N is exactly the kernel of π, every element of N maps to the identity of G/N, which lies in Q; hence N ≤ L. This containment is what lets N be relativized to a normal subgroup of ↥L in the next steps, where Schur–Zassenhaus is actually applied.",
+    "mathContext": "$$L = \\pi^{-1}(Q),\\qquad N = \\ker\\pi \\le L.$$",
+    "significance": "supporting",
+    "relatedConcepts": ["quotient map", "kernel", "Subgroup.comap", "preimage subgroup"],
+    "prerequisites": ["QuotientGroup.mk'", "Subgroup.mem_comap", "QuotientGroup.eq_one_iff"]
+  },
+  {
+    "id": "lagrange-oq010301-card-L",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-01",
+    "range": { "startLine": 105, "endLine": 118 },
+    "type": "insight",
+    "title": "Counting the Preimage: |L| = |N|·d",
+    "content": "The order of the preimage is pinned down purely by index arithmetic. Surjectivity of π gives [G:L] = [G/N:Q] (index_comap_of_surjective). Two applications of the identity |H|·[G:H] = |G| (card_mul_index) — once for L, once for N together with |Q| = d — show |L|·[G:L] and (|N|·d)·[G:L] both equal |G|, so cancelling the common nonzero factor [G:L] yields |L| = |N|·d. No structure theory is used; it is bookkeeping on the multiplicative index identity.",
+    "mathContext": "$$|L|\\cdot[G:L] = |G| = (|N|\\cdot d)\\cdot[G:L] \\implies |L| = |N|\\cdot d.$$",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange's theorem", "subgroup index", "card_mul_index", "index_comap_of_surjective"],
+    "prerequisites": ["Subgroup.index", "Nat.eq_of_mul_eq_mul_right", "finite group order"]
+  },
+  {
+    "id": "lagrange-oq010301-relativize",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-01",
+    "range": { "startLine": 119, "endLine": 133 },
+    "type": "technique",
+    "title": "Relativizing N Inside ↥L: Index d, Order |N|",
+    "content": "To apply Schur–Zassenhaus inside L rather than G, N is transported to N.subgroupOf L, the copy of N living in the subgroup type ↥L. Its order is unchanged (|N.subgroupOf L| = |N|, since mapping it back via L.subtype recovers N exactly because N ≤ L), and its index inside ↥L is |L|/|N| = d. Therefore the coprimality gcd(|N|, d) = 1 transfers verbatim to gcd(|N.subgroupOf L|, [L : N.subgroupOf L]) = 1 — exactly the hypothesis Schur–Zassenhaus demands.",
+    "mathContext": "$$|N.\\mathrm{subgroupOf}\\,L| = |N|,\\qquad [L : N.\\mathrm{subgroupOf}\\,L] = \\frac{|L|}{|N|} = d.$$",
+    "significance": "key",
+    "relatedConcepts": ["Subgroup.subgroupOf", "relativized subgroup", "index inside a subgroup", "coprimality transfer"],
+    "prerequisites": ["Subgroup.subgroupOf_map_subtype", "Subgroup.card_subtype", "card_mul_index"]
+  },
+  {
+    "id": "lagrange-oq010301-apply-sz",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-01",
+    "range": { "startLine": 134, "endLine": 143 },
+    "type": "insight",
+    "title": "Applying Schur–Zassenhaus and Pushing the Complement Back",
+    "content": "With the coprimality in hand, Schur–Zassenhaus inside ↥L produces a complement KL to N.subgroupOf L. Multiplicativity of the complement (hKL.card_mul: |N.subgroupOf L|·|KL| = |L|) forces |KL| = |L|/|N| = d. Finally KL is pushed forward to G along the inclusion L.subtype: the image KL.map L.subtype lies inside L (hence inside the preimage of Q) and preserves cardinality, giving the desired order-d subgroup of G. This forward image is the lifted Hall subgroup.",
+    "mathContext": "$$|N.\\mathrm{subgroupOf}\\,L|\\cdot|K_L| = |L| \\implies |K_L| = d,\\qquad |K_L.\\mathrm{map}\\,L.\\mathrm{subtype}| = d.$$",
+    "significance": "key",
+    "relatedConcepts": ["subgroup complement", "IsComplement'.card_mul", "Subgroup.map", "Hall subgroup lift"],
+    "prerequisites": ["exists_right_complement'_of_coprime", "map_subtype_le", "Subgroup.card_subtype"]
+  },
+  {
+    "id": "lagrange-oq010301-existence",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-01",
+    "range": { "startLine": 145, "endLine": 154 },
+    "type": "concept",
+    "title": "The Existence Form of the Lifting Step",
+    "content": "hall_lift_of_coprime is the clean statement of the induction step: if N ⊴ G is normal with |N| coprime to d, and G/N has a subgroup of order d, then G has a subgroup of order d. It simply forgets the extra containment information from the subgroup form. This is the exact proposition the parent entry assumed as the axiom hall_solvable for the coprime branch — now a theorem.",
+    "mathContext": "$$N \\trianglelefteq G,\\ \\gcd(|N|,d)=1,\\ \\bigl(\\exists Q \\le G/N,\\ |Q| = d\\bigr) \\implies \\exists K \\le G,\\ |K| = d.$$",
+    "significance": "supporting",
+    "relatedConcepts": ["Hall's theorem", "induction on group order", "Hall subgroup"],
+    "prerequisites": ["normal subgroup", "quotient group", "subgroup of given order"]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
@@ -35,6 +35,52 @@
     ],
     "proofStrategy": "Hall's existence proof inducts on |G| using a (minimal) normal subgroup N. In the branch where the prime dividing N does not divide the target order d (equivalently gcd(|N|, d) = 1), one lifts the order-d subgroup of G/N to G. This file formalizes exactly that lift: set L = π⁻¹(Q) for the quotient map π : G → G/N and the order-d subgroup Q ≤ G/N. Then N ≤ L (kernel lands in the preimage), and a card computation via card_mul_index, index_eq_card, and index_comap_of_surjective gives |L| = |N|·d. Viewing N as N.subgroupOf L, its index in L is d and its order is |N|, so gcd(|N.subgroupOf L|, (N.subgroupOf L).index) = gcd(|N|, d) = 1. Schur–Zassenhaus (Subgroup.exists_right_complement'_of_coprime) applied inside ↥L yields a complement KL of order d; pushing KL forward along L.subtype gives the required subgroup of G. The construction mirrors the internal step1 recursion of Mathlib's own Schur–Zassenhaus proof."
   },
+  "overview": {
+    "historicalContext": "Philip Hall's theorem (1928) is the great extension of Sylow's theorems from prime powers to arbitrary coprime divisors, valid precisely for **solvable** groups: a finite solvable group of order $n$ contains a subgroup of every order $d \\mid n$ with $\\gcd(d, n/d) = 1$ — a *Hall subgroup*. (The solvability hypothesis is essential: $A_5$, of order $60$, has no subgroup of order $15$.) The classical proof inducts on $|G|$ through a minimal normal subgroup $N$, which in a solvable group is elementary abelian, and splits into two cases according to whether the prime dividing $|N|$ also divides the target order $d$. The coprime case is handled by the **Schur–Zassenhaus theorem** — Issai Schur (1904) for abelian kernels, Hans Zassenhaus (1937) in general — which says a normal subgroup whose order is coprime to its index always has a complement. This entry isolates exactly that Schur–Zassenhaus lifting step and verifies it with zero axioms, and in doing so corrects the parent gallery entry, which had axiomatized Hall's theorem citing a (false) claim that Schur–Zassenhaus was absent from Mathlib 4.26.",
+    "problemStatement": "Formalize, with no axioms, the inductive lifting step of Hall's theorem: given a finite group $G$, a normal subgroup $N \\trianglelefteq G$, and a subgroup $Q \\le G/N$ of order $d$ with $\\gcd(|N|, d) = 1$, produce a subgroup $K \\le G$ of order $d$ (lying inside the preimage $\\pi^{-1}(Q)$). This is the precise mechanism the parent entry `lagrange-theorem-oq-01-oq-03` axiomatized as `hall_solvable`; the open question is which parts of a fully axiom-free Hall's theorem are already reachable in Mathlib 4.26 and which genuinely are not.",
+    "proofStrategy": "Set $L = \\pi^{-1}(Q)$ for the quotient map $\\pi : G \\to G/N$. The kernel $N$ lands in every preimage, so $N \\le L$; surjectivity of $\\pi$ gives $[G:L] = [G/N : Q]$ via `index_comap_of_surjective`, and the multiplicativity identity `card_mul_index` then forces $|L| = |N| \\cdot d$. Transporting $N$ to $N.\\mathrm{subgroupOf}\\,L$ preserves cardinality ($|N|$) and yields index $d$ inside $L$, so $\\gcd\\bigl(|N.\\mathrm{subgroupOf}\\,L|, [L : N.\\mathrm{subgroupOf}\\,L]\\bigr) = \\gcd(|N|, d) = 1$. Schur–Zassenhaus (`Subgroup.exists_right_complement'_of_coprime`) applied **inside** $\\uparrow L$ produces a complement $K_L$, whose order is $|L|/|N| = d$; pushing it forward along `L.subtype` gives the required order-$d$ subgroup of $G$. The construction mirrors the `step1` recursion inside Mathlib's own Schur–Zassenhaus development.",
+    "keyInsights": [
+      "**The lift is Schur–Zassenhaus relativized to a preimage.** Rather than complementing $N$ in all of $G$, one complements the *relativized* copy $N.\\mathrm{subgroupOf}\\,L$ inside the preimage $L = \\pi^{-1}(Q)$. The complement automatically has order $|L|/|N| = d$, which is exactly the Hall subgroup being lifted.",
+      "**The whole step is bookkeeping on indices and orders.** Every nontrivial fact reduces to the single multiplicative identity $|H| \\cdot [G:H] = |G|$ (`card_mul_index`) applied to $N$, $Q$, $L$, and $N.\\mathrm{subgroupOf}\\,L$; coprimality is then inherited verbatim from $\\gcd(|N|,d)=1$.",
+      "**The coprime branch is the *easy* half of Hall's induction.** Because Schur–Zassenhaus is fully available in Mathlib, this branch needs no new theory. The genuine obstruction to a 0-axiom Hall's theorem is the other branch ($p \\mid d$), which requires minimal-normal-subgroup structure (elementary-abelianness) that Mathlib still lacks.",
+      "**A documentation correction is part of the mathematical content.** The parent entry axiomatized Hall's theorem on the false premise that Schur–Zassenhaus was missing from Mathlib 4.26; `schur_zassenhaus_available` exhibits `Subgroup.exists_right_complement'_of_coprime` directly, turning a believed axiom into a proved lemma.",
+      "**Solvability enters only through the missing branch.** Nothing in this lifting step uses solvability — it holds for any finite $G$, normal $N$, and coprime $d$. Solvability is what guarantees a minimal normal subgroup is elementary abelian, which is needed only to start and to close the $p \\mid d$ branch."
+    ]
+  },
+  "sections": [
+    {
+      "id": "schur-zassenhaus-available",
+      "title": "Schur–Zassenhaus Is Available in Mathlib",
+      "startLine": 68,
+      "endLine": 79,
+      "summary": "schur_zassenhaus_available restates Mathlib's Subgroup.exists_right_complement'_of_coprime: a normal subgroup whose order is coprime to its index has a complement. This documents — against the parent entry's claim — that Schur–Zassenhaus needs no axiom.",
+      "mathContext": "$\\gcd(|N|, [G:N]) = 1 \\implies \\exists K,\\ N.\\mathrm{IsComplement'}\\,K.$"
+    },
+    {
+      "id": "lifting-step-subgroup",
+      "title": "The Lifting Step (Subgroup Form)",
+      "startLine": 85,
+      "endLine": 143,
+      "summary": "hall_lift_of_coprime_subgroup: with N ⊴ G normal and Q ≤ G/N of order d coprime to |N|, the preimage L = π⁻¹(Q) contains a subgroup of order d. Proven by computing |L| = |N|·d, relativizing N to N.subgroupOf L (index d), applying Schur–Zassenhaus inside ↥L, and pushing the complement forward along L.subtype.",
+      "mathContext": "$L = \\pi^{-1}(Q),\\quad |L| = |N|\\cdot d,\\quad [L : N.\\mathrm{subgroupOf}\\,L] = d.$"
+    },
+    {
+      "id": "lifting-step-existence",
+      "title": "The Lifting Step (Existence Form)",
+      "startLine": 145,
+      "endLine": 154,
+      "summary": "hall_lift_of_coprime: the clean existence statement — if N ⊴ G is normal with |N| coprime to d and G/N has a subgroup of order d, then so does G. Obtained by forgetting the containment in the subgroup form.",
+      "mathContext": "$N \\trianglelefteq G,\\ \\gcd(|N|,d)=1,\\ (\\exists Q \\le G/N,\\ |Q|=d) \\implies \\exists K \\le G,\\ |K| = d.$"
+    },
+    {
+      "id": "sanity-specialization",
+      "title": "Sanity Specialization: Trivial Kernel",
+      "startLine": 156,
+      "endLine": 168,
+      "summary": "hall_lift_trivial_coprime: the degenerate case N = ⊥. Since gcd(1, d) = 1 always holds, a subgroup of order d in G/⊥ ≅ G lifts to one in G — confirming the lifting step specializes correctly.",
+      "mathContext": "$N = \\bot:\\ \\gcd(1, d) = 1$, so the lift is essentially the identity $G/\\bot \\cong G$."
+    }
+  ],
   "leanFile": {
     "path": "Proofs/LagrangeTheoremOQ01OQ03OQ01.lean",
     "imports": [


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-01-oq-03-oq-01` (quality 15 → standard depth, passes 0 → 1).

This entry had rich prose buried in non-standard meta fields but was **missing the schema fields the gallery renders**, scoring only 15. Added all of them:

## Changes
- **`overview`** (was absent): `historicalContext` (Hall 1928, Schur 1904 / Zassenhaus 1937, why solvability is essential — $ has no order-15 subgroup), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **`sections`** (was absent): 4 sections covering the whole Lean file — SZ availability, the lifting step (subgroup + existence forms), and the trivial-kernel sanity specialization.
- **`annotations.json`** (did not exist): 6 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, walking through the preimage  = \pi^{-1}(Q)$, the count $|L| = |N|\cdot d$, the relativization .\mathrm{subgroupOf}\,L$, and the Schur–Zassenhaus application + forward image.

## Integrity
No change to `status`/`badge`/`axiomCount` — remains `verified`/`verified`/0 axioms, matching the Lean file (0 sorries, uses Mathlib's `exists_right_complement'_of_coprime`, no structure-encoded assumptions). Existing `crossReferences` use the preferred `proofId` field (valid per `src/types/proof.ts`).

## Size
meta.json 13.5 KB (≪ 60 KB cap); 6 annotations, 5 keyInsights, 4 sections, 3 crossRefs — all under caps.

Math-agent PR; no `loom:review-requested` label (deployer merges directly).