### PR TITLE
research(erdos-1001-oq-02-oq-01): reduce axioms 4→2, derive convergence_rate_sharp [VERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos1001OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos1001OQ02OQ01.lean
@@ -24,10 +24,12 @@ Via Abel summation, the Walfisz bound propagates to the range totient sum:
 Since (log N)^(2/3) / log N = 1 / (log N)^(1/3) → 0, the improved rate is
 strictly smaller order than the O(log N / N) bound in OQ-02.
 
-**Proof content**:
-- `totient_sum_walfisz_error`: Walfisz's sharp totient partial sum error (axiom — deep)
-- `rangeTotientSum_walfisz_error`: improved range sum error from Walfisz (axiom — Abel sum)
-- `convergence_rate_sharp`: EST-regime reduction to the range sum (axiom — disjointness)
+**Proof content** (axioms reduced 4 → 2 on 2026-06-28; see history note below):
+- `rangeTotientSum_walfisz_error`: improved range sum error from Walfisz (axiom —
+  the only number-theoretic input, parallel to the parent's `rangeTotientSum_error`)
+- `est_reduction_to_rangeTotientSum`: pure measure-theoretic EST reduction of |S - f|
+  to the range totient sum error + O(A/N) boundary (axiom — disjointness geometry)
+- `convergence_rate_sharp`: now a THEOREM, derived from the two axioms above
 - `log_rpow_two_thirds_isLittleO_log`, `walfisz_rate_isLittleO_mertens_rate`,
   `walfisz_full_rate_isLittleO_mertens_rate`, `sharp_rate_isLittleO_oq02_rate`,
   `improvement_factor_tends_to_zero`: the asymptotic comparisons (all PROVED, 0 axioms,
@@ -35,9 +37,20 @@ strictly smaller order than the O(log N / N) bound in OQ-02.
 - `oq02_rate_not_sharp`: main result — O(log N / N) is NOT the tight rate (proved from
   `convergence_rate_sharp` + the asymptotic comparison)
 
-**Status**: AXIOMATIZED (3 deep number-theory inputs: Walfisz totient bound, its Abel-sum
-propagation, and the EST-regime reduction; plus the Mertens bound used for context).
-All real-analysis asymptotics are now fully PROVED (0 sorries).
+**Status**: AXIOMATIZED (2 load-bearing axioms: the Walfisz range-sum bound and the
+EST-regime measure reduction). The Mertens and Walfisz *totient partial sum* bounds are
+now commentary only — exactly as the parent OQ-02 keeps Mertens — since the proof uses
+only their Abel-summation consequence, `rangeTotientSum_walfisz_error`. All real-analysis
+asymptotics are fully PROVED (0 sorries).
+
+**History (2026-06-28, researcher-2)**: the previous version declared 4 axioms, but three
+of them (`totient_sum_mertens_error`, `totient_sum_walfisz_error`,
+`rangeTotientSum_walfisz_error`) were never referenced by any proof — the result rested
+entirely on a single monolithic `convergence_rate_sharp` axiom that *assumed its own
+conclusion* (the Walfisz rate for |S - f| directly). This refactor (a) drops the two dead
+totient-sum axioms to commentary, matching the parent's hygiene, (b) splits off the pure
+EST reduction as `est_reduction_to_rangeTotientSum`, and (c) derives `convergence_rate_sharp`
+as a theorem from that reduction + `rangeTotientSum_walfisz_error`, which is now load-bearing.
 
 **Related**: Erdos1001OQ02.lean (parent, established O(log N/N) rate)
 -/
@@ -95,38 +108,28 @@ noncomputable def partialTotientSum (n : ℕ) : ℝ :=
   ∑ y ∈ Finset.range (n + 1), (Nat.totient y : ℝ)
 
 /-
-## The Elementary vs. Walfisz Error Bounds
+## The Mertens and Walfisz Totient-Sum Bounds (commentary, not axioms)
 
-The parent proof (OQ-02) relied on the Mertens bound:
-  partialTotientSum n = (3/π²) n² + E(n),  E(n) = O(n log n)
+These two classical bounds on the totient partial sum `partialTotientSum` motivate
+the range-sum estimate below. Following the parent OQ-02 — which keeps Mertens as
+commentary rather than as a separate axiom — they are NOT axiomatized here: the only
+number-theoretic input we actually assume is their Abel-summation consequence,
+`rangeTotientSum_walfisz_error`. Stating them as `axiom`s as well (as a previous
+version did) added two assumptions that no proof referenced.
 
-Walfisz (1963) proved the dramatically sharper:
-  E(n) = O(n (log n)^(2/3) (log log n)^(4/3))
+  • Mertens (1874), the bound OQ-02 used:
+        ∑_{n≤x} φ(n) = (3/π²)x² + O(x log x).
+    Follows by partial summation from ∑_{n≤x} μ(n)/n = O(1).
 
-Both bounds are beyond Mathlib's current scope and must be axiomatized.
+  • Walfisz (1963), the sharp bound:
+        ∑_{n≤x} φ(n) = (3/π²)x² + O(x (log x)^(2/3) (log log x)^(4/3)).
+    Proved by Vinogradov's exponential-sum method via the Vinogradov–Korobov
+    zero-free region for ζ(s); ~60 pages in Walfisz, "Weylsche Exponentialsummen
+    in der neueren Zahlentheorie". Not in Mathlib (as of v4.26).
+
+The (log x)^(2/3) saving propagates through Abel summation to the range totient sum,
+which is exactly the content of the `rangeTotientSum_walfisz_error` axiom below.
 -/
-
-/-- The Mertens bound on the totient partial sum error (used in OQ-02).
-
-    This is the *weaker* bound: E(N) = O(N log N). -/
-axiom totient_sum_mertens_error :
-    (fun N : ℕ => |partialTotientSum N - densityConst * 2⁻¹ * N^2|)
-    =O[atTop] (fun N : ℕ => (N : ℝ) * Real.log N)
-
-/-- Walfisz's sharp bound on the totient partial sum error (1963).
-
-    Walfisz proved: ∑_{n≤x} φ(n) = (3/π²)x² + O(x (log x)^(2/3) (log log x)^(4/3))
-
-    This is the *sharp* bound — substantially better than Mertens' O(N log N).
-    The proof uses Vinogradov's exponential sum method via Dirichlet series for
-    L(s, χ) and zero-free regions for ζ(s); about 60 pages in Walfisz (1963)
-    "Weylsche Exponentialsummen in der neueren Zahlentheorie".
-
-    Not yet in Mathlib (as of v4.26). -/
-axiom totient_sum_walfisz_error :
-    (fun N : ℕ => |partialTotientSum N - densityConst * 2⁻¹ * N^2|)
-    =O[atTop] (fun N : ℕ => (N : ℝ) * (Real.log N) ^ ((2:ℝ)/3) *
-                             (Real.log (Real.log N)) ^ ((4:ℝ)/3))
 
 /-
 ## Comparison: Walfisz rate vs. Mertens rate
@@ -252,6 +255,26 @@ This answers the sub-question: the error does NOT "grow like log N / N" —
 it converges strictly faster.
 -/
 
+/-- **EST-regime measure reduction (axiom).** In the EST regime the approximation
+    intervals are disjoint, so the measure error reduces to the range totient sum
+    error plus an `O(A/N)` boundary correction:
+
+      |S(N,A,c) - f(A,c)| = O( A · (|rangeTotientSum N c - (6/π²) log c| + 1/N) ).
+
+    This is the pure measure-theoretic content (parallel to OQ-02's
+    `convergence_rate_est`), now stated WITHOUT baking in any totient bound — the
+    number theory enters only through `rangeTotientSum_walfisz_error`. Here
+    f(A,c) = 12A log(c)/π² = 2A · densityConst · log c, and the `O(A/N)` term collects
+    the boundary intervals near 0 and 1. Splitting this off (rather than axiomatizing
+    the final Walfisz rate for |S - f| directly, as the previous monolithic
+    `convergence_rate_sharp` axiom did) is what lets `convergence_rate_sharp` become a
+    theorem and makes `rangeTotientSum_walfisz_error` load-bearing. -/
+axiom est_reduction_to_rangeTotientSum (A c : ℝ) (hA : 0 < A) (hc : c > 1)
+    (hregime : inESTRegime A c) :
+    (fun N : ℕ => |S N A c - f A c|)
+    =O[atTop]
+    (fun N : ℕ => A * (|rangeTotientSum N c - densityConst * Real.log c| + 1 / N))
+
 /-- The O(log N / N) rate from OQ-02 is NOT sharp.
 
     In the EST regime, the actual convergence rate of S(N,A,c) to f(A,c)
@@ -261,22 +284,52 @@ it converges strictly faster.
 
     which is o(A log N / N).
 
-    **Proof structure**:
-    This follows from:
-    1. `rangeTotientSum_walfisz_error`: range sum error is O((log N)^(2/3+ε)/N)
-    2. `walfisz_full_rate_isLittleO_mertens_rate`: this rate is o(log N / N)
-    3. The reduction from |S - f| to the range sum error (parallel to OQ-02's
-       `convergence_rate_est` but with the sharper input)
-
-    **Axiom needed**: The EST regime reduction (parallel to OQ-02's `convergence_rate_est`)
-    is also axiomatized here, since it requires the same disjointness argument.
-    -/
-axiom convergence_rate_sharp (A c : ℝ) (hA : 0 < A) (hc : c > 1)
+    **Now a theorem** (was an axiom). It follows from:
+    1. `est_reduction_to_rangeTotientSum`: |S - f| = O(A·(rangeError + 1/N))
+    2. `rangeTotientSum_walfisz_error`: rangeError = O((log N)^(2/3)(log log N)^(4/3)/N)
+    3. `1/N = O((log N)^(2/3)(log log N)^(4/3)/N)`, since the Walfisz numerator → ∞.
+    Summing (2) and (3) bounds `rangeError + 1/N`, and rescaling by `A > 0` then composing
+    with (1) gives the claim. -/
+theorem convergence_rate_sharp (A c : ℝ) (hA : 0 < A) (hc : c > 1)
     (hregime : inESTRegime A c) :
     (fun N : ℕ => |S N A c - f A c|)
     =O[atTop]
     (fun N : ℕ => A * ((Real.log N) ^ ((2:ℝ)/3) *
-                       (Real.log (Real.log N)) ^ ((4:ℝ)/3) / N))
+                       (Real.log (Real.log N)) ^ ((4:ℝ)/3) / N)) := by
+  have hlogtop : Tendsto (fun N : ℕ => Real.log N) atTop atTop :=
+    tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  have hloglogtop : Tendsto (fun N : ℕ => Real.log (Real.log N)) atTop atTop :=
+    tendsto_log_atTop.comp hlogtop
+  -- The Walfisz range-sum error bound (the sole number-theoretic input).
+  have hRE := rangeTotientSum_walfisz_error c hc
+  -- The constant 1 is dominated by the Walfisz numerator (which → ∞).
+  have hconst : (fun _ : ℕ => (1:ℝ)) =O[atTop]
+      (fun N : ℕ => (Real.log N) ^ ((2:ℝ)/3) * (Real.log (Real.log N)) ^ ((4:ℝ)/3)) := by
+    rw [isBigO_iff]
+    refine ⟨1, ?_⟩
+    filter_upwards [hlogtop.eventually_ge_atTop 1, hloglogtop.eventually_ge_atTop 1]
+      with N hlog1 hloglog1
+    have hf1 : (1:ℝ) ≤ (Real.log N) ^ ((2:ℝ)/3) := by
+      simpa using Real.rpow_le_rpow zero_le_one hlog1 (by norm_num : (0:ℝ) ≤ 2/3)
+    have hf2 : (1:ℝ) ≤ (Real.log (Real.log N)) ^ ((4:ℝ)/3) := by
+      simpa using Real.rpow_le_rpow zero_le_one hloglog1 (by norm_num : (0:ℝ) ≤ 4/3)
+    have hWnn : (0:ℝ) ≤ (Real.log N) ^ ((2:ℝ)/3) * (Real.log (Real.log N)) ^ ((4:ℝ)/3) :=
+      mul_nonneg (le_trans zero_le_one hf1) (le_trans zero_le_one hf2)
+    rw [one_mul, norm_one, Real.norm_eq_abs, abs_of_nonneg hWnn]
+    calc (1:ℝ) = 1 * 1 := (one_mul 1).symm
+      _ ≤ (Real.log N) ^ ((2:ℝ)/3) * (Real.log (Real.log N)) ^ ((4:ℝ)/3) :=
+          mul_le_mul hf1 hf2 zero_le_one (le_trans zero_le_one hf1)
+  -- Hence 1/N = O(Walfisz/N): multiply the previous bound by the common factor N⁻¹.
+  have hone : (fun N : ℕ => (1:ℝ) / N) =O[atTop]
+      (fun N : ℕ => (Real.log N) ^ ((2:ℝ)/3) *
+                    (Real.log (Real.log N)) ^ ((4:ℝ)/3) / N) := by
+    have h := hconst.mul (isBigO_refl (fun N : ℕ => (N : ℝ)⁻¹) atTop)
+    simpa [div_eq_mul_inv] using h
+  -- rangeError + 1/N is O(Walfisz/N).
+  have hsum := hRE.add hone
+  -- Rescale by A on both sides.
+  have hAmul := (hsum.const_mul_left A).const_mul_right hA.ne'
+  exact (est_reduction_to_rangeTotientSum A c hA hc hregime).trans hAmul
 
 /-- The sharp rate is strictly little-o of the O(log N / N) rate from OQ-02.
 

--- a/proofs/Proofs/Erdos340GreedySidonOQ05.lean
+++ b/proofs/Proofs/Erdos340GreedySidonOQ05.lean
@@ -73,6 +73,19 @@ upper bound.
   The positive-slope affine group is thus the symmetry group of the `B_h` upper bound,
   letting one normalise a `B_h` set by an affine change of variable before counting.
 
+* `IsBh.card_forbidden_poly` — **the forbidden-value count**.  At most
+  `2·h·(|A|+1)^{2h-1}` small values `m` break the `B_h` property when inserted (an
+  explicit degree-`(2h-1)` polynomial in `|A|`), via `card_sym_le_pow` / `card_pool_le`.
+
+* `IsBh.exists_insert_le` / `exists_isBh_subset_Icc` / `exists_isBh_subset_Icc_card` —
+  **the end-to-end greedy lower bound inside `{1, …, N}`**.  Feeding the forbidden count
+  into a counting argument, a `B_h` set with `|A| + 2·h·(|A|+1)^{2h-1} < N` admits a
+  fresh element of `{1, …, N}` (`exists_insert_le`); iterating from `∅` builds a `B_h`
+  subset of `{1, …, N}` of cardinality `k` whenever `k + 2·h·k^{2h-1} ≤ N`
+  (`exists_isBh_subset_Icc_card`).  This is the combinatorial half of the
+  `|A| = Ω(N^{1/(2h-1)})` greedy rate; only the real-power inversion of the count
+  condition remains open.
+
 ## Mathematical note
 
 The bound is *sharp in order*: Singer difference sets give `B_2` sets of size
@@ -1018,5 +1031,116 @@ theorem IsBh.card_forbidden_poly {h : ℕ} {A : Finset ℕ} (hh : 1 ≤ h) (hA :
     _ = 2 * (h' + 1) * (A.card + 1) ^ (2 * (h' + 1) - 1) := by
         rw [mul_assoc (2 * (h' + 1)), ← pow_add,
           show h' + (h' + 1) = 2 * (h' + 1) - 1 from by omega]
+
+/-! ## Part 9: The end-to-end greedy lower bound inside `{1, …, N}`
+
+Parts 5–8 reduced the open `B_h` lower bound to a *counting* statement:
+`card_forbidden_poly` shows that at most `2·h·(|A|+1)^{2h-1}` small values are
+forbidden.  This part runs the greedy algorithm to completion **inside the interval**
+`{1, …, N}`, with no remaining counting.  A `B_h` set whose size and forbidden count
+together stay below `N` admits a fresh element of `{1, …, N}` (`exists_insert_le`), and
+iterating from `∅` builds a `B_h` subset of `{1, …, N}` of any cardinality `k` for which
+the count condition holds (`exists_isBh_subset_Icc` / `exists_isBh_subset_Icc_card`).
+
+The only piece left genuinely open is the *real-power arithmetic* converting the count
+condition `k + 2·h·k^{2h-1} ≤ N` into an explicit rate `k ≥ c·N^{1/(2h-1)}`; the
+combinatorial greedy iteration itself is now complete and verified. -/
+
+/-- **One greedy step inside `{1, …, N}`.**  If `A` is a `B_h` set (`h ≥ 1`) and the sum
+of `|A|` with the forbidden-value bound `2·h·(|A|+1)^{2h-1}` is still below `N`, then
+there is a fresh element `m ∈ {1, …, N}` (so `1 ≤ m ≤ N` and `m ∉ A`) whose insertion
+keeps `A` a `B_h` set.
+
+*Proof.*  Call `m ∈ {1, …, N}` *bad* if `m ∈ A` or `insert m A` is not `B_h`.  The bad
+values number at most `|A|` (those in `A`) plus the forbidden ones; every forbidden value
+is `≤ h·max A` (by `insert_of_large`, any larger `m` is automatically fine), so the
+forbidden values among `{1, …, N}` inject into those counted by `card_forbidden_poly`,
+giving `≤ 2·h·(|A|+1)^{2h-1}`.  Hence fewer than `N` of the `N` values in `{1, …, N}` are
+bad, so a good one remains. ∎ -/
+theorem IsBh.exists_insert_le {h N : ℕ} {A : Finset ℕ}
+    (hh : 1 ≤ h) (hA : IsBh h A)
+    (hN : A.card + 2 * h * (A.card + 1) ^ (2 * h - 1) < N) :
+    ∃ m, 1 ≤ m ∧ m ≤ N ∧ m ∉ A ∧ IsBh h (insert m A) := by
+  classical
+  -- The set of "bad" values in `{1, …, N}`.
+  set Bad : Finset ℕ :=
+    (Finset.Icc 1 N).filter (fun m => m ∈ A ∨ ¬ IsBh h (insert m A)) with hBad
+  -- Bound its cardinality by `|A|` plus the forbidden count.
+  have hBadcard : Bad.card ≤ A.card + 2 * h * (A.card + 1) ^ (2 * h - 1) := by
+    have hsplit :
+        Bad = (Finset.Icc 1 N).filter (fun m => m ∈ A)
+            ∪ (Finset.Icc 1 N).filter (fun m => ¬ IsBh h (insert m A)) := by
+      rw [hBad, Finset.filter_or]
+    rw [hsplit]
+    refine (Finset.card_union_le _ _).trans ?_
+    have hAcount : ((Finset.Icc 1 N).filter (fun m => m ∈ A)).card ≤ A.card := by
+      apply Finset.card_le_card
+      intro x hx
+      exact (Finset.mem_filter.mp hx).2
+    have hForb :
+        ((Finset.Icc 1 N).filter (fun m => ¬ IsBh h (insert m A))).card
+          ≤ 2 * h * (A.card + 1) ^ (2 * h - 1) := by
+      refine le_trans (Finset.card_le_card ?_) (hA.card_forbidden_poly hh)
+      intro m hm
+      rw [Finset.mem_filter] at hm ⊢
+      refine ⟨Finset.mem_range.mpr ?_, hm.2⟩
+      by_contra hlt
+      push_neg at hlt          -- `h * A.sup id + 1 ≤ m`
+      exact hm.2 (hA.insert_of_large (by omega))
+    omega
+  -- `{1, …, N}` has `N` elements, strictly more than `Bad`, so a good value remains.
+  have hIcc : (Finset.Icc 1 N).card = N := by rw [Nat.card_Icc]; omega
+  have hexists : ∃ m ∈ Finset.Icc 1 N, m ∉ Bad := by
+    by_contra hcon
+    push_neg at hcon
+    have hss : Finset.Icc 1 N ⊆ Bad := fun x hx => hcon x hx
+    have hle := Finset.card_le_card hss
+    omega
+  obtain ⟨m, hmIcc, hmnBad⟩ := hexists
+  have hpred : ¬ (m ∈ A ∨ ¬ IsBh h (insert m A)) := fun hp =>
+    hmnBad (by rw [hBad]; exact Finset.mem_filter.mpr ⟨hmIcc, hp⟩)
+  push_neg at hpred
+  rw [Finset.mem_Icc] at hmIcc
+  exact ⟨m, hmIcc.1, hmIcc.2, hpred.1, hpred.2⟩
+
+/-- **The greedy `B_h` set inside `{1, …, N}`.**  For every target cardinality `k` such
+that the count condition `j + 2·h·(j+1)^{2h-1} < N` holds at each intermediate size
+`j < k`, there is a `B_h` subset of `{1, …, N}` with exactly `k` elements.  This is the
+end-to-end greedy lower bound — the existence of a large `B_h` set inside an interval,
+obtained by iterating `exists_insert_le` from `∅`. -/
+theorem exists_isBh_subset_Icc {h : ℕ} (hh : 1 ≤ h) (N : ℕ) :
+    ∀ k, (∀ j, j < k → j + 2 * h * (j + 1) ^ (2 * h - 1) < N) →
+      ∃ A : Finset ℕ, A ⊆ Finset.Icc 1 N ∧ IsBh h A ∧ A.card = k := by
+  intro k
+  induction k with
+  | zero =>
+      intro _
+      exact ⟨∅, Finset.empty_subset _, isBh_empty, Finset.card_empty⟩
+  | succ k ih =>
+      intro hcond
+      obtain ⟨A, hsub, hbh, hcard⟩ := ih (fun j hj => hcond j (by omega))
+      obtain ⟨m, hm1, hmN, hmA, hins⟩ :=
+        hbh.exists_insert_le hh (by rw [hcard]; exact hcond k (by omega))
+      refine ⟨insert m A, ?_, hins, ?_⟩
+      · intro x hx
+        rw [Finset.mem_insert] at hx
+        rcases hx with rfl | hx
+        · exact Finset.mem_Icc.mpr ⟨hm1, hmN⟩
+        · exact hsub hx
+      · rw [Finset.card_insert_of_notMem hmA, hcard]
+
+/-- **Greedy lower bound, closed-form sufficient condition.**  If `k + 2·h·k^{2h-1} ≤ N`
+then `{1, …, N}` contains a `B_h` set of cardinality `k`: the greedy algorithm reaches
+size `k` whenever the degree-`(2h-1)` polynomial budget fits inside `N`.  This is the
+combinatorial half of the `B_h` greedy lower bound `|A| = Ω(N^{1/(2h-1)})`; only the
+real-power inversion of `k + 2·h·k^{2h-1} ≤ N` into `k ≥ c·N^{1/(2h-1)}` remains open. -/
+theorem exists_isBh_subset_Icc_card {h k N : ℕ} (hh : 1 ≤ h)
+    (hkN : k + 2 * h * k ^ (2 * h - 1) ≤ N) :
+    ∃ A : Finset ℕ, A ⊆ Finset.Icc 1 N ∧ IsBh h A ∧ A.card = k := by
+  refine exists_isBh_subset_Icc hh N k (fun j hj => ?_)
+  have hmono : 2 * h * (j + 1) ^ (2 * h - 1) ≤ 2 * h * k ^ (2 * h - 1) := by
+    gcongr
+    omega
+  omega
 
 end Erdos340Bh

--- a/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
+++ b/research/problems/erdos-340-greedy-sidon-oq-05/knowledge.md
@@ -410,3 +410,62 @@ card_pool_le` = `[propext, Classical.choice, Quot.sound]` (0-axiom). 923 → 102
   iterate "forbidden count `< N` ⟹ a small extension exists" inside `{1,…,N}`, then the
   real-power inequality `2h(k+1)^{2h−1} < N` ⟹ `k ≥ (N/(2h))^{1/(2h−1)} − 1`. Only
   remaining open piece; no further counting needed.
+
+### Session 2026-06-27 (researcher-2) — end-to-end greedy lower bound inside {1,…,N}
+
+**Mode**: CONTINUE (RICH) · **Outcome**: progress (verified increment, 0 sorries / 0 axioms).
+
+Closed the long-standing "end-to-end greedy iteration" next-step (Part 9, 3 new theorems).
+Turns the abstract forbidden-count polynomial `card_forbidden_poly` into an actual greedy
+**existence** statement: a large `B_h` set lives inside the interval `{1,…,N}`.
+
+#### What I Did
+- `IsBh.exists_insert_le` (`h≥1`): if `|A| + 2h(|A|+1)^{2h-1} < N` then there is a fresh
+  `m ∈ {1,…,N}` (`1 ≤ m ≤ N`, `m ∉ A`) with `insert m A` still `B_h`. Proof: the *bad*
+  values in `{1,…,N}` (`m∈A` or insertion breaks `B_h`) split as `filter_or` into the
+  `A`-part (`≤ |A|`) and the forbidden part; the forbidden part injects into the
+  `card_forbidden_poly` count because any `m > h·max A` is automatically insertable
+  (`insert_of_large`), so only `m ≤ h·max A` can be forbidden. Hence `|Bad| < N = |Icc 1 N|`,
+  so a good value survives.
+- `exists_isBh_subset_Icc` (`h≥1`): induction on target size `k` — if the per-step count
+  condition `j + 2h(j+1)^{2h-1} < N` holds for every `j<k`, then `{1,…,N}` has a `B_h`
+  subset of size exactly `k`. Base `∅`; step applies `exists_insert_le` to the size-`k`
+  set from the IH.
+- `exists_isBh_subset_Icc_card` (`h≥1`): clean closed-form consumer — `k + 2h·k^{2h-1} ≤ N`
+  ⟹ a `B_h` subset of `{1,…,N}` of size `k` exists. Derives the per-step `∀ j<k` condition
+  from the single bound via `gcongr` (pow monotonicity `(j+1)^{2h-1} ≤ k^{2h-1}`) + `omega`.
+
+#### Why it matters
+This is the **combinatorial half** of the `B_h` greedy lower bound `|A| = Ω(N^{1/(2h-1)})`,
+now a verified existence theorem. The ONLY remaining open piece is the real-power inversion
+of `k + 2h·k^{2h-1} ≤ N` into an explicit `k ≥ c·N^{1/(2h-1)}` — pure analysis, no more
+combinatorics. The whole Parts 5–9 arc (forbidden structure → orientation bound → sharp
+count → explicit polynomial → greedy iteration) is now closed end-to-end.
+
+#### Key Findings / gotchas
+- `Finset.card_sdiff` in this Mathlib (v4.26.0) is NOT the subset-hypothesis form
+  `(h:s⊆t)→(t\s).card = t.card - s.card`; it resolved to the unconditional
+  `#(s\t) = #s - #(s∩t)`. Avoided it entirely: proved a good value exists by
+  contradiction — if every `m ∈ Icc 1 N` were bad then `Icc 1 N ⊆ Bad`, so
+  `card_le_card` gives `N ≤ |Bad|`, contradicting `|Bad| < N` (`omega`).
+- `Nat.card_Icc 1 N` leaves the goal `N + 1 - 1 = N`; close with `omega` (not `rfl`).
+- The existence goal `∃ m, …` needs the witness `m` as the FIRST tuple component:
+  `⟨m, hm1, hmN, hmA, hins⟩`, not `⟨hm1, …⟩` (an easy off-by-one in the anonymous ctor).
+- `Finset.filter_or` splits `filter (p ∨ q)` into `filter p ∪ filter q`; `card_union_le`
+  + `card_le_card` then bound each part. `omega` abstracts the nonlinear
+  `2*h*(…)^(2h-1)` product as a consistent atom across the hypotheses.
+- The per-step → closed-form reduction: `gcongr` proves
+  `2h(j+1)^{2h-1} ≤ 2h·k^{2h-1}` leaving the base goal `j+1 ≤ k` (closed by `omega`).
+
+#### Verification
+Docker host down (`docker info` unavailable). Verified via host `v4.26.0`
+`lake env lean`: built the imported `Proofs.Erdos340GreedySidon` olean, then
+`lake env lean Proofs/Erdos340GreedySidonOQ05.lean` → exit 0, no warnings.
+`#print axioms IsBh.exists_insert_le / exists_isBh_subset_Icc / exists_isBh_subset_Icc_card`
+= `[propext, Classical.choice, Quot.sound]` (0-axiom). 1022 → 1146 lines, 34 → 37 theorems.
+
+#### Next Steps
+- Real-power closure: convert `k + 2h·k^{2h-1} ≤ N` into an explicit `Ω(N^{1/(2h-1)})`
+  rate (the last open piece, pure analysis).
+- Optional `h=2` specialization recovering an explicit `|A| ≥ c√N` Sidon lower bound
+  inside `{1,…,N}`, bridging to the parent `greedySidonSeq`.

--- a/src/data/proofs/erdos-1001-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1001-oq-02-oq-01/annotations.json
@@ -3,12 +3,12 @@
     "id": "ann-sharpness-question",
     "proofId": "erdos-1001-oq-02-oq-01",
     "range": {
-      "startLine": 45,
-      "endLine": 95
+      "startLine": 58,
+      "endLine": 108
     },
     "type": "insight",
     "title": "The O(log N / N) Rate Is Not Sharp: Walfisz Gives a Strictly Better Bound",
-    "content": "The sharpness question for the O(A log N / N) rate has a definitive negative answer: the rate is NOT tight. This is because the elementary Mertens bound used in OQ-02 is not the best possible — Walfisz's 1963 theorem improves it by a factor of (log N)^(1/3). The proof axiomatizes both bounds and then uses IsLittleO transitivity to show the sharper rate dominates.",
+    "content": "The sharpness question for the O(A log N / N) rate has a definitive negative answer: the rate is NOT tight. This is because the elementary Mertens bound used in OQ-02 is not the best possible — Walfisz's 1963 theorem improves it by a factor of (log N)^(1/3). The formalization keeps both totient-sum bounds as commentary and assumes only their Abel-summation consequence (the axiom rangeTotientSum_walfisz_error) plus a pure measure-theoretic EST reduction (est_reduction_to_rangeTotientSum); from these it derives the sharper |S - f| rate and uses IsLittleO transitivity to show it dominates the OQ-02 rate.",
     "mathContext": "The parent proof axiomatized $|S(N,A,c) - f(A,c)| = O(A \\log N/N)$ using the elementary bound $\\sum_{n \\leq x} \\varphi(n) = (3/\\pi^2)x^2 + O(x \\log x)$ (Mertens 1874). Walfisz's sharper $O(x(\\log x)^{2/3}(\\log\\log x)^{4/3})$ error (1963) propagates to a strictly better convergence rate $O(A(\\log N)^{2/3}(\\log\\log N)^{4/3}/N) = o(A \\log N/N)$.",
     "significance": "key",
     "relatedConcepts": [
@@ -27,12 +27,12 @@
     "id": "ann-walfisz-theorem",
     "proofId": "erdos-1001-oq-02-oq-01",
     "range": {
-      "startLine": 95,
-      "endLine": 140
+      "startLine": 110,
+      "endLine": 132
     },
     "type": "concept",
     "title": "Walfisz's 1963 Theorem: Deep Number Theory via Vinogradov Exponential Sums",
-    "content": "Walfisz's 1963 theorem is a major result in analytic number theory, appearing in his monograph 'Weylsche Exponentialsummen in der neueren Zahlentheorie'. The proof uses Vinogradov's exponential sum method to obtain a zero-free region for ζ(s) near the real axis, which in turn controls the error in Dirichlet series averages like ∑ φ(n). Both the elementary Mertens bound and the Walfisz bound are axiomatized here — neither appears in Mathlib v4.26.",
+    "content": "Walfisz's 1963 theorem is a major result in analytic number theory, appearing in his monograph 'Weylsche Exponentialsummen in der neueren Zahlentheorie'. The proof uses Vinogradov's exponential sum method to obtain a zero-free region for ζ(s) near the real axis, which in turn controls the error in Dirichlet series averages like ∑ φ(n). Both the elementary Mertens bound and the Walfisz bound are kept as commentary here (neither appears in Mathlib v4.26); the formalization assumes only their Abel-summation consequence on the range sum.",
     "mathContext": "The Vinogradov–Korobov zero-free region: $\\zeta(\\sigma + it) \\neq 0$ for $\\sigma > 1 - c / (\\log |t|)^{2/3}(\\log\\log |t|)^{1/3}$. This gives the error $E(N) = \\sum_{n \\leq N} \\varphi(n) - (3/\\pi^2)N^2 = O(N(\\log N)^{2/3}(\\log\\log N)^{4/3})$ (Walfisz 1963).",
     "significance": "supporting",
     "relatedConcepts": [
@@ -51,8 +51,8 @@
     "id": "ann-exponent-2-3",
     "proofId": "erdos-1001-oq-02-oq-01",
     "range": {
-      "startLine": 95,
-      "endLine": 135
+      "startLine": 110,
+      "endLine": 132
     },
     "type": "insight",
     "title": "The Exponent 2/3: Connection Between Zero-Free Regions and Arithmetic Averages",
@@ -75,12 +75,12 @@
     "id": "ann-comparison-proof",
     "proofId": "erdos-1001-oq-02-oq-01",
     "range": {
-      "startLine": 140,
-      "endLine": 178
+      "startLine": 134,
+      "endLine": 211
     },
     "type": "concept",
     "title": "IsLittleO Comparison via Real.tendsto_log_div_rpow_atTop",
-    "content": "The core comparison (log N)^(2/3)/N = o(log N/N) reduces to 1/(log N)^(1/3) → 0. In Lean, this follows from Real.tendsto_log_div_rpow_atTop with exponent p=1/3: log(N)/N^(1/3) → 0 implies N^(1/3)/log(N) → ∞ implies (log N)^(1/3) → ∞. Two sorries remain for the formal rpow manipulation — these are Aristotle candidates since the mathematical content is clear. The main result `oq02_rate_not_sharp` uses `IsBigO.trans_isLittleO` to chain the Walfisz O-bound with the IsLittleO comparison.",
+    "content": "The core comparison (log N)^(2/3)/N = o(log N/N) reduces to 1/(log N)^(1/3) → 0. In Lean, this follows from rpow asymptotics: (log N)^(2/3) = o(log N) via tendsto_rpow_neg_atTop, and the log log factor is absorbed by isLittleO_log_rpow_atTop. These comparisons (log_rpow_two_thirds_isLittleO_log, walfisz_rate_isLittleO_mertens_rate, walfisz_full_rate_isLittleO_mertens_rate) are fully proved with 0 sorries and 0 axioms. The main result `oq02_rate_not_sharp` uses `IsBigO.trans_isLittleO` to chain the Walfisz O-bound with the IsLittleO comparison.",
     "mathContext": "IsLittleO comparison: $\\frac{(\\log N)^{2/3}}{N} \\div \\frac{\\log N}{N} = (\\log N)^{-1/3} \\to 0$. `Real.tendsto_log_div_rpow_atTop (p:=1/3)`: $\\log(x)/x^{1/3} \\to 0$. Used via: $(\\log N)^{1/3} \\to \\infty$ iff $1/(\\log N)^{1/3} \\to 0$.",
     "significance": "key",
     "relatedConcepts": [
@@ -99,8 +99,8 @@
     "id": "ann-practical-implication",
     "proofId": "erdos-1001-oq-02-oq-01",
     "range": {
-      "startLine": 218,
-      "endLine": 248
+      "startLine": 360,
+      "endLine": 380
     },
     "type": "concept",
     "title": "Slow Improvement: The Factor 1/(log N)^(1/3) in Practice",
@@ -121,8 +121,8 @@
     "id": "ann-rh-conjecture",
     "proofId": "erdos-1001-oq-02-oq-01",
     "range": {
-      "startLine": 248,
-      "endLine": 313
+      "startLine": 382,
+      "endLine": 413
     },
     "type": "insight",
     "title": "Under RH: Exponential Improvement to O(√N log N) for the Totient Error",

--- a/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
@@ -22,8 +22,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 4,
-    "assumptions": "4 axioms (all deep number-theoretic inputs beyond Mathlib v4.26): totient_sum_mertens_error (elementary Mertens O(N log N) totient-sum error), totient_sum_walfisz_error (Walfisz 1963, O(N(logN)^(2/3)(loglogN)^(4/3)) via Vinogradov exponential sums), rangeTotientSum_walfisz_error (Abel-summation propagation of Walfisz to the range sum), convergence_rate_sharp (EST-regime reduction to the range sum). 0 sorries: all four real-analysis rpow/little-o comparisons (walfisz_rate_isLittleO_mertens_rate, walfisz_full_rate_isLittleO_mertens_rate, sharp_rate_isLittleO_oq02_rate, improvement_factor_tends_to_zero) are now fully PROVED with 0 axioms (#print axioms = propext/Classical.choice/Quot.sound), verified 2026-06-27. The main result oq02_rate_not_sharp rests only on convergence_rate_sharp.",
+    "axiomCount": 2,
+    "assumptions": "2 load-bearing axioms (verified via #print axioms 2026-06-28: every main result — oq02_rate_not_sharp, convergence_rate_sharp, erdos_1001_oq02_oq01_summary — depends on exactly these two plus the foundational propext/Classical.choice/Quot.sound, and no sorryAx): rangeTotientSum_walfisz_error (the sole number-theoretic input — the Abel-summation propagation of Walfisz's 1963 totient bound to the range sum ∑_{y=N}^{cN} φ(y)/y², beyond Mathlib v4.26; parallels the parent OQ-02's rangeTotientSum_error) and est_reduction_to_rangeTotientSum (the pure measure-theoretic EST-regime reduction of |S(N,A,c)-f(A,c)| to the range-sum error plus an O(A/N) boundary, parallel to OQ-02's convergence_rate_est). Reduced from 4 axioms on 2026-06-28 (researcher-2): the previous version declared totient_sum_mertens_error, totient_sum_walfisz_error and rangeTotientSum_walfisz_error but NONE were referenced by any proof — the result rested entirely on a monolithic convergence_rate_sharp axiom that assumed its own conclusion. The two dead totient-sum axioms are now commentary (matching the parent, which keeps Mertens as prose), and convergence_rate_sharp is now a THEOREM derived from the two remaining axioms. 0 sorries: the real-analysis rpow/little-o comparisons (walfisz_rate_isLittleO_mertens_rate, walfisz_full_rate_isLittleO_mertens_rate, sharp_rate_isLittleO_oq02_rate, improvement_factor_tends_to_zero) remain fully PROVED with 0 axioms.",
     "erdosNumber": 1001,
     "erdosUrl": "https://erdosproblems.com/1001",
     "mathlibDependencies": [
@@ -54,17 +54,16 @@
       }
     ],
     "originalContributions": [
-      "totient_sum_mertens_error: elementary Mertens O(N log N) partial totient sum error",
-      "totient_sum_walfisz_error: Walfisz's sharp O(N(logN)^(2/3)(loglogN)^(4/3)) bound",
-      "partialTotientSum: definition of Φ(n) = ∑_{y≤n} φ(y)",
-      "rangeTotientSum_walfisz_error: improved range sum error from Walfisz",
+      "rangeTotientSum_walfisz_error: improved range sum error from Walfisz (the sole number-theoretic axiom)",
+      "est_reduction_to_rangeTotientSum: pure measure-theoretic EST reduction of |S-f| to the range-sum error (axiom)",
+      "convergence_rate_sharp: now a THEOREM deriving the Walfisz |S-f| rate from the two axioms above",
       "walfisz_rate_isLittleO_mertens_rate: (logN)^(2/3)/N = o(logN/N)",
       "oq02_rate_not_sharp: main result — O(logN/N) is not the tight rate",
       "improvement_factor_tends_to_zero: the factor 1/(logN)^(1/3) → 0",
       "erdos_1001_oq02_oq01_summary: existential witness for the sharper rate"
     ],
-    "lineCount": 360,
-    "theoremCount": 7,
+    "lineCount": 413,
+    "theoremCount": 8,
     "defCount": 3,
     "definitionCount": 7,
     "additionalFiles": [
@@ -72,12 +71,12 @@
     ]
   },
   "conclusion": {
-    "summary": "The O(A log N / N) convergence rate from OQ-02 is NOT sharp: by Walfisz's 1963 theorem, the true rate is the strictly smaller O(A (log N)^(2/3) (log log N)^(4/3) / N) = o(A log N / N). This is proved via IsBigO.trans_isLittleO from four axioms and six theorems (4 sorries remain for rpow manipulations, all Aristotle candidates). The diophantine approximation rate is thus fully governed by the Vinogradov–Korobov zero-free region for ζ(s), not merely by the elementary Mertens bound.",
+    "summary": "The O(A log N / N) convergence rate from OQ-02 is NOT sharp: by Walfisz's 1963 theorem, the true rate is the strictly smaller O(A (log N)^(2/3) (log log N)^(4/3) / N) = o(A log N / N). This is proved via IsBigO.trans_isLittleO from two load-bearing axioms (rangeTotientSum_walfisz_error and est_reduction_to_rangeTotientSum) and eight theorems, with 0 sorries; the key intermediate convergence_rate_sharp is now itself a theorem derived from those two axioms. The diophantine approximation rate is thus fully governed by the Vinogradov–Korobov zero-free region for ζ(s), not merely by the elementary Mertens bound.",
     "implications": "This result connects the convergence rate of a diophantine approximation density to the zero-free region of the Riemann zeta function — a deep link between Diophantine analysis and analytic number theory. The exponent 2/3 in the Walfisz error bound equals the Vinogradov–Korobov zero-free exponent, so any improvement to the zero-free region (e.g., under RH: exponent → 1/2) would sharpen the diophantine approximation rate. The gap between the unconditional Walfisz bound and the RH-conditional O(√N log N) bound is one of the central open problems in analytic number theory.",
     "openQuestions": [
       "Under the Riemann Hypothesis, the totient error E(N) = O(√N log N²), giving convergence rate O(A log²N/√N). Can this conditional improvement be formalized with RH as an axiom?",
       "Is the current Walfisz bound E(N) = O(N(logN)^(2/3)(loglogN)^(4/3)) the best unconditional bound, or can the exponent 2/3 be improved? The best known lower bound is E(N) = Ω(√N).",
-      "Can the Abel summation step (rangeTotientSum_walfisz_error) be proved in Lean using Mathlib's summation-by-parts? This would remove one of the four axioms."
+      "Can the Abel summation step (rangeTotientSum_walfisz_error) be proved in Lean using Mathlib's summation-by-parts (Mathlib.NumberTheory.AbelSummation), starting from Walfisz's totient partial-sum bound? This would remove one of the two remaining load-bearing axioms."
     ]
   },
   "crossReferences": [
@@ -101,9 +100,9 @@
     "path": "Proofs/Erdos1001OQ02OQ01.lean",
     "namespace": "Erdos1001OQ02OQ01",
     "sorries": 0,
-    "axiomCount": 4,
-    "lineCount": 360,
-    "theoremCount": 7,
+    "axiomCount": 2,
+    "lineCount": 413,
+    "theoremCount": 8,
     "definitionCount": 7,
     "additionalFiles": [
       "Proofs/Erdos1001OQ02OQ01Aristotle.lean"
@@ -127,65 +126,65 @@
       "id": "header",
       "title": "Module Header and Problem Statement",
       "startLine": 1,
-      "endLine": 54,
+      "endLine": 56,
       "summary": "States Erdős #1001 OQ-02-OQ-01: whether the $O(\\log N/N)$ convergence rate for the totient-sum density is sharp. Overview of the Mertens vs. Walfisz comparison.",
       "mathContext": "Sharpness of the $O(\\log N/N)$ totient-sum convergence rate."
     },
     {
       "id": "part1",
       "title": "Core Definitions (from Erdos1001OQ02)",
-      "startLine": 55,
-      "endLine": 89,
+      "startLine": 58,
+      "endLine": 108,
       "summary": "Defines `isApproximable`, `S`, `f`, `inESTRegime`, `densityConst` ($6/\\pi^2$), `rangeTotientSum`, `partialTotientSum`.",
       "mathContext": "Totient-sum density constant $6/\\pi^2$; range/partial sums."
     },
     {
       "id": "part2",
-      "title": "The Elementary vs. Walfisz Error Bounds",
-      "startLine": 90,
-      "endLine": 123,
-      "summary": "States the AXIOMS `totient_sum_mertens_error` (elementary Mertens error) and `totient_sum_walfisz_error` (Walfisz's sharper error).",
-      "mathContext": "Axioms: Mertens vs. Walfisz error terms for $\\sum\\varphi$."
+      "title": "The Mertens and Walfisz Totient-Sum Bounds (commentary, not axioms)",
+      "startLine": 110,
+      "endLine": 132,
+      "summary": "Commentary only (NOT axioms): the Mertens $O(N\\log N)$ and Walfisz $O(N(\\log N)^{2/3}(\\log\\log N)^{4/3})$ totient partial-sum bounds, kept as prose exactly as the parent OQ-02 keeps Mertens. The only number-theoretic assumption is their Abel-summation consequence, the axiom `rangeTotientSum_walfisz_error` below.",
+      "mathContext": "Mertens vs. Walfisz error terms for $\\sum\\varphi$ (commentary, not axioms)."
     },
     {
       "id": "part3",
       "title": "Comparison: Walfisz rate vs. Mertens rate",
-      "startLine": 124,
-      "endLine": 164,
-      "summary": "Proves `walfisz_rate_isLittleO_mertens_rate` and `walfisz_full_rate_isLittleO_mertens_rate` (2 `sorry`): the Walfisz rate is $o(\\cdot)$ of Mertens.",
-      "mathContext": "Walfisz error $=o(\\text{Mertens error})$ (2 sorries)."
+      "startLine": 134,
+      "endLine": 211,
+      "summary": "Proves `log_rpow_two_thirds_isLittleO_log`, `walfisz_rate_isLittleO_mertens_rate`, and `walfisz_full_rate_isLittleO_mertens_rate` (0 sorries, 0 axioms): the Walfisz rate is $o(\\cdot)$ of Mertens.",
+      "mathContext": "Walfisz error $=o(\\text{Mertens error})$ (fully proved)."
     },
     {
       "id": "part4",
       "title": "Sharp Range Totient Sum Error via Abel Summation",
-      "startLine": 165,
-      "endLine": 198,
-      "summary": "States the AXIOM `rangeTotientSum_walfisz_error`: the improved range-sum error obtained by Abel summation.",
+      "startLine": 213,
+      "endLine": 245,
+      "summary": "States the AXIOM `rangeTotientSum_walfisz_error`: the improved range-sum error obtained by Abel summation. This is the sole number-theoretic assumption and is load-bearing for the main result.",
       "mathContext": "Axiom: improved range-sum error via Abel summation."
     },
     {
       "id": "part5",
       "title": "Main Result: O(log N / N) Is NOT the Tight Rate",
-      "startLine": 199,
-      "endLine": 264,
-      "summary": "States the AXIOM `convergence_rate_sharp` and proves `sharp_rate_isLittleO_oq02_rate` and `oq02_rate_not_sharp` (1 `sorry`): the OQ-02 rate is not sharp.",
-      "mathContext": "$O(\\log N/N)$ is not the tight rate (1 sorry)."
+      "startLine": 247,
+      "endLine": 358,
+      "summary": "States the AXIOM `est_reduction_to_rangeTotientSum` (the pure measure-theoretic EST reduction), then DERIVES `convergence_rate_sharp` as a theorem from it together with `rangeTotientSum_walfisz_error`, and proves `sharp_rate_isLittleO_oq02_rate` and `oq02_rate_not_sharp` (0 sorries): the OQ-02 rate is not sharp.",
+      "mathContext": "$O(\\log N/N)$ is not the tight rate (0 sorries; convergence_rate_sharp now a theorem)."
     },
     {
       "id": "part6",
       "title": "Quantitative Comparison: How Much Better?",
-      "startLine": 265,
-      "endLine": 282,
-      "summary": "Proves `improvement_factor_tends_to_zero` (1 `sorry`): the improvement factor $\\to0$.",
-      "mathContext": "Improvement factor $\\to0$ (1 sorry)."
+      "startLine": 360,
+      "endLine": 380,
+      "summary": "Proves `improvement_factor_tends_to_zero` (0 sorries): the improvement factor $\\to0$.",
+      "mathContext": "Improvement factor $\\to0$ (fully proved)."
     },
     {
       "id": "part7",
       "title": "Historical Context and Summary",
-      "startLine": 283,
-      "endLine": 313,
+      "startLine": 382,
+      "endLine": 413,
       "summary": "Gives historical context and proves `erdos_1001_oq02_oq01_summary` packaging the result.",
-      "mathContext": "Summary: OQ-02 rate improvable; 4 axioms, 4 sorries remain."
+      "mathContext": "Summary: OQ-02 rate improvable; 2 load-bearing axioms, 0 sorries."
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
+++ b/src/data/research/problems/erdos-340-greedy-sidon-oq-05.json
@@ -6,14 +6,14 @@
   "tier": "B",
   "tractability": "medium — the foundational B_h theory and the sharp B_h counting upper bound are now formalized and verified (0-axiom). The deep open direction (improving the greedy B_h lower bound toward the N^{1/h} ceiling) remains open, exactly as for the parent #340.",
   "started": "2026-06-27",
-  "lastUpdate": "2026-06-27T20:00:00.000Z",
+  "lastUpdate": "2026-06-27T21:00:00.000Z",
   "path": "research/problems/erdos-340-greedy-sidon-oq-05",
   "leanFiles": [
     {
       "path": "Proofs/Erdos340GreedySidonOQ05.lean",
       "filename": "Erdos340GreedySidonOQ05.lean",
-      "lineCount": 1022,
-      "theoremCount": 34,
+      "lineCount": 1146,
+      "theoremCount": 37,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,
@@ -52,7 +52,8 @@
       "IsBh.exists_insert: every B_h set has SOME extension m∉A with insert m A still B_h; the explicit witness m = h·(max A) + 1 works (m∉A because any a∈A has a ≤ max A ≤ h·max A < m via Nat.le_mul_of_pos_left, needs h≥1). Iterating yields B_h sets of unbounded size — the constructive starting point for the B_h greedy lower bound. This is the B_h analogue of the parent's sidon_insert_of_large / sidon_exists_extension.",
       "EXPLICIT GREEDY FAMILY: iterating exists_insert gives, for every h≥1 and every n, a concrete B_h set of cardinality EXACTLY n (exists_isBh_card). Built via greedyBhAux : (n:ℕ) → {A : Finset ℕ // IsBh h A ∧ A.card = n} — a subtype-bundled structural recursion that carries the B_h proof alongside the set so that exists_insert's hypothesis is available at each definition step (Classical.choose the witness; choose_spec gives m∉A ∧ B_h(insert m A)). Projections greedyBhSet/_isBh/_card. Needs isBh_empty (∅ is B_h: h=0 domain is a Sym-subsingleton, h≥1 domain is empty). This SEPARATES the open question: a B_h set's COUNT is unbounded for free; the open core is how small its LARGEST ELEMENT can be (the N^{1/(2h-1)} bound). 0-axiom (Classical.choice only).",
       "ORIENTATION REFINEMENT closes the open forbidden-count gap. exists_diff_eq_of_not_insert now also yields card sA + card tA + d ≤ 2·h: the multiplicity gap d = |j−k| is paid out of the 2h slots of the two h-multisets, so the A-parts together carry ≤ 2h − d ≤ 2h − 1 elements. Hence at least one of sA, tA has size < h. card_forbidden_le' uses this to bound the forbidden set by 2·h·T₋·T₊ where T₋ = #multisets over A of size < h (degree h−1) and T₊ = #multisets of size ≤ h (degree h) — total degree 1+(h−1)+h = 2h−1 in |A|, one degree below the prior trivial T² bound. This is the count realising the SHARP N^{1/(2h-1)} greedy lower bound, the open quantitative core of #340's B_h generalisation. Proof: no parity/tagging bijection — just case-split on which side is short, union of two products, card_union_le + card_product. 0-axiom verified.",
-      "Part 8 (explicit closed form): card_forbidden_poly bounds the forbidden set by 2*h*(|A|+1)^(2h-1) — an explicit degree-(2h-1) polynomial in |A|, the form the greedy lower bound consumes. Built on card_sym_le_pow (|A.sym n| <= |A|^n, a Finset.sym cardinality bound Mathlib lacks) and geom_sum_le_pow (sum_{i<=k} n^i <= (n+1)^k)."
+      "Part 8 (explicit closed form): card_forbidden_poly bounds the forbidden set by 2*h*(|A|+1)^(2h-1) — an explicit degree-(2h-1) polynomial in |A|, the form the greedy lower bound consumes. Built on card_sym_le_pow (|A.sym n| <= |A|^n, a Finset.sym cardinality bound Mathlib lacks) and geom_sum_le_pow (sum_{i<=k} n^i <= (n+1)^k).",
+      "The greedy lower bound is now formalized end-to-end as an EXISTENCE statement inside an interval: exists_isBh_subset_Icc_card says {1,...,N} contains a B_h set of size k whenever k + 2h*k^(2h-1) <= N. This is exactly the combinatorial half of |A| = Omega(N^(1/(2h-1))); the ONLY remaining gap is the real-power arithmetic inverting 'k + 2h*k^(2h-1) <= N' into 'k >= c*N^(1/(2h-1))', which is analysis, not combinatorics. Key step: forbidden values in {1,...,N} inject into the card_forbidden_poly count because any m > h*max A is always insertable (insert_of_large), so only m <= h*max A can be forbidden."
     ],
     "builtItems": [
       "Erdos340GreedySidonOQ05.lean: def IsBh (h-fold-sum-distinctness via multiset-sum InjOn on A.sym h); IsBh.subset; isBh_one (every set is B_1); IsBh.sum_injOn_powersetCard (distinct h-subset sums); IsBh.choose_card_le (MAIN: Nat.choose |A| h ≤ h·N for B_h A ⊆ [1,N]); IsBh.two_card_mul_pred_le (Sidon recovery |A|(|A|-1) ≤ 4N). 206 lines, 6 theorems, 1 def, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only).",
@@ -67,15 +68,17 @@
       "card_sym_le_pow: (A.sym n).card <= A.card^n (Finset.sym cardinality bound, missing from Mathlib)",
       "geom_sum_le_pow: sum_{i<=k} n^i <= (n+1)^k",
       "card_pool_le: multiset pool of size <=k over A has card <= (|A|+1)^k",
-      "IsBh.card_forbidden_poly (h>=1): #forbidden <= 2*h*(|A|+1)^(2h-1), explicit closed form"
+      "IsBh.card_forbidden_poly (h>=1): #forbidden <= 2*h*(|A|+1)^(2h-1), explicit closed form",
+      "Erdos340GreedySidonOQ05.lean Part 9 (end-to-end greedy lower bound inside {1,...,N}): IsBh.exists_insert_le (B_h set with |A|+2h(|A|+1)^(2h-1) < N admits a fresh m in {1,...,N} keeping B_h, via card_forbidden_poly + a |Bad| < N counting argument); exists_isBh_subset_Icc (iterate from empty: a B_h subset of {1,...,N} of size k exists when the per-step count condition holds at each j<k); exists_isBh_subset_Icc_card (clean closed-form sufficient condition k + 2h*k^(2h-1) <= N => such a set of size k exists). All 0-axiom."
     ],
     "mathlibGaps": [
       "Mathlib has no B_h-set theory and no Sidon/B_h upper bound; the whole development is original relative to Mathlib.",
       "Finset.sym s n has no direct cardinality (multichoose) lemma in Mathlib — only the Fintype-level Sym.card_sym_eq_choose. This is why the counting bound is routed through h-subsets (powersetCard, which DOES have card_powersetCard) rather than the full multiset family."
     ],
     "nextSteps": [
-      "End-to-end greedy lower bound: iterate 'forbidden count < N => a small extension exists' inside {1,...,N}, then the real-power inequality 2h(k+1)^(2h-1) < N => k >= (N/(2h))^(1/(2h-1)) - 1. Only remaining open piece; no further counting needed."
+      "Real-power closure: turn exists_isBh_subset_Icc_card's condition 'k + 2h*k^(2h-1) <= N' into an explicit rate 'exists A subset {1,...,N}, IsBh h A and |A| >= floor((N/(4h))^(1/(2h-1)))' or similar, using Nat/real power monotonicity. This is the last open piece and is pure analysis (no more combinatorics).",
+      "Optional: specialize exists_isBh_subset_Icc_card at h=2 to recover an explicit Sidon lower bound |A| >= c*sqrt(N) inside {1,...,N}, bridging to the parent gallery's greedySidonSeq."
     ],
-    "progressSummary": "Foundational B_h theory + sharp upper bound (choose(|A|,h) <= h*N), Sidon bridge (IsBh 2 <-> IsSidon), affine invariance, greedy extension + explicit greedy family, and the forbidden-set structure/counting chain: card_forbidden_le (trivial T^2), card_forbidden_le' (sharp orientation 2h*T-*T+), and now card_forbidden_poly (explicit closed form 2h*(|A|+1)^(2h-1), degree 2h-1 in |A|). Remaining open: the [1,N]-bounded greedy iteration realising |A| = Omega(N^{1/(2h-1)})."
+    "progressSummary": "Foundational B_h theory + sharp upper bound (choose(|A|,h) <= h*N), Sidon bridge (IsBh 2 <-> IsSidon), affine invariance, greedy extension/family, and the sharp degree-(2h-1) forbidden-value polynomial (card_forbidden_poly). NEW: the end-to-end greedy LOWER bound inside {1,...,N} -- exists_isBh_subset_Icc_card gives a B_h subset of {1,...,N} of size k whenever k + 2h*k^(2h-1) <= N. Only the real-power inversion to an explicit N^(1/(2h-1)) rate remains open. 37 theorems, 0 sorries, 0 axioms."
   }
 }


### PR DESCRIPTION
## Summary

Axiom-integrity refactor of the Walfisz-sharpness entry **erdos-1001-oq-02-oq-01**.

A `#print axioms` audit revealed that although the file *declared* 4 axioms, only **one** was load-bearing: three (`totient_sum_mertens_error`, `totient_sum_walfisz_error`, `rangeTotientSum_walfisz_error`) were never referenced by any proof, and the entire result rested on a single monolithic `convergence_rate_sharp` axiom that **assumed its own conclusion** (the Walfisz rate for `|S − f|` directly). That is the "scaffolding, not formalization" anti-pattern.

## Changes

- **Drop the two dead totient-sum axioms to commentary**, matching the parent `Erdos1001OQ02.lean`'s hygiene (it keeps Mertens as prose, never as an axiom).
- **Split off the pure measure-theoretic EST reduction** as a clean axiom `est_reduction_to_rangeTotientSum`: `|S − f|` reduces to the range-sum error `+ O(A/N)` boundary, with *no* totient bound baked in.
- **Derive `convergence_rate_sharp` as a theorem** from that reduction together with `rangeTotientSum_walfisz_error` (now load-bearing): `1/N = O(Walfisz/N)` because the Walfisz numerator → ∞, summed with the range error and rescaled by `A`.

Net: **declared axioms 4 → 2, both load-bearing**, and the main result genuinely derives from the Walfisz range-sum bound instead of assuming itself. This is also cleaner than the parent, which axiomatizes its `convergence_rate_est` directly.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1001OQ02OQ01` — **builds clean, 0 sorries**.
- `#print axioms` confirms every main result (`oq02_rate_not_sharp`, `convergence_rate_sharp`, `erdos_1001_oq02_oq01_summary`) depends on exactly the **2** custom axioms plus `propext`/`Classical.choice`/`Quot.sound`, with **no `sorryAx`** and no `Lean.ofReduceBool`.

## Gallery data

`meta.json` / `annotations.json` updated: `axiomCount` 4→2, `theoremCount` 7→8, line counts (360→413), all `sections` ranges re-anchored, and every stale "axiomatizes both bounds / N sorries remain" claim corrected. Status remains `axiomatized` / badge `axiom` (2 stated assumptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)