### PR TITLE
research(lucas-sequence-degree2-identities): master degree-2 identity for general Lucas sequences [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3613,6 +3613,7 @@ import Proofs.LovaszLocalLemma
 import Proofs.LovaszLocalLemmaOQ02
 import Proofs.LovaszLocalLemmaOQ02Aristotle
 import Proofs.LucasLehmerTestOQ01
+import Proofs.LucasSequenceDegree2Identities
 import Proofs.LucasTheoremOQ01
 import Proofs.LucasTheoremOQ01OQ01
 import Proofs.LucasTheoremOQ01OQ01OQ01

--- a/proofs/Proofs/LucasSequenceDegree2Identities.lean
+++ b/proofs/Proofs/LucasSequenceDegree2Identities.lean
@@ -1,0 +1,174 @@
+import Mathlib.Tactic
+
+/-
+# The Master Degree-2 Identity for General Lucas Sequences
+
+## Open Question (gallery gap)
+
+The gallery already records the degree-2 algebra of the **specific** Fibonacci/Lucas
+pair `Fₙ, Lₙ` (`FibonacciIdentitiesOQ02OQ01OQ01`), e.g. the difference identity
+`Lₙ² − 5·Fₙ² = 4·(−1)ⁿ` and its companion sum/cross identities.  Those are all the
+`P = 1, Q = −1` instance of a far more general fact.
+
+For **any** integer parameters `P, Q` the *Lucas sequences* are the two solutions of the
+second-order recurrence `xₙ₊₂ = P·xₙ₊₁ − Q·xₙ` with the canonical initial data
+
+  `Uₙ(P,Q)` : `U₀ = 0, U₁ = 1`        (the *fundamental* / first Lucas sequence)
+  `Vₙ(P,Q)` : `V₀ = 2, V₁ = P`        (the *companion* / second Lucas sequence)
+
+Their discriminant is `D = P² − 4Q`.  The single identity governing the whole theory is
+
+  **`Vₙ² − D·Uₙ² = 4·Qⁿ`**                                                    (★)
+
+Specializing recovers the gallery's results and the classical special cases:
+
+| `(P, Q)`   | `D`  | `(★)` becomes                | sequences           |
+|------------|------|------------------------------|---------------------|
+| `(1, −1)`  | `5`  | `Lₙ² − 5·Fₙ² = 4·(−1)ⁿ`       | Fibonacci / Lucas   |
+| `(2, −1)`  | `8`  | `Qₙ² − 8·Pₙ² = 4·(−1)ⁿ`       | Pell / Pell-Lucas   |
+| `(3, 2)`   | `1`  | `Vₙ² − Uₙ² = 4·2ⁿ`            | `Uₙ = 2ⁿ−1, Vₙ = 2ⁿ+1` |
+
+## Proof architecture (elementary, no closed form, no `√D`)
+
+Everything is purely algebraic over `ℤ`; we never leave the integers or invoke the
+Binet closed form.  Two lemmas carry the whole argument:
+
+1. `V_eq` — the **companion-from-fundamental** relation `Vₙ = 2·Uₙ₊₁ − P·Uₙ`, proved by
+   a two-step induction (the recurrence couples `n` and `n+1`).  This is what lets us
+   eliminate `V` entirely and reduce `(★)` to a statement about `U` alone.
+
+2. `U_quad` — the **invariant quadratic form** `Uₙ₊₁² − P·Uₙ·Uₙ₊₁ + Q·Uₙ² = Qⁿ`,
+   proved by a single induction: the form is multiplied by exactly `Q` at each step,
+   so it equals `Qⁿ`.  This is the Lucas-sequence Cassini identity in disguise
+   (`U_cassini`: `Uₙ₊₁² − Uₙ₊₂·Uₙ = Qⁿ`).
+
+Substituting `Vₙ = 2Uₙ₊₁ − P Uₙ` into `Vₙ² − D Uₙ²` collapses it to
+`4·(Uₙ₊₁² − P Uₙ Uₙ₊₁ + Q Uₙ²) = 4·Qⁿ`, which is `(★)`.
+
+## Results
+
+* `U`, `V`                  — the two Lucas sequences over `ℤ`, parametrized by `P, Q`.
+* `V_eq`                    — `Vₙ = 2·Uₙ₊₁ − P·Uₙ`.
+* `U_quad`                  — `Uₙ₊₁² − P·Uₙ·Uₙ₊₁ + Q·Uₙ² = Qⁿ` (invariant quadratic form).
+* `U_cassini`               — `Uₙ₊₁² − Uₙ₊₂·Uₙ = Qⁿ` (Lucas-sequence Cassini).
+* `V_sq_sub_D_U_sq`         — **(★)** `Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ`, the master identity.
+* `fib_lucas_instance`      — `(★)` at `(1,−1)`: `Vₙ² − 5·Uₙ² = 4·(−1)ⁿ`.
+* `pell_instance`           — `(★)` at `(2,−1)`: `Vₙ² − 8·Uₙ² = 4·(−1)ⁿ`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace LucasSequenceDegree2Identities
+
+/-- The **fundamental Lucas sequence** `Uₙ(P,Q)`: `U₀ = 0`, `U₁ = 1`,
+`Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ`.  For `(P,Q) = (1,−1)` this is the Fibonacci sequence. -/
+def U (P Q : ℤ) : ℕ → ℤ
+  | 0 => 0
+  | 1 => 1
+  | (n + 2) => P * U P Q (n + 1) - Q * U P Q n
+
+/-- The **companion Lucas sequence** `Vₙ(P,Q)`: `V₀ = 2`, `V₁ = P`,
+`Vₙ₊₂ = P·Vₙ₊₁ − Q·Vₙ`.  For `(P,Q) = (1,−1)` this is the Lucas sequence `2,1,3,4,…`. -/
+def V (P Q : ℤ) : ℕ → ℤ
+  | 0 => 2
+  | 1 => P
+  | (n + 2) => P * V P Q (n + 1) - Q * V P Q n
+
+@[simp] theorem U_zero (P Q : ℤ) : U P Q 0 = 0 := rfl
+@[simp] theorem U_one (P Q : ℤ) : U P Q 1 = 1 := rfl
+@[simp] theorem V_zero (P Q : ℤ) : V P Q 0 = 2 := rfl
+@[simp] theorem V_one (P Q : ℤ) : V P Q 1 = P := rfl
+
+/-- The defining recurrence of the fundamental sequence: `Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ`. -/
+theorem U_add_two (P Q : ℤ) (n : ℕ) :
+    U P Q (n + 2) = P * U P Q (n + 1) - Q * U P Q n := rfl
+
+/-- The defining recurrence of the companion sequence: `Vₙ₊₂ = P·Vₙ₊₁ − Q·Vₙ`. -/
+theorem V_add_two (P Q : ℤ) (n : ℕ) :
+    V P Q (n + 2) = P * V P Q (n + 1) - Q * V P Q n := rfl
+
+/-- **Companion-from-fundamental relation.** `Vₙ = 2·Uₙ₊₁ − P·Uₙ`.
+
+Proved by a two-step induction packaged as the conjunction of the statement at `n` and
+at `n+1`; the recurrence `Vₙ₊₂ = P·Vₙ₊₁ − Q·Vₙ` consumes both consecutive cases. -/
+theorem V_eq (P Q : ℤ) (n : ℕ) : V P Q n = 2 * U P Q (n + 1) - P * U P Q n := by
+  -- Strengthen to consecutive pairs so ordinary induction suffices.
+  suffices key : ∀ m : ℕ,
+      (V P Q m = 2 * U P Q (m + 1) - P * U P Q m) ∧
+      (V P Q (m + 1) = 2 * U P Q (m + 2) - P * U P Q (m + 1)) from (key n).1
+  intro m
+  induction m with
+  | zero =>
+    refine ⟨?_, ?_⟩
+    · simp
+    · rw [V_one, U_add_two, U_one, U_zero]; ring
+  | succ k ih =>
+    obtain ⟨ih1, ih2⟩ := ih
+    refine ⟨ih2, ?_⟩
+    have hV : V P Q (k + 2) = P * V P Q (k + 1) - Q * V P Q k := V_add_two P Q k
+    have hU3 : U P Q (k + 3) = P * U P Q (k + 2) - Q * U P Q (k + 1) := U_add_two P Q (k + 1)
+    have hU2 : U P Q (k + 2) = P * U P Q (k + 1) - Q * U P Q k := U_add_two P Q k
+    rw [hV, ih1, ih2, hU3, hU2]; ring
+
+/-- **Invariant quadratic form.** `Uₙ₊₁² − P·Uₙ·Uₙ₊₁ + Q·Uₙ² = Qⁿ`.
+
+The form is exactly `Q`-homogeneous along the recurrence: substituting
+`Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ` multiplies it by `Q`, and it starts at `1` for `n = 0`, so it
+equals `Qⁿ`. -/
+theorem U_quad (P Q : ℤ) (n : ℕ) :
+    (U P Q (n + 1)) ^ 2 - P * U P Q n * U P Q (n + 1) + Q * (U P Q n) ^ 2 = Q ^ n := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    have hrec : U P Q (k + 2) = P * U P Q (k + 1) - Q * U P Q k := U_add_two P Q k
+    rw [hrec, pow_succ]
+    linear_combination Q * ih
+
+/-- **Lucas-sequence Cassini identity.** `Uₙ₊₁² − Uₙ₊₂·Uₙ = Qⁿ`.
+
+Equivalently the determinant `det [[Uₙ₊₁, Uₙ], [Uₙ₊₂, Uₙ₊₁]] = Qⁿ`; immediate from the
+invariant quadratic form `U_quad` after expanding `Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ`. -/
+theorem U_cassini (P Q : ℤ) (n : ℕ) :
+    (U P Q (n + 1)) ^ 2 - U P Q (n + 2) * U P Q n = Q ^ n := by
+  have h := U_quad P Q n
+  rw [U_add_two]; linear_combination h
+
+/-- **Master degree-2 identity (★).** `Vₙ² − (P² − 4Q)·Uₙ² = 4·Qⁿ`.
+
+The single relation from which the entire degree-2 algebra of any Lucas sequence pair
+descends.  Eliminate `V` via `V_eq`, then `(★)` reduces by `linear_combination` to four
+times the invariant quadratic form `U_quad`. -/
+theorem V_sq_sub_D_U_sq (P Q : ℤ) (n : ℕ) :
+    (V P Q n) ^ 2 - (P ^ 2 - 4 * Q) * (U P Q n) ^ 2 = 4 * Q ^ n := by
+  rw [V_eq]
+  linear_combination 4 * U_quad P Q n
+
+/-- Instantiation at `(P, Q) = (1, −1)` recovers the gallery's Fibonacci/Lucas identity
+`Lₙ² − 5·Fₙ² = 4·(−1)ⁿ`: here `U = Fibonacci`, `V = Lucas`, and `D = 1² − 4·(−1) = 5`. -/
+theorem fib_lucas_instance (n : ℕ) :
+    (V 1 (-1) n) ^ 2 - 5 * (U 1 (-1) n) ^ 2 = 4 * (-1 : ℤ) ^ n := by
+  have h := V_sq_sub_D_U_sq 1 (-1) n
+  norm_num at h
+  linarith [h]
+
+/-- Instantiation at `(P, Q) = (2, −1)` gives the Pell / Pell-Lucas identity
+`Vₙ² − 8·Uₙ² = 4·(−1)ⁿ`: here `D = 2² − 4·(−1) = 8`. -/
+theorem pell_instance (n : ℕ) :
+    (V 2 (-1) n) ^ 2 - 8 * (U 2 (-1) n) ^ 2 = 4 * (-1 : ℤ) ^ n := by
+  have h := V_sq_sub_D_U_sq 2 (-1) n
+  norm_num at h
+  linarith [h]
+
+/-- Numeric sanity check of the definitions and `(★)` at `(1,−1)`, `n = 5`:
+`U₅ = F₅ = 5`, `V₅ = L₅ = 11`, and `11² − 5·5² = 121 − 125 = −4 = 4·(−1)⁵`. -/
+example : U 1 (-1) 5 = 5 ∧ V 1 (-1) 5 = 11 ∧
+    (V 1 (-1) 5) ^ 2 - 5 * (U 1 (-1) 5) ^ 2 = 4 * (-1 : ℤ) ^ 5 := by
+  refine ⟨by decide, by decide, by decide⟩
+
+/-- Numeric sanity check at `(2,−1)` (Pell), `n = 4`:
+`U₄ = 12`, `V₄ = 34`, and `34² − 8·12² = 1156 − 1152 = 4 = 4·(−1)⁴`. -/
+example : U 2 (-1) 4 = 12 ∧ V 2 (-1) 4 = 34 ∧
+    (V 2 (-1) 4) ^ 2 - 8 * (U 2 (-1) 4) ^ 2 = 4 * (-1 : ℤ) ^ 4 := by
+  refine ⟨by decide, by decide, by decide⟩
+
+end LucasSequenceDegree2Identities

--- a/research/problems/lucas-sequence-degree2-identities/knowledge.md
+++ b/research/problems/lucas-sequence-degree2-identities/knowledge.md
@@ -1,0 +1,53 @@
+# Lucas Sequence Degree-2 Identities
+
+**Slug:** `lucas-sequence-degree2-identities`
+**Status:** COMPLETED (verified, 0 axioms, 0 sorries)
+**Lean file:** `proofs/Proofs/LucasSequenceDegree2Identities.lean`
+
+## Problem
+
+The gallery's degree-2 Fibonacci/Lucas algebra (`FibonacciIdentitiesOQ02OQ01OQ01` and
+children) is entirely the `(P,Q) = (1,−1)` instance of the general theory of Lucas
+sequences `U_n(P,Q)`, `V_n(P,Q)`. Goal: formalize the **master degree-2 identity**
+
+  `V_n² − (P²−4Q)·U_n² = 4·Q^n`
+
+over `ℤ` for arbitrary parameters `P, Q`, recovering the gallery's
+`L_n² − 5·F_n² = 4·(−1)ⁿ` and the Pell relation as instances.
+
+## Session 2026-06-28 (Session 1) — FRESH, COMPLETED
+
+**Outcome:** completed. New 0-axiom verified gallery entry.
+
+### What I did
+- Confirmed the gap: the gallery has only the specific Fibonacci/Lucas pair (and Pell
+  separately); no general two-parameter `U_n(P,Q)`, `V_n(P,Q)` with the `V²−DU²=4Q^n`
+  master identity.
+- Defined `U`, `V : ℤ → ℤ → ℕ → ℤ` and proved, all over `ℤ`, no Binet/`√D`:
+  - `V_eq`: `V_n = 2·U_{n+1} − P·U_n` (two-step induction via consecutive-pair strengthening).
+  - `U_quad`: `U_{n+1}² − P·U_n·U_{n+1} + Q·U_n² = Q^n` (single induction; the form is a
+    `Q`-eigenvector of the recurrence — step is `linear_combination Q * ih`).
+  - `U_cassini`: `U_{n+1}² − U_{n+2}·U_n = Q^n` (Lucas-sequence Cassini, from `U_quad`).
+  - `V_sq_sub_D_U_sq`: the master identity, via `rw [V_eq]; linear_combination 4 * U_quad`.
+  - `fib_lucas_instance` (1,−1)→D=5, `pell_instance` (2,−1)→D=8.
+- Built clean in Docker: `✔ Built Proofs.LucasSequenceDegree2Identities`. 12 theorems,
+  2 defs, 0 sorries, kernel `decide` only (no `native_decide`).
+
+### Key findings / techniques
+- **Eliminate-then-invariant** architecture: the companion relation `V_eq` removes `V`,
+  so the whole degree-2 identity reduces to the single invariant quadratic form on `U`.
+- The quadratic form `U_{n+1}² − P U_n U_{n+1} + Q U_n²` is multiplied by exactly `Q` per
+  recurrence step ⇒ equals `Q^n` by a one-line induction. This is the engine; it is also
+  the Lucas-sequence Cassini determinant.
+- `linear_combination` discharges both the inductive step and the final algebraic collapse.
+
+### Files modified
+- `proofs/Proofs/LucasSequenceDegree2Identities.lean` (new, 174 lines)
+- `proofs/Proofs.lean` (import added)
+- `src/data/proofs/lucas-sequence-degree2-identities/{meta.json,annotations.json,index.ts}` (new)
+- `research/registry.json` (entry added)
+
+### Next steps / follow-up open questions
+- General doubling formulas `U_{2n} = U_n·V_n`, `V_{2n} = V_n² − 2·Q^n` over arbitrary `(P,Q)`.
+- Bilinear addition laws `2·U_{m+n} = U_m·V_n + U_n·V_m`, `2·V_{m+n} = V_m·V_n + D·U_m·U_n`,
+  and `gcd(U_n, V_n) ∣ 2` when `Q` is a unit, derived from the master identity.

--- a/research/registry.json
+++ b/research/registry.json
@@ -31549,6 +31549,15 @@
       "completed": "2026-06-27T00:25:01.660Z"
     },
     {
+      "slug": "lucas-sequence-degree2-identities",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-06-28T18:00:00.000Z",
+      "status": "completed",
+      "lastUpdate": "2026-06-28T18:40:00.000Z",
+      "completed": "2026-06-28T18:40:00.000Z"
+    },
+    {
       "slug": "centered-hexagonal-sum-oq-01",
       "phase": "COMPLETED",
       "path": "fast",

--- a/src/data/proofs/lucas-sequence-degree2-identities/annotations.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-programme",
+    "proofId": "lucas-sequence-degree2-identities",
+    "range": { "startLine": 4, "endLine": 59 },
+    "type": "concept",
+    "title": "One Identity Governs Every Lucas-Sequence Pair",
+    "content": "The docstring frames the gap: the gallery already records the degree-2 algebra of the specific Fibonacci/Lucas pair (e.g. L_n² − 5·F_n² = 4·(−1)ⁿ), but that is only the (P,Q) = (1,−1) case of a far more general fact. For any integer parameters P, Q the fundamental sequence U_n(P,Q) (U₀=0, U₁=1) and the companion sequence V_n(P,Q) (V₀=2, V₁=P) both obey x_{n+2} = P·x_{n+1} − Q·x_n, and with discriminant D = P²−4Q they satisfy the master degree-2 identity V_n² − D·U_n² = 4·Q^n. Specializing recovers Fibonacci/Lucas (D=5), Pell/Pell-Lucas (D=8), and the 2ⁿ∓1 family (D=1). The proof stays entirely over ℤ — no Binet closed form, no √D.",
+    "mathContext": "$V_n^2 - (P^2-4Q)\\,U_n^2 = 4Q^n$; at $(P,Q)=(1,-1)$ this is $L_n^2 - 5F_n^2 = 4(-1)^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lucas sequences U_n(P,Q), V_n(P,Q)",
+      "discriminant D = P²−4Q",
+      "Fibonacci/Lucas and Pell special cases",
+      "second-order linear recurrence"
+    ],
+    "prerequisites": [
+      "second-order linear recurrences",
+      "the Fibonacci/Lucas and Pell sequences"
+    ]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "lucas-sequence-degree2-identities",
+    "range": { "startLine": 63, "endLine": 88 },
+    "type": "concept",
+    "title": "The Fundamental and Companion Lucas Sequences over ℤ",
+    "content": "U P Q and V P Q : ℕ → ℤ are the two canonical solutions of x_{n+2} = P·x_{n+1} − Q·x_n: the fundamental sequence with U₀=0, U₁=1 and the companion sequence with V₀=2, V₁=P. Both are defined by structural recursion over ℕ with parameters P, Q : ℤ. The boundary values are recorded as @[simp] lemmas, and the recurrences U_add_two, V_add_two hold by rfl, giving later rewrites an index form (n+2) that matches the goals. For (P,Q) = (1,−1) these are exactly the Fibonacci and Lucas numbers; for (2,−1), the Pell and Pell-Lucas numbers.",
+    "mathContext": "$U_0=0,\\ U_1=1,\\ U_{n+2}=P U_{n+1}-Q U_n$;\\ $V_0=2,\\ V_1=P,\\ V_{n+2}=P V_{n+1}-Q V_n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "structural recursion on ℕ",
+      "parametrized integer sequences",
+      "@[simp] boundary lemmas",
+      "rfl-provable recurrence"
+    ],
+    "prerequisites": [
+      "recursive definitions in Lean",
+      "the Lucas-sequence recurrence"
+    ]
+  },
+  {
+    "id": "ann-companion-relation",
+    "proofId": "lucas-sequence-degree2-identities",
+    "range": { "startLine": 90, "endLine": 111 },
+    "type": "technique",
+    "title": "Eliminating V: the Companion-from-Fundamental Relation",
+    "content": "V_eq proves V_n = 2·U_{n+1} − P·U_n, the relation that expresses the companion sequence entirely in terms of the fundamental one. Because the recurrence V_{n+2}=P·V_{n+1}−Q·V_n couples two consecutive indices, a naive induction stalls; the fix is to strengthen the goal to the conjunction of the statement at n and at n+1, so ordinary induction on the pair carries both cases forward. In the step the U- and V-recurrences are substituted and ring closes the polynomial goal. This relation is what reduces the two-sequence degree-2 identity to a statement about U alone.",
+    "mathContext": "$V_n = 2U_{n+1} - P U_n$; check $n=1$: $V_1 = P = 2U_2 - P U_1 = 2P - P$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "two-step (second-order) induction",
+      "strengthening the induction hypothesis",
+      "consecutive-pair invariants",
+      "linear recurrence elimination"
+    ],
+    "prerequisites": [
+      "induction on a strengthened statement",
+      "the ring tactic over ℤ"
+    ]
+  },
+  {
+    "id": "ann-invariant-form",
+    "proofId": "lucas-sequence-degree2-identities",
+    "range": { "startLine": 113, "endLine": 134 },
+    "type": "key-step",
+    "title": "The Engine: a Q-Eigenvector Quadratic Form",
+    "content": "U_quad proves U_{n+1}² − P·U_n·U_{n+1} + Q·U_n² = Q^n by a single induction. The form is a Q-eigenvector of the recurrence: substituting U_{n+2}=P·U_{n+1}−Q·U_n shows the value at n+1 is exactly Q times the value at n, and it is 1 at n=0, so it equals Q^n. The inductive step is one line, linear_combination (Q · ih). Expanding U_{n+2} in this same form gives U_cassini: U_{n+1}² − U_{n+2}·U_n = Q^n, the Lucas-sequence Cassini identity — the determinant of the 2×2 shift matrix [[U_{n+1}, U_n],[U_{n+2}, U_{n+1}]]. This quadratic form is the engine that powers the master identity.",
+    "mathContext": "$U_{n+1}^2 - P U_n U_{n+1} + Q U_n^2 = Q^n$, equivalently $U_{n+1}^2 - U_{n+2}U_n = Q^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cassini / Catalan determinant identity",
+      "invariant of a linear recurrence",
+      "linear_combination tactic",
+      "2×2 shift matrix determinant"
+    ],
+    "prerequisites": [
+      "induction over ℕ",
+      "polynomial identities via linear_combination"
+    ]
+  },
+  {
+    "id": "ann-master-identity",
+    "proofId": "lucas-sequence-degree2-identities",
+    "range": { "startLine": 136, "endLine": 159 },
+    "type": "key-step",
+    "title": "The Master Identity V_n² − D·U_n² = 4·Q^n",
+    "content": "V_sq_sub_D_U_sq assembles the two structural lemmas. Rewriting V via V_eq turns the left side into (2U_{n+1} − P U_n)² − (P²−4Q)U_n², which expands to 4·(U_{n+1}² − P·U_n·U_{n+1} + Q·U_n²) — exactly four times the invariant quadratic form. So linear_combination (4 · U_quad) closes the goal in a single step, yielding 4·Q^n. This is the source identity from which the entire degree-2 algebra of any Lucas pair (doubling formulas, addition laws, gcd bounds) descends.",
+    "mathContext": "$V_n^2 - (P^2-4Q)U_n^2 = (2U_{n+1}-PU_n)^2 - (P^2-4Q)U_n^2 = 4(U_{n+1}^2 - PU_nU_{n+1}+QU_n^2) = 4Q^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "degree-2 Lucas-sequence identities",
+      "discriminant D = P²−4Q",
+      "linear_combination assembly",
+      "Pell and Fibonacci/Lucas algebra"
+    ],
+    "prerequisites": [
+      "the companion relation V_eq",
+      "the invariant quadratic form U_quad"
+    ]
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "lucas-sequence-degree2-identities",
+    "range": { "startLine": 146, "endLine": 174 },
+    "type": "concept",
+    "title": "Specializations: Fibonacci/Lucas and Pell",
+    "content": "fib_lucas_instance instantiates the master identity at (P,Q) = (1,−1): there U = Fibonacci, V = Lucas, D = 1²−4·(−1) = 5, and Q^n = (−1)ⁿ, reproducing the gallery's L_n² − 5·F_n² = 4·(−1)ⁿ. pell_instance instantiates at (2,−1), where D = 8, giving the Pell/Pell-Lucas relation V_n² − 8·U_n² = 4·(−1)ⁿ. Numeric sanity checks via kernel decide (not native_decide) confirm U₅ = 5, V₅ = 11 at (1,−1) and U₄ = 12, V₄ = 34 at (2,−1), keeping the file 0-axiom.",
+    "mathContext": "$(1,-1)$: $L_n^2 - 5F_n^2 = 4(-1)^n$;\\ $(2,-1)$: $V_n^2 - 8U_n^2 = 4(-1)^n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fibonacci/Lucas identity",
+      "Pell equation",
+      "specialization of parameters",
+      "kernel decide vs native_decide"
+    ],
+    "prerequisites": [
+      "the master identity V_sq_sub_D_U_sq",
+      "evaluating sequences at small n"
+    ]
+  }
+]

--- a/src/data/proofs/lucas-sequence-degree2-identities/index.ts
+++ b/src/data/proofs/lucas-sequence-degree2-identities/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LucasSequenceDegree2Identities.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lucasSequenceDegree2IdentitiesProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lucasSequenceDegree2IdentitiesAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lucasSequenceDegree2IdentitiesData: ProofData = {
+  proof: lucasSequenceDegree2IdentitiesProof,
+  annotations: lucasSequenceDegree2IdentitiesAnnotations,
+}

--- a/src/data/proofs/lucas-sequence-degree2-identities/meta.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "lucas-sequence-degree2-identities",
+  "slug": "lucas-sequence-degree2-identities",
+  "title": "The Master Degree-2 Identity for General Lucas Sequences: Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ",
+  "status": "verified",
+  "badge": "original",
+  "description": "The single quadratic identity governing every Lucas-sequence pair. For integer parameters P, Q the fundamental and companion Lucas sequences Uₙ(P,Q) (U₀=0, U₁=1) and Vₙ(P,Q) (V₀=2, V₁=P) both obey xₙ₊₂ = P·xₙ₊₁ − Q·xₙ; with discriminant D = P²−4Q they satisfy Vₙ² − D·Uₙ² = 4·Qⁿ. The gallery previously held only the (P,Q) = (1,−1) instance (Lₙ² − 5·Fₙ² = 4·(−1)ⁿ) for the specific Fibonacci/Lucas pair; this entry proves the two-parameter master identity over ℤ, with Fibonacci/Lucas and Pell as corollaries. Elementary and closed-form-free: the proof rests on V_eq (Vₙ = 2·Uₙ₊₁ − P·Uₙ, two-step induction) and U_quad (the invariant quadratic form Uₙ₊₁² − P·Uₙ·Uₙ₊₁ + Q·Uₙ² = Qⁿ, single induction), after which linear_combination collapses the identity to 4·U_quad. Includes the Lucas-sequence Cassini identity Uₙ₊₁² − Uₙ₊₂·Uₙ = Qⁿ and the (1,−1) and (2,−1) specializations. Fully verified: 12 theorems, 2 definitions, 0 sorries, 0 axioms, kernel decide only (no native_decide).",
+  "overview": {
+    "historicalContext": "Lucas sequences U_n(P,Q) and V_n(P,Q), introduced by Édouard Lucas in the 1870s, unify the Fibonacci/Lucas numbers (P=1, Q=−1), the Pell/Pell-Lucas numbers (P=2, Q=−1), the Jacobsthal numbers (P=1, Q=−2), the Mersenne-type 2ⁿ∓1 family (P=3, Q=2), and many others as a single two-parameter family obeying x_{n+2} = P·x_{n+1} − Q·x_n. Their arithmetic underlies the Lucas–Lehmer primality test and Lucas pseudoprimes. The discriminant D = P²−4Q plays the role that 5 plays for the Fibonacci numbers, and the quadratic relation V_n² − D·U_n² = 4·Q^n is the source identity from which the whole degree-2 algebra (doubling formulas, addition laws, gcd bounds) descends.",
+    "problemStatement": "Define the fundamental and companion Lucas sequences U_n(P,Q), V_n(P,Q) over ℤ for arbitrary parameters P, Q, and prove the master degree-2 identity V_n² − (P²−4Q)·U_n² = 4·Q^n for all n, without leaving the integers (no Binet closed form, no √D). Recover the gallery's specific Fibonacci/Lucas identity L_n² − 5·F_n² = 4·(−1)ⁿ and the Pell identity as instances.",
+    "proofStrategy": "Eliminate V, then reduce to an invariant. (1) V_eq: prove V_n = 2·U_{n+1} − P·U_n by a two-step induction packaged as the conjunction of the statement at n and n+1 (the recurrence V_{n+2}=P·V_{n+1}−Q·V_n consumes both consecutive cases), so ordinary induction on the strengthened pair suffices. (2) U_quad: prove the quadratic form U_{n+1}² − P·U_n·U_{n+1} + Q·U_n² equals Q^n by a single induction — substituting U_{n+2}=P·U_{n+1}−Q·U_n multiplies the form by exactly Q, and it is 1 at n=0, so it is Q^n (linear_combination Q·ih closes the step). (3) Main: rewrite V via V_eq; then V_n² − (P²−4Q)·U_n² expands to 4·(U_{n+1}² − P·U_n·U_{n+1} + Q·U_n²), so linear_combination (4 · U_quad) finishes. The Lucas-sequence Cassini U_{n+1}² − U_{n+2}·U_n = Q^n is U_quad after expanding U_{n+2}.",
+    "keyInsights": [
+      "The whole degree-2 theory of any Lucas pair is one identity, V_n² − D·U_n² = 4·Q^n with D = P²−4Q; the gallery's L_n² − 5·F_n² = 4·(−1)ⁿ is just its (P,Q) = (1,−1) instance.",
+      "V is redundant given U: the companion-from-fundamental relation V_n = 2·U_{n+1} − P·U_n eliminates V entirely, turning a statement about two sequences into one about U alone.",
+      "The quadratic form U_{n+1}² − P·U_n·U_{n+1} + Q·U_n² is a Q-eigenvector of the recurrence: each step multiplies it by exactly Q, so it equals Q^n by a one-line induction — this is the engine of the whole proof.",
+      "Everything is purely algebraic over ℤ: no Binet closed form, no square root of D, no field extension. linear_combination discharges both the inductive step and the final collapse.",
+      "The same quadratic form is the Lucas-sequence Cassini identity U_{n+1}² − U_{n+2}·U_n = Q^n (the determinant of the 2×2 shift matrix), unifying Cassini and the V²−DU² identity as two readings of one fact."
+    ],
+    "prerequisites": [
+      "Second-order linear recurrences and the two canonical Lucas-sequence initial data",
+      "Two-step (second-order) induction via a strengthened consecutive-pair statement",
+      "The discriminant D = P²−4Q of a Lucas sequence and its role as the quadratic-form coefficient",
+      "Lean tactics linear_combination and ring for polynomial identities over ℤ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Section I: The Two Lucas Sequences over ℤ",
+      "startLine": 63,
+      "endLine": 88,
+      "summary": "U P Q and V P Q : ℕ → ℤ, the fundamental (U₀=0, U₁=1) and companion (V₀=2, V₁=P) sequences for the recurrence x_{n+2} = P·x_{n+1} − Q·x_n, with the boundary simp lemmas and the rfl-recurrences U_add_two, V_add_two.",
+      "mathContext": "A single two-parameter family subsuming Fibonacci/Lucas (1,−1), Pell (2,−1), and 2ⁿ∓1 (3,2); the recurrence is stated as an explicit theorem so later rewrites can match the goal's index form."
+    },
+    {
+      "id": "companion-relation",
+      "title": "Section II: Companion-from-Fundamental (V_eq)",
+      "startLine": 90,
+      "endLine": 111,
+      "summary": "V_eq: V_n = 2·U_{n+1} − P·U_n, proved by strengthening to the conjunction at n and n+1 so ordinary induction handles the second-order recurrence.",
+      "mathContext": "Eliminates V in terms of U, reducing the degree-2 identity to a statement about the fundamental sequence alone; the step substitutes the U- and V-recurrences and closes by ring."
+    },
+    {
+      "id": "invariant-form",
+      "title": "Section III: The Invariant Quadratic Form (U_quad) and Cassini",
+      "startLine": 113,
+      "endLine": 134,
+      "summary": "U_quad: U_{n+1}² − P·U_n·U_{n+1} + Q·U_n² = Q^n by single induction; U_cassini: U_{n+1}² − U_{n+2}·U_n = Q^n.",
+      "mathContext": "The form is a Q-eigenvector of the recurrence (each step multiplies by Q), so it equals Q^n; linear_combination (Q·ih) discharges the step. Expanding U_{n+2} gives the Lucas-sequence Cassini identity."
+    },
+    {
+      "id": "master-identity",
+      "title": "Section IV: The Master Identity and Instances",
+      "startLine": 136,
+      "endLine": 174,
+      "summary": "V_sq_sub_D_U_sq: V_n² − (P²−4Q)·U_n² = 4·Q^n; specializations fib_lucas_instance (1,−1) → 4·(−1)ⁿ with D=5, and pell_instance (2,−1) → 4·(−1)ⁿ with D=8, plus numeric sanity checks via kernel decide.",
+      "mathContext": "rw [V_eq] then linear_combination (4 · U_quad) collapses the identity; the (1,−1) instance reproduces the gallery's L_n² − 5·F_n² = 4·(−1)ⁿ, validating the generalization."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, kernel decide only — no native_decide) 174-line file with 12 theorems and 2 definitions establishing the master degree-2 identity V_n² − (P²−4Q)·U_n² = 4·Q^n for the general two-parameter Lucas sequences U_n(P,Q), V_n(P,Q) over ℤ. The proof is elementary and closed-form-free, resting on the companion relation V_n = 2·U_{n+1} − P·U_n and the invariant quadratic form U_{n+1}² − P·U_n·U_{n+1} + Q·U_n² = Q^n. The Fibonacci/Lucas identity L_n² − 5·F_n² = 4·(−1)ⁿ (gallery entry fibonacci-identities-oq-02-oq-01-oq-01) and the Pell identity are corollaries. #print axioms reports only [propext, Classical.choice, Quot.sound].",
+    "implications": "Generalizes the gallery's specific Fibonacci/Lucas degree-2 algebra to the entire Lucas-sequence family in one identity, with the Lucas-sequence Cassini relation as a byproduct. The definitions U, V and the two structural lemmas (V_eq, U_quad) are reusable infrastructure for further degree-2 work over arbitrary (P,Q): doubling formulas U_{2n}=U_n·V_n, V_{2n}=V_n²−2Q^n, addition laws, and gcd/divisibility results all reduce to these. The result itself is classical; the contribution is the clean, parameter-general, axiom-free formalization where the gallery previously had only the (1,−1) instance.",
+    "openQuestions": [
+      "Prove the general doubling formulas U_{2n} = U_n·V_n and V_{2n} = V_n² − 2·Q^n over arbitrary (P,Q), generalizing the gallery's Fibonacci/Lucas doubling identities.",
+      "Establish the bilinear addition laws 2·U_{m+n} = U_m·V_n + U_n·V_m and 2·V_{m+n} = V_m·V_n + D·U_m·U_n for general Lucas sequences, and derive the gcd bound gcd(U_n, V_n) ∣ 2 from V_n² − D·U_n² = 4·Q^n when Q is a unit."
+    ]
+  },
+  "references": [
+    {
+      "key": "Lucas1878",
+      "citation": "Lucas, É., Théorie des fonctions numériques simplement périodiques, American Journal of Mathematics 1 (1878), 184–240, 289–321.",
+      "type": "article"
+    },
+    {
+      "key": "Ribenboim",
+      "citation": "Ribenboim, P., The New Book of Prime Number Records, Springer (1996), Ch. on Lucas sequences U_n(P,Q), V_n(P,Q) and the identity V_n² − D·U_n² = 4·Q^n.",
+      "type": "book"
+    },
+    {
+      "key": "Williams",
+      "citation": "Williams, H. C., Édouard Lucas and Primality Testing, Canadian Mathematical Society Monographs, Wiley (1998).",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "fibonacci-identities-oq-02-oq-01-oq-01",
+      "relation": "Specializes at (P,Q) = (1,−1) to that entry's L_n² − 5·F_n² = 4·(−1)ⁿ; this entry is its two-parameter generalization."
+    },
+    {
+      "proofId": "lucas-sum-oq-01",
+      "relation": "Shares the self-contained Lucas-sequence theme; that entry treats the specific Lucas numbers, this one the general U_n(P,Q), V_n(P,Q) family."
+    },
+    {
+      "proofId": "pell-equation",
+      "relation": "The (P,Q) = (2,−1) instance V_n² − 8·U_n² = 4·(−1)ⁿ is the Pell/Pell-Lucas degree-2 relation underlying Pell's equation."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "LucasSequenceDegree2Identities",
+    "lineCount": 174,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/LucasSequenceDegree2Identities.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_sequence",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LucasSequenceDegree2Identities.lean",
+    "tags": [
+      "number-theory",
+      "lucas-sequences",
+      "fibonacci",
+      "pell",
+      "recurrence",
+      "quadratic-identity",
+      "cassini",
+      "induction",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "linear_combination",
+        "description": "Closes the polynomial inductive step of U_quad (Q · ih) and the final collapse of the master identity (4 · U_quad) over ℤ",
+        "module": "Mathlib.Tactic.LinearCombination"
+      },
+      {
+        "theorem": "ring",
+        "description": "Discharges the polynomial goal in the two-step induction step of V_eq after the recurrences are substituted",
+        "module": "Mathlib.Tactic.Ring"
+      }
+    ],
+    "originalContributions": [
+      "U, V: the general two-parameter Lucas sequences U_n(P,Q), V_n(P,Q) over ℤ, with rfl-recurrences U_add_two, V_add_two",
+      "V_eq: the companion-from-fundamental relation V_n = 2·U_{n+1} − P·U_n by two-step induction",
+      "U_quad: the invariant quadratic form U_{n+1}² − P·U_n·U_{n+1} + Q·U_n² = Q^n (the proof engine)",
+      "U_cassini: the Lucas-sequence Cassini identity U_{n+1}² − U_{n+2}·U_n = Q^n",
+      "V_sq_sub_D_U_sq: the master degree-2 identity V_n² − (P²−4Q)·U_n² = 4·Q^n, generalizing the gallery's (1,−1) Fibonacci/Lucas instance",
+      "fib_lucas_instance, pell_instance: the (1,−1) and (2,−1) specializations recovering L_n²−5F_n²=4(−1)ⁿ and the Pell relation V_n²−8U_n²=4(−1)ⁿ"
+    ],
+    "axiomCount": 0,
+    "lineCount": 174,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The four numeric checks use kernel `decide` (not `native_decide`), so #print axioms reports only [propext, Classical.choice, Quot.sound]. Compiled against Mathlib v4.26.0. The identity is classical (Lucas, 1878); the contribution is the parameter-general, axiom-free formalization where the gallery previously had only the (P,Q) = (1,−1) Fibonacci/Lucas instance.",
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "prerequisites": [
+      "Second-order linear recurrences and the two canonical Lucas-sequence initial data",
+      "Two-step induction via a strengthened consecutive-pair statement",
+      "The discriminant D = P²−4Q and its role as the quadratic-form coefficient",
+      "Lean tactics linear_combination and ring over ℤ"
+    ],
+    "relatedProblems": [
+      "fibonacci-identities-oq-02-oq-01-oq-01",
+      "lucas-sum-oq-01",
+      "pell-equation"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Generalizes the gallery's **specific** Fibonacci/Lucas degree-2 algebra to the **general two-parameter Lucas sequences** over ℤ. The gallery previously held only the `(P,Q) = (1,−1)` instance `L_n² − 5·F_n² = 4·(−1)ⁿ` (entry `fibonacci-identities-oq-02-oq-01-oq-01`) and Pell separately. This entry proves the single quadratic identity from which the entire degree-2 theory of **every** Lucas pair descends:

> **`V_n² − (P² − 4Q)·U_n² = 4·Q^n`**

for the fundamental `U_n(P,Q)` (`U₀=0, U₁=1`) and companion `V_n(P,Q)` (`V₀=2, V₁=P`) sequences, both obeying `x_{n+2} = P·x_{n+1} − Q·x_n`, with discriminant `D = P²−4Q`.

| `(P,Q)`  | `D` | identity                  | sequences          |
|----------|-----|---------------------------|--------------------|
| `(1,−1)` | 5   | `L_n² − 5F_n² = 4(−1)ⁿ`    | Fibonacci / Lucas  |
| `(2,−1)` | 8   | `V_n² − 8U_n² = 4(−1)ⁿ`    | Pell / Pell-Lucas  |
| `(3,2)`  | 1   | `V_n² − U_n² = 4·2ⁿ`       | `2ⁿ−1, 2ⁿ+1`       |

## Proof architecture (elementary, no Binet, no √D — all over ℤ)

1. **`V_eq`** — companion-from-fundamental `V_n = 2·U_{n+1} − P·U_n`, by two-step induction (strengthened to consecutive pairs). Eliminates `V`.
2. **`U_quad`** — the invariant quadratic form `U_{n+1}² − P·U_n·U_{n+1} + Q·U_n² = Q^n`. The form is a `Q`-eigenvector of the recurrence, so a single induction (`linear_combination Q * ih`) gives `Q^n`. This is the engine.
3. **`V_sq_sub_D_U_sq`** — `rw [V_eq]; linear_combination 4 * U_quad` collapses the master identity.
4. **`U_cassini`** — the Lucas-sequence Cassini identity `U_{n+1}² − U_{n+2}·U_n = Q^n` (the 2×2 shift-matrix determinant), a corollary of `U_quad`.
5. **`fib_lucas_instance` / `pell_instance`** — the `(1,−1)` and `(2,−1)` specializations.

## Verification

- `✔ Built Proofs.LucasSequenceDegree2Identities` (Docker, Mathlib v4.26.0)
- **12 theorems, 2 definitions, 0 sorries, 0 axioms**
- Numeric checks use kernel `decide` (not `native_decide`); `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`.

## Files

- `proofs/Proofs/LucasSequenceDegree2Identities.lean` (new, 174 lines) + import in `proofs/Proofs.lean`
- `src/data/proofs/lucas-sequence-degree2-identities/{meta.json,annotations.json,index.ts}` (new gallery entry)
- `research/registry.json`, `research/problems/lucas-sequence-degree2-identities/knowledge.md`

## Follow-up open questions

- General doubling `U_{2n} = U_n·V_n`, `V_{2n} = V_n² − 2·Q^n` over arbitrary `(P,Q)`.
- Bilinear addition laws and `gcd(U_n, V_n) ∣ 2` (for `Q` a unit) from the master identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)