### PR TITLE
research(erdos-1110-oq-01): multiplicative closure of representability [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1004OQ02.lean
+++ b/proofs/Proofs/Erdos1004OQ02.lean
@@ -26,6 +26,11 @@ totient value is attained by only finitely many integers (`totient_fiber_finite`
 (★) is **sharp** at `n = 2`, where `2·φ(2)² = 2·1 = 2`.  A real-analytic
 restatement `√(n/2) ≤ φ(n)` is recorded as well.
 
+The finiteness is moreover **effective**: the fiber over `v` is recovered by a
+finite search of `Iic (2v²)` (`totient_fiber_eq_filter`), giving a decidable
+enumeration domain and the explicit cardinality bound `#{n : φ(n)=v} ≤ 2v²+1`
+(`totient_fiber_ncard_le`), which is **sharp at `v = 0`**.
+
 ## The idea
 Both bounds are *multiplicative invariants*.  Factoring `n` into coprime
 prime powers, the inequality is tight only at the single prime power `2¹`
@@ -169,5 +174,57 @@ theorem totient_ge_sqrt_half (n : ℕ) :
   calc Real.sqrt ((n : ℝ) / 2)
         ≤ Real.sqrt ((Nat.totient n : ℝ) ^ 2) := Real.sqrt_le_sqrt h2
     _ = (Nat.totient n : ℝ) := Real.sqrt_sq (by positivity)
+
+/-! ### Effective finite-to-one: enumeration domain and explicit cardinality
+
+`totient_fiber_finite` is qualitative.  The fiber bound `n ≤ 2v²` makes the
+finiteness *effective*: the whole fiber is recovered by a finite search over
+`Iic (2v²)`, giving both a decidable enumeration domain and an explicit
+cardinality bound.  The cardinality bound is **sharp at `v = 0`**. -/
+
+/-- **Effective fiber description.** The (a priori infinite) set of integers with
+totient `v` equals the coercion of an explicit, computable `Finset`: it suffices
+to search the initial segment `Iic (2v²)`.  This upgrades the qualitative
+`totient_fiber_finite` to a concrete decidable enumeration domain. -/
+theorem totient_fiber_eq_filter (v : ℕ) :
+    {n : ℕ | Nat.totient n = v}
+      = ↑((Finset.Iic (2 * v ^ 2)).filter (fun n => Nat.totient n = v)) := by
+  ext n
+  simp only [Finset.coe_filter, Finset.mem_Iic, Set.mem_setOf_eq]
+  constructor
+  · intro h; exact ⟨totient_fiber_bound h, h⟩
+  · intro h; exact h.2
+
+/-- **Explicit fiber cardinality bound.** Each totient value `v` is attained by
+at most `2v² + 1` integers — the fiber sits inside `Iic (2v²)`, which has exactly
+`2v² + 1` elements.  Sharp at `v = 0`. -/
+theorem totient_fiber_ncard_le (v : ℕ) :
+    {n : ℕ | Nat.totient n = v}.ncard ≤ 2 * v ^ 2 + 1 := by
+  have hsub : {n : ℕ | Nat.totient n = v} ⊆ Set.Iic (2 * v ^ 2) := by
+    intro n hn
+    simp only [Set.mem_setOf_eq] at hn
+    exact Set.mem_Iic.mpr (totient_fiber_bound hn)
+  have hcard : (Set.Iic (2 * v ^ 2)).ncard = 2 * v ^ 2 + 1 := by
+    rw [← Finset.coe_Iic, Set.ncard_coe_finset, Nat.card_Iic]
+  calc {n : ℕ | Nat.totient n = v}.ncard
+      ≤ (Set.Iic (2 * v ^ 2)).ncard := Set.ncard_le_ncard hsub (Set.finite_Iic _)
+    _ = 2 * v ^ 2 + 1 := hcard
+
+/-- The unique solution of `φ(n) = 0` is `n = 0` (every positive integer has a
+positive totient).  This pins down the `v = 0` fiber. -/
+theorem totient_fiber_zero : {n : ℕ | Nat.totient n = 0} = {0} := by
+  ext n
+  simp only [Set.mem_setOf_eq, Set.mem_singleton_iff]
+  constructor
+  · intro h
+    by_contra hn
+    have hpos : 0 < Nat.totient n := Nat.totient_pos.mpr (Nat.pos_of_ne_zero hn)
+    omega
+  · rintro rfl; exact Nat.totient_zero
+
+/-- **Sharpness of the cardinality bound at `v = 0`.** Equality `1 = 2·0² + 1`
+holds: the fiber over `0` is the singleton `{0}`. -/
+example : {n : ℕ | Nat.totient n = 0}.ncard = 2 * 0 ^ 2 + 1 := by
+  rw [totient_fiber_zero]; simp
 
 end Erdos1004OQ02

--- a/proofs/Proofs/Erdos1110Problem.lean
+++ b/proofs/Proofs/Erdos1110Problem.lean
@@ -647,6 +647,145 @@ example : (3 : ℕ) ∈ NonRepresentable 5 2 :=
   add_one_nonRepresentable_of_lt (by norm_num) (by norm_num)
 
 /-
+## Part IIe: Multiplicative Closure of Representability (unconditional, 0-axiom)
+
+The `{2,3}` induction (`case_2_3_all_representable`) rested on a *doubling* step:
+multiplying a representing antichain by `2` keeps it a representing antichain
+(`isPowerForm_mul_two`, `noOneDividesAnother_image_mul_two`, …). That doubling is
+the `c = 2` instance of a single structural fact valid for **either base**: scaling
+a representation by `p` (or `q`) is again a representation. We record the general
+statement here.
+
+The key algebraic point is that the antichain ("no element divides another")
+relation is *invariant under scaling by a fixed positive constant*: `c·a ∣ c·b ↔
+a ∣ b`. Combined with the fact that `c · p^k q^l` is still a power form (with the
+exponent of the relevant base raised by one), this yields:
+
+* `IsRepresentable p q n ⟹ IsRepresentable p q (p·n)` and `(q·n)`;
+* by iteration, `IsRepresentable p q n ⟹ IsRepresentable p q (p^a q^b · n)` — the
+  set of representable numbers is closed under multiplication by every power form;
+* contrapositively, **non-representability propagates to power-form divisors**: if
+  `p^a q^b · n` is non-representable, then so is `n`.
+
+This is genuine structural theory (a `ℕ`-action of the multiplicative monoid of
+power forms on the representable set), 0-axiom, and it subsumes the ad-hoc doubling
+machinery. It does **not** resolve the open infinitude direction: the propagation
+goes *downward* (to divisors), so it cannot manufacture infinitely many
+non-representables from a single witness — the deep axiom `erdos_lewin_infinite`
+remains untouched.
+-/
+
+/-- Multiplying a power form by `p` stays a power form: `p · p^k q^l = p^{k+1} q^l`. -/
+lemma isPowerForm_mul_base_left {p q s : ℕ} (h : IsPowerForm p q s) :
+    IsPowerForm p q (s * p) := by
+  obtain ⟨k, l, rfl⟩ := h
+  exact ⟨k + 1, l, by ring⟩
+
+/-- Multiplying a power form by `q` stays a power form: `q · p^k q^l = p^k q^{l+1}`. -/
+lemma isPowerForm_mul_base_right {p q s : ℕ} (h : IsPowerForm p q s) :
+    IsPowerForm p q (s * q) := by
+  obtain ⟨k, l, rfl⟩ := h
+  exact ⟨k, l + 1, by ring⟩
+
+/-- Scaling every element of an antichain by a fixed positive `c` preserves the
+antichain property, since `c·a ∣ c·b ↔ a ∣ b`. (Generalises
+`noOneDividesAnother_image_mul_two`, the `c = 2` case.) -/
+lemma noOneDividesAnother_image_mul_const {S : Finset ℕ} {c : ℕ} (hc : 0 < c)
+    (hS : NoOneDividesAnother S) :
+    NoOneDividesAnother (S.image (· * c)) := by
+  intro a ha b hb hab
+  rw [Finset.mem_image] at ha hb
+  obtain ⟨a', ha', rfl⟩ := ha
+  obtain ⟨b', hb', rfl⟩ := hb
+  have hne : a' ≠ b' := by intro heq; subst heq; exact hab rfl
+  intro hdvd
+  exact hS a' ha' b' hb' hne ((Nat.mul_dvd_mul_iff_right hc).mp hdvd)
+
+/-- Multiplication by a positive constant is injective on a `Finset` of naturals. -/
+lemma mul_const_injOn (S : Finset ℕ) {c : ℕ} (hc : 0 < c) :
+    Set.InjOn (· * c) (↑S) := by
+  intro a _ b _ h
+  exact Nat.eq_of_mul_eq_mul_right hc h
+
+/-- Scaling the antichain by `c` scales its sum by `c`. -/
+lemma sum_image_mul_const {S : Finset ℕ} {c : ℕ} (hinj : Set.InjOn (· * c) (↑S)) :
+    (S.image (· * c)).sum id = c * S.sum id := by
+  rw [Finset.sum_image (fun a ha b hb => hinj ha hb)]
+  simp [Finset.mul_sum, mul_comm]
+
+/-- **Representability is closed under multiplication by `p`** (unconditional,
+0-axiom). Scale a representing antichain of `n` by `p`: each summand `p^k q^l`
+becomes `p^{k+1} q^l` (still a power form), the antichain property is preserved
+(`noOneDividesAnother_image_mul_const`), and the sum scales to `p·n`. -/
+theorem isRepresentable_mul_base_left {p q n : ℕ} (hp : 0 < p)
+    (h : IsRepresentable p q n) : IsRepresentable p q (p * n) := by
+  obtain ⟨S, hne, hpf, hac, hsum⟩ := h
+  refine ⟨S.image (· * p), Finset.Nonempty.image hne _, ?_, ?_, ?_⟩
+  · intro s hs
+    rw [Finset.mem_image] at hs
+    obtain ⟨a, ha, rfl⟩ := hs
+    exact isPowerForm_mul_base_left (hpf a ha)
+  · exact noOneDividesAnother_image_mul_const hp hac
+  · rw [sum_image_mul_const (mul_const_injOn S hp), hsum]
+
+/-- **Representability is closed under multiplication by `q`** (unconditional,
+0-axiom). Same argument scaling by `q`; each summand `p^k q^l` becomes
+`p^k q^{l+1}`. -/
+theorem isRepresentable_mul_base_right {p q n : ℕ} (hq : 0 < q)
+    (h : IsRepresentable p q n) : IsRepresentable p q (q * n) := by
+  obtain ⟨S, hne, hpf, hac, hsum⟩ := h
+  refine ⟨S.image (· * q), Finset.Nonempty.image hne _, ?_, ?_, ?_⟩
+  · intro s hs
+    rw [Finset.mem_image] at hs
+    obtain ⟨a, ha, rfl⟩ := hs
+    exact isPowerForm_mul_base_right (hpf a ha)
+  · exact noOneDividesAnother_image_mul_const hq hac
+  · rw [sum_image_mul_const (mul_const_injOn S hq), hsum]
+
+/-- Closure under multiplication by `p^a` (iterating `isRepresentable_mul_base_left`). -/
+theorem isRepresentable_mul_pow_left {p q n : ℕ} (hp : 0 < p) (a : ℕ)
+    (h : IsRepresentable p q n) : IsRepresentable p q (p ^ a * n) := by
+  induction a with
+  | zero => simpa using h
+  | succ k ih =>
+    have h2 := isRepresentable_mul_base_left hp ih
+    have heq : p ^ (k + 1) * n = p * (p ^ k * n) := by ring
+    rwa [heq]
+
+/-- Closure under multiplication by `q^b` (iterating `isRepresentable_mul_base_right`). -/
+theorem isRepresentable_mul_pow_right {p q n : ℕ} (hq : 0 < q) (b : ℕ)
+    (h : IsRepresentable p q n) : IsRepresentable p q (q ^ b * n) := by
+  induction b with
+  | zero => simpa using h
+  | succ k ih =>
+    have h2 := isRepresentable_mul_base_right hq ih
+    have heq : q ^ (k + 1) * n = q * (q ^ k * n) := by ring
+    rwa [heq]
+
+/-- **Representability is closed under multiplication by every power form**
+(unconditional, 0-axiom). If `n` is representable then so is `p^a q^b · n`: the
+representable set is invariant under the multiplicative monoid action of the power
+forms. This is the full structural generalisation of the `{2,3}` doubling step. -/
+theorem isRepresentable_mul_powerForm {p q n : ℕ} (hp : 0 < p) (hq : 0 < q)
+    (a b : ℕ) (h : IsRepresentable p q n) :
+    IsRepresentable p q (p ^ a * q ^ b * n) := by
+  have h1 := isRepresentable_mul_pow_left hp a h
+  have h2 := isRepresentable_mul_pow_right hq b h1
+  have heq : p ^ a * q ^ b * n = q ^ b * (p ^ a * n) := by ring
+  rwa [heq]
+
+/-- **Non-representability propagates to power-form divisors** (unconditional,
+0-axiom). Contrapositive of `isRepresentable_mul_powerForm`: if `p^a q^b · n` is
+non-representable, then `n` itself is non-representable. (The implication runs
+*downward* to smaller divisors, so it does not generate new non-representables —
+the open infinitude direction is unaffected.) -/
+theorem nonRepresentable_of_mul_powerForm {p q n a b : ℕ} (hp : 0 < p) (hq : 0 < q)
+    (h : (p ^ a * q ^ b * n) ∈ NonRepresentable p q) :
+    n ∈ NonRepresentable p q := by
+  rw [NonRepresentable, Set.mem_setOf_eq] at h ⊢
+  exact fun hrep => h (isRepresentable_mul_powerForm hp hq a b hrep)
+
+/-
 ## Part III: General Case (p,q) ≠ (2,3)
 -/
 

--- a/research/problems/erdos-1110-oq-01/state.md
+++ b/research/problems/erdos-1110-oq-01/state.md
@@ -86,3 +86,36 @@ remaining unused `minSummandBound`/`CoprimeNonRepresentable` scaffolding.
 - Total attempts: 0
 - Current approach attempts: 0
 - Approaches tried: 0
+
+## S6 ACT (researcher-8, 2026-06-28) — Multiplicative closure of representability, 0-axiom
+
+Generalized the `{2,3}`-specific *doubling* step into a base-symmetric structural
+theorem and added it as a new Part IIe:
+- `isPowerForm_mul_base_left/right`: `c·p^k q^l` is again a power form (`c = p` or `q`).
+- `noOneDividesAnother_image_mul_const` / `mul_const_injOn` / `sum_image_mul_const`:
+  the `c > 0` generalizations of the existing `c = 2` doubling helpers; the antichain
+  relation is scale-invariant (`c·a ∣ c·b ↔ a ∣ b`).
+- `isRepresentable_mul_base_left` / `isRepresentable_mul_base_right`: representability
+  closed under multiplication by `p` and by `q`.
+- `isRepresentable_mul_pow_left/right` and `isRepresentable_mul_powerForm`: by iteration,
+  closed under `×(p^a q^b)` — the full multiplicative monoid action of the power forms.
+- `nonRepresentable_of_mul_powerForm`: contrapositive — non-representability propagates
+  DOWNWARD to power-form divisors.
+
+Docker-build verified (`Proofs.Erdos1110Problem`, EXIT 0, 0 sorries). Only warning is the
+pre-existing unused `hpos` in the old `noOneDividesAnother_image_mul_two`.
+
+Honest scope: the closure runs the wrong way for the open problem — it propagates
+non-representability only to *smaller* divisors, so it cannot manufacture infinitely
+many non-representables. The single deep axiom `erdos_lewin_infinite` (Erdős–Lewin 1996,
+the upward/infinitude direction) is UNCHANGED. This is structural theory, not a step
+toward eliminating the axiom.
+
+## Current Focus
+
+The deep infinitude direction `erdos_lewin_infinite` remains the sole residual axiom.
+
+## Next Action
+
+Give `minSummandBound` content or remove it; or attempt higher-window characterization
+combining multiplicative closure with the `[q,2q)` window result.

--- a/src/data/proofs/erdos-1004-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1004-oq-02/annotations.json
@@ -2,85 +2,188 @@
   {
     "id": "ann-erdos1004oq02-header",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 3, "endLine": 41 },
+    "range": {
+      "startLine": 3,
+      "endLine": 41
+    },
     "type": "context",
     "title": "Why finite fibers make the run question well-posed",
     "content": "The header sets up the role of this entry within Erdős #1004. The parent asks how long a run of distinct consecutive totient values φ(n+1),…,φ(n+K) can be; for that to constrain anything, each value must be attained by only finitely many integers. This file supplies that finite-to-one fact with an explicit, elementary, 0-axiom bound φ(n)² ≥ n/2, packaged as a multiplicative invariant so that a single per-prime-power inequality propagates to all n.",
     "mathContext": "$\\varphi(n)^2 \\ge n/2$, i.e. $n \\le 2\\varphi(n)^2$, sharp at $n=2$ ($2\\varphi(2)^2 = 2$); odd refinement $n \\le \\varphi(n)^2$ for odd $n$.",
     "significance": "context",
-    "relatedConcepts": ["Euler totient", "multiplicative functions", "finite fibers", "Erdős problems"],
-    "prerequisites": ["Euler totient", "number theory"]
+    "relatedConcepts": [
+      "Euler totient",
+      "multiplicative functions",
+      "finite fibers",
+      "Erdős problems"
+    ],
+    "prerequisites": [
+      "Euler totient",
+      "number theory"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-primepow-odd",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 49, "endLine": 64 },
+    "range": {
+      "startLine": 49,
+      "endLine": 64
+    },
     "type": "technique",
     "title": "Odd prime-power core: pᵏ ≤ φ(pᵏ)²",
     "content": "The strong (factor-of-2-free) bound for odd prime powers. Writing k = j+1 and φ(p^(j+1)) = p^j(p−1) (totient_prime_pow_succ), the claim p^j·p ≤ (p^j(p−1))² reduces, after pulling out p^j, to the base inequality p ≤ (p−1)² for p ≥ 3 — discharged by nlinarith after substituting p = m+3. The calc chain then scales by Q = p^j (using Q ≤ Q²) and folds back into a perfect square.",
     "mathContext": "For prime $p \\ge 3$, $k \\ge 1$: $p^k \\le \\varphi(p^k)^2$. Core fact $p \\le (p-1)^2$ holds for $p \\ge 3$ since $(p-1)^2 - p = p^2 - 3p + 1 > 0$.",
     "significance": "supporting",
-    "relatedConcepts": ["prime powers", "totient of prime power", "nlinarith", "polynomial inequalities"],
-    "prerequisites": ["Euler totient", "prime powers"]
+    "relatedConcepts": [
+      "prime powers",
+      "totient of prime power",
+      "nlinarith",
+      "polynomial inequalities"
+    ],
+    "prerequisites": [
+      "Euler totient",
+      "prime powers"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-primepow-two",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 66, "endLine": 82 },
+    "range": {
+      "startLine": 66,
+      "endLine": 82
+    },
     "type": "technique",
     "title": "General prime-power core: pᵏ ≤ 2·φ(pᵏ)²",
     "content": "The weaker bound carrying the factor of 2, valid for every prime including p = 2. The same reduction φ(p^(j+1)) = p^j(p−1) leaves the base inequality p ≤ 2(p−1)² for p ≥ 2 — true even at p = 2 where it reads 2 ≤ 2·1 = 2 (tight). This single factor of 2 at the prime 2 is the entire source of slack in the global bound, isolated here.",
     "mathContext": "For any prime $p$, $k \\ge 1$: $p^k \\le 2\\varphi(p^k)^2$. Base case $p \\le 2(p-1)^2$ is tight at $p = 2$ ($2 = 2\\cdot 1$).",
     "significance": "supporting",
-    "relatedConcepts": ["prime powers", "totient of prime power", "sharpness", "nlinarith"],
-    "prerequisites": ["Euler totient", "prime powers"]
+    "relatedConcepts": [
+      "prime powers",
+      "totient of prime power",
+      "sharpness",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "Euler totient",
+      "prime powers"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-invariant",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 86, "endLine": 132 },
+    "range": {
+      "startLine": 86,
+      "endLine": 132
+    },
     "type": "insight",
     "title": "The multiplicative invariant that closes the recursion",
     "content": "The heart of the proof. Neither bound alone is closed under coprime multiplication (the factor of 2 would double in a product), so the statement is strengthened to the conjunction P(n): (Odd n → n ≤ φ(n)²) ∧ (n ≤ 2φ(n)²). Nat.recOnPosPrimePosCoprime reduces P to: prime powers (handled by the two core lemmas), the base cases 0 and 1, and coprime products. In a coprime product a·b at most one factor is even, so the factor of 2 is spent on that one even factor while the bare odd bound covers the other — making P genuinely multiplicative. The coprime case splits on the parity of a, using gcd(a,b)=1 to force the other factor odd.",
     "mathContext": "$P(n): (\\text{Odd } n \\to n \\le \\varphi(n)^2) \\wedge (n \\le 2\\varphi(n)^2)$. With $\\varphi(ab) = \\varphi(a)\\varphi(b)$ for $\\gcd(a,b)=1$, at most one of $a,b$ is even, so the factor $2$ is never spent twice.",
     "significance": "key",
-    "relatedConcepts": ["multiplicative induction", "recOnPosPrimePosCoprime", "totient_mul", "coprime factorization", "strengthening hypotheses"],
-    "prerequisites": ["multiplicative functions", "coprimality", "induction principles"]
+    "relatedConcepts": [
+      "multiplicative induction",
+      "recOnPosPrimePosCoprime",
+      "totient_mul",
+      "coprime factorization",
+      "strengthening hypotheses"
+    ],
+    "prerequisites": [
+      "multiplicative functions",
+      "coprimality",
+      "induction principles"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-headline",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 134, "endLine": 147 },
+    "range": {
+      "startLine": 134,
+      "endLine": 147
+    },
     "type": "concept",
     "title": "Headline bounds and sharpness at n = 2",
     "content": "The two halves of the invariant are projected out as the public theorems: totient_sq_two_ge (n ≤ 2φ(n)² for all n) and totient_sq_ge_of_odd (n ≤ φ(n)² for odd n). The example 2 = 2·φ(2)², closed by kernel decide, certifies the constant 2 is optimal — it cannot be lowered without failing at n = 2. Using kernel decide rather than native_decide keeps the entry free of Lean.ofReduceBool.",
     "mathContext": "$n \\le 2\\varphi(n)^2$ (all $n$); $n \\le \\varphi(n)^2$ (odd $n$); sharp: $2 = 2\\varphi(2)^2$.",
     "significance": "key",
-    "relatedConcepts": ["totient lower bound", "sharpness", "kernel decide", "axiom-free"],
-    "prerequisites": ["Euler totient"]
+    "relatedConcepts": [
+      "totient lower bound",
+      "sharpness",
+      "kernel decide",
+      "axiom-free"
+    ],
+    "prerequisites": [
+      "Euler totient"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-fiber",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 149, "endLine": 162 },
+    "range": {
+      "startLine": 149,
+      "endLine": 162
+    },
     "type": "insight",
     "title": "Finite-to-one: every totient fiber is finite",
     "content": "The structural payoff. From n ≤ 2φ(n)² follows the explicit fiber bound totient_fiber_bound: φ(n)=v ⟹ n ≤ 2v². Hence totient_fiber_finite shows {n : φ(n) = v} is finite by exhibiting it as a subset of the finite initial segment Iic (2v²) = {0,…,2v²}. This is exactly the finite-to-one property the parent problem presupposes — without it, distinctness of consecutive totient values would impose no arithmetic constraint.",
     "mathContext": "$\\varphi(n) = v \\Rightarrow n \\le 2v^2$, so $\\{n : \\varphi(n) = v\\} \\subseteq \\{0, 1, \\dots, 2v^2\\}$ is finite for every $v$.",
     "significance": "key",
-    "relatedConcepts": ["finite fibers", "finite-to-one maps", "Set.Finite", "initial segments"],
-    "prerequisites": ["Euler totient", "finiteness of sets"]
+    "relatedConcepts": [
+      "finite fibers",
+      "finite-to-one maps",
+      "Set.Finite",
+      "initial segments"
+    ],
+    "prerequisites": [
+      "Euler totient",
+      "finiteness of sets"
+    ]
   },
   {
     "id": "ann-erdos1004oq02-real",
     "proofId": "erdos-1004-oq-02",
-    "range": { "startLine": 164, "endLine": 172 },
+    "range": {
+      "startLine": 164,
+      "endLine": 172
+    },
     "type": "context",
     "title": "Real-analytic restatement √(n/2) ≤ φ(n)",
     "content": "The only analytic touch in an otherwise purely arithmetic file. Casting n ≤ 2φ(n)² into ℝ gives n/2 ≤ φ(n)²; monotonicity of √ (Real.sqrt_le_sqrt) plus Real.sqrt_sq on the nonnegative φ(n) yields √(n/2) ≤ φ(n). This is the familiar textbook form of the bound, recovered here as a corollary of the integer inequality rather than proved analytically.",
     "mathContext": "$\\sqrt{n/2} \\le \\varphi(n)$, from $n/2 \\le \\varphi(n)^2$ via $\\sqrt{\\cdot}$ monotone and $\\sqrt{x^2} = x$ for $x \\ge 0$.",
     "significance": "supporting",
-    "relatedConcepts": ["square root", "monotonicity", "casting ℕ to ℝ", "Real.sqrt_sq"],
-    "prerequisites": ["real analysis", "square roots"]
+    "relatedConcepts": [
+      "square root",
+      "monotonicity",
+      "casting ℕ to ℝ",
+      "Real.sqrt_sq"
+    ],
+    "prerequisites": [
+      "real analysis",
+      "square roots"
+    ]
+  },
+  {
+    "id": "ann-erdos1004oq02-effective",
+    "proofId": "erdos-1004-oq-02",
+    "range": {
+      "startLine": 174,
+      "endLine": 230
+    },
+    "type": "insight",
+    "title": "Effective finite-to-one: enumeration domain and explicit cardinality",
+    "content": "Upgrades the qualitative finiteness to a constructive, quantitative form. totient_fiber_eq_filter rewrites the (a priori infinite) set {n : φ(n)=v} as the coercion of the explicit, computable Finset (Iic (2v²)).filter (fun n => φ n = v): to find every preimage of v it suffices to test n ≤ 2v², a decidable enumeration domain. totient_fiber_ncard_le then bounds the count by #{n : φ(n)=v} ≤ 2v²+1, proved by Set.ncard_le_ncard into Iic (2v²) together with Nat.card_Iic. The bound is sharp at v=0: totient_fiber_zero shows the only solution of φ(n)=0 is n=0, so the fiber is the singleton {0} and 1 = 2·0²+1.",
+    "mathContext": "$\\{n:\\varphi(n)=v\\} = \\uparrow\\big((\\mathrm{Iic}\\,2v^2)\\text{.filter}(\\varphi\\,\\cdot = v)\\big)$ and $\\#\\{n:\\varphi(n)=v\\}\\le 2v^2+1$, attained at $v=0$ ($\\{0\\}$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "effective finiteness",
+      "decidable enumeration",
+      "Set.ncard",
+      "Finset.filter",
+      "totient multiplicity"
+    ],
+    "prerequisites": [
+      "Euler totient",
+      "finiteness of sets",
+      "cardinality"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-1004-oq-02/meta.json
+++ b/src/data/proofs/erdos-1004-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1004-oq-02",
   "title": "Erdős #1004: Why Totient Fibers Are Finite — the Elementary Bound φ(n)² ≥ n/2",
   "slug": "erdos-1004-oq-02",
-  "description": "Companion to the Erdős #1004 entry (distinct consecutive totient values). For the question 'how long a run φ(n+1),…,φ(n+K) of pairwise-distinct totient values can be' to be meaningful, each totient value must be attained by only finitely many integers; otherwise distinctness of values carries no arithmetic information. This entry supplies that structural fact with an explicit, fully verified, 0-axiom bound: n ≤ 2·φ(n)² for every n (totient_sq_two_ge), equivalently φ(n) ≥ √(n/2) (totient_ge_sqrt_half), with the sharp odd refinement n ≤ φ(n)² for odd n (totient_sq_ge_of_odd). From it, φ(n)=v ⟹ n ≤ 2v² (totient_fiber_bound), so every totient value has a finite fiber contained in an explicit initial segment (totient_fiber_finite) — the reason runs of distinct totient values are a well-posed object. The proof is a multiplicative-invariant argument: factoring n into coprime prime powers, the inequality is tight only at the single prime power 2¹ (φ(2)=1); the strengthened conjunction (Odd n → n ≤ φ(n)²) ∧ (n ≤ 2φ(n)²) is closed under coprime multiplication because in a coprime product at most one factor is even, so the lone factor-of-2 deficit is never spent twice. Proved by Nat.recOnPosPrimePosCoprime with per-prime-power one-variable polynomial inequalities (nlinarith). The bound is SHARP at n=2 (2·φ(2)²=2). Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
+  "description": "Companion to the Erdős #1004 entry (distinct consecutive totient values). For the question 'how long a run φ(n+1),…,φ(n+K) of pairwise-distinct totient values can be' to be meaningful, each totient value must be attained by only finitely many integers; otherwise distinctness of values carries no arithmetic information. This entry supplies that structural fact with an explicit, fully verified, 0-axiom bound: n ≤ 2·φ(n)² for every n (totient_sq_two_ge), equivalently φ(n) ≥ √(n/2) (totient_ge_sqrt_half), with the sharp odd refinement n ≤ φ(n)² for odd n (totient_sq_ge_of_odd). From it, φ(n)=v ⟹ n ≤ 2v² (totient_fiber_bound), so every totient value has a finite fiber contained in an explicit initial segment (totient_fiber_finite) — the reason runs of distinct totient values are a well-posed object. The proof is a multiplicative-invariant argument: factoring n into coprime prime powers, the inequality is tight only at the single prime power 2¹ (φ(2)=1); the strengthened conjunction (Odd n → n ≤ φ(n)²) ∧ (n ≤ 2φ(n)²) is closed under coprime multiplication because in a coprime product at most one factor is even, so the lone factor-of-2 deficit is never spent twice. Proved by Nat.recOnPosPrimePosCoprime with per-prime-power one-variable polynomial inequalities (nlinarith). The bound is SHARP at n=2 (2·φ(2)²=2). The finiteness is moreover made EFFECTIVE: the fiber over v is the coercion of an explicit, computable Finset obtained by searching the segment Iic(2v²) (totient_fiber_eq_filter), yielding the explicit cardinality bound #{n:φ(n)=v} ≤ 2v²+1 (totient_fiber_ncard_le), which is sharp at v=0. Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
   "meta": {
     "author": "lean-genius researcher",
     "sourceUrl": "https://erdosproblems.com/1004",
@@ -53,6 +53,7 @@
       "totient_sq_ge_of_odd: PROVED the sharp odd refinement n ≤ φ(n)² for odd n (the factor of 2 is needed only at the prime 2)",
       "totient_invariant: PROVED the strengthened conjunction (Odd n → n ≤ φ(n)²) ∧ (n ≤ 2φ(n)²) is a multiplicative invariant, the key device making the recursion close",
       "totient_fiber_bound / totient_fiber_finite: DERIVED the explicit fiber bound φ(n)=v ⟹ n ≤ 2v² and finiteness of every totient fiber — the structural reason distinct totient runs are well-posed",
+      "totient_fiber_eq_filter / totient_fiber_ncard_le: UPGRADED finiteness to an EFFECTIVE form — the fiber equals an explicit Finset searched over Iic(2v²) (decidable enumeration domain) and #{n:φ(n)=v} ≤ 2v²+1, sharp at v=0 (witnessed by totient_fiber_zero: the only solution of φ(n)=0 is n=0)",
       "totient_ge_sqrt_half: PROVED the real-analytic restatement √(n/2) ≤ φ(n)",
       "primePow_odd_bound / primePow_two_bound: PROVED the per-prime-power cores p^k ≤ φ(p^k)² (odd p) and p^k ≤ 2φ(p^k)² (any p) by elementary polynomial inequalities"
     ],
@@ -62,7 +63,7 @@
       "Euler totient as a multiplicative function; φ(p^k) = p^(k-1)(p-1)",
       "Multiplicative induction over coprime factorizations"
     ],
-    "lineCount": 173,
+    "lineCount": 230,
     "relatedProblems": [
       {
         "id": "erdos-1004",
@@ -74,14 +75,14 @@
       }
     ],
     "assumptions": "None. 0 axioms, 0 sorries (the theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound; the single sharpness witness at n=2 uses kernel `decide`, NOT `native_decide`, so no `Lean.ofReduceBool` is introduced). The bound n ≤ 2φ(n)² is a classical elementary fact; the contribution is a clean, fully verified, 0-axiom formalization via a multiplicative invariant, together with the explicit totient-fiber finiteness that underpins Erdős #1004.",
-    "theoremCount": 6,
+    "theoremCount": 9,
     "definitionCount": 0,
     "structureCount": 0
   },
   "overview": {
     "historicalContext": "Erdős Problem #1004 asks, for c > 0 and large x, whether some n ≤ x has φ(n+1),…,φ(n+⌊(log x)^c⌋) all distinct — how long a run of consecutive integers can carry pairwise-distinct Euler totients. Implicit in even posing the question is that φ is finite-to-one: each value is attained by only finitely many integers, so that 'distinct values' is a genuine constraint. The quantitative form of this is the classical lower bound φ(n) ≥ √(n/2): the totient cannot be too small relative to n, hence cannot repeat a given value indefinitely. This bound is elementary but, like most multiplicative-function estimates, is cleanest when organized as a multiplicative invariant.",
     "problemStatement": "Prove, unconditionally and axiom-free, an explicit lower bound on the Euler totient (φ(n) ≥ √(n/2)) and derive from it that every totient value has a finite fiber inside an explicit initial segment — the structural fact that makes distinct-totient-run questions well-posed.",
-    "text": "A 173-line self-contained file proving n ≤ 2·φ(n)² for all n (with the sharp odd refinement n ≤ φ(n)²), the real restatement √(n/2) ≤ φ(n), the explicit fiber bound φ(n)=v ⟹ n ≤ 2v², and finiteness of every totient fiber — all 0 sorries, 0 axioms, no native_decide.",
+    "text": "A 230-line self-contained file proving n ≤ 2·φ(n)² for all n (with the sharp odd refinement n ≤ φ(n)²), the real restatement √(n/2) ≤ φ(n), the explicit fiber bound φ(n)=v ⟹ n ≤ 2v², finiteness of every totient fiber, and its effective refinement (explicit Finset enumeration domain plus the cardinality bound #{n:φ(n)=v} ≤ 2v²+1, sharp at v=0) — all 0 sorries, 0 axioms, no native_decide.",
     "proofStrategy": "The bound is a multiplicative invariant. Per prime power, φ(p^(k+1)) = p^k(p−1), and the inequality p^k ≤ φ(p^k)² (for odd p) / p^k ≤ 2φ(p^k)² (any p) reduces, after factoring p^k, to the one-variable polynomial fact p ≤ (p−1)² / p ≤ 2(p−1)², dispatched by nlinarith. To combine prime powers one must control the single deficient factor φ(2)=1, so the statement is strengthened to the conjunction P(n): (Odd n → n ≤ φ(n)²) ∧ (n ≤ 2φ(n)²). In a coprime product a·b at most one factor is even, so the 'factor of 2' is spent on that one even factor and the bare bound n ≤ φ(n)² covers the odd one — making P closed under coprime multiplication. Nat.recOnPosPrimePosCoprime assembles the prime-power and coprime cases into a proof for all n. The fiber statements follow by substitution; the real form by monotonicity of √ and Real.sqrt_sq.",
     "keyInsights": [
       "**Finite fibers make the question meaningful.** φ(n) ≥ √(n/2) gives φ(n)=v ⟹ n ≤ 2v², so each totient value is attained finitely often — without this, 'distinct consecutive totient values' would impose no constraint.",
@@ -145,6 +146,13 @@
       "startLine": 164,
       "endLine": 172,
       "summary": "totient_ge_sqrt_half: √(n/2) ≤ φ(n), obtained from the integer bound by casting to ℝ and applying monotonicity of √ with Real.sqrt_sq."
+    },
+    {
+      "id": "effective",
+      "title": "Effective finite-to-one: enumeration and cardinality",
+      "startLine": 174,
+      "endLine": 230,
+      "summary": "totient_fiber_eq_filter expresses the (a priori infinite) fiber {n : φ(n)=v} as the coercion of the explicit Finset (Iic (2v²)).filter (φ · = v) — a decidable enumeration domain; totient_fiber_ncard_le bounds its cardinality by 2v²+1 (via Set.ncard_le_ncard into Iic and Nat.card_Iic); totient_fiber_zero pins the v=0 fiber to {0}, witnessing sharpness 1 = 2·0²+1."
     }
   ],
   "crossReferences": [
@@ -160,13 +168,13 @@
     }
   ],
   "leanFile": {
-    "lineCount": 173,
+    "lineCount": 230,
     "namespace": "Erdos1004OQ02",
     "opens": ["Nat"],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 6,
-    "substantiveTheoremCount": 5,
+    "theoremCount": 9,
+    "substantiveTheoremCount": 8,
     "computationalVerifications": 1,
     "lemmaCount": 2,
     "imports": ["Mathlib"],
@@ -176,7 +184,7 @@
   },
   "conclusion": {
     "summary": "A fully machine-checked (0 sorries, 0 axioms) elementary lower bound on the Euler totient: n ≤ 2·φ(n)² for every n (φ(n) ≥ √(n/2)), with the sharp odd refinement n ≤ φ(n)², proved as a multiplicative invariant via Nat.recOnPosPrimePosCoprime. From it follows the explicit fiber bound φ(n)=v ⟹ n ≤ 2v² and finiteness of every totient fiber.",
-    "implications": "Makes precise the finite-to-one property of φ that underlies Erdős #1004: each totient value is attained by only finitely many integers, lying in an explicit initial segment {0,…,2v²}. Complements the sibling oq-03 (which bounds run length from above) by bounding totient values from below, and isolates the single source of slack (the prime 2) in the classical √(n/2) estimate.",
+    "implications": "Makes precise the finite-to-one property of φ that underlies Erdős #1004: each totient value is attained by only finitely many integers, lying in an explicit initial segment {0,…,2v²}. Complements the sibling oq-03 (which bounds run length from above) by bounding totient values from below, and isolates the single source of slack (the prime 2) in the classical √(n/2) estimate. The finiteness is moreover effective: the fiber over v is recovered by a finite, decidable search of Iic(2v²) and has at most 2v²+1 elements (sharp at v=0), turning 'finite-to-one' into a computable enumeration with an explicit cardinality bound.",
     "openQuestions": [
       "Sharpen the constant by tracking the 2-adic valuation: integers with many distinct odd prime factors have φ much larger than √(n/2), so a refined bound φ(n) ≥ c·√(n·ω(n)) or similar may be provable elementarily.",
       "Combine the fiber bound n ≤ 2v² with oq-03's run-length bound to give an explicit, axiom-free count of how many distinct totient values appear among {φ(1),…,φ(N)}.",
@@ -213,6 +221,18 @@
       "type": "supporting",
       "description": "Real-analytic restatement √(n/2) ≤ φ(n) (PROVED, 0 axioms)",
       "leanType": "∀ (n : ℕ), Real.sqrt ((n : ℝ) / 2) ≤ (Nat.totient n : ℝ)"
+    },
+    {
+      "name": "totient_fiber_ncard_le",
+      "type": "core",
+      "description": "Effective finite-to-one: each totient value v is attained by at most 2v²+1 integers; sharp at v=0 (PROVED, 0 axioms)",
+      "leanType": "∀ (v : ℕ), {n : ℕ | Nat.totient n = v}.ncard ≤ 2 * v ^ 2 + 1"
+    },
+    {
+      "name": "totient_fiber_eq_filter",
+      "type": "supporting",
+      "description": "Effective enumeration domain: {n : φ(n)=v} equals the coercion of the explicit Finset (Iic (2v²)).filter (φ·=v) (PROVED, 0 axioms)",
+      "leanType": "∀ (v : ℕ), {n : ℕ | Nat.totient n = v} = ↑((Finset.Iic (2 * v ^ 2)).filter (fun n => Nat.totient n = v))"
     }
   ],
   "sections": [
@@ -263,6 +283,14 @@
       "endLine": 172,
       "summary": "totient_ge_sqrt_half recasts the integer bound over ℝ as √(n/2) ≤ φ(n) via Real.sqrt_le_sqrt and Real.sqrt_sq — the only analytic step in an otherwise elementary file.",
       "mathContext": "$\\sqrt{n/2}\\le\\varphi(n)$, the classical analytic form of the totient lower bound."
+    },
+    {
+      "id": "effective",
+      "title": "Effective finite-to-one: enumeration and cardinality",
+      "startLine": 174,
+      "endLine": 230,
+      "summary": "Upgrades the qualitative finiteness to an effective form: totient_fiber_eq_filter writes the fiber as an explicit decidable Finset search over Iic (2v²); totient_fiber_ncard_le gives #{n : φ(n)=v} ≤ 2v²+1; totient_fiber_zero shows the v=0 fiber is {0}, so the bound is sharp at v=0.",
+      "mathContext": "$\\#\\{n:\\varphi(n)=v\\}\\le 2v^2+1$, attained at $v=0$ where the fiber is $\\{0\\}$."
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -262,9 +262,9 @@
       "Finset"
     ],
     "namespace": "Erdos1110",
-    "lineCount": 951,
+    "lineCount": 1090,
     "axiomCount": 1,
-    "theoremCount": 39,
+    "theoremCount": 51,
     "definitionCount": 7,
     "path": "Proofs/Erdos1110Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1110-oq-01.json
+++ b/src/data/research/problems/erdos-1110-oq-01.json
@@ -33,7 +33,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "The {2,3} case is fully solved 0-axiom (representability + NonRepresentable={0}). Iter 2 proved the EASY Erdos-Lewin direction unconditionally, weakening the axiom to the deep hard direction only (erdos_lewin_infinite). Iter 3 (S4): proved the {2,3} Yu-Chen density-zero instance 0-axiom (HasDensity (NonRepresentable 2 3) 0). Iter 4 (researcher-10): proved the unconditional EXISTENCE shadow of the deep infinitude axiom 0-axiom — every coprime pair {p,q}!={2,3} has at least one POSITIVE non-representable number (exists_positive_nonRepresentable_of_ne_two_three), with universal witnesses 2 (q>=3) and 3 (q=2). Iter 4 (S5, researcher-3): settled the {2,3} Yu-Chen COPRIME case 0-axiom — CoprimeNonRepresentable {2,3} = empty (the only non-representable 0 is not coprime to 6), with density-zero corollaries via hasDensity_empty; first content for the previously-unused CoprimeNonRepresentable def. Residual assumption unchanged: the single deep axiom erdos_lewin_infinite (existence=>infinitude jump, not in Mathlib).",
+    "progressSummary": "PROGRESS (S6): proved multiplicative closure of representability (×p, ×q, ×p^a q^b) and downward non-rep propagation, 0-axiom — structural generalization of the {2,3} doubling. Deep axiom erdos_lewin_infinite unchanged (closure is downward, cannot give infinitude).",
     "builtItems": [
       "add_one_nonRepresentable_iff (iter 5, researcher-8, 0-axiom): sharp criterion for the canonical candidate q+1. For every p>q>=2, q+1 (always in the window [q,2q)) is non-representable EXACTLY when q+1 is not a power of p: (q+1) in NonRepresentable p q <-> not exists k, q+1 = p^k. Forced via the window characterization isRepresentable_iff_isPowerForm_window: the only power form q+1 can be is a pure power of p, since a q^l factor with l>=1 gives q | q+1 hence q | 1. For q=2 this isolates {2,3} as the unique q=2 exception (3 = 3^1 is a power form exactly when p=3).",
       "add_one_nonRepresentable_of_lt (iter 5, researcher-8, 0-axiom): if q>=2 and q+1 < p (i.e. p >= q+2) then q+1 is non-representable, because q+1 can be no power p^k (p^0=1<q+1, p^k>=p>q+1 for k>=1). Trivially-checkable explicit witness for every pair with p>=q+2; verified instance 3 in NonRepresentable 5 2.",
@@ -50,7 +50,11 @@
       "hasDensity_singleton_zero (0-axiom): a single point has natural density 0 (count=1, ratio 1/n -> 0).",
       "nonRepresentable_two_three_density_zero / _three_two_density_zero (0-axiom): the {2,3} non-representable set {0} has density zero — the sharpest Yu-Chen density-zero instance, giving content to the previously def-only HasDensity scaffolding.",
       "coprimeNonRepresentable_two_three_eq_empty / _three_two_eq_empty (iter 4/S5, 0-axiom): the {2,3} Yu-Chen COPRIME non-representable set is EMPTY — NonRepresentable 2 3 = {0} and 0 is not coprime to 2*3=6 (Nat.coprime_zero_left: Coprime 0 6 iff 6=1, false). Sharpens Yu-Chen's '{2,3}-excluded' coprime infinitude: zero coprime non-representables, not merely finitely many. First content for the previously-unused CoprimeNonRepresentable def.",
-      "hasDensity_empty (0-axiom): the empty set has natural density 0 (numerator always 0) — feeds coprimeNonRepresentable_two_three_density_zero / _three_two_density_zero."
+      "hasDensity_empty (0-axiom): the empty set has natural density 0 (numerator always 0) — feeds coprimeNonRepresentable_two_three_density_zero / _three_two_density_zero.",
+      "isRepresentable_mul_base_left/right: representability closed under ×p and ×q (Erdos1110Problem.lean) — scale antichain by a base, 0-axiom",
+      "isRepresentable_mul_powerForm: representable set closed under ×(p^a q^b), the full power-form monoid action generalizing the {2,3} doubling step, 0-axiom",
+      "nonRepresentable_of_mul_powerForm: non-representability propagates DOWNWARD to power-form divisors (contrapositive of closure), 0-axiom",
+      "Helpers noOneDividesAnother_image_mul_const / mul_const_injOn / sum_image_mul_const: c>0 generalizations of the c=2 doubling helpers"
     ],
     "insights": [
       "The deep infinitude axiom has an elementary EXISTENCE shadow: every non-{2,3} coprime pair has a SMALL universal non-representable witness — 2 when q>=3, 3 when q=2. The witness is forced purely by which power forms lie below it: below 2 only 1 exists (both bases>=3), below 3 only {1,2} (q=2, p>=4), and neither lets an antichain hit the target. The (3,2) pair is exactly the exception because there 3=3^1 IS a power form.",
@@ -61,16 +65,18 @@
       "omega cannot see through an un-beta-reduced lambda ((fun x=>x*2) a) nor multiply two unknowns (3^k * c); dsimp/explicit c=1 substitution fixes both. ring fails on Nat truncated subtraction; rw [pow_succ] then omega works.",
       "A subst is blocked when a `let`-bound local (k := Nat.log 3 n) depends on the variable; rewrite the goal with the equation instead of subst.",
       "The {2,3} case realizes Yu-Chen density-zero exactly: NonRepresentable={0} has density 0 (not just below some bound). Provable 0-axiom by reducing HasDensity {0} 0 to 1/n->0 via Finset.filter_eq' on the singleton.",
-      "Mathlib-4.26 gotcha: div_lt_iff renamed to div_lt_iff₀ (a/c<b iff a<b*c for 0<c); Finset.filter_eq' evaluates filter(.=a) to (if a in s then {a} else empty), sidestepping the Set-vs-Classical Decidable-instance mismatch that blocks rw on a hand-stated card lemma."
+      "Mathlib-4.26 gotcha: div_lt_iff renamed to div_lt_iff₀ (a/c<b iff a<b*c for 0<c); Finset.filter_eq' evaluates filter(.=a) to (if a in s then {a} else empty), sidestepping the Set-vs-Classical Decidable-instance mismatch that blocks rw on a hand-stated card lemma.",
+      "The {2,3} doubling step is the c=2 instance of a general structural fact: the antichain relation is scale-invariant (c·a | c·b iff a | b for c>0), so multiplying a representation by p or q is again a representation. Representables form a monoid-action-closed set under the power forms.",
+      "Multiplicative closure runs the WRONG way for infinitude: non-rep propagates only to (smaller) power-form divisors, so it cannot manufacture infinitely many non-representables from one witness. Confirms the deep axiom is genuinely needed for the upward/infinitude direction."
     ],
     "mathlibGaps": [
       "Erdos-Lewin deep direction: {p,q}!={2,3} (p>q>=2 coprime) => infinitely many non-representable numbers. Not in Mathlib 4.26.",
       "Yu-Chen density-zero and coprime-non-representable results (2022). Not in Mathlib."
     ],
     "nextSteps": [
-      "Attempt the deep direction erdos_lewin_infinite (or a concrete special case, e.g. a single (p,q)) to reduce/eliminate the last axiom — genuinely hard (Erdos-Lewin 1996, not in Mathlib).",
-      "CoprimeNonRepresentable {2,3} is now settled (= empty, S5). Remaining scaffolding gap: minSummandBound is still unused (no theorem exercises it) — give it content (a bound for the {2,3} case) or remove it.",
-      "Yu-Chen coprime INFINITUDE for non-{2,3} pairs (q>3, or q=3 p!=5, or q=2 p not in {3,5,9}) — a deeper companion to erdos_lewin_infinite, also not in Mathlib."
+      "Deep direction erdos_lewin_infinite (Erdos-Lewin 1996) remains the sole axiom; confirmed across 6 sessions as not session-sized and genuinely upward (closure cannot help).",
+      "minSummandBound is still unused scaffolding — give it content (e.g. minSummandBound 1 = 1 via sSup of Iio 1) or remove it.",
+      "Consider whether multiplicative closure + window characterization combine to characterize representability on higher windows [q·p^j, ...)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Erdős #1110 — Multiplicative closure of representability

Continues the rich `erdos-1110-oq-01` development (window characterization #31247, sharp `q+1` criterion #31359, Yu-Chen coprime ∅ #31197). This session generalizes the **doubling** step that powered the `{2,3}` induction into a base-symmetric **structural theorem**, fully unconditional and 0-axiom.

### What's new (Part IIe)
The antichain relation "no element divides another" is *scale-invariant*: `c·a ∣ c·b ↔ a ∣ b` for `c > 0`. Combined with `c · p^k q^l` staying a power form, this gives:

- `isRepresentable_mul_base_left` / `isRepresentable_mul_base_right` — representability closed under `×p` and `×q`.
- `isRepresentable_mul_pow_left/right`, `isRepresentable_mul_powerForm` — by iteration, closed under `×(p^a q^b)`: the full multiplicative monoid action of the power forms on the representable set. This subsumes the ad-hoc doubling helpers (`isPowerForm_mul_two`, etc.) used in `case_2_3_all_representable`.
- `nonRepresentable_of_mul_powerForm` — contrapositive: non-representability propagates **downward** to power-form divisors.

Supporting `c > 0` helpers (`noOneDividesAnother_image_mul_const`, `mul_const_injOn`, `sum_image_mul_const`) generalize the existing `c = 2` versions.

### Honest scope
This is structural theory, **not** a step toward eliminating the axiom. The closure propagates non-representability only to *smaller* divisors, so it cannot manufacture infinitely many non-representables from a witness. The single deep axiom `erdos_lewin_infinite` (Erdős–Lewin 1996, the genuinely hard upward/infinitude direction) is **unchanged**.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos1110Problem` → EXIT 0
- 0 sorries; 1 axiom (`erdos_lewin_infinite`, pre-existing), `status: axiomatized`
- Only warning is the pre-existing unused `hpos` in `noOneDividesAnother_image_mul_two`

🤖 Generated with [Claude Code](https://claude.com/claude-code)