### PR TITLE
research(erdos-490): prove distinct_minimal_energy (2→1 sorry, 0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -229,17 +229,101 @@ noncomputable def multiplicativeEnergy (A B : Finset ℕ) : ℕ :=
     (fun ((a₁, a₂), (b₁, b₂)) => a₁ * b₁ = a₂ * b₂)
     |>.card
 
-/-- Distinct products means minimal energy.  DEFERRED (genuine fiber-counting
-combinatorics, ~50–80 lines): the multiplicative energy is `∑_{p} r(p)²` where
-`r(p) = #{(a,b) ∈ A×B : ab = p}`, while `|A||B| = ∑_p r(p)` and
-`(productSet A B).card = #{p : r(p) > 0}`.  The diagonal already contributes `|A||B|`
-to the energy, so `energy = |A||B| ↔ every fiber has size ≤ 1 ↔ the product map is
-injective ↔ HasDistinctProducts`.  Formalizing requires `Finset.card_eq_sum_card_fiberwise`
-on the product map and a per-fiber `r(p)² = r(p) ↔ r(p) ≤ 1` argument; left for a
-follow-up session. -/
+/-- **Distinct products means minimal energy.**  PROVED via the diagonal-subset
+argument (cleaner than the fiber-sum route): the multiplicative-energy set `E`
+always contains the diagonal `Δ = {((a,a),(b,b))}`, whose size is exactly
+`|A||B|`.  The product map is injective on `A ×ˢ B` iff `E = Δ` (no off-diagonal
+coincidences), and since `Δ ⊆ E` that is equivalent to `|E| = |Δ| = |A||B|`.
+The injectivity is in turn equivalent to `HasDistinctProducts` via
+`Finset.card_image_iff` (the product set is the image of the product map). -/
 theorem distinct_minimal_energy (A B : Finset ℕ) :
     HasDistinctProducts A B ↔ multiplicativeEnergy A B = A.card * B.card := by
-  sorry
+  classical
+  set s : Finset (ℕ × ℕ) := A ×ˢ B with hsdef
+  set f : ℕ × ℕ → ℕ := fun p => p.1 * p.2 with hfdef
+  have hcard : s.card = A.card * B.card := Finset.card_product A B
+  -- HasDistinctProducts ⇔ the product map is injective on `A ×ˢ B`.
+  have hps : productSet A B = s.image f := by
+    ext n
+    simp only [productSet, hsdef, hfdef, Finset.mem_biUnion, Finset.mem_image,
+      Finset.mem_product]
+    constructor
+    · rintro ⟨a, ha, b, hb, rfl⟩; exact ⟨(a, b), ⟨ha, hb⟩, rfl⟩
+    · rintro ⟨⟨a, b⟩, ⟨ha, hb⟩, rfl⟩; exact ⟨a, ha, b, hb, rfl⟩
+  have hHD : HasDistinctProducts A B ↔ Set.InjOn f ↑s := by
+    rw [HasDistinctProducts, hps, ← hcard, Finset.card_image_iff]
+  -- The energy filter `E` and its diagonal `Δ` inside `S = (A×A)×(B×B)`.
+  set S : Finset ((ℕ × ℕ) × (ℕ × ℕ)) := (A ×ˢ A) ×ˢ (B ×ˢ B) with hSdef
+  set E : Finset ((ℕ × ℕ) × (ℕ × ℕ)) :=
+    S.filter (fun q => q.1.1 * q.2.1 = q.1.2 * q.2.2) with hEdef
+  set Δ : Finset ((ℕ × ℕ) × (ℕ × ℕ)) :=
+    S.filter (fun q => q.1.1 = q.1.2 ∧ q.2.1 = q.2.2) with hΔdef
+  have henergy : multiplicativeEnergy A B = E.card := rfl
+  -- Δ ⊆ E.
+  have hsub : Δ ⊆ E := by
+    intro q hq
+    rw [hΔdef, Finset.mem_filter] at hq
+    rw [hEdef, Finset.mem_filter]
+    exact ⟨hq.1, by rw [hq.2.1, hq.2.2]⟩
+  -- |Δ| = |A||B|, via the bijection ((a,a),(b,b)) ↔ (a,b).
+  have hΔcard : Δ.card = A.card * B.card := by
+    rw [← hcard]
+    refine Finset.card_bij' (fun q _ => (q.1.1, q.2.1))
+      (fun p _ => ((p.1, p.1), (p.2, p.2))) ?hi ?hj ?left ?right
+    case hi =>
+      rintro ⟨⟨a₁, a₂⟩, ⟨b₁, b₂⟩⟩ hq
+      rw [hΔdef, Finset.mem_filter] at hq
+      simp only [hSdef, Finset.mem_product] at hq
+      rw [hsdef, Finset.mem_product]
+      exact ⟨hq.1.1.1, hq.1.2.1⟩
+    case hj =>
+      rintro ⟨a, b⟩ hp
+      rw [hsdef, Finset.mem_product] at hp
+      rw [hΔdef, Finset.mem_filter]
+      simp only [hSdef, Finset.mem_product]
+      exact ⟨⟨⟨hp.1, hp.1⟩, hp.2, hp.2⟩, trivial, trivial⟩
+    case left =>
+      rintro ⟨⟨a₁, a₂⟩, ⟨b₁, b₂⟩⟩ hq
+      rw [hΔdef, Finset.mem_filter] at hq
+      obtain ⟨_, h1, h2⟩ := hq
+      simp only at h1 h2
+      subst h1; subst h2; rfl
+    case right =>
+      rintro ⟨a, b⟩ _; rfl
+  -- InjOn ⇔ E = Δ.
+  have hED : Set.InjOn f ↑s ↔ E = Δ := by
+    constructor
+    · intro hinj
+      refine Finset.Subset.antisymm ?_ hsub
+      rintro ⟨⟨a₁, a₂⟩, ⟨b₁, b₂⟩⟩ hq
+      rw [hEdef, Finset.mem_filter] at hq
+      simp only [hSdef, Finset.mem_product] at hq
+      obtain ⟨⟨⟨ha1, ha2⟩, hb1, hb2⟩, hprod⟩ := hq
+      have hx : (a₁, b₁) ∈ s := by rw [hsdef, Finset.mem_product]; exact ⟨ha1, hb1⟩
+      have hy : (a₂, b₂) ∈ s := by rw [hsdef, Finset.mem_product]; exact ⟨ha2, hb2⟩
+      have heq := hinj hx hy hprod
+      rw [Prod.mk.injEq] at heq
+      rw [hΔdef, Finset.mem_filter]
+      simp only [hSdef, Finset.mem_product]
+      exact ⟨⟨⟨ha1, ha2⟩, hb1, hb2⟩, heq.1, heq.2⟩
+    · intro hEΔ
+      rintro ⟨a₁, b₁⟩ hx ⟨a₂, b₂⟩ hy hfxy
+      rw [Finset.mem_coe, hsdef, Finset.mem_product] at hx hy
+      have hqE : (((a₁, a₂), (b₁, b₂)) : (ℕ × ℕ) × (ℕ × ℕ)) ∈ E := by
+        rw [hEdef, Finset.mem_filter]
+        simp only [hSdef, Finset.mem_product]
+        exact ⟨⟨⟨hx.1, hy.1⟩, hx.2, hy.2⟩, hfxy⟩
+      rw [hEΔ, hΔdef, Finset.mem_filter] at hqE
+      obtain ⟨_, h1, h2⟩ := hqE
+      simp only at h1 h2
+      rw [Prod.mk.injEq]
+      exact ⟨h1, h2⟩
+  -- Assemble.
+  rw [hHD, henergy, hED]
+  constructor
+  · intro h; rw [h, hΔcard]
+  · intro h
+    exact (Finset.eq_of_subset_of_card_le hsub (by rw [h, hΔcard])).symm
 
 /-
 ## Part VIII: Bounds History

--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -49,3 +49,37 @@ updated: sorries 6→2, lineCount 282→339.
 ## Still open (NOT done here)
 - distinct_minimal_energy fiber-counting; bound_is_optimal PNT lower bound.
 - Erdos490OQ01.lean carries 3 axioms (separate, untouched).
+
+## Session 2026-06-28 (researcher-3) — distinct_minimal_energy proved (2 → 1 sorry)
+
+**Mode**: ACT. **Outcome**: progress — eliminated 1 of the 2 remaining sorries, 0-axiom.
+
+### What I Did (verified, 0-axiom)
+Proved `distinct_minimal_energy : HasDistinctProducts A B ↔ multiplicativeEnergy A B = A.card * B.card`
+via the **diagonal-subset argument** (cleaner than the deferred fiber-sum route):
+- The energy set `E = filter (a₁b₁=a₂b₂) ((A×ˢA)×ˢ(B×ˢB))` always contains the diagonal
+  `Δ = filter (a₁=a₂ ∧ b₁=b₂)`, and `|Δ| = |A||B|` (bijection `((a,a),(b,b)) ↔ (a,b)` via
+  `Finset.card_bij'`).
+- `Set.InjOn f ↑(A×ˢB)` (product map injective) ↔ `E = Δ` (no off-diagonal coincidence); since
+  `Δ ⊆ E` this is `|E| = |Δ| = |A||B|`, i.e. `energy = |A||B|`.
+- `HasDistinctProducts ↔ InjOn` comes from `productSet A B = (A×ˢB).image f` + `Finset.card_image_iff`.
+
+### Gotchas / API
+- `Finset.card_bij'` signature: `(i) (j) (hi) (hj) (left_inv) (right_inv) : #s = #t`. `apply` REORDERS
+  the four side-goals (left_inv came first!) → use `refine card_bij' i j ?hi ?hj ?left ?right` with
+  named `case hi/hj/left/right =>` blocks instead of positional `·` bullets.
+- After `simp only [Finset.mem_product]` the diagonal predicate `a=a ∧ b=b` reduces to `True ∧ True`,
+  not a single `True` → discharge with `⟨trivial, trivial⟩` (not `rfl`/`trivial`).
+- `Finset.card_image_iff : #(s.image f) = #s ↔ Set.InjOn f ↑s` is the clean bridge from the
+  cardinality-style `HasDistinctProducts` to injectivity.
+
+### Verification
+Host `lake env lean Proofs/Erdos490Problem.lean` (Lean 4.26.0) → EXIT 0 (pre-existing unused-var
+warnings only). `#print axioms distinct_minimal_energy` = `[propext, Classical.choice, Quot.sound]`
+(0-axiom). File 339 → 423 lines, sorries 2 → 1. Gallery meta `src/data/proofs/erdos-490/meta.json`
+updated (sorries, lineCount, theoremCount, assumptions).
+
+### Remaining (1 sorry, genuinely hard)
+- `bound_is_optimal` lower bound: needs `|optimalB| = π(N) − π(N/2) ≳ N/(2 log N)`, a Chebyshev/PNT
+  prime-count estimate not currently wired into the file. 2 deep axioms remain (szemeredi_theorem,
+  optimal_has_distinct_products).

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 490,
     "erdosUrl": "https://erdosproblems.com/490",
     "erdosProblemStatus": "solved",
@@ -68,9 +68,9 @@
       "bound_is_optimal: matching lower bound (partially proved)"
     ],
     "axiomCount": 2,
-    "lineCount": 339,
-    "assumptions": "2 axioms (szemeredi_theorem — Szemerédi 1976, deep; optimal_has_distinct_products — the optimal example has distinct products, deep) and 2 sorries (distinct_minimal_energy — multiplicative-energy fiber-counting; bound_is_optimal lower bound — needs a Chebyshev/PNT prime-count estimate). Reduced from 6 sorries (2026-06-28, researcher-8): repaired the build against the current Mathlib pin (orphan doc-comments, Finset.card_Icc → Nat.card_Icc, DecidablePred via open scoped Classical) and eliminated 4 sorries with 0-axiom proofs — optimal_works_because_primes (positivity-corrected and proved), the two IsSubsetUpTo subgoals, and a false primes_sidon claim replaced by the correct primes_products_determine_pair (product of two primes determines the unordered pair).",
-    "theoremCount": 10,
+    "lineCount": 423,
+    "assumptions": "2 axioms (szemeredi_theorem — Szemerédi 1976, deep; optimal_has_distinct_products — the optimal example has distinct products, deep) and 1 sorry (bound_is_optimal lower bound — needs a Chebyshev/PNT prime-count estimate π(N)−π(N/2) ≳ N/(2 log N)). Reduced from 6 sorries: researcher-8 (2026-06-28) repaired the build against the current Mathlib pin and eliminated 4 sorries with 0-axiom proofs (optimal_works_because_primes, the two IsSubsetUpTo subgoals, primes_products_determine_pair). researcher-3 (2026-06-28) then proved distinct_minimal_energy (HasDistinctProducts ↔ multiplicative energy = |A||B|) 0-axiom via the diagonal-subset argument, leaving 1 sorry.",
+    "theoremCount": 11,
     "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
@@ -202,12 +202,12 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 339,
+    "lineCount": 423,
     "axiomCount": 2,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
-    "sorries": 2,
+    "sorries": 1,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
       "Proofs/Erdos490Aristotle.lean"
@@ -230,5 +230,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, number-theory, solved"
     }
   ],
-  "sorries": 6
+  "sorries": 1
 }

--- a/src/data/research/problems/erdos-490-incomplete-01.json
+++ b/src/data/research/problems/erdos-490-incomplete-01.json
@@ -46,10 +46,10 @@
       "No prime-counting lower bound (π(N) − π(N/2)) readily available for the optimal-example lower bound."
     ],
     "nextSteps": [
-      "Prove distinct_minimal_energy via Finset.card_eq_sum_card_fiberwise on the product map.",
-      "Prove the bound_is_optimal lower bound using a Chebyshev-type prime count."
+      "Prove the bound_is_optimal lower bound: needs a Chebyshev-type prime-count estimate π(N)−π(N/2) ≳ N/(2 log N) (not currently in the file/Mathlib pin).",
+      "Optional: prove the HasDistinctProducts ↔ ProductMapInjective bridge as a standalone lemma (now subsumed inside distinct_minimal_energy)."
     ],
-    "progressSummary": "PROGRESS 2026-06-28 (researcher-8): repaired build + reduced Erdos490Problem.lean sorries 6 → 2 (all eliminations 0-axiom), corrected two false lemma statements. 2 deep axioms + 2 hard sorries remain."
+    "progressSummary": "PROGRESS 2026-06-28 (researcher-3): proved distinct_minimal_energy (HasDistinctProducts ↔ multiplicative energy = |A||B|) 0-axiom via the diagonal-subset argument; sorries 2 → 1. Remaining sorry is the bound_is_optimal PNT lower bound. 2 deep axioms remain."
   },
   "knownResults": {
     "established": [


### PR DESCRIPTION
## Summary

Eliminates one of the two remaining sorries in `Erdos490Problem.lean` (Erdős #490, distinct products of two sets). Proves `distinct_minimal_energy` — that distinct products is equivalent to minimal multiplicative energy — fully (0-axiom), reducing the file from **2 sorries to 1**.

## What changed

`distinct_minimal_energy : HasDistinctProducts A B ↔ multiplicativeEnergy A B = A.card * B.card`, proved via the **diagonal-subset argument** (the prior in-file note had deferred this as ~50–80 lines of fiber-sum combinatorics; the diagonal route is cleaner):

- The energy set `E = filter (a₁b₁=a₂b₂) ((A×ˢA)×ˢ(B×ˢB))` always contains the diagonal `Δ = filter (a₁=a₂ ∧ b₁=b₂)`, and `|Δ| = |A||B|` (bijection `((a,a),(b,b)) ↔ (a,b)` via `Finset.card_bij'`).
- The product map is injective on `A ×ˢ B` iff `E = Δ`; since `Δ ⊆ E`, that is iff `|E| = |Δ| = |A||B|`, i.e. `energy = |A||B|`.
- `HasDistinctProducts ↔ InjOn` follows from `productSet A B = (A ×ˢ B).image (·.1 * ·.2)` and `Finset.card_image_iff`.

## Verification

- `lake env lean` (Lean 4.26.0): **EXIT 0** (pre-existing unused-variable warnings only).
- `#print axioms distinct_minimal_energy` = `[propext, Classical.choice, Quot.sound]` — 0-axiom.
- File 339→423 lines, sorries 2→1. Gallery `meta.json` updated (sorries, lineCount, theoremCount, assumptions).

## Remaining (1 sorry, genuinely hard)

`bound_is_optimal` lower bound needs `π(N) − π(N/2) ≳ N/(2 log N)`, a Chebyshev/PNT prime-count estimate not wired into the file. Two deep axioms remain (`szemeredi_theorem`, `optimal_has_distinct_products`), so the entry stays `axiomatized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)