### PR TITLE
Enrich Sₐ/Aₐ solvability cardinality-intrinsic: +§2 annotation, +conclusion

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01/annotations.json
@@ -41,6 +41,23 @@
     "prerequisites": ["solvable groups", "group homomorphisms", "Lean typeclass resolution"]
   },
   {
+    "id": "ann-perm-solvable-congr",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
+    "range": { "startLine": 65, "endLine": 77 },
+    "type": "key-step",
+    "title": "Conjugation by a relabelling: permCongrHom",
+    "content": "A bijection $e : \\alpha \\simeq \\beta$ of the underlying sets does not just match points — it conjugates whole permutations. Mathlib packages this as `Equiv.permCongrHom e : Perm α ≃* Perm β`, the *multiplicative* isomorphism sending $\\sigma \\mapsto e \\circ \\sigma \\circ e^{-1}$ (i.e. `e.permCongr σ`). That it is multiplicative is the content of conjugation being a group homomorphism: $(e\\sigma e^{-1})(e\\tau e^{-1}) = e(\\sigma\\tau)e^{-1}$.\n\nFeeding this `MulEquiv` to `isSolvable_congr` from §1 gives `perm_solvable_congr` in a single line:\n$$\\mathrm{IsSolvable}(\\mathrm{Perm}\\,\\alpha) \\iff \\mathrm{IsSolvable}(\\mathrm{Perm}\\,\\beta).$$\nNo hypothesis on $\\alpha$ or $\\beta$ beyond the bijection is needed; the symmetric group of a finite set is determined up to isomorphism by the set's size alone, so its solvability is too. Note the section variables fix `[DecidableEq α] [Fintype α]` (and likewise for $\\beta$) — these instances are what let `Perm α` carry a `sign` and a `Fintype` structure downstream.",
+    "mathContext": "permCongrHom is the unindexed form of the standard isomorphism $S_n \\cong S_m$ when $n = m$: relabelling the ground set is an isomorphism of the full symmetric group, here realized functorially as a single `MulEquiv` rather than chosen by hand.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Equiv.permCongrHom",
+      "conjugation as a group homomorphism",
+      "MulEquiv",
+      "symmetric group functoriality"
+    ],
+    "prerequisites": ["permutation groups", "conjugation", "group isomorphism"]
+  },
+  {
     "id": "ann-map-permCongrHom-alternating",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01",
     "range": { "startLine": 78, "endLine": 112 },

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01/meta.json
@@ -280,5 +280,19 @@
       "relationship": "related",
       "description": "Sibling Sₙ solvable iff n ≤ 4 (Fin n). perm_solvable_iff_card is the arbitrary-finite-type form."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "Both classical solvability classifications — IsSolvable (Perm α) ↔ Fintype.card α ≤ 4 and IsSolvable (alternatingGroup α) ↔ Fintype.card α ≤ 4 — are established for an arbitrary finite type α, not just the indexed model Fin n. The mechanism is a single transport: any bijection e : α ≃ β induces the conjugation isomorphism permCongrHom e : Perm α ≃* Perm β, which preserves sign (sign_permCongr) and therefore restricts to a canonical isomorphism alternatingCongr : alternatingGroup α ≃* alternatingGroup β. Since solvability is a MulEquiv invariant (isSolvable_congr), specialising e to Fintype.equivFin α : α ≃ Fin (card α) collapses each arbitrary-type statement onto the parent's already-proved Fin n verdict by one rewrite. The result is a 0-axiom Mathlib bridge — no native_decide, no sorries — that answers the parent's first future direction and exposes Fintype.card α as the sole invariant governing solvability.",
+    "implications": [
+      "The Abel–Ruffini obstruction is coordinate-free: any 5-element set, however presented (roots of a quintic, vertices of a graph, a chosen basis), has non-solvable symmetric and alternating groups, with no enumeration required.",
+      "Equinumerous finite types receive a canonical — not merely abstract-existence — isomorphism of alternating groups via alternatingCongr, so the cardinality-invariance comes with an explicit witness usable in further constructions.",
+      "isSolvable_congr is a small reusable lemma: it makes solvability transparent to any group isomorphism, so any future relabelling or coordinate change in the gallery's group-theory entries is automatically invisible to the solvability verdict.",
+      "The reduction pattern (transport along Fintype.equivFin to inherit a Fin n classification) is a template for lifting any isomorphism-invariant property of permutation groups off the indexed model onto arbitrary finite types."
+    ],
+    "openQuestions": [
+      "Can the same permCongrHom transport carry finer invariants than solvability — e.g. the derived length, nilpotency class, or the full subgroup lattice — from Fin n to an arbitrary finite type with equally short proofs?",
+      "Does alternatingCongr assemble into a functor on the groupoid of finite types and bijections, making 'alternating group of a finite set' a genuinely natural construction rather than a per-bijection isomorphism?",
+      "What is the analogous intrinsic (Fin-free) statement and transport for solvability of other naturally-indexed group families, such as the classical Weyl groups or wreath products on a finite ground set?"
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01` (quality 85, pass 0).

## Changes
- **Annotation coverage**: added `ann-perm-solvable-congr` for §2 (the `perm_solvable_congr` theorem / `Equiv.permCongrHom` conjugation isomorphism), lines 65–77. This was the only gap — annotations previously jumped §1 (45–63) → §3 (78–112), skipping the transport step that the whole file is built on. Now 6 annotations, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- **Conclusion**: added `meta.conclusion` (previously absent) with `summary`, 4 `implications` (coordinate-free Abel–Ruffini obstruction, explicit `alternatingCongr` witness, reusable `isSolvable_congr`, the equivFin transport template), and 3 `openQuestions`.

## Guardrails
- meta.json 22 KB → 24 KB, well under the 60 KB cap (`gallery:check-size` passes).
- Annotation validator clean for this entry; JSON valid.
- 0-axiom mathlib bridge unchanged; no existing content removed.