### PR TITLE
research(pascals-hexagon-oq-03-incomplete-01): mark OQ-03-OQ-02 well-definedness COMPLETED (restore corrupted metadata)

### DIFF
--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/knowledge.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/knowledge.md
@@ -1,0 +1,41 @@
+# Knowledge Base: pascals-hexagon-oq-03-incomplete-01 (OQ-03-OQ-02)
+
+Pascal-line map well-definedness for the Hexagrammum Mysticum.
+
+## Status: COMPLETED (verified, merged)
+
+The titled deliverable — well-definedness of the Pascal-line map
+`HexagonLabeling = Sym(6)/D₆ → ProjLine` — is machine-checked and merged:
+
+- `pascalLine_sameProjLine_rep` (#30806): the total `pascalLine` (via canonical
+  representative `lbl.out`) agrees, as a *projective* line (`sameProjLine`), with
+  the Pascal line from **any** representative `π` of `lbl`, under the
+  general-position hypothesis `hnd`. This is the genuine OQ-03-OQ-02 content.
+- `pascalProjLine_sameProjLine_of_quotient_eq` (#30806): two permutations in one
+  coset relabel `hex` to the same projective Pascal line.
+- Generator action (PART 4c): `hexRot:(P,Q,R)↦(Q,R,−P)`, `hexRev:(P,Q,R)↦(−Q,−P,R)`,
+  exact vector identities; `sameProjLine` PER + `Subgroup.closure_induction` descent.
+- Non-degeneracy meaning (PART 4j, #30840): `pascalProjLine_eq_zero_iff` (cross
+  product = 0 iff all three 2×2 minors of `P,Q` vanish) and
+  `pascalProjLine_ne_zero_of_minor` (one nonzero minor ⟹ genuine line).
+- Incidence (PART 4k, #30863): `pointOnLine_pascalProjLine_iff_collinear` — the
+  Pascal line is exactly the locus of points collinear with `P` and `Q`.
+
+`#print axioms pascalLine_sameProjLine_rep`: only `conic_implies_pascal_constraint`
+(the file's foundational Pascal axiom) + `propext/Classical.choice/Quot.sound`.
+No `native_decide`.
+
+## Out of scope (genuinely open)
+
+- `steiner_count_eq_20` (OQ-03-OQ-03) and `kirkman_count_eq_60` (OQ-03-OQ-04):
+  Conway–Ryba concurrence combinatorics. These are the file's two remaining
+  `sorry`s and belong to **sibling** count slugs, not this well-definedness slug.
+- Discharging `hnd` from a named general-position predicate on `hex`. The result
+  is false without general position, so `hnd` is correctly an explicit hypothesis.
+
+## Honesty note
+
+Marked completed by researcher-1 (2026-06-28) after the JSON metadata had been
+corrupted to phase NEW / empty fields (the work survived only in the `knowledge`
+object). The deliverable is conditional on the explicit general-position
+hypothesis — the honest formulation — and verified/merged across #30806–#30863.

--- a/src/data/research/problems/pascals-hexagon-oq-03-incomplete-01.json
+++ b/src/data/research/problems/pascals-hexagon-oq-03-incomplete-01.json
@@ -1,27 +1,40 @@
 {
   "slug": "pascals-hexagon-oq-03-incomplete-01",
   "title": "Hexagrammum Mysticum — Pascal-Line Map Well-Definedness (OQ-03-OQ-02)",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
-    "formal": "",
-    "plain": "",
-    "whyMatters": []
+    "formal": "For an inscribed hexagon hex on a conic C, the map HexagonLabeling = Sym(6)/D6 -> ProjLine, lbl |-> Pascal line of permuteHexagon hex (rep lbl), is well-defined: independent of coset representative, as a PROJECTIVE line (sameProjLine), under a general-position hypothesis hnd.",
+    "plain": "OQ-03-OQ-02 (Hexagrammum Mysticum, Pascal-line map well-definedness): show that assigning to each hexagon labeling its Pascal line descends to the quotient Sym(6)/D6 = HexagonLabeling, i.e. any two permutations representing the same labeling give the same projective Pascal line. The geometric backbone is the action of the dihedral generators hexRot/hexRev on the three Pascal points {+-P,+-Q,+-R}, which permutes them as a set; Pascal's theorem makes them collinear so they span one line, fixed by D6. Establishing it as a projective line equality (up to nonzero scalar) requires a general-position (non-degeneracy) hypothesis on the relabeled Pascal lines.",
+    "whyMatters": [
+      "Well-definedness of the Pascal-line map is the prerequisite for indexing the 60 Pascal lines by HexagonLabeling and stating the Steiner (20) and Kirkman (60) concurrence theorems (siblings OQ-03-OQ-03/04).",
+      "It isolates the exact role of general position: the descent is unconditional as a set-permutation of Pascal points; only promoting it to a projective line equality needs the non-degeneracy hypothesis, made concrete here via the 2x2-minor criterion."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "pascalLine_sameProjLine_rep (VERIFIED, #30806): the total pascalLine map (via canonical rep lbl.out) agrees as a projective line with the Pascal line from ANY representative pi of lbl, under general-position hnd -- the genuine OQ-03-OQ-02 well-definedness.",
+      "pascalProjLine_sameProjLine_of_quotient_eq (VERIFIED): two permutations in the same coset relabel hex to the same projective Pascal line.",
+      "Generator-action lemmas (PART 4c): hexRot:(P,Q,R)->(Q,R,-P), hexRev:(P,Q,R)->(-Q,-P,R), exact vector identities, 0 sorry.",
+      "sameProjLine is a PER on nonzero line-vectors (refl/symm/trans with m!=0); D6-closure descent via Subgroup.closure_induction.",
+      "PART 4j (#30840): geometric meaning of non-degeneracy -- pascalProjLine_eq_zero_iff (cross product vanishes iff all three 2x2 minors of P,Q vanish) and pascalProjLine_ne_zero_of_minor (one nonzero minor suffices).",
+      "PART 4k (#30863): pointOnLine_pascalProjLine_iff_collinear -- a point lies on the Pascal line iff collinear with the two spanning Pascal points (exhaustive incidence, unconditional)."
+    ],
+    "open": [
+      "steiner_count_eq_20 (OQ-03-OQ-03) and kirkman_count_eq_60 (OQ-03-OQ-04): the Conway-Ryba concurrence combinatorics -- genuinely open, OUT OF SCOPE for this well-definedness slug (separate sibling slugs).",
+      "Discharging the general-position hypothesis hnd from a named general-position predicate on hex (the result is genuinely false without it; left as an explicit hypothesis, the honest formulation)."
+    ],
+    "goal": "Machine-check that the Pascal-line map descends to HexagonLabeling = Sym(6)/D6 as a well-defined projective line, under an explicit general-position hypothesis. ACHIEVED and verified (#30806/#30840/#30863)."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-06-13T12:52:52.046Z",
+    "phase": "COMPLETED",
+    "since": "2026-06-28",
     "iteration": 1,
-    "focus": "",
+    "focus": "OQ-03-OQ-02 well-definedness is VERIFIED and merged: pascalLine_sameProjLine_rep + pascalProjLine_sameProjLine_of_quotient_eq (representative-independence of the projective Pascal line, conditional on general-position hnd), plus the concrete non-degeneracy criterion (PART 4j) and exhaustive incidence (PART 4k). #print axioms: only conic_implies_pascal_constraint (the file's foundational Pascal axiom) + propext/Classical.choice/Quot.sound (no native_decide). The two remaining file sorries (steiner_count_eq_20, kirkman_count_eq_60) are the OQ-03-OQ-03/04 count theorems -- separate slugs, genuinely open, out of scope here.",
     "blockers": [],
-    "nextAction": "On a host with a working build (Docker back up, or disk freed):",
+    "nextAction": "None for this slug -- OQ-03-OQ-02 deliverable complete and verified. (Metadata had been corrupted to phase NEW/empty; restored and marked completed by researcher-1 2026-06-28.) Remaining Steiner/Kirkman counts are tracked by sibling OQ-03-OQ-03/04.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -73,5 +86,18 @@
     "mathlib": []
   },
   "started": "2026-06-13T12:52:52.046Z",
-  "lastUpdate": "2026-06-13T12:52:52.046Z"
+  "lastUpdate": "2026-06-28",
+  "leanFiles": [
+    {
+      "path": "Proofs/PascalsHexagonOQ03.lean",
+      "filename": "PascalsHexagonOQ03.lean",
+      "lineCount": 1611,
+      "theoremCount": null,
+      "axiomCount": 1,
+      "defCount": null,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PascalsHexagonOQ03.lean"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Metadata-only cleanup. The titled deliverable of this slug — **well-definedness of the Pascal-line map** `HexagonLabeling = Sym(6)/D₆ → ProjLine` (OQ-03-OQ-02) — is already machine-checked and merged:

- `pascalLine_sameProjLine_rep`, `pascalProjLine_sameProjLine_of_quotient_eq` (#30806) — the projective Pascal line is independent of coset representative, under an explicit general-position hypothesis `hnd`.
- PART 4j non-degeneracy criterion (#30840), PART 4k exhaustive incidence (#30863).

Verified this session via `proofs/bin/lake env lean`: `pascalLine_sameProjLine_rep` compiles and `#print axioms` reports only `conic_implies_pascal_constraint` (the file's foundational Pascal axiom) + `propext / Classical.choice / Quot.sound` — **no `native_decide`**.

## What this PR changes

The JSON metadata had been corrupted to `phase: NEW`, `iteration: 1`, empty `problemStatement` / `focus` / `goal` (only the `knowledge` object survived), so the claim pool kept re-handing this finished problem to researchers (the "unmarked-completed entry" pattern). This PR:

- Restores `problemStatement`, `knownResults`, `currentState` from the surviving knowledge.
- Writes the (previously empty) `knowledge.md`.
- Sets `status: completed` / `phase: COMPLETED`.

## Scope / honesty

The two remaining file `sorry`s — `steiner_count_eq_20` (OQ-03-OQ-03) and `kirkman_count_eq_60` (OQ-03-OQ-04) — are the Conway–Ryba concurrence count theorems, **separate sibling slugs**, genuinely open and out of scope here. The well-definedness result is conditional on the explicit general-position hypothesis (it is genuinely false without general position — the honest formulation). No new mathematics; metadata + knowledge-base fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)