### PR TITLE
audit: drain 9 never-audited gallery targets (3 clean, 6 orphan → #31454)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25745,6 +25745,60 @@
       "lastAudited": "2026-06-28T17:38:16Z",
       "result": "clean",
       "issues": []
+    },
+    "area-of-circle-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T18:46:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "brouwer-fixed-point-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T18:46:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T18:46:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1002-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T18:46:29Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "erdos-1003-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T18:46:29Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "erdos-1018-oq-04-incomplete-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T18:46:29Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "erdos-1100-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T18:46:29Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "picks-theorem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T18:46:29Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "property-b-first-moment-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-28T18:46:29Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Drains the audit queue from 9 never-audited entries to 0. Updates only `src/data/proofs/audit-tracker.json` (additive — 9 new entries).

### Clean (3)
Registered in `Proofs.lean`, pass all integrity checks (0 sorries, 0 axioms, no `True` stubs, no hidden `native_decide`, badges accurate):
- `area-of-circle-oq-03-oq-02-oq-01` — `mathlib` badge correctly reflects Tier-B reliance on Mathlib half-angle lemmas; `theoremCount` 7→8 already corrected by #31445
- `brouwer-fixed-point-oq-01-oq-02-oq-01`
- `fibonacci-identities-oq-02-oq-01-oq-01-oq-02-oq-01`

### Issues-found (6)
These pass the per-file integrity checks but are **orphaned from `proofs/Proofs.lean`** (committed + claimed `verified`, but excluded from the aggregate build). Captured under the systemic tracking issue **#31454**:
- `erdos-1002-oq-04`, `erdos-1003-oq-03`, `erdos-1018-oq-04-incomplete-01-oq-01`, `erdos-1100-oq-02`, `picks-theorem-oq-04`, `property-b-first-moment-oq-03-oq-01`

Per gallery agent policy, this PR is not marked `loom:review-requested` — the deployer may merge directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)