### PR TITLE
audit(cycleV63): erdos-340-greedy-sidon-oq-05-oq-01 CLEAN [Tier A]

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25619,6 +25619,12 @@
       "lastAudited": "2026-06-28T10:14:09Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-340-greedy-sidon-oq-05-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T10:32:12Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — cycleV63

Audited the sole never-audited gallery entry **erdos-340-greedy-sidon-oq-05-oq-01** (the analytic O(N^{1/h}) upper bound `IsBh.card_le_rpow` for B_h sets, merged via #31235).

### Result: CLEAN (Tier A)

| Check | meta.json | Lean source | OK |
|-------|-----------|-------------|-----|
| sorries | 0 | 0 | ✓ |
| axiom decls | 0 | 0 (no `axiom`, no `native_decide`) | ✓ |
| True stubs | — | 0 | ✓ |
| lineCount | 137 | 137 | ✓ |
| theoremCount | 1 | 1 | ✓ |

- **Not a Mathlib wrapper**: the core combinatorial content `IsBh.choose_card_le` (C(k,h) ≤ h·N) is the project's *own* theorem from the OQ-05 prerequisite. Mathlib deps (`Nat.pow_le_choose`, `Real.rpow_*`) are generic binomial/analysis infrastructure, fully disclosed in `mathlibDependencies`. Badge `original`/Tier A is appropriate.
- **No overclaiming**: description explicitly states the open #340 exponent gap (1/(2h-1) vs 1/h) is *not* addressed; `assumptions` field honest about foundational axioms only.
- Prerequisite `Erdos340GreedySidonOQ05.lean` independently confirmed 0-sorry / 0-axiom.

### Standing false positives reconfirmed honest (no change)
- **erdos-57-oq-04** (`axiom undercount` flag): parent entry `erdos-57` correctly carries `axiomatized/axiom/axiomCount=1`. The `axiom erdos_57` lives in the shared host file `Erdos57Problem.lean`; oq-04 contributes only the 0-axiom bipartite⟺no-odd-cycle lemmas. Detector greps the whole host file → host FP.
- **erdos-156** (`sorry mismatch` flag): `formalized/wip`, does **not** claim verified — no overclaim. Detector's chain-15 vs meta's 3 is a counting-method discrepancy.

Tracker updated: `erdos-340-greedy-sidon-oq-05-oq-01` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)