### PR TITLE
research(hermite-floor-identity-oq-01): companion sawtooth identity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/HermiteFloorIdentityOQ01.lean
+++ b/proofs/Proofs/HermiteFloorIdentityOQ01.lean
@@ -1,0 +1,142 @@
+/-
+# Companion Sawtooth Identity for Hermite's Floor Identity
+
+For every real `x` and every integer `n ≥ 1`,
+$$\sum_{k=0}^{n-1} \left\{ x + \frac{k}{n} \right\} = \{n x\} + \frac{n-1}{2},$$
+where `{y} = y - ⌊y⌋` denotes the fractional part (`Int.fract`).
+
+This is the fractional-part **companion** to Hermite's classical floor identity
+(`HermiteFloorIdentity.lean`)
+$$\sum_{k=0}^{n-1} \left\lfloor x + \frac{k}{n} \right\rfloor = \lfloor n x \rfloor,$$
+and answers its open question oq-01.
+
+## Strategy
+
+The companion is a one-line consequence of the floor version, obtained by
+subtracting it from the *exact* (un-floored) sum.  Writing `{y} = y - ⌊y⌋`,
+
+```
+∑_{k<n} {x + k/n}
+  = ∑_{k<n} (x + k/n)            -- exact part
+      - ∑_{k<n} ⌊x + k/n⌋        -- floor part
+  = (n·x + (n-1)/2)              -- arithmetic series ∑ k/n = (n-1)/2
+      - ⌊n·x⌋                    -- Hermite's identity
+  = (n·x - ⌊n·x⌋) + (n-1)/2
+  = {n·x} + (n-1)/2.
+```
+
+The only non-elementary input is Hermite's floor identity itself; everything else
+is `Finset.sum_range_id` (the triangular-number formula) packaged through
+`Int.fract`.
+
+To keep this file self-contained and kernel-checkable on its own (single-file
+elaboration via `lake env lean`), the two lemmas of the parent entry
+(`int_hermite_sum`, `hermite_floor_identity`) are reproduced verbatim as
+`private` helpers below.
+
+No axioms beyond Lean/Mathlib's foundations; `0` sorries.
+-/
+import Mathlib
+
+open Finset
+
+namespace HermiteFloorIdentityOQ01
+
+/-! ## Parent helpers (reproduced for self-containment)
+
+These are the two theorems of `Proofs/HermiteFloorIdentity.lean`, copied here so
+that this file elaborates standalone.  See that entry for the full exposition. -/
+
+/-- **Integer Hermite sum.**  For `n ≥ 1` and any integer `a`,
+the Euclidean quotients `(a + k) / n` over `k = 0, …, n-1` sum to `a`. -/
+private theorem int_hermite_sum (n : ℕ) (hn : 0 < n) (a : ℤ) :
+    ∑ k ∈ range n, (a + (k : ℤ)) / (n : ℤ) = a := by
+  have hn' : (n : ℤ) ≠ 0 := by exact_mod_cast hn.ne'
+  have step : ∀ b : ℤ,
+      (∑ k ∈ range n, (b + 1 + (k : ℤ)) / (n : ℤ))
+        = (∑ k ∈ range n, (b + (k : ℤ)) / (n : ℤ)) + 1 := by
+    intro b
+    have key : (∑ k ∈ range n, (b + 1 + (k : ℤ)) / (n : ℤ))
+        = (∑ k ∈ range n, (b + (((k + 1 : ℕ) : ℤ))) / (n : ℤ)) := by
+      refine Finset.sum_congr rfl ?_
+      intro k _; congr 1; push_cast; ring
+    rw [key]
+    have h1 := Finset.sum_range_succ' (fun j : ℕ => (b + (j : ℤ)) / (n : ℤ)) n
+    have h2 := Finset.sum_range_succ (fun j : ℕ => (b + (j : ℤ)) / (n : ℤ)) n
+    simp only at h1 h2
+    have hg0 : (b + (((0 : ℕ) : ℤ))) / (n : ℤ) = b / (n : ℤ) := by norm_num
+    have hgn : (b + ((n : ℤ))) / (n : ℤ) = b / (n : ℤ) + 1 := by
+      rw [show b + (n : ℤ) = b + 1 * (n : ℤ) by ring, Int.add_mul_ediv_right b 1 hn']
+    linarith [h1, h2, hg0, hgn]
+  refine Int.induction_on a ?_ ?_ ?_
+  · refine Finset.sum_eq_zero ?_
+    intro x hx
+    rw [Finset.mem_range] at hx
+    rw [zero_add]
+    have hnabs : |(n : ℤ)| = (n : ℤ) := abs_of_pos (by exact_mod_cast hn)
+    refine Int.ediv_eq_zero_of_lt_abs (by positivity) ?_
+    rw [hnabs]; exact_mod_cast hx
+  · intro i ih
+    rw [step (i : ℤ), ih]
+  · intro i ih
+    have hs := step (-(i : ℤ) - 1)
+    have heq : (∑ k ∈ range n, (-(i : ℤ) - 1 + 1 + (k : ℤ)) / (n : ℤ))
+        = (∑ k ∈ range n, (-(i : ℤ) + (k : ℤ)) / (n : ℤ)) := by
+      refine Finset.sum_congr rfl ?_
+      intro k _; congr 1; ring
+    rw [heq, ih] at hs
+    linarith [hs]
+
+/-- **Hermite's identity.**  For every real `x` and every `n ≥ 1`,
+`∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋`. -/
+private theorem hermite_floor_identity (x : ℝ) (n : ℕ) (hn : 0 < n) :
+    ∑ k ∈ range n, ⌊x + (k : ℝ) / (n : ℝ)⌋ = ⌊(n : ℝ) * x⌋ := by
+  have hterm : ∀ k ∈ range n,
+      ⌊x + (k : ℝ) / (n : ℝ)⌋ = (⌊(n : ℝ) * x⌋ + (k : ℤ)) / (n : ℤ) := by
+    intro k _
+    have hx : x + (k : ℝ) / (n : ℝ) = ((n : ℝ) * x + (k : ℝ)) / (n : ℝ) := by
+      field_simp
+    rw [hx, Int.floor_div_natCast, Int.floor_add_natCast]
+  rw [Finset.sum_congr rfl hterm, int_hermite_sum n hn ⌊(n : ℝ) * x⌋]
+
+/-! ## The companion sawtooth identity -/
+
+/-- **Sum of `k/n` over `k = 0, …, n-1`.**  The arithmetic-series contribution to
+the exact (un-floored) sum: `∑_{k<n} k/n = (n-1)/2`. -/
+private theorem sum_div_eq (n : ℕ) (hn : 0 < n) :
+    ∑ k ∈ range n, (k : ℝ) / (n : ℝ) = (n - 1) / 2 := by
+  have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  -- Gauss's sum over ℝ, proved by induction to avoid `ℕ`-division under the cast.
+  have hsum : ∀ m : ℕ, ∑ k ∈ range m, (k : ℝ) = (m : ℝ) * ((m : ℝ) - 1) / 2 := by
+    intro m
+    induction m with
+    | zero => simp
+    | succ p ih => rw [Finset.sum_range_succ, ih]; push_cast; ring
+  rw [← Finset.sum_div, hsum n]
+  field_simp
+
+/-- **Companion sawtooth identity.**  For every real `x` and every `n ≥ 1`,
+`∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n-1)/2`, where `{·} = Int.fract` is the
+fractional part.  The fractional-part analogue of Hermite's floor identity. -/
+theorem hermite_fract_sum (x : ℝ) (n : ℕ) (hn : 0 < n) :
+    ∑ k ∈ range n, Int.fract (x + (k : ℝ) / (n : ℝ))
+      = Int.fract ((n : ℝ) * x) + (n - 1) / 2 := by
+  -- Expand each fractional part as `value − floor`.
+  have hterm : ∀ k ∈ range n,
+      Int.fract (x + (k : ℝ) / (n : ℝ))
+        = (x + (k : ℝ) / (n : ℝ)) - (⌊x + (k : ℝ) / (n : ℝ)⌋ : ℝ) := by
+    intro k _; rw [Int.fract]
+  rw [Finset.sum_congr rfl hterm, Finset.sum_sub_distrib]
+  -- The exact part: `∑ (x + k/n) = n·x + (n-1)/2`.
+  have hexact : ∑ k ∈ range n, (x + (k : ℝ) / (n : ℝ))
+      = (n : ℝ) * x + (n - 1) / 2 := by
+    rw [Finset.sum_add_distrib, Finset.sum_const, sum_div_eq n hn, card_range,
+      nsmul_eq_mul]
+  -- The floor part: `∑ ⌊x + k/n⌋ = ⌊n·x⌋` (Hermite), cast to ℝ.
+  have hfloor : ∑ k ∈ range n, (⌊x + (k : ℝ) / (n : ℝ)⌋ : ℝ)
+      = (⌊(n : ℝ) * x⌋ : ℝ) := by
+    rw [← Int.cast_sum, hermite_floor_identity x n hn]
+  rw [hexact, hfloor, Int.fract]
+  ring
+
+end HermiteFloorIdentityOQ01

--- a/research/problems/hermite-floor-identity-oq-01/knowledge.md
+++ b/research/problems/hermite-floor-identity-oq-01/knowledge.md
@@ -1,0 +1,49 @@
+# hermite-floor-identity-oq-01 — Companion Sawtooth Identity
+
+**Status**: COMPLETED (verified, 0-axiom) · **Phase**: COMPLETED
+
+## Problem
+
+Resolve the open question posed by the parent entry `hermite-floor-identity`:
+the fractional-part companion to Hermite's floor identity,
+$$\sum_{k=0}^{n-1} \left\{ x + \frac{k}{n} \right\} = \{n x\} + \frac{n-1}{2}, \qquad \{y\} = y - \lfloor y\rfloor,$$
+for every real `x` and every integer `n ≥ 1`.
+
+## Resolution
+
+Proved as `HermiteFloorIdentityOQ01.hermite_fract_sum` in
+`proofs/Proofs/HermiteFloorIdentityOQ01.lean` (142 lines, 0 axioms, 0 sorries;
+`#print axioms` → propext / Classical.choice / Quot.sound only).
+
+## Session 2026-06-28 (Session 1) — FRESH
+
+**Outcome**: completed.
+
+### What I Did
+- Selected from the available pool (most candidates were stale/already-shipped).
+  This one was genuinely new (no gallery dir, no Lean file) and the parent's
+  conclusion explicitly names the sawtooth identity as its open question.
+- Proved the identity by the `value = exact − floor` decomposition:
+  `∑{x+k/n} = ∑(x+k/n) − ∑⌊x+k/n⌋ = (nx + (n−1)/2) − ⌊nx⌋ = {nx} + (n−1)/2`.
+- Reproduced the parent's two lemmas (`int_hermite_sum`, `hermite_floor_identity`)
+  as `private` helpers so the file elaborates standalone.
+
+### Key Findings
+- The sawtooth identity is the mirror of Hermite's floor identity; the only new
+  arithmetic input is the Gauss sum `∑_{k<n} k/n = (n−1)/2`.
+- GOTCHA: casting `Finset.sum_range_id` into ℝ leaves the ℕ-quotient
+  `n(n−1)/2`, which blocks `ring`/`field_simp` (Nat division under cast).
+  Fix: prove `∑_{k<n} (k:ℝ) = n(n−1)/2` directly over ℝ by induction
+  (`Finset.sum_range_succ`; each step closed by `ring`).
+- GOTCHA: after `rw [Finset.sum_const, card_range, nsmul_eq_mul]` the exact-part
+  goal closes by `rfl` — trailing `push_cast; ring` then errors "no goals".
+- `Int.fract` unfolds via `rw [Int.fract]` to `y - ↑⌊y⌋`; combine the cast floor
+  sum with `Int.cast_sum` then apply Hermite.
+
+### Files Modified
+- `proofs/Proofs/HermiteFloorIdentityOQ01.lean` (new)
+- `src/data/proofs/hermite-floor-identity-oq-01/meta.json` (new)
+
+### Next Steps
+- Follow-up (not attempted): Bernoulli/Raabe multiplication formula
+  `∑ B_m(x + k/n) = n^{1−m} B_m(nx)`, whose m=1 case packages both identities.

--- a/src/data/proofs/hermite-floor-identity-oq-01/meta.json
+++ b/src/data/proofs/hermite-floor-identity-oq-01/meta.json
@@ -1,0 +1,117 @@
+{
+  "id": "hermite-floor-identity-oq-01",
+  "title": "Companion Sawtooth Identity for Hermite's Floor Identity",
+  "slug": "hermite-floor-identity-oq-01",
+  "description": "The fractional-part companion to Hermite's classical floor identity. Hermite's identity (entry hermite-floor-identity) states ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋ for every real x and integer n ≥ 1; its parent entry explicitly poses the companion sawtooth identity as an open question. This entry resolves it: for every real x and every n ≥ 1, ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n-1)/2, where {y} = y − ⌊y⌋ = Int.fract y is the fractional part. The proof is a one-line consequence of the floor version, obtained by subtracting it from the exact (un-floored) sum: ∑_{k<n} {x + k/n} = ∑_{k<n}(x + k/n) − ∑_{k<n} ⌊x + k/n⌋ = (n·x + (n−1)/2) − ⌊n·x⌋ = (n·x − ⌊n·x⌋) + (n−1)/2 = {n·x} + (n−1)/2. The exact sum contributes the triangular-number term ∑_{k<n} k/n = (n−1)/2 (Gauss's formula, proved over ℝ by induction to avoid ℕ-division under the cast), and the floor sum is exactly Hermite's identity. To keep the file standalone and kernel-checkable on its own, the two lemmas of the parent (int_hermite_sum, hermite_floor_identity) are reproduced verbatim as private helpers.",
+  "meta": {
+    "author": "Charles Hermite (companion identity); formalization 2026",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HermiteFloorIdentityOQ01.lean",
+    "tags": [
+      "number-theory",
+      "floor-function",
+      "fractional-part",
+      "real-analysis",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 142,
+    "assumptions": "0 axioms, 0 sorries; kernel-checked at Mathlib (single-file elaboration via `lake env lean Proofs/HermiteFloorIdentityOQ01.lean`, exit 0; `#print axioms HermiteFloorIdentityOQ01.hermite_fract_sum` lists only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, so the entry is axiom-free per the project's axiom-integrity policy). Mathlib supplies the floor/fractional-part and Finset infrastructure used (`Int.fract`, `Int.floor_div_natCast`, `Int.floor_add_natCast`, `Finset.sum_sub_distrib`, `Finset.sum_add_distrib`, `Finset.sum_range_succ`, `nsmul_eq_mul`) but contains neither Hermite's floor identity nor the companion sawtooth identity ∑_{k<n}{x + k/n} = {nx} + (n−1)/2 proved here.",
+    "dateAdded": "2026-06-28",
+    "originalContributions": [
+      "The companion sawtooth (fractional-part) identity ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n−1)/2 over ℝ for every n ≥ 1, resolving the open question posed by the parent Hermite floor-identity entry. Absent from Mathlib.",
+      "A clean derivation of the fractional-part identity from the floor identity by the value = exact − floor decomposition, isolating the triangular-number contribution ∑_{k<n} k/n = (n−1)/2 as the sole arithmetic input beyond Hermite's identity.",
+      "A real-valued Gauss-sum lemma ∑_{k<n} k/n = (n−1)/2 proved by induction over ℝ, sidestepping the natural-number division n(n−1)/2 that obstructs `ring`/`field_simp` after a naive cast of `Finset.sum_range_id`."
+    ],
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Hermite's floor identity (1880s) has a fractional-part twin: subtracting ⌊·⌋ from the identity function turns the floor identity into a statement about the sawtooth function {y} = y − ⌊y⌋. Because the n equally spaced fractional parts {x + k/n} sample one period of the sawtooth uniformly, their sum is governed by the average value 1/2 of the sawtooth, producing the constant (n−1)/2 (the sum of 1/2 over the n−1 nonzero offsets) plus the single anomalous term {n·x}. The identity is a staple companion to Hermite's in elementary number theory and underlies the standard 'sawtooth sum' identities used in the analytic theory of Dedekind sums. Mathlib records `Int.fract` and a rich floor/fractional-part API but neither Hermite's floor identity nor this companion.",
+    "problemStatement": "Prove that for every real number $x$ and every integer $n \\ge 1$, $$\\sum_{k=0}^{n-1} \\left\\{ x + \\frac{k}{n} \\right\\} = \\{n x\\} + \\frac{n-1}{2},$$ where $\\{y\\} = y - \\lfloor y \\rfloor$ denotes the fractional part.",
+    "text": "The headline theorem `hermite_fract_sum (x : ℝ) (n : ℕ) (hn : 0 < n) : ∑ k ∈ range n, Int.fract (x + k/n) = Int.fract (n·x) + (n−1)/2`, derived from the parent's `hermite_floor_identity` together with the auxiliary Gauss sum `sum_div_eq : ∑ k ∈ range n, k/n = (n−1)/2`.",
+    "proofStrategy": "Expand each summand with the definition {y} = y − ⌊y⌋ (`Int.fract`), then split the sum (`Finset.sum_sub_distrib`) into an exact part and a floor part. The exact part ∑_{k<n}(x + k/n) splits again (`Finset.sum_add_distrib`) into ∑_{k<n} x = n·x (`Finset.sum_const`, `card_range`, `nsmul_eq_mul`) and ∑_{k<n} k/n = (n−1)/2 (the Gauss-sum lemma sum_div_eq). The floor part ∑_{k<n} ⌊x + k/n⌋, cast to ℝ via `Int.cast_sum`, equals ⌊n·x⌋ by Hermite's identity. Substituting both and unfolding {n·x} = n·x − ⌊n·x⌋ leaves an identity closed by `ring`. The Gauss-sum lemma is proved over ℝ by induction on n (each step `Finset.sum_range_succ` then `ring`), deliberately avoiding the natural-number quotient n(n−1)/2 that would block algebraic normalization after casting `Finset.sum_range_id`.",
+    "keyInsights": [
+      "The sawtooth identity is not independent of Hermite's floor identity — it is its mirror image. Writing {y} = y − ⌊y⌋, summing termwise turns ∑{x + k/n} into (exact sum) − (floor sum), where the floor sum is precisely Hermite's identity and the exact sum is elementary.",
+      "The only genuinely new arithmetic is the average of the offsets: ∑_{k<n} k/n = (n−1)/2, the discrete average 1/2 of the sawtooth over its n−1 nonzero samples. This is why the additive constant is (n−1)/2.",
+      "Casting `Finset.sum_range_id` (which yields the ℕ-quotient n(n−1)/2) into ℝ obstructs `ring` because natural-number division is not a ring operation; proving the Gauss sum directly over ℝ by induction removes the obstruction entirely."
+    ],
+    "prerequisites": [
+      "The fractional-part function {·} = Int.fract and the identity {y} = y − ⌊y⌋",
+      "Hermite's floor identity ∑_{k<n} ⌊x + k/n⌋ = ⌊n·x⌋ (parent entry, reproduced here)",
+      "Finite sums over Finset.range and their additive splitting (sum_add_distrib, sum_sub_distrib)",
+      "Gauss's triangular-number sum"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "§0: Module Setup and Statement",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring stating the companion sawtooth identity ∑_{k<n}{x + k/n} = {nx} + (n−1)/2, the value = exact − floor strategy, the note that the parent's two lemmas are reproduced for self-containment, imports (full Mathlib), and the namespace.",
+      "mathContext": "Targets $\\sum_{k=0}^{n-1}\\{x + k/n\\} = \\{nx\\} + (n-1)/2$ for real $x$ and $n \\ge 1$."
+    },
+    {
+      "id": "parent-helpers",
+      "title": "Parent Helpers (Reproduced)",
+      "startLine": 45,
+      "endLine": 100,
+      "summary": "The two theorems of the parent entry, copied verbatim as private helpers so the file elaborates standalone: int_hermite_sum (∑_{k<n}(a+k)/n = a over ℤ, by shift-recurrence integer induction) and hermite_floor_identity (∑_{k<n}⌊x + k/n⌋ = ⌊n·x⌋ over ℝ, by the real→integer reduction).",
+      "mathContext": "Provides $\\sum_{k<n}\\lfloor x + k/n\\rfloor = \\lfloor nx\\rfloor$, the floor sum subtracted off below."
+    },
+    {
+      "id": "sawtooth-identity",
+      "title": "The Companion Sawtooth Identity",
+      "startLine": 102,
+      "endLine": 142,
+      "summary": "sum_div_eq: ∑_{k<n} k/n = (n−1)/2, a real-valued Gauss sum proved by induction to avoid ℕ-division. hermite_fract_sum: expands {y} = y − ⌊y⌋, splits the sum into exact and floor parts, evaluates the exact part as n·x + (n−1)/2 and the floor part as ⌊n·x⌋ (Hermite), then closes by ring after unfolding {n·x}.",
+      "mathContext": "$\\sum\\{x+k/n\\} = (nx + (n-1)/2) - \\lfloor nx\\rfloor = \\{nx\\} + (n-1)/2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The companion sawtooth identity ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n−1)/2 is proved for every real x and every n ≥ 1, with 0 axioms and 0 sorries, resolving the open question posed by the parent Hermite floor-identity entry. The derivation subtracts Hermite's floor identity from the exact sum, leaving only the triangular-number contribution (n−1)/2.",
+    "openQuestions": [
+      "State and prove the Bernoulli-polynomial refinement that interpolates between the floor and fractional-part identities, e.g. the Raabe-type multiplication formula ∑_{k=0}^{n-1} B_m(x + k/n) = n^{1−m} B_m(nx) for the Bernoulli polynomials B_m, of which the m = 1 case packages both Hermite's identity and this sawtooth companion.",
+      "Use the sawtooth sum to derive the reciprocity-free evaluation of a Dedekind-type sum ∑_{k} {x + k/n}, or relate (n−1)/2 to the average value of the sawtooth as the m = 1 instance of the Bernoulli multiplication theorem."
+    ],
+    "implications": "The fractional-part companion completes the floor/fractional-part pair for uniformly sampled sums and exposes the constant (n−1)/2 as the discrete average of the sawtooth. Together with the parent entry it gives the gallery both halves of the Hermite multiplication identity, the m = 1 case of the Bernoulli/Raabe multiplication formula."
+  },
+  "crossReferences": [
+    {
+      "targetId": "hermite-floor-identity",
+      "relationship": "extends",
+      "description": "Directly resolves the companion sawtooth/fractional-part open question stated in the parent's conclusion. Reuses the parent's hermite_floor_identity (reproduced here as a private helper) as the floor part of the value = exact − floor decomposition."
+    }
+  ],
+  "references": [
+    {
+      "author": "Hermite, C.",
+      "title": "Sur quelques conséquences arithmétiques des formules de la théorie des fonctions elliptiques",
+      "year": 1884,
+      "note": "Period in which Hermite recorded the floor-summation identity, of which the sawtooth identity is the fractional-part companion"
+    },
+    {
+      "author": "Graham, R. L.; Knuth, D. E.; Patashnik, O.",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "note": "Chapter 3 (Integer Functions) treats Hermite's identity, the sawtooth function {x}, and floor/fractional-part sum manipulations"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "HermiteFloorIdentityOQ01",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/HermiteFloorIdentityOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the open question explicitly posed in the conclusion of the parent
entry **hermite-floor-identity**: the fractional-part **companion** to Hermite's
classical floor identity.

For every real `x` and every integer `n ≥ 1`:
$$\sum_{k=0}^{n-1} \left\{ x + \frac{k}{n} \right\} = \{n x\} + \frac{n-1}{2},$$
where `{y} = y − ⌊y⌋ = Int.fract y` is the fractional part.

**Headline theorem**: `HermiteFloorIdentityOQ01.hermite_fract_sum`.

## Proof idea

A one-line consequence of Hermite's floor identity via `value = exact − floor`:
$$\sum_{k<n}\{x+k/n\} = \underbrace{\sum_{k<n}(x+k/n)}_{nx + (n-1)/2} - \underbrace{\sum_{k<n}\lfloor x+k/n\rfloor}_{\lfloor nx\rfloor} = (nx - \lfloor nx\rfloor) + \tfrac{n-1}{2} = \{nx\} + \tfrac{n-1}{2}.$$

The only new arithmetic input beyond Hermite's identity is the Gauss sum
`∑_{k<n} k/n = (n−1)/2`, proved over ℝ by induction to avoid the ℕ-division
`n(n−1)/2` that otherwise blocks `ring`. The parent's two lemmas
(`int_hermite_sum`, `hermite_floor_identity`) are reproduced as `private`
helpers so the file elaborates standalone.

## Verification

- `lake env lean Proofs/HermiteFloorIdentityOQ01.lean` → exit 0, no errors/warnings
- `#print axioms HermiteFloorIdentityOQ01.hermite_fract_sum` → `propext`,
  `Classical.choice`, `Quot.sound` only ⇒ axiom-free per project policy
- 0 sorries, 142 lines

## Files
- `proofs/Proofs/HermiteFloorIdentityOQ01.lean` (new)
- `src/data/proofs/hermite-floor-identity-oq-01/meta.json` (new)
- `research/problems/hermite-floor-identity-oq-01/knowledge.md` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)