### PR TITLE
Enrich Erdős #340 OQ-05 B_h upper bound (index.ts + enums + structure)

### DIFF
--- a/src/data/proofs/erdos-340-greedy-sidon-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/erdos-340-greedy-sidon-oq-05-oq-01/annotations.json
@@ -2,73 +2,126 @@
   {
     "id": "ann-statement",
     "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
-    "range": { "startLine": 65, "endLine": 79 },
-    "type": "definition",
+    "range": {
+      "startLine": 65,
+      "endLine": 79
+    },
+    "type": "theorem",
     "title": "The Analytic Upper Bound and Its Explicit Constant",
     "content": "The theorem asserts a single constant `C > 0`, depending only on `h`, that caps every `B_h` set:\n\n```lean\ntheorem IsBh.card_le_rpow {h : ℕ} (hh : 1 ≤ h) :\n    ∃ C : ℝ, 0 < C ∧ ∀ (N : ℕ) (A : Finset ℕ), A ⊆ Finset.Icc 1 N → IsBh h A →\n      (A.card : ℝ) ≤ C * (N : ℝ) ^ ((h : ℝ)⁻¹) := by\n```\n\nThe witness is `C = (h − 1) + C₂coef` where `C₂coef = (h·h!)^{1/h}` (`set C₂coef` at line 73). Positivity of `C₂coef` follows from `Real.rpow_pos_of_pos` applied to the positive base `h!·h`, and `linarith` discharges `0 < C` from `0 < C₂coef` together with `1 ≤ h`.",
     "mathContext": "For a $B_h$ set $A \\subseteq \\{1, \\dots, N\\}$ the claim is $|A| \\le \\big((h-1) + (h\\cdot h!)^{1/h}\\big)\\, N^{1/h}$. The exponent $1/h$ is the counting-bound ceiling; the constant is fully explicit.",
-    "significance": "central",
-    "relatedConcepts": ["B_h set", "Real.rpow", "explicit constant", "Erdős #340"],
-    "prerequisites": ["erdos-340-greedy-sidon-oq-05", "Real power function"]
+    "significance": "critical",
+    "relatedConcepts": [
+      "B_h set",
+      "Real.rpow",
+      "explicit constant",
+      "Erdős #340"
+    ],
+    "prerequisites": [
+      "erdos-340-greedy-sidon-oq-05",
+      "Real power function"
+    ]
   },
   {
     "id": "ann-edge-n0",
     "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
-    "range": { "startLine": 81, "endLine": 87 },
-    "type": "technique",
+    "range": {
+      "startLine": 81,
+      "endLine": 87
+    },
+    "type": "tactic",
     "title": "The N = 0 Edge Case",
     "content": "```lean\nrcases Nat.eq_zero_or_pos N with hN0 | hN1\n· subst hN0\n  have hAe : A = ∅ := by\n    rw [Finset.Icc_eq_empty (by omega)] at hAN\n    exact Finset.subset_empty.mp hAN\n  simp [hAe, Real.zero_rpow hexp_ne]\n```\n\nWhen `N = 0` the containing interval `Icc 1 0` is empty, forcing `A = ∅` and `|A| = 0`. The right-hand side is `C · 0^{1/h}`, and `Real.zero_rpow` (with `1/h ≠ 0`) makes `0^{1/h} = 0`, so the inequality is `0 ≤ 0`. Splitting this case off lets the main argument freely assume `N ≥ 1` (needed for `N^{1/h} ≥ 1`).",
     "mathContext": "The interval $[1, 0]$ is empty, so the only $B_h$ subset is $\\varnothing$. Since $1/h \\ne 0$, $0^{1/h} = 0$ and the bound holds trivially.",
     "significance": "supporting",
-    "relatedConcepts": ["Finset.Icc_eq_empty", "Real.zero_rpow"],
+    "relatedConcepts": [
+      "Finset.Icc_eq_empty",
+      "Real.zero_rpow"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-counting-to-power",
     "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
-    "range": { "startLine": 88, "endLine": 101 },
-    "type": "key-step",
+    "range": {
+      "startLine": 88,
+      "endLine": 101
+    },
+    "type": "theorem",
     "title": "From the Counting Bound to a Polynomial Inequality in |A|",
     "content": "The combinatorial input is the OQ-05 counting bound and Mathlib's reverse binomial estimate:\n\n```lean\nhave hcc : Nat.choose A.card h ≤ h * N := hA.choose_card_le hh hAN\nhave hpc : ((k + 1 - h : ℕ) : ℝ) ^ h / (h ! : ℝ) ≤ (Nat.choose k h : ℝ) :=\n  Nat.pow_le_choose (α := ℝ) h k\n```\n\n`IsBh.choose_card_le` gives `C(k, h) ≤ h·N` (with `k = |A|`); `Nat.pow_le_choose` gives the reverse `(k+1−h)^h / h! ≤ C(k, h)` directly over `ℝ`. Chaining them (clearing the `h!` denominator with `div_le_iff₀`, then `mul_le_mul_of_nonneg_left`) yields the key polynomial inequality `(k+1−h)^h ≤ h! · (h · N)` over `ℝ` (line 100).",
     "mathContext": "Binomial squeeze: $\\frac{(k+1-h)^h}{h!} \\le \\binom{k}{h} \\le hN$, hence $(k+1-h)^h \\le h!\\,h\\,N$. This converts the cardinality $k$ into a degree-$h$ polynomial bounded linearly in $N$.",
-    "significance": "central",
-    "relatedConcepts": ["Nat.pow_le_choose", "IsBh.choose_card_le", "binomial coefficient bounds"],
-    "prerequisites": ["erdos-340-greedy-sidon-oq-05"]
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.pow_le_choose",
+      "IsBh.choose_card_le",
+      "binomial coefficient bounds"
+    ],
+    "prerequisites": [
+      "erdos-340-greedy-sidon-oq-05"
+    ]
   },
   {
     "id": "ann-take-roots",
     "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
-    "range": { "startLine": 102, "endLine": 114 },
-    "type": "key-step",
+    "range": {
+      "startLine": 102,
+      "endLine": 114
+    },
+    "type": "theorem",
     "title": "Taking h-th Roots via Real.rpow Monotonicity",
     "content": "With `q = k+1−h ≥ 0`, applying `x ↦ x^{1/h}` to `q^h ≤ h!·h·N` recovers `q` on the left and splits the constant on the right:\n\n```lean\ncalc q = (q ^ h) ^ ((h : ℝ)⁻¹) := (Real.pow_rpow_inv_natCast hq0 hh0).symm\n  _ ≤ ((h ! : ℝ) * ((h : ℝ) * (N : ℝ))) ^ ((h : ℝ)⁻¹) :=\n      Real.rpow_le_rpow (by positivity) hqh_le (by positivity)\n```\n\n`Real.pow_rpow_inv_natCast` is the identity `(q^h)^{1/h} = q` for `q ≥ 0`; `Real.rpow_le_rpow` is monotonicity of the root on `[0, ∞)`; and `Real.mul_rpow` (line 113) factors `(h!·h·N)^{1/h} = (h!·h)^{1/h}·N^{1/h} = C₂coef · N^{1/h}`. The result is `q ≤ C₂coef · N^{1/h}`.",
     "mathContext": "Raising both sides of $q^h \\le h!\\,h\\,N$ to the power $1/h$ (monotone for nonnegative arguments) gives $q = (q^h)^{1/h} \\le (h!\\,h)^{1/h} N^{1/h}$, where $(ab)^{1/h} = a^{1/h}b^{1/h}$ splits off the constant.",
-    "significance": "central",
-    "relatedConcepts": ["Real.pow_rpow_inv_natCast", "Real.rpow_le_rpow", "Real.mul_rpow"],
-    "prerequisites": ["Real power function"]
+    "significance": "critical",
+    "relatedConcepts": [
+      "Real.pow_rpow_inv_natCast",
+      "Real.rpow_le_rpow",
+      "Real.mul_rpow"
+    ],
+    "prerequisites": [
+      "Real power function"
+    ]
   },
   {
     "id": "ann-absorb-defect",
     "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
-    "range": { "startLine": 115, "endLine": 135 },
-    "type": "technique",
+    "range": {
+      "startLine": 115,
+      "endLine": 135
+    },
+    "type": "tactic",
     "title": "Absorbing the Additive Defect h − 1",
     "content": "The binomial bound controls `k+1−h`, not `k` directly. The elementary `ℕ` inequality recovers `k`:\n\n```lean\nhave hk_nat : k ≤ (k + 1 - h) + (h - 1) := by omega\n```\n\nThis holds even when `k < h` (truncated subtraction makes `k+1−h = 0`), which `omega` handles. Transported to `ℝ` it gives `k ≤ q + (h−1)`. Because `N ≥ 1` forces `N^{1/h} ≥ 1` (via `Real.rpow_le_rpow` on `1 ≤ N`), the constant term is absorbed: `(h−1) ≤ (h−1)·N^{1/h}` (`le_mul_of_one_le_right`). A final `linarith` combines `k ≤ q + (h−1)`, `q ≤ C₂coef·N^{1/h}`, and `(h−1) ≤ (h−1)·N^{1/h}` into `k ≤ ((h−1) + C₂coef)·N^{1/h}`.",
     "mathContext": "Since $k \\le (k{+}1{-}h) + (h{-}1)$ and $N^{1/h} \\ge 1$, the additive defect is folded into the leading coefficient: $k \\le (h{-}1)N^{1/h} + (h!\\,h)^{1/h}N^{1/h} = C_2\\,N^{1/h}$.",
     "significance": "supporting",
-    "relatedConcepts": ["omega", "truncated subtraction", "le_mul_of_one_le_right", "linarith"],
+    "relatedConcepts": [
+      "omega",
+      "truncated subtraction",
+      "le_mul_of_one_le_right",
+      "linarith"
+    ],
     "prerequisites": []
   },
   {
     "id": "ann-open-gap",
     "proofId": "erdos-340-greedy-sidon-oq-05-oq-01",
-    "range": { "startLine": 18, "endLine": 26 },
+    "range": {
+      "startLine": 18,
+      "endLine": 26
+    },
     "type": "insight",
     "title": "What Remains Open: the Exponent Gap",
     "content": "Pairing this upper bound with the OQ-05 greedy lower bound `exists_isBh_rpow_lower` brackets the maximal $B_h$ size $\\sigma_h(N)$:\n\n  `C₁ · N^{1/(2h−1)} ≤ σ_h(N) ≤ C₂ · N^{1/h}`.\n\nThe two exponents `1/(2h−1)` (greedy/probabilistic) and `1/h` (counting) do **not** match. Closing that gap is the genuinely open quantitative content of Erdős #340. At `h = 2` it is the classical Sidon question — `1/3` (greedy) versus `1/2` (counting) — and is deliberately **not** resolved here; only the two endpoints are formalized.",
     "mathContext": "The Bose–Chowla construction shows the counting ceiling $N^{1/h}$ is attained to within $(1-o(1))$ for $B_h$ sets, so for $h \\ge 2$ the upper bound is essentially sharp; the open problem is whether the *greedy* lower exponent $1/(2h-1)$ can be pushed toward it.",
-    "significance": "central",
-    "relatedConcepts": ["Sidon set", "Bose–Chowla construction", "exists_isBh_rpow_lower", "open problem"],
-    "prerequisites": ["erdos-340-greedy-sidon-oq-05"]
+    "significance": "critical",
+    "relatedConcepts": [
+      "Sidon set",
+      "Bose–Chowla construction",
+      "exists_isBh_rpow_lower",
+      "open problem"
+    ],
+    "prerequisites": [
+      "erdos-340-greedy-sidon-oq-05"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-340-greedy-sidon-oq-05-oq-01/index.ts
+++ b/src/data/proofs/erdos-340-greedy-sidon-oq-05-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos340BhUpperBound.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos340GreedySidonOq05Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos340GreedySidonOq05Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos340GreedySidonOq05Oq01Data: ProofData = {
+  proof: erdos340GreedySidonOq05Oq01Proof,
+  annotations: erdos340GreedySidonOq05Oq01Annotations,
+}

--- a/src/data/proofs/erdos-340-greedy-sidon-oq-05-oq-01/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon-oq-05-oq-01/meta.json
@@ -82,7 +82,78 @@
     "keyInsights": [
       "The upper bound is a clean h-th-root of the combinatorial counting bound: Nat.pow_le_choose turns C(k,h) ≤ h·N into (k+1−h)^h ≤ h!·h·N, and rpow monotonicity does the rest — no further B_h structure is needed.",
       "The additive defect h−1 from the binomial lower bound is harmless: since N ≥ 1 forces N^{1/h} ≥ 1, it is absorbed into the constant, giving a single clean coefficient C₂ = (h−1) + (h·h!)^{1/h}.",
-      "Pairing IsBh.card_le_rpow with exists_isBh_rpow_lower brackets σ_h(N) in [C₁·N^{1/(2h-1)}, C₂·N^{1/h}]; the exponent gap is precisely the open core of Erdős #340 (1/3 vs 1/2 at h=2) and is deliberately left open."
+      "Pairing IsBh.card_le_rpow with exists_isBh_rpow_lower brackets σ_h(N) in [C₁·N^{1/(2h-1)}, C₂·N^{1/h}]; the exponent gap is precisely the open core of Erdős #340 (1/3 vs 1/2 at h=2) and is deliberately left open.",
+      "The asymmetry of the bracket is the whole story: by Bose–Chowla the counting ceiling N^{1/h} is attained up to a (1−o(1)) factor, so the upper bound is essentially sharp and not where progress is needed — all the open difficulty lives in lifting the greedy lower exponent 1/(2h−1). Formalizing the easy-but-explicit side anchors exactly how far the hard side has to travel."
     ]
-  }
+  },
+  "sections": [
+    {
+      "id": "docstring-overview",
+      "title": "Docstring: the bracket and the open gap",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Module docstring recalling the OQ-05 companion results (the greedy lower bound exists_isBh_rpow_lower and the counting bound IsBh.choose_card_le), stating the analytic upper bound |A| ≤ C₂·N^{1/h} this file supplies, and framing the exponent gap 1/(2h−1) vs 1/h as the open quantitative core of Erdős #340 (the 1/3 vs 1/2 Sidon gap at h=2)."
+    },
+    {
+      "id": "statement-and-constant",
+      "title": "Theorem statement and the explicit constant",
+      "startLine": 50,
+      "endLine": 80,
+      "summary": "Declaration of IsBh.card_le_rpow and construction of the witness constant C = (h−1) + C₂coef with C₂coef = (h·h!)^{1/h}. Positivity of C₂coef comes from Real.rpow_pos_of_pos on the positive base h!·h, and linarith establishes 0 < C from 0 < C₂coef and 1 ≤ h."
+    },
+    {
+      "id": "edge-case-n-zero",
+      "title": "The N = 0 edge case",
+      "startLine": 81,
+      "endLine": 87,
+      "summary": "Dispatches N = 0: the interval Icc 1 0 is empty, forcing A = ∅, and Real.zero_rpow (using 1/h ≠ 0) makes the right-hand side 0, so the bound is 0 ≤ 0. This frees the main case to assume N ≥ 1."
+    },
+    {
+      "id": "counting-to-polynomial",
+      "title": "From the counting bound to a polynomial inequality",
+      "startLine": 88,
+      "endLine": 101,
+      "summary": "Combines IsBh.choose_card_le (C(k,h) ≤ h·N) with Mathlib's reverse binomial bound Nat.pow_le_choose ((k+1−h)^h/h! ≤ C(k,h)), clearing the h! denominator (div_le_iff₀) and scaling (mul_le_mul_of_nonneg_left), to reach (k+1−h)^h ≤ h!·(h·N) over ℝ."
+    },
+    {
+      "id": "take-roots",
+      "title": "Taking h-th roots via rpow monotonicity",
+      "startLine": 102,
+      "endLine": 114,
+      "summary": "Applies x ↦ x^{1/h} to the polynomial inequality. Real.pow_rpow_inv_natCast recovers q = k+1−h on the left, Real.rpow_le_rpow gives monotonicity on the right, and Real.mul_rpow factors the constant, yielding q ≤ C₂coef·N^{1/h}."
+    },
+    {
+      "id": "absorb-defect",
+      "title": "Absorbing the additive defect and finishing",
+      "startLine": 115,
+      "endLine": 137,
+      "summary": "Recovers k from q via the ℕ inequality k ≤ (k+1−h)+(h−1) (omega, valid even when k < h). Using N^{1/h} ≥ 1 (from 1 ≤ N) absorbs h−1 into (h−1)·N^{1/h} (le_mul_of_one_le_right), and a final linarith assembles k ≤ ((h−1)+C₂coef)·N^{1/h}."
+    }
+  ],
+  "conclusion": {
+    "summary": "IsBh.card_le_rpow gives, for every h ≥ 1, an explicit constant C = (h−1) + (h·h!)^{1/h} > 0 such that every B_h set A ⊆ {1,…,N} satisfies |A| ≤ C·N^{1/h}, proved 0-axiom by taking h-th roots of the combinatorial counting bound C(|A|,h) ≤ h·N. Paired with the OQ-05 greedy lower bound exists_isBh_rpow_lower, it pins the maximal B_h size σ_h(N) inside the bracket C₁·N^{1/(2h−1)} ≤ σ_h(N) ≤ C₂·N^{1/h}.",
+    "implications": "The result completes the analytic bracket that the Erdős #340 literature states for B_h growth and makes the constant on the upper side fully explicit rather than asymptotic. Because the Bose–Chowla construction shows the N^{1/h} ceiling is achieved up to (1−o(1)), the upper bound is essentially tight: it certifies that the entire open quantitative content of the problem lives in the lower bound's exponent 1/(2h−1), not the upper one. The proof also illustrates a reusable pattern — converting a combinatorial counting inequality into a sharp size bound by a single application of rpow monotonicity, with truncated-subtraction defects absorbed into the leading constant.",
+    "openQuestions": [
+      "Can the greedy/probabilistic lower exponent 1/(2h−1) be improved toward the counting ceiling 1/h? For h = 2 this is whether dense Sidon sets in {1,…,N} can exceed the greedy N^{1/3} order — the classical 1/3 vs 1/2 gap that remains open.",
+      "What is the true second-order behavior of σ_h(N) just below the N^{1/h} ceiling — i.e. can the explicit constant C₂ = (h−1)+(h·h!)^{1/h} be sharpened toward the Bose–Chowla optimal leading coefficient?",
+      "Does the upper-bound argument transfer verbatim to B_h^+ sets (distinct sums without the ordering convention) or to B_h sets in higher-dimensional or group settings, where the counting bound takes a different form?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "erdos-340-greedy-sidon",
+      "relationship": "Foundational infrastructure",
+      "description": "Defines IsBh and proves the OQ-05 results this entry builds on: the counting bound IsBh.choose_card_le (C(|A|,h) ≤ h·N) that is the sole combinatorial input here, and the greedy lower bound exists_isBh_rpow_lower that pairs with this upper bound to bracket σ_h(N)."
+    },
+    {
+      "proofId": "erdos-340",
+      "relationship": "Parent problem",
+      "description": "The gallery's top-level Erdős #340 entry on the growth of the greedy Sidon sequence; this entry supplies the matching analytic upper bound for the general B_h (h ≥ 2) version of that growth question."
+    },
+    {
+      "proofId": "erdos-28-additive-bases",
+      "relationship": "Adjacent additive-combinatorics theme",
+      "description": "Another Erdős additive-combinatorics entry concerning the sizes of sumset-constrained sequences; shares the counting-bound-versus-construction tension that governs B_h and additive-basis growth rates."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `erdos-340-greedy-sidon-oq-05-oq-01` (0 prior passes, quality 71).

## Changes
- **Created missing `index.ts`** — without it Vite's loader cannot find the proof and the page shows "proof not found" on the live site. This was the highest-impact gap.
- **Fixed 6 invalid annotation enum values** (systemic defect tracked in #31246):
  - `type`: `technique`→`tactic`, `key-step`→`theorem`, and `definition`→`theorem` at the theorem-declaration line
  - `significance`: `central`→`critical`
  - Entry now passes `annotations:validate --strict` with **0 warnings**.
- **Added `sections[]`** (6) covering the docstring and all five proof phases (statement/constant, N=0 edge case, counting→polynomial, h-th roots, defect absorption).
- **Added `conclusion`** with summary, implications, and 3 open questions (the 1/(2h−1) vs 1/h exponent gap, sharpening C₂ toward Bose–Chowla, and B_h^+/group generalizations).
- **Added `crossReferences`** to `erdos-340-greedy-sidon` (foundational infra), `erdos-340` (parent problem), and `erdos-28-additive-bases` (adjacent theme).
- **+1 keyInsight** on the Bose–Chowla sharpness of the upper bound (now 4 total).

## Validation
- `gallery:check-size`: within caps (meta.json 13 KB ≤ 60 KB).
- `annotations:validate --strict`: no warnings for this entry.
- JSON parses cleanly; mathematical content unchanged and accurate (0-axiom status preserved).