### PR TITLE
Enrich 'Reciprocals of the odd numbers diverge' (harmonic-divergence-oq-06): finer annotations + index.ts

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-06/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-06/annotations.json
@@ -26,10 +26,10 @@
     "id": "ann-hdoq06-main",
     "proofId": "harmonic-divergence-oq-06",
     "range": {
-      "startLine": 38,
+      "startLine": 39,
       "endLine": 64
     },
-    "type": "key_step",
+    "type": "key-step",
     "title": "Main Theorem: Σ 1/(a·n+b) Diverges for a, b > 0",
     "content": "not_summable_one_div_arith proceeds by contradiction. Assuming the progression series is summable, scaling by the constant a+b (Summable.mul_left) keeps it summable. The pointwise comparison 1/(n+1) ≤ (a+b)·(1/(a·n+b)) is established by clearing denominators with le_div_iff₀ and div_le_iff₀ (both denominators are positive since a > 0, b > 0), reducing to a·n+b ≤ (a+b)·(n+1), which nlinarith closes from 0 ≤ a + b·n. The comparison test Summable.of_nonneg_of_le then yields summability of the shifted harmonic series Σ 1/(n+1); summable_nat_add_iff identifies this with summability of Σ 1/n, contradicting Real.not_summable_one_div_natCast.",
     "mathContext": "The crux inequality $a n + b \\le (a+b)(n+1) = (a+b)n + (a+b)$ is equivalent to $0 \\le a + b n$, which holds for all $n \\ge 0$ when $a, b > 0$. Hence $\\frac{1}{n+1} \\le \\frac{a+b}{a n + b}$, exhibiting the harmonic series as dominated by a scalar multiple of the progression series.",
@@ -45,6 +45,54 @@
       "Comparison test Summable.of_nonneg_of_le",
       "Index-shift lemma summable_nat_add_iff",
       "Divergence of the harmonic series"
+    ]
+  },
+  {
+    "id": "ann-hdoq06-comparison",
+    "proofId": "harmonic-divergence-oq-06",
+    "range": {
+      "startLine": 50,
+      "endLine": 58
+    },
+    "type": "key-step",
+    "title": "The crux inequality and why b > 0 matters",
+    "content": "This block establishes the single inequality the whole proof turns on: 1/(n+1) ≤ (a+b)·(1/(a·n+b)), pointwise for every n. After `mul_one_div` rewrites the right side as (a+b)/(a·n+b), the two `…div_iff₀` rewrites clear both denominators — each guarded by a `positivity` proof that the denominator is strictly positive — turning the goal into the polynomial inequality 1·(a·n+b) ≤ (a+b)·(n+1). `push_cast` moves the ℕ→ℝ casts inward and `nlinarith` finishes from a·n+b ≤ (a+b)(n+1) ⟺ 0 ≤ a + b·n, which holds because a, b > 0 and n ≥ 0. The role of the hypothesis b > 0 (not merely b ≥ 0) is precisely to make a·n+b > 0 at n = 0: without it the n = 0 denominator could be a·0 + 0 = 0, the `positivity` guard would fail, and 1/0 = 0 would silently break the comparison at the very first term.",
+    "mathContext": "$a n + b \\le (a+b)(n+1) = (a+b)n + (a+b) \\iff 0 \\le a + b n$, valid for $a,b>0$, $n\\ge 0$. Both denominators $a n + b$ and $n+1$ are positive, which is what licenses clearing them with `le_div_iff₀` / `div_le_iff₀`.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "le_div_iff₀",
+      "div_le_iff₀",
+      "positivity",
+      "nlinarith",
+      "strict positivity of the denominator"
+    ],
+    "prerequisites": [
+      "Manipulating inequalities between positive reals",
+      "Clearing denominators",
+      "Why 1/0 = 0 in Lean breaks naive comparisons"
+    ]
+  },
+  {
+    "id": "ann-hdoq06-contradiction",
+    "proofId": "harmonic-divergence-oq-06",
+    "range": {
+      "startLine": 59,
+      "endLine": 61
+    },
+    "type": "key-step",
+    "title": "Closing the contradiction across the index shift",
+    "content": "The comparison has produced summability of the *shifted* harmonic series Σ 1/(n+1), but Mathlib states harmonic divergence for Σ 1/n (`Real.not_summable_one_div_natCast`), whose n = 0 term is the junk value 1/0 = 0. The two are bridged by `summable_nat_add_iff … 1`, which says Summable (fun n => f (n+1)) ↔ Summable f: dropping or restoring finitely many leading terms never changes summability. Applying its `.mp` direction transports the established summability of Σ 1/(n+1) back to Σ 1/n, which `Real.not_summable_one_div_natCast` refutes — discharging the `intro hsum` assumption and completing the proof by contradiction.",
+    "mathContext": "Summability is invariant under a finite index shift: $\\sum_n f(n+1)$ converges $\\iff \\sum_n f(n)$ converges. So summability of $\\sum 1/(n+1)$ would force summability of $\\sum 1/n$, contradicting harmonic divergence.",
+    "significance": "key",
+    "relatedConcepts": [
+      "summable_nat_add_iff",
+      "Real.not_summable_one_div_natCast",
+      "proof by contradiction",
+      "finite index shift invariance"
+    ],
+    "prerequisites": [
+      "Summability is unchanged by dropping finitely many terms",
+      "The 1/0 = 0 junk term in Mathlib's harmonic statement"
     ]
   },
   {

--- a/src/data/proofs/harmonic-divergence-oq-06/index.ts
+++ b/src/data/proofs/harmonic-divergence-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HarmonicDivergenceOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const harmonicDivergenceOq06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const harmonicDivergenceOq06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const harmonicDivergenceOq06Data: ProofData = {
+  proof: harmonicDivergenceOq06Proof,
+  annotations: harmonicDivergenceOq06Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `harmonic-divergence-oq-06` (quality 83, pass 0).

This entry was already content-complete (conclusion, full overview, references, cross-references) and **already live** (present in listings.json + data-manifest.json). Improvements focus on annotation granularity and a couple of corrections.

## Changes
- **Annotation granularity (3 → 5)**: the dense single 'main theorem' annotation bundled several distinct teachable steps. Added two line-precise annotations:
  - `ann-hdoq06-comparison` (lines 50–58): the crux inequality a·n+b ≤ (a+b)(n+1) ⟺ 0 ≤ a+b·n, the denominator-clearing via `le_div_iff₀`/`div_le_iff₀`, and **why the hypothesis is b > 0 not b ≥ 0** (keeps the n=0 denominator positive, avoiding the 1/0=0 junk term that would break the comparison).
  - `ann-hdoq06-contradiction` (lines 59–61): closing the contradiction by transporting summability of Σ1/(n+1) back to Σ1/n across `summable_nat_add_iff`.
  All 5 annotations carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.
- **Fixed a pre-existing misalignment**: `ann-hdoq06-main` had `startLine: 38` (a blank line → 'No Lean construct found') and the invalid type `key_step`; corrected to `39` / `key-step` so the annotation validator passes.
- **Added `index.ts`** (was missing) for consistency with the gallery shim convention.

## Guardrails
- meta.json 12 KB, well under the 60 KB cap (`gallery:check-size` passes).
- Annotation validator now clean for this entry (previously had 1 standing error).
- 0-axiom verified entry unchanged; no existing content removed.