### PR TITLE
research(cassini-identity-oq-01-oq-02): d'Ocagne's identity via the adjugate [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CassiniIdentityOQ01OQ02.lean
+++ b/proofs/Proofs/CassiniIdentityOQ01OQ02.lean
@@ -26,10 +26,17 @@
                        `fib_add_matrix` (odd-index duplication).
   - `fib_two_mul_add_two` : `F(2n+2) = F(n+2)F(n+1) + F(n+1)F(n)`  — the `m = n` diagonal
                        of `fib_add_offdiag` (even-index duplication).
+  - `fib_dOcagne`    : `F(m+n+1)F(n) − F(m+n)F(n+1) = (−1)^(n+1)F(m)`  — d'Ocagne's
+                       *subtraction*-type identity, read off an entry of the **adjugate**
+                       factorisation `Q^{m+n+1}·adjugate(Q^{n+1}) = (−1)^{n+1}•Q^m`
+                       (`Matrix.mul_adjugate`). The adjugate stands in for the inverse
+                       power `Q^{−n}`, realising the difference index `m = (m+n)−n` without
+                       leaving `ℕ` or invoking the `F_{−1}` convention.
 
   Worked over `ℤ` (entries `(Nat.fib k : ℤ)`), 0 sorries, 0 axioms. Mathlib has no
   Fibonacci Q-matrix of its own, so the closed form `Q_pow_succ` is a genuinely new
-  artifact.
+  artifact; the adjugate factorisation extends the same "one matrix, many corollaries"
+  pattern from the addition (product) identities to the subtraction (d'Ocagne) family.
 -/
 
 import Mathlib
@@ -147,5 +154,68 @@ theorem fib_two_mul_add_two (n : ℕ) :
       = Nat.fib (n + 2) * Nat.fib (n + 1) + Nat.fib (n + 1) * Nat.fib n := by
   have h := fib_add_offdiag n n
   rw [show 2 * n + 2 = n + n + 2 from by ring, h]
+
+/-!
+## Subtraction-type identities via the adjugate (d'Ocagne)
+
+The addition formulas above read entries of the *product* `Q^a · Q^b = Q^{a+b}`. The
+classical *subtraction*-type identities (d'Ocagne, Catalan, Vajda) instead need a
+difference index `F_{a−b}`, i.e. an *inverse* power `Q^{a−b} = Q^a (Q^b)^{-1}`. Over `ℤ`
+we avoid `(Q^b)^{-1}` (and the `F_{-1}` convention) by using the **adjugate**: since
+`A · adjugate A = (det A) • 1` (`Matrix.mul_adjugate`) and `det (Q^{n+1}) = (−1)^{n+1}`,
+
+`Q^{m+n+1} · adjugate (Q^{n+1}) = (det Q^{n+1}) • Q^m = (−1)^{n+1} • Q^m`,
+
+a factorisation in the *same* spirit as `Q_factor` but with an adjugate in place of the
+second power. Reading off an entry now yields d'Ocagne's identity with all indices kept
+`≥ 0` (the difference `m = (m+n) − n` is materialised as the bare exponent `m`).
+-/
+
+/-- Entry `(2,1)` of `Q^m` is `F(m)`, for *every* `m` — including `m = 0`, where `Q^0 = 1`
+gives the `(2,1)` entry `0 = F(0)`. (For `m = k+1` this is the off-diagonal of
+`Q_pow_succ`.) Needed because the adjugate factorisation lands on a bare power `Q^m`. -/
+theorem Q_pow_entry_10 (m : ℕ) : (Q ^ m) 1 0 = (Nat.fib m : ℤ) := by
+  cases m with
+  | zero => simp
+  | succ k =>
+      rw [Q_pow_succ]
+      simp
+
+/-- `det (Q^{n+1}) = (−1)^{n+1}` (the scalar of the adjugate factorisation), from
+`det (Q^k) = (det Q)^k` and `det Q = −1`. -/
+theorem Q_pow_succ_det (n : ℕ) : (Q ^ (n + 1)).det = (-1 : ℤ) ^ (n + 1) := by
+  rw [Matrix.det_pow, show Q = !![(1 : ℤ), 1; 1, 0] from rfl, Matrix.det_fin_two_of]
+  norm_num
+
+/-- **Adjugate factorisation** (subtraction companion of `Q_factor`):
+`Q^{m+n+1} · adjugate (Q^{n+1}) = det (Q^{n+1}) • Q^m`. Pure `Matrix.mul_adjugate` +
+`pow_add` — no inverse, no negative index. -/
+private theorem Q_adj_factor (m n : ℕ) :
+    Q ^ (m + n + 1) * (Q ^ (n + 1)).adjugate = (Q ^ (n + 1)).det • Q ^ m := by
+  have hexp : m + n + 1 = m + (n + 1) := by ring
+  rw [hexp, pow_add, Matrix.mul_assoc, Matrix.mul_adjugate, mul_smul_comm, Matrix.mul_one]
+
+/-- **d'Ocagne's identity** (reindexed to keep every Fibonacci index `≥ 0`):
+`F(m+n+1)·F(n) − F(m+n)·F(n+1) = (−1)^{n+1}·F(m)`.
+
+Read off the `(2,1)` entry of the adjugate factorisation
+`Q^{m+n+1}·adjugate (Q^{n+1}) = (−1)^{n+1}•Q^m`. The standard form
+`F_a F_{b+1} − F_{a+1} F_b = (−1)^b F_{a−b}` is the case `a = m+n`, `b = n`; the difference
+`a − b = m` appears here as the exponent of the bare power `Q^m`, so no `F_{m−n}` /
+negative-index convention is required. This is the subtraction analogue of the addition
+formulas, obtained from the *same* Q-matrix by replacing the second factor with its
+adjugate. -/
+theorem fib_dOcagne (m n : ℕ) :
+    (Nat.fib (m + n + 1) : ℤ) * Nat.fib n - (Nat.fib (m + n) : ℤ) * Nat.fib (n + 1)
+      = (-1 : ℤ) ^ (n + 1) * Nat.fib m := by
+  have h := Q_adj_factor m n
+  rw [show m + n + 1 = (m + n) + 1 from rfl, Q_pow_succ_det, Q_pow_succ (m + n),
+    Q_pow_succ n, Matrix.adjugate_fin_two_of] at h
+  have h10 := congrFun (congrFun h 1) 0
+  rw [Matrix.mul_apply, Fin.sum_univ_two, Matrix.smul_apply, Q_pow_entry_10,
+    smul_eq_mul] at h10
+  simp only [Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.cons_val_fin_one, Matrix.of_apply, Matrix.empty_val'] at h10
+  linear_combination h10
 
 end CassiniIdentityOQ01OQ02

--- a/research/problems/cassini-identity-oq-01-oq-02/knowledge.md
+++ b/research/problems/cassini-identity-oq-01-oq-02/knowledge.md
@@ -93,3 +93,49 @@ lineCount 151, +duplication section).
 the corollary list. The substantive open items (d'Ocagne, Catalan, Vajda) remain — they
 involve index subtraction (`F_{m-n}`) needing either `Q^{-1}` (Q ∈ GL₂(ℤ), det = −1) or a
 2-step induction, neither attempted this session.
+
+---
+
+## Session 2026-06-28 (researcher-2, session 2) — d'Ocagne via the adjugate [VERIFIED, 0-axiom]
+
+**Outcome**: progress — closed the first of the three documented subtraction-type open
+items (**d'Ocagne**) within the existing Q-matrix framework, 0 sorry / 0 axiom.
+
+### The key idea (resolves the "needs `Q^{-1}`" blocker from the prior note)
+The prior session said the subtraction identities need `Q^{-1}` or a 2-step induction.
+Neither is necessary: over `ℤ` use the **adjugate**. `Matrix.mul_adjugate` gives
+`A · adjugate A = (det A) • 1`, so with `Q^{m+n+1} = Q^m · Q^{n+1}` (`pow_add`),
+```
+Q^{m+n+1} · adjugate (Q^{n+1}) = Q^m · (det (Q^{n+1}) • 1) = (−1)^{n+1} • Q^m.
+```
+No inverse, no `F_{−1}`. Reading the `(2,1)` entry (with `adjugate_fin_two_of`,
+`Q_pow_succ`, `Q_pow_succ_det`, and a new `Q_pow_entry_10 : (Q^m) 1 0 = F m` covering
+`m=0`) gives **d'Ocagne** in the index-`≥0` form
+`F(m+n+1)·F(n) − F(m+n)·F(n+1) = (−1)^{n+1}·F(m)` — the standard
+`F_a F_{b+1} − F_{a+1} F_b = (−1)^b F_{a−b}` at `a=m+n, b=n`, the difference `a−b=m`
+materialised as the bare exponent of `Q^m`.
+
+### What I added (4 theorems, all 0-axiom)
+- `Q_pow_entry_10 (m) : (Q^m) 1 0 = F m`  (covers `m=0`: `Q^0=1`, entry `0 = F 0`).
+- `Q_pow_succ_det (n) : det (Q^{n+1}) = (−1)^{n+1}`.
+- `Q_adj_factor (m n)` (private): the adjugate factorisation above.
+- `fib_dOcagne (m n)`: d'Ocagne, by `congrFun` on the `(2,1)` entry + `linear_combination`.
+
+### Verification
+Single-file `LAKE_UNSAFE=1 lake env lean Proofs/CassiniIdentityOQ01OQ02.lean` → **EXIT 0,
+0 warnings, 0 errors**. `#print axioms fib_dOcagne` = `[propext, Classical.choice,
+Quot.sound]` (no `sorryAx`, no `ofReduceBool`). File 151→221 LOC, 7→11 theorems.
+Gallery `meta.json` updated (theoremCount 11, lineCount 221, +d'Ocagne contribution,
++`Matrix.mul_adjugate`/`adjugate_fin_two_of` deps); `gallery:check-size` passes.
+
+### Rewrite-order gotcha (for next session)
+In `fib_dOcagne`, rewrite `Q_pow_succ_det` **before** `Q_pow_succ n` — otherwise
+`Q_pow_succ n` rewrites the `Q^{n+1}` *inside* `(Q^{n+1}).det` first and the det rewrite
+then finds no `(Q^{n+1}).det` pattern (the original error).
+
+### Still open (Catalan, Vajda)
+- **Catalan** `F_n² − F_{n−r}F_{n+r} = (−1)^{n−r}F_r²` and **Vajda**
+  `F_{n+i}F_{n+j} − F_n F_{n+i+j} = (−1)^n F_i F_j` are the natural next targets — both
+  should yield to the *same* adjugate trick (an entry or a 2×2 determinant of a product of
+  the form `Q^a · adjugate(Q^b)`), reindexed to keep indices `≥0`. Vajda generalises both
+  Catalan and d'Ocagne, so proving Vajda would subsume this. Recommended next session.

--- a/src/data/proofs/cassini-identity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "cassini-identity-oq-01-oq-02",
   "title": "Fibonacci Addition Formula from the Q-Matrix Factorisation Q^{m+n} = Q^m Q^n",
   "slug": "cassini-identity-oq-01-oq-02",
-  "description": "Answers the open question of the parent entry (cassini-identity-oq-01): the Fibonacci addition formula is read off directly from the entries of the matrix law Q^{m+n} = Q^m Q^n, with Q = !![1,1;1,0] the Fibonacci companion matrix. A single induction establishes the closed power Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n]; every identity is then a corollary obtained by reading off one entry of Q^{(m+1)+(n+1)} = Q^{m+1}·Q^{n+1} or by taking a determinant. The (2,2) entry gives F_{m+n+1} = F_{m+1}F_{n+1} + F_m F_n (recovering Mathlib's Nat.fib_add), the (1,2) entry gives the addition formula F_{m+n+2} = F_{m+2}F_{n+1} + F_{m+1}F_n, and the determinant gives Cassini's identity F_{n+2}F_n − F_{n+1}² = (−1)^{n+1} — all packaged as corollaries of the one factorisation. Mathlib records no Fibonacci companion matrix, so the closed power form is a genuinely new artifact.",
+  "description": "Answers the open question of the parent entry (cassini-identity-oq-01): the Fibonacci addition formula is read off directly from the entries of the matrix law Q^{m+n} = Q^m Q^n, with Q = !![1,1;1,0] the Fibonacci companion matrix. A single induction establishes the closed power Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n]; every identity is then a corollary obtained by reading off one entry of Q^{(m+1)+(n+1)} = Q^{m+1}·Q^{n+1} or by taking a determinant. The (2,2) entry gives F_{m+n+1} = F_{m+1}F_{n+1} + F_m F_n (recovering Mathlib's Nat.fib_add), the (1,2) entry gives the addition formula F_{m+n+2} = F_{m+2}F_{n+1} + F_{m+1}F_n, and the determinant gives Cassini's identity F_{n+2}F_n − F_{n+1}² = (−1)^{n+1} — all packaged as corollaries of the one factorisation. The same pattern extends to the subtraction family: replacing the second power by its adjugate gives Q^{m+n+1}·adjugate(Q^{n+1}) = (−1)^{n+1}•Q^m, whose (2,1) entry is d'Ocagne's identity F_{m+n+1}F_n − F_{m+n}F_{n+1} = (−1)^{n+1}F_m (the difference index realised as a bare power, no F_{−1} convention). Mathlib records no Fibonacci companion matrix and none of d'Ocagne/Catalan/Vajda, so the closed power form and the adjugate factorisation are genuinely new artifacts.",
   "meta": {
     "author": "Fibonacci addition formula (classical); Q-matrix factorisation proof formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Matrix_form",
@@ -47,6 +47,16 @@
         "theorem": "pow_add",
         "description": "a^(m+n) = a^m · a^n in a monoid. Instantiated at the matrix Q it is the factorisation Q^{(m+1)+(n+1)} = Q^{m+1}·Q^{n+1} whose entries are the addition formulas — the associativity content the open question asks to exploit.",
         "module": "Mathlib.Algebra.Group.Defs"
+      },
+      {
+        "theorem": "Matrix.mul_adjugate",
+        "description": "A · adjugate A = (det A) • 1. With A = Q^{n+1} and Q^{m+n+1} = Q^m·Q^{n+1} (pow_add) it gives the adjugate factorisation Q^{m+n+1}·adjugate(Q^{n+1}) = det(Q^{n+1})•Q^m without any matrix inverse — the negative-index analogue of pow_add that powers d'Ocagne's subtraction identity.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Adjugate"
+      },
+      {
+        "theorem": "Matrix.adjugate_fin_two_of",
+        "description": "adjugate !![a,b;c,d] = !![d,-b;-c,a]. Evaluates adjugate(Q^{n+1}) = !![F_n,-F_{n+1};-F_{n+1},F_{n+2}] in closed form so the (2,1) entry of the adjugate factorisation reads off as d'Ocagne's identity.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Adjugate"
       }
     ],
     "originalContributions": [
@@ -54,14 +64,15 @@
       "The closed Q-matrix power Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n] over ℤ proved by one induction on the Fibonacci recurrence — Mathlib records no Fibonacci companion matrix",
       "Three classical identities packaged as corollaries of one factorisation: the (2,2) entry F_{m+n+1} = F_{m+1}F_{n+1} + F_m F_n (recovering Nat.fib_add), the (1,2) entry F_{m+n+2} = F_{m+2}F_{n+1} + F_{m+1}F_n, and Cassini's identity F_{n+2}F_n − F_{n+1}² = (−1)^{n+1} via the determinant",
       "Demonstrates the 'one matrix identity, many corollaries' pattern: a family of bilinear Fibonacci identities becomes entry-reading on a single associativity equation",
-      "Adds the duplication formulas F_{2n+1} = F_{n+1}² + F_n² and F_{2n+2} = F_{n+2}F_{n+1} + F_{n+1}F_n as the m = n diagonal of the addition formulas (the entries of the square Q^{n+1}·Q^{n+1}), extending the corollary list with no extra induction"
+      "Adds the duplication formulas F_{2n+1} = F_{n+1}² + F_n² and F_{2n+2} = F_{n+2}F_{n+1} + F_{n+1}F_n as the m = n diagonal of the addition formulas (the entries of the square Q^{n+1}·Q^{n+1}), extending the corollary list with no extra induction",
+      "Extends the 'one matrix, many corollaries' pattern from the product (addition) identities to the subtraction family via the adjugate: the factorisation Q^{m+n+1}·adjugate(Q^{n+1}) = det(Q^{n+1})•Q^m = (−1)^{n+1}•Q^m (Matrix.mul_adjugate, no inverse and no negative index) yields d'Ocagne's identity F_{m+n+1}F_n − F_{m+n}F_{n+1} = (−1)^{n+1}F_m by reading its (2,1) entry — the difference index m = (m+n)−n is materialised as the bare power Q^m, sidestepping the F_{−1} convention; neither d'Ocagne, Catalan, nor Vajda appear anywhere in Mathlib"
     ],
     "dateAdded": "2026-06-27",
     "axiomCount": 0,
-    "lineCount": 151,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The proof uses only structural Mathlib lemmas (Matrix.mul_fin_two, Matrix.det_pow, Matrix.det_fin_two_of, pow_add, Nat.fib_add_two) with induction, push_cast, ring, and exact_mod_cast; no native_decide and no structure-encoded hypotheses. #print axioms reports only the foundational propext, Classical.choice, Quot.sound, none of which count as assumptions.",
+    "lineCount": 221,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The proof uses only structural Mathlib lemmas (Matrix.mul_fin_two, Matrix.det_pow, Matrix.det_fin_two_of, pow_add, Nat.fib_add_two, Matrix.mul_adjugate, Matrix.adjugate_fin_two_of) with induction, push_cast, ring, linear_combination, and exact_mod_cast; no native_decide and no structure-encoded hypotheses. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for every theorem (including the d'Ocagne identity fib_dOcagne), none of which count as assumptions.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 11,
     "definitionCount": 1
   },
   "sections": [


### PR DESCRIPTION
## Summary

Extends the Q-matrix Fibonacci entry with **d'Ocagne's identity**, closing the first of the three documented subtraction-type open items (d'Ocagne, Catalan, Vajda). Fully machine-checked, **0 sorries, 0 axioms**.

The prior session's note said the subtraction identities need `Q⁻¹` or a 2-step induction. **Neither is required** — over ℤ the **adjugate** does the job, extending the file's "one matrix, many corollaries" thesis from the product (addition) family to the subtraction family:

```
Matrix.mul_adjugate:   A · adjugate A = (det A) • 1
with  Q^{m+n+1} = Q^m · Q^{n+1}  (pow_add):
   Q^{m+n+1} · adjugate(Q^{n+1}) = (det Q^{n+1}) • Q^m = (−1)^{n+1} • Q^m
```

No inverse, no `F₋₁` convention. Reading the **(2,1) entry** gives d'Ocagne in index-≥0 form:

```
F(m+n+1)·F(n) − F(m+n)·F(n+1) = (−1)^{n+1}·F(m)
```

— the classical `F_a F_{b+1} − F_{a+1} F_b = (−1)^b F_{a−b}` at `a=m+n, b=n`, with the difference index `a−b=m` materialised as the bare exponent of `Q^m`.

## New theorems (all 0-axiom)
| theorem | statement |
|---|---|
| `Q_pow_entry_10` | `(Q^m) 1 0 = F m` (covers `m=0`: `Q⁰=1`, entry `0=F 0`) |
| `Q_pow_succ_det` | `det(Q^{n+1}) = (−1)^{n+1}` |
| `Q_adj_factor` (private) | the adjugate factorisation above |
| `fib_dOcagne` | d'Ocagne's identity |

## Verification
- `LAKE_UNSAFE=1 lake env lean Proofs/CassiniIdentityOQ01OQ02.lean` → **EXIT 0, 0 warnings, 0 errors** (Docker host down; single-file host elaboration against prebuilt Mathlib oleans, v4.26.0).
- `#print axioms fib_dOcagne` = `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `Lean.ofReduceBool`**.
- File 151→221 LOC, 7→11 theorems. Gallery `meta.json` updated (theoremCount, lineCount, +d'Ocagne contribution, +`Matrix.mul_adjugate`/`adjugate_fin_two_of` deps); `gallery:check-size` passes.

Neither d'Ocagne, Catalan, nor Vajda appear anywhere in Mathlib, so the adjugate factorisation is a genuinely new artifact.

## Still open
Catalan and Vajda — should yield to the same adjugate trick (an entry or 2×2 determinant of `Q^a · adjugate(Q^b)`), reindexed to keep indices ≥0. Vajda generalises both, so it is the recommended next target. Documented in `knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)