### PR TITLE
research(pythagorean-triples-oq-01): eliminate r2_pos_iff axiom (7→6)

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ01.lean
@@ -53,6 +53,7 @@ asymptotically N/(2π). Specifically:
 - Axiomatized (3): sector lattice point density, coprime fraction, bothOdd fraction
 -/
 import Mathlib.NumberTheory.PythagoreanTriples
+import Mathlib.NumberTheory.SumTwoSquares
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
@@ -2076,10 +2077,49 @@ noncomputable def r2 (n : ℕ) : ℕ :=
     ∃ b : ℕ, b ≤ n ∧ a * a + b * b = n)).card
 
 /-- r₂(n) > 0 iff n has no prime factor ≡ 3 (mod 4) to an odd power.
-    This is Fermat's theorem on sums of two squares.
-    Full proof requires the Gaussian integer UFD structure. -/
-axiom r2_pos_iff (n : ℕ) (hn : 0 < n) :
-    0 < r2 n ↔ ∀ p, Nat.Prime p → p % 4 = 3 → Even (n.factorization p)
+    This is Fermat's theorem on sums of two squares (the full characterization).
+
+    PROVED from Mathlib's `Nat.eq_sq_add_sq_iff`. The proof has two bridges:
+    (1) `0 < r2 n ↔ ∃ x y, n = x² + y²` — positivity of the (nonnegative-pair)
+        representation count is equivalence to existence of a representation; the
+        `a, b ≤ n` bounds in `r2` are automatic since `a ≤ a² ≤ n`.
+    (2) the prime-factorization condition `∀ q ∈ n.primeFactors, q % 4 = 3 →
+        Even (padicValNat q n)` from Mathlib equals `∀ p, p.Prime → p % 4 = 3 →
+        Even (n.factorization p)`: for primes outside `primeFactors` the
+        factorization exponent is `0` (even), so the two universally quantified
+        forms agree. (The `hn : 0 < n` hypothesis is now unused but kept for the
+        stable downstream signature.) -/
+theorem r2_pos_iff (n : ℕ) (_hn : 0 < n) :
+    0 < r2 n ↔ ∀ p, Nat.Prime p → p % 4 = 3 → Even (n.factorization p) := by
+  -- A small fact: x ≤ x² in ℕ, used to discharge the `a, b ≤ n` bounds in `r2`.
+  have le_sq : ∀ x : ℕ, x ≤ x ^ 2 := by
+    intro x
+    rcases Nat.eq_zero_or_pos x with h | h
+    · simp [h]
+    · calc x = x ^ 1 := (pow_one x).symm
+        _ ≤ x ^ 2 := Nat.pow_le_pow_right h (by norm_num)
+  -- Step 1: positivity of r2 ↔ existence of a sum-of-two-squares representation.
+  have hrepr : 0 < r2 n ↔ ∃ x y : ℕ, n = x ^ 2 + y ^ 2 := by
+    rw [r2, Finset.card_pos, Finset.filter_nonempty_iff]
+    constructor
+    · rintro ⟨a, -, b, -, hab⟩
+      exact ⟨a, b, by rw [← hab]; ring⟩
+    · rintro ⟨x, y, hxy⟩
+      have hx : x ≤ n := le_trans (le_sq x) (by rw [hxy]; exact Nat.le_add_right _ _)
+      have hy : y ≤ n := le_trans (le_sq y) (by rw [hxy]; exact Nat.le_add_left _ _)
+      exact ⟨x, Finset.mem_Icc.mpr ⟨Nat.zero_le _, hx⟩, y, hy, by rw [hxy]; ring⟩
+  rw [hrepr, Nat.eq_sq_add_sq_iff]
+  -- Step 2: bridge the two forms of the prime-factorization condition.
+  constructor
+  · intro H p hp hp4
+    by_cases hmem : p ∈ n.primeFactors
+    · rw [Nat.factorization_def n hp]; exact H p hmem hp4
+    · have hz : n.factorization p = 0 := by
+        rw [← Finsupp.notMem_support_iff, Nat.support_factorization]; exact hmem
+      rw [hz]; exact ⟨0, rfl⟩
+  · intro H q hq hq4
+    have hp : q.Prime := Nat.prime_of_mem_primeFactors hq
+    rw [← Nat.factorization_def n hp]; exact H q hp hq4
 
 /-- The average order of r₂: (1/N) Σ_{n≤N} r₂(n) → π.
     This is equivalent to the Gauss circle problem: the number of
@@ -2204,7 +2244,8 @@ theorem all_primitive_triples_from_gaussian :
 
 ### New Definitions and Theorems:
 - **r2**: representation function r₂(n) = #{(a,b) : a²+b² = n}
-- **r2_pos_iff**: characterization via prime factorization (partial)
+- **r2_pos_iff**: characterization via prime factorization [PROVED from Mathlib's
+  `Nat.eq_sq_add_sq_iff` — no longer an axiom]
 - **r2_average_order**: (1/N)Σr₂(n) → π (Gauss circle) [AXIOM]
 - **GaussianInt**: Gaussian integer structure
 - **gaussian_norm_mul**: norm multiplicativity (PROVED)
@@ -2212,7 +2253,10 @@ theorem all_primitive_triples_from_gaussian :
 - **gaussian_square_components**: real and imaginary parts of z² (PROVED)
 - **landau_two_squares_statement**: Landau-Ramanujan constant (documentation)
 
-### Axiom Count: 5 total (3 original + 2 new: r2_average_order, primitive_by_leg_density)
+### Axiom Count: 6 total — 3 core (sector_lattice_point_density,
+###   coprime_fraction_in_sector, bothOdd_fraction_in_coprime_sector) +
+###   3 supplementary (r2_average_order, landau_two_squares, primitive_by_leg_density).
+###   (r2_pos_iff was previously an axiom; it is now PROVED.)
 ### Sorries: 0
 -/
 
@@ -2471,9 +2515,11 @@ The straddling analysis explains WHY the parity axiom holds:
 - Summing: total straddling = O(sqrt(N)) << coprime sector = Theta(N)
 
 ### Overall File Statistics:
-- **Axioms**: 6 (3 core + 3 supplementary)
+- **Axioms**: 6 (3 core + 3 supplementary: r2_average_order, landau_two_squares,
+  primitive_by_leg_density). `r2_pos_iff` was eliminated — it is now a proved
+  theorem (`Nat.eq_sq_add_sq_iff`), so the file is down from 7 axioms to 6.
 - **Sorries**: 0
-- **Theorems proved**: ~120
+- **Theorems proved**: ~121
 - **Definitions**: ~39
 
 ### The 3 Core Axioms (irreducible given current Mathlib):

--- a/research/problems/pythagorean-theorem-oq-01/knowledge.md
+++ b/research/problems/pythagorean-theorem-oq-01/knowledge.md
@@ -51,3 +51,39 @@ Insights accumulated during research on this problem.
 ### Next Steps
 - Optionally add a gallery entry for the now-complete `PythagoreanTheoremOQ05`.
 - Audit sibling pythagorean files for the same drift.
+
+## Session 2026-06-28 (researcher-3) — Family axiom elimination in PythagoreanTriplesOQ01
+
+**Mode**: FRESH (claimed pythagorean-theorem-oq-01; base theorem already SOLVED) · **Outcome**: progress (eliminated 1 axiom in a sibling family file)
+
+### What I Did
+- Base 2-D `PythagoreanTheorem.lean` reconfirmed COMPLETE (0 sorry, 0 axioms). The only
+  remaining "axiom debt" in the whole pythagorean family lives in the triples-density file.
+- Surveyed all 24 `Pythagorean*` files: the sole high-axiom file is
+  `PythagoreanTriplesOQ01.lean` (was 7 axioms). Audited each axiom for Mathlib provability.
+- **Eliminated `r2_pos_iff`** (Fermat's two-square characterization,
+  `0 < r2 n ↔ ∀ p prime, p%4=3 → Even (n.factorization p)`): converted from `axiom` to a
+  proved `theorem` using Mathlib's `Nat.eq_sq_add_sq_iff`. File now has **6 axioms** (down from 7).
+
+### Key Findings
+- Mathlib's `Nat.eq_sq_add_sq_iff` (`Mathlib/NumberTheory/SumTwoSquares.lean`) gives
+  `(∃ x y, n = x²+y²) ↔ ∀ q ∈ n.primeFactors, q%4=3 → Even (padicValNat q n)`.
+- Two bridges needed: (1) `0 < r2 n ↔ ∃ x y, n = x²+y²` — positivity of the nonneg-pair
+  count, with the `a,b ≤ n` filter bounds discharged by `x ≤ x² ≤ n`; (2) the
+  `∀ q ∈ primeFactors …` (Mathlib) vs `∀ p prime …` (axiom) forms agree because primes
+  outside `primeFactors` have factorization exponent `0` (even). Glue lemmas:
+  `Nat.factorization_def`, `Nat.support_factorization`, `Finsupp.notMem_support_iff`,
+  `Nat.prime_of_mem_primeFactors`.
+- The remaining 6 axioms are genuinely deep analytic NT (Gauss circle / Möbius density /
+  parity equidistribution / Landau–Ramanujan / leg density) with no current Mathlib coverage.
+- GOTCHA: `even_zero` is not a global identifier in this Mathlib pin — use `⟨0, rfl⟩` for `Even 0`.
+
+### Files Modified
+- `proofs/Proofs/PythagoreanTriplesOQ01.lean` — `r2_pos_iff` axiom→theorem; added
+  `import Mathlib.NumberTheory.SumTwoSquares`; refreshed summary/axiom-count comments.
+- `src/data/proofs/pythagorean-triples-oq-01/meta.json` — axiomCount 7→6, theoremCount/lineCount, section text.
+
+### Verification
+- `lake env lean` (Lean 4.26.0) against main-repo Mathlib cache: EXIT 0, 0 sorries, no new
+  warnings. `#print axioms r2_pos_iff` = `[propext, Classical.choice, Quot.sound]` only
+  (no `Lean.ofReduceBool`/`sorryAx`) — the eliminated axiom is a clean, fully-verified theorem.

--- a/src/data/proofs/pythagorean-triples-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "pythagorean-triples-oq-01",
   "title": "Density of Primitive Pythagorean Triples",
   "slug": "pythagorean-triples-oq-01",
-  "description": "Proves that the number of primitive Pythagorean triples with hypotenuse c ≤ N is asymptotically N/(2π). Decomposes the result into sector lattice point density (π/8), coprime fraction (6/π²), and parity correction (2/3). Includes parity involutions, column decomposition, and computational verification. 117 theorems, 7 axioms, 0 sorries.",
+  "description": "Proves that the number of primitive Pythagorean triples with hypotenuse c ≤ N is asymptotically N/(2π). Decomposes the result into sector lattice point density (π/8), coprime fraction (6/π²), and parity correction (2/3). Includes parity involutions, column decomposition, and computational verification. 118 theorems, 6 axioms, 0 sorries.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Pythagorean_triple#Generating_a_triple",
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "axiom",
-    "assumptions": "7 axiom declarations encoding deep analytic number theory results: sector lattice point density (π/8, from Gauss circle problem), coprime fraction in sector (6/π², from Möbius inversion), bothOdd fraction (1/3, from parity equidistribution), r2 positivity criterion, r2 average order, Landau two-squares counting, and primitive-by-leg density. Full proofs would require sieve methods or complex analysis beyond current Mathlib.",
+    "assumptions": "6 axiom declarations encoding deep analytic number theory results: sector lattice point density (π/8, from Gauss circle problem), coprime fraction in sector (6/π², from Möbius inversion), bothOdd fraction (1/3, from parity equidistribution), r2 average order, Landau two-squares counting, and primitive-by-leg density. Full proofs would require sieve methods or complex analysis beyond current Mathlib. (The r2 positivity criterion r2_pos_iff was previously axiomatized but is now PROVED from Mathlib's Nat.eq_sq_add_sq_iff.) native_decide is used for small-N computational checks, so Lean.ofReduceBool is also relied upon.",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -85,10 +85,10 @@
         "relationship": "CRT structure underlies the independence of coprime conditions modulo different primes"
       }
     ],
-    "axiomCount": 7,
-    "lineCount": 2485,
+    "axiomCount": 6,
+    "lineCount": 2531,
     "mathlib_version": "4.26.0",
-    "theoremCount": 117,
+    "theoremCount": 118,
     "definitionCount": 40,
     "additionalFiles": [
       "Proofs/PythagoreanTriplesOQ01Aristotle.lean"
@@ -97,7 +97,7 @@
   "overview": {
     "historicalContext": "**Density of Primitive Pythagorean Triples**\n\nPythagorean triples have been studied since Babylonian times (the tablet Plimpton 322, c. 1800 BCE, lists 15 triples). Euclid gave the first complete parametrization in Book X of the *Elements*: every primitive triple $(a,b,c)$ with $a^2+b^2=c^2$ and $\\gcd(a,b,c)=1$ corresponds to a unique pair $(m,n)$ with $m>n>0$, $\\gcd(m,n)=1$, $m \\not\\equiv n \\pmod{2}$, via $a=m^2-n^2$, $b=2mn$, $c=m^2+n^2$.\n\nThe asymptotic density question—how many primitive triples have hypotenuse $c \\le N$?—was answered by D. N. Lehmer in 1900 and refined by subsequent work connecting it to the Gauss circle problem and the density of coprime integers. The result $N/(2\\pi)$ combines three classical facts: lattice point counting in circular sectors (Gauss, 1801), the probability $6/\\pi^2$ that two random integers are coprime (Euler/Cesàro, 1883), and the parity structure of coprime pairs. This formalization appears to be the first mechanized proof of this density result.",
     "problemStatement": "**Theorem**: lim_{N→∞} primitiveTripleCount(N) · (2π)/N = 1. That is, the number of primitive Pythagorean triples with hypotenuse ≤ N grows as N/(2π).",
-    "text": "Proves that the number of primitive Pythagorean triples with hypotenuse c ≤ N is asymptotically N/(2π). Decomposes the result into sector lattice point density (π/8), coprime fraction (6/π²), and parity correction (2/3). Includes parity involutions, column decomposition, and computational verification. 117 theorems, 7 axioms, 0 sorries.",
+    "text": "Proves that the number of primitive Pythagorean triples with hypotenuse c ≤ N is asymptotically N/(2π). Decomposes the result into sector lattice point density (π/8), coprime fraction (6/π²), and parity correction (2/3). Includes parity involutions, column decomposition, and computational verification. 118 theorems, 6 axioms, 0 sorries.",
     "proofStrategy": "The proof decomposes the density into three independent factors, then telescopes their limits:\n\n1. **Sector lattice density** (axiom): The sector $\\{(m,n) : 0 < n < m,\\, m^2+n^2 \\le N\\}$ contains $\\sim \\pi N/8$ lattice points (from the Gauss circle problem — the sector is $1/8$ of the full disk of area $\\pi N$)\n2. **Coprime density** (axiom): Among lattice points in the sector, the fraction with $\\gcd(m,n)=1$ tends to $6/\\pi^2 = 1/\\zeta(2)$ (from Möbius inversion on the Euler product)\n3. **Parity correction** (axiom + proved structure): Among coprime pairs, $2/3$ have $m \\not\\equiv n \\pmod{2}$. This is reduced to showing the both-odd fraction is $1/3$, then verified structurally via the involution $(m,n) \\mapsto (m, m-n)$ which bijects OE and OO classes\n\n**Telescoping**: $\\frac{\\text{count}(N)}{N} = \\frac{\\text{count}}{\\text{coprime}} \\cdot \\frac{\\text{coprime}}{\\text{sector}} \\cdot \\frac{\\text{sector}}{N} \\to \\frac{2}{3} \\cdot \\frac{6}{\\pi^2} \\cdot \\frac{\\pi}{8} = \\frac{1}{2\\pi}$\n\nThe proof also verifies the algebraic identity and establishes growth/monotonicity of intermediate counting functions needed for the ratio convergence.",
     "keyInsights": [
       "The three-factor decomposition $\\pi N/8 \\times 6/\\pi^2 \\times 2/3 = N/(2\\pi)$ cleanly separates geometry (lattice counting), number theory (coprime density via $\\zeta(2)$), and combinatorics (parity sieving) into independent ingredients",
@@ -267,10 +267,10 @@
     {
       "id": "sum-of-two-squares",
       "title": "Part XX: Sum of Two Squares and r₂(n)",
-      "summary": "Connects to the sum-of-two-squares function r2 with r2_pos_iff and r2_average_order axioms, triple_count_from_r2_connection, sumOfTwoSquaresCount, and the landau_two_squares counting axiom.",
+      "summary": "Connects to the sum-of-two-squares function r2: r2_pos_iff (Fermat's two-square characterization, now PROVED from Mathlib's Nat.eq_sq_add_sq_iff) and the r2_average_order axiom, triple_count_from_r2_connection, sumOfTwoSquaresCount, and the landau_two_squares counting axiom.",
       "startLine": 2064,
       "endLine": 2116,
-      "mathContext": "Connects to the sum-of-two-squares function r2 with r2_pos_iff and r2_average_order axioms, triple_count_from_r2_connection, sumOfTwoSquaresCount, and the landau_two_squares counting axiom."
+      "mathContext": "Connects to the sum-of-two-squares function r2: r2_pos_iff (Fermat's two-square characterization, now PROVED from Mathlib's Nat.eq_sq_add_sq_iff) and the r2_average_order axiom, triple_count_from_r2_connection, sumOfTwoSquaresCount, and the landau_two_squares counting axiom."
     },
     {
       "id": "triples-by-leg-and-area",
@@ -298,7 +298,7 @@
     }
   ],
   "conclusion": {
-    "summary": "A thorough formalization of the primitive Pythagorean triple density theorem, establishing $\\text{primitiveTripleCount}(N)/N \\to 1/(2\\pi)$ via a clean three-factor decomposition. The proof comprises 117 theorems, 7 axioms (encoding deep analytic number theory), and 0 sorries. The axioms isolate analytic content (Gauss circle problem, Möbius inversion, parity equidistribution, Landau two-squares counting) that would require sieve methods or complex analysis to prove formally.",
+    "summary": "A thorough formalization of the primitive Pythagorean triple density theorem, establishing $\\text{primitiveTripleCount}(N)/N \\to 1/(2\\pi)$ via a clean three-factor decomposition. The proof comprises 118 theorems, 6 axioms (encoding deep analytic number theory), and 0 sorries. The axioms isolate analytic content (Gauss circle problem, Möbius inversion, parity equidistribution, Landau two-squares counting) that would require sieve methods or complex analysis to prove formally.",
     "implications": "**Theoretical Significance**: **Significance**\n\n1. **First mechanized proof**: This appears to be the first formal verification of the $N/(2\\pi)$ density result for primitive Pythagorean triples in any proof assistant.\n2. **Modular architecture**: The three-factor decomposition into geometry ($\\pi/8$), number theory ($6/\\pi^2$), and combinatorics ($2/3$) makes each component independently verifiable and replaceable.\n**3. Bijective technique**: The parity involution $(m,n) \\mapsto (m, m-n)$ is a general technique applicable to any coprime-parity counting problem, not just Pythagorean triples.\n4. **Computational confidence**: Verification of counting functions for $N = 0, 4, 5, 13, 25, 50, 100$ via native_decide confirms the formalized definitions match the intended mathematical objects.\n5. **Connection to $\\zeta(2)$**: The coprime density factor $6/\\pi^2 = 1/\\zeta(2)$ links this result to the Basel problem, demonstrating how the Riemann zeta function controls the distribution of coprime pairs.",
     "openQuestions": [
       "Can the sector lattice point density axiom ($\\pi/8$) be proved from Gauss circle problem results in Mathlib, using the error term $O(\\sqrt{N})$?",
@@ -325,9 +325,9 @@
       "Topology"
     ],
     "namespace": "PythagoreanTriplesDensity",
-    "lineCount": 2485,
-    "axiomCount": 7,
-    "theoremCount": 117,
+    "lineCount": 2531,
+    "axiomCount": 6,
+    "theoremCount": 118,
     "definitionCount": 40,
     "path": "Proofs/PythagoreanTriplesOQ01.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Axiom elimination in `PythagoreanTriplesOQ01.lean` (primitive Pythagorean triple density). Converts the Fermat two-square characterization `r2_pos_iff` from an `axiom` to a fully-proved `theorem`. File axiom count drops **7 → 6**.

The base `pythagorean-theorem-oq-01` problem (claimed this session) was already SOLVED (0 sorry / 0 axiom); the only standing axiom debt in the whole pythagorean family lives in this triples-density file, so the session targeted axiom elimination there per the researcher axiom-priority policy.

## What changed

`r2_pos_iff : 0 < r2 n ↔ ∀ p, Prime p → p % 4 = 3 → Even (n.factorization p)` is now proved from Mathlib's `Nat.eq_sq_add_sq_iff` (`Mathlib/NumberTheory/SumTwoSquares.lean`), via two bridges:

1. `0 < r2 n ↔ ∃ x y, n = x² + y²` — positivity of the nonnegative-pair representation count; the `a, b ≤ n` filter bounds are discharged by `x ≤ x² ≤ n`.
2. The `∀ q ∈ n.primeFactors …` (Mathlib) and `∀ p prime …` (axiom) forms agree because primes outside `primeFactors` have factorization exponent `0`, which is even.

## Verification

- `lake env lean` (Lean 4.26.0) against the Mathlib cache: **EXIT 0, 0 sorries, no new warnings**.
- `#print axioms r2_pos_iff` = `[propext, Classical.choice, Quot.sound]` only — **no `Lean.ofReduceBool` / `sorryAx`**, so the eliminated axiom is now a clean, fully-verified theorem.

## Remaining axioms (6, all genuinely deep / no Mathlib coverage)

`sector_lattice_point_density` (Gauss circle), `coprime_fraction_in_sector` (Möbius/ζ(2)), `bothOdd_fraction_in_coprime_sector` (parity equidistribution), `r2_average_order` (Gauss circle), `landau_two_squares` (Landau–Ramanujan), `primitive_by_leg_density`. Status remains `axiomatized` (the file still relies on `Lean.ofReduceBool` via `native_decide` for small-N checks).

Gallery `meta.json` updated: `axiomCount` 7→6, theorem/line counts, `assumptions` field, and stale "7 axioms" prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)