### PR TITLE
research(erdos-1020-oq-02): exact step-difference + sharp crossover threshold n₀(4,2)=8 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1020OQ02.lean
+++ b/proofs/Proofs/Erdos1020OQ02.lean
@@ -162,4 +162,71 @@ example : conjecturedValue 8 4 2 = construction2 8 4 2 := by decide
 /-- Monotonicity of `conjecturedValue` across the crossover, concretely. -/
 example : conjecturedValue 7 4 2 ≤ conjecturedValue 8 4 2 := by decide
 
+/-! ### 5. The exact step difference, and a strict refinement.
+
+`construction2_mono_step` only records the *inequality* `≤`. The increment is
+in fact exactly `C(n, r−1) − C(n−k+1, r−1)`. We state this additively to keep
+everything in `ℕ` without truncated subtraction, then read off both the
+original monotonicity and a strict version. -/
+
+/-- Exact one-step increment of `construction2`:
+    `construction2 (n+1) − construction2 n = C(n, r−1) − C(n−k+1, r−1)`,
+    written additively. This is the precise identity behind
+    `construction2_mono_step`. -/
+theorem construction2_step_eq (n r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 1) (hn : n ≥ k) :
+    construction2 (n + 1) r k + Nat.choose (n - k + 1) (r - 1)
+      = construction2 n r k + Nat.choose n (r - 1) := by
+  unfold construction2
+  have hidx : n + 1 - k + 1 = n - k + 2 := by omega
+  rw [hidx]
+  have hr1 : r - 1 + 1 = r := Nat.sub_add_cancel hr
+  -- Pascal at the top: C(n+1, r) = C(n, r-1) + C(n, r).
+  have eq1 : Nat.choose (n + 1) r = Nat.choose n (r - 1) + Nat.choose n r := by
+    have h := Nat.choose_succ_succ n (r - 1)
+    simp only [Nat.succ_eq_add_one] at h
+    rw [hr1] at h
+    omega
+  -- Pascal at the shifted index: C(n-k+2, r) = C(n-k+1, r-1) + C(n-k+1, r).
+  have eq2 : Nat.choose (n - k + 2) r
+      = Nat.choose (n - k + 1) (r - 1) + Nat.choose (n - k + 1) r := by
+    have h := Nat.choose_succ_succ (n - k + 1) (r - 1)
+    simp only [Nat.succ_eq_add_one] at h
+    rw [hr1, show n - k + 1 + 1 = n - k + 2 from by omega] at h
+    omega
+  -- Both truncated subtractions in `construction2` are genuine (no underflow).
+  have hsub1 : Nat.choose (n - k + 2) r ≤ Nat.choose (n + 1) r :=
+    Nat.choose_le_choose r (by omega)
+  have hsub2 : Nat.choose (n - k + 1) r ≤ Nat.choose n r :=
+    Nat.choose_le_choose r (by omega)
+  omega
+
+/-- Strict one-step monotonicity: whenever the lower binomial is strictly
+    smaller, `construction2` strictly increases. (The hypothesis
+    `C(n−k+1, r−1) < C(n, r−1)` holds, e.g., once `k ≥ 2` and `r−1 ≤ n−k+1`.) -/
+theorem construction2_strict_mono_step (n r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 1)
+    (hn : n ≥ k) (hlt : Nat.choose (n - k + 1) (r - 1) < Nat.choose n (r - 1)) :
+    construction2 n r k < construction2 (n + 1) r k := by
+  have h := construction2_step_eq n r k hr hk hn
+  omega
+
+/-! ### 6. The exact crossover threshold for the worked instance `r = 4, k = 2`.
+
+Monotonicity turns the two boundary evaluations (`n = 7` below, `n = 8` at)
+into a *complete* characterization of the construction2-dominant region:
+it is exactly `{ n : 8 ≤ n }`. This pins the crossover threshold to the
+single value `n₀(4, 2) = 8`. -/
+
+/-- `construction2` overtakes `construction1` (for `r = 4, k = 2`) at exactly
+    `n = 8`: the regime boundary is the sharp threshold `n₀ = 8`. -/
+theorem crossover_r4k2 (n : ℕ) :
+    construction1 4 2 ≤ construction2 n 4 2 ↔ 8 ≤ n := by
+  constructor
+  · intro h
+    by_contra hlt
+    push_neg at hlt
+    interval_cases n <;> exact absurd h (by decide)
+  · intro h
+    have h8 : construction1 4 2 ≤ construction2 8 4 2 := by decide
+    exact construction2_dominant_up 8 n 4 2 (by norm_num) (by norm_num) (by norm_num) h h8
+
 end Erdos1020OQ02

--- a/research/problems/erdos-1020-oq-02/state.md
+++ b/research/problems/erdos-1020-oq-02/state.md
@@ -1,27 +1,27 @@
 # Current State
 
-**Phase**: NEW
+**Phase**: ACT
 **Since**: 2026-03-30T21:46:38.106Z
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Regime-transition structure verified; sharpening the threshold characterization.
 
 ## Active Approach
 
-None yet.
+Exact step-difference identity + sharp crossover threshold for worked instances.
 
 ## Blockers
 
-None.
+The core open gap (Erdős Matching Conjecture for r≥4) is out of reach by these methods.
 
 ## Next Action
 
-Begin problem exploration.
+Generalize crossover_r4k2 to a closed-form threshold n₀(r,k); prove construction2→∞ for threshold existence.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/erdos-1020-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1020-oq-02/annotations.json
@@ -108,5 +108,44 @@
       "binomial coefficient evaluation",
       "decide"
     ]
+  },
+  {
+    "id": "construction2-step-eq",
+    "proofId": "erdos-1020-oq-02",
+    "range": {
+      "startLine": 177,
+      "endLine": 205
+    },
+    "type": "theorem",
+    "significance": "key",
+    "title": "Exact Step-Difference Identity",
+    "content": "construction2_step_eq sharpens the monotonicity inequality into an exact equality, written additively to stay in ℕ without truncated subtraction: construction2(n+1) + C(n-k+1,r-1) = construction2 n + C(n,r-1). Equivalently the one-step increment is exactly C(n,r-1) - C(n-k+1,r-1). Same Pascal machinery as construction2_mono_step (two Nat.choose_succ_succ rewrites), plus the two facts that the subtractions in construction2 do not underflow (Nat.choose_le_choose), with omega closing the linear nat-arithmetic.",
+    "mathContext": "$$\\mathrm{construction2}(n{+}1)-\\mathrm{construction2}(n)=\\binom{n}{r-1}-\\binom{n-k+1}{r-1}.$$"
+  },
+  {
+    "id": "construction2-strict-mono-step",
+    "proofId": "erdos-1020-oq-02",
+    "range": {
+      "startLine": 207,
+      "endLine": 214
+    },
+    "type": "theorem",
+    "significance": "supporting",
+    "title": "Strict Monotonicity Refinement",
+    "content": "construction2_strict_mono_step reads strict increase straight off the exact identity: when C(n-k+1,r-1) < C(n,r-1) the value strictly increases. The hypothesis holds, e.g., once k ≥ 2 and r-1 ≤ n-k+1, isolating exactly when the regime band has positive width at a given n.",
+    "mathContext": "$$\\binom{n-k+1}{r-1}<\\binom{n}{r-1}\\ \\Rightarrow\\ \\mathrm{construction2}(n)<\\mathrm{construction2}(n{+}1).$$"
+  },
+  {
+    "id": "crossover-r4k2",
+    "proofId": "erdos-1020-oq-02",
+    "range": {
+      "startLine": 216,
+      "endLine": 231
+    },
+    "type": "theorem",
+    "significance": "key",
+    "title": "Sharp Crossover Threshold (r=4, k=2)",
+    "content": "crossover_r4k2 promotes the two boundary checks into a complete characterization of the construction2-dominant region. Backward direction: 8 ≤ n gives dominance by construction2_dominant_up from the n=8 base case. Forward direction: for n < 8, interval_cases enumerates n ∈ {0,…,7} and decide refutes dominance in each. Hence construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n, pinning the crossover threshold to the single value n₀(4,2)=8 — a concrete answer to the file's open next step of characterizing the threshold.",
+    "mathContext": "$$\\binom{7}{4}\\le\\binom{n}{4}-\\binom{n-1}{4}\\iff 8\\le n.$$"
   }
 ]

--- a/src/data/proofs/erdos-1020-oq-02/meta.json
+++ b/src/data/proofs/erdos-1020-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1020-oq-02",
   "title": "Erdős #1020 OQ-02: The Small-n / Large-n Regime Transition",
   "slug": "erdos-1020-oq-02",
-  "description": "Open question OQ-02 of Erdős Problem #1020 (the Erdős Matching Conjecture) asks whether the gap between the two regimes in which the conjecture is known — Frankl's small-n result and Huang–Loh–Sudakov's large-n result — can be closed for general r. The conjectured extremal value of f(n;r,k) is max(construction1, construction2) where construction1 r k = C(rk-1,r) (independent of n) and construction2 n r k = C(n,r) - C(n-k+1,r); construction1 is the maximiser for small n and construction2 for large n. This entry does NOT resolve the open gap (OPEN for r≥4). Instead it pins down, axiom-free, the structure of the transition between the two regimes: construction2 is monotonically nondecreasing in n (construction2_mono, via a Pascal-telescoping identity construction2(n+1)-construction2(n) = C(n,r-1)-C(n-k+1,r-1) ≥ 0); hence the set of n on which construction2 dominates construction1 is upward-closed (construction2_dominant_up), so a single threshold separates the small-n regime (extremal value = construction1, conjecturedValue_small) from the large-n regime (extremal value = construction2, conjecturedValue_large); consequently conjecturedValue is itself monotone nondecreasing in n (conjecturedValue_mono). A worked instance (r=4, k=2) exhibits the crossover concretely at n=8 via kernel-decidable checks. No axioms, no native_decide, no sorries.",
+  "description": "Open question OQ-02 of Erdős Problem #1020 (the Erdős Matching Conjecture) asks whether the gap between the two regimes in which the conjecture is known — Frankl's small-n result and Huang–Loh–Sudakov's large-n result — can be closed for general r. The conjectured extremal value of f(n;r,k) is max(construction1, construction2) where construction1 r k = C(rk-1,r) (independent of n) and construction2 n r k = C(n,r) - C(n-k+1,r); construction1 is the maximiser for small n and construction2 for large n. This entry does NOT resolve the open gap (OPEN for r≥4). Instead it pins down, axiom-free, the structure of the transition between the two regimes: construction2 is monotonically nondecreasing in n (construction2_mono, via a Pascal-telescoping identity construction2(n+1)-construction2(n) = C(n,r-1)-C(n-k+1,r-1) ≥ 0); hence the set of n on which construction2 dominates construction1 is upward-closed (construction2_dominant_up), so a single threshold separates the small-n regime (extremal value = construction1, conjecturedValue_small) from the large-n regime (extremal value = construction2, conjecturedValue_large); consequently conjecturedValue is itself monotone nondecreasing in n (conjecturedValue_mono). A worked instance (r=4, k=2) exhibits the crossover concretely at n=8 via kernel-decidable checks. No axioms, no native_decide, no sorries. A follow-up section sharpens this: the exact step-difference identity construction2_step_eq (construction2(n+1) + C(n-k+1,r-1) = construction2 n + C(n,r-1), the equality form of the inequality above), a strict-monotonicity refinement construction2_strict_mono_step, and — using monotonicity to upgrade the two boundary evaluations into a complete characterization — the exact crossover threshold for the worked instance: construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n (crossover_r4k2), pinning n₀(4,2)=8.",
   "meta": {
     "author": "Research formalization 2026",
     "sourceUrl": "https://www.erdosproblems.com/1020",
@@ -20,11 +20,11 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 165,
+    "lineCount": 232,
     "assumptions": "None. The file introduces no axioms and no sorries; every theorem depends only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms). The concrete crossover examples use kernel `decide` (not `native_decide`), so they introduce no Lean.ofReduceBool dependency. The open content of OQ-02 — whether the small-n/large-n gap can be closed for general r, i.e. the Erdős Matching Conjecture itself for r≥4 — is left unproved and unaxiomatized; only the regime-transition structure of the conjectured extremal value is established.",
     "dateAdded": "2026-06-27",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
+    "theoremCount": 9,
     "definitionCount": 3
   },
   "overview": {
@@ -37,7 +37,8 @@
       "construction2 is monotonically nondecreasing in n, because its one-step increment is a Pascal telescoping difference construction2(n+1)-construction2(n) = C(n,r-1)-C(n-k+1,r-1), nonnegative since n ≥ n-k+1 for k≥1.",
       "Monotonicity forces the regimes to be cleanly separated: the set of n on which construction2 dominates the constant construction1 is upward-closed (construction2_dominant_up), so there is a single threshold, not an interleaving — once the large-n construction catches up it never falls behind.",
       "Consequently the conjectured extremal value is monotone nondecreasing in n (conjecturedValue_mono) and collapses to construction1 below the threshold (conjecturedValue_small) and to construction2 at and above it (conjecturedValue_large).",
-      "This is unconditional structure of the conjectured value — it does NOT close the open gap (the conjecture for r≥4 is left stated, not axiomatized). It frames the open question precisely: the unknown is whether f equals this value throughout the middle band, not where the two constructions cross."
+      "This is unconditional structure of the conjectured value — it does NOT close the open gap (the conjecture for r≥4 is left stated, not axiomatized). It frames the open question precisely: the unknown is whether f equals this value throughout the middle band, not where the two constructions cross.",
+      "The inequality construction2(n+1) ≥ construction2(n) is in fact an exact identity construction2(n+1)-construction2(n) = C(n,r-1)-C(n-k+1,r-1) (construction2_step_eq); combined with the boundary values this upgrades the worked r=4,k=2 crossover into a sharp characterization construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n, fixing the exact threshold n₀(4,2)=8."
     ],
     "prerequisites": [
       "The Erdős Matching Conjecture and its two extremal constructions",
@@ -94,6 +95,14 @@
       "endLine": 163,
       "summary": "Kernel-decidable checks locating the crossover at n=8: construction2 7 4 2 = 20 < 35 = construction1 4 2, while construction2 8 4 2 = 35; conjecturedValue switches from construction1 to construction2 across n=7→8 and is monotone there.",
       "mathContext": "$\\binom{7}{4}-\\binom{6}{4}=20<35=\\binom{7}{4}$ but $\\binom{8}{4}-\\binom{7}{4}=35$: crossover at $n=8$."
+    },
+    {
+      "id": "exact-step-and-threshold",
+      "title": "Exact Step Difference and the Sharp Crossover Threshold",
+      "startLine": 166,
+      "endLine": 231,
+      "summary": "construction2_step_eq gives the exact increment construction2(n+1)+C(n-k+1,r-1) = construction2 n + C(n,r-1) (the equality behind construction2_mono_step); construction2_strict_mono_step is the strict refinement; crossover_r4k2 uses monotonicity to turn the two boundary checks into the complete region {n : 8 ≤ n}, the exact crossover threshold for r=4,k=2.",
+      "mathContext": "$\\mathrm{construction2}(n+1)-\\mathrm{construction2}(n)=\\binom{n}{r-1}-\\binom{n-k+1}{r-1}$; for $r=4,k=2$: $\\binom{rk-1}{r}\\le\\mathrm{construction2}(n)\\iff 8\\le n$."
     }
   ],
   "conclusion": {

--- a/src/data/research/problems/erdos-1020-oq-02.json
+++ b/src/data/research/problems/erdos-1020-oq-02.json
@@ -29,23 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "VERIFIED (0-axiom). Created gallery entry erdos-1020-oq-02 + Proofs/Erdos1020OQ02.lean. Did NOT resolve the open gap (Erdős Matching Conjecture, OPEN r≥4); instead formalized the unconditional structure of the small-n/large-n regime transition of the conjectured value max(construction1, construction2): construction2 monotone in n (Pascal telescoping), dominance region upward-closed (single threshold), conjecturedValue monotone, collapse on each side. Worked instance r=4,k=2 crossover at n=8 by kernel decide.",
+    "progressSummary": "VERIFIED (0-axiom). Created gallery entry erdos-1020-oq-02 + Proofs/Erdos1020OQ02.lean. Did NOT resolve the open gap (Erdős Matching Conjecture, OPEN r≥4); instead formalized the unconditional structure of the small-n/large-n regime transition of the conjectured value max(construction1, construction2): construction2 monotone in n (Pascal telescoping), dominance region upward-closed (single threshold), conjecturedValue monotone, collapse on each side. Worked instance r=4,k=2 crossover at n=8 by kernel decide. [Session 2] Added 3 verified theorems sharpening the transition: construction2_step_eq (EXACT step difference = C(n,r-1)-C(n-k+1,r-1), the equality behind the old inequality), construction2_strict_mono_step (strict refinement), and crossover_r4k2 — the SHARP crossover threshold for r=4,k=2: construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n (n₀=8). All 0-axiom (decide, not native_decide). File now 232 lines, 9 theorems.",
     "builtItems": [
       "Proofs/Erdos1020OQ02.lean (165 lines, 0 axioms, 0 sorries, verified): construction2_mono_step, construction2_mono, construction2_dominant_up, conjecturedValue_mono, conjecturedValue_large, conjecturedValue_small + 5 kernel-decide crossover examples.",
-      "Gallery entry src/data/proofs/erdos-1020-oq-02/ (meta.json + annotations.json)."
+      "Gallery entry src/data/proofs/erdos-1020-oq-02/ (meta.json + annotations.json).",
+      "Proofs/Erdos1020OQ02.lean extended to 232 lines / 9 theorems (was 165/6): construction2_step_eq, construction2_strict_mono_step, crossover_r4k2 (exact threshold iff for r=4,k=2)."
     ],
     "insights": [
       "construction1 r k = C(rk-1,r) is constant in n; construction2 n r k = C(n,r)-C(n-k+1,r) is monotone nondecreasing in n. The gap is the band around their crossover.",
       "construction2(n+1)-construction2(n) = C(n,r-1)-C(n-k+1,r-1) ≥ 0 (two Pascal identities + Nat.choose_le_choose); this is the heart of the monotonicity.",
       "Monotonicity ⇒ the construction2-dominant region is upward-closed: a SINGLE threshold separates small-n and large-n regimes (no interleaving).",
       "conjecturedValue = max(const, monotone) is monotone in n; collapses to construction1 below threshold, construction2 at/above (max_eq_left/right).",
-      "OQ-02 framed: regime boundary is a well-defined single threshold; the open difficulty is whether f attains the conjectured value across the gap band kr+... < n < 3kr² for r≥4."
+      "OQ-02 framed: regime boundary is a well-defined single threshold; the open difficulty is whether f attains the conjectured value across the gap band kr+... < n < 3kr² for r≥4.",
+      "The crossover threshold IS characterizable exactly in a worked instance: monotonicity converts two boundary evaluations into a complete iff (construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n), giving n₀(4,2)=8 — partial progress on the 'characterize exact threshold' next step."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Open: prove the Erdős Matching Conjecture across the middle band (r≥4) — the actual gap closure.",
-      "Characterize the exact crossover threshold n₀(r,k) in closed form.",
-      "Decide whether extremal hypergraphs interpolate between the two constructions inside the gap."
+      "Decide whether extremal hypergraphs interpolate between the two constructions inside the gap.",
+      "Generalize crossover_r4k2 to a closed-form threshold n₀(r,k) for all r,k (instance r=4,k=2 done).",
+      "Prove construction2 → ∞ (k≥2) to establish threshold EXISTENCE for general r,k, not just the worked instance."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Extends the existing **erdos-1020-oq-02** entry (regime transition of the Erdős Matching Conjecture's conjectured value) with three new fully-verified, 0-axiom theorems. `Proofs/Erdos1020OQ02.lean` grows 165→232 lines, 6→9 theorems.

The core conjecture (Erdős Matching Conjecture for r≥4) remains **OPEN** — this PR does not close it. It sharpens the *unconditional structure* already in the file.

## What's new

- **`construction2_step_eq`** — the monotonicity inequality `construction2_mono_step` is in fact an **exact identity**:
  `construction2(n+1) − construction2(n) = C(n, r−1) − C(n−k+1, r−1)`,
  stated additively to stay in ℕ without truncated subtraction. Same Pascal machinery (two `Nat.choose_succ_succ`) + non-underflow facts + `omega`.
- **`construction2_strict_mono_step`** — strict monotonicity read straight off the identity (hypothesis: `C(n−k+1,r−1) < C(n,r−1)`, which holds once `k≥2`, `r−1 ≤ n−k+1`).
- **`crossover_r4k2`** — monotonicity upgrades the two boundary evaluations into a **complete characterization** of the construction2-dominant region:
  `construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n`,
  pinning the **exact crossover threshold** `n₀(4,2) = 8`. This is concrete progress on the file's stated next step "characterize the exact crossover threshold".

## Verification

- `lake env lean Proofs/Erdos1020OQ02.lean` → clean, exit 0.
- `#print axioms` on all three: only `propext` / `Quot.sound` / `Classical.choice`. No `sorryAx`, no `Lean.ofReduceBool` (crossover uses kernel `decide`, not `native_decide`). **0-axiom** by project policy.

Gallery `meta.json` / `annotations.json` and the research-state JSON updated to match (counts, new section, annotations, next steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)