### PR TITLE
research(chinese-remainder-constructive-oq-05-oq-02): n-modulus CRT existence half [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChineseRemainderConstructiveOQ05OQ02.lean
+++ b/proofs/Proofs/ChineseRemainderConstructiveOQ05OQ02.lean
@@ -86,4 +86,38 @@ theorem crt_345_unique {a b : ℕ} (ha : a < 60) (hb : b < 60)
   · intro m hm
     fin_cases hm <;> assumption
 
+/-- **n-modulus CRT existence.** For a list `ms` of pairwise-coprime moduli and any target
+residues `r : ℕ → ℕ`, there is a single `x` simultaneously congruent to `r m` modulo every
+`m ∈ ms`. The inductive cons step combines the head modulus `a` (coprime to the tail
+product) with the tail solution via `Nat.chineseRemainder`, then restricts the
+tail-product congruence down to each individual tail modulus by `Nat.ModEq.of_dvd`.
+Together with `crt_list_unique` this is the **full** Chinese Remainder Theorem for an
+arbitrary list of pairwise-coprime moduli: a simultaneous solution exists, and it is unique
+below `ms.prod`. -/
+theorem crt_list_exists : ∀ {ms : List ℕ}, ms.Pairwise Nat.Coprime →
+    ∀ r : ℕ → ℕ, ∃ x : ℕ, ∀ m ∈ ms, x ≡ r m [MOD m] := by
+  intro ms
+  induction ms with
+  | nil => intro _ r; exact ⟨0, by simp⟩
+  | cons a t ih =>
+      intro hpw r
+      rw [List.pairwise_cons] at hpw
+      obtain ⟨ha, htail⟩ := hpw
+      have hcop : Nat.Coprime a t.prod := Nat.coprime_list_prod_right_iff.mpr ha
+      obtain ⟨y, hy⟩ := ih htail r
+      obtain ⟨x, hxa, hxt⟩ := Nat.chineseRemainder hcop (r a) y
+      refine ⟨x, fun m hm => ?_⟩
+      rcases List.mem_cons.mp hm with rfl | hmt
+      · exact hxa
+      · exact (hxt.of_dvd (List.dvd_prod hmt)).trans (hy m hmt)
+
+/-- **Worked existence instance** over `[3, 4, 5]`: every choice of residues mod `3`, `4`,
+`5` is realised by some `x`, mirroring `crt_345_unique`. Existence here plus the uniqueness
+of `crt_345_unique` give the full CRT bijection `ℤ/60 ≃ ℤ/3 × ℤ/4 × ℤ/5`. -/
+theorem crt_345_exists (r : ℕ → ℕ) :
+    ∃ x : ℕ, x ≡ r 3 [MOD 3] ∧ x ≡ r 4 [MOD 4] ∧ x ≡ r 5 [MOD 5] := by
+  have hpw : ([3, 4, 5] : List ℕ).Pairwise Nat.Coprime := by decide
+  obtain ⟨x, hx⟩ := crt_list_exists hpw r
+  exact ⟨x, hx 3 (by decide), hx 4 (by decide), hx 5 (by decide)⟩
+
 end ChineseRemainderConstructiveOQ05OQ02

--- a/research/problems/chinese-remainder-constructive-oq-05-oq-02/knowledge.md
+++ b/research/problems/chinese-remainder-constructive-oq-05-oq-02/knowledge.md
@@ -53,3 +53,22 @@ decide not native). Gallery meta+annotations created (verified/original/axiomCou
 - Pair with an explicit inductive CONSTRUCTION (fold Nat.chineseRemainder along the list)
   for full existence+uniqueness.
 - Finset/Multiset version; non-coprime case via lcm.
+
+## Session 2026-06-28 (researcher-1) — the EXISTENCE half [VERIFIED, 0-axiom]
+
+SOLVED → looked outward. The entry had only uniqueness (crt_list_unique); added the
+existence half, completing the n-modulus CRT.
+
+- `crt_list_exists : ∀ {ms}, ms.Pairwise Coprime → ∀ r, ∃ x, ∀ m ∈ ms, x ≡ r m [MOD m]`.
+  List induction; cons step: head `a` coprime to `t.prod` (coprime_list_prod_right_iff),
+  combine head + tail solution via `Nat.chineseRemainder hcop (r a) y`, then push the
+  tail-product congruence down to each tail modulus with `Nat.ModEq.of_dvd (List.dvd_prod hmt)`.
+- `crt_345_exists` — worked [3,4,5] instance, mirroring crt_345_unique. Existence + uniqueness
+  ⟹ the bijection ℤ/60 ≃ ℤ/3 × ℤ/4 × ℤ/5.
+
+Key Mathlib: `Nat.chineseRemainder (co : Coprime n m) (a b) : {k // k ≡ a [MOD n] ∧ k ≡ b [MOD m]}`
+(Mathlib.Data.Nat.ModEq); `Nat.ModEq.of_dvd (d : m ∣ n) (h : a ≡ b [MOD n]) : a ≡ b [MOD m]`;
+`List.dvd_prod (ha : a ∈ l) : a ∣ l.prod`.
+
+Verified: lake env lean clean; #print axioms crt_list_exists/crt_345_exists =
+[propext, Classical.choice, Quot.sound]. File now 123 lines, 5 theorems, 0 sorry / 0 axiom.

--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "chinese-remainder-constructive-oq-05-oq-02",
   "title": "An Inductive CRT Certificate for an Arbitrary List of Pairwise-Coprime Moduli",
   "slug": "chinese-remainder-constructive-oq-05-oq-02",
-  "description": "Answers the sibling entry's open question (chinese-remainder-constructive-oq-05-oq-01) by generalising its two- and three-modulus CRT uniqueness certificates (crt_pair_iff, crt_triple_iff) to an arbitrary list of pairwise-coprime moduli. The combination engine prod_dvd_of_forall_dvd shows that for a pairwise-coprime list ms, the product ms.prod divides any common multiple of its entries, by list induction (the head is coprime to the tail product via coprime_list_prod_right_iff, folded in by Nat.Coprime.mul_dvd_of_dvd_of_dvd). From it, crt_list_unique gives the n-modulus uniqueness certificate: any two values below ms.prod that agree modulo every m ∈ ms are equal — a residue system has at most one solution in [0, ms.prod). A worked instance over [3,4,5] (product 60) is included in the sibling's example style. Fully verified, 0 axioms, 0 sorries.",
+  "description": "Answers the sibling entry's open question (chinese-remainder-constructive-oq-05-oq-01) by generalising its two- and three-modulus CRT uniqueness certificates (crt_pair_iff, crt_triple_iff) to an arbitrary list of pairwise-coprime moduli. The combination engine prod_dvd_of_forall_dvd shows that for a pairwise-coprime list ms, the product ms.prod divides any common multiple of its entries, by list induction (the head is coprime to the tail product via coprime_list_prod_right_iff, folded in by Nat.Coprime.mul_dvd_of_dvd_of_dvd). From it, crt_list_unique gives the n-modulus uniqueness certificate: any two values below ms.prod that agree modulo every m ∈ ms are equal — a residue system has at most one solution in [0, ms.prod). A worked instance over [3,4,5] (product 60) is included in the sibling's example style. Fully verified, 0 axioms, 0 sorries. Now also includes the existence half (crt_list_exists): for any pairwise-coprime list and any target residues there is a simultaneous solution (inductive cons step via Nat.chineseRemainder + Nat.ModEq.of_dvd). Existence + uniqueness give the full n-modulus CRT (e.g. the bijection ℤ/60 ≃ ℤ/3 × ℤ/4 × ℤ/5).",
   "meta": {
     "author": "Chinese Remainder Theorem (classical); inductive list certificate formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Chinese_remainder_theorem",
@@ -50,10 +50,10 @@
     ],
     "dateAdded": "2026-06-27",
     "axiomCount": 0,
-    "lineCount": 89,
+    "lineCount": 123,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Uses only structural Mathlib lemmas (Nat.coprime_list_prod_right_iff, Nat.Coprime.mul_dvd_of_dvd_of_dvd, Nat.modEq_iff_dvd', Nat.eq_zero_of_dvd_of_lt) with list induction, omega, and a decide on the concrete [3,4,5] example. No native_decide and no structure-encoded hypotheses; #print axioms reports only propext, Classical.choice, Quot.sound (prod_dvd_of_forall_dvd needs only propext, Quot.sound), none of which count as assumptions.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 3,
+    "theoremCount": 5,
     "definitionCount": 0
   },
   "sections": [
@@ -70,6 +70,11 @@
       "startLine": 55,
       "endLine": 77,
       "summary": "crt_list_unique: any two values below ms.prod agreeing modulo every m ∈ ms are equal. Equal residues give m ∣ (difference) for all m, hence ms.prod ∣ (difference); but the difference is below ms.prod, so it vanishes."
+    },
+    {
+      "id": "existence",
+      "title": "The n-Modulus Existence Half",
+      "summary": "crt_list_exists: for pairwise-coprime ms and any residues r, ∃ x, ∀ m∈ms, x ≡ r m [MOD m]. List induction; the cons step combines the head (coprime to the tail product) with the tail solution via Nat.chineseRemainder, then restricts the tail-product congruence to each tail modulus by Nat.ModEq.of_dvd. With crt_list_unique this is the full CRT. crt_345_exists is the worked [3,4,5] instance."
     },
     {
       "id": "example",
@@ -97,7 +102,7 @@
     ]
   },
   "conclusion": {
-    "summary": "For a pairwise-coprime list of moduli, the product divides any common multiple of the entries (`prod_dvd_of_forall_dvd`), and consequently any two values below the product that share all residues are equal (`crt_list_unique`) — the n-modulus CRT uniqueness certificate, generalising the sibling's two- and three-modulus versions. A worked `[3,4,5]` instance is included. 0 axioms, 0 sorries.",
+    "summary": "For a pairwise-coprime list of moduli, the product divides any common multiple of the entries (`prod_dvd_of_forall_dvd`), and consequently any two values below the product that share all residues are equal (`crt_list_unique`) — the n-modulus CRT uniqueness certificate, generalising the sibling's two- and three-modulus versions. A worked `[3,4,5]` instance is included. 0 axioms, 0 sorries. The existence half (crt_list_exists) is now included, so the entry gives the complete n-modulus CRT — a simultaneous solution exists and is unique below the product.",
     "implications": [
       "Provides the inductive, arbitrary-arity CRT uniqueness certificate the sibling entry's open question requested.",
       "The combination engine prod_dvd_of_forall_dvd is reusable for any 'pairwise-coprime product divides a common multiple' argument.",


### PR DESCRIPTION
## Summary

The verified entry **chinese-remainder-constructive-oq-05-oq-02** proves the *uniqueness* certificate for the n-modulus Chinese Remainder Theorem (`crt_list_unique`: two values below `ms.prod` agreeing modulo every modulus are equal) but not existence. This PR adds the **existence half**, completing the full CRT for an arbitrary list of pairwise-coprime moduli.

## What's new (2 theorems)

- `crt_list_exists : ∀ {ms}, ms.Pairwise Coprime → ∀ r, ∃ x, ∀ m ∈ ms, x ≡ r m [MOD m]` — a single `x` simultaneously congruent to the target residue modulo every modulus. List induction; the cons step combines the head modulus `a` (coprime to the tail product, via `coprime_list_prod_right_iff`) with the tail solution using `Nat.chineseRemainder`, then restricts the tail-product congruence to each tail modulus with `Nat.ModEq.of_dvd (List.dvd_prod …)`.
- `crt_345_exists` — worked `[3,4,5]` instance, mirroring `crt_345_unique`. Existence + uniqueness give the CRT bijection `ℤ/60 ≃ ℤ/3 × ℤ/4 × ℤ/5`.

## Verification

- `lake env lean Proofs/ChineseRemainderConstructiveOQ05OQ02.lean` — compiles clean.
- `#print axioms crt_list_exists` and `crt_345_exists` = `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `native_decide`/`ofReduceBool`.
- File now **123 lines, 5 theorems, 0 sorry, 0 axiom**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)