### PR TITLE
Enrich 'Hadamard's Inequality, Matrix Form' (gram-linear-independence-iff-oq-01-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "gram-hadamard-overview",
+    "proofId": "gram-linear-independence-iff-oq-01-oq-01-oq-02",
+    "range": { "startLine": 4, "endLine": 40 },
+    "type": "context",
+    "title": "Hadamard's Matrix Inequality as a Corollary of the Gramian Bound",
+    "content": "The module docstring frames the result as the classical matrix form of **Hadamard's inequality** (Hadamard, 1893): for a square matrix A over 𝕜 = ℝ or ℂ, ‖det A‖ ≤ ∏_j ‖col A j‖ — the determinant is bounded by the product of the Euclidean norms of the columns. Geometrically, the volume of the parallelepiped spanned by the columns never exceeds the product of the edge lengths, with equality exactly when the columns are pairwise orthogonal (a box of fixed edge lengths is largest when rectangular). Crucially, this entry does **not** reprove the inequality from scratch: it answers the second open question of the parent `gram-linear-independence-iff-oq-01-oq-01` by transporting that entry's abstract Gramian bound `det(gram 𝕜 v) ≤ ∏ ‖v i‖²` back to the concrete matrix statement via the column identification `gram(col A) = Aᴴ A`. The file delivers three flavours — the norm form, the squared form, and the explicit `‖det A‖ ≤ ∏_j √(∑_i ‖A i j‖²)` — all machine-checked with no sorry and no extra axioms.",
+    "mathContext": "$\\lVert\\det A\\rVert \\le \\prod_j \\lVert a_j\\rVert$, with equality iff the columns $a_j$ are pairwise orthogonal; geometrically $\\mathrm{vol}(\\text{parallelepiped}) \\le \\prod_j \\lVert a_j\\rVert$.",
+    "significance": "context",
+    "relatedConcepts": ["Hadamard's inequality (1893)", "Gram determinant", "parallelepiped volume", "orthogonality equality case", "RCLike field"],
+    "prerequisites": ["determinants", "Euclidean norm", "parent Gramian Hadamard bound"]
+  },
+  {
     "id": "gram-col-eq-bridge",
     "proofId": "gram-linear-independence-iff-oq-01-oq-01-oq-02",
     "range": { "startLine": 41, "endLine": 58 },

--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GramHadamardMatrixOQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const gramLinearIndependenceIffOq01Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const gramLinearIndependenceIffOq01Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const gramLinearIndependenceIffOq01Oq01Oq02Data: ProofData = {
+  proof: gramLinearIndependenceIffOq01Oq01Oq02Proof,
+  annotations: gramLinearIndependenceIffOq01Oq01Oq02Annotations,
+}

--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02/meta.json
@@ -22,6 +22,7 @@
     "sorries": 0
   },
   "title": "Hadamard's Inequality, Matrix Form: |det A| ≤ ∏ ‖column‖",
+  "description": "Answers the second open question of gram-linear-independence-iff-oq-01-oq-01 by specialising the abstract Gramian Hadamard bound back to the classical matrix statement. For a square matrix A over an RCLike field 𝕜 (ℝ or ℂ), Hadamard's 1893 inequality ‖det A‖ ≤ ∏_j ‖col A j‖ — the determinant is bounded by the product of the Euclidean column norms, with equality iff the columns are pairwise orthogonal — is derived as a corollary, not re-proved. The bridge: the Gram matrix of the columns (as vectors of EuclideanSpace 𝕜 (Fin n)) is the Hermitian product Aᴴ·A (gram_col_eq), so det(gram(col A)) = conj(det A)·det A = ‖det A‖² (gram_col_det); feeding the columns into the parent's hadamard_inequality_euclidean gives ‖det A‖² ≤ ∏_j ‖col A j‖², and one monotone square root yields the norm form. The explicit version ‖det A‖ ≤ ∏_j √(∑_i ‖A i j‖²) recovers Hadamard's original statement. Verified: 96 lines, 7 theorems, 1 definition, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `gram-linear-independence-iff-oq-01-oq-01-oq-02` (quality 86, passes 0).

## Changes
- **Added missing `index.ts`** (critical): without it Vite's `import.meta.glob` cannot discover the proof, so the page rendered "proof not found" on the live site. Dominant quality gap.
- **Added missing top-level `description`** field: the meta.json had none, so the gallery listing and proof page had no summary text. Added a substantive description of the corollary-of-Gramian-bound derivation.
- **Annotation coverage 4 → 5**: added a header/context annotation (lines 4–40) framing Hadamard's 1893 inequality and the corollary structure, with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. The five annotations now span the whole Lean file.

## Notes
- `meta.json` (14 KB) was already comprehensive and accurate — left the existing rich overview/sections/conclusion as-is per the diminishing-returns rule.
- Axiom integrity verified against the Lean source: `status: verified`, `axiomCount: 0`, `badge: original` correct (0 sorries, 0 axioms, no native_decide, no structure-encoded assumptions).
- `pnpm build` passes (tsc type-check + data generation).

Branch note: pushed to `feature/enricher-3-gram-hadamard` because `feature/enricher-3` still hosts open PR #31387.