### PR TITLE
research(erdos-214-incomplete-01-oq-01): the √2-scaled integer lattice is unit-distance-free [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1760,6 +1760,7 @@ import Proofs.Erdos211Problem
 import Proofs.Erdos211SteinerLineCount
 import Proofs.Erdos212Problem
 import Proofs.Erdos213Problem
+import Proofs.Erdos214Incomplete01OQ01
 import Proofs.Erdos214Problem
 import Proofs.Erdos214ProblemAristotle
 import Proofs.Erdos215Problem

--- a/proofs/Proofs/Erdos214Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos214Incomplete01OQ01.lean
@@ -1,0 +1,127 @@
+/-
+# Erdős #214: the √2-scaled integer lattice is unit-distance-free
+  (the hypothesis of Problem #214 is non-vacuous)
+
+## Source
+The gallery entry `erdos-214` (Juhász's theorem: a unit-distance-free set has a
+unit square in its complement) defines the example set
+
+  `ScaledLattice = { (√2·a, √2·b) : a, b ∈ ℤ }`
+
+but proves nothing about it. This entry supplies the missing verification that
+`ScaledLattice` is genuinely **unit-distance-free**, so the hypothesis of #214 is
+non-vacuous — a concrete, fully machine-checked (0-axiom) witness, independent of
+the axiomatized Juhász theorem.
+
+## What This Proves
+
+For two points of `ScaledLattice`, say `(√2·a, √2·b)` and `(√2·a', √2·b')`, the
+squared Euclidean distance is
+
+  `(√2)²·(a-a')² + (√2)²·(b-b')² = 2·((a-a')² + (b-b')²)`,
+
+an **even** integer. It can never equal `1²= 1`, because `2·(m² + k²) = 1` is
+impossible for integers `m, k` (the left side is even). Hence no two lattice
+points are at distance exactly `1`.
+
+**Main results:**
+- `dist_eq_coords`: the coordinate formula `dist p q = √((p₀-q₀)² + (p₁-q₁)²)`.
+- `two_mul_sq_add_sq_ne_one`: `2·(m² + k²) ≠ 1` for integers `m, k` (the arithmetic core).
+- `scaledLattice_dist_ne_one`: any two points of `ScaledLattice` are at distance `≠ 1`.
+- `scaledLattice_unitDistanceFree`: `ScaledLattice` is unit-distance-free.
+- `scaledLattice_nonempty`: `0 ∈ ScaledLattice` (the set is inhabited).
+
+## Structure of the Argument
+
+`dist_eq_coords` unfolds the Euclidean norm on `EuclideanSpace ℝ (Fin 2)` to the
+two-coordinate Pythagorean form (mirroring the `dist_coords` helper of the parent
+entry). Substituting the lattice coordinates and using `(√2)² = 2` collapses each
+squared coordinate difference to `2·(integer)²`; the radicand is `2·((a-a')² +
+(b-b')²)`. If its square root were `1`, squaring gives `2·((a-a')² + (b-b')²) = 1`,
+refuted by `two_mul_sq_add_sq_ne_one` (an `omega` parity argument after casting
+back to `ℤ`). Note the conclusion needs no `p ≠ q` hypothesis: the distance is
+never `1` even for equal points (it is then `0`).
+
+Fully machine-checked, self-contained over Mathlib, no `sorry`, no extra axioms
+(in particular it does **not** use the parent's `juhasz_1979` / `juhasz_stronger`).
+
+## Depends on
+Mathlib only. Re-states the parent's `Plane`, `dist`, `IsUnitDistanceFree`,
+`ScaledLattice` so the result stands free of the axiomatized core.
+-/
+
+import Mathlib
+
+set_option linter.unusedVariables false
+
+namespace Erdos214Incomplete01OQ01
+
+/-- The Euclidean plane `ℝ²`. -/
+abbrev Plane := EuclideanSpace ℝ (Fin 2)
+
+/-- Euclidean distance between two points of the plane. -/
+noncomputable def dist (p q : Plane) : ℝ := ‖p - q‖
+
+/-- `S` is **unit-distance-free** if no two distinct points are exactly distance `1` apart. -/
+def IsUnitDistanceFree (S : Set Plane) : Prop :=
+  ∀ p q : Plane, p ∈ S → q ∈ S → p ≠ q → dist p q ≠ 1
+
+/-- The **`√2`-scaled integer lattice** `{ (√2·a, √2·b) : a, b ∈ ℤ }`. -/
+def ScaledLattice : Set Plane :=
+  {p : Plane | ∃ a b : ℤ, p 0 = Real.sqrt 2 * a ∧ p 1 = Real.sqrt 2 * b}
+
+/-- **Coordinate distance formula.** On `EuclideanSpace ℝ (Fin 2)` the distance is
+the Pythagorean combination of the two coordinate differences. -/
+theorem dist_eq_coords (p q : Plane) :
+    dist p q = Real.sqrt ((p 0 - q 0) ^ 2 + (p 1 - q 1) ^ 2) := by
+  unfold dist
+  rw [← dist_eq_norm, EuclideanSpace.dist_eq, Fin.sum_univ_two]
+  simp only [Real.dist_eq, sq_abs]
+
+/-- **Arithmetic core.** `2·(m² + k²) = 1` is impossible for integers `m, k`: the
+left-hand side is even. -/
+theorem two_mul_sq_add_sq_ne_one (m k : ℤ) : 2 * ((m : ℝ) ^ 2 + (k : ℝ) ^ 2) ≠ 1 := by
+  intro h
+  have hc : ((2 * (m ^ 2 + k ^ 2) : ℤ) : ℝ) = ((1 : ℤ) : ℝ) := by push_cast; linarith
+  have : 2 * (m ^ 2 + k ^ 2) = 1 := by exact_mod_cast hc
+  omega
+
+/-- **Any two points of `ScaledLattice` are at distance `≠ 1`.** The squared
+distance is `2·((a-a')² + (b-b')²)`, an even integer, never equal to `1`. (No
+`p ≠ q` hypothesis is needed.) -/
+theorem scaledLattice_dist_ne_one {p q : Plane}
+    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice) : dist p q ≠ 1 := by
+  obtain ⟨a, b, hpa, hpb⟩ := hp
+  obtain ⟨a', b', hqa, hqb⟩ := hq
+  rw [dist_eq_coords]
+  have hs : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have hx : (p 0 - q 0) ^ 2 = 2 * ((a : ℝ) - a') ^ 2 := by
+    rw [hpa, hqa]
+    have e : (Real.sqrt 2 * (a : ℝ) - Real.sqrt 2 * a') ^ 2
+        = Real.sqrt 2 ^ 2 * ((a : ℝ) - a') ^ 2 := by ring
+    rw [e, hs]
+  have hy : (p 1 - q 1) ^ 2 = 2 * ((b : ℝ) - b') ^ 2 := by
+    rw [hpb, hqb]
+    have e : (Real.sqrt 2 * (b : ℝ) - Real.sqrt 2 * b') ^ 2
+        = Real.sqrt 2 ^ 2 * ((b : ℝ) - b') ^ 2 := by ring
+    rw [e, hs]
+  rw [hx, hy]
+  intro hcontra
+  have hnn : 0 ≤ 2 * ((a : ℝ) - a') ^ 2 + 2 * ((b : ℝ) - b') ^ 2 := by positivity
+  have h1 := Real.sq_sqrt hnn
+  rw [hcontra] at h1
+  have hsq : 2 * ((a : ℝ) - a') ^ 2 + 2 * ((b : ℝ) - b') ^ 2 = 1 := by simpa using h1.symm
+  have hkey : 2 * (((a - a' : ℤ) : ℝ) ^ 2 + ((b - b' : ℤ) : ℝ) ^ 2) = 1 := by
+    push_cast; linarith
+  exact two_mul_sq_add_sq_ne_one (a - a') (b - b') hkey
+
+/-- **The `√2`-scaled integer lattice is unit-distance-free** — so the hypothesis
+of Erdős #214 is non-vacuous. Immediate from `scaledLattice_dist_ne_one`. -/
+theorem scaledLattice_unitDistanceFree : IsUnitDistanceFree ScaledLattice :=
+  fun p q hp hq _ => scaledLattice_dist_ne_one hp hq
+
+/-- `ScaledLattice` is inhabited: the origin lies in it (`a = b = 0`). -/
+theorem scaledLattice_nonempty : (0 : Plane) ∈ ScaledLattice := by
+  refine ⟨0, 0, ?_, ?_⟩ <;> simp
+
+end Erdos214Incomplete01OQ01

--- a/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
@@ -1,0 +1,120 @@
+{
+  "id": "erdos-214-incomplete-01-oq-01",
+  "title": "Erdős #214: the √2-scaled integer lattice is unit-distance-free (the hypothesis is non-vacuous)",
+  "slug": "erdos-214-incomplete-01-oq-01",
+  "description": "The gallery entry erdos-214 (Juhász's theorem) defines the example set ScaledLattice = {(√2·a, √2·b) : a,b ∈ ℤ} but proves nothing about it. This entry supplies the missing verification that ScaledLattice is genuinely unit-distance-free, so the hypothesis of Erdős #214 is non-vacuous. The squared distance between two lattice points is 2·((a-a')² + (b-b')²), an even integer, which can never equal 1² = 1 because 2·(m²+k²) = 1 is impossible for integers. Fully machine-checked, 0 axioms, independent of the axiomatized Juhász theorem.",
+  "meta": {
+    "author": "researcher-10 (Lean Genius)",
+    "sourceUrl": "https://www.erdosproblems.com/214",
+    "date": "2026-06-28",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos214Incomplete01OQ01.lean",
+    "tags": [
+      "combinatorial-geometry",
+      "erdos-problems",
+      "unit-distance",
+      "euclidean-plane",
+      "lattice",
+      "distance-geometry",
+      "non-vacuity",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "EuclideanSpace.dist_eq",
+        "description": "the distance on EuclideanSpace ℝ (Fin 2) is the root-sum-of-squares of coordinate distances — unfolded to the Pythagorean coordinate formula",
+        "module": "Mathlib.Analysis.InnerProductSpace.EuclideanDist"
+      },
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "(√x)² = x for x ≥ 0 — used both for (√2)² = 2 and to square the distance equation back to its radicand",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      }
+    ],
+    "originalContributions": [
+      "dist_eq_coords: the coordinate distance formula dist p q = √((p₀-q₀)² + (p₁-q₁)²) on EuclideanSpace ℝ (Fin 2)",
+      "two_mul_sq_add_sq_ne_one: 2·(m² + k²) ≠ 1 for integers m,k — the parity/arithmetic core (omega after casting to ℤ)",
+      "scaledLattice_dist_ne_one: any two points of ScaledLattice are at distance ≠ 1 (no p ≠ q hypothesis needed; the squared distance is an even integer)",
+      "scaledLattice_unitDistanceFree: the √2-scaled integer lattice is unit-distance-free — the hypothesis of Erdős #214 is non-vacuous",
+      "scaledLattice_nonempty: the origin lies in ScaledLattice (the set is inhabited)"
+    ],
+    "references": [
+      {
+        "authors": "Erdős, Paul",
+        "title": "Problem #214",
+        "year": "",
+        "venue": "erdosproblems.com",
+        "note": "If S ⊂ ℝ² has no two points at distance 1, must Sᶜ contain a unit square? Resolved affirmatively by Juhász (1979)."
+      },
+      {
+        "authors": "Juhász, Rozália",
+        "title": "Ramsey type theorems in the plane",
+        "year": "1979",
+        "venue": "Journal of Combinatorial Theory, Series A",
+        "note": "Sᶜ contains a congruent copy of every 4-point configuration when S is unit-distance-free"
+      }
+    ],
+    "prerequisites": [
+      "The gallery entry erdos-214 (Plane, dist, IsUnitDistanceFree, ScaledLattice; the axiomatized Juhász theorem)",
+      "Euclidean distance on EuclideanSpace ℝ (Fin 2)",
+      "Elementary integer parity (2·(m²+k²) ≠ 1)"
+    ],
+    "dateAdded": "2026-06-28",
+    "axiomCount": 0,
+    "lineCount": 127,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound). In particular this result does NOT use the parent entry's axiomatized juhasz_1979 / juhasz_stronger.",
+    "theoremCount": 5,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #214 asks whether the complement of every unit-distance-free planar set S (no two points exactly distance 1 apart) must contain the four vertices of a unit square; Juhász (1979) proved the stronger statement that Sᶜ contains a congruent copy of every 4-point configuration. The gallery entry erdos-214 formalizes the statement and Juhász's theorem as axioms and derives the unit-square corollary from the stronger form. Among its definitions is a concrete example, ScaledLattice = √2·ℤ², intended to illustrate a unit-distance-free set — but the entry never proves it actually is one, leaving the example inert and the #214 hypothesis formally unwitnessed.",
+    "problemStatement": "**Goal**: Verify that the example set ScaledLattice = {(√2·a, √2·b) : a,b ∈ ℤ} is unit-distance-free, making the hypothesis of Erdős #214 non-vacuous with a concrete, axiom-free witness.\n\n**Resolution**: The squared distance between two lattice points (√2·a, √2·b) and (√2·a', √2·b') equals 2·((a-a')² + (b-b')²), an even non-negative integer; it equals 1 only if 2·(m²+k²) = 1 for integers m,k, which is impossible. Hence no two points are at distance 1, and ScaledLattice (which contains the origin) is a genuine unit-distance-free set.",
+    "text": "A 127-line, axiom-free, self-contained development (5 theorems, 4 definitions). dist_eq_coords unfolds the Euclidean norm on EuclideanSpace ℝ (Fin 2) into the two-coordinate Pythagorean form (mirroring the parent's dist_coords helper). two_mul_sq_add_sq_ne_one is the arithmetic heart: casting 2·(m²+k²) = 1 back to ℤ, omega refutes it on parity. scaledLattice_dist_ne_one substitutes the lattice coordinates, uses (√2)² = 2 (Real.sq_sqrt) to collapse each squared coordinate difference to 2·(integer)², squares the hypothetical distance equation (Real.sq_sqrt on the non-negative radicand) and lands the contradiction; notably it needs no p ≠ q hypothesis. scaledLattice_unitDistanceFree is the immediate corollary, and scaledLattice_nonempty records that the origin (a = b = 0) belongs to the set. The development re-states the parent's Plane / dist / IsUnitDistanceFree / ScaledLattice so it stands free of the axiomatized Juhász core.",
+    "proofStrategy": "(1) dist_eq_coords: rewrite ‖p - q‖ via dist_eq_norm and EuclideanSpace.dist_eq, expand the Fin 2 sum, and identify |·|² with (·)². (2) For two lattice points, substitute p 0 = √2·a etc., factor (√2·a - √2·a')² = (√2)²·(a-a')² and rewrite (√2)² = 2, giving radicand 2·(a-a')² + 2·(b-b')². (3) Assume the distance is 1; squaring (Real.sq_sqrt on the non-negative radicand) yields 2·((a-a')² + (b-b')²) = 1 over ℝ; push the equation to ℤ and refute by two_mul_sq_add_sq_ne_one (omega parity). (4) The unit-distance-free property and the inhabitedness witness follow directly.",
+    "keyInsights": [
+      "The √2 scaling makes every squared inter-point distance an even integer (2·(m²+k²)), so distance 1 — whose square is the odd number 1 — is structurally excluded by parity.",
+      "The exclusion needs no distinctness hypothesis: equal points give distance 0, distinct points give √(even integer ≥ 2) > 1, and neither equals 1.",
+      "Reducing the geometric claim to the integer fact 2·(m²+k²) ≠ 1 lets omega finish, keeping the whole proof elementary and free of the axiomatized Juhász theorem.",
+      "Proving the example set is genuinely unit-distance-free turns the parent entry's inert ScaledLattice definition into a concrete, machine-checked witness that #214's hypothesis is satisfiable."
+    ],
+    "prerequisites": [
+      "Euclidean geometry of the plane (distance, lattices)",
+      "Elementary number theory (integer parity)",
+      "The #214 framework (unit-distance-free sets)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The √2-scaled integer lattice ScaledLattice = {(√2·a, √2·b) : a,b ∈ ℤ} is unit-distance-free: the squared distance between any two of its points is 2·((a-a')² + (b-b')²), an even integer never equal to 1. This makes the hypothesis of Erdős #214 non-vacuous with a concrete witness, and it is verified independently of the axiomatized Juhász theorem (0 axioms, 0 sorries).",
+    "implications": "This closes a real gap in the parent erdos-214 entry, whose ScaledLattice example was defined but never shown to satisfy the unit-distance-free property. The result certifies that #214's hypothesis class is non-empty (so the theorem is not vacuously true) and provides reusable elementary infrastructure — the coordinate distance formula and the 2·(m²+k²) ≠ 1 parity lemma — for further lattice/geometry formalizations in the gallery.",
+    "openQuestions": [
+      "Does the property hold for all 5-point configurations? This is the first open case after Juhász's 4-point theorem.",
+      "Quantify the maximum n for which every n-point configuration appears in the complement of every unit-distance-free set.",
+      "Construct other explicit unit-distance-free sets (e.g. other scaled or rotated lattices) and compare their densities.",
+      "Extend to higher dimensions: characterise scaled lattices √c·ℤ^d that are unit-distance-free."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-214",
+      "relationship": "extends",
+      "description": "Proves the unit-distance-free property of the parent entry's ScaledLattice example, which the parent defines but leaves unverified; independent of the parent's axiomatized juhasz_1979 / juhasz_stronger"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "Erdos214Incomplete01OQ01",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 4,
+    "sorries": 0,
+    "path": "Proofs/Erdos214Incomplete01OQ01.lean"
+  }
+}


### PR DESCRIPTION
## Summary

The gallery entry `erdos-214` (Juhász's theorem on unit-distance-free sets) defines the example set
```
ScaledLattice = { (√2·a, √2·b) : a, b ∈ ℤ }
```
but **proves nothing about it**. This entry supplies the missing verification that `ScaledLattice` is genuinely **unit-distance-free**, making the hypothesis of Erdős #214 non-vacuous — a concrete, axiom-free witness independent of the parent's axiomatized `juhasz_1979` / `juhasz_stronger`.

### The argument
The squared distance between two lattice points `(√2·a, √2·b)` and `(√2·a', √2·b')` is
```
(√2)²·(a-a')² + (√2)²·(b-b')² = 2·((a-a')² + (b-b')²),
```
an **even integer**. It can never equal `1² = 1`, because `2·(m² + k²) = 1` is impossible for integers (parity). Hence no two points are at distance exactly 1 — and notably this needs no `p ≠ q` hypothesis.

### Theorems (5)
- `dist_eq_coords`: coordinate distance formula on `EuclideanSpace ℝ (Fin 2)`
- `two_mul_sq_add_sq_ne_one`: `2·(m²+k²) ≠ 1` for integers (the arithmetic core, `omega` after casting to ℤ)
- `scaledLattice_dist_ne_one`: any two lattice points are at distance ≠ 1
- `scaledLattice_unitDistanceFree`: ScaledLattice is unit-distance-free
- `scaledLattice_nonempty`: the origin lies in ScaledLattice

### Verification
- Compiles clean (`lake env lean`, exit 0, no errors/warnings).
- Self-contained over Mathlib. 5 theorems, 4 definitions, 127 lines.
- 0 sorries, 0 `axiom` declarations.
- `#print axioms scaledLattice_unitDistanceFree`: only `propext`, `Classical.choice`, `Quot.sound` — does **not** use the parent's Juhász axioms.
- `meta.json` passes JSON validation and the gallery size cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)