### PR TITLE
research(property-b-first-moment-oq-03-oq-01): asymmetry cannot beat Erdős — symmetric coloring is the unique first-moment optimum [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PropertyBFirstMomentAsymmetric.lean
+++ b/proofs/Proofs/PropertyBFirstMomentAsymmetric.lean
@@ -1,0 +1,125 @@
+/-
+  Property B — the asymmetric first moment cannot beat Erdős's 2^(k-1).
+
+  Open question (property-b-first-moment-oq-03): sharpen Erdős's 1963 bound
+  m(k) ≥ 2^(k-1) to the Radhakrishnan–Srinivasan m(k) = Ω(2^k·√(k/log k))
+  via the "asymmetric / recoloring" refinement of the first moment argument.
+
+  The OQ names two ingredients — *asymmetry* of the random coloring and a
+  *recoloring* repair step. This file isolates the first and settles it
+  *negatively*: asymmetry alone yields no improvement whatsoever.
+
+  Setup. Color each vertex of a k-uniform hypergraph independently Red with
+  probability `p` and Blue with probability `1 - p`. A fixed edge of size
+  `k` is monochromatic (all-Red or all-Blue) with probability
+      monoProb k p = p^k + (1-p)^k.
+  The first-moment threshold — the largest edge count `m` for which the
+  expected number of monochromatic edges `m · monoProb k p` stays below 1,
+  forcing a proper coloring to exist — is `1 / monoProb k p`.
+
+  Results (all over the finite/real first-moment model, 0 axioms):
+
+    • `monoProb_ge`     : monoProb k p ≥ 2·(1/2)^k = 2^(1-k) for every bias
+                          p ∈ [0,1], k ≥ 1.
+    • `monoProb_half_le`: the symmetric coloring p = 1/2 MINIMIZES the
+                          monochromatic probability.
+    • `monoProb_half_lt`: for k ≥ 2 it is the UNIQUE minimizer — any bias
+                          p ≠ 1/2 strictly increases monoProb, hence strictly
+                          LOWERS the threshold 1 / monoProb k p.
+    • `threshold_half`  : the symmetric threshold is exactly Erdős's 2^(k-1),
+                          so no bias raises the threshold above 2^(k-1).
+    • `expected_mono_half_le` : for an m-edge hypergraph, the expected number
+                          of monochromatic edges is minimized at p = 1/2.
+
+  Conclusion. Biasing the colors never improves Erdős's 2^(k-1); the
+  Radhakrishnan–Srinivasan gain of order √(k/log k) must come entirely from
+  the *recoloring* step, not from asymmetry. This is a structural ORIENT
+  result for oq-03, not the RS bound itself, and it sharply scopes the
+  remaining work (the recoloring analysis) for future sessions.
+
+  Companion to `PropertyBFirstMoment.lean`, which formalizes Erdős's
+  original symmetric bound `m(k) ≥ 2^(k-1)`.
+
+  Status: 0 sorries, 0 axioms. No `native_decide`.
+-/
+import Mathlib
+
+namespace ProbMethod.PropertyB.Asymmetric
+
+open Set
+
+/-- Probability that a fixed edge of size `k` is monochromatic when each
+    vertex is colored Red independently with probability `p` (and Blue with
+    probability `1 - p`): one of the two colors must hit every one of the
+    `k` vertices, giving `p^k + (1-p)^k`. -/
+def monoProb (k : ℕ) (p : ℝ) : ℝ := p ^ k + (1 - p) ^ k
+
+@[simp] lemma monoProb_half (k : ℕ) : monoProb k (1 / 2) = 2 * (1 / 2) ^ k := by
+  unfold monoProb; norm_num; ring
+
+/-- **Asymmetry never helps (first moment).**
+    For `k ≥ 1` and any bias `p ∈ [0,1]`, the monochromatic probability is
+    at least the symmetric value `2·(1/2)^k = 2^(1-k)`. This is convexity of
+    `x ↦ x^k` applied to the midpoint of `p` and `1 - p`. -/
+theorem monoProb_ge (k : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) :
+    2 * (1 / 2) ^ k ≤ monoProb k p := by
+  have hmem_p : p ∈ Ici (0 : ℝ) := hp0
+  have hmem_q : (1 - p) ∈ Ici (0 : ℝ) := by simp only [mem_Ici]; linarith
+  have h := (convexOn_pow (𝕜 := ℝ) k).2 hmem_p hmem_q
+      (by norm_num : (0 : ℝ) ≤ 1 / 2) (by norm_num : (0 : ℝ) ≤ 1 / 2)
+      (by norm_num : (1 / 2 : ℝ) + 1 / 2 = 1)
+  simp only [smul_eq_mul] at h
+  have hmid : (1 / 2) * p + (1 / 2) * (1 - p) = (1 / 2 : ℝ) := by ring
+  rw [hmid] at h
+  unfold monoProb
+  linarith [h]
+
+/-- The symmetric coloring `p = 1/2` minimizes the monochromatic
+    probability over all biases in `[0,1]`. -/
+theorem monoProb_half_le (k : ℕ) {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) :
+    monoProb k (1 / 2) ≤ monoProb k p := by
+  rw [monoProb_half]; exact monoProb_ge k hp0 hp1
+
+/-- **Symmetry is the unique optimum for `k ≥ 2`.**
+    Any bias `p ≠ 1/2` strictly increases the monochromatic probability, by
+    strict convexity of `x ↦ x^k` for `k ≥ 2`. Consequently a biased
+    coloring strictly lowers the first-moment threshold `1 / monoProb k p`. -/
+theorem monoProb_half_lt (k : ℕ) (hk : 2 ≤ k) {p : ℝ}
+    (hp0 : 0 ≤ p) (hp1 : p ≤ 1) (hne : p ≠ 1 / 2) :
+    monoProb k (1 / 2) < monoProb k p := by
+  have hmem_p : p ∈ Ici (0 : ℝ) := hp0
+  have hmem_q : (1 - p) ∈ Ici (0 : ℝ) := by simp only [mem_Ici]; linarith
+  have hxy : p ≠ 1 - p := by intro h; apply hne; linarith
+  have h := (strictConvexOn_pow hk).2 hmem_p hmem_q hxy
+      (by norm_num : (0 : ℝ) < 1 / 2) (by norm_num : (0 : ℝ) < 1 / 2)
+      (by norm_num : (1 / 2 : ℝ) + 1 / 2 = 1)
+  simp only [smul_eq_mul] at h
+  have hmid : (1 / 2) * p + (1 / 2) * (1 - p) = (1 / 2 : ℝ) := by ring
+  rw [hmid] at h
+  rw [monoProb_half, monoProb]
+  linarith [h]
+
+/-- The symmetric first-moment threshold equals Erdős's `2^(k-1)`:
+    `1 / monoProb k (1/2) = 2^(k-1)`. Combined with `monoProb_half_le`, no
+    bias `p` raises the threshold `1 / monoProb k p` above `2^(k-1)` — the
+    asymmetric first moment cannot beat the Erdős bound. -/
+theorem threshold_half (k : ℕ) (hk : 1 ≤ k) :
+    1 / monoProb k (1 / 2) = 2 ^ (k - 1) := by
+  have hk2 : (2 : ℝ) ^ (k - 1) * 2 = 2 ^ k := by
+    rw [← pow_succ]; congr 1; omega
+  rw [monoProb_half]
+  have hpk : (1 / 2 : ℝ) ^ k = 1 / 2 ^ k := by rw [one_div_pow]
+  rw [hpk]
+  have h2k : (2 : ℝ) ^ k ≠ 0 := by positivity
+  field_simp
+  linarith [hk2]
+
+/-- For a `k`-uniform hypergraph with `m` edges, the expected number of
+    monochromatic edges under a `p`-biased random coloring, `m · monoProb k p`,
+    is minimized at the symmetric `p = 1/2`. -/
+theorem expected_mono_half_le (k : ℕ) (m : ℝ) (hm : 0 ≤ m)
+    {p : ℝ} (hp0 : 0 ≤ p) (hp1 : p ≤ 1) :
+    m * monoProb k (1 / 2) ≤ m * monoProb k p :=
+  mul_le_mul_of_nonneg_left (monoProb_half_le k hp0 hp1) hm
+
+end ProbMethod.PropertyB.Asymmetric

--- a/research/problems/property-b-first-moment-oq-03/knowledge.md
+++ b/research/problems/property-b-first-moment-oq-03/knowledge.md
@@ -66,7 +66,38 @@ RS formalization is a **moonshot** in Lean 4.26.0:
   effort. Until (1)–(3) exist, further single-round first-moment work adds nothing new
   beyond the criterion proved this session.
 
+## Session (2026-06-28, researcher-4): asymmetry cannot beat Erdős (RS sub-question, NEGATIVE)
+
+Addressed the **first follow-up open question** of the merged oq-03 (formalize the RS
+recoloring sharpening) by settling its **asymmetry ingredient negatively**. The RS program
+has two parts — (1) biasing/asymmetry of the random coloring, (2) the recoloring repair.
+This session proves part (1) is **worthless on its own**, sharply isolating the recoloring
+step as the sole remaining target. Published as new gallery entry
+`property-b-first-moment-oq-03-oq-01`.
+
+New file `PropertyBFirstMomentAsymmetric.lean` (125 lines, `ProbMethod.PropertyB.Asymmetric`,
+**0 sorries / 0 axioms**, `#print axioms` = propext/Classical.choice/Quot.sound only; no
+`native_decide`, no `Lean.ofReduceBool`):
+
+* `monoProb k p := p^k + (1-p)^k` — the p-biased monochromatic probability of a k-edge.
+* `monoProb_ge` — `2·(1/2)^k ≤ monoProb k p` for all `p ∈ [0,1]`, `k ≥ 1`. One application of
+  Mathlib's `convexOn_pow` (convexity of `x ↦ x^k` on `Ici 0`) to the midpoint of `p`, `1-p`.
+* `monoProb_half_lt` — for `k ≥ 2`, `p ≠ 1/2` ⟹ strict increase, via `strictConvexOn_pow`.
+  So `p = 1/2` is the **unique** first-moment optimum.
+* `threshold_half` — `1/monoProb(k,1/2) = 2^(k-1)`, exactly Erdős' bound. No bias lifts the
+  first-moment threshold above `2^(k-1)`.
+* `expected_mono_half_le` — the expectation form: `m·monoProb(k,p)` minimized at `p = 1/2`.
+
+**Key takeaway**: biasing the random coloring can only *raise* the monochromatic probability
+(convexity, symmetric about 1/2), so the entire RS gain of order `√(k/log k)` is attributable
+to the recoloring step alone — confirming and sharpening the prior session's "recoloring is
+the moonshot" verdict by formally excluding the asymmetry shortcut. No Mathlib gap for this
+sub-result (`convexOn_pow`/`strictConvexOn_pow` suffice).
+
 ## Verification
 `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PropertyBFirstMomentOQ03.lean`
 exits 0 (~45s, host toolchain, single-file against prebuilt Mathlib oleans). `#print axioms`
-checked by appending the print lines, `env lean`, then reverting.
+checked by appending the print lines, `env lean`, then reverting. The researcher-4 asymmetry
+file `PropertyBFirstMomentAsymmetric.lean` was built clean via
+`./proofs/scripts/docker-build.sh Proofs.PropertyBFirstMomentAsymmetric` and axiom-checked
+the same way.

--- a/src/data/proofs/property-b-first-moment-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-01/annotations.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "ann-pbfm-oq03oq01-monoprob",
+    "proofId": "property-b-first-moment-oq-03-oq-01",
+    "range": { "startLine": 55, "endLine": 61 },
+    "type": "definition",
+    "title": "The p-Biased Monochromatic Probability",
+    "content": "`monoProb k p := p^k + (1-p)^k` models the probability that a fixed edge of size `k` is monochromatic when each vertex is colored Red independently with probability `p` (and Blue with probability `1-p`): one of the two colors must hit all `k` vertices, contributing `p^k` (all Red) and `(1-p)^k` (all Blue). This generalizes the parent file's symmetric count, where every edge is monochromatic with probability `2·2^(-k) = 2^(1-k)`. The simp lemma `monoProb_half` evaluates the symmetric case `monoProb k (1/2) = 2·(1/2)^k`."
+  },
+  {
+    "id": "ann-pbfm-oq03oq01-ge",
+    "proofId": "property-b-first-moment-oq-03-oq-01",
+    "range": { "startLine": 63, "endLine": 77 },
+    "type": "theorem",
+    "title": "Asymmetry Never Helps (monoProb_ge)",
+    "content": "`monoProb_ge` is the crux: for `k ≥ 1` and any bias `p ∈ [0,1]`, `2·(1/2)^k ≤ monoProb k p`. The proof is one application of `convexOn_pow` (convexity of `x ↦ x^k` on `[0,∞)`): with `p` and `1-p` both in `Ici 0` and weights `a = b = 1/2`, convexity gives `((1/2)p + (1/2)(1-p))^k ≤ (1/2)p^k + (1/2)(1-p)^k`. The argument collapses to `(1/2)^k` (via `ring`), yielding `(1/2)^k ≤ (1/2)·monoProb k p`, i.e. `2·(1/2)^k ≤ monoProb k p`. Since `2·(1/2)^k = 2^(1-k)`, the symmetric value is a global lower bound — biasing the coloring can only raise the monochromatic probability."
+  },
+  {
+    "id": "ann-pbfm-oq03oq01-lt",
+    "proofId": "property-b-first-moment-oq-03-oq-01",
+    "range": { "startLine": 87, "endLine": 104 },
+    "type": "theorem",
+    "title": "Symmetry is the Unique Optimum for k ≥ 2 (monoProb_half_lt)",
+    "content": "`monoProb_half_lt` upgrades optimality to uniqueness: for `k ≥ 2` and `p ∈ [0,1]` with `p ≠ 1/2`, `monoProb k (1/2) < monoProb k p`. The bias condition `p ≠ 1/2` is exactly `p ≠ 1-p`, the distinctness needed to apply `strictConvexOn_pow` (strict convexity of `x ↦ x^k` for `k ≥ 2`) at the points `p` and `1-p`. The strict midpoint inequality then gives `(1/2)^k < (1/2)·monoProb k p`. So any nonzero bias *strictly* increases the monochromatic probability, hence strictly *lowers* the first-moment threshold `1/monoProb k p`."
+  },
+  {
+    "id": "ann-pbfm-oq03oq01-threshold",
+    "proofId": "property-b-first-moment-oq-03-oq-01",
+    "range": { "startLine": 106, "endLine": 118 },
+    "type": "theorem",
+    "title": "The Symmetric Threshold is Exactly 2^(k-1) (threshold_half)",
+    "content": "`threshold_half` anchors the optimum to Erdős' original bound: `1 / monoProb k (1/2) = 2^(k-1)` for `k ≥ 1`. Rewriting `monoProb k (1/2) = 2·(1/2)^k` and `(1/2)^k = 1/2^k` (`one_div_pow`), then clearing denominators (`field_simp`) reduces the claim to `2·2^(k-1) = 2^k` (`pow_succ`). Combined with `monoProb_half_le`, this shows no bias `p` raises the threshold above `2^(k-1)`: the asymmetric first moment cannot beat Erdős, so the Radhakrishnan–Srinivasan gain of order √(k/log k) must come entirely from the recoloring step. `expected_mono_half_le` records the expectation form: an m-edge hypergraph's expected monochromatic-edge count `m·monoProb k p` is minimized at `p = 1/2`."
+  }
+]

--- a/src/data/proofs/property-b-first-moment-oq-03-oq-01/meta.json
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-01/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "property-b-first-moment-oq-03-oq-01",
+  "title": "Property B: Asymmetry Cannot Beat Erdős — the Symmetric Coloring is the Unique First-Moment Optimum",
+  "slug": "property-b-first-moment-oq-03-oq-01",
+  "description": "Partial, negative-direction answer to the first open question of property-b-first-moment-oq-03, which asks to formalize the Radhakrishnan–Srinivasan random-recoloring argument sharpening Erdős' m(k) ≥ 2^(k-1) to m(k) = Ω(2^k·√(k/log k)). The RS program has two ingredients — biasing (asymmetry of) the random coloring and a recoloring repair step. This entry isolates the asymmetry ingredient and settles it negatively: biasing alone yields no improvement. Color each vertex of a k-uniform hypergraph independently Red with probability p (Blue with probability 1-p); a fixed k-edge is monochromatic with probability monoProb(k,p) = p^k + (1-p)^k, and the first-moment threshold (largest edge count guaranteeing a proper coloring) is 1/monoProb(k,p). By convexity of x ↦ x^k, monoProb(k,p) ≥ 2·(1/2)^k = 2^(1-k) for every bias p ∈ [0,1] (monoProb_ge), so the symmetric p = 1/2 minimizes the monochromatic probability (monoProb_half_le); by strict convexity for k ≥ 2 it is the UNIQUE minimizer (monoProb_half_lt), and the symmetric threshold is exactly Erdős' 2^(k-1) (threshold_half). Conclusion: biasing the colors never raises the first-moment threshold above 2^(k-1) — the Radhakrishnan–Srinivasan gain of order √(k/log k) must come entirely from the recoloring step, not from asymmetry. This sharply scopes the remaining work. Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Lean Genius researcher (structural result for the Radhakrishnan–Srinivasan / Property B program)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Property_B",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PropertyBFirstMomentAsymmetric.lean",
+    "tags": [
+      "probabilistic-method",
+      "first-moment-method",
+      "property-b",
+      "convexity",
+      "combinatorics",
+      "graph-coloring",
+      "erdos",
+      "extremal-bounds"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "convexOn_pow",
+        "description": "x ↦ x^n is convex on [0,∞) for every n. Applied to the midpoint a = b = 1/2 of the points p and 1-p in Ici 0, it gives ((p+(1-p))/2)^k = (1/2)^k ≤ (1/2)p^k + (1/2)(1-p)^k, i.e. 2·(1/2)^k ≤ monoProb(k,p) — the non-strict 'asymmetry never helps' inequality monoProb_ge.",
+        "module": "Mathlib.Analysis.Convex.Mul"
+      },
+      {
+        "theorem": "strictConvexOn_pow",
+        "description": "x ↦ x^n is strictly convex on [0,∞) for n ≥ 2. Applied at the distinct points p ≠ 1-p, it upgrades the midpoint inequality to strict, giving (1/2)^k < (1/2)p^k + (1/2)(1-p)^k whenever p ≠ 1/2 — the uniqueness of the symmetric optimum monoProb_half_lt for k ≥ 2.",
+        "module": "Mathlib.Analysis.Convex.SpecificFunctions.Deriv"
+      },
+      {
+        "theorem": "ConvexOn.2 / StrictConvexOn.2",
+        "description": "The defining inequality field of (strict) convexity: for x,y ∈ s and weights a,b ≥ 0 (resp. > 0) with a+b = 1, f(a•x+b•y) ≤ a•f(x)+b•f(y) (resp. <). Instantiated with x = p, y = 1-p, a = b = 1/2.",
+        "module": "Mathlib.Analysis.Convex.Function"
+      },
+      {
+        "theorem": "pow_succ / one_div_pow",
+        "description": "Elementary power algebra used in threshold_half to evaluate the symmetric threshold 1/(2·(1/2)^k) = 2^(k-1), tying the optimum back to Erdős' integer bound from the parent file.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "monoProb_ge: for k ≥ 1 and any bias p ∈ [0,1], the monochromatic probability p^k + (1-p)^k is at least the symmetric value 2·(1/2)^k = 2^(1-k). A one-line consequence of the convexity of x ↦ x^k applied to the midpoint of p and 1-p — the precise statement that the asymmetric first moment cannot beat Erdős.",
+      "monoProb_half_lt: for k ≥ 2 the symmetric coloring p = 1/2 is the UNIQUE minimizer — any bias p ≠ 1/2 strictly increases the monochromatic probability, hence strictly lowers the first-moment threshold. Proved via strict convexity of x ↦ x^k at the distinct points p and 1-p.",
+      "threshold_half: the symmetric first-moment threshold 1/monoProb(k,1/2) equals Erdős' 2^(k-1) exactly, anchoring the optimality result to the parent entry's integer bound and confirming no bias raises the threshold above 2^(k-1).",
+      "monoProb (k,p) := p^k + (1-p)^k: the clean real-valued model of the p-biased monochromatic-edge probability, generalizing the parent file's symmetric count 2·2^(-k); the modeling step that makes 'asymmetry' a precise optimization over p ∈ [0,1].",
+      "expected_mono_half_le: for an m-edge hypergraph the expected number of monochromatic edges m·monoProb(k,p) is minimized at p = 1/2 — the first-moment expectation form of the optimality result.",
+      "A scoping conclusion: because asymmetry is provably exhausted by p = 1/2, the entire Radhakrishnan–Srinivasan improvement of order √(k/log k) must originate in the recoloring step, isolating the remaining formalization target of the parent oq-03's first open question."
+    ],
+    "dateAdded": "2026-06-28",
+    "relatedProblems": [
+      {
+        "id": "property-b-first-moment-oq-03",
+        "relationship": "Partially answers the first open question of oq-03 (formalize the Radhakrishnan–Srinivasan random-recoloring argument). This entry proves the asymmetry ingredient of that program gives no improvement: under a p-biased coloring the symmetric p = 1/2 is the unique first-moment optimum, with threshold exactly the parent's 2^(k-1), so the RS gain must come solely from the recoloring step."
+      },
+      {
+        "id": "property-b-first-moment",
+        "relationship": "Grandparent entry: formalizes Erdős' symmetric Property B bound m(k) ≥ 2^(k-1). This entry shows that biasing the random coloring cannot improve that bound, recovering its threshold exactly at p = 1/2."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 125,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The hypotheses (k ≥ 1 or k ≥ 2, p ∈ [0,1], m ≥ 0) are inputs to the statements, not standing assumptions. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for monoProb_ge, monoProb_half_lt, threshold_half, and expected_mono_half_le — no sorryAx, no Lean.ofReduceBool. This entry proves the negative/structural sub-result (asymmetry is exhausted by p=1/2); it does NOT prove the full Radhakrishnan–Srinivasan bound m(k) = Ω(2^k·√(k/log k)), which requires the recoloring analysis and remains open.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Erdős (1963) introduced m(k), the minimum number of edges in a non-2-colorable k-uniform hypergraph, and proved m(k) ≥ 2^(k-1) by the prototypical first-moment argument: a uniformly random 2-coloring makes a fixed k-edge monochromatic with probability 2^(1-k), so fewer than 2^(k-1) edges leave the expected number of monochromatic edges below 1. The lower bound was improved by Beck (1978) and then by Radhakrishnan and Srinivasan (2000) to m(k) = Ω(2^k·√(k/log k)) via a random coloring followed by a careful recoloring of monochromatic edges (a proof later streamlined by Cherkashin–Kozik using a random permutation). The Erdős–Lovász upper bound m(k) = O(k²·2^k) shows the truth lies in a narrow window. A natural first question when seeking to beat Erdős' bound is whether merely biasing the random coloring — coloring Red with some probability p ≠ 1/2 — already helps. This entry answers that sub-question in the negative.",
+    "problemStatement": "Model a p-biased random 2-coloring of a k-uniform hypergraph: each vertex is colored Red independently with probability p ∈ [0,1] (Blue with probability 1-p). A fixed edge of size k is monochromatic with probability monoProb(k,p) = p^k + (1-p)^k, and the first-moment threshold below which a proper coloring is guaranteed is 1/monoProb(k,p). Question: does any bias p ≠ 1/2 raise this threshold above Erdős' symmetric value 2^(k-1)? Answer: no. For all p ∈ [0,1] and k ≥ 1, monoProb(k,p) ≥ 2^(1-k) with equality iff p = 1/2 (strictly, for k ≥ 2), so the symmetric coloring is the unique first-moment optimum and its threshold is exactly 2^(k-1).",
+    "text": "The monochromatic probability of a k-edge under a p-biased coloring is p^k + (1-p)^k. Because x ↦ x^k is convex, this quantity is at least its value at the symmetric point p = 1/2, namely 2·(1/2)^k = 2^(1-k); for k ≥ 2 strict convexity makes p = 1/2 the unique minimizer. Equivalently, the first-moment threshold 1/(p^k+(1-p)^k) is maximized at p = 1/2, where it equals 2^(k-1) — exactly Erdős' bound. Hence asymmetry, by itself, cannot improve the Property B lower bound; the Radhakrishnan–Srinivasan gain must come from the recoloring step.",
+    "proofStrategy": "Define monoProb(k,p) = p^k + (1-p)^k.\n\n1. **monoProb_ge (asymmetry never helps).** For p ∈ [0,1], both p and 1-p lie in Ici 0. Apply the convexity field of convexOn_pow (over ℝ) at x = p, y = 1-p with weights a = b = 1/2: f((1/2)p + (1/2)(1-p)) ≤ (1/2)f(p) + (1/2)f(1-p). The argument simplifies to 1/2, giving (1/2)^k ≤ (1/2)(p^k + (1-p)^k), i.e. 2·(1/2)^k ≤ monoProb(k,p).\n\n2. **monoProb_half_le (symmetric is optimal).** Immediate from monoProb_ge and the evaluation monoProb(k,1/2) = 2·(1/2)^k.\n\n3. **monoProb_half_lt (uniqueness, k ≥ 2).** Note p ≠ 1/2 ⟹ p ≠ 1-p. Apply strictConvexOn_pow (k ≥ 2) at the distinct points p, 1-p with weights 1/2,1/2 to get the strict midpoint inequality, hence monoProb(k,1/2) < monoProb(k,p).\n\n4. **threshold_half.** Evaluate 1/(2·(1/2)^k) = 2^(k-1) by elementary power algebra (one_div_pow, pow_succ), tying the optimum to the parent file's integer bound.\n\n5. **expected_mono_half_le.** Multiply monoProb_half_le by the nonnegative edge count m to get the first-moment expectation form.",
+    "keyInsights": [
+      "**Asymmetry is convexity-exhausted.** p^k + (1-p)^k is a convex function of p symmetric about 1/2, so its minimum over [0,1] is at p = 1/2; no bias can lower the monochromatic probability, hence none can raise the first-moment threshold above 2^(k-1).",
+      "**Uniqueness needs strict convexity (k ≥ 2).** For k ≥ 2 the strict convexity of x ↦ x^k makes p = 1/2 the unique optimum — any nonzero bias strictly hurts. For k = 1 the probability is identically 1 (every single-vertex edge is trivially monochromatic) and the bound degenerates.",
+      "**The optimum matches Erdős exactly.** The symmetric threshold 1/monoProb(k,1/2) = 2^(k-1) recovers the grandparent entry's integer bound, so this optimality result is anchored to the known theorem rather than a separate model.",
+      "**This isolates where the real gain lives.** Since asymmetry is provably worthless on its own, the Radhakrishnan–Srinivasan improvement of order √(k/log k) is attributable entirely to the recoloring repair step — a precise scoping of the remaining formalization work for oq-03's first open question.",
+      "**A clean reuse of Mathlib convexity.** The whole argument is two applications of (strict) convexity of x ↦ x^k to the midpoint of p and 1-p — no probability measure machinery is needed for the first-moment-threshold optimization."
+    ],
+    "prerequisites": [
+      "Erdős' Property B first-moment bound m(k) ≥ 2^(k-1) (grandparent entry property-b-first-moment)",
+      "Convexity and strict convexity of x ↦ x^n on [0,∞)",
+      "The first moment method and the notion of a probability threshold for a random structure",
+      "Background on the Radhakrishnan–Srinivasan improvement and the recoloring technique"
+    ]
+  },
+  "sections": [
+    {
+      "id": "model",
+      "title": "The p-Biased Monochromatic Probability",
+      "startLine": 1,
+      "endLine": 62,
+      "mathContext": "$\\mathrm{monoProb}(k,p) := p^k + (1-p)^k, \\qquad \\mathrm{monoProb}(k,\\tfrac12) = 2\\cdot(\\tfrac12)^k = 2^{1-k}$",
+      "summary": "Module docstring framing the result as the negative resolution of the 'asymmetry' half of the Radhakrishnan–Srinivasan program. monoProb(k,p) = p^k + (1-p)^k models the probability a k-edge is monochromatic under a p-biased independent coloring; monoProb_half evaluates it at the symmetric point to 2·(1/2)^k."
+    },
+    {
+      "id": "optimality",
+      "title": "Asymmetry Never Helps; Symmetry is the Unique Optimum",
+      "startLine": 63,
+      "endLine": 104,
+      "mathContext": "$2^{1-k} \\le \\mathrm{monoProb}(k,p)\\ \\ (p\\in[0,1]); \\quad \\mathrm{monoProb}(k,\\tfrac12) < \\mathrm{monoProb}(k,p)\\ \\ (k\\ge2,\\ p\\ne\\tfrac12)$",
+      "summary": "monoProb_ge: convexity of x ↦ x^k at the midpoint of p and 1-p gives monoProb(k,p) ≥ 2·(1/2)^k. monoProb_half_le restates this as optimality of p = 1/2. monoProb_half_lt uses strict convexity (k ≥ 2) at the distinct points p ≠ 1-p to make p = 1/2 the unique minimizer."
+    },
+    {
+      "id": "threshold",
+      "title": "The Symmetric Threshold is Exactly Erdős' 2^(k-1)",
+      "startLine": 105,
+      "endLine": 125,
+      "mathContext": "$\\dfrac{1}{\\mathrm{monoProb}(k,\\tfrac12)} = 2^{k-1}, \\qquad m\\cdot\\mathrm{monoProb}(k,\\tfrac12) \\le m\\cdot\\mathrm{monoProb}(k,p)$",
+      "summary": "threshold_half evaluates the symmetric first-moment threshold 1/(2·(1/2)^k) = 2^(k-1), tying the optimum to the grandparent entry's integer bound. expected_mono_half_le gives the first-moment expectation form: an m-edge hypergraph's expected monochromatic-edge count is minimized at p = 1/2."
+    }
+  ],
+  "conclusion": {
+    "summary": "A verified, 0-axiom resolution of the 'asymmetry' half of the Radhakrishnan–Srinivasan program (oq-03's first open question): under a p-biased random 2-coloring, the probability that a k-edge is monochromatic, p^k + (1-p)^k, is minimized over p ∈ [0,1] at the symmetric p = 1/2 (uniquely so for k ≥ 2), where it equals 2^(1-k). Equivalently the first-moment threshold 1/(p^k+(1-p)^k) is maximized at p = 1/2 with value exactly Erdős' 2^(k-1). Biasing the colors therefore cannot improve the Property B lower bound.",
+    "implications": "This entry rules out the asymmetry ingredient of the Radhakrishnan–Srinivasan improvement m(k) = Ω(2^k·√(k/log k)): the gain must come entirely from the recoloring repair step, not from biasing the random coloring. It thereby isolates the recoloring analysis as the sole remaining target for a full formalization, and supplies the clean convexity-based optimization (monoProb_ge, monoProb_half_lt) and the threshold identity (threshold_half = 2^(k-1)) anchoring the result to the grandparent entry.",
+    "openQuestions": [
+      "Formalize the recoloring step of Radhakrishnan–Srinivasan (or the Cherkashin–Kozik random-permutation version) to obtain the full lower bound m(k) = Ω(2^k·√(k/log k)) — the genuine remaining content, now isolated from the (settled) asymmetry question.",
+      "Quantify the loss from a fixed bias: derive an explicit lower bound on monoProb(k,p) - 2^(1-k) in terms of |p - 1/2| and k, making precise how much a biased coloring degrades the first-moment threshold."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "property-b-first-moment-oq-03",
+      "relationship": "extends",
+      "description": "Partially answers oq-03's first open question (formalize the Radhakrishnan–Srinivasan random recoloring) by proving the asymmetry ingredient gives no improvement: the symmetric p = 1/2 is the unique first-moment optimum, with threshold exactly Erdős' 2^(k-1)."
+    },
+    {
+      "targetId": "property-b-first-moment",
+      "relationship": "extends",
+      "description": "Shows that biasing the random coloring cannot improve Erdős' symmetric Property B bound m(k) ≥ 2^(k-1), recovering its threshold exactly at p = 1/2."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/PropertyBFirstMomentAsymmetric.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set"
+    ],
+    "namespace": "ProbMethod.PropertyB.Asymmetric",
+    "lineCount": 125,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 6
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "On a combinatorial problem",
+      "year": "1963",
+      "venue": "Nordisk Matematisk Tidskrift 11, 5–10",
+      "note": "Introduces m(k) and the first-moment lower bound m(k) ≥ 2^(k-1) sharpened (in the asymmetry direction, negatively) here."
+    },
+    {
+      "authors": "Radhakrishnan, Jaikumar; Srinivasan, Aravind",
+      "title": "Improved bounds and algorithms for hypergraph 2-coloring",
+      "year": "2000",
+      "venue": "Random Structures & Algorithms 16(1), 4–32",
+      "note": "Proves m(k) = Ω(2^k·√(k/log k)) via random coloring plus recoloring — the recoloring step is the remaining content after this entry rules out asymmetry."
+    },
+    {
+      "authors": "Cherkashin, Danila; Kozik, Jakub",
+      "title": "A note on random greedy coloring of uniform hypergraphs",
+      "year": "2015",
+      "venue": "Random Structures & Algorithms 47(3), 407–413",
+      "note": "A streamlined random-permutation proof of the Radhakrishnan–Srinivasan bound."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "monoProb_ge",
+      "type": "core",
+      "description": "For k ≥ 1 and any bias p ∈ [0,1], the monochromatic probability p^k + (1-p)^k is at least the symmetric value 2·(1/2)^k = 2^(1-k). Asymmetry never beats Erdős.",
+      "leanType": "(k : ℕ) → 0 ≤ p → p ≤ 1 → 2 * (1/2)^k ≤ monoProb k p"
+    },
+    {
+      "name": "monoProb_half_lt",
+      "type": "core",
+      "description": "For k ≥ 2, the symmetric coloring p = 1/2 is the unique minimizer: any bias p ≠ 1/2 strictly increases the monochromatic probability.",
+      "leanType": "(k : ℕ) → 2 ≤ k → 0 ≤ p → p ≤ 1 → p ≠ 1/2 → monoProb k (1/2) < monoProb k p"
+    },
+    {
+      "name": "threshold_half",
+      "type": "supporting",
+      "description": "The symmetric first-moment threshold equals Erdős' 2^(k-1): 1/monoProb(k,1/2) = 2^(k-1).",
+      "leanType": "(k : ℕ) → 1 ≤ k → 1 / monoProb k (1/2) = 2^(k-1)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Partial, **negative-direction** answer to the first follow-up open question of the merged
`property-b-first-moment-oq-03` (#31375), which asks to formalize the **Radhakrishnan–Srinivasan**
random-recoloring sharpening of Erdős' Property B bound `m(k) ≥ 2^(k-1)` to
`m(k) = Ω(2^k·√(k/log k))`.

The RS program has two ingredients: (1) **biasing/asymmetry** of the random coloring, and
(2) a **recoloring** repair step. This PR isolates ingredient (1) and **settles it negatively**:
asymmetry alone yields no improvement, sharply isolating the recoloring step as the sole
remaining target.

New gallery entry: `property-b-first-moment-oq-03-oq-01`.

## The result

Color each vertex independently Red with probability `p` (Blue with `1-p`). A fixed `k`-edge is
monochromatic with probability `monoProb(k,p) = p^k + (1-p)^k`; the first-moment threshold is
`1/monoProb(k,p)`. By convexity of `x ↦ x^k`:

- **`monoProb_ge`** — `monoProb(k,p) ≥ 2·(1/2)^k = 2^(1-k)` for every bias `p ∈ [0,1]`, `k ≥ 1`.
- **`monoProb_half_lt`** — for `k ≥ 2`, `p = 1/2` is the **unique** minimizer (strict convexity);
  any bias `p ≠ 1/2` strictly increases the monochromatic probability.
- **`threshold_half`** — the symmetric threshold `1/monoProb(k,1/2) = 2^(k-1)`, exactly Erdős' bound.
- **`expected_mono_half_le`** — expectation form: `m·monoProb(k,p)` is minimized at `p = 1/2`.

**Conclusion:** biasing the colors never raises the first-moment threshold above `2^(k-1)`.
The RS gain of order `√(k/log k)` must therefore come **entirely from the recoloring step**,
not from asymmetry — a precise scoping of the remaining formalization work.

## Verification

- `proofs/Proofs/PropertyBFirstMomentAsymmetric.lean` (125 lines, namespace
  `ProbMethod.PropertyB.Asymmetric`).
- Built clean via `./proofs/scripts/docker-build.sh Proofs.PropertyBFirstMomentAsymmetric`.
- **0 sorries, 0 axioms.** `#print axioms` reports only `propext / Classical.choice / Quot.sound`
  for all theorems — no `sorryAx`, no `Lean.ofReduceBool`. No `native_decide`.

## Honesty note

This is the **negative/structural sub-result** of the RS sharpening (asymmetry is exhausted by
`p = 1/2`). It does **not** prove the full `m(k) = Ω(2^k·√(k/log k))` bound, which requires the
two-round recoloring (alteration) analysis and remains open — now isolated from the settled
asymmetry question. Status `verified` reflects the proven sub-result only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)