### PR TITLE
research(de-moivre-oq-01-oq-03-oq-01-oq-01): Chebyshev index map n ↦ Cₙ is a monoid homomorphism (ℤ,·) → (End,∘) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DeMoivreOQ01OQ03OQ01OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ01OQ03OQ01OQ01.lean
@@ -1,0 +1,162 @@
+/-
+# The Chebyshev index map `n ↦ Cₙ` is a monoid homomorphism `(ℤ, ·) → (End, ∘)`
+  (de-moivre-oq-01-oq-03-oq-01-oq-01)
+
+## Open Question (OQ-01 of de-moivre-oq-01-oq-03-oq-01)
+The parent `de-moivre-oq-01-oq-03-oq-01` proved the integer-index
+De Moivre–Chebyshev identity over the "unit-circle locus" `z · w = 1`:
+  `(C R n).eval (z + z⁻¹) = zⁿ + z⁻ⁿ`        for every `n : ℤ`.
+Pointwise this says the index map `n ↦ Cₙ` *acts* like the power map `z ↦ zⁿ`.
+OQ-01 asks for the **structural** upgrade: does this assemble into the full
+semigroup / group law `C_{mn} = Cₘ ∘ Cₙ`, exhibiting `n ↦ Cₙ` as a genuine
+**monoid homomorphism** `(ℤ, ·) → (End, ∘)`?
+
+## Answer: YES.
+
+The composition law itself is `Polynomial.Chebyshev.C_mul`:
+  `C R (m * n) = (C R m).comp (C R n)`        (for all `m n : ℤ`),
+with unit `C R 1 = X` (`Polynomial.Chebyshev.C_one`), the identity for `∘`.
+These are exactly the two monoid-homomorphism axioms once the target is the
+**endomorphism monoid** `Function.End R[X]` (the polynomials under composition,
+with `mul = (· ∘ ·)` and `one = id`).  We package them:
+
+  `chebyshevCEnd : ℤ →* Function.End R[X]`,  `chebyshevCEnd n = (C R n).comp ·`.
+
+Then `map_mul` *is* the composition law `C_{mn} = Cₘ ∘ Cₙ` and `map_one` *is*
+`C₁ = X`.  Because `(ℤ, ·)` is commutative the image is a commutative submonoid:
+the Chebyshev polynomials commute under composition, `Cₘ ∘ Cₙ = Cₙ ∘ Cₘ`.
+
+## The unit-circle locus made structural
+The homomorphism is conjugate to the integer power map on `z · z⁻¹ = 1`.  Nesting
+two Chebyshev evaluations is the same as a single evaluation at the product index:
+
+  `chebyshevC_nest_eval_field_int` :
+    `(C F m).eval ((C F n).eval (z + z⁻¹)) = z^{mn} + z^{-mn}`,
+
+i.e. `Cₘ(Cₙ(z + z⁻¹)) = z^{mn} + z^{-mn} = C_{mn}(z + z⁻¹)`.  So under the
+conjugating substitution `z ↦ z + z⁻¹`, the composition monoid `(End, ∘)` of
+Chebyshev polynomials is carried to the power monoid `(ℤ, ·)` acting by `z ↦ zⁿ`
+— the precise sense in which `n ↦ Cₙ` is "the power map restricted to the
+unit-circle locus".
+
+## Status
+- `0` sorries, `0` axioms, no `native_decide`.
+- New content: the bundled `MonoidHom` and the nesting/conjugacy theorem.
+  The composition law `C_mul` and unit `C_one` are cited from Mathlib; the
+  unit-circle identity is the parent's `chebyshevC_eval_field_int`.
+-/
+
+import Mathlib.RingTheory.Polynomial.Chebyshev
+import Mathlib.NumberTheory.Padics.PadicNumbers
+import Mathlib.Tactic
+import Proofs.DeMoivreOQ01OQ03OQ01
+
+namespace DeMoivreChebyshevMonoidHom
+
+open Polynomial.Chebyshev
+open DeMoivreChebyshevIntegerIndex
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: THE MONOID HOMOMORPHISM `(ℤ, ·) → (End R[X], ∘)`
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+variable (R : Type*) [CommRing R]
+
+/-- **The Chebyshev index map as a monoid homomorphism.**
+    `n ↦ (Cₙ ∘ ·)` is a monoid homomorphism from the multiplicative monoid
+    `(ℤ, ·)` to the endomorphism monoid `Function.End R[X]` (polynomials under
+    composition).  Its two structure axioms are precisely the Chebyshev
+    composition law `C R (m * n) = (C R m).comp (C R n)` (`map_mul`) and the unit
+    `C R 1 = X` (`map_one`). -/
+noncomputable def chebyshevCEnd : ℤ →* Function.End (Polynomial R) where
+  toFun n := fun p => (C R n).comp p
+  map_one' := by
+    funext p
+    show (C R 1).comp p = p
+    rw [C_one, Polynomial.X_comp]
+  map_mul' m n := by
+    funext p
+    show (C R (m * n)).comp p = (C R m).comp ((C R n).comp p)
+    rw [C_mul, Polynomial.comp_assoc]
+
+@[simp] theorem chebyshevCEnd_apply (n : ℤ) (p : Polynomial R) :
+    chebyshevCEnd R n p = (C R n).comp p := rfl
+
+/-- The homomorphism's `map_mul` *is* the Chebyshev composition law
+    `C_{mn} = Cₘ ∘ Cₙ`, recovered as a function identity on `R[X]`. -/
+theorem chebyshevCEnd_mul (m n : ℤ) :
+    chebyshevCEnd R (m * n) = chebyshevCEnd R m * chebyshevCEnd R n :=
+  (chebyshevCEnd R).map_mul m n
+
+/-- The homomorphism's `map_one` *is* the unit law `C₁ = X`: the identity
+    endomorphism of `R[X]`. -/
+theorem chebyshevCEnd_one : chebyshevCEnd R 1 = 1 :=
+  (chebyshevCEnd R).map_one
+
+/-- **The Chebyshev polynomials commute under composition.**  Because `(ℤ, ·)` is
+    commutative and `chebyshevCEnd` is a homomorphism, the image is a commutative
+    submonoid: `Cₘ ∘ Cₙ = Cₙ ∘ Cₘ` for all integer indices. -/
+theorem chebyshevC_comp_comm (m n : ℤ) :
+    (C R m).comp (C R n) = (C R n).comp (C R m) := by
+  rw [← C_mul, ← C_mul, mul_comm]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: THE UNIT-CIRCLE LOCUS — CONJUGACY TO THE POWER MONOID
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Nesting = single evaluation at the product index (field form).**
+    On the unit-circle locus `z · z⁻¹ = 1`, composing two Chebyshev evaluations
+    equals one evaluation at the product index:
+      `(C F m).eval ((C F n).eval (z + z⁻¹)) = z^{mn} + z^{-mn}`.
+    This is the structural content of the monoid homomorphism transported through
+    the conjugating substitution `z ↦ z + z⁻¹`: the composition monoid `(End, ∘)`
+    is carried to the integer power map `z ↦ zⁿ`. -/
+theorem chebyshevC_nest_eval_field_int {F : Type*} [Field F] (z : F) (hz : z ≠ 0)
+    (m n : ℤ) :
+    (C F m).eval ((C F n).eval (z + z⁻¹)) = z ^ (m * n) + (z⁻¹) ^ (m * n) := by
+  rw [← Polynomial.eval_comp, ← C_mul, chebyshevC_eval_field_int z hz (m * n)]
+
+/-- **Finite-field nesting law.** Over `ZMod p` (prime `p`), nesting Chebyshev
+    evaluations on the unit circle collapses to the product index. -/
+theorem chebyshevC_nest_eval_zmod_int (p : ℕ) [Fact p.Prime] (z : ZMod p)
+    (hz : z ≠ 0) (m n : ℤ) :
+    (C (ZMod p) m).eval ((C (ZMod p) n).eval (z + z⁻¹))
+      = z ^ (m * n) + (z⁻¹) ^ (m * n) :=
+  chebyshevC_nest_eval_field_int z hz m n
+
+/-- **p-adic nesting law.** Over `ℚ_[p]`, nesting Chebyshev evaluations on the
+    unit circle collapses to the product index. -/
+theorem chebyshevC_nest_eval_padic_int (p : ℕ) [Fact p.Prime] (z : ℚ_[p])
+    (hz : z ≠ 0) (m n : ℤ) :
+    (C ℚ_[p] m).eval ((C ℚ_[p] n).eval (z + z⁻¹))
+      = z ^ (m * n) + (z⁻¹) ^ (m * n) :=
+  chebyshevC_nest_eval_field_int z hz m n
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: CONSISTENCY CHECKS
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Over `ℝ`: nesting `C₂` after `C₃` at `z + z⁻¹` equals the index-`6` value
+    `z⁶ + z⁻⁶`, the `m = 2, n = 3` instance. -/
+example (z : ℝ) (hz : z ≠ 0) :
+    (C ℝ 2).eval ((C ℝ 3).eval (z + z⁻¹)) = z ^ (6 : ℤ) + (z⁻¹) ^ (6 : ℤ) := by
+  have h := chebyshevC_nest_eval_field_int z hz 2 3
+  norm_num at h ⊢
+  exact h
+
+/-- The homomorphism sends the zero index to the constant endomorphism `p ↦ 2`
+    (since `C R 0 = 2`), consistent with `0` not being a unit of `(ℤ, ·)`. -/
+example : chebyshevCEnd ℝ 0 = fun _ => (2 : Polynomial ℝ) := by
+  funext p
+  show (C ℝ 0).comp p = 2
+  rw [C_zero]
+  simp
+
+#check @chebyshevCEnd
+#check @chebyshevCEnd_mul
+#check @chebyshevC_nest_eval_field_int
+
+end DeMoivreChebyshevMonoidHom

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "The open question: from pointwise action to monoid homomorphism",
+    "content": "The parent proved the integer-index De Moivre–Chebyshev identity `(C R n).eval(z + z⁻¹) = zⁿ + z⁻ⁿ` for every `n ∈ ℤ` on the unit-circle locus `z·z⁻¹ = 1`. Pointwise this says the index map `n ↦ Cₙ` *acts like* the power map `z ↦ zⁿ`. The open question asks for the structural upgrade: does this assemble into the full law `C_{mn} = Cₘ ∘ Cₙ`, making `n ↦ Cₙ` a genuine monoid homomorphism `(ℤ, ·) → (End, ∘)`? The header records the answer — YES — and the strategy: the composition law `C_mul` and unit `C_one` are exactly the two homomorphism axioms in the endomorphism monoid `Function.End R[X]`.",
+    "mathContext": "$n \\mapsto C_n$ as a homomorphism $(\\mathbb{Z}, \\cdot) \\to (\\mathrm{End}\\,R[X], \\circ)$, with $C_{mn} = C_m \\circ C_n$ and $C_1 = X$.",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev polynomials of the third kind", "monoid homomorphism", "polynomial composition", "endomorphism monoid", "De Moivre's theorem"],
+    "prerequisites": ["Chebyshev polynomials", "monoids and homomorphisms", "polynomial composition"]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 49, "endLine": 57 },
+    "type": "concept",
+    "title": "Imports and namespace",
+    "content": "Imports Mathlib's Chebyshev library — supplying the composition law `Polynomial.Chebyshev.C_mul` and unit `C_one` — the p-adic numbers for the specialization, and the parent file `DeMoivreOQ01OQ03OQ01` whose `chebyshevC_eval_field_int` provides the integer-index evaluation identity. Opening `Polynomial.Chebyshev` resolves `C` to the Chebyshev polynomial of the third kind (not `Polynomial.C`, the constant embedding); `Polynomial` is deliberately left unopened to avoid that clash, so `comp_assoc`, `X_comp`, `eval_comp` are referenced fully qualified.",
+    "mathContext": "Brings in `C_mul`, `C_one`, `ℚ_[p]`, and the parent's `chebyshevC_eval_field_int`.",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib Chebyshev library", "namespace resolution"],
+    "prerequisites": ["Lean imports"]
+  },
+  {
+    "id": "ann-monoidhom-def",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 84 },
+    "type": "definition",
+    "title": "chebyshevCEnd: the bundled monoid homomorphism",
+    "content": "The headline definition: `chebyshevCEnd R : ℤ →* Function.End R[X]` sends `n` to the endomorphism `p ↦ (C R n).comp p`. Its two structure fields are the homomorphism axioms. `map_one'` unfolds to `(C R 1).comp p = p`, closed by `C_one` (`C R 1 = X`) and `X_comp` (`X.comp p = p`). `map_mul'` unfolds to `(C R (m*n)).comp p = (C R m).comp ((C R n).comp p)`, closed by `C_mul` (`C R (m*n) = (C R m).comp (C R n)`) and `comp_assoc`. The map is `noncomputable` only because Chebyshev `C` is — a definitional attribute, not a logical assumption. This is precisely the packaging the open question requests and which Mathlib leaves unbundled.",
+    "mathContext": "$\\texttt{chebyshevCEnd}\\,R : \\mathbb{Z} \\to^* \\mathrm{End}\\,R[X]$, $n \\mapsto (C_R\\,n)\\circ(-)$; `map_mul` $=$ $C_{mn} = C_m\\circ C_n$, `map_one` $=$ $C_1 = X$.",
+    "significance": "critical",
+    "relatedConcepts": ["MonoidHom", "Function.End", "polynomial composition", "C_mul", "C_one"],
+    "prerequisites": ["bundled homomorphisms", "endomorphism monoid"]
+  },
+  {
+    "id": "ann-mul-one",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 86, "endLine": 95 },
+    "type": "theorem",
+    "title": "Composition law and unit as homomorphism axioms",
+    "content": "`chebyshevCEnd_mul` is `map_mul`: `chebyshevCEnd R (m*n) = chebyshevCEnd R m * chebyshevCEnd R n`, i.e. the Chebyshev composition law `C_{mn} = Cₘ ∘ Cₙ` realised as a multiplication identity in `Function.End R[X]`. `chebyshevCEnd_one` is `map_one`: `chebyshevCEnd R 1 = 1`, i.e. the unit law `C₁ = X` realised as the identity endomorphism. Both are one-line consequences of the bundled `MonoidHom`, demonstrating that the abstract structure recovers the concrete algebraic facts.",
+    "mathContext": "$C_{mn} = C_m\\circ C_n$ and $C_1 = X$ as the `map_mul` / `map_one` of $\\texttt{chebyshevCEnd}$.",
+    "significance": "key",
+    "relatedConcepts": ["map_mul", "map_one", "composition law"],
+    "prerequisites": ["MonoidHom API"]
+  },
+  {
+    "id": "ann-comp-comm",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 97, "endLine": 102 },
+    "type": "theorem",
+    "title": "Chebyshev polynomials commute under composition",
+    "content": "`chebyshevC_comp_comm`: `(C R m).comp (C R n) = (C R n).comp (C R m)` for all integer indices. This is a free consequence of the homomorphism into a commutative source: since `(ℤ, ·)` is commutative, the image submonoid commutes. The proof rewrites both sides via `C_mul` back to `C R (m*n)` and `C R (n*m)` and finishes with `mul_comm`. It records the classical fact that the Chebyshev family is a commuting chain under composition — a Ritt-type phenomenon.",
+    "mathContext": "$C_m\\circ C_n = C_n\\circ C_m$, inherited from $mn = nm$ in $(\\mathbb{Z}, \\cdot)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["commuting polynomials", "Ritt's theorem", "commutative monoid image"],
+    "prerequisites": ["mul_comm", "C_mul"]
+  },
+  {
+    "id": "ann-nest-field",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 109, "endLine": 119 },
+    "type": "theorem",
+    "title": "Unit-circle conjugacy: nesting equals the product index",
+    "content": "`chebyshevC_nest_eval_field_int`: over any field, for `z ≠ 0` and all `m n : ℤ`, `(C F m).eval ((C F n).eval (z + z⁻¹)) = z^{mn} + z^{-mn}`. The proof is three rewrites: `← eval_comp` turns the nested evaluation into `((C F m).comp (C F n)).eval (z + z⁻¹)`, `← C_mul` collapses the composition to `(C F (m*n)).eval (z + z⁻¹)`, and the parent's `chebyshevC_eval_field_int` evaluates it to `z^{mn} + z^{-mn}`. This is the structural homomorphism transported through the conjugating substitution `z ↦ z + z⁻¹`: the composition monoid (End, ∘) is carried to the integer power map `z ↦ zⁿ`, the precise meaning of 'the power map restricted to the unit-circle locus'.",
+    "mathContext": "$C_m(C_n(z + z^{-1})) = z^{mn} + z^{-mn} = C_{mn}(z + z^{-1})$.",
+    "significance": "critical",
+    "relatedConcepts": ["eval_comp", "C_mul", "conjugacy", "power map", "unit-circle locus"],
+    "prerequisites": ["polynomial evaluation of composites", "integer-index De Moivre identity"]
+  },
+  {
+    "id": "ann-specializations",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 121, "endLine": 135 },
+    "type": "theorem",
+    "title": "Finite-field and p-adic nesting laws",
+    "content": "`chebyshevC_nest_eval_zmod_int` and `chebyshevC_nest_eval_padic_int` are one-line instantiations of the field nesting law at `ZMod p` (prime `p`) and `ℚ_[p]`. They record that the Chebyshev composition–power conjugacy holds verbatim over finite fields and the p-adics, where negative indices correspond to inverse exponentiation — the setting relevant to Chebyshev-map cryptography.",
+    "mathContext": "The nesting law $C_m(C_n(z + z^{-1})) = z^{mn} + z^{-mn}$ over $\\mathbb{F}_p$ and $\\mathbb{Q}_p$.",
+    "significance": "supporting",
+    "relatedConcepts": ["finite fields", "p-adic numbers", "Chebyshev-map cryptography"],
+    "prerequisites": ["field instances on ZMod p and ℚ_[p]"]
+  },
+  {
+    "id": "ann-consistency",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 137, "endLine": 162 },
+    "type": "insight",
+    "title": "Consistency checks",
+    "content": "Two sanity checks. Over ℝ, nesting `C₂` after `C₃` at `z + z⁻¹` returns the index-6 value `z⁶ + z⁻⁶`, the `m = 2, n = 3` instance of the nesting law. Separately, `chebyshevCEnd ℝ 0` is computed to be the constant endomorphism `p ↦ 2` (since `C 0 = 2`), consistent with `0` not being a unit of `(ℤ, ·)` — the homomorphism need not send `0` to the identity. Both use only kernel-level rewriting/`simp`, no `native_decide`.",
+    "mathContext": "$C_2(C_3(z+z^{-1})) = z^6 + z^{-6}$; $\\texttt{chebyshevCEnd}\\,0 = (p \\mapsto 2)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "C_zero", "non-unit index"],
+    "prerequisites": ["evaluation", "Chebyshev C_zero"]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+  "title": "The Chebyshev index map n ↦ Cₙ is a monoid homomorphism (ℤ, ·) → (End, ∘)",
+  "slug": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+  "description": "Closes the parent's open question: the integer-index De Moivre–Chebyshev identity (C R n).eval(z + z⁻¹) = zⁿ + z⁻ⁿ is upgraded from a pointwise statement to the full structural one. The Chebyshev composition law C R (m·n) = (C R m).comp (C R n) (Mathlib's Polynomial.Chebyshev.C_mul) and the unit C R 1 = X (C_one) are exactly the two monoid-homomorphism axioms once the target is the endomorphism monoid Function.End R[X] (polynomials under composition, mul = (· ∘ ·), one = id). They are packaged as a genuine bundled MonoidHom chebyshevCEnd : ℤ →* Function.End R[X], n ↦ (C R n).comp ·, whose map_mul IS the composition law and map_one IS the unit. Because (ℤ, ·) is commutative the image is a commutative submonoid: the Chebyshev polynomials commute under composition. The unit-circle meaning is made structural by chebyshevC_nest_eval_field_int: (C F m).eval((C F n).eval(z + z⁻¹)) = z^{mn} + z^{-mn}, so under the substitution z ↦ z + z⁻¹ the composition monoid (End, ∘) is carried to the integer power monoid (ℤ, ·). 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_polynomials",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ01OQ03OQ01OQ01.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "de-moivre",
+      "monoid-homomorphism",
+      "composition",
+      "endomorphism-monoid",
+      "integer-indices",
+      "finite-fields",
+      "p-adic",
+      "polynomials",
+      "ring-theory",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.Chebyshev.C_mul",
+        "description": "C R (m * n) = (C R m).comp (C R n): the Chebyshev composition (nesting) law over ℤ — the core algebraic fact that becomes the homomorphism's map_mul",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.C_one",
+        "description": "C R 1 = X: the index-1 Chebyshev polynomial is the identity for composition, becoming the homomorphism's map_one",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.comp_assoc",
+        "description": "(φ.comp ψ).comp χ = φ.comp (ψ.comp χ): associativity of polynomial composition, matching the associativity of Function.End multiplication",
+        "module": "Mathlib.Algebra.Polynomial.Eval.Defs"
+      },
+      {
+        "theorem": "Polynomial.eval_comp",
+        "description": "(p.comp q).eval x = p.eval (q.eval x): turns nested Chebyshev evaluations into a single composed-polynomial evaluation, the bridge to the unit-circle nesting law",
+        "module": "Mathlib.Algebra.Polynomial.Eval.Defs"
+      }
+    ],
+    "originalContributions": [
+      "chebyshevCEnd: a bundled MonoidHom ℤ →* Function.End R[X], n ↦ (C R n).comp ·, over an arbitrary commutative ring — the structural packaging the open question asks for, which Mathlib does not provide; its map_mul is the composition law C_{mn} = Cₘ ∘ Cₙ and its map_one is C₁ = X",
+      "chebyshevCEnd_mul and chebyshevCEnd_one: the composition law and unit recovered as the homomorphism's structure axioms on Function.End R[X]",
+      "chebyshevC_comp_comm: the Chebyshev polynomials commute under composition, Cₘ ∘ Cₙ = Cₙ ∘ Cₘ, a free consequence of the commutativity of (ℤ, ·)",
+      "chebyshevC_nest_eval_field_int: the unit-circle conjugacy (C F m).eval((C F n).eval(z + z⁻¹)) = z^{mn} + z^{-mn}, showing the composition monoid (End, ∘) is carried to the integer power map z ↦ zⁿ under z ↦ z + z⁻¹",
+      "chebyshevC_nest_eval_zmod_int and chebyshevC_nest_eval_padic_int: the finite-field and p-adic specializations of the nesting law, free corollaries"
+    ],
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 162,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All theorems depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms on chebyshevCEnd, chebyshevCEnd_mul, chebyshevC_nest_eval_field_int, chebyshevC_comp_comm). chebyshevCEnd is noncomputable because the Chebyshev polynomial C is noncomputable; this is a definitional attribute, not a logical assumption.",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "**From pointwise action to group law**\n\nThe parent chain built up the algebraic heart of De Moivre's theorem on the unit-circle locus $z\\cdot z^{-1} = 1$: the power map $z \\mapsto z^n$ is conjugate to evaluation of a single integer-indexed polynomial, the Chebyshev polynomial of the third kind $C_n$, giving $(C_R\\,n)(z + z^{-1}) = z^n + z^{-n}$ for every $n \\in \\mathbb{Z}$. Pointwise, this says the index map $n \\mapsto C_n$ *acts* like the power map.\n\nThe power map is more than a family of functions: it is a monoid homomorphism, $z^{mn} = (z^n)^m$. The natural question is whether the Chebyshev index map inherits that structure — whether $C_{mn} = C_m \\circ C_n$, so that $n \\mapsto C_n$ is a genuine homomorphism from the multiplicative monoid $(\\mathbb{Z}, \\cdot)$ into the monoid of polynomials under composition. This is the classical Chebyshev nesting law, and bundling it as a `MonoidHom` is the structural closure of the De Moivre orbit.",
+    "problemStatement": "**Open question (OQ-01 of de-moivre-oq-01-oq-03-oq-01):** Does the integer-index identity assemble into the full semigroup/group law $C_{mn} = C_m \\circ C_n$ over $\\mathbb{Z}$, exhibiting $n \\mapsto C_n$ as a monoid homomorphism $(\\mathbb{Z}, \\cdot) \\to (\\mathrm{End}, \\circ)$ restricted to the unit-circle locus?\n\n**Answer: YES.** The composition law $C_R(m\\cdot n) = (C_R\\,m)\\circ(C_R\\,n)$ (Mathlib's `Polynomial.Chebyshev.C_mul`) and the unit $C_R\\,1 = X$ (`C_one`) are precisely the two homomorphism axioms in the endomorphism monoid $\\mathrm{End}\\,R[X]$ (polynomials under composition). They bundle into $\\texttt{chebyshevCEnd} : \\mathbb{Z} \\to^* \\mathrm{End}\\,R[X]$, whose `map_mul` is the composition law and `map_one` the unit.",
+    "text": "The integer-index De Moivre–Chebyshev identity is upgraded from a pointwise statement to a structural one: n ↦ Cₙ is a bundled monoid homomorphism from (ℤ, ·) to the endomorphism monoid Function.End R[X] (polynomials under composition), via the Chebyshev composition law C(m·n) = Cₘ ∘ Cₙ and the unit C₁ = X. The unit-circle meaning is recovered as a conjugacy: nesting two Chebyshev evaluations at z + z⁻¹ equals one evaluation at the product index, z^{mn} + z^{-mn}.",
+    "proofStrategy": "**Strategy**\n\n1. **Identify the target monoid.** Polynomials under composition form the endomorphism monoid `Function.End R[X]`, with `mul = (· ∘ ·)` and `one = id`. The index map sends $n$ to the endomorphism $p \\mapsto (C_R\\,n)\\circ p$.\n\n2. **Verify the two axioms from Mathlib.** `map_one'` is $C_R\\,1 = X$ together with `X_comp : X.comp p = p`, so the index-1 endomorphism is the identity. `map_mul'` is the Chebyshev composition law `C_mul : C_R(m\\cdot n) = (C_R\\,m).comp(C_R\\,n)` together with `comp_assoc`, matching the associativity of `Function.End` multiplication. Both reduce to definitional unfolding plus a single rewrite.\n\n3. **Free consequences.** `chebyshevCEnd_mul` and `chebyshevCEnd_one` are `map_mul` / `map_one`. Commutativity of the image, `chebyshevC_comp_comm`, follows from `mul_comm` in $(\\mathbb{Z}, \\cdot)$.\n\n4. **The unit-circle conjugacy.** `chebyshevC_nest_eval_field_int` rewrites the nested evaluation $(C_F\\,m)((C_F\\,n)(x))$ as $((C_F\\,m)\\circ(C_F\\,n))(x) = C_F(m\\cdot n)(x)$ via `eval_comp` and `C_mul`, then applies the parent's integer-index identity to get $z^{mn} + z^{-mn}$. Finite-field and p-adic versions are one-line instantiations."
+    ,
+    "keyInsights": [
+      "**Composition is the hidden group law.** The pointwise identity Cₙ(z + z⁻¹) = zⁿ + z⁻ⁿ already says n ↦ Cₙ acts like z ↦ zⁿ; the structural fact C_{mn} = Cₘ ∘ Cₙ promotes 'acts like' to 'is a homomorphism into (End, ∘)'.",
+      "**The right codomain is Function.End, not the ring.** Polynomials carry two products — ring multiplication and composition. The monoid-homomorphism statement only makes sense in the composition monoid Function.End R[X]; bundling it there is the content Mathlib leaves unbundled.",
+      "**Commutativity is inherited, not proved by hand.** Because (ℤ, ·) is commutative and the map is a homomorphism, the image automatically commutes: Cₘ ∘ Cₙ = Cₙ ∘ Cₘ for all integer indices.",
+      "**Conjugacy makes the unit circle structural.** Under z ↦ z + z⁻¹, nesting Chebyshev evaluations equals a single evaluation at the product index — the composition monoid (End, ∘) is literally carried to the integer power map z ↦ zⁿ, which is the precise meaning of 'the power map restricted to the unit-circle locus'.",
+      "**Mathlib already had the algebra; the work is the packaging.** C_mul and C_one supply the mathematics; the original contribution is recognising them as homomorphism axioms in the correct monoid and assembling the bundled MonoidHom over an arbitrary commutative ring."
+    ],
+    "prerequisites": [
+      "The parent's integer-index identity (C F n).eval(z + z⁻¹) = zⁿ + z⁻ⁿ for all n ∈ ℤ",
+      "Chebyshev polynomials of the third kind over ℤ and the composition law C(m·n) = Cₘ ∘ Cₙ",
+      "Polynomial composition: associativity (comp_assoc), X as identity (X_comp), and eval_comp",
+      "The endomorphism monoid Function.End α (mul = ∘, one = id) and bundled MonoidHom"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports",
+      "summary": "Imports Mathlib's Chebyshev polynomial library (providing C_mul, C_one), the p-adic numbers, and the parent file providing the integer-index evaluation identity.",
+      "startLine": 48,
+      "endLine": 53,
+      "mathContext": "Brings in `Polynomial.Chebyshev.C` with the composition law `C_mul` and unit `C_one`, `ℚ_[p]`, and the parent's `chebyshevC_eval_field_int`."
+    },
+    {
+      "id": "monoid-hom",
+      "title": "The Monoid Homomorphism (ℤ, ·) → (End R[X], ∘)",
+      "summary": "Defines chebyshevCEnd : ℤ →* Function.End R[X], n ↦ (C R n).comp ·, with map_one from C_one/X_comp and map_mul from C_mul/comp_assoc. Extracts chebyshevCEnd_mul, chebyshevCEnd_one, and the composition-commutativity corollary.",
+      "startLine": 58,
+      "endLine": 108,
+      "mathContext": "The bundled homomorphism whose structure axioms are the Chebyshev composition law $C_{mn} = C_m\\circ C_n$ and unit $C_1 = X$; the image is a commutative submonoid of $\\mathrm{End}\\,R[X]$."
+    },
+    {
+      "id": "unit-circle",
+      "title": "The Unit-Circle Locus — Conjugacy to the Power Monoid",
+      "summary": "Proves chebyshevC_nest_eval_field_int: (C F m).eval((C F n).eval(z + z⁻¹)) = z^{mn} + z^{-mn}, with finite-field and p-adic specializations, exhibiting the composition monoid as conjugate to the integer power map.",
+      "startLine": 114,
+      "endLine": 148,
+      "mathContext": "Under $z \\mapsto z + z^{-1}$, $(C_F\\,m)\\circ(C_F\\,n)$ acts as $z \\mapsto z^{mn}$; nesting collapses to one evaluation at the product index."
+    },
+    {
+      "id": "consistency",
+      "title": "Consistency Checks",
+      "summary": "Numeric check over ℝ (C₂ after C₃ gives index 6) and the zero-index endomorphism p ↦ 2 (since C 0 = 2), confirming 0 is not a unit of (ℤ, ·).",
+      "startLine": 154,
+      "endLine": 162,
+      "mathContext": "$C_2(C_3(z + z^{-1})) = z^6 + z^{-6}$; $\\texttt{chebyshevCEnd}\\,0$ is the constant endomorphism $p \\mapsto 2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent's open question is answered affirmatively and structurally: the Chebyshev index map n ↦ Cₙ is a genuine monoid homomorphism from (ℤ, ·) into the endomorphism monoid Function.End R[X] (polynomials under composition), packaged as the bundled MonoidHom chebyshevCEnd over an arbitrary commutative ring. Its map_mul is the composition law C_{mn} = Cₘ ∘ Cₙ and its map_one is C₁ = X; the image is commutative. The unit-circle meaning is recovered as a conjugacy: nesting Chebyshev evaluations at z + z⁻¹ collapses to one evaluation at the product index, z^{mn} + z^{-mn}. 5 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+    "implications": "**Significance**\n\n1. **The De Moivre orbit is structurally closed.** Beyond the pointwise action z ↦ zⁿ, the index map is now a homomorphism into the composition monoid — the algebraic analogue of De Moivre's exponent additivity, realised as Chebyshev nesting.\n\n2. **Ring-level generality.** The homomorphism is built over any commutative ring; the unit-circle conjugacy specializes for free to ZMod p, ℚ_p, ℝ and ℂ.\n\n3. **Iteration and dynamics.** Chebyshev maps under composition are a classical commuting family (a Ritt-type phenomenon); bundling them as a homomorphic image of (ℤ, ·) is the entry point for their dynamics and for Chebyshev-map cryptographic schemes, where key composition Cₘ ∘ Cₙ = C_{mn} is exactly the homomorphism property.",
+    "openQuestions": [
+      "Does the homomorphism extend to a group action on the unit-circle locus when restricted to the units of (ℤ, ·) (i.e. ±1), and how does the commuting Chebyshev family relate to Ritt's theorem classifying commuting polynomials under composition?",
+      "Can the bundled MonoidHom be upgraded to an algebra-endomorphism-valued homomorphism ℤ →* (R[X] →ₐ[R] R[X]) via aeval, recording that each Cₙ-substitution is an R-algebra endomorphism?"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-01-oq-03-oq-01",
+      "relationship": "Parent. This closes its open question by upgrading the pointwise integer-index identity (C R n).eval(z + z⁻¹) = zⁿ + z⁻ⁿ to the structural monoid-homomorphism law C_{mn} = Cₘ ∘ Cₙ."
+    },
+    {
+      "id": "de-moivre-oq-01-oq-03",
+      "relationship": "Grandparent. Established the natural-index De Moivre–Chebyshev identity on the unit-circle locus."
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "Root De Moivre formalization; the homomorphism C_{mn} = Cₘ ∘ Cₙ is the composition-monoid analogue of De Moivre's exponent law (e^{iθ})^{mn} = ((e^{iθ})^n)^m."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Polynomial.Chebyshev",
+      "Mathlib.NumberTheory.Padics.PadicNumbers",
+      "Mathlib.Tactic",
+      "Proofs.DeMoivreOQ01OQ03OQ01"
+    ],
+    "opens": [
+      "Polynomial.Chebyshev",
+      "DeMoivreChebyshevIntegerIndex"
+    ],
+    "namespace": "DeMoivreChebyshevMonoidHom",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/DeMoivreOQ01OQ03OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "A. de Moivre",
+      "title": "Miscellanea Analytica de Seriebus et Quadraturis",
+      "year": "1730",
+      "venue": "London",
+      "note": "(cos θ + i sin θ)^n = cos(nθ) + i sin(nθ); exponent additivity is mirrored by the Chebyshev composition law"
+    },
+    {
+      "authors": "J. F. Ritt",
+      "title": "Prime and composite polynomials",
+      "year": "1922",
+      "venue": "Transactions of the American Mathematical Society 23(1), 51–66",
+      "note": "Classifies commuting polynomials under composition; the Chebyshev family Cₙ is one of the canonical commuting chains, here realised as a homomorphic image of (ℤ, ·)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-01-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "Upgrades the parent's pointwise integer-index identity to the structural monoid-homomorphism law C_{mn} = Cₘ ∘ Cₙ, bundled as chebyshevCEnd : ℤ →* Function.End R[X]"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "The Chebyshev composition law is the composition-monoid analogue of De Moivre's exponent law for (e^{iθ})ⁿ"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the open question of `de-moivre-oq-01-oq-03-oq-01`: does the integer-index De Moivre–Chebyshev identity `Cₙ(z+z⁻¹) = zⁿ + z⁻ⁿ` assemble into the full semigroup/group law `C_{mn} = Cₘ ∘ Cₙ`, exhibiting `n ↦ Cₙ` as a **monoid homomorphism `(ℤ,·) → (End,∘)`**?

**Answer: YES.** Mathlib supplies the algebra (`Polynomial.Chebyshev.C_mul`, `C_one`); the new content is recognising these as the homomorphism axioms in the endomorphism monoid `Function.End R[X]` and bundling them.

## New content

- **`chebyshevCEnd : ℤ →* Function.End R[X]`**, `n ↦ (C R n).comp ·`, over an arbitrary `CommRing` — the bundled `MonoidHom` the OQ asks for, which Mathlib leaves unbundled. Its `map_mul` **is** the composition law `C_{mn} = Cₘ ∘ Cₙ` and its `map_one` **is** the unit `C₁ = X`.
- **`chebyshevC_comp_comm`**: the Chebyshev polynomials commute under composition (`Cₘ ∘ Cₙ = Cₙ ∘ Cₘ`) — a free consequence of `(ℤ,·)` being commutative (a Ritt-type fact).
- **`chebyshevC_nest_eval_field_int`**: the unit-circle conjugacy `Cₘ(Cₙ(z+z⁻¹)) = z^{mn} + z^{-mn}`, showing the composition monoid `(End,∘)` is carried to the integer power map `z ↦ zⁿ` under `z ↦ z + z⁻¹`. Specialized to `ZMod p` and `ℚ_[p]`.

## Verification

- **5 theorems, 1 definition, 0 sorries, 0 axioms**, no `native_decide`.
- `#print axioms` on `chebyshevCEnd`, `chebyshevCEnd_mul`, `chebyshevC_nest_eval_field_int`, `chebyshevC_comp_comm` → only `propext / Classical.choice / Quot.sound`.
- Compiles via `lake env lean Proofs/DeMoivreOQ01OQ03OQ01OQ01.lean`.
- `chebyshevCEnd` is `noncomputable` (Chebyshev `C` is) — a definitional attribute, not a logical assumption.
- Gallery `meta.json` + `annotations.json` added; annotations pass `pnpm annotations:validate` (entry-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)