### PR TITLE
research(lhopital-oq-01-oq-01): monotone quotients don't rescue (and aren't needed for) L'Hôpital's converse [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LHopitalOQ01OQ01.lean
+++ b/proofs/Proofs/LHopitalOQ01OQ01.lean
@@ -1,0 +1,127 @@
+/-
+# Monotone Quotients and the Converse of L'Hôpital (OQ-01 / OQ-01)
+
+## The Question
+
+The parent entry (`lhopital-oq-01`, namespace `LHopitalConverse`) exhibits the classic
+failure of the *converse* of L'Hôpital's rule: with `f(x) = x + sin x`, `g(x) = x`,
+
+    lim_{x→∞} f(x)/g(x) = 1,   but   lim_{x→∞} f'(x)/g'(x) = lim_{x→∞}(1 + cos x)
+
+does **not exist**. The follow-up question asked here is:
+
+  *Can the converse be rescued by a monotonicity hypothesis? If `f/g` is monotone and the
+  indeterminate-form conditions hold, must `lim f/g = lim f'/g'` whenever both limits exist?*
+
+## The Answer
+
+**Yes — but the monotonicity hypothesis is entirely superfluous.** Whenever `lim f'/g'`
+exists (under the standard 0/0 indeterminate-form hypotheses), L'Hôpital's rule in its
+*forward* direction already forces
+
+    lim f/g = lim f'/g'.
+
+So if *both* limits exist they cannot differ, irrespective of whether `f/g` is monotone.
+The qualifier "whenever both limits exist" does all the work: the only way the converse
+can fail (as in the parent example) is for `lim f'/g'` to fail to *exist*. Monotonicity of
+`f/g` neither helps nor is required.
+
+This file makes that precise in two ways:
+
+* `converse_holds_when_both_limits_exist` — no monotonicity hypothesis appears at all; the
+  two existing limits are proved equal by combining forward L'Hôpital with uniqueness of
+  limits.
+* `monotone_quotient_converse` — the literal statement from the question, carrying an
+  explicit `MonotoneOn` hypothesis `_hmono`. The underscore in its name records that the
+  hypothesis is **discharged without ever being used**: the proof is the previous theorem
+  applied verbatim.
+
+The mathematical content is therefore a sharpening of the parent counterexample: the
+converse of L'Hôpital fails *only* through non-existence of `lim f'/g'`, never through a
+genuine disagreement of two existing limits — and no order/monotonicity assumption changes
+that.
+
+Self-contained: imports only Mathlib. The single analytic input is Mathlib's forward
+L'Hôpital rule at infinity, `HasDerivAt.lhopital_zero_atTop_on_Ioi`.
+-/
+
+import Mathlib
+
+namespace LHopitalOQ01OQ01
+
+open Filter Topology Set
+
+/-- **Forward L'Hôpital at infinity (0/0 form).** Repackaged from Mathlib for readability:
+if `f, g` are differentiable on `(a, ∞)` with `f, g → 0`, `g' ≠ 0` there, and the derivative
+quotient `f'/g'` tends to `c`, then the quotient `f/g` also tends to `c`. -/
+theorem lhopital_atTop {f g f' g' : ℝ → ℝ} {a c : ℝ}
+    (hff' : ∀ x ∈ Ioi a, HasDerivAt f (f' x) x)
+    (hgg' : ∀ x ∈ Ioi a, HasDerivAt g (g' x) x)
+    (hg' : ∀ x ∈ Ioi a, g' x ≠ 0)
+    (hf0 : Tendsto f atTop (𝓝 0))
+    (hg0 : Tendsto g atTop (𝓝 0))
+    (hdiv : Tendsto (fun x => f' x / g' x) atTop (𝓝 c)) :
+    Tendsto (fun x => f x / g x) atTop (𝓝 c) :=
+  HasDerivAt.lhopital_zero_atTop_on_Ioi hff' hgg' hg' hf0 hg0 hdiv
+
+/-- **Main theorem: when both limits exist they coincide — monotonicity is not needed.**
+
+Under the standard 0/0 indeterminate-form hypotheses at infinity, if the quotient `f/g`
+tends to `l` *and* the derivative quotient `f'/g'` tends to `L`, then `l = L`.
+
+Notice the hypothesis list: there is **no** monotonicity assumption on `f/g`. The forward
+direction of L'Hôpital already produces `Tendsto (f/g) atTop (𝓝 L)` from the existence of
+`L`, and uniqueness of limits in a Hausdorff space then forces `l = L`. This is the precise
+sense in which "must `lim f/g = lim f'/g'` whenever both limits exist?" is answered *yes,
+unconditionally*. -/
+theorem converse_holds_when_both_limits_exist
+    {f g f' g' : ℝ → ℝ} {a l L : ℝ}
+    (hff' : ∀ x ∈ Ioi a, HasDerivAt f (f' x) x)
+    (hgg' : ∀ x ∈ Ioi a, HasDerivAt g (g' x) x)
+    (hg' : ∀ x ∈ Ioi a, g' x ≠ 0)
+    (hf0 : Tendsto f atTop (𝓝 0))
+    (hg0 : Tendsto g atTop (𝓝 0))
+    (hfg : Tendsto (fun x => f x / g x) atTop (𝓝 l))
+    (hfg' : Tendsto (fun x => f' x / g' x) atTop (𝓝 L)) :
+    l = L := by
+  have hL : Tendsto (fun x => f x / g x) atTop (𝓝 L) :=
+    lhopital_atTop hff' hgg' hg' hf0 hg0 hfg'
+  exact tendsto_nhds_unique hfg hL
+
+/-- **The question, stated literally — with the monotonicity hypothesis shown to be unused.**
+
+This is exactly the proposition posed by the open question: assume in addition that the
+quotient `f/g` is monotone on `(a, ∞)`. The conclusion `l = L` follows. The hypothesis
+`_hmono` is named with a leading underscore precisely because it is *discharged without
+being referenced* — the proof is `converse_holds_when_both_limits_exist` applied verbatim.
+Thus monotonicity is a red herring: it can be assumed, but it contributes nothing. -/
+theorem monotone_quotient_converse
+    {f g f' g' : ℝ → ℝ} {a l L : ℝ}
+    (_hmono : MonotoneOn (fun x => f x / g x) (Ioi a))
+    (hff' : ∀ x ∈ Ioi a, HasDerivAt f (f' x) x)
+    (hgg' : ∀ x ∈ Ioi a, HasDerivAt g (g' x) x)
+    (hg' : ∀ x ∈ Ioi a, g' x ≠ 0)
+    (hf0 : Tendsto f atTop (𝓝 0))
+    (hg0 : Tendsto g atTop (𝓝 0))
+    (hfg : Tendsto (fun x => f x / g x) atTop (𝓝 l))
+    (hfg' : Tendsto (fun x => f' x / g' x) atTop (𝓝 L)) :
+    l = L :=
+  converse_holds_when_both_limits_exist hff' hgg' hg' hf0 hg0 hfg hfg'
+
+/-- **The failure mode is exactly non-existence.** Contrapositive packaging of the main
+theorem: if the derivative quotient `f'/g'` *converges* to some `L`, then the original
+quotient `f/g` converges to the *same* value. Hence the only route to a "converse failure"
+(as realised by the parent example `f = x + sin x`, `g = x`) is for `lim f'/g'` to fail to
+exist — never for two existing limits to disagree. -/
+theorem converse_failure_only_via_nonexistence
+    {f g f' g' : ℝ → ℝ} {a L : ℝ}
+    (hff' : ∀ x ∈ Ioi a, HasDerivAt f (f' x) x)
+    (hgg' : ∀ x ∈ Ioi a, HasDerivAt g (g' x) x)
+    (hg' : ∀ x ∈ Ioi a, g' x ≠ 0)
+    (hf0 : Tendsto f atTop (𝓝 0))
+    (hg0 : Tendsto g atTop (𝓝 0))
+    (hfg' : Tendsto (fun x => f' x / g' x) atTop (𝓝 L)) :
+    Tendsto (fun x => f x / g x) atTop (𝓝 L) :=
+  lhopital_atTop hff' hgg' hg' hf0 hg0 hfg'
+
+end LHopitalOQ01OQ01

--- a/src/data/proofs/lhopital-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lhopital-oq-01-oq-01/annotations.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "ann-lh-oq0101-wrapper",
+    "proofId": "lhopital-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 65 },
+    "type": "context",
+    "title": "The sole analytic input: forward L'Hôpital",
+    "content": "lhopital_atTop is a thin, readable repackaging of Mathlib's HasDerivAt.lhopital_zero_atTop_on_Ioi for the 0/0 indeterminate form at infinity. Everything else in the file is purely logical: it consumes the existence of lim f'/g' and uniqueness of limits. Crucially, this rule says the existence of c = lim f'/g' is enough to conclude lim f/g = c — there is no order or monotonicity premise anywhere in its statement.",
+    "mathContext": "$f, g \\to 0$ on $(a,\\infty),\\ g' \\ne 0,\\ f'/g' \\to c \\ \\Rightarrow\\ f/g \\to c.$",
+    "significance": "context"
+  },
+  {
+    "id": "ann-lh-oq0101-main",
+    "proofId": "lhopital-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 89 },
+    "type": "key-step",
+    "title": "Both limits existing forces them equal — no monotonicity",
+    "content": "This is the headline answer. The hypothesis list contains NO monotonicity assumption. The two-line proof is the whole argument: forward L'Hôpital turns the assumed limit L = lim f'/g' into Tendsto (f/g) atTop (𝓝 L); then tendsto_nhds_unique pits this against the assumed Tendsto (f/g) atTop (𝓝 l) to force l = L. So the open question's 'whenever both limits exist' qualifier already settles equality, independently of how f/g behaves order-wise.",
+    "mathContext": "$\\lim f'/g' = L \\Rightarrow \\lim f/g = L$ (forward rule); with $\\lim f/g = l$, uniqueness gives $l = L$.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-lh-oq0101-unused-hyp",
+    "proofId": "lhopital-oq-01-oq-01",
+    "range": { "startLine": 98, "endLine": 109 },
+    "type": "insight",
+    "title": "The monotonicity hypothesis, certified inert",
+    "content": "monotone_quotient_converse states the open question verbatim — it explicitly assumes MonotoneOn (fun x => f x / g x) (Ioi a). The proof is converse_holds_when_both_limits_exist applied with exactly the other hypotheses; the monotonicity argument is bound to the name `_hmono` and never appears in the proof term. The leading underscore is a machine-checkable certificate that the hypothesis is discharged without use: monotonicity is a tempting but completely inert addition.",
+    "mathContext": "Assuming $f/g$ monotone on $(a,\\infty)$ leaves the conclusion $l = L$ untouched; the hypothesis is logically idle.",
+    "significance": "high"
+  },
+  {
+    "id": "ann-lh-oq0101-contrapositive",
+    "proofId": "lhopital-oq-01-oq-01",
+    "range": { "startLine": 116, "endLine": 125 },
+    "type": "insight",
+    "title": "Non-existence is the only failure mode",
+    "content": "converse_failure_only_via_nonexistence re-presents the forward rule as a transfer principle: if f'/g' converges to L, then f/g converges to the same L. Read contrapositively, two existing limits can never disagree, so the converse of L'Hôpital can break in exactly one way — lim f'/g' failing to exist. This is precisely what happens in the parent entry, where f'/g' = 1 + cos x oscillates between 0 and 2 with no limit.",
+    "mathContext": "$f'/g' \\to L \\Rightarrow f/g \\to L$; the parent's $f'/g' = 1 + \\cos x$ has no limit, the sole obstruction.",
+    "significance": "high"
+  },
+  {
+    "id": "ann-lh-oq0101-axioms",
+    "proofId": "lhopital-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "context",
+    "title": "Verified, zero axioms",
+    "content": "All four theorems depend only on Lean's foundational axioms propext, Classical.choice, and Quot.sound (confirmed by #print axioms). There is no sorryAx and no native_decide / Lean.ofReduceBool, so per the project's axiom-integrity policy the entry is a genuine 0-axiom, fully machine-verified result. The only mathematical assumption is Mathlib's forward L'Hôpital rule, used as a lemma, not an axiom.",
+    "mathContext": "Foundational axioms (propext, Classical.choice, Quot.sound) do not count as assumptions under the project policy.",
+    "significance": "context"
+  }
+]

--- a/src/data/proofs/lhopital-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-01-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "lhopital-oq-01-oq-01",
+  "title": "Monotone Quotients Do Not Rescue L'Hôpital's Converse — and Need Not",
+  "slug": "lhopital-oq-01-oq-01",
+  "description": "Answers the parent counterexample's first open question: if f/g is monotone and the 0/0 indeterminate-form conditions hold, must lim f/g = lim f'/g' whenever both limits exist? The answer is yes — but the monotonicity hypothesis is entirely superfluous. Whenever lim f'/g' exists, the forward direction of L'Hôpital already forces lim f/g = lim f'/g', so two existing limits can never disagree, with or without monotonicity. The only way the converse can fail (as in the parent example f = x + sin x, g = x) is for lim f'/g' to fail to exist. Formalized two ways: a clean theorem carrying no monotonicity hypothesis, and the literal question with an explicit MonotoneOn hypothesis whose underscore-prefixed name records that it is discharged without ever being used. Verified, zero axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Rudin §5.13 lineage); formalized in Lean 4 with Mathlib",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LHopitalOQ01OQ01.lean",
+    "tags": [
+      "calculus",
+      "analysis",
+      "limits",
+      "lhopital",
+      "counterexample",
+      "monotonicity",
+      "extension"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 127,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-28",
+    "assumptions": "0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound, the foundational Lean axioms). Fully machine-verified; no native_decide.",
+    "originalContributions": [
+      "lhopital_atTop: a readable repackaging of Mathlib's forward L'Hôpital rule at infinity (HasDerivAt.lhopital_zero_atTop_on_Ioi) for the 0/0 form — f, g → 0 on (a, ∞), g' ≠ 0, f'/g' → c implies f/g → c.",
+      "converse_holds_when_both_limits_exist: the headline answer. Under the 0/0 indeterminate-form hypotheses, if f/g → l and f'/g' → L then l = L. The hypothesis list carries NO monotonicity assumption — forward L'Hôpital produces f/g → L from the existence of L, and tendsto_nhds_unique forces l = L. This is the precise sense in which the open question is answered 'yes, unconditionally'.",
+      "monotone_quotient_converse: the open question stated verbatim, with an explicit MonotoneOn (f/g) (Ioi a) hypothesis. Its proof is converse_holds_when_both_limits_exist applied with the monotonicity argument named `_hmono` and never referenced — a formal certificate that monotonicity contributes nothing.",
+      "converse_failure_only_via_nonexistence: the contrapositive packaging — if f'/g' converges to L then f/g converges to the same L. Hence the converse can only ever fail through non-existence of lim f'/g', never through disagreement of two existing limits (sharpening the parent entry's f = x + sin x, g = x example)."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "HasDerivAt.lhopital_zero_atTop_on_Ioi",
+        "description": "Forward L'Hôpital at infinity (0/0 form): if f, g are differentiable on (a, ∞) with f, g → 0, g' ≠ 0 there, and f'/g' → c, then f/g → c. The single analytic input to the whole entry.",
+        "module": "Mathlib.Analysis.Calculus.LHopital"
+      },
+      {
+        "theorem": "tendsto_nhds_unique",
+        "description": "Limits in a Hausdorff space are unique. Combined with forward L'Hôpital, it forces the two existing limits l and L to coincide.",
+        "module": "Mathlib.Topology.Separation.Hausdorff"
+      }
+    ],
+    "prerequisites": [
+      "L'Hôpital's rule, forward direction (LHopital.lean, Wiedijk #64)",
+      "The parent counterexample lhopital-oq-01: lim f/g may exist while lim f'/g' does not",
+      "Uniqueness of limits in Hausdorff spaces",
+      "Order-theoretic monotonicity (MonotoneOn) as a hypothesis form"
+    ]
+  },
+  "overview": {
+    "historicalContext": "L'Hôpital's rule (Wiedijk #64) is one-directional: lim f'/g' = L implies lim f/g = L, but the converse is false. The parent gallery entry lhopital-oq-01 formalizes the canonical counterexample from Rudin's Principles of Mathematical Analysis (§5.13): f(x) = x + sin x, g(x) = x give lim f/g = 1 while lim f'/g' = lim (1 + cos x) does not exist. That entry then asks, as its first open question, whether a monotonicity hypothesis on the quotient f/g could rescue the converse. This entry settles that question. The subtlety it exposes is pedagogically valuable: the qualifier 'whenever both limits exist' is doing all of the work, because as soon as lim f'/g' exists, forward L'Hôpital already pins lim f/g to the same value. Monotonicity is a tempting but inert hypothesis.",
+    "problemStatement": "If f/g is monotone on (a, ∞) and the 0/0 indeterminate-form conditions hold (f, g → 0, g' ≠ 0), must lim f/g = lim f'/g' whenever both limits exist?",
+    "text": "The entry proves that the converse of L'Hôpital, restricted to the case where both limits exist, holds unconditionally — and in particular the monotonicity of f/g posed in the open question is unnecessary. The key observation is that the forward direction of L'Hôpital already produces Tendsto (f/g) atTop (𝓝 L) from the mere existence of L = lim f'/g'; uniqueness of limits then forces lim f/g = L. The entry packages this as: (1) a clean theorem with no monotonicity hypothesis, (2) the question stated literally with a deliberately-unused MonotoneOn hypothesis, and (3) the contrapositive isolating non-existence as the sole failure route.",
+    "proofStrategy": "All four results funnel through lhopital_atTop, a thin wrapper over Mathlib's HasDerivAt.lhopital_zero_atTop_on_Ioi. For converse_holds_when_both_limits_exist: apply lhopital_atTop to the existing L = lim f'/g' to get Tendsto (f/g) atTop (𝓝 L), then close with tendsto_nhds_unique against the assumed Tendsto (f/g) atTop (𝓝 l). The monotone variant reuses this verbatim, with the MonotoneOn argument bound to `_hmono` and never used. The contrapositive variant is lhopital_atTop itself, re-presented to emphasize that convergence of f'/g' transfers to f/g.",
+    "keyInsights": [
+      "The answer is 'yes', but for a reason unrelated to monotonicity: forward L'Hôpital forces lim f/g = lim f'/g' the instant lim f'/g' exists.",
+      "Two existing limits can never disagree — so the converse can only 'fail' through non-existence of lim f'/g', exactly as in the parent example f = x + sin x, g = x.",
+      "The MonotoneOn hypothesis in monotone_quotient_converse is bound to `_hmono` and never referenced; the underscore is a formal certificate that the hypothesis is inert.",
+      "Monotonicity of f/g does not even guarantee that lim f'/g' exists, so it cannot be what rescues the converse — the 'both limits exist' qualifier carries the whole argument.",
+      "The single analytic input is Mathlib's forward L'Hôpital at infinity; everything else is uniqueness of limits in a Hausdorff space."
+    ],
+    "prerequisites": [
+      "L'Hôpital's rule, forward direction (LHopital.lean)",
+      "Parent counterexample lhopital-oq-01",
+      "Uniqueness of limits (tendsto_nhds_unique)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header — Question and Answer",
+      "summary": "The block comment (lines 1-46) states the open question verbatim and its resolution: yes, but the monotonicity hypothesis is superfluous because forward L'Hôpital already forces equality whenever lim f'/g' exists. It previews the two formalizations (no-hypothesis and literal-with-unused-hypothesis) and the contrapositive.",
+      "startLine": 1,
+      "endLine": 46,
+      "mathContext": "The converse of L'Hôpital fails only through non-existence of $\\lim f'/g'$; if that limit exists, $\\lim f/g = \\lim f'/g'$ is automatic."
+    },
+    {
+      "id": "wrapper",
+      "title": "Forward L'Hôpital at Infinity (Repackaged)",
+      "summary": "lhopital_atTop wraps Mathlib's HasDerivAt.lhopital_zero_atTop_on_Ioi for the 0/0 form: differentiability on (a, ∞), f, g → 0, g' ≠ 0, and f'/g' → c imply f/g → c. This is the only analytic input used by the rest of the file.",
+      "startLine": 53,
+      "endLine": 65,
+      "mathContext": "If $f, g \\to 0$ on $(a, \\infty)$, $g' \\ne 0$, and $f'/g' \\to c$, then $f/g \\to c$."
+    },
+    {
+      "id": "main",
+      "title": "Main Theorem — Both Limits Existing Forces Equality",
+      "summary": "converse_holds_when_both_limits_exist: with no monotonicity hypothesis, if f/g → l and f'/g' → L then l = L. Proof: forward L'Hôpital turns L into Tendsto (f/g) atTop (𝓝 L); tendsto_nhds_unique against f/g → l gives l = L.",
+      "startLine": 67,
+      "endLine": 89,
+      "mathContext": "$\\lim f'/g' = L$ exists $\\Rightarrow \\lim f/g = L$ (forward L'Hôpital); with $\\lim f/g = l$ assumed, uniqueness gives $l = L$. No monotonicity used."
+    },
+    {
+      "id": "literal",
+      "title": "The Question, Stated Literally — Hypothesis Shown Unused",
+      "summary": "monotone_quotient_converse carries the explicit MonotoneOn (f/g) (Ioi a) hypothesis from the open question, bound to `_hmono`. The proof is the main theorem applied verbatim; the underscore certifies the monotonicity is discharged without being referenced.",
+      "startLine": 91,
+      "endLine": 109,
+      "mathContext": "Assuming $f/g$ monotone on $(a, \\infty)$ changes nothing: the conclusion $l = L$ follows from the same forward-L'Hôpital + uniqueness argument."
+    },
+    {
+      "id": "contrapositive",
+      "title": "Failure Mode Is Exactly Non-Existence",
+      "summary": "converse_failure_only_via_nonexistence: if f'/g' → L then f/g → the same L. This isolates non-existence of lim f'/g' as the unique way the converse can fail, sharpening the parent example where lim f'/g' = lim(1 + cos x) oscillates and has no limit.",
+      "startLine": 111,
+      "endLine": 125,
+      "mathContext": "Convergence of $f'/g'$ to $L$ transfers to $f/g$; hence two existing limits never disagree, and only non-existence of $\\lim f'/g'$ breaks the converse."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms): four theorems resolving the parent entry's first open question. If f/g is monotone and the 0/0 indeterminate-form conditions hold, lim f/g = lim f'/g' whenever both limits exist — but the monotonicity hypothesis is provably superfluous, as certified by the unused `_hmono` argument. The converse of L'Hôpital can fail only through non-existence of lim f'/g'.",
+    "implications": "**Resolves an open question**: directly answers the first open question of lhopital-oq-01. **Pedagogical**: clarifies that the natural 'monotonicity rescues the converse' guess is mislocated — the real content is that any existing lim f'/g' is automatically inherited by lim f/g via the forward rule. **Sharpens the parent**: recasts the f = x + sin x, g = x counterexample as the generic situation, where the only obstruction is non-existence of lim f'/g'.",
+    "openQuestions": [
+      "What is the weakest additional hypothesis on f and g that makes the full converse (existence of lim f'/g' from existence of lim f/g) valid — e.g. uniform continuity of f'/g', or a Tauberian regularity condition?",
+      "Can one construct, and formalize, a quotient f/g that IS monotone with an existing limit yet has lim f'/g' non-existent — confirming that monotonicity does not even force lim f'/g' to exist?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lhopital-oq-01",
+      "relationship": "extends",
+      "description": "Parent counterexample (f = x + sin x, g = x); this entry answers its first open question about monotone quotients."
+    },
+    {
+      "targetId": "lhopital",
+      "relationship": "depends",
+      "description": "Forward L'Hôpital rule, whose existence-of-lim-f'/g' hypothesis is exactly what makes the converse-with-both-limits trivial."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "Set"
+    ],
+    "namespace": "LHopitalOQ01OQ01",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/LHopitalOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Rudin, W.",
+      "title": "Principles of Mathematical Analysis, 3rd ed.",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "note": "§5.13 — the parent counterexample f(x) = x + sin x, g(x) = x to the converse of L'Hôpital."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the **first open question** of the parent gallery entry `lhopital-oq-01` (the canonical converse counterexample $f = x + \sin x$, $g = x$):

> *Can the converse hold for monotone quotients? If $f/g$ is monotone and the indeterminate-form conditions hold, must $\lim f/g = \lim f'/g'$ whenever both limits exist?*

**Answer: yes — but the monotonicity hypothesis is entirely superfluous.** Whenever $\lim f'/g'$ exists (under the 0/0 hypotheses), the *forward* direction of L'Hôpital already forces $\lim f/g = \lim f'/g'$. So two existing limits can never disagree, with or without monotonicity. The converse can fail **only** through non-existence of $\lim f'/g'$ — exactly the parent example, where $f'/g' = 1 + \cos x$ oscillates and has no limit.

## Lean

`proofs/Proofs/LHopitalOQ01OQ01.lean` — 127 lines, **0 sorries, 0 axioms** (`#print axioms` = `propext`/`Classical.choice`/`Quot.sound` only; no `native_decide`, no `Lean.ofReduceBool`). Builds clean via the Docker wrapper.

- `lhopital_atTop` — readable wrapper over Mathlib's `HasDerivAt.lhopital_zero_atTop_on_Ioi` (the sole analytic input).
- `converse_holds_when_both_limits_exist` — both limits exist ⟹ equal; **no monotonicity hypothesis appears in the statement**. Proof: forward L'Hôpital + `tendsto_nhds_unique`.
- `monotone_quotient_converse` — the question stated **verbatim** with an explicit `MonotoneOn (f/g) (Ioi a)` hypothesis bound to `_hmono` and **never referenced** — a machine-checkable certificate that monotonicity is inert.
- `converse_failure_only_via_nonexistence` — contrapositive packaging isolating non-existence of $\lim f'/g'$ as the unique failure route.

## Gallery

`src/data/proofs/lhopital-oq-01-oq-01/` — `meta.json` (status `verified`, badge `verified`, `axiomCount` 0) + `annotations.json` (5 annotations). Cross-references the parent `lhopital-oq-01` (extends) and `lhopital` (depends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)