### PR TITLE
research(erdos-728-oq-04): multinomial factorial-divisibility barrier [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos728FactorialDivisibilityOQ04.lean
+++ b/proofs/Proofs/Erdos728FactorialDivisibilityOQ04.lean
@@ -144,11 +144,101 @@ theorem log_barrier_of_prime {a b n : ℕ} (h : a ! * b ! ∣ n !) :
   have := log_barrier_prime 2 h
   omega
 
+/-!
+## Multinomial / multi-factorial form of the barrier
+
+The two-factorial barrier `log_barrier_prime` generalizes verbatim to an arbitrary
+product of factorials `a₁! · … · a_k! ∣ n!` — the natural setting of multinomial
+coefficients `n! / (a₁! ⋯ a_k!)`.  The valuation step is identical: `v_p` of a product
+of (nonzero) factorials is the sum of the `v_p(aᵢ!)`, so the divisibility forces
+`∑ᵢ v_p(aᵢ!) ≤ v_p(n!)`; scaling by `(p − 1)` and substituting Legendre
+`m = (p − 1)·v_p(m!) + s_p(m)` term-by-term yields
+
+  `∑ᵢ aᵢ + s_p(n) ≤ n + ∑ᵢ s_p(aᵢ)`   for every prime `p`.
+
+We phrase the family as a `Multiset ℕ` (so repeated values — e.g. the central
+multinomial `aᵢ = n/k` — are allowed), and give the indexed `Finset` form as a
+corollary.  Specializing the multiset to `{a, b}` recovers `log_barrier_prime`.
+-/
+
+/-- **`v_p` of a product of factorials is the sum of the factorial valuations.**
+`v_p(∏ᵢ aᵢ!) = ∑ᵢ v_p(aᵢ!)`.  Multiset induction off `padicValNat.mul`, using that
+every factorial is nonzero so the product is too. -/
+theorem padicValNat_prod_factorials (p : ℕ) [Fact p.Prime] (s : Multiset ℕ) :
+    padicValNat p ((s.map (fun a => a !)).prod)
+      = (s.map (fun a => padicValNat p (a !))).sum := by
+  induction s using Multiset.induction with
+  | empty => simp
+  | cons a t ih =>
+    have hne : (t.map (fun a => a !)).prod ≠ 0 := by
+      apply Multiset.prod_ne_zero
+      intro hmem
+      obtain ⟨b, -, hb⟩ := Multiset.mem_map.mp hmem
+      exact absurd hb (Nat.factorial_ne_zero b)
+    simp only [Multiset.map_cons, Multiset.prod_cons, Multiset.sum_cons]
+    rw [padicValNat.mul (Nat.factorial_ne_zero a) hne, ih]
+
+/-- **Legendre's additive identity, summed over a multiset.**
+`∑ᵢ aᵢ = (p − 1)·∑ᵢ v_p(aᵢ!) + ∑ᵢ s_p(aᵢ)`, the term-by-term lift of
+`factorial_pval_add_digitsum`. -/
+theorem legendre_sum_multiset (p : ℕ) [Fact p.Prime] (s : Multiset ℕ) :
+    s.sum = (p - 1) * (s.map (fun a => padicValNat p (a !))).sum
+            + (s.map (fun a => (Nat.digits p a).sum)).sum := by
+  induction s using Multiset.induction with
+  | empty => simp
+  | cons a t ih =>
+    simp only [Multiset.sum_cons, Multiset.map_cons]
+    have ha := factorial_pval_add_digitsum p a
+    rw [Nat.mul_add]
+    omega
+
+/-- **The multinomial barrier (sharp, prime-uniform).**  For any finite family of
+naturals presented as a multiset `s` (repeats allowed) with `∏ᵢ aᵢ! ∣ n!`,
+`∑ᵢ aᵢ + s_p(n) ≤ n + ∑ᵢ s_p(aᵢ)` for every prime `p`.  This is the multinomial
+generalization of `log_barrier_prime`; the two-factorial case is `s = {a, b}`.
+Proof: the divisibility gives `∑ᵢ v_p(aᵢ!) ≤ v_p(n!)` (`padicValNat_prod_factorials`
++ `padicValNat_dvd_iff_le`); scaling by `(p − 1)` and substituting the summed Legendre
+identity (`legendre_sum_multiset`) and Legendre for `n` lets `omega` finish, atomizing
+the shared `(p − 1)·v_p(·!)` products. -/
+theorem log_barrier_prime_multiset {p : ℕ} [Fact p.Prime] {s : Multiset ℕ} {n : ℕ}
+    (h : (s.map (fun a => a !)).prod ∣ n !) :
+    s.sum + (Nat.digits p n).sum
+      ≤ n + (s.map (fun a => (Nat.digits p a).sum)).sum := by
+  have hmono : padicValNat p ((s.map (fun a => a !)).prod) ≤ padicValNat p (n !) :=
+    (padicValNat_dvd_iff_le (Nat.factorial_ne_zero n)).mp
+      (dvd_trans (pow_padicValNat_dvd (p := p) (n := (s.map (fun a => a !)).prod)) h)
+  rw [padicValNat_prod_factorials p s] at hmono
+  have hscaled := mul_le_mul_left' hmono (p - 1)
+  have hleg := legendre_sum_multiset p s
+  have hn := factorial_pval_add_digitsum p n
+  omega
+
+/-- **The multinomial barrier, indexed `Finset` form.**  For a finite family
+`a : ι → ℕ` over `s : Finset ι` with `∏ i ∈ s, (a i)! ∣ n!`,
+`(∑ i ∈ s, a i) + s_p(n) ≤ n + ∑ i ∈ s, s_p(a i)` for every prime `p`.  This is the
+form matching the multinomial coefficient `n! / ∏ᵢ (a i)!`; it is the multiset barrier
+applied to `s.val.map a`. -/
+theorem log_barrier_prime_finset {ι : Type*} {p : ℕ} [Fact p.Prime]
+    {s : Finset ι} {a : ι → ℕ} {n : ℕ} (h : (∏ i ∈ s, (a i)!) ∣ n !) :
+    (∑ i ∈ s, a i) + (Nat.digits p n).sum
+      ≤ n + ∑ i ∈ s, (Nat.digits p (a i)).sum := by
+  have h' : ((s.val.map a).map (fun x => x !)).prod ∣ n ! := by
+    rw [Multiset.map_map]; exact h
+  have key := log_barrier_prime_multiset (p := p) (s := s.val.map a) (n := n) h'
+  rw [Multiset.map_map] at key
+  have e1 : (∑ i ∈ s, a i) = (s.val.map a).sum := rfl
+  have e2 : (∑ i ∈ s, (Nat.digits p (a i)).sum)
+      = (s.val.map (fun i => (Nat.digits p (a i)).sum)).sum := rfl
+  rw [e1, e2]
+  simpa [Function.comp] using key
+
 #check @factorial_val_add_digitsum
 #check @factorial_pval_add_digitsum
 #check @log_barrier
 #check @log_barrier_prime
 #check @log_barrier_length
+#check @log_barrier_prime_multiset
+#check @log_barrier_prime_finset
 
 -- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
 -- no sorryAx, no Lean.ofReduceBool.
@@ -159,5 +249,9 @@ theorem log_barrier_of_prime {a b n : ℕ} (h : a ! * b ! ∣ n !) :
 #print axioms log_barrier_of_prime
 #print axioms digitsum_two_le_length
 #print axioms log_barrier_length
+#print axioms padicValNat_prod_factorials
+#print axioms legendre_sum_multiset
+#print axioms log_barrier_prime_multiset
+#print axioms log_barrier_prime_finset
 
 end Erdos728FactorialDivisibilityOQ04

--- a/research/problems/erdos-728-factorial-divisibility-oq-04/knowledge.md
+++ b/research/problems/erdos-728-factorial-divisibility-oq-04/knowledge.md
@@ -39,3 +39,44 @@ propext/Classical.choice/Quot.sound only.
 - Multinomial barrier: a₁!·…·a_k! ∣ n! ⇒ ∑aᵢ + s_p(n) ≤ n + ∑s_p(aᵢ).
 - This is the barrier #728/#729 surpass; the actual #729 resolution (large-prime
   carry analysis) is in `Erdos728FactorialDivisibility.lean`, not here.
+
+## Session 2026-06-28 (researcher-10) — Multinomial barrier [DONE]
+
+**Mode**: FRESH (claimed from pool, knowledge score 14, MODERATE)
+**Outcome**: progress — resolved the listed **multinomial / multi-factorial** follow-up.
+
+### What I did
+Extended the file from the two-factorial barrier to an arbitrary product of
+factorials (4 new theorems, 167–233):
+- `padicValNat_prod_factorials p s`: `v_p((∏ aᵢ!)) = ∑ v_p(aᵢ!)` — Multiset
+  induction off `padicValNat.mul`; nonzero product via `Multiset.prod_ne_zero`.
+- `legendre_sum_multiset p s`: `∑ aᵢ = (p−1)·∑ v_p(aᵢ!) + ∑ s_p(aᵢ)` — Multiset
+  induction; `Nat.mul_add` then `omega` (atomizing `(p−1)·v_p(aᵢ!)`).
+- `log_barrier_prime_multiset`: `(∏ aᵢ!) ∣ n! ⇒ ∑ aᵢ + s_p(n) ≤ n + ∑ s_p(aᵢ)`
+  for every prime p. Scale `hmono` by `(p−1)` via `mul_le_mul_left'`, feed
+  `legendre_sum_multiset` + Legendre-for-n to `omega`.
+- `log_barrier_prime_finset`: indexed `Finset` reindexing (the multinomial-coefficient
+  form `n!/∏(a i)!`). Bridge `∑ i ∈ s, f i = (s.val.map f).sum` holds by `rfl`;
+  `Multiset.map_map` + `Function.comp` align the maps.
+
+Now **11 theorems, 0 def, 0 axioms, 0 sorries**. Verified via
+`lake env lean` against Mathlib 4.26.0; `#print axioms` on all four new theorems →
+`propext/Classical.choice/Quot.sound` only (no sorryAx, no Lean.ofReduceBool).
+
+### Key technique / gotcha
+- The whole generalization is omega-after-substitution again: the only genuinely new
+  pieces are the two multiset-induction helpers; everything else is the p=2/two-term
+  argument verbatim. Multiset (not Finset) is the right primitive — repeats allowed,
+  clean cons recursion — with the Finset form a `rfl`/`map_map` reindex.
+- `mul_le_mul_left' : a ≤ b → ∀ c, c*a ≤ c*b` (ordered-monoid) is the robust scaler;
+  `Nat.mul_le_mul_left`'s signature has churned across Mathlib versions.
+
+### Files modified
+- proofs/Proofs/Erdos728FactorialDivisibilityOQ04.lean (7 → 11 theorems)
+- src/data/proofs/erdos-728-factorial-divisibility-oq-04/{meta,annotations}.json
+- src/data/research/problems/erdos-728-factorial-divisibility-oq-04.json
+
+### Still open
+- Sharpness of the multinomial barrier: characterize equality families
+  (central-multinomial extremal case).
+- Two-term equality families at p=2 (central binomial).

--- a/src/data/proofs/erdos-728-factorial-divisibility-oq-04/annotations.json
+++ b/src/data/proofs/erdos-728-factorial-divisibility-oq-04/annotations.json
@@ -2,85 +2,223 @@
   {
     "id": "ann-header",
     "proofId": "erdos-728-factorial-divisibility-oq-04",
-    "range": { "startLine": 1, "endLine": 34 },
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
     "type": "concept",
     "title": "The Elementary Barrier #728/#729 Surpass",
     "content": "The classical baseline that Erdős #728 and #729 are built to break: if a!·b! ∣ n! then a + b ≤ n + O(log n). Erdős's proof needs only the prime 2. By Legendre's formula v₂(m!) = m − s₂(m) (with s₂ the binary digit sum), the divisibility forces v₂(a!) + v₂(b!) ≤ v₂(n!), i.e. (a − s₂a) + (b − s₂b) ≤ (n − s₂n), hence a + b ≤ n + s₂(a) + s₂(b), and each binary digit sum is O(log). This file formalizes that barrier exactly over ℕ — it is the lower bound the #728/#729 resolutions surpass, not a resolution of #729.",
     "mathContext": "$a!\\,b! \\mid n! \\Rightarrow a+b \\le n + s_2(a) + s_2(b) \\le n + O(\\log n)$.",
     "significance": "essential",
-    "relatedConcepts": ["Legendre's formula", "p-adic valuation", "binary digit sum", "Erdős #728", "Erdős #729"],
-    "prerequisites": ["factorial valuation", "base-2 expansion"]
+    "relatedConcepts": [
+      "Legendre's formula",
+      "p-adic valuation",
+      "binary digit sum",
+      "Erdős #728",
+      "Erdős #729"
+    ],
+    "prerequisites": [
+      "factorial valuation",
+      "base-2 expansion"
+    ]
   },
   {
     "id": "ann-legendre-2",
     "proofId": "erdos-728-factorial-divisibility-oq-04",
-    "range": { "startLine": 41, "endLine": 50 },
+    "range": {
+      "startLine": 41,
+      "endLine": 50
+    },
     "type": "theorem",
     "title": "Legendre's Formula at p = 2 (additive form)",
     "content": "factorial_val_add_digitsum: every m splits as m = v₂(m!) + s₂(m). This is v₂(m!) = m − s₂(m) rearranged to avoid truncated subtraction, read off from Mathlib's sub_one_mul_padicValNat_factorial at p = 2 (where the (p−1) factor is 1). The bound s₂(m) ≤ m (Nat.digit_sum_le) lets omega close it.",
     "mathContext": "$m = v_2(m!) + s_2(m)$, equivalently $v_2(m!) = m - s_2(m)$.",
     "significance": "essential",
-    "relatedConcepts": ["Legendre's formula", "padicValNat", "digit sum"],
-    "prerequisites": ["sub_one_mul_padicValNat_factorial", "Nat.digit_sum_le"]
+    "relatedConcepts": [
+      "Legendre's formula",
+      "padicValNat",
+      "digit sum"
+    ],
+    "prerequisites": [
+      "sub_one_mul_padicValNat_factorial",
+      "Nat.digit_sum_le"
+    ]
   },
   {
     "id": "ann-log-barrier",
     "proofId": "erdos-728-factorial-divisibility-oq-04",
-    "range": { "startLine": 53, "endLine": 68 },
+    "range": {
+      "startLine": 53,
+      "endLine": 68
+    },
     "type": "theorem",
     "title": "The Logarithmic Barrier (Legendre form)",
     "content": "log_barrier: a!·b! ∣ n! ⇒ a + b ≤ n + s₂(a) + s₂(b). The divisibility gives v₂(a!) + v₂(b!) ≤ v₂(n!) (via padicValNat_dvd_iff_le on pow_padicValNat_dvd, then padicValNat.mul to split the product). Substituting Legendre's m = v₂(m!) + s₂(m) for a, b, n and clearing the valuations with omega yields the bound. Only the prime 2 is used — Erdős's original elementary argument.",
     "mathContext": "$v_2(a!)+v_2(b!) \\le v_2(n!) \\Rightarrow a+b \\le n + s_2(a)+s_2(b)$.",
     "significance": "essential",
-    "relatedConcepts": ["factorial divisibility", "p-adic valuation", "Legendre's formula"],
-    "prerequisites": ["factorial_val_add_digitsum", "padicValNat_dvd_iff_le", "padicValNat.mul"]
+    "relatedConcepts": [
+      "factorial divisibility",
+      "p-adic valuation",
+      "Legendre's formula"
+    ],
+    "prerequisites": [
+      "factorial_val_add_digitsum",
+      "padicValNat_dvd_iff_le",
+      "padicValNat.mul"
+    ]
   },
   {
     "id": "ann-log-barrier-length",
     "proofId": "erdos-728-factorial-divisibility-oq-04",
-    "range": { "startLine": 70, "endLine": 89 },
+    "range": {
+      "startLine": 70,
+      "endLine": 89
+    },
     "type": "theorem",
     "title": "Explicit O(log) Form via Popcount ≤ Length",
     "content": "digitsum_two_le_length bounds the binary digit sum by the binary length (each base-2 digit is ≤ 1, so the sum ≤ the number of digits, via List.sum_le_card_nsmul). log_barrier_length then gives a + b ≤ n + len₂(a) + len₂(b) with len₂(m) = ⌊log₂ m⌋ + 1 for m > 0 — the a + b ≤ n + O(log n) barrier in fully explicit form.",
     "mathContext": "$s_2(m) \\le \\mathrm{len}_2(m)$, so $a+b \\le n + \\mathrm{len}_2(a) + \\mathrm{len}_2(b)$.",
     "significance": "supporting",
-    "relatedConcepts": ["popcount", "binary length", "logarithmic bound"],
-    "prerequisites": ["log_barrier", "List.sum_le_card_nsmul"]
+    "relatedConcepts": [
+      "popcount",
+      "binary length",
+      "logarithmic bound"
+    ],
+    "prerequisites": [
+      "log_barrier",
+      "List.sum_le_card_nsmul"
+    ]
   },
   {
     "id": "ann-legendre-p",
     "proofId": "erdos-728-factorial-divisibility-oq-04",
-    "range": { "startLine": 108, "endLine": 121 },
+    "range": {
+      "startLine": 108,
+      "endLine": 121
+    },
     "type": "theorem",
     "title": "Legendre at a General Prime p",
     "content": "factorial_pval_add_digitsum: m = (p − 1)·v_p(m!) + s_p(m) for every prime p. This is the prime-uniform additive form of Legendre's formula; at p = 2 the (p−1) factor collapses to 1, recovering factorial_val_add_digitsum. The (p−1) factor is exactly why Erdős's argument is most elementary at p = 2.",
     "mathContext": "$m = (p-1)\\,v_p(m!) + s_p(m)$, i.e. $v_p(m!) = \\dfrac{m - s_p(m)}{p-1}$.",
     "significance": "essential",
-    "relatedConcepts": ["Legendre's formula", "general prime", "base-p digit sum"],
-    "prerequisites": ["sub_one_mul_padicValNat_factorial", "Nat.digit_sum_le"]
+    "relatedConcepts": [
+      "Legendre's formula",
+      "general prime",
+      "base-p digit sum"
+    ],
+    "prerequisites": [
+      "sub_one_mul_padicValNat_factorial",
+      "Nat.digit_sum_le"
+    ]
   },
   {
     "id": "ann-log-barrier-prime",
     "proofId": "erdos-728-factorial-divisibility-oq-04",
-    "range": { "startLine": 123, "endLine": 139 },
+    "range": {
+      "startLine": 123,
+      "endLine": 139
+    },
     "type": "theorem",
     "title": "Prime-Uniform Sharp Barrier",
     "content": "log_barrier_prime: a!·b! ∣ n! ⇒ a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for EVERY prime p. Strictly stronger than the classical statement: it adds the s_p(n) term on the small side (dropped in log_barrier) and holds for an arbitrary prime, so one may take the prime minimizing the right-hand side. The valuation inequality v_p(a!) + v_p(b!) ≤ v_p(n!) is scaled by (p−1) (Nat.mul_le_mul + Nat.mul_add) and combined with Legendre via omega, which atomizes the shared (p−1)·v_p(·!) subterms. The prime 2 is optimal for the asymptotic O(log n) rate because s₂ grows slowest, but the inequality itself is prime-independent.",
     "mathContext": "$\\forall p \\text{ prime}: a+b+s_p(n) \\le n + s_p(a) + s_p(b)$.",
     "significance": "essential",
-    "relatedConcepts": ["prime-uniform bound", "sharpening", "Legendre's formula", "omega atomization"],
-    "prerequisites": ["factorial_pval_add_digitsum", "Nat.mul_le_mul"]
+    "relatedConcepts": [
+      "prime-uniform bound",
+      "sharpening",
+      "Legendre's formula",
+      "omega atomization"
+    ],
+    "prerequisites": [
+      "factorial_pval_add_digitsum",
+      "Nat.mul_le_mul"
+    ]
   },
   {
     "id": "ann-log-barrier-of-prime",
     "proofId": "erdos-728-factorial-divisibility-oq-04",
-    "range": { "startLine": 141, "endLine": 150 },
+    "range": {
+      "startLine": 141,
+      "endLine": 150
+    },
     "type": "theorem",
     "title": "Recovering the Classical Barrier (p = 2)",
     "content": "log_barrier_of_prime: specializing the prime-uniform sharp form to p = 2 and discarding the s₂(n) slack recovers exactly log_barrier (a + b ≤ n + s₂(a) + s₂(b)). This makes the generalization precise — the classical barrier is the p = 2 corner of the prime-uniform family.",
     "mathContext": "$p = 2$: drop $s_2(n) \\ge 0$ to get $a+b \\le n + s_2(a) + s_2(b)$.",
     "significance": "supporting",
-    "relatedConcepts": ["specialization", "classical barrier"],
-    "prerequisites": ["log_barrier_prime"]
+    "relatedConcepts": [
+      "specialization",
+      "classical barrier"
+    ],
+    "prerequisites": [
+      "log_barrier_prime"
+    ]
+  },
+  {
+    "id": "ann-multinomial-section",
+    "proofId": "erdos-728-factorial-divisibility-oq-04",
+    "range": {
+      "startLine": 147,
+      "endLine": 165
+    },
+    "type": "concept",
+    "title": "Multinomial Generalization of the Barrier",
+    "content": "The two-factorial barrier generalizes verbatim to an arbitrary product of factorials a_1!...a_k! | n! — the natural setting of multinomial coefficients n!/(a_1!...a_k!). The valuation step is identical: v_p of a product of (nonzero) factorials is the sum of the v_p(a_i!), so the divisibility forces (sum) v_p(a_i!) <= v_p(n!); scaling by (p-1) and substituting Legendre term-by-term gives (sum) a_i + s_p(n) <= n + (sum) s_p(a_i) for every prime p. This resolves the multi-factorial open question listed for this entry.",
+    "mathContext": "$\\prod_i a_i! \\mid n! \\Rightarrow \\sum_i a_i + s_p(n) \\le n + \\sum_i s_p(a_i)$ for every prime $p$.",
+    "significance": "essential",
+    "relatedConcepts": [
+      "multinomial coefficient",
+      "Legendre formula",
+      "p-adic valuation",
+      "multiset induction"
+    ],
+    "prerequisites": [
+      "product of factorials",
+      "factorial valuation"
+    ]
+  },
+  {
+    "id": "ann-multinomial-helpers",
+    "proofId": "erdos-728-factorial-divisibility-oq-04",
+    "range": {
+      "startLine": 167,
+      "endLine": 201
+    },
+    "type": "theorem",
+    "title": "Valuation-of-Product and Summed-Legendre Helpers",
+    "content": "Two multiset-induction lemmas powering the multinomial barrier. padicValNat_prod_factorials: v_p of the product of factorials equals the sum of v_p(a_i!), proved by Multiset.induction off padicValNat.mul (each factorial is nonzero, so the partial product is too). legendre_sum_multiset: (sum) a_i = (p-1)*(sum) v_p(a_i!) + (sum) s_p(a_i), the term-by-term lift of the single-number Legendre identity factorial_pval_add_digitsum, closed by omega after distributing (p-1).",
+    "mathContext": "$v_p(\\prod_i a_i!) = \\sum_i v_p(a_i!)$ and $\\sum_i a_i = (p-1)\\sum_i v_p(a_i!) + \\sum_i s_p(a_i)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiset induction",
+      "padicValNat.mul",
+      "Legendre formula"
+    ],
+    "prerequisites": [
+      "p-adic valuation is additive on products"
+    ]
+  },
+  {
+    "id": "ann-multinomial-barrier",
+    "proofId": "erdos-728-factorial-divisibility-oq-04",
+    "range": {
+      "startLine": 203,
+      "endLine": 233
+    },
+    "type": "theorem",
+    "title": "The Multinomial Barrier (multiset and Finset forms)",
+    "content": "log_barrier_prime_multiset: for any multiset s of naturals with the product of a_i! dividing n!, (sum) a_i + s_p(n) <= n + (sum) s_p(a_i) for every prime p. The divisibility gives (sum) v_p(a_i!) <= v_p(n!) via padicValNat_prod_factorials and padicValNat_dvd_iff_le; scaling by (p-1) (mul_le_mul_left) and substituting legendre_sum_multiset plus Legendre for n lets omega finish, atomizing the shared (p-1)*v_p products. log_barrier_prime_finset reindexes this to a Finset family a : iota -> N — the form matching the multinomial coefficient n!/(prod) (a i)!. Specializing to s = {a,b} recovers log_barrier_prime.",
+    "mathContext": "$\\sum_{i\\in s} a_i + s_p(n) \\le n + \\sum_{i\\in s} s_p(a_i)$ when $\\prod_{i\\in s}(a_i)! \\mid n!$.",
+    "significance": "essential",
+    "relatedConcepts": [
+      "multinomial coefficient",
+      "prime-uniform barrier",
+      "Finset big operators"
+    ],
+    "prerequisites": [
+      "padicValNat_prod_factorials",
+      "legendre_sum_multiset"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-728-factorial-divisibility-oq-04/meta.json
+++ b/src/data/proofs/erdos-728-factorial-divisibility-oq-04/meta.json
@@ -24,7 +24,9 @@
       "factorial_pval_add_digitsum: m = (p−1)·v_p(m!) + s_p(m) (Legendre at general prime p)",
       "log_barrier: a!·b! ∣ n! ⇒ a + b ≤ n + s₂(a) + s₂(b)",
       "log_barrier_prime: a!·b! ∣ n! ⇒ a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for every prime p (sharp, prime-uniform)",
-      "log_barrier_length: a!·b! ∣ n! ⇒ a + b ≤ n + len₂(a) + len₂(b) (explicit O(log) form)"
+      "log_barrier_length: a!·b! ∣ n! ⇒ a + b ≤ n + len₂(a) + len₂(b) (explicit O(log) form)",
+      "log_barrier_prime_multiset: prod of a_i! divides n! implies (sum) a_i + s_p(n) <= n + (sum) s_p(a_i) for every prime p (multinomial barrier, multiset form)",
+      "log_barrier_prime_finset: indexed Finset form of the multinomial barrier, matching the multinomial coefficient n!/(prod a_i!)"
     ],
     "references": [
       "Erdős problem #728: https://www.erdosproblems.com/728",
@@ -33,13 +35,13 @@
       "Legendre, A.-M. *Théorie des nombres* (1830) — the formula v_p(m!) = (m − s_p(m))/(p − 1)."
     ]
   },
-  "description": "Verified (0-axiom, 0-sorry) formalization of the elementary logarithmic barrier underlying Erdős #728/#729: a!·b! ∣ n! ⇒ a + b ≤ n + O(log n), proved from Legendre's formula using only the prime 2. This research session integrates the file into the gallery (it was previously committed un-integrated: not in the aggregator, no gallery metadata) and adds a prime-uniform sharpening — log_barrier_prime: a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for every prime p — strictly stronger than the classical p = 2 statement, from which log_barrier is recovered. 7 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "description": "Verified (0-axiom, 0-sorry) formalization of the elementary logarithmic barrier underlying Erdős #728/#729: a!·b! ∣ n! ⇒ a + b ≤ n + O(log n), proved from Legendre's formula using only the prime 2. This research session integrates the file into the gallery (it was previously committed un-integrated: not in the aggregator, no gallery metadata) and adds a prime-uniform sharpening — log_barrier_prime: a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for every prime p — strictly stronger than the classical p = 2 statement, from which log_barrier is recovered. 11 theorems, 0 definitions, 0 axioms, 0 sorries (this session adds the multinomial / multi-factorial generalization).",
   "conclusion": {
-    "summary": "Formalizes Erdős's elementary O(log n) barrier for factorial divisibility in exact Legendre/popcount form, and generalizes it to a prime-uniform bound holding for every prime p. All 7 theorems are machine-checked with only the foundational axioms (propext, Classical.choice, Quot.sound). This is foundational infrastructure — the lower bound that the #728/#729 resolutions surpass — not a resolution of #729 itself.",
-    "implications": "Provides a verified, reusable statement of the barrier in the same padicValNat/Legendre vocabulary used by the #728 resolution file, so future work on #729 (the large-prime carry analysis) can cite it directly. The prime-uniform form clarifies exactly why the prime 2 is the optimal elementary choice for the asymptotic rate while the inequality itself is prime-independent.",
+    "summary": "Formalizes Erdős's elementary O(log n) barrier for factorial divisibility in exact Legendre/popcount form, and generalizes it to a prime-uniform bound holding for every prime p. All 11 theorems are machine-checked with only the foundational axioms (propext, Classical.choice, Quot.sound). This is foundational infrastructure — the lower bound that the #728/#729 resolutions surpass — not a resolution of #729 itself.",
+    "implications": "Provides a verified, reusable statement of the barrier in the same padicValNat/Legendre vocabulary used by the #728 resolution file, so future work on #729 (the large-prime carry analysis) can cite it directly. The prime-uniform form clarifies exactly why the prime 2 is the optimal elementary choice for the asymptotic rate while the inequality itself is prime-independent. This session also generalizes the barrier from two factorials to an arbitrary product (the multinomial setting n!/(a_1!...a_k!)), via two self-contained multiset-induction helpers; the multiset and Finset forms resolve the multi-factorial open question previously listed for this entry.",
     "openQuestions": [
-      "Sharpness of the barrier: construct explicit infinite families of triples (a, b, n) with a!·b! ∣ n! achieving a + b = n + s₂(a) + s₂(b) − s₂(n) (equality in log_barrier_prime at p = 2), e.g. via the central binomial / multinomial cases, to show the popcount bound is attained.",
-      "Multi-factorial / multinomial barrier: extend to a₁!·…·a_k! ∣ n! ⇒ ∑ aᵢ + s_p(n) ≤ n + ∑ s_p(aᵢ), the natural generalization to multinomial coefficients, via the same Legendre argument."
+      "Sharpness of the barrier: construct explicit infinite families of triples (a, b, n) with a!*b! dividing n! achieving equality in log_barrier_prime at p = 2 (e.g. central binomial / multinomial cases), to show the popcount bound is attained.",
+      "Sharpness of the multinomial barrier: characterize the families (a_1,...,a_k; n) achieving equality (sum) a_i + s_p(n) = n + (sum) s_p(a_i), generalizing the central-multinomial extremal case."
     ]
   },
   "crossReferences": [
@@ -49,12 +51,16 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Nat"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
     "namespace": "Erdos728FactorialDivisibilityOQ04",
-    "lineCount": 163,
+    "lineCount": 257,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 11,
     "definitionCount": 0,
     "path": "Proofs/Erdos728FactorialDivisibilityOQ04.lean",
     "sorries": 0
@@ -82,12 +88,14 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 163,
-    "theoremCount": 7,
+    "lineCount": 257,
+    "theoremCount": 11,
     "definitionCount": 0,
-    "assumptions": "None. All 7 theorems are machine-checked; #print axioms reports only propext, Classical.choice, Quot.sound (no sorryAx, no custom axioms, no Lean.ofReduceBool). This file proves the elementary barrier that Erdős #728/#729 surpass; it is not a resolution of #729.",
+    "assumptions": "None. All 11 theorems are machine-checked; #print axioms reports only propext, Classical.choice, Quot.sound (no sorryAx, no custom axioms, no Lean.ofReduceBool). This file proves the elementary barrier that Erdős #728/#729 surpass; it is not a resolution of #729.",
     "mathlib_version": "4.26.0",
-    "relatedProblems": ["erdos-728-factorial-divisibility"],
+    "relatedProblems": [
+      "erdos-728-factorial-divisibility"
+    ],
     "originalContributions": [
       "factorial_val_add_digitsum: Legendre's formula at p = 2 in additive ℕ form m = v₂(m!) + s₂(m), avoiding truncated subtraction.",
       "log_barrier: PROVEN formalization of Erdős's elementary barrier a!·b! ∣ n! ⇒ a + b ≤ n + s₂(a) + s₂(b) using only the prime 2.",
@@ -95,7 +103,11 @@
       "factorial_pval_add_digitsum (this session): Legendre at a general prime p, m = (p−1)·v_p(m!) + s_p(m).",
       "log_barrier_prime (this session): PROVEN prime-uniform sharp barrier a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for every prime p — strictly stronger than the classical p = 2 statement (adds the s_p(n) term, holds for all primes).",
       "log_barrier_of_prime (this session): recovers the classical log_barrier as the p = 2 specialization of the sharp prime-uniform form.",
-      "Gallery integration (this session): added the previously un-integrated file to Proofs.lean and created gallery metadata + annotations."
+      "Gallery integration (this session): added the previously un-integrated file to Proofs.lean and created gallery metadata + annotations.",
+      "padicValNat_prod_factorials (this session): v_p of a product of factorials equals the sum of the factorial valuations, by multiset induction off padicValNat.mul.",
+      "legendre_sum_multiset (this session): the summed Legendre identity (sum) a_i = (p-1)*(sum) v_p(a_i!) + (sum) s_p(a_i).",
+      "log_barrier_prime_multiset (this session): PROVEN multinomial barrier — prod of a_i! divides n! implies (sum) a_i + s_p(n) <= n + (sum) s_p(a_i) for every prime p; the multinomial generalization of log_barrier_prime (recovered at s = {a,b}).",
+      "log_barrier_prime_finset (this session): the indexed Finset form of the multinomial barrier, matching multinomial coefficients n!/(prod (a i)!)."
     ],
     "mathlibDependencies": [
       {
@@ -165,6 +177,14 @@
       "endLine": 163,
       "summary": "#check and #print axioms for all theorems: each depends only on propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool).",
       "mathContext": "0-axiom, 0-sorry verification."
+    },
+    {
+      "id": "multinomial",
+      "title": "Multinomial / multi-factorial barrier",
+      "startLine": 147,
+      "endLine": 233,
+      "summary": "padicValNat_prod_factorials (v_p of a product of factorials = sum of valuations) and legendre_sum_multiset (summed Legendre identity), then log_barrier_prime_multiset (prod a_i! | n! implies (sum) a_i + s_p(n) <= n + (sum) s_p(a_i)) and its Finset reindexing log_barrier_prime_finset. Generalizes log_barrier_prime from two factorials to an arbitrary product; multiset induction + omega; 0-axiom.",
+      "mathContext": "For every prime $p$: $\\sum_i a_i + s_p(n) \\le n + \\sum_i s_p(a_i)$ when $\\prod_i a_i! \\mid n!$."
     }
   ]
 }

--- a/src/data/research/problems/erdos-728-factorial-divisibility-oq-04.json
+++ b/src/data/research/problems/erdos-728-factorial-divisibility-oq-04.json
@@ -37,7 +37,9 @@
       "Erdős's argument is elementary because Legendre's (p−1)·v_p(m!) = m − s_p(m) has the (p−1) factor equal to 1 at p = 2.",
       "The barrier is prime-uniform: a + b + s_p(n) ≤ n + s_p(a) + s_p(b) for every prime p (log_barrier_prime), strictly stronger than the classical p=2 statement (adds s_p(n), holds for all p).",
       "p = 2 is optimal for the asymptotic O(log n) rate because the binary digit sum s₂ grows slowest; the inequality itself is prime-independent.",
-      "omega atomizes the nonlinear (p−1)·v_p(·!) subterms, so the final linear arithmetic discharges even with a variable prime p (scale hmono by (p−1) via Nat.mul_le_mul + Nat.mul_add first)."
+      "omega atomizes the nonlinear (p−1)·v_p(·!) subterms, so the final linear arithmetic discharges even with a variable prime p (scale hmono by (p−1) via Nat.mul_le_mul + Nat.mul_add first).",
+      "The multinomial generalization needs no new mathematics beyond the two-factorial case: v_p additivity over the product (padicValNat.mul lifted by multiset induction) plus the term-by-term summed Legendre identity reduce it to the same (p-1)-scaled valuation inequality, closed by omega.",
+      "Multiset (not Finset) is the right primitive for the proof: repeats are allowed (central multinomial a_i = n/k), Multiset.induction gives clean cons-step recursion, and the Finset form follows by reindexing through s.val.map a."
     ],
     "builtItems": [
       "factorial_val_add_digitsum: Legendre at p=2, m = v₂(m!)+s₂(m) (Erdos728FactorialDivisibilityOQ04.lean:46)",
@@ -46,16 +48,20 @@
       "factorial_pval_add_digitsum: Legendre at general prime p (Erdos728FactorialDivisibilityOQ04.lean:112)",
       "log_barrier_prime: prime-uniform sharp barrier (Erdos728FactorialDivisibilityOQ04.lean:123)",
       "log_barrier_of_prime: recovers classical barrier at p=2 (Erdos728FactorialDivisibilityOQ04.lean:141)",
-      "Gallery integration: added to Proofs.lean, created meta.json + annotations.json"
+      "Gallery integration: added to Proofs.lean, created meta.json + annotations.json",
+      "padicValNat_prod_factorials (Erdos728FactorialDivisibilityOQ04.lean:167): v_p of a product of factorials = sum of factorial valuations, by Multiset.induction off padicValNat.mul.",
+      "legendre_sum_multiset (Erdos728FactorialDivisibilityOQ04.lean:184): summed Legendre identity (sum) a_i = (p-1)*(sum) v_p(a_i!) + (sum) s_p(a_i).",
+      "log_barrier_prime_multiset (Erdos728FactorialDivisibilityOQ04.lean:203): PROVEN multinomial barrier, prod a_i! | n! implies (sum) a_i + s_p(n) <= n + (sum) s_p(a_i) for every prime p; recovers log_barrier_prime at s={a,b}. 0-axiom.",
+      "log_barrier_prime_finset (Erdos728FactorialDivisibilityOQ04.lean:221): indexed Finset form matching multinomial coefficient n!/(prod (a i)!). 0-axiom."
     ],
     "mathlibGaps": [
       "No Mathlib-level statement of the factorial-divisibility / Kummer-carry barrier; this file supplies the elementary Legendre baseline."
     ],
     "nextSteps": [
-      "Exhibit infinite families achieving equality in log_barrier_prime at p=2 (central binomial / multinomial cases) to show sharpness.",
-      "Multinomial barrier: a₁!·…·a_k! ∣ n! ⇒ ∑aᵢ + s_p(n) ≤ n + ∑s_p(aᵢ)."
+      "Sharpness of the multinomial barrier: characterize families achieving equality (sum) a_i + s_p(n) = n + (sum) s_p(a_i) (central-multinomial extremal case).",
+      "Exhibit explicit infinite equality families for the two-term barrier at p=2 (central binomial)."
     ],
-    "progressSummary": "COMPLETED 2026-06-28 (researcher-8): integrated the previously un-integrated #728→#729 barrier file into the gallery and sharpened the barrier to a prime-uniform form (every prime p), recovering the classical p=2 statement. 0-axiom, 0-sorry, 7 theorems."
+    "progressSummary": "PROGRESS 2026-06-28 (researcher-10): resolved the multi-factorial / multinomial open question for this entry. Added log_barrier_prime_multiset and log_barrier_prime_finset (prod a_i! | n! implies (sum) a_i + s_p(n) <= n + (sum) s_p(a_i) for every prime p), with helpers padicValNat_prod_factorials and legendre_sum_multiset. File now 11 theorems, 0-axiom, 0-sorry; verified via lake env lean against Mathlib 4.26.0 (#print axioms: propext/Classical.choice/Quot.sound only)."
   },
   "knownResults": {
     "established": [


### PR DESCRIPTION
## Summary

Generalizes the two-factorial prime-uniform barrier of Erdős #728/#729 (`log_barrier_prime`) to an **arbitrary product of factorials** — the natural multinomial-coefficient setting `n!/(a₁!⋯a_k!)`. This resolves the *multi-factorial / multinomial barrier* open question explicitly listed in this entry's `meta.json`.

For every prime `p`, if `a₁!·…·a_k! ∣ n!` then
```
∑ᵢ aᵢ + s_p(n) ≤ n + ∑ᵢ s_p(aᵢ)
```
where `s_p` is the base-`p` digit sum.

## New theorems (file: `Proofs/Erdos728FactorialDivisibilityOQ04.lean`, 7 → 11 theorems)

- `padicValNat_prod_factorials`: `v_p(∏ᵢ aᵢ!) = ∑ᵢ v_p(aᵢ!)` — `Multiset.induction` off `padicValNat.mul`.
- `legendre_sum_multiset`: `∑ᵢ aᵢ = (p−1)·∑ᵢ v_p(aᵢ!) + ∑ᵢ s_p(aᵢ)` — term-by-term lift of Legendre.
- `log_barrier_prime_multiset`: the multinomial barrier, multiset form (recovers `log_barrier_prime` at `s = {a,b}`).
- `log_barrier_prime_finset`: indexed `Finset` form matching the multinomial coefficient.

## Verification

- `lake env lean` against Mathlib 4.26.0 — compiles clean, no errors/sorries.
- `#print axioms` on all four new theorems: only `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- File remains **0-axiom, 0-sorry**; gallery `meta.json` size check passes.

## Approach

No new mathematics beyond the two-factorial case: `v_p`-additivity over the product (lifted by multiset induction) plus the summed Legendre identity reduce to the same `(p−1)`-scaled valuation inequality, closed by `omega` (which atomizes the shared nonlinear `(p−1)·v_p(·!)` subterms). Multiset is the natural primitive (repeats allowed, e.g. central multinomial `aᵢ = n/k`); the Finset form follows by reindexing.

Gallery metadata (`meta.json`, `annotations.json`) and research knowledge updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)