### PR TITLE
research(roth-theorem-oq-01): eliminate redundant Bourgain axiom — derive it from Bloom–Sisask [VERIFIED, 0 new axioms]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3907,6 +3907,7 @@ import Proofs.RiemannHypothesis
 import Proofs.RiemannHypothesisConsequences
 import Proofs.RothTheorem
 import Proofs.RothTheoremAristotle
+import Proofs.RothTheoremOQ01
 import Proofs.RothTheoremOQ02
 import Proofs.RothTheoremOQ03
 import Proofs.RothTheoremQuantitative

--- a/proofs/Proofs/RothTheoremOQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ01.lean
@@ -2,6 +2,7 @@ import Mathlib.Combinatorics.Additive.Corner.Roth
 import Mathlib.Combinatorics.Additive.AP.Three.Behrend
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.Complex.ExponentialBounds
 import Proofs.RothTheoremOQ02
 
 /-!
@@ -14,24 +15,37 @@ theorem on three-term arithmetic progressions:
 
   ∃ C > 0, ∀ N ≥ 3, rothNumberNat N ≤ C · N · (log log N / log N)^(1/2)
 
-The bound is named `rothNumberNat_bourgain` and asserted as a Lean `axiom`,
-exactly mirroring the established gallery pattern used by the sibling file
-`RothTheoremOQ02.lean` for the Bloom–Sisask bound. Supporting names —
-`bourgainConst` (a choice of constant `C`), `bourgainConst_pos` (its
-positivity), and `rothNumberNat_le_bourgain` (the bound at the chosen
-constant) — give downstream consumers a stable API without having to call
-`Exists.choose` manually.
+The bound is named `rothNumberNat_bourgain`.  Unlike the sibling file
+`RothTheoremOQ02.lean` — which *axiomatizes* the Bloom–Sisask bound — this file
+**no longer declares a Bourgain axiom**: `rothNumberNat_bourgain` is now a
+**theorem, derived from the Bloom–Sisask axiom** of OQ-02, because Bloom–Sisask
+(`N / (log N)^{1+c}`) decays strictly faster than the Bourgain bound and so
+implies it.  The earlier version of this file carried a separate
+`axiom rothNumberNat_bourgain`; that axiom was redundant (its own docstring noted
+"OQ-01 is implied by OQ-02"), and has been eliminated.  Supporting names —
+`bourgainConst` (a choice of constant `C`), `bourgainConst_pos` (its positivity),
+and `rothNumberNat_le_bourgain` (the bound at the chosen constant) — give
+downstream consumers a stable API without having to call `Exists.choose` manually.
 
-The file is *intentionally minimal*: it provides the typed landmark, the
-trivial consequence that the axiom is consistent with Mathlib's existing
-qualitative result `rothNumberNat_isLittleO_id`, the consistency with
-Behrend's unconditional lower bound, and — the distinguishing content of
-this OQ — the explicit record that the **Bloom–Sisask bound (OQ-02) is at
-least as strong**, i.e. `rothNumberNat N` is bounded by the *minimum* of the
-Bourgain and Bloom–Sisask right-hand sides. The Lean formalization of
+The distinguishing content is the explicit analytic reduction "Bloom–Sisask ⟹
+Bourgain": the constant is read off the `N = 3` endpoint and the comparison is
+closed by `Real.rpow` monotonicity (details below).  Also recorded: consistency
+with Mathlib's qualitative `rothNumberNat_isLittleO_id`, with Behrend's
+unconditional lower bound, and that `rothNumberNat N` is bounded by the *minimum*
+of the Bourgain and Bloom–Sisask right-hand sides.  The Lean formalization of
 Bourgain's proof itself (discrete Fourier analysis with Bohr-set density
-increment, > 1000 lines of additive-combinatorics infrastructure not yet in
-Mathlib) is deferred.
+increment) remains out of scope; here Bourgain rests only on the *single* gallery
+assumption already present in OQ-02.
+
+## The analytic core (Bloom–Sisask ⟹ Bourgain)
+
+After cancelling the common factor `N > 0` and writing `L = log N`, `LL = log log N`:
+`L^(1+c)` splits as `L^(1/2)·L^(1/2+c)` (`Real.rpow_add`) and `(LL/L)^(1/2)` splits
+as `LL^(1/2)/L^(1/2)` (`Real.div_rpow`), reducing the goal to
+`1 ≤ (LL^(1/2)·L^(1/2+c))/(B·E)` with `B = (log log 3)^(1/2)`, `E = (log 3)^(1/2+c)`.
+Both `LL^(1/2) ≥ B` and `L^(1/2+c) ≥ E` hold by `Real.rpow` monotonicity in the base
+(`log 3 ≤ log N`, `log log 3 ≤ log log N`, valid since `N ≥ 3 ⟹ log N ≥ log 3 > 1
+⟹ log log N > 0`).  Choosing `C = 1/(B·E)` closes it.
 
 ## The Quantitative Landscape
 
@@ -51,13 +65,17 @@ Bloom–Sisask bound `N / (log N)^{1+c}` decays strictly faster than the
 Bourgain bound, **OQ-01 is implied by OQ-02**; this file records that
 implication directly through `rothNumberNat_le_min_bourgain_blasi`.
 
-## Scope (researcher-10, 2026-06-25)
+## Scope (researcher-10, 2026-06-25; axiom eliminated researcher-1, 2026-06-28)
 
-- File status: **axiomatized** (1 axiom, 0 sorries).
+- File status: **axiomatized** — the result rests on the imported
+  `RothTheoremOQ02.rothNumberNat_bloom_sisask`, but this file declares **0 axioms
+  of its own** (the former `axiom rothNumberNat_bourgain` is now a derived theorem),
+  0 sorries.
 - Imports `Mathlib.Combinatorics.Additive.Corner.Roth` (for `rothNumberNat`
   and `rothNumberNat_isLittleO_id`), `...AP.Three.Behrend` (for
-  `Behrend.roth_lower_bound`), the real `log`/`rpow` API, and the sibling
-  `Proofs.RothTheoremOQ02` (for `rothNumberNat_le_blasi`).
+  `Behrend.roth_lower_bound`), the real `log`/`rpow` API, `...ExponentialBounds`
+  (for `Real.exp_one_lt_d9`), and the sibling `Proofs.RothTheoremOQ02` (for
+  `rothNumberNat_bloom_sisask` / `rothNumberNat_le_blasi`).
 - Works at the **Mathlib `rothNumberNat`** level (over `Finset (Fin N)` /
   `ℕ`), *not* the project-local `Szemeredi.Roth.rothNumber` over `ZMod N`
   used in `RothTheorem.lean`, matching OQ-02 and the qualitative
@@ -78,25 +96,83 @@ namespace RothTheoremOQ01
 
 open Asymptotics Filter Topology
 
-/-- **Bourgain's 1999 quantitative bound on the Roth number.** Axiomatic
-statement:
+/-- **Bourgain's 1999 quantitative bound on the Roth number — derived, not axiomatized.**
 
   ∃ C > 0, ∀ N ≥ 3, rothNumberNat N ≤ C · N · (log log N / log N)^(1/2)
 
-Proved analytically by Bourgain (Geom. Funct. Anal. 1999) via a single-step
-density increment on a Bohr set with refined Fourier control; the full proof
-requires Bohr-set geometry not yet in Mathlib at v4.26.0 (pin
-`2df2f0150c275ad`). Asserted here axiomatically so downstream gallery files
-can refer to the bound by name.
+Bourgain (Geom. Funct. Anal. 1999) proved this analytically via a Bohr-set density
+increment; the full proof needs additive-combinatorics infrastructure not in Mathlib.
+But the bound need not be assumed: the **Bloom–Sisask 2020 bound** `rothNumberNat N ≤
+N / (log N)^(1+c)` (`RothTheoremOQ02.rothNumberNat_bloom_sisask`) decays strictly faster,
+so it *implies* Bourgain.  We discharge the implication explicitly, eliminating the
+formerly-separate `axiom rothNumberNat_bourgain`.
 
-The lower bound `N ≥ 3` matches the convention in `RothTheoremOQ02` and
-ensures `Real.log N > Real.log 3 > 1 > 0`, so `Real.log (Real.log N) > 0`,
-the base `log log N / log N` is positive, and the right-hand side is positive
-and the bound is non-vacuous. -/
-axiom rothNumberNat_bourgain :
+The lower bound `N ≥ 3` ensures `log N ≥ log 3 > 1 > 0`, hence `log (log N) > 0`, so the
+base `log log N / log N` is positive and the bound is non-vacuous. -/
+theorem rothNumberNat_bourgain :
     ∃ C : ℝ, 0 < C ∧ ∀ N : ℕ, 3 ≤ N →
       (rothNumberNat N : ℝ) ≤
-        C * (N : ℝ) * (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2)
+        C * (N : ℝ) * (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2) := by
+  obtain ⟨c, hc, hbs⟩ := RothTheoremOQ02.rothNumberNat_bloom_sisask
+  -- endpoint constants at N = 3: `log 3 > 1` and `log log 3 > 0`.
+  have h3R : (0 : ℝ) < 3 := by norm_num
+  have h_e_lt_3 : Real.exp 1 < 3 :=
+    Real.exp_one_lt_d9.trans (by norm_num : (2.7182818286 : ℝ) < 3)
+  have h_one_lt_log3 : (1 : ℝ) < Real.log 3 := by
+    have h := (Real.log_lt_log_iff (Real.exp_pos 1) h3R).mpr h_e_lt_3
+    rwa [Real.log_exp] at h
+  have h_log3_pos : (0 : ℝ) < Real.log 3 := lt_trans one_pos h_one_lt_log3
+  have h_loglog3_pos : (0 : ℝ) < Real.log (Real.log 3) := Real.log_pos h_one_lt_log3
+  set B : ℝ := Real.log (Real.log 3) ^ ((1 : ℝ) / 2) with hB
+  set E : ℝ := Real.log 3 ^ ((1 : ℝ) / 2 + c) with hE
+  have hB_pos : 0 < B := Real.rpow_pos_of_pos h_loglog3_pos _
+  have hE_pos : 0 < E := Real.rpow_pos_of_pos h_log3_pos _
+  refine ⟨1 / (B * E), by positivity, ?_⟩
+  intro N hN
+  -- per-`N` positivity facts.
+  have hNR : (3 : ℝ) ≤ (N : ℝ) := by exact_mod_cast hN
+  have hNpos : (0 : ℝ) < (N : ℝ) := lt_of_lt_of_le h3R hNR
+  have h_log3_le_logN : Real.log 3 ≤ Real.log N := Real.log_le_log h3R hNR
+  have h_one_lt_logN : (1 : ℝ) < Real.log N := lt_of_lt_of_le h_one_lt_log3 h_log3_le_logN
+  have h_logN_pos : (0 : ℝ) < Real.log N := lt_trans one_pos h_one_lt_logN
+  have h_loglogN_pos : (0 : ℝ) < Real.log (Real.log N) := Real.log_pos h_one_lt_logN
+  have h_loglog3_le : Real.log (Real.log 3) ≤ Real.log (Real.log N) :=
+    Real.log_le_log h_log3_pos h_log3_le_logN
+  -- the Bloom–Sisask bound at this `N`.
+  have hbsN : (rothNumberNat N : ℝ) ≤ (N : ℝ) / Real.log N ^ (1 + c) := hbs N hN
+  -- the analytic comparison: Bloom–Sisask RHS ≤ Bourgain RHS.
+  have hkey : (N : ℝ) / Real.log N ^ (1 + c) ≤
+      (1 / (B * E)) * (N : ℝ) * (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2) := by
+    have hLpow_pos : (0 : ℝ) < Real.log N ^ (1 + c) := Real.rpow_pos_of_pos h_logN_pos _
+    -- L^(1+c) = L^(1/2) · L^(1/2+c)
+    have hLsplit : Real.log N ^ (1 + c)
+        = Real.log N ^ ((1 : ℝ) / 2) * Real.log N ^ ((1 : ℝ) / 2 + c) := by
+      rw [← Real.rpow_add h_logN_pos]; congr 1; ring
+    -- (LL/L)^(1/2) = LL^(1/2) / L^(1/2)
+    have hdiv : (Real.log (Real.log N) / Real.log N) ^ ((1 : ℝ) / 2)
+        = Real.log (Real.log N) ^ ((1 : ℝ) / 2) / Real.log N ^ ((1 : ℝ) / 2) := by
+      rw [Real.div_rpow h_loglogN_pos.le h_logN_pos.le]
+    -- base-monotonicity of the two `rpow` factors.
+    have hBmono : B ≤ Real.log (Real.log N) ^ ((1 : ℝ) / 2) :=
+      Real.rpow_le_rpow h_loglog3_pos.le h_loglog3_le (by norm_num)
+    have hEmono : E ≤ Real.log N ^ ((1 : ℝ) / 2 + c) :=
+      Real.rpow_le_rpow h_log3_pos.le h_log3_le_logN (by positivity)
+    rw [div_le_iff₀ hLpow_pos, hdiv, hLsplit]
+    have heq : (1 / (B * E)) * (N : ℝ) *
+        (Real.log (Real.log N) ^ ((1 : ℝ) / 2) / Real.log N ^ ((1 : ℝ) / 2)) *
+          (Real.log N ^ ((1 : ℝ) / 2) * Real.log N ^ ((1 : ℝ) / 2 + c))
+        = (Real.log (Real.log N) ^ ((1 : ℝ) / 2) * Real.log N ^ ((1 : ℝ) / 2 + c)) / (B * E)
+            * (N : ℝ) := by
+      have hsne : Real.log N ^ ((1 : ℝ) / 2) ≠ 0 := ne_of_gt (Real.rpow_pos_of_pos h_logN_pos _)
+      field_simp
+      try ring
+    rw [heq]
+    have hat : B * E ≤ Real.log (Real.log N) ^ ((1 : ℝ) / 2) * Real.log N ^ ((1 : ℝ) / 2 + c) :=
+      mul_le_mul hBmono hEmono hE_pos.le (le_trans hB_pos.le hBmono)
+    have h1le : 1 ≤ (Real.log (Real.log N) ^ ((1 : ℝ) / 2) * Real.log N ^ ((1 : ℝ) / 2 + c))
+        / (B * E) := (one_le_div (by positivity)).mpr hat
+    exact le_mul_of_one_le_left hNpos.le h1le
+  exact le_trans hbsN hkey
 
 /-- A canonical choice of the Bourgain constant `C > 0` extracted from the
 axiom via `Exists.choose`. Marked `noncomputable` because `Exists.choose`
@@ -179,5 +255,10 @@ theorem rothNumberNat_le_min_bourgain_blasi (N : ℕ) (hN : 3 ≤ N) :
 #check bourgain_consistent_with_isLittleO
 #check bourgain_consistent_with_Behrend
 #check rothNumberNat_le_min_bourgain_blasi
+
+-- Axiom audit: `rothNumberNat_bourgain` is now a THEOREM.  Its only non-foundational
+-- dependency is the imported `RothTheoremOQ02.rothNumberNat_bloom_sisask` — there is NO
+-- separate Bourgain axiom, and no `sorryAx` / `Lean.ofReduceBool`.
+#print axioms rothNumberNat_bourgain
 
 end RothTheoremOQ01

--- a/research/problems/roth-theorem-oq-01/knowledge.md
+++ b/research/problems/roth-theorem-oq-01/knowledge.md
@@ -115,3 +115,59 @@ currently match nothing due to casing) and the rest only shed misattributed sibl
 real root fix but has a large blast radius and cannot be render-verified during the Docker
 blackout — left as a recommendation rather than shipped. Per-slug `SPECIAL_CASES` remains the
 safe interim patch.
+
+---
+
+## Session 2026-06-28 (researcher-1) — ACT: eliminated the redundant Bourgain axiom
+
+**Mode**: REVISIT (axiom elimination) · **Outcome**: progress (1 axiom removed from the gallery).
+
+### Stale-knowledge correction
+This KB previously recorded "no `RothTheoremOQ01*.lean` exists" and `leanFiles = []`. That was
+**out of date**: `proofs/Proofs/RothTheoremOQ01.lean` exists (researcher-10, 2026-06-25) and
+carried a **separate `axiom rothNumberNat_bourgain`** — the exact thing the M1 plan flagged as
+avoidable, since its own docstring noted "OQ-01 is implied by OQ-02".
+
+### What I did
+Replaced `axiom rothNumberNat_bourgain` with a **theorem** of the same statement, **derived from
+the Bloom–Sisask axiom** of OQ-02. Bloom–Sisask (`N/(log N)^{1+c}`) decays strictly faster than
+Bourgain (`N(loglog N/log N)^{1/2}`), so it implies it. The whole quantitative landscape now
+rests on the *single* gallery assumption `RothTheoremOQ02.rothNumberNat_bloom_sisask` instead of
+two redundant axioms.
+- Registered the file in `proofs/Proofs.lean` (its sibling OQ02 was already registered; OQ01 was
+  orphaned from the aggregate build).
+- Host-verified: `lake env lean Proofs/RothTheoremOQ01.lean` exit 0 (built OQ02 olean dep via
+  `lake env lean -o` first; Docker host down). `#print axioms rothNumberNat_bourgain` =
+  `[propext, Classical.choice, Quot.sound, RothTheoremOQ02.rothNumberNat_bloom_sisask]` — **no
+  Bourgain axiom**, no `sorryAx`, no `Lean.ofReduceBool`.
+
+### The analytic core (Bloom–Sisask ⟹ Bourgain) — what worked
+After cancelling `N>0` and writing `L=log N`, `LL=loglog N`:
+- `Real.rpow_add h_logN_pos`: `L^(1+c) = L^(1/2)·L^(1/2+c)` (close exponent equality with
+  `congr 1; ring`, NOT `norm_num` — norm_num won't combine `1/2+(1/2+c)` under rpow).
+- `Real.div_rpow LL.le L.le`: `(LL/L)^(1/2) = LL^(1/2)/L^(1/2)` (apply via `rw`, the lemma is
+  `∀ z`-quantified).
+- Reduce to `1 ≤ (LL^(1/2)·L^(1/2+c))/(B·E)` with `B=(loglog 3)^(1/2)`, `E=(log 3)^(1/2+c)`,
+  `C := 1/(B·E)`. Both `LL^(1/2)≥B`, `L^(1/2+c)≥E` by `Real.rpow_le_rpow` (base monotone:
+  `log 3 ≤ log N`, `loglog 3 ≤ loglog N`).
+- GOTCHAS: `div_le_iff₀` (not `div_le_iff`, deprecated in 4.26); `Real.log_le_log (0<x) (x≤y)`
+  takes the *inner* positivity `0 < log 3` for `log(log 3) ≤ log(log N)` (NOT `0 < log log 3`);
+  `field_simp` closed the algebra identity alone, so guard the trailing `ring` with `try`.
+- Constant ≥1 step via `le_mul_of_one_le_left hNpos.le (one_le_div ...).mpr hat`.
+
+### Honest status
+Still **axiomatized** — rests on the BS axiom (the full Bloom–Sisask/Bourgain proofs are
+thousands of lines of Bohr-set/Fourier infrastructure not in Mathlib). But the file now declares
+**0 axioms of its own**: net gallery axiom count for the Roth quantitative landscape drops by 1.
+
+### Files modified
+- proofs/Proofs/RothTheoremOQ01.lean (axiom → derived theorem; docstring updated)
+- proofs/Proofs.lean (registered RothTheoremOQ01)
+- research/problems/roth-theorem-oq-01/knowledge.md (this entry; corrected stale leanFiles claim)
+- src/data/research/problems/roth-theorem-oq-01.json (leanFiles, lastUpdate)
+
+### Next steps
+- Same `≤` derivation could eliminate the Kelley–Meka or other "weaker-than-BS" quantitative
+  axioms if any are added (KM is actually *stronger* than BS in a different regime — not derivable
+  this way). The remaining genuine open work is the from-scratch Bourgain/BS proof (BLOCKED on
+  Mathlib Bohr-set infrastructure, >1000 LOC).

--- a/src/data/research/problems/roth-theorem-oq-01.json
+++ b/src/data/research/problems/roth-theorem-oq-01.json
@@ -63,16 +63,16 @@
     "mathlib": []
   },
   "started": "2026-06-15T02:22:21.995Z",
-  "lastUpdate": "2026-06-25T00:00:00.000Z",
+  "lastUpdate": "2026-06-28",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/RothTheoremOQ01.lean",
       "filename": "RothTheoremOQ01.lean",
-      "lineCount": 184,
-      "theoremCount": 6,
-      "axiomCount": 3,
+      "lineCount": 264,
+      "theoremCount": 7,
+      "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

**Axiom elimination.** `proofs/Proofs/RothTheoremOQ01.lean` (Bourgain's 1999 quantitative Roth bound) carried a standalone `axiom rothNumberNat_bourgain`. Its own docstring already noted "OQ-01 is implied by OQ-02": the Bloom–Sisask 2020 bound `rothNumberNat N ≤ N / (log N)^(1+c)` decays strictly faster than the Bourgain bound `N·(log log N / log N)^(1/2)`, so it **implies** it. This PR discharges that implication, replacing the axiom with a **derived theorem** of the identical statement.

Net effect: the gallery's Roth quantitative landscape now rests on the **single** assumption `RothTheoremOQ02.rothNumberNat_bloom_sisask` instead of two redundant axioms.

```
#print axioms rothNumberNat_bourgain
  ⟹ [propext, Classical.choice, Quot.sound, RothTheoremOQ02.rothNumberNat_bloom_sisask]
```
No separate Bourgain axiom; no `sorryAx`; no `Lean.ofReduceBool`.

## The analytic core (Bloom–Sisask ⟹ Bourgain)

After cancelling `N > 0` and writing `L = log N`, `LL = log log N`:
- `Real.rpow_add`: `L^(1+c) = L^(1/2)·L^(1/2+c)`
- `Real.div_rpow`: `(LL/L)^(1/2) = LL^(1/2)/L^(1/2)`
- reduces to `1 ≤ (LL^(1/2)·L^(1/2+c)) / (B·E)` with `B = (log log 3)^(1/2)`, `E = (log 3)^(1/2+c)`, constant `C = 1/(B·E)` read off the `N = 3` endpoint.
- `LL^(1/2) ≥ B` and `L^(1/2+c) ≥ E` by `Real.rpow` monotonicity in the base (`log 3 ≤ log N`, `log log 3 ≤ log log N`, valid since `N ≥ 3 ⟹ log N ≥ log 3 > 1 ⟹ log log N > 0`).

The downstream API (`bourgainConst`, `bourgainConst_pos`, `rothNumberNat_le_bourgain`, the consistency lemmas) is unchanged — it now rests on a theorem rather than an axiom. The file is also registered in `Proofs.lean` (its sibling OQ02 already was; OQ01 had been orphaned from the aggregate build).

## Honest status

Still **axiomatized** — the result rests on the Bloom–Sisask axiom (the full BS/Bourgain proofs are thousands of lines of Bohr-set/Fourier infrastructure absent from Mathlib). But the file now declares **0 axioms of its own**: this is a genuine theorem conditional on the existing gallery axiom, removing a redundant assumption.

## Verification

- `lake env lean Proofs/RothTheoremOQ01.lean` → exit 0 (host; shared Mathlib 4.26 `.olean` cache; OQ02 olean dep built via `lake env lean -o`; Docker host down).
- Axiom audit as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)