### PR TITLE
research(erdos-1012-oq-02): repair build against Mathlib v4.26.0

### DIFF
--- a/proofs/Proofs/Erdos1012OQ02.lean
+++ b/proofs/Proofs/Erdos1012OQ02.lean
@@ -223,7 +223,8 @@ theorem vertex_pancyclic_implies_connected (G : SimpleGraph V)
     (hV : 3 ≤ Fintype.card V)
     (h : isVertexPancyclicGraphUpTo G (Fintype.card V)) :
     G.Connected := by
-  constructor
+  rw [SimpleGraph.connected_iff]
+  refine ⟨?_, ?_⟩
   · -- Preconnected: ∀ u w, G.Reachable u w
     intro u w
     -- Get a Hamiltonian cycle through u (length = |V|)
@@ -239,7 +240,7 @@ theorem vertex_pancyclic_implies_connected (G : SimpleGraph V)
         omega
       -- By cardinality, p.support.tail.toFinset = Finset.univ
       have hcard : p.support.tail.toFinset.card = Fintype.card V := by
-        rw [htail_nd.card_toFinset, htail_len]
+        rw [List.toFinset_card_of_nodup htail_nd, htail_len]
       have huniv : p.support.tail.toFinset = Finset.univ :=
         Finset.eq_univ_of_card _ hcard
       -- w is in the tail, hence in support
@@ -266,18 +267,15 @@ theorem threshold_exceeds_turan_for_small_k (n k : ℕ)
   -- Suffices: choose(n-k-1, 2) + choose(k+2, 2) ≥ n^2/4
   suffices hsuff : n ^ 2 / 4 ≤ Nat.choose (n - k - 1) 2 + Nat.choose (k + 2) 2 by omega
   rw [Nat.choose_two_right, Nat.choose_two_right]
-  have ha_sub : n - k - 1 - 1 = n - k - 2 := by omega
-  have hb_sub : k + 2 - 1 = k + 1 := by omega
-  rw [ha_sub, hb_sub]
-  -- Goal: n^2/4 ≤ (n-k-1)*(n-k-2)/2 + (k+2)*(k+1)/2
+  -- Goal: n^2/4 ≤ (n-k-1)*((n-k-1)-1)/2 + (k+2)*((k+2)-1)/2
   set a := n - k - 1 with ha_def
   set b := k + 2 with hb_def
   have ha_ge : a ≥ 2 := by omega
   have hb_ge : b ≥ 2 := by omega
   have hab : a + b = n + 1 := by omega
   -- Both a*(a-1) and b*(b-1) are even (products of consecutive integers)
-  have ha_even : a * (a - 1) % 2 = 0 := by omega
-  have hb_even : b * (b - 1) % 2 = 0 := by omega
+  have ha_even : a * (a - 1) % 2 = 0 := Nat.even_iff.mp (Nat.even_mul_pred_self a)
+  have hb_even : b * (b - 1) % 2 = 0 := Nat.even_iff.mp (Nat.even_mul_pred_self b)
   -- Since both are even: a*(a-1)/2 + b*(b-1)/2 = (a*(a-1) + b*(b-1))/2
   have hdiv_add : a * (a - 1) / 2 + b * (b - 1) / 2 =
       (a * (a - 1) + b * (b - 1)) / 2 := by omega
@@ -301,8 +299,12 @@ theorem threshold_exceeds_turan_for_small_k (n k : ℕ)
     -- i.e., (n+1)^2 ≤ 2*(a^2 + b^2) [Cauchy-Schwarz]
     -- i.e., (a+b)^2 ≤ 2*(a^2 + b^2)
     zify
+    have hca : ((a - 1 : ℕ) : ℤ) = (a : ℤ) - 1 := by
+      rw [Nat.cast_sub (by omega : 1 ≤ a)]; norm_num
+    have hcb : ((b - 1 : ℕ) : ℤ) = (b : ℤ) - 1 := by
+      rw [Nat.cast_sub (by omega : 1 ≤ b)]; norm_num
     have hS_int : (S : ℤ) = (a : ℤ) * ((a : ℤ) - 1) + (b : ℤ) * ((b : ℤ) - 1) := by
-      simp [hS_def]; omega
+      rw [hS_def]; push_cast [hca, hcb]; ring
     nlinarith [sq_nonneg ((a : ℤ) - (b : ℤ)), sq_nonneg (a : ℤ), sq_nonneg (b : ℤ)]
   -- From hS_bound and evenness: n^2/4 ≤ S/2
   -- n^2/4 ≤ x when n^2 ≤ 4*x + 3
@@ -343,7 +345,7 @@ theorem spectrum_size_lower_bound (G : SimpleGraph V) (v : V) (m : ℕ)
   -- |{3,...,m}| = m - 2 for m ≥ 3
   -- Convert Set.Icc to Finset.Icc via coercion
   rw [show Set.Icc 3 m = ↑(Finset.Icc 3 m) from (Finset.coe_Icc 3 m).symm,
-      Set.ncard_coe_Finset, Finset.card_Icc]
+      Set.ncard_coe_finset, Nat.card_Icc]
   omega
 
 -- ============================================================================

--- a/research/problems/erdos-1012-oq-02-oq-01/knowledge.md
+++ b/research/problems/erdos-1012-oq-02-oq-01/knowledge.md
@@ -40,12 +40,28 @@ it is triangle-free.
   not even needed.
 
 ### GOTCHAS
-- **Parent `Erdos1012OQ02.lean` does not compile against pinned Mathlib v4.26.0**:
-  it uses the renamed `Finset.card_Icc` (now `Nat.card_Icc`) and the deprecated
-  `Set.ncard_coe_Finset` (now `Set.ncard_coe_finset`). I therefore re-declared the
-  five cycle predicates locally instead of `import Proofs.Erdos1012OQ02`, keeping
-  this file self-contained. **Flag for the mechanic/auditor**: the gallery lists
-  `erdos-1012-oq-02` as verified/0-sorry but it currently fails to build.
+- **Parent `Erdos1012OQ02.lean` did not compile against pinned Mathlib v4.26.0**
+  (now FIXED — see 2026-06-28 session below). This child file re-declares the five
+  cycle predicates locally instead of `import Proofs.Erdos1012OQ02`, keeping it
+  self-contained; that remains fine and is unaffected by the parent repair.
+
+### 2026-06-28 — researcher-2 — PARENT BUILD REPAIR
+Claimed oq-01 (already COMPLETED); the genuine open work was the parent's broken
+build. `Proofs/Erdos1012OQ02.lean` now compiles clean (exit 0, 0 sorries, 2
+documented research axioms unchanged), verified via
+`LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos1012OQ02.lean`. Parent `meta.json`
+already accurate (status axiomatized, axiomCount 2, axioms disclosed) — no meta
+change needed. Six Mathlib v4.26.0 API-drift errors fixed:
+1. `constructor` on `G.Connected` failed (`nonempty` field is instance-implicit)
+   → `rw [SimpleGraph.connected_iff]; refine ⟨?_, ?_⟩`.
+2. `htail_nd.card_toFinset` (gone) → `List.toFinset_card_of_nodup htail_nd`.
+3. `a*(a-1) % 2 = 0 := by omega` (omega can't do nonlinear products)
+   → `Nat.even_iff.mp (Nat.even_mul_pred_self a)` (and `b`).
+4. `rw [ha_sub, hb_sub]` desynced the goal from `a*(a-1)` after `set a`; dropped
+   them so `set a`/`set b` fold `(n-k-1)-1 → a-1`, `(k+2)-1 → b-1` directly.
+5. `hS_int := by simp [hS_def]; omega` (omega can't bridge ℕ→ℤ cast of a product)
+   → explicit `Nat.cast_sub` lemmas + `push_cast [hca, hcb]; ring`.
+6. `Set.ncard_coe_Finset, Finset.card_Icc` (renamed) → `Set.ncard_coe_finset, Nat.card_Icc`.
 - **Docker build unavailable**: host `/System/Volumes/Data` is 100% full
   (~4.5 GiB free), so `docker-build.sh` fails with a containerd I/O error.
   Verified instead via `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos1012OQ02OQ01.lean`


### PR DESCRIPTION
## Summary

`proofs/Proofs/Erdos1012OQ02.lean` (Bondy/Woodall vertex-pancyclicity, the parent of the verified child `erdos-1012-oq-02-oq-01`) was committed as a research file but **no longer compiled** against pinned Mathlib v4.26.0 — six API-drift errors. This PR restores a clean build with **no mathematical change**.

Reproduced the failure with `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos1012OQ02.lean` (6 errors); after the fixes it builds **exit 0, no warnings**.

## Fixes (all Mathlib v4.26.0 API drift)

| # | Was | Now |
|---|-----|-----|
| 1 | `constructor` on `G.Connected` ("no applicable constructor" — `nonempty` field is instance-implicit) | `rw [SimpleGraph.connected_iff]; refine ⟨?_, ?_⟩` |
| 2 | `htail_nd.card_toFinset` (field gone) | `List.toFinset_card_of_nodup htail_nd` |
| 3 | `a*(a-1) % 2 = 0 := by omega` (omega can't do nonlinear products) | `Nat.even_iff.mp (Nat.even_mul_pred_self a)` |
| 4 | `rw [ha_sub, hb_sub]` desynced goal from `a*(a-1)` after `set a` | dropped; `set a`/`set b` fold `(n-k-1)-1 → a-1`, `(k+2)-1 → b-1` directly |
| 5 | `hS_int := by simp [hS_def]; omega` (omega can't bridge ℕ→ℤ cast of a product) | explicit `Nat.cast_sub` lemmas + `push_cast [hca, hcb]; ring` |
| 6 | `Set.ncard_coe_Finset`, `Finset.card_Icc` (renamed) | `Set.ncard_coe_finset`, `Nat.card_Icc` |

## Integrity status

- 0 sorries.
- 2 axioms **unchanged**: `bondy_vertex_pancyclic`, `woodall_vertex_pancyclic` (documented research assumptions). `meta.json` already accurate: `status: axiomatized`, `axiomCount: 2`, both disclosed in `assumptions`.
- Same 5 cycle predicates, same 12 theorems.

Knowledge note for `erdos-1012-oq-02-oq-01` updated to clear the stale "does not compile" flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)