### PR TITLE
Enrich anisotropic n-dim Gaussian integral: annotations 3→5, enum fixes

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02/annotations.json
@@ -31,9 +31,9 @@
       "startLine": 51,
       "endLine": 70
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "General n-Variable Fubini: Distinct Per-Axis Factors",
-    "content": "`gaussian_anisotropic_eq_prod` proves `∫_{ℝⁿ} e^{-∑ᵢ bᵢ xᵢ²} = ∏ᵢ √(π/bᵢ)` for *every* real weight vector `b` — no positivity or integrability hypothesis. An auxiliary `key` evaluates the product-form integral `∫_{ℝⁿ} ∏ᵢ e^{-bᵢ xᵢ²} = ∏ᵢ ∫_ℝ e^{-bᵢ x²}` by Mathlib's `integral_fintype_prod_volume_eq_prod`, then closes each factor with `integral_gaussian (bᵢ) : ∫_ℝ e^{-bᵢ x²} = √(π/bᵢ)` under `Finset.prod_congr`. Rewriting the goal by `← key` reduces it to the pointwise identity between the diagonal integrand `e^{-∑ᵢ bᵢ xᵢ²}` and the product `∏ᵢ e^{-bᵢ xᵢ²}`, closed under `integral_congr_ae` by `Real.exp_sum` together with `Finset.sum_neg_distrib` and `neg_mul` (distributing the negation through the sum and each summand).",
+    "content": "`gaussian_anisotropic_eq_prod` proves `∫_{ℝⁿ} e^{-∑ᵢ bᵢ xᵢ²} = ∏ᵢ √(π/bᵢ)` for *every* real weight vector `b` — no positivity or integrability hypothesis. An auxiliary `key` evaluates the product-form integral `∫_{ℝⁿ} ∏ᵢ e^{-bᵢ xᵢ²} = ∏ᵢ ∫_ℝ e^{-bᵢ x²}` by Mathlib's `integral_fintype_prod_volume_eq_prod`, then closes each factor with `integral_gaussian (bᵢ) : ∫_ℝ e^{-bᵢ x²} = √(π/bᵢ)` under `Finset.prod_congr`. Rewriting the goal by `← key` reduces it to the pointwise identity between the diagonal integrand `e^{-∑ᵢ bᵢ xᵢ²}` and the product `∏ᵢ e^{-bᵢ xᵢ²}`, closed under `integral_congr_ae` by `Real.exp_sum` together with `Finset.sum_neg_distrib` and `neg_mul` (distributing the negation through the sum and each summand). Note a Lean subtlety: an explicit beta-reduction (`simp only []`) was needed before `Real.exp_sum` could fire on the integrand.",
     "mathContext": "Unlike the isotropic case — where $\\int_{\\mathbb R^n}\\prod_i f(x_i) = (\\int f)^n$ uses a single integral — here the factors $f_i(t) = e^{-b_i t^2}$ differ, so the relevant Fubini lemma is the general $\\int_{\\mathbb R^n}\\prod_i f_i(x_i) = \\prod_i \\int f_i$. The factorization holds for any $b$; the closed-form value of each factor enters via integral_gaussian.",
     "significance": "key",
     "relatedConcepts": [
@@ -53,12 +53,12 @@
     "id": "ann-aoc07oq04010102-determinant",
     "proofId": "area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02",
     "range": {
-      "startLine": 72,
-      "endLine": 110
+      "startLine": 74,
+      "endLine": 99
     },
-    "type": "technique",
-    "title": "Determinant Closed Form π^{n/2}/√(∏ bᵢ) and Isotropic Recovery",
-    "content": "`gaussian_anisotropic_closed_form` (for `bᵢ > 0`) re-packages the product `∏ᵢ √(π/bᵢ)` into the determinant form `π^{n/2}/√(∏ᵢ bᵢ)`. It factors `√(π/bᵢ) = √π/√bᵢ` (`Real.sqrt_div`), splits the product (`Finset.prod_div_distrib`), collapses the constant numerator `∏ᵢ √π = (√π)ⁿ` (`Finset.prod_const` + `Fintype.card_fin`) which becomes `π^{n/2}` via the rpow identity `Real.sqrt_eq_rpow`/`Real.rpow_natCast`/`Real.rpow_mul`, and collects the denominator `∏ᵢ √bᵢ = √(∏ᵢ bᵢ)` via `Real.finset_prod_rpow` at exponent 1/2 — exhibiting the determinant `∏ᵢ bᵢ` of the diagonal matrix. `gaussian_isotropic_recover` then specializes the constant weight `bᵢ = c > 0` and applies the same rpow algebra to land back on the parent's `(π/c)^{n/2}`, certifying this entry as a strict generalization.",
+    "type": "tactic",
+    "title": "Determinant Closed Form π^{n/2}/√(∏ bᵢ)",
+    "content": "`gaussian_anisotropic_closed_form` (for `bᵢ > 0`) re-packages the product `∏ᵢ √(π/bᵢ)` into the determinant form `π^{n/2}/√(∏ᵢ bᵢ)`. It factors `√(π/bᵢ) = √π/√bᵢ` (`Real.sqrt_div`), splits the product (`Finset.prod_div_distrib`), collapses the constant numerator `∏ᵢ √π = (√π)ⁿ` (`Finset.prod_const` + `Fintype.card_fin`) which becomes `π^{n/2}` via the rpow identities `Real.sqrt_eq_rpow`/`Real.rpow_natCast`/`Real.rpow_mul`, and collects the denominator `∏ᵢ √bᵢ = √(∏ᵢ bᵢ)` via `Real.finset_prod_rpow` at exponent 1/2 — exhibiting the determinant `∏ᵢ bᵢ` of the diagonal matrix. Positivity of the weights enters only here (not in the factorization step), because it is needed to pull the determinant under a single square root.",
     "mathContext": "$\\prod_i \\sqrt{\\pi/b_i} = \\frac{(\\sqrt\\pi)^n}{\\prod_i\\sqrt{b_i}} = \\frac{\\pi^{n/2}}{\\sqrt{\\prod_i b_i}}$, where $\\prod_i b_i = \\det\\operatorname{diag}(b_1,\\dots,b_n)$. The key algebraic facts are $\\prod_i \\sqrt{b_i} = \\sqrt{\\prod_i b_i}$ (a square root is multiplicative on nonnegatives, here via Real.finset_prod_rpow with exponent 1/2) and $(\\sqrt\\pi)^n = \\pi^{n/2}$.",
     "significance": "key",
     "relatedConcepts": [
@@ -72,6 +72,53 @@
       "square root is multiplicative on nonnegatives",
       "rpow algebra for half-integer powers",
       "product over a finite type"
+    ]
+  },
+  {
+    "id": "ann-aoc07oq04010102-recovery",
+    "proofId": "area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 100,
+      "endLine": 112
+    },
+    "type": "theorem",
+    "title": "Isotropic Recovery: the Parent as a Special Case",
+    "content": "`gaussian_isotropic_recover` specializes the constant weight vector `bᵢ = c` (with `c > 0`). Feeding `(fun _ => c)` to `gaussian_anisotropic_eq_prod` collapses the product `∏ᵢ √(π/c)` to a power via `Finset.prod_const` + `Fintype.card_fin`, and the same rpow algebra (`Real.sqrt_eq_rpow`, `Real.rpow_natCast`, `Real.rpow_mul`) lands on the parent's isotropic closed form `(π/c)^{n/2}`. Because the parent is recovered verbatim, this entry is certified as a *strict generalization* rather than a parallel result — a small but important hygiene check for a follow-up entry.",
+    "mathContext": "$b_i = c \\Rightarrow \\prod_i \\sqrt{\\pi/c} = (\\sqrt{\\pi/c})^n = (\\pi/c)^{n/2}$, the parent's value. The anisotropic statement contains the isotropic one as the constant-weight slice.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "specialization",
+      "Finset.prod_const",
+      "isotropic Gaussian",
+      "strict generalization"
+    ],
+    "prerequisites": [
+      "gaussian_anisotropic_eq_prod",
+      "product of a constant over a finite type"
+    ]
+  },
+  {
+    "id": "ann-aoc07oq04010102-quadform-bridge",
+    "proofId": "area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 19,
+      "endLine": 24
+    },
+    "type": "insight",
+    "title": "Why the Diagonal Case Is the Crux of the General Quadratic Form",
+    "content": "The closed form π^{n/2}/√(∏ᵢ bᵢ) is the diagonal instance of the general positive-definite Gaussian ∫_{ℝⁿ} e^{-⟨Ax,x⟩} = π^{n/2}/√(det A). This diagonal case is not merely an example — it is essentially the whole theorem: any symmetric positive-definite A is orthogonally diagonalizable, A = Oᵀ D O with O orthogonal, and the change of variables x ↦ Oᵀx has unit Jacobian (|det O| = 1), so the general integral reduces to the diagonal one over D = diag(λ₁,…,λₙ) with det A = ∏ᵢ λᵢ. That reduction is exactly the declared open follow-up (oq-01); formalizing the diagonal case here supplies its analytic core, leaving only the orthogonal change-of-variables bookkeeping.",
+    "mathContext": "$A = O^\\top D O,\\ |\\det O| = 1 \\Rightarrow \\int_{\\mathbb R^n} e^{-\\langle Ax,x\\rangle}\\,dx = \\int_{\\mathbb R^n} e^{-\\langle Dy,y\\rangle}\\,dy = \\frac{\\pi^{n/2}}{\\sqrt{\\prod_i \\lambda_i}} = \\frac{\\pi^{n/2}}{\\sqrt{\\det A}}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positive-definite quadratic form",
+      "orthogonal diagonalization",
+      "change of variables",
+      "determinant",
+      "spectral theorem"
+    ],
+    "prerequisites": [
+      "symmetric matrices are orthogonally diagonalizable",
+      "orthogonal maps preserve Lebesgue measure"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02` (quality 83, pass 0).

The entry's meta.json was already rich (5 keyInsights, conclusion, cross-references, openQuestions, references) and `index.ts` is present, so this pass focuses on annotation coverage.

## Changes
- **Fixed invalid annotation enums** (systemic defect #31246): `type` `technique`→`tactic` (×2). Valid types per `src/types/proof.ts`: {theorem,lemma,definition,tactic,concept,insight,warning}.
- **Annotations 3 → 5**: split the previously-combined closed-form/recovery annotation into a focused **determinant closed form** and a dedicated **isotropic recovery** annotation; added a **general-quadratic-form bridge** insight explaining why the diagonal case is the analytic core of ∫ e^{−⟨Ax,x⟩} = π^{n/2}/√(det A) via orthogonal diagonalization (the declared open follow-up oq-01).
- Added the beta-reduction (`simp only []`) Lean subtlety to the Fubini annotation.

## Verification
- annotations.json valid JSON; all 5 annotations have `mathContext` and valid enums. `tsc -b` clean. Axiom integrity untouched (verified, 0 axioms/sorries).