### PR TITLE
audit: erdos-214-incomplete-01-oq-01 CLEAN (tracker update)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25589,6 +25589,12 @@
       "lastAudited": "2026-06-28T09:14:57Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-214-incomplete-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T09:26:58Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `erdos-214-incomplete-01-oq-01` (new gallery entry from #31193)
**Result**: ✅ clean — all public claims match the Lean kernel guarantee.

## Verification

Audited `src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json` against `proofs/Proofs/Erdos214Incomplete01OQ01.lean`:

| Claim | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| status / badge | verified / original | Tier A elementary proof | ✓ |
| sorries | 0 | 0 (only docstring mentions "no sorry") | ✓ |
| axiomCount | 0 | 0 axiom decls, 0 axiom-carrying structures | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 4 | 4 | ✓ |
| lineCount | 127 | 127 | ✓ |

- No `True` stubs, no `native_decide`.
- **Tier A**: Mathlib deps (`EuclideanSpace.dist_eq`, `Real.sq_sqrt`) are infrastructure, not the core argument — the parity result `2·(m²+k²) ≠ 1` is proved independently via `omega`. Badge `original` is appropriate.
- **No overclaiming**: title scopes the claim to non-vacuity of #214's hypothesis, independent of the parent's axiomatized Juhász theorem. Does not claim to prove #214 itself.

This PR only updates `audit-tracker.json`.

---
Discovered during gallery integrity audit. Deployer may merge directly (no Judge review needed).