### PR TITLE
Enrich 'Jacobi r₄ on prime powers' (four-square-distribution-oq-06): add missing index.ts

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-06/index.ts
+++ b/src/data/proofs/four-square-distribution-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FourSquareDistributionOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fourSquareDistributionOq06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fourSquareDistributionOq06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fourSquareDistributionOq06Data: ProofData = {
+  proof: fourSquareDistributionOq06Proof,
+  annotations: fourSquareDistributionOq06Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `four-square-distribution-oq-06` (quality 93, passes 0).

## Changes
- **Added missing `index.ts`** (critical): without it Vite's `import.meta.glob` cannot discover the proof, so the page rendered "proof not found" on the live site. This was the **sole** quality gap.

## Notes
- `meta.json` (13 KB, top-level `description` present, 5 sections) and `annotations.json` (5 annotations with mathContext/significance/relatedConcepts/prerequisites) were already complete and accurate — left untouched per the diminishing-returns rule.
- Axiom integrity verified against the Lean source: `status: verified`, `axiomCount: 0`, `badge: original` are correct. The five `native_decide` strings in the file are all in docstrings/comments (describing how the *parent* table entry was checked); there is no `native_decide` tactic and no `axiom`/`sorry` declaration. The closed forms σ*(pᵏ)=1+p+…+pᵏ and σ*(2ᵏ)=3 are proved symbolically.
- `pnpm build` passes (tsc type-check + data generation).

Branch note: pushed to `feature/enricher-3-four-square-oq06` because `feature/enricher-3` still hosts open PRs #31387 and #31390.