### PR TITLE
research(lovasz-local-lemma-oq-04): degree bound k·(D-1) is sharp [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LovaszLocalLemmaOQ04.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ04.lean
@@ -202,6 +202,26 @@ theorem variable_lll_symmetric (vars : Fin n → Finset V) (k D : ℕ)
     (sharedDep_maxDegree vars k D hk hD) hprob
 
 -- ═══════════════════════════════════════════════════════════════════
+-- PART V': SHARPNESS OF THE DEGREE BOUND
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- A concrete witness that the degree bound `k·(D-1)` of `sharedDep_maxDegree`
+    is attained, hence cannot be improved in general.  Here `k = 2`, `D = 3`:
+    event `0` uses both variables `{0,1}`; variable `0` is also used by events
+    `1,2` and variable `1` by events `3,4`.  Every event uses ≤ 2 variables and
+    every variable is used by ≤ 3 events, yet event `0` has exactly
+    `2·(3-1) = 4` neighbours. -/
+def tightVars : Fin 5 → Finset (Fin 2) := ![{0, 1}, {0}, {0}, {1}, {1}]
+
+/-- **Sharpness of `sharedDep_maxDegree`.** With `tightVars` (k = 2 variables per
+    event, D = 3 events per variable) the central event has degree exactly
+    `k·(D-1) = 4`, so the bound `sharedDep_maxDegree` is tight. -/
+theorem sharedDep_maxDegree_tight :
+    (∀ i, (tightVars i).card ≤ 2) ∧
+    (∀ v, (occ tightVars v).card ≤ 3) ∧
+    (sharedDep tightVars 0).card = 2 * (3 - 1) := by decide
+
+-- ═══════════════════════════════════════════════════════════════════
 -- PART V: THE ASYMMETRIC LLL BEATS THE UNION BOUND
 -- ═══════════════════════════════════════════════════════════════════
 

--- a/research/problems/lovasz-local-lemma-oq-04/knowledge.md
+++ b/research/problems/lovasz-local-lemma-oq-04/knowledge.md
@@ -62,3 +62,20 @@ algebraic cores over ℚ.
 - Lift the algebraic avoidance core to a measure-theoretic product space.
 - Sharpen the degree bound for partial overlaps → asymmetric weights beating the
   uniform symmetric threshold.
+
+## Session 2026-06-28 (Session 2, researcher-1) — sharpness of the degree bound
+
+SOLVED-strategy on the already-verified entry → looked outward. Part III bounded
+the variable-model max degree by k·(D-1) but did not show it is best possible.
+
+Added Part V': `tightVars : Fin 5 → Finset (Fin 2) := ![{0,1},{0},{0},{1},{1}]`
+(k=2 variables per event, D=3 events per variable) and `sharedDep_maxDegree_tight`:
+the central event 0 has degree exactly k·(D-1) = 4, with every event using ≤2
+variables and every variable used by ≤3 events. So `sharedDep_maxDegree` is sharp.
+
+- Proved by a single `decide` — kernel reduction (occ/sharedDep over Fin 5, Fin 2
+  are fully computable), so NO native_decide / no Lean.ofReduceBool; still 0-axiom.
+- Using V = Fin 2 (only two underlying variables) makes "∀ v, occ v ≤ D" a finite
+  decidable check, which is what lets the whole statement fall to `decide`.
+- `#print axioms sharedDep_maxDegree_tight` = [propext, Classical.choice, Quot.sound].
+- File now 259 lines, 15 theorems, 4 defs, 0 sorry / 0 axiom.

--- a/src/data/proofs/lovasz-local-lemma-oq-04/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "lovasz-local-lemma-oq-04",
   "title": "Lovász Local Lemma OQ-04: Variable Version with Asymmetric Dependencies",
   "slug": "lovasz-local-lemma-oq-04",
-  "description": "The asymmetric (general) Lovász Local Lemma gives each event A_i its own weight x_i ∈ [0,1) and requires P[A_i] ≤ x_i·∏_{j∈Γ(i)}(1-x_j). This file formalizes the asymmetric hypothesis as a predicate and derives its algebraic consequences (avoidance positivity, P[A_i] ≤ x_i), then builds the variable model of dependency — events as functions of shared underlying variables — proving the shared-variable graph is a valid (irreflexive, symmetric) dependency graph and bounding its maximum degree by k·(D-1) when each event uses ≤ k variables and each variable ≤ D events. Capstones combine these with the parent's symmetric threshold, and a separation theorem shows the local lemma strictly beats the union bound (avoidance possible while ∑P[A_i] > 1). Fully machine-verified, 0 sorries, 0 axioms.",
+  "description": "The asymmetric (general) Lovász Local Lemma gives each event A_i its own weight x_i ∈ [0,1) and requires P[A_i] ≤ x_i·∏_{j∈Γ(i)}(1-x_j). This file formalizes the asymmetric hypothesis as a predicate and derives its algebraic consequences (avoidance positivity, P[A_i] ≤ x_i), then builds the variable model of dependency — events as functions of shared underlying variables — proving the shared-variable graph is a valid (irreflexive, symmetric) dependency graph and bounding its maximum degree by k·(D-1) when each event uses ≤ k variables and each variable ≤ D events. Capstones combine these with the parent's symmetric threshold, and a separation theorem shows the local lemma strictly beats the union bound (avoidance possible while ∑P[A_i] > 1). Fully machine-verified, 0 sorries, 0 axioms. A sharpness witness shows the k·(D-1) degree bound is attained (and hence best possible).",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-28",
@@ -21,9 +21,9 @@
     "dateAdded": "2026-06-28",
     "axiomCount": 0,
     "assumptions": "0 axioms beyond Lean/Mathlib foundations (propext, Classical.choice, Quot.sound). The asymmetric LLL inequality P[A_i] ≤ x_i·∏(1-x_j) appears only as the antecedent of conditional theorems (predicate AsymLLL), not as an axiom: every result is a fully-proved implication. The probabilistic conclusion P[⋂ Āᵢ] ≥ ∏(1-x_i) is represented by its algebraic core (positivity of the avoidance product), matching the parent file's treatment.",
-    "lineCount": 239,
-    "theoremCount": 14,
-    "definitionCount": 3,
+    "lineCount": 259,
+    "theoremCount": 15,
+    "definitionCount": 4,
     "additionalFiles": [],
     "originalContributions": [
       "AsymLLL predicate: the asymmetric LLL hypothesis (per-event weights x_i ∈ [0,1) with P[A_i] ≤ x_i·∏_{j∈Γ(i)}(1-x_j)) packaged as a reusable Prop",
@@ -33,7 +33,8 @@
       "sharedDep_maxDegree: clean uniform degree bound k·(D−1) (≤ k variables per event, ≤ D events per variable) — the quantity feeding the symmetric threshold T(d)",
       "variable_lll_symmetric: capstone plugging the degree bound into the parent's symmetric_lll_complete, connecting the variable model to the threshold T(k·(D−1))",
       "asymLLL_beats_union_bound: for n > 2 there is an instance with ∑P[A_i] > 1 (union bound useless) yet positive avoidance product — the qualitative advantage of the local lemma",
-      "asymLLL_asymmetric_weights: concrete two-event mutually-dependent instance with distinct optimal weights x_0 = 1/4 ≠ 1/2 = x_1, both LLL inequalities tight"
+      "asymLLL_asymmetric_weights: concrete two-event mutually-dependent instance with distinct optimal weights x_0 = 1/4 ≠ 1/2 = x_1, both LLL inequalities tight",
+      "sharedDep_maxDegree_tight: a concrete witness (tightVars, k=2 vars/event, D=3 events/var on 5 events) where the central event attains degree exactly k·(D-1)=4, proving the degree bound sharedDep_maxDegree is sharp and cannot be improved in general (kernel decide, no native_decide)."
     ]
   },
   "overview": {
@@ -88,6 +89,13 @@
       "mathContext": "Uses Finset.card_biUnion_le and Finset.card_erase_of_mem; the uniform bound feeds the symmetric threshold."
     },
     {
+      "id": "sec-degree-sharp",
+      "title": "Sharpness of the Degree Bound",
+      "startLine": 205,
+      "endLine": 223,
+      "summary": "tightVars (k=2 variables per event, D=3 events per variable, 5 events) and sharedDep_maxDegree_tight: the central event has degree exactly k·(D-1)=4, so sharedDep_maxDegree is tight. Proved by kernel decide (no native_decide)."
+    },
+    {
       "id": "sec-capstones",
       "title": "Part IV: Capstones — The Variable LLL",
       "startLine": 176,
@@ -122,7 +130,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The asymmetric and variable versions of the Lovász Local Lemma are formalized and fully machine-verified: the asymmetric hypothesis yields avoidance positivity and per-event bounds, the shared-variable dependency graph is a valid dependency graph with maximum degree k·(D−1), and these combine with the symmetric threshold. A separation theorem shows the local lemma strictly beats the union bound. 0 sorries, 0 axioms.",
+    "summary": "The asymmetric and variable versions of the Lovász Local Lemma are formalized and fully machine-verified: the asymmetric hypothesis yields avoidance positivity and per-event bounds, the shared-variable dependency graph is a valid dependency graph with maximum degree k·(D−1), and these combine with the symmetric threshold. A separation theorem shows the local lemma strictly beats the union bound. 0 sorries, 0 axioms. The degree bound k·(D-1) is shown sharp by an explicit witness (sharedDep_maxDegree_tight).",
     "implications": "**Mathematical significance**: the variable model is the form of the LLL used in nearly all applications (constraint satisfaction, hypergraph colouring, Moser–Tardos). Formalizing that 'share a variable' yields a valid dependency graph, and quantifying its degree by local incidence data, makes the bridge from a problem's combinatorial structure to the symmetric threshold fully rigorous.\n\n**Connection to the constructive LLL**: the degree k·(D−1) is exactly the parameter governing the Moser–Tardos resampling bound; bounding it from the variable-event incidence is the first step in any algorithmic application.",
     "openQuestions": [
       "Can the degree bound be sharpened to account for events whose variable sets overlap only partially, yielding a per-event asymmetric weight assignment that beats the uniform symmetric threshold?",
@@ -139,12 +147,12 @@
       "ProbMethod.LovaszLocal"
     ],
     "namespace": "ProbMethod.LovaszLocal.OQ04",
-    "lineCount": 239,
+    "lineCount": 259,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 15,
     "substantiveTheoremCount": 12,
     "duplicateTheorems": 0,
-    "definitionCount": 3,
+    "definitionCount": 4,
     "path": "Proofs/LovaszLocalLemmaOQ04.lean",
     "sorries": 0,
     "additionalFiles": []
@@ -217,6 +225,11 @@
       "type": "corollary",
       "description": "A concrete mutually-dependent two-event instance with distinct optimal weights x_0 = 1/4 ≠ 1/2 = x_1",
       "leanType": "AsymLLL 2 ![1/8, 3/8] ![1/4, 1/2] ![{1}, {0}] ∧ (1/4 : ℚ) ≠ 1/2"
+    },
+    {
+      "name": "sharedDep_maxDegree_tight",
+      "statement": "An explicit variable assignment (k=2, D=3) where the central event attains degree exactly k·(D-1)=4.",
+      "significance": "Proves the degree bound sharedDep_maxDegree is sharp — k·(D-1) cannot be improved in general."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

The verified entry **lovasz-local-lemma-oq-04** (variable/asymmetric Lovász Local Lemma) proves in Part III that the shared-variable dependency graph has maximum degree `≤ k·(D−1)` when every event uses `≤ k` variables and every variable is used by `≤ D` events. It did **not** show this bound is best possible.

This PR adds the missing **sharpness witness**: an explicit configuration attaining the bound, so `sharedDep_maxDegree` cannot be improved in general.

## What's new (Part V′ — 1 def, 1 theorem)

- `tightVars : Fin 5 → Finset (Fin 2) := ![{0,1},{0},{0},{1},{1}]` — `k = 2` variables per event, `D = 3` events per variable. Event `0` uses both variables; variable `0` is shared with events `1,2` and variable `1` with events `3,4`.
- `sharedDep_maxDegree_tight`: every event uses `≤ 2` variables, every variable is used by `≤ 3` events, yet the central event has degree **exactly** `k·(D−1) = 4`.

## Verification

- `lake env lean Proofs/LovaszLocalLemmaOQ04.lean` — compiles clean.
- Proved by a single **kernel `decide`** (`occ`/`sharedDep` over `Fin 5`, `Fin 2` are fully computable) — **not** `native_decide`, so no `Lean.ofReduceBool`.
- `#print axioms sharedDep_maxDegree_tight` = `[propext, Classical.choice, Quot.sound]` only.
- File now **259 lines, 15 theorems, 0 sorry, 0 axiom**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)