### PR TITLE
research(spectral-trace-det-eigenvalues-oq-01-oq-01): similarity transfer — tr(Aᵏ)=Σλᵢᵏ for every matrix similar to upper-triangular [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean
+++ b/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean
@@ -38,9 +38,11 @@ available cleanly from [oq-01] is the tautological reading
 
 Identifying those `μⱼ` with `λᵢ ᵏ` (the multiset spectral mapping for the full characteristic
 polynomial) is the remaining content. The closing sections below establish this mapping
-unconditionally for **diagonal** and **upper-triangular** matrices — the computational core — and
-isolate the single classical ingredient (Schur triangularisation over an algebraically closed
-field) needed to extend it to every matrix.
+unconditionally for **diagonal** and **upper-triangular** matrices — the computational core — then
+show, via similarity-invariance of the eigenvalue multiset and the trace, that it transfers to every
+matrix **similar to an upper-triangular one**. This isolates the single classical ingredient (Schur
+triangularisation over an algebraically closed field) to one explicit, machine-checked hypothesis
+(`trace_pow_eq_sum_pow_eigenvalues_of_triangularizable`).
 
 All results below are fully machine-checked with no `sorry` and no extra axioms.
 -/
@@ -269,6 +271,73 @@ theorem trace_pow_eq_sum_pow_eigenvalues_blockTriangular [IsAlgClosed K] {M : Ma
     (M ^ k).trace = ((eigenvalues M).map (· ^ k)).sum :=
   trace_pow_of_eigenvalues_pow M k (eigenvalues_pow_blockTriangular hM k)
 
+/-! #### General matrices via similarity: the Schur reduction made precise
+
+Both the eigenvalue multiset and the trace power sum are **similarity invariants**: conjugating a
+matrix by an invertible matrix leaves its characteristic polynomial — hence its eigenvalue multiset
+(`Matrix.charpoly_units_conj`) — unchanged, and conjugation commutes with taking powers
+(`units_conj_pow`). Consequently the multiset spectral mapping, and with it the power sum
+`tr(Aᵏ) = Σ λᵢᵏ`, transfers from any matrix `T` for which it is already known to **every** conjugate
+`U T U⁻¹`. Feeding the upper-triangular case above into this transfer collapses the *entire* general
+statement down to the single hypothesis that `A` is **similar to an upper-triangular matrix** —
+`A = U T U⁻¹` with `T` upper-triangular. Over an algebraically closed field that hypothesis is
+exactly the conclusion of the classical **Schur triangularisation theorem**, the one ingredient not
+yet available at the matrix level in Mathlib. The closing theorem below makes the reduction a single
+explicit, machine-checked hypothesis rather than an informal remark. -/
+
+omit [LinearOrder N] in
+/-- **Conjugation by a unit commutes with matrix powers:** `(U A U⁻¹)ᵏ = U Aᵏ U⁻¹`. The
+off-diagonal `U⁻¹ U` factors telescope away inside the power. -/
+theorem units_conj_pow (U : (Matrix N N K)ˣ) (A : Matrix N N K) (k : ℕ) :
+    (U.val * A * U⁻¹.val) ^ k = U.val * A ^ k * U⁻¹.val := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+      rw [pow_succ, ih, pow_succ]
+      simp only [Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc U⁻¹.val U.val, U.inv_mul, Matrix.one_mul]
+
+omit [LinearOrder N] in
+/-- **Eigenvalue multiset is a similarity invariant:** conjugation by a unit preserves it, since it
+preserves the characteristic polynomial. -/
+theorem eigenvalues_units_conj (U : (Matrix N N K)ˣ) (A : Matrix N N K) :
+    eigenvalues (U.val * A * U⁻¹.val) = eigenvalues A := by
+  unfold eigenvalues; rw [charpoly_units_conj]
+
+/-- **Multiset spectral mapping for matrices similar to an upper-triangular one** (any field, all
+`k`): if `A = U T U⁻¹` with `T` upper-triangular, then
+`eigenvalues (Aᵏ) = (eigenvalues A).map (· ^ k)`. The spectral mapping transfers from `T` to its
+conjugate `A` by conjugation-invariance of the eigenvalue multiset together with
+`(U T U⁻¹)ᵏ = U Tᵏ U⁻¹`. -/
+theorem eigenvalues_pow_of_units_conj_blockTriangular {A T : Matrix N N K}
+    (U : (Matrix N N K)ˣ) (hA : A = U.val * T * U⁻¹.val) (hT : T.BlockTriangular id) (k : ℕ) :
+    eigenvalues (A ^ k) = (eigenvalues A).map (· ^ k) := by
+  subst hA
+  rw [units_conj_pow, eigenvalues_units_conj, eigenvalues_units_conj,
+    eigenvalues_pow_blockTriangular hT]
+
+/-- **Eigenvalue power sum for matrices similar to an upper-triangular one** (all `k`):
+`tr (Aᵏ) = Σ λᵢᵏ` whenever `A = U T U⁻¹` with `T` upper-triangular. -/
+theorem trace_pow_eq_sum_pow_eigenvalues_of_units_conj_blockTriangular [IsAlgClosed K]
+    {A T : Matrix N N K} (U : (Matrix N N K)ˣ) (hA : A = U.val * T * U⁻¹.val)
+    (hT : T.BlockTriangular id) (k : ℕ) :
+    (A ^ k).trace = ((eigenvalues A).map (· ^ k)).sum :=
+  trace_pow_of_eigenvalues_pow A k
+    (eigenvalues_pow_of_units_conj_blockTriangular U hA hT k)
+
+/-- **The general trace power sum, modulo Schur triangularisation.** Over an algebraically closed
+field, *if* `A` is similar to an upper-triangular matrix — the conclusion of the classical Schur
+triangularisation theorem, the sole ingredient not yet available at the matrix level in Mathlib —
+then the full eigenvalue power sum identity `tr (Aᵏ) = Σ λᵢᵏ` holds in every dimension. This isolates
+the remaining gap to a single explicit, machine-checked hypothesis. -/
+theorem trace_pow_eq_sum_pow_eigenvalues_of_triangularizable [IsAlgClosed K] {A : Matrix N N K}
+    (k : ℕ)
+    (h : ∃ (U : (Matrix N N K)ˣ) (T : Matrix N N K),
+      A = U.val * T * U⁻¹.val ∧ T.BlockTriangular id) :
+    (A ^ k).trace = ((eigenvalues A).map (· ^ k)).sum := by
+  obtain ⟨U, T, hA, hT⟩ := h
+  exact trace_pow_eq_sum_pow_eigenvalues_of_units_conj_blockTriangular U hA hT k
+
 end Triangular
 
 end SpectralTraceDetEigenvaluesOQ01OQ01
@@ -280,3 +349,6 @@ end SpectralTraceDetEigenvaluesOQ01OQ01
 #print axioms SpectralTraceDetEigenvaluesOQ01OQ01.eigenvalues_pow_diagonal
 #print axioms SpectralTraceDetEigenvaluesOQ01OQ01.eigenvalues_pow_blockTriangular
 #print axioms SpectralTraceDetEigenvaluesOQ01OQ01.trace_pow_eq_sum_pow_eigenvalues_blockTriangular
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01.units_conj_pow
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01.eigenvalues_pow_of_units_conj_blockTriangular
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01.trace_pow_eq_sum_pow_eigenvalues_of_triangularizable

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "spectral-trace-det-eigenvalues-oq-01-oq-01",
   "title": "Power Sums of Eigenvalues: det(Aᵏ) and tr(A²) Spectrally",
   "slug": "spectral-trace-det-eigenvalues-oq-01-oq-01",
-  "description": "Follow-up to spectral-trace-det-eigenvalues-oq-01, which posed the open question of proving that the power sums of the eigenvalues equal trace(Aᵏ). This entry settles the determinant half of the spectral mapping theorem in full generality and the trace half in the first nontrivial dimension. For the eigenvalue multiset eigenvalues A := A.charpoly.roots over an algebraically closed field: det(Aᵏ) = Π(λᵢᵏ), the product of the k-th powers of the eigenvalues (det_pow_eq_prod_pow_eigenvalues) — proven for ALL n and k from multiplicativity of the determinant alone, with no triangularisation; tr(Aᵏ) = Σ μⱼ where the μⱼ are the eigenvalues of Aᵏ (trace_pow_eq_sum_eigenvalues_pow_self); and the genuine trace power sum tr(A²) = λ₁² + λ₂² for 2×2 matrices (trace_sq_eq_sum_sq_eigenvalues), via Newton's identity p₂ = e₁² − 2e₂ with e₁ = trace and e₂ = determinant. Concrete 2×2 complex examples give det(A²) = 4 and tr(A²) = 29 for !![1,2;3,4] without computing its irrational eigenvalues. Fully verified, 0 axioms, 0 sorries, no decide/native_decide. The general trace power sum tr(Aᵏ) = Σλᵢᵏ (all n) is identified as requiring the full multiset spectral mapping, absent from the current Mathlib snapshot.",
+  "description": "Follow-up to spectral-trace-det-eigenvalues-oq-01, which posed the open question of proving that the power sums of the eigenvalues equal trace(Aᵏ). This entry settles the determinant half of the spectral mapping theorem in full generality and the trace half in the first nontrivial dimension. For the eigenvalue multiset eigenvalues A := A.charpoly.roots over an algebraically closed field: det(Aᵏ) = Π(λᵢᵏ), the product of the k-th powers of the eigenvalues (det_pow_eq_prod_pow_eigenvalues) — proven for ALL n and k from multiplicativity of the determinant alone, with no triangularisation; tr(Aᵏ) = Σ μⱼ where the μⱼ are the eigenvalues of Aᵏ (trace_pow_eq_sum_eigenvalues_pow_self); and the genuine trace power sum tr(A²) = λ₁² + λ₂² for 2×2 matrices (trace_sq_eq_sum_sq_eigenvalues), via Newton's identity p₂ = e₁² − 2e₂ with e₁ = trace and e₂ = determinant. Concrete 2×2 complex examples give det(A²) = 4 and tr(A²) = 29 for !![1,2;3,4] without computing its irrational eigenvalues. Fully verified, 0 axioms, 0 sorries, no decide/native_decide. The general trace power sum tr(Aᵏ) = Σλᵢᵏ is further established in every dimension for diagonal, upper-triangular, and — via similarity-invariance of the eigenvalue multiset and the power identity (U A U⁻¹)ᵏ = U Aᵏ U⁻¹ — every matrix SIMILAR to an upper-triangular one. The remaining gap to arbitrary matrices is isolated to one explicit, machine-checked hypothesis (trace_pow_eq_sum_pow_eigenvalues_of_triangularizable: the existence of a triangularisation A = U T U⁻¹), which over an algebraically closed field is exactly the Schur triangularisation theorem, absent at the matrix level from the current Mathlib snapshot.",
   "meta": {
     "author": "Classical (Newton's identities; spectral mapping theorem); formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_identities",
@@ -60,6 +60,11 @@
         "theorem": "Matrix.trace_fin_two",
         "description": "trace of a 2×2 matrix is M 0 0 + M 1 1. With det_fin_two and mul_apply it computes tr(A²) = (tr A)² − 2 det A, the matrix side of the first Newton identity.",
         "module": "Mathlib.LinearAlgebra.Matrix.Trace"
+      },
+      {
+        "theorem": "Matrix.charpoly_units_conj",
+        "description": "(↑U * N * ↑U⁻¹).charpoly = N.charpoly for a unit matrix U: the characteristic polynomial, and hence the eigenvalue multiset, is a similarity invariant. This is what lets the spectral mapping transfer from an upper-triangular matrix to every conjugate of it, reducing the general case to similar-to-triangular.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
       }
     ],
     "originalContributions": [
@@ -74,13 +79,18 @@
       "blockTriangular_pow_diag: the diagonal of Mᵏ is (M i i)ᵏ for upper-triangular M, proved by induction using blockTriangular_mul_diag (diagonal entry of a product of triangular matrices is the product of the diagonal entries)",
       "trace_pow_eq_sum_pow_eigenvalues_blockTriangular: tr(Mᵏ) = Σ λᵢᵏ for every upper-triangular matrix over an algebraically closed field, all k — the general (all-dimension) trace power sum specialised to triangular form",
       "eigenvalues_pow_diagonal / trace_pow_eq_sum_pow_eigenvalues_diagonal: the spectral mapping and trace power sum tr((diagonal d)ᵏ) = Σ (d i)ᵏ for diagonal matrices in EVERY dimension n and all k",
-      "trace_pow_of_eigenvalues_pow: the reduction lemma showing the full general trace power sum tr(Aᵏ) = Σ λᵢᵏ follows immediately from the multiset spectral mapping eigenvalues(Aᵏ) = (eigenvalues A).map(·^k), isolating the single remaining classical ingredient (Schur triangularisation)"
+      "trace_pow_of_eigenvalues_pow: the reduction lemma showing the full general trace power sum tr(Aᵏ) = Σ λᵢᵏ follows immediately from the multiset spectral mapping eigenvalues(Aᵏ) = (eigenvalues A).map(·^k), isolating the single remaining classical ingredient (Schur triangularisation)",
+      "units_conj_pow: conjugation by a unit commutes with matrix powers, (U A U⁻¹)ᵏ = U Aᵏ U⁻¹ over any field, proved by induction with the off-diagonal U⁻¹U factors telescoping — the algebraic engine of the similarity transfer",
+      "eigenvalues_units_conj: the eigenvalue multiset is a similarity invariant, eigenvalues(U A U⁻¹) = eigenvalues A, read directly from Mathlib's charpoly_units_conj",
+      "eigenvalues_pow_of_units_conj_blockTriangular: the multiset spectral mapping eigenvalues(Aᵏ) = (eigenvalues A).map(·^k) for ANY matrix similar to an upper-triangular one (A = U T U⁻¹), over any field and all k — transferring the triangular computational core to every conjugate by similarity-invariance plus units_conj_pow",
+      "trace_pow_eq_sum_pow_eigenvalues_of_units_conj_blockTriangular: tr(Aᵏ) = Σ λᵢᵏ for every matrix similar to an upper-triangular one, all k",
+      "trace_pow_eq_sum_pow_eigenvalues_of_triangularizable: the capstone reduction — over an algebraically closed field, the general trace power sum tr(Aᵏ) = Σ λᵢᵏ holds for every matrix admitting an explicit triangularisation A = U T U⁻¹ (T upper-triangular). This collapses the remaining gap from informal prose to a single machine-checked hypothesis that is exactly the conclusion of the Schur triangularisation theorem"
     ],
     "dateAdded": "2026-06-24",
-    "lineCount": 282,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlibs foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used. The spectral identities require an algebraically closed field. SCOPE: the determinant power identity det(Aᵏ)=Π(λᵢᵏ) is proven in full generality (all n, all k). The trace power sum tr(Aᵏ)=Σλᵢᵏ is now proven, in EVERY dimension and for all k, for two structured families — diagonal matrices and upper-triangular (BlockTriangular id) matrices — via the multiset spectral mapping eigenvalues(Mᵏ)=(eigenvalues M).map(·^k), established from charpoly_blockTriangular and blockTriangular_pow_diag (no algebraic closure even needed for the multiset identity itself). The remaining gap to arbitrary matrices is isolated to a single classical ingredient — Schur/triangularisation over an algebraically closed field — which the current Mathlib snapshot (v4.26.0) does not supply at the matrix level (only Module.End-level generalized-eigenspace decompositions and RCLike Schur triangulation). The reduction lemma trace_pow_of_eigenvalues_pow makes this dependency explicit. The fully general trace power sum for arbitrary matrices remains the standing open question.",
+    "lineCount": 354,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlibs foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used. The spectral identities require an algebraically closed field. SCOPE: the determinant power identity det(Aᵏ)=Π(λᵢᵏ) is proven in full generality (all n, all k). The trace power sum tr(Aᵏ)=Σλᵢᵏ is proven, in EVERY dimension and for all k, for diagonal matrices, upper-triangular (BlockTriangular id) matrices, and — via similarity-invariance — for every matrix SIMILAR to an upper-triangular one (A = U T U⁻¹). The transfer rests on units_conj_pow ((U A U⁻¹)ᵏ = U Aᵏ U⁻¹) and eigenvalues_units_conj (the eigenvalue multiset is a similarity invariant, from Mathlib charpoly_units_conj). The remaining gap to ARBITRARY matrices is now isolated to a single explicit, machine-checked hypothesis (trace_pow_eq_sum_pow_eigenvalues_of_triangularizable: the existence of a triangularisation A = U T U⁻¹) — which over an algebraically closed field is exactly the conclusion of the classical Schur triangularisation theorem, not supplied at the matrix level by the current Mathlib snapshot (v4.26.0; only Module.End-level generalized-eigenspace decompositions are present). Supplying that one hypothesis yields the fully general trace power sum; producing it unconditionally for every matrix remains the standing open question.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 23,
+    "theoremCount": 28,
     "definitionCount": 1
   },
   "overview": {
@@ -140,6 +150,22 @@
       "endLine": 155,
       "summary": "det_sq_example and trace_sq_example: for !![1,2;3,4] over ℂ the determinant of A² is 4 (product of the squared eigenvalues) and the trace of A² is 29 (sum of the squared eigenvalues), even though the eigenvalues (5 ± √33)/2 are irrational and never computed.",
       "mathContext": "$\\det(A^2)=4,\\ \\operatorname{tr}(A^2)=29$ for $\\lambda_{1,2}=\\tfrac{5\\pm\\sqrt{33}}{2}$."
+    },
+    {
+      "id": "spectral-mapping-structured",
+      "title": "The Multiset Spectral Mapping for Diagonal and Upper-Triangular Matrices",
+      "startLine": 153,
+      "endLine": 272,
+      "summary": "trace_pow_of_eigenvalues_pow reduces the general tr(Aᵏ)=Σλᵢᵏ to the multiset spectral mapping eigenvalues(Aᵏ)=(eigenvalues A).map(·^k). prod_X_sub_C_roots and eigenvalues_diagonal/eigenvalues_pow_diagonal discharge the diagonal case in every dimension; charmatrix_blockTriangular, charpoly_blockTriangular, blockTriangular_mul_diag, blockTriangular_pow, blockTriangular_pow_diag and eigenvalues_pow_blockTriangular discharge the upper-triangular case over any field, the genuinely spectral computational core.",
+      "mathContext": "$\\operatorname{eig}(M^k) = \\{(M_{ii})^k\\}$ for upper-triangular $M$, hence $\\operatorname{tr}(M^k)=\\sum_i (M_{ii})^k$."
+    },
+    {
+      "id": "similarity-reduction",
+      "title": "General Matrices via Similarity: the Schur Reduction Made Precise",
+      "startLine": 273,
+      "endLine": 341,
+      "summary": "units_conj_pow ((U A U⁻¹)ᵏ = U Aᵏ U⁻¹, by induction with the off-diagonal factors telescoping) and eigenvalues_units_conj (the eigenvalue multiset is a similarity invariant, from charpoly_units_conj) transfer the spectral mapping from the upper-triangular core to every conjugate: eigenvalues_pow_of_units_conj_blockTriangular and trace_pow_eq_sum_pow_eigenvalues_of_units_conj_blockTriangular give tr(Aᵏ)=Σλᵢᵏ for any A = U T U⁻¹ with T upper-triangular. The capstone trace_pow_eq_sum_pow_eigenvalues_of_triangularizable states the general identity under the single explicit hypothesis that A admits such a triangularisation — exactly the Schur conclusion absent from the Mathlib snapshot.",
+      "mathContext": "$A = UTU^{-1},\\ T$ upper-triangular $\\Rightarrow \\operatorname{tr}(A^k)=\\sum_i \\lambda_i^{\\,k}$."
     }
   ],
   "crossReferences": [
@@ -156,7 +182,7 @@
     "summary": "Fully verified (0 sorries, 0 axioms) formalization settling the determinant half of the eigenvalue power-sum question in full generality — det(Aᵏ) = Π(λᵢᵏ) for all n and k — and the trace half in the first nontrivial dimension — tr(A²) = λ₁² + λ₂² via Newton's identity p₂ = e₁² − 2e₂ — with concrete complex examples computing the squared-eigenvalue invariants 4 and 29 of an irrational spectrum.",
     "implications": "Advances the parent entry's open question by separating the easy (determinant, multiplicative) and hard (trace, spectral) halves of the spectral mapping theorem for powers, and by delivering the trace power sum where Newton's identity reduces it to the already-established trace and determinant. Pinpoints the remaining obstruction — the multiset spectral mapping (A^k).charpoly.roots = A.charpoly.roots.map(·^k) — as the precise Mathlib gap blocking the all-dimensions trace power sum.",
     "openQuestions": [
-      "Prove the general trace power sum tr(Aᵏ) = Σλᵢᵏ for all dimensions n, equivalently the multiset spectral mapping (A^k).charpoly.roots = A.charpoly.roots.map(·^k), by building Schur triangulation over an algebraically closed field or a Newton-identity bridge from charpoly coefficients to root power sums.",
+      "Discharge the single remaining hypothesis of trace_pow_eq_sum_pow_eigenvalues_of_triangularizable: prove that every matrix over an algebraically closed field admits a triangularisation A = U T U⁻¹ with T upper-triangular (the Schur triangularisation theorem) at the Mathlib matrix level — either by transporting the existing Module.End-level generalized-eigenspace decomposition to a basis-induced matrix conjugation, or via a Newton-identity bridge from charpoly coefficients to root power sums. Together with the similarity-transfer lemmas already proven here, this yields the fully general trace power sum tr(Aᵏ) = Σλᵢᵏ for all n.",
       "Extend the 2×2 Newton identity to a uniform tr(A³) = e₁³ − 3e₁e₂ + 3e₃ (and higher) in fixed small dimensions, expressing each trace power sum through the elementary symmetric functions of the spectrum from oq-01."
     ]
   },
@@ -169,9 +195,9 @@
       "Polynomial"
     ],
     "namespace": "SpectralTraceDetEigenvaluesOQ01OQ01",
-    "lineCount": 282,
+    "lineCount": 354,
     "axiomCount": 0,
-    "theoremCount": 23,
+    "theoremCount": 28,
     "definitionCount": 1,
     "path": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/spectral-trace-det-eigenvalues-oq-01-oq-01.json
+++ b/src/data/research/problems/spectral-trace-det-eigenvalues-oq-01-oq-01.json
@@ -25,13 +25,13 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-24T08:00:00.000Z",
-    "iteration": 2,
-    "focus": "Shipped verified entry: determinant power identity in full generality + 2×2 trace power sum (Newton). General trace power sum reduced to the multiset spectral mapping, blocked on missing Mathlib infra.",
+    "since": "2026-06-28T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "Shipped verified entry: determinant power identity in full generality + 2×2 trace power sum (Newton) + the multiset spectral mapping for diagonal, upper-triangular, AND every matrix similar to an upper-triangular one (similarity transfer). General trace power sum now blocked on exactly one explicit hypothesis: matrix-level Schur triangularisation.",
     "blockers": [
-      "General trace power sum tr(Aᵏ)=Σλᵢᵏ needs (A^k).charpoly.roots = A.charpoly.roots.map(·^k) — the full multiset spectral mapping. Mathlib v4.26.0 snapshot has no Schur triangulation over a general algebraically closed field and no Newton-identity bridge from charpoly coefficients to root power sums."
+      "General trace power sum tr(Aᵏ)=Σλᵢᵏ for ARBITRARY matrices needs A = U T U⁻¹ with T upper-triangular (Schur). All else is done: trace_pow_eq_sum_pow_eigenvalues_of_triangularizable proves the identity GIVEN that hypothesis. Mathlib v4.26.0 snapshot has no Schur triangulation at the matrix level over a general algebraically closed field (only Module.End genEigenspace decomposition)."
     ],
-    "nextAction": "Build Schur triangulation (matrix conjugate to upper-triangular with eigenvalues on the diagonal over IsAlgClosed) OR a multiset Newton-identities bridge, to lift the trace power sum to all n.",
+    "nextAction": "Discharge the lone triangularizability hypothesis: build matrix-level Schur triangularisation over IsAlgClosed K (∃ unit U, A = U T U⁻¹, T BlockTriangular id), e.g. by bridging Module.End.iSup_maxGenEigenspace_eq_top to a matrix basis. Then trace_pow_eq_sum_pow_eigenvalues_of_triangularizable closes the general case immediately.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -39,7 +39,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: general trace power sum tr(Aᵏ)=Σλᵢᵏ now VERIFIED in every dimension for diagonal AND upper-triangular matrices (PR #31184, 13 new 0-axiom theorems). Open problem reduced (trace_pow_of_eigenvalues_pow) to the single classical Mathlib gap: matrix-level Schur triangularisation over an alg-closed field.",
+    "progressSummary": "PROGRESS: general trace power sum tr(Aᵏ)=Σλᵢᵏ now VERIFIED in every dimension for diagonal, upper-triangular, AND every matrix SIMILAR to an upper-triangular one (PR #31184, 18 new 0-axiom theorems). Similarity transfer (units_conj_pow + eigenvalues_units_conj) reduces the open problem to a SINGLE explicit machine-checked hypothesis — trace_pow_eq_sum_pow_eigenvalues_of_triangularizable — namely matrix-level Schur triangularisation over an alg-closed field.",
     "builtItems": [
       "det_pow_eq_prod_pow_eigenvalues: det(Aᵏ) = Π(λᵢᵏ) over IsAlgClosed K, all n and k — from Matrix.det_pow + det_eq_prod_roots_charpoly + Multiset.prod_hom (SpectralTraceDetEigenvaluesOQ01OQ01.lean)",
       "prod_map_pow_eigenvalues: Π(λᵢᵏ) = (Πλᵢ)ᵏ via powMonoidHom and Multiset.prod_hom",
@@ -52,7 +52,11 @@
       "charpoly_blockTriangular + charmatrix_blockTriangular: charpoly of triangular = ∏(X−C diag)",
       "blockTriangular_pow_diag + blockTriangular_mul_diag + blockTriangular_pow: (Mᵏ)ᵢᵢ=(Mᵢᵢ)ᵏ for triangular M",
       "eigenvalues_pow_diagonal + trace_pow_eq_sum_pow_eigenvalues_diagonal: spectral mapping + power sum for diagonal matrices, all n,k",
-      "trace_pow_of_eigenvalues_pow + trace_pow_eq_sum_pow_eigenvalues_blockTriangular + prod_X_sub_C_roots: reduction lemma + triangular trace power sum + roots-of-product helper"
+      "trace_pow_of_eigenvalues_pow + trace_pow_eq_sum_pow_eigenvalues_blockTriangular + prod_X_sub_C_roots: reduction lemma + triangular trace power sum + roots-of-product helper",
+      "units_conj_pow: (U A U⁻¹)ᵏ = U Aᵏ U⁻¹ over any field, induction with the off-diagonal U⁻¹U factors telescoping (SpectralTraceDetEigenvaluesOQ01OQ01.lean)",
+      "eigenvalues_units_conj: eigenvalues(U A U⁻¹) = eigenvalues A from Mathlib Matrix.charpoly_units_conj (similarity invariance of the eigenvalue multiset)",
+      "eigenvalues_pow_of_units_conj_blockTriangular + trace_pow_eq_sum_pow_eigenvalues_of_units_conj_blockTriangular: spectral mapping + trace power sum for any A = U T U⁻¹ with T upper-triangular, all k",
+      "trace_pow_eq_sum_pow_eigenvalues_of_triangularizable: CAPSTONE — tr(Aᵏ)=Σλᵢᵏ over IsAlgClosed K under the single hypothesis ∃ U T, A = U T U⁻¹ ∧ T.BlockTriangular id (exactly the Schur conclusion); reduces the remaining gap from prose to one machine-checked hypothesis"
     ],
     "insights": [
       "The determinant half of the eigenvalue power sum is FREE: det(Aᵏ)=(det A)ᵏ by multiplicativity (Matrix.det_pow), so det(Aᵏ)=Π(λᵢᵏ) needs no triangularisation and holds for all n, k. The trace half is the genuinely spectral content.",
@@ -62,7 +66,9 @@
       "The general trace power sum tr(Aᵏ)=Σλᵢᵏ is EXACTLY the multiset spectral mapping eigenvalues(Aᵏ)=(eigenvalues A).map(·^k); trace_pow_of_eigenvalues_pow makes this a one-line reduction (rw into trace_eq_sum_roots_charpoly).",
       "The triangular case needs NO algebraic closure for the multiset identity itself: charpoly of an upper-triangular M is ∏(X−C(M i i)) (charmatrix preserves BlockTriangular id + det_of_upperTriangular), and (Mᵏ)ᵢᵢ=(Mᵢᵢ)ᵏ by induction (blockTriangular_mul_diag isolates the j=i term). Mapping diagonals under (·^k) gives the spectral mapping over any field.",
       "Diagonal case is fully elementary via charpoly_diagonal + diagonal_pow + roots_multiset_prod_X_sub_C; holds in every dimension.",
-      "The ONLY remaining gap to arbitrary matrices is matrix-level Schur triangularisation over an alg-closed field — confirmed absent in Mathlib v4.26.0 (only Module.End genEigenspace decomposition Module.End.iSup_maxGenEigenspace_eq_top and RCLike Matrix.schur_triangulation exist; no charpoly-similarity-invariance-to-triangular bridge, no multiset Newton identities — MvPolynomial.NewtonIdentities is σ-variable only)."
+      "The ONLY remaining gap to arbitrary matrices is matrix-level Schur triangularisation over an alg-closed field — confirmed absent in Mathlib v4.26.0 (only Module.End genEigenspace decomposition Module.End.iSup_maxGenEigenspace_eq_top exists; no charpoly-similarity-invariance-to-triangular bridge, no multiset Newton identities — MvPolynomial.NewtonIdentities is σ-variable only).",
+      "SIMILARITY TRANSFER closes the gap from the triangular core to the general case CONDITIONALLY: the eigenvalue multiset is a similarity invariant (Matrix.charpoly_units_conj ⟹ eigenvalues_units_conj) and conjugation commutes with powers ((U A U⁻¹)ᵏ = U Aᵏ U⁻¹, proven by induction as units_conj_pow). So eigenvalues((U T U⁻¹)ᵏ) = eigenvalues(U Tᵏ U⁻¹) = eigenvalues(Tᵏ) = (eigenvalues T).map(·^k) = (eigenvalues(U T U⁻¹)).map(·^k). The general statement now needs ONLY the existence of the triangularising U — stated as the explicit hypothesis of trace_pow_eq_sum_pow_eigenvalues_of_triangularizable.",
+      "Matrix.charpoly_units_conj ((↑U * N * ↑U⁻¹).charpoly = N.charpoly) is the key Mathlib lever for similarity-invariance; it is proven via charpoly_mul_comm and lives in Mathlib.LinearAlgebra.Matrix.Charpoly.Basic."
     ],
     "mathlibGaps": [
       "No matrix Schur triangulation over a general algebraically closed field: no lemma giving ∃ invertible P, P⁻¹AP is BlockTriangular id with the charpoly roots on the diagonal (only GramSchmidt block-triangularisation for RCLike inner-product spaces, and Module.End-level genEigenspace decomposition that is awkward to bridge to the matrix charpoly multiset).",
@@ -105,7 +111,7 @@
     ]
   },
   "started": "2026-06-24T07:25:28.998Z",
-  "lastUpdate": "2026-06-24T08:00:00.000Z",
+  "lastUpdate": "2026-06-28T00:00:00.000Z",
   "significance": 6,
   "tractability": 7,
   "leanFiles": [
@@ -123,11 +129,11 @@
     {
       "path": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean",
       "filename": "SpectralTraceDetEigenvaluesOQ01OQ01.lean",
-      "lineCount": 156,
-      "theoremCount": 10,
+      "lineCount": 354,
+      "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean"
     },


### PR DESCRIPTION
## Summary

Follow-up to PR #31184 (merged) on `spectral-trace-det-eigenvalues-oq-01-oq-01`. The previous entry proved the trace power sum `tr(Aᵏ) = Σ λᵢᵏ` in every dimension for **diagonal** and **upper-triangular** matrices, leaving the general case as informal prose ("needs Schur triangularisation").

This PR collapses that gap to a **single explicit, machine-checked hypothesis** by proving that the spectral mapping is a **similarity invariant** and transfers from the upper-triangular core to every conjugate.

## New 0-axiom lemmas

- `units_conj_pow`: `(U A U⁻¹)ᵏ = U Aᵏ U⁻¹` over any field (induction; the off-diagonal `U⁻¹U` factors telescope).
- `eigenvalues_units_conj`: the eigenvalue multiset is similarity-invariant, from Mathlib's `Matrix.charpoly_units_conj`.
- `eigenvalues_pow_of_units_conj_blockTriangular`: the multiset spectral mapping `eigenvalues(Aᵏ) = (eigenvalues A).map(·^k)` for any `A = U T U⁻¹` with `T` upper-triangular.
- `trace_pow_eq_sum_pow_eigenvalues_of_units_conj_blockTriangular`: `tr(Aᵏ) = Σ λᵢᵏ` for any such `A`.
- `trace_pow_eq_sum_pow_eigenvalues_of_triangularizable` (**capstone**): over an algebraically closed field, the general identity holds under the lone hypothesis `∃ U T, A = U T U⁻¹ ∧ T.BlockTriangular id` — which is exactly the conclusion of the classical **Schur triangularisation theorem**.

## Status

The remaining gap to *arbitrary* matrices is now isolated to matrix-level Schur triangularisation, absent from the Mathlib v4.26.0 snapshot (only `Module.End`-level generalized-eigenspace decomposition is present).

- File: 282 → 354 lines, 23 → 28 theorems
- **0 axioms** (only `propext`/`Classical.choice`/`Quot.sound`), **0 sorries**, no `decide`/`native_decide`
- Verified standalone via `./bin/lake env lean Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean`
- `meta.json` and research knowledge updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)