### PR TITLE
Enrich 'No-Retraction via the Analytic (Measure-Theoretic) Route' (brouwer-fixed-point-oq-01-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 8, "endLine": 81 },
     "type": "concept",
     "title": "Replacing homology with analysis: Milnor's measure-theoretic route",
-    "content": "The companion file proves No-Retraction via singular homology with three homology axioms. This file pursues Milnor's 1978 argument, which never mentions homology: a smooth retraction r : B^n → S^{n-1} would map the positive-volume ball onto the measure-zero sphere, while a Jacobian/degree computation forces it to preserve volume — a contradiction. The header lays out exactly which ingredients Mathlib already supports and which single analytic fact remains, then commits to honesty: the file proves the scaffolding and the reduction, not no-retraction itself."
+    "content": "The companion file proves No-Retraction via singular homology with three homology axioms. This file pursues Milnor's 1978 argument, which never mentions homology: a smooth retraction r : B^n → S^{n-1} would map the positive-volume ball onto the measure-zero sphere, while a Jacobian/degree computation forces it to preserve volume — a contradiction. The header lays out exactly which ingredients Mathlib already supports and which single analytic fact remains, then commits to honesty: the file proves the scaffolding and the reduction, not no-retraction itself.",
+    "mathContext": "A retraction $r : B^n \\to S^{n-1}$ would give $\\operatorname{vol}(r(B^n)) = \\operatorname{vol}(S^{n-1}) = 0$ yet (smoothly) $\\operatorname{vol}(r(B^n)) = \\operatorname{vol}(B^n) > 0$.",
+    "significance": "context",
+    "relatedConcepts": ["No-Retraction Theorem", "Brouwer fixed-point theorem", "singular homology vs measure theory", "Milnor analytic proof"],
+    "prerequisites": ["Lebesgue measure", "retractions", "basic algebraic topology vocabulary"]
   },
   {
     "id": "ann-defs",
@@ -13,7 +17,11 @@
     "range": { "startLine": 92, "endLine": 113 },
     "type": "definition",
     "title": "Ball, sphere, retraction (interoperable with the homology companion)",
-    "content": "ClosedBall and UnitSphere are defined as Metric.closedBall 0 1 and Metric.sphere 0 1 in EuclideanSpace ℝ (Fin n), matching the homology file so results can be cross-applied. The Retraction structure bundles continuity, mapping the ball into the sphere, and fixing the sphere pointwise. unitSphere_subset_closedBall records S^{n-1} ⊆ B^n, used to show a retraction's image hits every sphere point."
+    "content": "ClosedBall and UnitSphere are defined as Metric.closedBall 0 1 and Metric.sphere 0 1 in EuclideanSpace ℝ (Fin n), matching the homology file so results can be cross-applied. The Retraction structure bundles continuity, mapping the ball into the sphere, and fixing the sphere pointwise. unitSphere_subset_closedBall records S^{n-1} ⊆ B^n, used to show a retraction's image hits every sphere point.",
+    "mathContext": "$B^n = \\overline{B}(0,1)$, $S^{n-1} = \\{x : \\|x\\| = 1\\}$; a retraction satisfies $r|_{S^{n-1}} = \\mathrm{id}$ and $r(B^n) \\subseteq S^{n-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["EuclideanSpace", "Metric.closedBall", "Metric.sphere", "structure bundling in Lean"],
+    "prerequisites": ["metric spaces", "Lean 4 structures", "continuous maps"]
   },
   {
     "id": "ann-nontrivial",
@@ -21,7 +29,11 @@
     "range": { "startLine": 120, "endLine": 125 },
     "type": "technique",
     "title": "Nontriviality from positive finrank",
-    "content": "Measure.addHaar_sphere requires the ambient space to be Nontrivial. For n ≥ 1 this follows from finrank ℝ (EuclideanSpace ℝ (Fin n)) = n > 0 via Module.nontrivial_of_finrank_pos and finrank_euclideanSpace_fin — a clean way to discharge the typeclass without hand-constructing distinct points."
+    "content": "Measure.addHaar_sphere requires the ambient space to be Nontrivial. For n ≥ 1 this follows from finrank ℝ (EuclideanSpace ℝ (Fin n)) = n > 0 via Module.nontrivial_of_finrank_pos and finrank_euclideanSpace_fin — a clean way to discharge the typeclass without hand-constructing distinct points.",
+    "mathContext": "$\\operatorname{finrank}_{\\mathbb{R}} \\mathbb{R}^n = n > 0 \\Rightarrow \\mathbb{R}^n$ is nontrivial (it contains $0 \\ne e_0$).",
+    "significance": "technical",
+    "relatedConcepts": ["finrank", "Nontrivial typeclass", "typeclass inference", "EuclideanSpace dimension"],
+    "prerequisites": ["finite-dimensional vector spaces", "Lean typeclass resolution"]
   },
   {
     "id": "ann-sphere-null",
@@ -29,7 +41,11 @@
     "range": { "startLine": 129, "endLine": 137 },
     "type": "theorem",
     "title": "The sphere is Lebesgue-null (analytic replacement for sphere_singularHomology_nonzero)",
-    "content": "unitSphere_volume_zero: vol(S^{n-1}) = 0 for n ≥ 1, directly from Mathlib's Measure.addHaar_sphere (spheres have zero additive-Haar measure). Where the homology route asserts the sphere is 'detected' by a nonzero homology group, the analytic route captures the sphere's thinness as measure zero — and this is already a theorem in Mathlib, not an axiom."
+    "content": "unitSphere_volume_zero: vol(S^{n-1}) = 0 for n ≥ 1, directly from Mathlib's Measure.addHaar_sphere (spheres have zero additive-Haar measure). Where the homology route asserts the sphere is 'detected' by a nonzero homology group, the analytic route captures the sphere's thinness as measure zero — and this is already a theorem in Mathlib, not an axiom.",
+    "mathContext": "$\\operatorname{vol}(S^{n-1}) = 0$: a sphere is a lower-dimensional hypersurface, hence Lebesgue-null in $\\mathbb{R}^n$ (Haar measure of a sphere vanishes).",
+    "significance": "key",
+    "relatedConcepts": ["Lebesgue null set", "additive Haar measure", "Measure.addHaar_sphere", "codimension-one submanifold"],
+    "prerequisites": ["Lebesgue measure", "Haar measure on ℝⁿ"]
   },
   {
     "id": "ann-ball-pos",
@@ -37,7 +53,11 @@
     "range": { "startLine": 139, "endLine": 150 },
     "type": "theorem",
     "title": "The ball has positive (and finite) volume",
-    "content": "closedBall_volume_pos: 0 < vol(B^n) via measure_closedBall_pos; closedBall_volume_lt_top: vol(B^n) < ∞ via measure_closedBall_lt_top. Together with the sphere being null, these are the two opposing poles of Milnor's contradiction — the analytic counterpart of 'the ball is contractible, its homology vanishes'."
+    "content": "closedBall_volume_pos: 0 < vol(B^n) via measure_closedBall_pos; closedBall_volume_lt_top: vol(B^n) < ∞ via measure_closedBall_lt_top. Together with the sphere being null, these are the two opposing poles of Milnor's contradiction — the analytic counterpart of 'the ball is contractible, its homology vanishes'.",
+    "mathContext": "$0 < \\operatorname{vol}(B^n) < \\infty$; the ball is a full-dimensional bounded body, so it has strictly positive finite Lebesgue measure ($\\operatorname{vol}(B^n) = \\pi^{n/2}/\\Gamma(\\tfrac n2 + 1)$).",
+    "significance": "key",
+    "relatedConcepts": ["positive measure", "measure_closedBall_pos", "finite measure", "volume of the unit ball"],
+    "prerequisites": ["Lebesgue measure", "bounded sets are finite-measure"]
   },
   {
     "id": "ann-image-sphere",
@@ -45,7 +65,11 @@
     "range": { "startLine": 152, "endLine": 168 },
     "type": "theorem",
     "title": "A retraction surjects the ball onto the sphere, collapsing its volume",
-    "content": "retraction_image_eq_sphere shows r '' B^n = S^{n-1} exactly: ⊆ is maps_to_sphere, ⊇ holds because r fixes the sphere (which lies in the ball). retraction_image_volume_zero then gives vol(r '' B^n) = 0. So a retraction sends a positive-volume set onto a null set — the geometric heart of the obstruction."
+    "content": "retraction_image_eq_sphere shows r '' B^n = S^{n-1} exactly: ⊆ is maps_to_sphere, ⊇ holds because r fixes the sphere (which lies in the ball). retraction_image_volume_zero then gives vol(r '' B^n) = 0. So a retraction sends a positive-volume set onto a null set — the geometric heart of the obstruction.",
+    "mathContext": "$r(B^n) = S^{n-1}$: $\\subseteq$ by definition of retraction; $\\supseteq$ since $S^{n-1} \\subseteq B^n$ and $r|_{S^{n-1}} = \\mathrm{id}$. Hence $\\operatorname{vol}(r(B^n)) = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["image of a set", "surjectivity", "Set.Subset.antisymm", "monotonicity of measure"],
+    "prerequisites": ["set images under maps", "the retraction definition"]
   },
   {
     "id": "ann-reduction",
@@ -53,7 +77,11 @@
     "range": { "startLine": 170, "endLine": 196 },
     "type": "insight",
     "title": "The reduction: the only gap is volume-preservation",
-    "content": "retraction_collapses_volume packages 'ball positive, image null'. By itself this is NOT a contradiction — a continuous map can collapse volume. no_retraction_of_volume_preserved makes the frontier precise: a retraction is impossible the moment one supplies vol(r '' B^n) = vol(B^n). That hypothesis is exactly what Milnor's smooth degree/Jacobian computation yields, and it is an explicit hypothesis rather than an axiom — so the whole file is genuinely 0-axiom while isolating the entire remaining analytic content into one statement."
+    "content": "retraction_collapses_volume packages 'ball positive, image null'. By itself this is NOT a contradiction — a continuous map can collapse volume. no_retraction_of_volume_preserved makes the frontier precise: a retraction is impossible the moment one supplies vol(r '' B^n) = vol(B^n). That hypothesis is exactly what Milnor's smooth degree/Jacobian computation yields, and it is an explicit hypothesis rather than an axiom — so the whole file is genuinely 0-axiom while isolating the entire remaining analytic content into one statement.",
+    "mathContext": "From $\\operatorname{vol}(r(B^n)) = 0$ and the hypothesis $\\operatorname{vol}(r(B^n)) = \\operatorname{vol}(B^n)$, get $\\operatorname{vol}(B^n) = 0$, contradicting $\\operatorname{vol}(B^n) > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["proof by contradiction", "explicit hypothesis vs axiom", "Jacobian / degree argument", "0-axiom formalization"],
+    "prerequisites": ["the sphere-null and ball-positive lemmas", "change-of-variables intuition"]
   },
   {
     "id": "ann-homotopy",
@@ -61,6 +89,10 @@
     "range": { "startLine": 198, "endLine": 224 },
     "type": "concept",
     "title": "Milnor's straight-line homotopy f_t = (1-t)·id + t·r",
-    "content": "straightLine records the family Milnor integrates: continuous for each t (straightLine_continuous), with f_0 = id and f_1 = r (straightLine_zero/one), and fixing the sphere for all t (straightLine_fixes_sphere). The remaining analytic work is to show t ↦ vol(f_t(B^n)) is polynomial in t (the integral of the polynomial determinant det Df_t), forcing vol(f_1(B^n)) = vol(B^n) — the hypothesis discharged above. Mathlib's MeasureTheory.Function.Jacobian supplies the change-of-variables engine for this step."
+    "content": "straightLine records the family Milnor integrates: continuous for each t (straightLine_continuous), with f_0 = id and f_1 = r (straightLine_zero/one), and fixing the sphere for all t (straightLine_fixes_sphere). The remaining analytic work is to show t ↦ vol(f_t(B^n)) is polynomial in t (the integral of the polynomial determinant det Df_t), forcing vol(f_1(B^n)) = vol(B^n) — the hypothesis discharged above. Mathlib's MeasureTheory.Function.Jacobian supplies the change-of-variables engine for this step.",
+    "mathContext": "$f_t = (1-t)\\,\\mathrm{id} + t\\,r$; $f_0 = \\mathrm{id}$, $f_1 = r$, and $t \\mapsto \\operatorname{vol}(f_t(B^n)) = \\int_{B^n} \\det(Df_t)$ is a polynomial in $t$, hence constant once constant near $0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["homotopy", "convex combination of maps", "change of variables", "determinant of the Jacobian", "MeasureTheory.Function.Jacobian"],
+    "prerequisites": ["affine combinations", "differentiable maps", "Jacobian determinant", "integration on ℝⁿ"]
   }
 ]

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/meta.json
@@ -23,44 +23,85 @@
     "axiomCount": 0
   },
   "overview": {
-    "historicalContext": "The companion entry brouwer-fixed-point-oq-01-oq-02 proves the No-Retraction Theorem via singular homology, but at the cost of three homology axioms standing in for Mathlib gaps (H_{n-1}(S^{n-1}) ≅ ℤ and the contractibility/prism vanishing). John Milnor's 1978 note *Analytic proof of the 'hairy ball' theorem and the Brouwer fixed-point theorem* (Amer. Math. Monthly 85, 521–524) gives a proof that never mentions homology: it is pure real analysis and measure theory. The contradiction is that a smooth retraction r : B^n → S^{n-1} would map the positive-volume ball onto the measure-zero sphere, while a Jacobian/degree (change-of-variables) computation forces such a map to preserve the ball's volume. This entry transcribes that route into Lean and pins down exactly which ingredients Mathlib already supports.",
-    "keyInsight": "Mathlib *already* has the two measure-theoretic poles of Milnor's contradiction: spheres are Lebesgue-null (Measure.addHaar_sphere) and balls have positive finite volume (measure_closedBall_pos). A retraction's image is exactly the sphere, so it collapses positive volume to zero. The single missing ingredient — that a retraction nonetheless preserves the ball's volume — is captured here as an explicit hypothesis (not an axiom), making the file 0-axiom while precisely locating the analytic frontier."
+    "historicalContext": "The companion entry brouwer-fixed-point-oq-01-oq-02 proves the No-Retraction Theorem via singular homology, but at the cost of three homology axioms standing in for Mathlib gaps (H_{n-1}(S^{n-1}) ≅ ℤ and the contractibility/prism vanishing). John Milnor's 1978 note *Analytic proof of the 'hairy ball' theorem and the Brouwer fixed-point theorem* (Amer. Math. Monthly 85, 521–524) gives a proof that never mentions homology: it is pure real analysis and measure theory. Building on ideas of Asimov and a 1946 argument structure, Milnor showed the Brouwer and hairy-ball theorems both fall out of one elementary observation about volumes of perturbed maps. The contradiction is that a smooth retraction r : B^n → S^{n-1} would map the positive-volume ball onto the measure-zero sphere, while a Jacobian/degree (change-of-variables) computation forces such a map to preserve the ball's volume. This entry transcribes that route into Lean and pins down exactly which ingredients Mathlib already supports.",
+    "problemStatement": "**OQ-01-OQ-02-OQ-01 of brouwer-fixed-point.** Can the three singular-homology axioms used by the companion No-Retraction proof (sphere_singularHomology_nonzero, contractible_singularHomology_zero, H_n_minus_1_sphere_nonzero) be replaced by Mathlib's analysis/measure-theory library along Milnor's measure-theoretic route? The target obstruction: a retraction r : B^n → S^{n-1} ($n \\ge 1$) maps the positive-finite-volume ball onto the Lebesgue-null sphere, contradicting volume preservation. Formalize every ingredient Mathlib already supports and isolate the precise remaining analytic gap.",
+    "proofStrategy": "Set B^n = closedBall 0 1 and S^{n-1} = sphere 0 1 in EuclideanSpace ℝ (Fin n), exactly as the homology companion, so the two routes interoperate. Establish nontriviality of ℝⁿ for n ≥ 1 from finrank = n > 0 (needed by the Haar-measure lemma). Then assemble Milnor's two poles directly from Mathlib: vol(S^{n-1}) = 0 via Measure.addHaar_sphere, and 0 < vol(B^n) < ∞ via measure_closedBall_pos and measure_closedBall_lt_top. Show a retraction's image is exactly the sphere (⊆ from maps_to_sphere, ⊇ because r fixes S^{n-1} ⊆ B^n pointwise), so vol(r '' B^n) = 0. This is the qualitative obstruction, but not yet a contradiction. The reduction no_retraction_of_volume_preserved derives False from the extra hypothesis vol(r '' B^n) = vol(B^n): rewriting the image volume to 0 contradicts positivity. That hypothesis is an explicit argument, not an axiom, so the file stays 0-axiom. Finally record Milnor's straight-line homotopy f_t = (1-t)·id + t·r with continuous endpoints (f_0 = id, f_1 = r) fixing the sphere for all t — the family whose volume t ↦ vol(f_t(B^n)) is polynomial, the step that would discharge the hypothesis.",
+    "keyInsights": [
+      "Mathlib already has the two measure-theoretic poles of Milnor's contradiction: spheres are Lebesgue-null (Measure.addHaar_sphere) and balls have positive finite volume (measure_closedBall_pos, measure_closedBall_lt_top). The whole analytic scaffolding is therefore a library-assembly problem, not new analysis.",
+      "Measure zero is the analytic surrogate for homological 'thinness.' Where the homology route detects S^{n-1} by a nonzero group H_{n-1}, the analytic route detects it as a null set — and unlike the homology fact, this one is a Mathlib theorem rather than an axiom.",
+      "A retraction's image is *exactly* the sphere, not merely contained in it: surjectivity comes for free because r fixes the boundary sphere pointwise. This turns 'r maps into S^{n-1}' into the sharp volume statement vol(r '' B^n) = 0.",
+      "The qualitative collapse (positive volume ↦ null image) is honestly not a contradiction by itself — continuous surjections B^n ↠ S^{n-1} that crush volume do exist. The genuine content lives entirely in volume *preservation*, which is why isolating it as a single hypothesis is faithful to Milnor rather than a dodge.",
+      "Capturing the remaining gap as an explicit hypothesis (hvol) rather than an axiom keeps the file genuinely 0-axiom while pinpointing the exact frontier: Milnor's polynomial-in-t volume computation for the smooth homotopy, for which Mathlib's MeasureTheory.Function.Jacobian change-of-variables engine already exists."
+    ]
   },
   "sections": [
     {
       "id": "geometry",
       "title": "Geometry: ball, sphere, and retractions",
+      "startLine": 90,
+      "endLine": 113,
       "summary": "Defines the closed unit ball and unit sphere in EuclideanSpace ℝ (Fin n) (matching the homology companion for interoperability), the Retraction structure, and the inclusion S^{n-1} ⊆ B^n.",
       "mathContext": "The Retraction structure bundles continuity, mapping the ball into the sphere, and fixing the sphere pointwise — a definition, not an assumption that any claimed result depends on."
     },
     {
       "id": "nontriviality",
       "title": "Nontriviality of ℝⁿ for n ≥ 1",
+      "startLine": 115,
+      "endLine": 125,
       "summary": "nontrivial_euclidean: for n ≥ 1, EuclideanSpace ℝ (Fin n) is Nontrivial, via finrank = n > 0. Needed to invoke Measure.addHaar_sphere.",
       "mathContext": "Module.nontrivial_of_finrank_pos composed with finrank_euclideanSpace_fin."
     },
     {
       "id": "measure-obstruction",
       "title": "The measure-theoretic obstruction",
+      "startLine": 127,
+      "endLine": 175,
       "summary": "unitSphere_volume_zero (sphere is null), closedBall_volume_pos / closedBall_volume_lt_top (ball positive and finite), retraction_image_eq_sphere (a retraction surjects B^n onto S^{n-1}), retraction_image_volume_zero and retraction_collapses_volume (hence it maps positive volume onto a null set).",
       "mathContext": "These are the analytic replacements for the homology axioms sphere_singularHomology_nonzero and contractible_singularHomology_zero."
     },
     {
       "id": "reduction",
       "title": "The reduction: one analytic gap",
+      "startLine": 177,
+      "endLine": 188,
       "summary": "no_retraction_of_volume_preserved: a retraction cannot exist once one supplies vol(r '' B^n) = vol(B^n). This isolates the whole remaining content of the analytic route into a single explicit hypothesis — exactly what Milnor's degree/Jacobian computation provides for smooth maps. The hypothesis is not an axiom, so the file remains 0-axiom.",
       "mathContext": "Continuity alone does not forbid a volume-collapsing surjection; the contradiction genuinely needs the smooth volume-preservation input. The file is honest that it does not prove no-retraction outright."
     },
     {
       "id": "homotopy",
       "title": "Milnor's straight-line homotopy",
+      "startLine": 190,
+      "endLine": 226,
       "summary": "straightLine f_t = (1-t)·id + t·r with continuous endpoints (f_0 = id, f_1 = r) and the fact that f_t fixes the sphere for every t. This is the family whose volume t ↦ vol(f_t(B^n)) Milnor proves is polynomial in t.",
       "mathContext": "Lays out the analytic program end to end; the polynomiality/degree bookkeeping is the remaining gap named in no_retraction_of_volume_preserved."
     }
   ],
   "conclusion": {
-    "summary": "The homology axioms of the No-Retraction Theorem can be replaced by Mathlib analysis tools along Milnor's measure-theoretic route. This entry proves, 0-axiom and 0-sorry, the sphere-is-null and ball-has-positive-volume poles of the contradiction and the fact that a retraction collapses positive volume to zero, then reduces the entire remaining argument to one explicit analytic hypothesis: that a retraction preserves the ball's volume. Discharging that hypothesis is precisely Milnor's smooth degree/Jacobian computation, for which Mathlib already has the change-of-variables engine (MeasureTheory.Function.Jacobian); the open work is the polynomiality/degree bookkeeping plus a smoothing step. The file does not claim to prove no-retraction — it maps out and machine-checks the analytic scaffolding and the precise frontier."
+    "summary": "The homology axioms of the No-Retraction Theorem can be replaced by Mathlib analysis tools along Milnor's measure-theoretic route. This entry proves, 0-axiom and 0-sorry, the sphere-is-null and ball-has-positive-volume poles of the contradiction and the fact that a retraction collapses positive volume to zero, then reduces the entire remaining argument to one explicit analytic hypothesis: that a retraction preserves the ball's volume. Discharging that hypothesis is precisely Milnor's smooth degree/Jacobian computation, for which Mathlib already has the change-of-variables engine (MeasureTheory.Function.Jacobian); the open work is the polynomiality/degree bookkeeping plus a smoothing step. The file does not claim to prove no-retraction — it maps out and machine-checks the analytic scaffolding and the precise frontier.",
+    "implications": "Demonstrates that the obstruction to a retraction is fully expressible in measure-theoretic terms already in Mathlib, narrowing the gap to No-Retraction (and hence Brouwer) from 'three homology axioms' to 'one volume-preservation lemma for smooth maps.' This reframes a topological theorem as an analysis problem with a known engine (change-of-variables / Jacobian), and provides a reusable, interoperable geometric vocabulary (ClosedBall, UnitSphere, Retraction shared with the homology companion) so the two routes can be cross-applied. Once the polynomial-volume step is formalized, this scaffolding upgrades directly into an axiom-free analytic proof of Brouwer's fixed-point theorem in arbitrary dimension.",
+    "openQuestions": [
+      "Can the volume-preservation hypothesis hvol : vol(r '' B^n) = vol(B^n) be discharged in Lean by formalizing Milnor's key lemma — that for a smooth self-map perturbation, t ↦ vol(f_t(B^n)) is a polynomial in t — using MeasureTheory.Function.Jacobian and the integral of det(Df_t)?",
+      "Is the smoothing step formalizable: approximating a merely continuous retraction by a smooth (or real-analytic) one that still maps B^n onto S^{n-1}, so the smooth volume argument applies to the continuous case Brouwer actually needs?",
+      "Does the same measure-theoretic scaffolding yield Mathlib-native proofs of the sibling results Milnor derives identically — the hairy-ball theorem (no continuous nonvanishing tangent vector field on even spheres) and Brouwer's fixed-point theorem proper?",
+      "Could the homology companion's three axioms be retired entirely by routing No-Retraction through this analytic file, once hvol is proved, leaving the gallery's Brouwer family axiom-free?"
+    ]
   },
+  "references": [
+    {
+      "authors": "John W. Milnor",
+      "title": "Analytic proofs of the 'hairy ball theorem' and the Brouwer fixed point theorem",
+      "year": "1978",
+      "venue": "American Mathematical Monthly 85 (7), 521–524",
+      "note": "Source of the measure-theoretic route formalized here: a smooth self-map perturbation has polynomial-in-t image volume, forcing volume preservation and contradicting the collapse onto the null sphere."
+    },
+    {
+      "authors": "C. A. Rogers",
+      "title": "A less strange version of Milnor's proof of Brouwer's fixed-point theorem",
+      "year": "1980",
+      "venue": "American Mathematical Monthly 87 (7), 525–527",
+      "note": "Streamlined exposition of Milnor's polynomial-volume argument; clarifies the change-of-variables bookkeeping behind the volume-preservation hypothesis."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "brouwer-fixed-point-oq-01-oq-02",


### PR DESCRIPTION
Enrichment pass for `brouwer-fixed-point-oq-01-oq-02-oq-01` (quality 50, pass 0). This entry had several genuine gaps.

## Changes
- **Annotations**: added the *required* `significance` field, which was missing on all 8 annotations (a schema defect), plus `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to every annotation.
- **overview**: the file had only a singular `keyInsight` string and lacked `problemStatement`/`proofStrategy`. Replaced with a proper 5-item `keyInsights` array and added both missing fields (matching the `ProofOverview` type).
- **sections**: added `startLine`/`endLine` to all 5 sections (were absent), anchoring them to the Lean source (geometry 90–113, nontriviality 115–125, measure-obstruction 127–175, reduction 177–188, homotopy 190–226).
- **conclusion**: added `implications` and 4 `openQuestions` (formalizing Milnor's polynomial-volume step via MeasureTheory.Function.Jacobian; the smoothing step; the hairy-ball/Brouwer siblings; retiring the homology companion's axioms).
- **references**: added Milnor (1978) and Rogers (1980).

## Note: index.ts intentionally not added
The enricher role doc says `index.ts` is required, but that is stale — the loader was rebuilt in #20993 to use `listings.json` + `data-manifest.json` + runtime fetch from `public/data/proofs/`, not per-proof `import.meta.glob` shims. None of the brouwer siblings have `index.ts` and they render fine; adding one would be dead weight.

## Verification
- meta.json valid JSON, 13 KB (well under 60 KB cap); all collections under caps.
- `pnpm build` passes (gallery size check, annotations/research build+enrich, tsc, vite).
- Axiom integrity reviewed: status `verified`, badge `verified`, axiomCount 0 — accurate; the remaining analytic gap is an explicit hypothesis (hvol), not an axiom, as the Lean file and annotations make clear.