### PR TITLE
research(pythagorean-triples-oq-03): gallery entry for merged 0-axiom proof

### DIFF
--- a/research/problems/pythagorean-triples-oq-03/knowledge.md
+++ b/research/problems/pythagorean-triples-oq-03/knowledge.md
@@ -59,3 +59,26 @@ For a prime p, study the conic C_p : x² + y² = p over ℚ:
 - Docker (containerd) backend was down this session; verification used `lean`
   directly with a hand-assembled LEAN_PATH over the prebuilt olean cache
   (build dirs now nest under `.lake/build/lib/lean/`).
+
+## Session 2026-06-28 (Session 2) — GALLERY INTEGRATION
+
+**Mode:** FOLLOW-UP (proof already merged via #30916)
+**Outcome:** added missing gallery entry
+
+### What I Did
+- The verified proof shipped in #30916 but had NO gallery directory
+  (`src/data/proofs/pythagorean-triples-oq-03/` was absent), so it never
+  surfaced in the web gallery. Created it:
+  - `meta.json` — full overview/sections/conclusion/crossReferences, 13 theorems,
+    2 defs, 255 lines, badge `mathlib`, 0 sorries / 0 axioms.
+  - `annotations.json` — 9 annotations (header, param def, param-on-circle,
+    completeness, easy existence, mod-p obstruction, descent, rational
+    obstruction + iff, instances), ranges verified within the 255-line file.
+- Validated: `pnpm gallery:check-size` EXIT 0 ("all 4124 entries within caps").
+  `pnpm annotations:validate` scans all 4124 proofs and times out (~200s, perf
+  limit, not a schema error); both files are valid JSON matching the live
+  erdos-307-oq-02-oq-01 schema field-for-field.
+
+### Files Modified
+- `src/data/proofs/pythagorean-triples-oq-03/meta.json` (new)
+- `src/data/proofs/pythagorean-triples-oq-03/annotations.json` (new)

--- a/src/data/proofs/pythagorean-triples-oq-03/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-03/annotations.json
@@ -1,0 +1,184 @@
+[
+  {
+    "id": "ann-pt-oq03-header",
+    "proofId": "pythagorean-triples-oq-03",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "concept",
+    "title": "Rational Points of the Circle x² + y² = p",
+    "content": "The file studies the conic C_p : x² + y² = p over ℚ from two angles. EXISTENCE: C_p has a rational point if and only if p ≢ 3 (mod 4). PARAMETRIZATION: once a single rational base point (a,b) is known, every other rational point arises by stereographic projection — intersect C_p with the line of rational slope t through (a,b). The file is deliberately distinct from its siblings FermatTwoSquares.lean (the integer sum-of-two-squares characterization) and PythagoreanTriplesOQ02.lean (the Gaussian-integer view): here the object of study is the set of RATIONAL points and its one-parameter rational sweep. Everything is verified at 0 sorries and 0 axioms (propext / Classical.choice / Quot.sound only).",
+    "summary": "Existence (p ≢ 3 mod 4) and stereographic parametrization of the rational points of x² + y² = p.",
+    "mathContext": "$C_p : x^2 + y^2 = p$ over $\\mathbb{Q}$. Existence $\\iff p \\not\\equiv 3 \\pmod 4$; given a base point $(a,b)$, every rational point is the stereographic image of a chord of rational slope $t$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "conics over ℚ",
+      "stereographic projection",
+      "Fermat two-square theorem",
+      "rational points",
+      "sum of two squares"
+    ],
+    "prerequisites": [
+      "rational arithmetic",
+      "primes mod 4",
+      "finite fields ℤ/p"
+    ]
+  },
+  {
+    "id": "ann-pt-oq03-param-def",
+    "proofId": "pythagorean-triples-oq-03",
+    "range": { "startLine": 45, "endLine": 64 },
+    "type": "definition",
+    "title": "The Stereographic Coordinates px, py",
+    "content": "px a b t and py a b t are the coordinates of the SECOND intersection of the line of slope t through the base point (a,b) with the circle x²+y²=a²+b². Concretely px = (a(t²−1) − 2bt)/(1+t²) and py = (b(1−t²) − 2at)/(1+t²). The denominator 1+t² is strictly positive over ℚ (one_add_sq_ne, by positivity), so the map is total — no exceptional slopes to exclude. param_on_circle then verifies px²+py² = a²+b² as an identity in a, b, t: after unfold and field_simp the goal is a polynomial identity closed by ring.",
+    "summary": "Defines the slope-t stereographic image of the base point and proves it lands back on the circle.",
+    "mathContext": "$p_x = \\dfrac{a(t^2-1)-2bt}{1+t^2}$, $p_y = \\dfrac{b(1-t^2)-2at}{1+t^2}$; $1+t^2 \\neq 0$ over $\\mathbb{Q}$, and $p_x^2+p_y^2 = a^2+b^2$ identically.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "stereographic projection",
+      "chord of a conic",
+      "field_simp",
+      "positivity"
+    ],
+    "prerequisites": [
+      "rational functions",
+      "polynomial identities"
+    ]
+  },
+  {
+    "id": "ann-pt-oq03-param-circle",
+    "proofId": "pythagorean-triples-oq-03",
+    "range": { "startLine": 66, "endLine": 70 },
+    "type": "theorem",
+    "title": "Parametrized Points Lie on x² + y² = p",
+    "content": "param_mem_circle specializes param_on_circle to a base point on the target circle: if a²+b² = p then px²+py² = p for every slope t. This is the 'forward' half of the parametrization — the map ℚ → C_p is well-defined — and it is immediate from param_on_circle by rewriting with the hypothesis a²+b² = p.",
+    "summary": "If the base point lies on x²+y²=p, so does every parametrized point.",
+    "mathContext": "$a^2+b^2 = p \\Rightarrow p_x(t)^2 + p_y(t)^2 = p$ for all $t$, by $p_x^2+p_y^2 = a^2+b^2$ and substitution.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "well-defined map into a conic"
+    ],
+    "prerequisites": [
+      "rewriting hypotheses"
+    ]
+  },
+  {
+    "id": "ann-pt-oq03-recovers",
+    "proofId": "pythagorean-triples-oq-03",
+    "range": { "startLine": 76, "endLine": 96 },
+    "type": "theorem",
+    "title": "Completeness: Every Rational Point Is Parametrized",
+    "content": "param_recovers proves surjectivity of the parametrization: any rational point (x,y) on the circle through (a,b) with x ≠ a equals (px(t), py(t)) for the chord slope t = (y−b)/(x−a). Combined with param_on_circle this is a bijection between ℚ ∪ {∞} and the rational points of the circle. The proof is an EXACT algebraic identity: clearing the denominator with div_eq_iff and field_simp, both px(t)−x and py(t)−y become multiples of the circle relation x²+y²−a²−b², which vanishes by hcirc. linear_combination (a−x)·hcirc and (b−y)·hcirc — the coefficients found by dividing the goal difference by the circle relation — discharge the two components.",
+    "summary": "Surjectivity of the parametrization, via an exact identity closed by linear_combination against the circle relation.",
+    "mathContext": "With $t=(y-b)/(x-a)$: $p_x(t)-x$ and $p_y(t)-y$ are each a multiple of $x^2+y^2-a^2-b^2 = 0$. Closed by $\\texttt{linear\\_combination}\\ (a-x)\\,h_{circ}$ and $(b-y)\\,h_{circ}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "surjectivity",
+      "linear_combination",
+      "div_eq_iff",
+      "rational parametrization of conics"
+    ],
+    "prerequisites": [
+      "exact polynomial identities",
+      "linear_combination tactic"
+    ]
+  },
+  {
+    "id": "ann-pt-oq03-exist-easy",
+    "proofId": "pythagorean-triples-oq-03",
+    "range": { "startLine": 102, "endLine": 109 },
+    "type": "theorem",
+    "title": "Existence, Easy Direction: Fermat Two Squares",
+    "content": "rational_point_of_not_three_mod_four: a prime p ≢ 3 (mod 4) yields a rational point on x²+y²=p. This is immediate from Mathlib's Nat.Prime.sq_add_sq, which produces integers a, b with a²+b²=p; an integer point is a fortiori rational, so casting to ℚ finishes. The whole content of this direction is Fermat's two-square theorem.",
+    "summary": "p ≢ 3 (mod 4) ⟹ a (in fact integer) rational point exists, via Nat.Prime.sq_add_sq.",
+    "mathContext": "$p \\not\\equiv 3 \\pmod 4 \\Rightarrow \\exists a,b \\in \\mathbb{N},\\ a^2+b^2=p$ (Fermat); cast to $\\mathbb{Q}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fermat two-square theorem",
+      "Nat.Prime.sq_add_sq"
+    ],
+    "prerequisites": [
+      "sum of two squares",
+      "cast ℕ → ℚ"
+    ]
+  },
+  {
+    "id": "ann-pt-oq03-modp",
+    "proofId": "pythagorean-triples-oq-03",
+    "range": { "startLine": 111, "endLine": 136 },
+    "type": "theorem",
+    "title": "The mod-p Obstruction via ZMod",
+    "content": "prime_dvd_of_dvd_sq_add_sq is the arithmetic heart of the hard direction: for prime p ≡ 3 (mod 4), if p ∣ X²+Y² then p ∣ X and p ∣ Y. Work in the field ZMod p. There X²+Y²=0; if Y were a unit then (X/Y)² = −1, making −1 a square mod p — contradicting ZMod.exists_sq_eq_neg_one_iff, which says −1 is a square mod p exactly when p % 4 ≠ 3. Hence Y ≡ 0, and then X² ≡ 0 forces X ≡ 0. This is the Gaussian-integer obstruction recast entirely inside ℤ/p — no ℤ[i] needed.",
+    "summary": "p ≡ 3 (mod 4), p ∣ X²+Y² ⟹ p ∣ X ∧ p ∣ Y, because −1 is not a square mod p (ZMod.exists_sq_eq_neg_one_iff).",
+    "mathContext": "In $\\mathbb{Z}/p$: $X^2+Y^2=0$ and $Y \\neq 0 \\Rightarrow (X/Y)^2=-1$, impossible when $p \\equiv 3 \\pmod 4$. So $Y \\equiv 0$, then $X^2 \\equiv 0 \\Rightarrow X \\equiv 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic residues",
+      "−1 as a square mod p",
+      "ZMod.exists_sq_eq_neg_one_iff",
+      "finite field ℤ/p"
+    ],
+    "prerequisites": [
+      "ZMod p is a field",
+      "quadratic residue −1 mod p"
+    ]
+  },
+  {
+    "id": "ann-pt-oq03-descent",
+    "proofId": "pythagorean-triples-oq-03",
+    "range": { "startLine": 138, "endLine": 171 },
+    "type": "theorem",
+    "title": "Infinite Descent on |W|",
+    "content": "no_int_sol_of_three_mod_four rules out X²+Y² = p·W² for W ≠ 0 when p ≡ 3 (mod 4), by strong induction on |W| (Nat.strongRecOn). At each step the obstruction gives p ∣ X and p ∣ Y; writing X = pX′, Y = pY′ and cancelling p yields p(X′²+Y′²) = W², so p ∣ W and W = pW′. Substituting produces X′²+Y′² = p·W′² with |W′| < |W| (since p > 1), a strictly smaller solution — contradiction. This is classical Fermat descent, organized as well-founded recursion on the natural number |W|.",
+    "summary": "X²+Y²=p·W² with W ≠ 0 is impossible for p ≡ 3 (mod 4), by strong induction on |W|.",
+    "mathContext": "$p \\mid X, Y \\Rightarrow p(X'^2+Y'^2)=W^2 \\Rightarrow p \\mid W \\Rightarrow X'^2+Y'^2=pW'^2$ with $|W'|<|W|$. Descent terminates only at $W=0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "infinite descent",
+      "Nat.strongRecOn",
+      "well-founded recursion",
+      "Fermat descent"
+    ],
+    "prerequisites": [
+      "strong induction",
+      "Int.natAbs"
+    ]
+  },
+  {
+    "id": "ann-pt-oq03-rational-obstruction",
+    "proofId": "pythagorean-triples-oq-03",
+    "range": { "startLine": 173, "endLine": 212 },
+    "type": "theorem",
+    "title": "Rational Obstruction and the Existence Characterization",
+    "content": "no_rational_point_three_mod_four upgrades the integer descent to ℚ: a hypothetical rational solution (x,y) is cleared to integers X = x.num·y.den, Y = y.num·x.den, W = x.den·y.den with W ≠ 0, satisfying X²+Y² = p·W²; no_int_sol_of_three_mod_four then closes it. The key realization is that the rational case needs NO new descent — clearing denominators lands exactly in the integer equation already ruled out. rational_point_iff assembles both directions into the clean characterization: x²+y²=p has a rational point ⟺ p ≢ 3 (mod 4).",
+    "summary": "Clearing denominators reduces the rational obstruction to the integer one; rational_point_iff packages the full ⟺.",
+    "mathContext": "Clear $(x,y)$ to $X=x.\\mathrm{num}\\,y.\\mathrm{den}$, $Y=y.\\mathrm{num}\\,x.\\mathrm{den}$, $W=x.\\mathrm{den}\\,y.\\mathrm{den}\\neq 0$, giving $X^2+Y^2=pW^2$. Then $\\exists$ rational point $\\iff p \\not\\equiv 3 \\pmod 4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "clearing denominators",
+      "Rat.num_div_den",
+      "existence dichotomy",
+      "rational vs integer solubility"
+    ],
+    "prerequisites": [
+      "rational number numerator/denominator",
+      "exact_mod_cast"
+    ]
+  },
+  {
+    "id": "ann-pt-oq03-instances",
+    "proofId": "pythagorean-triples-oq-03",
+    "range": { "startLine": 214, "endLine": 233 },
+    "type": "example",
+    "title": "Concrete Rational Points",
+    "content": "Worked instances anchor the abstractions. base_5 and base_13 exhibit integer base points (2,1) on x²+y²=5 and (3,2) on x²+y²=13. rational_point_5 and rational_point_5_coords then run the parametrization from (2,1) at slope t=2 to produce the genuinely NON-integer rational point (2/5, −11/5) on x²+y²=5 — concrete evidence that the rational points strictly extend the integer points.",
+    "summary": "Base points (2,1) on x²+y²=5 and (3,2) on x²+y²=13, and the non-integer rational point (2/5,−11/5) on x²+y²=5.",
+    "mathContext": "At $p=5$, base $(2,1)$, slope $t=2$: $(p_x,p_y) = (2/5,\\,-11/5)$ and $(2/5)^2+(-11/5)^2 = 125/25 = 5$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked examples",
+      "non-integer rational points"
+    ],
+    "prerequisites": [
+      "norm_num"
+    ]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-03/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-03/meta.json
@@ -1,0 +1,123 @@
+{
+  "id": "pythagorean-triples-oq-03",
+  "title": "Rational Points on x² + y² = p: Existence and Stereographic Parametrization",
+  "slug": "pythagorean-triples-oq-03",
+  "description": "For a prime p, characterizes the rational points of the conic x² + y² = p: a rational point exists iff p ≢ 3 (mod 4) (Fermat two-square theorem one way, infinite descent the other), and once a rational base point (a,b) is fixed every rational point is the stereographic image of a chord of rational slope. Both directions are proved elementarily — the p ≡ 3 obstruction uses ZMod field arithmetic plus descent, no Gaussian integers.",
+  "meta": {
+    "author": "Research (rational points of x² + y² = p)",
+    "sourceUrl": "https://erdosproblems.com/",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ03.lean",
+    "tags": [
+      "number-theory",
+      "conics",
+      "rational-points",
+      "stereographic-projection",
+      "fermat-two-squares",
+      "sum-of-two-squares",
+      "infinite-descent",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 255,
+    "assumptions": "0 sorries, 0 axioms (depends only on propext, Classical.choice, Quot.sound). Fully verified.",
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Full rational-point existence characterization rational_point_iff: x²+y²=p has a rational point ⟺ p ≢ 3 (mod 4)",
+      "Rational obstruction no_rational_point_three_mod_four: p ≡ 3 (mod 4) ⟹ p is not a sum of two RATIONAL squares, via clear-denominators + integer infinite descent",
+      "Elementary mod-p obstruction prime_dvd_of_dvd_sq_add_sq via ZMod.exists_sq_eq_neg_one_iff (no Gaussian integers)",
+      "Stereographic parametrization with explicit completeness: param_recovers shows every rational point with x ≠ a is the image of the chord slope t = (y−b)/(x−a)"
+    ],
+    "theoremCount": 13,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The rational points of a conic with one rational point form a one-parameter family, classically swept out by stereographic projection — the line of rational slope $t$ through a fixed base point meets the conic in a second rational point. For the circle $x^2 + y^2 = p$ this is the rational analogue of the parametrization behind the Pythagorean-triple formula. The existence question — for which primes $p$ does $x^2+y^2=p$ have ANY rational point — is governed by Fermat's two-square theorem: a rational point exists exactly when $p \\not\\equiv 3 \\pmod 4$.\n\nThis file separates the two phenomena cleanly. Part I–II give the stereographic map and prove it is both well-defined (lands on the circle) and complete (hits every rational point). Part III settles existence in both directions, with the hard direction — that $p \\equiv 3 \\pmod 4$ admits no rational point — handled by an infinite descent that needs no Gaussian-integer machinery.",
+    "problemStatement": "For a prime p: (existence) x² + y² = p has a rational point iff p ≢ 3 (mod 4); (parametrization) given a rational base point (a,b) on the circle, every rational point is px(t), py(t) for the chord slope t, and conversely every such parametrized point lies on the circle.",
+    "text": "Defines the stereographic coordinates px(a,b,t) = (a(t²−1) − 2bt)/(1+t²) and py(a,b,t) = (b(1−t²) − 2at)/(1+t²). param_on_circle shows px²+py² = a²+b² (pure algebra), and param_recovers shows surjectivity. For existence, the easy direction p ≢ 3 ⟹ rational point is Fermat's two-square theorem; the hard direction p ≡ 3 ⟹ no rational point clears denominators to an integer equation X²+Y² = p·W² and runs infinite descent on |W|, using the field ZMod p to force p ∣ X and p ∣ Y at each step.",
+    "proofStrategy": "Stereographic projection from a base point (a,b) gives the parametrized coordinates; field_simp; ring proves the points lie on the circle, and linear_combination against the circle relation proves completeness. For existence: the forward direction is Nat.Prime.sq_add_sq. For the obstruction, prime_dvd_of_dvd_sq_add_sq uses that −1 is not a square mod p when p ≡ 3 (mod 4) (ZMod.exists_sq_eq_neg_one_iff) to show p ∣ X²+Y² forces p ∣ X and p ∣ Y; no_int_sol_of_three_mod_four then runs strong induction on |W| to rule out X²+Y² = p·W² with W ≠ 0; and no_rational_point_three_mod_four clears denominators of a hypothetical rational solution to reach that integer equation.",
+    "keyInsights": [
+      "The rational obstruction needs no separate descent machinery: p ≡ 3 ⟹ p is not a sum of two RATIONAL squares reduces, by clearing denominators, to the integer equation X²+Y²=p·W² (W ≠ 0), and ordinary descent on |W| closes it",
+      "The mod-p step is short via ZMod: ZMod.exists_sq_eq_neg_one_iff together with the field structure of ZMod p gives p ≡ 3 (mod 4), p ∣ X²+Y² ⟹ p ∣ X ∧ p ∣ Y in about ten lines — no Gaussian integers required",
+      "param_recovers is an EXACT algebraic identity: with t = (y−b)/(x−a), both px(t)−x and py(t)−y are multiples of the circle relation x²+y²−a²−b², so linear_combination discharges them against hcirc",
+      "Separating existence (which primes work) from parametrization (how to sweep out the points) keeps each half elementary and self-contained",
+      "The whole development is 0-axiom: every step is constructive algebra or descent, depending only on the foundational propext / Classical.choice / Quot.sound"
+    ]
+  },
+  "sections": [
+    {
+      "id": "parametrization",
+      "title": "The Stereographic Parametrization",
+      "summary": "Defines px, py — the second intersection of the slope-t line through (a,b) with x²+y²=a²+b² — and proves param_on_circle (px²+py² = a²+b²) and param_mem_circle (the parametrized point lies on x²+y²=p when the base point does).",
+      "startLine": 41,
+      "endLine": 70,
+      "mathContext": "$p_x(t) = \\dfrac{a(t^2-1) - 2bt}{1+t^2}$, $p_y(t) = \\dfrac{b(1-t^2) - 2at}{1+t^2}$. The denominator $1+t^2 > 0$ never vanishes over $\\mathbb{Q}$, and $p_x^2 + p_y^2 = a^2 + b^2$ identically (cleared via field_simp; ring)."
+    },
+    {
+      "id": "completeness",
+      "title": "Completeness of the Parametrization",
+      "summary": "Proves param_recovers: every rational point (x,y) on the circle with x ≠ a is hit by the chord slope t = (y−b)/(x−a). With param_on_circle this gives a bijection between ℚ ∪ {∞} and the rational points.",
+      "startLine": 72,
+      "endLine": 96,
+      "mathContext": "With $t = (y-b)/(x-a)$, both $p_x(t) - x$ and $p_y(t) - y$ reduce to a multiple of the circle relation $x^2+y^2-a^2-b^2$, which vanishes by hypothesis. The two surjectivity identities are closed by linear_combination $(a-x)\\cdot h_{circ}$ and $(b-y)\\cdot h_{circ}$."
+    },
+    {
+      "id": "existence",
+      "title": "Existence of Rational Points",
+      "summary": "Settles which primes admit a rational point: the easy direction p ≢ 3 ⟹ rational point via Fermat two-squares; the mod-p obstruction prime_dvd_of_dvd_sq_add_sq; the infinite descent no_int_sol_of_three_mod_four; the rational obstruction no_rational_point_three_mod_four; and the assembled characterization rational_point_iff.",
+      "startLine": 98,
+      "endLine": 212,
+      "mathContext": "Forward: $p \\not\\equiv 3 \\pmod 4 \\Rightarrow \\exists a,b \\in \\mathbb{Z},\\ a^2+b^2=p$ (Nat.Prime.sq_add_sq). Obstruction: in $\\mathbb{Z}/p$, $X^2+Y^2=0$ with $Y \\neq 0$ would make $-1=(X/Y)^2$ a square, contradicting $p \\equiv 3 \\pmod 4$; hence $p \\mid X, p \\mid Y$. Descent: $X^2+Y^2 = pW^2$ forces $p \\mid X, Y$, then $p \\mid W$, producing a strictly smaller solution — impossible for $W \\neq 0$. Clearing denominators of a rational solution lands in this integer equation."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances",
+      "summary": "Worked examples: base points (2,1) on x²+y²=5 and (3,2) on x²+y²=13, and the genuinely non-integer rational point (2/5, −11/5) on x²+y²=5 obtained from slope t=2.",
+      "startLine": 214,
+      "endLine": 233,
+      "mathContext": "At $p=5$, base $(2,1)$, slope $t=2$: $p_x = 2/5$, $p_y = -11/5$, and $(2/5)^2 + (-11/5)^2 = 4/25 + 121/25 = 125/25 = 5$ — a rational point that is not an integer point."
+    }
+  ],
+  "conclusion": {
+    "summary": "The rational points of x² + y² = p are completely described: they exist iff p ≢ 3 (mod 4), and when they exist a single stereographic parametrization sweeps out all of them. Both the existence dichotomy and the parametrization's completeness are proved axiom-free.",
+    "openQuestions": [
+      "Extend the rational-point characterization from primes to general n = x² + y² (sum-of-two-squares for composites, via the multiplicativity of the norm form)",
+      "Quantify the rational points by height and compare the count to the integer-point count on x² + y² = p"
+    ],
+    "implications": "Demonstrates that the p ≡ 3 (mod 4) obstruction — usually phrased through Gaussian integers — has a short ZMod-plus-descent formulation, and that the classical stereographic parametrization of a conic admits a fully verified completeness proof via a single linear_combination against the circle relation. Companion to the integer sum-of-two-squares results in FermatTwoSquares.lean and the Gaussian-integer triple formula in PythagoreanTriplesOQ02.lean."
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "ancestor-problem",
+      "description": "Root: the classical formula parametrizing Pythagorean triples, of which this is the rational-circle analogue"
+    },
+    {
+      "targetId": "pythagorean-triples-oq-02",
+      "relationship": "sibling-problem",
+      "description": "Sibling: the Gaussian-integer view of the triple formula; this file instead studies the rational points of the circle directly"
+    },
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "related",
+      "description": "Supplies the integer sum-of-two-squares characterization; the existence direction here is its rational upgrade"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "PythagoreanTriplesOQ03",
+    "lineCount": 255,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 2,
+    "path": "Proofs/PythagoreanTriplesOQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The verified proof for **pythagorean-triples-oq-03** — *Rational Points on x² + y² = p* — was merged in #30916 but never received a gallery directory, so it does not appear in the web gallery. This PR adds the missing `src/data/proofs/pythagorean-triples-oq-03/` integration files.

No Lean source changes; the proof itself is unchanged and already on `main`.

## What the proof establishes (0 sorries, 0 axioms)

- **Existence dichotomy** (`rational_point_iff`): `x² + y² = p` has a rational point ⟺ `p ≢ 3 (mod 4)`.
  - Easy direction: Fermat two-square theorem (`Nat.Prime.sq_add_sq`).
  - Hard direction: a `ZMod p` mod-`p` obstruction (`ZMod.exists_sq_eq_neg_one_iff`, no Gaussian integers) plus infinite descent on `|W|` for `X²+Y² = p·W²`.
- **Stereographic parametrization**: `param_on_circle` (the slope-`t` image lands on the circle) and `param_recovers` (completeness — every rational point with `x ≠ a` is the chord-slope image), the latter an exact identity closed by `linear_combination` against the circle relation.

## Files

- `src/data/proofs/pythagorean-triples-oq-03/meta.json` — overview, 4 sections, conclusion, cross-references to `pythagorean-triples`, `pythagorean-triples-oq-02`, `fermat-two-squares`. 13 theorems, 2 defs, 255 lines, badge `mathlib`.
- `src/data/proofs/pythagorean-triples-oq-03/annotations.json` — 9 annotations (ranges verified within the 255-line file).
- `research/problems/pythagorean-triples-oq-03/knowledge.md` — session log.

## Validation

- `pnpm gallery:check-size` → exit 0 ("all 4124 entries within caps").
- Both JSON files are valid and match the live `erdos-307-oq-02-oq-01` schema field-for-field. (`pnpm annotations:validate` scans all 4124 proofs and exceeds the local time budget — a perf limit, not a schema error.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)