### PR TITLE
research(puiseux-theorem-oq-03): refine analytic-bridge blocker — base K((x)) valuation now upstream, ℚ-valued Puiseux field still absent [BLOCKED]

### DIFF
--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -386,3 +386,27 @@ Verification: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheo
 exits 0 (~34s, host toolchain, single-file against prebuilt Mathlib oleans). `#print axioms`
 checked by appending the print lines, `env lean`, then reverting (importing the module to a
 fresh file to print axioms segfaults with no built olean).
+
+---
+
+## Session (2026-06-28, researcher-5, S05): blocker refined — base valuation present, Puiseux ℚ-valuation absent
+
+Doc-only ORIENT. Re-checked the standing "analytic bridge blocked, no Mathlib bearer"
+verdict against the drifted Mathlib cache. Refined it to a **precise** statement:
+
+- **PRESENT** (new since 4.26.0): `Valued.v : Valuation K⸨X⸩ ℤᵐ⁰` on Laurent series
+  (`Mathlib/RingTheory/LaurentSeries.lean`), with monomial API `valuation_X_pow`,
+  `valuation_single_zpow`, `coeff_zero_of_lt_valuation`, etc. The base field `K⸨x⸩` is
+  now a valued field upstream — *more* than prior sessions assumed.
+- **ABSENT**: no `PuiseuxSeries`, no ℚ-valued / rational-exponent (`HahnSeries ℚ K`)
+  valuation. The polygon slopes / root valuations are **ℚ-valued** (roots live in the
+  ramified `K⸨x^{1/n}⸩`, e.g. a root of `Y²−x` has valuation ½); the available valuation
+  is **ℤᵐ⁰-valued** on the *unramified* base. The codomains (ℚ vs ℤ) don't match, so the
+  correspondence `edgeSlope = −v(root)` is not even *statable* without first building the
+  ramified Puiseux extension and its ℚ-valued valuation.
+
+**Verdict: BLOCKED** (combinatorially complete, analytically blocked). The missing
+primitive is a valued Puiseux field (`PuiseuxSeries K` / `HahnSeries ℚ K` + ℚ-valuation +
+ramified embedding of `K⸨x⸩`), foundational >1000-line infra not upstream. Next ACT step
+is to *construct that field*, not to add combinatorial lemmas (the polygon side is done).
+See `sessions/2026-06-28-s05-valuation-api-drift-blocker-refine.md`.

--- a/research/problems/puiseux-theorem-oq-03/sessions/2026-06-28-s05-valuation-api-drift-blocker-refine.md
+++ b/research/problems/puiseux-theorem-oq-03/sessions/2026-06-28-s05-valuation-api-drift-blocker-refine.md
@@ -1,0 +1,79 @@
+# 2026-06-28 — S05: Refining the analytic-bridge blocker (Mathlib valuation-API drift)
+
+**Researcher**: researcher-5
+**Branch**: `research/puiseux-theorem-oq-03-work`
+**Mode**: ORIENT (re-assess the standing blocker against the drifted Mathlib cache)
+**Outcome**: doc-only. No Lean change — the combinatorial API is complete and the
+remaining open core is confirmed **BLOCKED**, but the blocker is now stated *precisely*
+(which primitive is present, which is absent) instead of "no Mathlib bearer".
+
+## Context
+
+By the end of S04 + the 2026-06-28 researcher-1 session, the **combinatorial** Newton
+polygon theorem is fully formalized in `proofs/Proofs/PuiseuxTheoremOQ03.lean`
+(1081 lines, 53 theorems, **0 sorries / 0 axioms**): all three invariants —
+sorted edge slopes (valuations), positive widths summing to the index span
+(multiplicities), and the slope×width vertical drop (valuation of the root product) —
+now hold on the **same concrete hull** `exists_lowerHull` produces.
+
+The single remaining gap is the **analytic bridge**: slopes/widths of the polygon ↔
+actual valuations/multiplicities of the roots of `P ∈ K⸨x⸩[Y]`. Every prior session
+recorded this as "blocked on a `K((x))[Y]` valuation API absent from Mathlib 4.26.0."
+
+## What I checked (against the live `.lake` Mathlib cache, drifted past 4.26.0)
+
+**PRESENT — the base-field valuation now exists.** `Mathlib/RingTheory/LaurentSeries.lean`
+provides a genuine valuation on `K⸨X⸩`:
+
+- `Valued.v : Valuation K⸨X⸩ ℤᵐ⁰` with `valuation_def : Valued.v = (PowerSeries.idealX K).valuation _`.
+- Monomial API: `valuation_X_pow (s : ℕ)`, `valuation_single_zpow (s : ℤ)`,
+  `coeff_zero_of_lt_valuation`, `valuation_le_iff_coeff_lt_eq_zero`,
+  `eq_coeff_of_valuation_sub_lt`, plus the `RatFunc`/adic-completion comparison theorems.
+
+This is strictly more than the "absent" the standing note assumed — the **base field**
+`K⸨x⸩` is now a valued field in Mathlib, integer (`ℤᵐ⁰`) valued.
+
+**ABSENT — the Puiseux extension, the object the bridge actually needs.**
+
+- No `PuiseuxSeries` anywhere in the cache (`find -iname '*puiseux*'` → ∅;
+  `grep -rln 'PuiseuxSeries\|Puiseux'` → ∅).
+- No ℚ-valued / rational-exponent valuation (`HahnSeries ℚ K` model) → ∅.
+
+## Why this is the precise blocker (not cosmetic, a real type mismatch)
+
+The polygon's edge slopes / root valuations are **`ℚ`-valued** (`edgeSlope : ... → ℚ`,
+`rootValuation`), because the roots of `P ∈ K⸨x⸩[Y]` live in the **ramified** Puiseux
+field `K⸨x^{1/n}⸩`, whose valuation is `ℚ`-valued (a root of `Y² − x` has valuation `½`).
+The valuation Mathlib now supplies is on the **unramified** base `K⸨x⸩` and is
+**`ℤᵐ⁰`-valued**. So the available primitive cannot even *state* the correspondence
+`edgeSlope = −v(root)` — the codomains (`ℚ` vs `ℤ`) don't match without first
+constructing the ramified Puiseux extension and its `ℚ`-valued valuation.
+
+**Verdict: still BLOCKED**, now for a concrete reason. The missing primitive is a
+`PuiseuxSeries` / `HahnSeries ℚ K` field together with its `ℚ`-valued valuation (and
+the fact that `K⸨x⸩` embeds with the valuation scaling by the ramification index).
+This is foundational, >1000-line Mathlib-grade infrastructure that does not exist
+upstream — squarely the role's BLOCKED category (needs > 1000 lines foundational work),
+not a tactic-search gap. Submitting it to Aristotle would not help (no statement to prove
+until the field is built).
+
+## Concrete pointer for the next ACT session (if/when attempted)
+
+The smallest real step toward the bridge is to **construct the valued Puiseux field**,
+not to add more combinatorial lemmas:
+
+1. Define `PuiseuxSeries K := ⋃ₙ K⸨x^{1/n}⸩` (or `HahnSeries ℚ K` restricted to
+   finitely-generated-denominator support) and its `ℚ`-valued valuation.
+2. Prove `K⸨x⸩ ↪ PuiseuxSeries K` scales valuation by the ramification index.
+3. Only then is `edgeSlope = −v(root)` statable; the combinatorial side (this file)
+   already supplies everything on the polygon side.
+
+Until (1)–(3) exist upstream or are built here as a separate large infrastructure PR,
+`puiseux-theorem-oq-03` is **combinatorially complete, analytically blocked**.
+
+## Verification
+
+No Lean edit this session; the file remains the S04+researcher-1 state (verified
+`0 sorries / 0 axioms`). Findings above are from reading the in-tree Mathlib cache
+`proofs/.lake/packages/mathlib/Mathlib/RingTheory/LaurentSeries.lean` and exhaustive
+`find`/`grep` for Puiseux/rational-valuation modules.

--- a/research/problems/puiseux-theorem-oq-03/state.md
+++ b/research/problems/puiseux-theorem-oq-03/state.md
@@ -1,16 +1,20 @@
 # Research State: puiseux-theorem-oq-03
 
 ## Current State
-**Phase**: ACT
-**Path**: fast
-**Since**: 2026-06-28T07:20:55-07:00
-**Iteration**: 1
+**Phase**: BLOCKED (combinatorially complete; analytic bridge blocked)
+**Path**: full
+**Since**: 2026-06-28T13:30:00-07:00
+**Iteration**: 6
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Combinatorial Newton-polygon theorem is fully formalized (1081L, 53 thm,
+0 sorries / 0 axioms; all three invariants — sorted slopes, widths-sum,
+slope×width drop — on the concrete `exists_lowerHull` chain). Remaining open
+core is the analytic bridge (polygon slopes/widths ↔ valuations/multiplicities
+of roots of `P ∈ K⸨x⸩[Y]`).
 
 ## Active Approach
-None yet.
+None active — blocked on missing Mathlib infrastructure (see Blockers).
 
 ## Attempt Count
 - Total attempts: 0
@@ -18,8 +22,19 @@ None yet.
 - Approaches tried: 0
 
 ## Blockers
-None.
+**Analytic bridge needs a valued Puiseux field, absent from Mathlib.**
+- PRESENT (drifted cache, new since 4.26.0): `Valued.v : Valuation K⸨X⸩ ℤᵐ⁰`
+  (`Mathlib/RingTheory/LaurentSeries.lean`) + monomial API. Base field `K⸨x⸩`
+  is now a valued field upstream.
+- ABSENT: `PuiseuxSeries` / `HahnSeries ℚ K` and a ℚ-valued (rational-exponent)
+  valuation. Polygon slopes are ℚ-valued (roots live in ramified `K⸨x^{1/n}⸩`);
+  the available valuation is ℤᵐ⁰-valued on the unramified base, so the
+  correspondence `edgeSlope = −v(root)` is not even statable.
+- Building the valued Puiseux field is foundational >1000-line infra (BLOCKED
+  category). See `sessions/2026-06-28-s05-valuation-api-drift-blocker-refine.md`.
 
 ## Next Action
-Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.
-See FAST_PATH.md for protocol.
+If revisited: construct the valued Puiseux field (`PuiseuxSeries K` + ℚ-valuation
++ ramified embedding of `K⸨x⸩`) as a separate large infrastructure PR — the polygon
+(combinatorial) side is already complete. Do NOT add further combinatorial lemmas;
+that is cosmetic on a finished API.

--- a/src/data/research/problems/puiseux-theorem-oq-03.json
+++ b/src/data/research/problems/puiseux-theorem-oq-03.json
@@ -16,12 +16,14 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "BLOCKED",
     "since": "2026-05-12T13:53:16-07:00",
     "iteration": 2,
-    "focus": "Shipped combinatorial Newton polygon (S2-A): IsLowerVertex predicate + structure lemmas + Y^2-x example, verified 0-sorry 0-axiom.",
-    "blockers": [],
-    "nextAction": "S2-A harder half: Newton polygon theorem (edge slopes = root valuations) once a valuation API on K((x))[Y] exists; then S2-B termination measure.",
+    "focus": "Combinatorial Newton-polygon theorem fully formalized (all 3 invariants on the concrete hull); analytic bridge (slopes/widths <-> root valuations of P in K((x))[Y]) is blocked on missing Mathlib infra.",
+    "blockers": [
+      "Analytic bridge needs a valued Puiseux field absent from Mathlib. PRESENT (drifted cache): Valuation K((x)) -> Z^m0 (LaurentSeries.lean) + monomial API. ABSENT: PuiseuxSeries / HahnSeries Q K and a Q-valued (rational-exponent) valuation. Polygon slopes are Q-valued (roots in ramified K((x^(1/n))), e.g. root of Y^2-x has valuation 1/2); available valuation is Z^m0-valued on the unramified base, so edgeSlope = -v(root) is not even statable. Building the valued Puiseux field is foundational >1000-line infra (BLOCKED)."
+    ],
+    "nextAction": "If revisited: construct the valued Puiseux field (PuiseuxSeries K + Q-valuation + ramified embedding of K((x))) as a separate large infrastructure PR. The combinatorial side is complete; do not add further combinatorial lemmas.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (2026-06-28, researcher-9): capstone closed. exists_lowerHull_newtonPolygon bundles existence + sorted slopes + positive widths + widths-sum-to-span on the single recursion-built hull chain — the first statement uniting the valuation and multiplicity halves on one concrete object. File 949->1033 lines, 48->51 theorems, verified 0-axiom (propext/Classical.choice/Quot.sound only). Analytic Newton polygon theorem (slopes = root valuations) remains the open frontier, blocked on a Mathlib K((x))[Y] valuation API.",
+    "progressSummary": "BLOCKED (combinatorially complete, analytically blocked). 2026-06-28 researcher-5 S05: re-checked the standing \"no Mathlib valuation bearer\" verdict against the drifted cache and refined it. PRESENT now: Valued.v : Valuation K((x)) Z^m0 on Laurent series (LaurentSeries.lean) with monomial API (valuation_X_pow, valuation_single_zpow). ABSENT: PuiseuxSeries / HahnSeries Q K and any Q-valued valuation. Polygon slopes/root valuations are Q-valued (ramified K((x^(1/n)))) while the available valuation is Z^m0-valued on the unramified base -> the correspondence edgeSlope = -v(root) is not statable without first building the ramified Puiseux extension and its Q-valuation (foundational >1000-line infra, not upstream). The combinatorial Newton-polygon theorem itself (1081L, 53 thm, 0 sorries/0 axioms; all three invariants on the concrete exists_lowerHull chain) is COMPLETE. --- PRIOR: PROGRESS (2026-06-28, researcher-9): capstone closed. exists_lowerHull_newtonPolygon bundles existence + sorted slopes + positive widths + widths-sum-to-span on the single recursion-built hull chain — the first statement uniting the valuation and multiplicity halves on one concrete object. File 949->1033 lines, 48->51 theorems, verified 0-axiom (propext/Classical.choice/Quot.sound only). Analytic Newton polygon theorem (slopes = root valuations) remains the open frontier, blocked on a Mathlib K((x))[Y] valuation API.",
     "builtItems": [
       "IsLowerVertex: supporting-line characterization of a Newton-polygon lower-hull vertex (algorithm-independent Prop)",
       "isLowerVertex_of_minimal: the min-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -65,7 +67,8 @@
       "S2-A hull correctness (researcher-5, 2026-06-28): the obstruction to the documented \"peel-and-recurse\" hull construction is that a lower edge of the right restriction pts.filter(q.1 ≤ ·.1) can dip below a left point. RESOLVED: isLowerEdge_of_right proves it cannot, provided the edge slope clears the dominant slope m₀ — convexity forces the right edge line above the dominant line on the left half. This is the precise reason divide-and-conquer Newton-polygon construction is sound.",
       "exists_lowerHull (2026-06-28, researcher-4): the hull-construction recursion now runs to completion. Fuelled strong induction on pts.length (exists_lowerHull_aux) peels the dominant edge p→q₀ (exists_isLowerEdge_of_leftmost) and recurses on the right restriction pts.filter (q₀.1 ≤ ·.1), which strictly shrinks because the leftmost p is dropped (List.length_filter_eq_length_iff). isLowerEdge_chain_extend splices each peel. Result: a single chain of lower edges p::vs ending at a maximal-index vertex w — the existence half of the Newton polygon, VERIFIED 0-axiom.",
       "Prior valuation-half (edgeSlopes_pairwise_le) and multiplicity-half (sum_edgeWidths/edgeWidths_pos) were stated about an ABSTRACT chain hypothesis; exists_lowerHull produced a CONCRETE chain but said nothing about slopes/widths. The capstone discharges the chain hypothesis with the recursion-built chain, uniting all three on one object.",
-      "getLast?->getLast bridge: from (p::vs).getLast? = some w use List.mem_getLast?_eq_getLast to get ∃ h, w = getLast (p::vs) h; proof-irrelevance makes getLast _ (by simp) defeq, so the .symm closes getLast (by simp) = w and rw [sum_edgeWidths, hgl] telescopes the width sum to w.1 - p.1."
+      "getLast?->getLast bridge: from (p::vs).getLast? = some w use List.mem_getLast?_eq_getLast to get ∃ h, w = getLast (p::vs) h; proof-irrelevance makes getLast _ (by simp) defeq, so the .symm closes getLast (by simp) = w and rw [sum_edgeWidths, hgl] telescopes the width sum to w.1 - p.1.",
+      "Mathlib drift (2026-06-28): K((x)) is now a valued field upstream (Valuation K((x)) -> Z^m0, LaurentSeries.lean), but the Puiseux extension K((x^(1/n))) and its Q-valued valuation are still absent. The blocker is therefore a type-level mismatch (Q-valued polygon slopes vs Z-valued base valuation), not merely a missing lemma: the analytic correspondence cannot be stated until a ramified, Q-valued Puiseux field is constructed."
     ],
     "mathlibGaps": [
       "No Newton polygon API in Mathlib 4.26.0 (no Polynomial.newtonPolygon / lowerConvexHull as combinatorial vertex data).",
@@ -139,5 +142,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PuiseuxTheoremOQ02.lean"
     }
-  ]
+  ],
+  "lastUpdate": "2026-06-28T13:30:00.000Z"
 }


### PR DESCRIPTION
## Summary

Doc-only ORIENT session (S05) on `puiseux-theorem-oq-03` ("can Newton–Puiseux be made efficient at scale?").

The **combinatorial** Newton-polygon theorem is already fully formalized in `proofs/Proofs/PuiseuxTheoremOQ03.lean` (1081 lines, 53 theorems, **0 sorries / 0 axioms**): all three invariants — sorted edge slopes, positive widths summing to the index span, and the slope×width vertical drop — hold on the **same concrete hull** that `exists_lowerHull` produces. **No Lean change this session** — that API is complete; adding more combinatorial lemmas would be cosmetic.

The only remaining open core is the **analytic bridge** (polygon slopes/widths ↔ valuations/multiplicities of the roots of `P ∈ K⸨x⸩[Y]`). Prior sessions recorded it as "blocked, no Mathlib bearer." This session re-checks that against the drifted Mathlib cache and makes the blocker **precise**:

| | status in current cache |
|---|---|
| `Valued.v : Valuation K⸨X⸩ ℤᵐ⁰` (base Laurent-series valuation) + monomial API | ✅ **PRESENT** (new since 4.26.0, `RingTheory/LaurentSeries.lean`) |
| `PuiseuxSeries` / `HahnSeries ℚ K` and a ℚ-valued valuation | ❌ **ABSENT** |

### Why it stays BLOCKED (a real type mismatch, not a missing tactic)

The polygon's edge slopes / root valuations are **ℚ-valued** — the roots of `P ∈ K⸨x⸩[Y]` live in the ramified Puiseux field `K⸨x^{1/n}⸩` (a root of `Y²−x` has valuation `½`). The valuation Mathlib now supplies is on the **unramified** base `K⸨x⸩` and is **ℤᵐ⁰-valued**. The codomains (`ℚ` vs `ℤ`) don't match, so the correspondence `edgeSlope = −v(root)` cannot even be *stated* without first constructing the ramified Puiseux extension and its ℚ-valued valuation — foundational >1000-line infrastructure absent upstream.

### Deliverable

- New session note `sessions/2026-06-28-s05-valuation-api-drift-blocker-refine.md` with the exact present/absent API and a concrete next-step recipe (build the valued Puiseux field, *then* state the bridge).
- `knowledge.md` + `state.md` + research JSON updated to the refined **BLOCKED** verdict (combinatorially complete, analytically blocked).
- Problem status → `blocked`.

This saves the next session the rediscovery and redirects effort from cosmetic combinatorial additions to the one real prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)