### PR TITLE
Enrich 'Hadamard's Inequality, Matrix Form': add missing index.ts + description

### DIFF
--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GramHadamardMatrixOQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const gramLinearIndependenceIffOq01Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const gramLinearIndependenceIffOq01Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const gramLinearIndependenceIffOq01Oq01Oq02Data: ProofData = {
+  proof: gramLinearIndependenceIffOq01Oq01Oq02Proof,
+  annotations: gramLinearIndependenceIffOq01Oq01Oq02Annotations,
+}

--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02/meta.json
@@ -1,6 +1,7 @@
 {
   "id": "gram-linear-independence-iff-oq-01-oq-01-oq-02",
   "slug": "gram-linear-independence-iff-oq-01-oq-01-oq-02",
+  "description": "Derives the classical matrix form of Hadamard's inequality ‖det A‖ ≤ ∏ⱼ ‖colⱼ‖ for a square matrix over an RCLike field as a corollary of the parent Gramian bound. The bridge is gram(col A) = AᴴA together with det(gram(col A)) = ‖det A‖²: the columns' Gram matrix is the Hermitian product, so the abstract bound det(gram v) ≤ ∏ ‖vⱼ‖² transports to ‖det A‖² ≤ ∏ ‖colⱼ‖², and one monotone square root gives the norm form — plus the explicit ‖det A‖ ≤ ∏ⱼ √(∑ᵢ ‖Aᵢⱼ‖²) of Hadamard's original 1893 statement. Verified, zero axioms.",
   "leanFile": {
     "imports": [
       "Mathlib",


### PR DESCRIPTION
Enrichment pass for `gram-linear-independence-iff-oq-01-oq-01-oq-02` (pass 0, find-targets quality 0).

The meta.json and 4 annotations were already rich and well within size caps (~13.8 KB). The quality-0 ranking traced to two concrete defects, both fixed here:

- **Missing `index.ts`.** The proof directory had no `index.ts`. Added one following the standard template (Lean source `Proofs/GramHadamardMatrixOQ01OQ01OQ02.lean`, exports `gramLinearIndependenceIffOq01Oq01Oq02{Proof,Annotations,Data}`).
- **Empty top-level `description`.** The entry had no top-level `description`, so its `listings.json` card showed an empty string. Added a substantive one-paragraph summary; the regenerated listing now carries it.

No content removed. `pnpm build` passes and regenerates listings/manifest cleanly.