### PR TITLE
Enrich 'Cayley–Menger polynomials are determinants' (herons-formula-oq-05-oq-03): header annotation + alignment fixes

### DIFF
--- a/src/data/proofs/herons-formula-oq-05-oq-03/annotations.json
+++ b/src/data/proofs/herons-formula-oq-05-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-cmoq0503-header",
+    "proofId": "herons-formula-oq-05-oq-03",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "context",
+    "title": "Certifying an asserted-but-unproven claim",
+    "content": "The parent entry (`CayleyMengerHeronOQ05`) defines the Cayley–Menger *polynomials* cmDet3 (triangle) and cmDet4 (tetrahedron) as hand-expanded polynomials in the squared edge lengths, and proves they equal −16·Area² and 288·V². Their docstrings *assert* that these polynomials are the determinants of the bordered squared-distance matrices (the border-of-ones layout shown in the header), but the parent never **certifies** that — the polynomials are just typed in by hand. This file closes the parent's open question oq-03: it builds the bordered matrices as honest `Matrix (Fin 4) (Fin 4) ℝ` and `Matrix (Fin 5) (Fin 5) ℝ` objects and proves by Laplace cofactor expansion that `Matrix.det` of each literally equals the parent polynomial — upgrading an asserted identity to a machine-checked one. The polynomial and geometric-scalar definitions are reproduced verbatim from the parent so the file machine-checks standalone.",
+    "mathContext": "Bordered squared-distance (Cayley–Menger) matrix $\\det\\begin{psmallmatrix}0&1&1&1\\\\1&0&d_{01}&d_{02}\\\\1&d_{01}&0&d_{12}\\\\1&d_{02}&d_{12}&0\\end{psmallmatrix} = -16\\,\\mathrm{Area}^2$, and the $5\\times5$ analogue $=288\\,V^2$. Mathlib has `det_fin_three` but no `det_fin_four`/`det_fin_five`, so these come from the general Laplace expansion `Matrix.det_succ_row_zero` down to the $3\\times3$ base.",
+    "significance": "context",
+    "relatedConcepts": ["Cayley–Menger determinant", "Laplace cofactor expansion", "bordered matrix", "Heron's formula", "certifying an assertion"],
+    "prerequisites": ["determinants of small matrices", "Matrix.det in Mathlib", "Heron / Cayley–Menger background"]
+  },
+  {
     "id": "ann-det-fin-four",
     "proofId": "herons-formula-oq-05-oq-03",
     "range": {
@@ -28,7 +40,7 @@
     "proofId": "herons-formula-oq-05-oq-03",
     "range": {
       "startLine": 77,
-      "endLine": 122
+      "endLine": 120
     },
     "type": "theorem",
     "title": "The Triangle Polynomial Is the 4×4 Determinant",
@@ -56,7 +68,7 @@
     "id": "ann-tetrahedron",
     "proofId": "herons-formula-oq-05-oq-03",
     "range": {
-      "startLine": 123,
+      "startLine": 122,
       "endLine": 189
     },
     "type": "theorem",

--- a/src/data/proofs/herons-formula-oq-05-oq-03/index.ts
+++ b/src/data/proofs/herons-formula-oq-05-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CayleyMengerHeronOQ0503.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const heronsFormulaOq05Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const heronsFormulaOq05Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const heronsFormulaOq05Oq03Data: ProofData = {
+  proof: heronsFormulaOq05Oq03Proof,
+  annotations: heronsFormulaOq05Oq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `herons-formula-oq-05-oq-03` (quality 83, pass 0). Already content-complete and live.

## Changes
- **Annotation coverage (3 → 4)**: the module docstring (lines 1–44) was unannotated. Added `ann-cmoq0503-header` explaining the point of the entry — the parent *asserts* (in docstrings) that cmDet3/cmDet4 are the bordered Cayley–Menger determinants but never certifies it; this file builds honest `Matrix` objects and proves `det = polynomial` by Laplace expansion, plus the determinant forms det = −16·Area² and det = 288·V².
- **Fixed a pre-existing misalignment**: `ann-tetrahedron` had `startLine: 123` (a blank line → 'No Lean construct found'); moved to `122` (the section-doc, which accepts the `theorem` type) and trimmed `ann-triangle` `endLine` 122 → 120 to avoid overlap.
- **Added `index.ts`** (was missing).

## Guardrails
- meta.json under the 60 KB cap; annotation validator now clean (previously 1 standing error); JSON valid; 0-axiom verified entry unchanged; no content removed.