### PR TITLE
Enrich Second Supplement (2|p) mod 8: add sections, fix significance

### DIFF
--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-03/annotations.json
@@ -2,12 +2,15 @@
   {
     "id": "ann-overview",
     "proofId": "euler-criterion-squares-oq-01-oq-03",
-    "range": { "startLine": 2, "endLine": 46 },
+    "range": {
+      "startLine": 2,
+      "endLine": 46
+    },
     "type": "context",
     "title": "Specializing Euler's Criterion to the Base 2",
     "content": "The parent entry proves Euler's criterion: a nonzero residue a is a square mod an odd prime p exactly when a^((p−1)/2) = 1. That test is universal but does not say, for a fixed a, which primes p make a a square. This leaf carries out that computation for the smallest interesting case a = 2, recovering the classical second supplementary law of quadratic reciprocity: 2 is a quadratic residue mod p iff p ≡ 1 or 7 (mod 8). Beyond restating Mathlib's headline equivalence for the parent's odd-prime convention, the file supplies the non-residue complement, the prime-only residuacity interpretation, and — its distinctive content — the explicit bridge from the parent's exponential test 2^((p−1)/2) to the mod-8 Gauss-sum sign (−1)^((p²−1)/8).",
     "mathContext": "$\\exists x\\in\\mathbb{Z}/p\\mathbb{Z},\\ x^2 = 2 \\iff p\\equiv\\pm1\\pmod 8$, equivalently $2^{(p-1)/2}\\equiv(-1)^{(p^2-1)/8}\\pmod p$.",
-    "significance": "context",
+    "significance": "supporting",
     "relatedConcepts": [
       "Euler's criterion",
       "second supplementary law of quadratic reciprocity",
@@ -23,61 +26,108 @@
   {
     "id": "ann-issquare-two-iff",
     "proofId": "euler-criterion-squares-oq-01-oq-03",
-    "range": { "startLine": 72, "endLine": 82 },
+    "range": {
+      "startLine": 72,
+      "endLine": 82
+    },
     "type": "key-step",
     "title": "Residue / Non-Residue Characterization",
     "content": "isSquare_two_iff is Mathlib's ZMod.exists_sq_eq_two_iff, restated for the parent's [Fact (2 < p)] convention via p ≠ 2. The non-residue complement not_isSquare_two_iff is then the complement across the four reduced residue classes: an odd prime satisfies p % 8 ∈ {1,3,5,7}, so the negation of 'p ≡ 1 or 7' is exactly 'p ≡ 3 or 5', closed by omega.",
     "mathContext": "$\\text{IsSquare}(2:\\mathbb{Z}/p) \\iff p\\bmod 8\\in\\{1,7\\}$; complement $\\iff p\\bmod 8\\in\\{3,5\\}$.",
-    "significance": "central",
-    "relatedConcepts": ["quadratic residues", "residue classes mod 8"],
-    "prerequisites": ["quadratic residues", "case analysis mod 8"]
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic residues",
+      "residue classes mod 8"
+    ],
+    "prerequisites": [
+      "quadratic residues",
+      "case analysis mod 8"
+    ]
   },
   {
     "id": "ann-chi8-closed-form",
     "proofId": "euler-criterion-squares-oq-01-oq-03",
-    "range": { "startLine": 87, "endLine": 118 },
+    "range": {
+      "startLine": 87,
+      "endLine": 118
+    },
     "type": "key-step",
     "title": "The Closed Form χ₈ n = (−1)^((n²−1)/8)",
     "content": "Mathlib provides the (−1)-power form of χ₄ (χ₄_eq_neg_one_pow) but no analogue for χ₈. This lemma fills that gap by a case analysis on n mod 8: writing n = 8k + r with r ∈ {1,3,5,7}, a single `ring` identity (8k+r)² = 8·E + 1 lets omega evaluate (n²−1)/8 = E. The quotient is even (2·…) for r ∈ {1,7} — sign +1 — and odd (2·…+1) for r ∈ {3,5} — sign −1 — exactly matching χ₈'s residue-class values. (The sibling Jacobi leaf reproves the same identity for the composite-modulus setting.)",
     "mathContext": "For odd $n$: $8\\mid n^2-1$ and $(n^2-1)/8$ is even $\\iff n\\bmod 8\\in\\{1,7\\}$.",
-    "significance": "central",
-    "relatedConcepts": ["quadratic Dirichlet character χ₈", "Gauss-sum sign", "parity"],
-    "prerequisites": ["modular arithmetic", "parity of integer divisions"]
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic Dirichlet character χ₈",
+      "Gauss-sum sign",
+      "parity"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "parity of integer divisions"
+    ]
   },
   {
     "id": "ann-euler-bridge",
     "proofId": "euler-criterion-squares-oq-01-oq-03",
-    "range": { "startLine": 128, "endLine": 149 },
+    "range": {
+      "startLine": 128,
+      "endLine": 149
+    },
     "type": "insight",
     "title": "The Euler-Criterion Bridge",
     "content": "two_pow_half_eq_neg_one_pow is the leaf's headline contribution: (2 : ZMod p)^((p−1)/2) = (−1 : ZMod p)^((p²−1)/8). It chains Mathlib's legendreSym.eq_pow ((legendreSym p 2 : ZMod p) = 2^(p/2)), rewritten via p/2 = (p−1)/2, with the exponent form legendreSym p 2 = (−1)^((p²−1)/8), then casts the right-hand sign into ZMod p. This equates the parent's universal exponential test, evaluated at 2, with the concrete mod-8 Gauss-sum sign — the link the sibling Jacobi leaf cannot form, having no Euler criterion for composite moduli.",
     "mathContext": "$2^{(p-1)/2}\\equiv(-1)^{(p^2-1)/8}\\pmod p$, the textbook Euler-criterion form of the second supplement.",
-    "significance": "central",
-    "relatedConcepts": ["Euler's criterion", "Gauss sums", "Legendre symbol as a power"],
-    "prerequisites": ["Euler's criterion", "the Legendre symbol congruence"]
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's criterion",
+      "Gauss sums",
+      "Legendre symbol as a power"
+    ],
+    "prerequisites": [
+      "Euler's criterion",
+      "the Legendre symbol congruence"
+    ]
   },
   {
     "id": "ann-residuacity",
     "proofId": "euler-criterion-squares-oq-01-oq-03",
-    "range": { "startLine": 151, "endLine": 168 },
+    "range": {
+      "startLine": 151,
+      "endLine": 168
+    },
     "type": "insight",
     "title": "Symbol Value +1 Means Residue — for Primes Only",
     "content": "isSquare_two_iff_legendreSym records IsSquare (2 : ZMod p) ↔ legendreSym p 2 = 1, via Mathlib's legendreSym.eq_one_iff at a = 2 (which needs 2 ≠ 0 mod p, supplied by two_ne_zero). For a prime modulus the symbol value +1 genuinely detects quadratic residuacity — exactly the interpretation the sibling Jacobi leaf must drop, since for composite moduli the Jacobi symbol can equal +1 at a non-residue.",
     "mathContext": "$\\text{IsSquare}(2:\\mathbb{Z}/p)\\iff\\left(\\tfrac{2}{p}\\right)=1$ (prime $p$ only).",
     "significance": "supporting",
-    "relatedConcepts": ["Legendre symbol", "quadratic residuacity", "Jacobi symbol contrast"],
-    "prerequisites": ["the Legendre symbol", "quadratic residues"]
+    "relatedConcepts": [
+      "Legendre symbol",
+      "quadratic residuacity",
+      "Jacobi symbol contrast"
+    ],
+    "prerequisites": [
+      "the Legendre symbol",
+      "quadratic residues"
+    ]
   },
   {
     "id": "ann-numerics",
     "proofId": "euler-criterion-squares-oq-01-oq-03",
-    "range": { "startLine": 170, "endLine": 189 },
+    "range": {
+      "startLine": 170,
+      "endLine": 189
+    },
     "type": "context",
     "title": "Concrete Checks (decide, no native_decide)",
     "content": "Worked corollaries confirm the criterion in both directions: 2 is a residue mod 7 (3²=2), mod 17 (6²=36=2), and mod 23 (5²=25=2) — the classes p ≡ 7, 1, 7 (mod 8) — and a non-residue mod 5, 11, 13 — the classes p ≡ 5, 3, 5 (mod 8). All checks use decide, keeping the entry free of native_decide and the Lean.ofReduceBool axiom.",
     "mathContext": "$2$ a residue mod $7,17,23$; non-residue mod $5,11,13$.",
     "significance": "supporting",
-    "relatedConcepts": ["decidable quadratic residues", "worked examples"],
-    "prerequisites": ["ZMod arithmetic"]
+    "relatedConcepts": [
+      "decidable quadratic residues",
+      "worked examples"
+    ],
+    "prerequisites": [
+      "ZMod arithmetic"
+    ]
   }
 ]

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-03/meta.json
@@ -130,5 +130,54 @@
       "description": "The main reciprocity law the supplements accompany; together they form the complete by-hand Legendre-symbol evaluation toolkit."
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Odd-Prime Setup Helpers",
+      "startLine": 53,
+      "endLine": 68,
+      "summary": "Under [Fact p.Prime] [Fact (2 < p)]: ne_two (p ≠ 2), p_mod_two (p is odd), half_eq (p/2 = (p−1)/2, reconciling Mathlib's exponent with Euler's criterion), and mod_eight_cases (an odd prime lies in p % 8 ∈ {1,3,5,7}).",
+      "mathContext": "An odd prime $p$ satisfies $p \\bmod 2 = 1$, $p/2 = (p-1)/2$, and $p \\bmod 8 \\in \\{1,3,5,7\\}$."
+    },
+    {
+      "id": "residue-characterisation",
+      "title": "The Residue / Non-Residue Characterisation",
+      "startLine": 70,
+      "endLine": 83,
+      "summary": "isSquare_two_iff: IsSquare (2 : ZMod p) ↔ p ≡ 1 or 7 (mod 8) — the second supplementary law, from Mathlib's ZMod.exists_sq_eq_two_iff. not_isSquare_two_iff: the non-residue complement p ≡ 3 or 5 (mod 8), by omega over the four odd classes.",
+      "mathContext": "$\\mathrm{IsSquare}(2 \\bmod p) \\iff p \\equiv \\pm 1 \\pmod 8$; non-residue $\\iff p \\equiv \\pm 3 \\pmod 8$."
+    },
+    {
+      "id": "legendre-exponent",
+      "title": "The Legendre Symbol at 2 and the (−1)^((p²−1)/8) Exponent",
+      "startLine": 85,
+      "endLine": 126,
+      "summary": "chi8_eq_neg_one_pow: the original closed form χ₈ n = (−1)^((n²−1)/8) for odd n (Mathlib has only the χ₄ analogue), by mod-8 case analysis. legendreSym_two_eq_chi8 (= χ₈ p, Mathlib) and legendreSym_two_eq_neg_one_pow then give the second supplement in exponent form.",
+      "mathContext": "$\\chi_8(n) = (-1)^{(n^2-1)/8}$ for odd $n$, hence $\\mathrm{legendreSym}\\,p\\,2 = (-1)^{(p^2-1)/8}$."
+    },
+    {
+      "id": "euler-bridge",
+      "title": "The Euler-Criterion Bridge",
+      "startLine": 128,
+      "endLine": 149,
+      "summary": "two_pow_half_eq_legendreSym casts Mathlib's legendreSym.eq_pow to the (p−1)/2 exponent; two_pow_half_eq_neg_one_pow is the bridge (2 : ZMod p)^((p−1)/2) = (−1)^((p²−1)/8), connecting the parent's universal Euler-criterion exponential to the concrete mod-8 sign.",
+      "mathContext": "$(2 \\bmod p)^{(p-1)/2} = (-1)^{(p^2-1)/8}$ in $\\mathbb{Z}/p$ — Euler's exponential test equals the mod-8 Gauss-sum sign."
+    },
+    {
+      "id": "residuacity-symbol",
+      "title": "Residuacity ⟺ Symbol Value (the Prime-Only Feature)",
+      "startLine": 151,
+      "endLine": 168,
+      "summary": "two_ne_zero and isSquare_two_iff_legendreSym: for a prime modulus, IsSquare 2 ↔ legendreSym p 2 = 1 — the residuacity interpretation that fails for composite Jacobi moduli (the sibling leaf can state the sign but not this equivalence).",
+      "mathContext": "$\\mathrm{IsSquare}(2 \\bmod p) \\iff \\mathrm{legendreSym}\\,p\\,2 = 1$ — valid only because $p$ is prime."
+    },
+    {
+      "id": "concrete-checks",
+      "title": "Concrete Checks (decide, no native_decide)",
+      "startLine": 170,
+      "endLine": 189,
+      "summary": "Six worked corollaries by kernel decide: 2 is a residue mod 7, 17, 23 (with explicit square roots 3, 6, 5) and a non-residue mod 5, 11, 13 — the residue classes p ≡ ±1 vs ±3 (mod 8) made concrete, keeping the file axiom-free (plain decide).",
+      "mathContext": "$2$ is a QR mod $7, 17, 23$ ($\\equiv \\pm 1 \\bmod 8$) and a non-QR mod $5, 11, 13$ ($\\equiv \\pm 3 \\bmod 8$)."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `euler-criterion-squares-oq-01-oq-03`.

## Quality improvements
- **Added the missing `sections` array** (6 entries) mapping the file's named sections: odd-prime setup helpers, the residue/non-residue characterisation, the Legendre symbol at 2 + χ₈ exponent form, the Euler-criterion bridge, residuacity⟺symbol value, and the concrete `decide` checks. Replaced the empty `"sections": []` in place.
- **Normalized off-spec annotation significance values:** `"central"` → `key`, `"context"` → `supporting` (`AnnotationSignificance` is only `critical | key | supporting`).
- The 6 annotations are already full-depth and validate with **Misaligned: 0**; `crossReferences` already use the correct `proofId` schema.

meta.json is under the 60 KB cap. No `index.ts` (loader uses `data-manifest.json`).