### PR TITLE
Enrich Minimal Normal Subgroups (existence + abelianness, 0 axioms)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "lagrange-oq010302-isminimalnormal-def",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 66, "endLine": 70 },
+    "type": "definition",
+    "title": "The Minimal-Normal-Subgroup Predicate",
+    "content": "IsMinimalNormal N packages three conditions: N is normal, N is nontrivial (N ≠ ⊥), and N is minimal among nontrivial normal subgroups (any normal M ≤ N with M ≠ ⊥ must equal N). Mathlib 4.26 ships no minimal-normal-subgroup API, so this predicate — and the two existence/structure theorems built on it — are original gallery contributions. Note the minimality is phrased positively (every nontrivial normal subgroup below N is all of N) rather than via the order-theoretic Minimal, which keeps later proofs working directly with subgroup containments.",
+    "mathContext": "$\\mathrm{IsMinimalNormal}(N) \\;:\\equiv\\; N \\trianglelefteq G \\;\\wedge\\; N \\neq \\bot \\;\\wedge\\; \\bigl(\\forall M \\trianglelefteq G,\\; M \\le N \\wedge M \\neq \\bot \\Rightarrow M = N\\bigr).$",
+    "significance": "key",
+    "relatedConcepts": ["minimal normal subgroup", "normal subgroup", "subgroup lattice", "characteristically simple group"],
+    "prerequisites": ["normal subgroup", "subgroup order (≤, ⊥)"]
+  },
+  {
+    "id": "lagrange-oq010302-finite-lattice",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 86, "endLine": 87 },
+    "type": "technique",
+    "title": "Finiteness of the Subgroup Lattice",
+    "content": "The existence argument needs the lattice Subgroup G to be finite. This is not automatic from [Finite G]: it is derived by observing that SetLike.coe : Subgroup G → Set G is injective, so Subgroup G injects into the finite power set Set G. The instance haveI : Finite (Subgroup G) := Finite.of_injective _ SetLike.coe_injective must be supplied by hand before Set.toFinite can see that the candidate set of nontrivial normal subgroups is finite. A subtle Lean gotcha: Finite (Subgroup G) is not synthesized just from [Finite G].",
+    "mathContext": "$\\text{SetLike.coe}: \\mathrm{Subgroup}\\,G \\hookrightarrow \\mathcal{P}(G),\\quad |G| < \\infty \\Rightarrow |\\mathrm{Subgroup}\\,G| \\le 2^{|G|} < \\infty.$",
+    "significance": "technical",
+    "relatedConcepts": ["subgroup lattice", "finiteness", "injective coercion", "SetLike"],
+    "prerequisites": ["finite types", "power set", "injective functions"]
+  },
+  {
+    "id": "lagrange-oq010302-exists-minimal",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 79, "endLine": 94 },
+    "type": "insight",
+    "title": "Existence via a Minimal Element of a Finite Poset",
+    "content": "Existence of a minimal normal subgroup reduces to a finiteness principle: the set s = {K | K.Normal ∧ K ≠ ⊥} is nonempty (⊤ is normal and ≠ ⊥ because G is nontrivial) and finite (it sits in the finite lattice), so Set.Finite.exists_minimal hands back a minimal element N of the order restricted to s. The final step shows minimality within s is exactly the minimality demanded by IsMinimalNormal: any nontrivial normal M ≤ N is in s and ≤ N, so minimality gives N ≤ M, and le_antisymm closes M = N. No well-ordering or choice beyond the foundational axioms is needed — the descent terminates because the lattice is finite.",
+    "mathContext": "$s = \\{K \\trianglelefteq G : K \\neq \\bot\\},\\quad \\top \\in s,\\ |s| < \\infty \\;\\Rightarrow\\; \\exists N \\in s\\ \\text{minimal};\\quad M \\in s,\\ M \\le N \\Rightarrow N \\le M \\Rightarrow M = N.$",
+    "significance": "key",
+    "relatedConcepts": ["minimal element", "finite poset", "well-foundedness", "le_antisymm"],
+    "prerequisites": ["partial order", "minimal element of a finite set", "nontrivial group"]
+  },
+  {
+    "id": "lagrange-oq010302-commutator-descent",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 109, "endLine": 116 },
+    "type": "insight",
+    "title": "Strict Commutator Descent Forces ⁅N,N⁆ = ⊥",
+    "content": "The heart of the abelianness proof. For a minimal normal N of a solvable group, the commutator ⁅N, N⁆ is (a) normal in G — Subgroup.commutator_normal, (b) contained in N — Subgroup.commutator_le_self, and crucially (c) strictly smaller than N — IsSolvable.commutator_lt_of_ne_bot, the solvable-group descent lemma stating that a nontrivial subgroup of a solvable group properly contains its own commutator subgroup. A normal subgroup strictly below the minimal N cannot itself be nontrivial (minimality would force equality, contradicting strictness), so ⁅N, N⁆ = ⊥. Solvability is used exactly once, precisely here, to get the strict inequality.",
+    "mathContext": "$\\lbrack N, N\\rbrack \\trianglelefteq G,\\quad \\lbrack N, N\\rbrack \\le N,\\quad \\lbrack N, N\\rbrack \\lneq N \\ (\\text{solvable}) \\;\\Rightarrow\\; \\lbrack N, N\\rbrack = \\bot.$",
+    "significance": "key",
+    "relatedConcepts": ["commutator subgroup", "solvable group", "derived series", "minimality"],
+    "prerequisites": ["commutator subgroup", "solvable group", "strict order"]
+  },
+  {
+    "id": "lagrange-oq010302-centralizer-abelian",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 117, "endLine": 123 },
+    "type": "technique",
+    "title": "⁅N,N⁆ = ⊥ Means N Centralizes Itself",
+    "content": "Translating the vanishing commutator into a commuting law: Subgroup.commutator_eq_bot_iff_le_centralizer turns ⁅N, N⁆ = ⊥ into N ≤ centralizer N, i.e. every element of N commutes with every element of N. Unpacking the centralizer membership via mem_centralizer_iff gives b * a = a * b for elements a, b of N (note the order — the lemma yields the equation with the factors swapped, so Subtype.ext h.symm is needed to land on a * b = b * a in the subtype). This is the definition of N being abelian.",
+    "mathContext": "$\\lbrack N, N\\rbrack = \\bot \\iff N \\le C_G(N) \\;\\Rightarrow\\; \\forall a, b \\in N,\\ ab = ba.$",
+    "significance": "supporting",
+    "relatedConcepts": ["centralizer", "abelian group", "commutator", "Subtype.ext"],
+    "prerequisites": ["centralizer of a set", "abelian groups", "subtype equality"]
+  },
+  {
+    "id": "lagrange-oq010302-packaged-existence",
+    "proofId": "lagrange-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 125, "endLine": 133 },
+    "type": "context",
+    "title": "Packaging the Structural Input for Hall's Induction",
+    "content": "exists_abelian_minimal_normal_subgroup combines existence (Part I) with abelianness (Part II) into the single statement Hall's induction actually consumes: every nontrivial finite solvable group has an abelian minimal normal subgroup N. This is the structural starting point for the induction in Hall's theorem on solvable groups — it provides the abelian normal kernel on which the induction splits. Together with the Schur–Zassenhaus lifting step (sibling entry oq-01) and the abelian base case (oq-03), the only remaining gap toward a fully 0-axiom Hall's theorem is upgrading 'abelian' to 'elementary abelian' (exponent p), pinning |N| = pᵃ.",
+    "mathContext": "$G \\ \\text{finite, nontrivial, solvable} \\;\\Rightarrow\\; \\exists N \\trianglelefteq G\\ \\text{minimal with}\\ \\forall a, b \\in N,\\ ab = ba.$",
+    "significance": "key",
+    "relatedConcepts": ["Hall's theorem", "solvable group induction", "elementary abelian group", "minimal normal subgroup"],
+    "prerequisites": ["solvable group", "minimal normal subgroup", "mathematical induction"]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-02/meta.json
@@ -34,6 +34,53 @@
     ],
     "proofStrategy": "Existence: for finite G the lattice Subgroup G is finite (SetLike injects into the finite Set G), so the set {K | K.Normal ∧ K ≠ ⊥} is a finite, nonempty (⊤ belongs since G is nontrivial) subset of the partial order Subgroup G and therefore has a minimal element by Set.Finite.exists_minimal. Minimality in the order restricted to that set is exactly minimality among nontrivial normal subgroups, extracted by le_antisymm. Abelianness: for a minimal normal N of solvable G, the commutator ⁅N, N⁆ is normal in G (Subgroup.commutator_normal), is ≤ N (Subgroup.commutator_le_self), and is strictly below N (IsSolvable.commutator_lt_of_ne_bot, the solvable-group descent). A normal subgroup strictly below the minimal N cannot be nontrivial, so ⁅N, N⁆ = ⊥; by Subgroup.commutator_eq_bot_iff_le_centralizer this means N ≤ centralizer N, i.e. every two elements of N commute."
   },
+  "overview": {
+    "historicalContext": "The notion of a minimal normal subgroup is a cornerstone of finite group theory, central to the local analysis that culminated in the classification of finite simple groups. A minimal normal subgroup of a finite group is always a direct product of isomorphic simple groups (it is characteristically simple), and in the solvable world it specializes all the way down: it is elementary abelian, a vector space over a prime field. This last fact powers the inductive proofs of Philip Hall's 1928 theorems on solvable groups — the existence of Hall π-subgroups and their conjugacy — by furnishing an abelian normal kernel on which to induct. Mathlib 4.26 has a rich solvable-group and commutator API but, surprisingly, no minimal-normal-subgroup machinery; the sibling entry that formalized Hall's Schur–Zassenhaus lifting step identified exactly this as the gap blocking a fully axiom-free Hall theorem. This entry builds the missing layer from primitives: the finiteness of the subgroup lattice for existence, and the solvable-group commutator descent for abelianness.",
+    "problemStatement": "Formalize, with 0 axioms, the two structural facts about minimal normal subgroups that Hall's induction requires: (1) every nontrivial finite group $G$ has a minimal normal subgroup $N$ (normal, $N \\neq \\bot$, with no nontrivial normal subgroup strictly below it), and (2) if $G$ is solvable then such an $N$ is abelian. Package these into: every nontrivial finite solvable group has an abelian minimal normal subgroup.",
+    "proofStrategy": "Existence is a finiteness argument: the set $s = \\{K \\trianglelefteq G : K \\neq \\bot\\}$ is nonempty ($\\top \\in s$ since $G$ is nontrivial) and finite (because Subgroup $G$ injects into the finite power set of $G$), so Set.Finite.exists_minimal returns a minimal element, and le_antisymm shows order-minimality within $s$ coincides with the IsMinimalNormal predicate. Abelianness is a commutator-descent argument: $\\lbrack N, N\\rbrack$ is normal in $G$, lies in $N$, and — because $G$ is solvable — is strictly below $N$ (IsSolvable.commutator_lt_of_ne_bot). Minimality of $N$ then forces $\\lbrack N, N\\rbrack = \\bot$, which by commutator_eq_bot_iff_le_centralizer says $N$ centralizes itself, i.e. $N$ is abelian.",
+    "keyInsights": [
+      "Existence of a minimal normal subgroup is not a transfinite or Zorn-style argument here but a plain finite-poset descent: the subgroup lattice of a finite group is finite, so any nonempty family of subgroups has a minimal member. This keeps the proof within the foundational axioms (no extra choice).",
+      "Finite (Subgroup G) does not follow automatically from [Finite G] in Lean — it must be constructed from the injectivity of the SetLike coercion into the finite power set. This is the one non-obvious instance the existence proof has to supply by hand.",
+      "Solvability enters the abelianness proof at a single, sharp point: IsSolvable.commutator_lt_of_ne_bot, the statement that a nontrivial subgroup of a solvable group strictly contains its own derived subgroup. Everything else (normality and containment of the commutator) holds in any group.",
+      "Minimality is the lever that converts 'strictly smaller and normal' into 'trivial': a normal subgroup properly below a minimal normal N cannot be nontrivial, so the strictly-smaller commutator ⁅N,N⁆ must be ⊥. This is the recurring shape of minimal-normal-subgroup arguments.",
+      "A vanishing self-commutator is exactly abelianness, mediated by commutator_eq_bot_iff_le_centralizer: ⁅N,N⁆ = ⊥ ⟺ N ≤ centralizer N. The proof closes by unpacking centralizer membership into the elementwise commuting law.",
+      "The packaged theorem exists_abelian_minimal_normal_subgroup is deliberately shaped to be the exact hypothesis Hall's induction consumes — abelianness, not just existence, is what lets the induction descend to a quotient by an abelian normal subgroup."
+    ]
+  },
+  "sections": [
+    {
+      "id": "isminimalnormal-def",
+      "title": "The Minimal-Normal-Subgroup Predicate",
+      "startLine": 66,
+      "endLine": 70,
+      "summary": "Defines IsMinimalNormal N — normal, nontrivial, and minimal among nontrivial normal subgroups — the API Mathlib 4.26 lacks and the rest of the file is built on.",
+      "mathContext": "$\\mathrm{IsMinimalNormal}(N) :\\equiv N \\trianglelefteq G \\wedge N \\neq \\bot \\wedge (\\forall M \\trianglelefteq G,\\ M \\le N \\wedge M \\neq \\bot \\Rightarrow M = N).$"
+    },
+    {
+      "id": "existence",
+      "title": "Part I — Existence of a Minimal Normal Subgroup",
+      "startLine": 72,
+      "endLine": 94,
+      "summary": "Proves exists_minimal_normal_subgroup: a nontrivial finite group has a minimal normal subgroup, via finiteness of the subgroup lattice and Set.Finite.exists_minimal, with le_antisymm matching order-minimality to the predicate.",
+      "mathContext": "$s = \\{K \\trianglelefteq G : K \\neq \\bot\\}\\ \\text{nonempty, finite} \\Rightarrow \\exists N \\in s\\ \\text{minimal}.$"
+    },
+    {
+      "id": "abelianness",
+      "title": "Part II — Minimal Normal Subgroups of Solvable Groups Are Abelian",
+      "startLine": 96,
+      "endLine": 123,
+      "summary": "Proves minimal_normal_abelian_of_solvable: the commutator ⁅N,N⁆ is normal, ≤ N, and (by solvability) strictly below N, so minimality forces it to ⊥, i.e. N centralizes itself.",
+      "mathContext": "$\\lbrack N, N\\rbrack \\lneq N\\ (\\text{solvable}) \\Rightarrow \\lbrack N, N\\rbrack = \\bot \\Rightarrow N \\le C_G(N).$"
+    },
+    {
+      "id": "packaged",
+      "title": "Packaged Existence of an Abelian Minimal Normal Subgroup",
+      "startLine": 125,
+      "endLine": 135,
+      "summary": "Combines Parts I and II into exists_abelian_minimal_normal_subgroup — the exact structural input Hall's induction on solvable groups requires.",
+      "mathContext": "$G\\ \\text{finite, nontrivial, solvable} \\Rightarrow \\exists N\\ \\text{minimal normal, abelian}.$"
+    }
+  ],
   "leanFile": {
     "path": "Proofs/LagrangeTheoremOQ01OQ03OQ02.lean",
     "imports": [


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-01-oq-03-oq-02` (passes: 0, quality: 15).

This new entry shipped with only `meta.json` (no `overview`, `sections`, or annotations). This pass adds the full presentation layer.

## Changes
- **overview**: added `historicalContext` (minimal normal subgroups in finite group theory and Hall's program), `problemStatement`, `proofStrategy`, and 6 `keyInsights`.
- **sections**: 4 sections mapping the Lean file — IsMinimalNormal predicate, Part I existence, Part II abelianness, packaged result — each with `mathContext`.
- **annotations.json** (new): 6 annotations, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, covering the predicate definition, the finite-lattice existence argument (incl. the `Finite (Subgroup G)` instance gotcha), the strict commutator descent that forces ⁅N,N⁆ = ⊥, the centralizer translation to abelianness, and the packaged Hall input.

## Integrity
- `status: verified`, `axiomCount: 0` unchanged and consistent with the Lean source (no structure-encoded assumptions; #print axioms reports only the foundational propext/Classical.choice/Quot.sound).
- `meta.json` now 13 KB, well under the 60 KB cap.
- `pnpm annotations:build` passes with no warnings for this entry (all annotation ranges align with Lean constructs).