### PR TITLE
research(puiseux-theorem-oq-03): third invariant on the concrete hull — valuation of the root product [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -1030,4 +1030,52 @@ theorem ysqMinusX_newtonPolygon :
     (by intro a ha b hb hab; fin_cases ha <;> fin_cases hb <;> simp_all)
     (by intro q hq hne; fin_cases hq <;> simp_all)
 
+/-! ### The third invariant on the concrete hull: valuation of the root product
+
+The capstone `exists_lowerHull_newtonPolygon` bundles the *valuation* half (sorted edge
+slopes) and the *multiplicity* half (positive widths summing to the index span) on the
+recursion-built hull.  It omits the third Newton-polygon bookkeeping identity — the
+slope-weighted-by-width drop `Σ (valuationᵢ · multiplicityᵢ) = v(constant) − v(leading)`
+(`neg_sum_slope_mul_width`) — which until now lived only on an *abstract* chain
+hypothesis, never on the chain the algorithm actually walks.  The corollary below lands
+it on the concrete hull, so all three combinatorial invariants of the Newton polygon now
+hold of the same object. -/
+
+/-- **Valuation of the root product, on the concrete recursion-built hull.**  For a
+distinct-index support with strictly-leftmost vertex `p`, the hull chain produced by
+`exists_lowerHull` satisfies the third Newton-polygon invariant: the sum of root
+valuations counted with multiplicity equals the vertical drop between the leftmost and
+rightmost vertices, `−Σ (valuationᵢ · multiplicityᵢ) = p.2 − w.2 = v(constant) −
+v(leading)`.  Combined with `exists_lowerHull_newtonPolygon` (sorted slopes + total
+multiplicity) this puts *all three* combinatorial Newton-polygon invariants on one chain. -/
+theorem exists_lowerHull_valuationProduct {pts : List SupportPoint} (p : SupportPoint)
+    (hp : p ∈ pts)
+    (hdist : ∀ a ∈ pts, ∀ b ∈ pts, a.1 = b.1 → a = b)
+    (hleft : ∀ q ∈ pts, q ≠ p → p.1 < q.1) :
+    ∃ (vs : List SupportPoint) (w : SupportPoint),
+      List.IsChain (IsLowerEdge pts) (p :: vs) ∧
+      (p :: vs).getLast? = some w ∧ w ∈ pts ∧ (∀ r ∈ pts, r.1 ≤ w.1) ∧
+      -(List.zipWith (· * ·) (edgeSlopes (p :: vs)) (edgeWidths (p :: vs))).sum
+        = p.2 - w.2 := by
+  obtain ⟨vs, w, hchain, hlast, hw, hwmax⟩ := exists_lowerHull p hp hdist hleft
+  have hgl : (p :: vs).getLast (by simp) = w := by
+    obtain ⟨_, hwgl⟩ := List.mem_getLast?_eq_getLast hlast
+    exact hwgl.symm
+  refine ⟨vs, w, hchain, hlast, hw, hwmax, ?_⟩
+  rw [neg_sum_slope_mul_width hchain, hgl]
+
+/-- `Y² − x`: the valuation of the root product read straight off the hull endpoints.
+`−Σ (valuationᵢ · multiplicityᵢ) = 1 − 0 = 1` — the constant coefficient `(0,1)` sits one
+unit above the leading coefficient `(2,0)`, so the single root has valuation `½` with
+multiplicity `2`, total `1`. -/
+theorem ysqMinusX_valuationProduct :
+    ∃ (vs : List SupportPoint) (w : SupportPoint),
+      List.IsChain (IsLowerEdge YsqMinusX) ((0, 1) :: vs) ∧
+      ((0, 1) :: vs).getLast? = some w ∧ w ∈ YsqMinusX ∧ (∀ r ∈ YsqMinusX, r.1 ≤ w.1) ∧
+      -(List.zipWith (· * ·) (edgeSlopes ((0, 1) :: vs)) (edgeWidths ((0, 1) :: vs))).sum
+        = (1 : ℚ) - w.2 :=
+  exists_lowerHull_valuationProduct (0, 1) (by simp [YsqMinusX])
+    (by intro a ha b hb hab; fin_cases ha <;> fin_cases hb <;> simp_all)
+    (by intro q hq hne; fin_cases hq <;> simp_all)
+
 end PuiseuxTheoremOQ03

--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -351,3 +351,38 @@ file itself, `env lean`, then revert.
 Verification: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean
 Proofs/PuiseuxTheoremOQ03.lean` exits 0 (host toolchain, single-file against
 prebuilt Mathlib oleans).
+
+---
+
+## Session (2026-06-28, researcher-1): third invariant on the concrete hull
+
+The capstone `exists_lowerHull_newtonPolygon` bundled two of the three Newton-polygon
+invariants onto the recursion-built hull (sorted edge slopes = valuation half; positive
+widths summing to the index span = multiplicity half), but the **third** invariant — the
+slope-weighted-by-width drop `−Σ (valuationᵢ · multiplicityᵢ) = v(constant) − v(leading)`
+(`neg_sum_slope_mul_width`, session 6) — still floated on an *abstract* `IsChain` hypothesis
+and had never been discharged on the concrete chain the algorithm walks. This session lands
+it. File 1033→1081 lines, 51→53 theorems, still **0 sorries / 0 axioms** (`#print axioms`
+on both new results = propext/Classical.choice/Quot.sound only).
+
+* `exists_lowerHull_valuationProduct` (PuiseuxTheoremOQ03.lean) — for a distinct-index
+  support with strictly-leftmost vertex `p`, the hull chain from `exists_lowerHull`
+  satisfies `−(zipWith (·*·) (edgeSlopes (p::vs)) (edgeWidths (p::vs))).sum = p.2 − w.2`,
+  i.e. the sum of root valuations counted with multiplicity equals the vertical drop
+  between leftmost and rightmost vertices. Two lines: destructure `exists_lowerHull`, the
+  same `getLast? → getLast` bridge as the capstone (`List.mem_getLast?_eq_getLast`), then
+  `rw [neg_sum_slope_mul_width hchain, hgl]`.
+* `ysqMinusX_valuationProduct` — the `Y²−x` worked instance: `−Σ = 1 − 0 = 1` (single root,
+  valuation ½, multiplicity 2).
+
+**Why this matters.** With this, *all three* combinatorial Newton-polygon invariants
+(sorted valuations, total multiplicity, valuation-of-root-product) now hold of the **same
+concrete hull** the Newton–Puiseux recursion produces — the capstone bundle plus this
+corollary close the gap where the third invariant lived only abstractly. Only the analytic
+bridge (slopes/widths ↔ actual roots of `P ∈ K((x))[Y]`) remains, still blocked on a
+`K((x))[Y]` valuation API absent from Mathlib 4.26.0.
+
+Verification: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean`
+exits 0 (~34s, host toolchain, single-file against prebuilt Mathlib oleans). `#print axioms`
+checked by appending the print lines, `env lean`, then reverting (importing the module to a
+fresh file to print axioms segfaults with no built olean).

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -245,9 +245,9 @@
       "Mathlib.Data.List.Sort"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 1033,
+    "lineCount": 1081,
     "axiomCount": 0,
-    "theoremCount": 51,
+    "theoremCount": 53,
     "definitionCount": 8,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Lands the **third** combinatorial Newton-polygon invariant on the concrete recursion-built hull, completing the unification the capstone left at two-of-three.

Prior sessions built three parallel invariants of the Newton polygon:
1. **valuation half** — `edgeSlopes_pairwise_le` (sorted root valuations)
2. **multiplicity half** — `sum_edgeWidths` / `edgeWidths_pos` (widths sum to the degree)
3. **valuation-of-root-product** — `neg_sum_slope_mul_width`: `−Σ(valuationᵢ·multiplicityᵢ) = v(constant) − v(leading)`

The capstone `exists_lowerHull_newtonPolygon` discharged (1) and (2) on the concrete chain that `exists_lowerHull` builds, but (3) still lived only on an **abstract** `IsChain (IsLowerEdge pts)` hypothesis — never on the chain the Newton–Puiseux recursion actually walks. This PR closes that gap.

## What's new

- **`exists_lowerHull_valuationProduct`** — for a distinct-index support with strictly-leftmost vertex `p`, the hull chain from `exists_lowerHull` satisfies
  `−(zipWith (·*·) (edgeSlopes (p::vs)) (edgeWidths (p::vs))).sum = p.2 − w.2`,
  i.e. the sum of root valuations counted with multiplicity equals the vertical drop between the leftmost and rightmost vertices = `v(constant) − v(leading)`. Two lines: destructure `exists_lowerHull`, the same `getLast? → getLast` bridge as the capstone, then `rw [neg_sum_slope_mul_width, hgl]`.
- **`ysqMinusX_valuationProduct`** — the `Y²−x` worked instance: `−Σ = 1 − 0 = 1` (single root, valuation ½, multiplicity 2).

With these, **all three** combinatorial Newton-polygon invariants now hold of the **same concrete hull**. Only the analytic bridge (slopes/widths ↔ actual roots of `P ∈ K((x))[Y]`) remains, still blocked on a `K((x))[Y]` valuation API absent from Mathlib 4.26.0.

## Verification

- `1033 → 1081` lines, `51 → 53` theorems, **0 sorries / 0 axioms**
- `#print axioms` on both new results = `propext` / `Classical.choice` / `Quot.sound` only
- `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean` exits 0 (~34s, single-file against prebuilt Mathlib oleans)

🤖 Generated with [Claude Code](https://claude.com/claude-code)