### PR TITLE
Enrich Sylow nilpotency (oq-02-oq-01): index.ts, enum fixes, +2 annotations

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-01/annotations.json
@@ -1,13 +1,33 @@
 [
   {
+    "id": "ann-sylnil-setup",
+    "proofId": "sylow-theorem-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "concept",
+    "title": "From Per-Prime Counting to Global Nilpotency",
+    "content": "The module docstring frames the whole file as a *local-to-global lift*. The parent entry sylow-theorem-oq-02 worked one prime at a time: it computed n_p = [G : N_G(P)] from the conjugation action and deduced the per-prime criterion n_p = 1 ⟺ P ◁ G. The question here is what it means for that local uniqueness to hold *simultaneously at every prime*. The answer — nilpotency — is a genuinely global structure theorem. The standing context is minimal: `variable {G : Type*} [Group G] [Finite G]`. Finiteness is essential, because the equivalence with all-Sylow-normality is special to finite groups (Mathlib's isNilpotent_of_finite_tfae carries that hypothesis); for infinite groups nilpotency and Sylow normality decouple.",
+    "mathContext": "Local criterion (parent): $n_p = 1 \\iff P \\trianglelefteq G$ for each prime $p$. Global theorem (here): $G$ nilpotent $\\iff$ this holds for *all* $p$ at once.",
+    "significance": "key",
+    "relatedConcepts": [
+      "nilpotent group",
+      "Sylow subgroup",
+      "finite group",
+      "local-global principle"
+    ],
+    "prerequisites": [
+      "Group.IsNilpotent",
+      "sylow-theorem-oq-02"
+    ]
+  },
+  {
     "id": "ann-sylnil-headline",
     "proofId": "sylow-theorem-oq-02-oq-01",
     "range": { "startLine": 51, "endLine": 56 },
-    "type": "technique",
+    "type": "tactic",
     "title": "Extracting a Two-Way Slice from a TFAE",
     "content": "nilpotent_iff_forall_sylow_normal is the (1) ⟺ (4) slice of Mathlib's five-way isNilpotent_of_finite_tfae, obtained in one line by TFAE.out 0 3. The TFAE lists [IsNilpotent, NormalizerCondition, all maximal subgroups normal, all Sylow normal, internal direct product of Sylow]; .out i j returns the bi-implication between entries i and j, here nilpotency and all-Sylow-normality. The explicit (_hp : Fact p.Prime) binder matches the TFAE's statement verbatim and is definitionally the instance-implicit form.",
     "mathContext": "$$G \\text{ nilpotent} \\iff \\forall p,\\ P \\in \\mathrm{Syl}_p(G) \\Rightarrow P \\trianglelefteq G.$$",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "nilpotent group",
       "Sylow subgroup",
@@ -17,6 +37,25 @@
     "prerequisites": [
       "Group.IsNilpotent",
       "isNilpotent_of_finite_tfae"
+    ]
+  },
+  {
+    "id": "ann-sylnil-forward",
+    "proofId": "sylow-theorem-oq-02-oq-01",
+    "range": { "startLine": 56, "endLine": 60 },
+    "type": "theorem",
+    "title": "The Forward Direction, Packaged for Reuse",
+    "content": "sylow_normal_of_nilpotent is the forward implication of the headline, repackaged with the prime hypothesis as an *instance-implicit* `[hp : Fact p.Prime]` rather than the explicit `(_hp : ...)` binder of the TFAE statement. This small repackaging is what lets every downstream lemma (the normalizer corollary, the counting characterization) apply it by typeclass resolution without threading the primality proof by hand. It is the directly usable form 'in a finite nilpotent group, every Sylow p-subgroup is normal'.",
+    "mathContext": "$$G \\text{ nilpotent} \\ \\Rightarrow\\ \\forall p,\\ P \\in \\mathrm{Syl}_p(G):\\ P \\trianglelefteq G.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Sylow subgroup",
+      "normal subgroup",
+      "instance-implicit argument",
+      "Fact"
+    ],
+    "prerequisites": [
+      "nilpotent_iff_forall_sylow_normal"
     ]
   },
   {
@@ -42,11 +81,11 @@
     "id": "ann-sylnil-counting",
     "proofId": "sylow-theorem-oq-02-oq-01",
     "range": { "startLine": 76, "endLine": 94 },
-    "type": "technique",
+    "type": "tactic",
     "title": "Normality ⟺ Uniqueness Turns Structure into Counting",
     "content": "nilpotent_iff_forall_card_sylow_eq_one fuses the headline with the fact that a Sylow p-subgroup is normal iff it is the unique one. Forward: from normality, Sylow.unique_of_normal yields Unique (Sylow p G), so Nat.card_unique gives n_p = 1. Backward: from n_p = 1, Nat.card_eq_one_iff_unique recovers Subsingleton (Sylow p G), and Sylow.normal_of_subsingleton (via characteristicity) returns normality. Quantifying over all primes converts 'all Sylow normal' into the arithmetic statement 'all n_p = 1', the global counterpart of the parent's per-prime n_p = 1 ⟺ P ◁ G.",
     "mathContext": "$$G \\text{ nilpotent} \\iff \\forall p,\\ n_p = \\#\\,\\mathrm{Syl}_p(G) = 1.$$",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "Sylow uniqueness",
       "subsingleton",

--- a/src/data/proofs/sylow-theorem-oq-02-oq-01/index.ts
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SylowTheoremOQ02OQ01Nilpotent.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const sylowTheoremOq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const sylowTheoremOq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const sylowTheoremOq02Oq01Data: ProofData = {
+  proof: sylowTheoremOq02Oq01Proof,
+  annotations: sylowTheoremOq02Oq01Annotations,
+}

--- a/src/data/proofs/sylow-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-01/meta.json
@@ -85,6 +85,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Setup: Local-to-Global Framing",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring framing the lift from the parent's per-prime n_p = [G : N_G(P)] criterion to a global nilpotency characterization, imports (Nilpotent, Sylow, Subgroup.Basic, Tactic), namespace SylowNilpotent, and the standing context variable {G : Type*} [Group G] [Finite G].",
+      "mathContext": "Finiteness is essential: nilpotent ⟺ all-Sylow-normal is special to finite groups."
+    },
+    {
       "id": "headline",
       "title": "Nilpotent ⟺ All Sylow Normal",
       "startLine": 50,


### PR DESCRIPTION
Enrichment pass for `sylow-theorem-oq-02-oq-01` (quality 81, pass 0).

## Changes
- **Created missing `index.ts`** — the proof had no Vite entry point (page rendered "proof not found" on the live site). Highest-impact fix.
- **Fixed invalid annotation enums** (systemic defect #31246): `type` `technique`→`tactic` (×2), `significance` `central`→`critical` (×2). Valid enums per `src/types/proof.ts`: type ∈ {theorem,lemma,definition,tactic,concept,insight,warning}; significance ∈ {critical,key,supporting}.
- **Added 2 annotations** (module-docstring local-to-global framing; the packaged forward direction `sylow_normal_of_nilpotent`) → 5 total, covering setup + all 4 theorems.
- **Added a `setup` section** covering lines 1–49 (imports/docstring/context), which the prior 3 sections left uncovered.

## Verification
- meta.json + annotations.json valid JSON; meta 14 KB (under caps). All 5 annotations use valid enums. `tsc -b` clean. Axiom integrity unchanged (verified, 0 axioms/sorries).