### PR TITLE
Enrich Explicit 3×3 Cayley–Hamilton (cayley-hamilton-oq-04-oq-01): annotations 3→5

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-04-oq-01/annotations.json
@@ -26,42 +26,93 @@
     "id": "ann-ch0401-c2",
     "proofId": "cayley-hamilton-oq-04-oq-01",
     "range": {
-      "startLine": 56,
-      "endLine": 64
+      "startLine": 58,
+      "endLine": 66
     },
     "type": "definition",
     "title": "The Middle Coefficient c₂ as a Sum of Principal Minors",
-    "content": "`c2 A` is defined as (a₀₀a₁₁ − a₀₁a₁₀) + (a₀₀a₂₂ − a₀₂a₂₀) + (a₁₁a₂₂ − a₁₂a₂₁), the sum of the three 2×2 principal minors of A. This is the second elementary symmetric function e₂(λ₁,λ₂,λ₃) of the eigenvalues and the coefficient of X in the characteristic polynomial. Naming it as a definition makes the main identity read like the textbook characteristic polynomial.",
+    "content": "`c2 A` is defined as (a₀₀a₁₁ − a₀₁a₁₀) + (a₀₀a₂₂ − a₀₂a₂₀) + (a₁₁a₂₂ − a₁₂a₂₁), the sum of the three 2×2 principal minors of A. This is the second elementary symmetric function e₂(λ₁,λ₂,λ₃) of the eigenvalues and the coefficient of X in the characteristic polynomial. Naming it as a definition makes the main identity read like the textbook characteristic polynomial, and isolates the one coefficient that has no single-symbol Mathlib primitive (unlike trace and determinant).",
     "mathContext": "$c_2=\\sum_{i<j}(a_{ii}a_{jj}-a_{ij}a_{ji})=\\lambda_1\\lambda_2+\\lambda_1\\lambda_3+\\lambda_2\\lambda_3=e_2(\\lambda)$.",
     "significance": "supporting",
     "relatedConcepts": [
       "principal minors",
-      "elementary symmetric polynomials"
+      "elementary symmetric polynomials",
+      "Newton's identities (power sums ↔ symmetric functions)"
     ],
     "prerequisites": [
-      "2×2 minors of a matrix"
+      "2×2 minors of a matrix",
+      "elementary symmetric functions of eigenvalues"
     ]
   },
   {
-    "id": "ann-ch0401-main",
+    "id": "ann-ch0401-main-statement",
     "proofId": "cayley-hamilton-oq-04-oq-01",
     "range": {
-      "startLine": 66,
-      "endLine": 90
+      "startLine": 68,
+      "endLine": 73
     },
-    "type": "proof-technique",
-    "title": "Entrywise Fin 3 Expansion Closed by ring",
-    "content": "`cube_sub_trace_smul_sq_add_c2_smul_sub_det_smul` proves A³ − (tr A)·A² + c₂·A − (det A)·1 = 0 by first rewriting A³ = A·A·A and A² = A·A, then reducing to the nine scalar entries with `Matrix.ext` and `fin_cases` over Fin 3 × Fin 3. Each entry is expanded with `Matrix.mul_apply`, `Fin.sum_univ_three`, `Matrix.trace_fin_three`, `Matrix.det_fin_three`, and the smul/add/sub entry lemmas, then closed with `ring` — every entry equation is a degree-3 polynomial identity in the nine entries. `cube_eq` rearranges this to the cube reduction A³ = (tr A)·A² − c₂·A + (det A)·1 via `linear_combination (norm := module)`.",
-    "mathContext": "Entry $(i,j)$ of $A^3$ is $\\sum_{k,l}a_{ik}a_{kl}a_{lj}$; subtracting $(\\operatorname{tr}A)(A^2)_{ij}$, adding $c_2 a_{ij}$, and subtracting $(\\det A)\\delta_{ij}$ gives $0$ as a polynomial identity.",
-    "significance": "central",
+    "type": "theorem",
+    "title": "Explicit 3×3 Cayley–Hamilton Identity",
+    "content": "`cube_sub_trace_smul_sq_add_c2_smul_sub_det_smul` is the headline result: every 3×3 matrix A over any commutative ring satisfies A³ − (tr A)·A² + c₂·A − (det A)·1 = 0. This is the bare trace/minor/determinant form of Cayley–Hamilton — the matrix substituted into its own characteristic polynomial — stated for an arbitrary `CommRing R`, so it holds over ℤ, ℝ, polynomial rings, and finite rings alike, not just fields. The generality is what makes the from-scratch entrywise proof worthwhile: it avoids any reliance on eigenvalues, splitting fields, or the abstract `charpoly` machinery.",
+    "mathContext": "$A^3 - (\\operatorname{tr}A)\\,A^2 + c_2\\,A - (\\det A)\\,I = 0$, the degree-3 instance of $\\chi_A(A)=0$, valid over any commutative ring $R$.",
+    "significance": "critical",
     "relatedConcepts": [
       "Cayley-Hamilton theorem",
-      "matrix multiplication",
+      "characteristic polynomial",
+      "scalar multiplication of matrices (•)",
+      "commutative ring coefficients"
+    ],
+    "prerequisites": [
+      "matrix powers and the identity matrix",
+      "trace, determinant, and the c₂ coefficient"
+    ]
+  },
+  {
+    "id": "ann-ch0401-main-proof",
+    "proofId": "cayley-hamilton-oq-04-oq-01",
+    "range": {
+      "startLine": 74,
+      "endLine": 80
+    },
+    "type": "technique",
+    "title": "Proof: Entrywise Fin 3 Expansion Closed by ring",
+    "content": "The proof reduces the matrix equation to nine scalar polynomial identities. It first rewrites A³ = A·A·A (`pow_succ`/`pow_one`) and A² = A·A (`pow_two`), then `ext i j` followed by `fin_cases i <;> fin_cases j` splits into the nine entries of Fin 3 × Fin 3. Each entry is expanded with `Matrix.mul_apply`, `Fin.sum_univ_three`, `Matrix.trace_fin_three`, `Matrix.det_fin_three`, `c2`, and the smul/add/sub/zero entry lemmas, then closed by `ring` — every entry equation is a degree-3 polynomial identity in the nine matrix entries, exactly the kind `ring` decides. The whole theorem is therefore self-contained down to `ring`, depending on no high-level Cayley–Hamilton lemma.",
+    "mathContext": "Entry $(i,j)$ of $A^3$ is $\\sum_{k,l}a_{ik}a_{kl}a_{lj}$; subtracting $(\\operatorname{tr}A)(A^2)_{ij}$, adding $c_2 a_{ij}$, and subtracting $(\\det A)\\delta_{ij}$ gives $0$ as a polynomial identity in the nine entries.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix.mul_apply",
+      "Fin.sum_univ_three",
+      "fin_cases",
+      "the ring tactic",
       "polynomial identities"
     ],
     "prerequisites": [
       "matrix multiplication via Matrix.mul_apply",
+      "case-splitting finite indices with fin_cases",
       "the ring tactic"
+    ]
+  },
+  {
+    "id": "ann-ch0401-cube-eq",
+    "proofId": "cayley-hamilton-oq-04-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 90
+    },
+    "type": "theorem",
+    "title": "Cube Reduction: A³ as a Linear Combination of A², A, 1",
+    "content": "`cube_eq` rearranges the Cayley–Hamilton identity into the practically useful reduction A³ = (tr A)·A² − c₂·A + (det A)·1, expressing the cube of any 3×3 matrix as a linear combination of A², A, and the identity. This is the mechanism behind reducing arbitrary high powers Aⁿ of a 3×3 matrix to the basis {1, A, A²} — the standard route to closed-form matrix-power and matrix-exponential formulas. The rearrangement is one line: `linear_combination (norm := module) h`, which treats the previous identity h as a module-linear relation and lets the module-normalization discharge the smul algebra.",
+    "mathContext": "$A^3 = (\\operatorname{tr}A)\\,A^2 - c_2\\,A + (\\det A)\\,I$. Iterating expresses every $A^n$ ($n\\ge 3$) in the 3-dimensional span $\\{I, A, A^2\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "minimal/characteristic polynomial reduction",
+      "matrix power formulas",
+      "linear_combination tactic",
+      "module normalization"
+    ],
+    "prerequisites": [
+      "the main Cayley–Hamilton identity",
+      "linear_combination with a module norm"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-oq-04-oq-01` (quality 83, pass 0).

## Gap addressed
Entry already had a complete overview (5 keyInsights + prerequisites), 3 sections, conclusion, and 2 cross-references. The gap was **annotation count: 3 vs the ≥5 minimum**, with the third annotation lumping the main theorem and `cube_eq` into one 25-line range.

## Changes
Refined the 3 coarse annotations into **5 tightly-scoped** inline annotations:
1. Docstring background (6–50)
2. The c₂ coefficient definition (58–66)
3. Main identity statement — A³ − (tr A)·A² + c₂·A − (det A)·1 = 0 over any CommRing (68–73)
4. Proof technique — entrywise Fin 3 expansion closed by `ring` (74–80)
5. `cube_eq` reduction — A³ as a linear combination of A², A, 1 (82–90)

Each keeps `mathContext`, `significance`, `relatedConcepts`, `prerequisites`; ranges corrected to the actual def/theorem boundaries (the old c₂ range 56–64 was off). No content removed.

## Verification
- `pnpm build` passes.
- annotations.json valid; 5 annotations, non-overlapping ranges covering lines 6–90.
- meta.json unchanged (already complete).