### PR TITLE
research(erdos-985-incomplete-01): formalize the φ(p−1) primitive-root count [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos985Problem.lean
+++ b/proofs/Proofs/Erdos985Problem.lean
@@ -213,6 +213,38 @@ theorem erdos_985_iff_all_odd_primes :
    among 1,...,p-1, we expect roughly φ(p-1)/log(p) prime primitive roots. For p
    large enough, this is > 0, suggesting the conjecture should hold. -/
 
+/-- **The number of primitive roots modulo `p` is exactly `φ(p-1)`.**
+
+    This is the verified, unconditional starting point of the density heuristic
+    quoted above: in the cyclic group `(ℤ/pℤ)ˣ` of order `p - 1`, the elements of
+    maximal order `p - 1` (i.e. the generators = primitive roots) number exactly
+    `φ(p - 1)`, since a cyclic group of order `n` has `φ(n)` generators.
+
+    Proof: `(ℤ/pℤ)ˣ` is cyclic with `Fintype.card = p - 1` (`ZMod.card_units`), so
+    `IsCyclic.card_orderOf_eq_totient` (the count of elements of order `d ∣ |G|` in
+    a finite cyclic group is `φ(d)`) applied with `d = p - 1` gives the result. -/
+theorem card_primitiveRoots_units (p : ℕ) [Fact p.Prime] :
+    (Finset.univ.filter (fun u : (ZMod p)ˣ => orderOf u = p - 1)).card
+      = Nat.totient (p - 1) := by
+  have hd : (p - 1) ∣ Fintype.card (ZMod p)ˣ := by rw [ZMod.card_units p]
+  simpa using IsCyclic.card_orderOf_eq_totient (α := (ZMod p)ˣ) hd
+
+/-- **There is at least one primitive root modulo `p`** (counting form).
+
+    A direct corollary of `card_primitiveRoots_units`: for any prime `p`, the count
+    `φ(p - 1)` of primitive roots is strictly positive (`Nat.totient_pos`, since
+    `p - 1 ≥ 1`), so the filtered set is nonempty. This recovers the existence half
+    of `exists_primitiveRoot_lt` from the exact count, and quantifies *how many*
+    primitive roots the prime witness in Erdős 985 must be hunted among. -/
+theorem exists_primitiveRoot_units (p : ℕ) (hp : p.Prime) :
+    ∃ u : (ZMod p)ˣ, orderOf u = p - 1 := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hpos : 0 < (Finset.univ.filter (fun u : (ZMod p)ˣ => orderOf u = p - 1)).card := by
+    rw [card_primitiveRoots_units p]
+    exact Nat.totient_pos.mpr (by have := hp.two_le; omega)
+  obtain ⟨u, hu⟩ := Finset.card_pos.mp hpos
+  exact ⟨u, (Finset.mem_filter.mp hu).2⟩
+
 /- ## Connection to Other Problems -/
 
 /- **Caveat on Artin's conjecture.** It is tempting to claim that the

--- a/src/data/proofs/erdos-985/meta.json
+++ b/src/data/proofs/erdos-985/meta.json
@@ -55,12 +55,14 @@
       "Removed the mathematically invalid artin_implies_erdos_985 (qualitative Artin does NOT imply the pointwise conclusion); replaced with an honest caveat and the genuine Heath-Brown consequence",
       "heath_brown_theorem axiom: {2,3,5} covers infinitely many primes",
       "erdos_985_conjecture axiom: main open conjecture",
-      "erdos_985_iff_all_odd_primes equivalence theorem"
+      "erdos_985_iff_all_odd_primes equivalence theorem",
+      "card_primitiveRoots_units: the number of primitive roots modulo p equals φ(p-1) exactly (verified, 0-axiom) — formalizes the previously-informal count underlying the density heuristic, via IsCyclic.card_orderOf_eq_totient on the cyclic group (ZMod p)ˣ of order p-1",
+      "exists_primitiveRoot_units: φ(p-1) > 0 gives a primitive root in (ZMod p)ˣ (verified, 0-axiom) — recovers existence from the exact count"
     ],
     "axiomCount": 2,
-    "lineCount": 298,
-    "assumptions": "2 axioms: heath_brown_theorem (Heath-Brown 1986, unconditional) and erdos_985_conjecture (the open problem itself). 0 sorries. All non-axiom results are machine-checked over [propext, Classical.choice, Quot.sound] only — no native_decide / Lean.ofReduceBool (concrete orders use kernel `decide` via `orderOf_eq_iff`).",
-    "theoremCount": 20,
+    "lineCount": 330,
+    "assumptions": "2 axioms: heath_brown_theorem (Heath-Brown 1986, unconditional) and erdos_985_conjecture (the open problem itself). 0 sorries. All non-axiom results are machine-checked over [propext, Classical.choice, Quot.sound] only — no native_decide / Lean.ofReduceBool (concrete orders use kernel `decide` via `orderOf_eq_iff`; the primitive-root count uses IsCyclic.card_orderOf_eq_totient).",
+    "theoremCount": 22,
     "definitionCount": 3
   },
   "overview": {
@@ -176,9 +178,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 298,
+    "lineCount": 330,
     "axiomCount": 2,
-    "theoremCount": 20,
+    "theoremCount": 22,
     "definitionCount": 3,
     "path": "Proofs/Erdos985Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary
Research session for **erdos-985-incomplete-01** (a completion problem for the
gallery entry *Erdős Problem #985: Prime Primitive Roots*).

## Pre-work assessment
- **Axiom question**: the file carries 2 axioms — `heath_brown_theorem`
  (deep 1986 analytic NT result, far beyond current Mathlib) and
  `erdos_985_conjecture` (the OPEN problem itself). **Neither is eliminable.**
  Per the axiom-integrity policy I did not touch them and did not add scaffolding
  on top of them.
- **Value question**: the main conjecture is open and cannot be closed here. The
  honest progress available is verified *unconditional* content.

## Progress
The file's "Density Considerations" section asserted **informally** that there
are `φ(p−1)` primitive roots modulo `p`. This was never formalized. Now it is:

- **`card_primitiveRoots_units`** — `#{u : (ZMod p)ˣ | orderOf u = p−1} = φ(p−1)`.
  Proof: `(ZMod p)ˣ` is cyclic of order `p−1` (`ZMod.card_units`), and a finite
  cyclic group has exactly `φ(d)` elements of each order `d ∣ |G|`
  (`IsCyclic.card_orderOf_eq_totient`).
- **`exists_primitiveRoot_units`** — `φ(p−1) > 0 ⇒ ∃ u : (ZMod p)ˣ, orderOf u = p−1`,
  recovering existence from the exact count.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos985Problem` ✅
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]`
  only — **no `native_decide`, no `sorry`**. The file's honesty claim is preserved.
- Declared axiom count **unchanged at 2**; `theoremCount` 20→22.

## Files modified
- `proofs/Proofs/Erdos985Problem.lean` (+2 verified theorems)
- `src/data/proofs/erdos-985/meta.json` (counts + contributions + assumptions note)

## Status
**Outcome**: progress (verified, 0-axiom additions; open conjecture remains
axiomatized as it must). No follow-up OQ proposed — the count is a supporting
fact, not a new research direction.

🤖 Generated by researcher-7