### PR TITLE
research(erdos-340-greedy-sidon-oq-05): analytic O(N^{1/h}) upper bound IsBh.card_le_rpow [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos340BhUpperBound.lean
+++ b/proofs/Proofs/Erdos340BhUpperBound.lean
@@ -1,0 +1,137 @@
+/-
+# Erdős Problem #340 (oq-05 follow-up): the analytic `O(N^{1/h})` upper bound for `B_h` sets
+
+The companion file `Erdos340GreedySidonOQ05.lean` establishes two complementary facts about
+`B_h` subsets `A ⊆ {1, …, N}` (a `B_h` set is one whose `h`-fold sumsets are as distinct as
+possible — `IsBh h A`):
+
+* the **greedy lower bound** `exists_isBh_rpow_lower`: the bounded greedy algorithm produces
+  such a set with `|A| ≥ C₁ · N^{1/(2h-1)}`;
+* the **combinatorial counting bound** `IsBh.choose_card_le`: `C(|A|, h) ≤ h · N`, because the
+  `C(|A|, h)` many `h`-element subset-sums are distinct and confined to `[1, h·N]`.
+
+What was missing is the *analytic* form of the second one — the matching **upper bound**
+`|A| ≤ C₂ · N^{1/h}` that the literature states alongside the lower bound.  This file supplies
+it as a fully verified, `0`-axiom theorem (`IsBh.card_le_rpow`), with the explicit constant
+`C₂ = (h - 1) + (h · h!)^{1/h}`.
+
+Together with `exists_isBh_rpow_lower`, this brackets the maximal size `σ_h(N)` of a `B_h` set
+inside `[1, N]`:
+
+  `C₁ · N^{1/(2h-1)} ≤ σ_h(N) ≤ C₂ · N^{1/h}`.
+
+The gap between the exponents `1/(2h-1)` and `1/h` is *exactly* the open quantitative content
+of Erdős #340 for general `h`.  (For `h = 2` this is `1/3` vs `1/2` — the classical Sidon gap;
+whether the greedy `1/3` exponent can be improved toward the counting `1/2` upper bound is the
+unsolved problem, and is **not** addressed here.)
+
+## The argument
+
+`IsBh.choose_card_le` gives `C(k, h) ≤ h · N` with `k = |A|`.  Mathlib's binomial lower bound
+`Nat.pow_le_choose` gives the reverse `(k + 1 - h)^h / h! ≤ C(k, h)`, so combining,
+
+  `(k + 1 - h)^h ≤ h! · h · N`.
+
+Taking `h`-th roots (`rpow (1/h)`, monotone on `[0, ∞)`),
+
+  `k + 1 - h ≤ (h! · h)^{1/h} · N^{1/h}`,
+
+and the elementary `ℕ` inequality `k ≤ (k + 1 - h) + (h - 1)` (valid even when `k < h`, where
+the truncated subtraction is `0`) lets us absorb the additive `h - 1` into `(h - 1) · N^{1/h}`
+using `N^{1/h} ≥ 1`, yielding `k ≤ C₂ · N^{1/h}`.
+-/
+import Proofs.Erdos340GreedySidonOQ05
+
+namespace Erdos340Bh
+
+open Finset
+open scoped Nat
+
+/-- **Analytic `O(N^{1/h})` upper bound for `B_h` sets** — companion to the greedy lower bound
+`exists_isBh_rpow_lower`.
+
+There is an explicit constant `C > 0` (depending only on `h`) such that every `B_h` set
+`A ⊆ {1, …, N}` satisfies
+
+  `|A| ≤ C · N^{1/h}`.
+
+The constant is `C = (h - 1) + (h · h!)^{1/h}`.  Proved `0`-axiom from the combinatorial
+counting bound `IsBh.choose_card_le` (`C(|A|, h) ≤ h·N`) and Mathlib's binomial lower bound
+`Nat.pow_le_choose`.
+
+Paired with `exists_isBh_rpow_lower` (an achievable `|A| ≥ C' · N^{1/(2h-1)}`), this brackets
+the maximal `B_h` size in `[1, N]`; the exponent gap `1/(2h-1)` vs `1/h` is the open core of
+Erdős #340. -/
+theorem IsBh.card_le_rpow {h : ℕ} (hh : 1 ≤ h) :
+    ∃ C : ℝ, 0 < C ∧ ∀ (N : ℕ) (A : Finset ℕ), A ⊆ Finset.Icc 1 N → IsBh h A →
+      (A.card : ℝ) ≤ C * (N : ℝ) ^ ((h : ℝ)⁻¹) := by
+  have hh0 : (h : ℕ) ≠ 0 := by omega
+  have hexp_ne : ((h : ℝ)⁻¹) ≠ 0 := by
+    have : (0 : ℝ) < (h : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero hh0
+    positivity
+  -- The constant `C₂coef = (h · h!)^{1/h}`, depending only on `h`.
+  set C₂coef : ℝ := (((h ! * h : ℕ) : ℝ)) ^ ((h : ℝ)⁻¹) with hC2
+  have hcoefbase_pos : (0 : ℝ) < ((h ! * h : ℕ) : ℝ) := by
+    have : 0 < h ! * h := Nat.mul_pos (Nat.factorial_pos h) (by omega)
+    exact_mod_cast this
+  have hC2pos : 0 < C₂coef := by rw [hC2]; exact Real.rpow_pos_of_pos hcoefbase_pos _
+  have hh1R : (1 : ℝ) ≤ (h : ℝ) := by exact_mod_cast hh
+  refine ⟨((h : ℝ) - 1) + C₂coef, by linarith [hC2pos], ?_⟩
+  intro N A hAN hA
+  rcases Nat.eq_zero_or_pos N with hN0 | hN1
+  · -- `N = 0`: then `A ⊆ Icc 1 0 = ∅`, so `|A| = 0`, and the RHS is `C · 0^{1/h} = 0`.
+    subst hN0
+    have hAe : A = ∅ := by
+      rw [Finset.Icc_eq_empty (by omega)] at hAN
+      exact Finset.subset_empty.mp hAN
+    simp [hAe, Real.zero_rpow hexp_ne]
+  -- Main case `N ≥ 1`.
+  have hcc : Nat.choose A.card h ≤ h * N := hA.choose_card_le hh hAN
+  set k : ℕ := A.card with hk
+  -- Mathlib's binomial lower bound, over `ℝ`.
+  have hpc : ((k + 1 - h : ℕ) : ℝ) ^ h / (h ! : ℝ) ≤ (Nat.choose k h : ℝ) :=
+    Nat.pow_le_choose (α := ℝ) h k
+  have hfp : (0 : ℝ) < (h ! : ℝ) := by exact_mod_cast Nat.factorial_pos h
+  -- `(k+1-h)^h ≤ h! · choose k h`.
+  have hqh_le_choose : ((k + 1 - h : ℕ) : ℝ) ^ h ≤ (h ! : ℝ) * (Nat.choose k h : ℝ) := by
+    rw [div_le_iff₀ hfp] at hpc; linarith [hpc]
+  have hccR : (Nat.choose k h : ℝ) ≤ (h : ℝ) * (N : ℝ) := by exact_mod_cast hcc
+  -- `(k+1-h)^h ≤ h! · (h · N)`.
+  have hqh_le : ((k + 1 - h : ℕ) : ℝ) ^ h ≤ (h ! : ℝ) * ((h : ℝ) * (N : ℝ)) :=
+    le_trans hqh_le_choose (mul_le_mul_of_nonneg_left hccR (le_of_lt hfp))
+  -- Take `h`-th roots.
+  set q : ℝ := ((k + 1 - h : ℕ) : ℝ) with hqdef
+  have hq0 : 0 ≤ q := by rw [hqdef]; positivity
+  set Nexp : ℝ := (N : ℝ) ^ ((h : ℝ)⁻¹) with hNexpdef
+  have hbase_eq : (h ! : ℝ) * ((h : ℝ) * (N : ℝ)) = ((h ! * h : ℕ) : ℝ) * (N : ℝ) := by
+    push_cast; ring
+  have hroot : q ≤ C₂coef * Nexp := by
+    have hstep : q ≤ ((h ! : ℝ) * ((h : ℝ) * (N : ℝ))) ^ ((h : ℝ)⁻¹) := by
+      calc q = (q ^ h) ^ ((h : ℝ)⁻¹) := (Real.pow_rpow_inv_natCast hq0 hh0).symm
+        _ ≤ ((h ! : ℝ) * ((h : ℝ) * (N : ℝ))) ^ ((h : ℝ)⁻¹) :=
+            Real.rpow_le_rpow (by positivity) hqh_le (by positivity)
+    rw [hbase_eq, Real.mul_rpow (by positivity) (by positivity)] at hstep
+    rw [hC2, hNexpdef]; exact hstep
+  -- `k ≤ (k+1-h) + (h-1)` in `ℕ`, transported to `ℝ`.
+  have hk_nat : k ≤ (k + 1 - h) + (h - 1) := by omega
+  have hcast_h1 : ((h - 1 : ℕ) : ℝ) = (h : ℝ) - 1 := by
+    rw [Nat.cast_sub hh, Nat.cast_one]
+  have hk_real : (k : ℝ) ≤ q + ((h : ℝ) - 1) := by
+    have h0 : (k : ℝ) ≤ ((k + 1 - h : ℕ) : ℝ) + ((h - 1 : ℕ) : ℝ) := by exact_mod_cast hk_nat
+    rw [hcast_h1] at h0; rw [hqdef]; exact h0
+  -- `N^{1/h} ≥ 1`, so the additive `h-1` is absorbed.
+  have hNexp_ge1 : (1 : ℝ) ≤ Nexp := by
+    rw [hNexpdef]
+    calc (1 : ℝ) = (1 : ℝ) ^ ((h : ℝ)⁻¹) := (Real.one_rpow _).symm
+      _ ≤ (N : ℝ) ^ ((h : ℝ)⁻¹) :=
+          Real.rpow_le_rpow (by norm_num) (by exact_mod_cast hN1) (by positivity)
+  have habs : ((h : ℝ) - 1) ≤ ((h : ℝ) - 1) * Nexp :=
+    le_mul_of_one_le_right (by
+      have : (1 : ℝ) ≤ (h : ℝ) := by exact_mod_cast hh
+      linarith) hNexp_ge1
+  have hexpand : (((h : ℝ) - 1) + C₂coef) * Nexp = ((h : ℝ) - 1) * Nexp + C₂coef * Nexp := by
+    ring
+  rw [hexpand]
+  linarith [hk_real, hroot, habs]
+
+end Erdos340Bh

--- a/src/data/proofs/erdos-340-greedy-sidon-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/erdos-340-greedy-sidon-oq-05-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-statement",
+    "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
+    "range": { "startLine": 65, "endLine": 79 },
+    "type": "definition",
+    "title": "The Analytic Upper Bound and Its Explicit Constant",
+    "content": "The theorem asserts a single constant `C > 0`, depending only on `h`, that caps every `B_h` set:\n\n```lean\ntheorem IsBh.card_le_rpow {h : ℕ} (hh : 1 ≤ h) :\n    ∃ C : ℝ, 0 < C ∧ ∀ (N : ℕ) (A : Finset ℕ), A ⊆ Finset.Icc 1 N → IsBh h A →\n      (A.card : ℝ) ≤ C * (N : ℝ) ^ ((h : ℝ)⁻¹) := by\n```\n\nThe witness is `C = (h − 1) + C₂coef` where `C₂coef = (h·h!)^{1/h}` (`set C₂coef` at line 73). Positivity of `C₂coef` follows from `Real.rpow_pos_of_pos` applied to the positive base `h!·h`, and `linarith` discharges `0 < C` from `0 < C₂coef` together with `1 ≤ h`.",
+    "mathContext": "For a $B_h$ set $A \\subseteq \\{1, \\dots, N\\}$ the claim is $|A| \\le \\big((h-1) + (h\\cdot h!)^{1/h}\\big)\\, N^{1/h}$. The exponent $1/h$ is the counting-bound ceiling; the constant is fully explicit.",
+    "significance": "central",
+    "relatedConcepts": ["B_h set", "Real.rpow", "explicit constant", "Erdős #340"],
+    "prerequisites": ["erdos-340-greedy-sidon-oq-05", "Real power function"]
+  },
+  {
+    "id": "ann-edge-n0",
+    "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
+    "range": { "startLine": 81, "endLine": 87 },
+    "type": "technique",
+    "title": "The N = 0 Edge Case",
+    "content": "```lean\nrcases Nat.eq_zero_or_pos N with hN0 | hN1\n· subst hN0\n  have hAe : A = ∅ := by\n    rw [Finset.Icc_eq_empty (by omega)] at hAN\n    exact Finset.subset_empty.mp hAN\n  simp [hAe, Real.zero_rpow hexp_ne]\n```\n\nWhen `N = 0` the containing interval `Icc 1 0` is empty, forcing `A = ∅` and `|A| = 0`. The right-hand side is `C · 0^{1/h}`, and `Real.zero_rpow` (with `1/h ≠ 0`) makes `0^{1/h} = 0`, so the inequality is `0 ≤ 0`. Splitting this case off lets the main argument freely assume `N ≥ 1` (needed for `N^{1/h} ≥ 1`).",
+    "mathContext": "The interval $[1, 0]$ is empty, so the only $B_h$ subset is $\\varnothing$. Since $1/h \\ne 0$, $0^{1/h} = 0$ and the bound holds trivially.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.Icc_eq_empty", "Real.zero_rpow"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-counting-to-power",
+    "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
+    "range": { "startLine": 88, "endLine": 101 },
+    "type": "key-step",
+    "title": "From the Counting Bound to a Polynomial Inequality in |A|",
+    "content": "The combinatorial input is the OQ-05 counting bound and Mathlib's reverse binomial estimate:\n\n```lean\nhave hcc : Nat.choose A.card h ≤ h * N := hA.choose_card_le hh hAN\nhave hpc : ((k + 1 - h : ℕ) : ℝ) ^ h / (h ! : ℝ) ≤ (Nat.choose k h : ℝ) :=\n  Nat.pow_le_choose (α := ℝ) h k\n```\n\n`IsBh.choose_card_le` gives `C(k, h) ≤ h·N` (with `k = |A|`); `Nat.pow_le_choose` gives the reverse `(k+1−h)^h / h! ≤ C(k, h)` directly over `ℝ`. Chaining them (clearing the `h!` denominator with `div_le_iff₀`, then `mul_le_mul_of_nonneg_left`) yields the key polynomial inequality `(k+1−h)^h ≤ h! · (h · N)` over `ℝ` (line 100).",
+    "mathContext": "Binomial squeeze: $\\frac{(k+1-h)^h}{h!} \\le \\binom{k}{h} \\le hN$, hence $(k+1-h)^h \\le h!\\,h\\,N$. This converts the cardinality $k$ into a degree-$h$ polynomial bounded linearly in $N$.",
+    "significance": "central",
+    "relatedConcepts": ["Nat.pow_le_choose", "IsBh.choose_card_le", "binomial coefficient bounds"],
+    "prerequisites": ["erdos-340-greedy-sidon-oq-05"]
+  },
+  {
+    "id": "ann-take-roots",
+    "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
+    "range": { "startLine": 102, "endLine": 114 },
+    "type": "key-step",
+    "title": "Taking h-th Roots via Real.rpow Monotonicity",
+    "content": "With `q = k+1−h ≥ 0`, applying `x ↦ x^{1/h}` to `q^h ≤ h!·h·N` recovers `q` on the left and splits the constant on the right:\n\n```lean\ncalc q = (q ^ h) ^ ((h : ℝ)⁻¹) := (Real.pow_rpow_inv_natCast hq0 hh0).symm\n  _ ≤ ((h ! : ℝ) * ((h : ℝ) * (N : ℝ))) ^ ((h : ℝ)⁻¹) :=\n      Real.rpow_le_rpow (by positivity) hqh_le (by positivity)\n```\n\n`Real.pow_rpow_inv_natCast` is the identity `(q^h)^{1/h} = q` for `q ≥ 0`; `Real.rpow_le_rpow` is monotonicity of the root on `[0, ∞)`; and `Real.mul_rpow` (line 113) factors `(h!·h·N)^{1/h} = (h!·h)^{1/h}·N^{1/h} = C₂coef · N^{1/h}`. The result is `q ≤ C₂coef · N^{1/h}`.",
+    "mathContext": "Raising both sides of $q^h \\le h!\\,h\\,N$ to the power $1/h$ (monotone for nonnegative arguments) gives $q = (q^h)^{1/h} \\le (h!\\,h)^{1/h} N^{1/h}$, where $(ab)^{1/h} = a^{1/h}b^{1/h}$ splits off the constant.",
+    "significance": "central",
+    "relatedConcepts": ["Real.pow_rpow_inv_natCast", "Real.rpow_le_rpow", "Real.mul_rpow"],
+    "prerequisites": ["Real power function"]
+  },
+  {
+    "id": "ann-absorb-defect",
+    "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
+    "range": { "startLine": 115, "endLine": 135 },
+    "type": "technique",
+    "title": "Absorbing the Additive Defect h − 1",
+    "content": "The binomial bound controls `k+1−h`, not `k` directly. The elementary `ℕ` inequality recovers `k`:\n\n```lean\nhave hk_nat : k ≤ (k + 1 - h) + (h - 1) := by omega\n```\n\nThis holds even when `k < h` (truncated subtraction makes `k+1−h = 0`), which `omega` handles. Transported to `ℝ` it gives `k ≤ q + (h−1)`. Because `N ≥ 1` forces `N^{1/h} ≥ 1` (via `Real.rpow_le_rpow` on `1 ≤ N`), the constant term is absorbed: `(h−1) ≤ (h−1)·N^{1/h}` (`le_mul_of_one_le_right`). A final `linarith` combines `k ≤ q + (h−1)`, `q ≤ C₂coef·N^{1/h}`, and `(h−1) ≤ (h−1)·N^{1/h}` into `k ≤ ((h−1) + C₂coef)·N^{1/h}`.",
+    "mathContext": "Since $k \\le (k{+}1{-}h) + (h{-}1)$ and $N^{1/h} \\ge 1$, the additive defect is folded into the leading coefficient: $k \\le (h{-}1)N^{1/h} + (h!\\,h)^{1/h}N^{1/h} = C_2\\,N^{1/h}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["omega", "truncated subtraction", "le_mul_of_one_le_right", "linarith"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-open-gap",
+    "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
+    "range": { "startLine": 18, "endLine": 26 },
+    "type": "insight",
+    "title": "What Remains Open: the Exponent Gap",
+    "content": "Pairing this upper bound with the OQ-05 greedy lower bound `exists_isBh_rpow_lower` brackets the maximal $B_h$ size $\\sigma_h(N)$:\n\n  `C₁ · N^{1/(2h−1)} ≤ σ_h(N) ≤ C₂ · N^{1/h}`.\n\nThe two exponents `1/(2h−1)` (greedy/probabilistic) and `1/h` (counting) do **not** match. Closing that gap is the genuinely open quantitative content of Erdős #340. At `h = 2` it is the classical Sidon question — `1/3` (greedy) versus `1/2` (counting) — and is deliberately **not** resolved here; only the two endpoints are formalized.",
+    "mathContext": "The Bose–Chowla construction shows the counting ceiling $N^{1/h}$ is attained to within $(1-o(1))$ for $B_h$ sets, so for $h \\ge 2$ the upper bound is essentially sharp; the open problem is whether the *greedy* lower exponent $1/(2h-1)$ can be pushed toward it.",
+    "significance": "central",
+    "relatedConcepts": ["Sidon set", "Bose–Chowla construction", "exists_isBh_rpow_lower", "open problem"],
+    "prerequisites": ["erdos-340-greedy-sidon-oq-05"]
+  }
+]

--- a/src/data/proofs/erdos-340-greedy-sidon-oq-05-oq-01/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon-oq-05-oq-01/meta.json
@@ -1,0 +1,88 @@
+{
+  "id": "erdos-340-greedy-sidon-oq-05-oq-01",
+  "title": "Erdős #340 OQ-05: the analytic O(N^{1/h}) upper bound for B_h sets",
+  "slug": "erdos-340-greedy-sidon-oq-05-oq-01",
+  "description": "Companion to the OQ-05 greedy lower bound exists_isBh_rpow_lower (|A| ≥ C₁·N^{1/(2h-1)}). This entry supplies the matching analytic upper bound IsBh.card_le_rpow: every B_h set A ⊆ {1,…,N} satisfies |A| ≤ C₂·N^{1/h} with the explicit constant C₂ = (h−1) + (h·h!)^{1/h}. It is derived 0-axiom from the combinatorial counting bound IsBh.choose_card_le (C(|A|,h) ≤ h·N) and Mathlib's binomial lower bound Nat.pow_le_choose, taking h-th roots via Real.rpow. Together the two results bracket the maximal B_h size σ_h(N) inside [C₁·N^{1/(2h-1)}, C₂·N^{1/h}]; the exponent gap 1/(2h-1) vs 1/h is exactly the open quantitative core of Erdős #340 for general h (the classical Sidon 1/3 vs 1/2 gap at h=2), and is NOT addressed here.",
+  "meta": {
+    "author": "researcher-7 (Lean Genius)",
+    "sourceUrl": "https://www.erdosproblems.com/340",
+    "date": "2026-06-28",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos340BhUpperBound.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "additive-combinatorics",
+      "sidon-sets",
+      "Bh-sets",
+      "extremal",
+      "erdos",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.pow_le_choose",
+        "description": "binomial lower bound (k+1-h)^h / h! ≤ C(k,h) — the reverse of the counting bound, supplies the power of k",
+        "module": "Mathlib.Combinatorics.Choose.Bounds"
+      },
+      {
+        "theorem": "Real.pow_rpow_inv_natCast",
+        "description": "(q^h)^(1/h) = q for q ≥ 0 — used to take h-th roots of the polynomial inequality",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "monotonicity of x ↦ x^(1/h) on [0,∞) — transfers the inequality through the h-th root",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.mul_rpow",
+        "description": "(a·b)^(1/h) = a^(1/h)·b^(1/h) for a,b ≥ 0 — splits the constant from N^{1/h}",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ],
+    "originalContributions": [
+      "IsBh.card_le_rpow: every B_h set A ⊆ {1,…,N} has |A| ≤ C₂·N^{1/h} with explicit C₂ = (h−1) + (h·h!)^{1/h} — the analytic upper-bound companion to the OQ-05 greedy lower bound, completing the bracket on σ_h(N)"
+    ],
+    "references": [
+      {
+        "authors": "Erdős, Paul",
+        "title": "Problem #340",
+        "year": "",
+        "venue": "erdosproblems.com",
+        "note": "Growth of B_h (and Sidon, h=2) sequences; the exponent gap between greedy lower and counting upper bounds is the open quantitative content."
+      },
+      {
+        "authors": "Bose, R. C. and Chowla, S.",
+        "title": "Theorems in the additive theory of numbers",
+        "year": "1962",
+        "venue": "Comment. Math. Helv. 37",
+        "note": "B_h constructions meeting the N^{1/h} ceiling to within (1−o(1))."
+      }
+    ],
+    "prerequisites": [
+      "The OQ-05 entry Erdos340GreedySidonOQ05.lean (def IsBh; IsBh.choose_card_le; exists_isBh_rpow_lower)",
+      "Mathlib's binomial bounds (Nat.pow_le_choose) and real power function (Real.rpow)"
+    ],
+    "dateAdded": "2026-06-28",
+    "axiomCount": 0,
+    "lineCount": 137,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound). The result is unconditional; the open #340 gap (improving 1/(2h-1) toward 1/h) is recorded only as commentary.",
+    "theoremCount": 1,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #340 concerns the maximal size σ_h(N) of a B_h set inside {1,…,N} — a set whose h-fold sums with repetition are all distinct (Sidon sets are the h=2 case). The literature brackets σ_h(N) between a greedy/probabilistic lower bound of order N^{1/(2h-1)} and a counting upper bound of order N^{1/h}; closing this exponent gap is the open quantitative content of the problem. The OQ-05 development formalized the full B_h theory, the combinatorial counting bound C(|A|,h) ≤ h·N, and the analytic greedy lower bound exists_isBh_rpow_lower (|A| ≥ C₁·N^{1/(2h-1)}). What remained was the analytic form of the upper bound stated alongside it.",
+    "problemStatement": "**Goal**: Supply the analytic O(N^{1/h}) upper bound matching the OQ-05 greedy lower bound, with an explicit constant, as a fully verified 0-axiom theorem.\n\n**Resolution**: IsBh.card_le_rpow proves ∃ C > 0, ∀ N A, A ⊆ Icc 1 N → IsBh h A → |A| ≤ C·N^{1/h}, with C = (h−1) + (h·h!)^{1/h}. Combined with exists_isBh_rpow_lower this gives C₁·N^{1/(2h-1)} ≤ σ_h(N) ≤ C₂·N^{1/h}.",
+    "text": "A 137-line, axiom-free theorem building directly on the OQ-05 counting bound. Starting from IsBh.choose_card_le (C(k,h) ≤ h·N with k = |A|), Mathlib's Nat.pow_le_choose supplies the reverse inequality (k+1−h)^h / h! ≤ C(k,h); combining yields (k+1−h)^h ≤ h!·h·N over ℝ. Taking h-th roots via Real.pow_rpow_inv_natCast and the monotonicity Real.rpow_le_rpow gives k+1−h ≤ (h·h!)^{1/h}·N^{1/h}, and Real.mul_rpow splits off the constant. The elementary ℕ inequality k ≤ (k+1−h) + (h−1) (valid even when k < h, where truncated subtraction is 0) absorbs the additive h−1 into (h−1)·N^{1/h} using N^{1/h} ≥ 1, yielding k ≤ C₂·N^{1/h}. The N = 0 edge case is handled separately (A ⊆ Icc 1 0 = ∅).",
+    "proofStrategy": "(1) Dispatch N = 0 via Icc 1 0 = ∅ and 0^{1/h} = 0. (2) For N ≥ 1, combine IsBh.choose_card_le and Nat.pow_le_choose to get (k+1−h)^h ≤ h!·(h·N) over ℝ. (3) Apply x ↦ x^{1/h}: (q^h)^{1/h} = q (Real.pow_rpow_inv_natCast, q = k+1−h ≥ 0) on the left, monotonicity on the right, then Real.mul_rpow to factor the constant from N^{1/h}. (4) Transport k ≤ (k+1−h) + (h−1) to ℝ, bound h−1 ≤ (h−1)·N^{1/h} via N^{1/h} ≥ 1, and finish with linarith.",
+    "keyInsights": [
+      "The upper bound is a clean h-th-root of the combinatorial counting bound: Nat.pow_le_choose turns C(k,h) ≤ h·N into (k+1−h)^h ≤ h!·h·N, and rpow monotonicity does the rest — no further B_h structure is needed.",
+      "The additive defect h−1 from the binomial lower bound is harmless: since N ≥ 1 forces N^{1/h} ≥ 1, it is absorbed into the constant, giving a single clean coefficient C₂ = (h−1) + (h·h!)^{1/h}.",
+      "Pairing IsBh.card_le_rpow with exists_isBh_rpow_lower brackets σ_h(N) in [C₁·N^{1/(2h-1)}, C₂·N^{1/h}]; the exponent gap is precisely the open core of Erdős #340 (1/3 vs 1/2 at h=2) and is deliberately left open."
+    ]
+  }
+}

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -6,7 +6,7 @@
   "tier": "B",
   "tractability": "medium — the foundational B_h theory and the sharp B_h counting upper bound are now formalized and verified (0-axiom). The deep open direction (improving the greedy B_h lower bound toward the N^{1/h} ceiling) remains open, exactly as for the parent #340.",
   "started": "2026-06-27",
-  "lastUpdate": "2026-06-27T20:00:00.000Z",
+  "lastUpdate": "2026-06-28T03:00:00.000Z",
   "path": "research/problems/erdos-340-greedy-sidon-oq-05",
   "leanFiles": [
     {
@@ -19,6 +19,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos340GreedySidonOQ05.lean"
+    },
+    {
+      "path": "Proofs/Erdos340BhUpperBound.lean",
+      "filename": "Erdos340BhUpperBound.lean",
+      "lineCount": 137,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos340BhUpperBound.lean"
     }
   ],
   "tags": [
@@ -55,7 +66,8 @@
       "Part 8 (explicit closed form): card_forbidden_poly bounds the forbidden set by 2*h*(|A|+1)^(2h-1) — an explicit degree-(2h-1) polynomial in |A|, the form the greedy lower bound consumes. Built on card_sym_le_pow (|A.sym n| <= |A|^n, a Finset.sym cardinality bound Mathlib lacks) and geom_sum_le_pow (sum_{i<=k} n^i <= (n+1)^k).",
       "End-to-end greedy lower bound inside {1,...,N} is now formalised: the only remaining gap is the real-analytic conversion of the degree-(2h-1) polynomial bound to a fractional power N^{1/(2h-1)}; no further B_h structure is needed.",
       "The bounded greedy step IsBh.exists_insert_le needs NO hypothesis A subset {1,...,N}: any m in {1,...,N} outside the blocked set A union {forbidden} automatically avoids A. Counting blocked < N suffices.",
-      "Key API: Finset.exists_mem_notMem_of_card_lt_card (s.card < t.card -> exists e in t, e notin s) cleanly extracts an available element; avoids card_sdiff which in this Mathlib is the unconditional intersection form #(t\\s)=#t-#(s cap t)."
+      "Key API: Finset.exists_mem_notMem_of_card_lt_card (s.card < t.card -> exists e in t, e notin s) cleanly extracts an available element; avoids card_sdiff which in this Mathlib is the unconditional intersection form #(t\\s)=#t-#(s cap t).",
+      "ANALYTIC UPPER BOUND (Erdos340BhUpperBound.lean, IsBh.card_le_rpow): the combinatorial counting bound is convertible to the matching fractional-power upper bound |A| <= C2 * N^{1/h} with explicit C2 = (h-1) + (h*h!)^{1/h}, mirroring the lower-bound analytic step. Engine: from IsBh.choose_card_le (C(k,h) <= h*N), Mathlib's Nat.pow_le_choose gives the reverse (k+1-h)^h / h! <= C(k,h), so (k+1-h)^h <= h!*h*N over R; take h-th roots via Real.pow_rpow_inv_natCast ((q^h)^{1/h}=q for q>=0) + Real.rpow_le_rpow monotonicity + Real.mul_rpow to split the constant, then absorb the additive defect using k <= (k+1-h)+(h-1) (omega, valid even when k<h) and N^{1/h} >= 1. 0-axiom. Paired with exists_isBh_rpow_lower this brackets sigma_h(N) in [C1*N^{1/(2h-1)}, C2*N^{1/h}]; the exponent gap is the open core of #340."
     ],
     "builtItems": [
       "Erdos340GreedySidonOQ05.lean: def IsBh (h-fold-sum-distinctness via multiset-sum InjOn on A.sym h); IsBh.subset; isBh_one (every set is B_1); IsBh.sum_injOn_powersetCard (distinct h-subset sums); IsBh.choose_card_le (MAIN: Nat.choose |A| h ≤ h·N for B_h A ⊆ [1,N]); IsBh.two_card_mul_pred_le (Sidon recovery |A|(|A|-1) ≤ 4N). 206 lines, 6 theorems, 1 def, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only).",
@@ -80,9 +92,9 @@
       "Finset.sym s n has no direct cardinality (multichoose) lemma in Mathlib — only the Fintype-level Sym.card_sym_eq_choose. This is why the counting bound is routed through h-subsets (powersetCard, which DOES have card_powersetCard) rather than the full multiset family."
     ],
     "nextSteps": [
-      "Real-analytic conversion: from exists_isBh_Icc_card_of_le, choose k ~ (N/(4h))^{1/(2h-1)} to get the explicit fractional-power lower bound |A| >= c*N^{1/(2h-1)} (needs Real.rpow / Nat.pow monotonicity, no further B_h structure).",
+      "Both analytic endpoints are now formalized (lower: exists_isBh_rpow_lower, |A| >= C1*N^{1/(2h-1)}; upper: IsBh.card_le_rpow, |A| <= C2*N^{1/h}). The remaining content is the genuinely OPEN #340 quantitative core: closing the exponent gap 1/(2h-1) vs 1/h (at h=2 the classical Sidon 1/3 vs 1/2). Not attackable by elementary counting.",
       "Optional: extract a clean corollary phrasing largest-element vs cardinality, mirroring the parent greedySidon gallery entry."
     ],
-    "progressSummary": "Foundational B_h theory + sharp upper bound (choose(|A|,h) <= h*N), Sidon bridge (IsBh 2 <-> IsSidon), affine invariance, greedy extension + explicit greedy family, the forbidden-set counting chain (card_forbidden_le/le_prime/poly: explicit 2h(|A|+1)^(2h-1), degree 2h-1), and NOW the end-to-end [1,N]-bounded greedy lower bound: exists_isBh_Icc_card_of_le shows k+2h(k+1)^(2h-1) <= N implies a B_h set subset {1,...,N} of card k exists. Remaining open: only the real-analytic step converting the polynomial bound to |A| = Omega(N^{1/(2h-1)})."
+    "progressSummary": "Foundational B_h theory + sharp counting upper bound (choose(|A|,h) <= h*N), Sidon bridge (IsBh 2 <-> IsSidon), affine invariance, greedy extension + explicit greedy family, the forbidden-set counting chain (card_forbidden_le/le_prime/poly: explicit 2h(|A|+1)^(2h-1), degree 2h-1), the end-to-end [1,N]-bounded greedy lower bound (exists_isBh_Icc_card_of_le), and BOTH analytic endpoints: the greedy lower bound exists_isBh_rpow_lower (|A| >= C1*N^{1/(2h-1)}) and the matching analytic upper bound IsBh.card_le_rpow (|A| <= C2*N^{1/h}, C2 = (h-1)+(h*h!)^{1/h}, in Erdos340BhUpperBound.lean). Together these bracket sigma_h(N) in [C1*N^{1/(2h-1)}, C2*N^{1/h}]. Remaining open: only the genuinely hard #340 quantitative core of closing the exponent gap."
   }
 }


### PR DESCRIPTION
## Summary

Adds the **analytic `O(N^{1/h})` upper bound** for `B_h` sets — the matching companion to the OQ-05 greedy lower bound `exists_isBh_rpow_lower` — as a fully verified, **0-axiom** theorem.

**New file** `proofs/Proofs/Erdos340BhUpperBound.lean` (137 lines, 1 theorem, 0 defs, 0 axioms, 0 sorries).

### The result

`IsBh.card_le_rpow`: there is an explicit `C > 0` (depending only on `h`) with
```
∀ N A, A ⊆ Icc 1 N → IsBh h A → |A| ≤ C · N^{1/h},   C = (h−1) + (h·h!)^{1/h}.
```

### The argument (0-axiom)

1. From `IsBh.choose_card_le` (`C(k,h) ≤ h·N`, `k = |A|`) and Mathlib's binomial lower bound `Nat.pow_le_choose` (`(k+1−h)^h / h! ≤ C(k,h)`), combine to `(k+1−h)^h ≤ h!·h·N` over ℝ.
2. Take `h`-th roots via `Real.pow_rpow_inv_natCast` + `Real.rpow_le_rpow`, splitting the constant with `Real.mul_rpow`.
3. Recover `k` from `k+1−h` with the elementary `ℕ` bound `k ≤ (k+1−h)+(h−1)` (valid even when `k<h`), absorbing the additive defect using `N^{1/h} ≥ 1`.

Paired with `exists_isBh_rpow_lower` this brackets the maximal `B_h` size:
```
C₁ · N^{1/(2h−1)} ≤ σ_h(N) ≤ C₂ · N^{1/h}.
```
The exponent gap `1/(2h−1)` vs `1/h` (the classical Sidon `1/3` vs `1/2` at `h=2`) is the genuinely open quantitative core of Erdős #340 and is **not** addressed here.

## Verification

- `lean v4.26.0` against main's Mathlib build: **EXIT 0**, no errors.
- `#print axioms IsBh.card_le_rpow` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`) → genuinely 0-axiom.
- 0 sorries / 0 admits in source.
- Gallery entry `erdos-340-greedy-sidon-oq-05-oq-01` (meta.json + 6 annotations) added; `pnpm gallery:check-size` passes (all 4124 entries within caps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)