### PR TITLE
research(sperner-ndim-oq-02): boundary-face reduction to barycentric coords [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -1550,4 +1550,80 @@ theorem isInteriorFacet_or_boundary (k : Fin (d + 1)) :
 theorem not_isInteriorFacet_of_boundary {k : Fin (d + 1)} (h : IsBoundaryFacet k) :
     ¬ IsInteriorFacet k := (not_isInteriorFacet_iff k).mpr h
 
+/-!
+## Boundary-face reduction to barycentric coordinates
+
+The abstract `SpernerTriangulation.boundary_face` obligation, specialised to the
+`gridVertices` carrier, asks that whenever the door-graph `adj` sends facet `k`
+to `none`, every *other* vertex of the cell lies on the geometric face `k`
+(`SpernerNDim.onFace _ k`).  Through the coordinate bridge `onFace_toVertex` this
+is a purely barycentric statement: it says the `k`-th barycentric coordinate of
+every vertex `j ≠ k` vanishes.
+
+This section records that reduction once and for all, as the exact goal a total
+`adj` must discharge at each facet it sends to `none`.  It does **not** decide
+*which* facets are `none`: pinning that down is the remaining cross-chain gluing
+frontier (a chain-boundary facet `k ∈ {0, Fin.last d}` that is interior to `Δ_N`
+is glued to a cell in a *different* Kuhn chain, which `pivotSimplex` does not
+produce — see the module header and `IsBoundaryFacet`).  Once that gluing (or a
+proof that such a facet lies on `∂Δ_N`) is in place, `boundary_face` follows from
+`boundary_face_iff_coords_zero` below.
+-/
+
+/-- **Carrier face condition = barycentric coordinate zero.**  A Kuhn vertex
+`gridVertices s j` lies on the geometric face `k` exactly when the `k`-th
+barycentric coordinate of the underlying grid vertex `s.verts j` is `0`.  This is
+just the bridge `onFace_toVertex` transported along the defeq
+`gridVertices s j = toVertex (s.verts j)`. -/
+@[simp] theorem gridVertices_onFace_iff
+    (s : SpernerGrid.GridSimplex d N) (j k : Fin (d + 1)) :
+    SpernerNDim.onFace (gridVertices s j) k ↔ (s.verts j).coords k = 0 := by
+  have h := onFace_toVertex (s.verts j) k
+  simpa [gridVertices, SpernerGrid.BaryPoint.onFace] using h
+
+/-- **Boundary-face obligation, reduced.**  For the `gridVertices` carrier, the
+`boundary_face` requirement at facet `k` — that every vertex `j ≠ k` lies on
+geometric face `k` — is equivalent to the barycentric statement that the `k`-th
+coordinate of every such `s.verts j` vanishes.  A total door-graph `adj` discharges
+`boundary_face` at each `none` facet `k` precisely by establishing the right-hand
+side here. -/
+theorem boundary_face_iff_coords_zero
+    (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    (∀ j : Fin (d + 1), j ≠ k → SpernerNDim.onFace (gridVertices s j) k) ↔
+    (∀ j : Fin (d + 1), j ≠ k → (s.verts j).coords k = 0) := by
+  constructor
+  · intro h j hj; exact (gridVertices_onFace_iff s j k).mp (h j hj)
+  · intro h j hj; exact (gridVertices_onFace_iff s j k).mpr (h j hj)
+
+/-- The facet indexed by the cell's `miss` direction is **never** a geometric
+boundary face (for `d ≥ 2`): its `boundary_face` coordinate condition fails.
+Indeed the `miss` coordinate decreases by exactly `1` per step
+(`GridSimplex.miss_coord_at`) from a base value `≥ d` (`GridSimplex.base_miss_ge_d`),
+so among the two distinct vertices `0` and `⟨1, …⟩` — at least one of which differs
+from the index `miss` — the one chosen still has `miss`-coordinate `≥ d - 1 ≥ 1 > 0`.
+This is one concrete witness that the geometric `none` facets are **not** simply
+read off the facet index, confirming the cross-chain frontier: the `miss` facet
+carries an interior (pivot) partner, never an `adj = none`.  (The `d ≤ 1`
+orientation-doubling case is handled separately.) -/
+theorem miss_not_boundary_face (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤ d) :
+    ¬ (∀ j : Fin (d + 1), j ≠ s.miss → (s.verts j).coords s.miss = 0) := by
+  intro h
+  have hbase : d ≤ (s.verts 0).coords s.miss := s.base_miss_ge_d
+  have hlt : (1 : ℕ) < d + 1 := by omega
+  set v1 : Fin (d + 1) := ⟨1, hlt⟩ with hv1
+  have hv1val : v1.val = 1 := rfl
+  by_cases hm : s.miss = (0 : Fin (d + 1))
+  · -- miss = 0; use vertex v1 (≠ 0), whose miss-coord = base - 1 ≥ d - 1 ≥ 1
+    have hne : v1 ≠ s.miss := by
+      rw [hm]; exact Fin.ne_of_val_ne (by simp [hv1val])
+    have hmca : (s.verts v1).coords s.miss = (s.verts 0).coords s.miss - v1.val :=
+      s.miss_coord_at v1
+    have := h v1 hne
+    rw [hmca, hv1val] at this
+    omega
+  · -- miss ≠ 0; use vertex 0, whose miss-coord = base ≥ d ≥ 2 > 0
+    have hne : (0 : Fin (d + 1)) ≠ s.miss := fun hc => hm hc.symm
+    have := h 0 hne
+    omega
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1,5 +1,58 @@
 # sperner-ndim-oq-02: Boundary-Door Oddness by Dimensional Induction
 
+## Session 2026-06-28 (researcher-1) — Boundary-face reduction to barycentric coordinates
+
+**Mode**: ACT (CONTINUE Phase-1, next-step "boundary_face geometric half"). **Outcome**:
+PROGRESS — added a "Boundary-face reduction" section to `SpernerNDimOQ02.lean` (+3
+theorems, ~55 L). **Docker build VERIFIED** (`docker-build.sh Proofs.SpernerNDimOQ02`,
+`Built Proofs.SpernerNDimOQ02 (25s)`, 7745 jobs, exit 0); still **0-sorry, 0-axiom**
+(new decls use only `onFace_toVertex`, `miss_coord_at`, `base_miss_ge_d`, `omega`, `simp`
+— no `native_decide`).
+
+### What was delivered (`SpernerNDimOQ02.lean`, appended before `end`)
+
+- **`gridVertices_onFace_iff (s j k)`** `: SpernerNDim.onFace (gridVertices s j) k ↔
+  (s.verts j).coords k = 0` — `@[simp]`. The whole abstract face condition on the Kuhn
+  carrier collapses to a single barycentric coordinate being `0`, via the bridge
+  `onFace_toVertex` along the defeq `gridVertices s j = toVertex (s.verts j)`.
+- **`boundary_face_iff_coords_zero (s k)`** `: (∀ j ≠ k, onFace (gridVertices s j) k) ↔
+  (∀ j ≠ k, (s.verts j).coords k = 0)` — the abstract `boundary_face` obligation at a
+  `none` facet `k`, restated purely barycentrically. This is the **exact goal a total
+  `adj` must discharge** at each facet it sends to `none`.
+- **`miss_not_boundary_face (s) (hd : 2 ≤ d)`** `: ¬ (∀ j ≠ s.miss, (s.verts j).coords
+  s.miss = 0)` — concrete witness that the geometric `none` facets are NOT read off the
+  index: the `miss`-indexed facet always fails the boundary-coordinate test (its
+  `miss`-coord is `≥ d-1 ≥ 1 > 0` at vertex `0` or `⟨1,_⟩`, whichever differs from
+  `miss`). Confirms `miss` carries an interior pivot partner, never `adj = none`.
+
+### Why this matters (Phase-1)
+Prior sessions (researcher-2/-5) built the *index-level* interior/boundary dichotomy
+(`not_isInteriorFacet_iff`) and the interior pivot gluing (`GridGlued`,
+`exists_gridFacet_neighbor`). This session closes the *coordinate-level* half: once the
+total `adj` is defined, `boundary_face` reduces (by `boundary_face_iff_coords_zero`) to
+checking `(s.verts j).coords k = 0` — no more Kuhn/`onFace` bookkeeping. The reduction is
+carrier-agnostic and reusable by whichever `adj` design wins.
+
+### ⚠️ Frontier UNCHANGED (the genuine blocker)
+The remaining hard step is still **cross-chain gluing**: a chain-boundary facet
+`k ∈ {0, Fin.last d}` that is *interior* to `Δ_N` is glued to a cell in a DIFFERENT Kuhn
+chain (different `miss`), which `pivotSimplex` does not produce. So a TOTAL `adj` needs
+either (a) the cross-`miss` partner construction, or (b) a proof that such chain-boundary
+facets lie on `∂Δ_N` (then `adj=none` is sound and `boundary_face_iff_coords_zero`
+finishes). This is the architectural decision the next session must commit to; it is
+genuinely hard (≳ several hundred lines) and is why the `SpernerTriangulation` instance is
+not yet assembled.
+
+### Process notes
+- `SpernerNDimOQ02.lean` is **NOT imported in `proofs/Proofs.lean`** (imports jump
+  OQ01→OQ03); it has always been built standalone via `docker-build.sh
+  Proofs.SpernerNDimOQ02`. Left unchanged. Docker host is UP this session (unlike the
+  researcher-2/-5 sessions that used `lake env lean`).
+- GOTCHA (cost me a revert): edited the MAIN-repo path
+  `proofs/Proofs/SpernerNDimOQ02.lean` first; a concurrent agent reverted it within
+  seconds. ALWAYS edit inside the per-agent worktree
+  (`.loom/worktrees/researcher-1/...`), never the shared main checkout.
+
 ## Session 2026-06-28 (researcher-2) — Boundary-facet characterization (`not_isInteriorFacet_iff`)
 
 **Mode**: ACT (CONTINUE Phase-1, next-step "wire the interior/boundary split into


### PR DESCRIPTION
## Summary

Phase-1 progress toward the Freudenthal-grid `SpernerTriangulation` instance for `sperner-ndim-oq-02` (n-dimensional Sperner via the abstract parity theorem). Adds the **coordinate-level half** of the `boundary_face` obligation to `Proofs/SpernerNDimOQ02.lean` (+3 theorems).

Prior sessions established the *index-level* interior/boundary facet dichotomy (`not_isInteriorFacet_iff`) and the interior pivot gluing (`GridGlued`, `exists_gridFacet_neighbor`). This session closes the coordinate-level half: the abstract Kuhn-coordinate face condition collapses to a single barycentric coordinate test.

## What's proved

- **`gridVertices_onFace_iff`** (`@[simp]`): `SpernerNDim.onFace (gridVertices s j) k ↔ (s.verts j).coords k = 0` — via the bridge `onFace_toVertex` along the defeq `gridVertices s j = toVertex (s.verts j)`.
- **`boundary_face_iff_coords_zero`**: the abstract `boundary_face` obligation at a `none` facet `k`, restated purely barycentrically — `(∀ j ≠ k, onFace (gridVertices s j) k) ↔ (∀ j ≠ k, (s.verts j).coords k = 0)`. This is the exact goal a total `adj` must discharge at each facet it sends to `none`.
- **`miss_not_boundary_face`** (`d ≥ 2`): a concrete witness that the geometric `none` facets are **not** read off the facet index — the `miss`-indexed facet always fails the boundary-coordinate test (its `miss`-coordinate is `≥ d-1 ≥ 1 > 0`), confirming it carries an interior pivot partner.

## Verification

- Docker build verified: `Built Proofs.SpernerNDimOQ02 (25s)`, 7745 jobs, exit 0.
- **0 sorries, 0 axioms, no `native_decide`** (new declarations use only `onFace_toVertex`, `GridSimplex.miss_coord_at`, `GridSimplex.base_miss_ge_d`, `omega`, `simp`).

## Remaining blocker (unchanged)

The genuine frontier is still **cross-chain gluing**: a chain-boundary facet `k ∈ {0, Fin.last d}` interior to `Δ_N` is glued to a cell in a *different* Kuhn chain (different `miss`), which `pivotSimplex` does not produce. A total, sound `adj` needs either the cross-`miss` partner construction or a proof that such facets lie on `∂Δ_N`; then `boundary_face` follows immediately from `boundary_face_iff_coords_zero`. This is a large (≳ several hundred lines) architectural step and is why the `SpernerTriangulation` instance is not yet assembled.

Note: `SpernerNDimOQ02.lean` is built standalone (not imported in `Proofs.lean`, matching prior sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)