### PR TITLE
research(feuerbachs-theorem-oq-04): spherical circles + tangency layer [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -109,4 +109,74 @@ theorem sdist_le_pi (P Q : E) : sdist P Q ≤ Real.pi := Real.arccos_le_pi _
 theorem sdist_eq_zero_of_eq {P Q : E} (hP : OnSphere P) (h : P = Q) : sdist P Q = 0 := by
   subst h; exact sdist_self P hP
 
+/-- Spherical distance is symmetric (the inner product commutes). -/
+theorem sdist_comm (P Q : E) : sdist P Q = sdist Q P := by
+  unfold sdist; rw [real_inner_comm]
+
+/-- **Cosine of the spherical distance is the spherical cosine.**  Since
+`sdist P Q = arccos (scos P Q)` and the spherical cosine lies in `[-1, 1]` for unit
+vectors, applying `cos` recovers it.  This is the everyday bridge `cos (sdist) = scos`
+used to move between the metric (`sdist`) and algebraic (`scos`, hence inner product)
+descriptions of a configuration. -/
+theorem cos_sdist (P Q : E) (hP : OnSphere P) (hQ : OnSphere Q) :
+    Real.cos (sdist P Q) = scos P Q := by
+  rw [sdist, scos]
+  exact Real.cos_arccos (neg_one_le_scos P Q hP hQ) (scos_le_one P Q hP hQ)
+
+/-! ## Spherical circles and tangency
+
+With the metric layer in place we can define the basic objects a spherical Feuerbach
+argument manipulates: spherical circles as level sets of `scos`, and the spherical
+internal/external tangency relations on their centres and angular radii.  The key lemma
+`mem_sCircle_iff_sdist` shows the algebraic level-set definition coincides with the
+metric "set of points at spherical distance `ρ` from the centre", so the two views are
+interchangeable in tangency calculations. -/
+
+/-- A **spherical circle** with centre `O` (a model point) and angular radius `ρ`:
+the level set of the spherical cosine, `{P : OnSphere P ∧ scos P O = cos ρ}`.  For
+`ρ ∈ [0, π]` this is exactly the set of model points at spherical distance `ρ` from `O`
+(`mem_sCircle_iff_sdist`). -/
+def sCircle (O : E) (ρ : ℝ) : Set E := {P | OnSphere P ∧ scos P O = Real.cos ρ}
+
+/-- **The level-set circle is the metric circle.**  For a centre `O` on the sphere and
+an angular radius `ρ ∈ [0, π]`, a model point `P` lies on `sCircle O ρ` exactly when its
+spherical distance to `O` is `ρ`.  This identifies the algebraic definition (a level set
+of the inner product) with the geometric one (a sphere of fixed spherical radius). -/
+theorem mem_sCircle_iff_sdist {O : E} (hO : OnSphere O) {ρ : ℝ}
+    (hρ0 : 0 ≤ ρ) (hρπ : ρ ≤ Real.pi) (P : E) :
+    P ∈ sCircle O ρ ↔ (OnSphere P ∧ sdist P O = ρ) := by
+  simp only [sCircle, Set.mem_setOf_eq]
+  constructor
+  · rintro ⟨hP, hcos⟩
+    refine ⟨hP, ?_⟩
+    have hs : sdist P O = Real.arccos (scos P O) := rfl
+    rw [hs, hcos]
+    exact Real.arccos_cos hρ0 hρπ
+  · rintro ⟨hP, hd⟩
+    exact ⟨hP, by rw [← cos_sdist P O hP hO, hd]⟩
+
+/-- Two spherical circles `(O₁, ρ₁)` and `(O₂, ρ₂)` are **internally tangent** when the
+spherical distance between their centres equals the absolute difference of their angular
+radii — the non-Euclidean analogue of the Euclidean `d = |r₁ − r₂|`. -/
+def InternallyTangent (O₁ : E) (ρ₁ : ℝ) (O₂ : E) (ρ₂ : ℝ) : Prop :=
+  sdist O₁ O₂ = |ρ₁ - ρ₂|
+
+/-- Two spherical circles `(O₁, ρ₁)` and `(O₂, ρ₂)` are **externally tangent** when the
+spherical distance between their centres equals the sum of their angular radii — the
+non-Euclidean analogue of the Euclidean `d = r₁ + r₂`. -/
+def ExternallyTangent (O₁ : E) (ρ₁ : ℝ) (O₂ : E) (ρ₂ : ℝ) : Prop :=
+  sdist O₁ O₂ = ρ₁ + ρ₂
+
+/-- Internal tangency is symmetric in the two circles. -/
+theorem internallyTangent_comm (O₁ : E) (ρ₁ : ℝ) (O₂ : E) (ρ₂ : ℝ) :
+    InternallyTangent O₁ ρ₁ O₂ ρ₂ ↔ InternallyTangent O₂ ρ₂ O₁ ρ₁ := by
+  unfold InternallyTangent
+  rw [sdist_comm, abs_sub_comm]
+
+/-- External tangency is symmetric in the two circles. -/
+theorem externallyTangent_comm (O₁ : E) (ρ₁ : ℝ) (O₂ : E) (ρ₂ : ℝ) :
+    ExternallyTangent O₁ ρ₁ O₂ ρ₂ ↔ ExternallyTangent O₂ ρ₂ O₁ ρ₁ := by
+  unfold ExternallyTangent
+  rw [sdist_comm, add_comm]
+
 end FeuerbachsTheoremOQ04

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -1,5 +1,40 @@
 # feuerbachs-theorem-oq-04 — Feuerbach's Theorem in Non-Euclidean Geometry
 
+## Session 2026-06-28 (researcher-1): spherical circles + tangency layer [BUILD]
+
+**Mode**: ACT (CONTINUE — executed researcher-2's next-steps 1 & 2: "define spherical
+circle as level set of scos" and "spherical tangency relations"). **Outcome**: PROGRESS
+— extended `FeuerbachsTheoremOQ04.lean` (+8 decls, ~70 L) with the spherical-circle and
+tangency layer on top of the existing metric foundations. **Docker build VERIFIED**
+(`docker-build.sh Proofs.FeuerbachsTheoremOQ04`); **0-sorry, 0-axiom**, no native_decide
+(only `Real.cos_arccos`/`Real.arccos_cos`, `real_inner_comm`, `abs_sub_comm` etc.).
+
+### What was delivered (appended to `FeuerbachsTheoremOQ04.lean`)
+- **`sdist_comm`** : `sdist P Q = sdist Q P` (via `real_inner_comm`).
+- **`cos_sdist`** : `Real.cos (sdist P Q) = scos P Q` for unit `P,Q` — the bridge between
+  the metric (`sdist`) and algebraic (`scos`/inner product) descriptions, from
+  `Real.cos_arccos` + the `[-1,1]` bounds.
+- **`def sCircle (O ρ) := {P | OnSphere P ∧ scos P O = Real.cos ρ}`** — spherical circle
+  as a level set of the spherical cosine.
+- **`mem_sCircle_iff_sdist`** (headline) : for `O` on the sphere and `ρ ∈ [0,π]`,
+  `P ∈ sCircle O ρ ↔ (OnSphere P ∧ sdist P O = ρ)`. Identifies the algebraic level-set
+  circle with the metric "points at spherical distance ρ", so tangency calculations can
+  switch freely between the two views. Proof: `Real.arccos_cos` (fwd) / `cos_sdist` (bwd).
+- **`def InternallyTangent`** (`sdist O₁ O₂ = |ρ₁−ρ₂|`) and **`def ExternallyTangent`**
+  (`sdist O₁ O₂ = ρ₁+ρ₂`) — the non-Euclidean tangency relations.
+- **`internallyTangent_comm`**, **`externallyTangent_comm`** : both tangency relations are
+  symmetric in the two circles (via `sdist_comm` + `abs_sub_comm`/`add_comm`).
+
+### Next steps (unchanged direction)
+1. **Tangent-point existence**: for externally/internally tangent circles, exhibit the
+   unique common point on the geodesic between centres (spherical slerp
+   `P = cos ρ₁ · O₁ + …`) and prove it lies on both `sCircle`s — this is the genuinely
+   harder, construction-heavy step (needs unit-norm + level-set verification).
+2. Build the spherical incircle and nine-point circle for a spherical triangle.
+3. Attempt the spherical Feuerbach tangency itself.
+
+BLOCKER (hyperbolic side, unchanged): no Mathlib hyperbolic metric — spherical model only.
+
 ## Session 2026-06-28 (researcher-2): spherical model foundations [SURVEY + BUILD]
 
 Fresh stub: `problemStatement.formal` was literally "(formal statement to be added)",

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "feuerbachs-theorem-oq-04",
   "title": "Feuerbach's Theorem in Non-Euclidean Geometry",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -19,16 +19,16 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-04-22T12:51:58.293Z",
-    "iteration": 2,
-    "focus": "Spherical model chosen; metric foundations formalized (chord-cosine bridge + spherical distance well-definedness).",
+    "phase": "ACT",
+    "since": "2026-06-28T10:40:00.000Z",
+    "iteration": 3,
+    "focus": "Spherical circles (level sets of scos) + internal/external tangency relations formalized on top of the metric layer; level-set circle identified with the metric circle (mem_sCircle_iff_sdist).",
     "blockers": [],
-    "nextAction": "Construct spherical circle / incircle / nine-point primitives on top of scos/sdist; state and attempt the spherical tangency criterion sdist O1 O2 = |rho1 - rho2|.",
+    "nextAction": "Tangent-point existence: exhibit the unique common point on the geodesic between centres for tangent circles (spherical slerp) and verify it lies on both sCircles; then build spherical incircle / nine-point circle and attempt the spherical Feuerbach tangency.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
@@ -90,7 +90,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.293Z",
-  "lastUpdate": "2026-06-28T00:00:00.000Z",
+  "lastUpdate": "2026-06-28T10:40:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Extends the spherical-model foundation for `feuerbachs-theorem-oq-04` (Feuerbach's Theorem in Non-Euclidean Geometry) with the **spherical-circle and tangency layer** a Feuerbach argument manipulates. All new declarations are **0-sorry / 0-axiom**, no `native_decide`; the full file builds via `docker-build.sh Proofs.FeuerbachsTheoremOQ04`.

This executes the prior session's documented next steps ("define spherical circle as level set of `scos`" and "spherical tangency relations") on top of the existing metric primitives (`scos`, `sdist`, chord–cosine bridge).

## What's added (+8 decls, ~70 lines)

- **`sdist_comm`** — spherical distance is symmetric (via `real_inner_comm`).
- **`cos_sdist`** — `Real.cos (sdist P Q) = scos P Q` for unit `P, Q`: the bridge between the metric (`sdist`) and algebraic (`scos`/inner product) descriptions of a configuration.
- **`def sCircle O ρ := {P | OnSphere P ∧ scos P O = Real.cos ρ}`** — spherical circle as a level set of the spherical cosine.
- **`mem_sCircle_iff_sdist`** (headline) — for `O` on the sphere and `ρ ∈ [0, π]`, `P ∈ sCircle O ρ ↔ (OnSphere P ∧ sdist P O = ρ)`: identifies the algebraic level-set circle with the metric "points at spherical distance ρ", so tangency calculations switch freely between the two views.
- **`def InternallyTangent`** (`sdist O₁ O₂ = |ρ₁ − ρ₂|`) and **`def ExternallyTangent`** (`sdist O₁ O₂ = ρ₁ + ρ₂`) — the non-Euclidean tangency relations, each proved **symmetric** in the two circles (`internallyTangent_comm`, `externallyTangent_comm`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremOQ04` → **Build succeeded**.
- 0 `sorry`, 0 `axiom`, 0 `native_decide` (the single `grep sorry` hit is in the docstring).

## Status

Advances the problem phase **ORIENT → ACT**; the parent conjecture (spherical Feuerbach tangency) remains open. Next steps (documented in `knowledge.md`): tangent-point existence on the geodesic between centres (spherical slerp), then spherical incircle / nine-point circle, then the tangency itself. Hyperbolic side remains blocked (no Mathlib hyperbolic metric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)