### PR TITLE
research(erdos-1003-oq-03): density layer of consecutive equal totients [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1003OQ03.lean
+++ b/proofs/Proofs/Erdos1003OQ03.lean
@@ -1,0 +1,177 @@
+/-
+  Erdős Problem #1003 — Open Question OQ-03:
+  "What is the true asymptotic density of the solution set
+   `{ n | φ n = φ (n+1) }`?"
+
+This file does NOT resolve the open question.  The conjectured answer is that
+the natural density is `0` (solutions are extremely sparse — Erdős–Pomerance–Sárközy
+give the sparsity bound `#{n ≤ x : φ n = φ(n+1)} ≤ x / exp((log x)^{1/3})`
+eventually), while the set is *conjectured to be infinite* (this is #1003 itself,
+still open even in the base case).  Neither the infinitude nor the exact density
+is known.
+
+Instead we formalize the *honest structural layer* of the density question: we
+introduce the counting function and the natural-density predicate, and prove the
+exact logical relationships that pin down what an eventual answer must supply.
+
+  1. The counting function `countConsecutiveEqual N = #{n ≤ N : φ n = φ(n+1)}`
+     is monotone and bounded by `N + 1`.
+
+  2. **The density object is the right one**: the solution set is infinite *iff*
+     the counting function is unbounded (`infinite_iff_count_unbounded`).  This is
+     the bridge between the density/counting view of OQ-03 and the infinitude view
+     of the main #1003 conjecture (and of OQ-02).
+
+  3. **A positive density would settle #1003**: if the natural density exists and
+     is positive, the set is infinite (`infinite_of_pos_density`).  Hence one
+     cannot exhibit a positive density without first resolving the open infinitude
+     conjecture.
+
+  4. **Density 0 is strictly weaker information**: whenever the set is *finite* its
+     natural density is `0` (`hasNaturalDensity_zero_of_finite`).  So the conjectured
+     answer (density 0) is exactly the value forced by finiteness — it does not by
+     itself decide infinitude.  Together with (3) this isolates the genuine content
+     of OQ-03: the density is `0` in both the finite and the (conjectured) sparse-but-
+     infinite worlds, and any *positive* density is equivalent to a strong form of
+     the open #1003 conjecture.
+
+These are fully machine-checked (0 sorry, 0 axiom) consequences of the
+definitions.  The definitions agree verbatim with the parent #1003 entry
+(`Proofs.Erdos1003Problem`) and the sibling OQ-02 file.
+
+Reference: https://erdosproblems.com/1003
+-/
+
+import Mathlib.Data.Nat.Totient
+import Mathlib.Data.Set.Finite.Basic
+import Mathlib.Analysis.SpecificLimits.Basic
+
+open Nat Set Filter Topology
+
+namespace Erdos1003.OQ03
+
+/-! ## Definitions (mirroring `Proofs.Erdos1003Problem`) -/
+
+/-- The set of `n` with `φ n = φ (n+1)` — the main Erdős #1003 set. -/
+def ConsecutiveEqualTotients : Set ℕ :=
+  { n : ℕ | φ n = φ (n + 1) }
+
+/-- Count of `n ≤ N` with `φ n = φ (n+1)` (i.e. over `Finset.range (N+1)`).
+Agrees verbatim with `Proofs.Erdos1003Problem.countConsecutiveEqual`. -/
+def countConsecutiveEqual (N : ℕ) : ℕ :=
+  (Finset.filter (fun n => φ n = φ (n + 1)) (Finset.range (N + 1))).card
+
+/-- Membership in the counted finset is exactly "is a solution and is `≤ N`". -/
+theorem mem_filter_iff {N n : ℕ} :
+    n ∈ Finset.filter (fun n => φ n = φ (n + 1)) (Finset.range (N + 1)) ↔
+      n ∈ ConsecutiveEqualTotients ∧ n ≤ N := by
+  rw [Finset.mem_filter, Finset.mem_range, Nat.lt_succ_iff]
+  exact ⟨fun h => ⟨h.2, h.1⟩, fun h => ⟨h.2, h.1⟩⟩
+
+/-! ## Elementary properties of the counting function -/
+
+/-- The counting function is monotone: a wider window contains at least as many
+solutions. -/
+theorem countConsecutiveEqual_monotone : Monotone countConsecutiveEqual := by
+  intro a b hab
+  apply Finset.card_le_card
+  intro x hx
+  rw [mem_filter_iff] at hx ⊢
+  exact ⟨hx.1, hx.2.trans hab⟩
+
+/-- At most `N + 1` integers lie in the window `0, …, N`, so the count is bounded
+by `N + 1`. -/
+theorem countConsecutiveEqual_le (N : ℕ) : countConsecutiveEqual N ≤ N + 1 := by
+  refine le_trans (Finset.card_filter_le _ _) ?_
+  rw [Finset.card_range]
+
+/-! ## The bridge: density-counting view ⇔ infinitude view
+
+This connects OQ-03 (asymptotic density) to the main #1003 conjecture / OQ-02
+(infinitude): the solution set is infinite exactly when the counting function is
+unbounded. -/
+
+theorem infinite_iff_count_unbounded :
+    ConsecutiveEqualTotients.Infinite ↔
+      ∀ M, ∃ N, M ≤ countConsecutiveEqual N := by
+  constructor
+  · -- infinite ⇒ unbounded count: take a finite subset of size `M` and bound the
+    -- window by its largest element.
+    intro hinf M
+    obtain ⟨t, hts, htc⟩ := hinf.exists_subset_card_eq M
+    refine ⟨t.sup id, ?_⟩
+    have hsub : t ⊆ Finset.filter (fun n => φ n = φ (n + 1))
+        (Finset.range (t.sup id + 1)) := by
+      intro x hx
+      rw [mem_filter_iff]
+      refine ⟨hts (Finset.mem_coe.mpr hx), ?_⟩
+      exact Finset.le_sup (f := id) hx
+    calc M = t.card := htc.symm
+      _ ≤ _ := Finset.card_le_card hsub
+  · -- unbounded count ⇒ infinite: otherwise the count is bounded by the (finite)
+    -- total number of solutions.
+    intro h
+    by_contra hfin
+    rw [Set.not_infinite] at hfin
+    obtain ⟨N, hN⟩ := h (hfin.toFinset.card + 1)
+    have hle : countConsecutiveEqual N ≤ hfin.toFinset.card := by
+      apply Finset.card_le_card
+      intro x hx
+      rw [mem_filter_iff] at hx
+      rw [Set.Finite.mem_toFinset]
+      exact hx.1
+    omega
+
+/-! ## Natural density -/
+
+/-- The solution set "has natural density `d`" if the proportion of solutions in
+`{0, …, N}` converges to `d` as `N → ∞`. -/
+def HasNaturalDensity (d : ℝ) : Prop :=
+  Tendsto (fun N : ℕ => (countConsecutiveEqual N : ℝ) / (N + 1)) atTop (𝓝 d)
+
+/-- The density ratio is always nonnegative. -/
+theorem density_ratio_nonneg (N : ℕ) :
+    0 ≤ (countConsecutiveEqual N : ℝ) / (N + 1) := by
+  positivity
+
+/-- The density ratio never exceeds `1`. -/
+theorem density_ratio_le_one (N : ℕ) :
+    (countConsecutiveEqual N : ℝ) / (N + 1) ≤ 1 := by
+  rw [div_le_one (by positivity)]
+  exact_mod_cast countConsecutiveEqual_le N
+
+/-- If the solution set is finite, its natural density is `0`: the count is
+bounded by a constant while the window grows. -/
+theorem hasNaturalDensity_zero_of_finite
+    (hfin : ConsecutiveEqualTotients.Finite) : HasNaturalDensity 0 := by
+  unfold HasNaturalDensity
+  set C : ℕ := hfin.toFinset.card with hC
+  -- count is uniformly bounded by `C`
+  have hbound : ∀ N, countConsecutiveEqual N ≤ C := by
+    intro N
+    apply Finset.card_le_card
+    intro x hx
+    rw [mem_filter_iff] at hx
+    rw [Set.Finite.mem_toFinset]
+    exact hx.1
+  -- squeeze `0 ≤ count/(N+1) ≤ C/(N+1) → 0`
+  have hupper : Tendsto (fun N : ℕ => (C : ℝ) / ((N : ℝ) + 1)) atTop (𝓝 0) := by
+    have h := (tendsto_const_div_atTop_nhds_zero_nat (C : ℝ)).comp
+      (tendsto_add_atTop_nat 1)
+    simpa [Function.comp_def, Nat.cast_add, Nat.cast_one] using h
+  refine squeeze_zero density_ratio_nonneg (fun N => ?_) hupper
+  gcongr
+  exact_mod_cast hbound N
+
+/-- A positive natural density would resolve Erdős #1003 affirmatively: the
+solution set would be infinite.  (Proof: a finite set has density `0`, so by
+uniqueness of limits a positive density forces the set to be infinite.) -/
+theorem infinite_of_pos_density {d : ℝ} (hd : 0 < d)
+    (h : HasNaturalDensity d) : ConsecutiveEqualTotients.Infinite := by
+  by_contra hfin
+  rw [Set.not_infinite] at hfin
+  have h0 : HasNaturalDensity 0 := hasNaturalDensity_zero_of_finite hfin
+  have : d = 0 := tendsto_nhds_unique h h0
+  exact absurd this (ne_of_gt hd)
+
+end Erdos1003.OQ03

--- a/src/data/proofs/erdos-1003-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1003-oq-03/annotations.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "ann-e1003-oq03-defs",
+    "proofId": "erdos-1003-oq-03",
+    "range": { "startLine": 53, "endLine": 69 },
+    "type": "context",
+    "title": "The counting function and its bookkeeping lemma",
+    "content": "ConsecutiveEqualTotients = {n | φ(n) = φ(n+1)} and countConsecutiveEqual N = #{n ≤ N : φ(n)=φ(n+1)} mirror the parent #1003 entry verbatim, keeping the density layer compatible with the existing definitions. mem_filter_iff is the workhorse identity: an element of the counted finset over Finset.range (N+1) is exactly a solution that is ≤ N. Every later proof routes membership through this equivalence, so the counting function and the set-theoretic solution set are kept in lockstep.",
+    "mathContext": "$\\text{count}(N) = \\#\\{n \\le N : \\varphi(n)=\\varphi(n+1)\\}$, and $n$ counted $\\iff \\varphi(n)=\\varphi(n+1) \\wedge n \\le N$.",
+    "significance": "context"
+  },
+  {
+    "id": "ann-e1003-oq03-elementary",
+    "proofId": "erdos-1003-oq-03",
+    "range": { "startLine": 71, "endLine": 86 },
+    "type": "context",
+    "title": "Monotone and bounded: the density ratio is well-behaved",
+    "content": "countConsecutiveEqual_monotone shows a wider window never loses solutions (proved directly from mem_filter_iff: a solution ≤ a is a solution ≤ b when a ≤ b), and countConsecutiveEqual_le bounds the count by N+1 (the size of {0,…,N}). With density_ratio_nonneg / density_ratio_le_one these confine count/(N+1) to [0,1], so any limit value (the natural density) necessarily lies in [0,1].",
+    "mathContext": "$\\text{count}$ monotone, $\\text{count}(N) \\le N+1$, hence $\\text{count}(N)/(N+1) \\in [0,1]$.",
+    "significance": "context"
+  },
+  {
+    "id": "ann-e1003-oq03-bridge",
+    "proofId": "erdos-1003-oq-03",
+    "range": { "startLine": 88, "endLine": 123 },
+    "type": "key-step",
+    "title": "The bridge: infinitude ⇔ unbounded count",
+    "content": "infinite_iff_count_unbounded is the structural heart, tying OQ-03's density/counting view to the infinitude view of the main #1003 conjecture and sibling OQ-02. Forward: from an infinite set, Set.Infinite.exists_subset_card_eq supplies a size-M subset; its supremum bounds a single window containing all M elements, so count there is ≥ M. Reverse (contrapositive): if the solution set is finite, every window injects into the finite set of all solutions, capping count by its cardinality — so unbounded count forces infinitude.",
+    "mathContext": "$\\{n : \\varphi(n)=\\varphi(n+1)\\}$ infinite $\\iff \\forall M,\\ \\exists N,\\ M \\le \\text{count}(N)$.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-e1003-oq03-finite-zero",
+    "proofId": "erdos-1003-oq-03",
+    "range": { "startLine": 143, "endLine": 164 },
+    "type": "key-step",
+    "title": "Finiteness forces density 0 — the conjectured value is the baseline",
+    "content": "hasNaturalDensity_zero_of_finite shows that if the solution set is finite then count is uniformly bounded by its total cardinality C, so 0 ≤ count/(N+1) ≤ C/(N+1) and squeeze_zero (with C/(N+1) → 0 from tendsto_const_div_atTop_nhds_zero_nat) gives density 0. The point: density 0 is exactly the value any finite solution set exhibits, so the conjectured answer 'density 0' is the finiteness baseline and carries strictly less information than the open infinitude conjecture.",
+    "mathContext": "Finite $\\Rightarrow 0 \\le \\text{count}(N)/(N+1) \\le C/(N+1) \\to 0 \\Rightarrow$ density $0$.",
+    "significance": "high"
+  },
+  {
+    "id": "ann-e1003-oq03-pos-density",
+    "proofId": "erdos-1003-oq-03",
+    "range": { "startLine": 166, "endLine": 175 },
+    "type": "insight",
+    "title": "Positive density would resolve #1003 — locating the difficulty",
+    "content": "infinite_of_pos_density: a positive natural density forces the solution set to be infinite. The proof is a one-line contradiction — were the set finite it would have density 0, and uniqueness of limits (tendsto_nhds_unique) would force d = 0, contradicting d > 0. The consequence sharpens OQ-03: any positive density is equivalent to a strong form of the open #1003 conjecture, so the genuine content lies entirely in the lower bound — the density is 0 in both the finite world and the conjectured sparse-but-infinite world.",
+    "mathContext": "$\\text{density} = d > 0 \\Rightarrow$ infinite (else density $0$ and $d = 0$ by uniqueness of limits).",
+    "significance": "high"
+  }
+]

--- a/src/data/proofs/erdos-1003-oq-03/meta.json
+++ b/src/data/proofs/erdos-1003-oq-03/meta.json
@@ -1,0 +1,182 @@
+{
+  "id": "erdos-1003-oq-03",
+  "title": "The Density Layer of Erdős #1003: What an Answer to \"True Asymptotic Density\" Must Supply",
+  "slug": "erdos-1003-oq-03",
+  "description": "Open question OQ-03 of Erdős #1003 asks for the true asymptotic density of the solution set {n | φ(n) = φ(n+1)}. The question is open: the set is conjectured infinite (#1003 itself, unproven even in the base case) and its density is conjectured to be 0 (the Erdős–Pomerance–Sárközy sparsity bound gives #{n ≤ x : φ(n)=φ(n+1)} ≤ x/exp((log x)^{1/3}) eventually). This entry formalizes the honest structural layer of the density question: it introduces the counting function and the natural-density predicate and proves the exact logical relationships that pin down what an eventual answer must supply. Three results carry the content: (1) the solution set is infinite iff the counting function is unbounded — the bridge between OQ-03's density view and the main conjecture's infinitude view; (2) any positive natural density would resolve #1003 affirmatively, so positivity cannot be exhibited without first settling the open infinitude conjecture; (3) finiteness forces density 0, so the conjectured answer (density 0) is exactly the value forced by finiteness and therefore carries strictly less information than infinitude. Verified, zero axioms, no native_decide.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1003OQ03.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "asymptotic-density",
+      "counting-function",
+      "erdos",
+      "open-question",
+      "extension"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 177,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "dateAdded": "2026-06-28",
+    "assumptions": "0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound, the foundational Lean axioms). Fully machine-verified; no native_decide. Does NOT resolve the open question — it formalizes the logical scaffolding of the density question and its exact relationship to the (open) infinitude conjecture.",
+    "originalContributions": [
+      "infinite_iff_count_unbounded: the central bridge. The solution set {n | φ(n)=φ(n+1)} is infinite iff its counting function countConsecutiveEqual N = #{n ≤ N : φ(n)=φ(n+1)} is unbounded. This connects OQ-03's density/counting view to the infinitude view of the main #1003 conjecture (and of sibling OQ-02). Proved both directions elementarily: infinitude yields, for each M, a size-M subset whose maximum bounds a window with ≥ M solutions; conversely a finite solution set caps every window by its total cardinality.",
+      "infinite_of_pos_density: a positive natural density resolves #1003. If HasNaturalDensity d with d > 0, then the set is infinite. Proof: a finite set has density 0 (next item), so uniqueness of limits would force d = 0, a contradiction. Hence one cannot demonstrate any positive density without first proving the open infinitude conjecture — locating the difficulty of OQ-03 precisely.",
+      "hasNaturalDensity_zero_of_finite: finiteness forces density 0. If the solution set is finite, countConsecutiveEqual N is uniformly bounded by its total cardinality C, so the ratio count/(N+1) is squeezed between 0 and C/(N+1) → 0. Consequence: the conjectured answer (density 0) is exactly the value any finite solution set would have, so 'density 0' alone is strictly weaker information than the infinitude conjecture.",
+      "countConsecutiveEqual_monotone and countConsecutiveEqual_le: the counting function is monotone and bounded by N+1, and density_ratio_nonneg / density_ratio_le_one confine the density ratio to [0,1] — the elementary well-definedness facts underpinning the density predicate.",
+      "mem_filter_iff: the counted finset over Finset.range (N+1) is exactly the set of solutions ≤ N, the bookkeeping lemma threading the membership ↔ (is-a-solution ∧ ≤ N) correspondence through every proof."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.Infinite.exists_subset_card_eq",
+        "description": "An infinite set contains a finite subset of any prescribed cardinality. Supplies the size-M witness whose maximum bounds a counting window in the forward direction of the bridge.",
+        "module": "Mathlib.Data.Set.Finite.Basic"
+      },
+      {
+        "theorem": "tendsto_const_div_atTop_nhds_zero_nat",
+        "description": "C / n → 0 as the natural n → ∞. Composed with tendsto_add_atTop_nat gives C/(N+1) → 0, the upper envelope in the squeeze for the finite-set density-zero result.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "squeeze_zero",
+        "description": "If 0 ≤ f ≤ g pointwise and g → 0 then f → 0. Drives hasNaturalDensity_zero_of_finite via 0 ≤ count/(N+1) ≤ C/(N+1).",
+        "module": "Mathlib.Topology.MetricSpace.Pseudo.Lemmas"
+      },
+      {
+        "theorem": "tendsto_nhds_unique",
+        "description": "Limits in a Hausdorff space are unique. Turns 'finite ⇒ density 0' into 'positive density ⇒ infinite' by contradiction.",
+        "module": "Mathlib.Topology.Separation.Hausdorff"
+      }
+    ],
+    "prerequisites": [
+      "Euler's totient function φ (Nat.totient)",
+      "The main Erdős #1003 set {n | φ(n) = φ(n+1)} and its conjectured infinitude (parent entry erdos-1003)",
+      "Sibling OQ-02: the nested-chain reduction of the infinitude family",
+      "Natural (asymptotic) density as a limit of counting ratios",
+      "Uniqueness of limits in Hausdorff spaces; the squeeze theorem"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős #1003 asks whether there are infinitely many n with φ(n) = φ(n+1) (consecutive equal totients), a question still open even in this base case; Erdős further conjectured arbitrarily long runs of equal consecutive totients. Open question OQ-03 sharpens the lens from existence to distribution: what is the true asymptotic density of the solution set? The conjectured answer is density 0 — solutions are extremely sparse. Erdős, Pomerance, and Sárközy (1987, 'On locally repeated values of certain arithmetic functions, I') proved the sparsity bound #{n ≤ x : φ(n)=φ(n+1)} ≤ x/exp((log x)^{1/3}) for large x, which would give density 0 unconditionally — but the matching lower bound (even infinitude) is unproven. This entry does not close that analytic gap; instead it formalizes the logical skeleton that any density answer must respect.",
+    "problemStatement": "What is the true asymptotic density of {n | φ(n) = φ(n+1)}?",
+    "text": "The entry introduces countConsecutiveEqual N = #{n ≤ N : φ(n)=φ(n+1)} and the predicate HasNaturalDensity d (the ratio count/(N+1) tends to d). It then proves the exact relationships between density, the counting function, and infinitude. The headline is a clean dichotomy: a positive density would settle #1003 affirmatively (so cannot be shown without new ideas), while density 0 is exactly the value forced by finiteness (so is weaker than infinitude). The bridge theorem infinite_iff_count_unbounded ties OQ-03 to the infinitude conjecture studied by the parent and sibling OQ-02.",
+    "proofStrategy": "Everything is anchored on mem_filter_iff, the identification of the counted finset with the solutions ≤ N. The bridge's forward direction extracts a size-M subset of the infinite set (Set.Infinite.exists_subset_card_eq) and bounds a window by its supremum; the reverse direction caps every window by the total cardinality of a finite solution set. The density-zero result squeezes count/(N+1) between 0 and C/(N+1) → 0. Positive-density-implies-infinite is then a one-line contradiction via uniqueness of limits.",
+    "keyInsights": [
+      "The counting function is the right object: infinitude of the solution set is equivalent to unboundedness of countConsecutiveEqual.",
+      "A positive asymptotic density would, by itself, prove the open infinitude conjecture — so OQ-03 is at least as hard as #1003 in the positive-density regime.",
+      "Density 0 is precisely the value a finite solution set would exhibit; hence the conjectured density (0) carries strictly less information than the infinitude conjecture and cannot decide it.",
+      "Combining the two, the genuine content of OQ-03 is the lower bound: the density is 0 in both the finite world and the conjectured sparse-but-infinite world, and any value above 0 collapses into a proof of infinitude.",
+      "The analytic heavy lifting (the EPS sparsity bound that would give density exactly 0) is deliberately left as a cited external input; the formalized layer is the exact logic surrounding it."
+    ],
+    "prerequisites": [
+      "Euler's totient φ and the #1003 solution set (parent entry erdos-1003)",
+      "Sibling OQ-02 (infinitude family reduction)",
+      "Natural density, the squeeze theorem, and uniqueness of limits"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header — Question and Honest Scope",
+      "summary": "The block comment states OQ-03 (true asymptotic density of {n | φ(n)=φ(n+1)}), records that it is open, cites the Erdős–Pomerance–Sárközy sparsity bound and the conjectured density 0, and lays out the three structural results that pin down what an answer must supply. It is explicit that the open question is NOT resolved.",
+      "startLine": 1,
+      "endLine": 43,
+      "mathContext": "Density conjecturally 0 via $\\#\\{n \\le x : \\varphi(n)=\\varphi(n+1)\\} \\le x/\\exp((\\log x)^{1/3})$; infinitude (hence a matching lower bound) is open."
+    },
+    {
+      "id": "definitions",
+      "title": "Definitions and the Bookkeeping Lemma",
+      "summary": "ConsecutiveEqualTotients and countConsecutiveEqual mirror the parent #1003 entry verbatim. mem_filter_iff identifies the counted finset over Finset.range (N+1) with exactly the solutions ≤ N, the lemma threaded through every later proof.",
+      "startLine": 53,
+      "endLine": 69,
+      "mathContext": "$\\text{count}(N) = \\#\\{n \\le N : \\varphi(n)=\\varphi(n+1)\\}$; membership $\\iff$ (is a solution) $\\wedge\\ n \\le N$."
+    },
+    {
+      "id": "elementary",
+      "title": "Elementary Properties of the Counting Function",
+      "summary": "countConsecutiveEqual_monotone (a wider window contains at least as many solutions) and countConsecutiveEqual_le (at most N+1 integers lie in {0,…,N}). These make the density ratio well-behaved.",
+      "startLine": 71,
+      "endLine": 86,
+      "mathContext": "$\\text{count}$ is monotone and $\\text{count}(N) \\le N+1$."
+    },
+    {
+      "id": "bridge",
+      "title": "The Bridge — Density-Counting View ⇔ Infinitude View",
+      "summary": "infinite_iff_count_unbounded: the solution set is infinite iff the counting function is unbounded. Forward: a size-M subset of an infinite set is contained in a single window (bounded by its sup). Reverse: a finite solution set caps every window by its cardinality. This links OQ-03 to the #1003 / OQ-02 infinitude question.",
+      "startLine": 88,
+      "endLine": 123,
+      "mathContext": "$\\{n : \\varphi(n)=\\varphi(n+1)\\}$ infinite $\\iff \\forall M, \\exists N,\\ M \\le \\text{count}(N)$."
+    },
+    {
+      "id": "density",
+      "title": "Natural Density and Its Dichotomy",
+      "summary": "HasNaturalDensity d (the ratio count/(N+1) → d), the ratio bounds in [0,1], then the two structural results: hasNaturalDensity_zero_of_finite (finiteness squeezes the density to 0) and infinite_of_pos_density (a positive density forces infinitude, by uniqueness of limits against the finite case).",
+      "startLine": 125,
+      "endLine": 175,
+      "mathContext": "Finite $\\Rightarrow$ density $0$ (squeeze $0 \\le \\text{count}/(N+1) \\le C/(N+1) \\to 0$); density $> 0 \\Rightarrow$ infinite."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms): the honest structural layer of Erdős #1003's open density question OQ-03. The solution set is infinite iff its counting function is unbounded; a positive asymptotic density would resolve the open infinitude conjecture; and finiteness forces density 0. Together these isolate the genuine content of OQ-03 — the density is 0 in both the finite and the conjectured sparse-but-infinite worlds, and any positive density collapses into a proof of #1003.",
+    "implications": "**Frames an open question**: locates OQ-03's difficulty precisely — positivity of the density is equivalent to (a strong form of) the open #1003 conjecture, while the conjectured value 0 is the finiteness baseline. **Connects siblings**: the bridge theorem ties the density view to the infinitude view formalized by the parent and OQ-02. **Honest scope**: the analytic Erdős–Pomerance–Sárközy sparsity bound that would establish density exactly 0 is cited as an external input, not claimed.",
+    "openQuestions": [
+      "Formalize the Erdős–Pomerance–Sárközy upper bound #{n ≤ x : φ(n)=φ(n+1)} ≤ x/exp((log x)^{1/3}), which would give natural density 0 unconditionally (independent of infinitude).",
+      "Is the natural density even known to exist (i.e. does count/(N+1) converge), or only that its limsup is 0? Formalize the upper-density formulation and its relationship to the limit formulation used here."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1003",
+      "relationship": "extends",
+      "description": "Parent entry: the #1003 solution set {n | φ(n)=φ(n+1)} and its conjectured infinitude; this entry formalizes the density question OQ-03 built on the same definitions."
+    },
+    {
+      "targetId": "erdos-1003-oq-02",
+      "relationship": "related",
+      "description": "Sibling: the nested-chain reduction of the infinitude family. The bridge theorem here connects density-unboundedness to the infinitude OQ-02 studies."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Totient",
+      "Mathlib.Data.Set.Finite.Basic",
+      "Mathlib.Analysis.SpecificLimits.Basic"
+    ],
+    "opens": [
+      "Nat",
+      "Set",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "Erdos1003.OQ03",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1003OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "P. Erdős, C. Pomerance, A. Sárközy",
+      "title": "On locally repeated values of certain arithmetic functions, I",
+      "year": "1987",
+      "venue": "Journal of Number Theory 21, 319–332",
+      "note": "Proves the sparsity bound #{n ≤ x : φ(n)=φ(n+1)} ≤ x/exp((log x)^{1/3}); the cited external input that would give natural density 0."
+    },
+    {
+      "authors": "P. Erdős",
+      "title": "Erdős Problem #1003",
+      "year": "",
+      "venue": "erdosproblems.com/1003",
+      "note": "The source problem: are there infinitely many n with φ(n) = φ(n+1)? Open. OQ-03 asks for the true asymptotic density of the solution set."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Open question **OQ-03** of Erdős #1003 asks for the **true asymptotic density** of the solution set `{n | φ(n) = φ(n+1)}` (consecutive equal totients). The question is open: the set is conjectured infinite (#1003 itself, unproven even in the base case) and its density conjectured to be `0` (Erdős–Pomerance–Sárközy: `#{n ≤ x : φ(n)=φ(n+1)} ≤ x/exp((log x)^{1/3})` eventually).

This PR does **not** resolve OQ-03. It formalizes the **honest structural layer** of the density question — the counting function, the natural-density predicate, and the exact logical relationships that pin down what an eventual answer must supply. Mirrors the established pattern of sibling `Erdos1003OQ02.lean` (which packages the *infinitude* family).

## What is proved (`proofs/Proofs/Erdos1003OQ03.lean`, 177 lines, 0 sorries, 0 axioms)

- **`infinite_iff_count_unbounded`** — the bridge: the solution set is infinite **iff** the counting function `count(N) = #{n ≤ N : φ(n)=φ(n+1)}` is unbounded. Connects OQ-03's density/counting view to the infinitude view of #1003 and OQ-02.
- **`infinite_of_pos_density`** — a *positive* natural density would resolve #1003 affirmatively (the set would be infinite), so positivity cannot be exhibited without first settling the open infinitude conjecture.
- **`hasNaturalDensity_zero_of_finite`** — finiteness forces density `0` (squeeze `0 ≤ count/(N+1) ≤ C/(N+1) → 0`), so the conjectured answer (density 0) is exactly the finiteness baseline and carries strictly less information than infinitude.
- Supporting: `countConsecutiveEqual_monotone`, `countConsecutiveEqual_le`, `density_ratio_nonneg/_le_one`, `mem_filter_iff`, and `def HasNaturalDensity`.

**Takeaway:** the genuine content of OQ-03 lies entirely in the lower bound — the density is `0` in both the finite world and the conjectured sparse-but-infinite world, and any positive density collapses into a proof of #1003.

## Verification

- Built with `./proofs/scripts/docker-build.sh Proofs.Erdos1003OQ03` ✅
- `#print axioms` on all three headline theorems = `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`/`native_decide`. **Genuinely 0-axiom (verified).**
- Gallery entry `src/data/proofs/erdos-1003-oq-03` (meta + 5 annotations), `status: verified`, `badge: verified`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)