### PR TITLE
Enrich 'Exact Gaussian-Elimination Cost: (n³ − n)/3' (cramers-rule-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/cramers-rule-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-cramer-oq0201-01-imports",
+    "proofId": "cramers-rule-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 2 },
+    "type": "context",
+    "title": "Building on the Parent Cramer-vs-Gauss File",
+    "content": "Imports all of Mathlib (for `Finset.sum`, `Finset.sum_range_succ`, and the `omega`/`ring`/`norm_num` tactics) and the parent entry `Proofs.CramersRuleOQ02`. The parent supplies `CramersComplexity.cramersRuleMuls n` (the Cramer's-rule multiplication count) and `CramersComplexity.gauss_beats_cramer` (Gaussian elimination beats Cramer's rule for n ≥ 4 under the loose n³ model). This file reuses those results unchanged and only tightens the Gaussian cost model, so the parent's comparison conclusion is inherited rather than re-proved.",
+    "mathContext": "Parent model: $\\texttt{gaussMuls}\\,n = n^3$, $\\texttt{cramersRuleMuls}\\,n = (n+1)\\,n\\,n!$, with $\\texttt{gaussMuls}\\,n < \\texttt{cramersRuleMuls}\\,n$ for $n \\ge 4$.",
+    "significance": "context",
+    "relatedConcepts": ["Gaussian-elimination", "Cramer's-rule", "computational-complexity", "code-reuse"],
+    "prerequisites": ["Lean-imports", "Mathlib"]
+  },
+  {
+    "id": "ann-cramer-oq0201-02-exact-model",
+    "proofId": "cramers-rule-oq-02-oq-01",
+    "range": { "startLine": 57, "endLine": 61 },
+    "type": "definition",
+    "title": "The Exact Per-Step Cost Model",
+    "content": "`gaussExactOps n = ∑_{j ∈ range n} (j² + j)` is the exact multiplication-plus-division count for forward elimination of an n×n system. The summation index `j` is the number of rows beneath the current pivot: clearing that column costs `j` divisions (one multiplier per row) and `j²` multiplications (updating the `j` trailing entries of each of the `j` rows). Summing `j² + j` as `j` ranges over `0, …, n−1` recovers the per-step total; the `j = 0` term vanishes, so this equals the textbook `∑_{j=1}^{n−1} (j² + j)`.",
+    "mathContext": "$\\texttt{gaussExactOps}(n) = \\sum_{j=0}^{n-1} (j^2 + j) = \\sum_{j=1}^{n-1}(j^2 + j)$, where step $k$ (with $j = n-k$ rows below the pivot) contributes $j$ divisions and $j^2$ multiplications.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum", "flop-count", "forward-elimination", "pivot"],
+    "prerequisites": ["finite-sums", "Gaussian-elimination", "algorithm-complexity"]
+  },
+  {
+    "id": "ann-cramer-oq0201-03-succ",
+    "proofId": "cramers-rule-oq-02-oq-01",
+    "range": { "startLine": 63, "endLine": 67 },
+    "type": "technique",
+    "title": "Peeling One Elimination Step",
+    "content": "`gaussExactOps_succ` unfolds the sum by one term: `gaussExactOps (n+1) = gaussExactOps n + (n² + n)`. This is a direct application of `Finset.sum_range_succ`, which splits `∑_{x < n+1} f x` into `∑_{x < n} f x + f n`. This one-step recurrence is the engine of the inductive closed-form proof that follows — it expresses the cost of an (n+1)×(n+1) system as the n×n cost plus the new outermost elimination step.",
+    "mathContext": "$\\sum_{x<n+1} f(x) = \\left(\\sum_{x<n} f(x)\\right) + f(n)$, here with $f(j) = j^2 + j$ so the new term is $n^2 + n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_range_succ", "recurrence", "telescoping"],
+    "prerequisites": ["finite-sums", "induction"]
+  },
+  {
+    "id": "ann-cramer-oq0201-04-closed-form",
+    "proofId": "cramers-rule-oq-02-oq-01",
+    "range": { "startLine": 69, "endLine": 81 },
+    "type": "insight",
+    "title": "Subtraction-Free Closed Form: 3·ops + n = n³",
+    "content": "The central theorem `gaussExactOps_closed` proves `3 · gaussExactOps n + n = n³` by induction on n. The key design choice is to state the identity in the additive, subtraction-free form `3·ops + n = n³` rather than the division form `ops = (n³ − n)/3`. Because ℕ is a commutative *semiring* (no subtraction, no division), the entire successor step closes with `ring`: the calc block rewrites with `gaussExactOps_succ`, substitutes the induction hypothesis `3·gaussExactOps m + m = m³`, and lets `ring` verify `m³ + (3(m² + m) + 1) = (m+1)³`. Phrasing it with truncated subtraction would have forced `linear_combination` over a ring, which ℕ is not.",
+    "mathContext": "$3\\sum_{j=1}^{n-1}(j^2+j) + n = n^3$, equivalently $\\sum_{j=1}^{n-1}(j^2+j) = \\tfrac{(n-1)n(n+1)}{3} = \\tfrac{n^3-n}{3}$. Successor identity: $m^3 + \\bigl(3(m^2+m)+1\\bigr) = (m+1)^3$.",
+    "significance": "key",
+    "relatedConcepts": ["mathematical-induction", "commutative-semiring", "ring-tactic", "closed-form", "truncated-subtraction"],
+    "prerequisites": ["induction", "semiring-vs-ring", "polynomial-identities"]
+  },
+  {
+    "id": "ann-cramer-oq0201-05-div-form",
+    "proofId": "cramers-rule-oq-02-oq-01",
+    "range": { "startLine": 83, "endLine": 88 },
+    "type": "technique",
+    "title": "Recovering the Textbook (n³ − n)/3 Form",
+    "content": "`gaussExactOps_eq_div` converts the additive closed form into the headline division form `gaussExactOps n = (n³ − n)/3`. From `3·gaussExactOps n + n = n³`, `omega` derives `3·gaussExactOps n = n³ − n` (now legitimate in ℕ since `n ≤ n³`), and `Nat.mul_div_cancel_left` cancels the exact factor of 3. Because the division is exact — `3` genuinely divides `n³ − n = (n−1)n(n+1)`, a product of three consecutive integers — no rounding or floor appears, and the result is the literal `n³/3` flop count of numerical linear algebra.",
+    "mathContext": "$3 \\mid n^3 - n = (n-1)\\,n\\,(n+1)$ (three consecutive integers), so $\\texttt{gaussExactOps}\\,n = \\dfrac{n^3 - n}{3}$ exactly in $\\mathbb{N}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.mul_div_cancel_left", "exact-division", "omega", "consecutive-integers"],
+    "prerequisites": ["natural-number-division", "divisibility"]
+  },
+  {
+    "id": "ann-cramer-oq0201-06-bounds",
+    "proofId": "cramers-rule-oq-02-oq-01",
+    "range": { "startLine": 90, "endLine": 113 },
+    "type": "insight",
+    "title": "The Tightening Is Genuine, Not Just Asymptotic",
+    "content": "Two bounds quantify the gap against the parent's loose model. `gaussExactOps_le_cube` proves `gaussExactOps n ≤ n³` (consistency with the n³ upper model), and `gaussExactOps_lt_cube` proves the inequality is *strict* for n ≥ 2 — the exact count is provably below n³ for every system of size ≥ 2, so the factor-3 improvement is real rather than merely asymptotic. Both are discharged by `omega` treating `n³` and `gaussExactOps n` as opaque atoms linked only by the linear closed-form hypothesis. The lemma `gaussExactOps_small` sanity-checks the formula against hand computation: n = 2,3,4,5 give 2, 8, 20, 40.",
+    "mathContext": "$\\texttt{gaussExactOps}\\,n \\le n^3$ always; strictly $< n^3$ for $n \\ge 2$. The overcount of the loose model is $n^3 - \\tfrac{n^3-n}{3} = \\tfrac{2n^3+n}{3} \\approx \\tfrac{2}{3}n^3$.",
+    "significance": "key",
+    "relatedConcepts": ["omega", "strict-inequality", "asymptotics", "leading-constant", "sanity-check"],
+    "prerequisites": ["inequalities", "Presburger-arithmetic"]
+  },
+  {
+    "id": "ann-cramer-oq0201-07-comparison",
+    "proofId": "cramers-rule-oq-02-oq-01",
+    "range": { "startLine": 115, "endLine": 131 },
+    "type": "concept",
+    "title": "A Tighter Cost Cannot Overturn the Verdict",
+    "content": "`gaussExact_beats_cramer` shows the exact model still beats Cramer's rule for n ≥ 4, obtained a fortiori by chaining `gaussExactOps n ≤ n³` (this file) with the parent's `gaussMuls n < cramersRuleMuls n` (i.e. `gauss_beats_cramer`) through `lt_of_le_of_lt`. The logic is structural: lowering the *winner's* cost estimate can never reverse a comparison it already won, so every conclusion of the parent survives the tightening unchanged. `gauss_exact_summary` bundles all five facts — closed form, division form, the ≤ and < bounds, and the preserved comparison — into a single citable theorem.",
+    "mathContext": "Since $\\texttt{gaussExactOps}\\,n \\le n^3 = \\texttt{gaussMuls}\\,n < \\texttt{cramersRuleMuls}\\,n$ for $n \\ge 4$, transitivity gives $\\texttt{gaussExactOps}\\,n < \\texttt{cramersRuleMuls}\\,n$.",
+    "significance": "key",
+    "relatedConcepts": ["lt_of_le_of_lt", "transitivity", "a-fortiori", "monotone-comparison", "proof-reuse"],
+    "prerequisites": ["order-relations", "transitivity"]
+  }
+]

--- a/src/data/proofs/cramers-rule-oq-02-oq-01/index.ts
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CramersRuleOQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cramersRuleOq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cramersRuleOq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cramersRuleOq02Oq01Data: ProofData = {
+  proof: cramersRuleOq02Oq01Proof,
+  annotations: cramersRuleOq02Oq01Annotations,
+}

--- a/src/data/proofs/cramers-rule-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01/meta.json
@@ -108,7 +108,15 @@
       "mathContext": "Since gaussExactOps n ≤ n³ = gaussMuls n and the parent proved gaussMuls n < cramersRuleMuls n for n ≥ 4, the tighter model beats Cramer's rule a fortiori — tightening the winner's cost cannot overturn the comparison."
     }
   ],
-  "conclusion": "This entry pins down the exact leading cost of Gaussian elimination — (n³ − n)/3 multiplications and divisions — that the parent Cramer-vs-Gauss comparison only bounded by n³. The closed form 3·gaussExactOps n + n = n³ is proved by a short subtraction-free induction in the ℕ semiring, its (n³ − n)/3 division form follows in one line, and omega supplies both the consistency bound (≤ n³) and the strict tightening (< n³ for n ≥ 2). Because a smaller cost can only strengthen a comparison the winner already led, the headline verdict — Gaussian beats Cramer for n ≥ 4 — carries over to the exact model for free. The whole file is axiom-free (no sorries, no native_decide), upgrading the parent's axiomatized model to a fully kernel-checked exact count.",
+  "conclusion": {
+    "summary": "This entry pins down the exact leading cost of Gaussian elimination — (n³ − n)/3 multiplications and divisions — that the parent Cramer-vs-Gauss comparison only bounded by n³. The closed form 3·gaussExactOps n + n = n³ is proved by a short subtraction-free induction in the ℕ semiring, its (n³ − n)/3 division form follows in one line, and omega supplies both the consistency bound (≤ n³) and the strict tightening (< n³ for n ≥ 2). The whole file is axiom-free (no sorries, no native_decide), upgrading the parent's axiomatized model to a fully kernel-checked exact count.",
+    "implications": "Because a smaller cost can only strengthen a comparison the winner already led, the headline verdict — Gaussian elimination beats Cramer's rule for n ≥ 4 — carries over to the exact model for free, with no re-proof needed. More broadly, the entry demonstrates a reusable pattern for formalizing exact flop counts: state the polynomial identity in subtraction-free additive form (k·sum + remainder = closed form) so the induction stays in the ℕ semiring and closes by ring, then recover the conventional division form as a one-line corollary. The same template applies to the ~2n³/3 LU-factorization count, the n²/2 back-substitution count, and other textbook complexity figures that are usually quoted asymptotically but rarely formalized exactly.",
+    "openQuestions": [
+      "Can the back-substitution phase (≈ n²/2 operations) and the full solve cost (forward elimination + back-substitution) be formalized with the same subtraction-free closed-form technique and composed with this result?",
+      "Does the exact count extend to blocked/partial-pivoting LU factorization, where row interchanges add a lower-order term but the leading (n³ − n)/3 multiplication count is unchanged?",
+      "Can a matching lower bound be formalized — that no elimination-based dense solver uses asymptotically fewer than n³/3 multiplications — to complement this exact upper count?"
+    ]
+  },
   "relatedProblems": [
     "cramers-rule-oq-02",
     "cramers-rule"


### PR DESCRIPTION
Enrichment pass for **cramers-rule-oq-02-oq-01** (passes: 0, quality: 30 → first pass).

The entry had a rich `meta.json` but was **missing both `annotations.json` and `index.ts`**, and its `conclusion` was stored as a plain string rather than a structured `ProofConclusion`.

## Changes

- **Added `annotations.json`** — 7 substantive annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering:
  - the parent-file imports and inherited Cramer-vs-Gauss machinery
  - the exact per-step model `gaussExactOps n = ∑_{j<n} (j² + j)`
  - the one-step recurrence via `Finset.sum_range_succ`
  - the subtraction-free closed form `3·ops + n = n³` (and why staying in the ℕ semiring lets `ring` close the induction)
  - the textbook `(n³ − n)/3` division form via exact divisibility
  - the genuine (strict, non-asymptotic) tightening bounds against the n³ model
  - the a-fortiori preservation of the `n ≥ 4` comparison verdict
- **Added missing `index.ts`** (page previously could fail to load via the legacy shim path).
- **Restructured `conclusion`** from a plain string into a proper `ProofConclusion` object (`summary` + `implications` + 3 genuine `openQuestions`: back-substitution/full-solve cost, blocked LU with pivoting, a matching n³/3 lower bound) so it renders correctly.

## Verification

- JSON validated for both files; `meta.json` is 14.3 KB, well under the 60 KB cap (`check-meta-size.ts`: within caps).
- Data-generation build steps (`annotations:build`, `research:build`, `research:enrich`) ran clean; the entry now appears in regenerated `listings.json`. (`tsc`/`vite` not run — worktree lacks `node_modules`; gitignored `listings.json`/`data-manifest.json` are regenerated at deploy.)
- Axiom integrity unchanged: `status: verified`, `axiomCount: 0` — consistent with the Lean source (0 sorries, 0 axioms, no `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)