### PR TITLE
audit(cycleC1): drain 5 never-audited CLEAN + 2 standing FPs reconfirmed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4925,9 +4925,9 @@
       "result": "clean"
     },
     "erdos-156": {
-      "auditCount": 8,
+      "auditCount": 9,
       "issues": [],
-      "lastAudited": "2026-06-28T12:01:27Z",
+      "lastAudited": "2026-06-28T13:50:05Z",
       "result": "clean"
     },
     "erdos-157": {
@@ -25171,8 +25171,8 @@
       "issues": []
     },
     "erdos-57-oq-04": {
-      "auditCount": 5,
-      "lastAudited": "2026-06-28T12:01:27Z",
+      "auditCount": 6,
+      "lastAudited": "2026-06-28T13:50:05Z",
       "result": "clean",
       "issues": []
     },
@@ -25647,6 +25647,36 @@
     "fibonacci-identities-oq-04-oq-01-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-06-28T12:20:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-pnt-bridge-oq-06-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T13:50:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq-01-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T13:50:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq-02-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T13:50:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1026-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T13:50:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "markov-equation-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T13:50:04Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Gallery Integrity Audit — cycleC1

Persists audit completions that prior cycles repeatedly lost, causing the same 5 entries to resurface every cycle.

### 5 fresh entries — CLEAN (Tier A)
Re-verified 0-axiom / 0-sorry against Lean source, no True stubs:
- `chebyshev-pnt-bridge-oq-06-oq-02`
- `de-moivre-oq-01-oq-03-oq-01-oq-01` — lone `native_decide` is a docstring line stating "no native_decide" (FP)
- `de-moivre-oq-02-oq-03-oq-02-oq-01`
- `erdos-1026-oq-02-oq-01` — lone `admit` is the English word in prose (FP)
- `markov-equation-oq-02`

### 2 standing heuristic FPs — reconfirmed CLEAN
- `erdos-57-oq-04`: heuristic "axiom undercount" — the axiom lives in the `proofRepoPath` parent `Erdos57Problem.lean`; this sub-entry is axiom-free. meta `axiomCount: 0` is correct.
- `erdos-156`: heuristic "sorry mismatch" — conservative **under**claim on a `wip`/`formalized` entry; no public overclaim.

### Root cause of resurfacing
`scripts/auditor/claim-target.sh` resolves `REPO_ROOT` from the env, which points at the auditor worktree (`.loom/worktrees/auditor-agent`). That worktree has no `src/`, so completion writes silently failed and never persisted. This PR writes the completions from a full checkout so the queue stays drained (4137/4137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)