### PR TITLE
research(erdos-1-oq-02-incomplete-01): second-moment identity + Chebyshev tail toward axiom discharge [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -139,6 +139,87 @@ axiom anticoncentration_bound (A : Finset ℕ) (hDSS : hasDistinctSubsetSums A)
     (hpos : 0 < A.card) :
     (2 : ℝ) ^ A.card ≤ 3 * Real.sqrt (↑(A.sum (fun a => a ^ 2))) + 2
 
+/-! ## Verified ingredients toward discharging `anticoncentration_bound`
+
+The axiom above isolates the anticoncentration estimate `2ⁿ ≤ 3√Q + 2`
+(`Q = Σaᵢ²`).  Its standard proofs go through probability theory (Chebyshev on the
+random subset sum).  The two lemmas below are the *probability-free* core of an
+elementary discharge, both fully verified (0 axioms):
+
+* `second_moment_identity` — the exact second-moment identity over the powerset,
+  `∑_{T ⊆ A} (2·(Σ_{i∈T} i) − Σ_{i∈A} i)² = 2^{|A|} · Σ_{i∈A} i²`.  This is the
+  discrete variance computation (`Var = Q/4` rescaled by `2ⁿ`, doubled to stay in
+  `ℤ`), proved by induction on `A`: inserting a new element `a` doubles the
+  powerset and replaces each drop `d` by the pair `d ± a`, and
+  `(d−a)² + (d+a)² = 2d² + 2a²` gives the `f(A∪{a}) = 2 f(A) + 2^{|A|+1} a²`
+  recurrence that matches `2^{|A|} Q`.
+* `card_mul_le_second_moment` — the elementary discrete Chebyshev/Markov count:
+  for nonnegative `g`, `#{i : t ≤ g i} · t ≤ ∑ g i`.  Applied to
+  `g T = (2·(Σ_{i∈T} i) − S)²` this bounds how many subset sums lie far from the
+  mean.
+
+**Remaining step (and a constant correction).** To finish the discharge one combines
+these with the fact that the `2ⁿ` subset sums of a distinct-subset-sums set are
+*distinct integers* of one fixed parity (`2·(Σ_T) − S ≡ S mod 2`).  Counting the
+distinct same-parity integers inside the central interval `|2·Σ_T − S| < t` gives
+`≤ t + 1`, and with `t = 2√Q` the Chebyshev tail removes a `2ⁿ/4` fraction, leaving
+`(3/4)·2ⁿ ≤ 2√Q + 1`, i.e. `2ⁿ ≤ (8√Q + 4)/3 ≤ 3√Q + 2` — the axiom's constant.
+NOTE: the *pure* second-moment route (lower-bounding `∑(2Σ_T − S)² ≥ (M³−M)/12`
+for `M = 2ⁿ` distinct integers) only yields `2ⁿ ≤ √(12Q + 1) ≈ 3.46√Q`, which is
+**weaker** than `3√Q + 2`; the central-interval-count step (using parity) is what
+recovers the sharper constant `3`. -/
+
+/-- **Second-moment identity over the powerset (0 axioms).**  For any finite set
+`A` of naturals, the doubled deviations `2·(Σ_{i∈T} i) − S` (where `S = Σ_{i∈A} i`)
+have second moment exactly `2^{|A|} · Σ_{i∈A} i²` when summed over all subsets `T`.
+This is the discrete variance computation at the heart of the DFX anticoncentration
+bound, kept in `ℤ` via doubling to avoid the half-integer mean. -/
+theorem second_moment_identity (A : Finset ℕ) :
+    ∑ T ∈ A.powerset, (2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ A, (i : ℤ)) ^ 2
+      = 2 ^ A.card * ∑ i ∈ A, (i : ℤ) ^ 2 := by
+  induction A using Finset.induction with
+  | empty => simp
+  | @insert a s ha ih =>
+    rw [Finset.sum_powerset_insert ha]
+    have hS : (∑ i ∈ insert a s, (i : ℤ)) = (a : ℤ) + ∑ i ∈ s, (i : ℤ) := by
+      rw [Finset.sum_insert ha]
+    have h1 : ∑ T ∈ s.powerset, (2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ insert a s, (i : ℤ)) ^ 2
+        = ∑ T ∈ s.powerset, ((2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ s, (i : ℤ)) - a) ^ 2 := by
+      refine Finset.sum_congr rfl (fun T _ => ?_)
+      rw [hS]; ring
+    have h2 : ∑ T ∈ s.powerset, (2 * (∑ i ∈ insert a T, (i : ℤ)) - ∑ i ∈ insert a s, (i : ℤ)) ^ 2
+        = ∑ T ∈ s.powerset, ((2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ s, (i : ℤ)) + a) ^ 2 := by
+      refine Finset.sum_congr rfl (fun T hT => ?_)
+      have haT : a ∉ T := fun h => ha (Finset.mem_powerset.mp hT h)
+      rw [hS, Finset.sum_insert haT]; ring
+    rw [h1, h2, ← Finset.sum_add_distrib]
+    have hcomb : ∀ T : Finset ℕ,
+        ((2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ s, (i : ℤ)) - a) ^ 2
+          + ((2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ s, (i : ℤ)) + a) ^ 2
+        = 2 * (2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ s, (i : ℤ)) ^ 2 + 2 * (a : ℤ) ^ 2 :=
+      fun T => by ring
+    rw [Finset.sum_congr rfl (fun T _ => hcomb T), Finset.sum_add_distrib,
+      ← Finset.mul_sum, ih, Finset.sum_const, Finset.card_powerset,
+      Finset.card_insert_of_notMem ha, Finset.sum_insert ha]
+    ring
+
+/-- **Discrete Chebyshev/Markov count (0 axioms).**  For a nonnegative integer
+weight `g` and a positive threshold `t`, the number of indices with `g i ≥ t`,
+times `t`, is at most the total weight `∑ g i`.  Specialised to
+`g T = (2·Σ_{i∈T} i − S)²` this is the tail count feeding the anticoncentration
+estimate. -/
+theorem card_mul_le_second_moment (s : Finset ℕ) (g : ℕ → ℤ)
+    (hg : ∀ i ∈ s, 0 ≤ g i) (t : ℤ) :
+    ((s.filter (fun i => t ≤ g i)).card : ℤ) * t ≤ ∑ i ∈ s, g i := by
+  calc ((s.filter (fun i => t ≤ g i)).card : ℤ) * t
+      = ∑ _i ∈ s.filter (fun i => t ≤ g i), t := by
+        rw [Finset.sum_const, nsmul_eq_mul]
+    _ ≤ ∑ i ∈ s.filter (fun i => t ≤ g i), g i :=
+        Finset.sum_le_sum (fun i hi => (Finset.mem_filter.mp hi).2)
+    _ ≤ ∑ i ∈ s, g i :=
+        Finset.sum_le_sum_of_subset_of_nonneg (Finset.filter_subset _ _)
+          (fun i hi _ => hg i hi)
+
 /-- **DFX Lower Bound Statement** (Chebyshev constant): If A ⊆ {1,...,N} has n ≥ 1
     elements with distinct subset sums, then:
       2ⁿ ≤ 3·√n·N + 2,    equivalently    N ≥ (2ⁿ − 2) / (3·√n).
@@ -225,6 +306,10 @@ The DFX framework is formalized with:
 - 0 sorries (dfx_lower_bound fully proved)
 - Variance bounds and Cauchy–Schwarz (proved)
 - Small case verifications (proved)
+- The probability-free CORE of the axiom's discharge now proved in-file
+  (`second_moment_identity` and `card_mul_le_second_moment`, both 0-axiom); only
+  the same-parity distinct-integer interval count remains to fully eliminate the
+  axiom. See the "Verified ingredients toward discharging" section above.
 
 The axiom isolates the probability theory (the variance computation plus
 Chebyshev's inequality) that requires Mathlib probability infrastructure to

--- a/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
@@ -56,3 +56,34 @@ verified lemma worth landing first; step 2's distinct-integer-spread lemma is re
    0-axiom lemma (powerset sum + off-diagonal cancellation via membership-toggle bijection).
 2. Prove the distinct-integer spread `∑(v_j − c)² ≥ (M³−M)/12` for M distinct integers.
 3. Combine to discharge `anticoncentration_bound`, eliminating the file's last axiom.
+
+## Session 2026-06-28 (researcher-2) — BUILD: landed step 1 + the Chebyshev tail (0-axiom)
+
+Added to `Erdos1OQ02.lean` (241→322 lines, +2 theorems, all 0-axiom; verified via
+`lake env lean`), in a new "Verified ingredients toward discharging" section right
+after the axiom:
+
+- **`second_moment_identity`** (step 1, DONE): `∑_{T∈A.powerset} (2·(∑_{i∈T} i) − S)²
+  = 2^|A| · Σaᵢ²` over `ℤ` (S = A.sum). Proof: `Finset.induction` + `Finset.sum_powerset_insert`;
+  inserting `a` sends each drop `d` to the pair `d±a`, and `(d−a)²+(d+a)² = 2d²+2a²`
+  gives the recurrence `f(A∪{a}) = 2f(A) + 2^{|A|+1}a²` matching `2^{|A|}Q`. Cleaner
+  than the survey's "expand + off-diagonal cancellation" — no bijection bookkeeping.
+- **`card_mul_le_second_moment`** (the discrete Chebyshev/Markov tail): for nonneg `g`,
+  `#{i : t ≤ g i}·t ≤ ∑ g i`. Elementary (`Finset.sum_le_sum_of_subset_of_nonneg`).
+
+### CORRECTION to the survey's combine step (IMPORTANT for the next BUILD)
+The survey's *pure second-moment* route (step 2: spread `∑(v−c)² ≥ (M³−M)/12`) only
+yields `2ⁿ ≤ √(12Q+1) ≈ 3.46√Q`, which is **WEAKER** than the axiom's `3√Q + 2`
+(for large Q, `√(12Q+1) − 3√Q = (√12−3)√Q → ∞`). To recover the sharp constant `3`
+you must instead use the **central-interval count**: the `2ⁿ` doubled drops
+`2·Σ_T − S` are distinct integers of one fixed parity (`≡ S mod 2`), so at most
+`t+1` of them lie in `(−t, t)`; with `t = 2√Q`, the Chebyshev tail
+(`card_mul_le_second_moment`) removes a `2ⁿ/4` fraction, leaving
+`(3/4)2ⁿ ≤ 2√Q+1`, i.e. `2ⁿ ≤ (8√Q+4)/3 ≤ 3√Q+2`. So the remaining BUILD step is
+the parity-aware interval count + injectivity of `T ↦ Σ_T` from `hasDistinctSubsetSums`,
+NOT the (M³−M)/12 spread.
+
+### GOTCHA
+`Finset.card_insert_of_not_mem` is deprecated → `Finset.card_insert_of_notMem`.
+Worktree `feature/researcher-2` predates main; branched off `origin/main`
+(`research/erdos1-oq02-variance`), symlinked `proofs/.lake`, verified `lake env lean`.

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 268,
+    "lineCount": 322,
     "assumptions": "One axiom: anticoncentration_bound (Berry-Esseen anticoncentration for subset sums). dfx_lower_bound and pow2_dss proved in 2026-04-26 commit. sum_sq_cauchy_schwarz proved via induction in Z.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -55,7 +55,7 @@
       "dfx_improves_counting: DFX bound is asymptotically better than counting bound (n < n² for n ≥ 2)",
       "Concrete cases: f(1)=1 via Finset.subset_singleton_iff, f(2)=2 via simp"
     ],
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 0
   },
   "overview": {
@@ -122,7 +122,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The DFX 2021 framework is formalized: variance bounds (Σaᵢ²≤n·N² and Cauchy–Schwarz) and a single anticoncentration axiom. The main lower bound 2ⁿ ≤ 3·√n·N + 2 (i.e. N = Ω(2ⁿ/√n)) is fully proved with 0 sorries. INTEGRITY FIX (2026-06-28): the previous anticoncentration axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was mathematically FALSE (e.g. A={1,2} makes it assert 4 ≤ 2.85), which rendered the file logically unsound; it was replaced with the true Chebyshev bound `2ⁿ ≤ 3·√Q + 2`. The file (which had also broken on the Mathlib 4.26 toolchain bump: div_le_iff→div_le_iff₀, a simp recursion, an nlinarith cast mismatch, and omega on a nonlinear goal) now compiles cleanly with 1 axiom.",
+    "summary": "The DFX 2021 framework is formalized: variance bounds (Σaᵢ²≤n·N² and Cauchy–Schwarz) and a single anticoncentration axiom. The main lower bound 2ⁿ ≤ 3·√n·N + 2 (i.e. N = Ω(2ⁿ/√n)) is fully proved with 0 sorries. INTEGRITY FIX (2026-06-28): the previous anticoncentration axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was mathematically FALSE (e.g. A={1,2} makes it assert 4 ≤ 2.85), which rendered the file logically unsound; it was replaced with the true Chebyshev bound `2ⁿ ≤ 3·√Q + 2`. The file (which had also broken on the Mathlib 4.26 toolchain bump: div_le_iff→div_le_iff₀, a simp recursion, an nlinarith cast mismatch, and omega on a nonlinear goal) now compiles cleanly with 1 axiom. Progress (2026-06-28): the probability-free core of the axiom's discharge is now proved in-file with 0 axioms — second_moment_identity (∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σaᵢ²) and card_mul_le_second_moment (discrete Chebyshev tail count). The only remaining step to eliminate the axiom is the same-parity distinct-integer central-interval count.",
     "implications": "The Dubroff-Fox-Xu result is currently the best known lower bound for Erdős's distinct subset sums problem (Problem #1, $500 prize). The gap between the lower bound ~2ⁿ/√n and the upper bound ~2ⁿ (from the Conway-Guy sequence) is a factor of √n. Closing this gap requires either a new construction (improving the upper bound) or a new anticoncentration argument (improving the lower bound). Formalizing the full Berry-Esseen step would complete the proof in Lean.",
     "openQuestions": [
       "Can the `anticoncentration_bound` axiom be proved in Lean? This requires: (1) formalizing the Bernoulli random walk on $\\{0, a_1, \\ldots, a_1 + a_2, \\ldots\\}$, (2) proving Berry-Esseen bounds for discrete distributions, (3) counting distinct sum values via the normal approximation. Mathlib's `ProbabilityTheory.ConditionalExpectation` and `CLT` developments are the entry points.",
@@ -211,13 +211,13 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 268,
+    "lineCount": 322,
     "axiomCount": 1,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/Erdos1OQ02.lean",
     "sorries": 0
   },
   "sorries": 0,
-  "assumptions": "One axiom: anticoncentration_bound — the Chebyshev anticoncentration bound 2ⁿ ≤ 3·√(Σaᵢ²) + 2 for distinct-subset-sum sets. It is unconditionally true (Chebyshev's inequality applied to X = Σ εᵢaᵢ, plus the distinctness counting argument) and in principle dischargeable from Mathlib's `ProbabilityTheory` Chebyshev lemmas. dfx_lower_bound and the variance/Cauchy–Schwarz lemmas are fully proved (0 sorries). NOTE: the earlier axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was FALSE and has been corrected."
+  "assumptions": "One axiom: anticoncentration_bound — the Chebyshev anticoncentration bound 2ⁿ ≤ 3·√(Σaᵢ²) + 2 for distinct-subset-sum sets. It is unconditionally true (Chebyshev's inequality applied to X = Σ εᵢaᵢ, plus the distinctness counting argument) and in principle dischargeable from Mathlib's `ProbabilityTheory` Chebyshev lemmas. dfx_lower_bound and the variance/Cauchy–Schwarz lemmas are fully proved (0 sorries). NOTE: the earlier axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was FALSE and has been corrected. Progress (2026-06-28): the probability-free core of the axiom's discharge is now proved in-file with 0 axioms — second_moment_identity (∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σaᵢ²) and card_mul_le_second_moment (discrete Chebyshev tail count). The only remaining step to eliminate the axiom is the same-parity distinct-integer central-interval count."
 }

--- a/src/data/research/problems/erdos-1-oq-02-incomplete-01.json
+++ b/src/data/research/problems/erdos-1-oq-02-incomplete-01.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-03-30T11:03:20-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Landed the second-moment identity + discrete Chebyshev tail (0-axiom) toward discharging anticoncentration_bound.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Parity-aware central-interval count + subset-sum injectivity to eliminate the axiom (constant 3 needs interval-count route, not the (M^3-M)/12 spread).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -60,5 +60,5 @@
     "mathlib": []
   },
   "started": "2026-03-30T18:27:56.397Z",
-  "lastUpdate": "2026-03-30T18:27:56.410Z"
+  "lastUpdate": "2026-06-28"
 }


### PR DESCRIPTION
## Summary

A BUILD step toward eliminating the **sole axiom** in `Erdos1OQ02.lean` — `anticoncentration_bound : 2^|A| ≤ 3·√(Σaᵢ²) + 2` (the Dubroff–Fox–Xu distinct-subset-sums lower bound). Adds the **probability-free core** of the axiom's discharge as two 0-axiom verified lemmas (file `241 → 322` lines). The axiom itself remains for now (full discharge is the next BUILD); status stays `axiomatized`.

## New theorems (0-axiom)

| Theorem | Statement |
|---------|-----------|
| `second_moment_identity` | `∑_{T ⊆ A} (2·(∑_{i∈T} i) − S)² = 2^{\|A\|} · ∑_{i∈A} i²` (S = A.sum) |
| `card_mul_le_second_moment` | discrete Chebyshev/Markov: for `g ≥ 0`, `#{i : t ≤ g i}·t ≤ ∑ g i` |

## Proof ideas

- **Second-moment identity:** `Finset.induction` + `Finset.sum_powerset_insert`. Inserting an element `a` doubles the powerset and sends each doubled drop `d = 2·Σ_T − S` to the pair `d ± a`; since `(d−a)² + (d+a)² = 2d² + 2a²`, the sum satisfies `f(A∪{a}) = 2·f(A) + 2^{|A|+1}·a²`, matching `2^{|A|}·Q`. This is the discrete variance computation (`Var = Q/4`, rescaled by `2ⁿ`, doubled to stay in `ℤ` and avoid the half-integer mean). Cleaner than the expand-and-cancel-off-diagonals route — no toggle bijection.
- **Chebyshev tail:** elementary, via `Finset.sum_le_sum_of_subset_of_nonneg`.

## Constant correction (recorded for the next BUILD)

The earlier survey (#31296) proposed finishing via the pure second-moment spread `∑(v−c)² ≥ (M³−M)/12`. That only yields `2ⁿ ≤ √(12Q+1) ≈ 3.46·√Q`, which is **weaker** than the axiom's `3·√Q + 2` (for large `Q`, `√(12Q+1) − 3√Q → ∞`). Recovering the sharp constant `3` requires the **parity-aware central-interval count**: the `2ⁿ` doubled drops are distinct integers of one fixed parity (`≡ S mod 2`), so `≤ t+1` lie in `(−t, t)`; with `t = 2√Q` the Chebyshev tail removes a `2ⁿ/4` fraction, giving `(3/4)2ⁿ ≤ 2√Q+1`, i.e. `2ⁿ ≤ (8√Q+4)/3 ≤ 3√Q+2`. So the remaining step is that interval count + subset-sum injectivity, **not** the `(M³−M)/12` spread. This is documented in-file and in the problem's `knowledge.md`.

## Verification

```
lake env lean Proofs/Erdos1OQ02.lean   # 0 errors (pre-existing warnings only)
#print axioms → propext, Classical.choice, Quot.sound   # both new lemmas
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)