### PR TITLE
Enrich Banach Fixed Point Theorem (banach-fixed-point-oq-01): refine annotations 3→5

### DIFF
--- a/src/data/proofs/banach-fixed-point-oq-01/annotations.json
+++ b/src/data/proofs/banach-fixed-point-oq-01/annotations.json
@@ -20,45 +20,87 @@
     "content": "Existence and uniqueness are the foundation. `exists_fixedPoint` packages Mathlib's `ContractingWith.fixedPoint f hf` together with `fixedPoint_isFixedPt` to produce `∃ p, IsFixedPt f p`. `fixedPoint_unique_of_isFixedPt` shows any two fixed points coincide via `fixedPoint_unique'`. Crucially this uniqueness statement omits the `CompleteSpace` and `Nonempty` instances: uniqueness needs neither — it follows purely from the contraction inequality, since if f x = x and f y = y then d(x,y) = d(f x, f y) ≤ K·d(x,y) with K < 1, which forces d(x,y) = 0. Completeness and nonemptiness are only needed to guarantee a fixed point actually exists (the Picard iterates form a Cauchy sequence whose limit must lie in the space)."
   },
   {
-    "title": "Constructive convergence with a geometric rate",
-    "mathContext": "`tendsto_iterate_fixedPoint` states f^[n] x → p in the neighborhood filter 𝓝 p. The a-priori estimate `apriori_dist_iterate_fixedPoint_le` gives dist (f^[n] x) p ≤ dist x (f x) · Kⁿ / (1 − K): the right-hand side is computable from the very first step x, f x and decays geometrically. The a-posteriori estimate `dist_fixedPoint_le` is the n = 0 specialization, dist x p ≤ dist x (f x)/(1 − K). The denominator 1 − K is the sum of the geometric tail Σ_{k≥0} Kᵏ.",
+    "title": "Picard iteration: the fixed point is the limit of an algorithm",
+    "mathContext": "`tendsto_iterate` restates `ContractingWith.tendsto_iterate_fixedPoint`: for every seed x, the iterate sequence f^[n] x converges in the neighborhood filter 𝓝 p to p = `ContractingWith.fixedPoint f hf`. Convergence holds from ANY starting point — there is no basin-of-attraction restriction, because the single global contraction constant K < 1 contracts the whole space uniformly. Mechanically, d(f^[n+1] x, f^[n] x) ≤ Kⁿ · d(f x, x), so the partial sums of step displacements are dominated by the convergent geometric series Σ Kⁿ, making (f^[n] x) Cauchy.",
     "significance": "core",
     "relatedConcepts": [
       "ContractingWith.tendsto_iterate_fixedPoint",
-      "ContractingWith.apriori_dist_iterate_fixedPoint_le",
-      "ContractingWith.dist_fixedPoint_le",
-      "geometric series Σ Kⁿ = 1/(1−K)"
+      "Picard iteration f^[n] x",
+      "Filter.Tendsto and the neighborhood filter 𝓝 p",
+      "Cauchy sequences from geometric domination"
     ],
     "prerequisites": [
       "function iteration f^[n] and its convergence",
       "Filter.Tendsto and the neighborhood filter",
-      "geometric series and their tails"
+      "Cauchy sequences and completeness"
     ],
     "proofId": "banach-fixed-point-oq-01",
-    "range": { "startLine": 57, "endLine": 75 },
-    "id": "ann-banach-oq01-rate",
+    "range": { "startLine": 57, "endLine": 61 },
+    "id": "ann-banach-oq01-picard",
     "type": "insight",
-    "content": "What distinguishes Banach's theorem from purely existential fixed point theorems (Brouwer, Schauder) is that it is constructive AND quantitative. `tendsto_iterate` says the Picard iterates f^[n] x converge to p from ANY starting point x — the fixed point is the limit of an explicit algorithm. `apriori_estimate` then bounds the error before you iterate: d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K), geometric decay with ratio K. The factor 1/(1−K) is exactly the geometric series sum Σ Kᵏ that accumulates the contraction over the infinite tail of remaining steps. `aposteriori_estimate` is the n=0 instance and is the practically useful one: after a single application of f you can already certify d(x,p) ≤ d(x,fx)/(1−K), which is the standard stopping criterion in numerical fixed-point iteration."
+    "content": "What distinguishes Banach's theorem from purely existential fixed point theorems (Brouwer, Schauder) is that it is CONSTRUCTIVE: `tendsto_iterate` says the Picard iterates f^[n] x converge to p from any starting point x, so the fixed point is the explicit limit of the algorithm x, f(x), f(f(x)), …. The proof that the iterates converge is the heart of the classical theorem: consecutive steps shrink geometrically, d(f^[n+1] x, f^[n] x) ≤ Kⁿ d(f x, x), so the sequence is Cauchy (its tail displacements are bounded by the convergent series Σ Kⁿ) and completeness supplies a limit, which continuity of f forces to be a fixed point. Here that whole argument is delegated to Mathlib's `tendsto_iterate_fixedPoint`; the entry's contribution is to surface it as a named, textbook-shaped statement."
   },
   {
-    "title": "A worked example: x ↦ x/2 + c has fixed point 2c",
-    "mathContext": "`contractAffine c = fun x => x/2 + c`. To apply the abstract theorem we must discharge `ContractingWith (1/2) (contractAffine c)`. The Lipschitz half is proved by `LipschitzWith.of_dist_le_mul`: |f(x)−f(y)| = |(x−y)/2| = |x−y|/2, so distances scale by exactly 1/2. Then `contractAffine_fixedPoint` exhibits 2c as a fixed point (2c/2 + c = 2c) and pins it down as THE fixed point via `fixedPoint_unique`. The convergence and rate theorems are instantiated at this map by rewriting with the computed fixed point 2c.",
+    "title": "Geometric error control: a-priori and a-posteriori bounds",
+    "mathContext": "`apriori_estimate` restates `apriori_dist_iterate_fixedPoint_le`: dist (f^[n] x) p ≤ dist x (f x) · Kⁿ / (1 − K). The right-hand side is computable from the very first step (x, f x) and decays geometrically in n, so the accuracy after n steps is known BEFORE iterating. `aposteriori_estimate` is the n = 0 specialization (`dist_fixedPoint_le`): dist x p ≤ dist x (f x)/(1 − K). The denominator 1 − K is exactly the sum of the geometric tail Σ_{k≥0} Kᵏ that accumulates the remaining contraction.",
+    "significance": "core",
+    "relatedConcepts": [
+      "ContractingWith.apriori_dist_iterate_fixedPoint_le",
+      "ContractingWith.dist_fixedPoint_le",
+      "geometric series Σ Kⁿ = 1/(1−K)",
+      "stopping criteria in numerical analysis"
+    ],
+    "prerequisites": [
+      "geometric series and their tails",
+      "the distance dist and the triangle inequality",
+      "asymptotic / rate-of-convergence reasoning"
+    ],
+    "proofId": "banach-fixed-point-oq-01",
+    "range": { "startLine": 63, "endLine": 75 },
+    "id": "ann-banach-oq01-estimates",
+    "type": "technique",
+    "content": "Banach's theorem is not only constructive but QUANTITATIVE, and these two estimates are why it dominates numerical practice. `apriori_estimate` bounds the error before you iterate: d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K), geometric decay with ratio K, so you can pre-compute how many steps guarantee a target accuracy. The factor 1/(1−K) is precisely the geometric series Σ Kᵏ summing the contraction over the infinite tail of remaining steps. `aposteriori_estimate` is the n=0 instance and is the practically useful one: after a single application of f you can already certify d(x,p) ≤ d(x,fx)/(1−K), turning the observed one-step displacement into a guaranteed error bound — the standard stopping rule for fixed-point iteration. Together they bracket the classic 'how far am I, and how far will I be' questions of iterative solvers."
+  },
+  {
+    "title": "Recognizing a contraction in the wild: x ↦ x/2 + c is (1/2)-Lipschitz",
+    "mathContext": "`contractAffine c = fun x => x/2 + c`. The hypothesis `ContractingWith (1/2) (contractAffine c)` is `(1/2 : ℝ≥0) < 1 ∧ LipschitzWith (1/2) (contractAffine c)`. The Lipschitz half uses `LipschitzWith.of_dist_le_mul`: |f(x)−f(y)| = |(x−y)/2| = |x−y|/2 via `Real.dist_eq`, `abs_div`, and |2|=2, so distances scale by exactly 1/2. The NNReal constant must be coerced to ℝ (`((1/2 : ℝ≥0) : ℝ) = 1/2`) to compare with the real distance.",
     "significance": "supporting",
     "relatedConcepts": [
       "LipschitzWith.of_dist_le_mul",
       "Real.dist_eq and abs_div",
-      "ContractingWith.fixedPoint_unique for identifying the fixed point",
-      "NNReal coercion of the constant 1/2"
+      "NNReal coercion of the constant 1/2",
+      "affine maps and their Lipschitz constants"
     ],
     "prerequisites": [
       "affine maps on ℝ and their Lipschitz constants",
-      "solving x = x/2 + c for the fixed point",
-      "real absolute value and the metric dist x y = |x − y|"
+      "real absolute value and the metric dist x y = |x − y|",
+      "NNReal vs ℝ coercions in Lean"
     ],
     "proofId": "banach-fixed-point-oq-01",
-    "range": { "startLine": 77, "endLine": 121 },
-    "id": "ann-banach-oq01-concrete",
+    "range": { "startLine": 77, "endLine": 94 },
+    "id": "ann-banach-oq01-concrete-lipschitz",
     "type": "example",
-    "content": "The abstract theorem is only useful once you can recognize contractions in the wild, so the file closes with a fully worked instance: the affine map f(x) = x/2 + c on ℝ. `contractAffine_contracting` verifies it is (1/2)-Lipschitz — distances scale by exactly 1/2 — which combined with 1/2 < 1 gives `ContractingWith (1/2) f`. `contractAffine_fixedPoint` then computes the fixed point in closed form: solving x = x/2 + c gives x = 2c, and uniqueness from the contraction property guarantees there is no other. Finally `contractAffine_tendsto` and `contractAffine_apriori` specialize the abstract Picard convergence and geometric error bound to this map, so from any real starting point the iterates x, x/2+c, x/4+3c/2, … converge to 2c at rate (1/2)ⁿ. This is the simplest nontrivial contraction and makes every part of the abstract theorem concrete and checkable."
+    "content": "The abstract theorem is only useful once you can recognize contractions in the wild, so the file closes with a fully worked instance: the affine map f(x) = x/2 + c on ℝ. The first step is `contractAffine_contracting`, the verification that f is (1/2)-Lipschitz: rewriting with Real.dist_eq turns the goal into |(x−y)/2| ≤ (1/2)|x−y|, and since |(x−y)/2| = |x−y|/2 the distances scale by exactly 1/2. Combined with 1/2 < 1 this discharges `ContractingWith (1/2) f`, so every conclusion of the abstract theorem now applies to this map. The mildly fiddly part is the coercion bookkeeping between the NNReal contraction constant and the real-valued distance, handled by `push_cast`."
+  },
+  {
+    "title": "Closed-form fixed point 2c and concrete geometric convergence",
+    "mathContext": "`contractAffine_fixedPoint`: solving x = x/2 + c gives x = 2c; the proof exhibits 2c as a fixed point (`IsFixedPt`, since (2c)/2 + c = 2c) and then uses `ContractingWith.fixedPoint_unique` to identify it as THE fixed point. `contractAffine_tendsto` and `contractAffine_apriori` rewrite the abstract `ContractingWith.fixedPoint … = 2c` and instantiate convergence and the a-priori bound: |f^[n] x − 2c| ≤ |x − (x/2+c)| · (1/2)ⁿ / (1 − 1/2).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ContractingWith.fixedPoint_unique for identifying the fixed point",
+      "solving x = x/2 + c for the closed-form 2c",
+      "instantiating abstract estimates at a concrete map",
+      "geometric convergence at rate (1/2)ⁿ"
+    ],
+    "prerequisites": [
+      "solving x = x/2 + c for the fixed point",
+      "rewriting with a computed equality to specialize a theorem",
+      "uniqueness of the fixed point of a contraction"
+    ],
+    "proofId": "banach-fixed-point-oq-01",
+    "range": { "startLine": 96, "endLine": 121 },
+    "id": "ann-banach-oq01-concrete-fixedpoint",
+    "type": "example",
+    "content": "With the contraction hypothesis in hand, `contractAffine_fixedPoint` computes the fixed point in closed form: solving x = x/2 + c gives x = 2c, and because a contraction has at most one fixed point, exhibiting 2c as a fixed point and invoking uniqueness pins it down completely — there is no other. The remaining two theorems make the abstract results fully concrete: `contractAffine_tendsto` specializes Picard convergence (from any real seed the iterates x, x/2+c, x/4+3c/2, … converge to 2c) and `contractAffine_apriori` specializes the geometric error bound to |f^[n] x − 2c| ≤ |x − (x/2+c)|·(1/2)ⁿ/(1−1/2). Both are obtained by rewriting the abstract `ContractingWith.fixedPoint` with the value 2c. This is the simplest nontrivial contraction and makes every part of the abstract theorem checkable by hand."
   }
 ]


### PR DESCRIPTION
Enrichment pass for `banach-fixed-point-oq-01` (quality 83, pass 0).

## Gaps addressed
The entry already had a complete overview (5 keyInsights + prerequisites), 3 well-written sections, conclusion, and 2 cross-references. The one gap against the quality targets was **annotation count: 3 vs the ≥5 minimum**, and the 3 existing annotations spanned large line ranges (one covered lines 57–75, another 77–121).

## Changes
Refined the 3 coarse annotations into **5 tightly-scoped** inline annotations at genuine logical boundaries in the Lean file:
1. Existence & uniqueness (46–55)
2. Picard iteration / constructivity (57–61)
3. A-priori & a-posteriori geometric error estimates (63–75)
4. Concrete contraction verification — x↦x/2+c is (1/2)-Lipschitz (77–94)
5. Closed-form fixed point 2c & concrete convergence (96–121)

Each annotation keeps `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. No content removed — the coarse annotations' material is preserved and sharpened, with tighter ranges so each theorem group gets targeted inline commentary.

## Verification
- `pnpm build` passes.
- annotations.json valid; 5 annotations with non-overlapping ranges covering lines 46–121.
- meta.json unchanged (already complete, 10.8 KB, under cap).