### PR TITLE
audit(erdos-156): correct stale sorries field 3→15 (chain literal count)

### DIFF
--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -19,7 +19,7 @@
       "extremal-combinatorics"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 15,
     "erdosNumber": 156,
     "erdosUrl": "https://erdosproblems.com/156",
     "erdosProblemStatus": "open",
@@ -191,7 +191,7 @@
     "theoremCount": 19,
     "definitionCount": 12,
     "path": "Proofs/Erdos156Problem.lean",
-    "sorries": 3,
+    "sorries": 15,
     "additionalFiles": [
       "Proofs/Erdos156ProblemAristotle.lean",
       "Proofs/Erdos156Aristotle.lean",
@@ -229,5 +229,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
     }
   ],
-  "sorries": 3
+  "sorries": 15
 }


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `erdos-156`
**Severity**: HIGH (sorry count mismatch) — but no overclaim; entry is correctly `wip`/`formalized`.

## Problem

`erdos-156` declares three `additionalFiles` but its `sorries` field was `3`, matching **neither** accepted convention:

| Convention | Count |
|---|---|
| main-file only (`Erdos156Problem.lean`) | 0 literal `sorry` |
| chain-aggregate (main + additionalFiles) | **15** literal `sorry` |
| claimed (stale) | 3 |

Per-file literal `\bsorry\b` counts:
- `Erdos156Problem.lean`: 0
- `Erdos156ProblemAristotle.lean`: 3
- `Erdos156Aristotle.lean`: 12
- `Erdos156OQ02.lean`: 0
- **chain total: 15**

The `3` referred semantically to the "3 shadow-bound lemmas" named in the `assumptions` field, not a literal token count. The auditor heuristic (`scripts/auditor/find-targets.ts`) counts literal `\bsorry\b` and re-flagged this entry on every cycle (9 audits) as `sorry mismatch: claims 3, actual main 0 / chain 15`.

## Fix

Set all three `sorries` fields (`meta.sorries`, `leanFile.sorries`, top-level `sorries`) to **15** — the chain-aggregate literal count matching the declared `additionalFiles`. This is the conservative correction: the prior value *understated* open sorries.

- Entry remains correctly `badge: wip`, `status: formalized` — no overclaim introduced or removed.
- The `assumptions` field already discloses non-compilation against pinned Mathlib v4.26.0.
- **No Lean source changed** — meta.json only.

---
Discovered and fixed during gallery integrity audit.