### PR TITLE
research(spectral-trace-det-eigenvalues-oq-01-oq-01): general trace power sum for diagonal + upper-triangular matrices [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean
+++ b/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean
@@ -37,7 +37,10 @@ available cleanly from [oq-01] is the tautological reading
   i.e. the trace of `Aᵏ` is the sum of the eigenvalues *of `Aᵏ`*.
 
 Identifying those `μⱼ` with `λᵢ ᵏ` (the multiset spectral mapping for the full characteristic
-polynomial) is the remaining content; see the closing note.
+polynomial) is the remaining content. The closing sections below establish this mapping
+unconditionally for **diagonal** and **upper-triangular** matrices — the computational core — and
+isolate the single classical ingredient (Schur triangularisation over an algebraically closed
+field) needed to extend it to every matrix.
 
 All results below are fully machine-checked with no `sorry` and no extra axioms.
 -/
@@ -147,9 +150,133 @@ theorem trace_sq_example :
       = ((eigenvalues (!![(1 : ℂ), 2; 3, 4])).map (· ^ 2)).sum := by
   rw [trace_sq_eq_sum_sq_eigenvalues]
 
+/-! ### From the spectral mapping to the general power sum
+
+The general trace power sum `tr(Aᵏ) = Σ λᵢᵏ`, valid in **every** dimension, is equivalent to the
+*multiset spectral mapping* `eigenvalues (Aᵏ) = (eigenvalues A).map (· ^ k)`. We record this
+reduction, then discharge the spectral mapping **unconditionally** for two structured families that
+between them form the computational core of the general statement: **diagonal** matrices and
+**upper-triangular** matrices. For an upper-triangular `M`, `M.charpoly = ∏ᵢ (X − C (M i i))` and the
+diagonal of `Mᵏ` is `(M i i)ᵏ`, so the eigenvalue multiset maps under `(· ^ k)` directly — no
+algebraic-closure hypothesis is even needed for the multiset identity. The only remaining ingredient
+for an *arbitrary* matrix is the classical Schur/triangularisation fact that over an algebraically
+closed field every matrix is conjugate to an upper-triangular one, which is not yet available at the
+matrix level in Mathlib (only `Module.End`-level generalized-eigenspace decompositions and
+`RCLike` Schur triangulation are present). -/
+
+/-- Roots of `∏ i, (X - C (f i))` are exactly the multiset of values `f i`. -/
+theorem prod_X_sub_C_roots (f : n → K) :
+    (∏ i, (X - C (f i))).roots = Finset.univ.val.map f := by
+  have h : (∏ i, (X - C (f i)))
+      = ((Finset.univ.val.map f).map (fun a => X - C a)).prod := by
+    rw [Multiset.map_map]; rfl
+  rw [h, roots_multiset_prod_X_sub_C]
+
+/-- **Reduction.** The general eigenvalue power sum `tr(Aᵏ) = Σ λᵢᵏ` follows from the multiset
+spectral mapping `eigenvalues (Aᵏ) = (eigenvalues A).map (· ^ k)`: substitute the latter into the
+tautological `trace_pow_eq_sum_eigenvalues_pow_self`. -/
+theorem trace_pow_of_eigenvalues_pow [IsAlgClosed K] (A : Matrix n n K) (k : ℕ)
+    (h : eigenvalues (A ^ k) = (eigenvalues A).map (· ^ k)) :
+    (A ^ k).trace = ((eigenvalues A).map (· ^ k)).sum := by
+  rw [trace_pow_eq_sum_eigenvalues_pow_self, h]
+
+/-! #### Diagonal matrices: the spectral mapping holds in every dimension -/
+
+/-- The eigenvalue multiset of a diagonal matrix is the multiset of its diagonal entries. -/
+theorem eigenvalues_diagonal (d : n → K) :
+    eigenvalues (diagonal d) = Finset.univ.val.map d := by
+  unfold eigenvalues; rw [charpoly_diagonal, prod_X_sub_C_roots]
+
+/-- **Multiset spectral mapping for diagonal matrices** (all `n`, all `k`):
+`eigenvalues ((diagonal d)ᵏ) = (eigenvalues (diagonal d)).map (· ^ k)`. -/
+theorem eigenvalues_pow_diagonal (d : n → K) (k : ℕ) :
+    eigenvalues (diagonal d ^ k) = (eigenvalues (diagonal d)).map (· ^ k) := by
+  rw [diagonal_pow, eigenvalues_diagonal, eigenvalues_diagonal, Multiset.map_map]; rfl
+
+/-- **Eigenvalue power sum for diagonal matrices** (all `n`, all `k`):
+`tr ((diagonal d)ᵏ) = Σ λᵢᵏ`. -/
+theorem trace_pow_eq_sum_pow_eigenvalues_diagonal [IsAlgClosed K] (d : n → K) (k : ℕ) :
+    (diagonal d ^ k).trace = ((eigenvalues (diagonal d)).map (· ^ k)).sum :=
+  trace_pow_of_eigenvalues_pow (diagonal d) k (eigenvalues_pow_diagonal d k)
+
+/-! #### Upper-triangular matrices: the computational core of the spectral mapping -/
+
+section Triangular
+variable {N : Type*} [Fintype N] [DecidableEq N] [LinearOrder N]
+
+/-- The characteristic matrix `X • 1 − M` of an upper-triangular matrix is upper-triangular. -/
+theorem charmatrix_blockTriangular {M : Matrix N N K} (hM : M.BlockTriangular id) :
+    (charmatrix M).BlockTriangular id := by
+  intro i j hij
+  have hlt : j < i := hij
+  rw [charmatrix_apply_ne M i j (ne_of_lt hlt).symm, hM hij, map_zero, neg_zero]
+
+/-- **Characteristic polynomial of an upper-triangular matrix** is `∏ᵢ (X − C (M i i))`, the
+product over the diagonal entries (its roots are precisely the diagonal, with multiplicity). -/
+theorem charpoly_blockTriangular {M : Matrix N N K} (hM : M.BlockTriangular id) :
+    M.charpoly = ∏ i, (X - C (M i i)) := by
+  rw [Matrix.charpoly, det_of_upperTriangular (charmatrix_blockTriangular hM)]
+  simp only [charmatrix_apply_eq]
+
+/-- The `(i,i)` entry of a product of two upper-triangular matrices is the product of their
+`(i,i)` entries (off-diagonal cross terms vanish by triangularity). -/
+theorem blockTriangular_mul_diag {M P : Matrix N N K}
+    (hM : M.BlockTriangular id) (hP : P.BlockTriangular id) (i : N) :
+    (M * P) i i = M i i * P i i := by
+  rw [Matrix.mul_apply, Finset.sum_eq_single i]
+  · intro j _ hji
+    rcases lt_or_gt_of_ne hji with h | h
+    · rw [hM h, zero_mul]
+    · rw [hP h, mul_zero]
+  · intro hni; exact absurd (Finset.mem_univ i) hni
+
+/-- Powers of an upper-triangular matrix are upper-triangular. -/
+theorem blockTriangular_pow {M : Matrix N N K} (hM : M.BlockTriangular id) (k : ℕ) :
+    (M ^ k).BlockTriangular id := by
+  induction k with
+  | zero => simpa using blockTriangular_one
+  | succ k ih => rw [pow_succ]; exact ih.mul hM
+
+/-- The diagonal of `Mᵏ` is the `k`-th power of the diagonal of an upper-triangular `M`:
+`(Mᵏ) i i = (M i i)ᵏ`. -/
+theorem blockTriangular_pow_diag {M : Matrix N N K} (hM : M.BlockTriangular id) (k : ℕ) (i : N) :
+    (M ^ k) i i = (M i i) ^ k := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+      rw [pow_succ, blockTriangular_mul_diag (blockTriangular_pow hM k) hM i, ih, pow_succ]
+
+/-- The eigenvalue multiset of an upper-triangular matrix is the multiset of its diagonal entries. -/
+theorem eigenvalues_blockTriangular {M : Matrix N N K} (hM : M.BlockTriangular id) :
+    eigenvalues M = Finset.univ.val.map (fun i => M i i) := by
+  unfold eigenvalues; rw [charpoly_blockTriangular hM, prod_X_sub_C_roots]
+
+/-- **Multiset spectral mapping for upper-triangular matrices** (any field, all `k`):
+`eigenvalues (Mᵏ) = (eigenvalues M).map (· ^ k)`. This is the genuinely spectral computational
+core; the general case for arbitrary matrices reduces to it via Schur triangularisation. -/
+theorem eigenvalues_pow_blockTriangular {M : Matrix N N K} (hM : M.BlockTriangular id) (k : ℕ) :
+    eigenvalues (M ^ k) = (eigenvalues M).map (· ^ k) := by
+  rw [eigenvalues_blockTriangular (blockTriangular_pow hM k), eigenvalues_blockTriangular hM,
+    Multiset.map_map]
+  apply Multiset.map_congr rfl
+  intro i _
+  exact blockTriangular_pow_diag hM k i
+
+/-- **Eigenvalue power sum for upper-triangular matrices** (all `k`):
+`tr (Mᵏ) = Σ λᵢᵏ` over the eigenvalues (diagonal entries) of an upper-triangular `M`. -/
+theorem trace_pow_eq_sum_pow_eigenvalues_blockTriangular [IsAlgClosed K] {M : Matrix N N K}
+    (hM : M.BlockTriangular id) (k : ℕ) :
+    (M ^ k).trace = ((eigenvalues M).map (· ^ k)).sum :=
+  trace_pow_of_eigenvalues_pow M k (eigenvalues_pow_blockTriangular hM k)
+
+end Triangular
+
 end SpectralTraceDetEigenvaluesOQ01OQ01
 
 #print axioms SpectralTraceDetEigenvaluesOQ01OQ01.det_pow_eq_prod_pow_eigenvalues
 #print axioms SpectralTraceDetEigenvaluesOQ01OQ01.trace_pow_eq_sum_eigenvalues_pow_self
 #print axioms SpectralTraceDetEigenvaluesOQ01OQ01.prod_map_pow_eigenvalues
 #print axioms SpectralTraceDetEigenvaluesOQ01OQ01.trace_sq_eq_sum_sq_eigenvalues
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01.eigenvalues_pow_diagonal
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01.eigenvalues_pow_blockTriangular
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01.trace_pow_eq_sum_pow_eigenvalues_blockTriangular

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01/meta.json
@@ -18,7 +18,8 @@
       "newtons-identities",
       "spectral-mapping",
       "symmetric-functions",
-      "research"
+      "research",
+      "triangular-matrices"
     ],
     "proofRepoPath": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean",
     "badge": "original",
@@ -67,13 +68,19 @@
       "trace_pow_eq_sum_eigenvalues_pow_self: the tautological-but-useful reading tr(Aᵏ) = Σ(eigenvalues of Aᵏ), the oq-01 trace identity applied to the power matrix",
       "trace_sq_eq_sum_sq_eigenvalues: the genuine trace power sum tr(A²) = λ₁² + λ₂² for 2×2 matrices over an algebraically closed field, the first Newton identity p₂ = e₁² − 2e₂ with e₁ = trace and e₂ = determinant — the headline power-sum statement in the first nontrivial dimension",
       "sum_sq_of_card_eq_two: Newton's identity Σxᵢ² = (Σxᵢ)² − 2∏xᵢ for a two-element multiset, the dimension-free heart of the 2×2 trace power sum",
-      "det_sq_example / trace_sq_example: det(A²) = 4 and tr(A²) = 29 for !![1,2;3,4] over ℂ — the product and sum of the SQUARED irrational eigenvalues (5 ± √33)/2, read off without computing them"
+      "det_sq_example / trace_sq_example: det(A²) = 4 and tr(A²) = 29 for !![1,2;3,4] over ℂ — the product and sum of the SQUARED irrational eigenvalues (5 ± √33)/2, read off without computing them",
+      "eigenvalues_pow_blockTriangular: the multiset spectral mapping eigenvalues(Mᵏ) = (eigenvalues M).map(·^k) for every upper-triangular (BlockTriangular id) matrix over ANY field and all k — the genuinely spectral computational core of the general trace power sum, with the general case for arbitrary matrices reducing to it purely via Schur triangularisation",
+      "charpoly_blockTriangular: the characteristic polynomial of an upper-triangular matrix equals ∏ᵢ (X − C (M i i)) over its diagonal, via charmatrix_blockTriangular (the characteristic matrix of a triangular matrix is triangular) and Mathlib det_of_upperTriangular",
+      "blockTriangular_pow_diag: the diagonal of Mᵏ is (M i i)ᵏ for upper-triangular M, proved by induction using blockTriangular_mul_diag (diagonal entry of a product of triangular matrices is the product of the diagonal entries)",
+      "trace_pow_eq_sum_pow_eigenvalues_blockTriangular: tr(Mᵏ) = Σ λᵢᵏ for every upper-triangular matrix over an algebraically closed field, all k — the general (all-dimension) trace power sum specialised to triangular form",
+      "eigenvalues_pow_diagonal / trace_pow_eq_sum_pow_eigenvalues_diagonal: the spectral mapping and trace power sum tr((diagonal d)ᵏ) = Σ (d i)ᵏ for diagonal matrices in EVERY dimension n and all k",
+      "trace_pow_of_eigenvalues_pow: the reduction lemma showing the full general trace power sum tr(Aᵏ) = Σ λᵢᵏ follows immediately from the multiset spectral mapping eigenvalues(Aᵏ) = (eigenvalues A).map(·^k), isolating the single remaining classical ingredient (Schur triangularisation)"
     ],
     "dateAdded": "2026-06-24",
-    "lineCount": 155,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used. The spectral identities require an algebraically closed field. SCOPE: the determinant power identity det(Aᵏ)=Π(λᵢᵏ) is proven in full generality (all n, all k); the trace power sum tr(Aᵏ)=Σλᵢᵏ is proven for 2×2 matrices (k=2). The general trace power sum for all n is NOT proven here — it is equivalent to the eigenvalue multiset of Aᵏ being (eigenvalues A).map(·^k), i.e. the full multiset spectral mapping, which the current Mathlib snapshot (v4.26.0) does not supply (no Schur triangulation over a general algebraically closed field, no Newton-identity bridge from charpoly coefficients to root power sums). That generalisation is left as the standing open question.",
+    "lineCount": 282,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlibs foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used. The spectral identities require an algebraically closed field. SCOPE: the determinant power identity det(Aᵏ)=Π(λᵢᵏ) is proven in full generality (all n, all k). The trace power sum tr(Aᵏ)=Σλᵢᵏ is now proven, in EVERY dimension and for all k, for two structured families — diagonal matrices and upper-triangular (BlockTriangular id) matrices — via the multiset spectral mapping eigenvalues(Mᵏ)=(eigenvalues M).map(·^k), established from charpoly_blockTriangular and blockTriangular_pow_diag (no algebraic closure even needed for the multiset identity itself). The remaining gap to arbitrary matrices is isolated to a single classical ingredient — Schur/triangularisation over an algebraically closed field — which the current Mathlib snapshot (v4.26.0) does not supply at the matrix level (only Module.End-level generalized-eigenspace decompositions and RCLike Schur triangulation). The reduction lemma trace_pow_of_eigenvalues_pow makes this dependency explicit. The fully general trace power sum for arbitrary matrices remains the standing open question.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 23,
     "definitionCount": 1
   },
   "overview": {
@@ -162,9 +169,9 @@
       "Polynomial"
     ],
     "namespace": "SpectralTraceDetEigenvaluesOQ01OQ01",
-    "lineCount": 155,
+    "lineCount": 282,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 23,
     "definitionCount": 1,
     "path": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/spectral-trace-det-eigenvalues-oq-01-oq-01.json
+++ b/src/data/research/problems/spectral-trace-det-eigenvalues-oq-01-oq-01.json
@@ -39,7 +39,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PARTIAL/SHIPPED: verified 0-axiom entry proving det(Aᵏ)=Π(λᵢᵏ) for all n,k and tr(A²)=Σλᵢ² for 2×2 (Newton). General trace power sum for all n remains open, blocked on the multiset spectral mapping absent from Mathlib.",
+    "progressSummary": "PROGRESS: general trace power sum tr(Aᵏ)=Σλᵢᵏ now VERIFIED in every dimension for diagonal AND upper-triangular matrices (PR #31184, 13 new 0-axiom theorems). Open problem reduced (trace_pow_of_eigenvalues_pow) to the single classical Mathlib gap: matrix-level Schur triangularisation over an alg-closed field.",
     "builtItems": [
       "det_pow_eq_prod_pow_eigenvalues: det(Aᵏ) = Π(λᵢᵏ) over IsAlgClosed K, all n and k — from Matrix.det_pow + det_eq_prod_roots_charpoly + Multiset.prod_hom (SpectralTraceDetEigenvaluesOQ01OQ01.lean)",
       "prod_map_pow_eigenvalues: Π(λᵢᵏ) = (Πλᵢ)ᵏ via powMonoidHom and Multiset.prod_hom",
@@ -47,23 +47,33 @@
       "sum_sq_of_card_eq_two: Σxᵢ² = (Σxᵢ)² − 2∏xᵢ for a 2-element multiset (Multiset.card_eq_two + ring)",
       "card_eigenvalues_fin_two: a 2×2 matrix over IsAlgClosed K has exactly 2 eigenvalues",
       "trace_sq_eq_sum_sq_eigenvalues: tr(A²) = λ₁²+λ₂² for 2×2, via tr(A²)=(trA)²−2detA and Newton p₂=e₁²−2e₂",
-      "det_sq_example / trace_sq_example: det(A²)=4, tr(A²)=29 for !![1,2;3,4] over ℂ"
+      "det_sq_example / trace_sq_example: det(A²)=4, tr(A²)=29 for !![1,2;3,4] over ℂ",
+      "eigenvalues_pow_blockTriangular: eigenvalues(Mᵏ)=(eigenvalues M).map(·^k) for upper-triangular M, any field, all k (SpectralTraceDetEigenvaluesOQ01OQ01.lean)",
+      "charpoly_blockTriangular + charmatrix_blockTriangular: charpoly of triangular = ∏(X−C diag)",
+      "blockTriangular_pow_diag + blockTriangular_mul_diag + blockTriangular_pow: (Mᵏ)ᵢᵢ=(Mᵢᵢ)ᵏ for triangular M",
+      "eigenvalues_pow_diagonal + trace_pow_eq_sum_pow_eigenvalues_diagonal: spectral mapping + power sum for diagonal matrices, all n,k",
+      "trace_pow_of_eigenvalues_pow + trace_pow_eq_sum_pow_eigenvalues_blockTriangular + prod_X_sub_C_roots: reduction lemma + triangular trace power sum + roots-of-product helper"
     ],
     "insights": [
       "The determinant half of the eigenvalue power sum is FREE: det(Aᵏ)=(det A)ᵏ by multiplicativity (Matrix.det_pow), so det(Aᵏ)=Π(λᵢᵏ) needs no triangularisation and holds for all n, k. The trace half is the genuinely spectral content.",
       "trace_eq_sum_roots_charpoly applied to Aᵏ gives tr(Aᵏ)=Σ(eigenvalues of Aᵏ) directly, but identifying those eigenvalues with λᵢᵏ is exactly the multiset spectral mapping that is missing.",
       "In dimension two Newton's identity p₂=e₁²−2e₂ reduces the trace power sum to the trace and determinant from oq-01: tr(A²)=(trA)²−2detA, the 2×2 Cayley–Hamilton identity, gives tr(A²)=λ₁²+λ₂² with no eigenvalue computation.",
-      "Concrete check on !![1,2;3,4]: eigenvalues (5±√33)/2 irrational, yet λ₁²+λ₂²=(λ₁+λ₂)²−2λ₁λ₂=25−2(−2)=29=tr(A²), and λ₁²λ₂²=(det A)²=4=det(A²)."
+      "Concrete check on !![1,2;3,4]: eigenvalues (5±√33)/2 irrational, yet λ₁²+λ₂²=(λ₁+λ₂)²−2λ₁λ₂=25−2(−2)=29=tr(A²), and λ₁²λ₂²=(det A)²=4=det(A²).",
+      "The general trace power sum tr(Aᵏ)=Σλᵢᵏ is EXACTLY the multiset spectral mapping eigenvalues(Aᵏ)=(eigenvalues A).map(·^k); trace_pow_of_eigenvalues_pow makes this a one-line reduction (rw into trace_eq_sum_roots_charpoly).",
+      "The triangular case needs NO algebraic closure for the multiset identity itself: charpoly of an upper-triangular M is ∏(X−C(M i i)) (charmatrix preserves BlockTriangular id + det_of_upperTriangular), and (Mᵏ)ᵢᵢ=(Mᵢᵢ)ᵏ by induction (blockTriangular_mul_diag isolates the j=i term). Mapping diagonals under (·^k) gives the spectral mapping over any field.",
+      "Diagonal case is fully elementary via charpoly_diagonal + diagonal_pow + roots_multiset_prod_X_sub_C; holds in every dimension.",
+      "The ONLY remaining gap to arbitrary matrices is matrix-level Schur triangularisation over an alg-closed field — confirmed absent in Mathlib v4.26.0 (only Module.End genEigenspace decomposition Module.End.iSup_maxGenEigenspace_eq_top and RCLike Matrix.schur_triangulation exist; no charpoly-similarity-invariance-to-triangular bridge, no multiset Newton identities — MvPolynomial.NewtonIdentities is σ-variable only)."
     ],
     "mathlibGaps": [
       "No matrix Schur triangulation over a general algebraically closed field: no lemma giving ∃ invertible P, P⁻¹AP is BlockTriangular id with the charpoly roots on the diagonal (only GramSchmidt block-triangularisation for RCLike inner-product spaces, and Module.End-level genEigenspace decomposition that is awkward to bridge to the matrix charpoly multiset).",
       "No multiset/Polynomial-roots Newton-identity bridge: nothing relates A.charpoly.roots power sums to the charpoly coefficients (esymm) at the multiset level; MvPolynomial.NewtonIdentities is stated for polynomial rings in σ variables, not a multiset of field elements.",
-      "No spectral mapping for the full charpoly root multiset under powers: (A^k).charpoly.roots = A.charpoly.roots.map(·^k) is not in the snapshot (spectrum-level polynomial mapping exists only via the continuous functional calculus, set-valued, losing multiplicity)."
+      "No spectral mapping for the full charpoly root multiset under powers: (A^k).charpoly.roots = A.charpoly.roots.map(·^k) is not in the snapshot (spectrum-level polynomial mapping exists only via the continuous functional calculus, set-valued, losing multiplicity).",
+      "Confirmed v4.26.0: no matrix-level upper-triangularisation/Schur over a general algebraically closed field (grep: zero hits for schur_triangulation/IsUpperTriangular/exists upperTriangular outside RCLike); no Matrix.charpoly similarity invariance to a triangular form."
     ],
     "nextSteps": [
-      "Build Schur triangulation: over IsAlgClosed K, every Matrix n n K is conjugate to an upper-triangular matrix whose diagonal is the charpoly root multiset; then A^k is upper-triangular with diagonal (·^k), giving the multiset spectral mapping and hence the general trace power sum.",
-      "Alternatively formalize the multiset Newton identities (pₖ in terms of eⱼ) and the Cayley–Hamilton trace recurrence, showing tr(Aᵏ) and Σλᵢᵏ satisfy the same recurrence with the same charpoly-coefficient data.",
-      "Extend the fixed-dimension Newton identities to tr(A³)=e₁³−3e₁e₂+3e₃ for 3×3 matrices as a further verified slice while the general infra is built."
+      "Build matrix-level Schur triangularisation over IsAlgClosed K: ∃ invertible P, P⁻¹AP is BlockTriangular id. Either (a) bridge Module.End.iSup_maxGenEigenspace_eq_top to a triangular matrix basis, or (b) prove charpoly similarity-invariance for matrices + induct on dimension. With it, eigenvalues_pow (general) = eigenvalues_pow_blockTriangular applied to the conjugate, since charpoly (hence eigenvalues) is conjugation-invariant.",
+      "Alternative: formalize multiset Newton identities (psum in terms of esymm) at the field-element level, then show tr(Aᵏ) satisfies the same Cayley-Hamilton-driven recurrence — avoids triangularisation but needs the matrix Newton/CH trace recurrence.",
+      "Submit the general lemma eigenvalues_pow_general (charpoly.roots of Aᵏ = roots of A mapped by ·^k over IsAlgClosed) to Aristotle once the MCP endpoint is reachable (async submit returned Resource not found this session)."
     ],
     "markdown": "# Knowledge Base: spectral-trace-det-eigenvalues-oq-01-oq-01\n\n## Problem\n\ntrace(Aᵏ) = Σλᵢᵏ (and det(Aᵏ) = Πλᵢᵏ): the trace and determinant halves of the spectral mapping theorem applied to p(X)=Xᵏ, where λᵢ are the eigenvalues (charpoly roots with multiplicity).\n\n## Status (Session 2, 2026-06-24) — PARTIAL, SHIPPED\n\nVerified 0-axiom entry `SpectralTraceDetEigenvaluesOQ01OQ01.lean` (10 theorems, 1 def):\n\n- **det(Aᵏ) = Π(λᵢᵏ)** — proven for ALL n and k. Free from multiplicativity of det; no triangularisation.\n- **tr(A²) = λ₁² + λ₂²** — proven for 2×2 via Newton's identity p₂ = e₁² − 2e₂ = (tr A)² − 2 det A.\n- tr(Aᵏ) = Σ(eigenvalues of Aᵏ) — the parent identity applied to the power.\n- Worked ℂ example: det(A²)=4, tr(A²)=29 for !![1,2;3,4] (irrational spectrum).\n\n## Open / Blocker\n\nThe **general** trace power sum tr(Aᵏ)=Σλᵢᵏ (all n) reduces to the multiset spectral mapping `(A^k).charpoly.roots = A.charpoly.roots.map(·^k)`. Mathlib v4.26.0 lacks:\n- matrix Schur triangulation over a general algebraically closed field;\n- a multiset Newton-identities bridge (esymm ↔ power sums for charpoly roots).\n\nBuilding Schur triangulation (matrix conjugate to upper-triangular, eigenvalues on diagonal) is the cleanest path and the recommended next step.\n\n## Dead Ends\n\n- Direct search for `schur_triangulation` / matrix upper-triangular conjugation existence: not present.\n- Aristotle delegation of the crux lemma: backend returned \"Resource not found\" (down).\n"
   },


### PR DESCRIPTION
## Summary

Advances the **open** general trace power sum `tr(Aᵏ) = Σ λᵢᵏ` (eigenvalues with algebraic multiplicity) from the previously-shipped 2×2 case to **every dimension** for two structured matrix families, and isolates the single remaining classical ingredient for the fully general case.

Prior state of this entry: `det(Aᵏ)=Π(λᵢᵏ)` proven for all n,k; trace power sum only for 2×2. The blocker was the *multiset spectral mapping* `eigenvalues(Aᵏ) = (eigenvalues A).map(·^k)`, flagged across sessions as a Mathlib gap.

## What's new (13 theorems, all verified, 0 axioms)

**Reduction.** `trace_pow_of_eigenvalues_pow` — the general `tr(Aᵏ)=Σλᵢᵏ` follows *immediately* from the multiset spectral mapping. This makes the remaining dependency explicit.

**Diagonal case** (all `n`, all `k`): `eigenvalues_pow_diagonal`, `trace_pow_eq_sum_pow_eigenvalues_diagonal`.

**Upper-triangular kernel** (any field, all `k`) — the genuine spectral computational core:
- `charmatrix_blockTriangular` → `charpoly_blockTriangular`: charpoly of a triangular matrix = `∏ᵢ (X − C (M i i))`.
- `blockTriangular_mul_diag`, `blockTriangular_pow`, `blockTriangular_pow_diag`: `(Mᵏ)ᵢᵢ = (Mᵢᵢ)ᵏ`.
- `eigenvalues_pow_blockTriangular`: the spectral mapping for triangular matrices.
- `trace_pow_eq_sum_pow_eigenvalues_blockTriangular`: `tr(Mᵏ)=Σλᵢᵏ` for upper-triangular `M` over an algebraically closed field, all `k`.

## Remaining gap (honest scope)

The only missing ingredient for **arbitrary** matrices is Schur/triangularisation over an algebraically closed field — "every matrix is conjugate to an upper-triangular one" — which is **absent at the matrix level** in Mathlib v4.26.0 (only `Module.End` generalized-eigenspace decompositions and `RCLike` Schur triangulation are present). The reduction lemma reduces the standing open question to exactly this.

## Verification

- `lake env lean Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean` — compiles clean.
- All 7 headline theorems depend only on `propext, Classical.choice, Quot.sound`.
- 0 sorries, 0 `axiom` declarations, no `decide`/`native_decide`.
- File: 155→282 lines, 10→23 theorems. meta.json scope/contributions updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)