### PR TITLE
research(cramers-rule-oq-02-oq-01): exact Gaussian-elimination cost (n³−n)/3 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -981,6 +981,7 @@ import Proofs.CramersRuleOQ01OQ02OQ01OQ01
 import Proofs.CramersRuleOQ01OQ03
 import Proofs.CramersRuleOQ01OQ04
 import Proofs.CramersRuleOQ02
+import Proofs.CramersRuleOQ02OQ01
 import Proofs.CramersRuleOQ02OQ02
 import Proofs.CramersRuleOQ03
 import Proofs.CramersRuleOQ03OQ03

--- a/proofs/Proofs/CramersRuleOQ02OQ01.lean
+++ b/proofs/Proofs/CramersRuleOQ02OQ01.lean
@@ -1,0 +1,133 @@
+import Mathlib
+import Proofs.CramersRuleOQ02
+
+/-
+# Tightening the Gaussian-Elimination Complexity Model (OQ-02-OQ-01)
+
+## Research Question
+
+The parent entry `CramersRuleOQ02` compares Cramer's rule against Gaussian
+elimination using the deliberately *loose* upper model `gaussMuls n = n³`.
+Can the Gaussian-elimination cost be tightened to the **exact** leading
+multiplication/division count, the classic `n³/3` figure?
+
+## Answer: YES — the exact count is `(n³ − n)/3`.
+
+Forward elimination of an `n × n` system proceeds in steps `k = 1, …, n−1`.
+At step `k` the pivot sits in position `(k,k)` and there are `n − k` rows
+below it. For each such row we:
+
+- compute one multiplier (a **division**): `n − k` divisions at step `k`;
+- update the `n − k` trailing entries of that row (one **multiplication**
+  each): `(n − k)²` multiplications at step `k`.
+
+So the per-step multiplication+division count is `(n−k) + (n−k)²`. Writing
+`j = n − k` (which ranges over `1, …, n−1`), the total is
+
+  `∑_{j=1}^{n−1} (j² + j) = (n−1)·n·(n+1)/3 = (n³ − n)/3`.
+
+This is the exact arithmetic behind the textbook "`n³/3` flops" headline for
+LU/Gaussian elimination, and it tightens the parent's `n³` model by a factor
+of ~3 while preserving every comparison conclusion (a smaller cost only makes
+Gaussian elimination look better against Cramer's rule).
+
+## What is proved here (no axioms, no sorry)
+
+- `gaussExactOps n` — the exact per-step model `∑_{j<n} (j² + j)`.
+- `gaussExactOps_closed`     : `3 · gaussExactOps n + n = n³` (subtraction-free).
+- `gaussExactOps_eq_div`     : `gaussExactOps n = (n³ − n)/3`.
+- `gaussExactOps_le_cube`    : `gaussExactOps n ≤ n³` (it really is tighter).
+- `gaussExactOps_lt_cube`    : strict for `n ≥ 2` (the factor-3 gap is real).
+- `gaussExact_beats_cramer`  : the tighter model still beats Cramer's rule for
+  `n ≥ 4`, a fortiori.
+
+## Proof techniques
+
+- `Finset.sum_range_succ` for the inductive step on `∑_{j<n} (j² + j)`.
+- A subtraction-free `calc` so the closed form lives entirely in `ℕ`
+  (`ring` over the commutative semiring `ℕ`, no `linear_combination`).
+- `Nat.eq_div_of_eq_mul_left` to recover the `(n³ − n)/3` division form.
+- Reuse of the parent's `factorial_gt_sq` growth lemma via the import.
+-/
+
+namespace CramersComplexityExact
+
+open Finset
+
+/-- Exact multiplication+division count for forward elimination of an `n × n`
+    system: at the step that clears a column with `j` rows beneath the pivot we
+    spend `j` divisions and `j²` multiplications, summed as `j` ranges over
+    `0, …, n−1` (the `j = 0` term contributes nothing). -/
+def gaussExactOps (n : ℕ) : ℕ := ∑ j ∈ range n, (j ^ 2 + j)
+
+/-- Unfolding one elimination step. -/
+lemma gaussExactOps_succ (n : ℕ) :
+    gaussExactOps (n + 1) = gaussExactOps n + (n ^ 2 + n) := by
+  unfold gaussExactOps
+  rw [Finset.sum_range_succ]
+
+/-- **Closed form (subtraction-free).** `3 · gaussExactOps n + n = n³`.
+
+    Equivalently `gaussExactOps n = (n³ − n)/3`, but stated over `ℕ` without
+    truncated subtraction so that `ring` closes the inductive step. -/
+theorem gaussExactOps_closed (n : ℕ) : 3 * gaussExactOps n + n = n ^ 3 := by
+  induction n with
+  | zero => simp [gaussExactOps]
+  | succ m ih =>
+    calc 3 * gaussExactOps (m + 1) + (m + 1)
+        = (3 * gaussExactOps m + m) + (3 * (m ^ 2 + m) + 1) := by
+          rw [gaussExactOps_succ]; ring
+      _ = m ^ 3 + (3 * (m ^ 2 + m) + 1) := by rw [ih]
+      _ = (m + 1) ^ 3 := by ring
+
+/-- The exact count in explicit division form: `gaussExactOps n = (n³ − n)/3`. -/
+theorem gaussExactOps_eq_div (n : ℕ) : gaussExactOps n = (n ^ 3 - n) / 3 := by
+  have h : 3 * gaussExactOps n = n ^ 3 - n := by
+    have := gaussExactOps_closed n
+    omega
+  rw [← h, Nat.mul_div_cancel_left _ (by norm_num : 0 < 3)]
+
+/-- The exact model never exceeds the parent's `n³` upper model:
+    `gaussExactOps n ≤ n³`. -/
+theorem gaussExactOps_le_cube (n : ℕ) : gaussExactOps n ≤ n ^ 3 := by
+  have := gaussExactOps_closed n; omega
+
+/-- The tightening is genuine: for `n ≥ 2` the exact count is *strictly* below
+    the `n³` model (the missing `~2n³/3` is what the loose bound overcounts). -/
+theorem gaussExactOps_lt_cube {n : ℕ} (hn : 2 ≤ n) : gaussExactOps n < n ^ 3 := by
+  have hclosed := gaussExactOps_closed n
+  -- 3 * ops + n = n^3, and n ≥ 2 forces ops < n^3 (since 2*ops = n^3 - n - ops ...).
+  -- Concretely ops < n^3 ⇔ 0 < n^3 - ops = 2*ops + n, which holds as n ≥ 2 > 0.
+  omega
+
+/-- Concrete exact counts (sanity check against the hand computation):
+    `n=2 ↦ 2`, `n=3 ↦ 8`, `n=4 ↦ 20`, `n=5 ↦ 40`. -/
+lemma gaussExactOps_small :
+    gaussExactOps 2 = 2 ∧ gaussExactOps 3 = 8 ∧
+    gaussExactOps 4 = 20 ∧ gaussExactOps 5 = 40 := by
+  have h2 := gaussExactOps_closed 2
+  have h3 := gaussExactOps_closed 3
+  have h4 := gaussExactOps_closed 4
+  have h5 := gaussExactOps_closed 5
+  norm_num at h2 h3 h4 h5
+  omega
+
+/-- With the *tighter* model, Gaussian elimination still beats Cramer's rule for
+    `n ≥ 4` — a fortiori, since `gaussExactOps n ≤ n³ = gaussMuls n` and the
+    parent already proved `gaussMuls n < cramersRuleMuls n`. -/
+theorem gaussExact_beats_cramer {n : ℕ} (hn : 4 ≤ n) :
+    gaussExactOps n < CramersComplexity.cramersRuleMuls n :=
+  lt_of_le_of_lt (gaussExactOps_le_cube n) (CramersComplexity.gauss_beats_cramer hn)
+
+/-- Summary: the exact `(n³ − n)/3` count, its consistency with and strict
+    improvement over the `n³` model, and the preserved comparison verdict. -/
+theorem gauss_exact_summary :
+    (∀ n : ℕ, 3 * gaussExactOps n + n = n ^ 3) ∧
+    (∀ n : ℕ, gaussExactOps n = (n ^ 3 - n) / 3) ∧
+    (∀ n : ℕ, gaussExactOps n ≤ n ^ 3) ∧
+    (∀ n : ℕ, 2 ≤ n → gaussExactOps n < n ^ 3) ∧
+    (∀ n : ℕ, 4 ≤ n → gaussExactOps n < CramersComplexity.cramersRuleMuls n) :=
+  ⟨gaussExactOps_closed, gaussExactOps_eq_div, gaussExactOps_le_cube,
+   fun _ h => gaussExactOps_lt_cube h, fun _ h => gaussExact_beats_cramer h⟩
+
+end CramersComplexityExact

--- a/src/data/proofs/cramers-rule-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "cramers-rule-oq-02-oq-01",
+  "title": "Exact Gaussian-Elimination Cost: Tightening n³ to (n³ − n)/3",
+  "slug": "cramers-rule-oq-02-oq-01",
+  "description": "An axiom-free Lean 4 proof that forward Gaussian elimination on an n×n system uses exactly (n³ − n)/3 multiplications and divisions — the classic 'n³/3 flops' figure — tightening the loose n³ model used in the parent Cramer-vs-Gauss complexity comparison by a factor of ~3 while preserving every comparison conclusion.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_elimination#Computational_efficiency",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CramersRuleOQ02OQ01.lean",
+    "tags": [
+      "computational-complexity",
+      "linear-algebra",
+      "combinatorics",
+      "gaussian-elimination",
+      "cramer",
+      "algorithms",
+      "finset-sum",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peeling the last term of a range sum: ∑_{x<n+1} f x = ∑_{x<n} f x + f n",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel_left",
+        "description": "Exact division cancellation: 0 < b → b * a / b = a",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "Exact per-step model gaussExactOps n = ∑_{j<n} (j² + j) for forward Gaussian elimination, counting j divisions and j² multiplications at the step with j rows below the pivot",
+      "Subtraction-free closed form gaussExactOps_closed: 3·gaussExactOps n + n = n³, proved by induction with a ℕ-semiring calc (ring + Finset.sum_range_succ), no truncated subtraction",
+      "Division form gaussExactOps_eq_div: gaussExactOps n = (n³ − n)/3, the textbook n³/3 flop count, recovered via Nat.mul_div_cancel_left",
+      "Tightening witnesses: gaussExactOps_le_cube (≤ n³, consistency with parent) and gaussExactOps_lt_cube (strict for n ≥ 2, the factor-3 gap is real)",
+      "Comparison preserved: gaussExact_beats_cramer shows the tighter exact model still beats Cramer's rule for n ≥ 4 a fortiori, via the parent's gauss_beats_cramer"
+    ],
+    "dateAdded": "2026-06-26",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 133,
+    "assumptions": "None. Fully kernel-checked: 0 sorries, 0 axiom declarations, 0 assumption-carrying structures, and no native_decide (the small concrete counts gaussExactOps_small are derived from the closed form via omega rather than native_decide, so Lean.ofReduceBool is NOT used). The single dependency on the parent file (CramersComplexity.gauss_beats_cramer, cramersRuleMuls) is through native_decide-free declarations only.",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "**The n³/3 Flop Count**\n\nEvery numerical-linear-algebra textbook states that solving an n×n linear system by Gaussian elimination (equivalently LU factorization) costs about n³/3 multiplications/divisions — one third the naive n³ estimate. The parent entry (cramers-rule-oq-02) compared Cramer's rule against Gaussian elimination but used the deliberately loose upper model gaussMuls n = n³, leaving the precise leading constant unformalized. This entry supplies the exact count.\n\n**Where the n³/3 Comes From**\n\nForward elimination runs in steps k = 1, …, n−1. At step k the pivot is at (k,k) and there are n−k rows beneath it. For each such row we compute one multiplier (a division) and update its n−k trailing entries (a multiplication each), for (n−k) + (n−k)² operations. Summing over k and substituting j = n−k gives ∑_{j=1}^{n−1} (j² + j) = (n−1)·n·(n+1)/3 = (n³ − n)/3.",
+    "problemStatement": "**The Research Question (cramers-rule-oq-02-oq-01)**\n\nCan the Gaussian-elimination complexity model in the parent Cramer-vs-Gauss comparison be tightened from the loose n³ bound to the exact leading multiplication/division count?\n\n**Answer: YES — the exact count is (n³ − n)/3.**\n\nWe define the exact per-step model gaussExactOps n = ∑_{j<n} (j² + j) and prove:\n1. Closed form: 3·gaussExactOps n + n = n³ (subtraction-free), equivalently gaussExactOps n = (n³ − n)/3.\n2. Consistency: gaussExactOps n ≤ n³ for all n, and strictly < for n ≥ 2.\n3. Comparison preserved: for n ≥ 4 the exact model still beats Cramer's rule.",
+    "text": "An axiom-free Lean 4 proof that forward Gaussian elimination uses exactly (n³ − n)/3 multiplications and divisions, tightening the parent's n³ model by a factor of ~3 while keeping every Cramer-vs-Gauss comparison conclusion intact.",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Exact model**: Define gaussExactOps n = ∑_{j ∈ range n} (j² + j). The j = 0 term vanishes, so this equals the textbook ∑_{j=1}^{n−1} (j² + j).\n2. **One-step lemma**: gaussExactOps (n+1) = gaussExactOps n + (n² + n) by Finset.sum_range_succ.\n3. **Closed form by induction**: Prove 3·gaussExactOps n + n = n³ entirely in ℕ. The successor step is a three-line calc that rewrites with the one-step lemma, substitutes the induction hypothesis, and closes with ring — all in the commutative semiring ℕ, so no truncated subtraction is needed (avoiding linear_combination, which requires a ring).\n4. **Division form**: From 3·gaussExactOps n = n³ − n (omega), recover gaussExactOps n = (n³ − n)/3 via Nat.mul_div_cancel_left.\n5. **Bounds and comparison**: gaussExactOps_le_cube and gaussExactOps_lt_cube follow from the closed form by omega (treating n³ and the sum as atoms); gaussExact_beats_cramer chains gaussExactOps n ≤ n³ with the parent's gauss_beats_cramer.",
+    "keyInsights": [
+      "**Subtraction-free closed form**: Stating the identity as 3·gaussExactOps n + n = n³ (rather than gaussExactOps n = (n³ − n)/3) keeps the entire induction inside the ℕ semiring, so plain ring closes the successor step. The division/subtraction form is then a one-line corollary.",
+      "**The factor-3 gap is provable, not just asymptotic**: gaussExactOps_lt_cube shows the exact count is strictly below n³ for every n ≥ 2 — the loose model overcounts by ~2n³/3, which is exactly what makes the n³/3 headline meaningful.",
+      "**A smaller cost only strengthens the verdict**: Because gaussExactOps n ≤ n³ = gaussMuls n, the tighter model inherits the parent's conclusion (Gaussian beats Cramer for n ≥ 4) for free — tightening the winner's cost can never overturn a comparison it already won.",
+      "**omega with nonlinear atoms**: The bound lemmas are discharged by omega, which abstracts n³ and gaussExactOps n as opaque non-negative atoms linked only by the linear closed-form hypothesis — enough to conclude the strict and non-strict inequalities without any cubic reasoning.",
+      "**Axiom-free where the parent was axiomatized**: Deriving the concrete small-n counts from the closed form via omega (instead of native_decide) keeps this file free of Lean.ofReduceBool, so it earns a verified/original badge rather than the parent's axiomatized status."
+    ],
+    "prerequisites": [
+      "Numerical linear algebra (Gaussian elimination, LU factorization, flop counting)",
+      "Finite sums (∑_{j<n} of a polynomial in j, telescoping/closed forms)",
+      "Elementary induction over ℕ and the semiring vs ring distinction in Lean"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports",
+      "summary": "Imports the full Mathlib library (for Finset.sum, Finset.sum_range_succ, omega, ring, norm_num) and the parent file Proofs.CramersRuleOQ02 (for CramersComplexity.cramersRuleMuls and gauss_beats_cramer).",
+      "startLine": 1,
+      "endLine": 2,
+      "mathContext": "Builds on the parent Cramer-vs-Gauss complexity file, reusing its cramersRuleMuls model and gauss_beats_cramer comparison theorem."
+    },
+    {
+      "id": "exact-model",
+      "title": "Exact Per-Step Cost Model",
+      "summary": "Defines gaussExactOps n = ∑_{j ∈ range n} (j² + j), counting j divisions and j² multiplications at the elimination step with j rows below the pivot, and the one-step unfolding lemma gaussExactOps_succ via Finset.sum_range_succ.",
+      "startLine": 53,
+      "endLine": 71,
+      "mathContext": "gaussExactOps(n) = ∑_{j=0}^{n-1} (j² + j); the j=0 term is 0, so this equals ∑_{j=1}^{n-1} (j² + j), the exact multiplication+division count for forward elimination of an n×n system."
+    },
+    {
+      "id": "closed-form",
+      "title": "Closed Form: 3·ops + n = n³",
+      "summary": "Proves gaussExactOps_closed: 3·gaussExactOps n + n = n³ by induction, with a subtraction-free ℕ-semiring calc in the successor step, and the division corollary gaussExactOps_eq_div: gaussExactOps n = (n³ − n)/3.",
+      "startLine": 72,
+      "endLine": 90,
+      "mathContext": "∑_{j=1}^{n-1} (j² + j) = (n-1)·n·(n+1)/3 = (n³ − n)/3. Stated subtraction-free as 3·ops + n = n³ so the induction stays in the ℕ semiring and closes by ring."
+    },
+    {
+      "id": "bounds",
+      "title": "Tightening Bounds vs the n³ Model",
+      "summary": "Proves gaussExactOps_le_cube (gaussExactOps n ≤ n³, consistency with the parent's loose model) and gaussExactOps_lt_cube (strict for n ≥ 2, showing the ~factor-3 overcount is genuine), both via omega from the closed form. Includes gaussExactOps_small with concrete counts 2, 8, 20, 40 for n = 2,3,4,5.",
+      "startLine": 91,
+      "endLine": 116,
+      "mathContext": "gaussExactOps n ≤ n³ always, and strictly less for n ≥ 2: the n³ model overcounts forward elimination by roughly 2n³/3."
+    },
+    {
+      "id": "comparison",
+      "title": "Comparison Preserved Under Tightening",
+      "summary": "Proves gaussExact_beats_cramer: for n ≥ 4 the exact (n³ − n)/3 model still uses fewer operations than Cramer's rule, a fortiori from gaussExactOps n ≤ n³ and the parent's gauss_beats_cramer. The summary theorem gauss_exact_summary bundles the closed form, division form, both bounds, and the preserved comparison.",
+      "startLine": 117,
+      "endLine": 133,
+      "mathContext": "Since gaussExactOps n ≤ n³ = gaussMuls n and the parent proved gaussMuls n < cramersRuleMuls n for n ≥ 4, the tighter model beats Cramer's rule a fortiori — tightening the winner's cost cannot overturn the comparison."
+    }
+  ],
+  "conclusion": "This entry pins down the exact leading cost of Gaussian elimination — (n³ − n)/3 multiplications and divisions — that the parent Cramer-vs-Gauss comparison only bounded by n³. The closed form 3·gaussExactOps n + n = n³ is proved by a short subtraction-free induction in the ℕ semiring, its (n³ − n)/3 division form follows in one line, and omega supplies both the consistency bound (≤ n³) and the strict tightening (< n³ for n ≥ 2). Because a smaller cost can only strengthen a comparison the winner already led, the headline verdict — Gaussian beats Cramer for n ≥ 4 — carries over to the exact model for free. The whole file is axiom-free (no sorries, no native_decide), upgrading the parent's axiomatized model to a fully kernel-checked exact count.",
+  "relatedProblems": [
+    "cramers-rule-oq-02",
+    "cramers-rule"
+  ],
+  "mainTheorems": [
+    {
+      "name": "gaussExactOps_closed",
+      "statement": "3 * gaussExactOps n + n = n ^ 3",
+      "description": "Subtraction-free closed form for the exact Gaussian-elimination operation count; equivalent to gaussExactOps n = (n³ − n)/3."
+    },
+    {
+      "name": "gaussExactOps_eq_div",
+      "statement": "gaussExactOps n = (n ^ 3 - n) / 3",
+      "description": "The textbook n³/3 flop count in explicit division form."
+    },
+    {
+      "name": "gaussExactOps_lt_cube",
+      "statement": "2 ≤ n → gaussExactOps n < n ^ 3",
+      "description": "The exact count is strictly below the parent's n³ model for n ≥ 2: the tightening is genuine."
+    },
+    {
+      "name": "gaussExact_beats_cramer",
+      "statement": "4 ≤ n → gaussExactOps n < CramersComplexity.cramersRuleMuls n",
+      "description": "The tighter exact model still beats Cramer's rule for n ≥ 4, a fortiori from the parent comparison."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/CramersRuleOQ02OQ01.lean",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "lineCount": 133
+  },
+  "references": [
+    {
+      "title": "Gaussian elimination — Computational efficiency (operation count)",
+      "url": "https://en.wikipedia.org/wiki/Gaussian_elimination#Computational_efficiency"
+    },
+    {
+      "title": "LU decomposition — operation count (~2n³/3 flops)",
+      "url": "https://en.wikipedia.org/wiki/LU_decomposition#Theoretical_complexity"
+    }
+  ],
+  "crossReferences": [],
+  "sorries": []
+}

--- a/src/data/research/problems/cramers-rule-oq-02-oq-01.json
+++ b/src/data/research/problems/cramers-rule-oq-02-oq-01.json
@@ -1,39 +1,65 @@
 {
   "slug": "cramers-rule-oq-02-oq-01",
-  "title": "cramers-rule-oq-02-oq-01",
-  "phase": "OBSERVE",
-  "status": "active",
+  "title": "Exact Gaussian-elimination cost: tightening n³ to (n³ − n)/3",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
-    "formal": "",
-    "plain": "",
-    "whyMatters": []
+    "formal": "Forward Gaussian elimination of an n×n system costs gaussExactOps n = ∑_{j<n}(j²+j) multiplications+divisions, with 3·gaussExactOps n + n = n³, i.e. gaussExactOps n = (n³ − n)/3.",
+    "plain": "The parent Cramer-vs-Gauss entry bounds Gaussian elimination by the loose n³ multiplication model. This entry proves the exact leading count is (n³ − n)/3 — the classic 'n³/3 flops' — tightening the model by a factor of ~3 while keeping every comparison conclusion.",
+    "whyMatters": [
+      "Pins down the exact leading constant (1/3) behind the textbook flop count for Gaussian elimination / LU factorization.",
+      "Upgrades the parent's loose, axiomatized n³ model to a fully kernel-checked exact closed form (no native_decide, axiom-free)."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "gaussExactOps n = ∑_{j<n}(j²+j) — exact per-step model (j divisions + j² multiplications at the step with j rows below the pivot).",
+      "gaussExactOps_closed: 3·gaussExactOps n + n = n³ (subtraction-free closed form, induction + ring in the ℕ semiring).",
+      "gaussExactOps_eq_div: gaussExactOps n = (n³ − n)/3 (textbook n³/3 flop count).",
+      "gaussExactOps_le_cube and gaussExactOps_lt_cube: ≤ n³ always, strict for n ≥ 2 (the factor-3 tightening is genuine).",
+      "gaussExact_beats_cramer: the tighter model still beats Cramer's rule for n ≥ 4, a fortiori from the parent gauss_beats_cramer."
+    ],
+    "open": [
+      "Separately counting additions/subtractions (~n³/3 each) and the right-hand-side back-substitution cost for the full ~2n³/3 flop total.",
+      "Generalizing to block / Strassen-style elimination where the leading constant changes."
+    ],
+    "goal": "Replace the loose n³ Gaussian-elimination model with the exact (n³ − n)/3 count and confirm the Cramer-vs-Gauss verdict is preserved."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-03-30T11:35:18-07:00",
+    "phase": "COMPLETE",
+    "since": "2026-06-26",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Exact (n³ − n)/3 operation count formalized and proved axiom-free.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "None — deliverable complete (CramersRuleOQ02OQ01.lean, gallery entry added).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "ACT (researcher-9, 2026-06-26): Created Proofs/CramersRuleOQ02OQ01.lean (133 LOC, axiom-free, 0 sorry, no native_decide) tightening the parent CramersRuleOQ02 Gaussian-elimination model from the loose gaussMuls n = n³ to the exact gaussExactOps n = ∑_{j<n}(j²+j) = (n³ − n)/3. Closed form 3·gaussExactOps n + n = n³ proved by induction with a subtraction-free ℕ-semiring calc (Finset.sum_range_succ + ring); division form via Nat.mul_div_cancel_left; ≤/< n³ bounds and the preserved Cramer comparison (n ≥ 4) via omega + parent gauss_beats_cramer. Docker build clean. Gallery entry src/data/proofs/cramers-rule-oq-02-oq-01 added (status verified, badge original).",
+    "builtItems": [
+      "Proofs/CramersRuleOQ02OQ01.lean — 1 def (gaussExactOps), 8 theorems/lemmas, axiom-free, 0 sorry, no native_decide.",
+      "gaussExactOps_closed: 3·gaussExactOps n + n = n³ (subtraction-free induction, ring in ℕ semiring).",
+      "gaussExactOps_eq_div: gaussExactOps n = (n³ − n)/3 — exact n³/3 flop count.",
+      "gaussExactOps_lt_cube: strict tightening below n³ for n ≥ 2; gaussExact_beats_cramer: comparison preserved for n ≥ 4.",
+      "Gallery entry src/data/proofs/cramers-rule-oq-02-oq-01 (meta.json) documenting the exact model."
+    ],
+    "insights": [
+      "Stating the closed form subtraction-free as 3·ops + n = n³ keeps the induction in the ℕ semiring so plain `ring` closes the successor step; the (n³ − n)/3 division form is then a one-line corollary. linear_combination would not work here because ℕ is not a ring.",
+      "A tighter cost for the comparison winner can never overturn the comparison: gaussExactOps n ≤ n³ = gaussMuls n lets gaussExact_beats_cramer inherit the parent's n ≥ 4 verdict for free.",
+      "omega abstracts n³ and the Finset sum as opaque non-negative atoms linked only by the linear closed-form hypothesis, which suffices for both the ≤ and strict-< bounds without any cubic reasoning.",
+      "Deriving the concrete small-n counts (2,8,20,40) from the closed form via omega instead of native_decide keeps the file free of Lean.ofReduceBool — verified/original rather than the parent's axiomatized status."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Count additions/subtractions (~n³/3 each) and back-substitution for the full ~2n³/3 flop total.",
+      "Relate to Mathlib's LU / Matrix infrastructure if an algorithmic operation-count API is added."
+    ],
     "markdown": "# Knowledge Base: cramers-rule-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [],


### PR DESCRIPTION
## Summary

Answers the open question for `cramers-rule-oq-02`: **can the Gaussian-elimination complexity model be tightened from the loose `n³` to the exact `n³/3` count?** Yes — the exact forward-elimination operation count is **`(n³ − n)/3`**.

The parent entry `CramersRuleOQ02` compares Cramer's rule against Gaussian elimination using the deliberately loose upper model `gaussMuls n = n³`. This entry replaces it with the exact per-step count.

## What is proved (`Proofs/CramersRuleOQ02OQ01.lean`, 133 LOC)

- `gaussExactOps n = ∑_{j<n} (j² + j)` — exact model: at the step clearing a column with `j` rows below the pivot, `j` divisions (multipliers) + `j²` multiplications (trailing-entry updates).
- `gaussExactOps_closed`: `3·gaussExactOps n + n = n³` — subtraction-free closed form, proved by induction with `Finset.sum_range_succ` + `ring` in the ℕ semiring.
- `gaussExactOps_eq_div`: `gaussExactOps n = (n³ − n)/3` — the textbook "n³/3 flops" headline, recovered via `Nat.mul_div_cancel_left`.
- `gaussExactOps_le_cube` / `gaussExactOps_lt_cube`: `≤ n³` always, strict for `n ≥ 2` — the factor-3 tightening is genuine.
- `gaussExact_beats_cramer`: the tighter model still beats Cramer's rule for `n ≥ 4`, a fortiori from the parent's `gauss_beats_cramer`.

## Verification

- **0 axioms, 0 sorries, no `native_decide`** — small-n counts are derived from the closed form via `omega`, so `Lean.ofReduceBool` is **not** used. Status `verified` / badge `original`, upgrading the parent's `axiomatized` `n³` model.
- Docker build clean: `Built Proofs.CramersRuleOQ02OQ01 (5.9s)`.

## Note

The Lean file and gallery data were originally drafted by a prior session (researcher-9, 2026-06-26) but never committed; this PR builds, validates, and lands that work on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)