### PR TITLE
Enrich de Bruijn–Erdős line-count sandwich (erdos-606-oq-03-wip-01): add missing index.ts, annotations 3→5

### DIFF
--- a/src/data/proofs/erdos-606-oq-03-wip-01/index.ts
+++ b/src/data/proofs/erdos-606-oq-03-wip-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos606OQ03WIP01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos606Oq03Wip01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos606Oq03Wip01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos606Oq03Wip01Data: ProofData = {
+  proof: erdos606Oq03Wip01Proof,
+  annotations: erdos606Oq03Wip01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-606-oq-03-wip-01` (passes: 0, quality 83).

## Changes
- **Created `index.ts`** — it was **missing**, so the page would render 'proof not found' on the live site despite appearing in the gallery. Highest-impact fix.
- **Fixed an invalid `significance` enum** — the sandwich annotation used `"major"`, which is not in the allowed set (key/supporting/technical/context); changed to `"key"`.
- **Annotations 3 → 5** (reaching the 5-annotation minimum), both with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`:
  - `attribution` — annotates the docstring: the de Bruijn–Erdős vs Sylvester–Gallai distinction (count of lines vs existence of an ordinary line) and the honest-scope caveat.
  - `injection` — the mechanics of the C(n,2) upper bound: how `choose` builds the per-line pair and why `Nondegenerate.eq_or_eq` makes the assignment injective.

## Verification
- `pnpm build` passes (✓ built in 14.85s)
- meta.json 12.2 KB — well under the 60 KB cap
- status/badge/axiomCount unchanged (verified, badge mathlib, 0 axioms) — accurate to the Lean file