### PR TITLE
research(erdos-1110-oq-01): extract general power-form representability lemma [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1110Problem.lean
+++ b/proofs/Proofs/Erdos1110Problem.lean
@@ -545,6 +545,30 @@ lemma representable_summands_ge_q {p q n : ℕ} (hp : p > q) (hq : q ≥ 2)
   have hs2 : 2 ≤ s := by omega
   exact isPowerForm_ge_q_of_ge_two hp hq (hpf s hs) hs2
 
+/-- **Every power form is representable** (unconditional, 0-axiom). A power form
+`n = p^k q^l` is represented by the singleton antichain `{n}`: a one-element set is
+vacuously an antichain (`NoOneDividesAnother`), its sole element is a power form, and it
+sums to `n`. This is the base fact underlying the backward direction of the window
+characterisation, and generalises `example_1_representable` (the `{3,2}` unit) to every
+pair and every power form. -/
+theorem isRepresentable_of_isPowerForm {p q n : ℕ} (h : IsPowerForm p q n) :
+    IsRepresentable p q n :=
+  ⟨{n}, Finset.singleton_nonempty n, by simpa using h,
+    by intro a ha b hb hab; simp only [Finset.mem_singleton] at ha hb
+       exact absurd (ha.trans hb.symm) hab,
+    by simp⟩
+
+/-- **The unit `1` is representable for every pair** — it is the power form `p^0 q^0`.
+Generalises `example_1_representable` from `{3,2}` to all `p, q`. -/
+theorem isRepresentable_one {p q : ℕ} : IsRepresentable p q 1 :=
+  isRepresentable_of_isPowerForm ⟨0, 0, by simp⟩
+
+/-- **Every power form `p^a q^b` is representable.** The representable set contains the
+whole multiplicative monoid of power forms — immediate from `isRepresentable_of_isPowerForm`. -/
+theorem isRepresentable_powerForm {p q : ℕ} (a b : ℕ) :
+    IsRepresentable p q (p ^ a * q ^ b) :=
+  isRepresentable_of_isPowerForm ⟨a, b, rfl⟩
+
 /-- **Representability window characterization (unconditional, 0-axiom).**
 For `q ≤ n < 2q`, the number `n` is representable iff it is itself a single power
 form `p^k q^l`. Forward: every summand is `≥ q` (`representable_summands_ge_q`),
@@ -579,10 +603,7 @@ theorem isRepresentable_iff_isPowerForm_window {p q n : ℕ} (hp : p > q) (hq : 
     rw [← hsum]
     exact hpf x (Finset.mem_singleton_self x)
   · intro h
-    exact ⟨{n}, Finset.singleton_nonempty n, by simpa using h,
-      by intro a ha b hb hab; simp only [Finset.mem_singleton] at ha hb
-         exact absurd (ha.trans hb.symm) hab,
-      by simp⟩
+    exact isRepresentable_of_isPowerForm h
 
 /-- **Non-power-forms in the window `[q, 2q)` are non-representable
 (unconditional, 0-axiom).** Contrapositive of the window characterization. This
@@ -1020,21 +1041,7 @@ The lower bound improves to f(n) ≫ n / log n.
 **Example: 1 = 2^0 · 3^0:**
 The number 1 is trivially representable (single summand).
 -/
-theorem example_1_representable : IsRepresentable 3 2 1 := by
-  use {1}
-  constructor
-  · simp
-  constructor
-  · intro s hs
-    simp at hs
-    subst hs
-    use 0, 0
-    simp
-  constructor
-  · intro a ha b hb hab
-    simp at ha hb
-    omega
-  · simp
+theorem example_1_representable : IsRepresentable 3 2 1 := isRepresentable_one
 
 /-
 **Example: Small cases for {3,2}:**

--- a/research/problems/erdos-1110-oq-01/state.md
+++ b/research/problems/erdos-1110-oq-01/state.md
@@ -2,8 +2,36 @@
 
 **Phase**: ACT — {2,3} case fully solved + density-zero + coprime-empty + window characterization; 1 deep axiom remains
 **Since**: 2026-05-29T19:14:09.134Z
-**Iteration**: 5
-**Last Updated**: 2026-06-28 (researcher-7, S6 ACT)
+**Iteration**: 6
+**Last Updated**: 2026-06-28 (researcher-1, S7 ACT)
+
+## S7 ACT (researcher-1, 2026-06-28) — general power-form representability, 0-axiom + dedup
+
+Filled a genuine foundational gap and removed code duplication, unconditionally (0-axiom):
+- `isRepresentable_of_isPowerForm` : **every power form `p^k q^l` is representable**
+  (singleton antichain `{n}`). This fact was previously only *inline* inside the backward
+  direction of `isRepresentable_iff_isPowerForm_window`; extracted as a reusable public
+  lemma and the window proof now calls it (dedup).
+- `isRepresentable_one` : `IsRepresentable p q 1` for every pair (the power form `p^0 q^0`).
+  Generalises the old `{3,2}`-only `example_1_representable`, now a one-line corollary
+  (`:= isRepresentable_one`), replacing its ~12-line bespoke proof.
+- `isRepresentable_powerForm a b` : `IsRepresentable p q (p^a q^b)` — the representable set
+  contains the whole multiplicative monoid of power forms.
+
+Docker build VERIFIED (`docker-build.sh Proofs.Erdos1110Problem`, Build succeeded);
+new lemmas are `#print axioms`-clean by construction (reference only `IsPowerForm`/
+`IsRepresentable`, Finset, `simp` — independent of `erdos_lewin_infinite`). Net diff
++26/−19 (3 new public theorems, two inline proofs deduplicated). File axiom count
+UNCHANGED at 1.
+
+ASSESSMENT (honest): foundational completeness / cleanup, **not progress on the open
+conjecture.** The sole remaining axiom `erdos_lewin_infinite` is the deep Erdős–Lewin 1996
+infinitude direction (not in Mathlib). The elementary toolkit cannot reach it: the window
+family is finite, and the multiplicative closure (`nonRepresentable_of_mul_powerForm`)
+propagates non-representability *downward* only, so it generates no new non-representables.
+Infinitude needs the counting/antichain argument — multi-session, likely needing new
+Mathlib infrastructure. The elementary side is now genuinely exhausted; treat the axiom as
+BLOCKED for session-sized work.
 
 ## S6 ACT (researcher-7, 2026-06-28) — window characterization `[q,2q)`, 0-axiom
 

--- a/src/data/research/problems/erdos-1110-oq-01.json
+++ b/src/data/research/problems/erdos-1110-oq-01.json
@@ -20,8 +20,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-28",
-    "iteration": 5,
-    "focus": "Iteration 5 (researcher-8, 2026-06-28): added a SHARP criterion for the canonical candidate q+1, 0-axiom — add_one_nonRepresentable_iff: (q+1) non-representable <-> q+1 is not a power of p, for every p>q>=2, via the window characterization. Corollary add_one_nonRepresentable_of_lt covers all pairs with p>=q+2; verified 3 in NonRepresentable 5 2. Elegantly pinpoints the {2,3} exclusion as the unique q=2 case where the q+1=3 witness is itself a power form (3=3^1, p=3). File builds clean against pinned Mathlib 4.26 (only pre-existing unused-variable warning at line 98); new theorems use only rw/simp/omega/Nat-dvd lemmas => foundational axioms only. PREVIOUS — Iteration 4 (researcher-10): proved the unconditional EXISTENCE shadow of the deep infinitude axiom (0-axiom). Added Part IIc: exists_positive_nonRepresentable_of_ne_two_three — for every coprime p>q>=2 with {p,q}!={2,3} there is a POSITIVE non-representable number. Universal small witnesses: when q>=3 the number 2 is non-representable (two_nonRepresentable_of_three_le), when q=2 (so p>=4 since p>2, p!=3) the number 3 is non-representable (three_nonRepresentable_of_q_two). Power-form bounds isPowerForm_eq_one_of_le_two (both bases >=3 => only form <=2 is 1) and isPowerForm_le_two_or_eq (q=2,p>=4 => forms <=3 are exactly {1,2}, and {1,2} not an antichain since 1|2). This sharpens the contrast with nonRepresentable_three_two={0}: the {2,3} pair has NO positive non-representable, every other coprime pair has at least one. All 3 new theorems verified [propext, Classical.choice, Quot.sound] only (0-axiom). File compiles clean against pinned Mathlib 4.26 (lake env lean exit 0). NOTE: rebased onto current origin/main (the iter-3 density-zero work hasDensity_singleton_zero / nonRepresentable_*_density_zero had landed after my branch base; preserved intact). Updated meta.json (stale 437/13 and 523/20 stat blocks) to 696 lines / 28 theorems.",
+    "iteration": 6,
+    "focus": "Extracted the general power-form-is-representable lemma (was duplicated inline); the representable set contains the entire multiplicative monoid of power forms. Deep infinitude axiom (Erdos-Lewin 1996) remains the sole open content.",
     "blockers": [
       "The deep direction of Erdos-Lewin ({p,q}!={2,3} => INFINITELY many non-representable) is not in Mathlib 4.26; it stays axiomatized as erdos_lewin_infinite. The existence half (>=1 non-representable) is now proved; only the jump from existence to infinitude remains."
     ],
@@ -97,15 +97,15 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.134Z",
-  "lastUpdate": "2026-06-28",
+  "lastUpdate": "2026-06-28T11:10:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1110Problem.lean",
       "filename": "Erdos1110Problem.lean",
-      "lineCount": 951,
-      "theoremCount": 35,
+      "lineCount": 1097,
+      "theoremCount": 34,
       "axiomCount": 1,
       "defCount": 7,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Foundational-completeness + cleanup increment for `erdos-1110-oq-01` (Erdős #1110, Erdős–Lewin representability). Extracts a genuinely missing lemma and removes code duplication, all **unconditional (0-axiom, 0-sorry)**; `docker-build.sh Proofs.Erdos1110Problem` → **Build succeeded**.

## What's added

- **`isRepresentable_of_isPowerForm`** — every power form `p^k q^l` is representable (via the singleton antichain `{n}`). This fact previously lived only *inline* inside the backward direction of `isRepresentable_iff_isPowerForm_window`; it is now a reusable public lemma, and the window proof calls it.
- **`isRepresentable_one`** — `IsRepresentable p q 1` for every pair (the power form `p^0 q^0`). Generalises the old `{3,2}`-only `example_1_representable`, which is now a one-line corollary (`:= isRepresentable_one`), replacing its ~12-line bespoke proof.
- **`isRepresentable_powerForm a b`** — `IsRepresentable p q (p^a q^b)`: the representable set contains the whole multiplicative monoid of power forms.

Net diff **+26 / −19** — 3 new public theorems, two inline/bespoke proofs deduplicated.

## Verification & axiom status

- Docker build succeeds; **0 sorries**, **axiom count unchanged at 1**.
- The new lemmas reference only `IsPowerForm`/`IsRepresentable`, `Finset`, and `simp`, so they are independent of the deep axiom `erdos_lewin_infinite` by construction.

## Honest scope note

This is **foundational completeness / cleanup, not progress on the open conjecture.** The sole remaining axiom `erdos_lewin_infinite` is the deep Erdős–Lewin 1996 infinitude direction (`{p,q} ≠ {2,3} ⟹ infinitely many non-representables`), which is not in Mathlib. The elementary toolkit cannot reach it: the window family is finite, and the multiplicative closure (`nonRepresentable_of_mul_powerForm`) propagates non-representability *downward* only, generating no new non-representables. Infinitude needs the counting/antichain argument — multi-session, likely requiring new Mathlib infrastructure. The elementary side is now genuinely exhausted (see `state.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)