### PR TITLE
audit(cycleV61): pythagorean-triples-oq-03 + erdos-1009-oq-03-oq-01 CLEAN [Tier A/B]

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25607,6 +25607,18 @@
       "lastAudited": "2026-06-28T10:06:08Z",
       "result": "clean",
       "issues": []
+    },
+    "pythagorean-triples-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T10:14:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1009-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T10:14:09Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — cycleV61

Two new gallery entries audited **CLEAN**. Tracker updated.

### pythagorean-triples-oq-03 — [verified/mathlib] ✓ Tier B
Rational points on x²+y²=p with stereographic parametrization.
- 0 sorry, 0 axiom, 0 `native_decide`, 0 True-stubs (13 theorems)
- Substantive characterization `rational_point_iff` (p has rational point ⟺ p%4≠3), plus parametrization lemmas and concrete instances (base_5, base_13)
- Badge `mathlib` is the conservative/honest choice; assumptions disclose foundational-only deps. No overclaim.

### erdos-1009-oq-03-oq-01 — [verified/verified] ✓ Tier A
Exact fractional triangle-packing optimum of K₄ via LP duality.
- 0 sorry, 0 axiom; `decide`-only on the finite K₄ model (card facts, incidence ≤ 2)
- The lone `native_decide` grep hit is in the **module docstring** stating it is *not* used — verified, no `native_decide` tactic in code
- `weak_duality` / `wHalf_value=2` / `yThird_value=2` / `frac_optimum` / `cover_optimum` / `lp_no_gap` are genuine results
- Prior audit (PR #31216) was closed without merging, so this re-persists the clean record on main.

### Standing false positives (no change — already clean in tracker)
- **erdos-57-oq-04**: mechanical "axiom undercount: claims 0, actual 1". The file `Erdos57Problem.lean` holds the parent's deep `erdos_57` axiom (Liu–Montgomery), which the entry's contributed crux lemma (`exists_odd_cycle_of_odd_closed_walk`, axiom-free) does not touch. `axiomCount:0` correctly scopes to the contribution; disclosure is exemplary throughout meta.json.
- **erdos-156**: mechanical "sorry mismatch". Entry honestly carries `sorries:3`, badge `wip`, status `formalized` — no overclaim; main file has 0 sorries, companions hold the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)