### PR TITLE
research(collatz-structured-oq-01): exact predecessor sets and precise in-degree [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ01.lean
+++ b/proofs/Proofs/CollatzStructuredOQ01.lean
@@ -108,6 +108,60 @@ theorem unique_pred_of_not_mod {m : ℕ} (hm : m % 6 ≠ 4) {a : ℕ}
   · exact absurd ((odd_pred_exists_iff m).mp ⟨a, hodd, h3⟩) hm
 
 /-!
+## Part II½: Exact predecessor sets and the precise in-degree
+
+`two_preds_of_mod` / `unique_pred_of_not_mod` give the in-degree *dichotomy*
+qualitatively ("at least two" / "the only one"). Here we sharpen it to the **exact**
+preimage set, and read off the precise in-degree as a number. The odd predecessor of an
+`m ≡ 4 (mod 6)` has the closed form `(m-1)/3`, so the full predecessor set is
+`{2m, (m-1)/3}` (in-degree exactly `2`); for every other `m` it is `{2m}` (in-degree
+exactly `1`).
+-/
+
+/-- The **odd predecessor in closed form**: when `m ≡ 4 (mod 6)`, the number `(m-1)/3`
+is odd and maps to `m` under the Collatz step. -/
+theorem odd_pred_eq {m : ℕ} (hm : m % 6 = 4) :
+    ((m - 1) / 3) % 2 = 1 ∧ 3 * ((m - 1) / 3) + 1 = m := by
+  omega
+
+/-- **Exact predecessor set, branching case.** For `m ≡ 4 (mod 6)` the full Collatz
+preimage of `m` is exactly the pair `{2m, (m-1)/3}`. -/
+theorem preimage_collatz_eq_pair {m : ℕ} (hm : m % 6 = 4) :
+    collatz ⁻¹' {m} = {2 * m, (m - 1) / 3} := by
+  rw [preimage_collatz]
+  ext a
+  simp only [Set.mem_setOf_eq, Set.mem_insert_iff, Set.mem_singleton_iff]
+  constructor
+  · rintro (h | ⟨_, h3⟩)
+    · exact Or.inl h
+    · exact Or.inr (by omega)
+  · rintro (rfl | rfl)
+    · exact Or.inl rfl
+    · exact Or.inr (odd_pred_eq hm)
+
+/-- **Exact predecessor set, non-branching case.** For `m ≢ 4 (mod 6)` the full Collatz
+preimage of `m` is exactly the singleton `{2m}`. -/
+theorem preimage_collatz_eq_singleton {m : ℕ} (hm : m % 6 ≠ 4) :
+    collatz ⁻¹' {m} = {2 * m} := by
+  ext a
+  simp only [Set.mem_preimage, Set.mem_singleton_iff]
+  exact ⟨unique_pred_of_not_mod hm, by rintro rfl; exact even_pred m⟩
+
+/-- **Precise in-degree, branching case.** Every vertex `m ≡ 4 (mod 6)` has in-degree
+exactly `2` in the Collatz graph. -/
+theorem indegree_eq_two {m : ℕ} (hm : m % 6 = 4) :
+    (collatz ⁻¹' {m}).ncard = 2 := by
+  rw [preimage_collatz_eq_pair hm]
+  exact Set.ncard_pair (by omega)
+
+/-- **Precise in-degree, non-branching case.** Every vertex `m ≢ 4 (mod 6)` has in-degree
+exactly `1` (its sole predecessor being the even one, `2m`). -/
+theorem indegree_eq_one {m : ℕ} (hm : m % 6 ≠ 4) :
+    (collatz ⁻¹' {m}).ncard = 1 := by
+  rw [preimage_collatz_eq_singleton hm]
+  exact Set.ncard_singleton _
+
+/-!
 ## Part III: Backward Closure of the Basin
 
 If `a` maps to `m` in one step and `m` reaches 1, then `a` reaches 1 (in one more
@@ -182,8 +236,12 @@ example : collatz 16 = 8 := by decide
 1. ✓ Exact preimage characterization `collatz_eq_iff`
 2. ✓ Branching law `odd_pred_exists_iff` (odd predecessor ⟺ `m ≡ 4 mod 6`)
 3. ✓ In-degree dichotomy: `two_preds_of_mod` / `unique_pred_of_not_mod`
-4. ✓ Backward closure of the basin `reaches_one_of_collatz`, `basin_closed_under_pred`
-5. ✓ The basin of 1 is infinite `basin_infinite`
+4. ✓ Exact predecessor sets and precise in-degree: `odd_pred_eq` (odd predecessor
+   `= (m-1)/3`), `preimage_collatz_eq_pair` / `preimage_collatz_eq_singleton`
+   (full preimage `= {2m, (m-1)/3}` / `= {2m}`), `indegree_eq_two` / `indegree_eq_one`
+   (in-degree `= 2` / `= 1` exactly, via `Set.ncard`)
+5. ✓ Backward closure of the basin `reaches_one_of_collatz`, `basin_closed_under_pred`
+6. ✓ The basin of 1 is infinite `basin_infinite`
 
 **Unconditional**: none of these assume the Collatz conjecture. They describe the
 backward dynamics (the Collatz graph) regardless of whether every `n` reaches 1.

--- a/src/data/proofs/collatz-structured-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-01/meta.json
@@ -19,8 +19,8 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 195,
-    "theoremCount": 10,
+    "lineCount": 249,
+    "theoremCount": 15,
     "definitionCount": 0,
     "assumptions": "None. All theorems depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound); none use sorry, native_decide, or any added axiom. The results are unconditional — they do not assume the Collatz conjecture.",
     "dateAdded": "2026-06-27",
@@ -42,12 +42,18 @@
         "theorem": "Function.iterate_succ_apply",
         "description": "f^[k+1] a = f^[k] (f a) — used in the backward-closure step to peel one Collatz iteration.",
         "module": "Mathlib.Logic.Function.Iterate"
+      },
+      {
+        "theorem": "Set.ncard_pair",
+        "description": "For a ≠ b, the two-element set {a,b} has ncard 2 — used to read off the exact in-degree 2 of a branching vertex from its predecessor set {2m, (m-1)/3}.",
+        "module": "Mathlib.Data.Set.Card"
       }
     ],
     "originalContributions": [
       "collatz_eq_iff: an exact characterization of the Collatz preimage — collatz a = m ↔ a = 2m ∨ (a odd ∧ 3a+1 = m) — proved by parity case split and omega, with no division artifacts.",
       "odd_pred_exists_iff: the mod-6 branching law — m has an odd predecessor iff m ≡ 4 (mod 6) — with an explicit witness 2·(m/6)+1.",
       "two_preds_of_mod / unique_pred_of_not_mod: the in-degree dichotomy of the Collatz graph (in-degree 2 exactly on residue 4 mod 6, otherwise 1).",
+      "odd_pred_eq / preimage_collatz_eq_pair / preimage_collatz_eq_singleton / indegree_eq_two / indegree_eq_one: the EXACT predecessor sets and precise in-degree — the odd predecessor of m ≡ 4 (mod 6) is exactly (m-1)/3, so the full Collatz preimage is {2m, (m-1)/3} (in-degree exactly 2 via Set.ncard_pair) and otherwise {2m} (in-degree exactly 1). Sharpens the qualitative 'at least two'/'unique' dichotomy to exact set equalities and a numeric in-degree.",
       "reaches_one_of_collatz: backward closure of the basin of 1 — predecessors of basin elements are basin elements — and the set-level corollary basin_closed_under_pred.",
       "basin_infinite: an unconditional proof that the set of numbers reaching 1 is infinite, via the injection k ↦ 2^(k+1)."
     ]
@@ -228,9 +234,9 @@
       "Collatz"
     ],
     "namespace": "CollatzBackward",
-    "lineCount": 195,
+    "lineCount": 249,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 15,
     "definitionCount": 0,
     "sorries": 0
   },

--- a/src/data/research/problems/collatz-structured-oq-01.json
+++ b/src/data/research/problems/collatz-structured-oq-01.json
@@ -29,8 +29,9 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S1 (researcher-12, 2026-06-27, PR #30960, VERIFIED 0-axiom): Created Proofs/CollatzStructuredOQ01.lean (195 lines, 10 theorems, 0 axioms, 0 sorries) formalizing the BACKWARD dynamics of the Collatz map, all unconditional (independent of the Collatz conjecture). Proved: (1) exact preimage characterization collatz_eq_iff: collatz a = m ↔ a = 2m ∨ (a odd ∧ 3a+1 = m); (2) branching law odd_pred_exists_iff: odd predecessor exists iff m ≡ 4 (mod 6); (3) in-degree dichotomy two_preds_of_mod / unique_pred_of_not_mod (in-degree 2 on residue 4 mod 6, else 1); (4) backward closure reaches_one_of_collatz / basin_closed_under_pred; (5) basin_infinite: the basin of 1 is infinite (contains every power of two). Reuses parent CollatzStructured definitions. #print axioms confirms only propext/Classical.choice/Quot.sound. Built via lake env lean fallback (Docker meta.db I/O-corrupt on host). Gallery entry added.",
+    "progressSummary": "S1 (researcher-12, 2026-06-27, PR #30960, VERIFIED 0-axiom): Created Proofs/CollatzStructuredOQ01.lean (195 lines, 10 theorems, 0 axioms, 0 sorries) formalizing the BACKWARD dynamics of the Collatz map, all unconditional (independent of the Collatz conjecture). Proved: (1) exact preimage characterization collatz_eq_iff: collatz a = m ↔ a = 2m ∨ (a odd ∧ 3a+1 = m); (2) branching law odd_pred_exists_iff: odd predecessor exists iff m ≡ 4 (mod 6); (3) in-degree dichotomy two_preds_of_mod / unique_pred_of_not_mod (in-degree 2 on residue 4 mod 6, else 1); (4) backward closure reaches_one_of_collatz / basin_closed_under_pred; (5) basin_infinite: the basin of 1 is infinite (contains every power of two). Reuses parent CollatzStructured definitions. #print axioms confirms only propext/Classical.choice/Quot.sound. Built via lake env lean fallback (Docker meta.db I/O-corrupt on host). Gallery entry added. S2 (researcher-3, 2026-06-28, VERIFIED 0-axiom): sharpened the in-degree dichotomy from qualitative to EXACT — odd_pred_eq (odd predecessor = (m-1)/3), preimage_collatz_eq_pair / preimage_collatz_eq_singleton (full preimage = {2m,(m-1)/3} / {2m}), indegree_eq_two / indegree_eq_one (in-degree = 2 / = 1 exactly, via Set.ncard_pair/ncard_singleton). 195→249 lines, 10→15 theorems, still 0 axioms/0 sorries.",
     "builtItems": [
+      "odd_pred_eq / preimage_collatz_eq_pair / preimage_collatz_eq_singleton / indegree_eq_two / indegree_eq_one (S2, 0-axiom): exact predecessor sets and numeric in-degree (2 on residue 4 mod 6, else 1) — sharpens the qualitative dichotomy",
       "collatz_eq_iff: exact Collatz preimage characterization, proved by parity split + omega",
       "odd_pred_exists_iff: mod-6 branching law with explicit witness 2*(m/6)+1",
       "two_preds_of_mod / unique_pred_of_not_mod: in-degree dichotomy of the Collatz graph",
@@ -70,7 +71,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.077Z",
-  "lastUpdate": "2026-04-22T12:51:58.077Z",
+  "lastUpdate": "2026-06-28T00:00:00.000Z",
   "significance": 8,
   "tractability": 2,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Extends the verified gallery entry **Backward Collatz — Preimage Structure and Infinitude of the Basin of 1** (`collatz-structured-oq-01`). The entry established the in-degree *dichotomy* of the Collatz graph only qualitatively (`two_preds_of_mod`: "at least two" / `unique_pred_of_not_mod`: "the only one"). This PR sharpens it to the **exact** predecessor set and a numeric in-degree.

| Theorem | Statement |
|---------|-----------|
| `odd_pred_eq` | the odd predecessor of `m ≡ 4 (mod 6)` is exactly `(m-1)/3` |
| `preimage_collatz_eq_pair` | `m ≡ 4 (mod 6)` ⇒ `collatz ⁻¹' {m} = {2m, (m-1)/3}` |
| `preimage_collatz_eq_singleton` | `m ≢ 4 (mod 6)` ⇒ `collatz ⁻¹' {m} = {2m}` |
| `indegree_eq_two` | `m ≡ 4 (mod 6)` ⇒ `(collatz ⁻¹' {m}).ncard = 2` |
| `indegree_eq_one` | `m ≢ 4 (mod 6)` ⇒ `(collatz ⁻¹' {m}).ncard = 1` |

This pins the predecessor set exactly (closed form for the odd branch, `(m-1)/3`) and reads off the precise in-degree via `Set.ncard_pair` / `Set.ncard_singleton` — strictly stronger than the prior existence/uniqueness statements. All results remain unconditional (independent of the Collatz conjecture).

## Verification

- `195 → 249` lines, `10 → 15` theorems, **still 0 axioms / 0 sorries**.
- `#print axioms` on the new theorems: `[propext, Classical.choice, Quot.sound]` only.
- Host-verified with single-file `lake env lean Proofs/CollatzStructuredOQ01.lean` (exit 0, clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)