### PR TITLE
Enrich Abel–Ruffini ⊕/× boundary: annotations 5→6, cover multiplicative escape

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -14,13 +14,13 @@
   {
     "id": "ann-sum-threshold",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 64, "endLine": 70 },
+    "range": { "startLine": 63, "endLine": 81 },
     "type": "technique",
     "title": "Rewriting the threshold through a cardinality formula",
-    "content": "`perm_sum_solvable_iff` is one `rw`: apply the intrinsic threshold `perm_solvable_iff_card` to $S_{\\alpha\\oplus\\beta}$, then `Fintype.card_sum` evaluates $|\\alpha\\oplus\\beta| = |\\alpha| + |\\beta|$. The result\n$$\\mathrm{IsSolvable}(S_{\\alpha\\oplus\\beta}) \\iff |\\alpha| + |\\beta| \\le 4$$\nis the disjoint-union threshold as an **additive** condition. `perm_prod_solvable_iff` is the same proof with `Fintype.card_prod`, yielding the **multiplicative** condition $|\\alpha|\\cdot|\\beta| \\le 4$.",
-    "mathContext": "$\\mathrm{IsSolvable}(S_{\\alpha\\oplus\\beta}) \\iff |\\alpha|+|\\beta| \\le 4$ and $\\mathrm{IsSolvable}(S_{\\alpha\\times\\beta}) \\iff |\\alpha|\\cdot|\\beta| \\le 4$.",
+    "content": "`perm_sum_solvable_iff` is one `rw`: apply the intrinsic threshold `perm_solvable_iff_card` to $S_{\\alpha\\oplus\\beta}$, then `Fintype.card_sum` evaluates $|\\alpha\\oplus\\beta| = |\\alpha| + |\\beta|$. The result\n$$\\mathrm{IsSolvable}(S_{\\alpha\\oplus\\beta}) \\iff |\\alpha| + |\\beta| \\le 4$$\nis the disjoint-union threshold as an **additive** condition. `perm_prod_solvable_iff` is the same proof with `Fintype.card_prod`, yielding the **multiplicative** condition $|\\alpha|\\cdot|\\beta| \\le 4$. `alternating_sum_solvable_iff` repeats the rewrite against the alternating classification `alternating_solvable_iff_card`, so the *same* additive threshold $|\\alpha|+|\\beta| \\le 4$ governs $A_{\\alpha\\oplus\\beta}$ — the two intrinsic classifications $S_n$ and $A_n$ share the boundary $n \\le 4$, hence share its image under $\\oplus$.",
+    "mathContext": "$\\mathrm{IsSolvable}(S_{\\alpha\\oplus\\beta}) \\iff |\\alpha|+|\\beta| \\le 4$, $\\mathrm{IsSolvable}(S_{\\alpha\\times\\beta}) \\iff |\\alpha|\\cdot|\\beta| \\le 4$, and $\\mathrm{IsSolvable}(A_{\\alpha\\oplus\\beta}) \\iff |\\alpha|+|\\beta| \\le 4$.",
     "significance": "supporting",
-    "relatedConcepts": ["Fintype.card_sum", "Fintype.card_prod", "rewriting tactic"],
+    "relatedConcepts": ["Fintype.card_sum", "Fintype.card_prod", "alternating group classification", "rewriting tactic"],
     "prerequisites": ["intrinsic solvability threshold", "cardinality formulas"]
   },
   {
@@ -36,9 +36,21 @@
     "prerequisites": ["monotonicity of multiplication", "Fintype.card_pos"]
   },
   {
+    "id": "ann-mult-escape",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 115, "endLine": 125 },
+    "type": "insight",
+    "title": "The multiplicative escape overshoots the boundary",
+    "content": "The flip side of reflection. `perm_prod_not_solvable_of_factors` shows the product can also *escape* solvability — but it costs more than the additive escape does. From $2 \\le |\\alpha|$ and $3 \\le |\\beta|$, `Nat.mul_le_mul` gives $6 = 2\\cdot 3 \\le |\\alpha|\\cdot|\\beta|$, so the product threshold $|\\alpha|\\cdot|\\beta| \\le 4$ fails and $S_{\\alpha\\times\\beta}$ is unsolvable. The smallest unsolvable product of two genuinely-larger-than-one factors is $2 \\cdot 3 = 6$. Compare §4: the smallest unsolvable *sum* is $2 + 3 = 5$. So the disjoint union lands its minimal escape **exactly** on the Abel–Ruffini degree, while the product **overshoots** it by one — the additive boundary is the tight one, and the asymmetry between $\\oplus$ and $\\times$ is visible already in the cost of escaping.",
+    "mathContext": "$2 \\le |\\alpha|,\\ 3 \\le |\\beta| \\Rightarrow 6 \\le |\\alpha|\\cdot|\\beta| \\Rightarrow \\neg\\,\\mathrm{IsSolvable}(S_{\\alpha\\times\\beta})$; minimal product escape $2\\cdot 3 = 6 > 5 = 2 + 3$, the minimal sum escape.",
+    "significance": "supporting",
+    "relatedConcepts": ["multiplicative escape", "Nat.mul_le_mul", "tightness of the additive boundary"],
+    "prerequisites": ["monotonicity of multiplication", "product solvability threshold"]
+  },
+  {
     "id": "ann-sums-fail",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 149, "endLine": 162 },
+    "range": { "startLine": 134, "endLine": 150 },
     "type": "insight",
     "title": "Disjoint unions do NOT preserve solvability",
     "content": "The exact opposite of products. `perm_sum_solvability_not_preserved` exhibits the minimal witness: $S_{\\mathrm{Fin}\\,2}$ and $S_{\\mathrm{Fin}\\,3}$ are both solvable ($2,3 \\le 4$), yet $S_{\\mathrm{Fin}\\,2 \\oplus \\mathrm{Fin}\\,3}$ is **not** — the union has $2 + 3 = 5$ points, and $5 \\not\\le 4$. Two solvable systems join into an unsolvable one. This is the Abel–Ruffini obstruction in combinatorial dress: solvability of the pieces carries no information about solvability of their union.",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01` (passes: 0, quality: 85).

## Changes (annotations.json, data-only)
- **New annotation `ann-mult-escape`** covering `perm_prod_not_solvable_of_factors` (lines 115–125), previously uncovered. It surfaces a central theme of the entry: the minimal unsolvable *product* $2\cdot3=6$ **overshoots** the Abel–Ruffini boundary, whereas the minimal unsolvable *sum* $2+3=5$ **lands on** it — so the additive boundary is the tight one.
- **Extended `ann-sum-threshold`** (range 64–70 → 63–81; content) to include the original contribution `alternating_sum_solvable_iff`: $A_n$ shares the $n\le4$ boundary, hence shares its image under $\oplus$.
- **Fixed misaligned range on `ann-sums-fail`** (149–162 → 134–150) so it actually covers §3's theorems `perm_sum_fin_two_three_not_solvable` and `perm_sum_solvability_not_preserved`.

## Verification
- `annotations.json` and `meta.json` parse as valid JSON.
- `check-meta-size.ts`: within all caps (meta.json 20.5 KB ≤ 60 KB).
- `pnpm build` data-generation/enrichment step processed the entry successfully. The final `tsc` typecheck could not run in this worktree (no `node_modules`; `pnpm install` blocked by a `better-sqlite3` native build failure under node v26) — environmental, unrelated to this data-only change.

All claims verified against the Lean source `Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01.lean`.