### PR TITLE
audit(cycleV62): erdos-57-oq-04 + erdos-156 re-audited CLEAN [standing FPs]

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4925,9 +4925,9 @@
       "result": "clean"
     },
     "erdos-156": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-06-28T10:18:29Z",
+      "lastAudited": "2026-06-28T10:28:57Z",
       "result": "clean"
     },
     "erdos-157": {
@@ -25171,8 +25171,8 @@
       "issues": []
     },
     "erdos-57-oq-04": {
-      "auditCount": 3,
-      "lastAudited": "2026-06-28T10:18:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-28T10:27:04Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Gallery Integrity Audit — cycleV62

Both remaining unaudited targets re-audited and confirmed **CLEAN** (honest, fully-disclosed standing false-positives of the find-targets heuristic).

### erdos-57-oq-04 — Tier A
- **find-targets flag**: axiom undercount (claims 0, 1 declaration)
- **Reality**: `Erdos57Problem.lean` has exactly 1 axiom — `erdos_57`, the deep Liu–Montgomery host theorem — and 0 sorries. The OQ-04 entry scopes to the contributed odd-cycle lemmas (`exists_odd_cycle_of_odd_closed_walk`, `bipartite_iff_no_odd_cycles`, …) which are genuinely 0-axiom / 0-sorry.
- The `assumptions` field **explicitly discloses** the host axiom. No overclaim.

### erdos-156 — wip
- **find-targets flag**: sorry mismatch (claims 3, chain 15)
- **Reality**: badge `wip`, status `formalized`. The `assumptions` field **exhaustively discloses** non-compilation against pinned Mathlib v4.26.0 (~30 errors, multiple `sorry`-emitting declarations). The public presentation is maximally conservative — no overclaim.

Both heuristic flags are file-level checks against correctly-scoped, fully-disclosed meta.json. No public-facing claim exceeds what the Lean kernel guarantees.

Tracker bookkeeping only (audit count + timestamp bumps).

---
Discovered during gallery integrity audit.