### PR TITLE
research: erdos-1-oq-02 axiom ELIMINATED (0-axiom verified) + erdos-1005-oq-02 §22 continuant trichotomy [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -2031,4 +2031,129 @@ theorem continuant_replicate_one_abs_le_one (n : ℕ) :
     |Continuant (List.replicate n 1)| ≤ 1 := by
   rcases continuant_replicate_one_bounded n with h | h | h <;> rw [h] <;> decide
 
+/-! ## §22: The constant-quotient continuant — one recurrence, three growth regimes
+
+§20 and §21 computed the continuant of the two *extreme* constant lists: the
+all-`2` ladder grows **linearly** (`continuant_replicate_two`: `K = n + 1`) and the
+all-`1` orbit stays **bounded** (`continuant_replicate_one_abs_le_one`: `|K| ≤ 1`,
+period `6`).  Both are instances of a single statement: the continuant of the
+constant list `[k, k, …, k]` obeys the second-order linear recurrence
+
+  `K([k]^(n+2)) = k · K([k]^(n+1)) − K([k]^n)`,    `K([k]^0) = 1`,  `K([k]^1) = k`,
+
+the Chebyshev/Dickson recurrence with characteristic equation `x² − k x + 1 = 0`
+and roots `(k ± √(k² − 4)) / 2`.  The discriminant `k² − 4` fixes the regime:
+
+* `k = 1` — roots `e^{±iπ/3}` on the unit circle ⇒ **bounded, period `6`** (§21);
+* `k = 2` — double root `1` ⇒ **linear** `K = n + 1` (§20);
+* `k ≥ 3` — real roots, the larger `> 1` ⇒ **exponential** growth.
+
+This section proves the unifying recurrence and closes the missing third regime:
+for `k ≥ 2` the constant continuant is bounded below by `(k − 1)^n`, so for
+`k ≥ 3` it grows at least like `2^n` — the constant list is *not* metrically cheap
+once the common quotient exceeds `2`.  Together with §20/§21 this gives the full
+trichotomy of the constant-quotient continuant.
+
+Depends only on the §14 `continuant_cons` recurrence, §17 `continuant_pos`, and the
+§20-style `continuant_strict_mono`. -/
+
+/-- **The constant-quotient recurrence (headline).**  The continuant of the constant
+list `[k]^(n+2)` satisfies the second-order linear recurrence
+`K([k]^(n+2)) = k · K([k]^(n+1)) − K([k]^n)` — the order-side Chebyshev/Dickson
+recurrence `x² = k x − 1`.  Both §20 (`k = 2`, linear) and §21 (`k = 1`, period-`6`)
+are the discriminant-`0` and discriminant-`(−3)` instances of this single law. -/
+theorem continuant_replicate_recurrence (k : ℤ) (n : ℕ) :
+    Continuant (List.replicate (n + 2) k)
+      = k * Continuant (List.replicate (n + 1) k) - Continuant (List.replicate n k) := by
+  have e2 : List.replicate (n + 2) k = k :: k :: List.replicate n k := by
+    rw [List.replicate_succ, List.replicate_succ]
+  have e1 : List.replicate (n + 1) k = k :: List.replicate n k := by
+    rw [List.replicate_succ]
+  rw [e2, e1, continuant_cons]
+  simp only [secondCont]
+
+/-- **Strict monotonicity of the constant-quotient ladder (`k ≥ 2`).**  Appending one
+more quotient `k ≥ 2` strictly increases the constant continuant:
+`K([k]^n) < K([k]^(n+1))`.  Immediate from §20-style `continuant_strict_mono`, since
+every entry of `[k]^n` equals `k ≥ 2`. -/
+theorem continuant_replicate_mono {k : ℤ} (hk : (2 : ℤ) ≤ k) (n : ℕ) :
+    Continuant (List.replicate n k) < Continuant (List.replicate (n + 1) k) := by
+  rw [List.replicate_succ]
+  exact continuant_strict_mono hk
+    (fun j hj => by rw [List.eq_of_mem_replicate hj]; exact hk)
+
+/-- **Geometric step (`k ≥ 2`).**  Each step of the constant-quotient continuant
+multiplies by at least `k − 1`: `(k − 1) · K([k]^(n+1)) ≤ K([k]^(n+2))`.  From the
+recurrence `K([k]^(n+2)) = k·K([k]^(n+1)) − K([k]^n)`, this is exactly the
+monotonicity `K([k]^n) ≤ K([k]^(n+1))`.  For `k ≥ 3` the multiplier `k − 1 ≥ 2`
+forces genuine exponential growth. -/
+theorem continuant_replicate_geometric_step {k : ℤ} (hk : (2 : ℤ) ≤ k) (n : ℕ) :
+    (k - 1) * Continuant (List.replicate (n + 1) k)
+      ≤ Continuant (List.replicate (n + 2) k) := by
+  rw [continuant_replicate_recurrence]
+  have hm := continuant_replicate_mono hk n
+  have hexp : (k - 1) * Continuant (List.replicate (n + 1) k)
+      = k * Continuant (List.replicate (n + 1) k)
+        - Continuant (List.replicate (n + 1) k) := by ring
+  rw [hexp]
+  linarith [hm]
+
+/-- **Power lower bound (`k ≥ 2`).**  The constant-quotient continuant dominates the
+geometric sequence `(k − 1)^n`: `(k − 1)^n ≤ K([k]^(n+1))`.  By induction on the
+geometric step, starting from `K([k]^1) = k ≥ 1 = (k − 1)^0`.  This brackets the
+constant continuant from below to match the `K([k]^n) ≤ k^n` product ceiling. -/
+theorem continuant_replicate_pow_le {k : ℤ} (hk : (2 : ℤ) ≤ k) (n : ℕ) :
+    (k - 1) ^ n ≤ Continuant (List.replicate (n + 1) k) := by
+  induction n with
+  | zero =>
+    rw [pow_zero]
+    have h1 : List.replicate (0 + 1) k = [k] := rfl
+    rw [h1, continuant_one]; linarith
+  | succ m ih =>
+    have hk1 : (0 : ℤ) ≤ k - 1 := by linarith
+    calc (k - 1) ^ (m + 1)
+        = (k - 1) * (k - 1) ^ m := by ring
+      _ ≤ (k - 1) * Continuant (List.replicate (m + 1) k) :=
+            mul_le_mul_of_nonneg_left ih hk1
+      _ ≤ Continuant (List.replicate (m + 2) k) :=
+            continuant_replicate_geometric_step hk m
+
+/-- **The third regime — exponential growth (`k ≥ 3`, headline).**  Completing the
+constant-quotient trichotomy beyond §20 (linear, `k = 2`) and §21 (bounded, `k = 1`):
+for every common quotient `k ≥ 3` the continuant of `[k]^(n+1)` is at least `2^n`, so
+the constant-quotient run grows exponentially.  Hence the metric "cheapness" of long
+constant runs is special to `k ≤ 2`; raising the common quotient to `3` already makes
+the continuant — and therefore (via the §14 closed form) the Farey run endpoints —
+exponentially expensive. -/
+theorem continuant_replicate_exp_ge_two {k : ℤ} (hk : (3 : ℤ) ≤ k) (n : ℕ) :
+    (2 : ℤ) ^ n ≤ Continuant (List.replicate (n + 1) k) := by
+  have hk2 : (2 : ℤ) ≤ k := by linarith
+  induction n with
+  | zero =>
+    rw [pow_zero]
+    have h1 : List.replicate (0 + 1) k = [k] := rfl
+    rw [h1, continuant_one]; linarith
+  | succ m ih =>
+    have hstep := continuant_replicate_geometric_step hk2 m
+    have hpos : (0 : ℤ) ≤ Continuant (List.replicate (m + 1) k) :=
+      le_trans (by positivity) ih
+    calc (2 : ℤ) ^ (m + 1)
+        = 2 * (2 : ℤ) ^ m := by ring
+      _ ≤ 2 * Continuant (List.replicate (m + 1) k) :=
+            mul_le_mul_of_nonneg_left ih (by norm_num)
+      _ ≤ (k - 1) * Continuant (List.replicate (m + 1) k) :=
+            mul_le_mul_of_nonneg_right (by linarith) hpos
+      _ ≤ Continuant (List.replicate (m + 2) k) := hstep
+
+/-- **Recovering §20 from the recurrence (`k = 2`, sanity check).**  The all-`2`
+specialisation of `continuant_replicate_recurrence` is `K([2]^(n+2)) =
+2·K([2]^(n+1)) − K([2]^n)`, the constant-difference recurrence whose solution is the
+arithmetic ladder `n + 1` (`continuant_replicate_two`).  Stated as a consistency
+check that the §22 recurrence specialises correctly. -/
+theorem continuant_replicate_recurrence_two (n : ℕ) :
+    Continuant (List.replicate (n + 2) (2 : ℤ))
+      = 2 * Continuant (List.replicate (n + 1) (2 : ℤ))
+        - Continuant (List.replicate n (2 : ℤ)) :=
+  continuant_replicate_recurrence 2 n
+
 end Erdos1005OQ02

--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -30,8 +30,8 @@ The proof uses a variance argument:
 - **Variance lower bound**: Σaᵢ² ≥ (Σaᵢ)²/n (Cauchy–Schwarz)
 - **Sum-max relationship**: max(A) ≥ Σaᵢ/n for finite sets
 - **DFX bound deduction**: 2ⁿ ≤ 3·√n·N + 2 (i.e. N = Ω(2ⁿ/√n)) from the
-  axiomatized Chebyshev anticoncentration bound (order-correct; the sharp √(2/π)
-  constant is the Berry–Esseen literature result, not formalized here)
+  fully proved (0-axiom) Chebyshev anticoncentration bound (order-correct; the sharp
+  √(2/π) constant is the Berry–Esseen literature result, not formalized here)
 
 ## Connection to Prior Work
 
@@ -106,38 +106,33 @@ The core of the DFX proof is an anticoncentration inequality: the number of
 distinct values of a sum of independent bounded random variables is limited
 by the ratio of range to standard deviation.
 
-This step requires probability theory (Berry–Esseen theorem or direct
-anticoncentration bounds) which is axiomatized here.
+The probability-theory route (Berry–Esseen / Chebyshev on the random subset sum) is
+*replaced* here by an elementary, probability-free discrete second-moment argument, so
+the Chebyshev form `2ⁿ ≤ 3√Q + 2` is proved outright (0 axioms) rather than assumed.
 -/
 
-/-- **Chebyshev anticoncentration bound** [Axiom]: If A has n elements with
-    distinct subset sums and Q = Σaᵢ², then:
-      2ⁿ ≤ 3·√Q + 2
+/-! ### The anticoncentration bound `2ⁿ ≤ 3√Q + 2` — now a theorem, not an axiom
 
-    This is the rigorous (Chebyshev) form of the Dubroff–Fox–Xu anticoncentration
-    step. View the 2ⁿ subset sums as the values of the random variable
-    X = Σᵢ εᵢ aᵢ with εᵢ ∈ {0,1} i.i.d. Bernoulli(1/2); then
-      E[X] = S/2,    Var[X] = Σaᵢ²/4 = Q/4,    σ = √Q/2.
-    Chebyshev's inequality gives, for any k > 0,
-      P(|X − S/2| < k) ≥ 1 − Q/(4k²).
-    The distinct-subset-sums hypothesis forces the sums to be *distinct integers*,
-    so the values with |x − S/2| < k are distinct integer points of an open
-    interval of length 2k, of which there are at most 2k + 1. Each such value
-    carries probability 2⁻ⁿ, hence
-      1 − Q/(4k²) ≤ P(|X − S/2| < k) ≤ (2k + 1)·2⁻ⁿ.
-    Taking k = √Q (so Q/(4k²) = 1/4) yields
-      (3/4)·2ⁿ ≤ 2√Q + 1,   i.e.   2ⁿ ≤ (8√Q + 4)/3 ≤ 3√Q + 2.
+This estimate was previously *axiomatized* (the probability-theory route via Chebyshev
+on the random subset sum). It is now **fully proved below** (`anticoncentration_bound`,
+0 axioms) by the elementary, probability-free discrete second-moment argument whose
+ingredients are assembled in this section. The proof is:
 
-    Unlike the sharp √(2/π) constant from Berry–Esseen (the literature bound), the
-    constant 3 here comes only from Chebyshev and is *unconditionally true* — it can
-    in principle be discharged from `ProbabilityTheory.meas_ge_le_variance_div_sq`
-    (Chebyshev) plus the variance computation for the {0,aᵢ} sum. The earlier
-    formulation `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was FALSE (e.g. A = {1,2} gives 4 ≤ 2.85);
-    this corrected statement holds for every distinct-subset-sums set, including
-    the asymptotic extremal (powers of two). -/
-axiom anticoncentration_bound (A : Finset ℕ) (hDSS : hasDistinctSubsetSums A)
-    (hpos : 0 < A.card) :
-    (2 : ℝ) ^ A.card ≤ 3 * Real.sqrt (↑(A.sum (fun a => a ^ 2))) + 2
+* the exact discrete variance identity `∑_{T⊆A}(2Σ_T − S)² = 2ⁿ·Q`
+  (`second_moment_identity`);
+* the `2ⁿ` doubled deviations are `2ⁿ` distinct same-parity integers
+  (`card_doubledDrop_image_of_distinct`, `doubledDrop_injOn_of_distinct`);
+* a central-interval count (`card_le_of_sameParity_interval`) and a discrete
+  Chebyshev/Markov tail (`card_mul_le_second_moment`), combined into the
+  parameter-free integer inequality `(2ⁿ − (L+1))·(L+1)² ≤ 2ⁿ·Q`
+  (`powerset_interval_chebyshev`);
+* a real `Nat.sqrt`-based optimisation of the cutoff `L ≈ 2√Q` recovering
+  `2ⁿ ≤ (8√Q + 4)/3 ≤ 3√Q + 2` — the sharp Chebyshev constant `3`.
+
+Unlike the sharp √(2/π) constant from Berry–Esseen (the literature bound), the constant
+`3` here comes only from Chebyshev. The earlier formulation `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was
+mathematically FALSE (e.g. A = {1,2} gives 4 ≤ 2.85); the proved statement
+`2ⁿ ≤ 3√Q + 2` holds for every distinct-subset-sums set. -/
 
 /-! ## Verified ingredients toward discharging `anticoncentration_bound`
 
@@ -208,9 +203,10 @@ weight `g` and a positive threshold `t`, the number of indices with `g i ≥ t`,
 times `t`, is at most the total weight `∑ g i`.  Specialised to
 `g T = (2·Σ_{i∈T} i − S)²` this is the tail count feeding the anticoncentration
 estimate. -/
-theorem card_mul_le_second_moment (s : Finset ℕ) (g : ℕ → ℤ)
+theorem card_mul_le_second_moment {α : Type*} (s : Finset α) (g : α → ℤ)
     (hg : ∀ i ∈ s, 0 ≤ g i) (t : ℤ) :
     ((s.filter (fun i => t ≤ g i)).card : ℤ) * t ≤ ∑ i ∈ s, g i := by
+  classical
   calc ((s.filter (fun i => t ≤ g i)).card : ℤ) * t
       = ∑ _i ∈ s.filter (fun i => t ≤ g i), t := by
         rw [Finset.sum_const, nsmul_eq_mul]
@@ -293,6 +289,149 @@ theorem card_le_of_sameParity_interval (V : Finset ℤ) (p L : ℤ) (hL : 0 ≤ 
   rw [Int.toNat_of_nonneg (by omega)] at this
   exact this
 
+/-- **Central-interval + Chebyshev tail, combined (0 axioms).**  For a
+distinct-subset-sums set `A` and any cutoff `L ≥ 0`, the `2^{|A|}` doubled deviations
+`2·Σ_T − S` split into a central band `|·| ≤ L` (at most `L + 1` of them, since they are
+distinct same-parity integers — `card_le_of_sameParity_interval`) and a tail `|·| ≥ L+1`
+whose count is bounded by the discrete Chebyshev/Markov inequality
+(`card_mul_le_second_moment`) against the second moment `2^{|A|}·Q`
+(`second_moment_identity`).  Eliminating the two counts gives the parameter-free integer
+inequality
+  `(2^{|A|} − (L+1))·(L+1)² ≤ 2^{|A|}·Q`,    `Q = Σ_{i∈A} i²`,
+valid for every `L ≥ 0`.  Optimising `L ≈ 2√Q` turns this into `anticoncentration_bound`. -/
+theorem powerset_interval_chebyshev {A : Finset ℕ} (hDSS : hasDistinctSubsetSums A)
+    (L : ℤ) (hL : 0 ≤ L) :
+    ((2 : ℤ) ^ A.card - (L + 1)) * (L + 1) ^ 2
+      ≤ 2 ^ A.card * ∑ i ∈ A, (i : ℤ) ^ 2 := by
+  classical
+  set f : Finset ℕ → ℤ := fun T => 2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ A, (i : ℤ) with hf
+  -- second moment over the powerset
+  have hsm : ∑ T ∈ A.powerset, f T ^ 2 = 2 ^ A.card * ∑ i ∈ A, (i : ℤ) ^ 2 := by
+    simp only [hf]; exact second_moment_identity A
+  -- injectivity of f on the powerset
+  have hinj : Set.InjOn f (A.powerset : Set (Finset ℕ)) := by
+    simp only [hf]; exact doubledDrop_injOn_of_distinct hDSS
+  -- |x| < L+1 ⇒ −L ≤ x ≤ L (integrality)
+  have habs : ∀ x : ℤ, x ^ 2 < (L + 1) ^ 2 → -L ≤ x ∧ x ≤ L := by
+    intro x hx
+    have hlo : -(L + 1) < x := by nlinarith [hx, hL, sq_nonneg (x + (L + 1))]
+    have hhi : x < L + 1 := by nlinarith [hx, hL, sq_nonneg (x - (L + 1))]
+    omega
+  -- partition the powerset into central band and tail
+  have hpart :
+      (A.powerset.filter (fun T => f T ^ 2 < (L + 1) ^ 2)).card
+        + (A.powerset.filter (fun T => ¬ (f T ^ 2 < (L + 1) ^ 2))).card
+        = A.powerset.card :=
+    Finset.filter_card_add_filter_neg_card_eq_card _
+  -- central band: at most L+1 elements
+  have hcentral :
+      ((A.powerset.filter (fun T => f T ^ 2 < (L + 1) ^ 2)).card : ℤ) ≤ L + 1 := by
+    have hsub : A.powerset.filter (fun T => f T ^ 2 < (L + 1) ^ 2) ⊆ A.powerset :=
+      Finset.filter_subset _ _
+    have hinj' : Set.InjOn f
+        ((A.powerset.filter (fun T => f T ^ 2 < (L + 1) ^ 2)) : Set (Finset ℕ)) :=
+      hinj.mono (by exact_mod_cast hsub)
+    have hpar : ∀ v ∈ (A.powerset.filter (fun T => f T ^ 2 < (L + 1) ^ 2)).image f,
+        v % 2 = (∑ i ∈ A, (i : ℤ)) % 2 := by
+      intro v hv
+      rw [Finset.mem_image] at hv
+      obtain ⟨T, _, rfl⟩ := hv
+      simp only [hf]; omega
+    have hbd : ∀ v ∈ (A.powerset.filter (fun T => f T ^ 2 < (L + 1) ^ 2)).image f,
+        -L ≤ v ∧ v ≤ L := by
+      intro v hv
+      rw [Finset.mem_image] at hv
+      obtain ⟨T, hT, rfl⟩ := hv
+      rw [Finset.mem_filter] at hT
+      exact habs (f T) hT.2
+    have himg := card_le_of_sameParity_interval
+      ((A.powerset.filter (fun T => f T ^ 2 < (L + 1) ^ 2)).image f)
+      (∑ i ∈ A, (i : ℤ)) L hL hpar hbd
+    rwa [Finset.card_image_of_injOn hinj'] at himg
+  -- tail: Chebyshev/Markov against the second moment
+  have hcheb := card_mul_le_second_moment A.powerset (fun T => f T ^ 2)
+    (fun T _ => sq_nonneg _) ((L + 1) ^ 2)
+  rw [hsm] at hcheb
+  have hfilter_eq :
+      A.powerset.filter (fun T => (L + 1) ^ 2 ≤ f T ^ 2)
+        = A.powerset.filter (fun T => ¬ (f T ^ 2 < (L + 1) ^ 2)) :=
+    Finset.filter_congr (fun T _ => by rw [not_lt])
+  rw [hfilter_eq] at hcheb
+  -- card of the powerset is 2^|A|
+  have hPc : (A.powerset.card : ℤ) = 2 ^ A.card := by
+    rw [Finset.card_powerset]; push_cast; ring
+  have hsum :
+      ((A.powerset.filter (fun T => f T ^ 2 < (L + 1) ^ 2)).card : ℤ)
+        + ((A.powerset.filter (fun T => ¬ (f T ^ 2 < (L + 1) ^ 2))).card : ℤ)
+        = 2 ^ A.card := by
+    have h := congrArg (Nat.cast : ℕ → ℤ) hpart
+    push_cast at h
+    rw [h]; exact hPc
+  -- combine: 2^n − (L+1) ≤ tail.card, then multiply by (L+1)² and use Chebyshev
+  have ht_ge :
+      (2 : ℤ) ^ A.card - (L + 1)
+        ≤ ((A.powerset.filter (fun T => ¬ (f T ^ 2 < (L + 1) ^ 2))).card : ℤ) := by
+    linarith [hcentral, hsum]
+  calc ((2 : ℤ) ^ A.card - (L + 1)) * (L + 1) ^ 2
+      ≤ ((A.powerset.filter (fun T => ¬ (f T ^ 2 < (L + 1) ^ 2))).card : ℤ) * (L + 1) ^ 2 := by
+        apply mul_le_mul_of_nonneg_right ht_ge; positivity
+    _ ≤ 2 ^ A.card * ∑ i ∈ A, (i : ℤ) ^ 2 := hcheb
+
+/-- **Chebyshev anticoncentration bound (0 axioms).**  If `A` has `n ≥ 1` elements with
+distinct subset sums and `Q = Σaᵢ²`, then `2ⁿ ≤ 3·√Q + 2`.  This is the discharge of the
+former `anticoncentration_bound` axiom: combine the parameter-free integer inequality
+`powerset_interval_chebyshev` at the cutoff `L = ⌊√(4Q)⌋ = Nat.sqrt(4Q)` (so
+`(L+1)² > 4Q ≥ (L)²`, i.e. `L ≤ 2√Q < L+1`) with the real estimate.  Writing
+`x = 2ⁿ`, `m = L+1`, the integer inequality gives `(x − m)·m² ≤ x·Q`; since `m² > 4Q`
+this forces `3x < 4m ≤ 4(2√Q + 1)`, i.e. `x ≤ (8√Q + 4)/3 ≤ 3√Q + 2`. -/
+theorem anticoncentration_bound (A : Finset ℕ) (hDSS : hasDistinctSubsetSums A)
+    (hpos : 0 < A.card) :
+    (2 : ℝ) ^ A.card ≤ 3 * Real.sqrt (↑(A.sum (fun a => a ^ 2))) + 2 := by
+  classical
+  set Qn : ℕ := A.sum (fun a => a ^ 2) with hQn
+  -- cast Q to ℤ matching the powerset second moment
+  have hQcast : ((Qn : ℕ) : ℤ) = ∑ i ∈ A, (i : ℤ) ^ 2 := by
+    rw [hQn, Nat.cast_sum]
+    exact Finset.sum_congr rfl (fun i _ => by push_cast; ring)
+  -- cutoff L = ⌊√(4Q)⌋
+  set s : ℕ := Nat.sqrt (4 * Qn) with hs
+  set L : ℤ := (s : ℤ) with hLdef
+  have hL : 0 ≤ L := by rw [hLdef]; positivity
+  -- the integer inequality at this cutoff
+  have hPIC := powerset_interval_chebyshev hDSS L hL
+  rw [← hQcast] at hPIC
+  -- (L+1)² > 4Q  (from Nat.lt_succ_sqrt)
+  have hB : (4 * (Qn : ℤ)) < (L + 1) ^ 2 := by
+    have h := Nat.lt_succ_sqrt (4 * Qn)
+    rw [← hs] at h                       -- h : 4*Qn < (s+1)*(s+1)
+    have hcast : (4 * (Qn : ℤ)) < ((s : ℤ) + 1) * ((s : ℤ) + 1) := by exact_mod_cast h
+    rw [hLdef]; nlinarith [hcast]
+  -- s ≤ 2√Q  (from Nat.sqrt_le)
+  have hsr : ((s : ℝ)) ^ 2 ≤ 4 * (Qn : ℝ) := by
+    have h := Nat.sqrt_le (4 * Qn)       -- sqrt(4Qn)*sqrt(4Qn) ≤ 4Qn
+    rw [← hs] at h                        -- h : s*s ≤ 4*Qn
+    have hcast : ((s * s : ℕ) : ℝ) ≤ ((4 * Qn : ℕ) : ℝ) := by exact_mod_cast h
+    push_cast at hcast; nlinarith [hcast]
+  have hr0 : (0 : ℝ) ≤ Real.sqrt (Qn : ℝ) := Real.sqrt_nonneg _
+  have hsqq : Real.sqrt (Qn : ℝ) ^ 2 = (Qn : ℝ) := Real.sq_sqrt (by positivity)
+  have hsle : (s : ℝ) ≤ 2 * Real.sqrt (Qn : ℝ) := by
+    nlinarith [hsr, hsqq, hr0, (Nat.cast_nonneg s : (0 : ℝ) ≤ (s : ℝ)),
+      (by positivity : (0 : ℝ) ≤ (s : ℝ) + 2 * Real.sqrt (Qn : ℝ))]
+  have hLsqrt : (L : ℝ) ≤ 2 * Real.sqrt (Qn : ℝ) := by rw [hLdef]; push_cast; exact hsle
+  -- move the integer facts to ℝ
+  have hxpos : (0 : ℝ) < (2 : ℝ) ^ A.card := by positivity
+  have hA : ((2 : ℝ) ^ A.card - ((L : ℝ) + 1)) * ((L : ℝ) + 1) ^ 2
+      ≤ (2 : ℝ) ^ A.card * (Qn : ℝ) := by exact_mod_cast hPIC
+  have hBr : 4 * (Qn : ℝ) < ((L : ℝ) + 1) ^ 2 := by exact_mod_cast hB
+  -- the optimisation: 3·2ⁿ < 4(L+1) ≤ 8√Q + 4
+  have hm2pos : (0 : ℝ) < ((L : ℝ) + 1) ^ 2 := by positivity
+  have step1 : 4 * ((2 : ℝ) ^ A.card - ((L : ℝ) + 1)) * ((L : ℝ) + 1) ^ 2
+      < (2 : ℝ) ^ A.card * ((L : ℝ) + 1) ^ 2 := by nlinarith [hA, hBr, hxpos]
+  have step2 : 3 * (2 : ℝ) ^ A.card < 4 * ((L : ℝ) + 1) := by nlinarith [step1, hm2pos]
+  have hfin : (2 : ℝ) ^ A.card ≤ 3 * Real.sqrt (Qn : ℝ) + 2 := by
+    nlinarith [step2, hLsqrt, hr0]
+  exact hfin
+
 /-- **DFX Lower Bound Statement** (Chebyshev constant): If A ⊆ {1,...,N} has n ≥ 1
     elements with distinct subset sums, then:
       2ⁿ ≤ 3·√n·N + 2,    equivalently    N ≥ (2ⁿ − 2) / (3·√n).
@@ -374,26 +513,28 @@ theorem f_two_max : ∃ (A : Finset ℕ), A.card = 2 ∧ A.sup id = 2 := by
 /-! ## Conclusion
 
 The DFX framework is formalized with:
-- 1 axiom (Chebyshev anticoncentration bound `2ⁿ ≤ 3√Q + 2`, true and in
-  principle dischargeable from Mathlib's Chebyshev inequality)
-- 0 sorries (dfx_lower_bound fully proved)
+- **0 axioms** — the Chebyshev anticoncentration bound `2ⁿ ≤ 3√Q + 2`
+  (`anticoncentration_bound`) is now a fully proved theorem, not an axiom
+- 0 sorries (`dfx_lower_bound` fully proved)
 - Variance bounds and Cauchy–Schwarz (proved)
 - Small case verifications (proved)
-- The probability-free CORE of the axiom's discharge now proved in-file
-  (`second_moment_identity` and `card_mul_le_second_moment`, both 0-axiom); only
-  the same-parity distinct-integer interval count remains to fully eliminate the
-  axiom. See the "Verified ingredients toward discharging" section above.
 
-The axiom isolates the probability theory (the variance computation plus
-Chebyshev's inequality) that requires Mathlib probability infrastructure to
-formalize directly. The algebraic framework (variance bounds, Cauchy–Schwarz,
-sqrt manipulation) is fully proved.
+The anticoncentration step is discharged by an elementary, probability-free discrete
+second-moment argument (no `MeasureTheory`/`ProbabilityTheory`):
+`second_moment_identity` (the exact variance identity over the powerset),
+`card_doubledDrop_image_of_distinct` (the `2ⁿ` subset sums are `2ⁿ` distinct
+same-parity integers), `card_le_of_sameParity_interval` (central-interval count) and
+`card_mul_le_second_moment` (discrete Chebyshev/Markov tail), combined in
+`powerset_interval_chebyshev` into the parameter-free integer inequality
+`(2ⁿ − (L+1))·(L+1)² ≤ 2ⁿ·Q`, then optimised at the cutoff `L = ⌊√(4Q)⌋` via
+`Nat.sqrt`/`Real.sqrt` to recover the Chebyshev constant `3`.
 
 NOTE (2026-06-27 integrity fix): the previous `anticoncentration_bound` axiom
 `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was mathematically FALSE (it fails already for
 A = {1,2}: it asserts 4 ≤ 2.85), which made the file logically unsound. It was
-replaced with the true Chebyshev bound `2ⁿ ≤ 3√Q + 2`; `dfx_lower_bound` was
-re-derived with the honest (order-correct) constant.
+replaced with the true Chebyshev bound `2ⁿ ≤ 3√Q + 2` (2026-06-28: now proved,
+eliminating the last axiom); `dfx_lower_bound` uses the honest (order-correct)
+constant.
 -/
 
 end Erdos1OQ02

--- a/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
@@ -153,3 +153,43 @@ Added `card_le_of_sameParity_interval` (0-axiom): a `Finset ℤ` whose elements 
 - src/data/proofs/erdos-1-oq-02/meta.json (counts 367/13 → 399/14 + highlight)
 
 ### Status: IN-PROGRESS (axiom not yet discharged; only the sqrt assembly remains).
+
+## Session 2026-06-28 (researcher-1) — BUILD: AXIOM ELIMINATED, file now 0-axiom VERIFIED
+
+**Mode**: BUILD (docker-build.sh, 7744 jobs, clean). **Outcome**: DISCHARGED the file's last
+axiom `anticoncentration_bound` — `Erdos1OQ02.lean` is now fully verified, 0 axioms, 0 sorries.
+`#print axioms anticoncentration_bound / dfx_lower_bound / powerset_interval_chebyshev`
+= [propext, Classical.choice, Quot.sound] only (no sorryAx, no native_decide).
+
+This completes the multi-session discharge that prior researchers (3,2,3) set up. All
+combinatorial inputs were already 0-axiom; I landed the two missing pieces and assembled.
+
+### What I added (theorems 14→16; file 399→540 lines)
+- **powerset_interval_chebyshev** (the assembly the notes flagged as "ONLY remaining"):
+  for any cutoff `L ≥ 0`, `(2ⁿ − (L+1))·(L+1)² ≤ 2ⁿ·Q` (Q=Σaᵢ²). Partition the powerset by
+  `(f T)² < (L+1)²` (central) vs `≥` (tail). Central ≤ L+1 via card_le_of_sameParity_interval
+  on the image (InjOn ⇒ card image = card filter); tail via the (now-generalized)
+  card_mul_le_second_moment with `g T = (f T)²`, `t=(L+1)²`, and `∑(f T)² = 2ⁿQ`
+  (second_moment_identity). Combine: 2ⁿ = central+tail ≤ (L+1)+tail and tail·(L+1)² ≤ 2ⁿQ.
+- **anticoncentration_bound** (axiom→theorem): apply powerset_interval_chebyshev at
+  `L = Nat.sqrt(4Q)`. Then `(L+1)² > 4Q` (Nat.lt_succ_sqrt) and `L ≤ 2√Q` (Nat.sqrt_le).
+  Real chain: from `(x−m)m² ≤ xQ` and `4Q<m²` (x=2ⁿ,m=L+1): step1 `4(x−m)m² < x·m²`
+  (×4 on hA, ×x on hB), step2 `3x<4m` (÷m²>0 via nlinarith product trick), then
+  `x < (4/3)m ≤ (4/3)(2√Q+1) ≤ 3√Q+2`. NO probability theory, NO Q>0 needed (chain valid as-is).
+
+### GOTCHAs (for future sessions)
+- **Generalized card_mul_le_second_moment** from `(s:Finset ℕ)` to `{α}(s:Finset α)` so it
+  applies over `A.powerset : Finset (Finset ℕ)`. Proof body unchanged (added `classical`).
+- `-L ≤ x` from `x²<(L+1)²` is NOT real-valid (fails at x=−L−0.5) — MUST get strict
+  `-(L+1)<x` via nlinarith [sq_nonneg(x+(L+1))], THEN omega (integrality) to `-L≤x`.
+- `Nat.cast_nonneg s` bare ⇒ "IsOrderedRing ?m stuck" (ambiguous target). Annotate
+  `(Nat.cast_nonneg s : (0:ℝ) ≤ (s:ℝ))`.
+- `Nat.lt_succ_sqrt`/`Nat.sqrt_le` give `Nat.sqrt(4Qn)` not the `set s` var — `rw [← hs] at h`.
+- Casting ℤ→ℝ: keep the goal in EXPLICIT form (no `set x/mr/qr`) so `exact_mod_cast hPIC/hB`
+  matches; `set` makes the reals opaque to norm_cast.
+- nlinarith `3x<4m` from `4(x−m)m²<x·m²` + `0<m²`: works because neg-goal×(m²>0) gives the
+  refuting product (nlinarith ring-normalizes both sides).
+
+### Status: COMPLETE (axiom eliminated; file VERIFIED 0-axiom). The sharp √(2/π) DFX constant
+(vs the Chebyshev 3 proved here) remains the only open formalization direction — that one
+genuinely needs Berry-Esseen/CLT for discrete distributions.

--- a/research/problems/erdos-1005-oq-02/knowledge.md
+++ b/research/problems/erdos-1005-oq-02/knowledge.md
@@ -174,3 +174,44 @@ content, unused); left as-is.
 
 NOTE: this touches the `Provable` file, **not** the active OQ02 continuant theory
 (§16–§21) — no overlap with the in-flight Stern–Brocot / 1-12-constant frontier.
+
+## Session 2026-06-28 (researcher-1): §22 constant-quotient continuant trichotomy
+
+PR (VERIFIED, 0-axiom; docker-build.sh clean, 3058 jobs; no native_decide/sorry/axiom
+in §22 — only linarith/nlinarith/ring/induction/mul_le_mul, foundational axioms only).
+Closed the missing third regime of the constant-quotient continuant K([k]^n), unifying
+§20 (all-`2`, linear) and §21 (all-`1`, bounded/period-6) under one recurrence.
+
+Six new theorems, no new def:
+- **continuant_replicate_recurrence** (HEADLINE): K([k]^(n+2)) = k·K([k]^(n+1)) − K([k]^n)
+  — the Chebyshev/Dickson 2nd-order recurrence x²=kx−1, char. roots (k±√(k²−4))/2.
+  Both §20 (k=2, disc 0, double root 1 → linear) and §21 (k=1, disc −3, |root|=1 →
+  period 6) are discriminant instances. Proof: replicate_succ ×2 + continuant_cons +
+  `simp only [secondCont]` (secondCont(k::ks)=Continuant ks defeq did NOT auto-close
+  rw's rfl — needed explicit simp only [secondCont]).
+- **continuant_replicate_mono** (k≥2): K([k]^n) < K([k]^(n+1)), from §20-style
+  continuant_strict_mono since every entry = k ≥ 2.
+- **continuant_replicate_geometric_step** (k≥2): (k−1)·K([k]^(n+1)) ≤ K([k]^(n+2)) —
+  from the recurrence this is exactly monotonicity K([k]^n)≤K([k]^(n+1)). GOTCHA:
+  nlinarith won't expand (k−1)·A; rewrite (k−1)·A = k·A − A via `ring` first, then
+  linarith treats k·A as one atom.
+- **continuant_replicate_pow_le** (k≥2): (k−1)^n ≤ K([k]^(n+1)) — induction on the
+  geometric step. Brackets the constant continuant from BELOW to match the K([k]^n)≤k^n
+  product ceiling (cf. open PR #31379 product upper bound — complementary, (k−1)^n ≤ K ≤ k^n).
+- **continuant_replicate_exp_ge_two** (k≥3, HEADLINE): 2^n ≤ K([k]^(n+1)) — the third
+  regime: common quotient ≥3 forces EXPONENTIAL growth. Self-contained induction
+  (avoided pow_le_pow_left name-churn risk; used mul_le_mul_of_nonneg_left/right + the
+  geometric step). Base case `List.replicate (0+1) k = [k]` by rfl (NOT List.replicate_one
+  — `0+1` vs `1` syntactic mismatch under rw).
+- **continuant_replicate_recurrence_two**: k=2 specialisation as a consistency check
+  recovering the §20 arithmetic ladder.
+
+SIGNIFICANCE: completes the constant-quotient trichotomy. K([k]^n) is governed by ONE
+linear recurrence whose discriminant k²−4 partitions behaviour: k=1 bounded (§21),
+k=2 linear (§20), k≥3 exponential (§22, ≥2^n). Order-side statement that long constant
+runs are metrically cheap ONLY for k≤2; quotient ≥3 makes the Farey run endpoints
+exponentially expensive (via §14 closed form). Mixed-quotient regime (open 1/12–1/4
+constant, van Doorn 2025) untouched — remains the hard frontier.
+
+REMAINING (unchanged hard part): aggregate explicit break windows along a Stern–Brocot
+path toward the open 1/12 constant.

--- a/research/problems/van-der-waerden-first-moment-oq-01/knowledge.md
+++ b/research/problems/van-der-waerden-first-moment-oq-01/knowledge.md
@@ -19,3 +19,37 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-06-28 (researcher-1) — SURVEY: OQ already SOLVED and over-delivered
+
+**Mode**: SURVEY (no code change — the problem is already solved beyond what it asked).
+**State**: `VanDerWaerdenFirstMomentOQ01.lean` (152 lines) is COMPLETE, 0 sorries / 0 axioms /
+no native_decide; `#print axioms` = propext/Classical.choice/Quot.sound only.
+
+### The OQ is solved, and sharpened by a factor of 2
+The open question asked to sharpen the base entry's loose family bound `|vdwFamily| ≤ n²`
+to `~ n²/(k-1)` by bounding the AP step. The file does BETTER — it computes the exact
+parameter count and extracts `2(k-1)·|family| ≤ n²`, i.e. `|family| ≤ n²/(2(k-1))`, twice
+as sharp as requested. Key chain (all elementary, on top of the base entry's verified
+`vdwAP`/`vdwFamily`/`vdw_two_coloring_exists`):
+- `vdwFilter_card_eq_sum`: exact box count = ∑_{d=1}^{n}(n−(k−1)d) (group by step, fiberwise
+  `card_filter_lt`).
+- `two_mul_sum_sq_le`: telescoping-of-squares `2c·∑(N−cd) + (N−cm)² ≤ N²` (per-step slack
+  `2c(N−cd) ≤ (N−c(d−1))²−(N−cd)²`, induction on m).
+- `card_vdwFamily_two_mul_le`: `2(k−1)|family| ≤ n²`.
+- `vdw_lower_bound_sharp`: `n² < 2(k−1)·2^(k−1) ⟹ ∃ 2-colouring` ⟹ `W(k) ≳ √(2(k−1))·2^((k−1)/2)`
+  (a √(2(k−1)) factor over the base `n² < 2^(k−1)`).
+
+### Concrete follow-up direction (for the Seeker / a future ACT session)
+The family bound is `≤` (via `Finset.card_image_le`). It can be upgraded to EQUALITY —
+exact enumeration of length-k APs in [n] — because for `k ≥ 2`, `d ≥ 1` and fitting
+`a+(k−1)d<n` (no wraparound), the map `(a,d) ↦ vdwAP n a d k` is INJECTIVE on the box:
+`a = min` of the value-set and `d = (2nd smallest − min)`. Proving `vdwAP` InjOn the fitting
+box (recover a,d from the Finset (Fin n)) would give `card_vdwFamily_eq_sum` (=, not ≤) and
+a precise count `∑_{d:(k−1)d<n}(n−(k−1)d)`. Estimated ~40–60 lines (the fiddly part is
+min/2nd-min of an image set of `Fin n` casts). NOTE: this does NOT improve the lower-bound
+threshold (which only needs ≤) — it is an exact-enumeration / sharp-boundary refinement, not
+a strengthening of `vdw_lower_bound_sharp`. Honest assessment: nice-to-have, not high-value
+for the OQ itself, which is already solved.
+
+### Status: SOLVED (no further high-value code increment; over-delivers on the OQ).

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -2,12 +2,12 @@
   "id": "erdos-1-oq-02",
   "title": "Dubroff–Fox–Xu Subset Sum Lower Bound Framework",
   "slug": "erdos-1-oq-02",
-  "description": "Formalizes the algebraic framework for the Dubroff–Fox–Xu (2021) lower bound N ≥ √(2/π) · 2ⁿ/√n for the distinct subset sums problem (Erdős #1). Proves variance bounds (sum of squares ≤ n·N², sum ≤ n·N) and axiomatizes the anticoncentration step from Berry–Esseen.",
+  "description": "Formalizes the Dubroff–Fox–Xu (2021) lower bound N = Ω(2ⁿ/√n) for the distinct subset sums problem (Erdős #1), with the Chebyshev anticoncentration step 2ⁿ ≤ 3√(Σaᵢ²)+2 now FULLY PROVED (0 axioms) by an elementary probability-free discrete second-moment argument. Proves variance bounds (sum of squares ≤ n·N², Cauchy–Schwarz), the second-moment identity over the powerset, a central-interval + Chebyshev count, and assembles the order-correct bound 2ⁿ ≤ 3√n·N + 2.",
   "meta": {
     "author": "Dubroff, Fox, Xu (2021); framework formalized 2026",
     "sourceUrl": "https://erdosproblems.com/1",
     "date": "2021",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1OQ02.lean",
     "tags": [
       "additive-combinatorics",
@@ -15,13 +15,14 @@
       "distinct-subset-sums",
       "variance",
       "anticoncentration",
-      "berry-esseen"
+      "second-moment",
+      "chebyshev"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
-    "axiomCount": 1,
-    "lineCount": 399,
-    "assumptions": "One axiom: anticoncentration_bound (Berry-Esseen anticoncentration for subset sums). dfx_lower_bound and pow2_dss proved in 2026-04-26 commit. sum_sq_cauchy_schwarz proved via induction in Z.",
+    "axiomCount": 0,
+    "lineCount": 540,
+    "assumptions": "None. The former anticoncentration_bound axiom (Chebyshev step 2ⁿ ≤ 3√Q+2) is now a proved theorem via second_moment_identity + powerset_interval_chebyshev (central-interval count + discrete Chebyshev) optimised at L=⌊√(4Q)⌋. #print axioms anticoncentration_bound / dfx_lower_bound = [propext, Classical.choice, Quot.sound] only (no sorryAx, no native_decide).",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -50,24 +51,27 @@
       "sum_sq_le_card_mul_max_sq: Σa² ≤ |A|·N² (crude variance upper bound, term-by-term)",
       "sum_sq_cauchy_schwarz: (Σa)² ≤ |A|·Σa² (Cauchy-Schwarz, proved by ℤ-lifting + Finset induction)",
       "sum_le_card_mul_max: Σa ≤ |A|·max(A) (sum bounded by n times the maximum element)",
-      "anticoncentration_bound axiom: Berry-Esseen step 2^n ≤ √(2/π)·2(ΣA+1)/√(Σa²) for distinct subset sum sets",
-      "dfx_lower_bound: N ≥ √(2/π)·2ⁿ/√n (1 sorry for base-case arithmetic) — assembles the DFX framework",
+      "anticoncentration_bound: 2ⁿ ≤ 3√(Σa²)+2 for distinct-subset-sum sets — PROVED (0 axioms, 2026-06-28), formerly an axiom, via an elementary probability-free discrete second-moment argument",
+      "second_moment_identity: ∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σa² — exact discrete variance identity over the powerset, by Finset induction",
+      "powerset_interval_chebyshev: (2ⁿ−(L+1))·(L+1)² ≤ 2ⁿ·Σa² — central-interval count (card_le_of_sameParity_interval) + discrete Chebyshev tail (card_mul_le_second_moment) combined, parameter-free over all cutoffs L",
+      "card_doubledDrop_image_of_distinct / doubledDrop_injOn_of_distinct: the 2^|A| doubled subset-sum deviations are 2^|A| distinct same-parity integers",
+      "dfx_lower_bound: 2ⁿ ≤ 3√n·N + 2 (N = Ω(2ⁿ/√n)) — assembles the DFX framework, 0 sorries, 0 axioms",
       "dfx_improves_counting: DFX bound is asymptotically better than counting bound (n < n² for n ≥ 2)",
       "Concrete cases: f(1)=1 via Finset.subset_singleton_iff, f(2)=2 via simp"
     ],
-    "theoremCount": 10,
+    "theoremCount": 16,
     "definitionCount": 0
   },
   "overview": {
     "historicalContext": "Erdős Problem #1 ($500 prize) asks: if $A \\subseteq \\{1,\\ldots,N\\}$ has $n$ elements with all $2^n$ subset sums distinct, must $N \\geq c \\cdot 2^n$? Erdős conjectured the answer is yes with $c = 1/\\sqrt{2}$, matching the Conway–Guy sequence. The basic counting bound (1964) gives $N \\geq (2^n-1)/n$: since the sums lie in $[0, nN]$ with $nN+1$ possible values and there are $2^n$ sums, we need $nN + 1 \\geq 2^n$.\n\nDubroff, Fox, and Xu (2021) improved this to $N \\geq \\sqrt{2/\\pi} \\cdot 2^n/\\sqrt{n}$ using a variance-based anticoncentration argument rooted in the Berry–Esseen theorem. Their key idea: view the $2^n$ subset sums as values of the random variable $X = \\sum_{i=1}^n \\varepsilon_i a_i$ where $\\varepsilon_i \\in \\{0,1\\}$ are i.i.d. Bernoulli(1/2). The distinct subset sums condition forces $X$ to take $2^n$ distinct values. By the normal approximation, the density of $X$ is approximately Gaussian with mean $S/2$ and variance $V = \\sum a_i^2/4$; the anticoncentration of the Gaussian limits the number of distinct achievable values to $\\sim S/\\sqrt{V}$. Using Cauchy–Schwarz ($V \\geq S^2/(4n)$) and $S \\leq nN$, this gives $N \\geq \\sqrt{2/\\pi} \\cdot 2^n/\\sqrt{n}$, improving the counting bound by $\\sqrt{n}$.\n\nThe gap between DFX ($\\sim 2^n/\\sqrt{n}$) and the conjectured optimum ($\\sim 2^n/\\sqrt{2}$) remains open. The Conway–Guy sequence (formalized in the companion erdos-1-oq-03) suggests the true answer is $N \\sim 2^n/\\sqrt{2}$, but this has not been proved.",
     "problemStatement": "**Theorem (DFX 2021)**: If A ⊆ {1,...,N} has n elements with all 2ⁿ subset sums distinct, then N ≥ √(2/π) · 2ⁿ/√n.",
-    "text": "Formalizes the framework for the DFX lower bound, including variance bounds and the anticoncentration axiom.",
-    "proofStrategy": "The proof proceeds in three stages: (1) **Variance bounds** — for A ⊆ {1,…,N}, Σaᵢ² ≤ n·N² (term-by-term) and the Cauchy–Schwarz bound (Σaᵢ)² ≤ n·Σaᵢ² (lifted to ℤ for nlinarith). (2) **Anticoncentration axiom** — `anticoncentration_bound`: if A has distinct subset sums then 2^{|A|} ≤ 3·√(Σaᵢ²) + 2. This is the rigorous Chebyshev form (the sharp √(2/π) constant from Berry–Esseen is the literature result, not formalized). (3) **Assembly** — combine √(Σaᵢ²) ≤ √n·N (from Σaᵢ²≤n·N²) with the axiom to derive 2ⁿ ≤ 3·√n·N + 2, i.e. N = Ω(2ⁿ/√n). Fully proved, 0 sorries. The √n improvement over the counting bound is verified separately via n < n² for n ≥ 2.",
+    "text": "Formalizes the DFX lower bound — variance bounds plus the Chebyshev anticoncentration step, now fully proved (0 axioms) by a discrete second-moment argument.",
+    "proofStrategy": "The proof proceeds in three stages: (1) **Variance bounds** — for A ⊆ {1,…,N}, Σaᵢ² ≤ n·N² (term-by-term) and the Cauchy–Schwarz bound (Σaᵢ)² ≤ n·Σaᵢ² (lifted to ℤ for nlinarith). (2) **Anticoncentration theorem (0 axioms)** — `anticoncentration_bound`: if A has distinct subset sums then 2^{|A|} ≤ 3·√(Σaᵢ²) + 2, now PROVED (not axiomatized) by an elementary probability-free discrete second-moment argument. The exact identity ∑_{T⊆A}(2·ΣT−S)² = 2^{|A|}·Σaᵢ² (`second_moment_identity`), the fact that the 2^{|A|} doubled deviations are distinct same-parity integers (`card_doubledDrop_image_of_distinct`), a central-interval count (`card_le_of_sameParity_interval`) and a discrete Chebyshev tail (`card_mul_le_second_moment`) combine into the parameter-free integer inequality (2ⁿ−(L+1))·(L+1)² ≤ 2ⁿ·Σaᵢ² (`powerset_interval_chebyshev`), optimised at the cutoff L=⌊√(4Σaᵢ²)⌋ via Nat.sqrt/Real.sqrt to give the Chebyshev constant 3. (The sharp √(2/π) constant from Berry–Esseen is the literature result, not formalized.) (3) **Assembly** — combine √(Σaᵢ²) ≤ √n·N (from Σaᵢ²≤n·N²) with the theorem to derive 2ⁿ ≤ 3·√n·N + 2, i.e. N = Ω(2ⁿ/√n). Fully proved, 0 sorries, 0 axioms. The √n improvement over the counting bound is verified separately via n < n² for n ≥ 2.",
     "keyInsights": [
       "The Dubroff-Fox-Xu argument converts the distinct subset sums constraint into an anticoncentration problem. View the random variable $X = \\sum_{i=1}^n \\varepsilon_i a_i$ where $\\varepsilon_i \\in \\{0, 1\\}$ are i.i.d. Bernoulli(1/2). The distinct subset sums condition forces $X$ to take $2^n$ distinct values in $[0, S]$ (where $S = \\sum a_i$). Anticoncentration says $X$ cannot concentrate too much, bounding the number of achievable values.",
       "The quantitative anticoncentration step (the `anticoncentration_bound` axiom) is, in its rigorous Chebyshev form, 2ⁿ ≤ 3·√(Σaᵢ²) + 2. Derivation: view X = Σ εᵢaᵢ with εᵢ i.i.d. Bernoulli(1/2); then E[X]=S/2 and Var[X]=Σaᵢ²/4, so σ=√(Σaᵢ²)/2. Chebyshev gives P(|X−S/2|<k) ≥ 1−Σaᵢ²/(4k²). Because the subset sums are DISTINCT integers, the values within an open interval of length 2k number at most 2k+1, each of probability 2⁻ⁿ; taking k=√(Σaᵢ²) yields (3/4)·2ⁿ ≤ 2√(Σaᵢ²)+1 ≤ 3√(Σaᵢ²)+2. The sharp DFX constant √(2/π) instead comes from Berry–Esseen (the Gaussian density normalization 1/√(2π)); the Chebyshev constant 3 used here is weaker but unconditionally true and still captures the √n improvement. (The earlier formulation 2ⁿ ≤ √(2/π)·2(S+1)/√(Σaᵢ²) was FALSE — it fails already for A={1,2}.)",
       "The variance bound `sum_sq_cauchy_schwarz` proves $\\left(\\sum_{a \\in A} a\\right)^2 \\leq |A| \\cdot \\sum_{a \\in A} a^2$ (Cauchy-Schwarz). In the DFX framework: $V = \\sum a_i^2/4 \\geq (\\sum a_i)^2/(4n) = S^2/(4n)$. This gives the lower bound on variance in terms of the mean, which is the key inequality connecting $\\sum a_i$ to $\\max(a_i)$.",
-      "The `anticoncentration_bound` axiom encodes the Berry-Esseen step as: if $A$ has distinct subset sums then $\\max(A) \\geq c \\cdot 2^{|A|} / |A|$ for some constant $c$. This is axiomatized because the full Berry-Esseen argument requires: (1) probability theory on finite probability spaces, (2) the normal approximation, (3) quantitative anticoncentration bounds. None of these are currently streamlined in Mathlib for this specific use case.",
+      "The `anticoncentration_bound` theorem (0 axioms, proved 2026-06-28) gives the Chebyshev step 2^{|A|} ≤ 3·√(Σaᵢ²) + 2. Rather than going through probability theory (Berry-Esseen / a probability space), it is proved by an elementary discrete second-moment argument: the exact identity ∑_{T⊆A}(2·ΣT−S)² = 2^{|A|}·Σaᵢ², the 2^{|A|} distinct same-parity integer subset sums, a central-interval count and a discrete Chebyshev/Markov tail, combined into (2ⁿ−(L+1))·(L+1)² ≤ 2ⁿ·Σaᵢ² and optimised at L=⌊√(4Σaᵢ²)⌋. This sidesteps the Mathlib probability infrastructure entirely.",
       "The `dfx_improves_counting` theorem proves the DFX bound is better than the basic counting bound $(2^n - 1)/n$ for $n \\geq 2$: i.e., $\\sqrt{2/\\pi} \\cdot 2^n/\\sqrt{n} > (2^n-1)/n$ for large $n$. This asymptotic improvement is the main point of the DFX result — the DFX bound is tighter by a factor of $\\sqrt{n}$.",
       "The gap between the DFX lower bound and the Conway–Guy upper bound is a constant factor only: both are $\\Theta(2^n/\\sqrt{n})$. The DFX lower bound gives $c_1 \\cdot 2^n/\\sqrt{n}$ with $c_1 = \\sqrt{2/\\pi} \\approx 0.798$; the Conway–Guy sequence gives the upper bound with $c_2 \\approx 0.220$ (the sequence achieves $N \\approx c_2 \\cdot 2^n$ but the growth factor in $n$ matches). Erdős conjectured the true constant is $1/\\sqrt{2} \\approx 0.707$, with the Conway–Guy sequence as the extremal example. The formalization split — lower bound here (OQ-02) and upper bound in OQ-03 — mirrors this upper/lower bound duality.",
       "The single `sorry` in `dfx_lower_bound` reveals a fundamental tension between asymptotic mathematics and formal verification: the DFX bound $N \\geq \\sqrt{2/\\pi} \\cdot 2^n/\\sqrt{n}$ is an **asymptotic result** that fails for small $n$. For $n = 1$: the set $\\{1\\}$ has all subset sums distinct ($\\{0, 1\\}$), but $\\max(A) = 1 < \\sqrt{2/\\pi} \\cdot 2/1 \\approx 1.60$. The mathematical paper implicitly restricts to large $n$; Lean forces this to be explicit. A complete formalization would take one of two forms: (1) state the theorem for $n \\geq n_0$ and use `norm_num` or `decide` for base cases $n < n_0$; or (2) add the restriction $n \\geq 2$ to the hypothesis. This is a case where formal verification adds genuine value over the original paper — it pinpoints exactly where the 'for large $n$' assumption enters and forces the threshold to be made explicit."
@@ -106,11 +110,11 @@
     },
     {
       "id": "part-ii-anticonc",
-      "title": "Part II: Anticoncentration Axiom and DFX Main Bound",
+      "title": "Part II: Anticoncentration Theorem (0 axioms) and DFX Main Bound",
       "startLine": 121,
       "endLine": 160,
-      "summary": "Axiom anticoncentration_bound (Berry-Esseen step). Theorem dfx_lower_bound (1 sorry): assembles the variance bounds and anticoncentration axiom to derive N ≥ √(2/π)·2ⁿ/√n. Theorem dfx_improves_counting: the DFX bound is asymptotically better than the basic counting bound.",
-      "mathContext": "`anticoncentration_bound` axiom: $2^n \\leq \\sqrt{2/\\pi} \\cdot 2(S+1)/\\sqrt{\\sum a^2}$. This axiomatizes the normal anticoncentration: $\\mathcal{N}(S/2, V)$ has density $\\leq 1/\\sqrt{2\\pi V}$, so at most $S/\\sqrt{2\\pi V} = S\\sqrt{2/\\pi}/\\sqrt{\\sum a^2/2}$ distinct values can each receive probability mass $\\geq 1/\\sqrt{2\\pi V}$. The `sorry` in `dfx_lower_bound` is at the real-arithmetic assembly: combining $2^n \\lesssim S\\sqrt{n}/S = \\sqrt{n}$ and $S \\leq nN$ to isolate $N$."
+      "summary": "Theorem anticoncentration_bound (Chebyshev step 2ⁿ ≤ 3√Q+2), proved 0-axiom via the discrete second-moment ingredients (second_moment_identity, card_doubledDrop_image_of_distinct, card_le_of_sameParity_interval, card_mul_le_second_moment, powerset_interval_chebyshev). Theorem dfx_lower_bound (0 sorries): assembles the variance bounds and the anticoncentration theorem to derive 2ⁿ ≤ 3√n·N + 2. Theorem dfx_improves_counting: the DFX bound is asymptotically better than the basic counting bound.",
+      "mathContext": "`anticoncentration_bound`: $2^n \\leq 3\\sqrt{\\sum a^2} + 2$, proved (not assumed). The discrete second moment $\\sum_{T\\subseteq A}(2\\Sigma_T - S)^2 = 2^n\\sum a^2$ together with the fact that the $2^n$ doubled deviations are distinct same-parity integers gives, via a central-interval count plus a discrete Chebyshev/Markov tail, the integer inequality $(2^n-(L+1))(L+1)^2 \\le 2^n\\sum a^2$; optimising the cutoff at $L=\\lfloor\\sqrt{4\\sum a^2}\\rfloor \\approx 2\\sqrt{\\sum a^2}$ yields the Chebyshev constant $3$."
     },
     {
       "id": "part-iii-concrete",
@@ -122,10 +126,10 @@
     }
   ],
   "conclusion": {
-    "summary": "The DFX 2021 framework is formalized: variance bounds (Σaᵢ²≤n·N² and Cauchy–Schwarz) and a single anticoncentration axiom. The main lower bound 2ⁿ ≤ 3·√n·N + 2 (i.e. N = Ω(2ⁿ/√n)) is fully proved with 0 sorries. INTEGRITY FIX (2026-06-28): the previous anticoncentration axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was mathematically FALSE (e.g. A={1,2} makes it assert 4 ≤ 2.85), which rendered the file logically unsound; it was replaced with the true Chebyshev bound `2ⁿ ≤ 3·√Q + 2`. The file (which had also broken on the Mathlib 4.26 toolchain bump: div_le_iff→div_le_iff₀, a simp recursion, an nlinarith cast mismatch, and omega on a nonlinear goal) now compiles cleanly with 1 axiom. Progress (2026-06-28): the probability-free core of the axiom's discharge is now proved in-file with 0 axioms — second_moment_identity (∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σaᵢ²) and card_mul_le_second_moment (discrete Chebyshev tail count). The only remaining step to eliminate the axiom is the same-parity distinct-integer central-interval count.",
+    "summary": "The DFX 2021 framework is formalized with 0 axioms and 0 sorries. Variance bounds (Σaᵢ²≤n·N² and Cauchy–Schwarz) plus the Chebyshev anticoncentration step 2ⁿ ≤ 3√(Σaᵢ²)+2 (anticoncentration_bound) — now a PROVED theorem — assemble into the main lower bound 2ⁿ ≤ 3·√n·N + 2 (N = Ω(2ⁿ/√n)). AXIOM ELIMINATED (2026-06-28): the anticoncentration step is discharged by an elementary probability-free discrete second-moment argument — second_moment_identity (∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σaᵢ²), card_doubledDrop_image_of_distinct (2^|A| distinct same-parity integers), card_le_of_sameParity_interval (central-interval count), card_mul_le_second_moment (discrete Chebyshev tail), combined in powerset_interval_chebyshev into (2ⁿ−(L+1))·(L+1)²≤2ⁿ·Σaᵢ² and optimised at L=⌊√(4Σaᵢ²)⌋. #print axioms = [propext, Classical.choice, Quot.sound] only. EARLIER INTEGRITY FIX: a prior axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was mathematically FALSE (A={1,2} asserts 4 ≤ 2.85) and was corrected to the true Chebyshev bound before being proved.",
     "implications": "The Dubroff-Fox-Xu result is currently the best known lower bound for Erdős's distinct subset sums problem (Problem #1, $500 prize). The gap between the lower bound ~2ⁿ/√n and the upper bound ~2ⁿ (from the Conway-Guy sequence) is a factor of √n. Closing this gap requires either a new construction (improving the upper bound) or a new anticoncentration argument (improving the lower bound). Formalizing the full Berry-Esseen step would complete the proof in Lean.",
     "openQuestions": [
-      "Can the `anticoncentration_bound` axiom be proved in Lean? This requires: (1) formalizing the Bernoulli random walk on $\\{0, a_1, \\ldots, a_1 + a_2, \\ldots\\}$, (2) proving Berry-Esseen bounds for discrete distributions, (3) counting distinct sum values via the normal approximation. Mathlib's `ProbabilityTheory.ConditionalExpectation` and `CLT` developments are the entry points.",
+      "RESOLVED (2026-06-28): the `anticoncentration_bound` (Chebyshev constant 3) is now proved in Lean — but via an elementary discrete second-moment argument rather than the probability route, sidestepping Berry-Esseen/CLT entirely. Open: can the SHARP √(2/π) DFX constant (not just the Chebyshev 3) be formalized? That genuinely requires Berry-Esseen bounds for discrete distributions; Mathlib's `ProbabilityTheory.CLT` developments are the entry points.",
       "Can `anticoncentration_bound` be discharged from Mathlib? The Chebyshev form 2ⁿ ≤ 3·√(Σaᵢ²)+2 needs only (1) the variance computation Var(Σεᵢaᵢ)=Σaᵢ²/4 and (2) Chebyshev's inequality (`ProbabilityTheory.meas_ge_le_variance_div_sq` or `Finset`-level second-moment bounds), together with the distinct-integer counting step — no Berry–Esseen needed. Recovering the sharp √(2/π) constant would additionally require a local CLT / Berry–Esseen bound.",
       "Can the Conway-Guy sequence (believed to give the optimal upper bound for Erdős #1) be formalized? The sequence gives a DSS set with $\\max(A) \\approx c \\cdot 2^n / \\sqrt{n}$, matching the DFX lower bound up to a constant.",
       "Is there a direct proof of the DFX bound that avoids Berry-Esseen and instead uses only combinatorial anticoncentration? Recent work on 'additive energy' and 'Roth-type' arguments in additive combinatorics might provide a more elementary path."
@@ -211,15 +215,15 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 399,
-    "axiomCount": 1,
-    "theoremCount": 14,
+    "lineCount": 540,
+    "axiomCount": 0,
+    "theoremCount": 16,
     "definitionCount": 0,
     "path": "Proofs/Erdos1OQ02.lean",
     "sorries": 0
   },
   "sorries": 0,
-  "assumptions": "One axiom: anticoncentration_bound — the Chebyshev anticoncentration bound 2ⁿ ≤ 3·√(Σaᵢ²) + 2 for distinct-subset-sum sets. It is unconditionally true (Chebyshev's inequality applied to X = Σ εᵢaᵢ, plus the distinctness counting argument) and in principle dischargeable from Mathlib's `ProbabilityTheory` Chebyshev lemmas. dfx_lower_bound and the variance/Cauchy–Schwarz lemmas are fully proved (0 sorries). NOTE: the earlier axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was FALSE and has been corrected. Progress (2026-06-28): the probability-free core of the axiom's discharge is now proved in-file with 0 axioms — second_moment_identity (∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σaᵢ²) and card_mul_le_second_moment (discrete Chebyshev tail count). The only remaining step to eliminate the axiom is the same-parity distinct-integer central-interval count.",
+  "assumptions": "None — fully verified, 0 axioms. The Chebyshev anticoncentration bound 2ⁿ ≤ 3·√(Σaᵢ²) + 2 (anticoncentration_bound) was previously axiomatized but is now PROVED (2026-06-28) by an elementary probability-free discrete second-moment argument: second_moment_identity (∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σaᵢ²), card_doubledDrop_image_of_distinct (the 2ⁿ subset sums are 2ⁿ distinct same-parity integers), card_le_of_sameParity_interval (central-interval count) and card_mul_le_second_moment (discrete Chebyshev tail), combined in powerset_interval_chebyshev into (2ⁿ−(L+1))·(L+1)² ≤ 2ⁿ·Q, then optimised at L=⌊√(4Q)⌋. #print axioms = [propext, Classical.choice, Quot.sound] only (no sorryAx, no native_decide). NOTE: an earlier axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was FALSE and was corrected before being proved.",
   "highlights": [
     "Central-interval count landed (card_le_of_sameParity_interval, 0-axiom): a finite set of integers all of one parity confined to [-L,L] has <= L+1 elements (via v |-> (v+L)/2 injecting into Icc 0 L). This is the LAST combinatorial input to discharging anticoncentration_bound with the sharp constant 3 -- joins second_moment_identity, the 2^|A|-distinct-integers image, and the Chebyshev tail. Only the real-sqrt optimization assembly remains.",
     "Verified inputs toward discharging the anticoncentration axiom (0-axiom): subset sums are injective on the powerset for a distinct-subset-sums set (subsetSum_injOn_of_distinct), hence the 2^|A| doubled deviations 2*Sum_T - S are 2^|A| DISTINCT integers (card_doubledDrop_image_of_distinct) -- the precise 'distinct integers' input to the central-interval count that recovers the sharp constant 3. Joins second_moment_identity + card_mul_le_second_moment; only the parity-aware interval count + real-sqrt combine remain."


### PR DESCRIPTION
Two independent verified, 0-axiom research increments.

## 1. erdos-1-oq-02 — Dubroff–Fox–Xu: **last axiom eliminated** (file now fully VERIFIED)

`Erdos1OQ02.lean` previously carried a single axiom, `anticoncentration_bound`
(the Chebyshev anticoncentration step `2ⁿ ≤ 3√(Σaᵢ²) + 2`). This PR **discharges it**,
completing a multi-session effort whose combinatorial ingredients were already in place.

- `powerset_interval_chebyshev` (the assembly step prior sessions flagged as the only
  remaining piece): for every cutoff `L ≥ 0`, `(2ⁿ − (L+1))·(L+1)² ≤ 2ⁿ·Q` — partition the
  powerset into a central band (`≤ L+1` distinct same-parity integers, via
  `card_le_of_sameParity_interval`) and a tail bounded by the discrete Chebyshev/Markov
  inequality (`card_mul_le_second_moment`) against the second moment `2ⁿ·Q`
  (`second_moment_identity`).
- `anticoncentration_bound` (axiom → **theorem**): apply the above at `L = ⌊√(4Q)⌋`
  (`Nat.sqrt`), where `(L+1)² > 4Q` and `L ≤ 2√Q`, then a short real optimisation gives
  `2ⁿ < (4/3)(2√Q + 1) ≤ 3√Q + 2`. No probability theory used.
- Generalised `card_mul_le_second_moment` to an arbitrary index type.

**Result**: `Erdos1OQ02.lean` is now **0 axioms, 0 sorries**.
`#print axioms anticoncentration_bound / dfx_lower_bound / powerset_interval_chebyshev`
= `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `native_decide`).
`docker-build.sh` clean (7744 jobs). meta.json updated `axiomatized → verified`,
`axiomCount 1 → 0`.

## 2. erdos-1005-oq-02 — §22 constant-quotient continuant trichotomy

Completes the constant-quotient picture of the §14 continuant: §20 (all-`2`, linear) and
§21 (all-`1`, bounded/period-6) are unified under one second-order recurrence
`continuant_replicate_recurrence`: `K([k]^(n+2)) = k·K([k]^(n+1)) − K([k]^n)`
(Chebyshev/Dickson, discriminant `k²−4`). The missing third regime is closed:
`continuant_replicate_exp_ge_two` (`k ≥ 3`): `2ⁿ ≤ K([k]^(n+1))` — exponential growth.
Plus monotonicity, geometric step, and the `(k−1)ⁿ` lower bracket. Foundational axioms
only (no `native_decide`/`sorry`/`axiom`); `docker-build.sh` clean (3058 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)