### PR TITLE
Enrich Erdős #1100 prime-power equality family (erdos-1100-oq-02): index.ts + annotation depth

### DIFF
--- a/src/data/proofs/erdos-1100-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1100-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 41 },
     "type": "concept",
     "title": "Open Question and Answer",
-    "content": "**Which n minimize τ⊥, i.e. achieve τ⊥(n) = ω(n)?**\n\nErdős #1100 gives the bound τ⊥(n) ≥ ω(n), with equality known for primes (τ⊥(p) = 1 = ω(p)). This entry settles the **prime-power** case of the extremal-minimum question: every prime power pᵏ achieves equality, τ⊥(pᵏ) = ω(pᵏ) = 1.\n\nThe results are unconditional and exact, sitting strictly below the conjectural growth regime of the open Erdős–Hall / Erdős–Simonovits questions."
+    "content": "**Which n minimize τ⊥, i.e. achieve τ⊥(n) = ω(n)?**\n\nErdős #1100 gives the bound τ⊥(n) ≥ ω(n), with equality known for primes (τ⊥(p) = 1 = ω(p)). This entry settles the **prime-power** case of the extremal-minimum question: every prime power pᵏ achieves equality, τ⊥(pᵏ) = ω(pᵏ) = 1.\n\nThe results are unconditional and exact, sitting strictly below the conjectural growth regime of the open Erdős–Hall / Erdős–Simonovits questions.",
+    "mathContext": "$\\tau^{\\perp}(n) \\ge \\omega(n)$, with equality on $\\{p^k : p \\text{ prime},\\ k \\ge 1\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["Erdős #1100", "extremal minimum", "coprime consecutive divisors", "number of prime factors"],
+    "prerequisites": ["sorted divisors of n", "ω(n) = number of distinct prime factors"]
   },
   {
     "id": "ann-e1100oq02-defs",
@@ -13,7 +17,11 @@
     "range": { "startLine": 43, "endLine": 57 },
     "type": "definition",
     "title": "τ⊥, ω, divisorList",
-    "content": "The definitions mirror the parent `Erdos1100Problem.lean`:\n\n- `divisorList n` — the divisors of n in increasing order (sort of {d ≤ n : d ∣ n}).\n- `omega n = |n.primeFactors|` — the number of distinct prime divisors ω(n).\n- `tauPerp n` — the count of indices i with gcd(dᵢ, dᵢ₊₁) = 1.\n\nKept self-contained (imports only Mathlib) so the entry verifies independently of the parent."
+    "content": "The definitions mirror the parent `Erdos1100Problem.lean`:\n\n- `divisorList n` — the divisors of n in increasing order (sort of {d ≤ n : d ∣ n}).\n- `omega n = |n.primeFactors|` — the number of distinct prime divisors ω(n).\n- `tauPerp n` — the count of indices i with gcd(dᵢ, dᵢ₊₁) = 1.\n\nKept self-contained (imports only Mathlib) so the entry verifies independently of the parent.",
+    "mathContext": "$\\tau^{\\perp}(n) = \\#\\{ i : \\gcd(d_i, d_{i+1}) = 1 \\}$, $\\omega(n) = \\#\\{p \\text{ prime} : p \\mid n\\}$, where $1 = d_1 < \\cdots < d_{\\tau(n)} = n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sort", "Nat.primeFactors", "List.getD", "consecutive-pair predicate"],
+    "prerequisites": ["Finset filtering and sorting", "noncomputable definitions"]
   },
   {
     "id": "ann-e1100oq02-divlist",
@@ -21,7 +29,11 @@
     "range": { "startLine": 59, "endLine": 95 },
     "type": "proof",
     "title": "Sorted divisors of pᵏ are [1, p, …, pᵏ]",
-    "content": "`divisorList_prime_pow`: for prime p and k ≥ 1, the increasing divisor list of pᵏ is (List.range (k+1)).map (p ^ ·).\n\nProof: bridge the range-filtered divisor set to `Nat.divisors` (only 0 is dropped), rewrite via `Nat.divisors_prime_pow` to an image of `range`, then push the sort through the strictly-monotone embedding p ^ · using `Finset.map_sort` and `range_sort` ((range m).sort = List.range m)."
+    "content": "`divisorList_prime_pow`: for prime p and k ≥ 1, the increasing divisor list of pᵏ is (List.range (k+1)).map (p ^ ·).\n\nProof: bridge the range-filtered divisor set to `Nat.divisors` (only 0 is dropped), rewrite via `Nat.divisors_prime_pow` to an image of `range`, then push the sort through the strictly-monotone embedding p ^ · using `Finset.map_sort` and `range_sort` ((range m).sort = List.range m).",
+    "mathContext": "$\\operatorname{divisorList}(p^k) = [p^0, p^1, \\ldots, p^k]$; the embedding $i \\mapsto p^i$ is strictly monotone since $p \\ge 2$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.divisors_prime_pow", "Finset.map_sort", "strictly monotone embedding", "sort through order-isomorphism"],
+    "prerequisites": ["divisors of a prime power", "Nat.pow_right_injective", "Finset.sort vs List.range"]
   },
   {
     "id": "ann-e1100oq02-tauperp",
@@ -29,7 +41,11 @@
     "range": { "startLine": 97, "endLine": 151 },
     "type": "proof",
     "title": "τ⊥(pᵏ) = 1 = ω(pᵏ)",
-    "content": "`tauPerp_prime_pow`: among consecutive pairs (pⁱ, pⁱ⁺¹), gcd = pⁱ, which equals 1 exactly when i = 0. So the unique coprime consecutive pair is (1, p), giving τ⊥(pᵏ) = 1. The filter predicate is reduced to `i = 0` and the single surviving index counted.\n\n`omega_prime_pow`: ω(pᵏ) = 1 via `Nat.primeFactors_prime_pow`."
+    "content": "`tauPerp_prime_pow`: among consecutive pairs (pⁱ, pⁱ⁺¹), gcd = pⁱ, which equals 1 exactly when i = 0. So the unique coprime consecutive pair is (1, p), giving τ⊥(pᵏ) = 1. The filter predicate is reduced to `i = 0` and the single surviving index counted.\n\n`omega_prime_pow`: ω(pᵏ) = 1 via `Nat.primeFactors_prime_pow`.",
+    "mathContext": "$\\gcd(p^i, p^{i+1}) = p^i$, and $p^i = 1 \\iff i = 0$ (since $p \\ge 2$); hence exactly one coprime consecutive pair $(p^0, p^1) = (1, p)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.gcd_eq_left", "pow_dvd_pow", "List.filter_congr", "Nat.primeFactors_prime_pow"],
+    "prerequisites": ["gcd of nested prime powers", "counting a singleton filter", "Nat.pow_eq_one"]
   },
   {
     "id": "ann-e1100oq02-family",
@@ -37,6 +53,10 @@
     "range": { "startLine": 153, "endLine": 169 },
     "type": "concept",
     "title": "The equality family",
-    "content": "`tauPerp_eq_omega_prime_pow`: τ⊥(pᵏ) = ω(pᵏ) for all prime powers. `tau_perp_equality_prime_powers`: equality holds at arbitrarily large n, realised by 2^(N+1) — a strict strengthening of the prime-only equality-infinitely-often statement.\n\n**Open**: characterize ALL minimizers (are they exactly the prime powers?), and prove the parent axiom τ⊥(n) ≥ ω(n) unconditionally."
+    "content": "`tauPerp_eq_omega_prime_pow`: τ⊥(pᵏ) = ω(pᵏ) for all prime powers. `tau_perp_equality_prime_powers`: equality holds at arbitrarily large n, realised by 2^(N+1) — a strict strengthening of the prime-only equality-infinitely-often statement.\n\n**Open**: characterize ALL minimizers (are they exactly the prime powers?), and prove the parent axiom τ⊥(n) ≥ ω(n) unconditionally.",
+    "mathContext": "$\\forall N,\\ \\exists n > N:\\ \\tau^{\\perp}(n) = \\omega(n)$, witnessed by $n = 2^{N+1}$ (using $N < 2^{N+1}$).",
+    "significance": "key",
+    "relatedConcepts": ["equality infinitely often", "Nat.lt_two_pow_self", "extremal family", "strengthening the prime case"],
+    "prerequisites": ["the prime-power lemmas above", "existential over arbitrarily large n"]
   }
 ]

--- a/src/data/proofs/erdos-1100-oq-02/index.ts
+++ b/src/data/proofs/erdos-1100-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1100OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1100Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1100Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1100Oq02Data: ProofData = {
+  proof: erdos1100Oq02Proof,
+  annotations: erdos1100Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-1100-oq-02` (Erdős #1100: prime powers are the extremal-minimum family for τ⊥).

## Changes
- **Created missing `index.ts`** — without it the proof page renders "proof not found" on the live site despite appearing in the gallery listing. Template-identical to the 508 existing entries.
- **Added annotation depth**: all 5 annotations previously carried only `id`/`range`/`type`/`title`/`content`. Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to each, grounded in the actual Lean lemmas (`divisorList_prime_pow`, `tauPerp_prime_pow`, `omega_prime_pow`, the `2^(N+1)` witness, etc.).

## Verification
- `pnpm build` passes (exit 0): `tsc -b` + `vite build` succeed; annotation resolver reports 0 errors for this entry.
- meta.json unchanged at 10.8 KB (well under the 60 KB cap); no prose inflation.
- **Axiom integrity confirmed**: badge `verified` / `axiomCount: 0` is accurate against `Proofs/Erdos1100OQ02.lean` — 0 `axiom` declarations, 0 sorries, no `native_decide`. The τ⊥(n) ≥ ω(n) axiom referenced in the open-questions text lives only in the **parent** `Erdos1100Problem.lean` and is not used by this self-contained file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
