### PR TITLE
Enrich erdos-214 √2-lattice unit-distance-free: add index.ts, annotations, sections

### DIFF
--- a/src/data/proofs/erdos-214-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-214-incomplete-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "erdos214-incomplete01oq01-ann-header",
+    "proofId": "erdos-214-incomplete-01-oq-01",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "context",
+    "title": "Making the #214 hypothesis non-vacuous",
+    "content": "Erdős Problem #214 asks whether the complement of every unit-distance-free planar set (no two points exactly distance 1 apart) must contain the vertices of a unit square; Juhász (1979) proved the stronger statement that the complement contains a congruent copy of every 4-point configuration. The parent gallery entry formalizes Juhász's theorem as an axiom and defines a concrete example set, the √2-scaled lattice, meant to illustrate a unit-distance-free set — but never proves it actually is one, leaving the example inert and the hypothesis formally unwitnessed. This entry closes that gap with an elementary, 0-axiom proof, independent of the axiomatized Juhász core.",
+    "mathContext": "A set $S \\subseteq \\mathbb{R}^2$ is **unit-distance-free** if $\\forall p,q \\in S,\\ p \\ne q \\Rightarrow \\lVert p-q\\rVert \\ne 1$.",
+    "significance": "key",
+    "relatedConcepts": ["unit-distance graph", "combinatorial geometry", "non-vacuity", "Juhász's theorem"],
+    "prerequisites": ["Euclidean geometry", "combinatorics"]
+  },
+  {
+    "id": "erdos214-incomplete01oq01-ann-lattice",
+    "proofId": "erdos-214-incomplete-01-oq-01",
+    "range": { "startLine": 69, "endLine": 71 },
+    "type": "definition",
+    "title": "The √2-scaled integer lattice",
+    "content": "ScaledLattice is the set of plane points whose two coordinates are both integer multiples of √2. The irrational scaling factor √2 is the whole point: it makes every squared inter-point distance an even integer, which is what forbids a unit distance. The definition is taken verbatim from the parent entry, so that proving its unit-distance-freeness directly upgrades the parent's inert example into a verified witness.",
+    "mathContext": "$\\mathrm{ScaledLattice} = \\{\\,p : p_0 = \\sqrt2\\,a,\\ p_1 = \\sqrt2\\,b,\\ a,b \\in \\mathbb{Z}\\,\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["integer lattice", "scaled lattice", "irrational scaling"],
+    "prerequisites": ["lattices in the plane"]
+  },
+  {
+    "id": "erdos214-incomplete01oq01-ann-distformula",
+    "proofId": "erdos-214-incomplete-01-oq-01",
+    "range": { "startLine": 73, "endLine": 79 },
+    "type": "technique",
+    "title": "Unfolding the Euclidean norm into coordinates",
+    "content": "dist_eq_coords rewrites the abstract norm ‖p - q‖ on EuclideanSpace ℝ (Fin 2) into the concrete Pythagorean form √((p₀-q₀)² + (p₁-q₁)²). The key steps are EuclideanSpace.dist_eq (distance is the root-sum-of-squares of coordinate distances), Fin.sum_univ_two (expand the 2-element sum), and sq_abs to turn |·|² into (·)². This bridges Mathlib's general inner-product machinery and the elementary coordinate computation that follows.",
+    "mathContext": "$\\mathrm{dist}\\,p\\,q = \\sqrt{(p_0-q_0)^2 + (p_1-q_1)^2}$ on $\\mathbb{R}^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euclidean norm", "Pythagorean theorem", "inner product space"],
+    "prerequisites": ["normed vector spaces"]
+  },
+  {
+    "id": "erdos214-incomplete01oq01-ann-arith",
+    "proofId": "erdos-214-incomplete-01-oq-01",
+    "range": { "startLine": 81, "endLine": 87 },
+    "type": "theorem",
+    "title": "The parity core: 2·(m²+k²) ≠ 1",
+    "content": "two_mul_sq_add_sq_ne_one is the arithmetic heart of the argument, isolated as a standalone integer lemma. The real equation 2·(m²+k²) = 1 is cast back to ℤ (the values are genuine integers), and omega finishes by parity: the left-hand side is even, 1 is odd, contradiction. Reducing the geometric claim to this single number-theoretic fact is what keeps the whole proof elementary and decidable.",
+    "mathContext": "For all $m,k \\in \\mathbb{Z}$: $2(m^2 + k^2) \\ne 1$, since the left side is even.",
+    "significance": "key",
+    "relatedConcepts": ["parity argument", "omega tactic", "quadratic forms", "even integers"],
+    "prerequisites": ["integer arithmetic"]
+  },
+  {
+    "id": "erdos214-incomplete01oq01-ann-main",
+    "proofId": "erdos-214-incomplete-01-oq-01",
+    "range": { "startLine": 89, "endLine": 116 },
+    "type": "theorem",
+    "title": "No two lattice points are at distance 1",
+    "content": "scaledLattice_dist_ne_one is the main geometric result. Substituting the lattice coordinates and factoring (√2·a − √2·a')² = (√2)²·(a−a')² with (√2)² = 2 (Real.sq_sqrt) collapses the radicand to the even integer 2·((a−a')² + (b−b')²). If the distance were 1, squaring via Real.sq_sqrt on the non-negative radicand gives that even integer = 1, refuted by the parity core. A subtle strength: the proof needs no p ≠ q hypothesis — equal points give distance 0, distinct points give √(even ≥ 2) > 1, and neither is 1.",
+    "mathContext": "$\\lVert p-q\\rVert^2 = (\\sqrt2)^2(a-a')^2 + (\\sqrt2)^2(b-b')^2 = 2\\big((a-a')^2 + (b-b')^2\\big)$, an even integer $\\ne 1$.",
+    "significance": "key",
+    "relatedConcepts": ["squared distance", "lattice distances", "proof by contradiction"],
+    "prerequisites": ["Euclidean distance", "integer parity"]
+  },
+  {
+    "id": "erdos214-incomplete01oq01-ann-corollary",
+    "proofId": "erdos-214-incomplete-01-oq-01",
+    "range": { "startLine": 118, "endLine": 127 },
+    "type": "insight",
+    "title": "A concrete, inhabited unit-distance-free witness",
+    "content": "scaledLattice_unitDistanceFree falls out immediately: since no two points are at distance 1, the set is unit-distance-free (the p ≠ q clause of the predicate is simply unused). scaledLattice_nonempty adds that the origin (a = b = 0) lies in the set, so the witness is genuinely inhabited rather than vacuously satisfying the property. Together these certify that #214's hypothesis class is non-empty — the theorem is not vacuously true — and hand future formalizations reusable infrastructure: the coordinate distance formula and the 2·(m²+k²) ≠ 1 parity lemma.",
+    "mathContext": "$\\mathrm{IsUnitDistanceFree}(\\mathrm{ScaledLattice})$ and $0 \\in \\mathrm{ScaledLattice}$.",
+    "significance": "important",
+    "relatedConcepts": ["non-vacuity", "witness construction", "reusable lemmas"],
+    "prerequisites": ["unit-distance-free sets"]
+  }
+]

--- a/src/data/proofs/erdos-214-incomplete-01-oq-01/index.ts
+++ b/src/data/proofs/erdos-214-incomplete-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos214Incomplete01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos214Incomplete01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos214Incomplete01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos214Incomplete01Oq01Data: ProofData = {
+  proof: erdos214Incomplete01Oq01Proof,
+  annotations: erdos214Incomplete01Oq01Annotations,
+}

--- a/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-214-incomplete-01-oq-01/meta.json
@@ -86,6 +86,50 @@
       "The #214 framework (unit-distance-free sets)"
     ]
   },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: closing the non-vacuity gap in erdos-214",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring. The parent erdos-214 entry defines the example set ScaledLattice = √2·ℤ² to illustrate a unit-distance-free set but never proves it is one, leaving the #214 hypothesis formally unwitnessed. This entry supplies that missing verification with a 0-axiom, self-contained proof independent of the axiomatized Juhász theorem."
+    },
+    {
+      "id": "definitions",
+      "title": "Plane, distance, and the scaled lattice",
+      "startLine": 59,
+      "endLine": 71,
+      "summary": "Re-states the parent's framework so the entry stands free of the axiomatized core: the Euclidean plane EuclideanSpace ℝ (Fin 2), Euclidean distance, the predicate IsUnitDistanceFree, and ScaledLattice = {(√2·a, √2·b) : a,b ∈ ℤ}."
+    },
+    {
+      "id": "dist-formula",
+      "title": "Coordinate distance formula",
+      "startLine": 73,
+      "endLine": 79,
+      "summary": "dist_eq_coords unfolds the Euclidean norm on EuclideanSpace ℝ (Fin 2) into the two-coordinate Pythagorean form √((p₀-q₀)² + (p₁-q₁)²) via EuclideanSpace.dist_eq and Fin.sum_univ_two."
+    },
+    {
+      "id": "arithmetic-core",
+      "title": "Arithmetic core: 2·(m²+k²) ≠ 1",
+      "startLine": 81,
+      "endLine": 87,
+      "summary": "two_mul_sq_add_sq_ne_one: the parity heart of the proof. Casting the real equation 2·(m²+k²) = 1 back to ℤ, omega refutes it because the left-hand side is even while 1 is odd."
+    },
+    {
+      "id": "main-distance",
+      "title": "Lattice points are never at distance 1",
+      "startLine": 89,
+      "endLine": 116,
+      "summary": "scaledLattice_dist_ne_one: substitute the lattice coordinates, use (√2)² = 2 to collapse each squared coordinate difference to 2·(integer)², square the hypothetical distance equation via Real.sq_sqrt on the non-negative radicand, and discharge by the arithmetic core. Notably needs no p ≠ q hypothesis."
+    },
+    {
+      "id": "corollaries",
+      "title": "Unit-distance-freeness and inhabitedness",
+      "startLine": 118,
+      "endLine": 127,
+      "summary": "scaledLattice_unitDistanceFree is the immediate corollary (the #214 hypothesis is non-vacuous), and scaledLattice_nonempty records that the origin (a = b = 0) lies in the set, so it is a genuine, inhabited witness."
+    }
+  ],
   "conclusion": {
     "summary": "The √2-scaled integer lattice ScaledLattice = {(√2·a, √2·b) : a,b ∈ ℤ} is unit-distance-free: the squared distance between any two of its points is 2·((a-a')² + (b-b')²), an even integer never equal to 1. This makes the hypothesis of Erdős #214 non-vacuous with a concrete witness, and it is verified independently of the axiomatized Juhász theorem (0 axioms, 0 sorries).",
     "implications": "This closes a real gap in the parent erdos-214 entry, whose ScaledLattice example was defined but never shown to satisfy the unit-distance-free property. The result certifies that #214's hypothesis class is non-empty (so the theorem is not vacuously true) and provides reusable elementary infrastructure — the coordinate distance formula and the 2·(m²+k²) ≠ 1 parity lemma — for further lattice/geometry formalizations in the gallery.",


### PR DESCRIPTION
Enrichment pass for `erdos-214-incomplete-01-oq-01` (quality 33, pass 0).

Like its sibling, this freshly-merged entry shipped with **only meta.json** — no `index.ts` (so the proof page would render *'proof not found'* on the live site) and no annotations.

## Changes
- **Created `index.ts`** (REQUIRED for Vite's `import.meta.glob` to discover the proof).
- **Added `annotations.json`** — 6 substantive annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering: the #214 non-vacuity framing, the √2-scaled lattice definition, unfolding the Euclidean norm into coordinates, the `2·(m²+k²) ≠ 1` parity core, the main 'no two points at distance 1' theorem, and the unit-distance-free / inhabited corollary.
- **Added `sections`** array to meta.json covering all 6 logical parts of the 127-line Lean file.

## Verification
- `pnpm build` passes.
- meta.json is 12.2 KB — well under the ~60 KB cap.
- Mathematical claims cross-checked against the Lean source; status/badge/axiomCount (verified / original / 0) confirmed accurate — the proof is elementary (omega parity) and independent of the parent's axiomatized Juhász theorem.