### PR TITLE
research(erdos-490): eliminate last sorry in Erdős #490 — isolate Chebyshev input as explicit axiom

### DIFF
--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -261,6 +261,38 @@ theorem card_doubledDrop_image_of_distinct {A : Finset ℕ}
   rw [Finset.card_image_of_injOn (doubledDrop_injOn_of_distinct hDSS),
     Finset.card_powerset]
 
+/-- **Same-parity integers in a symmetric interval (0 axioms).**  A finite set `V` of
+integers all sharing one parity and all lying in `[−L, L]` (`L ≥ 0`) has at most `L + 1`
+elements.  This is the central-interval count that — applied to the `2^{|A|}` distinct
+same-parity doubled deviations `2·Σ_T − S` confined to `|·| ≤ L` — recovers the sharp
+constant `3` in `anticoncentration_bound` (the pure second-moment spread bound only gives
+`≈ 3.46√Q`).  Proof: `v ↦ (v + L) / 2` maps `V` injectively (same parity ⟹ no collisions,
+`omega`) into `Finset.Icc 0 L`, whose cardinality is `L + 1`. -/
+theorem card_le_of_sameParity_interval (V : Finset ℤ) (p L : ℤ) (hL : 0 ≤ L)
+    (hpar : ∀ v ∈ V, v % 2 = p % 2) (hbd : ∀ v ∈ V, -L ≤ v ∧ v ≤ L) :
+    (V.card : ℤ) ≤ L + 1 := by
+  have hinj : Set.InjOn (fun v => (v + L) / 2) (V : Set ℤ) := by
+    intro u hu v hv h
+    have hu' := hpar u (Finset.mem_coe.mp hu)
+    have hv' := hpar v (Finset.mem_coe.mp hv)
+    simp only at h
+    omega
+  have hsub : V.image (fun v => (v + L) / 2) ⊆ Finset.Icc 0 L := by
+    intro y hy
+    simp only [Finset.mem_image] at hy
+    obtain ⟨v, hv, rfl⟩ := hy
+    obtain ⟨h1, h2⟩ := hbd v hv
+    rw [Finset.mem_Icc]; omega
+  have hcard : V.card ≤ (Finset.Icc 0 L).card := by
+    rw [← Finset.card_image_of_injOn hinj]
+    exact Finset.card_le_card hsub
+  have hIcc : (Finset.Icc (0 : ℤ) L).card = (L + 1).toNat := by
+    rw [Int.card_Icc]; congr 1; omega
+  rw [hIcc] at hcard
+  have : (V.card : ℤ) ≤ ((L + 1).toNat : ℤ) := by exact_mod_cast hcard
+  rw [Int.toNat_of_nonneg (by omega)] at this
+  exact this
+
 /-- **DFX Lower Bound Statement** (Chebyshev constant): If A ⊆ {1,...,N} has n ≥ 1
     elements with distinct subset sums, then:
       2ⁿ ≤ 3·√n·N + 2,    equivalently    N ≥ (2ⁿ − 2) / (3·√n).

--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -128,6 +128,31 @@ def optimalB (N : ℕ) : Finset ℕ :=
 axiom optimal_has_distinct_products (N : ℕ) (hN : N ≥ 4) :
   HasDistinctProducts (optimalA N) (optimalB N)
 
+/-- The first half is exactly `Icc 1 (N/2)`, so it has `⌊N/2⌋` elements. -/
+theorem optimalA_card (N : ℕ) : (optimalA N).card = N / 2 := by
+  have hset : optimalA N = Finset.Icc 1 (N / 2) := by
+    ext n
+    simp only [optimalA, Finset.mem_filter, Finset.mem_range, Finset.mem_Icc]
+    constructor
+    · rintro ⟨_, h1, h2⟩; exact ⟨h1, h2⟩
+    · rintro ⟨h1, h2⟩
+      -- `n ≤ N/2 ≤ N < N+1`, so the `range (N+1)` membership is automatic.
+      exact ⟨by omega, h1, h2⟩
+  rw [hset, Nat.card_Icc]; omega
+
+/-- **Chebyshev-type prime-counting lower bound** (the one irreducible analytic input
+to the optimal-example *lower* bound).  The number of primes in `(N/2, N]` — i.e.
+`(optimalB N).card = π(N) − π(N/2)` — is `≳ N / log N`.  The true asymptotic is
+`~ N / (2 log N)` by the prime number theorem; the existence of *some* positive
+constant `c` valid for all `N ≥ 4` is Chebyshev-strength and elementary, but Mathlib's
+`Nat.primeCounting` API currently provides only an *upper* bound
+(`Nat.primeCounting'_add_le`) and monotonicity — no lower bound on `π(N) − π(N/2)`.
+We therefore isolate exactly this fact as an explicit axiom; the rest of the
+lower-bound derivation (`bound_is_optimal`) is fully verified from it. -/
+axiom primes_upper_half_lower_bound :
+  ∃ c : ℝ, c > 0 ∧ ∀ N : ℕ, N ≥ 4 →
+    c * N / Real.log N ≤ ((optimalB N).card : ℝ)
+
 /- The optimal example achieves |A||B| ~ N²/(2 log N). -/
 /-- Why it works: products `a·p` are distinct because each prime `p > N/2` exceeds
 every `a ≤ N/2`, so `p` cannot divide a nonzero `a`.  Positivity `1 ≤ aᵢ` (which holds
@@ -385,7 +410,14 @@ theorem erdos_490_main :
           (A.card * B.card : ℝ) ≤ C * N^2 / Real.log N :=
   szemeredi_theorem
 
-/-- The bound is optimal up to a constant. -/
+/-- The bound is optimal up to a constant.
+
+The lower-bound constant is *not* hardcoded: a fixed `c` such as `1/3` is in fact
+**false** at small `N` (e.g. `N = 10`, where the product ratio dips to `≈ 0.115`),
+so the theorem is stated and proved in its honest `∃ c > 0` form.  The constant is
+produced from the Chebyshev-type input `primes_upper_half_lower_bound`: from
+`(optimalB N).card ≥ c·N/log N` and `(optimalA N).card = ⌊N/2⌋ ≥ N/4` (for `N ≥ 4`),
+the product is `≥ (c/4)·N²/log N`. -/
 theorem bound_is_optimal :
     ∃ c : ℝ, c > 0 ∧
       ∀ N : ℕ, N ≥ 4 →
@@ -393,31 +425,44 @@ theorem bound_is_optimal :
           IsSubsetUpTo A N ∧ IsSubsetUpTo B N ∧
           HasDistinctProducts A B ∧
           (A.card * B.card : ℝ) ≥ c * N^2 / Real.log N := by
-  use 1/3  -- lower bound constant
-  constructor
-  · norm_num
-  · intro N hN
-    use optimalA N, optimalB N
-    constructor
-    · -- IsSubsetUpTo (optimalA N) N : elements satisfy 1 ≤ n ≤ N/2 ≤ N
-      intro a ha
-      simp only [optimalA, Finset.mem_filter, Finset.mem_range] at ha
-      obtain ⟨_, ha1, ha2⟩ := ha
-      exact ⟨ha1, le_trans ha2 (Nat.div_le_self N 2)⟩
-    constructor
-    · -- IsSubsetUpTo (optimalB N) N : primes p with N/2 < p ≤ N satisfy 1 ≤ p ≤ N
-      intro b hb
-      simp only [optimalB, Finset.mem_filter, Finset.mem_range] at hb
-      obtain ⟨_, hbprime, _, hbN⟩ := hb
-      exact ⟨hbprime.one_lt.le, hbN⟩
-    constructor
-    · exact optimal_has_distinct_products N (by linarith)
-    · -- Lower bound. DEFERRED (requires prime-counting / PNT-level input): one needs
-      -- |optimalA N| = ⌊N/2⌋ and |optimalB N| = π(N) − π(N/2) ~ N/(2 log N), so the
-      -- product is ~ N²/(4 log N).  The lower bound on π(N) − π(N/2) is a Chebyshev /
-      -- Bertrand-type estimate not yet wired in here; left for a follow-up session.
-      -- (Note: the constant 1/3 chosen above is only attainable asymptotically and
-      -- with the sharper N²/(4 log N) main term would need adjusting to ≤ 1/4.)
-      sorry
+  obtain ⟨c, hc, hcB⟩ := primes_upper_half_lower_bound
+  refine ⟨c / 4, by positivity, ?_⟩
+  intro N hN
+  use optimalA N, optimalB N
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · -- IsSubsetUpTo (optimalA N) N : elements satisfy 1 ≤ n ≤ N/2 ≤ N
+    intro a ha
+    simp only [optimalA, Finset.mem_filter, Finset.mem_range] at ha
+    obtain ⟨_, ha1, ha2⟩ := ha
+    exact ⟨ha1, le_trans ha2 (Nat.div_le_self N 2)⟩
+  · -- IsSubsetUpTo (optimalB N) N : primes p with N/2 < p ≤ N satisfy 1 ≤ p ≤ N
+    intro b hb
+    simp only [optimalB, Finset.mem_filter, Finset.mem_range] at hb
+    obtain ⟨_, hbprime, _, hbN⟩ := hb
+    exact ⟨hbprime.one_lt.le, hbN⟩
+  · exact optimal_has_distinct_products N (by linarith)
+  · -- Lower bound: combine |optimalA N| ≥ N/4 with the Chebyshev input on |optimalB N|.
+    have hNR : (4 : ℝ) ≤ (N : ℝ) := by exact_mod_cast hN
+    have hlogpos : 0 < Real.log N := Real.log_pos (by linarith)
+    -- |optimalA N| = ⌊N/2⌋, and `N ≤ 4·⌊N/2⌋` for `N ≥ 4` gives `↑⌊N/2⌋ ≥ N/4`.
+    have hAcard : (optimalA N).card = N / 2 := optimalA_card N
+    have hAnat : N ≤ 4 * (N / 2) := by omega
+    have hAR : (N : ℝ) / 4 ≤ ((optimalA N).card : ℝ) := by
+      rw [hAcard]
+      have : (N : ℝ) ≤ 4 * ((N / 2 : ℕ) : ℝ) := by exact_mod_cast hAnat
+      linarith
+    -- |optimalB N| ≥ c·N/log N from the axiom.
+    have hBR : c * N / Real.log N ≤ ((optimalB N).card : ℝ) := hcB N hN
+    -- Both lower bounds are nonnegative, so the products multiply.
+    have hA0 : (0 : ℝ) ≤ (N : ℝ) / 4 := by positivity
+    have hB0 : (0 : ℝ) ≤ c * N / Real.log N := by positivity
+    have hprod : ((N : ℝ) / 4) * (c * N / Real.log N) ≤
+        ((optimalA N).card : ℝ) * ((optimalB N).card : ℝ) :=
+      mul_le_mul hAR hBR hB0 (le_trans hA0 hAR)
+    -- The left-hand product equals (c/4)·N²/log N (a formal field identity).
+    have hsimp : ((N : ℝ) / 4) * (c * N / Real.log N) = c / 4 * (N : ℝ) ^ 2 / Real.log N := by
+      ring
+    rw [ge_iff_le]
+    linarith [hprod, hsimp]
 
 end Erdos490

--- a/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
@@ -123,3 +123,33 @@ Added 3 verified (0-axiom) lemmas after `card_mul_le_second_moment`:
 - src/data/proofs/erdos-1-oq-02/meta.json (counts 322/10 → 367/13 + highlight)
 
 ### Status: IN-PROGRESS (axiom not yet discharged).
+
+## Session 2026-06-28 (researcher-3, cycle 3) — BUILD: central-interval count landed (0-axiom)
+
+**Mode**: BUILD (offline `LAKE_UNSAFE=1 lake env lean` EXIT 0). **Outcome**: progress — the LAST
+combinatorial input to discharging `anticoncentration_bound` is now verified.
+
+### What I Did
+Added `card_le_of_sameParity_interval` (0-axiom): a `Finset ℤ` whose elements all share one parity
+(`∀ v ∈ V, v % 2 = p % 2`) and lie in `[−L, L]` (`L ≥ 0`) has `V.card ≤ L + 1`. Proof:
+`v ↦ (v + L) / 2` is `Set.InjOn` on V (same parity ⟹ `omega` kills collisions) into `Finset.Icc 0 L`
+(card `L+1`); `card_image_of_injOn` + `card_le_card` + `Int.card_Icc`. First-try clean build.
+
+### Status of the discharge — all COMBINATORIAL inputs now verified (0-axiom):
+1. `second_moment_identity`: ∑_{T⊆A}(2Σ_T−S)² = 2^|A|·Q ✓
+2. `card_doubledDrop_image_of_distinct`: the 2^|A| doubled drops are 2^|A| distinct integers ✓
+3. `card_mul_le_second_moment`: discrete Chebyshev/Markov tail ✓ (NOTE: typed over `Finset ℕ`; the
+   assembly needs it over `Finset (Finset ℕ)` = the powerset — trivial generalization to `{α}`)
+4. `card_le_of_sameParity_interval`: ≤ L+1 same-parity integers in [−L,L] ✓  ← THIS SESSION
+
+### ONLY remaining step: the real-sqrt optimization assembly
+`2^n = #{|vT| ≤ L} + #{|vT| > L} ≤ (L+1) + 2^n·Q/(L+1)²` (interval count + Chebyshev with threshold
+(L+1)²; vT all ≡ S mod 2). Optimize the integer `m = L+1 ≈ 2√Q`: gives `(3/4)2^n ≤ 2√Q+1`, i.e.
+`2^n ≤ (8√Q+4)/3 ≤ 3√Q+2`. Analysis content: pick `m = ⌈2·Real.sqrt Q⌉` (or `Nat.sqrt`-based),
+`Real.sq_sqrt`/`Real.sqrt_le_sqrt`, cast ℤ→ℝ. ~40-80 lines; the only non-elementary piece left.
+
+### Files Modified
+- proofs/Proofs/Erdos1OQ02.lean (+1 theorem 13→14, 367→399 lines; 1 axiom unchanged, 0 sorries)
+- src/data/proofs/erdos-1-oq-02/meta.json (counts 367/13 → 399/14 + highlight)
+
+### Status: IN-PROGRESS (axiom not yet discharged; only the sqrt assembly remains).

--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -83,3 +83,51 @@ updated (sorries, lineCount, theoremCount, assumptions).
 - `bound_is_optimal` lower bound: needs `|optimalB| = π(N) − π(N/2) ≳ N/(2 log N)`, a Chebyshev/PNT
   prime-count estimate not currently wired into the file. 2 deep axioms remain (szemeredi_theorem,
   optimal_has_distinct_products).
+
+## Session 2026-06-28 (researcher-3) — last sorry eliminated (1 → 0; 2 → 3 axioms)
+
+**Mode**: ACT. **Outcome**: progress — file is now 0-sorry. Traded the final hard sorry
+for one explicit, minimal, true axiom isolating the irreducible analytic input.
+
+### What I Did (verified)
+- Proved `optimalA_card : (optimalA N).card = N / 2` **(0-axiom)** via
+  `optimalA N = Finset.Icc 1 (N/2)` (`Finset.ext` + `simp`; the `range (N+1)` bound is
+  automatic since `n ≤ N/2 ≤ N < N+1`) then `Nat.card_Icc; omega`.
+- Added axiom `primes_upper_half_lower_bound : ∃ c>0, ∀ N≥4, c*N/log N ≤ (optimalB N).card`
+  — the **Chebyshev-type lower bound** on `π(N)−π(N/2)`. This is the *one* irreducible
+  input: Mathlib's `Nat.primeCounting` has only an **upper** bound (`primeCounting'_add_le`)
+  + monotonicity, **no** lower bound. Confirmed by grepping the pinned Mathlib.
+- Rewrote `bound_is_optimal` to derive the lower bound from that axiom:
+  `|A|=⌊N/2⌋ ≥ N/4` (for N≥4) and `|B| ≥ c·N/log N` give `|A||B| ≥ (c/4)·N²/log N`.
+  `#print axioms bound_is_optimal` = `[propext, Classical.choice,
+  optimal_has_distinct_products, primes_upper_half_lower_bound, Quot.sound]` (no sorry,
+  and note it does NOT depend on szemeredi_theorem — that's the upper bound).
+
+### Key correctness finding
+The file's previously-hardcoded constant `1/3` in `bound_is_optimal` is **FALSE** at small N:
+numerically the product ratio `|A||B|·log N/N²` dips to **≈0.115 at N=10** (optimalA=[1,5]
+card 5, optimalB={7} card 1, product 5; `5·log10/100 ≈ 0.115`). Only the `∃ c>0` form is
+true (a valid c exists, ≲0.11). The theorem is now stated/proved in that honest form, with
+the constant produced from the axiom's `c` (final constant `c/4`).
+
+### Gotchas / API
+- The goal `(A.card * B.card : ℝ)` elaborates with casts **already distributed**
+  (`↑#A * ↑#B`), so do NOT `rw [Nat.cast_mul]` — it fails with "pattern not found".
+- The field identity `N/4 * (c*N/L) = c/4 * N²/L` is proved by **`ring` alone** (ℝ is a
+  field; `ring` handles `⁻¹` formally, no `L≠0` needed). `field_simp; ring` here errors
+  with "No goals to be solved" because `field_simp` closes it first.
+- `↑(N/2) ≥ N/4` (real): from nat `N ≤ 4*(N/2)` (proved by `omega`, which knows `/2`),
+  then `exact_mod_cast` + `linarith`. Combine the two nonneg lower bounds with `mul_le_mul`.
+- One spurious `lake env lean` **exit 139 (segfault, empty log)** occurred then a re-run
+  gave exit 0 — transient, not a real error. Always re-run before trusting a 139.
+
+### Status
+File: 423 → 468 lines, sorries 1 → 0, axioms 2 → 3, theorems 11 → 13. Gallery meta
+`src/data/proofs/erdos-490/meta.json` updated (sorries→0, axiomCount→3, lineCount→468,
+theoremCount→13, assumptions rewritten, stale "sorried" section prose corrected).
+
+### Still open (NOT done here)
+- Eliminating `primes_upper_half_lower_bound` needs a real Chebyshev lower bound on
+  `π(N)−π(N/2)` built from Mathlib's Bertrand/`centralBinom` machinery — a multi-session
+  infrastructure effort, not a single sorry. Optional bridge:
+  `(optimalB N).card = N.primeCounting − (N/2).primeCounting`.

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 367,
+    "lineCount": 399,
     "assumptions": "One axiom: anticoncentration_bound (Berry-Esseen anticoncentration for subset sums). dfx_lower_bound and pow2_dss proved in 2026-04-26 commit. sum_sq_cauchy_schwarz proved via induction in Z.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -211,9 +211,9 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 367,
+    "lineCount": 399,
     "axiomCount": 1,
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 0,
     "path": "Proofs/Erdos1OQ02.lean",
     "sorries": 0
@@ -221,6 +221,7 @@
   "sorries": 0,
   "assumptions": "One axiom: anticoncentration_bound — the Chebyshev anticoncentration bound 2ⁿ ≤ 3·√(Σaᵢ²) + 2 for distinct-subset-sum sets. It is unconditionally true (Chebyshev's inequality applied to X = Σ εᵢaᵢ, plus the distinctness counting argument) and in principle dischargeable from Mathlib's `ProbabilityTheory` Chebyshev lemmas. dfx_lower_bound and the variance/Cauchy–Schwarz lemmas are fully proved (0 sorries). NOTE: the earlier axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was FALSE and has been corrected. Progress (2026-06-28): the probability-free core of the axiom's discharge is now proved in-file with 0 axioms — second_moment_identity (∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σaᵢ²) and card_mul_le_second_moment (discrete Chebyshev tail count). The only remaining step to eliminate the axiom is the same-parity distinct-integer central-interval count.",
   "highlights": [
+    "Central-interval count landed (card_le_of_sameParity_interval, 0-axiom): a finite set of integers all of one parity confined to [-L,L] has <= L+1 elements (via v |-> (v+L)/2 injecting into Icc 0 L). This is the LAST combinatorial input to discharging anticoncentration_bound with the sharp constant 3 -- joins second_moment_identity, the 2^|A|-distinct-integers image, and the Chebyshev tail. Only the real-sqrt optimization assembly remains.",
     "Verified inputs toward discharging the anticoncentration axiom (0-axiom): subset sums are injective on the powerset for a distinct-subset-sums set (subsetSum_injOn_of_distinct), hence the 2^|A| doubled deviations 2*Sum_T - S are 2^|A| DISTINCT integers (card_doubledDrop_image_of_distinct) -- the precise 'distinct integers' input to the central-interval count that recovers the sharp constant 3. Joins second_moment_identity + card_mul_le_second_moment; only the parity-aware interval count + real-sqrt combine remain."
   ]
 }

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 490,
     "erdosUrl": "https://erdosproblems.com/490",
     "erdosProblemStatus": "solved",
@@ -61,16 +61,18 @@
       "szemeredi_theorem axiom: Szemerédi's 1976 upper bound",
       "optimalA, optimalB: extremal construction with primes > N/2",
       "optimal_has_distinct_products axiom: construction is valid",
-      "optimal_works_because_primes: divisibility argument (sorried)",
+      "optimal_works_because_primes: divisibility argument (proved)",
+      "optimalA_card: |optimalA N| = ⌊N/2⌋ (0-axiom, proved)",
+      "primes_upper_half_lower_bound axiom: Chebyshev lower bound π(N)−π(N/2) ≳ N/log N",
       "productRatio, LimitQuestion: open limit formalization",
       "IsMultiplicativeSidon: A = B special case",
       "multiplicativeEnergy: counting quadruples a₁b₁ = a₂b₂",
-      "bound_is_optimal: matching lower bound (partially proved)"
+      "bound_is_optimal: matching lower bound (proved from the 3 axioms, 0 sorries)"
     ],
-    "axiomCount": 2,
-    "lineCount": 423,
-    "assumptions": "2 axioms (szemeredi_theorem — Szemerédi 1976, deep; optimal_has_distinct_products — the optimal example has distinct products, deep) and 1 sorry (bound_is_optimal lower bound — needs a Chebyshev/PNT prime-count estimate π(N)−π(N/2) ≳ N/(2 log N)). Reduced from 6 sorries: researcher-8 (2026-06-28) repaired the build against the current Mathlib pin and eliminated 4 sorries with 0-axiom proofs (optimal_works_because_primes, the two IsSubsetUpTo subgoals, primes_products_determine_pair). researcher-3 (2026-06-28) then proved distinct_minimal_energy (HasDistinctProducts ↔ multiplicative energy = |A||B|) 0-axiom via the diagonal-subset argument, leaving 1 sorry.",
-    "theoremCount": 11,
+    "axiomCount": 3,
+    "lineCount": 468,
+    "assumptions": "3 axioms, 0 sorries. Axioms: szemeredi_theorem (Szemerédi 1976 upper bound, deep); optimal_has_distinct_products (the optimal example has distinct products, deep); primes_upper_half_lower_bound (Chebyshev-type lower bound — the count of primes in (N/2,N] is ≳ N/log N; isolated as an axiom because Mathlib's Nat.primeCounting provides only an upper bound, no lower bound on π(N)−π(N/2)). Progression: researcher-8 (2026-06-28) repaired the build against the current Mathlib pin and eliminated 4 sorries with 0-axiom proofs (optimal_works_because_primes, the two IsSubsetUpTo subgoals, primes_products_determine_pair). researcher-3 (2026-06-28) then proved distinct_minimal_energy (HasDistinctProducts ↔ multiplicative energy = |A||B|) 0-axiom via the diagonal-subset argument, and in a follow-up session eliminated the last sorry: proved optimalA_card (|optimalA N| = ⌊N/2⌋, 0-axiom) and discharged the bound_is_optimal lower bound from the isolated Chebyshev axiom (note: the previously hardcoded constant 1/3 was false at small N, e.g. N=10 where the product ratio dips to ≈0.115, so the theorem is now in its honest ∃c>0 form).",
+    "theoremCount": 13,
     "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
@@ -81,7 +83,7 @@
     "historicalContext": "Erdős posed Problem #490 at the 1972 Number Theory Conference at the University of Colorado, asking for the maximum of $|A||B|$ when $A, B \\subseteq \\{1,\\ldots,N\\}$ have all products $ab$ distinct. The problem sits at the intersection of multiplicative number theory and extremal combinatorics.\n\nSzemerédi resolved the problem in 1976 in his paper \"On a problem of P. Erdős\" in the Journal of Number Theory, proving that $|A||B| \\ll N^2/\\log N$. His argument is a counting argument based on the divisor function: the total number of divisor pairs $(a,b)$ with $ab \\leq N^2$ is $\\sum_{n \\leq N^2} d(n) \\sim N^2 \\log N$, but the distinct products condition restricts each $n$ to contribute at most one pair, yielding the $\\log N$ savings.\n\nThe bound is sharp. The construction $A = [1, N/2]$ and $B = \\{p \\text{ prime} : N/2 < p \\leq N\\}$ achieves $|A||B| \\sim N^2/(4\\log N)$. The key insight is that primes $p > N/2$ cannot divide any integer $\\leq N/2$ (since $p > N/2 \\geq a$ for $a \\in A$), so $a_1 p_1 = a_2 p_2$ forces $p_1 = p_2$ by unique factorization, and then $a_1 = a_2$. By the prime number theorem, $|B| = \\pi(N) - \\pi(N/2) \\sim N/(2\\log N)$.\n\nErdős also posed the finer question: does $\\lim_{N\\to\\infty} \\max |A||B| \\cdot \\log N / N^2$ exist? Van Doorn observed that if the limit exists, it must be $\\geq 1$. This limit question remains open and connects to deep questions about the distribution of smooth numbers and the multiplicative structure of intervals.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet A, B ⊆ {1,...,N} be such that all products ab with a ∈ A, b ∈ B are distinct.\n\nIs it true that |A||B| ≪ N²/log N?\n\n**Answer: YES** (Szemerédi 1976)\n\n**Best Possible:** A = [1, N/2], B = primes in (N/2, N]\nachieve |A||B| ~ N²/(2 log N).\n\n**Open (Erdős 1972):** Does lim max|A||B|·log N/N² exist? What is its value?",
     "text": "If A, B ⊆ {1,...,N} have all products ab distinct, is |A||B| ≪ N²/log N? SOLVED: YES (Szemerédi 1976). Optimal example achieves N²/(2 log N).",
-    "proofStrategy": "The formalization takes a layered approach. First, it establishes two equivalent definitions of distinct products — the cardinality-based `HasDistinctProducts` ($|A \\cdot B| = |A||B|$) and the injectivity-based `ProductMapInjective` (the map $(a,b) \\mapsto ab$ is injective). Szemerédi's upper bound is axiomatized, and the answer YES is derived immediately.\n\nThe optimal construction is then formalized: `optimalA N = [1, N/2]` and `optimalB N = primes in (N/2, N]`. The theorem `optimal_works_because_primes` sketches why products are distinct (prime divisibility argument, currently sorried). The matching lower bound `bound_is_optimal` shows $|A||B| \\geq c N^2/\\log N$, establishing tightness.\n\nBeyond the main result, the formalization explores the open limit question (productRatio, van Doorn's observation), the special case of multiplicative Sidon sets ($A = B$), multiplicative energy as a measure of product collisions, and connections to related Erdős problems (#425 on sums, #896 on general products).",
+    "proofStrategy": "The formalization takes a layered approach. First, it establishes two equivalent definitions of distinct products — the cardinality-based `HasDistinctProducts` ($|A \\cdot B| = |A||B|$) and the injectivity-based `ProductMapInjective` (the map $(a,b) \\mapsto ab$ is injective). Szemerédi's upper bound is axiomatized, and the answer YES is derived immediately.\n\nThe optimal construction is then formalized: `optimalA N = [1, N/2]` and `optimalB N = primes in (N/2, N]`. The theorem `optimal_works_because_primes` sketches why products are distinct (prime divisibility argument, proved). The matching lower bound `bound_is_optimal` shows $|A||B| \\geq c N^2/\\log N$, establishing tightness.\n\nBeyond the main result, the formalization explores the open limit question (productRatio, van Doorn's observation), the special case of multiplicative Sidon sets ($A = B$), multiplicative energy as a measure of product collisions, and connections to related Erdős problems (#425 on sums, #896 on general products).",
     "keyInsights": [
       "**Why N²/log N:** The divisor function $d(n) = \\sum_{d|n} 1$ averages $\\log n$, so $\\sum_{n \\leq N^2} d(n) \\sim N^2 \\log N$. Distinct products restrict each $n$ to at most one divisor pair, saving a factor of $\\log N$.",
       "**Primes as Extremizers:** The optimal construction exploits primes $p > N/2$ that are too large to divide any element of $A$. This forces $a_1 p_1 = a_2 p_2 \\Rightarrow p_1 = p_2$ by unique factorization.",
@@ -131,10 +133,10 @@
     {
       "id": "optimal-example",
       "title": "The Optimal Example",
-      "summary": "optimalA = [1, N/2], optimalB = primes in (N/2, N]; optimal_has_distinct_products axiom; optimal_works_because_primes (prime divisibility, sorried)",
+      "summary": "optimalA = [1, N/2], optimalB = primes in (N/2, N]; optimal_has_distinct_products axiom; optimal_works_because_primes (prime divisibility, proved)",
       "startLine": 112,
       "endLine": 133,
-      "mathContext": "Axiomatized: optimalA = [1, N/2], optimalB = primes in (N/2, N]; optimal_has_distinct_products axiom; optimal_works_because_primes (prime divisibility, sorried)"
+      "mathContext": "Axiomatized: optimalA = [1, N/2], optimalB = primes in (N/2, N]; optimal_has_distinct_products axiom; optimal_works_because_primes (prime divisibility, proved)"
     },
     {
       "id": "limit-question",
@@ -147,34 +149,34 @@
     {
       "id": "special-cases",
       "title": "Special Cases: Multiplicative Sidon Sets",
-      "summary": "IsMultiplicativeSidon (A = B case), primes_sidon (primes form a Sidon set, sorried); the sidon_bound (|A|² ≤ CN²/log N) is noted in a docstring comment only — no axiom or theorem declared",
+      "summary": "IsMultiplicativeSidon (A = B case), primes_products_determine_pair (primes determine their product pair, proved; the false primes_sidon was replaced); the sidon_bound (|A|² ≤ CN²/log N) is noted in a docstring comment only — no axiom or theorem declared",
       "startLine": 155,
       "endLine": 177,
-      "mathContext": "IsMultiplicativeSidon (A = B case), primes_sidon (primes form a Sidon set, sorried); sidon_bound is docstring-only"
+      "mathContext": "IsMultiplicativeSidon (A = B case), primes_products_determine_pair (primes determine their product pair, proved; the false primes_sidon was replaced); sidon_bound is docstring-only"
     },
     {
       "id": "related-problems",
       "title": "Related Problems and Multiplicative Energy",
-      "summary": "Connections to Problems #425 (sums) and #896 (products); multiplicativeEnergy counting quadruples; distinct_minimal_energy equivalence (sorried)",
+      "summary": "Connections to Problems #425 (sums) and #896 (products); multiplicativeEnergy counting quadruples; distinct_minimal_energy equivalence (proved, 0-axiom, diagonal-subset argument)",
       "startLine": 178,
       "endLine": 202,
-      "mathContext": "Mathematical content: Connections to Problems #425 (sums) and #896 (products); multiplicativeEnergy counting quadruples; distinct_minimal_energy equivalence (sorried)"
+      "mathContext": "Mathematical content: Connections to Problems #425 (sums) and #896 (products); multiplicativeEnergy counting quadruples; distinct_minimal_energy equivalence (proved, 0-axiom, diagonal-subset argument)"
     },
     {
       "id": "bounds-history",
       "title": "Bounds History",
-      "summary": "Progression from trivial N² bound to Szemerédi's N²/log N; trivial_bound and counting_bound (sorried), szemeredi_bound (derived from axiom)",
+      "summary": "Progression from trivial N² bound to Szemerédi's N²/log N; trivial_bound and counting_bound (proved), szemeredi_bound (derived from axiom)",
       "startLine": 203,
       "endLine": 227,
-      "mathContext": "Axiomatized: Progression from trivial N² bound to Szemerédi's N²/log N; trivial_bound and counting_bound (sorried), szemeredi_bound (derived from axiom)"
+      "mathContext": "Axiomatized: Progression from trivial N² bound to Szemerédi's N²/log N; trivial_bound and counting_bound (proved), szemeredi_bound (derived from axiom)"
     },
     {
       "id": "summary",
       "title": "Summary and Optimality",
-      "summary": "erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (partially proved)",
+      "summary": "erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (proved from the 3 axioms, 0 sorries)",
       "startLine": 228,
       "endLine": 282,
-      "mathContext": "Bound: erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (partially proved)"
+      "mathContext": "Bound: erdos_490 and erdos_490_main restating the YES answer; bound_is_optimal showing Θ(N²/log N) tightness via the prime construction (proved from the 3 axioms, 0 sorries)"
     }
   ],
   "conclusion": {
@@ -202,12 +204,12 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 423,
-    "axiomCount": 2,
-    "theoremCount": 11,
+    "lineCount": 468,
+    "axiomCount": 3,
+    "theoremCount": 13,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
       "Proofs/Erdos490Aristotle.lean"
@@ -230,5 +232,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, number-theory, solved"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/erdos-490-incomplete-01.json
+++ b/src/data/research/problems/erdos-490-incomplete-01.json
@@ -26,7 +26,7 @@
     ]
   },
   "currentState": {
-    "summary": "IN PROGRESS. Repaired the build (orphan doc-comments, Finset.card_Icc → Nat.card_Icc, DecidablePred via open scoped Classical) and reduced sorries 6 → 2 with 0-axiom proofs (optimal_works_because_primes fixed+proved, two IsSubsetUpTo subgoals, false primes_sidon replaced by correct primes_products_determine_pair). 2 deep axioms and 2 hard sorries remain.",
+    "summary": "DONE (build-repair + full sorry elimination). File builds against Mathlib 4.26 with 0 sorries and 3 axioms (szemeredi_theorem, optimal_has_distinct_products, primes_upper_half_lower_bound). All tractable sorries discharged; the only remaining assumptions are the three deep/analytic axioms, each explicitly stated and documented. The Chebyshev prime-counting axiom is the single irreducible analytic input absent from the current Mathlib pin.",
     "outcome": "progress"
   },
   "knowledge": {
@@ -34,7 +34,9 @@
       "optimal_works_because_primes was false without positivity (a₁=a₂=0 ⇒ 0=0 for distinct primes); fixed by requiring 1 ≤ aᵢ.",
       "primes_sidon was false: ordered HasDistinctProducts P P (card = |P|²) fails because p·q = q·p collapses in the product set; the correct statement is primes_products_determine_pair.",
       "distinct_minimal_energy is a real iff but needs fiber-counting (energy = ∑ r(p)², |A||B| = ∑ r(p)); deferred.",
-      "the lower bound in bound_is_optimal needs π(N) − π(N/2) ~ N/(2 log N), a Chebyshev/PNT estimate; deferred."
+      "the lower bound in bound_is_optimal needs π(N) − π(N/2) ~ N/(2 log N), a Chebyshev/PNT estimate; deferred.",
+      "bound_is_optimal cannot use a fixed lower-bound constant: the product ratio |A||B|·log N/N² dips to ≈0.115 at N=10, so only the ∃c>0 form is true; the file's old hardcoded 1/3 was false.",
+      "optimalA N = Finset.Icc 1 (N/2), so |optimalA N| = N/2 exactly (proved 0-axiom via Finset.ext + Nat.card_Icc + omega)."
     ],
     "builtItems": [
       "Build repair: Nat.card_Icc, open scoped Classical, orphan-comment fixes (Erdos490Problem.lean)",
@@ -46,10 +48,10 @@
       "No prime-counting lower bound (π(N) − π(N/2)) readily available for the optimal-example lower bound."
     ],
     "nextSteps": [
-      "Prove the bound_is_optimal lower bound: needs a Chebyshev-type prime-count estimate π(N)−π(N/2) ≳ N/(2 log N) (not currently in the file/Mathlib pin).",
-      "Optional: prove the HasDistinctProducts ↔ ProductMapInjective bridge as a standalone lemma (now subsumed inside distinct_minimal_energy)."
+      "Eliminate primes_upper_half_lower_bound by proving a Chebyshev lower bound π(N)−π(N/2) ≳ N/log N from Mathlib primitives (Bertrand/centralBinom machinery) — a multi-session infrastructure effort; Mathlib's Nat.primeCounting currently has only an upper bound.",
+      "Optionally prove (optimalB N).card = N.primeCounting - (N/2).primeCounting to bridge the axiom to Mathlib's primeCounting API."
     ],
-    "progressSummary": "PROGRESS 2026-06-28 (researcher-3): proved distinct_minimal_energy (HasDistinctProducts ↔ multiplicative energy = |A||B|) 0-axiom via the diagonal-subset argument; sorries 2 → 1. Remaining sorry is the bound_is_optimal PNT lower bound. 2 deep axioms remain."
+    "progressSummary": "DONE 2026-06-28 (researcher-3): eliminated the last sorry. Proved optimalA_card (|optimalA N| = ⌊N/2⌋, 0-axiom) and discharged the bound_is_optimal lower bound by isolating the one irreducible Chebyshev prime-counting input (|optimalB N| = π(N)−π(N/2) ≳ N/log N) as an explicit axiom `primes_upper_half_lower_bound`. File now 0 sorries, 3 axioms. Switched bound_is_optimal to its honest ∃c>0 form: the previously hardcoded 1/3 is FALSE at small N (e.g. N=10, product ratio ≈0.115)."
   },
   "knownResults": {
     "established": [
@@ -71,11 +73,11 @@
     {
       "path": "Proofs/Erdos490Problem.lean",
       "filename": "Erdos490Problem.lean",
-      "lineCount": 339,
-      "theoremCount": 10,
-      "axiomCount": 2,
+      "lineCount": 468,
+      "theoremCount": 13,
+      "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos490Problem.lean"
     }


### PR DESCRIPTION
## Summary

Eliminates the **last sorry** in `Proofs/Erdos490Problem.lean` (Erdős #490, distinct products of two sets, Szemerédi 1976). The file is now **0-sorry**, with the single remaining hard input cleanly isolated as an explicit, minimal axiom — mirroring how the file already axiomatizes `szemeredi_theorem`.

## What changed

- **Proved `optimalA_card`** (0-axiom): `(optimalA N).card = N / 2`, via `optimalA N = Finset.Icc 1 (N/2)` + `Nat.card_Icc`.
- **Isolated the irreducible analytic input** as `axiom primes_upper_half_lower_bound`: the Chebyshev-type lower bound `∃ c>0, ∀ N≥4, c·N/log N ≤ (optimalB N).card` (i.e. `π(N)−π(N/2) ≳ N/log N`). Mathlib's `Nat.primeCounting` provides only an **upper** bound (`primeCounting'_add_le`) and monotonicity — there is no lower bound on `π(N)−π(N/2)` in the pinned Mathlib, so this is the genuine missing piece.
- **Proved `bound_is_optimal`** from that axiom: `|A| = ⌊N/2⌋ ≥ N/4` and `|B| ≥ c·N/log N` give `|A||B| ≥ (c/4)·N²/log N`. The full cardinality + real-arithmetic derivation is verified.

## Correctness fix

`bound_is_optimal` previously hardcoded `c = 1/3`, which is **false at small N** — the product ratio `|A||B|·log N/N²` dips to **≈0.115 at N=10**. The theorem is now in its honest `∃ c>0` form, with the constant derived from the axiom.

## Verification

```
#print axioms bound_is_optimal
  ⇒ [propext, Classical.choice, optimal_has_distinct_products,
     primes_upper_half_lower_bound, Quot.sound]   -- no sorry
#print axioms optimalA_card
  ⇒ [propext, Classical.choice, Quot.sound]        -- 0-axiom
```

`lake env lean Proofs/Erdos490Problem.lean` → EXIT 0 (warnings only).

Counts: sorries 1→0, axioms 2→3, theorems 11→13, 423→468 lines. Gallery meta and research knowledge updated (counts, assumptions, and pre-existing stale "sorried" section prose corrected).

## Status note

This trades one sorry for one explicit, true, named axiom that makes the only remaining assumption reviewable. The file remains `status: axiomatized` (3 deep axioms). Fully eliminating `primes_upper_half_lower_bound` would require building a Chebyshev lower bound from Mathlib's Bertrand/`centralBinom` machinery — a separate multi-session infrastructure effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)