### PR TITLE
Enrich Non-Uniform Property B first moment (property-b-first-moment-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/property-b-first-moment-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 55, "endLine": 61 },
     "type": "definition",
     "title": "The p-Biased Monochromatic Probability",
-    "content": "`monoProb k p := p^k + (1-p)^k` models the probability that a fixed edge of size `k` is monochromatic when each vertex is colored Red independently with probability `p` (and Blue with probability `1-p`): one of the two colors must hit all `k` vertices, contributing `p^k` (all Red) and `(1-p)^k` (all Blue). This generalizes the parent file's symmetric count, where every edge is monochromatic with probability `2·2^(-k) = 2^(1-k)`. The simp lemma `monoProb_half` evaluates the symmetric case `monoProb k (1/2) = 2·(1/2)^k`."
+    "content": "`monoProb k p := p^k + (1-p)^k` models the probability that a fixed edge of size `k` is monochromatic when each vertex is colored Red independently with probability `p` (and Blue with probability `1-p`): one of the two colors must hit all `k` vertices, contributing `p^k` (all Red) and `(1-p)^k` (all Blue). This generalizes the parent file's symmetric count, where every edge is monochromatic with probability `2·2^(-k) = 2^(1-k)`. The simp lemma `monoProb_half` evaluates the symmetric case `monoProb k (1/2) = 2·(1/2)^k`.",
+    "mathContext": "$\\mathrm{monoProb}(k,p) = p^k + (1-p)^k$, with $\\mathrm{monoProb}(k,\\tfrac12) = 2\\cdot(\\tfrac12)^k = 2^{1-k}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["independent vertex coloring", "monochromatic edge", "Bernoulli(p) model", "Property B"],
+    "prerequisites": ["independent events and product probabilities", "the parent symmetric first-moment bound"]
   },
   {
     "id": "ann-pbfm-oq03oq01-ge",
@@ -13,7 +17,11 @@
     "range": { "startLine": 63, "endLine": 77 },
     "type": "theorem",
     "title": "Asymmetry Never Helps (monoProb_ge)",
-    "content": "`monoProb_ge` is the crux: for `k ≥ 1` and any bias `p ∈ [0,1]`, `2·(1/2)^k ≤ monoProb k p`. The proof is one application of `convexOn_pow` (convexity of `x ↦ x^k` on `[0,∞)`): with `p` and `1-p` both in `Ici 0` and weights `a = b = 1/2`, convexity gives `((1/2)p + (1/2)(1-p))^k ≤ (1/2)p^k + (1/2)(1-p)^k`. The argument collapses to `(1/2)^k` (via `ring`), yielding `(1/2)^k ≤ (1/2)·monoProb k p`, i.e. `2·(1/2)^k ≤ monoProb k p`. Since `2·(1/2)^k = 2^(1-k)`, the symmetric value is a global lower bound — biasing the coloring can only raise the monochromatic probability."
+    "content": "`monoProb_ge` is the crux: for `k ≥ 1` and any bias `p ∈ [0,1]`, `2·(1/2)^k ≤ monoProb k p`. The proof is one application of `convexOn_pow` (convexity of `x ↦ x^k` on `[0,∞)`): with `p` and `1-p` both in `Ici 0` and weights `a = b = 1/2`, convexity gives `((1/2)p + (1/2)(1-p))^k ≤ (1/2)p^k + (1/2)(1-p)^k`. The argument collapses to `(1/2)^k` (via `ring`), yielding `(1/2)^k ≤ (1/2)·monoProb k p`, i.e. `2·(1/2)^k ≤ monoProb k p`. Since `2·(1/2)^k = 2^(1-k)`, the symmetric value is a global lower bound — biasing the coloring can only raise the monochromatic probability.",
+    "mathContext": "By convexity of $x\\mapsto x^k$: $\\left(\\tfrac{p+(1-p)}2\\right)^k \\le \\tfrac{p^k+(1-p)^k}2$, i.e. $2\\,(\\tfrac12)^k \\le \\mathrm{monoProb}(k,p)$ — Jensen at the midpoint.",
+    "significance": "key",
+    "relatedConcepts": ["convexity / Jensen's inequality", "convexOn_pow", "midpoint inequality", "first-moment method"],
+    "prerequisites": ["convexity of x ↦ x^k on [0,∞)", "ConvexOn.2 / midpoint instantiation"]
   },
   {
     "id": "ann-pbfm-oq03oq01-lt",
@@ -21,7 +29,11 @@
     "range": { "startLine": 87, "endLine": 104 },
     "type": "theorem",
     "title": "Symmetry is the Unique Optimum for k ≥ 2 (monoProb_half_lt)",
-    "content": "`monoProb_half_lt` upgrades optimality to uniqueness: for `k ≥ 2` and `p ∈ [0,1]` with `p ≠ 1/2`, `monoProb k (1/2) < monoProb k p`. The bias condition `p ≠ 1/2` is exactly `p ≠ 1-p`, the distinctness needed to apply `strictConvexOn_pow` (strict convexity of `x ↦ x^k` for `k ≥ 2`) at the points `p` and `1-p`. The strict midpoint inequality then gives `(1/2)^k < (1/2)·monoProb k p`. So any nonzero bias *strictly* increases the monochromatic probability, hence strictly *lowers* the first-moment threshold `1/monoProb k p`."
+    "content": "`monoProb_half_lt` upgrades optimality to uniqueness: for `k ≥ 2` and `p ∈ [0,1]` with `p ≠ 1/2`, `monoProb k (1/2) < monoProb k p`. The bias condition `p ≠ 1/2` is exactly `p ≠ 1-p`, the distinctness needed to apply `strictConvexOn_pow` (strict convexity of `x ↦ x^k` for `k ≥ 2`) at the points `p` and `1-p`. The strict midpoint inequality then gives `(1/2)^k < (1/2)·monoProb k p`. So any nonzero bias *strictly* increases the monochromatic probability, hence strictly *lowers* the first-moment threshold `1/monoProb k p`.",
+    "mathContext": "Strict convexity for $k\\ge 2$ and $p \\neq 1-p$: $\\left(\\tfrac{p+(1-p)}2\\right)^k < \\tfrac{p^k+(1-p)^k}2$, so $\\mathrm{monoProb}(k,\\tfrac12) < \\mathrm{monoProb}(k,p)$ — equality iff $p=\\tfrac12$.",
+    "significance": "key",
+    "relatedConcepts": ["strict convexity", "strictConvexOn_pow", "uniqueness of optimum", "p ≠ 1/2 ⟺ p ≠ 1−p"],
+    "prerequisites": ["strict convexity of x ↦ x^k for k ≥ 2", "the distinctness hypothesis p ≠ 1−p"]
   },
   {
     "id": "ann-pbfm-oq03oq01-threshold",
@@ -29,6 +41,10 @@
     "range": { "startLine": 106, "endLine": 118 },
     "type": "theorem",
     "title": "The Symmetric Threshold is Exactly 2^(k-1) (threshold_half)",
-    "content": "`threshold_half` anchors the optimum to Erdős' original bound: `1 / monoProb k (1/2) = 2^(k-1)` for `k ≥ 1`. Rewriting `monoProb k (1/2) = 2·(1/2)^k` and `(1/2)^k = 1/2^k` (`one_div_pow`), then clearing denominators (`field_simp`) reduces the claim to `2·2^(k-1) = 2^k` (`pow_succ`). Combined with `monoProb_half_le`, this shows no bias `p` raises the threshold above `2^(k-1)`: the asymmetric first moment cannot beat Erdős, so the Radhakrishnan–Srinivasan gain of order √(k/log k) must come entirely from the recoloring step. `expected_mono_half_le` records the expectation form: an m-edge hypergraph's expected monochromatic-edge count `m·monoProb k p` is minimized at `p = 1/2`."
+    "content": "`threshold_half` anchors the optimum to Erdős' original bound: `1 / monoProb k (1/2) = 2^(k-1)` for `k ≥ 1`. Rewriting `monoProb k (1/2) = 2·(1/2)^k` and `(1/2)^k = 1/2^k` (`one_div_pow`), then clearing denominators (`field_simp`) reduces the claim to `2·2^(k-1) = 2^k` (`pow_succ`). Combined with `monoProb_half_le`, this shows no bias `p` raises the threshold above `2^(k-1)`: the asymmetric first moment cannot beat Erdős, so the Radhakrishnan–Srinivasan gain of order √(k/log k) must come entirely from the recoloring step. `expected_mono_half_le` records the expectation form: an m-edge hypergraph's expected monochromatic-edge count `m·monoProb k p` is minimized at `p = 1/2`.",
+    "mathContext": "$\\dfrac{1}{\\mathrm{monoProb}(k,\\tfrac12)} = \\dfrac{1}{2^{1-k}} = 2^{k-1}$, and $\\mathbb{E}[\\#\\text{mono edges}] = m\\cdot\\mathrm{monoProb}(k,p)$ is minimized at $p=\\tfrac12$.",
+    "significance": "key",
+    "relatedConcepts": ["Erdős 2^(k-1) bound", "Property B threshold", "Radhakrishnan–Srinivasan recoloring", "linearity of expectation"],
+    "prerequisites": ["monoProb_half and monoProb_half_le", "field_simp / pow_succ arithmetic"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `property-b-first-moment-oq-03-oq-01` — that the symmetric coloring p = 1/2 uniquely minimizes the monochromatic probability, so the asymmetric first moment cannot beat Erdős' 2^(k-1).

**Core gap fixed:** all 4 annotations previously had only `content` — none had `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`. Added all four fields to each, with LaTeX `mathContext` capturing:
- the p-biased monochromatic probability monoProb(k,p) = p^k + (1−p)^k;
- the convexity (Jensen midpoint) lower bound 2·(1/2)^k ≤ monoProb(k,p);
- the strict-convexity uniqueness upgrade (k ≥ 2, p ≠ 1/2 ⟺ p ≠ 1−p);
- the threshold identity 1/monoProb(k,1/2) = 2^(k−1).

meta.json was already complete (conclusion has implications + openQuestions, 5 keyInsights, 3 sections) and under the size cap, so it was left untouched.

`pnpm build` green. Axiom integrity unchanged (verified, 0 axioms).