### PR TITLE
Enrich 'Non-Uniform First-Moment Property B Criterion' (property-b-first-moment-oq-03)

### DIFF
--- a/src/data/proofs/property-b-first-moment-oq-03/annotations.json
+++ b/src/data/proofs/property-b-first-moment-oq-03/annotations.json
@@ -1,11 +1,39 @@
 [
   {
+    "id": "ann-pbfm-oq03-overview",
+    "proofId": "property-b-first-moment-oq-03",
+    "range": { "startLine": 1, "endLine": 26 },
+    "type": "context",
+    "title": "Scope: Sharp First Moment, Not Radhakrishnan–Srinivasan",
+    "content": "The module docstring fixes the result against the larger goal of open question oq-03. The parent `PropertyBFirstMoment.lean` proves Erdős 1963 for **uniform** hypergraphs (a `k`-uniform family with `< 2^(k-1)` edges is 2-colorable), a bound that depends only on the edge *count*. This file sharpens the same first-moment argument to **arbitrary edge sizes**: large edges contribute geometrically less, so a family dominated by large edges is 2-colorable even when its raw edge count dwarfs `2^(k-1)` for the smallest edge size `k`. Crucially, the docstring is honest that this is the *sharp single-round first moment* and **not** the Radhakrishnan–Srinivasan bound `m(k) = Ω(2^k·√(k/log k))`, which needs a genuinely different random-recoloring (alteration) argument left open here.",
+    "mathContext": "$\\sum_{e\\in E} 2^{\\,1-|e|} < 1 \\;\\Rightarrow\\; E \\text{ has Property B}, \\qquad \\text{stated over } \\mathbb{N} \\text{ as } 2\\sum_{e} 2^{\\,n-|e|} < 2^{n}.$",
+    "significance": "context",
+    "relatedConcepts": ["Property B", "hypergraph 2-coloring", "probabilistic method", "first moment method", "Radhakrishnan–Srinivasan bound"],
+    "prerequisites": ["hypergraph coloring", "asymptotic notation"]
+  },
+  {
     "id": "ann-pbfm-oq03-criterion",
     "proofId": "property-b-first-moment-oq-03",
-    "range": { "startLine": 35, "endLine": 71 },
+    "range": { "startLine": 35, "endLine": 48 },
     "type": "theorem",
     "title": "The Non-Uniform First-Moment Criterion",
-    "content": "`property_b_of_weighted_first_moment` sharpens Erdős' uniform Property B bound to **arbitrary edge sizes**: a finite family `E` of nonempty edges is 2-colorable as soon as `2·∑_{e∈E} 2^(n-|e|) < 2^n`, equivalently `∑_e 2^(1-|e|) < 1`. The proof is the parent's first moment over the `2^n` colorings, now per-edge: the incidence total `∑_c #(mono edges) = ∑_e 2·2^(n-|e|)` (by `card_filter` + `Finset.sum_comm` + the parent's exact count `card_mono` applied to each edge's own size), and `Finset.mul_sum` matches the factor of 2 to the hypothesis, after which `exists_zero_of_sum_lt_card` returns a coloring whose monochromatic-edge filter is empty. Dropping uniformity costs nothing because `card_mono` is already a per-edge statement."
+    "content": "`property_b_of_weighted_first_moment` is the central result: a finite family `E` of nonempty edges (each of size `≤ n = |V|`) is 2-colorable as soon as `2·∑_{e∈E} 2^(n-|e|) < 2^n`, equivalently `∑_e 2^(1-|e|) < 1`. The statement weights each edge by its **own** size `|e|` rather than a single uniform `k`, which is exactly what lets it absorb heterogeneous families. Dropping uniformity costs nothing because the per-edge monochromatic count `card_mono` reused from the parent is already a statement about a single edge `e` and its individual size, never about the family being uniform.",
+    "mathContext": "$2\\sum_{e\\in E} 2^{\\,n-|e|} < 2^{n} \\;\\Rightarrow\\; \\exists\\,c:V\\to\\mathrm{Bool},\\ \\forall e\\in E,\\ \\neg\\,\\mathrm{Mono}(e,c).$",
+    "significance": "key",
+    "relatedConcepts": ["first moment method", "linearity of expectation", "Property B", "Erdős–Lovász criterion"],
+    "prerequisites": ["finite probability", "Finset.sum", "Erdős uniform Property B bound"]
+  },
+  {
+    "id": "ann-pbfm-oq03-first-moment-body",
+    "proofId": "property-b-first-moment-oq-03",
+    "range": { "startLine": 49, "endLine": 71 },
+    "type": "technique",
+    "title": "Linearity of Expectation as an Integer Incidence Count",
+    "content": "The proof body realizes linearity of expectation as an exact integer double count over the finite sample space of `2^n` colorings. `hsum` computes the total `(coloring, monochromatic edge)` incidence `∑_c #(mono edges under c)` by rewriting `Finset.card_filter`, swapping the two sums with `Finset.sum_comm` (Fubini), and applying the parent's exact count `card_mono e` to each edge — yielding `∑_e 2·2^(n-|e|)`. `hcard` evaluates the sample-space size `|V→Bool| = 2^n` via `Fintype.card_fun` and `Fintype.card_bool`. `hlt` then matches the hypothesis by pulling the factor `2` out with `Finset.mul_sum`, and `exists_zero_of_sum_lt_card` (the parent's pigeonhole/first-moment principle) returns a coloring whose monochromatic-edge filter is empty — i.e. no edge is monochromatic. No real-valued probability ever appears; everything stays in `ℕ`.",
+    "mathContext": "$\\sum_{c:V\\to\\mathrm{Bool}} \\#\\{e\\in E : \\mathrm{Mono}(e,c)\\} = \\sum_{e\\in E} 2\\cdot 2^{\\,n-|e|} < 2^{n} = |V\\to\\mathrm{Bool}|.$",
+    "significance": "key",
+    "relatedConcepts": ["Fubini / double counting", "pigeonhole principle", "Finset.sum_comm", "card_mono", "averaging argument"],
+    "prerequisites": ["double counting", "Finset.card_filter", "Fintype.card"]
   },
   {
     "id": "ann-pbfm-oq03-uniform-corollary",
@@ -13,7 +41,11 @@
     "range": { "startLine": 73, "endLine": 108 },
     "type": "theorem",
     "title": "Recovering Erdős' Uniform Bound",
-    "content": "`property_b_two_colorable_of_uniform` re-derives the parent's theorem (k-uniform, `< 2^(k-1)` edges) from the non-uniform criterion, confirming the refinement is faithful. With every `|e| = k` the weighted sum collapses to `|E|·2^(n-k)` (`Finset.sum_const`); the hypothesis `|E| < 2^(k-1)` gives `2·|E| < 2^k`, hence `2·|E|·2^(n-k) < 2^k·2^(n-k) = 2^n` using `2^n = 2^k·2^(n-k)` with `k ≤ n` from any edge `⊆ univ`. The empty-family case is handled separately with the constant `true` coloring."
+    "content": "`property_b_two_colorable_of_uniform` re-derives the parent's theorem (`k`-uniform, `< 2^(k-1)` edges) from the non-uniform criterion, confirming the refinement is faithful and strictly more general. With every `|e| = k` the weighted sum collapses to `|E|·2^(n-k)` (`Finset.sum_const`); the hypothesis `|E| < 2^(k-1)` gives `2·|E| < 2^k`, hence `2·|E|·2^(n-k) < 2^k·2^(n-k) = 2^n` using `2^n = 2^k·2^(n-k)` with `k ≤ n` (any edge `⊆ univ`, so `e₀.card ≤ |V|`). The empty-family case is dispatched separately with the constant `true` coloring, since the weighted-sum hypothesis is vacuous there.",
+    "mathContext": "$|e| = k,\\ |E| < 2^{\\,k-1} \\;\\Rightarrow\\; 2|E|\\,2^{\\,n-k} < 2^{k}\\,2^{\\,n-k} = 2^{n}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization / corollary", "Finset.sum_const", "uniform hypergraph", "faithful refinement"],
+    "prerequisites": ["exponent arithmetic", "Finset.sum_const"]
   },
   {
     "id": "ann-pbfm-oq03-mixed-example",
@@ -21,6 +53,10 @@
     "range": { "startLine": 110, "endLine": 122 },
     "type": "example",
     "title": "A Mixed-Size Family the Uniform Theorem Misses",
-    "content": "`mixed_example_two_colorable`: over `V = Fin 3` the family `{{0,1},{0,1,2}}` mixes a size-2 and a size-3 edge, so the uniform theorem does not apply directly. The weighted sum is `2^(3-2) + 2^(3-3) = 2 + 1 = 3`, and `2·3 = 6 < 8 = 2^3`, so the non-uniform criterion certifies a proper 2-coloring. The two hypotheses (edges nonempty; the threshold inequality) are discharged by `decide` — not `native_decide`, so the result remains free of `Lean.ofReduceBool`."
+    "content": "`mixed_example_two_colorable`: over `V = Fin 3` the family `{{0,1},{0,1,2}}` mixes a size-2 and a size-3 edge, so the uniform theorem does not apply directly. The weighted sum is `2^(3-2) + 2^(3-3) = 2 + 1 = 3`, and `2·3 = 6 < 8 = 2^3`, so the non-uniform criterion certifies a proper 2-coloring. Both hypotheses — edges nonempty and the threshold inequality — are discharged by `decide`, **not** `native_decide`, so the result stays free of `Lean.ofReduceBool` and the whole entry remains 0-axiom.",
+    "mathContext": "$E = \\{\\{0,1\\},\\{0,1,2\\}\\}\\subseteq 2^{\\mathrm{Fin}\\,3},\\quad 2\\,(2^{1}+2^{0}) = 6 < 8 = 2^{3}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "decide vs native_decide", "axiom integrity", "concrete hypergraph"],
+    "prerequisites": ["Fin n", "Finset literals", "Lean decide tactic"]
   }
 ]

--- a/src/data/proofs/property-b-first-moment-oq-03/index.ts
+++ b/src/data/proofs/property-b-first-moment-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PropertyBFirstMomentOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const propertyBFirstMomentOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const propertyBFirstMomentOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const propertyBFirstMomentOq03Data: ProofData = {
+  proof: propertyBFirstMomentOq03Proof,
+  annotations: propertyBFirstMomentOq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `property-b-first-moment-oq-03` (quality 54, passes 0).

## Changes
- **Added missing `index.ts`** (critical): without it Vite's `import.meta.glob` cannot discover the proof, so the page rendered "proof not found" on the live site despite appearing in the gallery listing.
- **Annotation depth**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- **Annotation coverage 3 → 5**: added a module-docstring scope annotation (clarifying this is the *sharp single-round first moment*, not the Radhakrishnan–Srinivasan √(k/log k) bound) and split out a dedicated technique annotation for the proof body (lines 49–71) explaining the linearity-of-expectation step as an exact integer incidence count.

## Notes
- `meta.json` was already comprehensive (16 KB, well under the 60 KB cap) and accurate — left as-is per the diminishing-returns rule; focused effort on the genuine gaps (missing index.ts, shallow annotations).
- Axiom integrity verified: `status: verified`, `axiomCount: 0`, `badge: original` match the Lean file (0 sorries, 0 axioms, `decide` not `native_decide`, no structure-encoded assumptions).
- `pnpm build` passes (tsc type-check + data generation).