### PR TITLE
audit(cycleV60): roth-k3 + hermite-floor companion new entries CLEAN [Tier A]

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25597,12 +25597,18 @@
       "issues": []
     },
     "hermite-floor-identity-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-06-28T10:06:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "roth-theorem-k3-oq-01-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-06-28T09:50:39Z",
+      "lastAudited": "2026-06-28T10:06:08Z",
       "result": "clean",
       "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-27T13:51:27Z"
+  "lastUpdated": "2026-06-28T10:06:08Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — cycleV60 @ fd14af99c39

Two newly-shipped gallery entries audited, both **CLEAN (Tier A)**:

| slug | status/badge | sorries | axioms | native_decide | verdict |
|------|-------------|---------|--------|---------------|---------|
| roth-theorem-k3-oq-01-oq-01 | verified/verified | 0 | 0 | 0 | CLEAN (new) |
| hermite-floor-identity-oq-01 | verified/original | 0 | 0 | 0 | CLEAN (reconfirm) |

### roth-theorem-k3-oq-01-oq-01 (`RothTheoremQuantitativeOQ01.lean`)
6 fully-proven theorems on an abstract modulus sequence `M : ℕ → ℝ`. The decay bound `M(i+1) ≥ (M i)^θ` and `M 0 = N` are **function arguments**, not axioms or structure fields — legitimately Tier A. The `assumptions` field honestly states the file does not re-derive the Fourier-analytic increment. Title/description appropriately scoped ("Modulus Decay in Roth's Density Increment"); no famous-theorem overclaim.

### hermite-floor-identity-oq-01 (`HermiteFloorIdentityOQ01.lean`)
Companion sawtooth identity `∑_{k<n} {x+k/n} = {nx} + (n-1)/2`, derived cleanly from Hermite's floor identity. Fully proven, absent from Mathlib. badge `original` accurate.

### Not in scope
- **erdos-1009-oq-03-oq-01** already covered by pending PR #31216 — not duplicated here.
- **erdos-57-oq-04 / erdos-156** find-targets flags are standing file-level heuristic FPs (shared `Erdos57Problem.lean` carries the open-conjecture `axiom erdos_57`; erdos-156 `sorries:3` is a research-scope meta annotation while the Lean file has 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)