### PR TITLE
Enrich denumerability-rationals-oq-07: annotation coverage + enum fix

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-07/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-07/annotations.json
@@ -1,12 +1,35 @@
 [
   {
+    "id": "ann-header-orientation",
+    "proofId": "denumerability-rationals-oq-07",
+    "range": {
+      "startLine": 3,
+      "endLine": 32
+    },
+    "type": "concept",
+    "title": "Cantor's two-stage argument, made into an explicit Σ",
+    "content": "The docstring frames the whole file. Cantor's 1874 countability argument has two stages — there are only ℵ₀-many polynomials over ℚ (OQ-06: #(ℚ[X]) = ℵ₀), and each polynomial has only finitely many roots. The gallery previously recorded #{x : ℝ // IsAlgebraic ℚ x} = ℵ₀ only through Mathlib's black-box one-liner Algebraic.cardinalMk_of_countable_of_charZero; this entry lays the structure bare as a single injection x ↦ (minpoly ℚ x, x) into Σ p : ℚ[X], p.rootSet ℝ — a countable union (over the ℵ₀ index ℚ[X]) of finite root fibers. Nothing uses the order or completeness of ℝ, only that the target is a characteristic-zero field, so the complex count ℂ follows from the identical argument.",
+    "mathContext": "$\\{x : \\mathbb{R} \\mid \\text{alg}\\} \\hookrightarrow \\Sigma_{p \\in \\mathbb{Q}[X]} \\mathrm{rootSet}(p)$, a countable union of finite sets.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cantor's countability of algebraic numbers",
+      "countable union of finite sets",
+      "minimal polynomial as a canonical witness",
+      "characteristic-zero fields"
+    ],
+    "prerequisites": [
+      "cardinal numbers and ℵ₀",
+      "algebraic numbers and minimal polynomials"
+    ]
+  },
+  {
     "id": "ann-polynomial-count",
     "proofId": "denumerability-rationals-oq-07",
     "range": {
-      "startLine": 46,
-      "endLine": 50
+      "startLine": 38,
+      "endLine": 41
     },
-    "type": "key-step",
+    "type": "lemma",
     "title": "The Index Set: #(ℚ[X]) = ℵ₀",
     "content": "cardinalMk_polynomial_rat reproves OQ-06's fact inline so this entry stands alone: rewriting with Polynomial.cardinalMk_eq_max turns the goal into max #ℚ ℵ₀, mk_eq_aleph0 ℚ substitutes #ℚ = ℵ₀, and max_self collapses max ℵ₀ ℵ₀ to ℵ₀. This ℵ₀-sized polynomial ring is the index over which the algebraic numbers are organised in the rest of the file.",
     "mathContext": "$\\#(\\mathbb{Q}[X]) = \\max(\\#\\mathbb{Q}, \\aleph_0) = \\aleph_0$ — the countable index set of the Cantor argument.",
@@ -26,8 +49,8 @@
     "id": "ann-sigma-bound",
     "proofId": "denumerability-rationals-oq-07",
     "range": {
-      "startLine": 56,
-      "endLine": 67
+      "startLine": 47,
+      "endLine": 59
     },
     "type": "theorem",
     "title": "Countable Union of Finite Fibers: #(Σ p, p.rootSet K) ≤ ℵ₀",
@@ -51,26 +74,49 @@
     "id": "ann-injection-and-count",
     "proofId": "denumerability-rationals-oq-07",
     "range": {
-      "startLine": 64,
-      "endLine": 126
+      "startLine": 61,
+      "endLine": 80
     },
     "type": "theorem",
-    "title": "The Injection x ↦ (minpoly ℚ x, x) and the ℵ₀ Count",
-    "content": "algebraicReal_inject_sigma maps each algebraic real x to the pair (minpoly ℚ x, x): membership x ∈ (minpoly ℚ x).rootSet ℝ follows from isAlgebraic_iff_isIntegral (giving IsIntegral, hence a nonzero minimal polynomial via minpoly.ne_zero) together with minpoly.aeval, packaged by mem_rootSet; injectivity is immediate because the second coordinate is literally x. Composing this injection's cardinal bound (mk_le_of_injective) with cardinalMk_sigma_rootSet_le gives cardinalMk_algebraic_reals_le : #{x : ℝ // IsAlgebraic ℚ x} ≤ ℵ₀, and cardinalMk_algebraic_reals closes the equality by antisymmetry against aleph0_le_cardinalMk_algebraic — the self-contained lower bound ℵ₀ ≤ #{x : K // IsAlgebraic ℚ x} built from the ℕ-injection n ↦ (n : K) (every natural is algebraic, isAlgebraic_nat). The complex analogues reuse the identical argument.",
-    "mathContext": "$x \\mapsto (\\mathrm{minpoly}_\\mathbb{Q} x, x)$ injects the algebraic reals into the $\\Sigma$, so $\\#\\{x:\\mathbb{R}\\mid \\text{alg}\\} \\le \\aleph_0$; with $\\aleph_0 \\le \\#\\{\\cdots\\}$ the count is exactly $\\aleph_0$.",
+    "title": "The Injection x ↦ (minpoly ℚ x, x)",
+    "content": "algebraicReal_inject_sigma maps each algebraic real x to the pair (minpoly ℚ x, x): membership x ∈ (minpoly ℚ x).rootSet ℝ follows from isAlgebraic_iff_isIntegral (giving IsIntegral, hence a nonzero minimal polynomial via minpoly.ne_zero) together with minpoly.aeval, packaged by mem_rootSet; injectivity is immediate because the second coordinate is literally x. Composing this injection's cardinal bound (mk_le_of_injective) with cardinalMk_sigma_rootSet_le gives cardinalMk_algebraic_reals_le : #{x : ℝ // IsAlgebraic ℚ x} ≤ ℵ₀. The minimal polynomial is doing the real work: an algebraic number has no canonical name, but minpoly ℚ x is a canonical witness that pins x to a specific ℚ[X]-fiber.",
+    "mathContext": "$x \\mapsto (\\mathrm{minpoly}_\\mathbb{Q} x, x)$ injects the algebraic reals into the $\\Sigma$, so $\\#\\{x:\\mathbb{R}\\mid \\text{alg}\\} \\le \\aleph_0$.",
     "significance": "critical",
     "relatedConcepts": [
       "minpoly.aeval",
       "minpoly.ne_zero",
       "isAlgebraic_iff_isIntegral",
       "Polynomial.mem_rootSet",
-      "Cardinal.mk_le_of_injective",
-      "isAlgebraic_nat"
+      "Cardinal.mk_le_of_injective"
     ],
     "prerequisites": [
       "minimal polynomials",
+      "injections and cardinal comparison"
+    ]
+  },
+  {
+    "id": "ann-lower-bound-and-equality",
+    "proofId": "denumerability-rationals-oq-07",
+    "range": {
+      "startLine": 82,
+      "endLine": 125
+    },
+    "type": "theorem",
+    "title": "The char-zero lower bound and the ℵ₀ equality (ℝ and ℂ)",
+    "content": "The upper bound ≤ ℵ₀ is only half the equality; aleph0_le_cardinalMk_algebraic supplies the reverse ℵ₀ ≤ #{x : K // IsAlgebraic ℚ x} for any characteristic-zero field K, built explicitly with no black-box lemma: ℕ injects into the algebraic elements via n ↦ (n : K) (every natural is algebraic, isAlgebraic_nat), and Nat.cast is injective in characteristic zero, so ℵ₀ = #ℕ ≤ #(algebraic elements). cardinalMk_algebraic_reals then closes #{x : ℝ // IsAlgebraic ℚ x} = ℵ₀ by le_antisymm of the Σ upper bound against this lower bound. Because the decomposition never used any special property of ℝ beyond char-zero-field, cardinalMk_algebraic_complex_le and cardinalMk_algebraic_complex repeat the identical injection-and-fiber argument for ℂ.",
+    "mathContext": "$\\aleph_0 = \\#\\mathbb{N} \\le \\#\\{x : K \\mid \\text{alg}\\}$ via $n \\mapsto (n:K)$; with the $\\Sigma$ bound, $\\#\\{x:\\mathbb{R}\\mid\\text{alg}\\} = \\#\\{x:\\mathbb{C}\\mid\\text{alg}\\} = \\aleph_0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "isAlgebraic_nat",
+      "CharZero and Nat.cast injectivity",
+      "Cardinal.mk_le_of_injective",
+      "le_antisymm on cardinals",
+      "ℝ/ℂ interchangeability"
+    ],
+    "prerequisites": [
+      "antisymmetry of ≤ on cardinals",
       "injections and cardinal comparison",
-      "antisymmetry of ≤ on cardinals"
+      "characteristic-zero fields"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `denumerability-rationals-oq-07` (algebraic reals as a Σ over ℚ[X], #{alg} = ℵ₀).

## Changes
- **Annotations 3 → 5**, partitioning the file cleanly with no overlap:
  - `ann-header-orientation` (3–32, concept) — Cantor's two-stage argument and the separating-mechanism-from-black-box framing.
  - `ann-lower-bound-and-equality` (82–125, theorem) — the char-zero lower bound `ℵ₀ ≤ #{alg}` from the ℕ-injection `n ↦ (n:K)`, the `le_antisymm` closing the ℝ equality, and the ℂ analogues (previously bundled inside the broad injection annotation).
- **Fixed invalid enum**: `type: "key-step"` → `"lemma"` on the `#(ℚ[X]) = ℵ₀` index lemma (`key-step` is not in `AnnotationType`).
- **Re-scoped ranges** to the actual theorem line ranges (the existing annotations pointed a few lines off).

meta.json was already rich (5 keyInsights, references, crossRefs, conclusion) and is unchanged.

## Verification
- `pnpm gallery:check-size` — within caps. `tsc -b` — 0 errors. All 5 annotation enums valid.

No `index.ts` created — the slug-based loader (#20992) discovers entries directly.