### PR TITLE
audit(erdos-1043): fix stale sorries field 2→0

### DIFF
--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -17,7 +17,7 @@
       "geometry"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 1043,
     "erdosUrl": "https://erdosproblems.com/1043",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-1043
**Problem**: `meta.meta.sorries` stale — claims 2, actual 0

## Evidence

- `meta.meta.sorries` = **2**
- `proofs/Proofs/Erdos1043Problem.lean`: **0** `sorry`, 2 `axiom` (`pommerenke_counterexample`, `pommerenke_upper_bound`)
- `proofs/Proofs/Erdos1043Aristotle.lean`: 0 `sorry`
- PR #31142 ("eliminate both sorries — prove levelSet_compact, fix FALSE levelSet_connected_iff") removed the two sorries but did not update the `sorries` field.

`status: axiomatized`, `badge: axiom`, `axiomCount: 2` already correctly describe the two axiom declarations. Only the `sorries` count was stale, which caused `find-targets.ts` to re-flag a sorry mismatch every audit cycle.

## Fix

Set `meta.meta.sorries` 2 → 0 to match the Lean source. No status/badge/axiom change (those are already correct).

---
Discovered during gallery integrity audit.