### PR TITLE
research(erdos-882-oq-03): cardinality counting anchor |subsetSums A| ≤ 2^|A|−1 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos882ProblemOQ03.lean
+++ b/proofs/Proofs/Erdos882ProblemOQ03.lean
@@ -14,11 +14,17 @@ This file supplies that missing structural layer — all fully machine-checked
   * `DivisibilityFree.mono`   — divisibility-freeness is hereditary;
   * `validSubset_subset`      — **`ValidSubset` is downward closed**;
   * `subsetSums_nonempty`     — a non-empty set has a non-empty sum set;
-  * `subsetSums_pos`          — subset sums of positive sets are positive.
+  * `subsetSums_pos`          — subset sums of positive sets are positive;
+  * `nonemptySubsets_card`    — there are exactly `2^|A| − 1` non-empty subsets;
+  * `subsetSums_card_le`      — **`|subsetSums A| ≤ 2^|A| − 1`** (counting anchor);
+  * `subsetSums_singleton`    — `subsetSums {a} = {a}`.
 
 The headline is downward closure: any subset of a valid set is valid — the
 standard "WLOG pass to a sub-configuration" tool for extremal arguments, and
-the exact monotonicity the upper-bound proof leans on.
+the exact monotonicity the upper-bound proof leans on.  The new cardinality
+bound `subsetSums_card_le` supplies the information-theoretic counting anchor
+behind the `(1+o(1)) log₂ n` upper bound: the sum map cannot manufacture more
+than `2^|A| − 1` distinct subset sums.
 
 Self-contained: the four predicates are re-declared here (the parent file
 predates the current Mathlib toolchain and no longer builds), using the modern
@@ -100,5 +106,45 @@ theorem subsetSums_pos {A : Finset ℕ} (hA : ∀ a ∈ A, 1 ≤ a) :
   obtain ⟨b, hb⟩ := Finset.nonempty_iff_ne_empty.mpr hSne
   calc 1 ≤ b := hA b (hSsub hb)
     _ ≤ S.sum id := Finset.single_le_sum (fun i _ => Nat.zero_le (id i)) hb
+
+/-- The family of non-empty subsets has exactly `2^|A| − 1` members: the full
+    powerset has `2^|A|` elements and we discard only the empty set. -/
+theorem nonemptySubsets_card (A : Finset ℕ) :
+    (nonemptySubsets A).card = 2 ^ A.card - 1 := by
+  unfold nonemptySubsets
+  rw [Finset.filter_ne', Finset.card_erase_of_mem (Finset.empty_mem_powerset A),
+    Finset.card_powerset]
+
+/-- **Information-theoretic cardinality bound.**  A set with `|A|` elements has at
+    most `2^|A| − 1` distinct non-empty subset sums — the sum map can only collapse
+    the `2^|A| − 1` non-empty subsets, never create new values.  This is the
+    counting anchor behind the `(1+o(1))log₂ n` upper bound: a divisibility-free
+    family of subset sums inside `{1,…,n·|A|}` cannot be too large, while the sums
+    themselves number at most `2^|A| − 1`. -/
+theorem subsetSums_card_le (A : Finset ℕ) :
+    (subsetSums A).card ≤ 2 ^ A.card - 1 := by
+  unfold subsetSums
+  exact le_trans Finset.card_image_le (le_of_eq (nonemptySubsets_card A))
+
+/-- The subset-sum set of a singleton is the singleton itself: the only non-empty
+    subset of `{a}` is `{a}`, whose sum is `a`. -/
+theorem subsetSums_singleton (a : ℕ) : subsetSums {a} = {a} := by
+  apply Finset.Subset.antisymm
+  · intro s hs
+    unfold subsetSums nonemptySubsets at hs
+    rw [Finset.mem_image] at hs
+    obtain ⟨S, hS, rfl⟩ := hs
+    rw [Finset.mem_filter, Finset.mem_powerset, Finset.subset_singleton_iff] at hS
+    rcases hS.1 with h | h
+    · exact absurd h hS.2
+    · simp [h]
+  · intro s hs
+    rw [Finset.mem_singleton] at hs
+    subst hs
+    unfold subsetSums nonemptySubsets
+    rw [Finset.mem_image]
+    refine ⟨{s}, ?_, by simp⟩
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    exact ⟨Finset.Subset.refl _, Finset.singleton_ne_empty s⟩
 
 end Erdos882OQ03

--- a/src/data/research/problems/erdos-882-oq-03.json
+++ b/src/data/research/problems/erdos-882-oq-03.json
@@ -10,17 +10,19 @@
       "Headline: ValidSubset is DOWNWARD CLOSED — any subset of a valid set is valid. This is the WLOG 'pass to a sub-configuration' tool extremal arguments rely on, and the exact monotonicity the upper bound uses.",
       "Built from two monotonicities: subsetSums_mono (A ⊆ B ⟹ subsetSums A ⊆ subsetSums B, since any non-empty S ⊆ A is a non-empty subset of B) and DivisibilityFree.mono (hereditary).",
       "subsetSums_nonempty (a non-empty set has a non-empty subset sum via a singleton) and subsetSums_pos (positive sets have positive subset sums, via Finset.single_le_sum) pin down basic positivity/non-triviality.",
-      "The parent Erdos882Problem.lean is BIT-ROTTED on the current toolchain (Finset.sum_le_sum unknown, Algebra.id.smul_eq_mul unknown, maxValidSize Nat.find Decidable synthesis fails) — so this child re-declares the four predicates self-contained with the modern Finset API."
+      "The parent Erdos882Problem.lean is BIT-ROTTED on the current toolchain (Finset.sum_le_sum unknown, Algebra.id.smul_eq_mul unknown, maxValidSize Nat.find Decidable synthesis fails) — so this child re-declares the four predicates self-contained with the modern Finset API.",
+      "Counting anchor: |subsetSums A| ≤ 2^|A| − 1 (subsetSums_card_le) follows from Finset.card_image_le composed with nonemptySubsets_card (|A.powerset.filter (·≠∅)| = 2^|A| − 1, via Finset.filter_ne' + card_erase_of_mem + card_powerset). The sum map can only collapse the 2^|A|−1 non-empty subsets, never create values — this is the information-theoretic side of the (1+o(1))log₂ n upper bound."
     ],
     "builtItems": [
-      "Erdos882ProblemOQ03.lean: 4 defs + 5 theorems, 0 axioms, 0 sorries, self-contained.",
-      "subsetSums_mono, DivisibilityFree.mono, validSubset_subset (downward closure), subsetSums_nonempty, subsetSums_pos."
+      "Erdos882ProblemOQ03.lean: 4 defs + 8 theorems, 0 axioms, 0 sorries, self-contained.",
+      "subsetSums_mono, DivisibilityFree.mono, validSubset_subset (downward closure), subsetSums_nonempty, subsetSums_pos.",
+      "nonemptySubsets_card (|nonemptySubsets A| = 2^|A| − 1), subsetSums_card_le (|subsetSums A| ≤ 2^|A| − 1 — the information-theoretic counting anchor), subsetSums_singleton (subsetSums {a} = {a})."
     ],
-    "progressSummary": "Child of erdos-882 (Subset Sums Without Divisibility). The parent states the analytic bounds as axioms but proves no structural facts; this entry supplies the structural layer: subset-sum and divisibility-free monotonicity, the downward closure of ValidSubset (WLOG sub-configuration tool), and basic non-emptiness/positivity. All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide. Self-contained re-declaration of the four predicates (parent file no longer builds on the current Mathlib).",
+    "progressSummary": "Child of erdos-882 (Subset Sums Without Divisibility). The parent states the analytic bounds as axioms but proves no structural facts; this entry supplies the structural layer: subset-sum and divisibility-free monotonicity, the downward closure of ValidSubset (WLOG sub-configuration tool), basic non-emptiness/positivity, the exact non-empty-subset count 2^|A|−1, the cardinality bound |subsetSums A| ≤ 2^|A|−1 anchoring the information-theoretic side of the (1+o(1))log₂ n upper bound, and the singleton sum set. All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide. Self-contained re-declaration of the four predicates (parent file no longer builds on the current Mathlib).",
     "nextSteps": [
-      "Prove subsetSums_singleton (subsetSums {a} = {a}) and subsetSums of an insert, to compute sum sets of explicit constructions.",
+      "Prove subsetSums of an insert (subsetSums (insert a A) in terms of subsetSums A) to compute sum sets of explicit constructions.",
       "Formalize 'distinct subset sums' as a consequence of, or relation to, divisibility-free sums (the parent's DistinctSubsetSums is defined but unconnected).",
-      "Establish the cardinality bound |subsetSums A| ≤ 2^|A| − 1 to anchor the information-theoretic side of the upper bound.",
+      "Combine subsetSums_card_le with the membership bound subsetSums A ⊆ {1,…,n·|A|} to make the counting side of the upper bound explicit.",
       "Repair the parent Erdos882Problem.lean toolchain drift so the structural lemmas can be imported back."
     ]
   },
@@ -44,8 +46,8 @@
     {
       "path": "Proofs/Erdos882ProblemOQ03.lean",
       "filename": "Erdos882ProblemOQ03.lean",
-      "lineCount": 105,
-      "theoremCount": 5,
+      "lineCount": 150,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Extends the structural layer of **Erdős Problem #882 OQ-03** (`Erdos882ProblemOQ03.lean`) with three machine-checked theorems, completing two of the entry's documented next steps (the `subsetSums_singleton` computation and the `2^|A|−1` cardinality bound).

Erdős #882 asks for the largest `A ⊆ {1,…,n}` whose non-empty subset sums are pairwise non-dividing (answer `(1+o(1)) log₂ n`). The parent file states the deep analytic bounds as axioms but proves no structural facts; this file supplies the structural/counting layer, fully self-contained on the modern Finset API.

## New theorems

| Theorem | Statement |
|---|---|
| `nonemptySubsets_card` | `|A.powerset.filter (·≠∅)| = 2^|A| − 1` |
| `subsetSums_card_le` | `|subsetSums A| ≤ 2^|A| − 1` — information-theoretic counting anchor |
| `subsetSums_singleton` | `subsetSums {a} = {a}` |

The cardinality bound composes `Finset.card_image_le` with `nonemptySubsets_card`: the sum map can only **collapse** the `2^|A|−1` non-empty subsets, never create new values. This is the counting side of the `(1+o(1)) log₂ n` upper bound.

## Verification

- 0 axioms, 0 sorries. `#print axioms` on each new theorem lists only `propext`, `Classical.choice`, `Quot.sound` (the ordinary foundational axioms — none count under the project axiom policy). No `native_decide`.
- Single-file typecheck under `lean v4.26.0` + Mathlib oleans: **EXIT 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)