### PR TITLE
research(fermat-defect-one-oq-06): explicit sign-flip involution Ψ(a,b,c)=(c,−b,a) negating the cubic defect [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3003,6 +3003,7 @@ import Proofs.FermatDefectOneFamilies
 import Proofs.FermatDefectOneNegInfinitude
 import Proofs.FermatDefectOneOQ03
 import Proofs.FermatDefectOneOQ04
+import Proofs.FermatDefectOneOQ06
 import Proofs.FermatsLastTheorem
 import Proofs.FermatsLastTheoremOQ03
 import Proofs.FermatTwoSquares

--- a/proofs/Proofs/FermatDefectOneOQ06.lean
+++ b/proofs/Proofs/FermatDefectOneOQ06.lean
@@ -1,0 +1,194 @@
+/-
+  Fermat Defect-One — OQ-06: the sign-flip structural map
+
+  Parent problem (`Proofs.FermatDefectOne`): does the Fermat defect
+  $|a^n + b^n - c^n|$ ever equal exactly $1$ for a primitive nontrivial triple
+  $2 \le a \le b < c$, $\gcd(a,b,c) = 1$?  At $n = 3$ both signs are witnessed,
+  each along an explicit Mahler family (`FermatDefectOneFamilies.lean`,
+  `FermatDefectOneNegInfinitude.lean`):
+
+      negative defect  $a^3 + b^3 + 1 = c^3$   (i.e. $a^3+b^3-c^3 = -1$)
+      positive defect  $a^3 + b^3 = c^3 + 1$   (i.e. $a^3+b^3-c^3 = +1$)
+
+  OQ-06 asks the **symmetry-between-signs** question: is there a *structural map*
+  (sign-flip / involution) carrying negative-defect witnesses to positive-defect
+  witnesses and back?
+
+  ## Answer: yes — an explicit involution that negates the cubic defect
+
+  Working over `ℤ` (so the `±1` is a single signed quantity rather than a
+  `Nat`-disjunction), define
+
+      Ψ(a, b, c) = (c, -b, a).
+
+  Then `Ψ` is an **involution** (`Ψ ∘ Ψ = id`, `signFlip_involutive`) and it
+  **negates the cubic defect**:
+
+      (Ψ(a,b,c) as (a',b',c')):   a'^3 + b'^3 - c'^3 = -(a^3 + b^3 - c^3)
+      (`signFlip_negates_defect`).
+
+  Consequently `Ψ` carries every integer negative-defect solution to a
+  positive-defect solution and vice versa (`signFlip_neg_to_pos`,
+  `signFlip_pos_to_neg`).  This is the structural sign-flip map OQ-06 asks for.
+
+  ## Compatibility with the Mahler families
+
+  The two gallery families are
+      negTriple t = (9t⁴ − 3t, 9t³ − 1, 9t⁴)      (negative defect, `defect_neg_family`)
+      posTriple t = (9t⁴,      9t³ + 1, 9t⁴ + 3t)  (positive defect, `defect_pos_family`)
+  and on these families `Ψ` is exactly the **parameter-negation** `t ↦ −t`:
+
+      Ψ(negTriple t) = posTriple (−t)        (`signFlip_negTriple`)
+      Ψ(posTriple t) = negTriple (−t)        (`signFlip_posTriple`).
+
+  So the sign symmetry of the defect at $n = 3$ is the involution `t ↦ −t` of
+  Mahler's parametrization of $x^3 + y^3 + z^3 = 1$, realised pointwise by `Ψ`.
+  The canonical taxicab witness `(9,10,12)` is `Ψ` applied to the negative-defect
+  point `negTriple (−1) = (12,−10,9)` (`taxicab_is_signflip_of_neg`).
+
+  Everything here is a polynomial identity over `ℤ`, closed by `ring` /
+  `linear_combination` / `norm_num`.  No `axiom`, no `sorry`, no `native_decide`:
+  this is a fully verified, 0-axiom result.
+-/
+
+import Mathlib
+import Proofs.FermatDefectOne
+import Proofs.FermatDefectOneFamilies
+
+namespace FermatDefectOneOQ06
+
+open scoped Polynomial
+
+/-! ## The structural sign-flip map -/
+
+/-- The **sign-flip map** on integer triples: `Ψ(a, b, c) = (c, -b, a)`.
+This is the structural map OQ-06 asks for: it is an involution and it negates
+the cubic defect `a³ + b³ - c³`. -/
+def signFlip (T : ℤ × ℤ × ℤ) : ℤ × ℤ × ℤ := (T.2.2, -T.2.1, T.1)
+
+/-- `Ψ` is an **involution**: applying it twice is the identity.
+`(a,b,c) ↦ (c,-b,a) ↦ (a, -(-b), c) = (a,b,c)`. -/
+@[simp] theorem signFlip_involutive (T : ℤ × ℤ × ℤ) : signFlip (signFlip T) = T := by
+  simp [signFlip]
+
+/-- **Headline.** `Ψ` negates the cubic defect: if `Ψ(a,b,c) = (a',b',c')` then
+`a'³ + b'³ - c'³ = -(a³ + b³ - c³)`.  Hence `Ψ` exchanges the two defect signs. -/
+theorem signFlip_negates_defect (a b c : ℤ) :
+    (signFlip (a, b, c)).1 ^ 3 + (signFlip (a, b, c)).2.1 ^ 3
+        - (signFlip (a, b, c)).2.2 ^ 3
+      = -(a ^ 3 + b ^ 3 - c ^ 3) := by
+  simp only [signFlip]
+  ring
+
+/-- `Ψ` carries every integer **negative-defect** solution `a³ + b³ + 1 = c³`
+to a **positive-defect** solution `a'³ + b'³ = c'³ + 1`. -/
+theorem signFlip_neg_to_pos {a b c : ℤ} (h : a ^ 3 + b ^ 3 + 1 = c ^ 3) :
+    (signFlip (a, b, c)).1 ^ 3 + (signFlip (a, b, c)).2.1 ^ 3
+      = (signFlip (a, b, c)).2.2 ^ 3 + 1 := by
+  simp only [signFlip]
+  linear_combination -h
+
+/-- `Ψ` carries every integer **positive-defect** solution `a³ + b³ = c³ + 1`
+to a **negative-defect** solution `a'³ + b'³ + 1 = c'³`. -/
+theorem signFlip_pos_to_neg {a b c : ℤ} (h : a ^ 3 + b ^ 3 = c ^ 3 + 1) :
+    (signFlip (a, b, c)).1 ^ 3 + (signFlip (a, b, c)).2.1 ^ 3 + 1
+      = (signFlip (a, b, c)).2.2 ^ 3 := by
+  simp only [signFlip]
+  linear_combination -h
+
+/-! ## The Mahler families and parameter negation
+
+`Ψ` restricted to the gallery families is the parameter involution `t ↦ −t`. -/
+
+/-- Negative-defect base triple from the Mahler parameter `t`:
+`(9t⁴ − 3t, 9t³ − 1, 9t⁴)`, satisfying `a³ + b³ + 1 = c³`
+(`FermatDefectOne.defect_neg_family`).  `t = 1 ↦ (6, 8, 9)`. -/
+def negTriple (t : ℤ) : ℤ × ℤ × ℤ := (9 * t ^ 4 - 3 * t, 9 * t ^ 3 - 1, 9 * t ^ 4)
+
+/-- Positive-defect base triple from the Mahler parameter `t`:
+`(9t⁴, 9t³ + 1, 9t⁴ + 3t)`, satisfying `a³ + b³ = c³ + 1`
+(`FermatDefectOne.defect_pos_family`).  `t = 1 ↦ (9, 10, 12)`. -/
+def posTriple (t : ℤ) : ℤ × ℤ × ℤ := (9 * t ^ 4, 9 * t ^ 3 + 1, 9 * t ^ 4 + 3 * t)
+
+/-- The negative-defect triple really satisfies the negative-defect equation. -/
+theorem negTriple_defect (t : ℤ) :
+    (negTriple t).1 ^ 3 + (negTriple t).2.1 ^ 3 + 1 = (negTriple t).2.2 ^ 3 := by
+  simp only [negTriple]
+  ring
+
+/-- The positive-defect triple really satisfies the positive-defect equation. -/
+theorem posTriple_defect (t : ℤ) :
+    (posTriple t).1 ^ 3 + (posTriple t).2.1 ^ 3 = (posTriple t).2.2 ^ 3 + 1 := by
+  simp only [posTriple]
+  ring
+
+/-- **Compatibility.** On the Mahler families `Ψ` is the parameter involution:
+`Ψ(negTriple t) = posTriple (−t)`. -/
+theorem signFlip_negTriple (t : ℤ) : signFlip (negTriple t) = posTriple (-t) := by
+  simp only [signFlip, negTriple, posTriple, Prod.mk.injEq]
+  refine ⟨by ring, by ring, by ring⟩
+
+/-- **Compatibility (other branch).** `Ψ(posTriple t) = negTriple (−t)`. -/
+theorem signFlip_posTriple (t : ℤ) : signFlip (posTriple t) = negTriple (-t) := by
+  simp only [signFlip, posTriple, negTriple, Prod.mk.injEq]
+  refine ⟨by ring, by ring, by ring⟩
+
+/-- The two compatibilities are consistent with `Ψ` being an involution: applying
+`Ψ` twice to a negative-defect Mahler point returns the same point (parameter
+`t ↦ −t ↦ t`). -/
+theorem signFlip_negTriple_involutive (t : ℤ) :
+    signFlip (signFlip (negTriple t)) = negTriple t := by
+  simp
+
+/-! ## Concrete benchmarks
+
+The two gallery benchmarks `(6,8,9)` (negative) and `(9,10,12)` (positive)
+are related by the sign-flip map. -/
+
+/-- `negTriple 1 = (6, 8, 9)`, the negative-defect benchmark. -/
+theorem negTriple_one : negTriple 1 = (6, 8, 9) := by
+  simp only [negTriple]; norm_num
+
+/-- `posTriple 1 = (9, 10, 12)`, the positive-defect (taxicab) benchmark. -/
+theorem posTriple_one : posTriple 1 = (9, 10, 12) := by
+  simp only [posTriple]; norm_num
+
+/-- `Ψ` sends the negative benchmark `(6,8,9)` to the integer positive-defect
+solution `(9, -8, 6)`: indeed `9³ + (-8)³ = 6³ + 1` (`729 - 512 = 217`). -/
+theorem signFlip_benchmark : signFlip (6, 8, 9) = (9, -8, 6) := by
+  simp only [signFlip]
+
+/-- The image `(9, -8, 6)` is genuinely a positive-defect solution over `ℤ`. -/
+theorem signFlip_benchmark_pos_defect : (9 : ℤ) ^ 3 + (-8) ^ 3 = 6 ^ 3 + 1 := by
+  norm_num
+
+/-- The **canonical taxicab positive witness** `(9,10,12) = posTriple 1` is the
+sign-flip image of the negative-defect Mahler point `negTriple (-1) = (12,-10,9)`.
+So `(6,8,9) → (9,10,12)` is realised structurally through the parameter
+involution: `posTriple 1 = Ψ(negTriple (-1))`. -/
+theorem taxicab_is_signflip_of_neg :
+    posTriple 1 = signFlip (negTriple (-1)) := by
+  rw [signFlip_negTriple]; norm_num
+
+/-- `negTriple (-1) = (12, -10, 9)`, an integer negative-defect solution
+(`12³ + (-10)³ + 1 = 9³`). -/
+theorem negTriple_neg_one : negTriple (-1) = (12, -10, 9) := by
+  simp only [negTriple]; norm_num
+
+/-! ## Summary statement
+
+Both signs at `n = 3` are the two branches of one identity under `t ↦ -t`. -/
+
+/-- **Sign symmetry (OQ-06), packaged.** For every parameter `t`:
+* the negative-defect Mahler triple satisfies `a³ + b³ + 1 = c³`;
+* the positive-defect Mahler triple satisfies `a³ + b³ = c³ + 1`;
+* the explicit involution `Ψ(a,b,c) = (c,-b,a)` carries one to the other,
+  matching the parameter negation `t ↦ -t`. -/
+theorem sign_symmetry (t : ℤ) :
+    ((negTriple t).1 ^ 3 + (negTriple t).2.1 ^ 3 + 1 = (negTriple t).2.2 ^ 3) ∧
+    ((posTriple t).1 ^ 3 + (posTriple t).2.1 ^ 3 = (posTriple t).2.2 ^ 3 + 1) ∧
+    (signFlip (negTriple t) = posTriple (-t)) ∧
+    (signFlip (posTriple t) = negTriple (-t)) :=
+  ⟨negTriple_defect t, posTriple_defect t, signFlip_negTriple t, signFlip_posTriple t⟩
+
+end FermatDefectOneOQ06

--- a/research/problems/fermat-defect-one-oq-06/knowledge.md
+++ b/research/problems/fermat-defect-one-oq-06/knowledge.md
@@ -1,0 +1,91 @@
+# Knowledge Base: fermat-defect-one-oq-06
+
+Gallery-extracted open question on the **fermat-defect-one** family. The parent asks
+whether the Fermat defect `|aⁿ + bⁿ − cⁿ|` is ever exactly `1` for a primitive nontrivial
+triple `2 ≤ a ≤ b < c`. At `n = 3` both signs are witnessed along explicit Mahler families:
+
+- negative defect `a³ + b³ + 1 = c³` (`FermatDefectOneNegInfinitude.lean`)
+- positive defect `a³ + b³ = c³ + 1` (`FermatDefectOneFamilies.lean`)
+
+**OQ-06** asks the *symmetry-between-signs* question: is there a **structural map**
+(sign-flip / involution) carrying negative-defect witnesses to positive-defect witnesses
+and back?
+
+---
+
+## Answer: yes — an explicit involution that negates the cubic defect
+
+Working over `ℤ` (so the `±1` is one signed quantity rather than a `Nat`-disjunction),
+define the **sign-flip map**
+
+```
+Ψ(a, b, c) = (c, −b, a).
+```
+
+This session proves (`Proofs/FermatDefectOneOQ06.lean`, 194L, 16 thm, 3 def,
+0 sorry, 0 axiom, 0 `native_decide` — fully verified, 0-axiom):
+
+### Ψ is an involution and negates the cubic defect
+- `signFlip_involutive`:  `Ψ(Ψ T) = T`.
+- `signFlip_negates_defect`:  for `Ψ(a,b,c) = (a',b',c')`,
+  `a'³ + b'³ − c'³ = −(a³ + b³ − c³)` (a pure `ring` identity).
+
+Hence `Ψ` exchanges the two defect signs:
+- `signFlip_neg_to_pos`:  `a³+b³+1 = c³  ⟹  c³ + (−b)³ = a³ + 1`.
+- `signFlip_pos_to_neg`:  `a³+b³ = c³+1  ⟹  c³ + (−b)³ + 1 = a³`.
+
+### Compatibility with the Mahler families: Ψ is parameter negation t ↦ −t
+With the gallery families
+```
+negTriple t = (9t⁴ − 3t, 9t³ − 1, 9t⁴)      (negative defect)
+posTriple t = (9t⁴,      9t³ + 1, 9t⁴ + 3t)  (positive defect)
+```
+the involution `Ψ` restricts on these families to the parameter involution `t ↦ −t`:
+- `signFlip_negTriple`:  `Ψ(negTriple t) = posTriple (−t)`.
+- `signFlip_posTriple`:  `Ψ(posTriple t) = negTriple (−t)`.
+
+So the sign symmetry of the defect at `n = 3` *is* the involution `t ↦ −t` of Mahler's
+parametrisation of `x³ + y³ + z³ = 1`, realised pointwise by `Ψ`.
+
+### Concrete benchmarks
+- `negTriple 1 = (6, 8, 9)` (negative benchmark), `posTriple 1 = (9, 10, 12)` (taxicab).
+- `signFlip_benchmark`: `Ψ(6,8,9) = (9,−8,6)`, a genuine integer positive-defect solution
+  `9³ + (−8)³ = 6³ + 1` (729 − 512 = 217).
+- `taxicab_is_signflip_of_neg`: the canonical taxicab witness `(9,10,12)` is `Ψ` applied to
+  the negative-defect point `negTriple (−1) = (12,−10,9)`.
+- `sign_symmetry` packages all four facts (both defect equations + both compatibilities)
+  into a single statement parameterised by `t`.
+
+---
+
+## Insights
+
+- Passing to `ℤ` is the key move. Over `ℕ` the `±1` is a disjunction of two equations and
+  there is no natural negation; over `ℤ` the defect `a³+b³−c³` is a single signed quantity
+  and the sign flip is literally `× (−1)`, realised by the linear involution `(a,b,c) ↦ (c,−b,a)`.
+- The middle coordinate must be negated (`b ↦ −b`), not the outer ones: it is the
+  odd-degree cube that carries the sign, so `Ψ` swaps the roles of `a` and `c` and flips `b`.
+- The map is *structural* (independent of the Mahler parametrisation) yet *compatible* with
+  it: on the families it collapses to `t ↦ −t`, explaining why the two gallery families are
+  mirror images rather than independent objects.
+- Everything is a polynomial identity over `ℤ`, closed by `ring` / `linear_combination` /
+  `simp`. No enumeration, no `native_decide`, no axioms.
+
+## Mathlib gaps
+- None. The result needs only `ℤ` ring arithmetic and `Prod` projections.
+
+## Next steps / open directions
+- The structural involution is specific to the exponent-3 defect (`a³+b³−c³` is the unique
+  odd cube combination where `(a,b,c) ↦ (c,−b,a)` negates the form). Whether an analogous
+  sign-flip exists at higher odd exponents `n` is open and is *not* a mere reindexing — at
+  `n ≥ 4` no defect-one witness is known (cf. OQ-04 bounded non-existence), so there is
+  nothing to map. This is a genuinely different direction, not an OQ recursion.
+
+## Lean artefacts (all 0-axiom: propext / Classical.choice / Quot.sound only)
+`Proofs/FermatDefectOneOQ06.lean`: `signFlip`, `signFlip_involutive`,
+`signFlip_negates_defect`, `signFlip_neg_to_pos`, `signFlip_pos_to_neg`,
+`negTriple`, `posTriple`, `negTriple_defect`, `posTriple_defect`,
+`signFlip_negTriple`, `signFlip_posTriple`, `signFlip_negTriple_involutive`,
+`negTriple_one`, `posTriple_one`, `signFlip_benchmark`, `signFlip_benchmark_pos_defect`,
+`taxicab_is_signflip_of_neg`, `negTriple_neg_one`, `sign_symmetry`.
+Registered in `Proofs.lean`.

--- a/src/data/research/problems/fermat-defect-one-oq-06.json
+++ b/src/data/research/problems/fermat-defect-one-oq-06.json
@@ -1,0 +1,85 @@
+{
+  "slug": "fermat-defect-one-oq-06",
+  "title": "Fermat Defect-One: an explicit sign-flip involution exchanging the two defect signs at n = 3",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "tags": [],
+  "relatedProofs": [
+    "fermat-defect-one"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-28T00:00:00.000Z",
+  "lastUpdate": "2026-06-28T13:00:00.000Z",
+  "significance": 4,
+  "tractability": 9,
+  "problemStatement": {
+    "formal": "\\exists\\,\\Psi:\\mathbb{Z}^3\\to\\mathbb{Z}^3,\\ \\Psi\\circ\\Psi=\\mathrm{id}\\ \\wedge\\ \\forall a,b,c:\\ (a',b',c')=\\Psi(a,b,c)\\Rightarrow a'^3+b'^3-c'^3 = -(a^3+b^3-c^3)",
+    "plain": "The parent fermat-defect-one exhibits, at n = 3, both signs of the unit Fermat defect: a negative-defect family a^3+b^3+1=c^3 and a positive-defect family a^3+b^3=c^3+1. OQ-06 asks whether there is a STRUCTURAL map (an involution / sign-flip) carrying negative-defect witnesses to positive-defect witnesses and back. Answer: yes. Over Z the explicit involution Psi(a,b,c) = (c,-b,a) negates the cubic defect a^3+b^3-c^3, so it exchanges the two defect signs; restricted to the gallery Mahler families it is exactly the parameter negation t -> -t, and it sends the negative benchmark (6,8,9) to the integer positive-defect solution (9,-8,6) and realises the taxicab witness (9,10,12) as Psi(12,-10,9).",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-28T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Explicit sign-flip involution Psi(a,b,c)=(c,-b,a) negating the cubic defect over Z, with compatibility t -> -t on the Mahler families.",
+    "blockers": [],
+    "nextAction": "Whether an analogous sign-flip involution exists at higher odd exponents is open but vacuous in practice (no defect-one witness known for n >= 4, cf. OQ-04).",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED: explicit structural sign-flip for the n=3 Fermat unit defect. Over Z the linear involution Psi(a,b,c) = (c,-b,a) is an involution (signFlip_involutive) and negates the cubic defect a^3+b^3-c^3 (signFlip_negates_defect, a ring identity), hence carries negative-defect solutions a^3+b^3+1=c^3 to positive-defect solutions a^3+b^3=c^3+1 and back (signFlip_neg_to_pos / signFlip_pos_to_neg). On the gallery Mahler families negTriple/posTriple, Psi is exactly the parameter negation t -> -t (signFlip_negTriple, signFlip_posTriple), so the sign symmetry of the defect is the involution t -> -t of Mahler's parametrisation of x^3+y^3+z^3=1 realised pointwise. Benchmarks: Psi(6,8,9)=(9,-8,6) with 9^3+(-8)^3=6^3+1, and the taxicab witness (9,10,12)=Psi(negTriple(-1))=Psi(12,-10,9). Proofs/FermatDefectOneOQ06.lean (194L, 16 thm, 3 def, 0 sorry, 0 axiom decls, 0 native_decide; fully verified 0-axiom) is registered in Proofs.lean. Everything is polynomial identities over Z closed by ring / linear_combination / simp.",
+    "builtItems": [
+      "signFlip (T) = (T.2.2, -T.2.1, T.1): the sign-flip map Psi(a,b,c)=(c,-b,a) on integer triples",
+      "signFlip_involutive: Psi (Psi T) = T",
+      "signFlip_negates_defect: c^3 + (-b)^3 - a^3 = -(a^3+b^3-c^3) for the Psi-image (ring identity)",
+      "signFlip_neg_to_pos / signFlip_pos_to_neg: Psi exchanges the negative-defect and positive-defect equations over Z",
+      "negTriple/posTriple t and their defect lemmas (negTriple_defect, posTriple_defect)",
+      "signFlip_negTriple: Psi(negTriple t) = posTriple(-t); signFlip_posTriple: Psi(posTriple t) = negTriple(-t)",
+      "signFlip_benchmark: Psi(6,8,9)=(9,-8,6); signFlip_benchmark_pos_defect: 9^3+(-8)^3=6^3+1",
+      "taxicab_is_signflip_of_neg: posTriple 1 = (9,10,12) = Psi(negTriple(-1)) = Psi(12,-10,9)",
+      "sign_symmetry t: packaged statement (both defect equations + both compatibilities) for all t"
+    ],
+    "insights": [
+      "Passing to Z is the key move: over N the +/-1 is a disjunction with no natural negation, but over Z the defect a^3+b^3-c^3 is one signed quantity and the sign flip is literally multiplication by -1, realised by the linear involution (a,b,c) -> (c,-b,a).",
+      "The middle coordinate must be negated (b -> -b), not the outer ones: the odd-degree cube carries the sign, so Psi swaps the roles of a and c and flips b.",
+      "The map is structural (independent of the Mahler parametrisation) yet compatible with it: on the families it collapses to t -> -t, explaining why the two gallery families are mirror images rather than independent objects.",
+      "The involution is specific to the exponent-3 defect; at n >= 4 no defect-one witness is known (cf. OQ-04 bounded non-existence), so an analogous sign-flip would have nothing to map -- a genuinely different open direction, not an OQ recursion."
+    ],
+    "mathlibGaps": [
+      "None: the result needs only Z ring arithmetic and Prod projections."
+    ],
+    "nextSteps": [
+      "Whether an analogous sign-flip involution exists at higher odd exponents n is open but practically vacuous (no defect-one witness for n >= 4).",
+      "Optionally express Psi as a Z-linear / affine involution and record its matrix to connect with the lattice geometry of x^3+y^3+z^3=1."
+    ],
+    "markdown": "# Knowledge Base: fermat-defect-one-oq-06\n\n## Source\nGallery-extracted open question extending **fermat-defect-one**: a structural sign-flip map exchanging the two defect signs at n = 3.\n\n## Progress Summary\nProved an explicit involution Psi(a,b,c) = (c,-b,a) over Z that negates the cubic defect a^3+b^3-c^3, hence exchanges negative- and positive-defect solutions, and restricts to the parameter negation t -> -t on the Mahler families. See Proofs/FermatDefectOneOQ06.lean (fully verified, 0-axiom)."
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/FermatDefectOneOQ06.lean",
+      "filename": "FermatDefectOneOQ06.lean",
+      "lineCount": 194,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FermatDefectOneOQ06.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

**OQ-06** of the `fermat-defect-one` family asks for a **structural map** (involution / sign-flip) exchanging the two signs of the unit Fermat defect at `n = 3`:

- negative defect `a³ + b³ + 1 = c³`
- positive defect `a³ + b³ = c³ + 1`

**Answer: yes.** Working over `ℤ`, the linear involution

```
Ψ(a, b, c) = (c, −b, a)
```

is an involution (`signFlip_involutive`) and **negates the cubic defect** `a³+b³−c³` (`signFlip_negates_defect`, a pure `ring` identity), so it carries negative-defect solutions to positive-defect solutions and back (`signFlip_neg_to_pos`, `signFlip_pos_to_neg`).

## Compatibility with the Mahler families

On the two gallery families
```
negTriple t = (9t⁴−3t, 9t³−1, 9t⁴)      posTriple t = (9t⁴, 9t³+1, 9t⁴+3t)
```
`Ψ` is exactly the **parameter negation `t ↦ −t`** (`signFlip_negTriple`, `signFlip_posTriple`). The sign symmetry of the defect at `n = 3` *is* the involution `t ↦ −t` of Mahler's parametrisation of `x³+y³+z³=1`, realised pointwise.

## Benchmarks

- `Ψ(6,8,9) = (9,−8,6)`, a genuine integer positive-defect solution `9³+(−8)³ = 6³+1` (729−512 = 217).
- The taxicab witness `(9,10,12)` is `Ψ(negTriple(−1)) = Ψ(12,−10,9)` (`taxicab_is_signflip_of_neg`).
- `sign_symmetry t` packages all four facts into one statement.

## Verification

`proofs/Proofs/FermatDefectOneOQ06.lean` — **194 lines, 16 theorems, 3 defs, 0 sorry, 0 axiom declarations, 0 `native_decide`**. Builds clean via `./proofs/scripts/docker-build.sh Proofs.FermatDefectOneOQ06`; everything is polynomial identities over `ℤ` closed by `ring` / `linear_combination` / `simp`. Fully verified, **0-axiom** (`propext` / `Classical.choice` / `Quot.sound` only). Registered in `Proofs.lean`.

Status: `fermat-defect-one-oq-06` → **completed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)