### PR TITLE
Enrich Fatou ⇒ DCT via g ± fₙ (fatou-lemma-oq-01-oq-02-oq-01): add missing index.ts, annotations 3→5

### DIFF
--- a/src/data/proofs/fatou-lemma-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/fatou-lemma-oq-01-oq-02-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "framing-not-circular",
+    "proofId": "fatou-lemma-oq-01-oq-02-oq-01",
+    "range": { "startLine": 5, "endLine": 57 },
+    "type": "context",
+    "title": "Why the g ± fₙ Route Is Genuinely 'via Fatou' and Not Circular",
+    "content": "The module docstring frames the entry's two claims to non-triviality. First, the derivation is genuinely a Fatou ⇒ DCT route: the nonnegative shifts g ± fₙ are handled by Mathlib's tendsto_lintegral_of_dominated_convergence, whose proof is literally tendsto_of_le_liminf_of_limsup_le applied to forward Fatou (lintegral_liminf_le) and reverse Fatou (limsup_lintegral_le) — the two Fatou inequalities squeezing the nonnegative integrals. Second, it is not circular: it never invokes Mathlib's Bochner DCT (tendsto_integral_of_dominated_convergence), which is proved separately through abstract setToFun/L1 machinery. The integrable majorant g earns its keep precisely by making the reverse-Fatou bracket of g ± fₙ finite. This is the positive answer to the follow-up question oq-01 left open by the sibling fatou-lemma-oq-01-oq-02, which handled the obstruction side (the parent's escaping mass has no integrable majorant, so DCT cannot apply there).",
+    "mathContext": "Nonnegative DCT $=$ forward Fatou $\\int^-\\liminf \\le \\liminf\\int^-$ $+$ reverse Fatou $\\limsup\\int^- \\le \\int^-\\limsup$, squeezed on $g \\pm f_n$.",
+    "significance": "context",
+    "relatedConcepts": ["Fatou's lemma", "dominated convergence theorem", "circularity avoidance", "monotone/Fatou/DCT hierarchy", "integrable majorant"],
+    "prerequisites": ["liminf/limsup of integrals", "the nonnegative dominated convergence theorem", "logical dependencies among Lebesgue convergence theorems"]
+  },
+  {
+    "id": "setup-meas-integ",
+    "proofId": "fatou-lemma-oq-01-oq-02-oq-01",
+    "range": { "startLine": 83, "endLine": 100 },
+    "type": "technique",
+    "title": "Promoting the Hypotheses: Measurability, Bound, and Integrability of F",
+    "content": "Before any Fatou bracket can be applied, the limit F and the shifts must be shown integrable. From the per-term data the proof derives: g ≥ 0 pointwise (since 0 ≤ |f₀| ≤ g); F measurable as the pointwise limit of the measurable fₙ (measurable_of_tendsto_metrizable together with tendsto_pi_nhds); the bound |F| ≤ g by passing the inequalities |fₙ| ≤ g to the limit (le_of_tendsto applied to |fₙ| → |F|); and finally integrability of each fₙ and of F by domination against the integrable g (Integrable.mono', converting |·| ≤ g to the norm bound via Real.norm_eq_abs). The pointwise nonnegativity 0 ≤ g + fₙ and 0 ≤ g + F then follows from −g ≤ −|fₙ| ≤ fₙ. These are the standing facts that make every subsequent integral well-defined and finite.",
+    "mathContext": "$0 \\le |f_n| \\le g \\Rightarrow$ $F$ measurable, $|F| \\le g$, $f_n, F$ integrable, and $g + f_n \\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["measurable_of_tendsto_metrizable", "le_of_tendsto", "Integrable.mono'", "domination by an integrable majorant"],
+    "prerequisites": ["pointwise limits of measurable functions", "passing inequalities to limits", "integrability via domination"]
+  },
+  {
     "id": "dct-add-bracket",
     "proofId": "fatou-lemma-oq-01-oq-02-oq-01",
     "range": { "startLine": 77, "endLine": 139 },

--- a/src/data/proofs/fatou-lemma-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/fatou-lemma-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FatouLemmaOQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fatouLemmaOq01Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fatouLemmaOq01Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fatouLemmaOq01Oq02Oq01Data: ProofData = {
+  proof: fatouLemmaOq01Oq02Oq01Proof,
+  annotations: fatouLemmaOq01Oq02Oq01Annotations,
+}

--- a/src/data/proofs/fatou-lemma-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fatou-lemma-oq-01-oq-02-oq-01/meta.json
@@ -2,6 +2,7 @@
   "id": "fatou-lemma-oq-01-oq-02-oq-01",
   "slug": "fatou-lemma-oq-01-oq-02-oq-01",
   "title": "The Elementary Fatou ⇒ Dominated Convergence Derivation via g ± fₙ",
+  "description": "Formalizes the classical textbook derivation of the dominated convergence theorem from Fatou's lemma for signed integrands. For real measurable fₙ with |fₙ| ≤ g (g integrable) and fₙ → F pointwise, the nonnegative shifts g + fₙ and g − fₙ are dominated by 2g, so the nonnegative Fatou bracket squeezes ∫(g ± fₙ) → ∫(g ± F); cancelling the constant ∫ g gives ∫ fₙ → ∫ F. Both brackets are exposed explicitly (dct_of_dominated, dct_of_dominated_sub), and the route uses only the nonnegative (lintegral) dominated convergence theorem — never the Bochner DCT — so it is not circular.",
   "leanFile": {
     "imports": [
       "Mathlib.MeasureTheory.Integral.Lebesgue.DominatedConvergence",


### PR DESCRIPTION
Enrichment pass for `fatou-lemma-oq-01-oq-02-oq-01` (passes: 0, quality 83).

## Changes
- **Created `index.ts`** — it was **missing**. Without it Vite's `import.meta.glob` cannot discover the proof, so the page renders 'proof not found' on the live site despite appearing in the gallery listing. This is the highest-impact fix.
- **Added top-level `description`** — the field was absent from meta.json (the index.ts `Proof.description` was undefined).
- **Annotations 3 → 5** (reaching the 5-annotation minimum), both with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`:
  - `framing-not-circular` — annotates the module docstring: why the g ± fₙ route is genuinely *via Fatou* (the nonnegative DCT is the forward/reverse Fatou squeeze) and *not circular* (it never invokes the Bochner DCT).
  - `setup-meas-integ` — the measurability/bound/integrability promotion of the limit F from |fₙ| ≤ g, the standing facts that make every integral finite.

## Verification
- `pnpm build` passes (✓ built in 17.18s)
- meta.json 17.2 KB — well under the 60 KB cap
- status/badge/axiomCount unchanged (verified, 0 axioms) — accurate to the Lean file (the decay/domination data are theorem hypotheses, not assumptions)