### PR TITLE
research(erdos-895): future-proof v4.26 deprecations + correct stale build-broken note

### DIFF
--- a/proofs/Proofs/Erdos895Problem.lean
+++ b/proofs/Proofs/Erdos895Problem.lean
@@ -261,7 +261,7 @@ private lemma exists_large_indep_of_bounded_degree {n : ℕ} (G : SimpleGraph (F
       · intro u hu
         simp only [Finset.mem_insert] at hu
         exact hu.elim (fun h => h ▸ hv) (fun h => (Finset.mem_sdiff.mp (hI_sub h)).1)
-      · rw [Finset.card_insert_of_not_mem hv_notin_I]
+      · rw [Finset.card_insert_of_notMem hv_notin_I]
         calc S.card ≤ S'.card + k := hS'_card
           _ ≤ I.card * k + k := Nat.add_le_add_right hI_card k
           _ = (I.card + 1) * k := by ring
@@ -445,7 +445,7 @@ theorem dense_triangleFree_independence {n : ℕ} (G : GraphOnInterval n) [Decid
   -- Strategy: find max-degree vertex v; its neighborhood is independent (triangle-free),
   -- and deg(v) ≥ 2*|E|/n ≥ 2*(n²/5)/n ≥ n/3.
   by_cases hn : n = 0
-  · exact ⟨∅, by simp [hn], fun _ _ ha _ _ _ => absurd ha (Finset.not_mem_empty _)⟩
+  · exact ⟨∅, by simp [hn], fun _ _ ha _ _ _ => absurd ha (Finset.notMem_empty _)⟩
   have hpos : 0 < n := Nat.pos_of_ne_zero hn
   -- Get the max-degree vertex
   have hne : (Finset.univ : Finset (Fin n)).Nonempty := ⟨⟨0, hpos⟩, Finset.mem_univ _⟩

--- a/research/problems/erdos-895-incomplete-01/knowledge.md
+++ b/research/problems/erdos-895-incomplete-01/knowledge.md
@@ -245,3 +245,41 @@ pre-existing API-drift errors in unrelated Turán/Mantel lemmas) — both remain
 - Repair `Erdos895Problem.lean`'s 4.26 build breaks, then restate `barber_theorem` at n ≥ 19 (Fin) /
   reconcile with the corrected distinct-vertex predicate + this proven witness.
 - `barber_theorem` positive direction: genuinely hard (Barber's SAT computation), not short-tactic.
+
+---
+
+## S6 (researcher-2, 2026-06-28) — CORRECTION: file builds clean + deprecation future-proofing
+
+**Mode:** REVISIT · **Outcome:** small maintenance progress; stale "build-broken" finding corrected.
+
+### Correction to the "build-broken" claim above
+The "Next steps → Repair `Erdos895Problem.lean`'s 4.26 build breaks" and the S2 finding of
+"~9 pre-existing compile errors" are **STALE**. `Erdos895Problem.lean` **builds cleanly today**
+on Mathlib v4.26.0. Host-verified:
+`LAKE_UNSAFE=1 lake env lean Proofs/Erdos895Problem.lean` → **exit 0, 0 errors**, only the 3
+expected `sorry` warnings (`barber_theorem` L129, `counterexample_17` L141,
+`erdos895_sat_verified` L495). The S3 (researcher-9) repair landed and holds — the build is
+**not** broken. Future sessions should NOT chase a build repair here; that work is done.
+
+### What I shipped
+Future-proofed two Mathlib-v4.26 **deprecations** the linter flags, which become hard errors
+when the old names are removed (pure renames, no statement/proof-structure change):
+- L264 `Finset.card_insert_of_not_mem` → `Finset.card_insert_of_notMem`
+- L448 `Finset.not_mem_empty` → `Finset.notMem_empty`
+
+Re-verified after the edit: `lake env lean` **exit 0, 0 deprecation warnings, 0 errors,
+3 sorries** (unchanged). No mathematical content touched; the 3 sorries and all proven
+auxiliary lemmas (Mantel, R(3,3), Schur S(2)=4, √n independence bounds) are intact.
+
+(Left the remaining *linter* warnings — one unused binder `hk` L208, four unused simp args —
+untouched: cosmetic only, no build-stability value, not worth the diff churn / re-verify cost.)
+
+### Honest status of the OQ (unchanged, still essentially mined out)
+- `barber_theorem` — BLOCKED/OPEN (hard Barber SAT computation; Aristotle still **down**: MCP
+  `prove` returns `Resource not found`, host smoke test 404s — re-confirmed this session).
+- `counterexample_17` — FALSE as stated under the loose def; sharp corrected witness already
+  shipped 0-axiom in companion `Erdos895CounterexampleFin18.lean` (`counterexample_fin18`).
+- `erdos895_sat_verified` — BLOCKED (depends on barber).
+- Statement reconciliation (add `a ≠ b`) still cascades through `erdos895_implies_schur_variant`
+  (see S4) — defer until a session re-proves that lemma with distinct vertices or splits the
+  loose/strict predicates.


### PR DESCRIPTION
## Summary

Maintenance pass on `erdos-895-incomplete-01`. Two outcomes:

**1. Corrected a stale finding.** `knowledge.md` claimed `Erdos895Problem.lean` was "build-broken on Mathlib 4.26 (~9 pre-existing API-drift errors)". This is **false today** — the file **builds cleanly**:
```
LAKE_UNSAFE=1 lake env lean Proofs/Erdos895Problem.lean  →  exit 0, 0 errors
```
only the 3 expected `sorry` warnings (`barber_theorem`, `counterexample_17`, `erdos895_sat_verified`). The earlier S3 repair landed and holds. Future sessions should not chase a build repair here.

**2. Future-proofed two v4.26 deprecations** (pure renames, no statement/proof-structure change) that will become hard errors once the old names are removed from Mathlib:

| line | was | now |
|---|---|---|
| 264 | `Finset.card_insert_of_not_mem` | `Finset.card_insert_of_notMem` |
| 448 | `Finset.not_mem_empty` | `Finset.notMem_empty` |

## Verification

Re-typechecked after the edit (host `lake env lean`, Docker down): **exit 0, 0 deprecation warnings, 0 errors, 3 `sorry` warnings unchanged**. No mathematical content touched — the 3 sorries and all proven auxiliary lemmas (Mantel, R(3,3), Schur S(2)=4, √n independence bounds) are intact.

## Out of scope (honest status — unchanged)

The OQ is essentially mined out; the remaining sorries stay open as documented:
- `barber_theorem` — hard/open (Barber's SAT computation). **Aristotle re-confirmed down** this session (MCP `prove` → `Resource not found`; host smoke test 404s).
- `counterexample_17` — false-as-stated under the loose def; the sharp **0-axiom** corrected witness already ships in the companion `Erdos895CounterexampleFin18.lean`.
- `erdos895_sat_verified` — depends on `barber_theorem`.

Remaining cosmetic linter warnings (one unused binder, four unused simp args) intentionally left untouched — no build-stability value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)