### PR TITLE
audit(cycleV73): fibonacci matrix-Cassini CLEAN (compile-verified) + 2 reconfirmed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25633,14 +25633,20 @@
       "issues": []
     },
     "erdos-1009-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-28T12:08:06Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-28T12:20:07Z",
       "result": "clean",
       "issues": []
     },
     "erdos-340-greedy-sidon-oq-05": {
+      "auditCount": 2,
+      "lastAudited": "2026-06-28T12:20:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-04-oq-01-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-06-28T12:08:07Z",
+      "lastAudited": "2026-06-28T12:20:07Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Gallery Integrity Audit — cycleV73

Audited 3 entries; **all CLEAN**.

### fibonacci-identities-oq-04-oq-01-oq-01 (NEW — first audit)
Matrix-form proof of Cassini's identity (`det Qⁿ⁺¹ = (−1)ⁿ⁺¹`), from #31277.
- **Compile-verified**: `lake env lean Proofs/FibonacciIdentitiesOQ04OQ01OQ01.lean` → EXIT=0, no errors/warnings.
- 0 sorries, 0 `axiom` declarations, no `native_decide`/`decide` in code (the only `sorry`/`native_decide` text hits are in the disclaimer comment on line 37).
- Mathlib deps (`Matrix.det_pow`, `Matrix.det_fin_two_of`, `Nat.fib_add_two`) are foundational matrix/recurrence lemmas. The core argument — the Fibonacci Q-matrix identity proved by induction, plus determinant multiplicativity — is the file's own work. Genuinely distinct from the parent's parity-based proof.
- **Tier A**; `verified`/`original` claim is accurate. ✅

### erdos-1009-oq-03 (reconfirmed)
K₄ triangle-packing LP-duality integrality gap. 0 sorries, 0 axioms; uses plain kernel-checked `decide` only (no `native_decide` → no `Lean.ofReduceBool`). The classical NP-hardness complexity claim is explicitly **not** formalized and is disclosed in `assumptions`. `verified`/`verified` accurate. ✅

### erdos-340-greedy-sidon-oq-05 (reconfirmed)
0 sorries, 0 axioms, no `native_decide`. `verified`/`original` accurate. ✅

---
Tracker-only change. Discovered during periodic gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)