### PR TITLE
Enrich erdos-214-incomplete-01-oq-01: sections + annotations

### DIFF
--- a/src/data/proofs/erdos-214-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-214-incomplete-01-oq-01/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-framework-defs",
+    "proofId": "erdos-214-incomplete-01-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 71
+    },
+    "type": "definition",
+    "title": "The Plane, Unit-Distance-Free Sets, and the √2-Scaled Lattice",
+    "content": "The entry re-states the parent erdos-214 framework so it stands free of the axiomatized Juhász core:\n\n```lean\nabbrev Plane := EuclideanSpace ℝ (Fin 2)\ndef IsUnitDistanceFree (S : Set Plane) : Prop :=\n  ∀ p q : Plane, p ∈ S → q ∈ S → p ≠ q → dist p q ≠ 1\ndef ScaledLattice : Set Plane :=\n  {p | ∃ a b : ℤ, p 0 = Real.sqrt 2 * a ∧ p 1 = Real.sqrt 2 * b}\n```\n\nThe parent entry *defines* `ScaledLattice` as a candidate unit-distance-free example but proves nothing about it — leaving Problem #214's hypothesis formally unwitnessed. This entry closes exactly that gap.",
+    "mathContext": "A set $S \\subseteq \\mathbb{R}^2$ is *unit-distance-free* if no two distinct points are at Euclidean distance exactly $1$. The $\\sqrt 2$-scaled integer lattice is $\\sqrt 2 \\cdot \\mathbb{Z}^2 = \\{(\\sqrt 2\\, a, \\sqrt 2\\, b) : a, b \\in \\mathbb{Z}\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "unit-distance-free set",
+      "integer lattice",
+      "EuclideanSpace",
+      "Erdős #214"
+    ],
+    "prerequisites": [
+      "erdos-214",
+      "Euclidean geometry"
+    ]
+  },
+  {
+    "id": "ann-dist-eq-coords",
+    "proofId": "erdos-214-incomplete-01-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 79
+    },
+    "type": "technique",
+    "title": "Unfolding the Euclidean Norm to Pythagorean Coordinates",
+    "content": "```lean\ntheorem dist_eq_coords (p q : Plane) :\n    dist p q = Real.sqrt ((p 0 - q 0) ^ 2 + (p 1 - q 1) ^ 2) := by\n  unfold dist\n  rw [← dist_eq_norm, EuclideanSpace.dist_eq, Fin.sum_univ_two]\n  simp only [Real.dist_eq, sq_abs]\n```\n\nThe `EuclideanSpace ℝ (Fin 2)` distance is defined abstractly as a root-sum-of-squares over the index type. `EuclideanSpace.dist_eq` exposes that sum, `Fin.sum_univ_two` expands it to the two explicit coordinates, and `sq_abs` ($|x|^2 = x^2$) removes the absolute values, yielding the familiar planar formula. This reusable helper mirrors the parent's `dist_coords` and is the bridge from abstract Mathlib geometry to a hands-on algebraic computation.",
+    "mathContext": "On $\\mathbb{R}^2$, $\\operatorname{dist}(p, q) = \\sqrt{\\sum_{i} |p_i - q_i|^2} = \\sqrt{(p_0 - q_0)^2 + (p_1 - q_1)^2}$. The squared absolute value equals the square, so $|p_i - q_i|^2 = (p_i - q_i)^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Euclidean distance",
+      "EuclideanSpace.dist_eq",
+      "Fin.sum_univ_two",
+      "sq_abs"
+    ],
+    "prerequisites": [
+      "inner product spaces",
+      "Euclidean geometry"
+    ]
+  },
+  {
+    "id": "ann-arithmetic-core",
+    "proofId": "erdos-214-incomplete-01-oq-01",
+    "range": {
+      "startLine": 81,
+      "endLine": 87
+    },
+    "type": "insight",
+    "title": "The Parity Heart: 2·(m²+k²) Can Never Equal 1",
+    "content": "```lean\ntheorem two_mul_sq_add_sq_ne_one (m k : ℤ) :\n    2 * ((m : ℝ) ^ 2 + (k : ℝ) ^ 2) ≠ 1 := by\n  intro h\n  have hc : ((2 * (m ^ 2 + k ^ 2) : ℤ) : ℝ) = ((1 : ℤ) : ℝ) := by push_cast; linarith\n  have : 2 * (m ^ 2 + k ^ 2) = 1 := by exact_mod_cast hc\n  omega\n```\n\nThe entire geometric problem reduces to this one-line integer fact. The hypothetical equation lives over $\\mathbb{R}$, but both sides are images of integers; `push_cast` + `exact_mod_cast` transport it to $\\mathbb{Z}$, where `omega` instantly refutes it on parity (the left side is even, $1$ is odd). Reducing the geometry to a decidable integer statement is what keeps the whole proof elementary and axiom-free.",
+    "mathContext": "$2(m^2 + k^2)$ is even for every $m, k \\in \\mathbb{Z}$, while $1$ is odd — so the equation $2(m^2+k^2) = 1$ has no integer solutions. This is the squared-distance value $1$ being structurally excluded.",
+    "significance": "key",
+    "relatedConcepts": [
+      "parity",
+      "omega",
+      "exact_mod_cast",
+      "Diophantine impossibility"
+    ],
+    "prerequisites": [
+      "integer arithmetic",
+      "parity"
+    ]
+  },
+  {
+    "id": "ann-main-distance",
+    "proofId": "erdos-214-incomplete-01-oq-01",
+    "range": {
+      "startLine": 89,
+      "endLine": 116
+    },
+    "type": "technique",
+    "title": "Main Lemma: Squaring Away the Square Root via (√2)² = 2",
+    "content": "```lean\ntheorem scaledLattice_dist_ne_one {p q : Plane}\n    (hp : p ∈ ScaledLattice) (hq : q ∈ ScaledLattice) : dist p q ≠ 1\n```\n\nThe proof substitutes the lattice coordinates $p_0 = \\sqrt2\\,a$, etc., and uses the key identity $(\\sqrt2\\,a - \\sqrt2\\,a')^2 = (\\sqrt 2)^2 (a-a')^2 = 2(a-a')^2$ (`Real.sq_sqrt` gives $(\\sqrt2)^2 = 2$) to collapse the radicand to $2((a-a')^2 + (b-b')^2)$. Assuming the distance equals $1$, squaring both sides — again via `Real.sq_sqrt`, which needs the radicand non-negative (`positivity`) — produces $2((a-a')^2 + (b-b')^2) = 1$ over $\\mathbb{R}$, pushed to $\\mathbb{Z}$ and killed by the parity lemma. **No `p ≠ q` hypothesis is required**: equal points give distance $0$, distinct points give $\\sqrt{\\text{even} \\ge 2} > 1$.",
+    "mathContext": "Squared distance $= 2(a-a')^2 + 2(b-b')^2 = 2\\big((a-a')^2 + (b-b')^2\\big)$. If $\\sqrt{\\,\\cdot\\,} = 1$ then $(\\cdot) = 1$, i.e. $2((a-a')^2+(b-b')^2) = 1$ with $a-a', b-b' \\in \\mathbb{Z}$ — contradicting `two_mul_sq_add_sq_ne_one`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.sq_sqrt",
+      "lattice distance",
+      "positivity",
+      "proof by contradiction"
+    ],
+    "prerequisites": [
+      "real square roots",
+      "Euclidean geometry"
+    ]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "erdos-214-incomplete-01-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 127
+    },
+    "type": "insight",
+    "title": "Non-Vacuity: A Concrete Witness for Erdős #214",
+    "content": "```lean\ntheorem scaledLattice_unitDistanceFree : IsUnitDistanceFree ScaledLattice :=\n  fun p q hp hq _ => scaledLattice_dist_ne_one hp hq\n\ntheorem scaledLattice_nonempty : (0 : Plane) ∈ ScaledLattice := by\n  refine ⟨0, 0, ?_, ?_⟩ <;> simp\n```\n\nThe unit-distance-free property follows by simply *discarding* the `p ≠ q` argument of the main lemma (the distance is never $1$ regardless of distinctness). Together with inhabitedness (the origin, $a = b = 0$), this certifies that Erdős #214's hypothesis class is **non-empty**: there really exists a unit-distance-free planar set, so Juhász's theorem is not vacuously true. The parent entry's inert `ScaledLattice` definition becomes a concrete, machine-checked witness.",
+    "mathContext": "Non-vacuity matters because #214 / Juhász (1979) is a conditional statement about unit-distance-free $S$; an explicit such $S$ (here $\\sqrt2 \\cdot \\mathbb{Z}^2$, which is also dense enough to be a genuine example) guarantees the antecedent is satisfiable.",
+    "significance": "key",
+    "relatedConcepts": [
+      "non-vacuity",
+      "Juhász theorem",
+      "Erdős #214",
+      "concrete witness"
+    ],
+    "prerequisites": [
+      "erdos-214",
+      "logic of conditional theorems"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
@@ -86,6 +86,56 @@
       "The #214 framework (unit-distance-free sets)"
     ]
   },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and the Non-Vacuity Gap",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "File docstring explaining that the parent erdos-214 entry defines ScaledLattice = √2·ℤ² but never proves it unit-distance-free, leaving Problem #214's hypothesis unwitnessed; states the parity argument and the five results. Imports Mathlib only.",
+      "mathContext": "The squared distance between two lattice points is 2·((a-a')² + (b-b')²), an even integer, hence never 1. The entry is self-contained and independent of the axiomatized Juhász theorem."
+    },
+    {
+      "id": "framework-definitions",
+      "title": "Re-stated Framework: Plane, dist, IsUnitDistanceFree, ScaledLattice",
+      "startLine": 57,
+      "endLine": 71,
+      "summary": "Re-states the parent's Plane = EuclideanSpace ℝ (Fin 2), the distance dist p q = ‖p - q‖, the unit-distance-free predicate, and the √2-scaled lattice example set, so the entry stands free of the axiomatized core.",
+      "mathContext": "ScaledLattice = {p : ∃ a b ∈ ℤ, p₀ = √2·a ∧ p₁ = √2·b}. IsUnitDistanceFree S: no two distinct points of S are at distance exactly 1."
+    },
+    {
+      "id": "dist-formula",
+      "title": "The Coordinate Distance Formula",
+      "startLine": 73,
+      "endLine": 79,
+      "summary": "dist_eq_coords unfolds the Euclidean norm on Fin 2 into the Pythagorean two-coordinate form dist p q = √((p₀-q₀)² + (p₁-q₁)²), via EuclideanSpace.dist_eq and Fin.sum_univ_two.",
+      "mathContext": "On EuclideanSpace ℝ (Fin 2), ‖p - q‖ = √(Σᵢ |pᵢ - qᵢ|²) = √((p₀-q₀)² + (p₁-q₁)²) using sq_abs to drop the absolute values."
+    },
+    {
+      "id": "arithmetic-core",
+      "title": "The Arithmetic Core: 2·(m²+k²) ≠ 1",
+      "startLine": 81,
+      "endLine": 87,
+      "summary": "two_mul_sq_add_sq_ne_one proves the integer fact at the heart of the argument: 2·(m² + k²) = 1 is impossible because the left side is even. Cast back to ℤ, then omega refutes it by parity.",
+      "mathContext": "2·(m² + k²) is even for all integers m, k, while 1 is odd; omega discharges the parity contradiction after exact_mod_cast lands the equation in ℤ."
+    },
+    {
+      "id": "main-distance",
+      "title": "Main Lemma: Lattice Points Are Never at Distance 1",
+      "startLine": 89,
+      "endLine": 116,
+      "summary": "scaledLattice_dist_ne_one substitutes lattice coordinates into dist_eq_coords, uses (√2)² = 2 to collapse each squared coordinate difference to 2·(integer)², squares a hypothetical distance-1 equation via Real.sq_sqrt, and lands the contradiction through two_mul_sq_add_sq_ne_one. No p ≠ q hypothesis needed.",
+      "mathContext": "Radicand = 2·(a-a')² + 2·(b-b')² = 2·((a-a')² + (b-b')²); if its square root were 1, squaring gives 2·((a-a')²+(b-b')²) = 1, impossible. Real.sq_sqrt requires the non-negative radicand (positivity)."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries: Unit-Distance-Free and Inhabited",
+      "startLine": 118,
+      "endLine": 127,
+      "summary": "scaledLattice_unitDistanceFree is the immediate corollary that ScaledLattice satisfies IsUnitDistanceFree (so #214's hypothesis is non-vacuous); scaledLattice_nonempty records that the origin (a = b = 0) belongs to the set.",
+      "mathContext": "The unit-distance-free property follows by discarding the p ≠ q argument of scaledLattice_dist_ne_one; the origin witnesses inhabitedness with √2·0 = 0."
+    }
+  ],
   "conclusion": {
     "summary": "The √2-scaled integer lattice ScaledLattice = {(√2·a, √2·b) : a,b ∈ ℤ} is unit-distance-free: the squared distance between any two of its points is 2·((a-a')² + (b-b')²), an even integer never equal to 1. This makes the hypothesis of Erdős #214 non-vacuous with a concrete witness, and it is verified independently of the axiomatized Juhász theorem (0 axioms, 0 sorries).",
     "implications": "This closes a real gap in the parent erdos-214 entry, whose ScaledLattice example was defined but never shown to satisfy the unit-distance-free property. The result certifies that #214's hypothesis class is non-empty (so the theorem is not vacuously true) and provides reusable elementary infrastructure — the coordinate distance formula and the 2·(m²+k²) ≠ 1 parity lemma — for further lattice/geometry formalizations in the gallery.",


### PR DESCRIPTION
Enrichment pass for `erdos-214-incomplete-01-oq-01` (passes: 0, quality: 33).

## Gaps addressed
The entry had a rich `meta.json` (with `overview`, `conclusion`, `crossReferences`) but **no `sections` array** and **no `annotations.json`**.

## Changes
- **Added `sections`** to meta.json — 6 sections covering all 127 lines (header/non-vacuity gap, re-stated framework, coordinate distance formula, the 2·(m²+k²)≠1 arithmetic core, the main distance-≠-1 lemma, and the corollaries).
- **Added `annotations.json`** — 5 annotations:
  1. The Plane / IsUnitDistanceFree / ScaledLattice framework
  2. `dist_eq_coords` — unfolding the Euclidean norm to Pythagorean coordinates
  3. The parity heart `two_mul_sq_add_sq_ne_one` (2·(m²+k²)≠1 via omega)
  4. The main lemma — squaring away √ via (√2)²=2, no `p ≠ q` needed
  5. Non-vacuity: a concrete machine-checked witness for #214's hypothesis
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
- Both JSON files valid; within all size caps; all annotation line ranges align with Lean constructs (`annotations:build` clean for this entry).
- Axiom integrity preserved: `verified`/`original`/0 axioms is accurate — the result is independent of the parent's axiomatized Juhász theorem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)