### PR TITLE
audit(area-of-circle-oq-03-oq-02-oq-01): correct theoremCount 7→8

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
@@ -66,7 +66,7 @@
     "assumptions": "Fully verified: 0 axioms, 0 sorries remain.",
     "lineCount": 223,
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 1
   },
   "overview": {
@@ -179,7 +179,7 @@
     "namespace": "AreaOfCircleOQ03OQ02OQ01",
     "lineCount": 223,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 1,
     "mainTheorems": [
       "archimedes_sin_doubling",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: area-of-circle-oq-03-oq-02-oq-01 (Archimedes' Half-Angle Doubling Method)
**Problem**: `theoremCount` metadata understated the theorem count.

## Evidence

`proofs/Proofs/AreaOfCircleOQ03OQ02OQ01.lean` contains **8** theorems:
- `archimedes_sin_doubling`
- `archimedes_cos_doubling`
- `halfPerimeter_hexagon`
- `halfPerimeter_pow_two`
- `halfPerimeter_doubling`
- `halfPerimeter_lt_pi`
- `halfPerimeter_tendsto_pi`
- `archimedes_doubling_method_verified`

But `meta.json` reported `"theoremCount": 7` in **both** `meta.meta` and `leanFile`. The `leanFile.mainTheorems` array already correctly lists all 8.

## Fix

Corrected both `theoremCount` fields from 7 → 8.

## Other Claims Verified (all accurate)

- 0 sorries (matches) ✓
- 0 axioms / 0 `axiom` declarations (matches) ✓
- 0 True stubs ✓
- 1 definition (`halfPerimeter`, matches) ✓
- badge `mathlib` correctly signals reliance on Mathlib's half-angle lemmas; description honestly says "derived/specialized from Mathlib" — no overclaiming ✓

---
Discovered during gallery integrity audit. LOW severity (undercount, conservative direction).