### PR TITLE
audit(sum-of-divisors-oq-01-oq-01): new entry reconfirmed CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25559,6 +25559,12 @@
       "lastAudited": "2026-06-28T08:45:55Z",
       "result": "clean",
       "issues": []
+    },
+    "sum-of-divisors-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T08:56:08Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: \`sum-of-divisors-oq-01-oq-01\` — "Odd Perfect Numbers Have at Least Three Distinct Prime Factors" (new committed entry, #31173-era).

### Verdict: CLEAN — all meta.json claims match the Lean source.

| Claim (meta.json) | Lean source | Match |
|---|---|---|
| status `verified`, badge `verified` | proves real theorem, no stubs | ✓ |
| `sorries: 0` | 0 `sorry` | ✓ |
| `axiomCount: 0` | 0 `axiom` declarations, no structure-encoded assumptions | ✓ |
| "no native_decide" (×3) | only occurrence is the docstring phrase "\`native_decide\`-free" — no tactic | ✓ |
| `theoremCount: 4` | 4 theorems (`sigma_one_primePow_succ_eq`, `two_le_prod`, `odd_perfect_three_primeFactors`, `not_perfect_of_odd_of_card_le_two`) | ✓ |
| `lineCount: 201` | 201 lines | ✓ |

### Tier / narrative check
- **Not a Mathlib wrapper**: the headline `odd_perfect_three_primeFactors` (odd perfect ⇒ ω(N) ≥ 3) is proved in-file via the abundancy-index obstruction. Mathlib supplies infrastructure only (σ multiplicativity, `geom_sum_mul`, `perfect_iff_sum_divisors_eq_two_mul`), all **fully disclosed** in `mathlibDependencies`. No delegation opacity.
- **No axiom masking / no inequality-as-theorem inflation**: `originalContributions` are scoped to genuinely-new lemmas; result is correctly framed as an unconditional structural constraint (assumes nothing about existence of odd perfect numbers).
- Badge `verified`/`original` is honest.

Marks the entry audited `clean` in `audit-tracker.json`.

---
Discovered during gallery integrity audit (cycleV49). Queue drained to 0 genuine unaudited after #31174 merged; this is the one new committed entry that appeared post-merge.