### PR TITLE
research(lagrange-oq-01-oq-03-oq-01): minimal-normal existence + abelianness in solvable groups [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01OQ03OQ01.lean
@@ -41,18 +41,30 @@ what `hall_lift_of_coprime` below proves.
 | `hall_lift_of_coprime` | If `N ⊴ G`, `gcd(\|N\|, d) = 1`, and `G/N` has a subgroup of order `d`, then so does `G` | Proved (0 axioms) |
 | `hall_lift_of_coprime_subgroup` | The lifted subgroup can be taken inside the preimage of the quotient subgroup | Proved (0 axioms) |
 | `schur_zassenhaus_available` | Restatement of Mathlib's Schur–Zassenhaus, witnessing it exists | Proved (0 axioms) |
+| `exists_minimal_normal` | Every nontrivial finite group has a minimal nontrivial normal subgroup | Proved (0 axioms) |
+| `exists_minimal_normal_atom` | …stated as an atom in the normal-subgroup lattice | Proved (0 axioms) |
+| `minimal_normal_abelian_of_solvable` | A minimal normal subgroup of a solvable group is abelian | Proved (0 axioms) |
+| `exists_abelian_minimal_normal` | A nontrivial finite solvable group has an abelian minimal normal subgroup | Proved (0 axioms) |
 
-## The remaining gap (for a full 0-axiom Hall theorem)
+## Status of the remaining gap (for a full 0-axiom Hall theorem)
 
-The induction also has a branch where `p ∣ d` (the prime dividing the minimal
-normal subgroup `N` also divides `d`). Closing that branch needs:
-* existence of a *minimal* normal subgroup of a nontrivial finite group, and
-* the fact that in a *solvable* group such a subgroup is elementary abelian.
+The induction has a branch where `p ∣ d` (the prime dividing the minimal normal
+subgroup `N` also divides `d`). The parent entry flagged two missing Mathlib
+ingredients for it; **both are now supplied in this file with 0 axioms**:
 
-Neither is in Mathlib 4.26. With those, `hall_lift_of_coprime` (this file) plus
-the abelian base case (`lagrange-theorem-oq-03`'s `abelian_hall_exists`) and the
-cyclic/prime cases (the parent) would assemble into a 0-axiom proof of
-`hall_solvable`.
+* existence of a *minimal* normal subgroup of a nontrivial finite group
+  (`exists_minimal_normal` / `exists_minimal_normal_atom`, Part II), and
+* the fact that in a *solvable* group such a subgroup is **abelian**
+  (`minimal_normal_abelian_of_solvable`, Part III), assembled as
+  `exists_abelian_minimal_normal`.
+
+What is left for the *elementary*-abelian sharpening is only that an abelian
+minimal normal subgroup is a `p`-group — its `p`-torsion is characteristic, hence
+normal, hence (by minimality) all of `N`. That is a refinement of the abelian
+result above, not a new obstruction. With Part I (the lifting step), the abelian
+base case (`lagrange-theorem-oq-03`'s `abelian_hall_exists`), and these descent
+ingredients, the pieces of a 0-axiom `hall_solvable` are in place; what remains is
+the bookkeeping of the induction itself.
 
 ## References
 - Hall, P. (1928), "A note on soluble groups", J. London Math. Soc.
@@ -154,7 +166,114 @@ theorem hall_lift_of_coprime [Finite G] (N : Subgroup G) [N.Normal]
   exact ⟨K, hK⟩
 
 -- ============================================================
--- Part II: Sanity specializations
+-- Part II: Existence of a minimal normal subgroup
+-- ============================================================
+--
+-- This is the first of the two structural inputs the parent entry flagged as
+-- missing from Mathlib (the other being "minimal normal ⇒ elementary abelian in
+-- the solvable case", handled in Part III). Hall's induction, in the branch where
+-- the relevant prime divides the target order `d`, needs a *minimal* normal
+-- subgroup to descend along. Mathlib 4.26 has no such existence theorem; we supply
+-- it with 0 axioms.
+
+/-- In a finite group, a subgroup contained in another of no-smaller cardinality
+must equal it. (Antisymmetry of `≤` forced by finite cardinality.) -/
+private theorem eq_of_le_of_card_le [Finite G] {M N : Subgroup G}
+    (hle : M ≤ N) (hcard : Nat.card N ≤ Nat.card M) : M = N := by
+  apply SetLike.coe_injective
+  refine Set.eq_of_subset_of_ncard_le hle ?_ (Set.toFinite _)
+  simpa only [Nat.card_coe_set_eq] using hcard
+
+/-- **Existence of a minimal normal subgroup.** Every nontrivial finite group `G`
+has a normal subgroup `N ≠ ⊥` that is minimal among nontrivial normal subgroups:
+any normal `M` with `M ≤ N` and `M ≠ ⊥` already equals `N`. This is the
+structural ingredient (beyond the Schur–Zassenhaus lifting step of Part I) that
+Hall's induction uses to handle the branch where the prime dividing the chosen
+minimal normal subgroup also divides the target order. Mathlib 4.26 has no such
+theorem; proved here with 0 axioms by minimizing `Nat.card` over the finite,
+nonempty (`⊤` qualifies) collection of nontrivial normal subgroups. -/
+theorem exists_minimal_normal [Finite G] [Nontrivial G] :
+    ∃ N : Subgroup G, N.Normal ∧ N ≠ ⊥ ∧
+      ∀ M : Subgroup G, M.Normal → M ≤ N → M ≠ ⊥ → M = N := by
+  haveI : Nontrivial (Subgroup G) := Subgroup.nontrivial_iff.mpr inferInstance
+  -- The subtype of nontrivial normal subgroups is finite and nonempty (`⊤`).
+  haveI : Nonempty {N : Subgroup G // N.Normal ∧ N ≠ ⊥} :=
+    ⟨⟨⊤, inferInstance, top_ne_bot⟩⟩
+  -- Pick one of minimal order.
+  obtain ⟨⟨N, hNnorm, hNne⟩, hmin⟩ :=
+    Finite.exists_min
+      (fun s : {N : Subgroup G // N.Normal ∧ N ≠ ⊥} => Nat.card (s.1 : Subgroup G))
+  refine ⟨N, hNnorm, hNne, ?_⟩
+  intro M hMnorm hMle hMne
+  -- `M` is itself a nontrivial normal subgroup, so minimality gives `|N| ≤ |M|`.
+  have hge : Nat.card N ≤ Nat.card M := hmin ⟨M, hMnorm, hMne⟩
+  -- Combined with `M ≤ N`, finite cardinality forces `M = N`.
+  exact eq_of_le_of_card_le hMle hge
+
+/-- Restatement of `exists_minimal_normal` as an *atom* in the lattice of normal
+subgroups: a minimal normal subgroup `N` has, below it, no normal subgroup other
+than `⊥` and `N` itself. -/
+theorem exists_minimal_normal_atom [Finite G] [Nontrivial G] :
+    ∃ N : Subgroup G, N.Normal ∧ N ≠ ⊥ ∧
+      ∀ M : Subgroup G, M.Normal → M ≤ N → M = ⊥ ∨ M = N := by
+  obtain ⟨N, hNnorm, hNne, hmin⟩ := exists_minimal_normal (G := G)
+  refine ⟨N, hNnorm, hNne, fun M hMnorm hMle => ?_⟩
+  by_cases hM : M = ⊥
+  · exact Or.inl hM
+  · exact Or.inr (hmin M hMnorm hMle hM)
+
+-- ============================================================
+-- Part III: A minimal normal subgroup of a solvable group is abelian
+-- ============================================================
+--
+-- This closes the *second* structural gap the parent entry flagged. Together with
+-- Part II it gives the full descent target for Hall's induction: a nontrivial
+-- finite solvable group has an abelian minimal normal subgroup to factor out.
+
+/-- **A minimal normal subgroup of a solvable group is abelian.** If `N ⊴ G` is
+nontrivial and minimal among normal subgroups (every normal `M ≤ N` is `⊥` or
+`N`), and `G` is solvable, then `N` is abelian: any two of its elements commute.
+
+Proof: the commutator subgroup `⁅N, N⁆` is normal in `G` (commutator of normal
+subgroups) and, since `G` is solvable and `N ≠ ⊥`, strictly smaller than `N`
+(`IsSolvable.commutator_lt_of_ne_bot`). Minimality then forces `⁅N, N⁆ = ⊥`,
+i.e. every commutator of elements of `N` is trivial. Mathlib 4.26 has the
+solvable-commutator descent but not this minimal-normal consequence. -/
+theorem minimal_normal_abelian_of_solvable [IsSolvable G]
+    (N : Subgroup G) [N.Normal] (hNne : N ≠ ⊥)
+    (hmin : ∀ M : Subgroup G, M.Normal → M ≤ N → M = ⊥ ∨ M = N) :
+    ∀ a ∈ N, ∀ b ∈ N, a * b = b * a := by
+  -- `⁅N, N⁆` is normal in `G` and strictly below `N` (solvable, `N ≠ ⊥`).
+  have hlt : ⁅N, N⁆ < N := IsSolvable.commutator_lt_of_ne_bot hNne
+  -- Minimality: the only normal subgroup strictly below `N` is `⊥`.
+  have hbot : ⁅N, N⁆ = ⊥ := by
+    rcases hmin ⁅N, N⁆ inferInstance hlt.le with h | h
+    · exact h
+    · exact absurd h hlt.ne
+  -- `⁅N, N⁆ = ⊥` says every commutator of elements of `N` is trivial.
+  intro a ha b hb
+  have hmem : ⁅a, b⁆ ∈ (⊥ : Subgroup G) :=
+    Subgroup.commutator_le.mp hbot.le a ha b hb
+  rw [Subgroup.mem_bot, commutatorElement_eq_one_iff_mul_comm] at hmem
+  exact hmem
+
+/-- **A nontrivial finite solvable group has an abelian minimal normal subgroup.**
+The combined descent target for Hall's induction: a normal `N ≠ ⊥` that is an atom
+in the normal-subgroup lattice (Part II) and is abelian (Part III). This is the
+ingredient the parent entry axiomatized away; it is now assembled with 0 axioms.
+What remains for a full elementary-abelian conclusion is only that an abelian
+minimal normal subgroup is a `p`-group (its `p`-torsion is characteristic, hence
+normal, hence all of `N` by minimality) — a refinement, not a new obstruction. -/
+theorem exists_abelian_minimal_normal [Finite G] [Nontrivial G] [IsSolvable G] :
+    ∃ N : Subgroup G, N.Normal ∧ N ≠ ⊥ ∧
+      (∀ M : Subgroup G, M.Normal → M ≤ N → M = ⊥ ∨ M = N) ∧
+      (∀ a ∈ N, ∀ b ∈ N, a * b = b * a) := by
+  obtain ⟨N, hNnorm, hNne, hatom⟩ := exists_minimal_normal_atom (G := G)
+  haveI := hNnorm
+  exact ⟨N, hNnorm, hNne, hatom, minimal_normal_abelian_of_solvable N hNne hatom⟩
+
+-- ============================================================
+-- Part IV: Sanity specializations
 -- ============================================================
 
 /-- Degenerate check: when `N` is trivial, the lift is the identity — a subgroup

--- a/research/problems/lagrange-theorem-oq-01-oq-03-oq-01/knowledge.md
+++ b/research/problems/lagrange-theorem-oq-01-oq-03-oq-01/knowledge.md
@@ -44,3 +44,39 @@ minimal normal subgroup induction from scratch?
   abelian; close the p | d branch.
 - Assemble full 0-axiom Hall's theorem: lifting step (here) + abelian base case
   (lagrange-theorem-oq-03) + minimal-normal-subgroup structure.
+
+## Session 2026-06-28 (Session 2, researcher-2) — PROGRESS
+**Outcome:** progress (0-axiom verified contribution) — closes BOTH minimal-normal
+Mathlib gaps that Session 1 only pinpointed.
+
+### Key findings / what I built (all 0 axioms; #print axioms = propext/Choice/Quot)
+- `exists_minimal_normal` (+ `exists_minimal_normal_atom`): every nontrivial
+  finite group has a minimal nontrivial normal subgroup. Proof: `Finite.exists_min`
+  over the finite, nonempty (⊤ qualifies) subtype `{N // N.Normal ∧ N ≠ ⊥}`,
+  minimizing `Nat.card`. Equality from a private antisymmetry lemma
+  `eq_of_le_of_card_le` (`SetLike.coe_injective` + `Set.eq_of_subset_of_ncard_le`,
+  bridged by `Nat.card_coe_set_eq`).
+- `minimal_normal_abelian_of_solvable`: a minimal normal subgroup of a solvable
+  group is abelian. KEY lemma found: `IsSolvable.commutator_lt_of_ne_bot`
+  (Mathlib/GroupTheory/Solvable.lean) gives `⁅N,N⁆ < N` for N ≠ ⊥. `⁅N,N⁆` is
+  normal in G via the `Subgroup.commutator_normal` instance, so minimality forces
+  `⁅N,N⁆ = ⊥`; then `Subgroup.commutator_le` + `commutatorElement_eq_one_iff_mul_comm`
+  give pairwise commutativity.
+- `exists_abelian_minimal_normal`: assembles the two into the descent target Hall's
+  induction needs — a nontrivial finite solvable group has an abelian minimal
+  normal subgroup.
+- Updated header docstring, meta.json (theoremCount 4→8, lineCount 169→288,
+  contributions, sections, OQs, conclusion).
+
+### GOTCHA (process)
+- The Session-1 file `LagrangeTheoremOQ01OQ03OQ01.lean` is on origin/main (#31159)
+  but the assigned `feature/researcher-2` branch predates it → file absent there.
+  Worked on a fresh branch off `origin/main` (`research/hall-minimal-normal`) and
+  symlinked `proofs/.lake` → main's for `lake env lean` verification.
+
+### Remaining next steps (narrowed)
+- Elementary-abelian sharpening: an abelian minimal normal subgroup is a p-group
+  (p-torsion characteristic ⇒ normal ⇒ all of N by minimality). Now MEDIUM, not
+  hard — abelianness is done.
+- Thread lifting step + `exists_abelian_minimal_normal` + abelian base case through
+  the induction on |G| for a 0-axiom `hall_solvable`.

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "lagrange-theorem-oq-01-oq-03-oq-01",
-  "title": "Hall's Theorem: the Schur–Zassenhaus Lifting Step (0 axioms)",
+  "title": "Hall's Theorem: Schur–Zassenhaus Lifting Step and Minimal-Normal Descent (0 axioms)",
   "slug": "lagrange-theorem-oq-01-oq-03-oq-01",
-  "description": "Isolates and proves, with 0 axioms, the inductive lifting step of Hall's theorem for solvable groups: if N ⊴ G is normal with |N| coprime to d, and the quotient G/N has a subgroup of order d, then G has a subgroup of order d. This is the precise Schur–Zassenhaus mechanism that the parent entry (lagrange-theorem-oq-01-oq-03) axiomatized away. It also corrects the parent's factually wrong justification — Schur–Zassenhaus IS in Mathlib 4.26 (Subgroup.exists_right_complement'_of_coprime) — and pinpoints the genuine remaining gap (minimal-normal-subgroup elementary-abelian structure) for a fully 0-axiom Hall's theorem.",
+  "description": "Proves, with 0 axioms, the two structural ingredients of Hall's theorem for solvable groups that the parent entry axiomatized away. (1) The Schur–Zassenhaus lifting step: if N ⊴ G is normal with |N| coprime to d and G/N has a subgroup of order d, then so does G. (2) The descent target: every nontrivial finite group has a minimal nontrivial normal subgroup (exists_minimal_normal), and in a solvable group such a subgroup is abelian (minimal_normal_abelian_of_solvable), assembled as exists_abelian_minimal_normal. The parent flagged the minimal-normal machinery as a Mathlib gap; both halves are now supplied. It also corrects the parent's factually wrong justification — Schur–Zassenhaus IS in Mathlib 4.26 (Subgroup.exists_right_complement'_of_coprime). Only the elementary-abelian sharpening (an abelian minimal normal subgroup is a p-group) remains as a refinement.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-28",
@@ -22,15 +22,18 @@
     "sorries": 0,
     "dateAdded": "2026-06-28",
     "axiomCount": 0,
-    "lineCount": 169,
-    "theoremCount": 4,
+    "lineCount": 288,
+    "theoremCount": 8,
     "definitionCount": 0,
     "assumptions": "None. All results are machine-checked with 0 axioms; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for every theorem.",
     "originalContributions": [
       "hall_lift_of_coprime: the Schur–Zassenhaus inductive step of Hall's theorem, formalized with 0 axioms — lifts a subgroup of order d from a quotient G/N to G when gcd(|N|, d) = 1",
       "hall_lift_of_coprime_subgroup: the sharper form locating the lifted subgroup inside the preimage π⁻¹(Q) of the quotient subgroup (a complement to N inside that preimage)",
+      "exists_minimal_normal: every nontrivial finite group has a minimal nontrivial normal subgroup (0 axioms), obtained by minimizing Nat.card over the finite nonempty collection of nontrivial normal subgroups — supplies one of the two minimal-normal Mathlib gaps the parent flagged",
+      "exists_minimal_normal_atom: the same result phrased as an atom in the lattice of normal subgroups (any normal M ≤ N is ⊥ or N)",
+      "minimal_normal_abelian_of_solvable: a minimal normal subgroup of a solvable group is abelian (0 axioms), via ⁅N,N⁆ ⊴ G being strictly below N (IsSolvable.commutator_lt_of_ne_bot) and forced to ⊥ by minimality — supplies the second minimal-normal gap (in its abelian, pre-elementary form)",
+      "exists_abelian_minimal_normal: the assembled descent target — a nontrivial finite solvable group has an abelian minimal normal subgroup",
       "Correction of a false claim in the parent entry: Schur–Zassenhaus IS in Mathlib 4.26 as Subgroup.exists_right_complement'_of_coprime; the parent axiomatized Hall's theorem citing its supposed absence",
-      "Precise identification of the actual remaining gap for a 0-axiom Hall's theorem: existence of a minimal normal subgroup of a nontrivial finite group and its elementary-abelian structure in the solvable case (the p | d branch)",
       "schur_zassenhaus_available: a documented restatement witnessing Mathlib's Schur–Zassenhaus"
     ],
     "proofStrategy": "Hall's existence proof inducts on |G| using a (minimal) normal subgroup N. In the branch where the prime dividing N does not divide the target order d (equivalently gcd(|N|, d) = 1), one lifts the order-d subgroup of G/N to G. This file formalizes exactly that lift: set L = π⁻¹(Q) for the quotient map π : G → G/N and the order-d subgroup Q ≤ G/N. Then N ≤ L (kernel lands in the preimage), and a card computation via card_mul_index, index_eq_card, and index_comap_of_surjective gives |L| = |N|·d. Viewing N as N.subgroupOf L, its index in L is d and its order is |N|, so gcd(|N.subgroupOf L|, (N.subgroupOf L).index) = gcd(|N|, d) = 1. Schur–Zassenhaus (Subgroup.exists_right_complement'_of_coprime) applied inside ↥L yields a complement KL of order d; pushing KL forward along L.subtype gives the required subgroup of G. The construction mirrors the internal step1 recursion of Mathlib's own Schur–Zassenhaus proof."
@@ -73,10 +76,26 @@
       "mathContext": "$N \\trianglelefteq G,\\ \\gcd(|N|,d)=1,\\ (\\exists Q \\le G/N,\\ |Q|=d) \\implies \\exists K \\le G,\\ |K| = d.$"
     },
     {
+      "id": "minimal-normal-existence",
+      "title": "Existence of a Minimal Normal Subgroup",
+      "startLine": 169,
+      "endLine": 224,
+      "summary": "exists_minimal_normal: every nontrivial finite group has a normal N ≠ ⊥ minimal among nontrivial normal subgroups. Proven (0 axioms) by Finite.exists_min over the finite subtype of nontrivial normal subgroups (nonempty since ⊤ qualifies), minimizing Nat.card; a private antisymmetry lemma eq_of_le_of_card_le closes equality. exists_minimal_normal_atom restates it as an atom in the normal-subgroup lattice.",
+      "mathContext": "$\\exists N \\trianglelefteq G,\\ N \\ne \\bot,\\ \\forall M \\trianglelefteq G,\\ M \\le N \\Rightarrow M = \\bot \\lor M = N.$"
+    },
+    {
+      "id": "minimal-normal-abelian",
+      "title": "Minimal Normal Subgroup of a Solvable Group Is Abelian",
+      "startLine": 226,
+      "endLine": 274,
+      "summary": "minimal_normal_abelian_of_solvable: for solvable G, a minimal normal N is abelian. The commutator ⁅N,N⁆ is normal in G and, by IsSolvable.commutator_lt_of_ne_bot, strictly below N; minimality forces ⁅N,N⁆ = ⊥, so all commutators of elements of N vanish. exists_abelian_minimal_normal assembles this with the atom result: a nontrivial finite solvable group has an abelian minimal normal subgroup.",
+      "mathContext": "$G$ solvable, $N$ minimal normal $\\Rightarrow \\langle\\!\\langle N,N\\rangle\\!\\rangle < N \\Rightarrow \\lbrack N,N\\rbrack = \\bot \\Rightarrow N$ abelian."
+    },
+    {
       "id": "sanity-specialization",
       "title": "Sanity Specialization: Trivial Kernel",
-      "startLine": 156,
-      "endLine": 168,
+      "startLine": 276,
+      "endLine": 287,
       "summary": "hall_lift_trivial_coprime: the degenerate case N = ⊥. Since gcd(1, d) = 1 always holds, a subgroup of order d in G/⊥ ≅ G lifts to one in G — confirming the lifting step specializes correctly.",
       "mathContext": "$N = \\bot:\\ \\gcd(1, d) = 1$, so the lift is essentially the identity $G/\\bot \\cong G$."
     }
@@ -92,34 +111,33 @@
       "Subgroup"
     ],
     "namespace": "LagrangeOQ01OQ03OQ01",
-    "lineCount": 169,
+    "lineCount": 288,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 4
+    "theoremCount": 8
   },
   "openQuestions": [
     {
       "id": "oq-01",
-      "question": "Can the existence of a minimal normal subgroup of a nontrivial finite group, and its elementary-abelian structure in the solvable case, be formalized in Mathlib? Together with this file's lifting step and the abelian base case, that would yield a fully 0-axiom proof of Hall's theorem for solvable groups.",
-      "difficulty": "hard",
+      "question": "Can the elementary-abelian sharpening be formalized: an abelian minimal normal subgroup of a finite group is a p-group (its p-torsion is characteristic, hence normal, hence — by minimality — all of N)? The existence of a minimal normal subgroup and its abelianness in the solvable case are now proved in this file (exists_minimal_normal, minimal_normal_abelian_of_solvable); only this last refinement remains.",
+      "difficulty": "medium",
       "status": "open"
     },
     {
       "id": "oq-02",
-      "question": "Can the p | d branch of Hall's induction (where the prime of the minimal normal subgroup also divides the target order) be formalized using the elementary-abelian structure, completing the induction whose coprime branch is proved here?",
+      "question": "Can the p | d branch of Hall's induction (where the prime of the minimal normal subgroup also divides the target order) be assembled from the now-available descent target (exists_abelian_minimal_normal) plus the lifting step, completing the full induction for a 0-axiom hall_solvable?",
       "difficulty": "hard",
       "status": "open"
     }
   ],
   "parentId": "lagrange-theorem-oq-01-oq-03",
   "conclusion": {
-    "summary": "The Schur–Zassenhaus inductive step of Hall's theorem — lifting a Hall subgroup from a quotient G/N to G in the coprime branch — is now machine-checked with 0 axioms. This is the exact mechanism the parent Hall entry axiomatized, and the parent's stated reason for axiomatizing it (Schur–Zassenhaus 'not in Mathlib 4.26') is incorrect: Mathlib does provide it.",
-    "implications": "With the lifting step verified, the only obstruction to a fully 0-axiom Hall's theorem for solvable groups is the minimal-normal-subgroup machinery (existence and elementary-abelian structure), which would close the complementary p | d branch. The coprime branch proved here, the abelian base case from lagrange-theorem-oq-03, and the prime/cyclic cases from the parent together cover everything except that structural input.",
+    "summary": "Both structural ingredients of Hall's theorem that the parent entry axiomatized are now machine-checked with 0 axioms: the Schur–Zassenhaus lifting step (coprime branch) AND the descent target — existence of a minimal normal subgroup of any nontrivial finite group (exists_minimal_normal) and its abelianness in the solvable case (minimal_normal_abelian_of_solvable), assembled as exists_abelian_minimal_normal. The parent's stated reason for axiomatizing (Schur–Zassenhaus 'not in Mathlib 4.26') is incorrect: Mathlib provides it.",
+    "implications": "The minimal-normal-subgroup machinery that the parent flagged as the genuine Mathlib gap is now supplied (in abelian form). What remains for a fully 0-axiom Hall's theorem is the elementary-abelian sharpening (an abelian minimal normal subgroup is a p-group — a short characteristic-subgroup argument) and the bookkeeping that threads the lifting step and the abelian descent target through the induction on |G|. The lifting step, the descent target, the abelian base case from lagrange-theorem-oq-03, and the prime/cyclic cases from the parent now cover all the mathematical content.",
     "openQuestions": [
-      "Formalize existence of a minimal normal subgroup of a nontrivial finite group in Mathlib.",
-      "Formalize that a minimal normal subgroup of a finite solvable group is elementary abelian, closing the p | d branch.",
-      "Assemble the full 0-axiom Hall's theorem from the lifting step, the abelian base case, and minimal-normal-subgroup structure."
+      "Sharpen minimal_normal_abelian_of_solvable to elementary abelian: an abelian minimal normal subgroup is a p-group (p-torsion is characteristic, hence normal, hence all of N).",
+      "Assemble the full 0-axiom hall_solvable from the lifting step, the abelian descent target (exists_abelian_minimal_normal), and the abelian base case."
     ]
   },
   "crossReferences": [

--- a/src/data/research/problems/lagrange-theorem-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01-oq-03-oq-01.json
@@ -11,31 +11,31 @@
   "started": "2026-06-28",
   "lastUpdate": "2026-06-28",
   "tags": ["group-theory", "hall-theorem", "schur-zassenhaus", "solvable-groups", "lagrange"],
-  "currentState": "Schur–Zassenhaus lifting step proved with 0 axioms (hall_lift_of_coprime). Parent's false 'SZ not in Mathlib' claim corrected. Remaining gap: minimal-normal-subgroup elementary-abelian structure (p|d branch).",
-  "knownResults": "Hall (1928). Schur–Zassenhaus is in Mathlib 4.26 as Subgroup.exists_right_complement'_of_coprime. Mathlib has solvable-group derived series but no minimal-normal-subgroup structure theory and no Hall's theorem for solvable groups.",
+  "currentState": "Session 2: BOTH minimal-normal Mathlib gaps now closed with 0 axioms. exists_minimal_normal (every nontrivial finite group has a minimal normal subgroup) + minimal_normal_abelian_of_solvable (minimal normal of solvable group is abelian), assembled as exists_abelian_minimal_normal. Plus Session 1's Schur–Zassenhaus lifting step. Remaining: elementary-abelian sharpening (abelian minimal normal is a p-group) + induction bookkeeping.",
+  "knownResults": "Hall (1928). Schur–Zassenhaus is in Mathlib 4.26 as Subgroup.exists_right_complement'_of_coprime. KEY: Mathlib has IsSolvable.commutator_lt_of_ne_bot (⁅N,N⁆<N for N≠⊥ in solvable G) and the Subgroup.commutator_normal instance, which together yield minimal-normal-abelianness. Mathlib still has no minimal-normal existence theorem and no Hall's theorem for solvable groups.",
   "knowledge": {
     "insights": [
       "Parent entry's axiom justification is factually wrong: Schur–Zassenhaus IS in Mathlib 4.26 (Subgroup.exists_right_complement'_of_coprime), already used by lagrange-theorem-oq-03 and sylow-theorem-oq-03.",
-      "The genuine remaining obstacle to a 0-axiom Hall's theorem is minimal-normal-subgroup machinery (existence + elementary-abelian structure in the solvable case), not Schur–Zassenhaus.",
-      "Mathlib has Hall's marriage theorem (Combinatorics) but NOT Hall's theorem for solvable groups.",
-      "The lifting step (case gcd(|N|,d)=1) reduces to Schur–Zassenhaus inside the preimage L=π⁻¹(Q), with the card bookkeeping |L|=|N|·d done via card_mul_index / index_eq_card / index_comap_of_surjective."
+      "Minimal-normal existence is a clean Finite.exists_min argument over {N // N.Normal ∧ N≠⊥}, minimizing Nat.card; equality from SetLike.coe_injective + Set.eq_of_subset_of_ncard_le.",
+      "Minimal-normal-abelianness in the solvable case follows immediately from IsSolvable.commutator_lt_of_ne_bot: ⁅N,N⁆ is normal in G (commutator_normal instance) and strictly below N, so minimality forces it to ⊥.",
+      "The lifting step (case gcd(|N|,d)=1) reduces to Schur–Zassenhaus inside the preimage L=π⁻¹(Q), with the card bookkeeping |L|=|N|·d done via card_mul_index / index_eq_card / index_comap_of_surjective.",
+      "Mathlib has Hall's marriage theorem (Combinatorics) but NOT Hall's theorem for solvable groups."
     ],
     "builtItems": [
-      "hall_lift_of_coprime (LagrangeTheoremOQ01OQ03OQ01.lean): 0-axiom Schur–Zassenhaus lifting step of Hall's theorem",
-      "hall_lift_of_coprime_subgroup: sharper form locating the lift inside π⁻¹(Q)",
-      "schur_zassenhaus_available: documents Mathlib's SZ",
-      "Correction of parent's false 'SZ not in Mathlib' claim (docstring + meta.json)"
+      "hall_lift_of_coprime (+_subgroup) (LagrangeTheoremOQ01OQ03OQ01.lean): 0-axiom Schur–Zassenhaus lifting step of Hall's theorem (Session 1)",
+      "exists_minimal_normal (+_atom): 0-axiom existence of a minimal normal subgroup of a nontrivial finite group (Session 2)",
+      "minimal_normal_abelian_of_solvable: 0-axiom proof that a minimal normal subgroup of a solvable group is abelian (Session 2)",
+      "exists_abelian_minimal_normal: assembled descent target — nontrivial finite solvable group has an abelian minimal normal subgroup (Session 2)",
+      "schur_zassenhaus_available + correction of parent's false 'SZ not in Mathlib' claim"
     ],
     "mathlibGaps": [
-      "No existence theorem for a minimal normal subgroup of a nontrivial finite group",
-      "No theorem that a minimal normal subgroup of a finite solvable group is elementary abelian",
-      "No Hall's theorem for solvable groups"
+      "No theorem that an abelian minimal normal subgroup is a p-group (elementary-abelian sharpening) — now MEDIUM since abelianness is done",
+      "No Hall's theorem for solvable groups (induction assembly)"
     ],
     "nextSteps": [
-      "Formalize minimal-normal-subgroup existence for nontrivial finite groups",
-      "Prove minimal normal subgroup of finite solvable group is elementary abelian; close the p|d branch",
-      "Assemble full 0-axiom Hall's theorem from lifting step + abelian base case + minimal-normal structure"
+      "Sharpen to elementary abelian: abelian minimal normal subgroup is a p-group (p-torsion characteristic ⇒ normal ⇒ all of N by minimality)",
+      "Assemble full 0-axiom hall_solvable from lifting step + exists_abelian_minimal_normal + abelian base case (lagrange-theorem-oq-03)"
     ],
-    "progressSummary": "PROGRESS: Schur–Zassenhaus lifting step of Hall's theorem verified 0-axiom; parent false claim corrected; remaining gap pinpointed (minimal-normal-subgroup structure)."
+    "progressSummary": "PROGRESS (Session 2): both minimal-normal-subgroup Mathlib gaps closed 0-axiom — existence (exists_minimal_normal) and abelianness in the solvable case (minimal_normal_abelian_of_solvable, assembled as exists_abelian_minimal_normal). Combined with Session 1's lifting step, only the elementary-abelian sharpening and induction bookkeeping remain."
   }
 }


### PR DESCRIPTION
## Summary

Extends the Hall's-theorem entry `lagrange-theorem-oq-01-oq-03-oq-01` by **closing both minimal-normal-subgroup Mathlib gaps** that Session 1 (#31159) only identified. All new results are machine-checked with **0 axioms** (`#print axioms` = `propext / Classical.choice / Quot.sound` only).

The parent Hall entry axiomatized `hall_solvable`, citing missing minimal-normal-subgroup machinery as the genuine obstacle. This PR supplies that machinery (in abelian form).

## New theorems (all 0-axiom)

| Theorem | Statement |
|---------|-----------|
| `exists_minimal_normal` | Every nontrivial finite group has a minimal nontrivial normal subgroup |
| `exists_minimal_normal_atom` | …phrased as an atom in the normal-subgroup lattice (any normal `M ≤ N` is `⊥` or `N`) |
| `minimal_normal_abelian_of_solvable` | A minimal normal subgroup of a solvable group is abelian |
| `exists_abelian_minimal_normal` | A nontrivial finite solvable group has an abelian minimal normal subgroup (assembled descent target) |

## Proof ideas

- **Existence:** `Finite.exists_min` over the finite, nonempty (`⊤` qualifies) subtype `{N // N.Normal ∧ N ≠ ⊥}`, minimizing `Nat.card`. Equality from a private antisymmetry lemma (`SetLike.coe_injective` + `Set.eq_of_subset_of_ncard_le`, bridged by `Nat.card_coe_set_eq`).
- **Abelianness:** The commutator `⁅N, N⁆` is normal in `G` (`Subgroup.commutator_normal`) and, by `IsSolvable.commutator_lt_of_ne_bot`, strictly below `N`; minimality forces `⁅N, N⁆ = ⊥`, so all commutators of elements of `N` vanish.

## Verification

```
lake env lean Proofs/LagrangeTheoremOQ01OQ03OQ01.lean   # 0 errors
#print axioms → propext, Classical.choice, Quot.sound   # for all 4 new theorems
```

0 sorries, 0 `axiom` declarations. `theoremCount` 4→8, `lineCount` 169→288.

## What remains (open questions, narrowed)

- Elementary-abelian sharpening: an abelian minimal normal subgroup is a `p`-group (its `p`-torsion is characteristic, hence normal, hence all of `N` by minimality) — now **medium**, not hard, since abelianness is done.
- Thread the lifting step + `exists_abelian_minimal_normal` + the abelian base case through the induction on `|G|` for a 0-axiom `hall_solvable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)