### PR TITLE
research(puiseux-theorem-oq-03): Newton polygon capstone — sorted slopes + counted widths on the recursion-built hull [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -946,4 +946,88 @@ theorem ysqMinusX_lowerHull :
     (by intro a ha b hb hab; fin_cases ha <;> fin_cases hb <;> simp_all)
     (by intro q hq hne; fin_cases hq <;> simp_all)
 
+/-! ### Capstone: the complete Newton polygon, sorted and counted
+
+The prior sessions built three pieces that never quite met on the *same* object:
+
+* `exists_lowerHull` — the connected hull chain from the leftmost to the rightmost
+  vertex actually exists (the divide-and-conquer recursion runs to completion);
+* `edgeSlopes_pairwise_le` — the **valuation** half: any lower-edge chain has sorted
+  edge slopes (negated = root valuations, non-increasing);
+* `sum_edgeWidths` / `edgeWidths_pos` — the **multiplicity** half: the edge widths
+  are positive and telescope to the index span (the `Y`-degree when anchored at `0`).
+
+The first two were stated about an *abstract* chain hypothesis; the existence theorem
+produced a *concrete* chain but said nothing about its slopes or widths.  The two
+corollaries below close that gap by discharging the chain hypothesis with the very
+chain the recursion builds, so the bundled combinatorial Newton polygon is now a
+single existence statement. -/
+
+/-- **The hull the recursion builds has sorted edge slopes.**  This is the literal
+"single corollary" the construction was aiming for: compose `exists_lowerHull`
+(existence of the connected lower hull) with `edgeSlopes_pairwise_le` (global
+convexity) to obtain a hull chain from the leftmost to the rightmost vertex whose
+edge slopes are sorted — i.e. whose negated slopes are the root valuations in sorted
+(non-increasing) order, read off end to end. -/
+theorem exists_lowerHull_sorted {pts : List SupportPoint} (p : SupportPoint)
+    (hp : p ∈ pts)
+    (hdist : ∀ a ∈ pts, ∀ b ∈ pts, a.1 = b.1 → a = b)
+    (hleft : ∀ q ∈ pts, q ≠ p → p.1 < q.1) :
+    ∃ (vs : List SupportPoint) (w : SupportPoint),
+      List.IsChain (IsLowerEdge pts) (p :: vs) ∧
+      (p :: vs).getLast? = some w ∧ w ∈ pts ∧ (∀ r ∈ pts, r.1 ≤ w.1) ∧
+      (edgeSlopes (p :: vs)).Pairwise (· ≤ ·) := by
+  obtain ⟨vs, w, hchain, hlast, hw, hwmax⟩ := exists_lowerHull p hp hdist hleft
+  exact ⟨vs, w, hchain, hlast, hw, hwmax, edgeSlopes_pairwise_le hchain⟩
+
+/-- **The combinatorial Newton polygon, assembled end to end.**  For a distinct-index
+support with strictly-leftmost point `p`, the lower-hull chain produced by
+`exists_lowerHull` simultaneously satisfies every combinatorial property the
+Newton–Puiseux recursion needs:
+
+* it is a genuine chain of lower edges from `p` to a rightmost vertex `w`
+  (`w` has maximal index over all of `pts`);
+* its **edge slopes are sorted** (`Pairwise (· ≤ ·)`) — negated, the root valuations
+  in sorted (non-increasing) order;
+* its **edge widths are all positive** — every edge genuinely moves left-to-right;
+* its **widths sum to the index span** `w.1 − p.1` — all roots accounted for with
+  multiplicity (the `Y`-degree count when `p.1 = 0`).
+
+This single statement bundles the valuation half (`edgeSlopes_pairwise_le`), the
+multiplicity half (`sum_edgeWidths`, `edgeWidths_pos`), and the existence of the hull
+(`exists_lowerHull`) into the complete combinatorial content of the Newton polygon
+theorem.  Only the analytic bridge (slopes/widths ↔ actual roots of `P ∈ K((x))[Y]`)
+remains, blocked on a `K((x))[Y]` valuation API absent from Mathlib 4.26.0. -/
+theorem exists_lowerHull_newtonPolygon {pts : List SupportPoint} (p : SupportPoint)
+    (hp : p ∈ pts)
+    (hdist : ∀ a ∈ pts, ∀ b ∈ pts, a.1 = b.1 → a = b)
+    (hleft : ∀ q ∈ pts, q ≠ p → p.1 < q.1) :
+    ∃ (vs : List SupportPoint) (w : SupportPoint),
+      List.IsChain (IsLowerEdge pts) (p :: vs) ∧
+      (p :: vs).getLast? = some w ∧ w ∈ pts ∧ (∀ r ∈ pts, r.1 ≤ w.1) ∧
+      (edgeSlopes (p :: vs)).Pairwise (· ≤ ·) ∧
+      (∀ z ∈ edgeWidths (p :: vs), 0 < z) ∧
+      (edgeWidths (p :: vs)).sum = (w.1 : ℚ) - (p.1 : ℚ) := by
+  obtain ⟨vs, w, hchain, hlast, hw, hwmax⟩ := exists_lowerHull p hp hdist hleft
+  have hgl : (p :: vs).getLast (by simp) = w := by
+    obtain ⟨_, hwgl⟩ := List.mem_getLast?_eq_getLast hlast
+    exact hwgl.symm
+  refine ⟨vs, w, hchain, hlast, hw, hwmax,
+    edgeSlopes_pairwise_le hchain, edgeWidths_pos hchain, ?_⟩
+  rw [sum_edgeWidths, hgl]
+
+/-- The worked example `Y² − x`: the complete Newton polygon from the leftmost vertex
+`(0,1)` exists with sorted slopes, positive widths, and widths summing to the index
+span — the single combinatorial Newton polygon of the support `{(0,1), (2,0)}`. -/
+theorem ysqMinusX_newtonPolygon :
+    ∃ (vs : List SupportPoint) (w : SupportPoint),
+      List.IsChain (IsLowerEdge YsqMinusX) ((0, 1) :: vs) ∧
+      ((0, 1) :: vs).getLast? = some w ∧ w ∈ YsqMinusX ∧ (∀ r ∈ YsqMinusX, r.1 ≤ w.1) ∧
+      (edgeSlopes ((0, 1) :: vs)).Pairwise (· ≤ ·) ∧
+      (∀ z ∈ edgeWidths ((0, 1) :: vs), 0 < z) ∧
+      (edgeWidths ((0, 1) :: vs)).sum = (w.1 : ℚ) - (0 : ℚ) :=
+  exists_lowerHull_newtonPolygon (0, 1) (by simp [YsqMinusX])
+    (by intro a ha b hb hab; fin_cases ha <;> fin_cases hb <;> simp_all)
+    (by intro q hq hne; fin_cases hq <;> simp_all)
+
 end PuiseuxTheoremOQ03

--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -301,3 +301,53 @@ API absent from Mathlib 4.26.0.
 Verification: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean
 Proofs/PuiseuxTheoremOQ03.lean` exits 0 (~26s, host toolchain, single-file against
 prebuilt Mathlib oleans).
+
+---
+
+## Session (2026-06-28, researcher-9): capstone — Newton polygon assembled end to end
+
+Closed the follow-on the previous session flagged as "the cleanest next step":
+compose `exists_lowerHull` with the convexity/multiplicity infrastructure so the
+combinatorial Newton polygon is a *single* existence statement about the chain the
+recursion actually builds. File 949→1033 lines, 48→51 theorems, all still
+**0 sorries / 0 axioms** (`#print axioms` on all three new results lists only
+`propext`/`Classical.choice`/`Quot.sound`).
+
+**The gap this closes.** Prior sessions proved the valuation half
+(`edgeSlopes_pairwise_le`) and the multiplicity half (`sum_edgeWidths`,
+`edgeWidths_pos`) about an *abstract* `IsChain (IsLowerEdge pts)` hypothesis, while
+`exists_lowerHull` produced a *concrete* hull chain but asserted nothing about its
+slopes or widths. The two never met on the same object. This session discharges the
+abstract chain hypothesis with the recursion-built chain.
+
+* `exists_lowerHull_sorted` (PuiseuxTheoremOQ03.lean:972) — the literal "single
+  corollary": the hull chain from leftmost to rightmost vertex has
+  `(edgeSlopes (p :: vs)).Pairwise (· ≤ ·)`. Two lines: destructure
+  `exists_lowerHull`, apply `edgeSlopes_pairwise_le` to the produced chain.
+* **`exists_lowerHull_newtonPolygon`** (PuiseuxTheoremOQ03.lean:1001) — the capstone
+  bundling *all* combinatorial Newton-polygon data on one chain: it reaches a
+  maximal-index vertex `w`, its edge slopes are sorted (sorted root valuations),
+  its edge widths are all positive, and the widths sum to the index span
+  `w.1 − p.1` (the `Y`-degree when `p.1 = 0`). First statement uniting the
+  valuation and multiplicity halves.
+* `ysqMinusX_newtonPolygon` (PuiseuxTheoremOQ03.lean:1022) — the `Y²−x` worked
+  example of the bundle.
+
+**Why this matters.** The combinatorial content of the Newton polygon theorem is now
+a single theorem about the object the Newton–Puiseux algorithm walks: existence +
+sorted valuations + correct total multiplicity, end to end, on the concrete hull.
+Only the analytic bridge (slopes/widths ↔ actual roots of `P ∈ K((x))[Y]`) remains,
+still blocked on a `K((x))[Y]` valuation API absent from Mathlib 4.26.0.
+
+### GOTCHA: `getLast?` → `getLast` bridge for the width-sum field
+`sum_edgeWidths` is stated with `getLast (by simp)`, but `exists_lowerHull` returns
+`(p :: vs).getLast? = some w`. Convert via `List.mem_getLast?_eq_getLast hlast`
+(`x ∈ l.getLast? → ∃ h, x = getLast l h`); the proof argument of `getLast` is
+proof-irrelevant, so `hwgl.symm` closes `getLast (by simp) = w` and
+`rw [sum_edgeWidths, hgl]` telescopes the sum to `w.1 − p.1`. Importing the module to
+`#print axioms` segfaults (no olean built); append the `#print axioms` lines into the
+file itself, `env lean`, then revert.
+
+Verification: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean
+Proofs/PuiseuxTheoremOQ03.lean` exits 0 (host toolchain, single-file against
+prebuilt Mathlib oleans).

--- a/research/problems/puiseux-theorem-oq-03/state.md
+++ b/research/problems/puiseux-theorem-oq-03/state.md
@@ -3,7 +3,7 @@
 ## Current State
 **Phase**: ACT
 **Path**: fast
-**Since**: 2026-06-27T13:54:10-07:00
+**Since**: 2026-06-28T07:20:55-07:00
 **Iteration**: 1
 
 ## Current Focus

--- a/research/registry.json
+++ b/research/registry.json
@@ -22236,7 +22236,7 @@
       "path": "fast",
       "started": "2026-05-12T13:53:16-07:00",
       "status": "active",
-      "lastUpdate": "2026-06-27T13:54:10-07:00"
+      "lastUpdate": "2026-06-28T07:20:55-07:00"
     },
     {
       "slug": "puiseux-theorem-wip-01",

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -245,9 +245,9 @@
       "Mathlib.Data.List.Sort"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 949,
+    "lineCount": 1033,
     "axiomCount": 0,
-    "theoremCount": 48,
+    "theoremCount": 51,
     "definitionCount": 8,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0

--- a/src/data/research/problems/puiseux-theorem-oq-03.json
+++ b/src/data/research/problems/puiseux-theorem-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-06-28, researcher-4): hull-construction recursion COMPLETED. exists_lowerHull assembles the full lower-hull chain (leftmost→rightmost vertex) by fuelled strong induction over pts.length, splicing one dominant edge per peel via isLowerEdge_chain_extend; verified 0-axiom. The combinatorial Newton-polygon existence is now closed end-to-end. The analytic Newton polygon theorem (slopes = root valuations) remains open, blocked on a Mathlib valuation API.",
+    "progressSummary": "PROGRESS (2026-06-28, researcher-9): capstone closed. exists_lowerHull_newtonPolygon bundles existence + sorted slopes + positive widths + widths-sum-to-span on the single recursion-built hull chain — the first statement uniting the valuation and multiplicity halves on one concrete object. File 949->1033 lines, 48->51 theorems, verified 0-axiom (propext/Classical.choice/Quot.sound only). Analytic Newton polygon theorem (slopes = root valuations) remains the open frontier, blocked on a Mathlib K((x))[Y] valuation API.",
     "builtItems": [
       "IsLowerVertex: supporting-line characterization of a Newton-polygon lower-hull vertex (algorithm-independent Prop)",
       "isLowerVertex_of_minimal: the min-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -47,7 +47,10 @@
       "chain_transfer (PuiseuxTheoremOQ03.lean): propagates dominant-slope bound along a whole right sub-hull via edgeSlope_mono; upgrades every edge to full-support edge",
       "isLowerEdge_chain_extend (PuiseuxTheoremOQ03.lean): one verified peel of Newton-Puiseux recursion — prepend dominant edge to right sub-hull chain ⇒ IsChain (IsLowerEdge pts) over full support",
       "threeVertex_chain_via_extend + threeVertex_rightHull + threeVertex_filter: worked example rebuilt constructively through the splice combinator",
-      "exists_lowerHull_aux + exists_lowerHull in PuiseuxTheoremOQ03.lean: complete lower-hull existence (chain from leftmost vertex to max-index vertex) for distinct-index support; ysqMinusX_lowerHull worked example. 0 sorries / 0 axioms (#print axioms: propext/Classical.choice/Quot.sound only)."
+      "exists_lowerHull_aux + exists_lowerHull in PuiseuxTheoremOQ03.lean: complete lower-hull existence (chain from leftmost vertex to max-index vertex) for distinct-index support; ysqMinusX_lowerHull worked example. 0 sorries / 0 axioms (#print axioms: propext/Classical.choice/Quot.sound only).",
+      "exists_lowerHull_sorted (PuiseuxTheoremOQ03.lean:972): the literal single corollary — exists_lowerHull composed with edgeSlopes_pairwise_le; the constructively-built hull chain has sorted edge slopes",
+      "exists_lowerHull_newtonPolygon (PuiseuxTheoremOQ03.lean:1001): capstone bundling existence + sorted slopes + positive widths + widths-sum-to-span on ONE concrete hull chain — first theorem uniting the valuation and multiplicity halves on the object the recursion builds",
+      "ysqMinusX_newtonPolygon (PuiseuxTheoremOQ03.lean:1022): Y^2-x worked example of the bundled Newton polygon capstone"
     ],
     "insights": [
       "Supporting-line predicate beats a verified convex-hull construction: same downstream value, far less proof burden, algorithm-agnostic.",
@@ -60,7 +63,9 @@
       "Capstone bookkeeping: Σ (slopeᵢ · widthᵢ) telescopes to the total vertical drop (last).2 − (first).2; equivalently Σ (root valuationᵢ · multiplicityᵢ) = v(constant) − v(leading), the valuation of the product of all roots",
       "The polygon now reads off ALL combinatorial Newton-polygon data from one vertex chain: sorted valuations (edgeSlopes_pairwise_le), total multiplicity (sum_edgeWidths_eq_degree), AND sum-of-valuations-with-multiplicity (neg_sum_slope_mul_width)",
       "S2-A hull correctness (researcher-5, 2026-06-28): the obstruction to the documented \"peel-and-recurse\" hull construction is that a lower edge of the right restriction pts.filter(q.1 ≤ ·.1) can dip below a left point. RESOLVED: isLowerEdge_of_right proves it cannot, provided the edge slope clears the dominant slope m₀ — convexity forces the right edge line above the dominant line on the left half. This is the precise reason divide-and-conquer Newton-polygon construction is sound.",
-      "exists_lowerHull (2026-06-28, researcher-4): the hull-construction recursion now runs to completion. Fuelled strong induction on pts.length (exists_lowerHull_aux) peels the dominant edge p→q₀ (exists_isLowerEdge_of_leftmost) and recurses on the right restriction pts.filter (q₀.1 ≤ ·.1), which strictly shrinks because the leftmost p is dropped (List.length_filter_eq_length_iff). isLowerEdge_chain_extend splices each peel. Result: a single chain of lower edges p::vs ending at a maximal-index vertex w — the existence half of the Newton polygon, VERIFIED 0-axiom."
+      "exists_lowerHull (2026-06-28, researcher-4): the hull-construction recursion now runs to completion. Fuelled strong induction on pts.length (exists_lowerHull_aux) peels the dominant edge p→q₀ (exists_isLowerEdge_of_leftmost) and recurses on the right restriction pts.filter (q₀.1 ≤ ·.1), which strictly shrinks because the leftmost p is dropped (List.length_filter_eq_length_iff). isLowerEdge_chain_extend splices each peel. Result: a single chain of lower edges p::vs ending at a maximal-index vertex w — the existence half of the Newton polygon, VERIFIED 0-axiom.",
+      "Prior valuation-half (edgeSlopes_pairwise_le) and multiplicity-half (sum_edgeWidths/edgeWidths_pos) were stated about an ABSTRACT chain hypothesis; exists_lowerHull produced a CONCRETE chain but said nothing about slopes/widths. The capstone discharges the chain hypothesis with the recursion-built chain, uniting all three on one object.",
+      "getLast?->getLast bridge: from (p::vs).getLast? = some w use List.mem_getLast?_eq_getLast to get ∃ h, w = getLast (p::vs) h; proof-irrelevance makes getLast _ (by simp) defeq, so the .symm closes getLast (by simp) = w and rw [sum_edgeWidths, hgl] telescopes the width sum to w.1 - p.1."
     ],
     "mathlibGaps": [
       "No Newton polygon API in Mathlib 4.26.0 (no Polynomial.newtonPolygon / lowerConvexHull as combinatorial vertex data).",
@@ -68,10 +73,9 @@
       "No arithmetic-complexity model (Bürgisser-Clausen-Shokrollahi style) to state the Poteaux-Weimann Õ(d·δ) bound."
     ],
     "nextSteps": [
-      "Strengthen exists_lowerHull: prove the produced chain edge-slopes are sorted by composing with edgeSlopes_pairwise_le (global convexity) — gives sorted root valuations end-to-end as a single corollary.",
-      "Newton polygon theorem proper (negated edge slopes = root valuations): blocked on missing valuation API on K((x))[Y] in Mathlib 4.26.0.",
-      "S2-B termination measure for one Newton-Puiseux reduction step (Y-degree strictly decreases) — edgeWidths sum-to-degree machinery is the combinatorial half.",
-      "Quasi-linear complexity bound (Poteaux-Weimann Õ(d·δ)): blocked on absence of arithmetic-complexity model in Mathlib."
+      "Analytic Newton polygon theorem (edge slopes = root valuations of P in K((x))[Y]): still blocked on a valuation API for K((x))[Y] absent from Mathlib 4.26.0 — the principal remaining gap.",
+      "Optional: a fully-reduced ysqMinusX_newtonPolygon stating the concrete witness vs=[] and w=(2,0) so the slopes/widths lists evaluate (edgeSlopes [(0,1),(2,0)] = [-1/2], edgeWidths = [2]).",
+      "S2-B termination measure and S2-C quasi-linear complexity bound remain open (S2-C blocked on lack of an arithmetic-complexity model in Mathlib)."
     ],
     "markdown": "# Knowledge Base: puiseux-theorem-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
     "archivedSessions": [


### PR DESCRIPTION
## Summary

Composes `exists_lowerHull` (the connected lower-hull chain the divide-and-conquer recursion builds, proved last session) with the previously-**abstract** convexity and multiplicity layers, uniting them on a single **concrete** object. Prior sessions proved the valuation half (`edgeSlopes_pairwise_le`) and the multiplicity half (`sum_edgeWidths`/`edgeWidths_pos`) about an abstract `IsChain (IsLowerEdge pts)` hypothesis, while `exists_lowerHull` produced a concrete chain but asserted nothing about its slopes or widths. The two never met. This PR discharges the abstract chain hypothesis with the recursion-built chain.

## New results (all 0-sorry, 0-axiom)

- **`exists_lowerHull_sorted`** — the literal "single corollary" the construction was aiming for: the hull chain from leftmost to rightmost vertex has `(edgeSlopes (p :: vs)).Pairwise (· ≤ ·)` (sorted edge slopes ⟹ sorted root valuations). Two lines: `exists_lowerHull` ∘ `edgeSlopes_pairwise_le`.
- **`exists_lowerHull_newtonPolygon`** — capstone bundling *all* combinatorial Newton-polygon data on one chain: reaches a maximal-index vertex `w`, edge slopes sorted, edge widths all positive, and widths summing to the index span `w.1 − p.1` (the `Y`-degree when `p.1 = 0`). **First statement uniting the valuation and multiplicity halves on the object the recursion builds.**
- **`ysqMinusX_newtonPolygon`** — the `Y²−x` worked example of the bundle.

## Verification

- File `Proofs/PuiseuxTheoremOQ03.lean`: 949 → 1033 lines, 48 → 51 theorems, **0 sorries**.
- `#print axioms` on all three new results lists only `propext`/`Classical.choice`/`Quot.sound` — genuinely 0-axiom.
- Single-file build: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean` exits 0, no diagnostics.

## Status

The combinatorial content of the Newton polygon theorem is now a single theorem about the object the Newton–Puiseux algorithm walks: existence + sorted valuations + correct total multiplicity, end to end. The **analytic** bridge (slopes/widths ↔ actual roots of `P ∈ K((x))[Y]`) remains the open frontier, blocked on a `K((x))[Y]` valuation API absent from Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)