### PR TITLE
Enrich erdos-1010-oq-01: add annotations (0 → 6)

### DIFF
--- a/src/data/proofs/erdos-1010-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1010-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-definitions",
+    "proofId": "erdos-1010-oq-01",
+    "range": { "startLine": 58, "endLine": 66 },
+    "type": "definition",
+    "title": "Turán threshold and triangle count",
+    "content": "Two definitions mirroring the parent file Erdos1010Problem.lean. `turanThreshold n := n²/4` is the maximum edge count of a triangle-free graph on n vertices (Turán's theorem for K₃, achieved by the balanced complete bipartite graph). `triangleCount G` counts triangles as 3-element vertex subsets that are pairwise adjacent — a directly decidable formulation over a Fintype, deliberately avoiding heavy clique-enumeration machinery so the concrete witness counts close by `decide`.",
+    "mathContext": "$\\mathrm{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$; $\\mathrm{triangleCount}(G) = \\#\\{ s \\subseteq V : |s| = 3,\\ s\\ \\text{a clique}\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Turán's theorem", "triangle-free graphs", "clique counting", "Fintype-decidable predicates"],
+    "prerequisites": ["extremal graph theory basics", "SimpleGraph and Finset in Mathlib"]
+  },
+  {
+    "id": "ann-crossover",
+    "proofId": "erdos-1010-oq-01",
+    "range": { "startLine": 83, "endLine": 90 },
+    "type": "insight",
+    "title": "The crossover lemma — arithmetic heart of the transition",
+    "content": "The whole phenomenon reduces to one Nat inequality: (t+1)·k < t·(k+1) ↔ k < t. Both products ring-normalise to t·k + k and t·k + t, after which `omega` finishes. Interpreted in the extremal setting with m = k+1 = ⌊n/2⌋: the unbalanced construction K_{m-1,m+1} + (t+1) internal edges produces (t+1)(m-1) triangles, which dips below the balanced construction's t·m exactly when t ≥ m. So the regime change is located at a single exact value with no graph theory at all — just arithmetic. Stated with m = k+1 to keep m−1 = k clear of truncated Nat subtraction.",
+    "mathContext": "$(t+1)k < t(k+1) \\iff k < t$, since $(t+1)k = tk + k$ and $t(k+1) = tk + t$.",
+    "significance": "key",
+    "relatedConcepts": ["ring normalization", "omega decision procedure", "Nat subtraction pitfalls", "extremal regime transition"],
+    "prerequisites": ["natural-number arithmetic in Lean", "ring and omega tactics"]
+  },
+  {
+    "id": "ann-linear-bound-beaten",
+    "proofId": "erdos-1010-oq-01",
+    "range": { "startLine": 92, "endLine": 100 },
+    "type": "insight",
+    "title": "Linear bound is beaten iff t ≥ ⌊n/2⌋",
+    "content": "Recasts the crossover for m = ⌊n/2⌋ ≥ 1 with honest Nat subtraction: (t+1)(m−1) < t·m ↔ m ≤ t. The proof destructures m = k+1 via `Nat.exists_eq_add_of_lt`, simplifies m−1 to k with `Nat.add_sub_cancel`, then applies `crossover`. This is the formal statement that the conclusion of Erdős #1010 (at least t·⌊n/2⌋ triangles) cannot extend past t = ⌊n/2⌋: at and beyond that threshold the unbalanced complete-bipartite base yields strictly fewer triangles than the linear prediction.",
+    "mathContext": "For $m \\ge 1$: $(t+1)(m-1) < t\\,m \\iff m \\le t$, with $m = \\lfloor n/2 \\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": ["sharpness of a hypothesis", "complete bipartite constructions", "Nat.exists_eq_add_of_lt", "supersaturation"],
+    "prerequisites": ["the crossover lemma above", "Lovász–Simonovits supersaturation bound (parent)"]
+  },
+  {
+    "id": "ann-witness-graph",
+    "proofId": "erdos-1010-oq-01",
+    "range": { "startLine": 120, "endLine": 138 },
+    "type": "definition",
+    "title": "Explicit witness graph Gw = K_{2,4} + C₄ on Fin 6",
+    "content": "Realizes the unbalanced construction at the first failing value n = 6, t = 3. The graph is given as a fixed 6×6 boolean adjacency matrix `Mbool`: rows/cols 0–1 are the smaller side S = {0,1}, rows/cols 2–5 the larger side B = {2,3,4,5}. The S–B block is the complete bipartite K_{2,4} (8 edges); the B-block is the 4-cycle 2–3–4–5–2 (4 edges, triangle-free — the diagonals 2–4 and 3–5 are absent). `Gw` wraps this matrix as a SimpleGraph, discharging symmetry and looplessness by `decide` on the concrete matrix, with a matching DecidableRel instance so all downstream counts are decidable.",
+    "mathContext": "$G_w = K_{2,4} \\cup C_4(B)$ on $\\mathrm{Fin}\\,6$; smaller side $\\{0,1\\}$, larger side $\\{2,3,4,5\\}$ carrying the 4-cycle.",
+    "significance": "supporting",
+    "relatedConcepts": ["adjacency matrix", "complete bipartite graph", "4-cycle C₄", "DecidableRel instance", "SimpleGraph construction"],
+    "prerequisites": ["Fin n and Matrix notation in Lean", "SimpleGraph structure fields (symm, loopless)"]
+  },
+  {
+    "id": "ann-witness-counts",
+    "proofId": "erdos-1010-oq-01",
+    "range": { "startLine": 140, "endLine": 145 },
+    "type": "technique",
+    "title": "Edge and triangle counts by plain decide",
+    "content": "`witness_edge_count` certifies Gw has exactly turanThreshold 6 + 3 = 12 edges (8 from K_{2,4}, 4 from the cycle), placing it at t = 3 = ⌊n/2⌋ past the Turán threshold. `witness_triangle_count` certifies exactly 8 triangles: each of the 4 cycle-edges in B pairs with each of the 2 vertices of S (4·2 = 8), and there are no others (S has no internal edge, the C₄ has no triangle). Both close by plain `decide` on the concrete finite graph — crucially NOT `native_decide`, so no `Lean.ofReduceBool` axiom is incurred; `#print axioms` reports only the foundational three.",
+    "mathContext": "$|E(G_w)| = \\lfloor 6^2/4 \\rfloor + 3 = 12$ and $\\mathrm{triangleCount}(G_w) = 4 \\cdot 2 = 8$.",
+    "significance": "key",
+    "relatedConcepts": ["kernel decide vs native_decide", "axiom-free verification", "edge counting", "triangle bookkeeping"],
+    "prerequisites": ["the witness graph definition above", "Decidable finite computations"]
+  },
+  {
+    "id": "ann-headline-sharpness",
+    "proofId": "erdos-1010-oq-01",
+    "range": { "startLine": 147, "endLine": 167 },
+    "type": "insight",
+    "title": "Headline: the bound fails at t = ⌊n/2⌋ (sharpness)",
+    "content": "`supersaturation_bound_fails_at_threshold` combines the counts into the answer to OQ-01: at t = ⌊n/2⌋ (n = 6, t = 3) there is a graph with ⌊n²/4⌋ + t edges and only 8 triangles — strictly below the linear prediction t·⌊n/2⌋ = 9. Hence the hypothesis t < ⌊n/2⌋ of Erdős #1010 is sharp and the linear regime ends precisely here. `supersaturation_fails_card` restates this through `Fintype.card (Fin 6) = 6`, making explicit that n is the vertex count and t = n/2, so the violated quantity is genuinely the parent's extrapolated bound.",
+    "mathContext": "$8 < 3 \\cdot 3 = 9$ at $t = \\lfloor 6/2 \\rfloor$: the bound $t\\,\\lfloor n/2\\rfloor$ does not survive $t \\ge \\lfloor n/2 \\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": ["counterexample / sharp hypothesis", "Erdős–Rademacher problem", "Fintype.card restatement", "supersaturation threshold"],
+    "prerequisites": ["the crossover and witness lemmas above", "statement of Erdős #1010 (parent)"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-1010-oq-01` (Triangle supersaturation sharpness, Erdős #1010 OQ-01).

**Gap closed:** `annotations.json` did not exist. meta.json is already comprehensive (15.9 KB, under cap); the quality deficit (q=43) was entirely missing inline annotations.

**Added 6 annotations**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, mapped to actual theorem line ranges:
- Shared definitions (`turanThreshold`, `triangleCount`)
- `crossover` — arithmetic heart, (t+1)k < t(k+1) ↔ k<t
- `linear_bound_beaten_iff` — beaten iff t ≥ ⌊n/2⌋
- Explicit witness graph `Gw = K_{2,4}+C₄` on Fin 6
- `witness_edge_count`/`witness_triangle_count` (plain decide, no native_decide)
- Headline `supersaturation_bound_fails_at_threshold` + `supersaturation_fails_card`

JSON validated; all ranges within the 167-line file; meta within size caps. No status/badge/axiomCount changes (verified, 0-axiom confirmed accurate against the Lean source).