### PR TITLE
research(sperner-ndim-oq-02): per-vertex evaluation of the reduced boundary-coordinate condition [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -1626,4 +1626,79 @@ theorem miss_not_boundary_face (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤ d) 
     have := h 0 hne
     omega
 
+/-!
+## Per-vertex evaluation of the reduced boundary-coordinate condition
+
+The previous section reduced `boundary_face` at a `none` facet `k` to the
+barycentric statement `∀ j ≠ k, (s.verts j).coords k = 0`
+(`boundary_face_iff_coords_zero`) but did **not** evaluate that coordinate
+condition.  This section does, vertex by vertex, exploiting the fact that
+`incDir : Fin d → Fin (d+1)` is a bijection onto the complement of `miss`
+(`incDir_surj_complement`): every barycentric coordinate is *either* the `miss`
+direction or exactly one increase direction `incDir k`.  So each
+`(s.verts m).coords c = 0` test resolves into one of two closed forms:
+
+  * **increase direction** `c = incDir k`: zero iff it starts at zero and step
+    `k` has not yet occurred (`m.val ≤ k.val`) — `coord_incDir_eq_zero_iff`;
+  * **miss direction** `c = miss`: zero iff `m` has reached the base value
+    `(s.verts 0).coords miss` — `miss_coord_eq_zero_iff` — which, since that base
+    value is `≥ d`, forces `m = Fin.last d` (`onFace_miss_imp_last`).
+
+These are the evaluation lemmas a total `adj` will feed into
+`boundary_face_iff_coords_zero`; they sharpen `miss_not_boundary_face` from a mere
+existence witness into a full localization of *which* vertices fail.  All
+0-sorry, 0-axiom.
+-/
+
+/-- **Vanishing of a non-miss coordinate, per vertex.**  The increase-direction
+coordinate `incDir k` is zero at chain vertex `m` exactly when it starts at zero
+(`(verts 0).coords (incDir k) = 0`) and step `k` has not yet been taken
+(`m.val ≤ k.val`).  Direct consequence of the per-vertex formula
+`coord_incDir_at`, which makes this coordinate `base + (1 if k < m else 0)`.
+Complements `boundary_face_iff_coords_zero`: it evaluates the reduced coordinate
+condition at every increase-direction facet. -/
+theorem coord_incDir_eq_zero_iff (s : SpernerGrid.GridSimplex d N) (k : Fin d)
+    (m : Fin (d + 1)) :
+    (s.verts m).coords (s.incDir k) = 0 ↔
+      (s.verts 0).coords (s.incDir k) = 0 ∧ m.val ≤ k.val := by
+  rw [s.coord_incDir_at k m]
+  by_cases h : k.val < m.val
+  · rw [if_pos h]; omega
+  · rw [if_neg h]; omega
+
+/-- **Vanishing of the miss coordinate, per vertex.**  The `miss` coordinate is
+zero at chain vertex `m` exactly when `m` has reached the base value:
+`(verts 0).coords miss ≤ m.val`.  Direct consequence of `miss_coord_at`
+(`miss` coordinate `= base - m`, truncated subtraction). -/
+theorem miss_coord_eq_zero_iff (s : SpernerGrid.GridSimplex d N)
+    (m : Fin (d + 1)) :
+    (s.verts m).coords s.miss = 0 ↔ (s.verts 0).coords s.miss ≤ m.val := by
+  rw [s.miss_coord_at m]; omega
+
+/-- **The miss coordinate is positive away from the last vertex.**  Because the
+base `miss` value is at least `d` and the coordinate only drops by one per step,
+every chain vertex `m ≠ Fin.last d` still has a strictly positive `miss`
+coordinate.  Sharpens `miss_not_boundary_face`: not merely *some* vertex but
+*every* non-last vertex violates the `miss`-facet boundary condition. -/
+theorem miss_coord_pos_of_ne_last (s : SpernerGrid.GridSimplex d N)
+    (m : Fin (d + 1)) (hm : m ≠ Fin.last d) :
+    0 < (s.verts m).coords s.miss := by
+  have hge := s.miss_coord_ge m
+  have hmd : m.val < d := by
+    have hle : m.val ≤ d := Nat.lt_succ_iff.mp m.isLt
+    rcases hle.lt_or_eq with h | h
+    · exact h
+    · exact absurd (Fin.ext (h.trans (Fin.val_last d).symm)) hm
+  omega
+
+/-- **The miss-face is reached only by the last vertex.**  If grid vertex `m` lies
+on the geometric `miss`-face (`(s.verts m).coords miss = 0`) then `m = Fin.last d`.
+The pointwise localization behind `miss_not_boundary_face`: the geometric
+`miss`-boundary touches a Freudenthal cell only at the extreme end of its chain
+(and only in the extremal cell whose base `miss = d`). -/
+theorem onFace_miss_imp_last (s : SpernerGrid.GridSimplex d N) (m : Fin (d + 1))
+    (h : (s.verts m).coords s.miss = 0) : m = Fin.last d := by
+  by_contra hm
+  exact absurd h (Nat.pos_iff_ne_zero.mp (miss_coord_pos_of_ne_last s m hm))
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1,5 +1,73 @@
 # sperner-ndim-oq-02: Boundary-Door Oddness by Dimensional Induction
 
+## Session 2026-06-28 (researcher-4) — Per-vertex evaluation of the reduced boundary-coordinate condition
+
+**Mode**: ACT (CONTINUE Phase-1, next-step "boundary_face geometric half"). **Outcome**:
+PROGRESS — added a "Per-vertex evaluation" section to `SpernerNDimOQ02.lean` (+4
+theorems, ~75 L) building directly on researcher-1's same-day
+`boundary_face_iff_coords_zero` reduction. **Type-check VERIFIED via `lake env lean`
+against the main-repo olean cache (EXIT 0, clean)**; **`#print axioms` obtained** —
+`coord_incDir_eq_zero_iff`, `miss_coord_eq_zero_iff`, `miss_coord_pos_of_ne_last`,
+`onFace_miss_imp_last` all `[propext, Classical.choice, Quot.sound]`, i.e. **genuinely
+0-axiom**. (lean 4.26 single-file channel; the new lemmas only depend on already-built oleans.)
+
+### ⚠️ Concurrency note (read before claiming)
+researcher-1 landed an OVERLAPPING "Boundary-face reduction" section on `main`
+(`gridVertices_onFace_iff` / `boundary_face_iff_coords_zero` / `miss_not_boundary_face`)
+WHILE this session was in flight. My first draft duplicated their bridge and a miss-face
+lemma; I **rebased onto the new `origin/main` and deleted the duplicates**, keeping only
+what is genuinely novel relative to r1 (the per-vertex coordinate-vanishing
+characterizations — r1 has nothing on increase-direction coordinates or pointwise
+localization). Lesson reconfirmed: on a hot RICH problem several agents land within
+minutes; ALWAYS `git fetch origin main` and rebase before pushing, and diff your planned
+decls against the just-merged section. (Also: the shared worktree gets `reset --hard` by
+a concurrent process — commit each file change immediately, don't leave edits uncommitted.)
+
+### What was delivered (`SpernerNDimOQ02.lean`, after `miss_not_boundary_face`)
+The structural key is that `incDir : Fin d → Fin (d+1)` is a bijection onto the
+complement of `miss` (`incDir_surj_complement`): **every** barycentric coordinate is
+either `miss` (decreasing) or exactly one increase direction `incDir k` (a single +1
+step). There are **no flat coordinates** — useful negative fact: do not look for a
+"constant coordinate" lemma, it would be vacuous. So r1's reduced RHS
+`(s.verts j).coords k = 0` resolves into two closed forms:
+
+- **`coord_incDir_eq_zero_iff (s k m)`** `: (s.verts m).coords (s.incDir k) = 0 ↔
+  (s.verts 0).coords (s.incDir k) = 0 ∧ m.val ≤ k.val` — an increase-direction
+  coordinate vanishes at vertex `m` iff it starts at 0 and step `k` has not yet
+  happened. From `coord_incDir_at` (`= base + (1 if k<m else 0)`) + `omega`.
+- **`miss_coord_eq_zero_iff (s m)`** `: (s.verts m).coords s.miss = 0 ↔
+  (s.verts 0).coords s.miss ≤ m.val` — from `miss_coord_at` (`= base - m`) + `omega`.
+- **`miss_coord_pos_of_ne_last (s m) (hm : m ≠ Fin.last d)`** `: 0 < (s.verts m).coords
+  s.miss` — sharpens r1's `miss_not_boundary_face` from "some vertex fails" to "EVERY
+  non-last vertex fails". From `miss_coord_ge` (`≥ d - m`) + `base_miss_ge_d`.
+- **`onFace_miss_imp_last (s m)`** `: (s.verts m).coords s.miss = 0 → m = Fin.last d` —
+  pointwise localization: the geometric `miss`-face touches a Freudenthal cell only at
+  the last chain vertex (and only in the extremal cell with base `miss = d`).
+
+### Why this matters (Phase-1)
+r1 reduced `boundary_face` at a `none` facet to a coordinate test but left it
+unevaluated. These lemmas EVALUATE that test vertex-by-vertex. The `miss` facet is
+excluded outright (`miss_coord_pos_of_ne_last`); an increase-direction facet's condition
+becomes a pure chain-index inequality (`coord_incDir_eq_zero_iff`). This is the concrete
+arithmetic toolkit the cross-chain decision needs.
+
+### ⚠️ Frontier UNCHANGED (the genuine blocker — same as r1/r2/r5)
+Still the **cross-chain gluing**: a chain-boundary facet `k ∈ {0, Fin.last d}` interior
+to `Δ_N` is glued to a cell in a DIFFERENT Kuhn chain (different `miss`), which
+`pivotSimplex` does not produce. A TOTAL `adj` needs either the cross-`miss` partner
+construction or a proof that such facets lie on `∂Δ_N`. The coordinate toolkit (r1's
+reduction + this session's evaluation lemmas) is now complete; the missing piece is
+purely the gluing geometry (≳ several hundred lines).
+
+### Next steps
+1. **(next)** Commit to a cross-chain `adj` design: either (a) construct the cross-`miss`
+   partner cell for a chain-boundary facet interior to `Δ_N`, or (b) prove a chain-boundary
+   facet lies on `∂Δ_N` exactly when [coordinate condition], then `adj=none` is sound and
+   `boundary_face_iff_coords_zero` + this session's evaluation lemmas finish `boundary_face`.
+2. Use `coord_incDir_eq_zero_iff` to prove the increase-direction `boundary_face`
+   characterization as a standalone lemma if (b) is chosen.
+3. Assemble the `SpernerTriangulation` instance; then Phase 2 door oddness by induction on `d`.
+
 ## Session 2026-06-28 (researcher-1) — Boundary-face reduction to barycentric coordinates
 
 **Mode**: ACT (CONTINUE Phase-1, next-step "boundary_face geometric half"). **Outcome**:


### PR DESCRIPTION
## Summary

Continues Phase-1 of `sperner-ndim-oq-02` (assembling the Freudenthal `SpernerTriangulation` instance toward boundary-door oddness). Builds directly on researcher-1's same-day `boundary_face_iff_coords_zero` reduction (which reduced the abstract `boundary_face` obligation at a `none` facet `k` to the barycentric test `∀ j ≠ k, (s.verts j).coords k = 0`) by **evaluating that coordinate test vertex-by-vertex**.

Structural key: `incDir : Fin d → Fin (d+1)` is a bijection onto the complement of `miss` (`incDir_surj_complement`), so every barycentric coordinate is *either* the `miss` direction (decreasing) *or* exactly one increase direction `incDir k` (a single +1 step). There are **no flat coordinates**, so each `(s.verts m).coords c = 0` test resolves into one of two closed forms.

## New theorems (`proofs/Proofs/SpernerNDimOQ02.lean`, +4 decls, ~75 L)

- **`coord_incDir_eq_zero_iff`** — `(s.verts m).coords (s.incDir k) = 0 ↔ (s.verts 0).coords (s.incDir k) = 0 ∧ m.val ≤ k.val`. An increase-direction coordinate vanishes at vertex `m` iff it starts at 0 and step `k` hasn't happened. (From `coord_incDir_at` + `omega`.)
- **`miss_coord_eq_zero_iff`** — `(s.verts m).coords s.miss = 0 ↔ (s.verts 0).coords s.miss ≤ m.val`. (From `miss_coord_at` + `omega`.)
- **`miss_coord_pos_of_ne_last`** — `m ≠ Fin.last d → 0 < (s.verts m).coords s.miss`. Sharpens r1's `miss_not_boundary_face` from "*some* vertex fails" to "*every* non-last vertex fails".
- **`onFace_miss_imp_last`** — `(s.verts m).coords s.miss = 0 → m = Fin.last d`. Pointwise localization: the geometric `miss`-face touches a cell only at the last chain vertex.

## Why it matters

r1 reduced `boundary_face` to a coordinate test but left it unevaluated. These lemmas evaluate it: the `miss` facet is excluded outright, and an increase-direction facet's condition collapses to a pure chain-index inequality. This is the arithmetic toolkit the remaining **cross-chain gluing** frontier needs (a chain-boundary facet interior to Δ_N is glued to a different Kuhn chain — the genuine, still-open blocker).

## Verification

- Type-checked via `lake env lean` against the main-repo olean cache (lean 4.26): **EXIT 0, clean**.
- `#print axioms` on all 4 new decls: `[propext, Classical.choice, Quot.sound]` only — **genuinely 0-axiom, 0-sorry** (no `Lean.ofReduceBool`, no `sorryAx`).

## Note on overlap

researcher-1's overlapping reduction landed on `main` while this was in flight; the branch was rebased onto it and duplicate drafts (the `gridVertices_onFace_iff` bridge + a miss-face lemma) were removed. What remains is novel relative to r1 (per-vertex increase-direction coordinates + pointwise localization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)