### PR TITLE
audit(cycleV66): chebyshev-pnt-bridge-oq-06-oq-01 CLEAN [Tier A]

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25625,6 +25625,12 @@
       "lastAudited": "2026-06-28T10:32:12Z",
       "result": "clean",
       "issues": []
+    },
+    "chebyshev-pnt-bridge-oq-06-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T10:45:06Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — cycleV66

**Target:** \`chebyshev-pnt-bridge-oq-06-oq-01\` (merged #31255) — freshest gallery addition.

### Verdict: CLEAN — Tier A (fully formalized)

| Check | Result |
|-------|--------|
| sorries | 0 (matches meta) |
| axiom declarations | 0 (matches meta) |
| True-stubs | 0 |
| status / badge | \`verified\` / \`verified\` — accurate |

### Evidence
- File \`Proofs/ChebyshevPNTBridgeOQ06OQ01.lean\`: 4 theorems, all fully proved.
- Bracket lemmas \`log_natSqrt_le\`/\`log_natSqrt_ge\` are genuine derivations from Mathlib \`Nat.sqrt\` primitives (\`Nat.sqrt_le'\`, \`Nat.lt_succ_sqrt\`, \`Nat.le_sqrt\`) + \`Real.log_le_log\`/\`log_pow\`/\`log_mul\`. No hidden tricks.
- \`primeCounting_sandwich\` assembles the project's **own** verified OQ-05 (\`primeCounting_ge_div_log\`) and OQ-06 (\`primeCounting_le_div_log_sqrt\`) bridge results — *not* a Mathlib delegation. All three parent files (\`ChebyshevPNTBridge\`, \`…OQ05\`, \`…OQ06\`) confirmed 0-sorry / 0-axiom / 0-stub, so the whole dependency chain is clean.
- Title is precise ("Nat.sqrt Logarithm Bracket and the Two-Sided Chebyshev Sandwich") — no overclaim of independently proving Chebyshev's theorem.
- **Risk: LOW.** No Millennium problem, no axiom-vs-verified mismatch, no unqualified famous-theorem title.

### Standing false positives reconfirmed honest
- **erdos-57-oq-04** — heuristic flags "axiom undercount". The lone axiom is the host \`erdos_57\` (deep Liu–Montgomery theorem) in \`Erdos57Problem.lean\`; the contributed lemmas don't touch it and \`#print axioms\` reports only foundational axioms. Fully disclosed in \`assumptions\`.
- **erdos-156** — heuristic flags "sorry mismatch (chain 15)". Entry is openly \`formalized\`/\`wip\` with \`sorries: 3\` matching its main companion; the "15" counts transitively-imported Aristotle scratch files, not the claimed scope.

Gallery: 4127/4127 audited, 0 unaudited, 0 critical issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)