### PR TITLE
research(sperner-ndim-oq-02): facet combinatorics on sound GridSimplex carrier (d≥2) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -1218,4 +1218,155 @@ theorem gridVertices_finset_injective (hd : 2 ≤ d) :
       = ↑(Finset.univ.image (gridVertices t)) := by rw [h']
   simpa only [Finset.coe_image, Finset.coe_univ, Set.image_univ] using hcoe
 
+-- ============================================================
+-- SECTION: GridSimplex-direct facet combinatorics (`d ≥ 2`)
+-- ============================================================
+-- The facet section above (`facet`, `facet_injective`,
+-- `canon_eq_of_facet_and_vertex`, `facet_unique_neighbor`, …) is stated
+-- over the `CanonSimplex` carrier, whose existence failure for `d ≥ 2`
+-- (`SpernerNDimOQ02Obstruction.sBad_no_canon_rep`) makes it unsound as the
+-- door-counting carrier.  This section re-points the same combinatorics at the
+-- repaired `GridSimplex`-direct carrier, citing `gridVertices`,
+-- `gridVertices_injective`, and `grid_eq_of_vertices_range hd` in place of
+-- `vertices`, `vertices_injective`, and `canon_eq_of_vertices_range`.  The
+-- proofs are otherwise identical to the `CanonSimplex` versions — the carrier
+-- swap is the whole content.  The crux is `gridFacet_unique_neighbor` (the
+-- `adj_unique_facet` obligation: a neighbour is glued across at most one facet),
+-- now sound because no cell is omitted.  All 0-sorry; the `d ≥ 2` hypothesis
+-- enters only through `grid_eq_of_vertices_range`.
+
+/-- The `k`-th **facet** of a grid simplex on the `GridSimplex`-direct carrier:
+delete vertex `k`, push the rest through the Kuhn bridge.  GridSimplex analogue
+of `facet`. -/
+def gridFacet (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    Finset (SpernerNDim.Vertex d N) :=
+  (Finset.univ.erase k).image (gridVertices s)
+
+/-- Membership in a grid facet: a Kuhn vertex lies on `gridFacet s k` exactly
+when it is the image of some vertex `j ≠ k`. -/
+theorem mem_gridFacet_iff (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1))
+    (v : SpernerNDim.Vertex d N) :
+    v ∈ gridFacet s k ↔ ∃ j : Fin (d + 1), j ≠ k ∧ gridVertices s j = v := by
+  simp only [gridFacet, Finset.mem_image, Finset.mem_erase, Finset.mem_univ, and_true]
+
+/-- The deleted vertex is absent from its own grid facet. -/
+theorem gridVertices_not_mem_gridFacet (s : SpernerGrid.GridSimplex d N)
+    (k : Fin (d + 1)) : gridVertices s k ∉ gridFacet s k := by
+  rw [mem_gridFacet_iff]
+  rintro ⟨j, hjk, hj⟩
+  exact hjk (gridVertices_injective s hj)
+
+/-- Each grid facet carries exactly `d` vertices. -/
+theorem gridFacet_card (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    (gridFacet s k).card = d := by
+  rw [gridFacet, Finset.card_image_of_injective _ (gridVertices_injective s),
+    Finset.card_erase_of_mem (Finset.mem_univ k), Finset.card_univ, Fintype.card_fin]
+  omega
+
+/-- **The `d + 1` grid facets of a single cell are distinct.**  GridSimplex
+analogue of `facet_injective`; the within-cell half of `adj_unique_facet`. -/
+theorem gridFacet_injective (s : SpernerGrid.GridSimplex d N) :
+    Function.Injective (gridFacet s) := by
+  intro k₁ k₂ h
+  by_contra hne
+  have hmem : gridVertices s k₁ ∈ gridFacet s k₂ :=
+    (mem_gridFacet_iff s k₂ _).mpr ⟨k₁, hne, rfl⟩
+  rw [← h] at hmem
+  exact gridVertices_not_mem_gridFacet s k₁ hmem
+
+/-- The full vertex set of a grid cell is its `k`-th grid facet plus the deleted
+vertex `gridVertices s k`.  GridSimplex analogue of
+`image_univ_eq_insert_facet`. -/
+theorem gridImage_univ_eq_insert_gridFacet (s : SpernerGrid.GridSimplex d N)
+    (k : Fin (d + 1)) :
+    Finset.univ.image (gridVertices s) = insert (gridVertices s k) (gridFacet s k) := by
+  rw [gridFacet, ← Finset.image_insert, Finset.insert_erase (Finset.mem_univ k)]
+
+/-- The grid cell's Finset vertex set coerces to the range of its vertex map.
+GridSimplex analogue of `coe_image_univ_vertices`. -/
+theorem gridCoe_image_univ_vertices (s : SpernerGrid.GridSimplex d N) :
+    (↑(Finset.univ.image (gridVertices s)) : Set (SpernerNDim.Vertex d N))
+      = Set.range (gridVertices s) := by
+  rw [Finset.coe_image, Finset.coe_univ, Set.image_univ]
+
+/-- **A grid cell is determined by one facet and its opposite vertex (`d ≥ 2`).**
+GridSimplex analogue of `canon_eq_of_facet_and_vertex`, sound because no cell is
+omitted: both cells share the same full vertex set (facet ∪ {opposite vertex}),
+and `grid_eq_of_vertices_range hd` collapses that to cell equality. -/
+theorem grid_eq_of_facet_and_vertex (hd : 2 ≤ d) {s t : SpernerGrid.GridSimplex d N}
+    {k l : Fin (d + 1)}
+    (hface : gridFacet s k = gridFacet t l)
+    (hvert : gridVertices s k = gridVertices t l) : s = t := by
+  apply grid_eq_of_vertices_range hd
+  rw [← gridCoe_image_univ_vertices s, ← gridCoe_image_univ_vertices t,
+    gridImage_univ_eq_insert_gridFacet s k, gridImage_univ_eq_insert_gridFacet t l,
+    hface, hvert]
+
+/-- Two distinct grid facets of a cell union to all its vertices.  GridSimplex
+analogue of `facet_union_facet`. -/
+theorem gridFacet_union_gridFacet (s : SpernerGrid.GridSimplex d N)
+    {k₁ k₂ : Fin (d + 1)} (h : k₁ ≠ k₂) :
+    gridFacet s k₁ ∪ gridFacet s k₂ = Finset.univ.image (gridVertices s) := by
+  rw [gridFacet, gridFacet, ← Finset.image_union]
+  congr 1
+  apply Finset.eq_univ_of_forall
+  intro a
+  rw [Finset.mem_union, Finset.mem_erase, Finset.mem_erase]
+  by_cases ha : a = k₁
+  · exact Or.inr ⟨ha ▸ h, Finset.mem_univ _⟩
+  · exact Or.inl ⟨ha, Finset.mem_univ _⟩
+
+/-- A grid cell has exactly `d + 1` distinct Kuhn vertices.  GridSimplex
+analogue of `image_univ_card`. -/
+theorem gridImage_univ_card (s : SpernerGrid.GridSimplex d N) :
+    (Finset.univ.image (gridVertices s)).card = d + 1 := by
+  rw [Finset.card_image_of_injective _ (gridVertices_injective s), Finset.card_univ,
+    Fintype.card_fin]
+
+/-- **At most one neighbour across a grid facet (`adj_unique_facet`, `d ≥ 2`).**
+If a cell `s` shares two facets with the same other cell `t` (`s ≠ t`), then the
+two facet indices coincide.  GridSimplex analogue of `facet_unique_neighbor`,
+sound on the repaired carrier: the two distinct facets of `s` union to all of
+`s`'s vertices while both lie in `t`'s vertex set; equal cardinalities force
+equal vertex sets, and `grid_eq_of_vertices_range hd` gives `s = t`,
+contradicting `s ≠ t`. -/
+theorem gridFacet_unique_neighbor (hd : 2 ≤ d) {s t : SpernerGrid.GridSimplex d N}
+    {k₁ k₂ l₁ l₂ : Fin (d + 1)} (hne : s ≠ t)
+    (h₁ : gridFacet s k₁ = gridFacet t l₁) (h₂ : gridFacet s k₂ = gridFacet t l₂) :
+    k₁ = k₂ := by
+  by_contra hk
+  have hs : Finset.univ.image (gridVertices s) = gridFacet s k₁ ∪ gridFacet s k₂ :=
+    (gridFacet_union_gridFacet s hk).symm
+  have hsub : Finset.univ.image (gridVertices s) ⊆ Finset.univ.image (gridVertices t) := by
+    rw [hs, h₁, h₂]
+    apply Finset.union_subset
+    · rw [gridFacet]; exact Finset.image_subset_image (Finset.erase_subset _ _)
+    · rw [gridFacet]; exact Finset.image_subset_image (Finset.erase_subset _ _)
+  have hcard :
+      (Finset.univ.image (gridVertices t)).card ≤ (Finset.univ.image (gridVertices s)).card := by
+    rw [gridImage_univ_card, gridImage_univ_card]
+  have heq : Finset.univ.image (gridVertices s) = Finset.univ.image (gridVertices t) :=
+    Finset.eq_of_subset_of_card_le hsub hcard
+  apply hne
+  apply grid_eq_of_vertices_range hd
+  rw [← gridCoe_image_univ_vertices s, ← gridCoe_image_univ_vertices t, heq]
+
+/-- **Global facet/opposite-vertex coherence (`d ≥ 2`).**  The pair
+`(gridFacet s k, gridVertices s k)` identifies both the cell `s` and the index
+`k` across the entire `GridSimplex` carrier.  GridSimplex analogue of
+`facet_vertex_injective`: the cross-cell direction (`grid_eq_of_facet_and_vertex`)
+collapses the cell, then the within-cell direction (`gridFacet_injective`)
+collapses the index.  The `(facet, opposite-vertex)` payload of an `adj` entry
+names at most one `(cell, facet)` slot. -/
+theorem gridFacet_vertex_injective (hd : 2 ≤ d) :
+    Function.Injective
+      (fun p : SpernerGrid.GridSimplex d N × Fin (d + 1) =>
+        (gridFacet p.1 p.2, gridVertices p.1 p.2)) := by
+  rintro ⟨s, k⟩ ⟨t, l⟩ h
+  simp only [Prod.mk.injEq] at h
+  obtain ⟨hface, hvert⟩ := h
+  obtain rfl : s = t := grid_eq_of_facet_and_vertex hd hface hvert
+  obtain rfl : k = l := gridFacet_injective s hface
+  rfl
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1,5 +1,61 @@
 # sperner-ndim-oq-02: Boundary-Door Oddness by Dimensional Induction
 
+## Session 2026-06-28 (researcher-9, cont.) — Re-point the facet combinatorics onto the sound `GridSimplex` carrier (`d ≥ 2`)
+
+**Mode**: ACT (CONTINUE Phase-1, execute next-step 1 of prior session).
+**Outcome**: PROGRESS — added the "GridSimplex-direct facet combinatorics"
+section to `SpernerNDimOQ02.lean` (+10 decls: 1 `def gridFacet`, 9 theorems,
+~140 L). **Type-check VERIFIED via `lake env lean` against the worktree olean
+cache (EXIT 0, clean)**; **`#print axioms` obtained** — the crux decls
+(`gridFacet_unique_neighbor`, `gridFacet_vertex_injective`,
+`grid_eq_of_facet_and_vertex`, `gridFacet_injective`) depend only on
+`[propext, Classical.choice, Quot.sound]`, i.e. **genuinely 0-axiom**. Pushed
+to the same branch/PR **#31163**.
+
+### What was delivered
+
+The entire `CanonSimplex` facet section (`facet`, `mem_facet_iff`,
+`vertices_not_mem_facet`, `facet_card`, `facet_injective`,
+`image_univ_eq_insert_facet`, `coe_image_univ_vertices`,
+`canon_eq_of_facet_and_vertex`, `facet_union_facet`, `image_univ_card`,
+`facet_unique_neighbor`, `facet_vertex_injective`) re-stated over the repaired
+`GridSimplex`-direct carrier as `gridFacet`/`gridFacet_*`/`grid*`. The proofs
+are *mechanically identical* to the `CanonSimplex` versions — the only changes
+are `vertices → gridVertices`, `vertices_injective → gridVertices_injective`,
+and `canon_eq_of_vertices_range → grid_eq_of_vertices_range hd` (the `2 ≤ d`
+hypothesis threads through `grid_eq_of_facet_and_vertex`,
+`gridFacet_unique_neighbor`, `gridFacet_vertex_injective`).
+
+**Crux**: `gridFacet_unique_neighbor (hd : 2 ≤ d)` — the `adj_unique_facet`
+obligation (a neighbour is glued across at most one facet of `s`), now **sound**:
+the `CanonSimplex` version relied on `canon_eq_of_vertices_range`, whose carrier
+omits cells (existence failure, #31156); the GridSimplex version cites
+`grid_eq_of_vertices_range hd` with no such gap. `gridFacet_vertex_injective`
+packages the cross-cell + within-cell directions into the single injectivity of
+`p ↦ (gridFacet p.1 p.2, gridVertices p.1 p.2)`.
+
+### Why this matters (Phase-1)
+
+With this section, the full `(facet, opposite-vertex)` adjacency bookkeeping the
+door-counting argument needs is now available **on the sound carrier** for
+`d ≥ 2`. The remaining gap to a well-defined `adj` is: (a) define the neighbour
+map via finite facet-search over `GridSimplex` (`Fintype` available), wiring
+`pivotSimplex`/`pivot_involutive`/`pivot_facet_eq` (already carrier-agnostic, on
+`GridSimplex`) to `gridFacet`; (b) discharge the abstract compatibility fields
+using `gridFacet_card` (= d), `gridFacet_injective`, `gridFacet_unique_neighbor`,
+`gridFacet_vertex_injective`. The `CanonSimplex` facet lemmas can now be retired
+from the `d ≥ 2` path.
+
+### Next steps
+1. **(next)** Define `gridAdj`/the neighbour map by finite facet-search over
+   `GridSimplex d N`, pairing each interior `gridFacet s k` with the unique cell
+   sharing it (`pivotSimplex` supplies existence; `gridFacet_unique_neighbor`
+   supplies uniqueness).
+2. Assemble the abstract door-graph instance for `d ≥ 2` from the `gridFacet_*`
+   lemmas (`adj_card`, `adj_unique_facet`, `boundary_face`, …).
+3. Handle `d ≤ 1` base cases separately (orientation doubling is real there).
+4. Phase 2: last-face door oddness by induction on `d`; apply `sperner_ndim`.
+
 ## Session 2026-06-28 (researcher-9) — Sound carrier for `d ≥ 2`: drop `IsCanon`, use `GridSimplex` directly (`grid_eq_of_vertices_range`)
 
 **Mode**: ACT (CONTINUE Phase-1, execute the #31156 repair). **Outcome**:

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Phase-1 carrier-soundness blocker resolved for d≥2 — GridSimplex-direct carrier with grid_eq_of_vertices_range. Next: re-point facet/adj combinatorics; d≤1 base cases.",
+    "progressSummary": "PROGRESS: facet combinatorics re-pointed onto sound GridSimplex carrier for d≥2 (gridFacet_* section, 0-axiom); adj/door-graph assembly is the remaining Phase-1 gap",
     "builtItems": [
       "proofs/Proofs/SpernerNDimOQ02.lean (canonical-base selection, VERIFIED 0-axiom Session 9: lake env lean exit 0, #print axioms = [propext, Classical.choice, Quot.sound] only): vertexSet s := univ.image s.verts (+mem_vertexSet, vertexSet_nonempty); baseOf s := (exists_lex_min (vertexSet s) ..).choose (noncomputable, the lex-min vertex = recanonicalization target base) with baseOf_mem/baseOf_lexLE; baseOf_unique (lexLE_antisymm: any vertex lex-<= all equals baseOf); baseOf_eq_of_vertexSet_eq and baseOf_eq_of_range_eq (base depends only on the cell geometry, not the chain order — the maps well-definedness, phrased over Set.range to match IsCanon.geometry_unique); isCanon_baseOf_eq (on a canonical cell baseOf = verts 0) + baseOf_canon (CanonSimplex form). Step 1 of the recanonicalization map; the remaining piece is the re-sorted GridSimplex construction realizing this base.",
       "proofs/Proofs/SpernerNDimOQ02.lean (interior-pivot canonicality, VERIFIED 0-axiom Session 8: lake env lean exit 0, #print axioms = [propext, Classical.choice, Quot.sound] only): pivot_base_eq (the interior Freudenthal pivot fixes the lex-base verts 0 — it only updates verts a.succ and a.succ ≠ 0, by Function.update_of_ne (Fin.succ_ne_zero a).symm); pivot_isCanon_iff (given s canonical, IsCanon (pivotSimplex s a b hb) ⟺ (s.verts 0).lexLE (pivotPoint s a b ...) — the unchanged vertices already dominate the shared base, so only the one moved vertex needs checking). Reduces the d+1 canonicality conditions of the pivoted cell to one lex comparison — the recanonicalization test the CanonSimplex-level adj construction must perform.",
@@ -41,7 +41,8 @@
       "proofs/Proofs/SpernerNDimOQ02.lean (Session 3, VERIFIED): baryEquivVertex d N : BaryPoint d N ≃ Vertex d N (toVertex drops last bary coord, toBary appends slack N-∑); coord simp lemmas; onFace_toVertex (face correspondence); isSperner_iff (transports Sperner condition). 0 sorries, 0 new axioms. This is Option C step 0.",
       "SpernerGridBase.lean: factored GridSimplex foundation (structure+DecidableEq+Fintype+verts_injective+coord trackers, SpernerGrid lines 241-513) into clean base — verified 0-axiom",
       "SpernerGridBase.GridSimplex.incDir_const_before / last_coord_non_miss / last_coord_miss: every vertex = explicit fn of (verts 0, miss, incDir) — verified 0-axiom",
-      "proofs/Proofs/SpernerNDimOQ02.lean (VERIFIED 0-axiom): interior Freudenthal pivot — pivotPoint (opposite-corner vertex), pivotSimplex (full GridSimplex with all 5 Kuhn axioms via incDir∘swap a b + Function.update of the one moved vertex), pivot_facet_eq (deleted-vertex facet preserved), pivot_opposite_ne (moved vertex differs at incDir a), pivot_ne (different cell). #print axioms = [propext, Classical.choice, Quot.sound]."
+      "proofs/Proofs/SpernerNDimOQ02.lean (VERIFIED 0-axiom): interior Freudenthal pivot — pivotPoint (opposite-corner vertex), pivotSimplex (full GridSimplex with all 5 Kuhn axioms via incDir∘swap a b + Function.update of the one moved vertex), pivot_facet_eq (deleted-vertex facet preserved), pivot_opposite_ne (moved vertex differs at incDir a), pivot_ne (different cell). #print axioms = [propext, Classical.choice, Quot.sound].",
+      "GridSimplex-direct facet combinatorics for d≥2 in SpernerNDimOQ02.lean: gridFacet + 9 thms (gridFacet_card=d, gridFacet_injective, gridFacet_unique_neighbor, grid_eq_of_facet_and_vertex, gridFacet_vertex_injective). Mechanical re-point of the CanonSimplex facet section onto the sound carrier; 0-axiom (propext/Classical.choice/Quot.sound)."
     ],
     "insights": [
       "SpernerNDim.lean is complete (669 lines, 0 sorries): structure SpernerTriangulation (8 fields) + theorem sperner_ndim (line 654) which yields a fully-colored simplex from an odd count of last-face boundary doors. This is the exact finish line for sperner_grid.",
@@ -53,14 +54,15 @@
       "The chain-interior facet (delete vertex a.succ, 0<a.succ<d) always has a neighbour: swap the two consecutive increment steps a,b (b.castSucc=a.succ). Only the middle vertex moves to the opposite corner verts(a.castSucc)+e_{incDir b}-e_miss; the miss coordinate is untouched at every vertex (so step_dec is inherited verbatim), and only steps a,b have a moved endpoint. This is the GridSimplex-level EXISTENCE half of the search-based adj boundary_face obligation (an interior facet must have a partner).",
       "Pitfall: subst hka with hka:k=a eliminates a (replacing a by k), not k — breaks references to the def binder a. Use rw [hka] (and rw [hka] at hjI ⊢) instead to keep a.",
       "Pitfall: nat (x+1)+0 is defeq x+1, so rw/simp auto-closes such goals by rfl — a trailing omega then errors with No goals.",
-      "Carrier repair (d≥2): the lex-min IsCanon carrier omits cells (#31156); use GridSimplex directly — existence definitional, uniqueness via eq_of_range_eq. grid_eq_of_vertices_range is the sound replacement for canon_eq_of_vertices_range (PR #31163, 0-axiom)."
+      "Carrier repair (d≥2): the lex-min IsCanon carrier omits cells (#31156); use GridSimplex directly — existence definitional, uniqueness via eq_of_range_eq. grid_eq_of_vertices_range is the sound replacement for canon_eq_of_vertices_range (PR #31163, 0-axiom).",
+      "The facet/adj bookkeeping (facet_card, facet_injective, facet_unique_neighbor, facet_vertex_injective) is now available on the SOUND GridSimplex carrier for d≥2, with proofs identical to the CanonSimplex versions modulo vertices→gridVertices and canon_eq_of_vertices_range→grid_eq_of_vertices_range hd. The crux gridFacet_unique_neighbor (adj_unique_facet) no longer relies on the cell-omitting CanonSimplex carrier (#31156 existence failure)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "NEXT: re-sorted GridSimplex construction realizing base baseOf s (recover incDir/miss order of the chain from the new lex-min base; uniqueness of the result is IsCanon.geometry_unique, base well-definedness is baseOf_eq_of_range_eq).",
-      "Boundary-chain pivots: handle deleted vertex a.succ = 0 (vertex index 0) and = d (Fin.last) — these change the base/miss and are the genuine boundary vs interior dichotomy.",
-      "Define adj by finite facet-search over CanonSimplex; discharge adj_symm/adj_vertices/adj_ne via facet_vertex_injective + pivot existence, boundary_face via (contrapositive) interior⟹pivot-partner.",
-      "Phase 2: last-face door oddness by induction on d; apply sperner_ndim."
+      "Define gridAdj/neighbour map by finite facet-search over GridSimplex d N (pivotSimplex=existence, gridFacet_unique_neighbor=uniqueness)",
+      "Assemble abstract door-graph instance for d≥2 from gridFacet_* lemmas (adj_card, adj_unique_facet, boundary_face)",
+      "Handle d≤1 base cases separately (orientation doubling is real there)",
+      "Phase 2: last-face door oddness by induction on d; apply sperner_ndim"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Continues #31163 (which switched the `d ≥ 2` carrier from the cell-omitting `CanonSimplex` to `GridSimplex` directly, repairing the existence failure found in #31156). This PR re-points the **facet/adjacency combinatorics** onto that sound carrier.

Adds a `gridFacet` section (1 def + 9 theorems, ~150 L) mirroring the existing `CanonSimplex` facet section, with proofs **mechanically identical** modulo:
- `vertices → gridVertices`
- `vertices_injective → gridVertices_injective`
- `canon_eq_of_vertices_range → grid_eq_of_vertices_range hd` (threads the `2 ≤ d` hypothesis)

| New decl | Role |
|---|---|
| `gridFacet`, `mem_gridFacet_iff`, `gridVertices_not_mem_gridFacet` | facet definition + membership |
| `gridFacet_card` (= d) | facet cardinality |
| `gridFacet_injective` | within-cell `adj_unique_facet` |
| `grid_eq_of_facet_and_vertex` | cell determined by one (facet, opposite-vertex) pair |
| `gridFacet_union_gridFacet`, `gridImage_univ_card` (= d+1) | union/count helpers |
| **`gridFacet_unique_neighbor`** | **crux: a neighbour is glued across at most one facet** |
| `gridFacet_vertex_injective` | global (facet, opposite-vertex) coherence |

### Why it matters
The crux `gridFacet_unique_neighbor` (the abstract `adj_unique_facet` obligation) previously relied on `canon_eq_of_vertices_range`, whose carrier **omits cells** (#31156 existence failure). On the `GridSimplex` carrier it cites `grid_eq_of_vertices_range hd` with no such gap. The full `(facet, opposite-vertex)` bookkeeping the door-counting argument needs is now sound for `d ≥ 2`. Remaining Phase-1 gap: define the neighbour map by finite facet-search and assemble the abstract door-graph instance.

### Verification
- Type-checks via `lake env lean Proofs/SpernerNDimOQ02.lean` (EXIT 0, clean).
- `#print axioms` on the crux decls (`gridFacet_unique_neighbor`, `gridFacet_vertex_injective`, `grid_eq_of_facet_and_vertex`, `gridFacet_injective`) = `[propext, Classical.choice, Quot.sound]` — **genuinely 0-axiom** (no `sorryAx`, no `Lean.ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)