### PR TITLE
Research: erdos-564-incomplete-01 — Ramsey-property monotonicity API [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos564Incomplete01.lean
+++ b/proofs/Proofs/Erdos564Incomplete01.lean
@@ -107,4 +107,47 @@ theorem tower_three_one : tower 3 1 = 16 := by decide
 /-- The base bound in action: `5 ≤ tower 4 5`. -/
 theorem self_le_tower_example : 5 ≤ tower 4 5 := self_le_tower 4 5
 
+/-! ## Monotonicity of the Ramsey property
+
+The parent axiomatizes the Ramsey number `R` but proves no theory of the underlying
+predicate `HasHypergraphRamseyProperty k m n` ("every 2-colouring of the k-subsets of
+`Fin m` has a monochromatic n-clique").  Two structural monotonicities hold for *any*
+such Ramsey-type property and are exactly the facts that make `R k n` well-behaved as a
+*threshold* (the least `m` with the property):
+
+* **more vertices preserve the property** (`…_mono`) — so the set of good `m` is upward
+  closed, which is what lets one speak of the *least* such `m`;
+* **a smaller target clique is easier** (`…_antitone_clique`) — so `R k ·` is monotone in
+  the clique size.
+
+Both are verified and **0-axiom** (they do not touch `R` or the EHR bounds). They are the
+first genuine theory of the property predicate itself, complementing the `tower`-growth
+theory above. -/
+
+/-- **Vertex monotonicity.**  If every 2-colouring on `m` vertices yields a monochromatic
+`n`-clique and `m ≤ m'`, the same holds on `m'` vertices: restrict a colouring of `Fin m'`
+along the embedding `Fin m ↪ Fin m'`, find the clique downstairs, and push it back up
+(`Finset.map` preserves cardinality and subset structure). -/
+theorem hasHypergraphRamseyProperty_mono {k m m' n : ℕ} (hmm : m ≤ m')
+    (h : HasHypergraphRamseyProperty k m n) : HasHypergraphRamseyProperty k m' n := by
+  intro c'
+  set f : Fin m ↪ Fin m' := Fin.castLEEmb hmm with hf
+  obtain ⟨S, colour, hScard, hSmono⟩ := h (fun e => c' (e.map f))
+  refine ⟨S.map f, colour, ?_, ?_⟩
+  · rw [Finset.card_map]; exact hScard
+  · intro e' he'sub he'card
+    obtain ⟨e, hesub, rfl⟩ := Finset.subset_map_iff.mp he'sub
+    rw [Finset.card_map] at he'card
+    simpa using hSmono e hesub he'card
+
+/-- **Clique-size antitonicity.**  A monochromatic `n`-clique contains a monochromatic
+`n'`-clique for every `n' ≤ n`: take any `n'`-element subset of the clique — its
+`k`-subsets are still `k`-subsets of the original clique, hence still monochromatic. -/
+theorem hasHypergraphRamseyProperty_antitone_clique {k m n n' : ℕ} (hnn : n' ≤ n)
+    (h : HasHypergraphRamseyProperty k m n) : HasHypergraphRamseyProperty k m n' := by
+  intro c
+  obtain ⟨S, colour, hScard, hSmono⟩ := h c
+  obtain ⟨T, hTsub, hTcard⟩ := Finset.le_card_iff_exists_subset_card.mp (hScard ▸ hnn)
+  exact ⟨T, colour, hTcard, fun e hesub hecard => hSmono e (hesub.trans hTsub) hecard⟩
+
 end Erdos564.Incomplete01

--- a/research/problems/erdos-564-incomplete-01/knowledge.md
+++ b/research/problems/erdos-564-incomplete-01/knowledge.md
@@ -82,3 +82,33 @@ Parent now **0 sorries**. The 3 remaining `axiom`s (`R`, `erdos_hajnal_rado_uppe
 `erdos_hajnal_rado_lower`) are the legitimate open-problem axiomatization (the
 hypergraph Ramsey number and the EHR 1965 bounds) — not provable here. The open
 conjecture (raising the lower bound to tower height 2, $500) is out of reach.
+
+## Session 2 (2026-06-28, researcher-4): Ramsey-property monotonicity API
+
+**Heads-up for future sessions:** the parent sorry `bounds_gap_enormous` was already
+eliminated on `origin/main` by a concurrent researcher (`nsq_add_four_hundred_le_two_pow`,
+`+400` margin) — do NOT re-prove it. (researcher-4 independently proved it with a `+924`
+margin before noticing the collision; that work was discarded. Lesson: `git show
+origin/main:<path> | grep -c sorry` right after claiming.)
+
+Added the **first verified theory of the property predicate** `HasHypergraphRamseyProperty`
+itself (the parent only axiomatizes the number `R`). Child file 110→153 lines, 11→13
+theorems, still **0-sorry / 0-axiom** (`#print axioms`: propext/Classical.choice/Quot.sound
+only; the R/EHR axioms are untouched):
+
+* `hasHypergraphRamseyProperty_mono {k m m' n} (m ≤ m') : property k m n → property k m' n`
+  — **vertex monotonicity**. Restrict a colouring of `Fin m'` along `Fin.castLEEmb (m≤m')`,
+  solve downstairs, push the clique back up. Key lemmas: `Finset.subset_map_iff`
+  (`s ⊆ t.map f ↔ ∃ u ⊆ t, s = u.map f`), `Finset.card_map`. The clique-membership goal
+  closes by `simpa using hSmono e …` (beta-reduces the restricted colouring `c' (e.map f)`).
+* `hasHypergraphRamseyProperty_antitone_clique {k m n n'} (n' ≤ n) : property k m n →
+  property k m n'` — **clique-size antitonicity**. Take an `n'`-subset of the solved clique
+  via `Finset.le_card_iff_exists_subset_card.mp (hScard ▸ hnn)`; its k-subsets are k-subsets
+  of the original clique, so still monochromatic.
+
+These are the structural facts that make `R k n` (least `m` with the property) a sensible
+*threshold*: the good-`m` set is upward closed, and `R k ·` is monotone in clique size.
+
+GOTCHAs (session 2): `Fin.castLEEmb (h : n ≤ m) : Fin n ↪ Fin m` is the embedding;
+`Finset.le_card_iff_exists_subset_card : n ≤ s.card ↔ ∃ t ⊆ s, t.card = n` is the
+subset-of-given-size lemma (NOT `exists_smaller_set`/`exists_subset_card_eq` in this Mathlib).

--- a/src/data/proofs/erdos-564-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-564-incomplete-01/meta.json
@@ -158,9 +158,9 @@
       "Proofs.Erdos564Problem"
     ],
     "namespace": "Erdos564.Incomplete01",
-    "lineCount": 110,
+    "lineCount": 153,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 0,
     "path": "Proofs/Erdos564Incomplete01.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-564-incomplete-01.json
+++ b/src/data/research/problems/erdos-564-incomplete-01.json
@@ -39,28 +39,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S1 ACT: standalone verified tower-growth theory for Erdős #564 (Erdos564Incomplete01.lean, 110 lines, 11 theorems, 0-sorry 0-axiom). Strict monotonicity in height and base, base lower bound, and the crux 2^n < 2^{2^n} making precise the one-tower-level gap of the open conjecture. Fixed the parent's 6 dangling /-- doc comments (parent did not parse at all on main). Iter 2: discharged the parent's bounds_gap_enormous arithmetic sorry (axiom-free); Erdos564Problem.lean now 0 sorries, leaving only the legitimate Ramsey axiomatization (R + EHR bounds).",
+    "progressSummary": "S2 ACT (2026-06-28, researcher-4): added the first verified theory of the Ramsey property predicate — vertex monotonicity (hasHypergraphRamseyProperty_mono) and clique-size antitonicity (hasHypergraphRamseyProperty_antitone_clique), both 0-axiom, in Erdos564Incomplete01.lean (110→153 lines, 11→13 theorems). These are the structural facts making R k n well-defined as a threshold. The parent sorry bounds_gap_enormous was already eliminated upstream on main; open $500 conjecture stays out of reach.",
     "builtItems": [
       "Erdos564Incomplete01.lean: tower_succ, tower_lt_succ_height, tower_strictMono_height, self_le_tower, tower_strictMono_base, tower_mono_base, tower_two_eq, tower_one_lt_tower_two, plus 3 concrete checks (all 0-axiom verified)",
       "Parent fix: 6 dangling /-- doc comments in Erdos564Problem.lean (lines 65/66/153/154/164/186) converted to /- so the file parses",
-      "[parent sorry discharged] Erdos564Problem.lean bounds_gap_enormous (axiom-free, propext/Classical.choice/Quot.sound): 2^(2^n)/2^(n^2) > 10^100 for n>=10, via single-rpow rewrite (Real.rpow_sub) + exponent bound 2^n-n^2 >= 400 (aux nat lemma n^2+400 <= 2^n by Nat.le_induction) + 2^400=16^100>10^100. Parent file now 0 sorries."
+      "[parent sorry discharged] Erdos564Problem.lean bounds_gap_enormous (axiom-free, propext/Classical.choice/Quot.sound): 2^(2^n)/2^(n^2) > 10^100 for n>=10, via single-rpow rewrite (Real.rpow_sub) + exponent bound 2^n-n^2 >= 400 (aux nat lemma n^2+400 <= 2^n by Nat.le_induction) + 2^400=16^100>10^100. Parent file now 0 sorries.",
+      "hasHypergraphRamseyProperty_mono + hasHypergraphRamseyProperty_antitone_clique in Erdos564Incomplete01.lean (110→153 lines, 11→13 theorems, 0-sorry 0-axiom)."
     ],
     "insights": [
       "Tower height growth needs no positivity hypothesis: m < 2^m holds even at m=0, so tower k n < tower (k+1) n for all n (strengthens the parent's positivity-gated tower_pos framing).",
       "tower_one_lt_tower_two (2^n < 2^{2^n}) is the formal content of 'the EHR lower bound is one tower level below the upper bound' — the precise gap Erdős #564 asks to close.",
       "Importing a parent file with axioms + a sorry does NOT taint #print axioms of theorems that don't transitively use them: all 11 results are 0-axiom despite importing Erdos564Problem (which has axiom R + 2 EHR axioms + 1 sorry).",
       "The parent Erdos564Problem.lean did not parse on main (dangling /-- doc comments before /- blocks) — same bug class as the puiseux-theorem parent fix. Its olean was therefore missing; had to build it single-file to the lean/Proofs libdir (extra lean/ segment).",
-      "Real.rpow_sub (0<x) collapses 2^a/2^b to 2^(a-b); then Real.rpow_le_rpow_of_exponent_le (1<=base) lifts a real exponent lower bound. Avoid huge-number norm_num: bound 10^100 < 16^100 = 2^400 via Nat.pow_lt_pow_left + cast, not by evaluating 100-digit literals. pow_lt_pow_left is gone in Mathlib 4.26 -> use Nat.pow_lt_pow_left."
+      "Real.rpow_sub (0<x) collapses 2^a/2^b to 2^(a-b); then Real.rpow_le_rpow_of_exponent_le (1<=base) lifts a real exponent lower bound. Avoid huge-number norm_num: bound 10^100 < 16^100 = 2^400 via Nat.pow_lt_pow_left + cast, not by evaluating 100-digit literals. pow_lt_pow_left is gone in Mathlib 4.26 -> use Nat.pow_lt_pow_left.",
+      "Monotonicity API for HasHypergraphRamseyProperty (2026-06-28, researcher-4): added the first theory of the Ramsey *property* predicate (parent only axiomatized R). hasHypergraphRamseyProperty_mono (vertex monotonicity m≤m′ via Fin.castLEEmb + Finset.subset_map_iff, upward-closed set of good m) and hasHypergraphRamseyProperty_antitone_clique (n′≤n via Finset.le_card_iff_exists_subset_card). Both 0-axiom. NOTE: parent sorry bounds_gap_enormous was already eliminated on origin/main by a concurrent researcher (+400 margin) — do not re-prove."
     ],
     "mathlibGaps": [
       "No hypergraph Ramsey number API in Mathlib (R₃ is axiomatized in the parent).",
       "No formal Erdős–Hajnal–Rado bound proofs (axiomatized)."
     ],
     "nextSteps": [
-      "DONE (iter 2): bounds_gap_enormous discharged (axiom-free). Remaining sorry-free; only the R/EHR axioms persist (open).",
-      "Prove monotonicity of HasHypergraphRamseyProperty (more vertices preserve a monochromatic clique) toward a verified R₃.",
-      "Prove the parent's bounds_gap_enormous (2^{2^n}/2^{n²} > 10^100 for n≥10): induction 2^n ≥ n²+924 for n≥10, then rpow_sub + monotonicity; norm_num on 2^924 > 10^100.",
-      "The conjecture R₃(n) ≥ 2^{2^{cn}} is open ($500) — out of reach."
+      "Optional: derive monotonicity of the threshold R k · from the property monotonicities once/if R is given a least-witness characterization (currently R is a bare axiom, so no link to the property yet).",
+      "The conjecture R₃(n) ≥ 2^{2^{cn}} is open ($500) — out of reach. R / erdos_hajnal_rado_* are legitimate assumptions.",
+      "Parent sorry bounds_gap_enormous: ALREADY DONE on origin/main (do not repeat)."
     ],
     "markdown": "# Knowledge: erdos-564-incomplete-01\nSee research/problems/erdos-564-incomplete-01/knowledge.md for full session notes.\n"
   },


### PR DESCRIPTION
## Summary
Research session for `erdos-564-incomplete-01` (child of Erdős #564, 3-uniform hypergraph Ramsey numbers; OPEN, \$500). Adds the **first verified theory of the property predicate** `HasHypergraphRamseyProperty` itself — the parent file only axiomatizes the Ramsey *number* `R`.

## Progress
Two structural monotonicities, both 0-axiom, in `proofs/Proofs/Erdos564Incomplete01.lean`:
- **`hasHypergraphRamseyProperty_mono`** — vertex monotonicity: `m ≤ m'` preserves the property. Restrict a colouring of `Fin m'` along `Fin.castLEEmb (m≤m')`, solve downstairs, push the clique back up (`Finset.subset_map_iff`, `Finset.card_map`).
- **`hasHypergraphRamseyProperty_antitone_clique`** — clique-size antitonicity: `n' ≤ n`. Take an `n'`-subset of the solved clique (`Finset.le_card_iff_exists_subset_card`); its `k`-subsets are still `k`-subsets of the original clique, hence monochromatic.

Together these are the facts that make `R k n` (least `m` with the property) well-defined as a *threshold*: the good-`m` set is upward closed and `R k ·` is monotone in clique size.

## Verification
`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos564Incomplete01.lean` exits 0. **0 sorries, 0 axioms** — `#print axioms` on both new lemmas lists only `propext`/`Classical.choice`/`Quot.sound`; the parent's `R` / EHR axioms are untouched. Child file 110→153 lines, 11→13 theorems. No parent-file changes.

## Status
**Outcome**: progress (verified Ramsey-property infrastructure)
**Next Steps**: link these property monotonicities to threshold monotonicity of `R k ·` if/when `R` is given a least-witness characterization (currently a bare axiom). The open conjecture `R₃(n) ≥ 2^{2^{cn}}` (\$500) remains out of reach. (Note: the parent sorry `bounds_gap_enormous` was already eliminated upstream on `main` — not touched here.)

🤖 Generated by researcher-4