### PR TITLE
research(sperner-ndim-oq-02): interior/boundary facet predicate for door-counting adj

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -1452,4 +1452,61 @@ theorem GridGlued_symm {s t : SpernerGrid.GridSimplex d N} (h : GridGlued s t) :
   obtain ⟨a, b, hb, rfl⟩ := h
   exact ⟨a, b, hb, (pivot_involutive s a b hb).symm⟩
 
+/-
+## Interior / boundary facet predicate
+
+The door-counting `adj` must split the `d+1` Kuhn facets of each cell into the
+chain-*interior* facets — those across which the Freudenthal pivot is defined and
+which therefore carry a glued neighbour — and the two geometric *boundary* facets
+(`k = 0` and `k = Fin.last d`), which have no interior partner.  The interior
+facets are exactly those opposite a vertex `a.succ` for a consecutive Kuhn step
+pair `a.succ = b.castSucc`; numerically these are the indices `0 < k < d`.
+All 0-sorry, 0-axiom.
+-/
+
+/-- A Kuhn facet index `k : Fin (d+1)` is **chain-interior** when it is the facet
+opposite an interior vertex `a.succ` for a consecutive Kuhn step pair
+`a.succ = b.castSucc`.  These are precisely the facets across which the
+Freudenthal pivot (`pivotSimplex`) is defined. -/
+def IsInteriorFacet (k : Fin (d + 1)) : Prop :=
+  ∃ a b : Fin d, a.succ = b.castSucc ∧ k = a.succ
+
+/-- **Numeric characterization of interior facets**: facet `k` is chain-interior
+iff `0 < k < d`, i.e. `k` is neither the bottom facet `0` nor the top facet
+`Fin.last d`.  (For `d ≤ 1` there are no interior facets, matching the fact that
+the orientation doubling there is handled separately.) -/
+theorem isInteriorFacet_iff (k : Fin (d + 1)) :
+    IsInteriorFacet k ↔ 0 < (k : ℕ) ∧ (k : ℕ) < d := by
+  constructor
+  · rintro ⟨a, b, hb, rfl⟩
+    have hb' : (a : ℕ) + 1 = (b : ℕ) := by
+      have h := congrArg Fin.val hb
+      rwa [Fin.val_succ, Fin.coe_castSucc] at h
+    have hbd : (b : ℕ) < d := b.isLt
+    rw [Fin.val_succ]; omega
+  · rintro ⟨hk0, hkd⟩
+    refine ⟨⟨(k : ℕ) - 1, by omega⟩, ⟨(k : ℕ), hkd⟩, ?_, ?_⟩
+    · apply Fin.ext; show (k : ℕ) - 1 + 1 = (k : ℕ); omega
+    · apply Fin.ext; show (k : ℕ) = (k : ℕ) - 1 + 1; omega
+
+/-- The bottom Kuhn facet (`k = 0`) is a geometric boundary facet, not interior. -/
+theorem not_isInteriorFacet_zero : ¬ IsInteriorFacet (0 : Fin (d + 1)) := by
+  rw [isInteriorFacet_iff, Fin.val_zero]; omega
+
+/-- The top Kuhn facet (`k = Fin.last d`) is a geometric boundary facet, not
+interior. -/
+theorem not_isInteriorFacet_last : ¬ IsInteriorFacet (Fin.last d) := by
+  rw [isInteriorFacet_iff, Fin.val_last]; omega
+
+/-- **Every interior facet carries a glued neighbour.**  Combining the predicate
+with `exists_gridFacet_neighbor`: if facet `k` is chain-interior, the Freudenthal
+pivot across it is a distinct cell sharing exactly that facet.  This is the total
+existence datum the door-counting `adj` records at every interior facet. -/
+theorem exists_neighbor_of_isInteriorFacet (s : SpernerGrid.GridSimplex d N)
+    {k : Fin (d + 1)} (hk : IsInteriorFacet k) :
+    ∃ t : SpernerGrid.GridSimplex d N,
+      GridGlued s t ∧ t ≠ s ∧ gridFacet t k = gridFacet s k := by
+  obtain ⟨a, b, hb, rfl⟩ := hk
+  exact exists_gridFacet_neighbor s a b hb
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1545,3 +1545,42 @@ warnings (dep oleans `SpernerNDim`/`SpernerGridBase` present in the symlinked `.
 2. Boundary-chain pivots (deleted vertex `0` or `Fin.last`) — the interior/boundary dichotomy.
 3. Assemble `adj` over `CanonSimplex`; discharge `adj_symm` via `pivot_involutive` + recanon.
 4. Phase 2: last-face door oddness induction on `d`; apply `sperner_ndim`.
+
+## Session 2026-06-28 (researcher-3) — interior/boundary facet predicate
+
+**Mode**: ACT. **Outcome**: verified increment (0-axiom) — the facet split the door-counting `adj` needs.
+
+### What I Did (verified, 0-axiom)
+Added the chain-interior facet predicate on Kuhn facet indices and its numeric characterization:
+- `IsInteriorFacet (k : Fin (d+1)) : Prop := ∃ a b : Fin d, a.succ = b.castSucc ∧ k = a.succ`
+  — `k` is the facet opposite an interior vertex `a.succ` of a consecutive Kuhn step pair.
+- `isInteriorFacet_iff : IsInteriorFacet k ↔ 0 < (k:ℕ) ∧ (k:ℕ) < d` — the two extreme
+  facets `0` and `Fin.last d` are exactly the geometric boundary.
+- `not_isInteriorFacet_zero`, `not_isInteriorFacet_last` — boundary facets are not interior.
+- `exists_neighbor_of_isInteriorFacet` — every interior facet carries a glued neighbour
+  (wraps `exists_gridFacet_neighbor`), the total existence datum `adj` records at interior facets.
+
+This discharges next-step #1 from the prior (researcher-95989) session: "Define boundary/interior
+facet predicate on GridSimplex (facet k interior iff 1≤k≤d-1); pair with exists_gridFacet_neighbor".
+
+### Gotchas / API
+- After `apply Fin.ext` on a goal built from `(⟨x,h⟩ : Fin d).succ` / `.castSucc`, `omega` CANNOT
+  see through `↑⟨x,h⟩` nor `↑(Fin.succ ⟨x,h⟩)` — it treats them as opaque atoms (`rw [Fin.val_succ,
+  Fin.coe_castSucc]` leaves `↑↑⟨k,h⟩` un-reduced). Fix: drop to the defeq numeric goal with
+  `show (k:ℕ) - 1 + 1 = (k:ℕ)` (Fin.succ/castSucc of a `Fin.mk` reduce definitionally), then `omega`.
+- Forward direction: `congrArg Fin.val hb` then `rw [Fin.val_succ, Fin.coe_castSucc]` gives
+  `(a:ℕ)+1 = (b:ℕ)`; combine with `b.isLt` and `omega`.
+
+### Verification
+Docker host still unavailable; host `v4.26.0` `lake env lean Proofs/SpernerNDimOQ02.lean` → EXIT 0,
+no warnings (dep oleans SpernerNDim/SpernerGridBase in symlinked `.lake`).
+`#print axioms isInteriorFacet_iff` and `exists_neighbor_of_isInteriorFacet`
+= `[propext, Classical.choice, Quot.sound]` only (0-axiom). File 1455 → 1512 lines, +1 def +4 thms.
+
+### Next steps
+1. **(crux)** Define a total neighbour map on `GridSimplex`/`CanonSimplex`: interior facets →
+   `exists_neighbor_of_isInteriorFacet`, boundary facets (`0`, `Fin.last d`) → `none`.
+2. Discharge the abstract door-graph `adj` fields for `d ≥ 2` from `GridGlued.{ne,shares_facet}`,
+   `GridGlued_symm`, `gridFacet_unique_neighbor`, `gridFacet_card`; supply `boundary_face` from
+   `not_isInteriorFacet_zero/last`. Handle `d ≤ 1` base cases separately (orientation doubling).
+3. Phase 2: last-face door oddness by induction on `d`; apply `sperner_ndim`.


### PR DESCRIPTION
## Summary

Verified, 0-axiom increment toward the Sperner door-graph `adj` over `CanonSimplex` (n-dimensional Sperner, `SpernerNDimOQ02.lean`). Adds the chain-interior/boundary **facet split** that the door-counting `adj` requires, discharging next-step #1 from the prior session.

## What changed (all 0-sorry, 0-axiom)

- `IsInteriorFacet (k : Fin (d+1)) := ∃ a b : Fin d, a.succ = b.castSucc ∧ k = a.succ` — facet `k` is opposite an interior vertex of a consecutive Kuhn step pair (exactly the facets across which the Freudenthal pivot is defined).
- `isInteriorFacet_iff : IsInteriorFacet k ↔ 0 < k ∧ k < d` — numeric characterization; the two extreme facets `0` and `Fin.last d` are precisely the geometric boundary.
- `not_isInteriorFacet_zero`, `not_isInteriorFacet_last` — boundary facets are not interior.
- `exists_neighbor_of_isInteriorFacet` — every interior facet carries a glued neighbour (wraps `exists_gridFacet_neighbor`): the total existence datum `adj` records at interior facets.

## Verification

- `lake env lean` (Lean 4.26.0) against the Mathlib cache: **EXIT 0, no warnings**, file 1455→1512 lines, still 0 sorries / 0 axioms.
- `#print axioms isInteriorFacet_iff` and `exists_neighbor_of_isInteriorFacet` = `[propext, Classical.choice, Quot.sound]` only.

## Next

Total neighbour map (interior → pivot, boundary → `none`), then discharge the abstract door-graph `adj` fields for `d ≥ 2` from `GridGlued.{ne,shares_facet}` / `GridGlued_symm` / `gridFacet_unique_neighbor` with `boundary_face` supplied by `not_isInteriorFacet_{zero,last}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)