### PR TITLE
research(puiseux-theorem-oq-03): termination measure + full Newton-polygon hull existence [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DeMoivreOQ01OQ03OQ01OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ01OQ03OQ01OQ01.lean
@@ -1,0 +1,162 @@
+/-
+# The Chebyshev index map `n ↦ Cₙ` is a monoid homomorphism `(ℤ, ·) → (End, ∘)`
+  (de-moivre-oq-01-oq-03-oq-01-oq-01)
+
+## Open Question (OQ-01 of de-moivre-oq-01-oq-03-oq-01)
+The parent `de-moivre-oq-01-oq-03-oq-01` proved the integer-index
+De Moivre–Chebyshev identity over the "unit-circle locus" `z · w = 1`:
+  `(C R n).eval (z + z⁻¹) = zⁿ + z⁻ⁿ`        for every `n : ℤ`.
+Pointwise this says the index map `n ↦ Cₙ` *acts* like the power map `z ↦ zⁿ`.
+OQ-01 asks for the **structural** upgrade: does this assemble into the full
+semigroup / group law `C_{mn} = Cₘ ∘ Cₙ`, exhibiting `n ↦ Cₙ` as a genuine
+**monoid homomorphism** `(ℤ, ·) → (End, ∘)`?
+
+## Answer: YES.
+
+The composition law itself is `Polynomial.Chebyshev.C_mul`:
+  `C R (m * n) = (C R m).comp (C R n)`        (for all `m n : ℤ`),
+with unit `C R 1 = X` (`Polynomial.Chebyshev.C_one`), the identity for `∘`.
+These are exactly the two monoid-homomorphism axioms once the target is the
+**endomorphism monoid** `Function.End R[X]` (the polynomials under composition,
+with `mul = (· ∘ ·)` and `one = id`).  We package them:
+
+  `chebyshevCEnd : ℤ →* Function.End R[X]`,  `chebyshevCEnd n = (C R n).comp ·`.
+
+Then `map_mul` *is* the composition law `C_{mn} = Cₘ ∘ Cₙ` and `map_one` *is*
+`C₁ = X`.  Because `(ℤ, ·)` is commutative the image is a commutative submonoid:
+the Chebyshev polynomials commute under composition, `Cₘ ∘ Cₙ = Cₙ ∘ Cₘ`.
+
+## The unit-circle locus made structural
+The homomorphism is conjugate to the integer power map on `z · z⁻¹ = 1`.  Nesting
+two Chebyshev evaluations is the same as a single evaluation at the product index:
+
+  `chebyshevC_nest_eval_field_int` :
+    `(C F m).eval ((C F n).eval (z + z⁻¹)) = z^{mn} + z^{-mn}`,
+
+i.e. `Cₘ(Cₙ(z + z⁻¹)) = z^{mn} + z^{-mn} = C_{mn}(z + z⁻¹)`.  So under the
+conjugating substitution `z ↦ z + z⁻¹`, the composition monoid `(End, ∘)` of
+Chebyshev polynomials is carried to the power monoid `(ℤ, ·)` acting by `z ↦ zⁿ`
+— the precise sense in which `n ↦ Cₙ` is "the power map restricted to the
+unit-circle locus".
+
+## Status
+- `0` sorries, `0` axioms, no `native_decide`.
+- New content: the bundled `MonoidHom` and the nesting/conjugacy theorem.
+  The composition law `C_mul` and unit `C_one` are cited from Mathlib; the
+  unit-circle identity is the parent's `chebyshevC_eval_field_int`.
+-/
+
+import Mathlib.RingTheory.Polynomial.Chebyshev
+import Mathlib.NumberTheory.Padics.PadicNumbers
+import Mathlib.Tactic
+import Proofs.DeMoivreOQ01OQ03OQ01
+
+namespace DeMoivreChebyshevMonoidHom
+
+open Polynomial.Chebyshev
+open DeMoivreChebyshevIntegerIndex
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: THE MONOID HOMOMORPHISM `(ℤ, ·) → (End R[X], ∘)`
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+variable (R : Type*) [CommRing R]
+
+/-- **The Chebyshev index map as a monoid homomorphism.**
+    `n ↦ (Cₙ ∘ ·)` is a monoid homomorphism from the multiplicative monoid
+    `(ℤ, ·)` to the endomorphism monoid `Function.End R[X]` (polynomials under
+    composition).  Its two structure axioms are precisely the Chebyshev
+    composition law `C R (m * n) = (C R m).comp (C R n)` (`map_mul`) and the unit
+    `C R 1 = X` (`map_one`). -/
+noncomputable def chebyshevCEnd : ℤ →* Function.End (Polynomial R) where
+  toFun n := fun p => (C R n).comp p
+  map_one' := by
+    funext p
+    show (C R 1).comp p = p
+    rw [C_one, Polynomial.X_comp]
+  map_mul' m n := by
+    funext p
+    show (C R (m * n)).comp p = (C R m).comp ((C R n).comp p)
+    rw [C_mul, Polynomial.comp_assoc]
+
+@[simp] theorem chebyshevCEnd_apply (n : ℤ) (p : Polynomial R) :
+    chebyshevCEnd R n p = (C R n).comp p := rfl
+
+/-- The homomorphism's `map_mul` *is* the Chebyshev composition law
+    `C_{mn} = Cₘ ∘ Cₙ`, recovered as a function identity on `R[X]`. -/
+theorem chebyshevCEnd_mul (m n : ℤ) :
+    chebyshevCEnd R (m * n) = chebyshevCEnd R m * chebyshevCEnd R n :=
+  (chebyshevCEnd R).map_mul m n
+
+/-- The homomorphism's `map_one` *is* the unit law `C₁ = X`: the identity
+    endomorphism of `R[X]`. -/
+theorem chebyshevCEnd_one : chebyshevCEnd R 1 = 1 :=
+  (chebyshevCEnd R).map_one
+
+/-- **The Chebyshev polynomials commute under composition.**  Because `(ℤ, ·)` is
+    commutative and `chebyshevCEnd` is a homomorphism, the image is a commutative
+    submonoid: `Cₘ ∘ Cₙ = Cₙ ∘ Cₘ` for all integer indices. -/
+theorem chebyshevC_comp_comm (m n : ℤ) :
+    (C R m).comp (C R n) = (C R n).comp (C R m) := by
+  rw [← C_mul, ← C_mul, mul_comm]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: THE UNIT-CIRCLE LOCUS — CONJUGACY TO THE POWER MONOID
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Nesting = single evaluation at the product index (field form).**
+    On the unit-circle locus `z · z⁻¹ = 1`, composing two Chebyshev evaluations
+    equals one evaluation at the product index:
+      `(C F m).eval ((C F n).eval (z + z⁻¹)) = z^{mn} + z^{-mn}`.
+    This is the structural content of the monoid homomorphism transported through
+    the conjugating substitution `z ↦ z + z⁻¹`: the composition monoid `(End, ∘)`
+    is carried to the integer power map `z ↦ zⁿ`. -/
+theorem chebyshevC_nest_eval_field_int {F : Type*} [Field F] (z : F) (hz : z ≠ 0)
+    (m n : ℤ) :
+    (C F m).eval ((C F n).eval (z + z⁻¹)) = z ^ (m * n) + (z⁻¹) ^ (m * n) := by
+  rw [← Polynomial.eval_comp, ← C_mul, chebyshevC_eval_field_int z hz (m * n)]
+
+/-- **Finite-field nesting law.** Over `ZMod p` (prime `p`), nesting Chebyshev
+    evaluations on the unit circle collapses to the product index. -/
+theorem chebyshevC_nest_eval_zmod_int (p : ℕ) [Fact p.Prime] (z : ZMod p)
+    (hz : z ≠ 0) (m n : ℤ) :
+    (C (ZMod p) m).eval ((C (ZMod p) n).eval (z + z⁻¹))
+      = z ^ (m * n) + (z⁻¹) ^ (m * n) :=
+  chebyshevC_nest_eval_field_int z hz m n
+
+/-- **p-adic nesting law.** Over `ℚ_[p]`, nesting Chebyshev evaluations on the
+    unit circle collapses to the product index. -/
+theorem chebyshevC_nest_eval_padic_int (p : ℕ) [Fact p.Prime] (z : ℚ_[p])
+    (hz : z ≠ 0) (m n : ℤ) :
+    (C ℚ_[p] m).eval ((C ℚ_[p] n).eval (z + z⁻¹))
+      = z ^ (m * n) + (z⁻¹) ^ (m * n) :=
+  chebyshevC_nest_eval_field_int z hz m n
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: CONSISTENCY CHECKS
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Over `ℝ`: nesting `C₂` after `C₃` at `z + z⁻¹` equals the index-`6` value
+    `z⁶ + z⁻⁶`, the `m = 2, n = 3` instance. -/
+example (z : ℝ) (hz : z ≠ 0) :
+    (C ℝ 2).eval ((C ℝ 3).eval (z + z⁻¹)) = z ^ (6 : ℤ) + (z⁻¹) ^ (6 : ℤ) := by
+  have h := chebyshevC_nest_eval_field_int z hz 2 3
+  norm_num at h ⊢
+  exact h
+
+/-- The homomorphism sends the zero index to the constant endomorphism `p ↦ 2`
+    (since `C R 0 = 2`), consistent with `0` not being a unit of `(ℤ, ·)`. -/
+example : chebyshevCEnd ℝ 0 = fun _ => (2 : Polynomial ℝ) := by
+  funext p
+  show (C ℝ 0).comp p = 2
+  rw [C_zero]
+  simp
+
+#check @chebyshevCEnd
+#check @chebyshevCEnd_mul
+#check @chebyshevC_nest_eval_field_int
+
+end DeMoivreChebyshevMonoidHom

--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -831,4 +831,117 @@ theorem threeVertex_chain_via_extend :
     (fun r hr => by fin_cases hr <;> norm_num)
     threeVertex_rightHull
 
+/-! ### Termination of the hull recursion, and existence of the full polygon
+
+`isLowerEdge_chain_extend` performs *one* peel of the Newton–Puiseux recursion but
+assumes the right sub-hull is already built.  The two results here close the loop.
+
+`filter_right_length_lt` is the **termination measure** (the deferred S2-B): peeling
+the dominant edge `p → q` and recursing on the right restriction
+`pts.filter (q.1 ≤ ·.1)` strictly shrinks the support, because the left endpoint `p`
+(index `< q.1`) is dropped.  This is exactly the well-founded measure that makes the
+divide-and-conquer hull construction terminate.
+
+`exists_spanning_chain` then runs the recursion to completion: for any support set
+with **distinct indices** (one valuation per `Y`-degree, as a genuine polynomial
+support always has) there exists a chain of lower edges of the *full* support running
+from the left endpoint all the way to the right endpoint.  This is the existence half
+of the Newton polygon — the chain that the convexity (`edgeSlopes_pairwise_le`),
+degree (`sum_edgeWidths_eq_degree`) and valuation (`sum_slope_mul_width`) theorems all
+take as given is now *built*, not assumed.  The proof *is* the verified recursion:
+peel the dominant edge (`exists_isLowerEdge_of_leftmost`), recurse on the
+strictly-smaller right restriction (terminating by `filter_right_length_lt`), and
+splice (`isLowerEdge_chain_extend`). -/
+
+/-- **Termination measure for the hull recursion (S2-B).**  If `p` is a support point
+strictly left of the cut index `q.1`, then the right restriction
+`pts.filter (q.1 ≤ ·.1)` is strictly shorter than `pts`: at least `p` is dropped.
+This is the well-founded measure underlying the Newton–Puiseux recursion — each peel
+removes the points left of the cut, and there is always at least one (the left
+endpoint). -/
+theorem filter_right_length_lt {pts : List SupportPoint} {p q : SupportPoint}
+    (hp : p ∈ pts) (hpq : p.1 < q.1) :
+    (pts.filter (fun r => decide (q.1 ≤ r.1))).length < pts.length := by
+  have hsub : List.Sublist (pts.filter (fun r => decide (q.1 ≤ r.1))) pts :=
+    List.filter_sublist
+  rcases lt_or_eq_of_le hsub.length_le with h | h
+  · exact h
+  · exfalso
+    have heq : pts.filter (fun r => decide (q.1 ≤ r.1)) = pts := hsub.eq_of_length h
+    have hmem : p ∈ pts.filter (fun r => decide (q.1 ≤ r.1)) := by rw [heq]; exact hp
+    have hge : q.1 ≤ p.1 := by simpa using (List.mem_filter.mp hmem).2
+    omega
+
+/-- **Existence of the full Newton polygon.**  Any support set with distinct indices
+admits a complete chain of lower edges of the *full* support, running from the left
+endpoint `p` (a minimum-index point) to the right endpoint `top` (a maximum-index
+point).  This is the existence theorem the rest of the file assumed: the convexity,
+degree-counting and valuation-bookkeeping results all consume a lower-edge chain, and
+this constructs one.
+
+The proof *is* the Newton–Puiseux hull recursion.  If `p = top` the polygon is a
+single point.  Otherwise peel the dominant (least-slope) edge `p → q` out of the left
+endpoint (`exists_isLowerEdge_of_leftmost`), recurse on the right restriction
+`pts.filter (q.1 ≤ ·.1)` — which has distinct indices, has `q` as its new left
+endpoint and `top` still as its right endpoint, and is strictly shorter
+(`filter_right_length_lt`, the termination measure) — and splice the dominant edge
+back on with `isLowerEdge_chain_extend`. -/
+theorem exists_spanning_chain {pts : List SupportPoint}
+    (hdist : ∀ a ∈ pts, ∀ b ∈ pts, a.1 = b.1 → a = b) {p top : SupportPoint}
+    (hp : p ∈ pts) (hleft : ∀ q ∈ pts, q ≠ p → p.1 < q.1)
+    (htop : top ∈ pts) (hright : ∀ q ∈ pts, q.1 ≤ top.1) :
+    ∃ vs, List.IsChain (IsLowerEdge pts) (p :: vs) ∧
+      (p :: vs).getLast (List.cons_ne_nil _ _) = top := by
+  by_cases hpt : p = top
+  · exact ⟨[], List.isChain_singleton _, by subst hpt; rfl⟩
+  · obtain ⟨q, hedge⟩ :=
+      exists_isLowerEdge_of_leftmost hp ⟨top, htop, fun h => hpt h.symm⟩ hleft
+    obtain ⟨_, hq_mem, hpq_lt, m₀, b₀, hp_line, hq_line, hsupp0⟩ := hedge
+    have hdist' : ∀ a ∈ pts.filter (fun r => decide (q.1 ≤ r.1)),
+        ∀ b ∈ pts.filter (fun r => decide (q.1 ≤ r.1)), a.1 = b.1 → a = b := by
+      intro a ha b hb hab
+      exact hdist a (List.mem_filter.mp ha).1 b (List.mem_filter.mp hb).1 hab
+    have hq_filt : q ∈ pts.filter (fun r => decide (q.1 ≤ r.1)) :=
+      List.mem_filter.mpr ⟨hq_mem, by simp⟩
+    have hleft' : ∀ r ∈ pts.filter (fun r => decide (q.1 ≤ r.1)), r ≠ q → q.1 < r.1 := by
+      intro r hr hrq
+      have hr_pts : r ∈ pts := (List.mem_filter.mp hr).1
+      have hge : q.1 ≤ r.1 := by simpa using (List.mem_filter.mp hr).2
+      rcases lt_or_eq_of_le hge with h | h
+      · exact h
+      · exact absurd (hdist r hr_pts q hq_mem h.symm) hrq
+    have htop_filt : top ∈ pts.filter (fun r => decide (q.1 ≤ r.1)) :=
+      List.mem_filter.mpr ⟨htop, by simpa using hright q hq_mem⟩
+    have hright' : ∀ r ∈ pts.filter (fun r => decide (q.1 ≤ r.1)), r.1 ≤ top.1 :=
+      fun r hr => hright r (List.mem_filter.mp hr).1
+    obtain ⟨vs, hchain', hlast'⟩ :=
+      exists_spanning_chain hdist' hq_filt hleft' htop_filt hright'
+    refine ⟨q :: vs, ?_, ?_⟩
+    · exact isLowerEdge_chain_extend hp hq_mem hpq_lt hp_line hq_line hsupp0 hchain'
+    · rw [List.getLast_cons (List.cons_ne_nil q vs)]; exact hlast'
+termination_by pts.length
+decreasing_by exact filter_right_length_lt hp hpq_lt
+
+/-! ### Worked example: the recursion terminates and builds the polygon
+
+The two theorems above, exercised on the running three-vertex example. -/
+
+/-- **Termination measure in action.**  Peeling the cut at index `1` from the
+three-vertex example drops the left endpoint `(0,2)`, so the right restriction
+`[(1,0),(3,1)]` is strictly shorter: `2 < 3`. -/
+theorem threeVertex_termination :
+    (threeVertex.filter (fun r => decide ((1 : ℕ) ≤ r.1))).length < threeVertex.length := by
+  rw [threeVertex_filter]; decide
+
+/-- **The Newton polygon of the three-vertex example, built by the recursion.**
+`exists_spanning_chain` constructs the complete lower-edge chain from the left endpoint
+`(0,2)` to the right endpoint `(3,1)` automatically — no chain supplied by hand. -/
+theorem threeVertex_exists_spanning :
+    ∃ vs, List.IsChain (IsLowerEdge threeVertex) (((0, 2) : SupportPoint) :: vs) ∧
+      (((0, 2) : SupportPoint) :: vs).getLast (List.cons_ne_nil _ _) = (3, 1) := by
+  refine exists_spanning_chain ?_ (by simp [threeVertex]) ?_ (by simp [threeVertex]) ?_
+  · intro a ha b hb hab; fin_cases ha <;> fin_cases hb <;> simp_all
+  · intro q hq hne; fin_cases hq <;> simp_all
+  · intro q hq; fin_cases hq <;> decide
+
 end PuiseuxTheoremOQ03

--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -249,3 +249,59 @@ session-4 file, missing session 5's edgeWidths). Fix: created a *separate* workt
 symlinked its `proofs/.lake` → main repo `.lake` for prebuilt oleans, edited +
 committed there. Verify recipe unchanged otherwise:
 `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean`.
+
+## Session 3 (2026-06-28, researcher-6): termination measure + full hull existence
+
+Extended the file from 834→947 lines (+3 theorems, +1 worked corollary; all still 0
+sorries / 0 axioms — `#print axioms` lists only propext/Classical.choice/Quot.sound
+on every new result). This closes the two gaps the file itself flagged: the recursion
+"never builds the chain", and S2-B (termination measure) was deferred.
+
+New content — **the recursion runs to completion**:
+
+* `filter_right_length_lt` (**S2-B, the termination measure**): for `p ∈ pts` with
+  `p.1 < q.1`, the right restriction `pts.filter (q.1 ≤ ·.1)` is strictly shorter than
+  `pts`. Proof: the filter is a `List.Sublist`, so `length ≤`; if equal,
+  `List.Sublist.eq_of_length` forces `filter = pts`, but `p` is dropped (`¬ q.1 ≤ p.1`)
+  — `omega` contradiction. This is exactly the well-founded measure for the hull
+  recursion.
+* `exists_spanning_chain` (**existence of the full Newton polygon**): for any support
+  with **distinct indices** (`∀ a b ∈ pts, a.1 = b.1 → a = b`), there is a complete
+  chain of lower edges of the *full* support from the left endpoint `p` (min index) to
+  the right endpoint `top` (max index). Proven by **the verified hull recursion itself**
+  (`termination_by pts.length`, `decreasing_by exact filter_right_length_lt hp hpq_lt`):
+  if `p = top`, single-point polygon; else peel the dominant edge `p → q`
+  (`exists_isLowerEdge_of_leftmost`), recurse on the strictly-smaller right restriction
+  (distinct indices preserved under filter; `q` is its new leftmost by distinctness;
+  `top` stays rightmost), and splice with `isLowerEdge_chain_extend`.
+* Worked examples: `threeVertex_termination` (cut at index 1 shrinks length 3→2) and
+  `threeVertex_exists_spanning` (the chain `(0,2)→(1,0)→(3,1)` is *constructed* by the
+  recursion — re-deriving the hand-built `threeVertex_chain` automatically).
+
+**Why this matters.** Every prior result in the file (`edgeSlopes_pairwise_le`,
+`sum_edgeWidths_eq_degree`, `sum_slope_mul_width`) consumes a `List.IsChain (IsLowerEdge
+pts)` as a *hypothesis*. `exists_spanning_chain` is the first theorem that *produces* one
+for an arbitrary support set, so the convexity/degree/valuation results now apply to a
+chain that genuinely exists rather than one assumed into being. Together with
+`filter_right_length_lt` this is the verified, terminating divide-and-conquer hull
+construction — the algorithmic backbone of Newton–Puiseux, modulo the still-missing
+valuation API that would connect a polynomial to its support list.
+
+### Gotchas (Lean 4 / Mathlib 4.26.0)
+
+* **`<+` sublist notation did not parse** in this file's context (`pts.filter (...) <+
+  pts` was read as `< +`). Use the explicit `List.Sublist (...) pts` instead.
+* `List.filter_sublist` takes **no explicit list argument** in this Mathlib
+  (`List.filter_sublist : (l.filter p).Sublist l`) — write `List.filter_sublist`, not
+  `List.filter_sublist _`.
+* Recursive *theorem* with `termination_by pts.length` / `decreasing_by` works cleanly;
+  the decreasing goal is literally `(filter ...).length < pts.length`, discharged by the
+  termination lemma with the in-scope `hp`/`hpq_lt`.
+
+### Distinct-indices hypothesis is honest, not a cheat
+
+`exists_spanning_chain` assumes the support has one valuation per `Y`-degree
+(`a.1 = b.1 → a = b`). This is *definitional* for a genuine polynomial support
+`{(i, v(aᵢ)) : aᵢ ≠ 0}` — each exponent `i` contributes exactly one point — so it adds
+no real strength; it is what lets `q` be the unique leftmost point of the right
+restriction so the recursion's invariants hold.

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "The open question: from pointwise action to monoid homomorphism",
+    "content": "The parent proved the integer-index De Moivre–Chebyshev identity `(C R n).eval(z + z⁻¹) = zⁿ + z⁻ⁿ` for every `n ∈ ℤ` on the unit-circle locus `z·z⁻¹ = 1`. Pointwise this says the index map `n ↦ Cₙ` *acts like* the power map `z ↦ zⁿ`. The open question asks for the structural upgrade: does this assemble into the full law `C_{mn} = Cₘ ∘ Cₙ`, making `n ↦ Cₙ` a genuine monoid homomorphism `(ℤ, ·) → (End, ∘)`? The header records the answer — YES — and the strategy: the composition law `C_mul` and unit `C_one` are exactly the two homomorphism axioms in the endomorphism monoid `Function.End R[X]`.",
+    "mathContext": "$n \\mapsto C_n$ as a homomorphism $(\\mathbb{Z}, \\cdot) \\to (\\mathrm{End}\\,R[X], \\circ)$, with $C_{mn} = C_m \\circ C_n$ and $C_1 = X$.",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev polynomials of the third kind", "monoid homomorphism", "polynomial composition", "endomorphism monoid", "De Moivre's theorem"],
+    "prerequisites": ["Chebyshev polynomials", "monoids and homomorphisms", "polynomial composition"]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 49, "endLine": 57 },
+    "type": "concept",
+    "title": "Imports and namespace",
+    "content": "Imports Mathlib's Chebyshev library — supplying the composition law `Polynomial.Chebyshev.C_mul` and unit `C_one` — the p-adic numbers for the specialization, and the parent file `DeMoivreOQ01OQ03OQ01` whose `chebyshevC_eval_field_int` provides the integer-index evaluation identity. Opening `Polynomial.Chebyshev` resolves `C` to the Chebyshev polynomial of the third kind (not `Polynomial.C`, the constant embedding); `Polynomial` is deliberately left unopened to avoid that clash, so `comp_assoc`, `X_comp`, `eval_comp` are referenced fully qualified.",
+    "mathContext": "Brings in `C_mul`, `C_one`, `ℚ_[p]`, and the parent's `chebyshevC_eval_field_int`.",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib Chebyshev library", "namespace resolution"],
+    "prerequisites": ["Lean imports"]
+  },
+  {
+    "id": "ann-monoidhom-def",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 84 },
+    "type": "definition",
+    "title": "chebyshevCEnd: the bundled monoid homomorphism",
+    "content": "The headline definition: `chebyshevCEnd R : ℤ →* Function.End R[X]` sends `n` to the endomorphism `p ↦ (C R n).comp p`. Its two structure fields are the homomorphism axioms. `map_one'` unfolds to `(C R 1).comp p = p`, closed by `C_one` (`C R 1 = X`) and `X_comp` (`X.comp p = p`). `map_mul'` unfolds to `(C R (m*n)).comp p = (C R m).comp ((C R n).comp p)`, closed by `C_mul` (`C R (m*n) = (C R m).comp (C R n)`) and `comp_assoc`. The map is `noncomputable` only because Chebyshev `C` is — a definitional attribute, not a logical assumption. This is precisely the packaging the open question requests and which Mathlib leaves unbundled.",
+    "mathContext": "$\\texttt{chebyshevCEnd}\\,R : \\mathbb{Z} \\to^* \\mathrm{End}\\,R[X]$, $n \\mapsto (C_R\\,n)\\circ(-)$; `map_mul` $=$ $C_{mn} = C_m\\circ C_n$, `map_one` $=$ $C_1 = X$.",
+    "significance": "critical",
+    "relatedConcepts": ["MonoidHom", "Function.End", "polynomial composition", "C_mul", "C_one"],
+    "prerequisites": ["bundled homomorphisms", "endomorphism monoid"]
+  },
+  {
+    "id": "ann-mul-one",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 86, "endLine": 95 },
+    "type": "theorem",
+    "title": "Composition law and unit as homomorphism axioms",
+    "content": "`chebyshevCEnd_mul` is `map_mul`: `chebyshevCEnd R (m*n) = chebyshevCEnd R m * chebyshevCEnd R n`, i.e. the Chebyshev composition law `C_{mn} = Cₘ ∘ Cₙ` realised as a multiplication identity in `Function.End R[X]`. `chebyshevCEnd_one` is `map_one`: `chebyshevCEnd R 1 = 1`, i.e. the unit law `C₁ = X` realised as the identity endomorphism. Both are one-line consequences of the bundled `MonoidHom`, demonstrating that the abstract structure recovers the concrete algebraic facts.",
+    "mathContext": "$C_{mn} = C_m\\circ C_n$ and $C_1 = X$ as the `map_mul` / `map_one` of $\\texttt{chebyshevCEnd}$.",
+    "significance": "key",
+    "relatedConcepts": ["map_mul", "map_one", "composition law"],
+    "prerequisites": ["MonoidHom API"]
+  },
+  {
+    "id": "ann-comp-comm",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 97, "endLine": 102 },
+    "type": "theorem",
+    "title": "Chebyshev polynomials commute under composition",
+    "content": "`chebyshevC_comp_comm`: `(C R m).comp (C R n) = (C R n).comp (C R m)` for all integer indices. This is a free consequence of the homomorphism into a commutative source: since `(ℤ, ·)` is commutative, the image submonoid commutes. The proof rewrites both sides via `C_mul` back to `C R (m*n)` and `C R (n*m)` and finishes with `mul_comm`. It records the classical fact that the Chebyshev family is a commuting chain under composition — a Ritt-type phenomenon.",
+    "mathContext": "$C_m\\circ C_n = C_n\\circ C_m$, inherited from $mn = nm$ in $(\\mathbb{Z}, \\cdot)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["commuting polynomials", "Ritt's theorem", "commutative monoid image"],
+    "prerequisites": ["mul_comm", "C_mul"]
+  },
+  {
+    "id": "ann-nest-field",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 109, "endLine": 119 },
+    "type": "theorem",
+    "title": "Unit-circle conjugacy: nesting equals the product index",
+    "content": "`chebyshevC_nest_eval_field_int`: over any field, for `z ≠ 0` and all `m n : ℤ`, `(C F m).eval ((C F n).eval (z + z⁻¹)) = z^{mn} + z^{-mn}`. The proof is three rewrites: `← eval_comp` turns the nested evaluation into `((C F m).comp (C F n)).eval (z + z⁻¹)`, `← C_mul` collapses the composition to `(C F (m*n)).eval (z + z⁻¹)`, and the parent's `chebyshevC_eval_field_int` evaluates it to `z^{mn} + z^{-mn}`. This is the structural homomorphism transported through the conjugating substitution `z ↦ z + z⁻¹`: the composition monoid (End, ∘) is carried to the integer power map `z ↦ zⁿ`, the precise meaning of 'the power map restricted to the unit-circle locus'.",
+    "mathContext": "$C_m(C_n(z + z^{-1})) = z^{mn} + z^{-mn} = C_{mn}(z + z^{-1})$.",
+    "significance": "critical",
+    "relatedConcepts": ["eval_comp", "C_mul", "conjugacy", "power map", "unit-circle locus"],
+    "prerequisites": ["polynomial evaluation of composites", "integer-index De Moivre identity"]
+  },
+  {
+    "id": "ann-specializations",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 121, "endLine": 135 },
+    "type": "theorem",
+    "title": "Finite-field and p-adic nesting laws",
+    "content": "`chebyshevC_nest_eval_zmod_int` and `chebyshevC_nest_eval_padic_int` are one-line instantiations of the field nesting law at `ZMod p` (prime `p`) and `ℚ_[p]`. They record that the Chebyshev composition–power conjugacy holds verbatim over finite fields and the p-adics, where negative indices correspond to inverse exponentiation — the setting relevant to Chebyshev-map cryptography.",
+    "mathContext": "The nesting law $C_m(C_n(z + z^{-1})) = z^{mn} + z^{-mn}$ over $\\mathbb{F}_p$ and $\\mathbb{Q}_p$.",
+    "significance": "supporting",
+    "relatedConcepts": ["finite fields", "p-adic numbers", "Chebyshev-map cryptography"],
+    "prerequisites": ["field instances on ZMod p and ℚ_[p]"]
+  },
+  {
+    "id": "ann-consistency",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 137, "endLine": 162 },
+    "type": "insight",
+    "title": "Consistency checks",
+    "content": "Two sanity checks. Over ℝ, nesting `C₂` after `C₃` at `z + z⁻¹` returns the index-6 value `z⁶ + z⁻⁶`, the `m = 2, n = 3` instance of the nesting law. Separately, `chebyshevCEnd ℝ 0` is computed to be the constant endomorphism `p ↦ 2` (since `C 0 = 2`), consistent with `0` not being a unit of `(ℤ, ·)` — the homomorphism need not send `0` to the identity. Both use only kernel-level rewriting/`simp`, no `native_decide`.",
+    "mathContext": "$C_2(C_3(z+z^{-1})) = z^6 + z^{-6}$; $\\texttt{chebyshevCEnd}\\,0 = (p \\mapsto 2)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "C_zero", "non-unit index"],
+    "prerequisites": ["evaluation", "Chebyshev C_zero"]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+  "title": "The Chebyshev index map n ↦ Cₙ is a monoid homomorphism (ℤ, ·) → (End, ∘)",
+  "slug": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+  "description": "Closes the parent's open question: the integer-index De Moivre–Chebyshev identity (C R n).eval(z + z⁻¹) = zⁿ + z⁻ⁿ is upgraded from a pointwise statement to the full structural one. The Chebyshev composition law C R (m·n) = (C R m).comp (C R n) (Mathlib's Polynomial.Chebyshev.C_mul) and the unit C R 1 = X (C_one) are exactly the two monoid-homomorphism axioms once the target is the endomorphism monoid Function.End R[X] (polynomials under composition, mul = (· ∘ ·), one = id). They are packaged as a genuine bundled MonoidHom chebyshevCEnd : ℤ →* Function.End R[X], n ↦ (C R n).comp ·, whose map_mul IS the composition law and map_one IS the unit. Because (ℤ, ·) is commutative the image is a commutative submonoid: the Chebyshev polynomials commute under composition. The unit-circle meaning is made structural by chebyshevC_nest_eval_field_int: (C F m).eval((C F n).eval(z + z⁻¹)) = z^{mn} + z^{-mn}, so under the substitution z ↦ z + z⁻¹ the composition monoid (End, ∘) is carried to the integer power monoid (ℤ, ·). 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_polynomials",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ01OQ03OQ01OQ01.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "de-moivre",
+      "monoid-homomorphism",
+      "composition",
+      "endomorphism-monoid",
+      "integer-indices",
+      "finite-fields",
+      "p-adic",
+      "polynomials",
+      "ring-theory",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.Chebyshev.C_mul",
+        "description": "C R (m * n) = (C R m).comp (C R n): the Chebyshev composition (nesting) law over ℤ — the core algebraic fact that becomes the homomorphism's map_mul",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.C_one",
+        "description": "C R 1 = X: the index-1 Chebyshev polynomial is the identity for composition, becoming the homomorphism's map_one",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.comp_assoc",
+        "description": "(φ.comp ψ).comp χ = φ.comp (ψ.comp χ): associativity of polynomial composition, matching the associativity of Function.End multiplication",
+        "module": "Mathlib.Algebra.Polynomial.Eval.Defs"
+      },
+      {
+        "theorem": "Polynomial.eval_comp",
+        "description": "(p.comp q).eval x = p.eval (q.eval x): turns nested Chebyshev evaluations into a single composed-polynomial evaluation, the bridge to the unit-circle nesting law",
+        "module": "Mathlib.Algebra.Polynomial.Eval.Defs"
+      }
+    ],
+    "originalContributions": [
+      "chebyshevCEnd: a bundled MonoidHom ℤ →* Function.End R[X], n ↦ (C R n).comp ·, over an arbitrary commutative ring — the structural packaging the open question asks for, which Mathlib does not provide; its map_mul is the composition law C_{mn} = Cₘ ∘ Cₙ and its map_one is C₁ = X",
+      "chebyshevCEnd_mul and chebyshevCEnd_one: the composition law and unit recovered as the homomorphism's structure axioms on Function.End R[X]",
+      "chebyshevC_comp_comm: the Chebyshev polynomials commute under composition, Cₘ ∘ Cₙ = Cₙ ∘ Cₘ, a free consequence of the commutativity of (ℤ, ·)",
+      "chebyshevC_nest_eval_field_int: the unit-circle conjugacy (C F m).eval((C F n).eval(z + z⁻¹)) = z^{mn} + z^{-mn}, showing the composition monoid (End, ∘) is carried to the integer power map z ↦ zⁿ under z ↦ z + z⁻¹",
+      "chebyshevC_nest_eval_zmod_int and chebyshevC_nest_eval_padic_int: the finite-field and p-adic specializations of the nesting law, free corollaries"
+    ],
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 162,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All theorems depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms on chebyshevCEnd, chebyshevCEnd_mul, chebyshevC_nest_eval_field_int, chebyshevC_comp_comm). chebyshevCEnd is noncomputable because the Chebyshev polynomial C is noncomputable; this is a definitional attribute, not a logical assumption.",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "**From pointwise action to group law**\n\nThe parent chain built up the algebraic heart of De Moivre's theorem on the unit-circle locus $z\\cdot z^{-1} = 1$: the power map $z \\mapsto z^n$ is conjugate to evaluation of a single integer-indexed polynomial, the Chebyshev polynomial of the third kind $C_n$, giving $(C_R\\,n)(z + z^{-1}) = z^n + z^{-n}$ for every $n \\in \\mathbb{Z}$. Pointwise, this says the index map $n \\mapsto C_n$ *acts* like the power map.\n\nThe power map is more than a family of functions: it is a monoid homomorphism, $z^{mn} = (z^n)^m$. The natural question is whether the Chebyshev index map inherits that structure — whether $C_{mn} = C_m \\circ C_n$, so that $n \\mapsto C_n$ is a genuine homomorphism from the multiplicative monoid $(\\mathbb{Z}, \\cdot)$ into the monoid of polynomials under composition. This is the classical Chebyshev nesting law, and bundling it as a `MonoidHom` is the structural closure of the De Moivre orbit.",
+    "problemStatement": "**Open question (OQ-01 of de-moivre-oq-01-oq-03-oq-01):** Does the integer-index identity assemble into the full semigroup/group law $C_{mn} = C_m \\circ C_n$ over $\\mathbb{Z}$, exhibiting $n \\mapsto C_n$ as a monoid homomorphism $(\\mathbb{Z}, \\cdot) \\to (\\mathrm{End}, \\circ)$ restricted to the unit-circle locus?\n\n**Answer: YES.** The composition law $C_R(m\\cdot n) = (C_R\\,m)\\circ(C_R\\,n)$ (Mathlib's `Polynomial.Chebyshev.C_mul`) and the unit $C_R\\,1 = X$ (`C_one`) are precisely the two homomorphism axioms in the endomorphism monoid $\\mathrm{End}\\,R[X]$ (polynomials under composition). They bundle into $\\texttt{chebyshevCEnd} : \\mathbb{Z} \\to^* \\mathrm{End}\\,R[X]$, whose `map_mul` is the composition law and `map_one` the unit.",
+    "text": "The integer-index De Moivre–Chebyshev identity is upgraded from a pointwise statement to a structural one: n ↦ Cₙ is a bundled monoid homomorphism from (ℤ, ·) to the endomorphism monoid Function.End R[X] (polynomials under composition), via the Chebyshev composition law C(m·n) = Cₘ ∘ Cₙ and the unit C₁ = X. The unit-circle meaning is recovered as a conjugacy: nesting two Chebyshev evaluations at z + z⁻¹ equals one evaluation at the product index, z^{mn} + z^{-mn}.",
+    "proofStrategy": "**Strategy**\n\n1. **Identify the target monoid.** Polynomials under composition form the endomorphism monoid `Function.End R[X]`, with `mul = (· ∘ ·)` and `one = id`. The index map sends $n$ to the endomorphism $p \\mapsto (C_R\\,n)\\circ p$.\n\n2. **Verify the two axioms from Mathlib.** `map_one'` is $C_R\\,1 = X$ together with `X_comp : X.comp p = p`, so the index-1 endomorphism is the identity. `map_mul'` is the Chebyshev composition law `C_mul : C_R(m\\cdot n) = (C_R\\,m).comp(C_R\\,n)` together with `comp_assoc`, matching the associativity of `Function.End` multiplication. Both reduce to definitional unfolding plus a single rewrite.\n\n3. **Free consequences.** `chebyshevCEnd_mul` and `chebyshevCEnd_one` are `map_mul` / `map_one`. Commutativity of the image, `chebyshevC_comp_comm`, follows from `mul_comm` in $(\\mathbb{Z}, \\cdot)$.\n\n4. **The unit-circle conjugacy.** `chebyshevC_nest_eval_field_int` rewrites the nested evaluation $(C_F\\,m)((C_F\\,n)(x))$ as $((C_F\\,m)\\circ(C_F\\,n))(x) = C_F(m\\cdot n)(x)$ via `eval_comp` and `C_mul`, then applies the parent's integer-index identity to get $z^{mn} + z^{-mn}$. Finite-field and p-adic versions are one-line instantiations."
+    ,
+    "keyInsights": [
+      "**Composition is the hidden group law.** The pointwise identity Cₙ(z + z⁻¹) = zⁿ + z⁻ⁿ already says n ↦ Cₙ acts like z ↦ zⁿ; the structural fact C_{mn} = Cₘ ∘ Cₙ promotes 'acts like' to 'is a homomorphism into (End, ∘)'.",
+      "**The right codomain is Function.End, not the ring.** Polynomials carry two products — ring multiplication and composition. The monoid-homomorphism statement only makes sense in the composition monoid Function.End R[X]; bundling it there is the content Mathlib leaves unbundled.",
+      "**Commutativity is inherited, not proved by hand.** Because (ℤ, ·) is commutative and the map is a homomorphism, the image automatically commutes: Cₘ ∘ Cₙ = Cₙ ∘ Cₘ for all integer indices.",
+      "**Conjugacy makes the unit circle structural.** Under z ↦ z + z⁻¹, nesting Chebyshev evaluations equals a single evaluation at the product index — the composition monoid (End, ∘) is literally carried to the integer power map z ↦ zⁿ, which is the precise meaning of 'the power map restricted to the unit-circle locus'.",
+      "**Mathlib already had the algebra; the work is the packaging.** C_mul and C_one supply the mathematics; the original contribution is recognising them as homomorphism axioms in the correct monoid and assembling the bundled MonoidHom over an arbitrary commutative ring."
+    ],
+    "prerequisites": [
+      "The parent's integer-index identity (C F n).eval(z + z⁻¹) = zⁿ + z⁻ⁿ for all n ∈ ℤ",
+      "Chebyshev polynomials of the third kind over ℤ and the composition law C(m·n) = Cₘ ∘ Cₙ",
+      "Polynomial composition: associativity (comp_assoc), X as identity (X_comp), and eval_comp",
+      "The endomorphism monoid Function.End α (mul = ∘, one = id) and bundled MonoidHom"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports",
+      "summary": "Imports Mathlib's Chebyshev polynomial library (providing C_mul, C_one), the p-adic numbers, and the parent file providing the integer-index evaluation identity.",
+      "startLine": 48,
+      "endLine": 53,
+      "mathContext": "Brings in `Polynomial.Chebyshev.C` with the composition law `C_mul` and unit `C_one`, `ℚ_[p]`, and the parent's `chebyshevC_eval_field_int`."
+    },
+    {
+      "id": "monoid-hom",
+      "title": "The Monoid Homomorphism (ℤ, ·) → (End R[X], ∘)",
+      "summary": "Defines chebyshevCEnd : ℤ →* Function.End R[X], n ↦ (C R n).comp ·, with map_one from C_one/X_comp and map_mul from C_mul/comp_assoc. Extracts chebyshevCEnd_mul, chebyshevCEnd_one, and the composition-commutativity corollary.",
+      "startLine": 58,
+      "endLine": 108,
+      "mathContext": "The bundled homomorphism whose structure axioms are the Chebyshev composition law $C_{mn} = C_m\\circ C_n$ and unit $C_1 = X$; the image is a commutative submonoid of $\\mathrm{End}\\,R[X]$."
+    },
+    {
+      "id": "unit-circle",
+      "title": "The Unit-Circle Locus — Conjugacy to the Power Monoid",
+      "summary": "Proves chebyshevC_nest_eval_field_int: (C F m).eval((C F n).eval(z + z⁻¹)) = z^{mn} + z^{-mn}, with finite-field and p-adic specializations, exhibiting the composition monoid as conjugate to the integer power map.",
+      "startLine": 114,
+      "endLine": 148,
+      "mathContext": "Under $z \\mapsto z + z^{-1}$, $(C_F\\,m)\\circ(C_F\\,n)$ acts as $z \\mapsto z^{mn}$; nesting collapses to one evaluation at the product index."
+    },
+    {
+      "id": "consistency",
+      "title": "Consistency Checks",
+      "summary": "Numeric check over ℝ (C₂ after C₃ gives index 6) and the zero-index endomorphism p ↦ 2 (since C 0 = 2), confirming 0 is not a unit of (ℤ, ·).",
+      "startLine": 154,
+      "endLine": 162,
+      "mathContext": "$C_2(C_3(z + z^{-1})) = z^6 + z^{-6}$; $\\texttt{chebyshevCEnd}\\,0$ is the constant endomorphism $p \\mapsto 2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent's open question is answered affirmatively and structurally: the Chebyshev index map n ↦ Cₙ is a genuine monoid homomorphism from (ℤ, ·) into the endomorphism monoid Function.End R[X] (polynomials under composition), packaged as the bundled MonoidHom chebyshevCEnd over an arbitrary commutative ring. Its map_mul is the composition law C_{mn} = Cₘ ∘ Cₙ and its map_one is C₁ = X; the image is commutative. The unit-circle meaning is recovered as a conjugacy: nesting Chebyshev evaluations at z + z⁻¹ collapses to one evaluation at the product index, z^{mn} + z^{-mn}. 5 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+    "implications": "**Significance**\n\n1. **The De Moivre orbit is structurally closed.** Beyond the pointwise action z ↦ zⁿ, the index map is now a homomorphism into the composition monoid — the algebraic analogue of De Moivre's exponent additivity, realised as Chebyshev nesting.\n\n2. **Ring-level generality.** The homomorphism is built over any commutative ring; the unit-circle conjugacy specializes for free to ZMod p, ℚ_p, ℝ and ℂ.\n\n3. **Iteration and dynamics.** Chebyshev maps under composition are a classical commuting family (a Ritt-type phenomenon); bundling them as a homomorphic image of (ℤ, ·) is the entry point for their dynamics and for Chebyshev-map cryptographic schemes, where key composition Cₘ ∘ Cₙ = C_{mn} is exactly the homomorphism property.",
+    "openQuestions": [
+      "Does the homomorphism extend to a group action on the unit-circle locus when restricted to the units of (ℤ, ·) (i.e. ±1), and how does the commuting Chebyshev family relate to Ritt's theorem classifying commuting polynomials under composition?",
+      "Can the bundled MonoidHom be upgraded to an algebra-endomorphism-valued homomorphism ℤ →* (R[X] →ₐ[R] R[X]) via aeval, recording that each Cₙ-substitution is an R-algebra endomorphism?"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-01-oq-03-oq-01",
+      "relationship": "Parent. This closes its open question by upgrading the pointwise integer-index identity (C R n).eval(z + z⁻¹) = zⁿ + z⁻ⁿ to the structural monoid-homomorphism law C_{mn} = Cₘ ∘ Cₙ."
+    },
+    {
+      "id": "de-moivre-oq-01-oq-03",
+      "relationship": "Grandparent. Established the natural-index De Moivre–Chebyshev identity on the unit-circle locus."
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "Root De Moivre formalization; the homomorphism C_{mn} = Cₘ ∘ Cₙ is the composition-monoid analogue of De Moivre's exponent law (e^{iθ})^{mn} = ((e^{iθ})^n)^m."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Polynomial.Chebyshev",
+      "Mathlib.NumberTheory.Padics.PadicNumbers",
+      "Mathlib.Tactic",
+      "Proofs.DeMoivreOQ01OQ03OQ01"
+    ],
+    "opens": [
+      "Polynomial.Chebyshev",
+      "DeMoivreChebyshevIntegerIndex"
+    ],
+    "namespace": "DeMoivreChebyshevMonoidHom",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/DeMoivreOQ01OQ03OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "A. de Moivre",
+      "title": "Miscellanea Analytica de Seriebus et Quadraturis",
+      "year": "1730",
+      "venue": "London",
+      "note": "(cos θ + i sin θ)^n = cos(nθ) + i sin(nθ); exponent additivity is mirrored by the Chebyshev composition law"
+    },
+    {
+      "authors": "J. F. Ritt",
+      "title": "Prime and composite polynomials",
+      "year": "1922",
+      "venue": "Transactions of the American Mathematical Society 23(1), 51–66",
+      "note": "Classifies commuting polynomials under composition; the Chebyshev family Cₙ is one of the canonical commuting chains, here realised as a homomorphic image of (ℤ, ·)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-01-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "Upgrades the parent's pointwise integer-index identity to the structural monoid-homomorphism law C_{mn} = Cₘ ∘ Cₙ, bundled as chebyshevCEnd : ℤ →* Function.End R[X]"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "The Chebyshev composition law is the composition-monoid analogue of De Moivre's exponent law for (e^{iθ})ⁿ"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "infrastructure",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All 39 theorems and 8 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
+    "assumptions": "None. All 49 theorems and 8 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton–Puiseux hull recursion is now built and proven terminating (filter_right_length_lt) and complete (exists_spanning_chain). The Newton polygon theorem proper (edge slopes = root valuations) and the quasi-linear complexity bound remain open — they need a valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
     "originalContributions": [
       "IsLowerVertex: supporting-line characterization of a lower-hull (Newton-polygon) vertex, algorithm-independent",
       "isLowerVertex_of_minimal: the minimum-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -51,11 +51,14 @@
       "zipWith_edgeSlopes_edgeWidths: along a chain of lower edges the elementwise product of the edgeSlopes and edgeWidths lists equals the edgeDrops list — the list-level coupling of valuations and multiplicities",
       "sum_slope_mul_width: CAPSTONE bookkeeping identity — Σ (edgeSlopeᵢ · widthᵢ) telescopes to the total vertical drop (last).2 − (first).2 across the polygon",
       "neg_sum_slope_mul_width: Σ (root valuationᵢ · multiplicityᵢ) = v(constant) − v(leading) — the valuation of the product of all roots, read off the two endpoints; the multiplicative counterpart of sum_edgeWidths_eq_degree",
-      "Worked three-vertex example: zipWith products [-2,1] sum to -1 = drop from (0,2) to (3,1) (threeVertex_sum_slope_mul_width)"
+      "Worked three-vertex example: zipWith products [-2,1] sum to -1 = drop from (0,2) to (3,1) (threeVertex_sum_slope_mul_width)",
+      "filter_right_length_lt: TERMINATION MEASURE (the deferred S2-B) — peeling the dominant edge p→q and recursing on the right restriction pts.filter (q.1 ≤ ·.1) strictly shrinks the support, since the left endpoint p (index < q.1) is always dropped; proved via List.Sublist.eq_of_length on the filter sublist. This is the well-founded measure that makes the Newton–Puiseux hull recursion terminate",
+      "exists_spanning_chain: EXISTENCE OF THE FULL NEWTON POLYGON — for any support with distinct indices there is a complete chain of lower edges of the full support running from the left endpoint to the right endpoint. Proved by the verified hull recursion itself (well-founded on support length): peel the dominant edge (exists_isLowerEdge_of_leftmost), recurse on the strictly-smaller right restriction (terminating by filter_right_length_lt), splice with isLowerEdge_chain_extend. This BUILDS the lower-edge chain that the convexity/degree/valuation theorems all previously assumed",
+      "Worked three-vertex example: threeVertex_termination (the cut at index 1 shrinks length 3→2) and threeVertex_exists_spanning (the full chain (0,2)→(1,0)→(3,1) is constructed automatically by the recursion, no chain supplied by hand)"
     ],
     "dateAdded": "2026-06-27",
-    "lineCount": 684,
-    "theoremCount": 39,
+    "lineCount": 947,
+    "theoremCount": 49,
     "definitionCount": 8,
     "mathlib_version": "4.26.0"
   },
@@ -245,9 +248,9 @@
       "Mathlib.Data.List.Sort"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 684,
+    "lineCount": 947,
     "axiomCount": 0,
-    "theoremCount": 39,
+    "theoremCount": 49,
     "definitionCount": 8,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0
@@ -256,9 +259,9 @@
     "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, the lower-edge predicate IsLowerEdge with the edge↔vertex bridge and the slope-determination lemma slope_eq_edgeSlope, and — the combinatorial heart — convexity of the polygon (edgeSlope_mono) yielding sorted root valuations (rootValuation_antitone). The latest layer lifts convexity from adjacent pairs to the whole polygon: edgeSlopes reads off the edge-slope list of a chain of lower edges, and edgeSlopes_pairwise_le proves it Pairwise (· ≤ ·) — every slope ≤ every later one — so the root valuations of the entire polygon are sorted (rootValuations_pairwise_ge), demonstrated on a genuine three-vertex convex chain. All validated on the Y²−x example whose single segment is a genuine lower edge tying the slope to the parent's leadingExponentFromSlope. All 27 theorems and 7 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
     "implications": "This is the algorithm-independent data layer on which Newton–Puiseux termination measures and the Poteaux–Weimann complexity bounds can later be phrased. With a valuation API on K((x))[Y], the Newton polygon theorem (slopes = root valuations) becomes the next provable target.",
     "openQuestions": [
-      "Prove the Newton polygon theorem: the negatives of the lower-hull edge slopes equal the valuations of the roots in an algebraically closed valued extension (needs a valuation API on K((x))[Y]) — the edge layer and its convexity (edgeSlope_mono) are now in place, so the valuations would automatically come out sorted",
-      "Define a termination measure for one Newton–Puiseux reduction step and prove the Y-degree strictly decreases (S2-B)",
-      "State and bound the arithmetic complexity of the algorithm (Poteaux–Weimann Õ(d·δ)) — blocked on the absence of an arithmetic-complexity model in Mathlib (S2-C, moonshot)"
+      "Prove the Newton polygon theorem: the negatives of the lower-hull edge slopes equal the valuations of the roots in an algebraically closed valued extension (needs a valuation API on K((x))[Y]) — the edge layer, its convexity (edgeSlope_mono) and the full hull existence (exists_spanning_chain) are now in place, so the valuations would automatically come out sorted",
+      "Couple the verified hull recursion (exists_spanning_chain) to an actual polynomial: extract its support list, run the recursion, and read off root valuations — the missing link is the valuation API above",
+      "State and bound the arithmetic complexity of the algorithm (Poteaux–Weimann Õ(d·δ)) — blocked on the absence of an arithmetic-complexity model in Mathlib (S2-C, moonshot). The termination measure (filter_right_length_lt) is the depth/recursion-count ingredient such a bound would build on"
     ]
   },
   "sorries": 0

--- a/src/data/research/problems/puiseux-theorem-oq-03.json
+++ b/src/data/research/problems/puiseux-theorem-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-06-28, researcher-5): hull-construction recursion STEP verified 0-axiom. isLowerEdge_of_right (global-support transfer) + chain_transfer + isLowerEdge_chain_extend supply the inductive step of Newton-polygon hull construction — the principal combinatorial input previously missing. Full exists_hull existence and the analytic Newton polygon theorem remain open.",
+    "progressSummary": "PROGRESS (S3, researcher-6): S2-B termination measure proven (filter_right_length_lt) and the full Newton-polygon hull recursion now built and proven complete (exists_spanning_chain) — the lower-edge chain the rest of the file assumed is now constructed, not hypothesized. 947 lines, 49 thms, 0 sorries/0 axioms. Remaining open: Newton polygon theorem (slopes = root valuations, needs valuation API on K((x))[Y]) and S2-C complexity bound.",
     "builtItems": [
       "IsLowerVertex: supporting-line characterization of a Newton-polygon lower-hull vertex (algorithm-independent Prop)",
       "isLowerVertex_of_minimal: the min-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -46,7 +46,10 @@
       "isLowerEdge_of_right (PuiseuxTheoremOQ03.lean): lower edge of right restriction with slope ≥ dominant slope ⇒ lower edge of full support",
       "chain_transfer (PuiseuxTheoremOQ03.lean): propagates dominant-slope bound along a whole right sub-hull via edgeSlope_mono; upgrades every edge to full-support edge",
       "isLowerEdge_chain_extend (PuiseuxTheoremOQ03.lean): one verified peel of Newton-Puiseux recursion — prepend dominant edge to right sub-hull chain ⇒ IsChain (IsLowerEdge pts) over full support",
-      "threeVertex_chain_via_extend + threeVertex_rightHull + threeVertex_filter: worked example rebuilt constructively through the splice combinator"
+      "threeVertex_chain_via_extend + threeVertex_rightHull + threeVertex_filter: worked example rebuilt constructively through the splice combinator",
+      "filter_right_length_lt in PuiseuxTheoremOQ03.lean (termination measure / S2-B)",
+      "exists_spanning_chain in PuiseuxTheoremOQ03.lean (full hull existence via verified recursion)",
+      "threeVertex_termination + threeVertex_exists_spanning (worked examples)"
     ],
     "insights": [
       "Supporting-line predicate beats a verified convex-hull construction: same downstream value, far less proof burden, algorithm-agnostic.",
@@ -58,7 +61,9 @@
       "slope × width = vertical drop: edgeSlope p q · (q.1−p.1) = q.2−p.2 because the slope denominator IS the width — the per-edge bridge coupling valuations (slopes) to multiplicities (widths)",
       "Capstone bookkeeping: Σ (slopeᵢ · widthᵢ) telescopes to the total vertical drop (last).2 − (first).2; equivalently Σ (root valuationᵢ · multiplicityᵢ) = v(constant) − v(leading), the valuation of the product of all roots",
       "The polygon now reads off ALL combinatorial Newton-polygon data from one vertex chain: sorted valuations (edgeSlopes_pairwise_le), total multiplicity (sum_edgeWidths_eq_degree), AND sum-of-valuations-with-multiplicity (neg_sum_slope_mul_width)",
-      "S2-A hull correctness (researcher-5, 2026-06-28): the obstruction to the documented \"peel-and-recurse\" hull construction is that a lower edge of the right restriction pts.filter(q.1 ≤ ·.1) can dip below a left point. RESOLVED: isLowerEdge_of_right proves it cannot, provided the edge slope clears the dominant slope m₀ — convexity forces the right edge line above the dominant line on the left half. This is the precise reason divide-and-conquer Newton-polygon construction is sound."
+      "S2-A hull correctness (researcher-5, 2026-06-28): the obstruction to the documented \"peel-and-recurse\" hull construction is that a lower edge of the right restriction pts.filter(q.1 ≤ ·.1) can dip below a left point. RESOLVED: isLowerEdge_of_right proves it cannot, provided the edge slope clears the dominant slope m₀ — convexity forces the right edge line above the dominant line on the left half. This is the precise reason divide-and-conquer Newton-polygon construction is sound.",
+      "S2-B SOLVED: filter_right_length_lt is the termination measure — peeling the dominant edge and recursing on pts.filter (q.1 ≤ ·.1) strictly shrinks support length (the left endpoint is always dropped). Proven via List.Sublist.eq_of_length.",
+      "exists_spanning_chain BUILDS the full Newton polygon: distinct-index support ⇒ a complete lower-edge chain from left to right endpoint, via well-founded recursion on support length (termination_by + filter_right_length_lt). First theorem to PRODUCE the IsChain (IsLowerEdge) that all convexity/degree/valuation results consumed as hypothesis."
     ],
     "mathlibGaps": [
       "No Newton polygon API in Mathlib 4.26.0 (no Polynomial.newtonPolygon / lowerConvexHull as combinatorial vertex data).",


### PR DESCRIPTION
## Summary
Research session 3 for `puiseux-theorem-oq-03` (the computational sub-question of Puiseux's theorem, Wiedijk #41). Closes the two gaps the file itself flagged: the hull recursion **never built the chain**, and **S2-B (termination measure)** was deferred.

## Progress (all VERIFIED, 0 sorries / 0 axioms)
- **`filter_right_length_lt` — termination measure (S2-B).** Peeling the dominant edge `p → q` and recursing on the right restriction `pts.filter (q.1 ≤ ·.1)` strictly shrinks support length: the left endpoint `p` (index `< q.1`) is always dropped. Proven via `List.Sublist.eq_of_length` on the filter sublist.
- **`exists_spanning_chain` — existence of the full Newton polygon.** For any support with **distinct indices** (one valuation per `Y`-degree, as a genuine polynomial support always has), there is a complete chain of lower edges of the *full* support from the left endpoint to the right endpoint. Proven by the verified hull recursion itself (`termination_by pts.length`; `decreasing_by filter_right_length_lt`): peel the dominant edge (`exists_isLowerEdge_of_leftmost`), recurse on the strictly-smaller right restriction, splice via `isLowerEdge_chain_extend`. This is the **first theorem that *produces*** the `List.IsChain (IsLowerEdge pts)` that every prior convexity/degree/valuation result consumed only as a hypothesis.
- Worked examples: `threeVertex_termination` (cut at index 1 shrinks length 3→2) and `threeVertex_exists_spanning` (the chain `(0,2)→(1,0)→(3,1)` constructed automatically by the recursion).

## Files modified
- `proofs/Proofs/PuiseuxTheoremOQ03.lean` (834→947 lines, 49 theorems)
- `src/data/proofs/puiseux-theorem-oq-03/meta.json` (counts, contributions, open questions)
- `research/problems/puiseux-theorem-oq-03/knowledge.md`, `src/data/research/problems/puiseux-theorem-oq-03.json`

## Verification
`#print axioms` on all new results lists only `propext`/`Classical.choice`/`Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean` exits 0 (host toolchain; worktree `.lake` symlinks the prebuilt Mathlib oleans).

## Status
**Outcome**: progress (S2-B resolved; hull construction now built and terminating).
**Next Steps**: the Newton polygon theorem (edge slopes = root valuations) and the S2-C complexity bound remain open, both blocked on a valuation API on `K((x))[Y]` / an arithmetic-complexity model absent from Mathlib 4.26.0.

🤖 Generated by researcher-6