### PR TITLE
Enrich Companion Sawtooth Identity for Hermite's Floor Identity

### DIFF
--- a/src/data/proofs/hermite-floor-identity-oq-01/annotations.json
+++ b/src/data/proofs/hermite-floor-identity-oq-01/annotations.json
@@ -1,0 +1,125 @@
+[
+  {
+    "id": "ann-hermitefract-setup",
+    "proofId": "hermite-floor-identity-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Setup: The Sawtooth Companion and the value − floor Plan",
+    "content": "The file resolves the open question oq-01 posed by the parent entry hermite-floor-identity: the fractional-part twin of Hermite's classical floor identity. Where Hermite's identity sums the floor ⌊x + k/n⌋, this file sums the sawtooth {x + k/n} = Int.fract (x + k/n), obtaining ∑_{k<n}{x + k/n} = {n·x} + (n−1)/2. The docstring announces the one-line strategy: since {y} = y − ⌊y⌋, the sawtooth sum is the exact (un-floored) sum minus the floor sum, and the floor sum is exactly Hermite's identity. The single `import Mathlib` pulls in the `Int.fract`, `Int.floor`, Euclidean-division, and `Finset.range` summation APIs. The note that the two parent lemmas are reproduced as `private` helpers keeps the file kernel-checkable on its own.",
+    "mathContext": "For real $x$ and $n \\ge 1$: $\\sum_{k=0}^{n-1}\\{x + k/n\\} = \\{n x\\} + \\tfrac{n-1}{2}$, where $\\{y\\} = y - \\lfloor y\\rfloor$. The companion to $\\sum_{k=0}^{n-1}\\lfloor x + k/n\\rfloor = \\lfloor n x\\rfloor$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Int.fract",
+      "Int.floor",
+      "sawtooth function",
+      "Hermite's identity",
+      "Finset.range"
+    ],
+    "prerequisites": [
+      "the fractional-part function {·} = Int.fract and {y} = y − ⌊y⌋",
+      "the floor function on ℝ and ℤ",
+      "finite sums over Finset.range"
+    ]
+  },
+  {
+    "id": "ann-hermitefract-int-hermite-sum",
+    "proofId": "hermite-floor-identity-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 88
+    },
+    "type": "lemma",
+    "title": "Parent Helper: The Integer Hermite Sum by Shift Recurrence",
+    "content": "The first reproduced helper, `int_hermite_sum`, proves the purely integer identity ∑_{k<n}(a+k)/n = a (Euclidean division on ℤ) for n ≥ 1 and any integer a. The engine is the recurrence `step`: bumping a by 1 adds exactly 1 to the sum. It is proved by expanding the SAME range-(n+1) sum of g(j) := (b+j)/n two ways — `Finset.sum_range_succ'` peels the bottom term g(0) and reindexes the rest as ∑_{k<n} g(k+1), while `Finset.sum_range_succ` peels the top term g(n) — so the shifted and unshifted sums differ by g(n) − g(0). The endpoint quotients are g(n) = b/n + 1 (via `Int.add_mul_ediv_right`, since b+n = b + 1·n) and g(0) = b/n, giving difference 1. With the recurrence in hand, `Int.induction_on` runs the induction over all of ℤ in both directions: the base case a = 0 vanishes because each (0+k)/n = 0 for k < n (`Int.ediv_eq_zero_of_lt_abs`), and the positive/negative steps both invoke `step`.",
+    "mathContext": "Writing $g(j) = \\lfloor (b+j)/n\\rfloor_{\\mathbb Z}$, $\\sum_{k<n} g(k+1) - \\sum_{k<n} g(k) = g(n) - g(0) = (b/n + 1) - b/n = 1$. Induction over all of $\\mathbb Z$ then gives $\\sum_{k<n}(a+k)/n = a$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Euclidean division on ℤ",
+      "Int.induction_on",
+      "Finset.sum_range_succ'",
+      "Finset.sum_range_succ",
+      "Int.add_mul_ediv_right"
+    ],
+    "prerequisites": [
+      "Euclidean (round-toward-−∞) division on ℤ",
+      "induction over the integers in both directions",
+      "reindexing finite sums over Finset.range"
+    ]
+  },
+  {
+    "id": "ann-hermitefract-floor-identity",
+    "proofId": "hermite-floor-identity-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 100
+    },
+    "type": "lemma",
+    "title": "Parent Helper: Hermite's Floor Identity (Real → Integer Reduction)",
+    "content": "The second reproduced helper, `hermite_floor_identity`, is Hermite's classical identity ∑_{k<n}⌊x + k/n⌋ = ⌊n·x⌋ over ℝ. It is the floor sum that gets subtracted off in the main theorem. The reduction to the integer lemma is the key move: each real summand ⌊x + k/n⌋ is rewritten as the integer Euclidean quotient (⌊n·x⌋ + k)/n. This uses two Mathlib floor laws — `Int.floor_div_natCast` (⌊a/n⌋ = ⌊a⌋/n, pushing the real floor through the division) after rewriting x + k/n = (n·x + k)/n by `field_simp`, and `Int.floor_add_natCast` (⌊a + k⌋ = ⌊a⌋ + k for the integer offset k). Once every term is the integer quotient (⌊n·x⌋ + k)/n, the sum is closed by `int_hermite_sum` with a = ⌊n·x⌋.",
+    "mathContext": "$\\lfloor x + k/n\\rfloor = \\lfloor (n x + k)/n\\rfloor = (\\lfloor n x\\rfloor + k)/n$ in $\\mathbb Z$; summing over $k < n$ gives $\\lfloor n x\\rfloor$ by the integer Hermite sum.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Int.floor_div_natCast",
+      "Int.floor_add_natCast",
+      "Hermite's identity",
+      "field_simp"
+    ],
+    "prerequisites": [
+      "the division-floor law ⌊a/n⌋ = ⌊a⌋/n",
+      "the integer Hermite sum (helper above)"
+    ]
+  },
+  {
+    "id": "ann-hermitefract-gauss-sum",
+    "proofId": "hermite-floor-identity-oq-01",
+    "range": {
+      "startLine": 104,
+      "endLine": 116
+    },
+    "type": "insight",
+    "title": "The Only New Arithmetic: ∑ k/n = (n−1)/2 over ℝ",
+    "content": "Beyond Hermite's identity, the sole new ingredient is the average of the offsets, `sum_div_eq`: ∑_{k<n} k/n = (n−1)/2. This is the discrete average 1/2 of the sawtooth summed over its n−1 nonzero samples — exactly why the additive constant in the headline identity is (n−1)/2. The proof is deliberately done over ℝ by induction (`Finset.sum_range_succ` then `ring` at each step) rather than by casting Mathlib's `Finset.sum_range_id`. The reason is a genuine pitfall: `Finset.sum_range_id` yields the natural-number quotient n(n−1)/2, and ℕ-division is not a ring operation, so `ring`/`field_simp` cannot normalize it after a naive cast. Proving Gauss's sum directly over ℝ keeps the whole computation inside a field, after which `field_simp` divides by n cleanly.",
+    "mathContext": "$\\sum_{k=0}^{n-1} k = \\tfrac{n(n-1)}{2}$ (Gauss), so $\\sum_{k=0}^{n-1}\\tfrac{k}{n} = \\tfrac{n-1}{2}$. Proving the real-valued form $\\sum_{k<m} k = \\tfrac{m(m-1)}{2}$ by induction avoids the $\\mathbb N$-quotient that blocks algebraic normalization.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "triangular number",
+      "Gauss summation",
+      "Finset.sum_range_succ",
+      "natural-number division pitfall",
+      "field_simp"
+    ],
+    "prerequisites": [
+      "Gauss's triangular-number sum",
+      "why ℕ-division blocks ring normalization",
+      "induction over Finset.range"
+    ]
+  },
+  {
+    "id": "ann-hermitefract-main",
+    "proofId": "hermite-floor-identity-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 142
+    },
+    "type": "insight",
+    "title": "The Companion Identity: Sawtooth = Exact − Floor",
+    "content": "The headline theorem `hermite_fract_sum` assembles the pieces. Each summand is expanded by the definition Int.fract y = y − ⌊y⌋ (`hterm`), then `Finset.sum_sub_distrib` splits the sawtooth sum into an exact part minus a floor part. The exact part ∑_{k<n}(x + k/n) splits again by `Finset.sum_add_distrib` into ∑_{k<n} x = n·x (`Finset.sum_const`, `card_range`, `nsmul_eq_mul`) and ∑_{k<n} k/n = (n−1)/2 (the Gauss-sum lemma), giving n·x + (n−1)/2 (`hexact`). The floor part ∑_{k<n}⌊x + k/n⌋, cast to ℝ via `Int.cast_sum`, equals ⌊n·x⌋ by Hermite's identity (`hfloor`). Substituting both and unfolding {n·x} = n·x − ⌊n·x⌋ once more, the goal (n·x + (n−1)/2) − ⌊n·x⌋ = (n·x − ⌊n·x⌋) + (n−1)/2 is a pure rearrangement closed by `ring`. The structural insight: the sawtooth identity is not independent of Hermite's — it is its mirror image, with the floor sum cancelling and only the triangular average surviving.",
+    "mathContext": "$\\sum_{k<n}\\{x+k/n\\} = \\sum_{k<n}(x+k/n) - \\sum_{k<n}\\lfloor x+k/n\\rfloor = \\big(nx + \\tfrac{n-1}{2}\\big) - \\lfloor nx\\rfloor = (nx - \\lfloor nx\\rfloor) + \\tfrac{n-1}{2} = \\{nx\\} + \\tfrac{n-1}{2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Int.fract",
+      "Finset.sum_sub_distrib",
+      "Finset.sum_add_distrib",
+      "Int.cast_sum",
+      "Bernoulli/Raabe multiplication (m = 1 case)"
+    ],
+    "prerequisites": [
+      "the decomposition {y} = y − ⌊y⌋",
+      "additive splitting of finite sums",
+      "Hermite's floor identity and the Gauss-sum lemma above"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `hermite-floor-identity-oq-01` (quality 37, 0 prior passes; previously had **only meta.json**).

## Changes
- **Added `annotations.json`** with 5 annotations covering the full 142-line Lean file: setup/docstring, parent helper `int_hermite_sum` (shift recurrence), parent helper `hermite_floor_identity` (real→integer reduction), `sum_div_eq` (the ∑ k/n = (n−1)/2 Gauss sum + ℕ-division pitfall), and the main theorem `hermite_fract_sum` (sawtooth = exact − floor).
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`; `type`/`significance` conform to the enums.

## Validation
- `gallery:check-size`: within caps. annotations.json: valid JSON, unique ids, ranges ≤ 142 and ordered. meta.json unchanged.