### PR TITLE
research(feuerbachs-theorem-oq-04): point separation — sdist is a genuine metric [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -42,6 +42,10 @@ construction; this file establishes the metric layer underneath that constructio
   `[-1, 1]`, so `sdist` is a genuine angle.
 * `scos_self`, `sdist_self`, `sdist_nonneg`, `sdist_le_pi`, `sdist_eq_zero_of_eq` — `sdist`
   is a well-defined `[0, π]`-valued quantity vanishing on the diagonal.
+* `scos_eq_one_iff`, `sdist_eq_zero_iff`, `sdist_pos` — **point separation**: for unit
+  vectors `sdist P Q = 0 ↔ P = Q`, so together with symmetry and nonnegativity `sdist`
+  separates points and is a genuine metric on the spherical model (modulo the spherical
+  triangle inequality).
 -/
 import Mathlib
 
@@ -112,6 +116,42 @@ theorem sdist_eq_zero_of_eq {P Q : E} (hP : OnSphere P) (h : P = Q) : sdist P Q 
 /-- Spherical distance is symmetric (the inner product commutes). -/
 theorem sdist_comm (P Q : E) : sdist P Q = sdist Q P := by
   unfold sdist; rw [real_inner_comm]
+
+/-- **Spherical cosine `1` characterises equality.**  For unit vectors `P, Q`, the chord
+`‖P − Q‖² = 2 − 2·scos P Q` (`chord_sq`) vanishes exactly when `scos P Q = 1`, i.e. exactly
+when `P = Q`.  This is the algebraic heart of point separation. -/
+theorem scos_eq_one_iff {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q) :
+    scos P Q = 1 ↔ P = Q := by
+  refine ⟨fun h => ?_, fun h => h ▸ scos_self P hP⟩
+  have hsq : ‖P - Q‖ ^ 2 = 0 := by rw [chord_sq P Q hP hQ, h]; ring
+  have hz : ‖P - Q‖ = 0 := by
+    have hnn := norm_nonneg (P - Q)
+    have hle : ‖P - Q‖ ≤ 0 := by nlinarith [hsq, hnn]
+    linarith
+  rw [norm_eq_zero, sub_eq_zero] at hz
+  exact hz
+
+/-- **Point separation.**  For unit vectors, spherical distance `0` characterises equality.
+Combined with `sdist_self` (vanishing on the diagonal), `sdist_nonneg`, and `sdist_comm`
+(symmetry), this shows `sdist` separates points, so it is a genuine metric on the spherical
+model — only the spherical triangle inequality remains to make `(Sⁿ, sdist)` a metric
+space.  Proof: `arccos` of the inner product is `0` iff that inner product is `≥ 1`, which
+for unit vectors forces `scos P Q = 1`, hence `P = Q` by `scos_eq_one_iff`. -/
+theorem sdist_eq_zero_iff {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q) :
+    sdist P Q = 0 ↔ P = Q := by
+  rw [sdist, Real.arccos_eq_zero]
+  constructor
+  · intro h
+    exact (scos_eq_one_iff hP hQ).mp (le_antisymm (scos_le_one P Q hP hQ) h)
+  · intro h
+    have h1 : scos P Q = 1 := (scos_eq_one_iff hP hQ).mpr h
+    rw [scos] at h1
+    exact h1.ge
+
+/-- Distinct model points are at strictly positive spherical distance. -/
+theorem sdist_pos {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q) (hPQ : P ≠ Q) :
+    0 < sdist P Q :=
+  lt_of_le_of_ne (sdist_nonneg P Q) fun h => hPQ ((sdist_eq_zero_iff hP hQ).mp h.symm)
 
 /-- **Cosine of the spherical distance is the spherical cosine.**  Since
 `sdist P Q = arccos (scos P Q)` and the spherical cosine lies in `[-1, 1]` for unit

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -1,5 +1,44 @@
 # feuerbachs-theorem-oq-04 — Feuerbach's Theorem in Non-Euclidean Geometry
 
+## Session 2026-06-28 (researcher-4): point separation — sdist is a genuine metric [BUILD]
+
+**Mode**: ACT (CONTINUE). The metric foundations + spherical-circle/tangency layers were
+already verified on `main`; the one property still missing for `sdist` to be a genuine
+metric (besides the hard spherical triangle inequality) was **point separation** — that
+`sdist P Q = 0` forces `P = Q`. `main` only had the trivial forward direction
+(`sdist_eq_zero_of_eq`). **Outcome**: PROGRESS — added 3 verified declarations
+(~30 L). **Docker build VERIFIED** (`docker-build.sh Proofs.FeuerbachsTheoremOQ04`,
+`✔ [7743/7743]`); **0-sorry, 0-axiom**, no native_decide.
+
+### What was delivered (appended after `sdist_comm` in `FeuerbachsTheoremOQ04.lean`)
+- **`scos_eq_one_iff`** (algebraic core) : for unit `P,Q`, `scos P Q = 1 ↔ P = Q`. Forward
+  via `chord_sq` — `‖P−Q‖² = 2 − 2·scos P Q = 0`, so `‖P−Q‖ = 0` (norm nonneg + `nlinarith`)
+  and `sub_eq_zero`; backward is `scos_self`.
+- **`sdist_eq_zero_iff`** (headline) : for unit `P,Q`, `sdist P Q = 0 ↔ P = Q`. Uses
+  `Real.arccos_eq_zero` (`arccos x = 0 ↔ 1 ≤ x`); for unit vectors `scos P Q ≤ 1`, so
+  `1 ≤ scos P Q` forces `scos P Q = 1`, then `scos_eq_one_iff`.
+- **`sdist_pos`** : distinct model points are at strictly positive spherical distance
+  (`lt_of_le_of_ne` on `sdist_nonneg` + `sdist_eq_zero_iff`).
+
+Together with `sdist_self`, `sdist_nonneg`, and `sdist_comm` (all already on `main`), this
+makes `sdist` **separate points** — so `(Sⁿ, sdist)` is a genuine metric on the spherical
+model *modulo* the spherical triangle inequality (the only remaining axiom of a metric).
+
+GOTCHA: `Real.arccos_eq_zero` is stated as `arccos x = 0 ↔ 1 ≤ x` (a one-sided bound, not
+`x = 1`); the `scos P Q ≤ 1` bound is what upgrades `1 ≤ scos` to the equality. For
+`‖P−Q‖² = 0 ⇒ ‖P−Q‖ = 0`, `le_antisymm` of a `nlinarith`-proved `≤ 0` with `norm_nonneg`
+is robust (avoids guessing the exact `pow_eq_zero_iff` argument form).
+
+### Next steps (unchanged direction)
+1. **Spherical triangle inequality** `sdist P R ≤ sdist P Q + sdist Q R` would complete
+   `(Sⁿ, sdist)` as a `MetricSpace`. This is the genuinely hard analytic step (arccos
+   subadditivity / spherical law of cosines); check `InnerProductGeometry.angle` lemmas
+   in Mathlib first — for unit vectors `sdist = InnerProductGeometry.angle`.
+2. **Tangent-point existence** for tangent circles (construction-heavy slerp midpoint).
+3. Spherical incircle + nine-point circle; attempt the spherical Feuerbach tangency.
+
+BLOCKER (hyperbolic side, unchanged): no Mathlib hyperbolic metric — spherical model only.
+
 ## Session 2026-06-28 (researcher-1): spherical circles + tangency layer [BUILD]
 
 **Mode**: ACT (CONTINUE — executed researcher-2's next-steps 1 & 2: "define spherical

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -32,12 +32,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY+BUILD: gave the fresh stub a concrete formal grounding in the spherical model and a verified metric foundation layer (FeuerbachsTheoremOQ04.lean, 0-axiom). chord_sq is the chord-cosine bridge; scos/sdist are shown well-defined ([-1,1] cosine, [0,pi] distance vanishing on the diagonal). Hyperbolic model deferred (no Mathlib support). Next: spherical circle/incircle/nine-point constructions and the tangency criterion.",
+    "progressSummary": "BUILD: spherical model verified layer (FeuerbachsTheoremOQ04.lean, 0-axiom). chord_sq is the chord-cosine bridge; scos/sdist well-defined ([-1,1] cosine, [0,pi] distance). Spherical circles defined as scos level sets with the internal/external tangency criterion (mem_sCircle_iff_sdist, InternallyTangent/ExternallyTangent + symmetry). NEW (researcher-4): point separation — scos_eq_one_iff, sdist_eq_zero_iff (sdist P Q = 0 <-> P = Q), sdist_pos; with sdist_self/nonneg/comm this makes sdist a genuine metric modulo the spherical triangle inequality. Hyperbolic model deferred (no Mathlib support). Next: spherical triangle inequality, then incircle/nine-point constructions and the Feuerbach tangency.",
     "builtItems": [
       "FeuerbachsTheoremOQ04.chord_sq (Proofs/FeuerbachsTheoremOQ04.lean) — chord-cosine bridge: for unit vectors, ||P-Q||^2 = 2 - 2*scos P Q; turns spherical tangency into an inner-product equation. 0-axiom.",
       "FeuerbachsTheoremOQ04.abs_scos_le_one/scos_le_one/neg_one_le_scos — spherical cosine in [-1,1] (Cauchy-Schwarz on unit vectors)",
       "FeuerbachsTheoremOQ04.scos_self/sdist_self/sdist_nonneg/sdist_le_pi/sdist_eq_zero_of_eq — sdist is a well-defined [0,pi]-valued angle vanishing on the diagonal",
-      "defs OnSphere (unit vector), scos := <P,Q>, sdist := arccos <P,Q> — the spherical model primitives"
+      "defs OnSphere (unit vector), scos := <P,Q>, sdist := arccos <P,Q> — the spherical model primitives",
+      "FeuerbachsTheoremOQ04.scos_eq_one_iff/sdist_eq_zero_iff/sdist_pos (researcher-4) — point separation: for unit vectors sdist P Q = 0 iff P = Q, so sdist separates points (genuine metric modulo triangle ineq). 0-axiom."
     ],
     "insights": [
       "Mathlib has clean spherical geometry for free (unit vectors of any InnerProductSpace R E; geodesic distance = arccos of inner product) but essentially no hyperbolic metric, so the spherical model is the tractable non-Euclidean route for Feuerbach.",
@@ -49,8 +50,8 @@
       "No spherical-triangle incircle / nine-point-circle construction in Mathlib; must be built on scos/sdist."
     ],
     "nextSteps": [
-      "Define spherical circle (O, rho) as a level set of scos and prove the membership/tangency algebra via chord_sq.",
-      "Prove the spherical circle tangency criterion: two circles tangent iff sdist of centres = |rho1-rho2| (internal) or rho1+rho2 (external).",
+      "Prove the spherical triangle inequality sdist P R <= sdist P Q + sdist Q R to make (S^n, sdist) a MetricSpace; check InnerProductGeometry.angle lemmas (sdist = angle on unit vectors).",
+      "Tangent-point existence for tangent spherical circles (slerp midpoint on the geodesic between centres).",
       "Construct the spherical incircle and nine-point circle for a spherical triangle, then attempt the tangency conclusion."
     ]
   },
@@ -90,7 +91,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.293Z",
-  "lastUpdate": "2026-06-28T10:40:00.000Z",
+  "lastUpdate": "2026-06-28T11:30:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Extends the spherical-model foundations for **Feuerbach's Theorem in Non-Euclidean Geometry** (`feuerbachs-theorem-oq-04`) with the **point-separation** layer — the property that completes `sdist` as a *genuine metric* on the spherical model (modulo the spherical triangle inequality).

`main` already had the metric foundations (`chord_sq`, `scos`/`sdist` bounds), spherical circles, and the internal/external tangency criterion, but only the trivial forward direction `sdist_eq_zero_of_eq`. This adds the converse.

## New verified declarations (`proofs/Proofs/FeuerbachsTheoremOQ04.lean`)

- **`scos_eq_one_iff`** — for unit vectors `P, Q`: `scos P Q = 1 ↔ P = Q`. Forward via the chord–cosine bridge `chord_sq` (`‖P−Q‖² = 2 − 2·scos P Q = 0` ⇒ `P = Q`); backward is `scos_self`.
- **`sdist_eq_zero_iff`** (headline) — `sdist P Q = 0 ↔ P = Q`. Uses `Real.arccos_eq_zero` (`arccos x = 0 ↔ 1 ≤ x`); the unit-vector bound `scos P Q ≤ 1` upgrades `1 ≤ scos` to `scos = 1`, then `scos_eq_one_iff`.
- **`sdist_pos`** — distinct model points are at strictly positive spherical distance.

Together with `sdist_self`, `sdist_nonneg`, and `sdist_comm` (already on `main`), `sdist` now **separates points** — so `(Sⁿ, sdist)` is a genuine metric on the spherical model, with only the spherical triangle inequality remaining.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremOQ04` → `✔ [7743/7743] Built Proofs.FeuerbachsTheoremOQ04`
- **0 sorries, 0 `axiom` declarations, no `native_decide`** — foundational axioms only.

## Next steps (documented in knowledge.md)

1. Spherical triangle inequality → upgrade to a Mathlib `MetricSpace` (check `InnerProductGeometry.angle`).
2. Tangent-point existence for tangent circles (slerp midpoint).
3. Spherical incircle + nine-point circle; attempt the spherical Feuerbach tangency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)