### PR TITLE
research(bounded-prime-gaps-oq-02): explicit equipartition level chain for EH ascent [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ02.lean
@@ -453,6 +453,29 @@ theorem EHAtLevel_discrepancySum_up_chain (f : ℕ → ℝ → ℝ) {L : ℕ →
   | succ k ih =>
       exact EHAtLevel_discrepancySum_up f (hmono (Nat.le_succ k)) ih (hband k)
 
+/-- **Equally-spaced (arithmetic) chain ascent.**  The explicit instantiation of
+`EHAtLevel_discrepancySum_up_chain` at the arithmetic level sequence `L k = θ₀ + k·δ`
+(`δ ≥ 0`): from an EH bound at the base `θ₀` together with an EH-type bound on every equal
+step `θ₀ + k·δ → θ₀ + (k+1)·δ`, EH holds at `θ₀ + n·δ` for all `n`.  This is the concrete,
+equipartition form of the dyadic ascent — by taking `δ := (θ - θ₀)/n` it reaches any
+prescribed target level `θ ≥ θ₀` in `n` equal blocks, with the abstract `Monotone L`
+hypothesis discharged outright from `δ ≥ 0`. -/
+theorem EHAtLevel_discrepancySum_up_arith (f : ℕ → ℝ → ℝ) {θ₀ δ : ℝ} (hδ : 0 ≤ δ)
+    (hlow : EHAtLevel (discrepancySum f) θ₀)
+    (hband : ∀ k : ℕ, ∀ A : ℝ, 0 < A → ∃ C : ℝ, 0 < C ∧ ∀ x : ℝ, 2 ≤ x →
+        discrepancyBand f (θ₀ + k * δ) (θ₀ + (k + 1) * δ) x ≤ C * x / (Real.log x) ^ A) :
+    ∀ n : ℕ, EHAtLevel (discrepancySum f) (θ₀ + n * δ) := by
+  have hmono : Monotone (fun k : ℕ => θ₀ + (k : ℝ) * δ) := by
+    intro a b hab
+    have hc : (a : ℝ) ≤ (b : ℝ) := by exact_mod_cast hab
+    have := mul_le_mul_of_nonneg_right hc hδ
+    simp only []
+    linarith
+  have hlow' : EHAtLevel (discrepancySum f) ((fun k : ℕ => θ₀ + (k : ℝ) * δ) 0) := by
+    simpa using hlow
+  refine EHAtLevel_discrepancySum_up_chain f hmono hlow' (fun k A hA => ?_)
+  simpa only [Nat.cast_succ] using hband k A hA
+
 /-! ## Grounding the hierarchy in the genuine von-Mangoldt discrepancy
 
 Everything above treats the per-modulus weight `f` abstractly, requiring only
@@ -581,5 +604,20 @@ theorem EHAtLevel_vonMangoldt_up_chain {L : ℕ → ℝ} (hmono : Monotone L)
         discrepancyBand vonMangoldtWeight (L k) (L (k + 1)) x ≤ C * x / (Real.log x) ^ A) :
     ∀ n : ℕ, EHAtLevel vonMangoldtDiscrepancySum (L n) :=
   EHAtLevel_discrepancySum_up_chain vonMangoldtWeight hmono hlow hband
+
+/-- **Equally-spaced chain ascent for the genuine sum.**  The explicit arithmetic
+instantiation `L k = θ₀ + k·δ` (`δ ≥ 0`) of `EHAtLevel_vonMangoldt_up_chain`: bounding the
+real worst-case von-Mangoldt discrepancy on each equal step `θ₀ + k·δ → θ₀ + (k+1)·δ`
+raises the genuine level of distribution to `θ₀ + n·δ` for every `n`.  With `δ := (θ-θ₀)/n`
+this is the formal license to reach any target level `θ ≥ θ₀` in `n` equal modulus blocks —
+the equipartition form of the dyadic attack on Elliott–Halberstam, for the actual
+von-Mangoldt weight. -/
+theorem EHAtLevel_vonMangoldt_up_arith {θ₀ δ : ℝ} (hδ : 0 ≤ δ)
+    (hlow : EHAtLevel vonMangoldtDiscrepancySum θ₀)
+    (hband : ∀ k : ℕ, ∀ A : ℝ, 0 < A → ∃ C : ℝ, 0 < C ∧ ∀ x : ℝ, 2 ≤ x →
+        discrepancyBand vonMangoldtWeight (θ₀ + k * δ) (θ₀ + (k + 1) * δ) x
+          ≤ C * x / (Real.log x) ^ A) :
+    ∀ n : ℕ, EHAtLevel vonMangoldtDiscrepancySum (θ₀ + n * δ) :=
+  EHAtLevel_discrepancySum_up_arith vonMangoldtWeight hδ hlow hband
 
 end BoundedPrimeGapsOQ02

--- a/research/problems/bounded-prime-gaps-oq-02/knowledge.md
+++ b/research/problems/bounded-prime-gaps-oq-02/knowledge.md
@@ -21,9 +21,27 @@ arbitrarily-many-blocks form of dyadic decomposition of the modulus range — th
 analytic strategy uses `≍ log x` blocks, not two, so the prior two-band lemma was only
 the first nontrivial instance.
 
-File now: 585 lines, 34 theorems, 12 defs, 0 axioms/sorries.
+File (after session 2026-06-27): 585 lines, 34 theorems, 12 defs, 0 axioms/sorries.
 
-## Verification gotchas (this session)
+## Session 2026-06-28 (researcher-3) — explicit equipartition chain
+
+Instantiated the abstract finite chain at the explicit arithmetic level sequence
+`L k = θ₀ + k·δ` (`δ ≥ 0`) — the "explicit dyadic chain" flagged as an outward
+direction:
+
+- `EHAtLevel_discrepancySum_up_arith` (abstract weight): EH at base `θ₀` + EH-type
+  bound on each equal step `θ₀ + k·δ → θ₀ + (k+1)·δ` ⟹ EH at `θ₀ + n·δ` for all `n`.
+  `Monotone L` is discharged from `δ ≥ 0`. Choosing `δ = (θ-θ₀)/n` reaches any target
+  `θ ≥ θ₀` in `n` equal blocks — the concrete equipartition form.
+- `EHAtLevel_vonMangoldt_up_arith`: the genuine von-Mangoldt specialization.
+
+GOTCHA: stating hband with `θ₀ + (k+1)*δ` elaborates to `θ₀ + (↑k+1)*δ`, but the
+chain lemma's `L (k+1)` is `θ₀ + ↑(k+1)*δ`. Bridge when applying the chain:
+`refine … (fun k A hA => ?_); simpa only [Nat.cast_succ] using hband k A hA`.
+
+File now: 623 lines, 36 theorems, 12 defs, 0 axioms/sorries.
+
+## Verification gotchas (2026-06-27 session)
 - Docker build infra was DOWN (containerd `meta.db` I/O error). Verified instead via
   `cd proofs && LAKE_UNSAFE=1 lake env lean Proofs/BoundedPrimeGapsOQ02.lean` (EXIT 0).
   Local oleans live at `proofs/.lake/packages/mathlib/.lake/build/lib/lean/`; toolchain
@@ -37,4 +55,7 @@ File now: 585 lines, 34 theorems, 12 defs, 0 axioms/sorries.
 ## Possible further outward directions (not done)
 - Bridge the band-bound hypothesis form to `EHAtLevel (fun _ x => discrepancyBand …) ·`
   to unify it with the convex-cone lemmas.
-- Finset/list-indexed (non-ℕ) chain version; explicit dyadic chain `L k = log2`-spaced.
+- Finset/list-indexed (non-ℕ) chain version.
+- A target-θ wrapper `EHAtLevel … θ` that picks `δ = (θ-θ₀)/n` internally and proves
+  `θ₀ + n·δ = θ` (the arith chain `EHAtLevel_discrepancySum_up_arith` already gives the
+  content; this would just package the algebra).

--- a/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
@@ -83,12 +83,14 @@
       "discrepancyBand_add_consecutive: the additive cocycle (Chasles) identity for the band — for θ₁≤θ₂≤θ₃ on x≥1, discrepancyBand θ₁ θ₃ = discrepancyBand θ₁ θ₂ + discrepancyBand θ₂ θ₃, subdividing the new-moduli band at any intermediate level",
       "EHAtLevel_discrepancySum_up_split: subdivided ascent — raising the level from θ₁ to θ₃ needs only EH-type bounds on each consecutive sub-band, recombined via the convex-cone closure; the formal statement that the modulus range may be attacked dyadically",
       "EHAtLevel_discrepancySum_up_chain: finite-chain ascent — for a monotone level sequence L : ℕ → ℝ, EH at base level L 0 plus an EH-type bound on every consecutive band L k → L (k+1) lifts EH to every level L n (induction iterating the single-band ascent); the arbitrarily-many-blocks form of dyadic decomposition of the modulus range, of which EHAtLevel_discrepancySum_up_split is the n=2 case",
-      "EHAtLevel_vonMangoldt_up_chain: the finite-chain dyadic ascent specialized to the genuine von-Mangoldt EH weight — raising the genuine level of distribution to any L n by bounding the real worst-case discrepancy on each consecutive sub-band"
+      "EHAtLevel_vonMangoldt_up_chain: the finite-chain dyadic ascent specialized to the genuine von-Mangoldt EH weight — raising the genuine level of distribution to any L n by bounding the real worst-case discrepancy on each consecutive sub-band",
+      "EHAtLevel_discrepancySum_up_arith: the explicit EQUIPARTITION instantiation of the finite-chain ascent at the arithmetic level sequence L k = θ₀ + k·δ (δ ≥ 0) — EH at base θ₀ plus an EH-type bound on each equal step lifts EH to θ₀ + n·δ; choosing δ = (θ-θ₀)/n reaches any target θ ≥ θ₀ in n equal modulus blocks, with Monotone L discharged from δ ≥ 0",
+      "EHAtLevel_vonMangoldt_up_arith: the equipartition ascent for the genuine von-Mangoldt sum — bounding the real worst-case discrepancy on each equal step θ₀ + k·δ → θ₀ + (k+1)·δ raises the genuine level of distribution to θ₀ + n·δ, the concrete equipartition form of the dyadic attack on Elliott–Halberstam"
     ],
-    "lineCount": 585,
+    "lineCount": 623,
     "erdosUrl": null,
     "dateAdded": "2026-06-27",
-    "theoremCount": 34,
+    "theoremCount": 36,
     "definitionCount": 12
   },
   "overview": {
@@ -201,9 +203,9 @@
       "Real"
     ],
     "namespace": "BoundedPrimeGapsOQ02",
-    "lineCount": 585,
+    "lineCount": 623,
     "axiomCount": 0,
-    "theoremCount": 34,
+    "theoremCount": 36,
     "definitionCount": 12,
     "path": "Proofs/BoundedPrimeGapsOQ02.lean",
     "sorries": 0

--- a/src/data/research/problems/bounded-prime-gaps-oq-02.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-02.json
@@ -45,7 +45,9 @@
       "EHAtLevel_add / EHAtLevel_smul / EHAtLevel_nonneg_linear — EH-bound class is a convex cone (constants C₁+C₂ and c·C+1)",
       "EHAtLevel_discrepancySum_up: EHAtLevel(discrepancySum f) θ₁ + band EH-bound ⟹ EHAtLevel(discrepancySum f) θ₂ — quantitative ascent converse to the descent hierarchy",
       "psiAP/apDiscrepancy/vonMangoldtWeight + vonMangoldtDiscrepancySum(Clamped) in BoundedPrimeGapsOQ02.lean: genuine EH weight from ArithmeticFunction.vonMangoldt + Nat.totient; vonMangoldtWeight_nonneg via Finset.le_sup'+abs_nonneg",
-      "Capstones EHAtLevel_of_le_vonMangoldt, bombieriVinogradov_of_EH_vonMangoldt, bombieriVinogradov_of_EHAtLevel_vonMangoldt, vonMangoldtDiscrepancySum_mono_level, vonMangoldtDiscrepancySum_eq_add_band, EHAtLevel_vonMangoldt_up_split — full hierarchy/band/cone/ascent now applies to the genuine functional, 0-axiom"
+      "Capstones EHAtLevel_of_le_vonMangoldt, bombieriVinogradov_of_EH_vonMangoldt, bombieriVinogradov_of_EHAtLevel_vonMangoldt, vonMangoldtDiscrepancySum_mono_level, vonMangoldtDiscrepancySum_eq_add_band, EHAtLevel_vonMangoldt_up_split — full hierarchy/band/cone/ascent now applies to the genuine functional, 0-axiom",
+      "EHAtLevel_discrepancySum_up_chain / EHAtLevel_vonMangoldt_up_chain (2026-06-27): finite-chain ascent over a monotone level sequence L : ℕ → ℝ — arbitrarily-many-blocks dyadic decomposition, of which the two-band split is the n=2 case",
+      "EHAtLevel_discrepancySum_up_arith / EHAtLevel_vonMangoldt_up_arith (2026-06-28, researcher-3, 0-axiom): the explicit EQUIPARTITION instantiation of the chain at the arithmetic level sequence L k = θ₀ + k·δ (δ ≥ 0) — Monotone L discharged from δ ≥ 0; choosing δ = (θ-θ₀)/n reaches any target θ ≥ θ₀ in n equal modulus blocks. GOTCHA: hband's θ₀+(k+1)·δ elaborates to ↑k+1, chain's L(k+1) is ↑(k+1); bridge with simpa only [Nat.cast_succ]"
     ],
     "insights": [
       "EH is a conjecture, so formalize it as a logical skeleton over an abstract discrepancy functional D θ x — never axiomatize EH itself.",
@@ -99,7 +101,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.076Z",
-  "lastUpdate": "2026-04-22T12:51:58.076Z",
+  "lastUpdate": "2026-06-28T00:00:00.000Z",
   "significance": 8,
   "tractability": 3,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Extends the verified, axiom-free **Elliott–Halberstam level-of-distribution hierarchy** (`bounded-prime-gaps-oq-02`). The prior session added the abstract finite-chain ascent `EHAtLevel_discrepancySum_up_chain` over an arbitrary monotone level sequence `L : ℕ → ℝ`. This PR supplies the **explicit equipartition instantiation** flagged in the problem's outward directions ("explicit dyadic chain").

| Theorem | Statement |
|---------|-----------|
| `EHAtLevel_discrepancySum_up_arith` | abstract weight: EH at base `θ₀` + EH-type bound on each equal step `θ₀ + k·δ → θ₀ + (k+1)·δ` (`δ ≥ 0`) ⟹ EH at `θ₀ + n·δ` for all `n` |
| `EHAtLevel_vonMangoldt_up_arith` | the same for the genuine von-Mangoldt discrepancy sum |

The arithmetic level sequence `L k = θ₀ + k·δ` discharges the abstract `Monotone L` hypothesis outright (from `δ ≥ 0`), and choosing `δ = (θ − θ₀)/n` reaches **any** prescribed target level `θ ≥ θ₀` in `n` equal modulus blocks — the concrete equipartition form of the dyadic attack on Elliott–Halberstam, where the genuine analytic strategy partitions `q ≤ x^θ` into `≍ log x` blocks.

## Verification

- `585 → 623` lines, `34 → 36` theorems, **still 0 axioms / 0 sorries** (EH itself is never axiomatized — it enters only as per-theorem hypotheses).
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only.
- Host-verified with single-file `lake env lean Proofs/BoundedPrimeGapsOQ02.lean` (exit 0, clean).

Note: one cast bridge was needed — `hband`'s `θ₀ + (k+1)·δ` elaborates to `↑k + 1` while the chain's `L (k+1)` is `↑(k+1)`; reconciled via `simpa only [Nat.cast_succ]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)