### PR TITLE
research(feuerbachs-theorem-oq-04): tangent-point existence for externally tangent spherical circles [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -259,4 +259,89 @@ theorem externallyTangent_comm (O₁ : E) (ρ₁ : ℝ) (O₂ : E) (ρ₂ : ℝ)
   unfold ExternallyTangent
   rw [sdist_comm, add_comm]
 
+/-! ## The tangent point of two externally tangent circles
+
+The defining geometric content of tangency is that the two circles actually **meet** — at
+the point on the geodesic joining the centres, at angular distance `ρ₁` from `O₁` (hence
+`ρ₂` from `O₂`).  For externally tangent circles with `0 < ρ₁ + ρ₂ < π` we construct that
+point explicitly by spherical interpolation (`slerp`):
+
+  `P = cos ρ₁ · O₁ + (sin ρ₁ / sin(ρ₁+ρ₂)) · (O₂ − cos(ρ₁+ρ₂) · O₁)`,
+
+and verify it is a model point lying on **both** circles.  The second summand is the unit
+tangent at `O₁` pointing toward `O₂`; the coefficients are exactly the spherical law that
+sends `P` an arc `ρ₁` along the geodesic.  This is the construction-heavy crux underneath
+any tangency conclusion (and ultimately the spherical Feuerbach statement). -/
+
+/-- **Existence of the tangent point (external case).**  Two externally tangent spherical
+circles `(O₁, ρ₁)`, `(O₂, ρ₂)` with `0 < ρ₁ + ρ₂ < π` have a common point — the spherical
+interpolation point at arc `ρ₁` from `O₁` along the geodesic to `O₂`. -/
+theorem externallyTangent_has_common_point {O₁ O₂ : E}
+    (h₁ : OnSphere O₁) (h₂ : OnSphere O₂) {ρ₁ ρ₂ : ℝ}
+    (htan : ExternallyTangent O₁ ρ₁ O₂ ρ₂)
+    (hpos : 0 < ρ₁ + ρ₂) (hlt : ρ₁ + ρ₂ < Real.pi) :
+    ∃ P : E, P ∈ sCircle O₁ ρ₁ ∧ P ∈ sCircle O₂ ρ₂ := by
+  set c : ℝ := ⟪O₁, O₂⟫ with hc_def
+  set s : ℝ := Real.sin (ρ₁ + ρ₂) with hs_def
+  -- unit-vector self-inner products
+  have hO₁O₁ : (⟪O₁, O₁⟫ : ℝ) = 1 := by rw [real_inner_self_eq_norm_sq, h₁]; norm_num
+  have hO₂O₂ : (⟪O₂, O₂⟫ : ℝ) = 1 := by rw [real_inner_self_eq_norm_sq, h₂]; norm_num
+  -- cos / sin of the centre distance
+  have hcos : Real.cos (ρ₁ + ρ₂) = c := by
+    have h := cos_sdist O₁ O₂ h₁ h₂
+    rw [htan] at h
+    rw [h]; rfl
+  have hspos : 0 < s := Real.sin_pos_of_pos_of_lt_pi hpos hlt
+  have hsne : s ≠ 0 := ne_of_gt hspos
+  have hs2 : s ^ 2 = 1 - c ^ 2 := by
+    have h := Real.sin_sq_add_cos_sq (ρ₁ + ρ₂)
+    rw [hcos] at h; linarith
+  -- the spherical interpolation point
+  set P : E := Real.cos ρ₁ • O₁ + (Real.sin ρ₁ / s) • (O₂ - c • O₁) with hP_def
+  -- the inner product commutes (folded to c)
+  have hc21 : (⟪O₂, O₁⟫ : ℝ) = c := (real_inner_comm O₂ O₁).symm
+  -- orthogonality and norm of the tangent vector W = O₂ - c • O₁
+  have hW1 : (⟪O₁, O₂ - c • O₁⟫ : ℝ) = 0 := by
+    rw [inner_sub_right, real_inner_smul_right, hO₁O₁]; ring
+  have hW1' : (⟪O₂ - c • O₁, O₁⟫ : ℝ) = 0 := by
+    rw [real_inner_comm]; exact hW1
+  have hWW : (⟪O₂ - c • O₁, O₂ - c • O₁⟫ : ℝ) = s ^ 2 := by
+    simp only [inner_sub_left, inner_sub_right, real_inner_smul_left, real_inner_smul_right,
+      hc21, hO₁O₁, hO₂O₂]
+    rw [hs2]; ring
+  -- P is a model point
+  have hPP : (⟪P, P⟫ : ℝ) = 1 := by
+    have e : (⟪P, P⟫ : ℝ)
+        = Real.cos ρ₁ ^ 2 * ⟪O₁, O₁⟫
+          + 2 * (Real.cos ρ₁ * (Real.sin ρ₁ / s)) * ⟪O₁, O₂ - c • O₁⟫
+          + (Real.sin ρ₁ / s) ^ 2 * ⟪O₂ - c • O₁, O₂ - c • O₁⟫ := by
+      rw [hP_def]
+      simp only [inner_add_left, inner_add_right, real_inner_smul_left, real_inner_smul_right,
+        real_inner_comm (O₂ - c • O₁) O₁]
+      ring
+    rw [e, hO₁O₁, hW1, hWW]
+    have hss : (Real.sin ρ₁ / s) ^ 2 * s ^ 2 = Real.sin ρ₁ ^ 2 := by field_simp
+    linear_combination hss + Real.sin_sq_add_cos_sq ρ₁
+  have hP_sphere : OnSphere P := by
+    have hsq : ‖P‖ ^ 2 = 1 := by rw [← real_inner_self_eq_norm_sq]; exact hPP
+    have hfac : (‖P‖ - 1) * (‖P‖ + 1) = 0 := by nlinarith [hsq]
+    rcases mul_eq_zero.mp hfac with h | h
+    · show ‖P‖ = 1; linarith
+    · exact absurd h (by have := norm_nonneg P; positivity)
+  -- P lies on the first circle
+  have hPO₁ : scos P O₁ = Real.cos ρ₁ := by
+    rw [scos, hP_def, inner_add_left, real_inner_smul_left, real_inner_smul_left,
+      hO₁O₁, hW1']; ring
+  -- P lies on the second circle (spherical angle-subtraction)
+  have hPO₂ : scos P O₂ = Real.cos ρ₂ := by
+    have hsimp : Real.sin ρ₁ / s * s ^ 2 = Real.sin ρ₁ * s := by field_simp
+    rw [scos, hP_def, inner_add_left, real_inner_smul_left, real_inner_smul_left,
+      inner_sub_left, real_inner_smul_left, hO₂O₂,
+      show (1 : ℝ) - c * c = s ^ 2 from by linear_combination -hs2, hsimp,
+      show Real.cos ρ₂
+          = Real.cos (ρ₁ + ρ₂) * Real.cos ρ₁ + Real.sin (ρ₁ + ρ₂) * Real.sin ρ₁
+        from by rw [← Real.cos_sub]; congr 1; ring, hcos, ← hs_def]
+    ring
+  exact ⟨P, ⟨hP_sphere, hPO₁⟩, ⟨hP_sphere, hPO₂⟩⟩
+
 end FeuerbachsTheoremOQ04

--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -259,55 +259,60 @@ theorem externallyTangent_comm (O₁ : E) (ρ₁ : ℝ) (O₂ : E) (ρ₂ : ℝ)
   unfold ExternallyTangent
   rw [sdist_comm, add_comm]
 
-/-! ## The tangent point of two externally tangent circles
+/-! ## The tangent point of two tangent circles
 
 The defining geometric content of tangency is that the two circles actually **meet** — at
 the point on the geodesic joining the centres, at angular distance `ρ₁` from `O₁` (hence
-`ρ₂` from `O₂`).  For externally tangent circles with `0 < ρ₁ + ρ₂ < π` we construct that
-point explicitly by spherical interpolation (`slerp`):
+`ρ₂` from `O₂`).  We construct that point explicitly by spherical interpolation (`slerp`).
+If `d = sdist O₁ O₂ ∈ (0, π)` then
 
-  `P = cos ρ₁ · O₁ + (sin ρ₁ / sin(ρ₁+ρ₂)) · (O₂ − cos(ρ₁+ρ₂) · O₁)`,
+  `P = cos ρ₁ · O₁ + (sin ρ₁ / sin d) · (O₂ − cos d · O₁)`
 
-and verify it is a model point lying on **both** circles.  The second summand is the unit
-tangent at `O₁` pointing toward `O₂`; the coefficients are exactly the spherical law that
-sends `P` an arc `ρ₁` along the geodesic.  This is the construction-heavy crux underneath
-any tangency conclusion (and ultimately the spherical Feuerbach statement). -/
+is the point an arc `ρ₁` along the geodesic from `O₁` toward `O₂` (the second summand is
+the unit tangent at `O₁` pointing toward `O₂`).  The core lemma
+`sphere_slerp_common_point` shows `P` is a model point with `sdist P O₁ = ρ₁` and, *given
+the spherical angle relation* `cos ρ₂ = cos ρ₁ cos d + sin ρ₁ sin d`, also `sdist P O₂ = ρ₂`.
+Both the **external** (`d = ρ₁ + ρ₂`) and **internal** (`d = |ρ₁ − ρ₂|`) tangency cases are
+then immediate, since each supplies that angle relation by the cosine subtraction formula.
+This is the construction-heavy crux underneath any tangency conclusion (and ultimately the
+spherical Feuerbach statement). -/
 
-/-- **Existence of the tangent point (external case).**  Two externally tangent spherical
-circles `(O₁, ρ₁)`, `(O₂, ρ₂)` with `0 < ρ₁ + ρ₂ < π` have a common point — the spherical
-interpolation point at arc `ρ₁` from `O₁` along the geodesic to `O₂`. -/
-theorem externallyTangent_has_common_point {O₁ O₂ : E}
-    (h₁ : OnSphere O₁) (h₂ : OnSphere O₂) {ρ₁ ρ₂ : ℝ}
-    (htan : ExternallyTangent O₁ ρ₁ O₂ ρ₂)
-    (hpos : 0 < ρ₁ + ρ₂) (hlt : ρ₁ + ρ₂ < Real.pi) :
+/-- **Spherical slerp common point (core).**  For model points `O₁, O₂` at spherical
+distance `d = sdist O₁ O₂ ∈ (0, π)`, and angular radii `ρ₁, ρ₂` related by the spherical
+law `cos ρ₂ = cos ρ₁ cos d + sin ρ₁ sin d`, the slerp point at arc `ρ₁` from `O₁` toward
+`O₂` lies on both `sCircle O₁ ρ₁` and `sCircle O₂ ρ₂`.  This is the shared engine behind
+the external and internal tangent-point existence theorems. -/
+theorem sphere_slerp_common_point {O₁ O₂ : E}
+    (h₁ : OnSphere O₁) (h₂ : OnSphere O₂) {ρ₁ ρ₂ d : ℝ}
+    (hd : sdist O₁ O₂ = d) (hdpos : 0 < d) (hdpi : d < Real.pi)
+    (hangle : Real.cos ρ₂ = Real.cos ρ₁ * Real.cos d + Real.sin ρ₁ * Real.sin d) :
     ∃ P : E, P ∈ sCircle O₁ ρ₁ ∧ P ∈ sCircle O₂ ρ₂ := by
-  set c : ℝ := ⟪O₁, O₂⟫ with hc_def
-  set s : ℝ := Real.sin (ρ₁ + ρ₂) with hs_def
+  set c : ℝ := Real.cos d with hc_def
+  set s : ℝ := Real.sin d with hs_def
   -- unit-vector self-inner products
   have hO₁O₁ : (⟪O₁, O₁⟫ : ℝ) = 1 := by rw [real_inner_self_eq_norm_sq, h₁]; norm_num
   have hO₂O₂ : (⟪O₂, O₂⟫ : ℝ) = 1 := by rw [real_inner_self_eq_norm_sq, h₂]; norm_num
-  -- cos / sin of the centre distance
-  have hcos : Real.cos (ρ₁ + ρ₂) = c := by
+  -- the inner product of the two centres is cos d (the spherical cosine), here `c`
+  have hcio : (⟪O₁, O₂⟫ : ℝ) = c := by
     have h := cos_sdist O₁ O₂ h₁ h₂
-    rw [htan] at h
-    rw [h]; rfl
-  have hspos : 0 < s := Real.sin_pos_of_pos_of_lt_pi hpos hlt
+    rw [hd] at h
+    rw [hc_def]; exact h.symm
+  have hc21 : (⟪O₂, O₁⟫ : ℝ) = c := by rw [real_inner_comm]; exact hcio
+  have hspos : 0 < s := Real.sin_pos_of_pos_of_lt_pi hdpos hdpi
   have hsne : s ≠ 0 := ne_of_gt hspos
   have hs2 : s ^ 2 = 1 - c ^ 2 := by
-    have h := Real.sin_sq_add_cos_sq (ρ₁ + ρ₂)
-    rw [hcos] at h; linarith
+    have h := Real.sin_sq_add_cos_sq d
+    rw [← hc_def, ← hs_def] at h; linarith
   -- the spherical interpolation point
   set P : E := Real.cos ρ₁ • O₁ + (Real.sin ρ₁ / s) • (O₂ - c • O₁) with hP_def
-  -- the inner product commutes (folded to c)
-  have hc21 : (⟪O₂, O₁⟫ : ℝ) = c := (real_inner_comm O₂ O₁).symm
   -- orthogonality and norm of the tangent vector W = O₂ - c • O₁
   have hW1 : (⟪O₁, O₂ - c • O₁⟫ : ℝ) = 0 := by
-    rw [inner_sub_right, real_inner_smul_right, hO₁O₁]; ring
+    rw [inner_sub_right, real_inner_smul_right, hcio, hO₁O₁]; ring
   have hW1' : (⟪O₂ - c • O₁, O₁⟫ : ℝ) = 0 := by
     rw [real_inner_comm]; exact hW1
   have hWW : (⟪O₂ - c • O₁, O₂ - c • O₁⟫ : ℝ) = s ^ 2 := by
     simp only [inner_sub_left, inner_sub_right, real_inner_smul_left, real_inner_smul_right,
-      hc21, hO₁O₁, hO₂O₂]
+      hcio, hc21, hO₁O₁, hO₂O₂]
     rw [hs2]; ring
   -- P is a model point
   have hPP : (⟪P, P⟫ : ℝ) = 1 := by
@@ -332,16 +337,37 @@ theorem externallyTangent_has_common_point {O₁ O₂ : E}
   have hPO₁ : scos P O₁ = Real.cos ρ₁ := by
     rw [scos, hP_def, inner_add_left, real_inner_smul_left, real_inner_smul_left,
       hO₁O₁, hW1']; ring
-  -- P lies on the second circle (spherical angle-subtraction)
+  -- P lies on the second circle (via the spherical angle relation)
   have hPO₂ : scos P O₂ = Real.cos ρ₂ := by
     have hsimp : Real.sin ρ₁ / s * s ^ 2 = Real.sin ρ₁ * s := by field_simp
     rw [scos, hP_def, inner_add_left, real_inner_smul_left, real_inner_smul_left,
-      inner_sub_left, real_inner_smul_left, hO₂O₂,
-      show (1 : ℝ) - c * c = s ^ 2 from by linear_combination -hs2, hsimp,
-      show Real.cos ρ₂
-          = Real.cos (ρ₁ + ρ₂) * Real.cos ρ₁ + Real.sin (ρ₁ + ρ₂) * Real.sin ρ₁
-        from by rw [← Real.cos_sub]; congr 1; ring, hcos, ← hs_def]
-    ring
+      inner_sub_left, real_inner_smul_left, hcio, hO₂O₂,
+      show (1 : ℝ) - c * c = s ^ 2 from by linear_combination -hs2, hsimp]
+    linear_combination -hangle
   exact ⟨P, ⟨hP_sphere, hPO₁⟩, ⟨hP_sphere, hPO₂⟩⟩
+
+/-- **Existence of the tangent point (external case).**  Two externally tangent spherical
+circles `(O₁, ρ₁)`, `(O₂, ρ₂)` with `0 < ρ₁ + ρ₂ < π` have a common point — the spherical
+interpolation point at arc `ρ₁` from `O₁` along the geodesic to `O₂`. -/
+theorem externallyTangent_has_common_point {O₁ O₂ : E}
+    (h₁ : OnSphere O₁) (h₂ : OnSphere O₂) {ρ₁ ρ₂ : ℝ}
+    (htan : ExternallyTangent O₁ ρ₁ O₂ ρ₂)
+    (hpos : 0 < ρ₁ + ρ₂) (hlt : ρ₁ + ρ₂ < Real.pi) :
+    ∃ P : E, P ∈ sCircle O₁ ρ₁ ∧ P ∈ sCircle O₂ ρ₂ :=
+  sphere_slerp_common_point h₁ h₂ htan hpos hlt
+    (by rw [← Real.cos_sub, show ρ₁ - (ρ₁ + ρ₂) = -ρ₂ from by ring, Real.cos_neg])
+
+/-- **Existence of the tangent point (internal case).**  Two internally tangent spherical
+circles `(O₁, ρ₁)`, `(O₂, ρ₂)` with `0 < ρ₁ − ρ₂ < π` (so the second is the smaller, strictly
+inside the first) have a common point — again the geodesic interpolation point at arc `ρ₁`
+from `O₁` toward `O₂`, which overshoots `O₂` by exactly `ρ₂`. -/
+theorem internallyTangent_has_common_point {O₁ O₂ : E}
+    (h₁ : OnSphere O₁) (h₂ : OnSphere O₂) {ρ₁ ρ₂ : ℝ}
+    (htan : InternallyTangent O₁ ρ₁ O₂ ρ₂)
+    (hpos : 0 < ρ₁ - ρ₂) (hlt : ρ₁ - ρ₂ < Real.pi) :
+    ∃ P : E, P ∈ sCircle O₁ ρ₁ ∧ P ∈ sCircle O₂ ρ₂ := by
+  have hd : sdist O₁ O₂ = ρ₁ - ρ₂ := by rw [htan]; exact abs_of_pos hpos
+  exact sphere_slerp_common_point h₁ h₂ hd hpos hlt
+    (by rw [← Real.cos_sub]; congr 1; ring)
 
 end FeuerbachsTheoremOQ04

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -115,3 +115,42 @@ Spherical Feuerbach: spherical nine-point circle tangent to incircle + 3 excircl
 3. Build spherical incircle + nine-point circle for a spherical triangle; attempt tangency.
 
 BLOCKER (hyperbolic side): no Mathlib hyperbolic metric — deferred until spherical case lands.
+
+## Session 2026-06-28 (researcher-3): tangent-point existence (external case) [ACT/DEEP DIVE]
+
+**Mode**: ACT (CONTINUE — executed the standing next-step "tangent-point existence:
+exhibit the common point on the geodesic between centres"). **Outcome**: PROGRESS —
+added the construction-heavy crux lemma. `FeuerbachsTheoremOQ04.lean` 182→267 lines,
+**0 sorry / 0 axiom** (`#print axioms externallyTangent_has_common_point` =
+propext/Classical.choice/Quot.sound only; no native_decide). Verified single-file:
+`LAKE_UNSAFE=1 ./bin/lake env lean Proofs/FeuerbachsTheoremOQ04.lean` exit 0.
+
+### Delivered
+- **`externallyTangent_has_common_point`** (headline): for externally tangent spherical
+  circles (O₁,ρ₁),(O₂,ρ₂) with `0 < ρ₁+ρ₂ < π`, the circles share a point — the
+  spherical-interpolation (slerp) point
+  `P = cos ρ₁ • O₁ + (sin ρ₁ / sin(ρ₁+ρ₂)) • (O₂ − cos(ρ₁+ρ₂) • O₁)`,
+  proved to be a model point on BOTH `sCircle`s.
+  - `OnSphere P`: ⟪P,P⟫ = cos²ρ₁ + (sinρ₁/s)²·s² = 1 (the tangent vector W = O₂−c•O₁ is
+    ⊥ O₁ with ⟪W,W⟫ = s² = 1−c²).
+  - `scos P O₁ = cos ρ₁`: ⟪P,O₁⟫ = cos ρ₁ (W ⊥ O₁ kills the second term).
+  - `scos P O₂ = cos ρ₂`: ⟪P,O₂⟫ = cos ρ₁ cos(ρ₁+ρ₂) + sin ρ₁ sin(ρ₁+ρ₂) = cos ρ₂ by
+    `Real.cos_sub` (angle subtraction (ρ₁+ρ₂)−ρ₁ = ρ₂).
+
+### GOTCHAs
+- `real_inner_comm a b : ⟪b,a⟫ = ⟪a,b⟫` (NOT ⟪a,b⟫=⟪b,a⟫). To fold ⟪O₂,O₁⟫→c (with
+  c := ⟪O₁,O₂⟫ via `set`) use `(real_inner_comm O₂ O₁).symm`. A bare `simp [real_inner_comm O₂ O₁]`
+  inside the proof did NOT fold the term reliably; pass an explicit commuted `have`.
+- Use `real_inner_smul_left/right` (real inner) to avoid the `conj` from generic
+  `inner_smul_left`.
+- `field_simp` on `sinρ₁/s * s^2 = sinρ₁*s` CLOSES the goal — a trailing `; ring` then
+  errors "No goals to be solved". Make it a standalone `have hsimp := by field_simp` and
+  `ring` only the final (non-division) goal.
+- **Capturing build exit code**: `lake … | tail -n; echo $?` reports TAIL's exit, not
+  lean's — a false "exit 0". Redirect to a file (`> out 2>&1; echo exit=$?`) to read the
+  real status.
+
+### Next steps (unchanged direction)
+1. Internal-tangency common point (d = |ρ₁−ρ₂|; analogous slerp, sign care).
+2. Uniqueness of the tangent point (it is the ONLY common point).
+3. Spherical incircle / nine-point circle constructions, then the Feuerbach tangency.

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -154,3 +154,17 @@ propext/Classical.choice/Quot.sound only; no native_decide). Verified single-fil
 1. Internal-tangency common point (d = |ρ₁−ρ₂|; analogous slerp, sign care).
 2. Uniqueness of the tangent point (it is the ONLY common point).
 3. Spherical incircle / nine-point circle constructions, then the Feuerbach tangency.
+
+### Addendum (same session): refactor to shared core + internal-tangency case
+Refactored the construction into a single engine **`sphere_slerp_common_point`**
+(parameterized by d = sdist O₁ O₂ with the spherical angle relation
+`cos ρ₂ = cos ρ₁ cos d + sin ρ₁ sin d` as a hypothesis), then derived BOTH:
+- `externallyTangent_has_common_point` (d = ρ₁+ρ₂; angle relation via cos(ρ₁-(ρ₁+ρ₂))=cos(-ρ₂)).
+- `internallyTangent_has_common_point` (d = |ρ₁-ρ₂|, smaller circle inside; angle relation
+  via cos(ρ₁-(ρ₁-ρ₂))=cos ρ₂).
+File 267→293 lines, all three 0-axiom (verified). EXTRA GOTCHA: a `set c := ⟪O₁,O₂⟫`
+(inner product) does NOT let `ring`/`linear_combination` equate a *freshly* rewrite-produced
+`⟪O₁,O₂⟫` with `c` (atom mismatch). Fix: set `c := Real.cos d` (a plain real) and rewrite
+every inner product to it via an explicit `hcio : ⟪O₁,O₂⟫ = c` (one `rw [hcio]` rewrites all
+occurrences). Then the spherical angle hypothesis `hangle`, stated in `cos d`/`sin d`, is
+auto-folded to `c`/`s` by `set` and closes hPO₂ with `linear_combination -hangle`.


### PR DESCRIPTION
## Summary

Continues the spherical-model program for **Feuerbach's theorem in non-Euclidean geometry**
(`feuerbachs-theorem-oq-04`). Prior sessions built the metric foundations (`OnSphere`,
`scos`, `sdist`, `chord_sq`) and the spherical circles + internal/external tangency
relations (`sCircle`, `mem_sCircle_iff_sdist`, `…Tangent`). This session adds the
**construction-heavy crux** the notes flagged as the next step:

> **`externallyTangent_has_common_point`** — two externally tangent spherical circles
> `(O₁, ρ₁)`, `(O₂, ρ₂)` with `0 < ρ₁ + ρ₂ < π` actually **meet**.

The witness is the spherical-interpolation (slerp) point at arc `ρ₁` from `O₁` along the
geodesic to `O₂`:

```
P = cos ρ₁ • O₁ + (sin ρ₁ / sin(ρ₁+ρ₂)) • (O₂ − cos(ρ₁+ρ₂) • O₁)
```

proved to be a model point lying on **both** circles:
- `OnSphere P`: ⟪P,P⟫ = cos²ρ₁ + (sin ρ₁/s)²·s² = 1, since the tangent vector
  `W = O₂ − c•O₁` is ⊥ `O₁` with `⟪W,W⟫ = s² = 1 − c²`.
- `scos P O₁ = cos ρ₁` (the W-term drops out by orthogonality).
- `scos P O₂ = cos ρ₂` via `Real.cos_sub`: `cos ρ₁ cos(ρ₁+ρ₂) + sin ρ₁ sin(ρ₁+ρ₂) = cos((ρ₁+ρ₂)−ρ₁) = cos ρ₂`.

## Verification

`FeuerbachsTheoremOQ04.lean` 182 → 267 lines, **0 sorries / 0 axioms**.
`#print axioms externallyTangent_has_common_point` = `propext / Classical.choice / Quot.sound`
only (no `native_decide`). Built single-file against prebuilt Mathlib oleans:
`LAKE_UNSAFE=1 ./bin/lake env lean Proofs/FeuerbachsTheoremOQ04.lean` → exit 0.

## Scope

This is a **make-progress** session, not a completion — the headline spherical Feuerbach
tangency (nine-point circle tangent to incircle/excircles) is still open. Next steps:
internal-tangency common point (`d = |ρ₁−ρ₂|`), uniqueness of the tangent point, then the
spherical incircle / nine-point constructions.

## Files

- `proofs/Proofs/FeuerbachsTheoremOQ04.lean` — new theorem + supporting lemmas.
- `research/problems/feuerbachs-theorem-oq-04/knowledge.md`, `src/data/research/problems/feuerbachs-theorem-oq-04.json` — research records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)