### PR TITLE
research(british-flag-oq-01-oq-02-oq-01): explicit n=4 fourth-moment defect [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BritishFlagFourthMomentOQ010201.lean
+++ b/proofs/Proofs/BritishFlagFourthMomentOQ010201.lean
@@ -44,12 +44,18 @@
     vanishing (`n ≥ 4` / `n ≥ 5`).
   * `fourth_moment_defect_eq_zero` — **headline**: for `n ≥ 5`, `defect₄ = 0` for every
     parallelepiped, observer `X`, base `c`, and arbitrary (possibly skew) edges `u`.
+  * `defect4_eq_quartic_piece` — for `n ≥ 4` the defect collapses to its degree-`4` Gram-square
+    piece (the lower five pieces are annihilated by the signed powerset sum).
+  * `quartic_term_eval` — companion to `quartic_term_zero` valid for *every* `n`: the signed
+    powerset sum of a quadruple `∑_{∈t}` extracts exactly the full-support quadruples, each
+    weighted by `(-1)^n`.
+  * `fourth_moment_defect_n4` — **the first nonvanishing case**: for `n = 4`,
+        defect₄ = 8 · (⟪u₀,u₁⟫⟪u₂,u₃⟫ + ⟪u₀,u₂⟫⟪u₁,u₃⟫ + ⟪u₀,u₃⟫⟪u₁,u₂⟫),
+    the symmetric sum over the three ways of pairing the four edges.  It is independent of `X`
+    and `c`, and vanishes exactly when the three pairing products cancel (e.g. mutually
+    orthogonal edges — a box — recovering the `n ≥ 5` vanishing).
 
   Everything is `sorry`-free and axiom-free; the parent's lemmas are reused by import.
-
-  The first nonzero case `n = 4` carries an explicit top-degree "pairing" defect
-      8 · (⟪u₀,u₁⟫⟪u₂,u₃⟫ + ⟪u₀,u₂⟫⟪u₁,u₃⟫ + ⟪u₀,u₃⟫⟪u₁,u₂⟫),
-  which is left as a documented next step.
 -/
 
 import Mathlib
@@ -374,6 +380,232 @@ theorem fourth_moment_defect_eq_zero (hn : 5 ≤ n) (X c : V) (u : Fin n → V) 
   simp_rw [key]
   simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
   rw [h1, h2, h3, h4, h5, h6]
+  ring
+
+/-! ### The first nonvanishing case: `n = 4`
+
+For `n = 4` the degree-`0,1,2,3` pieces still vanish (their thresholds `1,2,3,4` are all
+met), but the degree-`4` piece survives, producing the **first nonzero** British-flag
+fourth-moment defect.  We evaluate it explicitly: it is the symmetric sum over the three
+ways of pairing the four edges,
+
+    defect₄ = 8 · (⟪u₀,u₁⟫⟪u₂,u₃⟫ + ⟪u₀,u₂⟫⟪u₁,u₃⟫ + ⟪u₀,u₃⟫⟪u₁,u₂⟫).
+
+It is independent of the observer `X` and base `c`, and vanishes precisely when the three
+pairing products cancel — e.g. mutually orthogonal edges (a box), recovering the `n ≥ 5`
+vanishing. -/
+
+/-- **The defect reduces to its degree-`4` piece for `n ≥ 4`.**  The constant, linear, two
+    quadratic, and cubic pieces are each annihilated by the signed powerset sum once
+    `n ≥ 4`, leaving only the quartic Gram-square piece. -/
+theorem defect4_eq_quartic_piece (hn : 4 ≤ n) (X c : V) (u : Fin n → V) :
+    defect4 X c u
+      = ∑ t ∈ (univ : Finset (Fin n)).powerset, (-1 : ℝ) ^ t.card *
+          ((∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫) * (∑ k ∈ t, ∑ l ∈ t, ⟪u k, u l⟫)) := by
+  have key : ∀ t : Finset (Fin n), (-1 : ℝ) ^ t.card * sqDist4 X c u t
+      = (-1 : ℝ) ^ t.card * (‖X - c‖ ^ 2) ^ 2
+        - (-1 : ℝ) ^ t.card * (4 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ⟪X - c, u i⟫))
+        + (-1 : ℝ) ^ t.card * (2 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫))
+        + (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ⟪X - c, u j⟫)))
+        - (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ∑ l ∈ t, ⟪u j, u l⟫)))
+        + (-1 : ℝ) ^ t.card * ((∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫) * (∑ k ∈ t, ∑ l ∈ t, ⟪u k, u l⟫)) := by
+    intro t
+    have hsq : sqDist4 X c u t = (sqDist X c u t) ^ 2 := by
+      simp only [sqDist4, sqDist]; ring
+    rw [hsq, sqDist_expand]
+    ring
+  have h1 : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * (‖X - c‖ ^ 2) ^ 2 = 0 :=
+    const_term_zero (by omega) ((‖X - c‖ ^ 2) ^ 2)
+  have h2 : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * (4 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ⟪X - c, u i⟫)) = 0 := by
+    have hpt : ∀ t : Finset (Fin n),
+        (-1 : ℝ) ^ t.card * (4 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ⟪X - c, u i⟫))
+          = 4 * ‖X - c‖ ^ 2 * ((-1 : ℝ) ^ t.card * (∑ i ∈ t, ⟪X - c, u i⟫)) := fun t => by ring
+    simp_rw [hpt]
+    rw [← Finset.mul_sum, linear_term_zero (by omega) (fun i => ⟪X - c, u i⟫), mul_zero]
+  have h3 : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * (2 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫)) = 0 := by
+    have hpt : ∀ t : Finset (Fin n),
+        (-1 : ℝ) ^ t.card * (2 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫))
+          = 2 * ‖X - c‖ ^ 2 * ((-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫)) :=
+      fun t => by ring
+    simp_rw [hpt]
+    rw [← Finset.mul_sum, quadratic_term_zero (by omega) (fun i j => ⟪u i, u j⟫), mul_zero]
+  have h4 : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ⟪X - c, u j⟫))) = 0 := by
+    have hconv : ∀ t : Finset (Fin n),
+        (∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ⟪X - c, u j⟫)
+          = ∑ i ∈ t, ∑ j ∈ t, ⟪X - c, u i⟫ * ⟪X - c, u j⟫ := by
+      intro t; rw [Finset.sum_mul_sum]
+    have hpt : ∀ t : Finset (Fin n),
+        (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ⟪X - c, u j⟫)))
+          = 4 * ((-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ j ∈ t, ⟪X - c, u i⟫ * ⟪X - c, u j⟫)) := by
+      intro t; rw [hconv t]; ring
+    simp_rw [hpt]
+    rw [← Finset.mul_sum,
+      quadratic_term_zero (by omega) (fun i j => ⟪X - c, u i⟫ * ⟪X - c, u j⟫), mul_zero]
+  have h5 : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ∑ l ∈ t, ⟪u j, u l⟫))) = 0 := by
+    have hconv : ∀ t : Finset (Fin n),
+        (∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ∑ l ∈ t, ⟪u j, u l⟫)
+          = ∑ i ∈ t, ∑ j ∈ t, ∑ l ∈ t, ⟪X - c, u i⟫ * ⟪u j, u l⟫ := by
+      intro t
+      rw [Finset.sum_mul_sum]
+      apply Finset.sum_congr rfl; intro i _
+      apply Finset.sum_congr rfl; intro j _
+      rw [Finset.mul_sum]
+    have hpt : ∀ t : Finset (Fin n),
+        (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ∑ l ∈ t, ⟪u j, u l⟫)))
+          = 4 * ((-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ j ∈ t, ∑ l ∈ t, ⟪X - c, u i⟫ * ⟪u j, u l⟫)) := by
+      intro t; rw [hconv t]; ring
+    simp_rw [hpt]
+    rw [← Finset.mul_sum,
+      cubic_term_zero (by omega) (fun i j l => ⟪X - c, u i⟫ * ⟪u j, u l⟫), mul_zero]
+  unfold defect4
+  simp_rw [key]
+  simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+  rw [h1, h2, h3, h4, h5]
+  ring
+
+/-- **Full-support monomial.**  When `S = univ`, only `t = univ` satisfies `S ⊆ t`, so the
+    signed powerset sum collapses to the single surviving term `(-1)^n · a`. -/
+theorem monomial_term_univ (a : ℝ) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset,
+        (-1 : ℝ) ^ t.card * (if (univ : Finset (Fin n)) ⊆ t then a else 0)
+      = (-1 : ℝ) ^ n * a := by
+  classical
+  rw [Finset.sum_eq_single (univ : Finset (Fin n))]
+  · simp [Finset.card_univ, Fintype.card_fin]
+  · intro t _ hne
+    have hnsub : ¬ (univ : Finset (Fin n)) ⊆ t := fun hsub =>
+      hne (Finset.Subset.antisymm (Finset.subset_univ t) hsub)
+    simp [hnsub]
+  · intro h
+    exact absurd (Finset.mem_powerset.mpr (Finset.subset_univ _)) h
+
+/-- **Monomial evaluator.**  The signed powerset sum of the indicator `[S ⊆ t]` is `(-1)^n`
+    when `S = univ` and `0` otherwise: the finite-difference principle (`monomial_term_zero`)
+    together with its single surviving full-support term (`monomial_term_univ`). -/
+theorem monomial_term_eval (S : Finset (Fin n)) (a : ℝ) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset,
+        (-1 : ℝ) ^ t.card * (if S ⊆ t then a else 0)
+      = (if S = univ then (-1 : ℝ) ^ n else 0) * a := by
+  by_cases hS : S = univ
+  · subst hS; rw [if_pos rfl]; exact monomial_term_univ a
+  · rw [if_neg hS, zero_mul]; exact monomial_term_zero S hS a
+
+/-- **Quartic term evaluator** (companion to `quartic_term_zero`, valid for every `n`).  The
+    signed powerset sum of a quadruple `∑_{∈t}` picks out exactly the full-support quadruples
+    `{i,j,k,l} = univ`, each weighted by `(-1)^n`.  For `n ≥ 5` no quadruple is full-support
+    (recovering `quartic_term_zero`); for `n = 4` the surviving quadruples are the `4! = 24`
+    permutations of the coordinates. -/
+theorem quartic_term_eval (d : Fin n → Fin n → Fin n → Fin n → ℝ) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset,
+        (-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ j ∈ t, ∑ k ∈ t, ∑ l ∈ t, d i j k l)
+      = ∑ i, ∑ j, ∑ k, ∑ l,
+          (if ({i, j, k, l} : Finset (Fin n)) = univ then (-1 : ℝ) ^ n else 0) * d i j k l := by
+  classical
+  have hrw : ∀ t : Finset (Fin n),
+      (∑ i ∈ t, ∑ j ∈ t, ∑ k ∈ t, ∑ l ∈ t, d i j k l)
+        = ∑ i, ∑ j, ∑ k, ∑ l, if i ∈ t ∧ j ∈ t ∧ k ∈ t ∧ l ∈ t then d i j k l else 0 := by
+    intro t
+    have inner3 : ∀ i j k, (∑ l ∈ t, d i j k l) = ∑ l, if l ∈ t then d i j k l else 0 :=
+      fun i j k => (sum_ite_mem_eq' t (d i j k)).symm
+    simp_rw [inner3]
+    have inner2 : ∀ i j, (∑ k ∈ t, ∑ l, if l ∈ t then d i j k l else 0)
+        = ∑ k, if k ∈ t then (∑ l, if l ∈ t then d i j k l else 0) else 0 :=
+      fun i j => (sum_ite_mem_eq' t _).symm
+    simp_rw [inner2]
+    have inner1 : ∀ i, (∑ j ∈ t, ∑ k, if k ∈ t then (∑ l, if l ∈ t then d i j k l else 0) else 0)
+        = ∑ j, if j ∈ t then
+            (∑ k, if k ∈ t then (∑ l, if l ∈ t then d i j k l else 0) else 0) else 0 :=
+      fun i => (sum_ite_mem_eq' t _).symm
+    simp_rw [inner1]
+    rw [← sum_ite_mem_eq' t
+      (fun i => ∑ j, if j ∈ t then
+        (∑ k, if k ∈ t then (∑ l, if l ∈ t then d i j k l else 0) else 0) else 0)]
+    apply Finset.sum_congr rfl
+    intro i _
+    by_cases hi : i ∈ t
+    · rw [if_pos hi]
+      apply Finset.sum_congr rfl
+      intro j _
+      by_cases hj : j ∈ t
+      · rw [if_pos hj]
+        apply Finset.sum_congr rfl
+        intro k _
+        by_cases hk : k ∈ t
+        · rw [if_pos hk]
+          apply Finset.sum_congr rfl
+          intro l _
+          by_cases hl : l ∈ t
+          · rw [if_pos hl, if_pos ⟨hi, hj, hk, hl⟩]
+          · rw [if_neg hl, if_neg (by tauto)]
+        · rw [if_neg hk, eq_comm]
+          apply Finset.sum_eq_zero
+          intro l _
+          rw [if_neg (by tauto)]
+      · rw [if_neg hj, eq_comm]
+        apply Finset.sum_eq_zero
+        intro k _
+        apply Finset.sum_eq_zero
+        intro l _
+        rw [if_neg (by tauto)]
+    · rw [if_neg hi, eq_comm]
+      apply Finset.sum_eq_zero
+      intro j _
+      apply Finset.sum_eq_zero
+      intro k _
+      apply Finset.sum_eq_zero
+      intro l _
+      rw [if_neg (by tauto)]
+  simp_rw [hrw, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl; intro i _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl; intro j _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl; intro k _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl; intro l _
+  simp_rw [mem4_iff_subset i j k l]
+  exact monomial_term_eval _ _
+
+set_option maxHeartbeats 800000 in
+/-- **First nonvanishing British-flag fourth-moment defect (`n = 4`).**  For any
+    parallelepiped in a real inner product space with base `c`, edge vectors `u : Fin 4 → V`,
+    and observer `X`, the alternating fourth-power defect over the `16` vertices equals the
+    symmetric pairing sum of the edge Gram entries.  In particular it does not depend on `X`
+    or `c`, and vanishes exactly when the three pairing products cancel (e.g. mutually
+    orthogonal edges — a box — recovering the `n ≥ 5` vanishing). -/
+theorem fourth_moment_defect_n4 {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+    (X c : V) (u : Fin 4 → V) :
+    defect4 X c u
+      = 8 * (⟪u 0, u 1⟫ * ⟪u 2, u 3⟫
+           + ⟪u 0, u 2⟫ * ⟪u 1, u 3⟫
+           + ⟪u 0, u 3⟫ * ⟪u 1, u 2⟫) := by
+  rw [defect4_eq_quartic_piece (by norm_num) X c u]
+  -- turn the product of the two double sums into a single quadruple `∑_{∈t}`
+  have hconv : ∀ t : Finset (Fin 4),
+      (∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫) * (∑ k ∈ t, ∑ l ∈ t, ⟪u k, u l⟫)
+        = ∑ i ∈ t, ∑ k ∈ t, ∑ j ∈ t, ∑ l ∈ t, ⟪u i, u j⟫ * ⟪u k, u l⟫ := by
+    intro t
+    rw [Finset.sum_mul_sum]
+    apply Finset.sum_congr rfl; intro i _
+    apply Finset.sum_congr rfl; intro k _
+    rw [Finset.sum_mul_sum]
+  simp_rw [hconv]
+  rw [quartic_term_eval (fun i k j l => ⟪u i, u j⟫ * ⟪u k, u l⟫)]
+  -- expand the four `Fin 4` sums into the 256 explicit terms; the surviving weight is `(-1)^4 = 1`
+  simp only [Fin.sum_univ_four, show ((-1 : ℝ) ^ 4) = 1 from by norm_num]
+  -- decide each full-support indicator `{i,k,j,l} = univ`; only the 24 permutations survive
+  simp (config := { decide := true }) only [if_true, if_false, one_mul, zero_mul,
+    add_zero, zero_add]
+  -- canonicalise the inner products by symmetry, then collect the 24 surviving terms
+  simp only [real_inner_comm (u 1) (u 0), real_inner_comm (u 2) (u 0),
+    real_inner_comm (u 3) (u 0), real_inner_comm (u 2) (u 1),
+    real_inner_comm (u 3) (u 1), real_inner_comm (u 3) (u 2)]
   ring
 
 end BritishFlagFourthMomentOQ010201

--- a/src/data/research/problems/british-flag-theorem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/british-flag-theorem-oq-01-oq-02-oq-01.json
@@ -28,7 +28,7 @@
   },
   "knownResults": "Parent oq-01-oq-02 proved the orthotope (orthogonal-edge) case vanishes for n ≥ 2. Sibling oq-01-oq-01 proved the n = 2 parallelogram defect 2⟪u,v⟫. Mathlib supplies polarization (norm_sub_sq_real), inner-product bilinearity, and powerset machinery.",
   "knowledge": {
-    "progressSummary": "PROGRESS: 4th-moment defect vanishing proved for n>=5 (verified, 0-axiom, new file BritishFlagFourthMomentOQ010201.lean, 379 lines, 4 main + 3 helper theorems). Key generalization: monomial_term_zero isolates the finite-difference principle. Parent (2nd moment, n>=3) COMPLETE. Open: explicit n=4 pairing defect; general 2k-th moment via variadic infra.",
+    "progressSummary": "PROGRESS: n=4 FIRST NONVANISHING case proved explicitly — defect4 = 8*(pairing sum) [VERIFIED, 0-axiom]. Added defect4_eq_quartic_piece (n>=4 collapse), monomial_term_univ/eval, quartic_term_eval (all-n companion). The moment-defect story is now complete through n=4: n<=3 lower moments vanish, n>=5 fourth-moment vanishes, n=4 is the explicit edge case. Parent (2nd moment) COMPLETE. Open: general 2k-th first-nonvanishing value via variadic infra.",
     "insights": [
       "The squared distance ‖X − vertex t‖² is a polynomial of degree exactly 2 in the membership indicators [i ∈ t], with constant coeff ‖X−c‖², linear coeffs ⟪X−c,uᵢ⟫, and quadratic coeffs ⟪uᵢ,uⱼ⟫. The parent's orthotope hid this because there the quadratic coefficients are all zero.",
       "The alternating powerset sum g ↦ ∑_t (−1)^{|t|}·g t is the n-th iterated finite difference on the Boolean cube; it annihilates every monomial omitting a coordinate, hence every polynomial of degree < n. This single fact explains both the n ≥ 3 vanishing and the surviving n = 2 defect.",
@@ -37,7 +37,9 @@
       "The k=1 squared-distance result (parent, vanishes n>=3) generalizes to the 2k-th moment: ||X-vertex||^(2k) is degree-2k in indicators, so defect_2k=0 for n>=2k+1. The 4th moment (k=2) is the first new case: vanishes for n>=5.",
       "Clean organizing lemma is monomial_term_zero: every even-moment expansion is a sum of indicator monomials [S subseteq t], and the signed powerset sum kills each S != univ. Subsumes parent const/linear/quadratic_term_zero (S=empty,{i},{i,j}) and scales to any degree.",
       "Per-degree new infra is only (a) conjunction-indicator rewrite of nested sum_{i1..im in t} into sum over univ^m with [i1 in t and ...] indicator (by_cases cascade, parent-style), and (b) product-of-sums -> nested-sum via Finset.sum_mul_sum. ring handles (P-2L+Q)^2 with L,Q as atoms (alpha-equiv sums collapse to one atom).",
-      "Sharp boundary at n=2k (here n=4): only the top degree-2k monomial survives, giving explicit defect = sum over perfect matchings of the 2k edge slots. For 4th moment: 8*(<u0,u1><u2,u3>+<u0,u2><u1,u3>+<u0,u3><u1,u2>) — computed on paper (24 perms / 3 matchings x symmetry), not yet formalized."
+      "Sharp boundary at n=2k (here n=4): only the top degree-2k monomial survives, giving explicit defect = sum over perfect matchings of the 2k edge slots. For 4th moment: 8*(<u0,u1><u2,u3>+<u0,u2><u1,u3>+<u0,u3><u1,u2>) — computed on paper (24 perms / 3 matchings x symmetry), not yet formalized.",
+      "The n=4 fourth-moment defect is the FIRST nonvanishing case: degrees 0,1,2,3 all vanish (thresholds 1,2,3,4 met), only the degree-4 Gram-square piece survives. Its value is the symmetric pairing sum 8*(<u0,u1><u2,u3>+<u0,u2><u1,u3>+<u0,u3><u1,u2>) — the (-1)^n-weighted signed powerset sum picks out exactly the 4!=24 full-support quadruples (permutations of the coordinates), and each of the 3 unordered pair-of-pairs is hit by 8 of them.",
+      "Independence of observer X and base c is automatic: defect4 reduces to a pure function of the edge Gram matrix once the lower-degree pieces cancel. Orthogonal edges (a genuine box) give defect 0, smoothly recovering the n>=5 vanishing."
     ],
     "builtItems": [
       "alt_sum_eq_zero_of_indep (BritishFlagParallelepipedOQ010201.lean:90): finite-difference annihilation — coordinate-independent g ⟹ ∑_t (−1)^{|t|}·g t = 0",
@@ -49,7 +51,11 @@
       "monomial_term_zero (Proofs/BritishFlagFourthMomentOQ010201.lean): the finite-difference principle abstracted — for any S != univ, signed powerset sum of [S subseteq t] = 0; ~12-line proof from parent alt_sum_eq_zero_of_indep (pick k notin S; [S subseteq .] is k-independent)",
       "cubic_term_zero (n>=4) and quartic_term_zero (n>=5): degree-3/4 term vanishing via conjunction-indicator hrw + monomial_term_zero with card({i,j,l})<=3<n / card({i,j,k,l})<=4<n bound",
       "fourth_moment_defect_eq_zero (HEADLINE): defect_4 = signed powerset sum of ||X-vertex t||^4 = 0 for n>=5, any X,c,skew edges u — verified, 0-axiom, 0-sorry",
-      "sqDist4 / defect4 definitions; key expansion (sqDist)^2 = (P-2L+Q)^2 split into 6 pieces (deg 0,1,2,2,3,4) each killed by const/linear/quadratic(x2)/cubic/quartic term lemmas via sum_mul_sum product->multisum conversions"
+      "sqDist4 / defect4 definitions; key expansion (sqDist)^2 = (P-2L+Q)^2 split into 6 pieces (deg 0,1,2,2,3,4) each killed by const/linear/quadratic(x2)/cubic/quartic term lemmas via sum_mul_sum product->multisum conversions",
+      "defect4_eq_quartic_piece (BritishFlagFourthMomentOQ010201.lean): for n>=4 the defect collapses to its degree-4 Gram-square piece; all five lower pieces annihilated. [VERIFIED 0-axiom]",
+      "monomial_term_univ + monomial_term_eval: signed powerset sum of [S subset t] = (if S=univ then (-1)^n else 0)*a — finite-difference principle PLUS its single surviving full-support term. [VERIFIED 0-axiom]",
+      "quartic_term_eval: companion to quartic_term_zero valid for EVERY n — extracts the full-support quadruples weighted by (-1)^n (n>=5 gives 0, recovering quartic_term_zero). [VERIFIED 0-axiom]",
+      "fourth_moment_defect_n4 (HEADLINE): defect4 = 8*(<u0,u1><u2,u3>+<u0,u2><u1,u3>+<u0,u3><u1,u2>) for n=4, the explicit first nonvanishing pairing defect. [VERIFIED 0-axiom]"
     ],
     "mathlibGaps": "none — the proof is self-contained over Mathlib's inner-product and Finset libraries.",
     "nextSteps": [
@@ -57,7 +63,9 @@
       "Relate the n = 2 defect 2⟪u₀,u₁⟫ to the deviation of the parallelogram from a rectangle and to the mixed second difference of the squared-distance field over the cube.",
       "Formalize explicit n=4 fourth-moment defect = 8*(<u0,u1><u2,u3>+<u0,u2><u1,u3>+<u0,u3><u1,u2>) by enumerating the 16 subsets of Fin 4 (decide-style powerset + surviving quartic top monomial). Orthogonal edges => 0.",
       "General 2k-th moment: state/prove defect_2k=0 for n>=2k+1 uniformly via a variadic mfold_term_zero (sum over p:Fin m->Fin n with image subseteq t indicator), removing per-degree by_cases hrw. Mathlib gap: no off-the-shelf 'n-th finite difference annihilates degree<n' lemma on the Boolean cube.",
-      "Odd moments ||X-vertex||^(2k+1) are not polynomial in the indicators (norm, not squared-norm) — likely no clean finite-difference vanishing; document the parity asymmetry."
+      "Odd moments ||X-vertex||^(2k+1) are not polynomial in the indicators (norm, not squared-norm) — likely no clean finite-difference vanishing; document the parity asymmetry.",
+      "General 2k-th moment first-nonvanishing value at n=2k via a variadic monomial_term_eval (signed powerset over p:Fin(2k)->Fin(2k) with full-support indicator), generalising the 8*(3 pairings) to a sum over perfect matchings of 2k edges weighted by 2^k * (number of matchings).",
+      "n=4 expansion currently brute-forces 256 terms via Fin.sum_univ_four + decide-config simp; for n=6 (2k=6, deg-6 piece) this is 6^6=46656 terms — needs the variadic route instead of decide."
     ]
   },
   "leanFiles": [


### PR DESCRIPTION
## Summary

Proves the **documented open next step** for the British-flag fourth-moment defect: the **first nonvanishing case `n = 4`**. For a general (possibly skew) parallelepiped with edges `u : Fin 4 → V` in a real inner product space, observer `X`, and base `c`,

$$\mathrm{defect}_4 = 8\,(\langle u_0,u_1\rangle\langle u_2,u_3\rangle + \langle u_0,u_2\rangle\langle u_1,u_3\rangle + \langle u_0,u_3\rangle\langle u_1,u_2\rangle),$$

the symmetric sum over the three ways of pairing the four edges. It is independent of `X` and `c`, and vanishes exactly when the three pairing products cancel (e.g. mutually orthogonal edges — a box — recovering the `n ≥ 5` vanishing already proved by `fourth_moment_defect_eq_zero`).

This closes the gap left by the parent file's header (previously: *"the first nonzero case `n = 4` ... is left as a documented next step"*). The moment-defect story is now complete through `n = 4`:
- `n ≤ 3`: lower moments vanish (parent + `cubic_term_zero`),
- `n ≥ 5`: fourth moment vanishes (`fourth_moment_defect_eq_zero`),
- `n = 4`: this explicit edge case.

## New theorems (`proofs/Proofs/BritishFlagFourthMomentOQ010201.lean`)

All `sorry`-free and 0-axiom (`#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`):

- **`defect4_eq_quartic_piece`** `(hn : 4 ≤ n)` — the defect collapses to its degree-4 Gram-square piece; the constant/linear/two-quadratic/cubic pieces are each annihilated by the signed powerset sum once `n ≥ 4`.
- **`monomial_term_univ`** / **`monomial_term_eval`** — the signed powerset sum of the indicator `[S ⊆ t]` equals `(-1)^n` when `S = univ` and `0` otherwise: the finite-difference principle (`monomial_term_zero`) plus its single surviving full-support term.
- **`quartic_term_eval`** — companion to `quartic_term_zero` valid for **every** `n`: extracts the full-support quadruples `{i,j,k,l} = univ`, each weighted by `(-1)^n` (for `n ≥ 5` none survive, recovering `quartic_term_zero`).
- **`fourth_moment_defect_n4`** (headline) — the explicit `n = 4` pairing defect; the `4! = 24` surviving full-support quadruples (permutations of the coordinates) group `8`-per-pairing into the three pairing products.

## Verification

```
proofs/bin/lake env lean Proofs/BritishFlagFourthMomentOQ010201.lean   # 0 errors, 0 sorries
#print axioms fourth_moment_defect_n4   # [propext, Classical.choice, Quot.sound]
```

(Docker host wedged this session; verified via `lake env lean` against the prebuilt Mathlib + freshly built parent olean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)