### PR TITLE
research(cassini-identity-oq-01-oq-01-oq-01): Vajda's identity via direct bilinear expansion [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CassiniIdentityOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CassiniIdentityOQ01OQ01OQ01.lean
@@ -1,0 +1,156 @@
+/-
+# Vajda's Identity (the bilinear master identity for `Nat.fib`)
+
+Vajda's identity states that for the Fibonacci numbers `F` and all `n, i, j`,
+
+  `F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j} = (−1)ⁿ · Fᵢ·Fⱼ`.
+
+It is the common generalization of **all three** classical bilinear Fibonacci
+identities, and unlike the signed Catalan/d'Ocagne forms it is *fully additive*
+in its indices — no `Nat` subtraction appears anywhere:
+
+* **Cassini** is `i = j = 1`:    `F_{n+1}² − Fₙ·F_{n+2} = (−1)ⁿ`.
+* **Catalan** (`catalan_aux` of the parent file) is `i = j = r`:
+    `F_{n+r}² − Fₙ·F_{n+2r} = (−1)ⁿ·Fᵣ²`.
+* **d'Ocagne (shift form)** is `j = 1`:
+    `F_{n+i}·F_{n+1} − Fₙ·F_{n+i+1} = (−1)ⁿ·Fᵢ`.
+
+The parent entry (`CassiniIdentityOQ01OQ01`) proved Catalan, and its docstring
+noted that "Mathlib records neither Catalan's identity nor the general
+Vajda/d'Ocagne bilinear identities for `Nat.fib`". This file supplies exactly
+that missing master identity, from which Catalan is recovered as the diagonal
+`i = j = r` case.
+
+## Proof
+
+The proof is a single bilinear expansion, with no second induction beyond the
+one already inside Cassini. Writing `A = Fₙ`, `B = F_{n+1}`, we expand each of
+`F_{n+i}`, `F_{n+j}`, `F_{n+i+j}` by Mathlib's **addition formula** `Nat.fib_add`
+(`F_{m+k+1} = Fₘ·F_k + F_{m+1}·F_{k+1}`). All the cross terms collapse, leaving
+
+  `LHS = F_i·F_j · (B² − A·B − A²) = F_i·F_j · (−1)ⁿ`,
+
+where the last step is Cassini in the normalized form `cassini_sub` proved by the
+parent file. We reuse `cassini_sub` directly via `import`.
+
+The same Vajda identity is also proved elsewhere in the gallery
+(`FibonacciIdentitiesOQ01OQ02OQ01.fib_vajda_gap`) by a two-step induction on `j`
+off d'Ocagne's identity. This file gives the *independent, non-inductive*
+derivation native to the Cassini lineage: one addition-formula expansion against
+the imported Cassini core, no induction beyond the one already inside Cassini.
+
+No axioms, no `native_decide`, no sorries.
+-/
+import Mathlib
+import Proofs.CassiniIdentityOQ01OQ01
+
+namespace CassiniIdentityOQ01OQ01OQ01
+
+open CassiniIdentityOQ01OQ01 (cassini_sub)
+
+/-- **Vajda's identity.**
+`F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j} = (−1)ⁿ · Fᵢ·Fⱼ`, for all `n i j : ℕ`.
+
+This is the bilinear master identity for `Nat.fib`: it specializes to Cassini
+(`i = j = 1`), Catalan (`i = j = r`), and the d'Ocagne shift identity (`j = 1`).
+The index arithmetic is entirely additive, so no `Nat` subtraction is needed.
+
+The proof expands the three Fibonacci values by the addition formula
+`Nat.fib_add` and collapses the cross terms with Cassini (`cassini_sub`). -/
+theorem vajda (n i j : ℕ) :
+    (Nat.fib (n + i) : ℤ) * Nat.fib (n + j) - Nat.fib n * Nat.fib (n + i + j)
+      = (-1) ^ n * (Nat.fib i : ℤ) * Nat.fib j := by
+  cases i with
+  | zero =>
+    -- `i = 0`: both sides vanish (`F₀ = 0`, and `F_{n}·F_{n+j}` cancels).
+    simp only [Nat.add_zero, Nat.fib_zero, Nat.cast_zero, mul_zero, zero_mul]
+    ring
+  | succ s =>
+    cases j with
+    | zero =>
+      -- `j = 0`: symmetric vanishing.
+      simp only [Nat.add_zero, Nat.fib_zero, Nat.cast_zero, mul_zero]
+      ring
+    | succ t =>
+      -- Normalize the three indices into `· + 1` shape for `Nat.fib_add`.
+      have ei : n + (s + 1) = n + s + 1 := by ring
+      have ej : n + (t + 1) = n + t + 1 := by ring
+      -- `ei` first rewrites `n + (s+1) ↦ n + s + 1` everywhere, including inside the
+      -- `F_{n+i+j}` argument, so `eij` must match that already-normalized form.
+      have eij : n + s + 1 + (t + 1) = n + (s + t + 1) + 1 := by ring
+      rw [ei, ej, eij]
+      -- Addition-formula expansions of the three Fibonacci values.
+      have hI : (Nat.fib (n + s + 1) : ℤ)
+          = Nat.fib n * Nat.fib s + Nat.fib (n + 1) * Nat.fib (s + 1) := by
+        exact_mod_cast Nat.fib_add n s
+      have hJ : (Nat.fib (n + t + 1) : ℤ)
+          = Nat.fib n * Nat.fib t + Nat.fib (n + 1) * Nat.fib (t + 1) := by
+        exact_mod_cast Nat.fib_add n t
+      have hIJ : (Nat.fib (n + (s + t + 1) + 1) : ℤ)
+          = Nat.fib n * Nat.fib (s + t + 1) + Nat.fib (n + 1) * Nat.fib (s + t + 2) := by
+        exact_mod_cast Nat.fib_add n (s + t + 1)
+      -- Addition-formula expansions of the two combined inner indices.
+      have hsum1 : (Nat.fib (s + t + 1) : ℤ)
+          = Nat.fib s * Nat.fib t + Nat.fib (s + 1) * Nat.fib (t + 1) := by
+        exact_mod_cast Nat.fib_add s t
+      have hsum2 : (Nat.fib (s + t + 2) : ℤ)
+          = Nat.fib s * Nat.fib (t + 1) + Nat.fib (s + 1) * Nat.fib (t + 2) := by
+        have : s + t + 2 = s + (t + 1) + 1 := by ring
+        rw [this]; exact_mod_cast Nat.fib_add s (t + 1)
+      -- `F_{t+2} = F_t + F_{t+1}` to eliminate the stray `F_{t+2}`.
+      have ht2 : (Nat.fib (t + 2) : ℤ) = Nat.fib t + Nat.fib (t + 1) := by
+        exact_mod_cast (Nat.fib_add_two (n := t))
+      -- Cassini supplies `B² − A·B − A² = (−1)ⁿ`.
+      have hcas := cassini_sub n
+      rw [hI, hJ, hIJ, hsum1, hsum2, ht2]
+      linear_combination (Nat.fib (s + 1) : ℤ) * Nat.fib (t + 1) * hcas
+
+/-! ### Specializations: Vajda recovers the classical bilinear identities -/
+
+/-- **Cassini** is Vajda at `i = j = 1`: `F_{n+1}² − Fₙ·F_{n+2} = (−1)ⁿ`. -/
+theorem vajda_cassini (n : ℕ) :
+    (Nat.fib (n + 1) : ℤ) ^ 2 - Nat.fib n * Nat.fib (n + 2) = (-1) ^ n := by
+  have h := vajda n 1 1
+  simp only [Nat.fib_one, Nat.cast_one, mul_one] at h
+  have e : n + 1 + 1 = n + 2 := by ring
+  rw [e] at h
+  linear_combination h
+
+/-- **Catalan (subtraction-free form)** is Vajda at `i = j = r`:
+`F_{n+r}² − Fₙ·F_{n+2r} = (−1)ⁿ·Fᵣ²`. This is exactly the parent file's
+`catalan_aux`, here obtained as a corollary of the more general `vajda`. -/
+theorem vajda_catalan (n r : ℕ) :
+    (Nat.fib (n + r) : ℤ) ^ 2 - Nat.fib n * Nat.fib (n + 2 * r)
+      = (-1) ^ n * (Nat.fib r : ℤ) ^ 2 := by
+  have h := vajda n r r
+  have e : n + r + r = n + 2 * r := by ring
+  rw [e] at h
+  linear_combination h
+
+/-- **d'Ocagne shift identity** is Vajda at `j = 1`:
+`F_{n+i}·F_{n+1} − Fₙ·F_{n+i+1} = (−1)ⁿ·Fᵢ`. -/
+theorem vajda_docagne (n i : ℕ) :
+    (Nat.fib (n + i) : ℤ) * Nat.fib (n + 1) - Nat.fib n * Nat.fib (n + i + 1)
+      = (-1) ^ n * (Nat.fib i : ℤ) := by
+  have h := vajda n i 1
+  simp only [Nat.fib_one, Nat.cast_one, mul_one] at h
+  linear_combination h
+
+/-! ### Numerical sanity checks -/
+
+/-- `n = 2, i = 1, j = 3`: `F₃·F₅ − F₂·F₆ = 2·5 − 1·8 = 2 = (−1)²·F₁·F₃`. -/
+theorem vajda_2_1_3 :
+    (Nat.fib 3 : ℤ) * Nat.fib 5 - Nat.fib 2 * Nat.fib 6
+      = (-1) ^ 2 * (Nat.fib 1 : ℤ) * Nat.fib 3 := by
+  have := vajda 2 1 3
+  norm_num at this ⊢
+
+/-- `n = 3, i = 2, j = 2`: `F₅² − F₃·F₇ = 25 − 2·13 = −1 = (−1)³·F₂²`
+(the Catalan instance `catalan_5_2` of the parent, via the diagonal of Vajda). -/
+theorem vajda_3_2_2 :
+    (Nat.fib 5 : ℤ) * Nat.fib 5 - Nat.fib 3 * Nat.fib 7
+      = (-1) ^ 3 * (Nat.fib 2 : ℤ) * Nat.fib 2 := by
+  have := vajda 3 2 2
+  norm_num at this ⊢
+
+end CassiniIdentityOQ01OQ01OQ01

--- a/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,75 @@
+[
+  {
+    "id": "ann-vajda-master",
+    "proofId": "cassini-identity-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 98
+    },
+    "type": "theorem",
+    "title": "Vajda's identity, the bilinear master identity",
+    "content": "`vajda` proves $F_{n+i}F_{n+j} - F_n F_{n+i+j} = (-1)^n F_i F_j$ for all $n, i, j$. The two boundary cases $i = 0$ and $j = 0$ make both sides vanish ($F_0 = 0$). For $i = s+1$, $j = t+1$ the proof rewrites the inner indices into the $\\cdot + 1$ shape required by `Nat.fib_add`, then expands $F_{n+i}$, $F_{n+j}$, $F_{n+i+j}$ and the combined inner values $F_{s+t+1}$, $F_{s+t+2}$ — five applications of the addition formula in all. After substituting $F_{t+2} = F_t + F_{t+1}$, a single `linear_combination (F (s+1))·(F (t+1))·cassini_sub n` cancels every cross term.",
+    "mathContext": "$F_{n+i}F_{n+j} - F_n F_{n+i+j} = (-1)^n F_i F_j$. Writing $A = F_n$, $B = F_{n+1}$, the expansion factors as $F_{s+1}F_{t+1}(B^2 - AB - A^2) = F_i F_j (-1)^n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Vajda's identity",
+      "Fibonacci addition formula",
+      "Bilinear identity",
+      "Cassini's identity"
+    ]
+  },
+  {
+    "id": "ann-vajda-catalan",
+    "proofId": "cassini-identity-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 114,
+      "endLine": 122
+    },
+    "type": "theorem",
+    "title": "Catalan recovered as the diagonal i = j = r",
+    "content": "`vajda_catalan` derives $F_{n+r}^2 - F_n F_{n+2r} = (-1)^n F_r^2$ from `vajda n r r` in two lines: rewrite $n + r + r = n + 2r$, then `linear_combination`. This is exactly the parent file's `catalan_aux`, now exhibited as a one-line corollary of the strictly more general master identity — the affirmative answer to the parent Catalan entry's first open question.",
+    "mathContext": "Catalan (subtraction-free): $F_{n+r}^2 - F_n F_{n+2r} = (-1)^n F_r^2$, the diagonal $i = j = r$ of Vajda.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Catalan's identity",
+      "Diagonal specialization",
+      "Open question resolution"
+    ]
+  },
+  {
+    "id": "ann-vajda-docagne",
+    "proofId": "cassini-identity-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 124,
+      "endLine": 129
+    },
+    "type": "theorem",
+    "title": "d'Ocagne shift identity as the j = 1 slice",
+    "content": "`vajda_docagne` gives $F_{n+i}F_{n+1} - F_n F_{n+i+1} = (-1)^n F_i$ from `vajda n i 1` (using $F_1 = 1$). This is a subtraction-free companion of the classical d'Ocagne identity $F_m F_{n+1} - F_{m+1} F_n = (-1)^n F_{m-n}$, obtained without any natural-number subtraction.",
+    "mathContext": "d'Ocagne (shift form): $F_{n+i}F_{n+1} - F_n F_{n+i+1} = (-1)^n F_i$, the $j = 1$ specialization of Vajda.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "d'Ocagne's identity",
+      "Specialization",
+      "Fibonacci shift"
+    ]
+  },
+  {
+    "id": "ann-vajda-cassini",
+    "proofId": "cassini-identity-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 103,
+      "endLine": 111
+    },
+    "type": "theorem",
+    "title": "Cassini recovered as i = j = 1",
+    "content": "`vajda_cassini` recovers $F_{n+1}^2 - F_n F_{n+2} = (-1)^n$ from `vajda n 1 1`, where $F_1 = 1$ collapses the right-hand side to the bare sign $(-1)^n$. This closes the loop back to the grandparent Cassini entry: Vajda is the full bilinear generalization, and Cassini is its smallest non-trivial instance.",
+    "mathContext": "Cassini: $F_{n+1}^2 - F_n F_{n+2} = (-1)^n$, the $i = j = 1$ specialization of Vajda.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cassini's identity",
+      "Specialization",
+      "Fibonacci recurrence"
+    ]
+  }
+]

--- a/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "cassini-identity-oq-01-oq-01-oq-01",
+  "slug": "cassini-identity-oq-01-oq-01-oq-01",
+  "title": "Vajda's Identity: the bilinear master identity for Fibonacci numbers",
+  "leanFile": {
+    "path": "Proofs/CassiniIdentityOQ01OQ01OQ01.lean",
+    "axiomCount": 0,
+    "sorryCount": 0
+  },
+  "sorries": [],
+  "mainTheorems": [
+    {
+      "name": "vajda",
+      "statement": "For all n, i, j: F (n+i) · F (n+j) − F n · F (n+i+j) = (−1)^n · F i · F j in ℤ.",
+      "description": "Vajda's identity, the bilinear master identity for Nat.fib. Unlike the signed Catalan/d'Ocagne forms it is fully additive in its indices — no Nat subtraction appears. Proved by a single bilinear expansion: each of F_{n+i}, F_{n+j}, F_{n+i+j} is expanded by the addition formula Nat.fib_add, the cross terms collapse, and the whole left-hand side factors as F_i · F_j · (Cassini core) = F_i · F_j · (−1)^n via one linear_combination against cassini_sub."
+    },
+    {
+      "name": "vajda_catalan",
+      "statement": "(F (n+r))² − F n · F (n+2r) = (−1)^n · (F r)² in ℤ, for all n, r.",
+      "description": "Catalan's subtraction-free form recovered as the diagonal i = j = r of Vajda. This is exactly the parent file's catalan_aux, here obtained as a one-line corollary of the strictly more general vajda — directly resolving the parent entry's first open question."
+    },
+    {
+      "name": "vajda_docagne",
+      "statement": "F (n+i) · F (n+1) − F n · F (n+i+1) = (−1)^n · F i in ℤ.",
+      "description": "The d'Ocagne shift identity recovered as the j = 1 specialization of Vajda. A subtraction-free companion to the classical d'Ocagne F_m F_{n+1} − F_{m+1} F_n = (−1)^n F_{m−n}."
+    },
+    {
+      "name": "vajda_cassini",
+      "statement": "(F (n+1))² − F n · F (n+2) = (−1)^n in ℤ.",
+      "description": "Cassini's identity recovered as the i = j = 1 specialization of Vajda (F_1 = 1, so the right side collapses to the bare sign)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "cassini-identity-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The parent proves Catalan's identity F_n² − F_{n−r}·F_{n+r} = (−1)^{n−r}·F_r² and ends with the open question of whether the same expand-then-Cassini method yields the full Vajda identity F_{n+i}F_{n+j} − F_n F_{n+i+j} = (−1)^n F_i F_j, with Catalan the diagonal case i = j = r. This entry answers that question affirmatively, and recovers Catalan (vajda_catalan) as the diagonal corollary of vajda."
+    },
+    {
+      "proofId": "cassini-identity-oq-01",
+      "relationship": "ancestor",
+      "description": "The grandparent proves Cassini's identity via the determinant of the Fibonacci companion matrix Q. Vajda is the full bilinear generalization; Cassini is the case i = j = 1 (vajda_cassini)."
+    },
+    {
+      "proofId": "fibonacci-identities-oq-01-oq-02-oq-01",
+      "relationship": "related",
+      "description": "An independent gallery proof of the same Vajda identity, reached through the separate fibonacci-identities lineage. That entry (fib_vajda_gap) proves Vajda by a two-step induction on j off d'Ocagne's identity; this entry instead gives a non-inductive proof, expanding all three compound Fibonacci values by the addition formula in one shot and collapsing them against the imported Cassini core. The two derivations are mathematically equivalent — this entry is the Cassini-lineage's independent answer to its parent Catalan entry's open question, not a new theorem."
+    }
+  ],
+  "references": [
+    {
+      "title": "Cassini and Catalan identities",
+      "url": "https://en.wikipedia.org/wiki/Cassini_and_Catalan_identities",
+      "type": "encyclopedia"
+    },
+    {
+      "title": "Vajda, Fibonacci and Lucas Numbers, and the Golden Section",
+      "url": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Other_identities",
+      "type": "book"
+    }
+  ],
+  "description": "A fully machine-checked proof of Vajda's identity F_{n+i}·F_{n+j} − F_n·F_{n+i+j} = (−1)^n·F_i·F_j for the Fibonacci numbers and all n, i, j. This is the bilinear master identity from which Cassini (i = j = 1), Catalan (i = j = r), and the d'Ocagne shift identity (j = 1) all descend as one-line corollaries. Where Catalan (the parent entry) compares three terms in arithmetic progression of a single step r, Vajda allows two independent offsets i and j, and — crucially for formalization — is entirely additive in its indices, so no truncated natural-number subtraction ever appears. The proof is a single bilinear expansion: each of F_{n+i}, F_{n+j}, F_{n+i+j} is rewritten with Mathlib's Fibonacci addition formula Nat.fib_add, all cross terms cancel, and the left-hand side factors as F_i·F_j·(F_{n+1}² − F_n·F_{n+1} − F_n²) = F_i·F_j·(−1)^n by the Cassini core cassini_sub. Mathlib records none of the Vajda/Catalan/d'Ocagne bilinear Fibonacci identities. This directly answers the parent Catalan entry's first open question.",
+  "overview": {
+    "historicalContext": "**Vajda's Identity**\n\nStephen Vajda collected the bilinear Fibonacci identities in *Fibonacci and Lucas Numbers, and the Golden Section* (1989). The identity now bearing his name,\n$$F_{n+i}\\,F_{n+j} - F_n\\,F_{n+i+j} = (-1)^n\\,F_i\\,F_j,$$\nstands at the head of the Cassini–Catalan–d'Ocagne family: every classical bilinear Fibonacci identity is one of its specializations. Cassini (1680) is $i = j = 1$; Catalan (1879) is the diagonal $i = j = r$; d'Ocagne is the $j = 1$ slice. Mathlib contains only the integer-indexed Cassini specialization `Int.fib_succ_mul_fib_pred_sub_fib_sq` and no general bilinear identity, so the full two-offset law is new infrastructure here. It is also the answer to the open question posed at the end of the parent Catalan entry.",
+    "problemStatement": "**Vajda's Identity**\n\nFor Fibonacci numbers viewed inside $\\mathbb{Z}$ and any $n, i, j$,\n$$F_{n+i}\\,F_{n+j} - F_n\\,F_{n+i+j} = (-1)^n\\,F_i\\,F_j.$$\nThe goal is a fully machine-checked, axiom-free proof, together with the explicit recovery of Cassini ($i=j=1$), Catalan ($i=j=r$), and the d'Ocagne shift identity ($j=1$) as corollaries.",
+    "proofStrategy": "**One bilinear expansion, then Cassini**\n\nThe boundary cases $i = 0$ and $j = 0$ make both sides vanish ($F_0 = 0$). For $i = s+1$, $j = t+1$ the three compound Fibonacci values are expanded with Mathlib's addition formula $F_{a+b+1} = F_a F_b + F_{a+1}F_{b+1}$ (`Nat.fib_add`): $F_{n+i}$ and $F_{n+j}$ in the basis $\\{F_n, F_{n+1}\\}$, and the inner index $F_{n+i+j}$ together with the combined inner values $F_{s+t+1}, F_{s+t+2}$. After substituting $F_{t+2} = F_t + F_{t+1}$, every cross term cancels and the left-hand side factors as\n$$F_{s+1}\\,F_{t+1}\\,\\bigl(F_{n+1}^2 - F_n F_{n+1} - F_n^2\\bigr) = F_i\\,F_j\\,(-1)^n,$$\nthe parenthesised factor being the Cassini core `cassini_sub` (the one induction in the whole development, reused from the parent file). A single `linear_combination` closes the goal — no induction on the bilinear identity itself.",
+    "keyInsights": [
+      "**Two offsets, no subtraction.** Vajda's two independent offsets $i, j$ enter the statement purely additively ($n+i$, $n+j$, $n+i+j$), so unlike the classical signed Catalan/d'Ocagne forms the formal statement never needs truncated natural-number subtraction — the whole proof stays friction-free over $\\mathbb{N}$.",
+      "**Bilinear, not quadratic.** Where Catalan is a one-parameter (diagonal) identity, Vajda is genuinely bilinear in $(F_s, F_{s+1})$ and $(F_t, F_{t+1})$. The single Cassini scalar $(-1)^n$ factors out of the whole expansion, multiplied by $F_i F_j$.",
+      "**Master identity = Cassini × F_i F_j.** Every dependence on $n$ collapses to the Cassini core $(-1)^n$; the offsets contribute only the multiplicative factor $F_i F_j$. Cassini, Catalan, and d'Ocagne are then the choices $(i,j) = (1,1)$, $(r,r)$, $(i,1)$.",
+      "**One induction, reused.** The only induction in the development is Cassini itself (`cassini_sub`), imported from the parent entry. Vajda adds no further induction: it is pure addition-formula algebra plus one `linear_combination`."
+    ],
+    "prerequisites": [
+      "Fibonacci numbers and the recurrence F_{n+2} = F_n + F_{n+1}",
+      "The Fibonacci addition formula F_{m+n+1} = F_m F_n + F_{m+1} F_{n+1} (Nat.fib_add)",
+      "Cassini's identity in normalized form (the parent entry's cassini_sub)",
+      "Elementary polynomial algebra (linear_combination, ring)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "vajda-master",
+      "title": "Vajda's identity (the bilinear master identity)",
+      "startLine": 54,
+      "endLine": 98,
+      "summary": "vajda proves F_{n+i}·F_{n+j} − F_n·F_{n+i+j} = (−1)^n·F_i·F_j. After the i=0 and j=0 vanishing cases, the i=s+1, j=t+1 case expands all three compound Fibonacci values (and the inner F_{s+t+1}, F_{s+t+2}) with Nat.fib_add, then a single linear_combination against the Cassini core cassini_sub collapses every cross term."
+    },
+    {
+      "id": "vajda-specializations",
+      "title": "Specializations: Cassini, Catalan, d'Ocagne",
+      "startLine": 100,
+      "endLine": 129,
+      "summary": "vajda_cassini (i=j=1), vajda_catalan (i=j=r, recovering the parent's catalan_aux), and vajda_docagne (j=1) each follow from vajda by a one-line linear_combination, exhibiting the three classical bilinear identities as instances of the master identity."
+    },
+    {
+      "id": "vajda-sanity",
+      "title": "Numerical sanity checks",
+      "startLine": 131,
+      "endLine": 147,
+      "summary": "vajda_2_1_3 (F₃F₅ − F₂F₆ = 2) and vajda_3_2_2 (F₅² − F₃F₇ = −1, the Catalan instance) check concrete numerical instances of the master identity."
+    }
+  ],
+  "conclusion": {
+    "summary": "Vajda's identity $F_{n+i}F_{n+j} - F_n F_{n+i+j} = (-1)^n F_i F_j$ is proved by a single bilinear expansion: each compound Fibonacci value is rewritten with the addition formula `Nat.fib_add`, the cross terms cancel, and the left-hand side factors as $F_i F_j$ times the Cassini core $F_{n+1}^2 - F_n F_{n+1} - F_n^2 = (-1)^n$. The offsets $i, j$ enter the statement entirely additively, so no natural-number subtraction is needed. Cassini ($i=j=1$), Catalan ($i=j=r$), and the d'Ocagne shift identity ($j=1$) all follow as one-line corollaries. 0 axioms, 0 sorries.",
+    "implications": [
+      "Answers the parent Catalan entry's first open question affirmatively: the expand-then-Cassini method does give the full Vajda identity, with Catalan the diagonal case i = j = r (vajda_catalan reproduces the parent's catalan_aux verbatim).",
+      "Gives an independent, non-inductive proof of Vajda's identity. The gallery already proves the same identity via the separate fibonacci-identities lineage (fib_vajda_gap, a two-step induction on j); this Cassini-lineage proof reaches it instead by a single addition-formula expansion, so the contribution is the alternative derivation and lineage closure rather than a new theorem.",
+      "Supplies the general bilinear Fibonacci identity that Mathlib lacks entirely — a single statement from which the whole Cassini/Catalan/d'Ocagne family descends.",
+      "Isolates the structural fact that the master identity is Cassini scaled by F_i F_j: the entire dependence on the base index n is the single Cassini scalar (−1)^n, and the two offsets contribute only the product F_i F_j."
+    ],
+    "openQuestions": [
+      "Does the analogous bilinear identity hold for the Lucas numbers L_n, and does the same expand-then-Cassini route prove it (with the Lucas Cassini L_{n+1}L_{n−1} − L_n² = 5(−1)^{n+1} as the core)?",
+      "Can Vajda be packaged for arbitrary second-order linear recurrences x_{n+2} = p·x_{n+1} + q·x_n, recovering the Fibonacci case at p = q = 1?"
+    ]
+  },
+  "meta": {
+    "author": "Stephen Vajda (1989); classical (Cassini 1680, Catalan 1879, d'Ocagne); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cassini_and_Catalan_identities",
+    "date": "1989",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "vajda-identity",
+      "catalan-identity",
+      "cassini",
+      "docagne",
+      "addition-formula",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CassiniIdentityOQ01OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add",
+        "description": "The Fibonacci addition formula fib (m + n + 1) = fib m · fib n + fib (m+1) · fib (n+1). Applied five times, it expands F_{n+i}, F_{n+j}, F_{n+i+j} and the combined inner values F_{s+t+1}, F_{s+t+2} into the basis {F_n, F_{n+1}, F_s, F_{s+1}, F_t, F_{t+1}}, turning Vajda's identity into polynomial algebra.",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "The Fibonacci recurrence fib (n+2) = fib n + fib (n+1), used to rewrite F_{t+2} = F_t + F_{t+1} before the final collapse (and inside the imported Cassini core).",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      }
+    ],
+    "originalContributions": [
+      "An independent, non-inductive Lean proof of Vajda's identity F_{n+i}·F_{n+j} − F_n·F_{n+i+j} = (−1)^n·F_i·F_j for Nat.fib via a single addition-formula expansion against the imported Cassini core (the gallery's other proof, fib_vajda_gap in the fibonacci-identities lineage, instead inducts on j off d'Ocagne; Mathlib itself has only the r = 1 integer-indexed Cassini specialization and no general bilinear Fibonacci identity)",
+      "The fully additive index form: because i and j enter only as n+i, n+j, n+i+j, the formal statement needs no truncated natural-number subtraction, unlike the classical signed Catalan/d'Ocagne forms",
+      "Explicit one-line recovery of Catalan (vajda_catalan, reproducing the parent's catalan_aux as the diagonal i=j=r), Cassini (vajda_cassini, i=j=1), and the d'Ocagne shift identity (vajda_docagne, j=1) from the single master identity",
+      "Directly resolves the parent Catalan entry's first open question (whether the expand-then-Cassini method extends to the full Vajda identity)"
+    ],
+    "dateAdded": "2026-06-28",
+    "axiomCount": 0,
+    "lineCount": 148,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The proof uses only Mathlib's Fibonacci lemmas (Nat.fib_add, Nat.fib_add_two), the imported Cassini core cassini_sub (itself a three-line induction), exact_mod_cast, linear_combination, simp, and ring; no native_decide and no structure-encoded hypotheses. #print axioms reports only the foundational propext / Classical.choice / Quot.sound, none of which counts as an assumption.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  }
+}


### PR DESCRIPTION
## Summary

Adds the gallery entry **cassini-identity-oq-01-oq-01-oq-01**: Vajda's master bilinear identity for `Nat.fib`, proved in the Cassini lineage and answering the parent Catalan entry's first open question.

$$F_{n+i}\cdot F_{n+j} - F_n\cdot F_{n+i+j} = (-1)^n\, F_i\, F_j \qquad (\forall\, n,i,j:\mathbb{N})$$

Cassini ($i=j=1$), Catalan ($i=j=r$, reproducing the parent's `catalan_aux`), and the d'Ocagne shift identity ($j=1$) all follow as one-line corollaries.

## Proof method

Non-inductive. Each compound Fibonacci value $F_{n+i}, F_{n+j}, F_{n+i+j}$ is expanded once by `Nat.fib_add`; all cross terms collapse and the LHS factors as
$$F_i\,F_j\,(F_{n+1}^2 - F_n F_{n+1} - F_n^2) = F_i\,F_j\,(-1)^n$$
via a single `linear_combination` against the imported Cassini core `cassini_sub`. The indices enter entirely additively, so no `Nat` subtraction appears.

## Honesty note (duplication is intentional and disclosed)

The gallery **already** proves the same identity via the separate `fibonacci-identities` lineage (`fib_vajda_gap`, PR #28961 — a two-step induction on `j` off d'Ocagne). This entry is the **independent, non-inductive** Cassini-lineage derivation. The duplication is cross-referenced in `meta.json` (`relationship: related`) and disclosed in the Lean docstring, `implications`, and `originalContributions`. The contribution is the alternative proof + lineage closure, **not** a new theorem. Badge `original` is retained in the project's "absent-from-Mathlib" sense, consistent with the sibling entry.

## Fix applied

The earlier draft did not build: `rw [ei, ej, eij]` failed because `ei` rewrites `n+(s+1) ↦ n+s+1` inside the `F_{n+i+j}` argument too, so the `eij` pattern was gone. Fixed `eij` to match the already-normalized form.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CassiniIdentityOQ01OQ01OQ01` → **Build completed successfully (7744 jobs)**
- 0 `axiom` declarations, 0 sorries, no `native_decide`/`decide` in the substantive theorems; standard tactics only (`induction`, `Nat.fib_add`, `exact_mod_cast`, `linear_combination`, `simp`, `ring`, `norm_num`) → foundational axioms only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)