### PR TITLE
Enrich Viviani interior witnesses (viviani-theorem-oq-01-oq-01-oq-02): finer annotations

### DIFF
--- a/src/data/proofs/viviani-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/viviani-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-header-strategy",
+    "proofId": "viviani-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 4,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "From Abstract Non-Constancy to Constructive Interior Witnesses",
+    "content": "The parent `viviani-theorem-oq-01-oq-01` proves the converse of Viviani as a characterisation: the signed distance-sum `sumDist A B C P` is independent of P ⇔ the triangle is equilateral. Merely negating the right side gives only the abstract fact that a non-equilateral triangle's distance-sum is non-constant *somewhere in the plane*. This leaf sharpens it to a constructive, interior statement — two points in the *open interior* with distinct distance-sums. Interiority matters: there all three inward signed distances are positive, so the signed sumDist coincides with the genuine perpendicular-distance sum of classical Viviani, making the witnesses honest. The strategy: sumDist is affine with constant gradient g = nA+nB+nC; non-equilaterality forces g ≠ 0; the two edge vectors span the plane, so g cannot be orthogonal to both; perturbing the centroid by ±1/6 along a non-orthogonal edge yields interior points whose sums differ by ⅓·⟪g, edge⟫ ≠ 0.",
+    "mathContext": "$\\mathrm{sumDist}(P) = \\langle g, P\\rangle + c$ is affine with $g = n_A+n_B+n_C$; the parent gives equilateral $\\iff g = 0$, so non-equilateral $\\Rightarrow g \\neq 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "converse of Viviani's theorem",
+      "affine functional",
+      "signed vs perpendicular distance",
+      "constructive existence"
+    ],
+    "prerequisites": [
+      "the parent converse characterisation",
+      "barycentric coordinates",
+      "real inner products in the plane"
+    ]
+  },
+  {
     "id": "ann-isinterior-def",
     "proofId": "viviani-theorem-oq-01-oq-01-oq-02",
     "range": {
@@ -25,41 +49,64 @@
     "id": "ann-interior-witnesses",
     "proofId": "viviani-theorem-oq-01-oq-01-oq-02",
     "range": {
-      "startLine": 61,
-      "endLine": 139
+      "startLine": 55,
+      "endLine": 94
     },
     "type": "theorem",
-    "title": "Interior Witnesses of Non-Constancy",
-    "content": "`viviani_interior_witnesses`: a non-degenerate, non-equilateral triangle has two interior points P, Q with `sumDist A B C P ≠ sumDist A B C Q`. The proof rewrites the parent's non-degeneracy determinant into the (B−A, C−A) basis, derives that the gradient g = nA+nB+nC is non-zero (non-equilaterality, via the parent's viviani_converse and const_iff_normalSum_zero), and shows by a 2×2 Cramer argument that g cannot be rdot-orthogonal to both spanning edges. Perturbing the centroid by ±1/6 of the barycentric weight along the non-orthogonal edge yields interior witnesses with coordinates (1/6,1/2,1/3) and (1/2,1/6,1/3), whose distance-sums differ by ⅓·⟪g, edge⟫ ≠ 0 (computed via the parent's sumDist_sub).",
-    "mathContext": "$\\mathrm{sumDist}(P)-\\mathrm{sumDist}(Q) = \\langle g, P-Q\\rangle$ with $g = n_A+n_B+n_C \\neq 0$; the witnesses give $P-Q = \\tfrac13(\\text{edge})$, so the gap is $\\tfrac13\\langle g,\\text{edge}\\rangle \\neq 0$.",
+    "title": "Interior Witnesses: Reducing to a Non-Orthogonal Gradient",
+    "content": "`viviani_interior_witnesses` states that a non-degenerate, non-equilateral triangle has two interior points P, Q with `sumDist A B C P ≠ sumDist A B C Q`. This first half is the reduction. It rewrites the parent's non-degeneracy determinant into the (B−A, C−A) basis (a pure `ring` identity), then derives that the gradient g = nA+nB+nC is non-zero from non-equilaterality (via the parent's `viviani_converse` composed with `const_iff_normalSum_zero`). A 2×2 Cramer argument — two `linear_combination` identities that isolate g.re and g.im against the non-vanishing determinant — shows g cannot be rdot-orthogonal to both spanning edges, giving the dichotomy `⟪g, B−A⟫ ≠ 0 ∨ ⟪g, C−A⟫ ≠ 0` that selects which edge to perturb along.",
+    "mathContext": "If $\\langle g, B-A\\rangle = \\langle g, C-A\\rangle = 0$ then, since the edges span $\\mathbb{C}$ (determinant $\\neq 0$), Cramer forces $g = 0$ — a contradiction. E.g. $g_{\\mathrm{re}}\\cdot\\det = (C{-}A)_{\\mathrm{im}}\\langle g,B{-}A\\rangle - (B{-}A)_{\\mathrm{im}}\\langle g,C{-}A\\rangle$.",
     "significance": "central",
     "relatedConcepts": [
-      "Viviani's theorem",
-      "affine functional",
-      "gradient",
       "Cramer's rule",
-      "centroid perturbation"
+      "2×2 determinant",
+      "inner-product orthogonality",
+      "gradient of an affine map"
     ],
     "prerequisites": [
-      "the parent converse (sumDist, sumDist_sub, viviani_converse)",
-      "real inner product and orthogonality",
-      "2×2 determinants"
+      "the parent viviani_converse and const_iff_normalSum_zero",
+      "real inner product rdot",
+      "linear_combination tactic"
+    ]
+  },
+  {
+    "id": "ann-construction-perturbation",
+    "proofId": "viviani-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 95,
+      "endLine": 137
+    },
+    "type": "technique",
+    "title": "The ±1/6 Centroid Perturbation",
+    "content": "With the non-orthogonal edge selected (`rcases` on the dichotomy), the two witnesses are explicit barycentric points: (1/6, 1/2, 1/3) and (1/2, 1/6, 1/3) for edge B−A, with the mirror-image triple for edge C−A. All weights are strictly positive and sum to 1, so both points are interior — the four `norm_num` plus `rfl` obligations discharge `IsInterior`. Their difference is exactly ⅓(B−A), so by the parent's affine law `sumDist_sub` the distance-sum gap equals `rdot g (P−Q) = ⅓·⟪g, B−A⟫`, nonzero on the chosen branch; `linarith` then refutes equality. The two `rcases` branches are mirror images of each other.",
+    "mathContext": "$P - Q = (\\tfrac16-\\tfrac12)A + (\\tfrac12-\\tfrac16)B = \\tfrac13(B-A)$, hence $\\mathrm{sumDist}(P)-\\mathrm{sumDist}(Q) = \\langle g, P-Q\\rangle = \\tfrac13\\langle g, B-A\\rangle \\neq 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "barycentric perturbation",
+      "centroid",
+      "affine difference (sumDist_sub)",
+      "case split on a disjunction"
+    ],
+    "prerequisites": [
+      "the parent sumDist_sub affine law",
+      "the strictly-positive barycentric interior criterion"
     ]
   },
   {
     "id": "ann-not-constant",
     "proofId": "viviani-theorem-oq-01-oq-01-oq-02",
     "range": {
-      "startLine": 142,
+      "startLine": 139,
       "endLine": 149
     },
     "type": "theorem",
     "title": "No Constant Value on the Interior",
-    "content": "`sumDist_not_constant_on_interior`: for a non-degenerate, non-equilateral triangle there is no real number `k` such that `sumDist A B C P = k` for every interior point `P`. This is the packaged contrapositive form of the witness theorem — directly contradicting any claimed constant value by feeding the two distinct-sum interior witnesses through it — and it is the explicit realisation of the interior-witness open question recorded by the sibling entry viviani-theorem-oq-01-oq-01-oq-01.",
+    "content": "`sumDist_not_constant_on_interior`: for a non-degenerate, non-equilateral triangle there is no real number `k` with `sumDist A B C P = k` for every interior point `P`. This is the packaged contrapositive of the witness theorem — it feeds the two distinct-sum interior witnesses through any claimed constant `k` to derive `sumDist P = sumDist Q`, contradicting `hPQ`. It is the explicit realisation of the interior-witness open question recorded by the sibling entry viviani-theorem-oq-01-oq-01-oq-01.",
     "mathContext": "$\\neg\\,\\exists k,\\ \\forall P \\in \\mathrm{int}(ABC),\\ \\mathrm{sumDist}(P) = k$.",
     "significance": "supporting",
     "relatedConcepts": [
       "non-constant functional",
+      "contrapositive packaging",
       "converse of Viviani's theorem"
     ],
     "prerequisites": [


### PR DESCRIPTION
## Enrichment pass

Target `viviani-theorem-oq-01-oq-01-oq-02` — *interior witnesses of non-constancy for Viviani's converse* (quality 83, pass 0).

meta.json was already rich (14.8 KB, within caps). The 3 existing annotations left the construction-strategy docstring unannotated and treated the 78-line main proof as a single block.

### Changes (annotations.json only)
Raised annotation count 3 → 5:
- **ann-header-strategy** (4–43): the research-problem framing (sharpening abstract non-constancy to constructive *interior* witnesses) and the affine-gradient + ±1/6 centroid-perturbation strategy.
- Split the proof of `viviani_interior_witnesses` into its two natural phases: **reduction to a non-orthogonal gradient** via a 2×2 Cramer argument (55–94) and the **explicit ±1/6 centroid perturbation** producing the interior witnesses (95–137).
- Kept the `IsInterior` definition and the non-constancy restatement.

All five carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

### Verification
- Entry passes the annotation-line validator clean (the split sub-annotations resolve to the enclosing theorem construct); JSON parses; manifest regenerated.
- The downstream `tsc` typecheck can't run in this worktree (`pnpm install` fails on `better-sqlite3` native build under Node v26 — environmental, unrelated to this JSON-only change).
- No mathematical claims altered; meta.json unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)