### PR TITLE
research(inverse-galois-oq-04): confirm BLOCKED — Dedekind's theorem absent from Mathlib

### DIFF
--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -756,9 +756,45 @@ Combined with |Gal| ∈ {5, 10, 20, 60} and 3 | |Gal|:
 | Infrastructure | Status | Needed For |
 |----------------|--------|------------|
 | Trinomial discriminant formula | Not in Mathlib | Ingredient 1 |
-| Disc square → Gal ⊆ Aₙ | Not in Mathlib | Ingredient 1 |
+| Disc square → Gal ⊆ Aₙ | Done here (Part XIV) | Ingredient 1 |
 | Dedekind's theorem | Not in Mathlib | Ingredient 3 |
 | Polynomial factorization over finite fields | Partial | Ingredient 3 |
+
+### Concrete Mathlib bridge plan for Ingredient 3 (Dedekind's theorem)
+
+Surveyed Mathlib 4.26.0 (researcher-3, 2026-06-28). The factorization↔cycle-type
+correspondence is the ONLY thing keeping `three_dvd_gal_card` an axiom, and it is
+genuinely absent. There is no "Frobenius element of Gal as a permutation of roots"
+primitive in Mathlib. What DOES exist as building blocks:
+
+  * `KummerDedekind.normalizedFactorsMapEquivNormalizedFactorsMinPolyMk`
+    (Mathlib/NumberTheory/KummerDedekind.lean): bijection between the prime
+    ideals above (p) and the irreducible factors of the min poly mod p, when the
+    conductor is coprime to (p). Gives the *ideal* factorization, not yet the
+    permutation cycle type.
+  * `Ideal.inertiaDeg`, `Ideal.ramificationIdx`
+    (Mathlib/NumberTheory/RamificationInertia/Basic.lean) and the Galois-case
+    identities `Ideal.card_inertia_eq_ramificationIdxIn`,
+    `Ideal.ncard_primesOver_mul_ramificationIdxIn_mul_inertiaDegIn`
+    (RamificationInertia/Galois.lean): degree d_i of an irreducible factor = the
+    inertia degree of the corresponding prime; orbit/decomposition-group sizes.
+  * `Polynomial.Gal.galActionHom : p.Gal →* Equiv.Perm (p.rootSet E)` and
+    `Polynomial.Gal.galActionHom_injective`
+    (Mathlib/FieldTheory/PolynomialGaloisGroup.lean): the faithful action of Gal
+    on the roots, into which a constructed Frobenius element would map.
+  * `Equiv.Perm.cycleType`, `Equiv.Perm.lcm_cycleType` (= orderOf)
+    (Mathlib/GroupTheory/Perm/Cycle/Type.lean): target side of the statement.
+
+The missing bridge: define the Frobenius automorphism for a prime P | (p) in the
+ring of integers of q.SplittingField (unramified since 7 ∤ disc q = 2¹⁶·5⁶),
+show it reduces to the residue-field Frobenius, and prove its cycle type on the
+roots equals the inertia-degree multiset = the mod-p factorization degrees. This
+needs Frobenius-as-Galois-automorphism (not a Mathlib primitive) plus the
+lift of roots through KummerDedekind — estimated 800–1500 lines of foundational
+number theory. This is beyond a single research session and is the standing
+blocker for eliminating `three_dvd_gal_card`. The alternative bridge (Dummit's
+resolvent-sextic correspondence, evidenced by `resolvent_no_*_root` below) is
+equally absent from Mathlib.
 
 ### Monotonicity and Real Root Count
 
@@ -1904,7 +1940,9 @@ theorem gal_card_dvd_60_proved : Fintype.card q.Gal ∣ 60 :=
 /-- The Galois group of q has exactly 60 elements (= |A₅|).
 
     **PROVED** from axiom B + gal_card_dvd_60_proved + structural lemmas.
-    Uses only 2 axioms: vandermondeProduct_sq_eq and three_dvd_gal_card.
+    Depends on the file's single remaining axiom, three_dvd_gal_card.
+    (vandermondeProduct_sq_eq was eliminated; it is now the theorem
+    vandermondeProduct_sq_eq_proved in Part XV.)
 
     Proof: |Gal| | 60 (gal_card_dvd_60_proved) and 15 | |Gal| (from B + proved 5 | |Gal|)
     gives |Gal| ∈ {15, 30, 60}. No S₅ subgroup of order 15 or 30 exists.

--- a/research/problems/inverse-galois-oq-04/knowledge.md
+++ b/research/problems/inverse-galois-oq-04/knowledge.md
@@ -1,0 +1,78 @@
+# Knowledge: Dedekind Theorem to Eliminate A5 Axiom (inverse-galois-oq-04)
+
+## Goal
+
+Eliminate the single remaining axiom in `proofs/Proofs/InverseGaloisA5.lean`:
+
+```lean
+axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal
+```
+
+where `q = X⁵ - 5X⁴ + 10X³ - 10X² + 25X - 5` (translate of X⁵ + 20X + 16,
+Galois group A₅). This is the "Axiom B" of the file, intended to be discharged
+by **Dedekind's theorem** applied at p = 7.
+
+## Session 1 (researcher-3, 2026-06-28): ASSESSED → BLOCKED on infrastructure
+
+### State of the proof
+
+The file is mature: exactly **1 axiom** (`three_dvd_gal_card`), 0 sorries.
+Everything else needed for |Gal(q)| = 60 is already proved:
+- `five_dvd_gal_card` : 5 ∣ |Gal| (irreducibility, Eisenstein at 5)
+- `gal_card_dvd_60_proved` : |Gal| ∣ 60 (Vandermonde/discriminant ⇒ Gal ⊆ A₅;
+  this is the *former* Axiom A, now a theorem — Part XIV)
+- `gal_card_ne_15`, `gal_card_ne_30` : exclude orders 15, 30 (Sylow + A₅ simplicity)
+- `vandermondeProduct_sq_eq_proved` : Δ² = disc (former axiom, now proved — Part XV)
+
+`q_gal_card` (|Gal| = 60) is then: 15 ∣ |Gal| (= 3·5 dvd) ∧ |Gal| ∣ 60 ∧ ≠15 ∧ ≠30
+⇒ |Gal| = 60. The ONLY input still axiomatized is `3 ∣ |Gal|`.
+
+### Why 3 ∣ |Gal| has no axiom-free shortcut for this polynomial
+
+With the proved facts, Gal is a transitive subgroup of A₅ on 5 points, so
+|Gal| ∈ {5, 10, 60} (C₅, D₅, A₅; F₂₀ ⊄ A₅). Distinguishing D₅ (order 10) from
+A₅ (order 60) is *exactly* the question of whether Gal contains an order-3
+element. There is no computational route: Gal lives over the splitting field of
+q (a degree-60 number field), not a decidable finite structure, so `native_decide`
+cannot reach it. Detecting the 3-cycle requires one of:
+  (a) Dedekind's theorem at p=7 (q mod 7 = (X-5)(X-6)(irred cubic) ⇒ (1,1,3)
+      cycle type ⇒ order-3 element), or
+  (b) Dummit's resolvent-sextic correspondence (R₆ has no rational root ⇒ not D₅).
+Both are absent from Mathlib.
+
+### Mathlib gap (surveyed Mathlib 4.26.0)
+
+Dedekind's theorem — "factorization type of f mod p (p ∤ disc) = cycle type of
+Frobenius in Gal acting on roots" — is **entirely absent**. There is no
+Frobenius-element-as-Galois-permutation primitive. Building blocks that exist:
+- `KummerDedekind.normalizedFactorsMapEquivNormalizedFactorsMinPolyMk`
+  (ideal factorization ↔ min-poly factors mod p)
+- `Ideal.inertiaDeg` / `ramificationIdx`, `Ideal.card_inertia_eq_ramificationIdxIn`,
+  `Ideal.ncard_primesOver_mul_ramificationIdxIn_mul_inertiaDegIn`
+  (RamificationInertia/Galois.lean)
+- `Polynomial.Gal.galActionHom` (+ `_injective`) — faithful action on rootSet
+- `Equiv.Perm.cycleType`, `lcm_cycleType` (= orderOf)
+
+Missing bridge: define the Frobenius automorphism at an unramified prime
+P | (7), show it induces the residue-field Frobenius, and prove its cycle type
+on the roots = the inertia-degree multiset = the mod-7 factorization degrees.
+**Estimate: 800–1500 lines of foundational number theory.** This exceeds the
+BUILD threshold (<500 lines) and a single session.
+
+### What this session did
+
+- Confirmed exactly 1 axiom remains; verified the downstream proof chain.
+- Fixed a stale docstring on `q_gal_card` (claimed "2 axioms"; vandermonde was
+  already eliminated) — comment-only.
+- Replaced the vague "What's Missing in Mathlib" roadmap with a concrete,
+  citeable Mathlib bridge plan (KummerDedekind + RamificationInertia/Galois +
+  galActionHom + cycleType) and the 800–1500-line estimate — comment-only.
+- All Lean edits are comments; no proof terms touched, compilation unaffected.
+
+### Classification: BLOCKED (needs >1000 lines foundational Mathlib work)
+
+Recommend parking until Mathlib gains Dedekind's theorem / Frobenius-as-Galois-
+automorphism, or until a dedicated multi-session effort builds the bridge here.
+The gallery entry `inverse-galois-a5` is already correctly `axiomatized` /
+badge `axiom` / axiomCount 1 with an accurate `assumptions` note — no gallery
+change needed.

--- a/research/problems/inverse-galois-oq-04/state.md
+++ b/research/problems/inverse-galois-oq-04/state.md
@@ -1,27 +1,35 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-03-30T22:19:31.122Z
+**Phase**: BLOCKED
+**Since**: 2026-06-28
 **Iteration**: 1
 
 ## Current Focus
 
-Initial exploration of the problem.
+Eliminate `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` in InverseGaloisA5.lean
+via Dedekind's theorem at p = 7.
 
 ## Active Approach
 
-None yet.
+None viable in-session. The 3 ∣ |Gal| fact requires either Dedekind's theorem
+(mod-7 factorization → 3-cycle) or Dummit's resolvent correspondence; both are
+absent from Mathlib and there is no computational/axiom-free shortcut.
 
 ## Blockers
 
-None.
+Dedekind's theorem (factorization type mod p = cycle type of Frobenius in Gal)
+is absent from Mathlib 4.26.0; no Frobenius-as-Galois-permutation primitive.
+Estimated 800–1500 lines of foundational number theory to build. See
+`knowledge.md` for the concrete Mathlib bridge plan (KummerDedekind +
+RamificationInertia/Galois + galActionHom + cycleType).
 
 ## Next Action
 
-Begin problem exploration.
+Park until Mathlib gains Dedekind's theorem, or commit a dedicated multi-session
+bridge effort.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (assess-and-document)

--- a/src/data/research/problems/inverse-galois-oq-04.json
+++ b/src/data/research/problems/inverse-galois-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "inverse-galois-oq-04",
   "title": "Dedekind Theorem to Eliminate A5 Axiom",
-  "phase": "NEW",
+  "phase": "BLOCKED",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,12 +16,14 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-03-30T22:19:31.122Z",
+    "phase": "BLOCKED",
+    "since": "2026-06-28T00:00:00.000Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "focus": "Eliminate three_dvd_gal_card via Dedekind's theorem at p=7.",
+    "blockers": [
+      "Dedekind's theorem (factorization type mod p = cycle type of Frobenius in Gal) is absent from Mathlib 4.26.0; no Frobenius-as-Galois-permutation primitive. Estimated 800-1500 lines of foundational number theory to build."
+    ],
+    "nextAction": "Park until Mathlib gains Dedekind's theorem / Frobenius-as-Galois-automorphism, or commit a dedicated multi-session bridge effort.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +31,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "Assessed (researcher-3, 2026-06-28). InverseGaloisA5.lean has exactly 1 axiom, three_dvd_gal_card (3 | |Gal(q)|), encoding Dedekind's theorem at p=7. All other inputs to |Gal|=60 are proved (5|Gal, Gal|60 via discriminant, no order-15/30 subgroup). The 3|Gal step has no axiom-free or computational shortcut: distinguishing D5 from A5 requires detecting an order-3 element, i.e. Dedekind's theorem (mod-7 cycle type) or Dummit's resolvent correspondence -- both absent from Mathlib.",
     "builtItems": [],
     "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "mathlibGaps": [
+      "Dedekind's theorem: factorization type of f mod p (p not dividing disc) = cycle type of Frobenius in Gal on roots. Entirely absent.",
+      "Frobenius element as a Galois automorphism / permutation of roots: no primitive.",
+      "Building blocks present: KummerDedekind.normalizedFactorsMapEquivNormalizedFactorsMinPolyMk; Ideal.inertiaDeg/ramificationIdx + RamificationInertia/Galois identities; Polynomial.Gal.galActionHom; Equiv.Perm.cycleType."
+    ],
+    "nextSteps": [
+      "If pursued: define Frobenius automorphism at an unramified prime P|(7), show it induces residue-field Frobenius, prove its cycle type on roots = inertia-degree multiset = mod-7 factorization degrees. ~800-1500 lines.",
+      "Alternatively formalize Dummit's resolvent-sextic correspondence (resolvent_no_*_root evidence already in file)."
+    ]
   },
   "tags": [
     "seeker-selected",
@@ -61,7 +70,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T22:19:31.122Z",
-  "lastUpdate": "2026-03-30T22:19:31.122Z",
+  "lastUpdate": "2026-06-28T00:00:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Problem **inverse-galois-oq-04** ("Dedekind Theorem to Eliminate A5 Axiom") targets
the single remaining axiom in `proofs/Proofs/InverseGaloisA5.lean`:

```lean
axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal
```

where `q = X⁵ - 5X⁴ + 10X³ - 10X² + 25X - 5` (Galois group A₅). This session
**assessed the problem and confirms it is BLOCKED on Mathlib infrastructure**, and
documents the gap concretely so future work isn't re-derived.

## Findings

- **The file is mature: exactly 1 axiom, 0 sorries.** Every other input to
  `|Gal(q)| = 60` is already proved: `five_dvd_gal_card` (5 | |Gal|),
  `gal_card_dvd_60_proved` (Gal ⊆ A₅ via the Vandermonde/discriminant argument —
  the former Axiom A), `gal_card_ne_15`, `gal_card_ne_30`, and
  `vandermondeProduct_sq_eq_proved` (former axiom, now a theorem).
- **No axiom-free or computational shortcut exists for `3 | |Gal|`.** With the
  proved facts, Gal is a transitive subgroup of A₅ on 5 points, so
  |Gal| ∈ {5, 10, 60}. Distinguishing D₅ (10) from A₅ (60) is exactly the
  existence of an order-3 element. Gal lives over a degree-60 number field, so
  `native_decide` cannot reach it; detecting the 3-cycle needs Dedekind's theorem
  (mod-7 cycle type) or Dummit's resolvent correspondence — both absent from Mathlib.
- **Mathlib gap (surveyed 4.26.0).** Dedekind's theorem and a
  Frobenius-as-Galois-permutation primitive are entirely absent. Building blocks
  that exist: `KummerDedekind.normalizedFactorsMapEquivNormalizedFactorsMinPolyMk`,
  `Ideal.inertiaDeg`/`ramificationIdx` + the `RamificationInertia/Galois`
  identities, `Polynomial.Gal.galActionHom`, `Equiv.Perm.cycleType`. Bridging them
  (Frobenius automorphism at an unramified prime → cycle type = inertia-degree
  multiset = mod-7 factorization degrees) is **~800–1500 lines** of foundational
  number theory — beyond a single session and the BUILD threshold.

## Changes

- `proofs/Proofs/InverseGaloisA5.lean` — **comment-only** (no proof terms touched,
  compilation unaffected):
  - Fix a stale `q_gal_card` docstring that claimed "2 axioms"
    (`vandermondeProduct_sq_eq` was already eliminated).
  - Replace the vague "What's Missing in Mathlib" roadmap with a concrete,
    citeable Mathlib bridge plan and the line estimate.
- `research/problems/inverse-galois-oq-04/{knowledge.md,state.md}` — full
  assessment; problem marked BLOCKED.
- `src/data/research/problems/inverse-galois-oq-04.json` — phase BLOCKED, blocker
  + mathlibGaps + nextSteps recorded.

## Honesty note

This is a **SURVEY/BLOCKED** result, not an axiom elimination. The deliverable is a
concrete, actionable gap analysis. The gallery entry `inverse-galois-a5` is already
correctly `axiomatized` (badge `axiom`, axiomCount 1) with an accurate `assumptions`
note — no gallery status change is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)