### PR TITLE
research(erdos-895): Fin-18 counterexample now 0-axiom — native_decide → decide [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos895CounterexampleFin18.lean
+++ b/proofs/Proofs/Erdos895CounterexampleFin18.lean
@@ -25,13 +25,15 @@
   This file gives the **corrected, machine-checked** statement: the explicit 42-edge
   witness, built as a genuine `SimpleGraph (Fin 18)`, is triangle-free and has no
   independent additive triple among three distinct vertices. Both facts are discharged
-  by `native_decide` (exhaustive over `Fin 18`). The witness graph is
+  by **plain kernel `decide`** (exhaustive over `Fin 18`). The witness graph is
   `research/problems/erdos-895-incomplete-01/counterexample-fin18.json`.
 
-  Note on axioms: `native_decide` relies on `Lean.ofReduceBool` (the Lean compiler's
-  kernel-reduction trust). This file is therefore *axiomatized* in the gallery sense,
-  with that single disclosed assumption; the underlying combinatorial claim is an
-  exhaustive finite check.
+  Note on axioms: the exhaustive checks use plain `decide`, not `native_decide`, so this
+  file is **0-axiom** — `#print axioms` lists only `propext` / `Quot.sound`, with **no**
+  `Lean.ofReduceBool` and no `sorryAx`. (An earlier version used `native_decide`, which
+  trusts the compiler's kernel reduction via `Lean.ofReduceBool`; the finite search here
+  is small enough — `18³` triples over a 42-edge adjacency list — that the trusted kernel
+  evaluates it directly in a few seconds, so the extra axiom is unnecessary.)
 -/
 
 import Mathlib
@@ -87,15 +89,18 @@ instance : DecidableRel G895.Adj := fun a b =>
 
 /-! ## Verified properties (exhaustive `native_decide` over `Fin 18`) -/
 
-/-- `G895` is triangle-free. -/
-theorem ce895_triangleFree : IsTriangleFree G895 := by native_decide
+set_option maxRecDepth 10000 in
+/-- `G895` is triangle-free.  Exhaustive over `Fin 18` by plain kernel `decide` (0 axioms). -/
+theorem ce895_triangleFree : IsTriangleFree G895 := by decide
 
+set_option maxRecDepth 10000 in
 /-- `G895` has **no** independent additive triple among three DISTINCT vertices.
 (Under the loose predicate of `Erdos895Problem.lean` the degenerate triples `(k, k, 2k)`
-would spuriously count; with `a ≠ b` enforced there is genuinely none.) -/
+would spuriously count; with `a ≠ b` enforced there is genuinely none.)
+Exhaustive over `Fin 18` by plain kernel `decide` (0 axioms — no `native_decide`). -/
 theorem ce895_no_distinct_independent_additive_triple :
     ¬ ∃ a b c : Fin 18, IsDistinctAdditiveTriple a b c ∧ IsIndependentTriple G895 a b c := by
-  native_decide
+  decide
 
 /-- **Corrected sharpness witness for Erdős #895.** There is a triangle-free graph on
 `Fin 18` (= `{1,…,17}`, vertex `0` isolated) with no independent additive triple among
@@ -107,5 +112,9 @@ theorem counterexample_fin18 :
     ∃ G : SimpleGraph (Fin 18), IsTriangleFree G ∧
       ¬ ∃ a b c : Fin 18, IsDistinctAdditiveTriple a b c ∧ IsIndependentTriple G a b c :=
   ⟨G895, ce895_triangleFree, ce895_no_distinct_independent_additive_triple⟩
+
+-- Axiom audit: plain `decide` (NOT `native_decide`) ⇒ foundational axioms only
+-- (propext / Quot.sound); no `Lean.ofReduceBool`, no `sorryAx`.
+#print axioms counterexample_fin18
 
 end Erdos895CounterexampleFin18

--- a/research/problems/erdos-895-incomplete-01/knowledge.md
+++ b/research/problems/erdos-895-incomplete-01/knowledge.md
@@ -206,3 +206,42 @@ the v4.26 build repair) is already shipped. The remaining work is the genuinely-
 session willing to *also* re-prove `erdos895_implies_schur_variant` with distinct
 vertices (or split the loose/strict predicates into two named defs and keep both
 lemmas). Recommend leaving the loose def + header warning as-is until then.
+
+---
+
+## Session 2026-06-28 (researcher-1) — ACT: counterexample upgraded to 0-axiom (native_decide → decide)
+
+**Mode**: REVISIT (axiom elimination) · **Outcome**: progress — the corrected Fin-18 counterexample
+is now **0-axiom verified**, not `axiomatized`.
+
+### Context
+The prior session (2026-06-25) documented that `Erdos895Problem.lean`'s `counterexample_17` is FALSE
+(Z3 UNSAT on Fin 17; two bugs: missing `a ≠ b`, and Fin n ↔ {1,…,n−1} off-by-one) and shipped the
+corrected witness `Erdos895CounterexampleFin18.lean` (`counterexample_fin18`) — but discharged the two
+exhaustive checks with `native_decide`, so it carried `Lean.ofReduceBool` (status `axiomatized`).
+
+### What I did
+Replaced both `native_decide` with plain kernel `decide` (`set_option maxRecDepth 10000 in`). The search
+is tiny — `18³ = 5832` triples over a 42-edge adjacency list — so the trusted kernel evaluates it directly
+(~few seconds). `#print axioms counterexample_fin18` now = `[propext, Quot.sound]` — **no
+`Lean.ofReduceBool`, no `sorryAx`**. Host-verified `lake env lean` exit 0 (Docker host down).
+- Updated the gallery meta `src/data/proofs/erdos-895-counterexample-fin18/meta.json`: it previously
+  OVERCLAIMED the now-absent axiom (`status: axiomatized`, `badge: axiom`, `axiomCount: 1`, ofReduceBool
+  in `assumptions`). Corrected to `status: verified`, `badge: verified`, `axiomCount: 0`, rewrote
+  `assumptions` and the native_decide prose. (`listings.json` regenerates from meta on `pnpm build`.)
+
+### Honest status
+This upgrades only the **counterexample** companion (one of the two directions). The positive direction
+`barber_theorem` (n ≥ 18 ⟹ a distinct-vertex independent additive triple always exists) is still a hard
+SAT-verified `sorry` in `Erdos895Problem.lean`, and that file is build-broken on Mathlib 4.26 (~9
+pre-existing API-drift errors in unrelated Turán/Mantel lemmas) — both remain open.
+
+### Files modified
+- proofs/Proofs/Erdos895CounterexampleFin18.lean (native_decide → decide; docstring + axiom audit)
+- src/data/proofs/erdos-895-counterexample-fin18/meta.json (verified, 0-axiom)
+- research/problems/erdos-895-incomplete-01/knowledge.md (this entry)
+
+### Next steps
+- Repair `Erdos895Problem.lean`'s 4.26 build breaks, then restate `barber_theorem` at n ≥ 19 (Fin) /
+  reconcile with the corrected distinct-vertex predicate + this proven witness.
+- `barber_theorem` positive direction: genuinely hard (Barber's SAT computation), not short-tactic.

--- a/src/data/proofs/erdos-895-counterexample-fin18/meta.json
+++ b/src/data/proofs/erdos-895-counterexample-fin18/meta.json
@@ -2,12 +2,12 @@
   "id": "erdos-895-counterexample-fin18",
   "title": "Erdős 895: Sharp Fin-18 Counterexample (machine-verified)",
   "slug": "erdos-895-counterexample-fin18",
-  "description": "The corrected, machine-verified sharp counterexample for Erdős Problem #895 (independent additive/Schur triples in triangle-free graphs). Barber (2015) proved every triangle-free graph on {1,…,n} contains three pairwise-non-adjacent vertices a, b, a+b for all n ≥ 18, with the threshold sharp at {1,…,17}. This companion to Erdos895Problem.lean builds the explicit 42-edge witness as a genuine `SimpleGraph (Fin 18)` (vertex 0 isolated, modelling {1,…,17}) and proves by `native_decide`, exhaustively over Fin 18, that it is triangle-free (`ce895_triangleFree`) and has NO independent additive triple among three DISTINCT vertices (`ce895_no_distinct_independent_additive_triple`); `counterexample_fin18` packages both. It corrects the sibling Erdos895Problem.lean's `counterexample_17`, which is false as stated: that statement uses an additive-triple predicate omitting `a ≠ b` (admitting degenerate (k,k,2k)) and is placed on Fin 17 — an exhaustive SAT search (Z3 UNSAT) proves every triangle-free graph on Fin 17 has such a loose triple, so the genuine distinct-vertex counterexample lives on Fin 18, not Fin 17.",
+  "description": "The corrected, machine-verified sharp counterexample for Erdős Problem #895 (independent additive/Schur triples in triangle-free graphs). Barber (2015) proved every triangle-free graph on {1,…,n} contains three pairwise-non-adjacent vertices a, b, a+b for all n ≥ 18, with the threshold sharp at {1,…,17}. This companion to Erdos895Problem.lean builds the explicit 42-edge witness as a genuine `SimpleGraph (Fin 18)` (vertex 0 isolated, modelling {1,…,17}) and proves by `decide`, exhaustively over Fin 18, that it is triangle-free (`ce895_triangleFree`) and has NO independent additive triple among three DISTINCT vertices (`ce895_no_distinct_independent_additive_triple`); `counterexample_fin18` packages both. It corrects the sibling Erdos895Problem.lean's `counterexample_17`, which is false as stated: that statement uses an additive-triple predicate omitting `a ≠ b` (admitting degenerate (k,k,2k)) and is placed on Fin 17 — an exhaustive SAT search (Z3 UNSAT) proves every triangle-free graph on Fin 17 has such a loose triple, so the genuine distinct-vertex counterexample lives on Fin 18, not Fin 17.",
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://erdosproblems.com/895",
     "date": "2026-06-25",
-    "status": "axiomatized",
+    "status": "verified",
     "tags": [
       "erdos-problems",
       "graph-theory",
@@ -15,12 +15,12 @@
       "triangle-free",
       "schur-triple",
       "counterexample",
-      "native_decide"
+      "verified"
     ],
     "proofRepoPath": "Proofs/Erdos895CounterexampleFin18.lean",
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 111,
     "dateAdded": "06/25/26",
     "erdosNumber": 895,
@@ -33,34 +33,35 @@
       },
       {
         "theorem": "Fintype.decidableForallFintype / decidableExistsFintype",
-        "description": "Decidability of bounded quantifiers over the finite type Fin 18, enabling the exhaustive native_decide checks.",
+        "description": "Decidability of bounded quantifiers over the finite type Fin 18, enabling the exhaustive decide checks.",
         "module": "Mathlib.Data.Fintype.Basic"
       }
     ],
     "originalContributions": [
       "G895: the explicit 42-edge sharp counterexample built as a genuine SimpleGraph (Fin 18) with a symmetric (min/max) Boolean adjacency and a clean DecidableRel instance.",
-      "ce895_triangleFree: native_decide proof that G895 is triangle-free (exhaustive over Fin 18³).",
-      "ce895_no_distinct_independent_additive_triple: native_decide proof that G895 has no independent additive triple among three DISTINCT vertices — the corrected statement Barber's theorem is about.",
+      "ce895_triangleFree: decide proof that G895 is triangle-free (exhaustive over Fin 18³).",
+      "ce895_no_distinct_independent_additive_triple: decide proof that G895 has no independent additive triple among three DISTINCT vertices — the corrected statement Barber's theorem is about.",
       "counterexample_fin18: packages the two into the sharp-threshold witness, the machine-verified replacement for the false `counterexample_17` (Fin 17) in Erdos895Problem.lean.",
       "IsDistinctAdditiveTriple: the corrected predicate adding `a ≠ b`, isolating the bug in the sibling file's loose IsAdditiveTriple."
     ],
-    "assumptions": "1 axiom: `Lean.ofReduceBool`, introduced by the two `native_decide` proofs (`ce895_triangleFree`, `ce895_no_distinct_independent_additive_triple`). Both are exhaustive finite checks over Fin 18 (triangle-freeness over all triples; absence of a distinct-vertex independent additive triple), so the trusted step is the Lean compiler's kernel reduction. No `sorry`, no literal `axiom` declarations (`leanFile.axiomCount = 0`); the witness graph is independently re-verified by Z3 (UNSAT) and pure Python in research/problems/erdos-895-incomplete-01/. Status `axiomatized` per the project's native_decide policy.",
+    "assumptions": "None — 0 axioms. The two exhaustive finite checks over Fin 18 (triangle-freeness over all triples; absence of a distinct-vertex independent additive triple) are discharged by plain kernel `decide`, NOT `native_decide`, so `#print axioms counterexample_fin18` lists only the foundational axioms `propext` / `Quot.sound` — no `Lean.ofReduceBool`, no `sorry`, no literal `axiom` declarations. The witness graph is independently re-verified by Z3 (UNSAT) and pure Python in research/problems/erdos-895-incomplete-01/. The `18³`-triple search is small enough that the trusted kernel evaluates it directly in a few seconds, so the compiler-trust step of `native_decide` is unnecessary.",
     "theoremCount": 5,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "lastUpdated": "2026-06-28"
   },
   "overview": {
     "historicalContext": "Erdős Problem #895 (Erdős–Hajnal) asks whether, for large n, every triangle-free graph on {1,…,n} must contain three pairwise-non-adjacent vertices a, b, a+b — an independent additive (Schur) triple. Ben Barber (2015) answered YES for all n ≥ 18 using SAT-solver verification, and showed the threshold is sharp: a triangle-free graph on {1,…,17} exists with no such triple among three distinct vertices.",
     "problemStatement": "Exhibit and machine-verify the sharp counterexample on {1,…,17}: a triangle-free graph with no independent additive triple in three distinct vertices a, b, a+b. (Companion to Erdos895Problem.lean, whose `counterexample_17` is false as stated.)",
-    "proofStrategy": "Encode the 42-edge witness (researcher-1's Z3/Python-verified graph) as a List of ascending pairs on {1,…,17}; define a symmetric Boolean adjacency `ce895Adj` via the ascending pair (min, max); build `G895 : SimpleGraph (Fin 18)` with that adjacency plus `a ≠ b` (symmetry from min/max commutativity, looplessness immediate). Mark the triangle-free / independent-triple / distinct-additive-triple predicates `@[reducible]` so instance synthesis sees the bounded quantifiers, then discharge `IsTriangleFree G895` and the negated existence statement by `native_decide` — each an exhaustive check over Fin 18.",
+    "proofStrategy": "Encode the 42-edge witness (researcher-1's Z3/Python-verified graph) as a List of ascending pairs on {1,…,17}; define a symmetric Boolean adjacency `ce895Adj` via the ascending pair (min, max); build `G895 : SimpleGraph (Fin 18)` with that adjacency plus `a ≠ b` (symmetry from min/max commutativity, looplessness immediate). Mark the triangle-free / independent-triple / distinct-additive-triple predicates `@[reducible]` so instance synthesis sees the bounded quantifiers, then discharge `IsTriangleFree G895` and the negated existence statement by `decide` — each an exhaustive check over Fin 18.",
     "keyInsights": [
       "**Distinctness is the crux.** Barber's theorem concerns three DISTINCT vertices a, b, a+b. A predicate omitting `a ≠ b` admits the degenerate (k, k, 2k) and changes the answer — making every triangle-free graph on Fin 17 (indeed Fin 12+) trivially have a 'triple'. The sibling Erdos895Problem.lean uses the loose predicate, so its `counterexample_17` (Fin 17) is false.",
       "**Index alignment: Fin 18 = {1,…,17}.** `SimpleGraph (Fin 18)` has vertices {0,…,17}; vertex 0 is inert (never part of an additive triple since a+b ≥ 2). So the {1,…,17} counterexample lives on Fin 18, not Fin 17 — an off-by-one in the sibling file.",
-      "**native_decide makes the SAT result a kernel-checkable fact.** The exhaustive search Barber ran with a SAT solver becomes, for this specific witness, a `native_decide` evaluation over Fin 18 — turning an external computation into a Lean-verified (modulo Lean.ofReduceBool) statement, cross-checked by an independent Z3 UNSAT proof and a pure-Python verifier.",
-      "**fromRel vs explicit structure.** Building `G895` as an explicit `SimpleGraph` structure (Adj := symmetric Bool ∧ a ≠ b) gives a directly-decidable adjacency, avoiding the extra unfolding `SimpleGraph.fromRel` would interpose before native_decide."
+      "**The SAT result becomes a 0-axiom kernel-checkable fact.** The exhaustive search Barber ran with a SAT solver becomes, for this specific witness, a plain `decide` evaluation over Fin 18 — turning an external computation into a fully Lean-verified statement (only `propext`/`Quot.sound`, no compiler-trust axiom), cross-checked by an independent Z3 UNSAT proof and a pure-Python verifier.",
+      "**fromRel vs explicit structure.** Building `G895` as an explicit `SimpleGraph` structure (Adj := symmetric Bool ∧ a ≠ b) gives a directly-decidable adjacency, avoiding the extra unfolding `SimpleGraph.fromRel` would interpose before decide."
     ],
     "prerequisites": [
       "Mathlib.Combinatorics.SimpleGraph.Basic (SimpleGraph, Adj)",
-      "Decidability of bounded quantifiers over Fintype (native_decide)",
+      "Decidability of bounded quantifiers over Fintype (decide)",
       "Erdos895Problem.lean (sibling: Barber's theorem statement, the loose-predicate bug)",
       "Basic additive combinatorics (Schur triples) and triangle-free graphs"
     ]
@@ -71,7 +72,7 @@
       "title": "Preamble: background and the corrected statement",
       "startLine": 1,
       "endLine": 43,
-      "summary": "Docstring: Erdős #895 / Barber's theorem, why counterexample_17 (Fin 17, loose predicate) is false, and that the genuine distinct-vertex counterexample lives on Fin 18. Discloses the native_decide / Lean.ofReduceBool assumption.",
+      "summary": "Docstring: Erdős #895 / Barber's theorem, why counterexample_17 (Fin 17, loose predicate) is false, and that the genuine distinct-vertex counterexample lives on Fin 18. Notes that the checks use plain `decide` (0 axioms — no `Lean.ofReduceBool`).",
       "mathContext": "Barber (2015): triangle-free graphs on {1,…,n} have an independent additive triple for n ≥ 18; sharp at {1,…,17}."
     },
     {
@@ -79,7 +80,7 @@
       "title": "Predicates (with distinctness corrected)",
       "startLine": 44,
       "endLine": 57,
-      "summary": "IsIndependentTriple, IsTriangleFree, and the corrected IsDistinctAdditiveTriple (adding a ≠ b). Marked @[reducible] so native_decide's instance synthesis sees the bounded quantifiers.",
+      "summary": "IsIndependentTriple, IsTriangleFree, and the corrected IsDistinctAdditiveTriple (adding a ≠ b). Marked @[reducible] so decide's instance synthesis sees the bounded quantifiers.",
       "mathContext": "The distinctness constraint a ≠ b is exactly what the sibling file's IsAdditiveTriple omits."
     },
     {
@@ -92,15 +93,15 @@
     },
     {
       "id": "verified-properties",
-      "title": "Verified properties (exhaustive native_decide)",
+      "title": "Verified properties (exhaustive decide)",
       "startLine": 87,
       "endLine": 111,
-      "summary": "ce895_triangleFree and ce895_no_distinct_independent_additive_triple (both native_decide over Fin 18), combined into counterexample_fin18 — the sharp-threshold witness.",
+      "summary": "ce895_triangleFree and ce895_no_distinct_independent_additive_triple (both decide over Fin 18), combined into counterexample_fin18 — the sharp-threshold witness.",
       "mathContext": "Triangle-freeness over all triples and absence of any distinct-vertex independent additive triple, checked exhaustively."
     }
   ],
   "conclusion": {
-    "summary": "An explicit triangle-free graph on Fin 18 (= {1,…,17}) with no independent additive triple among three distinct vertices, machine-verified by native_decide and independently cross-checked by Z3 and pure Python. This is the corrected, sharp counterexample for Erdős #895, replacing the false-as-stated `counterexample_17` (Fin 17) of the sibling Erdos895Problem.lean.",
+    "summary": "An explicit triangle-free graph on Fin 18 (= {1,…,17}) with no independent additive triple among three distinct vertices, machine-verified by decide and independently cross-checked by Z3 and pure Python. This is the corrected, sharp counterexample for Erdős #895, replacing the false-as-stated `counterexample_17` (Fin 17) of the sibling Erdos895Problem.lean.",
     "implications": "Establishes the n = 18 threshold of Barber's theorem is sharp, on the mathematically correct (distinct-vertex) reading. Isolates two bugs in the sibling formalization: (1) the additive-triple predicate must require a ≠ b; (2) the Fin n ↔ {1,…,n-1} off-by-one places the counterexample on Fin 18, not Fin 17.",
     "openQuestions": [
       "Formalize Barber's positive direction (n ≥ 18 ⟹ a distinct-vertex independent additive triple always exists). Barber's proof is a large SAT/case computation; it remains the genuinely-open `barber_theorem` sorry in Erdos895Problem.lean and is not attemptable via short tactics.",
@@ -126,17 +127,17 @@
     {
       "name": "counterexample_fin18",
       "statement": "∃ G : SimpleGraph (Fin 18), IsTriangleFree G ∧ ¬ ∃ a b c : Fin 18, IsDistinctAdditiveTriple a b c ∧ IsIndependentTriple G a b c",
-      "description": "The sharp counterexample: a triangle-free graph on Fin 18 (= {1,…,17}) with no independent additive triple among three distinct vertices. Machine-verified (native_decide), the corrected replacement for the false counterexample_17."
+      "description": "The sharp counterexample: a triangle-free graph on Fin 18 (= {1,…,17}) with no independent additive triple among three distinct vertices. Machine-verified (decide), the corrected replacement for the false counterexample_17."
     },
     {
       "name": "ce895_triangleFree",
       "statement": "IsTriangleFree G895",
-      "description": "The 42-edge witness graph G895 is triangle-free (native_decide, exhaustive over Fin 18)."
+      "description": "The 42-edge witness graph G895 is triangle-free (decide, exhaustive over Fin 18)."
     },
     {
       "name": "ce895_no_distinct_independent_additive_triple",
       "statement": "¬ ∃ a b c : Fin 18, IsDistinctAdditiveTriple a b c ∧ IsIndependentTriple G895 a b c",
-      "description": "G895 has no independent additive triple among three distinct vertices (native_decide)."
+      "description": "G895 has no independent additive triple among three distinct vertices (decide)."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

**Axiom elimination.** The corrected sharp counterexample for Erdős #895 (`Erdos895CounterexampleFin18.lean`, `counterexample_fin18`) was proven via `native_decide`, which trusts the compiler's kernel reduction through `Lean.ofReduceBool` — so it was `status: axiomatized`, `axiomCount: 1`.

The two exhaustive checks (triangle-freeness; absence of a distinct-vertex independent additive triple) run over `Fin 18` — only `18³ = 5832` triples against a 42-edge adjacency list. That is small enough for the **trusted kernel** to evaluate directly, so I replaced both `native_decide` with plain `decide` (`set_option maxRecDepth 10000 in`). The result is now genuinely **0-axiom**:

```
#print axioms counterexample_fin18  ⟹  [propext, Quot.sound]
```
No `Lean.ofReduceBool`, no `sorryAx`, no literal `axiom`.

## Changes

- `proofs/Proofs/Erdos895CounterexampleFin18.lean`: `native_decide` → `decide` on `ce895_triangleFree` and `ce895_no_distinct_independent_additive_triple`; docstring + axiom-audit updated.
- `src/data/proofs/erdos-895-counterexample-fin18/meta.json`: the meta previously **overclaimed** the now-absent axiom (`axiomatized` / `badge: axiom` / `axiomCount: 1` / `Lean.ofReduceBool` in `assumptions`). Corrected to `verified` / `badge: verified` / `axiomCount: 0`, with the `native_decide` prose rewritten. (`listings.json` regenerates from meta on `pnpm build`.)

## Scope / honest status

This upgrades only the **counterexample** direction (the verified-true half). The positive direction `barber_theorem` (n ≥ 18 ⟹ a distinct-vertex independent additive triple always exists) remains a hard SAT-verified `sorry` in the sibling `Erdos895Problem.lean`, which is additionally build-broken on Mathlib 4.26 — both still open (noted in the research knowledge base). The underlying combinatorial claim of the witness was already independently cross-checked by Z3 (UNSAT) and pure Python.

## Verification

- `lake env lean Proofs/Erdos895CounterexampleFin18.lean` → exit 0 (host; shared Mathlib 4.26 `.olean` cache; Docker host down).
- Axiom audit as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)