### PR TITLE
Enrich 'The Companion Cosine Limit: (1 − cos x)/x² → 1/2'

### DIFF
--- a/src/data/proofs/lhopital-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/lhopital-oq-05-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-strategy",
+    "proofId": "lhopital-oq-05-oq-01",
+    "range": { "startLine": 3, "endLine": 31 },
+    "type": "context",
+    "title": "Why Divide the Remainder Instead of Iterating L'Hôpital",
+    "content": "The header states the whole plan. Both 1 − cos x and x² vanish to second order at 0, so the naive limit is 0/0 and the textbook route applies L'Hôpital twice. Instead the proof exploits that Mathlib already proves the explicit quadratic Taylor bound Real.cos_bound: |cos x − (1 − x²/2)| ≤ |x|⁴·(5/96) for |x| ≤ 1. Because the error has degree 4 and the denominator only degree 2, subtracting the limit 1/2 and dividing leaves a residue bounded by (5/96)·|x|² — an honest O(|x|²) that needs no differentiation. The hypothesis |x| ≤ 1 is free: it holds on a whole punctured neighbourhood of 0. This is the same skeleton as the sibling cubic sine limit (x − sin x)/x³ → 1/6, with Real.sin_bound swapped for Real.cos_bound and one fewer power of x divided out.",
+    "mathContext": "$\\dfrac{1-\\cos x}{x^2}=\\dfrac12+\\dfrac{(1-\\cos x)-x^2/2}{x^2}$, and the second term is $O(|x|^2)$ because $\\cos x-(1-x^2/2)=O(|x|^4)$.",
+    "significance": "context",
+    "relatedConcepts": ["L'Hôpital's rule", "Taylor's theorem with remainder", "indeterminate forms", "order of vanishing"],
+    "prerequisites": ["limits and indeterminate forms", "Maclaurin series"]
+  },
+  {
     "id": "ann-deviation-bound",
     "proofId": "lhopital-oq-05-oq-01",
     "range": { "startLine": 38, "endLine": 52 },
@@ -14,14 +26,26 @@
   {
     "id": "ann-the-limit",
     "proofId": "lhopital-oq-05-oq-01",
-    "range": { "startLine": 54, "endLine": 73 },
+    "range": { "startLine": 54, "endLine": 67 },
     "type": "insight",
     "title": "One Squeeze Finishes It",
-    "content": "tendsto_cosine_quadratic reduces the limit-to-1/2 to a limit-to-0 (tendsto_sub_nhds_zero_iff) and applies the eventual normed squeeze squeeze_zero_norm' with envelope a x = (5/96)·|x|². The bound |deviation| ≤ a x of abs_sub_le needs |x| ≤ 1, which holds eventually on 𝓝[≠] 0 because the closed unit ball is a neighbourhood of 0 (Metric.closedBall_mem_nhds). The envelope tends to 0 since |x|² → 0 by continuity of absolute value squared (continuous_abs.tendsto then .pow 2). This is the exact even-order mirror of the sibling cubic sine squeeze (lhopital-oq-05).",
-    "mathContext": "$0 \\le \\left|\\tfrac{1-\\cos x}{x^2} - \\tfrac12\\right| \\le \\tfrac{5}{96}|x|^2 \\to 0$ on $\\mathcal{N}_{\\neq}(0)$ (squeeze).",
+    "content": "tendsto_cosine_quadratic reduces the limit-to-1/2 to a limit-to-0 (tendsto_sub_nhds_zero_iff) and applies the eventual normed squeeze squeeze_zero_norm' with envelope a x = (5/96)·|x|². The bound |deviation| ≤ a x of abs_sub_le needs |x| ≤ 1, which holds eventually on 𝓝[≠] 0 because the closed unit ball is a neighbourhood of 0 (Metric.closedBall_mem_nhds). The filter_upwards combines two facts from the punctured-neighbourhood filter — that x ≠ 0 (self_mem_nhdsWithin) and that |x| ≤ 1 (the ball membership) — which together discharge exactly abs_sub_le's hypotheses. This is the even-order mirror of the sibling cubic sine squeeze (lhopital-oq-05).",
+    "mathContext": "$0 \\le \\left|\\tfrac{1-\\cos x}{x^2} - \\tfrac12\\right| \\le \\tfrac{5}{96}|x|^2$ eventually on $\\mathcal{N}_{\\neq}(0)$.",
     "significance": "key",
-    "relatedConcepts": ["squeeze theorem", "punctured neighbourhood filter", "eventual bounds", "continuity"],
+    "relatedConcepts": ["squeeze theorem", "punctured neighbourhood filter", "eventual bounds", "filter_upwards"],
     "prerequisites": ["squeeze/sandwich theorem", "filters and neighbourhoods"]
+  },
+  {
+    "id": "ann-envelope-to-zero",
+    "proofId": "lhopital-oq-05-oq-01",
+    "range": { "startLine": 68, "endLine": 73 },
+    "type": "technique",
+    "title": "The Envelope Vanishes by Continuity",
+    "content": "The squeeze only closes if the upper envelope (5/96)·|x|² itself tends to 0. This is pure continuity, not analysis: |x|² → 0 as x → 0 because absolute value is continuous (continuous_abs.tendsto 0) and squaring preserves the limit (.pow 2), giving |0|² = 0; scaling by the constant 5/96 keeps the limit 0 (const_mul). The limit is taken along the full neighbourhood 𝓝 0 and then restricted to the punctured filter via mono_left nhdsWithin_le_nhds, since a function tending to a value on a larger filter still does so on any sub-filter. No Taylor information is needed for this half — the only analytic input to the entire proof remains the single use of Real.cos_bound above.",
+    "mathContext": "$\\tfrac{5}{96}|x|^2 \\to \\tfrac{5}{96}\\cdot 0 = 0$ as $x\\to 0$, by continuity of $x\\mapsto |x|^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["continuity", "limits along sub-filters", "monotonicity of filters", "constant multiples of limits"],
+    "prerequisites": ["continuity of elementary functions", "filter convergence"]
   },
   {
     "id": "ann-taylor-coefficient",

--- a/src/data/proofs/lhopital-oq-05-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-05-oq-01/meta.json
@@ -72,6 +72,14 @@
   },
   "sections": [
     {
+      "id": "strategy-and-setup",
+      "title": "Strategy: Divide the Remainder",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "The header lays out the plan — exploit Mathlib's explicit quadratic Taylor bound Real.cos_bound rather than iterate L'Hôpital, dividing the degree-4 cosine error by the degree-2 denominator to control the deviation from 1/2 quadratically. Imports only Mathlib; opens Filter and Topology.",
+      "mathContext": "Both 1 − cos x and x² vanish to order 2 at 0; the leading Taylor term x²/2 forces the ratio to 1/2."
+    },
+    {
       "id": "deviation-bound",
       "title": "The Quadratic Deviation Bound",
       "startLine": 38,


### PR DESCRIPTION
Enrichment pass for `lhopital-oq-05-oq-01` (pass 0, quality 83).

The entry's meta/overview/conclusion were already strong (~13 KB, well under cap), so this pass closes the two real gaps:

- **Annotation coverage 3 → 5.** Added a `context` annotation over the header explaining *why* the proof divides the Taylor remainder instead of iterating L'Hôpital, and a `technique` annotation on the envelope-vanishes-by-continuity half of the squeeze (previously folded into one block). Narrowed the squeeze annotation so the two cover disjoint line ranges.
- **Section coverage.** Added a 'Strategy: Divide the Remainder' section for the header/setup (lines 1–36), which no section previously covered.

All 5 annotations carry `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. No content removed; no caps approached (meta.json ~13.5 KB). `pnpm build` passes.