### PR TITLE
research(de-moivre-oq-02-oq-03-oq-02-oq-01): degree & leading coeff of 2nd-kind Chebyshev Uₙ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DeMoivreOQ02OQ03OQ02OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ02OQ03OQ02OQ01.lean
@@ -1,0 +1,129 @@
+/-
+# Degree and Leading Coefficient of the Second-Kind Chebyshev Polynomials Uₙ
+
+For the second-kind Chebyshev polynomials `U n` (Mathlib's `Polynomial.Chebyshev.U`)
+over `ℤ`, this file proves
+
+* `natDegree (U ℤ n) = n`;
+* `leadingCoeff (U ℤ n) = 2 ^ n`.
+
+This is the second-kind companion to `DeMoivreOQ02OQ03OQ02` (which handled the
+first-kind `Tₙ`, with `leadingCoeff (T ℤ n) = 2 ^ (n-1)`).  Mathlib's
+`RingTheory/Polynomial/Chebyshev.lean` provides the defining three-term
+recurrence `U (n+2) = 2·X·U (n+1) − U n` with `U 0 = 1`, `U 1 = 2·X`, but records
+no degree or leading-coefficient lemma for either family — both results here are
+fresh.
+
+The second-kind formula is *cleaner* than the first-kind one: because
+`U 1 = 2·X` already carries the factor of two, the leading coefficient is the
+uniform `2 ^ n` with no truncated subtraction, valid at `n = 0` too
+(`U 0 = 1 = 2⁰`).
+
+## Strategy
+
+A single two-step induction on `n` tracking `natDegree` and `leadingCoeff`
+simultaneously.  Base cases `U 0 = 1` (degree 0, leading coeff `1 = 2⁰`) and
+`U 1 = 2·X` (degree 1, leading coeff `2 = 2¹`).  For the step, write
+`U (n+2) = 2·X·U (n+1) − U n`.  Over the domain `ℤ`:
+
+* `2·X·U (n+1)` has degree `1 + (n+1) = n+2` and leading coefficient
+  `2 · 2ⁿ⁺¹ = 2ⁿ⁺²` (degree and leading coefficient are additive/multiplicative
+  on products of nonzero polynomials);
+* `U n` has degree `n < n+2`, so subtracting it changes neither the degree
+  nor the leading coefficient of the `n+2` term.
+
+Hence `natDegree (U (n+2)) = n+2` and `leadingCoeff (U (n+2)) = 2ⁿ⁺²`, completing
+the induction.
+
+No axioms beyond Lean/Mathlib's foundations; `0` sorries.
+-/
+import Mathlib
+
+open Polynomial Polynomial.Chebyshev
+
+namespace DeMoivreOQ02OQ03OQ02OQ01
+
+/-- `2 * X` over `ℤ` has `natDegree` one. -/
+theorem natDegree_two_mul_X : (2 * X : ℤ[X]).natDegree = 1 := by
+  have : (2 * X : ℤ[X]) = C 2 * X := by simp
+  rw [this, natDegree_C_mul (by norm_num : (2 : ℤ) ≠ 0), natDegree_X]
+
+/-- `2 * X` over `ℤ` has leading coefficient `2`. -/
+theorem leadingCoeff_two_mul_X : (2 * X : ℤ[X]).leadingCoeff = 2 := by
+  have : (2 * X : ℤ[X]) = C 2 * X := by simp
+  rw [this, leadingCoeff_mul, leadingCoeff_C, leadingCoeff_X, mul_one]
+
+theorem two_mul_X_ne_zero : (2 * X : ℤ[X]) ≠ 0 := by
+  intro h
+  have := congrArg natDegree h
+  rw [natDegree_two_mul_X, natDegree_zero] at this
+  exact one_ne_zero this
+
+/-- **Degree and leading coefficient of `Uₙ`.**  Over `ℤ`, the `n`-th second-kind
+Chebyshev polynomial has degree `n` and leading coefficient `2 ^ n`. -/
+theorem U_natDegree_leadingCoeff (n : ℕ) :
+    (U ℤ (n : ℤ)).natDegree = n ∧ (U ℤ (n : ℤ)).leadingCoeff = 2 ^ n := by
+  induction n using Nat.twoStepInduction with
+  | zero =>
+      refine ⟨?_, ?_⟩
+      · simp [U_zero]
+      · simp [U_zero]
+  | one =>
+      have hU1 : U ℤ ((1 : ℕ) : ℤ) = 2 * X := by simp [U_one]
+      refine ⟨?_, ?_⟩
+      · rw [hU1, natDegree_two_mul_X]
+      · rw [hU1, leadingCoeff_two_mul_X]; norm_num
+  | more n ih0 ih1 =>
+      obtain ⟨hd0, _hl0⟩ := ih0
+      obtain ⟨hd1, hl1⟩ := ih1
+      -- The defining recurrence, with the index cast through ℕ.
+      have hrec : U ℤ ((n + 2 : ℕ) : ℤ)
+          = 2 * X * U ℤ ((n + 1 : ℕ) : ℤ) - U ℤ ((n : ℕ) : ℤ) := by
+        have h := U_add_two ℤ (n : ℤ)
+        push_cast
+        push_cast at h
+        linear_combination h
+      -- `U (n+1) ≠ 0` since its leading coefficient `2ⁿ⁺¹` is nonzero.
+      have hUn1_ne : U ℤ ((n + 1 : ℕ) : ℤ) ≠ 0 := by
+        intro h0
+        rw [h0, leadingCoeff_zero] at hl1
+        have : (2 : ℤ) ^ (n + 1) ≠ 0 := pow_ne_zero _ (by norm_num)
+        exact this hl1.symm
+      -- Degree and leading coefficient of `A := 2·X·U (n+1)`.
+      have hdA : (2 * X * U ℤ ((n + 1 : ℕ) : ℤ)).natDegree = n + 2 := by
+        rw [natDegree_mul two_mul_X_ne_zero hUn1_ne, natDegree_two_mul_X, hd1]
+        omega
+      have hlA : (2 * X * U ℤ ((n + 1 : ℕ) : ℤ)).leadingCoeff = 2 ^ (n + 2) := by
+        rw [leadingCoeff_mul, leadingCoeff_two_mul_X, hl1]
+        ring
+      -- `U n` has strictly smaller degree.
+      have hdeg_lt : (U ℤ ((n : ℕ) : ℤ)).natDegree
+          < (2 * X * U ℤ ((n + 1 : ℕ) : ℤ)).natDegree := by
+        rw [hdA, hd0]; omega
+      refine ⟨?_, ?_⟩
+      · rw [hrec, natDegree_sub_eq_left_of_natDegree_lt hdeg_lt, hdA]
+      · rw [hrec]
+        have hsub : (2 * X * U ℤ ((n + 1 : ℕ) : ℤ) - U ℤ ((n : ℕ) : ℤ)).leadingCoeff
+            = (2 * X * U ℤ ((n + 1 : ℕ) : ℤ)).leadingCoeff := by
+          rw [sub_eq_add_neg]
+          rw [leadingCoeff_add_of_degree_lt']
+          rw [degree_neg]
+          exact degree_lt_degree hdeg_lt
+        rw [hsub, hlA]
+
+/-- **Degree of `Uₙ`.**  `natDegree (U ℤ n) = n`. -/
+theorem U_natDegree (n : ℕ) : (U ℤ (n : ℤ)).natDegree = n :=
+  (U_natDegree_leadingCoeff n).1
+
+/-- **Leading coefficient of `Uₙ`.**  `leadingCoeff (U ℤ n) = 2 ^ n`. -/
+theorem U_leadingCoeff (n : ℕ) : (U ℤ (n : ℤ)).leadingCoeff = 2 ^ n :=
+  (U_natDegree_leadingCoeff n).2
+
+/-- `Uₙ` is monic up to the scalar `2ⁿ`: it is never the zero polynomial. -/
+theorem U_ne_zero (n : ℕ) : U ℤ (n : ℤ) ≠ 0 := by
+  intro h0
+  have := U_leadingCoeff n
+  rw [h0, leadingCoeff_zero] at this
+  exact (pow_ne_zero n (by norm_num : (2 : ℤ) ≠ 0)) this.symm
+
+end DeMoivreOQ02OQ03OQ02OQ01

--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-01/annotations.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "ann-dm-oq02030201-setup",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "concept",
+    "title": "Setup: The Missing Degree Lemma for Chebyshev Uₙ",
+    "content": "The file proves natDegree (U ℤ n) = n and leadingCoeff (U ℤ n) = 2ⁿ for the second-kind Chebyshev polynomials over ℤ. Mathlib defines U via the recurrence U(n+2) = 2·X·U(n+1) − U n with U 0 = 1, U 1 = 2·X, but records neither the degree nor the leading coefficient of either Chebyshev family. This entry is the second-kind companion to de-moivre-oq-02-oq-03-oq-02 (first-kind Tₙ) and answers that entry's first open question verbatim. The second-kind leading coefficient 2ⁿ is uniform with no truncated subtraction, because U 1 = 2·X already carries the factor of two that T 1 = X lacks. The strategy is one simultaneous two-step induction carrying degree and leading coefficient together.",
+    "mathContext": "$U_n(\\cos\\theta) = \\sin((n+1)\\theta)/\\sin\\theta$ has degree $n$ and leading coefficient $2^{n}$; $U_0 = 1$, $U_1 = 2X$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Polynomial.Chebyshev.U",
+      "natDegree",
+      "leadingCoeff",
+      "Chebyshev recurrence"
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the second kind",
+      "polynomial degree and leading coefficient",
+      "two-step induction"
+    ]
+  },
+  {
+    "id": "ann-dm-oq02030201-twox",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02-oq-01",
+    "range": { "startLine": 47, "endLine": 59 },
+    "type": "technique",
+    "title": "Degree Bookkeeping for the Factor 2·X",
+    "content": "Three short helpers over ℤ[X] isolate the arithmetic of the recurrence's multiplier 2·X: natDegree (2·X) = 1 (rewriting 2·X = C 2 · X and using natDegree_C_mul with 2 ≠ 0, then natDegree_X), leadingCoeff (2·X) = 2 (via leadingCoeff_mul, leadingCoeff_C, leadingCoeff_X), and 2·X ≠ 0 (a nonzero polynomial cannot have natDegree 1 and be 0). Keeping these separate makes the inductive step's product computation a single natDegree_mul / leadingCoeff_mul application — identical to the first-kind entry, since both recurrences share the multiplier 2·X.",
+    "mathContext": "$\\deg(2X) = 1$, $\\mathrm{lc}(2X) = 2$, $2X \\neq 0$ over $\\mathbb{Z}[X]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Polynomial.natDegree_C_mul",
+      "Polynomial.leadingCoeff_mul",
+      "Polynomial.leadingCoeff_C",
+      "Polynomial.natDegree_X"
+    ],
+    "prerequisites": [
+      "degree and leading coefficient of a constant times X",
+      "ℤ[X] is an integral domain"
+    ]
+  },
+  {
+    "id": "ann-dm-oq02030201-induction",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02-oq-01",
+    "range": { "startLine": 64, "endLine": 113 },
+    "type": "key-step",
+    "title": "Simultaneous Two-Step Induction on Degree and Leading Coefficient",
+    "content": "U_natDegree_leadingCoeff proves the conjunction natDegree (U ℤ n) = n ∧ leadingCoeff (U ℤ n) = 2ⁿ by Nat.twoStepInduction. Base cases: U 0 = 1 (degree 0, leading coeff 2⁰ = 1) and U 1 = 2·X (degree 1, leading coeff 2¹ = 2 via the 2·X helpers). In the step, the recurrence U(n+2) = 2·X·U(n+1) − U n is obtained from Mathlib's U_add_two with the index cast through ℕ (push_cast + linear_combination). The leading-coefficient hypothesis from the previous step doubles as the proof that U(n+1) ≠ 0 (its leading coefficient 2ⁿ⁺¹ is nonzero), which natDegree_mul needs. Then 2·X·U(n+1) has degree 1 + (n+1) = n+2 and leading coefficient 2·2ⁿ⁺¹ = 2ⁿ⁺², while U n has degree n < n+2, so natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt' (after sub_eq_add_neg, degree_lt_degree) carry both facts to U(n+2).",
+    "mathContext": "Step: $U_{n+2} = 2X\\,U_{n+1} - U_n$; $\\deg(2X\\,U_{n+1}) = n+2$, $\\mathrm{lc} = 2^{n+2}$, and $\\deg U_n = n < n+2$ leaves them unchanged.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.twoStepInduction",
+      "Polynomial.natDegree_mul",
+      "Polynomial.natDegree_sub_eq_left_of_natDegree_lt",
+      "Polynomial.leadingCoeff_add_of_degree_lt'",
+      "Polynomial.Chebyshev.U_add_two"
+    ],
+    "prerequisites": [
+      "the Chebyshev recurrence",
+      "degree/leading-coefficient calculus over a domain",
+      "two-step induction with two inductive hypotheses"
+    ]
+  },
+  {
+    "id": "ann-dm-oq02030201-corollaries",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02-oq-01",
+    "range": { "startLine": 115, "endLine": 129 },
+    "type": "concept",
+    "title": "Extracted Theorems for Downstream Use",
+    "content": "U_natDegree and U_leadingCoeff project the two conjuncts of the induction into standalone statements. U_ne_zero records that Uₙ is never the zero polynomial — an immediate consequence of leadingCoeff (U ℤ n) = 2ⁿ ≠ 0 — which downstream root-counting and derivative arguments (Tₙ′ = n·Uₙ₋₁) rely on.",
+    "mathContext": "$\\deg U_n = n$, $\\mathrm{lc}(U_n) = 2^{n}$, and $U_n \\ne 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "leadingCoeff",
+      "polynomial nonvanishing",
+      "second-kind Chebyshev"
+    ],
+    "prerequisites": [
+      "projecting a conjunction",
+      "a nonzero leading coefficient forces a nonzero polynomial"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-01/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "de-moivre-oq-02-oq-03-oq-02-oq-01",
+  "title": "Degree and Leading Coefficient of the Second-Kind Chebyshev Polynomials Uₙ",
+  "slug": "de-moivre-oq-02-oq-03-oq-02-oq-01",
+  "description": "Answers the open question recorded with the first-kind degree/leading-coefficient entry (de-moivre-oq-02-oq-03-oq-02): for the second-kind Chebyshev polynomials U n (Mathlib's Polynomial.Chebyshev.U) over ℤ, natDegree (U ℤ n) = n and leadingCoeff (U ℤ n) = 2ⁿ. Like the first-kind facts, neither is recorded anywhere in Mathlib's RingTheory/Polynomial/Chebyshev.lean, which supplies the defining three-term recurrence U(n+2) = 2·X·U(n+1) − U n with base cases U 0 = 1, U 1 = 2·X but no degree or leading-coefficient lemma for T or U. The second-kind formula is strictly cleaner than the first-kind one: because U 1 = 2·X already carries the factor of two, the leading coefficient is the uniform 2ⁿ with no truncated subtraction, valid at n = 0 (U 0 = 1 = 2⁰) without a special case. The proof is a single two-step induction tracking natDegree and leadingCoeff simultaneously: in the step, U(n+2) = 2·X·U(n+1) − U n, and over the integral domain ℤ the product 2·X·U(n+1) has degree 1 + (n+1) = n+2 and leading coefficient 2·2ⁿ⁺¹ = 2ⁿ⁺², while the subtracted U n has strictly smaller degree n, so it perturbs neither the degree nor the leading coefficient of the top term.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib); classical facts about Chebyshev polynomials",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ02OQ03OQ02OQ01.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "de-moivre",
+      "polynomial-degree",
+      "leading-coefficient",
+      "polynomials",
+      "induction",
+      "ring-theory",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 129,
+    "assumptions": "0 axioms, 0 sorries; kernel-checked at Mathlib (single-file elaboration via `lean Proofs/DeMoivreOQ02OQ03OQ02OQ01.lean` against prebuilt Mathlib oleans, exit 0; `#print axioms U_natDegree` and `#print axioms U_leadingCoeff` list only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, so the entry is axiom-free per the project's axiom-integrity policy). No native_decide. Mathlib supplies the Chebyshev recurrence and base cases (`Polynomial.Chebyshev.U_add_two`, `U_zero`, `U_one`) and the polynomial degree/leading-coefficient calculus used (`Polynomial.natDegree_mul`, `Polynomial.leadingCoeff_mul`, `Polynomial.natDegree_C_mul`, `Polynomial.natDegree_sub_eq_left_of_natDegree_lt`, `Polynomial.leadingCoeff_add_of_degree_lt'`, `Polynomial.degree_lt_degree`) but does NOT record the degree or leading coefficient of Uₙ (or Tₙ); both are proved here.",
+    "dateAdded": "2026-06-28",
+    "originalContributions": [
+      "U_natDegree: natDegree (U ℤ n) = n for the second-kind Chebyshev polynomial over ℤ — a fact Mathlib's Chebyshev development does not contain.",
+      "U_leadingCoeff: leadingCoeff (U ℤ n) = 2ⁿ, a uniform formula valid at every n ≥ 0 (no truncated subtraction, since U 0 = 1 = 2⁰ and U 1 = 2·X already carries the leading 2).",
+      "U_ne_zero: U ℤ n ≠ 0 for all n, an immediate corollary of the nonzero leading coefficient.",
+      "A clean simultaneous two-step induction (U_natDegree_leadingCoeff) carrying degree and leading coefficient together, so the lower-degree subtraction in the recurrence is dispatched once via natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt'."
+    ],
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Chebyshev polynomials of the second kind, defined by Uₙ(cos θ) = sin((n+1)θ)/sin θ, are the orthogonal-polynomial companions of the first-kind Tₙ and satisfy the same three-term recurrence with the different start U 0 = 1, U 1 = 2X (whereas T 1 = X). They appear as the derivative relation Tₙ′ = n·Uₙ₋₁, in the resolvent/transfer-matrix calculus, and as the orthogonal polynomials for the weight √(1−x²) on [−1,1]. Mathlib formalizes the Chebyshev recurrences and many identities relating T and U but, as of this writing, records neither the degree nor the leading coefficient of either family. This entry supplies the missing second-kind degree/leading-coefficient lemmas, the companion to the first-kind entry de-moivre-oq-02-oq-03-oq-02.",
+    "problemStatement": "Prove that for every natural number $n$, the second-kind Chebyshev polynomial $U_n$ over $\\mathbb{Z}$ satisfies $\\deg U_n = n$ and has leading coefficient $2^n$, with $U_0 = 1$ and $U_1 = 2X$.",
+    "text": "The headline results `U_natDegree (n : ℕ) : (U ℤ n).natDegree = n` and `U_leadingCoeff (n : ℕ) : (U ℤ n).leadingCoeff = 2 ^ n`, both extracted from the simultaneous induction `U_natDegree_leadingCoeff`. The corollary `U_ne_zero : U ℤ n ≠ 0` records that Uₙ never vanishes as a polynomial.",
+    "proofStrategy": "Two-step induction (`Nat.twoStepInduction`) on n, proving the conjunction natDegree (U ℤ n) = n ∧ leadingCoeff (U ℤ n) = 2ⁿ. Base cases: U 0 = 1 has degree 0 and leading coefficient 1 = 2⁰; U 1 = 2·X has degree 1 and leading coefficient 2 = 2¹. Step: rewrite U(n+2) = 2·X·U(n+1) − U n (from Mathlib's U_add_two, with the index cast through ℕ). Set A = 2·X·U(n+1). Over the domain ℤ, natDegree A = natDegree(2·X) + natDegree(U(n+1)) = 1 + (n+1) = n+2 (natDegree_mul, with 2·X ≠ 0 and U(n+1) ≠ 0 because its leading coefficient 2ⁿ⁺¹ ≠ 0), and leadingCoeff A = leadingCoeff(2·X)·leadingCoeff(U(n+1)) = 2·2ⁿ⁺¹ = 2ⁿ⁺² (leadingCoeff_mul). Since natDegree (U n) = n < n+2, subtracting U n preserves both: natDegree (A − U n) = natDegree A by natDegree_sub_eq_left_of_natDegree_lt, and leadingCoeff (A − U n) = leadingCoeff A by leadingCoeff_add_of_degree_lt' (after sub_eq_add_neg and degree_lt_degree). This closes the induction with natDegree (U(n+2)) = n+2 and leadingCoeff (U(n+2)) = 2ⁿ⁺².",
+    "keyInsights": [
+      "The second-kind leading-coefficient formula 2ⁿ is uniform — no truncated subtraction is needed — because U 1 = 2·X already supplies the factor of two that T 1 = X lacks; the base value 2⁰ = 1 at n = 0 matches U 0 = 1 automatically.",
+      "Tracking natDegree and leadingCoeff together is what makes the induction go through: the leading-coefficient hypothesis (2ⁿ⁺¹ ≠ 0) is exactly the witness that U(n+1) ≠ 0, which the degree calculus for the product 2·X·U(n+1) requires.",
+      "Working over the integral domain ℤ keeps degree additive and leading coefficient multiplicative on products (natDegree_mul / leadingCoeff_mul) with no monic hypotheses — Uₙ is not monic for n ≥ 1, so a monic-based argument would not apply.",
+      "The subtracted lower-degree term U n is handled once, generically: natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt' encapsulate 'a strictly-lower-degree perturbation changes neither the degree nor the leading coefficient'."
+    ],
+    "prerequisites": [
+      "The second-kind Chebyshev polynomials and their recurrence U(n+2) = 2·X·U(n+1) − U n (Mathlib's Polynomial.Chebyshev.U)",
+      "Degree and leading-coefficient calculus over an integral domain (natDegree_mul, leadingCoeff_mul, natDegree_sub_eq_left_of_natDegree_lt)",
+      "Two-step induction on ℕ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "§0: Module Setup and Statement",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring stating the degree and leading-coefficient results for Uₙ, noting that Mathlib records the recurrence but no degree/leading-coefficient lemma for either Chebyshev family, and that the second-kind leading coefficient 2ⁿ is uniform with no truncated subtraction. Opens Polynomial and Polynomial.Chebyshev under the namespace.",
+      "mathContext": "Targets $\\deg U_n = n$ and $\\mathrm{lc}(U_n) = 2^{n}$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "two-x-helpers",
+      "title": "Degree Facts for 2·X",
+      "startLine": 47,
+      "endLine": 59,
+      "summary": "Small helper lemmas over ℤ[X]: natDegree (2·X) = 1 (via natDegree_C_mul and natDegree_X), leadingCoeff (2·X) = 2 (via leadingCoeff_mul, leadingCoeff_C, leadingCoeff_X), and 2·X ≠ 0. These feed the product-degree computation in the inductive step.",
+      "mathContext": "$\\deg(2X) = 1$, $\\mathrm{lc}(2X) = 2$, $2X \\ne 0$."
+    },
+    {
+      "id": "main-induction",
+      "title": "Simultaneous Degree/Leading-Coefficient Induction",
+      "startLine": 64,
+      "endLine": 113,
+      "summary": "U_natDegree_leadingCoeff: by Nat.twoStepInduction, proves natDegree (U ℤ n) = n ∧ leadingCoeff (U ℤ n) = 2ⁿ. Base cases use U_zero / U_one. The step rewrites the recurrence (U_add_two with ℕ-cast index), shows 2·X·U(n+1) has degree n+2 and leading coefficient 2ⁿ⁺², and uses that U n has strictly smaller degree to conclude via natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt'.",
+      "mathContext": "Inductive step: $U_{n+2} = 2X\\,U_{n+1} - U_n$, with $\\deg(2X\\,U_{n+1}) = n+2 > n = \\deg U_n$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Extracted Degree, Leading-Coefficient, and Nonvanishing Theorems",
+      "startLine": 115,
+      "endLine": 129,
+      "summary": "U_natDegree and U_leadingCoeff project the two halves of the induction; U_ne_zero deduces that Uₙ is never the zero polynomial from the nonzero leading coefficient 2ⁿ.",
+      "mathContext": "$\\deg U_n = n$; $\\mathrm{lc}(U_n) = 2^{n}$; $U_n \\ne 0$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Over ℤ, the second-kind Chebyshev polynomial Uₙ is shown to have degree n and leading coefficient 2ⁿ, with 0 axioms and 0 sorries, by a single two-step induction tracking both quantities through the recurrence U(n+2) = 2·X·U(n+1) − U n. Together with the first-kind entry de-moivre-oq-02-oq-03-oq-02 this records the degree/leading-coefficient data of both Chebyshev families, none of which is currently in Mathlib; it answers the open question listed there verbatim.",
+    "openQuestions": [
+      "Combine the first- and second-kind leading coefficients with the derivative identity Tₙ′ = n·Uₙ₋₁ to cross-check leadingCoeff and natDegree of the derivative, giving an independent verification path inside Mathlib.",
+      "Use natDegree (U ℤ n) = n together with the orthogonality weight √(1−x²) to locate the n roots of Uₙ at the interior nodes cos(kπ/(n+1)), the second-kind analogue of the Chebyshev-node computation for Tₙ."
+    ],
+    "implications": "The degree and leading coefficient of Uₙ are the base layer beneath every quantitative statement about second-kind Chebyshev polynomials: their root/extremum locations, the derivative relation Tₙ′ = n·Uₙ₋₁, and the transfer-matrix/Dirichlet-kernel expansions. Recording them as standalone, domain-level lemmas — alongside the first-kind entry — gives the gallery (and a prospective Mathlib contribution) the complete degree/leading-coefficient data for both Chebyshev families."
+  },
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-02-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "Answers the first open question listed in the first-kind degree/leading-coefficient entry ('Establish the analogous degree/leading-coefficient pair for the second-kind Chebyshev polynomials Uₙ: natDegree (U ℤ n) = n and leadingCoeff (U ℤ n) = 2ⁿ'). Uses the same simultaneous two-step induction technique, specialized to the U-recurrence with base cases U 0 = 1, U 1 = 2·X."
+    }
+  ],
+  "references": [
+    {
+      "author": "Rivlin, T. J.",
+      "title": "Chebyshev Polynomials: From Approximation Theory to Algebra and Number Theory",
+      "year": 1990,
+      "note": "Standard reference: Uₙ has degree n and leading coefficient 2ⁿ; second-kind orthogonality"
+    },
+    {
+      "author": "Mason, J. C.; Handscomb, D. C.",
+      "title": "Chebyshev Polynomials",
+      "year": 2002,
+      "note": "Recurrence Uₙ₊₁ = 2x Uₙ − Uₙ₋₁ with U₀ = 1, U₁ = 2x; elementary degree/coefficient facts"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "DeMoivreOQ02OQ03OQ02OQ01",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ02OQ03OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the recorded open question of the first-kind degree/leading-coefficient entry `de-moivre-oq-02-oq-03-oq-02` (which lists it verbatim): for the **second-kind** Chebyshev polynomials `U n` (Mathlib's `Polynomial.Chebyshev.U`) over ℤ,

- `U_natDegree : natDegree (U ℤ n) = n`
- `U_leadingCoeff : leadingCoeff (U ℤ n) = 2 ^ n`
- `U_ne_zero : U ℤ n ≠ 0`

## Why it matters

Mathlib's `RingTheory/Polynomial/Chebyshev.lean` provides the recurrence `U(n+2) = 2·X·U(n+1) − U n` with `U 0 = 1`, `U 1 = 2·X`, but records **no** degree or leading-coefficient lemma for either Chebyshev family (T or U) — a genuine gap. The second-kind leading coefficient `2ⁿ` is *uniform* (no truncated subtraction), because `U 1 = 2·X` already carries the factor of two that `T 1 = X` lacks.

## Proof

A single simultaneous two-step induction (`Nat.twoStepInduction`) tracking `natDegree` and `leadingCoeff` together. In the step, over the domain ℤ the product `2·X·U(n+1)` has degree `n+2` and leading coefficient `2·2ⁿ⁺¹ = 2ⁿ⁺²`, while the subtracted `U n` has strictly smaller degree `n`, so it perturbs neither (`natDegree_sub_eq_left_of_natDegree_lt`, `leadingCoeff_add_of_degree_lt'`). Mirrors the first-kind entry's technique.

## Verification

- 0 sorries, 0 axioms. `#print axioms U_natDegree` / `U_leadingCoeff` list only `propext`, `Classical.choice`, `Quot.sound` — axiom-free per the project's axiom-integrity policy. No `native_decide`.
- Kernel-checked via `lake env lean Proofs/DeMoivreOQ02OQ03OQ02OQ01.lean` (exit 0) against prebuilt Mathlib oleans.

## Files

- `proofs/Proofs/DeMoivreOQ02OQ03OQ02OQ01.lean` (129 lines, 7 theorems)
- `src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-01/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)