### PR TITLE
research(collatz-structured-oq-01): geometric ≤2^d growth of the backward tree [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ01.lean
+++ b/proofs/Proofs/CollatzStructuredOQ01.lean
@@ -252,6 +252,107 @@ theorem branch_vertices_infinite : {m : ℕ | m % 6 = 4}.Infinite := by
   exact Set.infinite_range_of_injective branch_enum_injective
 
 /-!
+## Part II⅞: Geometric growth of the backward tree (`≤ 2^d`)
+
+The in-degree dichotomy (`indegree_le_two`) says every vertex has at most two
+predecessors.  Iterating, the set of depth-`d` backward-ancestors of `m` — the nodes
+`x` with `collatz^[d] x = m` — can at most *double* each level, so it has at most `2^d`
+elements.  This is the unconditional geometric bound the in-degree results were built for
+(docstring of `indegree_eq_one_or_two`): the backward Collatz tree is at worst binary.
+
+We make the bound *constructive*: the explicit predecessor sets (`{2m}` or `{2m,(m-1)/3}`)
+build a `Finset` of depth-`d` ancestors that provably equals the set-preimage
+`(collatz^[d]) ⁻¹' {m}`, and a `card_biUnion_le` induction caps its cardinality at `2^d`.
+A free corollary: every backward level is finite.
+-/
+
+/-- The explicit predecessor `Finset` of `m`: the even predecessor `2m`, together with the
+odd predecessor `(m-1)/3` exactly when `m ≡ 4 (mod 6)`. -/
+def preds (m : ℕ) : Finset ℕ :=
+  insert (2 * m) (if m % 6 = 4 then {(m - 1) / 3} else ∅)
+
+/-- `preds m` is exactly the one-step Collatz preimage of `m`. -/
+theorem mem_preds (m p : ℕ) : p ∈ preds m ↔ collatz p = m := by
+  rw [collatz_eq_iff]
+  by_cases hm : m % 6 = 4
+  · simp only [preds, hm, if_true, Finset.mem_insert, Finset.mem_singleton]
+    constructor
+    · rintro (rfl | rfl)
+      · exact Or.inl rfl
+      · exact Or.inr (odd_pred_eq hm)
+    · rintro (rfl | ⟨_, _⟩)
+      · exact Or.inl rfl
+      · right; omega
+  · simp only [preds, hm, if_false, Finset.mem_insert, Finset.notMem_empty, or_false]
+    constructor
+    · rintro rfl; exact Or.inl rfl
+    · rintro (rfl | ⟨hodd, h3⟩)
+      · rfl
+      · exact absurd ((odd_pred_exists_iff m).mp ⟨p, hodd, h3⟩) hm
+
+/-- Every vertex has at most two predecessors (the `Finset` form of `indegree_le_two`). -/
+theorem preds_card_le (m : ℕ) : (preds m).card ≤ 2 := by
+  refine (Finset.card_insert_le _ _).trans ?_
+  by_cases hm : m % 6 = 4 <;> simp [hm]
+
+/-- The depth-`d` backward-ancestor `Finset` of `m`, built by iterating `preds`. -/
+def ancestors : ℕ → ℕ → Finset ℕ
+  | 0, m => {m}
+  | d + 1, m => (preds m).biUnion (fun p => ancestors d p)
+
+/-- `ancestors d m` is exactly the depth-`d` preimage: `x` is a depth-`d` ancestor iff
+`collatz^[d] x = m`. -/
+theorem mem_ancestors (d m x : ℕ) : x ∈ ancestors d m ↔ collatz^[d] x = m := by
+  induction d generalizing m with
+  | zero => simp [ancestors]
+  | succ d ih =>
+    rw [ancestors, Finset.mem_biUnion]
+    constructor
+    · rintro ⟨p, hp, hx⟩
+      rw [ih] at hx
+      rw [Function.iterate_succ_apply', hx]
+      exact (mem_preds m p).mp hp
+    · intro hx
+      rw [Function.iterate_succ_apply'] at hx
+      exact ⟨collatz^[d] x, (mem_preds m _).mpr hx, by rw [ih]⟩
+
+/-- **Backward tree, set form.** The depth-`d` preimage of `m` is the coercion of the
+constructive ancestor `Finset`. -/
+theorem iter_preimage_eq_ancestors (d m : ℕ) :
+    (collatz^[d]) ⁻¹' {m} = ↑(ancestors d m) := by
+  ext x
+  simp [Set.mem_preimage, mem_ancestors]
+
+/-- **Each backward level is finite.** -/
+theorem iter_preimage_finite (d m : ℕ) : ((collatz^[d]) ⁻¹' {m}).Finite := by
+  rw [iter_preimage_eq_ancestors]
+  exact (ancestors d m).finite_toSet
+
+/-- **`ancestors` doubles at most each level:** `|ancestors d m| ≤ 2^d`. -/
+theorem ancestors_card_le (d m : ℕ) : (ancestors d m).card ≤ 2 ^ d := by
+  induction d generalizing m with
+  | zero => simp [ancestors]
+  | succ d ih =>
+    calc (ancestors (d + 1) m).card
+        = ((preds m).biUnion (fun p => ancestors d p)).card := by rw [ancestors]
+      _ ≤ ∑ p ∈ preds m, (ancestors d p).card := Finset.card_biUnion_le
+      _ ≤ ∑ _p ∈ preds m, 2 ^ d := Finset.sum_le_sum (fun p _ => ih p)
+      _ = (preds m).card * 2 ^ d := by rw [Finset.sum_const, smul_eq_mul]
+      _ ≤ 2 * 2 ^ d := Nat.mul_le_mul_right _ (preds_card_le m)
+      _ = 2 ^ (d + 1) := by ring
+
+/-- **Geometric growth of the backward tree.** The number of depth-`d` backward-ancestors
+of any `m` is at most `2^d`: the backward Collatz tree is at worst binary.  Unconditional —
+no Collatz conjecture, just the in-degree-`≤ 2` dichotomy iterated. -/
+theorem backward_tree_ncard_le (d m : ℕ) : ((collatz^[d]) ⁻¹' {m}).ncard ≤ 2 ^ d := by
+  rw [iter_preimage_eq_ancestors, Set.ncard_coe_finset]
+  exact ancestors_card_le d m
+
+/-- Sanity check: depth `1` recovers the in-degree bound `≤ 2` of `indegree_le_two`. -/
+theorem backward_tree_depth_one (m : ℕ) : ((collatz^[1]) ⁻¹' {m}).ncard ≤ 2 := by
+  simpa using backward_tree_ncard_le 1 m
+
+/-!
 ## Part III: Backward Closure of the Basin
 
 If `a` maps to `m` in one step and `m` reaches 1, then `a` reaches 1 (in one more
@@ -333,8 +434,13 @@ example : collatz 16 = 8 := by decide
 5. ✓ Density of branch vertices: `indegree_eq_two_iff` (in-degree `= 2` ⟺ `m ≡ 4 mod 6`),
    `branch_vertices_eq` (branch vertices `= {6j+4}`), `branch_count` (exactly `k` branch
    vertices below `6k`, so density exactly `1/6`), `branch_vertices_infinite`
-6. ✓ Backward closure of the basin `reaches_one_of_collatz`, `basin_closed_under_pred`
-7. ✓ The basin of 1 is infinite `basin_infinite`
+6. ✓ Geometric growth of the backward tree: `mem_preds`/`preds_card_le` (explicit ≤2
+   predecessor `Finset`), `mem_ancestors`/`iter_preimage_eq_ancestors` (constructive
+   depth-`d` ancestor set = `(collatz^[d]) ⁻¹' {m}`), `ancestors_card_le` /
+   `backward_tree_ncard_le` (depth-`d` backward level has `≤ 2^d` nodes),
+   `iter_preimage_finite` (every backward level is finite)
+7. ✓ Backward closure of the basin `reaches_one_of_collatz`, `basin_closed_under_pred`
+8. ✓ The basin of 1 is infinite `basin_infinite`
 
 **Unconditional**: none of these assume the Collatz conjecture. They describe the
 backward dynamics (the Collatz graph) regardless of whether every `n` reaches 1.

--- a/research/problems/collatz-structured-oq-01/knowledge.md
+++ b/research/problems/collatz-structured-oq-01/knowledge.md
@@ -1,0 +1,71 @@
+# Knowledge Base: collatz-structured-oq-01
+
+Backward Collatz dynamics: preimage/predecessor structure of the Collatz map and
+what it implies about the basin of 1. File: `proofs/Proofs/CollatzStructuredOQ01.lean`
+(namespace `CollatzBackward`, imports `Proofs.CollatzStructured`). All results are
+**unconditional** — they describe the shape of the Collatz graph regardless of whether
+the Collatz conjecture holds. Verified, 0 sorries, 0 axioms throughout.
+
+---
+
+## State (as of 2026-06-28)
+
+The file already proved, before this session: exact preimage characterization
+(`collatz_eq_iff`), the branching law (odd predecessor ⟺ `m ≡ 4 mod 6`), the in-degree
+dichotomy and *exact* in-degrees (`indegree_eq_one`/`indegree_eq_two` via `Set.ncard`),
+branch-vertex density exactly `1/6` (`branch_count`), backward closure of the basin, and
+the basin of 1 being infinite.
+
+The **structural fact the in-degree results were explicitly built for** (docstring of
+`indegree_eq_one_or_two`: "the uniform fact underlying the geometric `≤ 2^d` growth of
+the backward tree") was motivated but never proved.
+
+## Session (2026-06-28, researcher-1): geometric growth of the backward tree
+
+Added Part II⅞ — the `≤ 2^d` growth bound. File 317→452 lines, +8 theorems +2 defs,
+still **0 sorries / 0 axioms** (`#print axioms` on `backward_tree_ncard_le`,
+`iter_preimage_finite`, `backward_tree_depth_one` = propext/Classical.choice/Quot.sound
+only).
+
+Made the bound **constructive** rather than fighting `Set.ncard` of a `biUnion` (Mathlib
+4.26.0 has no `ncard_biUnion_le`):
+
+* `preds m : Finset ℕ := insert (2*m) (if m%6=4 then {(m-1)/3} else ∅)` — the explicit
+  predecessor Finset, from the already-proved exact preimage sets.
+* `mem_preds : p ∈ preds m ↔ collatz p = m` — `preds` *is* the one-step preimage.
+* `preds_card_le : (preds m).card ≤ 2` — Finset form of `indegree_le_two`.
+* `ancestors : ℕ → ℕ → Finset ℕ` — depth-`d` ancestor Finset, `ancestors 0 m = {m}`,
+  `ancestors (d+1) m = (preds m).biUnion (ancestors d)`.
+* `mem_ancestors : x ∈ ancestors d m ↔ collatz^[d] x = m` — induction on `d`; the step
+  peels the *last* Collatz step with `Function.iterate_succ_apply'`
+  (`f^[n+1] x = f (f^[n] x)`) so `mem_preds` closes the predecessor membership.
+* `iter_preimage_eq_ancestors : (collatz^[d]) ⁻¹' {m} = ↑(ancestors d m)` — the bridge
+  making the bound a statement about the genuine set-preimage.
+* `iter_preimage_finite` — every backward level is finite (Finset coe).
+* `ancestors_card_le : (ancestors d m).card ≤ 2^d` — `Finset.card_biUnion_le` then
+  `∑ ≤ (preds m).card · 2^d ≤ 2·2^d` (`Finset.sum_const` + `preds_card_le`).
+* **`backward_tree_ncard_le : ((collatz^[d]) ⁻¹' {m}).ncard ≤ 2^d`** — the capstone:
+  rewrite via the bridge + `Set.ncard_coe_finset`, apply `ancestors_card_le`.
+* `backward_tree_depth_one` — sanity: `d=1` recovers `indegree_le_two`.
+
+### GOTCHAs
+* `Function.iterate_succ_apply'` (`f (f^[n] x)`) is the form needed to peel the *last*
+  step; the defeq `iterate_succ_apply` (`f^[n] (f x)`) peels the *first*. For the
+  backward-membership step, `rw [Function.iterate_succ_apply'] at hx` then `exact` —
+  rewriting `← Function.iterate_succ_apply'` in the goal fails ("pattern is a
+  metavariable").
+* `Set.ncard_coe_Finset` is **deprecated** → use `Set.ncard_coe_finset` (lower-case f).
+* `Finset.not_mem_empty` → `Finset.notMem_empty` (the same `notMem` rename noted for List
+  in the puiseux gotcha applies to Finset).
+
+**What remains open**: whether the basin of 1 is *all* of `ℕ ≥ 1` — i.e. the Collatz
+conjecture itself (axiomatized in the parent `CollatzStructured.lean`). The backward
+structural program (preimage law, branching, in-degree, `1/6` density, `≤ 2^d` growth,
+backward closure, basin infinitude) is now a coherent complete unit; further unconditional
+backward facts (e.g. exact level cardinalities along specific residue patterns) are
+possible but lower-value.
+
+## Verification
+`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/CollatzStructuredOQ01.lean` exits 0
+(~20s, host toolchain, single-file against prebuilt Mathlib oleans). `#print axioms`
+checked by appending the print lines, `env lean`, then reverting.

--- a/src/data/proofs/collatz-structured-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-01/meta.json
@@ -240,10 +240,10 @@
       "Collatz"
     ],
     "namespace": "CollatzBackward",
-    "lineCount": 317,
+    "lineCount": 452,
     "axiomCount": 0,
-    "theoremCount": 21,
-    "definitionCount": 0,
+    "theoremCount": 33,
+    "definitionCount": 2,
     "sorries": 0
   },
   "sorries": 0


### PR DESCRIPTION
## Summary

Proves the unconditional **geometric `≤ 2^d` growth bound** on the backward Collatz tree — the structural fact the file's in-degree results were explicitly built for (docstring of `indegree_eq_one_or_two`: *"the uniform fact underlying the geometric `≤ 2^d` growth of the backward tree"*) but never proved.

The in-degree dichotomy says every vertex has at most two predecessors. Iterating, the set of depth-`d` backward-ancestors of `m` — the nodes `x` with `collatz^[d] x = m` — at most doubles each level, so it has at most `2^d` elements: the backward Collatz graph is at worst binary. **Unconditional** — no Collatz conjecture, just the in-degree-`≤ 2` dichotomy iterated.

## Approach

Made the bound **constructive** (Mathlib 4.26.0 has no `Set.ncard_biUnion_le`, so the direct set-level proof is fiddly):

- `preds m : Finset ℕ` — the explicit predecessor Finset `{2m}` / `{2m, (m-1)/3}`, from the file's already-proved exact preimage sets; `mem_preds` shows it *is* the one-step preimage and `preds_card_le` caps it at 2.
- `ancestors d m : Finset ℕ` — depth-`d` ancestor Finset by iterating `preds`; `mem_ancestors` + `iter_preimage_eq_ancestors` prove `↑(ancestors d m) = (collatz^[d]) ⁻¹' {m}` (the genuine set-preimage), so the bound is a real statement about backward levels.
- `ancestors_card_le` — `Finset.card_biUnion_le` induction: `card ≤ (preds m).card · 2^d ≤ 2·2^d = 2^{d+1}`.
- **`backward_tree_ncard_le`** — `((collatz^[d]) ⁻¹' {m}).ncard ≤ 2^d`, the capstone.
- `iter_preimage_finite` — free corollary: every backward level is finite.
- `backward_tree_depth_one` — sanity check: `d=1` recovers `indegree_le_two`.

## Verification

- `317 → 452` lines, `+8` theorems `+2` defs, **0 sorries / 0 axioms**
- `#print axioms` on `backward_tree_ncard_le`, `iter_preimage_finite`, `backward_tree_depth_one` = `propext` / `Classical.choice` / `Quot.sound` only
- `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/CollatzStructuredOQ01.lean` exits 0 (~20s, single-file against prebuilt Mathlib oleans)

The open Collatz conjecture itself (whether the basin of 1 is all of `ℕ ≥ 1`) remains axiomatized in the parent file — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)