### PR TITLE
Enrich Ptolemy equality-case (OQ-01-01-03): full annotation coverage

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01-oq-03/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-ptolemy-eqcase-oq010103-setup",
+    "proofId": "ptolemys-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 66
+    },
+    "type": "concept",
+    "title": "Setup: The Inversion–Betweenness Certificate for Ptolemy Equality",
+    "content": "Mathlib already supplies the Ptolemy inequality dist a c · dist b d ≤ dist a b · dist c d + dist b c · dist a d in any real inner-product space (mul_dist_le_mul_dist_add_mul_dist). This file pins down the missing half — exactly when equality holds — without coordinates, a unit circle, or a cyclic-order hypothesis. The key idea is that Mathlib's own proof of the inequality applies the triangle inequality to the inversion images b' = inversion a 1 b, c', d', so equality in Ptolemy is equality in that single triangle inequality, which strict convexity (dist_add_dist_eq_iff) characterises as weak betweenness Wbtw ℝ b' c' d'. Real inner-product spaces are strictly convex (InnerProductSpace.toUniformConvexSpace → StrictConvexSpace), so no extra hypotheses appear. Geometrically, inversion centred at a sends the circle through a, b, c, d to the line through b', c', d', so the betweenness is the analytic incarnation of 'a, b, c, d concyclic with c separated from a'. Crucially, where the parent leaf ptolemys-theorem-oq-01-oq-01 sealed its trigonometric ordering step behind an axiom (positive_ratio_implies_cyclic_order), this fully general result is 0-axiom / 0-sorry.",
+    "mathContext": "$$AC\\cdot BD = AB\\cdot CD + BC\\cdot DA \\iff \\mathrm{Wbtw}_{\\mathbb R}(b',c',d'),\\quad x' = \\mathrm{inversion}_a^1 x,$$ with strict convexity supplying the betweenness characterisation of triangle-inequality equality.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ptolemy's inequality",
+      "Euclidean inversion",
+      "strict convexity",
+      "weak betweenness",
+      "cyclic quadrilateral"
+    ],
+    "prerequisites": [
+      "the Ptolemy inequality in inner-product spaces",
+      "inversion about a point",
+      "strict convexity of inner-product spaces"
+    ]
+  },
+  {
     "id": "ann-ptolemy-eqcase-oq010103-key-algebra",
     "proofId": "ptolemys-theorem-oq-01-oq-01-oq-03",
     "range": {
@@ -66,6 +91,29 @@
     "prerequisites": [
       "mul_dist_le_mul_dist_add_mul_dist (Ptolemy inequality)",
       "Wbtw.collinear"
+    ]
+  },
+  {
+    "id": "ann-ptolemy-eqcase-oq010103-sanity",
+    "proofId": "ptolemys-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 138,
+      "endLine": 148
+    },
+    "type": "context",
+    "title": "Sanity Check: The Degenerate c = b Case Lands on the Locus",
+    "content": "A closing `example` validates the characterisation against a degenerate configuration: when c = b (both still ≠ a), Ptolemy's two sides both collapse to dist a b · dist b d, so equality holds trivially. Feeding this into the main theorem, the inversion images must satisfy Wbtw ℝ b' b' d' — weak betweenness with a repeated endpoint, which holds vacuously (a point is always 'between' itself and any other). The proof discharges the equality hypothesis with `simp [dist_self]` and lets ptolemy_eq_iff_wbtw_inversion do the rest. This is not new mathematics but a guardrail: it confirms the iff behaves correctly at the boundary of its hypotheses (degenerate quadrilaterals are concyclic in the limiting sense), catching any accidental strictness or non-reflexivity in the betweenness encoding.",
+    "mathContext": "$c = b \\Rightarrow AC\\cdot BD = AB\\cdot BD = AB\\cdot CD + BC\\cdot DA$ (since $BC = 0$), and correspondingly $\\mathrm{Wbtw}_{\\mathbb R}(b',b',d')$ holds with a repeated point.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "degenerate configuration",
+      "reflexivity of Wbtw",
+      "dist_self",
+      "boundary sanity check"
+    ],
+    "prerequisites": [
+      "the main equality characterisation",
+      "Wbtw with a repeated point"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `ptolemys-theorem-oq-01-oq-01-oq-03` (quality 81 → 94, 0 prior passes).

## Gap addressed
The meta.json was already strong (complete conclusion, history, key insights), but `annotations.json` had only **3 annotations** leaving the file header and the closing sanity check uncovered.

## Changes
Added 2 annotations for full file coverage:
- **Setup** (lines 1–66) — the inversion–betweenness certificate, the strict-convexity mechanism turning triangle-equality into `Wbtw`, and the 0-axiom contrast with the parent leaf's axiom-sealed trigonometric ordering step
- **Sanity check** (138–148) — the degenerate `c = b` case validating the iff at its hypothesis boundary (`Wbtw` with a repeated point)

Annotation count 3 → 5; each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Existing 3 annotations unchanged.

## Verification
- `annotations.json` valid JSON, 5 entries covering lines 1–148; `meta.json` within size caps
- Quality score 81 → 94
- No changes to axiom/status claims (0-axiom / 0-sorry, matching the Lean source)