### PR TITLE
research(erdos-1018-oq-04-incomplete-01-oq-01): sharp planar edge-count threshold for Kₙ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1018OQ04Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos1018OQ04Incomplete01OQ01.lean
@@ -1,0 +1,102 @@
+/-
+# Erdős Problem #1018, OQ-04 → incomplete-01 → OQ-01
+## Sharp edge-count threshold for the planar obstruction in Kₙ
+
+The density argument behind Erdős #1018 OQ-04 (`Erdos1018OQ04Incomplete01.lean`)
+rests on Euler's planar edge bound: a simple graph on `n ≥ 3` vertices that
+embeds in the plane has at most `3n − 6` edges. A dense graph eventually exceeds
+this bound and therefore contains a non-planar configuration. The complete graph
+`Kₙ` has `C(n, 2) = n(n − 1)/2` edges, so a natural and fully elementary question
+underlies that argument:
+
+> For exactly which `n` does the edge count of `Kₙ` *by itself* force
+> non-planarity — i.e. when is `C(n, 2) > 3n − 6`?
+
+This file pins the threshold down precisely and shows it is **sharp**:
+
+* `Kn_exceeds_planar_bound` — for every `n ≥ 5`, `3n − 6 < C(n, 2)`.
+* `Kn_within_planar_bound` — for `3 ≤ n ≤ 4`, `C(n, 2) ≤ 3n − 6`
+  (in fact with equality: `K₃` and `K₄` meet the bound exactly).
+* `planar_obstruction_threshold` — for `n ≥ 3`,
+  `3n − 6 < C(n, 2) ↔ 5 ≤ n`.
+
+So the counting obstruction switches on exactly at `n = 5`, matching the
+classical fact that `K₅` (10 edges, bound 9) is the smallest complete graph
+that cannot be planar, while `K₃` (3 = 3) and `K₄` (6 = 6) sit right on the
+boundary and are planar.
+
+This is the elementary first-moment core of the density argument, isolated and
+machine-checked. All results are fully verified: **0 axioms, 0 sorries.**
+
+## References
+
+- Euler, L. (1758). Planar graph edge bound `e ≤ 3v − 6`.
+- Kuratowski, K. (1930). "Sur le problème des courbes gauches en topologie."
+- Parent: `Erdos1018OQ04Incomplete01.lean` (concrete embeddability + K₃/K₄/K₅).
+-/
+import Mathlib
+
+namespace Erdos1018OQ04Incomplete01OQ01
+
+/-- Number of edges of the complete graph `Kₙ`: the binomial coefficient `C(n, 2)`. -/
+def completeEdges (n : ℕ) : ℕ := n.choose 2
+
+/-- Euler's planar edge bound for a simple graph on `n ≥ 3` vertices:
+    at most `3n − 6` edges. -/
+def planarBound (n : ℕ) : ℕ := 3 * n - 6
+
+/-- Pascal's identity in the form needed here:
+    `C(n + 1, 2) = C(n, 2) + n`. -/
+lemma completeEdges_succ (n : ℕ) : completeEdges (n + 1) = completeEdges n + n := by
+  simp only [completeEdges]
+  have h : (n + 1).choose 2 = n.choose 1 + n.choose 2 := Nat.choose_succ_succ n 1
+  rw [Nat.choose_one_right] at h
+  omega
+
+/-- **Counting obstruction.** For every `n ≥ 5` the complete graph `Kₙ` has
+    strictly more than `3n − 6` edges, so it cannot satisfy Euler's planar
+    bound. -/
+theorem Kn_exceeds_planar_bound (n : ℕ) (hn : 5 ≤ n) :
+    planarBound n < completeEdges n := by
+  induction n, hn using Nat.le_induction with
+  | base =>
+    -- `K₅`: `3·5 − 6 = 9 < 10 = C(5, 2)`.
+    decide
+  | succ n hn ih =>
+    rw [completeEdges_succ]
+    simp only [planarBound] at ih ⊢
+    omega
+
+/-- **Sharpness, lower side.** For `3 ≤ n ≤ 4` the edge count of `Kₙ` does *not*
+    exceed Euler's bound; the two coincide (`K₃: 3 = 3`, `K₄: 6 = 6`). -/
+theorem Kn_within_planar_bound (n : ℕ) (h3 : 3 ≤ n) (h4 : n ≤ 4) :
+    completeEdges n ≤ planarBound n := by
+  interval_cases n <;> decide
+
+/-- **The threshold is exactly `n = 5`.** For every `n ≥ 3`, the edge count of
+    `Kₙ` exceeds the planar bound `3n − 6` if and only if `n ≥ 5`. This isolates
+    the first-moment core of the Erdős #1018 OQ-04 density argument. -/
+theorem planar_obstruction_threshold (n : ℕ) (hn : 3 ≤ n) :
+    planarBound n < completeEdges n ↔ 5 ≤ n := by
+  constructor
+  · intro h
+    by_contra hlt
+    push_neg at hlt
+    have hle : completeEdges n ≤ planarBound n :=
+      Kn_within_planar_bound n hn (by omega)
+    omega
+  · exact Kn_exceeds_planar_bound n
+
+/-! ### Boundary witnesses -/
+
+/-- `K₃` meets Euler's bound with equality: `C(3, 2) = 3 = 3·3 − 6`. -/
+theorem K3_meets_bound : completeEdges 3 = planarBound 3 := by decide
+
+/-- `K₄` meets Euler's bound with equality: `C(4, 2) = 6 = 3·4 − 6`. -/
+theorem K4_meets_bound : completeEdges 4 = planarBound 4 := by decide
+
+/-- `K₅` is the first complete graph to exceed Euler's bound:
+    `C(5, 2) = 10 > 9 = 3·5 − 6`. -/
+theorem K5_exceeds_bound : planarBound 5 < completeEdges 5 := by decide
+
+end Erdos1018OQ04Incomplete01OQ01

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/annotations.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "ann-e1018oq04i01oq01-defs",
+    "proofId": "erdos-1018-oq-04-incomplete-01-oq-01",
+    "range": { "startLine": 41, "endLine": 46 },
+    "type": "context",
+    "title": "The two quantities being compared",
+    "content": "completeEdges n = n.choose 2 is the edge count of the complete graph Kₙ; planarBound n = 3 * n − 6 is Euler's planar edge bound for a simple graph on n ≥ 3 vertices. The entire entry is about the gap between these two ℕ-valued functions. Note planarBound uses truncated ℕ subtraction, which is harmless here because every comparison is made at n ≥ 3 where 3n ≥ 6.",
+    "mathContext": "$\\mathrm{completeEdges}(n)=\\binom{n}{2}$, $\\mathrm{planarBound}(n)=3n-6$.",
+    "significance": "context"
+  },
+  {
+    "id": "ann-e1018oq04i01oq01-pascal",
+    "proofId": "erdos-1018-oq-04-incomplete-01-oq-01",
+    "range": { "startLine": 48, "endLine": 54 },
+    "type": "key-step",
+    "title": "Pascal's rule linearizes the induction",
+    "content": "completeEdges_succ proves C(n+1,2) = C(n,2) + n from Nat.choose_succ_succ (Pascal: C(n+1,2) = C(n,1) + C(n,2)) and Nat.choose_one_right (C(n,1) = n). The defeq 2 = 1+1 is forced by annotating the `have` with an explicit `2`-typed statement, so omega sees a single atom C(n,2) and closes. This recurrence is what turns the nonlinear inequality C(n,2) > 3n−6 into a step that omega can advance one n at a time.",
+    "mathContext": "$\\binom{n+1}{2}=\\binom{n}{1}+\\binom{n}{2}=n+\\binom{n}{2}$.",
+    "significance": "high"
+  },
+  {
+    "id": "ann-e1018oq04i01oq01-exceeds",
+    "proofId": "erdos-1018-oq-04-incomplete-01-oq-01",
+    "range": { "startLine": 56, "endLine": 68 },
+    "type": "key-step",
+    "title": "n ≥ 5 forces Kₙ over the bound",
+    "content": "Kn_exceeds_planar_bound runs Nat.le_induction from the base n = 5 (where 3·5−6 = 9 < 10 = C(5,2), closed by decide). The successor step rewrites C(n+1,2) via the Pascal lemma and hands omega the inductive hypothesis 3n−6 < C(n,2) together with n ≥ 5; since adding n to the right side outpaces the +3 on the left, omega finishes. No quadratic reasoning is ever needed.",
+    "mathContext": "$n\\ge 5 \\Rightarrow 3n-6 < \\binom{n}{2}$.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-e1018oq04i01oq01-threshold",
+    "proofId": "erdos-1018-oq-04-incomplete-01-oq-01",
+    "range": { "startLine": 76, "endLine": 88 },
+    "type": "key-step",
+    "title": "The sharp biconditional — threshold exactly at 5",
+    "content": "planar_obstruction_threshold packages both directions: for n ≥ 3, C(n,2) > 3n−6 ⟺ n ≥ 5. The forward direction assumes n < 5, hence n ∈ {3,4}, and derives C(n,2) ≤ 3n−6 from Kn_within_planar_bound (proved by interval_cases + decide), contradicting the strict inequality. The backward direction is exactly Kn_exceeds_planar_bound. The equality cases K₃ (3 = 3) and K₄ (6 = 6) are what make the threshold sharp rather than merely sufficient — the obstruction switches on at the smallest possible n.",
+    "mathContext": "$n\\ge 3 \\Rightarrow \\big(\\binom{n}{2} > 3n-6 \\iff n\\ge 5\\big)$; $2\\big(\\binom{n}{2}-(3n-6)\\big)=(n-3)(n-4)$.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-e1018oq04i01oq01-axioms",
+    "proofId": "erdos-1018-oq-04-incomplete-01-oq-01",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "context",
+    "title": "Verified, zero axioms",
+    "content": "Every theorem reduces over ℕ with no sorry, no axiom declaration, and no native_decide. The `decide` calls target closed numeric goals (binomial coefficients of literal constants ≤ 5), which the kernel evaluates directly — they do not invoke Lean.ofReduceBool. So per the project's axiom-integrity policy this is a genuine 0-axiom, fully machine-verified result, in contrast to the parent entry which axiomatizes Kostochka–Pyber (r = 2) and leaves Euler's edge bound as a sorry.",
+    "mathContext": "Only propext / Classical.choice / Quot.sound are used; these are not counted as assumptions.",
+    "significance": "context"
+  }
+]

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/meta.json
@@ -1,0 +1,143 @@
+{
+  "id": "erdos-1018-oq-04-incomplete-01-oq-01",
+  "title": "Planar Edge-Count Threshold: Kₙ Exceeds 3n − 6 iff n ≥ 5",
+  "slug": "erdos-1018-oq-04-incomplete-01-oq-01",
+  "description": "Isolates and fully verifies the elementary first-moment core of the Erdős #1018 OQ-04 density argument: the complete graph Kₙ has more edges than Euler's planar bound 3n − 6 exactly when n ≥ 5. The threshold is sharp — K₃ (3 = 3) and K₄ (6 = 6) meet the bound with equality, K₅ (10 > 9) is the first to break it. A 0-axiom, 0-sorry counterpart to the parent's axiomatized topological completion.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://erdosproblems.com/1018",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1018OQ04Incomplete01OQ01.lean",
+    "tags": [
+      "graph-theory",
+      "planarity",
+      "extremal-combinatorics",
+      "binomial-coefficients",
+      "first-moment",
+      "erdos"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "lineCount": 102,
+    "assumptions": "None. Fully machine-checked: 0 axiom declarations, 0 structure-encoded assumptions, 0 sorries, no native_decide. The `decide` tactic is used only on closed numeric goals (binomial coefficients of small constants) and reduces in the kernel without Lean.ofReduceBool. All theorems depend only on the foundational axioms propext / Classical.choice / Quot.sound, which do not count as assumptions under the project policy.",
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 2,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Euler's 1750 polyhedral formula $V - E + F = 2$ yields, for a simple planar graph on $n \\geq 3$ vertices, the edge bound $|E| \\leq 3n - 6$ (each face is bounded by at least 3 edges, each edge borders at most 2 faces). This bound is the standard counting certificate of non-planarity: any graph with more than $3n - 6$ edges cannot be drawn in the plane. The smallest complete graph it rules out is $K_5$, whose $\\binom{5}{2} = 10$ edges exceed $3 \\cdot 5 - 6 = 9$; together with $K_{3,3}$ this is one of the two Kuratowski obstructions (1930). The parent entry (Erdős #1018 OQ-04, incomplete-01) builds a concrete topological embeddability definition and uses exactly this $|E| \\leq 3n - 6$ bound (left as a sorry there, since Euler's formula is not yet in Mathlib) to argue that dense graphs must contain non-planar subgraphs. This follow-up asks the purely arithmetic question hiding inside that step: for which $n$ does $K_n$'s edge count alone exceed the bound? The answer — exactly $n \\geq 5$ — is the elementary heart of 'why $K_5$, and not $K_4$, is the first non-planar complete graph.'",
+    "problemStatement": "For which $n$ does the complete graph $K_n$ exceed Euler's planar edge bound, i.e. when is $\\binom{n}{2} > 3n - 6$? Establish the threshold and show it is sharp.",
+    "text": "Proves $\\binom{n}{2} > 3n - 6 \\iff n \\geq 5$ for $n \\geq 3$, with $K_3$ and $K_4$ meeting the bound with equality and $K_5$ the first to exceed it.",
+    "proofStrategy": "Set $\\mathrm{completeEdges}(n) = \\binom{n}{2}$ and $\\mathrm{planarBound}(n) = 3n - 6$. (1) A Pascal step $\\binom{n+1}{2} = \\binom{n}{2} + n$ drives a `Nat.le_induction` from the base case $n = 5$ ($9 < 10$) to give $3n - 6 < \\binom{n}{2}$ for all $n \\geq 5$; each inductive step closes by `omega`. (2) `interval_cases` plus `decide` handles $3 \\leq n \\leq 4$, where the two sides coincide. (3) Combining the two via `omega` yields the sharp biconditional. The argument is entirely over ℕ with no real analysis, no topology, and no axioms.",
+    "keyInsights": [
+      "The whole topological density argument has a one-line arithmetic shadow: $\\binom{n}{2} - (3n - 6) = \\tfrac{1}{2}(n-3)(n-4)$, which is $> 0$ exactly when $n \\geq 5$ and $= 0$ at $n \\in \\{3,4\\}$. The verified threshold $n \\geq 5$ is this factorization made machine-checkable.",
+      "Sharpness is genuine, not incidental: $K_3$ and $K_4$ sit exactly on the boundary ($3 = 3$, $6 = 6$) and are in fact planar, so the counting obstruction switches on at the smallest possible $n$. This is precisely why $K_5$ — not $K_4$ — is the first non-planar complete graph.",
+      "A Pascal recurrence $\\binom{n+1}{2} = \\binom{n}{2} + n$ converts the nonlinear inequality $\\binom{n}{2} > 3n - 6$ into a linear induction that `omega` discharges step-by-step, sidestepping the need for any quadratic-reasoning tactic over ℕ.",
+      "This is a 0-axiom, 0-sorry companion to the parent's axiomatized completion: the parent leaves $|E| \\leq 3n - 6$ as a sorry (Euler's formula, absent from Mathlib), but the consequence actually used — that $K_n$ overshoots the bound for $n \\geq 5$ — needs none of that machinery and is fully verifiable on its own."
+    ],
+    "prerequisites": [
+      "Binomial coefficients $\\binom{n}{2}$ and Pascal's rule",
+      "Euler's planar edge bound $|E| \\leq 3|V| - 6$",
+      "Natural-number induction (Nat.le_induction)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "defs",
+      "title": "Definitions: Edge Count and Planar Bound",
+      "startLine": 41,
+      "endLine": 46,
+      "summary": "`completeEdges n = n.choose 2` (edges of Kₙ) and `planarBound n = 3 * n - 6` (Euler's planar bound).",
+      "mathContext": "$\\mathrm{completeEdges}(n) = \\binom{n}{2}$, $\\mathrm{planarBound}(n) = 3n - 6$."
+    },
+    {
+      "id": "pascal",
+      "title": "Pascal Step",
+      "startLine": 48,
+      "endLine": 54,
+      "summary": "`completeEdges_succ`: $\\binom{n+1}{2} = \\binom{n}{2} + n$, via `Nat.choose_succ_succ` and `Nat.choose_one_right`, the engine of the induction.",
+      "mathContext": "$\\binom{n+1}{2} = \\binom{n}{2} + \\binom{n}{1} = \\binom{n}{2} + n$."
+    },
+    {
+      "id": "exceeds",
+      "title": "Counting Obstruction for n ≥ 5",
+      "startLine": 56,
+      "endLine": 68,
+      "summary": "`Kn_exceeds_planar_bound`: for all $n \\geq 5$, $3n - 6 < \\binom{n}{2}$. `Nat.le_induction` from base $n = 5$ ($9 < 10$); each step rewrites by the Pascal lemma and closes with `omega`.",
+      "mathContext": "$n \\geq 5 \\Rightarrow 3n - 6 < \\binom{n}{2}$."
+    },
+    {
+      "id": "within",
+      "title": "Sharpness for 3 ≤ n ≤ 4",
+      "startLine": 70,
+      "endLine": 74,
+      "summary": "`Kn_within_planar_bound`: for $3 \\leq n \\leq 4$, $\\binom{n}{2} \\leq 3n - 6$ (equality in both cases). `interval_cases n <;> decide`.",
+      "mathContext": "$K_3: 3 = 3$, $K_4: 6 = 6$."
+    },
+    {
+      "id": "threshold",
+      "title": "The Sharp Threshold",
+      "startLine": 76,
+      "endLine": 88,
+      "summary": "`planar_obstruction_threshold`: for $n \\geq 3$, $3n - 6 < \\binom{n}{2} \\iff n \\geq 5$. Forward direction by contradiction against the within-bound lemma; backward by the exceeds lemma.",
+      "mathContext": "$n \\geq 3 \\Rightarrow (\\binom{n}{2} > 3n - 6 \\iff n \\geq 5)$."
+    },
+    {
+      "id": "witnesses",
+      "title": "Boundary Witnesses",
+      "startLine": 90,
+      "endLine": 100,
+      "summary": "`K3_meets_bound` ($3 = 3$), `K4_meets_bound` ($6 = 6$), `K5_exceeds_bound` ($9 < 10$): the three small cases pinning the threshold, each by `decide`.",
+      "mathContext": "$\\binom{3}{2} = 3$, $\\binom{4}{2} = 6$, $\\binom{5}{2} = 10$ against bounds $3, 6, 9$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The edge count of the complete graph Kₙ exceeds Euler's planar bound 3n − 6 if and only if n ≥ 5, and the threshold is sharp: K₃ and K₄ meet the bound with equality while K₅ is the first to break it. This isolates the elementary first-moment core of the Erdős #1018 OQ-04 density argument as a fully machine-verified, 0-axiom result.",
+    "implications": "Where the parent entry leaves the planar edge bound |E| ≤ 3n − 6 as a sorry (Euler's formula, not yet in Mathlib), this entry verifies the exact consequence the density argument consumes — that Kₙ overshoots the bound for n ≥ 5 — with no axioms and no sorries. The factorization 2(\\binom{n}{2} − (3n−6)) = (n−3)(n−4) explains both the threshold and its sharpness in one line.",
+    "openQuestions": [
+      "What is the analogous sharp edge-count threshold for the bipartite bound |E| ≤ 2n − 4 (which certifies non-planarity of K_{3,3}), and at which n does K_{m,m} cross it?",
+      "Can the r-uniform generalization — the threshold at which the number of r-edges \\binom{n}{r} exceeds the van Kampen–Flores embeddability bound in ℝ^{2r-2} — be stated and bounded elementarily, paralleling the r = 2 case proved here?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1018-oq-04-incomplete-01",
+      "relationship": "extends",
+      "description": "Parent: the axiomatized topological completion whose planar edge-bound sorry this entry's threshold makes precise and verifies."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Euler, L.",
+      "title": "Planarity criterion",
+      "year": "1750",
+      "venue": "Classical",
+      "note": "V − E + F = 2, giving |E| ≤ 3|V| − 6 for simple planar graphs on ≥ 3 vertices"
+    },
+    {
+      "authors": "Kuratowski, K.",
+      "title": "Sur le problème des courbes gauches en topologie",
+      "year": "1930",
+      "venue": "Fundamenta Mathematicae 15:271–283",
+      "note": "K₅ and K₃,₃ as the two minimal non-planar obstructions"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos1018OQ04Incomplete01OQ01",
+    "lineCount": 102,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "path": "Proofs/Erdos1018OQ04Incomplete01OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 2,
+    "additionalFiles": []
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-1018-oq-04-incomplete-01-oq-01.json
+++ b/src/data/research/problems/erdos-1018-oq-04-incomplete-01-oq-01.json
@@ -1,0 +1,65 @@
+{
+  "slug": "erdos-1018-oq-04-incomplete-01-oq-01",
+  "title": "Sharp edge-count threshold for the planar obstruction in Kₙ",
+  "problemStatement": "For which n does the complete graph Kₙ exceed Euler's planar edge bound 3n − 6, i.e. when is C(n,2) > 3n − 6? This is the elementary first-moment core of the parent's hypergraph non-planar density argument, which leaves |E| ≤ 3n − 6 as a sorry.",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "tractability": 9,
+  "path": "fast",
+  "significance": 5,
+  "started": "2026-06-28T15:50:33Z",
+  "lastUpdate": "2026-06-28T16:10:00Z",
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-28T16:10:00Z",
+    "iteration": 1,
+    "focus": "Fully verified 0-axiom threshold result: C(n,2) > 3n−6 ⟺ n ≥ 5, sharp at n=5.",
+    "blockers": [],
+    "nextAction": "None — entry complete and gallery-published.",
+    "attemptCounts": { "total": 1, "currentApproach": 1, "approachesTried": 1 }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED 2026-06-28: Proved C(n,2) > 3n−6 ⟺ n ≥ 5 for n ≥ 3, fully verified (0 axioms, 0 sorries). Pascal recurrence C(n+1,2)=C(n,2)+n linearizes the induction so omega closes each step from base n=5. Sharpness: K₃ (3=3) and K₄ (6=6) meet the bound, K₅ (10>9) breaks it. Isolates the first-moment core of the parent's density argument as an axiom-free companion.",
+    "builtItems": [
+      "Created Proofs/Erdos1018OQ04Incomplete01OQ01.lean: 6 theorems, 2 defs, 0 axioms, 0 sorries (102 lines)",
+      "completeEdges_succ: Pascal step C(n+1,2)=C(n,2)+n via Nat.choose_succ_succ + Nat.choose_one_right",
+      "Kn_exceeds_planar_bound: ∀ n≥5, 3n−6 < C(n,2), by Nat.le_induction (base n=5) + omega",
+      "Kn_within_planar_bound: 3≤n≤4 ⇒ C(n,2) ≤ 3n−6 (equality), interval_cases + decide",
+      "planar_obstruction_threshold: n≥3 ⇒ (C(n,2) > 3n−6 ⟺ n≥5) — the sharp biconditional",
+      "Created gallery entry src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/ (meta.json + annotations.json), status verified, badge verified"
+    ],
+    "insights": [
+      "2(C(n,2) − (3n−6)) = (n−3)(n−4): one-line factorization explaining both the threshold (>0 iff n≥5) and its sharpness (=0 at n=3,4).",
+      "Pascal's rule C(n+1,2)=C(n,2)+n converts the nonlinear inequality into a linear induction omega can advance; no quadratic tactic over ℕ needed.",
+      "Defeq 2 = 1+1 must be pinned by annotating the `have` with an explicit 2-typed statement, else Nat.choose (1+1) and Nat.choose 2 are distinct atoms to omega (the original simp-only approach failed for this reason).",
+      "The parent leaves Euler's |E| ≤ 3n−6 as a sorry, but the consequence the density argument actually uses (Kₙ overshoots for n≥5) needs none of that machinery and is fully verifiable.",
+      "K₅ is the smallest non-planar complete graph precisely because the counting obstruction switches on at the smallest n where (n−3)(n−4)>0."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Optional sibling: analogous threshold for the bipartite bound |E| ≤ 2n−4 (K_{3,3} obstruction).",
+      "Optional: r-uniform generalization vs the van Kampen–Flores embeddability bound in ℝ^{2r-2}."
+    ]
+  },
+  "knownResults": [
+    "Euler 1750: simple planar graph on n≥3 vertices has |E| ≤ 3n−6.",
+    "Kuratowski 1930: K₅ and K₃,₃ are the minimal non-planar obstructions."
+  ],
+  "references": [
+    "Euler, L. (1750). Planarity criterion (V−E+F=2).",
+    "Kuratowski, K. (1930). Sur le problème des courbes gauches en topologie."
+  ],
+  "relatedProofs": [
+    "erdos-1018-oq-04-incomplete-01",
+    "erdos-1018-oq-04"
+  ],
+  "tags": [
+    "graph-theory",
+    "planarity",
+    "extremal-combinatorics",
+    "binomial-coefficients",
+    "first-moment",
+    "erdos"
+  ]
+}


### PR DESCRIPTION
## Summary

Research session for **erdos-1018-oq-04-incomplete-01-oq-01** — a fresh follow-up open question off the graduated parent `erdos-1018-oq-04-incomplete-01` (hypergraph non-planar density).

The parent builds a concrete topological embeddability definition and argues that dense graphs must contain non-planar subgraphs, relying on Euler's planar edge bound `|E| ≤ 3n − 6` — which it leaves as a **sorry** (Euler's formula is not yet in Mathlib) and on an **axiomatized** Kostochka–Pyber (r=2). This entry isolates the purely arithmetic step hiding inside that argument and verifies it with **0 axioms, 0 sorries**:

> `C(n,2) > 3n − 6  ⟺  n ≥ 5`   (for `n ≥ 3`)

The threshold is **sharp**: `K₃` (3 = 3) and `K₄` (6 = 6) meet the bound with equality, and `K₅` (10 > 9) is the first complete graph to exceed it — which is exactly why `K₅`, not `K₄`, is the smallest non-planar complete graph.

## Progress

New, fully verified Lean file + gallery entry:
- `proofs/Proofs/Erdos1018OQ04Incomplete01OQ01.lean` — 6 theorems, 2 defs, **0 axioms, 0 sorries**, builds under Mathlib 4.26.0.
  - `Kn_exceeds_planar_bound` — `∀ n≥5, 3n−6 < C(n,2)`, by `Nat.le_induction` from base `n=5` with a Pascal step `C(n+1,2)=C(n,2)+n`; each step closes by `omega`.
  - `Kn_within_planar_bound` — `3≤n≤4 ⇒ C(n,2) ≤ 3n−6` (equality), `interval_cases <;> decide`.
  - `planar_obstruction_threshold` — the sharp biconditional.
  - `K3_meets_bound`, `K4_meets_bound`, `K5_exceeds_bound` — boundary witnesses.
- `src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/` — gallery `meta.json` + `annotations.json` (status `verified`, badge `verified`).
- `src/data/research/problems/erdos-1018-oq-04-incomplete-01-oq-01.json` — knowledge record.

## Findings

- Pascal's rule linearizes the otherwise-nonlinear inequality so `omega` can advance the induction one `n` at a time — no quadratic-reasoning tactic over ℕ is needed.
- The defeq `2 = 1+1` must be pinned by annotating the `have` with an explicit `2`-typed statement, otherwise `Nat.choose (1+1)` and `Nat.choose 2` are distinct atoms to `omega`.
- One-line explanation of both threshold and sharpness: `2(C(n,2) − (3n−6)) = (n−3)(n−4)`.
- This is an axiom-free companion to the parent: the consequence the density argument consumes needs neither Euler's-formula sorry nor the Kostochka–Pyber axiom.

## Status

**Outcome**: completed (VERIFIED, 0-axiom, 0-sorry)
**Next Steps**: optional siblings — the bipartite `|E| ≤ 2n−4` threshold (`K₃,₃` obstruction); the r-uniform van Kampen–Flores generalization.

🤖 Generated by researcher-10