### PR TITLE
research(chebyshev-pnt-bridge-oq-06-oq-02): n·log n lower bound on the n-th prime [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChebyshevPNTBridgeOQ06OQ02.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ06OQ02.lean
@@ -1,0 +1,158 @@
+/-
+# Chebyshev–PNT Bridge OQ-06-OQ-02: an `n·log n` lower bound on the n-th prime
+
+The sibling entries OQ-05 / OQ-06 and the sandwich OQ-06-OQ-01 package the elementary
+Chebyshev bounds on the prime-counting function `π` into real-logarithmic form, with
+upper density `limsup π(x)·log x / x ≤ 2·log 4`.  Reading that **upper** bound at the
+primes themselves *inverts* it into a growth statement for the n-th prime
+`pₙ := Nat.nth Nat.Prime n` (`Nat`-indexed from `0`, so `p₀ = 2`).
+
+The bridge is the identity `π(pₙ) = n + 1` (`primeCounting_nth_prime`): `pₙ` is the
+`(n+1)`-st prime, and `π` counts primes `≤ pₙ`.  Feeding `m = pₙ` into OQ-06's
+`primeCounting_mul_log_sqrt_le` gives
+
+    (n + 1)·log(√pₙ) ≤ pₙ·log 4 + √pₙ·log(√pₙ).
+
+The correction `√pₙ·log(√pₙ)` is absorbed by `√pₙ·log(√pₙ) ≤ pₙ·log 4`
+(because `log(√pₙ) ≤ √pₙ ≤ √pₙ·log 4`, using `log 4 ≥ 1`), collapsing this to
+
+    (n + 1)·log(√pₙ) ≤ 2·pₙ·log 4.
+
+Finally the OQ-06-OQ-01 bracket `log(√pₙ) ≥ ½·log pₙ − log 2` together with the trivial
+`pₙ ≥ n + 2` (`Nat.add_two_le_nth_prime`) gives the explicit
+
+    pₙ ≥ (n + 1)·(½·log(n+2) − log 2) / (2·log 4)      ~   n·log n / (4·log 4),
+
+an honest `n·log n` lower bound on the n-th prime — strictly sharper than Mathlib's
+linear `Nat.add_two_le_nth_prime` (`pₙ ≥ n + 2`).  This is the elementary-Chebyshev
+inverse of the prime-counting upper density.  `0 sorries, 0 axioms`.
+-/
+import Mathlib.NumberTheory.PrimeCounting
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.Complex.ExponentialBounds
+import Mathlib.Tactic
+import Proofs.ChebyshevPNTBridge
+import Proofs.ChebyshevPNTBridgeOQ06
+
+namespace ChebyshevPNTBridgeOQ06OQ02
+
+open Nat
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART 0: THE `Nat.sqrt` LOGARITHM BRACKET (lower half)
+
+`log(√m) ≥ ½·log m − log 2` for `m ≥ 4`.  This mirrors `log_natSqrt_ge` from the
+sibling `ChebyshevPNTBridgeOQ06OQ01`; it is reproved here (self-contained, needs only
+the defining inequalities of `Nat.sqrt`) so this file depends on nothing beyond OQ-06.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Lower half of the `Nat.sqrt` log bracket:** `½·log m − log 2 ≤ log(Nat.sqrt m)`
+for `m ≥ 4`, from `m < (Nat.sqrt m + 1)² ≤ (2·Nat.sqrt m)² = 4·(Nat.sqrt m)²`. -/
+theorem log_natSqrt_ge (m : ℕ) (hm : 4 ≤ m) :
+    Real.log m / 2 - Real.log 2 ≤ Real.log (Nat.sqrt m) := by
+  have hsqrt_ge2 : 2 ≤ Nat.sqrt m := by rw [Nat.le_sqrt]; omega
+  have hlt : m < (Nat.sqrt m + 1) * (Nat.sqrt m + 1) := Nat.lt_succ_sqrt m
+  have hbound : m ≤ 4 * (Nat.sqrt m) ^ 2 := by nlinarith [hlt, hsqrt_ge2]
+  have hboundR : (m : ℝ) ≤ 4 * (Nat.sqrt m : ℝ) ^ 2 := by exact_mod_cast hbound
+  have hmR : (0 : ℝ) < (m : ℝ) := by exact_mod_cast (by omega : 0 < m)
+  have hlog := Real.log_le_log hmR hboundR
+  rw [Real.log_mul (by norm_num) (by positivity), Real.log_pow] at hlog
+  have hlog4 : Real.log 4 = 2 * Real.log 2 := by
+    rw [show (4 : ℝ) = 2 ^ 2 by norm_num, Real.log_pow]; ring
+  rw [hlog4] at hlog
+  push_cast at hlog
+  linarith
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART I: THE BRIDGE IDENTITY  `π(nth Prime n) = n + 1`
+
+`Nat.nth Nat.Prime n` is the `(n+1)`-st prime (`Nat`-indexed from `0`).  Mathlib's
+`primeCounting'` counts primes *strictly below* its argument, so
+`π'(nth Prime n) = n`; since `nth Prime n` is itself prime, the inclusive count
+`π(nth Prime n) = π'(nth Prime n + 1)` adds exactly one, giving `n + 1`.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Bridge identity:** `π(nth Prime n) = n + 1`. -/
+theorem primeCounting_nth_prime (n : ℕ) :
+    Nat.primeCounting (Nat.nth Nat.Prime n) = n + 1 := by
+  have h : Nat.primeCounting' (Nat.nth Nat.Prime n + 1)
+      = Nat.primeCounting' (Nat.nth Nat.Prime n) + 1 := by
+    unfold Nat.primeCounting'
+    rw [Nat.count_succ]
+    simp [Nat.prime_nth_prime n]
+  unfold Nat.primeCounting
+  rw [h, Nat.primeCounting'_nth_eq]
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART II: THE `n·log n` LOWER BOUND ON THE N-TH PRIME
+
+Read OQ-06's upper bound at `m = nth Prime n`, absorb the `√pₙ` correction, and
+substitute the `Nat.sqrt` log bracket of OQ-06-OQ-01.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **The Chebyshev `n·log n` lower bound on the n-th prime.**  For every `n ≥ 2`,
+with `pₙ = Nat.nth Nat.Prime n`,
+
+    (n + 1)·(½·log(n+2) − log 2)  ≤  2·log 4·pₙ,
+
+i.e. `pₙ ≥ (n + 1)·(½·log(n+2) − log 2) / (2·log 4) ~ n·log n / (4·log 4)`.  This is the
+elementary-Chebyshev inverse of the prime-counting upper density, strictly sharper than
+the linear `Nat.add_two_le_nth_prime` (`pₙ ≥ n + 2`). -/
+theorem nth_prime_lower_bound (n : ℕ) (hn : 2 ≤ n) :
+    (n + 1 : ℝ) * (Real.log (n + 2) / 2 - Real.log 2)
+      ≤ 2 * Real.log 4 * (Nat.nth Nat.Prime n : ℝ) := by
+  set p := Nat.nth Nat.Prime n with hp
+  -- pₙ ≥ n + 2 ≥ 4
+  have hge : n + 2 ≤ p := by
+    have := Nat.add_two_le_nth_prime n; rw [← hp] at this; exact this
+  have hp4 : 4 ≤ p := by omega
+  -- positivity scaffolding
+  have hpR : (0 : ℝ) < (p : ℝ) := by exact_mod_cast (by omega : 0 < p)
+  have hsqrt_ge2 : 2 ≤ Nat.sqrt p := by rw [Nat.le_sqrt]; omega
+  have hsqrtR2 : (2 : ℝ) ≤ (Nat.sqrt p : ℝ) := by exact_mod_cast hsqrt_ge2
+  have hsqrtR : (0 : ℝ) < (Nat.sqrt p : ℝ) := by linarith
+  have hlogsqrt_pos : 0 < Real.log (Nat.sqrt p) := Real.log_pos (by linarith)
+  -- log 4 ≥ 1, via 1 = log(exp 1) ≤ log 4 (exp 1 < 2.72 ≤ 4)
+  have hlog4 : (1 : ℝ) ≤ Real.log 4 := by
+    rw [show (1 : ℝ) = Real.log (Real.exp 1) by rw [Real.log_exp]]
+    apply Real.log_le_log (Real.exp_pos 1)
+    have := Real.exp_one_lt_d9; linarith
+  -- π(pₙ) = n + 1
+  have hpi : (Nat.primeCounting p : ℝ) = (n + 1 : ℝ) := by
+    rw [hp, primeCounting_nth_prime]; push_cast; ring
+  -- (A) OQ-06 mul bound at m = pₙ:  (n+1)·log√p ≤ p·log4 + √p·log√p
+  have hA := ChebyshevPNTBridgeOQ06.primeCounting_mul_log_sqrt_le p hp4
+  rw [hpi] at hA
+  -- (B) absorb the correction:  √p·log√p ≤ p·log4
+  have hlogle : Real.log (Nat.sqrt p) ≤ (Nat.sqrt p : ℝ) := by
+    have := Real.log_le_sub_one_of_pos hsqrtR; linarith
+  have hsqNat : Nat.sqrt p ^ 2 ≤ p := Nat.sqrt_le' p
+  have hsq : (Nat.sqrt p : ℝ) * (Nat.sqrt p : ℝ) ≤ (p : ℝ) := by
+    have hR : (Nat.sqrt p : ℝ) ^ 2 ≤ (p : ℝ) := by exact_mod_cast hsqNat
+    nlinarith [hR]
+  have hB : (Nat.sqrt p : ℝ) * Real.log (Nat.sqrt p) ≤ (p : ℝ) * Real.log 4 := by
+    have h1 : (Nat.sqrt p : ℝ) * Real.log (Nat.sqrt p)
+        ≤ (Nat.sqrt p : ℝ) * (Nat.sqrt p : ℝ) :=
+      mul_le_mul_of_nonneg_left hlogle (by linarith)
+    have h3 : (p : ℝ) ≤ (p : ℝ) * Real.log 4 := by nlinarith [hlog4, hpR]
+    linarith
+  -- (C) collapse:  (n+1)·log√p ≤ 2·p·log4
+  have hC : (n + 1 : ℝ) * Real.log (Nat.sqrt p) ≤ 2 * (p : ℝ) * Real.log 4 := by
+    nlinarith [hA, hB]
+  -- (D) bracket + monotonicity:  ½·log(n+2) − log2 ≤ log√p
+  have hbr := log_natSqrt_ge p hp4
+  have hnp : (n + 2 : ℝ) ≤ (p : ℝ) := by exact_mod_cast hge
+  have hlogmono : Real.log (n + 2) ≤ Real.log p :=
+    Real.log_le_log (by positivity) hnp
+  have hD : Real.log (n + 2) / 2 - Real.log 2 ≤ Real.log (Nat.sqrt p) := by
+    linarith [hbr, hlogmono]
+  -- combine (D) and (C)
+  have hn1 : (0 : ℝ) ≤ (n + 1 : ℝ) := by positivity
+  have hfin : (n + 1 : ℝ) * (Real.log (n + 2) / 2 - Real.log 2)
+      ≤ (n + 1 : ℝ) * Real.log (Nat.sqrt p) := mul_le_mul_of_nonneg_left hD hn1
+  nlinarith [hfin, hC]
+
+#check primeCounting_nth_prime   -- π(nth Prime n) = n + 1
+#check nth_prime_lower_bound      -- (n+1)·(½log(n+2)−log2) ≤ 2·log4·pₙ
+
+end ChebyshevPNTBridgeOQ06OQ02

--- a/research/problems/chebyshev-pnt-bridge-oq-06/knowledge.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-06/knowledge.md
@@ -44,3 +44,37 @@ GOTCHAs / reusable facts:
 * Tighter constants (Chebyshev's 0.921/1.106) need sharper primorial/central-binomial
   estimates — deferred.
 * Full PNT π(x) ~ x/log x needs analytic ζ machinery — out of reach here.
+
+## Session 2 (2026-06-28, researcher-6): invert upper density → n·log n lower bound on pₙ
+
+**Mode:** FRESH (problem was SOLVED — deliverable + sandwich OQ-06-OQ-01 already merged).
+**Outcome:** new verified follow-up entry `ChebyshevPNTBridgeOQ06OQ02.lean` (158 lines,
+3 theorems, **0-sorry 0-axiom**), PR #31282. Marked parent problem `completed`.
+
+Read OQ-06's upper density at the primes themselves to bound the n-th prime
+`pₙ = Nat.nth Nat.Prime n` from below:
+
+* `primeCounting_nth_prime`: **π(nth Prime n) = n + 1** — the bridge. `π'(nth Prime n)=n`
+  (`Nat.primeCounting'_nth_eq`) and one `Nat.count_succ` increment (justified by
+  `Nat.prime_nth_prime`) bump the inclusive count by 1.
+* `log_natSqrt_ge`: reproved self-contained (mirrors OQ-06-OQ-01) so the file depends
+  ONLY on parent OQ-06, not on OQ-05/OQ-06-OQ-01 (whose oleans weren't built locally).
+* `nth_prime_lower_bound`: **pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4) ~ n·log n/(4·log 4)**
+  for n ≥ 2 — strictly sharper than Mathlib's linear `Nat.add_two_le_nth_prime` (pₙ ≥ n+2).
+
+Key steps: instantiate `primeCounting_mul_log_sqrt_le` at m=pₙ, sub π(pₙ)=n+1, absorb the
+`√pₙ·log√pₙ ≤ pₙ·log4` tail (via `log√pₙ ≤ √pₙ` and `log4 ≥ 1`), collapse to
+`(n+1)·log√pₙ ≤ 2·pₙ·log4`, then bracket + `pₙ ≥ n+2`.
+
+GOTCHAs / reusable:
+* `log 4 ≥ 1` cleanly: `1 = log(exp 1) ≤ log 4` via `Real.exp_one_lt_d9` (exp 1 < 2.72 < 4),
+  in `Mathlib.Analysis.Complex.ExponentialBounds` (NOT Log.Basic — needs explicit import).
+  `Real.log_two_gt_d9` exists but is `Real.`-namespaced in that same module too.
+* `Nat.sqrt_le' p : (Nat.sqrt p)^2 ≤ p` (the `^2` form, not `*`).
+* Verify in-worktree: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/ChebyshevPNTBridgeOQ06OQ02.lean`
+  (parent OQ-06 olean present in symlinked main `.lake`; OQ-05/OQ-06-OQ-01 oleans were NOT).
+
+## Open follow-up (next session)
+* Invert OQ-05's LOWER density to get `pₙ ≤ C·n·log n`, completing the elementary
+  `pₙ ≍ n·log n` sandwich. (Upper bound on pₙ is the harder direction — OQ-05 bound has
+  the ⌊m/2⌋ and log(m+1) correction terms.)

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "chebyshev-pnt-bridge-oq-06-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 29
+    },
+    "type": "concept",
+    "title": "Inverting the Chebyshev Upper Density at the Primes",
+    "content": "The sibling OQ-06 bounds the prime-counting function by π(m) ≤ m·log 4/log(√m) + √m, giving the upper density limsup π(x)·log x/x ≤ 2 log 4. Reading that bound at the primes themselves inverts it into a growth statement for the n-th prime pₙ = Nat.nth Nat.Prime n. The pivot is the identity π(pₙ) = n + 1: pₙ is the (n+1)-st prime and π counts primes ≤ pₙ. A counting bound π(m) ≤ C·m/log m forces pₙ ≳ (1/C)·n·log n, so Chebyshev's density 2 log 4 becomes the prime-growth denominator 4 log 4. The result, pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4) ~ n·log n/(4·log 4), is sharper than Mathlib's linear pₙ ≥ n + 2. 0 axioms, 0 sorries.",
+    "mathContext": "$p_n \\ge \\dfrac{(n+1)\\,(\\tfrac12\\log(n+2) - \\log 2)}{2\\log 4} \\sim \\dfrac{n\\log n}{4\\log 4}$ for $n \\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "prime-counting function π",
+      "n-th prime Nat.nth Nat.Prime",
+      "Chebyshev's theorem",
+      "prime growth pₙ ≍ n log n"
+    ],
+    "prerequisites": [
+      "the sibling OQ-06 Chebyshev upper bound",
+      "the n-th prime Nat.nth Nat.Prime",
+      "Real.log basics"
+    ]
+  },
+  {
+    "id": "ann-bracket",
+    "proofId": "chebyshev-pnt-bridge-oq-06-oq-02",
+    "range": {
+      "startLine": 41,
+      "endLine": 64
+    },
+    "type": "lemma",
+    "title": "The Nat.sqrt Logarithm Bracket: ½ log m − log 2 ≤ log(Nat.sqrt m)",
+    "content": "log_natSqrt_ge reproves, self-contained, the lower half of the integer-square-root logarithm bracket for m ≥ 4. From Nat.le_sqrt we get Nat.sqrt m ≥ 2, hence Nat.sqrt m + 1 ≤ 2·Nat.sqrt m, so Nat.lt_succ_sqrt's m < (Nat.sqrt m + 1)² upgrades to the crude m < 4·(Nat.sqrt m)². Taking logs and expanding log(4·(√m)²) = 2 log 2 + 2 log(√m) gives log m ≤ 2 log 2 + 2 log(√m), i.e. ½ log m − log 2 ≤ log(√m). Reproving it here (rather than importing OQ-06-OQ-01) keeps this file's dependency footprint to just the parent OQ-06.",
+    "mathContext": "$m < (\\lfloor\\sqrt m\\rfloor+1)^2 \\le 4(\\lfloor\\sqrt m\\rfloor)^2 \\implies \\tfrac12\\log m - \\log 2 \\le \\log(\\lfloor\\sqrt m\\rfloor)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "integer square root Nat.sqrt",
+      "Nat.lt_succ_sqrt",
+      "Nat.le_sqrt",
+      "Real.log monotonicity"
+    ],
+    "prerequisites": [
+      "defining inequalities of Nat.sqrt",
+      "Real.log_mul and Real.log_pow"
+    ]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "chebyshev-pnt-bridge-oq-06-oq-02",
+    "range": {
+      "startLine": 66,
+      "endLine": 84
+    },
+    "type": "lemma",
+    "title": "The Bridge Identity: π(Nat.nth Prime n) = n + 1",
+    "content": "primeCounting_nth_prime is the link that lets the prime-counting bounds be read at the primes. Mathlib's primeCounting' counts primes STRICTLY below its argument, so Nat.primeCounting'_nth_eq gives π'(nth Prime n) = n. The inclusive count is π(nth Prime n) = π'(nth Prime n + 1); since nth Prime n is itself prime (Nat.prime_nth_prime), Nat.count_succ bumps the count by exactly one as the argument crosses nth Prime n, yielding π(nth Prime n) = n + 1. This +1 — pₙ counting itself — is exactly what converts the index n into the prime-counting value at pₙ.",
+    "mathContext": "$\\pi'(p_n) = n$ and $p_n$ prime $\\implies \\pi(p_n) = \\pi'(p_n + 1) = n + 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.primeCounting'_nth_eq",
+      "Nat.prime_nth_prime",
+      "Nat.count_succ",
+      "inclusive vs strict prime counting"
+    ],
+    "prerequisites": [
+      "definitions of Nat.primeCounting and Nat.primeCounting'",
+      "Nat.nth Nat.Prime as the n-th prime"
+    ]
+  },
+  {
+    "id": "ann-nth-prime-bound",
+    "proofId": "chebyshev-pnt-bridge-oq-06-oq-02",
+    "range": {
+      "startLine": 86,
+      "endLine": 153
+    },
+    "type": "theorem",
+    "title": "The n·log n Lower Bound on the n-th Prime",
+    "content": "nth_prime_lower_bound assembles the explicit bound. Instantiate OQ-06's primeCounting_mul_log_sqrt_le at m = pₙ (legal since pₙ ≥ n + 2 ≥ 4) and substitute π(pₙ) = n + 1: (n+1)·log(√pₙ) ≤ pₙ·log 4 + √pₙ·log(√pₙ). The correction √pₙ·log(√pₙ) is absorbed using log(√pₙ) ≤ √pₙ (Real.log_le_sub_one_of_pos) and log 4 ≥ 1 (from exp 1 < 4, Real.exp_one_lt_d9): √pₙ·log(√pₙ) ≤ √pₙ·√pₙ ≤ pₙ ≤ pₙ·log 4, collapsing the bound to (n+1)·log(√pₙ) ≤ 2·pₙ·log 4. Finally the bracket log(√pₙ) ≥ ½·log pₙ − log 2 and log pₙ ≥ log(n+2) (from pₙ ≥ n+2) give (n+1)·(½·log(n+2) − log 2) ≤ 2·log 4·pₙ. The constant 1/(4 log 4) ≈ 0.18 is not sharp — PNT gives pₙ/(n log n) → 1 — but the n·log n order is correct and strictly beats the linear Nat.add_two_le_nth_prime.",
+    "mathContext": "$(n+1)\\big(\\tfrac12\\log(n+2)-\\log 2\\big) \\le 2\\log 4 \\cdot p_n$, i.e. $p_n \\gtrsim \\dfrac{n\\log n}{4\\log 4}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Chebyshev upper density",
+      "n-th prime growth pₙ ≍ n log n",
+      "Nat.add_two_le_nth_prime",
+      "Real.log_le_sub_one_of_pos",
+      "Real.exp_one_lt_d9"
+    ],
+    "prerequisites": [
+      "OQ-06's primeCounting_mul_log_sqrt_le",
+      "the bridge identity π(nth Prime n) = n + 1",
+      "the Nat.sqrt logarithm bracket"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/index.ts
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevPNTBridgeOQ06OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevPntBridgeOq06Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevPntBridgeOq06Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevPntBridgeOq06Oq02Data: ProofData = {
+  proof: chebyshevPntBridgeOq06Oq02Proof,
+  annotations: chebyshevPntBridgeOq06Oq02Annotations,
+}

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-06-oq-02/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "chebyshev-pnt-bridge-oq-06-oq-02",
+  "title": "An n·log n Lower Bound on the n-th Prime from the Chebyshev Upper Density",
+  "slug": "chebyshev-pnt-bridge-oq-06-oq-02",
+  "description": "Inverts the elementary Chebyshev upper density into a growth statement for the n-th prime pₙ = Nat.nth Nat.Prime n. The bridge is the identity π(pₙ) = n + 1: pₙ is the (n+1)-st prime and π counts primes ≤ pₙ. Feeding m = pₙ into the sibling OQ-06's upper bound π(m)·log(√m) ≤ m·log 4 + √m·log(√m) gives (n+1)·log(√pₙ) ≤ pₙ·log 4 + √pₙ·log(√pₙ); the correction √pₙ·log(√pₙ) is absorbed by √pₙ·log(√pₙ) ≤ pₙ·log 4 (since log(√pₙ) ≤ √pₙ ≤ √pₙ·log 4, using log 4 ≥ 1), collapsing to (n+1)·log(√pₙ) ≤ 2·pₙ·log 4. The Nat.sqrt logarithm bracket log(√pₙ) ≥ ½·log pₙ − log 2 together with the trivial pₙ ≥ n + 2 then yields the explicit pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4) ~ n·log n/(4·log 4) — an honest n·log n lower bound on the n-th prime, strictly sharper than Mathlib's linear Nat.add_two_le_nth_prime (pₙ ≥ n + 2). 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Pafnuty Chebyshev",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_function",
+    "date": "1852",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ06OQ02.lean",
+    "tags": [
+      "number-theory",
+      "prime-counting",
+      "nth-prime",
+      "chebyshev",
+      "analytic-number-theory",
+      "prime-number-theorem",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.primeCounting'_nth_eq",
+        "description": "π'(Nat.nth Prime n) = n; π' counts primes strictly below its argument, so at the (n+1)-st prime it equals n — the half of the bridge identity that does not yet count pₙ itself",
+        "module": "Mathlib.NumberTheory.PrimeCounting"
+      },
+      {
+        "theorem": "Nat.prime_nth_prime",
+        "description": "Nat.nth Prime n is prime; this makes Nat.count Prime increment by exactly one as the argument passes nth Prime n, upgrading π'(pₙ) = n to π(pₙ) = n + 1",
+        "module": "Mathlib.NumberTheory.PrimeCounting"
+      },
+      {
+        "theorem": "Nat.count_succ",
+        "description": "count p (k+1) = count p k + (if p k then 1 else 0); the step relation that turns π'(pₙ + 1) into π'(pₙ) + 1 because pₙ is prime",
+        "module": "Mathlib.Data.Nat.Count"
+      },
+      {
+        "theorem": "Nat.add_two_le_nth_prime",
+        "description": "n + 2 ≤ Nat.nth Prime n; the trivial linear lower bound on pₙ, used both to obtain pₙ ≥ 4 (so all the log estimates apply) and, via log monotonicity, to replace log pₙ by log(n+2) in the final explicit bound",
+        "module": "Mathlib.NumberTheory.PrimeCounting"
+      },
+      {
+        "theorem": "Nat.sqrt_le' / Nat.lt_succ_sqrt / Nat.le_sqrt",
+        "description": "the defining inequalities (Nat.sqrt m)² ≤ m < (Nat.sqrt m + 1)² and the characterisation a ≤ Nat.sqrt m ↔ a² ≤ m; supply √pₙ ≥ 2, √pₙ² ≤ pₙ (correction absorption), and the lower half of the log bracket",
+        "module": "Mathlib.Algebra.Order.Ring.Nat"
+      },
+      {
+        "theorem": "Real.log_le_sub_one_of_pos",
+        "description": "log x ≤ x − 1 for x > 0; gives log(√pₙ) ≤ √pₙ, the step that lets √pₙ·log(√pₙ) be absorbed into pₙ·log 4",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.exp_one_lt_d9",
+        "description": "exp 1 < 2.7182818286 < 4; via log monotonicity this gives 1 = log(exp 1) ≤ log 4, the inequality log 4 ≥ 1 used to dominate √pₙ ≤ √pₙ·log 4",
+        "module": "Mathlib.Analysis.Complex.ExponentialBounds"
+      },
+      {
+        "theorem": "Real.log_le_log / Real.log_pow / Real.log_mul",
+        "description": "monotonicity of log and the expansions log(xⁿ) = n log x, log(xy) = log x + log y; transfer the integer inequalities to the log bracket and to log pₙ ≥ log(n+2)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "primeCounting_nth_prime: the bridge identity π(Nat.nth Prime n) = n + 1, derived from π'(nth Prime n) = n (Nat.primeCounting'_nth_eq) and the single-step count increment (Nat.count_succ) justified by primality of nth Prime n — the link that lets the prime-counting bounds be read at the primes themselves",
+      "log_natSqrt_ge (reproved self-contained): the lower half of the Nat.sqrt log bracket ½·log m − log 2 ≤ log(Nat.sqrt m) for m ≥ 4, from m < (Nat.sqrt m + 1)² ≤ 4·(Nat.sqrt m)², so this entry depends on nothing beyond the parent OQ-06",
+      "nth_prime_lower_bound: the explicit n·log n lower bound (n+1)·(½·log(n+2) − log 2) ≤ 2·log 4·pₙ for n ≥ 2, i.e. pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4) ~ n·log n/(4·log 4) — the elementary-Chebyshev inverse of the upper density, strictly sharper than the linear Nat.add_two_le_nth_prime (pₙ ≥ n + 2)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 158,
+    "assumptions": "None — fully verified from Mathlib and the parent bridge file OQ-06 with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide. The constant 1/(4·log 4) ≈ 0.18 in pₙ ≳ n·log n/(4·log 4) is not asymptotically sharp (the true ratio pₙ/(n log n) → 1 by the Prime Number Theorem); the loss comes from the crude correction-absorption step √pₙ·log(√pₙ) ≤ pₙ·log 4 and the elementary Chebyshev density 2 log 4. Sharpening the constant and the full PNT asymptotic pₙ ~ n log n remain separate open questions of the parent bridge.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's 1852 bounds place π(x) between two constant multiples of x/log x. The classical companion statement, read off the same estimates, is that the n-th prime satisfies pₙ ≍ n·log n — the order of magnitude that the Prime Number Theorem later sharpened to pₙ ~ n·log n. In the formalized bridge, the sibling OQ-06 exported the upper density π(m) ≤ m·log 4/log(√m) + √m. This entry performs the elementary inversion: evaluating that bound at the primes themselves turns an upper bound on a counting function into a lower bound on the n-th prime.",
+    "problemStatement": "The prime-counting bounds of OQ-05/OQ-06 are statements about π(m) for general m. The dual, and arguably more tangible, object is the n-th prime pₙ itself. Convert the Chebyshev upper density into an explicit lower bound on pₙ that exhibits the n·log n growth, improving on the trivial linear pₙ ≥ n + 2 already in Mathlib.",
+    "text": "Establishes π(Nat.nth Prime n) = n + 1, reads the OQ-06 upper bound at m = pₙ, absorbs the √pₙ correction term, and substitutes the Nat.sqrt logarithm bracket to obtain the explicit lower bound pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4).",
+    "proofStrategy": "Part 0 reproves the lower half of the Nat.sqrt log bracket ½·log m − log 2 ≤ log(Nat.sqrt m) (m ≥ 4) self-contained, from m < (√m+1)² ≤ 4·(√m)². Part I proves the bridge identity π(nth Prime n) = n + 1: π'(nth Prime n) = n (Nat.primeCounting'_nth_eq), and since nth Prime n is prime, Nat.count_succ bumps the inclusive count π(nth Prime n) = π'(nth Prime n + 1) to n + 1. Part II instantiates OQ-06's primeCounting_mul_log_sqrt_le at m = pₙ (legal since pₙ ≥ n+2 ≥ 4), substitutes π(pₙ) = n+1 to get (n+1)·log(√pₙ) ≤ pₙ·log 4 + √pₙ·log(√pₙ); bounds √pₙ·log(√pₙ) ≤ pₙ·log 4 via log(√pₙ) ≤ √pₙ (Real.log_le_sub_one_of_pos) and log 4 ≥ 1 (from exp 1 < 4); collapses to (n+1)·log(√pₙ) ≤ 2·pₙ·log 4; and finally substitutes the bracket log(√pₙ) ≥ ½·log pₙ − log 2 ≥ ½·log(n+2) − log 2 (using pₙ ≥ n+2 and log monotonicity), with nlinarith assembling the explicit bound.",
+    "keyInsights": [
+      "The identity π(Nat.nth Prime n) = n + 1 is the precise bridge that lets a bound on the counting function π be re-read as a bound on the n-th prime — π' counts primes strictly below, so the +1 comes from pₙ being prime itself",
+      "A bound π(m) ≤ C·m/log m on the counting function inverts to a lower bound pₙ ≳ (1/C)·n·log n on the n-th prime; the upper density constant 2 log 4 of Chebyshev becomes the denominator 4 log 4 of the prime growth",
+      "The √pₙ tail in the OQ-06 bound, a nuisance for the density reading, is harmless here: log(√pₙ) ≤ √pₙ and log 4 ≥ 1 give √pₙ·log(√pₙ) ≤ pₙ·log 4, so the tail merely doubles the leading term",
+      "The result is genuinely sharper than Mathlib's Nat.add_two_le_nth_prime (pₙ ≥ n + 2): it supplies the extra log(n+2) factor, recovering the correct n·log n order of magnitude rather than mere linear growth"
+    ],
+    "prerequisites": [
+      "the prime-counting function π, π', and the n-th prime Nat.nth Nat.Prime",
+      "the sibling OQ-06 Chebyshev upper bound",
+      "the defining inequalities of the integer square root Nat.sqrt and elementary Real.log inequalities"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "Module docstring: invert the OQ-06 Chebyshev upper density at the primes to obtain an n·log n lower bound on the n-th prime."
+    },
+    {
+      "id": "bracket",
+      "title": "The Nat.sqrt logarithm bracket (lower half)",
+      "startLine": 41,
+      "endLine": 64,
+      "summary": "log_natSqrt_ge: ½·log m − log 2 ≤ log(Nat.sqrt m) for m ≥ 4, reproved self-contained from m < (√m+1)² ≤ 4·(√m)²."
+    },
+    {
+      "id": "bridge",
+      "title": "The bridge identity π(nth Prime n) = n + 1",
+      "startLine": 66,
+      "endLine": 84,
+      "summary": "primeCounting_nth_prime: π' at the (n+1)-st prime is n, and primality bumps the inclusive count to n + 1 via Nat.count_succ."
+    },
+    {
+      "id": "nth-prime-bound",
+      "title": "The n·log n lower bound on the n-th prime",
+      "startLine": 86,
+      "endLine": 153,
+      "summary": "nth_prime_lower_bound: read OQ-06 at m = pₙ, absorb the √pₙ correction, substitute the log bracket and pₙ ≥ n+2, yielding pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, no native_decide) entry that inverts the elementary Chebyshev upper density into an explicit n·log n lower bound on the n-th prime: pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4) for n ≥ 2, via the bridge identity π(nth Prime n) = n + 1 and the parent OQ-06 upper bound.",
+    "implications": "Supplies the dual, prime-indexed reading of the Chebyshev bounds — a growth statement for pₙ rather than a density statement for π — and improves Mathlib's trivial linear pₙ ≥ n + 2 to the correct n·log n order of magnitude using only elementary inputs.",
+    "openQuestions": [
+      "Derive the matching upper bound pₙ ≤ C·n·log n by inverting the OQ-05 lower density, completing the elementary sandwich pₙ ≍ n·log n.",
+      "Sharpen the constant 1/(4·log 4) toward the true pₙ/(n log n) → 1 by tightening the correction-absorption step and the underlying Chebyshev density constant.",
+      "State the bound as a formal asymptotic pₙ = Θ(n log n) (and ultimately pₙ ~ n log n via PNT), packaging it as a Filter.Tendsto statement."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-06",
+      "relationship": "parent",
+      "description": "Direct parent supplying the upper bound π(m)·log(√m) ≤ m·log 4 + √m·log(√m) (primeCounting_mul_log_sqrt_le) that is read at m = pₙ"
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-06-oq-01",
+      "relationship": "sibling",
+      "description": "Companion consolidation supplying the Nat.sqrt logarithm bracket log_natSqrt_ge, reproved self-contained here so the file depends only on OQ-06"
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-05",
+      "relationship": "related",
+      "description": "The lower-density sibling whose inversion would yield the matching upper bound pₙ ≤ C·n·log n, completing the elementary pₙ ≍ n·log n sandwich"
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge",
+      "relationship": "ancestor",
+      "description": "Root of the bridge chain establishing π(x) = Θ(x/log x), the density form dual to this prime-growth statement"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.PrimeCounting",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Analysis.Complex.ExponentialBounds",
+      "Mathlib.Tactic",
+      "Proofs.ChebyshevPNTBridge",
+      "Proofs.ChebyshevPNTBridgeOQ06"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "ChebyshevPNTBridgeOQ06OQ02",
+    "lineCount": 158,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/ChebyshevPNTBridgeOQ06OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": []
+}

--- a/src/data/research/problems/chebyshev-pnt-bridge-oq-06.json
+++ b/src/data/research/problems/chebyshev-pnt-bridge-oq-06.json
@@ -8,11 +8,21 @@
   "problemStatement": {
     "formal": "Package the parent's ℕ-power Chebyshev upper bound (Nat.sqrt n)^(π(n)−π(√n)) ≤ 4^n into real-logarithmic and density form, mirroring the lower bound done in OQ-05.",
     "plain": "The parent proves Chebyshev's upper bound on the prime-counting function π(n) only in power form; OQ-05 carried the lower bound into log form. This delivers the matching upper-bound log/density form, giving limsup π(x)·log x/x ≤ 2 log 4.",
-    "whyMatters": ["Completes the symmetric real-log packaging of both halves of Chebyshev's 1852 theorem", "Upper density mirror of OQ-05's lower density"]
+    "whyMatters": [
+      "Completes the symmetric real-log packaging of both halves of Chebyshev's 1852 theorem",
+      "Upper density mirror of OQ-05's lower density"
+    ]
   },
   "knownResults": {
-    "proven": ["(π(n)−π(√n))·log(√n) ≤ n·log 4", "π(n)·log(√n) ≤ n·log 4 + √n·log(√n)", "π(n) ≤ n·log 4/log(√n) + √n"],
-    "open": ["tighter constants toward Chebyshev's 0.921/1.106", "full PNT π(x) ~ x/log x"],
+    "proven": [
+      "(π(n)−π(√n))·log(√n) ≤ n·log 4",
+      "π(n)·log(√n) ≤ n·log 4 + √n·log(√n)",
+      "π(n) ≤ n·log 4/log(√n) + √n"
+    ],
+    "open": [
+      "tighter constants toward Chebyshev's 0.921/1.106",
+      "full PNT π(x) ~ x/log x"
+    ],
     "goal": "Real-log upper bound on π(n) matching OQ-05's lower bound."
   },
   "currentState": {
@@ -22,20 +32,27 @@
     "focus": "Delivered ChebyshevPNTBridgeOQ06.lean (3 thms, 0-sorry 0-axiom): real-log upper bound on π(n) by taking Real.log of the parent's power inequality, absorbing the π(√n) correction, and dividing by log(√n). Mirrors OQ-05's lower-bound development.",
     "blockers": [],
     "nextAction": "Combine OQ-05 + OQ-06 into a single two-sided sandwich; tighten constants; the full PNT is out of reach (needs analytic ζ machinery).",
-    "attemptCounts": { "total": 1, "currentApproach": 1, "approachesTried": 1 }
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
   },
   "knowledge": {
-    "progressSummary": "S1 ACT: real-log UPPER bound on π(n) for Chebyshev–PNT bridge (ChebyshevPNTBridgeOQ06.lean, 160 lines, 3 theorems, 0-sorry 0-axiom). primeCounting_diff_mul_log_sqrt_le, primeCounting_mul_log_sqrt_le, primeCounting_le_div_log_sqrt — the upper-density mirror of OQ-05's lower density, giving limsup π(x)·log x/x ≤ 2 log 4.",
+    "progressSummary": "SOLVED (deliverable + sandwich OQ-06-OQ-01 merged). S2: added OQ-06-OQ-02 — inverted the upper density into an explicit n·log n lower bound on the n-th prime (pₙ ≥ (n+1)(½log(n+2)−log2)/(2log4)), 0-sorry 0-axiom. Remaining: matching pₙ upper bound, sharp constants, full PNT (out of reach).",
     "builtItems": [
       "primeCounting_diff_mul_log_sqrt_le: (π(n)−π(√n))·log(√n) ≤ n·log 4 (Real.log of parent's pow_sqrt_primeCounting_diff_le)",
       "primeCounting_mul_log_sqrt_le: π(n)·log(√n) ≤ n·log 4 + √n·log(√n) (absorb π(√n) ≤ √n)",
-      "primeCounting_le_div_log_sqrt: π(n) ≤ n·log 4/log(√n) + √n (divide by log(√n) > 0)"
+      "primeCounting_le_div_log_sqrt: π(n) ≤ n·log 4/log(√n) + √n (divide by log(√n) > 0)",
+      "ChebyshevPNTBridgeOQ06OQ02.lean (158 lines, 3 thms, 0-sorry 0-axiom): inverts the upper density at the primes — primeCounting_nth_prime (π(nth Prime n)=n+1) + nth_prime_lower_bound: pₙ ≥ (n+1)(½log(n+2)−log2)/(2log4) ~ n·log n/(4log4), sharper than Mathlib add_two_le_nth_prime"
     ],
     "insights": [
       "Mirrors OQ-05's lower-bound log transcription exactly (Real.log_le_log + Real.log_pow + Nat.cast_sub); only the parent inequality fed in differs.",
       "Keeping Nat.sqrt n makes inequalities exact; the asymptotic 2 log 4 is read off via log(√n) ≈ ½ log n afterward.",
       "Nat.monotone_primeCounting exists in Mathlib — no need to reprove π monotonicity.",
-      "π(√n) ≤ √n (parent's primeCounting_le) is exactly what turns the difference bound into an absolute π(n) bound."
+      "π(√n) ≤ √n (parent's primeCounting_le) is exactly what turns the difference bound into an absolute π(n) bound.",
+      "The bridge identity π(nth Prime n)=n+1 (via primeCounting'_nth_eq + count_succ on the prime nth Prime n) lets the π-bounds be read AT the primes, inverting an upper density on π into an n·log n lower bound on pₙ.",
+      "√pₙ tail in OQ-06 is harmless for the prime-growth reading: log(√pₙ)≤√pₙ and log4≥1 give √pₙ·log√pₙ ≤ pₙ·log4, merely doubling the leading term."
     ],
     "mathlibGaps": [
       "No real-log Chebyshev bounds in Mathlib (only the combinatorial primorial / central-binomial pieces).",
@@ -44,13 +61,30 @@
     "nextSteps": [
       "Combine OQ-05 (lower) and OQ-06 (upper) into one two-sided sandwich theorem with a common normalisation.",
       "Tighten constants toward Chebyshev's 0.921/1.106 via sharper estimates.",
-      "Full PNT is out of reach in this elementary development."
+      "Full PNT is out of reach in this elementary development.",
+      "Invert OQ-05 lower density to get pₙ ≤ C·n·log n, completing the elementary pₙ ≍ n·log n sandwich (NEW open: chebyshev-pnt-bridge-oq-06-oq-02 follow-up)."
     ],
     "markdown": "# Knowledge: chebyshev-pnt-bridge-oq-06\nSee research/problems/chebyshev-pnt-bridge-oq-06/knowledge.md for session notes.\n"
   },
-  "tags": ["number-theory", "prime-counting", "chebyshev", "analytic-number-theory"],
-  "relatedProofs": ["chebyshev-pnt-bridge", "chebyshev-pnt-bridge-oq-05"],
-  "references": { "papers": [], "urls": ["https://en.wikipedia.org/wiki/Chebyshev_function"], "mathlib": ["Mathlib.NumberTheory.PrimeCounting"] },
+  "tags": [
+    "number-theory",
+    "prime-counting",
+    "chebyshev",
+    "analytic-number-theory"
+  ],
+  "relatedProofs": [
+    "chebyshev-pnt-bridge",
+    "chebyshev-pnt-bridge-oq-05"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Chebyshev_function"
+    ],
+    "mathlib": [
+      "Mathlib.NumberTheory.PrimeCounting"
+    ]
+  },
   "started": "2026-06-27T00:00:00.000Z",
   "lastUpdate": "2026-06-27T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

Inverts the elementary **Chebyshev upper density** at the primes themselves to obtain an explicit **n·log n lower bound on the n-th prime** `pₙ = Nat.nth Nat.Prime n`.

The parent problem `chebyshev-pnt-bridge-oq-06` (upper-density deliverable) and its sandwich follow-up OQ-06-OQ-01 are both already merged. Its remaining listed next-steps were either out of reach (full PNT) or hard (sharp constants); the natural *theory-level-distinct* follow-up — bounds on the n-th prime — was absent from the gallery. This entry supplies the lower half.

## What is proved (`proofs/Proofs/ChebyshevPNTBridgeOQ06OQ02.lean`, 3 theorems)

- **`primeCounting_nth_prime`** — the bridge identity `π(nth Prime n) = n + 1`, from `Nat.primeCounting'_nth_eq` plus a single `Nat.count_succ` increment justified by primality of `nth Prime n`. This is what lets the π-bounds be read *at* the primes.
- **`log_natSqrt_ge`** — the lower half of the `Nat.sqrt` log bracket `½·log m − log 2 ≤ log(Nat.sqrt m)` (m ≥ 4), reproved self-contained so the file depends only on the parent OQ-06.
- **`nth_prime_lower_bound`** — for `n ≥ 2`,

  ```
  (n+1)·(½·log(n+2) − log 2)  ≤  2·log 4·pₙ
  ```
  i.e. `pₙ ≥ (n+1)·(½·log(n+2) − log 2)/(2·log 4) ~ n·log n/(4·log 4)`.

## Why it is new

Strictly sharper than Mathlib's linear `Nat.add_two_le_nth_prime` (`pₙ ≥ n + 2`): it supplies the extra `log(n+2)` factor, recovering the correct **n·log n** order of magnitude from purely elementary Chebyshev inputs.

## Proof sketch

Read OQ-06's `primeCounting_mul_log_sqrt_le` at `m = pₙ`, substitute `π(pₙ) = n+1`:
`(n+1)·log(√pₙ) ≤ pₙ·log 4 + √pₙ·log(√pₙ)`. The tail `√pₙ·log(√pₙ) ≤ pₙ·log 4` (since `log(√pₙ) ≤ √pₙ ≤ √pₙ·log 4`, using `log 4 ≥ 1` from `exp 1 < 4`) collapses it to `(n+1)·log(√pₙ) ≤ 2·pₙ·log 4`; the bracket and `pₙ ≥ n+2` finish.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` lists only `propext / Classical.choice / Quot.sound`; no `native_decide`.
- Typechecked via `lake env lean Proofs/ChebyshevPNTBridgeOQ06OQ02.lean` against the prebuilt parent oleans.
- Gallery `meta.json` passes `gallery:check-size`; annotations integrate cleanly (no errors for this entry in `annotations:build`).

Closes the `chebyshev-pnt-bridge-oq-06` problem. Open follow-up: invert the OQ-05 lower density for the matching `pₙ ≤ C·n·log n`, completing the elementary `pₙ ≍ n·log n` sandwich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)