### PR TITLE
research(erdos-1110-oq-01): window characterization [q,2q) — representable ↔ power form [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbundantNumberOQ02OQ01Squarefree.lean
+++ b/proofs/Proofs/AbundantNumberOQ02OQ01Squarefree.lean
@@ -1,0 +1,428 @@
+/-
+  **The smallest SQUAREFREE odd abundant number coprime to 3 — exactly resolved.**
+
+  The companion files settle the general (not-necessarily-squarefree) case for odd
+  abundant numbers coprime to 3:
+  `AbundantNumberOQ02OQ01Unconditional.lean` proves `ω(n) ≥ 7` and
+  `AbundantNumberOQ02OQ01LowerBound.lean` upgrades it to the *radical* magnitude bound
+  `n ≥ 5·7·11·13·17·19·23 = 37182145`.  The true overall minimum, `5391411025 =
+  5²·7·11·13·17·19·23·29`, is larger precisely because it is **not** squarefree: the
+  repeated prime `5²` buys extra abundancy cheaply, letting the witness use only 8 primes.
+
+  This file isolates the **squarefree boundary phenomenon** and resolves it *exactly*.
+  Forbidding repeated prime factors removes the exponent-boosting trick, so the abundancy
+  index of a squarefree `n` coprime to 6 is the strictly smaller product `∏_{p∣n}(p+1)/p`
+  (rather than the Euler envelope `∏ p/(p−1)`).  The eight smallest primes `≥ 5` give
+
+      (6/5)(8/7)(12/11)(14/13)(18/17)(20/19)(24/23)(30/29) = 2090188800/1078282205 ≈ 1.938 < 2,
+
+  so **a squarefree odd abundant number coprime to 3 has at least 9 distinct prime factors**
+  (`squarefree_odd_abundant_coprime_three_nine_primeFactors`) — strictly more than the
+  general bound of 7.  Since for squarefree `n` the radical equals `n`, the magnitude bound
+  is then sharp:
+
+      n squarefree, odd, coprime to 3, abundant  ⟹  n ≥ 5·7·11·13·17·19·23·29·31 = 33426748355,
+
+  and `33426748355` itself *is* squarefree, odd, coprime to 3 and abundant
+  (`σ = 6·8·12·14·18·20·24·30·32 = 66886041600 > 66853496710 = 2n`).  Hence
+
+      IsLeast { n | Squarefree n ∧ Odd n ∧ ¬3∣n ∧ Abundant n } 33426748355
+        (`squarefree_odd_abundant_coprime_three_least`).
+
+  Engine reuse: the abundancy/extremal machinery (`GapList`, `dom`-style domination,
+  `domProd`, the prime-gap facts `gap5 … gap19`) comes verbatim from the companion files.
+  The genuinely new ingredients are the squarefree divisor-sum identity
+  `σ(n) = ∏_{p∣n}(p+1)`, the antitone weight `g p = (p+1)/p` with its own domination
+  lemma `domg`, two further prime gaps (`gap23`, `gap29`), and the witness verification.
+
+  Everything is axiom-free (only `propext`/`Classical.choice`/`Quot.sound`; no
+  `Lean.ofReduceBool`, no `native_decide`, no `sorry`).
+-/
+import Mathlib
+import Proofs.AbundantNumberOQ02OQ01LowerBound
+
+namespace AbundantNumberOQ02OQ01Squarefree
+
+open Nat ArithmeticFunction Finset
+open scoped ArithmeticFunction.sigma
+open AbundantNumberOQ02OQ01Unconditional
+open AbundantNumberOQ02OQ01LowerBound
+
+/-! ### The squarefree divisor-sum identity `σ(n) = ∏_{p∣n}(p+1)` -/
+
+/-- For squarefree `n`, the sum-of-divisors function factors as `σ(n) = ∏_{p∣n}(p+1)`.
+Each prime power in `n` is a single prime (`vₚ(n) = 1`), whose `σ` is `1 + p = p + 1`. -/
+theorem sigma_one_squarefree {n : ℕ} (hsf : Squarefree n) :
+    σ 1 n = ∏ p ∈ n.primeFactors, (p + 1) := by
+  rw [sigma_eq_prod_primeFactors_sum_range_factorization_pow_mul hsf.ne_zero]
+  refine Finset.prod_congr rfl (fun p hp => ?_)
+  have hpp : p.Prime := Nat.prime_of_mem_primeFactors hp
+  have hpd : p ∣ n := Nat.dvd_of_mem_primeFactors hp
+  have hf1 : n.factorization p = 1 := Nat.factorization_eq_one_of_squarefree hsf hpp hpd
+  rw [hf1]
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, mul_one, pow_zero, pow_one, zero_add]
+  ring
+
+/-! ### The antitone abundancy weight `g p = (p+1)/p` -/
+
+/-- The decreasing weight `g p = (p+1)/p` over ℚ (the per-prime factor of `σ(n)/n` for
+squarefree `n`).  It is strictly smaller than the Euler weight `p/(p−1)`. -/
+def g (p : ℕ) : ℚ := ((p : ℚ) + 1) / (p : ℚ)
+
+lemma g_pos {p : ℕ} (hp : 2 ≤ p) : 0 < g p := by
+  have hpc : (2 : ℚ) ≤ (p : ℚ) := by exact_mod_cast hp
+  unfold g
+  exact div_pos (by linarith) (by linarith)
+
+lemma one_le_g {p : ℕ} (hp : 2 ≤ p) : 1 ≤ g p := by
+  have hpc : (2 : ℚ) ≤ (p : ℚ) := by exact_mod_cast hp
+  have hpos : (0 : ℚ) < (p : ℚ) := by linarith
+  unfold g
+  rw [le_div_iff₀ hpos]
+  linarith
+
+/-- `g` is antitone on `{p ≥ 2}`: larger primes give smaller weight `(p+1)/p`. -/
+lemma g_antitone {a b : ℕ} (ha : 2 ≤ a) (hab : a ≤ b) : g b ≤ g a := by
+  have hac : (2 : ℚ) ≤ (a : ℚ) := by exact_mod_cast ha
+  have hbc : (a : ℚ) ≤ (b : ℚ) := by exact_mod_cast hab
+  have hpa : (0 : ℚ) < (a : ℚ) := by linarith
+  have hpb : (0 : ℚ) < (b : ℚ) := by linarith
+  unfold g
+  rw [div_le_div_iff₀ hpb hpa]
+  nlinarith [hbc]
+
+/-- The product of weights `g` over a list of integers all `≥ 2` is `≥ 1`. -/
+lemma one_le_listprod_g : ∀ {C : List ℕ}, (∀ c ∈ C, 2 ≤ c) → 1 ≤ (C.map g).prod
+  | [], _ => by simp
+  | c :: rest, h => by
+      simp only [List.map_cons, List.prod_cons]
+      have h1 : 1 ≤ g c := one_le_g (h c (List.mem_cons_self))
+      have h2 : 1 ≤ (rest.map g).prod := one_le_listprod_g (fun x hx => h x (List.mem_cons_of_mem c hx))
+      nlinarith [h1, h2]
+
+/-- **Domination lemma for the squarefree weight `g`** (mirror of the companion's `dom`).
+If `L` is a strictly increasing list of primes dominating the floors of a gap list `C`, and
+`L` is no longer than `C`, then `∏ g` over `L` is bounded above by `∏ g` over `C`. -/
+lemma domg : ∀ (C L : List ℕ),
+    L.Pairwise (· < ·) →
+    (∀ x ∈ L, x.Prime) →
+    (∀ x ∈ L, ∀ c0 ∈ C.head?, c0 ≤ x) →
+    L.length ≤ C.length →
+    GapList C →
+    (L.map g).prod ≤ (C.map g).prod := by
+  intro C L
+  induction L generalizing C with
+  | nil =>
+      intro _ _ _ _ hG
+      simp only [List.map_nil, List.prod_nil]
+      exact one_le_listprod_g (gapList_all_ge_two hG)
+  | cons a L' ih =>
+      intro hpair hprime hfloor hlen hG
+      cases C with
+      | nil => simp only [List.length_nil, List.length_cons] at hlen; omega
+      | cons c0 C1 =>
+          obtain ⟨hc0, hgap, hG1⟩ := hG
+          have hac0 : c0 ≤ a := hfloor a (List.mem_cons_self) c0 (by simp)
+          have hga : g a ≤ g c0 := g_antitone hc0 hac0
+          have hpc := List.pairwise_cons.mp hpair
+          have hlt : ∀ x ∈ L', a < x := hpc.1
+          have hpair' : L'.Pairwise (· < ·) := hpc.2
+          have hprime' : ∀ x ∈ L', x.Prime := fun x hx => hprime x (List.mem_cons_of_mem a hx)
+          have hfloor' : ∀ x ∈ L', ∀ c1 ∈ C1.head?, c1 ≤ x := by
+            intro x hx c1 hc1
+            have hpx : x.Prime := hprime' x hx
+            have hc0x : c0 < x := lt_of_le_of_lt hac0 (hlt x hx)
+            exact hgap x hpx hc0x c1 hc1
+          have hlen' : L'.length ≤ C1.length := by
+            simp only [List.length_cons] at hlen; omega
+          have hIH : (L'.map g).prod ≤ (C1.map g).prod := ih C1 hpair' hprime' hfloor' hlen' hG1
+          have hnn : 0 ≤ (L'.map g).prod :=
+            le_trans (by norm_num) (one_le_listprod_g (fun x hx => (hprime' x hx).two_le))
+          have hgc0nn : 0 ≤ g c0 := le_of_lt (g_pos hc0)
+          simp only [List.map_cons, List.prod_cons]
+          exact mul_le_mul hga hIH hnn hgc0nn
+
+/-! ### Two further prime gaps and the canonical gap lists -/
+
+/-- No prime lies strictly between `23` and `29`. -/
+lemma gap23 (p : ℕ) (hp : p.Prime) (h : 23 < p) : 29 ≤ p := by
+  rcases Nat.lt_or_ge p 29 with h29 | h29
+  · interval_cases p
+    all_goals exact absurd hp (by decide)
+  · exact h29
+
+/-- No prime lies strictly between `29` and `31`. -/
+lemma gap29 (p : ℕ) (hp : p.Prime) (h : 29 < p) : 31 ≤ p := by
+  rcases Nat.lt_or_ge p 31 with h31 | h31
+  · interval_cases p
+    all_goals exact absurd hp (by decide)
+  · exact h31
+
+/-- The eight smallest primes `≥ 5` form a gap list. -/
+lemma gapList8 : GapList [5, 7, 11, 13, 17, 19, 23, 29] := by
+  refine ⟨by norm_num, ?_, by norm_num, ?_, by norm_num, ?_, by norm_num, ?_, by norm_num, ?_,
+          by norm_num, ?_, by norm_num, ?_, by norm_num, ?_, trivial⟩
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap5 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap7 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap11 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap13 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap17 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap19 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap23 p hp h
+  · intro p hp h c1 hc1; simp at hc1
+
+/-- The nine smallest primes `≥ 5` form a gap list. -/
+lemma gapList9 : GapList [5, 7, 11, 13, 17, 19, 23, 29, 31] := by
+  refine ⟨by norm_num, ?_, by norm_num, ?_, by norm_num, ?_, by norm_num, ?_, by norm_num, ?_,
+          by norm_num, ?_, by norm_num, ?_, by norm_num, ?_, by norm_num, ?_, trivial⟩
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap5 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap7 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap11 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap13 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap17 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap19 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap23 p hp h
+  · intro p hp h c1 hc1; simp only [List.head?_cons, Option.mem_some_iff] at hc1; subst hc1; exact gap29 p hp h
+  · intro p hp h c1 hc1; simp at hc1
+
+/-- The canonical squarefree-abundancy product over the eight smallest primes `≥ 5`:
+`(6/5)(8/7)(12/11)(14/13)(18/17)(20/19)(24/23)(30/29) = 2090188800/1078282205 < 2`. -/
+lemma canon8_g_prod_lt_two :
+    (([5, 7, 11, 13, 17, 19, 23, 29] : List ℕ).map g).prod < 2 := by
+  simp only [List.map_cons, List.map_nil, List.prod_cons, List.prod_nil, g]
+  norm_num
+
+/-- The product of the nine smallest primes `≥ 5` is `33426748355`. -/
+lemma canon9_prod : ([5, 7, 11, 13, 17, 19, 23, 29, 31] : List ℕ).prod = 33426748355 := by
+  decide
+
+/-! ### Lower bound on the number of prime factors (the sharp count) -/
+
+/-- **Main lower bound on `ω`.**  Every *squarefree* odd abundant number coprime to 3 has
+at least **9** distinct prime factors — strictly more than the general bound of 7.  The
+extra two come from squarefreeness: with no repeated primes the abundancy index is the
+smaller product `∏ (p+1)/p`, and the eight smallest primes `≥ 5` already fall short of 2. -/
+theorem squarefree_odd_abundant_coprime_three_nine_primeFactors
+    {n : ℕ} (hsf : Squarefree n) (hodd : Odd n) (h3 : ¬ (3 ∣ n))
+    (habund : Nat.Abundant n) :
+    9 ≤ n.primeFactors.card := by
+  by_contra hlt
+  push_neg at hlt
+  have hcard8 : n.primeFactors.card ≤ 8 := by omega
+  set S := n.primeFactors with hS
+  -- every prime factor is ≥ 5 (odd ⟹ ≠ 2; coprime to 3 ⟹ ≠ 3)
+  have hge5 : ∀ p ∈ S, 5 ≤ p := by
+    intro p hp
+    have hpp : p.Prime := Nat.prime_of_mem_primeFactors hp
+    have hpn : p ∣ n := Nat.dvd_of_mem_primeFactors hp
+    have h2 : p ≠ 2 := by
+      rintro rfl
+      obtain ⟨k, hk⟩ := hodd
+      obtain ⟨m, hm⟩ := hpn
+      omega
+    have h3' : p ≠ 3 := by rintro rfl; exact h3 hpn
+    have hp2 := hpp.two_le
+    rcases Nat.lt_or_ge p 5 with h5 | h5
+    · interval_cases p
+      · exact absurd rfl h2
+      · exact absurd rfl h3'
+      · exact absurd hpp (by decide)
+    · exact h5
+  -- squarefree abundancy: `2 · ∏ p < ∏ (p+1)` over ℕ
+  have hσeq : σ 1 n = ∏ p ∈ S, (p + 1) := sigma_one_squarefree hsf
+  have hpe : ∏ p ∈ S, p = n := prod_primeFactors_of_squarefree hsf
+  have h2lt : 2 * n < σ 1 n := by
+    have : Nat.Abundant n ↔ 2 * n < σ 1 n := by
+      rw [Nat.Abundant, sigma_one_apply, Nat.sum_divisors_eq_sum_properDivisors_add_self]
+      omega
+    exact this.mp habund
+  have hNN : 2 * ∏ p ∈ S, p < ∏ p ∈ S, (p + 1) := by
+    rw [hpe, ← hσeq]; exact h2lt
+  -- cast to ℚ and assemble the abundancy index `∏ g`
+  have hDpos : 0 < ∏ p ∈ S, (p : ℚ) := by
+    apply Finset.prod_pos
+    intro p hp
+    have : (5 : ℚ) ≤ (p : ℚ) := by exact_mod_cast hge5 p hp
+    linarith
+  have hg_eq : (∏ p ∈ S, g p) = (∏ p ∈ S, ((p : ℚ) + 1)) / (∏ p ∈ S, (p : ℚ)) := by
+    simp only [g]; rw [Finset.prod_div_distrib]
+  have hcastNum : ((∏ p ∈ S, (p + 1) : ℕ) : ℚ) = ∏ p ∈ S, ((p : ℚ) + 1) := by
+    rw [Nat.cast_prod]; refine Finset.prod_congr rfl (fun p _ => ?_); push_cast; ring
+  have hcastDen : ((∏ p ∈ S, p : ℕ) : ℚ) = ∏ p ∈ S, (p : ℚ) := by rw [Nat.cast_prod]
+  have hQ : 2 * (∏ p ∈ S, (p : ℚ)) < ∏ p ∈ S, ((p : ℚ) + 1) := by
+    have hc : ((2 * ∏ p ∈ S, p : ℕ) : ℚ) < ((∏ p ∈ S, (p + 1) : ℕ) : ℚ) := by exact_mod_cast hNN
+    rwa [Nat.cast_mul, Nat.cast_ofNat, hcastDen, hcastNum] at hc
+  have key : 2 * (∏ p ∈ S, (p : ℚ)) < (∏ p ∈ S, g p) * (∏ p ∈ S, (p : ℚ)) := by
+    have heq : (∏ p ∈ S, g p) * (∏ p ∈ S, (p : ℚ)) = ∏ p ∈ S, ((p : ℚ) + 1) := by
+      rw [hg_eq, div_mul_cancel₀]; exact ne_of_gt hDpos
+    rw [heq]; exact hQ
+  have hgt : 2 < ∏ p ∈ S, g p := lt_of_mul_lt_mul_right key (le_of_lt hDpos)
+  -- extremal upper bound via `domg`: `∏ g ≤ canon8 < 2`, contradiction
+  have hprodF : ((S.sort (· ≤ ·)).map g).prod = ∏ p ∈ S, g p := by
+    rw [← Finset.prod_map_toList S g]
+    exact List.Perm.prod_eq ((Finset.sort_perm_toList S (· ≤ ·)).map g)
+  have hLpair : (S.sort (· ≤ ·)).Pairwise (· < ·) := by
+    have hsorted : List.Pairwise (· ≤ ·) (S.sort (· ≤ ·)) := Finset.pairwise_sort S (· ≤ ·)
+    have hnodup : (S.sort (· ≤ ·)).Nodup := Finset.sort_nodup S (· ≤ ·)
+    exact (hsorted.and hnodup).imp (fun h => lt_of_le_of_ne h.1 h.2)
+  have hLprime : ∀ x ∈ S.sort (· ≤ ·), x.Prime := by
+    intro x hx
+    rw [Finset.mem_sort] at hx
+    exact Nat.prime_of_mem_primeFactors (hS ▸ hx)
+  have hLfloor : ∀ x ∈ S.sort (· ≤ ·),
+      ∀ c0 ∈ ([5, 7, 11, 13, 17, 19, 23, 29] : List ℕ).head?, c0 ≤ x := by
+    intro x hx c0 hc0
+    simp only [List.head?_cons, Option.mem_some_iff] at hc0
+    subst hc0
+    rw [Finset.mem_sort] at hx
+    exact hge5 x hx
+  have hLlen : (S.sort (· ≤ ·)).length ≤ ([5, 7, 11, 13, 17, 19, 23, 29] : List ℕ).length := by
+    rw [Finset.length_sort]; simpa using hcard8
+  have hdomprod :
+      ((S.sort (· ≤ ·)).map g).prod ≤ (([5, 7, 11, 13, 17, 19, 23, 29] : List ℕ).map g).prod :=
+    domg [5, 7, 11, 13, 17, 19, 23, 29] (S.sort (· ≤ ·)) hLpair hLprime hLfloor hLlen gapList8
+  have hprodlt : (∏ p ∈ S, g p) < 2 := by
+    rw [← hprodF]; exact lt_of_le_of_lt hdomprod canon8_g_prod_lt_two
+  linarith [hprodlt, hgt]
+
+/-! ### Sharp magnitude lower bound (radical = n for squarefree) -/
+
+/-- **Sharp magnitude lower bound.**  Every squarefree odd abundant number coprime to 3 is
+at least `5·7·11·13·17·19·23·29·31 = 33426748355`.  For squarefree `n` the radical equals
+`n`, so the `≥ 9`-prime-factors bound translates directly into this magnitude bound — and it
+is *attained* (see `squarefree_odd_abundant_coprime_three_least`). -/
+theorem squarefree_odd_abundant_coprime_three_ge
+    {n : ℕ} (hsf : Squarefree n) (hodd : Odd n) (h3 : ¬ (3 ∣ n))
+    (habund : Nat.Abundant n) :
+    33426748355 ≤ n := by
+  have h9 := squarefree_odd_abundant_coprime_three_nine_primeFactors hsf hodd h3 habund
+  set S := n.primeFactors with hS
+  have hge5 : ∀ p ∈ S, 5 ≤ p := by
+    intro p hp
+    have hpp : p.Prime := Nat.prime_of_mem_primeFactors hp
+    have hpn : p ∣ n := Nat.dvd_of_mem_primeFactors hp
+    have h2 : p ≠ 2 := by
+      rintro rfl
+      obtain ⟨k, hk⟩ := hodd
+      obtain ⟨m, hm⟩ := hpn
+      omega
+    have h3' : p ≠ 3 := by rintro rfl; exact h3 hpn
+    have hp2 := hpp.two_le
+    rcases Nat.lt_or_ge p 5 with h5 | h5
+    · interval_cases p
+      · exact absurd rfl h2
+      · exact absurd rfl h3'
+      · exact absurd hpp (by decide)
+    · exact h5
+  have hLpair : (S.sort (· ≤ ·)).Pairwise (· < ·) := by
+    have hsorted : List.Pairwise (· ≤ ·) (S.sort (· ≤ ·)) := Finset.pairwise_sort S (· ≤ ·)
+    have hnodup : (S.sort (· ≤ ·)).Nodup := Finset.sort_nodup S (· ≤ ·)
+    exact (hsorted.and hnodup).imp (fun h => lt_of_le_of_ne h.1 h.2)
+  have hLprime : ∀ x ∈ S.sort (· ≤ ·), x.Prime := by
+    intro x hx
+    rw [Finset.mem_sort] at hx
+    exact Nat.prime_of_mem_primeFactors (hS ▸ hx)
+  have hLfloor : ∀ x ∈ S.sort (· ≤ ·),
+      ∀ c0 ∈ ([5, 7, 11, 13, 17, 19, 23, 29, 31] : List ℕ).head?, c0 ≤ x := by
+    intro x hx c0 hc0
+    simp only [List.head?_cons, Option.mem_some_iff] at hc0
+    subst hc0
+    rw [Finset.mem_sort] at hx
+    exact hge5 x hx
+  have hLlen :
+      ([5, 7, 11, 13, 17, 19, 23, 29, 31] : List ℕ).length ≤ (S.sort (· ≤ ·)).length := by
+    rw [Finset.length_sort]; simpa using h9
+  have hdom :
+      ([5, 7, 11, 13, 17, 19, 23, 29, 31] : List ℕ).prod ≤ (S.sort (· ≤ ·)).prod :=
+    domProd [5, 7, 11, 13, 17, 19, 23, 29, 31] (S.sort (· ≤ ·)) hLpair hLprime hLfloor hLlen gapList9
+  rw [canon9_prod] at hdom
+  have hprodList : (S.sort (· ≤ ·)).prod = ∏ p ∈ S, p := by
+    have h1 : (S.sort (· ≤ ·)).prod = S.toList.prod :=
+      List.Perm.prod_eq (Finset.sort_perm_toList S (· ≤ ·))
+    have h2 : S.toList.prod = ∏ p ∈ S, p := by
+      simpa using Finset.prod_map_toList S (fun p => p)
+    rw [h1]; exact h2
+  rw [hprodList] at hdom
+  have hpe : ∏ p ∈ S, p = n := prod_primeFactors_of_squarefree hsf
+  rw [hpe] at hdom
+  exact hdom
+
+/-! ### The witness `33426748355 = 5·7·11·13·17·19·23·29·31` -/
+
+/-- The witness number `W = 5·7·11·13·17·19·23·29·31`. -/
+abbrev W : ℕ := 33426748355
+
+/-- `σ₁` of the nine small primes, by direct reduction of each divisor sum. -/
+theorem sigma_5  : σ 1 5  = 6  := by rw [sigma_one_apply]; decide
+theorem sigma_7  : σ 1 7  = 8  := by rw [sigma_one_apply]; decide
+theorem sigma_11 : σ 1 11 = 12 := by rw [sigma_one_apply]; decide
+theorem sigma_13 : σ 1 13 = 14 := by rw [sigma_one_apply]; decide
+theorem sigma_17 : σ 1 17 = 18 := by rw [sigma_one_apply]; decide
+theorem sigma_19 : σ 1 19 = 20 := by rw [sigma_one_apply]; decide
+theorem sigma_23 : σ 1 23 = 24 := by rw [sigma_one_apply]; decide
+theorem sigma_29 : σ 1 29 = 30 := by rw [sigma_one_apply]; decide
+theorem sigma_31 : σ 1 31 = 32 := by rw [sigma_one_apply]; decide
+
+/-- **The divisor sum of the witness.**  `σ(33426748355) = 66886041600`, computed from
+the prime factorisation via multiplicativity of `σ` (no `native_decide`). -/
+theorem sigma_W : σ 1 W = 66886041600 := by
+  have e : (W : ℕ) = 5 * (7 * (11 * (13 * (17 * (19 * (23 * (29 * 31))))))) := by norm_num
+  rw [e,
+    isMultiplicative_sigma.map_mul_of_coprime (by norm_num),
+    isMultiplicative_sigma.map_mul_of_coprime (by norm_num),
+    isMultiplicative_sigma.map_mul_of_coprime (by norm_num),
+    isMultiplicative_sigma.map_mul_of_coprime (by norm_num),
+    isMultiplicative_sigma.map_mul_of_coprime (by norm_num),
+    isMultiplicative_sigma.map_mul_of_coprime (by norm_num),
+    isMultiplicative_sigma.map_mul_of_coprime (by norm_num),
+    isMultiplicative_sigma.map_mul_of_coprime (by norm_num),
+    sigma_5, sigma_7, sigma_11, sigma_13, sigma_17, sigma_19, sigma_23, sigma_29, sigma_31]
+  norm_num
+
+/-- **`33426748355` is squarefree** (a product of distinct primes). -/
+theorem squarefree_W : Squarefree W := by
+  have e : (W : ℕ) = 5 * (7 * (11 * (13 * (17 * (19 * (23 * (29 * 31))))))) := by norm_num
+  rw [e]
+  have sp : ∀ p : ℕ, p.Prime → Squarefree p := fun p hp => hp.prime.squarefree
+  refine (Nat.squarefree_mul (by norm_num)).mpr ⟨sp 5 (by norm_num), ?_⟩
+  refine (Nat.squarefree_mul (by norm_num)).mpr ⟨sp 7 (by norm_num), ?_⟩
+  refine (Nat.squarefree_mul (by norm_num)).mpr ⟨sp 11 (by norm_num), ?_⟩
+  refine (Nat.squarefree_mul (by norm_num)).mpr ⟨sp 13 (by norm_num), ?_⟩
+  refine (Nat.squarefree_mul (by norm_num)).mpr ⟨sp 17 (by norm_num), ?_⟩
+  refine (Nat.squarefree_mul (by norm_num)).mpr ⟨sp 19 (by norm_num), ?_⟩
+  refine (Nat.squarefree_mul (by norm_num)).mpr ⟨sp 23 (by norm_num), ?_⟩
+  exact (Nat.squarefree_mul (by norm_num)).mpr ⟨sp 29 (by norm_num), sp 31 (by norm_num)⟩
+
+/-- **`33426748355` is odd.** -/
+theorem odd_W : Odd W := by decide
+
+/-- **`33426748355` is not divisible by 3.** -/
+theorem not_three_dvd_W : ¬ (3 ∣ W) := by decide
+
+/-- **`33426748355` is abundant.**  `σ(W) = 66886041600 > 66853496710 = 2W`. -/
+theorem abundant_W : Nat.Abundant W := by
+  have hiff : Nat.Abundant W ↔ 2 * W < σ 1 W := by
+    rw [Nat.Abundant, sigma_one_apply, Nat.sum_divisors_eq_sum_properDivisors_add_self]
+    omega
+  rw [hiff, sigma_W]
+  norm_num
+
+/-! ### The exact minimum -/
+
+/-- **The smallest squarefree odd abundant number coprime to 3 is exactly `33426748355`.**
+Combining the sharp lower bound with the witness gives the least element of the set of
+squarefree odd abundant numbers coprime to 3 — the squarefree analogue of the (still open)
+unrestricted minimum `5391411025`. -/
+theorem squarefree_odd_abundant_coprime_three_least :
+    IsLeast {n : ℕ | Squarefree n ∧ Odd n ∧ ¬ (3 ∣ n) ∧ Nat.Abundant n} 33426748355 := by
+  constructor
+  · exact ⟨squarefree_W, odd_W, not_three_dvd_W, abundant_W⟩
+  · rintro m ⟨hsf, hodd, h3, hab⟩
+    exact squarefree_odd_abundant_coprime_three_ge hsf hodd h3 hab
+
+-- Axiom audit: only the foundational axioms (`propext`, `Classical.choice`, `Quot.sound`);
+-- in particular NO `Lean.ofReduceBool` (no `native_decide`) and NO `sorryAx`.
+#print axioms squarefree_odd_abundant_coprime_three_nine_primeFactors
+#print axioms squarefree_odd_abundant_coprime_three_least
+
+end AbundantNumberOQ02OQ01Squarefree

--- a/proofs/Proofs/Erdos1110Problem.lean
+++ b/proofs/Proofs/Erdos1110Problem.lean
@@ -484,6 +484,120 @@ theorem exists_positive_nonRepresentable_of_ne_two_three
     exact ⟨2, by norm_num, two_nonRepresentable_of_three_le (by omega) hq3⟩
 
 /-
+## Part IId: Window Characterization (unconditional, 0-axiom)
+
+The two ad-hoc witnesses above (`2` when `q ≥ 3`, `3` when `q = 2`) are special
+cases of a single structural fact: because the unit power form `1 = p^0 q^0`
+divides *every* other power form, it can never sit in a representing antichain
+alongside another summand. Hence for `n ≥ 2` **every summand is `≥ q`** (the
+smallest power form exceeding `1`). Two or more such summands already sum past
+`2q`, so on the window `[q, 2q)` a representation can only be the singleton `{n}`
+— i.e. `n` is representable iff it is itself a power form. This *characterises*
+representability on the whole window (not just exhibits one witness) and
+uniformly recovers both special cases above.
+-/
+
+/-- The smallest power form exceeding `1` is `q`: any `p^k q^l ≥ 2` (necessarily
+with a positive exponent, given `p > q ≥ 2`) is at least `q`. -/
+lemma isPowerForm_ge_q_of_ge_two {p q n : ℕ} (hp : p > q) (hq : q ≥ 2)
+    (h : IsPowerForm p q n) (hn : 2 ≤ n) : q ≤ n := by
+  obtain ⟨k, l, rfl⟩ := h
+  rcases Nat.eq_zero_or_pos k with hk | hk
+  · subst hk
+    simp only [pow_zero, one_mul] at hn ⊢
+    rcases Nat.eq_zero_or_pos l with hl | hl
+    · subst hl; simp only [pow_zero] at hn; omega
+    · calc q = q ^ 1 := (pow_one q).symm
+        _ ≤ q ^ l := Nat.pow_le_pow_right (by omega) hl
+  · have hpk : p ≤ p ^ k := Nat.le_self_pow (by omega) p
+    have hql : 1 ≤ q ^ l := Nat.one_le_pow _ _ (by omega)
+    calc q ≤ p := by omega
+      _ ≤ p ^ k := hpk
+      _ ≤ p ^ k * q ^ l := Nat.le_mul_of_pos_right (p ^ k) hql
+
+/-- **Every summand of a representation of `n ≥ 2` is at least `q`.** The unit
+power form `1` cannot appear alongside any other summand (it divides everything,
+breaking the antichain) nor on its own (it would sum to `1 < 2 ≤ n`); so every
+summand is `≥ 2`, hence `≥ q` by `isPowerForm_ge_q_of_ge_two`. -/
+lemma representable_summands_ge_q {p q n : ℕ} (hp : p > q) (hq : q ≥ 2)
+    (hn : 2 ≤ n) {S : Finset ℕ}
+    (hpf : ∀ s ∈ S, IsPowerForm p q s)
+    (hac : NoOneDividesAnother S) (hsum : S.sum id = n) :
+    ∀ s ∈ S, q ≤ s := by
+  have hpos : ∀ s ∈ S, 1 ≤ s := by
+    intro s hs
+    obtain ⟨k, l, rfl⟩ := hpf s hs
+    have : 0 < p ^ k * q ^ l := mul_pos (pow_pos (by omega) k) (pow_pos (by omega) l)
+    omega
+  -- `1 ∉ S`: it would divide a distinct second element, or be the lone summand.
+  have h1 : (1 : ℕ) ∉ S := by
+    intro h1mem
+    by_cases hcard : S = {1}
+    · rw [hcard] at hsum; simp at hsum; omega
+    · obtain ⟨b, hbmem, hbne⟩ : ∃ b ∈ S, b ≠ 1 := by
+        by_contra hcon
+        push_neg at hcon
+        exact hcard (Finset.eq_singleton_iff_unique_mem.mpr ⟨h1mem, hcon⟩)
+      exact hac 1 h1mem b hbmem (Ne.symm hbne) (one_dvd b)
+  intro s hs
+  have hsne1 : s ≠ 1 := by rintro rfl; exact h1 hs
+  have h1le := hpos s hs
+  have hs2 : 2 ≤ s := by omega
+  exact isPowerForm_ge_q_of_ge_two hp hq (hpf s hs) hs2
+
+/-- **Representability window characterization (unconditional, 0-axiom).**
+For `q ≤ n < 2q`, the number `n` is representable iff it is itself a single power
+form `p^k q^l`. Forward: every summand is `≥ q` (`representable_summands_ge_q`),
+so two or more summands already exceed `2q > n`; the representation must be the
+singleton `{n}`, forcing `n` to be a power form. Backward: a power form `n` is
+represented by `{n}`. -/
+theorem isRepresentable_iff_isPowerForm_window {p q n : ℕ} (hp : p > q) (hq : q ≥ 2)
+    (hlo : q ≤ n) (hhi : n < 2 * q) :
+    IsRepresentable p q n ↔ IsPowerForm p q n := by
+  constructor
+  · rintro ⟨S, hne, hpf, hac, hsum⟩
+    have hn2 : 2 ≤ n := by omega
+    have hge : ∀ s ∈ S, q ≤ s := representable_summands_ge_q hp hq hn2 hpf hac hsum
+    have hcard1 : S.card = 1 := by
+      rcases Nat.lt_or_ge S.card 2 with hc | hc
+      · have : 1 ≤ S.card := Finset.card_pos.mpr hne
+        omega
+      · exfalso
+        obtain ⟨a, b, ha, hb, hab⟩ := Finset.one_lt_card_iff.mp hc
+        have hsub : ({a, b} : Finset ℕ) ⊆ S := by
+          intro x hx; simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+          rcases hx with rfl | rfl <;> assumption
+        have hpair : ({a, b} : Finset ℕ).sum id ≤ S.sum id :=
+          Finset.sum_le_sum_of_subset hsub
+        rw [Finset.sum_pair hab, hsum] at hpair
+        simp only [id_eq] at hpair
+        have hqa := hge a ha
+        have hqb := hge b hb
+        omega
+    obtain ⟨x, rfl⟩ := Finset.card_eq_one.mp hcard1
+    rw [Finset.sum_singleton, id_eq] at hsum
+    rw [← hsum]
+    exact hpf x (Finset.mem_singleton_self x)
+  · intro h
+    exact ⟨{n}, Finset.singleton_nonempty n, by simpa using h,
+      by intro a ha b hb hab; simp only [Finset.mem_singleton] at ha hb
+         exact absurd (ha.trans hb.symm) hab,
+      by simp⟩
+
+/-- **Non-power-forms in the window `[q, 2q)` are non-representable
+(unconditional, 0-axiom).** Contrapositive of the window characterization. This
+furnishes, for *every* pair `p > q ≥ 2`, an explicit family of non-representable
+numbers (each non-power-form strictly between `q` and `2q`), uniformly subsuming
+the ad-hoc witnesses `two_nonRepresentable_of_three_le` (take `n = 2`, `q ≥ 3`)
+and `three_nonRepresentable_of_q_two` (take `n = 3`, `q = 2`). -/
+theorem nonRepresentable_of_window {p q n : ℕ} (hp : p > q) (hq : q ≥ 2)
+    (hlo : q ≤ n) (hhi : n < 2 * q) (hnp : ¬ IsPowerForm p q n) :
+    n ∈ NonRepresentable p q := by
+  rw [NonRepresentable, Set.mem_setOf_eq,
+    isRepresentable_iff_isPowerForm_window hp hq hlo hhi]
+  exact hnp
+
+/-
 ## Part III: General Case (p,q) ≠ (2,3)
 -/
 

--- a/research/problems/abundant-number-oq-02-oq-01/knowledge.md
+++ b/research/problems/abundant-number-oq-02-oq-01/knowledge.md
@@ -153,3 +153,55 @@ harder, still open).
 - Push beyond the radical: incorporate exponents / the ≥8th-prime obligation to raise the
   bound toward `5391411025`. Likely needs a per-prime-power refinement of the Euler bound
   combined with the size constraint, not just the prime set.
+
+## Session 2026-06-28 (researcher-7) — SQUAREFREE case resolved EXACTLY (ω≥9, least = 33426748355)
+
+**Mode**: REVISIT (RICH; radical bound `n ≥ 37182145` already closed) · **Outcome**: progress
+(squarefree subproblem fully resolved). New file
+`Proofs/AbundantNumberOQ02OQ01Squarefree.lean` (≈428 LOC, 0 sorries, 0 axioms).
+Verified standalone via host `lake env lean` (Docker host down): built the dep olean
+`LowerBound` (then `Minimality`/`Unconditional` already present) into
+`.lake/build/lib/lean/Proofs/`, compiled the file — `#print axioms` on both headline
+theorems = `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`,
+no `native_decide`). Not registered in `Proofs.lean` (sibling-chain convention).
+
+### What I did
+Isolated and *exactly* resolved the **squarefree boundary** of the problem:
+- `squarefree_odd_abundant_coprime_three_nine_primeFactors` :
+  `Squarefree n → Odd n → ¬3∣n → Abundant n → 9 ≤ ω(n)` — strictly more than the general
+  `≥ 7`, because squarefreeness forbids the exponent-boost.
+- `squarefree_odd_abundant_coprime_three_ge` : `… → 33426748355 ≤ n` (sharp: for squarefree
+  `n` the radical equals `n`, so `domProd` over the 9 smallest primes ≥5 is exact).
+- `squarefree_odd_abundant_coprime_three_least` :
+  `IsLeast {Squarefree ∧ Odd ∧ ¬3∣ ∧ Abundant} 33426748355` — the witness
+  `W = 5·7·11·13·17·19·23·29·31` proved squarefree/odd/¬3∣/abundant.
+
+### Key technique (what worked)
+- **Squarefree σ identity** `σ(n) = ∏_{p∣n}(p+1)`: specialize the Mathlib decomposition
+  `sigma_eq_prod_primeFactors_sum_range_factorization_pow_mul` with
+  `Nat.factorization_eq_one_of_squarefree` (vₚ(n)=1), so each `∑_{i<2} pⁱ = 1+p`.
+- **New antitone weight** `g p = (p+1)/p` (strictly below the Euler weight `p/(p−1)`),
+  with its own `domg` (verbatim mirror of the companion `dom`, antitone product bounded
+  above by the canonical gap list). The 8-smallest product `(6/5)…(30/29) ≈ 1.938 < 2` is
+  the boundary; it's `< 2` where the Euler envelope `∏ p/(p−1)` for 8 primes is `> 2`,
+  so the squarefree-specific tightness is what buys the extra two prime factors.
+- Reused **verbatim** from the merged chain: `GapList`, `gapList_all_ge_two`, `gap5..gap19`,
+  `domProd`, the prime-factor-≥5 argument. Added only `gap23`, `gap29`, `gapList8/9`.
+- Witness abundancy `σ(W)=66886041600 > 66853496710 = 2W` via `isMultiplicative_sigma`
+  (no `native_decide`); squarefree-of-`W` via iterated `Nat.squarefree_mul` + `Prime.squarefree`.
+
+### Why this is the natural milestone
+The unrestricted minimum `5391411025 = 5²·7·11·13·17·19·23·29` is *non-squarefree*; the `5²`
+buys abundancy with only 8 primes. The squarefree analogue is forced up to 9 primes and a
+larger value `33426748355`. This pins down exactly how much the non-squarefree structure
+contributes, and it is *complete* (both directions), unlike the still-open general minimum.
+
+### Files modified
+- proofs/Proofs/AbundantNumberOQ02OQ01Squarefree.lean (new)
+- research/problems/abundant-number-oq-02-oq-01/knowledge.md (this entry)
+- src/data/research/problems/abundant-number-oq-02-oq-01.json (leanFiles + knowledge)
+
+### Next steps
+- Squarefree case CLOSED exactly. General non-squarefree exact minimality toward 5391411025
+  remains open: needs a per-prime-power refinement of the Euler bound bounding exponents,
+  combined with the size constraint — not reachable from the prime set alone.

--- a/research/problems/erdos-1110-oq-01/state.md
+++ b/research/problems/erdos-1110-oq-01/state.md
@@ -1,9 +1,33 @@
 # Current State
 
-**Phase**: ACT — {2,3} case fully solved + density-zero + coprime-empty proved; 1 deep axiom remains
+**Phase**: ACT — {2,3} case fully solved + density-zero + coprime-empty + window characterization; 1 deep axiom remains
 **Since**: 2026-05-29T19:14:09.134Z
-**Iteration**: 4
-**Last Updated**: 2026-06-28 (researcher-3, S5 ACT)
+**Iteration**: 5
+**Last Updated**: 2026-06-28 (researcher-7, S6 ACT)
+
+## S6 ACT (researcher-7, 2026-06-28) — window characterization `[q,2q)`, 0-axiom
+
+Captured the structural insight behind both existing ad-hoc non-representable
+witnesses and turned existence into a *characterization*, unconditionally (0-axiom):
+- `isPowerForm_ge_q_of_ge_two` : any power form `p^k q^l ≥ 2` is `≥ q` (smallest
+  power form exceeding the unit `1`).
+- `representable_summands_ge_q` : **every summand of a representation of `n ≥ 2` is
+  `≥ q`**. The unit power form `1 = p^0 q^0` divides every other power form, so it
+  can sit neither alongside another summand (antichain broken) nor alone (sums to
+  `1 < 2 ≤ n`); hence all summands are `≥ 2`, thus `≥ q`. This is the reusable
+  structural lemma the file previously lacked.
+- `isRepresentable_iff_isPowerForm_window` : for `q ≤ n < 2q`,
+  `IsRepresentable p q n ↔ IsPowerForm p q n`. Two summands already exceed `2q > n`,
+  so any representation is the singleton `{n}`.
+- `nonRepresentable_of_window` : every non-power-form in `[q, 2q)` is
+  non-representable — an explicit family for *every* pair `p > q ≥ 2`, uniformly
+  subsuming `two_nonRepresentable_of_three_le` (`n=2, q≥3`) and
+  `three_nonRepresentable_of_q_two` (`n=3, q=2`).
+
+Host-verified (`lean` + LEAN_PATH, EXIT 0, ~41s); `#print axioms` on all three new
+public results = `[propext, Classical.choice, Quot.sound]` only (independent of
+`erdos_lewin_infinite`). The deep axiom `erdos_lewin_infinite` (Erdős–Lewin 1996
+infinitude, not in Mathlib) is UNCHANGED — file axiom count remains 1.
 
 ## S5 ACT (researcher-3, 2026-06-28) — Yu-Chen coprime {2,3} = ∅, 0-axiom
 

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -55,6 +55,7 @@
       "exists_positive_nonRepresentable_of_ne_two_three theorem (0-axiom): unconditional EXISTENCE shadow of the deep infinitude axiom — every coprime pair {p,q}≠{2,3} admits a positive non-representable number (universal witness 2 when q≥3, 3 when q=2), via two_nonRepresentable_of_three_le / three_nonRepresentable_of_q_two and the power-form bounds isPowerForm_eq_one_of_le_two / isPowerForm_le_two_or_eq",
       "Yu-Chen density-zero {2,3} instance proved unconditionally (0-axiom): hasDensity_singleton_zero ⟹ nonRepresentable_two_three_density_zero / nonRepresentable_three_two_density_zero",
       "Yu-Chen COPRIME non-representables, {2,3} case proved unconditionally (0-axiom): coprimeNonRepresentable_two_three_eq_empty / _three_two_eq_empty — the coprime non-representable set is EMPTY for {2,3} (the only non-representable is 0, which is not coprime to 2·3=6), sharpening Yu-Chen's '{2,3}-excluded' infinitude to 'zero coprime non-representables'; hasDensity_empty gives the corresponding density-zero corollaries and supplies the first content to the previously-unused CoprimeNonRepresentable definition",
+      "Window characterization proved unconditionally (0-axiom): the structural lemma representable_summands_ge_q shows every summand of a representation of n≥2 is ≥q (the unit power form 1 divides everything, so it can sit neither alongside another summand nor alone). This yields isRepresentable_iff_isPowerForm_window — for q ≤ n < 2q, IsRepresentable p q n ↔ IsPowerForm p q n — and the corollary nonRepresentable_of_window, an explicit non-representable family (every non-power-form in [q,2q)) for EVERY pair p>q≥2, uniformly subsuming the ad-hoc witnesses two_nonRepresentable_of_three_le (n=2,q≥3) and three_nonRepresentable_of_q_two (n=3,q=2). Helper isPowerForm_ge_q_of_ge_two.",
       "erdos_lewin_infinite axiom: the genuinely deep forward direction (infinitely many non-representables for {p,q}≠{2,3}); only the infinitude — not finiteness or existence — is now assumed",
       "Yu-Chen coprime infinite theorem",
       "Minimum summand bounds (Yu-Chen, Yang-Zhao)",
@@ -62,9 +63,9 @@
       "Connections to Problems #123, #845, #246"
     ],
     "axiomCount": 1,
-    "lineCount": 788,
+    "lineCount": 902,
     "assumptions": "1 axiom: erdos_lewin_infinite (Erdős-Lewin 1996, deep forward direction: {p,q}≠{2,3} ⟹ infinitely many non-representable numbers). The backward direction ({2,3} ⟹ finite, in fact NonRepresentable = {0}) is proved unconditionally (finite_nonRepresentable_of_two_three), and the EXISTENCE of a positive non-representable for every other coprime pair is also proved unconditionally (exists_positive_nonRepresentable_of_ne_two_three) — only the infinitude itself remains axiomatized.",
-    "theoremCount": 33,
+    "theoremCount": 37,
     "definitionCount": 7
   },
   "overview": {
@@ -260,9 +261,9 @@
       "Finset"
     ],
     "namespace": "Erdos1110",
-    "lineCount": 788,
+    "lineCount": 902,
     "axiomCount": 1,
-    "theoremCount": 33,
+    "theoremCount": 37,
     "definitionCount": 7,
     "path": "Proofs/Erdos1110Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/abundant-number-oq-02-oq-01.json
+++ b/src/data/research/problems/abundant-number-oq-02-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (unconditional): the extremal/monotonicity follow-up is now CLOSED. odd_abundant_coprime_three_seven_primeFactors proves UNCONDITIONALLY that any odd abundant number coprime to 3 has >=7 distinct prime factors, fully verified 0-axiom (no native_decide, no enumeration of the 5.4e9 range).",
+    "progressSummary": "PROGRESS: squarefree subproblem fully resolved (exact least element 33426748355, omega>=9), 0-axiom. General non-squarefree exact minimality still open.",
     "builtItems": [
       "geomSum_mul_pred_lt (per-prime-power Euler bound) in Proofs/AbundantNumberOQ02OQ01Minimality.lean",
       "sigma_mul_prod_sub_one_lt (Euler abundancy bound, N form) in Proofs/AbundantNumberOQ02OQ01Minimality.lean",
@@ -39,7 +39,11 @@
       "dom (domination lemma): for a strictly increasing list of primes whose i-th entry dominates a gap-list floor, the weighted product prod p/(p-1) is bounded by the product over the gap list. Proof by list recursion with f antitone. In Proofs/AbundantNumberOQ02OQ01Unconditional.lean",
       "GapList predicate + gapList_canon: [5,7,11,13,17,19] is a primorial gap list (consecutive entries forced apart by primality via gap5/gap7/gap11/gap13/gap17). In Proofs/AbundantNumberOQ02OQ01Unconditional.lean",
       "canon_prod_lt_two: (5/4)(7/6)(11/10)(13/12)(17/16)(19/18) = 1616615/829440 < 2 (norm_num). In Proofs/AbundantNumberOQ02OQ01Unconditional.lean",
-      "odd_abundant_coprime_three_seven_primeFactors (MAIN, unconditional, 0-axiom): Odd n -> not 3|n -> Abundant n -> 7 <= n.primeFactors.card. In Proofs/AbundantNumberOQ02OQ01Unconditional.lean"
+      "odd_abundant_coprime_three_seven_primeFactors (MAIN, unconditional, 0-axiom): Odd n -> not 3|n -> Abundant n -> 7 <= n.primeFactors.card. In Proofs/AbundantNumberOQ02OQ01Unconditional.lean",
+      "Proofs/AbundantNumberOQ02OQ01Squarefree.lean: sigma_one_squarefree (sigma(n)=prod(p+1) for squarefree via factorization_eq_one_of_squarefree), antitone weight g p=(p+1)/p with domg domination lemma, gap23/gap29, gapList8/gapList9, canon8_g_prod_lt_two, canon9_prod=33426748355.",
+      "squarefree_odd_abundant_coprime_three_nine_primeFactors : Squarefree n -> Odd n -> not 3|n -> Abundant n -> 9 <= omega(n) [VERIFIED 0-axiom].",
+      "squarefree_odd_abundant_coprime_three_ge : ... -> 33426748355 <= n (sharp; radical=n for squarefree, via domProd) [VERIFIED 0-axiom].",
+      "squarefree_odd_abundant_coprime_three_least : IsLeast {Squarefree & Odd & not3| & Abundant} 33426748355, with witness W=33426748355 proved Squarefree/Odd/not3|/Abundant (sigma_W=66886041600>2W via multiplicativity, no native_decide) [VERIFIED 0-axiom]."
     ],
     "insights": [
       "Euler abundancy bound holds purely over N: for n>1, sigma(n)*prod_{p|n}(p-1) < n*prod_{p|n} p. Proved multiplicatively from (sum_{i<=a} p^i)*(p-1)=p^{a+1}-1 (Mathlib geom_sum_mul_add, valid in any semiring). No native_decide.",
@@ -47,13 +51,16 @@
       "For odd n coprime to 3 all prime factors are >=5; the six smallest such primes give prod p/(p-1) = 1.949 < 2 and seven give 2.038 > 2, so the smallest odd abundant number coprime to 3 must have >=7 distinct prime factors (witness 5391411025 has exactly 8).",
       "The extremal step is cleanest as a list recursion in Q (not a Finset optimization): sort the prime factors, peel the head, advance a per-rank floor along a gap list. f(p)=p/(p-1) antitone + per-term domination + product monotonicity. The gap list [5,7,11,13,17,19] encodes the only nontrivial number theory (no prime strictly between consecutive entries), each gap discharged by interval_cases+decide.",
       "Crude bounds fail: (5/4)^6 ~= 3.81 > 2, and 6 distinct INTEGERS >=5 can telescope to 2.5 > 2 (e.g. 5..10). Primality (coprimality to 6) is essential: it forces the i-th smallest prime factor >= the i-th prime >=5, which is exactly the gap-list domination.",
-      "Linking the Q ratio product to the N Euler bound: prod_{p in S} p/(p-1) = (prod p)/(prod (p-1)) over Q (Finset.prod_div_distrib), and 2*prod(p-1) < prod p in N casts up; cancel the positive denominator with lt_of_mul_lt_mul_right. No division-inequality lemma needed."
+      "Linking the Q ratio product to the N Euler bound: prod_{p in S} p/(p-1) = (prod p)/(prod (p-1)) over Q (Finset.prod_div_distrib), and 2*prod(p-1) < prod p in N casts up; cancel the positive denominator with lt_of_mul_lt_mul_right. No division-inequality lemma needed.",
+      "SHARP squarefree boundary: a squarefree odd abundant number coprime to 3 has >=9 distinct prime factors (vs >=7 general). Squarefreeness removes exponent-boosting, so the abundancy index is the strictly smaller product prod (p+1)/p; the 8 smallest primes >=5 give (6/5)(8/7)(12/11)(14/13)(18/17)(20/19)(24/23)(30/29)=2090188800/1078282205~1.938<2, the 9th (31) pushes it >2.",
+      "EXACT squarefree minimum: smallest squarefree odd abundant coprime-to-3 number is 5*7*11*13*17*19*23*29*31 = 33426748355 (IsLeast). Larger than the general min 5391411025 precisely because the latter is non-squarefree (5^2 buys abundancy with only 8 primes)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Optional: extend the gap-list method to bound omega(n) for odd abundant n with other small-prime exclusions (e.g. coprime to 15) — same dom lemma, different canonical gap list.",
       "Optional gallery: the unconditional >=7 result could anchor a short gallery entry on Euler abundancy bounds, pairing the witness (oq-02) with this minimality lower bound.",
-      "The full minimality claim (smallest is exactly 5391411025) still needs the matching upper structure; >=7 prime factors is the proven lower bound on omega, not the full numeric minimality."
+      "The full minimality claim (smallest is exactly 5391411025) still needs the matching upper structure; >=7 prime factors is the proven lower bound on omega, not the full numeric minimality.",
+      "Squarefree case is now CLOSED exactly. For the general (non-squarefree) minimality toward 5391411025, the remaining obstruction is bounding exponents: a per-prime-power refinement combining the Euler bound with the size constraint."
     ],
     "markdown": "# Knowledge Base: abundant-number-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -127,6 +134,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbundantNumberOQ02OQ01LowerBound.lean"
+    },
+    {
+      "path": "Proofs/AbundantNumberOQ02OQ01Squarefree.lean",
+      "filename": "AbundantNumberOQ02OQ01Squarefree.lean",
+      "lineCount": 428,
+      "theoremCount": 29,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbundantNumberOQ02OQ01Squarefree.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Erdős Problem #1110 (representability by antichain sums of `p^k q^l`). Adds a **0-axiom window characterization** that captures the structural insight behind both pre-existing ad-hoc non-representable witnesses and upgrades *existence* to a *characterization*.

The key observation: the unit power form `1 = p^0 q^0` divides **every** other power form, so it can never sit in a representing antichain alongside another summand (antichain broken) nor alone (it would sum to `1`). Hence for `n ≥ 2` every summand is `≥ q` (the smallest power form exceeding `1`).

## New results (all 0-axiom)

- `isPowerForm_ge_q_of_ge_two` — any power form `p^k q^l ≥ 2` is `≥ q`.
- `representable_summands_ge_q` — **every summand of a representation of `n ≥ 2` is `≥ q`** (the reusable structural lemma the file previously lacked).
- `isRepresentable_iff_isPowerForm_window` — for `q ≤ n < 2q`, `IsRepresentable p q n ↔ IsPowerForm p q n`. Two summands already exceed `2q > n`, so a representation must be the singleton `{n}`.
- `nonRepresentable_of_window` — every non-power-form in `[q, 2q)` is non-representable: an explicit non-representable family for **every** pair `p > q ≥ 2`, uniformly subsuming `two_nonRepresentable_of_three_le` (`n=2, q≥3`) and `three_nonRepresentable_of_q_two` (`n=3, q=2`).

## Verification

- Host-verified single-file typecheck (`lean` + `LEAN_PATH`), **EXIT 0**, no errors (only a pre-existing unused-variable warning at line 98).
- `#print axioms` on all three new public results = `[propext, Classical.choice, Quot.sound]` only — independent of `erdos_lewin_infinite`.
- **File axiom count unchanged at 1**: the deep `erdos_lewin_infinite` (Erdős–Lewin 1996 infinitude, not in Mathlib) remains the sole assumption.

## Honest significance

Modest and elementary, but genuinely new: a *characterization* on a window (not just one witness), plus a reusable min-summand structural lemma. Does not touch the deep open infinitude direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)