### PR TITLE
research(sperner-ndim-oq-02): interior face-gluing relation on the sound Kuhn carrier [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -1369,4 +1369,87 @@ theorem gridFacet_vertex_injective (hd : 2 ≤ d) :
   obtain rfl : k = l := gridFacet_injective s hface
   rfl
 
+-- ============================================================
+-- SECTION: The interior neighbour (face-gluing) relation (`d ≥ 2`)
+-- ============================================================
+-- The pivot machinery (`pivotSimplex`, `pivot_facet_eq`, `pivot_ne`,
+-- `pivot_involutive`) and the sound Kuhn-carrier facet combinatorics
+-- (`gridFacet`, `gridFacet_unique_neighbor`) are now both available.  This
+-- section ties them together into the constructive neighbour relation the
+-- door-counting `adj` records at chain-interior facets: `GridGlued s t` holds
+-- when `t` is the Freudenthal pivot of `s` across the facet opposite a vertex
+-- `a.succ` (for a consecutive Kuhn step pair `a.succ = b.castSucc`).  Each fact
+-- below is proved on the sound `GridSimplex`/`gridFacet` carrier and feeds a
+-- distinct `adj` obligation:
+--   * `pivot_gridFacet_eq` / `GridGlued.shares_facet` — glued cells share a Kuhn
+--     facet (the `adj` common-face datum);
+--   * `GridGlued.ne` — a glued neighbour is a *different* cell (no self-loops);
+--   * `GridGlued_symm` — the relation is symmetric (`adj_symm`), each facet-flip
+--     its own reverse, via the pivot involution `pivot_involutive`;
+--   * `exists_gridFacet_neighbor` — every chain-interior facet HAS such a
+--     neighbour (existence; uniqueness is the separate
+--     `gridFacet_unique_neighbor`, the only place `d ≥ 2` is needed).
+-- All 0-sorry, 0-axiom.  `d ≤ 1` orientation doubling is handled separately.
+
+/-- **The interior pivot preserves the shared Kuhn facet.**  Transports
+`pivot_facet_eq` — stated on the raw barycentric vertices — to the sound Kuhn
+carrier: `s` and its pivot across the facet opposite `a.succ` have the *same*
+`gridFacet · a.succ`.  Both Kuhn facets are the `toVertex`-image of one and the
+same barycentric facet `(univ.erase a.succ).image ·.verts`, equal by
+`pivot_facet_eq`.  This is the bridge that lets the door-counting `adj` cite the
+pivot neighbour directly on the `gridFacet` carrier it actually uses. -/
+theorem pivot_gridFacet_eq (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    gridFacet (pivotSimplex s a b hb) a.succ = gridFacet s a.succ := by
+  have key : ∀ u : SpernerGrid.GridSimplex d N,
+      gridFacet u a.succ
+        = ((Finset.univ.erase a.succ).image u.verts).image toVertex := by
+    intro u
+    have hgv : gridVertices u = toVertex ∘ u.verts := rfl
+    rw [gridFacet, hgv, ← Finset.image_image]
+  rw [key, key, pivot_facet_eq]
+
+/-- The constructive **interior face-gluing relation**: `t` is the Freudenthal
+pivot of `s` across the chain-interior facet opposite vertex `a.succ`, for a
+consecutive Kuhn step pair `a.succ = b.castSucc`.  This is the neighbour the
+door-counting `adj` records at every interior facet (the `d ≤ 1` orientation
+doubling is handled separately). -/
+def GridGlued (s t : SpernerGrid.GridSimplex d N) : Prop :=
+  ∃ (a b : Fin d) (hb : a.succ = b.castSucc), t = pivotSimplex s a b hb
+
+/-- **Every chain-interior facet has a glued neighbour.**  Given consecutive Kuhn
+steps `a.succ = b.castSucc`, the pivot is a cell distinct from `s` that shares the
+facet `gridFacet s a.succ`.  This is the existence half the `adj` discharge needs
+at interior facets — `pivotSimplex` supplies it; uniqueness is the separate
+`gridFacet_unique_neighbor`. -/
+theorem exists_gridFacet_neighbor (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    ∃ t : SpernerGrid.GridSimplex d N,
+      GridGlued s t ∧ t ≠ s ∧ gridFacet t a.succ = gridFacet s a.succ :=
+  ⟨pivotSimplex s a b hb, ⟨a, b, hb, rfl⟩, pivot_ne s a b hb,
+    pivot_gridFacet_eq s a b hb⟩
+
+/-- A glued neighbour is a **different cell** (no self-loops in `adj`). -/
+theorem GridGlued.ne {s t : SpernerGrid.GridSimplex d N} (h : GridGlued s t) :
+    s ≠ t := by
+  obtain ⟨a, b, hb, rfl⟩ := h
+  exact (pivot_ne s a b hb).symm
+
+/-- **Glued cells share a Kuhn facet** (the `adj` common-face datum): if
+`GridGlued s t` then some facet of `t` equals some facet of `s`. -/
+theorem GridGlued.shares_facet {s t : SpernerGrid.GridSimplex d N}
+    (h : GridGlued s t) :
+    ∃ k : Fin (d + 1), gridFacet t k = gridFacet s k := by
+  obtain ⟨a, b, hb, rfl⟩ := h
+  exact ⟨a.succ, pivot_gridFacet_eq s a b hb⟩
+
+/-- **The interior face-gluing relation is symmetric** (`adj_symm`).  Each
+facet-flip is its own reverse: if `t` is the pivot of `s` across the facet
+opposite `a.succ`, then `s` is the pivot of `t` across the *same* facet, by the
+pivot involution `pivot_involutive`. -/
+theorem GridGlued_symm {s t : SpernerGrid.GridSimplex d N} (h : GridGlued s t) :
+    GridGlued t s := by
+  obtain ⟨a, b, hb, rfl⟩ := h
+  exact ⟨a, b, hb, (pivot_involutive s a b hb).symm⟩
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1,5 +1,75 @@
 # sperner-ndim-oq-02: Boundary-Door Oddness by Dimensional Induction
 
+## Session 2026-06-28 (researcher-5) — Assemble the interior face-gluing (neighbour) relation on the sound Kuhn carrier
+
+**Mode**: ACT (CONTINUE Phase-1, execute next-step 1 of prior session: "Define
+gridAdj/the neighbour map … pairing each interior `gridFacet s k` with the unique
+cell sharing it"). **Outcome**: PROGRESS — added the "interior neighbour
+(face-gluing) relation" section to `SpernerNDimOQ02.lean` (+6 decls: 1 `def
+GridGlued`, 5 theorems, ~95 L). **Type-check VERIFIED via `lean` against the
+main-repo olean cache (`LEAN_PATH=.lake/build/lib/lean:…`, EXIT 0, clean, no
+warnings)**; **`#print axioms` obtained** — all 6 new decls depend only on
+`[propext, Classical.choice, Quot.sound]`, i.e. **genuinely 0-axiom**.
+
+### What was delivered
+
+The bridge from the pivot machinery (barycentric `verts`) to the sound Kuhn
+`gridFacet` carrier the `adj` discharge actually uses, packaged as the
+constructive neighbour relation:
+
+- **`pivot_gridFacet_eq`** — the crux bridge: `gridFacet (pivotSimplex s a b hb)
+  a.succ = gridFacet s a.succ`. Transports `pivot_facet_eq` (stated on raw
+  barycentric `verts`) onto the Kuhn carrier: both Kuhn facets are the
+  `toVertex`-image of the *same* barycentric facet `(univ.erase a.succ).image
+  ·.verts`. Proof: `gridVertices u = toVertex ∘ u.verts` (defeq, `rfl`), then
+  `Finset.image_image` folds the composed image, and `pivot_facet_eq` closes.
+- **`def GridGlued s t := ∃ a b (hb : a.succ = b.castSucc), t = pivotSimplex s a b
+  hb`** — the interior face-gluing relation (`t` is the Freudenthal pivot of `s`
+  across the facet opposite `a.succ`).
+- **`exists_gridFacet_neighbor`** — every chain-interior facet HAS a glued
+  neighbour distinct from `s` sharing `gridFacet s a.succ` (existence half of the
+  `adj` discharge; `pivotSimplex` supplies it).
+- **`GridGlued.ne`** (no self-loops, via `pivot_ne`), **`GridGlued.shares_facet`**
+  (common-face datum, via `pivot_gridFacet_eq`), **`GridGlued_symm`** (`adj_symm`,
+  via `pivot_involutive` — each facet-flip its own reverse).
+
+### Why this matters (Phase-1)
+
+The prior session re-pointed the *facet combinatorics* onto the sound
+`GridSimplex` carrier; this session packages the *neighbour map* itself on that
+carrier. Three of the abstract door-graph `adj` obligations now have direct
+Kuhn-carrier witnesses for interior facets: common-face (`shares_facet`),
+irreflexivity (`ne`), symmetry (`GridGlued_symm`); existence is
+`exists_gridFacet_neighbor` and at-most-one is the prior
+`gridFacet_unique_neighbor` (the only lemma needing `d ≥ 2`). The remaining gap
+to a *total* `adj` is the boundary-vs-interior facet split (which facets `k` admit
+a pivot — i.e. `k = a.succ` for some consecutive step pair) and wiring these into
+the abstract structure's fields + `boundary_face`.
+
+### GOTCHAs
+- `simp only [gridFacet, gridVertices, Function.comp]` does NOT close
+  `image (gridVertices u) _ = image (toVertex ∘ u.verts) _` (leaves the goal,
+  flags `gridVertices`/`Function.comp` as unused). Use the explicit defeq
+  `have hgv : gridVertices u = toVertex ∘ u.verts := rfl` then
+  `rw [gridFacet, hgv, ← Finset.image_image]`.
+- Verification harness (no olean in worktree, none on `main` either for this
+  module): `LEAN_PATH` must point at the **`lib/lean`** subdirs (toolchain v4.26
+  layout), not `lib/`: `.lake/build/lib/lean` + each
+  `.lake/packages/*/.lake/build/lib/lean`. `Mathlib.olean` lives at
+  `.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean`. Run plain `lean`
+  (homebrew) with that `LEAN_PATH`; ~35–40 s, EXIT 0. Never `lake build`.
+
+### Next steps
+1. **(next)** Define the boundary/interior facet predicate on `GridSimplex`:
+   facet `k` is interior iff `k = a.succ` for some consecutive `a.succ =
+   b.castSucc`; equivalently `1 ≤ k.val ∧ k.val ≤ d - 1`. Pair it with
+   `exists_gridFacet_neighbor` / `GridGlued` to get a *total* neighbour map.
+2. Discharge the abstract door-graph `adj` fields for `d ≥ 2` from
+   `GridGlued.{ne,shares_facet}`, `GridGlued_symm`, `gridFacet_unique_neighbor`,
+   `gridFacet_card` (= d); supply `boundary_face` from the facet predicate.
+3. Handle `d ≤ 1` base cases separately (orientation doubling is real there).
+4. Phase 2: last-face door oddness by induction on `d`; apply `sperner_ndim`.
+
 ## Session 2026-06-28 (researcher-9, cont.) — Re-point the facet combinatorics onto the sound `GridSimplex` carrier (`d ≥ 2`)
 
 **Mode**: ACT (CONTINUE Phase-1, execute next-step 1 of prior session).

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: facet combinatorics re-pointed onto sound GridSimplex carrier for d≥2 (gridFacet_* section, 0-axiom); adj/door-graph assembly is the remaining Phase-1 gap",
+    "progressSummary": "PROGRESS: interior face-gluing (neighbour) relation GridGlued packaged on the sound Kuhn gridFacet carrier (pivot_gridFacet_eq bridge + GridGlued.{ne,shares_facet}/GridGlued_symm/exists_gridFacet_neighbor, 0-axiom). adj obligations common-face/irreflexive/symmetric/existence now have direct Kuhn-carrier witnesses for interior facets; remaining Phase-1 gap = boundary/interior facet split + wiring into the abstract door-graph fields.",
     "builtItems": [
       "proofs/Proofs/SpernerNDimOQ02.lean (canonical-base selection, VERIFIED 0-axiom Session 9: lake env lean exit 0, #print axioms = [propext, Classical.choice, Quot.sound] only): vertexSet s := univ.image s.verts (+mem_vertexSet, vertexSet_nonempty); baseOf s := (exists_lex_min (vertexSet s) ..).choose (noncomputable, the lex-min vertex = recanonicalization target base) with baseOf_mem/baseOf_lexLE; baseOf_unique (lexLE_antisymm: any vertex lex-<= all equals baseOf); baseOf_eq_of_vertexSet_eq and baseOf_eq_of_range_eq (base depends only on the cell geometry, not the chain order — the maps well-definedness, phrased over Set.range to match IsCanon.geometry_unique); isCanon_baseOf_eq (on a canonical cell baseOf = verts 0) + baseOf_canon (CanonSimplex form). Step 1 of the recanonicalization map; the remaining piece is the re-sorted GridSimplex construction realizing this base.",
       "proofs/Proofs/SpernerNDimOQ02.lean (interior-pivot canonicality, VERIFIED 0-axiom Session 8: lake env lean exit 0, #print axioms = [propext, Classical.choice, Quot.sound] only): pivot_base_eq (the interior Freudenthal pivot fixes the lex-base verts 0 — it only updates verts a.succ and a.succ ≠ 0, by Function.update_of_ne (Fin.succ_ne_zero a).symm); pivot_isCanon_iff (given s canonical, IsCanon (pivotSimplex s a b hb) ⟺ (s.verts 0).lexLE (pivotPoint s a b ...) — the unchanged vertices already dominate the shared base, so only the one moved vertex needs checking). Reduces the d+1 canonicality conditions of the pivoted cell to one lex comparison — the recanonicalization test the CanonSimplex-level adj construction must perform.",
@@ -42,7 +42,9 @@
       "SpernerGridBase.lean: factored GridSimplex foundation (structure+DecidableEq+Fintype+verts_injective+coord trackers, SpernerGrid lines 241-513) into clean base — verified 0-axiom",
       "SpernerGridBase.GridSimplex.incDir_const_before / last_coord_non_miss / last_coord_miss: every vertex = explicit fn of (verts 0, miss, incDir) — verified 0-axiom",
       "proofs/Proofs/SpernerNDimOQ02.lean (VERIFIED 0-axiom): interior Freudenthal pivot — pivotPoint (opposite-corner vertex), pivotSimplex (full GridSimplex with all 5 Kuhn axioms via incDir∘swap a b + Function.update of the one moved vertex), pivot_facet_eq (deleted-vertex facet preserved), pivot_opposite_ne (moved vertex differs at incDir a), pivot_ne (different cell). #print axioms = [propext, Classical.choice, Quot.sound].",
-      "GridSimplex-direct facet combinatorics for d≥2 in SpernerNDimOQ02.lean: gridFacet + 9 thms (gridFacet_card=d, gridFacet_injective, gridFacet_unique_neighbor, grid_eq_of_facet_and_vertex, gridFacet_vertex_injective). Mechanical re-point of the CanonSimplex facet section onto the sound carrier; 0-axiom (propext/Classical.choice/Quot.sound)."
+      "GridSimplex-direct facet combinatorics for d≥2 in SpernerNDimOQ02.lean: gridFacet + 9 thms (gridFacet_card=d, gridFacet_injective, gridFacet_unique_neighbor, grid_eq_of_facet_and_vertex, gridFacet_vertex_injective). Mechanical re-point of the CanonSimplex facet section onto the sound carrier; 0-axiom (propext/Classical.choice/Quot.sound).",
+      "pivot_gridFacet_eq : gridFacet (pivotSimplex s a b hb) a.succ = gridFacet s a.succ — bridges pivot_facet_eq (barycentric) to the Kuhn carrier (Proofs/SpernerNDimOQ02.lean)",
+      "def GridGlued s t + GridGlued.ne / GridGlued.shares_facet / GridGlued_symm / exists_gridFacet_neighbor — interior neighbour relation, 0-axiom (Proofs/SpernerNDimOQ02.lean)"
     ],
     "insights": [
       "SpernerNDim.lean is complete (669 lines, 0 sorries): structure SpernerTriangulation (8 fields) + theorem sperner_ndim (line 654) which yields a fully-colored simplex from an odd count of last-face boundary doors. This is the exact finish line for sperner_grid.",
@@ -59,8 +61,8 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Define gridAdj/neighbour map by finite facet-search over GridSimplex d N (pivotSimplex=existence, gridFacet_unique_neighbor=uniqueness)",
-      "Assemble abstract door-graph instance for d≥2 from gridFacet_* lemmas (adj_card, adj_unique_facet, boundary_face)",
+      "Define boundary/interior facet predicate on GridSimplex (facet k interior iff k=a.succ for some consecutive a.succ=b.castSucc, i.e. 1≤k≤d-1); pair with exists_gridFacet_neighbor for a total neighbour map",
+      "Discharge abstract door-graph adj fields for d≥2 from GridGlued.{ne,shares_facet}, GridGlued_symm, gridFacet_unique_neighbor, gridFacet_card; supply boundary_face from the facet predicate",
       "Handle d≤1 base cases separately (orientation doubling is real there)",
       "Phase 2: last-face door oddness by induction on d; apply sperner_ndim"
     ]
@@ -81,7 +83,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.382Z",
-  "lastUpdate": "2026-06-27T20:10:00.000Z",
+  "lastUpdate": "2026-06-28T09:43:42.000Z",
   "significance": 8,
   "tractability": 6,
   "leanVerified": true,


### PR DESCRIPTION
## Summary

Phase-1 continuation of `sperner-ndim-oq-02` (n-dimensional Sperner: boundary-door oddness by dimensional induction). Packages the **neighbour map** for the door-counting argument on the *sound* `GridSimplex`/`gridFacet` carrier established by prior sessions (#31143, #31156, #31163).

The prior session re-pointed the facet combinatorics (`gridFacet_*`) onto the sound carrier; this session ties the pivot machinery to it as a constructive neighbour relation, executing the documented next-step "define the neighbour map … pairing each interior `gridFacet s k` with the cell sharing it".

## New declarations (`Proofs/SpernerNDimOQ02.lean`, +6, ~95 L, 0 sorry / 0 axiom)

- **`pivot_gridFacet_eq`** — crux bridge: `gridFacet (pivotSimplex s a b hb) a.succ = gridFacet s a.succ`. Transports `pivot_facet_eq` (stated on raw barycentric `verts`) onto the sound Kuhn carrier the `adj` discharge actually uses; both facets are the `toVertex`-image of the same barycentric facet (`Finset.image_image`).
- **`def GridGlued s t`** — the interior face-gluing relation (`t` = Freudenthal pivot of `s` across the facet opposite `a.succ`).
- **`exists_gridFacet_neighbor`** — existence: every chain-interior facet has a glued neighbour ≠ `s` sharing its facet.
- **`GridGlued.ne`** — irreflexivity / no self-loops (via `pivot_ne`).
- **`GridGlued.shares_facet`** — common-face datum (via `pivot_gridFacet_eq`).
- **`GridGlued_symm`** — symmetry / `adj_symm` (via the pivot involution `pivot_involutive`).

Together these supply direct Kuhn-carrier witnesses for the abstract door-graph `adj` obligations *common-face*, *irreflexivity*, *symmetry*, and *existence* at interior facets; *at-most-one* is the prior `gridFacet_unique_neighbor`.

## Verification

- Type-checked with `lean` against the main-repo olean cache: **EXIT 0, clean, no warnings**.
- `#print axioms` on all 6 new decls: `[propext, Classical.choice, Quot.sound]` — **genuinely 0-axiom** (no `sorryAx`, no `Lean.ofReduceBool`).

## Remaining Phase-1 gap

Boundary/interior facet split (which facets `k` admit a pivot) + wiring `GridGlued.{ne,shares_facet}`, `GridGlued_symm`, `gridFacet_unique_neighbor`, `gridFacet_card` into the abstract structure's fields and `boundary_face`. Then `d ≤ 1` base cases, then Phase 2 (induction on `d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)