### PR TITLE
research(erdos-1005-oq-02): §21 all-ones continuant — period-6 + bounded [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -1909,4 +1909,126 @@ theorem continuant_head_mono {k k' : ℤ} {ks : List ℤ}
   have hpos : 0 < Continuant ks := continuant_pos ks h
   nlinarith [mul_nonneg (sub_nonneg.mpr hkk) (le_of_lt hpos)]
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 21: The balanced extreme — all-ones continuant is period-6 and bounded
+-- ══════════════════════════════════════════════════════════════════
+
+/-
+§ 17 exhibited the two regimes of the continuant.  In the **large-quotient**
+regime (every entry `≥ 2`) it is strictly positive and grows at least linearly
+(`continuant_ge_length`, sharp via the all-`2` ladder `continuant_replicate_two`).
+The opposite, **balanced** extreme is the all-`1` list, where §17 recorded only
+the two witnesses `continuant_ones_two` (`K[1,1] = 0`) and `continuant_ones_three`
+(`K[1,1,1] = −1`), noting they sit on the period-6 orbit `1,1,0,−1,−1,0,…` of the
+rotation matrix `[[1,−1],[1,0]]` but proving only those two points.
+
+This section promotes the witnesses to the full statement.  Writing
+`aₙ = K(1ⁿ)`, `sₙ = secondCont(1ⁿ)`, the §14 single-step recurrence
+`continuant_cons` specialises (every quotient `= 1`) to the coupled linear system
+`aₙ₊₁ = aₙ − sₙ`, `sₙ₊₁ = aₙ`, i.e. `aₙ₊₁ = aₙ − aₙ₋₁`.  Its companion matrix is
+the order-6 rotation, whose sixth power is the identity, so the pair is
+**6-periodic**; the continuant therefore takes only the three values `−1, 0, 1`
+and, unlike the all-`2` ladder, never grows.  This is the exact quantitative form
+of the §15/§17 dichotomy: a long run of small quotients keeps the continuant
+bounded, whereas a regime of large quotients forces linear growth — the structural
+reason the open `1/12`–`1/4` optimisation must trade the two regimes against the
+order-`n` denominator cap (a similarly ordered run cannot be both long and
+metrically cheap at once).
+-/
+
+/-- All-ones trailing continuant: `secondCont(1ⁿ⁺¹) = K(1ⁿ)`.  Immediate from the
+`secondCont (_ :: ks) = Continuant ks` convention. -/
+theorem secondCont_replicate_one (m : ℕ) :
+    secondCont (List.replicate (m + 1) 1) = Continuant (List.replicate m 1) := by
+  rw [List.replicate_succ]; rfl
+
+/-- All-ones continuant single-step recurrence `aₙ₊₁ = aₙ − sₙ`: every quotient
+being `1`, the §14 `continuant_cons` loses its leading factor. -/
+theorem continuant_replicate_one_succ (m : ℕ) :
+    Continuant (List.replicate (m + 1) 1)
+      = Continuant (List.replicate m 1) - secondCont (List.replicate m 1) := by
+  rw [List.replicate_succ, continuant_cons]; ring
+
+/-- **The all-ones continuant is period-6 (joint headline).**  Both the continuant
+`aₙ = K(1ⁿ)` and its trailing companion `sₙ = secondCont(1ⁿ)` satisfy
+`a₍ₙ₊₆₎ = aₙ` and `s₍ₙ₊₆₎ = sₙ`.  The coupled recurrence `aₙ₊₁ = aₙ − sₙ`,
+`sₙ₊₁ = aₙ` is the order-6 rotation `[[1,−1],[1,0]]`, whose sixth power is the
+identity; unfolding six steps reduces the claim to linear integer arithmetic that
+`omega` discharges. -/
+theorem continuant_secondCont_replicate_one (n : ℕ) :
+    Continuant (List.replicate (n + 6) 1) = Continuant (List.replicate n 1)
+      ∧ secondCont (List.replicate (n + 6) 1) = secondCont (List.replicate n 1) := by
+  have c1 : Continuant (List.replicate (n + 1) 1)
+      = Continuant (List.replicate n 1) - secondCont (List.replicate n 1) :=
+    continuant_replicate_one_succ n
+  have s1 : secondCont (List.replicate (n + 1) 1) = Continuant (List.replicate n 1) :=
+    secondCont_replicate_one n
+  have c2 : Continuant (List.replicate (n + 2) 1)
+      = Continuant (List.replicate (n + 1) 1) - secondCont (List.replicate (n + 1) 1) :=
+    continuant_replicate_one_succ (n + 1)
+  have s2 : secondCont (List.replicate (n + 2) 1) = Continuant (List.replicate (n + 1) 1) :=
+    secondCont_replicate_one (n + 1)
+  have c3 : Continuant (List.replicate (n + 3) 1)
+      = Continuant (List.replicate (n + 2) 1) - secondCont (List.replicate (n + 2) 1) :=
+    continuant_replicate_one_succ (n + 2)
+  have s3 : secondCont (List.replicate (n + 3) 1) = Continuant (List.replicate (n + 2) 1) :=
+    secondCont_replicate_one (n + 2)
+  have c4 : Continuant (List.replicate (n + 4) 1)
+      = Continuant (List.replicate (n + 3) 1) - secondCont (List.replicate (n + 3) 1) :=
+    continuant_replicate_one_succ (n + 3)
+  have s4 : secondCont (List.replicate (n + 4) 1) = Continuant (List.replicate (n + 3) 1) :=
+    secondCont_replicate_one (n + 3)
+  have c5 : Continuant (List.replicate (n + 5) 1)
+      = Continuant (List.replicate (n + 4) 1) - secondCont (List.replicate (n + 4) 1) :=
+    continuant_replicate_one_succ (n + 4)
+  have s5 : secondCont (List.replicate (n + 5) 1) = Continuant (List.replicate (n + 4) 1) :=
+    secondCont_replicate_one (n + 4)
+  have c6 : Continuant (List.replicate (n + 6) 1)
+      = Continuant (List.replicate (n + 5) 1) - secondCont (List.replicate (n + 5) 1) :=
+    continuant_replicate_one_succ (n + 5)
+  have s6 : secondCont (List.replicate (n + 6) 1) = Continuant (List.replicate (n + 5) 1) :=
+    secondCont_replicate_one (n + 5)
+  constructor <;> omega
+
+/-- The all-ones continuant alone is period-6: `K(1ⁿ⁺⁶) = K(1ⁿ)`. -/
+theorem continuant_replicate_one_period (n : ℕ) :
+    Continuant (List.replicate (n + 6) 1) = Continuant (List.replicate n 1) :=
+  (continuant_secondCont_replicate_one n).1
+
+/-- Period-6 across any multiple of `6`: `K(1^(6q+r)) = K(1ʳ)`, by induction on the
+number of full turns `q` of the rotation orbit. -/
+theorem continuant_replicate_one_six_mul (q r : ℕ) :
+    Continuant (List.replicate (6 * q + r) 1) = Continuant (List.replicate r 1) := by
+  induction q with
+  | zero => simp
+  | succ q ih =>
+    have hidx : 6 * (q + 1) + r = (6 * q + r) + 6 := by ring
+    rw [hidx, continuant_replicate_one_period, ih]
+
+/-- **Closed form via residue mod 6.**  `K(1ⁿ)` depends only on `n % 6`, so the
+period-6 orbit `1,1,0,−1,−1,0` (for `n % 6 = 0,…,5`) determines every value. -/
+theorem continuant_replicate_one_mod (n : ℕ) :
+    Continuant (List.replicate n 1) = Continuant (List.replicate (n % 6) 1) := by
+  conv_lhs => rw [← Nat.div_add_mod n 6]
+  exact continuant_replicate_one_six_mul (n / 6) (n % 6)
+
+/-- **The balanced extreme stays bounded.**  For *every* length `n`,
+`K(1ⁿ) ∈ {1, 0, −1}` — the all-ones continuant never grows.  This is the sharp
+contrast with the all-`2` ladder `continuant_replicate_two` (`K = n + 1`, linear
+growth): the §17 dichotomy made fully quantitative on its two extremes. -/
+theorem continuant_replicate_one_bounded (n : ℕ) :
+    Continuant (List.replicate n 1) = 1 ∨ Continuant (List.replicate n 1) = 0
+      ∨ Continuant (List.replicate n 1) = -1 := by
+  rw [continuant_replicate_one_mod n]
+  have h6 : n % 6 < 6 := by omega
+  set r := n % 6 with hr
+  clear_value r
+  interval_cases r <;> decide
+
+/-- `|K(1ⁿ)| ≤ 1` for all `n` — the bound packaged as an absolute value, the
+order-side statement that the balanced extreme is metrically flat. -/
+theorem continuant_replicate_one_abs_le_one (n : ℕ) :
+    |Continuant (List.replicate n 1)| ≤ 1 := by
+  rcases continuant_replicate_one_bounded n with h | h | h <;> rw [h] <;> decide
+
 end Erdos1005OQ02

--- a/research/problems/erdos-1005-oq-02/knowledge.md
+++ b/research/problems/erdos-1005-oq-02/knowledge.md
@@ -107,3 +107,31 @@ is its minimiser.
 REMAINING (unchanged hard part): aggregate the explicit break windows along a
 Stern–Brocot path to bound expected run length toward the open 1/12 constant
 (van Doorn 2025, c∈[1/12,1/4]).
+
+## Session 2026-06-28 (researcher-6): §21 all-ones continuant — period-6 + bounded
+
+PR (VERIFIED, 0-axiom; docker-build.sh clean, `#print axioms` = propext /
+Classical.choice / Quot.sound only on all 8 new theorems — `decide`, NOT
+`native_decide`, so no `Lean.ofReduceBool`). Completed §17's named Next Action
+"All-ones period-6 closed form": promoted the two §17 witnesses
+`continuant_ones_two` (K[1,1]=0) / `continuant_ones_three` (K[1,1,1]=−1) to the
+FULL closed form for the balanced extreme.
+
+Eight theorems, no new def:
+- `secondCont_replicate_one` / `continuant_replicate_one_succ` — all-`1`
+  specialisation of `continuant_cons`: aₙ=K(1ⁿ), sₙ=secondCont(1ⁿ) satisfy
+  `aₙ₊₁ = aₙ − sₙ`, `sₙ₊₁ = aₙ` (i.e. aₙ₊₁=aₙ−aₙ₋₁), the order-6 rotation [[1,−1],[1,0]].
+- `continuant_secondCont_replicate_one` (HEADLINE) — joint period-6
+  `a₍ₙ₊₆₎=aₙ ∧ s₍ₙ₊₆₎=sₙ`; 12 `have`s unfold six steps, then `omega`. KEY TRICK:
+  type-ascribe each `have` index in `n+k` form so `continuant_replicate_one_succ (n+j)`
+  (type carries `(n+j)+1`) unifies by defeq `(n+j)+1 ≡ n+(j+1)` → omega sees one atom
+  per index, not two.
+- `continuant_replicate_one_period` / `_six_mul` / `_mod` — `K(1ⁿ)=K(1^(n%6))` via
+  `conv_lhs => rw [← Nat.div_add_mod n 6]` + induction on the quotient (NO strong
+  induction — avoids eliminator-name fragility).
+- `continuant_replicate_one_bounded` (`K(1ⁿ)∈{1,0,−1}`), `_abs_le_one` (`|K(1ⁿ)|≤1`).
+
+SIGNIFICANCE: §15/§17 dichotomy now fully quantitative on its two extremes —
+all-`2` ladder grows LINEARLY (`continuant_replicate_two` K=n+1), all-`1` orbit
+stays BOUNDED (|K|≤1, period 6). Order-side reason a similarly ordered run is never
+both long and metrically cheap. Mixed-quotient regime (open 1/12–1/4) untouched.

--- a/research/problems/erdos-1005-oq-02/state.md
+++ b/research/problems/erdos-1005-oq-02/state.md
@@ -334,3 +334,34 @@ continuant grows at least linearly with run length there.
   cap (`stepSeq b d ks = K·d − secondCont·b ≤ n`) to bound the run length of a
   large-quotient run by `O(n / d)` — the first genuine run-length *upper* bound in the
   all-`≥2` regime, a sanity check against the `n/4 + 5` global upper bound.
+
+## Iteration 17 addition (verified, 0-axiom — researcher-6, docker-build.sh)
+
+Added **§21 (the balanced extreme — all-ones continuant is period-6 and bounded)**,
+0-sorry / 0-axiom (`docker-build.sh Proofs.Erdos1005ProblemOQ02` clean; `#print
+axioms` = propext / Classical.choice / Quot.sound only on all 8 new theorems —
+`decide`, not `native_decide`, so NO `Lean.ofReduceBool`). Delivers §17's named
+Next Action "All-ones period-6 closed form": the two §17 witnesses
+`continuant_ones_two` (K[1,1]=0), `continuant_ones_three` (K[1,1,1]=−1) promoted
+to the complete closed form.
+
+- `secondCont_replicate_one`, `continuant_replicate_one_succ` — all-`1`
+  specialisation of `continuant_cons`: `aₙ₊₁=aₙ−sₙ`, `sₙ₊₁=aₙ` (order-6 rotation).
+- `continuant_secondCont_replicate_one` (headline) — joint period-6; 6 unfolded steps + omega.
+- `continuant_replicate_one_period` / `_six_mul` / `_mod` — `K(1ⁿ)=K(1^(n%6))`.
+- `continuant_replicate_one_bounded` (`K(1ⁿ)∈{1,0,−1}`), `_abs_le_one` (`|K(1ⁿ)|≤1`).
+
+File: 1912 → 2034 lines, 82 → 90 theorems (file-internal count).
+
+**Quantitative dichotomy, both extremes closed.** all-`2`: K=n+1 (linear); all-`1`:
+|K|≤1 (bounded, period 6). Mixed regime (open 1/12–1/4 constant) remains open.
+
+## Next Action (after §21)
+
+- **Mixed regime.** Characterise via `continuant_cons` which mixed quotient lists keep
+  `Continuant ks ≥ 1` (boundary between the large-quotient positive cone and the
+  balanced period-6 orbit) — e.g. a threshold on accumulated quotient mass between
+  consecutive `1`s.
+- **Density aggregation.** Combine `continuant_ge_length` (all-`≥2`) with the order-`n`
+  cap `stepSeq b d ks = K·d − sc·b ≤ n` to bound large-quotient run length by `O(n/d)`
+  — first genuine run-length upper bound, sanity check vs `n/4+5`.

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -5,12 +5,12 @@
   "title": "Mediant Insertion and the Farey Gap Calculus: The Mediant Is the Unique Smallest-Denominator Fraction in a Gap",
   "description": "A self-contained, axiom-free formalization of the exact arithmetic of mediant insertion — the operation that refines the Farey sequence F_n into F_{n+1} by inserting, between adjacent fractions a/b < c/d, their mediant (a+c)/(b+d). Two threads are proved. First, the gap-splitting calculus: a unimodular gap of size 1/(bd) is split by its mediant into a left sub-gap 1/(b(b+d)) and a right sub-gap 1/(d(b+d)); these sum back to 1/(bd), stand in ratio d:b, and each is strictly smaller than the whole. Second, the headline minimal-denominator theorem: any fraction p/q strictly between two unimodular neighbours has denominator q ≥ b+d, and equality forces p/q = (a+c)/(b+d) exactly. Hence the mediant is the unique fraction of smallest denominator inside any Farey gap, and b+d is a hard lower bound on refining it — no construction can introduce a fraction of smaller denominator. The parent entry (Erdős #1005) records the open lower bound f(n) ≥ (1/12−o(1))n on runs of similarly ordered Farey fractions; that constant remains open and is NOT addressed here. This entry formalizes the verified mediant calculus on which such lower-bound constructions are built.",
   "leanFile": {
-    "lineCount": 1912,
+    "lineCount": 2034,
     "axiomCount": 0,
     "path": "Proofs/Erdos1005ProblemOQ02.lean",
     "sorries": 0,
     "definitionCount": 15,
-    "theoremCount": 116
+    "theoremCount": 124
   },
   "meta": {
     "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot mediant theory)",

--- a/src/data/research/problems/erdos-1005-oq-02.json
+++ b/src/data/research/problems/erdos-1005-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: §10–§11 added (verified, 0-axiom). §10: every Farey-adjacent pair is similarly ordered (single steps never break a run, any k). §11: the first NON-adjacent obstruction — a length-3 run a/b,c/d,e/f reduces to its outer pair, similarly ordered iff (2a−k·c)(2b−k·d)≥0; break interval for k is (2a/c,2b/d) of width 2/(cd), the first explicit metric break criterion. Open 1/12 constant untouched.",
+    "progressSummary": "PROGRESS: §21 added (verified, 0-axiom). All-ones (balanced extreme) continuant K(1ⁿ) proved period-6 with closed form K(1^(n%6)) and bound |K(1ⁿ)|≤1, promoting the two §17 witnesses to the full statement. Quantitative §15/§17 dichotomy now closed on both extremes (all-2 linear K=n+1 vs all-1 bounded period-6). Mixed regime / open 1/12 constant untouched.",
     "builtItems": [
       "unimodular_iterate_left/right (Erdos1005ProblemOQ02.lean §6): k-fold one-sided mediant insertion stays unimodular, a/b<(k·a+c)/(k·b+d); proved by scale-invariance of bc=ad+1 (no induction)",
       "denom_ge_iterate_left/right (Erdos1005ProblemOQ02.lean §6): depth-k interior denominator bound q ≥ (k+1)·b+d, LINEAR in depth",
@@ -44,7 +44,11 @@
       "simOrd_long_iff: SimOrd a b g h ↔ ((k₂+1)a−(k₁k₂−1)c)((k₂+1)b−(k₁k₂−1)d) ≥ 0, the long-range criterion for the endpoints of a two-step (length-4) Farey run. [verified, 0-axiom]",
       "simOrd_quad: length-4 run a/b,c/d,e/f,g/h pairwise similarly ordered ↔ conjunction of the two §11 length-3 windows and the simOrd_long_iff long-range window. [verified, 0-axiom]",
       "§13/§14 (merged PRs #31014/#31072): the continuant K(ks) = (minus-sign) continuant of a quotient list governs the run-length criterion at every length; simOrd_run_iff states a length-(|ks|+1) run is similarly ordered iff the single continuant window ((1+secondCont ks)a − K·c)((1+secondCont ks)b − K·d) ≥ 0. defs Continuant, secondCont, stepSeq; continuant_cons unified recurrence; stepSeq_eq_continuant closed form.",
-      "§15 (THIS SESSION): stepPair a c ks — the iterated §9/§14 successor returning the final consecutive PAIR (t_{|ks|}, t_{|ks|+1}); stepPair_snd: its 2nd component is stepSeq a c ks. stepPair_cross (HEADLINE): the walk's cross-determinant (stepPair a c ks).1·(stepPair b d ks).2 − (stepPair a c ks).2·(stepPair b d ks).1 = a·d − b·c — INVARIANT under every step (det of [[k,−1],[1,0]] is 1), proved by list induction threading the seed pair. stepPair_cross_unimodular: a unimodular seed (b·c=a·d+1) stays unimodular (cross = −1) at EVERY depth. stepPair_cross_one: §9 subsumption. The depth-uniform form of §9's single-step consecutiveness bridge. [verified, 0-axiom]"
+      "§15 (THIS SESSION): stepPair a c ks — the iterated §9/§14 successor returning the final consecutive PAIR (t_{|ks|}, t_{|ks|+1}); stepPair_snd: its 2nd component is stepSeq a c ks. stepPair_cross (HEADLINE): the walk's cross-determinant (stepPair a c ks).1·(stepPair b d ks).2 − (stepPair a c ks).2·(stepPair b d ks).1 = a·d − b·c — INVARIANT under every step (det of [[k,−1],[1,0]] is 1), proved by list induction threading the seed pair. stepPair_cross_unimodular: a unimodular seed (b·c=a·d+1) stays unimodular (cross = −1) at EVERY depth. stepPair_cross_one: §9 subsumption. The depth-uniform form of §9's single-step consecutiveness bridge. [verified, 0-axiom]",
+      "§21 continuant_secondCont_replicate_one (Erdos1005ProblemOQ02.lean:1958) — joint period-6 a₍ₙ₊₆₎=aₙ ∧ s₍ₙ₊₆₎=sₙ, 6 unfolded steps + omega, 0-axiom",
+      "§21 continuant_replicate_one_mod (:2010) — closed form K(1ⁿ)=K(1^(n%6)) via div_add_mod + induction on quotient",
+      "§21 continuant_replicate_one_bounded/_abs_le_one (:2019/:2030) — K(1ⁿ)∈{1,0,−1}, |K(1ⁿ)|≤1 for all n",
+      "§21 secondCont_replicate_one / continuant_replicate_one_succ (:1941/:1947) — all-1 specialisation of continuant_cons"
     ],
     "insights": [
       "CORRECTION: the roadmap heuristic that the order-n cap forces O(log n) refinement depth is FALSE for arbitrary mediant chains. The one-sided chain 0/1,1/2,1/3,…,1/n fits Θ(n) levels under q≤n with only LINEAR denominator growth (k+1)·b+d.",
@@ -56,13 +60,14 @@
       "§12: a length-4 Farey run (two quotients k₁,k₂) breaks ONLY through three explicit non-adjacent windows — the two §11 length-3 windows plus a NEW long-range endpoint window. The three adjacent pairs are always free (§10).",
       "§12: the long-range endpoint pair a/b,g/h of a length-4 run is controlled by the Stern–Brocot PRODUCT k₁·k₂−1 (combined depth of both steps), not by either quotient alone — the first break invisible to any single Farey step. Closed form g=(k₁k₂−1)c−k₂a, h=(k₁k₂−1)d−k₂b.",
       "CORRECTION to the §14 state.md 'Next Action (1)': the proposed target 'K(ks) ≥ 1 for all-≥1 quotient lists' is mathematically FALSE for the minus-sign continuant. Counterexamples: K([1,1]) = 1·1−1 = 0, K([1,1,1]) = 1−1−1 = −1. With all quotients = 1 the continuant is periodic (period 6: 1,1,0,−1,−1,0,…), the rotation-by-60° orbit of [[1,−1],[1,0]]. So blanket continuant positivity is unavailable; the windows' sign structure must be analysed via the DETERMINANT (Cassini) invariant instead — which is what §15 supplies (det of each step matrix is 1, so the walk's cross-determinant is invariant).",
-      "§15: the iterated Farey walk's cross-determinant nₘ·dₘ₊₁ − nₘ₊₁·dₘ is INVARIANT = a·d − b·c at every depth (stepPair_cross), because each §14 step is the unimodular matrix [[k,−1],[1,0]] (det 1). Hence a Farey-adjacent (unimodular) seed walks along genuinely consecutive Farey fractions at EVERY depth — the depth-uniform consecutiveness §9 gave one step at a time. This is the correct structural invariant of the quotient-list walk (replacing the false continuant-positivity target), and the right handle for a Cassini/continuant determinant identity."
+      "§15: the iterated Farey walk's cross-determinant nₘ·dₘ₊₁ − nₘ₊₁·dₘ is INVARIANT = a·d − b·c at every depth (stepPair_cross), because each §14 step is the unimodular matrix [[k,−1],[1,0]] (det 1). Hence a Farey-adjacent (unimodular) seed walks along genuinely consecutive Farey fractions at EVERY depth — the depth-uniform consecutiveness §9 gave one step at a time. This is the correct structural invariant of the quotient-list walk (replacing the false continuant-positivity target), and the right handle for a Cassini/continuant determinant identity.",
+      "All-1 continuant K(1ⁿ) is period-6: every quotient =1 collapses continuant_cons to aₙ₊₁=aₙ−sₙ, sₙ₊₁=aₙ — the order-6 rotation [[1,−1],[1,0]], whose 6th power is the identity",
+      "Quantitative §15/§17 dichotomy CLOSED on both extremes: all-2 ladder grows linearly (K=n+1) while all-1 orbit stays bounded (|K|≤1) — the order-side reason a similarly ordered run is never both long and metrically cheap"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Continuant Cassini identity (REPLACES the false §14 'K(ks)≥1' target): prove K(ks)·m11 − m01·secondCont ks = 1 where (m01,m11) is the companion second column of the step-matrix product (base (0,1)), or the consecutive-list form K(ks++[k])·sc(ks) − K(ks)·sc(ks++[k]) = ±1. Re-expresses §15 stepPair_cross purely in continuant terms; same det-1 reasoning.",
-      "Continuant reversal symmetry K(ks.reverse) = K(ks) (true; holds at rungs 2,3) — the palindrome structure of the run windows a density count exploits.",
-      "Aggregate the explicit break windows (length-3 width 2/(cd); length-4 long-range product k₁k₂−1; general continuant window simOrd_run_iff) along a Stern–Brocot path to bound expected run length — the quantitative route toward the open 1/12 constant."
+      "Mixed regime: characterise via continuant_cons which mixed quotient lists keep Continuant ks ≥ 1 (boundary between large-quotient positive cone and balanced period-6 orbit)",
+      "Density aggregation: combine continuant_ge_length with order-n cap stepSeq b d ks ≤ n to bound large-quotient run length by O(n/d) — first run-length upper bound vs n/4+5"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Extends the Farey-gap continuant development (Erdős #1005 OQ-02) with **§21**, completing §17's explicitly-named Next Action *"All-ones period-6 closed form"*. It promotes the two §17 witnesses `continuant_ones_two` (K[1,1]=0) and `continuant_ones_three` (K[1,1,1]=−1) — previously the only proven points of the balanced extreme — to the **full closed form**.

## What's new (8 theorems, no new def; 1912 → 2034 lines)

Writing `aₙ = K(1ⁿ)`, `sₙ = secondCont(1ⁿ)`:

- **`secondCont_replicate_one` / `continuant_replicate_one_succ`** — the all-`1` specialisation of §14 `continuant_cons`: every quotient `= 1` collapses the recurrence to `aₙ₊₁ = aₙ − sₙ`, `sₙ₊₁ = aₙ` (i.e. `aₙ₊₁ = aₙ − aₙ₋₁`), the companion form of the order-6 rotation `[[1,−1],[1,0]]`.
- **`continuant_secondCont_replicate_one`** (headline) — joint period-6 `a₍ₙ₊₆₎ = aₙ ∧ s₍ₙ₊₆₎ = sₙ`. Six unfolded recurrence steps reduce it to linear integer arithmetic discharged by `omega`.
- **`continuant_replicate_one_period` / `_six_mul` / `_mod`** — the residue closed form `K(1ⁿ) = K(1^(n%6))`, via `Nat.div_add_mod` + induction on the number of full turns.
- **`continuant_replicate_one_bounded`** (`K(1ⁿ) ∈ {1, 0, −1}`) and **`_abs_le_one`** (`|K(1ⁿ)| ≤ 1`) for every `n`.

## Why it matters

This makes the §15/§17 dichotomy **fully quantitative on both extremes**:
- all-`2` ladder → continuant grows **linearly** (`continuant_replicate_two`, `K = n+1`);
- all-`1` orbit → continuant stays **bounded** (`|K| ≤ 1`, period 6).

The order-side reason a similarly ordered Farey run cannot be simultaneously long and metrically cheap. The mixed-quotient regime — the actual open `1/12`–`1/4` constant (van Doorn 2025) — **remains open and is not claimed here**.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1005ProblemOQ02` — clean build.
- `#print axioms` on all 8 new theorems reports only `propext / Classical.choice / Quot.sound` (uses `decide`, **not** `native_decide` — no `Lean.ofReduceBool`).
- 0 sorry, 0 `axiom` declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)