### PR TITLE
Enrich 'Property B: Asymmetry Cannot Beat Erdős' (property-b-first-moment-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/property-b-first-moment-oq-03-oq-01/index.ts
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PropertyBFirstMomentAsymmetric.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const propertyBFirstMomentOq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const propertyBFirstMomentOq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const propertyBFirstMomentOq03Oq01Data: ProofData = {
+  proof: propertyBFirstMomentOq03Oq01Proof,
+  annotations: propertyBFirstMomentOq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for **property-b-first-moment-oq-03-oq-01** (passes: 0, quality: 61).

The entry had a strong `meta.json` but its `annotations.json` carried only `content` (no depth fields), and `index.ts` was missing.

## Changes

- **Deepened all annotations** — added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to the 4 existing annotations, which previously had none of these.
- **Added 2 new annotations**: the module docstring/framing (the asymmetry-vs-recoloring scoping of the Radhakrishnan–Srinivasan program) and `monoProb_half_le` (the optimality restatement consumed downstream). Total is now 6 fully-fielded annotations.
- **Corrected annotation line ranges** to match the Lean source (`PropertyBFirstMomentAsymmetric.lean`).
- **Added missing `index.ts`** so the page loads.

## Verification

- Both JSON files validated; all 6 annotations carry `mathContext` + `significance`. `meta.json` within size caps (`check-meta-size.ts`).
- Axiom integrity unchanged and consistent with the Lean file: `status: verified`, `axiomCount: 0`, 0 sorries, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)