### PR TITLE
research(pascals-hexagon-incomplete-01-oq-01): de-risk Sylvester gap — identify toMatrix'_comp bridge

### DIFF
--- a/proofs/Proofs/PascalsHexagon.lean
+++ b/proofs/Proofs/PascalsHexagon.lean
@@ -1333,7 +1333,37 @@ private lemma diag_pm_one_congr_stdConic (w : Fin 3 → ℝ)
        **Step 4 is now discharged by `diag_pm_one_congr_stdConic` (proved above, 0-axiom).**
        The sole remaining obstacle is step 2: extracting the matrix congruence
        `C = Lᵀ * diagonal w * L` from the abstract `IsometryEquiv` across the
-       `Fin (finrank ℝ (Fin 3 → ℝ)) ↔ Fin 3` cast. -/
+       `Fin (finrank ℝ (Fin 3 → ℝ)) ↔ Fin 3` cast.
+
+    CONCRETE SKELETON for step 2 (researcher-3, 2026-06-28 — the central bridge lemma
+    `QuadraticMap.toMatrix'_comp` was not previously identified; it removes the need to
+    reason about the abstract isometry directly):
+
+      Let `φ : (toQuadraticMap' C).IsometryEquiv (weightedSumSquares ℝ w)` from step 1.
+      a. `IsometryEquiv.map_app φ : ∀ x, weightedSumSquares ℝ w (φ x) = toQuadraticMap' C x`,
+         i.e. `toQuadraticMap' C = (weightedSumSquares ℝ w).comp φ.toLinearEquiv.toLinearMap`
+         (by `QuadraticMap.ext`).
+      b. Apply `QuadraticMap.toMatrix'` to both sides and rewrite the RHS with
+         `QuadraticMap.toMatrix'_comp` :
+           `(toQuadraticMap' C).toMatrix' = (LinearMap.toMatrix' φ)ᵀ
+                                              * (weightedSumSquares ℝ w).toMatrix'
+                                              * (LinearMap.toMatrix' φ)`.
+      c. Two round-trip rewrites collapse the endpoints to plain matrices:
+           - `(toQuadraticMap' C).toMatrix' = C`  — because `mathlibQF_separatingLeft`'s
+             internal computation already shows `associated (toQuadraticMap' C)
+             = toLinearMap₂' C`, and `toMatrix' Q = toMatrix₂' (associated Q)`, so this is
+             the `toMatrix₂'`/`toLinearMap₂'` round trip on the symmetric `C`.
+           - `(weightedSumSquares ℝ w).toMatrix' = Matrix.diagonal w`  — prove a standalone
+             helper from `weightedSumSquares_apply` + `QuadraticMap.associated`'s diagonal
+             form (the off-diagonal mixed terms vanish).
+      d. The ONLY genuinely type-dependent step is making `L := LinearMap.toMatrix' φ`
+         **square**: its column index is `Fin 3` but its row index is `Fin (finrank …)`.
+         Reindex via `e := finCongr Module.finrank_fin_fun : Fin (finrank ℝ (Fin 3 → ℝ)) ≃ Fin 3`
+         (so `diagonal w` becomes `diagonal (w ∘ e.symm)` and `L` becomes `L.submatrix e id`),
+         after which `L'.det ≠ 0` follows from `LinearMap.toMatrix'` of the equiv `φ` being a
+         unit (`Matrix.isUnit_iff_isUnit_det`, `LinearEquiv.toMatrix'`-style). Then step 3
+         gives indefiniteness of `w ∘ e.symm` and step 4 (`diag_pm_one_congr_stdConic`)
+         finishes. This is the right Aristotle target once the service is reachable. -/
 private lemma exists_scaledCongr_stdConic_of_isotropic (C : Conic)
     (hC_sym : C.symmetric) (hC_nd : Conic.nondegenerate C)
     (p₀ : ProjPoint) (hp₀v : ProjPoint.valid p₀) (hp₀ : pointOnConic p₀ C) :

--- a/research/problems/pascals-hexagon-incomplete-01-oq-01/knowledge.md
+++ b/research/problems/pascals-hexagon-incomplete-01-oq-01/knowledge.md
@@ -56,3 +56,49 @@ non-degenerate conics).
 2. Prove the matrix-congruence extraction from `IsometryEquiv` + finrank cast — the hard part;
    ideal Aristotle target once the service is reachable again (submit
    `exists_scaledCongr_stdConic_of_isotropic`).
+
+## Session 2026-06-28 (researcher-3) — ORIENT/de-risk: central bridge `toMatrix'_comp` identified
+
+**Mode**: ORIENT (Aristotle UNREACHABLE — `mcp-smoke-test.sh` returns HTTP 404 on
+`/api/v1/project`, same as researcher-8's session 1; all work manual). **Outcome**:
+de-risk — converted step 2 ("the main remaining obstacle") into a concrete, near-mechanical
+skeleton by identifying the Mathlib lemma the prior session had not named.
+
+### Key finding
+The matrix-congruence extraction `C = Lᵀ · diagonal w · L` from the abstract
+`IsometryEquiv` is exactly **`QuadraticMap.toMatrix'_comp`** (Mathlib
+`LinearAlgebra/QuadraticForm/Basic.lean`):
+  `(Q.comp f).toMatrix' = (LinearMap.toMatrix' f)ᵀ * Q.toMatrix' * (LinearMap.toMatrix' f)`.
+Combined with `QuadraticMap.IsometryEquiv.map_app` (`Q₂ (φ x) = Q₁ x`), the abstract
+isometry becomes `toQuadraticMap' C = (weightedSumSquares ℝ w).comp φ`, and applying
+`.toMatrix'` to both sides + `toMatrix'_comp` gives the congruence directly — no need to
+reason about the isometry's action pointwise.
+
+### Concrete remaining sub-steps (now spelled out in the lemma docstring)
+- `(toQuadraticMap' C).toMatrix' = C`: from the already-proven `associated (toQuadraticMap' C)
+  = toLinearMap₂' C` (inside `mathlibQF_separatingLeft`) + `toMatrix' Q = toMatrix₂'(associated Q)`
+  + the `toMatrix₂'`/`toLinearMap₂'` round trip. NOTE: the round-trip lemma is NOT named
+  `toMatrix₂'_toLinearMap₂'` in Mathlib 4.26 — `LinearMap.toMatrix₂'` is a `LinearEquiv`, so use
+  `.apply_symm_apply` / `Matrix.toLinearMap₂'` as its symm. (Verify name on next attempt.)
+- `(weightedSumSquares ℝ w).toMatrix' = Matrix.diagonal w`: needs a standalone helper
+  (off-diagonal mixed terms of the associated bilinear form vanish). No direct Mathlib lemma.
+- **The one genuinely type-dependent step**: `L := LinearMap.toMatrix' φ` is `Fin (finrank) × Fin 3`,
+  NOT square. Reindex with `e := finCongr Module.finrank_fin_fun : Fin (finrank ℝ (Fin 3→ℝ)) ≃ Fin 3`
+  (`Module.finrank_fin_fun : finrank R (Fin n → R) = n` confirmed present). `det ≠ 0` from φ being
+  a `LinearEquiv` (`Matrix.isUnit_iff_isUnit_det`). Then steps 3 (indefinite) + 4
+  (`diag_pm_one_congr_stdConic`, already proven) finish.
+
+### Honest status
+- NO new verified Lean this session (the round-trip helper names + finrank-cast reindexing each
+  cost a ~60s offline build to test; closing them reliably without Aristotle is a multi-iteration
+  effort I did not complete). The file still builds (offline `LAKE_UNSAFE=1 lake env lean` EXIT 0,
+  1 real sorry, 1 axiom `conic_implies_pascal_constraint`). The deliverable is the sharpened,
+  lemma-named skeleton in the docstring — this is the right Aristotle target the moment the
+  service is reachable again (submit `exists_scaledCongr_stdConic_of_isotropic` via `prove`).
+- Problem remains IN-PROGRESS (1 sorry), not completed.
+
+### Next steps
+1. When Aristotle is back: `prove_file Proofs/PascalsHexagon.lean` (single sorry) or
+   `prove` the isolated `exists_scaledCongr_stdConic_of_isotropic` with the docstring skeleton.
+2. Manual fallback: prove the two round-trip helpers as standalone lemmas first (build-verifiable
+   independently), then the finrank-cast reindex, then assemble via `toMatrix'_comp`.


### PR DESCRIPTION
## Summary

ORIENT/de-risk session on the sole remaining `sorry` of `PascalsHexagon.lean`'s general-conic path: `exists_scaledCongr_stdConic_of_isotropic` (a non-degenerate symmetric real conic carrying a real point is congruent to a scalar multiple of `stdConic = diag(1,1,-1)` — Sylvester's law of inertia + a sign/permutation correction).

**Aristotle was unreachable** this session (`mcp-smoke-test.sh` → HTTP 404 on `/api/v1/project`, same as the prior session), so this is a manual de-risk rather than a closure.

**Key finding.** The prior session documented step 2 — extracting a matrix congruence `C = Lᵀ·diag(w)·L` from an abstract `QuadraticForm.IsometryEquiv` — as "the main remaining technical obstacle," without a concrete route. That extraction is exactly **`QuadraticMap.toMatrix'_comp`**:
```
(Q.comp f).toMatrix' = (LinearMap.toMatrix' f)ᵀ * Q.toMatrix' * (LinearMap.toMatrix' f)
```
Combined with `QuadraticMap.IsometryEquiv.map_app` (`Q₂ (φ x) = Q₁ x`), the abstract isometry becomes the matrix identity directly — no pointwise reasoning about the isometry needed. The lemma docstring now carries a concrete, lemma-named skeleton (the two `.toMatrix'` round-trips + the one genuinely type-dependent step: reindexing `L` via `finCongr Module.finrank_fin_fun` to make it square with `det ≠ 0`).

## Verification

- Offline `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PascalsHexagon.lean` → **EXIT 0** (Docker host down). Docstring-only Lean change; **1 real sorry and 1 axiom unchanged**.

## Honest status

**No new verified Lean** — the round-trip helper names and the finrank-cast reindexing each need build-verified iteration that I did not complete reliably without Aristotle. The deliverable is the sharpened, near-mechanical skeleton, which is the right `prove`/`prove_file` target the moment Aristotle is reachable. The problem **remains in-progress** (1 sorry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)