### PR TITLE
Enrich 'Ptolemy's inequality via inversion' (ptolemys-theorem-oq-05): header annotation + index.ts

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-05/annotations.json
+++ b/src/data/proofs/ptolemys-theorem-oq-05/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-ptoq05-header",
+    "proofId": "ptolemys-theorem-oq-05",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "Why inversion, and what the plane proof cannot reach",
+    "content": "The gallery already proves Ptolemy's inequality in the plane (`PtolemysComplexProof.lean`) from the complex algebraic identity (z₁−z₃)(z₂−z₄) = (z₁−z₂)(z₃−z₄) + (z₁−z₄)(z₂−z₃) plus |z+w| ≤ |z|+|w|. That identity lives in the commutative ring ℂ and so is **intrinsically two-dimensional** — it has no analogue in ℝⁿ. Mathlib, separately, proves only the *equality* case for cospherical points. This file closes the gap: Ptolemy's inequality is really a metric statement, true for four arbitrary points of any real inner product space in any dimension. The dimension-free engine is the classical proof by **spherical inversion** x ↦ (‖x‖²)⁻¹•x, which scales the distance between u and w by exactly 1/(‖u‖‖w‖); the triangle inequality among three inverted points, after clearing denominators, becomes Ptolemy. The setup fixes a real inner product space V (`NormedAddCommGroup` + `InnerProductSpace ℝ V`) and opens `RealInnerProductSpace` for the ⟪·,·⟫ notation.",
+    "mathContext": "Inversion in the unit sphere at the origin, $x \\mapsto \\frac{x}{\\|x\\|^2}$, has the distance law $\\left\\|\\frac{u}{\\|u\\|^2}-\\frac{w}{\\|w\\|^2}\\right\\| = \\frac{\\|u-w\\|}{\\|u\\|\\,\\|w\\|}$. Triangle inequality for the three images $\\Rightarrow$ Ptolemy $\\|x-z\\|\\|y\\| \\le \\|x-y\\|\\|z\\| + \\|y-z\\|\\|x\\|$.",
+    "significance": "context",
+    "relatedConcepts": ["spherical inversion", "real inner product space", "dimension-free geometry", "triangle inequality", "complex-number proof (planar)"],
+    "prerequisites": ["inner product spaces", "the norm and distance on a normed space", "geometric inversion"]
+  },
+  {
     "id": "ann-inversion-dist",
     "proofId": "ptolemys-theorem-oq-05",
     "range": { "startLine": 57, "endLine": 87 },

--- a/src/data/proofs/ptolemys-theorem-oq-05/index.ts
+++ b/src/data/proofs/ptolemys-theorem-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PtolemyInequalityInnerProduct.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const ptolemysTheoremOq05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const ptolemysTheoremOq05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const ptolemysTheoremOq05Data: ProofData = {
+  proof: ptolemysTheoremOq05Proof,
+  annotations: ptolemysTheoremOq05Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `ptolemys-theorem-oq-05` (quality 83, pass 0). Already content-complete and live.

## Changes
- **Annotation coverage (3 → 4)**: the module docstring (lines 1–53) was unannotated — all three theorems were covered but not the framing. Added `ann-ptoq05-header` explaining why inversion is used (the gallery's complex-number proof is intrinsically 2D; Mathlib only has the cospherical *equality* case), the inversion distance law ‖u/‖u‖²−w/‖w‖²‖ = ‖u−w‖/(‖u‖‖w‖), and the real-inner-product-space setup. File now fully covered; all 4 annotations carry every enrichment field.
- **Added `index.ts`** (was missing).

## Guardrails
- meta.json ~10.5 KB, far under the 60 KB cap.
- Annotation validator clean; JSON valid; 0-axiom verified entry unchanged; no content removed.