### PR TITLE
Enrich Jacobi-Symbol Supplementary Laws: add sections, fix significance

### DIFF
--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-02-oq-03/annotations.json
@@ -2,12 +2,15 @@
   {
     "id": "ann-overview",
     "proofId": "euler-criterion-squares-oq-01-oq-02-oq-03",
-    "range": { "startLine": 3, "endLine": 36 },
+    "range": {
+      "startLine": 3,
+      "endLine": 36
+    },
     "type": "context",
     "title": "From Legendre to Jacobi: Supplements for Composite Moduli",
     "content": "The parent entry proved the supplementary laws of quadratic reciprocity for the Legendre symbol (a | p), defined only for a prime modulus p. The Jacobi symbol J(a | n) extends the Legendre symbol to all odd n > 0 by multiplicativity over the prime factorization of n. This file shows the clean mod-4 and mod-8 exponent formulas survive the passage to composite moduli: J(-1 | n) = (-1)^((n-1)/2) and J(2 | n) = (-1)^((n²-1)/8) for every odd n. Mathlib already provides the (-1)-power form of χ₄ but not of χ₈, so the second formula carries the file's genuine new content.",
     "mathContext": "$\\left(\\tfrac{-1}{n}\\right)_J = (-1)^{(n-1)/2},\\quad \\left(\\tfrac{2}{n}\\right)_J = (-1)^{(n^2-1)/8}$ for odd $n>0$.",
-    "significance": "context",
+    "significance": "supporting",
     "relatedConcepts": [
       "Jacobi symbol",
       "Legendre symbol",
@@ -23,61 +26,109 @@
   {
     "id": "ann-first-supplement",
     "proofId": "euler-criterion-squares-oq-01-oq-02-oq-03",
-    "range": { "startLine": 45, "endLine": 57 },
+    "range": {
+      "startLine": 45,
+      "endLine": 57
+    },
     "type": "technique",
     "title": "First Supplement: J(-1 | n) = (-1)^((n-1)/2)",
     "content": "Mathlib's jacobiSym.at_neg_one evaluates J(-1 | n) = χ₄ n for odd n, and ZMod.χ₄_eq_neg_one_pow already gives χ₄ n = (-1)^(n/2). Since for odd n the Nat divisions n/2 and (n-1)/2 coincide, a single `congr 1; omega` closes the gap. This is the easy half — Mathlib supplies the χ₄ power form directly.",
     "mathContext": "$J(-1\\mid n) = \\chi_4(n) = (-1)^{n/2} = (-1)^{(n-1)/2}$ since $n/2 = (n-1)/2$ for odd $n$.",
-    "significance": "important",
-    "relatedConcepts": ["Jacobi symbol", "character χ₄", "Nat floor division"],
-    "prerequisites": ["modular arithmetic", "the Jacobi symbol"]
+    "significance": "key",
+    "relatedConcepts": [
+      "Jacobi symbol",
+      "character χ₄",
+      "Nat floor division"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "the Jacobi symbol"
+    ]
   },
   {
     "id": "ann-chi8-power-form",
     "proofId": "euler-criterion-squares-oq-01-oq-02-oq-03",
-    "range": { "startLine": 59, "endLine": 100 },
+    "range": {
+      "startLine": 59,
+      "endLine": 100
+    },
     "type": "key-step",
     "title": "The New Lemma: χ₈ n = (-1)^((n²-1)/8)",
     "content": "Mathlib has the χ₄ power form but NO power-of-(-1) form for χ₈, so this is the file's genuine contribution. Starting from the residue-class description χ₈_nat_eq_if_mod_eight, the even branch is discarded (n odd) and n is written as 8k + r with r ∈ {1,3,5,7}. In each class a single `ring` identity of the shape (8k+r)² = 8·E + 1 lets omega evaluate (n²-1)/8 = E exactly; the parity of E (even for r ∈ {1,7}, odd for r ∈ {3,5}) is read off via pow_mul / pow_succ with neg_one_sq, matching χ₈'s sign in each class.",
     "mathContext": "For odd $n$, $8 \\mid n^2-1$ and $(n^2-1)/8$ is even iff $n \\equiv \\pm1 \\pmod 8$, giving $\\chi_8(n) = (-1)^{(n^2-1)/8}$.",
     "significance": "critical",
-    "relatedConcepts": ["character χ₈", "case analysis mod 8", "parity of (-1)-powers", "omega division reasoning"],
-    "prerequisites": ["modular arithmetic", "Dirichlet characters"]
+    "relatedConcepts": [
+      "character χ₈",
+      "case analysis mod 8",
+      "parity of (-1)-powers",
+      "omega division reasoning"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "Dirichlet characters"
+    ]
   },
   {
     "id": "ann-second-supplement",
     "proofId": "euler-criterion-squares-oq-01-oq-02-oq-03",
-    "range": { "startLine": 102, "endLine": 105 },
+    "range": {
+      "startLine": 102,
+      "endLine": 105
+    },
     "type": "technique",
     "title": "Second Supplement: J(2 | n) = (-1)^((n²-1)/8)",
     "content": "With the χ₈ power form in hand, the second supplement is a one-line composition: jacobiSym.at_two rewrites J(2 | n) to χ₈ n, and χ₈_eq_neg_one_pow finishes. The deep Gauss-sum content (J(2 | n) = χ₈ n) is Mathlib's; the closed exponent form is the file's.",
     "mathContext": "$J(2\\mid n) = \\chi_8(n) = (-1)^{(n^2-1)/8}$ for odd $n$.",
-    "significance": "important",
-    "relatedConcepts": ["Jacobi symbol", "second supplementary law"],
-    "prerequisites": ["the Jacobi symbol", "character χ₈"]
+    "significance": "key",
+    "relatedConcepts": [
+      "Jacobi symbol",
+      "second supplementary law"
+    ],
+    "prerequisites": [
+      "the Jacobi symbol",
+      "character χ₈"
+    ]
   },
   {
     "id": "ann-multiplicativity",
     "proofId": "euler-criterion-squares-oq-01-oq-02-oq-03",
-    "range": { "startLine": 107, "endLine": 114 },
+    "range": {
+      "startLine": 107,
+      "endLine": 114
+    },
     "type": "context",
     "title": "Top-Argument Multiplicativity (Re-exported)",
     "content": "J(a·b | n) = J(a | n)·J(b | n) is restated from Mathlib's jacobiSym.mul_left. This multiplicativity holds for every modulus, prime or not — the structural property that distinguishes the Jacobi symbol from the Legendre symbol and, with the supplements and reciprocity, powers the factorization-free evaluation algorithm.",
     "mathContext": "$J(ab\\mid n) = J(a\\mid n)\\,J(b\\mid n)$ for all $a,b\\in\\mathbb{Z}$, $n\\in\\mathbb{N}$.",
-    "significance": "context",
-    "relatedConcepts": ["multiplicativity", "completely multiplicative functions"],
-    "prerequisites": ["the Jacobi symbol"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicativity",
+      "completely multiplicative functions"
+    ],
+    "prerequisites": [
+      "the Jacobi symbol"
+    ]
   },
   {
     "id": "ann-residue-dictionaries",
     "proofId": "euler-criterion-squares-oq-01-oq-02-oq-03",
-    "range": { "startLine": 116, "endLine": 134 },
+    "range": {
+      "startLine": 116,
+      "endLine": 134
+    },
     "type": "technique",
     "title": "Residue Dictionaries and a Caveat for Composite n",
     "content": "J(-1 | n) = 1 ⟺ n ≡ 1 (mod 4) and J(2 | n) = 1 ⟺ n ≡ 1 or 7 (mod 8), each proved by reducing the character if-expression with omega from oddness. Caveat: for prime p the value +1 means a is a quadratic residue, but for composite n the Jacobi symbol can equal +1 while a is a non-residue — so these are value dictionaries, not residuacity criteria.",
     "mathContext": "$J(-1\\mid n)=1 \\iff n\\equiv1\\ (4)$;\\quad $J(2\\mid n)=1 \\iff n\\equiv1,7\\ (8)$.",
-    "significance": "important",
-    "relatedConcepts": ["residue classes", "Jacobi vs Legendre symbol", "quadratic non-residues"],
-    "prerequisites": ["modular arithmetic", "the Jacobi symbol"]
+    "significance": "key",
+    "relatedConcepts": [
+      "residue classes",
+      "Jacobi vs Legendre symbol",
+      "quadratic non-residues"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "the Jacobi symbol"
+    ]
   }
 ]

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-02-oq-03/meta.json
@@ -107,6 +107,40 @@
       "State and prove the contrast theorem for composite moduli: exhibit an odd composite n and an integer a with J(a | n) = 1 yet a a quadratic non-residue mod n, quantifying how far the Jacobi symbol departs from detecting residuacity."
     ]
   },
+  "sections": [
+    {
+      "id": "first-supplementary-law",
+      "title": "First Supplementary Law: J(−1 | n)",
+      "startLine": 45,
+      "endLine": 57,
+      "summary": "jacobiSym_neg_one: J(−1 | n) = (−1)^((n−1)/2) for odd n. Mathlib's jacobiSym.at_neg_one gives J(−1 | n) = χ₄ n and ZMod.χ₄_eq_neg_one_pow gives χ₄ n = (−1)^(n/2); for odd n the Nat divisions n/2 and (n−1)/2 agree (omega).",
+      "mathContext": "$J(-1 \\mid n) = (-1)^{(n-1)/2}$ for odd $n$ — the mod-4 supplement lifted to the Jacobi symbol."
+    },
+    {
+      "id": "second-supplementary-law",
+      "title": "Second Supplementary Law: J(2 | n) and the χ₈ Power Form",
+      "startLine": 59,
+      "endLine": 105,
+      "summary": "The file's original content: χ₈_eq_neg_one_pow proves χ₈ n = (−1)^((n²−1)/8) for odd n — a closed form Mathlib lacks — by case analysis on n mod 8 ∈ {1,3,5,7}, computing (n²−1)/8 explicitly via n = 8k+r. jacobiSym_two then reads off J(2 | n) = (−1)^((n²−1)/8) from jacobiSym.at_two.",
+      "mathContext": "$\\chi_8(n) = (-1)^{(n^2-1)/8}$ and $J(2 \\mid n) = (-1)^{(n^2-1)/8}$ for odd $n$ — the mod-8 supplement at the Jacobi level."
+    },
+    {
+      "id": "multiplicativity",
+      "title": "Multiplicativity in the Top Argument",
+      "startLine": 107,
+      "endLine": 114,
+      "summary": "jacobiSym_mul_top: J(a·b | n) = J(a | n)·J(b | n), the structural property that holds for every modulus (prime or composite) and distinguishes the Jacobi symbol from the Legendre symbol.",
+      "mathContext": "$J(ab \\mid n) = J(a \\mid n)\\,J(b \\mid n)$ for all $a,b$ and every odd $n$."
+    },
+    {
+      "id": "residue-class-forms",
+      "title": "Residue-Class Value Dictionaries",
+      "startLine": 116,
+      "endLine": 134,
+      "summary": "jacobiSym_neg_one_eq_one_iff (J(−1 | n) = 1 ↔ n ≡ 1 mod 4) and jacobiSym_two_eq_one_iff (J(2 | n) = 1 ↔ n ≡ ±1 mod 8): the supplements restated as explicit residue-class conditions, the practical lookup forms used in evaluation.",
+      "mathContext": "$J(-1 \\mid n) = 1 \\iff n \\equiv 1 \\pmod 4$; $\\;J(2 \\mid n) = 1 \\iff n \\equiv \\pm 1 \\pmod 8$."
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "euler-criterion-squares-oq-01-oq-02",
@@ -123,6 +157,5 @@
       "relationship": "related",
       "description": "The main quadratic reciprocity law these supplements accompany; the Jacobi-level supplements plus Jacobi reciprocity give the factorization-free evaluation algorithm."
     }
-  ],
-  "sections": []
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `euler-criterion-squares-oq-01-oq-02-oq-03`.

## Quality improvements
- **Added the missing `sections` array** (4 entries) mapping the Lean file's named sections: first supplementary law J(−1 | n), second supplementary law J(2 | n) + the original χ₈ power-form lemma, top-argument multiplicativity, and the residue-class value dictionaries.
- **Removed a stray duplicate `"sections": []`** at the end of the file that (being last) silently overrode any sections content via JSON last-key-wins.
- **Normalized off-spec annotation significance values:** `"important"` → `key`, `"context"` → `supporting` (`AnnotationSignificance` is only `critical | key | supporting`).
- The 6 annotations are already full-depth (mathContext/significance/relatedConcepts/prerequisites) and validate with **Misaligned: 0**; `crossReferences` already use the correct `proofId`/`relationship`/`description` schema.

meta.json is under the 60 KB cap. No `index.ts` (loader uses `data-manifest.json`).