### PR TITLE
research(de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01): Chebyshev monoid homomorphism is 2-to-1 — fibers are exactly the sign flips

### DIFF
--- a/proofs/Proofs/DeMoivreOQ01OQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ01OQ03OQ01OQ01OQ01.lean
@@ -1,0 +1,208 @@
+/-
+# Sharp injectivity of the Chebyshev monoid homomorphism `n ↦ Cₙ`
+  (de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01)
+
+## Open Question (OQ-01 of de-moivre-oq-01-oq-03-oq-01-oq-01)
+The parent `de-moivre-oq-01-oq-03-oq-01-oq-01` bundled the integer-index Chebyshev
+map into a **monoid homomorphism**
+  `chebyshevCEnd R : (ℤ, ·) →* Function.End R[X]`,   `n ↦ (Cₙ ∘ ·)`.
+A homomorphism invites the immediate structural question: **is it injective?**
+Equivalently, what are its fibers — when do two indices give the *same* Chebyshev
+operator `Cₘ ∘ · = Cₙ ∘ ·`?
+
+## Answer: NO, and the failure is *exactly* the even symmetry `C₋ₙ = Cₙ`.
+
+The map is **not** injective: already `chebyshevCEnd R 1 = chebyshevCEnd R (-1)`
+because `C₁ = X = C₋₁`.  We pin the fibers down completely:
+
+  `chebyshevCEnd R m = chebyshevCEnd R n  ↔  m = n ∨ m = -n`.
+
+So the only coincidences are the sign flips `n ↔ -n`; the homomorphism is **2-to-1
+away from `0`** and injective on the nonnegative cone `{n ≥ 0}`.  Structurally it
+factors through the multiplicative monoid map `ℤ → ℕ, n ↦ |n|` (note `|mn| = |m||n|`),
+and the induced map on indices `|n|` is injective.
+
+## The engine: `Cₙ` is monic of degree `|n|`
+The first-kind integer-index Chebyshev polynomial is **monic of degree `|n|`** for
+`n ≥ 1` (and `C₀ = 2` has degree `0 = |0|`).  We prove this from the three-term
+recurrence `C_{n+2} = X·C_{n+1} − Cₙ` by two-step induction, exactly mirroring the
+gallery's `Tₙ` degree proof (`DeMoivreOQ02OQ03OQ02`).  The degree is the injectivity
+invariant: `Cₘ = Cₙ ⟹ |m| = |n|` (compare degrees), and conversely
+`|m| = |n| ⟹ Cₘ = Cₙ` via `C_natAbs`.  Combining with `Int.natAbs_eq_natAbs_iff`
+gives the `m = ±n` characterization.
+
+## Status
+- `0` sorries, `0` axioms, no `native_decide`.
+- New content: `Cₙ` monic of degree `|n|` (general `[CommRing R] [Nontrivial R]`),
+  the equality criterion `Cₘ = Cₙ ↔ m = ±n`, and the resulting fiber description,
+  non-injectivity, and injectivity-on-the-cone for `chebyshevCEnd`.
+- Reuses Mathlib's `C_neg`, `C_natAbs`, `C_add_two`, `monic_X_pow_sub_C`, and the
+  parent's `chebyshevCEnd` monoid homomorphism.
+-/
+
+import Mathlib.RingTheory.Polynomial.Chebyshev
+import Mathlib.Tactic
+import Proofs.DeMoivreOQ01OQ03OQ01OQ01
+
+namespace DeMoivreChebyshevInjectivity
+
+open Polynomial Polynomial.Chebyshev
+open DeMoivreChebyshevMonoidHom
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: `Cₙ` IS MONIC OF DEGREE `|n|`
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+variable (R : Type*) [CommRing R] [Nontrivial R]
+
+/-- **Monicity and degree of `Cₙ` for positive index.**  For every `n : ℕ`, the
+    Chebyshev polynomial `C R (n+1)` is monic of degree `n+1`.  Proof by two-step
+    induction on the recurrence `C_{k+2} = X·C_{k+1} − C_k`. -/
+theorem C_monic_natDegree_succ (n : ℕ) :
+    (C R ((n : ℤ) + 1)).Monic ∧ (C R ((n : ℤ) + 1)).natDegree = n + 1 := by
+  induction n using Nat.twoStepInduction with
+  | zero =>
+    refine ⟨?_, ?_⟩
+    · have : ((0 : ℕ) : ℤ) + 1 = 1 := by norm_num
+      rw [this, C_one]; exact monic_X
+    · have : ((0 : ℕ) : ℤ) + 1 = 1 := by norm_num
+      rw [this, C_one]; simp
+  | one =>
+    have hcast : ((1 : ℕ) : ℤ) + 1 = 2 := by norm_num
+    have hC2 : C R (2 : ℤ) = X ^ 2 - Polynomial.C (2 : R) := by
+      rw [C_two, ← map_ofNat Polynomial.C 2]
+    refine ⟨?_, ?_⟩
+    · rw [hcast, hC2]; exact monic_X_pow_sub_C _ (by norm_num)
+    · rw [hcast, hC2, natDegree_X_pow_sub_C]
+  | more n ih0 ih1 =>
+    obtain ⟨hmon0, hdeg0⟩ := ih0
+    obtain ⟨hmon1, hdeg1⟩ := ih1
+    -- recurrence: C R (n+3) = X * C R (n+2) - C R (n+1)
+    have hrec : C R (((n + 2 : ℕ) : ℤ) + 1)
+        = X * C R (((n + 1 : ℕ) : ℤ) + 1) - C R (((n : ℕ) : ℤ) + 1) := by
+      have h := C_add_two R (((n : ℕ) : ℤ) + 1)
+      have e1 : ((n + 2 : ℕ) : ℤ) + 1 = ((n : ℕ) : ℤ) + 1 + 2 := by push_cast; ring
+      have e2 : ((n + 1 : ℕ) : ℤ) + 1 = ((n : ℕ) : ℤ) + 1 + 1 := by push_cast; ring
+      rw [e1, e2]; exact h
+    -- C R (n+2) ≠ 0 (it is monic, hence nonzero in a nontrivial ring)
+    have hne1 : C R (((n + 1 : ℕ) : ℤ) + 1) ≠ 0 := hmon1.ne_zero
+    -- degree of A := X * C R (n+2)
+    have hdA : (X * C R (((n + 1 : ℕ) : ℤ) + 1)).natDegree = n + 3 := by
+      rw [natDegree_X_mul hne1, hdeg1]
+    -- A is monic
+    have hmonA : (X * C R (((n + 1 : ℕ) : ℤ) + 1)).Monic := monic_X.mul hmon1
+    -- C R (n+1) has strictly smaller degree
+    have hdeg_lt : (C R (((n : ℕ) : ℤ) + 1)).natDegree
+        < (X * C R (((n + 1 : ℕ) : ℤ) + 1)).natDegree := by
+      rw [hdA, hdeg0]; omega
+    have hdeg_lt' : (C R (((n : ℕ) : ℤ) + 1)).degree
+        < (X * C R (((n + 1 : ℕ) : ℤ) + 1)).degree := degree_lt_degree hdeg_lt
+    refine ⟨?_, ?_⟩
+    · rw [hrec, sub_eq_add_neg]
+      exact hmonA.add_of_left (by rwa [degree_neg])
+    · rw [hrec, natDegree_sub_eq_left_of_natDegree_lt hdeg_lt, hdA]
+
+/-- **Degree of `Cₙ` for natural index.**  `natDegree (C R n) = n`. -/
+theorem C_natDegree_nat (m : ℕ) : (C R (m : ℤ)).natDegree = m := by
+  cases m with
+  | zero => simp
+  | succ k =>
+    have h := (C_monic_natDegree_succ R k).2
+    have e : ((k + 1 : ℕ) : ℤ) = (k : ℤ) + 1 := by push_cast; ring
+    rw [e]; exact h
+
+/-- **Degree of `Cₙ`.**  For every integer index, `natDegree (C R n) = |n|`. -/
+theorem C_natDegree (n : ℤ) : (C R n).natDegree = n.natAbs := by
+  rw [← C_natAbs R n, C_natDegree_nat]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: THE EQUALITY CRITERION `Cₘ = Cₙ ↔ m = ±n`
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Equality of Chebyshev polynomials is exactly equality of `|index|`.**
+    `C R m = C R n ↔ |m| = |n|`.  Forward by comparing degrees; backward by the
+    even symmetry `C_natAbs`. -/
+theorem C_eq_iff_natAbs (m n : ℤ) : C R m = C R n ↔ m.natAbs = n.natAbs := by
+  constructor
+  · intro h
+    have := congrArg Polynomial.natDegree h
+    rwa [C_natDegree, C_natDegree] at this
+  · intro h
+    rw [← C_natAbs R m, ← C_natAbs R n, h]
+
+/-- **Sharp equality criterion.**  `C R m = C R n ↔ m = n ∨ m = -n`: the only
+    coincidences among Chebyshev polynomials are the sign flips. -/
+theorem C_eq_iff (m n : ℤ) : C R m = C R n ↔ m = n ∨ m = -n := by
+  rw [C_eq_iff_natAbs, Int.natAbs_eq_natAbs_iff]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: FIBERS, NON-INJECTIVITY, AND INJECTIVITY ON THE CONE
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Two Chebyshev endomorphisms agree iff their generating polynomials agree:
+    `chebyshevCEnd R m = chebyshevCEnd R n ↔ C R m = C R n`.  (Evaluate at `X`.) -/
+theorem chebyshevCEnd_eq_iff_C (m n : ℤ) :
+    chebyshevCEnd R m = chebyshevCEnd R n ↔ C R m = C R n := by
+  constructor
+  · intro h
+    have hX : chebyshevCEnd R m X = chebyshevCEnd R n X := by rw [h]
+    rwa [chebyshevCEnd_apply, chebyshevCEnd_apply, Polynomial.comp_X,
+      Polynomial.comp_X] at hX
+  · intro h
+    funext p
+    rw [chebyshevCEnd_apply, chebyshevCEnd_apply, h]
+
+/-- **Fiber description of the monoid homomorphism.**
+    `chebyshevCEnd R m = chebyshevCEnd R n ↔ m = n ∨ m = -n`. -/
+theorem chebyshevCEnd_eq_iff (m n : ℤ) :
+    chebyshevCEnd R m = chebyshevCEnd R n ↔ m = n ∨ m = -n := by
+  rw [chebyshevCEnd_eq_iff_C, C_eq_iff]
+
+/-- **The Chebyshev monoid homomorphism is not injective.**  Witnessed by the
+    even symmetry `C₁ = X = C₋₁`, so `1` and `-1` have the same image. -/
+theorem chebyshevCEnd_not_injective :
+    ¬ Function.Injective (chebyshevCEnd R) := by
+  intro hinj
+  have h11 : (1 : ℤ) = -1 := by
+    apply hinj
+    rw [chebyshevCEnd_eq_iff]; right; rfl
+  norm_num at h11
+
+/-- **Injectivity on the nonnegative cone.**  Restricted to `{n ≥ 0}`, the monoid
+    homomorphism `chebyshevCEnd` *is* injective: distinct nonnegative indices give
+    distinct Chebyshev operators. -/
+theorem chebyshevCEnd_injOn_nonneg :
+    Set.InjOn (chebyshevCEnd R) {n : ℤ | 0 ≤ n} := by
+  intro m hm n hn h
+  rw [chebyshevCEnd_eq_iff] at h
+  simp only [Set.mem_setOf_eq] at hm hn
+  rcases h with h | h
+  · exact h
+  · omega
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV: CONSISTENCY CHECKS
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- `C₂ = X² − 2` has degree `2 = |2|` over `ℝ`. -/
+example : (C ℝ 2).natDegree = 2 := by
+  have := C_natDegree ℝ 2; simpa using this
+
+/-- The sign-flip coincidence `C₃ = C₋₃` over `ℝ`. -/
+example : C ℝ 3 = C ℝ (-3) := by
+  rw [C_eq_iff]; right; rfl
+
+/-- `C₂ ≠ C₃` (different degrees), so the indices `2` and `3` are distinguished. -/
+example : C ℝ 2 ≠ C ℝ 3 := by
+  rw [Ne, C_eq_iff]; decide
+
+#check @C_natDegree
+#check @C_eq_iff
+#check @chebyshevCEnd_eq_iff
+#check @chebyshevCEnd_not_injective
+
+end DeMoivreChebyshevInjectivity

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,186 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 41
+    },
+    "type": "concept",
+    "title": "The open question: are the fibers of n ↦ Cₙ exactly the sign flips?",
+    "content": "The parent bundled the integer-index Chebyshev map into a monoid homomorphism `chebyshevCEnd R : ℤ →* Function.End R[X]`, `n ↦ Cₙ ∘ ·`. A homomorphism invites the injectivity question, and the header records the complete answer: the map is **NOT** injective — already `chebyshevCEnd R 1 = chebyshevCEnd R (-1)` since `C₁ = X = C₋₁` — and its fibers are exactly the sign-flip pairs, `chebyshevCEnd R m = chebyshevCEnd R n ↔ m = n ∨ m = -n`. The map is 2-to-1 away from 0 and injective on `{n ≥ 0}`, factoring through `n ↦ |n|`. The engine is announced too: `Cₙ` is monic of degree `|n|`, so equal Chebyshev polynomials have equal `|index|`.",
+    "mathContext": "Fibers of $\\texttt{chebyshevCEnd}$ are $\\{n, -n\\}$; the failure of injectivity is exactly the even symmetry $C_{-n} = C_n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chebyshev polynomials of the third kind",
+      "monoid homomorphism",
+      "injectivity and fibers",
+      "even symmetry",
+      "polynomial degree"
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials",
+      "monoid homomorphisms",
+      "injective functions"
+    ]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 43,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "Imports and namespace",
+    "content": "Imports Mathlib's Chebyshev library — supplying the recurrence `C_add_two` (`C R (n+2) = X * C R (n+1) - C R n`) and the even symmetry `C_natAbs` (`C R n.natAbs = C R n`) — and the parent file `DeMoivreOQ01OQ03OQ01OQ01`, which provides the bundled homomorphism `chebyshevCEnd` and its `chebyshevCEnd_apply` simp lemma. Opening `Polynomial.Chebyshev` resolves `C` to the third-kind Chebyshev polynomial; `Polynomial` is opened for `Monic`, `natDegree`, `comp`, and the degree lemmas. The variable block fixes `R` to be a nontrivial commutative ring — nontriviality is required so that monic polynomials are nonzero and their degree is determined.",
+    "mathContext": "Brings in `C_add_two`, `C_natAbs`, and the parent's `chebyshevCEnd`; assumes `[CommRing R] [Nontrivial R]`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Mathlib Chebyshev library",
+      "nontrivial rings",
+      "namespace resolution"
+    ],
+    "prerequisites": [
+      "Lean imports",
+      "typeclass assumptions"
+    ]
+  },
+  {
+    "id": "ann-monic-degree",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 104
+    },
+    "type": "theorem",
+    "title": "C_monic_natDegree_succ: Cₙ₊₁ is monic of degree n+1",
+    "content": "The degree engine. By `Nat.twoStepInduction` on the recurrence `C_{k+2} = X·C_{k+1} − C_k`: the two base cases are `C₁ = X` (monic, degree 1) and `C₂ = X² − 2` (monic of degree 2 via `monic_X_pow_sub_C`). The inductive step writes `C_{n+3} = X·C_{n+2} − C_{n+1}` (from `C_add_two` after `push_cast`/`linear_combination`); since `C_{n+2}` is monic it is nonzero, so `X·C_{n+2}` is monic of degree `n+3`, while `C_{n+1}` has degree `n+1 < n+3`. Then `Monic.add_of_left` keeps monicity and `natDegree_sub_eq_left_of_natDegree_lt` keeps the degree under the subtraction. This mirrors the gallery's first-kind `Tₙ` degree proof — the recurrence makes the leading term predictable.",
+    "mathContext": "$C_{n+1}$ is monic with $\\deg C_{n+1} = n+1$; proved from $C_{k+2} = X\\,C_{k+1} - C_k$ because $\\deg C_k < \\deg(X\\,C_{k+1})$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "two-step induction",
+      "monic polynomials",
+      "three-term recurrence",
+      "natDegree of a product and difference"
+    ],
+    "prerequisites": [
+      "Nat.twoStepInduction",
+      "monic_X_pow_sub_C",
+      "degree arithmetic"
+    ]
+  },
+  {
+    "id": "ann-natdegree",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 106,
+      "endLine": 116
+    },
+    "type": "theorem",
+    "title": "C_natDegree: deg Cₙ = |n| for all integer indices",
+    "content": "Extends the positive-index degree result to all of `ℤ`. `C_natDegree_nat` handles natural indices by casing on `0` (`C₀ = 2`, degree 0) and `k+1` (the previous theorem). `C_natDegree` then reduces the general integer case to the natural one through the even symmetry `C_natAbs : C R n.natAbs = C R n`: since `Cₙ = C_{|n|}` and `|n|` is a natural number, `natDegree (C R n) = natDegree (C R |n|) = |n|`. This is the invariant the rest of the file rests on — the degree is a faithful fingerprint of `|n|`.",
+    "mathContext": "$\\mathrm{natDegree}(C_R\\,n) = |n|$ for every $n \\in \\mathbb{Z}$, via $C_n = C_{|n|}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "even symmetry C_natAbs",
+      "Int.natAbs",
+      "degree as invariant"
+    ],
+    "prerequisites": [
+      "C_natAbs",
+      "natDegree"
+    ]
+  },
+  {
+    "id": "ann-eq-criterion",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 123,
+      "endLine": 137
+    },
+    "type": "theorem",
+    "title": "The equality criterion Cₘ = Cₙ ↔ m = ±n",
+    "content": "`C_eq_iff_natAbs : C R m = C R n ↔ |m| = |n|`. Forward direction applies `natDegree` to both sides and rewrites by `C_natDegree`, so equal polynomials have equal `|index|` — this is where the degree computation pays off. Backward direction rewrites both sides through `C_natAbs` and uses `|m| = |n|`. `C_eq_iff : C R m = C R n ↔ m = n ∨ m = -n` then sharpens it with `Int.natAbs_eq_natAbs_iff`, the integer dichotomy `|m| = |n| ↔ m = ±n`. The upshot: the **only** coincidences among Chebyshev polynomials are the even-symmetry sign flips.",
+    "mathContext": "$C_m = C_n \\iff |m| = |n| \\iff m = n \\lor m = -n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "degree comparison",
+      "Int.natAbs_eq_natAbs_iff",
+      "sign-flip dichotomy"
+    ],
+    "prerequisites": [
+      "C_natDegree",
+      "C_natAbs",
+      "congrArg natDegree"
+    ]
+  },
+  {
+    "id": "ann-transfer",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 144,
+      "endLine": 161
+    },
+    "type": "theorem",
+    "title": "Transferring the criterion to the homomorphism",
+    "content": "`chebyshevCEnd_eq_iff_C : chebyshevCEnd R m = chebyshevCEnd R n ↔ C R m = C R n`. Forward: evaluate both endomorphisms at `X`; since `(Cₙ ∘ ·)(X) = Cₙ.comp X = Cₙ`, agreement of operators forces agreement of generating polynomials. Backward: if the polynomials agree, the endomorphisms agree pointwise by `funext`. Composing with `C_eq_iff` gives `chebyshevCEnd_eq_iff : chebyshevCEnd R m = chebyshevCEnd R n ↔ m = n ∨ m = -n` — the complete fiber description of the parent's monoid homomorphism.",
+    "mathContext": "Operators agree iff polynomials agree (evaluate at $X$), so the fibers of $\\texttt{chebyshevCEnd}$ are exactly $\\{n, -n\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Function.End",
+      "evaluation at X",
+      "comp_X",
+      "fiber description"
+    ],
+    "prerequisites": [
+      "chebyshevCEnd_apply",
+      "funext",
+      "C_eq_iff"
+    ]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 163,
+      "endLine": 183
+    },
+    "type": "theorem",
+    "title": "Non-injectivity and injectivity on the cone",
+    "content": "Two corollaries reading off the fiber description. `chebyshevCEnd_not_injective`: the map is not injective — if it were, `chebyshevCEnd R 1 = chebyshevCEnd R (-1)` (true since `C₁ = X = C₋₁`) would force `1 = -1`, a contradiction by `norm_num`. `chebyshevCEnd_injOn_nonneg`: on the nonnegative cone `{n ≥ 0}` the map *is* injective — the fiber dichotomy `m = n ∨ m = -n` collapses to `m = n` because `m = -n` with `m, n ≥ 0` forces `m = n = 0` (discharged by `omega`). So the homomorphism is exactly 2-to-1 away from 0 and faithful on the natural indices.",
+    "mathContext": "$\\texttt{chebyshevCEnd}$ is 2-to-1 (collision $1 \\leftrightarrow -1$) and $\\mathrm{InjOn}$ the cone $\\{n \\ge 0\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Function.Injective",
+      "Set.InjOn",
+      "even symmetry",
+      "nonnegative cone"
+    ],
+    "prerequisites": [
+      "chebyshevCEnd_eq_iff",
+      "omega"
+    ]
+  },
+  {
+    "id": "ann-consistency",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 185,
+      "endLine": 208
+    },
+    "type": "insight",
+    "title": "Consistency checks",
+    "content": "Three numeric sanity checks over `ℝ` instantiating the general results: `deg C₂ = 2` (from `C_natDegree`, confirming the degree formula on a concrete index), the sign-flip coincidence `C₃ = C₋₃` (from `C_eq_iff`, the `m = -n` branch), and `C₂ ≠ C₃` (from `C_eq_iff` plus `decide` on `2 = 3 ∨ 2 = -3`), confirming that distinct `|index|` yields distinct polynomials. Together they exhibit both faces of the criterion — coincidence exactly at sign flips, distinctness otherwise — on small explicit cases.",
+    "mathContext": "$\\deg C_2 = 2$; $C_3 = C_{-3}$; $C_2 \\ne C_3$ over $\\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sanity checks",
+      "specialization to ℝ"
+    ],
+    "prerequisites": [
+      "C_natDegree",
+      "C_eq_iff"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,200 @@
+{
+  "id": "de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01",
+  "title": "The Chebyshev monoid homomorphism n ↦ Cₙ is 2-to-1: its fibers are exactly the sign flips n ↔ -n",
+  "slug": "de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01",
+  "description": "Closes the parent's open question on the fibers of the Chebyshev index homomorphism chebyshevCEnd R : ℤ →* Function.End R[X], n ↦ (C R n).comp ·. The map is NOT injective — already chebyshevCEnd R 1 = chebyshevCEnd R (-1) because C₁ = X = C₋₁ — and we pin its fibers down completely: chebyshevCEnd R m = chebyshevCEnd R n ↔ m = n ∨ m = -n. So the only coincidences are the even-symmetry sign flips n ↔ -n; the homomorphism is exactly 2-to-1 away from 0 and injective on the nonnegative cone {n ≥ 0}. The engine is a degree computation: the third-kind Chebyshev polynomial Cₙ is monic of degree |n| (proved from the recurrence C_{k+2} = X·C_{k+1} − C_k by two-step induction), so Cₘ = Cₙ forces |m| = |n| by comparing degrees, and conversely |m| = |n| gives Cₘ = Cₙ by Mathlib's even symmetry C_natAbs. Combining with Int.natAbs_eq_natAbs_iff yields the sharp m = ±n criterion. 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_polynomials",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ01OQ03OQ01OQ01OQ01.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "de-moivre",
+      "monoid-homomorphism",
+      "injectivity",
+      "fibers",
+      "polynomial-degree",
+      "monic-polynomials",
+      "integer-indices",
+      "polynomials",
+      "ring-theory",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.Chebyshev.C_natAbs",
+        "description": "C R (n.natAbs) = C R n: the even symmetry C₋ₙ = Cₙ of the third-kind Chebyshev polynomials, the backward direction of |m| = |n| ⟹ Cₘ = Cₙ",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.C_add_two",
+        "description": "C R (n+2) = X * C R (n+1) - C R n: the three-term recurrence driving the two-step induction that computes deg Cₙ = |n|",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.monic_X_pow_sub_C",
+        "description": "Monic (X^n - C a) for n ≠ 0: seeds the induction base case C₂ = X² − 2 as a monic degree-2 polynomial",
+        "module": "Mathlib.Algebra.Polynomial.Monic"
+      },
+      {
+        "theorem": "Polynomial.natDegree_sub_eq_left_of_natDegree_lt",
+        "description": "natDegree (p - q) = natDegree p when deg q < deg p: extracts deg(X·C_{n+1} − Cₙ) = deg(X·C_{n+1}) in the inductive step",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Operations"
+      },
+      {
+        "theorem": "Int.natAbs_eq_natAbs_iff",
+        "description": "m.natAbs = n.natAbs ↔ m = n ∨ m = -n: converts the degree equality |m| = |n| into the sign-flip dichotomy",
+        "module": "Mathlib.Data.Int.NatAbs"
+      }
+    ],
+    "originalContributions": [
+      "C_monic_natDegree_succ / C_natDegree: the third-kind Chebyshev polynomial Cₙ is monic of degree |n| over an arbitrary nontrivial commutative ring, proved from the recurrence by two-step induction — the degree invariant that powers the whole injectivity analysis",
+      "C_eq_iff_natAbs and C_eq_iff: the sharp equality criterion Cₘ = Cₙ ↔ |m| = |n| ↔ m = ±n — equality of Chebyshev polynomials is exactly equality of absolute index, so the only coincidences are the sign flips",
+      "chebyshevCEnd_eq_iff: the complete fiber description of the parent's monoid homomorphism, chebyshevCEnd R m = chebyshevCEnd R n ↔ m = n ∨ m = -n (the endomorphisms agree iff their generating polynomials do, evaluated at X)",
+      "chebyshevCEnd_not_injective: the homomorphism is NOT injective, witnessed structurally by the even symmetry C₁ = X = C₋₁ collapsing 1 and -1",
+      "chebyshevCEnd_injOn_nonneg: injectivity is recovered exactly on the nonnegative cone {n ≥ 0} — the map factors through n ↦ |n| and is 2-to-1 away from 0"
+    ],
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 208,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All theorems depend only on the standard foundational axioms propext / Classical.choice / Quot.sound. The degree results require [CommRing R] [Nontrivial R] (a nontrivial ring is needed for monicity to pin the degree); this is a typeclass hypothesis, not a logical assumption.",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**A homomorphism invites the injectivity question**\n\nThe parent bundled the integer-index Chebyshev map into a genuine monoid homomorphism $\\texttt{chebyshevCEnd}\\,R : (\\mathbb{Z}, \\cdot) \\to^* \\mathrm{End}\\,R[X]$, $n \\mapsto C_n \\circ (-)$, whose $\\mathtt{map\\_mul}$ is the composition law $C_{mn} = C_m \\circ C_n$. Once a map is a homomorphism, the first structural question is whether it is injective — and if not, what its fibers are.\n\nFor the Chebyshev family the answer is governed by a single classical fact: the third-kind polynomial $C_n$ is even in its index, $C_{-n} = C_n$. So $1$ and $-1$ already collide ($C_1 = X = C_{-1}$), and the map cannot be injective. The content of this entry is the *converse*: these sign flips are the **only** coincidences, which is proved by computing the degree of $C_n$ and reading injectivity off the degree.",
+    "problemStatement": "**Open question (OQ-01 of de-moivre-oq-01-oq-03-oq-01-oq-01):** Is the Chebyshev monoid homomorphism $\\texttt{chebyshevCEnd}\\,R : \\mathbb{Z} \\to^* \\mathrm{End}\\,R[X]$ injective? If not, what are its fibers — when do two indices give the same Chebyshev operator $C_m \\circ (-) = C_n \\circ (-)$?\n\n**Answer: NO, and the failure is exactly the even symmetry $C_{-n} = C_n$.** The fibers are pinned down completely: $\\texttt{chebyshevCEnd}\\,R\\,m = \\texttt{chebyshevCEnd}\\,R\\,n \\iff m = n \\lor m = -n$. The homomorphism is $2$-to-$1$ away from $0$ and injective on the nonnegative cone $\\{n \\ge 0\\}$; it factors through the multiplicative monoid map $\\mathbb{Z} \\to \\mathbb{N}$, $n \\mapsto |n|$.",
+    "text": "The parent's Chebyshev index homomorphism n ↦ Cₙ is shown to be exactly 2-to-1: its fibers are the sign-flip pairs {n, -n}. Non-injectivity is forced by the even symmetry C₁ = X = C₋₁; that these are the only collisions is proved by computing deg Cₙ = |n| (two-step induction on the recurrence) and combining the resulting criterion Cₘ = Cₙ ↔ |m| = |n| with the integer fact |m| = |n| ↔ m = ±n. Injectivity is recovered on the nonnegative cone.",
+    "proofStrategy": "**Strategy**\n\n1. **The degree engine.** Prove $C_n$ is monic of degree $|n|$. For $n \\ge 1$, two-step induction on the recurrence $C_{k+2} = X\\,C_{k+1} - C_k$: the base cases are $C_1 = X$ (monic, degree 1) and $C_2 = X^2 - 2$ (monic, degree 2 via `monic_X_pow_sub_C`); the step uses that $\\deg C_k < \\deg(X\\,C_{k+1})$ so the subtraction keeps the leading term. Extend to all of $\\mathbb{Z}$ through the even symmetry `C_natAbs`, giving `C_natDegree : natDegree (C R n) = n.natAbs`.\n\n2. **The equality criterion.** Forward: $C_m = C_n \\Rightarrow |m| = |n|$ by applying `natDegree` to both sides. Backward: $|m| = |n| \\Rightarrow C_m = C_n$ by rewriting both through `C_natAbs`. This gives `C_eq_iff_natAbs : C R m = C R n ↔ |m| = |n|`, and `Int.natAbs_eq_natAbs_iff` sharpens it to `C_eq_iff : C R m = C R n ↔ m = n ∨ m = -n`.\n\n3. **Transfer to the homomorphism.** Two Chebyshev endomorphisms agree iff their generating polynomials agree (evaluate at $X$, since $(C_n \\circ -)(X) = C_n$), giving `chebyshevCEnd_eq_iff_C`. Composing with `C_eq_iff` yields the fiber description `chebyshevCEnd_eq_iff`.\n\n4. **The two corollaries.** Non-injectivity `chebyshevCEnd_not_injective` is the collision $1 \\leftrightarrow -1$; injectivity on the cone `chebyshevCEnd_injOn_nonneg` discards the $m = -n$ branch when both are $\\ge 0$ by `omega`.",
+    "keyInsights": [
+      "**Degree is the injectivity invariant.** Equality of Chebyshev polynomials is detected entirely by a single number — the degree — because Cₙ is monic of degree |n|. So Cₘ = Cₙ forces |m| = |n|, and the whole fiber structure reduces to an integer identity.",
+      "**The even symmetry is the only obstruction.** C₋ₙ = Cₙ is both why the map fails to be injective (1 and -1 collide) and the entire content of the failure: m = ±n is the complete list of coincidences. The map is genuinely 2-to-1, not merely 'somewhere non-injective'.",
+      "**The homomorphism factors through n ↦ |n|.** Since |mn| = |m||n|, the multiplicative monoid map ℤ → ℕ, n ↦ |n| is itself a homomorphism, and chebyshevCEnd factors through it injectively — the cleanest description of the fiber structure.",
+      "**Injectivity is recovered on the cone.** Restricted to {n ≥ 0} the map is injective: the m = -n branch is impossible for distinct nonnegative indices. So the parent's homomorphism is faithful exactly on the natural-number indices.",
+      "**Two-step induction mirrors the Tₙ degree proof.** The monicity/degree argument follows the recurrence C_{k+2} = X·C_{k+1} − C_k by Nat.twoStepInduction, exactly paralleling the gallery's first-kind Tₙ degree computation — the recurrence makes the leading term predictable."
+    ],
+    "prerequisites": [
+      "The parent's Chebyshev monoid homomorphism chebyshevCEnd R : ℤ →* Function.End R[X], n ↦ (C R n).comp ·",
+      "Third-kind Chebyshev polynomials Cₙ over ℤ, the recurrence C_{n+2} = X·C_{n+1} − Cₙ, and the even symmetry C₋ₙ = Cₙ (C_natAbs)",
+      "Monic polynomials and natDegree: degree of a product, degree of a difference with a strictly-smaller subtrahend",
+      "Int.natAbs and the dichotomy |m| = |n| ↔ m = ±n"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports",
+      "summary": "Imports Mathlib's Chebyshev polynomial library (recurrence C_add_two, even symmetry C_natAbs) and the parent file providing the chebyshevCEnd monoid homomorphism.",
+      "startLine": 43,
+      "endLine": 50,
+      "mathContext": "Brings in `Polynomial.Chebyshev.C` with the recurrence `C_add_two` and even symmetry `C_natAbs`, and the parent's `chebyshevCEnd`."
+    },
+    {
+      "id": "degree",
+      "title": "Cₙ is Monic of Degree |n|",
+      "summary": "Proves C_monic_natDegree_succ (Cₙ₊₁ monic of degree n+1, by two-step induction on the recurrence), then C_natDegree_nat and C_natDegree (natDegree (C R n) = |n| for all integer indices via C_natAbs).",
+      "startLine": 52,
+      "endLine": 116,
+      "mathContext": "$C_n$ is monic of degree $|n|$; the base cases are $C_1 = X$ and $C_2 = X^2 - 2$, the step uses $\\deg C_k < \\deg(X\\,C_{k+1})$."
+    },
+    {
+      "id": "criterion",
+      "title": "The Equality Criterion Cₘ = Cₙ ↔ m = ±n",
+      "summary": "Proves C_eq_iff_natAbs (Cₘ = Cₙ ↔ |m| = |n|, forward by degrees, backward by C_natAbs) and sharpens it to C_eq_iff (↔ m = n ∨ m = -n) via Int.natAbs_eq_natAbs_iff.",
+      "startLine": 118,
+      "endLine": 137,
+      "mathContext": "Equality of Chebyshev polynomials equals equality of $|\\text{index}|$, and $|m| = |n| \\iff m = \\pm n$."
+    },
+    {
+      "id": "fibers",
+      "title": "Fibers, Non-Injectivity, and Injectivity on the Cone",
+      "summary": "Transfers the criterion to the homomorphism: chebyshevCEnd_eq_iff_C (operators agree iff polynomials do), chebyshevCEnd_eq_iff (fiber = sign-flip pair), chebyshevCEnd_not_injective (collision 1 ↔ -1), and chebyshevCEnd_injOn_nonneg (injective on {n ≥ 0}).",
+      "startLine": 139,
+      "endLine": 183,
+      "mathContext": "Fibers of $\\texttt{chebyshevCEnd}$ are exactly $\\{n, -n\\}$; the map is 2-to-1 away from 0 and injective on the nonnegative cone."
+    },
+    {
+      "id": "consistency",
+      "title": "Consistency Checks",
+      "summary": "Numeric checks over ℝ: deg C₂ = 2, the sign-flip coincidence C₃ = C₋₃, and C₂ ≠ C₃ (distinct degrees), confirming the criterion on small indices.",
+      "startLine": 185,
+      "endLine": 208,
+      "mathContext": "$\\deg C_2 = 2$; $C_3 = C_{-3}$; $C_2 \\ne C_3$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent's open question is answered: the Chebyshev monoid homomorphism chebyshevCEnd R : ℤ →* Function.End R[X], n ↦ (C R n).comp ·, is NOT injective, and its fibers are exactly the sign-flip pairs — chebyshevCEnd R m = chebyshevCEnd R n ↔ m = n ∨ m = -n. The map is 2-to-1 away from 0 (witnessed by C₁ = X = C₋₁) and injective on the nonnegative cone {n ≥ 0}, factoring through n ↦ |n|. The engine is the degree computation natDegree (C R n) = |n|, proved from the three-term recurrence by two-step induction; equality of degrees forces equality of |index|, and the integer dichotomy |m| = |n| ↔ m = ±n completes the characterization. 9 theorems, 0 definitions, 0 sorries, 0 axioms, no native_decide.",
+    "implications": "**Significance**\n\n1. **The De Moivre orbit's symmetry is now exact.** The parent showed n ↦ Cₙ is a homomorphism; this entry shows it is precisely 2-to-1, with the redundancy being exactly the even symmetry C₋ₙ = Cₙ — the Chebyshev analogue of cos(−θ) = cos(θ).\n\n2. **A clean faithful model.** Restricting to the nonnegative cone makes the homomorphism injective, so {Cₙ : n ≥ 0} under composition is a faithful copy of (ℕ, ·) — the natural setting for Chebyshev-map iteration and the commuting-family dynamics.\n\n3. **Degree as a fingerprint.** The proof packages a reusable principle: monicity of degree |n| means the Chebyshev index can be recovered (up to sign) from the polynomial alone, with no evaluation — useful wherever Chebyshev polynomials must be distinguished or inverted.",
+    "openQuestions": [
+      "Does the 2-to-1 structure descend to a genuine isomorphism (ℤ/±1, ·) ≅ image, i.e. is the induced map from the quotient monoid ℤ⧸{±1} onto the Chebyshev composition monoid a monoid isomorphism, and what is the right statement of this quotient in Lean's MonoidHom API?",
+      "For the first-kind Tₙ (which satisfy T_{mn} = Tₘ ∘ Tₙ and T₋ₙ = Tₙ as well), is the same fiber description {n, -n} provable by the identical degree argument, and does it extend to a uniform statement across the Chebyshev kinds?"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+      "relationship": "Parent. This closes its open question by computing the fibers of its monoid homomorphism chebyshevCEnd: the map is 2-to-1 with fibers {n, -n}, non-injective, but injective on the nonnegative cone."
+    },
+    {
+      "id": "de-moivre-oq-01-oq-03-oq-01",
+      "relationship": "Grandparent. Established the integer-index De Moivre–Chebyshev identity whose structural packaging (the homomorphism) is what this entry analyzes for injectivity."
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "Root De Moivre formalization; the even symmetry C₋ₙ = Cₙ governing the fibers is the Chebyshev analogue of cos(−θ) = cos(θ)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Polynomial.Chebyshev",
+      "Mathlib.Tactic",
+      "Proofs.DeMoivreOQ01OQ03OQ01OQ01"
+    ],
+    "opens": [
+      "Polynomial",
+      "Polynomial.Chebyshev",
+      "DeMoivreChebyshevMonoidHom"
+    ],
+    "namespace": "DeMoivreChebyshevInjectivity",
+    "lineCount": 208,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ01OQ03OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "A. de Moivre",
+      "title": "Miscellanea Analytica de Seriebus et Quadraturis",
+      "year": "1730",
+      "venue": "London",
+      "note": "(cos θ + i sin θ)^n = cos(nθ) + i sin(nθ); the even symmetry C₋ₙ = Cₙ mirrors cos(−θ) = cos(θ)"
+    },
+    {
+      "authors": "T. J. Rivlin",
+      "title": "Chebyshev Polynomials: From Approximation Theory to Algebra and Number Theory",
+      "year": "1990",
+      "venue": "Wiley-Interscience, 2nd ed.",
+      "note": "Standard reference for the degree, parity, and composition structure of the Chebyshev families"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-01-oq-03-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Computes the fibers of the parent's monoid homomorphism chebyshevCEnd: the map is 2-to-1 with fibers {n, -n}, non-injective, injective on the nonnegative cone"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "The even symmetry C₋ₙ = Cₙ that governs the fibers is the Chebyshev analogue of De Moivre's cos(−θ) = cos(θ)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the parent's open question (**OQ-01 of `de-moivre-oq-01-oq-03-oq-01-oq-01`**) on the **injectivity** of the Chebyshev index homomorphism

`chebyshevCEnd R : ℤ →* Function.End R[X]`, `n ↦ (C R n).comp ·`.

**Answer: the map is NOT injective, and its fibers are exactly the sign-flip pairs.**

```
chebyshevCEnd R m = chebyshevCEnd R n ↔ m = n ∨ m = -n
```

Already `chebyshevCEnd R 1 = chebyshevCEnd R (-1)` because `C₁ = X = C₋₁` (the even symmetry `C₋ₙ = Cₙ`). The content is the *converse*: these sign flips are the **only** coincidences. So the homomorphism is **2-to-1 away from 0** and **injective on the nonnegative cone `{n ≥ 0}`**, factoring through `n ↦ |n|`.

## The engine: deg Cₙ = |n|

`Cₙ` is **monic of degree `|n|`**, proved from the recurrence `C_{k+2} = X·C_{k+1} − C_k` by two-step induction (mirroring the gallery's first-kind `Tₙ` degree proof). Equal Chebyshev polynomials then have equal `|index|` (compare degrees); the even symmetry `C_natAbs` gives the converse; `Int.natAbs_eq_natAbs_iff` sharpens `|m| = |n|` to `m = ±n`.

## Contents

- `C_monic_natDegree_succ` / `C_natDegree` — `Cₙ` monic of degree `|n|` over any nontrivial commutative ring
- `C_eq_iff_natAbs` / `C_eq_iff` — the sharp criterion `Cₘ = Cₙ ↔ |m| = |n| ↔ m = ±n`
- `chebyshevCEnd_eq_iff_C` / `chebyshevCEnd_eq_iff` — the complete fiber description
- `chebyshevCEnd_not_injective` — non-injectivity, witnessed by `C₁ = X = C₋₁`
- `chebyshevCEnd_injOn_nonneg` — injectivity recovered on `{n ≥ 0}`

**9 theorems, 0 definitions, 0 sorries, 0 axioms, no `native_decide`.**

## Verification

Builds clean under `./proofs/scripts/docker-build.sh Proofs.DeMoivreOQ01OQ03OQ01OQ01OQ01` (3066 jobs, exit 0). Depends only on the foundational axioms `propext` / `Classical.choice` / `Quot.sound`.

Gallery integration added under `src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01-oq-01/` (meta.json + 8 annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)