### PR TITLE
Enrich Dini sharp modulus of xⁿ on [0,1) (dini-theorem-oq-01-oq-02): annotations 3→5

### DIFF
--- a/src/data/proofs/dini-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-02/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "dini-oq0102-ann-overview",
     "proofId": "dini-theorem-oq-01-oq-02",
-    "range": { "startLine": 1, "endLine": 52 },
+    "range": { "startLine": 1, "endLine": 50 },
     "type": "concept",
     "title": "The Sharp Modulus Question",
     "content": "The header frames OQ-02. The parent (dini-theorem-oq-01) uses xⁿ on the non-compact [0,1) as a witness that Dini's compactness hypothesis is necessary: xⁿ is continuous, antitone in n, and converges pointwise to the continuous function 0, yet not uniformly. The parent's non-uniformity bound was the non-sharp 1/2 (a value attained via the intermediate value theorem). This file asks for the exact modulus: the uniform error sup_x |xⁿ| on [0,1), and proves it equals exactly 1.",
@@ -14,25 +14,49 @@
   {
     "id": "dini-oq0102-ann-lub",
     "proofId": "dini-theorem-oq-01-oq-02",
-    "range": { "startLine": 53, "endLine": 105 },
-    "type": "insight",
+    "range": { "startLine": 52, "endLine": 94 },
+    "type": "theorem",
     "title": "The Supremum of xⁿ over [0,1) is Exactly 1",
-    "content": "pow_image_Ico_isLUB proves IsLUB { xⁿ : x ∈ [0,1) } 1 for n ≥ 1. Upper bound: x ∈ [0,1) ⟹ xⁿ ≤ 1 (pow_le_one₀). Least: for any upper bound b, the explicit sequence xₖ = 1 − 1/(k+1) lies in [0,1) and tends to 1 (since 1/(k+1) → 0 via tendsto_one_div_add_atTop_nhds_zero_nat), so xₖⁿ → 1ⁿ = 1; each xₖⁿ ≤ b, and le_of_tendsto' passes to the limit to give 1 ≤ b. Hence 1 is the least upper bound and pow_sSup_Ico concludes sSup = 1 (IsLUB.csSup_eq on the nonempty image). Crucially the supremum is never attained — every xⁿ < 1 — which is the analytic signature of the missing compactness.",
-    "mathContext": "$\\operatorname{IsLUB}\\{x^n : x\\in[0,1)\\}\\,1$; approached along $x_k=1-\\tfrac{1}{k+1}\\to 1$, never attained.",
+    "content": "pow_image_Ico_isLUB proves IsLUB { xⁿ : x ∈ [0,1) } 1 for n ≥ 1. Upper bound: x ∈ [0,1) ⟹ xⁿ ≤ 1 (pow_le_one₀). Least: for any upper bound b, the explicit sequence xₖ = 1 − 1/(k+1) lies in [0,1) and tends to 1 (since 1/(k+1) → 0 via tendsto_one_div_add_atTop_nhds_zero_nat), so xₖⁿ → 1ⁿ = 1; each xₖⁿ ≤ b, and le_of_tendsto' passes to the limit to give 1 ≤ b. The trivial pow_image_Ico_nonempty (0ⁿ = 0 is in the image) then lets pow_sSup_Ico conclude sSup = 1 via IsLUB.csSup_eq. Crucially the supremum is never attained — every xⁿ < 1 — which is the analytic signature of the missing compactness.",
+    "mathContext": "$\\operatorname{IsLUB}\\{x^n : x\\in[0,1)\\}\\,1$, hence $\\operatorname{sSup} = 1$; approached along $x_k=1-\\tfrac{1}{k+1}\\to 1$, never attained.",
     "significance": "critical",
-    "relatedConcepts": ["least upper bound", "passing to the limit", "approximating sequence"],
-    "prerequisites": ["limits of sequences", "monotone power functions"]
+    "relatedConcepts": ["least upper bound", "passing to the limit (le_of_tendsto')", "approximating sequence", "IsLUB.csSup_eq"],
+    "prerequisites": ["limits of sequences", "monotone power functions", "conditionally complete order sSup"]
   },
   {
     "id": "dini-oq0102-ann-modulus",
     "proofId": "dini-theorem-oq-01-oq-02",
-    "range": { "startLine": 106, "endLine": 172 },
-    "type": "insight",
-    "title": "The Sharp Modulus and Sharpened Non-Uniformity",
-    "content": "pow_uniform_error_Ico reads off the headline: since |xⁿ − 0| = xⁿ on [0,1) (image_congr after abs_of_nonneg), the error-supremum equals the xⁿ-supremum, namely 1 — the exact modulus of non-uniform convergence. pow_exists_gt_of_lt_one unpacks the LUB: any c < 1 fails to be an upper bound, so some x ∈ [0,1) has xⁿ > c. Feeding this into the negated ε-criterion (Metric.tendstoUniformlyOn_iff) gives pow_not_tendstoUniformlyOn_Ico_sharp: the convergence is non-uniform with ANY threshold c ∈ (0,1), not merely the parent's 1/2.",
-    "mathContext": "For all $c\\in(0,1)$ and $N$, some $n\\ge N$ and $x\\in[0,1)$ have $|x^n-0|>c$; taking $c\\uparrow 1$ gives the sharp modulus.",
+    "range": { "startLine": 96, "endLine": 117 },
+    "type": "theorem",
+    "title": "The Sharp Modulus: sup |xⁿ − 0| = 1",
+    "content": "pow_uniform_error_Ico is the headline result answering OQ-02. On [0,1) the error |xⁿ − 0| equals xⁿ itself, because xⁿ ≥ 0 there (abs_of_nonneg after sub_zero); `Set.image_congr` rewrites the error-image to the plain power-image, so its supremum is the xⁿ-supremum from pow_sSup_Ico, namely 1. This is the exact modulus of non-uniform convergence — the supremal pointwise error over the whole domain — and it sharpens the parent's lower bound of 1/2 to the optimal value 1, which cannot be improved (no value > 1 is even an upper bound, and no value < 1 bounds the image).",
+    "mathContext": "$\\sup_{x\\in[0,1)}|x^n-0| = \\sup_{x\\in[0,1)} x^n = 1$ for $n\\ge 1$, since $|x^n-0| = x^n$ on $[0,1)$.",
     "significance": "critical",
-    "relatedConcepts": ["modulus of convergence", "uniform convergence criterion", "sharpness"],
-    "prerequisites": ["ε-N definition of uniform convergence", "least upper bound"]
+    "relatedConcepts": ["modulus of convergence", "supremum norm", "Set.image_congr", "sharpness"],
+    "prerequisites": ["the supremum of xⁿ equals 1", "abs_of_nonneg on a nonnegative power"]
+  },
+  {
+    "id": "dini-oq0102-ann-exists-gt",
+    "proofId": "dini-theorem-oq-01-oq-02",
+    "range": { "startLine": 119, "endLine": 130 },
+    "type": "theorem",
+    "title": "The LUB Unpacked: Any c < 1 is Exceeded",
+    "content": "pow_exists_gt_of_lt_one converts the abstract least-upper-bound fact into a concrete witness: for any c < 1 and n ≥ 1, some x ∈ [0,1) has xⁿ > c. The proof is by contradiction — if no such x existed, then c would itself be an upper bound of { xⁿ : x ∈ [0,1) }, and since 1 is the LEAST upper bound (pow_image_Ico_isLUB.2) this forces 1 ≤ c, contradicting c < 1. This is the workhorse lemma that turns 'sup = 1, not attained' into the explicit threshold-exceeding statement needed for the non-uniformity argument.",
+    "mathContext": "For $c<1$, $n\\ge 1$: $\\exists\\,x\\in[0,1),\\ x^n > c$ — because $c$ being an upper bound would force $1\\le c$ by leastness of the LUB.",
+    "significance": "key",
+    "relatedConcepts": ["least upper bound", "upperBounds", "proof by contradiction", "non-attained supremum"],
+    "prerequisites": ["the IsLUB result for xⁿ", "definition of upperBounds"]
+  },
+  {
+    "id": "dini-oq0102-ann-nonuniform",
+    "proofId": "dini-theorem-oq-01-oq-02",
+    "range": { "startLine": 132, "endLine": 172 },
+    "type": "theorem",
+    "title": "Sharpened Non-Uniformity at Any Threshold c ∈ (0,1)",
+    "content": "pow_not_tendstoUniformlyOn_Ico_sharp shows the convergence xⁿ → 0 on [0,1) fails to be uniform with ANY threshold c ∈ (0,1), not merely the parent's 1/2. After unfolding the negated ε-criterion (Metric.tendstoUniformlyOn_iff + push_neg), it must produce, for every N, some n ≥ N and x ∈ [0,1) with error ≥ c. It picks n = N+1 and feeds c into pow_exists_gt_of_lt_one to get x with xⁿ > c; rewriting dist 0 (xⁿ) = xⁿ (Real.dist_eq, abs_neg, abs_of_nonneg) and `linarith` finishes. Letting c ↑ 1 recovers the sharp modulus: the uniform error is bounded below by every c < 1, hence equals 1.",
+    "mathContext": "For all $c\\in(0,1)$ and $N$, $\\exists\\,n\\ge N,\\ x\\in[0,1):\\ |x^n-0|>c$; so $\\neg\\,\\text{TendstoUniformlyOn}$, and $c\\uparrow 1$ gives the sharp modulus $1$.",
+    "significance": "key",
+    "relatedConcepts": ["ε-N uniform convergence criterion", "Metric.tendstoUniformlyOn_iff", "Filter.frequently_atTop", "sharpness"],
+    "prerequisites": ["ε-N definition of uniform convergence", "the threshold-exceeding existence lemma"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `dini-theorem-oq-01-oq-02` (quality 83, pass 0).

## Gap addressed
Entry already had a complete overview (5 keyInsights), 3 sections, conclusion (3 openQuestions), and 3 cross-references. The gap was **annotation count: 3 vs the ≥5 minimum** — the third annotation lumped three distinct theorems into a single 66-line range.

## Changes
Refined into **5** inline annotations aligned to the file's theorem groups:
1. Header — the sharp modulus question (1–50)
2. The LUB=1 group — `pow_image_Ico_isLUB` + `pow_sSup_Ico` (52–94)
3. The sharp modulus — `pow_uniform_error_Ico` (96–117)
4. The LUB unpacked — `pow_exists_gt_of_lt_one` (119–130)
5. Sharpened non-uniformity — `pow_not_tendstoUniformlyOn_Ico_sharp` (132–172)

Each keeps `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. No content removed.

## Verification
- `pnpm build` passes.
- annotations.json valid; 5 annotations, non-overlapping ranges covering lines 1–172.
- meta.json unchanged (already complete).