### PR TITLE
research(erdos-1007-oq-04): chromatic-number bound dim(G) ≤ χ(G) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1007OQ04.lean
+++ b/proofs/Proofs/Erdos1007OQ04.lean
@@ -244,6 +244,50 @@ theorem hasUnitEmbedding_two_mul_edges {V : Type*} [Fintype V] [DecidableEq V]
       _ ≤ ∑ v, G.degree v := Finset.sum_le_sum_of_subset (Finset.subset_univ _)
   exact hasUnitEmbedding_mono hle hbase
 
+/-! ## The chromatic-number bound: dimension ≤ χ(G)
+
+The index-embedding engine `hasUnitEmbedding_of_idx` asks exactly for an index map
+that sends adjacent vertices to *distinct* coordinates — i.e. a **proper coloring**.
+So a proper `N`-coloring embeds the graph in `ℝ^N`, and the dimension is bounded by
+the chromatic number `χ(G)`. Since `χ(G) ≤ |V|` (and `χ(G)` can be far smaller — `2`
+for any bipartite graph), this strictly refines the universal bound `dim ≤ |V|`:
+a graph of low chromatic number has low dimension regardless of how many vertices
+*or edges* it has. -/
+
+/-- A proper `Fin N`-coloring is precisely a separating index map, so it yields a
+    unit-distance embedding in `ℝ^N`. -/
+theorem hasUnitEmbedding_of_coloring {V : Type*} {N : ℕ}
+    (G : SimpleGraph V) (C : G.Coloring (Fin N)) :
+    hasUnitEmbedding V G.Adj N :=
+  hasUnitEmbedding_of_idx (fun v => C v) (fun _ _ huv => C.valid huv)
+
+/-- If `G` is `N`-colorable then it embeds as unit distances in `ℝ^N`. -/
+theorem hasUnitEmbedding_of_colorable {V : Type*} {N : ℕ}
+    (G : SimpleGraph V) (h : G.Colorable N) :
+    hasUnitEmbedding V G.Adj N :=
+  h.elim (hasUnitEmbedding_of_coloring G)
+
+/-- **Chromatic-number bound.** Whenever the chromatic number satisfies `χ(G) ≤ N`,
+    the graph embeds in `ℝ^N`. Hence the dimension is at most the chromatic number. -/
+theorem hasUnitEmbedding_of_chromaticNumber_le {V : Type*} {N : ℕ}
+    (G : SimpleGraph V) (h : G.chromaticNumber ≤ N) :
+    hasUnitEmbedding V G.Adj N :=
+  hasUnitEmbedding_of_colorable G (G.chromaticNumber_le_iff_colorable.mp h)
+
+/-- For a finite graph the chromatic number is realized: `G` embeds in `ℝ^{χ(G)}`. -/
+theorem hasUnitEmbedding_chromaticNumber {V : Type*} [Finite V] (G : SimpleGraph V) :
+    hasUnitEmbedding V G.Adj (ENat.toNat G.chromaticNumber) :=
+  hasUnitEmbedding_of_colorable G G.colorable_chromaticNumber_of_fintype
+
+/-- **Bipartite graphs embed in the plane.** Any `2`-colorable graph (in particular
+    every bipartite graph) has a unit-distance embedding in `ℝ²` — its dimension is at
+    most `2`, however large its vertex or edge count. This is the chromatic bound at its
+    sharpest contrast with the edge-count bound `dim ≤ 2m`. -/
+theorem hasUnitEmbedding_two_of_colorable_two {V : Type*}
+    (G : SimpleGraph V) (h : G.Colorable 2) :
+    hasUnitEmbedding V G.Adj 2 :=
+  hasUnitEmbedding_of_colorable G h
+
 end Erdos1007OQ04
 
 /-!
@@ -260,6 +304,11 @@ For the dimension of a graph on `n` vertices and `m` edges:
   `dim ≤ 2m`** — only the non-isolated vertices matter, so a sparse graph has low dimension
   irrespective of `n`. This is the rigorous form of "sparse graphs cannot have *arbitrarily*
   high dimension": their dimension is tied to the edge count, not the vertex count.
+- `hasUnitEmbedding_of_coloring` / `hasUnitEmbedding_of_chromaticNumber_le` /
+  `hasUnitEmbedding_chromaticNumber`: **chromatic-number bound `dim ≤ χ(G)`** — the
+  separating index map of the embedding engine *is* a proper coloring. Since `χ(G) ≤ |V|`
+  (and is often far smaller), this refines `dim ≤ |V|`; e.g. every bipartite graph embeds
+  in `ℝ²` (`hasUnitEmbedding_two_of_colorable_two`), no matter how many vertices or edges.
 
 **Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
 -/

--- a/research/problems/erdos-1007-oq-04/knowledge.md
+++ b/research/problems/erdos-1007-oq-04/knowledge.md
@@ -1,0 +1,50 @@
+# erdos-1007-oq-04 — knowledge
+
+Max dimension of a graph on n vertices and m edges (unit-distance / Euclidean
+graph dimension). Parent's 4th open question; deep extremal geometry (House 2013)
+not formalized. The gallery file `Erdos1007OQ04.lean` proves the clean bounds.
+
+## Status
+VERIFIED (extended). 0 sorry / 0 axiom, no native_decide.
+
+## Session 2026-06-28 (researcher-1): chromatic-number bound dim(G) ≤ χ(G)
+
+SOLVED-strategy on an already-verified entry → looked outward. The entry already
+had: subgraph monotonicity, universal bound dim ≤ |V| (`hasUnitEmbedding_card`),
+and edge-count bound dim ≤ 2m (`hasUnitEmbedding_two_mul_edges`).
+
+### Key observation
+The embedding engine `hasUnitEmbedding_of_idx` asks for an index map
+`idx : V → Fin N` with `idx u ≠ idx v` for every edge — that is **exactly a proper
+N-coloring**. So a proper coloring with N colors embeds the graph in ℝᴺ (all
+vertices of one color sit on the same scaled basis vector; edges go between colors
+so they are at distance 1; non-edges are unconstrained). Hence:
+
+**dim(G) ≤ χ(G).**
+
+Since χ(G) ≤ |V| (often far smaller), this strictly refines `dim ≤ |V|`. Sharpest
+contrast with `dim ≤ 2m`: every **bipartite** graph (χ = 2) embeds in ℝ², no matter
+how many vertices or edges it has.
+
+### New theorems (5)
+- `hasUnitEmbedding_of_coloring` (G.Coloring (Fin N) → embed N) — one-liner over the engine via `Coloring.valid`.
+- `hasUnitEmbedding_of_colorable` (G.Colorable N → embed N).
+- `hasUnitEmbedding_of_chromaticNumber_le` (χ(G) ≤ N → embed N) via `chromaticNumber_le_iff_colorable`.
+- `hasUnitEmbedding_chromaticNumber` (Finite V → embed in ℝ^{ENat.toNat χ}) via `colorable_chromaticNumber_of_fintype`.
+- `hasUnitEmbedding_two_of_colorable_two` (bipartite ⇒ dim ≤ 2).
+
+### Mathlib API used
+- `SimpleGraph.Coloring α := G →g completeGraph α`; apply as `C v`; `Coloring.valid : G.Adj v w → C v ≠ C w`.
+- `Colorable n := Nonempty (G.Coloring (Fin n))`.
+- `chromaticNumber_le_iff_colorable {n:ℕ} : G.chromaticNumber ≤ n ↔ G.Colorable n`.
+- `colorable_chromaticNumber_of_fintype [Finite V] : G.Colorable (ENat.toNat G.chromaticNumber)`.
+
+### Verification
+`lake env lean Proofs/Erdos1007OQ04.lean` clean; `#print axioms` on all new
+theorems = [propext, Classical.choice, Quot.sound] only. File 314 lines,
+11 theorems, 0 sorry / 0 axiom.
+
+### Possible follow-ups (Seeker)
+- The genuinely open/sharp content is the LOWER side: a sparse graph realizing
+  dimension close to its edge-count or chromatic bound (House 2013 constructions).
+- Relate the three bounds: dim ≤ min(|V|, 2m, χ(G)); when is each tight?

--- a/src/data/proofs/erdos-1007-oq-04/meta.json
+++ b/src/data/proofs/erdos-1007-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1007-oq-04",
   "title": "The Maximum Dimension of a Graph on n Vertices and m Edges: Monotonicity and the Edge-Count Bound",
   "slug": "erdos-1007-oq-04",
-  "description": "Toward the parent's fourth open question — the maximum graph (Euclidean) dimension as a function of both the vertex count n and the edge count m — this entry proves the two clean, fully-verified bounds available without the deep extremal geometry of House (2013): (1) subgraph monotonicity, so deleting edges never raises the dimension and the maximum over n-vertex graphs is attained by Kₙ (giving n−1 with the simplex bound); and (2) an edge-count upper bound, dim(G) ≤ 2·|E(G)|, proved via a vertex-support embedding and the handshake lemma — only non-isolated vertices cost dimension, so a sparse graph cannot have dimension much larger than its edge count regardless of how many isolated vertices it has.",
+  "description": "Toward the parent's fourth open question — the maximum graph (Euclidean) dimension as a function of both the vertex count n and the edge count m — this entry proves the two clean, fully-verified bounds available without the deep extremal geometry of House (2013): (1) subgraph monotonicity, so deleting edges never raises the dimension and the maximum over n-vertex graphs is attained by Kₙ (giving n−1 with the simplex bound); and (2) an edge-count upper bound, dim(G) ≤ 2·|E(G)|, proved via a vertex-support embedding and the handshake lemma — only non-isolated vertices cost dimension, so a sparse graph cannot have dimension much larger than its edge count regardless of how many isolated vertices it has. A new chromatic-number bound dim(G) ≤ χ(G) is added: the embedding engine's edge-separating index map is exactly a proper coloring, so an N-coloring embeds G in ℝᴺ; since χ(G) ≤ |V| this refines the universal bound (e.g. every bipartite graph embeds in ℝ²).",
   "meta": {
     "author": "Paul Erdős (problem #1007); formalized in Lean 4",
     "date": "2026",
@@ -20,15 +20,16 @@
     "badge": "verified",
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 265,
-    "theoremCount": 6,
+    "lineCount": 314,
+    "theoremCount": 11,
     "definitionCount": 3,
     "originalContributions": [
       "hasUnitEmbedding_of_idx: a single reusable engine — placing vertex v at the scaled basis vector (1/√2)·e_{idx v} gives a unit-distance embedding in ℝᴺ whenever the index map idx separates the endpoints of every edge (distinct scaled basis vectors are at distance exactly 1).",
       "hasUnitEmbedding_restrict: subgraph monotonicity — any unit embedding of a graph restricts to every subgraph, so the dimension is monotone under edge addition and the maximum over a fixed vertex set is realized by the complete graph.",
       "hasUnitEmbedding_card: the universal bound dim(G) ≤ |V| for every loopless graph (index all vertices injectively); with dim(Kₙ)=n−1 from Erdos1007OQ01 this pins the maximum dimension on n vertices at exactly n−1.",
       "hasUnitEmbedding_of_cover: an edge-cover bound — if a finite set S contains both endpoints of every edge, the graph embeds in ℝ^{|S|}; isolated vertices are sent to the origin and cost nothing.",
-      "hasUnitEmbedding_two_mul_edges: the edge-count bound dim(G) ≤ 2·|E(G)| for finite simple graphs, via the handshake lemma (∑ degrees = 2m) bounding the support size, independent of |V| — the rigorous form of 'a sparse graph has low dimension'."
+      "hasUnitEmbedding_two_mul_edges: the edge-count bound dim(G) ≤ 2·|E(G)| for finite simple graphs, via the handshake lemma (∑ degrees = 2m) bounding the support size, independent of |V| — the rigorous form of 'a sparse graph has low dimension'.",
+      "hasUnitEmbedding_of_coloring / hasUnitEmbedding_of_chromaticNumber_le / hasUnitEmbedding_chromaticNumber: the chromatic-number bound dim(G) ≤ χ(G). The embedding engine's separating index map IS a proper coloring, so an N-coloring embeds G in ℝᴺ; with χ(G) ≤ |V| this strictly refines the universal bound, and for finite G the chromatic value is realized. Corollary hasUnitEmbedding_two_of_colorable_two: every bipartite (2-colorable) graph embeds in ℝ², regardless of vertex/edge count."
     ],
     "prerequisites": [
       "Unit-distance embeddings of graphs and the graph (Euclidean) dimension",
@@ -94,10 +95,18 @@
       "endLine": 240,
       "summary": "hasUnitEmbedding_card (dim ≤ |V|), hasUnitEmbedding_of_cover (dim ≤ |S| for an edge cover), hasUnitEmbedding_two_mul_edges (dim ≤ 2m via the handshake lemma).",
       "mathContext": "Dimension is bounded by the vertex count and, more finely, by twice the edge count."
+    },
+    {
+      "id": "chromatic-bound",
+      "title": "The Chromatic-Number Bound",
+      "startLine": 247,
+      "endLine": 289,
+      "mathContext": "A proper coloring is a separating index map, so the dimension is bounded by the chromatic number χ(G) ≤ |V|.",
+      "summary": "hasUnitEmbedding_of_coloring (an N-coloring embeds G in ℝᴺ), hasUnitEmbedding_of_chromaticNumber_le (dim ≤ χ when χ ≤ N), hasUnitEmbedding_chromaticNumber (finite G embeds in ℝ^{χ(G)}), hasUnitEmbedding_two_of_colorable_two (bipartite ⇒ dim ≤ 2)."
     }
   ],
   "conclusion": {
-    "summary": "For the dimension of a graph on n vertices and m edges, this entry proves subgraph monotonicity (so the maximum over n vertices is the complete graph's, n−1) and the edge-count bound dim(G) ≤ 2·|E(G)| (so a sparse graph has dimension tied to its edge count, not its vertex count).",
+    "summary": "For the dimension of a graph on n vertices and m edges, this entry proves subgraph monotonicity (so the maximum over n vertices is the complete graph's, n−1) and the edge-count bound dim(G) ≤ 2·|E(G)| (so a sparse graph has dimension tied to its edge count, not its vertex count). In addition, the dimension is bounded by the chromatic number: dim(G) ≤ χ(G) ≤ |V|, since a proper coloring is exactly a separating index map — so e.g. every bipartite graph embeds in ℝ².",
     "implications": "Monotonicity makes 'maximum dimension on n vertices = n−1' rigorous once Kₙ's simplex dimension is known, and shows adding edges can only increase dimension. The edge-count bound formalizes the intuition behind the open question's remark that 'sparse graphs may also have high dimension' by capping that dimension at 2m: high dimension forces many edges. Together they bracket the (n,m) extremal function from both sides.",
     "openQuestions": [
       "Determine the sharp maximum dimension as a function of (n, m), beyond the n−1 and 2m brackets — the heart of the open question.",
@@ -130,11 +139,17 @@
       "Finset"
     ],
     "namespace": "Erdos1007OQ04",
-    "lineCount": 265,
+    "lineCount": 314,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 11,
     "definitionCount": 3,
     "mainTheorems": [
+      {
+        "name": "hasUnitEmbedding_of_chromaticNumber_le",
+        "description": "Chromatic-number bound: if χ(G) ≤ N the graph embeds in ℝᴺ, so dim(G) ≤ χ(G)",
+        "leanType": "{V : Type*} → {N : ℕ} → (G : SimpleGraph V) → G.chromaticNumber ≤ N → hasUnitEmbedding V G.Adj N",
+        "type": "key"
+      },
       {
         "name": "hasUnitEmbedding_two_mul_edges",
         "type": "core",
@@ -181,6 +196,11 @@
       "type": "key",
       "description": "Universal bound dim ≤ |V| via distinct scaled basis vectors",
       "leanType": "(V : Type*) → [Fintype V] → [DecidableEq V] → (adj : V → V → Prop) → (∀ v, ¬ adj v v) → hasUnitEmbedding V adj (Fintype.card V)"
+    },
+    {
+      "name": "hasUnitEmbedding_of_chromaticNumber_le",
+      "statement": "If χ(G) ≤ N then G has a unit-distance embedding in ℝᴺ; the dimension is bounded by the chromatic number.",
+      "significance": "Refines dim ≤ |V| (since χ ≤ |V|) and dim ≤ 2m; e.g. bipartite graphs embed in ℝ²."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

Adds a new, strictly sharper bound to the verified graph-dimension entry **erdos-1007-oq-04** (max dimension of a graph on n vertices and m edges): the **chromatic-number bound**

> **dim(G) ≤ χ(G).**

### The observation

The entry's embedding engine `hasUnitEmbedding_of_idx` asks for an index map `idx : V → Fin N` with `idx u ≠ idx v` for every edge — which is **exactly a proper N-coloring**. So a proper N-coloring places each color class on a single scaled basis vector, making every edge a unit distance, and embeds G in ℝᴺ. Hence the dimension is bounded by the chromatic number.

Since `χ(G) ≤ |V|` (and is frequently far smaller), this strictly refines the existing universal bound `dim ≤ |V|`. Sharpest contrast with the existing edge-count bound `dim ≤ 2m`: **every bipartite graph (χ = 2) embeds in ℝ²**, regardless of how many vertices or edges it has.

## New theorems (5)

- `hasUnitEmbedding_of_coloring` — a `G.Coloring (Fin N)` yields an embedding in ℝᴺ (one line over the engine via `Coloring.valid`).
- `hasUnitEmbedding_of_colorable` — `G.Colorable N → dim ≤ N`.
- `hasUnitEmbedding_of_chromaticNumber_le` — `χ(G) ≤ N → dim ≤ N` (via `chromaticNumber_le_iff_colorable`).
- `hasUnitEmbedding_chromaticNumber` — finite G embeds in ℝ^{χ(G)} (via `colorable_chromaticNumber_of_fintype`).
- `hasUnitEmbedding_two_of_colorable_two` — bipartite ⇒ dim ≤ 2.

## Verification

- `lake env lean Proofs/Erdos1007OQ04.lean` — compiles clean, no errors/warnings.
- `#print axioms` on all new results = `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.
- File now **314 lines, 11 theorems, 0 sorry, 0 axiom**.

Gallery `meta.json` and `knowledge.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)