### PR TITLE
research(chebyshev-pnt-bridge-oq-06-oq-01): Nat.sqrt log bracket + two-sided Chebyshev sandwich [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChebyshevPNTBridgeOQ06OQ01.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ06OQ01.lean
@@ -1,0 +1,162 @@
+/-
+# Chebyshev–PNT Bridge OQ-06-OQ-01: the Two-Sided Density Sandwich
+
+Two sibling entries package the elementary Chebyshev bounds on the prime-counting
+function `π` into real-logarithmic form:
+
+* `ChebyshevPNTBridgeOQ05` — the **lower** density
+    `(⌊m/2⌋·log 4 − log(m+1)) / log m ≤ π(m)`   (`primeCounting_ge_div_log`),
+* `ChebyshevPNTBridgeOQ06` — the **upper** density
+    `π(m) ≤ m·log 4 / log(√m) + √m`             (`primeCounting_le_div_log_sqrt`),
+
+where `√m = Nat.sqrt m` is the integer square root. This entry combines them into a
+single two-sided **sandwich** and, more substantially, makes the asymptotic reading
+of the two constants rigorous.
+
+The upper bound is stated with the denominator `log(Nat.sqrt m)`, and one informally
+reads off `limsup π(x)·log x / x ≤ 2 log 4` using "`log(√m) ≈ ½ log m`". That step is
+not free: `Nat.sqrt m` is the *integer* square root, so `log(Nat.sqrt m)` is only
+approximately `½ log m`. We pin it down exactly with the bracket
+
+    ½·log m − log 2  ≤  log(Nat.sqrt m)  ≤  ½·log m            (all m ≥ 4),
+
+derived purely from the defining inequalities of `Nat.sqrt`
+(`(Nat.sqrt m)² ≤ m < (Nat.sqrt m + 1)²`) — the lower half via `m < 4·(Nat.sqrt m)²`.
+This `O(1)` two-sided control on `log(Nat.sqrt m)` is exactly what turns the OQ-06
+quotient bound into the honest density statement.
+
+Putting the pieces together:
+
+* **`log_natSqrt_le`** / **`log_natSqrt_ge`** — the bracket above.
+* **`primeCounting_sandwich`** — both Chebyshev bounds on `π(m)` at once.
+* **`primeCounting_mul_log_upper`** — the upper bound renormalised to the common
+  `π(m)·log m` scale of OQ-05: `π(m)·log m ≤ 2·(n·log 4 + √m·log √m)` with
+  `n = ⌊m/2⌋`-free constant `2·m·log 4 + (lower-order)`, the clean companion to
+  OQ-05's `primeCounting_mul_log_lower`.
+
+Everything is derived from the two sibling files plus the `Nat.sqrt` bracket; no new
+axioms.  `0 sorries, 0 axioms`.
+-/
+
+import Mathlib.NumberTheory.PrimeCounting
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Tactic
+import Proofs.ChebyshevPNTBridge
+import Proofs.ChebyshevPNTBridgeOQ05
+import Proofs.ChebyshevPNTBridgeOQ06
+
+namespace ChebyshevPNTBridgeOQ06OQ01
+
+open Nat
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART I: THE `Nat.sqrt` LOGARITHM BRACKET  `½ log m − log 2 ≤ log(√m) ≤ ½ log m`
+
+`Nat.sqrt m` satisfies `(Nat.sqrt m)² ≤ m < (Nat.sqrt m + 1)²`.  The left inequality
+gives `log(√m) ≤ ½ log m`; for the right, `Nat.sqrt m ≥ 2` (when `m ≥ 4`) makes
+`Nat.sqrt m + 1 ≤ 2·Nat.sqrt m`, so `m < 4·(Nat.sqrt m)²` and hence
+`log m ≤ log 4 + 2 log(√m)`, i.e. `½ log m − log 2 ≤ log(√m)`.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Upper half of the bracket:** `log(Nat.sqrt m) ≤ ½ · log m`, from
+`(Nat.sqrt m)² ≤ m`.  Valid for every `m ≥ 1`. -/
+theorem log_natSqrt_le (m : ℕ) (hm : 1 ≤ m) :
+    Real.log (Nat.sqrt m) ≤ Real.log m / 2 := by
+  have hsqrt_pos : 0 < Nat.sqrt m := Nat.sqrt_pos.mpr hm
+  -- (Nat.sqrt m)^2 ≤ m as reals
+  have hle : ((Nat.sqrt m : ℝ)) ^ 2 ≤ (m : ℝ) := by
+    have : (Nat.sqrt m) ^ 2 ≤ m := by
+      have := Nat.sqrt_le' m   -- Nat.sqrt m * Nat.sqrt m ≤ m  (via sq)
+      nlinarith [Nat.sqrt_le' m]
+    exact_mod_cast this
+  have hsqrt_posR : (0 : ℝ) < (Nat.sqrt m : ℝ) := by exact_mod_cast hsqrt_pos
+  have hlog := Real.log_le_log (by positivity) hle
+  rw [Real.log_pow] at hlog
+  push_cast at hlog
+  -- hlog : 2 * log(√m) ≤ log m
+  linarith
+
+/-- **Lower half of the bracket:** `½ · log m − log 2 ≤ log(Nat.sqrt m)`, equivalently
+`log m ≤ log 4 + 2·log(Nat.sqrt m)`.  For `m ≥ 4` we have `Nat.sqrt m ≥ 2`, so
+`m < (Nat.sqrt m + 1)² ≤ (2·Nat.sqrt m)² = 4·(Nat.sqrt m)²`. -/
+theorem log_natSqrt_ge (m : ℕ) (hm : 4 ≤ m) :
+    Real.log m / 2 - Real.log 2 ≤ Real.log (Nat.sqrt m) := by
+  have hsqrt_ge2 : 2 ≤ Nat.sqrt m := by rw [Nat.le_sqrt]; omega
+  -- m < (Nat.sqrt m + 1)^2 ≤ 4 * (Nat.sqrt m)^2  in ℕ
+  have hlt : m < (Nat.sqrt m + 1) * (Nat.sqrt m + 1) := Nat.lt_succ_sqrt m
+  have hbound : m ≤ 4 * (Nat.sqrt m) ^ 2 := by nlinarith [hlt, hsqrt_ge2]
+  -- pass to ℝ
+  have hboundR : (m : ℝ) ≤ 4 * (Nat.sqrt m : ℝ) ^ 2 := by exact_mod_cast hbound
+  have hsqrt_posR : (0 : ℝ) < (Nat.sqrt m : ℝ) := by exact_mod_cast (by omega : 0 < Nat.sqrt m)
+  have hmR : (0 : ℝ) < (m : ℝ) := by exact_mod_cast (by omega : 0 < m)
+  have hlog := Real.log_le_log hmR hboundR
+  -- log m ≤ log (4 * (√m)^2) = log 4 + 2 log(√m)
+  rw [Real.log_mul (by norm_num) (by positivity), Real.log_pow] at hlog
+  -- log 4 = 2 * log 2
+  have hlog4 : Real.log 4 = 2 * Real.log 2 := by
+    rw [show (4 : ℝ) = 2 ^ 2 by norm_num, Real.log_pow]; ring
+  rw [hlog4] at hlog
+  push_cast at hlog
+  linarith
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART II: THE TWO-SIDED SANDWICH
+
+Both elementary Chebyshev bounds on `π(m)` in one statement, each in its natural
+normalisation, for every `m ≥ 4`.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **The Chebyshev density sandwich.**  For every `m ≥ 4`, the prime-counting
+function is squeezed between the OQ-05 lower bound and the OQ-06 upper bound:
+
+    (⌊m/2⌋·log 4 − log(m+1)) / log m  ≤  π(m)  ≤  m·log 4 / log(√m) + √m,
+
+with `√m = Nat.sqrt m`.  The two leading densities are `log 2` (lower) and
+`2 log 4` (upper), the elementary Chebyshev gap. -/
+theorem primeCounting_sandwich (m : ℕ) (hm : 4 ≤ m) :
+    ((m / 2 : ℕ) * Real.log 4 - Real.log (m + 1)) / Real.log m
+        ≤ (Nat.primeCounting m : ℝ)
+      ∧ (Nat.primeCounting m : ℝ)
+        ≤ (m : ℝ) * Real.log 4 / Real.log (Nat.sqrt m) + (Nat.sqrt m : ℝ) :=
+  ⟨ChebyshevPNTBridgeOQ05.primeCounting_ge_div_log m (by omega),
+   ChebyshevPNTBridgeOQ06.primeCounting_le_div_log_sqrt m hm⟩
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART III: UPPER BOUND ON THE COMMON `π(m)·log m` SCALE
+
+OQ-05's lower bound is stated as a bound on `π(m)·log m`; OQ-06's upper bound uses
+`log(√m)` instead.  Using the bracket `log(√m) ≥ ½ log m − log 2` we renormalise the
+upper bound onto the same `π(m)·log m` scale, so both halves of Chebyshev's theorem
+are finally expressed against the identical quantity.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Upper bound on `π(m)·log m`, companion to OQ-05's `primeCounting_mul_log_lower`.**
+For every `m ≥ 4`,
+
+    π(m) · log m  ≤  2·(m·log 4 + √m·log √m)  +  2·log 2 · π(m).
+
+Obtained from OQ-06's `π(m)·log(√m) ≤ m·log 4 + √m·log √m` by replacing the small
+denominator `log(√m)` with its bracket lower bound `½·log m − log 2`. The residual
+`2·log 2·π(m)` is lower order relative to the `m·log 4` leading term, so the upper
+density `limsup π(m)·log m / m ≤ 2 log 4` is unaffected. -/
+theorem primeCounting_mul_log_upper (m : ℕ) (hm : 4 ≤ m) :
+    (Nat.primeCounting m : ℝ) * Real.log m
+      ≤ 2 * ((m : ℝ) * Real.log 4 + (Nat.sqrt m : ℝ) * Real.log (Nat.sqrt m))
+          + 2 * Real.log 2 * (Nat.primeCounting m : ℝ) := by
+  have hpi_nonneg : (0 : ℝ) ≤ (Nat.primeCounting m : ℝ) := by positivity
+  -- OQ-06 upper bound on π(m)·log(√m)
+  have hupper := ChebyshevPNTBridgeOQ06.primeCounting_mul_log_sqrt_le m hm
+  -- bracket: log(√m) ≥ ½ log m − log 2, so π(m)·log(√m) ≥ π(m)·(½ log m − log 2)
+  have hbr := log_natSqrt_ge m hm
+  have hmul : (Nat.primeCounting m : ℝ) * (Real.log m / 2 - Real.log 2)
+      ≤ (Nat.primeCounting m : ℝ) * Real.log (Nat.sqrt m) :=
+    mul_le_mul_of_nonneg_left hbr hpi_nonneg
+  -- chain and clear the 1/2
+  nlinarith [hupper, hmul]
+
+#check log_natSqrt_le              -- log(√m) ≤ ½ log m
+#check log_natSqrt_ge              -- ½ log m − log 2 ≤ log(√m)
+#check primeCounting_sandwich      -- two-sided Chebyshev sandwich
+#check primeCounting_mul_log_upper -- upper bound on the common π(m)·log m scale
+
+end ChebyshevPNTBridgeOQ06OQ01

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "chebyshev-pnt-bridge-oq-06-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 39
+    },
+    "type": "context",
+    "title": "Making the Integer-Square-Root Density Reading Rigorous",
+    "content": "The sibling OQ-06 bounds the prime-counting function by π(m) ≤ m·log 4 / log(Nat.sqrt m) + √m, with the INTEGER square root √m = Nat.sqrt m in the denominator. Reading off the density limsup π(x)·log x / x ≤ 2 log 4 informally replaces log(Nat.sqrt m) by ½ log m — but Nat.sqrt is the integer root, so that substitution carries an O(1) error in the logarithm. This entry pins the error down exactly with the bracket ½ log m − log 2 ≤ log(Nat.sqrt m) ≤ ½ log m (all m ≥ 4), then uses it to package both Chebyshev halves into one sandwich and to align the OQ-06 upper bound with the π(m)·log m scale of OQ-05. 0 axioms, 0 sorries.",
+    "mathContext": "$\\tfrac12\\log m - \\log 2 \\le \\log(\\lfloor\\sqrt m\\rfloor) \\le \\tfrac12\\log m$ for $m \\ge 4$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "prime-counting function π",
+      "Chebyshev's theorem",
+      "integer square root Nat.sqrt",
+      "order of magnitude Θ(x/log x)"
+    ],
+    "prerequisites": [
+      "the sibling OQ-05 and OQ-06 Chebyshev bounds",
+      "defining inequalities of Nat.sqrt",
+      "Real.log basics"
+    ]
+  },
+  {
+    "id": "ann-bracket",
+    "proofId": "chebyshev-pnt-bridge-oq-06-oq-01",
+    "range": {
+      "startLine": 52,
+      "endLine": 101
+    },
+    "type": "insight",
+    "title": "The Bracket: ½ log m − log 2 ≤ log(Nat.sqrt m) ≤ ½ log m",
+    "content": "Two theorems pin log(Nat.sqrt m) between ½ log m and ½ log m − log 2. The UPPER half log_natSqrt_le is easy: (Nat.sqrt m)² ≤ m (Nat.sqrt_le'), so taking logs and using log((√m)²) = 2 log(√m) gives log(√m) ≤ ½ log m, valid for all m ≥ 1. The LOWER half log_natSqrt_ge is the only non-trivial direction and needs m ≥ 4: then Nat.le_sqrt gives Nat.sqrt m ≥ 2, hence Nat.sqrt m + 1 ≤ 2·Nat.sqrt m, so from m < (Nat.sqrt m + 1)² (Nat.lt_succ_sqrt) we get the crude but clean m < 4·(Nat.sqrt m)². Taking logs and expanding log(4·(√m)²) = 2 log 2 + 2 log(√m) yields log m ≤ 2 log 2 + 2 log(√m), i.e. ½ log m − log 2 ≤ log(√m).",
+    "mathContext": "$(\\lfloor\\sqrt m\\rfloor)^2 \\le m < (\\lfloor\\sqrt m\\rfloor+1)^2 \\le 4(\\lfloor\\sqrt m\\rfloor)^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.sqrt_le'",
+      "Nat.lt_succ_sqrt",
+      "Nat.le_sqrt",
+      "Real.log_pow / Real.log_mul"
+    ],
+    "prerequisites": [
+      "(Nat.sqrt m)² ≤ m < (Nat.sqrt m + 1)²",
+      "Nat.sqrt m ≥ 2 for m ≥ 4",
+      "monotonicity of Real.log"
+    ]
+  },
+  {
+    "id": "ann-sandwich",
+    "proofId": "chebyshev-pnt-bridge-oq-06-oq-01",
+    "range": {
+      "startLine": 102,
+      "endLine": 123
+    },
+    "type": "insight",
+    "title": "The Two-Sided Sandwich: Both Chebyshev Halves at Once",
+    "content": "primeCounting_sandwich states, for every m ≥ 4, both (⌊m/2⌋·log 4 − log(m+1))/log m ≤ π(m) and π(m) ≤ m·log 4/log(√m) + √m, as a single ⟨lower, upper⟩ pair. No new analysis: the lower half is exactly ChebyshevPNTBridgeOQ05.primeCounting_ge_div_log (whose hypothesis 2 ≤ m follows from m ≥ 4) and the upper half is exactly ChebyshevPNTBridgeOQ06.primeCounting_le_div_log_sqrt. The two leading densities are log 2 (lower) and 2 log 4 (upper) — the elementary Chebyshev gap.",
+    "mathContext": "$\\dfrac{\\lfloor m/2\\rfloor\\log 4 - \\log(m+1)}{\\log m} \\le \\pi(m) \\le \\dfrac{m\\log 4}{\\log\\lfloor\\sqrt m\\rfloor} + \\sqrt m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ChebyshevPNTBridgeOQ05.primeCounting_ge_div_log",
+      "ChebyshevPNTBridgeOQ06.primeCounting_le_div_log_sqrt",
+      "two-sided estimate",
+      "Chebyshev density gap"
+    ],
+    "prerequisites": [
+      "the OQ-05 lower-density theorem",
+      "the OQ-06 upper-density theorem"
+    ]
+  },
+  {
+    "id": "ann-common-scale",
+    "proofId": "chebyshev-pnt-bridge-oq-06-oq-01",
+    "range": {
+      "startLine": 124,
+      "endLine": 156
+    },
+    "type": "insight",
+    "title": "Renormalising the Upper Bound onto the π(m)·log m Scale",
+    "content": "OQ-05's lower bound lives on the π(m)·log m scale, while OQ-06's upper bound uses log(√m). primeCounting_mul_log_upper aligns them: starting from OQ-06's π(m)·log(√m) ≤ m·log 4 + √m·log √m and the bracket lower bound log(√m) ≥ ½ log m − log 2 (multiplied by π(m) ≥ 0 via mul_le_mul_of_nonneg_left), it derives π(m)·log m ≤ 2·(m·log 4 + √m·log √m) + 2·log 2·π(m). The residual 2 log 2·π(m) is lower order relative to the m·log 4 leading term, so the upper density limsup π(m)·log m / m ≤ 2 log 4 is unaffected — exactly the point of pinning the bracket. The final nlinarith clears the ½ introduced by the bracket.",
+    "mathContext": "$\\pi(m)\\log m \\le 2\\big(m\\log 4 + \\sqrt m\\,\\log\\sqrt m\\big) + 2\\log 2\\cdot\\pi(m)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ChebyshevPNTBridgeOQ06.primeCounting_mul_log_sqrt_le",
+      "mul_le_mul_of_nonneg_left",
+      "common-scale normalisation",
+      "lower-order error term"
+    ],
+    "prerequisites": [
+      "the OQ-06 π(m)·log(√m) bound",
+      "the bracket lower bound log(√m) ≥ ½ log m − log 2",
+      "π(m) ≥ 0"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/index.ts
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevPNTBridgeOQ06OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevPntBridgeOq06Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevPntBridgeOq06Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevPntBridgeOq06Oq01Data: ProofData = {
+  proof: chebyshevPntBridgeOq06Oq01Proof,
+  annotations: chebyshevPntBridgeOq06Oq01Annotations,
+}

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-01/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "chebyshev-pnt-bridge-oq-06-oq-01",
+  "title": "The Nat.sqrt Logarithm Bracket and the Two-Sided Chebyshev Sandwich",
+  "slug": "chebyshev-pnt-bridge-oq-06-oq-01",
+  "description": "Makes rigorous the asymptotic reading of the elementary Chebyshev density bounds. The sibling OQ-06 states the upper bound π(m) ≤ m·log 4 / log(√m) + √m with the integer square root √m = Nat.sqrt m in the denominator; reading off limsup π(x)·log x / x ≤ 2 log 4 informally substitutes log(√m) ≈ ½ log m, which is NOT free because Nat.sqrt is the integer root. This entry pins down the exact bracket ½·log m − log 2 ≤ log(Nat.sqrt m) ≤ ½·log m (all m ≥ 4), derived purely from the defining inequalities (Nat.sqrt m)² ≤ m < (Nat.sqrt m + 1)² (lower half via m < 4·(Nat.sqrt m)²). It then packages the OQ-05 lower bound and the OQ-06 upper bound into a single two-sided sandwich, and renormalises the OQ-06 upper bound onto the common π(m)·log m scale of OQ-05 so both halves of Chebyshev's theorem are expressed against the identical quantity. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Pafnuty Chebyshev",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_function",
+    "date": "1852",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ06OQ01.lean",
+    "tags": [
+      "number-theory",
+      "prime-counting",
+      "chebyshev",
+      "analytic-number-theory",
+      "prime-number-theorem",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sqrt_le'",
+        "description": "(Nat.sqrt m)² ≤ m; the upper half of the bracket log(√m) ≤ ½ log m comes from taking logs of this defining lower inequality of the integer square root",
+        "module": "Mathlib.Algebra.Order.Ring.Nat"
+      },
+      {
+        "theorem": "Nat.lt_succ_sqrt",
+        "description": "m < (Nat.sqrt m + 1)²; combined with Nat.sqrt m ≥ 2 (m ≥ 4) it yields m < 4·(Nat.sqrt m)², the lower half of the bracket ½ log m − log 2 ≤ log(√m)",
+        "module": "Mathlib.Algebra.Order.Ring.Nat"
+      },
+      {
+        "theorem": "Nat.le_sqrt",
+        "description": "characterisation a ≤ Nat.sqrt m ↔ a² ≤ m; used to establish Nat.sqrt m ≥ 2 for m ≥ 4, the step that makes Nat.sqrt m + 1 ≤ 2·Nat.sqrt m",
+        "module": "Mathlib.Algebra.Order.Ring.Nat"
+      },
+      {
+        "theorem": "Real.log_le_log",
+        "description": "monotonicity of log on positive reals; applied to (√m)² ≤ m and to m ≤ 4·(√m)² to transfer the integer inequalities to the logarithmic bracket",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.log_pow / Real.log_mul",
+        "description": "log(xⁿ) = n·log x and log(xy) = log x + log y; expand log((√m)²) = 2 log(√m) and log(4·(√m)²) = log 4 + 2 log(√m) = 2 log 2 + 2 log(√m)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "log_natSqrt_le: the upper half of the bracket log(Nat.sqrt m) ≤ ½·log m for all m ≥ 1, from (Nat.sqrt m)² ≤ m via log monotonicity and Real.log_pow",
+      "log_natSqrt_ge: the lower half ½·log m − log 2 ≤ log(Nat.sqrt m) for m ≥ 4, the non-trivial direction — Nat.sqrt m ≥ 2 makes Nat.sqrt m + 1 ≤ 2·Nat.sqrt m so m < (Nat.sqrt m + 1)² ≤ 4·(Nat.sqrt m)², giving log m ≤ log 4 + 2 log(√m) = 2 log 2 + 2 log(√m)",
+      "primeCounting_sandwich: the two elementary Chebyshev bounds on π(m) in one statement for every m ≥ 4 — the OQ-05 lower density and the OQ-06 upper density conjoined verbatim",
+      "primeCounting_mul_log_upper: the OQ-06 upper bound renormalised onto the common π(m)·log m scale of OQ-05 by substituting the bracket lower bound log(√m) ≥ ½ log m − log 2, yielding π(m)·log m ≤ 2·(m·log 4 + √m·log √m) + 2·log 2·π(m) — the residual 2 log 2·π(m) is lower order so the upper density limsup π(m)·log m / m ≤ 2 log 4 is unaffected"
+    ],
+    "axiomCount": 0,
+    "lineCount": 162,
+    "assumptions": "None — fully verified from Mathlib and the sibling bridge files OQ-05 and OQ-06 with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide. The bracket constant log 2 in ½ log m − log 2 ≤ log(Nat.sqrt m) is a uniform O(1) gap from the crude bound m < 4·(Nat.sqrt m)² (it is loose for large m, where the true gap → 0, but holds for all m ≥ 4); the sharp Chebyshev density constants and the full PNT limit remain separate open questions of the parent bridge.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's 1852 estimate places π(x) between two constant multiples of x/log x, the right order of magnitude decades before the sharp Prime Number Theorem of 1896. In the formalized bridge the upper half was exported (OQ-06) with the integer square root Nat.sqrt m sitting in the denominator log(Nat.sqrt m). Informal accounts blur log(Nat.sqrt m) into ½ log m to read off the density constant 2 log 4, but the integer square root differs from the real one by an O(1) amount in the logarithm. This entry replaces that hand-wave with an exact two-sided bracket and uses it to align both Chebyshev halves on a common scale.",
+    "problemStatement": "The OQ-06 upper bound is stated with denominator log(Nat.sqrt m), while the OQ-05 lower bound lives on the π(m)·log m scale. To compare them — and to justify the density reading limsup π(m)·log x / x ≤ 2 log 4 — one must control log(Nat.sqrt m) against ½ log m precisely, not just asymptotically. State the exact bracket and consolidate the two bounds.",
+    "text": "Establishes ½·log m − log 2 ≤ log(Nat.sqrt m) ≤ ½·log m for all m ≥ 4 from the defining inequalities of the integer square root, packages the OQ-05 and OQ-06 bounds into one two-sided sandwich, and renormalises the upper bound onto the π(m)·log m scale.",
+    "proofStrategy": "Part I — the bracket. Upper half: (Nat.sqrt m)² ≤ m (Nat.sqrt_le'); take logs and use log((√m)²) = 2 log(√m) to get log(√m) ≤ ½ log m. Lower half: for m ≥ 4, Nat.le_sqrt gives Nat.sqrt m ≥ 2, so Nat.sqrt m + 1 ≤ 2·Nat.sqrt m and m < (Nat.sqrt m + 1)² ≤ 4·(Nat.sqrt m)² (Nat.lt_succ_sqrt + nlinarith); take logs and expand log(4·(√m)²) = 2 log 2 + 2 log(√m) to get ½ log m − log 2 ≤ log(√m). Part II conjoins the parent OQ-05 lower bound and the OQ-06 upper bound verbatim for m ≥ 4. Part III multiplies the OQ-06 form π(m)·log(√m) ≤ m·log 4 + √m·log √m by replacing log(√m) with its bracket lower bound (mul_le_mul_of_nonneg_left, then nlinarith to clear the ½), producing the upper bound on π(m)·log m.",
+    "keyInsights": [
+      "The substitution log(Nat.sqrt m) ≈ ½ log m used to read off the Chebyshev upper density is not free: the integer square root forces an O(1) correction, captured exactly by the additive log 2 in the bracket",
+      "The bracket's lower half is the only non-trivial direction; it rests entirely on the single elementary step Nat.sqrt m + 1 ≤ 2·Nat.sqrt m (valid once Nat.sqrt m ≥ 2), which upgrades m < (√m+1)² to m < 4·(√m)²",
+      "The bracket constant log 2 is not asymptotically sharp — it comes from the crude step m < 4·(√m)² and the true gap ½ log m − log(√m) tends to 0 as m grows — but it is a clean uniform O(1) constant, which is all the density application needs",
+      "Renormalising the upper bound onto the π(m)·log m scale shows the OQ-06 denominator switch from log m to log(√m) costs only a lower-order 2 log 2·π(m) term, leaving the leading density 2 log 4 intact"
+    ],
+    "prerequisites": [
+      "the prime-counting function π and the sibling OQ-05 / OQ-06 Chebyshev bounds",
+      "the defining inequalities of the integer square root Nat.sqrt",
+      "elementary Real.log inequalities and monotonicity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring framing OQ-06·OQ-01: pin the integer-square-root logarithm bracket and use it to consolidate the two Chebyshev halves onto a common scale."
+    },
+    {
+      "id": "bracket",
+      "title": "The Nat.sqrt logarithm bracket",
+      "startLine": 52,
+      "endLine": 101,
+      "summary": "log_natSqrt_le and log_natSqrt_ge: ½ log m − log 2 ≤ log(Nat.sqrt m) ≤ ½ log m for m ≥ 4, from (√m)² ≤ m < (√m+1)² ≤ 4·(√m)²."
+    },
+    {
+      "id": "sandwich",
+      "title": "The two-sided Chebyshev sandwich",
+      "startLine": 102,
+      "endLine": 123,
+      "summary": "primeCounting_sandwich: the OQ-05 lower density and the OQ-06 upper density on π(m) conjoined in one statement for every m ≥ 4."
+    },
+    {
+      "id": "common-scale",
+      "title": "Upper bound on the common π(m)·log m scale",
+      "startLine": 124,
+      "endLine": 156,
+      "summary": "primeCounting_mul_log_upper: substituting the bracket lower bound for log(√m) renormalises the OQ-06 upper bound onto the π(m)·log m scale of OQ-05, with only a lower-order 2 log 2·π(m) residual."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, no native_decide) entry that makes the asymptotic reading of the Chebyshev upper bound rigorous. The exact bracket ½ log m − log 2 ≤ log(Nat.sqrt m) ≤ ½ log m replaces the informal log(√m) ≈ ½ log m, the two-sided sandwich states both Chebyshev halves at once, and the renormalised upper bound aligns OQ-06 with the π(m)·log m scale of OQ-05.",
+    "implications": "Supplies the missing O(1) control on log(Nat.sqrt m) that turns the OQ-06 quotient bound into an honest density statement, and gives downstream entries both Chebyshev halves on a single common scale rather than two incompatible normalisations.",
+    "openQuestions": [
+      "Combine the two-sided sandwich with the OQ-05·OQ-01 order form to state the fully aligned Θ(x/log x) bound directly from log(√m), removing the denominator mismatch entirely.",
+      "Sharpen the lower-order 2 log 2·π(m) residual into an explicit o(m) bound to recover limsup π(m)·log m / m ≤ 2 log 4 as a formal limit statement.",
+      "Extend the bracket to Real.sqrt and continuous x ≥ 2, removing the integer-square-root correction altogether."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-06",
+      "relationship": "parent",
+      "description": "Direct parent supplying the upper bound π(m) ≤ m·log 4 / log(√m) + √m and the π(m)·log(√m) form primeCounting_mul_log_sqrt_le that is renormalised here"
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-05",
+      "relationship": "uses",
+      "description": "Supplies the lower density ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m (primeCounting_ge_div_log), the lower half of the two-sided sandwich"
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-05-oq-01",
+      "relationship": "sibling",
+      "description": "Companion consolidation of the two Chebyshev halves; that entry packages the clean order form, this one supplies the exact Nat.sqrt logarithm bracket and aligns the denominators"
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge",
+      "relationship": "ancestor",
+      "description": "Root of the bridge chain establishing π(x) = Θ(x/log x)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.PrimeCounting",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Tactic",
+      "Proofs.ChebyshevPNTBridge",
+      "Proofs.ChebyshevPNTBridgeOQ05",
+      "Proofs.ChebyshevPNTBridgeOQ06"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "ChebyshevPNTBridgeOQ06OQ01",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/ChebyshevPNTBridgeOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New research entry **chebyshev-pnt-bridge-oq-06-oq-01** — *The Nat.sqrt Logarithm Bracket and the Two-Sided Chebyshev Sandwich*.

The sibling OQ-06 states the elementary Chebyshev upper bound with the **integer** square root in the denominator:
`π(m) ≤ m·log 4 / log(Nat.sqrt m) + √m`. Reading off `limsup π(x)·log x / x ≤ 2 log 4` informally substitutes `log(√m) ≈ ½ log m`, which is **not free** because `Nat.sqrt` is the integer root. This entry makes that step rigorous.

## Contributions (4 theorems, 0 sorries, 0 axioms)

- **`log_natSqrt_le`** / **`log_natSqrt_ge`** — the exact bracket
  `½·log m − log 2 ≤ log(Nat.sqrt m) ≤ ½·log m` (m ≥ 4), from the defining inequalities
  `(Nat.sqrt m)² ≤ m < (Nat.sqrt m+1)² ≤ 4·(Nat.sqrt m)²` (lower half via `Nat.sqrt m ≥ 2 ⇒ Nat.sqrt m+1 ≤ 2·Nat.sqrt m`).
- **`primeCounting_sandwich`** — both Chebyshev bounds on `π(m)` in one statement for every `m ≥ 4`
  (OQ-05 lower density ∧ OQ-06 upper density).
- **`primeCounting_mul_log_upper`** — the OQ-06 upper bound renormalised onto the common `π(m)·log m`
  scale of OQ-05 by substituting the bracket lower bound, with only a lower-order `2·log 2·π(m)` residual.

## Verification

- Typechecks against Mathlib v4.26.0 (single-file `lake env lean`; Docker host was wedged).
- `#print axioms` on all four theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely 0-axiom / verified.
- Gallery integration (meta.json, annotations.json, index.ts) added; `pnpm gallery:check-size` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)