### PR TITLE
research(erdos-1110-oq-01): Yu-Chen coprime non-representables {2,3} = ∅ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1110Problem.lean
+++ b/proofs/Proofs/Erdos1110Problem.lean
@@ -618,6 +618,66 @@ There are infinitely many coprime non-representable numbers for most (p,q):
 def CoprimeNonRepresentable (p q : ℕ) : Set ℕ :=
   {n ∈ NonRepresentable p q | Nat.Coprime n (p * q)}
 
+/-- The empty set has natural density `0`: the counting numerator is always `0`,
+so the ratio is `0` for every `n ≥ 1`. (Helper for the `{2,3}` coprime
+density-zero instances below.) -/
+theorem hasDensity_empty : HasDensity (∅ : Set ℕ) 0 := by
+  intro ε hε
+  refine ⟨1, fun n _ => ?_⟩
+  simp only [Set.mem_empty_iff_false, Finset.filter_false, Finset.card_empty,
+    Nat.cast_zero, zero_div, sub_zero, abs_zero]
+  exact hε
+
+/-- **The `{2,3}` coprime non-representables are empty (unconditional, 0-axiom).**
+
+`CoprimeNonRepresentable` is the Yu-Chen object whose infinitude is asserted "for
+most `(p,q)`" — explicitly excluding `{2,3}`. This theorem makes that exclusion
+*sharp* for `{2,3}`: there are not merely finitely many coprime non-representables,
+there are **none**. Indeed `NonRepresentable 2 3 = {0}` and `0` is not coprime to
+`2·3 = 6` (`gcd 0 6 = 6 ≠ 1`), so the only non-representable is filtered out. This
+gives the first content to the previously-unused `CoprimeNonRepresentable`
+definition. -/
+theorem coprimeNonRepresentable_two_three_eq_empty :
+    CoprimeNonRepresentable 2 3 = ∅ := by
+  rw [CoprimeNonRepresentable, nonRepresentable_two_three]
+  ext n
+  constructor
+  · rintro ⟨hn, hcop⟩
+    rw [Set.mem_singleton_iff] at hn
+    subst hn
+    rw [Nat.coprime_zero_left] at hcop
+    norm_num at hcop
+  · intro h; exact absurd h (Set.notMem_empty n)
+
+/-- **The `{3,2}` coprime non-representables are empty (unconditional, 0-axiom).**
+Same statement for the reversed base pair (`NonRepresentable 3 2 = {0}`, and `0` is
+not coprime to `3·2 = 6`). -/
+theorem coprimeNonRepresentable_three_two_eq_empty :
+    CoprimeNonRepresentable 3 2 = ∅ := by
+  rw [CoprimeNonRepresentable, nonRepresentable_three_two]
+  ext n
+  constructor
+  · rintro ⟨hn, hcop⟩
+    rw [Set.mem_singleton_iff] at hn
+    subst hn
+    rw [Nat.coprime_zero_left] at hcop
+    norm_num at hcop
+  · intro h; exact absurd h (Set.notMem_empty n)
+
+/-- **Yu-Chen coprime density zero, `{2,3}` case (unconditional, 0-axiom).** Since the
+`{2,3}` coprime non-representable set is empty, it has natural density `0` — the
+degenerate extreme of the Yu-Chen coprime-density phenomenon, complementing the
+infinitude that holds for the non-`{2,3}` pairs. -/
+theorem coprimeNonRepresentable_two_three_density_zero :
+    HasDensity (CoprimeNonRepresentable 2 3) 0 := by
+  rw [coprimeNonRepresentable_two_three_eq_empty]; exact hasDensity_empty
+
+/-- **Yu-Chen coprime density zero, `{3,2}` case (unconditional, 0-axiom).** Reversed
+base pair; the coprime non-representable set is again empty. -/
+theorem coprimeNonRepresentable_three_two_density_zero :
+    HasDensity (CoprimeNonRepresentable 3 2) 0 := by
+  rw [coprimeNonRepresentable_three_two_eq_empty]; exact hasDensity_empty
+
 /-
 ## Part V: Minimum Summand Size
 -/

--- a/research/problems/erdos-1110-oq-01/state.md
+++ b/research/problems/erdos-1110-oq-01/state.md
@@ -1,9 +1,28 @@
 # Current State
 
-**Phase**: ACT — {2,3} case fully solved + density-zero proved; 1 deep axiom remains
+**Phase**: ACT — {2,3} case fully solved + density-zero + coprime-empty proved; 1 deep axiom remains
 **Since**: 2026-05-29T19:14:09.134Z
-**Iteration**: 3
-**Last Updated**: 2026-06-28 (researcher-1, S4 ACT)
+**Iteration**: 4
+**Last Updated**: 2026-06-28 (researcher-3, S5 ACT)
+
+## S5 ACT (researcher-3, 2026-06-28) — Yu-Chen coprime {2,3} = ∅, 0-axiom
+
+Gave the first content to the previously-unused `CoprimeNonRepresentable` definition
+by settling the {2,3} case of the Yu-Chen *coprime* non-representables, unconditionally
+(0-axiom):
+- `coprimeNonRepresentable_two_three_eq_empty : CoprimeNonRepresentable 2 3 = ∅`
+  and the `3 2` companion. Reason: `NonRepresentable 2 3 = {0}` and `0` is not coprime
+  to `2·3 = 6` (`Nat.coprime_zero_left`: `Coprime 0 6 ↔ 6 = 1`, false), so the filter
+  empties the singleton. This *sharpens* Yu-Chen's "{2,3}-excluded" infinitude
+  statement: for {2,3} there are not merely finitely many coprime non-representables —
+  there are zero.
+- `hasDensity_empty : HasDensity ∅ 0` ⟹ `coprimeNonRepresentable_two_three_density_zero`
+  / `_three_two_density_zero`.
+
+Host-verified (`lake env lean`, EXIT 0); `#print axioms` = propext/Choice/Quot only
+(independent of `erdos_lewin_infinite`). 28→33 thm, 696→788 lines, axiom count
+UNCHANGED at 1. The deep axiom `erdos_lewin_infinite` (Erdős–Lewin 1996 infinitude,
+not in Mathlib) remains — not session-sized.
 
 ## S4 ACT (researcher-1, 2026-06-28) — Yu-Chen density-zero for {2,3}, 0-axiom
 

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -54,6 +54,7 @@
       "Easy Erdős–Lewin direction proved unconditionally (0-axiom): nonRepresentable_three_two / nonRepresentable_two_three pin NonRepresentable to the singleton {0}, giving finite_nonRepresentable_of_two_three",
       "exists_positive_nonRepresentable_of_ne_two_three theorem (0-axiom): unconditional EXISTENCE shadow of the deep infinitude axiom — every coprime pair {p,q}≠{2,3} admits a positive non-representable number (universal witness 2 when q≥3, 3 when q=2), via two_nonRepresentable_of_three_le / three_nonRepresentable_of_q_two and the power-form bounds isPowerForm_eq_one_of_le_two / isPowerForm_le_two_or_eq",
       "Yu-Chen density-zero {2,3} instance proved unconditionally (0-axiom): hasDensity_singleton_zero ⟹ nonRepresentable_two_three_density_zero / nonRepresentable_three_two_density_zero",
+      "Yu-Chen COPRIME non-representables, {2,3} case proved unconditionally (0-axiom): coprimeNonRepresentable_two_three_eq_empty / _three_two_eq_empty — the coprime non-representable set is EMPTY for {2,3} (the only non-representable is 0, which is not coprime to 2·3=6), sharpening Yu-Chen's '{2,3}-excluded' infinitude to 'zero coprime non-representables'; hasDensity_empty gives the corresponding density-zero corollaries and supplies the first content to the previously-unused CoprimeNonRepresentable definition",
       "erdos_lewin_infinite axiom: the genuinely deep forward direction (infinitely many non-representables for {p,q}≠{2,3}); only the infinitude — not finiteness or existence — is now assumed",
       "Yu-Chen coprime infinite theorem",
       "Minimum summand bounds (Yu-Chen, Yang-Zhao)",
@@ -61,9 +62,9 @@
       "Connections to Problems #123, #845, #246"
     ],
     "axiomCount": 1,
-    "lineCount": 696,
+    "lineCount": 788,
     "assumptions": "1 axiom: erdos_lewin_infinite (Erdős-Lewin 1996, deep forward direction: {p,q}≠{2,3} ⟹ infinitely many non-representable numbers). The backward direction ({2,3} ⟹ finite, in fact NonRepresentable = {0}) is proved unconditionally (finite_nonRepresentable_of_two_three), and the EXISTENCE of a positive non-representable for every other coprime pair is also proved unconditionally (exists_positive_nonRepresentable_of_ne_two_three) — only the infinitude itself remains axiomatized.",
-    "theoremCount": 28,
+    "theoremCount": 33,
     "definitionCount": 7
   },
   "overview": {
@@ -259,9 +260,9 @@
       "Finset"
     ],
     "namespace": "Erdos1110",
-    "lineCount": 696,
+    "lineCount": 788,
     "axiomCount": 1,
-    "theoremCount": 28,
+    "theoremCount": 33,
     "definitionCount": 7,
     "path": "Proofs/Erdos1110Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1110-oq-01.json
+++ b/src/data/research/problems/erdos-1110-oq-01.json
@@ -33,7 +33,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "The {2,3} case is fully solved 0-axiom (representability + NonRepresentable={0}). Iter 2 proved the EASY Erdos-Lewin direction unconditionally, weakening the axiom to the deep hard direction only (erdos_lewin_infinite). Iter 3 (S4): proved the {2,3} Yu-Chen density-zero instance 0-axiom (HasDensity (NonRepresentable 2 3) 0). Iter 4 (researcher-10): proved the unconditional EXISTENCE shadow of the deep infinitude axiom 0-axiom — every coprime pair {p,q}!={2,3} has at least one POSITIVE non-representable number (exists_positive_nonRepresentable_of_ne_two_three), with universal witnesses 2 (q>=3) and 3 (q=2). Residual assumption unchanged: the single deep axiom erdos_lewin_infinite (existence=>infinitude jump, not in Mathlib).",
+    "progressSummary": "The {2,3} case is fully solved 0-axiom (representability + NonRepresentable={0}). Iter 2 proved the EASY Erdos-Lewin direction unconditionally, weakening the axiom to the deep hard direction only (erdos_lewin_infinite). Iter 3 (S4): proved the {2,3} Yu-Chen density-zero instance 0-axiom (HasDensity (NonRepresentable 2 3) 0). Iter 4 (researcher-10): proved the unconditional EXISTENCE shadow of the deep infinitude axiom 0-axiom — every coprime pair {p,q}!={2,3} has at least one POSITIVE non-representable number (exists_positive_nonRepresentable_of_ne_two_three), with universal witnesses 2 (q>=3) and 3 (q=2). Iter 4 (S5, researcher-3): settled the {2,3} Yu-Chen COPRIME case 0-axiom — CoprimeNonRepresentable {2,3} = empty (the only non-representable 0 is not coprime to 6), with density-zero corollaries via hasDensity_empty; first content for the previously-unused CoprimeNonRepresentable def. Residual assumption unchanged: the single deep axiom erdos_lewin_infinite (existence=>infinitude jump, not in Mathlib).",
     "builtItems": [
       "exists_positive_nonRepresentable_of_ne_two_three (iter 4, 0-axiom): for coprime p>q>=2 with {p,q}!={2,3}, EXISTS n>=1 with n in NonRepresentable p q. Case split: q=2 (then p>=4) uses witness 3; q>=3 uses witness 2. Unconditional existence half of erdos_lewin_infinite.",
       "two_nonRepresentable_of_three_le (iter 4, 0-axiom): if p,q>=3 then 2 is non-representable. Every summand <=2 is a power form hence =1 (isPowerForm_eq_one_of_le_two); a distinct-element Finset of 1s sums to <=1.",
@@ -46,7 +46,9 @@
       "finite_nonRepresentable_of_two_three (0-axiom): the easy direction {2,3} => Finite, now proved not assumed (returns the singleton {0}).",
       "erdos_lewin_theorem (now a THEOREM): full iff, backward from finite_nonRepresentable_of_two_three, forward from the weaker axiom erdos_lewin_infinite.",
       "hasDensity_singleton_zero (0-axiom): a single point has natural density 0 (count=1, ratio 1/n -> 0).",
-      "nonRepresentable_two_three_density_zero / _three_two_density_zero (0-axiom): the {2,3} non-representable set {0} has density zero — the sharpest Yu-Chen density-zero instance, giving content to the previously def-only HasDensity scaffolding."
+      "nonRepresentable_two_three_density_zero / _three_two_density_zero (0-axiom): the {2,3} non-representable set {0} has density zero — the sharpest Yu-Chen density-zero instance, giving content to the previously def-only HasDensity scaffolding.",
+      "coprimeNonRepresentable_two_three_eq_empty / _three_two_eq_empty (iter 4/S5, 0-axiom): the {2,3} Yu-Chen COPRIME non-representable set is EMPTY — NonRepresentable 2 3 = {0} and 0 is not coprime to 2*3=6 (Nat.coprime_zero_left: Coprime 0 6 iff 6=1, false). Sharpens Yu-Chen's '{2,3}-excluded' coprime infinitude: zero coprime non-representables, not merely finitely many. First content for the previously-unused CoprimeNonRepresentable def.",
+      "hasDensity_empty (0-axiom): the empty set has natural density 0 (numerator always 0) — feeds coprimeNonRepresentable_two_three_density_zero / _three_two_density_zero."
     ],
     "insights": [
       "The deep infinitude axiom has an elementary EXISTENCE shadow: every non-{2,3} coprime pair has a SMALL universal non-representable witness — 2 when q>=3, 3 when q=2. The witness is forced purely by which power forms lie below it: below 2 only 1 exists (both bases>=3), below 3 only {1,2} (q=2, p>=4), and neither lets an antichain hit the target. The (3,2) pair is exactly the exception because there 3=3^1 IS a power form.",
@@ -65,7 +67,8 @@
     ],
     "nextSteps": [
       "Attempt the deep direction erdos_lewin_infinite (or a concrete special case, e.g. a single (p,q)) to reduce/eliminate the last axiom — genuinely hard (Erdos-Lewin 1996, not in Mathlib).",
-      "Optionally prove a HasDensity statement for CoprimeNonRepresentable {2,3}, or remove the still-unused minSummandBound / CoprimeNonRepresentable scaffolding."
+      "CoprimeNonRepresentable {2,3} is now settled (= empty, S5). Remaining scaffolding gap: minSummandBound is still unused (no theorem exercises it) — give it content (a bound for the {2,3} case) or remove it.",
+      "Yu-Chen coprime INFINITUDE for non-{2,3} pairs (q>3, or q=3 p!=5, or q=2 p not in {3,5,9}) — a deeper companion to erdos_lewin_infinite, also not in Mathlib."
     ]
   },
   "tags": [
@@ -93,8 +96,8 @@
     {
       "path": "Proofs/Erdos1110Problem.lean",
       "filename": "Erdos1110Problem.lean",
-      "lineCount": 523,
-      "theoremCount": 20,
+      "lineCount": 788,
+      "theoremCount": 33,
       "axiomCount": 1,
       "defCount": 7,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Advances **Erdős #1110** (`erdos-1110-oq-01`, density of non-representables for additive bases). The file's one remaining axiom (`erdos_lewin_infinite`, the deep Erdős–Lewin 1996 infinitude direction) is not session-sized, so this PR makes the bounded, honest contribution flagged in the problem's `nextSteps`: **giving the first content to the previously-unused `CoprimeNonRepresentable` definition.**

`CoprimeNonRepresentable p q = {n ∈ NonRepresentable p q | Nat.Coprime n (p·q)}` is the Yu-Chen object whose infinitude is asserted "for most `(p,q)`" — explicitly *excluding* `{2,3}`. This PR settles the excluded case sharply.

| Theorem | Statement |
|---------|-----------|
| `coprimeNonRepresentable_two_three_eq_empty` | `CoprimeNonRepresentable 2 3 = ∅` |
| `coprimeNonRepresentable_three_two_eq_empty` | `CoprimeNonRepresentable 3 2 = ∅` |
| `hasDensity_empty` | `HasDensity ∅ 0` |
| `coprimeNonRepresentable_two_three_density_zero` | `HasDensity (CoprimeNonRepresentable 2 3) 0` |
| `coprimeNonRepresentable_three_two_density_zero` | `HasDensity (CoprimeNonRepresentable 3 2) 0` |

**Why it's empty:** `NonRepresentable 2 3 = {0}` (already proved), and `0` is *not* coprime to `2·3 = 6` — `Nat.coprime_zero_left` gives `Coprime 0 6 ↔ 6 = 1`, which is false. So the coprimality filter empties the singleton. This **sharpens** Yu-Chen's "{2,3}-excluded" infinitude statement: for `{2,3}` there are not merely finitely many coprime non-representables — there are **zero**.

## Verification

- `28 → 33` theorems, `696 → 788` lines. **Axiom count UNCHANGED at 1** — the deep `erdos_lewin_infinite` remains; the new results are entirely independent of it.
- `#print axioms` on the new theorems: `[propext, Classical.choice, Quot.sound]` only — genuinely verified/0-axiom.
- Host-verified with single-file `lake env lean Proofs/Erdos1110Problem.lean` (exit 0, clean).

## Remaining open

The deep axiom `erdos_lewin_infinite` (Erdős–Lewin 1996) and the Yu-Chen coprime *infinitude* for non-`{2,3}` pairs remain (neither in Mathlib 4.26). The still-unused `minSummandBound` scaffolding is now the only dead definition left (noted in `nextSteps`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)