### PR TITLE
research(binary-gcd-oq-01-oq-04-oq-02): symmetry of the step count + the b=1 slice [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BinaryGcdOQ01OQ04OQ02.lean
+++ b/proofs/Proofs/BinaryGcdOQ01OQ04OQ02.lean
@@ -1,0 +1,125 @@
+/-
+  Binary GCD: symmetry of the step count, and the `b = 1` slice closed form
+  Open Question OQ-02 of `binary-gcd-oq-01-oq-04`.
+
+  The sibling `BinaryGcdOQ01OQ04OQ01` characterised the `a = 1` slice
+  completely: `binaryGcdSteps 1 b = Nat.log 2 b + 1` (the binary bit-length).
+  It explicitly left open "the full two-argument worst-case set". A first
+  structural step toward that is the basic symmetry of the cost function,
+  which is *not* recorded in any sibling file even though the algorithm treats
+  its two arguments symmetrically.
+
+  **Main result `binaryGcdSteps_comm`.**
+      binaryGcdSteps a b = binaryGcdSteps b a   for all a b.
+  Proved by strong induction on `a + b`: in every branch of the recursion the
+  two unfoldings of `binaryGcdSteps (a+1) (b+1)` and `binaryGcdSteps (b+1) (a+1)`
+  reduce to recursive calls that are mirror images of each other, closed by the
+  induction hypothesis. The even/even, even/odd, odd/even branches map onto
+  their transposes directly; the odd/odd branch subtracts the smaller from the
+  larger in both orientations, so the `a > b` case of one side is the `b < a`
+  case of the other.
+
+  **Consequences (free from symmetry + the sibling's `a = 1` analysis).**
+  * `binaryGcdSteps_one_right_eq_log_succ`: `binaryGcdSteps a 1 = Nat.log 2 a + 1`
+    for every `a ≥ 1` — the `b = 1` slice is the same bit-length closed form.
+  * `binaryGcdSteps_one_right_eq_dyadic`: the `b = 1` cost depends only on the
+    bit-length of `a` (constant on each dyadic block `[2^n, 2^(n+1))`).
+  * `binaryGcdSteps_one_right_mono`: monotone non-decreasing in `a`.
+  * `binaryGcdSteps_one_right_pow2_sub_one`: `binaryGcdSteps (2^n - 1) 1 = n`.
+
+  All results are axiom-free (only the foundational `propext`/`Classical.choice`/
+  `Quot.sound`), 0 sorries.
+
+  References:
+  - Stein (1967), Binary GCD Algorithm
+  - BinaryGcdOQ01.lean (definition + upper bound),
+    BinaryGcdOQ01OQ04OQ01.lean (the `a = 1` slice closed form)
+-/
+import Mathlib
+import Proofs.BinaryGcdOQ01
+import Proofs.BinaryGcdOQ01OQ04OQ01
+
+namespace BinaryGcdOQ01OQ04OQ02
+
+open BinaryGcdOQ01 Nat
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: SYMMETRY OF THE BINARY-GCD STEP COUNT
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Fueled strong-induction core of symmetry. -/
+private theorem binaryGcdSteps_comm_aux :
+    ∀ n a b : ℕ, a + b ≤ n → binaryGcdSteps a b = binaryGcdSteps b a := by
+  intro n
+  induction n with
+  | zero =>
+    intro a b h
+    obtain ⟨rfl, rfl⟩ : a = 0 ∧ b = 0 := ⟨by omega, by omega⟩
+    rfl
+  | succ n ih =>
+    intro a b h
+    rcases a with _ | a'
+    · -- a = 0
+      simp [binaryGcdSteps]
+    · rcases b with _ | b'
+      · -- b = 0
+        simp [binaryGcdSteps]
+      · -- a = a'+1, b = b'+1: unfold both orientations and match branches
+        rw [binaryGcdSteps.eq_3, binaryGcdSteps.eq_3]
+        rcases lt_trichotomy a' b' with hlt | rfl | hgt
+        · -- a < b: the `a > b` branches are contradictory, the rest are transposes
+          split_ifs <;> first | (exfalso; omega) | (congr 1; apply ih; omega)
+        · -- a = b: both orientations unfold to the identical if-tree
+          rfl
+        · -- a > b: symmetric to the first case
+          split_ifs <;> first | (exfalso; omega) | (congr 1; apply ih; omega)
+
+/-- **Symmetry.** The binary-GCD step count is symmetric in its two arguments:
+    `binaryGcdSteps a b = binaryGcdSteps b a`. -/
+theorem binaryGcdSteps_comm (a b : ℕ) :
+    binaryGcdSteps a b = binaryGcdSteps b a :=
+  binaryGcdSteps_comm_aux (a + b) a b le_rfl
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: THE b = 1 SLICE (mirror of the a = 1 closed form)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **The `b = 1` slice closed form.** For every `a ≥ 1`,
+    `binaryGcdSteps a 1 = Nat.log 2 a + 1` — the same bit-length law as the
+    `a = 1` slice, now via symmetry. -/
+theorem binaryGcdSteps_one_right_eq_log_succ (a : ℕ) (ha : 1 ≤ a) :
+    binaryGcdSteps a 1 = Nat.log 2 a + 1 := by
+  rw [binaryGcdSteps_comm, BinaryGcdOQ01OQ04OQ01.binaryGcdSteps_one_eq_log_succ a ha]
+
+/-- The `b = 1` cost depends only on the bit-length of `a`: every `a` in the
+    dyadic block `[2^n, 2^(n+1))` takes exactly `n + 1` steps. -/
+theorem binaryGcdSteps_one_right_eq_dyadic {n a : ℕ}
+    (hlo : 2 ^ n ≤ a) (hhi : a < 2 ^ (n + 1)) :
+    binaryGcdSteps a 1 = n + 1 := by
+  rw [binaryGcdSteps_comm, BinaryGcdOQ01OQ04OQ01.binaryGcdSteps_one_eq_dyadic hlo hhi]
+
+/-- Monotonicity of the `b = 1` slice in `a`. -/
+theorem binaryGcdSteps_one_right_mono {a₁ a₂ : ℕ} (h1 : 1 ≤ a₁) (h : a₁ ≤ a₂) :
+    binaryGcdSteps a₁ 1 ≤ binaryGcdSteps a₂ 1 := by
+  rw [binaryGcdSteps_comm a₁ 1, binaryGcdSteps_comm a₂ 1]
+  exact BinaryGcdOQ01OQ04OQ01.binaryGcdSteps_one_mono h1 h
+
+/-- The family `(2^n - 1, 1)` takes exactly `n` steps — the transpose of the
+    parent worst-case family `(1, 2^n - 1)`. -/
+theorem binaryGcdSteps_one_right_pow2_sub_one {n : ℕ} (hn : 1 ≤ n) :
+    binaryGcdSteps (2 ^ n - 1) 1 = n := by
+  rw [binaryGcdSteps_comm, BinaryGcdOQ01OQ04OQ01.binaryGcdSteps_one_pow2_sub_one hn]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: SYMBOLIC CROSS-CHECKS (axiom-free)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Symmetry on a concrete asymmetric pair, derived (no `decide`). -/
+example : binaryGcdSteps 12 8 = binaryGcdSteps 8 12 := binaryGcdSteps_comm 12 8
+
+/-- The transposed worst-case `(7, 1) = (2^3 - 1, 1)` takes `3` steps. -/
+example : binaryGcdSteps 7 1 = 3 := by
+  have : (7 : ℕ) = 2 ^ 3 - 1 := by norm_num
+  rw [this, binaryGcdSteps_one_right_pow2_sub_one (by norm_num)]
+
+end BinaryGcdOQ01OQ04OQ02

--- a/src/data/proofs/binary-gcd-oq-01-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04-oq-02/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "symmetry",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 79,
+      "endLine": 86
+    },
+    "type": "theorem",
+    "title": "Symmetry of the Binary GCD step count",
+    "content": "binaryGcdSteps a b = binaryGcdSteps b a. Stein's recursion treats its two arguments symmetrically (the even/odd reductions and the subtract-smaller-from-larger rule are swap-invariant), so the step count does not depend on argument order. Proved by strong induction on a + b: both orientations of the (a+1, b+1) branch are unfolded and matched case by case, with a trichotomy isolating the odd/odd equal case.",
+    "mathContext": "\\\\text{binaryGcdSteps}(a,b) = \\\\text{binaryGcdSteps}(b,a)",
+    "significance": "key",
+    "relatedConcepts": [
+      "symmetry",
+      "Stein's algorithm",
+      "well-founded recursion",
+      "strong induction"
+    ]
+  },
+  {
+    "id": "b-one-closed-form",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 90,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "The b = 1 slice is the bit-length of a",
+    "content": "binaryGcdSteps a 1 = Nat.log 2 a + 1 for every a ≥ 1 — the exact transpose of the sibling's a = 1 closed form, obtained in one line from symmetry (binaryGcdSteps a 1 = binaryGcdSteps 1 a) plus OQ-01.",
+    "mathContext": "\\\\text{binaryGcdSteps}(a,1) = \\\\lfloor \\\\log_2 a \\\\rfloor + 1",
+    "significance": "key",
+    "relatedConcepts": [
+      "bit-length",
+      "worst case",
+      "dyadic blocks"
+    ]
+  },
+  {
+    "id": "transposed-family",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 109,
+      "endLine": 111
+    },
+    "type": "theorem",
+    "title": "Transposed worst-case family",
+    "content": "binaryGcdSteps (2^n - 1) 1 = n: the transpose of the parent's worst-case family (1, 2^n - 1), recovered as a corollary of symmetry and the b = 1 closed form.",
+    "mathContext": "\\\\text{binaryGcdSteps}(2^n-1,\\\\,1) = n",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Mersenne numbers",
+      "worst case",
+      "tight bounds"
+    ]
+  }
+]

--- a/src/data/proofs/binary-gcd-oq-01-oq-04-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04-oq-02/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "binary-gcd-oq-01-oq-04-oq-02",
+  "title": "Binary GCD: Symmetry of the Step Count and the b = 1 Slice",
+  "slug": "binary-gcd-oq-01-oq-04-oq-02",
+  "description": "Open question OQ-02 of binary-gcd-oq-01-oq-04. The sibling OQ-01 settled the a = 1 slice (binaryGcdSteps 1 b = Nat.log 2 b + 1) and explicitly left the full two-argument worst case open. A first structural step toward it is the basic symmetry of Stein's step count, which no sibling file records even though the algorithm treats its two arguments symmetrically: binaryGcdSteps a b = binaryGcdSteps b a for all a, b. It is proved by strong induction on a + b — in every branch of the recursion the two orientations reduce to mirror-image recursive calls closed by the induction hypothesis; the odd/odd case subtracts the smaller from the larger in both orientations, and the equal case unfolds to the identical if-tree. Symmetry immediately transfers the entire OQ-01 a = 1 analysis to the b = 1 slice: binaryGcdSteps a 1 = Nat.log 2 a + 1, the dyadic-block constancy, monotonicity in a, and the transposed worst-case family binaryGcdSteps (2^n - 1) 1 = n. Fully symbolic and axiom-free.",
+  "meta": {
+    "author": "researcher-2",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
+    "date": "2026-06-28",
+    "status": "verified",
+    "tags": [
+      "algorithms",
+      "number-theory",
+      "gcd",
+      "complexity",
+      "worst-case",
+      "symmetry",
+      "bit-length",
+      "open-question",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/BinaryGcdOQ01OQ04OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 125,
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "binaryGcdSteps.eq_3",
+        "description": "Equation lemma for the (a'+1, b'+1) branch of Stein's recursion; unfolded in BOTH orientations to compare them branch-by-branch.",
+        "module": "Proofs.BinaryGcdOQ01"
+      },
+      {
+        "theorem": "lt_trichotomy",
+        "description": "a' < b' ∨ a' = b' ∨ b' < a' — splits the odd/odd analysis so the equal case (identical if-tree) is handled separately from the two strict transposes.",
+        "module": "Mathlib.Order.Basic"
+      },
+      {
+        "theorem": "Nat.strong_induction_on",
+        "description": "Strong induction on ℕ used via an explicit a + b fuel parameter, since each recursive call strictly decreases a + b.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Stein's Binary GCD algorithm (1967) replaces Euclidean division by shifts and subtractions. The parent binary-gcd-oq-01-oq-04 verified one witness of worst-case tightness, and the sibling OQ-01 gave the exact a = 1 closed form (the bit-length law), explicitly leaving the full two-argument worst case open. This entry records the most basic structural fact that the two-argument analysis rests on but which had not been formalised: the step count is symmetric, binaryGcdSteps a b = binaryGcdSteps b a. Stein's recursion is visibly symmetric — the even/odd reduction rules and the subtract-smaller-from-larger rule are invariant under swapping the arguments — but turning that observation into a Lean theorem requires unfolding both orientations of the (a+1, b+1) branch and matching them case by case. Once proved, symmetry is a labour-saving device: the whole OQ-01 a = 1 analysis is reflected onto the b = 1 slice for free."
+  },
+  "sections": [
+    {
+      "id": "symmetry",
+      "title": "Symmetry of the step count",
+      "startLine": 47,
+      "endLine": 86,
+      "summary": "binaryGcdSteps_comm: binaryGcdSteps a b = binaryGcdSteps b a, via a fuelled strong induction on a + b (binaryGcdSteps_comm_aux). Both orientations of binaryGcdSteps.eq_3 are unfolded and split_ifs matches the branches; a lt_trichotomy on a' vs b' isolates the odd/odd equal case (identical if-tree) from the two strict transposes (closed by the IH).",
+      "mathContext": "Even/even → 1 + steps(a/2, b/2) vs 1 + steps(b/2, a/2); even/odd ↔ odd/even are transposes; odd/odd with a > b → 1 + steps((a-b)/2, b) matches the other orientation's b < a branch; a = b unfolds identically. Each recursive pair has strictly smaller argument sum, so the IH applies."
+    },
+    {
+      "id": "b-one-slice",
+      "title": "The b = 1 slice (mirror of the a = 1 closed form)",
+      "startLine": 88,
+      "endLine": 114,
+      "summary": "From symmetry plus OQ-01: binaryGcdSteps_one_right_eq_log_succ (binaryGcdSteps a 1 = Nat.log 2 a + 1 for a ≥ 1), binaryGcdSteps_one_right_eq_dyadic (constant n+1 on each dyadic block [2^n, 2^(n+1))), binaryGcdSteps_one_right_mono (monotone in a), and binaryGcdSteps_one_right_pow2_sub_one (the transposed worst-case family (2^n - 1, 1) takes n steps).",
+      "mathContext": "binaryGcdSteps a 1 = binaryGcdSteps 1 a = Nat.log 2 a + 1. The b = 1 cost depends only on the bit-length of a, so the worst case below 2^N is again an entire top dyadic block, now in the first argument."
+    },
+    {
+      "id": "cross-checks",
+      "title": "Symbolic cross-checks",
+      "startLine": 116,
+      "endLine": 124,
+      "summary": "Axiom-free spot checks: binaryGcdSteps 12 8 = binaryGcdSteps 8 12 (symmetry on a concrete asymmetric pair, no decide) and binaryGcdSteps 7 1 = 3 via the transposed worst-case corollary.",
+      "mathContext": "Concrete instances that exercise the symmetry theorem and the b = 1 closed form without native_decide."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "binary-gcd-oq-01-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Sibling OQ-01. It settled the a = 1 slice and left the two-argument worst case open; this file adds symmetry and uses OQ-01 to obtain the b = 1 slice (binaryGcdSteps a 1 = Nat.log 2 a + 1) and its dyadic/monotone/worst-case corollaries."
+    },
+    {
+      "targetId": "binary-gcd-oq-01",
+      "relationship": "depends-on",
+      "description": "Supplies the binaryGcdSteps definition and the equation lemma binaryGcdSteps.eq_3, whose (a'+1, b'+1) case is unfolded in both orientations to prove symmetry."
+    },
+    {
+      "targetId": "binary-gcd",
+      "relationship": "depends-on",
+      "description": "Underlying Stein Binary GCD algorithm whose step count is the object of study."
+    }
+  ],
+  "conclusion": {
+    "summary": "Stein's Binary GCD step count is symmetric: binaryGcdSteps a b = binaryGcdSteps b a, proved by strong induction on a + b with no axioms and no native_decide. Symmetry transfers the sibling's a = 1 closed form to the b = 1 slice, giving binaryGcdSteps a 1 = Nat.log 2 a + 1 and its worst-case consequences.",
+    "implications": "Symmetry halves any future two-argument worst-case analysis (it suffices to study a ≤ b) and shows the b = 1 slice is the exact transpose of the a = 1 slice. Combined with OQ-01 it pins both axis slices of the step-count surface to the bit-length law, a concrete step toward the still-open full two-argument worst case.",
+    "openProblems": "The full two-argument worst-case set of binaryGcdSteps (the maximum of binaryGcdSteps a b over a, b < N and its extremal configurations) remains open."
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BinaryGcdOQ01",
+      "Proofs.BinaryGcdOQ01OQ04OQ01"
+    ],
+    "opens": [
+      "BinaryGcdOQ01",
+      "Nat"
+    ],
+    "namespace": "BinaryGcdOQ01OQ04OQ02",
+    "lineCount": 125,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "substantiveTheoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BinaryGcdOQ01OQ04OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Stein, J.",
+      "title": "Computational problems associated with Racah algebra",
+      "year": "1967",
+      "note": "Journal of Computational Physics 1(3), 397-405. Original Binary GCD algorithm."
+    },
+    {
+      "authors": "Knuth, D.E.",
+      "title": "The Art of Computer Programming, Vol. 2: Seminumerical Algorithms",
+      "year": "1998",
+      "note": "Section 4.5.2. Analysis of GCD algorithms, including the Binary GCD step count."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "binaryGcdSteps_comm",
+      "type": "core",
+      "description": "Symmetry of Stein's Binary GCD step count in its two arguments",
+      "leanType": "(a b : ℕ) → binaryGcdSteps a b = binaryGcdSteps b a"
+    },
+    {
+      "name": "binaryGcdSteps_one_right_eq_log_succ",
+      "type": "core",
+      "description": "The b = 1 slice equals the binary bit-length of a (mirror of the a = 1 closed form, via symmetry)",
+      "leanType": "(a : ℕ) → 1 ≤ a → binaryGcdSteps a 1 = Nat.log 2 a + 1"
+    },
+    {
+      "name": "binaryGcdSteps_one_right_eq_dyadic",
+      "type": "supporting",
+      "description": "The b = 1 cost is constant n+1 on each dyadic block [2^n, 2^(n+1))",
+      "leanType": "{n a : ℕ} → 2^n ≤ a → a < 2^(n+1) → binaryGcdSteps a 1 = n + 1"
+    },
+    {
+      "name": "binaryGcdSteps_one_right_pow2_sub_one",
+      "type": "supporting",
+      "description": "The transposed worst-case family (2^n - 1, 1) takes exactly n steps",
+      "leanType": "{n : ℕ} → 1 ≤ n → binaryGcdSteps (2^n - 1) 1 = n"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

OQ-02 of `binary-gcd-oq-01-oq-04`. A new **0-axiom, 0-sorry** gallery entry establishing the **symmetry** of Stein's Binary GCD step count, plus the `b = 1` slice closed form that follows from it.

The sibling OQ-01 settled the `a = 1` slice (`binaryGcdSteps 1 b = Nat.log 2 b + 1`) and explicitly left "the full two-argument worst-case set" open. The most basic structural fact that any two-argument analysis rests on — but which no sibling file records — is that the step count does not depend on argument order:

```lean
theorem binaryGcdSteps_comm (a b : ℕ) : binaryGcdSteps a b = binaryGcdSteps b a
```

### Proof

Strong induction on `a + b`. Both orientations of the `(a+1, b+1)` branch of Stein's recursion are unfolded via `binaryGcdSteps.eq_3` and matched branch-by-branch with `split_ifs`; a `lt_trichotomy` on `a'` vs `b'` isolates the odd/odd **equal** case (both orientations unfold to the identical if-tree) from the two strict **transposes**, which close by the induction hypothesis on the strictly-smaller argument sum. The even/odd and odd/even branches are direct transposes; the odd/odd `a > b` branch matches the other orientation's `b < a` branch.

### Consequences (free from symmetry + OQ-01)

| Theorem | Statement |
|---|---|
| `binaryGcdSteps_one_right_eq_log_succ` | `binaryGcdSteps a 1 = Nat.log 2 a + 1` (`a ≥ 1`) |
| `binaryGcdSteps_one_right_eq_dyadic` | constant `n+1` on each dyadic block `[2^n, 2^(n+1))` |
| `binaryGcdSteps_one_right_mono` | monotone non-decreasing in `a` |
| `binaryGcdSteps_one_right_pow2_sub_one` | `binaryGcdSteps (2^n − 1) 1 = n` (transpose of the parent worst-case family `(1, 2^n − 1)`) |

So both axis slices of the step-count surface are now pinned to the bit-length law. The full two-argument worst case remains open.

## Files

- `proofs/Proofs/BinaryGcdOQ01OQ04OQ02.lean` (6 theorems, 0 axioms, 0 sorries, 125 lines)
- `src/data/proofs/binary-gcd-oq-01-oq-04-oq-02/{meta.json,annotations.json}` (new gallery entry)

## Verification

Host-verified against pinned Mathlib 4.26: `lake env lean` exit 0, **no warnings**, no sorries. `#print axioms` on `binaryGcdSteps_comm`, `binaryGcdSteps_one_right_eq_log_succ`, and `binaryGcdSteps_one_right_pow2_sub_one` shows only `propext / Classical.choice / Quot.sound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
