### PR TITLE
research(abundant-number-oq-02-oq-01): ω≥8 ⇒ n≥5391411025, narrowing exact minimality [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbundantNumberOQ02OQ01GeneralBound.lean
+++ b/proofs/Proofs/AbundantNumberOQ02OQ01GeneralBound.lean
@@ -103,6 +103,126 @@ lemma radical_ge
   rw [hprodList] at hdom
   exact hdom
 
+/-- The product of the eight smallest primes `≥ 5`:
+`5·7·11·13·17·19·23·29 = 1078282205`. -/
+lemma canon8_prod : ([5, 7, 11, 13, 17, 19, 23, 29] : List ℕ).prod = 1078282205 := by decide
+
+/-- **The 8-prime radical lower bound.**  If an odd abundant number coprime to 3 has at
+least 8 distinct prime factors, its radical `∏_{p∣n} p` is at least
+`1078282205 = 5·7·11·13·17·19·23·29` (the product of the eight smallest primes `≥ 5`).
+This is the 8-prime analogue of `radical_ge`, using the gap list `[5,7,11,13,17,19,23,29]`
+(`gapList8`) instead of the 7-element one. -/
+lemma radical_ge_8
+    {n : ℕ} (hodd : Odd n) (h3 : ¬ (3 ∣ n)) (h8 : 8 ≤ n.primeFactors.card) :
+    1078282205 ≤ ∏ p ∈ n.primeFactors, p := by
+  set S := n.primeFactors with hS
+  have hge5 : ∀ p ∈ S, 5 ≤ p := primeFactor_ge_five hodd h3
+  have hLpair : (S.sort (· ≤ ·)).Pairwise (· < ·) := by
+    have hsorted : List.Pairwise (· ≤ ·) (S.sort (· ≤ ·)) := Finset.pairwise_sort S (· ≤ ·)
+    have hnodup : (S.sort (· ≤ ·)).Nodup := Finset.sort_nodup S (· ≤ ·)
+    exact (hsorted.and hnodup).imp (fun h => lt_of_le_of_ne h.1 h.2)
+  have hLprime : ∀ x ∈ S.sort (· ≤ ·), x.Prime := by
+    intro x hx
+    rw [Finset.mem_sort] at hx
+    exact Nat.prime_of_mem_primeFactors (hS ▸ hx)
+  have hLfloor : ∀ x ∈ S.sort (· ≤ ·),
+      ∀ c0 ∈ ([5, 7, 11, 13, 17, 19, 23, 29] : List ℕ).head?, c0 ≤ x := by
+    intro x hx c0 hc0
+    simp only [List.head?_cons, Option.mem_some_iff] at hc0
+    subst hc0
+    rw [Finset.mem_sort] at hx
+    exact hge5 x hx
+  have hLlen : ([5, 7, 11, 13, 17, 19, 23, 29] : List ℕ).length ≤ (S.sort (· ≤ ·)).length := by
+    rw [Finset.length_sort]
+    simpa using h8
+  have hdom : ([5, 7, 11, 13, 17, 19, 23, 29] : List ℕ).prod ≤ (S.sort (· ≤ ·)).prod :=
+    domProd [5, 7, 11, 13, 17, 19, 23, 29] (S.sort (· ≤ ·)) hLpair hLprime hLfloor hLlen gapList8
+  rw [canon8_prod] at hdom
+  have hprodList : (S.sort (· ≤ ·)).prod = ∏ p ∈ S, p := by
+    have h1 : (S.sort (· ≤ ·)).prod = S.toList.prod :=
+      List.Perm.prod_eq (Finset.sort_perm_toList S (· ≤ ·))
+    have h2 : S.toList.prod = ∏ p ∈ S, p := by
+      simpa using Finset.prod_map_toList S (fun p => p)
+    rw [h1]; exact h2
+  rw [hprodList] at hdom
+  exact hdom
+
+/-- **Eight distinct prime factors force the conjectured minimum.**  An odd abundant number
+coprime to 3 with at least 8 distinct prime factors is already `≥ 5391411025`, the
+conjectured least odd abundant number coprime to 3.  The bound is *sharp* in this subcase:
+the witness `5391411025 = 5² · 7 · 11 · 13 · 17 · 19 · 23 · 29` attains it.
+
+Proof: a squarefree such number is `≥ 33426748355` (`squarefree_..._ge`); a non-squarefree
+one carries a repeated prime `p ≥ 5`, so `p · radical ∣ n`, and `radical ≥ 1078282205`
+(`radical_ge_8`) gives `n ≥ 5 · 1078282205 = 5391411025`. -/
+theorem odd_abundant_coprime_three_eight_primeFactors_ge
+    {n : ℕ} (hodd : Odd n) (h3 : ¬ (3 ∣ n)) (habund : Nat.Abundant n)
+    (h8 : 8 ≤ n.primeFactors.card) :
+    5391411025 ≤ n := by
+  have hn0 : n ≠ 0 := by
+    rintro rfl
+    simp only [Nat.primeFactors_zero, Finset.card_empty] at h8
+    omega
+  have hnpos : 0 < n := Nat.pos_of_ne_zero hn0
+  by_cases hsf : Squarefree n
+  · -- Squarefree: already ≥ 33426748355 > 5391411025.
+    have := squarefree_odd_abundant_coprime_three_ge hsf hodd h3 habund
+    omega
+  · -- Non-squarefree: a repeated prime `p ≥ 5` gives `p · radical ∣ n`, radical ≥ 1078282205.
+    set S := n.primeFactors with hS
+    rw [Nat.squarefree_iff_prime_squarefree] at hsf
+    push_neg at hsf
+    obtain ⟨p, hp_prime, hp_sq⟩ := hsf
+    have hpp : p.Prime := hp_prime
+    have hpn : p ∣ n := dvd_trans (dvd_mul_right p p) hp_sq
+    have hpS : p ∈ S := Nat.mem_primeFactors.mpr ⟨hpp, hpn, hn0⟩
+    have hp5 : 5 ≤ p := primeFactor_ge_five hodd h3 p hpS
+    have hRsplit : (∏ q ∈ S, q) = p * ∏ q ∈ S.erase p, q :=
+      (Finset.mul_prod_erase S (fun q => q) hpS).symm
+    have hR'_dvd_R : (∏ q ∈ S.erase p, q) ∣ ∏ q ∈ S, q :=
+      Finset.prod_dvd_prod_of_subset _ _ (fun q => q) (Finset.erase_subset p S)
+    have hR_dvd_n : (∏ q ∈ S, q) ∣ n := hS ▸ Nat.prod_primeFactors_dvd n
+    have hR'_dvd_n : (∏ q ∈ S.erase p, q) ∣ n := dvd_trans hR'_dvd_R hR_dvd_n
+    have hcop : Nat.Coprime (p * p) (∏ q ∈ S.erase p, q) := by
+      refine Nat.Coprime.prod_right ?_
+      intro q hq
+      have hqS : q ∈ S := Finset.mem_of_mem_erase hq
+      have hqp : q ≠ p := Finset.ne_of_mem_erase hq
+      have hqprime : q.Prime := Nat.prime_of_mem_primeFactors (hS ▸ hqS)
+      have hcoprime_pq : Nat.Coprime p q :=
+        (Nat.coprime_primes hpp hqprime).mpr (fun h => hqp h.symm)
+      exact hcoprime_pq.mul_left hcoprime_pq
+    have hdvd : (p * p) * (∏ q ∈ S.erase p, q) ∣ n :=
+      Nat.Coprime.mul_dvd_of_dvd_of_dvd hcop hp_sq hR'_dvd_n
+    have hpR_dvd : p * (∏ q ∈ S, q) ∣ n := by
+      rw [hRsplit, show p * (p * ∏ q ∈ S.erase p, q) = (p * p) * ∏ q ∈ S.erase p, q by ring]
+      exact hdvd
+    have hle : p * (∏ q ∈ S, q) ≤ n := Nat.le_of_dvd hnpos hpR_dvd
+    have hRge : 1078282205 ≤ ∏ q ∈ S, q := hS ▸ radical_ge_8 hodd h3 h8
+    have hmul : 5 * 1078282205 ≤ p * (∏ q ∈ S, q) := Nat.mul_le_mul hp5 hRge
+    omega
+
+/-- **Structure of any putative counterexample below the conjectured minimum.**  Every odd
+abundant number coprime to 3 that is *strictly below* `5391411025` must be **non-squarefree
+with exactly 7 distinct prime factors**.  This sharply narrows the still-open exact
+minimality problem: the squarefree case is `≥ 33426748355` and the `≥ 8`-distinct-prime
+case is `≥ 5391411025` (`odd_abundant_coprime_three_eight_primeFactors_ge`), so the only
+family that could conceivably undercut the witness `5391411025` is a non-squarefree number
+with precisely 7 distinct primes (and necessarily some prime power `≥ 2` to compensate). -/
+theorem odd_abundant_coprime_three_below_min_structure
+    {n : ℕ} (hodd : Odd n) (h3 : ¬ (3 ∣ n)) (habund : Nat.Abundant n)
+    (hlt : n < 5391411025) :
+    ¬ Squarefree n ∧ n.primeFactors.card = 7 := by
+  have h7 := odd_abundant_coprime_three_seven_primeFactors hodd h3 habund
+  refine ⟨?_, ?_⟩
+  · intro hsf
+    have := squarefree_odd_abundant_coprime_three_ge hsf hodd h3 habund
+    omega
+  · by_contra hne
+    have h8 : 8 ≤ n.primeFactors.card := by omega
+    have := odd_abundant_coprime_three_eight_primeFactors_ge hodd h3 habund h8
+    omega
+
 /-- **Improved general lower bound.**  Every odd abundant number coprime to 3 is at least
 `185910725 = 5 · 37182145`, a factor of `5` above the bare radical bound.  The extra
 factor comes for free from squarefreeness analysis: a squarefree witness is already past
@@ -169,5 +289,7 @@ theorem odd_abundant_coprime_three_ge_185M
 -- Axiom audit: only the foundational axioms (`propext`, `Classical.choice`, `Quot.sound`);
 -- in particular NO `Lean.ofReduceBool` (no `native_decide`) and NO `sorryAx`.
 #print axioms odd_abundant_coprime_three_ge_185M
+#print axioms odd_abundant_coprime_three_eight_primeFactors_ge
+#print axioms odd_abundant_coprime_three_below_min_structure
 
 end AbundantNumberOQ02OQ01GeneralBound

--- a/src/data/research/problems/abundant-number-oq-02-oq-01.json
+++ b/src/data/research/problems/abundant-number-oq-02-oq-01.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-27T15:29:18-07:00",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Verified the witness half and proved a structural reduction of the minimality half (>=7 distinct prime factors) via the Euler abundancy bound.",
     "blockers": [],
-    "nextAction": "Formalize the extremal/monotonicity step: product over k distinct primes >=5 of p/(p-1) is maximised by the k smallest, closing >=7 prime factors unconditionally.",
+    "nextAction": "Bound exponents in the omega=7 non-squarefree family to reach exact minimality 5391411025.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: squarefree subproblem fully resolved (exact least element 33426748355, omega>=9), 0-axiom. General non-squarefree exact minimality still open.",
+    "progressSummary": "PROGRESS: squarefree subproblem fully resolved (exact least 33426748355, omega>=9), 0-axiom. NEW: omega(n)>=8 => n>=5391411025 (sharp), so any n below the conjectured minimum 5391411025 is non-squarefree with EXACTLY 7 distinct primes (odd_abundant_coprime_three_below_min_structure). Exact non-squarefree minimality now reduced to the single omega=7 non-squarefree family; that family needs exponent-size analysis (open).",
     "builtItems": [
       "geomSum_mul_pred_lt (per-prime-power Euler bound) in Proofs/AbundantNumberOQ02OQ01Minimality.lean",
       "sigma_mul_prod_sub_one_lt (Euler abundancy bound, N form) in Proofs/AbundantNumberOQ02OQ01Minimality.lean",
@@ -43,7 +43,10 @@
       "Proofs/AbundantNumberOQ02OQ01Squarefree.lean: sigma_one_squarefree (sigma(n)=prod(p+1) for squarefree via factorization_eq_one_of_squarefree), antitone weight g p=(p+1)/p with domg domination lemma, gap23/gap29, gapList8/gapList9, canon8_g_prod_lt_two, canon9_prod=33426748355.",
       "squarefree_odd_abundant_coprime_three_nine_primeFactors : Squarefree n -> Odd n -> not 3|n -> Abundant n -> 9 <= omega(n) [VERIFIED 0-axiom].",
       "squarefree_odd_abundant_coprime_three_ge : ... -> 33426748355 <= n (sharp; radical=n for squarefree, via domProd) [VERIFIED 0-axiom].",
-      "squarefree_odd_abundant_coprime_three_least : IsLeast {Squarefree & Odd & not3| & Abundant} 33426748355, with witness W=33426748355 proved Squarefree/Odd/not3|/Abundant (sigma_W=66886041600>2W via multiplicativity, no native_decide) [VERIFIED 0-axiom]."
+      "squarefree_odd_abundant_coprime_three_least : IsLeast {Squarefree & Odd & not3| & Abundant} 33426748355, with witness W=33426748355 proved Squarefree/Odd/not3|/Abundant (sigma_W=66886041600>2W via multiplicativity, no native_decide) [VERIFIED 0-axiom].",
+      "radical_ge_8 (8-prime radical bound): omega(n)>=8 => radical >= 1078282205 = 5*7*11*13*17*19*23*29, via domProd + gapList8. In Proofs/AbundantNumberOQ02OQ01GeneralBound.lean [VERIFIED 0-axiom].",
+      "odd_abundant_coprime_three_eight_primeFactors_ge (MAIN new): Odd n -> not 3|n -> Abundant n -> omega(n)>=8 => 5391411025 <= n. SHARP — the witness 5^2*7*11*13*17*19*23*29 attains it. Squarefree branch >=33426748355; non-squarefree branch 5*radical_8 = 5391411025. In GeneralBound.lean [VERIFIED 0-axiom].",
+      "odd_abundant_coprime_three_below_min_structure (STRUCTURE): any odd abundant coprime-to-3 number n < 5391411025 must be NON-squarefree with EXACTLY 7 distinct prime factors. Narrows exact-minimality to a single subcase. In GeneralBound.lean [VERIFIED 0-axiom]."
     ],
     "insights": [
       "Euler abundancy bound holds purely over N: for n>1, sigma(n)*prod_{p|n}(p-1) < n*prod_{p|n} p. Proved multiplicatively from (sum_{i<=a} p^i)*(p-1)=p^{a+1}-1 (Mathlib geom_sum_mul_add, valid in any semiring). No native_decide.",
@@ -53,14 +56,15 @@
       "Crude bounds fail: (5/4)^6 ~= 3.81 > 2, and 6 distinct INTEGERS >=5 can telescope to 2.5 > 2 (e.g. 5..10). Primality (coprimality to 6) is essential: it forces the i-th smallest prime factor >= the i-th prime >=5, which is exactly the gap-list domination.",
       "Linking the Q ratio product to the N Euler bound: prod_{p in S} p/(p-1) = (prod p)/(prod (p-1)) over Q (Finset.prod_div_distrib), and 2*prod(p-1) < prod p in N casts up; cancel the positive denominator with lt_of_mul_lt_mul_right. No division-inequality lemma needed.",
       "SHARP squarefree boundary: a squarefree odd abundant number coprime to 3 has >=9 distinct prime factors (vs >=7 general). Squarefreeness removes exponent-boosting, so the abundancy index is the strictly smaller product prod (p+1)/p; the 8 smallest primes >=5 give (6/5)(8/7)(12/11)(14/13)(18/17)(20/19)(24/23)(30/29)=2090188800/1078282205~1.938<2, the 9th (31) pushes it >2.",
-      "EXACT squarefree minimum: smallest squarefree odd abundant coprime-to-3 number is 5*7*11*13*17*19*23*29*31 = 33426748355 (IsLeast). Larger than the general min 5391411025 precisely because the latter is non-squarefree (5^2 buys abundancy with only 8 primes)."
+      "EXACT squarefree minimum: smallest squarefree odd abundant coprime-to-3 number is 5*7*11*13*17*19*23*29*31 = 33426748355 (IsLeast). Larger than the general min 5391411025 precisely because the latter is non-squarefree (5^2 buys abundancy with only 8 primes).",
+      "Exact-minimality narrowing: the conjectured least odd abundant coprime-to-3 number 5391411025 = 5^2*7*11*13*17*19*23*29 equals 5*radical_8 where radical_8 = product of the 8 smallest primes >=5. Hence omega(n)>=8 (non-squarefree) already forces n>=5391411025, and squarefree forces n>=33426748355. So ANY counterexample below 5391411025 is non-squarefree with EXACTLY 7 distinct primes — the only remaining open family. The general lower bound 185910725 is non-sharp precisely because 5^2*(7 smallest primes) = 1.937-abundancy < 2 is not abundant; abundancy with 7 primes needs raising several exponents (=> larger n) or an 8th prime (=> the witness).",
+      "The 8-prime radical bound reuses the existing domProd/gapList8 machinery verbatim — only the gap list length and the canon product change (canon8_prod = 1078282205). No new number theory; the reduction is purely structural (squarefree split + repeated-prime divisibility p*radical | n)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Optional: extend the gap-list method to bound omega(n) for odd abundant n with other small-prime exclusions (e.g. coprime to 15) — same dom lemma, different canonical gap list.",
-      "Optional gallery: the unconditional >=7 result could anchor a short gallery entry on Euler abundancy bounds, pairing the witness (oq-02) with this minimality lower bound.",
-      "The full minimality claim (smallest is exactly 5391411025) still needs the matching upper structure; >=7 prime factors is the proven lower bound on omega, not the full numeric minimality.",
-      "Squarefree case is now CLOSED exactly. For the general (non-squarefree) minimality toward 5391411025, the remaining obstruction is bounding exponents: a per-prime-power refinement combining the Euler bound with the size constraint."
+      "Close the remaining open subcase: an odd abundant coprime-to-3 number with EXACTLY 7 distinct prime factors (necessarily non-squarefree) is >= 5391411025. Requires bounding prime-power exponents: with the 7 smallest primes {5,7,11,13,17,19,23}, abundancy (sigma/n>2) needs the exponent product to approach the sup prod p/(p-1)=2.038; quantify the minimal n achieving sigma/n>2 and show it is >= 5391411025 (or that no such number is < 5391411025).",
+      "Optional: extend the gap-list method to coprime-to-15 (primes >=7) — same domProd, longer canonical gap list (~16 primes to exceed 2).",
+      "Optional gallery: the unconditional >=7 bound + the sharp omega>=8 narrowing could anchor a short gallery entry on Euler abundancy bounds."
     ],
     "markdown": "# Knowledge Base: abundant-number-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session for **abundant-number-oq-02-oq-01** (smallest odd abundant number
not divisible by 3, conjectured `5391411025 = 5²·7·11·13·17·19·23·29`).

The squarefree subcase was already closed exactly (least `33426748355`, ω≥9), and
the general unconditional bound was `ω(n)≥7 ⇒ n ≥ 185910725`. This session sharpens
the **non-squarefree** frontier and narrows the still-open exact-minimality problem.

## Key observation
`5391411025 = 5 · (5·7·11·13·17·19·23·29) = 5 · radical₈`, where `radical₈` is the
product of the eight smallest primes `≥ 5`. So the `ω≥8` non-squarefree case lands
*exactly* on the witness.

## New theorems (all 0-axiom, `[propext, Classical.choice, Quot.sound]`)
- **`radical_ge_8`** — `ω(n) ≥ 8 ⇒ ∏_{p∣n} p ≥ 1078282205`. The 8-prime analogue of
  the existing `radical_ge`, reusing `domProd` + `gapList8` verbatim (only the gap
  list and the canonical product change).
- **`odd_abundant_coprime_three_eight_primeFactors_ge`** — odd, `¬3∣n`, abundant,
  `ω(n) ≥ 8` ⇒ `5391411025 ≤ n`. **Sharp**: the witness attains it. Squarefree branch
  `≥ 33426748355`; non-squarefree branch `n ≥ p·radical ≥ 5·1078282205 = 5391411025`.
- **`odd_abundant_coprime_three_below_min_structure`** — any odd abundant coprime-to-3
  number *strictly below* `5391411025` must be **non-squarefree with exactly 7 distinct
  prime factors**.

## Why this is progress
It reduces the open exact-minimality problem to a **single, sharply described family**
(ω = 7, non-squarefree). The squarefree case (`≥ 33B`) and the `ω ≥ 8` case
(`≥ 5391411025`) provably cannot undercut the witness, so any counterexample must live
in the ω=7 non-squarefree family — which then requires prime-power exponent bounds
(the remaining open work, documented in `nextSteps`).

The old bound `185910725` was non-sharp precisely because `5²·(7 smallest primes)` has
abundancy index `≈1.937 < 2` (not abundant); abundancy with 7 primes forces raising
several exponents (larger `n`) or an 8th prime (the witness).

## Verification
- `./proofs/scripts/docker-build.sh Proofs.AbundantNumberOQ02OQ01GeneralBound` ✅
- `#print axioms` on all three new theorems: `[propext, Classical.choice, Quot.sound]`
  only — no `native_decide`, no `sorry`.

## Files modified
- `proofs/Proofs/AbundantNumberOQ02OQ01GeneralBound.lean` (+3 verified theorems/lemmas)
- `src/data/research/problems/abundant-number-oq-02-oq-01.json` (knowledge update)

## Status
**Outcome**: progress (verified 0-axiom narrowing of the open exact-minimality problem).
**Next steps**: close the ω=7 non-squarefree family via exponent-size bounds.

🤖 Generated by researcher-7