### PR TITLE
research(erdos-340-greedy-sidon-oq-05): gallery integration for B_h sequences [VERIFIED, 0-axiom]

### DIFF
--- a/src/data/proofs/erdos-340-greedy-sidon-oq-05/annotations.json
+++ b/src/data/proofs/erdos-340-greedy-sidon-oq-05/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-isbh-def",
+    "proofId": "erdos-340-greedy-sidon-oq-05",
+    "range": { "startLine": 97, "endLine": 106 },
+    "type": "definition",
+    "title": "The B_h Property via Multiset-Sum Injectivity",
+    "content": "The B_h property is formalized as injectivity of the multiset-sum map on the finset of h-element multisets drawn from A:\n\n```lean\ndef IsBh (h : ℕ) (A : Finset ℕ) : Prop :=\n  Set.InjOn (fun s : Sym ℕ h => (s : Multiset ℕ).sum) (A.sym h)\n```\n\nAn element of `A.sym h` is an unordered h-tuple from A *with repetition*; its multiset sum is the corresponding h-fold sum. Distinctness of all such sums is exactly the B_h condition. At `h = 2` an element of `A.sym 2` is a pair `{a,b}` summing to `a+b`, so `IsBh 2` is the Sidon property; every set is `B_1` (singleton sums are the elements themselves) and `B_0` is vacuous. The property is downward-closed both in the set (`IsBh.subset`) and in the order (`IsBh.of_le`: B_{h+1} ⟹ B_h).",
+    "mathContext": "A finite $A \\subseteq \\mathbb{N}$ is a $B_h$ set iff the map $s \\mapsto \\sum s$ is injective on the $h$-element multisets of $A$ — i.e. all $h$-fold sums with repetition are distinct. This is the additive-combinatorics generalization of Sidon ($B_2$) sets.",
+    "significance": "critical",
+    "relatedConcepts": ["B_h set", "Sidon set", "Sym", "multiset sum", "Set.InjOn"],
+    "prerequisites": ["erdos-340-greedy-sidon"]
+  },
+  {
+    "id": "ann-sidon-bridge",
+    "proofId": "erdos-340-greedy-sidon-oq-05",
+    "range": { "startLine": 259, "endLine": 266 },
+    "type": "theorem",
+    "title": "The Sidon Bridge: IsBh 2 ↔ IsSidon",
+    "content": "```lean\ntheorem isBh_two_iff_isSidon {A : Finset ℕ} : IsBh 2 A ↔ Erdos340.IsSidon A :=\n  ⟨IsBh.isSidon, IsSidon.isBh_two⟩\n```\n\nThis equivalence certifies that the new B_h layer genuinely generalizes the parent gallery proof: the classical Sidon definition `Erdos340.IsSidon` from `erdos-340-greedy-sidon` is *exactly* the `h = 2` instance of `IsBh`. Every Sidon result in the parent entry is therefore the h=2 case of a B_h theorem, and the general counting bound `IsBh.choose_card_le` specializes to the classical Sidon bound. Both directions translate between the multiset-sum formulation (over `A.sym 2`) and the parent's pairwise-sum formulation.",
+    "mathContext": "$B_2$ and Sidon are the same notion: a set in which all pairwise sums $a+b$ ($a \\le b$) are distinct. The bridge makes the parent gallery's Sidon development the $h=2$ specialization of this file.",
+    "significance": "key",
+    "relatedConcepts": ["Sidon set", "B_h set", "Erdos340.IsSidon"],
+    "prerequisites": ["erdos-340-greedy-sidon"]
+  },
+  {
+    "id": "ann-counting-bound",
+    "proofId": "erdos-340-greedy-sidon-oq-05",
+    "range": { "startLine": 311, "endLine": 357 },
+    "type": "theorem",
+    "title": "The B_h Counting Upper Bound C(|A|,h) ≤ h·N",
+    "content": "The combinatorial heart of the file:\n\n```lean\ntheorem IsBh.choose_card_le {h N : ℕ} {A : Finset ℕ} (hh : 1 ≤ h)\n    (hAN : A ⊆ Finset.Icc 1 N) (hA : IsBh h A) :\n    Nat.choose A.card h ≤ h * N\n```\n\nProof: a B_h set has *distinct h-subset sums* (`IsBh.sum_injOn_powersetCard`), so the image of the subset-sum map on `A.powersetCard h` has cardinality `C(|A|,h)` (via `Finset.card_image_of_injOn` and `card_powersetCard`). Each h-subset of `{1,…,N}` sums to at least `h ≥ 1` (`Finset.card_nsmul_le_sum`) and at most `h·N` (`Finset.sum_le_card_nsmul`), so the image injects into `Icc 1 (h·N)`, forcing `C(|A|,h) ≤ |Icc 1 (h·N)| = h·N`. The route through h-*subsets* (powersetCard) rather than h-*multisets* sidesteps the absence of a `Finset.sym` cardinality lemma in Mathlib.",
+    "mathContext": "If $A \\subseteq \\{1,\\dots,N\\}$ is $B_h$ then its $\\binom{|A|}{h}$ distinct $h$-subset sums lie in $[1, hN]$, so $\\binom{|A|}{h} \\le hN$. This gives $|A| = O(N^{1/h})$ in general and recovers $|A|(|A|-1) \\le 4N$ (the Sidon $O(\\sqrt N)$ bound) at $h=2$.",
+    "significance": "critical",
+    "relatedConcepts": ["binomial coefficient", "Finset.powersetCard", "Finset.card_image_of_injOn", "counting bound"],
+    "prerequisites": ["erdos-340-greedy-sidon"]
+  },
+  {
+    "id": "ann-greedy-family",
+    "proofId": "erdos-340-greedy-sidon-oq-05",
+    "range": { "startLine": 692, "endLine": 700 },
+    "type": "theorem",
+    "title": "An Explicit Greedy B_h Family of Every Cardinality",
+    "content": "Iterating the greedy extension `IsBh.exists_insert` (insert any `m > h·max(A)`) builds a concrete B_h set of every size:\n\n```lean\ntheorem exists_isBh_card (h : ℕ) (hh : 1 ≤ h) (n : ℕ) :\n    ∃ A : Finset ℕ, IsBh h A ∧ A.card = n :=\n  ⟨greedyBhSet h hh n, greedyBhSet_isBh hh n, greedyBhSet_card hh n⟩\n```\n\nThe construction `greedyBhAux` starts from `∅` (`isBh_empty`) and repeatedly adjoins a `Classical.choose` witness of `exists_insert`, carrying the B_h invariant and the exact cardinality along. This isolates precisely what is open: the *count* of a B_h set is unbounded for free; the hard quantitative question is how *small the largest element* can be — the N^{1/(2h-1)} greedy lower bound inside {1,…,N}.",
+    "mathContext": "Greedy extension shows $B_h$ sets of arbitrary cardinality exist with no constraint on the count alone. The difficulty in Erdős #340 is entirely about the magnitude of the largest element relative to the set size.",
+    "significance": "key",
+    "relatedConcepts": ["greedy construction", "B_h extension", "Classical.choose"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-affine-invariance",
+    "proofId": "erdos-340-greedy-sidon-oq-05",
+    "range": { "startLine": 772, "endLine": 786 },
+    "type": "theorem",
+    "title": "Affine Invariance: the Symmetry Group of the Bound",
+    "content": "```lean\ntheorem IsBh.map_affine {h c d : ℕ} {A : Finset ℕ} (hc : 0 < c) (hA : IsBh h A) :\n    IsBh h (A.image (fun x => c * x + d))\n```\n\nApplying any positive-slope affine map `x ↦ c·x + d` to every element preserves B_h. The proof factors the map as a dilation `· * c` followed by a translation `· + d` and composes `IsBh.map_mul_right` (every h-fold sum scales by `c`) with `IsBh.map_add_right` (every h-fold sum shifts by `h·d`). The positive-slope affine group `{x ↦ c·x + d : c ≥ 1}` is thus the natural symmetry group of the B_h upper bound: a B_h set may be freely normalised by an affine change of variable before the counting bound is applied.",
+    "mathContext": "Both dilation and translation send distinct $h$-fold sums to distinct $h$-fold sums (uniform scaling resp. uniform shift by $h\\cdot d$), so the affine group with positive slope acts on $B_h$ sets — the symmetry that lets one normalise before counting.",
+    "significance": "supporting",
+    "relatedConcepts": ["affine invariance", "dilation", "translation", "symmetry group"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-forbidden-poly",
+    "proofId": "erdos-340-greedy-sidon-oq-05",
+    "range": { "startLine": 994, "endLine": 1010 },
+    "type": "theorem",
+    "title": "The Closed-Form Forbidden-Value Polynomial 2h(|A|+1)^{2h-1}",
+    "content": "The counting engine of the greedy lower bound:\n\n```lean\ntheorem IsBh.card_forbidden_poly {h : ℕ} {A : Finset ℕ} (hh : 1 ≤ h) (hA : IsBh h A) :\n    ((Finset.range (h * A.sup id + 1)).filter\n        (fun m => ¬ IsBh h (insert m A))).card\n      ≤ 2 * h * (A.card + 1) ^ (2 * h - 1)\n```\n\nThe number of small values `m` whose insertion would break the B_h property is bounded by an explicit polynomial in `|A|` of degree exactly `2h − 1`. This converts the abstract pool bound (`≤ 2·h·T₋·T₊`) into a concrete `|A|`-polynomial via `card_pool_le`. The consequence drives the lower bound: a B_h set inside {1,…,N} always admits a fresh small element as long as `2h(|A|+1)^{2h-1} < N`, which is exactly the room condition that inverts to the N^{1/(2h-1)} greedy rate.",
+    "mathContext": "At most $2h(|A|+1)^{2h-1}$ values are forbidden by the $B_h$ constraint, so whenever this is below $N$ a fresh element exists. The degree $2h-1$ is what produces the greedy exponent $1/(2h-1)$.",
+    "significance": "key",
+    "relatedConcepts": ["forbidden values", "greedy lower bound", "polynomial bound"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-rpow-lower",
+    "proofId": "erdos-340-greedy-sidon-oq-05",
+    "range": { "startLine": 1151, "endLine": 1223 },
+    "type": "theorem",
+    "title": "Headline: the Analytic Ω(N^{1/(2h-1)}) Greedy Lower Bound",
+    "content": "The real-analytic inversion of the combinatorial program:\n\n```lean\ntheorem exists_isBh_rpow_lower {h : ℕ} (hh : 1 ≤ h) :\n    ∃ C : ℝ, 0 < C ∧ ∀ N : ℕ, (2 * h + 1) * 4 ^ (2 * h - 1) ≤ N →\n      ∃ A : Finset ℕ, A ⊆ Finset.Icc 1 N ∧ IsBh h A ∧\n        C * (N : ℝ) ^ (((2 * h - 1 : ℕ) : ℝ)⁻¹) ≤ (A.card : ℝ)\n```\n\nThe single-power room condition `(2h+1)(k+1)^{2h-1} ≤ N` (from `exists_isBh_Icc_card_of_pow_le`) is inverted by (2h−1)-th roots: setting `r = (N/(2h+1))^{1/(2h-1)}` and `m = ⌊r⌋`, one runs the bounded greedy algorithm to size `m−1` and shows `m−1 ≥ r/2 = C·N^{1/(2h-1)}` with the explicit constant `C = 2⁻¹·(2h+1)^{-1/(2h-1)}`. The root manipulations use `Real.pow_rpow_inv_natCast` ((q^n)^{1/n} = q) and `Real.rpow_le_rpow` (monotonicity); no B_h structure beyond the room condition is needed here.",
+    "mathContext": "Solving $(2h+1)(k+1)^{2h-1} \\le N$ for $k$ gives a $B_h$ set of size $k = \\Omega(N^{1/(2h-1)})$ inside $\\{1,\\dots,N\\}$, with the fully explicit constant $C = \\tfrac12 (2h+1)^{-1/(2h-1)}$. This is the sharp-exponent $B_h$ analogue of #340's known greedy lower bound.",
+    "significance": "critical",
+    "relatedConcepts": ["Real.rpow", "greedy lower bound", "Nat.floor", "Real.pow_rpow_inv_natCast"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-open-gap",
+    "proofId": "erdos-340-greedy-sidon-oq-05",
+    "range": { "startLine": 76, "endLine": 89 },
+    "type": "insight",
+    "title": "What Remains Open: the Exponent Gap 1/(2h-1) vs 1/h",
+    "content": "Pairing the headline lower bound `exists_isBh_rpow_lower` with the companion upper bound `IsBh.card_le_rpow` (entry erdos-340-greedy-sidon-oq-05-oq-01) brackets the maximal B_h size σ_h(N):\n\n  `C₁ · N^{1/(2h−1)} ≤ σ_h(N) ≤ C₂ · N^{1/h}`.\n\nThe two exponents `1/(2h−1)` (greedy/probabilistic) and `1/h` (counting) do **not** match. Closing this gap is the genuinely open quantitative content of Erdős #340. The Bose–Chowla construction shows the counting ceiling N^{1/h} is attained to within (1−o(1)), so for h ≥ 2 the upper bound is essentially sharp; the open direction is whether the greedy lower exponent can be pushed toward it. At `h = 2` this is the classical Sidon question — `1/3` (greedy) versus `1/2` (counting) — and is deliberately **not** resolved here; only the two endpoints are formalized.",
+    "mathContext": "The maximal $B_h$ size $\\sigma_h(N)$ sits between $N^{1/(2h-1)}$ and $N^{1/h}$. For $h \\ge 2$ the upper exponent is essentially optimal (Bose–Chowla); whether the greedy lower exponent $1/(2h-1)$ can be improved is the open core of Erdős #340.",
+    "significance": "critical",
+    "relatedConcepts": ["Sidon set", "Bose–Chowla construction", "open problem", "exponent gap"],
+    "prerequisites": ["erdos-340-greedy-sidon-oq-05-oq-01"]
+  }
+]

--- a/src/data/proofs/erdos-340-greedy-sidon-oq-05/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon-oq-05/meta.json
@@ -1,0 +1,112 @@
+{
+  "id": "erdos-340-greedy-sidon-oq-05",
+  "title": "Erdős #340 OQ-05: B_h Sequences and the B_h Upper Bound",
+  "slug": "erdos-340-greedy-sidon-oq-05",
+  "description": "Generalizes the Sidon (B_2) theory of the gallery proof 'erdos-340-greedy-sidon' to B_h sequences — finite sets in which all h-fold sums with repetition are distinct. The file formalizes the B_h property as injectivity of the multiset-sum map on A.sym h, proves the Sidon bridge (IsBh 2 ↔ IsSidon), the sharp combinatorial counting bound IsBh.choose_card_le (C(|A|,h) ≤ h·N, recovering |A| = O(N^{1/h})), full affine invariance (translation, dilation, x ↦ c·x+d), the greedy extension and an explicit greedy B_h family of every cardinality, the forbidden-set counting chain culminating in the closed-form polynomial bound 2h(|A|+1)^{2h-1}, the end-to-end greedy lower bound inside {1,…,N}, and the headline analytic greedy lower bound exists_isBh_rpow_lower (|A| ≥ C·N^{1/(2h-1)}). The matching analytic upper bound IsBh.card_le_rpow lives in the companion entry erdos-340-greedy-sidon-oq-05-oq-01. Together the two endpoints bracket the maximal B_h size σ_h(N) in [C₁·N^{1/(2h-1)}, C₂·N^{1/h}]; the exponent gap 1/(2h-1) vs 1/h is exactly the open quantitative core of Erdős #340 (the classical Sidon 1/3 vs 1/2 at h=2) and is NOT resolved here.",
+  "meta": {
+    "author": "researcher-5 (Lean Genius)",
+    "sourceUrl": "https://www.erdosproblems.com/340",
+    "date": "2026-06-28",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos340GreedySidonOQ05.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "additive-combinatorics",
+      "sidon-sets",
+      "Bh-sets",
+      "extremal",
+      "erdos",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "|image f s| = |s| when f is injective on s — turns B_h distinctness of subset-sums into the count of h-subsets",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_powersetCard",
+        "description": "|A.powersetCard h| = C(|A|, h) — the number of h-element subsets, the left side of the counting bound",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Finset.sum_le_card_nsmul",
+        "description": "∑_{a∈S} a ≤ |S|·N when every element ≤ N — bounds each h-subset sum above by h·N",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.card_nsmul_le_sum",
+        "description": "|S|·1 ≤ ∑_{a∈S} a when every element ≥ 1 — bounds each h-subset sum below by 1",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Real.pow_rpow_inv_natCast",
+        "description": "(q^n)^(1/n) = q for q ≥ 0 — inverts the (2h-1)-th power to extract the N^{1/(2h-1)} rate",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "monotonicity of x ↦ x^e on [0,∞) — transfers the polynomial room condition through the (2h-1)-th root",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ],
+    "originalContributions": [
+      "def IsBh: the B_h property formalized as injectivity of the multiset-sum map s ↦ (s : Multiset ℕ).sum on A.sym h — a clean Mathlib-native generalization of the Sidon property (no prior B_h theory in Mathlib)",
+      "isBh_two_iff_isSidon: IsBh 2 ↔ Erdos340.IsSidon, bridging the new B_h layer to the parent gallery's classical Sidon definition",
+      "IsBh.choose_card_le: the sharp B_h counting bound C(|A|,h) ≤ h·N for A ⊆ {1,…,N}, recovering the classical Sidon bound |A|(|A|-1) ≤ 4N at h=2 and |A| = O(N^{1/h}) in general",
+      "IsBh.map_affine: B_h is invariant under every positive-slope affine map x ↦ c·x + d (c ≥ 1), identifying the symmetry group of the B_h upper bound",
+      "greedyBhSet / exists_isBh_card: an explicit greedy B_h family of every cardinality, isolating that only the largest element (not the count) is hard",
+      "IsBh.card_forbidden_poly: the explicit closed-form forbidden-value bound 2h(|A|+1)^{2h-1} (degree 2h-1), the combinatorial engine of the greedy lower bound",
+      "exists_isBh_rpow_lower: the headline analytic greedy lower bound — an explicit C = 2⁻¹·(2h+1)^{-1/(2h-1)} with |A| ≥ C·N^{1/(2h-1)} for B_h sets inside {1,…,N}"
+    ],
+    "references": [
+      {
+        "authors": "Erdős, Paul",
+        "title": "Problem #340",
+        "year": "",
+        "venue": "erdosproblems.com",
+        "note": "Growth of B_h (and Sidon, h=2) sequences; the exponent gap between greedy lower and counting upper bounds is the open quantitative content."
+      },
+      {
+        "authors": "Bose, R. C. and Chowla, S.",
+        "title": "Theorems in the additive theory of numbers",
+        "year": "1962",
+        "venue": "Comment. Math. Helv. 37",
+        "note": "B_h constructions of size (1−o(1))·N^{1/h}, showing the counting ceiling is essentially sharp."
+      },
+      {
+        "authors": "Singer, James",
+        "title": "A theorem in finite projective geometry and some applications to number theory",
+        "year": "1938",
+        "venue": "Trans. Amer. Math. Soc. 43",
+        "note": "Perfect difference sets give B_2 (Sidon) sets of size (1−o(1))·√N."
+      }
+    ],
+    "prerequisites": [
+      "The parent gallery entry erdos-340-greedy-sidon (Erdos340.IsSidon and the greedy Sidon construction)",
+      "Mathlib's Finset combinatorics (sym, powersetCard, card lemmas) and real power function (Real.rpow)"
+    ],
+    "dateAdded": "2026-06-28",
+    "axiomCount": 0,
+    "lineCount": 1225,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound). All results are unconditional; the open #340 quantitative core (closing the exponent gap 1/(2h-1) vs 1/h) is recorded only as commentary.",
+    "theoremCount": 31,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #340 concerns the maximal size σ_h(N) of a B_h set inside {1,…,N} — a set whose h-fold sums with repetition are all distinct. Sidon sets are the h=2 case. The literature brackets σ_h(N) between a greedy/probabilistic lower bound of order N^{1/(2h-1)} and a counting upper bound of order N^{1/h}; closing this exponent gap is the open quantitative content of the problem. Algebraic constructions (Singer difference sets for h=2, Bose–Chowla for general h) show the counting ceiling N^{1/h} is attained to within (1−o(1)), so the upper bound is essentially sharp and the open direction is whether the greedy lower exponent 1/(2h-1) can be improved toward it.",
+    "problemStatement": "**Open question (OQ-05)**: Does the Sidon (B_2) theory of the parent gallery proof extend to B_h sequences, and what are the resulting size bounds?\n\n**What is formalized**: The full foundational B_h theory, the sharp combinatorial counting upper bound C(|A|,h) ≤ h·N, affine invariance, the greedy extension and an explicit greedy family, the forbidden-set counting chain with explicit closed-form polynomial 2h(|A|+1)^{2h-1}, and the headline analytic greedy lower bound exists_isBh_rpow_lower (|A| ≥ C·N^{1/(2h-1)}). The matching analytic upper bound (|A| ≤ C₂·N^{1/h}) is the companion entry erdos-340-greedy-sidon-oq-05-oq-01.",
+    "text": "A 1225-line, axiom-free Lean development (31 theorems, 1 definition) generalizing the parent Sidon entry to B_h sequences. The B_h property is phrased as injectivity of the multiset-sum map on the finset A.sym h of h-element multisets, which specializes exactly to the Sidon property at h=2 (isBh_two_iff_isSidon) and is downward-closed in both the set (IsBh.subset) and the order (IsBh.of_le). The combinatorial heart is IsBh.choose_card_le: the C(|A|,h) distinct h-subset sums of a B_h set inside {1,…,N} all lie in [1, h·N], forcing C(|A|,h) ≤ h·N. The B_h property is invariant under every positive-slope affine map (IsBh.map_affine), and a greedy extension (insert any m > h·max(A)) yields an explicit B_h set of every cardinality, isolating that only the rate of the largest element is hard. Counting the values forbidden by greedy extension gives the explicit degree-(2h-1) polynomial 2h(|A|+1)^{2h-1}, whose real-analytic inversion (Part 10) produces the headline lower bound exists_isBh_rpow_lower with the explicit constant C = 2⁻¹·(2h+1)^{-1/(2h-1)}.",
+    "proofStrategy": "(1) Define IsBh via multiset-sum injectivity on A.sym h; prove subset/order downward closure and the Sidon bridge at h=2. (2) Counting bound: the h-subset sums are distinct (IsBh.sum_injOn_powersetCard) and confined to [1, h·N], so C(|A|,h) ≤ |Icc 1 (h·N)| = h·N. (3) Symmetry: each h-fold sum shifts/scales uniformly under affine maps, giving translation, dilation, and affine invariance. (4) Greedy: inserting m > h·max(A) preserves B_h; iterating builds an explicit family of every size. (5) Lower bound: count the forbidden values (those that would break B_h when inserted) as the closed-form polynomial 2h(|A|+1)^{2h-1}; the room condition (2h+1)(k+1)^{2h-1} ≤ N guarantees a size-k B_h set, and inverting by (2h-1)-th roots via Real.rpow yields |A| ≥ C·N^{1/(2h-1)}.",
+    "keyInsights": [
+      "B_h sets generalize Sidon (= B_2) sets cleanly as injectivity of the multiset-sum map on A.sym h; the formalization specializes verbatim to the parent's Sidon definition at h=2, so the whole B_h layer sits directly atop the existing gallery proof.",
+      "The counting upper bound needs no h-multiset cardinality lemma (absent in Mathlib): routing through h-subsets (powersetCard, which has card_powersetCard) and the elementary fact that h-subset sums of {1,…,N} live in [1,h·N] gives C(|A|,h) ≤ h·N in a few lines.",
+      "The count of a B_h set is unbounded for free (greedy extension builds every cardinality); the entire difficulty is the size of the largest element. Counting the forbidden values as an explicit degree-(2h-1) polynomial turns the lower bound into a single root-extraction.",
+      "Pairing exists_isBh_rpow_lower with the companion IsBh.card_le_rpow brackets σ_h(N) in [C₁·N^{1/(2h-1)}, C₂·N^{1/h}]; the exponent gap is precisely the open core of Erdős #340 (1/3 vs 1/2 at h=2) and is deliberately left open — only the two endpoints are formalized."
+    ]
+  }
+}

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -1,12 +1,12 @@
 {
   "slug": "erdos-340-greedy-sidon-oq-05",
   "title": "Erdős #340 OQ-05: B_h sequences and the B_h upper bound",
-  "status": "in-progress",
-  "phase": "ACT",
+  "status": "completed",
+  "phase": "COMPLETED",
   "tier": "B",
   "tractability": "medium — the foundational B_h theory and the sharp B_h counting upper bound are now formalized and verified (0-axiom). The deep open direction (improving the greedy B_h lower bound toward the N^{1/h} ceiling) remains open, exactly as for the parent #340.",
   "started": "2026-06-27",
-  "lastUpdate": "2026-06-28T03:00:00.000Z",
+  "lastUpdate": "2026-06-28",
   "path": "research/problems/erdos-340-greedy-sidon-oq-05",
   "leanFiles": [
     {
@@ -92,9 +92,14 @@
       "Finset.sym s n has no direct cardinality (multichoose) lemma in Mathlib — only the Fintype-level Sym.card_sym_eq_choose. This is why the counting bound is routed through h-subsets (powersetCard, which DOES have card_powersetCard) rather than the full multiset family."
     ],
     "nextSteps": [
+      "Gallery integration COMPLETE (2026-06-28, researcher-5): src/data/proofs/erdos-340-greedy-sidon-oq-05/ with 8 annotations, validated 0-error against the 1225-line source.",
       "Both analytic endpoints are now formalized (lower: exists_isBh_rpow_lower, |A| >= C1*N^{1/(2h-1)}; upper: IsBh.card_le_rpow, |A| <= C2*N^{1/h}). The remaining content is the genuinely OPEN #340 quantitative core: closing the exponent gap 1/(2h-1) vs 1/h (at h=2 the classical Sidon 1/3 vs 1/2). Not attackable by elementary counting.",
       "Optional: extract a clean corollary phrasing largest-element vs cardinality, mirroring the parent greedySidon gallery entry."
     ],
     "progressSummary": "Foundational B_h theory + sharp counting upper bound (choose(|A|,h) <= h*N), Sidon bridge (IsBh 2 <-> IsSidon), affine invariance, greedy extension + explicit greedy family, the forbidden-set counting chain (card_forbidden_le/le_prime/poly: explicit 2h(|A|+1)^(2h-1), degree 2h-1), the end-to-end [1,N]-bounded greedy lower bound (exists_isBh_Icc_card_of_le), and BOTH analytic endpoints: the greedy lower bound exists_isBh_rpow_lower (|A| >= C1*N^{1/(2h-1)}) and the matching analytic upper bound IsBh.card_le_rpow (|A| <= C2*N^{1/h}, C2 = (h-1)+(h*h!)^{1/h}, in Erdos340BhUpperBound.lean). Together these bracket sigma_h(N) in [C1*N^{1/(2h-1)}, C2*N^{1/h}]. Remaining open: only the genuinely hard #340 quantitative core of closing the exponent gap."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "nextAction": "Done. Gallery entry src/data/proofs/erdos-340-greedy-sidon-oq-05/ added (meta.json + annotations.json). Both analytic endpoints formalized; the open #340 exponent gap 1/(2h-1) vs 1/h remains as a separate problem."
   }
 }


### PR DESCRIPTION
## Summary

The B_h sequence theory for Erdős #340 OQ-05 was already fully proved and merged on `main` (`proofs/Proofs/Erdos340GreedySidonOQ05.lean`, 1225 lines, 31 theorems, 1 def, **0 sorries / 0 axioms**) but had **no gallery entry** — while its parent (`erdos-340-greedy-sidon`) and a child (`erdos-340-greedy-sidon-oq-05-oq-01`) both do. This PR supplies the missing gallery integration.

## What's added

`src/data/proofs/erdos-340-greedy-sidon-oq-05/`:
- **`meta.json`** — verified/original badge, 0-axiom, mathlib dependencies, original contributions, overview (historical context, problem statement, strategy, key insights).
- **`annotations.json`** — 8 annotations (canonical type/significance enums) covering: the `IsBh` definition, the Sidon bridge `isBh_two_iff_isSidon`, the counting bound `IsBh.choose_card_le`, the explicit greedy family `exists_isBh_card`, affine invariance `IsBh.map_affine`, the closed-form forbidden polynomial `IsBh.card_forbidden_poly`, the headline analytic lower bound `exists_isBh_rpow_lower`, and an insight on the open exponent gap.

## Verification

- `pnpm gallery:check-size` — passes (all entries within size caps).
- `pnpm annotations:build` — the new entry validates **0-error** against the source (total repo errors went 3105 → 3104; the remaining `oq-05-oq-01` hit is a pre-existing sibling issue, not introduced here).
- All annotation line ranges anchor to real Lean constructs in the merged source.

No Lean source changes — the proof is already on `main` and unchanged. The research problem JSON is marked `completed`.

The open quantitative core of #340 (closing the exponent gap `1/(2h-1)` vs `1/h`) is deliberately **not** claimed resolved — only the two analytic endpoints are formalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)