### PR TITLE
research(feuerbachs-theorem-oq-04): spherical triangle inequality — sdist is a genuine metric [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -44,8 +44,11 @@ construction; this file establishes the metric layer underneath that constructio
   is a well-defined `[0, π]`-valued quantity vanishing on the diagonal.
 * `scos_eq_one_iff`, `sdist_eq_zero_iff`, `sdist_pos` — **point separation**: for unit
   vectors `sdist P Q = 0 ↔ P = Q`, so together with symmetry and nonnegativity `sdist`
-  separates points and is a genuine metric on the spherical model (modulo the spherical
-  triangle inequality).
+  separates points.
+* `sdist_eq_angle`, `sdist_triangle`, `sdist_isMetric` — the **spherical triangle
+  inequality** and metric capstone: identifying `sdist` with Mathlib's unoriented angle
+  transports `angle_le_angle_add_angle` to `sdist P R ≤ sdist P Q + sdist Q R`, completing
+  all four metric-space axioms — `(Sⁿ, sdist)` is a genuine metric on the spherical model.
 -/
 import Mathlib
 
@@ -162,6 +165,43 @@ theorem cos_sdist (P Q : E) (hP : OnSphere P) (hQ : OnSphere Q) :
     Real.cos (sdist P Q) = scos P Q := by
   rw [sdist, scos]
   exact Real.cos_arccos (neg_one_le_scos P Q hP hQ) (scos_le_one P Q hP hQ)
+
+/-- **`sdist` is Mathlib's unoriented vector angle.**  Mathlib defines
+`InnerProductGeometry.angle P Q = arccos (⟪P, Q⟫ / (‖P‖·‖Q‖))`; for unit vectors the
+normalising factor `‖P‖·‖Q‖` is `1`, so it collapses to `arccos ⟪P, Q⟫ = sdist P Q`.  This
+bridge lets the spherical metric inherit Mathlib's developed angle theory — in particular
+the angle triangle inequality, which becomes the spherical triangle inequality below. -/
+theorem sdist_eq_angle {P Q : E} (hP : OnSphere P) (hQ : OnSphere Q) :
+    sdist P Q = InnerProductGeometry.angle P Q := by
+  rw [sdist, InnerProductGeometry.angle, hP, hQ]
+  norm_num
+
+/-- **Spherical triangle inequality.**  For model points (unit vectors),
+`sdist P R ≤ sdist P Q + sdist Q R`.  This is the final metric-space axiom: combined with
+`sdist_self` (vanishing on the diagonal), `sdist_eq_zero_iff` (point separation),
+`sdist_nonneg`, and `sdist_comm` (symmetry), it makes `(Sⁿ, sdist)` a genuine metric space.
+The proof transports Mathlib's `InnerProductGeometry.angle_le_angle_add_angle` along the
+identification `sdist_eq_angle`. -/
+theorem sdist_triangle {P Q R : E} (hP : OnSphere P) (hQ : OnSphere Q) (hR : OnSphere R) :
+    sdist P R ≤ sdist P Q + sdist Q R := by
+  rw [sdist_eq_angle hP hR, sdist_eq_angle hP hQ, sdist_eq_angle hQ hR]
+  exact InnerProductGeometry.angle_le_angle_add_angle P Q R
+
+/-- **`sdist` is a genuine metric on the spherical model.**  All four metric-space axioms
+hold for `sdist` restricted to model points (unit vectors): it vanishes on the diagonal,
+separates points, is symmetric, and satisfies the triangle inequality.  Packaging this as a
+bundled `MetricSpace` instance would only additionally require carving the sphere out as a
+subtype; the mathematical content — the axioms themselves — is exactly this conjunction. -/
+theorem sdist_isMetric :
+    (∀ P : E, OnSphere P → sdist P P = 0) ∧
+    (∀ P Q : E, OnSphere P → OnSphere Q → (sdist P Q = 0 ↔ P = Q)) ∧
+    (∀ P Q : E, sdist P Q = sdist Q P) ∧
+    (∀ P Q R : E, OnSphere P → OnSphere Q → OnSphere R →
+      sdist P R ≤ sdist P Q + sdist Q R) :=
+  ⟨fun P hP => sdist_self P hP,
+   fun _ _ hP hQ => sdist_eq_zero_iff hP hQ,
+   fun P Q => sdist_comm P Q,
+   fun _ _ _ hP hQ hR => sdist_triangle hP hQ hR⟩
 
 /-! ## Spherical circles and tangency
 

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -32,13 +32,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BUILD: spherical model verified layer (FeuerbachsTheoremOQ04.lean, 0-axiom). chord_sq is the chord-cosine bridge; scos/sdist well-defined ([-1,1] cosine, [0,pi] distance). Spherical circles defined as scos level sets with the internal/external tangency criterion (mem_sCircle_iff_sdist, InternallyTangent/ExternallyTangent + symmetry). NEW (researcher-4): point separation — scos_eq_one_iff, sdist_eq_zero_iff (sdist P Q = 0 <-> P = Q), sdist_pos; with sdist_self/nonneg/comm this makes sdist a genuine metric modulo the spherical triangle inequality. Hyperbolic model deferred (no Mathlib support). Next: spherical triangle inequality, then incircle/nine-point constructions and the Feuerbach tangency.",
+    "progressSummary": "BUILD: spherical model verified layer (FeuerbachsTheoremOQ04.lean, 0-axiom). chord_sq is the chord-cosine bridge; scos/sdist well-defined ([-1,1] cosine, [0,pi] distance). Spherical circles defined as scos level sets with the internal/external tangency criterion (mem_sCircle_iff_sdist, InternallyTangent/ExternallyTangent + symmetry). Point separation: scos_eq_one_iff, sdist_eq_zero_iff (sdist P Q = 0 <-> P = Q), sdist_pos. NEW (researcher-4): spherical triangle inequality — sdist_eq_angle identifies sdist with Mathlib's InnerProductGeometry.angle on unit vectors, transporting angle_le_angle_add_angle to sdist_triangle (sdist P R <= sdist P Q + sdist Q R); sdist_isMetric bundles all four metric-space axioms, so (S^n, sdist) is now a genuine metric on the spherical model. Hyperbolic model deferred (no Mathlib support). Next: tangent-point existence and incircle/nine-point constructions toward the Feuerbach tangency.",
     "builtItems": [
       "FeuerbachsTheoremOQ04.chord_sq (Proofs/FeuerbachsTheoremOQ04.lean) — chord-cosine bridge: for unit vectors, ||P-Q||^2 = 2 - 2*scos P Q; turns spherical tangency into an inner-product equation. 0-axiom.",
       "FeuerbachsTheoremOQ04.abs_scos_le_one/scos_le_one/neg_one_le_scos — spherical cosine in [-1,1] (Cauchy-Schwarz on unit vectors)",
       "FeuerbachsTheoremOQ04.scos_self/sdist_self/sdist_nonneg/sdist_le_pi/sdist_eq_zero_of_eq — sdist is a well-defined [0,pi]-valued angle vanishing on the diagonal",
       "defs OnSphere (unit vector), scos := <P,Q>, sdist := arccos <P,Q> — the spherical model primitives",
-      "FeuerbachsTheoremOQ04.scos_eq_one_iff/sdist_eq_zero_iff/sdist_pos (researcher-4) — point separation: for unit vectors sdist P Q = 0 iff P = Q, so sdist separates points (genuine metric modulo triangle ineq). 0-axiom."
+      "FeuerbachsTheoremOQ04.scos_eq_one_iff/sdist_eq_zero_iff/sdist_pos (researcher-4) — point separation: for unit vectors sdist P Q = 0 iff P = Q, so sdist separates points (genuine metric modulo triangle ineq). 0-axiom.",
+      "FeuerbachsTheoremOQ04.sdist_eq_angle/sdist_triangle/sdist_isMetric (researcher-4) — spherical triangle inequality: sdist = InnerProductGeometry.angle on unit vectors, so angle_le_angle_add_angle gives sdist P R <= sdist P Q + sdist Q R; sdist_isMetric bundles all four metric-space axioms, completing (S^n, sdist) as a genuine metric on the spherical model. 0-axiom."
     ],
     "insights": [
       "Mathlib has clean spherical geometry for free (unit vectors of any InnerProductSpace R E; geodesic distance = arccos of inner product) but essentially no hyperbolic metric, so the spherical model is the tractable non-Euclidean route for Feuerbach.",
@@ -50,8 +51,8 @@
       "No spherical-triangle incircle / nine-point-circle construction in Mathlib; must be built on scos/sdist."
     ],
     "nextSteps": [
-      "Prove the spherical triangle inequality sdist P R <= sdist P Q + sdist Q R to make (S^n, sdist) a MetricSpace; check InnerProductGeometry.angle lemmas (sdist = angle on unit vectors).",
-      "Tangent-point existence for tangent spherical circles (slerp midpoint on the geodesic between centres).",
+      "Bundle (S^n, sdist) as an actual Mathlib MetricSpace instance on the sphere subtype (sdist_isMetric supplies all four axioms; the remaining work is the subtype packaging).",
+      "Tangent-point existence for tangent spherical circles (slerp midpoint on the geodesic between centres), using sdist_triangle for the betweenness/uniqueness argument.",
       "Construct the spherical incircle and nine-point circle for a spherical triangle, then attempt the tangency conclusion."
     ]
   },
@@ -91,7 +92,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.293Z",
-  "lastUpdate": "2026-06-28T11:30:00.000Z",
+  "lastUpdate": "2026-06-28T11:55:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Adds the **final metric-space axiom** for the spherical-model distance `sdist` in `FeuerbachsTheoremOQ04.lean`, completing the proof that `(Sⁿ, sdist)` is a genuine metric on the spherical model. Builds directly on the point-separation layer (merged in #31449).

The non-Euclidean Feuerbach problem (`feuerbachs-theorem-oq-04`) is anchored in the spherical model, where a model point is a unit vector and the geodesic distance is `sdist P Q = arccos ⟪P, Q⟫`. Prior layers established `sdist` is a well-defined `[0, π]`-valued quantity that vanishes on the diagonal, is symmetric, and separates points. The only remaining metric axiom was the triangle inequality.

## New lemmas (all 0-axiom, 0-sorry)

- **`sdist_eq_angle`** — identifies `sdist P Q` with Mathlib's `InnerProductGeometry.angle P Q` for unit vectors: the normalising factor `‖P‖·‖Q‖` collapses to `1`, so `arccos (⟪P,Q⟫ / (‖P‖·‖Q‖)) = arccos ⟪P,Q⟫`. This bridge lets the spherical metric inherit Mathlib's developed angle theory.
- **`sdist_triangle`** — the **spherical triangle inequality** `sdist P R ≤ sdist P Q + sdist Q R`, transported from Mathlib's `InnerProductGeometry.angle_le_angle_add_angle` along `sdist_eq_angle`.
- **`sdist_isMetric`** — capstone conjunction of all four metric-space axioms (vanishing on the diagonal, point separation, symmetry, triangle inequality), establishing `(Sⁿ, sdist)` as a genuine metric on the spherical model.

## Verification

- Docker build `Proofs.FeuerbachsTheoremOQ04` succeeds (7743/7743 jobs).
- 0 `sorry`, 0 `axiom` declarations, no `native_decide` / `decide`. No structure-encoded assumptions.
- Foundational axioms only (`propext` / `Classical.choice` / `Quot.sound`).

## Next steps (recorded in the research JSON)

Bundle `(Sⁿ, sdist)` as an actual Mathlib `MetricSpace` instance on the sphere subtype; tangent-point existence for tangent spherical circles; spherical incircle / nine-point constructions toward the Feuerbach tangency conclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)