### PR TITLE
research(erdos-1009-oq-03): gallery integration for certified K₄ integrality gap [VERIFIED, 0-axiom]

### DIFF
--- a/src/data/proofs/erdos-1009-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1009-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ek4gap-model",
+    "proofId": "erdos-1009-oq-03",
+    "range": { "startLine": 57, "endLine": 74 },
+    "type": "definition",
+    "title": "Decidable Model of K₄: Triangles, Edges, Edge-Disjointness",
+    "content": "K₄ is modelled on `Fin 4`. Its `triangles` are the four 3-element subsets of the vertex set, `allEdges` the six 2-element subsets, and `edgesOf T` the three 2-subsets of a triangle. `EdgeDisjoint S T` is `Disjoint (edgesOf S) (edgesOf T)`, made `Decidable` so every downstream combinatorial fact can be discharged by the kernel-checked `decide`. Working with this concrete decidable model (rather than the parent file's `sSup`-based maximum) is what makes the whole certificate finite and 0-axiom.",
+    "mathContext": "$K_4$ on $\\{0,1,2,3\\}$ has $\\binom{4}{3}=4$ triangles and $\\binom{4}{2}=6$ edges; a triangle's edge set is its three 2-subsets. Edge-disjoint means $E(S)\\cap E(T)=\\emptyset$.",
+    "significance": "key",
+    "relatedConcepts": ["complete graph", "Finset.powersetCard", "decidable predicate", "edge-disjoint subgraphs"],
+    "prerequisites": ["finite graph theory", "Lean 4 Finset", "Decidable instances"]
+  },
+  {
+    "id": "ek4gap-no-two-disjoint",
+    "proofId": "erdos-1009-oq-03",
+    "range": { "startLine": 88, "endLine": 92 },
+    "type": "insight",
+    "title": "Any Two Distinct Triangles of K₄ Share an Edge",
+    "content": "The combinatorial heart of the integer bound: `no_two_edge_disjoint` states that for all distinct triangles S, T of K₄, `¬ EdgeDisjoint S T`. Because the model is decidable and finite, the entire universally-quantified statement is checked by `decide` — the Lean kernel exhaustively verifies all pairs. This is the reason a packing can hold at most one triangle.",
+    "mathContext": "Among the four triangles of $K_4$, every pair shares exactly one edge (two 3-subsets of a 4-set intersect in 2 vertices, i.e. one edge). So no two triangles are edge-disjoint.",
+    "significance": "key",
+    "relatedConcepts": ["decide", "pairwise intersection", "set packing", "K₄ triangles"],
+    "prerequisites": ["decidable finite quantification", "edge-disjointness"]
+  },
+  {
+    "id": "ek4gap-integer-optimum",
+    "proofId": "erdos-1009-oq-03",
+    "range": { "startLine": 113, "endLine": 120 },
+    "type": "theorem",
+    "title": "Integer Optimum ν(K₄) = 1",
+    "content": "`integral_optimum` packages the integer packing number as `IsGreatest {n | ∃ F, IsPacking F ∧ F.card = n} 1`. The upper bound is `packing_card_le_one`: if a packing had two triangles, `Finset.one_lt_card` extracts a distinct pair, contradicting `no_two_edge_disjoint`. Achievability is `packing_singleton`: a single triangle is trivially a pairwise-edge-disjoint family (`Set.pairwise_singleton`). Together, ν(K₄) = 1.",
+    "mathContext": "$\\nu(K_4)=\\max\\{|F| : F$ a pairwise edge-disjoint family of triangles$\\}=1$: at most one triangle fits, and one is attainable.",
+    "significance": "key",
+    "relatedConcepts": ["IsGreatest", "maximum packing", "Finset.one_lt_card", "Set.pairwise_singleton"],
+    "prerequisites": ["suprema of finite sets", "edge-disjoint packing"]
+  },
+  {
+    "id": "ek4gap-fractional-feasible",
+    "proofId": "erdos-1009-oq-03",
+    "range": { "startLine": 138, "endLine": 157 },
+    "type": "theorem",
+    "title": "Uniform ½-Weighting is a Feasible Fractional Packing of Value 2",
+    "content": "A fractional packing assigns nonnegative weights to triangles with total edge-load ≤ 1 on every edge. `edge_incidence_le_two` (by `decide`) shows each edge lies in at most two triangles, so the uniform weight ½ keeps every edge-load at ≤ 2·½ = 1: this is `wHalf_isFracPacking`. The objective `wHalf_value` sums ½ over the four triangles to 2. Hence ν*(K₄) ≥ 2.",
+    "mathContext": "Each of the 6 edges of $K_4$ lies in exactly 2 of the 4 triangles. Weight $\\tfrac12$ per triangle gives edge-load $2\\cdot\\tfrac12=1$ (feasible) and total value $4\\cdot\\tfrac12=2$.",
+    "significance": "key",
+    "relatedConcepts": ["LP relaxation", "fractional packing", "edge incidence", "feasibility"],
+    "prerequisites": ["linear programming relaxation", "Finset.sum", "rational arithmetic"]
+  },
+  {
+    "id": "ek4gap-integrality-gap",
+    "proofId": "erdos-1009-oq-03",
+    "range": { "startLine": 161, "endLine": 191 },
+    "type": "theorem",
+    "title": "Certified Integrality Gap: ν*(K₄) ≥ 2 > 1 = ν(K₄)",
+    "content": "`integrality_gap` bundles the three facts — a feasible fractional packing of value 2, the integer optimum 1, and 2 > 1 — into one statement; `lp_relaxation_not_tight` gives the complexity reading (a fractional packing strictly exceeds the integer optimum, so the polynomial LP value cannot equal it); and `gap_factor_ge_two` records ν*(K₄) = 2·ν(K₄), the factor-2 separation. All are 0-axiom and kernel-checked.",
+    "mathContext": "$\\nu^*(K_4)\\geq 2 > 1 = \\nu(K_4)$. The LP relaxation is not tight: its (polynomial-time) optimum differs from the (NP-hard) integer optimum already on $K_4$.",
+    "significance": "key",
+    "relatedConcepts": ["integrality gap", "LP duality", "NP-hardness", "approximation", "set packing"],
+    "prerequisites": ["integer vs fractional optima", "computational complexity", "LP relaxation"]
+  }
+]

--- a/src/data/proofs/erdos-1009-oq-03/meta.json
+++ b/src/data/proofs/erdos-1009-oq-03/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "erdos-1009-oq-03",
+  "title": "Certified Integrality Gap for Edge-Disjoint Triangle Packing",
+  "slug": "erdos-1009-oq-03",
+  "description": "What is the computational complexity of maximum edge-disjoint triangle packing? The integer problem is NP-hard while its LP relaxation is polynomial. This entry certifies the canonical smallest witness of that gap: on K₄ the integer optimum is ν(K₄) = 1 while the fractional optimum is ν*(K₄) ≥ 2, so the LP relaxation is provably not tight.",
+  "meta": {
+    "author": "Erdős (open question, complexity of #1009 packing)",
+    "sourceUrl": "https://erdosproblems.com/1009",
+    "date": "1971",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1009OQ03.lean",
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "triangles",
+      "edge-disjoint",
+      "integrality-gap",
+      "linear-programming",
+      "complexity",
+      "decidable",
+      "extremal-combinatorics"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 1009,
+    "erdosUrl": "https://erdosproblems.com/1009",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "lineCount": 191,
+    "axiomCount": 0,
+    "assumptions": "Fully machine-checked: 0 sorries, 0 axioms, no native_decide (only kernel-checked `decide`). The complexity claim itself (integer packing is NP-hard) is classical and is not formalized; what is certified here is the concrete combinatorial separation — a feasible fractional packing of K₄ of value 2 together with the integer optimum 1 — that witnesses the integrality gap underlying the complexity separation.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.one_lt_card",
+        "description": "Extracting two distinct elements from a finset of card > 1, used to bound integer packings",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.powersetCard",
+        "description": "k-element subsets of a finset, used to model the triangles (3-subsets) and edges (2-subsets) of K₄",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Set.Pairwise",
+        "description": "Pairwise edge-disjointness of a triangle packing",
+        "module": "Mathlib.Data.Set.Pairwise.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Decidable Fin 4 model of K₄: its four triangles (3-subsets) and six edges (2-subsets), with edge-disjointness as a decidable predicate",
+      "no_two_edge_disjoint: any two distinct triangles of K₄ share an edge (kernel-checked by `decide`), so no two are edge-disjoint",
+      "integral_optimum: ν(K₄) = 1 packaged as IsGreatest — at most one triangle fits, and one is achievable",
+      "wHalf_isFracPacking + wHalf_value: the uniform ½-weighting is a feasible fractional packing of value 2",
+      "integrality_gap / lp_relaxation_not_tight / gap_factor_ge_two: certified ν*(K₄) ≥ 2 > 1 = ν(K₄), the factor-2 separation"
+    ],
+    "prerequisites": [
+      "Graph theory (triangles, edges, edge-disjoint subgraphs)",
+      "Linear programming relaxation and integrality gaps",
+      "Computational complexity (NP-hardness of packing)",
+      "Lean 4 and Mathlib (decidable Finset reasoning)"
+    ],
+    "theoremCount": 13,
+    "definitionCount": 9
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1009",
+      "relationship": "extends",
+      "description": "The parent problem: edge-disjoint triangles (K₃) beyond the Turán threshold ⌊n²/4⌋, SOLVED by Györi 1988. OQ-03 asks for the computational complexity of finding the maximum packing; this entry certifies the integrality gap that separates the LP value from the integer optimum."
+    },
+    {
+      "targetId": "erdos-1009-oq-01",
+      "relationship": "sibling",
+      "description": "Same Erdős #1009 family from the quantitative side: the optimal constant g(c) in Györi's bound. This entry instead addresses the complexity side, exhibiting the LP-vs-integer separation on the smallest witness K₄."
+    },
+    {
+      "targetId": "erdos-1009-oq-02",
+      "relationship": "sibling",
+      "description": "The structural K₄ analog of Györi's theorem (how many edge-disjoint K₄ copies are forced beyond the Turán threshold). This entry uses K₄ itself as the integrality-gap witness for the K₃ packing complexity question."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**From Györi's Theorem to a Complexity Question**\n\nErdős #1009, proved by Ervin Györi in 1988, is a quantitative extremal result: a graph with more than ⌊n²/4⌋ edges contains many edge-disjoint triangles. Once existence of large triangle packings is settled, the natural algorithmic question follows: how hard is it to *compute* a maximum edge-disjoint triangle packing?\n\nThe maximum edge-disjoint triangle packing problem is NP-hard in general (it is a special case of set packing / 3-dimensional-matching-style problems). Its natural linear-programming relaxation — assign nonnegative weights to triangles so that each edge carries total load ≤ 1, and maximize the total weight — is solvable in polynomial time. Whenever the LP optimum (the *fractional* packing number ν*) can strictly exceed the integer optimum ν, the LP value alone cannot recover the integer answer: the two optimization problems genuinely differ. This entry certifies that separation on the smallest possible graph.",
+    "problemStatement": "**Open Question (Complexity of #1009 Packing)**\n\nWhat is the computational complexity of finding the maximum edge-disjoint triangle packing of a graph? The integer problem is NP-hard, while the fractional relaxation is polynomial-time.\n\n**What is certified here.** On the complete graph $K_4$:\n- integer optimum $\\nu(K_4) = 1$ (maximum edge-disjoint triangle packing), and\n- fractional optimum $\\nu^*(K_4) \\geq 2$ (a feasible fractional packing of value 2).\n\nHence $\\nu^*(K_4) \\geq 2 > 1 = \\nu(K_4)$: the LP relaxation is not tight. This integrality gap is the canonical textbook certificate that the polynomial LP value cannot solve the NP-hard integer problem.",
+    "proofStrategy": "**Decidable Finite Model**\n\n1. Model $K_4$ on `Fin 4`: its triangles are the four 3-subsets, its edges the six 2-subsets, with `EdgeDisjoint S T := Disjoint (edgesOf S) (edgesOf T)` made `Decidable`.\n2. `no_two_edge_disjoint`: by `decide`, any two distinct triangles share an edge.\n3. Integer optimum: `packing_card_le_one` (any packing has ≤ 1 triangle) + `packing_singleton` (one is achievable) give `integral_optimum : IsGreatest … 1`.\n4. Fractional optimum: `edge_incidence_le_two` (each edge lies in ≤ 2 triangles, by `decide`) makes the uniform ½-weighting feasible (`wHalf_isFracPacking`), with objective value 2 (`wHalf_value`).\n5. Assemble `integrality_gap`, `lp_relaxation_not_tight`, and `gap_factor_ge_two`. Everything is finite and kernel-checked: 0 sorries, 0 axioms, only `decide`/`norm_num`/`linarith`.",
+    "keyInsights": [
+      "**K₄ is the minimal integrality-gap witness.** K₄ has exactly four triangles, every pair of which shares exactly one edge — so the integer packing holds at most one triangle. Yet each of the six edges lies in exactly two triangles, so weight ½ on every triangle keeps each edge-load at ½+½ = 1 (feasible) while summing to 4·½ = 2. The gap is a factor of 2.",
+      "**An integrality gap is what makes the LP relaxation insufficient.** A polynomial-time algorithm computes ν*(G), but ν*(K₄) = 2 ≠ 1 = ν(K₄), so the fractional value cannot equal the integer optimum. This is the standard certificate that solving the LP does not solve the (NP-hard) integer packing problem.",
+      "**Decidability replaces trust.** The combinatorial heart — `no_two_edge_disjoint` and `edge_incidence_le_two` — is discharged by `decide`, the kernel-checked decision procedure, rather than `native_decide`. The witness is therefore certified without trusting the compiled evaluator, keeping the entry genuinely 0-axiom.",
+      "**IsGreatest cleanly packages an optimum.** Rather than computing the maximum packing algorithmically, `integral_optimum` states ν(K₄) = 1 as `IsGreatest {n | ∃ F, IsPacking F ∧ F.card = n} 1`: 1 is attained (the singleton packing) and is an upper bound (`packing_card_le_one`). This separates the value of the optimum from any algorithm that finds it."
+    ]
+  },
+  "sections": [
+    {
+      "id": "model",
+      "title": "Decidable Model of K₄",
+      "startLine": 57,
+      "endLine": 85,
+      "summary": "Models K₄ on Fin 4: triangles (the four 3-subsets), allEdges (the six 2-subsets), edgesOf, and EdgeDisjoint with its Decidable instance. Sanity checks confirm 4 triangles and 6 edges by decide.",
+      "mathContext": "$K_4$ has $\\binom{4}{3} = 4$ triangles and $\\binom{4}{2} = 6$ edges. Each triangle is a 3-subset; its edge set is the three 2-subsets."
+    },
+    {
+      "id": "integer-optimum",
+      "title": "Integer Optimum ν(K₄) = 1",
+      "startLine": 87,
+      "endLine": 120,
+      "summary": "no_two_edge_disjoint (any two distinct triangles share an edge, by decide), IsPacking, packing_card_le_one, packing_singleton, and integral_optimum (ν(K₄) = 1 as IsGreatest).",
+      "mathContext": "Every pair of K₄ triangles shares exactly one edge, so a pairwise edge-disjoint family has at most one triangle: $\\nu(K_4) = 1$."
+    },
+    {
+      "id": "fractional-optimum",
+      "title": "Fractional Optimum ν*(K₄) ≥ 2",
+      "startLine": 122,
+      "endLine": 157,
+      "summary": "IsFracPacking, fracValue, the uniform half-weighting wHalf, edge_incidence_le_two (each edge in ≤ 2 triangles, by decide), wHalf_isFracPacking (feasibility), and wHalf_value = 2.",
+      "mathContext": "Weight $\\tfrac12$ on each triangle: every edge carries $\\tfrac12 + \\tfrac12 = 1$ (feasible), total $4 \\cdot \\tfrac12 = 2$. Hence $\\nu^*(K_4) \\geq 2$."
+    },
+    {
+      "id": "integrality-gap",
+      "title": "The Certified Integrality Gap",
+      "startLine": 159,
+      "endLine": 191,
+      "summary": "integrality_gap, lp_relaxation_not_tight, and gap_factor_ge_two assemble ν*(K₄) ≥ 2 > 1 = ν(K₄), giving the factor-2 separation between the LP relaxation and the integer optimum.",
+      "mathContext": "$\\nu^*(K_4) \\geq 2 > 1 = \\nu(K_4)$, i.e. $\\nu^*(K_4) = 2\\,\\nu(K_4)$: the LP relaxation strictly exceeds the integer optimum."
+    }
+  ],
+  "conclusion": {
+    "summary": "Certifies the canonical integrality gap underlying the complexity of edge-disjoint triangle packing: on K₄ the integer optimum is ν(K₄) = 1 (IsGreatest) while the uniform ½-weighting gives a feasible fractional packing of value ν*(K₄) ≥ 2. The factor-2 separation is fully machine-checked — 0 sorries, 0 axioms, kernel-checked decide (no native_decide).",
+    "implications": "The integrality gap explains why the polynomial-time LP relaxation does not solve the NP-hard integer packing problem: their optima genuinely differ already on the smallest witness. The decidable Fin 4 model makes the separation a finite, certified computation rather than an appeal to general complexity theory, complementing the parent #1009 existence results with a concrete complexity-side certificate.",
+    "openQuestions": [
+      "What is the exact computational complexity (e.g. APX-hardness, best approximation ratio) of maximum edge-disjoint triangle packing?",
+      "The fractional optimum of K₄ is in fact exactly ν*(K₄) = 2, matching the LP dual (fractional triangle cover); can the tight ν* = τ* duality be certified for larger instances?",
+      "Do larger witnesses (e.g. K_{2k}-type constructions) give integrality gaps growing with n, lower-bounding the gap asymptotically?"
+    ]
+  },
+  "references": [
+    {
+      "type": "paper",
+      "title": "On the number of edge disjoint triangles in K₄-free graphs",
+      "authors": [
+        "E. Györi"
+      ],
+      "year": 1988,
+      "journal": "Combinatorica"
+    },
+    {
+      "type": "book",
+      "title": "Approximation Algorithms",
+      "authors": [
+        "V. V. Vazirani"
+      ],
+      "year": 2001,
+      "journal": "Springer"
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/Erdos1009OQ03.lean",
+    "lineCount": 191,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 13,
+    "definitionCount": 9
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-1009-oq-03.json
+++ b/src/data/research/problems/erdos-1009-oq-03.json
@@ -37,7 +37,11 @@
     "focus": "0 sorries, 0 axioms (propext/Choice/Quot only; no native_decide). Certified integrality gap ν*(K₄) ≥ 2 > 1 = ν(K₄).",
     "blockers": [],
     "nextAction": "The general complexity classification (NP-hardness reduction) is a CS result, not a single Lean theorem; possible follow-up: integrality gap for larger constructions, or LP-duality lower bound for ν*.",
-    "attemptCounts": { "total": 1, "currentApproach": 1, "approachesTried": 1 }
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
   },
   "knowledge": {
     "insights": [
@@ -45,24 +49,26 @@
       "Any two distinct triangles of K₄ share exactly one edge, so no two are edge-disjoint — the integer edge-disjoint triangle packing holds at most one triangle (ν(K₄) = 1).",
       "Each of the 6 edges of K₄ lies in exactly two triangles, so uniform weight ½ keeps every edge-load at exactly 1 (feasible) while the objective sums to 4·½ = 2 (ν*(K₄) ≥ 2).",
       "The strict gap ν*(K₄) = 2 > 1 = ν(K₄) is the LP-relaxation-not-tight phenomenon that separates the polynomial fractional problem from the NP-hard integer problem.",
-      "Whole result is finite and decidable; certified with `decide` only (no native_decide), so it does not depend on Lean.ofReduceBool."
+      "Whole result is finite and decidable; certified with `decide` only (no native_decide), so it does not depend on Lean.ofReduceBool.",
+      "The verified OQ-03 integrality-gap proof (ν*(K₄)≥2>1=ν(K₄)) was merged and audited clean but had no gallery entry; the only remaining work on this candidate was gallery integration, now done."
     ],
     "builtItems": [
       "Erdos1009OQ03.triangles / edgesOf / allEdges — decidable model of K₄'s triangles and edges on Fin 4.",
       "Erdos1009OQ03.no_two_edge_disjoint — distinct triangles always share an edge (by decide).",
       "Erdos1009OQ03.IsPacking + packing_card_le_one + integral_optimum — integer optimum IsGreatest = 1.",
       "Erdos1009OQ03.IsFracPacking + wHalf + wHalf_isFracPacking + wHalf_value — feasible fractional packing of value 2.",
-      "Erdos1009OQ03.integrality_gap / lp_relaxation_not_tight / gap_factor_ge_two — the certified factor-2 integrality gap."
+      "Erdos1009OQ03.integrality_gap / lp_relaxation_not_tight / gap_factor_ge_two — the certified factor-2 integrality gap.",
+      "Gallery integration: created src/data/proofs/erdos-1009-oq-03/{meta.json,annotations.json} mirroring the verified Erdos1009OQ03.lean (13 thms, 9 defs, 0-axiom, 0-sorry, decide not native_decide) — entry now appears in the gallery alongside siblings oq-01/oq-02"
     ],
     "mathlibGaps": [
       "Mathlib has no notion of fractional graph packings / LP relaxations of combinatorial covering-packing problems; the small model here is self-contained.",
       "The parent file's maxEdgeDisjointTriangles is sSup-based (noncomputable); a decidable concrete model was needed for an explicit witness."
     ],
     "nextSteps": [
-      "Generalize the integrality-gap witness to a family (e.g. K_{2k} type constructions) to lower-bound the gap as n grows.",
-      "Formalize the fractional LP dual (fractional triangle cover) and an LP-duality bound ν* = τ* on a small instance."
+      "Optional: gallery-integrate the sub-result erdos-1009-oq-03-oq-01 (exact ν*=τ*=2 via LP duality, merged #31229) if/when promoted to a standalone entry.",
+      "Optional: certify integrality gaps growing with n via K_{2k}-type witnesses."
     ],
-    "progressSummary": "COMPLETE: certified integrality gap ν*(K₄) ≥ 2 > 1 = ν(K₄) for edge-disjoint triangle packing; 0 sorries, 0 axioms, no native_decide."
+    "progressSummary": "COMPLETE + GALLERY-INTEGRATED 2026-06-28 (researcher-5): verified K₄ integrality-gap entry now in gallery (erdos-1009-oq-03). 0-axiom, 0-sorry, badge verified. Remaining #1009 complexity core is classical/open, not elementarily formalizable."
   },
   "knownResults": [
     "Györi (1988): edge-disjoint triangles beyond the Turán threshold (parent #1009).",
@@ -73,7 +79,9 @@
       "E. Győri, On the number of edge-disjoint triangles in graphs (1988).",
       "I. Holyer, The NP-completeness of some edge-partition problems, SIAM J. Comput. 10 (1981)."
     ],
-    "urls": ["https://erdosproblems.com/1009"],
+    "urls": [
+      "https://erdosproblems.com/1009"
+    ],
     "mathlib": []
   },
   "relatedProofs": [


### PR DESCRIPTION
## Summary

The verified Lean proof `Erdos1009OQ03.lean` — a **certified integrality gap** for maximum edge-disjoint triangle packing — was merged and audited clean (#31150, audit #31229) but had **no gallery entry**, while its siblings `erdos-1009-oq-01` and `erdos-1009-oq-02` did. This PR adds the missing gallery integration so the entry appears on the site.

## What the proof certifies

On the complete graph K₄:
- integer optimum **ν(K₄) = 1** (max edge-disjoint triangle packing), and
- fractional optimum **ν*(K₄) ≥ 2** (uniform ½-weighting is a feasible fractional packing of value 2).

Hence **ν*(K₄) ≥ 2 > 1 = ν(K₄)**: the LP relaxation is not tight, the canonical certificate that the polynomial-time LP value cannot solve the NP-hard integer packing problem (Erdős #1009 OQ-03, the complexity question).

## Files added
- `src/data/proofs/erdos-1009-oq-03/meta.json` — full entry (overview, 4 sections, conclusion, cross-refs to the #1009 family, references)
- `src/data/proofs/erdos-1009-oq-03/annotations.json` — 5 annotations anchored to the proof
- `src/data/research/problems/erdos-1009-oq-03.json` — knowledge updated to COMPLETE + gallery-integrated

## Integrity
- **status: verified, badge: verified** — 0 sorries, 0 axioms, kernel-checked `decide` (the lone `native_decide` token is inside the file's docstring, not a tactic; consistent with the cycleV61 audit).
- 13 theorems, 9 definitions, 191 lines.
- `pnpm gallery:check-size` passes (4125 entries within caps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)