### PR TITLE
Enrich Σ k²·rᵏ closed form (summation-by-parts-oq-01-oq-02): sharper annotations

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-02/annotations.json
@@ -4,12 +4,12 @@
     "proofId": "summation-by-parts-oq-01-oq-02",
     "range": {
       "startLine": 1,
-      "endLine": 41
+      "endLine": 28
     },
     "type": "concept",
-    "title": "Module Overview and the Numerator Polynomial",
-    "content": "This module gives the closed form of the finite second-moment sum S(n) = Σ_{k<n} k²·rᵏ, the moment after the parent's Σ k·rᵏ. The strategy is to clear the (1−r)³ denominator and prove a polynomial identity by induction. The private definition `num r n = r(r+1) + rⁿ·(−n²(r−1)² + 2n·r(r−1) − r(r+1))` packages the numerator so the main identity reads (1−r)³·S(n) = num r n.",
-    "mathContext": "The numerator separates the n-independent part r(r+1) (governing the n→∞ limit Σ_{k≥0} k²rᵏ = r(r+1)/(1−r)³ for |r|<1) from the rⁿ boundary correction.",
+    "title": "Module Overview: the Second-Moment Sum Σ k²·rᵏ",
+    "content": "This module gives the closed form of the finite second-moment sum S(n) = Σ_{k<n} k²·rᵏ — the moment after the parent entry's arithmetico-geometric sum Σ k·rᵏ. The strategy is to clear the (1−r)³ denominator and prove a polynomial identity by induction (closing purely with `ring`), then divide by the nonzero (1−r)³ to recover the rational closed form. Keeping the cleared identity division-free until the very last step is what lets the core result hold for ALL r — including the removable point r = 1, where both sides vanish — rather than only for r ≠ 1.",
+    "mathContext": "For $|r|<1$ the $n\\to\\infty$ limit is $\\sum_{k\\ge0} k^2 r^k = \\dfrac{r(r+1)}{(1-r)^3}$; the finite sum adds an $r^n$-weighted boundary correction. The cube $(1-r)^3$ is the third power because differentiating the geometric series $\\sum r^k=1/(1-r)$ twice (the $k^2$ moment) raises the denominator degree to 3.",
     "significance": "key",
     "relatedConcepts": [
       "arithmetico-geometric sum",
@@ -22,16 +22,39 @@
     ]
   },
   {
+    "id": "ann-sbpoq0102-num",
+    "proofId": "summation-by-parts-oq-01-oq-02",
+    "range": {
+      "startLine": 34,
+      "endLine": 38
+    },
+    "type": "definition",
+    "title": "The Numerator Polynomial num r n",
+    "content": "The private definition `num r n = r(r+1) + rⁿ·(−n²(r−1)² + 2n·r(r−1) − r(r+1))` packages the closed form's numerator so the main identity reads cleanly as (1−r)³·S(n) = num r n. It separates the n-independent term r(r+1) — the only part that survives the n→∞ limit for |r|<1 — from the rⁿ-weighted boundary correction that carries all the n-dependence. The bracket multiplying rⁿ is a quadratic in n, the algebraic fingerprint of k² being a degree-2 moment (the first-moment sum Σ k·rᵏ has only a linear-in-n correction).",
+    "mathContext": "$\\mathrm{num}(r,n) = r(r+1) + r^n\\big(-n^2(r-1)^2 + 2n\\,r(r-1) - r(r+1)\\big)$; at $n=0$ the $r^n$ bracket reduces to $-r(r+1)$, cancelling the leading term so $\\mathrm{num}(r,0)=0$, matching the empty sum.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "numerator polynomial",
+      "second moment",
+      "boundary correction term",
+      "private definition"
+    ],
+    "prerequisites": [
+      "Polynomials in n and rⁿ",
+      "Real-valued definitions over ℝ"
+    ]
+  },
+  {
     "id": "ann-sbpoq0102-main",
     "proofId": "summation-by-parts-oq-01-oq-02",
     "range": {
-      "startLine": 43,
-      "endLine": 52
+      "startLine": 40,
+      "endLine": 50
     },
     "type": "key_step",
     "title": "Main Theorem: Division-Free Identity by Induction",
-    "content": "sq_geom_sum proves (1−r)³·Σ_{k<n} k²·rᵏ = num r n. The induction's zero case is closed by simp (empty sum = 0, and num r 0 = 0). The successor case rewrites Finset.sum_range_succ to peel the top term m²·rᵐ, distributes with mul_add, applies the inductive hypothesis, unfolds num at both m and m+1, and uses pow_succ for rᵐ⁺¹ = rᵐ·r; after push_cast the goal is a true polynomial identity in r and the atom rᵐ, closed by ring.",
-    "mathContext": "The step identity is num r m + (1−r)³·m²·rᵐ = num r (m+1). Holding rᵐ fixed as an atom and substituting rᵐ⁺¹ = rᵐ·r makes both sides equal polynomials, so no field arithmetic is needed.",
+    "content": "sq_geom_sum proves (1−r)³·Σ_{k<n} k²·rᵏ = num r n. The zero case is closed by simp (empty sum = 0, and num r 0 = 0). The successor case rewrites Finset.sum_range_succ to peel the top term m²·rᵐ, distributes with mul_add, applies the inductive hypothesis, unfolds num at both m and m+1, and uses pow_succ for rᵐ⁺¹ = rᵐ·r; after push_cast the goal is a true polynomial identity in r and the atom rᵐ, closed by ring. No field arithmetic is ever invoked.",
+    "mathContext": "The step identity is $\\mathrm{num}(r,m) + (1-r)^3 m^2 r^m = \\mathrm{num}(r,m+1)$. Treating $r^m$ as an opaque atom and substituting $r^{m+1}=r^m\\cdot r$ makes both sides equal polynomials, so `ring` suffices.",
     "significance": "critical",
     "relatedConcepts": [
       "Finset.sum_range_succ",
@@ -48,23 +71,45 @@
     "id": "ann-sbpoq0102-div",
     "proofId": "summation-by-parts-oq-01-oq-02",
     "range": {
-      "startLine": 54,
-      "endLine": 67
+      "startLine": 52,
+      "endLine": 58
     },
     "type": "concept",
-    "title": "Closed Form for r ≠ 1 and Sanity Checks",
-    "content": "sq_geom_sum_div derives the divided closed form S(n) = num r n / (1−r)³ for r ≠ 1: it establishes (1−r)³ ≠ 0 from r ≠ 1 (pow_ne_zero ∘ sub_ne_zero) and uses eq_div_iff together with mul_comm to reduce the goal to the division-free sq_geom_sum. Two examples then check the r = 2, n = 4 case (0 + 2 + 16 + 72 = 90) both by direct evaluation and against the identity.",
-    "mathContext": "For r ≠ 1 the denominator (1−r)³ is nonzero, so the polynomial identity transfers to the rational closed form. The numerical check confirms num 2 4 = (1−2)³·90 = −90.",
+    "title": "Closed Form for r ≠ 1",
+    "content": "sq_geom_sum_div derives the divided closed form S(n) = num r n / (1−r)³ for r ≠ 1. It establishes (1−r)³ ≠ 0 from r ≠ 1 (pow_ne_zero composed with sub_ne_zero), then uses eq_div_iff together with mul_comm to reduce the goal to the already-proved division-free sq_geom_sum. This is the only place division enters, and it is gated on the hypothesis r ≠ 1 — exactly the value the division-free form handled implicitly.",
+    "mathContext": "For $r\\neq1$ the denominator $(1-r)^3\\neq0$, so the polynomial identity $(1-r)^3 S(n)=\\mathrm{num}(r,n)$ transfers to the rational closed form $S(n)=\\mathrm{num}(r,n)/(1-r)^3$.",
     "significance": "supporting",
     "relatedConcepts": [
       "eq_div_iff",
       "pow_ne_zero",
-      "sub_ne_zero",
-      "sanity check"
+      "sub_ne_zero"
     ],
     "prerequisites": [
       "Division by a nonzero field element",
       "The main division-free identity"
+    ]
+  },
+  {
+    "id": "ann-sbpoq0102-checks",
+    "proofId": "summation-by-parts-oq-01-oq-02",
+    "range": {
+      "startLine": 61,
+      "endLine": 65
+    },
+    "type": "technique",
+    "title": "Sanity Checks Against Direct Evaluation",
+    "content": "Two `example` lemmas (lines 61-65) pin the formula to the concrete case r = 2, n = 4, where Σ_{k<4} k²·2ᵏ = 0 + 2 + 16 + 72 = 90. The first evaluates the sum directly with Finset.sum_range_succ + norm_num; the second checks the division-free identity by `simpa using sq_geom_sum 2 4`, confirming num 2 4 = (1−2)³·90 = −90. Such checks guard against sign errors or off-by-one slips in the numerator polynomial — cheap, machine-verified regression tests embedded in the source.",
+    "mathContext": "$\\sum_{k<4} k^2 2^k = 90$ and $(1-2)^3\\cdot90 = -90 = \\mathrm{num}(2,4)$, a direct numerical confirmation of the symbolic identity.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Finset.sum_range_succ",
+      "norm_num evaluation",
+      "regression test",
+      "numerical verification"
+    ],
+    "prerequisites": [
+      "Evaluating finite sums",
+      "The closed-form theorems above"
     ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass

Target `summation-by-parts-oq-01-oq-02` — *Closed form of the finite second-moment sum Σ k²·rᵏ* (quality 83, pass 0).

The 67-line file was already fully line-covered by 3 annotations, but two of them fused distinct elements. This pass restructures into 5 focused, non-overlapping annotations — a precision improvement, not inflation.

### Changes (annotations.json only)
- Split module-overview + `num` definition → **header overview** (1–28) and a dedicated **numerator-polynomial** annotation (34–38).
- Split divided-form + sanity-checks → **closed-form** annotation (52–58) and a dedicated **sanity-check** annotation (61–65).
- Anchored the **main-theorem** annotation at its docstring (40–50), which also clears a pre-existing `key_step type but found theorem` validator flag for this entry.

All 5 carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

### Verification
- Entry passes the annotation-line validator clean; JSON parses; manifest regenerated.
- The downstream `tsc` typecheck can't run in this worktree (`pnpm install` fails on `better-sqlite3` native build under Node v26 — environmental, unrelated to this JSON-only change).
- No mathematical claims altered; meta.json unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)