### PR TITLE
Fix banach-fixed-point-oq-01 annotation enums + add references

### DIFF
--- a/src/data/proofs/banach-fixed-point-oq-01/annotations.json
+++ b/src/data/proofs/banach-fixed-point-oq-01/annotations.json
@@ -2,7 +2,7 @@
   {
     "title": "From 'a fixed point exists' to a quantitative theorem",
     "mathContext": "Mathlib's `ContractingWith K f` bundles `K < 1` with `LipschitzWith K f`. Over a nonempty complete metric space, `ContractingWith.fixedPoint f hf` is THE fixed point, `fixedPoint_isFixedPt` proves `f p = p`, and `fixedPoint_unique'` proves any two fixed points coincide. The uniqueness lemma `fixedPoint_unique_of_isFixedPt` carries `omit [CompleteSpace α] [Nonempty α]` because uniqueness is a pure consequence of the contraction inequality — two fixed points x,y satisfy d(x,y) = d(fx,fy) ≤ K·d(x,y) with K<1, forcing d(x,y)=0.",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": [
       "ContractingWith.fixedPoint and fixedPoint_isFixedPt in Mathlib",
       "ContractingWith.fixedPoint_unique'",
@@ -14,7 +14,10 @@
       "the definition of a fixed point IsFixedPt f x ↔ f x = x"
     ],
     "proofId": "banach-fixed-point-oq-01",
-    "range": { "startLine": 46, "endLine": 55 },
+    "range": {
+      "startLine": 46,
+      "endLine": 55
+    },
     "id": "ann-banach-oq01-existence-uniqueness",
     "type": "insight",
     "content": "Existence and uniqueness are the foundation. `exists_fixedPoint` packages Mathlib's `ContractingWith.fixedPoint f hf` together with `fixedPoint_isFixedPt` to produce `∃ p, IsFixedPt f p`. `fixedPoint_unique_of_isFixedPt` shows any two fixed points coincide via `fixedPoint_unique'`. Crucially this uniqueness statement omits the `CompleteSpace` and `Nonempty` instances: uniqueness needs neither — it follows purely from the contraction inequality, since if f x = x and f y = y then d(x,y) = d(f x, f y) ≤ K·d(x,y) with K < 1, which forces d(x,y) = 0. Completeness and nonemptiness are only needed to guarantee a fixed point actually exists (the Picard iterates form a Cauchy sequence whose limit must lie in the space)."
@@ -22,7 +25,7 @@
   {
     "title": "Picard iteration: the fixed point is the limit of an algorithm",
     "mathContext": "`tendsto_iterate` restates `ContractingWith.tendsto_iterate_fixedPoint`: for every seed x, the iterate sequence f^[n] x converges in the neighborhood filter 𝓝 p to p = `ContractingWith.fixedPoint f hf`. Convergence holds from ANY starting point — there is no basin-of-attraction restriction, because the single global contraction constant K < 1 contracts the whole space uniformly. Mechanically, d(f^[n+1] x, f^[n] x) ≤ Kⁿ · d(f x, x), so the partial sums of step displacements are dominated by the convergent geometric series Σ Kⁿ, making (f^[n] x) Cauchy.",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": [
       "ContractingWith.tendsto_iterate_fixedPoint",
       "Picard iteration f^[n] x",
@@ -35,7 +38,10 @@
       "Cauchy sequences and completeness"
     ],
     "proofId": "banach-fixed-point-oq-01",
-    "range": { "startLine": 57, "endLine": 61 },
+    "range": {
+      "startLine": 57,
+      "endLine": 61
+    },
     "id": "ann-banach-oq01-picard",
     "type": "insight",
     "content": "What distinguishes Banach's theorem from purely existential fixed point theorems (Brouwer, Schauder) is that it is CONSTRUCTIVE: `tendsto_iterate` says the Picard iterates f^[n] x converge to p from any starting point x, so the fixed point is the explicit limit of the algorithm x, f(x), f(f(x)), …. The proof that the iterates converge is the heart of the classical theorem: consecutive steps shrink geometrically, d(f^[n+1] x, f^[n] x) ≤ Kⁿ d(f x, x), so the sequence is Cauchy (its tail displacements are bounded by the convergent series Σ Kⁿ) and completeness supplies a limit, which continuity of f forces to be a fixed point. Here that whole argument is delegated to Mathlib's `tendsto_iterate_fixedPoint`; the entry's contribution is to surface it as a named, textbook-shaped statement."
@@ -43,7 +49,7 @@
   {
     "title": "Geometric error control: a-priori and a-posteriori bounds",
     "mathContext": "`apriori_estimate` restates `apriori_dist_iterate_fixedPoint_le`: dist (f^[n] x) p ≤ dist x (f x) · Kⁿ / (1 − K). The right-hand side is computable from the very first step (x, f x) and decays geometrically in n, so the accuracy after n steps is known BEFORE iterating. `aposteriori_estimate` is the n = 0 specialization (`dist_fixedPoint_le`): dist x p ≤ dist x (f x)/(1 − K). The denominator 1 − K is exactly the sum of the geometric tail Σ_{k≥0} Kᵏ that accumulates the remaining contraction.",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": [
       "ContractingWith.apriori_dist_iterate_fixedPoint_le",
       "ContractingWith.dist_fixedPoint_le",
@@ -56,9 +62,12 @@
       "asymptotic / rate-of-convergence reasoning"
     ],
     "proofId": "banach-fixed-point-oq-01",
-    "range": { "startLine": 63, "endLine": 75 },
+    "range": {
+      "startLine": 63,
+      "endLine": 75
+    },
     "id": "ann-banach-oq01-estimates",
-    "type": "technique",
+    "type": "insight",
     "content": "Banach's theorem is not only constructive but QUANTITATIVE, and these two estimates are why it dominates numerical practice. `apriori_estimate` bounds the error before you iterate: d(fⁿx,p) ≤ d(x,fx)·Kⁿ/(1−K), geometric decay with ratio K, so you can pre-compute how many steps guarantee a target accuracy. The factor 1/(1−K) is precisely the geometric series Σ Kᵏ summing the contraction over the infinite tail of remaining steps. `aposteriori_estimate` is the n=0 instance and is the practically useful one: after a single application of f you can already certify d(x,p) ≤ d(x,fx)/(1−K), turning the observed one-step displacement into a guaranteed error bound — the standard stopping rule for fixed-point iteration. Together they bracket the classic 'how far am I, and how far will I be' questions of iterative solvers."
   },
   {
@@ -77,9 +86,12 @@
       "NNReal vs ℝ coercions in Lean"
     ],
     "proofId": "banach-fixed-point-oq-01",
-    "range": { "startLine": 77, "endLine": 94 },
+    "range": {
+      "startLine": 77,
+      "endLine": 94
+    },
     "id": "ann-banach-oq01-concrete-lipschitz",
-    "type": "example",
+    "type": "concept",
     "content": "The abstract theorem is only useful once you can recognize contractions in the wild, so the file closes with a fully worked instance: the affine map f(x) = x/2 + c on ℝ. The first step is `contractAffine_contracting`, the verification that f is (1/2)-Lipschitz: rewriting with Real.dist_eq turns the goal into |(x−y)/2| ≤ (1/2)|x−y|, and since |(x−y)/2| = |x−y|/2 the distances scale by exactly 1/2. Combined with 1/2 < 1 this discharges `ContractingWith (1/2) f`, so every conclusion of the abstract theorem now applies to this map. The mildly fiddly part is the coercion bookkeeping between the NNReal contraction constant and the real-valued distance, handled by `push_cast`."
   },
   {
@@ -98,9 +110,12 @@
       "uniqueness of the fixed point of a contraction"
     ],
     "proofId": "banach-fixed-point-oq-01",
-    "range": { "startLine": 96, "endLine": 121 },
+    "range": {
+      "startLine": 96,
+      "endLine": 121
+    },
     "id": "ann-banach-oq01-concrete-fixedpoint",
-    "type": "example",
+    "type": "concept",
     "content": "With the contraction hypothesis in hand, `contractAffine_fixedPoint` computes the fixed point in closed form: solving x = x/2 + c gives x = 2c, and because a contraction has at most one fixed point, exhibiting 2c as a fixed point and invoking uniqueness pins it down completely — there is no other. The remaining two theorems make the abstract results fully concrete: `contractAffine_tendsto` specializes Picard convergence (from any real seed the iterates x, x/2+c, x/4+3c/2, … converge to 2c) and `contractAffine_apriori` specializes the geometric error bound to |f^[n] x − 2c| ≤ |x − (x/2+c)|·(1/2)ⁿ/(1−1/2). Both are obtained by rewriting the abstract `ContractingWith.fixedPoint` with the value 2c. This is the simplest nontrivial contraction and makes every part of the abstract theorem checkable by hand."
   }
 ]

--- a/src/data/proofs/banach-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01/meta.json
@@ -109,5 +109,25 @@
     "path": "Proofs/BanachFixedPointOQ01.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Banach, S.",
+      "title": "Sur les opérations dans les ensembles abstraits et leur application aux équations intégrales",
+      "year": "1922",
+      "note": "Fundamenta Mathematicae 3, 133–181. The original contraction mapping principle, from Banach's doctoral thesis."
+    },
+    {
+      "authors": "Granas, A. and Dugundji, J.",
+      "title": "Fixed Point Theory",
+      "year": "2003",
+      "note": "Springer Monographs in Mathematics. Situates the Banach principle alongside the Brouwer and Schauder theorems."
+    },
+    {
+      "authors": "mathlib community",
+      "title": "Mathlib4: Mathlib.Topology.MetricSpace.Contracting (ContractingWith API)",
+      "year": "2024",
+      "note": "Source of fixedPoint, tendsto_iterate_fixedPoint, apriori_dist_iterate_fixedPoint_le, and dist_fixedPoint_le used here."
+    }
+  ]
 }


### PR DESCRIPTION
Follow-up repair to #31305, which enriched `banach-fixed-point-oq-01` annotations 3→5 but used **invalid enum values**:

- `significance: "core"` (×3) — not in `AnnotationSignificance` (critical|key|supporting)
- `type: "technique"` and `type: "example"` (×2) — not in `AnnotationType` (theorem|lemma|definition|tactic|concept|insight|warning)

These are cast through `as unknown as Annotation[]`, so `tsc` never caught them, but the renderer falls back to defaults on unknown values.

## Changes
- `significance` `core` → `critical` (the matching "Core to the proof" value) on the three abstract-principle annotations.
- `type` `technique` → `insight` (estimates) and `example` → `concept` (the two concrete annotations).
- Added a `references` array (Banach's 1922 thesis, Granas–Dugundji *Fixed Point Theory*, the Mathlib `ContractingWith` source) — the entry had none.

All #31305 annotation **content is preserved**; only enum fields and references change.

## Verification
- `pnpm gallery:check-size` — within caps. `tsc -b` — 0 errors. JSON valid; all annotation enums now valid.