### PR TITLE
Enrich lovasz-local-lemma-oq-04: add annotations

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-04/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-04/annotations.json
@@ -1,0 +1,182 @@
+[
+  {
+    "id": "ann-asymlll-predicate",
+    "proofId": "lovasz-local-lemma-oq-04",
+    "range": {
+      "startLine": 56,
+      "endLine": 61
+    },
+    "type": "definition",
+    "title": "The Asymmetric LLL Hypothesis as a Predicate",
+    "content": "```lean\ndef AsymLLL (n : ℕ) (prob x : Fin n → ℚ) (adj : Fin n → Finset (Fin n)) : Prop :=\n  (∀ i, 0 ≤ x i ∧ x i < 1) ∧\n  (∀ i, prob i ≤ x i * (adj i).prod (fun j => 1 - x j))\n```\n\nThe *asymmetric* (or general) Lovász Local Lemma replaces the single global probability bound $p$ and degree $d$ of the symmetric form with a per-event weight $x_i \\in [0,1)$. Packaging the hypothesis as a reusable `Prop` is the key design choice of this file: it makes the LLL conclusions *conditional theorems* (implications whose antecedent is `AsymLLL`) rather than axioms, keeping the file `0`-axiom. Every downstream result is a fully-proved implication from this predicate.",
+    "mathContext": "The asymmetric hypothesis is $\\Pr[A_i] \\leq x_i \\prod_{j \\in \\Gamma(i)} (1 - x_j)$ for weights $x_i \\in [0,1)$, where $\\Gamma(i)$ (here `adj i`) is the dependency neighbourhood. The symmetric form is the special case $x_i = 1/(d+1)$ with $|\\Gamma(i)| \\le d$. The conclusion is $\\Pr[\\bigcap_i \\overline{A_i}] \\ge \\prod_i (1 - x_i) > 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "asymmetric Lovász Local Lemma",
+      "dependency neighbourhood",
+      "probabilistic method",
+      "conditional theorem"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma"
+    ]
+  },
+  {
+    "id": "ann-asymlll-consequences",
+    "proofId": "lovasz-local-lemma-oq-04",
+    "range": {
+      "startLine": 65,
+      "endLine": 83
+    },
+    "type": "technique",
+    "title": "Avoidance Positivity and the Per-Event Bound as One-Line Corollaries",
+    "content": "The three consequences of `AsymLLL` reduce directly to the parent file's algebraic cores:\n\n```lean\ntheorem asymLLL_avoidance_pos (h : AsymLLL n prob x adj) :\n    0 < ∏ i, (1 - x i) := general_lll h.1\n\ntheorem asymLLL_prob_le (h : AsymLLL n prob x adj) :\n    ∀ i, prob i ≤ x i := lll_prob_bound h.1 h.2\n```\n\nThe avoidance product is positive because each factor $1 - x_i > 0$ (from $x_i < 1$); the per-event bound $\\Pr[A_i] \\le x_i$ follows because each neighbourhood product $\\prod_{j} (1 - x_j) \\le 1$. The punchline: **the asymmetric LLL needs no new algebra beyond the symmetric core** — only the per-event weights. `asymLLL_prob_lt_one` then chains $\\Pr[A_i] \\le x_i < 1$ by `linarith`.",
+    "mathContext": "$0 < \\prod_i (1 - x_i)$ since $x_i \\in [0,1)$ makes every factor lie in $(0,1]$. The bound $\\Pr[A_i] \\le x_i \\prod_{j}(1-x_j) \\le x_i$ uses $\\prod_j (1 - x_j) \\le 1$, a product of factors in $(0,1]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "general_lll",
+      "lll_prob_bound",
+      "Finset.prod_pos",
+      "linarith"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma"
+    ]
+  },
+  {
+    "id": "ann-occ-shareddep",
+    "proofId": "lovasz-local-lemma-oq-04",
+    "range": {
+      "startLine": 91,
+      "endLine": 106
+    },
+    "type": "definition",
+    "title": "The Variable Model: occ and the Shared-Variable Dependency Graph",
+    "content": "The variable model makes each event a function of a set `vars i` of underlying independent variables, with two events dependent iff their variable sets intersect:\n\n```lean\ndef occ (vars : Fin n → Finset V) (v : V) : Finset (Fin n) :=\n  Finset.univ.filter (fun j => v ∈ vars j)\n\ndef sharedDep (vars : Fin n → Finset V) (i : Fin n) : Finset (Fin n) :=\n  Finset.univ.filter (fun j => j ≠ i ∧ (vars i ∩ vars j).Nonempty)\n```\n\n`occ vars v` is the set of events reading variable $v$; `sharedDep vars i` is the dependency neighbourhood of event $i$. This is the dependency graph the constructive Moser–Tardos resampling algorithm operates on — when a bad event fires, exactly its `sharedDep`-neighbours need to be resampled.",
+    "mathContext": "Variable (or 'variable–clause') model: events $A_1, \\dots, A_n$ are determined by independent variables $\\{X_v\\}_{v \\in V}$, with $A_i$ measurable w.r.t. $\\{X_v : v \\in \\text{vars}(i)\\}$. Events sharing no variable are independent, so $\\Gamma(i) = \\{j \\ne i : \\text{vars}(i) \\cap \\text{vars}(j) \\ne \\emptyset\\}$ is a valid dependency neighbourhood.",
+    "significance": "key",
+    "relatedConcepts": [
+      "variable model",
+      "Moser–Tardos algorithm",
+      "dependency graph",
+      "Finset.filter"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma",
+      "Finset combinatorics"
+    ]
+  },
+  {
+    "id": "ann-shareddep-isvalid",
+    "proofId": "lovasz-local-lemma-oq-04",
+    "range": {
+      "startLine": 108,
+      "endLine": 127
+    },
+    "type": "insight",
+    "title": "Sharing a Variable Is Automatically a Valid Dependency Graph",
+    "content": "The shared-variable relation is irreflexive and symmetric *by construction*, independent of the events' probabilities:\n\n```lean\ntheorem sharedDep_isValid (vars : Fin n → Finset V) :\n    IsValidDepGraph n (sharedDep vars) :=\n  ⟨sharedDep_irrefl vars, sharedDep_symm vars⟩\n```\n\nIrreflexivity is immediate — the `j ≠ i` clause in the filter excludes $i$ itself. Symmetry is the one-line `Finset.inter_comm`: $\\text{vars}(i) \\cap \\text{vars}(j) \\ne \\emptyset \\iff \\text{vars}(j) \\cap \\text{vars}(i) \\ne \\emptyset$. This is the combinatorial heart of the variable LLL: a problem's structure alone (which variables each event reads) determines a legitimate dependency graph, with no probabilistic input required.",
+    "mathContext": "A dependency graph must be irreflexive ($i \\notin \\Gamma(i)$) and symmetric ($j \\in \\Gamma(i) \\iff i \\in \\Gamma(j)$). Both hold for `sharedDep` purely set-theoretically: symmetry from commutativity of intersection, irreflexivity from the explicit $j \\ne i$ guard.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsValidDepGraph",
+      "Finset.inter_comm",
+      "symmetric relation",
+      "irreflexive relation"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma"
+    ]
+  },
+  {
+    "id": "ann-degree-bound",
+    "proofId": "lovasz-local-lemma-oq-04",
+    "range": {
+      "startLine": 133,
+      "endLine": 173
+    },
+    "type": "technique",
+    "title": "The Degree Bound k·(D−1): From Local Incidence to Global Threshold",
+    "content": "The maximum degree of the shared-variable graph is bounded by purely local data — how many variables an event reads ($k$) and how many events read a variable ($D$):\n\n```lean\ntheorem sharedDep_maxDegree (vars : Fin n → Finset V) (k D : ℕ)\n    (hk : ∀ i, (vars i).card ≤ k) (hD : ∀ v, (occ vars v).card ≤ D) :\n    HasMaxDegree n (sharedDep vars) (k * (D - 1))\n```\n\nThe argument: every neighbour $j$ of $i$ shares some variable $v \\in \\text{vars}(i)$, so the neighbourhood is covered by $\\bigcup_{v \\in \\text{vars}(i)} (\\text{occ}(v) \\setminus \\{i\\})$. By `Finset.card_biUnion_le` and `card_erase_of_mem`, $\\deg(i) \\le \\sum_{v \\in \\text{vars}(i)} (|\\text{occ}(v)| - 1) \\le k(D-1)$. This degree is exactly the parameter the symmetric threshold $T(d)$ — and the Moser–Tardos resampling bound — consume.",
+    "mathContext": "$\\deg(i) = |\\Gamma(i)| \\le \\sum_{v \\in \\text{vars}(i)} (|\\text{occ}(v)| - 1) \\le |\\text{vars}(i)| \\cdot (D-1) \\le k(D-1)$. The $-1$ removes $i$ itself from each variable's occurrence set. Truncated natural subtraction makes $|\\text{occ}(v)| - 1 \\le D - 1$ hold even when a variable is used only once, with no positivity side-condition.",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasMaxDegree",
+      "Finset.card_biUnion_le",
+      "Finset.card_erase_of_mem",
+      "truncated subtraction",
+      "Moser–Tardos bound"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma",
+      "Finset combinatorics"
+    ]
+  },
+  {
+    "id": "ann-variable-lll-capstone",
+    "proofId": "lovasz-local-lemma-oq-04",
+    "range": {
+      "startLine": 179,
+      "endLine": 202
+    },
+    "type": "insight",
+    "title": "Capstones: Connecting the Variable Model to the Symmetric Threshold",
+    "content": "Two capstones tie the variable model back to the parent's threshold theory:\n\n```lean\ntheorem variable_lll (vars : Fin n → Finset V) (prob x : Fin n → ℚ)\n    (h : AsymLLL n prob x (sharedDep vars)) :\n    (0 < ∏ i, (1 - x i)) ∧ (∀ i, prob i ≤ x i)\n\ntheorem variable_lll_symmetric (vars : Fin n → Finset V) (k D : ℕ) ...\n```\n\n`variable_lll` simply instantiates Part I's consequences along `sharedDep`. `variable_lll_symmetric` is the real bridge: it feeds the degree bound $k(D-1)$ as the `hdeg` hypothesis of the parent's `symmetric_lll_complete`, so the uniform weight assignment $x_i = 1/(d+1)$ with $d = k(D-1)$ satisfies the LLL condition whenever every event probability is below $T(k(D-1))$. A sparse variable–event incidence directly yields a usable LLL.",
+    "mathContext": "With $d = k(D-1)$, the symmetric assignment $x_i = \\tfrac{1}{d+1}$ gives the threshold condition $\\Pr[A_i] \\le T(d) = \\tfrac{d^d}{(d+1)^{d+1}}$. This is the form used in nearly all applications: bound $k$ and $D$ from the problem's combinatorial structure, then read off whether the LLL applies.",
+    "significance": "key",
+    "relatedConcepts": [
+      "symmetric_lll_complete",
+      "lllThreshold",
+      "uniform weight assignment",
+      "constraint satisfaction"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma",
+      "lovasz-local-lemma-oq-02"
+    ]
+  },
+  {
+    "id": "ann-beats-union-bound",
+    "proofId": "lovasz-local-lemma-oq-04",
+    "range": {
+      "startLine": 208,
+      "endLine": 225
+    },
+    "type": "insight",
+    "title": "The Whole Point: Beating the Union Bound",
+    "content": "```lean\ntheorem asymLLL_beats_union_bound (n : ℕ) (hn : 2 < n) :\n    ∃ (prob x : Fin n → ℚ) (adj : Fin n → Finset (Fin n)),\n      AsymLLL n prob x adj ∧ 1 < ∑ i, prob i ∧ 0 < ∏ i, (1 - x i)\n```\n\nThe witness uses weights $x_i = 1/2$, probabilities $1/2$, and *no* dependencies. For $n > 2$ the total mass is $n/2 > 1$, so the union bound $\\Pr[\\bigcup A_i] \\le \\sum \\Pr[A_i]$ gives nothing (it only bounds the probability by something $> 1$). Yet the avoidance product $(1/2)^n > 0$ is strictly positive: the events can still be simultaneously avoided. This separation — a positive avoidance guarantee where the naive union bound is useless — is precisely the qualitative advantage that makes the LLL indispensable.",
+    "mathContext": "Union bound: $\\Pr[\\bigcap_i \\overline{A_i}] \\ge 1 - \\sum_i \\Pr[A_i]$, vacuous once $\\sum_i \\Pr[A_i] \\ge 1$. Here $\\sum_i \\Pr[A_i] = n/2 > 1$ for $n > 2$, but the LLL still certifies $\\Pr[\\bigcap_i \\overline{A_i}] \\ge \\prod_i (1 - x_i) = 2^{-n} > 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "union bound",
+      "probabilistic method",
+      "separation theorem",
+      "Finset.prod_pos"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma"
+    ]
+  },
+  {
+    "id": "ann-asymmetric-weights-needed",
+    "proofId": "lovasz-local-lemma-oq-04",
+    "range": {
+      "startLine": 227,
+      "endLine": 237
+    },
+    "type": "insight",
+    "title": "Why Asymmetric Weights Are Genuinely Needed",
+    "content": "```lean\ntheorem asymLLL_asymmetric_weights :\n    AsymLLL 2 ![1 / 8, 3 / 8] ![1 / 4, 1 / 2] ![{1}, {0}] ∧\n      (![1 / 4, 1 / 2] : Fin 2 → ℚ) 0 ≠ (![1 / 4, 1 / 2] : Fin 2 → ℚ) 1\n```\n\nA concrete two-event, mutually-dependent instance where the optimal weights *differ*: $x_0 = 1/4 \\ne 1/2 = x_1$. With $\\Pr[A_0] = 1/8$ and $\\Pr[A_1] = 3/8$, both asymmetric inequalities hold at equality — $1/8 = \\tfrac14(1 - \\tfrac12)$ and $3/8 = \\tfrac12(1 - \\tfrac14)$ — so no single symmetric weight could serve both events. This demonstrates that the asymmetric generalization is not a cosmetic convenience: events with unequal probabilities genuinely require unequal weights to be handled tightly. The proof discharges each case by `fin_cases` and `norm_num`.",
+    "mathContext": "Event 0 reads variable in $\\{1\\}$, event 1 reads $\\{0\\}$, so they are mutually dependent ($\\text{adj}(0) = \\{1\\}$, $\\text{adj}(1) = \\{0\\}$). Tightness: $\\Pr[A_0] = x_0(1 - x_1) = \\tfrac14 \\cdot \\tfrac12 = \\tfrac18$ and $\\Pr[A_1] = x_1(1 - x_0) = \\tfrac12 \\cdot \\tfrac34 = \\tfrac38$. A symmetric $x$ forcing both would need $x = 1/4$ and $x = 1/2$ simultaneously.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "asymmetric weights",
+      "tight inequality",
+      "fin_cases",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `lovasz-local-lemma-oq-04` (passes: 0, quality: 45).

## Gap addressed
The entry had a rich `meta.json` (17.8 KB, well under the 60 KB cap) but **no `annotations.json`** — zero inline annotation coverage. This pass adds a complete annotations file.

## Changes
- **Added `annotations.json`** with 8 annotations spanning all five parts of the Lean file:
  1. `AsymLLL` predicate (asymmetric hypothesis as a reusable Prop)
  2. Avoidance positivity + per-event bound as one-line corollaries of the parent's `general_lll`/`lll_prob_bound`
  3. The variable model: `occ` and the `sharedDep` shared-variable dependency graph
  4. Validity (irreflexive + symmetric) of the shared-variable graph
  5. The `k·(D−1)` degree bound bridging local incidence to the symmetric threshold
  6. The `variable_lll`/`variable_lll_symmetric` capstones
  7. Union-bound separation theorem
  8. The asymmetric-weights necessity witness (x₀ = 1/4 ≠ 1/2 = x₁)
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Verification
- JSON validated; `gallery:check-size`, `annotations:build`, `research:build`, `research:enrich` all pass.
- `meta.json` already meets quality targets and is under all size caps — left unchanged.
- Axiom integrity preserved: status `verified`, badge `original`, 0 axioms (accurate per the Lean file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)