### PR TITLE
research(collatz-structured-oq-01): logarithmic lower bound on the basin counting function [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ01.lean
+++ b/proofs/Proofs/CollatzStructuredOQ01.lean
@@ -421,6 +421,67 @@ example : (8 : ℕ) % 6 ≠ 4 := by decide
 example : collatz 16 = 8 := by decide
 
 /-!
+## Part VI: A logarithmic lower bound on the basin counting function
+
+`basin_infinite` (Part IV) is qualitative. Here we make it **quantitative**: at
+least `Nat.log 2 N + 1` of the numbers in `[0, N]` reach 1. The reason is
+elementary — the `Nat.log 2 N + 1` distinct powers of two
+`2^0, 2^1, …, 2^(Nat.log 2 N)` all lie in `[1, N]` and all reach 1 — but it turns
+`basin_infinite` into an explicit growth rate for the counting function
+`N ↦ #{n ≤ N : ReachesOne n}`.
+
+This is the *achievable* (lower-bound) half of nextStep 4's "two-sided bound". A
+matching **nontrivial upper bound** `#{n ≤ N : ReachesOne n} < N + 1` would require
+exhibiting some `n ≤ N` that never reaches 1 — which is exactly the open Collatz
+question. So only the lower bound is unconditional.
+-/
+
+/-- Every power of two reaches 1: `one_reaches_one` handles the exponent `0`
+(`2^0 = 1`) and `pow_two_reaches_one` the positive exponents. -/
+theorem pow_two_reaches_one' (k : ℕ) : ReachesOne (2 ^ k) := by
+  cases k with
+  | zero => simpa using one_reaches_one
+  | succ k => exact pow_two_reaches_one (k + 1) (by omega)
+
+/-- The basin elements not exceeding `N` form a finite set (a subset of `[0, N]`). -/
+theorem basin_below_finite (N : ℕ) : {n : ℕ | n ≤ N ∧ ReachesOne n}.Finite :=
+  (Set.finite_Iic N).subset (fun _ hn => Set.mem_Iic.mpr hn.1)
+
+/-- **Logarithmic lower bound on the basin counting function.** At least
+`Nat.log 2 N + 1` of the integers in `[0, N]` reach 1 — the `Nat.log 2 N + 1`
+distinct powers of two below `N` are a witness set. Unconditional: this is a lower
+bound on how *many* numbers reach 1, independent of the Collatz conjecture. -/
+theorem basin_count_lower (N : ℕ) (hN : 1 ≤ N) :
+    Nat.log 2 N + 1 ≤ {n : ℕ | n ≤ N ∧ ReachesOne n}.ncard := by
+  set L := Nat.log 2 N with hL
+  -- The powers of two `2^0, …, 2^L` sit inside the basin below `N`.
+  have hsub : ↑((Finset.range (L + 1)).image (fun k => 2 ^ k))
+      ⊆ {n : ℕ | n ≤ N ∧ ReachesOne n} := by
+    intro n hn
+    simp only [Finset.coe_image, Finset.coe_range, Set.mem_image, Set.mem_Iio] at hn
+    obtain ⟨k, hk, rfl⟩ := hn
+    refine ⟨?_, pow_two_reaches_one' k⟩
+    calc 2 ^ k ≤ 2 ^ L := Nat.pow_le_pow_right (by norm_num) (by omega)
+      _ ≤ N := Nat.pow_log_le_self 2 (by omega)
+  -- That witness set has exactly `L + 1` elements (powers of two are distinct).
+  have hcard : ((Finset.range (L + 1)).image (fun k => 2 ^ k)).card = L + 1 := by
+    rw [Finset.card_image_of_injective _ (Nat.pow_right_injective (le_refl 2)),
+      Finset.card_range]
+  calc L + 1
+      = ((Finset.range (L + 1)).image (fun k => 2 ^ k)).card := hcard.symm
+    _ = (↑((Finset.range (L + 1)).image (fun k => 2 ^ k)) : Set ℕ).ncard :=
+        (Set.ncard_coe_finset _).symm
+    _ ≤ {n : ℕ | n ≤ N ∧ ReachesOne n}.ncard :=
+        Set.ncard_le_ncard hsub (basin_below_finite N)
+
+-- N = 8: `Nat.log 2 8 = 3`, so at least 4 numbers in `[0, 8]` reach 1
+-- (indeed 1, 2, 4, 8 — the powers of two ≤ 8).
+example : 4 ≤ {n : ℕ | n ≤ 8 ∧ ReachesOne n}.ncard := by
+  have := basin_count_lower 8 (by norm_num)
+  norm_num [Nat.log] at this ⊢
+  omega
+
+/-!
 ## Summary
 
 **Proved (no axioms, no `sorry`)**:
@@ -441,6 +502,10 @@ example : collatz 16 = 8 := by decide
    `iter_preimage_finite` (every backward level is finite)
 7. ✓ Backward closure of the basin `reaches_one_of_collatz`, `basin_closed_under_pred`
 8. ✓ The basin of 1 is infinite `basin_infinite`
+9. ✓ Logarithmic lower bound on the basin counting function: `pow_two_reaches_one'`
+   (every power of two reaches 1), `basin_below_finite`, `basin_count_lower`
+   (`#{n ≤ N : ReachesOne n} ≥ Nat.log 2 N + 1`) — the unconditional lower-bound half
+   of a two-sided basin count; a nontrivial upper bound is exactly the open problem
 
 **Unconditional**: none of these assume the Collatz conjecture. They describe the
 backward dynamics (the Collatz graph) regardless of whether every `n` reaches 1.

--- a/src/data/research/problems/collatz-structured-oq-01.json
+++ b/src/data/research/problems/collatz-structured-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S4 (researcher-3, 2026-06-28, VERIFIED 0-axiom): added the uniform in-degree structure — indegree_finite (predecessor set always finite: singleton or pair), indegree_eq_one_or_two (unconditional 1-or-2 dichotomy, uniform over residues), indegree_le_two, indegree_pos (the 1 ≤ in-degree ≤ 2 bracket). These supply the finiteness + uniform bound that unblock geometric ≤ 2^d backward-tree node counting. File now ~346 lines, 0 axioms/0 sorries. | S3 (researcher-10, 2026-06-28, VERIFIED 0-axiom): added Part II¾ — a verified DENSITY result for the Collatz graph. indegree_eq_two_iff bridges in-degree to arithmetic (in-degree exactly 2 ⟺ m≡4 mod6); branch_vertices_eq identifies branch vertices with the progression {6j+4}; branch_count proves exactly k branch vertices lie below 6k (density exactly 1/6) via injective j↦6j+4 + Finset.card_image_of_injective; branch_vertices_infinite. 249→317 lines, 15→21 theorems, still 0 axioms/0 sorries. Prior: S1 (researcher-12, PR #30960) created the file (backward dynamics, preimage characterization, branching law, in-degree dichotomy, backward closure, basin infinite); S2 (researcher-3) sharpened in-degree to exact predecessor sets.",
+    "progressSummary": "S5 (researcher-6, 2026-06-28, VERIFIED 0-axiom): added Part VI — basin_count_lower, a logarithmic lower bound #{n≤N : ReachesOne n} ≥ Nat.log 2 N + 1, making basin_infinite quantitative (PR #31416). Note: the first nextStep (geometric ≤2^d tree bound) was already done in a prior session (backward_tree_ncard_le). | S4 (researcher-3, 2026-06-28, VERIFIED 0-axiom): added the uniform in-degree structure — indegree_finite (predecessor set always finite: singleton or pair), indegree_eq_one_or_two (unconditional 1-or-2 dichotomy, uniform over residues), indegree_le_two, indegree_pos (the 1 ≤ in-degree ≤ 2 bracket). These supply the finiteness + uniform bound that unblock geometric ≤ 2^d backward-tree node counting. File now ~346 lines, 0 axioms/0 sorries. | S3 (researcher-10, 2026-06-28, VERIFIED 0-axiom): added Part II¾ — a verified DENSITY result for the Collatz graph. indegree_eq_two_iff bridges in-degree to arithmetic (in-degree exactly 2 ⟺ m≡4 mod6); branch_vertices_eq identifies branch vertices with the progression {6j+4}; branch_count proves exactly k branch vertices lie below 6k (density exactly 1/6) via injective j↦6j+4 + Finset.card_image_of_injective; branch_vertices_infinite. 249→317 lines, 15→21 theorems, still 0 axioms/0 sorries. Prior: S1 (researcher-12, PR #30960) created the file (backward dynamics, preimage characterization, branching law, in-degree dichotomy, backward closure, basin infinite); S2 (researcher-3) sharpened in-degree to exact predecessor sets.",
     "builtItems": [
       "odd_pred_eq / preimage_collatz_eq_pair / preimage_collatz_eq_singleton / indegree_eq_two / indegree_eq_one (S2, 0-axiom): exact predecessor sets and numeric in-degree (2 on residue 4 mod 6, else 1) — sharpens the qualitative dichotomy",
       "collatz_eq_iff: exact Collatz preimage characterization, proved by parity split + omega",
@@ -37,7 +37,8 @@
       "two_preds_of_mod / unique_pred_of_not_mod: in-degree dichotomy of the Collatz graph",
       "reaches_one_of_collatz / basin_closed_under_pred: backward closure of the basin of 1",
       "basin_infinite: unconditional proof the basin of 1 is infinite via k ↦ 2^(k+1)",
-      "indegree_eq_two_iff / branch_vertices_eq / branch_count / branch_vertices_infinite (S3, 0-axiom): verified density — in-degree 2 ⟺ m≡4 mod6, branch vertices = {6j+4}, exactly k below 6k (density 1/6), set infinite. Via injective j↦6j+4 + Finset.card_image_of_injective."
+      "indegree_eq_two_iff / branch_vertices_eq / branch_count / branch_vertices_infinite (S3, 0-axiom): verified density — in-degree 2 ⟺ m≡4 mod6, branch vertices = {6j+4}, exactly k below 6k (density 1/6), set infinite. Via injective j↦6j+4 + Finset.card_image_of_injective.",
+      "basin_count_lower (S5, 0-axiom): #{n≤N : ReachesOne n} ≥ Nat.log 2 N + 1 — logarithmic lower bound on the basin counting function via powers-of-two injection; pow_two_reaches_one (all k incl. 0) and basin_below_finite supporting. CollatzStructuredOQ01.lean Part VI."
     ],
     "insights": [
       "The Collatz preimage is cleanly two-valued: splitting on the parity of a predecessor a gives a = 2m (even) or 3a+1 = m (odd); stating oddness as a % 2 = 1 keeps the whole proof inside omega.",
@@ -46,14 +47,14 @@
       "Backward closure (collatz a = m, m reaches 1 ⟹ a reaches 1) makes the basin of 1 exactly the set generated from 1 by the set-valued predecessor map — the Collatz tree rooted at 1.",
       "Infinitude of the basin is unconditional and elementary (powers of two), far weaker than the conjecture; it cleanly separates a provable sub-statement from the open problem.",
       "The in-degree-2 (branching) vertices of the Collatz graph are exactly the arithmetic progression 6j+4; enumerating them injectively gives an EXACT count — precisely k below 6k — so branch vertices have density exactly 1/6. This realizes the nextStep 'verified density result' in clean closed form, unconditionally.",
-      "omega does not beta-reduce a Set.range/Finset.image enumeration lambda left in the goal or hypothesis (↑((fun j => 6*j+4) x) stays opaque); coerce with show / a typed have (h : 6*a+4 = 6*b+4 := hab) before calling omega. Finset.mem_image-introduced existentials ARE beta-reduced by simp, but Set.mem_range ones are not."
+      "omega does not beta-reduce a Set.range/Finset.image enumeration lambda left in the goal or hypothesis (↑((fun j => 6*j+4) x) stays opaque); coerce with show / a typed have (h : 6*a+4 = 6*b+4 := hab) before calling omega. Finset.mem_image-introduced existentials ARE beta-reduced by simp, but Set.mem_range ones are not.",
+      "The basin counting function #{n≤N : ReachesOne n} admits an unconditional logarithmic LOWER bound (≥ log2 N + 1) from the powers-of-two family; the matching nontrivial UPPER bound (< N+1) is equivalent to exhibiting a non-reaching n, i.e. the open Collatz question itself — so only the lower half of nextStep 4 is achievable."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Geometric tree-growth bound (now unblocked by indegree_finite + indegree_le_two): prove (collatz ⁻¹' S).ncard ≤ 2·S.ncard for finite S via Set.biUnion_preimage_singleton, then iterate to |d-step preimage of {m}| ≤ 2^d (unconditional backward-tree size bound).",
-      "Describe the 2-step predecessor structure (preimage of preimage) in closed residue-class form by iterating collatz_eq_iff — count of 2-step predecessors ranges 1..4 by mod-cases.",
+      "Describe the 2-step predecessor structure (preimage of preimage) in closed residue-class form by iterating collatz_eq_iff — count of 2-step predecessors ranges 1..4 by mod-cases (sharpening backward_tree_ncard_le 2 ≤ 4 to exact counts).",
       "Connect backward closure + cycle-exclusion (collatz-cycles family) toward a verified acyclicity statement for the basin minus the {1,4,2} cycle.",
-      "Sharpen the density count to a two-sided bound on |{n ≤ N : ReachesOne n}| using the always-present even predecessor 2m."
+      "Lower bound the d-step backward-tree size below by the number of branch (6j+4) vertices reachable, complementing ancestors_card_le (≤2^d) with a nontrivial ≥ bound."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Adds **Part VI** to `proofs/Proofs/CollatzStructuredOQ01.lean`, sharpening the qualitative `basin_infinite` into a **quantitative** growth rate for the Collatz basin counting function.

**Main result** `basin_count_lower`:
```
#{n ≤ N : ReachesOne n} ≥ Nat.log 2 N + 1   (for N ≥ 1)
```
The witness set is the `Nat.log 2 N + 1` distinct powers of two `2^0, …, 2^(Nat.log 2 N)`, all of which lie in `[1, N]` and all reach 1 (powers-of-two injection into the basin).

### Lemmas added
- `pow_two_reaches_one'` — every power of two reaches 1 (covers exponent 0 via `one_reaches_one`, positive exponents via the parent file's `pow_two_reaches_one`)
- `basin_below_finite` — the basin restricted to `[0, N]` is finite (subset of `Set.Iic N`)
- `basin_count_lower` — the logarithmic lower bound

### Honesty note
This is the **achievable lower-bound half** of nextStep 4's "two-sided bound". A matching *nontrivial upper bound* `#{n ≤ N : ReachesOne n} < N + 1` would require exhibiting some `n ≤ N` that never reaches 1 — which is exactly the open Collatz question. So only the lower bound is unconditional, and the docstring states this.

### Verification
- 0 axioms, 0 sorries (uses only standard Mathlib lemmas + the 0-axiom parent results)
- Docker build: `./proofs/scripts/docker-build.sh Proofs.CollatzStructuredOQ01` → **3059 jobs, succeeded**

🤖 Generated with [Claude Code](https://claude.com/claude-code)