### PR TITLE
research(erdos-748): f_1/f_2/f_3 native_decide→kernel decide [axiom-reduction]

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -379,9 +379,12 @@ f(4) = 9
 f(5) = 16
 ...
 -/
-theorem f_1 : f 1 = 2 := by native_decide
-theorem f_2 : f 2 = 3 := by native_decide
-theorem f_3 : f 3 = 6 := by native_decide
+-- Kernel `decide` suffices (axiom-free): the `decidableIsSumFree` instance reduces
+-- `IsSumFree` to a bounded `∀ … ∈ A` decision, so these small `f n` values compute
+-- in the kernel without `native_decide` (which would add `Lean.ofReduceBool`).
+theorem f_1 : f 1 = 2 := by decide
+theorem f_2 : f 2 = 3 := by decide
+theorem f_3 : f 3 = 6 := by decide
 
 /-
 ## Part IX: Summary

--- a/research/problems/erdos-748-incomplete-01/knowledge.md
+++ b/research/problems/erdos-748-incomplete-01/knowledge.md
@@ -51,3 +51,18 @@ owned by **open PR #30202** (do not duplicate).
 
 - Axiom hunt: only `trivial_lower_bound` was routine; already eliminated upstream.
 - Structural additions (monotonicity of `f`) — done this session, 0 new axioms.
+
+### TCB reduction: native_decide → kernel decide (2026-06-28, researcher-3)
+
+The main `Erdos748Problem.lean` still proved the small OEIS values `f(1)=2`,
+`f(2)=3`, `f(3)=6` with `native_decide`, importing `Lean.ofReduceBool` /
+`Lean.trustCompiler` into those theorems. The companion file had long since
+shown kernel `decide` suffices (via the `decidableIsSumFree` bounded-∀ instance).
+Converted all three to kernel `decide`; `#print axioms` now reports only
+`[propext, Classical.choice, Quot.sound]` — compiler-trust axioms removed.
+Typechecks clean via `lake env lean` (Docker host wedged). PR #31261.
+
+No change to the substantive status: 2 deep axioms remain (Green 2004 /
+Sapozhenko 2003), entry stays `axiomatized` / axiomCount 2. The two axioms are
+genuine >1000-line literature results (BLOCKED). Follow-up "largest sum-free
+subset has size ⌈n/2⌉" owned by PR #30202. Nothing else routine to do here.

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -144,10 +144,10 @@
     {
       "id": "oeis",
       "title": "OEIS A007865",
-      "summary": "Proves $f(1) = 2$, $f(2) = 3$, $f(3) = 6$ by `native_decide`, matching OEIS A007865. These are fully machine-checked results, not axioms.",
+      "summary": "Proves $f(1) = 2$, $f(2) = 3$, $f(3) = 6$ by kernel `decide`, matching OEIS A007865. These are fully kernel-checked results (no `native_decide`, so no `Lean.ofReduceBool` dependency), not axioms.",
       "startLine": 274,
       "endLine": 289,
-      "mathContext": "Verified by `native_decide`: $f(1) = 2$, $f(2) = 3$, $f(3) = 6$. Matches OEIS A007865. The counting function $f(n) = |\\text{sumFreeSubsets}(n)|$ is evaluated computably for small $n$."
+      "mathContext": "Verified by kernel `decide` (axiom-free): $f(1) = 2$, $f(2) = 3$, $f(3) = 6$. The `decidableIsSumFree` instance reduces sum-freeness to a bounded $\\forall \\in A$ decision, so these small values compute in the kernel without `native_decide`. Matches OEIS A007865. The counting function $f(n) = |\\text{sumFreeSubsets}(n)|$ is evaluated computably for small $n$."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Summary

Erdős Problem #748 (Cameron–Erdős conjecture on sum-free sets) is a well-developed entry: **0 sorries, 2 genuinely deep literature axioms** (Green 2004 `green_upper_bound`, Sapozhenko 2003 `precise_asymptotic`), both >1000-line undertakings correctly kept as `axiomatized`.

The one concrete, honest win this session: the main file `Erdos748Problem.lean` proved the small OEIS A007865 values `f(1)=2`, `f(2)=3`, `f(3)=6` with **`native_decide`**, which trusts the Lean compiler and pulls in the `Lean.ofReduceBool` / `Lean.trustCompiler` axioms. The `Erdos748Aristotle.lean` companion already established these are provable by **kernel `decide`** (the `decidableIsSumFree` instance reduces sum-freeness to a bounded `∀ ∈ A` decision), so `native_decide` was unnecessary trust.

## Change

- `f_1`/`f_2`/`f_3`: `native_decide` → kernel `decide`.

Verified via `#print axioms` on the edited source: these theorems now depend only on `[propext, Classical.choice, Quot.sound]` — `Lean.ofReduceBool` and `Lean.trustCompiler` are **gone**.

## Verification

- `lake env lean Proofs/Erdos748Problem.lean` → exit 0 (Docker host wedged this cycle; verified against prebuilt oleans).
- `pnpm gallery:check-size` → all entries within caps.
- Updated the gallery OEIS annotation (`src/data/proofs/erdos-748/meta.json`) to describe kernel `decide` instead of `native_decide`.

The two deep axioms remain (no change to `axiomCount: 2`, `status: axiomatized`) — this is purely a trusted-computing-base reduction on the small example values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)