### PR TITLE
audit(erdos-214-incomplete-01-oq-01): new entry verified CLEAN [0-axiom Tier A]

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25589,8 +25589,14 @@
       "lastAudited": "2026-06-28T09:14:57Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-214-incomplete-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-28T09:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-27T13:51:27Z"
+  "lastUpdated": "2026-06-28T09:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: erdos-214-incomplete-01-oq-01 (committed via #31193, missing from audit tracker)
**Result**: ✅ CLEAN — Tier A, no integrity issues

This PR persists the audit-tracker entry for a new gallery proof that was merged but never recorded by the auditor (a prior `claim-target.sh complete` silently no-op'd).

### Verification

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✅ |
| axioms | 0 | 0 (no `axiom`, no `native_decide`) | ✅ |
| True stubs | — | none (5 real theorems) | ✅ |
| theoremCount | 5 | 5 | ✅ |
| definitionCount | 4 | 4 | ✅ |
| lineCount | 127 | 127 | ✅ |

- **Not a Mathlib wrapper**: the core claim (the √2-scaled lattice is unit-distance-free) is proved independently via the integer-parity fact `2·(m²+k²) ≠ 1` (`omega`). Mathlib is used only for the `EuclideanSpace` distance-formula helpers (`EuclideanSpace.dist_eq`, `Real.sq_sqrt`).
- **Honest scoping**: title/status present this as the *non-vacuity witness* for Erdős #214, explicitly independent of the parent entry's axiomatized Juhász theorem — no overclaiming of #214 itself.
- `status: verified` / `badge: original` confirmed correct.

---
Discovered during gallery integrity audit (auditor cycle V58).