### PR TITLE
research(egorov-theorem-oq-01-oq-03): convergence-in-measure face [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/EgorovTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/EgorovTheoremOQ01OQ03.lean
@@ -1,4 +1,5 @@
 import Mathlib.MeasureTheory.Function.Egorov
+import Mathlib.MeasureTheory.Function.ConvergenceInMeasure
 import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
 import Mathlib.Tactic
 
@@ -159,5 +160,51 @@ theorem marching_integral_not_tendsto_zero :
   simp only [marching_integral_eq_one]
   rw [tendsto_const_nhds_iff]
   norm_num
+
+/-! ## The same counterexample, seen through convergence in measure
+
+On a *finite*-measure space, almost-everywhere convergence implies convergence in
+measure (this is the easy half behind Egorov). The marching indicators show this too
+fails on `(ℝ, vol)`: they converge to `0` at every point, yet for the threshold
+`ε = 1/2` the bad set `{x : 1/2 ≤ |fₙ(x)|}` is exactly `[n, n+1]`, of constant measure
+`1`, which does not tend to `0`. So `fₙ` does **not** converge to `0` in measure. -/
+
+/-- **No convergence in measure.** Despite `fₙ → 0` everywhere (`marching_tendsto_zero`),
+the marching indicators do not converge to `0` in measure on `(ℝ, vol)`: for `ε = 1/2`
+the measure of `{x : 1/2 ≤ ‖fₙ(x)‖}` is the constant `1` (the length of `[n, n+1]`),
+so it cannot tend to `0`. This is the convergence-in-measure face of the infinite-measure
+pathology — on a finite-measure space a.e. convergence *would* force convergence in
+measure. -/
+theorem marching_not_tendstoInMeasure :
+    ¬ TendstoInMeasure volume marching atTop (fun _ => (0 : ℝ)) := by
+  intro h
+  have hpos : (0 : ℝ≥0∞) < 1 / 2 := ENNReal.half_pos one_ne_zero
+  have hmeas := h (1 / 2) hpos
+  have hvol : ∀ n : ℕ,
+      volume {x : ℝ | 1 / 2 ≤ edist (marching n x) ((fun _ => (0 : ℝ)) x)} = 1 := by
+    intro n
+    have hset : {x : ℝ | 1 / 2 ≤ edist (marching n x) ((fun _ => (0 : ℝ)) x)}
+        = Set.Icc (n : ℝ) (n + 1) := by
+      ext x
+      simp only [Set.mem_setOf_eq]
+      by_cases hx : x ∈ Set.Icc (n : ℝ) (n + 1)
+      · have hval : marching n x = 1 := by
+          unfold marching; rw [Set.indicator_of_mem hx, Pi.one_apply]
+        constructor
+        · intro _; exact hx
+        · intro _
+          rw [hval, edist_dist, Real.dist_eq, sub_zero, abs_one, ENNReal.ofReal_one]
+          exact ENNReal.half_le_self
+      · have hval : marching n x = 0 := by
+          unfold marching; rw [Set.indicator_of_notMem hx]
+        constructor
+        · intro hle
+          rw [hval, edist_self] at hle
+          exact absurd hle (not_le.mpr hpos)
+        · intro hxIcc; exact absurd hxIcc hx
+    rw [hset, Real.volume_Icc, show ((n : ℝ) + 1) - n = 1 from by ring, ENNReal.ofReal_one]
+  have htend : Tendsto (fun _ : ℕ => (1 : ℝ≥0∞)) atTop (𝓝 0) := hmeas.congr hvol
+  rw [tendsto_const_nhds_iff] at htend
+  exact one_ne_zero htend
 
 end EgorovTheoremOQ01OQ03

--- a/research/problems/egorov-theorem-oq-01-oq-03/knowledge.md
+++ b/research/problems/egorov-theorem-oq-01-oq-03/knowledge.md
@@ -78,3 +78,22 @@ GOTCHA: `setIntegral_const` yields `volume.real (Icc ..)` (the `Measure.real` fo
 - None required; problem resolved. Possible future follow-up: derive the same
   sharpness from a σ-finite-but-infinite abstract measure space rather than the
   concrete `(ℝ, Lebesgue)` instance.
+
+## Session 2026-06-28 (Session 3, researcher-1) — convergence-in-measure face
+
+SOLVED → looked outward. Added the fourth reading of the marching counterexample:
+`marching_not_tendstoInMeasure` — fₙ → 0 everywhere pointwise but does NOT converge
+to 0 in measure on (ℝ, vol). On a finite-measure space a.e. convergence forces
+convergence in measure (the easy half behind Egorov); this is the infinite-measure
+failure.
+
+- For ε = 1/2 the bad set `{x | 1/2 ≤ edist (marching n x) 0}` is exactly `Icc n (n+1)`,
+  volume constant 1 → the measure sequence is const 1 ↛ 𝓝 0.
+- `TendstoInMeasure` (Mathlib MeasureTheory.Function.ConvergenceInMeasure) uses
+  `edist` (ℝ≥0∞), ε : ℝ≥0∞: `∀ ε>0, Tendsto (fun i => μ {x | ε ≤ edist (f i x) (g x)}) l (𝓝 0)`.
+- GOTCHAs: `edist_dist`+`Real.dist_eq`+`sub_zero`+`abs_one`+`ENNReal.ofReal_one` to compute
+  edist 1 0 = 1; `ENNReal.half_le_self : a/2 ≤ a`; `ENNReal.half_pos one_ne_zero : 0 < 1/2`;
+  `edist_self` for the x∉Icc branch; finish via `hmeas.congr hvol` + `tendsto_const_nhds_iff`.
+  Needed an explicit `import Mathlib.MeasureTheory.Function.ConvergenceInMeasure`.
+- Verified: lake env lean clean; #print axioms = [propext, Classical.choice, Quot.sound].
+  File now 210 lines, 7 theorems, 0 sorry / 0 axiom.

--- a/src/data/proofs/egorov-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/egorov-theorem-oq-01-oq-03/meta.json
@@ -14,9 +14,9 @@
       "Topology"
     ],
     "namespace": "EgorovTheoremOQ01OQ03",
-    "lineCount": 163,
+    "lineCount": 210,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 1,
     "path": "Proofs/EgorovTheoremOQ01OQ03.lean",
     "sorries": 0
@@ -39,8 +39,8 @@
     ],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 163,
-    "theoremCount": 6,
+    "lineCount": 210,
+    "theoremCount": 7,
     "definitionCount": 1,
     "badge": "verified",
     "originalContributions": [
@@ -50,7 +50,8 @@
       "marching_not_tendstoUniformlyOn_univ: the s = ∅ corollary — fₙ does not converge uniformly to 0 on all of ℝ, the cleanest one-line statement of non-uniformity on the infinite-measure space.",
       "marching: the marching-indicator construction 𝟙_[n,n+1] on ℝ as a Set.indicator, the unit bump that marches to +∞.",
       "marching_integral_eq_one: each marching indicator integrates to exactly 1 (∫ 𝟙_[n,n+1] = vol[n,n+1] = 1) — the unit of mass is conserved for every n even as the bump escapes to +∞.",
-      "marching_integral_not_tendsto_zero: the SAME counterexample breaks the limit–integral interchange — although fₙ → 0 everywhere, ∫ fₙ = 1 ↛ 0 = ∫(lim fₙ). This exhibits the integral-side face of the infinite-measure pathology (mass escaping to infinity): on a finite-measure space Egorov would force uniform convergence off a small set and hence control the integrals."
+      "marching_integral_not_tendsto_zero: the SAME counterexample breaks the limit–integral interchange — although fₙ → 0 everywhere, ∫ fₙ = 1 ↛ 0 = ∫(lim fₙ). This exhibits the integral-side face of the infinite-measure pathology (mass escaping to infinity): on a finite-measure space Egorov would force uniform convergence off a small set and hence control the integrals.",
+      "marching_not_tendstoInMeasure: the convergence-in-measure face — the marching indicators converge to 0 everywhere yet do NOT converge to 0 in measure on (ℝ, vol), since {x : 1/2 ≤ ‖fₙ(x)‖} = [n,n+1] has constant measure 1. On a finite-measure space a.e. convergence would force convergence in measure; this exhibits the infinite-measure failure."
     ],
     "prerequisites": [
       "Metric.tendstoUniformlyOn_iff: the ε-characterization of uniform convergence on a set, used to refute uniformity at ε = 1/2",
@@ -165,11 +166,16 @@
       "endLine": 133,
       "summary": "marching_not_tendstoUniformlyOn_of_volume_lt_top: for any s with vol s < ∞, fₙ is not uniform on sᶜ. Uniformity at ε = 1/2 forces [n,n+1] ⊆ s for all n ≥ N, hence [N,∞) ⊆ s (via floor bounds), so vol s ≥ vol[N,∞) = ∞ — contradiction. Packaged as volume_finite_hypothesis_essential and specialized to s = ∅ in marching_not_tendstoUniformlyOn_univ.",
       "mathContext": "Uniform 1/2-control off s past index N ⇒ the tail [N,∞) ⊆ s ⇒ vol s = ∞, contradicting finiteness. Only monotonicity of measure is used; s need not be measurable."
+    },
+    {
+      "id": "conv-in-measure",
+      "title": "No Convergence in Measure",
+      "summary": "marching_not_tendstoInMeasure: fₙ → 0 everywhere but not in measure on (ℝ, vol). For ε = 1/2 the bad set {x : 1/2 ≤ edist (fₙ x) 0} equals [n,n+1] (volume 1, constant), so it cannot tend to 0 — the infinite-measure failure of the a.e. ⇒ in-measure implication that holds on finite-measure spaces."
     }
   ],
   "sorries": 0,
   "conclusion": {
-    "summary": "The finite-measure hypothesis in Egorov's theorem is essential. On (ℝ, Lebesgue) the marching indicators fₙ = 𝟙_[n,n+1] converge to 0 at every point (marching_tendsto_zero), yet for any set s of finite Lebesgue measure they fail to converge uniformly to 0 on sᶜ (marching_not_tendstoUniformlyOn_of_volume_lt_top): uniform 1/2-control off s would force the infinite-measure tail [N,∞) into s. Packaged as volume_finite_hypothesis_essential (no finite-measure exceptional set exists) and marching_not_tendstoUniformlyOn_univ (non-uniformity on all of ℝ). The same construction is read through integrals: each fₙ has integral 1 (marching_integral_eq_one), so ∫ fₙ = 1 ↛ 0 = ∫(lim fₙ) (marching_integral_not_tendsto_zero) — the mass-escaping-to-infinity, integral-side face of the infinite-measure pathology. 163 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "summary": "The finite-measure hypothesis in Egorov's theorem is essential. On (ℝ, Lebesgue) the marching indicators fₙ = 𝟙_[n,n+1] converge to 0 at every point (marching_tendsto_zero), yet for any set s of finite Lebesgue measure they fail to converge uniformly to 0 on sᶜ (marching_not_tendstoUniformlyOn_of_volume_lt_top): uniform 1/2-control off s would force the infinite-measure tail [N,∞) into s. Packaged as volume_finite_hypothesis_essential (no finite-measure exceptional set exists) and marching_not_tendstoUniformlyOn_univ (non-uniformity on all of ℝ). The same construction is read through integrals: each fₙ has integral 1 (marching_integral_eq_one), so ∫ fₙ = 1 ↛ 0 = ∫(lim fₙ) (marching_integral_not_tendsto_zero) — the mass-escaping-to-infinity, integral-side face of the infinite-measure pathology. 163 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries. A convergence-in-measure face is also added: fₙ → 0 everywhere yet not in measure, the infinite-measure failure of the a.e. ⇒ in-measure implication.",
     "implications": "Together with the parent entry — which shows the removed exceptional set cannot be taken null on a finite-measure example — this delimits Egorov's theorem from both sides: the conclusion needs a genuinely positive exceptional set, and the hypothesis needs genuinely finite total measure. The integral view links the failure to the failure of the limit–integral interchange (and dominated/bounded convergence) on infinite-measure spaces: a single escaping unit of mass defeats both. The counterexample is original to the gallery; Mathlib has the theorem but not the sharpness witness.",
     "openQuestions": []
   }


### PR DESCRIPTION
## Summary

Adds a fourth complementary reading of the marching-indicator counterexample in the verified entry **egorov-theorem-oq-01-oq-03** (sharpness of Egorov: the finite-measure hypothesis is essential).

The entry already shows the marching indicators `fₙ = 𝟙_[n,n+1]` (a) converge to `0` everywhere, (b) admit no finite-measure set off which convergence is uniform, and (c) break the limit–integral interchange. This PR adds the **convergence-in-measure** face:

> `marching_not_tendstoInMeasure` — `fₙ → 0` at every point, yet `fₙ` does **not** converge to `0` in measure on `(ℝ, vol)`.

On a *finite*-measure space, almost-everywhere convergence implies convergence in measure (the easy half behind Egorov). Here, for `ε = 1/2`, the bad set `{x : 1/2 ≤ edist(fₙ x, 0)}` is exactly `[n, n+1]`, of constant measure `1`, so the measure sequence is the constant `1` and cannot tend to `0`. This is precisely the infinite-measure failure of the implication.

## Verification

- `lake env lean Proofs/EgorovTheoremOQ01OQ03.lean` — compiles clean.
- `#print axioms marching_not_tendstoInMeasure` = `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `native_decide`/`ofReduceBool`.
- File now **210 lines, 7 theorems, 0 sorry, 0 axiom**. Added one import (`Mathlib.MeasureTheory.Function.ConvergenceInMeasure`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)