### PR TITLE
audit(cycleV52): 2 new gallery entries (cayley-hamilton, lagrange) reconfirmed CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25565,6 +25565,18 @@
       "lastAudited": "2026-06-28T08:56:08Z",
       "result": "clean",
       "issues": []
+    },
+    "cayley-hamilton-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T09:08:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-01-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T09:08:56Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — cycleV52

Audited the two genuine unaudited gallery entries on main. Both **CLEAN** — meta.json claims match the Lean kernel.

### cayley-hamilton-oq-01-oq-01-oq-01-oq-01
- Claims: `verified`/`original`, 0 axioms, 0 sorries, 4 theorems
- **Verified**: compiles via `bin/lake env lean`; `#print axioms` on both `exists_cyclicVector_iff_minpoly_eq_charpoly` and `exists_cyclicVector_iff_minpoly_natDegree_eq` reports only `propext, Classical.choice, Quot.sound` (foundational — do not count). 0 axiom declarations, 0 True stubs. The single `sorry` grep hit is docstring prose ("no `sorry`").
- Badge `original` is defensible: the forward-direction degree squeeze and the assembled equivalence are genuine contributions on top of Mathlib building blocks, not a single-theorem wrapper.

### lagrange-theorem-oq-01-oq-03-oq-02
- Claims: `verified`/`verified`, 0 axioms, 0 sorries, 3 theorems + 1 def
- **Verified**: compiles; `#print axioms` on all three theorems (`exists_minimal_normal_subgroup`, `minimal_normal_abelian_of_solvable`, `exists_abelian_minimal_normal_subgroup`) reports foundational axioms only. 0 axiom declarations, 0 sorries, 0 True stubs. Title accurately scoped to minimal-normal-subgroup existence + abelianness.

### Queue status
4119/4121 audited. The 2 remaining "unaudited" are standing tooling false positives, reconfirmed honest this cycle:
- **erdos-57-oq-04** — tooling flags axiom undercount (0 vs 1); the `axiom erdos_57` lives in the shared problem-statement file `Erdos57Problem.lean` (the conjecture statement), while oq-04's own contributions are 0-axiom. Honest.
- **erdos-156** — `formalized`/`wip`, sorries honestly disclosed (main file 0, dependency chain has sorries). Honest.

`roth-theorem-k3-oq-01-oq-01` is an untracked-scratch phantom on disk (not on origin/main, no tracker entry) — not a real target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)