### PR TITLE
Enrich 'Combinatorial Borsuk–Ulam (Tucker's Lemma, 1-D)' (sperner-ndim-mathlib-oq-03)

### DIFF
--- a/src/data/proofs/sperner-ndim-mathlib-oq-03/index.ts
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SpernerNDimMathlibOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const spernerNdimMathlibOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const spernerNdimMathlibOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const spernerNdimMathlibOq03Data: ProofData = {
+  proof: spernerNdimMathlibOq03Proof,
+  annotations: spernerNdimMathlibOq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `sperner-ndim-mathlib-oq-03` (quality 83, passes 0).

## Changes
- **Added missing `index.ts`** (critical): without it Vite's `import.meta.glob` cannot discover the proof, so the page rendered "proof not found" on the live site. This was the dominant quality gap.
- **Annotation coverage 3 → 5**, now spanning the entire Lean file:
  - `signChanges` definition + `signChanges_succ` recurrence (lines 77–93) — the discrete object and the inductive fuel for the parity engine.
  - Tucker extraction (lines 120–154) — how `Finset.card_pos` turns the parity statement into an actual complementary edge, plus the `{±1}`-integer corollary via the sign-bit encoding.
  - Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Notes
- `meta.json` was already comprehensive (14 KB, well under the 60 KB cap) and accurate — left as-is per the diminishing-returns rule; effort focused on the genuine gaps.
- Axiom integrity verified against the Lean source: `status: verified`, `axiomCount: 0`, `badge: original` are correct (0 sorries, 0 axioms; `decide` not `native_decide`; no structure-encoded assumptions — `signChanges_odd_iff` etc. depend only on propext/Classical.choice/Quot.sound).
- `pnpm build` passes (tsc type-check + data generation).