### PR TITLE
research(puiseux-theorem-oq-03): hull-construction recursion step — global-support transfer lemma [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -681,4 +681,154 @@ theorem threeVertex_sum_slope_mul_width :
   rw [threeVertex_edgeSlopes, threeVertex_edgeWidths]
   norm_num [List.zipWith_cons_cons]
 
+/-! ### Hull construction: splicing a dominant edge onto the right sub-hull
+
+The results so far identify vertices and edges and prove the polygon convex *given*
+a chain of lower edges, but they never *build* the chain.  `exists_isLowerEdge_of_leftmost`
+produces the dominant (least-slope) first edge `p → q` from the left endpoint; the
+Newton–Puiseux recursion then continues on the support to the right of `q`.
+
+The mathematical subtlety the recursion hides is this: a lower edge of the *right
+restriction* `pts.filter (q.1 ≤ ·.1)` need not be a lower edge of the *full* `pts`,
+because its supporting line — pinned only by the right points — could dip below a
+point left of `q`.  The **transfer lemma** `isLowerEdge_of_right` shows this never
+happens *provided the edge's slope is at least the dominant slope*: convexity forces
+the right edge's line to sit above the dominant line on the left half, where the
+dominant line already lies below every point.  This is the exact reason the
+divide-and-conquer hull recursion is correct, and it is the principal combinatorial
+input that was missing from this file.
+
+`chain_transfer` then propagates the bound along an entire right sub-hull (each edge
+slope dominates the previous one by `edgeSlope_mono`, so all of them clear the
+dominant slope), and `isLowerEdge_chain_extend` packages the whole step: prepend the
+dominant edge to a right sub-hull chain and obtain a genuine lower-edge chain of the
+full support — one peel of the Newton–Puiseux recursion, verified. -/
+
+/-- **Global-support transfer across a dominant split.**  Let `(m₀, b₀)` be the line
+of a *dominant* edge: it passes through the cut point `q` and lies weakly below every
+support point of `pts`.  If `a → c` is a lower edge of the right restriction
+`pts.filter (q.1 ≤ ·.1)` whose slope is at least the dominant slope `m₀`, then
+`a → c` is a lower edge of the *full* `pts`.
+
+The only nontrivial check is that the `a → c` line stays below the points left of the
+cut.  There its slope `m ≥ m₀` makes it sit below the dominant line (the two lines
+cross at the cut, where `a → c` is already below `q`), and the dominant line is below
+everything — so `a → c` clears the left points too. -/
+theorem isLowerEdge_of_right {pts : List SupportPoint} {q a c : SupportPoint}
+    {m₀ b₀ : ℚ} (hq_mem : q ∈ pts) (hq_line : q.2 = m₀ * (q.1 : ℚ) + b₀)
+    (hsupp0 : ∀ r ∈ pts, m₀ * (r.1 : ℚ) + b₀ ≤ r.2)
+    (hac : IsLowerEdge (pts.filter (fun r => decide (q.1 ≤ r.1))) a c)
+    (hslope : m₀ ≤ edgeSlope a c) :
+    IsLowerEdge pts a c := by
+  obtain ⟨ha_filt, hc_filt, hac_lt, m, b, ha_line, hc_line, hsupp_filt⟩ := hac
+  have ha_pts : a ∈ pts := (List.mem_filter.mp ha_filt).1
+  have hc_pts : c ∈ pts := (List.mem_filter.mp hc_filt).1
+  have hm : m = edgeSlope a c := slope_eq_edgeSlope ha_line hc_line (ne_of_lt hac_lt)
+  have hmge : m₀ ≤ m := by rw [hm]; exact hslope
+  -- the cut point `q` lies in the right restriction, so the `a → c` line is below it
+  have hq_filt : q ∈ pts.filter (fun r => decide (q.1 ≤ r.1)) :=
+    List.mem_filter.mpr ⟨hq_mem, by simp⟩
+  have hqcmp : m * (q.1 : ℚ) + b ≤ m₀ * (q.1 : ℚ) + b₀ := by
+    rw [← hq_line]; exact hsupp_filt q hq_filt
+  refine ⟨ha_pts, hc_pts, hac_lt, m, b, ha_line, hc_line, fun r hr => ?_⟩
+  by_cases hr_cut : q.1 ≤ r.1
+  · exact hsupp_filt r (List.mem_filter.mpr ⟨hr, by simpa using hr_cut⟩)
+  · push_neg at hr_cut
+    have hr_lt : (r.1 : ℚ) < (q.1 : ℚ) := by exact_mod_cast hr_cut
+    have hsupp0r : m₀ * (r.1 : ℚ) + b₀ ≤ r.2 := hsupp0 r hr
+    nlinarith [mul_nonneg (sub_nonneg.mpr hmge) (sub_nonneg.mpr (le_of_lt hr_lt)),
+      hqcmp, hsupp0r]
+
+/-- **Propagating the dominant bound along a right sub-hull.**  Given a dominant line
+`(m₀, b₀)` through the cut `q` lying below all of `pts`, any chain of lower edges of
+the right restriction whose first edge clears the dominant slope is, edge for edge, a
+chain of lower edges of the full `pts`.  Each successive edge slope dominates the
+previous one (`edgeSlope_mono`), so the bound carries to the whole chain and
+`isLowerEdge_of_right` upgrades every edge. -/
+theorem chain_transfer {pts : List SupportPoint} {q : SupportPoint} {m₀ b₀ : ℚ}
+    (hq_mem : q ∈ pts) (hq_line : q.2 = m₀ * (q.1 : ℚ) + b₀)
+    (hsupp0 : ∀ r ∈ pts, m₀ * (r.1 : ℚ) + b₀ ≤ r.2) :
+    ∀ (a : SupportPoint) (rest : List SupportPoint),
+      List.IsChain (IsLowerEdge (pts.filter (fun r => decide (q.1 ≤ r.1)))) (a :: rest) →
+      (∀ c, rest.head? = some c → m₀ ≤ edgeSlope a c) →
+      List.IsChain (IsLowerEdge pts) (a :: rest)
+  | _, [], _, _ => List.isChain_singleton _
+  | a, c :: rest', hchain, hbound => by
+      obtain ⟨hac, hchain'⟩ := List.isChain_cons_cons.mp hchain
+      have hac_slope : m₀ ≤ edgeSlope a c := hbound c rfl
+      have hi : IsLowerEdge pts a c :=
+        isLowerEdge_of_right hq_mem hq_line hsupp0 hac hac_slope
+      refine List.isChain_cons_cons.mpr ⟨hi, ?_⟩
+      refine chain_transfer hq_mem hq_line hsupp0 c rest' hchain' ?_
+      intro d hd
+      cases rest' with
+      | nil => simp at hd
+      | cons e rest'' =>
+        simp only [List.head?_cons, Option.some.injEq] at hd
+        subst hd
+        obtain ⟨hce, _⟩ := List.isChain_cons_cons.mp hchain'
+        exact le_trans hac_slope (edgeSlope_mono hac hce)
+
+/-- **One peel of the Newton–Puiseux recursion, verified.**  Prepend the dominant
+edge `p → q` (least-slope edge leaving the left endpoint, whose line `(m₀, b₀)`
+supports all of `pts`) to a chain of lower edges of the right restriction
+`pts.filter (q.1 ≤ ·.1)`, and obtain a genuine chain of lower edges of the full
+`pts`.  This is the inductive step of hull construction: the leftmost dominant edge
+followed by the recursively-built right sub-hull is the complete Newton polygon. -/
+theorem isLowerEdge_chain_extend {pts : List SupportPoint} {p q : SupportPoint}
+    {m₀ b₀ : ℚ} {rest : List SupportPoint}
+    (hp_mem : p ∈ pts) (hq_mem : q ∈ pts) (hpq_lt : p.1 < q.1)
+    (hp_line : p.2 = m₀ * (p.1 : ℚ) + b₀) (hq_line : q.2 = m₀ * (q.1 : ℚ) + b₀)
+    (hsupp0 : ∀ r ∈ pts, m₀ * (r.1 : ℚ) + b₀ ≤ r.2)
+    (hchain : List.IsChain (IsLowerEdge (pts.filter (fun r => decide (q.1 ≤ r.1))))
+      (q :: rest)) :
+    List.IsChain (IsLowerEdge pts) (p :: q :: rest) := by
+  refine List.isChain_cons_cons.mpr
+    ⟨⟨hp_mem, hq_mem, hpq_lt, m₀, b₀, hp_line, hq_line, hsupp0⟩, ?_⟩
+  refine chain_transfer hq_mem hq_line hsupp0 q rest hchain ?_
+  intro c hc
+  cases rest with
+  | nil => simp at hc
+  | cons d rest'' =>
+    simp only [List.head?_cons, Option.some.injEq] at hc
+    subst hc
+    obtain ⟨hqd, _⟩ := List.isChain_cons_cons.mp hchain
+    have hd_pts : d ∈ pts := (List.mem_filter.mp hqd.2.1).1
+    have hqd_lt : (q.1 : ℚ) < (d.1 : ℚ) := by exact_mod_cast hqd.2.2.1
+    exact edgeSlope_ge_of_supportingLine hq_line hd_pts hsupp0 hqd_lt
+
+/-! ### Worked example: building the two-edge polygon by splicing
+
+We rebuild `threeVertex_chain` — the chain `(0,2) → (1,0) → (3,1)` — *constructively*
+via `isLowerEdge_chain_extend`, supplying only the dominant edge `(0,2) → (1,0)` and
+the right sub-hull `(1,0) → (3,1)` over the restriction `{(1,0), (3,1)}`.  The transfer
+machinery promotes the right edge — whose hand-built supporting line ignores `(0,2)` —
+to a genuine lower edge of the full support. -/
+
+/-- The right restriction of `threeVertex` at the cut index `1` is `[(1,0), (3,1)]`. -/
+theorem threeVertex_filter :
+    threeVertex.filter (fun r => decide ((1 : ℕ) ≤ r.1)) = [((1, 0) : SupportPoint), (3, 1)] := by
+  decide
+
+/-- The right sub-hull is a single lower edge of the restriction. -/
+theorem threeVertex_rightHull :
+    List.IsChain (IsLowerEdge (threeVertex.filter (fun r => decide ((1 : ℕ) ≤ r.1))))
+      [((1, 0) : SupportPoint), (3, 1)] := by
+  rw [threeVertex_filter]
+  refine List.isChain_cons_cons.mpr ⟨?_, List.isChain_singleton _⟩
+  refine ⟨by simp, by simp, by norm_num, 1 / 2, -1 / 2, by norm_num, by norm_num, fun r hr => ?_⟩
+  fin_cases hr <;> norm_num
+
+/-- `threeVertex_chain` rebuilt by splicing the dominant edge onto the right sub-hull,
+exercising `isLowerEdge_chain_extend`.  The right edge `(1,0) → (3,1)` becomes a lower
+edge of the *full* `threeVertex` only because its slope `1/2` clears the dominant slope
+`-2` — exactly the transfer hypothesis. -/
+theorem threeVertex_chain_via_extend :
+    List.IsChain (IsLowerEdge threeVertex) threeVertex :=
+  isLowerEdge_chain_extend (p := (0, 2)) (q := (1, 0)) (m₀ := -2) (b₀ := 2)
+    (by simp [threeVertex]) (by simp [threeVertex]) (by norm_num)
+    (by norm_num) (by norm_num)
+    (fun r hr => by fin_cases hr <;> norm_num)
+    threeVertex_rightHull
+
 end PuiseuxTheoremOQ03

--- a/src/data/research/problems/puiseux-theorem-oq-03.json
+++ b/src/data/research/problems/puiseux-theorem-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S6 coupling: added the slope×width=drop layer (sum_slope_mul_width / neg_sum_slope_mul_width) linking the previously-disjoint valuation half (edgeSlopes_pairwise_le) and multiplicity half (sum_edgeWidths_eq_degree). Σ(valuation·multiplicity) = v(constant)−v(leading), the valuation of the root product. File 684 lines / 39 theorems / 8 defs, verified 0-sorry 0-axiom. Combinatorial Newton-polygon bookkeeping now complete; remaining: hull-construction recursion (chain assembly) and the analytic Newton polygon theorem (blocked on K((x))[Y] valuation API).",
+    "progressSummary": "PROGRESS (2026-06-28, researcher-5): hull-construction recursion STEP verified 0-axiom. isLowerEdge_of_right (global-support transfer) + chain_transfer + isLowerEdge_chain_extend supply the inductive step of Newton-polygon hull construction — the principal combinatorial input previously missing. Full exists_hull existence and the analytic Newton polygon theorem remain open.",
     "builtItems": [
       "IsLowerVertex: supporting-line characterization of a Newton-polygon lower-hull vertex (algorithm-independent Prop)",
       "isLowerVertex_of_minimal: the min-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -42,7 +42,11 @@
       "edgeSlope_mul_width in PuiseuxTheoremOQ03.lean (per-edge slope×width=drop)",
       "edgeDrops + sum_edgeDrops in PuiseuxTheoremOQ03.lean (vertical-drop list telescoping)",
       "zipWith_edgeSlopes_edgeWidths in PuiseuxTheoremOQ03.lean (list-level coupling)",
-      "sum_slope_mul_width + neg_sum_slope_mul_width in PuiseuxTheoremOQ03.lean (capstone identities)"
+      "sum_slope_mul_width + neg_sum_slope_mul_width in PuiseuxTheoremOQ03.lean (capstone identities)",
+      "isLowerEdge_of_right (PuiseuxTheoremOQ03.lean): lower edge of right restriction with slope ≥ dominant slope ⇒ lower edge of full support",
+      "chain_transfer (PuiseuxTheoremOQ03.lean): propagates dominant-slope bound along a whole right sub-hull via edgeSlope_mono; upgrades every edge to full-support edge",
+      "isLowerEdge_chain_extend (PuiseuxTheoremOQ03.lean): one verified peel of Newton-Puiseux recursion — prepend dominant edge to right sub-hull chain ⇒ IsChain (IsLowerEdge pts) over full support",
+      "threeVertex_chain_via_extend + threeVertex_rightHull + threeVertex_filter: worked example rebuilt constructively through the splice combinator"
     ],
     "insights": [
       "Supporting-line predicate beats a verified convex-hull construction: same downstream value, far less proof burden, algorithm-agnostic.",
@@ -53,7 +57,8 @@
       "Edge WIDTHS carry root multiplicities, complementing edge SLOPES (valuations): the polygon assigns (q.1-p.1) roots of valuation -edgeSlope p q to each edge. sum_edgeWidths + edgeSlopes_pairwise_le together are the full combinatorial bookkeeping of the Newton polygon theorem.",
       "slope × width = vertical drop: edgeSlope p q · (q.1−p.1) = q.2−p.2 because the slope denominator IS the width — the per-edge bridge coupling valuations (slopes) to multiplicities (widths)",
       "Capstone bookkeeping: Σ (slopeᵢ · widthᵢ) telescopes to the total vertical drop (last).2 − (first).2; equivalently Σ (root valuationᵢ · multiplicityᵢ) = v(constant) − v(leading), the valuation of the product of all roots",
-      "The polygon now reads off ALL combinatorial Newton-polygon data from one vertex chain: sorted valuations (edgeSlopes_pairwise_le), total multiplicity (sum_edgeWidths_eq_degree), AND sum-of-valuations-with-multiplicity (neg_sum_slope_mul_width)"
+      "The polygon now reads off ALL combinatorial Newton-polygon data from one vertex chain: sorted valuations (edgeSlopes_pairwise_le), total multiplicity (sum_edgeWidths_eq_degree), AND sum-of-valuations-with-multiplicity (neg_sum_slope_mul_width)",
+      "S2-A hull correctness (researcher-5, 2026-06-28): the obstruction to the documented \"peel-and-recurse\" hull construction is that a lower edge of the right restriction pts.filter(q.1 ≤ ·.1) can dip below a left point. RESOLVED: isLowerEdge_of_right proves it cannot, provided the edge slope clears the dominant slope m₀ — convexity forces the right edge line above the dominant line on the left half. This is the precise reason divide-and-conquer Newton-polygon construction is sound."
     ],
     "mathlibGaps": [
       "No Newton polygon API in Mathlib 4.26.0 (no Polynomial.newtonPolygon / lowerConvexHull as combinatorial vertex data).",
@@ -61,10 +66,10 @@
       "No arithmetic-complexity model (Bürgisser-Clausen-Shokrollahi style) to state the Poteaux-Weimann Õ(d·δ) bound."
     ],
     "nextSteps": [
-      "Iterate hull construction: from exists_isLowerEdge_of_leftmost, peel the first edge and recurse on the sub-support to the right of its right endpoint (building the ordered vertex/edge list).",
-      "S2-B: define a polynomial Newton-Puiseux reduction step and prove the Y-degree strictly decreases (needs Laurent-series polynomial modeling).",
-      "Newton polygon theorem: negatives of lower-edge slopes = root valuations (blocked on missing valuation API on K((x))[Y] in Mathlib 4.26.0).",
-      "Hull construction recursion: from exists_isLowerEdge_of_leftmost peel the first edge and recurse on the sub-support right of its right endpoint, producing a List.IsChain (IsLowerEdge pts) vertex list to feed edgeSlopes/edgeWidths."
+      "Assemble exists_hull: complete lower-hull vertex chain (head=leftmost, last=rightmost) via well-founded recursion on the right-restriction length, using isLowerEdge_chain_extend as the inductive step (now available). Remaining bookkeeping: monotone-index-along-chain + filter-narrowing from cut q.1 to next cut.",
+      "Newton polygon theorem proper (negated edge slopes = root valuations): blocked on missing valuation API on K((x))[Y] in Mathlib 4.26.0.",
+      "S2-B termination measure for one Newton-Puiseux reduction step (Y-degree strictly decreases).",
+      "Quasi-linear complexity bound (Poteaux-Weimann Õ(d·δ)): blocked on absence of arithmetic-complexity model in Mathlib."
     ],
     "markdown": "# Knowledge Base: puiseux-theorem-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
     "archivedSessions": [


### PR DESCRIPTION
## Summary

Advances `puiseux-theorem-oq-03` (combinatorial Newton polygon for the Newton–Puiseux algorithm) by supplying the **principal combinatorial input the file was missing**: a machine-checked proof that the divide-and-conquer Newton-polygon hull recursion is *correct*.

Prior sessions built the vertex/edge API, convexity (`edgeSlope_mono`), endpoint vertices, the existence of the first dominant edge (`exists_isLowerEdge_of_leftmost`), global slope sorting, degree-counting and slope×width bookkeeping — but **never built the edge chain**. The documented next step was "iterate hull construction: peel the first edge and recurse on the sub-support to the right." The subtle obstruction to that recursion is now resolved.

## What's new

- **`isLowerEdge_of_right`** (the transfer lemma): a lower edge of the right restriction `pts.filter (q.1 ≤ ·.1)` whose slope clears the dominant slope `m₀` is a lower edge of the **full** `pts`. The right edge's supporting line — pinned only by the right points — provably never dips below a point left of the cut, because slope `m ≥ m₀` forces it to sit above the dominant line on the left half, where the dominant line is already below everything. *This is the exact reason the recursion is sound.*
- **`chain_transfer`**: propagates the dominant-slope bound along an entire right sub-hull. Each successive edge slope dominates the previous one (`edgeSlope_mono`), so the bound carries to every edge and the transfer lemma upgrades all of them.
- **`isLowerEdge_chain_extend`**: one verified peel of the Newton–Puiseux recursion — prepend the dominant edge `p → q` to a right sub-hull chain over the restriction, and obtain a genuine `List.IsChain (IsLowerEdge pts)` over the full support.
- **`threeVertex_chain_via_extend`**: rebuilds the worked example `(0,2) → (1,0) → (3,1)` *constructively* through the splice combinator (the right edge `(1,0) → (3,1)`, slope `1/2`, is promoted to a full-support edge precisely because it clears the dominant slope `-2`).

## Verification

- `lake env lean Proofs/PuiseuxTheoremOQ03.lean` → exit 0
- 0 sorries, 0 `axiom` declarations
- `#print axioms` for all four new results → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`; kernel `decide` only, no `native_decide`)

## Honest scope

This is the inductive *step* of hull construction (the hard part — global-support correctness). Assembling the full `exists_hull` existence theorem via well-founded recursion, and the Newton polygon theorem proper (slopes = root valuations, blocked on missing `K((x))[Y]` valuation API in Mathlib 4.26), remain open as before.