### PR TITLE
audit(area-of-circle-oq-03-oq-02-oq-01): correct theoremCount 7→8

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
@@ -66,7 +66,7 @@
     "assumptions": "Fully verified: 0 axioms, 0 sorries remain.",
     "lineCount": 223,
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 1
   },
   "overview": {
@@ -179,7 +179,7 @@
     "namespace": "AreaOfCircleOQ03OQ02OQ01",
     "lineCount": 223,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 1,
     "mainTheorems": [
       "archimedes_sin_doubling",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `area-of-circle-oq-03-oq-02-oq-01` (Archimedes' Half-Angle Doubling Method)
**Severity**: LOW (cosmetic metadata, conservative undercount — no public credibility claim affected)

## Issue

`meta.json` reported `theoremCount: 7` in both `meta.meta` and `leanFile`, but the Lean source `proofs/Proofs/AreaOfCircleOQ03OQ02OQ01.lean` declares **8** theorems:

1. `archimedes_sin_doubling`
2. `archimedes_cos_doubling`
3. `halfPerimeter_hexagon`
4. `halfPerimeter_pow_two`
5. `halfPerimeter_doubling`
6. `halfPerimeter_lt_pi`
7. `halfPerimeter_tendsto_pi`
8. `archimedes_doubling_method_verified`

The `leanFile.mainTheorems` array already lists all 8 names, so the `theoremCount: 7` was internally inconsistent with the same file's own data.

## Fix

`theoremCount: 7 → 8` in both locations. No other field touched.

## Audit verdict (rest of entry is CLEAN)

- 0 sorries (matches) ✓
- 0 `axiom` declarations, no structure-encoded assumptions (matches `axiomCount: 0`) ✓
- No `True` stubs, no `native_decide` ✓
- `badge: "mathlib"` correctly reflects doubling identities derived from Mathlib half-angle lemmas (Tier B); Mathlib reliance is disclosed in `description`, `proofStrategy`, and `mathlibDependencies` — no delegation opacity ✓
- `status: "verified"` honest: fully machine-checked, 0 assumptions ✓
- `originalContributions` properly scoped ✓

---
Discovered during gallery integrity audit.