### PR TITLE
research(erdos-1009-oq-03-oq-01): exact fractional triangle-packing optimum of K₄ via LP duality [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1253,6 +1253,7 @@ import Proofs.Erdos1008ProblemProvable
 import Proofs.Erdos1009OQ01
 import Proofs.Erdos1009OQ02Problem
 import Proofs.Erdos1009OQ03
+import Proofs.Erdos1009OQ03OQ01
 import Proofs.Erdos1009Problem
 import Proofs.Erdos100OQ01
 import Proofs.Erdos100OQ01WIP01

--- a/proofs/Proofs/Erdos1009OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1009OQ03OQ01.lean
@@ -1,0 +1,239 @@
+/-
+  Erdős Problem #1009 — Open Question OQ-03 / OQ-01
+  The *exact* fractional triangle-packing optimum of K₄, via LP duality.
+
+  Parent: `Erdos1009OQ03.lean` certified a one-sided integrality gap for the
+  maximum edge-disjoint triangle packing of the complete graph K₄:
+
+    • integer optimum    ν(K₄)  = 1   (`integral_optimum`)
+    • fractional optimum  ν*(K₄) ≥ 2   (the uniform ½-weighting is feasible)
+
+  leaving the *exact* value of ν*(K₄) open (only the lower bound ν* ≥ 2 was
+  certified). This file closes that gap from both sides by formalizing the LP
+  **dual** — the fractional triangle *cover* — and the **weak-duality**
+  inequality relating the two:
+
+      (fractional packing value)  ≤  (fractional cover value).
+
+  Consequences certified here, all `decide`/elementary (0 sorries, 0 axioms,
+  no `native_decide`):
+
+    • `weak_duality` : for *every* feasible fractional packing `w` and *every*
+      feasible fractional cover `y`, `fracValue w ≤ coverValue y`. This is the
+      reusable structural core — a finite double-counting (Fubini) argument over
+      the triangle/edge incidence, valid for any packing/cover pair.
+
+    • `frac_optimum`  : ν*(K₄) = 2 *exactly*
+      (`IsGreatest` of the fractional packing values). The lower bound is the
+      ½-weighting of value 2; the matching upper bound is weak duality against
+      the explicit ⅓-edge cover.
+
+    • `cover_optimum` : τ*(K₄) = 2 *exactly*
+      (`IsLeast` of the fractional cover values), by the symmetric argument.
+
+  Hence ν*(K₄) = τ*(K₄) = 2: LP strong duality holds *with no gap between the
+  packing and cover relaxations* for this instance, and the integrality gap to
+  the integer optimum ν(K₄) = 1 is now pinned to the exact factor 2 (rather than
+  merely ≥ 2). The dual certificate `yThird` is the textbook "every edge weight
+  ⅓" fractional triangle cover.
+
+  Self-contained: reuses only the concrete decidable K₄ model
+  (`triangles`/`allEdges`/`edgesOf`) of the parent file, re-stated here so the
+  file stands alone.
+
+  Tags: graph-theory, triangles, edge-disjoint, integrality-gap,
+        linear-programming, lp-duality, fractional-cover, complexity
+-/
+
+import Mathlib
+
+namespace Erdos1009OQ03OQ01
+
+open Finset
+
+/-- Vertices of K₄. -/
+abbrev V := Fin 4
+
+/-- The four triangles of K₄: all 3-element subsets of the vertex set. -/
+def triangles : Finset (Finset V) := {{0, 1, 2}, {0, 1, 3}, {0, 2, 3}, {1, 2, 3}}
+
+/-- The potential edges of K₄: all 2-element subsets of the vertex set. -/
+def allEdges : Finset (Finset V) := (univ : Finset V).powersetCard 2
+
+/-- The edge set of a triangle: its three 2-element subsets. -/
+def edgesOf (T : Finset V) : Finset (Finset V) := T.powersetCard 2
+
+/-! ## Model facts -/
+
+/-- K₄ has four triangles. -/
+theorem triangles_card : triangles.card = 4 := by decide
+
+/-- K₄ has six edges. -/
+theorem allEdges_card : allEdges.card = 6 := by decide
+
+/-- The edges of any triangle are edges of K₄. -/
+theorem edgesOf_subset (T : Finset V) : edgesOf T ⊆ allEdges := by
+  intro e he
+  rw [edgesOf, Finset.mem_powersetCard] at he
+  rw [allEdges, Finset.mem_powersetCard]
+  exact ⟨he.1.trans (Finset.subset_univ T), he.2⟩
+
+/-- Each triangle has exactly three edges. -/
+theorem edgesOf_card_three : ∀ T ∈ triangles, (edgesOf T).card = 3 := by decide
+
+/-- Each edge of K₄ lies in at most two triangles. -/
+theorem edge_incidence_le_two :
+    ∀ e ∈ allEdges, (triangles.filter (fun T => e ∈ edgesOf T)).card ≤ 2 := by decide
+
+/-! ## The LP relaxation (primal: fractional packing) and its dual (cover) -/
+
+/-- A fractional triangle packing: nonnegative weights on triangles whose total
+    load on each edge is at most 1. (LP primal.) -/
+def IsFracPacking (w : Finset V → ℚ) : Prop :=
+  (∀ T ∈ triangles, 0 ≤ w T) ∧
+    ∀ e ∈ allEdges, (∑ T ∈ triangles, if e ∈ edgesOf T then w T else 0) ≤ 1
+
+/-- The value (objective) of a fractional packing: the total weight. -/
+def fracValue (w : Finset V → ℚ) : ℚ := ∑ T ∈ triangles, w T
+
+/-- A fractional triangle cover: nonnegative weights on edges such that every
+    triangle is covered to total weight at least 1. (LP dual.) -/
+def IsFracCover (y : Finset V → ℚ) : Prop :=
+  (∀ e ∈ allEdges, 0 ≤ y e) ∧
+    ∀ T ∈ triangles, 1 ≤ ∑ e ∈ edgesOf T, y e
+
+/-- The value (objective) of a fractional cover: the total edge weight. -/
+def coverValue (y : Finset V → ℚ) : ℚ := ∑ e ∈ allEdges, y e
+
+/-! ## Weak duality -/
+
+/-- **Weak LP duality.** For every feasible fractional packing `w` and every
+    feasible fractional cover `y`, the packing value is at most the cover value:
+    `fracValue w ≤ coverValue y`.
+
+    Proof is the standard finite double-counting over the triangle/edge
+    incidence: each packed triangle's weight is absorbed by the cover it must
+    pay for (cover constraint), then summation order is swapped (Fubini) and the
+    packing constraint bounds each edge's load by 1. -/
+theorem weak_duality (w y : Finset V → ℚ)
+    (hw : IsFracPacking w) (hy : IsFracCover y) :
+    fracValue w ≤ coverValue y := by
+  obtain ⟨hw0, hwload⟩ := hw
+  obtain ⟨hy0, hycov⟩ := hy
+  -- Step 1: bound the packing value below the incidence double sum.
+  have step1 : fracValue w
+      ≤ ∑ T ∈ triangles, ∑ e ∈ allEdges, (if e ∈ edgesOf T then w T * y e else 0) := by
+    unfold fracValue
+    apply Finset.sum_le_sum
+    intro T hT
+    have hrw : (∑ e ∈ allEdges, if e ∈ edgesOf T then w T * y e else 0)
+        = w T * ∑ e ∈ edgesOf T, y e := by
+      rw [Finset.sum_ite_mem, Finset.inter_eq_right.mpr (edgesOf_subset T), Finset.mul_sum]
+    rw [hrw]
+    calc w T = w T * 1 := by ring
+      _ ≤ w T * ∑ e ∈ edgesOf T, y e :=
+          mul_le_mul_of_nonneg_left (hycov T hT) (hw0 T hT)
+  -- Step 2: swap summation order and bound by the cover value.
+  have step2 : (∑ T ∈ triangles, ∑ e ∈ allEdges, (if e ∈ edgesOf T then w T * y e else 0))
+      ≤ coverValue y := by
+    rw [Finset.sum_comm]
+    unfold coverValue
+    apply Finset.sum_le_sum
+    intro e he
+    have hrw : (∑ T ∈ triangles, if e ∈ edgesOf T then w T * y e else 0)
+        = y e * ∑ T ∈ triangles, (if e ∈ edgesOf T then w T else 0) := by
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro T _
+      by_cases h : e ∈ edgesOf T
+      · simp only [h, if_true]; ring
+      · simp only [h, if_false, mul_zero]
+    rw [hrw]
+    calc y e * (∑ T ∈ triangles, if e ∈ edgesOf T then w T else 0)
+        ≤ y e * 1 := mul_le_mul_of_nonneg_left (hwload e he) (hy0 e he)
+      _ = y e := by ring
+  exact step1.trans step2
+
+/-! ## Explicit optimal primal and dual solutions -/
+
+/-- The uniform half-weight assignment: weight ½ on every triangle. (Optimal
+    fractional packing.) -/
+def wHalf : Finset V → ℚ := fun _ => 1 / 2
+
+/-- The uniform third-weight assignment: weight ⅓ on every edge. (Optimal
+    fractional cover — the LP dual certificate.) -/
+def yThird : Finset V → ℚ := fun _ => 1 / 3
+
+/-- **Primal feasibility.** The uniform ½-weighting is a valid fractional
+    packing. -/
+theorem wHalf_isFracPacking : IsFracPacking wHalf := by
+  refine ⟨fun T _ => by norm_num [wHalf], fun e he => ?_⟩
+  have hsum : (∑ T ∈ triangles, if e ∈ edgesOf T then wHalf T else 0)
+      = (triangles.filter (fun T => e ∈ edgesOf T)).card • (1 / 2 : ℚ) := by
+    rw [← Finset.sum_filter]; simp [wHalf]
+  rw [hsum, nsmul_eq_mul]
+  have hc : ((triangles.filter (fun T => e ∈ edgesOf T)).card : ℚ) ≤ 2 := by
+    exact_mod_cast edge_incidence_le_two e he
+  linarith
+
+/-- The ½-weighting has value 2: ν*(K₄) ≥ 2. -/
+theorem wHalf_value : fracValue wHalf = 2 := by
+  unfold fracValue wHalf
+  rw [Finset.sum_const, triangles_card, nsmul_eq_mul]; norm_num
+
+/-- **Dual feasibility.** The uniform ⅓-edge-weighting is a valid fractional
+    cover: every triangle (3 edges, each weight ⅓) is covered to total 1. -/
+theorem yThird_isFracCover : IsFracCover yThird := by
+  refine ⟨fun e _ => by norm_num [yThird], fun T hT => ?_⟩
+  simp only [yThird]
+  rw [Finset.sum_const, edgesOf_card_three T hT, nsmul_eq_mul]
+  norm_num
+
+/-- The ⅓-cover has value 2: τ*(K₄) ≤ 2. -/
+theorem yThird_value : coverValue yThird = 2 := by
+  unfold coverValue yThird
+  rw [Finset.sum_const, allEdges_card, nsmul_eq_mul]; norm_num
+
+/-! ## The exact LP optima -/
+
+/-- **Exact fractional packing optimum: ν*(K₄) = 2.**
+
+    The lower bound is the explicit ½-weighting (value 2); the matching upper
+    bound is weak duality against the ⅓-edge cover (value 2). So the fractional
+    optimum is *exactly* 2 — sharpening the parent file's one-sided ν* ≥ 2. -/
+theorem frac_optimum :
+    IsGreatest {v : ℚ | ∃ w, IsFracPacking w ∧ fracValue w = v} 2 := by
+  constructor
+  · exact ⟨wHalf, wHalf_isFracPacking, wHalf_value⟩
+  · rintro v ⟨w, hw, rfl⟩
+    have h := weak_duality w yThird hw yThird_isFracCover
+    rwa [yThird_value] at h
+
+/-- **Exact fractional cover optimum: τ*(K₄) = 2.**
+
+    By the symmetric argument: the ⅓-cover achieves 2, and weak duality against
+    the ½-packing (value 2) shows no cover can do better. -/
+theorem cover_optimum :
+    IsLeast {v : ℚ | ∃ y, IsFracCover y ∧ coverValue y = v} 2 := by
+  constructor
+  · exact ⟨yThird, yThird_isFracCover, yThird_value⟩
+  · rintro v ⟨y, hy, rfl⟩
+    have h := weak_duality wHalf y wHalf_isFracPacking hy
+    rwa [wHalf_value] at h
+
+/-- **LP strong duality with no gap: ν*(K₄) = τ*(K₄) = 2.**
+
+    Packaging the two exact optima together: the fractional packing optimum and
+    the fractional cover optimum coincide at 2. Combined with the integer
+    optimum ν(K₄) = 1 (parent `integral_optimum`), the integrality gap of the
+    edge-disjoint triangle packing of K₄ is *exactly* the factor 2. -/
+theorem lp_no_gap :
+    IsGreatest {v : ℚ | ∃ w, IsFracPacking w ∧ fracValue w = v} 2 ∧
+    IsLeast {v : ℚ | ∃ y, IsFracCover y ∧ coverValue y = v} 2 :=
+  ⟨frac_optimum, cover_optimum⟩
+
+#check @weak_duality
+#check @frac_optimum
+#check @cover_optimum
+
+end Erdos1009OQ03OQ01

--- a/src/data/proofs/erdos-1009-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1009-oq-03-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "e1009oq03oq01-model",
+    "proofId": "erdos-1009-oq-03-oq-01",
+    "range": { "startLine": 58, "endLine": 64 },
+    "type": "definition",
+    "title": "Decidable K₄ Model: Triangles and Edges",
+    "content": "The complete graph $K_4$ is modeled concretely on `Fin 4`: `triangles` are the four 3-element vertex subsets (every 3 vertices of a complete graph span a triangle) and `allEdges` are the six 2-element subsets. `edgesOf T` is a triangle's three edges, `T.powersetCard 2`. Keeping the model finite and decidable lets the structural facts (`triangles_card = 4`, `allEdges_card = 6`, each edge in $\\le 2$ triangles) be discharged by kernel-checked `decide`, so no compiler trust (`native_decide`) is needed.",
+    "mathContext": "$K_4$ has $\\binom{4}{3} = 4$ triangles and $\\binom{4}{2} = 6$ edges; each edge lies in exactly $4 - 2 = 2$ triangles.",
+    "significance": "foundational",
+    "relatedConcepts": ["complete graph", "powersetCard", "decidability", "finite combinatorics"],
+    "prerequisites": ["finite sets", "binomial coefficients", "Lean 4 Finset"]
+  },
+  {
+    "id": "e1009oq03oq01-primal",
+    "proofId": "erdos-1009-oq-03-oq-01",
+    "range": { "startLine": 92, "endLine": 99 },
+    "type": "definition",
+    "title": "LP Primal: Fractional Triangle Packing",
+    "content": "`IsFracPacking w` is the linear-programming relaxation of edge-disjoint triangle packing: nonnegative weights on triangles whose total load on each edge is at most 1. Its objective `fracValue w` is the total weight. The integer problem (each triangle in or out, pairwise edge-disjoint) is NP-hard; this fractional version is solvable in polynomial time, and the entry quantifies exactly how far apart the two optima are on $K_4$.",
+    "mathContext": "Maximize $\\sum_T w_T$ subject to $w_T \\ge 0$ and $\\sum_{T \\ni e} w_T \\le 1$ for every edge $e$. The optimum is $\\nu^*(K_4)$.",
+    "significance": "key",
+    "relatedConcepts": ["linear programming", "LP relaxation", "packing", "integrality gap"],
+    "prerequisites": ["linear programming", "combinatorial optimization"]
+  },
+  {
+    "id": "e1009oq03oq01-dual",
+    "proofId": "erdos-1009-oq-03-oq-01",
+    "range": { "startLine": 101, "endLine": 106 },
+    "type": "definition",
+    "title": "LP Dual: Fractional Triangle Cover",
+    "content": "`IsFracCover y` is the dual relaxation: nonnegative weights on edges such that every triangle accumulates total cover weight at least 1, with objective `coverValue y` the total edge weight. This dual object — absent from the parent K₄ integrality-gap file — is exactly what lets weak duality bound the packing optimum from above and pin $\\nu^*(K_4)$ to its exact value.",
+    "mathContext": "Minimize $\\sum_e y_e$ subject to $y_e \\ge 0$ and $\\sum_{e \\in T} y_e \\ge 1$ for every triangle $T$. The optimum is $\\tau^*(K_4)$, the fractional triangle cover number.",
+    "significance": "key",
+    "relatedConcepts": ["LP duality", "covering", "fractional cover", "Tuza's conjecture"],
+    "prerequisites": ["linear programming duality", "covering and packing"]
+  },
+  {
+    "id": "e1009oq03oq01-weakduality",
+    "proofId": "erdos-1009-oq-03-oq-01",
+    "range": { "startLine": 118, "endLine": 160 },
+    "type": "theorem",
+    "title": "Weak LP Duality via Finite Double-Counting",
+    "content": "The structural core: for any feasible fractional packing `w` and any feasible fractional cover `y`, `fracValue w ≤ coverValue y`. The proof is a finite Fubini argument over the triangle/edge incidence. Step 1 absorbs each packed triangle's weight into the cover it must pay for ($w_T = w_T\\cdot 1 \\le w_T \\sum_{e\\in T} y_e$, using the cover constraint and $w_T \\ge 0$), giving a double sum over (triangle, edge) incident pairs. Step 2 swaps the summation order (`Finset.sum_comm`) and applies the packing constraint $\\sum_{T \\ni e} w_T \\le 1$ at each edge. This lemma holds for every packing/cover pair, not just the optimal ones — it is the reusable bridge between the two relaxations.",
+    "mathContext": "$\\sum_T w_T \\le \\sum_T w_T \\sum_{e\\in T} y_e = \\sum_e y_e \\sum_{T \\ni e} w_T \\le \\sum_e y_e$. The middle equality is the order swap; the two inequalities are the dual and primal feasibility constraints.",
+    "significance": "critical",
+    "relatedConcepts": ["weak duality", "Fubini / double counting", "Finset.sum_comm", "LP relaxation"],
+    "prerequisites": ["linear programming duality", "double counting", "finite sums"]
+  },
+  {
+    "id": "e1009oq03oq01-certificates",
+    "proofId": "erdos-1009-oq-03-oq-01",
+    "range": { "startLine": 161, "endLine": 201 },
+    "type": "theorem",
+    "title": "Matching Primal and Dual Certificates",
+    "content": "Two explicit half-integral solutions meet weak duality with equality. The primal `wHalf` puts weight $\\tfrac12$ on every triangle: feasible because each edge is in $\\le 2$ triangles ($2\\cdot\\tfrac12 = 1$), with value $4\\cdot\\tfrac12 = 2$. The dual `yThird` puts weight $\\tfrac13$ on every edge: feasible because each triangle has exactly 3 edges ($3\\cdot\\tfrac13 = 1$), with value $6\\cdot\\tfrac13 = 2$. Both objective values equal 2, so by weak duality both are optimal.",
+    "mathContext": "$\\nu^*(K_4) \\ge \\text{value}(w_{1/2}) = 2$ and $\\tau^*(K_4) \\le \\text{value}(y_{1/3}) = 2$; weak duality forces equality.",
+    "significance": "key",
+    "relatedConcepts": ["complementary slackness", "half-integral solutions", "optimal certificate"],
+    "prerequisites": ["LP feasibility", "rational arithmetic"]
+  },
+  {
+    "id": "e1009oq03oq01-nogap",
+    "proofId": "erdos-1009-oq-03-oq-01",
+    "range": { "startLine": 204, "endLine": 236 },
+    "type": "theorem",
+    "title": "Exact Optima: ν*(K₄) = τ*(K₄) = 2",
+    "content": "`frac_optimum` packages the fractional packing optimum as `IsGreatest … 2` (lower bound `wHalf`, upper bound weak duality against `yThird`); `cover_optimum` packages the cover optimum as `IsLeast … 2` symmetrically; `lp_no_gap` states both together. This upgrades the parent file's one-sided $\\nu^* \\ge 2$ to the exact value, and certifies LP strong duality with no gap between the packing and cover relaxations. Against the integer optimum $\\nu(K_4) = 1$, the integrality gap is now pinned to the exact factor 2 — the textbook obstruction separating the polynomial fractional problem from the NP-hard integer one.",
+    "mathContext": "$\\nu(K_4) = 1 < 2 = \\nu^*(K_4) = \\tau^*(K_4)$. Strong duality $\\nu^* = \\tau^*$ holds; the integer–fractional gap is exactly $2$.",
+    "significance": "critical",
+    "relatedConcepts": ["strong duality", "integrality gap", "IsGreatest", "IsLeast", "NP-hardness"],
+    "prerequisites": ["LP duality", "computational complexity", "order theory (IsGreatest/IsLeast)"]
+  }
+]

--- a/src/data/proofs/erdos-1009-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1009-oq-03-oq-01/meta.json
@@ -1,0 +1,89 @@
+{
+  "id": "erdos-1009-oq-03-oq-01",
+  "title": "Exact Fractional Triangle-Packing Optimum of K₄ via LP Duality",
+  "slug": "erdos-1009-oq-03-oq-01",
+  "description": "Sharpens the K₄ integrality-gap witness for maximum edge-disjoint triangle packing: by formalizing the LP dual (the fractional triangle cover) and weak duality, the fractional optimum is pinned to exactly ν*(K₄) = τ*(K₄) = 2, versus the integer optimum ν(K₄) = 1. The parent file certified only ν* ≥ 2.",
+  "meta": {
+    "author": "Lean Genius Researcher (research-10)",
+    "sourceUrl": "https://erdosproblems.com/1009",
+    "date": "2026-06-28",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1009OQ03OQ01.lean",
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "triangles",
+      "edge-disjoint",
+      "integrality-gap",
+      "linear-programming",
+      "lp-duality",
+      "fractional-cover",
+      "complexity"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 1009,
+    "erdosUrl": "https://erdosproblems.com/1009",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "lineCount": 239,
+    "axiomCount": 0,
+    "assumptions": "Fully machine-checked: 0 sorries, 0 axioms, no native_decide (only kernel-checked `decide` on the finite K₄ model). Depends only on the foundational propext / Classical.choice / Quot.sound. The main objects are the LP primal (fractional packing) and dual (fractional cover) relaxations of edge-disjoint triangle packing on the complete graph K₄.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "Swapping the order of a double finite sum (Fubini), the core step of weak duality",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_ite_mem",
+        "description": "Reduces an indicator-masked sum over a superset to a sum over the intersection",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "mul_le_mul_of_nonneg_left",
+        "description": "Monotonicity of multiplication, used at both the cover and packing constraints",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "Finset.mem_powersetCard",
+        "description": "Membership in the family of fixed-cardinality subsets, used to model edges and triangle edge-sets",
+        "module": "Mathlib.Combinatorics.Enumerative.Powerset"
+      }
+    ],
+    "originalContributions": [
+      "weak_duality: the reusable structural core — for every feasible fractional packing w and every feasible fractional cover y, fracValue w ≤ coverValue y, via finite triangle/edge incidence double-counting (Fubini)",
+      "IsFracCover / coverValue: the LP dual (fractional triangle cover) of the triangle-packing relaxation, absent from the parent file",
+      "frac_optimum: the EXACT fractional packing optimum ν*(K₄) = 2 (IsGreatest), upgrading the parent's one-sided ν* ≥ 2",
+      "cover_optimum: the EXACT fractional cover optimum τ*(K₄) = 2 (IsLeast)",
+      "lp_no_gap: LP strong duality with no relaxation gap, ν*(K₄) = τ*(K₄) = 2, pinning the integrality gap to the exact factor 2 over ν(K₄) = 1",
+      "yThird: the explicit optimal dual certificate (weight ⅓ on every edge)"
+    ],
+    "prerequisites": [
+      "Linear programming duality (primal packing vs dual covering, weak duality)",
+      "Graph theory (triangles and edges of the complete graph K₄)",
+      "Finite double-counting / Fubini for finite sums",
+      "Lean 4 and Mathlib"
+    ],
+    "theoremCount": 11,
+    "definitionCount": 7
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1009-oq-02",
+      "relationship": "sibling",
+      "description": "Same Erdős #1009 family, K₄ side: that entry asks the structural K₄ analog of Györi's edge-disjoint-triangle theorem; this one quantifies the LP relaxation of the triangle-packing problem on the canonical K₄ witness."
+    },
+    {
+      "targetId": "erdos-1009",
+      "relationship": "extends",
+      "description": "The parent problem — edge-disjoint triangles (K₃) beyond the Turán threshold, solved by Györi 1988. This entry studies the computational/LP side: the integrality gap between the polynomial fractional relaxation and the NP-hard integer packing."
+    },
+    {
+      "targetId": "erdos-1009-oq-01",
+      "relationship": "sibling",
+      "description": "The quantitative side of #1009 (the optimal constant in Györi's bound); here we instead separate the integer optimum from its LP relaxation by an exact factor 2 on K₄."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Sharpens the K₄ integrality-gap witness for **maximum edge-disjoint triangle packing** (Erdős #1009, OQ-03). The parent file `Erdos1009OQ03.lean` certified only a one-sided bound ν*(K₄) ≥ 2 > 1 = ν(K₄). This entry formalizes the **LP dual** (the fractional triangle cover) and **weak duality**, pinning the fractional optimum to its *exact* value.

## Results (all verified)

- **`weak_duality`** — for every feasible fractional packing `w` and every feasible fractional cover `y`, `fracValue w ≤ coverValue y`. A finite Fubini double-count over the triangle/edge incidence; the reusable structural core, valid for *any* packing/cover pair.
- **`frac_optimum`** — ν*(K₄) = 2 *exactly* (`IsGreatest`). Lower bound: the uniform ½-weighting; matching upper bound: weak duality against the ⅓-edge cover.
- **`cover_optimum`** — τ*(K₄) = 2 *exactly* (`IsLeast`), symmetric argument.
- **`lp_no_gap`** — ν*(K₄) = τ*(K₄) = 2: LP strong duality with no gap between the packing and cover relaxations.

Against the integer optimum ν(K₄) = 1, the integrality gap of the edge-disjoint triangle packing of K₄ is now pinned to the **exact factor 2** (rather than merely ≥ 2) — the textbook obstruction separating the polynomial fractional problem from the NP-hard integer one.

## Integrity

- **0 sorries, 0 axiom declarations, no `native_decide`** (only kernel-checked `decide` on the finite K₄ model).
- `#print axioms` on `frac_optimum` / `cover_optimum` / `lp_no_gap` → `[propext, Classical.choice, Quot.sound]` only (no `Lean.ofReduceBool`, no `sorryAx`).
- Self-contained: imports only Mathlib; re-states the concrete decidable K₄ model so the file stands alone.
- Verified via `lake env lean` against prebuilt Mathlib oleans (the shared Docker build host was wedged this session by long-running sibling containers; single-file elaboration against the local olean cache confirms it type-checks cleanly).

## Files

- `proofs/Proofs/Erdos1009OQ03OQ01.lean` (new, 239 lines)
- `proofs/Proofs.lean` (register import)
- `src/data/proofs/erdos-1009-oq-03-oq-01/{meta.json,annotations.json}` (gallery entry, 6 annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)