### PR TITLE
Enrich De Moivre irrational-exponent single-valuedness (de-moivre-oq-03-oq-01-oq-01): annotations 3→5

### DIFF
--- a/src/data/proofs/de-moivre-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-03-oq-01-oq-01/annotations.json
@@ -6,7 +6,7 @@
       "startLine": 38,
       "endLine": 46
     },
-    "type": "concept",
+    "type": "theorem",
     "title": "The 'Almost Definitional' Single Value",
     "content": "principal_value proves (e^{iθ})^α = e^{iαθ} for θ in the principal strip (-π, π]. This is exactly the route the parent's open question proposes: cpow_def_of_ne_zero rewrites the complex power as exp(α · log(e^{iθ})), and Complex.log_exp — valid precisely because the imaginary part θ lies in (-π, π], the domain where the principal logarithm inverts exp — collapses log(e^{iθ}) to iθ. The principal power is therefore a single, well-defined value; cpow is, after all, a function, so 'single-valued' is automatic once the principal branch is fixed.",
     "mathContext": "$(e^{i\\theta})^\\alpha = e^{i\\alpha\\theta}$ for $\\theta \\in (-\\pi, \\pi]$, via $z^\\alpha = \\exp(\\alpha \\log z)$ and $\\log(e^{i\\theta}) = i\\theta$.",
@@ -15,33 +15,63 @@
     "prerequisites": ["complex exponential and logarithm", "the principal argument strip (-π, π]", "cpow_def_of_ne_zero"]
   },
   {
-    "id": "ann-aperiodic",
+    "id": "ann-orbit-never-returns",
     "proofId": "de-moivre-oq-03-oq-01-oq-01",
     "range": {
       "startLine": 48,
+      "endLine": 68
+    },
+    "type": "theorem",
+    "title": "The Orbit Never Returns: e^{2πiαn} ≠ 1",
+    "content": "exp_two_pi_ne_one_of_irrational is the crux of single-valuedness: for irrational α and n ≠ 0, e^{2πiαn} ≠ 1. The proof argues by contradiction — Complex.exp_eq_one_iff turns the supposed equality into 2παn = k·2π for some integer k, which cancels (mul_right_cancel₀ by I, then mul_left_cancel₀ by 2π) to n·α = k. But Irrational.intCast_mul makes n·α irrational when n ≠ 0, whereas k is an integer, and Int.not_irrational closes the contradiction. Mathematically, the multiplicative orbit of e^{2πiα} never returns to 1: there is no period, so no integer q can fold the value into a q-fold ambiguity.",
+    "mathContext": "For irrational $\\alpha$ and $n \\ne 0$: $e^{2\\pi i \\alpha n} = 1$ would force $n\\alpha = k \\in \\mathbb{Z}$, but $n\\alpha$ is irrational — contradiction.",
+    "significance": "critical",
+    "relatedConcepts": ["irrationality", "Complex.exp_eq_one_iff", "Irrational.intCast_mul", "Int.not_irrational", "aperiodic orbit"],
+    "prerequisites": ["e^z = 1 ⟺ z ∈ 2πiℤ", "irrational times nonzero integer is irrational", "an integer is not irrational"]
+  },
+  {
+    "id": "ann-branch-injective",
+    "proofId": "de-moivre-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 70,
       "endLine": 85
     },
-    "type": "insight",
-    "title": "Why Irrational Exponents Have No Multi-Valuedness",
-    "content": "The real content of 'single-valued' is the absence of a finite cyclic ambiguity. exp_two_pi_ne_one_of_irrational shows e^{2πiαn} ≠ 1 for n ≠ 0: via Complex.exp_eq_one_iff such an equality would force 2παn = k·2π, i.e. n·α = k for an integer k. But Irrational.intCast_mul makes n·α irrational (for n ≠ 0), while k is an integer (Int.not_irrational) — contradiction. branch_injective then upgrades this to: k ↦ e^{2πiαk} is injective (apply the previous lemma to the difference j − k via exp_eq_exp_iff_exp_sub_eq_one). The would-be branch shifts never coincide, so no integer q produces q distinct values — exactly the structural difference from the rational p/q case, which has exactly q values.",
-    "mathContext": "For irrational $\\alpha$ and $n \\ne 0$: $e^{2\\pi i \\alpha n} \\ne 1$, since $n\\alpha = k \\in \\mathbb{Z}$ would make the irrational $n\\alpha$ an integer; hence $k \\mapsto e^{2\\pi i \\alpha k}$ is injective.",
+    "type": "theorem",
+    "title": "The Branch Family is Injective",
+    "content": "branch_injective upgrades the orbit-never-returns lemma to full injectivity of k ↦ e^{2πiαk} on ℤ. Given e^{2πiαj} = e^{2πiαk}, Complex.exp_eq_exp_iff_exp_sub_eq_one turns it into e^{(difference)} = 1, and a push_cast/ring rewrite folds the difference of the two phase arguments into the single phase 2πiα(j−k); applying exp_two_pi_ne_one_of_irrational to j−k forces j−k = 0. So distinct integers give distinct points: the 'branches' never coincide, and there is no finite cyclic structure as in the rational case. This is the precise structural contrast that distinguishes irrational from rational exponents.",
+    "mathContext": "$e^{2\\pi i\\alpha j} = e^{2\\pi i\\alpha k} \\Rightarrow e^{2\\pi i\\alpha (j-k)} = 1 \\Rightarrow j-k = 0$; hence $k \\mapsto e^{2\\pi i\\alpha k}$ is injective on $\\mathbb{Z}$.",
     "significance": "key",
-    "relatedConcepts": ["irrationality", "equidistribution / dense orbit", "Complex.exp_eq_one_iff", "injectivity", "rational vs irrational exponents"],
-    "prerequisites": ["e^z = 1 ⟺ z ∈ 2πiℤ", "irrational times nonzero integer is irrational", "an integer is not irrational"]
+    "relatedConcepts": ["injectivity", "Complex.exp_eq_exp_iff_exp_sub_eq_one", "rational vs irrational exponents", "free orbit"],
+    "prerequisites": ["the orbit-never-returns lemma", "exp equality via the difference being a multiple of 2πi"]
   },
   {
     "id": "ann-bundle",
     "proofId": "de-moivre-oq-03-oq-01-oq-01",
     "range": {
       "startLine": 87,
+      "endLine": 98
+    },
+    "type": "theorem",
+    "title": "Replacing the True Stub: The Genuine Statement",
+    "content": "irrational_exponent_single_valued bundles the principal-value formula with branch injectivity — the honest replacement for the parent entry's placeholder `theorem … : True := trivial`. A stub proving only True asserts nothing about the actual claim; here the statement has explicit content (a single principal value (e^{iθ})^α = e^{iαθ} AND injectivity of the branch family, i.e. no finite cyclic ambiguity) and a machine-checked proof, directly answering the parent's first open question. The conjunction is the right shape: single-valuedness for irrational exponents is genuinely a two-part fact — the value exists and is unique, and the alternative branches are all distinct.",
+    "mathContext": "$\\big((e^{i\\theta})^\\alpha = e^{i\\alpha\\theta}\\big) \\wedge \\big(k \\mapsto e^{2\\pi i \\alpha k}\\text{ injective}\\big)$ for irrational $\\alpha$, $\\theta \\in (-\\pi,\\pi]$.",
+    "significance": "critical",
+    "relatedConcepts": ["honest formalization vs True-stub", "single-valuedness", "open-question resolution", "conjunction of formalized claims"],
+    "prerequisites": ["the principal-value formula", "branch injectivity"]
+  },
+  {
+    "id": "ann-free-orbit-corollary",
+    "proofId": "de-moivre-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 100,
       "endLine": 111
     },
-    "type": "insight",
-    "title": "Replacing the True Stub",
-    "content": "irrational_exponent_single_valued bundles the principal-value formula with branch injectivity — the honest replacement for the parent's `theorem … : True := trivial`. A placeholder proving only True asserts nothing about the actual claim; here the claim has explicit content (a single principal value AND no finite cyclic ambiguity) and a machine-checked proof, answering the parent's first open question. exp_two_pi_eq_one_iff records the clean corollary e^{2πiαn} = 1 ↔ n = 0: the multiplicative orbit {e^{2πiαn}} is a free, infinite family — the quantitative reason no q-th-root ambiguity ever arises for irrational exponents.",
-    "mathContext": "$\\big((e^{i\\theta})^\\alpha = e^{i\\alpha\\theta}\\big) \\wedge \\big(k \\mapsto e^{2\\pi i \\alpha k}\\text{ injective}\\big)$; and $e^{2\\pi i \\alpha n} = 1 \\iff n = 0$.",
-    "significance": "key",
-    "relatedConcepts": ["honest formalization vs True-stub", "free orbit", "single-valuedness", "open-question resolution"],
-    "prerequisites": ["the principal-value formula", "branch injectivity", "conjunction of formalized claims"]
+    "type": "theorem",
+    "title": "Corollary: The Free, Infinite Orbit e^{2πiαn} = 1 ⟺ n = 0",
+    "content": "exp_two_pi_eq_one_iff records the clean iff: for irrational α, e^{2πiαn} = 1 holds exactly when n = 0. The forward direction is the contrapositive of exp_two_pi_ne_one_of_irrational; the reverse is `simp` (n = 0 gives e^0 = 1). This packages the quantitative reason no q-th-root ambiguity ever arises for irrational exponents: the multiplicative orbit {e^{2πiαn} : n ∈ ℤ} is a free (torsion-free, infinite) family, with 1 occurring only at the identity index. It is the abelian-group restatement of branch injectivity — the orbit map is an injective homomorphism ℤ → 𝕋.",
+    "mathContext": "$e^{2\\pi i\\alpha n} = 1 \\iff n = 0$ for irrational $\\alpha$: the orbit $\\{e^{2\\pi i\\alpha n}\\}$ is a free infinite subgroup of the unit circle $\\mathbb{T}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["free abelian orbit", "torsion-free subgroup of 𝕋", "contrapositive", "Kronecker/Weyl equidistribution"],
+    "prerequisites": ["the orbit-never-returns lemma", "logical contrapositive and simp"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-03-oq-01-oq-01` (quality 83, pass 0).

## Gap addressed
Entry already had a complete overview (5 keyInsights), 3 sections, conclusion (3 openQuestions), and 2 cross-references. The gap was **annotation count: 3 vs the ≥5 minimum** — two of the three annotations each lumped two distinct theorems into a single large range.

## Changes
Refined into **5 one-theorem-per-annotation** inline annotations:
1. `principal_value` — the single principal value (38–46)
2. `exp_two_pi_ne_one_of_irrational` — the orbit never returns (48–68)
3. `branch_injective` — the branch family is injective (70–85)
4. `irrational_exponent_single_valued` — genuine statement replacing the True stub (87–98)
5. `exp_two_pi_eq_one_iff` — the free-orbit corollary (100–111)

Each keeps `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. No content removed.

## Verification
- `pnpm build` passes.
- annotations.json valid; 5 annotations, non-overlapping ranges covering lines 38–111.
- meta.json unchanged (already complete).