### PR TITLE
Enrich Fibonacci F(4n+3) sum-of-two-squares (fibonacci-identities-oq-03-oq-01): align annotation coverage

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-01/annotations.json
@@ -38,7 +38,7 @@
   {
     "id": "ann-fiboq0301-4",
     "proofId": "fibonacci-identities-oq-03-oq-01",
-    "range": { "startLine": 61, "endLine": 74 },
+    "range": { "startLine": 61, "endLine": 79 },
     "type": "theorem",
     "title": "Existential and Integer Forms",
     "content": "**Packaging.** `fib_four_mul_add_three_isSumSq` gives $\\exists a\\,b,\\ F_{4n+3} = a^2 + b^2$ over $\\mathbb{N}$ with the explicit witnesses; `fib_four_mul_add_three_iterated_int` casts the decomposition to $\\mathbb{Z}$. The three `decide` checks that follow ($F_3=2$, $F_7=13$, $F_{11}=89$) confirm the $n=0,1,2$ instances by kernel reduction — `decide`, not `native_decide`, so no `Lean.ofReduceBool` and the entry stays 0-axiom.",


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-03-oq-01` (quality 91, pass 0). This entry already meets every quality target — conclusion, 4 sections, 4 fully-fielded annotations, index.ts present, validator clean. Rather than pad a complete entry, this makes the single honest improvement:

- **Coverage alignment**: `ann-fiboq0301-4` already discusses the sanity checks (F₃=2, F₇=13, F₁₁=89) in its content, but its range stopped at line 74 and excluded those `example` lines (76–79). Extended the range to 79 so the highlight matches the prose.

Per the size/diminishing-returns guidance, no content was added to an entry that is already at its targets.