### PR TITLE
Enrich erdos-128 #128 hereditary-cliquefree: add index.ts, annotations, sections

### DIFF
--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "erdos128-wip01oq01oq01oq01oq01-ann-header",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "context",
+    "title": "Connecting hereditarity to the forbidden-subgraph framework",
+    "content": "Erdős Problem #128 ($250, open) asks whether forcing every ⌊n/2⌋-vertex induced subgraph to span more than n²/50 edges guarantees a triangle, with the constant 1/50 conjectured optimal via balanced blow-ups of C₅. Because the hypothesis is imposed on every large induced subgraph, a candidate extremal construction must keep its triangle-/clique-freeness on every vertex subset — i.e. hereditarily. The #128 chain built the forbidden-subgraph framework (homFree, blowup, C₅) and, separately, hereditary triangle-freeness (Graph.induce). This entry unifies them: the entire homFree relation is hereditary because the inclusion of an induced subgraph is a graph homomorphism.",
+    "mathContext": "A graph property $P$ is **hereditary** if $P(G)$ and $S \\subseteq V(G)$ imply $P(G[S])$.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey–Turán theory", "hereditary property", "C₅ blow-up", "extremal graph theory"],
+    "prerequisites": ["graph theory", "extremal combinatorics"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01oq01-ann-induce",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 65, "endLine": 71 },
+    "type": "definition",
+    "title": "Induced subgraph: keep only edges inside S",
+    "content": "Graph.induce S keeps every vertex of Fin n but retains an edge u–v only when both endpoints lie in the subset S. Symmetry and irreflexivity are inherited directly from the parent graph. Crucially, induction never adds an edge: every edge of G.induce S is already an edge of G. That one-directional fact is the entire engine of hereditarity below.",
+    "mathContext": "$(G.\\mathrm{induce}\\,S).\\mathrm{adj}\\,u\\,v := u \\in S \\wedge v \\in S \\wedge G.\\mathrm{adj}\\,u\\,v$.",
+    "significance": "key",
+    "relatedConcepts": ["induced subgraph", "vertex-deleted subgraph", "monotone property"],
+    "prerequisites": ["graph theory"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01oq01-ann-homfree",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 72, "endLine": 82 },
+    "type": "definition",
+    "title": "Forbidden-subgraph freeness via homomorphic copies",
+    "content": "IsHom is an edge-preserving map; G has a homomorphic copy of F (hasHomCopy) when some homomorphism φ : F → G exists, with no injectivity demanded. homFree F G is the absence of any such copy. Working with homomorphic copies rather than injective embeddings is what makes the pullback below purely formal — the same generic statement covers triangles, cliques, and any other forbidden F.",
+    "mathContext": "$\\mathrm{homFree}\\,F\\,G := \\neg\\,\\exists\\,\\varphi : \\mathrm{Fin}\\,m \\to \\mathrm{Fin}\\,n,\\ \\forall u\\,v,\\ F.\\mathrm{adj}\\,u\\,v \\to G.\\mathrm{adj}\\,(\\varphi u)\\,(\\varphi v)$.",
+    "significance": "important",
+    "relatedConcepts": ["graph homomorphism", "forbidden subgraph", "homomorphism density"],
+    "prerequisites": ["graph theory"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01oq01-ann-pullback",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 84, "endLine": 90 },
+    "type": "theorem",
+    "title": "homFree_of_hom — the parent's pullback principle",
+    "content": "The structural lemma reused from the parent: a homomorphism f : G → H into an F-free H makes G itself F-free, because a copy φ : F → G composes with f to give a copy f ∘ φ : F → H, contradicting H's freeness. No irreflexivity is needed — this is pure composition, and every hereditarity result in this file is an instance of it.",
+    "mathContext": "If $f : G \\to H$ is a homomorphism and $H$ is $F$-free, then $G$ is $F$-free, since $f \\circ \\varphi$ would be a copy of $F$ in $H$.",
+    "significance": "key",
+    "relatedConcepts": ["homomorphism composition", "pullback", "monotone graph parameters"],
+    "prerequisites": ["graph homomorphism"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01oq01-ann-bridge",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 118, "endLine": 141 },
+    "type": "theorem",
+    "title": "The Kᵣ bridge — clique-freeness is the F = Kᵣ case",
+    "content": "Over an irreflexive target, a homomorphic copy of the complete graph Kᵣ is exactly an r-clique: distinct vertices of Kᵣ are adjacent, so their images are adjacent and — by irreflexivity — distinct, forcing injectivity. Hence cliqueFree_iff_homFree_completeGraph, and cliqueFree_of_hom is recovered as the F = Kᵣ corollary of homFree_of_hom. This is the single place irreflexivity is used; everything clique-flavoured downstream passes through here.",
+    "mathContext": "$\\mathrm{hasHomCopy}\\,(K_r)\\,G \\iff G.\\mathrm{hasClique}\\,r$ for irreflexive $G$.",
+    "significance": "important",
+    "relatedConcepts": ["complete graph", "clique", "irreflexive graph", "injective homomorphism"],
+    "prerequisites": ["graph homomorphism", "clique"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01oq01-ann-induce-ishom",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 143, "endLine": 160 },
+    "type": "theorem",
+    "title": "induce_isHom — hereditarity is one homomorphism",
+    "content": "The crux of the entry. induce_isHom states the identity map is a homomorphism G.induce S → G — its proof is literally h.2.2, the third projection of the induced-adjacency conjunction, because induction only deletes edges. Feeding this inclusion to homFree_of_hom gives homFree_induce (forbidden-subgraph freeness is hereditary), and to cliqueFree_of_hom gives cliqueFree_induce (clique-freeness is hereditary). No new machinery: hereditarity is a one-line corollary of the pullback principle.",
+    "mathContext": "$\\mathrm{IsHom}\\,(G.\\mathrm{induce}\\,S)\\,G\\,\\mathrm{id}$, so $\\mathrm{homFree}\\,F\\,G \\to \\mathrm{homFree}\\,F\\,(G.\\mathrm{induce}\\,S)$ and $G.\\mathrm{cliqueFree}\\,r \\to (G.\\mathrm{induce}\\,S).\\mathrm{cliqueFree}\\,r$.",
+    "significance": "key",
+    "relatedConcepts": ["hereditary property", "identity homomorphism", "induced subgraph", "pullback"],
+    "prerequisites": ["graph homomorphism", "induced subgraph"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01oq01-ann-c5-decide",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 179, "endLine": 200 },
+    "type": "technique",
+    "title": "C₅ is K₃-free by ordinary decide (no native_decide)",
+    "content": "C₅, the 5-cycle, is the conjectured extremal witness for #128: it is triangle-free yet dense. C5_homFree_three certifies it has no homomorphic K₃ by exhausting the finite function space Fin 3 → Fin 5 with ordinary decide (with maxRecDepth 4000), deliberately avoiding native_decide so the entry stays free of the Lean.ofReduceBool axiom. hasHomCopy_mono along the inclusion K₃ → Kᵣ then lifts this to all r ≥ 3, and blowup_homFree transports it through every blow-up.",
+    "mathContext": "$\\mathrm{homFree}\\,(K_3)\\,C_5$, lifted to $\\mathrm{homFree}\\,(K_r)\\,C_5$ for all $r \\ge 3$ via the homomorphism $K_3 \\hookrightarrow K_r$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decidability", "native_decide", "axiom hygiene", "5-cycle", "chromatic number"],
+    "prerequisites": ["decision procedures", "graph homomorphism"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01oq01-ann-extremal",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 211, "endLine": 227 },
+    "type": "insight",
+    "title": "The extremal family is hereditarily clique-free",
+    "content": "The payoff: blowup_C5_induce_cliqueFree composes hereditarity with the C₅-blow-up results to show every induced subgraph of every C₅ blow-up is Kᵣ-free for r ≥ 3 — taking r = 3, every induced subgraph is triangle-free. This is precisely the qualitative robustness #128's hypothesis demands of a sharp construction: the property must survive on every ⌊n/2⌋-vertex subset, not merely globally. The remaining, quantitative half — that the balanced blow-up still spans > n²/50 edges on every such subset — stays open.",
+    "mathContext": "For all $c : \\mathrm{Fin}\\,n \\to \\mathrm{Fin}\\,5$, all $S$, and all $r \\ge 3$: $((\\mathrm{blowup}\\,C_5\\,c).\\mathrm{induce}\\,S).\\mathrm{cliqueFree}\\,r$.",
+    "significance": "key",
+    "relatedConcepts": ["extremal construction", "blow-up", "triangle-free graph", "Ramsey–Turán theory"],
+    "prerequisites": ["extremal graph theory", "hereditary property"]
+  }
+]

--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos128WIP01OQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos128Wip01Oq01Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos128Wip01Oq01Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos128Wip01Oq01Oq01Oq01Oq01Data: ProofData = {
+  proof: erdos128Wip01Oq01Oq01Oq01Oq01Proof,
+  annotations: erdos128Wip01Oq01Oq01Oq01Oq01Annotations,
+}

--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -89,6 +89,57 @@
       "The #128 chain's homFree / clique framework"
     ]
   },
+  "sections": [
+    {
+      "id": "framework-overview",
+      "title": "Overview: unifying hereditarity with the forbidden-subgraph framework",
+      "startLine": 1,
+      "endLine": 57,
+      "summary": "Module docstring framing the entry: the #128 chain separately built a forbidden-subgraph framework (homFree, blowup, C₅) and a hereditary-triangle-freeness result (Graph.induce). This file connects them by observing that the inclusion of an induced subgraph is a graph homomorphism, making the entire homFree relation hereditary."
+    },
+    {
+      "id": "graphs-and-induce",
+      "title": "Graphs and induced subgraphs",
+      "startLine": 59,
+      "endLine": 71,
+      "summary": "Re-derives the small framework: a finite simple Graph on Fin n (symmetric, irreflexive adjacency) and Graph.induce S, the induced subgraph keeping only edges with both endpoints in the vertex subset S."
+    },
+    {
+      "id": "homomorphisms-homfree",
+      "title": "Homomorphisms and forbidden-subgraph freeness",
+      "startLine": 72,
+      "endLine": 96,
+      "summary": "IsHom (edge-preserving maps), hasHomCopy / homFree (F-freeness as the absence of a homomorphic copy), and the two structural lemmas: homFree_of_hom (F-freeness pulls back along homomorphisms) and hasHomCopy_mono (copies are monotone along homomorphisms into F)."
+    },
+    {
+      "id": "cliques-Kr-case",
+      "title": "Cliques as the F = Kᵣ case",
+      "startLine": 98,
+      "endLine": 141,
+      "summary": "hasClique / cliqueFree, the complete graph Kᵣ, the bridge cliqueFree_iff_homFree_completeGraph (over an irreflexive target a homomorphic copy of Kᵣ is exactly an r-clique), and cliqueFree_of_hom as the F = Kᵣ corollary of homFree_of_hom."
+    },
+    {
+      "id": "hereditarity",
+      "title": "Hereditarity: the identity inclusion is a homomorphism",
+      "startLine": 143,
+      "endLine": 160,
+      "summary": "The heart of the entry. induce_isHom: the identity is a homomorphism G.induce S → G (induction only deletes edges). homFree_induce and cliqueFree_induce then pull F-freeness / Kᵣ-freeness back along that inclusion — hereditarity with no new machinery."
+    },
+    {
+      "id": "blowups-c5",
+      "title": "Blow-ups and the C₅ witness",
+      "startLine": 162,
+      "endLine": 209,
+      "summary": "The blow-up construction and blowup_homFree (every blow-up of an F-free graph is F-free), the 5-cycle C₅, C5_homFree_three (no homomorphic K₃, by ordinary decide), lifting to all r ≥ 3, and the resulting Kᵣ-freeness of every C₅ blow-up."
+    },
+    {
+      "id": "extremal-hereditary",
+      "title": "The extremal family is hereditarily clique-free",
+      "startLine": 211,
+      "endLine": 227,
+      "summary": "blowup_C5_induce_homFree / blowup_C5_induce_cliqueFree: composing hereditarity with the C₅-blow-up results, every induced subgraph of every C₅ blow-up is Kᵣ-free for r ≥ 3 (triangle-free at r = 3) — exactly the robustness #128's ⌊n/2⌋-subgraph hypothesis demands of a sharp construction."
+    }
+  ],
   "conclusion": {
     "summary": "Forbidden-subgraph freeness homFree F G is hereditary (closed under induced subgraphs), because the identity inclusion G.induce S → G is a graph homomorphism and the parent's homFree_of_hom pulls homFree back along it. Specialising to F = K_r gives hereditary clique-freeness, and chaining with the C₅-blow-up results shows every induced subgraph of every C₅ blow-up is K_r-free for r ≥ 3 (triangle-free at r = 3). Fully verified, 0 axioms, 0 sorries; C₅'s K₃-freeness uses ordinary decide.",
     "implications": "This connects the two halves of the #128 formalization — induced-subgraph hereditarity and the C₅-blow-up forbidden-subgraph framework — and certifies the structural robustness any candidate extremal construction for #128 must possess: triangle-/clique-freeness is preserved on every vertex subset, in particular every ⌊n/2⌋-subgraph. It is the qualitative half of the optimality argument; the quantitative half (that the balanced C₅ blow-up still spans > n²/50 edges on every ⌊n/2⌋-subgraph) remains open.",


### PR DESCRIPTION
Enrichment pass for `erdos-128-wip-01-oq-01-oq-01-oq-01-oq-01` (quality 33, pass 0).

This entry previously shipped with **only meta.json** — no `index.ts` (so the proof page would render *'proof not found'* on the live site) and no annotations.

## Changes
- **Created `index.ts`** (REQUIRED for Vite's `import.meta.glob` to discover the proof). Without it the entry appears in listings but the detail page 404s.
- **Added `annotations.json`** — 8 substantive annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering: the #128 framing, induced subgraphs, `homFree`, the `homFree_of_hom` pullback principle, the Kᵣ bridge, the `induce_isHom` hereditarity crux, the `C₅`/`decide` axiom-hygiene witness, and the hereditarily-clique-free extremal-family payoff.
- **Added `sections`** array to meta.json covering all 7 logical parts of the 227-line Lean file.

## Verification
- `pnpm build` passes (built in 13.6s).
- meta.json is 13.9 KB — well under the ~60 KB cap.
- Mathematical claims cross-checked against the Lean source; status/badge/axiomCount (verified / original / 0) confirmed accurate (C₅ K₃-freeness uses ordinary `decide`, so no `Lean.ofReduceBool`).