### PR TITLE
research(erdos-1-oq-02-incomplete-01): land 2^n-distinct-integers input toward anticoncentration discharge [0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -220,6 +220,47 @@ theorem card_mul_le_second_moment (s : Finset ℕ) (g : ℕ → ℤ)
         Finset.sum_le_sum_of_subset_of_nonneg (Finset.filter_subset _ _)
           (fun i hi _ => hg i hi)
 
+/-- **Subset sums are injective on the powerset (0 axioms).**  The integer subset-sum
+map `T ↦ ∑_{i∈T} i` is injective on `A.powerset` exactly when `A` has distinct subset
+sums.  This is the definitional content of `hasDistinctSubsetSums` transported to `ℤ`
+(via `Nat.cast_sum`), packaged as a `Set.InjOn` for use with `Finset.card_image_of_injOn`. -/
+theorem subsetSum_injOn_of_distinct {A : Finset ℕ} (hDSS : hasDistinctSubsetSums A) :
+    Set.InjOn (fun T : Finset ℕ => ∑ i ∈ T, (i : ℤ)) (A.powerset : Set (Finset ℕ)) := by
+  intro S hS T hT h
+  rw [Finset.mem_coe, Finset.mem_powerset] at hS hT
+  refine hDSS S T hS hT ?_
+  have e : ∀ U : Finset ℕ, ((U.sum id : ℕ) : ℤ) = ∑ i ∈ U, (i : ℤ) := by
+    intro U; simpa using (Nat.cast_sum U id)
+  have heq : ((S.sum id : ℕ) : ℤ) = ((T.sum id : ℕ) : ℤ) := by rw [e, e]; exact h
+  exact_mod_cast heq
+
+/-- **The doubled deviations are injective on the powerset (0 axioms).**  Since
+`T ↦ 2·(∑_{i∈T} i) − S` is an affine reparametrisation of the subset-sum map, it too is
+injective on `A.powerset` for a distinct-subset-sums set.  These are the integer points
+whose second moment is `2^{|A|}·Q` (`second_moment_identity`). -/
+theorem doubledDrop_injOn_of_distinct {A : Finset ℕ} (hDSS : hasDistinctSubsetSums A) :
+    Set.InjOn (fun T : Finset ℕ => 2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ A, (i : ℤ))
+      (A.powerset : Set (Finset ℕ)) := by
+  intro S hS T hT h
+  refine subsetSum_injOn_of_distinct hDSS hS hT ?_
+  show (∑ i ∈ S, (i : ℤ)) = ∑ i ∈ T, (i : ℤ)
+  have h' : 2 * (∑ i ∈ S, (i : ℤ)) - ∑ i ∈ A, (i : ℤ)
+      = 2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ A, (i : ℤ) := h
+  omega
+
+/-- **The `2^{|A|}` doubled deviations are `2^{|A|}` distinct integers (0 axioms).**
+For a distinct-subset-sums set `A`, the image of `A.powerset` under
+`T ↦ 2·(∑_{i∈T} i) − S` has exactly `2^{|A|}` elements.  This is the precise
+"`2ⁿ` distinct integers" input to the central-interval count that recovers the sharp
+constant `3` in `anticoncentration_bound`. -/
+theorem card_doubledDrop_image_of_distinct {A : Finset ℕ}
+    (hDSS : hasDistinctSubsetSums A) :
+    (A.powerset.image
+      (fun T : Finset ℕ => 2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ A, (i : ℤ))).card
+        = 2 ^ A.card := by
+  rw [Finset.card_image_of_injOn (doubledDrop_injOn_of_distinct hDSS),
+    Finset.card_powerset]
+
 /-- **DFX Lower Bound Statement** (Chebyshev constant): If A ⊆ {1,...,N} has n ≥ 1
     elements with distinct subset sums, then:
       2ⁿ ≤ 3·√n·N + 2,    equivalently    N ≥ (2ⁿ − 2) / (3·√n).

--- a/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
@@ -87,3 +87,39 @@ NOT the (M³−M)/12 spread.
 `Finset.card_insert_of_not_mem` is deprecated → `Finset.card_insert_of_notMem`.
 Worktree `feature/researcher-2` predates main; branched off `origin/main`
 (`research/erdos1-oq02-variance`), symlinked `proofs/.lake`, verified `lake env lean`.
+
+## Session 2026-06-28 (researcher-3, cycle 2) — BUILD: distinct-integers input landed (0-axiom)
+
+**Mode**: BUILD (Docker down; offline `LAKE_UNSAFE=1 ./bin/lake env lean`, REAL_EXIT 0, clean).
+**Outcome**: progress — landed the "2ⁿ distinct integers" input that researcher-2's CORRECTION
+flagged as the remaining BUILD step. Axiom still present (full discharge is multi-step).
+
+### What I Did
+Added 3 verified (0-axiom) lemmas after `card_mul_le_second_moment`:
+- `subsetSum_injOn_of_distinct` : `Set.InjOn (T ↦ ∑_{i∈T}(i:ℤ)) ↑A.powerset` for a
+  distinct-subset-sums `A`. Definitional content of `hasDistinctSubsetSums` transported to ℤ
+  via `Nat.cast_sum` (`((U.sum id:ℕ):ℤ) = ∑_{i∈U}(i:ℤ)`).
+- `doubledDrop_injOn_of_distinct` : same InjOn for `T ↦ 2·∑_{i∈T} − S` (affine reparam; `omega`
+  after a `show` to beta-reduce the InjOn goal).
+- `card_doubledDrop_image_of_distinct` : `(A.powerset.image (T ↦ 2·∑_T − S)).card = 2^|A|`
+  via `Finset.card_image_of_injOn` + `card_powerset`. This is the precise **2ⁿ distinct
+  integers** input to the central-interval count.
+
+### GOTCHAs
+- A lambda `fun T => ∑ i ∈ T, (i:ℤ)` defaults `T : Finset ℤ` (the `(i:ℤ)` types `i` as ℤ).
+  MUST annotate `fun T : Finset ℕ => …` or InjOn/image typecheck against `Finset ℤ`.
+- `Set.InjOn` goals leave β-redexes `(fun T => …) S`; `omega`/atoms don't see through them —
+  add `show <beta-reduced eq>` first.
+
+### Remaining to discharge `anticoncentration_bound` (now isolated to 2 steps)
+1. **Parity-aware central-interval count**: the `card_doubledDrop_image` integers are all
+   `≡ S (mod 2)`; distinct same-parity integers in `(−r, r)` number `≤ r+1`. (Pure ℤ/Finset.)
+2. **Combine over ℝ**: Chebyshev tail (`card_mul_le_second_moment` with `g T = (2∑_T−S)²`,
+   `t = 4Q`) ⟹ `#{|·|≥2√Q} ≤ 2ⁿ/4`, so `(3/4)2ⁿ ≤ 2√Q+1 ⟹ 2ⁿ ≤ (8√Q+4)/3 ≤ 3√Q+2`.
+   The only analysis is `Real.sqrt` monotonicity / `Real.sq_sqrt`.
+
+### Files Modified
+- proofs/Proofs/Erdos1OQ02.lean (+3 theorems 10→13, 322→367 lines; 1 axiom unchanged, 0 sorries)
+- src/data/proofs/erdos-1-oq-02/meta.json (counts 322/10 → 367/13 + highlight)
+
+### Status: IN-PROGRESS (axiom not yet discharged).

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 322,
+    "lineCount": 367,
     "assumptions": "One axiom: anticoncentration_bound (Berry-Esseen anticoncentration for subset sums). dfx_lower_bound and pow2_dss proved in 2026-04-26 commit. sum_sq_cauchy_schwarz proved via induction in Z.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -211,13 +211,16 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 322,
+    "lineCount": 367,
     "axiomCount": 1,
-    "theoremCount": 10,
+    "theoremCount": 13,
     "definitionCount": 0,
     "path": "Proofs/Erdos1OQ02.lean",
     "sorries": 0
   },
   "sorries": 0,
-  "assumptions": "One axiom: anticoncentration_bound — the Chebyshev anticoncentration bound 2ⁿ ≤ 3·√(Σaᵢ²) + 2 for distinct-subset-sum sets. It is unconditionally true (Chebyshev's inequality applied to X = Σ εᵢaᵢ, plus the distinctness counting argument) and in principle dischargeable from Mathlib's `ProbabilityTheory` Chebyshev lemmas. dfx_lower_bound and the variance/Cauchy–Schwarz lemmas are fully proved (0 sorries). NOTE: the earlier axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was FALSE and has been corrected. Progress (2026-06-28): the probability-free core of the axiom's discharge is now proved in-file with 0 axioms — second_moment_identity (∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σaᵢ²) and card_mul_le_second_moment (discrete Chebyshev tail count). The only remaining step to eliminate the axiom is the same-parity distinct-integer central-interval count."
+  "assumptions": "One axiom: anticoncentration_bound — the Chebyshev anticoncentration bound 2ⁿ ≤ 3·√(Σaᵢ²) + 2 for distinct-subset-sum sets. It is unconditionally true (Chebyshev's inequality applied to X = Σ εᵢaᵢ, plus the distinctness counting argument) and in principle dischargeable from Mathlib's `ProbabilityTheory` Chebyshev lemmas. dfx_lower_bound and the variance/Cauchy–Schwarz lemmas are fully proved (0 sorries). NOTE: the earlier axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was FALSE and has been corrected. Progress (2026-06-28): the probability-free core of the axiom's discharge is now proved in-file with 0 axioms — second_moment_identity (∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σaᵢ²) and card_mul_le_second_moment (discrete Chebyshev tail count). The only remaining step to eliminate the axiom is the same-parity distinct-integer central-interval count.",
+  "highlights": [
+    "Verified inputs toward discharging the anticoncentration axiom (0-axiom): subset sums are injective on the powerset for a distinct-subset-sums set (subsetSum_injOn_of_distinct), hence the 2^|A| doubled deviations 2*Sum_T - S are 2^|A| DISTINCT integers (card_doubledDrop_image_of_distinct) -- the precise 'distinct integers' input to the central-interval count that recovers the sharp constant 3. Joins second_moment_identity + card_mul_le_second_moment; only the parity-aware interval count + real-sqrt combine remain."
+  ]
 }


### PR DESCRIPTION
## Summary

`Erdos1OQ02.lean` (Erdős #1, Dubroff–Fox–Xu `N = Ω(2ⁿ/√n)` lower bound) is complete except for one axiom, `anticoncentration_bound` (`2^|A| ≤ 3·√Q + 2`, `Q = Σaᵢ²`). Prior sessions landed the probability-free core (`second_moment_identity`, `card_mul_le_second_moment`). This adds the **"2ⁿ distinct integers"** input that researcher-2's correction flagged as the remaining BUILD step — all 0-axiom:

- `subsetSum_injOn_of_distinct` — `T ↦ ∑_{i∈T}(i:ℤ)` is `Set.InjOn` on `A.powerset` for a distinct-subset-sums `A` (the definitional content of `hasDistinctSubsetSums`, transported to ℤ via `Nat.cast_sum`).
- `doubledDrop_injOn_of_distinct` — same for the doubled deviations `T ↦ 2·∑_T − S` (affine reparametrisation).
- `card_doubledDrop_image_of_distinct` — `(A.powerset.image (T ↦ 2·∑_T − S)).card = 2^|A|`: the `2ⁿ` doubled deviations are `2ⁿ` distinct integers — the precise input to the central-interval count that recovers the sharp constant `3`.

## Verification

- Offline `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos1OQ02.lean` → **EXIT 0**, clean (Docker host down).
- `#print axioms` on all three → `[propext, Classical.choice, Quot.sound]` only — **no `anticoncentration_bound`**, no sorry.
- +3 theorems (10→13), 322→367 lines; the 1 axiom is **unchanged** (not yet discharged), 0 sorries.

## Honest status

Verified inputs toward discharging the axiom — **the axiom is not yet eliminated**. Remaining: (1) the parity-aware central-interval count (`≤ r+1` same-parity integers in `(−r, r)`), and (2) the real-`sqrt` combine via the Chebyshev tail. Problem stays **in-progress**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)