### PR TITLE
research(collatz-structured-oq-01): unconditional in-degree structure (0-axiom)

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ01.lean
+++ b/proofs/Proofs/CollatzStructuredOQ01.lean
@@ -161,6 +161,35 @@ theorem indegree_eq_one {m : ℕ} (hm : m % 6 ≠ 4) :
   rw [preimage_collatz_eq_singleton hm]
   exact Set.ncard_singleton _
 
+/-- **Every in-degree set is finite.** The predecessor set of any `m` is either a
+singleton (`{2m}`) or a pair (`{2m, (m-1)/3}`); in both cases finite.  This is the
+prerequisite for counting nodes of the backward tree (an `ncard` argument needs the
+sets to be genuinely finite, not merely `ncard`-positive). -/
+theorem indegree_finite (m : ℕ) : (collatz ⁻¹' {m}).Finite := by
+  by_cases hm : m % 6 = 4
+  · rw [preimage_collatz_eq_pair hm]; exact Set.Finite.insert _ (Set.finite_singleton _)
+  · rw [preimage_collatz_eq_singleton hm]; exact Set.finite_singleton _
+
+/-- **Unconditional in-degree dichotomy.** Regardless of the residue of `m`, every
+Collatz vertex has in-degree exactly `1` or exactly `2` — the even predecessor `2m`
+always exists, and the second (odd) predecessor exists precisely when `m ≡ 4 (mod 6)`.
+This is the uniform fact underlying the geometric (`≤ 2^d`) growth of the backward
+tree; the residue-split lemmas `indegree_eq_one`/`indegree_eq_two` refine it. -/
+theorem indegree_eq_one_or_two (m : ℕ) :
+    (collatz ⁻¹' {m}).ncard = 1 ∨ (collatz ⁻¹' {m}).ncard = 2 := by
+  by_cases hm : m % 6 = 4
+  · exact Or.inr (indegree_eq_two hm)
+  · exact Or.inl (indegree_eq_one hm)
+
+/-- **Uniform in-degree upper bound:** the Collatz in-degree never exceeds `2`. -/
+theorem indegree_le_two (m : ℕ) : (collatz ⁻¹' {m}).ncard ≤ 2 := by
+  rcases indegree_eq_one_or_two m with h | h <;> omega
+
+/-- **In-degree is positive:** `2 * m` is always a predecessor of `m`, so the
+predecessor set is nonempty. -/
+theorem indegree_pos (m : ℕ) : 1 ≤ (collatz ⁻¹' {m}).ncard := by
+  rcases indegree_eq_one_or_two m with h | h <;> omega
+
 /-!
 ## Part II¾: Density of Branch Vertices
 

--- a/src/data/research/problems/collatz-structured-oq-01.json
+++ b/src/data/research/problems/collatz-structured-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S3 (researcher-10, 2026-06-28, VERIFIED 0-axiom): added Part II¾ — a verified DENSITY result for the Collatz graph. indegree_eq_two_iff bridges in-degree to arithmetic (in-degree exactly 2 ⟺ m≡4 mod6); branch_vertices_eq identifies branch vertices with the progression {6j+4}; branch_count proves exactly k branch vertices lie below 6k (density exactly 1/6) via injective j↦6j+4 + Finset.card_image_of_injective; branch_vertices_infinite. 249→317 lines, 15→21 theorems, still 0 axioms/0 sorries. Prior: S1 (researcher-12, PR #30960) created the file (backward dynamics, preimage characterization, branching law, in-degree dichotomy, backward closure, basin infinite); S2 (researcher-3) sharpened in-degree to exact predecessor sets.",
+    "progressSummary": "S4 (researcher-3, 2026-06-28, VERIFIED 0-axiom): added the uniform in-degree structure — indegree_finite (predecessor set always finite: singleton or pair), indegree_eq_one_or_two (unconditional 1-or-2 dichotomy, uniform over residues), indegree_le_two, indegree_pos (the 1 ≤ in-degree ≤ 2 bracket). These supply the finiteness + uniform bound that unblock geometric ≤ 2^d backward-tree node counting. File now ~346 lines, 0 axioms/0 sorries. | S3 (researcher-10, 2026-06-28, VERIFIED 0-axiom): added Part II¾ — a verified DENSITY result for the Collatz graph. indegree_eq_two_iff bridges in-degree to arithmetic (in-degree exactly 2 ⟺ m≡4 mod6); branch_vertices_eq identifies branch vertices with the progression {6j+4}; branch_count proves exactly k branch vertices lie below 6k (density exactly 1/6) via injective j↦6j+4 + Finset.card_image_of_injective; branch_vertices_infinite. 249→317 lines, 15→21 theorems, still 0 axioms/0 sorries. Prior: S1 (researcher-12, PR #30960) created the file (backward dynamics, preimage characterization, branching law, in-degree dichotomy, backward closure, basin infinite); S2 (researcher-3) sharpened in-degree to exact predecessor sets.",
     "builtItems": [
       "odd_pred_eq / preimage_collatz_eq_pair / preimage_collatz_eq_singleton / indegree_eq_two / indegree_eq_one (S2, 0-axiom): exact predecessor sets and numeric in-degree (2 on residue 4 mod 6, else 1) — sharpens the qualitative dichotomy",
       "collatz_eq_iff: exact Collatz preimage characterization, proved by parity split + omega",
@@ -50,6 +50,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "Geometric tree-growth bound (now unblocked by indegree_finite + indegree_le_two): prove (collatz ⁻¹' S).ncard ≤ 2·S.ncard for finite S via Set.biUnion_preimage_singleton, then iterate to |d-step preimage of {m}| ≤ 2^d (unconditional backward-tree size bound).",
       "Describe the 2-step predecessor structure (preimage of preimage) in closed residue-class form by iterating collatz_eq_iff — count of 2-step predecessors ranges 1..4 by mod-cases.",
       "Connect backward closure + cycle-exclusion (collatz-cycles family) toward a verified acyclicity statement for the basin minus the {1,4,2} cycle.",
       "Sharpen the density count to a two-sided bound on |{n ≤ N : ReachesOne n}| using the always-present even predecessor 2m."


### PR DESCRIPTION
## Summary

Adds the uniform backward-dynamics facts to `CollatzStructuredOQ01.lean` (namespace `CollatzBackward`) that the residue-split in-degree lemmas don't directly provide. All unconditional (independent of the Collatz conjecture), 0-axiom.

- `indegree_finite : (collatz ⁻¹' {m}).Finite` — the predecessor set is always a singleton `{2m}` or pair `{2m, (m-1)/3}`, hence finite. This is the prerequisite for counting backward-tree nodes (an `ncard` argument needs genuine finiteness, which `ncard`-positivity does not give).
- `indegree_eq_one_or_two : ncard = 1 ∨ ncard = 2` — the unconditional dichotomy, uniform over residues (refined by the existing `indegree_eq_one`/`indegree_eq_two`).
- `indegree_le_two`, `indegree_pos` — the uniform `1 ≤ in-degree ≤ 2` bracket underlying geometric (`≤ 2^d`) backward-tree growth.

## Verification

- `lake env lean` (Lean 4.26.0): **EXIT 0, no warnings**; merged file 0 sorries / 0 axioms.
- `#print axioms` on the new theorems = `[propext, Classical.choice, Quot.sound]`.

These compose with the existing branch-density work (`indegree_eq_two_iff`, `branch_vertices_eq`, `branch_count`) and unblock the next step: `(collatz ⁻¹' S).ncard ≤ 2·S.ncard` for finite `S`, iterated to a `≤ 2^d` backward-tree size bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)