### PR TITLE
audit(cycleV62): erdos-57-oq-04 + erdos-156 reconfirmed CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4925,9 +4925,9 @@
       "result": "clean"
     },
     "erdos-156": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-06-28T08:39:52Z",
+      "lastAudited": "2026-06-28T10:18:29Z",
       "result": "clean"
     },
     "erdos-157": {
@@ -25171,8 +25171,8 @@
       "issues": []
     },
     "erdos-57-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-28T08:39:52Z",
+      "auditCount": 3,
+      "lastAudited": "2026-06-28T10:18:29Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Gallery Integrity Audit — cycleV62 @4642ed95

Two unaudited/issue-flagged targets reconfirmed as **honest false positives** of the find-targets heuristic. No overclaim in either entry.

### erdos-57-oq-04 — Tier A, CLEAN
- meta: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`
- Heuristic flag: "axiom undercount: claims 0, actual declarations 1"
- **Verdict**: The single `axiom erdos_57` in the shared `Erdos57Problem.lean` is the open **Erdős–Hajnal parent conjecture** (a sibling result powering the `infinite_odd_cycle_lengths` corollary). The OQ04 contribution chain — `bipartite_iff_no_odd_cycles` → `exists_odd_cycle_of_odd_closed_walk` → `exists_odd_cycle_aux` — never invokes that axiom; it is proved from Mathlib. `axiomCount: 0` for this sub-result is honest, and the description fully discloses the axiom situation. find-targets greps the whole shared file → false positive.

### erdos-156 — wip, CLEAN
- meta: `status: formalized`, `badge: wip`, `sorries: 3`
- Heuristic flag: "sorry mismatch: claims 3, actual main 0 / chain 15"
- **Verdict**: Correctly downgraded (wip/formalized), does **not** claim verified — no overclaim risk. The sorry-count imprecision is a research-scope artifact across companion files (prior wip-correction #30958). LOW severity at most; conservatively labeled.

Tracker bumps audit count + timestamp only.

---
Discovered during gallery integrity audit loop.