### PR TITLE
Enrich geometric-series-oq-04: deepen annotations

### DIFF
--- a/src/data/proofs/geometric-series-oq-04/annotations.json
+++ b/src/data/proofs/geometric-series-oq-04/annotations.json
@@ -8,7 +8,19 @@
     },
     "type": "concept",
     "title": "Quantum integers: scope and Mathlib gap",
-    "content": "The file imports only the geometric-sum lemmas (geom_sum_mul, geom_sum_eq) and Mathlib.Tactic. Mathlib formalizes the geometric sum ∑_{i<n} q^i but has no named quantum integer [n]_q, q-factorial, or Gaussian binomial. This entry supplies the q-integer layer over an arbitrary commutative ring and proves the four laws that characterize it, all with 0 axioms."
+    "content": "The file imports only the geometric-sum lemmas (geom_sum_mul, geom_sum_eq) and Mathlib.Tactic. Mathlib formalizes the geometric sum ∑_{i<n} q^i but has no named quantum integer [n]_q, q-factorial, or Gaussian binomial. This entry supplies the q-integer layer over an arbitrary commutative ring and proves the four laws that characterize it, all with 0 axioms.",
+    "mathContext": "The quantum (or $q$-)integer is $[n]_q = \\sum_{i=0}^{n-1} q^i = \\dfrac{q^n - 1}{q - 1}$, a one-parameter deformation of $n$ with $[n]_1 = n$. It is the additive backbone of $q$-calculus: the $q$-factorial $[n]_q! = \\prod_{k=1}^n [k]_q$ and the Gaussian binomial $\\binom{n}{k}_q = \\frac{[n]_q!}{[k]_q!\\,[n-k]_q!}$ are built from it.",
+    "significance": "context",
+    "relatedConcepts": [
+      "q-analog",
+      "geometric series",
+      "q-calculus",
+      "Gaussian binomial coefficient"
+    ],
+    "prerequisites": [
+      "commutative ring theory",
+      "geometric series"
+    ]
   },
   {
     "id": "ann-gs04-def",
@@ -19,7 +31,19 @@
     },
     "type": "definition",
     "title": "The quantum integer [n]_q",
-    "content": "qNat q n = ∑_{i ∈ range n} q^i = 1 + q + … + q^{n-1}. Defined for any q in a commutative ring R. As q → 1 every summand is 1, foreshadowing [n]_1 = n."
+    "content": "qNat q n = ∑_{i ∈ range n} q^i = 1 + q + … + q^{n-1}. Defined for any q in a commutative ring R. As q → 1 every summand is 1, foreshadowing [n]_1 = n.",
+    "mathContext": "$[n]_q := \\sum_{i \\in \\text{range }n} q^i = 1 + q + \\cdots + q^{n-1}$ in a commutative ring $R$. Generality matters: defining it as a *sum* (not the quotient $\\frac{q^n-1}{q-1}$) keeps it valid with no division and no $q \\ne 1$ side-condition, so it lives in any $\\mathbb{Z}[q]$ or finite ring, not just a field.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.range",
+      "Finset.sum",
+      "q-integer",
+      "polynomial in q"
+    ],
+    "prerequisites": [
+      "finite sums over Finset",
+      "commutative ring theory"
+    ]
   },
   {
     "id": "ann-gs04-succ",
@@ -30,7 +54,19 @@
     },
     "type": "technique",
     "title": "The driving recurrence",
-    "content": "qNat_succ: [n+1]_q = [n]_q + q^n, a one-line consequence of Finset.sum_range_succ. Every later induction (additive and multiplicative laws) is powered by this single rewrite."
+    "content": "qNat_succ: [n+1]_q = [n]_q + q^n, a one-line consequence of Finset.sum_range_succ. Every later induction (additive and multiplicative laws) is powered by this single rewrite.",
+    "mathContext": "$[n+1]_q = [n]_q + q^n$: appending the top term $q^n$ to the sum. This is the $q$-analog of $n+1 = n + 1$, and the single rewrite that drives every subsequent induction (`Finset.sum_range_succ` peels off the last summand).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_range_succ",
+      "recurrence relation",
+      "induction",
+      "q-integer"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "finite sums"
+    ]
   },
   {
     "id": "ann-gs04-closed",
@@ -41,7 +77,19 @@
     },
     "type": "technique",
     "title": "Geometric closed form in any ring",
-    "content": "qNat_mul_qSub: [n]_q·(q-1) = q^n - 1. This is Mathlib's geom_sum_mul applied to the definition — valid in any commutative ring, with no division and no q ≠ 1 hypothesis."
+    "content": "qNat_mul_qSub: [n]_q·(q-1) = q^n - 1. This is Mathlib's geom_sum_mul applied to the definition — valid in any commutative ring, with no division and no q ≠ 1 hypothesis.",
+    "mathContext": "$[n]_q \\cdot (q - 1) = q^n - 1$, the *multiplicative* (division-free) closed form. It is the telescoping identity $(q-1)\\sum_{i<n} q^i = q^n - 1$ (Mathlib's `geom_sum_mul`), holding in every commutative ring; the field quotient $[n]_q = \\frac{q^n-1}{q-1}$ is only its specialization once $q-1$ is invertible.",
+    "significance": "key",
+    "relatedConcepts": [
+      "geom_sum_mul",
+      "telescoping sum",
+      "geometric series closed form",
+      "integral domain"
+    ],
+    "prerequisites": [
+      "geometric series",
+      "commutative ring theory"
+    ]
   },
   {
     "id": "ann-gs04-atone",
@@ -52,7 +100,18 @@
     },
     "type": "insight",
     "title": "Classical limit q = 1",
-    "content": "qNat_at_one: [n]_1 = n. Each power 1^i = 1, so the sum collapses to n. This is the sense in which q-integers deform the ordinary integers."
+    "content": "qNat_at_one: [n]_1 = n. Each power 1^i = 1, so the sum collapses to n. This is the sense in which q-integers deform the ordinary integers.",
+    "mathContext": "$[n]_1 = \\sum_{i<n} 1^i = \\sum_{i<n} 1 = n$. The point $q = 1$ is the *classical limit* of the deformation: every $q$-identity proved here must reduce to its ordinary counterpart at $q = 1$ (e.g. the additive law $[m+n]_q = [m]_q + q^m[n]_q$ becomes $m + n = m + n$). Marked `@[simp]` so the limit is automatic downstream.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "classical limit",
+      "deformation parameter",
+      "q → 1 specialization",
+      "simp lemma"
+    ],
+    "prerequisites": [
+      "powers of one"
+    ]
   },
   {
     "id": "ann-gs04-add",
@@ -63,7 +122,19 @@
     },
     "type": "insight",
     "title": "Additive cocycle law",
-    "content": "qNat_add: [m+n]_q = [m]_q + q^m·[n]_q. Proved by induction on n: the successor step rewrites m+(n+1) = (m+n)+1, applies the recurrence on both sides, and finishes with ring after q^{m+n} = q^m q^n. The factor q^m — absent at q=1 — is the structural heart of q-calculus."
+    "content": "qNat_add: [m+n]_q = [m]_q + q^m·[n]_q. Proved by induction on n: the successor step rewrites m+(n+1) = (m+n)+1, applies the recurrence on both sides, and finishes with ring after q^{m+n} = q^m q^n. The factor q^m — absent at q=1 — is the structural heart of q-calculus.",
+    "mathContext": "$[m+n]_q = [m]_q + q^m\\,[n]_q$. The twisting factor $q^m$ is a 1-cocycle: it records that the second block of $n$ powers starts at exponent $m$, i.e. $\\sum_{i<m+n} q^i = \\sum_{i<m} q^i + q^m\\sum_{j<n} q^j$. At $q=1$ the factor vanishes ($q^m = 1$) and the law degenerates to $m+n = m+n$ — so $q^m$ is exactly the $q$-deformation content.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cocycle",
+      "q-deformation",
+      "pow_add",
+      "index splitting"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "ring tactic"
+    ]
   },
   {
     "id": "ann-gs04-mul",
@@ -74,7 +145,19 @@
     },
     "type": "insight",
     "title": "Multiplicative base-change law",
-    "content": "qNat_mul: [m·n]_q = [m]_{q^n}·[n]_q. Induction on m: (m+1)n = mn+n splits via the additive law, the IH rewrites [mn]_q, and the recurrence in base q^n reassembles the product. The base change q ↦ q^n is invisible at q=1 (where it reduces to mn = m·n), making this a genuinely q-flavoured identity."
+    "content": "qNat_mul: [m·n]_q = [m]_{q^n}·[n]_q. Induction on m: (m+1)n = mn+n splits via the additive law, the IH rewrites [mn]_q, and the recurrence in base q^n reassembles the product. The base change q ↦ q^n is invisible at q=1 (where it reduces to mn = m·n), making this a genuinely q-flavoured identity.",
+    "mathContext": "$[mn]_q = [m]_{q^n}\\,[n]_q$, the $q$-analog of $mn = m\\cdot n$ with a **base change** $q \\mapsto q^n$ in the outer factor. It mirrors grouping $mn$ powers into $m$ blocks of $n$: $\\sum_{i<mn} q^i = \\big(\\sum_{k<m} (q^n)^k\\big)\\big(\\sum_{j<n} q^j\\big)$. The substitution $q \\mapsto q^n$ is the multiplicative counterpart of the additive law's $q^m$ twist, and is invisible at $q=1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "base change",
+      "q-deformation",
+      "pow_mul",
+      "block decomposition"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "the additive law qNat_add"
+    ]
   },
   {
     "id": "ann-gs04-field",
@@ -85,6 +168,18 @@
     },
     "type": "technique",
     "title": "Field quotient form",
-    "content": "qNat_eq_div: over a field with q ≠ 1, [n]_q = (q^n-1)/(q-1) — the familiar division formula, supplied by Mathlib's geom_sum_eq once division is available."
+    "content": "qNat_eq_div: over a field with q ≠ 1, [n]_q = (q^n-1)/(q-1) — the familiar division formula, supplied by Mathlib's geom_sum_eq once division is available.",
+    "mathContext": "Over a field $K$ with $q \\ne 1$: $[n]_q = \\dfrac{q^n - 1}{q - 1}$ (Mathlib's `geom_sum_eq`). This is the textbook closed form, but it is *strictly weaker* than the ring identity `qNat_mul_qSub`: it needs $q - 1$ invertible. Stating both makes explicit that the division form is a corollary of the division-free one, not the primary definition.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "geom_sum_eq",
+      "field of fractions",
+      "division",
+      "q ≠ 1 hypothesis"
+    ],
+    "prerequisites": [
+      "field theory",
+      "geometric series"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-04` (passes: 0, quality: 70).

## Gap addressed
The entry's `meta.json` was already complete (full overview, 5 sections, 3 openQuestions, 2 crossRefs), but **all 8 annotations carried only `title` + `content`** — none had `mathContext`, `significance`, or `relatedConcepts` (mission item #1, annotation depth).

## Changes
- Added **`mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`** to all 8 annotations of this q-integer / q-calculus entry:
  - the `[n]_q` definition (division-free sum, valid in any commutative ring)
  - the driving recurrence `[n+1]_q = [n]_q + q^n`
  - the ring closed form `[n]_q·(q−1) = q^n−1` vs the field quotient `(q^n−1)/(q−1)`
  - the `q=1` classical limit
  - the additive **cocycle** law (the `q^m` twist) and the multiplicative **base-change** law (`q ↦ q^n`)
- Preserved every existing `content` string verbatim; meta.json untouched.

## Verification
- JSON valid; within size caps; all annotation ranges align with Lean constructs (`annotations:build` clean for this entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)