### PR TITLE
Enrich Erdős #1009 OQ-03-OQ-01 (K₄ LP duality): index.ts, overview, sections, conclusion

### DIFF
--- a/src/data/proofs/erdos-1009-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1009-oq-03-oq-01/annotations.json
@@ -7,7 +7,7 @@
     "title": "Decidable K₄ Model: Triangles and Edges",
     "content": "The complete graph $K_4$ is modeled concretely on `Fin 4`: `triangles` are the four 3-element vertex subsets (every 3 vertices of a complete graph span a triangle) and `allEdges` are the six 2-element subsets. `edgesOf T` is a triangle's three edges, `T.powersetCard 2`. Keeping the model finite and decidable lets the structural facts (`triangles_card = 4`, `allEdges_card = 6`, each edge in $\\le 2$ triangles) be discharged by kernel-checked `decide`, so no compiler trust (`native_decide`) is needed.",
     "mathContext": "$K_4$ has $\\binom{4}{3} = 4$ triangles and $\\binom{4}{2} = 6$ edges; each edge lies in exactly $4 - 2 = 2$ triangles.",
-    "significance": "foundational",
+    "significance": "key",
     "relatedConcepts": ["complete graph", "powersetCard", "decidability", "finite combinatorics"],
     "prerequisites": ["finite sets", "binomial coefficients", "Lean 4 Finset"]
   },

--- a/src/data/proofs/erdos-1009-oq-03-oq-01/index.ts
+++ b/src/data/proofs/erdos-1009-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1009OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1009Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1009Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1009Oq03Oq01Data: ProofData = {
+  proof: erdos1009Oq03Oq01Proof,
+  annotations: erdos1009Oq03Oq01Annotations,
+}

--- a/src/data/proofs/erdos-1009-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1009-oq-03-oq-01/meta.json
@@ -69,6 +69,70 @@
     "theoremCount": 11,
     "definitionCount": 7
   },
+  "overview": {
+    "historicalContext": "Erdős Problem #1009 concerns edge-disjoint triangles (K₃) in graphs beyond the Turán threshold, the existence side resolved by Györi (1988). This entry studies the *computational* face of the problem on the canonical small witness K₄: the gap between the NP-hard integer maximum edge-disjoint triangle packing and its polynomial-time linear-programming relaxation. K₄ is the textbook example of an integrality gap for triangle packing — only one triangle can be chosen with edge-disjointness (ν = 1), yet the fractional relaxation, which may place weight ½ on all four triangles, achieves value 2. Linear-programming duality, the engine behind this analysis, is the 1940s framework of von Neumann, Gale, Kuhn and Tucker; the packing–covering pair here is its combinatorial incarnation, with weak duality reducing to a single double-counting (Fubini) over the triangle–edge incidence.",
+    "problemStatement": "On the complete graph K₄, model the maximum edge-disjoint triangle packing as a 0/1 integer program and its LP relaxation. The fractional packing (primal) places nonnegative weights w on the four triangles with ∑_{T ∋ e} w_T ≤ 1 at every edge e; its value is ∑_T w_T. The fractional cover (dual) places nonnegative weights y on the six edges with ∑_{e ∈ T} y_e ≥ 1 for every triangle T; its value is ∑_e y_e. Prove the exact LP optima ν*(K₄) = τ*(K₄) = 2 (the parent file certified only ν* ≥ 2), and hence pin the integrality gap to the exact factor 2 over the integer optimum ν(K₄) = 1.",
+    "proofStrategy": "(1) Re-state the decidable K₄ model — four triangles, six edges, edgesOf — so the file is self-contained, and certify the model facts by kernel `decide` (notably edge_incidence_le_two: every edge lies in ≤ 2 triangles). (2) Define the LP primal (IsFracPacking / fracValue) and its dual (IsFracCover / coverValue). (3) Prove weak_duality for *every* feasible pair (w, y): fracValue w = ∑_T w_T ≤ ∑_T w_T (∑_{e∈T} y_e) = ∑_e y_e (∑_{T∋e} w_T) ≤ ∑_e y_e = coverValue y, the middle equality being Finset.sum_comm (Fubini) over the incidence. (4) Exhibit matching certificates: the uniform ½-weighting wHalf (feasible, value 2) and the uniform ⅓-edge cover yThird (feasible, value 2). (5) Weak duality against these certificates squeezes both optima to 2 (frac_optimum as IsGreatest, cover_optimum as IsLeast), and lp_no_gap packages ν*(K₄) = τ*(K₄) = 2.",
+    "keyInsights": [
+      "Weak duality is the reusable structural core, and it is *purely a finite double-count*: ∑_T w_T·(∑_{e∈T} y_e) equals ∑_e y_e·(∑_{T∋e} w_T) by Finset.sum_comm over the triangle–edge incidence. The packing constraint bounds the inner sum on one side, the cover constraint on the other, so feasibility of any pair forces fracValue w ≤ coverValue y — no continuous optimization needed.",
+      "The exact optima need no general LP solver: a single feasible primal certificate (wHalf, value 2) and a single feasible dual certificate (yThird, value 2) bracket each other through weak duality. Equal certificate values collapse both relaxations to the same number, which is strong duality *witnessed*, not merely asserted.",
+      "K₄ realizes the triangle-packing integrality gap exactly: ν(K₄) = 1 (integer) versus ν*(K₄) = 2 (fractional), a factor-2 separation. Pinning ν* to *exactly* 2 (not just ≥ 2) is what turns the parent's one-sided bound into a sharp gap statement.",
+      "The proof is entirely kernel-checked `decide` and elementary rational arithmetic — no `native_decide`, so the result depends only on the foundational axioms. The finite K₄ model keeps every constraint a decidable proposition over Fin 4 subsets, making the LP duality concrete and machine-verifiable end to end."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: Closing the K₄ Integrality Gap",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring framing the goal: the parent Erdos1009OQ03 certified ν(K₄) = 1 and ν*(K₄) ≥ 2 only; this file formalizes the LP dual (fractional cover) and weak duality to pin ν*(K₄) = τ*(K₄) = 2 exactly, fixing the integrality gap at factor 2."
+    },
+    {
+      "id": "k4-model",
+      "title": "The Decidable K₄ Model and Incidence Facts",
+      "startLine": 50,
+      "endLine": 86,
+      "summary": "The self-contained finite model: V = Fin 4, the four triangles, the six edges (allEdges), and edgesOf. Model facts by kernel `decide`: triangles_card = 4, allEdges_card = 6, edgesOf_subset, edgesOf_card_three, and the key edge_incidence_le_two (each edge lies in ≤ 2 triangles)."
+    },
+    {
+      "id": "lp-defs",
+      "title": "The LP Primal and Dual Relaxations",
+      "startLine": 88,
+      "endLine": 106,
+      "summary": "IsFracPacking / fracValue define the primal (nonnegative triangle weights, ≤ 1 per edge; objective ∑ weights) and IsFracCover / coverValue the dual (nonnegative edge weights, ≥ 1 per triangle; objective ∑ weights) — the fractional triangle cover absent from the parent file."
+    },
+    {
+      "id": "weak-duality",
+      "title": "Weak LP Duality via Finite Double-Counting",
+      "startLine": 108,
+      "endLine": 155,
+      "summary": "weak_duality: for every feasible packing w and cover y, fracValue w ≤ coverValue y, by swapping a double sum over the triangle–edge incidence (Finset.sum_comm) and applying the packing constraint at each edge and the cover constraint at each triangle. The reusable structural core."
+    },
+    {
+      "id": "certificates",
+      "title": "Matching Primal and Dual Certificates",
+      "startLine": 157,
+      "endLine": 195,
+      "summary": "The explicit optimal solutions: wHalf (weight ½ on every triangle) is a feasible packing of value 2; yThird (weight ⅓ on every edge) is a feasible cover of value 2. Feasibility and objective values certified by elementary rational arithmetic."
+    },
+    {
+      "id": "exact-optima",
+      "title": "Exact Optima and No-Gap Strong Duality",
+      "startLine": 197,
+      "endLine": 239,
+      "summary": "frac_optimum (ν*(K₄) = 2 as IsGreatest) and cover_optimum (τ*(K₄) = 2 as IsLeast) squeeze each optimum between its certificate and weak duality; lp_no_gap packages ν*(K₄) = τ*(K₄) = 2, pinning the integrality gap to exactly 2 over ν(K₄) = 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "By formalizing the LP dual (the fractional triangle cover IsFracCover / coverValue) and the weak-duality inequality fracValue w ≤ coverValue y, this entry pins the fractional triangle-packing optimum of K₄ to exactly ν*(K₄) = τ*(K₄) = 2 (frac_optimum as IsGreatest, cover_optimum as IsLeast, lp_no_gap for the no-gap equality), upgrading the parent's one-sided ν* ≥ 2. The matching certificates are the uniform ½-triangle packing and the uniform ⅓-edge cover. 239 lines, 11 theorems, 7 definitions, 0 sorries, 0 axioms, no native_decide.",
+    "implications": "The result fixes the triangle-packing integrality gap on K₄ at the exact factor 2 (ν = 1 vs ν* = 2), turning the parent's lower bound into a sharp separation between the NP-hard integer packing and its polynomial LP relaxation. The reusable weak_duality lemma — a pure finite double-count over the triangle–edge incidence — is the structural template for the same packing/covering analysis on larger graphs, where the exact LP value is the natural next quantitative target. The kernel-checked (no native_decide) verification keeps the certificate-based strong-duality argument fully within the foundational axioms.",
+    "openQuestions": [
+      "Generalize the exact LP value ν*(Kₙ) = τ*(Kₙ) for the triangle-packing relaxation of the complete graph Kₙ, and determine how the integrality gap ν*(Kₙ)/ν(Kₙ) grows with n.",
+      "Identify the largest integrality gap for edge-disjoint triangle packing over all graphs on n vertices, and whether the uniform fractional certificate remains optimal beyond K₄.",
+      "Connect the LP relaxation value to Györi's edge-disjoint-triangle theorem quantitatively, relating the fractional optimum to the extremal triangle counts of Erdős #1009."
+    ]
+  },
   "crossReferences": [
     {
       "targetId": "erdos-1009-oq-02",


### PR DESCRIPTION
Enrichment pass for `erdos-1009-oq-03-oq-01` (quality 55, pass 0 — the lowest-quality entry in the queue, so the largest gaps).

## Changes
- **Created missing `index.ts`** — the proof had no Vite entry point (page rendered "proof not found" on the live site). Highest-impact fix.
- **Added a full `overview`** (was entirely absent): historicalContext (Erdős #1009 / Györi 1988, K₄ integrality gap, LP-duality framework), problemStatement (primal packing vs dual cover), proofStrategy, and 4 keyInsights.
- **Added 6 `sections`** covering all 239 lines (header, K₄ model + incidence facts, LP defs, weak duality, certificates, exact optima).
- **Added a `conclusion`**: summary, implications, 3 open questions (Kₙ generalization, largest gap, link to Györi).
- **Fixed invalid annotation enum** (#31246): significance `foundational`→`key`.

## Verification
- meta.json valid JSON, 12 KB (under caps). All 6 annotations have valid enums + mathContext. `tsc -b` clean. Axiom integrity confirmed against the Lean file (verified, 0 axioms/sorries, no native_decide — kernel `decide` only).