### PR TITLE
Research: puiseux-theorem-oq-03 — complete lower hull (recursion runs to completion) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -831,4 +831,119 @@ theorem threeVertex_chain_via_extend :
     (fun r hr => by fin_cases hr <;> norm_num)
     threeVertex_rightHull
 
+/-! ### The complete lower hull: a verified Newton–Puiseux peel-down
+
+Everything above builds *one* peel of the recursion (`isLowerEdge_chain_extend`) and
+proves a given chain convex.  The capstone is to run the recursion to completion: from
+the left endpoint, repeatedly splice the dominant edge onto the right sub-hull until the
+support is exhausted, and obtain a *single* chain of lower edges that starts at the
+leftmost vertex and ends at the rightmost.  This is the existence half of the Newton
+polygon construction — the object the Newton–Puiseux algorithm walks edge by edge.
+
+The recursion measure is `pts.length`: each peel removes the leftmost point from the
+right-restriction `pts.filter (q.1 ≤ ·.1)` (the dominant cut sits strictly to its right),
+so the restriction is strictly shorter and the fuelled strong induction below terminates.
+The only mathematical inputs are the existence of a dominant edge from the left endpoint
+(`exists_isLowerEdge_of_leftmost`) and the transfer step that promotes the recursively
+built right sub-hull to a chain of the full support (`isLowerEdge_chain_extend`). -/
+
+/-- **Fuelled strong-induction core of the hull construction.**  With `pts.length ≤ n`
+as the well-founded measure, a strictly-leftmost point `p` of a distinct-index support
+spawns a chain of lower edges `p :: vs` of `pts` ending at a vertex `w` of maximal index.
+Each recursion peels the dominant edge `p → q₀` and recurses on the right restriction,
+which is strictly shorter (so its length is `≤ n`). -/
+theorem exists_lowerHull_aux : ∀ (n : ℕ) (pts : List SupportPoint) (p : SupportPoint),
+    pts.length ≤ n → p ∈ pts →
+    (∀ a ∈ pts, ∀ b ∈ pts, a.1 = b.1 → a = b) →
+    (∀ q ∈ pts, q ≠ p → p.1 < q.1) →
+    ∃ (vs : List SupportPoint) (w : SupportPoint),
+      List.IsChain (IsLowerEdge pts) (p :: vs) ∧
+      (p :: vs).getLast? = some w ∧ w ∈ pts ∧ ∀ r ∈ pts, r.1 ≤ w.1 := by
+  intro n
+  induction n with
+  | zero =>
+    intro pts p hlen hp _ _
+    rw [List.eq_nil_iff_length_eq_zero.mpr (Nat.le_zero.mp hlen)] at hp
+    simp at hp
+  | succ n ih =>
+    intro pts p hlen hp hdist hleft
+    by_cases hmax : ∀ r ∈ pts, r.1 ≤ p.1
+    · -- `p` is already the rightmost vertex: the hull is the single point `[p]`.
+      exact ⟨[], p, List.isChain_singleton _, rfl, hp, hmax⟩
+    · -- some support point lies strictly to the right of `p`; peel the dominant edge.
+      push_neg at hmax
+      obtain ⟨r₀, hr₀, hr₀lt⟩ := hmax
+      have hother : ∃ q ∈ pts, q ≠ p :=
+        ⟨r₀, hr₀, fun h => by rw [h] at hr₀lt; exact lt_irrefl _ hr₀lt⟩
+      obtain ⟨q₀, hedge⟩ := exists_isLowerEdge_of_leftmost hp hother hleft
+      obtain ⟨hp_mem, hq₀_mem, hpq_lt, m₀, b₀, hp_line, hq₀_line, hsupp0⟩ := hedge
+      -- the right restriction at the dominant cut `q₀`
+      have hq₀' : q₀ ∈ pts.filter (fun r => decide (q₀.1 ≤ r.1)) :=
+        List.mem_filter.mpr ⟨hq₀_mem, by simp⟩
+      -- the restriction is strictly shorter (it drops `p`), so its length is `≤ n`
+      have hlen' : (pts.filter (fun r => decide (q₀.1 ≤ r.1))).length ≤ n := by
+        have hle := List.length_filter_le (fun r => decide (q₀.1 ≤ r.1)) pts
+        rcases lt_or_eq_of_le hle with h | h
+        · omega
+        · exfalso
+          rw [List.length_filter_eq_length_iff] at h
+          have hpp := h p hp
+          simp only [decide_eq_true_eq] at hpp
+          omega
+      -- distinctness passes to the sublist
+      have hdist' : ∀ a ∈ pts.filter (fun r => decide (q₀.1 ≤ r.1)),
+          ∀ b ∈ pts.filter (fun r => decide (q₀.1 ≤ r.1)), a.1 = b.1 → a = b :=
+        fun a ha b hb hab =>
+          hdist a (List.mem_filter.mp ha).1 b (List.mem_filter.mp hb).1 hab
+      -- `q₀` is strictly leftmost in the restriction
+      have hleft' : ∀ q ∈ pts.filter (fun r => decide (q₀.1 ≤ r.1)), q ≠ q₀ → q₀.1 < q.1 := by
+        intro q hq hqne
+        obtain ⟨hq_pts, hq_dec⟩ := List.mem_filter.mp hq
+        have hge : q₀.1 ≤ q.1 := by simpa using hq_dec
+        rcases lt_or_eq_of_le hge with h | h
+        · exact h
+        · exact absurd (hdist q hq_pts q₀ hq₀_mem h.symm) hqne
+      -- recurse on the strictly shorter restriction
+      obtain ⟨vs', w, hchain', hlast', hw_pts', hwmax'⟩ :=
+        ih (pts.filter (fun r => decide (q₀.1 ≤ r.1))) q₀ hlen' hq₀' hdist' hleft'
+      refine ⟨q₀ :: vs', w, ?_, ?_, (List.mem_filter.mp hw_pts').1, ?_⟩
+      · -- splice the dominant edge onto the recursively built right sub-hull
+        exact isLowerEdge_chain_extend hp_mem hq₀_mem hpq_lt hp_line hq₀_line hsupp0 hchain'
+      · -- the last vertex is unchanged by prepending `p`
+        rw [show (p :: q₀ :: vs').getLast? = (q₀ :: vs').getLast? from rfl]; exact hlast'
+      · -- `w` has maximal index over all of `pts`, not just the restriction
+        intro r hr
+        by_cases hcut : q₀.1 ≤ r.1
+        · exact hwmax' r (List.mem_filter.mpr ⟨hr, by simpa using hcut⟩)
+        · push_neg at hcut
+          have hq₀w : q₀.1 ≤ w.1 := hwmax' q₀ hq₀'
+          omega
+
+/-- **Existence of the complete lower hull (Newton polygon chain).**  For any
+distinct-index support with a strictly-leftmost point `p`, there is a chain of lower
+edges `p :: vs` of `pts` whose final vertex `w` has the maximal index over the whole
+support.  Equivalently: the dominant edges from the left endpoint splice into one
+connected lower hull reaching the right endpoint.  This is the existence statement the
+Newton–Puiseux recursion realizes; combined with `edgeSlopes_pairwise_le` (global
+convexity) the resulting chain has sorted edge slopes — sorted root valuations. -/
+theorem exists_lowerHull {pts : List SupportPoint} (p : SupportPoint)
+    (hp : p ∈ pts)
+    (hdist : ∀ a ∈ pts, ∀ b ∈ pts, a.1 = b.1 → a = b)
+    (hleft : ∀ q ∈ pts, q ≠ p → p.1 < q.1) :
+    ∃ (vs : List SupportPoint) (w : SupportPoint),
+      List.IsChain (IsLowerEdge pts) (p :: vs) ∧
+      (p :: vs).getLast? = some w ∧ w ∈ pts ∧ ∀ r ∈ pts, r.1 ≤ w.1 :=
+  exists_lowerHull_aux pts.length pts p le_rfl hp hdist hleft
+
+/-- The worked example `Y² − x`: the complete lower hull from the leftmost vertex
+`(0,1)` is the single edge to `(2,0)`, and `(2,0)` has maximal index — the constructive
+end-to-end Newton polygon of the support `{(0,1), (2,0)}`. -/
+theorem ysqMinusX_lowerHull :
+    ∃ (vs : List SupportPoint) (w : SupportPoint),
+      List.IsChain (IsLowerEdge YsqMinusX) ((0, 1) :: vs) ∧
+      ((0, 1) :: vs).getLast? = some w ∧ w ∈ YsqMinusX ∧ ∀ r ∈ YsqMinusX, r.1 ≤ w.1 :=
+  exists_lowerHull (0, 1) (by simp [YsqMinusX])
+    (by intro a ha b hb hab; fin_cases ha <;> fin_cases hb <;> simp_all)
+    (by intro q hq hne; fin_cases hq <;> simp_all)
+
 end PuiseuxTheoremOQ03

--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -249,3 +249,55 @@ session-4 file, missing session 5's edgeWidths). Fix: created a *separate* workt
 symlinked its `proofs/.lake` → main repo `.lake` for prebuilt oleans, edited +
 committed there. Verify recipe unchanged otherwise:
 `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean`.
+
+## Session (2026-06-28, researcher-4): complete lower hull — recursion runs to completion
+
+Closed the capstone the previous sessions were building toward. Added
+`exists_lowerHull` (+ fuelled core `exists_lowerHull_aux` and worked example
+`ysqMinusX_lowerHull`). File 834→949 lines, 47→48 theorems, all still
+**0 sorries / 0 axioms** (`#print axioms` on all three new results lists only
+`propext`/`Classical.choice`/`Quot.sound`).
+
+**Statement.** For a distinct-index support `pts` with a strictly-leftmost point
+`p`, there is a chain of lower edges `p :: vs` of `pts` whose final vertex `w` has
+maximal index over all of `pts`:
+
+```
+∃ vs w, List.IsChain (IsLowerEdge pts) (p :: vs) ∧
+        (p :: vs).getLast? = some w ∧ w ∈ pts ∧ ∀ r ∈ pts, r.1 ≤ w.1
+```
+
+This is the **existence half of the Newton polygon construction** — the object the
+Newton–Puiseux algorithm walks edge by edge. Prior sessions proved one peel
+(`isLowerEdge_chain_extend`) and convexity of a *given* chain; this runs the
+recursion to exhaustion.
+
+**Proof architecture.** Fuelled strong induction on `pts.length` (an explicit
+`∀ n, pts.length ≤ n → …` so no `termination_by` gymnastics):
+* If `p` is already rightmost (`∀ r ∈ pts, r.1 ≤ p.1`) return the singleton `[p]`.
+* Otherwise peel the dominant edge `p → q₀` (`exists_isLowerEdge_of_leftmost`),
+  recurse on the right restriction `pts.filter (q₀.1 ≤ ·.1)`, and splice with
+  `isLowerEdge_chain_extend`.
+
+**Termination key.** The restriction strictly shrinks because the leftmost `p` is
+dropped (`p.1 < q₀.1` so `decide (q₀.1 ≤ p.1) = false`):
+`List.length_filter_eq_length_iff` + `List.length_filter_le` give
+`(filter).length < pts.length`, hence `≤ n`.
+
+**Three bookkeeping facts that make the recursion close cleanly:**
+* `q₀` is *strictly* leftmost of the restriction — distinct indices turn
+  `q₀.1 ≤ r.1` into `q₀.1 < r.1` for `r ≠ q₀` (`hdist`).
+* The recursion's last vertex `w` (max index in the restriction) is also max over
+  all of `pts`: points left of the cut have index `< q₀.1 ≤ w.1`.
+* `(p :: q₀ :: vs').getLast? = (q₀ :: vs').getLast?` is `rfl`, so the last vertex
+  is preserved by prepending the dominant edge.
+
+**Next.** The cleanest follow-on is a *single* corollary composing `exists_lowerHull`
+with `edgeSlopes_pairwise_le` (global convexity, already in-file) to get a hull whose
+edge slopes are sorted — sorted root valuations, end to end. The analytic Newton
+polygon theorem (slopes = root valuations) stays blocked on a `K((x))[Y]` valuation
+API absent from Mathlib 4.26.0.
+
+Verification: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean
+Proofs/PuiseuxTheoremOQ03.lean` exits 0 (~26s, host toolchain, single-file against
+prebuilt Mathlib oleans).

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -245,9 +245,9 @@
       "Mathlib.Data.List.Sort"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 684,
+    "lineCount": 949,
     "axiomCount": 0,
-    "theoremCount": 39,
+    "theoremCount": 48,
     "definitionCount": 8,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0

--- a/src/data/research/problems/puiseux-theorem-oq-03.json
+++ b/src/data/research/problems/puiseux-theorem-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-06-28, researcher-5): hull-construction recursion STEP verified 0-axiom. isLowerEdge_of_right (global-support transfer) + chain_transfer + isLowerEdge_chain_extend supply the inductive step of Newton-polygon hull construction — the principal combinatorial input previously missing. Full exists_hull existence and the analytic Newton polygon theorem remain open.",
+    "progressSummary": "PROGRESS (2026-06-28, researcher-4): hull-construction recursion COMPLETED. exists_lowerHull assembles the full lower-hull chain (leftmost→rightmost vertex) by fuelled strong induction over pts.length, splicing one dominant edge per peel via isLowerEdge_chain_extend; verified 0-axiom. The combinatorial Newton-polygon existence is now closed end-to-end. The analytic Newton polygon theorem (slopes = root valuations) remains open, blocked on a Mathlib valuation API.",
     "builtItems": [
       "IsLowerVertex: supporting-line characterization of a Newton-polygon lower-hull vertex (algorithm-independent Prop)",
       "isLowerVertex_of_minimal: the min-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -46,7 +46,8 @@
       "isLowerEdge_of_right (PuiseuxTheoremOQ03.lean): lower edge of right restriction with slope ≥ dominant slope ⇒ lower edge of full support",
       "chain_transfer (PuiseuxTheoremOQ03.lean): propagates dominant-slope bound along a whole right sub-hull via edgeSlope_mono; upgrades every edge to full-support edge",
       "isLowerEdge_chain_extend (PuiseuxTheoremOQ03.lean): one verified peel of Newton-Puiseux recursion — prepend dominant edge to right sub-hull chain ⇒ IsChain (IsLowerEdge pts) over full support",
-      "threeVertex_chain_via_extend + threeVertex_rightHull + threeVertex_filter: worked example rebuilt constructively through the splice combinator"
+      "threeVertex_chain_via_extend + threeVertex_rightHull + threeVertex_filter: worked example rebuilt constructively through the splice combinator",
+      "exists_lowerHull_aux + exists_lowerHull in PuiseuxTheoremOQ03.lean: complete lower-hull existence (chain from leftmost vertex to max-index vertex) for distinct-index support; ysqMinusX_lowerHull worked example. 0 sorries / 0 axioms (#print axioms: propext/Classical.choice/Quot.sound only)."
     ],
     "insights": [
       "Supporting-line predicate beats a verified convex-hull construction: same downstream value, far less proof burden, algorithm-agnostic.",
@@ -58,7 +59,8 @@
       "slope × width = vertical drop: edgeSlope p q · (q.1−p.1) = q.2−p.2 because the slope denominator IS the width — the per-edge bridge coupling valuations (slopes) to multiplicities (widths)",
       "Capstone bookkeeping: Σ (slopeᵢ · widthᵢ) telescopes to the total vertical drop (last).2 − (first).2; equivalently Σ (root valuationᵢ · multiplicityᵢ) = v(constant) − v(leading), the valuation of the product of all roots",
       "The polygon now reads off ALL combinatorial Newton-polygon data from one vertex chain: sorted valuations (edgeSlopes_pairwise_le), total multiplicity (sum_edgeWidths_eq_degree), AND sum-of-valuations-with-multiplicity (neg_sum_slope_mul_width)",
-      "S2-A hull correctness (researcher-5, 2026-06-28): the obstruction to the documented \"peel-and-recurse\" hull construction is that a lower edge of the right restriction pts.filter(q.1 ≤ ·.1) can dip below a left point. RESOLVED: isLowerEdge_of_right proves it cannot, provided the edge slope clears the dominant slope m₀ — convexity forces the right edge line above the dominant line on the left half. This is the precise reason divide-and-conquer Newton-polygon construction is sound."
+      "S2-A hull correctness (researcher-5, 2026-06-28): the obstruction to the documented \"peel-and-recurse\" hull construction is that a lower edge of the right restriction pts.filter(q.1 ≤ ·.1) can dip below a left point. RESOLVED: isLowerEdge_of_right proves it cannot, provided the edge slope clears the dominant slope m₀ — convexity forces the right edge line above the dominant line on the left half. This is the precise reason divide-and-conquer Newton-polygon construction is sound.",
+      "exists_lowerHull (2026-06-28, researcher-4): the hull-construction recursion now runs to completion. Fuelled strong induction on pts.length (exists_lowerHull_aux) peels the dominant edge p→q₀ (exists_isLowerEdge_of_leftmost) and recurses on the right restriction pts.filter (q₀.1 ≤ ·.1), which strictly shrinks because the leftmost p is dropped (List.length_filter_eq_length_iff). isLowerEdge_chain_extend splices each peel. Result: a single chain of lower edges p::vs ending at a maximal-index vertex w — the existence half of the Newton polygon, VERIFIED 0-axiom."
     ],
     "mathlibGaps": [
       "No Newton polygon API in Mathlib 4.26.0 (no Polynomial.newtonPolygon / lowerConvexHull as combinatorial vertex data).",
@@ -66,9 +68,9 @@
       "No arithmetic-complexity model (Bürgisser-Clausen-Shokrollahi style) to state the Poteaux-Weimann Õ(d·δ) bound."
     ],
     "nextSteps": [
-      "Assemble exists_hull: complete lower-hull vertex chain (head=leftmost, last=rightmost) via well-founded recursion on the right-restriction length, using isLowerEdge_chain_extend as the inductive step (now available). Remaining bookkeeping: monotone-index-along-chain + filter-narrowing from cut q.1 to next cut.",
+      "Strengthen exists_lowerHull: prove the produced chain edge-slopes are sorted by composing with edgeSlopes_pairwise_le (global convexity) — gives sorted root valuations end-to-end as a single corollary.",
       "Newton polygon theorem proper (negated edge slopes = root valuations): blocked on missing valuation API on K((x))[Y] in Mathlib 4.26.0.",
-      "S2-B termination measure for one Newton-Puiseux reduction step (Y-degree strictly decreases).",
+      "S2-B termination measure for one Newton-Puiseux reduction step (Y-degree strictly decreases) — edgeWidths sum-to-degree machinery is the combinatorial half.",
       "Quasi-linear complexity bound (Poteaux-Weimann Õ(d·δ)): blocked on absence of arithmetic-complexity model in Mathlib."
     ],
     "markdown": "# Knowledge Base: puiseux-theorem-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",


### PR DESCRIPTION
## Summary
Research session for `puiseux-theorem-oq-03` (combinatorial Newton polygon; parent Wiedijk #41 Puiseux). Closes the capstone the prior 9 sessions were building toward: the hull-construction recursion now **runs to completion**.

## Progress
- **`exists_lowerHull`** (+ fuelled core `exists_lowerHull_aux`): for a distinct-index support with a strictly-leftmost point `p`, produces a single chain of lower edges `p :: vs` of `pts` ending at a vertex `w` of maximal index — the existence half of the Newton polygon, the object the Newton–Puiseux algorithm walks edge by edge.
- **`ysqMinusX_lowerHull`**: the worked `Y²−x` example, end to end.
- File `proofs/Proofs/PuiseuxTheoremOQ03.lean`: 834→949 lines, 47→48 theorems.

## Proof architecture
Fuelled strong induction on `pts.length` (explicit `∀ n, pts.length ≤ n → …`, no `termination_by`):
- if `p` is already rightmost, return the singleton `[p]`;
- otherwise peel the dominant edge `p → q₀` (`exists_isLowerEdge_of_leftmost`), recurse on the right restriction `pts.filter (q₀.1 ≤ ·.1)`, and splice with the existing one-peel lemma `isLowerEdge_chain_extend`.

**Termination key**: the restriction strictly shrinks because the leftmost `p` is dropped (`p.1 < q₀.1`), via `List.length_filter_eq_length_iff` + `List.length_filter_le`. Distinct indices turn `q₀.1 ≤ r.1` into strict `<` so `q₀` is strictly leftmost of the restriction; the recursion's max-index vertex is max over the *full* support because left-of-cut points have smaller index.

## Verification
`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean` exits 0 (~26s, single-file against prebuilt Mathlib oleans). **0 sorries, 0 axioms** — `#print axioms` on `exists_lowerHull`, `exists_lowerHull_aux`, `ysqMinusX_lowerHull` lists only `propext`/`Classical.choice`/`Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`).

## Status
**Outcome**: progress (combinatorial Newton-polygon existence closed end-to-end)
**Next Steps**: compose `exists_lowerHull` with the in-file global convexity (`edgeSlopes_pairwise_le`) for a hull with sorted edge slopes (sorted root valuations) as one corollary. The analytic Newton polygon theorem (slopes = root valuations) remains blocked on a `K((x))[Y]` valuation API absent from Mathlib 4.26.0.

🤖 Generated by researcher-4