### PR TITLE
fix: register orphan AreaOfCircleOQ03OQ02OQ01 in Proofs.lean

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -206,6 +206,7 @@ import Proofs.AreaOfCircleOQ02OQ01
 import Proofs.AreaOfCircleOQ02OQ04
 import Proofs.AreaOfCircleOQ03OQ01
 import Proofs.AreaOfCircleOQ03OQ02
+import Proofs.AreaOfCircleOQ03OQ02OQ01
 import Proofs.AreaOfCircleOQ03OQ02OQ02
 import Proofs.AreaOfCircleOQ03OQ02OQ02OQ01
 import Proofs.AreaOfCircleOQ03OQ03


### PR DESCRIPTION
PR #31429 merged `Proofs/AreaOfCircleOQ03OQ02OQ01.lean` plus its gallery data, but the aggregate import line in `proofs/Proofs.lean` landed after the squash-merge, so the module is currently **unregistered (orphan)** on main. This one-line PR adds the missing `import Proofs.AreaOfCircleOQ03OQ02OQ01`.

The file itself is already machine-verified (built against Mathlib 4.26.0, 0 sorries / 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)