### PR TITLE
Enrich '⁴√2 is irrational' (fourth-root-2-irrational-oq-02): add missing index.ts

### DIFF
--- a/src/data/proofs/fourth-root-2-irrational-oq-02/index.ts
+++ b/src/data/proofs/fourth-root-2-irrational-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FourthRoot2IrrationalOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fourthRoot2IrrationalOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fourthRoot2IrrationalOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fourthRoot2IrrationalOq02Data: ProofData = {
+  proof: fourthRoot2IrrationalOq02Proof,
+  annotations: fourthRoot2IrrationalOq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `fourth-root-2-irrational-oq-02` (quality 91, pass 0). The entry already meets every content target — conclusion, 3 sections, 4 fully-fielded annotations covering the whole file, validator clean. The one defect was the **missing `index.ts`** (the role's required per-proof entry-point shim), now added. No content was changed on an entry already at its quality targets.