### PR TITLE
Enrich 'L'Hôpital via Taylor expansion' (lhopital-oq-04): add header annotation

### DIFF
--- a/src/data/proofs/lhopital-oq-04/annotations.json
+++ b/src/data/proofs/lhopital-oq-04/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-lhoq04-header",
+    "proofId": "lhopital-oq-04",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "concept",
+    "title": "Why a Taylor route to L'Hôpital, and what replaces the MVT",
+    "content": "The parent entry `LHopital` proves the 0/0 rule through the Mean Value Theorem (Mathlib's `HasDerivAt.lhopital_zero_right`, which produces an auxiliary point ξ via Cauchy's MVT). OQ-04 asks for the *Taylor* viewpoint instead: if f and g both vanish at a, then near a each equals its leading linear Taylor term, f(x) ≈ f′(a)(x−a) and g(x) ≈ g′(a)(x−a), so their ratio tends to f′(a)/g′(a) simply because the shared (x−a) factor cancels. The file replaces the MVT's existential ξ with a single limit — the derivative-as-slope statement `HasDerivAt.tendsto_slope` — and pure limit arithmetic. The module imports only Mathlib and opens `Filter`/`Topology` for the punctured-neighbourhood filter 𝓝[≠] a in which every limit here lives.",
+    "mathContext": "Indeterminate $0/0$: $f(a)=g(a)=0$. Leading-order Taylor: $f(x)=f'(a)(x-a)+o(x-a)$, so $\\frac{f(x)}{g(x)}=\\frac{f'(a)(x-a)+o(x-a)}{g'(a)(x-a)+o(x-a)}\\to\\frac{f'(a)}{g'(a)}$ — no intermediate point required.",
+    "significance": "context",
+    "relatedConcepts": ["L'Hôpital's rule", "Taylor expansion", "Cauchy Mean Value Theorem", "punctured neighbourhood filter", "indeterminate forms"],
+    "prerequisites": ["the 0/0 indeterminate form", "Taylor's theorem at first order", "limits along a filter"]
+  },
+  {
     "id": "ann-leading-order",
     "proofId": "lhopital-oq-04",
     "range": { "startLine": 39, "endLine": 53 },


### PR DESCRIPTION
Enrichment pass for `lhopital-oq-04` (quality 83, pass 0). Already content-complete and live; this fills the one annotation-coverage gap.

## Change
- **Annotation coverage (3 → 4)**: lines 1–38 (the module docstring + imports) had no annotation — every theorem was covered but the framing header was not. Added `ann-lhoq04-header` explaining *why* the Taylor route is pursued (the parent proves 0/0 via the Cauchy MVT; this entry replaces the auxiliary point ξ with the derivative-as-slope limit `HasDerivAt.tendsto_slope` and pure limit arithmetic), and the role of the punctured-neighbourhood filter 𝓝[≠] a. All 4 annotations carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites`; the file is now fully covered.

## Guardrails
- meta.json ~11 KB, far under the 60 KB cap.
- Annotation validator clean for this entry; JSON valid.
- 0-axiom verified entry unchanged; no existing content removed.