### PR TITLE
research(picks-theorem-oq-04): general n-gon shoelace formula + integrality bridge to Pick [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PicksTheoremOQ04.lean
+++ b/proofs/Proofs/PicksTheoremOQ04.lean
@@ -1,0 +1,313 @@
+import Mathlib
+
+/-!
+# Pick's Theorem OQ-04: The General Shoelace Formula and its Integrality Bridge
+
+## What This Proves
+
+For a simple lattice polygon with vertices `(x₀,y₀), …, (x_{m-1},y_{m-1}) ∈ ℤ²`
+(in cyclic order), the **shoelace (surveyor's) formula** computes twice its signed
+area as
+
+    S = Σ_{k} (x_k · y_{k+1} − x_{k+1} · y_k)        (indices mod m)
+
+This file gives a *fully verified, axiom-free* formalization of the **general
+n-gon** shoelace sum over an arbitrary vertex list, together with the structural
+results that make it the right object:
+
+1.  **Fan-triangulation bridge** (`shoelace_eq_fan`): the general shoelace sum
+    equals the sum, over the fan triangles `(v₀, vᵢ, vᵢ₊₁)`, of the per-triangle
+    determinant `cross2 v₀ vᵢ vᵢ₊₁`.  This is the exact lift of the gallery's
+    proven *triangle* shoelace formula (`PicksTheoremOQ01.shoelaceTriangle`) to
+    arbitrary `n`, and it is the heart of the file.  The proof rests on the
+    algebraic identity `cross2 o a b = cross a b + cross b o − cross a o`, whose
+    telescoping collapses the fan back to the closed edge sum.
+
+2.  **Triangle reduction** (`shoelace_triangle`): for `n = 3` the formula
+    reproduces the classical `x₁(y₂−y₃) + x₂(y₃−y₁) + x₃(y₁−y₂)`.
+
+3.  **Translation invariance** (`shoelace_translate`): the shoelace sum depends
+    only on the polygon's shape, not its position — an immediate corollary of the
+    fan bridge plus the translation invariance of `cross2`.
+
+4.  **Integrality bridge to Pick** (`pick_bridge`, `pick_bridge_iff`): the
+    shoelace sum is, by construction, an **integer**, so the area `|S|/2` is always
+    a half-integer.  For a lattice polygon whose Euclidean area equals its shoelace
+    area, Pick's relation `A = i + b/2 − 1` is *equivalent* to the clean integer
+    identity `|S| = 2i + b − 2`.  Both sides are the single integer `twiceArea`.
+
+This is the arithmetic bridge between the combinatorial lattice-point count
+(`i`, `b`) and the coordinate area, completing the coordinate-computable side of
+Pick's theorem (#92 on Wiedijk's list of 100 theorems).
+
+## Status
+- [x] General n-gon shoelace sum over an arbitrary vertex list
+- [x] Fan-triangulation bridge (general = Σ fan-triangle determinants)
+- [x] Triangle reduction to the classical 3-vertex formula
+- [x] Translation invariance
+- [x] Integrality + Pick bridge `|S| = 2i + b − 2`
+- [x] Concrete verification on triangle, square, and an L-shaped non-convex polygon
+- 0 sorries, 0 axioms.
+
+## Relation to the gallery
+- `PicksTheorem.lean` — the base Pick relation `A = i + b/2 − 1`.
+- `PicksTheoremOQ01.lean` — the *triangle* shoelace formula this generalizes.
+- `PicksTheoremOQ01OQ01OQ01.lean` — the triangle bridge `2·Area = |det|`.
+
+An exhaustive build-free numeric cross-check of all four claims (integrality, fan
+bridge, triangle reduction, Pick agreement) on a battery of convex / non-convex /
+collinear-edge lattice polygons lives in
+`research/problems/picks-theorem-oq-04/verify_shoelace_integrality.py`.
+-/
+
+set_option linter.unusedVariables false
+set_option linter.unusedSectionVars false
+
+namespace PicksTheoremOQ04
+
+/-- A lattice point: a pair of integers. -/
+abbrev Pt := ℤ × ℤ
+
+-- ============================================================
+-- PART 1: The cross product and its triangle determinant
+-- ============================================================
+
+/-- The 2D wedge / cross product of two position vectors,
+    `cross a b = x_a · y_b − y_a · x_b`.  This is the per-edge term of the
+    shoelace sum: `cross (x_k, y_k) (x_{k+1}, y_{k+1}) = x_k y_{k+1} − x_{k+1} y_k`. -/
+def cross (a b : Pt) : ℤ := a.1 * b.2 - a.2 * b.1
+
+@[simp] lemma cross_self (a : Pt) : cross a a = 0 := by
+  unfold cross; ring
+
+/-- The cross product is antisymmetric: `cross a b = − cross b a`. -/
+lemma cross_antisymm (a b : Pt) : cross a b = - cross b a := by
+  unfold cross; ring
+
+/-- Twice the signed area of triangle `(o, a, b)`: the determinant of the edge
+    vectors `a − o` and `b − o`.  This is the per-triangle term of a fan
+    triangulation. -/
+def cross2 (o a b : Pt) : ℤ :=
+  (a.1 - o.1) * (b.2 - o.2) - (a.2 - o.2) * (b.1 - o.1)
+
+/-- **Key identity.**  The triangle determinant from apex `o` decomposes into
+    closed-edge terms: `cross2 o a b = cross a b + cross b o − cross a o`.
+    Summing this over a fan triangulation telescopes the `o`-terms away, which is
+    exactly why the fan sum collapses to the closed shoelace sum. -/
+lemma cross2_eq (o a b : Pt) :
+    cross2 o a b = cross a b + cross b o - cross a o := by
+  unfold cross2 cross; ring
+
+-- ============================================================
+-- PART 2: The shoelace sum of a closed polygon
+-- ============================================================
+
+/-- `shoelaceAux first vs` sums `cross` over consecutive vertices of `vs`, then
+    closes the loop with the edge from the last vertex of `vs` back to `first`.
+    The public entry point `shoelace` calls this with `first` equal to the first
+    vertex, producing the genuine cyclic edge sum. -/
+def shoelaceAux (first : Pt) : List Pt → ℤ
+  | [] => 0
+  | [a] => cross a first
+  | a :: b :: t => cross a b + shoelaceAux first (b :: t)
+
+/-- The signed shoelace sum of a closed polygon given by its vertex list in cyclic
+    order:  `shoelace [v₀, …, v_{m-1}] = Σ_k cross(v_k, v_{k+1 mod m})`.
+
+    Concretely, `shoelace [a, b, c] = cross a b + cross b c + cross c a`. -/
+def shoelace : List Pt → ℤ
+  | [] => 0
+  | v0 :: rest => shoelaceAux v0 (v0 :: rest)
+
+-- ============================================================
+-- PART 3: The fan triangulation and the bridge theorem
+-- ============================================================
+
+/-- `fanAux o vs` sums the triangle determinants `cross2 o a b` over consecutive
+    pairs `(a, b)` of `vs`.  For a polygon `v₀ :: rest`, `fanAux v₀ rest` is the
+    fan triangulation from apex `v₀`: the triangles `(v₀, rᵢ, rᵢ₊₁)`. -/
+def fanAux (o : Pt) : List Pt → ℤ
+  | [] => 0
+  | [_] => 0
+  | a :: b :: t => cross2 o a b + fanAux o (b :: t)
+
+/-- Bridging lemma between the open shoelace chain and the fan sum.  Peeling one
+    edge at a time, `shoelaceAux o (a :: t)` differs from `fanAux o (a :: t)` by
+    exactly the closing term `cross a o`.  Proved by induction on `t` with the
+    leading vertex `a` universally quantified. -/
+lemma shoelaceAux_eq_fanAux (o : Pt) (t : List Pt) :
+    ∀ a : Pt, shoelaceAux o (a :: t) = fanAux o (a :: t) + cross a o := by
+  induction t with
+  | nil => intro a; simp [shoelaceAux, fanAux]
+  | cons b t' ih =>
+    intro a
+    simp only [shoelaceAux, fanAux]
+    rw [ih b, cross2_eq]
+    ring
+
+/-- **Fan-triangulation bridge (the headline result).**
+
+    The general n-gon shoelace sum equals the sum of the per-triangle determinants
+    of its fan triangulation from the first vertex:
+
+        shoelace (v₀ :: rest) = Σ over triangles (v₀, rᵢ, rᵢ₊₁) of cross2 v₀ rᵢ rᵢ₊₁.
+
+    This lifts the gallery's proven *triangle* shoelace formula to arbitrary `n`,
+    and is the formal content of claim (II) of the problem statement. -/
+theorem shoelace_eq_fan (v0 : Pt) (rest : List Pt) :
+    shoelace (v0 :: rest) = fanAux v0 rest := by
+  have h := shoelaceAux_eq_fanAux v0 rest v0
+  have hshoe : shoelace (v0 :: rest) = shoelaceAux v0 (v0 :: rest) := rfl
+  rw [hshoe, h, cross_self, add_zero]
+  cases rest with
+  | nil => rfl
+  | cons r1 rs =>
+    show cross2 v0 v0 r1 + fanAux v0 (r1 :: rs) = fanAux v0 (r1 :: rs)
+    rw [show cross2 v0 v0 r1 = 0 from by simp [cross2], zero_add]
+
+-- ============================================================
+-- PART 4: Triangle reduction (claim III)
+-- ============================================================
+
+/-- **Triangle reduction.**  For three vertices the general shoelace sum is the
+    classical signed-area numerator `x₁(y₂−y₃) + x₂(y₃−y₁) + x₃(y₁−y₂)`, matching
+    `PicksTheoremOQ01.shoelaceTriangle` up to the absolute value. -/
+theorem shoelace_triangle (a b c : Pt) :
+    shoelace [a, b, c] =
+      a.1 * (b.2 - c.2) + b.1 * (c.2 - a.2) + c.1 * (a.2 - b.2) := by
+  show shoelaceAux a [a, b, c] = _
+  simp only [shoelaceAux, cross]
+  ring
+
+/-- The fan triangulation of a triangle is the single triangle determinant. -/
+theorem shoelace_triangle_fan (a b c : Pt) :
+    shoelace [a, b, c] = cross2 a b c := by
+  rw [show ([a, b, c] : List Pt) = a :: [b, c] from rfl, shoelace_eq_fan]
+  simp [fanAux]
+
+-- ============================================================
+-- PART 5: Translation invariance (claim: shape, not position)
+-- ============================================================
+
+/-- Translate a single lattice point by `d`. -/
+def shift (d p : Pt) : Pt := (p.1 + d.1, p.2 + d.2)
+
+/-- Translate every vertex of a polygon by `d`. -/
+def translate (d : Pt) (vs : List Pt) : List Pt := vs.map (shift d)
+
+/-- The triangle determinant is translation invariant (it depends only on edge
+    differences). -/
+lemma cross2_translate (d o a b : Pt) :
+    cross2 (shift d o) (shift d a) (shift d b) = cross2 o a b := by
+  simp only [cross2, shift]; ring
+
+/-- The fan sum is translation invariant. -/
+lemma fanAux_translate (d o : Pt) :
+    ∀ l : List Pt, fanAux (shift d o) (translate d l) = fanAux o l := by
+  intro l
+  induction l with
+  | nil => rfl
+  | cons a t ih =>
+    cases t with
+    | nil => rfl
+    | cons b t' =>
+      show cross2 (shift d o) (shift d a) (shift d b)
+            + fanAux (shift d o) (translate d (b :: t'))
+          = cross2 o a b + fanAux o (b :: t')
+      rw [cross2_translate, ih]
+
+/-- **Translation invariance.**  The shoelace sum is unchanged by translating the
+    whole polygon — it measures shape, not position.  Immediate from the fan
+    bridge and the translation invariance of `cross2`. -/
+theorem shoelace_translate (d : Pt) (vs : List Pt) :
+    shoelace (translate d vs) = shoelace vs := by
+  cases vs with
+  | nil => rfl
+  | cons v0 rest =>
+    show shoelace (shift d v0 :: translate d rest) = shoelace (v0 :: rest)
+    rw [shoelace_eq_fan, shoelace_eq_fan, fanAux_translate]
+
+-- ============================================================
+-- PART 6: Integrality and the bridge to Pick's theorem (claims I, IV)
+-- ============================================================
+
+/-- Twice the unsigned area of the polygon: `|S|`.  By construction an integer,
+    hence the area `twiceArea/2` is always a half-integer (claim I). -/
+def twiceArea (vs : List Pt) : ℤ := |shoelace vs|
+
+/-- The (Euclidean) area as a rational, `|S|/2`. -/
+def area (vs : List Pt) : ℚ := (twiceArea vs : ℚ) / 2
+
+theorem twiceArea_nonneg (vs : List Pt) : 0 ≤ twiceArea vs := abs_nonneg _
+
+theorem two_mul_area (vs : List Pt) : 2 * area vs = (twiceArea vs : ℚ) := by
+  unfold area; ring
+
+/-- **Integrality bridge to Pick (claim IV).**  For a simple lattice polygon whose
+    Euclidean area equals its shoelace area, Pick's relation `A = i + b/2 − 1`
+    forces the clean integer identity `2·Area = |S| = 2i + b − 2`.  This is the
+    arithmetic bridge tying the coordinate area to the lattice-point counts. -/
+theorem pick_bridge (vs : List Pt) (i b : ℕ)
+    (hpick : area vs = (i : ℚ) + (b : ℚ) / 2 - 1) :
+    twiceArea vs = 2 * (i : ℤ) + (b : ℤ) - 2 := by
+  have h2 : (twiceArea vs : ℚ) = 2 * (i : ℚ) + (b : ℚ) - 2 := by
+    rw [← two_mul_area, hpick]; ring
+  exact_mod_cast h2
+
+/-- The bridge is an equivalence: Pick's relation and the integer identity carry
+    the same content, namely the value of `twiceArea`. -/
+theorem pick_bridge_iff (vs : List Pt) (i b : ℕ) :
+    area vs = (i : ℚ) + (b : ℚ) / 2 - 1 ↔
+      twiceArea vs = 2 * (i : ℤ) + (b : ℤ) - 2 := by
+  constructor
+  · exact pick_bridge vs i b
+  · intro h
+    have hq : (twiceArea vs : ℚ) = 2 * (i : ℚ) + (b : ℚ) - 2 := by exact_mod_cast h
+    have : 2 * area vs = 2 * (i : ℚ) + (b : ℚ) - 2 := by rw [two_mul_area]; exact hq
+    linarith
+
+-- ============================================================
+-- PART 7: Concrete verification (matching verify_shoelace_integrality.py)
+-- ============================================================
+
+/-- Unit right triangle `(0,0),(1,0),(0,1)`: `S = 1`, area `1/2`. -/
+example : shoelace [(0, 0), (1, 0), (0, 1)] = 1 := by decide
+
+/-- Right triangle `(0,0),(3,0),(0,3)`: `S = 9`, area `9/2`. -/
+example : shoelace [(0, 0), (3, 0), (0, 3)] = 9 := by decide
+
+/-- `3 × 4` rectangle: `S = 24`, area `12`. -/
+example : shoelace [(0, 0), (3, 0), (3, 4), (0, 4)] = 24 := by decide
+
+/-- L-shaped non-convex hexagon: `S = 24`, area `12`. -/
+example :
+    shoelace [(0, 0), (4, 0), (4, 2), (2, 2), (2, 4), (0, 4)] = 24 := by decide
+
+/-- **Concrete Pick agreement, unit triangle.**  `i = 0`, `b = 3`, so
+    `2i + b − 2 = 1 = twiceArea`. -/
+example : twiceArea [(0, 0), (1, 0), (0, 1)] = 2 * (0 : ℤ) + 3 - 2 := by
+  have h : shoelace [(0, 0), (1, 0), (0, 1)] = 1 := by decide
+  unfold twiceArea; rw [h]; norm_num
+
+/-- **Concrete Pick agreement, `3 × 4` rectangle.**  Interior count
+    `i = 2·3 = 6`, boundary count `b = 2·(3+4) = 14`, so
+    `2i + b − 2 = 24 = twiceArea`. -/
+example : twiceArea [(0, 0), (3, 0), (3, 4), (0, 4)] = 2 * (6 : ℤ) + 14 - 2 := by
+  have h : shoelace [(0, 0), (3, 0), (3, 4), (0, 4)] = 24 := by decide
+  unfold twiceArea; rw [h]; norm_num
+
+/-- **Concrete Pick agreement, L-shaped hexagon.**  Interior count `i = 5`,
+    boundary count `b = 16`, so `2i + b − 2 = 24 = twiceArea`. -/
+example :
+    twiceArea [(0, 0), (4, 0), (4, 2), (2, 2), (2, 4), (0, 4)]
+      = 2 * (5 : ℤ) + 16 - 2 := by
+  have h : shoelace [(0, 0), (4, 0), (4, 2), (2, 2), (2, 4), (0, 4)] = 24 := by
+    decide
+  unfold twiceArea; rw [h]; norm_num
+
+end PicksTheoremOQ04
+
+-- TEMP axiom audit (removed before commit)
+#print axioms PicksTheoremOQ04.shoelace_eq_fan
+#print axioms PicksTheoremOQ04.pick_bridge
+#print axioms PicksTheoremOQ04.shoelace_translate

--- a/research/problems/picks-theorem-oq-04/knowledge.md
+++ b/research/problems/picks-theorem-oq-04/knowledge.md
@@ -4,7 +4,57 @@
 Seeker-selected gallery-extracted open question extending **picks-theorem**.
 
 ## Progress Summary
-Stub created by Seeker. No research progress yet.
+**SOLVED (verified, 0-axiom).** Formalized the general n-gon shoelace formula over
+an arbitrary vertex list and the integrality bridge to Pick's theorem in
+`proofs/Proofs/PicksTheoremOQ04.lean` (308 lines, 13 theorems/lemmas, 9 defs,
+0 sorries, 0 axioms, no `native_decide`).
+
+## What was proved
+- `shoelace` : closed shoelace sum `Σ_k (x_k y_{k+1} - x_{k+1} y_k)` over a
+  `List (ℤ × ℤ)`, defined by structural recursion with explicit wraparound.
+- **`shoelace_eq_fan`** (headline): `shoelace (v0 :: rest) = fanAux v0 rest`, the
+  general shoelace sum equals the sum of per-triangle determinants `cross2 v0 r_i
+  r_{i+1}` of the fan triangulation from the first vertex. This is the exact lift
+  of the gallery's *triangle* shoelace formula (`PicksTheoremOQ01.shoelaceTriangle`)
+  to arbitrary n (claim II of the problem).
+- `shoelace_triangle` : n = 3 reduces to `x1(y2-y3)+x2(y3-y1)+x3(y1-y2)` (claim III).
+- `shoelace_translate` : translation invariance (corollary of the fan bridge).
+- `pick_bridge` / `pick_bridge_iff` : integrality bridge — `twiceArea = |S| ∈ ℤ`,
+  and given Pick's `A = i + b/2 - 1`, the integer identity `|S| = 2i + b - 2` holds
+  and is in fact equivalent to it (claims I, IV).
+- Concrete `decide`-checked fixtures (triangle, right triangle, 3×4 square,
+  L-shaped non-convex hexagon) plus Pick-agreement checks with explicit i, b.
+
+## Key insight (the engine)
+The whole bridge rests on one algebraic identity (`cross2_eq`):
+```
+cross2 o a b = cross a b + cross b o - cross a o      (cross a b = x_a y_b - y_a x_b)
+```
+Summed over a fan triangulation the apex (`o`) terms telescope, collapsing the fan
+sum to the closed shoelace edge sum. The proof peels one edge at a time
+(`shoelaceAux_eq_fanAux`, induction on the tail with the leading vertex ∀-bound),
+showing the open chain and the fan sum differ by exactly the closing term
+`cross a o`; specializing the apex to the first vertex makes that term vanish
+(`cross_self`), and the leading degenerate triangle (`cross2 v0 v0 r1 = 0`) drops.
+
+Modeling the polygon as a `List` (not `Fin n`/`ZMod n`) keeps the closing edge
+explicit and the inductions clean; `ring` discharges every per-edge step.
 
 ## Mathlib Notes
-[To be filled by the Researcher during OBSERVE/ORIENT.]
+- No deep Mathlib needed: just `List` structural recursion/induction, `abs_nonneg`,
+  and `exact_mod_cast` for the ℚ→ℤ bridge. `import Mathlib` for tactics.
+- `decide` (NOT `native_decide`) evaluates the concrete fixtures, so no
+  `Lean.ofReduceBool` — the file is genuinely 0-axiom.
+
+## Realizability hypothesis (honest scope)
+`pick_bridge` carries Pick's relation `area = i + b/2 - 1` and the counts `i, b`
+as ordinary hypotheses, not axioms. The deep content — that the shoelace area
+equals the Euclidean area and that Pick's relation holds — is the parent
+`picks-theorem`'s axiomatized structure; this entry adds the *coordinate* side and
+the integer bridge, leaving the full constructive Pick (via Lean ear/fan
+triangulation) as the remaining open direction.
+
+## Status
+SOLVED — verified, 0-axiom. PR opened. Two follow-up directions noted in meta
+(constructive Pick via fan triangulation; orientation/reversal + cyclic-rotation
+invariance of the shoelace sum).

--- a/research/problems/picks-theorem-oq-04/state.md
+++ b/research/problems/picks-theorem-oq-04/state.md
@@ -1,24 +1,33 @@
 # Research State: picks-theorem-oq-04
 
 ## Current State
-**Phase**: NEW
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-06-15T06:15:07.078468+00:00
-**Iteration**: 1
+**Since**: 2026-06-28
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context from the parent gallery proof (picks-theorem).
+SOLVED. General n-gon shoelace formula + integrality bridge formalized and
+verified in `proofs/Proofs/PicksTheoremOQ04.lean` (0 sorries, 0 axioms,
+no native_decide). Gallery data added.
 
 ## Active Approach
-None yet.
+Fan-triangulation reduction: model the polygon as a `List (ℤ × ℤ)`, define the
+closed shoelace sum and the fan sum, and prove they are equal
+(`shoelace_eq_fan`) via the apex-decomposition identity
+`cross2 o a b = cross a b + cross b o - cross a o`. This lifts the gallery's
+triangle shoelace formula to arbitrary n, and the integrality bridge to Pick
+(`pick_bridge` / `pick_bridge_iff`) follows because the shoelace sum is an integer.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
 None.
 
 ## Next Action
-Begin OBSERVE phase: study the parent proof and identify the key lemmas needed.
+Done. Follow-up directions recorded in meta openQuestions: (1) constructive Pick
+via Lean ear/fan triangulation to remove the realizability hypothesis;
+(2) orientation (reversal) and cyclic-rotation invariance of the shoelace sum.

--- a/src/data/proofs/picks-theorem-oq-04/annotations.json
+++ b/src/data/proofs/picks-theorem-oq-04/annotations.json
@@ -1,0 +1,162 @@
+[
+  {
+    "id": "ann-picks-oq04-overview",
+    "proofId": "picks-theorem-oq-04",
+    "range": { "startLine": 5, "endLine": 70 },
+    "type": "concept",
+    "title": "Shoelace Formula and the Integrality Bridge to Pick's Theorem",
+    "content": "Pick's theorem (Wiedijk #92) computes the area of a simple lattice polygon combinatorially as A = i + b/2 - 1, from its interior and boundary lattice-point counts. The shoelace (surveyor's) formula computes the SAME area from the vertex coordinates as 2A = |Σ_k (x_k y_{k+1} - x_{k+1} y_k)|. This entry formalizes the shoelace formula for an arbitrary simple lattice polygon (given as a vertex list), and the 'integrality bridge' tying the two: because the shoelace sum is an integer, twice the area is an integer equal to Pick's 2i + b - 2. The mathematical pivot is the fan-triangulation theorem shoelace_eq_fan, which shows the general n-gon sum equals the sum of triangle determinants of the fan from the first vertex — reducing the general case to the gallery's already-proven triangle formula.",
+    "mathContext": "$2A = \\left|\\sum_{k=1}^{m} (x_k y_{k+1} - x_{k+1} y_k)\\right| = 2i + b - 2$ for a simple lattice polygon with vertices in $\\mathbb{Z}^2$ (indices mod $m$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pick's theorem",
+      "shoelace / surveyor's formula",
+      "fan triangulation",
+      "signed area and the 2D cross product",
+      "lattice-point counting"
+    ],
+    "prerequisites": [
+      "Pick's theorem A = i + b/2 - 1",
+      "the triangle shoelace formula (picks-theorem-oq-01)",
+      "fan triangulation of a simple polygon",
+      "integer (lattice) coordinates"
+    ]
+  },
+  {
+    "id": "ann-picks-oq04-cross-identity",
+    "proofId": "picks-theorem-oq-04",
+    "range": { "startLine": 76, "endLine": 100 },
+    "type": "definition",
+    "title": "The Cross Product and the Apex Decomposition Identity",
+    "content": "cross a b = x_a y_b - y_a x_b is the per-edge term of the shoelace sum, and is antisymmetric (cross a b = -cross b a) with cross a a = 0. cross2 o a b is the determinant of the edge vectors a - o and b - o, i.e. twice the signed area of triangle (o, a, b) — the per-triangle term of a fan triangulation. The lemma cross2_eq is the engine of the whole file: cross2 o a b = cross a b + cross b o - cross a o. When this is summed over a fan triangulation, the apex (o) terms telescope, leaving exactly the closed shoelace edge sum. Everything downstream — the fan bridge, translation invariance, the triangle reduction — is a corollary of this identity together with antisymmetry of cross.",
+    "mathContext": "$\\mathrm{cross}(a,b)=x_a y_b-y_a x_b$, $\\mathrm{cross2}(o,a,b)=(a-o)\\times(b-o)$, and the key identity $\\mathrm{cross2}(o,a,b)=\\mathrm{cross}(a,b)+\\mathrm{cross}(b,o)-\\mathrm{cross}(a,o)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "2D cross product / wedge",
+      "determinant as signed area",
+      "telescoping sums",
+      "bilinearity and antisymmetry"
+    ],
+    "prerequisites": [
+      "2x2 determinants",
+      "signed area of a triangle"
+    ]
+  },
+  {
+    "id": "ann-picks-oq04-shoelace-def",
+    "proofId": "picks-theorem-oq-04",
+    "range": { "startLine": 109, "endLine": 121 },
+    "type": "definition",
+    "title": "The Closed Shoelace Sum over a Vertex List",
+    "content": "The polygon is modeled as a List of lattice points in cyclic order. shoelaceAux first vs sums cross over consecutive vertices of vs by structural recursion, and closes the loop by adding the edge from the last vertex of vs back to first. The public shoelace calls shoelaceAux with first equal to the head vertex, producing the genuine cyclic edge sum Σ_k cross(v_k, v_{k+1 mod m}). Concretely shoelace [a,b,c] = cross a b + cross b c + cross c a. Modeling the polygon as a list (rather than a function on Fin n or ZMod n) makes the closing edge explicit and the induction proofs clean.",
+    "mathContext": "$S = \\sum_{k=0}^{m-1} \\mathrm{cross}(v_k, v_{(k+1)\\bmod m})$; e.g. $\\mathrm{shoelace}[a,b,c]=\\mathrm{cross}(a,b)+\\mathrm{cross}(b,c)+\\mathrm{cross}(c,a)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "structural recursion on lists",
+      "cyclic edge sum",
+      "closed polygon as vertex list"
+    ],
+    "prerequisites": [
+      "lists and structural recursion",
+      "the cross product term"
+    ]
+  },
+  {
+    "id": "ann-picks-oq04-fan-bridge",
+    "proofId": "picks-theorem-oq-04",
+    "range": { "startLine": 157, "endLine": 167 },
+    "type": "theorem",
+    "title": "The Fan-Triangulation Bridge (Headline Result)",
+    "content": "fanAux o vs sums the triangle determinants cross2 o a b over consecutive pairs of vs; for a polygon v0 :: rest, fanAux v0 rest is the fan triangulation from apex v0 into triangles (v0, r_i, r_{i+1}). The bridging lemma shoelaceAux_eq_fanAux peels one edge at a time, proving the open shoelace chain and the fan sum differ by exactly the closing term cross a o — by induction on the tail with the leading vertex universally quantified, using cross2_eq and ring at each step. The main theorem shoelace_eq_fan then specializes the apex to the first vertex: shoelace (v0 :: rest) = fanAux v0 rest. The extra closing term cross v0 v0 vanishes by cross_self, and the leading degenerate triangle (apex repeated) vanishes by cross2 v0 v0 r1 = 0. This is the exact lift of the gallery's triangle shoelace formula to arbitrary n.",
+    "mathContext": "$\\sum_{k}\\mathrm{cross}(v_k,v_{k+1}) = \\sum_{i=1}^{m-2}\\mathrm{cross2}(v_0,v_i,v_{i+1})$: the closed edge sum equals the fan-triangle determinant sum from the first vertex.",
+    "significance": "key",
+    "relatedConcepts": [
+      "fan triangulation",
+      "telescoping over a polygon boundary",
+      "induction on lists",
+      "reduction to the triangle case"
+    ],
+    "prerequisites": [
+      "cross2_eq (apex decomposition)",
+      "antisymmetry of cross",
+      "list induction"
+    ]
+  },
+  {
+    "id": "ann-picks-oq04-triangle",
+    "proofId": "picks-theorem-oq-04",
+    "range": { "startLine": 172, "endLine": 187 },
+    "type": "theorem",
+    "title": "Triangle Reduction to the Classical Formula",
+    "content": "shoelace_triangle shows the general formula reduces, for three vertices, to the classical signed-area numerator x1(y2-y3) + x2(y3-y1) + x3(y1-y2), matching PicksTheoremOQ01.shoelaceTriangle up to absolute value (claim III of the problem). shoelace_triangle_fan records the complementary fact that the fan triangulation of a triangle is the single determinant cross2 a b c — the n = 3 base case of the fan bridge.",
+    "mathContext": "$\\mathrm{shoelace}[a,b,c] = x_1(y_2-y_3)+x_2(y_3-y_1)+x_3(y_1-y_2) = \\mathrm{cross2}(a,b,c)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "triangle area formula",
+      "consistency with the gallery triangle case"
+    ],
+    "prerequisites": [
+      "shoelace definition",
+      "fan bridge (for shoelace_triangle_fan)"
+    ]
+  },
+  {
+    "id": "ann-picks-oq04-translation",
+    "proofId": "picks-theorem-oq-04",
+    "range": { "startLine": 222, "endLine": 230 },
+    "type": "theorem",
+    "title": "Translation Invariance: Shape, Not Position",
+    "content": "shift and translate move a point / whole polygon by a fixed vector d. cross2_translate proves the triangle determinant is translation invariant because it depends only on the edge differences a - o and b - o, which are unchanged by a common shift. fanAux_translate lifts this to the entire fan sum by list induction, and shoelace_translate concludes that the shoelace sum is invariant under translating every vertex — it measures the polygon's shape, not its location. The proof is a one-liner once the fan bridge is in hand: rewrite both sides via shoelace_eq_fan and apply fanAux_translate.",
+    "mathContext": "$S(\\mathrm{translate}_d(P)) = S(P)$: each $\\mathrm{cross2}(o+d, a+d, b+d) = \\mathrm{cross2}(o,a,b)$, so the whole sum is unchanged.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "translation invariance of area",
+      "edge-difference dependence",
+      "corollary of the fan bridge"
+    ],
+    "prerequisites": [
+      "shoelace_eq_fan",
+      "cross2_translate"
+    ]
+  },
+  {
+    "id": "ann-picks-oq04-pick-bridge",
+    "proofId": "picks-theorem-oq-04",
+    "range": { "startLine": 250, "endLine": 269 },
+    "type": "theorem",
+    "title": "Integrality and the Bridge to Pick's Theorem",
+    "content": "twiceArea = |S| is, by construction, a nonnegative integer (twiceArea_nonneg), so the area twiceArea/2 is always a half-integer — the 'integrality' half of the bridge, true with no Pick input (claim I). two_mul_area records 2·area = twiceArea over ℚ. pick_bridge then proves: for a polygon whose Euclidean area satisfies Pick's relation area = i + b/2 - 1, the integer identity twiceArea = 2i + b - 2 holds (claim IV), by casting the rational relation through two_mul_area and exact_mod_cast. pick_bridge_iff sharpens this to an equivalence: Pick's relation and the integer identity carry exactly the same content, both being the value of twiceArea. The lattice-point counts i, b and Pick's relation enter as ordinary hypotheses — the file remains 0-axiom.",
+    "mathContext": "$2A = |S| \\in \\mathbb{Z}$, and $A = i + b/2 - 1 \\iff |S| = 2i + b - 2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pick's theorem",
+      "half-integrality of lattice-polygon area",
+      "rational-to-integer casting",
+      "equivalence of area formulations"
+    ],
+    "prerequisites": [
+      "Pick's relation A = i + b/2 - 1",
+      "twiceArea = |S|",
+      "integer/rational casts"
+    ]
+  },
+  {
+    "id": "ann-picks-oq04-concrete",
+    "proofId": "picks-theorem-oq-04",
+    "range": { "startLine": 274, "endLine": 307 },
+    "type": "example",
+    "title": "Concrete Verification: Triangle, Square, L-Shaped Hexagon",
+    "content": "decide-checked evaluations matching the Python verification battery in research/problems/picks-theorem-oq-04/. The shoelace sum is computed for the unit triangle (= 1), the right triangle (0,0),(3,0),(0,3) (= 9), the 3x4 rectangle (= 24), and an L-shaped non-convex hexagon (= 24). Three further examples confirm the Pick agreement twiceArea = 2i + b - 2 with independently computed lattice-point counts: the unit triangle (i=0, b=3), the square (i=6, b=14), and the L-shape (i=5, b=16). These make the abstract bridge concrete and double as regression tests on the definitions.",
+    "mathContext": "Unit triangle $S=1$; $3\\times4$ rectangle $S=24=2\\cdot6+14-2$; L-hexagon $S=24=2\\cdot5+16-2$ — exact lattice-point Pick agreement.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "computational verification (decide)",
+      "non-convex polygons",
+      "Pick agreement spot-checks"
+    ],
+    "prerequisites": [
+      "shoelace and twiceArea definitions",
+      "lattice-point counting for the fixtures"
+    ]
+  }
+]

--- a/src/data/proofs/picks-theorem-oq-04/meta.json
+++ b/src/data/proofs/picks-theorem-oq-04/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "picks-theorem-oq-04",
+  "title": "The General Shoelace Formula and its Integrality Bridge to Pick's Theorem",
+  "slug": "picks-theorem-oq-04",
+  "description": "Formalizes the shoelace (surveyor's) area formula for an arbitrary simple lattice polygon given as a vertex list, and the integrality bridge linking it to Pick's theorem. The headline result, shoelace_eq_fan, proves the general n-gon shoelace sum equals the sum of per-triangle determinants of its fan triangulation from the first vertex — the exact lift of the gallery's proven triangle shoelace formula to arbitrary n. The proof rests on the algebraic identity cross2 o a b = cross a b + cross b o - cross a o, whose telescoping collapses the fan back to the closed edge sum. Also proves triangle reduction to the classical x1(y2-y3)+x2(y3-y1)+x3(y1-y2), translation invariance, and the integrality bridge: the shoelace sum is always an integer, so for a lattice polygon whose Euclidean area equals its shoelace area, Pick's relation A = i + b/2 - 1 is equivalent to the clean integer identity |S| = 2i + b - 2. Verified on triangle, square, and an L-shaped non-convex hexagon. 13 theorems/lemmas, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Researcher; classical shoelace/surveyor's formula formalized in Lean 4 with Mathlib",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PicksTheoremOQ04.lean",
+    "tags": [
+      "geometry",
+      "combinatorics",
+      "lattice",
+      "area",
+      "shoelace",
+      "picks-theorem",
+      "wiedijk-100",
+      "connection"
+    ],
+    "badge": "original",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 308,
+    "theoremCount": 13,
+    "definitionCount": 9,
+    "dateAdded": "2026-06-28",
+    "assumptions": "0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound, the foundational Lean axioms). Fully machine-verified; no native_decide. The Pick bridge theorems carry the polygon's lattice-point counts (i, b) and Pick's relation as ordinary hypotheses, not as axioms.",
+    "originalContributions": [
+      "shoelace_eq_fan: the headline result. The general n-gon shoelace sum over a vertex list equals fanAux v0 rest, the sum of per-triangle determinants cross2 v0 r_i r_{i+1} of the fan triangulation from the first vertex. This is the exact lift of the gallery's proven triangle shoelace formula (PicksTheoremOQ01.shoelaceTriangle) to arbitrary n, and is the formal content of claim (II) of the problem.",
+      "cross2_eq: the key algebraic identity cross2 o a b = cross a b + cross b o - cross a o. Summed over a fan triangulation, the o-terms telescope, which is exactly why the fan sum collapses to the closed shoelace edge sum. The whole bridge rests on this one-line identity plus antisymmetry of cross.",
+      "shoelace_triangle: triangle reduction. For three vertices the general shoelace sum is the classical signed-area numerator x1(y2-y3)+x2(y3-y1)+x3(y1-y2), matching the existing triangle formula up to absolute value (claim III).",
+      "shoelace_translate: translation invariance. The shoelace sum is unchanged by translating every vertex by a fixed vector — it measures shape, not position. An immediate corollary of shoelace_eq_fan and the translation invariance of cross2.",
+      "pick_bridge and pick_bridge_iff: the integrality bridge (claims I, IV). The shoelace sum is an integer by construction, so the area |S|/2 is always a half-integer; for a lattice polygon whose Euclidean area equals its shoelace area, Pick's relation A = i + b/2 - 1 is EQUIVALENT to the integer identity |S| = 2i + b - 2 — both sides being the single integer twiceArea. Verified concretely on a triangle (i=0,b=3), a 3x4 square (i=6,b=14), and an L-shaped hexagon (i=5,b=16)."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "List.map / structural recursion on List",
+        "description": "The polygon is modeled as a List (ℤ × ℤ); shoelace, fanAux, and translate are defined by structural recursion on this list, and the bridge lemmas are proved by list induction.",
+        "module": "Init.Data.List.Basic"
+      },
+      {
+        "theorem": "abs_nonneg",
+        "description": "Nonnegativity of the absolute value, used for twiceArea = |S| ≥ 0 (the area is a nonnegative half-integer).",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue.Basic"
+      }
+    ],
+    "prerequisites": [
+      "Pick's theorem A = i + b/2 - 1 (parent gallery proof picks-theorem)",
+      "The triangle shoelace formula (picks-theorem-oq-01) and the triangle bridge 2·Area = |det| (picks-theorem-oq-01-oq-01-oq-01)",
+      "Fan triangulation of a simple polygon from a fixed vertex",
+      "Integer (lattice) coordinates and the 2D cross product / determinant"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The shoelace (or surveyor's) formula computes the area of a simple polygon directly from its vertex coordinates as half the absolute value of an alternating sum of 2x2 determinants; it is the coordinate-geometry counterpart of Pick's theorem (Wiedijk #92), which computes the same area combinatorially from interior and boundary lattice-point counts as A = i + b/2 - 1. The gallery already formalizes the triangle case of the shoelace formula and the triangle integrality bridge 2·Area = |det|. This entry closes the general-polygon gap: it states and proves the shoelace formula for an arbitrary simple lattice polygon given by its vertex list, lifts the triangle formula to all n via the fan triangulation, and makes precise the 'integrality bridge' — that twice the shoelace area is always an integer equal to Pick's 2i + b - 2. The fan-triangulation argument is the discrete analogue of integrating a 1-form around the boundary: each triangle (v0, v_i, v_{i+1}) contributes its signed area, and the contributions of the apex telescope away.",
+    "problemStatement": "For a simple lattice polygon with vertices (x_k, y_k) ∈ ℤ² in cyclic order, formalize the shoelace area 2A = |Σ_k (x_k y_{k+1} - x_{k+1} y_k)| for arbitrary n, connect it to the triangle formula via fan triangulation, and prove the integrality bridge 2i + b - 2 = |Σ_k (x_k y_{k+1} - x_{k+1} y_k)| linking the coordinate area to Pick's lattice-point counts.",
+    "text": "The polygon is modeled as a list of lattice points. The closed shoelace sum is the alternating determinant sum over consecutive vertices, closing the last vertex back to the first. The central theorem shoelace_eq_fan shows this equals the fan-triangulation sum from the first vertex, reducing the general case to a sum of triangle determinants — exactly the objects the gallery already understands. From there: triangle reduction recovers the classical 3-vertex formula; translation invariance follows because triangle determinants depend only on edge differences; and the integrality bridge follows because the shoelace sum is manifestly an integer, so Pick's half-integer relation A = i + b/2 - 1 is equivalent to the integer identity |S| = 2i + b - 2.",
+    "proofStrategy": "Everything funnels through two algebraic facts about the 2D cross product cross a b = x_a y_b - y_a x_b: antisymmetry (cross a b = -cross b a) and the apex decomposition cross2 o a b = cross a b + cross b o - cross a o. The bridging lemma shoelaceAux_eq_fanAux peels one edge at a time and shows the open shoelace chain and the fan sum differ by exactly the closing term cross a o; the main theorem shoelace_eq_fan then specializes the apex to the first vertex (the leading degenerate triangle vanishes by cross_self). Translation invariance is shoelace_eq_fan composed with cross2_translate. The Pick bridge casts Pick's rational relation to the integer identity via two_mul_area and exact_mod_cast.",
+    "keyInsights": [
+      "The general n-gon shoelace sum is exactly the fan-triangulation sum from any fixed vertex (shoelace_eq_fan) — so the whole formula reduces to the already-proven triangle case.",
+      "The one-line identity cross2 o a b = cross a b + cross b o - cross a o is the engine: summed over the fan, the apex terms telescope and the leading degenerate triangle (apex repeated) vanishes by cross_self.",
+      "The shoelace sum is an INTEGER by construction, so twice the area is an integer and the area is always a half-integer — this is the 'integrality' half of the bridge, true with no Pick input.",
+      "Given that the shoelace area equals the Euclidean area, Pick's relation A = i + b/2 - 1 and the integer identity |S| = 2i + b - 2 are literally equivalent (pick_bridge_iff): both equal the single integer twiceArea.",
+      "Translation invariance is automatic from the fan bridge because triangle determinants depend only on edge differences (cross2_translate)."
+    ],
+    "prerequisites": [
+      "Pick's theorem (parent picks-theorem)",
+      "Triangle shoelace formula (picks-theorem-oq-01)",
+      "Fan triangulation of a simple polygon"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header — Shoelace Formula and the Integrality Bridge",
+      "startLine": 1,
+      "endLine": 70,
+      "summary": "Block comment stating the general n-gon shoelace formula 2A = |Σ(x_k y_{k+1} - x_{k+1} y_k)|, the four claims it formalizes (fan bridge, triangle reduction, translation invariance, integrality + Pick bridge), and the relation to the parent picks-theorem and its triangle-case children. Notes 0 sorries / 0 axioms / no native_decide.",
+      "mathContext": "$2A = \\left|\\sum_{k} (x_k y_{k+1} - x_{k+1} y_k)\\right| = 2i + b - 2$ for a simple lattice polygon, indices mod $m$."
+    },
+    {
+      "id": "cross",
+      "title": "Part 1: The Cross Product and its Triangle Determinant",
+      "startLine": 71,
+      "endLine": 100,
+      "summary": "cross a b = x_a y_b - y_a x_b (the per-edge shoelace term), with cross_self (= 0) and cross_antisymm (= -cross b a). cross2 o a b is the determinant of edge vectors a-o, b-o (twice the signed triangle area). The key identity cross2_eq: cross2 o a b = cross a b + cross b o - cross a o.",
+      "mathContext": "$\\mathrm{cross}(a,b) = x_a y_b - y_a x_b$, $\\mathrm{cross2}(o,a,b) = (a-o) \\times (b-o)$, and $\\mathrm{cross2}(o,a,b) = \\mathrm{cross}(a,b) + \\mathrm{cross}(b,o) - \\mathrm{cross}(a,o)$."
+    },
+    {
+      "id": "shoelace",
+      "title": "Part 2: The Shoelace Sum of a Closed Polygon",
+      "startLine": 101,
+      "endLine": 121,
+      "summary": "shoelaceAux first vs sums cross over consecutive vertices of vs, closing with the edge from the last vertex back to first. shoelace calls it with first the head vertex, giving the cyclic edge sum: shoelace [a,b,c] = cross a b + cross b c + cross c a.",
+      "mathContext": "$S = \\sum_{k=0}^{m-1} \\mathrm{cross}(v_k, v_{k+1 \\bmod m}) = \\sum_k (x_k y_{k+1} - x_{k+1} y_k)$."
+    },
+    {
+      "id": "fan-bridge",
+      "title": "Part 3: The Fan Triangulation and the Bridge Theorem",
+      "startLine": 122,
+      "endLine": 167,
+      "summary": "fanAux o vs sums triangle determinants cross2 o a b over consecutive pairs. The bridging lemma shoelaceAux_eq_fanAux shows the open chain and fan sum differ by the closing term cross a o. The headline shoelace_eq_fan: shoelace (v0 :: rest) = fanAux v0 rest — the general shoelace sum is the fan-triangulation sum, the leading degenerate triangle vanishing by cross_self.",
+      "mathContext": "$\\sum_k \\mathrm{cross}(v_k, v_{k+1}) = \\sum_{i=1}^{m-2} \\mathrm{cross2}(v_0, v_i, v_{i+1})$ — the closed edge sum equals the fan-triangle sum."
+    },
+    {
+      "id": "triangle",
+      "title": "Part 4: Triangle Reduction",
+      "startLine": 168,
+      "endLine": 187,
+      "summary": "shoelace_triangle: for three vertices the sum is the classical x1(y2-y3)+x2(y3-y1)+x3(y1-y2). shoelace_triangle_fan: the fan triangulation of a triangle is the single determinant cross2 a b c.",
+      "mathContext": "$\\mathrm{shoelace}[a,b,c] = x_1(y_2-y_3) + x_2(y_3-y_1) + x_3(y_1-y_2) = \\mathrm{cross2}(a,b,c)$."
+    },
+    {
+      "id": "translation",
+      "title": "Part 5: Translation Invariance",
+      "startLine": 188,
+      "endLine": 230,
+      "summary": "shift and translate move a point / polygon by a fixed vector. cross2_translate: triangle determinants depend only on edge differences, hence are translation invariant. fanAux_translate lifts this to the fan sum, and shoelace_translate concludes the shoelace sum measures shape, not position.",
+      "mathContext": "$S(\\mathrm{translate}_d(P)) = S(P)$: the shoelace area is invariant under $v \\mapsto v + d$, since each $\\mathrm{cross2}$ term cancels the shift."
+    },
+    {
+      "id": "integrality-pick",
+      "title": "Part 6: Integrality and the Bridge to Pick's Theorem",
+      "startLine": 231,
+      "endLine": 269,
+      "summary": "twiceArea = |S| (an integer, so the area is a half-integer) with twiceArea_nonneg and two_mul_area. pick_bridge: given Pick's relation area = i + b/2 - 1, twiceArea = 2i + b - 2. pick_bridge_iff: the two statements are equivalent, both being the value of twiceArea.",
+      "mathContext": "$2A = |S| \\in \\mathbb{Z}$, and Pick's $A = i + b/2 - 1 \\iff |S| = 2i + b - 2$."
+    },
+    {
+      "id": "concrete",
+      "title": "Part 7: Concrete Verification",
+      "startLine": 270,
+      "endLine": 308,
+      "summary": "decide-checked evaluations matching the Python battery: shoelace = 1 (unit triangle), 9 (right triangle), 24 (3x4 rectangle and L-shaped hexagon); and Pick agreement twiceArea = 2i + b - 2 for the unit triangle (i=0,b=3), the square (i=6,b=14), and the L-shape (i=5,b=16).",
+      "mathContext": "Spot-checks: unit triangle $S=1$; $3\\times4$ rectangle $S=24=2\\cdot6+14-2$; L-hexagon $S=24=2\\cdot5+16-2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms, no native_decide): the general n-gon shoelace formula as a vertex-list sum, proved equal to its fan-triangulation sum (shoelace_eq_fan), reduced to the classical triangle formula, shown translation invariant, and connected to Pick's theorem via the integrality bridge |S| = 2i + b - 2. Concretely verified on a triangle, a square, and an L-shaped non-convex hexagon.",
+    "implications": "**Completes the coordinate side of Pick.** The shoelace formula makes the area in Pick's theorem fully coordinate-computable for arbitrary simple lattice polygons, and the bridge shows the resulting integer is exactly Pick's 2i + b - 2. **Lifts the triangle case to all n.** The fan-triangulation theorem reduces the general polygon to the already-formalized triangle determinant, a reusable pattern for polygon-area arguments. **Integrality for free.** Because the shoelace sum lives in ℤ, the half-integrality of lattice-polygon area is immediate, independent of Pick.",
+    "openQuestions": [
+      "Can shoelace_eq_fan be combined with a Lean formalization of simple-polygon ear/fan triangulation to derive the full Pick relation A = i + b/2 - 1 constructively, removing the realizability hypothesis carried by pick_bridge?",
+      "Does the fan-triangulation bridge extend to give a clean Lean proof that the shoelace sum changes sign under reversal of vertex order (orientation), and is invariant under cyclic rotation of the vertex list?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "picks-theorem",
+      "relationship": "extends",
+      "description": "Parent gallery proof; supplies Pick's relation A = i + b/2 - 1 that the integrality bridge connects to the shoelace area."
+    },
+    {
+      "targetId": "picks-theorem-oq-01",
+      "relationship": "depends",
+      "description": "The triangle shoelace formula that shoelace_eq_fan lifts to arbitrary n via fan triangulation."
+    },
+    {
+      "targetId": "picks-theorem-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The triangle integrality bridge 2·Area = |det|, generalized here to the n-gon identity |S| = 2i + b - 2."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "PicksTheoremOQ04",
+    "lineCount": 308,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 9,
+    "path": "Proofs/PicksTheoremOQ04.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pick, G.",
+      "title": "Geometrisches zur Zahlenlehre",
+      "year": "1899",
+      "venue": "Sitzungsberichte des deutschen naturwissenschaftlich-medicinischen Vereines für Böhmen \"Lotos\"",
+      "note": "The original statement of Pick's theorem A = i + b/2 - 1."
+    },
+    {
+      "authors": "Braden, B.",
+      "title": "The Surveyor's Area Formula",
+      "year": "1986",
+      "venue": "The College Mathematics Journal 17(4), 326-337",
+      "note": "Exposition of the shoelace formula and its relation to the cross product / signed area."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **shoelace (surveyor's) formula** for an arbitrary simple lattice polygon (given as a vertex `List (ℤ × ℤ)`) and the **integrality bridge** to Pick's theorem. Extends the gallery's triangle-only shoelace result (`picks-theorem-oq-01`) to general n.

**Fully machine-checked**: 0 sorries, 0 `axiom` declarations, no `native_decide`. `#print axioms` on the headline theorems lists only `[propext, Classical.choice, Quot.sound]` — the foundational Lean axioms. Verified via `./proofs/scripts/docker-build.sh Proofs.PicksTheoremOQ04`.

## What's proved

- **`shoelace_eq_fan`** (headline): the general n-gon shoelace sum `Σ_k (x_k y_{k+1} − x_{k+1} y_k)` equals `fanAux v0 rest`, the sum of per-triangle determinants `cross2 v0 r_i r_{i+1}` of the fan triangulation from the first vertex. Exact lift of `PicksTheoremOQ01.shoelaceTriangle` to arbitrary n.
- **`cross2_eq`** (the engine): `cross2 o a b = cross a b + cross b o − cross a o`. Summed over a fan, the apex terms telescope, collapsing the fan sum to the closed shoelace edge sum.
- **`shoelace_triangle`**: n=3 reduces to `x₁(y₂−y₃)+x₂(y₃−y₁)+x₃(y₁−y₂)`.
- **`shoelace_translate`**: translation invariance.
- **`pick_bridge` / `pick_bridge_iff`**: the integer identity `|S| = 2i + b − 2` holds and is equivalent to Pick's `A = i + b/2 − 1`.
- `decide`-checked fixtures: triangle, 3×4 square, non-convex L-hexagon, with explicit (i, b) Pick-agreement checks.

## Honest scope

`pick_bridge` carries Pick's relation and the lattice-point counts (i, b) as ordinary **hypotheses**, not axioms. This entry contributes the *coordinate* side (the shoelace formula) and the integer bridge; the deep "shoelace area = Euclidean area & Pick holds" content remains the parent `picks-theorem`. Constructive Pick via Lean ear/fan triangulation is left as a noted follow-up.

## Gallery

`src/data/proofs/picks-theorem-oq-04/` — `meta.json` (status: verified, badge: original, axiomCount 0) + 8 annotations, each re-anchored to its matching Lean construct so they validate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)