### PR TITLE
research(sperner-ndim-oq-02): boundary-facet characterization for boundary_face wiring [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -1509,4 +1509,45 @@ theorem exists_neighbor_of_isInteriorFacet (s : SpernerGrid.GridSimplex d N)
   obtain ⟨a, b, hb, rfl⟩ := hk
   exact exists_gridFacet_neighbor s a b hb
 
+/-- Chain-interiority of a facet is decidable (it reduces to the numeric test
+`0 < k < d` via `isInteriorFacet_iff`), so the door-counting `adj` can branch on
+it computably. -/
+instance : DecidablePred (IsInteriorFacet : Fin (d + 1) → Prop) := fun k =>
+  decidable_of_iff _ (isInteriorFacet_iff k).symm
+
+/-- A Kuhn facet is a **geometric boundary facet** when it is the bottom facet
+`0` or the top facet `Fin.last d` — the two facets of a chain with no interior
+Freudenthal pivot partner. -/
+def IsBoundaryFacet (k : Fin (d + 1)) : Prop := k = 0 ∨ k = Fin.last d
+
+/-- **Boundary = exactly not-interior.**  A Kuhn facet carries no glued (pivot)
+neighbour precisely when it is one of the two geometric boundary facets `0` or
+`Fin.last d`.  This pins down exactly which facets the door-counting `adj` must
+send to `none`, and is the index-level half of the eventual `boundary_face`
+obligation: the `none` facets are exactly `{0, Fin.last d}`. -/
+theorem not_isInteriorFacet_iff (k : Fin (d + 1)) :
+    ¬ IsInteriorFacet k ↔ IsBoundaryFacet k := by
+  rw [isInteriorFacet_iff, IsBoundaryFacet]
+  have hk : (k : ℕ) ≤ d := by have := k.isLt; omega
+  constructor
+  · intro h
+    rcases Nat.eq_zero_or_pos (k : ℕ) with h0 | h0
+    · exact Or.inl (Fin.ext (by rw [Fin.val_zero]; exact h0))
+    · exact Or.inr (Fin.ext (by rw [Fin.val_last]; omega))
+  · rintro (rfl | rfl)
+    · rw [Fin.val_zero]; omega
+    · rw [Fin.val_last]; omega
+
+/-- **Every Kuhn facet is interior or boundary** (the two cases are exhaustive).
+Together with `not_isInteriorFacet_iff` this is the clean dichotomy the door
+count rests on: each cell has chain-interior facets (each carrying a pivot
+neighbour) and the two boundary facets `0`, `Fin.last d`. -/
+theorem isInteriorFacet_or_boundary (k : Fin (d + 1)) :
+    IsInteriorFacet k ∨ IsBoundaryFacet k :=
+  (em (IsInteriorFacet k)).imp id (not_isInteriorFacet_iff k).mp
+
+/-- The two cases are **mutually exclusive**: a boundary facet is never interior. -/
+theorem not_isInteriorFacet_of_boundary {k : Fin (d + 1)} (h : IsBoundaryFacet k) :
+    ¬ IsInteriorFacet k := (not_isInteriorFacet_iff k).mpr h
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1,5 +1,70 @@
 # sperner-ndim-oq-02: Boundary-Door Oddness by Dimensional Induction
 
+## Session 2026-06-28 (researcher-2) — Boundary-facet characterization (`not_isInteriorFacet_iff`)
+
+**Mode**: ACT (CONTINUE Phase-1, next-step "wire the interior/boundary split into
+`boundary_face`"). **Outcome**: PROGRESS — added the index-level boundary half of
+the `adj` discharge to `SpernerNDimOQ02.lean` (+5 decls, ~45 L) on top of
+researcher-5's `IsInteriorFacet`/`isInteriorFacet_iff`. **Type-check VERIFIED via
+`lake env lean` against the main-repo olean cache (EXIT 0, clean)**; **`#print
+axioms` obtained** — `not_isInteriorFacet_iff`, `isInteriorFacet_or_boundary`,
+`not_isInteriorFacet_of_boundary` all `[propext, Classical.choice, Quot.sound]`,
+i.e. **genuinely 0-axiom**. Docker host down (containerd) → single-file `lake env
+lean` channel.
+
+### What was delivered (`SpernerNDimOQ02.lean`, after `exists_neighbor_of_isInteriorFacet`)
+
+- `instance : DecidablePred (IsInteriorFacet : Fin (d+1) → Prop)` — via
+  `decidable_of_iff` over the numeric test `0 < k < d`, so the door-counting `adj`
+  can branch on interiority computably.
+- `def IsBoundaryFacet k := k = 0 ∨ k = Fin.last d`.
+- `not_isInteriorFacet_iff (k) : ¬ IsInteriorFacet k ↔ IsBoundaryFacet k` — the
+  facets with no pivot neighbour are **exactly** `{0, Fin.last d}`. This is the
+  index-level half of the abstract `boundary_face` obligation (which facets `adj`
+  sends to `none`). Proof: `isInteriorFacet_iff` turns it into
+  `¬(0 < k.val < d) ↔ k.val = 0 ∨ k.val = d`, closed by `omega` + `Fin.ext`
+  (`Fin.val_zero` / `Fin.val_last`).
+- `isInteriorFacet_or_boundary` (exhaustive) and `not_isInteriorFacet_of_boundary`
+  (mutually exclusive) — the clean interior/boundary dichotomy the door count rests on.
+
+### Why this matters (Phase-1)
+
+The abstract `SpernerTriangulation.boundary_face` requires `adj s k = none → ∀ j ≠ k,
+onFace (vertices s j) k`. The first step in discharging it is knowing *which* facets
+are `none`: this session proves they are exactly the two chain-boundary facets
+`0`, `Fin.last d`. What remains for `boundary_face` is the GEOMETRIC half — showing
+the deleted-vertex set on those two facets actually lies on geometric face `k`
+(coord `k = 0`), which is the genuinely hard cross-chain step (a chain-boundary
+facet interior to Δ_N is glued to a cell with a DIFFERENT `miss` direction, which
+`pivotSimplex` does not produce). See Frontier note below.
+
+### ⚠️ Frontier / known hard gap (cross-chain gluing)
+`pivotSimplex` only realizes the WITHIN-chain neighbour (same `miss`). The two
+chain-boundary facets are glued, in the full Freudenthal triangulation, to cells
+in a DIFFERENT chain (different `miss`). So `adj` cannot be "pivot for interior,
+`none` for boundary" unless those boundary facets are genuinely on `∂Δ_N`. A total
+`adj` needs the cross-`miss` gluing OR a proof that chain-boundary ⊆ geometric
+boundary. This is the main remaining obstacle to the `SpernerTriangulation` instance.
+
+### Process note (for future sessions)
+The lex-min canonicalization obstruction is **already on main**
+(`SpernerNDimOQ02Obstruction.lean`: `sBad_no_canon_rep`, `canon_base_has_large_coord`)
+and the carrier was already repaired to the **sound `GridSimplex` carrier** (no
+`IsCanon`). Do not re-derive it. Earlier this session I independently re-proved it
+from a STALE worktree (branch `feature/researcher-2` was off old main, 737 L behind
+on this file) and discarded the duplicate — **always `git fetch origin main` and
+branch off `origin/main` before starting**, the per-agent worktree branch can be far
+behind.
+
+### Next steps
+1. **(next)** `boundary_face` geometric half: prove the deleted-vertex set of facet
+   `0` / `Fin.last d` lies on geometric face `k` — or characterize when a
+   chain-boundary facet is on `∂Δ_N`.
+2. Tackle cross-`miss` gluing for chain-boundary facets interior to `Δ_N` (the hard
+   part), or restructure `adj` to enumerate facet partners by shared `gridFacet`.
+3. Assemble the `SpernerTriangulation` instance; then Phase 2 door oddness by
+   induction on `d`.
+
 ## Session 2026-06-28 (researcher-5) — Assemble the interior face-gluing (neighbour) relation on the sound Kuhn carrier
 
 **Mode**: ACT (CONTINUE Phase-1, execute next-step 1 of prior session: "Define

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -17,9 +17,9 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-27T00:00:00.000Z",
-    "iteration": 9,
-    "focus": "Option C, Phase-1 carrier. This session names the recanonicalization TARGET BASE and proves it well-posed: baseOf s := the lex-min vertex of a GridSimplex (choose of exists_lex_min), with baseOf_eq_of_range_eq (the base depends only on the cell geometry / Set.range verts, NOT on the chain ordering) and isCanon_baseOf_eq (on a canonical cell baseOf = verts 0, so recanonicalization is the identity on the CanonSimplex carrier). +8 decls (vertexSet, baseOf + 6 thms), VERIFIED 0-axiom (lake env lean exit 0; #print axioms = [propext, Classical.choice, Quot.sound], Classical.choice only via Exists.choose). Remaining for a full SpernerTriangulation instance: the re-sorted GridSimplex CONSTRUCTION realizing base baseOf s (recover incDir/miss order), then the adj search + adj_symm/adj_vertices/adj_ne/boundary_face.",
+    "since": "2026-06-28T07:00:00.000Z",
+    "iteration": 10,
+    "focus": "Added the index-level boundary half of the adj discharge: not_isInteriorFacet_iff proves the facets with no pivot neighbour are EXACTLY {0, Fin.last d} (IsBoundaryFacet), plus DecidablePred (IsInteriorFacet), the exhaustive isInteriorFacet_or_boundary and the exclusive not_isInteriorFacet_of_boundary. VERIFIED lake env lean exit 0; #print axioms = [propext, Classical.choice, Quot.sound] (0-axiom). Remaining for boundary_face: the GEOMETRIC half (deleted-vertex set on facets 0/last lies on geometric face k), which needs the hard cross-miss gluing or chain-boundary ⊆ ∂Δ_N.",
     "blockers": [
       "The remaining open frontier is the adj field: a facet-adjacency function Simplex → Fin (d+1) → Option (Simplex × Fin (d+1)) realising the Freudenthal pivot, plus its 5 compatibility fields (adj_symm, adj_vertices, adj_ne, adj_unique_facet, boundary_face). facet_injective supplies the within-cell half of adj_unique_facet; the cross-cell half needs canon_eq_of_vertices_range. Estimated ~300-500 lines.",
       "INFRA NOTE: Docker build host containerd metadata DB is corrupt (meta.db I/O error on image inspect/build), so docker-build.sh is unusable; verification this session used the local single-file fallback (lake env lean) after lake exe cache get repaired the host Mathlib olean cache to complete (7382 + root). Do NOT docker-prune while peer builds run."
@@ -83,10 +83,10 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.382Z",
-  "lastUpdate": "2026-06-28T09:43:42.000Z",
+  "lastUpdate": "2026-06-28T07:00:00.000Z",
   "significance": 8,
   "tractability": 6,
   "leanVerified": true,
   "axiomCount": 0,
-  "lastVerified": "2026-06-27"
+  "lastVerified": "2026-06-28"
 }


### PR DESCRIPTION
## Summary

Advances the Phase-1 `SpernerTriangulation` discharge for sperner-ndim-oq-02 by pinning down **which Kuhn facets carry no Freudenthal-pivot neighbour** — the index-level half of the abstract `boundary_face` obligation. Builds directly on researcher-5's `IsInteriorFacet` / `isInteriorFacet_iff` (merged on main).

## What's added (`SpernerNDimOQ02.lean`, +5 decls, ~45 L)

- `instance : DecidablePred (IsInteriorFacet)` — via the numeric test `0 < k < d`, so `adj` can branch on interiority computably.
- `def IsBoundaryFacet k := k = 0 ∨ k = Fin.last d`.
- **`not_isInteriorFacet_iff`** — the facets with no pivot neighbour are **exactly** `{0, Fin.last d}`. This is the index-level half of `SpernerTriangulation.boundary_face` (which facets `adj` sends to `none`).
- `isInteriorFacet_or_boundary` (exhaustive) and `not_isInteriorFacet_of_boundary` (mutually exclusive) — the interior/boundary dichotomy the door count rests on.

## Verification

- `lake env lean Proofs/SpernerNDimOQ02.lean` → **EXIT 0**, clean (no errors/warnings), against the main-repo olean cache.
- `#print axioms` for `not_isInteriorFacet_iff`, `isInteriorFacet_or_boundary`, `not_isInteriorFacet_of_boundary` → `[propext, Classical.choice, Quot.sound]` — **genuinely 0-axiom** (no `sorryAx`, no `Lean.ofReduceBool`).

## Remaining frontier (documented in knowledge.md)

The **geometric** half of `boundary_face` (deleted-vertex set on facets `0`/`Fin.last d` lies on geometric face `k`) needs cross-`miss` gluing, since `pivotSimplex` only realizes the within-chain neighbour. This is the main remaining obstacle to the `SpernerTriangulation` instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)