### PR TITLE
research(bounded-prime-gaps-oq-02): target-θ equipartition wrapper [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ02.lean
@@ -476,6 +476,28 @@ theorem EHAtLevel_discrepancySum_up_arith (f : ℕ → ℝ → ℝ) {θ₀ δ : 
   refine EHAtLevel_discrepancySum_up_chain f hmono hlow' (fun k A hA => ?_)
   simpa only [Nat.cast_succ] using hband k A hA
 
+/-- **Target-level ascent (equipartition wrapper).**  The packaged form of
+`EHAtLevel_discrepancySum_up_arith` that reaches a *prescribed* target level `θ ≥ θ₀` in a
+chosen number `n ≥ 1` of equal blocks.  It fixes the step `δ := (θ - θ₀)/n` internally and
+discharges the algebra `θ₀ + n·δ = θ`, so the caller only supplies the base EH bound at `θ₀`
+together with an EH-type bound on each of the `n` equal sub-bands
+`θ₀ + k·δ → θ₀ + (k+1)·δ`, and obtains EH at the exact endpoint `θ` (not at the cosmetic
+`θ₀ + n·δ`).  This is the directly usable equipartition form of the dyadic ascent. -/
+theorem EHAtLevel_discrepancySum_up_target (f : ℕ → ℝ → ℝ) {θ₀ θ : ℝ} {n : ℕ}
+    (hn : 0 < n) (hθ : θ₀ ≤ θ)
+    (hlow : EHAtLevel (discrepancySum f) θ₀)
+    (hband : ∀ k : ℕ, ∀ A : ℝ, 0 < A → ∃ C : ℝ, 0 < C ∧ ∀ x : ℝ, 2 ≤ x →
+        discrepancyBand f (θ₀ + k * ((θ - θ₀) / n)) (θ₀ + (k + 1) * ((θ - θ₀) / n)) x
+          ≤ C * x / (Real.log x) ^ A) :
+    EHAtLevel (discrepancySum f) θ := by
+  have hn' : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  set δ := (θ - θ₀) / n with hδdef
+  have hδ : 0 ≤ δ := by
+    rw [hδdef]; exact div_nonneg (by linarith) (by positivity)
+  have key := EHAtLevel_discrepancySum_up_arith f hδ hlow hband n
+  have heq : θ₀ + (n : ℝ) * δ = θ := by rw [hδdef]; field_simp; ring
+  rwa [heq] at key
+
 /-! ## Grounding the hierarchy in the genuine von-Mangoldt discrepancy
 
 Everything above treats the per-modulus weight `f` abstractly, requiring only
@@ -619,5 +641,21 @@ theorem EHAtLevel_vonMangoldt_up_arith {θ₀ δ : ℝ} (hδ : 0 ≤ δ)
           ≤ C * x / (Real.log x) ^ A) :
     ∀ n : ℕ, EHAtLevel vonMangoldtDiscrepancySum (θ₀ + n * δ) :=
   EHAtLevel_discrepancySum_up_arith vonMangoldtWeight hδ hlow hband
+
+/-- **Target-level ascent for the genuine sum.**  The von-Mangoldt specialization of
+`EHAtLevel_discrepancySum_up_target`: from the genuine EH bound at base `θ₀` together with a
+bound on the real worst-case von-Mangoldt discrepancy of each of `n` equal modulus blocks
+`θ₀ + k·δ → θ₀ + (k+1)·δ` (`δ = (θ - θ₀)/n`), the genuine level of distribution reaches the
+*exact* prescribed target `θ ≥ θ₀`.  This is the directly usable equipartition form of the
+dyadic attack on Elliott–Halberstam — the caller names the endpoint `θ` and the block count
+`n`, and the `θ₀ + n·δ = θ` algebra is discharged internally. -/
+theorem EHAtLevel_vonMangoldt_up_target {θ₀ θ : ℝ} {n : ℕ}
+    (hn : 0 < n) (hθ : θ₀ ≤ θ)
+    (hlow : EHAtLevel vonMangoldtDiscrepancySum θ₀)
+    (hband : ∀ k : ℕ, ∀ A : ℝ, 0 < A → ∃ C : ℝ, 0 < C ∧ ∀ x : ℝ, 2 ≤ x →
+        discrepancyBand vonMangoldtWeight (θ₀ + k * ((θ - θ₀) / n))
+            (θ₀ + (k + 1) * ((θ - θ₀) / n)) x ≤ C * x / (Real.log x) ^ A) :
+    EHAtLevel vonMangoldtDiscrepancySum θ :=
+  EHAtLevel_discrepancySum_up_target vonMangoldtWeight hn hθ hlow hband
 
 end BoundedPrimeGapsOQ02

--- a/research/problems/bounded-prime-gaps-oq-02/knowledge.md
+++ b/research/problems/bounded-prime-gaps-oq-02/knowledge.md
@@ -41,6 +41,29 @@ chain lemma's `L (k+1)` is `θ₀ + ↑(k+1)*δ`. Bridge when applying the chain
 
 File now: 623 lines, 36 theorems, 12 defs, 0 axioms/sorries.
 
+## Session 2026-06-28 (researcher-1) — target-θ wrapper (packaged equipartition)
+
+Closed the "target-θ wrapper" outward direction flagged in the prior session: package
+the arith chain so the caller names the *endpoint* `θ` and the block count `n`, with the
+`θ₀ + n·δ = θ` algebra discharged internally (`δ := (θ-θ₀)/n`).
+
+- `EHAtLevel_discrepancySum_up_target` (abstract weight `f`): `n ≥ 1`, `θ₀ ≤ θ`, EH at base
+  `θ₀`, plus an EH-type bound on each of the `n` equal sub-bands `θ₀+k·δ → θ₀+(k+1)·δ`
+  ⟹ EH at the *exact* target `θ` (not the cosmetic `θ₀+n·δ`). Proof: `set δ := (θ-θ₀)/n`,
+  derive `hδ ≥ 0` from `θ₀ ≤ θ` (div_nonneg + positivity), apply the arith chain at `n`,
+  then `rwa [heq]` with `heq : θ₀ + n·δ = θ`.
+- `EHAtLevel_vonMangoldt_up_target`: genuine von-Mangoldt specialization (one-line
+  delegation).
+
+GOTCHA: `heq` proof — `rw [hδdef]; field_simp` does NOT close `θ₀ + n·((θ-θ₀)/n) = θ`; it
+clears the division to leave `θ₀ + (θ-θ₀) = θ`, which then needs a trailing `ring`. So
+`by rw [hδdef]; field_simp; ring`. `field_simp` picks up `hn' : (↑n:ℝ) ≠ 0` from context
+(supply it explicitly via `Nat.cast_ne_zero.mpr hn.ne'`).
+
+File now: 661 lines, 38 theorems, 12 defs, 0 axioms/0 sorries. Verified offline
+`lake env lean` EXIT 0; both new theorems `#print axioms` = {propext, Classical.choice,
+Quot.sound} only.
+
 ## Verification gotchas (2026-06-27 session)
 - Docker build infra was DOWN (containerd `meta.db` I/O error). Verified instead via
   `cd proofs && LAKE_UNSAFE=1 lake env lean Proofs/BoundedPrimeGapsOQ02.lean` (EXIT 0).


### PR DESCRIPTION
## Summary

Closes the **target-θ wrapper** outward direction flagged in the prior session's
`knowledge.md` for the axiom-free Elliott–Halberstam level-of-distribution formalization
(`Proofs/BoundedPrimeGapsOQ02.lean`).

The existing `EHAtLevel_*_up_arith` lemmas give EH at `θ₀ + n·δ` for an explicit step `δ`.
This PR packages that into the directly usable form where the caller names the **exact
target level** `θ ≥ θ₀` and a block count `n ≥ 1`, and the wrapper picks `δ := (θ-θ₀)/n`
internally and discharges the `θ₀ + n·δ = θ` algebra — so the conclusion is EH at the exact
endpoint `θ`, not the cosmetic `θ₀ + n·δ`.

## New theorems

- `EHAtLevel_discrepancySum_up_target` (abstract weight `f`): from EH at base `θ₀` plus an
  EH-type bound on each of the `n` equal sub-bands `θ₀+k·δ → θ₀+(k+1)·δ`, conclude EH at the
  prescribed target `θ`.
- `EHAtLevel_vonMangoldt_up_target`: the genuine von-Mangoldt specialization (one-line
  delegation), matching the file's abstract+genuine pairing pattern.

## Verification

- File: 661 lines, 38 theorems, 12 defs, **0 axioms / 0 sorries**.
- Offline `lake env lean Proofs/BoundedPrimeGapsOQ02.lean` → EXIT 0.
- Docker build `Proofs.BoundedPrimeGapsOQ02` → EXIT 0.
- `#print axioms` for both new theorems = `{propext, Classical.choice, Quot.sound}` only
  (no `sorryAx`, no `Lean.ofReduceBool`).

Elliott–Halberstam itself remains genuinely open and is **not** axiomatized — the analytic
EH-type band bounds enter only as per-theorem hypotheses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)