### PR TITLE
research(stars-and-bars-weak-compositions-oq-01): weak-composition generating function = 1/(1−X)ᵏ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/StarsAndBarsWeakCompositionsOQ01.lean
+++ b/proofs/Proofs/StarsAndBarsWeakCompositionsOQ01.lean
@@ -1,0 +1,119 @@
+import Mathlib.RingTheory.PowerSeries.WellKnown
+import Mathlib.Tactic
+import Proofs.StarsAndBarsWeakCompositions
+
+/-
+# Generating-Function View of Weak Compositions: ∑ₙ #(weak comps) Xⁿ = 1/(1−X)ᵏ
+
+## What This Proves
+
+A *weak composition* of `n` into `k` parts is a function `f : Fin k → ℕ` with
+`∑ᵢ f(i) = n` (parts may be zero). The parent entry
+(`StarsAndBarsWeakCompositions.lean`) counts them combinatorially: there are
+`C(n + k − 1, n)` of them (stars and bars).
+
+This entry records the **generating-function** incarnation of that count. Over any
+commutative ring `S`, form the ordinary generating function of the sequence
+`n ↦ #(weak compositions of n into k parts)`:
+
+  `W k = ∑ₙ #{f : Fin k → ℕ // ∑ i, f i = n} · Xⁿ ∈ S⟦X⟧`.
+
+The headline result is that this is exactly the negative-binomial series, i.e. the
+multiplicative inverse of `(1 − X)ᵏ`:
+
+  `W k · (1 − X)ᵏ = 1`,    equivalently    `W k = 1/(1 − X)ᵏ`.
+
+Reading off the coefficient of `Xⁿ` recovers the closed form
+`C(n + k − 1, n)` from the parent, now seen as the `n`-th coefficient of `(1−X)⁻ᵏ`.
+
+## The argument
+
+Mathlib provides `PowerSeries.invOneSubPow S k`, the *unit* of `S⟦X⟧` that is the
+inverse of `(1 − X)ᵏ`, together with the explicit coefficient formula
+`(invOneSubPow S (d+1)).val = mk (n ↦ C(d + n, d))`
+(`invOneSubPow_val_succ_eq_mk_add_choose`) and the inverse relation
+`(invOneSubPow S k).inv = (1 − X)ᵏ` (`invOneSubPow_inv_eq_one_sub_pow`).
+
+The only content to add is the identification of the *enumerative* generating
+function `W k` with this *algebraic* power series. Coefficientwise, for `k = d+1`,
+
+  `coeff n (W k) = #(weak compositions) = C(n + k − 1, n) = C(d + n, d) = coeff n (invOneSubPow)`,
+
+where the middle equality is the parent's `card_weakComposition` and the last is the
+binomial symmetry `C(d + n, d) = C(n + d, n)`. Multiplying by `(1 − X)ᵏ` and using the
+unit relation gives `W k · (1 − X)ᵏ = 1`.
+
+## What Mathlib has — and what this adds
+
+Mathlib has the algebraic series `invOneSubPow` and its coefficients, and (via the
+imported parent) the combinatorial count `card_weakComposition`. It does **not**
+record that the ordinary generating function of the weak-composition *counts* is
+`1/(1−X)ᵏ`. The new content is precisely that bridge:
+`weakCompositionGenFun_eq_invOneSubPow` and its corollaries
+`weakCompositionGenFun_mul_one_sub_pow` ( `W k · (1−X)ᵏ = 1` ) and
+`coeff_weakCompositionGenFun` (the coefficient is the count).
+-/
+
+open PowerSeries
+
+namespace StarsAndBarsGenFun
+
+variable (S : Type*) [CommRing S]
+
+/-- The ordinary generating function of the weak-composition counts:
+`W k = ∑ₙ #{f : Fin k → ℕ // ∑ i, f i = n} · Xⁿ` in `S⟦X⟧`. -/
+noncomputable def weakCompositionGenFun (k : ℕ) : S⟦X⟧ :=
+  mk fun n => (Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} : S)
+
+@[simp]
+theorem coeff_weakCompositionGenFun (k n : ℕ) :
+    coeff n (weakCompositionGenFun S k) =
+      (Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} : S) := by
+  rw [weakCompositionGenFun, coeff_mk]
+
+/-- Binomial bookkeeping: the parent's count `C(n + k − 1, n)` for `k = d + 1`
+agrees with the coefficient `C(d + n, d)` of `invOneSubPow`. -/
+private theorem card_weakComposition_succ (d n : ℕ) :
+    Fintype.card {f : Fin (d + 1) → ℕ // ∑ i, f i = n} = Nat.choose (d + n) d := by
+  rw [StarsAndBars.card_weakComposition]
+  -- goal: (n + (d + 1) - 1).choose n = (d + n).choose d
+  have h1 : n + (d + 1) - 1 = d + n := by omega
+  rw [h1]
+  -- goal: (d + n).choose n = (d + n).choose d
+  have hsymm : (d + n).choose ((d + n) - d) = (d + n).choose d :=
+    Nat.choose_symm (Nat.le_add_right d n)
+  rwa [Nat.add_sub_cancel_left] at hsymm
+
+/-- **Generating function of weak compositions.** Over any commutative ring `S`, the
+ordinary generating function of the weak-composition counts equals Mathlib's
+`invOneSubPow S k`, the algebraic power series `1/(1 − X)ᵏ`. -/
+theorem weakCompositionGenFun_eq_invOneSubPow (k : ℕ) (hk : 0 < k) :
+    weakCompositionGenFun S k = (invOneSubPow S k).val := by
+  obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_lt hk
+  -- now k = 0 + d + 1
+  rw [Nat.zero_add, invOneSubPow_val_succ_eq_mk_add_choose]
+  ext n
+  rw [coeff_weakCompositionGenFun, coeff_mk, card_weakComposition_succ]
+
+/-- **The generating function is `1/(1 − X)ᵏ`.** The defining relation of the inverse:
+`W k · (1 − X)ᵏ = 1`. Equivalently, `W k = (1 − X)⁻ᵏ` in `S⟦X⟧`. -/
+theorem weakCompositionGenFun_mul_one_sub_pow (k : ℕ) (hk : 0 < k) :
+    weakCompositionGenFun S k * (1 - X) ^ k = 1 := by
+  rw [weakCompositionGenFun_eq_invOneSubPow S k hk,
+    ← invOneSubPow_inv_eq_one_sub_pow]
+  exact (invOneSubPow S k).val_inv
+
+/-- The `n`-th coefficient of `1/(1 − X)ᵏ` is the number of weak compositions of `n`
+into `k` parts — the generating-function reading of stars and bars. -/
+theorem coeff_invOneSubPow_eq_card (k n : ℕ) (hk : 0 < k) :
+    coeff n (invOneSubPow S k).val =
+      (Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} : S) := by
+  rw [← weakCompositionGenFun_eq_invOneSubPow S k hk, coeff_weakCompositionGenFun]
+
+/-- The same identification spelled out as the negative-binomial coefficient
+`C(n + k − 1, n)`, casting the parent's `card_weakComposition`. -/
+theorem coeff_invOneSubPow_eq_choose (k n : ℕ) (hk : 0 < k) :
+    coeff n (invOneSubPow S k).val = ((n + k - 1).choose n : S) := by
+  rw [coeff_invOneSubPow_eq_card S k n hk, StarsAndBars.card_weakComposition]
+
+end StarsAndBarsGenFun

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-01/annotations.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "stars-and-bars-weak-compositions-oq-01",
+    "range": { "startLine": 1, "endLine": 55 },
+    "type": "context",
+    "title": "Generating function of weak compositions = 1/(1−X)ᵏ",
+    "content": "The header recasts the parent's stars-and-bars count C(n+k−1, n) in generating-function form. Over any commutative ring S, the ordinary generating function of the counts, W k = ∑ₙ #{f : Fin k → ℕ // ∑ i, f i = n} · Xⁿ ∈ S⟦X⟧, equals the negative-binomial series 1/(1−X)ᵏ. The plan is purely a coefficientwise comparison against Mathlib's algebraically-defined invOneSubPow S k (the inverse unit of (1−X)ᵏ): coeff n (W k) = #(weak compositions) = C(n+k−1, n) = C(d+n, d) = coeff n (invOneSubPow), where the middle equality is the parent's card_weakComposition and the last is binomial symmetry. Mathlib has invOneSubPow and its coefficient formula, and the parent has the count, but the identification of the enumerative generating function with the algebraic series is new.",
+    "mathContext": "$W_k(X) = \\sum_{n}\\#\\{f : \\mathrm{Fin}\\,k\\to\\mathbb{N} \\mid \\sum_i f(i)=n\\}X^n = \\dfrac{1}{(1-X)^k}$.",
+    "significance": "context",
+    "relatedConcepts": ["generating function", "negative-binomial series", "stars and bars", "formal power series", "invOneSubPow"],
+    "prerequisites": ["binomial coefficients", "weak compositions (parent entry)", "formal power series over a ring"]
+  },
+  {
+    "id": "ann-genfun-def",
+    "proofId": "stars-and-bars-weak-compositions-oq-01",
+    "range": { "startLine": 63, "endLine": 72 },
+    "type": "definition",
+    "title": "The generating function weakCompositionGenFun and its coefficients",
+    "content": "weakCompositionGenFun S k = PowerSeries.mk (fun n => (Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} : S)) is the ordinary generating function whose n-th coefficient is the number of weak compositions of n into k parts, cast into the base ring S via the canonical ℕ → S map. The Fintype instance making the cardinality well-defined comes from the imported parent (the codomain ℕ is infinite, so finiteness is not automatic). The simp lemma coeff_weakCompositionGenFun reads the coefficient straight off by coeff_mk: coeff n (weakCompositionGenFun S k) = (card {…} : S). Working over an arbitrary commutative ring keeps the identity purely formal, with no convergence or characteristic assumptions.",
+    "mathContext": "$\\mathrm{coeff}_n\\,W_k = \\big(\\#\\{f : \\mathrm{Fin}\\,k\\to\\mathbb{N} \\mid \\sum_i f(i)=n\\} : S\\big)$.",
+    "significance": "standard",
+    "relatedConcepts": ["PowerSeries.mk", "coeff_mk", "cast ℕ → S", "Fintype.card"],
+    "prerequisites": ["formal power series", "Fintype instance from parent entry"]
+  },
+  {
+    "id": "ann-binomial-bridge",
+    "proofId": "stars-and-bars-weak-compositions-oq-01",
+    "range": { "startLine": 74, "endLine": 86 },
+    "type": "key-step",
+    "title": "The binomial bridge C(n+k−1, n) = C(d+n, d)",
+    "content": "card_weakComposition_succ is the one genuinely new mathematical step. Mathlib's invOneSubPow gives the coefficient of (1−X)⁻ᵏ for k = d+1 as C(d+n, d), while the parent's card_weakComposition gives the count as C(n+(d+1)−1, n) = C(n+d, n). Reconciling them: after omega simplifies n+(d+1)−1 = d+n, the goal is C(d+n, n) = C(d+n, d), exactly the symmetry of the lower index in a binomial coefficient. Nat.choose_symm (with d ≤ d+n) yields C(d+n, (d+n)−d) = C(d+n, d), and Nat.add_sub_cancel_left rewrites (d+n)−d = n to close it. Every other lemma in the file is plumbing around this single identity.",
+    "mathContext": "$\\#\\{f : \\mathrm{Fin}(d{+}1)\\to\\mathbb{N} \\mid \\sum_i f(i)=n\\} = \\binom{n+d}{n} = \\binom{d+n}{d}$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.choose_symm", "binomial symmetry", "Nat.add_sub_cancel_left", "card_weakComposition (parent)"],
+    "prerequisites": ["binomial coefficient symmetry C(n,k)=C(n,n−k)", "truncated ℕ subtraction"]
+  },
+  {
+    "id": "ann-main-identification",
+    "proofId": "stars-and-bars-weak-compositions-oq-01",
+    "range": { "startLine": 87, "endLine": 104 },
+    "type": "key-step",
+    "title": "Generating function = invOneSubPow, hence W k · (1−X)ᵏ = 1",
+    "content": "weakCompositionGenFun_eq_invOneSubPow is the headline equality of power series. For 0 < k, write k = d+1 (Nat.exists_eq_add_of_lt), unfold Mathlib's invOneSubPow_val_succ_eq_mk_add_choose to mk (n ↦ C(d+n, d)), then compare coefficient by coefficient with PowerSeries.ext, discharging each via coeff_weakCompositionGenFun, coeff_mk, and the binomial bridge card_weakComposition_succ. The corollary weakCompositionGenFun_mul_one_sub_pow turns this into the defining relation of the inverse: rewriting (1−X)ᵏ as (invOneSubPow S k).inv (invOneSubPow_inv_eq_one_sub_pow) and applying the unit's val_inv law gives W k · (1−X)ᵏ = 1 — the formal statement that the generating function is 1/(1−X)ᵏ. Because the two series are now equal as objects (not just coefficientwise as numbers), every algebraic fact Mathlib proves about invOneSubPow transfers to the combinatorial generating function.",
+    "mathContext": "$W_k = \\mathrm{invOneSubPow}\\,S\\,k \\;\\Longrightarrow\\; W_k\\cdot(1-X)^k = 1.$",
+    "significance": "key",
+    "relatedConcepts": ["PowerSeries.ext", "invOneSubPow_val_succ_eq_mk_add_choose", "invOneSubPow_inv_eq_one_sub_pow", "Units.val_inv"],
+    "prerequisites": ["coefficientwise equality of power series", "units in a ring and their inverse law"]
+  },
+  {
+    "id": "ann-coefficient-corollaries",
+    "proofId": "stars-and-bars-weak-compositions-oq-01",
+    "range": { "startLine": 106, "endLine": 119 },
+    "type": "key-step",
+    "title": "Reading off the coefficients of (1−X)⁻ᵏ",
+    "content": "coeff_invOneSubPow_eq_card and coeff_invOneSubPow_eq_choose transport the identification back through the coefficient map. The first reads the n-th coefficient of 1/(1−X)ᵏ as the number of weak compositions of n into k parts; the second spells it out as the negative-binomial coefficient C(n+k−1, n), casting the parent's card_weakComposition. These are the term-by-term face of the generating-function identity — the classical statement that the stars-and-bars numbers are exactly the coefficients of (1−X)⁻ᵏ, i.e. the negative binomial series. Sanity checks: k = 1 gives all coefficients 1 (the series 1/(1−X)); k = 2 gives coefficient n+1 = C(n+1, n) at Xⁿ.",
+    "mathContext": "$[X^n]\\,(1-X)^{-k} = \\#\\{f \\mid \\sum f = n\\} = \\binom{n+k-1}{n}.$",
+    "significance": "key",
+    "relatedConcepts": ["coefficient extraction", "negative binomial series", "card_weakComposition (parent)"],
+    "prerequisites": ["the main identification weakCompositionGenFun_eq_invOneSubPow", "coefficient maps on power series"]
+  }
+]

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-01/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-01/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "stars-and-bars-weak-compositions-oq-01",
+  "title": "Generating-Function View of Weak Compositions: ∑ₙ #(weak comps) Xⁿ = 1/(1−X)ᵏ",
+  "slug": "stars-and-bars-weak-compositions-oq-01",
+  "description": "A weak composition of n into k parts is a function f : Fin k → ℕ with ∑ᵢ f(i) = n (parts may be zero). The parent entry counts them combinatorially by stars and bars: C(n+k−1, n). This entry records the generating-function incarnation of that count. Over any commutative ring S, form the ordinary generating function of the sequence n ↦ #(weak compositions of n into k parts): W k = ∑ₙ #{f : Fin k → ℕ // ∑ i, f i = n} · Xⁿ ∈ S⟦X⟧. The headline result (weakCompositionGenFun_eq_invOneSubPow) is that this is exactly the negative-binomial series — Mathlib's PowerSeries.invOneSubPow S k, the multiplicative inverse unit of (1−X)ᵏ — so W k · (1−X)ᵏ = 1 (weakCompositionGenFun_mul_one_sub_pow), i.e. W k = 1/(1−X)ᵏ. Reading off the coefficient of Xⁿ recovers the closed form C(n+k−1, n) from the parent, now seen as the n-th coefficient of (1−X)⁻ᵏ (coeff_invOneSubPow_eq_choose). The bridge is coefficientwise: for k = d+1, coeff n (W k) = #(weak compositions) = C(n+k−1, n) = C(d+n, d) = coeff n (invOneSubPow), where the middle equality is the parent's card_weakComposition and the last is the binomial symmetry C(d+n, d) = C(n+d, n) (Nat.choose_symm). Mathlib has the algebraic series invOneSubPow with its coefficient formula and, via the imported parent, the combinatorial count card_weakComposition, but it does not record that the ordinary generating function of the weak-composition counts is 1/(1−X)ᵏ. The new content is precisely that bridge identifying the enumerative generating function with the algebraic power series.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.PowerSeries.WellKnown",
+      "Mathlib.Tactic",
+      "Proofs.StarsAndBarsWeakCompositions"
+    ],
+    "opens": [
+      "PowerSeries"
+    ],
+    "namespace": "StarsAndBarsGenFun",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/StarsAndBarsWeakCompositionsOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Stars_and_bars_(combinatorics)#Theorem_two",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StarsAndBarsWeakCompositionsOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "generating-functions",
+      "stars-and-bars",
+      "weak-compositions",
+      "power-series",
+      "negative-binomial-series",
+      "binomial-coefficients",
+      "counting"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-28",
+    "relatedProblems": [
+      {
+        "id": "stars-and-bars-weak-compositions",
+        "relationship": "Direct parent. That entry counts weak compositions of n into k parts as C(n+k−1, n) via the bijection to size-n multisets, and supplies the Fintype instance on the summing subtype. This entry packages those counts as the coefficients of an ordinary generating function and identifies the series with 1/(1−X)ᵏ; the proof imports and reuses the parent's card_weakComposition at the coefficient level."
+      },
+      {
+        "id": "stars-and-bars-weak-compositions-oq-02",
+        "relationship": "Sibling refinement in the same family. OQ-02 bounds every part by b and obtains the inclusion–exclusion count, whose generating function is (1+x+⋯+xᵇ)ᵏ = ((1−x^{b+1})/(1−x))ᵏ. This entry is the b → ∞ (unbounded-part) degeneration at the generating-function level: dropping the numerator (1−x^{b+1})ᵏ leaves exactly the 1/(1−x)ᵏ established here. OQ-02's first listed open question — derive its closed form as the coefficient of xⁿ in that rational function — is the bounded counterpart of the identity proved here."
+      },
+      {
+        "id": "composition-parts-choose-oq-01",
+        "relationship": "Sibling enumerative count. That entry counts compositions of n into exactly k POSITIVE parts as C(n−1, k−1), whose generating function is (x/(1−x))ᵏ = xᵏ/(1−x)ᵏ — the same 1/(1−x)ᵏ denominator established here, shifted by xᵏ to enforce the ≥ 1 lower bound on every part."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 119,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All three public theorems — weakCompositionGenFun_eq_invOneSubPow (the generating function equals Mathlib's invOneSubPow), weakCompositionGenFun_mul_one_sub_pow (W k · (1−X)ᵏ = 1), and coeff_invOneSubPow_eq_choose (the n-th coefficient is C(n+k−1, n)) — were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The results require 0 < k (for k = 0 the empty product is the constant power series 1, a separate degenerate case). The new content beyond Mathlib is the identification of the enumerative generating function of weak-composition counts with the algebraic series invOneSubPow; Mathlib supplies invOneSubPow with its coefficient formula (invOneSubPow_val_succ_eq_mk_add_choose) and inverse relation (invOneSubPow_inv_eq_one_sub_pow), and the imported parent supplies the unrestricted count card_weakComposition. The binomial bridge C(n+k−1, n) = C(d+n, d) for k = d+1 is Nat.choose_symm. Sanity check: at k = 1 the series is ∑ₙ 1·Xⁿ = 1/(1−X) (every n has the unique weak composition (n)); at k = 2 the coefficient of Xⁿ is n+1 = C(n+1, n), the n+1 weak compositions (i, n−i).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The number of nonnegative integer solutions of x₁ + ⋯ + x_k = n is the multichoose number C(n+k−1, n), the classical stars-and-bars count. The generating-function viewpoint packages all of these counts (over every n) into a single algebraic object: the ordinary generating function ∑ₙ C(n+k−1, n) xⁿ is the negative-binomial series, equal to (1−x)⁻ᵏ. This is the k-fold product of the geometric series 1/(1−x) = ∑ₙ xⁿ, reflecting that a weak composition of n into k parts is an independent choice of one geometric series factor per part. Newton's generalized binomial theorem gives the coefficients of (1−x)⁻ᵏ as (−1)ⁿ C(−k, n) = C(n+k−1, n), tying the analytic and combinatorial expansions together. The identity is the engine behind countless enumerative results: bounding or shifting the parts multiplies the numerator by polynomial factors (as in the bounded-parts sibling, whose generating function is ((1−x^{b+1})/(1−x))ᵏ), while the 1/(1−x)ᵏ denominator persists.",
+    "problemStatement": "Show that the ordinary generating function of the weak-composition counts, W(x) = ∑ₙ #{f : Fin k → ℕ | ∑ᵢ f(i) = n} xⁿ, is the negative-binomial series 1/(1−x)ᵏ; equivalently, that W(x) · (1−x)ᵏ = 1 in the ring of formal power series, recovering the n-th coefficient as the stars-and-bars number C(n+k−1, n).",
+    "text": "The parent entry (stars-and-bars-weak-compositions) counts the weak compositions of n into k parts as C(n+k−1, n) and supplies the Fintype instance making #{f : Fin k → ℕ | ∑ f = n} well-defined. This entry forms the ordinary generating function weakCompositionGenFun S k = mk (n ↦ (card … : S)) of those counts in the formal power series ring S⟦X⟧ over an arbitrary commutative ring S, and identifies it with Mathlib's invOneSubPow S k — the unit whose inverse is (1−X)ᵏ. Mathlib provides invOneSubPow together with the explicit coefficient formula (invOneSubPow S (d+1)).val = mk (n ↦ C(d+n, d)) and the relation (invOneSubPow S k).inv = (1−X)ᵏ, so the whole task reduces to a coefficientwise comparison.",
+    "proofStrategy": "Define weakCompositionGenFun S k = PowerSeries.mk (fun n => (Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} : S)); coeff_weakCompositionGenFun reads off its coefficients as the casts of the counts. For 0 < k, write k = d+1 (Nat.exists_eq_add_of_lt) and unfold Mathlib's invOneSubPow_val_succ_eq_mk_add_choose to (invOneSubPow S (d+1)).val = mk (n ↦ C(d+n, d)). Compare coefficient by coefficient (PowerSeries.ext): the private lemma card_weakComposition_succ supplies the Nat identity card {f : Fin (d+1) → ℕ // ∑ f = n} = C(d+n, d), proved by rewriting the parent's card_weakComposition (giving C(n+(d+1)−1, n) = C(n+d, n)) and applying the binomial symmetry Nat.choose_symm (C(d+n, n−d-complement) = C(d+n, d)) after simplifying n+(d+1)−1 = d+n by omega. This yields weakCompositionGenFun_eq_invOneSubPow: the generating function equals invOneSubPow.val. The corollary weakCompositionGenFun_mul_one_sub_pow rewrites (1−X)ᵏ as (invOneSubPow S k).inv and applies the unit's val_inv law to conclude W k · (1−X)ᵏ = 1. The coefficient corollaries coeff_invOneSubPow_eq_card and coeff_invOneSubPow_eq_choose transport the identity back to read each coefficient of 1/(1−X)ᵏ as the count, respectively the closed form C(n+k−1, n).",
+    "keyInsights": [
+      "**The enumerative series is the algebraic series**: the entire result is the identification of two a priori different power series — the combinatorial generating function mk (n ↦ #weak compositions) and Mathlib's algebraically-defined inverse unit invOneSubPow. Once they agree coefficientwise (PowerSeries.ext), every algebraic fact Mathlib proves about invOneSubPow (it is a unit, its inverse is (1−X)ᵏ, multiplicativity invOneSubPow_add) transfers for free to the combinatorial object.",
+      "**Mathlib already did the analysis; we supply the combinatorics**: invOneSubPow and its coefficient formula C(d+n, d) are Mathlib's; card_weakComposition is the parent's. The only genuinely new step is the binomial symmetry C(n+k−1, n) = C(d+n, d) (for k = d+1) connecting the two coefficient formulas — a one-line Nat.choose_symm. The work is plumbing two existing results together, not proving either.",
+      "**0 < k is essential and clean**: the coefficient formula C(d+n, d) is stated for k = d+1, so the result is phrased for positive k; the k = 0 case is the degenerate empty product 1/(1−X)⁰ = 1, whose only nonzero coefficient is the constant term (the empty tuple is the unique weak composition of 0). Handling it would require a separate trivial branch and adds no content.",
+      "**Coefficient extraction recovers the closed form**: weakCompositionGenFun_mul_one_sub_pow gives the slick 'W = 1/(1−X)ᵏ' statement, while coeff_invOneSubPow_eq_choose gives the down-to-earth payoff — the n-th coefficient of (1−X)⁻ᵏ is literally the stars-and-bars number C(n+k−1, n). The two readings are the generating-function and term-by-term faces of the same identity.",
+      "**Works over any commutative ring**: the generating function and the identity are stated over an arbitrary commutative ring S (the counts are cast via the canonical ℕ → S map), so the result is not tied to ℤ or ℚ. This matches invOneSubPow's generality and means the identity is purely formal, independent of any convergence or characteristic considerations."
+    ],
+    "prerequisites": [
+      "The unrestricted stars-and-bars count C(n+k−1, n) and the Fintype instance on the summing subtype from the parent entry (Proofs/StarsAndBarsWeakCompositions.lean)",
+      "Formal power series over a commutative ring: PowerSeries.mk, the coefficient maps PowerSeries.coeff and coeff_mk, and extensionality PowerSeries.ext",
+      "Mathlib's invOneSubPow S k as a unit of S⟦X⟧, with invOneSubPow_val_succ_eq_mk_add_choose (coefficient formula C(d+n, d)) and invOneSubPow_inv_eq_one_sub_pow ((invOneSubPow S k).inv = (1−X)ᵏ)",
+      "The unit laws Units.val_inv / val_inv used to turn the inverse relation into W k · (1−X)ᵏ = 1",
+      "The binomial symmetry Nat.choose_symm together with Nat.add_sub_cancel_left, used to reconcile C(n+k−1, n) with C(d+n, d) for k = d+1"
+    ]
+  },
+  "sections": [
+    {
+      "id": "statement-and-setup",
+      "title": "The Generating Function of Weak-Composition Counts",
+      "startLine": 1,
+      "endLine": 72,
+      "mathContext": "$W_k(X) = \\sum_{n} \\#\\{f : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid \\textstyle\\sum_i f(i) = n\\}\\, X^n \\in S\\llbracket X\\rrbracket$.",
+      "summary": "The module docstring fixes the object (the ordinary generating function of the weak-composition counts over an arbitrary commutative ring S) and states the target: this series equals Mathlib's invOneSubPow S k, the inverse unit of (1−X)ᵏ, so it is 1/(1−X)ᵏ. weakCompositionGenFun packages the counts as mk (n ↦ (card {f : Fin k → ℕ // ∑ f = n} : S)), and the simp lemma coeff_weakCompositionGenFun reads its n-th coefficient straight off as the cast of the count. It records the precise gap: Mathlib has invOneSubPow and the parent has card_weakComposition, but the identification of the two is new."
+    },
+    {
+      "id": "binomial-bridge",
+      "title": "The Binomial Bridge C(n+k−1, n) = C(d+n, d)",
+      "startLine": 74,
+      "endLine": 86,
+      "mathContext": "$\\#\\{f : \\mathrm{Fin}(d{+}1) \\to \\mathbb{N} \\mid \\textstyle\\sum_i f(i) = n\\} = \\binom{d+n}{d}$.",
+      "summary": "card_weakComposition_succ is the only genuinely new mathematical step: it reconciles the parent's count C(n+(d+1)−1, n) with the coefficient C(d+n, d) of invOneSubPow for k = d+1. After rewriting by the parent's card_weakComposition and simplifying n+(d+1)−1 = d+n (omega), the two binomials differ only by the symmetry of the lower index: C(d+n, n) = C(d+n, d), supplied by Nat.choose_symm with (d+n) − d = n via Nat.add_sub_cancel_left. Everything else in the file is plumbing around this identity."
+    },
+    {
+      "id": "main-identification",
+      "title": "Generating Function = invOneSubPow = 1/(1−X)ᵏ",
+      "startLine": 87,
+      "endLine": 104,
+      "mathContext": "$W_k = \\mathrm{invOneSubPow}\\,S\\,k$, hence $W_k \\cdot (1-X)^k = 1$.",
+      "summary": "weakCompositionGenFun_eq_invOneSubPow is the headline: for 0 < k, write k = d+1, unfold Mathlib's invOneSubPow_val_succ_eq_mk_add_choose to mk (n ↦ C(d+n, d)), and compare coefficientwise (PowerSeries.ext) using card_weakComposition_succ. The corollary weakCompositionGenFun_mul_one_sub_pow rewrites (1−X)ᵏ as (invOneSubPow S k).inv (invOneSubPow_inv_eq_one_sub_pow) and applies the unit's val_inv law to conclude W k · (1−X)ᵏ = 1 — the formal-power-series statement that W k is the inverse of (1−X)ᵏ, i.e. 1/(1−X)ᵏ."
+    },
+    {
+      "id": "coefficient-corollaries",
+      "title": "Reading Off the Coefficients",
+      "startLine": 106,
+      "endLine": 119,
+      "mathContext": "$[X^n]\\, (1-X)^{-k} = \\#\\{f \\mid \\textstyle\\sum f = n\\} = \\binom{n+k-1}{n}$.",
+      "summary": "coeff_invOneSubPow_eq_card and coeff_invOneSubPow_eq_choose transport the identification back through the coefficient map: the n-th coefficient of 1/(1−X)ᵏ is the number of weak compositions of n into k parts, and equivalently the negative-binomial coefficient C(n+k−1, n) (casting the parent's card_weakComposition). These are the term-by-term face of the generating-function identity — the classical statement that the stars-and-bars numbers are the coefficients of (1−X)⁻ᵏ."
+    }
+  ],
+  "conclusion": {
+    "summary": "The generating-function form of stars and bars is formalized sorry-free and axiom-free: the ordinary generating function W k = ∑ₙ #(weak compositions of n into k parts) Xⁿ over any commutative ring equals Mathlib's invOneSubPow S k, the inverse unit of (1−X)ᵏ (weakCompositionGenFun_eq_invOneSubPow), so W k · (1−X)ᵏ = 1 (weakCompositionGenFun_mul_one_sub_pow) and the n-th coefficient is the stars-and-bars number C(n+k−1, n) (coeff_invOneSubPow_eq_choose). The mathematical content beyond Mathlib and the imported parent is the identification of the enumerative generating function of the counts with the algebraically-defined series invOneSubPow, mediated by the binomial symmetry C(n+k−1, n) = C(d+n, d).",
+    "implications": "Identifying the combinatorial generating function with invOneSubPow as an equality of power series (not merely coefficientwise as numbers) lets every algebraic fact Mathlib proves about invOneSubPow — that it is a unit, that invOneSubPow_add factors it as a product over part-counts, that its inverse is (1−X)ᵏ — be read combinatorially as statements about weak-composition counts. The result is the unbounded denominator shared by the whole composition family: the bounded-parts sibling multiplies it by (1−x^{b+1})ᵏ and the positive-parts sibling by xᵏ, both keeping the 1/(1−x)ᵏ factor proved here. It is also the natural base case for a Mathlib-bound general 'generating function of constrained compositions' lemma.",
+    "openQuestions": [
+      "Formalize the geometric-series factorization invOneSubPow S k = (mk 1)^k explicitly as the k-fold Cauchy product, exhibiting the combinatorial statement 'a weak composition is an independent choice of one part per factor' and re-deriving card_weakComposition by coeff_mul induction rather than from the multiset bijection.",
+      "Derive Newton's generalized binomial coefficient identity (−1)ⁿ C(−k, n) = C(n+k−1, n) in Mathlib's formal-power-series setting and connect it to coeff_invOneSubPow_eq_choose, giving the 'negative binomial theorem' reading of the same coefficients."
+    ]
+  },
+  "crossReferences": [
+    "stars-and-bars-weak-compositions",
+    "stars-and-bars-weak-compositions-oq-02",
+    "composition-parts-choose-oq-01"
+  ]
+}


### PR DESCRIPTION
## Summary

Open question OQ-01 of **stars-and-bars-weak-compositions**: the *generating-function* view of weak compositions.

A weak composition of `n` into `k` parts is a function `f : Fin k → ℕ` with `∑ᵢ f(i) = n`. The parent entry counts them combinatorially by stars and bars: `C(n+k−1, n)`. This entry packages those counts as an ordinary generating function over an arbitrary commutative ring `S`,

```
W k = ∑ₙ #{f : Fin k → ℕ // ∑ i, f i = n} · Xⁿ ∈ S⟦X⟧
```

and proves it is the negative-binomial series `1/(1−X)ᵏ`.

## Results (`Proofs/StarsAndBarsWeakCompositionsOQ01.lean`)

- `weakCompositionGenFun_eq_invOneSubPow` — **headline**: `W k = (invOneSubPow S k).val`, identifying the enumerative generating function with Mathlib's algebraically-defined inverse unit of `(1−X)ᵏ`.
- `weakCompositionGenFun_mul_one_sub_pow` — `W k · (1−X)ᵏ = 1`, the formal statement that `W k = 1/(1−X)ᵏ`.
- `coeff_invOneSubPow_eq_card` / `coeff_invOneSubPow_eq_choose` — the `n`-th coefficient of `1/(1−X)ᵏ` is the number of weak compositions of `n` into `k` parts, equivalently `C(n+k−1, n)`.

## What's new vs Mathlib

Mathlib supplies `invOneSubPow` with its coefficient formula `C(d+n, d)` and inverse relation `(invOneSubPow S k).inv = (1−X)ᵏ`; the imported parent supplies the count `card_weakComposition`. The new content is the *identification* of the two — mediated by the binomial symmetry `C(n+k−1, n) = C(d+n, d)` (`Nat.choose_symm`). Once the series are equal as objects, every algebraic fact Mathlib proves about `invOneSubPow` transfers to the combinatorial object.

## Verification

- **0 sorries, 0 axioms.** `#print axioms` on all three public theorems lists only `propext`, `Classical.choice`, `Quot.sound`. No `native_decide`.
- Requires `0 < k` (`k = 0` is the degenerate empty product `1/(1−X)⁰ = 1`).
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.StarsAndBarsWeakCompositionsOQ01`.
- Sanity: `k=1` → all coefficients `1` (series `1/(1−X)`); `k=2` → coefficient `n+1 = C(n+1, n)` at `Xⁿ`.

Gallery entry: `src/data/proofs/stars-and-bars-weak-compositions-oq-01/` (meta + 5 annotations), validates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)