### PR TITLE
Enrich cayley-hamilton-oq-01-oq-01-oq-01-oq-01: sections + annotations

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-degree-squeeze",
+    "proofId": "cayley-hamilton-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 68, "endLine": 91 },
+    "type": "insight",
+    "title": "The degree squeeze: deg(minpoly) = n from one cyclic vector",
+    "content": "The crux theorem. The minimal polynomial's degree is squeezed to exactly n from two sides. Upper bound: M is integral (witnessed by its monic charpoly via Cayley–Hamilton), so minpoly ∣ charpoly (`minpoly.dvd`), and `natDegree_le_of_dvd` with `charpoly_natDegree_eq_dim` gives deg(minpoly) ≤ n. Lower bound: the minimal polynomial annihilates the cyclic vector v — established by `minpoly_mem_vecAnnIdeal` (parent) routed through the `aeval_eq_zero_iff_mem_vecAnnIdeal` bridge (grandparent) — so if deg(minpoly) were < n, the IsCyclicVector property (no nonzero low-degree annihilator) would force minpoly = 0, contradicting `minpoly.ne_zero`. `le_antisymm` then gives equality. No construction or counting — a single cyclic vector pins a global invariant.",
+    "mathContext": "$\\deg(\\mu_M) \\le n$ from $\\mu_M \\mid \\chi_M,\\ \\deg \\chi_M = n$; $\\deg(\\mu_M) \\ge n$ since $\\mu_M$ annihilates the cyclic $v$ and $\\mu_M \\ne 0$.",
+    "significance": "key",
+    "relatedConcepts": ["minimal polynomial", "characteristic polynomial", "Cayley–Hamilton", "cyclic vector", "annihilator ideal", "le_antisymm squeeze"],
+    "prerequisites": ["minpoly ∣ charpoly", "degree of polynomials", "the parent/grandparent vecAnnIdeal framework"]
+  },
+  {
+    "id": "ann-forward-equality",
+    "proofId": "cayley-hamilton-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 95, "endLine": 107 },
+    "type": "technique",
+    "title": "Forward direction: minpoly = charpoly from equal degree + divisibility",
+    "content": "Upgrades the degree equality of Part I to polynomial equality. Both minpoly and charpoly are monic (minpoly via `minpoly.monic`, charpoly via `charpoly_monic`), and minpoly ∣ charpoly; with deg(charpoly) = n = deg(minpoly) the lemma `Polynomial.eq_of_monic_of_dvd_of_natDegree_le` forces them equal. The general principle: two monic polynomials with one dividing the other and equal degree must coincide, because the cofactor is a degree-0 monic, i.e. 1. The `.symm` orients the equation as minpoly = charpoly.",
+    "mathContext": "Monic $p, q$ with $p \\mid q$ and $\\deg q \\le \\deg p \\Rightarrow p = q$; here $p = \\mu_M$, $q = \\chi_M$.",
+    "significance": "key",
+    "relatedConcepts": ["monic polynomials", "divisibility forces equality", "non-derogatory matrix", "Polynomial.eq_of_monic_of_dvd_of_natDegree_le"],
+    "prerequisites": ["the degree-squeeze theorem above", "monic polynomial basics"]
+  },
+  {
+    "id": "ann-equivalence-main",
+    "proofId": "cayley-hamilton-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 111, "endLine": 121 },
+    "type": "insight",
+    "title": "The full equivalence: cyclic vector ⟺ non-derogatory",
+    "content": "Assembles the biconditional (∃ v, IsCyclicVector M v) ↔ minpoly K M = M.charpoly. The forward arrow destructures a cyclic vector and applies Part II; the reverse arrow is exactly the grandparent's `exists_cyclicVector_of_minpoly_eq_charpoly` (proved there via Mathlib's PID structure theorem). This is the single-companion-block case of the rational canonical form — a matrix is similar to the companion matrix of its characteristic polynomial precisely when it is non-derogatory.",
+    "mathContext": "$(\\exists v,\\ \\mathrm{IsCyclicVector}\\,M\\,v) \\iff \\mu_M = \\chi_M$.",
+    "significance": "key",
+    "relatedConcepts": ["rational canonical form", "companion matrix", "non-derogatory matrices", "biconditional assembly"],
+    "prerequisites": ["the forward direction (Parts I–II)", "the grandparent's reverse direction"]
+  },
+  {
+    "id": "ann-equivalence-degree",
+    "proofId": "cayley-hamilton-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 123, "endLine": 131 },
+    "type": "context",
+    "title": "Degree form of the equivalence",
+    "content": "Restates the equivalence in terms of degree: (∃ v, IsCyclicVector M v) ↔ (minpoly K M).natDegree = n. This is the most directly usable form for downstream callers, since 'non-derogatory' is most often phrased as 'the minimal polynomial has full degree'. Forward via the Part I degree squeeze, reverse via the grandparent's `exists_cyclicVector_of_minpoly_natDegree_eq`.",
+    "mathContext": "$(\\exists v,\\ \\mathrm{IsCyclicVector}\\,M\\,v) \\iff \\deg(\\mu_M) = n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["full-degree minimal polynomial", "non-derogatory criterion", "degree characterisation"],
+    "prerequisites": ["the main equivalence above"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -108,6 +108,36 @@
       "The parent/grandparent annihilator-ideal framework (vecAnnIdeal, IsCyclicVector)"
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: completing the cyclic-vector characterisation",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Module docstring. Recalls the parent (vecAnnIdeal / IsCyclicVector framework) and grandparent (reverse direction minpoly = charpoly ⟹ ∃ cyclic vector), states the four main results, and lays out the forward direction as a degree squeeze: deg(minpoly) ≤ n from Cayley–Hamilton, deg(minpoly) ≥ n from cyclicity."
+    },
+    {
+      "id": "forward-degree",
+      "title": "Part I — A cyclic vector forces full-degree minimal polynomial",
+      "startLine": 66,
+      "endLine": 91,
+      "summary": "minpoly_natDegree_eq_of_isCyclicVector: the degree squeeze. Upper bound deg(minpoly) ≤ n via minpoly ∣ charpoly (Cayley–Hamilton) and charpoly_natDegree_eq_dim; lower bound deg(minpoly) ≥ n because the nonzero minimal polynomial annihilates the cyclic vector, so degree < n would force minpoly = 0 (contradicting minpoly.ne_zero). le_antisymm closes equality."
+    },
+    {
+      "id": "forward-equality",
+      "title": "Part II — A cyclic vector forces minpoly = charpoly",
+      "startLine": 93,
+      "endLine": 107,
+      "summary": "minpoly_eq_charpoly_of_isCyclicVector: with deg(minpoly) = n from Part I, the two monic polynomials minpoly and charpoly satisfy minpoly ∣ charpoly and equal degree, so Polynomial.eq_of_monic_of_dvd_of_natDegree_le upgrades divisibility to equality."
+    },
+    {
+      "id": "equivalences",
+      "title": "Part III — The full equivalences",
+      "startLine": 109,
+      "endLine": 131,
+      "summary": "exists_cyclicVector_iff_minpoly_eq_charpoly and its degree form exists_cyclicVector_iff_minpoly_natDegree_eq: pair this entry's forward direction with the grandparent's reverse direction (exists_cyclicVector_of_minpoly_eq_charpoly / _of_minpoly_natDegree_eq) to close the biconditional."
+    }
+  ],
   "conclusion": {
     "summary": "A cyclic vector forces (minpoly K M).natDegree = n and hence minpoly K M = M.charpoly (forward direction), via a degree squeeze: minpoly ∣ charpoly gives deg ≤ n, and the minimal polynomial annihilating the cyclic vector gives deg ≥ n. Combined with the grandparent's reverse direction this yields the full equivalence (∃ v, IsCyclicVector M v) ↔ minpoly K M = M.charpoly (and its degree form). Fully verified, 0 axioms, 0 sorries.",
     "implications": "This completes the cyclic-vector characterisation of non-derogatory matrices: the existence of a cyclic vector is now established as exactly equivalent to minpoly = charpoly, in both directions and machine-checked. It is the single-companion-block case of the rational canonical form, and it isolates the structural content of being non-derogatory in a form (the iff) directly usable by downstream entries.",


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-oq-01-oq-01-oq-01-oq-01` (Cyclic Vector ⟺ Non-Derogatory: the full equivalence).

**Gaps closed:** no `sections`, no `annotations.json` (overview already rich; quality was 35).

**Added:**
- `sections` (4): header, Part I forward degree squeeze, Part II forward equality, Part III equivalences
- `annotations.json` (4): degree squeeze, forward equality, full equivalence, degree form — each with mathContext (LaTeX), significance, relatedConcepts, prerequisites, mapped to actual line ranges

meta.json 12.2 KB → 14.2 KB (under 60 KB cap). JSON validated; all ranges within the 133-line file. No status/badge/axiomCount changes (verified, 0-axiom confirmed against the Lean source).