### PR TITLE
audit(cycleV47): 22 gallery proofs reconfirmed CLEAN, drain audit queue to 0

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25427,6 +25427,138 @@
       "lastAudited": "2026-06-28T00:28:12Z",
       "result": "clean",
       "issues": []
+    },
+    "binary-gcd-oq-01-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-05-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "central-limit-theorem-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "egorov-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-10-wip-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1005-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1007-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1010-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1011-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1034-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1042-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-728-factorial-divisibility-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-76-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "frobenius-endomorphism-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gelfond-schneider-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hermite-legendre-factorial-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lovasz-local-lemma-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ptolemys-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "stirling-formula-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:45:55Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — cycleV47

Audited all **22 remaining unaudited** gallery entries. Every one passes integrity checks. Drains the audit queue from 22 unaudited → **0**.

### Results (all CLEAN)

| Tier | Count | Entries |
|------|-------|---------|
| verified/original·verified (0 sorry / 0 axiom) | 18 | binary-gcd, binomial-theorem, buffons-needle, central-limit-theorem, egorov, erdos-10-wip, erdos-1005, erdos-1007, erdos-1010, erdos-1034, erdos-1042, erdos-728, erdos-76, geometric-series, hermite-legendre, lagrange, lovasz-local-lemma, stirling |
| mathlib-badged (correctly tiered) | 3 | erdos-1011, frobenius-endomorphism, ptolemys |
| axiomatized (badge=axiom, axiomCount=1) | 1 | gelfond-schneider |

For each: `meta.sorries`/`axiomCount` match Lean source, no `True` stubs, badge matches proof tier. Mathlib-reliant proofs use `badge: mathlib` (not overclaiming `original`); gelfond-schneider (a deep transcendence theorem) is honestly `axiomatized`.

### False-positive notes
- **erdos-1034-oq-02** & **erdos-728-...-oq-04**: a `grep` for `sorry` hit a token in each — both are docstring/comment prose asserting the *absence* of sorries ("no \`sorry\`", "0-sorry / 0-axiom"), not tactic sorries. Confirmed clean.

### Standing issue-flags (reconfirmed honest FPs, unchanged)
- **erdos-57-oq-04** "axiom undercount": `axiomCount: 0` correctly scopes the *contributed lemmas* (axiom-free); the host-file `erdos_57` axiom (Liu–Montgomery) is fully disclosed in `assumptions`.
- **erdos-156** "sorry mismatch": candidly self-disclosed broken WIP (`badge: wip`, `status: formalized`); assumptions field states it does not compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)