### PR TITLE
research(hilbert-13-oq-02-oq-01): discrete spaces are zero-dimensional [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Hilbert13OQ02OQ01.lean
+++ b/proofs/Proofs/Hilbert13OQ02OQ01.lean
@@ -1,0 +1,163 @@
+/-
+# Hilbert's 13th Problem — OQ-02 / OQ-01
+## Discrete spaces are zero-dimensional (a concrete value for the covering dimension)
+
+The parent file `Hilbert13OQ02.lean` defines a clean, universe-safe Lebesgue covering
+dimension `covDimLE X n` (every finite open cover admits a finite open refinement of order
+`≤ n+1`) and proves it is a *topological invariant*, so that the Kolmogorov–Arnold superposition
+term count `2·dim(X)+1` is presentation-independent. But the only space it actually *computes*
+the dimension of is a subsingleton (`covDimLE_of_subsingleton`).
+
+This file supplies the first nontrivial computation:
+
+> **Every discrete space has covering dimension `0`.** (`covDimLE_of_discrete`)
+
+This is the classical fact that a discrete space is `0`-dimensional. The proof is a clean
+*disjointification*: given any finite open cover `cover : Fin m → Set X`, replace each set by
+its "least-index" part
+`V i = { x | x ∈ cover i ∧ ∀ j, x ∈ cover j → i ≤ j }`,
+i.e. `x ∈ V i` exactly when `i` is the **smallest** index whose cover set contains `x`. The `V i`
+are pairwise disjoint (so the cover has order `≤ 1 = 0 + 1`), they still cover `X` (every point
+has a least containing index, found via `Finset.min'`), and each `V i ⊆ cover i` (a refinement).
+The single place discreteness enters is openness: `V i` is generally a finite intersection of a
+cover set with complements of cover sets, which is open **only because every subset of a discrete
+space is open** (`isOpen_discrete`). That is exactly why the statement fails for, e.g., `ℝⁿ`.
+
+As corollaries we recover the parent's `covDimLE_of_subsingleton` (a subsingleton space is
+discrete) and record the general monotonicity `covDimLE_of_le` in the dimension bound.
+
+## Results (0 axioms, 0 sorries)
+* `covDimLE_succ` / `covDimLE_of_le` — monotonicity of the dimension bound (`≤` version).
+* `covDimLE_of_discrete` — **every discrete space is `0`-dimensional** (headline).
+* `covDimLE_of_subsingleton` — recovered as a corollary (subsingleton ⟹ discrete).
+
+## References
+- Engelking, R. "Dimension Theory" (discrete spaces are zero-dimensional).
+- Kolmogorov, A.N. (1957) / Sternfeld, Y. (1985) — the `2n+1` superposition term count.
+-/
+
+import Mathlib
+
+namespace Hilbert13OQ02OQ01
+
+variable {X : Type*} [TopologicalSpace X]
+
+/-! ## Covering-dimension API (re-stated, self-contained — matches `Hilbert13OQ02.lean`) -/
+
+/-- The order of a cover at a point: how many cover sets contain it. -/
+noncomputable def coverOrderAt {ι : Type*} (sets : ι → Set X) (x : X) : ℕ :=
+  {i | x ∈ sets i}.ncard
+
+/-- A cover has order `≤ n + 1` if every point lies in at most `n + 1` of its sets. -/
+def coverOrderAtMost {ι : Type*} (sets : ι → Set X) (n : ℕ) : Prop :=
+  ∀ x : X, coverOrderAt sets x ≤ n + 1
+
+/-- `B` refines `A` if every set of `B` sits inside some set of `A`. -/
+def IsRefinement {ι₁ ι₂ : Type*} (A : ι₁ → Set X) (B : ι₂ → Set X) : Prop :=
+  ∀ j : ι₂, ∃ i : ι₁, B j ⊆ A i
+
+/-- Covering dimension `≤ n`: every finite open cover has a finite open refinement of order
+    `≤ n + 1`. -/
+def covDimLE (X : Type*) [TopologicalSpace X] (n : ℕ) : Prop :=
+  ∀ (m : ℕ) (cover : Fin m → Set X),
+    (∀ i, IsOpen (cover i)) → (∀ x : X, ∃ i, x ∈ cover i) →
+    ∃ (p : ℕ) (refine : Fin p → Set X),
+      (∀ j, IsOpen (refine j)) ∧
+      (∀ x : X, ∃ j, x ∈ refine j) ∧
+      IsRefinement cover refine ∧
+      coverOrderAtMost refine n
+
+/-! ## Part I: Monotonicity in the bound -/
+
+/-- Covering dimension is monotone in the bound: `dim X ≤ n ⟹ dim X ≤ n + 1`. -/
+theorem covDimLE_succ {n : ℕ} (h : covDimLE X n) : covDimLE X (n + 1) := by
+  intro m cover hopen hcov
+  obtain ⟨p, refine, hro, hrc, href, hord⟩ := h m cover hopen hcov
+  exact ⟨p, refine, hro, hrc, href, fun x => Nat.le_succ_of_le (hord x)⟩
+
+/-- General monotonicity: `dim X ≤ n` and `n ≤ N` give `dim X ≤ N`. -/
+theorem covDimLE_of_le {n N : ℕ} (hnN : n ≤ N) (h : covDimLE X n) : covDimLE X N := by
+  induction N, hnN using Nat.le_induction with
+  | base => exact h
+  | succ k _ ih => exact covDimLE_succ ih
+
+/-! ## Part II: Discrete spaces are zero-dimensional (headline) -/
+
+/-- **Every discrete space has covering dimension `0`.**
+
+    Given a finite open cover `cover`, define the "least-index" refinement
+    `V i = { x | x ∈ cover i ∧ ∀ j, x ∈ cover j → i ≤ j }`. The sets `V i` are pairwise disjoint
+    (each point belongs to `V i` only for its least covering index `i`), they cover `X`
+    (`Finset.min'` selects that least index), and `V i ⊆ cover i`. Openness of each `V i` is the
+    only step that uses discreteness: every subset of a discrete space is open. -/
+theorem covDimLE_of_discrete [DiscreteTopology X] : covDimLE X 0 := by
+  intro m cover _ hcov
+  classical
+  -- The least-index disjointification of the cover.
+  set V : Fin m → Set X :=
+    fun i => {x | x ∈ cover i ∧ ∀ j, x ∈ cover j → i ≤ j} with hV
+  refine ⟨m, V, ?_, ?_, ?_, ?_⟩
+  · -- Open: every subset of a discrete space is open.
+    intro i; exact isOpen_discrete (V i)
+  · -- Cover: each point has a least covering index.
+    intro x
+    obtain ⟨i, hi⟩ := hcov x
+    have hTne : (Finset.univ.filter (fun j => x ∈ cover j)).Nonempty :=
+      ⟨i, Finset.mem_filter.mpr ⟨Finset.mem_univ i, hi⟩⟩
+    refine ⟨(Finset.univ.filter (fun j => x ∈ cover j)).min' hTne, ?_, ?_⟩
+    · have hmem := (Finset.univ.filter (fun j => x ∈ cover j)).min'_mem hTne
+      rw [Finset.mem_filter] at hmem
+      exact hmem.2
+    · intro j hxj
+      exact Finset.min'_le _ j (Finset.mem_filter.mpr ⟨Finset.mem_univ j, hxj⟩)
+  · -- Refinement: `V i ⊆ cover i`.
+    intro i
+    exact ⟨i, fun x hx => hx.1⟩
+  · -- Order `≤ 1`: the `V i` are pairwise disjoint, so each point lies in at most one.
+    intro x
+    by_cases hx : ∃ i, x ∈ V i
+    · obtain ⟨i₀, hi₀⟩ := hx
+      have hsub : {i | x ∈ V i} ⊆ {i₀} := by
+        intro i hi
+        rw [Set.mem_setOf_eq] at hi
+        rw [Set.mem_singleton_iff]
+        have h1 : i ≤ i₀ := hi.2 i₀ hi₀.1
+        have h2 : i₀ ≤ i := hi₀.2 i hi.1
+        exact le_antisymm h1 h2
+      calc coverOrderAt V x
+            = {i | x ∈ V i}.ncard := rfl
+        _ ≤ ({i₀} : Set (Fin m)).ncard := Set.ncard_le_ncard hsub (Set.finite_singleton i₀)
+        _ = 1 := Set.ncard_singleton i₀
+    · have hempty : {i | x ∈ V i} = ∅ :=
+        Set.eq_empty_iff_forall_notMem.mpr (fun i hi => hx ⟨i, hi⟩)
+      have : coverOrderAt V x = 0 := by rw [coverOrderAt, hempty, Set.ncard_empty]
+      rw [this]; exact Nat.zero_le 1
+
+/-! ## Part III: Corollary — subsingleton spaces (recovering the parent's base case) -/
+
+/-- A subsingleton space is discrete: with at most one point, every subset is `∅` or `univ`,
+    both of which are open in any topology. -/
+theorem covDimLE_of_subsingleton [Subsingleton X] : covDimLE X 0 := by
+  have hdisc : DiscreteTopology X := by
+    rw [discreteTopology_iff_forall_isOpen]
+    intro s
+    rcases Set.eq_empty_or_nonempty s with h | ⟨a, ha⟩
+    · rw [h]; exact isOpen_empty
+    · have : s = Set.univ := Set.eq_univ_of_forall fun b => Subsingleton.elim b a ▸ ha
+      rw [this]; exact isOpen_univ
+  exact covDimLE_of_discrete
+
+/-! ## Summary
+
+Proved here (0 axioms, 0 sorries):
+* `covDimLE_succ`, `covDimLE_of_le` — monotonicity of the covering-dimension bound.
+* `covDimLE_of_discrete` — **every discrete space is zero-dimensional** (the first nontrivial,
+  non-subsingleton computation in this covering-dimension framework).
+* `covDimLE_of_subsingleton` — recovered as a corollary, since a subsingleton space is discrete.
+
+The genuinely open OQ-02 (the *computational* complexity of producing a KA superposition for an
+effectively-presented continuous function) remains untouched; this file only adds verified
+structural facts about the dimension that controls the `2n+1` term count.
+-/
+
+end Hilbert13OQ02OQ01

--- a/src/data/proofs/hilbert-13-oq-02-oq-01/meta.json
+++ b/src/data/proofs/hilbert-13-oq-02-oq-01/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "hilbert-13-oq-02-oq-01",
+  "title": "Discrete Spaces Are Zero-Dimensional (Hilbert #13, OQ-02 / OQ-01)",
+  "slug": "hilbert-13-oq-02-oq-01",
+  "description": "Extends the covering-dimension framework of hilbert-13-oq-02 with its first nontrivial computation: every discrete topological space has Lebesgue covering dimension 0. The proof disjointifies an arbitrary finite open cover into its 'least-index' sets, which are open precisely because every subset of a discrete space is open. This generalizes the parent's subsingleton base case (recovered here as a corollary) and records general monotonicity of the dimension bound. 4 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-28",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert13OQ02OQ01.lean",
+    "additionalFiles": [],
+    "tags": [
+      "topology",
+      "dimension-theory",
+      "covering-dimension",
+      "discrete-space",
+      "hilbert-problems",
+      "kolmogorov-arnold",
+      "superposition",
+      "mathlib"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-28",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the standard foundational axioms propext / Classical.choice / Quot.sound, which do not count as assumptions). Self-contained: re-states the covering-dimension API (coverOrderAt, coverOrderAtMost, IsRefinement, covDimLE) of the parent file Hilbert13OQ02.lean and depends only on Mathlib.",
+    "lineCount": 163,
+    "theoremCount": 4,
+    "definitionCount": 4,
+    "originalContributions": [
+      "covDimLE_of_discrete: every discrete topological space has covering dimension 0 — the first nontrivial, non-subsingleton computation in this covering-dimension framework, proved by least-index disjointification of an arbitrary finite open cover",
+      "covDimLE_of_subsingleton: recovered as a corollary, since a subsingleton space is discrete (every subset is empty or universal, hence open)",
+      "covDimLE_of_le: general monotonicity of the dimension bound — dim X ≤ n and n ≤ N give dim X ≤ N (by Nat.le_induction over the parent's covDimLE_succ)",
+      "covDimLE_succ: the single-step monotonicity dim X ≤ n ⟹ dim X ≤ n+1, re-stated self-contained"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Hilbert's 13th problem concerns representing continuous functions of several variables as superpositions of functions of fewer variables; the Kolmogorov–Arnold theorem (1957) and Sternfeld's refinement (1985) tie the minimal superposition term count of a space X to 2·dim(X)+1, where dim is Lebesgue covering dimension. The companion entry hilbert-13-oq-02 proved that covering dimension — and hence this term count — is a topological invariant, but only ever computed the dimension of a subsingleton (a single point). The classical foundational fact that *discrete* spaces are zero-dimensional is the next natural value to pin down.",
+    "problemStatement": "Within the universe-safe covering-dimension definition of hilbert-13-oq-02 (every finite open cover admits a finite open refinement of order ≤ n+1), prove that every discrete topological space X satisfies covDimLE X 0, i.e. dim X = 0.",
+    "text": "A 163-line self-contained companion file. It re-states the covering-dimension API (coverOrderAt, coverOrderAtMost, IsRefinement, covDimLE) verbatim from the parent so it can be read independently, records the monotonicity lemmas covDimLE_succ and covDimLE_of_le, then proves the headline covDimLE_of_discrete by an explicit disjointification, and finally derives covDimLE_of_subsingleton as a corollary.",
+    "proofStrategy": "Given a finite open cover cover : Fin m → Set X, define the least-index refinement V i = { x | x ∈ cover i ∧ ∀ j, x ∈ cover j → i ≤ j }: a point x lies in V i exactly when i is the smallest index whose cover set contains x.\n- **Disjoint (order ≤ 1)**: if x ∈ V i and x ∈ V i' then i ≤ i' and i' ≤ i, so i = i'; the index set {i | x ∈ V i} has at most one element, giving coverOrderAt V x ≤ 1 = 0+1 via Set.ncard_le_ncard against a singleton.\n- **Covers**: the finite set T = univ.filter (x ∈ cover ·) is nonempty (the cover covers x), so Finset.min' selects the least covering index, which witnesses x ∈ V (min').\n- **Refines**: V i ⊆ cover i by construction.\n- **Open**: each V i is open because in a discrete space every subset is open (isOpen_discrete) — the only step that uses discreteness, and precisely why the result fails for ℝⁿ.\nThe subsingleton corollary establishes DiscreteTopology X (every subset is ∅ or univ, both open) via discreteTopology_iff_forall_isOpen, then invokes covDimLE_of_discrete.",
+    "keyInsights": [
+      "Zero-dimensionality of a discrete space is exactly the statement that any finite open cover can be disjointified into an open cover of order 1 — and disjointification (set difference) preserves openness only when every subset is open, which is the defining feature of discreteness.",
+      "The 'least-index' construction V i = {x | x ∈ cover i ∧ ∀ j, x ∈ cover j → i ≤ j} is a clean, index-canonical way to disjointify a Fin m-indexed cover without choice beyond a finite minimum (Finset.min').",
+      "Pairwise disjointness is encoded as 'the index set containing each point is a subsingleton', which Set.ncard turns directly into the order bound ≤ 1.",
+      "The subsingleton base case of the parent is not a separate phenomenon: a subsingleton space is discrete, so covDimLE_of_subsingleton is a one-line corollary of covDimLE_of_discrete.",
+      "General monotonicity covDimLE_of_le follows from the single-step covDimLE_succ by Nat.le_induction, completing the order-theoretic picture of the dimension bound."
+    ],
+    "prerequisites": [
+      "hilbert-13-oq-02 — the covering-dimension definition covDimLE and its homeomorphism-invariance (motivates the framework re-stated here)",
+      "Lebesgue covering dimension via finite open covers and cover order",
+      "Discrete topology: every subset is open (isOpen_discrete, discreteTopology_iff_forall_isOpen)",
+      "Finset.min' for a least element of a nonempty finite subset, and Set.ncard order lemmas"
+    ]
+  },
+  "sections": [
+    {
+      "id": "api",
+      "title": "Covering-Dimension API (self-contained)",
+      "startLine": 43,
+      "endLine": 68,
+      "summary": "Re-states coverOrderAt, coverOrderAtMost, IsRefinement and covDimLE verbatim from the parent file so the entry reads independently.",
+      "mathContext": "Covering dimension ≤ n: every finite (Fin m) open cover admits a finite open refinement of order ≤ n+1, with order measured by Set.ncard (no decidability instance needed)."
+    },
+    {
+      "id": "monotone",
+      "title": "Part I: Monotonicity in the Bound",
+      "startLine": 70,
+      "endLine": 82,
+      "summary": "covDimLE_succ (dim ≤ n ⟹ dim ≤ n+1) and its iterate covDimLE_of_le (dim ≤ n and n ≤ N ⟹ dim ≤ N) by Nat.le_induction.",
+      "mathContext": "The dimension bound is upward closed; a higher bound is always satisfiable once a lower one is."
+    },
+    {
+      "id": "discrete",
+      "title": "Part II: Discrete Spaces Are Zero-Dimensional (headline)",
+      "startLine": 84,
+      "endLine": 134,
+      "summary": "covDimLE_of_discrete: disjointify any finite open cover into the least-index sets V i; prove open (isOpen_discrete), covering (Finset.min'), refining, and order ≤ 1 (subsingleton index set).",
+      "mathContext": "The single use of discreteness is openness of the disjointified sets; everything else is finite combinatorics on the cover indices."
+    },
+    {
+      "id": "subsingleton",
+      "title": "Part III: Subsingleton Corollary",
+      "startLine": 136,
+      "endLine": 148,
+      "summary": "covDimLE_of_subsingleton: a subsingleton space is discrete (every subset is ∅ or univ, both open), so the headline applies directly — recovering the parent's base case.",
+      "mathContext": "Bridges the new general result back to the parent file's isolated one-point computation."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file gives the covering-dimension framework of hilbert-13-oq-02 its first nontrivial value: every discrete topological space is zero-dimensional, proved by least-index disjointification of an arbitrary finite open cover. The parent's subsingleton base case is recovered as a corollary, and the dimension bound is shown monotone.",
+    "implications": "Together with the parent's homeomorphism-invariance of covering dimension, the result confirms the framework computes the classically correct dimension for the simplest infinite family of spaces (discrete spaces), strengthening confidence that the 2n+1 Kolmogorov–Arnold superposition term count it controls is the intended invariant. It does not address the genuinely open OQ-02: the computational complexity of producing a KA superposition for an effectively-presented continuous function.",
+    "futureWork": "Compute covDimLE for further concrete spaces (intervals, finite simplicial complexes, products) and connect to Mathlib's topological-dimension API once universe/decidability issues are resolved."
+  },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-13-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry defining the covering-dimension framework covDimLE and proving its homeomorphism-invariance; this file adds the first nontrivial computation within it."
+    },
+    {
+      "targetId": "hilbert-13",
+      "relationship": "extends",
+      "description": "Top-level Hilbert #13 entry on Kolmogorov–Arnold superposition."
+    },
+    {
+      "targetId": "hilbert-13-oq-04",
+      "relationship": "complements",
+      "description": "Sibling open-question formalization for Hilbert #13."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Kolmogorov, A.N.",
+      "title": "On the representation of continuous functions of several variables by superpositions of continuous functions of one variable and addition",
+      "year": "1957",
+      "venue": "Dokl. Akad. Nauk SSSR 114",
+      "note": "The Kolmogorov–Arnold superposition theorem"
+    },
+    {
+      "authors": "Sternfeld, Y.",
+      "title": "Dimension, superposition of functions and separation of points, in compact metric spaces",
+      "year": "1985",
+      "venue": "Israel Journal of Mathematics 50",
+      "note": "Minimal superposition term count is 2·dim(X)+1"
+    },
+    {
+      "authors": "Engelking, R.",
+      "title": "Dimension Theory",
+      "year": "1978",
+      "venue": "North-Holland",
+      "note": "Covering dimension; discrete spaces are zero-dimensional"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Hilbert13OQ02OQ01",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "path": "Proofs/Hilbert13OQ02OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 4,
+    "additionalFiles": []
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Extends the covering-dimension framework of **hilbert-13-oq-02** (Lebesgue covering dimension as a topological invariant, controlling the Kolmogorov–Arnold superposition term count `2·dim(X)+1`) with its **first nontrivial computation**:

> **Every discrete topological space has covering dimension `0`.** (`covDimLE_of_discrete`)

The parent entry only ever computed the dimension of a *subsingleton*. This file computes it for the simplest infinite family of spaces, the classically expected result that discrete spaces are zero-dimensional.

## Proof

Given any finite open cover `cover : Fin m → Set X`, disjointify it into the **least-index** sets
`V i = { x | x ∈ cover i ∧ ∀ j, x ∈ cover j → i ≤ j }` (a point lies in `V i` iff `i` is the smallest index whose cover set contains it):

- **order ≤ 1** — the `V i` are pairwise disjoint (each point's index set is a subsingleton), so `coverOrderAt V x ≤ 1 = 0+1`;
- **covers** — `Finset.min'` selects the least covering index of each point;
- **refines** — `V i ⊆ cover i`;
- **open** — each `V i` is open *only because every subset of a discrete space is open* (`isOpen_discrete`). This is the sole place discreteness enters, and exactly why the statement fails for `ℝⁿ`.

## Results (0 axioms, 0 sorries)

- `covDimLE_of_discrete` — every discrete space is zero-dimensional (headline)
- `covDimLE_of_subsingleton` — recovered as a corollary (subsingleton ⟹ discrete)
- `covDimLE_of_le` — general monotonicity of the dimension bound (`Nat.le_induction` over `covDimLE_succ`)

`#print axioms` on all theorems: only `propext / Classical.choice / Quot.sound`. Verified standalone via `./bin/lake env lean Proofs/Hilbert13OQ02OQ01.lean`. Self-contained (re-states the parent `covDimLE` API), depends only on Mathlib.

Does **not** touch the genuinely open OQ-02 (computational complexity of producing a KA superposition for an effectively-presented function); it adds verified structural facts about the dimension that controls the term count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)