### PR TITLE
research(cauchy-schwarz-integral-lp-duality-synthesis): flag BLOCKED on Mathlib gap + restore currentState

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
@@ -2,7 +2,7 @@
   "slug": "cauchy-schwarz-integral-lp-duality-synthesis",
   "title": "Synthesis: Eliminate riesz_lp_surjective axiom — Full Lp Duality",
   "type": "synthesis",
-  "status": "surveyed",
+  "status": "blocked",
   "tier": "A",
   "significance": 8,
   "tractability": 6,
@@ -91,5 +91,23 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean"
     }
-  ]
+  ],
+  "lastUpdate": "2026-06-28",
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-28",
+    "iteration": 10,
+    "focus": "BLOCKED on a genuine Mathlib gap. The headline goal — eliminate the riesz_lp_surjective axiom to give full Lᵖ–Lq duality — requires the converse-Hölder dual-norm bound ‖g‖_q ≤ sup_{‖f‖_p≤1} |∫ f·g| and Riesz surjectivity, neither of which exists in Mathlib 4.26 (no Dual Lp file under MeasureTheory/Function). Synthesis file CauchySchwarzIntegralLpDualitySynthesis.lean carries 12 sorries; its dep ...Incomplete01.lean carries 1. Progress across ~9 sessions has been ingredient lemmas (σ-finite pullback, q-power disjoint-union eLpNorm additivity, step-1 representer) but the headline axiom is NOT eliminated and the real remaining gap is the converse-Hölder norm bound — a deep Mathlib gap, not bookkeeping.",
+    "nextAction": "Upstream/Mathlib-scale work, out of single-session reach: build converse-Hölder dual-norm + Riesz surjectivity for Lᵖ. Concrete unblockers if resumed: (1) public re-export of extByZeroCLM (currently private in Incomplete01.lean); (2) sigmaFinite_restrict_iUnion (countable-union σ-finite restriction) — candidate upstream PR; (3) eLpNorm q-power disjoint-union additivity (have eLpNorm_rpow_restrict_union). Flagged BLOCKED per the 3+-sessions-stuck rule; revisit when Mathlib gains Lp duality or a contributor takes the converse-Hölder lemma.",
+    "blockers": [
+      "Mathlib 4.26 has NO general Lᵖ–Lq duality / Riesz surjectivity (no Dual Lp file).",
+      "Converse-Hölder dual-norm bound ‖g‖_q ≤ sup_{unit Lᵖ ball} |∫ f·g| is absent (Holder.lean has only the forward bound).",
+      "Synthesis file not in the standard build cache (no olean); dep ...Incomplete01.olean must be built first."
+    ],
+    "attemptCounts": {
+      "total": 9,
+      "currentApproach": 1,
+      "approachesTried": 2
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Honest status correction for a long-running (~9-session) synthesis whose goal — eliminate the `riesz_lp_surjective` axiom for full **Lᵖ–Lq duality** — is genuinely **blocked on a Mathlib gap**.

The real remaining gap (established across prior sessions) is the **converse-Hölder dual-norm bound** `‖g‖_q ≤ sup_{‖f‖_p≤1} |∫ f·g|` plus **Riesz surjectivity** for Lᵖ. Neither exists in Mathlib 4.26 (there is no `Dual` Lp file under `MeasureTheory/Function`; `Holder.lean` provides only the forward bound). The headline axiom is **not** eliminated — the synthesis file still carries 12 `sorry`s (+1 in its dependency).

## Changes (no new math)

- Set `status: blocked`.
- Restore the degraded/empty `currentState` with an accurate assessment, the precise gap, explicit blockers, and concrete unblockers for any future resumption:
  - public re-export of `extByZeroCLM` (currently `private`),
  - `sigmaFinite_restrict_iUnion` (countable-union σ-finite restriction) — candidate upstream PR,
  - `eLpNorm` q-power disjoint-union additivity (`eLpNorm_rpow_restrict_union`, already proved).

Per the project's "3+ sessions stuck on the same gap → flag BLOCKED, move on" guidance. The prior gallery-integrity issue (#28788, Mathlib drift) is already CLOSED; this PR only corrects the research-pool status and metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)