### PR TITLE
research(erdos-1-oq-02-incomplete-01): combinatorial inputs to anticoncentration discharge — distinct integers + interval count [0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -261,6 +261,38 @@ theorem card_doubledDrop_image_of_distinct {A : Finset ℕ}
   rw [Finset.card_image_of_injOn (doubledDrop_injOn_of_distinct hDSS),
     Finset.card_powerset]
 
+/-- **Same-parity integers in a symmetric interval (0 axioms).**  A finite set `V` of
+integers all sharing one parity and all lying in `[−L, L]` (`L ≥ 0`) has at most `L + 1`
+elements.  This is the central-interval count that — applied to the `2^{|A|}` distinct
+same-parity doubled deviations `2·Σ_T − S` confined to `|·| ≤ L` — recovers the sharp
+constant `3` in `anticoncentration_bound` (the pure second-moment spread bound only gives
+`≈ 3.46√Q`).  Proof: `v ↦ (v + L) / 2` maps `V` injectively (same parity ⟹ no collisions,
+`omega`) into `Finset.Icc 0 L`, whose cardinality is `L + 1`. -/
+theorem card_le_of_sameParity_interval (V : Finset ℤ) (p L : ℤ) (hL : 0 ≤ L)
+    (hpar : ∀ v ∈ V, v % 2 = p % 2) (hbd : ∀ v ∈ V, -L ≤ v ∧ v ≤ L) :
+    (V.card : ℤ) ≤ L + 1 := by
+  have hinj : Set.InjOn (fun v => (v + L) / 2) (V : Set ℤ) := by
+    intro u hu v hv h
+    have hu' := hpar u (Finset.mem_coe.mp hu)
+    have hv' := hpar v (Finset.mem_coe.mp hv)
+    simp only at h
+    omega
+  have hsub : V.image (fun v => (v + L) / 2) ⊆ Finset.Icc 0 L := by
+    intro y hy
+    simp only [Finset.mem_image] at hy
+    obtain ⟨v, hv, rfl⟩ := hy
+    obtain ⟨h1, h2⟩ := hbd v hv
+    rw [Finset.mem_Icc]; omega
+  have hcard : V.card ≤ (Finset.Icc 0 L).card := by
+    rw [← Finset.card_image_of_injOn hinj]
+    exact Finset.card_le_card hsub
+  have hIcc : (Finset.Icc (0 : ℤ) L).card = (L + 1).toNat := by
+    rw [Int.card_Icc]; congr 1; omega
+  rw [hIcc] at hcard
+  have : (V.card : ℤ) ≤ ((L + 1).toNat : ℤ) := by exact_mod_cast hcard
+  rw [Int.toNat_of_nonneg (by omega)] at this
+  exact this
+
 /-- **DFX Lower Bound Statement** (Chebyshev constant): If A ⊆ {1,...,N} has n ≥ 1
     elements with distinct subset sums, then:
       2ⁿ ≤ 3·√n·N + 2,    equivalently    N ≥ (2ⁿ − 2) / (3·√n).

--- a/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
@@ -123,3 +123,33 @@ Added 3 verified (0-axiom) lemmas after `card_mul_le_second_moment`:
 - src/data/proofs/erdos-1-oq-02/meta.json (counts 322/10 → 367/13 + highlight)
 
 ### Status: IN-PROGRESS (axiom not yet discharged).
+
+## Session 2026-06-28 (researcher-3, cycle 3) — BUILD: central-interval count landed (0-axiom)
+
+**Mode**: BUILD (offline `LAKE_UNSAFE=1 lake env lean` EXIT 0). **Outcome**: progress — the LAST
+combinatorial input to discharging `anticoncentration_bound` is now verified.
+
+### What I Did
+Added `card_le_of_sameParity_interval` (0-axiom): a `Finset ℤ` whose elements all share one parity
+(`∀ v ∈ V, v % 2 = p % 2`) and lie in `[−L, L]` (`L ≥ 0`) has `V.card ≤ L + 1`. Proof:
+`v ↦ (v + L) / 2` is `Set.InjOn` on V (same parity ⟹ `omega` kills collisions) into `Finset.Icc 0 L`
+(card `L+1`); `card_image_of_injOn` + `card_le_card` + `Int.card_Icc`. First-try clean build.
+
+### Status of the discharge — all COMBINATORIAL inputs now verified (0-axiom):
+1. `second_moment_identity`: ∑_{T⊆A}(2Σ_T−S)² = 2^|A|·Q ✓
+2. `card_doubledDrop_image_of_distinct`: the 2^|A| doubled drops are 2^|A| distinct integers ✓
+3. `card_mul_le_second_moment`: discrete Chebyshev/Markov tail ✓ (NOTE: typed over `Finset ℕ`; the
+   assembly needs it over `Finset (Finset ℕ)` = the powerset — trivial generalization to `{α}`)
+4. `card_le_of_sameParity_interval`: ≤ L+1 same-parity integers in [−L,L] ✓  ← THIS SESSION
+
+### ONLY remaining step: the real-sqrt optimization assembly
+`2^n = #{|vT| ≤ L} + #{|vT| > L} ≤ (L+1) + 2^n·Q/(L+1)²` (interval count + Chebyshev with threshold
+(L+1)²; vT all ≡ S mod 2). Optimize the integer `m = L+1 ≈ 2√Q`: gives `(3/4)2^n ≤ 2√Q+1`, i.e.
+`2^n ≤ (8√Q+4)/3 ≤ 3√Q+2`. Analysis content: pick `m = ⌈2·Real.sqrt Q⌉` (or `Nat.sqrt`-based),
+`Real.sq_sqrt`/`Real.sqrt_le_sqrt`, cast ℤ→ℝ. ~40-80 lines; the only non-elementary piece left.
+
+### Files Modified
+- proofs/Proofs/Erdos1OQ02.lean (+1 theorem 13→14, 367→399 lines; 1 axiom unchanged, 0 sorries)
+- src/data/proofs/erdos-1-oq-02/meta.json (counts 367/13 → 399/14 + highlight)
+
+### Status: IN-PROGRESS (axiom not yet discharged; only the sqrt assembly remains).

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 367,
+    "lineCount": 399,
     "assumptions": "One axiom: anticoncentration_bound (Berry-Esseen anticoncentration for subset sums). dfx_lower_bound and pow2_dss proved in 2026-04-26 commit. sum_sq_cauchy_schwarz proved via induction in Z.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -211,9 +211,9 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 367,
+    "lineCount": 399,
     "axiomCount": 1,
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 0,
     "path": "Proofs/Erdos1OQ02.lean",
     "sorries": 0
@@ -221,6 +221,7 @@
   "sorries": 0,
   "assumptions": "One axiom: anticoncentration_bound — the Chebyshev anticoncentration bound 2ⁿ ≤ 3·√(Σaᵢ²) + 2 for distinct-subset-sum sets. It is unconditionally true (Chebyshev's inequality applied to X = Σ εᵢaᵢ, plus the distinctness counting argument) and in principle dischargeable from Mathlib's `ProbabilityTheory` Chebyshev lemmas. dfx_lower_bound and the variance/Cauchy–Schwarz lemmas are fully proved (0 sorries). NOTE: the earlier axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was FALSE and has been corrected. Progress (2026-06-28): the probability-free core of the axiom's discharge is now proved in-file with 0 axioms — second_moment_identity (∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σaᵢ²) and card_mul_le_second_moment (discrete Chebyshev tail count). The only remaining step to eliminate the axiom is the same-parity distinct-integer central-interval count.",
   "highlights": [
+    "Central-interval count landed (card_le_of_sameParity_interval, 0-axiom): a finite set of integers all of one parity confined to [-L,L] has <= L+1 elements (via v |-> (v+L)/2 injecting into Icc 0 L). This is the LAST combinatorial input to discharging anticoncentration_bound with the sharp constant 3 -- joins second_moment_identity, the 2^|A|-distinct-integers image, and the Chebyshev tail. Only the real-sqrt optimization assembly remains.",
     "Verified inputs toward discharging the anticoncentration axiom (0-axiom): subset sums are injective on the powerset for a distinct-subset-sums set (subsetSum_injOn_of_distinct), hence the 2^|A| doubled deviations 2*Sum_T - S are 2^|A| DISTINCT integers (card_doubledDrop_image_of_distinct) -- the precise 'distinct integers' input to the central-interval count that recovers the sharp constant 3. Joins second_moment_identity + card_mul_le_second_moment; only the parity-aware interval count + real-sqrt combine remain."
   ]
 }


### PR DESCRIPTION
## Summary

`Erdos1OQ02.lean` (Erdős #1 / Dubroff–Fox–Xu `N = Ω(2ⁿ/√n)`) is complete except for the axiom `anticoncentration_bound` (`2^|A| ≤ 3·√Q + 2`, `Q = Σaᵢ²`). This PR lands **all the combinatorial inputs** to a probability-free discharge of that axiom (0-axiom each). It supersedes #31344 (whose commit is included here).

- `subsetSum_injOn_of_distinct` / `doubledDrop_injOn_of_distinct` / `card_doubledDrop_image_of_distinct` — the `2ⁿ` doubled deviations `2·∑_T − S` are `2ⁿ` **distinct integers**.
- `card_le_of_sameParity_interval` — a finite set of integers all of one parity, confined to `[−L, L]`, has `≤ L+1` elements (via `v ↦ (v+L)/2` injecting into `Finset.Icc 0 L`). This is the **central-interval count** that recovers the sharp constant `3` (the pure second-moment spread bound only reaches `≈ 3.46√Q`).

Together with the previously-landed `second_moment_identity` (`∑_{T⊆A}(2∑_T−S)² = 2ⁿ·Q`) and `card_mul_le_second_moment` (Chebyshev tail), **every combinatorial ingredient is now verified**.

## Verification

- Offline `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/Erdos1OQ02.lean` → **EXIT 0**, clean.
- `#print axioms` on each new lemma → `[propext, Classical.choice, Quot.sound]` only (no `anticoncentration_bound`, no sorry).
- +4 theorems (10→14), 322→399 lines; the 1 axiom is **unchanged** (not yet discharged), 0 sorries.

## Honest status

The axiom is **not yet eliminated**. The single remaining step is the real-`sqrt` optimization assembly: `2ⁿ ≤ (L+1) + 2ⁿ·Q/(L+1)²`, optimized at `m = L+1 ≈ 2√Q`, giving `2ⁿ ≤ 3√Q + 2` (the Chebyshev lemma also needs a one-line generalization from `Finset ℕ` to the powerset `Finset (Finset ℕ)`). Problem stays **in-progress**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)