### PR TITLE
research(inverse-galois-oq-06-oq-02): gap characterization — lone axiom ⇔ |q.Gal|=60

### DIFF
--- a/proofs/Proofs/InverseGaloisOQ06OQ02GapChar.lean
+++ b/proofs/Proofs/InverseGaloisOQ06OQ02GapChar.lean
@@ -1,0 +1,109 @@
+import Mathlib
+import Proofs.InverseGaloisA5
+
+/-
+# The remaining axiom has no slack: `three_dvd_gal_card ↔ |q.Gal| = 60`
+
+`InverseGaloisA5.lean` reduces A₅-realizability of
+`q = X⁵ - 5X⁴ + 10X³ - 10X² + 25X - 5` to a single axiom
+
+```
+axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal     -- InverseGaloisA5.lean:309
+```
+
+Every other ingredient of `|q.Gal| = 60` is machine-checked there:
+
+* `five_dvd_gal_card`      : `5 ∣ |q.Gal|`
+* `gal_card_dvd_60_proved` : `|q.Gal| ∣ 60`   (Vandermonde / all-even argument)
+* `gal_card_ne_15`         : `|q.Gal| ≠ 15`    (no `S₅`-subgroup of order 15)
+* `gal_card_ne_30`         : `|q.Gal| ≠ 30`    (no `S₅`-subgroup of order 30, A₅ simple)
+
+This file records, **without using the axiom**, that these constraints pin the
+group so tightly that the lone axiom is *logically equivalent* to the full
+conclusion: given everything `InverseGaloisA5` already proves,
+
+  `3 ∣ |q.Gal|   ↔   |q.Gal| = 60`.
+
+In other words the remaining gap has **no slack** — `three_dvd_gal_card` is
+exactly as strong as the A₅-realizability target, neither more nor less. The
+forward direction is the `q_gal_card` divisor argument with the axiom replaced by
+a hypothesis, so it does **not** depend on `three_dvd_gal_card` (verified by
+`#print axioms`). It does, however, inherit `Lean.ofReduceBool` /
+`Lean.trustCompiler` from the `InverseGaloisA5` constraint lemmas
+`gal_card_dvd_60_proved`, `gal_card_ne_15`, `gal_card_ne_30`, which are
+discharged by `native_decide` — so these results are *not* axiom-free, they carry
+the same `native_decide` trust base as the underlying A₅ entry. The point is
+narrower and exact: they remove the dependence on the *open* axiom
+`three_dvd_gal_card`, replacing it with an explicit hypothesis.
+
+Combining with the concrete Galois bridge of
+`InverseGaloisOQ06OQ02GalBridge.lean`, we obtain the sharpest statement of the
+residual input on the mod-7 Dedekind route:
+
+  *A single Galois automorphism acting on the five roots as a 3-cycle (the
+  Frobenius element at the unramified prime 7, whose existence is the only open
+  step) already forces `|q.Gal| = 60`.*
+
+Nothing here discharges the axiom; it characterises precisely what the axiom buys.
+-/
+
+open Polynomial InverseGaloisA5
+
+open scoped Classical
+
+namespace InverseGaloisOQ06OQ02GapChar
+
+/-- **Forward direction, axiom-free.** Given the machine-checked constraints of
+`InverseGaloisA5` (`5 ∣ |q.Gal|`, `|q.Gal| ∣ 60`, `|q.Gal| ≠ 15`, `≠ 30`), the
+hypothesis `3 ∣ |q.Gal|` forces `|q.Gal| = 60`. This is the body of
+`InverseGaloisA5.q_gal_card` with the axiom `three_dvd_gal_card` replaced by an
+explicit hypothesis, so it does **not** depend on that axiom. -/
+theorem card_eq_60_of_three_dvd (h3 : 3 ∣ Fintype.card q.Gal) :
+    Fintype.card q.Gal = 60 := by
+  have h15 : 15 ∣ Fintype.card q.Gal :=
+    Nat.Coprime.mul_dvd_of_dvd_of_dvd (by norm_num : Nat.Coprime 3 5)
+      h3 five_dvd_gal_card
+  have h_dvd := gal_card_dvd_60_proved
+  have hne15 := gal_card_ne_15
+  have hne30 := gal_card_ne_30
+  obtain ⟨k, hk⟩ := h15
+  have hk_pos : 0 < k := by
+    have hpos : 0 < Fintype.card q.Gal := Fintype.card_pos
+    rw [hk] at hpos; omega
+  have hk_dvd : k ∣ 4 := by
+    rw [hk] at h_dvd
+    exact Nat.dvd_of_mul_dvd_mul_left (by norm_num : 0 < 15) h_dvd
+  have hk_le : k ≤ 4 := Nat.le_of_dvd (by norm_num) hk_dvd
+  have hk_ne1 : k ≠ 1 := fun h => by rw [h, Nat.mul_one] at hk; exact hne15 hk
+  have hk_ne2 : k ≠ 2 := fun h => by subst h; norm_num at hk; exact hne30 hk
+  interval_cases k <;> simp_all
+
+/-- **The remaining axiom has no slack.** Modulo the constraints already proved
+in `InverseGaloisA5`, the single open axiom `three_dvd_gal_card` is logically
+equivalent to the A₅-realizability target `|q.Gal| = 60`. The reverse direction
+is `3 ∣ 60`; the forward direction is `card_eq_60_of_three_dvd`, which is
+independent of `three_dvd_gal_card` (it inherits only the `native_decide` trust
+base — `Lean.ofReduceBool` — of the A₅ constraint lemmas). -/
+theorem three_dvd_card_iff_card_eq_60 :
+    3 ∣ Fintype.card q.Gal ↔ Fintype.card q.Gal = 60 :=
+  ⟨card_eq_60_of_three_dvd, fun h => h ▸ (by norm_num)⟩
+
+/-- **Sharpest form of the residual input.** A single Galois automorphism acting
+on the five roots as a 3-cycle — the Frobenius element at the unramified prime 7,
+matching the verified `(1,1,3)` factorization `q_mod7_factor_type`, and the sole
+remaining open step — already forces the full count `|q.Gal| = 60`. This inlines
+the concrete deterministic-half bridge (injectivity of `galActionHom` carries the
+root-permutation cycle type to `orderOf σ = 3`, then `orderOf_dvd_card`) into
+`card_eq_60_of_three_dvd`. Like the rest of the file it is independent of the
+open axiom `three_dvd_gal_card`, inheriting only the `native_decide` trust base
+(`Lean.ofReduceBool`) of the A₅ constraint lemmas. -/
+theorem card_eq_60_of_exists_galAction_threeCycle
+    (h : ∃ σ : q.Gal, (Polynomial.Gal.galActionHom q q.SplittingField σ).IsThreeCycle) :
+    Fintype.card q.Gal = 60 := by
+  obtain ⟨σ, hσ⟩ := h
+  have horder : orderOf σ = 3 := by
+    rw [← orderOf_injective _ (Polynomial.Gal.galActionHom_injective q q.SplittingField) σ]
+    exact hσ.orderOf
+  exact card_eq_60_of_three_dvd (horder ▸ orderOf_dvd_card)
+
+end InverseGaloisOQ06OQ02GapChar

--- a/research/problems/inverse-galois-oq-06-oq-02/knowledge.md
+++ b/research/problems/inverse-galois-oq-06-oq-02/knowledge.md
@@ -96,3 +96,43 @@ half so the only remaining gap is the Frobenius ↔ factorization correspondence
   Use the `Irreducible.isRelPrime_iff_not_dvd` / `dvd_iff_isRoot` route instead.
 - `squarefree_mul_iff` is phrased with `IsRelPrime`, not `IsCoprime` — calling
   `IsCoprime.squarefree_mul_iff` fails; convert first.
+
+---
+
+## Gap characterization (iter 5 / GapChar file)
+
+`InverseGaloisOQ06OQ02GapChar.lean` records that the lone open axiom of the A₅
+entry has **no slack**: given the constraints `InverseGaloisA5` already proves
+(`5 ∣ |q.Gal|`, `|q.Gal| ∣ 60`, `≠ 15`, `≠ 30`),
+
+  `three_dvd_card_iff_card_eq_60 : 3 ∣ |q.Gal| ↔ |q.Gal| = 60`.
+
+So `three_dvd_gal_card` is *exactly* as strong as the A₅-realizability target
+`q_gal_card`, neither weaker nor stronger. Forward direction
+`card_eq_60_of_three_dvd` is the `q_gal_card` divisor argument
+(`Nat.Coprime.mul_dvd_of_dvd_of_dvd` to get `15 ∣ |Gal|`, then
+`gal_card_dvd_60_proved` bounds the cofactor `k ∣ 4`, `interval_cases k`) with
+the axiom replaced by an explicit hypothesis — so it is **independent of
+`three_dvd_gal_card`** (verified by `#print axioms`).
+
+Capstone `card_eq_60_of_exists_galAction_threeCycle` chains the inlined
+deterministic-half bridge (injective `galActionHom` ⟹ `orderOf σ = 3` ⟹
+`orderOf_dvd_card`) into the forward direction: a **single** Galois automorphism
+acting on the five roots as a 3-cycle (the Frobenius at 7) forces the full
+`|q.Gal| = 60`. This is the sharpest statement of the residual mod-7 input.
+
+### HONESTY CORRECTION (important)
+
+These GapChar theorems are **NOT** `0-axiom`/`propext-Classical-Quot only`.
+`#print axioms` shows they inherit **`Lean.ofReduceBool` + `Lean.trustCompiler`**
+from the A₅ constraint lemmas `gal_card_dvd_60_proved`, `gal_card_ne_15`,
+`gal_card_ne_30`, all of which are discharged by `native_decide`. The earlier
+sibling files (`Cycle`, `GalBridge`) avoided this only because they never pull in
+those constraint lemmas — they touch just `galActionHom` + `orderOf_dvd_card`.
+The honest claim is therefore narrower: GapChar removes dependence on the **open**
+axiom `three_dvd_gal_card`, replacing it with a hypothesis, while carrying the
+same `native_decide` trust base as the underlying A₅ entry. Do not call it
+axiom-free.
+
+(`five_dvd_gal_card` IS clean — propext/Classical.choice/Quot.sound only. The
+`native_decide` lives in the divisibility-bound and order-exclusion lemmas.)

--- a/src/data/research/problems/inverse-galois-oq-06-oq-02.json
+++ b/src/data/research/problems/inverse-galois-oq-06-oq-02.json
@@ -30,12 +30,12 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-28",
-    "iteration": 4,
-    "focus": "Iteration 4 (researcher-2, 2026-06-28): added Proofs/InverseGaloisOQ06OQ02GalBridge.lean (0-axiom, 0-sorry) instantiating the deterministic half of Dedekind against the REAL q.Gal of the A5 quintic (not an abstract Subgroup (Perm a)). Using the genuine, already-injective root action Polynomial.Gal.galActionHom q q.SplittingField, proves three_dvd_gal_card_of_galAction_isThreeCycle / _cycleType / _of_exists_galAction_threeCycle: IF some sigma in q.Gal acts on the five roots as a 3-cycle THEN 3 | Fintype.card q.Gal. orderOf_injective converts the root-permutation cycle type to orderOf sigma = 3, then orderOf_dvd_card. Also exists_order_three_of_exists_galAction_threeCycle shows this root-3-cycle hypothesis is at least as strong as the sibling InverseGaloisA5Dedekind.exists_gal_order_three. None depend on the three_dvd_gal_card axiom (verified via #print axioms: only propext/Classical.choice/Quot.sound). The residual gap is now exactly: produce sigma in q.Gal whose root permutation has cycle type {3} (Frobenius at 7), phrased directly in terms of the (1,1,3) factorization datum this slug verifies.",
+    "iteration": 5,
+    "focus": "Iteration 5 (researcher-1, 2026-06-28): added Proofs/InverseGaloisOQ06OQ02GapChar.lean characterizing the lone open axiom three_dvd_gal_card as having NO SLACK. Proves three_dvd_card_iff_card_eq_60 : 3 | |q.Gal| <-> |q.Gal| = 60, i.e. the axiom is logically equivalent (modulo the already-proven InverseGaloisA5 constraints 5 | |Gal|, |Gal| | 60, !=15, !=30) to the full A5-realizability target q_gal_card. Forward direction card_eq_60_of_three_dvd is the q_gal_card divisor argument with the axiom replaced by a hypothesis, verified by #print axioms to be INDEPENDENT of three_dvd_gal_card. Capstone card_eq_60_of_exists_galAction_threeCycle: a single Galois automorphism acting on the five roots as a 3-cycle (Frobenius at 7) already forces |q.Gal| = 60 (inlines the injective-galActionHom -> orderOf 3 -> orderOf_dvd_card bridge). HONESTY: these theorems are NOT axiom-free -- #print axioms shows they inherit Lean.ofReduceBool + Lean.trustCompiler (native_decide) from the A5 constraint lemmas gal_card_dvd_60_proved / gal_card_ne_15 / gal_card_ne_30. The narrow, exact claim is only that they remove dependence on the OPEN axiom three_dvd_gal_card.",
     "blockers": [
       "Dedekind's theorem is not in Mathlib 4.26; the (1,1,3) => 3-cycle => 3 | |Gal| implication stays axiomatized (sibling track)."
     ],
-    "nextAction": "Residual gap is part (A) only and now maximally precise: exhibit sigma in q.Gal with (galActionHom q q.SplittingField sigma).IsThreeCycle (the Frobenius at the unramified prime 7, cycle type matching q_mod7_factor_type). Feeding it to three_dvd_gal_card_of_exists_galAction_threeCycle discharges three_dvd_gal_card for the real q.Gal. Owned by sibling inverse-galois-a5-oq-01 (Frobenius/inertia API).",
+    "nextAction": "Residual gap is unchanged and now triply precise: produce sigma in q.Gal with (galActionHom q q.SplittingField sigma).IsThreeCycle (Frobenius at the unramified prime 7). By card_eq_60_of_exists_galAction_threeCycle this single existential discharges the whole |q.Gal| = 60 result, not merely 3 | |Gal|. Owned by sibling inverse-galois-a5-oq-01 (Frobenius/inertia API) -- a genuine Mathlib 4.26 gap (Dedekind's theorem), not closable within this slug's scope.",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 1,
@@ -43,7 +43,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT: shipped 0-axiom mod-7 Dedekind input (q_mod7_factor_type), corroborated at p=11 (q_mod11_factor_type), isolated the abstract permutation-group consequence (part B) in InverseGaloisOQ06OQ02Cycle.lean, and now (iter 4) instantiated that deterministic half against the ACTUAL q.Gal in InverseGaloisOQ06OQ02GalBridge.lean: IF a Galois automorphism acts on the 5 roots as a 3-cycle THEN 3 | |q.Gal|, via injectivity of galActionHom + orderOf_dvd_card (0-axiom/0-sorry, does not use the three_dvd_gal_card axiom). Residual gap is now the single existential: a Galois element whose root permutation has cycle type {3} (Frobenius at 7) — part (A), sibling track.",
+    "progressSummary": "ACT: shipped 0-axiom mod-7 Dedekind input (q_mod7_factor_type), corroborated at p=11 (q_mod11_factor_type), isolated the abstract permutation-group consequence (part B) in InverseGaloisOQ06OQ02Cycle.lean, and now (iter 4) instantiated that deterministic half against the ACTUAL q.Gal in InverseGaloisOQ06OQ02GalBridge.lean: IF a Galois automorphism acts on the 5 roots as a 3-cycle THEN 3 | |q.Gal|, via injectivity of galActionHom + orderOf_dvd_card (0-axiom/0-sorry, does not use the three_dvd_gal_card axiom). Residual gap is now the single existential: a Galois element whose root permutation has cycle type {3} (Frobenius at 7) — part (A), sibling track. Iter 5: GapChar.lean characterizes the lone open axiom as exactly equivalent (no slack) to |q.Gal|=60, and shows a single Frobenius 3-cycle forces the full result -- both independent of three_dvd_gal_card though native_decide-backed.",
     "builtItems": [
       "cubicMod7_irreducible via irreducible_of_degree_le_three_of_not_isRoot",
       "pairwise non-association of the three factors (eq_of_monic_of_associated + degree bounds)",
@@ -51,7 +51,8 @@
       "q_mod7_factor_type packaged Dedekind input",
       "[p=11 corroboration] InverseGaloisOQ06OQ02P11.lean (0-axiom, 0-sorry): q mod 11 = (X-4)(X-3)(X^3+2X^2+X-5), cubicMod11 irreducible (no roots in F_11), pairwise non-associated, squarefree, AND the full coefficient-by-coefficient factorization identity q_ℤ.map = (X-4)(X-3)*cubicMod11 — an independent (1,1,3) witness at a second unramified prime",
       "[part B: group-theory consequence] InverseGaloisOQ06OQ02Cycle.lean (0-axiom, 0-sorry): frob113 = swap 2 3 * swap 2 4 an explicit (1,1,3) permutation of the 5 roots (fixes 0,1 = the two linear-factor roots), frob113_isThreeCycle / frob113_cycleType={3} / frob113_orderOf=3; abstract bridges three_dvd_card_of_orderOf_three (finite group + order-3 elt => 3|card via orderOf_dvd_card), three_dvd_natCard_of_isThreeCycle_mem (subgroup of S(α) containing a 3-cycle => 3|Nat.card via Subgroup.orderOf_dvd_natCard), and dedekind_consequence_113. Verifies the deterministic half of Dedekind so the residual gap is exactly part (A).",
-      "[part B, instantiated to real q.Gal] InverseGaloisOQ06OQ02GalBridge.lean (0-axiom, 0-sorry): three_dvd_gal_card_of_galAction_isThreeCycle / _cycleType / _of_exists_galAction_threeCycle — if some sigma in q.Gal acts on the five roots as a 3-cycle (cycle type {3}, the (1,1,3) shape of q mod 7) then 3 | Fintype.card q.Gal. orderOf_galActionHom (= orderOf_injective on the injective Polynomial.Gal.galActionHom) carries the permutation cycle type to orderOf sigma = 3, then orderOf_dvd_card. exists_order_three_of_exists_galAction_threeCycle bridges to the sibling exists_gal_order_three shape. Verified by #print axioms to use only propext/Classical.choice/Quot.sound (no dependency on the three_dvd_gal_card axiom)."
+      "[part B, instantiated to real q.Gal] InverseGaloisOQ06OQ02GalBridge.lean (0-axiom, 0-sorry): three_dvd_gal_card_of_galAction_isThreeCycle / _cycleType / _of_exists_galAction_threeCycle — if some sigma in q.Gal acts on the five roots as a 3-cycle (cycle type {3}, the (1,1,3) shape of q mod 7) then 3 | Fintype.card q.Gal. orderOf_galActionHom (= orderOf_injective on the injective Polynomial.Gal.galActionHom) carries the permutation cycle type to orderOf sigma = 3, then orderOf_dvd_card. exists_order_three_of_exists_galAction_threeCycle bridges to the sibling exists_gal_order_three shape. Verified by #print axioms to use only propext/Classical.choice/Quot.sound (no dependency on the three_dvd_gal_card axiom).",
+      "[gap characterization] InverseGaloisOQ06OQ02GapChar.lean (3 thm, 0 sorry, 0 axiom decls; inherits Lean.ofReduceBool/native_decide from A5 constraint lemmas -- NOT axiom-free): three_dvd_card_iff_card_eq_60 (3 | |q.Gal| <-> |q.Gal| = 60), card_eq_60_of_three_dvd (forward dir, #print axioms confirms independent of the three_dvd_gal_card axiom), card_eq_60_of_exists_galAction_threeCycle (a single root-3-cycle Galois element forces |q.Gal| = 60). Shows the lone open axiom has no slack: it is exactly equivalent to the A5-realizability target."
     ],
     "insights": [
       "A degree-3 poly over a field with no root is irreducible: irreducible_of_degree_le_three_of_not_isRoot.",
@@ -62,13 +63,16 @@
       "Equiv.Perm.IsThreeCycle.orderOf : orderOf g = 3 (cycle type {3} => order 3 via lcm_cycleType).",
       "Subgroup.orderOf_dvd_natCard (s) (hx : x ∈ s) : orderOf x ∣ Nat.card s — turns an element's order directly into a divisor of the subgroup order (no Fintype needed).",
       "orderOf_injective (f : G ->* H) (hf : Function.Injective f) (x) : orderOf (f x) = orderOf x — converts an injective monoid hom (here Polynomial.Gal.galActionHom, injectivity already in InverseGaloisA5) into order preservation, turning a root-permutation cycle type into the abstract element order.",
-      "IsThreeCycle / cycleType over q.rootSet q.SplittingField needs DecidableEq on the (noncomputable) root subtype; supply via open scoped Classical (matching the A5 parent file)."
+      "IsThreeCycle / cycleType over q.rootSet q.SplittingField needs DecidableEq on the (noncomputable) root subtype; supply via open scoped Classical (matching the A5 parent file).",
+      "Given 5 | |G|, |G| | 60, |G| != 15, |G| != 30 (all machine-checked in A5), the cofactor argument (15 | |G|, k = |G|/15 | 4, interval_cases k) makes 3 | |G| EQUIVALENT to |G| = 60 -- the remaining axiom has no slack.",
+      "HONESTY/native_decide: A5's gal_card_dvd_60_proved, gal_card_ne_15, gal_card_ne_30 all carry Lean.ofReduceBool (native_decide); any downstream theorem using them inherits it and is NOT axiom-free. Only five_dvd_gal_card among the constraints is clean (propext/Classical.choice/Quot.sound)."
     ],
     "mathlibGaps": [
       "Dedekind's theorem: mod-p factorization type => Frobenius cycle type for number fields (not in Mathlib 4.26).",
       "Frobenius element / inertia degree machinery for number field extensions."
     ],
     "nextSteps": [
+      "DONE (iter 5): gap-characterization GapChar.lean -- axiom <-> |Gal|=60 equivalence + single-3-cycle => full result, both independent of the open axiom (but native_decide-backed).",
       "Residual: part (A) only — exhibit sigma in q.Gal with (galActionHom q q.SplittingField sigma).IsThreeCycle (Frobenius at the unramified prime 7). Feed to three_dvd_gal_card_of_exists_galAction_threeCycle to discharge three_dvd_gal_card for the real q.Gal. Owned by sibling inverse-galois-a5-oq-01 (exists_gal_order_three / Frobenius-inertia API).",
       "DONE (iter 4): instantiated the deterministic half against the real q.Gal via the injective galActionHom (InverseGaloisOQ06OQ02GalBridge.lean).",
       "DONE (iter 3): abstract part (B) in InverseGaloisOQ06OQ02Cycle.lean.",
@@ -97,6 +101,17 @@
   "started": "2026-06-27",
   "lastUpdate": "2026-06-28",
   "leanFiles": [
+    {
+      "path": "Proofs/InverseGaloisOQ06OQ02GapChar.lean",
+      "filename": "InverseGaloisOQ06OQ02GapChar.lean",
+      "lineCount": 109,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ06OQ02GapChar.lean"
+    },
     {
       "path": "Proofs/InverseGaloisOQ06OQ02GalBridge.lean",
       "filename": "InverseGaloisOQ06OQ02GalBridge.lean",


### PR DESCRIPTION
## Summary

Iteration 5 on `inverse-galois-oq-06-oq-02` (the mod-7 algebraic input to the A₅-realizability Dedekind route). The machine-checkable algebraic scope of this slug was already complete (`q_mod7_factor_type`, p=11 corroboration, abstract part-B cycle bridge, and the `q.Gal` instantiation `GalBridge`). This iteration adds a **gap-characterization** file.

`Proofs/InverseGaloisOQ06OQ02GapChar.lean` (3 theorems, 0 sorry, 0 axiom declarations):

- **`three_dvd_card_iff_card_eq_60 : 3 ∣ |q.Gal| ↔ |q.Gal| = 60`** — modulo the constraints `InverseGaloisA5` already proves (`5 ∣ |Gal|`, `|Gal| ∣ 60`, `≠ 15`, `≠ 30`), the lone open axiom `three_dvd_gal_card` is *exactly* as strong as the realizability target `q_gal_card`. The remaining gap has **no slack**.
- **`card_eq_60_of_three_dvd`** — forward direction: the `q_gal_card` divisor argument with the axiom replaced by a hypothesis. `#print axioms` confirms it does **not** depend on `three_dvd_gal_card`.
- **`card_eq_60_of_exists_galAction_threeCycle`** — capstone: a *single* Galois automorphism acting on the five roots as a 3-cycle (the Frobenius at the unramified prime 7) already forces the full `|q.Gal| = 60`. Inlines the injective-`galActionHom` → `orderOf σ = 3` → `orderOf_dvd_card` bridge.

## Honesty / axiom disclosure

These theorems are **NOT axiom-free**. `#print axioms` shows they inherit `Lean.ofReduceBool` + `Lean.trustCompiler` (`native_decide`) from the A₅ constraint lemmas `gal_card_dvd_60_proved` / `gal_card_ne_15` / `gal_card_ne_30`. The exact, narrow claim is only that they **remove dependence on the open axiom** `three_dvd_gal_card`, replacing it with an explicit hypothesis. (`five_dvd_gal_card` is clean; the `native_decide` lives in the divisibility-bound / order-exclusion lemmas.)

## Residual gap (unchanged, out of this slug's scope)

Exhibit the Frobenius 3-cycle `∃ σ : q.Gal, (galActionHom q q.SplittingField σ).IsThreeCycle` — Dedekind's theorem, a genuine Mathlib 4.26 gap owned by sibling `inverse-galois-a5-oq-01`. This PR does **not** eliminate `three_dvd_gal_card`; it characterizes precisely what that axiom buys.

## Verification

Builds cleanly via `proofs/bin/lake env lean Proofs/InverseGaloisOQ06OQ02GapChar.lean` (Docker host wedged; `lake env lean` against the prebuilt `InverseGaloisA5.olean`). `#print axioms` run on all three theorems: present `propext / Classical.choice / Quot.sound / Lean.ofReduceBool / Lean.trustCompiler`; **absent** `three_dvd_gal_card`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)