### PR TITLE
Enrich lagrange-theorem-oq-01-oq-03-oq-02: overview + sections + annotations

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-is-minimal-normal",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 66, "endLine": 70 },
+    "type": "definition",
+    "title": "The IsMinimalNormal predicate",
+    "content": "Defines what Mathlib 4.26 omits: N is a minimal normal subgroup if it is normal, nontrivial (N ≠ ⊥), and minimal among such — every normal M with M ≤ N and M ≠ ⊥ already equals N. Phrasing minimality as 'no smaller nontrivial normal subgroup' (rather than via the strict order <) is what lets the existence proof read a minimal element of a finite poset off directly and the abelianness proof contradict minimality cleanly.",
+    "mathContext": "$\\mathrm{IsMinimalNormal}(N) \\iff N \\trianglelefteq G,\\ N \\ne \\{1\\},\\ \\text{and}\\ (M \\trianglelefteq G,\\ M \\le N,\\ M \\ne \\{1\\}) \\Rightarrow M = N$.",
+    "significance": "key",
+    "relatedConcepts": ["normal subgroup", "socle of a group", "minimality predicate", "subgroup lattice"],
+    "prerequisites": ["normal subgroups", "the lattice order on Subgroup G", "bot (⊥) as the trivial subgroup"]
+  },
+  {
+    "id": "ann-existence",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 76, "endLine": 94 },
+    "type": "technique",
+    "title": "Existence via finiteness of the subgroup lattice",
+    "content": "Proves every nontrivial finite group has a minimal normal subgroup using only order-theoretic finiteness. The set s = {K | K.Normal ∧ K ≠ ⊥} is nonempty because ⊤ is normal and ≠ ⊥ (G nontrivial), and finite because Subgroup G injects into the finite Set G via `SetLike.coe_injective` (so `Finite (Subgroup G)`). `Set.Finite.exists_minimal` then hands back a minimal element N. Minimality in the order restricted to s is exactly the IsMinimalNormal property: any nontrivial normal M ≤ N lies in s, so minimality gives N ≤ M, and `le_antisymm` closes M = N. No group-specific machinery beyond 'top is normal'.",
+    "mathContext": "A nonempty finite subset of a partial order has a minimal element; apply to $\\{K \\trianglelefteq G : K \\ne \\{1\\}\\} \\subseteq \\mathrm{Subgroup}\\,G$.",
+    "significance": "key",
+    "relatedConcepts": ["Set.Finite.exists_minimal", "SetLike.coe_injective", "finite partial orders", "le_antisymm"],
+    "prerequisites": ["finiteness arguments in Mathlib", "order theory: minimal elements"]
+  },
+  {
+    "id": "ann-abelianness",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 100, "endLine": 123 },
+    "type": "insight",
+    "title": "Abelianness: where solvability forces ⁅N,N⁆ = ⊥",
+    "content": "The crux of the entry. For a minimal normal N of a solvable G, the commutator ⁅N,N⁆ is normal in G (`commutator_normal`), contained in N (`commutator_le_self`), and STRICTLY below N — this is the only place solvability is used, via `IsSolvable.commutator_lt_of_ne_bot`, which encodes that the derived series of a solvable group strictly descends. A normal subgroup strictly below the minimal N cannot be nontrivial, so by minimality ⁅N,N⁆ = ⊥. Then `commutator_eq_bot_iff_le_centralizer` converts 'commutator trivial' into N ≤ centralizer N, and `mem_centralizer_iff` extracts that any two elements of N commute (with a `Subtype.ext` to push the equality into the subgroup).",
+    "mathContext": "$\\lbrack N, N\\rbrack \\lhd G,\\ \\lbrack N,N\\rbrack < N \\Rightarrow \\lbrack N,N\\rbrack = \\{1\\} \\iff N \\le C_G(N)$, so $N$ is abelian.",
+    "significance": "key",
+    "relatedConcepts": ["solvable groups", "derived series strict descent", "commutator subgroup", "centralizer", "IsSolvable.commutator_lt_of_ne_bot"],
+    "prerequisites": ["commutator subgroup ⁅·,·⁆", "centralizers in Mathlib", "definition of solvable group"]
+  },
+  {
+    "id": "ann-packaged",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 125, "endLine": 133 },
+    "type": "context",
+    "title": "Packaged: an abelian minimal normal subgroup for Hall's induction",
+    "content": "Combines existence (Part I) and abelianness (Part II) into the single statement Hall's induction consumes: every nontrivial finite solvable group has an abelian minimal normal subgroup. This is the structural seed — the sibling lifting-step entry supplies the Schur–Zassenhaus extension step, and what remains for a fully 0-axiom Hall's theorem is upgrading 'abelian' to 'elementary abelian' (exponent p).",
+    "mathContext": "$\\exists N \\trianglelefteq G,\\ \\mathrm{IsMinimalNormal}(N) \\wedge N\\ \\text{abelian}$, for $G$ nontrivial finite solvable.",
+    "significance": "supporting",
+    "relatedConcepts": ["Hall's theorem", "induction on group order", "Schur–Zassenhaus", "elementary abelian groups"],
+    "prerequisites": ["the existence and abelianness theorems above"]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/meta.json
@@ -34,6 +34,55 @@
     ],
     "proofStrategy": "Existence: for finite G the lattice Subgroup G is finite (SetLike injects into the finite Set G), so the set {K | K.Normal ∧ K ≠ ⊥} is a finite, nonempty (⊤ belongs since G is nontrivial) subset of the partial order Subgroup G and therefore has a minimal element by Set.Finite.exists_minimal. Minimality in the order restricted to that set is exactly minimality among nontrivial normal subgroups, extracted by le_antisymm. Abelianness: for a minimal normal N of solvable G, the commutator ⁅N, N⁆ is normal in G (Subgroup.commutator_normal), is ≤ N (Subgroup.commutator_le_self), and is strictly below N (IsSolvable.commutator_lt_of_ne_bot, the solvable-group descent). A normal subgroup strictly below the minimal N cannot be nontrivial, so ⁅N, N⁆ = ⊥; by Subgroup.commutator_eq_bot_iff_le_centralizer this means N ≤ centralizer N, i.e. every two elements of N commute."
   },
+  "overview": {
+    "historicalContext": "Minimal normal subgroups are the atoms of a group's normal structure: a minimal normal subgroup is a nontrivial normal subgroup containing no smaller nontrivial normal subgroup, and the join of all of them is the socle. They are the engine of induction in finite group theory. Philip Hall's 1928 generalization of Sylow's theorems to solvable groups — the existence and conjugacy of Hall π-subgroups — is proved by inducting on the group order through a minimal normal subgroup, which in a solvable group is elementary abelian (a p-group of exponent p). The abelianness used here traces to the defining property of solvable groups: the derived series terminates, so commutators strictly descend. Mathlib 4.26 ships the solvable-group commutator descent lemma and the commutator/centralizer API but no minimal-normal-subgroup theory; this entry builds the existence and abelianness halves from general order-theoretic finiteness plus that descent lemma, supplying the structural seed that a 0-axiom formal proof of Hall's theorem requires.",
+    "problemStatement": "Build the minimal-normal-subgroup machinery absent from Mathlib 4.26, with 0 axioms: (1) every nontrivial finite group has a minimal normal subgroup, and (2) a minimal normal subgroup of a solvable group is abelian. Together they yield an abelian minimal normal subgroup in every nontrivial finite solvable group — the starting point of Hall's induction.",
+    "proofStrategy": "Existence is pure finiteness: Subgroup G injects into the finite Set G (SetLike.coe_injective), so the lattice is finite; the set {K | K.Normal ∧ K ≠ ⊥} is finite and nonempty (⊤ is normal and ≠ ⊥ since G is nontrivial), hence has a minimal element by Set.Finite.exists_minimal, and minimality in that restricted order is exactly minimality among nontrivial normal subgroups (extracted by le_antisymm). Abelianness is where solvability enters: for a minimal normal N of solvable G, the commutator ⁅N,N⁆ is normal in G (commutator_normal), is ≤ N (commutator_le_self), and is strictly below N (IsSolvable.commutator_lt_of_ne_bot). A normal subgroup strictly below the minimal N cannot be nontrivial, so ⁅N,N⁆ = ⊥; via commutator_eq_bot_iff_le_centralizer this gives N ≤ centralizer N, i.e. every pair of elements of N commutes.",
+    "keyInsights": [
+      "Minimal normal subgroups are the atoms of normal structure — the join of all of them is the socle — and inductions in finite group theory (Hall, Schur–Zassenhaus) characteristically begin by quotienting one out. This entry constructs that atom with 0 axioms.",
+      "Existence needs no deep group theory: it is the order-theoretic fact that a nonempty finite subset of a partial order has a minimal element, applied to the finite lattice of subgroups. The only group-specific inputs are that ⊤ is normal and nontrivial.",
+      "Solvability enters exactly once, through the strict commutator descent ⁅N,N⁆ < N (IsSolvable.commutator_lt_of_ne_bot). Colliding that strict inequality with minimality forces ⁅N,N⁆ = ⊥ — the single step that distinguishes the solvable case.",
+      "The bridge ⁅N,N⁆ = ⊥ ↔ N ≤ centralizer N (commutator_eq_bot_iff_le_centralizer) is the precise translation of 'the commutator subgroup is trivial' into 'the subgroup is abelian', turning a lattice fact into a statement about commuting elements.",
+      "The result is the structural input Hall's induction consumes; the only remaining increment toward a fully 0-axiom Hall theorem is refining 'abelian' to 'elementary abelian' (exponent p) via the characteristic p-torsion subgroup and Cauchy's theorem."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Background: the minimal-normal-subgroup gap in Hall's theorem",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Module docstring framing the open question: the sibling lifting-step entry pinpointed minimal-normal-subgroup machinery (absent from Mathlib 4.26) as the remaining gap for a 0-axiom Hall's theorem. Previews the three theorems and the existence/abelianness proof ideas, and notes the still-missing elementary-abelian refinement."
+    },
+    {
+      "id": "definition",
+      "title": "The IsMinimalNormal predicate",
+      "startLine": 66,
+      "endLine": 70,
+      "summary": "IsMinimalNormal N := N is normal, N ≠ ⊥, and every nontrivial normal subgroup M ≤ N equals N. Packages the minimal-normal-subgroup property that Mathlib lacks as a reusable predicate."
+    },
+    {
+      "id": "existence",
+      "title": "Part I — Existence of a minimal normal subgroup",
+      "startLine": 76,
+      "endLine": 94,
+      "summary": "exists_minimal_normal_subgroup: a nontrivial finite group has a minimal normal subgroup. The finite lattice Subgroup G (via SetLike.coe_injective) makes {K | K.Normal ∧ K ≠ ⊥} a finite nonempty poset subset, so Set.Finite.exists_minimal yields a minimal element; le_antisymm converts order-minimality to the predicate."
+    },
+    {
+      "id": "abelianness",
+      "title": "Part II — Minimal normal subgroups of solvable groups are abelian",
+      "startLine": 100,
+      "endLine": 123,
+      "summary": "minimal_normal_abelian_of_solvable: for minimal normal N of solvable G, ⁅N,N⁆ is normal, ≤ N, and strictly below N (IsSolvable.commutator_lt_of_ne_bot), so minimality forces ⁅N,N⁆ = ⊥; commutator_eq_bot_iff_le_centralizer then gives N ≤ centralizer N, i.e. N is abelian."
+    },
+    {
+      "id": "packaged",
+      "title": "Packaged existence of an abelian minimal normal subgroup",
+      "startLine": 125,
+      "endLine": 133,
+      "summary": "exists_abelian_minimal_normal_subgroup: combines Parts I and II into the exact structural input Hall's induction needs — every nontrivial finite solvable group has an abelian minimal normal subgroup."
+    }
+  ],
   "leanFile": {
     "path": "Proofs/LagrangeTheoremOQ01OQ03OQ02.lean",
     "imports": [


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-01-oq-03-oq-02` (Minimal normal subgroups: existence & abelianness in the solvable case).

**Gaps closed:** no `overview` block, no `sections`, no `annotations.json` (quality was 15).

**Added:**
- `overview`: historicalContext (minimal normal subgroups / socle / Hall's theorem), problemStatement, proofStrategy, 5 keyInsights
- `sections` (5): header, IsMinimalNormal definition, Part I existence, Part II abelianness, packaged existence
- `annotations.json` (4): each with mathContext (LaTeX), significance, relatedConcepts, prerequisites, mapped to actual line ranges

meta.json 7.2 KB → 13.1 KB (well under 60 KB cap). JSON validated; all ranges within the 135-line file. No status/badge/axiomCount changes (verified, 0-axiom confirmed against the Lean source — only propext/Classical.choice/Quot.sound).