### PR TITLE
research(cassini-identity-oq-01-oq-02): Fibonacci duplication formulas [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CassiniIdentityOQ01OQ02.lean
+++ b/proofs/Proofs/CassiniIdentityOQ01OQ02.lean
@@ -22,6 +22,10 @@
                        "addition formula" of the problem statement.
   - `cassini_matrix` : `F(n+2)F(n) − F(n+1)² = (−1)^(n+1)`  — from `det (Q^(n+1))`, the
                        Cassini identity recovered through the *same* factorisation.
+  - `fib_two_mul_add_one` : `F(2n+1) = F(n+1)² + F(n)²`  — the `m = n` diagonal of
+                       `fib_add_matrix` (odd-index duplication).
+  - `fib_two_mul_add_two` : `F(2n+2) = F(n+2)F(n+1) + F(n+1)F(n)`  — the `m = n` diagonal
+                       of `fib_add_offdiag` (even-index duplication).
 
   Worked over `ℤ` (entries `(Nat.fib k : ℤ)`), 0 sorries, 0 axioms. Mathlib has no
   Fibonacci Q-matrix of its own, so the closed form `Q_pow_succ` is a genuinely new
@@ -117,5 +121,31 @@ theorem cassini_matrix (n : ℕ) :
   -- hdet : F(n+2)·F(n) − F(n+1)·F(n+1) = (1·0 − 1·1)^(n+1)
   rw [sq, hdet]
   norm_num
+
+/-!
+## Duplication formulas (the diagonal `m = n` of the factorisation)
+
+Setting `m = n` in the addition formulas — i.e. reading the entries of the *square*
+`Q^{n+1} · Q^{n+1} = Q^{2n+2}` — collapses them to the classical Fibonacci *duplication*
+identities. No new induction is needed: these are immediate corollaries of
+`fib_add_matrix` / `fib_add_offdiag` at `m = n`.
+-/
+
+/-- **Odd-index duplication.** `F(2n+1) = F(n+1)² + F(n)²` — the `m = n` case of
+`fib_add_matrix`, the `(2,2)` entry of `Q^{n+1} · Q^{n+1}`. The classical fact that
+`F_{2n+1}` is a sum of two consecutive Fibonacci squares. -/
+theorem fib_two_mul_add_one (n : ℕ) :
+    Nat.fib (2 * n + 1) = Nat.fib (n + 1) ^ 2 + Nat.fib n ^ 2 := by
+  have h := fib_add_matrix n n
+  rw [show 2 * n + 1 = n + n + 1 from by ring, sq, sq, h]
+
+/-- **Even-index duplication.** `F(2n+2) = F(n+2)F(n+1) + F(n+1)F(n)` — the `m = n` case of
+`fib_add_offdiag`, the `(1,2)` entry of `Q^{n+1} · Q^{n+1}`. Equivalently
+`F(2n+2) = F(n+1)·(F(n+2) + F(n))`. -/
+theorem fib_two_mul_add_two (n : ℕ) :
+    Nat.fib (2 * n + 2)
+      = Nat.fib (n + 2) * Nat.fib (n + 1) + Nat.fib (n + 1) * Nat.fib n := by
+  have h := fib_add_offdiag n n
+  rw [show 2 * n + 2 = n + n + 2 from by ring, h]
 
 end CassiniIdentityOQ01OQ02

--- a/research/problems/cassini-identity-oq-01-oq-02/knowledge.md
+++ b/research/problems/cassini-identity-oq-01-oq-02/knowledge.md
@@ -70,3 +70,26 @@ verified, badge original, axiomCount 0). meta/annotations JSON validated.
 - d'Ocagne `F_m F_{n+1} - F_{m+1}F_n = (-1)^n F_{m-n}` from off-diagonal entries of a
   product (needs `Q^{-n}` or a det-of-product argument).
 - Catalan identity via `det(Q^{n-r} Q^{2r})`.
+
+---
+
+## Session 2026-06-28 (researcher-2) — duplication formulas [VERIFIED, 0-axiom]
+
+**Outcome**: incremental polish on the already-solved OQ. Added the two **duplication
+(doubling) formulas** as immediate corollaries of the existing addition formulas at the
+diagonal `m = n` (the entries of the square `Q^{n+1}·Q^{n+1} = Q^{2n+2}`):
+- `fib_two_mul_add_one (n) : F(2n+1) = F(n+1)² + F(n)²` — `(2,2)` entry, `m = n` of
+  `fib_add_matrix`. Proof: `rw [show 2*n+1 = n+n+1 from by ring, sq, sq, fib_add_matrix n n]`.
+- `fib_two_mul_add_two (n) : F(2n+2) = F(n+2)F(n+1) + F(n+1)F(n)` — `(1,2)` entry, `m = n`
+  of `fib_add_offdiag`. Proof: `rw [show 2*n+2 = n+n+2 from by ring, fib_add_offdiag n n]`.
+
+No new induction, no new Mathlib lemmas — pure reindex + `rw` off the prior addition
+formulas. File 121→151 LOC, 5→7 theorems, still 0 axioms / 0 sorries; `#print axioms` =
+`[propext, Classical.choice, Quot.sound]` for both. Single-file typecheck under
+`lean v4.26.0` + Mathlib oleans, EXIT 0. Gallery meta.json updated (theoremCount 7,
+lineCount 151, +duplication section).
+
+**Honest scope note**: the OQ was already resolved in the prior session; this only extends
+the corollary list. The substantive open items (d'Ocagne, Catalan, Vajda) remain — they
+involve index subtraction (`F_{m-n}`) needing either `Q^{-1}` (Q ∈ GL₂(ℤ), det = −1) or a
+2-step induction, neither attempted this session.

--- a/src/data/proofs/cassini-identity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-02/meta.json
@@ -53,14 +53,15 @@
       "Resolves the parent entry's open question: the Fibonacci addition formula is obtained by reading off a single entry of the matrix factorisation Q^{m+n} = Q^m Q^n, not by a dedicated induction",
       "The closed Q-matrix power Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n] over ℤ proved by one induction on the Fibonacci recurrence — Mathlib records no Fibonacci companion matrix",
       "Three classical identities packaged as corollaries of one factorisation: the (2,2) entry F_{m+n+1} = F_{m+1}F_{n+1} + F_m F_n (recovering Nat.fib_add), the (1,2) entry F_{m+n+2} = F_{m+2}F_{n+1} + F_{m+1}F_n, and Cassini's identity F_{n+2}F_n − F_{n+1}² = (−1)^{n+1} via the determinant",
-      "Demonstrates the 'one matrix identity, many corollaries' pattern: a family of bilinear Fibonacci identities becomes entry-reading on a single associativity equation"
+      "Demonstrates the 'one matrix identity, many corollaries' pattern: a family of bilinear Fibonacci identities becomes entry-reading on a single associativity equation",
+      "Adds the duplication formulas F_{2n+1} = F_{n+1}² + F_n² and F_{2n+2} = F_{n+2}F_{n+1} + F_{n+1}F_n as the m = n diagonal of the addition formulas (the entries of the square Q^{n+1}·Q^{n+1}), extending the corollary list with no extra induction"
     ],
     "dateAdded": "2026-06-27",
     "axiomCount": 0,
-    "lineCount": 121,
+    "lineCount": 151,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The proof uses only structural Mathlib lemmas (Matrix.mul_fin_two, Matrix.det_pow, Matrix.det_fin_two_of, pow_add, Nat.fib_add_two) with induction, push_cast, ring, and exact_mod_cast; no native_decide and no structure-encoded hypotheses. #print axioms reports only the foundational propext, Classical.choice, Quot.sound, none of which count as assumptions.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 1
   },
   "sections": [
@@ -95,9 +96,16 @@
     {
       "id": "cassini",
       "title": "Cassini's Identity from the Same Matrix",
-      "startLine": 112,
-      "endLine": 120,
+      "startLine": 116,
+      "endLine": 123,
       "summary": "F_{n+2}F_n − F_{n+1}² = (−1)^{n+1} from det(Q^{n+1}) = (det Q)^{n+1} = (−1)^{n+1}, recovering the parent entry's identity through the same Q used for the addition formulas."
+    },
+    {
+      "id": "duplication",
+      "title": "Duplication Formulas (the m = n diagonal)",
+      "startLine": 125,
+      "endLine": 150,
+      "summary": "Setting m = n in the addition formulas — reading the entries of the square Q^{n+1}·Q^{n+1} = Q^{2n+2} — yields the classical duplication identities with no new induction: F_{2n+1} = F_{n+1}² + F_n² (the (2,2) entry, fib_two_mul_add_one) and F_{2n+2} = F_{n+2}F_{n+1} + F_{n+1}F_n (the (1,2) entry, fib_two_mul_add_two)."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary

Incremental extension of the **Q-matrix Fibonacci identity** entry (`CassiniIdentityOQ01OQ02.lean`). The entry's open question — reading the Fibonacci addition formula off `Q^{m+n} = Q^m Q^n` — was already resolved in a prior session. This PR adds the two classical **duplication (doubling) formulas** as the `m = n` diagonal of the existing addition formulas (the entries of the square `Q^{n+1}·Q^{n+1} = Q^{2n+2}`):

| Theorem | Statement | Source |
|---|---|---|
| `fib_two_mul_add_one` | `F(2n+1) = F(n+1)² + F(n)²` | `(2,2)` entry, `m = n` of `fib_add_matrix` |
| `fib_two_mul_add_two` | `F(2n+2) = F(n+2)F(n+1) + F(n+1)F(n)` | `(1,2)` entry, `m = n` of `fib_add_offdiag` |

Each is a one-line reindex + `rw` off the prior addition formula — no new induction, no new Mathlib dependency.

## Verification

- 0 axioms, 0 sorries. `#print axioms` on both new theorems lists only `propext`, `Classical.choice`, `Quot.sound` (foundational — none count under the project axiom policy). No `native_decide`.
- Single-file typecheck under `lean v4.26.0` + Mathlib oleans: **EXIT 0**.
- Gallery `meta.json` updated: `theoremCount` 5→7, `lineCount` 121→151, new `duplication` section.

## Honest scope

This extends the corollary list; it does not resolve a new open problem. The substantive remaining identities (d'Ocagne, Catalan, Vajda) involve index subtraction (`F_{m−n}`) and require either `Q^{-1}` (Q ∈ GL₂(ℤ), det = −1) or a two-step induction — left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)