### PR TITLE
research(lagrange-oq-01-oq-03-oq-02): minimal normal subgroups — existence + abelianness in solvable case [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01OQ03OQ02.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01OQ03OQ02.lean
@@ -1,0 +1,135 @@
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.Commutator.Basic
+import Mathlib.GroupTheory.Subgroup.Centralizer
+import Mathlib.Order.Minimal
+import Mathlib.Tactic
+
+/-
+# Minimal normal subgroups: existence and abelianness in the solvable case (0 axioms)
+
+## Open Question (continuation of lagrange-theorem-oq-01-oq-03, OQ-01)
+
+The sibling file `LagrangeTheoremOQ01OQ03OQ01.lean` proved the Schur–Zassenhaus
+*lifting step* of Hall's theorem with 0 axioms, and pinpointed the remaining gap:
+a 0-axiom proof of Hall's theorem for solvable groups needs the **minimal normal
+subgroup** machinery, which Mathlib 4.26 lacks:
+
+* existence of a *minimal* normal subgroup of a nontrivial finite group, and
+* the fact that in a *solvable* group such a subgroup is abelian (indeed
+  elementary abelian).
+
+This file supplies the first two of those facts, **with 0 axioms**.
+
+## What this file proves
+
+| Theorem | Statement | Status |
+|---------|-----------|--------|
+| `exists_minimal_normal_subgroup` | A nontrivial finite group has a minimal normal subgroup `N` (normal, `≠ ⊥`, and no proper nontrivial normal subgroup sits below it) | Proved (0 axioms) |
+| `minimal_normal_abelian_of_solvable` | A minimal normal subgroup of a solvable group is abelian | Proved (0 axioms) |
+| `exists_abelian_minimal_normal_subgroup` | A nontrivial finite solvable group has an abelian minimal normal subgroup | Proved (0 axioms) |
+
+## Proof ideas
+
+* **Existence.** For finite `G` the lattice `Subgroup G` is finite, so the set
+  `{K | K.Normal ∧ K ≠ ⊥}` is a finite, nonempty (`⊤` belongs, as `G` is
+  nontrivial) subset of a partial order, hence has a minimal element
+  (`Set.Finite.exists_minimal`). Minimality in the order *restricted to that set*
+  is exactly minimality among nontrivial normal subgroups.
+
+* **Abelianness.** Let `N` be a minimal normal subgroup of a solvable group.
+  The commutator `⁅N, N⁆` is normal in `G` (`Subgroup.commutator_normal`), is
+  contained in `N` (`Subgroup.commutator_le_self`), and is *strictly* smaller than
+  `N` because `G` is solvable (`IsSolvable.commutator_lt_of_ne_bot`). By
+  minimality a normal subgroup strictly below `N` cannot be nontrivial, so
+  `⁅N, N⁆ = ⊥`; equivalently `N ≤ centralizer N`, i.e. `N` is abelian.
+
+## The remaining gap (toward a full 0-axiom Hall theorem)
+
+Still missing: that an abelian minimal normal subgroup of a finite group is
+*elementary abelian* (a `p`-group of exponent `p`). The argument: for a prime
+`p ∣ |N|`, the `p`-torsion of the abelian group `N` is characteristic in `N`,
+hence normal in `G`, and nontrivial by Cauchy — so by minimality it is all of
+`N`, forcing exponent `p`. Formalizing the characteristic-`p`-torsion subgroup is
+the next increment.
+
+## References
+- Hall, P. (1928), "A note on soluble groups", J. London Math. Soc.
+- Gorenstein, "Finite Groups", Ch. 6.
+-/
+
+namespace LagrangeOQ01OQ03OQ02
+
+open Subgroup
+
+variable {G : Type*} [Group G]
+
+/-- The minimality predicate used below: `N` is a *minimal normal subgroup* if it
+is normal, nontrivial, and every nontrivial normal subgroup contained in `N`
+equals `N`. -/
+def IsMinimalNormal (N : Subgroup G) : Prop :=
+  N.Normal ∧ N ≠ ⊥ ∧ ∀ M : Subgroup G, M.Normal → M ≤ N → M ≠ ⊥ → M = N
+
+-- ============================================================
+-- Part I: Existence of a minimal normal subgroup
+-- ============================================================
+
+/-- **Existence of a minimal normal subgroup.** Every nontrivial finite group has
+a minimal normal subgroup: a normal subgroup `N ≠ ⊥` such that no nontrivial
+normal subgroup lies strictly below it. Proved with 0 axioms. -/
+theorem exists_minimal_normal_subgroup [Finite G] [Nontrivial G] :
+    ∃ N : Subgroup G, IsMinimalNormal N := by
+  -- The set of nontrivial normal subgroups, as a subset of the finite lattice.
+  set s : Set (Subgroup G) := {K | K.Normal ∧ K ≠ ⊥} with hs
+  -- It is nonempty: `⊤` is normal and `≠ ⊥` since `G` is nontrivial.
+  have hne : s.Nonempty := ⟨⊤, ⟨inferInstance, top_ne_bot⟩⟩
+  -- It is finite: `Subgroup G` injects into the finite `Set G`, so it is finite.
+  haveI : Finite (Subgroup G) := Finite.of_injective _ SetLike.coe_injective
+  have hfin : s.Finite := Set.toFinite s
+  -- Pick a minimal element with respect to the subgroup order.
+  obtain ⟨N, hN⟩ := hfin.exists_minimal hne
+  obtain ⟨⟨hNnorm, hNbot⟩, hmin⟩ := hN
+  refine ⟨N, hNnorm, hNbot, ?_⟩
+  intro M hMnorm hMle hMbot
+  -- `M` belongs to `s`, sits below `N`, so by minimality `N ≤ M`, hence `M = N`.
+  exact le_antisymm hMle (hmin ⟨hMnorm, hMbot⟩ hMle)
+
+-- ============================================================
+-- Part II: Minimal normal subgroups of solvable groups are abelian
+-- ============================================================
+
+/-- **A minimal normal subgroup of a solvable group is abelian.** If `N` is a
+minimal normal subgroup of a solvable group `G`, then any two elements of `N`
+commute. Proved with 0 axioms. -/
+theorem minimal_normal_abelian_of_solvable [IsSolvable G]
+    {N : Subgroup G} (hN : IsMinimalNormal N) :
+    ∀ a b : N, a * b = b * a := by
+  obtain ⟨hNnorm, hNbot, hmin⟩ := hN
+  -- Register `N.Normal` as an instance so `commutator_normal` applies.
+  haveI : N.Normal := hNnorm
+  -- `⁅N, N⁆` is normal in `G`, contained in `N`, and strictly below `N`.
+  have hcn : (⁅N, N⁆ : Subgroup G).Normal := Subgroup.commutator_normal N N
+  have hle : (⁅N, N⁆ : Subgroup G) ≤ N := Subgroup.commutator_le_self N
+  have hlt : (⁅N, N⁆ : Subgroup G) < N := IsSolvable.commutator_lt_of_ne_bot hNbot
+  -- A normal subgroup strictly below the minimal `N` cannot be nontrivial.
+  have hbot : (⁅N, N⁆ : Subgroup G) = ⊥ := by
+    by_contra h
+    exact (ne_of_lt hlt) (hmin _ hcn hle h)
+  -- `⁅N, N⁆ = ⊥` means `N` centralizes itself, i.e. `N` is abelian.
+  have hcent : N ≤ Subgroup.centralizer (N : Set G) :=
+    Subgroup.commutator_eq_bot_iff_le_centralizer.mp hbot
+  intro a b
+  have h : (b : G) * (a : G) = (a : G) * (b : G) :=
+    (Subgroup.mem_centralizer_iff.mp (hcent a.2)) b b.2
+  exact Subtype.ext h.symm
+
+/-- **Existence of an abelian minimal normal subgroup.** Every nontrivial finite
+solvable group has a minimal normal subgroup, and it is abelian. This packages
+exactly the structural input that a 0-axiom proof of Hall's theorem requires (cf.
+the lifting step in `LagrangeTheoremOQ01OQ03OQ01.lean`). Proved with 0 axioms. -/
+theorem exists_abelian_minimal_normal_subgroup
+    [Finite G] [Nontrivial G] [IsSolvable G] :
+    ∃ N : Subgroup G, IsMinimalNormal N ∧ ∀ a b : N, a * b = b * a := by
+  obtain ⟨N, hN⟩ := exists_minimal_normal_subgroup (G := G)
+  exact ⟨N, hN, minimal_normal_abelian_of_solvable hN⟩
+
+end LagrangeOQ01OQ03OQ02

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/meta.json
@@ -1,0 +1,102 @@
+{
+  "id": "lagrange-theorem-oq-01-oq-03-oq-02",
+  "title": "Minimal Normal Subgroups: Existence and Abelianness in the Solvable Case (0 axioms)",
+  "slug": "lagrange-theorem-oq-01-oq-03-oq-02",
+  "description": "Supplies, with 0 axioms, the minimal-normal-subgroup machinery that the sibling Hall lifting-step entry (lagrange-theorem-oq-01-oq-03-oq-01) identified as the remaining gap for a fully 0-axiom proof of Hall's theorem. Proves: every nontrivial finite group has a minimal normal subgroup, and a minimal normal subgroup of a solvable group is abelian — hence a nontrivial finite solvable group has an abelian minimal normal subgroup. Mathlib 4.26 has no minimal-normal-subgroup API; this builds it from the finiteness of the subgroup lattice and the solvable-group commutator strict-descent lemma.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-28",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ01OQ03OQ02.lean",
+    "tags": [
+      "group-theory",
+      "algebra",
+      "hall-theorem",
+      "solvable-groups",
+      "minimal-normal-subgroup",
+      "commutator",
+      "lagrange",
+      "subgroups"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-28",
+    "axiomCount": 0,
+    "lineCount": 135,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "assumptions": "None. All results are machine-checked with 0 axioms; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for every theorem.",
+    "originalContributions": [
+      "IsMinimalNormal: a predicate packaging the minimal-normal-subgroup property (normal, nontrivial, no proper nontrivial normal subgroup below it), absent from Mathlib 4.26",
+      "exists_minimal_normal_subgroup: every nontrivial finite group has a minimal normal subgroup, formalized with 0 axioms via finiteness of the subgroup lattice and Set.Finite.exists_minimal",
+      "minimal_normal_abelian_of_solvable: a minimal normal subgroup of a solvable group is abelian, via the strict commutator descent IsSolvable.commutator_lt_of_ne_bot plus minimality forcing ⁅N, N⁆ = ⊥",
+      "exists_abelian_minimal_normal_subgroup: the packaged existence-of-abelian-minimal-normal-subgroup for nontrivial finite solvable groups — exactly the structural input Hall's induction needs"
+    ],
+    "proofStrategy": "Existence: for finite G the lattice Subgroup G is finite (SetLike injects into the finite Set G), so the set {K | K.Normal ∧ K ≠ ⊥} is a finite, nonempty (⊤ belongs since G is nontrivial) subset of the partial order Subgroup G and therefore has a minimal element by Set.Finite.exists_minimal. Minimality in the order restricted to that set is exactly minimality among nontrivial normal subgroups, extracted by le_antisymm. Abelianness: for a minimal normal N of solvable G, the commutator ⁅N, N⁆ is normal in G (Subgroup.commutator_normal), is ≤ N (Subgroup.commutator_le_self), and is strictly below N (IsSolvable.commutator_lt_of_ne_bot, the solvable-group descent). A normal subgroup strictly below the minimal N cannot be nontrivial, so ⁅N, N⁆ = ⊥; by Subgroup.commutator_eq_bot_iff_le_centralizer this means N ≤ centralizer N, i.e. every two elements of N commute."
+  },
+  "leanFile": {
+    "path": "Proofs/LagrangeTheoremOQ01OQ03OQ02.lean",
+    "imports": [
+      "Mathlib.GroupTheory.Solvable",
+      "Mathlib.GroupTheory.Commutator.Basic",
+      "Mathlib.GroupTheory.Subgroup.Centralizer",
+      "Mathlib.Order.Minimal"
+    ],
+    "opens": [
+      "Subgroup"
+    ],
+    "namespace": "LagrangeOQ01OQ03OQ02",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 3
+  },
+  "openQuestions": [
+    {
+      "id": "oq-01",
+      "question": "Can an abelian minimal normal subgroup of a finite group be shown to be elementary abelian (a p-group of exponent p)? The argument: for a prime p dividing |N|, the p-torsion of the abelian group N is characteristic in N, hence normal in G, and nontrivial by Cauchy, so by minimality it is all of N. Formalizing the characteristic p-torsion subgroup is the next increment.",
+      "difficulty": "hard",
+      "status": "open"
+    },
+    {
+      "id": "oq-02",
+      "question": "With existence + abelianness (this entry) and the lifting step (oq-01 sibling), can the p | d branch of Hall's induction be closed, assembling a fully 0-axiom proof of Hall's theorem for solvable groups?",
+      "difficulty": "hard",
+      "status": "open"
+    }
+  ],
+  "parentId": "lagrange-theorem-oq-01-oq-03",
+  "conclusion": {
+    "summary": "The minimal-normal-subgroup machinery flagged as the remaining gap by the Hall lifting-step entry is now machine-checked with 0 axioms: existence of a minimal normal subgroup in any nontrivial finite group, and abelianness of such a subgroup in the solvable case. Together these give an abelian minimal normal subgroup in every nontrivial finite solvable group.",
+    "implications": "This furnishes the structural starting point of Hall's induction. Combined with the Schur–Zassenhaus lifting step (lagrange-theorem-oq-01-oq-03-oq-01) and the abelian base case (lagrange-theorem-oq-03), the only piece still missing for a fully 0-axiom Hall's theorem is the refinement that the abelian minimal normal subgroup is elementary abelian (exponent p), which pins down |N| = p^a and lets the induction split on whether p divides the target order.",
+    "openQuestions": [
+      "Formalize that an abelian minimal normal subgroup of a finite group is elementary abelian (exponent p) via the characteristic p-torsion subgroup and Cauchy.",
+      "Close the p | d branch of Hall's induction using the elementary-abelian structure.",
+      "Assemble the full 0-axiom Hall's theorem from existence + abelianness (this entry), the lifting step, and the abelian base case."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "lagrange-theorem-oq-01-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "The sibling proved the Schur–Zassenhaus lifting step and pinpointed minimal-normal-subgroup structure as the remaining gap; this entry supplies the existence and abelianness halves of that gap with 0 axioms."
+    },
+    {
+      "proofId": "lagrange-theorem-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Parent Hall entry that axiomatized hall_solvable; this entry advances the program to discharge that axiom by building the minimal-normal-subgroup structural input."
+    },
+    {
+      "proofId": "lagrange-theorem-oq-03",
+      "relationship": "uses",
+      "description": "Complementary: oq-03 supplies the abelian Hall base case that the minimal abelian normal subgroup constructed here feeds into."
+    }
+  ],
+  "references": [
+    "Hall, P. (1928). A note on soluble groups. Journal of the London Mathematical Society, 3(2), 98–105.",
+    "Gorenstein, D. (1980). Finite Groups (2nd ed.), Chapter 6.",
+    "Mathlib4, Mathlib/GroupTheory/Solvable.lean (IsSolvable.commutator_lt_of_ne_bot), Mathlib/GroupTheory/Commutator/Basic.lean (commutator_normal, commutator_le_self, commutator_eq_bot_iff_le_centralizer)."
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Supplies, **with 0 axioms**, the minimal-normal-subgroup machinery that the sibling Hall lifting-step entry (`lagrange-theorem-oq-01-oq-03-oq-01`, #31159) identified as the remaining gap toward a fully 0-axiom proof of Hall's theorem for solvable groups. Mathlib 4.26 has no minimal-normal-subgroup API; this builds it from the finiteness of the subgroup lattice and the solvable-group commutator strict-descent lemma.

## Theorems (all 0-axiom)

| Theorem | Statement |
|---------|-----------|
| `exists_minimal_normal_subgroup` | Every nontrivial finite group has a minimal normal subgroup `N` (normal, `≠ ⊥`, no nontrivial normal subgroup strictly below) |
| `minimal_normal_abelian_of_solvable` | A minimal normal subgroup of a solvable group is abelian |
| `exists_abelian_minimal_normal_subgroup` | A nontrivial finite solvable group has an abelian minimal normal subgroup |

Plus the `IsMinimalNormal` predicate packaging the property (absent from Mathlib 4.26).

## Proof sketch

- **Existence.** `Subgroup G` injects into the finite `Set G` (`SetLike.coe_injective`), so it is finite; the set `{K | K.Normal ∧ K ≠ ⊥}` is finite and nonempty (`⊤` belongs), hence has a minimal element (`Set.Finite.exists_minimal`). Minimality in the restricted order is exactly minimality among nontrivial normals.
- **Abelianness.** For minimal normal `N` of solvable `G`: `⁅N,N⁆` is normal (`commutator_normal`), `≤ N` (`commutator_le_self`), and strictly below `N` (`IsSolvable.commutator_lt_of_ne_bot`). Minimality forces `⁅N,N⁆ = ⊥`, i.e. `N ≤ centralizer N` (`commutator_eq_bot_iff_le_centralizer`).

## Verification

`#print axioms` reports only `propext / Classical.choice / Quot.sound` for all three theorems — no `sorry`, no `Lean.ofReduceBool`, no substantive axioms. Verified standalone via `lake env lean Proofs/LagrangeTheoremOQ01OQ03OQ02.lean` (EXIT 0).

## Remaining gap

Still open (recorded in `openQuestions`): that an abelian minimal normal subgroup is *elementary* abelian (exponent `p`) via the characteristic `p`-torsion subgroup + Cauchy — the last piece for the `p ∣ d` branch of Hall's induction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)