### PR TITLE
research(sum-of-divisors-oq-01-oq-01): odd perfect numbers have ≥3 distinct prime factors [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4112,6 +4112,7 @@ import Proofs.SummationByPartsOQ01OQ01OQ01OQ02OQ02
 import Proofs.SummationByPartsOQ01OQ01OQ01OQ02OQ02OQ01
 import Proofs.SummationByPartsOQ01OQ02OQ01
 import Proofs.SumOfDivisors
+import Proofs.SumOfDivisorsOQ01OQ01
 import Proofs.SumOfDivisorsOQ02
 import Proofs.SumOfDivisorsOQ03
 import Proofs.SumOfDivisorsOQ04

--- a/proofs/Proofs/SumOfDivisorsOQ01OQ01.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ01OQ01.lean
@@ -1,0 +1,201 @@
+import Mathlib
+
+/-
+# Odd perfect numbers have at least three distinct prime factors
+
+## What this proves
+
+`odd_perfect_three_primeFactors` : every **odd** perfect number `N` satisfies
+`3 ≤ N.primeFactors.card`, i.e. it has at least three *distinct* prime factors.
+
+This is the classical sharp structural constraint that sits one step beyond
+Euler's form for odd perfect numbers (`odd_perfect_euler_form`, the
+`sum-of-divisors-oq-01` headline).  Euler's form fixes the *shape*
+`N = pᵃ m²`; this result bounds the *number of distinct primes* from below.
+
+## The mathematics (abundancy-index argument)
+
+For a prime power the sum-of-divisors function obeys the sharp geometric bound
+
+  `σ(pᵃ) · (p − 1) = p^{a+1} − 1 < p^{a+1}`,
+
+equivalently the abundancy contribution `σ(pᵃ)/pᵃ < p/(p−1)`.  If `N` had only
+one prime factor it would be a prime power, hence *deficient*
+(`σ(pᵃ) < 2pᵃ`), contradicting `σ(N) = 2N`.  If `N = pᵃ qᵇ` had exactly two
+(necessarily odd, so `≥ 3`) prime factors, multiplying the two sharp bounds
+gives `2(p−1)(q−1) < pq`, which is impossible for distinct integers `≥ 3`
+because `2(p−1)(q−1) − pq = (p−2)(q−2) − 2 ≥ 0`.  Hence `N` has `≥ 3` distinct
+primes.  (The bound is best possible for the *abundancy* threshold: the two
+smallest odd primes give `(3/2)(5/4) = 15/8 < 2`.)
+
+The proof is elementary, `native_decide`-free, and fully kernel-checked
+(0 axioms beyond Lean's logical foundations).
+
+## Why this is new
+
+The Perfect-Numbers / Sum-of-Divisors gallery contains Euler's form, prime-power
+deficiency (`PerfectNumbersOQ05.prime_pow_is_deficient`), and σ parity/square
+results, but **not** a lower bound on the count of distinct prime factors of an
+odd perfect number.  This file fills that gap.
+-/
+
+open ArithmeticFunction Finset Nat
+open scoped ArithmeticFunction.sigma
+
+namespace SumOfDivisorsOQ01OQ01
+
+/-! ## The sharp per-prime-power identity -/
+
+/-- **Sharp prime-power geometric identity (subtraction-free form).**
+For a prime `p` and any exponent `a`,
+`σ(pᵃ) · p + 1 = pᵃ · p + σ(pᵃ)`.
+
+This is the integer form of `σ(pᵃ)(p − 1) = p^{a+1} − 1`, the engine of the
+abundancy bound `σ(pᵃ)/pᵃ < p/(p−1)`.  Proved by casting the finite geometric
+sum `σ(pᵃ) = Σ_{k≤a} pᵏ` to `ℤ` and applying `geom_sum_mul`. -/
+theorem sigma_one_primePow_succ_eq {p a : ℕ} (hp : p.Prime) :
+    σ 1 (p ^ a) * p + 1 = p ^ a * p + σ 1 (p ^ a) := by
+  have key : ((σ 1 (p ^ a) * p + 1 : ℕ) : ℤ) = ((p ^ a * p + σ 1 (p ^ a) : ℕ) : ℤ) := by
+    rw [sigma_one_apply_prime_pow hp]
+    push_cast
+    linear_combination geom_sum_mul (p : ℤ) (a + 1)
+  exact_mod_cast key
+
+/-! ## The elementary number inequality at the heart of the two-prime case -/
+
+/-- For distinct integers `P, Q ≥ 3` one has `P·Q ≤ 2·(P−1)·(Q−1)`.
+
+Equivalently `(P−2)(Q−2) ≥ 2`: the two factors are `≥ 1` and, being distinct
+positives, are not both `1`, so their product is `≥ 2`.  The numerical content
+is `2(P−1)(Q−1) − PQ = (P−2)(Q−2) − 2 ≥ 0`. -/
+theorem two_le_prod {P Q : ℤ} (hP : 3 ≤ P) (hQ : 3 ≤ Q) (hne : P ≠ Q) :
+    P * Q ≤ 2 * (P - 1) * (Q - 1) := by
+  -- distinct integers `≥ 3` have sum `≥ 7`
+  have hs : 7 ≤ P + Q := by omega
+  nlinarith [mul_nonneg (show (0 : ℤ) ≤ P - 3 by omega) (show (0 : ℤ) ≤ Q - 3 by omega), hs]
+
+/-! ## Main theorem -/
+
+/-- **Odd perfect numbers have at least three distinct prime factors.**
+
+If `N` is odd and perfect then `3 ≤ N.primeFactors.card`. -/
+theorem odd_perfect_three_primeFactors {N : ℕ} (hodd : Odd N) (hperf : N.Perfect) :
+    3 ≤ N.primeFactors.card := by
+  have hN0 : 0 < N := hperf.2
+  have hN : N ≠ 0 := hN0.ne'
+  -- perfect ⇒ σ(N) = 2N
+  have hσ : σ 1 N = 2 * N := by
+    have h := (Nat.perfect_iff_sum_divisors_eq_two_mul hN0).mp hperf
+    rwa [← sigma_one_apply N] at h
+  by_contra hlt
+  push_neg at hlt
+  have hcases : N.primeFactors.card = 0 ∨ N.primeFactors.card = 1 ∨ N.primeFactors.card = 2 := by
+    omega
+  rcases hcases with hc | hc | hc
+  · -- ω = 0 ⇒ N = 1, but σ(1) = 1 ≠ 2
+    rw [Finset.card_eq_zero, Nat.primeFactors_eq_empty] at hc
+    rcases hc with h | h
+    · exact hN h
+    · subst h; simp at hσ
+  · -- ω = 1 ⇒ N is a prime power pᵏ, which is deficient
+    have hpp : IsPrimePow N := isPrimePow_iff_card_primeFactors_eq_one.mpr hc
+    obtain ⟨p, k, hp, _hk, rfl⟩ := (isPrimePow_nat_iff N).mp hpp
+    -- σ(pᵏ) < 2 pᵏ contradicts σ(pᵏ) = 2 pᵏ
+    have hdef : σ 1 (p ^ k) < 2 * p ^ k := by
+      rw [sigma_one_apply_prime_pow hp, Finset.sum_range_succ]
+      have hgeom : ∑ j ∈ range k, p ^ j < p ^ k :=
+        Nat.geomSum_lt hp.two_le (fun _ hj => mem_range.mp hj)
+      omega
+    rw [hσ] at hdef
+    exact lt_irrefl _ hdef
+  · -- ω = 2 ⇒ N = pᵃ qᵇ with distinct odd primes p, q
+    obtain ⟨p, q, hpq, hset⟩ := Finset.card_eq_two.mp hc
+    have hpmem : p ∈ N.primeFactors := by rw [hset]; exact Finset.mem_insert_self _ _
+    have hqmem : q ∈ N.primeFactors := by rw [hset]; simp
+    have hp : p.Prime := Nat.prime_of_mem_primeFactors hpmem
+    have hq : q.Prime := Nat.prime_of_mem_primeFactors hqmem
+    have hpdvd : p ∣ N := (Nat.mem_primeFactors.mp hpmem).2.1
+    have hqdvd : q ∣ N := (Nat.mem_primeFactors.mp hqmem).2.1
+    -- the prime factors are odd, hence ≥ 3
+    have hp_ge3 : 3 ≤ p := by
+      rcases hp.eq_two_or_odd' with rfl | hpo
+      · have hmod : N % 2 = 1 := Nat.odd_iff.mp hodd
+        have : (2 : ℕ) ∣ N := hpdvd
+        omega
+      · have := Nat.odd_iff.mp hpo; have := hp.two_le; omega
+    have hq_ge3 : 3 ≤ q := by
+      rcases hq.eq_two_or_odd' with rfl | hqo
+      · have hmod : N % 2 = 1 := Nat.odd_iff.mp hodd
+        have : (2 : ℕ) ∣ N := hqdvd
+        omega
+      · have := Nat.odd_iff.mp hqo; have := hq.two_le; omega
+    set a := N.factorization p with ha
+    set b := N.factorization q with hb
+    -- decompose N as the coprime product pᵃ qᵇ
+    have hNeq : N = p ^ a * q ^ b := by
+      have h1 := Nat.factorization_prod_pow_eq_self hN
+      rw [Nat.prod_factorization_eq_prod_primeFactors] at h1
+      rw [hset, Finset.prod_pair hpq, ← ha, ← hb] at h1
+      exact h1.symm
+    have hcop : Nat.Coprime (p ^ a) (q ^ b) := ((Nat.coprime_primes hp hq).mpr hpq).pow a b
+    have hσprod : σ 1 N = σ 1 (p ^ a) * σ 1 (q ^ b) := by
+      rw [hNeq]; exact isMultiplicative_sigma.map_mul_of_coprime hcop
+    -- ℕ facts
+    have E1n : σ 1 (p ^ a) * σ 1 (q ^ b) = 2 * (p ^ a * q ^ b) := by
+      rw [← hσprod, hσ, hNeq]
+    have hep := sigma_one_primePow_succ_eq (p := p) (a := a) hp
+    have heq := sigma_one_primePow_succ_eq (p := q) (a := b) hq
+    -- move to ℤ
+    have E1 : (σ 1 (p ^ a) : ℤ) * σ 1 (q ^ b) = 2 * ((p ^ a : ℤ) * (q ^ b : ℤ)) := by
+      exact_mod_cast E1n
+    have E2 : (σ 1 (p ^ a) : ℤ) * p + 1 = (p ^ a : ℤ) * p + σ 1 (p ^ a) := by
+      exact_mod_cast hep
+    have E3 : (σ 1 (q ^ b) : ℤ) * q + 1 = (q ^ b : ℤ) * q + σ 1 (q ^ b) := by
+      exact_mod_cast heq
+    have hP3 : (3 : ℤ) ≤ p := by exact_mod_cast hp_ge3
+    have hQ3 : (3 : ℤ) ≤ q := by exact_mod_cast hq_ge3
+    have hPQne : (p : ℤ) ≠ q := by exact_mod_cast hpq
+    have hA1 : (1 : ℤ) ≤ (p ^ a : ℤ) := by
+      exact_mod_cast Nat.one_le_iff_ne_zero.mpr (pow_ne_zero a hp.pos.ne')
+    have hB1 : (1 : ℤ) ≤ (q ^ b : ℤ) := by
+      exact_mod_cast Nat.one_le_iff_ne_zero.mpr (pow_ne_zero b hq.pos.ne')
+    -- sharp per-prime bounds in product form
+    have ep : (σ 1 (p ^ a) : ℤ) * ((p : ℤ) - 1) = (p ^ a : ℤ) * p - 1 := by
+      linear_combination E2
+    have eqb : (σ 1 (q ^ b) : ℤ) * ((q : ℤ) - 1) = (q ^ b : ℤ) * q - 1 := by
+      linear_combination E3
+    -- multiply the two sharp bounds, substituting σ(pᵃ)σ(qᵇ) = 2 pᵃ qᵇ
+    have hLHS :
+        (σ 1 (p ^ a) : ℤ) * ((p : ℤ) - 1) * ((σ 1 (q ^ b) : ℤ) * ((q : ℤ) - 1))
+          = 2 * (p ^ a : ℤ) * (q ^ b : ℤ) * (((p : ℤ) - 1) * ((q : ℤ) - 1)) := by
+      linear_combination (((p : ℤ) - 1) * ((q : ℤ) - 1)) * E1
+    have hRHS :
+        (σ 1 (p ^ a) : ℤ) * ((p : ℤ) - 1) * ((σ 1 (q ^ b) : ℤ) * ((q : ℤ) - 1))
+          = ((p ^ a : ℤ) * p - 1) * ((q ^ b : ℤ) * q - 1) := by
+      rw [ep, eqb]
+    have hR :
+        2 * (p ^ a : ℤ) * (q ^ b : ℤ) * (((p : ℤ) - 1) * ((q : ℤ) - 1))
+          = ((p ^ a : ℤ) * p - 1) * ((q ^ b : ℤ) * q - 1) := by
+      rw [← hLHS, hRHS]
+    -- the impossible inequality
+    have hpqle : (p : ℤ) * q ≤ 2 * ((p : ℤ) - 1) * ((q : ℤ) - 1) := two_le_prod hP3 hQ3 hPQne
+    have hABnn : (0 : ℤ) ≤ (p ^ a : ℤ) * (q ^ b : ℤ) := by positivity
+    have hkey :
+        (p ^ a : ℤ) * (q ^ b : ℤ) * ((p : ℤ) * q)
+          ≤ (p ^ a : ℤ) * (q ^ b : ℤ) * (2 * ((p : ℤ) - 1) * ((q : ℤ) - 1)) :=
+      mul_le_mul_of_nonneg_left hpqle hABnn
+    nlinarith [hkey, hR, hA1, hB1, hP3, hQ3,
+      mul_nonneg (show (0 : ℤ) ≤ (p ^ a : ℤ) - 1 by linarith)
+        (show (0 : ℤ) ≤ (p : ℤ) - 3 by linarith),
+      mul_nonneg (show (0 : ℤ) ≤ (q ^ b : ℤ) - 1 by linarith)
+        (show (0 : ℤ) ≤ (q : ℤ) - 3 by linarith)]
+
+/-- **Corollary.** An odd number with at most two distinct prime factors is not
+perfect. -/
+theorem not_perfect_of_odd_of_card_le_two {N : ℕ} (hodd : Odd N)
+    (hcard : N.primeFactors.card ≤ 2) : ¬ N.Perfect := by
+  intro hperf
+  have := odd_perfect_three_primeFactors hodd hperf
+  omega
+
+end SumOfDivisorsOQ01OQ01

--- a/src/data/proofs/sum-of-divisors-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/sum-of-divisors-oq-01-oq-01/annotations.json
@@ -1,0 +1,71 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "sum-of-divisors-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "context",
+    "title": "Odd perfect numbers have at least three distinct prime factors",
+    "content": "Beyond Euler's form N = pᵃm², the next structural constraint on a hypothetical odd perfect number bounds its number of distinct primes ω(N). This file proves the elementary base case ω(N) ≥ 3, fully verified with no axioms and no native_decide. The mechanism is the abundancy index h(N) = σ(N)/N = ∏ σ(p^{v_p})/p^{v_p}, where each local factor is strictly below p/(p−1); a perfect number needs h(N) = 2, but at most two odd primes give at most (3/2)(5/4) = 15/8 < 2.",
+    "mathContext": "$h(N)=\\dfrac{\\sigma(N)}{N}=\\prod_{p\\mid N}\\dfrac{\\sigma(p^{v_p})}{p^{v_p}}<\\prod_{p\\mid N}\\dfrac{p}{p-1}.$ Perfect $\\Rightarrow h(N)=2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "odd perfect numbers",
+      "abundancy index",
+      "distinct prime factors",
+      "deficiency"
+    ],
+    "prerequisites": [
+      "divisor-sum function σ",
+      "perfect numbers",
+      "prime factorization"
+    ]
+  },
+  {
+    "id": "ann-prime-power-identity",
+    "proofId": "sum-of-divisors-oq-01-oq-01",
+    "range": { "startLine": 47, "endLine": 63 },
+    "type": "technique",
+    "title": "Sharp per-prime-power identity (subtraction-free)",
+    "content": "sigma_one_primePow_succ_eq states σ(pᵃ)·p + 1 = pᵃ·p + σ(pᵃ), the integer form of σ(pᵃ)(p−1) = p^{a+1}−1 that avoids ℕ-truncated subtraction. Proof: rewrite σ(pᵃ) as the geometric sum ∑_{k≤a} pᵏ, cast to ℤ, and close with linear_combination geom_sum_mul. This is the engine giving σ(pᵃ)/pᵃ < p/(p−1).",
+    "mathContext": "$\\sigma(p^a)(p-1)=p^{a+1}-1$, equivalently $\\sigma(p^a)\\,p+1=p^a p+\\sigma(p^a)$.",
+    "significance": "key-technique",
+    "relatedConcepts": ["geometric series", "sum of divisors of a prime power"],
+    "prerequisites": ["finite geometric sum", "casting ℕ to ℤ"]
+  },
+  {
+    "id": "ann-number-inequality",
+    "proofId": "sum-of-divisors-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 76 },
+    "type": "technique",
+    "title": "The two-prime obstruction (p−2)(q−2) ≥ 2",
+    "content": "two_le_prod: for distinct integers P,Q ≥ 3, P·Q ≤ 2(P−1)(Q−1). The numerical content is 2(P−1)(Q−1) − PQ = (P−2)(Q−2) − 2 ≥ 0: the two factors are positive and, being distinct, not both 1. This is exactly the failure of a two-odd-prime abundancy product to reach the perfect threshold 2.",
+    "mathContext": "$2(P-1)(Q-1)-PQ=(P-2)(Q-2)-2\\ge 0$ for distinct integers $P,Q\\ge 3$.",
+    "significance": "key-technique",
+    "relatedConcepts": ["abundancy threshold", "elementary inequalities"],
+    "prerequisites": ["integer arithmetic"]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "sum-of-divisors-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 193 },
+    "type": "key-step",
+    "title": "Main theorem: a case split on the number of primes",
+    "content": "odd_perfect_three_primeFactors. From perfection σ(N) = 2N, suppose ω(N) ≤ 2. With 0 primes N = 1 and σ(1) = 1 ≠ 2. With 1 prime N = pᵏ is a prime power, deficient via Nat.geomSum_lt (σ(pᵏ) < 2pᵏ). With 2 primes N = pᵃqᵇ for distinct odd primes p,q ≥ 3; lifting the two sharp per-prime identities to ℤ and multiplying, then applying two_le_prod, gives a contradiction closed by nlinarith. Hence ω(N) ≥ 3.",
+    "mathContext": "$\\sigma(N)=2N,\\ \\omega(N)\\le 2 \\Rightarrow \\bot.$",
+    "significance": "central-result",
+    "relatedConcepts": ["multiplicativity of σ", "prime-power deficiency", "coprime factorization"],
+    "prerequisites": ["σ is multiplicative", "primeFactors and factorization"]
+  },
+  {
+    "id": "ann-corollary",
+    "proofId": "sum-of-divisors-oq-01-oq-01",
+    "range": { "startLine": 194, "endLine": 201 },
+    "type": "context",
+    "title": "Contrapositive corollary",
+    "content": "not_perfect_of_odd_of_card_le_two: an odd number with at most two distinct prime factors is never perfect — the immediate restatement of the main bound.",
+    "mathContext": "$\\omega(N)\\le 2\\wedge\\text{Odd }N\\Rightarrow\\neg\\,\\text{Perfect }N.$",
+    "significance": "context",
+    "relatedConcepts": ["odd perfect numbers"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/sum-of-divisors-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-01-oq-01/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "sum-of-divisors-oq-01-oq-01",
+  "title": "Odd Perfect Numbers Have at Least Three Distinct Prime Factors",
+  "slug": "sum-of-divisors-oq-01-oq-01",
+  "description": "A sharp structural follow-up to Euler's odd-perfect form (sum-of-divisors-oq-01): an odd perfect number has at least three distinct prime factors (3 ≤ ω(N)). The argument is the abundancy-index obstruction. A single prime power pᵃ is deficient (σ(pᵃ) < 2pᵃ), so an odd perfect number is not a prime power. For two distinct (necessarily odd, hence ≥3) primes, the sharp per-prime-power identity σ(pᵃ)·(p−1) = p^{a+1}−1 multiplied across both primes forces 2(p−1)(q−1) < pq, impossible because 2(p−1)(q−1) − pq = (p−2)(q−2) − 2 ≥ 0 for distinct integers ≥ 3. Verified in Lean 4 with 0 axioms, 0 sorries, and no native_decide. This directly answers an open question recorded in the parent entry ('lower bounds on the number of distinct prime factors').",
+  "meta": {
+    "author": "classical (folklore; abundancy-index bound). Formalized in Lean 4 with Mathlib.",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Perfect_number#Odd_perfect_numbers",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-function",
+      "sigma",
+      "perfect-numbers",
+      "odd-perfect-numbers",
+      "abundancy-index",
+      "prime-factors",
+      "deficiency",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SumOfDivisorsOQ01OQ01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.sigma_one_apply_prime_pow",
+        "description": "σ₁(pⁱ) = ∑_{k<i+1} pᵏ — the finite geometric form of σ on a prime power, the entry point for the sharp per-prime-power identity",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "geom_sum_mul",
+        "description": "(∑_{i<n} xⁱ)·(x−1) = xⁿ − 1 in a commutative ring — gives σ(pᵃ)·(p−1) = p^{a+1}−1 after casting to ℤ",
+        "module": "Mathlib.Algebra.Ring.GeomSum"
+      },
+      {
+        "theorem": "ArithmeticFunction.isMultiplicative_sigma",
+        "description": "σ is multiplicative; via map_mul_of_coprime it splits σ(pᵃqᵇ) = σ(pᵃ)·σ(qᵇ) on the coprime two-prime factorization",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "Nat.perfect_iff_sum_divisors_eq_two_mul",
+        "description": "0 < n → (Perfect n ↔ ∑_{d∣n} d = 2n) — converts perfection into σ(N) = 2N",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "isPrimePow_iff_card_primeFactors_eq_one",
+        "description": "IsPrimePow n ↔ n.primeFactors.card = 1 — identifies the one-prime case as a prime power, which is deficient",
+        "module": "Mathlib.Data.Nat.Factorization.PrimePow"
+      },
+      {
+        "theorem": "Nat.geomSum_lt",
+        "description": "2 ≤ m → (∀ k ∈ s, k < n) → ∑_{k∈s} mᵏ < mⁿ — the prime-power deficiency bound σ(pᵃ) < 2pᵃ used in the one-prime case",
+        "module": "Mathlib.Algebra.GeomSum"
+      },
+      {
+        "theorem": "Nat.factorization_prod_pow_eq_self",
+        "description": "n ≠ 0 → ∏_{p∈primeFactors} p^{v_p(n)} = n — packages the exactly-two-prime case as N = pᵃ·qᵇ",
+        "module": "Mathlib.Data.Nat.Factorization.Defs"
+      }
+    ],
+    "originalContributions": [
+      "sigma_one_primePow_succ_eq: the sharp, subtraction-free prime-power identity σ(pᵃ)·p + 1 = pᵃ·p + σ(pᵃ) (the ℕ form of σ(pᵃ)(p−1) = p^{a+1}−1), proved by casting the geometric sum to ℤ and applying geom_sum_mul — the abundancy engine σ(pᵃ)/pᵃ < p/(p−1)",
+      "two_le_prod: the elementary number fact P·Q ≤ 2(P−1)(Q−1) for distinct integers P,Q ≥ 3, i.e. (P−2)(Q−2) ≥ 2, which is exactly the failure of the two-prime abundancy product to reach 2",
+      "odd_perfect_three_primeFactors: the headline — every odd perfect number has 3 ≤ ω(N) distinct prime factors, by a three-way case split (0, 1, 2 primes) each contradicting σ(N) = 2N",
+      "not_perfect_of_odd_of_card_le_two: contrapositive corollary — an odd number with ≤ 2 distinct prime factors is never perfect"
+    ],
+    "dateAdded": "2026-06-28",
+    "lineCount": 201,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries, no native_decide. An unconditional structural constraint: it assumes nothing about whether any odd perfect number exists (open).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Whether any odd perfect number exists is one of the oldest open problems in mathematics. Beyond Euler's structural form N = pᵃm² (p ≡ a ≡ 1 mod 4), a long line of work pins down ever-stronger necessary conditions, among them lower bounds on the number of distinct prime factors ω(N). Today ω(N) ≥ 10 is known (Nielsen 2015), but the elementary base case — that ω(N) ≥ 3 — follows directly from the abundancy index ∏_{p∣N} p/(p−1) and was effectively known to the earliest investigators: the abundancy of any number built from at most the two smallest odd primes is at most (3/2)(5/4) = 15/8 < 2, so it cannot be perfect.",
+    "problemStatement": "**Open Question (sum-of-divisors-oq-01-oq-01)**, raised by the parent entry: extend the odd-perfect analysis to a lower bound on the number of distinct prime factors.\n\n**This entry's result**: a fully verified proof that every odd perfect number has at least three distinct prime factors, 3 ≤ N.primeFactors.card, together with the reusable sharp per-prime-power abundancy identity and the elementary inequality that makes the two-prime case fail.",
+    "text": "Let N be odd and perfect, so σ(N) = 2N. If N had ≤ 2 distinct prime factors: with 0 it is 1 (σ(1)=1≠2); with 1 it is a prime power pᵃ, which is deficient (σ(pᵃ) < 2pᵃ); with 2 it is pᵃqᵇ for distinct odd primes p,q ≥ 3, and the sharp bound σ(pᵃ)(p−1) = p^{a+1}−1 across both primes yields 2(p−1)(q−1) < pq, contradicting (p−2)(q−2) ≥ 2. Hence ω(N) ≥ 3.",
+    "keyInsights": [
+      "The whole result is the abundancy index h(N) = σ(N)/N = ∏_{p∣N} σ(p^{v_p})/p^{v_p}, with each local factor strictly below p/(p−1). A perfect number needs h(N) = 2, but at most two odd primes give at most (3/2)(5/4) = 15/8 < 2 — the bound is sharp at the two smallest odd primes 3 and 5.",
+      "Keeping the geometric identity in the subtraction-free integer form σ(pᵃ)·p + 1 = pᵃ·p + σ(pᵃ) (rather than σ(pᵃ)(p−1) = p^{a+1}−1 with ℕ-truncated subtraction) lets the whole two-prime contradiction run by linear_combination + nlinarith over ℤ with no casting hazards.",
+      "The two-prime case collapses to one elementary inequality: 2(P−1)(Q−1) − PQ = (P−2)(Q−2) − 2, which is ≥ 0 for distinct integers ≥ 3 because the two factors are positive and not both 1. No primality beyond 'odd, hence ≥ 3, and distinct' is used in the final step.",
+      "The one-prime case reuses the elementary fact that every prime power is deficient (the lower geometric tail 1 + p + ⋯ + pᵃ⁻¹ is smaller than the top term pᵃ); the gallery already isolates this as prime_pow_is_deficient.",
+      "The result is unconditional structure, not existence: it constrains the shape of any odd perfect number while assuming nothing about whether one exists."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Statement and the abundancy-index strategy",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Docstring stating the theorem (3 ≤ ω(N) for odd perfect N) and laying out the abundancy-index argument: prime-power deficiency for one prime, the sharp σ(pᵃ)(p−1) = p^{a+1}−1 identity for two primes, and the elementary (p−2)(q−2) ≥ 2 obstruction. Imports Mathlib, opens the σ scope.",
+      "mathContext": "$h(N)=\\sigma(N)/N=\\prod_{p\\mid N}\\frac{\\sigma(p^{a})}{p^{a}}<\\prod_{p\\mid N}\\frac{p}{p-1}.$"
+    },
+    {
+      "id": "prime-power-identity",
+      "title": "Sharp per-prime-power identity",
+      "startLine": 47,
+      "endLine": 63,
+      "summary": "sigma_one_primePow_succ_eq: σ(pᵃ)·p + 1 = pᵃ·p + σ(pᵃ), the subtraction-free integer form of σ(pᵃ)(p−1) = p^{a+1}−1. Proof casts σ(pᵃ) = ∑_{k≤a} pᵏ to ℤ and closes with linear_combination geom_sum_mul.",
+      "mathContext": "$\\sigma(p^a)(p-1)=p^{a+1}-1.$"
+    },
+    {
+      "id": "number-inequality",
+      "title": "The two-prime obstruction inequality",
+      "startLine": 64,
+      "endLine": 76,
+      "summary": "two_le_prod: for distinct integers P,Q ≥ 3, P·Q ≤ 2(P−1)(Q−1). Equivalently (P−2)(Q−2) ≥ 2; proved by omega (sum ≥ 7 for distinct integers ≥ 3) plus nlinarith on (P−3)(Q−3) ≥ 0.",
+      "mathContext": "$2(P-1)(Q-1)-PQ=(P-2)(Q-2)-2\\ge 0.$"
+    },
+    {
+      "id": "main",
+      "title": "Main theorem: ω(N) ≥ 3",
+      "startLine": 77,
+      "endLine": 193,
+      "summary": "odd_perfect_three_primeFactors. From σ(N) = 2N, a case split on N.primeFactors.card ∈ {0,1,2}: card 0 ⇒ N = 1 (σ(1)=1≠2); card 1 ⇒ prime power, deficient via Nat.geomSum_lt; card 2 ⇒ N = pᵃqᵇ with odd p,q ≥ 3, where multiplying the two sharp per-prime identities (lifted to ℤ) against two_le_prod yields a contradiction by nlinarith.",
+      "mathContext": "$\\sigma(N)=2N,\\ \\omega(N)\\le 2 \\Rightarrow \\bot.$"
+    },
+    {
+      "id": "corollary",
+      "title": "Contrapositive corollary",
+      "startLine": 194,
+      "endLine": 201,
+      "summary": "not_perfect_of_odd_of_card_le_two: an odd number with at most two distinct prime factors is never perfect.",
+      "mathContext": "$\\omega(N)\\le 2\\wedge \\text{Odd }N \\Rightarrow \\neg\\,\\text{Perfect }N.$"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-divisors-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry formalizes Euler's odd-perfect form N = pᵃm² and explicitly poses 'lower bounds on the number of distinct prime factors' as an open follow-up; this entry answers the base case ω(N) ≥ 3."
+    },
+    {
+      "targetId": "perfect-numbers-oq-05",
+      "relationship": "uses",
+      "description": "Reuses the prime-power deficiency phenomenon (σ(pᵃ) < 2pᵃ) that PerfectNumbersOQ05 isolates as prime_pow_is_deficient; the one-prime case is exactly that statement."
+    },
+    {
+      "targetId": "perfect-numbers",
+      "relationship": "related",
+      "description": "Perfect numbers are defined by σ(N) = 2N; this entry bounds the distinct-prime count of any odd solution via the abundancy index of that equation."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-checks, with 0 axioms and 0 sorries (no native_decide), that every odd perfect number has at least three distinct prime factors. The proof is the abundancy-index obstruction in elementary integer form: prime-power deficiency rules out one prime, and the sharp identity σ(pᵃ)(p−1) = p^{a+1}−1 combined with (p−2)(q−2) ≥ 2 rules out two.",
+    "implications": "Provides the verified base case of the distinct-prime-factor hierarchy for odd perfect numbers and a reusable sharp per-prime-power abundancy identity (sigma_one_primePow_succ_eq) that future entries can multiply across more primes to push the bound higher. It directly closes the parent entry's open follow-up at the ω ≥ 3 level.",
+    "openQuestions": [
+      "Do any odd perfect numbers exist at all? The present result is an unconditional structural constraint and assumes nothing about existence.",
+      "Can the same abundancy-index machinery be pushed to formalize ω(N) ≥ 4 or higher? Each additional prime requires controlling the product ∏ p/(p−1) over the smallest admissible primes, which the sharp per-prime identity already supports.",
+      "Can the special prime p ≡ 1 (mod 4) from Euler's form be combined with this count to recover sharper joint constraints (e.g. relating the special prime to ω(N))?"
+    ]
+  }
+}

--- a/src/data/research/problems/sum-of-divisors-oq-01-oq-01.json
+++ b/src/data/research/problems/sum-of-divisors-oq-01-oq-01.json
@@ -1,0 +1,57 @@
+{
+  "slug": "sum-of-divisors-oq-01-oq-01",
+  "title": "sum-of-divisors-oq-01-oq-01 — Odd perfect numbers have at least three distinct prime factors",
+  "path": "full",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "tags": ["number-theory", "perfect-numbers", "odd-perfect-numbers", "abundancy-index", "sigma"],
+  "started": "2026-06-28",
+  "lastUpdate": "2026-06-28",
+  "problemStatement": {
+    "formal": "Odd N ∧ Nat.Perfect N → 3 ≤ N.primeFactors.card",
+    "plain": "Every odd perfect number has at least three distinct prime factors (the base case of the ω(N) hierarchy for odd perfect numbers), answering the parent entry's open follow-up on lower bounds for the number of distinct prime factors.",
+    "whyMatters": [
+      "Provides the verified base case of the distinct-prime-factor lower bounds for odd perfect numbers.",
+      "Yields a reusable sharp per-prime-power abundancy identity that can be multiplied across more primes to push the bound higher."
+    ]
+  },
+  "leanFiles": [
+    {
+      "path": "proofs/Proofs/SumOfDivisorsOQ01OQ01.lean",
+      "sorries": 0,
+      "axiomCount": 0
+    }
+  ],
+  "knowledge": {
+    "insights": [
+      "Odd perfect ⇒ ω(N) ≥ 3 reduces to the abundancy index h(N) = σ(N)/N = ∏ σ(p^{v_p})/p^{v_p} with each factor < p/(p−1); at most two odd primes give ≤ (3/2)(5/4) = 15/8 < 2, while a perfect number needs h(N) = 2.",
+      "Keeping the prime-power geometric identity in subtraction-free integer form σ(pᵃ)·p + 1 = pᵃ·p + σ(pᵃ) lets the entire two-prime contradiction run by linear_combination + nlinarith over ℤ with no ℕ-subtraction hazards.",
+      "The two-prime case is exactly the elementary fact (p−2)(q−2) ≥ 2 for distinct integers ≥ 3 (equivalently 2(p−1)(q−1) ≥ pq); no primality beyond 'odd, distinct, ≥ 3' is used in the final step.",
+      "The one-prime case is precisely prime-power deficiency (σ(pᵃ) < 2pᵃ), already isolated in the gallery as PerfectNumbersOQ05.prime_pow_is_deficient."
+    ],
+    "builtItems": [
+      "sigma_one_primePow_succ_eq (SumOfDivisorsOQ01OQ01.lean:56): σ(pᵃ)·p + 1 = pᵃ·p + σ(pᵃ), the sharp abundancy engine via geom_sum_mul over ℤ.",
+      "two_le_prod (SumOfDivisorsOQ01OQ01.lean:71): distinct integers P,Q ≥ 3 satisfy P·Q ≤ 2(P−1)(Q−1).",
+      "odd_perfect_three_primeFactors (SumOfDivisorsOQ01OQ01.lean:82): the headline 3 ≤ ω(N) for odd perfect N, 0-axiom 0-sorry.",
+      "not_perfect_of_odd_of_card_le_two (SumOfDivisorsOQ01OQ01.lean:195): contrapositive corollary."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Push the same abundancy machinery to ω(N) ≥ 4 by controlling ∏ p/(p−1) over the four smallest admissible odd primes.",
+      "Combine with Euler's special prime (p ≡ 1 mod 4 from sum-of-divisors-oq-01) for sharper joint constraints relating the special prime to ω(N)."
+    ],
+    "progressSummary": "COMPLETE (verified, 0-axiom/0-sorry, no native_decide): odd perfect ⇒ ω(N) ≥ 3 via the abundancy-index obstruction; answers the parent's distinct-prime-factor open follow-up at the base case."
+  },
+  "knownResults": [
+    "Euler's form N = pᵃm², p ≡ a ≡ 1 (mod 4) (sum-of-divisors-oq-01).",
+    "ω(N) ≥ 10 is known (Nielsen 2015); this entry verifies the elementary base ω(N) ≥ 3."
+  ],
+  "relatedProofs": ["sum-of-divisors-oq-01", "perfect-numbers-oq-05", "perfect-numbers"],
+  "references": [
+    {
+      "title": "Perfect number — Odd perfect numbers",
+      "url": "https://en.wikipedia.org/wiki/Perfect_number#Odd_perfect_numbers"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **sum-of-divisors-oq-01-oq-01**: every **odd perfect number** `N` has at least three distinct prime factors, `3 ≤ N.primeFactors.card`. This is the base case of the distinct-prime-factor hierarchy for odd perfect numbers and directly answers a follow-up open question posed by the parent entry `sum-of-divisors-oq-01` (Euler's odd-perfect form).

## The mathematics — abundancy-index obstruction (elementary, `native_decide`-free)

Let `N` be odd and perfect, so `σ(N) = 2N`. Case split on `ω(N) = N.primeFactors.card`:
- **0 primes** ⇒ `N = 1`, but `σ(1) = 1 ≠ 2`.
- **1 prime** ⇒ `N = pᵃ` is a prime power, which is deficient (`σ(pᵃ) < 2pᵃ`).
- **2 primes** ⇒ `N = pᵃqᵇ` with distinct odd primes `p, q ≥ 3`. Multiplying the sharp per-prime identity `σ(pᵃ)(p−1) = p^{a+1}−1` across both primes forces `2(p−1)(q−1) < pq`, impossible because `2(p−1)(q−1) − pq = (p−2)(q−2) − 2 ≥ 0`.

## Original contributions

- `sigma_one_primePow_succ_eq` — sharp subtraction-free identity `σ(pᵃ)·p + 1 = pᵃ·p + σ(pᵃ)` (the ℤ form of `σ(pᵃ)(p−1) = p^{a+1}−1`)
- `two_le_prod` — `P·Q ≤ 2(P−1)(Q−1)` for distinct integers `≥ 3`
- `odd_perfect_three_primeFactors` — the headline `3 ≤ ω(N)`
- `not_perfect_of_odd_of_card_le_two` — contrapositive corollary

## Verification

- Compiles clean: `./bin/lake env lean Proofs/SumOfDivisorsOQ01OQ01.lean` (exit 0)
- `#print axioms` on both main theorems shows only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms, 0 sorries, no `native_decide`**
- Gallery data: `meta.json` (status `verified`, axiomCount 0), `annotations.json`, problem JSON — all valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)