### PR TITLE
audit(cycleV54): erdos-128 + hilbert-13 new entries reconfirmed CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25577,6 +25577,18 @@
       "lastAudited": "2026-06-28T09:08:56Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T09:14:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-13-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T09:14:57Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — cycleV54

Audited the 2 genuine never-audited gallery entries on `main` (ddd85541484). Both **CLEAN**.

### erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01 — `verified` / `original` ✓
- 0 `axiom` declarations, 0 real sorries (the lone `sorry` grep hit is docstring prose "no `sorry`")
- Uses ordinary `decide`, **not** `native_decide` — the two `native_decide` grep hits are docstrings stating it is *not* used; the actual tactics at L183/L189 are plain `decide`, so `Lean.ofReduceBool` is correctly **not** incurred. `axiomCount: 0` is honest.
- 18 theorems / 10 defs match meta. Hereditarity layer (`induce_isHom`, `homFree_induce`, `cliqueFree_induce`, `blowup_C5_induce_*`) is genuine original content; Mathlib deps used as building blocks, not as the main result.

### hilbert-13-oq-02-oq-01 — `verified` / `original` ✓
- 0 axioms, 0 sorries, no `native_decide`
- 4 defs + 4 theorems match meta exactly
- Discrete-space zero-dimensionality via least-index disjointification is original work, not a Mathlib wrapper. Badge `original` appropriate.

### Notes
- `roth-theorem-k3-oq-01-oq-01` showed as "never audited" only because `find-targets` globs disk including untracked scratch — it is **not on origin/main and has no PR** (phantom). Excluded.
- Standing false positives `erdos-57-oq-04` (axiom = the conjecture statement) and `erdos-156` (disclosed wip sorries) reconfirmed honest; no action.

Queue: unaudited 2 → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)