### PR TITLE
Enrich Eisenstein reciprocity sawtooth input (hermite-sawtooth-identity-oq-02)

### DIFF
--- a/src/data/proofs/hermite-sawtooth-identity-oq-02/annotations.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-02/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "hermite-sawtooth-identity-oq-02",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "context",
+    "title": "What is being proved and why it matters",
+    "content": "The header frames the target as the arithmetic ingredient of Eisenstein's lemma: the average of the sawtooth $\\{kp/q\\}$ over a *complete* residue system is exactly the diagonal value $(q-1)/2$, independent of $p$. Two elementary facts combine — the $x=0$ specialisation of the parent sawtooth identity and the residue permutation forced by $\\gcd(p,q)=1$. Note the genuinely averaged statement: dividing the sum by the number of terms $q$ gives mean $\\tfrac{q-1}{2q}\\to\\tfrac12$, the equidistribution value the sawtooth has over $[0,1)$.",
+    "mathContext": "$\\frac1q\\sum_{k<q}\\left\\{\\tfrac{kp}{q}\\right\\} = \\tfrac{q-1}{2q}\\xrightarrow{q\\to\\infty}\\tfrac12$.",
+    "significance": "context",
+    "prerequisites": ["Quadratic reciprocity", "Eisenstein's lemma"],
+    "relatedConcepts": ["Equidistribution", "Complete residue system", "Lattice-point counting"]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "hermite-sawtooth-identity-oq-02",
+    "range": { "startLine": 38, "endLine": 43 },
+    "type": "context",
+    "title": "Importing the parent identity",
+    "content": "Beyond `import Mathlib`, the file imports `Proofs.HermiteSawtoothIdentity` — the parent gallery entry — and reopens its namespace. This is what makes `hermite_sawtooth_identity` available for the one-line specialisation in `sum_fract_div`. The dependency is deliberate: this entry is a *consumer* of the parent identity, demonstrating that the analytic sawtooth formula is not a curiosity but the engine behind a concrete number-theoretic evaluation. `open Finset` brings `range`, `sum_image`, and `card_range` into scope for the residue-permutation argument.",
+    "mathContext": "`import Proofs.HermiteSawtoothIdentity` exposes $\\sum_{k<n}\\{x+k/n\\}=\\{nx\\}+\\tfrac{n-1}2$.",
+    "significance": "supporting",
+    "prerequisites": ["Lean module system", "Namespaces"],
+    "relatedConcepts": ["Proof reuse", "Sawtooth identity"]
+  },
+  {
     "id": "ann-sawtooth-zero",
     "proofId": "hermite-sawtooth-identity-oq-02",
     "range": { "startLine": 45, "endLine": 50 },

--- a/src/data/proofs/hermite-sawtooth-identity-oq-02/index.ts
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HermiteSawtoothIdentityOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hermiteSawtoothIdentityOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hermiteSawtoothIdentityOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hermiteSawtoothIdentityOq02Data: ProofData = {
+  proof: hermiteSawtoothIdentityOq02Proof,
+  annotations: hermiteSawtoothIdentityOq02Annotations,
+}

--- a/src/data/proofs/hermite-sawtooth-identity-oq-02/meta.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-02/meta.json
@@ -57,6 +57,13 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Statement and parent import",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Docstring framing the goal — the p-independent sawtooth average (q−1)/2 over a complete residue system — as the arithmetic input to Eisenstein's lemma, followed by `import Proofs.HermiteSawtoothIdentity` (the parent gallery entry supplying hermite_sawtooth_identity) and `open Finset` for the residue-permutation API."
+    },
+    {
       "id": "sawtooth-zero",
       "title": "Sawtooth at x = 0",
       "startLine": 45,
@@ -86,7 +93,8 @@
       "**The value is $p$-independent, and that is the whole point.** Coprimality means multiplication by $p$ only relabels the residues, so $\\sum_k\\{kp/q\\}$ cannot depend on $p$ — it equals the $p = 1$ value $(q-1)/2$ for every unit $p$.",
       "**The fractional part is a residue in disguise.** `Int.fract_div_natCast_eq_div_natCast_mod` turns the analytic $\\{kp/q\\}$ into the arithmetic $(kp \\bmod q)/q$, after which no analysis remains — only a finite sum over a permuted residue system.",
       "**Injective ⟹ bijective is the only number theory used.** Once $k \\mapsto kp \\bmod q$ is shown injective via coprime cancellation, the pigeonhole upgrade to a permutation (`eq_of_subset_of_card_le`) supplies the rearrangement for free.",
-      "**The diagonal term $(q-1)/2$ is the parent sawtooth's fingerprint.** Specialising $\\sum_{k<n}\\{x+k/n\\} = \\{nx\\}+(n-1)/2$ at $x=0$ exhibits exactly the $(n-1)/2$ term the open question asked to surface."
+      "**The diagonal term $(q-1)/2$ is the parent sawtooth's fingerprint.** Specialising $\\sum_{k<n}\\{x+k/n\\} = \\{nx\\}+(n-1)/2$ at $x=0$ exhibits exactly the $(n-1)/2$ term the open question asked to surface.",
+      "**The result is exact equidistribution.** The *average* of the sawtooth over the residue system is $\\tfrac1q\\sum_{k<q}\\{kp/q\\} = \\tfrac{q-1}{2q}$, which converges to $\\tfrac12$ — the mean of $\\{y\\}$ on $[0,1)$ — as $q\\to\\infty$. Coprimality makes this an identity, not just an asymptotic: the residues hit every point of the lattice $\\{0,1/q,\\dots,(q-1)/q\\}$ exactly once."
     ],
     "prerequisites": [
       "Fractional part Int.fract and floor",


### PR DESCRIPTION
Enrichment pass for `hermite-sawtooth-identity-oq-02` (∑_{k<q} {kp/q} = (q−1)/2 for coprime p,q).

## Changes
- **Created missing `index.ts`** — without it the proof page renders "proof not found" on the live site despite appearing in the gallery listing. This was the highest-impact fix.
- **Annotations 3 → 5**: added `ann-header` (frames the goal as Eisenstein's reciprocity input + the equidistribution average) and `ann-imports` (explains the deliberate dependency on the parent `HermiteSawtoothIdentity` entry). Code coverage now extends to lines 1–43, previously uncovered.
- **keyInsight added**: the result is *exact* equidistribution — the average `(1/q)·∑{kp/q} = (q−1)/(2q) → 1/2`, an identity (not just asymptotic) because coprimality makes the residues hit every lattice point once.
- **Section added**: "Statement and parent import" covering lines 1–43.

## Verification
- `pnpm build` passes (exit 0); size check confirms all entries within caps. meta.json 13.5 KB (well under 60 KB cap).
- Axiom integrity unchanged: status `verified`, 0 axioms, 0 sorries — consistent with the Lean source (`#print axioms` reports only propext/Classical.choice/Quot.sound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
