### PR TITLE
research(collatz-structured-oq-02-oq-03): sharpness of Terras drop criterion 3^a<2^b [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -1291,6 +1291,31 @@ theorem terras_attainsBelow {b r : ℕ} (v : List Bool) (hk : 0 < v.length)
   rw [affOrbit_fst, ← hcount, leadCoeff_two_pow, hcount]
   exact hlt
 
+/-- **Sharpness of the Terras criterion.**  For a power-of-two modulus `2^b` whose
+window performs exactly its `b` halvings (`v.count false = b`), the engine's
+leading-coefficient drop check `c_k < M` is *equivalent* to `3^a < 2^b` — not merely
+implied by it.  The realized leading coefficient is *forced* to `3^a` (`leadCoeff_two_pow`),
+so `3^a < 2^b` is the **exact** reach of the residue-determined method: a window with
+`3^a ≥ 2^b` (too many triplings for its halvings) can never satisfy the coefficient drop
+condition, whatever the residue `r`.  This is the necessity companion to
+`terras_attainsBelow`, and it pins down why the residue-determined density floor
+plateaus — enlarging the dyadic modulus `2^b` only ever certifies residues whose
+determined window already carries strictly more halvings than `(log₂ 3)·(triplings)`,
+so no purely residue-determined window certifies a class once `3^a ≥ 2^b`. -/
+theorem terras_drop_iff {b r : ℕ} (v : List Bool) (hcount : v.count false = b) :
+    (affOrbit v (2 ^ b, r)).1 < 2 ^ b ↔ 3 ^ v.count true < 2 ^ b := by
+  rw [affOrbit_fst, ← hcount]; exact leadCoeff_two_pow_lt_iff v
+
+/-- Concrete witness of the sharp boundary: the *realizable alternating* window
+`[odd, even, odd, even, odd, even]` (three triplings, three halvings) lands at leading
+coefficient `3^3 = 27`, which is **not** below its modulus `2^3 = 8`.  Three triplings
+need at least `⌈3·log₂ 3⌉ = 5` halvings to drop; three halvings are not enough, so this
+window — however its residue is chosen — cannot certify a drop.  (Contrast the gallery
+families, where the halvings always outnumber the triplings: e.g. `3 (mod 16)` uses
+`3^2 = 9 < 16 = 2^4`.) -/
+example : ¬ (leadCoeff [true, false, true, false, true, false] (2 ^ 3) < 2 ^ 3) := by
+  decide
+
 /-! ### Decidable certificates: the engine as a one-shot `by decide`
 
 `AffValid` is a `Prop`-valued inductive, so supplying a certificate still means writing

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -476,3 +476,50 @@ Classical.choice, Quot.sound]` only (no `tao_2019`, no `Lean.ofReduceBool`).
   → 1 (Terras natural-density-1 stopping time). `tao_2019` stays BLOCKED. Dyadic density
   levels (mod 256+) remain diminishing returns AND, per this session, the auto engine does
   not even recover the hand floor, so they still need the even-class argument by hand.
+
+## Session 2026-06-28 (researcher-3, cycle 2) — ACT: sharpness/necessity of the Terras criterion
+
+**Mode**: BUILD (Docker down; offline `LAKE_UNSAFE=1 ./bin/lake env lean`, REAL_EXIT 0, clean).
+**Outcome**: progress — necessity companion to last session's `terras_attainsBelow`; axiom-free.
+
+### What I Did
+Last commit (8c9045a) added `terras_attainsBelow` proving SUFFICIENCY (`3^a < 2^b ⟹` the
+engine certifies a drop). This session adds the missing NECESSITY/sharpness direction:
+- `terras_drop_iff {b r} (v) (hcount : v.count false = b) : (affOrbit v (2^b,r)).1 < 2^b
+  ↔ 3^(v.count true) < 2^b`. Proof is 1 line (`rw [affOrbit_fst, ← hcount];
+  exact leadCoeff_two_pow_lt_iff v`): the realized leading coefficient is *forced* to `3^a`
+  by `leadCoeff_two_pow`, so the engine's drop check is EQUIVALENT to `3^a < 2^b`, not just
+  implied by it. Hence `3^a ≥ 2^b` ⟹ NO residue-determined window certifies that class,
+  whatever the residue — this is the exact reach of the residue-determined method.
+- Added a concrete sharp-boundary witness `example`: the *realizable alternating* window
+  `[odd,even,odd,even,odd,even]` (a=3, b=3) lands at `3^3 = 27 ≥ 2^3 = 8`, so it cannot
+  certify (`by decide`). Contrast the gallery families where halvings outnumber triplings
+  (`3 (mod 16)`: `3^2 = 9 < 16`).
+
+### Key Findings
+- This makes precise WHY the residue-determined density floor plateaus at 115/128
+  (documented diminishing returns): enlarging `2^b` only certifies residues whose
+  determined window already carries strictly more halvings than `(log₂ 3)·triplings`. A
+  class with `3^a ≥ 2^b` in its determined window is *provably* uncertifiable by this engine
+  — it is not a search-budget limitation but a structural boundary. This dovetails with the
+  prior session's computed non-monotonicity of the auto-certified counts (b=6 → 0.61).
+- `#print axioms terras_drop_iff` → `[propext, Classical.choice, Quot.sound]` only (no
+  `tao_2019`, no `Lean.ofReduceBool`). The `example` uses kernel `decide`, not `native_decide`.
+
+### Honest status
+- This is a **sharpness/necessity companion**, not new Collatz mathematics: the density floor
+  is unchanged (115/128) and `tao_2019` stays BLOCKED. Value: completes the criterion from
+  one-directional (sufficient) to an exact equivalence (`iff`), and gives a structural — not
+  empirical — explanation of the documented plateau. Low-LOC, high-clarity.
+
+### Files Modified
+- proofs/Proofs/CollatzStructuredOQ02OQ03.lean (+1 theorem 58→59, +1 example; 1698→1723 lines;
+  1 axiom unchanged, 0 sorries)
+- src/data/proofs/collatz-structured-oq-02-oq-03/meta.json (counts 1698/58 → 1723/59 + highlight)
+- src/data/research/problems/collatz-structured-oq-02-oq-03.json (leanFiles counts synced)
+
+### Next Steps (unchanged, genuinely hard)
+- The only remaining real lever is the Terras natural-density-1 COUNT: show the fraction of
+  residues mod 2^b that are determined-drop classes → 1. The non-monotone auto counts plus
+  this sharpness result confirm a finite dyadic computation cannot reach it — it needs the
+  CLT-style combinatorial argument on parity vectors. `tao_2019` stays BLOCKED.

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1698,
+    "lineCount": 1723,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
@@ -133,15 +133,16 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1698,
+    "lineCount": 1723,
     "axiomCount": 1,
-    "theoremCount": 58,
+    "theoremCount": 59,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 13
   },
   "sorries": 0,
   "highlights": [
+    "Sharpness of the Terras criterion (terras_drop_iff): for a power-of-two modulus 2^b whose window does exactly its b halvings, the engine's leading-coefficient drop check c_k < 2^b is EQUIVALENT to 3^a < 2^b, not merely implied by it — the realized leading coefficient is forced to 3^a (leadCoeff_two_pow), so 3^a ≥ 2^b means no residue-determined window can ever certify a drop, whatever the residue. This necessity companion to terras_attainsBelow pins down why the residue-determined density floor plateaus (115/128). Includes a concrete witness: the realizable alternating window [odd,even,odd,even,odd,even] lands at 3^3=27 ≥ 2^3=8 and cannot certify. Axiom-free (propext, Classical.choice, Quot.sound; kernel decide).",
     "Fully auto-derived residue-drop certificate (autoDropCert / autoDropCert_attainsBelow): for a power-of-two modulus 2^b the parity vector is itself residue-determined, so deriveVec COMPUTES it from (b,r) alone (reading each forced parity off the affine constant d while the leading coefficient stays even) — the caller no longer supplies a parity vector at all, only the modulus exponent and residue. affValidB_deriveVec proves the derived vector is always a valid AffValid certificate unconditionally (the recursion branches on exactly the validity conditions), so soundness never depends on the fuel bound. A new residue family r (mod 2^b) is now one line: autoDropCert_attainsBelow (b:=…) (r:=…) (by decide) h — validated by re-deriving n≡3 (mod 16), n≡11 (mod 32), n≡7 (mod 128) end-to-end with no hand-built vector. Axiom-free (propext, Quot.sound only; kernel decide, not native_decide).",
     "General residue-class density floor (attainsBelow_density_of_residues): for ANY modulus M ≥ 1 and any finite set R of residues each certified to drop below itself, at least |R|·(N−1) of [1,M·N] attain a value below themselves — lower density ≥ |R|/M. One injectivity argument ((r,m) ↦ M·m+r, with r<M the remainder mod M) replaces all the per-level pairwise-disjointness bookkeeping; the four bespoke floors (3/4, 13/16, 7/8, 115/128) become one-line instantiations. Re-derived the 13/16 floor (attainsBelow_density_lower_16_general) from it with the residue count 13 discharged by a kernel `decide`. Axiom-free (propext, Classical.choice, Quot.sound).",
     "Decidable parity-vector certificate: affValidB reflects the AffValid validity predicate into a computable Bool, affValidB_sound transports a true result back to the Prop, and dropCert M r v bundles validity + the drop bounds c_k<M, d_k<r into one Boolean. dropCert_attainsBelow then makes a whole residue family a single `by decide` (no trajectory chase, no hand-built certificate term) — e.g. the n≡3 (mod 16) and n≡11 (mod 32) drops each collapse to one line. Axiom-free (propext, Quot.sound only)",

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -130,8 +130,8 @@
     {
       "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
       "filename": "CollatzStructuredOQ02OQ03.lean",
-      "lineCount": 1698,
-      "theoremCount": 58,
+      "lineCount": 1723,
+      "theoremCount": 59,
       "axiomCount": 1,
       "defCount": 12,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Two commits on `collatz-structured-oq-02-oq-03` (OQ-03: Tao 2019 almost-all Collatz, logarithmic density 1). This branch's new content (`f6bb767`) adds the **necessity/sharpness** companion to the prior commit's uniform Terras drop criterion.

- `terras_attainsBelow` (prior commit `8c9045a`) proved **sufficiency**: `3^a < 2^b ⟹` the residue-determined engine certifies a drop.
- `terras_drop_iff` (this commit) proves the **exact equivalence**: for a power-of-two modulus `2^b` whose window does exactly its `b` halvings, the engine's leading-coefficient drop check `c_k < 2^b` is **iff** `3^a < 2^b` — the realized leading coefficient is *forced* to `3^a` by `leadCoeff_two_pow`. So `3^a ≥ 2^b` means **no** residue-determined window can certify that class, whatever the residue.

This is a *structural* (not empirical) explanation for the documented 115/128 density-floor plateau: a class with `3^a ≥ 2^b` in its determined window is provably uncertifiable by the engine — not a search-budget limitation. Includes a concrete sharp-boundary witness: the realizable alternating window `[odd,even,odd,even,odd,even]` lands at `3^3 = 27 ≥ 2^3 = 8` and cannot certify (`by decide`).

## Verification

- Offline `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/CollatzStructuredOQ02OQ03.lean` → **EXIT 0**, no errors/warnings (Docker host down this session).
- `#print axioms terras_drop_iff` → `[propext, Classical.choice, Quot.sound]` only — **0-axiom** (no `tao_2019`, no `Lean.ofReduceBool`; `example` uses kernel `decide`, not `native_decide`).
- +1 theorem (58→59), 1698→1723 lines. The one deep axiom `tao_2019` is unchanged and remains BLOCKED (multi-thousand-line analytic project); 0 sorries.

## Honest status

Sharpness/necessity companion, **not** new Collatz mathematics. The density floor is unchanged (115/128) and `tao_2019` stays axiomatized/BLOCKED. Value: completes the drop criterion from one-directional to an exact `iff`, and explains the plateau structurally. The only genuine remaining lever — the Terras natural-density-1 *count* (`#{determined-drop residues mod 2^b}/2^b → 1`) — needs the CLT-style combinatorial argument and is not a finite dyadic computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)