### PR TITLE
research(erdos-564-incomplete-01): faithful quadratic crux 2^{n^2} < tower 2 n [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos564Incomplete01.lean
+++ b/proofs/Proofs/Erdos564Incomplete01.lean
@@ -24,6 +24,11 @@
     * `tower_one_lt_tower_two`  : `1 ≤ n → tower 1 n < tower 2 n`
       — the *singly*-exponential known lower bound is strictly below the
         *doubly*-exponential conjectured one: the exact gap Erdős #564 asks to close.
+    * `ehr_lower_lt_tower_two`  : `5 ≤ n → 2^{n²} < tower 2 n` — the same gap in its
+        *faithful quadratic form*: the real EHR lower bound `2^{cn²}` has a quadratic
+        exponent (not linear), yet `2^{n²}` is still a whole tower level below the
+        conjectured `2^{2^n}`, because `n² < 2^n` (`nsq_lt_two_pow_self`, `n ≥ 5`).
+    * `tower_lt_of_height_lt`   : `j < k → tower j n < tower k n` (general height gap).
 
   Nothing here resolves the open conjecture; this is the combinatorial scaffolding
   that makes its statement ("can R₃ reach tower height 2?") precise.
@@ -95,6 +100,40 @@ theorem tower_one_lt_tower_two (n : ℕ) : tower 1 n < tower 2 n := by
   rw [h1, h2]
   -- 2 ^ n < 2 ^ (2 ^ n) since n < 2 ^ n for every n
   exact Nat.pow_lt_pow_right (by norm_num) Nat.lt_two_pow_self
+
+/-- **General height gap.**  Any lower tower height is strictly dominated by any
+higher one (for the same base): `tower j n < tower k n` whenever `j < k`.  This is
+the height-monotonicity `tower_strictMono_height` named as a gap lemma;
+`tower_one_lt_tower_two` is the case `j = 1, k = 2`. -/
+theorem tower_lt_of_height_lt {j k n : ℕ} (h : j < k) : tower j n < tower k n :=
+  tower_strictMono_height n h
+
+/-- `n² < 2ⁿ` for every `n ≥ 5` (tight: `4² = 16 = 2⁴`).  Proved by induction from
+the base `5² = 25 < 32 = 2⁵`; the successor step uses `2m+1 ≤ m²` (valid for `m ≥ 5`)
+together with the inductive `m² < 2ᵐ` to clear `(m+1)² = m²+2m+1 < 2ᵐ + 2ᵐ = 2^{m+1}`. -/
+theorem nsq_lt_two_pow_self : ∀ {n : ℕ}, 5 ≤ n → n ^ 2 < 2 ^ n := by
+  intro n hn
+  induction n, hn using Nat.le_induction with
+  | base => decide
+  | succ m hm ih =>
+      have hb : 2 * m + 1 ≤ m ^ 2 := by nlinarith [hm]
+      have hsplit : 2 ^ (m + 1) = 2 ^ m + 2 ^ m := by rw [pow_succ]; ring
+      rw [hsplit]
+      nlinarith [ih, hb]
+
+/-- **The crux of Erdős #564 in its faithful quadratic form.**  The genuine
+Erdős–Hajnal–Rado *lower* bound is `2^{cn²}` — singly exponential with a **quadratic**
+argument — while the conjectured lower bound is the doubly-exponential `2^{2^{cn}}`
+(tower height `2`).  Stripping the constant `c` to its cleanest instance, the height-1
+quadratic bound `2^{n²}` sits strictly below the height-2 bound `tower 2 n = 2^{2^n}`
+for every `n ≥ 5`:
+    `2^{n²} < tower 2 n`.
+This is the more faithful statement of the gap `tower_one_lt_tower_two` gestures at:
+the known lower bound's exponent is quadratic (`n²`), not linear (`n`), yet it is still
+a whole tower level below the conjecture — `n²` is dwarfed by `2^n`. -/
+theorem ehr_lower_lt_tower_two {n : ℕ} (hn : 5 ≤ n) : 2 ^ (n ^ 2) < tower 2 n := by
+  rw [tower_two_eq]
+  exact Nat.pow_lt_pow_right (by norm_num) (nsq_lt_two_pow_self hn)
 
 /-! ### Concrete sanity checks -/
 

--- a/research/problems/erdos-564-incomplete-01/knowledge.md
+++ b/research/problems/erdos-564-incomplete-01/knowledge.md
@@ -112,3 +112,24 @@ These are the structural facts that make `R k n` (least `m` with the property) a
 GOTCHAs (session 2): `Fin.castLEEmb (h : n ≤ m) : Fin n ↪ Fin m` is the embedding;
 `Finset.le_card_iff_exists_subset_card : n ≤ s.card ↔ ∃ t ⊆ s, t.card = n` is the
 subset-of-given-size lemma (NOT `exists_smaller_set`/`exists_subset_card_eq` in this Mathlib).
+
+## Iteration (researcher-3, 2026-06-28): faithful quadratic crux + general height gap
+
+**Mode**: BUILD (Docker down; offline `LAKE_UNSAFE=1 ./bin/lake env lean`, REAL_EXIT 0, clean).
+**Base**: rebased onto origin/main 153-line/13-thm version (which already had the Ramsey
+monotonicity session) — caught that my initial worktree base was a stale 110-line snapshot
+and re-applied onto the current file rather than clobbering the merged Ramsey lemmas.
+
+### What I Did
+The file's crux `tower_one_lt_tower_two` compares `2^n < 2^{2^n}` (LINEAR exponent), but the
+real EHR lower bound is `2^{cn²}` — a QUADRATIC exponent. Added the faithful form:
+- `nsq_lt_two_pow_self {n} (5 ≤ n) : n^2 < 2^n` — `Nat.le_induction` from base `25 < 32`;
+  step `2m+1 ≤ m²` (`nlinarith [hm]`) + ih to clear `(m+1)² < 2^m + 2^m = 2^{m+1}`. Tight at n=4.
+- `ehr_lower_lt_tower_two {n} (5 ≤ n) : 2^(n^2) < tower 2 n` — the genuine gap: the
+  quadratic-exponent known lower bound `2^{n²}` is still a whole tower level below the
+  conjectured `2^{2^n} = tower 2 n`. More faithful to Erdős #564 than the linear crux.
+- `tower_lt_of_height_lt {j k n} (j < k) : tower j n < tower k n` — general height gap.
+
+### Verification
+- `#print axioms` on all three → foundational only; NONE of the parent's 3 axioms pulled in.
+- 13→16 theorems, 153→192 lines, 0 axioms, 0 sorries. The open conjecture ($500) stays out of reach.

--- a/src/data/proofs/erdos-564-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-564-incomplete-01/meta.json
@@ -35,7 +35,7 @@
       "Parent fix: repaired six dangling /-- doc comments (lines 65, 66, 153, 154, 164, 186) in Erdos564Problem.lean that caused 'unexpected token /--; expected lemma' parse errors — the parent file did not compile at all on main"
     ],
     "dateAdded": "2026-06-27",
-    "lineCount": 110,
+    "lineCount": 192,
     "theoremCount": 11,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
@@ -158,9 +158,9 @@
       "Proofs.Erdos564Problem"
     ],
     "namespace": "Erdos564.Incomplete01",
-    "lineCount": 153,
+    "lineCount": 192,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 16,
     "definitionCount": 0,
     "path": "Proofs/Erdos564Incomplete01.lean",
     "sorries": 0
@@ -174,5 +174,8 @@
       "Develop monotonicity of the hypergraph Ramsey property (more vertices preserve it) toward a verified definition of R₃ replacing the axiom."
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "highlights": [
+    "Faithful quadratic crux (ehr_lower_lt_tower_two): the real EHR lower bound 2^{cn^2} has a QUADRATIC exponent, yet 2^{n^2} is still a whole tower level below the conjectured 2^{2^n} = tower 2 n for n>=5, because n^2 < 2^n (nsq_lt_two_pow_self, tight at n=4). Sharpens the prior linear-exponent crux tower_one_lt_tower_two. Plus general height gap tower_lt_of_height_lt (j<k => tower j n < tower k n). Axiom-free (propext/Classical.choice/Quot.sound)."
+  ]
 }

--- a/src/data/research/problems/erdos-564-incomplete-01.json
+++ b/src/data/research/problems/erdos-564-incomplete-01.json
@@ -93,8 +93,8 @@
     {
       "path": "Proofs/Erdos564Incomplete01.lean",
       "filename": "Erdos564Incomplete01.lean",
-      "lineCount": 110,
-      "theoremCount": 11,
+      "lineCount": 192,
+      "theoremCount": 16,
       "axiomCount": 0,
       "defCount": null,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Erdős #564 (3-uniform hypergraph Ramsey `R₃(n)`, **OPEN, \$500**). The known EHR bounds are `2^{cn²} < R₃(n) < 2^{2^n}`; Erdős asks whether the lower bound can be raised to tower height 2 (`2^{2^{cn}}`).

The verified scaffolding file's central "gap" lemma `tower_one_lt_tower_two` compares `2^n < 2^{2^n}` — a **linear** exponent — but the genuine EHR lower bound `2^{cn²}` has a **quadratic** exponent. This adds the faithful quadratic form:

- `nsq_lt_two_pow_self (5 ≤ n) : n² < 2^n` — `Nat.le_induction` from base `25 < 32`; step `2m+1 ≤ m²` + ih. Tight: `4² = 16 = 2⁴`, hence `n ≥ 5`.
- `ehr_lower_lt_tower_two (5 ≤ n) : 2^(n²) < tower 2 n` — the quadratic-exponent known lower bound `2^{n²}` is still a whole tower level below the conjectured `2^{2^n} = tower 2 n`.
- `tower_lt_of_height_lt (j < k) : tower j n < tower k n` — general height gap (the named generalization of `tower_one_lt_tower_two`).

## Verification

- Offline `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos564Incomplete01.lean` → **EXIT 0**, no errors/warnings (Docker host down).
- `#print axioms` on all three new theorems → foundational only (`propext`[`, Classical.choice, Quot.sound`]); **none** of the parent's 3 axioms (`R`, `erdos_hajnal_rado_{upper,lower}`) are pulled in.
- 13→16 theorems, 153→192 lines; 0 axioms, 0 sorries. Rebased onto the current `main` (preserving the merged Ramsey-monotonicity session), not the stale snapshot.

## Honest status

Scaffolding that makes the *statement* of the gap quantitatively faithful — **not** a step toward the open conjecture, which (raising the lower bound to tower height 2, \$500) remains out of reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)