### PR TITLE
Enrich Complex Roots Come in Conjugate Pairs: annotations 3→6

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-03/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-complexroots-def",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-03",
+    "range": {
+      "startLine": 31,
+      "endLine": 32
+    },
+    "type": "definition",
+    "title": "The Complex Root Multiset of a Real Polynomial",
+    "content": "complexRoots p is defined as the root multiset of p.map(algebraMap ℝ ℂ): the real polynomial p is pushed into ℂ[X] by applying the canonical embedding ℝ ↪ ℂ to each coefficient, and then its roots (with multiplicity) are collected as a Multiset ℂ. Working with a multiset rather than a set is essential — multiplicity is exactly what makes the parity argument work, since a double real root contributes 2 to the count. Because ℂ is algebraically closed, this multiset has cardinality deg p, so it captures every root.",
+    "mathContext": "$\\mathrm{complexRoots}(p) = \\mathrm{roots}\\big(p^{\\mathbb{C}}\\big)$ where $p^{\\mathbb{C}} = p.\\mathrm{map}(\\mathbb{R} \\hookrightarrow \\mathbb{C}) \\in \\mathbb{C}[X]$; $|\\mathrm{complexRoots}(p)| = \\deg p$.",
+    "significance": "supporting",
+    "relatedConcepts": ["root multiset with multiplicity", "scalar extension of polynomials", "algebraMap ℝ ℂ", "algebraically closed field"],
+    "prerequisites": ["polynomial coefficient map (Polynomial.map)", "roots as a Multiset", "ℂ is algebraically closed"]
+  },
+  {
     "id": "ann-aeval-conj",
     "proofId": "descartes-rule-of-signs-oq-02-oq-03",
     "range": {
@@ -8,37 +23,67 @@
     },
     "type": "insight",
     "title": "Conjugating a Real Root Equation",
-    "content": "aeval_conj_eq_zero is the analytic heart of conjugate pairs. Mathlib's Polynomial.aeval_conj gives aeval(z̄)p = conj(aeval z p) for a real polynomial p, because conjugation fixes the real coefficients and is a ring homomorphism. So aeval(z̄)p = 0 ⟺ conj(aeval z p) = 0 ⟺ aeval z p = 0 (conjugation is injective, fixing 0). In one line: if z is a complex root of a real polynomial, so is its conjugate z̄.",
+    "content": "aeval_conj_eq_zero is the analytic heart of conjugate pairs. Mathlib's Polynomial.aeval_conj gives aeval(z̄)p = conj(aeval z p) for a real polynomial p, because conjugation fixes the real coefficients and is a ring homomorphism. So aeval(z̄)p = 0 ⟺ conj(aeval z p) = 0 ⟺ aeval z p = 0 (conjugation is injective, fixing 0). The proof is a one-liner: rw [aeval_conj]; simp, where simp discharges conj w = 0 ↔ w = 0 via star_eq_zero. In words: if z is a complex root of a real polynomial, so is its conjugate z̄.",
     "mathContext": "$p(\\bar z) = \\overline{p(z)}$ for $p \\in \\mathbb{R}[X]$, so $p(\\bar z) = 0 \\iff p(z) = 0$.",
     "significance": "key",
     "relatedConcepts": ["complex conjugation", "real polynomials", "Polynomial.aeval_conj", "ring homomorphism fixing reals"],
     "prerequisites": ["complex conjugation as a ring automorphism", "polynomial evaluation aeval", "conjugation fixes ℝ"]
   },
   {
-    "id": "ann-invariance",
+    "id": "ann-map-conj-real",
     "proofId": "descartes-rule-of-signs-oq-02-oq-03",
     "range": {
       "startLine": 41,
-      "endLine": 64
+      "endLine": 47
+    },
+    "type": "technique",
+    "title": "Conjugation Fixes the Mapped Polynomial",
+    "content": "map_conj_real establishes the technical lemma that pushing complex conjugation through p.map(algebraMap ℝ ℂ) leaves it unchanged. The proof composes the two coefficient maps via Polynomial.map_map (conj ∘ (ℝ↪ℂ)) and then shows that this composite ring hom equals ℝ↪ℂ by extensionality (RingHom.ext / ext r), since Complex.conj_ofReal says conjugation fixes every real number conj(↑r) = ↑r. This is the precise sense in which 'a real polynomial has real coefficients': as an element of ℂ[X], it is a fixed point of the conjugation action. It is the bridge that lets the invariance lemma apply conjugation as a root-preserving automorphism.",
+    "mathContext": "$\\overline{p^{\\mathbb{C}}} = p^{\\mathbb{C}}$ because each coefficient $\\overline{\\,\\overline{a_k}^{\\,\\mathbb{R}\\to\\mathbb{C}}} = a_k$, i.e. $\\mathrm{conj} \\circ (\\mathbb{R}\\hookrightarrow\\mathbb{C}) = (\\mathbb{R}\\hookrightarrow\\mathbb{C})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Polynomial.map_map", "Complex.conj_ofReal", "ring homomorphism extensionality", "fixed point of conjugation"],
+    "prerequisites": ["composition of coefficient maps", "RingHom extensionality", "conj fixes ℝ"]
+  },
+  {
+    "id": "ann-invariance",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-03",
+    "range": {
+      "startLine": 49,
+      "endLine": 57
     },
     "type": "insight",
     "title": "The Root Multiset Is Conjugation-Invariant",
-    "content": "map_conj_real shows conjugation fixes the mapped polynomial p.map(algebraMap ℝ ℂ) (its coefficients are real, Complex.conj_ofReal). complexRoots_conj_invariant then uses roots_map_of_injective_of_card_eq_natDegree together with IsAlgClosed.card_roots_eq_natDegree (the polynomial splits completely over the algebraically closed ℂ, so its root multiset has full size deg p) to conclude the root multiset is unchanged by conjugation. Because conjugation is injective, count_complexRoots_conj reads off that z and z̄ occur with exactly the same multiplicity (Multiset.count_map_eq_count').",
-    "mathContext": "$\\mathrm{conj}_*(\\mathrm{roots}\\,p) = \\mathrm{roots}\\,p$ in $\\mathbb{C}$, and $\\mathrm{mult}_z(p) = \\mathrm{mult}_{\\bar z}(p)$.",
+    "content": "complexRoots_conj_invariant is the structural core: applying conjugation to the entire complex root multiset returns the same multiset. The proof uses roots_map_of_injective_of_card_eq_natDegree — for an injective ring hom f, the roots of (q.map f) are the f-image of q's roots provided q's root multiset already has full cardinality deg q. That cardinality hypothesis is exactly IsAlgClosed.card_roots_eq_natDegree (over the algebraically closed ℂ, the polynomial splits completely). The map_conj_real lemma then rewrites (q.map conj) back to q, yielding (complexRoots p).map conj = complexRoots p. So conjugation merely permutes the roots — it sends the multiset to itself.",
+    "mathContext": "$\\mathrm{conj}_*\\big(\\mathrm{complexRoots}(p)\\big) = \\mathrm{complexRoots}(p)$, since $\\mathrm{conj}$ is an injective automorphism of $\\mathbb{C}$ and $p^{\\mathbb{C}}$ splits.",
     "significance": "key",
-    "relatedConcepts": ["root multiset", "Fundamental Theorem of Algebra (splitting)", "multiplicity", "injective image of a multiset"],
-    "prerequisites": ["roots with multiplicity as a Multiset", "ℂ is algebraically closed (full root count)", "count under an injective map"]
+    "relatedConcepts": ["root multiset", "Fundamental Theorem of Algebra (splitting)", "roots_map_of_injective_of_card_eq_natDegree", "injective image of a multiset"],
+    "prerequisites": ["roots with multiplicity as a Multiset", "ℂ is algebraically closed (full root count)", "image of a multiset under an injective map"]
+  },
+  {
+    "id": "ann-count",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-03",
+    "range": {
+      "startLine": 59,
+      "endLine": 64
+    },
+    "type": "technique",
+    "title": "Conjugate Roots Have Equal Multiplicity",
+    "content": "count_complexRoots_conj sharpens invariance from set membership to exact multiplicity: z and z̄ occur the same number of times. Rewriting the left side with the invariance lemma (so the count is taken inside the conjugated multiset) and applying Multiset.count_map_eq_count' for the injective conj gives count(z̄) = count(z). This upgrade from 'is a root' to 'is a root of the same order' is what guarantees the conjugate-pair packaging is balanced — a triple root z forces a triple root z̄ — and so the contribution of each non-real conjugate pair to the total degree is even.",
+    "mathContext": "$\\mathrm{mult}_{\\bar z}(p) = \\mathrm{mult}_{z}(p)$, i.e. $(\\mathrm{complexRoots}\\,p).\\mathrm{count}(\\bar z) = (\\mathrm{complexRoots}\\,p).\\mathrm{count}(z)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["multiplicity", "Multiset.count_map_eq_count'", "injective map preserves count", "balanced conjugate pairs"],
+    "prerequisites": ["count under an injective map", "conjugation-invariance of the root multiset"]
   },
   {
     "id": "ann-pairing",
     "proofId": "descartes-rule-of-signs-oq-02-oq-03",
     "range": {
       "startLine": 66,
-      "endLine": 93
+      "endLine": 76
     },
     "type": "concept",
     "title": "Non-Real Roots Split into {z, z̄} Pairs",
-    "content": "conjugate_pair packages the structure: a non-real root z (z̄ ≠ z) is accompanied by the distinct root z̄ of the same multiplicity. Conjugation is thus a fixed-point-free involution on the non-real roots, pairing them up, so their total count (with multiplicity) is even. The fixed points of conjugation are exactly the real roots — hence the number of non-real roots is even and the number of real roots has the same parity as deg p. This is precisely the parity recorded by the parent's budan_parity axiom, now grounded in the Fundamental Theorem of Algebra rather than assumed: the open question is answered by deriving the conjugate-pair content from Mathlib.",
+    "content": "conjugate_pair packages the structure: a non-real root z (z̄ ≠ z) is accompanied by the distinct root z̄ of the same multiplicity. Conjugation is thus a fixed-point-free involution on the non-real roots, pairing them up, so their total count (with multiplicity) is even. The fixed points of conjugation are exactly the real roots — hence the number of non-real roots is even and the number of real roots has the same parity as deg p. This is precisely the parity recorded by the parent's budan_parity axiom, now grounded in the Fundamental Theorem of Algebra rather than assumed: the open question is answered by deriving the conjugate-pair content from Mathlib. (The fully quantified even_card_nonreal_roots / real-root-parity statement remains an open extension — see the conclusion's open questions.)",
     "mathContext": "Conjugation is a fixed-point-free involution on the non-real roots, so $\\#\\{\\text{non-real roots}\\}$ is even and $\\#\\{\\text{real roots}\\} \\equiv \\deg p \\pmod 2$.",
     "significance": "key",
     "relatedConcepts": ["conjugate pairs", "fixed-point-free involution", "parity of real-root count", "budan_parity", "Descartes' rule of signs"],


### PR DESCRIPTION
Enrichment pass for `descartes-rule-of-signs-oq-02-oq-03`.

## Quality improvements
- **Annotation coverage 3 → 6.** The previous file lumped three theorems (`map_conj_real`, `complexRoots_conj_invariant`, `count_complexRoots_conj`) into one annotation spanning lines 41–64. Split them into focused, per-theorem annotations.
- **Covered the previously-unannotated `complexRoots` definition** (lines 31–32) with a new `definition` annotation explaining why a multiset (multiplicity) is essential to the parity argument.
- Added `ann-map-conj-real` (technique) and `ann-count` (technique) annotations with their own `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.
- All 6 annotations carry full metadata fields.
- Flagged in the pairing annotation that the fully-quantified `even_card_nonreal_roots` / real-root-parity statement remains an open extension (consistent with the conclusion's open questions; the Lean module docstring lists it but the theorem is not yet proved).

meta.json (12.5 KB) is well under the 60 KB cap and already meets quality targets, so it was left unchanged to avoid accretion.