### PR TITLE
audit(erdos-57-oq-04): fix axiom undercount (verified→axiomatized, axiomCount 0→1)

### DIFF
--- a/src/data/proofs/erdos-57-oq-04/meta.json
+++ b/src/data/proofs/erdos-57-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://erdosproblems.com/57",
     "date": "2026-06-27",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "graph-theory",
@@ -18,9 +18,9 @@
       "mathlib-gap"
     ],
     "proofRepoPath": "Proofs/Erdos57Problem.lean",
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 343,
     "dateAdded": "06/27/26",
     "mathlibDependencies": [


### PR DESCRIPTION
## Integrity Issue

**Proof**: `erdos-57-oq-04`
**Severity**: HIGH — a `verified`/`original` claim on a file carrying an open-conjecture axiom.

The entry's `proofRepoPath` is `Proofs/Erdos57Problem.lean`, which contains the open axiom `erdos_57` (the deep Liu–Montgomery theorem, χ(G)=∞ ⟹ ∑1/aᵢ=∞). The structured fields described the **whole file** as axiom-free verified, while the file carries one `axiom` declaration.

## Evidence

- `grep -n "^axiom " proofs/Proofs/Erdos57Problem.lean` → `63:axiom erdos_57 (G : SimpleGraph V) :` (exactly 1 axiom, 0 sorries, 0 True stubs).
- The **sibling parent entry `erdos-57`** points at the *identical* file and correctly reports `status=axiomatized`, `badge=axiom`, `axiomCount=1`. The two entries disagreed on the same source file.
- `scripts/auditor/find-targets.ts` flagged this 6×: "axiom undercount: claims 0, actual declarations 1".
- The entry's own prose (`description`, `assumptions`, `relatedProblems`) already discloses `erdos_57` honestly — only the badge/status/axiomCount were out of sync.

| Field | Before | After |
|-------|--------|-------|
| `status` | `verified` | `axiomatized` |
| `badge` | `original` | `axiom` |
| `axiomCount` | `0` | `1` |
| `sorries` | `0` | `0` (unchanged) |

Per the Axiom Integrity Policy: `axiomCount` must reflect ALL assumptions, and open-conjecture-level results axiomatized are always `axiomatized`. The contributed crux lemma `exists_odd_cycle_of_odd_closed_walk` remains genuinely sorry-free; this PR only corrects the file-level classification fields.

---
Discovered during gallery integrity audit.