### PR TITLE
research(hermite-sawtooth-identity-oq-02): ∑_{k<q}{kp/q}=(q-1)/2 for coprime p,q [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/HermiteSawtoothIdentityOQ02.lean
+++ b/proofs/Proofs/HermiteSawtoothIdentityOQ02.lean
@@ -1,0 +1,101 @@
+/-
+# Eisenstein's Reciprocity Input: ∑_{k<q} {kp/q} = (q-1)/2 for coprime p, q
+
+For coprime natural numbers `p` and `q` with `q ≥ 1`,
+$$\sum_{k=0}^{q-1} \left\{ \frac{k p}{q} \right\} = \frac{q-1}{2},$$
+where `{y} = y - ⌊y⌋` is the fractional part (`Int.fract`).
+
+This is the clean evaluation requested as a follow-up to the companion sawtooth
+identity (`HermiteSawtoothIdentity.lean`). It is the arithmetic ingredient that
+feeds Eisenstein's lemma and the lattice-point proof of quadratic reciprocity:
+the average of the sawtooth `{kp/q}` over a full residue system is exactly the
+"diagonal" value `(q-1)/2`, independent of `p`.
+
+## The argument
+
+Two elementary facts combine:
+
+1. **Sawtooth at `x = 0`.** Specialising the parent identity
+   `∑_{k<n} {x + k/n} = {nx} + (n-1)/2` at `x = 0` gives
+   `∑_{k<q} {k/q} = (q-1)/2`, since `{q·0} = 0`.
+
+2. **Multiplication by `p` permutes residues.** Because `gcd(p,q) = 1`, the map
+   `k ↦ k·p mod q` is a bijection of `{0, …, q-1}` onto itself. Hence the
+   residues `k·p mod q` are a rearrangement of `0, …, q-1`, and since
+   `{kp/q} = (k·p mod q)/q`, summing gives the same total as `∑_{k<q} {k/q}`.
+
+Concretely we show `∑_{k<q} (k·p mod q) = ∑_{k<q} k = q(q-1)/2`, divide by `q`,
+and read off `(q-1)/2`.
+
+## What this adds
+
+The parent entry proves the sawtooth identity for a single real `x`. This entry
+applies it to the number-theoretic sum `∑_{k<q} {kp/q}`, supplying the
+`p`-independent closed form `(q-1)/2`. Mathlib has `Int.fract` and the residue
+permutation machinery but does not record this Gauss/Eisenstein reciprocity
+input directly. Fully machine-checked, `0` sorries, no axioms.
+-/
+import Mathlib
+import Proofs.HermiteSawtoothIdentity
+
+open Finset
+
+namespace HermiteSawtoothIdentity
+
+/-- **Sawtooth at `x = 0`.** The equally spaced fractional parts `{k/q}`,
+`k = 0, …, q-1`, sum to `(q-1)/2`. -/
+theorem sum_fract_div (q : ℕ) (hq : 0 < q) :
+    ∑ k ∈ range q, Int.fract ((k : ℝ) / (q : ℝ)) = ((q : ℝ) - 1) / 2 := by
+  have h := hermite_sawtooth_identity 0 q hq
+  simpa using h
+
+/-- **Residue permutation.** When `gcd(p,q) = 1`, the map `k ↦ k·p mod q` permutes
+`{0, …, q-1}`, so the residues `k·p mod q` sum to the same value as `0, …, q-1`. -/
+theorem sum_mul_mod_coprime (p q : ℕ) (hq : 0 < q) (hpq : Nat.Coprime p q) :
+    ∑ k ∈ range q, (k * p % q) = ∑ k ∈ range q, k := by
+  -- `σ k = k·p mod q` maps `range q` into itself injectively, hence bijectively.
+  set σ : ℕ → ℕ := fun k => k * p % q with hσ
+  have hmaps : ∀ k ∈ range q, σ k ∈ range q := by
+    intro k _; simp only [hσ, mem_range]; exact Nat.mod_lt _ hq
+  have hinj : Set.InjOn σ (range q) := by
+    intro a ha b hb hab
+    simp only [mem_coe, mem_range] at ha hb
+    -- `σ a = σ b` is exactly `a·p ≡ b·p [MOD q]`.
+    have hmod : a * p ≡ b * p [MOD q] := hab
+    have hab' : a % q = b % q := Nat.ModEq.cancel_right_of_coprime hpq.symm hmod
+    rwa [Nat.mod_eq_of_lt ha, Nat.mod_eq_of_lt hb] at hab'
+  -- The image is contained in `range q` and has the same cardinality, so equals it.
+  have himg : (range q).image σ = range q := by
+    apply Finset.eq_of_subset_of_card_le
+    · intro x hx
+      rw [mem_image] at hx
+      obtain ⟨k, hk, rfl⟩ := hx
+      exact hmaps k hk
+    · rw [Finset.card_image_of_injOn hinj, card_range]
+  have hsum := Finset.sum_image (f := fun x => x) hinj
+  rw [himg] at hsum
+  exact hsum.symm
+
+/-- **Eisenstein reciprocity input.** For coprime `p, q` with `q ≥ 1`,
+`∑_{k<q} {kp/q} = (q-1)/2`. -/
+theorem sum_fract_mul_div_coprime (p q : ℕ) (hq : 0 < q) (hpq : Nat.Coprime p q) :
+    ∑ k ∈ range q, Int.fract ((k : ℝ) * (p : ℝ) / (q : ℝ)) = ((q : ℝ) - 1) / 2 := by
+  -- Each fractional part is the residue `(k·p mod q)/q`.
+  have hterm : ∀ k ∈ range q,
+      Int.fract ((k : ℝ) * (p : ℝ) / (q : ℝ)) = ((k * p % q : ℕ) : ℝ) / (q : ℝ) := by
+    intro k _
+    rw [show (k : ℝ) * (p : ℝ) = ((k * p : ℕ) : ℝ) by push_cast; ring]
+    exact Int.fract_div_natCast_eq_div_natCast_mod
+  rw [Finset.sum_congr rfl hterm, ← Finset.sum_div, ← Nat.cast_sum,
+    sum_mul_mod_coprime p q hq hpq]
+  -- Remaining: `↑(∑_{k<q} k) / q = (q-1)/2`, via the Gauss sum.
+  have hq0 : (q : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hq.ne'
+  have hgauss : ((∑ k ∈ range q, k : ℕ) : ℝ) * 2 = (q : ℝ) * ((q : ℝ) - 1) := by
+    have hc := congrArg (fun m : ℕ => (m : ℝ)) (Finset.sum_range_id_mul_two q)
+    push_cast [Nat.cast_sub hq] at hc
+    rw [Nat.cast_sum]
+    linarith [hc]
+  field_simp
+  linear_combination hgauss
+
+end HermiteSawtoothIdentity

--- a/src/data/proofs/hermite-sawtooth-identity-oq-02/annotations.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-02/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-sawtooth-zero",
+    "proofId": "hermite-sawtooth-identity-oq-02",
+    "range": { "startLine": 45, "endLine": 50 },
+    "type": "theorem",
+    "title": "Sawtooth at x = 0: ∑_{k<q} {k/q} = (q−1)/2",
+    "content": "The starting value, read straight off the parent identity. Setting $x = 0$ in $\\sum_{k<n}\\{x+k/n\\} = \\{nx\\}+(n-1)/2$ kills the right-hand fractional term, since $\\{q\\cdot 0\\} = 0$, leaving exactly the diagonal term $(q-1)/2$. A single `simpa` discharges the residual $0 + k/q$ simplifications inside the binder. This is the $p = 1$ instance of the main theorem, and the value every coprime $p$ will collapse to.",
+    "mathContext": "$\\sum_{k<q}\\left\\{\\tfrac kq\\right\\} = \\tfrac{q-1}2$.",
+    "significance": "key",
+    "prerequisites": ["Int.fract", "hermite_sawtooth_identity"],
+    "relatedConcepts": ["Sawtooth identity", "Fractional part"]
+  },
+  {
+    "id": "ann-residue-permutation",
+    "proofId": "hermite-sawtooth-identity-oq-02",
+    "range": { "startLine": 52, "endLine": 77 },
+    "type": "theorem",
+    "title": "Multiplication by a unit permutes residues",
+    "content": "The only number-theoretic step. The map $\\sigma(k) = kp \\bmod q$ sends $\\{0,\\dots,q-1\\}$ into itself by `Nat.mod_lt`, and is injective: $ap \\equiv bp \\pmod q$ cancels to $a \\equiv b \\pmod q$ via `Nat.ModEq.cancel_right_of_coprime` (using $\\gcd(p,q)=1$), and for $a,b < q$ that is $a = b$. An injective self-map of a finite set is surjective — formally, the image is a subset of `range q` of the same cardinality (`card_image_of_injOn`), so `eq_of_subset_of_card_le` forces equality. `Finset.sum_image` then reindexes $\\sum_{k<q}\\sigma(k)$ to $\\sum_{k<q} k$, proving the residues $kp \\bmod q$ are $0,\\dots,q-1$ rearranged.",
+    "mathContext": "$\\gcd(p,q)=1 \\implies \\sum_{k<q}(kp \\bmod q) = \\sum_{k<q} k$.",
+    "significance": "critical",
+    "prerequisites": ["Nat.ModEq.cancel_right_of_coprime", "Finset.eq_of_subset_of_card_le", "Set.InjOn"],
+    "relatedConcepts": ["Complete residue system", "Units modulo q", "Pigeonhole bijection"]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "hermite-sawtooth-identity-oq-02",
+    "range": { "startLine": 79, "endLine": 99 },
+    "type": "theorem",
+    "title": "∑_{k<q} {kp/q} = (q−1)/2 — the reciprocity input",
+    "content": "Assembly. Each summand $\\{kp/q\\}$ is rewritten as the residue $(kp \\bmod q)/q$ through `Int.fract_div_natCast_eq_div_natCast_mod`, after recasting $k\\cdot p$ as the natural number $kp$. The common $1/q$ is pulled out of the sum (`← Finset.sum_div`), the cast is pushed through (`← Nat.cast_sum`), and the residue sum is replaced by $\\sum_{k<q} k$ using the permutation lemma. The Gauss sum `Finset.sum_range_id_mul_two` ($(\\sum k)\\cdot 2 = q(q-1)$) then closes $\\uparrow(\\sum k)/q = (q-1)/2$ with `field_simp` and `linear_combination`. The $p$-independence is now manifest: every coprime $p$ produced the same residue multiset.",
+    "mathContext": "$\\sum_{k=0}^{q-1}\\left\\{\\tfrac{kp}{q}\\right\\} = \\tfrac{q-1}2$ for $\\gcd(p,q)=1$, $q \\ge 1$.",
+    "significance": "critical",
+    "prerequisites": ["Int.fract_div_natCast_eq_div_natCast_mod", "Finset.sum_range_id_mul_two", "Finset.sum_div"],
+    "relatedConcepts": ["Eisenstein's lemma", "Quadratic reciprocity", "Gauss sum"]
+  }
+]

--- a/src/data/proofs/hermite-sawtooth-identity-oq-02/meta.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-02/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "hermite-sawtooth-identity-oq-02",
+  "title": "Eisenstein's Reciprocity Input: ∑_{k<q} {kp/q} = (q−1)/2 for coprime p, q",
+  "slug": "hermite-sawtooth-identity-oq-02",
+  "description": "A fully machine-checked evaluation of the sawtooth sum ∑_{k=0}^{q-1} {kp/q} = (q-1)/2 for coprime natural numbers p, q with q ≥ 1, where {y} = y − ⌊y⌋ is the fractional part. This is the p-independent closed form that feeds Eisenstein's lemma and the lattice-point proof of quadratic reciprocity. The proof combines two elementary facts: specialising the parent sawtooth identity ∑_{k<n}{x+k/n} = {nx} + (n−1)/2 at x = 0 gives ∑_{k<q}{k/q} = (q−1)/2; and because gcd(p,q) = 1, the map k ↦ k·p mod q permutes {0,…,q−1}, so the residues k·p mod q are a rearrangement of 0,…,q−1 and the two sums agree. The bijection is established via Nat.ModEq.cancel_right_of_coprime plus a cardinality argument (Finset.eq_of_subset_of_card_le, card_image_of_injOn), and each fractional part is identified with its residue through Int.fract_div_natCast_eq_div_natCast_mod. Verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Ferdinand Gotthold Eisenstein (1844) / Carl Friedrich Gauss; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Eisenstein%27s_lemma",
+    "date": "1844",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "eisenstein-lemma",
+      "fractional-part",
+      "residue-permutation",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/HermiteSawtoothIdentityOQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.fract_div_natCast_eq_div_natCast_mod",
+        "description": "For m n : ℕ, Int.fract (↑m / ↑n) = ↑(m % n) / ↑n. Identifies the fractional part {kp/q} with the residue (k·p mod q)/q, turning the analytic sum into a sum over residues.",
+        "module": "Mathlib.Algebra.Order.Floor.Ring"
+      },
+      {
+        "theorem": "Nat.ModEq.cancel_right_of_coprime",
+        "description": "From gcd q p = 1 and a·p ≡ b·p [MOD q], concludes a ≡ b [MOD q]. The injectivity engine for the residue permutation k ↦ k·p mod q.",
+        "module": "Mathlib.Data.Nat.ModEq"
+      },
+      {
+        "theorem": "Finset.eq_of_subset_of_card_le",
+        "description": "An injective self-map of range q has full image; combined with card_image_of_injOn this upgrades injectivity to a bijection of {0,…,q−1}.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.sum_range_id_mul_two",
+        "description": "(∑_{i<n} i)·2 = n·(n−1), the Gauss sum, used to evaluate ∑_{k<q} k = q(q−1)/2 and read off (q−1)/2 after dividing by q.",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      }
+    ],
+    "originalContributions": [
+      "The Eisenstein/Gauss reciprocity input ∑_{k=0}^{q-1} {kp/q} = (q−1)/2 for coprime p, q (sum_fract_mul_div_coprime) machine-checked for general p and q ≥ 1 — the p-independent average of the sawtooth over a complete residue system, which Mathlib does not record directly",
+      "sum_fract_div: the x = 0 specialisation ∑_{k<q} {k/q} = (q−1)/2, obtained in one line from the parent sawtooth identity",
+      "sum_mul_mod_coprime: a clean statement that multiplication by a unit p permutes residues, ∑_{k<q} (k·p mod q) = ∑_{k<q} k, proved by an injectivity-plus-cardinality bijection argument over Finset.range q",
+      "An explicit reduction of the analytic fractional-part sum to a finite residue sum via Int.fract_div_natCast_eq_div_natCast_mod, isolating the only number-theoretic content (the coprimality-driven permutation) from the arithmetic"
+    ],
+    "dateAdded": "2026-06-28",
+    "axiomCount": 0,
+    "lineCount": 101,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for all results. No native_decide, no sorryAx, no structure-encoded hypotheses. The hypotheses (0 < q and Nat.Coprime p q) are explicit arguments of the theorems, not assumptions about the ambient theory.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "sawtooth-zero",
+      "title": "Sawtooth at x = 0",
+      "startLine": 45,
+      "endLine": 50,
+      "summary": "sum_fract_div: ∑_{k<q} {k/q} = (q−1)/2. A one-line specialisation of the parent identity hermite_sawtooth_identity at x = 0, where {q·0} = 0 collapses the right-hand side to the bare diagonal term (q−1)/2; `simpa` discharges the residual 0 + k/q simplifications."
+    },
+    {
+      "id": "residue-permutation",
+      "title": "Multiplication by a unit permutes residues",
+      "startLine": 52,
+      "endLine": 77,
+      "summary": "sum_mul_mod_coprime: ∑_{k<q} (k·p mod q) = ∑_{k<q} k. The map σ k = k·p mod q sends range q into itself (Nat.mod_lt) and is injective — a·p ≡ b·p [MOD q] with gcd(p,q)=1 forces a ≡ b [MOD q] (Nat.ModEq.cancel_right_of_coprime), and a, b < q then gives a = b. Injective + same-cardinality image ⟹ image = range q (eq_of_subset_of_card_le, card_image_of_injOn), so sum_image reindexes the sum to ∑_{k<q} k."
+    },
+    {
+      "id": "main",
+      "title": "The reciprocity input ∑_{k<q} {kp/q} = (q−1)/2",
+      "startLine": 79,
+      "endLine": 99,
+      "summary": "sum_fract_mul_div_coprime: each summand {kp/q} is rewritten as the residue (k·p mod q)/q via Int.fract_div_natCast_eq_div_natCast_mod; the 1/q is pulled out (← Finset.sum_div), the cast pushed through the sum (← Nat.cast_sum), and the residue sum replaced by ∑_{k<q} k via sum_mul_mod_coprime. The Gauss sum (sum_range_id_mul_two) then closes ↑(∑ k)/q = (q−1)/2 with field_simp and linear_combination."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Eisenstein's lemma and quadratic reciprocity**\n\nThe sum $\\sum_{k=0}^{q-1}\\{kp/q\\}$ is the arithmetic heart of the lattice-point proof of the law of quadratic reciprocity. Gauss's lemma counts the sign changes of $p, 2p, \\dots$ modulo $q$, and Eisenstein (1844) packaged the resulting count as a sum of floor terms $\\sum_k \\lfloor kp/q\\rfloor$ over a half-period; the complementary fractional-part sum $\\sum_k\\{kp/q\\}$ is its exact twin. Over a *full* residue system the fractional-part sum has a strikingly simple value — $(q-1)/2$, independent of $p$ — because multiplication by the unit $p$ merely permutes the residues. This is the parent gallery entry's fractional-part sawtooth identity ($\\sum_{k<n}\\{x+k/n\\} = \\{nx\\} + (n-1)/2$) specialised and combined with a residue permutation. Mathlib carries `Int.fract`, the modular-arithmetic API, and quadratic reciprocity itself, but not this packaged reciprocity input.",
+    "problemStatement": "**Sawtooth sum over a complete residue system**\n\nFor coprime natural numbers $p, q$ with $q \\ge 1$, evaluate\n$$\\sum_{k=0}^{q-1}\\left\\{\\frac{kp}{q}\\right\\} = \\frac{q-1}{2},$$\nexhibiting the $(q-1)/2$ diagonal term predicted by the parent sawtooth identity and the $p$-independence forced by coprimality. This is the Gauss/Eisenstein input to quadratic reciprocity.",
+    "proofStrategy": "**Specialise, then permute**\n\nThe value is built from two elementary observations. (1) Setting $x = 0$ in the parent identity $\\sum_{k<n}\\{x+k/n\\} = \\{nx\\}+(n-1)/2$ gives $\\sum_{k<q}\\{k/q\\} = (q-1)/2$ directly, since $\\{q\\cdot 0\\} = 0$. (2) Because $\\gcd(p,q)=1$, the map $k \\mapsto kp \\bmod q$ is a bijection of $\\{0,\\dots,q-1\\}$: it lands in range by `Nat.mod_lt`, and is injective because $ap \\equiv bp \\pmod q$ cancels to $a \\equiv b \\pmod q$ (`Nat.ModEq.cancel_right_of_coprime`), which for $a,b < q$ means $a = b$. An injective self-map of a finite set is surjective (`eq_of_subset_of_card_le` after `card_image_of_injOn`), so the residues $kp \\bmod q$ are exactly $0,\\dots,q-1$ rearranged. Since `Int.fract_div_natCast_eq_div_natCast_mod` gives $\\{kp/q\\} = (kp \\bmod q)/q$, the sum equals $\\frac1q\\sum_{k<q}(kp \\bmod q) = \\frac1q\\sum_{k<q}k = (q-1)/2$ by the Gauss sum.",
+    "keyInsights": [
+      "**The value is $p$-independent, and that is the whole point.** Coprimality means multiplication by $p$ only relabels the residues, so $\\sum_k\\{kp/q\\}$ cannot depend on $p$ — it equals the $p = 1$ value $(q-1)/2$ for every unit $p$.",
+      "**The fractional part is a residue in disguise.** `Int.fract_div_natCast_eq_div_natCast_mod` turns the analytic $\\{kp/q\\}$ into the arithmetic $(kp \\bmod q)/q$, after which no analysis remains — only a finite sum over a permuted residue system.",
+      "**Injective ⟹ bijective is the only number theory used.** Once $k \\mapsto kp \\bmod q$ is shown injective via coprime cancellation, the pigeonhole upgrade to a permutation (`eq_of_subset_of_card_le`) supplies the rearrangement for free.",
+      "**The diagonal term $(q-1)/2$ is the parent sawtooth's fingerprint.** Specialising $\\sum_{k<n}\\{x+k/n\\} = \\{nx\\}+(n-1)/2$ at $x=0$ exhibits exactly the $(n-1)/2$ term the open question asked to surface."
+    ],
+    "prerequisites": [
+      "Fractional part Int.fract and floor",
+      "Modular arithmetic and Nat.ModEq",
+      "Coprimality and cancellation of units mod q",
+      "Finite sums over Finset.range and the Gauss sum"
+    ]
+  },
+  "conclusion": {
+    "summary": "For coprime $p, q$ with $q \\ge 1$, the sawtooth sum $\\sum_{k<q}\\{kp/q\\} = (q-1)/2$ is established by specialising the parent identity at $x = 0$ and using the coprimality-driven permutation $k \\mapsto kp \\bmod q$ to reduce $\\sum_k(kp \\bmod q)$ to the Gauss sum $\\sum_k k = q(q-1)/2$. The fractional part is identified with its residue via `Int.fract_div_natCast_eq_div_natCast_mod`, isolating the single number-theoretic step. 3 theorems, 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the $p$-independent reciprocity input $\\sum_{k<q}\\{kp/q\\} = (q-1)/2$, the fractional-part companion of Eisenstein's floor sum, in a form reusable for lattice-point reciprocity arguments.",
+      "Records the reusable lemma sum_mul_mod_coprime — multiplication by a unit permutes residues, ∑_{k<q}(kp mod q) = ∑_{k<q} k — as a standalone fact about Finset.range.",
+      "Exhibits the parent sawtooth identity's $(n-1)/2$ diagonal term as the value of a concrete number-theoretic sum, closing the loop between the analytic identity and its arithmetic use."
+    ],
+    "openQuestions": [
+      "Evaluate the half-period floor sum ∑_{k=1}^{(q-1)/2} ⌊kp/q⌋ (Eisenstein's lemma proper) and assemble the reciprocity-sign count μ(p,q) = ∑ ⌊kp/q⌋, en route to a lattice-point proof of quadratic reciprocity.",
+      "Generalise to ∑_{k<q} {f(k)/q} for f any unit-multiplication-and-shift k ↦ ak+b with gcd(a,q)=1, showing the value depends only on the shift b through ∑{(k+b)/q}.",
+      "Relate the result to Dedekind sums s(p,q) = ∑_{k<q} ((k/q))((kp/q)), where the centred sawtooth ((·)) replaces {·}, and identify which part of the present argument survives."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "hermite-sawtooth-identity",
+      "relationship": "parent",
+      "description": "Parent entry: the fractional-part sawtooth identity ∑_{k<n} {x+k/n} = {nx} + (n−1)/2. This entry answers its open question oq-02 by using the x = 0 specialisation, together with a coprime residue permutation, to evaluate the Gauss/Eisenstein reciprocity sum ∑_{k<q} {kp/q} = (q−1)/2."
+    },
+    {
+      "proofId": "hermite-sawtooth-identity-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling follow-up that lifts the parent sawtooth to the Raabe multiplication formula for Bernoulli polynomials. Where oq-01 generalises the identity to polynomials, this entry applies it to a number-theoretic residue sum."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Eisenstein, Ferdinand Gotthold",
+      "title": "Geometrischer Beweis des Fundamentaltheorems für die quadratischen Reste",
+      "year": "1844",
+      "note": "Journal für die reine und angewandte Mathematik 28 — the lattice-point counting argument whose fractional-part sum is evaluated here."
+    },
+    {
+      "authors": "Ireland, Kenneth; Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "note": "Springer GTM 84 — Gauss's lemma, Eisenstein's lemma, and the role of ∑⌊kp/q⌋ and ∑{kp/q} in quadratic reciprocity."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers open question **oq-02** of `hermite-sawtooth-identity`: *use the sawtooth identity to derive a clean formula for ∑_{k<q}{kp/q} (Gauss-sum reciprocity input), exhibiting the (n−1)/2 diagonal term.*

For coprime natural numbers `p, q` with `q ≥ 1`:
47588\sum_{k=0}^{q-1}\left\{\frac{kp}{q}\right\} = \frac{q-1}{2},47588
the **p-independent** value that feeds Eisenstein's lemma and the lattice-point proof of quadratic reciprocity.

## Argument (two elementary facts)

1. **Sawtooth at x = 0** — specialising the parent identity `∑_{k<n}{x+k/n} = {nx}+(n−1)/2` at `x = 0` gives `∑_{k<q}{k/q} = (q−1)/2`, since `{q·0}=0`. This surfaces the `(n−1)/2` diagonal term the OQ asked for.
2. **Residue permutation** — because `gcd(p,q)=1`, the map `k ↦ kp mod q` permutes `{0,…,q−1}` (coprime cancellation via `Nat.ModEq.cancel_right_of_coprime` + pigeonhole bijection `eq_of_subset_of_card_le`), so `∑_{k<q}(kp mod q) = ∑_{k<q} k`.

Identifying `{kp/q} = (kp mod q)/q` (`Int.fract_div_natCast_eq_div_natCast_mod`) and closing with the Gauss sum gives the result.

## Verification
- 3 theorems, **0 sorries, 0 axioms** (foundational `propext`/`Classical.choice`/`Quot.sound` only; no `native_decide`)
- Builds against Mathlib 4.26.0 via `docker-build.sh Proofs.HermiteSawtoothIdentityOQ02`
- Gallery meta + annotations added; size + annotation-build checks pass

## Files
- `proofs/Proofs/HermiteSawtoothIdentityOQ02.lean` (101 lines)
- `src/data/proofs/hermite-sawtooth-identity-oq-02/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)