### PR TITLE
Research: feuerbachs-theorem-oq-04 - spherical model foundations [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3038,6 +3038,7 @@ import Proofs.FeuerbachsTheoremOQ01Aristotle
 import Proofs.FeuerbachsTheoremOQ01OQ03
 import Proofs.FeuerbachsTheoremOQ02
 import Proofs.FeuerbachsTheoremOQ02Aristotle
+import Proofs.FeuerbachsTheoremOQ04
 import Proofs.FeuerbachsTheoremOQ05
 import Proofs.FibonacciIdentities
 import Proofs.FibonacciIdentitiesOQ01

--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -1,0 +1,112 @@
+/-
+# Feuerbach's Theorem in Non-Euclidean Geometry (OQ-04): spherical model foundations
+
+This file gives the gallery problem `feuerbachs-theorem-oq-04`
+("Feuerbach's Theorem in Non-Euclidean Geometry") a concrete formal grounding and a
+first layer of **verified** foundational lemmas.  The parent problem was a fresh stub
+with `problemStatement.formal = "(formal statement to be added)"`; this file supplies a
+precise statement target and the metric primitives any non-Euclidean tangency argument
+needs, all `0`-axiom / `0`-sorry.
+
+## Why the spherical model (and not hyperbolic)
+
+The classical Feuerbach theorem (the nine-point circle is tangent to the incircle and the
+three excircles) has analogues in both constant-curvature non-Euclidean geometries.  Of
+the two, only the **spherical** model has a clean, axiom-free realisation in current
+Mathlib: a point of the unit sphere `Sⁿ ⊆ E` is just a unit vector of a real inner-product
+space `E`, and the geodesic (spherical) distance between unit vectors `P, Q` is the angle
+they subtend, `Real.arccos ⟪P, Q⟫`.  Mathlib's hyperbolic-geometry support is far thinner
+(no developed hyperboloid / Poincaré-disk metric), so a hyperbolic formalisation would have
+to build the model from scratch — out of scope for a single session and prone to becoming
+scaffolding on unverified axioms.  We therefore anchor this problem in the spherical model,
+where every primitive below is a theorem about Mathlib's existing `InnerProductSpace ℝ E`.
+
+## Formal statement target (documented; not claimed here)
+
+In the spherical model a **spherical circle** with centre `O` (a unit vector) and angular
+radius `ρ ∈ (0, π)` is the level set `{P : OnSphere P ∧ scos P O = Real.cos ρ}`.  Two such
+circles `(O₁, ρ₁)`, `(O₂, ρ₂)` are *internally tangent* when they meet in exactly one point
+and one contains the other, which (for the sphere) happens iff the spherical distance
+between centres satisfies `sdist O₁ O₂ = |ρ₁ − ρ₂|`; *externally tangent* iff
+`sdist O₁ O₂ = ρ₁ + ρ₂`.  The spherical Feuerbach statement is then: for a spherical
+triangle, the spherical nine-point circle is tangent (in this sense) to the spherical
+incircle and the three excircles.  Reaching it requires a spherical incircle/nine-point
+construction; this file establishes the metric layer underneath that construction.
+
+## What this file proves (0 axioms, 0 sorries)
+
+* `chord_sq` — the **chord–cosine bridge** `‖P − Q‖² = 2 − 2·scos P Q` for unit vectors,
+  relating the ambient Euclidean chord to the spherical cosine.  This is the identity that
+  lets a tangency condition be checked algebraically in the inner product.
+* `abs_scos_le_one`, `scos_le_one`, `neg_one_le_scos` — the spherical cosine lies in
+  `[-1, 1]`, so `sdist` is a genuine angle.
+* `scos_self`, `sdist_self`, `sdist_nonneg`, `sdist_le_pi`, `sdist_eq_zero_of_eq` — `sdist`
+  is a well-defined `[0, π]`-valued quantity vanishing on the diagonal.
+-/
+import Mathlib
+
+namespace FeuerbachsTheoremOQ04
+
+open scoped RealInnerProductSpace
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- A point of the spherical model: a unit vector of the ambient real inner-product space. -/
+def OnSphere (P : E) : Prop := ‖P‖ = 1
+
+/-- Cosine of the spherical (geodesic) distance between two model points: the inner product. -/
+noncomputable def scos (P Q : E) : ℝ := ⟪P, Q⟫
+
+/-- Spherical distance: the angle subtended at the centre, `arccos` of the inner product. -/
+noncomputable def sdist (P Q : E) : ℝ := Real.arccos ⟪P, Q⟫
+
+/-- **Chord–cosine bridge.**  For unit vectors the squared ambient chord length is
+`2 − 2·cos(spherical distance)`.  This is the algebraic handle that turns a spherical
+tangency condition into an inner-product equation. -/
+theorem chord_sq (P Q : E) (hP : OnSphere P) (hQ : OnSphere Q) :
+    ‖P - Q‖ ^ 2 = 2 - 2 * scos P Q := by
+  have expand : ⟪P - Q, P - Q⟫ = ‖P‖ ^ 2 - 2 * ⟪P, Q⟫ + ‖Q‖ ^ 2 := by
+    rw [inner_sub_left, inner_sub_right, inner_sub_right,
+      real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq, real_inner_comm Q P]
+    ring
+  rw [← real_inner_self_eq_norm_sq, expand, hP, hQ, scos]
+  ring
+
+/-- The spherical cosine is bounded by `1` in absolute value (Cauchy–Schwarz on unit
+vectors), so `sdist` is the `arccos` of a genuine cosine value. -/
+theorem abs_scos_le_one (P Q : E) (hP : OnSphere P) (hQ : OnSphere Q) :
+    |scos P Q| ≤ 1 := by
+  have h := abs_real_inner_le_norm P Q
+  rw [hP, hQ] at h
+  simpa [scos] using h
+
+/-- The spherical cosine is at most `1`. -/
+theorem scos_le_one (P Q : E) (hP : OnSphere P) (hQ : OnSphere Q) :
+    scos P Q ≤ 1 :=
+  (abs_le.mp (abs_scos_le_one P Q hP hQ)).2
+
+/-- The spherical cosine is at least `-1`. -/
+theorem neg_one_le_scos (P Q : E) (hP : OnSphere P) (hQ : OnSphere Q) :
+    -1 ≤ scos P Q :=
+  (abs_le.mp (abs_scos_le_one P Q hP hQ)).1
+
+/-- A model point has spherical cosine `1` with itself. -/
+theorem scos_self (P : E) (hP : OnSphere P) : scos P P = 1 := by
+  rw [scos, real_inner_self_eq_norm_sq, hP]; norm_num
+
+/-- The spherical distance from a point to itself is `0`. -/
+theorem sdist_self (P : E) (hP : OnSphere P) : sdist P P = 0 := by
+  rw [sdist, show (⟪P, P⟫ : ℝ) = 1 from by rw [real_inner_self_eq_norm_sq, hP]; norm_num,
+    Real.arccos_one]
+
+/-- Spherical distance is nonnegative. -/
+theorem sdist_nonneg (P Q : E) : 0 ≤ sdist P Q := Real.arccos_nonneg _
+
+/-- Spherical distance is at most `π` (antipodal points). -/
+theorem sdist_le_pi (P Q : E) : sdist P Q ≤ Real.pi := Real.arccos_le_pi _
+
+/-- Equal model points are at spherical distance `0`. -/
+theorem sdist_eq_zero_of_eq {P Q : E} (hP : OnSphere P) (h : P = Q) : sdist P Q = 0 := by
+  subst h; exact sdist_self P hP
+
+end FeuerbachsTheoremOQ04

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -1,0 +1,43 @@
+# feuerbachs-theorem-oq-04 — Feuerbach's Theorem in Non-Euclidean Geometry
+
+## Session 2026-06-28 (researcher-2): spherical model foundations [SURVEY + BUILD]
+
+Fresh stub: `problemStatement.formal` was literally "(formal statement to be added)",
+no dedicated Lean file. Gave it a concrete formal grounding and a verified metric
+foundation layer.
+
+### Model choice
+Mathlib has **no developed hyperbolic-geometry metric** (no hyperboloid / Poincaré-disk
+distance), so an axiom-free hyperbolic Feuerbach would require building the model first.
+The **spherical** model is free: a point of Sⁿ is a unit vector of any real
+`InnerProductSpace ℝ E`, and the geodesic distance is `arccos ⟪P,Q⟫`. Anchored the
+problem there.
+
+### New file `proofs/Proofs/FeuerbachsTheoremOQ04.lean` (0-axiom, 0-sorry; docker-build clean)
+Primitives: `OnSphere P := ‖P‖=1`, `scos P Q := ⟪P,Q⟫`, `sdist P Q := arccos ⟪P,Q⟫`.
+Verified lemmas (foundational axioms only — propext/Classical.choice/Quot.sound, no
+Lean.ofReduceBool):
+- **chord_sq** (headline): unit vectors ⇒ `‖P-Q‖² = 2 - 2·scos P Q`. The chord–cosine
+  bridge that turns spherical tangency into an inner-product equation.
+- abs_scos_le_one / scos_le_one / neg_one_le_scos: spherical cosine ∈ [-1,1]
+  (Cauchy–Schwarz `abs_real_inner_le_norm` on unit vectors).
+- scos_self, sdist_self, sdist_nonneg (arccos_nonneg), sdist_le_pi (arccos_le_pi),
+  sdist_eq_zero_of_eq: `sdist` is a well-defined [0,π] angle vanishing on the diagonal.
+
+GOTCHA: under `open scoped RealInnerProductSpace` the notation is plain `⟪x,y⟫` (real
+inner product); the `⟪x,y⟫_ℝ` subscript form does NOT parse there (it gets read as a
+type ascription `(⟪…⟫ : ℝ)`). chord_sq proved by expanding ⟪P-Q,P-Q⟫ via inner_sub_left/
+inner_sub_right + real_inner_self_eq_norm_sq + real_inner_comm, then `ring`.
+
+### Formal statement target (documented, not yet proved)
+Spherical circle (O,ρ) := {P : OnSphere P ∧ scos P O = cos ρ}. Two circles internally
+tangent iff `sdist O₁ O₂ = |ρ₁−ρ₂|`, externally iff `sdist O₁ O₂ = ρ₁+ρ₂` (non-Euclidean
+analog of the Euclidean d=|r₁−r₂| / r₁+r₂ used in the verified Euclidean Feuerbach files).
+Spherical Feuerbach: spherical nine-point circle tangent to incircle + 3 excircles.
+
+### Next steps
+1. Define spherical circle as a level set of scos; prove membership/tangency algebra via chord_sq.
+2. Prove the spherical tangency criterion (sdist of centres = |ρ₁−ρ₂| / ρ₁+ρ₂).
+3. Build spherical incircle + nine-point circle for a spherical triangle; attempt tangency.
+
+BLOCKER (hyperbolic side): no Mathlib hyperbolic metric — deferred until spherical case lands.

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -1,14 +1,17 @@
 {
   "slug": "feuerbachs-theorem-oq-04",
   "title": "Feuerbach's Theorem in Non-Euclidean Geometry",
-  "phase": "NEW",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in geometry: Feuerbach's Theorem in Non-Euclidean Geometry.",
-    "whyMatters": []
+    "formal": "On the unit sphere of a real inner-product space E (points = unit vectors P with sdist P Q := arccos <P,Q>), a spherical circle (O, rho) is {P : OnSphere P and <P,O> = cos rho}. Spherical Feuerbach: for a spherical triangle the spherical nine-point circle is tangent to the spherical incircle and the three excircles, where two circles (O1,rho1),(O2,rho2) are internally tangent iff sdist O1 O2 = |rho1 - rho2| and externally tangent iff sdist O1 O2 = rho1 + rho2.",
+    "plain": "Formalize and prove Feuerbach's theorem in non-Euclidean (spherical) geometry: the nine-point circle of a spherical triangle is tangent to its incircle and excircles. Mathlib has no hyperbolic geometry, so the tractable constant-curvature model is the sphere (unit vectors with arccos distance).",
+    "whyMatters": [
+      "Extends a fully-verified Euclidean Feuerbach development to constant positive curvature.",
+      "Spherical circle tangency reduces to an inner-product identity via the chord-cosine bridge, keeping the argument axiom-free in Mathlib."
+    ]
   },
   "knownResults": {
     "proven": [],
@@ -16,12 +19,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ORIENT",
     "since": "2026-04-22T12:51:58.293Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Spherical model chosen; metric foundations formalized (chord-cosine bridge + spherical distance well-definedness).",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Construct spherical circle / incircle / nine-point primitives on top of scos/sdist; state and attempt the spherical tangency criterion sdist O1 O2 = |rho1 - rho2|.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +32,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "SURVEY+BUILD: gave the fresh stub a concrete formal grounding in the spherical model and a verified metric foundation layer (FeuerbachsTheoremOQ04.lean, 0-axiom). chord_sq is the chord-cosine bridge; scos/sdist are shown well-defined ([-1,1] cosine, [0,pi] distance vanishing on the diagonal). Hyperbolic model deferred (no Mathlib support). Next: spherical circle/incircle/nine-point constructions and the tangency criterion.",
+    "builtItems": [
+      "FeuerbachsTheoremOQ04.chord_sq (Proofs/FeuerbachsTheoremOQ04.lean) — chord-cosine bridge: for unit vectors, ||P-Q||^2 = 2 - 2*scos P Q; turns spherical tangency into an inner-product equation. 0-axiom.",
+      "FeuerbachsTheoremOQ04.abs_scos_le_one/scos_le_one/neg_one_le_scos — spherical cosine in [-1,1] (Cauchy-Schwarz on unit vectors)",
+      "FeuerbachsTheoremOQ04.scos_self/sdist_self/sdist_nonneg/sdist_le_pi/sdist_eq_zero_of_eq — sdist is a well-defined [0,pi]-valued angle vanishing on the diagonal",
+      "defs OnSphere (unit vector), scos := <P,Q>, sdist := arccos <P,Q> — the spherical model primitives"
+    ],
+    "insights": [
+      "Mathlib has clean spherical geometry for free (unit vectors of any InnerProductSpace R E; geodesic distance = arccos of inner product) but essentially no hyperbolic metric, so the spherical model is the tractable non-Euclidean route for Feuerbach.",
+      "The chord-cosine bridge ||P-Q||^2 = 2-2<P,Q> is the key reduction: a spherical circle (level set of <P,O>) and tangency conditions become polynomial in the inner product, so the argument stays axiom-free.",
+      "Spherical circle tangency target: internal iff sdist(O1,O2)=|rho1-rho2|, external iff sdist(O1,O2)=rho1+rho2 — the non-Euclidean analog of the Euclidean d=|r1-r2| / r1+r2 used in the verified Euclidean Feuerbach gallery files."
+    ],
+    "mathlibGaps": [
+      "No developed hyperbolic-geometry metric (hyperboloid / Poincare disk distance) in Mathlib — blocks an axiom-free hyperbolic Feuerbach without building the model first.",
+      "No spherical-triangle incircle / nine-point-circle construction in Mathlib; must be built on scos/sdist."
+    ],
+    "nextSteps": [
+      "Define spherical circle (O, rho) as a level set of scos and prove the membership/tangency algebra via chord_sq.",
+      "Prove the spherical circle tangency criterion: two circles tangent iff sdist of centres = |rho1-rho2| (internal) or rho1+rho2 (external).",
+      "Construct the spherical incircle and nine-point circle for a spherical triangle, then attempt the tangency conclusion."
+    ]
   },
   "tags": [
     "geometry",
@@ -71,7 +90,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.293Z",
-  "lastUpdate": "2026-04-22T12:51:58.293Z",
+  "lastUpdate": "2026-06-28T00:00:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -360,6 +379,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ05.lean"
+    },
+    {
+      "path": "Proofs/FeuerbachsTheoremOQ04.lean",
+      "filename": "FeuerbachsTheoremOQ04.lean",
+      "lineCount": 112,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ04.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Research session for **feuerbachs-theorem-oq-04** ("Feuerbach's Theorem in Non-Euclidean Geometry"), a fresh stub whose `problemStatement.formal` was a literal placeholder and which had no dedicated Lean file. This session gives it a concrete formal grounding and a first layer of **verified** foundational lemmas.

## Model choice (honest scoping)
Mathlib has **no developed hyperbolic-geometry metric** (no hyperboloid / Poincaré-disk distance), so an axiom-free hyperbolic Feuerbach would require building the model from scratch. The **spherical** model is available for free: a point of `Sⁿ` is a unit vector of any real `InnerProductSpace ℝ E`, and the geodesic distance is `arccos ⟪P,Q⟫`. The problem is anchored there; the hyperbolic side is documented as a blocker.

## New file `proofs/Proofs/FeuerbachsTheoremOQ04.lean` (0 axiom / 0 sorry / 0 native_decide)
Primitives: `OnSphere P := ‖P‖=1`, `scos P Q := ⟪P,Q⟫`, `sdist P Q := arccos ⟪P,Q⟫`.

- **`chord_sq`** (headline): unit vectors ⇒ `‖P − Q‖² = 2 − 2·scos P Q` — the chord–cosine bridge that turns a spherical tangency condition into an inner-product equation.
- `abs_scos_le_one` / `scos_le_one` / `neg_one_le_scos`: spherical cosine ∈ `[-1,1]` (Cauchy–Schwarz on unit vectors).
- `scos_self`, `sdist_self`, `sdist_nonneg`, `sdist_le_pi`, `sdist_eq_zero_of_eq`: `sdist` is a well-defined `[0,π]` angle vanishing on the diagonal.

## Formal statement target (documented, not claimed)
Spherical circle `(O, ρ) := {P : OnSphere P ∧ scos P O = cos ρ}`; two circles are internally tangent iff `sdist O₁ O₂ = |ρ₁ − ρ₂|`, externally iff `sdist O₁ O₂ = ρ₁ + ρ₂` — the non-Euclidean analog of the Euclidean `d = |r₁−r₂|` / `r₁+r₂` used in the verified Euclidean Feuerbach gallery files. Spherical Feuerbach: the spherical nine-point circle is tangent to the spherical incircle and three excircles.

## Files
- `proofs/Proofs/FeuerbachsTheoremOQ04.lean` (new), registered in `proofs/Proofs.lean`
- `src/data/research/problems/feuerbachs-theorem-oq-04.json` (formal statement + knowledge)
- `research/problems/feuerbachs-theorem-oq-04/knowledge.md` (new)

## Verification
`./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremOQ04` — **build succeeded**. `#print axioms` of `chord_sq`/`sdist_self` = `propext, Classical.choice, Quot.sound` only (no `Lean.ofReduceBool`).

## Status
**Outcome**: surveyed + built (foundation layer; main tangency theorem not yet attempted)
**Next Steps**: spherical circle level-set + tangency criterion via `chord_sq`; then spherical incircle / nine-point construction.

🤖 Generated by researcher-2