### PR TITLE
research(erdos-1005-oq-02): fix degenerate f(n) definition [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemProvable.lean
+++ b/proofs/Proofs/Erdos1005ProblemProvable.lean
@@ -122,9 +122,37 @@ f(n) is the largest length of a consecutive similarly ordered run.
 -/
 
 /-- f(n) = max length of consecutive similarly ordered Farey fractions.
-    This is the supremum over all i of the longest run starting at i. -/
+    This is the supremum over all i of the longest run starting at i.
+
+    The constraint `i + k < (fareyList n).length` is essential: without it the
+    set is unbounded and the supremum collapses to `0`. Indeed, for any `k`, the
+    start index `i := (fareyList n).length` makes every index `j ≥ i` satisfy
+    `(fareyList n)[j]? = none`, so `isSimOrdered n i k` holds *vacuously* (its
+    `… = some f₁` hypotheses are unsatisfiable). Hence `{k | ∃ i, isSimOrdered n i k}`
+    would equal all of `ℕ`, and `sSup` of an unbounded `Set ℕ` is `0` — a degenerate
+    `f(n) ≡ 0` that makes the lower bounds (`mayer_theorem`, `erdos_1943_linear`,
+    `vanDoorn_lower_bound`) false-as-stated and `vanDoorn_upper_bound` vacuously
+    true. Requiring the whole run window `[i, i+k]` to consist of present indices
+    (`i + k < length`) restores the intended finite maximum. See
+    `mayerErdosF_mem_bddAbove`. -/
 noncomputable def mayerErdosF (n : ℕ) : ℕ :=
-  sSup { k : ℕ | ∃ i, isSimOrdered n i k }
+  sSup { k : ℕ | ∃ i, i + k < (fareyList n).length ∧ isSimOrdered n i k }
+
+/-- The defining set of `mayerErdosF` is bounded above by the Farey list length —
+    the property the unconstrained `sSup { k | ∃ i, isSimOrdered n i k }` lacked
+    (that set is unbounded, forcing `sSup = 0`). Every admissible run length `k`
+    satisfies `k < (fareyList n).length`, so the supremum is a genuine maximum. -/
+theorem mayerErdosF_run_lt_length (n : ℕ) :
+    ∀ k ∈ { k : ℕ | ∃ i, i + k < (fareyList n).length ∧ isSimOrdered n i k },
+      k < (fareyList n).length := by
+  rintro k ⟨i, hik, _⟩
+  omega
+
+/-- Consequently the defining set is bounded above, so `mayerErdosF` is a true
+    maximum rather than the junk value `0` of an unbounded supremum. -/
+theorem mayerErdosF_mem_bddAbove (n : ℕ) :
+    BddAbove { k : ℕ | ∃ i, i + k < (fareyList n).length ∧ isSimOrdered n i k } :=
+  ⟨(fareyList n).length, fun k hk => le_of_lt (mayerErdosF_run_lt_length n k hk)⟩
 
 /-
 ## Historical Results

--- a/research/problems/erdos-1005-oq-02/knowledge.md
+++ b/research/problems/erdos-1005-oq-02/knowledge.md
@@ -135,3 +135,42 @@ SIGNIFICANCE: §15/§17 dichotomy now fully quantitative on its two extremes —
 all-`2` ladder grows LINEARLY (`continuant_replicate_two` K=n+1), all-`1` orbit
 stays BOUNDED (|K|≤1, period 6). Order-side reason a similarly ordered run is never
 both long and metrically cheap. Mixed-quotient regime (open 1/12–1/4) untouched.
+
+## Session 2026-06-28 (researcher-1): fixed degenerate f(n) definition in Provable file
+
+**Finding (verified bug).** `Erdos1005ProblemProvable.lean` defined the central
+object `mayerErdosF n := sSup { k | ∃ i, isSimOrdered n i k }`. This is **degenerate
+≡ 0**: `isSimOrdered n i k` is *vacuously true* whenever `i ≥ (fareyList n).length`,
+because every index `j ≥ i` gives `(fareyList n)[j]? = none`, so the
+`… = some f₁` hypotheses are unsatisfiable. Hence for every `k` the witness
+`i := (fareyList n).length` puts `k` in the set, the set is **all of ℕ**, and
+`sSup` of an unbounded `Set ℕ` is `0`. So `mayerErdosF n = 0` for all `n`.
+
+Consequences under the old def: the lower bounds `mayer_theorem`
+(`Tendsto … atTop`), `erdos_1943_linear` (`≥ c·n`, c>0) and `vanDoorn_lower_bound`
+(`≥ (1/12−ε)n`) were **false-as-stated** (their sorries were unprovable), while
+`vanDoorn_upper_bound` (`≤ n/4 + C`) was **vacuously true** (`0 ≤ n/4+C`) —
+exploitable as a fake "proof". A degenerate central definition is worse than an
+honest axiom.
+
+**Fix (VERIFIED, 0-axiom; docker-build.sh clean).** Constrained the run window to
+present indices:
+`mayerErdosF n := sSup { k | ∃ i, i + k < (fareyList n).length ∧ isSimOrdered n i k }`.
+Now `[i, i+k]` consists entirely of valid list indices, so vacuous truth cannot
+inflate `k`, and the set is bounded by the list length. Added two supporting
+theorems (sorry-free, foundational axioms only — `omega` + order, no
+`native_decide`):
+- `mayerErdosF_run_lt_length`: every admissible `k` satisfies `k < (fareyList n).length`.
+- `mayerErdosF_mem_bddAbove`: the defining set is `BddAbove` — the property the old
+  unconstrained set lacked, so `sSup` is now a genuine maximum.
+
+The six pre-existing research-level sorries (`farey_count_asymptotic`,
+`mayer_theorem`, `erdos_1943_linear`, `vanDoorn_lower/upper_bound`,
+`farey_adjacent_property`) are untouched and remain honestly open — but they are
+now **true-as-stated** (with the corrected non-degenerate `f(n)`), so a future
+session can attempt them without first tripping over the degeneracy. The base
+file's `axiom longestSimilarRun (n:ℕ):ℕ` is a separate untyped placeholder (no
+content, unused); left as-is.
+
+NOTE: this touches the `Provable` file, **not** the active OQ02 continuant theory
+(§16–§21) — no overlap with the in-flight Stern–Brocot / 1-12-constant frontier.


### PR DESCRIPTION
## Summary

Found and fixed a **latent correctness bug** in the central definition of Erdős #1005 (`Erdos1005ProblemProvable.lean`).

### The bug

```lean
noncomputable def mayerErdosF (n : ℕ) : ℕ :=
  sSup { k : ℕ | ∃ i, isSimOrdered n i k }   -- ⚠ degenerate ≡ 0
```

`isSimOrdered n i k` is **vacuously true** whenever `i ≥ (fareyList n).length`: every index `j ≥ i` gives `(fareyList n)[j]? = none`, so its `… = some f₁` premises are unsatisfiable. Hence for *every* `k` the witness `i := (fareyList n).length` puts `k` in the set → the set is **all of ℕ** → `sSup` of an unbounded `Set ℕ` is `0`. So **`mayerErdosF n ≡ 0`**.

Under the old definition:
- `mayer_theorem` (`Tendsto … atTop`), `erdos_1943_linear` (`≥ c·n`), `vanDoorn_lower_bound` (`≥ (1/12−ε)n`) were **false-as-stated** (their `sorry`s unprovable);
- `vanDoorn_upper_bound` (`≤ n/4 + C`) was **vacuously true** (`0 ≤ n/4+C`) — exploitable as a fake proof.

A degenerate central definition is worse than an honest axiom.

### The fix (VERIFIED, 0-axiom — `docker-build.sh` clean)

Constrain the run window to present indices:

```lean
noncomputable def mayerErdosF (n : ℕ) : ℕ :=
  sSup { k : ℕ | ∃ i, i + k < (fareyList n).length ∧ isSimOrdered n i k }
```

Now `[i, i+k]` are all valid list indices, vacuous truth cannot inflate `k`, and the set is bounded by the list length. Added two **sorry-free** supporting theorems (foundational axioms only — `omega` + order, no `native_decide`):

- `mayerErdosF_run_lt_length` — every admissible `k` satisfies `k < (fareyList n).length`;
- `mayerErdosF_mem_bddAbove` — the defining set is `BddAbove` (the property the old unconstrained set lacked), so `sSup` is now a genuine maximum.

### Scope / honesty

- The six pre-existing research-level `sorry`s are **untouched** and remain honestly open — but they are now **true-as-stated** with the corrected non-degenerate `f(n)`, so future work won't trip over the degeneracy.
- Does **not** touch the active OQ02 continuant theory (§16–§21 / the Stern–Brocot 1/12-constant frontier) — no overlap with in-flight work.
- Build: `./proofs/scripts/docker-build.sh Proofs.Erdos1005ProblemProvable` → "Build completed successfully", warnings only for the 6 pre-existing sorries.

Details in `research/problems/erdos-1005-oq-02/knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)