### PR TITLE
research(property-b-first-moment-oq-03): non-uniform first-moment Property B criterion [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PropertyBFirstMomentOQ03.lean
+++ b/proofs/Proofs/PropertyBFirstMomentOQ03.lean
@@ -1,0 +1,122 @@
+/-
+  OQ-03: Non-uniform sharpening of the first-moment Property B criterion
+
+  Parent `PropertyBFirstMoment.lean` proves Erdős 1963 for *uniform* hypergraphs:
+  a `k`-uniform family with `< 2^(k-1)` edges has Property B (is 2-colorable).
+  That bound only uses the edge *count*. This file sharpens the same first-moment
+  argument to **arbitrary edge sizes**: the genuine Erdős criterion
+
+      ∑_{e ∈ E} 2^(1-|e|) < 1   ⟹   E has Property B,
+
+  stated over the natural numbers (no division) as `2 · ∑_{e} 2^(n-|e|) < 2^n`,
+  where `n = |V|`. Large edges contribute geometrically less, so a family with
+  many large edges and few small ones is 2-colorable even when its raw edge count
+  far exceeds `2^(k-1)` for the smallest edge size `k`. The uniform theorem is the
+  special case `|e| = k` (proved here as a corollary, confirming the refinement is
+  faithful).
+
+  This is the **sharp form of the first-moment lower bound**. It is NOT the
+  Radhakrishnan–Srinivasan bound `m(k) = Ω(2^k · √(k/log k))` that OQ-03 ultimately
+  targets: that extra `√(k/log k)` factor requires a *random recoloring* (alteration)
+  argument — a second round that repairs the monochromatic edges left by the first —
+  which is beyond the single-round first moment formalized here. See the knowledge
+  base for the recoloring roadmap and tractability assessment.
+
+  Status: 0 sorries, 0 axioms.
+-/
+import Proofs.PropertyBFirstMoment
+
+namespace ProbMethod.PropertyB
+
+open Finset BigOperators
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- **Non-uniform first-moment criterion for Property B.** A finite edge family `E`
+of nonempty edges (each of size `≤ n = |V|`) is 2-colorable as soon as the weighted
+edge sum satisfies `2 · ∑_{e ∈ E} 2^(n - |e|) < 2^n` — equivalently `∑_e 2^(1-|e|) < 1`.
+
+The proof is the parent's first moment over the `2^n` uniform 2-colorings, now without
+the uniformity assumption: the total `(coloring, monochromatic edge)` incidence count is
+`∑_{e} 2 · 2^(n-|e|)` (each edge `e` is monochromatic under exactly `2 · 2^(n-|e|)`
+colorings, by `card_mono`), and when that is `< 2^n` the first moment principle
+(`exists_zero_of_sum_lt_card`) hands back a coloring with no monochromatic edge. -/
+theorem property_b_of_weighted_first_moment
+    (E : Finset (Finset V))
+    (hne : ∀ e ∈ E, e.Nonempty)
+    (hsmall : 2 * ∑ e ∈ E, 2 ^ (Fintype.card V - e.card) < 2 ^ Fintype.card V) :
+    ∃ c : V → Bool, ∀ e ∈ E, ¬ Mono e c := by
+  -- ∑_c (#monochromatic edges under c) = ∑_e 2·2^(n-|e|)
+  have hsum :
+      (∑ c : V → Bool, (E.filter (fun e => Mono e c)).card)
+        = ∑ e ∈ E, 2 * 2 ^ (Fintype.card V - e.card) := by
+    simp_rw [Finset.card_filter]
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl ?_
+    intro e he
+    rw [← Finset.card_filter, card_mono e (hne e he)]
+  have hcard : (univ : Finset (V → Bool)).card = 2 ^ Fintype.card V := by
+    rw [Finset.card_univ, Fintype.card_fun, Fintype.card_bool]
+  -- strict inequality: incidence sum < number of colorings
+  have hlt :
+      (∑ c : V → Bool, (E.filter (fun e => Mono e c)).card)
+        < (univ : Finset (V → Bool)).card := by
+    rw [hsum, hcard, ← Finset.mul_sum]
+    exact hsmall
+  -- first moment principle yields a coloring with zero monochromatic edges
+  obtain ⟨c, -, hc⟩ := exists_zero_of_sum_lt_card hlt
+  refine ⟨c, ?_⟩
+  have hempty : E.filter (fun e => Mono e c) = ∅ := Finset.card_eq_zero.mp hc
+  intro e he
+  exact (Finset.filter_eq_empty_iff.mp hempty) he
+
+/-- **The uniform Erdős bound is the special case.** Re-deriving `property_b_two_colorable`
+(`k`-uniform, `< 2^(k-1)` edges) from the non-uniform criterion: with every `|e| = k` the
+weighted sum collapses to `|E| · 2^(n-k)`, and `|E| < 2^(k-1)` is exactly
+`2 · |E| · 2^(n-k) < 2^n`. This confirms the refinement faithfully extends the parent. -/
+theorem property_b_two_colorable_of_uniform
+    (E : Finset (Finset V)) (k : ℕ) (hk : 1 ≤ k)
+    (huniform : ∀ e ∈ E, e.card = k)
+    (hsmall : E.card < 2 ^ (k - 1)) :
+    ∃ c : V → Bool, ∀ e ∈ E, ¬ Mono e c := by
+  rcases E.eq_empty_or_nonempty with hE | hE
+  · exact ⟨fun _ => true, by simp [hE]⟩
+  obtain ⟨e₀, he₀⟩ := hE
+  have hkn : k ≤ Fintype.card V := by
+    have hle : e₀.card ≤ Fintype.card V := by
+      rw [← Finset.card_univ]; exact Finset.card_le_card (Finset.subset_univ e₀)
+    rw [huniform e₀ he₀] at hle; exact hle
+  apply property_b_of_weighted_first_moment E
+  · intro e he; exact Finset.card_pos.mp (by rw [huniform e he]; omega)
+  · -- 2 · ∑_e 2^(n-k) = 2 · |E| · 2^(n-k) < 2^n
+    have hsumc : (∑ e ∈ E, 2 ^ (Fintype.card V - e.card))
+        = E.card * 2 ^ (Fintype.card V - k) := by
+      rw [Finset.sum_congr rfl (fun e he => by rw [huniform e he]),
+        Finset.sum_const, smul_eq_mul]
+    rw [hsumc]
+    have e1 : (2 : ℕ) ^ Fintype.card V = 2 ^ k * 2 ^ (Fintype.card V - k) := by
+      rw [← pow_add]; congr 1; omega
+    have ekey : E.card * 2 < 2 ^ k := by
+      have e2 : (2 : ℕ) ^ k = 2 * 2 ^ (k - 1) := by
+        conv_lhs => rw [show k = 1 + (k - 1) by omega]
+        rw [pow_add, pow_one]
+      rw [e2]; omega
+    calc 2 * (E.card * 2 ^ (Fintype.card V - k))
+          = (E.card * 2) * 2 ^ (Fintype.card V - k) := by ring
+      _ < 2 ^ k * 2 ^ (Fintype.card V - k) :=
+          (Nat.mul_lt_mul_right (pow_pos (by norm_num) _)).mpr ekey
+      _ = 2 ^ Fintype.card V := e1.symm
+
+/-- **Worked example where non-uniformity is essential.** Over `V = Fin 3` the family
+`{{0,1}, {0,1,2}}` mixes a size-2 and a size-3 edge. The weighted sum is
+`2^(3-2) + 2^(3-3) = 2 + 1 = 3`, and `2 · 3 = 6 < 8 = 2^3`, so the criterion certifies a
+proper 2-coloring. (The uniform theorem does not apply directly — the edges have different
+sizes.) -/
+theorem mixed_example_two_colorable :
+    ∃ c : Fin 3 → Bool, ∀ e ∈ ({{0, 1}, {0, 1, 2}} : Finset (Finset (Fin 3))),
+      ¬ Mono e c := by
+  apply property_b_of_weighted_first_moment
+  · decide
+  · decide
+
+end ProbMethod.PropertyB

--- a/research/problems/property-b-first-moment-oq-03/knowledge.md
+++ b/research/problems/property-b-first-moment-oq-03/knowledge.md
@@ -1,0 +1,72 @@
+# Knowledge Base: property-b-first-moment-oq-03
+
+Open question: sharpen the Property B lower bound to the **Radhakrishnan–Srinivasan**
+`m(k) = Ω(2^k·√(k/log k))` (RS 2000) via the asymmetric/recoloring refinement of the
+first moment argument. Parent `property-b-first-moment` (file `PropertyBFirstMoment.lean`)
+proves Erdős' 1963 uniform bound `m(k) ≥ 2^(k-1)`.
+
+---
+
+## State of the parent / siblings (as of 2026-06-28)
+
+- Parent `PropertyBFirstMoment.lean` (`ProbMethod.PropertyB`): Erdős 1963 uniform
+  first-moment bound. Key reusable API: `Mono e c`, `card_mono` (exactly `2·2^(n-|e|)`
+  colorings are monochromatic on a nonempty edge `e`), `exists_zero_of_sum_lt_card`
+  (integer first moment principle), `card_const_on`. 0 sorries / 0 axioms.
+- Sibling oq-01 → `PropertyBUpperBound.lean`: explicit non-2-colorable hypergraphs
+  bracketing `m(k)` (upper bounds).
+- Sibling oq-02 → `PropertyBFirstMomentRamsey.lean`: Erdős' 1947 Ramsey bound via the
+  same template (edges of `K_n` as the 2-colored ground set).
+
+## Session (2026-06-28, researcher-1): non-uniform first-moment sharpening
+
+New file `PropertyBFirstMomentOQ03.lean` (122 lines, 3 theorems, **0 sorries / 0 axioms**,
+`#print axioms` = propext/Classical.choice/Quot.sound only; the worked example uses
+`decide`, NOT `native_decide`, so no `Lean.ofReduceBool`). Gallery entry
+`src/data/proofs/property-b-first-moment-oq-03/` (meta.json + annotations.json) added.
+
+Delivered the **sharp single-round first-moment criterion** — the honest, tractable part
+of oq-03:
+
+* `property_b_of_weighted_first_moment` — a finite family `E` of nonempty edges of
+  *arbitrary sizes* is 2-colorable as soon as `2·∑_{e∈E} 2^(n-|e|) < 2^n`, equivalently
+  the genuine Erdős criterion `∑_e 2^(1-|e|) < 1`. Proof = parent's first moment with
+  `card_mono` summed over heterogeneous edge sizes (`card_filter` + `sum_comm` +
+  `mul_sum` + `exists_zero_of_sum_lt_card`). Dropping uniformity is free because
+  `card_mono` is already per-edge.
+* `property_b_two_colorable_of_uniform` — recovers the parent's uniform theorem
+  (`|e|=k`, `<2^(k-1)` edges) as a corollary; the weighted sum collapses to `|E|·2^(n-k)`.
+  Confirms the refinement strictly extends the parent.
+* `mixed_example_two_colorable` — `{{0,1},{0,1,2}}` over `Fin 3`: weighted sum `2+1=3`,
+  `2·3=6<8`, certified 2-colorable though the uniform theorem can't be applied (mixed
+  sizes). Hypotheses by `decide`.
+
+### Why this is NOT the full oq-03 (honest scoping)
+
+The single-round first moment is **sharp at `∑ 2^(1-|e|) < 1`** and provably cannot reach
+RS `Ω(2^k·√(k/log k))`. The RS improvement needs a **random recoloring (alteration)**:
+after the first uniform 2-coloring, independently recolor the vertices lying in surviving
+monochromatic edges (in a fixed random vertex order, recolor with small probability `p`),
+and bound `P[some edge still monochromatic]` by `m·2^(1-k)·(stuff) + m·k·p·(1-p)^(...)`,
+optimized at `p ≈ (log k)/k` to give the `√(k/log k)` gain. This is a genuinely different
+(two-round, order-dependent) probability model — NOT expressible by summing `card_mono`
+over a single product sample space `V → Bool`.
+
+### Roadmap / tractability verdict for RS (oq-03 remainder)
+
+RS formalization is a **moonshot** in Lean 4.26.0:
+- Needs a real-valued (or rational) probability model with a *recoloring* second stage
+  and a vertex ordering — the current file's integer first-moment counting does not
+  scale to it.
+- Needs concentration / union-bound estimates with the `p ≈ log k / k` optimization and
+  `√(k/log k)` asymptotics — heavy real-analysis bookkeeping.
+- Recommended decomposition if pursued: (1) a rational two-stage "recolor-with-prob-`p`"
+  expectation lemma for a single edge; (2) the union bound over `m` edges; (3) the
+  `p = log k / k` optimization as a separate analytic lemma. Each is a multi-session
+  effort. Until (1)–(3) exist, further single-round first-moment work adds nothing new
+  beyond the criterion proved this session.
+
+## Verification
+`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PropertyBFirstMomentOQ03.lean`
+exits 0 (~45s, host toolchain, single-file against prebuilt Mathlib oleans). `#print axioms`
+checked by appending the print lines, `env lean`, then reverting.

--- a/src/data/proofs/property-b-first-moment-oq-03/annotations.json
+++ b/src/data/proofs/property-b-first-moment-oq-03/annotations.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ann-pbfm-oq03-criterion",
+    "proofId": "property-b-first-moment-oq-03",
+    "range": { "startLine": 35, "endLine": 71 },
+    "type": "theorem",
+    "title": "The Non-Uniform First-Moment Criterion",
+    "content": "`property_b_of_weighted_first_moment` sharpens Erdős' uniform Property B bound to **arbitrary edge sizes**: a finite family `E` of nonempty edges is 2-colorable as soon as `2·∑_{e∈E} 2^(n-|e|) < 2^n`, equivalently `∑_e 2^(1-|e|) < 1`. The proof is the parent's first moment over the `2^n` colorings, now per-edge: the incidence total `∑_c #(mono edges) = ∑_e 2·2^(n-|e|)` (by `card_filter` + `Finset.sum_comm` + the parent's exact count `card_mono` applied to each edge's own size), and `Finset.mul_sum` matches the factor of 2 to the hypothesis, after which `exists_zero_of_sum_lt_card` returns a coloring whose monochromatic-edge filter is empty. Dropping uniformity costs nothing because `card_mono` is already a per-edge statement."
+  },
+  {
+    "id": "ann-pbfm-oq03-uniform-corollary",
+    "proofId": "property-b-first-moment-oq-03",
+    "range": { "startLine": 73, "endLine": 108 },
+    "type": "theorem",
+    "title": "Recovering Erdős' Uniform Bound",
+    "content": "`property_b_two_colorable_of_uniform` re-derives the parent's theorem (k-uniform, `< 2^(k-1)` edges) from the non-uniform criterion, confirming the refinement is faithful. With every `|e| = k` the weighted sum collapses to `|E|·2^(n-k)` (`Finset.sum_const`); the hypothesis `|E| < 2^(k-1)` gives `2·|E| < 2^k`, hence `2·|E|·2^(n-k) < 2^k·2^(n-k) = 2^n` using `2^n = 2^k·2^(n-k)` with `k ≤ n` from any edge `⊆ univ`. The empty-family case is handled separately with the constant `true` coloring."
+  },
+  {
+    "id": "ann-pbfm-oq03-mixed-example",
+    "proofId": "property-b-first-moment-oq-03",
+    "range": { "startLine": 110, "endLine": 122 },
+    "type": "example",
+    "title": "A Mixed-Size Family the Uniform Theorem Misses",
+    "content": "`mixed_example_two_colorable`: over `V = Fin 3` the family `{{0,1},{0,1,2}}` mixes a size-2 and a size-3 edge, so the uniform theorem does not apply directly. The weighted sum is `2^(3-2) + 2^(3-3) = 2 + 1 = 3`, and `2·3 = 6 < 8 = 2^3`, so the non-uniform criterion certifies a proper 2-coloring. The two hypotheses (edges nonempty; the threshold inequality) are discharged by `decide` — not `native_decide`, so the result remains free of `Lean.ofReduceBool`."
+  }
+]

--- a/src/data/proofs/property-b-first-moment-oq-03/meta.json
+++ b/src/data/proofs/property-b-first-moment-oq-03/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "property-b-first-moment-oq-03",
+  "title": "Non-Uniform Sharpening of the First-Moment Property B Criterion (∑ 2^(1-|e|) < 1)",
+  "slug": "property-b-first-moment-oq-03",
+  "description": "Partially answers open question oq-03 of property-b-first-moment, which ultimately targets the Radhakrishnan–Srinivasan lower bound m(k) = Ω(2^k·√(k/log k)). This entry delivers the *sharp form of the first-moment lower bound itself*: the genuine Erdős criterion ∑_{e∈E} 2^(1-|e|) < 1 ⟹ Property B for hypergraphs with edges of ARBITRARY size, stated over ℕ (no division) as 2·∑_{e} 2^(n-|e|) < 2^n with n = |V|. Large edges contribute geometrically less, so a family dominated by large edges is 2-colorable even when its raw edge count far exceeds 2^(k-1) for the smallest edge size k. The parent file's uniform theorem property_b_two_colorable (k-uniform, < 2^(k-1) edges) is recovered here as the special case |e| = k, confirming the refinement is faithful. The proof reuses the parent's exact monochromatic count card_mono and first moment principle exists_zero_of_sum_lt_card verbatim, dropping only the uniformity assumption. This is NOT the Radhakrishnan–Srinivasan √(k/log k) factor: that needs a random recoloring (alteration) argument — a second round repairing the monochromatic edges left by the first — beyond the single-round first moment formalized here; the recoloring roadmap is recorded in the research knowledge base. Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Paul Erdős / László Lovász (non-uniform first moment), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Property_B",
+    "date": "1963",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PropertyBFirstMomentOQ03.lean",
+    "tags": [
+      "probabilistic-method",
+      "first-moment-method",
+      "property-b",
+      "hypergraph-coloring",
+      "combinatorics",
+      "erdos",
+      "counting"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ProbMethod.PropertyB.card_mono",
+        "description": "The parent file's exact count: exactly 2·2^(n - |e|) of the 2^n colorings c : V → Bool are monochromatic on a fixed nonempty edge e. Reused verbatim per edge — now WITHOUT the uniformity assumption, so each edge contributes its own size |e|.",
+        "module": "Proofs.PropertyBFirstMoment"
+      },
+      {
+        "theorem": "ProbMethod.PropertyB.exists_zero_of_sum_lt_card",
+        "description": "The parent's first moment principle: a nonnegative integer statistic summing to less than the number of outcomes vanishes somewhere. Applied to 'number of monochromatic edges' over the 2^n colorings.",
+        "module": "Proofs.PropertyBFirstMoment"
+      },
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "Swaps ∑ over colorings with ∑ over edges — the linearity-of-expectation step turning ∑_c #(mono edges) into ∑_e #(mono colorings).",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "Pulls the constant 2 inside/outside the edge sum, matching the incidence total ∑_e 2·2^(n-|e|) to the hypothesis 2·∑_e 2^(n-|e|) < 2^n.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "property_b_of_weighted_first_moment: a 0-axiom Lean proof of the non-uniform Erdős/Lovász Property B criterion — a finite family E of nonempty edges (arbitrary sizes) is 2-colorable as soon as 2·∑_{e∈E} 2^(n-|e|) < 2^n, equivalently ∑_e 2^(1-|e|) < 1. Obtained by re-running the parent's first-moment template with the per-edge count card_mono summed over heterogeneous edge sizes.",
+      "property_b_two_colorable_of_uniform: re-derivation of the parent's uniform theorem (k-uniform, < 2^(k-1) edges) as a corollary of the non-uniform criterion, with the weighted sum collapsing to |E|·2^(n-k). This verifies the refinement strictly extends the parent rather than diverging from it.",
+      "mixed_example_two_colorable: a worked instance over V = Fin 3 with the mixed-size family {{0,1},{0,1,2}} (a size-2 and a size-3 edge), whose weighted sum 2 + 1 = 3 satisfies 2·3 = 6 < 8 = 2^3 — certified 2-colorable by the criterion although the uniform theorem does not apply.",
+      "An honest scoping of open question oq-03: the single-round first moment is sharp at ∑ 2^(1-|e|) < 1 and cannot reach the Radhakrishnan–Srinivasan m(k) = Ω(2^k·√(k/log k)) bound, which requires random recoloring — recorded as the remaining moonshot."
+    ],
+    "dateAdded": "2026-06-28",
+    "relatedProblems": [
+      {
+        "id": "property-b-first-moment",
+        "relationship": "Answers (in part) open question oq-03. The parent formalizes Erdős' uniform Property B bound m(k) ≥ 2^(k-1); this entry sharpens the first-moment argument to arbitrary edge sizes, importing the parent's card_mono and exists_zero_of_sum_lt_card and recovering the uniform theorem as a corollary."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 122,
+    "assumptions": "0 axioms, 0 sorries, no native_decide (the worked example uses decide, which depends only on the foundational kernel, not Lean.ofReduceBool). The hypotheses (edges nonempty; 2·∑_e 2^(n-|e|) < 2^n) are inputs to the statement, not standing assumptions; V is an arbitrary Fintype with DecidableEq and n = Fintype.card V. #print axioms reports only propext, Classical.choice, Quot.sound for property_b_of_weighted_first_moment, property_b_two_colorable_of_uniform, and mixed_example_two_colorable — no sorryAx, no Lean.ofReduceBool. This is the sharp FIRST-MOMENT bound only; the Radhakrishnan–Srinivasan √(k/log k) improvement is NOT formalized and is left open.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "A k-uniform hypergraph has Property B if its vertices can be 2-colored with no monochromatic edge. Erdős (1963) used the first moment method to show every k-uniform hypergraph with fewer than 2^(k-1) edges has Property B, giving m(k) ≥ 2^(k-1) for the minimum number of edges in a non-2-colorable k-uniform hypergraph. The same first-moment argument, applied without assuming uniformity, yields the sharp criterion ∑_{e} 2^(1-|e|) < 1 ⟹ Property B (Erdős–Lovász). The deeper question of how large m(k) really is was advanced by Radhakrishnan and Srinivasan (2000), who proved m(k) = Ω(2^k·√(k/log k)) via a random recoloring (alteration) argument; the best known upper bound is Erdős' O(k^2·2^k) from a random construction. This entry formalizes the sharp single-round first-moment criterion and recovers Erdős' 1963 uniform bound from it.",
+    "problemStatement": "Let V be a finite vertex set with n = |V|, and let E be a finite family of nonempty subsets (edges) of V. If $2\\cdot\\sum_{e\\in E} 2^{\\,n-|e|} < 2^{n}$ — equivalently $\\sum_{e\\in E} 2^{\\,1-|e|} < 1$ — then E has Property B: there is a 2-coloring $c : V \\to \\mathrm{Bool}$ under which no edge of E is monochromatic.",
+    "text": "Color each vertex independently and uniformly at random. A fixed edge e is monochromatic with probability 2·2^(-|e|) = 2^(1-|e|). By linearity the expected number of monochromatic edges is ∑_e 2^(1-|e|); when this is below 1 some coloring has none. Over the finite sample space of 2^n colorings this is the integer statement ∑_c #(mono edges) = ∑_e 2·2^(n-|e|) < 2^n, after which the first moment principle hands back a witness coloring. Unlike Erdős' uniform bound, the criterion weights each edge by its own size, so heterogeneous families with large edges are handled directly.",
+    "proofStrategy": "1. **Per-edge count (reuse card_mono).** The parent file proves that exactly 2·2^(n-|e|) of the 2^n colorings are monochromatic on a fixed nonempty edge e. No uniformity is needed — the count is per-edge.\n\n2. **Incidence total (linearity / Fubini).** ∑_{c : V→Bool} #(monochromatic edges under c) = ∑_{e∈E} #{c : Mono e c} = ∑_{e∈E} 2·2^(n-|e|), via card_filter + sum_comm (the parent's exact pattern).\n\n3. **Threshold.** The sample space has 2^n colorings (Fintype.card (V→Bool) = 2^n). The incidence total ∑_e 2·2^(n-|e|) = 2·∑_e 2^(n-|e|) is < 2^n exactly by hypothesis (mul_sum to match the factor of 2).\n\n4. **First moment (reuse exists_zero_of_sum_lt_card).** Since the incidence total is below the number of colorings, some coloring has zero monochromatic edges; its monochromatic-edge filter is empty, so no edge is monochromatic under it.\n\n5. **Uniform corollary.** Specializing |e| = k collapses ∑_e 2^(n-|e|) to |E|·2^(n-k); the hypothesis |E| < 2^(k-1) becomes 2·|E|·2^(n-k) < 2^n via 2^n = 2^k·2^(n-k) and 2·|E| < 2^k, recovering property_b_two_colorable.",
+    "keyInsights": [
+      "**The first-moment bound is per-edge, not per-count.** Erdős' uniform theorem only uses the number of edges; dropping uniformity and summing card_mono over each edge's own size gives the strictly more general criterion ∑ 2^(1-|e|) < 1 at no extra cost.",
+      "**The criterion clears to an integer inequality.** ∑_e 2^(1-|e|) < 1 is exactly 2·∑_e 2^(n-|e|) < 2^n over ℕ (with each |e| ≤ n so the exponents are honest naturals), keeping the whole proof inside integer pigeonhole — no real-valued probability.",
+      "**The uniform theorem is a corollary.** Recovering property_b_two_colorable from the general lemma confirms the refinement faithfully extends the parent and isolates exactly what uniformity buys (a closed-form sum |E|·2^(n-k)).",
+      "**Single-round first moment is sharp here and stops here.** This bound cannot reach Radhakrishnan–Srinivasan's m(k) = Ω(2^k·√(k/log k)); that factor needs a random recoloring repairing the first round's monochromatic edges, a genuinely different (alteration) argument not formalized in this entry."
+    ],
+    "prerequisites": [
+      "Erdős' Property B first-moment proof (parent entry property-b-first-moment), whose card_mono and exists_zero_of_sum_lt_card are reused",
+      "The first moment method: a nonnegative integer statistic below its mean is zero somewhere",
+      "Linearity of expectation over a finite sample space, realized as Finset.sum_comm"
+    ]
+  },
+  "sections": [
+    {
+      "id": "criterion",
+      "title": "The Non-Uniform First-Moment Criterion",
+      "startLine": 1,
+      "endLine": 71,
+      "mathContext": "$2\\cdot\\sum_{e\\in E} 2^{\\,n-|e|} < 2^{n} \\;\\Rightarrow\\; \\exists c,\\ \\forall e\\in E,\\ \\neg\\,\\mathrm{Mono}(e,c)$",
+      "summary": "Module docstring scoping the result against the Radhakrishnan–Srinivasan target. property_b_of_weighted_first_moment: the incidence total ∑_c #(mono edges) = ∑_e 2·2^(n-|e|) via card_filter + sum_comm + the parent's card_mono per edge; the threshold is the hypothesis after mul_sum; exists_zero_of_sum_lt_card yields a coloring with empty monochromatic-edge filter."
+    },
+    {
+      "id": "uniform-corollary",
+      "title": "Recovering Erdős' Uniform Bound as a Special Case",
+      "startLine": 73,
+      "endLine": 108,
+      "mathContext": "$|e| = k,\\ |E| < 2^{k-1} \\;\\Rightarrow\\; 2|E|\\,2^{\\,n-k} < 2^{n}$",
+      "summary": "property_b_two_colorable_of_uniform: with every |e| = k the weighted sum collapses to |E|·2^(n-k) (sum_const), and |E| < 2^(k-1) gives 2·|E| < 2^k, hence 2·|E|·2^(n-k) < 2^k·2^(n-k) = 2^n. This re-derives the parent theorem from the non-uniform criterion, confirming the refinement is faithful."
+    },
+    {
+      "id": "mixed-example",
+      "title": "A Mixed-Size Family the Uniform Theorem Misses",
+      "startLine": 110,
+      "endLine": 122,
+      "mathContext": "$E = \\{\\{0,1\\},\\{0,1,2\\}\\}\\subseteq 2^{\\mathrm{Fin}\\,3},\\quad 2(2^{1}+2^{0}) = 6 < 8 = 2^{3}$",
+      "summary": "mixed_example_two_colorable: a size-2 and a size-3 edge over Fin 3; weighted sum 2 + 1 = 3, and 2·3 = 6 < 8, so the criterion certifies a proper 2-coloring. The hypotheses (edges nonempty, threshold) are dispatched by decide."
+    }
+  ],
+  "conclusion": {
+    "summary": "The sharp single-round first-moment criterion for Property B — a finite hypergraph of nonempty edges of arbitrary sizes is 2-colorable whenever ∑_{e} 2^(1-|e|) < 1 — formalized with zero sorries and zero axioms, reusing the parent file's exact monochromatic count card_mono and first moment principle exists_zero_of_sum_lt_card per edge. Erdős' uniform bound m(k) ≥ 2^(k-1) is recovered as the corollary |e| = k, and a mixed-size example shows the criterion strictly extends the uniform case.",
+    "implications": "This answers the first-moment portion of open question oq-03 and sharpens the parent's lower bound to its non-uniform optimum. It also delimits the method: the single-round first moment is sharp at ∑ 2^(1-|e|) < 1 and cannot by itself reach the Radhakrishnan–Srinivasan m(k) = Ω(2^k·√(k/log k)) bound that oq-03 ultimately targets.",
+    "openQuestions": [
+      "Formalize the Radhakrishnan–Srinivasan random recoloring argument: after the first random 2-coloring, recolor the vertices of surviving monochromatic edges and bound the probability that any edge remains monochromatic, yielding m(k) = Ω(2^k·√(k/log k)). This requires a second-round (alteration) probability model not present in the single-round first moment.",
+      "Formalize the matching upper bound m(k) = O(k^2·2^k) (Erdős' random construction of a non-2-colorable k-uniform hypergraph with O(k^2·2^k) edges)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "property-b-first-moment",
+      "relationship": "extends",
+      "description": "Sharpens the parent's uniform Property B bound to arbitrary edge sizes (∑ 2^(1-|e|) < 1), reusing card_mono and exists_zero_of_sum_lt_card and recovering the uniform theorem as a corollary."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/PropertyBFirstMomentOQ03.lean",
+    "imports": [
+      "Proofs.PropertyBFirstMoment"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "ProbMethod.PropertyB",
+    "lineCount": 122,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 3
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "On a combinatorial problem",
+      "year": "1963",
+      "venue": "Nordisk Matematisk Tidskrift 11, 5–10",
+      "note": "Introduces Property B and the first-moment lower bound m(k) ≥ 2^(k-1)."
+    },
+    {
+      "authors": "Radhakrishnan, Jaikumar; Srinivasan, Aravind",
+      "title": "Improved bounds and algorithms for hypergraph 2-coloring",
+      "year": "2000",
+      "venue": "Random Structures & Algorithms 16(1), 4–32",
+      "note": "Proves m(k) = Ω(2^k·√(k/log k)) by random recoloring — the target of open question oq-03, not formalized here."
+    },
+    {
+      "authors": "Alon, Noga; Spencer, Joel H.",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition",
+      "note": "Chapter 1 states the non-uniform first-moment Property B criterion ∑ 2^(1-|e|) < 1 and the recoloring improvement."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "property_b_of_weighted_first_moment",
+      "type": "core",
+      "description": "A finite family of nonempty edges with 2·∑_e 2^(n-|e|) < 2^n is 2-colorable.",
+      "leanType": "(∀ e ∈ E, e.Nonempty) → 2 * ∑ e ∈ E, 2^(Fintype.card V - e.card) < 2^(Fintype.card V) → ∃ c : V → Bool, ∀ e ∈ E, ¬ Mono e c"
+    },
+    {
+      "name": "property_b_two_colorable_of_uniform",
+      "type": "supporting",
+      "description": "The parent's uniform Erdős bound (k-uniform, < 2^(k-1) edges) recovered as a corollary of the non-uniform criterion.",
+      "leanType": "(1 ≤ k) → (∀ e ∈ E, e.card = k) → E.card < 2^(k-1) → ∃ c : V → Bool, ∀ e ∈ E, ¬ Mono e c"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Delivers the **sharp single-round first-moment lower bound** for hypergraph 2-colorability — the honest, tractable portion of open question oq-03. (oq-03's ultimate target, the Radhakrishnan–Srinivasan bound `m(k) = Ω(2^k·√(k/log k))`, requires a *random recoloring* argument and is left open, with a roadmap recorded in the knowledge base.)

The parent `PropertyBFirstMoment.lean` proves Erdős' **uniform** bound: a `k`-uniform hypergraph with `< 2^(k-1)` edges has Property B. That bound uses only the edge *count*. This entry sharpens the same first-moment argument to **arbitrary edge sizes**:

> **`property_b_of_weighted_first_moment`** — a finite family `E` of nonempty edges is 2-colorable as soon as `2·∑_{e∈E} 2^(n-|e|) < 2^n`, equivalently the genuine Erdős criterion `∑_e 2^(1-|e|) < 1`.

Large edges contribute geometrically less, so a family dominated by large edges is 2-colorable even when its raw edge count far exceeds `2^(k-1)` for the smallest edge size.

## Contents

- **`property_b_of_weighted_first_moment`** — the non-uniform criterion. Proof reuses the parent's per-edge count `card_mono` and first moment principle `exists_zero_of_sum_lt_card` verbatim, summed over heterogeneous edge sizes (`card_filter` + `Finset.sum_comm` + `Finset.mul_sum`). Dropping uniformity costs nothing because `card_mono` is already a per-edge statement.
- **`property_b_two_colorable_of_uniform`** — recovers the parent's uniform theorem as a corollary (`|e|=k` collapses the sum to `|E|·2^(n-k)`), confirming the refinement faithfully extends the parent.
- **`mixed_example_two_colorable`** — `{{0,1},{0,1,2}}` over `Fin 3`: weighted sum `2+1=3`, `2·3=6 < 8=2^3`, certified 2-colorable although the uniform theorem doesn't apply (mixed sizes).

## Scope (honest)

This is the **single-round** first moment, sharp at `∑ 2^(1-|e|) < 1`. It provably cannot reach the RS `√(k/log k)` factor, which needs a two-round random recoloring (alteration) with a `p ≈ log k / k` optimization — a genuinely different probability model not formalized here. The knowledge base documents the recoloring roadmap and a tractability verdict (moonshot for Lean 4.26.0).

## Verification

- New file `PropertyBFirstMomentOQ03.lean`: 122 lines, 3 theorems, **0 sorries / 0 axioms**
- `#print axioms` on all three = `propext` / `Classical.choice` / `Quot.sound` only — the worked example uses `decide` (not `native_decide`), so **no `Lean.ofReduceBool`**
- `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PropertyBFirstMomentOQ03.lean` exits 0 (~45s, single-file against prebuilt Mathlib oleans)
- Gallery entry (`meta.json` + `annotations.json`) added; annotation line ranges validate against the Lean source with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)