### PR TITLE
research(shannon-channel-coding-awgn-oq-03): restore stale completed-entry metadata + flag water-filling gap

### DIFF
--- a/research/problems/shannon-channel-coding-awgn-oq-03/knowledge.md
+++ b/research/problems/shannon-channel-coding-awgn-oq-03/knowledge.md
@@ -1,0 +1,25 @@
+# Knowledge Base: shannon-channel-coding-awgn-oq-03
+
+## Status: COMPLETED (Shannon–Hartley half verified & merged)
+
+`ShannonChannelCodingAWGNOQ03.lean` (#30994, VERIFIED, 0-axiom, 0-sorry, 11 thm)
+formalizes the bandlimited **Shannon–Hartley** capacity
+`C = B·log₂(1 + P/N)` bits/s:
+
+- `shannonHartley_eq_awgn` — bridge identity to the per-use AWGN capacity.
+- `shannonHartley_eq_two_B_bits_per_use` — Nyquist assembly (2B uses/s).
+- nonnegativity, zero-power, zero-bandwidth, positivity.
+- monotone in `B` and `P` (+ strict), antitone in noise `N`.
+- `shannonHartley_le_snr_linear` — low-SNR linear bound via `log(1+x) ≤ x`.
+
+## Genuinely open (out of shipped scope)
+
+The title also names **parallel Gaussian channels via water-filling** (vector AWGN
+capacity). This is NOT formalized. It needs:
+`C = Σᵢ ½log₂(1 + Pᵢ/Nᵢ)` maximised over `Σᵢ Pᵢ ≤ P`, with optimum
+`Pᵢ = max(0, ν − Nᵢ)` — an argument requiring concavity of `x ↦ log(1+x/N)` and
+KKT/Lagrangian convex-optimization. Recommend a **dedicated slug**.
+
+(Entry was already `status: completed`; this session restored stale stub
+metadata — `currentState.focus`/`nextAction` and empty `knownResults` — and fixed
+the pool tracker, which had re-served the finished problem. No new math.)

--- a/src/data/research/problems/shannon-channel-coding-awgn-oq-03.json
+++ b/src/data/research/problems/shannon-channel-coding-awgn-oq-03.json
@@ -13,17 +13,21 @@
     ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Bandlimited Shannon–Hartley capacity C = B·log₂(1+P/N) bits/s formalized and VERIFIED (0-axiom) in ShannonChannelCodingAWGNOQ03.lean (#30994): bridge identity to the parent per-use AWGN capacity (Nyquist 2B + base-change), nonnegativity, zero-power/zero-bandwidth, positivity, monotonicity in B and P, antitone in noise N, and the low-SNR linear upper bound log(1+x) ≤ x (11 theorems, 0 sorry, 0 axiom)."
+    ],
+    "open": [
+      "Vector AWGN / parallel Gaussian channels via water-filling (C = Σ ½log₂(1+Pᵢ/Nᵢ) maximised over ΣPᵢ ≤ P, optimum Pᵢ = max(0, ν−Nᵢ)). The second half of the title is NOT formalized; the optimality argument needs concavity/KKT convex-optimization infrastructure. Best spun off into a dedicated slug."
+    ],
+    "goal": "Formalize the bandlimited Shannon–Hartley capacity (DONE, verified #30994). Water-filling for parallel Gaussian channels remains a genuine open extension."
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-06-27T17:44:11.367Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Shannon–Hartley half COMPLETE and verified (#30994): ShannonChannelCodingAWGNOQ03.lean, 11 theorems, 0 sorry, 0 axiom. The title's water-filling / parallel-Gaussian half is genuinely unaddressed (needs concavity/KKT) and is best handled as a dedicated slug.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None for the shipped scope. Follow-up (separate slug recommended): vector AWGN capacity via water-filling — define ΣᵢC(Pᵢ,Nᵢ), prove concavity of x↦log(1+x/N), and the water-filling optimum Pᵢ=max(0,ν−Nᵢ).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -71,8 +75,21 @@
     "mathlib": []
   },
   "started": "2026-06-27T17:44:11.367Z",
-  "lastUpdate": "2026-06-27",
+  "lastUpdate": "2026-06-28",
   "significance": 6,
   "tractability": 5,
-  "currentPhase": "COMPLETED"
+  "currentPhase": "COMPLETED",
+  "leanFiles": [
+    {
+      "path": "Proofs/ShannonChannelCodingAWGNOQ03.lean",
+      "filename": "ShannonChannelCodingAWGNOQ03.lean",
+      "lineCount": 220,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingAWGNOQ03.lean"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Metadata + knowledge-base coherence fix for an already-completed entry. The slug's shipped deliverable — bandlimited **Shannon–Hartley** capacity `C = B·log₂(1 + P/N)` bits/s — is VERIFIED (0-axiom, 0-sorry, 11 theorems) in `ShannonChannelCodingAWGNOQ03.lean` (#30994), and the entry is already `status: completed`.

But the top-level metadata was stale: empty `knownResults`, stub `currentState.focus`/`nextAction` ("Begin problem exploration"), and no `knowledge.md` — while the claim pool kept re-serving the finished problem to researchers.

## Changes (no new math)

- Populate `knownResults` and `currentState.focus`/`nextAction` from the surviving `knowledge` object.
- Add `leanFiles` entry and write `knowledge.md`.
- Pool tracker updated to `completed` so it stops re-serving.

## Honesty / scope

The title also names **parallel Gaussian channels via water-filling** (vector AWGN capacity). This half is **genuinely not formalized** — it needs concavity of `x ↦ log(1+x/N)` plus KKT/Lagrangian convex optimization for the optimum `Pᵢ = max(0, ν − Nᵢ)`. Flagged explicitly as an open extension best handled by a dedicated slug, rather than silently absorbed under "completed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)