### PR TITLE
Enrich erdos-10-wip-01-oq-01: add annotations (0 → 6)

### DIFF
--- a/src/data/proofs/erdos-10-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-offset-reformulation",
+    "proofId": "erdos-10-wip-01-oq-01",
+    "range": { "startLine": 71, "endLine": 83 },
+    "type": "insight",
+    "title": "Offset reformulation: search m = n − p, not p",
+    "content": "Re-indexes the prime-plus-popcount characterization by the offset m = n − p. The parent file's `isPrimePlusKPowers_iff_popcount` quantifies over primes p ≤ n; here the proof substitutes m = n − p and uses that p ↦ n − p is its own inverse on {· ≤ n}. The forward direction sends a witnessing prime p to the offset n − p (with `Nat.sub_sub_self hpn` rewriting n − (n − p) back to p); the reverse sends an offset m to the prime n − m. The payoff is the search space: the offsets that can possibly work are exactly those with popcount ≤ k, of which there are only Θ((log n)^k), versus Θ(n) primes below n.",
+    "mathContext": "$\\mathrm{IsPrimePlusKPowers}\\,k\\,n \\iff \\exists\\,m \\le n,\\ \\operatorname{popcount} m \\le k \\ \\wedge\\ (n-m)\\ \\text{prime}$, via the involution $n-(n-x)=x$.",
+    "significance": "key",
+    "relatedConcepts": ["change of index variable", "involution / self-inverse map", "binary popcount", "Nat.sub_sub_self"],
+    "prerequisites": ["natural-number subtraction in Lean", "the prime-plus-popcount characterization (parent file)"]
+  },
+  {
+    "id": "ann-refutation-criterion",
+    "proofId": "erdos-10-wip-01-oq-01",
+    "range": { "startLine": 85, "endLine": 93 },
+    "type": "technique",
+    "title": "Finite, kernel-decidable refutation criterion",
+    "content": "Negates the offset reformulation with `push_neg` to obtain a bounded universal: n is NOT a prime plus ≤ k powers of two iff every offset m ≤ n with popcount ≤ k has composite complement n − m. Crucially the right-hand side is a `∀ m ≤ n` with a decidable body, so the kernel `decide` can check it directly — no `native_decide`, hence no `Lean.ofReduceBool` axiom. This is the architectural fix the parent WIP file left open: it converts certifying a witness from a Θ(n) prime search (which forced `native_decide`) into a finite, auditable verification.",
+    "mathContext": "$\\neg\\,\\mathrm{IsPrimePlusKPowers}\\,k\\,n \\iff \\forall\\,m \\le n,\\ \\operatorname{popcount} m \\le k \\Rightarrow \\neg\\,(n-m)\\ \\text{prime}$.",
+    "significance": "key",
+    "relatedConcepts": ["contrapositive", "bounded quantifier", "Decidable instances", "kernel decide vs native_decide", "Lean.ofReduceBool"],
+    "prerequisites": ["push_neg tactic", "decidability of bounded ∀ over ℕ"]
+  },
+  {
+    "id": "ann-compositeness-certificate",
+    "proofId": "erdos-10-wip-01-oq-01",
+    "range": { "startLine": 106, "endLine": 112 },
+    "type": "technique",
+    "title": "Compositeness from a single proper divisor",
+    "content": "A one-line lemma that certifies ¬ q.Prime by exhibiting a single proper divisor 1 < d < q. The proof assumes q is prime, invokes `Nat.Prime.eq_one_or_self_of_dvd` to force d ∈ {1, q}, and `omega` closes both cases against the strict bounds. For the genuine ~10⁹ witnesses each obligation ¬ (n − m).Prime is discharged this way — by naming the small prime from the relevant covering congruence — rather than by trial division, which is infeasible in the kernel. It is the kernel-fast tool that makes the refutation criterion scale.",
+    "mathContext": "If $1 < d < q$ and $d \\mid q$ then $q$ is composite: a prime's only divisors are $1$ and $q$.",
+    "significance": "supporting",
+    "relatedConcepts": ["primality vs compositeness", "covering congruences", "divisibility certificate", "Nat.Prime.eq_one_or_self_of_dvd"],
+    "prerequisites": ["definition of prime in Mathlib", "omega tactic"]
+  },
+  {
+    "id": "ann-popcount-le-one",
+    "proofId": "erdos-10-wip-01-oq-01",
+    "range": { "startLine": 127, "endLine": 149 },
+    "type": "concept",
+    "title": "Popcount ≤ 1 structure lemma (avoids kernel-stuck bitIndices)",
+    "content": "Characterizes the offsets with popcount ≤ 1 as exactly {0} ∪ {2^a}. This is the load-bearing kernel-friendliness move: `popcount = (Nat.bitIndices ·).length` does not reduce under kernel `decide` (only the compiler evaluates it), so the witness cannot simply compute popcount. Instead the proof case-splits on the bit-index list — empty list forces m = 0, a singleton [a] forces m = 2^a — reading m back off its bits via `Nat.twoPowSum_bitIndices`. `List.length_eq_zero_iff` collapses the tail to []. This replaces computation with a reusable structure theorem.",
+    "mathContext": "$\\operatorname{popcount} m \\le 1 \\iff m = 0 \\ \\vee\\ \\exists a,\\ m = 2^{a}$, proved from $\\sum_{i \\in \\mathrm{bitIndices}(m)} 2^{i} = m$.",
+    "significance": "key",
+    "relatedConcepts": ["binary representation", "Hamming weight / popcount", "Nat.bitIndices", "Nat.twoPowSum_bitIndices", "kernel reduction limits"],
+    "prerequisites": ["binary expansion of natural numbers", "List case analysis in Lean"]
+  },
+  {
+    "id": "ann-smallest-witness",
+    "proofId": "erdos-10-wip-01-oq-01",
+    "range": { "startLine": 164, "endLine": 182 },
+    "type": "insight",
+    "title": "Smallest witness 16, certified with no native_decide",
+    "content": "Assembles the pieces to prove 16 is not a prime plus ≤ 1 power of two — the smallest such integer and the first Erdős #10 witness certified axiom-free. The refutation criterion reduces the goal to checking the popcount-≤1 offsets m ≤ 16; the structure lemma turns those into m = 0 and m = 2^a. The exponent is bounded a ≤ 4 (since 2^5 = 32 > 16, proved by a `calc`/`omega` argument), and `interval_cases a <;> decide` discharges the five compositeness checks on complements {16, 15, 14, 12, 8, 0}, none prime. Every `decide` runs on numbers below 16, so the kernel checks it without `native_decide` — `#print axioms` shows only propext / Classical.choice / Quot.sound.",
+    "mathContext": "$\\neg\\,\\mathrm{IsPrimePlusKPowers}\\,1\\,16$: offsets $\\{0,1,2,4,8,16\\}$ give complements $\\{16,15,14,12,8,0\\}$, none prime.",
+    "significance": "key",
+    "relatedConcepts": ["interval_cases", "decide on small numerals", "axiom-free verification", "smallest counterexample"],
+    "prerequisites": ["powers of two", "the refutation criterion and popcount structure lemma above"]
+  },
+  {
+    "id": "ann-positive-sanity-check",
+    "proofId": "erdos-10-wip-01-oq-01",
+    "range": { "startLine": 184, "endLine": 188 },
+    "type": "context",
+    "title": "Positive sanity check: 15 = 13 + 2",
+    "content": "Confirms the offset criterion is the correct equivalence and not vacuously satisfied: 15 IS a prime plus one power of two, witnessed by the offset m = 2 (so n − m = 13 is prime and popcount 2 = 1). Exhibiting a genuine positive instance guards against an equivalence that accidentally always refutes, complementing the negative witness 16 directly above.",
+    "mathContext": "$\\mathrm{IsPrimePlusKPowers}\\,1\\,15$ via offset $m = 2$: $15 - 2 = 13$ prime, $\\operatorname{popcount} 2 = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["worked positive instance", "test of an equivalence", "powers of two"],
+    "prerequisites": ["the offset reformulation above"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-10-wip-01-oq-01` (Erdős #10: certifying witnesses by a finite offset search, no native_decide).

**Gap closed:** `annotations.json` was empty (`[]`). meta.json is already comprehensive (14.8 KB, under cap) — the quality deficit was entirely missing inline annotations.

**Added 6 annotations**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, mapped to the actual theorem line ranges:
- Offset reformulation `isPrimePlusKPowers_iff_offset` (m = n−p involution)
- Finite refutation criterion `not_isPrimePlusKPowers_iff` (kernel-decidable, no native_decide)
- Compositeness certificate `not_prime_of_proper_divisor`
- Popcount-≤1 structure lemma `popcount_le_one_iff` (avoids kernel-stuck bitIndices)
- Smallest witness `not_isPrimePlusKPowers_one_sixteen` (axiom-free, 16)
- Positive sanity check `isPrimePlusKPowers_one_fifteen` (15 = 13 + 2)

JSON validated; all ranges within the 196-line file; meta.json within size caps. No changes to status/badge/axiomCount (verified, 0 axioms confirmed accurate against the Lean source).