### PR TITLE
audit(gallery): record 3 flagged targets — 1 fixed, 2 honest FP

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3352,10 +3352,10 @@
       "result": "clean"
     },
     "erdos-1043": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-04T04:03:27Z",
-      "result": "clean"
+      "lastAudited": "2026-06-28T08:39:52Z",
+      "result": "issues-fixed"
     },
     "erdos-1044": {
       "auditCount": 4,
@@ -4925,9 +4925,9 @@
       "result": "clean"
     },
     "erdos-156": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-27T12:57:39Z",
+      "lastAudited": "2026-06-28T08:39:52Z",
       "result": "clean"
     },
     "erdos-157": {
@@ -25171,8 +25171,8 @@
       "issues": []
     },
     "erdos-57-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T15:01:50Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-28T08:39:52Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Gallery Audit — Tracker Update

Records audit results for the three entries that `find-targets.ts` flags every cycle.

| Entry | Result | Notes |
|-------|--------|-------|
| erdos-1043 | issues-fixed | Stale `sorries` 2→0, fixed in #31169 (sorries eliminated in #31142, field not updated) |
| erdos-57-oq-04 | clean | Shares `Erdos57Problem.lean` with base `erdos-57` (which owns `axiom erdos_57`). The oq-04 contribution is genuinely axiom-free and the host axiom is honestly disclosed in `assumptions`. The undercount flag is a file-level counting limitation, not an overclaim. |
| erdos-156 | clean | `formalized`/`wip`; `sorries: 3` matches the primary companion `Erdos156ProblemAristotle.lean`. The 0/15 main-vs-chain split is a 4-file counting artifact; `wip` badge is honest. |

Companion to #31169 (the erdos-1043 meta fix). Tracker edits don't survive concurrent `git reset --hard origin/main`, so they are persisted here as a committed PR.

---
Discovered during gallery integrity audit.