### PR TITLE
audit(erdos-564): sorries 1→0 — bounds_gap_enormous fully proved

### DIFF
--- a/src/data/proofs/erdos-564/meta.json
+++ b/src/data/proofs/erdos-564/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 564,
     "erdosUrl": "https://erdosproblems.com/564",
     "erdosProblemStatus": "open",
@@ -44,7 +44,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 207,
-    "assumptions": "3 axioms: R, erdos_hajnal_rado_upper, erdos_hajnal_rado_lower. 1 sorry.",
+    "assumptions": "3 axioms: R, erdos_hajnal_rado_upper, erdos_hajnal_rado_lower. 0 sorries (bounds_gap_enormous fully proved as of #31293).",
     "theoremCount": 6,
     "definitionCount": 5
   },
@@ -136,8 +136,8 @@
       "title": "The 4-Colour Case",
       "startLine": 191,
       "endLine": 207,
-      "summary": "bounds_gap_enormous (sorry) states the enormous gap between known bounds; 4-colour doubly exponential result is mentioned in a docstring only, with no associated Lean declaration",
-      "mathContext": "Sorry: bounds_gap_enormous captures the bounds gap; 4-colour content is docstring-only"
+      "summary": "bounds_gap_enormous (fully proved) states the enormous gap between known bounds; 4-colour doubly exponential result is mentioned in a docstring only, with no associated Lean declaration",
+      "mathContext": "Proved: bounds_gap_enormous captures the bounds gap (no sorry); 4-colour content is docstring-only"
     }
   ],
   "conclusion": {
@@ -166,7 +166,7 @@
     "theoremCount": 6,
     "definitionCount": 5,
     "path": "Proofs/Erdos564Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -185,5 +185,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, hypergraphs"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-564 (Hypergraph Ramsey Numbers, $500 open problem)
**Severity**: LOW (stale undercount — file is more complete than meta claimed)

### Mismatch
- **meta.json claimed**: `sorries: 1`
- **Lean source shows**: 0 sorries

PR #31293 discharged the last arithmetic sorry in `bounds_gap_enormous`
(proved via `nsq_add_four_hundred_le_two_pow` + `Real.rpow` monotonicity).
The meta was not updated to match.

### Verification
`proofs/Proofs/Erdos564Problem.lean`:
- 3 axioms: `R`, `erdos_hajnal_rado_upper`, `erdos_hajnal_rado_lower` (matches `axiomCount: 3`)
- 0 `sorry` declarations

### Changes
- `sorries`: 1 → 0 (3 locations: meta block, leanFile block, top-level)
- `assumptions`: "1 sorry." → "0 sorries (bounds_gap_enormous fully proved as of #31293)."
- four-colour section summary/mathContext: "(sorry)" → "(fully proved)"

Status stays `axiomatized`/`axiom` — the 3 EHR-bound axioms remain (correct for this open $500 problem).

---
Discovered during gallery integrity audit.