### PR TITLE
Enrich Erdős #10 Subadditivity & Binary Popcount: annotations 3→5

### DIFF
--- a/src/data/proofs/erdos-10-wip-01/annotations.json
+++ b/src/data/proofs/erdos-10-wip-01/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-popcount-def",
+    "proofId": "erdos-10-wip-01",
+    "range": {
+      "startLine": 40,
+      "endLine": 42
+    },
+    "type": "definition",
+    "title": "Popcount as the Length of bitIndices",
+    "content": "popcount n is defined as the abbreviation (Nat.bitIndices n).length — the number of set bits in the binary expansion of n. By the parent thread's repWithAtMost_iff_bitIndices_length, this equals the minimal number of distinct powers of two summing to n, so popcount is simultaneously a concrete bit count and the optimal representation cost. Defining it as an abbrev (rather than a def) keeps it definitionally transparent, so lemmas about Nat.bitIndices apply without unfolding.",
+    "mathContext": "$\\mathrm{popcount}(n) = |\\{\\,i : \\text{bit } i \\text{ of } n \\text{ is } 1\\}| = \\min\\{\\,|S| : n = \\textstyle\\sum_{i\\in S} 2^i\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Hamming weight", "Nat.bitIndices", "binary representation", "minimal representation cost"],
+    "prerequisites": ["binary expansion of a natural number", "Nat.bitIndices", "Lean abbreviations"]
+  },
+  {
     "id": "ann-rep-add",
     "proofId": "erdos-10-wip-01",
     "range": {
@@ -15,16 +30,31 @@
     "prerequisites": ["the RepWithAtMost predicate (parent Erdos10OQ02)", "multiset cardinality (card_add)", "powSum_add"]
   },
   {
-    "id": "ann-popcount-subadd",
+    "id": "ann-minimal-rep",
     "proofId": "erdos-10-wip-01",
     "range": {
       "startLine": 77,
+      "endLine": 85
+    },
+    "type": "technique",
+    "title": "Popcount Is the Minimal Representation",
+    "content": "Two lemmas convert between the popcount and the representation predicate. repWithAtMost_popcount instantiates the parent characterization at k = popcount n, certifying that n really is a sum of popcount(n) distinct powers — the binary representation realizes the bound. popcount_le_iff is the contrapositive packaging: popcount n ≤ k ↔ RepWithAtMost k n, expressing that popcount is the MINIMAL number of powers, so no representation can use fewer. Together they are the bridge that lets subadditivity of representation be read as subadditivity of popcount in the next theorem.",
+    "mathContext": "$\\mathrm{RepWithAtMost}\\,(\\mathrm{popcount}\\,n)\\,n$ and $\\mathrm{popcount}\\,n \\le k \\iff \\mathrm{RepWithAtMost}\\,k\\,n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["minimal representation", "repWithAtMost_iff_bitIndices_length", "optimality", "binary representation"],
+    "prerequisites": ["the RepWithAtMost ↔ popcount characterization (parent thread)", "popcount definition"]
+  },
+  {
+    "id": "ann-popcount-subadd",
+    "proofId": "erdos-10-wip-01",
+    "range": {
+      "startLine": 87,
       "endLine": 104
     },
     "type": "insight",
     "title": "Popcount Subadditivity, for Free",
-    "content": "bitIndices_length_add_le proves popcount(a+b) ≤ popcount(a)+popcount(b) without touching binary digits directly. The popcount representation is the MINIMAL one (repWithAtMost_popcount: every n is a sum of exactly popcount(n) distinct powers), so a is a sum of popcount(a) powers and b of popcount(b); subadditivity of representation (repWithAtMost_add) combines them into a representation of a+b with popcount(a)+popcount(b) powers; and the minimality direction (popcount_le_iff) reads off the bound. The arithmetic content — that carries in binary addition only merge bits (2^a + 2^a = 2^{a+1}), never create them — is delivered entirely through the powers-of-2 representation lemma. bitIndices_length_sum_le iterates it over a list.",
-    "mathContext": "$\\mathrm{popcount}(a+b) \\le \\mathrm{popcount}(a) + \\mathrm{popcount}(b)$; carries only merge bits.",
+    "content": "bitIndices_length_add_le proves popcount(a+b) ≤ popcount(a)+popcount(b) without touching binary digits directly. The popcount representation is the minimal one (repWithAtMost_popcount), so a is a sum of popcount(a) powers and b of popcount(b); subadditivity of representation (repWithAtMost_add) combines them into a representation of a+b with popcount(a)+popcount(b) powers; and the minimality direction (popcount_le_iff) reads off the bound. The arithmetic content — that carries in binary addition only merge bits (2^a + 2^a = 2^{a+1}), never create them — is delivered entirely through the powers-of-2 representation lemma. bitIndices_length_sum_le iterates the bound over a list by a one-line induction.",
+    "mathContext": "$\\mathrm{popcount}(a+b) \\le \\mathrm{popcount}(a) + \\mathrm{popcount}(b)$, and $\\mathrm{popcount}\\big(\\textstyle\\sum_i a_i\\big) \\le \\sum_i \\mathrm{popcount}(a_i)$; carries only merge bits.",
     "significance": "key",
     "relatedConcepts": ["Hamming weight / popcount", "binary carries", "minimal representation", "subadditivity"],
     "prerequisites": ["popcount = bitIndices length", "minimality of the binary representation", "repWithAtMost_add"]
@@ -33,8 +63,8 @@
     "id": "ann-prime-popcount",
     "proofId": "erdos-10-wip-01",
     "range": {
-      "startLine": 106,
-      "endLine": 146
+      "startLine": 114,
+      "endLine": 125
     },
     "type": "concept",
     "title": "The Erdős #10 Predicate in O(log) Form",


### PR DESCRIPTION
Enrichment pass for `erdos-10-wip-01`.

## Quality improvements
- **Annotation coverage 3 → 5.**
- **Covered the previously-unannotated `popcount` abbrev** (lines 40–42) with a `definition` annotation tying the bit count to the minimal representation cost.
- **Split the lumped Part II annotation** (old range 77–104) into two: `ann-minimal-rep` for the minimality machinery (`repWithAtMost_popcount`, `popcount_le_iff`) and `ann-popcount-subadd` for the subadditivity result itself.
- Tightened all annotation `range`s to the actual declaration boundaries.
- All 5 annotations carry full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

meta.json (12.5 KB) is under the 60 KB cap and already meets quality targets, so it was left unchanged to avoid accretion.