### PR TITLE
research(collatz-structured-oq-02-oq-03): uniform Terras drop criterion 3^a < 2^b [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -1272,6 +1272,25 @@ theorem parityVector_attainsBelow {M r : ℕ} (v : List Bool)
     {n : ℕ} (hn : n % M = r) : AttainsBelow n :=
   affine_residue_attainsBelow hk hc hd (fun m => affOrbit_realize hval m) hn
 
+/-- **Terras drop criterion as the textbook inequality `3^a < 2^b`.**  For a
+power-of-two modulus `2^b` whose residue-determined window `v` performs exactly its
+`b` halvings (`v.count false = b`, with `a := v.count true` triplings), the realized
+leading coefficient is *automatically* `3^a` (the Terras law `leadCoeff_two_pow`), so
+the drop condition `c_k < M` collapses to the classical Collatz inequality
+`3^a < 2^b` — "enough halvings to overcome the triplings."  This is the uniform drop
+theorem: a residue class drops below itself as soon as one exhibits a valid window
+with `a` odd steps, `b` even steps, `3^a < 2^b`, and a constant that lands below `r`.
+No `affOrbit.1` computation is needed — the leading coefficient is forced by the
+parity counts alone. -/
+theorem terras_attainsBelow {b r : ℕ} (v : List Bool) (hk : 0 < v.length)
+    (hcount : v.count false = b) (hval : AffValid v (2 ^ b) r)
+    (hlt : 3 ^ v.count true < 2 ^ b)
+    (hd : (affOrbit v (2 ^ b, r)).2 < r)
+    {n : ℕ} (hn : n % 2 ^ b = r) : AttainsBelow n := by
+  refine parityVector_attainsBelow v hk hval ?_ hd hn
+  rw [affOrbit_fst, ← hcount, leadCoeff_two_pow, hcount]
+  exact hlt
+
 /-! ### Decidable certificates: the engine as a one-shot `by decide`
 
 `AffValid` is a `Prop`-valued inductive, so supplying a certificate still means writing
@@ -1349,6 +1368,18 @@ manual trajectory chase and no hand-built `AffValid` term.  The whole drop-certi
 (validity, `9 < 16`, `2 < 3`, non-emptiness) collapses to one decidable check. -/
 example {n : ℕ} (h : n % 16 = 3) : AttainsBelow n :=
   dropCert_attainsBelow [true, false, true, false, false, false] (by decide) h
+
+/-- Worked instance of the uniform Terras criterion `terras_attainsBelow`: `n ≡ 3
+(mod 16)` drops because its six-step window has `a = 2` triplings and `b = 4`
+halvings with `3^2 = 9 < 16 = 2^4`.  The only genuine arithmetic content is that
+single inequality `3^a < 2^b`; the validity, halving count `b`, and constant drop are
+kernel computations.  This is the textbook "enough halvings beat the triplings"
+made into a one-line drop certificate. -/
+example {n : ℕ} (h : n % 16 = 3) : AttainsBelow n :=
+  terras_attainsBelow (b := 4) [true, false, true, false, false, false]
+    (by decide) (by decide) (affValidB_sound (by decide))
+    (by decide) (by decide)
+    (show n % 2 ^ 4 = 3 by rw [show (2 : ℕ) ^ 4 = 16 from by norm_num]; exact h)
 
 /-- The one-shot certificate scales to longer windows with no extra proof effort: the
 `n ≡ 11 (mod 32)` drop (eight steps, parity vector `[odd,even,odd,even,even,odd,even,even]`,

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -419,3 +419,60 @@ alone for a power-of-two modulus `2^b`.
   (one inductive statement covering all determined classes via the `3^a < 2^b` criterion),
   then Terras/Korec natural-density-1 stopping time. Tao axiom stays BLOCKED. Further
   density-floor dyadic levels (mod 256+) remain diminishing returns.
+
+## Session 2026-06-28 (researcher-3) — ACT: uniform Terras drop criterion `3^a < 2^b`
+
+**Mode**: BUILD (Docker down; offline `LAKE_UNSAFE=1 ./bin/lake env lean`, REAL_EXIT 0,
+clean). **Outcome**: progress — the long-documented "uniform drop theorem" lever, axiom-free.
+
+### What I Did
+Added `terras_attainsBelow`: the residue-drop criterion stated as the **textbook
+inequality `3^a < 2^b`** instead of the opaque `(affOrbit v (M,r)).1 < M`. For a
+power-of-two modulus `2^b` and a valid window `v` with `v.count false = b` halvings and
+`a = v.count true` triplings, the realized leading coefficient is *forced* to `3^a` by
+the Terras law (`leadCoeff_two_pow` ∘ `affOrbit_fst`), so the leading-coefficient drop
+check collapses to `3^a < 2^b` — "enough halvings to overcome the triplings." Proof is
+4 lines: `refine parityVector_attainsBelow …; rw [affOrbit_fst, ← hcount,
+leadCoeff_two_pow, hcount]; exact hlt`. Added a worked `n ≡ 3 (mod 16)` example whose
+only genuine arithmetic content is `3^2 = 9 < 16 = 2^4` (validity / halving count /
+constant drop are `decide`). `#print axioms terras_attainsBelow` → `[propext,
+Classical.choice, Quot.sound]` only (no `tao_2019`, no `Lean.ofReduceBool`).
+
+### Key Findings (computed, Python, mirroring the Lean defs)
+- **The auto engine `autoDropCert` is genuinely WEAKER than the hand-picked density
+  floor, not stronger.** Counts of auto-certified residues mod `2^b`: b=3→3/8, b=4→8/16,
+  b=5→24/32 (0.75), b=6→39/64 (0.61), b=7→**97/128** (0.758), b=8→211/256 (0.824). It is
+  **not monotone** in b and at b=7 gives 97/128 < the hand-picked **115/128**. The 18
+  missing residues (0,1,9,41,54,55,62,78,82,83,94,97,105,107,121,124,125,126 mod 128) are
+  exactly the ones whose drop needs a *non-residue-determined* argument: even residues that
+  drop in one step (`even_attainsBelow`, captured by the hand floor but NOT by the
+  "wait for the window to close with c odd" auto loop, since `c = 2^b` only becomes odd
+  after all b halvings), plus boundary classes failing `d_k < r` (e.g. r=0,1). So
+  `autoDropCert` certifies precisely the *odd* residue-determined drop classes; it does
+  not subsume evens. Wiring the auto engine into the density floor would *lower* the
+  proven floor — correctly NOT done.
+- This sharpens the honest status: the auto engine's value is turnkey certification of
+  individual residue-determined (odd) classes, not a better density floor.
+
+### Honest status
+- This is the **uniform drop theorem** (prior sessions' documented next lever): the drop
+  criterion is now the classical `3^a < 2^b`, derived once from the parity counts rather
+  than recomputed per residue. It is a *restatement/uniformization* of existing
+  infrastructure (`leadCoeff_two_pow`, `parityVector_attainsBelow`), not new Collatz
+  mathematics: the density floor is unchanged (115/128) and `tao_2019` stays BLOCKED.
+  Value: the load-bearing drop condition is now human-legible number theory, and the
+  Terras `3^a/2^b` law is connected directly to `AttainsBelow`.
+
+### Files Modified
+- proofs/Proofs/CollatzStructuredOQ02OQ03.lean (+1 theorem 57→58, +2 examples, 1667→1698
+  lines; 1 axiom unchanged, 0 sorries)
+- src/data/proofs/collatz-structured-oq-02-oq-03/meta.json (counts synced 1568/54/12 →
+  1698/58/13 — meta was stale vs origin/main; + highlight)
+- src/data/research/problems/collatz-structured-oq-02-oq-03.json (leanFiles counts synced)
+
+### Next Steps
+- The genuinely remaining lever is unchanged and hard: a single inductive statement that
+  COUNTS how many residues mod `2^b` are determined-drop classes and shows that count/2^b
+  → 1 (Terras natural-density-1 stopping time). `tao_2019` stays BLOCKED. Dyadic density
+  levels (mod 256+) remain diminishing returns AND, per this session, the auto engine does
+  not even recover the hand floor, so they still need the even-class argument by hand.

--- a/research/problems/collatz-structured-oq-02-oq-03/state.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/state.md
@@ -4,7 +4,7 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-06-27T19:00:00-07:00
-**Iteration**: 6
+**Iteration**: 7
 
 ## Current Focus
 ACT — completed de-risk **component (1)**: the residue-drop engine now AUTO-DERIVES the

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,12 +20,12 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1568,
+    "lineCount": 1698,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
-    "theoremCount": 54,
-    "definitionCount": 12
+    "theoremCount": 58,
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "The Collatz conjecture asserts every positive integer's orbit reaches 1. Short of the full conjecture, 'almost all' results bound the orbit for density-one sets of starting values. Terras (1976) and Korec (1994) showed almost all n (in natural density) have finite stopping time — their orbit drops below the starting value. Tao (2019, Forum Math. Pi) gave a dramatically stronger statement: for any f → ∞, almost all n (in the finer logarithmic density) have orbit minimum below f(n), i.e. orbits attain almost bounded values. OQ-03 asks whether this analytic landmark can be formalized in Lean.",
@@ -133,12 +133,12 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1568,
+    "lineCount": 1698,
     "axiomCount": 1,
-    "theoremCount": 54,
+    "theoremCount": 58,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
-    "definitionCount": 12
+    "definitionCount": 13
   },
   "sorries": 0,
   "highlights": [
@@ -152,6 +152,7 @@
     "Two new odd classes n ≡ 11 (mod 32) and n ≡ 23 (mod 32) each drop below themselves in exactly 8 residue-determined steps (…→27m+10<32m+11 and …→27m+20<32m+23), axiom-free",
     "Dyadic refinement is genuine: of the unstable classes 7,11,15 (mod 16), passing to mod 32 stabilises the half-classes 23 (from 7) and 11 (from 11); 7,15,27,31 (mod 32) remain m-dependent",
     "Earlier floor preserved: n ≡ 3 (mod 16) drops in 6 steps (attainsBelow_density_lower_16, ≥ 13/16); evens and powers of two handled by the n/2 branch",
-    "Tao 2019 stated precisely (tao_2019 axiom, HasLogDensityOne); deep analytic proof BLOCKED, all elementary content independent of the axiom"
+    "Tao 2019 stated precisely (tao_2019 axiom, HasLogDensityOne); deep analytic proof BLOCKED, all elementary content independent of the axiom",
+    "Uniform Terras drop criterion `terras_attainsBelow`: for a window with a triplings and b halvings on modulus 2^b, the drop condition c_k < 2^b collapses to the textbook inequality 3^a < 2^b — the leading coefficient is forced to 3^a by the parity counts (leadCoeff_two_pow), so no affine-orbit computation is needed. Axiom-free."
   ]
 }

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -130,13 +130,14 @@
     {
       "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
       "filename": "CollatzStructuredOQ02OQ03.lean",
-      "lineCount": 1568,
-      "theoremCount": 54,
+      "lineCount": 1698,
+      "theoremCount": 58,
       "axiomCount": 1,
       "defCount": 12,
       "sorryCount": 0,
       "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzStructuredOQ02OQ03.lean"
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzStructuredOQ02OQ03.lean",
+      "definitionCount": 13
     },
     {
       "path": "Proofs/CollatzStructuredOQ03.lean",


### PR DESCRIPTION
## Summary

Adds `terras_attainsBelow` — the **uniform drop theorem** flagged by prior sessions as the genuine next lever. It states the residue-drop condition as the **textbook Collatz inequality `3^a < 2^b`** instead of the opaque `(affOrbit v (M,r)).1 < M`.

For a power-of-two modulus `2^b` and a valid residue-determined window `v` with `v.count false = b` halvings and `a = v.count true` triplings, the realized leading coefficient is *forced* to `3^a` by the existing Terras law (`leadCoeff_two_pow ∘ affOrbit_fst`). So the leading-coefficient drop check collapses to `3^a < 2^b` — "enough halvings to overcome the triplings." Proof is 4 lines; a worked `n ≡ 3 (mod 16)` example reduces to the single arithmetic fact `3^2 = 9 < 16 = 2^4`.

## Verification
- Offline `LAKE_UNSAFE=1 ./bin/lake env lean` (Docker host down): whole file **REAL_EXIT 0**, no errors/warnings.
- `#print axioms terras_attainsBelow` → `[propext, Classical.choice, Quot.sound]` only — **axiom-free** (no `tao_2019`, no `Lean.ofReduceBool`).

## Honest scope
This is a **uniformization/restatement** of existing infrastructure, not new Collatz mathematics. The density floor is **unchanged (115/128)** and `tao_2019` stays **BLOCKED**. Value: the load-bearing drop condition is now human-legible number theory directly connecting the Terras `3^a/2^b` law to `AttainsBelow`.

This session also documents a Python-verified correction to the engine's framing: the turnkey auto engine `autoDropCert` is **weaker** than the hand-picked density floor (97/128 vs 115/128 at b=7, non-monotone in b) — it certifies only odd residue-determined classes, missing one-step even drops, so wiring it into the density floor would *lower* the proven bound.

## Counts
57→58 theorems, 1667→1698 lines, 1 axiom unchanged, 0 sorries. meta/research JSON counts synced (were stale at 1568/54/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)