### PR TITLE
Enrich Binary GCD symmetry (OQ-02): add index.ts + annotation coverage

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04-oq-02/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "comm-aux-strong-induction",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 75
+    },
+    "type": "tactic",
+    "title": "Fueled strong-induction core of symmetry",
+    "content": "binaryGcdSteps_comm_aux is the engine behind symmetry. Rather than re-deriving the algorithm's well-founded recursion, it threads an explicit fuel parameter n with the hypothesis a + b ≤ n and inducts on n. The a = 0 and b = 0 base branches simplify directly; the (a'+1, b'+1) branch unfolds BOTH orientations with binaryGcdSteps.eq_3 and aligns their if-trees with split_ifs. A lt_trichotomy on a' vs b' splits the odd/odd case three ways: the equal case a' = b' makes both orientations produce the identical if-tree (rfl), while a' < b' and a' > b' are mirror transposes — every impossible branch is killed by `exfalso; omega` and every surviving recursive pair is closed by `congr 1; apply ih; omega` because each call strictly shrinks a + b.",
+    "mathContext": "\\\\forall n\\\\,a\\\\,b,\\\\ a+b \\\\le n \\\\Rightarrow \\\\text{binaryGcdSteps}(a,b) = \\\\text{binaryGcdSteps}(b,a)",
+    "significance": "key",
+    "relatedConcepts": [
+      "strong induction",
+      "fuel parameter",
+      "well-founded recursion",
+      "trichotomy",
+      "split_ifs"
+    ],
+    "prerequisites": [
+      "strong induction on ℕ",
+      "equation lemmas for recursive definitions"
+    ]
+  },
+  {
     "id": "symmetry",
     "proofId": "binary-gcd-oq-01-oq-04-oq-02",
     "range": {
@@ -8,7 +32,7 @@
     },
     "type": "theorem",
     "title": "Symmetry of the Binary GCD step count",
-    "content": "binaryGcdSteps a b = binaryGcdSteps b a. Stein's recursion treats its two arguments symmetrically (the even/odd reductions and the subtract-smaller-from-larger rule are swap-invariant), so the step count does not depend on argument order. Proved by strong induction on a + b: both orientations of the (a+1, b+1) branch are unfolded and matched case by case, with a trichotomy isolating the odd/odd equal case.",
+    "content": "binaryGcdSteps a b = binaryGcdSteps b a. Stein's recursion treats its two arguments symmetrically (the even/odd reductions and the subtract-smaller-from-larger rule are swap-invariant), so the step count does not depend on argument order. The public theorem is a one-line wrapper that instantiates the fueled core at n = a + b. Proved by strong induction on a + b: both orientations of the (a+1, b+1) branch are unfolded and matched case by case, with a trichotomy isolating the odd/odd equal case.",
     "mathContext": "\\\\text{binaryGcdSteps}(a,b) = \\\\text{binaryGcdSteps}(b,a)",
     "significance": "key",
     "relatedConcepts": [
@@ -37,6 +61,25 @@
     ]
   },
   {
+    "id": "dyadic-block-constancy",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 94,
+      "endLine": 99
+    },
+    "type": "theorem",
+    "title": "Dyadic-block constancy of the b = 1 cost",
+    "content": "binaryGcdSteps a 1 = n + 1 for every a in the half-open dyadic block [2^n, 2^(n+1)). Because the b = 1 cost equals Nat.log 2 a + 1, it depends on a only through its bit-length and is therefore constant on each power-of-two block. The worst case below 2^N is thus an entire top block, now living in the first argument (the mirror of OQ-01's statement about the second argument). Proved by commuting the arguments and invoking OQ-01's dyadic lemma.",
+    "mathContext": "2^n \\\\le a < 2^{n+1} \\\\Rightarrow \\\\text{binaryGcdSteps}(a,1) = n+1",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "dyadic blocks",
+      "bit-length",
+      "step function",
+      "worst case"
+    ]
+  },
+  {
     "id": "transposed-family",
     "proofId": "binary-gcd-oq-01-oq-04-oq-02",
     "range": {
@@ -47,11 +90,29 @@
     "title": "Transposed worst-case family",
     "content": "binaryGcdSteps (2^n - 1) 1 = n: the transpose of the parent's worst-case family (1, 2^n - 1), recovered as a corollary of symmetry and the b = 1 closed form.",
     "mathContext": "\\\\text{binaryGcdSteps}(2^n-1,\\\\,1) = n",
-    "significance": "standard",
+    "significance": "supporting",
     "relatedConcepts": [
       "Mersenne numbers",
       "worst case",
       "tight bounds"
+    ]
+  },
+  {
+    "id": "symbolic-cross-checks",
+    "proofId": "binary-gcd-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 117,
+      "endLine": 123
+    },
+    "type": "insight",
+    "title": "Axiom-free symbolic cross-checks",
+    "content": "Two concrete spot checks that exercise the new theorems without ever calling decide or native_decide. binaryGcdSteps 12 8 = binaryGcdSteps 8 12 is discharged directly by the symmetry theorem on an asymmetric pair, and binaryGcdSteps 7 1 = 3 is obtained by rewriting 7 = 2^3 - 1 and applying the transposed worst-case corollary. Keeping the checks symbolic means the whole file avoids the Lean.ofReduceBool axiom and rests only on the foundational propext / Classical.choice / Quot.sound.",
+    "mathContext": "\\\\text{binaryGcdSteps}(12,8) = \\\\text{binaryGcdSteps}(8,12); \\\\quad \\\\text{binaryGcdSteps}(7,1) = 3",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "axiom-free verification",
+      "symbolic evaluation",
+      "Lean.ofReduceBool"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `binary-gcd-oq-01-oq-04-oq-02`.

## Changes
- **Created missing `index.ts`** — the entry had no Vite entry point, so its page rendered "proof not found" on the live site despite appearing in the gallery listing. Now wired with the standard `?raw` Lean-source import.
- **Annotations 3 → 6** (all with `mathContext`, `significance`, `relatedConcepts`):
  - `comm-aux-strong-induction` (lines 50–75) — the fueled strong-induction core that actually carries the symmetry proof (fuel parameter, `lt_trichotomy`, `split_ifs`, the mirror-transpose case structure).
  - `dyadic-block-constancy` (lines 94–99) — the `b = 1` cost is constant `n+1` on each dyadic block `[2^n, 2^(n+1))`.
  - `symbolic-cross-checks` (lines 117–123) — the axiom-free spot checks and why staying symbolic avoids `Lean.ofReduceBool`.

## Verification
- `pnpm gallery:check-size` — within caps (meta.json 13.4 KB ≤ 60 KB).
- `tsc -b` — 0 errors.
- meta.json + annotations.json parse as valid JSON.
- Gallery prebuild (`annotations:build`/`research:enrich`) processes the entry.

meta.json was already rich (6 keyInsights, full overview/conclusion/sections/crossReferences) and left unchanged — this pass focused on the missing entry point and annotation coverage, the two real gaps.