### PR TITLE
research(erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01): forbidden-subgraph freeness is hereditary; C₅-blow-up family is hereditarily clique-free [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1632,6 +1632,7 @@ import Proofs.Erdos128Problem
 import Proofs.Erdos128WIP01OQ01
 import Proofs.Erdos128WIP01OQ01OQ01
 import Proofs.Erdos128WIP01OQ01OQ01OQ01
+import Proofs.Erdos128WIP01OQ01OQ01OQ01OQ01
 import Proofs.Erdos129Problem
 import Proofs.Erdos12Problem
 import Proofs.Erdos12ProblemAPNPartI

--- a/proofs/Proofs/Erdos128WIP01OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos128WIP01OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,227 @@
+/-
+# Erdős #128: Forbidden-subgraph freeness is hereditary, and the C₅-blow-up
+  extremal family is hereditarily clique-free
+
+## Source
+Open question from `erdos-128-wip-01-oq-01-oq-01-oq-01` (the forbidden-subgraph
+framework: `homFree`, `blowup`, `C5`) combined with `erdos-128-wip-01`'s induced
+subgraph `Graph.induce` and its hereditary triangle-freeness.
+
+## What This Proves
+
+The parent established that forbidden-subgraph freeness `homFree F G`
+("`G` has no homomorphic copy of `F`") pulls back along homomorphisms, with
+clique-freeness the `F = Kᵣ` case, and that every blow-up of `C₅` is `Kᵣ`-free
+for `r ≥ 3`. The original `erdos-128-wip-01` separately proved triangle-freeness
+is **hereditary** (closed under induced subgraphs).
+
+This entry unifies the two threads: it shows the *whole* forbidden-subgraph
+relation is hereditary, because the inclusion of an induced subgraph is a graph
+homomorphism. Specialising to `F = Kᵣ` gives hereditary clique-freeness, and
+specialising further to the `C₅` blow-ups shows the extremal family for #128 is
+hereditarily clique-free — exactly the property a candidate extremal
+construction must have, since #128 constrains *every* `⌊n/2⌋`-vertex induced
+subgraph.
+
+**Main results:**
+- `induce_isHom`: the identity is a homomorphism `G.induce S → G`.
+- `homFree_induce`: `homFree F G → homFree F (G.induce S)` — forbidden-subgraph
+  freeness is hereditary.
+- `cliqueFree_induce`: `G.cliqueFree r → (G.induce S).cliqueFree r`.
+- `blowup_C5_induce_homFree` / `blowup_C5_induce_cliqueFree`: every induced
+  subgraph of every blow-up of `C₅` is `Kᵣ`-(hom-copy-)free for `r ≥ 3`.
+
+## Structure of the Argument
+
+An induced subgraph only deletes edges, so the identity map carries every edge
+of `G.induce S` to an edge of `G`: it is a homomorphism `G.induce S → G`. The
+parent's `homFree_of_hom` then pulls back `F`-freeness from `G` to `G.induce S`
+with no further work. Clique-freeness is the `F = Kᵣ` instance via the parent's
+bridge `cliqueFree_iff_homFree_completeGraph`, and the `C₅`-blow-up corollaries
+chain this with `blowup_C5_homFree`.
+
+The file is self-contained (the chain's convention: each entry re-derives the
+small graph framework it needs), fully machine-checked, no `sorry`, no extra
+axioms. `C5_homFree_three` uses ordinary `decide`, not `native_decide`.
+
+## Depends on
+Mathlib only. Mirrors the framework of `erdos-128-wip-01-oq-01-oq-01-oq-01`
+(`homFree`, `homFree_of_hom`, `blowup`, `C5`) and `erdos-128-wip-01`
+(`Graph.induce`).
+-/
+
+import Mathlib
+
+set_option linter.unusedVariables false
+
+namespace Erdos128WIP01OQ01OQ01OQ01OQ01
+
+/-- A finite simple graph on `Fin n`, given by a symmetric irreflexive adjacency. -/
+structure Graph (n : ℕ) where
+  adj : Fin n → Fin n → Prop
+  symm : ∀ u v, adj u v → adj v u
+  irrefl : ∀ v, ¬ adj v v
+
+/-- The **induced subgraph** on a vertex subset `S`: keep only edges with both
+    endpoints in `S`. -/
+def Graph.induce {n : ℕ} (G : Graph n) (S : Finset (Fin n)) : Graph n where
+  adj u v := u ∈ S ∧ v ∈ S ∧ G.adj u v
+  symm u v h := ⟨h.2.1, h.1, G.symm u v h.2.2⟩
+  irrefl v h := G.irrefl v h.2.2
+
+/-- A **graph homomorphism** `f : G → H` carries adjacent vertices to adjacent
+    vertices. -/
+def IsHom {n k : ℕ} (G : Graph n) (H : Graph k) (f : Fin n → Fin k) : Prop :=
+  ∀ u v, G.adj u v → H.adj (f u) (f v)
+
+/-- `G` **contains a homomorphic copy of `F`**: a graph homomorphism `φ : F → G`. -/
+def hasHomCopy {m n : ℕ} (F : Graph m) (G : Graph n) : Prop :=
+  ∃ φ : Fin m → Fin n, IsHom F G φ
+
+/-- `G` is **`F`-free**: it has no homomorphic copy of `F`. -/
+def homFree {m n : ℕ} (F : Graph m) (G : Graph n) : Prop := ¬ hasHomCopy F G
+
+/-- **`F`-freeness pulls back along homomorphisms** (parent's `homFree_of_hom`):
+    a homomorphism `f : G → H` with `H` `F`-free makes `G` `F`-free, by composing
+    a copy `φ : F → G` with `f`. -/
+theorem homFree_of_hom {m n k : ℕ} (F : Graph m) (G : Graph n) (H : Graph k)
+    (f : Fin n → Fin k) (hf : IsHom G H f) (hH : homFree F H) : homFree F G := by
+  rintro ⟨φ, hφ⟩
+  exact hH ⟨f ∘ φ, fun a b hab => hf _ _ (hφ a b hab)⟩
+
+/-- A homomorphism `g : F' → F` turns a copy of `F` into one of `F'` (precompose). -/
+theorem hasHomCopy_mono {m' m n : ℕ} (F' : Graph m') (F : Graph m) (G : Graph n)
+    (g : Fin m' → Fin m) (hg : IsHom F' F g) (h : hasHomCopy F G) : hasHomCopy F' G := by
+  obtain ⟨φ, hφ⟩ := h
+  exact ⟨φ ∘ g, fun a b hab => hφ (g a) (g b) (hg a b hab)⟩
+
+/-! ### Cliques as the `F = Kᵣ` case -/
+
+/-- `G` contains an **`r`-clique**: an injective family of `r` pairwise-adjacent vertices. -/
+def Graph.hasClique {n : ℕ} (G : Graph n) (r : ℕ) : Prop :=
+  ∃ s : Fin r → Fin n, Function.Injective s ∧ ∀ i j, i ≠ j → G.adj (s i) (s j)
+
+/-- `G` is **`Kᵣ`-free**. -/
+def Graph.cliqueFree {n : ℕ} (G : Graph n) (r : ℕ) : Prop := ¬ G.hasClique r
+
+/-- The **complete graph `Kᵣ`** on `Fin r`. -/
+def completeGraph (r : ℕ) : Graph r where
+  adj i j := i ≠ j
+  symm u v h := Ne.symm h
+  irrefl v h := h rfl
+
+/-- The inclusion `Fin.castLE` is a homomorphism `Kₘ → Kᵣ` for `m ≤ r`. -/
+theorem completeGraph_castLE_isHom {m r : ℕ} (hmr : m ≤ r) :
+    IsHom (completeGraph m) (completeGraph r) (Fin.castLE hmr) :=
+  fun a b hab heq => hab (Fin.castLE_injective hmr heq)
+
+/-- **A homomorphic copy of `Kᵣ` is exactly an `r`-clique** (the target's
+    irreflexivity forces a homomorphism out of `Kᵣ` to be injective). -/
+theorem hasHomCopy_completeGraph_iff {n : ℕ} (G : Graph n) (r : ℕ) :
+    hasHomCopy (completeGraph r) G ↔ G.hasClique r := by
+  constructor
+  · rintro ⟨φ, hφ⟩
+    refine ⟨φ, ?_, fun i j hij => hφ i j hij⟩
+    intro a b hab
+    by_contra hne
+    exact G.irrefl (φ b) (hab ▸ hφ a b hne)
+  · rintro ⟨s, hinj, hadj⟩
+    exact ⟨s, fun a b hab => hadj a b hab⟩
+
+/-- **`Kᵣ`-freeness is `Kᵣ`-homomorphic-copy-freeness.** -/
+theorem cliqueFree_iff_homFree_completeGraph {n : ℕ} (G : Graph n) (r : ℕ) :
+    G.cliqueFree r ↔ homFree (completeGraph r) G :=
+  not_congr (hasHomCopy_completeGraph_iff G r).symm
+
+/-- **`Kᵣ`-freeness pulls back along homomorphisms** — the `F = Kᵣ` corollary. -/
+theorem cliqueFree_of_hom {n k r : ℕ} (G : Graph n) (H : Graph k) (f : Fin n → Fin k)
+    (hf : IsHom G H f) (hH : H.cliqueFree r) : G.cliqueFree r :=
+  (cliqueFree_iff_homFree_completeGraph G r).2
+    (homFree_of_hom (completeGraph r) G H f hf
+      ((cliqueFree_iff_homFree_completeGraph H r).1 hH))
+
+/-! ### Hereditarity: the identity inclusion of an induced subgraph is a homomorphism -/
+
+/-- **The identity is a homomorphism `G.induce S → G`.** Induction only deletes
+    edges, so every edge of `G.induce S` is an edge of `G`. -/
+theorem induce_isHom {n : ℕ} (G : Graph n) (S : Finset (Fin n)) :
+    IsHom (G.induce S) G id := fun u v h => h.2.2
+
+/-- **Forbidden-subgraph freeness is hereditary.** Every induced subgraph of an
+    `F`-free graph is `F`-free — pull `homFree` back along the inclusion. -/
+theorem homFree_induce {m n : ℕ} (F : Graph m) (G : Graph n) (S : Finset (Fin n))
+    (hG : homFree F G) : homFree F (G.induce S) :=
+  homFree_of_hom F (G.induce S) G id (induce_isHom G S) hG
+
+/-- **Clique-freeness is hereditary.** Every induced subgraph of a `Kᵣ`-free graph
+    is `Kᵣ`-free — the `F = Kᵣ` instance (also direct from `cliqueFree_of_hom`). -/
+theorem cliqueFree_induce {n : ℕ} (G : Graph n) (r : ℕ) (S : Finset (Fin n))
+    (hG : G.cliqueFree r) : (G.induce S).cliqueFree r :=
+  cliqueFree_of_hom (G.induce S) G id (induce_isHom G S) hG
+
+/-! ### Blow-ups and the `C₅` witness -/
+
+/-- The **blow-up** of `H` along a class map `c`: adjacency is read off the classes. -/
+def blowup {n k : ℕ} (H : Graph k) (c : Fin n → Fin k) : Graph n where
+  adj u v := H.adj (c u) (c v)
+  symm u v h := H.symm (c u) (c v) h
+  irrefl v h := H.irrefl (c v) h
+
+/-- The class map of a blow-up is a homomorphism `blowup H c → H`. -/
+theorem blowup_isHom {n k : ℕ} (H : Graph k) (c : Fin n → Fin k) :
+    IsHom (blowup H c) H c := fun u v h => h
+
+/-- **Every blow-up of an `F`-free graph is `F`-free.** -/
+theorem blowup_homFree {m n k : ℕ} (F : Graph m) (H : Graph k) (c : Fin n → Fin k)
+    (hH : homFree F H) : homFree F (blowup H c) :=
+  homFree_of_hom F (blowup H c) H c (blowup_isHom H c) hH
+
+/-- The **5-cycle `C₅`** on `Fin 5`. -/
+def C5 : Graph 5 where
+  adj i j := i + 1 = j ∨ j + 1 = i
+  symm u v h := h.symm
+  irrefl := by decide
+
+set_option maxRecDepth 4000 in
+/-- **`C₅` has no homomorphic copy of `K₃`** (ordinary `decide`, not `native_decide`). -/
+theorem C5_homFree_three : homFree (completeGraph 3) C5 := by
+  unfold homFree hasHomCopy IsHom completeGraph C5
+  decide
+
+/-- **`C₅` has no homomorphic copy of `Kᵣ` for any `r ≥ 3`.** -/
+theorem C5_homFree {r : ℕ} (hr : 3 ≤ r) : homFree (completeGraph r) C5 :=
+  fun h => C5_homFree_three
+    (hasHomCopy_mono (completeGraph 3) (completeGraph r) C5 _
+      (completeGraph_castLE_isHom hr) h)
+
+/-- **Every blow-up of `C₅` is `Kᵣ`-hom-copy-free for `r ≥ 3`.** -/
+theorem blowup_C5_homFree {n r : ℕ} (c : Fin n → Fin 5) (hr : 3 ≤ r) :
+    homFree (completeGraph r) (blowup C5 c) :=
+  blowup_homFree (completeGraph r) C5 c (C5_homFree hr)
+
+/-- **`C₅` is `Kᵣ`-free for `r ≥ 3`.** -/
+theorem C5_cliqueFree {r : ℕ} (hr : 3 ≤ r) : C5.cliqueFree r :=
+  (cliqueFree_iff_homFree_completeGraph C5 r).2 (C5_homFree hr)
+
+/-- **Every blow-up of `C₅` is `Kᵣ`-free for `r ≥ 3`.** -/
+theorem blowup_C5_cliqueFree {n r : ℕ} (c : Fin n → Fin 5) (hr : 3 ≤ r) :
+    (blowup C5 c).cliqueFree r :=
+  (cliqueFree_iff_homFree_completeGraph (blowup C5 c) r).2 (blowup_C5_homFree c hr)
+
+/-! ### The extremal family is hereditarily clique-free -/
+
+/-- **Every induced subgraph of every blow-up of `C₅` is `Kᵣ`-hom-copy-free**
+    for `r ≥ 3` — hereditarity applied to the extremal family. -/
+theorem blowup_C5_induce_homFree {n r : ℕ} (c : Fin n → Fin 5) (S : Finset (Fin n))
+    (hr : 3 ≤ r) : homFree (completeGraph r) ((blowup C5 c).induce S) :=
+  homFree_induce (completeGraph r) (blowup C5 c) S (blowup_C5_homFree c hr)
+
+/-- **Every induced subgraph of every blow-up of `C₅` is `Kᵣ`-free** for `r ≥ 3`.
+    Taking `r = 3`, every induced subgraph of a `C₅` blow-up is triangle-free:
+    the candidate extremal construction for #128 keeps its forbidden-subgraph
+    property on *every* vertex subset, in particular on every `⌊n/2⌋`-subgraph. -/
+theorem blowup_C5_induce_cliqueFree {n r : ℕ} (c : Fin n → Fin 5) (S : Finset (Fin n))
+    (hr : 3 ≤ r) : ((blowup C5 c).induce S).cliqueFree r :=
+  cliqueFree_induce (blowup C5 c) r S (blowup_C5_cliqueFree c hr)
+
+end Erdos128WIP01OQ01OQ01OQ01OQ01

--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01",
+  "title": "Erdős #128: forbidden-subgraph freeness is hereditary; the C₅-blow-up extremal family is hereditarily clique-free",
+  "slug": "erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01",
+  "description": "Unifies the two threads of the #128 chain: the forbidden-subgraph framework (homFree, blowup, C5) from erdos-128-wip-01-oq-01-oq-01-oq-01 and the induced-subgraph hereditarity (Graph.induce, hereditary triangle-freeness) from erdos-128-wip-01. The identity inclusion of an induced subgraph is a graph homomorphism, so the parent's homFree_of_hom immediately yields that homFree F G is hereditary (closed under induced subgraphs); the F = K_r case gives hereditary clique-freeness. Applied to the C₅ blow-ups, every induced subgraph of every C₅ blow-up is K_r-free for r ≥ 3 — exactly the property a candidate extremal construction for #128 must keep on every ⌊n/2⌋-vertex subgraph.",
+  "meta": {
+    "author": "researcher-10 (Lean Genius)",
+    "sourceUrl": "https://www.erdosproblems.com/128",
+    "date": "2026-06-28",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos128WIP01OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "extremal-graph-theory",
+      "erdos-problems",
+      "triangle-free",
+      "clique-free",
+      "forbidden-subgraph",
+      "graph-homomorphism",
+      "induced-subgraph",
+      "hereditary-property",
+      "blowup",
+      "C5",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Fin.castLE_injective",
+        "description": "the order-embedding Fin m ↪ Fin r (m ≤ r) is injective — makes the inclusion K_m → K_r a homomorphism, feeding clique-order monotonicity",
+        "module": "Mathlib.Order.Fin.Basic"
+      },
+      {
+        "theorem": "Decidable.decide",
+        "description": "ordinary decision procedure over the finite function space Fin 3 → Fin 5 used to certify C5 has no homomorphic K₃ (decide, not native_decide)",
+        "module": "Mathlib (core)"
+      }
+    ],
+    "originalContributions": [
+      "induce_isHom: the identity map is a graph homomorphism G.induce S → G (induction only deletes edges)",
+      "homFree_induce: forbidden-subgraph freeness is hereditary — homFree F G → homFree F (G.induce S), by pulling homFree back along the inclusion via the parent's homFree_of_hom",
+      "cliqueFree_induce: clique-freeness is hereditary — G.cliqueFree r → (G.induce S).cliqueFree r, the F = K_r instance",
+      "blowup_C5_induce_homFree / blowup_C5_induce_cliqueFree: every induced subgraph of every blow-up of C₅ is K_r-(hom-copy-)free for r ≥ 3 (r = 3 gives triangle-free), establishing that the #128 candidate extremal family keeps its forbidden-subgraph property on every vertex subset"
+    ],
+    "references": [
+      {
+        "authors": "Erdős, Paul",
+        "title": "Problem #128",
+        "year": "",
+        "venue": "erdosproblems.com",
+        "note": "If every ⌊n/2⌋-vertex induced subgraph spans > n²/50 edges, does the graph contain a triangle? The C₅ blow-up shows the constant 1/50 cannot be lowered."
+      },
+      {
+        "authors": "Bollobás, Béla",
+        "title": "Extremal Graph Theory",
+        "year": "1978",
+        "venue": "Academic Press",
+        "note": "Blow-ups, forbidden subgraphs, hereditary properties and extremal constructions"
+      }
+    ],
+    "prerequisites": [
+      "The parent erdos-128-wip-01-oq-01-oq-01-oq-01 (homFree, homFree_of_hom, blowup, C5, the K_r bridge)",
+      "The root erdos-128-wip-01 (Graph.induce and hereditary triangle-freeness)",
+      "Graph homomorphisms, induced subgraphs, hereditary graph properties"
+    ],
+    "dateAdded": "2026-06-28",
+    "axiomCount": 0,
+    "lineCount": 227,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound). C5_homFree_three uses ordinary decide, not native_decide, so Lean.ofReduceBool is not incurred.",
+    "theoremCount": 18,
+    "definitionCount": 10
+  },
+  "overview": {
+    "historicalContext": "Erdős #128 asks whether a density condition imposed uniformly on all ⌊n/2⌋-vertex induced subgraphs (each spanning more than n²/50 edges) forces a triangle, with the constant 1/50 conjectured optimal via the balanced blow-up of the 5-cycle C₅. Any candidate extremal construction must therefore be controlled on every vertex subset, not just globally — the property at stake is hereditary. The #128 formalization chain built, in stages, a small graph framework: induced subgraphs and hereditary triangle-freeness (erdos-128-wip-01), blow-ups and triangle-freeness of C₅ blow-ups (…-oq-01), cliques and clique-order monotonicity (…-oq-01-oq-01), and finally the forbidden-subgraph generalisation homFree with clique-freeness as the F = K_r case (…-oq-01-oq-01-oq-01). What remained was to connect the hereditarity thread (induced subgraphs) to the forbidden-subgraph thread (homFree, C₅ blow-ups). This entry makes that connection.",
+    "problemStatement": "**Goal**: Show that forbidden-subgraph freeness is hereditary in the parent's homFree framework, and conclude that the C₅-blow-up extremal family is hereditarily clique-free.\n\n**Resolution**: The identity inclusion G.induce S → G is a graph homomorphism, so the parent's homFree_of_hom gives homFree F G → homFree F (G.induce S). Specialising F = K_r yields cliqueFree_induce, and chaining with blowup_C5_cliqueFree yields blowup_C5_induce_cliqueFree: every induced subgraph of every C₅ blow-up is K_r-free for r ≥ 3.",
+    "text": "A 227-line, axiom-free, self-contained development (18 theorems, 10 definitions; the chain's convention is for each entry to re-derive the small framework it uses). The new content is the hereditarity layer: induce_isHom proves the identity is a homomorphism G.induce S → G (an induced edge ⟨u∈S, v∈S, G.adj u v⟩ projects to G.adj u v); homFree_induce pulls homFree back along it via homFree_of_hom; cliqueFree_induce is the F = K_r instance through the bridge cliqueFree_iff_homFree_completeGraph; and blowup_C5_induce_homFree / blowup_C5_induce_cliqueFree apply hereditarity to the extremal family. C5_homFree_three is discharged by ordinary decide over Fin 3 → Fin 5 (with maxRecDepth 4000), avoiding native_decide and hence Lean.ofReduceBool.",
+    "proofStrategy": "Hereditarity is pure homomorphism pullback. (1) induce_isHom: IsHom (G.induce S) G id reduces to (G.induce S).adj u v → G.adj u v, which is the third projection of the induced-adjacency conjunction. (2) homFree_induce = homFree_of_hom F (G.induce S) G id (induce_isHom G S). (3) cliqueFree_induce = cliqueFree_of_hom (G.induce S) G id (induce_isHom G S), equivalently the F = K_r instance of (2). (4) The extremal corollaries compose (2)/(3) with the parent's blowup_C5_homFree / blowup_C5_cliqueFree. The C₅ facts are re-derived: C5_homFree_three by decide, lifted to all r ≥ 3 by hasHomCopy_mono along completeGraph_castLE_isHom, then transported through blow-ups by blowup_homFree.",
+    "keyInsights": [
+      "Hereditarity under induced subgraphs is a special case of homomorphism pullback: the identity inclusion of an induced subgraph is a graph homomorphism, so no new machinery is needed beyond the parent's homFree_of_hom.",
+      "Because the pullback is generic in F, one proof simultaneously gives hereditary triangle-freeness, hereditary clique-freeness, and hereditary F-freeness for any forbidden F.",
+      "The #128 extremal family (C₅ blow-ups) is therefore hereditarily clique-free: it keeps its forbidden-subgraph property on every vertex subset, the exact robustness #128's ⌊n/2⌋-subgraph hypothesis demands of a sharp construction.",
+      "Re-deriving the framework with ordinary decide (not native_decide) keeps the entry free of Lean.ofReduceBool, so the only axioms are the foundational propext / Classical.choice / Quot.sound."
+    ],
+    "prerequisites": [
+      "Extremal graph theory (forbidden subgraphs, blow-ups, hereditary properties)",
+      "Graph homomorphisms and induced subgraphs",
+      "The #128 chain's homFree / clique framework"
+    ]
+  },
+  "conclusion": {
+    "summary": "Forbidden-subgraph freeness homFree F G is hereditary (closed under induced subgraphs), because the identity inclusion G.induce S → G is a graph homomorphism and the parent's homFree_of_hom pulls homFree back along it. Specialising to F = K_r gives hereditary clique-freeness, and chaining with the C₅-blow-up results shows every induced subgraph of every C₅ blow-up is K_r-free for r ≥ 3 (triangle-free at r = 3). Fully verified, 0 axioms, 0 sorries; C₅'s K₃-freeness uses ordinary decide.",
+    "implications": "This connects the two halves of the #128 formalization — induced-subgraph hereditarity and the C₅-blow-up forbidden-subgraph framework — and certifies the structural robustness any candidate extremal construction for #128 must possess: triangle-/clique-freeness is preserved on every vertex subset, in particular every ⌊n/2⌋-subgraph. It is the qualitative half of the optimality argument; the quantitative half (that the balanced C₅ blow-up still spans > n²/50 edges on every ⌊n/2⌋-subgraph) remains open.",
+    "openQuestions": [
+      "Compute the edge count of the balanced C₅ blow-up and show every ⌊n/2⌋-vertex induced subgraph still spans more than n²/50 edges, completing the optimality (1/50 cannot be lowered).",
+      "Formalize the upper-bound direction: does density > n²/50 on every ⌊n/2⌋-subgraph force a triangle?",
+      "Repair the broken scaffold Erdos128Problem.lean (add the DecidablePred instance and remove the trailing docstrings)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-128-wip-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Reuses the parent's homFree / homFree_of_hom / blowup / C5 framework and adds the induced-subgraph hereditarity layer on top of it"
+    },
+    {
+      "targetId": "erdos-128-wip-01",
+      "relationship": "extends",
+      "description": "Generalises the root's hereditary triangle-freeness (triangleFree_induce) to hereditary forbidden-subgraph freeness, reusing Graph.induce"
+    },
+    {
+      "targetId": "erdos-128-wip-01-oq-01",
+      "relationship": "related",
+      "description": "Builds on the blow-up / C₅ triangle-free construction introduced there"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "Erdos128WIP01OQ01OQ01OQ01OQ01",
+    "lineCount": 227,
+    "axiomCount": 0,
+    "theoremCount": 18,
+    "definitionCount": 10,
+    "sorries": 0,
+    "path": "Proofs/Erdos128WIP01OQ01OQ01OQ01OQ01.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Connects the two threads of the Erdős #128 formalization chain — the **forbidden-subgraph framework** (`homFree`, `blowup`, `C5` from `erdos-128-wip-01-oq-01-oq-01-oq-01`) and **induced-subgraph hereditarity** (`Graph.induce` from `erdos-128-wip-01`).

### Key observation
The identity inclusion `G.induce S → G` is a graph homomorphism (an induced subgraph only deletes edges). So the parent's `homFree_of_hom` pulls forbidden-subgraph freeness straight back:

- `induce_isHom`: `IsHom (G.induce S) G id`
- `homFree_induce`: `homFree F G → homFree F (G.induce S)` — hereditary for **any** forbidden `F`
- `cliqueFree_induce`: `G.cliqueFree r → (G.induce S).cliqueFree r` (the `F = Kᵣ` case)

### Applied to the extremal family
- `blowup_C5_induce_homFree` / `blowup_C5_induce_cliqueFree`: **every induced subgraph of every blow-up of C₅ is Kᵣ-free for r ≥ 3** (triangle-free at `r = 3`).

This is exactly the structural robustness any candidate extremal construction for #128 must have, since #128 constrains *every* `⌊n/2⌋`-vertex induced subgraph — the qualitative half of the `1/50` optimality argument. (The quantitative edge-count half remains open and is recorded in `conclusion.openQuestions`.)

### Verification
- Compiles clean (`lake env lean`, exit 0, no errors/warnings).
- Self-contained (chain convention; each entry re-derives its small framework). 18 theorems, 10 definitions, 227 lines.
- 0 sorries, 0 `axiom` declarations.
- `C5_homFree_three` uses ordinary `decide` (not `native_decide`) → **no `Lean.ofReduceBool`**.
- `#print axioms` on the headline theorems: only `propext`, `Classical.choice`, `Quot.sound`.
- `meta.json` passes JSON validation and the gallery size cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)