### PR TITLE
research(pascals-hexagon-incomplete-01-oq-01): Sylvester step-4 permutation/sign correction [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PascalsHexagon.lean
+++ b/proofs/Proofs/PascalsHexagon.lean
@@ -1253,6 +1253,60 @@ private lemma pointOnConic_projTransform_iff_of_congr
   · intro h; rw [h, mul_zero]
   · intro h; exact (mul_eq_zero.mp h).resolve_left hc
 
+/-- **Permutation/sign correction — Sylvester step 4 (proved, 0-axiom).**
+    A `±1`-valued *indefinite* weight vector `w : Fin 3 → ℝ` has its diagonal
+    `Matrix.diagonal w` congruent, via an invertible permutation matrix `P`, to a
+    nonzero scalar multiple of `stdConic = diag(1,1,-1)`:
+    `Pᵀ * diagonal w * P = c • stdConic` with `c = ±1`.
+
+    This discharges step 4 of the `exists_scaledCongr_stdConic_of_isotropic` plan: once
+    Sylvester's law gives a congruence `C ≅ diagonal w` with `w` indefinite (steps 1–3),
+    this lemma rotates/signs the inertia form `diagonal w` onto `c • stdConic`. The proof
+    is a finite case split on the eight `±1` patterns: the two *definite* patterns are
+    excluded by `hindef`, and each of the six *indefinite* patterns is handled by an
+    explicit `3×3` permutation matrix (identity, swap `(1 2)`, or swap `(0 2)`) together
+    with `c = ±1`. -/
+private lemma diag_pm_one_congr_stdConic (w : Fin 3 → ℝ)
+    (hw : ∀ i, w i = 1 ∨ w i = -1)
+    (hindef : ∃ i j, w i ≠ w j) :
+    ∃ (P : Matrix (Fin 3) (Fin 3) ℝ), P.det ≠ 0 ∧
+      ∃ (c : ℝ), c ≠ 0 ∧ Pᵀ * Matrix.diagonal w * P = c • stdConic := by
+  rcases hw 0 with h0 | h0 <;> rcases hw 1 with h1 | h1 <;> rcases hw 2 with h2 | h2
+  · -- (+,+,+): definite, excluded by indefiniteness
+    exfalso; obtain ⟨i, j, hij⟩ := hindef; fin_cases i <;> fin_cases j <;> simp_all
+  · -- (+,+,-): identity, c = 1
+    refine ⟨!![1,0,0; 0,1,0; 0,0,1], by simp [Matrix.det_fin_three], 1, one_ne_zero, ?_⟩
+    ext i j; fin_cases i <;> fin_cases j <;>
+      simp [stdConic, Matrix.mul_apply, Fin.sum_univ_three, Matrix.diagonal_apply,
+        Matrix.transpose_apply, h0, h1, h2]
+  · -- (+,-,+): swap (1 2), c = 1
+    refine ⟨!![1,0,0; 0,0,1; 0,1,0], by simp [Matrix.det_fin_three], 1, one_ne_zero, ?_⟩
+    ext i j; fin_cases i <;> fin_cases j <;>
+      simp [stdConic, Matrix.mul_apply, Fin.sum_univ_three, Matrix.diagonal_apply,
+        Matrix.transpose_apply, h0, h1, h2]
+  · -- (+,-,-): swap (0 2), c = -1
+    refine ⟨!![0,0,1; 0,1,0; 1,0,0], by simp [Matrix.det_fin_three], -1, by norm_num, ?_⟩
+    ext i j; fin_cases i <;> fin_cases j <;>
+      simp [stdConic, Matrix.mul_apply, Fin.sum_univ_three, Matrix.diagonal_apply,
+        Matrix.transpose_apply, h0, h1, h2]
+  · -- (-,+,+): swap (0 2), c = 1
+    refine ⟨!![0,0,1; 0,1,0; 1,0,0], by simp [Matrix.det_fin_three], 1, one_ne_zero, ?_⟩
+    ext i j; fin_cases i <;> fin_cases j <;>
+      simp [stdConic, Matrix.mul_apply, Fin.sum_univ_three, Matrix.diagonal_apply,
+        Matrix.transpose_apply, h0, h1, h2]
+  · -- (-,+,-): swap (1 2), c = -1
+    refine ⟨!![1,0,0; 0,0,1; 0,1,0], by simp [Matrix.det_fin_three], -1, by norm_num, ?_⟩
+    ext i j; fin_cases i <;> fin_cases j <;>
+      simp [stdConic, Matrix.mul_apply, Fin.sum_univ_three, Matrix.diagonal_apply,
+        Matrix.transpose_apply, h0, h1, h2]
+  · -- (-,-,+): identity, c = -1
+    refine ⟨!![1,0,0; 0,1,0; 0,0,1], by simp [Matrix.det_fin_three], -1, by norm_num, ?_⟩
+    ext i j; fin_cases i <;> fin_cases j <;>
+      simp [stdConic, Matrix.mul_apply, Fin.sum_univ_three, Matrix.diagonal_apply,
+        Matrix.transpose_apply, h0, h1, h2]
+  · -- (-,-,-): definite, excluded by indefiniteness
+    exfalso; obtain ⟨i, j, hij⟩ := hindef; fin_cases i <;> fin_cases j <;> simp_all
+
 /-- **The linear-algebra core of the Sylvester reduction (remaining gap).**
     A non-degenerate symmetric real conic `C` carrying a real point is *congruent to a
     nonzero scalar multiple of* `stdConic = diag(1,1,-1)`: there is an invertible `M` and
@@ -1275,7 +1329,11 @@ private lemma pointOnConic_projTransform_iff_of_congr
     3. The real point `p₀ ≠ 0` with `conicQuadraticForm C p₀ = 0` forces `w` *indefinite*
        (a definite `±diag(1,1,1)` form vanishes only at `0`, while `φ p₀ ≠ 0`).
     4. For an indefinite `±1` weight vector there is a permutation/sign matrix `P` and
-       `c = ±1` with `Pᵀ * diagonal w * P = c • stdConic`; set `M := P * L`. -/
+       `c = ±1` with `Pᵀ * diagonal w * P = c • stdConic`; set `M := P * L`.
+       **Step 4 is now discharged by `diag_pm_one_congr_stdConic` (proved above, 0-axiom).**
+       The sole remaining obstacle is step 2: extracting the matrix congruence
+       `C = Lᵀ * diagonal w * L` from the abstract `IsometryEquiv` across the
+       `Fin (finrank ℝ (Fin 3 → ℝ)) ↔ Fin 3` cast. -/
 private lemma exists_scaledCongr_stdConic_of_isotropic (C : Conic)
     (hC_sym : C.symmetric) (hC_nd : Conic.nondegenerate C)
     (p₀ : ProjPoint) (hp₀v : ProjPoint.valid p₀) (hp₀ : pointOnConic p₀ C) :

--- a/src/data/research/problems/pascals-hexagon-incomplete-01-oq-01.json
+++ b/src/data/research/problems/pascals-hexagon-incomplete-01-oq-01.json
@@ -10,17 +10,18 @@
     "builtItems": [
       "conicQF_projTransform in proofs/Proofs/PascalsHexagon.lean (0-axiom): conicQuadraticForm S (M·p) = conicQuadraticForm (Mᵀ*S*M) p.",
       "pointOnConic_projTransform_iff_of_congr in proofs/Proofs/PascalsHexagon.lean (0-axiom): congruence reduction for projective equivalence of conics.",
+      "diag_pm_one_congr_stdConic in proofs/Proofs/PascalsHexagon.lean (0-axiom, NEW): the permutation/sign correction (Sylvester step 4). For ±1-valued indefinite w : Fin 3→ℝ, ∃ invertible P, c=±1 with Pᵀ*diagonal w*P = c•stdConic. Proof = finite case split on the 8 sign patterns; 2 definite patterns excluded by indefiniteness, 6 indefinite patterns each handled by an explicit permutation matrix (I, swap(1 2), swap(0 2)) with c=±1; each verified by ext+fin_cases+simp.",
       "sylvester_stdConic_of_isotropic now sorry-free, reduced to exists_scaledCongr_stdConic_of_isotropic via the congruence reduction.",
-      "exists_scaledCongr_stdConic_of_isotropic: isolated single-sorry core (∃ M, det≠0 ∧ ∃ c≠0, Mᵀ*stdConic*M = c•C) with a fully validated 4-step proof plan in its docstring."
+      "exists_scaledCongr_stdConic_of_isotropic: isolated single-sorry core (∃ M, det≠0 ∧ ∃ c≠0, Mᵀ*stdConic*M = c•C). Step 4 of its plan is now discharged by diag_pm_one_congr_stdConic; the sole remaining obstacle is step 2 (IsometryEquiv→matrix congruence)."
     ],
     "mathlibGaps": [
-      "No ready lemma turning an abstract QuadraticMap.IsometryEquiv into a matrix congruence across the Fin (finrank ℝ (Fin 3→ℝ)) ↔ Fin 3 cast — the main remaining obstacle.",
-      "No off-the-shelf 'Pᵀ * diagonal w * P = diagonal (w∘σ)' for permutation matrices found; the sign/permutation correction must be built (elementary)."
+      "No ready lemma turning an abstract QuadraticMap.IsometryEquiv into a matrix congruence across the Fin (finrank ℝ (Fin 3→ℝ)) ↔ Fin 3 cast — now the SOLE remaining obstacle.",
+      "(RESOLVED) The 'permutation/sign correction' gap is closed: built directly as diag_pm_one_congr_stdConic via explicit Fin 3 case analysis rather than a general permutation-matrix conjugation lemma."
     ],
     "nextSteps": [
-      "Prove the permutation/sign correction lemma: indefinite ±1 weights ⟹ ∃ invertible P, c≠0, Pᵀ*diagonal w*P = c•stdConic (elementary, finite cases).",
-      "Prove the matrix-congruence extraction from IsometryEquiv + finrank cast; submit exists_scaledCongr_stdConic_of_isotropic to Aristotle once reachable."
+      "Prove step 2: extract the matrix congruence C = Lᵀ*diagonal w*L (L = LinearMap.toMatrix' φ, invertible) from QuadraticForm.equivalent_one_neg_one_weighted_sum_squared's IsometryEquiv φ, handling the Fin (finrank ℝ (Fin 3→ℝ)) = 3 cast on the weight vector w. Then combine with diag_pm_one_congr_stdConic (set M := Pᵀ*L) to close exists_scaledCongr_stdConic_of_isotropic.",
+      "Alternatively, submit exists_scaledCongr_stdConic_of_isotropic to Aristotle once reachable — the only remaining content is the IsometryEquiv→matrix bridge."
     ],
-    "progressSummary": "PROGRESS: reduced sylvester_stdConic_of_isotropic to a single clean matrix-congruence core lemma; added 2 verified (0-axiom) reusable lemmas; Aristotle was down this session."
+    "progressSummary": "PROGRESS: discharged Sylvester step 4 by adding diag_pm_one_congr_stdConic (verified, 0-axiom) — the permutation/sign correction carrying any indefinite ±1 diagonal onto c•stdConic. The remaining sorry in exists_scaledCongr_stdConic_of_isotropic is now reduced to a single obstacle: the IsometryEquiv→matrix congruence bridge across the finrank=3 cast. File typechecks (lake env lean), no new axioms."
   }
 }


### PR DESCRIPTION
## Summary

Adds **`diag_pm_one_congr_stdConic`** (verified, 0-axiom) to `proofs/Proofs/PascalsHexagon.lean`, discharging **step 4** of the `exists_scaledCongr_stdConic_of_isotropic` proof plan in the Sylvester reduction for Pascal's theorem.

**Statement.** For any *indefinite* `±1`-valued weight vector `w : Fin 3 → ℝ`, the diagonal form `Matrix.diagonal w` is congruent — via an invertible permutation matrix `P` — to a nonzero scalar multiple of `stdConic = diag(1,1,-1)`:

```
∃ P, P.det ≠ 0 ∧ ∃ c ≠ 0, Pᵀ * Matrix.diagonal w * P = c • stdConic   (c = ±1)
```

**Proof.** Finite case split on the eight `±1` sign patterns of `(w 0, w 1, w 2)`:
- the two *definite* patterns (`+++` / `---`) are excluded by the indefiniteness hypothesis;
- each of the six *indefinite* patterns is closed by an explicit `3×3` permutation matrix (identity, swap `(1 2)`, or swap `(0 2)`) with `c = ±1`, verified by `ext` + `fin_cases` + `simp`.

## Why this matters

The single remaining `sorry` in this problem lives in `exists_scaledCongr_stdConic_of_isotropic` (`C` non-degenerate symmetric carrying a real point ⟹ `∃ M, c, Mᵀ*stdConic*M = c•C`). Its 4-step plan was: (1) Sylvester via `equivalent_one_neg_one_weighted_sum_squared`, (2) extract a matrix congruence from the abstract `IsometryEquiv`, (3) force `w` indefinite, (4) permutation/sign correction.

**Step 4 is now a proved lemma.** The remaining obstacle is reduced to **step 2 alone**: the `IsometryEquiv → matrix congruence` bridge across the `Fin (finrank ℝ (Fin 3 → ℝ)) = 3` cast.

## Verification

- `proofs/bin/lake env lean Proofs/PascalsHexagon.lean` — no errors.
- No new axioms; the file's single pre-existing `sorry` (`exists_scaledCongr_stdConic_of_isotropic`) is unchanged, and the pre-existing `axiom conic_implies_pascal_constraint` is untouched.
- The new lemma uses only `propext`/`Classical.choice`/`Quot.sound` (no `sorry`, no `native_decide`).

Knowledge JSON (`src/data/research/problems/pascals-hexagon-incomplete-01-oq-01.json`) updated to record the new built item and the reduced remaining step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)