### PR TITLE
research(fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01): degree-2 identities for a general Lucas sequence [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3047,6 +3047,7 @@ import Proofs.FibonacciIdentitiesOQ01OQ03
 import Proofs.FibonacciIdentitiesOQ02
 import Proofs.FibonacciIdentitiesOQ02OQ01
 import Proofs.FibonacciIdentitiesOQ02OQ01OQ01OQ02
+import Proofs.FibonacciIdentitiesOQ02OQ01OQ01OQ02OQ01
 import Proofs.FibonacciIdentitiesOQ03
 import Proofs.FibonacciIdentitiesOQ03OQ01
 import Proofs.FibonacciIdentitiesOQ03OQ02

--- a/proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,249 @@
+import Proofs.FibonacciIdentitiesOQ02OQ01OQ01
+import Mathlib.Tactic
+
+/-
+# The Degree-2 Identities for a General Lucas Sequence
+
+## Open Question OQ-02-OQ-01-OQ-01-OQ-02-OQ-01
+
+The parent (OQ-02-OQ-01-OQ-01-OQ-02) proved the three degree-2 relations between
+the Fibonacci numbers `Fₙ` and the Lucas numbers `Lₙ`:
+
+  Lₙ² − 5·Fₙ² = 4·(−1)ⁿ        (difference of squares)
+  Lₙ² + 5·Fₙ² = 2·L₂ₙ          (sum of squares)
+  Lₙ · Fₙ     =   F₂ₙ          (cross / doubling)
+
+Its first open question asks to **generalize this trio to an arbitrary Lucas
+sequence** `(P, Q)` with companion sequences `Uₙ`, `Vₙ` and discriminant
+`D = P² − 4Q`, proving uniformly
+
+  Vₙ² − D·Uₙ² = 4·Qⁿ           (difference of squares)        (Ⅰ)
+  Vₙ² + D·Uₙ² = 2·V₂ₙ          (sum of squares)               (Ⅱ)
+  Vₙ · Uₙ     =   U₂ₙ          (cross / doubling)             (Ⅲ)
+
+and recovering the Fibonacci–Lucas identities at `P = 1`, `Q = −1`, `D = 5`.
+
+## The Lucas sequences
+
+For parameters `P Q : ℤ` the *Lucas sequences of the first and second kind* are
+
+  U₀ = 0,  U₁ = 1,  Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ
+  V₀ = 2,  V₁ = P,  Vₙ₊₂ = P·Vₙ₊₁ − Q·Vₙ
+
+At `(P, Q) = (1, −1)` these are exactly the Fibonacci numbers `Uₙ = Fₙ` and the
+Lucas numbers `Vₙ = Lₙ`.
+
+## Proof architecture
+
+The whole degree-2 algebra rests on three inductive facts and two addition laws:
+
+* `lucas_V_eq` — the linear bridge `Vₙ = 2·Uₙ₊₁ − P·Uₙ` (two-step induction),
+  the single relation that ties the second-kind sequence to the first-kind one.
+* `lucas_U_invariant` — `Uₙ₊₁² − P·Uₙ₊₁·Uₙ + Q·Uₙ² = Qⁿ`, a one-step induction.
+  Combined with the bridge it instantly gives the **difference of squares (Ⅰ)**.
+* `lucas_addU` / `lucas_addV` — the addition laws
+  `2·Uₘ₊ₙ = Uₘ·Vₙ + Vₘ·Uₙ` and `2·Vₘ₊ₙ = Vₘ·Vₙ + D·Uₘ·Uₙ`
+  (two-step induction in `n`, base cases supplied by the bridge).
+  Setting `m = n` yields the **sum of squares (Ⅱ)** and the **cross identity (Ⅲ)**
+  (the latter cancelling the factor 2 over `ℤ`).
+
+The point of the generalization: (Ⅰ) needs only `lucas_U_invariant`, a *single*
+clean one-step induction, while (Ⅱ) and (Ⅲ) are the diagonal `m = n`
+specializations of the addition laws — the same Mathlib-free machinery the
+Fibonacci proof used, now stated once at the level of an arbitrary `(P, Q)`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace FibonacciIdentitiesOQ02OQ01OQ01OQ02OQ01
+
+/-- The pair `(Uₙ, Uₙ₊₁)` for the first-kind Lucas sequence with parameters `P, Q`. -/
+def Upair (P Q : ℤ) : ℕ → ℤ × ℤ
+  | 0 => (0, 1)
+  | n + 1 => ((Upair P Q n).2, P * (Upair P Q n).2 - Q * (Upair P Q n).1)
+
+/-- The first-kind Lucas sequence: `U₀ = 0`, `U₁ = 1`, `Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ`. -/
+def U (P Q : ℤ) (n : ℕ) : ℤ := (Upair P Q n).1
+
+/-- The pair `(Vₙ, Vₙ₊₁)` for the second-kind Lucas sequence with parameters `P, Q`. -/
+def Vpair (P Q : ℤ) : ℕ → ℤ × ℤ
+  | 0 => (2, P)
+  | n + 1 => ((Vpair P Q n).2, P * (Vpair P Q n).2 - Q * (Vpair P Q n).1)
+
+/-- The second-kind Lucas sequence: `V₀ = 2`, `V₁ = P`, `Vₙ₊₂ = P·Vₙ₊₁ − Q·Vₙ`. -/
+def V (P Q : ℤ) (n : ℕ) : ℤ := (Vpair P Q n).1
+
+variable (P Q : ℤ)
+
+@[simp] theorem U_zero : U P Q 0 = 0 := rfl
+@[simp] theorem U_one : U P Q 1 = 1 := rfl
+@[simp] theorem V_zero : V P Q 0 = 2 := rfl
+@[simp] theorem V_one : V P Q 1 = P := rfl
+
+/-- Defining recurrence for `U`: `Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ`. -/
+theorem U_rec (n : ℕ) : U P Q (n + 2) = P * U P Q (n + 1) - Q * U P Q n := rfl
+
+/-- Defining recurrence for `V`: `Vₙ₊₂ = P·Vₙ₊₁ − Q·Vₙ`. -/
+theorem V_rec (n : ℕ) : V P Q (n + 2) = P * V P Q (n + 1) - Q * V P Q n := rfl
+
+/-- **The linear bridge** `Vₙ = 2·Uₙ₊₁ − P·Uₙ`, the single relation linking the two
+    kinds of Lucas sequence.  Proved by two-step induction. -/
+theorem lucas_V_eq (n : ℕ) : V P Q n = 2 * U P Q (n + 1) - P * U P Q n := by
+  induction n using Nat.twoStepInduction with
+  | zero => simp
+  | one =>
+      have h2 : U P Q (1 + 1) = P * U P Q 1 - Q * U P Q 0 := rfl
+      simp only [V_one, U_one, U_zero, h2]; ring
+  | more n ih1 ih2 =>
+      have e2 : U P Q (n + 1 + 1) = U P Q (n + 2) := rfl
+      rw [e2] at ih2
+      show V P Q (n + 2) = 2 * U P Q (n + 3) - P * U P Q (n + 2)
+      have r2V : V P Q (n + 2) = P * V P Q (n + 1) - Q * V P Q n := rfl
+      have r3U : U P Q (n + 3) = P * U P Q (n + 2) - Q * U P Q (n + 1) := rfl
+      have r2U : U P Q (n + 2) = P * U P Q (n + 1) - Q * U P Q n := rfl
+      rw [r2V, ih1, ih2, r3U, r2U]; ring
+
+/-- **The fundamental `U`-invariant** `Uₙ₊₁² − P·Uₙ₊₁·Uₙ + Q·Uₙ² = Qⁿ`.  A clean
+    one-step induction: the substitution `Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ` multiplies the
+    quadratic form by exactly `Q`. -/
+theorem lucas_U_invariant (n : ℕ) :
+    U P Q (n + 1) ^ 2 - P * U P Q (n + 1) * U P Q n + Q * U P Q n ^ 2 = Q ^ n := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+      have r : U P Q (k + 1 + 1) = P * U P Q (k + 1) - Q * U P Q k := rfl
+      rw [r, pow_succ]
+      linear_combination Q * ih
+
+/-- **Difference of squares (Ⅰ)** `Vₙ² − D·Uₙ² = 4·Qⁿ`, where `D = P² − 4Q`.
+    Immediate from the bridge and the `U`-invariant: substituting
+    `Vₙ = 2·Uₙ₊₁ − P·Uₙ` turns the left side into `4·(Uₙ₊₁² − P·Uₙ₊₁·Uₙ + Q·Uₙ²)`. -/
+theorem lucas_sq_sub (n : ℕ) :
+    V P Q n ^ 2 - (P ^ 2 - 4 * Q) * U P Q n ^ 2 = 4 * Q ^ n := by
+  have hb := lucas_V_eq P Q n
+  have hi := lucas_U_invariant P Q n
+  rw [hb]; linear_combination 4 * hi
+
+/-- **First addition law** `2·Uₘ₊ₙ = Uₘ·Vₙ + Vₘ·Uₙ`, by two-step induction on `n`.
+    The base cases `n = 0, 1` are the bridge `lucas_V_eq` read off at `m`. -/
+theorem lucas_addU (m n : ℕ) :
+    2 * U P Q (m + n) = U P Q m * V P Q n + V P Q m * U P Q n := by
+  induction n using Nat.twoStepInduction with
+  | zero => simp only [V_zero, U_zero, mul_zero, add_zero]; ring
+  | one =>
+      have hb := lucas_V_eq P Q m
+      simp only [V_one, U_one, mul_one]
+      linear_combination -hb
+  | more n ih1 ih2 =>
+      have a1 : m + (n + 1) = (m + n) + 1 := by omega
+      have a2 : m + (n + 2) = (m + n) + 2 := by omega
+      rw [a1] at ih2
+      rw [a2]
+      have rU : U P Q ((m + n) + 2) = P * U P Q ((m + n) + 1) - Q * U P Q (m + n) := rfl
+      have rVn : V P Q (n + 2) = P * V P Q (n + 1) - Q * V P Q n := rfl
+      have rUn : U P Q (n + 2) = P * U P Q (n + 1) - Q * U P Q n := rfl
+      rw [rU, rVn, rUn]
+      linear_combination P * ih2 - Q * ih1
+
+/-- **Second addition law** `2·Vₘ₊ₙ = Vₘ·Vₙ + D·Uₘ·Uₙ` with `D = P² − 4Q`,
+    by two-step induction on `n`. -/
+theorem lucas_addV (m n : ℕ) :
+    2 * V P Q (m + n) = V P Q m * V P Q n + (P ^ 2 - 4 * Q) * U P Q m * U P Q n := by
+  induction n using Nat.twoStepInduction with
+  | zero => simp only [V_zero, U_zero, mul_zero, add_zero]; ring
+  | one =>
+      have hb1 := lucas_V_eq P Q m
+      have hb2 := lucas_V_eq P Q (m + 1)
+      have hu : U P Q (m + 1 + 1) = P * U P Q (m + 1) - Q * U P Q m := rfl
+      simp only [V_one, U_one, mul_one]
+      rw [hb2, hu, hb1]; ring
+  | more n ih1 ih2 =>
+      have a1 : m + (n + 1) = (m + n) + 1 := by omega
+      have a2 : m + (n + 2) = (m + n) + 2 := by omega
+      rw [a1] at ih2
+      rw [a2]
+      have rV : V P Q ((m + n) + 2) = P * V P Q ((m + n) + 1) - Q * V P Q (m + n) := rfl
+      have rVn : V P Q (n + 2) = P * V P Q (n + 1) - Q * V P Q n := rfl
+      have rUn : U P Q (n + 2) = P * U P Q (n + 1) - Q * U P Q n := rfl
+      rw [rV, rVn, rUn]
+      linear_combination P * ih2 - Q * ih1
+
+/-- **Sum of squares (Ⅱ)** `Vₙ² + D·Uₙ² = 2·V₂ₙ`, the diagonal `m = n` case of the
+    second addition law. -/
+theorem lucas_sq_add (n : ℕ) :
+    V P Q n ^ 2 + (P ^ 2 - 4 * Q) * U P Q n ^ 2 = 2 * V P Q (2 * n) := by
+  have h := lucas_addV P Q n n
+  rw [show (2 * n) = n + n from two_mul n]
+  linear_combination -h
+
+/-- **Cross identity (Ⅲ)** `Vₙ·Uₙ = U₂ₙ`, the diagonal `m = n` case of the first
+    addition law; the factor 2 cancels over `ℤ`. -/
+theorem lucas_mul (n : ℕ) :
+    V P Q n * U P Q n = U P Q (2 * n) := by
+  have h := lucas_addU P Q n n
+  rw [show (2 * n) = n + n from two_mul n]
+  have h2 : 2 * U P Q (n + n) = 2 * (V P Q n * U P Q n) := by linear_combination h
+  exact (mul_left_cancel₀ two_ne_zero h2).symm
+
+/-! ## Recovery: the Fibonacci–Lucas identities at `(P, Q) = (1, −1)`, `D = 5` -/
+
+open FibonacciIdentitiesOQ02OQ01OQ01 in
+/-- At `(P, Q) = (1, −1)` the first-kind Lucas sequence is the Fibonacci sequence. -/
+theorem U_eq_fib (n : ℕ) : U 1 (-1) n = (Nat.fib n : ℤ) := by
+  induction n using Nat.twoStepInduction with
+  | zero => simp
+  | one => simp
+  | more n ih1 ih2 =>
+      have r : U 1 (-1) (n + 2) = 1 * U 1 (-1) (n + 1) - (-1) * U 1 (-1) n := rfl
+      rw [r, ih1, ih2]
+      have hf : Nat.fib (n + 2) = Nat.fib n + Nat.fib (n + 1) := Nat.fib_add_two
+      rw [hf]; push_cast; ring
+
+open FibonacciIdentitiesOQ02OQ01OQ01 in
+/-- At `(P, Q) = (1, −1)` the second-kind Lucas sequence is the Lucas sequence. -/
+theorem V_eq_lucas (n : ℕ) : V 1 (-1) n = (lucas n : ℤ) := by
+  induction n using Nat.twoStepInduction with
+  | zero => simp
+  | one => simp
+  | more n ih1 ih2 =>
+      have r : V 1 (-1) (n + 2) = 1 * V 1 (-1) (n + 1) - (-1) * V 1 (-1) n := rfl
+      rw [r, ih1, ih2]
+      have hl : lucas (n + 2) = lucas n + lucas (n + 1) := lucas_add_two n
+      rw [hl]; push_cast; ring
+
+open FibonacciIdentitiesOQ02OQ01OQ01 in
+/-- Recovered difference of squares: `Lₙ² − 5·Fₙ² = 4·(−1)ⁿ`. -/
+theorem fib_lucas_sq_sub (n : ℕ) :
+    (lucas n : ℤ) ^ 2 - 5 * (Nat.fib n : ℤ) ^ 2 = 4 * (-1) ^ n := by
+  have h := lucas_sq_sub 1 (-1) n
+  rw [U_eq_fib, V_eq_lucas] at h
+  linear_combination h
+
+open FibonacciIdentitiesOQ02OQ01OQ01 in
+/-- Recovered sum of squares: `Lₙ² + 5·Fₙ² = 2·L₂ₙ`. -/
+theorem fib_lucas_sq_add (n : ℕ) :
+    (lucas n : ℤ) ^ 2 + 5 * (Nat.fib n : ℤ) ^ 2 = 2 * (lucas (2 * n) : ℤ) := by
+  have h := lucas_sq_add 1 (-1) n
+  simp only [U_eq_fib, V_eq_lucas] at h
+  linear_combination h
+
+open FibonacciIdentitiesOQ02OQ01OQ01 in
+/-- Recovered cross identity: `Lₙ · Fₙ = F₂ₙ`. -/
+theorem fib_lucas_mul (n : ℕ) :
+    (lucas n : ℤ) * (Nat.fib n : ℤ) = (Nat.fib (2 * n) : ℤ) := by
+  have h := lucas_mul 1 (-1) n
+  simp only [U_eq_fib, V_eq_lucas] at h
+  linear_combination h
+
+/-! ## Numeric sanity checks -/
+
+-- Difference of squares for the Pell-Lucas sequence `(P, Q) = (2, -1)` at `n = 4`:
+-- `U : 0,1,2,5,12`, `V : 2,2,6,14,34`; `D = 4 + 4 = 8`; `34² − 8·12² = 1156 − 1152 = 4 = 4·(−1)⁴`.
+example : V 2 (-1) 4 ^ 2 - ((2 : ℤ) ^ 2 - 4 * (-1)) * U 2 (-1) 4 ^ 2 = 4 * (-1 : ℤ) ^ 4 :=
+  lucas_sq_sub 2 (-1) 4
+
+-- Cross identity for `(P, Q) = (3, 2)` (so `Uₙ = 2ⁿ − 1`) at `n = 3`:
+-- `U₃ = 7`, `V₃ = 9`, `U₆ = 63 = 7·9`.
+example : V 3 2 3 * U 3 2 3 = U 3 2 6 := lucas_mul 3 2 3
+
+end FibonacciIdentitiesOQ02OQ01OQ01OQ02OQ01

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "lucas-gen-context",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 4, "endLine": 56 },
+    "type": "concept",
+    "title": "From Fibonacci to an Arbitrary Lucas Sequence",
+    "content": "The parent proved the degree-2 trio for the Fibonacci/Lucas pair: Lₙ² − 5Fₙ² = 4(−1)ⁿ, Lₙ² + 5Fₙ² = 2L₂ₙ, Lₙ·Fₙ = F₂ₙ. This entry answers its first open question by lifting all three to an arbitrary Lucas sequence. For integer parameters P, Q the first- and second-kind sequences Uₙ, Vₙ obey the same recurrence xₙ₊₂ = P·xₙ₊₁ − Q·xₙ (with U₀=0, U₁=1 and V₀=2, V₁=P), and with discriminant D = P² − 4Q one has uniformly Vₙ² − D·Uₙ² = 4Qⁿ, Vₙ² + D·Uₙ² = 2V₂ₙ, and Vₙ·Uₙ = U₂ₙ. The Fibonacci–Lucas relations are the D = 5 instance at (P, Q) = (1, −1).",
+    "mathContext": "$V_n^2 - D\\,U_n^2 = 4Q^n$, $\\;V_n^2 + D\\,U_n^2 = 2V_{2n}$, $\\;V_nU_n = U_{2n}$, with $D = P^2 - 4Q$; the $P{=}1, Q{=}{-}1, D{=}5$ case recovers $L_n^2 - 5F_n^2 = 4(-1)^n$, $L_n^2 + 5F_n^2 = 2L_{2n}$, $L_nF_n = F_{2n}$.",
+    "significance": "context",
+    "relatedConcepts": ["Lucas sequences", "Pell numbers", "Jacobsthal numbers", "discriminant", "quadratic identities"],
+    "prerequisites": ["linear recurrences", "Fibonacci and Lucas numbers", "elementary number theory"]
+  },
+  {
+    "id": "lucas-gen-bridge",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 89, "endLine": 103 },
+    "type": "insight",
+    "title": "One Linear Bridge Carries the Whole Degree-2 Algebra",
+    "content": "The single structural relation linking the two kinds of Lucas sequence is the linear bridge Vₙ = 2·Uₙ₊₁ − P·Uₙ, proved by two-step induction. Once V is written through U, the difference identity is the U-invariant scaled by 4, and the base cases of both addition laws are just the bridge read off at the index m. No Binet formula, no √D, and no generating functions enter anywhere — the entire quadratic theory routes through this one equation.",
+    "mathContext": "$V_n = 2U_{n+1} - P\\,U_n$; substituting it into $V_n^2 - D\\,U_n^2$ turns the difference of squares into $4(U_{n+1}^2 - P\\,U_{n+1}U_n + Q\\,U_n^2)$.",
+    "significance": "key",
+    "relatedConcepts": ["companion sequences", "two-step induction", "Binet formula", "linear recurrence"],
+    "prerequisites": ["Lucas sequence recurrences", "induction"]
+  },
+  {
+    "id": "lucas-gen-invariant",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 105, "endLine": 124 },
+    "type": "insight",
+    "title": "The Generalized Cassini Invariant",
+    "content": "The fundamental invariant Uₙ₊₁² − P·Uₙ₊₁·Uₙ + Q·Uₙ² = Qⁿ is a one-step induction in which substituting Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ multiplies the quadratic form by exactly Q — so the inductive step is the single tactic `linear_combination Q * ih`. This is the Lucas-sequence generalization of Cassini's identity Fₙ₊₁Fₙ₋₁ − Fₙ² = (−1)ⁿ, which is its P = 1, Q = −1 shadow. Combined with the bridge it gives the difference of squares (Ⅰ) outright.",
+    "mathContext": "$U_{n+1}^2 - P\\,U_{n+1}U_n + Q\\,U_n^2 = Q^n$; the recurrence scales the form by $Q$, so $\\text{(form at }n{+}1) = Q\\cdot(\\text{form at }n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Cassini identity", "quadratic invariant", "linear_combination tactic", "one-step induction"],
+    "prerequisites": ["Lucas recurrence", "polynomial algebra"]
+  },
+  {
+    "id": "lucas-gen-addition",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 126, "endLine": 185 },
+    "type": "technique",
+    "title": "Addition Laws and Their Diagonal Cases",
+    "content": "The two addition laws 2·Uₘ₊ₙ = Uₘ·Vₙ + Vₘ·Uₙ and 2·Vₘ₊ₙ = Vₘ·Vₙ + D·Uₘ·Uₙ are two-step inductions in n, base cases n = 0, 1 supplied by the bridge, inductive step closed by `linear_combination P * ih2 − Q * ih1`. Setting m = n collapses them to the diagonal: lucas_sq_add (the sum of squares Vₙ² + D·Uₙ² = 2V₂ₙ) and lucas_mul (the cross identity Vₙ·Uₙ = U₂ₙ). Keeping the factor 2 throughout keeps every step inside ℤ with no division; it cancels exactly once, in the cross identity, via `mul_left_cancel₀ two_ne_zero`.",
+    "mathContext": "$2U_{m+n} = U_mV_n + V_mU_n$ and $2V_{m+n} = V_mV_n + D\\,U_mU_n$; the diagonal $m = n$ gives $V_n^2 + D\\,U_n^2 = 2V_{2n}$ and $V_nU_n = U_{2n}$.",
+    "significance": "key",
+    "relatedConcepts": ["addition formulas", "doubling identities", "two-step induction", "cancellation over ℤ"],
+    "prerequisites": ["Lucas sequences", "induction", "ring algebra"]
+  },
+  {
+    "id": "lucas-gen-recovery",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 187, "endLine": 246 },
+    "type": "concept",
+    "title": "Recovering Fibonacci–Lucas as the D = 5 Instance",
+    "content": "U_eq_fib and V_eq_lucas prove by two-step induction that the (P, Q) = (1, −1) sequences are literally the gallery's Nat.fib and the parent's lucas, so fib_lucas_sq_sub, fib_lucas_sq_add, and fib_lucas_mul are corollaries of the general theorems rather than independent re-proofs. The same four-line identification specializes the entire trio to any concrete sequence: the numeric checks exhibit the difference identity for the Pell–Lucas sequence (P, Q) = (2, −1) and the cross identity for (P, Q) = (3, 2), where Uₙ = 2ⁿ − 1.",
+    "mathContext": "At $(P, Q) = (1, -1)$: $U_n = F_n$, $V_n = L_n$, $D = 5$, recovering the parent's trio. Pell–Lucas $(2,-1)$: $34^2 - 8\\cdot 12^2 = 4$. Mersenne-type $(3,2)$: $U_n = 2^n - 1$, $V_3U_3 = 9\\cdot 7 = 63 = U_6$.",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization", "Pell numbers", "Mersenne numbers", "sequence identification"],
+    "prerequisites": ["Fibonacci/Lucas definitions", "two-step induction"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01",
+  "title": "The Degree-2 Identities for a General Lucas Sequence",
+  "slug": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01",
+  "description": "Answers the parent (OQ-02-OQ-01-OQ-01-OQ-02)'s first open question: lift the degree-2 Fibonacci–Lucas trio to an arbitrary Lucas sequence. For integer parameters P, Q the first- and second-kind sequences Uₙ, Vₙ (U₀=0, U₁=1; V₀=2, V₁=P; both satisfying xₙ₊₂ = P·xₙ₊₁ − Q·xₙ) and discriminant D = P² − 4Q satisfy, uniformly in n, the difference Vₙ² − D·Uₙ² = 4·Qⁿ, the sum Vₙ² + D·Uₙ² = 2·V₂ₙ, and the cross identity Vₙ·Uₙ = U₂ₙ. The whole degree-2 algebra rests on a single linear bridge Vₙ = 2·Uₙ₊₁ − P·Uₙ, one one-step invariant Uₙ₊₁² − P·Uₙ₊₁·Uₙ + Q·Uₙ² = Qⁿ (giving the difference outright), and the two addition laws 2·Uₘ₊ₙ = Uₘ·Vₙ + Vₘ·Uₙ and 2·Vₘ₊ₙ = Vₘ·Vₙ + D·Uₘ·Uₙ whose diagonal m = n cases give the sum and cross identities. Specializing (P, Q) = (1, −1), D = 5 and proving Uₙ = Fₙ, Vₙ = Lₙ recovers the parent's Lₙ² − 5Fₙ² = 4(−1)ⁿ, Lₙ² + 5Fₙ² = 2L₂ₙ, and Lₙ·Fₙ = F₂ₙ.",
+  "meta": {
+    "author": "Lean Genius researcher-6",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 249,
+    "theoremCount": 18,
+    "definitionCount": 4,
+    "assumptions": "None. All identities hold for every n : ℕ and arbitrary integer parameters P, Q, fully machine-checked over ℤ. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the numeric sanity checks are direct applications of the proved theorems (no decide, no native_decide, no Lean.ofReduceBool, no sorryAx).",
+    "tags": [
+      "lucas-sequences",
+      "fibonacci",
+      "lucas-numbers",
+      "pell-numbers",
+      "degree-two-identity",
+      "difference-of-squares",
+      "sum-of-squares",
+      "addition-law",
+      "number-theory",
+      "generalization"
+    ],
+    "dateAdded": "2026-06-28",
+    "originalContributions": [
+      "A self-contained, Mathlib-free general Lucas sequence: Upair/Vpair pair-recursions defining the first- and second-kind sequences U, V for arbitrary integer parameters P, Q (Mathlib has neither the general Lucas sequence nor even the Lucas numbers)",
+      "lucas_V_eq: the linear bridge Vₙ = 2·Uₙ₊₁ − P·Uₙ tying the second-kind sequence to the first, by two-step induction — the single structural relation the rest of the file rests on",
+      "lucas_U_invariant: the fundamental quadratic invariant Uₙ₊₁² − P·Uₙ₊₁·Uₙ + Q·Uₙ² = Qⁿ, a clean one-step induction in which the recurrence multiplies the quadratic form by exactly Q",
+      "lucas_sq_sub: the difference of squares Vₙ² − D·Uₙ² = 4·Qⁿ (D = P² − 4Q), immediate from the bridge and the invariant via linear_combination",
+      "lucas_addU / lucas_addV: the two addition laws 2·Uₘ₊ₙ = Uₘ·Vₙ + Vₘ·Uₙ and 2·Vₘ₊ₙ = Vₘ·Vₙ + D·Uₘ·Uₙ, two-step induction in n with base cases supplied by the bridge",
+      "lucas_sq_add: the sum of squares Vₙ² + D·Uₙ² = 2·V₂ₙ, the diagonal m = n case of the second addition law",
+      "lucas_mul: the cross / doubling identity Vₙ·Uₙ = U₂ₙ, the diagonal m = n case of the first addition law (the factor 2 cancelled over ℤ via mul_left_cancel₀)",
+      "U_eq_fib / V_eq_lucas: identification of the (P, Q) = (1, −1) specialization with the gallery's Fibonacci (Nat.fib) and parent's lucas sequences, recovering fib_lucas_sq_sub, fib_lucas_sq_add, fib_lucas_mul",
+      "Worked checks for the Pell–Lucas sequence (P, Q) = (2, −1) and the (P, Q) = (3, 2) sequence Uₙ = 2ⁿ − 1, exhibiting the identities outside the Fibonacci case"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.twoStepInduction",
+        "description": "Two-step induction principle, the workhorse for the bridge lucas_V_eq and both addition laws lucas_addU / lucas_addV (and for identifying U, V with fib, lucas at P = 1, Q = −1).",
+        "module": "Mathlib.Logic.Basic"
+      },
+      {
+        "theorem": "mul_left_cancel₀",
+        "description": "Cancellation of the nonzero factor 2 over ℤ, turning 2·U₂ₙ = 2·(Vₙ·Uₙ) into the cross identity Vₙ·Uₙ = U₂ₙ.",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "Fₙ₊₂ = Fₙ + Fₙ₊₁, used in U_eq_fib to match the (P, Q) = (1, −1) first-kind sequence with Mathlib's Nat.fib.",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "FibonacciIdentitiesOQ02OQ01OQ01.lucas_add_two",
+        "description": "The parent-chain's Lucas recurrence Lₙ₊₂ = Lₙ + Lₙ₊₁, used in V_eq_lucas to match the (P, Q) = (1, −1) second-kind sequence with the gallery's `lucas`.",
+        "module": "Proofs.FibonacciIdentitiesOQ02OQ01OQ01"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ02OQ01.lean",
+    "namespace": "FibonacciIdentitiesOQ02OQ01OQ01OQ02OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 249,
+    "theoremCount": 18,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "The quadratic identities relating Fibonacci and Lucas numbers — Lₙ² − 5Fₙ² = 4(−1)ⁿ, Lₙ² + 5Fₙ² = 2L₂ₙ, Lₙ·Fₙ = F₂ₙ — are not special to the golden ratio. They are the P = 1, Q = −1, D = 5 instance of a degree-2 algebra shared by every Lucas sequence: the first- and second-kind sequences Uₙ(P,Q), Vₙ(P,Q) attached to the recurrence xₙ₊₂ = P·xₙ₊₁ − Q·xₙ, with discriminant D = P² − 4Q. These sequences specialize to the Pell numbers (P=2, Q=−1), the Pell–Lucas numbers, the Jacobsthal numbers (P=1, Q=−2), Mersenne-type sequences (P=3, Q=2 gives Uₙ = 2ⁿ − 1), and the convergents of periodic continued fractions. Mathlib formalizes Nat.fib with doubling formulas but has no Lucas numbers and no general Lucas sequence, so the parent chain built `lucas` from scratch; this entry takes the final step, stating and proving the degree-2 trio once and for all at the level of arbitrary integer (P, Q).",
+    "problemStatement": "Open Question OQ-02-OQ-01-OQ-01-OQ-02-OQ-01 (first open question of the parent): generalize the degree-2 Fibonacci–Lucas trio to an arbitrary Lucas sequence. For integer parameters P, Q with companion sequences Uₙ, Vₙ and discriminant D = P² − 4Q, prove uniformly in n the difference Vₙ² − D·Uₙ² = 4·Qⁿ, the sum Vₙ² + D·Uₙ² = 2·V₂ₙ, and the cross identity Vₙ·Uₙ = U₂ₙ, and recover the Fibonacci–Lucas relations at P = 1, Q = −1, D = 5.",
+    "proofStrategy": "Define U, V by pair-recursions (Upair, Vpair) so the recurrences and base values are definitional (rfl). Everything reduces to three facts and two laws. (1) The linear bridge lucas_V_eq: Vₙ = 2·Uₙ₊₁ − P·Uₙ, by two-step induction — the one relation linking the two kinds. (2) The invariant lucas_U_invariant: Uₙ₊₁² − P·Uₙ₊₁·Uₙ + Q·Uₙ² = Qⁿ, a one-step induction where substituting Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ multiplies the quadratic form by exactly Q (linear_combination Q·ih). Substituting the bridge into the invariant gives the difference of squares (Ⅰ) by linear_combination. (3) The addition laws lucas_addU (2·Uₘ₊ₙ = Uₘ·Vₙ + Vₘ·Uₙ) and lucas_addV (2·Vₘ₊ₙ = Vₘ·Vₙ + D·Uₘ·Uₙ), two-step induction in n with base cases n = 0, 1 read off the bridge; their diagonal m = n cases give the sum of squares (Ⅱ) directly and the cross identity (Ⅲ) after cancelling the factor 2 over ℤ. Recovery: U_eq_fib and V_eq_lucas identify the (1, −1) specialization with Nat.fib and the parent's lucas by two-step induction, after which the three Fibonacci–Lucas relations follow by linear_combination.",
+    "keyInsights": [
+      "The entire degree-2 algebra of a Lucas sequence hangs on one structural relation: the linear bridge Vₙ = 2·Uₙ₊₁ − P·Uₙ. Once V is expressed through U, the difference identity is just the U-invariant scaled by 4, and the sum and cross identities are diagonal cases of the two addition laws — no Binet formula, no √D, no generating functions.",
+      "The invariant Uₙ₊₁² − P·Uₙ₊₁·Uₙ + Q·Uₙ² = Qⁿ is the cleanest possible induction: the recurrence is engineered so the substitution multiplies the quadratic form by exactly Q, so the step is a single linear_combination Q·ih. This is the generalization of Cassini's identity, which is its P = 1, Q = −1 shadow.",
+      "Generalizing from Fibonacci actually simplifies the proofs. The parent worked over ℕ and had to lift Mathlib's truncated-subtraction doubling Nat.fib_two_mul to ℤ; here U and V are defined directly over ℤ, the addition laws are pure two-step inductions, and the only external facts are the induction principle itself and cancellation of 2.",
+      "The factor of 2 in the addition laws is essential and benign: 2·Uₘ₊ₙ and 2·Vₘ₊ₙ keep every step inside ℤ (no division), and it cancels exactly once, in the cross identity Vₙ·Uₙ = U₂ₙ, via mul_left_cancel₀ and two_ne_zero. The sum-of-squares identity keeps the 2 on the V₂ₙ side and needs no cancellation.",
+      "The recovery theorems make the generalization honest: U_eq_fib and V_eq_lucas prove the (1, −1) sequences are literally the gallery's Fibonacci and Lucas sequences, so fib_lucas_sq_sub / fib_lucas_sq_add / fib_lucas_mul are corollaries, not re-proofs. The same four-line identification pattern specializes the whole trio to Pell (P=2, Q=−1) or any other (P, Q)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and the General Trio",
+      "startLine": 4,
+      "endLine": 56,
+      "summary": "Header stating OQ-02-OQ-01-OQ-01-OQ-02-OQ-01: lift the degree-2 Fibonacci–Lucas trio to an arbitrary Lucas sequence (P, Q) with discriminant D = P² − 4Q, proving Vₙ² − D·Uₙ² = 4Qⁿ, Vₙ² + D·Uₙ² = 2V₂ₙ, Vₙ·Uₙ = U₂ₙ, and recovering Fibonacci–Lucas at P = 1, Q = −1, D = 5. Lays out the proof architecture: the bridge, the U-invariant, and the two addition laws."
+    },
+    {
+      "id": "definitions",
+      "title": "The Two Lucas Sequences",
+      "startLine": 58,
+      "endLine": 87,
+      "summary": "Pair-recursions Upair, Vpair defining the first- and second-kind Lucas sequences U, V over ℤ for parameters P, Q, with the base values (U₀=0, U₁=1, V₀=2, V₁=P) and recurrences U_rec, V_rec available definitionally as @[simp]/rfl lemmas."
+    },
+    {
+      "id": "bridge",
+      "title": "The Linear Bridge",
+      "startLine": 89,
+      "endLine": 103,
+      "summary": "lucas_V_eq: Vₙ = 2·Uₙ₊₁ − P·Uₙ, the single relation tying the second-kind sequence to the first, proved by two-step induction. Every subsequent identity routes through this bridge."
+    },
+    {
+      "id": "invariant",
+      "title": "The Fundamental U-Invariant and Difference of Squares",
+      "startLine": 105,
+      "endLine": 124,
+      "summary": "lucas_U_invariant: Uₙ₊₁² − P·Uₙ₊₁·Uₙ + Q·Uₙ² = Qⁿ, a one-step induction where the recurrence multiplies the quadratic form by Q (the generalized Cassini identity). lucas_sq_sub: the difference of squares Vₙ² − D·Uₙ² = 4·Qⁿ, immediate from the bridge plus the invariant via linear_combination 4·hi."
+    },
+    {
+      "id": "addition-laws",
+      "title": "The Two Addition Laws",
+      "startLine": 126,
+      "endLine": 168,
+      "summary": "lucas_addU: 2·Uₘ₊ₙ = Uₘ·Vₙ + Vₘ·Uₙ and lucas_addV: 2·Vₘ₊ₙ = Vₘ·Vₙ + D·Uₘ·Uₙ, both two-step inductions in n with base cases n = 0, 1 read off the bridge and the inductive step closed by linear_combination P·ih2 − Q·ih1."
+    },
+    {
+      "id": "diagonal",
+      "title": "Sum of Squares and Cross Identity",
+      "startLine": 170,
+      "endLine": 185,
+      "summary": "lucas_sq_add: Vₙ² + D·Uₙ² = 2·V₂ₙ, the diagonal m = n case of lucas_addV. lucas_mul: Vₙ·Uₙ = U₂ₙ, the diagonal m = n case of lucas_addU, with the factor 2 cancelled over ℤ via mul_left_cancel₀ and two_ne_zero."
+    },
+    {
+      "id": "recovery",
+      "title": "Recovery of the Fibonacci–Lucas Identities",
+      "startLine": 187,
+      "endLine": 246,
+      "summary": "U_eq_fib and V_eq_lucas identify the (P, Q) = (1, −1) sequences with the gallery's Nat.fib and parent's lucas by two-step induction; fib_lucas_sq_sub, fib_lucas_sq_add, fib_lucas_mul then specialize the general trio to Lₙ² − 5Fₙ² = 4(−1)ⁿ, Lₙ² + 5Fₙ² = 2L₂ₙ, Lₙ·Fₙ = F₂ₙ. Numeric checks for the Pell–Lucas sequence (2, −1) and the sequence Uₙ = 2ⁿ − 1 at (3, 2) exhibit the identities outside the Fibonacci case."
+    }
+  ],
+  "conclusion": {
+    "summary": "18 theorems, 4 definitions, 0 sorries, 0 axioms. The three degree-2 identities Vₙ² − D·Uₙ² = 4Qⁿ, Vₙ² + D·Uₙ² = 2V₂ₙ, and Vₙ·Uₙ = U₂ₙ are proved uniformly for every integer Lucas sequence (P, Q), all resting on one linear bridge, one quadratic invariant, and two addition laws — pure two-step inductions plus ring algebra, no Binet formula or √D. The (P, Q) = (1, −1) specialization is identified with the gallery's Fibonacci and Lucas sequences, recovering the parent's full trio as corollaries.",
+    "implications": "Settles the parent's first open question and reframes the Fibonacci–Lucas degree-2 relations as the D = 5 shadow of a uniform Lucas-sequence fact. The same identification pattern (prove Uₙ = the target sequence by two-step induction, then quote the general theorem) gives the trio for the Pell, Pell–Lucas, Jacobsthal, and 2ⁿ−1 sequences for free. The bridge + invariant + addition-law template is the natural foundation for a future Mathlib Lucas-sequence API and extends directly to higher-index identities (Catalan, d'Ocagne, Vajda) and to divisibility properties such as Uₘ ∣ Uₘₙ.",
+    "openQuestions": [
+      "Prove the divisibility/strong-divisibility laws for the general Lucas sequence — Uₘ ∣ Uₘₙ and gcd(Uₘ, Uₙ) = U_gcd(m,n) — extending the cross identity Vₙ·Uₙ = U₂ₙ from doubling to arbitrary index multiplication.",
+      "Establish the d'Ocagne / Vajda degree-2 identities Uₘ·Vₙ − Uₙ·Vₘ = ±2·Qⁿ·Uₘ₋ₙ and Uₘ₊ₖ·Uₙ₋ₖ − Uₘ·Uₙ = (−1)ⁿ⁻ᵏ·Qⁿ⁻ᵏ·Uₘ₋ₙ·Uₖ for the general Lucas sequence, the off-diagonal companions of the addition laws proved here."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02",
+      "relationship": "parent — proved the degree-2 Fibonacci–Lucas trio (difference, sum, cross) and posed this generalization to an arbitrary Lucas sequence as its first open question; this entry recovers all three parent identities at P = 1, Q = −1, D = 5"
+    },
+    {
+      "targetId": "fibonacci-identities-oq-02-oq-01-oq-01",
+      "relationship": "grandparent — supplies the gallery's `lucas` sequence and its recurrence lucas_add_two, used by V_eq_lucas to identify the (1, −1) second-kind sequence with the Lucas numbers"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of `fibonacci-identities-oq-02-oq-01-oq-01-oq-02`: **generalize the degree-2 Fibonacci–Lucas trio to an arbitrary Lucas sequence.**

For integer parameters `P, Q`, the first- and second-kind Lucas sequences `Uₙ, Vₙ` (`U₀=0, U₁=1; V₀=2, V₁=P`, both satisfying `xₙ₊₂ = P·xₙ₊₁ − Q·xₙ`) and discriminant `D = P² − 4Q` satisfy, uniformly in `n`:

| | identity |
|---|---|
| (Ⅰ) difference of squares | `Vₙ² − D·Uₙ² = 4·Qⁿ` |
| (Ⅱ) sum of squares | `Vₙ² + D·Uₙ² = 2·V₂ₙ` |
| (Ⅲ) cross / doubling | `Vₙ · Uₙ = U₂ₙ` |

Specializing `(P, Q) = (1, −1)`, `D = 5` and proving `Uₙ = Fₙ`, `Vₙ = Lₙ` recovers the parent's `Lₙ² − 5Fₙ² = 4(−1)ⁿ`, `Lₙ² + 5Fₙ² = 2L₂ₙ`, and `Lₙ·Fₙ = F₂ₙ` as corollaries.

## Proof architecture

The whole degree-2 algebra rests on:

- **`lucas_V_eq`** — the linear bridge `Vₙ = 2·Uₙ₊₁ − P·Uₙ` (two-step induction), the single relation tying the two kinds.
- **`lucas_U_invariant`** — `Uₙ₊₁² − P·Uₙ₊₁·Uₙ + Q·Uₙ² = Qⁿ`, a one-step induction (generalized Cassini); with the bridge it gives (Ⅰ) outright.
- **`lucas_addU` / `lucas_addV`** — addition laws `2·Uₘ₊ₙ = Uₘ·Vₙ + Vₘ·Uₙ` and `2·Vₘ₊ₙ = Vₘ·Vₙ + D·Uₘ·Uₙ`; diagonal `m = n` cases give (Ⅱ) and (Ⅲ).

No Binet formula, no `√D`, no generating functions — pure two-step inductions plus `ring`/`linear_combination`. Generalizing from Fibonacci actually *simplifies* the parent's proofs (the parent had to lift Mathlib's truncated-ℕ-subtraction doubling to ℤ; here `U, V` are defined directly over ℤ).

Numeric checks exhibit the identities for the Pell–Lucas sequence `(2, −1)` and the `Uₙ = 2ⁿ − 1` sequence `(3, 2)`, outside the Fibonacci case.

## Verification

- **18 theorems, 4 definitions, 0 sorries, 0 axioms.**
- `#print axioms` on `lucas_sq_sub`, `lucas_sq_add`, `lucas_mul`, `fib_lucas_sq_sub`, `fib_lucas_mul` → `[propext, Classical.choice, Quot.sound]` only (no `Lean.ofReduceBool`, no `sorryAx`).
- Builds via `./proofs/scripts/docker-build.sh Proofs.FibonacciIdentitiesOQ02OQ01OQ01OQ02OQ01` — clean, no warnings.

## Files

- `proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ02OQ01.lean` (new, 249 lines)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01/{meta.json,annotations.json}` (gallery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)