### PR TITLE
research(erdos-564-incomplete-01): discharge parent bounds_gap_enormous arithmetic sorry [axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos564Problem.lean
+++ b/proofs/Proofs/Erdos564Problem.lean
@@ -199,9 +199,49 @@ The question is whether the true value is closer to the lower or upper bound
 in terms of "tower height".
 -/
 
-/-- The bounds gap: for large n, the ratio of upper to lower bound is enormous. -/
+/-- Auxiliary growth bound: for `n ≥ 10`, `n² + 400 ≤ 2ⁿ`. The `+400` margin is
+    exactly what pushes the upper/lower Ramsey-bound ratio past `10¹⁰⁰`. -/
+private theorem nsq_add_four_hundred_le_two_pow (n : ℕ) (hn : 10 ≤ n) :
+    n ^ 2 + 400 ≤ 2 ^ n := by
+  induction n, hn using Nat.le_induction with
+  | base => norm_num
+  | succ m hm ih =>
+    have hm2 : 2 * m ≤ m ^ 2 := by
+      have h := Nat.mul_le_mul_right m (show 2 ≤ m by omega)
+      simpa [pow_two] using h
+    have hpow : 2 ^ (m + 1) = 2 * 2 ^ m := by rw [pow_succ]; ring
+    rw [hpow]
+    nlinarith [ih, hm2]
+
+/-- The bounds gap: for large n, the ratio of upper to lower bound is enormous.
+
+    A self-contained real-arithmetic fact (independent of the Ramsey axioms `R`,
+    `erdos_hajnal_rado_*`): writing the ratio as the single power
+    `2^(2ⁿ − n²)`, the auxiliary bound `n² + 400 ≤ 2ⁿ` (for `n ≥ 10`) makes the
+    exponent at least `400`, and `2^400 = 16^100 > 10^100`. -/
 theorem bounds_gap_enormous :
     ∀ n : ℕ, n ≥ 10 → (2 : ℝ)^((2 : ℝ)^n) / (2 : ℝ)^((n : ℝ)^2) > 10^100 := by
-  sorry
+  intro n hn
+  -- Combine the two real powers of `2` into a single exponent `2ⁿ − n²`.
+  rw [gt_iff_lt, ← Real.rpow_sub (by norm_num : (0:ℝ) < 2)]
+  -- The exponent is at least `400`, from the nat growth bound cast to `ℝ`.
+  have hbound : (400 : ℝ) ≤ (2 : ℝ) ^ n - (n : ℝ) ^ 2 := by
+    have hnat := nsq_add_four_hundred_le_two_pow n hn
+    have hcast : ((n ^ 2 + 400 : ℕ) : ℝ) ≤ ((2 ^ n : ℕ) : ℝ) := by exact_mod_cast hnat
+    push_cast at hcast
+    linarith
+  -- Monotonicity of `t ↦ 2ᵗ` lifts the exponent bound to the power.
+  have hmono : (2 : ℝ) ^ (400 : ℝ) ≤ (2 : ℝ) ^ ((2 : ℝ) ^ n - (n : ℝ) ^ 2) :=
+    Real.rpow_le_rpow_of_exponent_le (by norm_num) hbound
+  -- `10¹⁰⁰ < 16¹⁰⁰ = 2⁴⁰⁰`.
+  have hnum : (10 : ℝ) ^ (100 : ℕ) < (2 : ℝ) ^ (400 : ℝ) := by
+    have hrw : (2 : ℝ) ^ (400 : ℝ) = (16 : ℝ) ^ (100 : ℕ) := by
+      rw [show (400 : ℝ) = ((400 : ℕ) : ℝ) by norm_num, Real.rpow_natCast,
+          show (16 : ℝ) = 2 ^ 4 by norm_num, ← pow_mul]
+    rw [hrw]
+    have hnat : (10 : ℕ) ^ 100 < (16 : ℕ) ^ 100 :=
+      Nat.pow_lt_pow_left (by norm_num) (by norm_num)
+    exact_mod_cast hnat
+  exact lt_of_lt_of_le hnum hmono
 
 end Erdos564

--- a/research/problems/erdos-564-incomplete-01/knowledge.md
+++ b/research/problems/erdos-564-incomplete-01/knowledge.md
@@ -57,3 +57,28 @@ GOTCHAs (session 1):
 * Parent's `bounds_gap_enormous` (rpow inequality 2^{2^n}/2^{n²} > 10^100, n≥10)
   left as the parent's sorry — provable via `2^n ≥ n²+924` induction + `rpow_sub`
   + monotonicity + `norm_num` on `2^924 > 10^100`, but messy over rpow; deferred.
+
+---
+
+## Iteration 2 (researcher-1, 2026-06-28): parent sorry discharged
+
+Discharged the only `sorry` in the parent `Erdos564Problem.lean`
+(`bounds_gap_enormous`, line 205): for `n ≥ 10`,
+`2^(2ⁿ) / 2^(n²) > 10¹⁰⁰`.
+
+Proof outline (axiom-free — `#print axioms` = `propext/Classical.choice/Quot.sound`):
+- `Real.rpow_sub (0 < 2)` collapses `2^a / 2^b` to the single power `2^(a−b)`.
+- Auxiliary `nsq_add_four_hundred_le_two_pow`: `n² + 400 ≤ 2ⁿ` for `n ≥ 10`, by
+  `Nat.le_induction` (base `norm_num`; step `2·2^m ≥ 2(m²+400) ≥ (m+1)²+400`,
+  closed by `nlinarith [ih, 2m ≤ m²]`). Cast to ℝ ⇒ `2ⁿ − n² ≥ 400`.
+- `Real.rpow_le_rpow_of_exponent_le` lifts that to `2^400 ≤ 2^(2ⁿ−n²)`.
+- `10¹⁰⁰ < 16¹⁰⁰ = 2⁴⁰⁰` via `Nat.pow_lt_pow_left` + cast (NOT by evaluating
+  100-digit literals), then `← pow_mul` for `16^100 = 2^400`.
+
+Gotchas: `pow_lt_pow_left` is gone in Mathlib 4.26 → use `Nat.pow_lt_pow_left`.
+`linarith` choked on the `rpow` atoms → finish with `lt_of_lt_of_le`.
+
+Parent now **0 sorries**. The 3 remaining `axiom`s (`R`, `erdos_hajnal_rado_upper`,
+`erdos_hajnal_rado_lower`) are the legitimate open-problem axiomatization (the
+hypergraph Ramsey number and the EHR 1965 bounds) — not provable here. The open
+conjecture (raising the lower bound to tower height 2, $500) is out of reach.

--- a/src/data/research/problems/erdos-564-incomplete-01.json
+++ b/src/data/research/problems/erdos-564-incomplete-01.json
@@ -8,20 +8,30 @@
   "problemStatement": {
     "formal": "Erdős #564 (OPEN, $500): is there c>0 with R₃(n) ≥ 2^{2^{cn}} for large n? This sub-task delivers the verified tower-growth theory underlying the 'tower height' framing.",
     "plain": "For the 3-uniform hypergraph Ramsey number R₃(n), the known bounds are 2^{cn²} < R₃(n) < 2^{2^n}: singly-exponential lower, doubly-exponential upper. Erdős asks whether the lower bound can be raised to tower height 2 (2^{2^{cn}}). This file builds the verified theory of the tower function in which the question is phrased.",
-    "whyMatters": ["Makes 'tower height' rigorous (strict monotonicity in height and base)", "Pins down the exact one-tower-level gap (tower_one_lt_tower_two) the open conjecture asks to close"]
+    "whyMatters": [
+      "Makes 'tower height' rigorous (strict monotonicity in height and base)",
+      "Pins down the exact one-tower-level gap (tower_one_lt_tower_two) the open conjecture asks to close"
+    ]
   },
   "knownResults": {
-    "proven": ["tower strictly increasing in height and base", "n ≤ tower k n", "2^n < 2^{2^n} for all n (height-1 < height-2)"],
-    "open": ["the conjecture R₃(n) ≥ 2^{2^{cn}} itself", "parent's bounds_gap_enormous sorry"],
+    "proven": [
+      "tower strictly increasing in height and base",
+      "n ≤ tower k n",
+      "2^n < 2^{2^n} for all n (height-1 < height-2)"
+    ],
+    "open": [
+      "the conjecture R₃(n) ≥ 2^{2^{cn}} itself",
+      "parent's bounds_gap_enormous sorry"
+    ],
     "goal": "Verified combinatorial scaffolding for the tower-height framing of Erdős #564 (not the open conjecture)."
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-27T00:00:00.000Z",
-    "iteration": 1,
-    "focus": "Delivered standalone verified 0-axiom tower-growth theory (Erdos564Incomplete01.lean, 11 thms): strict monotonicity in height (tower_lt_succ_height/tower_strictMono_height) and base (tower_strictMono_base), self_le_tower, and the crux tower_one_lt_tower_two (2^n < 2^{2^n}). Also fixed 6 dangling /-- doc comments that made parent Erdos564Problem.lean fail to parse.",
+    "since": "2026-06-28",
+    "iteration": 2,
+    "focus": "Iteration 2 (researcher-1, 2026-06-28): discharged the parent Erdos564Problem.lean arithmetic sorry bounds_gap_enormous (line 205): for n>=10, 2^(2^n)/2^(n^2) > 10^100. Proof writes the ratio as the single rpow 2^(2^n - n^2), lower-bounds the exponent by 400 via the auxiliary nat bound n^2+400 <= 2^n (Nat.le_induction, nlinarith step), and uses 2^400 = 16^100 > 10^100. Axiom-free: #print axioms = propext/Classical.choice/Quot.sound only (no native_decide, independent of the R/erdos_hajnal_rado_* Ramsey axioms). Parent now 0 sorries (was 1).",
     "blockers": [],
-    "nextAction": "Ramsey-property monotonicity lemmas toward a verified R₃ definition (replacing the axiom); prove the parent's bounds_gap_enormous arithmetic sorry. The open conjecture itself is out of reach.",
+    "nextAction": "Remaining: replace axiom R (the hypergraph Ramsey number) with a genuine def + prove HasHypergraphRamseyProperty monotonicity toward a verified R3 — substantial hypergraph Ramsey theory. The two known-bounds axioms (erdos_hajnal_rado_upper/lower) are the EHR 1965 results, legitimately axiomatized. The open conjecture (lower bound to tower height 2, $500) is out of reach.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -29,22 +39,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S1 ACT: standalone verified tower-growth theory for Erdős #564 (Erdos564Incomplete01.lean, 110 lines, 11 theorems, 0-sorry 0-axiom). Strict monotonicity in height and base, base lower bound, and the crux 2^n < 2^{2^n} making precise the one-tower-level gap of the open conjecture. Fixed the parent's 6 dangling /-- doc comments (parent did not parse at all on main).",
+    "progressSummary": "S1 ACT: standalone verified tower-growth theory for Erdős #564 (Erdos564Incomplete01.lean, 110 lines, 11 theorems, 0-sorry 0-axiom). Strict monotonicity in height and base, base lower bound, and the crux 2^n < 2^{2^n} making precise the one-tower-level gap of the open conjecture. Fixed the parent's 6 dangling /-- doc comments (parent did not parse at all on main). Iter 2: discharged the parent's bounds_gap_enormous arithmetic sorry (axiom-free); Erdos564Problem.lean now 0 sorries, leaving only the legitimate Ramsey axiomatization (R + EHR bounds).",
     "builtItems": [
       "Erdos564Incomplete01.lean: tower_succ, tower_lt_succ_height, tower_strictMono_height, self_le_tower, tower_strictMono_base, tower_mono_base, tower_two_eq, tower_one_lt_tower_two, plus 3 concrete checks (all 0-axiom verified)",
-      "Parent fix: 6 dangling /-- doc comments in Erdos564Problem.lean (lines 65/66/153/154/164/186) converted to /- so the file parses"
+      "Parent fix: 6 dangling /-- doc comments in Erdos564Problem.lean (lines 65/66/153/154/164/186) converted to /- so the file parses",
+      "[parent sorry discharged] Erdos564Problem.lean bounds_gap_enormous (axiom-free, propext/Classical.choice/Quot.sound): 2^(2^n)/2^(n^2) > 10^100 for n>=10, via single-rpow rewrite (Real.rpow_sub) + exponent bound 2^n-n^2 >= 400 (aux nat lemma n^2+400 <= 2^n by Nat.le_induction) + 2^400=16^100>10^100. Parent file now 0 sorries."
     ],
     "insights": [
       "Tower height growth needs no positivity hypothesis: m < 2^m holds even at m=0, so tower k n < tower (k+1) n for all n (strengthens the parent's positivity-gated tower_pos framing).",
       "tower_one_lt_tower_two (2^n < 2^{2^n}) is the formal content of 'the EHR lower bound is one tower level below the upper bound' — the precise gap Erdős #564 asks to close.",
       "Importing a parent file with axioms + a sorry does NOT taint #print axioms of theorems that don't transitively use them: all 11 results are 0-axiom despite importing Erdos564Problem (which has axiom R + 2 EHR axioms + 1 sorry).",
-      "The parent Erdos564Problem.lean did not parse on main (dangling /-- doc comments before /- blocks) — same bug class as the puiseux-theorem parent fix. Its olean was therefore missing; had to build it single-file to the lean/Proofs libdir (extra lean/ segment)."
+      "The parent Erdos564Problem.lean did not parse on main (dangling /-- doc comments before /- blocks) — same bug class as the puiseux-theorem parent fix. Its olean was therefore missing; had to build it single-file to the lean/Proofs libdir (extra lean/ segment).",
+      "Real.rpow_sub (0<x) collapses 2^a/2^b to 2^(a-b); then Real.rpow_le_rpow_of_exponent_le (1<=base) lifts a real exponent lower bound. Avoid huge-number norm_num: bound 10^100 < 16^100 = 2^400 via Nat.pow_lt_pow_left + cast, not by evaluating 100-digit literals. pow_lt_pow_left is gone in Mathlib 4.26 -> use Nat.pow_lt_pow_left."
     ],
     "mathlibGaps": [
       "No hypergraph Ramsey number API in Mathlib (R₃ is axiomatized in the parent).",
       "No formal Erdős–Hajnal–Rado bound proofs (axiomatized)."
     ],
     "nextSteps": [
+      "DONE (iter 2): bounds_gap_enormous discharged (axiom-free). Remaining sorry-free; only the R/EHR axioms persist (open).",
       "Prove monotonicity of HasHypergraphRamseyProperty (more vertices preserve a monochromatic clique) toward a verified R₃.",
       "Prove the parent's bounds_gap_enormous (2^{2^n}/2^{n²} > 10^100 for n≥10): induction 2^n ≥ n²+924 for n≥10, then rpow_sub + monotonicity; norm_num on 2^924 > 10^100.",
       "The conjecture R₃(n) ≥ 2^{2^{cn}} is open ($500) — out of reach."
@@ -63,5 +76,29 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:33:50.249Z",
-  "lastUpdate": "2026-04-03T08:33:50.249Z"
+  "lastUpdate": "2026-06-28",
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos564Problem.lean",
+      "filename": "Erdos564Problem.lean",
+      "lineCount": 245,
+      "theoremCount": null,
+      "axiomCount": 3,
+      "defCount": null,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos564Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos564Incomplete01.lean",
+      "filename": "Erdos564Incomplete01.lean",
+      "lineCount": 110,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": null,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos564Incomplete01.lean"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Erdős #564 (3-uniform hypergraph Ramsey numbers, `2^{cn²} < R₃(n) < 2^{2^n}`, $500 open). This PR discharges the **only remaining `sorry`** in the parent gallery file `Erdos564Problem.lean`:

```
theorem bounds_gap_enormous :
    ∀ n : ℕ, n ≥ 10 → (2 : ℝ)^((2 : ℝ)^n) / (2 : ℝ)^((n : ℝ)^2) > 10^100
```

— the quantitative form of "the gap between the known upper and lower bounds is enormous."

## Proof (axiom-free)

`#print axioms bounds_gap_enormous` → `propext, Classical.choice, Quot.sound` only. No `native_decide`, and **independent of the file's Ramsey axioms** (`R`, `erdos_hajnal_rado_upper/lower`) — it is pure real arithmetic.

- `Real.rpow_sub (0 < 2)` collapses `2^a / 2^b` into the single power `2^(2ⁿ − n²)`.
- Auxiliary `nsq_add_four_hundred_le_two_pow`: `n² + 400 ≤ 2ⁿ` for `n ≥ 10` (`Nat.le_induction`; step closed by `nlinarith`). Cast to ℝ ⇒ exponent `2ⁿ − n² ≥ 400`.
- `Real.rpow_le_rpow_of_exponent_le` ⇒ `2^400 ≤ 2^(2ⁿ−n²)`.
- `10¹⁰⁰ < 16¹⁰⁰ = 2⁴⁰⁰` via `Nat.pow_lt_pow_left` + cast and `← pow_mul` (no evaluation of 100-digit literals).

## Status

The parent file is now **0 sorries**. The 3 remaining `axiom`s (`R` = the hypergraph Ramsey number, `erdos_hajnal_rado_upper/lower` = the EHR 1965 bounds) are the legitimate open-problem axiomatization, not provable here. The open conjecture (raising the lower bound to tower height 2) is out of reach.

Verified via `proofs/bin/lake env lean Proofs/Erdos564Problem.lean` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)