### PR TITLE
research(fibonacci-identities-oq-04-oq-01-oq-01): matrix proof of Cassini via det(Qⁿ)=(−1)ⁿ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ04OQ01OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ04OQ01OQ01.lean
@@ -1,0 +1,128 @@
+import Mathlib
+
+/-
+# The matrix form of Cassini's identity: `det(Qⁿ) = (−1)ⁿ`
+
+`fibonacci-identities-oq-04-oq-01` proved Vajda's identity for the Gibonacci
+(Horadam) sequences and recovered Cassini, Catalan, d'Ocagne and Gelin–Cesàro as
+corollaries — all by *algebraic* manipulation of the closed form
+`G n = a·F n + b·F(n−1)`.
+
+This entry supplies the **linear-algebra proof of Cassini's identity**, the first
+open question of that parent.  Let
+
+  `Q = [[1, 1], [1, 0]]`.
+
+The single structural fact is the **Fibonacci `Q`-matrix identity**
+
+  `Qⁿ⁺¹ = [[F(n+2), F(n+1)], [F(n+1), F n]]`,
+
+proved by induction using only `Qⁿ⁺² = Qⁿ⁺¹ · Q` and the recurrence
+`F(n+2) = F n + F(n+1)`.  Cassini then drops out of **multiplicativity of the
+determinant**:
+
+  `det(Qⁿ⁺¹) = (det Q)ⁿ⁺¹ = (−1)ⁿ⁺¹`,
+
+while the `2×2` determinant of the right-hand side is
+`F(n+2)·F n − F(n+1)²`.  Equating the two gives
+
+  `F(n+2)·F n − F(n+1)² = (−1)ⁿ⁺¹`,
+
+which is Cassini's identity.  Re-indexing recovers the textbook form
+`F(n−1)·F(n+1) − F n² = (−1)ⁿ`.
+
+This is a genuinely different proof from the parent: there the sign `(−1)ⁿ` came
+from a parity lemma about `(−1)^|x|`; here it is *the determinant of `Q` raised to
+a power* — the conceptual reason Cassini's sign alternates.  The whole development
+is over `ℤ` matrices.  No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace FibonacciIdentitiesOQ04OQ01OQ01
+
+open Matrix
+
+/-- The Fibonacci `Q`-matrix `Q = [[1, 1], [1, 0]]` over `ℤ`. -/
+def Q : Matrix (Fin 2) (Fin 2) ℤ := !![1, 1; 1, 0]
+
+/-- `det Q = −1`.  This `−1` is the entire source of Cassini's alternating sign. -/
+@[simp] theorem det_Q : Q.det = -1 := by
+  simp [Q, det_fin_two_of]
+
+/-- **The Fibonacci `Q`-matrix identity.**
+
+  `Qⁿ⁺¹ = [[F(n+2), F(n+1)], [F(n+1), F n]]`.
+
+Indexing from `n+1` keeps every entry a genuine (non-negative-index) Fibonacci
+number, so the base case is just `Q¹ = Q`. -/
+theorem Q_pow (n : ℕ) :
+    Q ^ (n + 1)
+      = !![(Nat.fib (n + 2) : ℤ), (Nat.fib (n + 1) : ℤ);
+            (Nat.fib (n + 1) : ℤ), (Nat.fib n : ℤ)] := by
+  induction n with
+  | zero =>
+    rw [pow_one]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [Q, Nat.fib_one, Nat.fib_two, Nat.fib_zero]
+  | succ k ih =>
+    rw [pow_succ, ih]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [Matrix.mul_apply, Fin.sum_univ_two, Q,
+        show k + 1 + 2 = k + 2 + 1 from rfl, show k + 1 + 1 = k + 2 from rfl] <;>
+      push_cast [Nat.fib_add_two] <;> ring
+
+/-- `det(Qⁿ⁺¹) = (−1)ⁿ⁺¹` by multiplicativity of the determinant. -/
+theorem det_Q_pow (n : ℕ) : (Q ^ (n + 1)).det = (-1 : ℤ) ^ (n + 1) := by
+  rw [det_pow, det_Q]
+
+/-- **Cassini's identity, matrix form.**
+
+  `F(n+2)·F n − F(n+1)² = (−1)ⁿ⁺¹`.
+
+The left side is `det` of the `Q`-matrix identity's right-hand side; the right side
+is `det(Qⁿ⁺¹) = (det Q)ⁿ⁺¹`. -/
+theorem cassini_matrix (n : ℕ) :
+    (Nat.fib (n + 2) : ℤ) * Nat.fib n - (Nat.fib (n + 1) : ℤ) ^ 2 = (-1) ^ (n + 1) := by
+  have h := det_Q_pow n
+  rw [Q_pow n, det_fin_two_of] at h
+  -- `det !![F(n+2), F(n+1); F(n+1), F n] = F(n+2)·F n − F(n+1)·F(n+1)`
+  linear_combination h
+
+/-- **Cassini's identity, textbook indexing.**
+
+  `F(n−1)·F(n+1) − F n² = (−1)ⁿ`   for `n ≥ 1`.
+
+Obtained from `cassini_matrix` at `n − 1`. -/
+theorem cassini_classic (n : ℕ) (hn : 1 ≤ n) :
+    (Nat.fib (n - 1) : ℤ) * Nat.fib (n + 1) - (Nat.fib n : ℤ) ^ 2 = (-1) ^ n := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_lt (Nat.lt_of_lt_of_le Nat.zero_lt_one hn)
+  -- now the index is `0 + m + 1 = m + 1`
+  simp only [Nat.zero_add, Nat.add_sub_cancel]
+  have h := cassini_matrix m
+  -- `F(m+2)·F m − F(m+1)² = (−1)^(m+1)`; rewrite `m+1` index target accordingly
+  rw [show m + 1 + 1 = m + 2 from rfl]
+  linear_combination h
+
+/-- **Cassini over `ℤ`-indexed Fibonacci**, recovering the parent's statement.
+
+  `F(n+1)·F(n−1) − F n² = (−1)ⁿ`  for `n : ℤ`,
+
+stated with `Int.fib`.  For non-negative indices this is exactly `cassini_classic`
+transported across `Int.fib_natCast`; it agrees with Mathlib's
+`Int.fib_succ_mul_fib_pred_sub_fib_sq`, but the proof here flows from the `Q`-matrix
+determinant rather than from `Int`-level algebra. -/
+theorem cassini_int_nonneg (n : ℕ) (hn : 1 ≤ n) :
+    Int.fib ((n : ℤ) + 1) * Int.fib ((n : ℤ) - 1) - Int.fib (n : ℤ) ^ 2 = (-1) ^ n := by
+  have h := cassini_classic n hn
+  have e1 : Int.fib ((n : ℤ) + 1) = (Nat.fib (n + 1) : ℤ) := by
+    rw [show (n : ℤ) + 1 = ((n + 1 : ℕ) : ℤ) by push_cast; ring, Int.fib_natCast]
+  have e2 : Int.fib ((n : ℤ) - 1) = (Nat.fib (n - 1) : ℤ) := by
+    obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_lt (Nat.lt_of_lt_of_le Nat.zero_lt_one hn)
+    rw [show ((0 + m + 1 : ℕ) : ℤ) - 1 = ((m : ℕ) : ℤ) by push_cast; ring, Int.fib_natCast]
+    simp
+  have e3 : Int.fib (n : ℤ) = (Nat.fib n : ℤ) := Int.fib_natCast n
+  rw [e1, e2, e3]
+  linear_combination h
+
+end FibonacciIdentitiesOQ04OQ01OQ01

--- a/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-fiboq040101-1",
+    "proofId": "fibonacci-identities-oq-04-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 49 },
+    "type": "definition",
+    "title": "The Fibonacci Q-Matrix and Its Determinant",
+    "content": "**`Q = !![1, 1; 1, 0]`** is the companion matrix of the Fibonacci recurrence $x^2 = x + 1$. The entire proof rests on two facts about it. First, **`det_Q`**: $\\det Q = 1\\cdot 0 - 1\\cdot 1 = -1$, read off by `Matrix.det_fin_two_of`. This single $-1$ is the whole source of Cassini's alternating sign — every later $(-1)^{n+1}$ is this number raised to a power. Working over $\\mathbb{Z}$ (not $\\mathbb{N}$) is essential so that the determinant can be negative.",
+    "mathContext": "$Q = \\begin{pmatrix}1&1\\\\1&0\\end{pmatrix},\\qquad \\det Q = -1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Companion matrix",
+      "Determinant of a 2×2 matrix",
+      "Fibonacci recurrence x² = x + 1"
+    ],
+    "prerequisites": [
+      "Matrix.det_fin_two_of"
+    ],
+    "tags": ["q-matrix", "determinant", "definition"]
+  },
+  {
+    "id": "ann-fiboq040101-2",
+    "proofId": "fibonacci-identities-oq-04-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 74 },
+    "type": "theorem",
+    "title": "The Q-Matrix Identity, by Induction",
+    "content": "**`Q_pow`** proves $Q^{\\,n+1} = \\begin{pmatrix}F_{n+2}&F_{n+1}\\\\F_{n+1}&F_n\\end{pmatrix}$. Indexing from $n+1$ (rather than $n$) keeps every entry a genuine non-negative-index Fibonacci number, so the **base case** is simply $Q^1 = Q$, checked entrywise after evaluating `Nat.fib 0,1,2`. The **inductive step** rewrites $Q^{\\,n+2} = Q^{\\,n+1}\\cdot Q$, substitutes the hypothesis, and expands each entry via `Matrix.mul_apply` / `Fin.sum_univ_two`. Every resulting entry is a single instance of the recurrence $F_{k+2} = F_k + F_{k+1}$, so `push_cast [Nat.fib_add_two]; ring` closes all four uniformly.",
+    "mathContext": "$Q^{\\,n+1} = \\begin{pmatrix}F_{n+2}&F_{n+1}\\\\F_{n+1}&F_n\\end{pmatrix}$, e.g. top-left $F_{n+2}+F_{n+1}=F_{n+3}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Matrix powers",
+      "Proof by induction",
+      "Entrywise matrix multiplication"
+    ],
+    "prerequisites": [
+      "Nat.fib_add_two",
+      "Matrix.mul_apply",
+      "Fin.sum_univ_two"
+    ],
+    "tags": ["induction", "matrix-power", "fibonacci"]
+  },
+  {
+    "id": "ann-fiboq040101-3",
+    "proofId": "fibonacci-identities-oq-04-oq-01-oq-01",
+    "range": { "startLine": 76, "endLine": 82 },
+    "type": "theorem",
+    "title": "Multiplicativity of the Determinant",
+    "content": "**`det_Q_pow`** is the conceptual heart: $\\det(Q^{\\,n+1}) = (\\det Q)^{\\,n+1} = (-1)^{n+1}$, a one-line consequence of `Matrix.det_pow` and `det_Q`. This is where the alternating sign is *born* — not from a parity argument about $(-1)^{|x|}$ (as in the parent), but from a scalar $-1$ propagated through the power by multiplicativity. The same step works for any companion matrix, with $-1$ replaced by its determinant.",
+    "mathContext": "$\\det(Q^{\\,n+1}) = (\\det Q)^{\\,n+1} = (-1)^{n+1}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Multiplicativity of the determinant",
+      "det(Aⁿ) = (det A)ⁿ"
+    ],
+    "prerequisites": [
+      "Matrix.det_pow"
+    ],
+    "tags": ["determinant", "multiplicativity", "sign"]
+  },
+  {
+    "id": "ann-fiboq040101-4",
+    "proofId": "fibonacci-identities-oq-04-oq-01-oq-01",
+    "range": { "startLine": 85, "endLine": 95 },
+    "type": "theorem",
+    "title": "Cassini's Identity Falls Out",
+    "content": "**`cassini_matrix`** equates the two ways of computing $\\det(Q^{\\,n+1})$. Substituting `Q_pow` into `det_Q_pow` and applying `Matrix.det_fin_two_of` to the explicit matrix gives $\\det = F_{n+2}\\cdot F_n - F_{n+1}\\cdot F_{n+1}$; equating with $(-1)^{n+1}$ and closing by `linear_combination` yields **Cassini's identity** $F_{n+2}F_n - F_{n+1}^2 = (-1)^{n+1}$. This is precisely the determinant proof the parent's open question #1 asked for.",
+    "mathContext": "$F_{n+2}F_n - F_{n+1}^2 = (-1)^{n+1}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Cassini's identity",
+      "Difference of products"
+    ],
+    "prerequisites": [
+      "Matrix.det_fin_two_of",
+      "linear_combination"
+    ],
+    "tags": ["cassini", "headline-result"]
+  },
+  {
+    "id": "ann-fiboq040101-5",
+    "proofId": "fibonacci-identities-oq-04-oq-01-oq-01",
+    "range": { "startLine": 97, "endLine": 128 },
+    "type": "theorem",
+    "title": "Textbook Indexing and the Int.fib Transport",
+    "content": "**`cassini_classic`** re-indexes `cassini_matrix` at $n-1$ (writing $n = m+1$) to recover the textbook form $F_{n-1}F_{n+1} - F_n^2 = (-1)^n$ for $n \\ge 1$. **`cassini_int_nonneg`** then transports this from `Nat.fib` to `Int.fib` across the cast `Int.fib_natCast`, reproducing — for non-negative indices — the statement of the parent and of Mathlib's `Int.fib_succ_mul_fib_pred_sub_fib_sq`, but now derived from the determinant rather than from `Int`-level algebra.",
+    "mathContext": "$F_{n-1}F_{n+1} - F_n^2 = (-1)^n$, also stated over $\\texttt{Int.fib}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Re-indexing a recurrence identity",
+      "Nat.fib ↔ Int.fib transport"
+    ],
+    "prerequisites": [
+      "Int.fib_natCast",
+      "Nat.exists_eq_add_of_lt"
+    ],
+    "tags": ["cassini", "int-fib", "re-indexing"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-01/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ04OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ04OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ04OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ04OQ01OQ01Data: ProofData = {
+  proof: fibonacciIdentitiesOQ04OQ01OQ01Proof,
+  annotations: fibonacciIdentitiesOQ04OQ01OQ01Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "fibonacci-identities-oq-04-oq-01-oq-01",
+  "title": "The Matrix Form of Cassini's Identity: det(Qⁿ) = (−1)ⁿ",
+  "slug": "fibonacci-identities-oq-04-oq-01-oq-01",
+  "description": "The parent (fibonacci-identities-oq-04-oq-01) proved Vajda's identity for Gibonacci sequences and recovered Cassini, Catalan and Gelin–Cesàro by algebraic manipulation of the closed form G(n) = a·Fₙ + b·Fₙ₋₁; its first open question asked for the linear-algebra proof of Cassini via the Fibonacci Q-matrix and multiplicativity of the determinant. This entry supplies exactly that. With Q = [[1,1],[1,0]] over ℤ, the single structural fact is the Q-matrix identity Qⁿ⁺¹ = [[F(n+2), F(n+1)], [F(n+1), F(n)]], proved by induction from Qⁿ⁺² = Qⁿ⁺¹·Q and the recurrence F(n+2) = F(n) + F(n+1). Cassini's identity then drops out of multiplicativity of the determinant: det(Qⁿ⁺¹) = (det Q)ⁿ⁺¹ = (−1)ⁿ⁺¹, while the 2×2 determinant of the right-hand side is F(n+2)·F(n) − F(n+1)². Equating gives F(n+2)·F(n) − F(n+1)² = (−1)ⁿ⁺¹, and re-indexing recovers the textbook form F(n−1)·F(n+1) − F(n)² = (−1)ⁿ. This is a genuinely different proof from the parent: there the alternating sign came from a parity lemma about (−1)^|x|; here it is the determinant of Q raised to a power — the conceptual reason Cassini's sign alternates. A final Int.fib transport (via Int.fib_natCast) recovers the parent/Mathlib statement for non-negative indices. Fully verified: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "J. D. Cassini (1680, identity); the Q-matrix / determinant proof is classical folklore; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Matrix_form",
+    "date": "1680",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "linear-algebra",
+      "fibonacci",
+      "cassini",
+      "q-matrix",
+      "determinant",
+      "matrix-power",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ04OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.det_pow",
+        "description": "det (M ^ n) = (det M) ^ n — multiplicativity of the determinant under matrix powers; the conceptual engine that turns det Q = −1 into the alternating sign (−1)ⁿ⁺¹ of Cassini",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_fin_two_of",
+        "description": "det !![a, b; c, d] = a·d − b·c — the explicit 2×2 determinant, applied both to compute det Q = −1 and to read F(n+2)·F(n) − F(n+1)² off the Q-matrix identity",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the defining Fibonacci recurrence, the only arithmetic fact needed in the inductive step of the Q-matrix identity",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Int.fib_natCast",
+        "description": "(Int.fib n : ℤ) = (Nat.fib n : ℤ) for n : ℕ — transports the ℕ-indexed matrix Cassini to the Int.fib statement of the parent/Mathlib for non-negative indices",
+        "module": "Mathlib.Data.Int.Fib.Basic"
+      },
+      {
+        "theorem": "Matrix.mul_apply / Fin.sum_univ_two",
+        "description": "Entrywise matrix product as a 2-term sum over Fin 2 — expands Qⁿ⁺¹·Q in the inductive step so each entry reduces to a Fibonacci recurrence step",
+        "module": "Mathlib.Data.Matrix.Mul / Mathlib.Algebra.BigOperators.Fin"
+      }
+    ],
+    "originalContributions": [
+      "Q : Matrix (Fin 2) (Fin 2) ℤ := !![1, 1; 1, 0] — the Fibonacci Q-matrix over ℤ, with det_Q : Q.det = −1 isolating the single source of Cassini's alternating sign",
+      "Q_pow : ∀ n : ℕ, Q ^ (n+1) = !![F(n+2), F(n+1); F(n+1), F n] — the Fibonacci Q-matrix identity, proved by induction using only Qⁿ⁺² = Qⁿ⁺¹·Q and Nat.fib_add_two; the n+1 indexing keeps every entry a genuine non-negative-index Fibonacci number so the base case is just Q¹ = Q",
+      "det_Q_pow : (Q ^ (n+1)).det = (−1)ⁿ⁺¹ — multiplicativity of the determinant (Matrix.det_pow) applied to det Q = −1",
+      "cassini_matrix : F(n+2)·F(n) − F(n+1)² = (−1)ⁿ⁺¹ — Cassini's identity obtained by equating the 2×2 determinant of the Q-matrix identity with det(Qⁿ⁺¹); the linear-algebra proof requested by the parent's open question #1",
+      "cassini_classic : F(n−1)·F(n+1) − F(n)² = (−1)ⁿ for n ≥ 1 — the textbook indexing, recovered by re-indexing cassini_matrix at n−1",
+      "cassini_int_nonneg : Int.fib(n+1)·Int.fib(n−1) − Int.fib(n)² = (−1)ⁿ for n ≥ 1 — the parent/Mathlib statement in Int.fib, transported across Int.fib_natCast, showing the matrix proof reproves the integer-indexed Cassini for non-negative indices"
+    ],
+    "dateAdded": "2026-06-28",
+    "lineCount": 128,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, confirmed by #print axioms on cassini_matrix, cassini_classic and cassini_int_nonneg). No native_decide and no decide are used.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Cassini's identity F(n−1)F(n+1) − F(n)² = (−1)ⁿ was discovered by Jean-Dominique Cassini in 1680 and rediscovered by Robert Simson in 1753. Among its many proofs, the matrix proof is the most structural: the Fibonacci numbers are the entries of the powers of the companion matrix Q = [[1,1],[1,0]] of the recurrence x² = x + 1, so Qⁿ⁺¹ = [[F(n+2), F(n+1)], [F(n+1), F(n)]]. Because det is multiplicative, det(Qⁿ⁺¹) = (det Q)ⁿ⁺¹ = (−1)ⁿ⁺¹, and the 2×2 determinant of the right-hand side is precisely the Cassini combination. This identifies the alternating sign of Cassini as nothing more than (−1) — the determinant of Q — raised to a power, and generalizes verbatim to any companion matrix. The parent Vajda entry derived Cassini algebraically; this entry answers its explicit open question for the determinant proof.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-04-oq-01, #1)**: Formalize the matrix form det(Qⁿ) = (−1)ⁿ for Q = [[1,1],[1,0]] and deduce the Fibonacci Cassini identity F(n+1)F(n−1) − F(n)² = (−1)ⁿ via multiplicativity of the determinant.\n\n**Result**: Q_pow (the Q-matrix identity Qⁿ⁺¹ = [[F(n+2),F(n+1)],[F(n+1),F(n)]]), det_Q_pow (det(Qⁿ⁺¹) = (−1)ⁿ⁺¹), and cassini_matrix (F(n+2)·F(n) − F(n+1)² = (−1)ⁿ⁺¹), with cassini_classic and cassini_int_nonneg recovering the textbook and Int.fib forms.",
+    "text": "The companion matrix of the Fibonacci recurrence is Q = [[1,1],[1,0]]. Its powers carry the Fibonacci numbers: Qⁿ⁺¹ = [[F(n+2), F(n+1)], [F(n+1), F(n)]]. Taking determinants and using det(Qⁿ⁺¹) = (det Q)ⁿ⁺¹ = (−1)ⁿ⁺¹ yields Cassini's identity F(n+2)F(n) − F(n+1)² = (−1)ⁿ⁺¹ at one stroke. The alternating sign is exactly det(Q) = −1 raised to a power.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **The Q-matrix and its determinant.** Define Q = !![1,1;1,0] over ℤ. det_Q computes Q.det = −1 directly from Matrix.det_fin_two_of (1·0 − 1·1 = −1).\n2. **The Q-matrix identity (induction).** Q_pow proves Qⁿ⁺¹ = !![F(n+2), F(n+1); F(n+1), F(n)] by induction on n. The base case is Q¹ = Q, checked entrywise after evaluating fib 0,1,2. The inductive step rewrites Qⁿ⁺² = Qⁿ⁺¹·Q, substitutes the hypothesis, expands each entry by Matrix.mul_apply / Fin.sum_univ_two, and closes with push_cast [Nat.fib_add_two]; ring — every entry is a single application of F(k+2) = F(k) + F(k+1).\n3. **Determinant of the power.** det_Q_pow rewrites det(Qⁿ⁺¹) = (det Q)ⁿ⁺¹ via Matrix.det_pow and det_Q, giving (−1)ⁿ⁺¹.\n4. **Cassini.** cassini_matrix substitutes Q_pow into det_Q_pow and applies Matrix.det_fin_two_of to the right-hand side, so the determinant equals F(n+2)·F(n) − F(n+1)²; linear_combination of the resulting hypothesis closes F(n+2)·F(n) − F(n+1)² = (−1)ⁿ⁺¹.\n5. **Re-indexing and transport.** cassini_classic re-indexes at n−1 (writing n = m+1) to obtain the textbook F(n−1)·F(n+1) − F(n)² = (−1)ⁿ; cassini_int_nonneg transports this to Int.fib via Int.fib_natCast, matching the parent and Mathlib's Int.fib_succ_mul_fib_pred_sub_fib_sq for non-negative indices.",
+    "keyInsights": [
+      "**The sign is a determinant raised to a power.** Cassini's (−1)ⁿ is exactly (det Q)ⁿ where det Q = −1. Multiplicativity of the determinant turns one scalar computation into the alternating sign for all n — a structural explanation the algebraic proof does not make visible.",
+      "**Indexing from n+1 removes the awkward n−1 entry.** Stating Qⁿ⁺¹ = [[F(n+2),F(n+1)],[F(n+1),F(n)]] keeps every entry a genuine non-negative-index Fibonacci number, so the base case is just Q¹ = Q and the ℕ-truncated subtraction F(n−1) never appears in the induction.",
+      "**The induction needs only one arithmetic fact.** After expanding the matrix product entrywise, every entry collapses to a single instance of the recurrence F(k+2) = F(k) + F(k+1); push_cast [Nat.fib_add_two]; ring discharges all four entries uniformly.",
+      "**Q is the companion matrix.** Q = [[1,1],[1,0]] is the companion matrix of x² = x + 1; the proof generalizes verbatim to any second-order linear recurrence, with the sign becoming (det of the companion matrix)ⁿ."
+    ],
+    "prerequisites": [
+      "Multiplicativity of the determinant Matrix.det_pow and the 2×2 determinant Matrix.det_fin_two_of",
+      "The Fibonacci recurrence Nat.fib_add_two and the cast Int.fib_natCast",
+      "Entrywise matrix multiplication (Matrix.mul_apply, Fin.sum_univ_two) and the linear_combination / ring / push_cast tactics"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and the Q-Matrix",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring framing the determinant proof of Cassini; defines Q = !![1,1;1,0] over ℤ and det_Q : Q.det = −1, isolating the single source of the alternating sign.",
+      "mathContext": "$Q = \\begin{pmatrix}1&1\\\\1&0\\end{pmatrix},\\quad \\det Q = -1$."
+    },
+    {
+      "id": "q-pow",
+      "title": "The Fibonacci Q-Matrix Identity",
+      "startLine": 57,
+      "endLine": 74,
+      "summary": "Q_pow: Qⁿ⁺¹ = !![F(n+2), F(n+1); F(n+1), F(n)], proved by induction. Base case Q¹ = Q; inductive step expands Qⁿ⁺¹·Q entrywise and closes each entry with the recurrence via push_cast [Nat.fib_add_two]; ring.",
+      "mathContext": "$Q^{\\,n+1} = \\begin{pmatrix}F_{n+2}&F_{n+1}\\\\F_{n+1}&F_n\\end{pmatrix}$."
+    },
+    {
+      "id": "det-q-pow",
+      "title": "Determinant of the Power",
+      "startLine": 76,
+      "endLine": 82,
+      "summary": "det_Q_pow: det(Qⁿ⁺¹) = (−1)ⁿ⁺¹ by multiplicativity of the determinant (Matrix.det_pow) applied to det Q = −1.",
+      "mathContext": "$\\det(Q^{\\,n+1}) = (\\det Q)^{n+1} = (-1)^{n+1}$."
+    },
+    {
+      "id": "cassini-matrix",
+      "title": "Cassini's Identity, Matrix Form",
+      "startLine": 85,
+      "endLine": 95,
+      "summary": "cassini_matrix: F(n+2)·F(n) − F(n+1)² = (−1)ⁿ⁺¹, obtained by equating the 2×2 determinant of the Q-matrix identity (via det_fin_two_of) with det(Qⁿ⁺¹).",
+      "mathContext": "$F_{n+2}F_n - F_{n+1}^2 = (-1)^{n+1}$."
+    },
+    {
+      "id": "cassini-classic-int",
+      "title": "Textbook Indexing and Int.fib Transport",
+      "startLine": 97,
+      "endLine": 128,
+      "summary": "cassini_classic re-indexes at n−1 to give the textbook F(n−1)·F(n+1) − F(n)² = (−1)ⁿ; cassini_int_nonneg transports it to Int.fib via Int.fib_natCast, matching the parent and Mathlib's Int.fib_succ_mul_fib_pred_sub_fib_sq for non-negative indices.",
+      "mathContext": "$F_{n-1}F_{n+1} - F_n^2 = (-1)^n$ (also stated over $\\texttt{Int.fib}$)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Answers open question #1 of the parent — the linear-algebra (Q-matrix / determinant) proof of Cassini — complementing the parent's algebraic derivation from the Gibonacci closed form"
+    },
+    {
+      "targetId": "fibonacci-identities-oq-04",
+      "relationship": "extends",
+      "description": "Realizes the determinant-multiplicativity proof of Cassini that the Vajda hierarchy's open questions pointed toward, giving the structural reason the Cassini sign alternates"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms, no native_decide) linear-algebra proof of Cassini's identity: the Fibonacci Q-matrix identity Qⁿ⁺¹ = [[F(n+2),F(n+1)],[F(n+1),F(n)]] together with multiplicativity of the determinant (det(Qⁿ⁺¹) = (det Q)ⁿ⁺¹ = (−1)ⁿ⁺¹) yields F(n+2)·F(n) − F(n+1)² = (−1)ⁿ⁺¹, with the textbook and Int.fib forms recovered by re-indexing and Int.fib_natCast.",
+    "implications": "Answers the parent's open question #1 and exhibits the structural source of Cassini's alternating sign: it is det(Q) = −1 raised to a power. The argument is the companion-matrix proof and generalizes verbatim to any second-order linear recurrence.",
+    "openQuestions": [
+      "Use the same Q-matrix to prove the addition formula F(m+n) = F(m+1)F(n) + F(m)F(n−1) directly from Qᵐ⁺ⁿ = Qᵐ·Qⁿ and entrywise multiplication, and recover d'Ocagne's identity from det of a product of two such matrices.",
+      "Extend the determinant proof to the general Gibonacci/Horadam companion matrix and to the Lucas Q-matrix, recovering the discriminant constant μ = a²−ab−b² as a determinant.",
+      "Prove the full integer-indexed Cassini (all n : ℤ, not only n ≥ 0) from the Q-matrix by extending Q to a unit in GL₂(ℤ) and using Qⁿ for negative n."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Cassini, J. D.",
+      "title": "Une nouvelle progression des nombres (Cassini's identity)",
+      "year": "1680",
+      "venue": "Histoire de l'Académie Royale des Sciences",
+      "note": "Original statement of F(n−1)F(n+1) − F(n)² = (−1)ⁿ"
+    },
+    {
+      "authors": "Knuth, D. E.",
+      "title": "The Art of Computer Programming, Vol. 1: Fundamental Algorithms",
+      "year": "1997",
+      "venue": "Addison-Wesley, §1.2.8",
+      "note": "The Fibonacci Q-matrix [[1,1],[1,0]] and its powers; Cassini via the determinant"
+    },
+    {
+      "authors": "Vorob'ev, N. N.",
+      "title": "Fibonacci Numbers",
+      "year": "2002",
+      "venue": "Birkhäuser",
+      "note": "Matrix methods for Fibonacci identities, including the determinant proof of Cassini"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question #1** of `fibonacci-identities-oq-04-oq-01`: the **linear-algebra proof of Cassini's identity** via the Fibonacci Q-matrix and multiplicativity of the determinant. The parent derived Cassini *algebraically* from the Gibonacci closed form; this entry derives it *structurally* from a determinant.

With `Q = [[1,1],[1,0]]` over ℤ:

- **`Q_pow`** — `Qⁿ⁺¹ = [[F(n+2), F(n+1)], [F(n+1), F(n)]]`, by induction (the only arithmetic fact in the step is `Nat.fib_add_two`). Indexing from `n+1` keeps every entry a genuine non-negative-index Fibonacci number, so the base case is just `Q¹ = Q`.
- **`det_Q_pow`** — `det(Qⁿ⁺¹) = (det Q)ⁿ⁺¹ = (−1)ⁿ⁺¹` via `Matrix.det_pow`.
- **`cassini_matrix`** — `F(n+2)·F(n) − F(n+1)² = (−1)ⁿ⁺¹`, by equating the 2×2 determinant of `Q_pow`'s RHS with `det(Qⁿ⁺¹)`.
- **`cassini_classic`** — textbook indexing `F(n−1)·F(n+1) − F(n)² = (−1)ⁿ` (n ≥ 1).
- **`cassini_int_nonneg`** — the same over `Int.fib` (via `Int.fib_natCast`), matching the parent and Mathlib's `Int.fib_succ_mul_fib_pred_sub_fib_sq` for non-negative indices.

**Key idea:** Cassini's alternating sign *is* `det(Q) = −1` raised to a power. Multiplicativity of the determinant turns one scalar computation into the sign for all `n` — the conceptual content the parent's parity argument about `(−1)^|x|` left implicit.

## Verification

- Compiles via `lake env lean Proofs/FibonacciIdentitiesOQ04OQ01OQ01.lean` (exit 0, no warnings).
- `#print axioms` on `cassini_matrix`, `cassini_classic`, `cassini_int_nonneg` → only `propext, Classical.choice, Quot.sound`.
- **0 sorries, 0 axioms, no `native_decide`, no `decide`.** Status: `verified`, badge `original`.

## Files

- `proofs/Proofs/FibonacciIdentitiesOQ04OQ01OQ01.lean` (128 lines)
- `src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-01/{meta.json,annotations.json,index.ts}` (annotations use only valid type/significance enums per #31246)

🤖 Generated with [Claude Code](https://claude.com/claude-code)