### PR TITLE
research(chinese-remainder-constructive-oq-03-oq-02): four-moduli parity dichotomy [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChineseRemainderConstructiveOQ03OQ02.lean
+++ b/proofs/Proofs/ChineseRemainderConstructiveOQ03OQ02.lean
@@ -42,6 +42,27 @@
     then reconstruct against the third (iterated two-modulus CRT).
   * Concrete cross-checks for n = 2,3,4: {3,4,5}, {7,8,9}, {15,16,17}.
 
+  ## Four-moduli extension and the parity dichotomy (Section VI)
+
+  Hardware designs frequently extend the three-moduli set to four channels by
+  appending one more `(n+1)`-bit modulus. There are two natural candidates,
+  `2^(n+1) + 1` and `2^(n+1) - 1`, and a clean *parity dichotomy* governs which
+  one is admissible:
+
+  * For ODD n, `{2^n-1, 2^n, 2^n+1, 2^(n+1)+1}` is pairwise coprime
+    (`fourModuli_pairwise_coprime_odd`, packaged as `fourModuliBaseOdd`), but the
+    other candidate `2^(n+1)-1` FAILS — it shares the factor 3 with `2^n+1`
+    (`not_coprime_high_extMersenne_odd`).
+  * For EVEN n, `{2^n-1, 2^n, 2^n+1, 2^(n+1)-1}` is pairwise coprime
+    (`fourModuli_pairwise_coprime_even`, packaged as `fourModuliBaseEven`), but
+    `2^(n+1)+1` FAILS — it shares the factor 3 with `2^n-1`
+    (`not_coprime_lowMersenne_extHigh_even`).
+
+  The obstruction is exactly divisibility by 3, controlled by `2^n mod 3`
+  (= 2 for odd n, = 1 for even n; `two_pow_mod_three_of_odd/even`). The capstone
+  `fourModuli_base_exists` shows every n ≥ 2 admits SOME valid four-channel
+  extension — you just pick the modulus matching the parity of n.
+
   This is a constructive, fully machine-checked characterization of the
   three-moduli set; it does not claim global optimality over all bases (that
   remains the open parent question) — it formalizes why this specific, widely
@@ -233,9 +254,287 @@ theorem example_n4_coprime : [15, 16, 17].Pairwise Nat.Coprime := by decide
 theorem example_n4_range : ([15, 16, 17] : List ℕ).prod = 4080 := by norm_num
 theorem example_n4_range_formula : 2 ^ (3 * 4) - 2 ^ 4 = 4080 := by norm_num
 
+-- ============================================================
+-- SECTION VI: Four-moduli extensions and the parity dichotomy
+-- ============================================================
+
+/-- `2^n mod 3 = 2` when n is odd: `2 ≡ -1 (mod 3)`, so odd powers are `≡ -1`. -/
+theorem two_pow_mod_three_of_odd {n : ℕ} (hn : Odd n) : 2 ^ n % 3 = 2 := by
+  obtain ⟨m, rfl⟩ := hn
+  have hb : ((2 : ℕ) ^ 2) ≡ 1 [MOD 3] := by decide
+  have h4 : ((2 : ℕ) ^ 2) ^ m % 3 = 1 := by
+    have := hb.pow m; simpa [Nat.ModEq] using this
+  calc 2 ^ (2 * m + 1) % 3
+      = ((2 : ℕ) ^ 2) ^ m * 2 % 3 := by rw [pow_succ, pow_mul]
+    _ = (((2 : ℕ) ^ 2) ^ m % 3) * (2 % 3) % 3 := by rw [Nat.mul_mod]
+    _ = 2 := by rw [h4]
+
+/-- `2^n mod 3 = 1` when n is even: `2 ≡ -1 (mod 3)`, so even powers are `≡ 1`. -/
+theorem two_pow_mod_three_of_even {n : ℕ} (hn : Even n) : 2 ^ n % 3 = 1 := by
+  obtain ⟨m, rfl⟩ := hn
+  have hb : ((2 : ℕ) ^ 2) ≡ 1 [MOD 3] := by decide
+  have h4 : ((2 : ℕ) ^ 2) ^ m % 3 = 1 := by
+    have := hb.pow m; simpa [Nat.ModEq] using this
+  calc 2 ^ (m + m) % 3
+      = ((2 : ℕ) ^ 2) ^ m % 3 := by rw [show m + m = 2 * m from by ring, pow_mul]
+    _ = 1 := h4
+
+/-- Any common divisor of `2^n - 1` and `2^(n+1) + 1` divides 3:
+    `(2^(n+1)+1) - 2·(2^n-1) = 3`. -/
+theorem gcd_lowMersenne_extHigh_dvd_three (n : ℕ) :
+    Nat.gcd (2 ^ n - 1) (2 ^ (n + 1) + 1) ∣ 3 := by
+  have hpow : 2 ^ (n + 1) = 2 * 2 ^ n := by rw [pow_succ]; ring
+  have ha1 : 1 ≤ 2 ^ n := Nat.one_le_pow n 2 (by norm_num)
+  have hdl := Nat.gcd_dvd_left (2 ^ n - 1) (2 ^ (n + 1) + 1)
+  have hdr := Nat.gcd_dvd_right (2 ^ n - 1) (2 ^ (n + 1) + 1)
+  have h2 : Nat.gcd (2 ^ n - 1) (2 ^ (n + 1) + 1) ∣ 2 * (2 ^ n - 1) := hdl.mul_left 2
+  have he : 2 ^ (n + 1) + 1 - 2 * (2 ^ n - 1) = 3 := by rw [hpow]; omega
+  have hsub := Nat.dvd_sub hdr h2
+  rwa [he] at hsub
+
+/-- Any common divisor of `2^n + 1` and `2^(n+1) - 1` divides 3:
+    `2·(2^n+1) - (2^(n+1)-1) = 3`. -/
+theorem gcd_high_extMersenne_dvd_three (n : ℕ) :
+    Nat.gcd (2 ^ n + 1) (2 ^ (n + 1) - 1) ∣ 3 := by
+  have hpow : 2 ^ (n + 1) = 2 * 2 ^ n := by rw [pow_succ]; ring
+  have ha1 : 1 ≤ 2 ^ n := Nat.one_le_pow n 2 (by norm_num)
+  have hdl := Nat.gcd_dvd_left (2 ^ n + 1) (2 ^ (n + 1) - 1)
+  have hdr := Nat.gcd_dvd_right (2 ^ n + 1) (2 ^ (n + 1) - 1)
+  have h2 : Nat.gcd (2 ^ n + 1) (2 ^ (n + 1) - 1) ∣ 2 * (2 ^ n + 1) := hdl.mul_left 2
+  have he : 2 * (2 ^ n + 1) - (2 ^ (n + 1) - 1) = 3 := by rw [hpow]; omega
+  have hsub := Nat.dvd_sub h2 hdr
+  rwa [he] at hsub
+
+/-- ODD n: the extended-high modulus `2^(n+1)+1` is coprime to `2^n - 1`.
+    The gcd divides 3, but `3 ∤ 2^n-1` for odd n (`2^n ≡ 2 mod 3`). -/
+theorem coprime_lowMersenne_extHigh_odd (n : ℕ) (hn : Odd n) :
+    Nat.Coprime (2 ^ n - 1) (2 ^ (n + 1) + 1) := by
+  have hd3 := gcd_lowMersenne_extHigh_dvd_three n
+  have hmod : 2 ^ n % 3 = 2 := two_pow_mod_three_of_odd hn
+  have hge : 1 ≤ 2 ^ n := Nat.one_le_pow n 2 (by norm_num)
+  have hnot3 : ¬ Nat.gcd (2 ^ n - 1) (2 ^ (n + 1) + 1) = 3 := by
+    intro hg
+    have h3 : (3 : ℕ) ∣ 2 ^ n - 1 := by rw [← hg]; exact Nat.gcd_dvd_left _ _
+    omega
+  rcases (Nat.dvd_prime (by norm_num)).mp hd3 with h1 | h3
+  · exact h1
+  · exact absurd h3 hnot3
+
+/-- `2^(n+1)+1` is coprime to the mid channel `2^n` (consecutive-to-double). -/
+theorem coprime_mid_extHigh (n : ℕ) : Nat.Coprime (2 ^ n) (2 ^ (n + 1) + 1) := by
+  have hpow : 2 ^ (n + 1) = 2 * 2 ^ n := by rw [pow_succ]; ring
+  have hdl := Nat.gcd_dvd_left (2 ^ n) (2 ^ (n + 1) + 1)
+  have hdr := Nat.gcd_dvd_right (2 ^ n) (2 ^ (n + 1) + 1)
+  have h2 : Nat.gcd (2 ^ n) (2 ^ (n + 1) + 1) ∣ 2 ^ (n + 1) := by
+    have := hdl.mul_left 2; rwa [← hpow] at this
+  have he : 2 ^ (n + 1) + 1 - 2 ^ (n + 1) = 1 := by omega
+  have hsub := Nat.dvd_sub hdr h2
+  rw [he] at hsub
+  exact Nat.dvd_one.mp hsub
+
+/-- `2^(n+1)+1` is coprime to the high channel `2^n + 1`:
+    `2·(2^n+1) - (2^(n+1)+1) = 1`. -/
+theorem coprime_high_extHigh (n : ℕ) : Nat.Coprime (2 ^ n + 1) (2 ^ (n + 1) + 1) := by
+  have hpow : 2 ^ (n + 1) = 2 * 2 ^ n := by rw [pow_succ]; ring
+  have hdl := Nat.gcd_dvd_left (2 ^ n + 1) (2 ^ (n + 1) + 1)
+  have hdr := Nat.gcd_dvd_right (2 ^ n + 1) (2 ^ (n + 1) + 1)
+  have h2 : Nat.gcd (2 ^ n + 1) (2 ^ (n + 1) + 1) ∣ 2 * (2 ^ n + 1) := hdl.mul_left 2
+  have he : 2 * (2 ^ n + 1) - (2 ^ (n + 1) + 1) = 1 := by rw [hpow]; omega
+  have hsub := Nat.dvd_sub h2 hdr
+  rw [he] at hsub
+  exact Nat.dvd_one.mp hsub
+
+/-- `2^(n+1)-1` is coprime to the low channel `2^n - 1` (for all n):
+    `(2^(n+1)-1) - 2·(2^n-1) = 1`. -/
+theorem coprime_lowMersenne_extMersenne (n : ℕ) :
+    Nat.Coprime (2 ^ n - 1) (2 ^ (n + 1) - 1) := by
+  have hpow : 2 ^ (n + 1) = 2 * 2 ^ n := by rw [pow_succ]; ring
+  have ha1 : 1 ≤ 2 ^ n := Nat.one_le_pow n 2 (by norm_num)
+  have hdl := Nat.gcd_dvd_left (2 ^ n - 1) (2 ^ (n + 1) - 1)
+  have hdr := Nat.gcd_dvd_right (2 ^ n - 1) (2 ^ (n + 1) - 1)
+  have h2 : Nat.gcd (2 ^ n - 1) (2 ^ (n + 1) - 1) ∣ 2 * (2 ^ n - 1) := hdl.mul_left 2
+  have he : 2 ^ (n + 1) - 1 - 2 * (2 ^ n - 1) = 1 := by rw [hpow]; omega
+  have hsub := Nat.dvd_sub hdr h2
+  rw [he] at hsub
+  exact Nat.dvd_one.mp hsub
+
+/-- `2^(n+1)-1` is coprime to the mid channel `2^n` (for all n):
+    `2^(n+1) - (2^(n+1)-1) = 1`. -/
+theorem coprime_mid_extMersenne (n : ℕ) : Nat.Coprime (2 ^ n) (2 ^ (n + 1) - 1) := by
+  have hpow : 2 ^ (n + 1) = 2 * 2 ^ n := by rw [pow_succ]; ring
+  have ha1 : 1 ≤ 2 ^ (n + 1) := Nat.one_le_pow _ _ (by norm_num)
+  have hdl := Nat.gcd_dvd_left (2 ^ n) (2 ^ (n + 1) - 1)
+  have hdr := Nat.gcd_dvd_right (2 ^ n) (2 ^ (n + 1) - 1)
+  have h2 : Nat.gcd (2 ^ n) (2 ^ (n + 1) - 1) ∣ 2 ^ (n + 1) := by
+    have := hdl.mul_left 2; rwa [← hpow] at this
+  have he : 2 ^ (n + 1) - (2 ^ (n + 1) - 1) = 1 := by omega
+  have hsub := Nat.dvd_sub h2 hdr
+  rw [he] at hsub
+  exact Nat.dvd_one.mp hsub
+
+/-- EVEN n: the extended-Mersenne modulus `2^(n+1)-1` is coprime to `2^n + 1`.
+    The gcd divides 3, but `3 ∤ 2^n+1` for even n (`2^n ≡ 1 mod 3`). -/
+theorem coprime_high_extMersenne_even (n : ℕ) (hn : Even n) :
+    Nat.Coprime (2 ^ n + 1) (2 ^ (n + 1) - 1) := by
+  have hd3 := gcd_high_extMersenne_dvd_three n
+  have hmod : 2 ^ n % 3 = 1 := two_pow_mod_three_of_even hn
+  have hnot3 : ¬ Nat.gcd (2 ^ n + 1) (2 ^ (n + 1) - 1) = 3 := by
+    intro hg
+    have h3 : (3 : ℕ) ∣ 2 ^ n + 1 := by rw [← hg]; exact Nat.gcd_dvd_left _ _
+    omega
+  rcases (Nat.dvd_prime (by norm_num)).mp hd3 with h1 | h3
+  · exact h1
+  · exact absurd h3 hnot3
+
+/-- Sharp boundary (odd ↛ Mersenne): for ODD n, `2^(n+1)-1` is NOT coprime to
+    `2^n+1` — both are divisible by 3 — so this extension fails at odd n. -/
+theorem not_coprime_high_extMersenne_odd (n : ℕ) (hn : Odd n) :
+    ¬ Nat.Coprime (2 ^ n + 1) (2 ^ (n + 1) - 1) := by
+  have hmodO : 2 ^ n % 3 = 2 := two_pow_mod_three_of_odd hn
+  have h1 : (3 : ℕ) ∣ 2 ^ n + 1 := by omega
+  have hmodE : 2 ^ (n + 1) % 3 = 1 := two_pow_mod_three_of_even (Odd.add_one hn)
+  have hge : 1 ≤ 2 ^ (n + 1) := Nat.one_le_pow _ _ (by norm_num)
+  have h2 : (3 : ℕ) ∣ 2 ^ (n + 1) - 1 := by omega
+  intro hco
+  have hco' : Nat.gcd (2 ^ n + 1) (2 ^ (n + 1) - 1) = 1 := hco
+  have hg : (3 : ℕ) ∣ Nat.gcd (2 ^ n + 1) (2 ^ (n + 1) - 1) := Nat.dvd_gcd h1 h2
+  rw [hco'] at hg
+  exact absurd hg (by norm_num)
+
+/-- Sharp boundary (even ↛ extended-high): for EVEN n, `2^(n+1)+1` is NOT coprime
+    to `2^n-1` — both are divisible by 3 — so this extension fails at even n. -/
+theorem not_coprime_lowMersenne_extHigh_even (n : ℕ) (hn : Even n) :
+    ¬ Nat.Coprime (2 ^ n - 1) (2 ^ (n + 1) + 1) := by
+  have hmodE : 2 ^ n % 3 = 1 := two_pow_mod_three_of_even hn
+  have hge : 1 ≤ 2 ^ n := Nat.one_le_pow n 2 (by norm_num)
+  have h1 : (3 : ℕ) ∣ 2 ^ n - 1 := by omega
+  have hmodO : 2 ^ (n + 1) % 3 = 2 := two_pow_mod_three_of_odd (Even.add_one hn)
+  have h2 : (3 : ℕ) ∣ 2 ^ (n + 1) + 1 := by omega
+  intro hco
+  have hco' : Nat.gcd (2 ^ n - 1) (2 ^ (n + 1) + 1) = 1 := hco
+  have hg : (3 : ℕ) ∣ Nat.gcd (2 ^ n - 1) (2 ^ (n + 1) + 1) := Nat.dvd_gcd h1 h2
+  rw [hco'] at hg
+  exact absurd hg (by norm_num)
+
+/-- ODD n: the four-moduli set `{2^n-1, 2^n, 2^n+1, 2^(n+1)+1}` is pairwise coprime. -/
+theorem fourModuli_pairwise_coprime_odd (n : ℕ) (hn : Odd n) :
+    [2 ^ n - 1, 2 ^ n, 2 ^ n + 1, 2 ^ (n + 1) + 1].Pairwise Nat.Coprime := by
+  have hpos : 1 ≤ n := by obtain ⟨k, hk⟩ := hn; omega
+  refine List.Pairwise.cons ?_ (List.Pairwise.cons ?_
+    (List.Pairwise.cons ?_ (List.Pairwise.cons ?_ List.Pairwise.nil)))
+  · intro a ha
+    rcases List.mem_cons.mp ha with rfl | ha1
+    · exact coprime_low_mid n
+    · rcases List.mem_cons.mp ha1 with rfl | ha2
+      · exact coprime_low_high n hpos
+      · rcases List.mem_singleton.mp ha2 with rfl
+        exact coprime_lowMersenne_extHigh_odd n hn
+  · intro a ha
+    rcases List.mem_cons.mp ha with rfl | ha1
+    · exact coprime_mid_high n
+    · rcases List.mem_singleton.mp ha1 with rfl
+      exact coprime_mid_extHigh n
+  · intro a ha
+    rcases List.mem_singleton.mp ha with rfl
+    exact coprime_high_extHigh n
+  · intro a ha
+    simp at ha
+
+/-- EVEN n: the four-moduli set `{2^n-1, 2^n, 2^n+1, 2^(n+1)-1}` is pairwise coprime. -/
+theorem fourModuli_pairwise_coprime_even (n : ℕ) (hn : Even n) (hpos : 1 ≤ n) :
+    [2 ^ n - 1, 2 ^ n, 2 ^ n + 1, 2 ^ (n + 1) - 1].Pairwise Nat.Coprime := by
+  refine List.Pairwise.cons ?_ (List.Pairwise.cons ?_
+    (List.Pairwise.cons ?_ (List.Pairwise.cons ?_ List.Pairwise.nil)))
+  · intro a ha
+    rcases List.mem_cons.mp ha with rfl | ha1
+    · exact coprime_low_mid n
+    · rcases List.mem_cons.mp ha1 with rfl | ha2
+      · exact coprime_low_high n hpos
+      · rcases List.mem_singleton.mp ha2 with rfl
+        exact coprime_lowMersenne_extMersenne n
+  · intro a ha
+    rcases List.mem_cons.mp ha with rfl | ha1
+    · exact coprime_mid_high n
+    · rcases List.mem_singleton.mp ha1 with rfl
+      exact coprime_mid_extMersenne n
+  · intro a ha
+    rcases List.mem_singleton.mp ha with rfl
+    exact coprime_high_extMersenne_even n hn
+  · intro a ha
+    simp at ha
+
+/-- The ODD-n four-moduli RNS base `{2^n-1, 2^n, 2^n+1, 2^(n+1)+1}` (n ≥ 2). -/
+def fourModuliBaseOdd (n : ℕ) (hn : Odd n) (hn2 : 2 ≤ n) : RNSBase where
+  moduli := [2 ^ n - 1, 2 ^ n, 2 ^ n + 1, 2 ^ (n + 1) + 1]
+  coprime := fourModuli_pairwise_coprime_odd n hn
+  ge_two := by
+    have hpow : 4 ≤ 2 ^ n := by
+      have : (2 : ℕ) ^ 2 ≤ 2 ^ n := Nat.pow_le_pow_right (by norm_num) hn2
+      simpa using this
+    intro m hm
+    rcases List.mem_cons.mp hm with rfl | hm'
+    · omega
+    · rcases List.mem_cons.mp hm' with rfl | hm''
+      · omega
+      · rcases List.mem_cons.mp hm'' with rfl | hm'''
+        · omega
+        · rcases List.mem_singleton.mp hm''' with rfl
+          have h1 : 1 ≤ 2 ^ (n + 1) := Nat.one_le_pow _ _ (by norm_num)
+          omega
+
+/-- The EVEN-n four-moduli RNS base `{2^n-1, 2^n, 2^n+1, 2^(n+1)-1}` (n ≥ 2). -/
+def fourModuliBaseEven (n : ℕ) (hn : Even n) (hn2 : 2 ≤ n) : RNSBase where
+  moduli := [2 ^ n - 1, 2 ^ n, 2 ^ n + 1, 2 ^ (n + 1) - 1]
+  coprime := fourModuli_pairwise_coprime_even n hn (by omega)
+  ge_two := by
+    have hpow : 4 ≤ 2 ^ n := by
+      have : (2 : ℕ) ^ 2 ≤ 2 ^ n := Nat.pow_le_pow_right (by norm_num) hn2
+      simpa using this
+    intro m hm
+    rcases List.mem_cons.mp hm with rfl | hm'
+    · omega
+    · rcases List.mem_cons.mp hm' with rfl | hm''
+      · omega
+      · rcases List.mem_cons.mp hm'' with rfl | hm'''
+        · omega
+        · rcases List.mem_singleton.mp hm''' with rfl
+          have h1 : 4 ≤ 2 ^ (n + 1) := by
+            have : (2 : ℕ) ^ 2 ≤ 2 ^ (n + 1) := Nat.pow_le_pow_right (by norm_num) (by omega)
+            simpa using this
+          omega
+
+theorem fourModuliBaseOdd_channels (n : ℕ) (hn : Odd n) (hn2 : 2 ≤ n) :
+    (fourModuliBaseOdd n hn hn2).channels = 4 := rfl
+
+theorem fourModuliBaseEven_channels (n : ℕ) (hn : Even n) (hn2 : 2 ≤ n) :
+    (fourModuliBaseEven n hn hn2).channels = 4 := rfl
+
+/-- Parity dichotomy capstone: every n ≥ 2 admits SOME valid four-channel RNS
+    extension of the three-moduli set — use `2^(n+1)+1` when n is odd and
+    `2^(n+1)-1` when n is even. -/
+theorem fourModuli_base_exists (n : ℕ) (hn2 : 2 ≤ n) :
+    ∃ b : RNSBase, b.channels = 4 := by
+  rcases Nat.even_or_odd n with he | ho
+  · exact ⟨fourModuliBaseEven n he hn2, fourModuliBaseEven_channels n he hn2⟩
+  · exact ⟨fourModuliBaseOdd n ho hn2, fourModuliBaseOdd_channels n ho hn2⟩
+
+-- Concrete cross-checks for the parity dichotomy.
+-- n = 3 (odd): {7,8,9,17} works; {7,8,9,15} fails (gcd(9,15) = 3).
+theorem example_n3_four_odd : [7, 8, 9, 17].Pairwise Nat.Coprime := by decide
+theorem example_n3_bad_mersenne_choice : ¬ [7, 8, 9, 15].Pairwise Nat.Coprime := by decide
+-- n = 2 (even): {3,4,5,7} works; {3,4,5,9} fails (gcd(3,9) = 3).
+theorem example_n2_four_even : [3, 4, 5, 7].Pairwise Nat.Coprime := by decide
+theorem example_n2_bad_high_choice : ¬ [3, 4, 5, 9].Pairwise Nat.Coprime := by decide
+-- n = 4 (even): {15,16,17,31} works.
+theorem example_n4_four_even : [15, 16, 17, 31].Pairwise Nat.Coprime := by decide
+
 #check @threeModuli_pairwise_coprime
 #check @dynamicRange_formula
 #check @threeModuliBase_dynamicRange
 #check @threeModuli_crt_step
+#check @fourModuli_pairwise_coprime_odd
+#check @fourModuli_pairwise_coprime_even
+#check @fourModuli_base_exists
+#check @two_pow_mod_three_of_odd
 
 end RNSThreeModuli

--- a/research/problems/chinese-remainder-constructive-oq-03-oq-02/knowledge.md
+++ b/research/problems/chinese-remainder-constructive-oq-03-oq-02/knowledge.md
@@ -1,0 +1,56 @@
+# chinese-remainder-constructive-oq-03-oq-02 — knowledge
+
+## Status
+VERIFIED (extended). The three-moduli core {2^n−1, 2^n, 2^n+1} was already
+verified (0 sorry / 0 axiom; PR #30734, #30762). This session (researcher-1,
+2026-06-28) extended the file with a four-moduli **parity dichotomy** — also
+0 sorry / 0 axiom, foundational axioms only.
+
+## Session 2026-06-28 (researcher-1): four-moduli parity dichotomy
+
+SOLVED-strategy: the core was already done, so I looked outward. The "nextSteps"
+flagged a 4-moduli extension. Working it out revealed a genuine sharp boundary.
+
+### Result
+The natural fourth (n+1)-bit modulus has two candidates, 2^(n+1)+1 and
+2^(n+1)−1, and exactly one is admissible depending on the parity of n:
+
+- **odd n**: {2^n−1, 2^n, 2^n+1, **2^(n+1)+1**} is pairwise coprime
+  (`fourModuli_pairwise_coprime_odd`, `fourModuliBaseOdd`). The other candidate
+  2^(n+1)−1 FAILS — `gcd(2^n+1, 2^(n+1)−1) = 3` (`not_coprime_high_extMersenne_odd`).
+- **even n**: {2^n−1, 2^n, 2^n+1, **2^(n+1)−1**} is pairwise coprime
+  (`fourModuli_pairwise_coprime_even`, `fourModuliBaseEven`). Now 2^(n+1)+1 FAILS —
+  `gcd(2^n−1, 2^(n+1)+1) = 3` (`not_coprime_lowMersenne_extHigh_even`).
+- Capstone `fourModuli_base_exists`: every n ≥ 2 admits SOME valid 4-channel base.
+
+### Why it works (the math)
+The only non-free pair is between an odd channel and the new odd modulus; their
+gcd always divides 3 (the difference combination collapses to 3). Whether 3
+actually divides depends on 2^n mod 3, which is governed entirely by parity:
+- `two_pow_mod_three_of_odd`:  2^n ≡ 2 (mod 3) for odd n  ⟹ 3 ∤ 2^n−1, 3 ∣ 2^n+1.
+- `two_pow_mod_three_of_even`: 2^n ≡ 1 (mod 3) for even n ⟹ 3 ∣ 2^n−1, 3 ∤ 2^n+1.
+So 2^n+1 picks up the factor 3 for odd n and 2^n−1 for even n — and the matching
+"+1 / −1" candidate is the one that dodges it.
+
+### Lean gotchas hit
+- `rw [hpow]` (hpow : 2^(n+1) = 2*2^n) rewrites the `2^(n+1)` INSIDE the gcd's
+  second argument too, so a follow-up `hdl.mul_left 2` (still phrased with the
+  original 2^(n+1)) type-mismatches. Fix: prove `d ∣ 2*2^n` first, then
+  `rwa [← hpow] at this` to land on `d ∣ 2^(n+1)` without touching the gcd term.
+- `two_pow_mod_three`: `((2:ℕ)^2) ≡ 1 [MOD 3] := by decide`, then `.pow m` and
+  `simpa [Nat.ModEq]`; finish odd case via `pow_succ, pow_mul, Nat.mul_mod`.
+- `Even.add_one : Even n → Odd (n+1)`, `Odd.add_one : Odd n → Even (n+1)`.
+- `omega` closes `3 ∣ 2^n ± 1` directly from a `2^n % 3 = c` hypothesis.
+- Coprime ⇒ gcd=1 used as `have hco' : Nat.gcd .. = 1 := hco` (defeq) before `rw`.
+
+### Verification
+`lake env lean Proofs/ChineseRemainderConstructiveOQ03OQ02.lean` — clean, no
+errors/warnings. `#print axioms` on all new theorems = [propext, Classical.choice,
+Quot.sound] only (no sorryAx, no Lean.ofReduceBool; small examples use kernel
+`decide`, not `native_decide`). File now 540 lines, 42 theorems, 5 defs, 0 axioms.
+
+### Possible follow-ups (left for Seeker; slug depth = 2, child depth 3 OK)
+- 5-moduli extensions {2^n−1, 2^n, 2^n+1, 2^(n+1)±1, ?} and whether the
+  coprimality obstruction is again pinned by small-prime residues of n.
+- Exact closed-form dynamic range of the 4-moduli set
+  (= (2^(3n)−2^n)·(2·2^n ± 1)).

--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "chinese-remainder-constructive-oq-03-oq-02",
   "title": "CRT RNS: The Balanced Three-Moduli Set {2ⁿ−1, 2ⁿ, 2ⁿ+1}",
   "slug": "chinese-remainder-constructive-oq-03-oq-02",
-  "description": "Formalizes the single most-cited efficient RNS base in the computer-arithmetic literature: the balanced three-moduli set {2ⁿ−1, 2ⁿ, 2ⁿ+1}. Proves pairwise coprimality for n ≥ 1 (decomposed into low–mid, mid–high, low–high facts), the exact dynamic-range formula (2ⁿ−1)·2ⁿ·(2ⁿ+1) = 2^(3n) − 2ⁿ, packages it into a genuine RNSBase with 3 channels, proves the balance bound 2ⁿ+1 ≤ 2·(2ⁿ−1), and supplies the CRT-reconstruction coprimality step gcd((2ⁿ−1)·2ⁿ, 2ⁿ+1) = 1 needed to fold the first two channels before reconstructing against the third. Cross-checks n = 2,3,4 against {3,4,5}, {7,8,9}, {15,16,17}.",
+  "description": "Formalizes the single most-cited efficient RNS base in the computer-arithmetic literature: the balanced three-moduli set {2ⁿ−1, 2ⁿ, 2ⁿ+1}. Proves pairwise coprimality for n ≥ 1 (decomposed into low–mid, mid–high, low–high facts), the exact dynamic-range formula (2ⁿ−1)·2ⁿ·(2ⁿ+1) = 2^(3n) − 2ⁿ, packages it into a genuine RNSBase with 3 channels, proves the balance bound 2ⁿ+1 ≤ 2·(2ⁿ−1), and supplies the CRT-reconstruction coprimality step gcd((2ⁿ−1)·2ⁿ, 2ⁿ+1) = 1 needed to fold the first two channels before reconstructing against the third. Cross-checks n = 2,3,4 against {3,4,5}, {7,8,9}, {15,16,17}. Section VI extends the set to four channels and proves a parity dichotomy: the fourth (n+1)-bit modulus must be 2^(n+1)+1 when n is odd and 2^(n+1)-1 when n is even — the opposite choice shares the factor 3 (it fails coprimality with 2ⁿ−1 resp. 2ⁿ+1), controlled by 2ⁿ mod 3 (=2 for odd n, =1 for even n). Both valid four-moduli bases are packaged as RNSBase instances with 4 channels, and fourModuli_base_exists shows every n ≥ 2 admits one.",
   "meta": {
     "author": "Lean Genius Researcher",
     "sourceUrl": "",
@@ -19,12 +19,12 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 241,
+    "lineCount": 540,
     "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. VERIFIED: compiles clean against Mathlib 4.26.0 via `lake env lean Proofs/ChineseRemainderConstructiveOQ03OQ02.lean` (no errors, no warnings); `#print axioms` on all top-level results reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no Lean.ofReduceBool (the n=2,3,4 cross-checks use kernel `decide`, not `native_decide`). The proof relies only on standard current Mathlib lemmas (Nat.dvd_sub, Nat.gcd_dvd_left/right, Nat.dvd_prime, Nat.prime_two, Nat.sub_add_cancel, Nat.Coprime.mul_left, List.Pairwise.cons, omega/ring/decide/norm_num). Global optimality over all bases is NOT claimed — that remains the open parent question; this entry formalizes why this specific widely-used base is valid and balanced.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 20,
+    "theoremCount": 42,
     "dateAdded": "2026-06-27",
-    "definitionCount": 4
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Residue Number Systems were introduced by Harvey Garner in 1959 for parallel computer arithmetic and developed by Szabó and Tanaka (1967). For practical hardware the dominant choice is the balanced three-moduli set {2ⁿ−1, 2ⁿ, 2ⁿ+1}, popularized by Soderstrand et al. in 'Residue Number System Arithmetic' (IEEE Press, 1986). It is favored because two of the three moduli admit trivial modular reduction: 2ⁿ is a bit-mask (x mod 2ⁿ = low n bits) and 2ⁿ−1 is a Mersenne wrap (x mod (2ⁿ−1) folds the high and low halves), while the three channels are nearly equal in width so the critical path is close to minimal. The parent entry ChineseRemainderConstructiveOQ03 formalized the general efficiency criteria for RNS bases (dynamic range, channel width, Mersenne-friendliness) but did not formalize this canonical concrete base; sibling OQ-03-OQ-01 handled prime-base growth for all k and OQ-03-OQ-03 handled a single power-of-2 channel alongside odd moduli.",
@@ -42,37 +42,44 @@
     {
       "id": "coprimality",
       "title": "Pairwise Coprimality of the Three Moduli",
-      "startLine": 66,
-      "endLine": 111,
+      "startLine": 90,
+      "endLine": 132,
       "summary": "coprime_consecutive (gcd divides the difference 1) gives low–mid and mid–high coprimality directly, since 2ⁿ−1, 2ⁿ and 2ⁿ, 2ⁿ+1 are consecutive. coprime_low_high handles the two odd ends 2ⁿ−1, 2ⁿ+1 (difference 2, both odd) via Nat.dvd_prime Nat.prime_two and the oddness of 2ⁿ−1."
     },
     {
       "id": "dynamic-range",
       "title": "Exact Dynamic-Range Formula",
-      "startLine": 113,
-      "endLine": 131,
+      "startLine": 134,
+      "endLine": 152,
       "summary": "dynamicRange_formula: (2ⁿ−1)·2ⁿ·(2ⁿ+1) = 2^(3n) − 2ⁿ. The polynomial identity a(a−1)(a+1) = a³−a with a = 2ⁿ, with natural subtraction handled by writing 2ⁿ = k+1 and closing k·(k+1)·(k+2)+(k+1) = (k+1)³ with ring."
     },
     {
       "id": "rns-base",
       "title": "The Three-Moduli Set as a Genuine RNS Base",
-      "startLine": 133,
-      "endLine": 191,
+      "startLine": 154,
+      "endLine": 212,
       "summary": "A self-contained RNSBase structure (pairwise-coprime moduli ≥ 2; the parent RNS file has bit-rotted against Mathlib 4.26.0). threeModuli_pairwise_coprime assembles pairwise coprimality via List.Pairwise.cons; threeModuliBase (n ≥ 2) is the base with channels = 3 and dynamicRange = 2^(3n) − 2ⁿ."
     },
     {
       "id": "balance-crt",
       "title": "Balance and CRT Reconstruction Step",
-      "startLine": 193,
-      "endLine": 214,
+      "startLine": 214,
+      "endLine": 235,
       "summary": "threeModuli_balanced: 2ⁿ+1 ≤ 2·(2ⁿ−1) for n ≥ 2 (the widest channel is below twice the narrowest). threeModuli_crt_step: Coprime ((2ⁿ−1)·2ⁿ) (2ⁿ+1), the fact that lets one fold the first two channels and reconstruct against the third by two-modulus CRT."
     },
     {
       "id": "cross-checks",
       "title": "Concrete Cross-Checks (n = 2, 3, 4)",
-      "startLine": 216,
-      "endLine": 241,
+      "startLine": 237,
+      "endLine": 255,
       "summary": "n = 2 gives {3,4,5} (range 60), n = 3 gives {7,8,9} (range 504), n = 4 gives {15,16,17} (range 4080), each confirmed pairwise coprime and matching the 2^(3n) − 2ⁿ formula by decide / norm_num."
+    },
+    {
+      "id": "parity-dichotomy",
+      "title": "Four-Moduli Extensions and the Parity Dichotomy",
+      "startLine": 257,
+      "endLine": 538,
+      "summary": "Extends the three-moduli set to four channels. two_pow_mod_three_of_odd/even fix 2ⁿ mod 3 (= 2 odd, = 1 even). For odd n, {2ⁿ−1, 2ⁿ, 2ⁿ+1, 2^(n+1)+1} is pairwise coprime (fourModuli_pairwise_coprime_odd / fourModuliBaseOdd); 2^(n+1)−1 instead fails (not_coprime_high_extMersenne_odd, gcd 3). For even n the roles swap: {…, 2^(n+1)−1} works (fourModuli_pairwise_coprime_even / fourModuliBaseEven) while 2^(n+1)+1 fails (not_coprime_lowMersenne_extHigh_even). The obstruction is always divisibility by 3. Capstone fourModuli_base_exists: every n ≥ 2 admits a valid 4-channel base. Cross-checked at n = 2 ({3,4,5,7} ✓, {3,4,5,9} ✗), n = 3 ({7,8,9,17} ✓, {7,8,9,15} ✗), n = 4 ({15,16,17,31} ✓)."
     }
   ],
   "conclusion": {
@@ -81,7 +88,7 @@
     "openQuestions": [
       "Does any 3-channel base of total width ~3n bits beat {2ⁿ−1, 2ⁿ, 2ⁿ+1} in dynamic range while remaining pairwise coprime and equally balanced — i.e. is this base optimal within its width class, not merely valid?",
       "Can the iterated two-modulus CRT reconstruction map (Garner's algorithm specialized to {2ⁿ−1, 2ⁿ, 2ⁿ+1}) be formalized with the bit-mask and Mersenne-wrap reductions made explicit and proved correct?",
-      "How does the balanced set generalize to more channels, e.g. {2ⁿ−1, 2ⁿ, 2ⁿ+1, 2^(2n)+1}, while preserving pairwise coprimality and a bounded width ratio?"
+      "Beyond four channels: which 5-moduli extensions {2ⁿ−1, 2ⁿ, 2ⁿ+1, 2^(n+1)±1, ?} stay pairwise coprime, and is the obstruction again controlled purely by small-prime residues of n?"
     ]
   },
   "crossReferences": [
@@ -102,12 +109,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 241,
+    "lineCount": 540,
     "path": "Proofs/ChineseRemainderConstructiveOQ03OQ02.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 4,
-    "theoremCount": 20
+    "definitionCount": 6,
+    "theoremCount": 42
   },
   "sorries": 0
 }

--- a/src/data/research/problems/chinese-remainder-constructive-oq-03-oq-02.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-03-oq-02.json
@@ -20,7 +20,10 @@
       "dynamicRange_formula: (2^n-1)*2^n*(2^n+1) = 2^(3n) - 2^n",
       "threeModuliBase n (n>=2): a genuine RNSBase with channels=3, dynamicRange=2^(3n)-2^n",
       "threeModuli_balanced (n>=2): 2^n+1 <= 2*(2^n-1)",
-      "threeModuli_crt_step: gcd((2^n-1)*2^n, 2^n+1) = 1 (two-step CRT reconstruction)"
+      "threeModuli_crt_step: gcd((2^n-1)*2^n, 2^n+1) = 1 (two-step CRT reconstruction)",
+      "fourModuli_pairwise_coprime_odd / _even: the parity-correct 4-moduli set is pairwise coprime",
+      "not_coprime_*_odd/even: the parity-wrong 4th modulus fails (gcd = 3)",
+      "fourModuli_base_exists: every n >= 2 admits a valid 4-channel RNS base"
     ],
     "open": [
       "Global optimality across ALL bases of a given width budget remains the open parent question (chinese-remainder-constructive-oq-03)."
@@ -30,40 +33,48 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-27T12:05:00.000Z",
-    "iteration": 1,
-    "focus": "Formalized the three-moduli set {2^n-1, 2^n, 2^n+1}: coprimality, exact dynamic range, balance, RNSBase instance, CRT step.",
+    "iteration": 2,
+    "focus": "Added Section VI: four-moduli parity dichotomy (sharp boundary at parity of n).",
     "blockers": [
       "None — verified. Earlier Docker/containerd outage resolved by compiling with `lake env lean` against the prebuilt Mathlib oleans."
     ],
-    "nextAction": "Done. Verified clean against Mathlib 4.26.0 (lake env lean; #print axioms = propext/Classical.choice/Quot.sound only). Gallery entry upgraded to status=verified, badge=original.",
+    "nextAction": "Done for this session. Verified clean. Optional: 5-moduli extension (Seeker follow-up).",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
       "approachesTried": 1
     },
-    "progressSummary": "VERIFIED: 20-theorem self-contained file (0 sorry/axiom) compiles clean against Mathlib 4.26.0 via `lake env lean`; #print axioms reports only the three standard foundational axioms. Fixed two pre-existing compile errors before verifying: Nat.dvd_sub' (removed upstream) -> Nat.dvd_sub, and an ambiguous `h2 ▸ hdl` rewrite -> explicit `rw [h2] at hdl`. Gallery entry verified/original."
+    "progressSummary": "VERIFIED + EXTENDED: core three-moduli set plus a new Section VI four-moduli parity dichotomy (admissible 4th modulus is 2^(n+1)+1 for odd n, 2^(n+1)-1 for even n; opposite choice shares factor 3). 540 lines, 42 theorems, 0 sorry/0 axiom; lake env lean clean, #print axioms foundational-only."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 20-theorem self-contained file complete (0 sorry/axiom), PR #30734 open. Manually reviewed sound but UNVERIFIED — Docker containerd corrupted (operator restart needed). Awaiting build host recovery to compile.",
+    "progressSummary": "VERIFIED + EXTENDED: core three-moduli set plus a new Section VI four-moduli parity dichotomy (admissible 4th modulus is 2^(n+1)+1 for odd n, 2^(n+1)-1 for even n; opposite choice shares factor 3). 540 lines, 42 theorems, 0 sorry/0 axiom; lake env lean clean, #print axioms foundational-only.",
     "builtItems": [
       "ChineseRemainderConstructiveOQ03OQ02.lean: coprime_consecutive, coprime_low_mid, coprime_mid_high, coprime_low_high",
       "dynamicRange_formula: (2^n-1)*2^n*(2^n+1) = 2^(3n) - 2^n",
       "RNSBase structure + threeModuliBase instance (n>=2), threeModuliBase_channels, threeModuliBase_dynamicRange",
       "threeModuli_balanced, threeModuli_crt_step",
-      "Concrete cross-checks for {3,4,5}, {7,8,9}, {15,16,17}"
+      "Concrete cross-checks for {3,4,5}, {7,8,9}, {15,16,17}",
+      "Section VI (4-moduli parity dichotomy): two_pow_mod_three_of_odd/even fix 2^n mod 3",
+      "gcd_lowMersenne_extHigh_dvd_three / gcd_high_extMersenne_dvd_three: obstruction gcd | 3",
+      "coprime_lowMersenne_extHigh_odd, coprime_mid_extHigh, coprime_high_extHigh (4th = 2^(n+1)+1, odd n)",
+      "coprime_lowMersenne_extMersenne, coprime_mid_extMersenne, coprime_high_extMersenne_even (4th = 2^(n+1)-1, even n)",
+      "not_coprime_high_extMersenne_odd / not_coprime_lowMersenne_extHigh_even (sharp boundary, gcd = 3)",
+      "fourModuliBaseOdd, fourModuliBaseEven (RNSBase, 4 channels); fourModuli_base_exists (every n>=2)"
     ],
     "insights": [
       "The three-moduli set is self-balancing: all three moduli lie within a factor 2 of each other, so the critical-path (widest) channel is nearly minimal for the dynamic range achieved.",
       "Coprimality decomposes cleanly: low-mid and mid-high are consecutive integers; low-high differ by 2 with both endpoints odd, so gcd | 2 and gcd is odd, forcing gcd = 1 (needs n >= 1).",
       "Dynamic range is the near-cube a^3 - a (a = 2^n); natural-number subtraction is handled by substituting a = k+1 to avoid truncated subtraction.",
       "threeModuli_crt_step (gcd((2^n-1)*2^n, 2^n+1) = 1) is exactly the coprimality enabling two-step iterated CRT reconstruction from the three residues.",
-      "Manual line-by-line review (researcher-1, build host down) found no math/tactic errors in ChineseRemainderConstructiveOQ03OQ02.lean; key non-obvious steps (coprime_low_high parity via in-scope hpow, dynamicRange_formula 2^n=k+1 substitution, Pairwise.cons shape) all check out. High confidence, still formally UNVERIFIED."
+      "Manual line-by-line review (researcher-1, build host down) found no math/tactic errors in ChineseRemainderConstructiveOQ03OQ02.lean; key non-obvious steps (coprime_low_high parity via in-scope hpow, dynamicRange_formula 2^n=k+1 substitution, Pairwise.cons shape) all check out. High confidence, still formally UNVERIFIED.",
+      "Parity dichotomy: the admissible fourth (n+1)-bit modulus is 2^(n+1)+1 for odd n and 2^(n+1)-1 for even n; the opposite candidate always shares the factor 3.",
+      "The single obstruction is divisibility by 3, controlled entirely by 2^n mod 3 (=2 odd, =1 even) since 2 ≡ -1 (mod 3).",
+      "Lean gotcha: rw [hpow: 2^(n+1)=2*2^n] also rewrites the 2^(n+1) inside a gcd argument; prove d ∣ 2*2^n then rwa [← hpow] to avoid the mismatch."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Machine-verify via docker-build once host disk/containerd recover.",
-      "If verified, add gallery meta.json (status verified, badge original, 0 axioms) and annotations.",
-      "Possible follow-up: extend to the 4-moduli restricted set {2^n-1, 2^n, 2^n+1, 2^(n+1)+1} and its coprimality constraints."
+      "5-moduli extensions {2^n-1,2^n,2^n+1,2^(n+1)±1,?}: which stay pairwise coprime; is the obstruction again small-prime residues of n?",
+      "Exact closed-form dynamic range of the 4-moduli set ((2^(3n)-2^n)*(2*2^n ± 1))."
     ]
   },
   "tags": [
@@ -88,7 +99,7 @@
     "mathlib": []
   },
   "started": "2026-06-27T12:05:00.000Z",
-  "lastUpdate": "2026-06-27T12:05:00.000Z",
+  "lastUpdate": "2026-06-28T00:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Extends the already-verified three-moduli RNS set **{2ⁿ−1, 2ⁿ, 2ⁿ+1}** to four channels and proves a clean **parity dichotomy** for the fourth modulus — a genuine sharp-boundary result, not a cosmetic variant.

The natural fourth `(n+1)`-bit modulus has two candidates, `2^(n+1)+1` and `2^(n+1)−1`, and **exactly one is admissible depending on the parity of n**:

| n | admissible 4-moduli set | the other candidate fails because |
|---|---|---|
| **odd** | {2ⁿ−1, 2ⁿ, 2ⁿ+1, **2^(n+1)+1**} | `gcd(2ⁿ+1, 2^(n+1)−1) = 3` |
| **even** | {2ⁿ−1, 2ⁿ, 2ⁿ+1, **2^(n+1)−1**} | `gcd(2ⁿ−1, 2^(n+1)+1) = 3` |

The single obstruction is divisibility by 3, governed entirely by `2ⁿ mod 3` (= 2 for odd n, = 1 for even n, since `2 ≡ −1 (mod 3)`).

## What's new (Section VI — 22 theorems, 2 defs)

- `two_pow_mod_three_of_odd` / `two_pow_mod_three_of_even` — fix `2ⁿ mod 3`.
- `gcd_lowMersenne_extHigh_dvd_three`, `gcd_high_extMersenne_dvd_three` — the obstruction `gcd | 3`.
- Six coprimality lemmas for the new pairs (three per parity branch).
- `not_coprime_high_extMersenne_odd`, `not_coprime_lowMersenne_extHigh_even` — the **failing** (sharp-boundary) directions.
- `fourModuli_pairwise_coprime_odd` / `_even`, packaged as `RNSBase` instances `fourModuliBaseOdd` / `fourModuliBaseEven` (4 channels).
- Capstone `fourModuli_base_exists`: **every n ≥ 2 admits a valid four-channel base** (pick by parity).
- Concrete cross-checks: n=2 ({3,4,5,7} ✓, {3,4,5,9} ✗), n=3 ({7,8,9,17} ✓, {7,8,9,15} ✗), n=4 ({15,16,17,31} ✓).

## Verification

- `lake env lean Proofs/ChineseRemainderConstructiveOQ03OQ02.lean` — compiles clean, no errors/warnings.
- `#print axioms` on all new results = `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool` (small examples use kernel `decide`, not `native_decide`).
- File now **540 lines, 42 theorems, 5 defs, 0 sorry, 0 axiom**.

Gallery `meta.json`, research problem JSON, and `knowledge.md` updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)