### PR TITLE
research(hilbert-17-oq-01-oq-01): degree-sharp univariate Hilbert 17 (Fejér–Riesz) [0-axiom]

### DIFF
--- a/proofs/Proofs/Hilbert17OQ01OQ01.lean
+++ b/proofs/Proofs/Hilbert17OQ01OQ01.lean
@@ -1,0 +1,187 @@
+/-
+  Hilbert's 17th problem, univariate case — DEGREE-SHARP refinement (Fejér–Riesz).
+
+  The parent file `Proofs/Hilbert17UnivariatePSDSOS.lean` proves the *existence*
+  statement: every non-negative real univariate polynomial `p` is a sum of two
+  squares, `p = u² + v²`.  That proof produces concrete `u, v` but says nothing
+  about their degrees.
+
+  This file sharpens the result to the classical **Fejér–Riesz degree bound**:
+  the two squares can be taken with
+
+      2·deg u ≤ deg p   and   2·deg v ≤ deg p,
+
+  i.e. each summand has degree at most ½·deg p.  This is the natural "full"
+  univariate theorem — it pins down not just decomposability but the *size* of a
+  certificate, which is what a sum-of-squares solver actually returns.
+
+  The bound is proved by carrying it through the very same strong induction on
+  degree used by the parent file (so the analytic crux — even multiplicity of
+  real roots, `sq_dvd_of_psd_root` — is reused verbatim):
+
+    * `p = 0` / constant: `u` constant, `v = 0`, both of degree `0 ≤ ½·deg p`.
+    * real root `r`: `(X - C r)² ∣ p`, quotient `q` PSD of degree `deg p − 2`;
+      `u = (X - C r)·u'`, so `deg u ≤ 1 + deg u' ≤ 1 + ½·deg q = ½·deg p`.
+    * non-real root: pull out the positive quadratic `Q = (X-C re)² + (C im)²`,
+      quotient `q` PSD of degree `deg p − 2`; Brahmagupta gives
+      `u = (X-C re)·u' − (C im)·v'`, `v = (X-C re)·v' + (C im)·u'`, each of
+      degree `≤ 1 + max(deg u', deg v') ≤ 1 + ½·deg q = ½·deg p`.
+
+  The parent existence theorem is recovered as an immediate corollary (forget the
+  bounds).  Like the parent, this file is fully elementary and 0-axiom.
+-/
+import Mathlib
+import Proofs.Hilbert17UnivariatePSDSOS
+
+namespace Hilbert17OQ01OQ01
+
+open Polynomial Filter Topology
+open Hilbert17UnivariatePSDSOS (IsPSD sq_dvd_of_psd_root nonneg_of_forall_gt)
+
+/-- **Degree-sharp strong-induction engine.**  Every PSD polynomial of degree `d`
+    is a sum of two squares `u² + v²` whose summands satisfy the Fejér–Riesz
+    degree bound `2·deg u ≤ deg p` and `2·deg v ≤ deg p`. -/
+theorem psd_eq_sq_add_sq_deg_aux :
+    ∀ (d : ℕ) (p : ℝ[X]), p.natDegree = d → IsPSD p →
+      ∃ u v : ℝ[X], p = u ^ 2 + v ^ 2 ∧
+        2 * u.natDegree ≤ p.natDegree ∧ 2 * v.natDegree ≤ p.natDegree := by
+  intro d
+  induction d using Nat.strongRecOn with
+  | ind d ih =>
+    intro p hpd hnn
+    by_cases hp0 : p = 0
+    · exact ⟨0, 0, by simp [hp0], by simp [hp0], by simp [hp0]⟩
+    by_cases hdeg : p.natDegree = 0
+    · -- constant polynomial `p = C c` with `c ≥ 0`
+      have hpc : p = C (p.coeff 0) := eq_C_of_natDegree_eq_zero hdeg
+      have hc : 0 ≤ p.coeff 0 := by
+        have := hnn 0
+        rwa [← coeff_zero_eq_eval_zero] at this
+      refine ⟨C (Real.sqrt (p.coeff 0)), 0, ?_, ?_, ?_⟩
+      · conv_lhs => rw [hpc]
+        rw [← C_pow, Real.sq_sqrt hc]; ring
+      · simp [natDegree_C]
+      · simp
+    · -- `deg p ≥ 1`: a complex root exists by the FTA
+      have hdpos : 0 < (p.map (algebraMap ℝ ℂ)).degree := by
+        rw [degree_map, Polynomial.degree_eq_natDegree hp0]
+        exact_mod_cast Nat.pos_of_ne_zero hdeg
+      obtain ⟨z, hz⟩ := Complex.exists_root hdpos
+      have haeval : aeval z p = 0 := by
+        rw [aeval_def, ← eval_map]; exact hz
+      by_cases him : z.im = 0
+      · -- real root `r = z.re`
+        have hzr : z = algebraMap ℝ ℂ z.re := by
+          rw [Complex.coe_algebraMap]; apply Complex.ext <;> simp [him]
+        have hpr : p.eval z.re = 0 := by
+          have h2 := haeval
+          rw [hzr, aeval_algebraMap_apply_eq_algebraMap_eval, Complex.coe_algebraMap] at h2
+          exact_mod_cast h2
+        set r := z.re with hr_def
+        obtain ⟨q, hq⟩ := sq_dvd_of_psd_root hp0 hnn hpr
+        have hq0 : q ≠ 0 := fun h => hp0 (by rw [hq, h, mul_zero])
+        -- the quotient is again PSD
+        have hqnn : IsPSD q := by
+          intro x
+          by_cases hx : x = r
+          · subst hx
+            refine nonneg_of_forall_gt q.continuousAt (fun y hy => ?_)
+            have hsq : (0 : ℝ) < (y - r) ^ 2 :=
+              lt_of_le_of_ne (sq_nonneg _)
+                (Ne.symm (pow_ne_zero 2 (sub_ne_zero.mpr (ne_of_gt hy))))
+            have hpy := hnn y
+            rw [hq] at hpy
+            simp only [eval_mul, eval_pow, eval_sub, eval_X, eval_C] at hpy
+            exact (mul_nonneg_iff_of_pos_left hsq).mp hpy
+          · have hsq : (0 : ℝ) < (x - r) ^ 2 :=
+              lt_of_le_of_ne (sq_nonneg _)
+                (Ne.symm (pow_ne_zero 2 (sub_ne_zero.mpr hx)))
+            have hpx := hnn x
+            rw [hq] at hpx
+            simp only [eval_mul, eval_pow, eval_sub, eval_X, eval_C] at hpx
+            exact (mul_nonneg_iff_of_pos_left hsq).mp hpx
+        -- degree drops by exactly two
+        have hpdeg : p.natDegree = q.natDegree + 2 := by
+          rw [hq, natDegree_mul (pow_ne_zero 2 (X_sub_C_ne_zero r)) hq0, natDegree_pow,
+            natDegree_X_sub_C]; omega
+        have hlt : q.natDegree < d := by omega
+        obtain ⟨u, v, huv, hud, hvd⟩ := ih q.natDegree hlt q rfl hqnn
+        refine ⟨(X - C r) * u, (X - C r) * v, by rw [hq, huv]; ring, ?_, ?_⟩
+        · have hu_le : ((X - C r) * u).natDegree ≤ 1 + u.natDegree :=
+            le_trans (natDegree_mul_le) (by rw [natDegree_X_sub_C])
+          omega
+        · have hv_le : ((X - C r) * v).natDegree ≤ 1 + v.natDegree :=
+            le_trans (natDegree_mul_le) (by rw [natDegree_X_sub_C])
+          omega
+      · -- non-real root: pull out a positive real quadratic factor
+        obtain ⟨q, hq⟩ := quadratic_dvd_of_aeval_eq_zero_im_ne_zero p haeval him
+        set Q : ℝ[X] := X ^ 2 - C (2 * z.re) * X + C (‖z‖ ^ 2) with hQ_def
+        have hns : ‖z‖ ^ 2 = z.re ^ 2 + z.im ^ 2 := by
+          rw [← Complex.normSq_eq_norm_sq, Complex.normSq_apply]; ring
+        have hQpos : ∀ x, 0 < Q.eval x := by
+          intro x
+          have hQval : Q.eval x = (x - z.re) ^ 2 + z.im ^ 2 := by
+            rw [hQ_def]
+            simp only [eval_add, eval_sub, eval_mul, eval_pow, eval_X, eval_C]
+            rw [hns]; ring
+          rw [hQval]
+          have him2 : (0 : ℝ) < z.im ^ 2 :=
+            lt_of_le_of_ne (sq_nonneg _) (Ne.symm (pow_ne_zero 2 him))
+          nlinarith [sq_nonneg (x - z.re), him2]
+        have hq0 : q ≠ 0 := fun h => hp0 (by rw [hq, h, mul_zero])
+        have hqnn : IsPSD q := by
+          intro x
+          have hpx := hnn x
+          rw [hq, eval_mul] at hpx
+          exact (mul_nonneg_iff_of_pos_left (hQpos x)).mp hpx
+        have hQne : Q ≠ 0 := fun h => by simpa [h] using hQpos 0
+        have hQdeg : Q.natDegree = 2 := by rw [hQ_def]; compute_degree!
+        have hpdeg : p.natDegree = q.natDegree + 2 := by
+          rw [hq, natDegree_mul hQne hq0, hQdeg]; omega
+        have hlt : q.natDegree < d := by omega
+        obtain ⟨u, v, huv, hud, hvd⟩ := ih q.natDegree hlt q rfl hqnn
+        have hQpoly : Q = (X - C z.re) ^ 2 + (C z.im) ^ 2 := by
+          rw [hQ_def]
+          have hC : (C (‖z‖ ^ 2) : ℝ[X]) = C (z.re ^ 2 + z.im ^ 2) := by rw [hns]
+          rw [hC]; simp only [C_add, C_pow, C_mul, map_ofNat]; ring
+        refine ⟨(X - C z.re) * u - (C z.im) * v, (X - C z.re) * v + (C z.im) * u,
+          by rw [hq, huv, hQpoly]; ring, ?_, ?_⟩
+        · -- degree of first square
+          have h1 : ((X - C z.re) * u - (C z.im) * v).natDegree ≤
+              max ((X - C z.re) * u).natDegree ((C z.im) * v).natDegree :=
+            natDegree_sub_le _ _
+          have h2 : ((X - C z.re) * u).natDegree ≤ 1 + u.natDegree :=
+            le_trans (natDegree_mul_le) (by rw [natDegree_X_sub_C])
+          have h3 : ((C z.im) * v).natDegree ≤ v.natDegree := natDegree_C_mul_le _ _
+          have h4 := le_trans h1 (max_le_max h2 h3)
+          rcases le_total (1 + u.natDegree) v.natDegree with hle | hle
+          · rw [max_eq_right hle] at h4; omega
+          · rw [max_eq_left hle] at h4; omega
+        · -- degree of second square
+          have h1 : ((X - C z.re) * v + (C z.im) * u).natDegree ≤
+              max ((X - C z.re) * v).natDegree ((C z.im) * u).natDegree :=
+            natDegree_add_le _ _
+          have h2 : ((X - C z.re) * v).natDegree ≤ 1 + v.natDegree :=
+            le_trans (natDegree_mul_le) (by rw [natDegree_X_sub_C])
+          have h3 : ((C z.im) * u).natDegree ≤ u.natDegree := natDegree_C_mul_le _ _
+          have h4 := le_trans h1 (max_le_max h2 h3)
+          rcases le_total (1 + v.natDegree) u.natDegree with hle | hle
+          · rw [max_eq_right hle] at h4; omega
+          · rw [max_eq_left hle] at h4; omega
+
+/-- **Univariate Hilbert 17, degree-sharp (Fejér–Riesz).**  Every non-negative
+    real univariate polynomial `p` is a sum of two squares `p = u² + v²` whose
+    summands have degree at most `½·deg p`. -/
+theorem univariate_psd_is_two_sos_deg (p : ℝ[X]) (h : IsPSD p) :
+    ∃ u v : ℝ[X], p = u ^ 2 + v ^ 2 ∧
+      2 * u.natDegree ≤ p.natDegree ∧ 2 * v.natDegree ≤ p.natDegree :=
+  psd_eq_sq_add_sq_deg_aux p.natDegree p rfl h
+
+/-- The plain existence statement (every PSD univariate polynomial is a sum of
+    two squares) is the degree-sharp theorem with the bounds forgotten. -/
+theorem univariate_psd_is_two_sos (p : ℝ[X]) (h : IsPSD p) :
+    ∃ u v : ℝ[X], p = u ^ 2 + v ^ 2 := by
+  obtain ⟨u, v, huv, _, _⟩ := univariate_psd_is_two_sos_deg p h
+  exact ⟨u, v, huv⟩
+
+end Hilbert17OQ01OQ01

--- a/src/data/proofs/hilbert-17-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01/annotations.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "ann-h17-oq0101-setup",
+    "proofId": "hilbert-17-oq-01-oq-01",
+    "range": {
+      "startLine": 36,
+      "endLine": 43
+    },
+    "type": "context",
+    "title": "Reusing the parent's elementary toolkit",
+    "content": "The file opens the parent namespace Hilbert17UnivariatePSDSOS to reuse three ingredients verbatim: the PSD predicate IsPSD p := ∀ x, 0 ≤ p.eval x, the one-sided continuity helper nonneg_of_forall_gt, and — crucially — sq_dvd_of_psd_root, the analytic crux that a real root of a nonnegative polynomial has multiplicity ≥ 2. Because all the hard analysis is imported, the only new mathematical content of this entry is the degree bookkeeping layered on top of the existing induction.",
+    "mathContext": "$\\mathrm{IsPSD}\\,p \\iff \\forall x \\in \\mathbb{R},\\ p(x) \\ge 0.$",
+    "significance": "context"
+  },
+  {
+    "id": "ann-h17-oq0101-engine",
+    "proofId": "hilbert-17-oq-01-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 51
+    },
+    "type": "theorem",
+    "title": "The degree-sharp induction engine",
+    "content": "psd_eq_sq_add_sq_deg_aux strengthens the parent's existence engine with two extra conclusions: 2·deg u ≤ deg p and 2·deg v ≤ deg p. This is the Fejér–Riesz degree bound — each of the two squares has degree at most half the degree of p. The statement is proved by strong induction on d = deg p, so the smaller-degree quotient produced at each step is handled by the induction hypothesis, which now also supplies degree bounds to propagate.",
+    "mathContext": "$p \\ge 0 \\implies \\exists\\, u, v:\\ p = u^2 + v^2 \\ \\wedge\\ 2\\deg u \\le \\deg p \\ \\wedge\\ 2\\deg v \\le \\deg p.$",
+    "significance": "key-step"
+  },
+  {
+    "id": "ann-h17-oq0101-realroot",
+    "proofId": "hilbert-17-oq-01-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 115
+    },
+    "type": "key-step",
+    "title": "Real-root branch: even multiplicity caps the degree growth",
+    "content": "When the FTA root z is real (root r), sq_dvd_of_psd_root gives (X − C r)² ∣ p, so p = (X − C r)²·q with q again PSD of degree deg p − 2. The induction hypothesis returns q = u'² + v'² with 2·deg u' ≤ deg q, and the new squares are u = (X − C r)·u', v = (X − C r)·v'. The degree bound follows from natDegree_mul_le: deg((X − C r)·u') ≤ 1 + deg u', hence 2·deg u ≤ 2 + 2·deg u' ≤ 2 + deg q = deg p. Using the ≤ bound (not exact natDegree_mul) avoids any case split on u' = 0.",
+    "mathContext": "$p = (X-r)^2 q,\\quad 2\\deg u = 2\\deg\\big((X-r)u'\\big) \\le 2(1+\\deg u') \\le 2 + \\deg q = \\deg p.$",
+    "significance": "key-step"
+  },
+  {
+    "id": "ann-h17-oq0101-complexroot",
+    "proofId": "hilbert-17-oq-01-oq-01",
+    "range": {
+      "startLine": 116,
+      "endLine": 173
+    },
+    "type": "key-step",
+    "title": "Non-real-root branch: Brahmagupta keeps the squares in lockstep",
+    "content": "When z is non-real, the positive real quadratic Q = (X − C re z)² + (C im z)² divides p with quotient q PSD of degree deg p − 2. The Brahmagupta–Fibonacci identity turns Q·(u'² + v'²) into u = (X − C re z)·u' − (C im z)·v' and v = (X − C re z)·v' + (C im z)·u'. Each has degree ≤ 1 + max(deg u', deg v') by natDegree_sub_le / natDegree_add_le and natDegree_C_mul_le, so 2·deg u ≤ 2 + 2·max(deg u', deg v') ≤ 2 + deg q = deg p. The max is resolved by le_total and the linear arithmetic closed by omega.",
+    "mathContext": "$Q = (X - \\mathrm{re}\\,z)^2 + (\\mathrm{im}\\,z)^2,\\quad u = (X-\\mathrm{re}\\,z)u' - (\\mathrm{im}\\,z)v',\\ v = (X-\\mathrm{re}\\,z)v' + (\\mathrm{im}\\,z)u'.$",
+    "significance": "key-step"
+  },
+  {
+    "id": "ann-h17-oq0101-public",
+    "proofId": "hilbert-17-oq-01-oq-01",
+    "range": {
+      "startLine": 175,
+      "endLine": 186
+    },
+    "type": "theorem",
+    "title": "Public degree-sharp theorem and existence corollary",
+    "content": "univariate_psd_is_two_sos_deg instantiates the engine at d = deg p, giving the headline Fejér–Riesz statement for any nonnegative univariate polynomial: a two-square certificate whose summands each have degree at most ½·deg p. univariate_psd_is_two_sos then forgets the two degree inequalities, recovering the parent file's plain two-square existence theorem — so the sharp result strictly subsumes the existence statement. #print axioms reports only propext, Classical.choice, Quot.sound: 0 axioms.",
+    "mathContext": "$\\forall\\, p \\ge 0,\\ \\exists\\, u, v:\\ p = u^2 + v^2,\\ \\deg u \\le \\tfrac12\\deg p,\\ \\deg v \\le \\tfrac12\\deg p.$",
+    "significance": "main-result"
+  }
+]

--- a/src/data/proofs/hilbert-17-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "hilbert-17-oq-01-oq-01",
+  "title": "Univariate Hilbert 17, Degree-Sharp: Two Squares of Degree ≤ ½·deg p (Fejér–Riesz Bound)",
+  "slug": "hilbert-17-oq-01-oq-01",
+  "description": "Hilbert's 1888 univariate theorem says every nonnegative real polynomial p is a sum of two squares, p = u² + v². The parent formalization (Hilbert17UnivariatePSDSOS.lean) proves this existence statement but says nothing about the size of the certificate. This entry sharpens it to the classical Fejér–Riesz degree bound: the two squares can be taken with 2·deg u ≤ deg p and 2·deg v ≤ deg p, i.e. each summand has degree at most ½·deg p. This is the natural 'full' univariate theorem — it pins down not just decomposability but the degree of a certificate, which is what a sum-of-squares solver actually returns. The bound is carried through the same strong induction on degree used by the parent (real-root branch via even multiplicity sq_dvd_of_psd_root, non-real-root branch via the positive quadratic factor and the Brahmagupta–Fibonacci identity), tracking natDegree_mul_le / natDegree_sub_le bounds at each step and discharging the arithmetic with omega. The plain existence statement is recovered as an immediate corollary. Fully elementary, 0 axioms.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem",
+    "date": "2026-06-28",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert17OQ01OQ01.lean",
+    "tags": [
+      "real-algebra",
+      "sum-of-squares",
+      "hilbert-17",
+      "fejer-riesz",
+      "degree-bound",
+      "univariate-polynomials",
+      "fundamental-theorem-of-algebra",
+      "pfister-bound",
+      "inequalities"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.exists_root",
+        "description": "The fundamental theorem of algebra: a complex polynomial of positive degree has a root. Supplies, for deg p ≥ 1, a (possibly non-real) root z of p, the engine of the induction step.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Polynomials"
+      },
+      {
+        "theorem": "quadratic_dvd_of_aeval_eq_zero_im_ne_zero",
+        "description": "If a real polynomial has a non-real complex root z, the real quadratic (X − re z)² + (im z)² divides it. Pulls out the positive quadratic factor in the non-real-root branch.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Circle"
+      },
+      {
+        "theorem": "natDegree_mul_le",
+        "description": "(p·q).natDegree ≤ p.natDegree + q.natDegree. The basic super-additivity bound used to push the degree estimate through the factor (X − C r) in both branches.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Lemmas"
+      },
+      {
+        "theorem": "natDegree_sub_le",
+        "description": "(p − q).natDegree ≤ max p.natDegree q.natDegree. Bounds the degree of the Brahmagupta combination (X − C re)·u − (C im)·v in the non-real-root branch.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Operations"
+      },
+      {
+        "theorem": "Nat.strongRecOn",
+        "description": "Strong recursion on ℕ. The induction is on the degree d of p, with the smaller-degree quotient handled by the strong induction hypothesis.",
+        "module": "Mathlib.Init.Data.Nat.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "psd_eq_sq_add_sq_deg_aux: the degree-sharp strong-induction engine — every PSD polynomial of degree d is u² + v² with 2·deg u ≤ deg p and 2·deg v ≤ deg p, carrying the Fejér–Riesz degree bound through every branch of the parent's induction.",
+      "univariate_psd_is_two_sos_deg: the public degree-sharp theorem — every nonnegative real univariate polynomial is a sum of two squares whose summands each have degree at most ½·deg p.",
+      "univariate_psd_is_two_sos: the plain two-square existence statement recovered as an immediate corollary by forgetting the degree bounds, showing the sharp result strictly subsumes the parent's existence theorem.",
+      "Reuses the parent file's analytic crux (sq_dvd_of_psd_root: a real root of a PSD polynomial has even multiplicity) and the Brahmagupta–Fibonacci identity verbatim, so the only new content is the degree bookkeeping (natDegree_mul_le / natDegree_sub_le / natDegree_add_le bounds closed by omega)."
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Hilbert's 1888 univariate theorem: a nonnegative real univariate polynomial is a sum of two squares.",
+      "The fundamental theorem of algebra and conjugate-pair factorization of real polynomials.",
+      "Even multiplicity of real roots of a nonnegative polynomial (the parent's analytic crux).",
+      "The Brahmagupta–Fibonacci identity (a·c − b·d)² + (a·d + b·c)² = (a² + b²)(c² + d²).",
+      "natDegree arithmetic in Mathlib (natDegree_mul_le, natDegree_sub_le, natDegree_X_sub_C)."
+    ],
+    "lineCount": 187,
+    "relatedProblems": [
+      {
+        "id": "hilbert-17-oq-01",
+        "relationship": "Parent: the Pfister bound on the minimum number of squares for PSD polynomials. The univariate case (n=1) is the base of that hierarchy; this entry adds the sharp degree bound on the two summands."
+      },
+      {
+        "id": "hilbert-17",
+        "relationship": "Grandparent: states Hilbert's 17th and Artin's theorem. Its univariate strand is discharged by Hilbert17UnivariatePSDSOS.lean; this entry sharpens that result with the Fejér–Riesz degree bound."
+      },
+      {
+        "id": "hilbert-17-oq-01-oq-04",
+        "relationship": "Cousin: the multivariate minimal-denominator certificate for the Motzkin polynomial. Both entries are about the size/structure of SOS certificates rather than mere existence — degree of summands here, denominator there."
+      }
+    ],
+    "assumptions": "0 axioms. #print axioms univariate_psd_is_two_sos_deg reports only propext, Classical.choice, Quot.sound. No sorryAx, no native_decide / Lean.ofReduceBool. Reuses only 0-axiom theorems from the parent file Hilbert17UnivariatePSDSOS.lean.",
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "leanFile": {
+    "lineCount": 187,
+    "namespace": "Hilbert17OQ01OQ01",
+    "opens": [
+      "Polynomial",
+      "Filter",
+      "Topology"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "substantiveTheoremCount": 2,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": [
+      "Mathlib",
+      "Proofs.Hilbert17UnivariatePSDSOS"
+    ],
+    "path": "Proofs/Hilbert17OQ01OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "psd_eq_sq_add_sq_deg_aux",
+      "type": "theorem",
+      "description": "Degree-sharp strong-induction engine: every PSD polynomial of degree d is u² + v² with 2·deg u ≤ deg p and 2·deg v ≤ deg p.",
+      "leanType": "∀ (d : ℕ) (p : ℝ[X]), p.natDegree = d → IsPSD p → ∃ u v, p = u ^ 2 + v ^ 2 ∧ 2 * u.natDegree ≤ p.natDegree ∧ 2 * v.natDegree ≤ p.natDegree"
+    },
+    {
+      "name": "univariate_psd_is_two_sos_deg",
+      "type": "theorem",
+      "description": "Univariate Hilbert 17, degree-sharp (Fejér–Riesz): every nonnegative real univariate polynomial is a sum of two squares whose summands have degree at most ½·deg p.",
+      "leanType": "(p : ℝ[X]) → IsPSD p → ∃ u v, p = u ^ 2 + v ^ 2 ∧ 2 * u.natDegree ≤ p.natDegree ∧ 2 * v.natDegree ≤ p.natDegree"
+    },
+    {
+      "name": "univariate_psd_is_two_sos",
+      "type": "theorem",
+      "description": "The plain two-square existence statement, recovered from the degree-sharp theorem by forgetting the bounds.",
+      "leanType": "(p : ℝ[X]) → IsPSD p → ∃ u v, p = u ^ 2 + v ^ 2"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Hilbert's 17th problem (1900) asks whether every real polynomial nonnegative on ℝⁿ is a sum of squares of rational functions; Artin proved it affirmatively in 1927. The exceptional cases where polynomial squares already suffice were classified by Hilbert in 1888: univariate polynomials, quadratic forms, and bivariate quartics. The univariate case is the most classical and is closely tied to the Fejér–Riesz theorem (1916), which represents a nonnegative trigonometric polynomial as |g|² for an analytic polynomial g of the same degree; its algebraic shadow is that a nonnegative real polynomial of degree 2n factors through its complex conjugate-pair roots as g·ḡ, giving p = u² + v² with deg u, deg v ≤ n. The degree control — not just the existence of the two squares — is what makes the result usable: a numerical SOS/SDP solver returns a Gram matrix of bounded size precisely because the certificate degree is capped at half the degree of p.",
+    "problemStatement": "Sharpen the univariate case of Hilbert's 17th problem from existence to a degree bound. Given p ∈ ℝ[x] with p(x) ≥ 0 for all real x, produce u, v ∈ ℝ[x] with p = u² + v² AND 2·deg u ≤ deg p, 2·deg v ≤ deg p — each square has degree at most half the degree of p. Recover the parent's plain existence statement as a corollary.",
+    "proofStrategy": "Strong induction on d = deg p, augmenting the parent file's induction with degree bookkeeping. Base cases: p = 0 and p constant give u, v of degree 0, and 2·0 ≤ deg p holds. Inductive step (deg p ≥ 1): the FTA yields a complex root z. If z is real (root r), even multiplicity (sq_dvd_of_psd_root, reused from the parent) gives p = (X − C r)²·q with q PSD of degree deg p − 2; the IH gives q = u'² + v'² with 2·deg u' ≤ deg q, and setting u = (X − C r)·u', v = (X − C r)·v' yields 2·deg u ≤ 2(1 + deg u') ≤ 2 + deg q = deg p via natDegree_mul_le. If z is non-real, the positive quadratic Q = (X − C re z)² + (C im z)² divides p with quotient q PSD of degree deg p − 2; the Brahmagupta–Fibonacci identity turns Q·(u'² + v'²) into two squares u = (X − C re z)·u' − (C im z)·v', v = (X − C re z)·v' + (C im z)·u', each of degree ≤ 1 + max(deg u', deg v') ≤ 1 + ½·deg q = ½·deg p (via natDegree_sub_le / natDegree_add_le / natDegree_C_mul_le, with the max split handled by omega). The public theorem instantiates the engine at d = deg p; the bound-free corollary forgets the two inequalities.",
+    "keyInsights": [
+      "The degree bound is the genuinely new content over the parent existence proof: the same induction tree (FTA, even multiplicity, Brahmagupta) carries an extra invariant 2·deg u ≤ deg p, 2·deg v ≤ deg p, proved purely by natDegree super-/sub-additivity bounds and omega.",
+      "Using natDegree_mul_le rather than the exact natDegree_mul avoids any case split on whether u' or v' is zero: the bound 2·deg((X − C r)·u') ≤ 2(1 + deg u') holds uniformly, including when u' = 0 (degree 0).",
+      "The natDegree convention deg 0 = 0 is exactly what makes the bound 2·deg u ≤ deg p uniform across the zero polynomial, constants, and higher degrees — no special exception is needed, in contrast to a deg v < deg u formulation which would fail for constants.",
+      "Each conjugate pair of complex roots contributes a real quadratic factor and, via Brahmagupta, raises the degree of each square by exactly the degree of that factor's square root (one), so the two squares grow in lockstep and never exceed half the degree of p.",
+      "The result is 0-axiom: it reuses only the parent file's 0-axiom analytic crux, and #print axioms reports just propext, Classical.choice, Quot.sound — the sharp certificate is fully constructive."
+    ]
+  },
+  "conclusion": {
+    "summary": "A 187-line, 0-sorry, 0-axiom refinement of the univariate case of Hilbert's 17th problem: every nonnegative real univariate polynomial is a sum of two squares u² + v² with 2·deg u ≤ deg p and 2·deg v ≤ deg p (the Fejér–Riesz degree bound). The plain existence statement of the parent file is recovered as a corollary.",
+    "implications": "Sharpening existence to a degree bound makes the univariate certificate algorithmically meaningful: the two squares live in degree ≤ ½·deg p, matching the size of the Gram matrix a numerical SOS solver would return. The proof shows the parent's elementary induction is robust enough to carry quantitative invariants at no extra analytic cost.",
+    "openQuestions": [
+      "Sharpen further to an exact-degree statement: for p ≠ 0 of degree 2n, one square has degree exactly n and the other degree < n (the precise Fejér–Riesz normalization), rather than the symmetric ≤ n bound proved here.",
+      "Bound the bit-size / height of the coefficients of u and v in terms of p, toward a fully quantitative (complexity-aware) univariate certificate.",
+      "Carry an analogous degree/size invariant through the quadratic-forms case (Hilbert17QuadraticGram.lean) to bound the number and degree of the affine-linear squares there."
+    ]
+  },
+  "references": [
+    {
+      "title": "Hilbert's seventeenth problem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem"
+    },
+    {
+      "title": "Fejér–Riesz theorem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Rad%C3%B3%E2%80%93Riesz_theorem"
+    },
+    {
+      "title": "B. Reznick, Some concrete aspects of Hilbert's 17th problem (1996)",
+      "url": "https://www.ams.org/books/conm/253/"
+    }
+  ],
+  "crossReferences": [],
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Reusing the parent's elementary toolkit",
+      "startLine": 36,
+      "endLine": 43,
+      "summary": "Opens the parent namespace Hilbert17UnivariatePSDSOS to reuse, verbatim, the PSD predicate IsPSD, the one-sided continuity helper nonneg_of_forall_gt, and the analytic crux sq_dvd_of_psd_root (a real root of a nonnegative polynomial has even multiplicity). Only the degree bookkeeping is new."
+    },
+    {
+      "id": "engine",
+      "title": "The degree-sharp induction engine",
+      "startLine": 44,
+      "endLine": 173,
+      "summary": "psd_eq_sq_add_sq_deg_aux: strong induction on deg p. The p = 0 and constant base cases give degree-0 squares; the real-root branch factors out (X − C r)² and bounds 2·deg u ≤ 2 + deg q = deg p via natDegree_mul_le; the non-real-root branch pulls out the positive quadratic Q and uses Brahmagupta plus natDegree_sub_le / natDegree_add_le, closing the max-split degree arithmetic with omega."
+    },
+    {
+      "id": "public",
+      "title": "Public degree-sharp theorem and existence corollary",
+      "startLine": 175,
+      "endLine": 186,
+      "summary": "univariate_psd_is_two_sos_deg instantiates the engine at d = deg p, giving the Fejér–Riesz bound for any PSD polynomial; univariate_psd_is_two_sos forgets the two degree inequalities to recover the parent's plain two-square existence statement."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Sharpens the **univariate case of Hilbert's 17th problem** from a bare existence statement to the classical **Fejér–Riesz degree bound**.

The parent file `Proofs/Hilbert17UnivariatePSDSOS.lean` already proves (0-axiom) that every nonnegative real univariate polynomial `p` is a sum of two squares `p = u² + v²`, but says nothing about the *size* of the certificate. This entry adds the degree control that makes the result algorithmically meaningful:

> every nonnegative `p ∈ ℝ[X]` is `u² + v²` with **`2·deg u ≤ deg p`** and **`2·deg v ≤ deg p`** — each square has degree at most `½·deg p`.

This is exactly the degree of the Gram matrix a numerical SOS/SDP solver returns, and it is the natural "full" univariate theorem the OQ `hilbert-17-oq-01-oq-01` asked for.

## Proof

Strong induction on `deg p`, carrying the degree invariant through the **same** induction tree as the parent (reused verbatim: the analytic crux `sq_dvd_of_psd_root` — a real root of a PSD polynomial has even multiplicity — and the Brahmagupta–Fibonacci identity):

- **base** (`p = 0` / constant): degree-0 squares, `2·0 ≤ deg p`.
- **real root** `r`: `(X − C r)² ∣ p`, quotient PSD of degree `deg p − 2`; `u = (X − C r)·u'`, so `2·deg u ≤ 2(1 + deg u') ≤ 2 + deg q = deg p` via `natDegree_mul_le` (the `≤` bound dodges any `u' = 0` case split).
- **non-real root**: positive quadratic `Q = (X − C re z)² + (C im z)²` divides `p`; Brahmagupta gives two squares of degree `≤ 1 + max(deg u', deg v')`, bounded via `natDegree_sub_le`/`natDegree_add_le`, max-split closed by `omega`.

The plain two-square existence statement is recovered as an immediate corollary (`univariate_psd_is_two_sos`).

## Verification

- `proofs/Proofs/Hilbert17OQ01OQ01.lean` — 187 lines, **0 sorries, 0 axioms**.
- `#print axioms univariate_psd_is_two_sos_deg` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`).
- Docker-build verified: `./proofs/scripts/docker-build.sh Proofs.Hilbert17OQ01OQ01` → success.
- Gallery entry `src/data/proofs/hilbert-17-oq-01-oq-01` (meta + 5 annotations); `pnpm annotations:build` validates with no errors for this entry.

## Status

`verified` / badge `original` — discharges OQ `hilbert-17-oq-01-oq-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)