### PR TITLE
research(egorov-theorem-oq-01-oq-03): integral-side face — marching mass escapes to infinity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/EgorovTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/EgorovTheoremOQ01OQ03.lean
@@ -131,4 +131,33 @@ theorem marching_not_tendstoUniformlyOn_univ :
     (s := (∅ : Set ℝ)) (by simp)
   rwa [Set.compl_empty] at h
 
+/-! ## The same counterexample, seen through integrals: mass escaping to infinity
+
+The marching indicators converge to `0` at every point, yet each one carries a *fixed
+unit of mass* that simply slides off to `+∞`. This is the integral-side face of the very
+same infinite-measure pathology that defeats Egorov: on a finite-measure space Egorov
+would force uniform convergence off a small set and hence control the integrals, but here
+the integrals stay pinned at `1` while the pointwise limit is `0`. So `(ℝ, vol)` also
+witnesses the failure of the limit–integral interchange `lim ∫ fₙ ≠ ∫ lim fₙ`. -/
+
+/-- Each marching indicator integrates to exactly `1`: it is the indicator of a unit-length
+interval, whose Lebesgue measure is `1`. The mass is conserved for every `n` even as the
+bump marches off to `+∞`. -/
+theorem marching_integral_eq_one (n : ℕ) :
+    ∫ x, marching n x ∂volume = 1 := by
+  have hmar : marching n = Set.indicator (Set.Icc (n : ℝ) (n + 1)) (fun _ => (1 : ℝ)) := rfl
+  rw [hmar, integral_indicator measurableSet_Icc, setIntegral_const,
+    Real.volume_real_Icc_of_le (by linarith : (n : ℝ) ≤ (n : ℝ) + 1), smul_eq_mul]
+  ring
+
+/-- **Mass escapes to infinity.** Although `fₙ → 0` everywhere (`marching_tendsto_zero`), the
+integrals `∫ fₙ = 1` do *not* tend to `0 = ∫ (lim fₙ)`: the same marching counterexample that
+breaks Egorov's finite-measure hypothesis also breaks the limit–integral interchange on
+`(ℝ, vol)`. The integral sequence is constantly `1`, so it converges to `1 ≠ 0`. -/
+theorem marching_integral_not_tendsto_zero :
+    ¬ Tendsto (fun n => ∫ x, marching n x ∂volume) atTop (𝓝 (0 : ℝ)) := by
+  simp only [marching_integral_eq_one]
+  rw [tendsto_const_nhds_iff]
+  norm_num
+
 end EgorovTheoremOQ01OQ03

--- a/research/problems/egorov-theorem-oq-01-oq-03/knowledge.md
+++ b/research/problems/egorov-theorem-oq-01-oq-03/knowledge.md
@@ -18,8 +18,23 @@ admits no finite-measure set off which the convergence is uniform.
 
 ## Status: COMPLETED (verified, 0-axiom)
 
-Proved in `proofs/Proofs/EgorovTheoremOQ01OQ03.lean` (134 lines, 4 theorems,
+Proved in `proofs/Proofs/EgorovTheoremOQ01OQ03.lean` (163 lines, 6 theorems,
 1 definition, 0 sorries, 0 axioms — only `propext`/`Classical.choice`/`Quot.sound`).
+
+---
+
+## Session 2026-06-28 (researcher-3) — integral-side face (mass escape)
+
+Added the integral reading of the same marching counterexample (SOLVED → looked outward):
+- `marching_integral_eq_one (n) : ∫ marching n = 1` — each bump has unit mass.
+- `marching_integral_not_tendsto_zero` — `∫ fₙ = 1 ↛ 0 = ∫(lim fₙ)`, so the same
+  example also breaks the limit–integral interchange on `(ℝ, vol)`. Constant-1 integral
+  sequence converges to 1 ≠ 0 via `tendsto_const_nhds_iff`.
+
+GOTCHA: `setIntegral_const` yields `volume.real (Icc ..)` (the `Measure.real` form), NOT
+`(volume ..).toReal` syntactically — `Real.volume_Icc` does not match. Use
+`Real.volume_real_Icc_of_le (h : a ≤ b) : volume.real (Icc a b) = b - a`, then
+`smul_eq_mul; ring`.
 
 ---
 

--- a/src/data/proofs/egorov-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/egorov-theorem-oq-01-oq-03/meta.json
@@ -14,9 +14,9 @@
       "Topology"
     ],
     "namespace": "EgorovTheoremOQ01OQ03",
-    "lineCount": 134,
+    "lineCount": 163,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 6,
     "definitionCount": 1,
     "path": "Proofs/EgorovTheoremOQ01OQ03.lean",
     "sorries": 0
@@ -39,8 +39,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 134,
-    "theoremCount": 4,
+    "lineCount": 163,
+    "theoremCount": 6,
     "definitionCount": 1,
     "badge": "verified",
     "originalContributions": [
@@ -48,7 +48,9 @@
       "marching_tendsto_zero: the marching indicators fₙ = 𝟙_[n,n+1] converge to 0 at EVERY point of ℝ (not merely a.e.) — for a fixed x, once n > x the bump [n,n+1] has marched past x, so fₙ(x) = 0 eventually. This is the everywhere-pointwise convergence that makes the failure of uniformity striking.",
       "volume_finite_hypothesis_essential: packaging the obstruction as a single non-existence statement — there is no finite-measure set s with fₙ → 0 uniformly off s, despite everywhere-pointwise convergence.",
       "marching_not_tendstoUniformlyOn_univ: the s = ∅ corollary — fₙ does not converge uniformly to 0 on all of ℝ, the cleanest one-line statement of non-uniformity on the infinite-measure space.",
-      "marching: the marching-indicator construction 𝟙_[n,n+1] on ℝ as a Set.indicator, the unit bump that marches to +∞."
+      "marching: the marching-indicator construction 𝟙_[n,n+1] on ℝ as a Set.indicator, the unit bump that marches to +∞.",
+      "marching_integral_eq_one: each marching indicator integrates to exactly 1 (∫ 𝟙_[n,n+1] = vol[n,n+1] = 1) — the unit of mass is conserved for every n even as the bump escapes to +∞.",
+      "marching_integral_not_tendsto_zero: the SAME counterexample breaks the limit–integral interchange — although fₙ → 0 everywhere, ∫ fₙ = 1 ↛ 0 = ∫(lim fₙ). This exhibits the integral-side face of the infinite-measure pathology (mass escaping to infinity): on a finite-measure space Egorov would force uniform convergence off a small set and hence control the integrals."
     ],
     "prerequisites": [
       "Metric.tendstoUniformlyOn_iff: the ε-characterization of uniform convergence on a set, used to refute uniformity at ε = 1/2",
@@ -77,6 +79,21 @@
         "theorem": "measure_mono",
         "description": "Monotonicity of an (outer) measure: s ⊆ t ⇒ μ s ≤ μ t, with no measurability hypothesis on s. Lets the obstruction hold for arbitrary finite-measure s, not just measurable ones.",
         "module": "Mathlib.MeasureTheory.Measure.MeasureSpace"
+      },
+      {
+        "theorem": "MeasureTheory.integral_indicator",
+        "description": "∫ x, (s.indicator f) x ∂μ = ∫ x in s, f x ∂μ for measurable s. Reduces ∫ marching n to a set integral over [n,n+1], used to compute ∫ fₙ = 1.",
+        "module": "Mathlib.MeasureTheory.Integral.SetIntegral"
+      },
+      {
+        "theorem": "Real.volume_real_Icc_of_le",
+        "description": "volume.real (Icc a b) = b - a for a ≤ b. Gives vol[n,n+1] = 1, so each marching indicator has integral exactly 1 even as the bump escapes to +∞.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
+      },
+      {
+        "theorem": "tendsto_const_nhds_iff",
+        "description": "For a nontrivial filter, the constant sequence c → a iff c = a. Since ∫ fₙ ≡ 1, the integral sequence converges to 1 ≠ 0, refuting lim ∫ fₙ = ∫ lim fₙ.",
+        "module": "Mathlib.Topology.Order.Basic"
       }
     ]
   },
@@ -152,8 +169,8 @@
   ],
   "sorries": 0,
   "conclusion": {
-    "summary": "The finite-measure hypothesis in Egorov's theorem is essential. On (ℝ, Lebesgue) the marching indicators fₙ = 𝟙_[n,n+1] converge to 0 at every point (marching_tendsto_zero), yet for any set s of finite Lebesgue measure they fail to converge uniformly to 0 on sᶜ (marching_not_tendstoUniformlyOn_of_volume_lt_top): uniform 1/2-control off s would force the infinite-measure tail [N,∞) into s. Packaged as volume_finite_hypothesis_essential (no finite-measure exceptional set exists) and marching_not_tendstoUniformlyOn_univ (non-uniformity on all of ℝ). 134 lines, 4 theorems, 1 definition, 0 axioms, 0 sorries.",
-    "implications": "Together with the parent entry — which shows the removed exceptional set cannot be taken null on a finite-measure example — this delimits Egorov's theorem from both sides: the conclusion needs a genuinely positive exceptional set, and the hypothesis needs genuinely finite total measure. The counterexample is original to the gallery; Mathlib has the theorem but not the sharpness witness.",
+    "summary": "The finite-measure hypothesis in Egorov's theorem is essential. On (ℝ, Lebesgue) the marching indicators fₙ = 𝟙_[n,n+1] converge to 0 at every point (marching_tendsto_zero), yet for any set s of finite Lebesgue measure they fail to converge uniformly to 0 on sᶜ (marching_not_tendstoUniformlyOn_of_volume_lt_top): uniform 1/2-control off s would force the infinite-measure tail [N,∞) into s. Packaged as volume_finite_hypothesis_essential (no finite-measure exceptional set exists) and marching_not_tendstoUniformlyOn_univ (non-uniformity on all of ℝ). The same construction is read through integrals: each fₙ has integral 1 (marching_integral_eq_one), so ∫ fₙ = 1 ↛ 0 = ∫(lim fₙ) (marching_integral_not_tendsto_zero) — the mass-escaping-to-infinity, integral-side face of the infinite-measure pathology. 163 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "Together with the parent entry — which shows the removed exceptional set cannot be taken null on a finite-measure example — this delimits Egorov's theorem from both sides: the conclusion needs a genuinely positive exceptional set, and the hypothesis needs genuinely finite total measure. The integral view links the failure to the failure of the limit–integral interchange (and dominated/bounded convergence) on infinite-measure spaces: a single escaping unit of mass defeats both. The counterexample is original to the gallery; Mathlib has the theorem but not the sharpness witness.",
     "openQuestions": []
   }
 }


### PR DESCRIPTION
## Summary

Extends the verified gallery entry **Sharpness of Egorov: the Finite-Measure Hypothesis is Essential** (`egorov-theorem-oq-01-oq-03`). The marching indicators `fₙ = 𝟙_[n,n+1]` converge to `0` everywhere yet admit no finite-measure set off which the convergence is uniform. This PR reads the *same* counterexample through integrals, exhibiting the mass-escaping-to-infinity face of the infinite-measure pathology.

| Theorem | Statement |
|---------|-----------|
| `marching_integral_eq_one` | `∫ x, fₙ x ∂vol = 1` for every `n` (the indicator of a unit-length interval) |
| `marching_integral_not_tendsto_zero` | `∫ fₙ = 1 ↛ 0 = ∫(lim fₙ)` — the limit–integral interchange fails |

Although `fₙ → 0` at every point (`marching_tendsto_zero`), each bump carries a conserved unit of mass that simply slides off to `+∞`, so the integrals stay pinned at `1`. This is the integral-side companion to the uniform-convergence obstruction: on a *finite*-measure space Egorov would force uniform convergence off a small set and hence control the integrals — the same finiteness failure breaks both Egorov and the limit–integral interchange (and dominated/bounded convergence).

## Verification

- `134 → 163` lines, `4 → 6` theorems, **still 0 axioms / 0 sorries**.
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only.
- Host-verified with single-file `lake env lean Proofs/EgorovTheoremOQ01OQ03.lean` (exit 0, clean).

Note: `setIntegral_const` produces the `Measure.real` form `volume.real (Icc …)`, not `(volume …).toReal` syntactically; the integral is computed with `Real.volume_real_Icc_of_le`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)