### PR TITLE
research(pythagorean-theorem-oq-04): (m,n) parameterization via Gaussian-integer norm [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PythagoreanTheoremOQ04.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ04.lean
@@ -1,0 +1,148 @@
+import Mathlib.NumberTheory.PythagoreanTriples
+import Mathlib.NumberTheory.Zsqrtd.GaussianInt
+import Mathlib.Tactic
+
+/-!
+# Pythagorean triples via the Gaussian-integer norm (pythagorean-theorem-oq-04)
+
+## What this proves
+
+The `(m, n)`-parameterization of Pythagorean triples is *exactly* the statement that
+squaring in the Gaussian integers `ℤ[i]` produces triples, and that the multiplicative
+norm `N(a + bi) = a² + b²` turns Pythagoras' equation `x² + y² = z²` into
+`N(x + yi) = z²`.
+
+Two layers:
+
+* **Soundness (norm route).** For every Gaussian integer `g = m + ni`,
+  `g² = (m² - n²) + (2mn)i`, and because the norm is multiplicative,
+  `N(g²) = N(g)² = (m² + n²)²`. Reading off real/imaginary parts gives
+  `(m² - n²)² + (2mn)² = (m² + n²)²`, i.e. `(m² - n², 2mn, m² + n²)` is a
+  Pythagorean triple. This is the Brahmagupta–Fibonacci identity *as* norm
+  multiplicativity, not as a brute `ring` identity.
+
+* **Completeness (Gaussian factorization).** Conversely, every *primitive*
+  Pythagorean triple `(x, y, z)` with `x` odd and `z > 0` is the square of a
+  Gaussian integer: there exist coprime `m, n` with
+  `(x + yi) = (m + ni)²` in `ℤ[i]` and `z = N(m + ni)`. So the parameterization is
+  not just a source of triples — it captures *all* primitive triples, and the
+  hypotenuse is literally the Gaussian norm of the generating integer.
+
+## Relation to the existing gallery entry
+
+`PythagoreanTriples.lean` derives the same parameterization from the *rational
+parametrization of the unit circle* (Mathlib's `coprime_classification`). This file
+gives the orthogonal, algebraic-number-theory viewpoint: the parameterization is the
+arithmetic of `ℤ[i]`. The completeness theorem `gaussian_completeness` is proved by
+transporting Mathlib's classification through the identity `gaussianInt_sq`.
+
+## Status
+
+- [x] Complete proof, no sorries
+- [x] 0 `axiom` declarations, no structure-encoded assumptions
+- [x] Soundness derived from norm multiplicativity (`Zsqrtd.norm_mul`)
+- [x] Completeness: primitive triples are Gaussian squares
+-/
+
+namespace PythagoreanTheoremOQ04
+
+open Zsqrtd
+
+local notation "ℤ[i]" => GaussianInt
+
+/-! ## The Gaussian-integer norm and squaring -/
+
+/-- The norm of a Gaussian integer is the sum of squares of its components:
+`N(m + ni) = m² + n²`. -/
+theorem gaussianInt_norm (m n : ℤ) :
+    (⟨m, n⟩ : ℤ[i]).norm = m * m + n * n := by
+  simp [Zsqrtd.norm_def]
+
+/-- Squaring in `ℤ[i]` realizes the parameterization map:
+`(m + ni)² = (m² - n²) + (2mn)i`. -/
+theorem gaussianInt_sq (m n : ℤ) :
+    (⟨m, n⟩ : ℤ[i]) ^ 2 = ⟨m * m - n * n, 2 * m * n⟩ := by
+  rw [sq]
+  apply Zsqrtd.ext <;> simp <;> ring
+
+/-- The norm of the square equals the square of the norm — multiplicativity applied to
+`g²`. This is the engine behind the Pythagorean identity. -/
+theorem norm_gaussianInt_sq (m n : ℤ) :
+    ((⟨m, n⟩ : ℤ[i]) ^ 2).norm = (m * m + n * n) ^ 2 := by
+  rw [sq, Zsqrtd.norm_mul, gaussianInt_norm, ← sq]
+
+/-! ## Soundness: the parameterization yields triples (via norm multiplicativity) -/
+
+/-- The Brahmagupta–Fibonacci identity, obtained from the multiplicativity of the
+Gaussian norm rather than by direct expansion:
+`(m² - n²)² + (2mn)² = (m² + n²)²`. -/
+theorem param_norm_identity (m n : ℤ) :
+    (m * m - n * n) * (m * m - n * n) + (2 * m * n) * (2 * m * n)
+      = (m * m + n * n) * (m * m + n * n) := by
+  -- LHS is `N((m+ni)²)` read off coordinates; RHS is `N(m+ni)²`.
+  have hcoord : ((⟨m, n⟩ : ℤ[i]) ^ 2).norm
+      = (m * m - n * n) * (m * m - n * n) + (2 * m * n) * (2 * m * n) := by
+    rw [gaussianInt_sq]; simp [Zsqrtd.norm_def]
+  have hmul : ((⟨m, n⟩ : ℤ[i]) ^ 2).norm = (m * m + n * n) * (m * m + n * n) := by
+    rw [norm_gaussianInt_sq]; ring
+  rw [hcoord] at hmul
+  exact hmul
+
+/-- The parameterized triple `(m² - n², 2mn, m² + n²)` is a Pythagorean triple.
+The proof routes through the Gaussian-norm identity `param_norm_identity`. -/
+theorem param_is_triple (m n : ℤ) :
+    PythagoreanTriple (m ^ 2 - n ^ 2) (2 * m * n) (m ^ 2 + n ^ 2) := by
+  -- The triple identity is exactly `param_norm_identity`, itself derived from
+  -- norm multiplicativity; feed it to `PythagoreanTriple` via `linear_combination`.
+  unfold PythagoreanTriple
+  linear_combination param_norm_identity m n
+
+/-! ## Completeness: every primitive triple is a Gaussian square -/
+
+/-- **Completeness via Gaussian integers.** A primitive Pythagorean triple `(x, y, z)`
+with `x` odd and `z > 0` is the square of a Gaussian integer: there are coprime `m, n`
+with `(x + yi) = (m + ni)²` in `ℤ[i]`, and the hypotenuse is the Gaussian norm
+`z = N(m + ni) = m² + n²`.
+
+This shows the `(m, n)`-parameterization is *complete*: it is not merely one way to
+manufacture triples, every primitive triple arises this way, and does so as an honest
+factorization in `ℤ[i]`. -/
+theorem gaussian_completeness {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) (hodd : x % 2 = 1) (hpos : 0 < z) :
+    ∃ m n : ℤ,
+      (⟨x, y⟩ : ℤ[i]) = (⟨m, n⟩ : ℤ[i]) ^ 2 ∧
+        z = (⟨m, n⟩ : ℤ[i]).norm ∧
+        Int.gcd m n = 1 := by
+  obtain ⟨m, n, hx, hy, hz, hmn, _, _⟩ := h.coprime_classification' hco hodd hpos
+  refine ⟨m, n, ?_, ?_, hmn⟩
+  · -- (x + yi) = (m + ni)²
+    rw [gaussianInt_sq]
+    apply Zsqrtd.ext
+    · simp [hx]; ring
+    · simp [hy]
+  · -- z = N(m + ni)
+    rw [gaussianInt_norm, hz]; ring
+
+/-! ## Worked examples -/
+
+/-- `(3, 4, 5)` from `m = 2, n = 1`: `(2 + i)² = 3 + 4i`, `N(2 + i) = 5`. -/
+example : (⟨2, 1⟩ : ℤ[i]) ^ 2 = ⟨3, 4⟩ := by
+  rw [gaussianInt_sq]; norm_num
+
+example : (⟨2, 1⟩ : ℤ[i]).norm = 5 := by
+  rw [gaussianInt_norm]; norm_num
+
+/-- `(5, 12, 13)` from `m = 3, n = 2`: `(3 + 2i)² = 5 + 12i`, `N(3 + 2i) = 13`. -/
+example : (⟨3, 2⟩ : ℤ[i]) ^ 2 = ⟨5, 12⟩ := by
+  rw [gaussianInt_sq]; norm_num
+
+example : (⟨3, 2⟩ : ℤ[i]).norm = 13 := by
+  rw [gaussianInt_norm]; norm_num
+
+/-- The `(3,4,5)` triple, derived through `param_is_triple` (`m = 2, n = 1`). -/
+example : PythagoreanTriple 3 4 5 := by
+  have := param_is_triple 2 1
+  norm_num at this
+  exact this
+
+end PythagoreanTheoremOQ04

--- a/src/data/proofs/pythagorean-theorem-oq-04/annotations.json
+++ b/src/data/proofs/pythagorean-theorem-oq-04/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "ann-pt-oq04-squaring",
+    "proofId": "pythagorean-theorem-oq-04",
+    "range": {
+      "startLine": 61,
+      "endLine": 66
+    },
+    "type": "concept",
+    "title": "Squaring in ℤ[i] IS the Parameterization Map",
+    "content": "gaussianInt_sq shows (m + ni)² = (m²−n²) + (2mn)i. The real part m²−n² and imaginary part 2mn are exactly the two legs of the (m,n) parameterization. So the classical formula a = m²−n², b = 2mn is not an ad-hoc recipe — it is literally the coordinate description of the squaring map z ↦ z² on the Gaussian integers. The proof is Zsqrtd.ext (compare real and imaginary parts) followed by ring on each component.",
+    "mathContext": "$(m+ni)^2 = (m^2-n^2) + (2mn)i$. The legs $a = m^2-n^2$, $b = 2mn$ are the real and imaginary parts of $g^2$ for $g = m+ni$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gaussian integers ℤ[i]",
+      "Zsqrtd.ext",
+      "(m,n) parameterization",
+      "squaring map"
+    ],
+    "prerequisites": [
+      "complex multiplication",
+      "Gaussian integers as pairs ⟨re, im⟩"
+    ]
+  },
+  {
+    "id": "ann-pt-oq04-norm-mult",
+    "proofId": "pythagorean-theorem-oq-04",
+    "range": {
+      "startLine": 68,
+      "endLine": 72
+    },
+    "type": "technique",
+    "title": "Norm Multiplicativity as the Engine",
+    "content": "norm_gaussianInt_sq proves N(g²) = N(g)² in one line via Zsqrtd.norm_mul, the multiplicativity of the Gaussian norm. This single fact is the whole mechanism: it is the Brahmagupta–Fibonacci two-square identity in disguise. Specializing N(zw) = N(z)N(w) to w = z and reading both sides off coordinates is what produces Pythagoras. No expansion of squares is needed — the identity is structural.",
+    "mathContext": "$N(g^2) = N(g)^2$, an instance of $N(zw) = N(z)N(w)$ (Zsqrtd.norm_mul). For $g = m+ni$ this is $(m^2+n^2)^2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Zsqrtd.norm_mul",
+      "Brahmagupta–Fibonacci identity",
+      "multiplicative norm",
+      "norm form a²+b²"
+    ],
+    "prerequisites": [
+      "multiplicative functions",
+      "norm on a quadratic ring"
+    ]
+  },
+  {
+    "id": "ann-pt-oq04-identity",
+    "proofId": "pythagorean-theorem-oq-04",
+    "range": {
+      "startLine": 79,
+      "endLine": 98
+    },
+    "type": "insight",
+    "title": "Pythagoras as Norm, Computed Two Ways",
+    "content": "param_norm_identity proves (m²−n²)² + (2mn)² = (m²+n²)² by computing the norm of g² in two different ways and equating them. Route one (hcoord): apply gaussianInt_sq, then read N off the coordinates to get the left-hand side. Route two (hmul): apply norm_gaussianInt_sq to get N(g)² = (m²+n²)². Since both equal N(g²), the two right-hand sides are equal — that equality IS the Pythagorean identity. param_is_triple then packages this into Mathlib's PythagoreanTriple via linear_combination, with the norm identity supplied as the linear combination.",
+    "mathContext": "$(m^2-n^2)^2 + (2mn)^2 = (m^2+n^2)^2$, obtained as $N(g^2)$ computed coordinatewise $=$ $N(g)^2$ via multiplicativity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "PythagoreanTriple",
+      "norm computed two ways",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "the squaring and norm-multiplicativity lemmas",
+      "Mathlib PythagoreanTriple definition"
+    ]
+  },
+  {
+    "id": "ann-pt-oq04-completeness",
+    "proofId": "pythagorean-theorem-oq-04",
+    "range": {
+      "startLine": 110,
+      "endLine": 124
+    },
+    "type": "insight",
+    "title": "Completeness: Every Primitive Triple Is a Gaussian Square",
+    "content": "gaussian_completeness is the converse and the genuinely arithmetic content. For a primitive triple (x,y,z) with x odd and z > 0, it produces coprime m, n with (x + yi) = (m + ni)² in ℤ[i] and z = N(m+ni). The proof obtains m, n from Mathlib's PythagoreanTriple.coprime_classification', then verifies (x + yi) = (m + ni)² coordinatewise (via gaussianInt_sq and the classification's equations hx, hy) and z = N(m+ni) via gaussianInt_norm. Conceptually this is surjectivity of the parameterization onto primitive triples: a primitive x + yi has square norm z², so in the UFD ℤ[i] it is a square up to a unit. That is WHY the (m,n) formula omits nothing.",
+    "mathContext": "For primitive $(x,y,z)$ with $x$ odd, $z>0$: $\\exists$ coprime $m,n$ with $x + yi = (m+ni)^2$ and $z = N(m+ni) = m^2+n^2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "PythagoreanTriple.coprime_classification'",
+      "unique factorization in ℤ[i]",
+      "surjectivity of the parameterization",
+      "primitive triples"
+    ],
+    "prerequisites": [
+      "Mathlib's classification of primitive triples",
+      "Gaussian-integer squaring identity",
+      "coprimality and parity normalization"
+    ]
+  },
+  {
+    "id": "ann-pt-oq04-examples",
+    "proofId": "pythagorean-theorem-oq-04",
+    "range": {
+      "startLine": 129,
+      "endLine": 147
+    },
+    "type": "example",
+    "title": "The 3-4-5 and 5-12-13 Triples as Gaussian Squares",
+    "content": "Concrete anchors for the abstract machinery. The triple (3,4,5) comes from m=2, n=1: (2 + i)² = 3 + 4i and N(2+i) = 5, so the hypotenuse is the norm of the generating Gaussian integer. The triple (5,12,13) comes from m=3, n=2: (3 + 2i)² = 5 + 12i and N(3+2i) = 13. The final example derives PythagoreanTriple 3 4 5 through param_is_triple at m=2, n=1, exercising the soundness pathway end to end on a familiar case.",
+    "mathContext": "$(2+i)^2 = 3+4i,\\ N(2+i)=5$; $(3+2i)^2 = 5+12i,\\ N(3+2i)=13$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "3-4-5 triple",
+      "5-12-13 triple",
+      "norm as hypotenuse",
+      "worked examples"
+    ],
+    "prerequisites": [
+      "the squaring and norm lemmas"
+    ]
+  }
+]

--- a/src/data/proofs/pythagorean-theorem-oq-04/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-04/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "pythagorean-theorem-oq-04",
+  "title": "Pythagorean Theorem OQ-04: The (m,n) Parameterization via the Gaussian-Integer Norm",
+  "slug": "pythagorean-theorem-oq-04",
+  "description": "Recasts the (m,n) parameterization of Pythagorean triples as the arithmetic of the Gaussian integers ℤ[i]. Squaring m + ni gives (m²−n²) + (2mn)i, and norm multiplicativity N(g²) = N(g)² turns Brahmagupta–Fibonacci into Pythagoras: (m²−n²)² + (2mn)² = (m²+n²)². The converse (completeness) shows every primitive triple with x odd is the square of a Gaussian integer, with hypotenuse z = N(m+ni). 6 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-28",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTheoremOQ04.lean",
+    "tags": [
+      "number-theory",
+      "pythagorean-triples",
+      "gaussian-integers",
+      "norm-multiplicativity",
+      "brahmagupta-fibonacci",
+      "algebraic-number-theory"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-28",
+    "axiomCount": 0,
+    "assumptions": "None. Soundness is derived from Mathlib's Zsqrtd.norm_mul (norm multiplicativity); completeness transports Mathlib's PythagoreanTriple.coprime_classification' through the squaring identity. Depends only on propext, Classical.choice, and Quot.sound.",
+    "lineCount": 148,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "originalContributions": [
+      "gaussianInt_sq: squaring in ℤ[i] realizes the parameterization map, (m + ni)² = (m²−n²) + (2mn)i",
+      "norm_gaussianInt_sq: N(g²) = N(g)² as an instance of norm multiplicativity Zsqrtd.norm_mul — the engine behind the Pythagorean identity",
+      "param_norm_identity: the Brahmagupta–Fibonacci identity (m²−n²)² + (2mn)² = (m²+n²)² derived from norm multiplicativity rather than by a brute ring expansion",
+      "param_is_triple: the parameterized triple (m²−n², 2mn, m²+n²) is a PythagoreanTriple, routed through the Gaussian-norm identity",
+      "gaussian_completeness: every primitive triple (x,y,z) with x odd and z > 0 is the square of a Gaussian integer — (x + yi) = (m + ni)² with coprime m, n and z = N(m+ni)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The (m,n) parameterization of Pythagorean triples a = m²−n², b = 2mn, c = m²+n² is classical, traceable to Euclid (Elements, Book X, Lemma 1 before Prop. 29) and known in essentially complete form to the Babylonians (Plimpton 322). The forward direction — that the formula always yields a triple — is the Brahmagupta–Fibonacci two-square identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)², stated by Diophantus, rediscovered by Brahmagupta (628 CE) and Fibonacci (1225). The decisive modern reframing is due to the arithmetic of the Gaussian integers ℤ[i], systematized by Gauss in the Disquisitiones (1801) and his 1832 memoir on biquadratic residues: a² + b² = c² becomes (a+bi)(a−bi) = c², and the two-square identity is nothing but multiplicativity of the norm N(a+bi) = a²+b². In this language the parameterization is the statement that a primitive triple is, up to units, the square of a Gaussian integer — completeness is a consequence of unique factorization in ℤ[i].",
+    "problemStatement": "Recast the (m,n) parameterization of Pythagorean triples through the Gaussian-integer norm N(m+ni) = m²+n². Prove soundness (the parameterized triple is Pythagorean) as an instance of norm multiplicativity, and prove completeness: every primitive triple with x odd and z > 0 is the square of a Gaussian integer, with the hypotenuse equal to that Gaussian integer's norm.",
+    "text": "Working in ℤ[i] = Zsqrtd (−1), the norm is N(m + ni) = m² + n². Squaring gives (m + ni)² = (m²−n²) + (2mn)i, so its real and imaginary parts are exactly the legs a = m²−n², b = 2mn of the parameterization. Because the norm is multiplicative, N((m+ni)²) = N(m+ni)² = (m²+n²)². Reading the norm off the coordinates of the square then gives (m²−n²)² + (2mn)² = (m²+n²)² — Pythagoras as norm multiplicativity, not as a ring identity. Conversely, completeness states that every primitive triple is captured: for a primitive triple (x,y,z) with x odd and z > 0, there are coprime m, n with (x + yi) = (m + ni)² in ℤ[i] and z = N(m+ni). This is the genuinely arithmetic content — the parameterization is surjective onto primitive triples because primitive Gaussian integers of square norm are themselves squares (up to units).",
+    "proofStrategy": "Establish gaussianInt_norm (N⟨m,n⟩ = m·m + n·n) and gaussianInt_sq (⟨m,n⟩² = ⟨m·m−n·n, 2mn⟩) by Zsqrtd.ext + ring. Derive norm_gaussianInt_sq from Zsqrtd.norm_mul. Then param_norm_identity equates the norm of the square computed two ways — coordinatewise (giving the LHS) and via multiplicativity (giving the RHS) — yielding the Brahmagupta–Fibonacci identity. param_is_triple feeds this identity into Mathlib's PythagoreanTriple via linear_combination. Completeness (gaussian_completeness) obtains m, n from Mathlib's PythagoreanTriple.coprime_classification', then checks (x + yi) = (m + ni)² coordinatewise and z = N(m+ni) by the norm formula — transporting the classification through the squaring identity rather than re-deriving descent.",
+    "keyInsights": [
+      "The two-square identity is not a coincidence to be verified by ring: it is exactly the multiplicativity of the Gaussian norm N(zw) = N(z)N(w) specialized to w = z, so (m²−n²)² + (2mn)² = (m²+n²)² is N(g²) = N(g)² read off coordinates",
+      "Squaring a Gaussian integer IS the parameterization map: g = m + ni ↦ g² has real part m²−n² and imaginary part 2mn, so the (m,n) formula is literally the coordinate description of squaring in ℤ[i]",
+      "Completeness is the surjectivity that elementary descent struggles to motivate: a primitive triple x + yi has square norm z², and in the UFD ℤ[i] such an element is (up to a unit) a perfect square m + ni — this is WHY the parameterization omits nothing",
+      "The hypotenuse is not just m²+n² by formula; it is the Gaussian norm N(m+ni) of the generating integer, so the third side carries intrinsic arithmetic meaning",
+      "This is the orthogonal viewpoint to the unit-circle rational parameterization used in the gallery's pythagorean-triples entry: same classification, derived from the algebra of ℤ[i] instead of from rational points on x² + y² = 1"
+    ],
+    "prerequisites": [
+      "Gaussian integers ℤ[i] = Zsqrtd (−1) and the norm N(a+bi) = a²+b² (Mathlib Zsqrtd.norm)",
+      "Norm multiplicativity Zsqrtd.norm_mul",
+      "Mathlib's PythagoreanTriple and its classification coprime_classification'",
+      "The Brahmagupta–Fibonacci two-square identity"
+    ]
+  },
+  "conclusion": {
+    "summary": "A fully machine-verified, axiom-free recasting of the (m,n) parameterization of Pythagorean triples as the arithmetic of the Gaussian integers. Soundness — that (m²−n², 2mn, m²+n²) is always a triple — is obtained from norm multiplicativity N(g²) = N(g)², making the Brahmagupta–Fibonacci identity a structural fact rather than a ring computation. Completeness — that every primitive triple with x odd is the square of a Gaussian integer, with z = N(m+ni) — establishes that the parameterization captures all primitive triples. Zero axioms, zero sorries.",
+    "implications": "The Gaussian-integer route is the canonical explanation for why the (m,n) parameterization is complete: a primitive triple corresponds to a Gaussian integer of square norm, which in the UFD ℤ[i] is a square up to units. This links elementary number theory to algebraic number theory — unique factorization, norm forms, and the unit group {±1, ±i} — and supplies reusable infrastructure (the norm/squaring lemmas) for sums-of-two-squares results such as Fermat's two-square theorem. The same norm-multiplicativity engine underlies the closure of sums of two squares under multiplication.",
+    "openQuestions": [
+      "Strengthen gaussian_completeness to full uniqueness of (m,n) up to the unit group {±1, ±i} and order, making the parameterization a bijection onto primitive triples",
+      "Remove the x-odd / z > 0 normalization by tracking the four units of ℤ[i] explicitly, recovering every primitive triple without a chosen representative",
+      "Derive completeness directly from unique factorization in ℤ[i] (g of square norm is a square up to a unit) rather than transporting Mathlib's coprime_classification'",
+      "Connect to Fermat's two-square theorem (pythagorean-triples-oq-04): both are shadows of the splitting behaviour of primes in ℤ[i]"
+    ]
+  },
+  "leanFile": {
+    "namespace": "PythagoreanTheoremOQ04",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/PythagoreanTheoremOQ04.lean",
+    "imports": [
+      "Mathlib.NumberTheory.PythagoreanTriples",
+      "Mathlib.NumberTheory.Zsqrtd.GaussianInt",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Zsqrtd"
+    ],
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "extends",
+      "description": "The parent entry formalizes the (m,n) parameterization via Mathlib's PythagoreanTriple, derived from the rational parametrization of the unit circle. This entry gives the orthogonal algebraic-number-theory viewpoint: the parameterization is the arithmetic of ℤ[i], with squaring as the parameterization map and the hypotenuse as a Gaussian norm."
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The classical Euclidean theorem a² + b² = c². Here a² + b² = c² is read as (a+bi)(a−bi) = c², so Pythagoras becomes a statement about the Gaussian norm."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-04",
+      "relationship": "related",
+      "description": "Fermat's two-square theorem for primes, also routed through ℤ[i]. Both entries exploit norm multiplicativity and the splitting of primes in the Gaussian integers; this entry handles squares of Gaussian integers, that one handles which primes are norms."
+    }
+  ],
+  "sections": [
+    {
+      "id": "norm-and-squaring",
+      "title": "Part I: The Gaussian norm and squaring",
+      "startLine": 53,
+      "endLine": 72,
+      "summary": "Establishes gaussianInt_norm (N⟨m,n⟩ = m·m + n·n), gaussianInt_sq (squaring realizes the parameterization: ⟨m,n⟩² = ⟨m·m−n·n, 2mn⟩, by Zsqrtd.ext + ring), and norm_gaussianInt_sq (N(g²) = N(g)² from Zsqrtd.norm_mul) — the multiplicativity engine driving the rest."
+    },
+    {
+      "id": "soundness",
+      "title": "Part II: Soundness via norm multiplicativity",
+      "startLine": 74,
+      "endLine": 98,
+      "summary": "param_norm_identity derives the Brahmagupta–Fibonacci identity (m²−n²)² + (2mn)² = (m²+n²)² by computing N(g²) two ways — coordinatewise and via multiplicativity. param_is_triple feeds it into Mathlib's PythagoreanTriple, so the parameterized triple is Pythagorean by an arithmetic identity, not a brute ring expansion."
+    },
+    {
+      "id": "completeness",
+      "title": "Part III: Completeness — primitive triples are Gaussian squares",
+      "startLine": 100,
+      "endLine": 125,
+      "summary": "gaussian_completeness: every primitive triple (x,y,z) with x odd and z > 0 is the square of a Gaussian integer — there are coprime m, n with (x + yi) = (m + ni)² and z = N(m+ni). Proved by transporting Mathlib's coprime_classification' through gaussianInt_sq, showing the parameterization is surjective onto primitive triples."
+    },
+    {
+      "id": "examples",
+      "title": "Part IV: Worked examples",
+      "startLine": 126,
+      "endLine": 147,
+      "summary": "Concrete instances: (2 + i)² = 3 + 4i with N(2+i) = 5 (the 3-4-5 triple) and (3 + 2i)² = 5 + 12i with N(3+2i) = 13 (the 5-12-13 triple), plus the 3-4-5 triple obtained through param_is_triple at m = 2, n = 1."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/pythagorean-theorem-oq-04.json
+++ b/src/data/research/problems/pythagorean-theorem-oq-04.json
@@ -1,0 +1,105 @@
+{
+  "slug": "pythagorean-theorem-oq-04",
+  "title": "Completeness of the (m,n) Parameterization of Primitive Pythagorean Triples via the Gaussian Integer Norm",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For coprime m > n > 0 of opposite parity, (m,n) ↦ (m²−n², 2mn, m²+n²) is a primitive Pythagorean triple, and every primitive triple arises this way; derive completeness through the Gaussian-integer norm N(m+ni) = m²+n² and the multiplicativity of the norm in ℤ[i].",
+    "plain": "The (m,n) formula for Pythagorean triples is recast as the arithmetic of the Gaussian integers ℤ[i]: squaring m+ni gives the legs, norm multiplicativity gives the Pythagorean identity, and every primitive triple is (up to units) the square of a Gaussian integer — so the parameterization omits nothing.",
+    "whyMatters": [
+      "The Gaussian-integer route is the canonical explanation for WHY the parameterization is complete, not merely a verification of the forward direction",
+      "Links elementary number theory to algebraic number theory: UFD structure of ℤ[i], norm multiplicativity, and the unit group {±1, ±i}",
+      "Supplies reusable norm/squaring infrastructure for sums-of-two-squares results (e.g. Fermat's two-square theorem)"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Soundness: (m²−n², 2mn, m²+n²) is a Pythagorean triple, derived from N(g²) = N(g)² (Zsqrtd.norm_mul) rather than a brute ring expansion",
+      "Completeness: every primitive triple (x,y,z) with x odd and z>0 is the square of a Gaussian integer, with z = N(m+ni)"
+    ],
+    "open": [
+      "Full uniqueness of (m,n) up to the unit group {±1, ±i} and order (bijection onto primitive triples)",
+      "Removing the x-odd / z>0 normalization by tracking the four units of ℤ[i] explicitly"
+    ],
+    "goal": "Formalize completeness (and the norm-multiplicativity derivation of soundness) of the (m,n) parameterization through ℤ[i]."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-28T11:30:00.000Z",
+    "iteration": 1,
+    "focus": "Proved in PythagoreanTheoremOQ04.lean (6 theorems, 0 sorry / 0 axiom, Docker build GREEN against Mathlib 4.26.0). Gallery entry created (meta.json + 5 annotations). PR #31460 open.",
+    "blockers": [],
+    "nextAction": "None for researcher track; optional follow-up is full uniqueness up to units.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE + GALLERIED: (m,n) parameterization recast via the Gaussian-integer norm (PythagoreanTheoremOQ04.lean, 6 theorems, 0-sorry/0-axiom, Docker GREEN on Mathlib 4.26.0). gaussianInt_sq: squaring m+ni = (m²−n²)+(2mn)i IS the parameterization map. norm_gaussianInt_sq: N(g²)=N(g)² from Zsqrtd.norm_mul is the engine. param_norm_identity derives Brahmagupta–Fibonacci (m²−n²)²+(2mn)²=(m²+n²)² by computing N(g²) two ways; param_is_triple feeds it to Mathlib's PythagoreanTriple via linear_combination. gaussian_completeness: every primitive triple (x odd, z>0) is a Gaussian square with z=N(m+ni), via coprime_classification' transported through the squaring identity. Gallery entry src/data/proofs/pythagorean-theorem-oq-04/ (meta.json + 5 annotations, annotations:validate clean). PR #31460.",
+    "builtItems": [
+      "gaussianInt_norm / gaussianInt_sq in Proofs/PythagoreanTheoremOQ04.lean — the norm formula and the squaring identity (m+ni)² = (m²−n²)+(2mn)i (Zsqrtd.ext + ring)",
+      "norm_gaussianInt_sq — N(g²)=N(g)² via Zsqrtd.norm_mul, the multiplicativity engine",
+      "param_norm_identity — Brahmagupta–Fibonacci identity obtained by computing the norm of the square two ways (coordinatewise vs multiplicativity)",
+      "param_is_triple — the parameterized triple is a Mathlib PythagoreanTriple, routed through param_norm_identity by linear_combination",
+      "gaussian_completeness — every primitive triple with x odd, z>0 is the square of a Gaussian integer with z=N(m+ni), via PythagoreanTriple.coprime_classification'",
+      "Gallery entry: src/data/proofs/pythagorean-theorem-oq-04/ (meta.json + 5 annotations)"
+    ],
+    "insights": [
+      "The Brahmagupta–Fibonacci two-square identity is exactly norm multiplicativity N(zw)=N(z)N(w) specialized to w=z — Pythagoras is N(g²)=N(g)² read off coordinates, not a ring coincidence",
+      "Squaring in ℤ[i] IS the (m,n) parameterization map: the legs m²−n² and 2mn are literally the real and imaginary parts of g²",
+      "Completeness is surjectivity onto primitive triples: a primitive x+yi has square norm z², so in the UFD ℤ[i] it is a square up to a unit — this is WHY no primitive triple is omitted; the hypotenuse z=N(m+ni) carries intrinsic arithmetic meaning"
+    ],
+    "mathlibGaps": [
+      "None blocking — GaussianInt/Zsqrtd.norm_mul and PythagoreanTriple.coprime_classification' provide everything needed"
+    ],
+    "nextSteps": [
+      "Strengthen gaussian_completeness to full uniqueness of (m,n) up to {±1, ±i} and order",
+      "Derive completeness directly from unique factorization in ℤ[i] (square-norm element is a square up to a unit) rather than transporting coprime_classification'",
+      "Connect to Fermat's two-square theorem (pythagorean-triples-oq-04): both are shadows of how primes split in ℤ[i]"
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "pythagorean-triples",
+    "gaussian-integers",
+    "norm-multiplicativity",
+    "gallery-gap",
+    "research"
+  ],
+  "relatedProofs": [
+    "pythagorean-theorem",
+    "pythagorean-triples",
+    "pythagorean-triples-oq-04"
+  ],
+  "references": {
+    "papers": [
+      "Hardy & Wright, An Introduction to the Theory of Numbers — Gaussian integers and sums of two squares"
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.NumberTheory.Zsqrtd.GaussianInt",
+      "Mathlib.NumberTheory.PythagoreanTriples"
+    ]
+  },
+  "started": "2026-06-28T10:47:35.000Z",
+  "lastUpdate": "2026-06-28",
+  "significance": 5,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/PythagoreanTheoremOQ04.lean",
+      "filename": "PythagoreanTheoremOQ04.lean",
+      "lineCount": 148,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTheoremOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes **pythagorean-theorem-oq-04**: the `(m,n)` parameterization of Pythagorean triples recast as the arithmetic of the Gaussian integers `ℤ[i]`. This is the canonical "right" proof — it explains *why* the parameterization is complete rather than just verifying the forward direction.

`proofs/Proofs/PythagoreanTheoremOQ04.lean` — **6 theorems, 0 axioms, 0 sorries**, Docker-built against Mathlib 4.26.0.

## Mathematical content

**Soundness (norm route).** Squaring `g = m + ni` in `ℤ[i]` gives `g² = (m²−n²) + (2mn)i`, so the legs `a = m²−n²`, `b = 2mn` are literally the real/imaginary parts of the squaring map. Because the norm is multiplicative, `N(g²) = N(g)² = (m²+n²)²`. Reading the norm off coordinates yields
`(m²−n²)² + (2mn)² = (m²+n²)²` — the Brahmagupta–Fibonacci identity **as norm multiplicativity** (`Zsqrtd.norm_mul`), not as a brute `ring` expansion. `param_is_triple` feeds this into Mathlib's `PythagoreanTriple` via `linear_combination`.

**Completeness (Gaussian factorization).** `gaussian_completeness`: every *primitive* triple `(x,y,z)` with `x` odd and `z > 0` is the square of a Gaussian integer — there are coprime `m, n` with `(x + yi) = (m + ni)²` and hypotenuse `z = N(m+ni)`. Proved by transporting Mathlib's `PythagoreanTriple.coprime_classification'` through the squaring identity. This is the genuinely arithmetic content: the parameterization is *surjective* onto primitive triples.

## Relation to existing gallery

The `pythagorean-triples` entry derives the same classification from the rational parametrization of the unit circle. This file gives the orthogonal algebraic-number-theory viewpoint: the parameterization **is** the arithmetic of `ℤ[i]`, with the hypotenuse a Gaussian norm. Cross-references `pythagorean-triples`, `pythagorean-theorem`, and `pythagorean-triples-oq-04` (Fermat two-square, also via `ℤ[i]`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.PythagoreanTheoremOQ04` → **Build completed successfully** (no errors, no warnings)
- `pnpm annotations:validate` → clean for this entry (5 annotations resolve)
- `pnpm gallery:check-size` → within caps
- 0 `axiom` declarations, no structure-encoded assumptions; depends only on `propext` / `Classical.choice` / `Quot.sound`

## Gallery files

- `src/data/proofs/pythagorean-theorem-oq-04/meta.json`
- `src/data/proofs/pythagorean-theorem-oq-04/annotations.json` (5 annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)