### PR TITLE
research(central-limit-theorem-oq-02-oq-03): α-mixing coefficient ≤ 1 + m-monotonicity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02OQ03.lean
@@ -37,8 +37,12 @@ This file proves, fully and axiom-free (reusing the parent's
    zero nonneg sequence has summable rpow powers.
 5. `mDependent_summable_mixing_rpow` — Ibragimov's series ∑ α(n)^θ converges for
    every θ > 0.
+6. `alphaMixingCoeff_le_one` — the α-mixing coefficient is always ≤ 1 on a
+   probability space (the upper bound the parent file leaves out).
+7. `mDependent_mono` — m-dependence is monotone in m, so the finite-range classes
+   nest upward (independent = 0-dependent ⊆ 1-dependent ⊆ …).
 
-Proved theorems: 6, Axioms: 0, Sorries: 0
+Proved theorems: 7, Axioms: 0, Sorries: 0
 -/
 
 import Mathlib
@@ -204,5 +208,49 @@ The `θ ≠ 0` hypothesis of `mDependent_summable_mixing_rpow` is necessary: at
 `θ = 0` each summand is `α(n)^0 = 1`, and `∑ₙ 1` diverges regardless of the
 mixing structure.
 -/
+
+/-
+## Part VII: The α-mixing coefficient is bounded by 1, and m-dependence is monotone
+
+Two structural facts. First, a reusable bound the parent file explicitly leaves
+out (its note: "`alphaMixingCoeff_nonneg` omitted due to nested ciSup elaboration
+complexity"): on a probability space `0 ≤ α ≤ 1` always, because every term of the
+defining supremum is `|x − y·z|` with `x, y, z ∈ [0,1]`. We supply the upper bound,
+which `Real.iSup_le` handles cleanly (its `0 ≤ a` side-condition absorbs the
+empty-index sup). Second, m-dependence is monotone in `m`: a stronger finite range
+of dependence implies every weaker one, so the chain
+`independent = 0-dependent ⊆ 1-dependent ⊆ 2-dependent ⊆ …` is genuine.
+-/
+
+/-- **The α-mixing coefficient is at most `1`.** On a probability space every term
+`|μ(A∩B).toReal − μA.toReal · μB.toReal|` of the defining supremum lies in `[0,1]`
+(all three measures are `≤ 1`), so the supremum is `≤ 1`. This supplies the upper
+bound the parent file omits (stated for the lag-indexed σ-algebras `σ_k`). -/
+theorem alphaMixingCoeff_le_one {μ : Measure Ω} [IsProbabilityMeasure μ]
+    (σ_k : ℕ → MeasurableSpace Ω) (k n : ℕ) :
+    alphaMixingCoeff μ (σ_k k) (σ_k (k + n)) ≤ 1 := by
+  simp only [alphaMixingCoeff]
+  refine Real.iSup_le (fun A => ?_) (by norm_num)
+  refine Real.iSup_le (fun _ => ?_) (by norm_num)
+  refine Real.iSup_le (fun B => ?_) (by norm_num)
+  refine Real.iSup_le (fun _ => ?_) (by norm_num)
+  have hx : (μ (A ∩ B)).toReal ≤ 1 := measureReal_le_one
+  have hy : (μ A).toReal ≤ 1 := measureReal_le_one
+  have hz : (μ B).toReal ≤ 1 := measureReal_le_one
+  have hx0 : 0 ≤ (μ (A ∩ B)).toReal := ENNReal.toReal_nonneg
+  have hy0 : 0 ≤ (μ A).toReal := ENNReal.toReal_nonneg
+  have hz0 : 0 ≤ (μ B).toReal := ENNReal.toReal_nonneg
+  rw [abs_le]
+  constructor <;>
+    nlinarith [hx, hx0, hy, hy0, hz, hz0, mul_nonneg hy0 hz0,
+      mul_nonneg (sub_nonneg.mpr hy) hz0]
+
+/-- **m-dependence is monotone in `m`.** If a family is `m`-dependent and `m ≤ m'`,
+it is `m'`-dependent: any gap `n > m'` already exceeds `m`. Hence the finite-range
+dependence classes are nested upward (`independent = 0-dependent ⊆ m-dependent ⊆ …`). -/
+theorem mDependent_mono {μ : Measure Ω} {σ_k : ℕ → MeasurableSpace Ω} {m m' : ℕ}
+    (hmm : m ≤ m') (hMdep : MDependent μ σ_k m) : MDependent μ σ_k m' := by
+  intro k n A B hn hA hB
+  exact hMdep k n A B (lt_of_le_of_lt hmm hn) hA hB
 
 end CentralLimitTheoremOQ02OQ03

--- a/research/problems/central-limit-theorem-oq-02-oq-03/knowledge.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-03/knowledge.md
@@ -64,3 +64,25 @@ research json, added import to Proofs.lean. status=verified, badge=original.
 - Berry–Esseen O(n^{-1/2}) rate for the m-dependent CLT (Stein's method).
 - Growing-range m_n-dependent arrays, m_n = o(n^{1/3}) (Romano–Wolf 2000).
 - Parent's deep CLT axiom martingale_clt (McLeish 1974) — unchanged.
+
+## Session 2026-06-28 (researcher-1) — coefficient bound + m-monotonicity [VERIFIED, 0-axiom]
+
+SOLVED → looked outward. Added two structural lemmas:
+- `alphaMixingCoeff_le_one` (σ_k k n): the α-mixing coefficient is ≤ 1 on a probability
+  space — the upper bound the PARENT file explicitly omits ("alphaMixingCoeff_nonneg omitted
+  due to nested ciSup elaboration complexity"). Each term |x−yz| with x,y,z∈[0,1]; the nested
+  iSup collapses via `Real.iSup_le (hf) (ha : 0 ≤ a)` whose nonneg side-condition absorbs the
+  empty Prop-indexed sup. measureReal_le_one gives (μ s).toReal ≤ 1; inner |x−yz|≤1 by nlinarith.
+- `mDependent_mono`: m ≤ m' → MDependent m → MDependent m' (gap n>m'≥m ⇒ n>m), formalizing the
+  upward nesting independent=0-dep ⊆ 1-dep ⊆ … that Part VI states informally.
+
+GOTCHA: stated alphaMixingCoeff_le_one with σ-algebras as `σ_k k`/`σ_k (k+n)` (function
+applications), NOT loose `(ℱ₁ ℱ₂ : MeasurableSpace Ω)` params — loose MeasurableSpace locals
+become instance candidates and `alphaMixingCoeff`'s implicit [MeasurableSpace Ω] then
+synthesizes ℱ₂ ≠ ambient (μ's) instance → "synthesized instance not defeq" error.
+
+Key Mathlib: `Real.iSup_le (∀ i, f i ≤ a) (0 ≤ a) : ⨆ i, f i ≤ a`; `measureReal_le_one`
+[IsZeroOrProbabilityMeasure]; `ENNReal.toReal_nonneg`.
+
+Verified: lake env lean clean; #print axioms both = [propext, Classical.choice, Quot.sound].
+File now 252 lines, 7 theorems, 1 def, 0 sorry / 0 axiom.

--- a/src/data/proofs/central-limit-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02-oq-03/meta.json
@@ -36,7 +36,7 @@
       "Doukhan, P. *Mixing: Properties and Examples*. Lecture Notes in Statistics 85, Springer, 1994."
     ]
   },
-  "description": "Fully verified (0-axiom, 0-sorry) formalization of the finite-range dependence case of the dependent-variable CLT. Defines MDependent μ σ_k m (events separated by gap > m are independent) and proves the headline mDependent_alpha_zero: the parent file's α-mixing coefficient vanishes at every lag n > m. The m = 0 case recovers the parent's independent_implies_zero_mixing. Two structural consequences make Ibragimov's mixing CLT apply for free: mixing decay α(n) → 0 holds trivially (coefficients eventually zero), and the Ibragimov series ∑ₙ α(n)^θ converges for every exponent θ > 0 (finite sum). Includes the reusable analytic lemma summable_rpow_of_eventually_zero. 6 theorems, 1 definition, 0 axioms, 0 sorries; reuses alphaMixingCoeff from the parent.",
+  "description": "Fully verified (0-axiom, 0-sorry) formalization of the finite-range dependence case of the dependent-variable CLT. Defines MDependent μ σ_k m (events separated by gap > m are independent) and proves the headline mDependent_alpha_zero: the parent file's α-mixing coefficient vanishes at every lag n > m. The m = 0 case recovers the parent's independent_implies_zero_mixing. Two structural consequences make Ibragimov's mixing CLT apply for free: mixing decay α(n) → 0 holds trivially (coefficients eventually zero), and the Ibragimov series ∑ₙ α(n)^θ converges for every exponent θ > 0 (finite sum). Includes the reusable analytic lemma summable_rpow_of_eventually_zero. 6 theorems, 1 definition, 0 axioms, 0 sorries; reuses alphaMixingCoeff from the parent. Also adds alphaMixingCoeff_le_one (the α-mixing coefficient is ≤ 1 on a probability space — the upper bound the parent file explicitly omits) and mDependent_mono (m-dependence is monotone in m, so the finite-range dependence classes nest upward).",
   "conclusion": {
     "summary": "This file generalizes the parent's independence endpoint to the full finite-range (m-dependent) family. The headline mDependent_alpha_zero proves the α-mixing coefficient vanishes at every lag n > m; independence is recovered as m = 0. Two consequences — eventual mixing decay and summability of the Ibragimov series for every exponent — show that any m-dependent stationary sequence with finite variance satisfies Ibragimov's mixing CLT (OQ-02-OQ-04) with no constraint on the mixing rate. All 6 theorems are machine-checked with only the foundational axioms (propext, Classical.choice, Quot.sound).",
     "implications": "m-dependence is the canonical first step beyond independence in the dependent-CLT hierarchy and the natural model for finite-order moving averages (MA(q) is q-dependent) and one-step functions of finite-state Markov chains. Establishing α(n) = 0 for n > m in Lean gives a reusable, axiom-free bridge from finite-range dependence directly into the parent's α-mixing API: it discharges every rate/moment hypothesis of the mixing CLT trivially. The analytic helper summable_rpow_of_eventually_zero is generic and could support other eventually-zero-rate arguments.",
@@ -96,12 +96,12 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 208,
+    "lineCount": 252,
     "assumptions": "None. All 6 theorems are machine-checked; #print axioms reports only the foundational axioms propext, Classical.choice, Quot.sound (no sorryAx, no custom axioms, no Lean.ofReduceBool). The file reuses the definition alphaMixingCoeff from the parent CentralLimitTheoremOQ02.lean; that parent definition is axiom-free (the parent's single axiom martingale_clt is unrelated and not referenced here).",
     "mathlib_version": "4.26.0",
     "historicalContext": "m-dependence was introduced by Hoeffding and Robbins (1948) as the first tractable dependence structure beyond independence admitting a CLT. It is the finite-range special case of Rosenblatt's (1956) α-mixing, with α(n) = 0 for n > m. Finite-order moving averages MA(q) are exactly q-dependent, and one-step functions of finite-state Markov chains are 1-dependent.",
     "proofStrategy": "Reuse the parent's nested-supremum-collapse: at lag n > m, m-dependence forces each term of the defining ⨆ to 0 (ENNReal.toReal_mul), and the Prop-indexed all-zero nested supremum over ℝ collapses via a Nonempty/IsEmpty case split. Derive the m = 0 (independence) recovery, eventual mixing decay (tendsto_atTop_of_eventually_const), and Ibragimov-series summability for every exponent (summable_of_ne_finset_zero + Real.zero_rpow).",
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 1,
     "originalContributions": [
       "MDependent: definition of m-dependence for a family of σ-algebras (events separated by gap > m are independent), generalizing the parent's independence hypothesis.",
@@ -201,6 +201,11 @@
       "endLine": 208,
       "summary": "Places m-dependence strictly between independence and general α-mixing: Independent (= 0-dependent) ⊊ m-dependent ⊊ α-mixing with summable rate ⊊ α-mixing. Notes the strictness witnesses (MA(1) is 1-dependent but not independent; long-memory α-mixing is not m-dependent) and the necessity of θ ≠ 0.",
       "mathContext": "Independent $\\subsetneq$ $m$-dependent $\\subsetneq$ summable-rate $\\alpha$-mixing $\\subsetneq$ $\\alpha$-mixing."
+    },
+    {
+      "id": "bounds-mono",
+      "title": "Coefficient Bound and m-Monotonicity",
+      "summary": "alphaMixingCoeff_le_one: on a probability space the α-mixing coefficient is ≤ 1 (every term |x−yz| with x,y,z∈[0,1]; proved via Real.iSup_le whose 0≤a side-condition absorbs the empty-index sup) — the upper bound the parent omits. mDependent_mono: m-dependence is monotone in m, nesting the finite-range classes upward."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two structural additions to the verified **central-limit-theorem-oq-02-oq-03** entry (m-dependent sequences are α-mixing):

1. **`alphaMixingCoeff_le_one`** — on a probability space the α-mixing coefficient is always `≤ 1`. Every term of the defining supremum is `|x − y·z|` with `x, y, z ∈ [0,1]`, so the nested supremum is bounded by `1`. This supplies the upper bound the **parent** file explicitly leaves out (its note: *"alphaMixingCoeff_nonneg omitted due to nested ciSup elaboration complexity"*). The key is `Real.iSup_le`, whose `0 ≤ a` side-condition cleanly absorbs the empty Prop-indexed suprema that blocked the parent's attempt.

2. **`mDependent_mono`** — m-dependence is monotone in `m`: if a family is `m`-dependent and `m ≤ m'`, it is `m'`-dependent (a gap `n > m'` already exceeds `m`). This formalizes the upward nesting `independent = 0-dependent ⊆ 1-dependent ⊆ …` that Part VI previously only stated informally.

## Note

`alphaMixingCoeff_le_one` is stated for the lag-indexed σ-algebras `σ_k k`, `σ_k (k+n)` (function applications) rather than loose `(ℱ₁ ℱ₂ : MeasurableSpace Ω)` parameters: loose `MeasurableSpace` locals are treated as instance candidates and make `alphaMixingCoeff`'s implicit `[MeasurableSpace Ω]` resolve to the wrong σ-algebra.

## Verification

- `lake env lean Proofs/CentralLimitTheoremOQ02OQ03.lean` — compiles clean.
- `#print axioms` on both new results = `[propext, Classical.choice, Quot.sound]` only.
- File now **252 lines, 7 theorems, 0 sorry, 0 axiom**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)