### PR TITLE
research(markov-equation-oq-02): build-verify mod-3 rigidity + gallery entry [VERIFIED, 0-axiom]

### DIFF
--- a/src/data/proofs/markov-equation-oq-02/annotations.json
+++ b/src/data/proofs/markov-equation-oq-02/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "markov-oq02-ann-header",
+    "proofId": "markov-equation-oq-02",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "concept",
+    "title": "Prime-3 Rigidity Complements the Parity Layer",
+    "content": "The Markov equation x² + y² + z² = 3xyz (parent Proofs.MarkovEquation, with pairwise coprimality in Proofs.MarkovCoprime) constrains its coordinates prime by prime. The parent develops the prime-2 (parity) layer: at most one coordinate is even. This file develops the prime-3 layer, which is sharper — the residues mod 3 are determined completely: no coordinate is divisible by 3, and every coordinate is ≡ ±1 (mod 3). The whole analysis lives in the finite ring ZMod 3, so it is decidable and axiom-free.",
+    "mathContext": "$x^2+y^2+z^2 = 3xyz \\;\\Longrightarrow\\; 3 \\nmid x,\\, 3 \\nmid y,\\, 3 \\nmid z \\;\\text{and}\\; x^2 \\equiv y^2 \\equiv z^2 \\equiv 1 \\pmod 3.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Markov equation",
+      "modular arithmetic",
+      "quadratic residues",
+      "coprimality"
+    ],
+    "prerequisites": [
+      "Diophantine equations",
+      "residues in ZMod 3",
+      "integer divisibility"
+    ]
+  },
+  {
+    "id": "markov-oq02-ann-coprime-three",
+    "proofId": "markov-equation-oq-02",
+    "range": { "startLine": 35, "endLine": 41 },
+    "type": "lemma",
+    "title": "A Coprime Pair Cannot Share the Factor 3",
+    "content": "not_three_dvd_both: if IsCoprime a b, then 3 does not divide both a and b. Any common divisor of a coprime pair is a unit (IsCoprime.isUnit_of_dvd'), but the only units of ℤ are ±1 (Int.isUnit_iff), and 3 is neither — norm_num closes both cases. This is the verbatim prime-3 analogue of the parent's not_two_dvd_both, and it is the bridge that converts a mod-3 vanishing into a contradiction with coprimality.",
+    "mathContext": "$\\gcd(a,b)=1 \\;\\Longrightarrow\\; \\neg(3\\mid a \\wedge 3\\mid b).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "coprimality",
+      "units of ℤ",
+      "prime divisors"
+    ],
+    "prerequisites": [
+      "IsCoprime",
+      "units in a commutative ring"
+    ]
+  },
+  {
+    "id": "markov-oq02-ann-not-three-dvd",
+    "proofId": "markov-equation-oq-02",
+    "range": { "startLine": 43, "endLine": 81 },
+    "type": "theorem",
+    "title": "No Markov Coordinate Is Divisible by 3",
+    "content": "markov_not_three_dvd is the main result. Casting the integer equation into ZMod 3 sends the right-hand side 3·x·y·z to 0, so the residues satisfy a² + b² + c² = 0 there. A finite decide proves the key implication over ZMod 3: if a² + b² + c² = 3abc and any one of a, b, c is 0, then all three are 0. So a single divisibility 3 ∣ x (which makes the residue of x zero, via ZMod.intCast_zmod_eq_zero_iff_dvd) would force a second coordinate divisible by 3 — impossible for the coprime pairs guaranteed by markov_coprime. The contradiction yields 3 ∤ x, 3 ∤ y, 3 ∤ z. markov_not_three_dvd_fst is the first-coordinate specialization.",
+    "mathContext": "$3xyz \\equiv 0 \\pmod 3 \\;\\Rightarrow\\; a^2+b^2+c^2\\equiv 0;\\quad \\text{one residue } 0 \\Rightarrow \\text{all } 0 \\;\\Rightarrow\\; \\text{contradicts coprimality}.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "reduction mod 3",
+      "ZMod 3",
+      "decide over finite types",
+      "pairwise coprimality"
+    ],
+    "prerequisites": [
+      "ZMod.intCast_zmod_eq_zero_iff_dvd",
+      "casting integer equations into ZMod n",
+      "decidable propositions over finite types"
+    ]
+  },
+  {
+    "id": "markov-oq02-ann-residue",
+    "proofId": "markov-equation-oq-02",
+    "range": { "startLine": 83, "endLine": 95 },
+    "type": "theorem",
+    "title": "Every Coordinate Is ≡ ±1 (mod 3)",
+    "content": "markov_sq_eq_one_mod_three completes the mod-3 determination: each coordinate's residue squares to 1 in ZMod 3, i.e. each coordinate is ≡ ±1 (mod 3). Since markov_not_three_dvd makes each residue nonzero, the result follows from a second decide — every nonzero element of the three-element ring ZMod 3 squares to 1. Where the parent's parity result leaves a one-bit ambiguity, the prime-3 structure is total: every coordinate is a unit mod 3.",
+    "mathContext": "$\\forall a \\in \\mathbb{Z}/3,\\; a \\neq 0 \\Rightarrow a^2 = 1 \\;\\Longrightarrow\\; x^2 \\equiv y^2 \\equiv z^2 \\equiv 1 \\pmod 3.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic residues mod 3",
+      "units of ZMod 3",
+      "complete residue determination"
+    ],
+    "prerequisites": [
+      "ZMod 3 arithmetic",
+      "nonzero residues are units"
+    ]
+  },
+  {
+    "id": "markov-oq02-ann-sanity",
+    "proofId": "markov-equation-oq-02",
+    "range": { "startLine": 97, "endLine": 105 },
+    "type": "concept",
+    "title": "Sanity Checks on Small Markov Triples",
+    "content": "Four example checks instantiate markov_not_three_dvd on the smallest Markov triples (1,1,1), (1,1,2), (1,2,5), (2,5,29), confirming 3 ∤ 1, 3 ∤ 2, 3 ∤ 5, 3 ∤ 29 — concrete witnesses that the rigidity statement is non-vacuous and matches the known Markov numbers.",
+    "mathContext": "$(1,1,1),\\ (1,1,2),\\ (1,2,5),\\ (2,5,29)\\ \\text{are Markov triples with no coordinate divisible by } 3.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Markov numbers",
+      "worked examples"
+    ],
+    "prerequisites": [
+      "small Markov triples"
+    ]
+  }
+]

--- a/src/data/proofs/markov-equation-oq-02/index.ts
+++ b/src/data/proofs/markov-equation-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MarkovEquationOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const markovEquationOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const markovEquationOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const markovEquationOq02Data: ProofData = {
+  proof: markovEquationOq02Proof,
+  annotations: markovEquationOq02Annotations,
+}

--- a/src/data/proofs/markov-equation-oq-02/meta.json
+++ b/src/data/proofs/markov-equation-oq-02/meta.json
@@ -1,0 +1,106 @@
+{
+  "id": "markov-equation-oq-02",
+  "slug": "markov-equation-oq-02",
+  "sorries": 0,
+  "title": "Mod-3 Arithmetic Structure of Markov Triples",
+  "description": "A self-contained, axiom-free formalization of the prime-3 rigidity of the Markov equation x² + y² + z² = 3xyz. The result complements the parent entry's parity (prime-2) layer: no coordinate of a Markov triple is divisible by 3, and consequently every coordinate is congruent to ±1 modulo 3 (its residue squares to 1 in ZMod 3). The proof is the standard residue argument — reduce the equation modulo 3, where the right-hand side 3xyz vanishes, so the residues satisfy a² + b² + c² ≡ 0; a finite decide over ZMod 3 shows any single zero residue forces all three to vanish, which contradicts the pairwise coprimality already established for Markov triples. The factor of 3 on the right-hand side is what flips the conclusion relative to the unscaled Markov–Hurwitz equation x² + y² + z² = xyz, whose mod-3 analysis forces every coordinate to be divisible by 3.",
+  "leanFile": {
+    "lineCount": 105,
+    "axiomCount": 0,
+    "path": "Proofs/MarkovEquationOQ02.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "meta": {
+    "author": "Formalization original to Lean Genius (Markov 1879)",
+    "date": "1879",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MarkovEquationOQ02.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "markov-equation",
+      "modular-arithmetic",
+      "quadratic-residues",
+      "coprimality"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-28",
+    "lineCount": 105,
+    "originalContributions": [
+      "not_three_dvd_both: a coprime pair of integers cannot share the non-unit factor 3 — the prime-3 analogue of the parent's not_two_dvd_both, proved via IsCoprime.isUnit_of_dvd' and Int.isUnit_iff",
+      "markov_not_three_dvd: the main result — no coordinate of a Markov triple x² + y² + z² = 3xyz is divisible by 3. The integer equation is cast into ZMod 3 (where the right-hand side 3xyz is identically 0), and a decide establishes that over ZMod 3 a single vanishing residue forces all three to vanish; the resulting triple-divisibility contradicts pairwise coprimality",
+      "markov_not_three_dvd_fst: the first-coordinate specialization of the main rigidity statement",
+      "markov_sq_eq_one_mod_three: every Markov coordinate is ≡ ±1 (mod 3), i.e. its residue squares to 1 in ZMod 3, obtained from the non-divisibility result plus the decide fact that every nonzero element of ZMod 3 squares to 1"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound. The decide calls are kernel decision procedures over the finite type ZMod 3 — no native_decide is used, so Lean.ofReduceBool is not introduced.",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Andrey Markov's 1879 equation x² + y² + z² = 3xyz governs the Markov numbers and the structure of the worst-approximable quadratic irrationals. Its positive solutions form a tree under Vieta jumping, and individual coordinates carry strong arithmetic constraints. The parent gallery entry develops the tree classification and the prime-2 (parity) facts — at most one coordinate is even. The natural complement is the prime-3 layer, which turns out to be even more rigid: the residues modulo 3 are pinned down completely.",
+    "problemStatement": "Determine the divisibility of Markov coordinates by 3, and the residues of Markov coordinates modulo 3.",
+    "proofStrategy": "Cast the integer equation x² + y² + z² = 3xyz into ZMod 3 via Int.cast; the right-hand side 3·x·y·z reduces to 0, leaving a² + b² + c² = 0 for the residues a, b, c. A finite decide over the three-element type ZMod 3 verifies the key implication: whenever a² + b² + c² = 0 (= 3abc), if any one of a, b, c is 0 then all three are 0. Pulling a single divisibility 3 ∣ x back through ZMod.intCast_zmod_eq_zero_iff_dvd then forces 3 to divide a second coordinate, contradicting the pairwise coprimality markov_coprime of Markov triples. Hence no coordinate is divisible by 3. The residue statement follows from a second decide: every nonzero element of ZMod 3 squares to 1.",
+    "keyInsights": [
+      "The scaling factor 3 on the right-hand side is decisive. For the genuine Markov equation x² + y² + z² = 3xyz the term 3xyz vanishes mod 3, so the residues must satisfy a² + b² + c² ≡ 0, which over ZMod 3 forces them all nonzero; for the unscaled Markov–Hurwitz equation x² + y² + z² = xyz the same analysis (three_dvd_all_of_hurwitz_one in the sibling entry) instead forces every coordinate divisible by 3 — the opposite conclusion.",
+      "Coprimality converts a mod-3 vanishing into a contradiction: any single coordinate divisible by 3 propagates (through the ZMod 3 decide) to a second coordinate divisible by 3, which a coprime pair cannot tolerate. The arithmetic rigidity is therefore a direct consequence of the descent-theoretic coprimality, not an independent input.",
+      "Over the finite ring ZMod 3 the entire residue analysis is decidable: both the implication 'one zero residue forces all zero' and 'every nonzero residue squares to 1' are discharged by kernel decide on at most 27 cases, keeping the proof axiom-free.",
+      "The complete residue determination x ≡ ±1 (mod 3) is the prime-3 strengthening of the parent's parity result: where parity leaves a one-bit ambiguity (at most one even coordinate), the mod-3 structure is total — every coordinate is a unit mod 3."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Overview: Prime-3 Rigidity of Markov Triples",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Docstring framing the prime-3 structure as the complement of the parent's prime-2 (parity) results: no coordinate of a Markov triple x² + y² + z² = 3xyz is divisible by 3, and every coordinate is ≡ ±1 (mod 3). Outlines the residue argument and contrasts it with the mod-3 obstruction of the unscaled Markov–Hurwitz equation, where the factor of 3 is absent and the conclusion flips. Imports Mathlib and the parent files Proofs.MarkovEquation and Proofs.MarkovCoprime."
+    },
+    {
+      "id": "sec-coprime-three",
+      "title": "Coprime Pairs Do Not Share the Factor 3",
+      "startLine": 35,
+      "endLine": 41,
+      "summary": "not_three_dvd_both: if IsCoprime a b then 3 cannot divide both a and b. A common divisor of a coprime pair is a unit (IsCoprime.isUnit_of_dvd'), but 3 is not a unit in ℤ (Int.isUnit_iff gives only ±1). This is the verbatim prime-3 analogue of the parent's not_two_dvd_both."
+    },
+    {
+      "id": "sec-not-three-dvd",
+      "title": "No Markov Coordinate Is Divisible by 3",
+      "startLine": 43,
+      "endLine": 81,
+      "summary": "markov_not_three_dvd, the main result. The equation is cast into ZMod 3 (the right-hand side 3xyz becomes 0); a decide proves that over ZMod 3 any single vanishing residue forces the other two to vanish. If 3 divided a coordinate, the corresponding residue would be 0, propagating to a second coordinate and contradicting pairwise coprimality (markov_coprime) via not_three_dvd_both. markov_not_three_dvd_fst records the first-coordinate specialization."
+    },
+    {
+      "id": "sec-residue",
+      "title": "Every Coordinate Is ≡ ±1 (mod 3)",
+      "startLine": 83,
+      "endLine": 95,
+      "summary": "markov_sq_eq_one_mod_three: each coordinate's residue squares to 1 in ZMod 3. From markov_not_three_dvd each residue is nonzero, and a decide verifies that every nonzero element of ZMod 3 squares to 1. Hence each coordinate is ≡ ±1 (mod 3) — the complete mod-3 determination."
+    },
+    {
+      "id": "sec-sanity",
+      "title": "Sanity Checks on Small Markov Triples",
+      "startLine": 97,
+      "endLine": 105,
+      "summary": "Four example checks instantiate markov_not_three_dvd on the small Markov triples (1,1,1), (1,1,2), (1,2,5), (2,5,29), confirming 3 ∤ 1, 3 ∤ 2, 3 ∤ 5, 3 ∤ 29."
+    }
+  ],
+  "conclusion": {
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (105 lines, 4 theorems) establishing the prime-3 arithmetic rigidity of the Markov equation: no coordinate of a Markov triple is divisible by 3, and every coordinate is ≡ ±1 (mod 3). The argument reduces the equation modulo 3 — where the right-hand side 3xyz vanishes — and combines a finite decide over ZMod 3 with the pairwise coprimality of Markov triples.",
+    "implications": "The result completes the small-prime residue picture for Markov triples, strengthening the parent's parity layer (at most one even coordinate, a one-bit constraint) to a total determination at the prime 3 (every coordinate a unit mod 3). The contrast with the unscaled Markov–Hurwitz equation isolates the role of the factor 3 in the right-hand side. The not_three_dvd_both lemma is a reusable coprimality-versus-prime-divisor gadget.",
+    "openQuestions": [
+      "Residues at other small primes: for which primes p is the residue set of Markov coordinates mod p constrained, and can the analysis be packaged uniformly in p?",
+      "A markov_three_coprime corollary (3 is coprime to each coordinate) once the IsCoprime-over-ℤ form of Prime.coprime_iff_not_dvd is in place, mirroring the gcd-style statements of the parent coprimality file."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "markov-equation",
+      "relationship": "extends",
+      "description": "Adds the prime-3 layer to the parent's arithmetic structure of Markov triples. The parity facts markov_at_most_one_even / markov_not_both_even constrain coordinates at the prime 2; this entry pins down the residues completely at the prime 3, reusing the parent's IsMarkov definition and the markov_coprime pairwise-coprimality theorem."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Build-verifies the **mod-3 arithmetic structure of Markov triples** and adds its missing gallery entry.

The proof file `proofs/Proofs/MarkovEquationOQ02.lean` was merged in #30882 marked **BUILD PENDING** (Docker host outage at the time). This PR confirms it compiles cleanly and ships the gallery presentation.

## What the proof establishes

For the Markov equation $x^2+y^2+z^2 = 3xyz$:
- `markov_not_three_dvd` — **no coordinate of a Markov triple is divisible by 3**. Reduce mod 3 (the RHS $3xyz \equiv 0$), a `decide` over `ZMod 3` shows one zero residue forces all three to zero, contradicting pairwise coprimality (`markov_coprime`).
- `markov_sq_eq_one_mod_three` — **every coordinate is $\equiv \pm1 \pmod 3$** (its residue squares to 1 in `ZMod 3`).
- `not_three_dvd_both`, `markov_not_three_dvd_fst` — supporting lemmas + first-coordinate specialization.

This is the prime-3 strengthening of the parent's prime-2 (parity) layer: where parity leaves a one-bit ambiguity, the mod-3 structure is total. The factor of 3 on the RHS flips the conclusion relative to the unscaled Markov–Hurwitz equation $x^2+y^2+z^2=xyz$ (whose mod-3 analysis forces *all* coordinates divisible by 3).

## Verification (0-axiom)

Docker build host is still down, so verified via single-file `lake env lean` elaboration against the main olean cache:
1. Built `Proofs.MarkovEquation` and `Proofs.MarkovCoprime` oleans into a temp `LEAN_PATH` dir.
2. Elaborated `Proofs.MarkovEquationOQ02` → **EXIT=0**.
3. `#print axioms` on the three theorems reports only `propext / Classical.choice / Quot.sound`.

The `decide` calls are kernel decision procedures over the finite ring `ZMod 3` (**no `native_decide`**), so `Lean.ofReduceBool` is **not** introduced — genuinely 0-axiom, 0-sorry.

## Files

- `src/data/proofs/markov-equation-oq-02/{meta.json, annotations.json, index.ts}` — new gallery entry (5 annotations; `status: verified`, `badge: original`).

No changes to the Lean source (already on main). `pnpm annotations:build` regenerates listings cleanly with no warnings for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)