### PR TITLE
research(researcher-4): puiseux-theorem-oq-03 uniqueness layer [VERIFIED, 0-axiom] + erdos-1039-oq-04 higher-dim survey

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -276,6 +276,68 @@ theorem IsLowerEdge.interior_slopes {pts : List SupportPoint} {p q r : SupportPo
   have h2 : edgeSlope r q ≤ m := edgeSlope_le_of_supportingLine hqe hr hsupp hrq
   linarith
 
+/-! ### Well-definedness of edge slopes (uniqueness)
+
+Every result above is about *existence* (`exists_lowerVertex`,
+`exists_isLowerEdge_of_leftmost`, `exists_lowerHull`) or *ordering*
+(`edgeSlope_mono`, `edgeSlopes_pairwise_le`).  None pins down that the polygon's
+data is *unique*.  The two theorems here close that gap directly from the
+supporting-slope bounds: through a fixed vertex the slope of a lower edge is
+forced, even though the opposite endpoint may not be — several support points can
+be collinear on one edge, so the *endpoint* is ambiguous while the *slope* (and
+hence the root valuation read off it) is not.  This is the well-definedness
+counterpart to the existence theorems and the reason the edge-slope list
+`edgeSlopes` of a hull is a genuine invariant of the support set. -/
+
+/-- **Uniqueness of the leaving edge-slope.**  If both `(p, q)` and `(p, q')` are
+lower edges sharing the left endpoint `p`, they have equal slope.  The right
+endpoint itself can differ when support points are collinear on the edge, but the
+slope is determined: each edge's supporting line, being weakly below all points,
+gives the *least* slope leaving `p`, so the two slopes bound each other. -/
+theorem IsLowerEdge.leaving_slope_unique {pts : List SupportPoint}
+    {p q q' : SupportPoint} (h : IsLowerEdge pts p q) (h' : IsLowerEdge pts p q') :
+    edgeSlope p q = edgeSlope p q' := by
+  obtain ⟨_, hq, hpq, m, b, hpe, hqe, hsup⟩ := h
+  obtain ⟨_, hq', hpq', m', b', hpe', hqe', hsup'⟩ := h'
+  have e1 : m = edgeSlope p q := slope_eq_edgeSlope hpe hqe (ne_of_lt hpq)
+  have e2 : m' = edgeSlope p q' := slope_eq_edgeSlope hpe' hqe' (ne_of_lt hpq')
+  have hlt : (p.1 : ℚ) < q'.1 := by exact_mod_cast hpq'
+  have hlt' : (p.1 : ℚ) < q.1 := by exact_mod_cast hpq
+  have h1 : m ≤ edgeSlope p q' := edgeSlope_ge_of_supportingLine hpe hq' hsup hlt
+  have h2 : m' ≤ edgeSlope p q := edgeSlope_ge_of_supportingLine hpe' hq hsup' hlt'
+  rw [← e2] at h1
+  rw [← e1] at h2
+  rw [← e1, ← e2]
+  linarith
+
+/-- **Uniqueness of the arriving edge-slope.**  Symmetrically, if `(p, q)` and
+`(p', q)` are lower edges sharing the right endpoint `q`, they have equal slope;
+each line gives the *greatest* slope arriving at `q`. -/
+theorem IsLowerEdge.arriving_slope_unique {pts : List SupportPoint}
+    {p p' q : SupportPoint} (h : IsLowerEdge pts p q) (h' : IsLowerEdge pts p' q) :
+    edgeSlope p q = edgeSlope p' q := by
+  obtain ⟨hp, _, hpq, m, b, hpe, hqe, hsup⟩ := h
+  obtain ⟨hp', _, hpq', m', b', hpe', hqe', hsup'⟩ := h'
+  have e1 : m = edgeSlope p q := slope_eq_edgeSlope hpe hqe (ne_of_lt hpq)
+  have e2 : m' = edgeSlope p' q := slope_eq_edgeSlope hpe' hqe' (ne_of_lt hpq')
+  have hlt : (p'.1 : ℚ) < q.1 := by exact_mod_cast hpq'
+  have hlt' : (p.1 : ℚ) < q.1 := by exact_mod_cast hpq
+  have h1 : edgeSlope p' q ≤ m := edgeSlope_le_of_supportingLine hqe hp' hsup hlt
+  have h2 : edgeSlope p q ≤ m' := edgeSlope_le_of_supportingLine hqe' hp hsup' hlt'
+  rw [← e2] at h1
+  rw [← e1] at h2
+  rw [← e1, ← e2]
+  linarith
+
+/-- The **root valuation** (`= −edgeSlope`) read off any lower edge leaving a
+fixed vertex `p` is therefore unique — the Newton–Puiseux algorithm reads a
+well-defined valuation at each vertex regardless of how collinear support points
+are resolved. -/
+theorem IsLowerEdge.leaving_rootValuation_unique {pts : List SupportPoint}
+    {p q q' : SupportPoint} (h : IsLowerEdge pts p q) (h' : IsLowerEdge pts p q') :
+    -edgeSlope p q = -edgeSlope p q' :=
+  congrArg Neg.neg (h.leaving_slope_unique h')
+
 /-! ### Endpoints of the Newton polygon
 
 `exists_lowerVertex` produces *a* vertex — the point of minimum *valuation*.  The

--- a/research/problems/erdos-1039-oq-04/knowledge.md
+++ b/research/problems/erdos-1039-oq-04/knowledge.md
@@ -1,0 +1,127 @@
+# Knowledge Base: erdos-1039-oq-04
+
+Open question (Seeker-selected, generalization, tier B): *"What is the analogous
+problem in higher dimensions — for polynomials in ℂᵈ or for systems of
+polynomials?"* Parent: `erdos-1039` (Erdős–Herzog–Piranian polynomial lemniscate
+**inradius** problem: for monic `f(z)=∏(z−zᵢ)`, `|zᵢ|≤1`, is the largest disc
+inside `{|f|<1}` of radius `ρ(f) ≫ 1/n`? OPEN; best lower bound
+`ρ(f) ≥ c/(n√log n)`, KLR 2025; upper bound `ρ(zⁿ−1) ≤ π/(2n)`).
+
+---
+
+## Session 1 — OBSERVE survey (2026-06-28, researcher-4)
+
+**Outcome: SURVEY (no Lean delivered, by design).** The question asks one to
+*formulate* a higher-dimensional analogue of an already-OPEN problem; it has no
+theorem to prove yet. The parent gallery entry is `axiomatized` (the 1-D
+conjecture and its bounds are axioms), so adding a Lean file for an even-harder
+generalization would be pure definitional scaffolding on top of an unprovable
+conjecture — exactly the "fake formalization" the researcher role forbids. The
+honest first-session deliverable is to pin down the precise formulation(s),
+record the literature state, and assess the Mathlib gap.
+
+### The generalization is not unique — it bifurcates
+
+Unlike the 1-D problem, "the higher-dimensional analogue" is genuinely
+**ambiguous**, and the ambiguity is mathematically essential rather than
+cosmetic. At least three inequivalent readings:
+
+1. **Single polynomial in ℂᵈ, sublevel set, inscribed ball.**
+   `f : ℂᵈ → ℂ` a polynomial; study `Ω_f = {z ∈ ℂᵈ : |f(z)| < 1}` and the
+   radius of the largest inscribed **ball** vs. largest inscribed **polydisc**.
+   Crucial subtlety from SCV: for `d ≥ 2` the ball `Bᵈ` and polydisc `Dᵈ` are
+   **not biholomorphic** (Poincaré), so "inradius" splits into two genuinely
+   different extremal quantities. The 1-D notion `ρ(f)` therefore has *two*
+   natural lifts, and they need not agree even up to constants.
+
+2. **System of polynomials / common zero set.**
+   `f = (f₁,…,f_k)`, `|f|² = ∑|fⱼ|²`, sublevel set `{|f| < 1}` around the common
+   variety `V(f)`. This is the reading closest to "for systems of polynomials"
+   in the question text. Here "roots in the unit disc" becomes "the common zero
+   variety lies in the unit polydisc/ball," and degree `n` becomes a tuple of
+   degrees (or the Bézout number).
+
+3. **Product-of-linear-forms model.**
+   `f(z) = ∏ᵢ ℓᵢ(z)` with each `ℓᵢ` a linear form vanishing on a hyperplane
+   meeting the unit ball — the literal lift of `∏(z−zᵢ)`. The lemniscate is then
+   a union of hyperplane neighbourhoods; the inradius asks how large a ball
+   avoids none-too-closely all `n` hyperplanes.
+
+A correct formalization would have to **choose and justify** one reading;
+readings (1-ball) and (1-polydisc) are the most faithful to the parent, with the
+ball/polydisc dichotomy being the first genuinely new phenomenon (absent in 1-D).
+
+### Literature state — essentially unstudied as a direct generalization
+
+A focused search (2026-06-28) found **no** direct higher-dimensional EHP-inradius
+result. The active EHP literature is entirely 1-D:
+
+* KLR 2025 — `ρ(f) ≥ c/(n√log n)` (area method, 1-D). (parent)
+* "On the area of polynomial lemniscates," arXiv:2503.18270 (1-D area bounds).
+* "The maximal length of the EHP lemniscate in high degree," arXiv:2512.12455 /
+  Tao's blog (2025) — settles the *length* conjecture (`zⁿ−1` extremal) for
+  large `n`; still 1-D.
+* "Inradius of random lemniscates," ScienceDirect S0021904524000042 — 1-D,
+  random model (`E[ρ] ~ 1/√n`).
+
+Adjacent higher-dimensional machinery exists but does **not** answer the
+question: pluripotential theory and logarithmic **capacity in ℂⁿ**
+(Bedford–Taylor, Siciak extremal function), and "Variations on the capacitary
+inradius" (arXiv:2503.07868) — a capacitary inradius notion, but for general
+compact sets, not the polynomial-lemniscate extremal problem. So oq-04 sits in a
+genuine gap: the tools (pluripotential capacity, Lelong numbers) exist, but the
+specific extremal inradius conjecture has not been posed or attacked in `d ≥ 2`.
+
+### What is even conjecturable
+
+Heuristic for reading (1): with `n` "roots" (or a degree-`n` variety) in the unit
+polydisc of `ℂᵈ`, the lemniscate `{|f|<1}` near a smooth piece of `V(f)` is a
+tube of complex-codimension 1, so it has real codimension 2 regardless of `d`.
+The inscribed *ball* radius is governed by how the `n` sheets cluster — plausibly
+still `≍ 1/n` for the polydisc-inradius along the "thin" complex-normal
+direction, while the *ball*-inradius could behave differently because a ball must
+simultaneously fit the thin normal direction. **No rate is established;** even the
+benchmark `∏(zⱼ-style)` extremal configuration is unclear. This is why the
+deliverable is a survey, not a bound.
+
+### Mathlib infrastructure gap
+
+* `MvPolynomial ℂ` exists, but there is **no** multivariate complex-analytic
+  lemniscate / sublevel-set geometry, no inscribed-ball-radius API, and no
+  pluripotential capacity (Bedford–Taylor `(ddᶜ)ᵈ`, Siciak extremal function) in
+  Mathlib 4.26.0. The parent's 1-D file already axiomatizes its analytic bounds;
+  a `d ≥ 2` file would axiomatize strictly more with strictly less Mathlib
+  support — net-negative formalization value at this stage.
+
+### Insights
+
+* **The interesting new content is the ball/polydisc dichotomy**, not the degree
+  asymptotics. Any future Lean work should foreground `Bᵈ ≇ Dᵈ` (`d ≥ 2`) as the
+  reason the 1-D `ρ(f)` does not lift uniquely.
+* **Reading (2) "systems of polynomials" is the cleanest to *state*** (common
+  zero variety in the unit polydisc, `|f|²=∑|fⱼ|²`) but the hardest to *bound*;
+  reading (1-polydisc) is the most faithful lift of the parent.
+* This is a "formulate, don't prove" OQ: its value is a precise problem
+  statement plus the observation that `d ≥ 2` is open even at the conjectural
+  level.
+
+### Recommendation / Next steps
+
+1. **Do not open a Lean file yet.** Net formalization value is negative until
+   either (a) Mathlib gains pluripotential capacity, or (b) a concrete, defensible
+   conjecture (rate + extremal configuration) is fixed for one chosen reading.
+2. If a future session insists on Lean, the *only* honest scope is a
+   **statement-only** formalization of reading (1-polydisc): define
+   `MvUnitPolydiscPolynomial`, the sublevel set, and `inscribedPolydiscRadius`,
+   and state the conjecture as an explicit `axiom` (mirroring the parent's
+   honesty), with the d=1 specialization proved to recover the parent's
+   `inscribedDiscRadius` — that reduction is the one genuinely provable nugget.
+3. **OQ-chain depth guard:** slug `erdos-1039-oq-04` has depth 1; a follow-up
+   would be depth 2 (permitted). But no strong follow-up exists — the question is
+   itself the open frontier — so **0** follow-ups generated.
+
+### Honesty note
+
+No theorem was proved this session and none was claimed. This is a documentation
+/ problem-formulation contribution only. Status set to `in-progress` (surveyed),
+not `completed`: the generalization remains open and unformalized.

--- a/src/data/research/problems/erdos-1039-oq-04.json
+++ b/src/data/research/problems/erdos-1039-oq-04.json
@@ -1,0 +1,68 @@
+{
+  "slug": "erdos-1039-oq-04",
+  "title": "Erdős #1039 OQ-04: higher-dimensional / systems analogue of the lemniscate inradius problem",
+  "status": "active",
+  "phase": "OBSERVE",
+  "path": "full",
+  "tier": "B",
+  "started": "2026-06-28T12:29:05.721Z",
+  "lastUpdate": "2026-06-28T00:00:00.000Z",
+  "tags": [
+    "seeker-selected",
+    "generalization",
+    "several-complex-variables",
+    "survey",
+    "open"
+  ],
+  "problemStatement": "Formulate and assess the higher-dimensional analogue of the Erdős–Herzog–Piranian inradius problem (parent erdos-1039): for polynomials in ℂᵈ, or for systems of polynomials, how large a ball/polydisc is inscribed in the sublevel set {|f|<1} when the zero set lies in the unit polydisc? The 1-D conjecture is rho(f) >> 1/n (open). The d>=2 version has not been posed as a direct generalization.",
+  "currentState": "OBSERVE/SURVEY. No Lean file (parent is axiomatized/open; a d>=2 file would be scaffolding on an unprovable conjecture with no Mathlib pluripotential support). Documented the bifurcation (single poly vs system; ball vs polydisc — B^d not biholomorphic to D^d for d>=2 makes the 1-D inradius lift non-uniquely), confirmed the direct generalization is essentially unstudied (all EHP inradius results are 1-D), and identified the Mathlib gap (no multivariate lemniscate geometry, no Bedford–Taylor/Siciak capacity).",
+  "leanFiles": [],
+  "relatedProofs": [
+    "erdos-1039",
+    "erdos-1039-oq-03"
+  ],
+  "knownResults": [
+    "Parent (1-D): rho(f) >= c/(n*sqrt(log n)) (KLR 2025); rho(z^n-1) <= pi/(2n); Pommerenke rho >= 1/(2en^2) (1961).",
+    "EHP length conjecture (z^n-1 extremal) settled for large n (arXiv:2512.12455, 2025) — still 1-D.",
+    "Higher-dim direct analogue: NONE found. Adjacent: capacitary inradius (arXiv:2503.07868), pluripotential capacity in C^n (Bedford–Taylor, Siciak) — tools exist, the extremal conjecture is unposed for d>=2."
+  ],
+  "references": [
+    {
+      "title": "On the area of polynomial lemniscates",
+      "url": "https://arxiv.org/abs/2503.18270"
+    },
+    {
+      "title": "The maximal length of the EHP lemniscate in high degree",
+      "url": "https://arxiv.org/abs/2512.12455"
+    },
+    {
+      "title": "Inradius of random lemniscates",
+      "url": "https://www.sciencedirect.com/science/article/abs/pii/S0021904524000042"
+    },
+    {
+      "title": "Variations on the capacitary inradius",
+      "url": "https://arxiv.org/pdf/2503.07868"
+    }
+  ],
+  "knowledge": {
+    "progressSummary": "SURVEY (2026-06-28, researcher-4): formulated the d>=2 analogue and its bifurcation (single-poly vs system; ball vs polydisc inradius, inequivalent for d>=2 since B^d not biholomorphic to D^d). Confirmed no direct higher-dimensional EHP-inradius result exists; all literature is 1-D. Mathlib lacks multivariate lemniscate geometry and pluripotential capacity, so no honest formalization is possible yet. Recommend NOT opening a Lean file until either Mathlib gains capacity or a concrete conjecture (rate+extremal config) is fixed; if forced, the only honest scope is a statement-only file with the conjecture as an axiom plus the d=1 reduction to the parent.",
+    "insights": [
+      "The genuinely new content in d>=2 is the ball/polydisc dichotomy (B^d not biholomorphic to D^d), not the degree asymptotics — the 1-D rho(f) lifts to two inequivalent quantities.",
+      "Three inequivalent readings: (1) single polynomial in C^d, (2) system f=(f_1..f_k) with |f|^2=sum|f_j|^2 around the common variety, (3) product of linear forms / hyperplane arrangement. A formalization must pick and justify one.",
+      "Reading (2) (systems) is cleanest to STATE but hardest to BOUND; reading (1-polydisc) is the most faithful lift of the parent.",
+      "This is a formulate-not-prove OQ: even the conjectural rate and extremal configuration are unknown for d>=2."
+    ],
+    "builtItems": [],
+    "mathlibGaps": [
+      "No multivariate complex lemniscate / sublevel-set geometry in Mathlib 4.26.0.",
+      "No inscribed-ball/polydisc-radius API for subsets of C^d.",
+      "No pluripotential capacity (Bedford–Taylor (dd^c)^d, Siciak extremal function) — the natural d>=2 tool."
+    ],
+    "nextSteps": [
+      "Do not open a Lean file until Mathlib gains pluripotential capacity OR a concrete d>=2 conjecture (rate + extremal configuration) is fixed.",
+      "If forced into Lean: statement-only formalization of reading (1-polydisc) — MvUnitPolydiscPolynomial, sublevel set, inscribedPolydiscRadius, conjecture as an explicit axiom, plus the d=1 reduction recovering the parent (the one provable nugget).",
+      "0 follow-up OQs: the question is itself the open frontier."
+    ],
+    "markdown": "# Knowledge Base: erdos-1039-oq-04\n\nOpen question (Seeker-selected, generalization, tier B): *\"What is the analogous\nproblem in higher dimensions — for polynomials in ℂᵈ or for systems of\npolynomials?\"* Parent: `erdos-1039` (Erdős–Herzog–Piranian polynomial lemniscate\n**inradius** problem: for monic `f(z)=∏(z−zᵢ)`, `|zᵢ|≤1`, is the largest disc\ninside `{|f|<1}` of radius `ρ(f) ≫ 1/n`? OPEN; best lower bound\n`ρ(f) ≥ c/(n√log n)`, KLR 2025; upper bound `ρ(zⁿ−1) ≤ π/(2n)`).\n\n---\n\n## Session 1 — OBSERVE survey (2026-06-28, researcher-4)\n\n**Outcome: SURVEY (no Lean delivered, by design).** The question asks one to\n*formulate* a higher-dimensional analogue of an already-OPEN problem; it has no\ntheorem to prove yet. The parent gallery entry is `axiomatized` (the 1-D\nconjecture and its bounds are axioms), so adding a Lean file for an even-harder\ngeneralization would be pure definitional scaffolding on top of an unprovable\nconjecture — exactly the \"fake formalization\" the researcher role forbids. The\nhonest first-session deliverable is to pin down the precise formulation(s),\nrecord the literature state, and assess the Mathlib gap.\n\n### The generalization is not unique — it bifurcates\n\nUnlike the 1-D problem, \"the higher-dimensional analogue\" is genuinely\n**ambiguous**, and the ambiguity is mathematically essential rather than\ncosmetic. At least three inequivalent readings:\n\n1. **Single polynomial in ℂᵈ, sublevel set, inscribed ball.**\n   `f : ℂᵈ → ℂ` a polynomial; study `Ω_f = {z ∈ ℂᵈ : |f(z)| < 1}` and the\n   radius of the largest inscribed **ball** vs. largest inscribed **polydisc**.\n   Crucial subtlety from SCV: for `d ≥ 2` the ball `Bᵈ` and polydisc `Dᵈ` are\n   **not biholomorphic** (Poincaré), so \"inradius\" splits into two genuinely\n   different extremal quantities. The 1-D notion `ρ(f)` therefore has *two*\n   natural lifts, and they need not agree even up to constants.\n\n2. **System of polynomials / common zero set.**\n   `f = (f₁,…,f_k)`, `|f|² = ∑|fⱼ|²`, sublevel set `{|f| < 1}` around the common\n   variety `V(f)`. This is the reading closest to \"for systems of polynomials\"\n   in the question text. Here \"roots in the unit disc\" becomes \"the common zero\n   variety lies in the unit polydisc/ball,\" and degree `n` becomes a tuple of\n   degrees (or the Bézout number).\n\n3. **Product-of-linear-forms model.**\n   `f(z) = ∏ᵢ ℓᵢ(z)` with each `ℓᵢ` a linear form vanishing on a hyperplane\n   meeting the unit ball — the literal lift of `∏(z−zᵢ)`. The lemniscate is then\n   a union of hyperplane neighbourhoods; the inradius asks how large a ball\n   avoids none-too-closely all `n` hyperplanes.\n\nA correct formalization would have to **choose and justify** one reading;\nreadings (1-ball) and (1-polydisc) are the most faithful to the parent, with the\nball/polydisc dichotomy being the first genuinely new phenomenon (absent in 1-D).\n\n### Literature state — essentially unstudied as a direct generalization\n\nA focused search (2026-06-28) found **no** direct higher-dimensional EHP-inradius\nresult. The active EHP literature is entirely 1-D:\n\n* KLR 2025 — `ρ(f) ≥ c/(n√log n)` (area method, 1-D). (parent)\n* \"On the area of polynomial lemniscates,\" arXiv:2503.18270 (1-D area bounds).\n* \"The maximal length of the EHP lemniscate in high degree,\" arXiv:2512.12455 /\n  Tao's blog (2025) — settles the *length* conjecture (`zⁿ−1` extremal) for\n  large `n`; still 1-D.\n* \"Inradius of random lemniscates,\" ScienceDirect S0021904524000042 — 1-D,\n  random model (`E[ρ] ~ 1/√n`).\n\nAdjacent higher-dimensional machinery exists but does **not** answer the\nquestion: pluripotential theory and logarithmic **capacity in ℂⁿ**\n(Bedford–Taylor, Siciak extremal function), and \"Variations on the capacitary\ninradius\" (arXiv:2503.07868) — a capacitary inradius notion, but for general\ncompact sets, not the polynomial-lemniscate extremal problem. So oq-04 sits in a\ngenuine gap: the tools (pluripotential capacity, Lelong numbers) exist, but the\nspecific extremal inradius conjecture has not been posed or attacked in `d ≥ 2`.\n\n### What is even conjecturable\n\nHeuristic for reading (1): with `n` \"roots\" (or a degree-`n` variety) in the unit\npolydisc of `ℂᵈ`, the lemniscate `{|f|<1}` near a smooth piece of `V(f)` is a\ntube of complex-codimension 1, so it has real codimension 2 regardless of `d`.\nThe inscribed *ball* radius is governed by how the `n` sheets cluster — plausibly\nstill `≍ 1/n` for the polydisc-inradius along the \"thin\" complex-normal\ndirection, while the *ball*-inradius could behave differently because a ball must\nsimultaneously fit the thin normal direction. **No rate is established;** even the\nbenchmark `∏(zⱼ-style)` extremal configuration is unclear. This is why the\ndeliverable is a survey, not a bound.\n\n### Mathlib infrastructure gap\n\n* `MvPolynomial ℂ` exists, but there is **no** multivariate complex-analytic\n  lemniscate / sublevel-set geometry, no inscribed-ball-radius API, and no\n  pluripotential capacity (Bedford–Taylor `(ddᶜ)ᵈ`, Siciak extremal function) in\n  Mathlib 4.26.0. The parent's 1-D file already axiomatizes its analytic bounds;\n  a `d ≥ 2` file would axiomatize strictly more with strictly less Mathlib\n  support — net-negative formalization value at this stage.\n\n### Insights\n\n* **The interesting new content is the ball/polydisc dichotomy**, not the degree\n  asymptotics. Any future Lean work should foreground `Bᵈ ≇ Dᵈ` (`d ≥ 2`) as the\n  reason the 1-D `ρ(f)` does not lift uniquely.\n* **Reading (2) \"systems of polynomials\" is the cleanest to *state*** (common\n  zero variety in the unit polydisc, `|f|²=∑|fⱼ|²`) but the hardest to *bound*;\n  reading (1-polydisc) is the most faithful lift of the parent.\n* This is a \"formulate, don't prove\" OQ: its value is a precise problem\n  statement plus the observation that `d ≥ 2` is open even at the conjectural\n  level.\n\n### Recommendation / Next steps\n\n1. **Do not open a Lean file yet.** Net formalization value is negative until\n   either (a) Mathlib gains pluripotential capacity, or (b) a concrete, defensible\n   conjecture (rate + extremal configuration) is fixed for one chosen reading.\n2. If a future session insists on Lean, the *only* honest scope is a\n   **statement-only** formalization of reading (1-polydisc): define\n   `MvUnitPolydiscPolynomial`, the sublevel set, and `inscribedPolydiscRadius`,\n   and state the conjecture as an explicit `axiom` (mirroring the parent's\n   honesty), with the d=1 specialization proved to recover the parent's\n   `inscribedDiscRadius` — that reduction is the one genuinely provable nugget.\n3. **OQ-chain depth guard:** slug `erdos-1039-oq-04` has depth 1; a follow-up\n   would be depth 2 (permitted). But no strong follow-up exists — the question is\n   itself the open frontier — so **0** follow-ups generated.\n\n### Honesty note\n\nNo theorem was proved this session and none was claimed. This is a documentation\n/ problem-formulation contribution only. Status set to `in-progress` (surveyed),\nnot `completed`: the generalization remains open and unformalized.\n"
+  }
+}


### PR DESCRIPTION
Two research contributions from researcher-4 on one branch.

---

## 1. puiseux-theorem-oq-03 — uniqueness layer (VERIFIED, 0-axiom)

Adds the **uniqueness / well-definedness** counterpart to the combinatorial Newton polygon. Every prior result established *existence* (`exists_lowerHull`) or *ordering* (`edgeSlope_mono`, `edgeSlopes_pairwise_le`); none ruled out two genuinely different edge slopes leaving the same vertex. Under collinear support points the edge **endpoint** is genuinely ambiguous, so uniqueness is phrased on the **slope**:

- `IsLowerEdge.leaving_slope_unique` — two lower edges sharing a left endpoint have equal slope (each supporting line realises the *least* slope leaving the vertex; the two bound each other).
- `IsLowerEdge.arriving_slope_unique` — symmetric, at a shared right endpoint.
- `IsLowerEdge.leaving_rootValuation_unique` — corollary: the root valuation read off each vertex is unique.

Result: `edgeSlopes` of a hull is now a genuine invariant of the support set; the root valuation at each vertex is well-defined.

`proofs/Proofs/PuiseuxTheoremOQ03.lean` 1033→1095 lines, 51→54 theorems, 0 sorries. Docker build: 3070 jobs, 0 errors. `#print axioms` on all three lists only `propext`/`Classical.choice`/`Quot.sound`.

---

## 2. erdos-1039-oq-04 — OBSERVE survey (no Lean, by design)

Fresh Seeker-selected generalization OQ of `erdos-1039` (EHP lemniscate inradius, OPEN): the higher-dimensional / systems analogue. No Lean delivered because the parent is axiomatized/open and a `d ≥ 2` file would be scaffolding atop an unprovable conjecture with no Mathlib pluripotential support.

- The analogue **bifurcates** (single poly vs system; **ball vs polydisc** inradius — `Bᵈ ≇ Dᵈ` for `d ≥ 2`, so the 1-D `ρ(f)` lifts non-uniquely).
- Literature (2026-06-28): **no direct higher-dimensional EHP-inradius result exists**; all work is 1-D. Adjacent pluripotential-capacity tools exist but the conjecture is unposed for `d ≥ 2`.
- Mathlib gap documented; recommendation is to defer any Lean file.

Files: `research/problems/erdos-1039-oq-04/knowledge.md`, `src/data/research/problems/erdos-1039-oq-04.json`.

---

## Status
- puiseux-theorem-oq-03: **progress** (combinatorial layer now complete: existence + ordering + uniqueness + multiplicity; analytic frontier blocked on missing Mathlib K((x))[Y] valuation API)
- erdos-1039-oq-04: **surveyed** (formulation/documentation only; no theorem proved or claimed)

🤖 Generated by researcher-4