### PR TITLE
research(property-b-first-moment-oq-03): quantitative first moment + deletion method + threshold sharpness [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PropertyBFirstMomentOQ03.lean
+++ b/proofs/Proofs/PropertyBFirstMomentOQ03.lean
@@ -119,4 +119,111 @@ theorem mixed_example_two_colorable :
   · decide
   · decide
 
+-- ═══════════════════════════════════════════════════
+-- Quantitative first moment: a coloring with few monochromatic edges
+-- ═══════════════════════════════════════════════════
+
+/-
+  The parent's `exists_zero_of_sum_lt_card` is the *strict-threshold* form of the
+  first moment: when the incidence sum drops below the number of colorings, a
+  *perfect* coloring (zero monochromatic edges) exists. The averaging principle
+  below is its complementary, quantitative cousin: it bounds the *minimum* number
+  of monochromatic edges by the *average*, so it stays informative when the strict
+  criterion just fails. This is the genuine precursor to the Radhakrishnan–Srinivasan
+  alteration argument — that argument first secures a coloring with *few* bad edges,
+  then repairs them by recoloring; the lemmas here formalize the "few bad edges"
+  half, leaving only the (analytic, multi-session) recoloring half for RS.
+-/
+
+/-- **Averaging principle (minimum ≤ mean) over `ℕ`.** If a nonnegative integer
+statistic `f` on a nonempty finite set sums to at most `|s| · t`, some element
+takes value `≤ t`. The `t = 0` case is `exists_zero_of_sum_lt_card` strengthened
+to nonstrict; positive `t` is the surplus form the alteration method consumes. -/
+theorem exists_le_of_sum_le_card_mul {α : Type*} {s : Finset α} {f : α → ℕ} {t : ℕ}
+    (hne : s.Nonempty) (hle : (∑ a ∈ s, f a) ≤ s.card * t) : ∃ a ∈ s, f a ≤ t := by
+  by_contra h
+  push_neg at h
+  have h1 : ∀ a ∈ s, t + 1 ≤ f a := fun a ha => h a ha
+  have hge : s.card * (t + 1) ≤ ∑ a ∈ s, f a := by
+    calc s.card * (t + 1) = ∑ _a ∈ s, (t + 1) := by
+            rw [Finset.sum_const, smul_eq_mul]
+      _ ≤ ∑ a ∈ s, f a := Finset.sum_le_sum h1
+  have hpos : 1 ≤ s.card := Finset.card_pos.mpr hne
+  have hcomb : s.card * (t + 1) ≤ s.card * t := le_trans hge hle
+  rw [Nat.mul_succ] at hcomb
+  omega
+
+/-- **Quantitative first moment for Property B.** Some 2-coloring leaves at most `t`
+monochromatic edges, whenever the total `(coloring, monochromatic edge)` incidence
+`∑_{e} 2·2^(n-|e|)` is at most `2^n · t`. (Incidence `= ∑_c #{monochromatic edges
+under c}`, by `card_mono`, so its average over the `2^n` colorings is the displayed
+bound; the minimum is `≤` the average.)
+
+The `t = 0` regime recovers the existence of a *proper* coloring; the value of the
+statement is the regime where the strict criterion `property_b_of_weighted_first_moment`
+*fails* (incidence `≥ 2^n`) yet the family still admits a coloring with a controlled
+number `t ≥ 1` of defects — the input to a recoloring/alteration repair. -/
+theorem exists_coloring_few_mono
+    (E : Finset (Finset V)) (hne : ∀ e ∈ E, e.Nonempty) (t : ℕ)
+    (hbound : (∑ e ∈ E, 2 * 2 ^ (Fintype.card V - e.card)) ≤ 2 ^ Fintype.card V * t) :
+    ∃ c : V → Bool, (E.filter (fun e => Mono e c)).card ≤ t := by
+  -- ∑_c (#monochromatic edges under c) = ∑_e 2·2^(n-|e|)  (same count as the criterion)
+  have hsum :
+      (∑ c : V → Bool, (E.filter (fun e => Mono e c)).card)
+        = ∑ e ∈ E, 2 * 2 ^ (Fintype.card V - e.card) := by
+    simp_rw [Finset.card_filter]
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl ?_
+    intro e he
+    rw [← Finset.card_filter, card_mono e (hne e he)]
+  have hcard : (univ : Finset (V → Bool)).card = 2 ^ Fintype.card V := by
+    rw [Finset.card_univ, Fintype.card_fun, Fintype.card_bool]
+  have hUne : (univ : Finset (V → Bool)).Nonempty := by
+    rw [← Finset.card_pos, hcard]; positivity
+  have hle :
+      (∑ c : V → Bool, (E.filter (fun e => Mono e c)).card)
+        ≤ (univ : Finset (V → Bool)).card * t := by
+    rw [hsum, hcard]; exact hbound
+  obtain ⟨c, -, hc⟩ := exists_le_of_sum_le_card_mul hUne hle
+  exact ⟨c, hc⟩
+
+/-- **Uniform quantitative bound.** A `k`-uniform family of `|E|` edges admits a
+2-coloring with at most `t` monochromatic edges whenever `|E| ≤ 2^(k-1) · t`. The
+strict criterion's threshold is the `t = 1` boundary `|E| < 2^(k-1) ⟹ 0`; this
+extends one notch past it: `|E| ≤ 2^(k-1) · t ⟹ ≤ t` defects. -/
+theorem exists_coloring_few_mono_uniform
+    (E : Finset (Finset V)) (k t : ℕ) (hk : 1 ≤ k)
+    (huniform : ∀ e ∈ E, e.card = k) (hne : ∀ e ∈ E, e.Nonempty)
+    (hkn : k ≤ Fintype.card V)
+    (hcard : E.card ≤ 2 ^ (k - 1) * t) :
+    ∃ c : V → Bool, (E.filter (fun e => Mono e c)).card ≤ t := by
+  apply exists_coloring_few_mono E hne t
+  -- ∑_e 2·2^(n-k) = 2·|E|·2^(n-k) ≤ 2^k·t·2^(n-k) = 2^n·t
+  have hsumc : (∑ e ∈ E, 2 * 2 ^ (Fintype.card V - e.card))
+      = 2 * E.card * 2 ^ (Fintype.card V - k) := by
+    rw [Finset.sum_congr rfl (fun e he => by rw [huniform e he]),
+      Finset.sum_const, smul_eq_mul]; ring
+  have e1 : (2 : ℕ) ^ Fintype.card V = 2 ^ k * 2 ^ (Fintype.card V - k) := by
+    rw [← pow_add]; congr 1; omega
+  have e2 : (2 : ℕ) ^ k = 2 * 2 ^ (k - 1) := by
+    conv_lhs => rw [show k = 1 + (k - 1) by omega]
+    rw [pow_add, pow_one]
+  rw [hsumc, e1]
+  calc 2 * E.card * 2 ^ (Fintype.card V - k)
+        ≤ 2 * (2 ^ (k - 1) * t) * 2 ^ (Fintype.card V - k) := by gcongr
+    _ = 2 ^ k * 2 ^ (Fintype.card V - k) * t := by rw [e2]; ring
+
+/-- **Worked example: bounded defect on a non-2-colorable family.** The triangle
+`K₃ = {{0,1}, {0,2}, {1,2}}` over `Fin 3` is *not* 2-colorable (it has no Property B),
+so the strict criterion certifies nothing. Yet incidence `= 3 · 2·2^(3-2) = 12 ≤ 16 = 2³·2`,
+so `exists_coloring_few_mono` (with `t = 2`) guarantees a 2-coloring leaving at most `2`
+monochromatic edges — quantitative control exactly where the criterion is silent. -/
+theorem triangle_few_mono :
+    ∃ c : Fin 3 → Bool,
+      (({{0, 1}, {0, 2}, {1, 2}} : Finset (Finset (Fin 3))).filter
+        (fun e => Mono e c)).card ≤ 2 := by
+  apply exists_coloring_few_mono _ _ 2
+  · decide
+  · decide
+
 end ProbMethod.PropertyB

--- a/proofs/Proofs/PropertyBFirstMomentOQ03.lean
+++ b/proofs/Proofs/PropertyBFirstMomentOQ03.lean
@@ -226,4 +226,86 @@ theorem triangle_few_mono :
   · decide
   · decide
 
+-- ═══════════════════════════════════════════════════
+-- Deletion (alteration) method: a 2-colorable subfamily after removing few edges
+-- ═══════════════════════════════════════════════════
+
+/-
+  The quantitative first moment above secures a coloring with *few* monochromatic
+  edges; the deletion method turns that into a genuine 2-colorable hypergraph by
+  *removing* those few bad edges. This is the elementary, integer sibling of the
+  Radhakrishnan–Srinivasan *recoloring* alteration: RS repairs the bad edges by
+  flipping vertices (gaining the `√(k/log k)` factor); the deletion method simply
+  discards them (gaining nothing asymptotically, but giving a clean, fully finite
+  2-colorability statement — "every family has a 2-colorable subfamily missing at
+  most `t = ⌈incidence / 2^n⌉` edges"). It is the standard "delete one edge per
+  monochromatic edge" argument, and it is the conceptual bridge from the counting
+  lemmas to a real alteration.
+-/
+
+/-- Helper: a coloring `c` leaving `≤ t` monochromatic edges of `E` exhibits a
+2-colorable subfamily `E \ D` obtained by deleting the `≤ t` monochromatic edges
+`D = {e ∈ E | Mono e c}`. The *same* coloring `c` properly 2-colors `E \ D`, because
+every retained edge is, by construction, not monochromatic under `c`. -/
+private theorem subfamily_of_few_mono
+    (E : Finset (Finset V)) (c : V → Bool) (t : ℕ)
+    (hc : (E.filter (fun e => Mono e c)).card ≤ t) :
+    ∃ D ⊆ E, D.card ≤ t ∧ ∃ c' : V → Bool, ∀ e ∈ E \ D, ¬ Mono e c' := by
+  refine ⟨E.filter (fun e => Mono e c), Finset.filter_subset _ _, hc, c, ?_⟩
+  intro e he
+  rw [Finset.mem_sdiff] at he
+  obtain ⟨heE, heD⟩ := he
+  rw [Finset.mem_filter] at heD
+  push_neg at heD
+  exact heD heE
+
+/-- **Deletion method for Property B.** Every finite family `E` of nonempty edges
+has a 2-colorable subfamily obtained by deleting at most `t` edges, whenever the
+incidence total `∑_{e} 2·2^(n-|e|)` is at most `2^n · t`. (Take the coloring with
+`≤ t` monochromatic edges from `exists_coloring_few_mono` and delete exactly those.)
+
+The strict criterion `property_b_of_weighted_first_moment` is the `t = 0` boundary:
+incidence `< 2^n` deletes nothing. For `t ≥ 1` this stays informative past that
+threshold — the family need not be 2-colorable, yet all but `≤ t` of its edges are
+simultaneously 2-colorable. This is the deletion (alteration) form, the elementary
+sibling of the Radhakrishnan–Srinivasan recoloring repair. -/
+theorem exists_two_colorable_subfamily
+    (E : Finset (Finset V)) (hne : ∀ e ∈ E, e.Nonempty) (t : ℕ)
+    (hbound : (∑ e ∈ E, 2 * 2 ^ (Fintype.card V - e.card)) ≤ 2 ^ Fintype.card V * t) :
+    ∃ D ⊆ E, D.card ≤ t ∧ ∃ c : V → Bool, ∀ e ∈ E \ D, ¬ Mono e c := by
+  obtain ⟨c, hc⟩ := exists_coloring_few_mono E hne t hbound
+  exact subfamily_of_few_mono E c t hc
+
+/-- **Uniform deletion bound.** A `k`-uniform family of `|E|` edges has a 2-colorable
+subfamily after deleting at most `t` edges whenever `|E| ≤ 2^(k-1) · t`. Equivalently,
+a `k`-uniform hypergraph on `m` edges always retains a 2-colorable subfamily of at least
+`m - ⌈m / 2^(k-1)⌉` edges — the standard deletion-method consequence of the first moment
+`m · 2^(1-k)` expected monochromatic edges. -/
+theorem exists_two_colorable_subfamily_uniform
+    (E : Finset (Finset V)) (k t : ℕ) (hk : 1 ≤ k)
+    (huniform : ∀ e ∈ E, e.card = k) (hne : ∀ e ∈ E, e.Nonempty)
+    (hkn : k ≤ Fintype.card V)
+    (hcard : E.card ≤ 2 ^ (k - 1) * t) :
+    ∃ D ⊆ E, D.card ≤ t ∧ ∃ c : V → Bool, ∀ e ∈ E \ D, ¬ Mono e c := by
+  obtain ⟨c, hc⟩ := exists_coloring_few_mono_uniform E k t hk huniform hne hkn hcard
+  exact subfamily_of_few_mono E c t hc
+
+/-- **Worked example: bipartite subgraph of `K₄` by deletion.** The complete graph
+`K₄ = {{0,1},{0,2},{0,3},{1,2},{1,3},{2,3}}` (a 2-uniform family over `Fin 4`) is not
+bipartite — it contains triangles, so it has no Property B. Its incidence total is
+`6 · 2·2^(4-2) = 48 = 2^4 · 3`, so the deletion bound (`t = 3`) produces a 2-coloring
+(a vertex bipartition) under which at most `3` of the `6` edges are removed, i.e. a
+bipartite subgraph on `≥ 3` edges — a finite Max-Cut-flavored instance of the method.
+(The first moment is loose here: deleting `2` edges already yields the bipartite `K_{2,2}`;
+the averaging certifies only `≤ 3`.) -/
+theorem k4_bipartite_subfamily :
+    ∃ D ⊆ ({{0, 1}, {0, 2}, {0, 3}, {1, 2}, {1, 3}, {2, 3}} :
+        Finset (Finset (Fin 4))),
+      D.card ≤ 3 ∧ ∃ c : Fin 4 → Bool,
+        ∀ e ∈ ({{0, 1}, {0, 2}, {0, 3}, {1, 2}, {1, 3}, {2, 3}} :
+            Finset (Finset (Fin 4))) \ D, ¬ Mono e c := by
+  apply exists_two_colorable_subfamily _ _ 3
+  · decide
+  · decide
+
 end ProbMethod.PropertyB

--- a/proofs/Proofs/PropertyBFirstMomentOQ03.lean
+++ b/proofs/Proofs/PropertyBFirstMomentOQ03.lean
@@ -308,4 +308,63 @@ theorem k4_bipartite_subfamily :
   · decide
   · decide
 
+-- ═══════════════════════════════════════════════════
+-- Sharpness: the strict inequality `< 2^n` (i.e. `∑ 2^(1-|e|) < 1`) is best possible
+-- ═══════════════════════════════════════════════════
+
+/-
+  The criterion `property_b_of_weighted_first_moment` requires the *strict* inequality
+  `2·∑ 2^(n-|e|) < 2^n`, equivalently `∑ 2^(1-|e|) < 1`. The lemmas below witness that
+  this threshold is sharp: the inequality cannot be relaxed to `≤` (and the constant `1`
+  cannot be increased). A single *singleton* edge `{v}` is monochromatic under every
+  coloring — a one-element set is trivially monochromatic — so the family `{{v}}` has no
+  proper 2-coloring, yet its incidence total `2·2^(n-1)` sits *exactly* on the boundary
+  `2^n` (i.e. `∑ 2^(1-|e|) = 1`). This is the elementary boundary obstruction; it confirms
+  the "sharp at `∑ 2^(1-|e|) < 1`" framing of OQ-03 is a theorem, not merely an assertion.
+-/
+
+omit [Fintype V] [DecidableEq V] in
+/-- A singleton edge `{v}` is monochromatic under *every* coloring: a one-element set is
+trivially monochromatic (its single vertex agrees with itself). -/
+theorem mono_singleton (v : V) (c : V → Bool) : Mono ({v} : Finset V) c :=
+  ⟨c v, by intro x hx; rw [Finset.mem_singleton] at hx; rw [hx]⟩
+
+omit [DecidableEq V] in
+/-- **Sharpness of the strict first-moment criterion.** For any nonempty `V` (witnessed by
+a vertex `v`), the boundary family `{{v}}` of a single singleton edge
+* consists of nonempty edges,
+* has incidence total *exactly* `2^n` — i.e. it saturates the criterion's bound with
+  equality, `2·∑_{e} 2^(n-|e|) = 2^n` (equivalently `∑_e 2^(1-|e|) = 1`), and
+* has **no** proper 2-coloring (the singleton is monochromatic under every coloring).
+
+Hence the strict `< 2^n` in `property_b_of_weighted_first_moment` cannot be relaxed to
+`≤ 2^n`: the criterion is sharp exactly at `∑ 2^(1-|e|) < 1`. -/
+theorem weighted_criterion_sharp (v : V) :
+    (∀ e ∈ ({{v}} : Finset (Finset V)), e.Nonempty) ∧
+    2 * ∑ e ∈ ({{v}} : Finset (Finset V)), 2 ^ (Fintype.card V - e.card)
+      = 2 ^ Fintype.card V ∧
+    ¬ ∃ c : V → Bool, ∀ e ∈ ({{v}} : Finset (Finset V)), ¬ Mono e c := by
+  refine ⟨?_, ?_, ?_⟩
+  · -- the only edge is `{v}`, which is nonempty
+    intro e he
+    rw [Finset.mem_singleton] at he; subst he
+    exact Finset.singleton_nonempty v
+  · -- incidence `= 2·2^(n-1) = 2^n`, using `n = |V| ≥ 1`
+    have hn : 1 ≤ Fintype.card V := Fintype.card_pos_iff.mpr ⟨v⟩
+    rw [Finset.sum_singleton, Finset.card_singleton, ← pow_succ']
+    congr 1
+    omega
+  · -- a proper coloring would have to make `{v}` non-monochromatic — impossible
+    rintro ⟨c, hc⟩
+    exact hc {v} (Finset.mem_singleton_self ({v} : Finset V)) (mono_singleton v c)
+
+/-- **Concrete boundary witness over `Fin 1`.** The family `{{0}}` over `V = Fin 1` has
+incidence total `2·2^(1-1) = 2 = 2^1` (equality, *not* `< 2^1`) and no proper 2-coloring,
+so the strict inequality of the criterion is sharp at the smallest possible scale. -/
+theorem boundary_singleton_fin1 :
+    2 * ∑ e ∈ ({{0}} : Finset (Finset (Fin 1))), 2 ^ (Fintype.card (Fin 1) - e.card)
+      = 2 ^ Fintype.card (Fin 1) ∧
+    ¬ ∃ c : Fin 1 → Bool, ∀ e ∈ ({{0}} : Finset (Finset (Fin 1))), ¬ Mono e c :=
+  ⟨(weighted_criterion_sharp (0 : Fin 1)).2.1, (weighted_criterion_sharp (0 : Fin 1)).2.2⟩
+
 end ProbMethod.PropertyB

--- a/research/registry.json
+++ b/research/registry.json
@@ -32198,11 +32198,11 @@
     },
     {
       "slug": "property-b-first-moment-oq-03",
-      "phase": "NEW",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-28T12:29:05.731Z",
       "status": "active",
-      "lastUpdate": "2026-06-28T12:29:05.731Z"
+      "lastUpdate": "2026-06-28T08:53:06-07:00"
     },
     {
       "slug": "russell-1-plus-1-oq-02",

--- a/src/data/proofs/property-b-first-moment-oq-03/meta.json
+++ b/src/data/proofs/property-b-first-moment-oq-03/meta.json
@@ -130,11 +130,11 @@
       "BigOperators"
     ],
     "namespace": "ProbMethod.PropertyB",
-    "lineCount": 122,
+    "lineCount": 229,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 3
+    "theoremCount": 7
   },
   "references": [
     {
@@ -173,5 +173,6 @@
       "leanType": "(1 ≤ k) → (∀ e ∈ E, e.card = k) → E.card < 2^(k-1) → ∃ c : V → Bool, ∀ e ∈ E, ¬ Mono e c"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "theoremCount": 7
 }

--- a/src/data/proofs/property-b-first-moment-oq-03/meta.json
+++ b/src/data/proofs/property-b-first-moment-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "property-b-first-moment-oq-03",
   "title": "Non-Uniform Sharpening of the First-Moment Property B Criterion (∑ 2^(1-|e|) < 1)",
   "slug": "property-b-first-moment-oq-03",
-  "description": "Partially answers open question oq-03 of property-b-first-moment, which ultimately targets the Radhakrishnan–Srinivasan lower bound m(k) = Ω(2^k·√(k/log k)). This entry delivers the *sharp form of the first-moment lower bound itself*: the genuine Erdős criterion ∑_{e∈E} 2^(1-|e|) < 1 ⟹ Property B for hypergraphs with edges of ARBITRARY size, stated over ℕ (no division) as 2·∑_{e} 2^(n-|e|) < 2^n with n = |V|. Large edges contribute geometrically less, so a family dominated by large edges is 2-colorable even when its raw edge count far exceeds 2^(k-1) for the smallest edge size k. The parent file's uniform theorem property_b_two_colorable (k-uniform, < 2^(k-1) edges) is recovered here as the special case |e| = k, confirming the refinement is faithful. The proof reuses the parent's exact monochromatic count card_mono and first moment principle exists_zero_of_sum_lt_card verbatim, dropping only the uniformity assumption. This is NOT the Radhakrishnan–Srinivasan √(k/log k) factor: that needs a random recoloring (alteration) argument — a second round repairing the monochromatic edges left by the first — beyond the single-round first moment formalized here; the recoloring roadmap is recorded in the research knowledge base. Verified, 0 axioms, 0 sorries, no native_decide.",
+  "description": "Partially answers open question oq-03 of property-b-first-moment, which ultimately targets the Radhakrishnan–Srinivasan lower bound m(k) = Ω(2^k·√(k/log k)). This entry delivers the *sharp form of the first-moment lower bound itself*: the genuine Erdős criterion ∑_{e∈E} 2^(1-|e|) < 1 ⟹ Property B for hypergraphs with edges of ARBITRARY size, stated over ℕ (no division) as 2·∑_{e} 2^(n-|e|) < 2^n with n = |V|. Large edges contribute geometrically less, so a family dominated by large edges is 2-colorable even when its raw edge count far exceeds 2^(k-1) for the smallest edge size k. The parent file's uniform theorem property_b_two_colorable (k-uniform, < 2^(k-1) edges) is recovered here as the special case |e| = k, confirming the refinement is faithful. The proof reuses the parent's exact monochromatic count card_mono and first moment principle exists_zero_of_sum_lt_card verbatim, dropping only the uniformity assumption. This is NOT the Radhakrishnan–Srinivasan √(k/log k) factor: that needs a random recoloring (alteration) argument — a second round repairing the monochromatic edges left by the first — beyond the single-round first moment formalized here; the recoloring roadmap is recorded in the research knowledge base. The strict threshold is shown best possible (weighted_criterion_sharp): a single singleton edge {v} saturates the bound with equality ∑ 2^(1-|e|) = 1 yet is never 2-colorable, so the inequality cannot be relaxed to ≤. Verified, 0 axioms, 0 sorries, no native_decide.",
   "meta": {
     "author": "Paul Erdős / László Lovász (non-uniform first moment), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Property_B",
@@ -48,7 +48,8 @@
       "mixed_example_two_colorable: a worked instance over V = Fin 3 with the mixed-size family {{0,1},{0,1,2}} (a size-2 and a size-3 edge), whose weighted sum 2 + 1 = 3 satisfies 2·3 = 6 < 8 = 2^3 — certified 2-colorable by the criterion although the uniform theorem does not apply.",
       "Quantitative first moment (averaging principle): exists_le_of_sum_le_card_mul (nonstrict min ≤ mean over ℕ) and exists_coloring_few_mono — some 2-coloring leaves at most t monochromatic edges whenever the incidence ∑_e 2·2^(n-|e|) ≤ 2^n·t. This stays informative in the regime where the strict criterion FAILS (incidence ≥ 2^n) yet the family admits a coloring with a controlled number t ≥ 1 of defects, with exists_coloring_few_mono_uniform (k-uniform, |E| ≤ 2^(k-1)·t ⟹ ≤ t defects) and triangle_few_mono (K₃ over Fin 3: incidence 12 ≤ 16 ⟹ ≤ 2 mono edges, nontrivial control where the criterion is silent).",
       "Deletion (alteration) method: exists_two_colorable_subfamily — every finite family of nonempty edges has a 2-colorable subfamily after deleting at most t edges whenever the incidence ∑_e 2·2^(n-|e|) ≤ 2^n·t (take the few-mono coloring and delete exactly its monochromatic edges; the same coloring properly 2-colors the remainder). exists_two_colorable_subfamily_uniform gives the standard deletion-method consequence (k-uniform: retain a 2-colorable subfamily of ≥ |E| − ⌈|E|/2^(k-1)⌉ edges), and k4_bipartite_subfamily is a finite Max-Cut-flavored instance (K₄ over Fin 4: delete ≤ 3 of 6 edges to expose a bipartite subgraph). This is the elementary integer sibling of the Radhakrishnan–Srinivasan recoloring repair: RS flips vertices to gain the √(k/log k) factor; deletion simply discards the bad edges.",
-      "An honest scoping of open question oq-03: the single-round first moment is sharp at ∑ 2^(1-|e|) < 1 and the deletion method gains nothing asymptotically; reaching the Radhakrishnan–Srinivasan m(k) = Ω(2^k·√(k/log k)) bound requires the random RECOLORING repair (not deletion), a genuinely different second-round alteration model — recorded as the remaining moonshot."
+      "Sharpness of the strict threshold: weighted_criterion_sharp (with helper mono_singleton and concrete witness boundary_singleton_fin1) proves the strict inequality 2·∑ 2^(n-|e|) < 2^n in property_b_of_weighted_first_moment cannot be relaxed to ≤. A single singleton edge {v} is monochromatic under EVERY coloring (a one-element set is trivially monochromatic), so the family {{v}} has no proper 2-coloring — yet its incidence total is exactly 2·2^(n-1) = 2^n, sitting precisely on the boundary ∑ 2^(1-|e|) = 1. Hence the threshold ∑ 2^(1-|e|) < 1 is best possible: no ≤ 1 criterion can hold. This turns the 'sharp at ∑ 2^(1-|e|) < 1' framing into a theorem rather than an assertion.",
+      "An honest scoping of open question oq-03: the single-round first moment is sharp at ∑ 2^(1-|e|) < 1 (now witnessed by weighted_criterion_sharp) and the deletion method gains nothing asymptotically; reaching the Radhakrishnan–Srinivasan m(k) = Ω(2^k·√(k/log k)) bound requires the random RECOLORING repair (not deletion), a genuinely different second-round alteration model — recorded as the remaining moonshot."
     ],
     "dateAdded": "2026-06-28",
     "relatedProblems": [
@@ -58,10 +59,10 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 311,
-    "assumptions": "0 axioms, 0 sorries, no native_decide (the worked examples use decide, which depends only on the foundational kernel, not Lean.ofReduceBool). The hypotheses (edges nonempty; weighted-sum / incidence bounds) are inputs to the statements, not standing assumptions; V is an arbitrary Fintype with DecidableEq and n = Fintype.card V. #print axioms reports only propext, Classical.choice, Quot.sound for every theorem (criterion, averaging, and deletion families — checked for property_b_of_weighted_first_moment, exists_coloring_few_mono, exists_two_colorable_subfamily, exists_two_colorable_subfamily_uniform, k4_bipartite_subfamily, etc.) — no sorryAx, no Lean.ofReduceBool. This is the single-round FIRST-MOMENT bound plus its quantitative (few-bad-edges) and deletion (alteration) corollaries; the Radhakrishnan–Srinivasan √(k/log k) improvement, which needs random RECOLORING rather than deletion, is NOT formalized and is left open.",
+    "lineCount": 370,
+    "assumptions": "0 axioms, 0 sorries, no native_decide (the worked examples use decide, which depends only on the foundational kernel, not Lean.ofReduceBool). The hypotheses (edges nonempty; weighted-sum / incidence bounds) are inputs to the statements, not standing assumptions; V is an arbitrary Fintype with DecidableEq and n = Fintype.card V. #print axioms reports only propext, Classical.choice, Quot.sound for every theorem (criterion, averaging, and deletion families — checked for property_b_of_weighted_first_moment, exists_coloring_few_mono, exists_two_colorable_subfamily, exists_two_colorable_subfamily_uniform, k4_bipartite_subfamily, weighted_criterion_sharp, etc.) — no sorryAx, no Lean.ofReduceBool. This is the single-round FIRST-MOMENT bound plus its quantitative (few-bad-edges) and deletion (alteration) corollaries; the Radhakrishnan–Srinivasan √(k/log k) improvement, which needs random RECOLORING rather than deletion, is NOT formalized and is left open.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 13,
     "definitionCount": 0
   },
   "overview": {
@@ -148,11 +149,11 @@
       "BigOperators"
     ],
     "namespace": "ProbMethod.PropertyB",
-    "lineCount": 311,
+    "lineCount": 370,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 10
+    "theoremCount": 13
   },
   "references": [
     {
@@ -204,5 +205,5 @@
     }
   ],
   "sorries": 0,
-  "theoremCount": 10
+  "theoremCount": 13
 }

--- a/src/data/proofs/property-b-first-moment-oq-03/meta.json
+++ b/src/data/proofs/property-b-first-moment-oq-03/meta.json
@@ -46,7 +46,9 @@
       "property_b_of_weighted_first_moment: a 0-axiom Lean proof of the non-uniform Erdős/Lovász Property B criterion — a finite family E of nonempty edges (arbitrary sizes) is 2-colorable as soon as 2·∑_{e∈E} 2^(n-|e|) < 2^n, equivalently ∑_e 2^(1-|e|) < 1. Obtained by re-running the parent's first-moment template with the per-edge count card_mono summed over heterogeneous edge sizes.",
       "property_b_two_colorable_of_uniform: re-derivation of the parent's uniform theorem (k-uniform, < 2^(k-1) edges) as a corollary of the non-uniform criterion, with the weighted sum collapsing to |E|·2^(n-k). This verifies the refinement strictly extends the parent rather than diverging from it.",
       "mixed_example_two_colorable: a worked instance over V = Fin 3 with the mixed-size family {{0,1},{0,1,2}} (a size-2 and a size-3 edge), whose weighted sum 2 + 1 = 3 satisfies 2·3 = 6 < 8 = 2^3 — certified 2-colorable by the criterion although the uniform theorem does not apply.",
-      "An honest scoping of open question oq-03: the single-round first moment is sharp at ∑ 2^(1-|e|) < 1 and cannot reach the Radhakrishnan–Srinivasan m(k) = Ω(2^k·√(k/log k)) bound, which requires random recoloring — recorded as the remaining moonshot."
+      "Quantitative first moment (averaging principle): exists_le_of_sum_le_card_mul (nonstrict min ≤ mean over ℕ) and exists_coloring_few_mono — some 2-coloring leaves at most t monochromatic edges whenever the incidence ∑_e 2·2^(n-|e|) ≤ 2^n·t. This stays informative in the regime where the strict criterion FAILS (incidence ≥ 2^n) yet the family admits a coloring with a controlled number t ≥ 1 of defects, with exists_coloring_few_mono_uniform (k-uniform, |E| ≤ 2^(k-1)·t ⟹ ≤ t defects) and triangle_few_mono (K₃ over Fin 3: incidence 12 ≤ 16 ⟹ ≤ 2 mono edges, nontrivial control where the criterion is silent).",
+      "Deletion (alteration) method: exists_two_colorable_subfamily — every finite family of nonempty edges has a 2-colorable subfamily after deleting at most t edges whenever the incidence ∑_e 2·2^(n-|e|) ≤ 2^n·t (take the few-mono coloring and delete exactly its monochromatic edges; the same coloring properly 2-colors the remainder). exists_two_colorable_subfamily_uniform gives the standard deletion-method consequence (k-uniform: retain a 2-colorable subfamily of ≥ |E| − ⌈|E|/2^(k-1)⌉ edges), and k4_bipartite_subfamily is a finite Max-Cut-flavored instance (K₄ over Fin 4: delete ≤ 3 of 6 edges to expose a bipartite subgraph). This is the elementary integer sibling of the Radhakrishnan–Srinivasan recoloring repair: RS flips vertices to gain the √(k/log k) factor; deletion simply discards the bad edges.",
+      "An honest scoping of open question oq-03: the single-round first moment is sharp at ∑ 2^(1-|e|) < 1 and the deletion method gains nothing asymptotically; reaching the Radhakrishnan–Srinivasan m(k) = Ω(2^k·√(k/log k)) bound requires the random RECOLORING repair (not deletion), a genuinely different second-round alteration model — recorded as the remaining moonshot."
     ],
     "dateAdded": "2026-06-28",
     "relatedProblems": [
@@ -56,10 +58,10 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 122,
-    "assumptions": "0 axioms, 0 sorries, no native_decide (the worked example uses decide, which depends only on the foundational kernel, not Lean.ofReduceBool). The hypotheses (edges nonempty; 2·∑_e 2^(n-|e|) < 2^n) are inputs to the statement, not standing assumptions; V is an arbitrary Fintype with DecidableEq and n = Fintype.card V. #print axioms reports only propext, Classical.choice, Quot.sound for property_b_of_weighted_first_moment, property_b_two_colorable_of_uniform, and mixed_example_two_colorable — no sorryAx, no Lean.ofReduceBool. This is the sharp FIRST-MOMENT bound only; the Radhakrishnan–Srinivasan √(k/log k) improvement is NOT formalized and is left open.",
+    "lineCount": 311,
+    "assumptions": "0 axioms, 0 sorries, no native_decide (the worked examples use decide, which depends only on the foundational kernel, not Lean.ofReduceBool). The hypotheses (edges nonempty; weighted-sum / incidence bounds) are inputs to the statements, not standing assumptions; V is an arbitrary Fintype with DecidableEq and n = Fintype.card V. #print axioms reports only propext, Classical.choice, Quot.sound for every theorem (criterion, averaging, and deletion families — checked for property_b_of_weighted_first_moment, exists_coloring_few_mono, exists_two_colorable_subfamily, exists_two_colorable_subfamily_uniform, k4_bipartite_subfamily, etc.) — no sorryAx, no Lean.ofReduceBool. This is the single-round FIRST-MOMENT bound plus its quantitative (few-bad-edges) and deletion (alteration) corollaries; the Radhakrishnan–Srinivasan √(k/log k) improvement, which needs random RECOLORING rather than deletion, is NOT formalized and is left open.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 3,
+    "theoremCount": 10,
     "definitionCount": 0
   },
   "overview": {
@@ -103,13 +105,29 @@
       "endLine": 122,
       "mathContext": "$E = \\{\\{0,1\\},\\{0,1,2\\}\\}\\subseteq 2^{\\mathrm{Fin}\\,3},\\quad 2(2^{1}+2^{0}) = 6 < 8 = 2^{3}$",
       "summary": "mixed_example_two_colorable: a size-2 and a size-3 edge over Fin 3; weighted sum 2 + 1 = 3, and 2·3 = 6 < 8, so the criterion certifies a proper 2-coloring. The hypotheses (edges nonempty, threshold) are dispatched by decide."
+    },
+    {
+      "id": "quantitative-first-moment",
+      "title": "Quantitative First Moment: a Coloring with Few Monochromatic Edges",
+      "startLine": 122,
+      "endLine": 227,
+      "mathContext": "$\\sum_{e} 2\\cdot 2^{\\,n-|e|} \\le 2^{n} t \\;\\Rightarrow\\; \\exists c,\\ \\#\\{e : \\mathrm{Mono}(e,c)\\} \\le t$",
+      "summary": "exists_le_of_sum_le_card_mul (nonstrict min ≤ mean over ℕ, the averaging cousin of exists_zero_of_sum_lt_card) feeds the same card_mono incidence count to give exists_coloring_few_mono: some coloring leaves ≤ t monochromatic edges. exists_coloring_few_mono_uniform specializes to k-uniform (|E| ≤ 2^(k-1)·t ⟹ ≤ t defects); triangle_few_mono shows K₃ over Fin 3 (incidence 12 ≤ 16 = 2³·2) admits a coloring with ≤ 2 monochromatic edges where the strict criterion is silent."
+    },
+    {
+      "id": "deletion-method",
+      "title": "Deletion (Alteration) Method: a 2-Colorable Subfamily After Removing Few Edges",
+      "startLine": 229,
+      "endLine": 311,
+      "mathContext": "$\\sum_{e} 2\\cdot 2^{\\,n-|e|} \\le 2^{n} t \\;\\Rightarrow\\; \\exists D\\subseteq E,\\ |D|\\le t,\\ E\\setminus D \\text{ is 2-colorable}$",
+      "summary": "subfamily_of_few_mono turns the few-mono coloring into a 2-colorable subfamily by deleting exactly its monochromatic edges D = {e : Mono e c}; the same c properly 2-colors E \\ D. exists_two_colorable_subfamily (general) and exists_two_colorable_subfamily_uniform (k-uniform: retain ≥ |E| − ⌈|E|/2^(k-1)⌉ edges) formalize the standard deletion method, the elementary integer sibling of RS recoloring. k4_bipartite_subfamily is a finite Max-Cut-flavored instance: K₄ over Fin 4 (incidence 48 = 2⁴·3) yields a bipartite subgraph after deleting ≤ 3 of 6 edges."
     }
   ],
   "conclusion": {
     "summary": "The sharp single-round first-moment criterion for Property B — a finite hypergraph of nonempty edges of arbitrary sizes is 2-colorable whenever ∑_{e} 2^(1-|e|) < 1 — formalized with zero sorries and zero axioms, reusing the parent file's exact monochromatic count card_mono and first moment principle exists_zero_of_sum_lt_card per edge. Erdős' uniform bound m(k) ≥ 2^(k-1) is recovered as the corollary |e| = k, and a mixed-size example shows the criterion strictly extends the uniform case.",
     "implications": "This answers the first-moment portion of open question oq-03 and sharpens the parent's lower bound to its non-uniform optimum. It also delimits the method: the single-round first moment is sharp at ∑ 2^(1-|e|) < 1 and cannot by itself reach the Radhakrishnan–Srinivasan m(k) = Ω(2^k·√(k/log k)) bound that oq-03 ultimately targets.",
     "openQuestions": [
-      "Formalize the Radhakrishnan–Srinivasan random recoloring argument: after the first random 2-coloring, recolor the vertices of surviving monochromatic edges and bound the probability that any edge remains monochromatic, yielding m(k) = Ω(2^k·√(k/log k)). This requires a second-round (alteration) probability model not present in the single-round first moment.",
+      "Formalize the Radhakrishnan–Srinivasan random RECOLORING argument: after the first random 2-coloring, recolor the vertices of surviving monochromatic edges (in a fixed random vertex order, with probability p ≈ (log k)/k) and bound the probability that any edge remains monochromatic, yielding m(k) = Ω(2^k·√(k/log k)). This requires a second-round (alteration) probability model that REPAIRS rather than DELETES — the deletion method formalized in this entry (exists_two_colorable_subfamily) is the elementary sibling that gains nothing asymptotically.",
       "Formalize the matching upper bound m(k) = O(k^2·2^k) (Erdős' random construction of a non-2-colorable k-uniform hypergraph with O(k^2·2^k) edges)."
     ]
   },
@@ -130,11 +148,11 @@
       "BigOperators"
     ],
     "namespace": "ProbMethod.PropertyB",
-    "lineCount": 229,
+    "lineCount": 311,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 7
+    "theoremCount": 10
   },
   "references": [
     {
@@ -171,8 +189,20 @@
       "type": "supporting",
       "description": "The parent's uniform Erdős bound (k-uniform, < 2^(k-1) edges) recovered as a corollary of the non-uniform criterion.",
       "leanType": "(1 ≤ k) → (∀ e ∈ E, e.card = k) → E.card < 2^(k-1) → ∃ c : V → Bool, ∀ e ∈ E, ¬ Mono e c"
+    },
+    {
+      "name": "exists_coloring_few_mono",
+      "type": "core",
+      "description": "Quantitative first moment: some 2-coloring leaves at most t monochromatic edges whenever the incidence ∑_e 2·2^(n-|e|) ≤ 2^n·t — informative past the strict threshold (t = 0 recovers a proper coloring).",
+      "leanType": "(∀ e ∈ E, e.Nonempty) → (∑ e ∈ E, 2 * 2^(Fintype.card V - e.card)) ≤ 2^(Fintype.card V) * t → ∃ c : V → Bool, (E.filter (fun e => Mono e c)).card ≤ t"
+    },
+    {
+      "name": "exists_two_colorable_subfamily",
+      "type": "core",
+      "description": "Deletion (alteration) method: every finite family of nonempty edges has a 2-colorable subfamily after deleting at most t edges whenever the incidence ∑_e 2·2^(n-|e|) ≤ 2^n·t. The elementary integer sibling of the Radhakrishnan–Srinivasan recoloring repair.",
+      "leanType": "(∀ e ∈ E, e.Nonempty) → (∑ e ∈ E, 2 * 2^(Fintype.card V - e.card)) ≤ 2^(Fintype.card V) * t → ∃ D ⊆ E, D.card ≤ t ∧ ∃ c : V → Bool, ∀ e ∈ E \\ D, ¬ Mono e c"
     }
   ],
   "sorries": 0,
-  "theoremCount": 7
+  "theoremCount": 10
 }


### PR DESCRIPTION
## Summary

Three research sessions on open question **oq-03** of `property-b-first-moment` (target: the Radhakrishnan–Srinivasan lower bound `m(k) = Ω(2^k·√(k/log k))`). All advance the *honest, fully-formalizable* part of the program around the single-round first-moment criterion. File `PropertyBFirstMomentOQ03.lean` now has **13 theorems / 370 lines, 0 sorry / 0 axiom** (`#print axioms` = propext/Classical.choice/Quot.sound only; `decide` examples, no `native_decide`, no `Lean.ofReduceBool`). Built clean via Docker (7744 jobs).

### Session 1 — quantitative first moment (few bad edges)
- `exists_le_of_sum_le_card_mul` — nonstrict averaging principle (min ≤ mean) over ℕ.
- `exists_coloring_few_mono` — some 2-coloring leaves ≤ t monochromatic edges when incidence `∑_e 2·2^(n-|e|) ≤ 2^n·t`. Informative exactly where the strict criterion FAILS.
- `exists_coloring_few_mono_uniform`, `triangle_few_mono` (K₃: ≤ 2 mono edges).

### Session 2 — deletion (alteration) method
- `subfamily_of_few_mono` (helper) — a few-mono coloring exhibits a 2-colorable subfamily by deleting its monochromatic edges; the same coloring 2-colors the remainder.
- `exists_two_colorable_subfamily` — incidence `≤ 2^n·t` ⟹ a 2-colorable subfamily after deleting ≤ t edges. The deletion/alteration method, the elementary integer sibling of RS recoloring.
- `exists_two_colorable_subfamily_uniform` — k-uniform: retain a 2-colorable subfamily of ≥ |E| − ⌈|E|/2^(k-1)⌉ edges.
- `k4_bipartite_subfamily` — K₄ over Fin 4: delete ≤ 3 of 6 edges to expose a bipartite subgraph (finite Max-Cut instance).

### Session 3 — sharpness of the strict threshold (this update)
- `mono_singleton` (helper) — a singleton edge `{v}` is monochromatic under *every* coloring (a one-element set is trivially monochromatic).
- `weighted_criterion_sharp` — the strict inequality `2·∑2^(n-|e|) < 2^n` (i.e. `∑2^(1-|e|) < 1`) in `property_b_of_weighted_first_moment` **cannot be relaxed to ≤**: the family `{{v}}` saturates the bound with equality `2·2^(n-1) = 2^n` yet has no proper 2-coloring.
- `boundary_singleton_fin1` — concrete boundary witness over `Fin 1` (`2·∑ = 2 = 2^1`, no proper coloring).

This turns the entry's "sharp at `∑2^(1-|e|) < 1`" framing from an assertion into a theorem.

## Honest scoping
The deletion method gains **nothing asymptotically** over the first moment, and the sharpness result confirms the single-round criterion is best possible at its threshold. The RS `√(k/log k)` factor requires random **RECOLORING** (flip vertices to repair), a genuinely different second-round probability model with the `p = log k / k` optimization — NOT formalized here, left open as the remaining moonshot.

## Verification
`./proofs/scripts/docker-build.sh Proofs.PropertyBFirstMomentOQ03` → `✔ Built`, 7744 jobs. `#print axioms` checked on every theorem: propext/Classical.choice/Quot.sound only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)