### PR TITLE
research(cayley-hamilton-oq-01-oq-01-oq-01-oq-01): full cyclic-vector ⟺ non-derogatory equivalence [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -791,6 +791,7 @@ import Proofs.CayleyHamiltonMinpolyOQ07OQ01
 import Proofs.CayleyHamiltonOQ01
 import Proofs.CayleyHamiltonOQ01OQ01
 import Proofs.CayleyHamiltonOQ01OQ01OQ01
+import Proofs.CayleyHamiltonOQ01OQ01OQ01OQ01
 import Proofs.CayleyHamiltonOQ01OQ02
 import Proofs.CayleyHamiltonOQ01OQ03
 import Proofs.CayleyHamiltonOQ01OQ04

--- a/proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,133 @@
+/-
+# Cyclic Vector ⟺ Non-Derogatory: The Full Equivalence
+
+## Source
+Completes the cyclic-vector characterisation begun in
+`cayley-hamilton-oq-01-oq-01` (the easy direction) and
+`cayley-hamilton-oq-01-oq-01-oq-01` (the converse existence statement).
+
+## What This Proves
+
+For an `n × n` matrix `M` over a field `K`, viewing `Kⁿ` as a `K[X]`-module via
+`M` (the parent's `Module.AEval'` framework), a vector `v` is **cyclic** when no
+nonzero polynomial of degree `< n` annihilates it (parent's `IsCyclicVector`).
+
+The grandparent proved the **converse existence** direction:
+`minpoly K M = M.charpoly → ∃ v, IsCyclicVector M v`
+(`cayley-hamilton-oq-01-oq-01-oq-01`).  This entry supplies the missing
+**forward** direction and assembles the full equivalence.
+
+**Main results:**
+- `minpoly_natDegree_eq_of_isCyclicVector`:
+    `IsCyclicVector M v → (minpoly K M).natDegree = n`.
+- `minpoly_eq_charpoly_of_isCyclicVector`:
+    `IsCyclicVector M v → minpoly K M = M.charpoly`.
+- `exists_cyclicVector_iff_minpoly_eq_charpoly`:
+    `(∃ v, IsCyclicVector M v) ↔ minpoly K M = M.charpoly`.
+- `exists_cyclicVector_iff_minpoly_natDegree_eq`:
+    `(∃ v, IsCyclicVector M v) ↔ (minpoly K M).natDegree = n`.
+
+## Structure of the Argument
+
+The forward direction is a clean degree squeeze, true because a cyclic vector
+witnesses that nothing of small degree kills the whole orbit:
+
+* **`deg(minpoly) ≤ n`** always: `minpoly K M ∣ M.charpoly` (Cayley–Hamilton)
+  and `deg(charpoly) = n`.
+* **`deg(minpoly) ≥ n`** from cyclicity: the minimal polynomial annihilates
+  every vector, in particular the cyclic `v`; were its degree `< n`, the cyclic
+  property would force `minpoly K M = 0`, contradicting that the minimal
+  polynomial of an integral element is nonzero.
+
+So `deg(minpoly) = n`.  Both `minpoly K M` and `M.charpoly` are monic with
+`minpoly ∣ charpoly` and equal degree, hence equal
+(`Polynomial.eq_of_monic_of_dvd_of_natDegree_le`).  Pairing this with the
+grandparent's reverse direction yields the equivalence.
+
+The whole development is fully machine-checked (no `sorry`, no extra axioms),
+reusing the grandparent's `aeval_eq_zero_iff_mem_vecAnnIdeal` bridge and the
+parent's `minpoly_mem_vecAnnIdeal`.
+
+## Depends on
+`Proofs.CayleyHamiltonOQ01OQ01OQ01` (the bridge + reverse direction) and, through
+it, `Proofs.CayleyHamiltonOQ01OQ01` (the `vecAnnIdeal` / `IsCyclicVector`
+framework).
+-/
+
+import Proofs.CayleyHamiltonOQ01OQ01OQ01
+
+open Matrix Polynomial Module BigOperators
+open CayleyHamiltonOQ01OQ01 CayleyHamiltonOQ01OQ01OQ01
+
+namespace CayleyHamiltonOQ01OQ01OQ01OQ01
+
+variable {K : Type*} [Field K] {n : ℕ}
+
+/-! ## I. Forward direction: a cyclic vector forces a full-degree minimal polynomial -/
+
+/-- If `M` has a cyclic vector `v`, then `(minpoly K M).natDegree = n`.
+
+`deg(minpoly) ≤ n` because `minpoly ∣ charpoly` and `deg(charpoly) = n`;
+`deg(minpoly) ≥ n` because the (nonzero) minimal polynomial annihilates `v`, so a
+degree `< n` would force it to vanish by cyclicity. -/
+theorem minpoly_natDegree_eq_of_isCyclicVector (M : Matrix (Fin n) (Fin n) K)
+    (v : Fin n → K) (hv : IsCyclicVector M v) : (minpoly K M).natDegree = n := by
+  have hM_int : IsIntegral K M :=
+    ⟨M.charpoly, Matrix.charpoly_monic M, Matrix.aeval_self_charpoly M⟩
+  -- deg(minpoly) ≤ n
+  have hdvd : minpoly K M ∣ M.charpoly := minpoly.dvd K M (Matrix.aeval_self_charpoly M)
+  have hcharne : M.charpoly ≠ 0 := (Matrix.charpoly_monic M).ne_zero
+  have hle : (minpoly K M).natDegree ≤ n := by
+    have h := Polynomial.natDegree_le_of_dvd hdvd hcharne
+    rwa [Matrix.charpoly_natDegree_eq_dim, Fintype.card_fin] at h
+  -- minpoly annihilates the cyclic vector v
+  have hannih : aeval M.mulVecLin (minpoly K M) v = 0 :=
+    (aeval_eq_zero_iff_mem_vecAnnIdeal M v (minpoly K M)).mpr (minpoly_mem_vecAnnIdeal M v)
+  -- deg(minpoly) ≥ n
+  have hge : n ≤ (minpoly K M).natDegree := by
+    by_contra hlt
+    push_neg at hlt
+    exact minpoly.ne_zero hM_int (hv (minpoly K M) hlt hannih)
+  exact le_antisymm hle hge
+
+/-! ## II. Forward direction: a cyclic vector forces `minpoly = charpoly` -/
+
+/-- If `M` has a cyclic vector, its minimal and characteristic polynomials
+coincide — the forward direction of the non-derogatory characterisation. -/
+theorem minpoly_eq_charpoly_of_isCyclicVector (M : Matrix (Fin n) (Fin n) K)
+    (v : Fin n → K) (hv : IsCyclicVector M v) : minpoly K M = M.charpoly := by
+  have hM_int : IsIntegral K M :=
+    ⟨M.charpoly, Matrix.charpoly_monic M, Matrix.aeval_self_charpoly M⟩
+  have hMonic : (minpoly K M).Monic := minpoly.monic hM_int
+  have hdvd : minpoly K M ∣ M.charpoly := minpoly.dvd K M (Matrix.aeval_self_charpoly M)
+  have hdeg : (minpoly K M).natDegree = n := minpoly_natDegree_eq_of_isCyclicVector M v hv
+  have hle : M.charpoly.natDegree ≤ (minpoly K M).natDegree := by
+    rw [hdeg, Matrix.charpoly_natDegree_eq_dim, Fintype.card_fin]
+  exact (Polynomial.eq_of_monic_of_dvd_of_natDegree_le hMonic (Matrix.charpoly_monic M)
+    hdvd hle).symm
+
+/-! ## III. The full equivalences -/
+
+/-- **Cyclic vector ⟺ non-derogatory.** `M` admits a cyclic vector iff its
+minimal and characteristic polynomials coincide. The forward direction is
+`minpoly_eq_charpoly_of_isCyclicVector`; the reverse is the grandparent's
+`exists_cyclicVector_of_minpoly_eq_charpoly`. -/
+theorem exists_cyclicVector_iff_minpoly_eq_charpoly (M : Matrix (Fin n) (Fin n) K) :
+    (∃ v : Fin n → K, IsCyclicVector M v) ↔ minpoly K M = M.charpoly := by
+  constructor
+  · rintro ⟨v, hv⟩
+    exact minpoly_eq_charpoly_of_isCyclicVector M v hv
+  · intro h
+    exact exists_cyclicVector_of_minpoly_eq_charpoly M h
+
+/-- **Degree form of the equivalence.** `M` admits a cyclic vector iff its
+minimal polynomial has full degree `n`. -/
+theorem exists_cyclicVector_iff_minpoly_natDegree_eq (M : Matrix (Fin n) (Fin n) K) :
+    (∃ v : Fin n → K, IsCyclicVector M v) ↔ (minpoly K M).natDegree = n := by
+  constructor
+  · rintro ⟨v, hv⟩
+    exact minpoly_natDegree_eq_of_isCyclicVector M v hv
+  · intro h
+    exact exists_cyclicVector_of_minpoly_natDegree_eq M h
+
+end CayleyHamiltonOQ01OQ01OQ01OQ01

--- a/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "cayley-hamilton-oq-01-oq-01-oq-01-oq-01",
+  "title": "Cyclic Vector ⟺ Non-Derogatory: The Full Equivalence",
+  "slug": "cayley-hamilton-oq-01-oq-01-oq-01-oq-01",
+  "description": "Completes the cyclic-vector characterisation of non-derogatory matrices. The grandparent entry proved the reverse direction (minpoly = charpoly ⟹ a cyclic vector exists); this entry supplies the missing forward direction — a cyclic vector forces (minpoly K M).natDegree = n and hence minpoly K M = M.charpoly — and assembles the full equivalence (∃ cyclic vector) ↔ minpoly = charpoly. The forward direction is a clean degree squeeze: minpoly ∣ charpoly gives deg ≤ n, and cyclicity (the minimal polynomial annihilates the cyclic vector, so a degree < n would force it to vanish) gives deg ≥ n.",
+  "meta": {
+    "author": "researcher-10 (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cyclic_module",
+    "date": "2026-06-28",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonOQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "minimal-polynomial",
+      "characteristic-polynomial",
+      "non-derogatory",
+      "cyclic-vector",
+      "module-theory",
+      "annihilator-ideal",
+      "rational-canonical-form",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.aeval_self_charpoly",
+        "description": "Cayley-Hamilton: aeval M M.charpoly = 0, giving M integral and minpoly K M ∣ M.charpoly",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
+      },
+      {
+        "theorem": "minpoly.dvd",
+        "description": "if aeval M p = 0 then minpoly K M ∣ p — used with charpoly to bound deg(minpoly) ≤ n",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "minpoly.ne_zero",
+        "description": "the minimal polynomial of an integral element is nonzero — needed for the cyclicity contradiction",
+        "module": "Mathlib.FieldTheory.Minpoly.Field"
+      },
+      {
+        "theorem": "Polynomial.natDegree_le_of_dvd",
+        "description": "if p ∣ q and q ≠ 0 then deg p ≤ deg q, converting minpoly ∣ charpoly into the degree bound",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Lemmas"
+      },
+      {
+        "theorem": "Polynomial.eq_of_monic_of_dvd_of_natDegree_le",
+        "description": "two monic polynomials with p ∣ q and deg q ≤ deg p are equal — upgrades equal degree + divisibility to minpoly = charpoly",
+        "module": "Mathlib.Algebra.Polynomial.Div"
+      },
+      {
+        "theorem": "Matrix.charpoly_natDegree_eq_dim",
+        "description": "the characteristic polynomial of an n×n matrix has degree n",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff"
+      }
+    ],
+    "originalContributions": [
+      "minpoly_natDegree_eq_of_isCyclicVector: a cyclic vector forces (minpoly K M).natDegree = n, by squeezing deg(minpoly) between the divisibility bound (≤ n via minpoly ∣ charpoly) and the cyclicity bound (≥ n: the nonzero minimal polynomial annihilates the cyclic vector, so a degree < n would force it to vanish)",
+      "minpoly_eq_charpoly_of_isCyclicVector: a cyclic vector forces minpoly K M = M.charpoly — the forward direction of the non-derogatory characterisation, obtained from equal degree + divisibility of two monic polynomials",
+      "exists_cyclicVector_iff_minpoly_eq_charpoly: the full equivalence (∃ v, IsCyclicVector M v) ↔ minpoly K M = M.charpoly, pairing this forward direction with the grandparent's reverse direction",
+      "exists_cyclicVector_iff_minpoly_natDegree_eq: the degree form of the equivalence, (∃ v, IsCyclicVector M v) ↔ (minpoly K M).natDegree = n"
+    ],
+    "references": [
+      {
+        "authors": "Hoffman, Kenneth; Kunze, Ray",
+        "title": "Linear Algebra",
+        "year": "1971",
+        "venue": "Prentice-Hall",
+        "note": "Cyclic subspaces and cyclic vectors; M has a cyclic vector iff its minimal and characteristic polynomials coincide"
+      },
+      {
+        "authors": "Dummit, David S.; Foote, Richard M.",
+        "title": "Abstract Algebra",
+        "year": "2004",
+        "venue": "Wiley",
+        "note": "Chapter 12: modules over a PID, invariant factors, rational canonical form, cyclic vectors and non-derogatory matrices"
+      }
+    ],
+    "prerequisites": [
+      "The grandparent entry cayley-hamilton-oq-01-oq-01-oq-01 (aeval_eq_zero_iff_mem_vecAnnIdeal bridge; reverse direction exists_cyclicVector_of_minpoly_eq_charpoly)",
+      "The parent entry cayley-hamilton-oq-01-oq-01 (vecAnnIdeal, IsCyclicVector, minpoly_mem_vecAnnIdeal)",
+      "Minimal and characteristic polynomials; Cayley-Hamilton; divisibility and degree of polynomials"
+    ],
+    "dateAdded": "2026-06-28",
+    "axiomCount": 0,
+    "lineCount": 133,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound).",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "An n×n matrix M over a field K turns Kⁿ into a module over K[X] (X acting as M). M is non-derogatory when its minimal polynomial has full degree n, equivalently when minpoly K M = M.charpoly; this is exactly the case in which Kⁿ is a single cyclic K[X]-block and M is similar to the companion matrix of its characteristic polynomial. The structural hallmark is a cyclic vector: a v whose K[X]-orbit {p(M)·v} spans Kⁿ, equivalently a v that no nonzero polynomial of degree < n annihilates.\n\nThe parent entry cayley-hamilton-oq-01-oq-01 built the per-vector annihilator theory (vecAnnIdeal, IsCyclicVector) and the easy direction (a cyclic vector has annihilator ideal span{minpoly}). The grandparent cayley-hamilton-oq-01-oq-01-oq-01 proved the converse existence statement (μ = χ ⟹ a cyclic vector exists) via Mathlib's PID structure theorem. What remained to close the loop was the forward implication — that the mere existence of a cyclic vector already pins minpoly = charpoly — and the packaging of both halves into a single iff. That is this entry.",
+    "problemStatement": "**Goal**: Establish the full equivalence M admits a cyclic vector ⟺ M is non-derogatory (minpoly K M = M.charpoly), supplying the forward direction missing from the grandparent entry.\n\n**Resolution**: We prove that any cyclic vector forces (minpoly K M).natDegree = n (a degree squeeze) and hence minpoly K M = M.charpoly, then combine with the grandparent's reverse direction to obtain the biconditional, also in its degree form.",
+    "text": "A 133-line, axiom-free development (4 theorems). minpoly_natDegree_eq_of_isCyclicVector is the crux: deg(minpoly) ≤ n always (minpoly ∣ charpoly by Cayley-Hamilton, deg charpoly = n), while deg(minpoly) ≥ n because the nonzero minimal polynomial annihilates the cyclic vector v — reusing the grandparent's aeval_eq_zero_iff_mem_vecAnnIdeal bridge together with the parent's minpoly_mem_vecAnnIdeal — so a degree < n would, by the cyclic property, force minpoly K M = 0, contradicting minpoly.ne_zero. With deg(minpoly) = n, minpoly_eq_charpoly_of_isCyclicVector upgrades the two monic polynomials (equal degree, minpoly ∣ charpoly) to equality via Polynomial.eq_of_monic_of_dvd_of_natDegree_le. The two iff theorems then pair this with the grandparent's exists_cyclicVector_of_minpoly_eq_charpoly / exists_cyclicVector_of_minpoly_natDegree_eq.",
+    "proofStrategy": "The forward direction is a degree squeeze. (1) Cayley-Hamilton (Matrix.aeval_self_charpoly) makes M integral and gives minpoly K M ∣ M.charpoly; with Matrix.charpoly_natDegree_eq_dim this bounds deg(minpoly) ≤ n. (2) The minimal polynomial annihilates the cyclic vector v: minpoly_mem_vecAnnIdeal (parent) plus the bridge aeval_eq_zero_iff_mem_vecAnnIdeal (grandparent) give aeval M.mulVecLin (minpoly K M) v = 0; if deg(minpoly) < n the IsCyclicVector property forces minpoly K M = 0, contradicting minpoly.ne_zero — so deg(minpoly) ≥ n. (3) Hence deg(minpoly) = n; two monic polynomials with minpoly ∣ charpoly and equal degree are equal (Polynomial.eq_of_monic_of_dvd_of_natDegree_le), giving minpoly = charpoly. (4) The biconditionals chain this with the grandparent's reverse direction.",
+    "keyInsights": [
+      "The existence of a single cyclic vector already determines the global invariant minpoly = charpoly — no construction or counting is needed, only a degree squeeze.",
+      "The upper bound deg(minpoly) ≤ n is free from Cayley-Hamilton (minpoly ∣ charpoly); only the lower bound uses cyclicity.",
+      "Cyclicity feeds the lower bound through exactly one fact: the minimal polynomial annihilates every vector, so it annihilates the cyclic one, and the cyclic property bans nonzero annihilators of degree < n.",
+      "Equal degree plus divisibility of two monic polynomials is enough for equality — the leading coefficients pin the unit factor.",
+      "Together with the grandparent's reverse direction this closes the cyclic-vector ⟺ non-derogatory equivalence, the single-block heart of rational canonical form."
+    ],
+    "prerequisites": [
+      "Linear algebra (minimal/characteristic polynomial, non-derogatory matrices, cyclic vectors)",
+      "Polynomial algebra (divisibility, degree, monic equality)",
+      "The parent/grandparent annihilator-ideal framework (vecAnnIdeal, IsCyclicVector)"
+    ]
+  },
+  "conclusion": {
+    "summary": "A cyclic vector forces (minpoly K M).natDegree = n and hence minpoly K M = M.charpoly (forward direction), via a degree squeeze: minpoly ∣ charpoly gives deg ≤ n, and the minimal polynomial annihilating the cyclic vector gives deg ≥ n. Combined with the grandparent's reverse direction this yields the full equivalence (∃ v, IsCyclicVector M v) ↔ minpoly K M = M.charpoly (and its degree form). Fully verified, 0 axioms, 0 sorries.",
+    "implications": "This completes the cyclic-vector characterisation of non-derogatory matrices: the existence of a cyclic vector is now established as exactly equivalent to minpoly = charpoly, in both directions and machine-checked. It is the single-companion-block case of the rational canonical form, and it isolates the structural content of being non-derogatory in a form (the iff) directly usable by downstream entries.",
+    "openQuestions": [
+      "Assemble the invariant factors d₁ | ... | dₖ = minpoly and the full rational canonical form from the cyclic decomposition (not just the single non-derogatory block).",
+      "Give an explicit construction of a maximal-order / cyclic vector rather than invoking the abstract PID structure theorem.",
+      "Quantify how many matrices over a finite field are non-derogatory, relating vector orders to the elementary divisors of M."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Supplies the forward direction missing from the grandparent (which proved only the reverse, μ = χ ⟹ cyclic vector exists), and reuses its aeval_eq_zero_iff_mem_vecAnnIdeal bridge"
+    },
+    {
+      "targetId": "cayley-hamilton-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Reuses the parent's vecAnnIdeal / IsCyclicVector framework and minpoly_mem_vecAnnIdeal"
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "Cayley-Hamilton (aeval_self_charpoly) supplies minpoly ∣ charpoly and deg(charpoly) = n, the upper half of the degree squeeze"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.CayleyHamiltonOQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial",
+      "Module",
+      "BigOperators",
+      "CayleyHamiltonOQ01OQ01",
+      "CayleyHamiltonOQ01OQ01OQ01"
+    ],
+    "namespace": "CayleyHamiltonOQ01OQ01OQ01OQ01",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/CayleyHamiltonOQ01OQ01OQ01OQ01.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Completes the cyclic-vector characterisation of non-derogatory matrices, child of `cayley-hamilton-oq-01-oq-01-oq-01`.

The grandparent entry proved only the **reverse** direction (`minpoly K M = M.charpoly ⟹ ∃ cyclic vector`) via Mathlib's PID structure theorem. This entry supplies the missing **forward** direction and assembles the full equivalence.

### Forward direction — a degree squeeze
For a cyclic vector `v`:
- **deg(minpoly) ≤ n**: `minpoly K M ∣ M.charpoly` (Cayley–Hamilton) and `deg(charpoly) = n`.
- **deg(minpoly) ≥ n**: the nonzero minimal polynomial annihilates `v` (parent's `minpoly_mem_vecAnnIdeal` + grandparent's `aeval_eq_zero_iff_mem_vecAnnIdeal` bridge); a degree `< n` would force `minpoly K M = 0` by cyclicity, contradicting `minpoly.ne_zero`.

Hence `deg(minpoly) = n`, and two monic polynomials with `minpoly ∣ charpoly` of equal degree are equal (`Polynomial.eq_of_monic_of_dvd_of_natDegree_le`), giving `minpoly K M = M.charpoly`.

### Theorems (4)
- `minpoly_natDegree_eq_of_isCyclicVector`: `IsCyclicVector M v → (minpoly K M).natDegree = n`
- `minpoly_eq_charpoly_of_isCyclicVector`: `IsCyclicVector M v → minpoly K M = M.charpoly`
- `exists_cyclicVector_iff_minpoly_eq_charpoly`: `(∃ v, IsCyclicVector M v) ↔ minpoly K M = M.charpoly`
- `exists_cyclicVector_iff_minpoly_natDegree_eq`: degree form of the equivalence

### Verification
- Compiles clean (`lake env lean`, exit 0, no errors/warnings).
- 0 sorries, 0 `axiom` declarations.
- `#print axioms` on the headline theorems: only `propext`, `Classical.choice`, `Quot.sound`.
- 133 lines. `meta.json` passes JSON validation and the gallery size cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)