### PR TITLE
research(erdos-1004-oq-02): effective totient finite-to-one — Finset enumeration domain + cardinality bound [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1004OQ02.lean
+++ b/proofs/Proofs/Erdos1004OQ02.lean
@@ -26,6 +26,11 @@ totient value is attained by only finitely many integers (`totient_fiber_finite`
 (★) is **sharp** at `n = 2`, where `2·φ(2)² = 2·1 = 2`.  A real-analytic
 restatement `√(n/2) ≤ φ(n)` is recorded as well.
 
+The finiteness is moreover **effective**: the fiber over `v` is recovered by a
+finite search of `Iic (2v²)` (`totient_fiber_eq_filter`), giving a decidable
+enumeration domain and the explicit cardinality bound `#{n : φ(n)=v} ≤ 2v²+1`
+(`totient_fiber_ncard_le`), which is **sharp at `v = 0`**.
+
 ## The idea
 Both bounds are *multiplicative invariants*.  Factoring `n` into coprime
 prime powers, the inequality is tight only at the single prime power `2¹`
@@ -169,5 +174,57 @@ theorem totient_ge_sqrt_half (n : ℕ) :
   calc Real.sqrt ((n : ℝ) / 2)
         ≤ Real.sqrt ((Nat.totient n : ℝ) ^ 2) := Real.sqrt_le_sqrt h2
     _ = (Nat.totient n : ℝ) := Real.sqrt_sq (by positivity)
+
+/-! ### Effective finite-to-one: enumeration domain and explicit cardinality
+
+`totient_fiber_finite` is qualitative.  The fiber bound `n ≤ 2v²` makes the
+finiteness *effective*: the whole fiber is recovered by a finite search over
+`Iic (2v²)`, giving both a decidable enumeration domain and an explicit
+cardinality bound.  The cardinality bound is **sharp at `v = 0`**. -/
+
+/-- **Effective fiber description.** The (a priori infinite) set of integers with
+totient `v` equals the coercion of an explicit, computable `Finset`: it suffices
+to search the initial segment `Iic (2v²)`.  This upgrades the qualitative
+`totient_fiber_finite` to a concrete decidable enumeration domain. -/
+theorem totient_fiber_eq_filter (v : ℕ) :
+    {n : ℕ | Nat.totient n = v}
+      = ↑((Finset.Iic (2 * v ^ 2)).filter (fun n => Nat.totient n = v)) := by
+  ext n
+  simp only [Finset.coe_filter, Finset.mem_Iic, Set.mem_setOf_eq]
+  constructor
+  · intro h; exact ⟨totient_fiber_bound h, h⟩
+  · intro h; exact h.2
+
+/-- **Explicit fiber cardinality bound.** Each totient value `v` is attained by
+at most `2v² + 1` integers — the fiber sits inside `Iic (2v²)`, which has exactly
+`2v² + 1` elements.  Sharp at `v = 0`. -/
+theorem totient_fiber_ncard_le (v : ℕ) :
+    {n : ℕ | Nat.totient n = v}.ncard ≤ 2 * v ^ 2 + 1 := by
+  have hsub : {n : ℕ | Nat.totient n = v} ⊆ Set.Iic (2 * v ^ 2) := by
+    intro n hn
+    simp only [Set.mem_setOf_eq] at hn
+    exact Set.mem_Iic.mpr (totient_fiber_bound hn)
+  have hcard : (Set.Iic (2 * v ^ 2)).ncard = 2 * v ^ 2 + 1 := by
+    rw [← Finset.coe_Iic, Set.ncard_coe_finset, Nat.card_Iic]
+  calc {n : ℕ | Nat.totient n = v}.ncard
+      ≤ (Set.Iic (2 * v ^ 2)).ncard := Set.ncard_le_ncard hsub (Set.finite_Iic _)
+    _ = 2 * v ^ 2 + 1 := hcard
+
+/-- The unique solution of `φ(n) = 0` is `n = 0` (every positive integer has a
+positive totient).  This pins down the `v = 0` fiber. -/
+theorem totient_fiber_zero : {n : ℕ | Nat.totient n = 0} = {0} := by
+  ext n
+  simp only [Set.mem_setOf_eq, Set.mem_singleton_iff]
+  constructor
+  · intro h
+    by_contra hn
+    have hpos : 0 < Nat.totient n := Nat.totient_pos.mpr (Nat.pos_of_ne_zero hn)
+    omega
+  · rintro rfl; exact Nat.totient_zero
+
+/-- **Sharpness of the cardinality bound at `v = 0`.** Equality `1 = 2·0² + 1`
+holds: the fiber over `0` is the singleton `{0}`. -/
+example : {n : ℕ | Nat.totient n = 0}.ncard = 2 * 0 ^ 2 + 1 := by
+  rw [totient_fiber_zero]; simp
 
 end Erdos1004OQ02

--- a/src/data/proofs/erdos-1004-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1004-oq-02/annotations.json
@@ -2,85 +2,188 @@
   {
     "id": "ann-erdos1004oq02-header",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 3, "endLine": 41 },
+    "range": {
+      "startLine": 3,
+      "endLine": 41
+    },
     "type": "context",
     "title": "Why finite fibers make the run question well-posed",
     "content": "The header sets up the role of this entry within Erdős #1004. The parent asks how long a run of distinct consecutive totient values φ(n+1),…,φ(n+K) can be; for that to constrain anything, each value must be attained by only finitely many integers. This file supplies that finite-to-one fact with an explicit, elementary, 0-axiom bound φ(n)² ≥ n/2, packaged as a multiplicative invariant so that a single per-prime-power inequality propagates to all n.",
     "mathContext": "$\\varphi(n)^2 \\ge n/2$, i.e. $n \\le 2\\varphi(n)^2$, sharp at $n=2$ ($2\\varphi(2)^2 = 2$); odd refinement $n \\le \\varphi(n)^2$ for odd $n$.",
     "significance": "context",
-    "relatedConcepts": ["Euler totient", "multiplicative functions", "finite fibers", "Erdős problems"],
-    "prerequisites": ["Euler totient", "number theory"]
+    "relatedConcepts": [
+      "Euler totient",
+      "multiplicative functions",
+      "finite fibers",
+      "Erdős problems"
+    ],
+    "prerequisites": [
+      "Euler totient",
+      "number theory"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-primepow-odd",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 49, "endLine": 64 },
+    "range": {
+      "startLine": 49,
+      "endLine": 64
+    },
     "type": "technique",
     "title": "Odd prime-power core: pᵏ ≤ φ(pᵏ)²",
     "content": "The strong (factor-of-2-free) bound for odd prime powers. Writing k = j+1 and φ(p^(j+1)) = p^j(p−1) (totient_prime_pow_succ), the claim p^j·p ≤ (p^j(p−1))² reduces, after pulling out p^j, to the base inequality p ≤ (p−1)² for p ≥ 3 — discharged by nlinarith after substituting p = m+3. The calc chain then scales by Q = p^j (using Q ≤ Q²) and folds back into a perfect square.",
     "mathContext": "For prime $p \\ge 3$, $k \\ge 1$: $p^k \\le \\varphi(p^k)^2$. Core fact $p \\le (p-1)^2$ holds for $p \\ge 3$ since $(p-1)^2 - p = p^2 - 3p + 1 > 0$.",
     "significance": "supporting",
-    "relatedConcepts": ["prime powers", "totient of prime power", "nlinarith", "polynomial inequalities"],
-    "prerequisites": ["Euler totient", "prime powers"]
+    "relatedConcepts": [
+      "prime powers",
+      "totient of prime power",
+      "nlinarith",
+      "polynomial inequalities"
+    ],
+    "prerequisites": [
+      "Euler totient",
+      "prime powers"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-primepow-two",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 66, "endLine": 82 },
+    "range": {
+      "startLine": 66,
+      "endLine": 82
+    },
     "type": "technique",
     "title": "General prime-power core: pᵏ ≤ 2·φ(pᵏ)²",
     "content": "The weaker bound carrying the factor of 2, valid for every prime including p = 2. The same reduction φ(p^(j+1)) = p^j(p−1) leaves the base inequality p ≤ 2(p−1)² for p ≥ 2 — true even at p = 2 where it reads 2 ≤ 2·1 = 2 (tight). This single factor of 2 at the prime 2 is the entire source of slack in the global bound, isolated here.",
     "mathContext": "For any prime $p$, $k \\ge 1$: $p^k \\le 2\\varphi(p^k)^2$. Base case $p \\le 2(p-1)^2$ is tight at $p = 2$ ($2 = 2\\cdot 1$).",
     "significance": "supporting",
-    "relatedConcepts": ["prime powers", "totient of prime power", "sharpness", "nlinarith"],
-    "prerequisites": ["Euler totient", "prime powers"]
+    "relatedConcepts": [
+      "prime powers",
+      "totient of prime power",
+      "sharpness",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "Euler totient",
+      "prime powers"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-invariant",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 86, "endLine": 132 },
+    "range": {
+      "startLine": 86,
+      "endLine": 132
+    },
     "type": "insight",
     "title": "The multiplicative invariant that closes the recursion",
     "content": "The heart of the proof. Neither bound alone is closed under coprime multiplication (the factor of 2 would double in a product), so the statement is strengthened to the conjunction P(n): (Odd n → n ≤ φ(n)²) ∧ (n ≤ 2φ(n)²). Nat.recOnPosPrimePosCoprime reduces P to: prime powers (handled by the two core lemmas), the base cases 0 and 1, and coprime products. In a coprime product a·b at most one factor is even, so the factor of 2 is spent on that one even factor while the bare odd bound covers the other — making P genuinely multiplicative. The coprime case splits on the parity of a, using gcd(a,b)=1 to force the other factor odd.",
     "mathContext": "$P(n): (\\text{Odd } n \\to n \\le \\varphi(n)^2) \\wedge (n \\le 2\\varphi(n)^2)$. With $\\varphi(ab) = \\varphi(a)\\varphi(b)$ for $\\gcd(a,b)=1$, at most one of $a,b$ is even, so the factor $2$ is never spent twice.",
     "significance": "key",
-    "relatedConcepts": ["multiplicative induction", "recOnPosPrimePosCoprime", "totient_mul", "coprime factorization", "strengthening hypotheses"],
-    "prerequisites": ["multiplicative functions", "coprimality", "induction principles"]
+    "relatedConcepts": [
+      "multiplicative induction",
+      "recOnPosPrimePosCoprime",
+      "totient_mul",
+      "coprime factorization",
+      "strengthening hypotheses"
+    ],
+    "prerequisites": [
+      "multiplicative functions",
+      "coprimality",
+      "induction principles"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-headline",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 134, "endLine": 147 },
+    "range": {
+      "startLine": 134,
+      "endLine": 147
+    },
     "type": "concept",
     "title": "Headline bounds and sharpness at n = 2",
     "content": "The two halves of the invariant are projected out as the public theorems: totient_sq_two_ge (n ≤ 2φ(n)² for all n) and totient_sq_ge_of_odd (n ≤ φ(n)² for odd n). The example 2 = 2·φ(2)², closed by kernel decide, certifies the constant 2 is optimal — it cannot be lowered without failing at n = 2. Using kernel decide rather than native_decide keeps the entry free of Lean.ofReduceBool.",
     "mathContext": "$n \\le 2\\varphi(n)^2$ (all $n$); $n \\le \\varphi(n)^2$ (odd $n$); sharp: $2 = 2\\varphi(2)^2$.",
     "significance": "key",
-    "relatedConcepts": ["totient lower bound", "sharpness", "kernel decide", "axiom-free"],
-    "prerequisites": ["Euler totient"]
+    "relatedConcepts": [
+      "totient lower bound",
+      "sharpness",
+      "kernel decide",
+      "axiom-free"
+    ],
+    "prerequisites": [
+      "Euler totient"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-fiber",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 149, "endLine": 162 },
+    "range": {
+      "startLine": 149,
+      "endLine": 162
+    },
     "type": "insight",
     "title": "Finite-to-one: every totient fiber is finite",
     "content": "The structural payoff. From n ≤ 2φ(n)² follows the explicit fiber bound totient_fiber_bound: φ(n)=v ⟹ n ≤ 2v². Hence totient_fiber_finite shows {n : φ(n) = v} is finite by exhibiting it as a subset of the finite initial segment Iic (2v²) = {0,…,2v²}. This is exactly the finite-to-one property the parent problem presupposes — without it, distinctness of consecutive totient values would impose no arithmetic constraint.",
     "mathContext": "$\\varphi(n) = v \\Rightarrow n \\le 2v^2$, so $\\{n : \\varphi(n) = v\\} \\subseteq \\{0, 1, \\dots, 2v^2\\}$ is finite for every $v$.",
     "significance": "key",
-    "relatedConcepts": ["finite fibers", "finite-to-one maps", "Set.Finite", "initial segments"],
-    "prerequisites": ["Euler totient", "finiteness of sets"]
+    "relatedConcepts": [
+      "finite fibers",
+      "finite-to-one maps",
+      "Set.Finite",
+      "initial segments"
+    ],
+    "prerequisites": [
+      "Euler totient",
+      "finiteness of sets"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-real",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 164, "endLine": 172 },
+    "range": {
+      "startLine": 164,
+      "endLine": 172
+    },
     "type": "context",
     "title": "Real-analytic restatement √(n/2) ≤ φ(n)",
     "content": "The only analytic touch in an otherwise purely arithmetic file. Casting n ≤ 2φ(n)² into ℝ gives n/2 ≤ φ(n)²; monotonicity of √ (Real.sqrt_le_sqrt) plus Real.sqrt_sq on the nonnegative φ(n) yields √(n/2) ≤ φ(n). This is the familiar textbook form of the bound, recovered here as a corollary of the integer inequality rather than proved analytically.",
     "mathContext": "$\\sqrt{n/2} \\le \\varphi(n)$, from $n/2 \\le \\varphi(n)^2$ via $\\sqrt{\\cdot}$ monotone and $\\sqrt{x^2} = x$ for $x \\ge 0$.",
     "significance": "supporting",
-    "relatedConcepts": ["square root", "monotonicity", "casting ℕ to ℝ", "Real.sqrt_sq"],
-    "prerequisites": ["real analysis", "square roots"]
+    "relatedConcepts": [
+      "square root",
+      "monotonicity",
+      "casting ℕ to ℝ",
+      "Real.sqrt_sq"
+    ],
+    "prerequisites": [
+      "real analysis",
+      "square roots"
+    ]
+  },
+  {
+    "id": "ann-erdos1004oq02-effective",
+    "proofId": "erdos-1004-oq-02",
+    "range": {
+      "startLine": 174,
+      "endLine": 230
+    },
+    "type": "insight",
+    "title": "Effective finite-to-one: enumeration domain and explicit cardinality",
+    "content": "Upgrades the qualitative finiteness to a constructive, quantitative form. totient_fiber_eq_filter rewrites the (a priori infinite) set {n : φ(n)=v} as the coercion of the explicit, computable Finset (Iic (2v²)).filter (fun n => φ n = v): to find every preimage of v it suffices to test n ≤ 2v², a decidable enumeration domain. totient_fiber_ncard_le then bounds the count by #{n : φ(n)=v} ≤ 2v²+1, proved by Set.ncard_le_ncard into Iic (2v²) together with Nat.card_Iic. The bound is sharp at v=0: totient_fiber_zero shows the only solution of φ(n)=0 is n=0, so the fiber is the singleton {0} and 1 = 2·0²+1.",
+    "mathContext": "$\\{n:\\varphi(n)=v\\} = \\uparrow\\big((\\mathrm{Iic}\\,2v^2)\\text{.filter}(\\varphi\\,\\cdot = v)\\big)$ and $\\#\\{n:\\varphi(n)=v\\}\\le 2v^2+1$, attained at $v=0$ ($\\{0\\}$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "effective finiteness",
+      "decidable enumeration",
+      "Set.ncard",
+      "Finset.filter",
+      "totient multiplicity"
+    ],
+    "prerequisites": [
+      "Euler totient",
+      "finiteness of sets",
+      "cardinality"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-1004-oq-02/meta.json
+++ b/src/data/proofs/erdos-1004-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1004-oq-02",
   "title": "Erdős #1004: Why Totient Fibers Are Finite — the Elementary Bound φ(n)² ≥ n/2",
   "slug": "erdos-1004-oq-02",
-  "description": "Companion to the Erdős #1004 entry (distinct consecutive totient values). For the question 'how long a run φ(n+1),…,φ(n+K) of pairwise-distinct totient values can be' to be meaningful, each totient value must be attained by only finitely many integers; otherwise distinctness of values carries no arithmetic information. This entry supplies that structural fact with an explicit, fully verified, 0-axiom bound: n ≤ 2·φ(n)² for every n (totient_sq_two_ge), equivalently φ(n) ≥ √(n/2) (totient_ge_sqrt_half), with the sharp odd refinement n ≤ φ(n)² for odd n (totient_sq_ge_of_odd). From it, φ(n)=v ⟹ n ≤ 2v² (totient_fiber_bound), so every totient value has a finite fiber contained in an explicit initial segment (totient_fiber_finite) — the reason runs of distinct totient values are a well-posed object. The proof is a multiplicative-invariant argument: factoring n into coprime prime powers, the inequality is tight only at the single prime power 2¹ (φ(2)=1); the strengthened conjunction (Odd n → n ≤ φ(n)²) ∧ (n ≤ 2φ(n)²) is closed under coprime multiplication because in a coprime product at most one factor is even, so the lone factor-of-2 deficit is never spent twice. Proved by Nat.recOnPosPrimePosCoprime with per-prime-power one-variable polynomial inequalities (nlinarith). The bound is SHARP at n=2 (2·φ(2)²=2). Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
+  "description": "Companion to the Erdős #1004 entry (distinct consecutive totient values). For the question 'how long a run φ(n+1),…,φ(n+K) of pairwise-distinct totient values can be' to be meaningful, each totient value must be attained by only finitely many integers; otherwise distinctness of values carries no arithmetic information. This entry supplies that structural fact with an explicit, fully verified, 0-axiom bound: n ≤ 2·φ(n)² for every n (totient_sq_two_ge), equivalently φ(n) ≥ √(n/2) (totient_ge_sqrt_half), with the sharp odd refinement n ≤ φ(n)² for odd n (totient_sq_ge_of_odd). From it, φ(n)=v ⟹ n ≤ 2v² (totient_fiber_bound), so every totient value has a finite fiber contained in an explicit initial segment (totient_fiber_finite) — the reason runs of distinct totient values are a well-posed object. The proof is a multiplicative-invariant argument: factoring n into coprime prime powers, the inequality is tight only at the single prime power 2¹ (φ(2)=1); the strengthened conjunction (Odd n → n ≤ φ(n)²) ∧ (n ≤ 2φ(n)²) is closed under coprime multiplication because in a coprime product at most one factor is even, so the lone factor-of-2 deficit is never spent twice. Proved by Nat.recOnPosPrimePosCoprime with per-prime-power one-variable polynomial inequalities (nlinarith). The bound is SHARP at n=2 (2·φ(2)²=2). The finiteness is moreover made EFFECTIVE: the fiber over v is the coercion of an explicit, computable Finset obtained by searching the segment Iic(2v²) (totient_fiber_eq_filter), yielding the explicit cardinality bound #{n:φ(n)=v} ≤ 2v²+1 (totient_fiber_ncard_le), which is sharp at v=0. Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
   "meta": {
     "author": "lean-genius researcher",
     "sourceUrl": "https://erdosproblems.com/1004",
@@ -53,6 +53,7 @@
       "totient_sq_ge_of_odd: PROVED the sharp odd refinement n ≤ φ(n)² for odd n (the factor of 2 is needed only at the prime 2)",
       "totient_invariant: PROVED the strengthened conjunction (Odd n → n ≤ φ(n)²) ∧ (n ≤ 2φ(n)²) is a multiplicative invariant, the key device making the recursion close",
       "totient_fiber_bound / totient_fiber_finite: DERIVED the explicit fiber bound φ(n)=v ⟹ n ≤ 2v² and finiteness of every totient fiber — the structural reason distinct totient runs are well-posed",
+      "totient_fiber_eq_filter / totient_fiber_ncard_le: UPGRADED finiteness to an EFFECTIVE form — the fiber equals an explicit Finset searched over Iic(2v²) (decidable enumeration domain) and #{n:φ(n)=v} ≤ 2v²+1, sharp at v=0 (witnessed by totient_fiber_zero: the only solution of φ(n)=0 is n=0)",
       "totient_ge_sqrt_half: PROVED the real-analytic restatement √(n/2) ≤ φ(n)",
       "primePow_odd_bound / primePow_two_bound: PROVED the per-prime-power cores p^k ≤ φ(p^k)² (odd p) and p^k ≤ 2φ(p^k)² (any p) by elementary polynomial inequalities"
     ],
@@ -62,7 +63,7 @@
       "Euler totient as a multiplicative function; φ(p^k) = p^(k-1)(p-1)",
       "Multiplicative induction over coprime factorizations"
     ],
-    "lineCount": 173,
+    "lineCount": 230,
     "relatedProblems": [
       {
         "id": "erdos-1004",
@@ -74,14 +75,14 @@
       }
     ],
     "assumptions": "None. 0 axioms, 0 sorries (the theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound; the single sharpness witness at n=2 uses kernel `decide`, NOT `native_decide`, so no `Lean.ofReduceBool` is introduced). The bound n ≤ 2φ(n)² is a classical elementary fact; the contribution is a clean, fully verified, 0-axiom formalization via a multiplicative invariant, together with the explicit totient-fiber finiteness that underpins Erdős #1004.",
-    "theoremCount": 6,
+    "theoremCount": 9,
     "definitionCount": 0,
     "structureCount": 0
   },
   "overview": {
     "historicalContext": "Erdős Problem #1004 asks, for c > 0 and large x, whether some n ≤ x has φ(n+1),…,φ(n+⌊(log x)^c⌋) all distinct — how long a run of consecutive integers can carry pairwise-distinct Euler totients. Implicit in even posing the question is that φ is finite-to-one: each value is attained by only finitely many integers, so that 'distinct values' is a genuine constraint. The quantitative form of this is the classical lower bound φ(n) ≥ √(n/2): the totient cannot be too small relative to n, hence cannot repeat a given value indefinitely. This bound is elementary but, like most multiplicative-function estimates, is cleanest when organized as a multiplicative invariant.",
     "problemStatement": "Prove, unconditionally and axiom-free, an explicit lower bound on the Euler totient (φ(n) ≥ √(n/2)) and derive from it that every totient value has a finite fiber inside an explicit initial segment — the structural fact that makes distinct-totient-run questions well-posed.",
-    "text": "A 173-line self-contained file proving n ≤ 2·φ(n)² for all n (with the sharp odd refinement n ≤ φ(n)²), the real restatement √(n/2) ≤ φ(n), the explicit fiber bound φ(n)=v ⟹ n ≤ 2v², and finiteness of every totient fiber — all 0 sorries, 0 axioms, no native_decide.",
+    "text": "A 230-line self-contained file proving n ≤ 2·φ(n)² for all n (with the sharp odd refinement n ≤ φ(n)²), the real restatement √(n/2) ≤ φ(n), the explicit fiber bound φ(n)=v ⟹ n ≤ 2v², finiteness of every totient fiber, and its effective refinement (explicit Finset enumeration domain plus the cardinality bound #{n:φ(n)=v} ≤ 2v²+1, sharp at v=0) — all 0 sorries, 0 axioms, no native_decide.",
     "proofStrategy": "The bound is a multiplicative invariant. Per prime power, φ(p^(k+1)) = p^k(p−1), and the inequality p^k ≤ φ(p^k)² (for odd p) / p^k ≤ 2φ(p^k)² (any p) reduces, after factoring p^k, to the one-variable polynomial fact p ≤ (p−1)² / p ≤ 2(p−1)², dispatched by nlinarith. To combine prime powers one must control the single deficient factor φ(2)=1, so the statement is strengthened to the conjunction P(n): (Odd n → n ≤ φ(n)²) ∧ (n ≤ 2φ(n)²). In a coprime product a·b at most one factor is even, so the 'factor of 2' is spent on that one even factor and the bare bound n ≤ φ(n)² covers the odd one — making P closed under coprime multiplication. Nat.recOnPosPrimePosCoprime assembles the prime-power and coprime cases into a proof for all n. The fiber statements follow by substitution; the real form by monotonicity of √ and Real.sqrt_sq.",
     "keyInsights": [
       "**Finite fibers make the question meaningful.** φ(n) ≥ √(n/2) gives φ(n)=v ⟹ n ≤ 2v², so each totient value is attained finitely often — without this, 'distinct consecutive totient values' would impose no constraint.",
@@ -145,6 +146,13 @@
       "startLine": 164,
       "endLine": 172,
       "summary": "totient_ge_sqrt_half: √(n/2) ≤ φ(n), obtained from the integer bound by casting to ℝ and applying monotonicity of √ with Real.sqrt_sq."
+    },
+    {
+      "id": "effective",
+      "title": "Effective finite-to-one: enumeration and cardinality",
+      "startLine": 174,
+      "endLine": 230,
+      "summary": "totient_fiber_eq_filter expresses the (a priori infinite) fiber {n : φ(n)=v} as the coercion of the explicit Finset (Iic (2v²)).filter (φ · = v) — a decidable enumeration domain; totient_fiber_ncard_le bounds its cardinality by 2v²+1 (via Set.ncard_le_ncard into Iic and Nat.card_Iic); totient_fiber_zero pins the v=0 fiber to {0}, witnessing sharpness 1 = 2·0²+1."
     }
   ],
   "crossReferences": [
@@ -160,13 +168,13 @@
     }
   ],
   "leanFile": {
-    "lineCount": 173,
+    "lineCount": 230,
     "namespace": "Erdos1004OQ02",
     "opens": ["Nat"],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 6,
-    "substantiveTheoremCount": 5,
+    "theoremCount": 9,
+    "substantiveTheoremCount": 8,
     "computationalVerifications": 1,
     "lemmaCount": 2,
     "imports": ["Mathlib"],
@@ -176,7 +184,7 @@
   },
   "conclusion": {
     "summary": "A fully machine-checked (0 sorries, 0 axioms) elementary lower bound on the Euler totient: n ≤ 2·φ(n)² for every n (φ(n) ≥ √(n/2)), with the sharp odd refinement n ≤ φ(n)², proved as a multiplicative invariant via Nat.recOnPosPrimePosCoprime. From it follows the explicit fiber bound φ(n)=v ⟹ n ≤ 2v² and finiteness of every totient fiber.",
-    "implications": "Makes precise the finite-to-one property of φ that underlies Erdős #1004: each totient value is attained by only finitely many integers, lying in an explicit initial segment {0,…,2v²}. Complements the sibling oq-03 (which bounds run length from above) by bounding totient values from below, and isolates the single source of slack (the prime 2) in the classical √(n/2) estimate.",
+    "implications": "Makes precise the finite-to-one property of φ that underlies Erdős #1004: each totient value is attained by only finitely many integers, lying in an explicit initial segment {0,…,2v²}. Complements the sibling oq-03 (which bounds run length from above) by bounding totient values from below, and isolates the single source of slack (the prime 2) in the classical √(n/2) estimate. The finiteness is moreover effective: the fiber over v is recovered by a finite, decidable search of Iic(2v²) and has at most 2v²+1 elements (sharp at v=0), turning 'finite-to-one' into a computable enumeration with an explicit cardinality bound.",
     "openQuestions": [
       "Sharpen the constant by tracking the 2-adic valuation: integers with many distinct odd prime factors have φ much larger than √(n/2), so a refined bound φ(n) ≥ c·√(n·ω(n)) or similar may be provable elementarily.",
       "Combine the fiber bound n ≤ 2v² with oq-03's run-length bound to give an explicit, axiom-free count of how many distinct totient values appear among {φ(1),…,φ(N)}.",
@@ -213,6 +221,18 @@
       "type": "supporting",
       "description": "Real-analytic restatement √(n/2) ≤ φ(n) (PROVED, 0 axioms)",
       "leanType": "∀ (n : ℕ), Real.sqrt ((n : ℝ) / 2) ≤ (Nat.totient n : ℝ)"
+    },
+    {
+      "name": "totient_fiber_ncard_le",
+      "type": "core",
+      "description": "Effective finite-to-one: each totient value v is attained by at most 2v²+1 integers; sharp at v=0 (PROVED, 0 axioms)",
+      "leanType": "∀ (v : ℕ), {n : ℕ | Nat.totient n = v}.ncard ≤ 2 * v ^ 2 + 1"
+    },
+    {
+      "name": "totient_fiber_eq_filter",
+      "type": "supporting",
+      "description": "Effective enumeration domain: {n : φ(n)=v} equals the coercion of the explicit Finset (Iic (2v²)).filter (φ·=v) (PROVED, 0 axioms)",
+      "leanType": "∀ (v : ℕ), {n : ℕ | Nat.totient n = v} = ↑((Finset.Iic (2 * v ^ 2)).filter (fun n => Nat.totient n = v))"
     }
   ],
   "sections": [
@@ -263,6 +283,14 @@
       "endLine": 172,
       "summary": "totient_ge_sqrt_half recasts the integer bound over ℝ as √(n/2) ≤ φ(n) via Real.sqrt_le_sqrt and Real.sqrt_sq — the only analytic step in an otherwise elementary file.",
       "mathContext": "$\\sqrt{n/2}\\le\\varphi(n)$, the classical analytic form of the totient lower bound."
+    },
+    {
+      "id": "effective",
+      "title": "Effective finite-to-one: enumeration and cardinality",
+      "startLine": 174,
+      "endLine": 230,
+      "summary": "Upgrades the qualitative finiteness to an effective form: totient_fiber_eq_filter writes the fiber as an explicit decidable Finset search over Iic (2v²); totient_fiber_ncard_le gives #{n : φ(n)=v} ≤ 2v²+1; totient_fiber_zero shows the v=0 fiber is {0}, so the bound is sharp at v=0.",
+      "mathContext": "$\\#\\{n:\\varphi(n)=v\\}\\le 2v^2+1$, attained at $v=0$ where the fiber is $\\{0\\}$."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

Extends the **Erdős #1004** companion entry *Why Totient Fibers Are Finite* (erdos-1004-oq-02) with an **effective** finite-to-one layer. The existing entry proves `n ≤ 2·φ(n)²` and the qualitative `totient_fiber_finite : {n | φ(n)=v}.Finite`. This PR upgrades that to a constructive, quantitative form.

## New results (all PROVED, 0 axioms, no native_decide)

- **`totient_fiber_eq_filter`** — the (a priori infinite) fiber equals the coercion of an explicit, computable `Finset`:
  `{n | φ(n)=v} = ↑((Finset.Iic (2·v²)).filter (fun n => φ n = v))`.
  A decidable enumeration domain: every preimage of `v` is found by testing `n ≤ 2v²`.
- **`totient_fiber_ncard_le`** — explicit cardinality bound `#{n | φ(n)=v} ≤ 2v²+1`, via `Set.ncard_le_ncard` into `Iic (2v²)` and `Nat.card_Iic`.
- **`totient_fiber_zero`** — `φ(n)=0 ⟺ n=0`, pinning the `v=0` fiber to `{0}` and witnessing **sharpness** of the cardinality bound at `v=0` (`1 = 2·0²+1`).

## Why this matters

`totient_fiber_finite` only asserts finiteness. These results make it *effective*: an explicit decidable search domain plus a closed-form cardinality bound, sharp at `v=0` — turning "finite-to-one" into a computable enumeration with a quantitative bound.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1004OQ02` — builds clean, **0 warnings**, 0 sorries.
- 0 `axiom` declarations, no `native_decide` (the foundational `propext`/`Classical.choice`/`Quot.sound` only).
- Gallery `meta.json` (counts, contributions, section, main theorems, conclusion) and `annotations.json` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)