### PR TITLE
research(erdos-1074): effective witness bounds for Pillai primes [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1074Problem.lean
+++ b/proofs/Proofs/Erdos1074Problem.lean
@@ -155,6 +155,59 @@ theorem mem_pillai_iff {p : ℕ} :
   · rintro ⟨hp, m, ⟨hm1, -⟩, hmc, hmd⟩
     exact ⟨hp, m, hm1, hmc, hmd⟩
 
+/- ## Effective Witness Bounds
+
+The non-congruence condition `¬ p ≡ 1 [MOD m]` combined with the factorial
+divisibility `p ∣ m! + 1` forces any witness `m` into a bounded window
+`1 ≤ m ≤ p - 2`. This is what makes membership in `PillaiPrimes` decidable by
+a *finite* search per prime: only finitely many candidate witnesses `m < p`
+need be checked. It also yields the lower bound `p ≥ 3` for every Pillai prime.
+-/
+
+/-- **Witness upper bound (divisibility).** If `p` is prime and `p ∣ m! + 1`,
+then `m < p`. Indeed if `p ≤ m` then `p ∣ m!` (a prime divides `n!` iff it is
+`≤ n`), so `p` would divide `(m! + 1) - m! = 1`, contradicting primality. -/
+theorem witness_lt_of_dvd_factorial_add_one {p m : ℕ} (hp : p.Prime)
+    (hmd : p ∣ m ! + 1) : m < p := by
+  by_contra h
+  push_neg at h  -- h : p ≤ m
+  have hfac : p ∣ m ! := Nat.dvd_factorial hp.pos h
+  have hone : p ∣ 1 := (Nat.dvd_add_right hfac).mp hmd
+  exact hp.one_lt.ne' (Nat.dvd_one.mp hone)
+
+/-- **Witness avoids the Wilson case.** The non-congruence hypothesis
+`¬ p ≡ 1 [MOD m]` rules out `m = p - 1`, since the Wilson witness `m = p - 1`
+always satisfies `p ≡ 1 [MOD (p - 1)]`. -/
+theorem witness_ne_pred {p m : ℕ} (hp : 1 ≤ p) (hmc : ¬ p ≡ 1 [MOD m]) :
+    m ≠ p - 1 := by
+  rintro rfl
+  exact hmc (prime_cong_one_mod_pred hp)
+
+/-- **Effective witness window.** Every witness `m` of a Pillai prime `p`
+satisfies `1 ≤ m` and `m + 2 ≤ p`, i.e. `1 ≤ m ≤ p - 2`. Combining the
+divisibility bound `m < p` with the exclusion `m ≠ p - 1`. -/
+theorem witness_add_two_le {p m : ℕ} (hp : p.Prime) (hm1 : 1 ≤ m)
+    (hmc : ¬ p ≡ 1 [MOD m]) (hmd : p ∣ m ! + 1) : m + 2 ≤ p := by
+  have hlt : m < p := witness_lt_of_dvd_factorial_add_one hp hmd
+  have hne : m ≠ p - 1 := witness_ne_pred hp.one_lt.le hmc
+  -- `m < p` and `m ≠ p - 1` give `m ≤ p - 2`, hence `m + 2 ≤ p`.
+  omega
+
+/-- **Existence of a bounded witness.** Membership in `PillaiPrimes` is
+witnessed by some `m` confined to the finite window `1 ≤ m` and `m + 2 ≤ p`. -/
+theorem pillai_bounded_witness {p : ℕ} (hp : p ∈ PillaiPrimes) :
+    ∃ m, 1 ≤ m ∧ m + 2 ≤ p ∧ ¬ p ≡ 1 [MOD m] ∧ p ∣ m ! + 1 := by
+  obtain ⟨hprime, m, hm1, hmc, hmd⟩ := hp
+  exact ⟨m, hm1, witness_add_two_le hprime hm1 hmc hmd, hmc, hmd⟩
+
+/-- **Every Pillai prime is at least 3.** Immediate from the witness window
+`1 ≤ m` and `m + 2 ≤ p`: the smallest possible witness `m = 1` already forces
+`p ≥ 3`. (The true minimum is `23`, but `p ≥ 3` is the structural bound
+provable from the definitions alone.) -/
+theorem three_le_of_mem_pillai {p : ℕ} (hp : p ∈ PillaiPrimes) : 3 ≤ p := by
+  obtain ⟨m, hm1, hm2, -, -⟩ := pillai_bounded_witness hp
+  omega
+
 /- ## Infinitude Results
 
 Erdős, Hardy, and Subbarao proved that both sets are infinite.

--- a/src/data/proofs/erdos-1074/meta.json
+++ b/src/data/proofs/erdos-1074/meta.json
@@ -67,12 +67,16 @@
       "Theorem prime_dvd_pred_factorial_add_one: Wilson connection p | (p-1)! + 1 for all primes p",
       "Theorem wilson_witness_excluded: the canonical witness m=p-1 gives p|(p-1)!+1 but also p≡1 [MOD p-1], so it is always excluded — this is exactly why EHS/Pillai are nontrivial",
       "Theorem mem_pillai_iff: EHS/Pillai duality — the Pillai primes are exactly the primes witnessing some EHS number",
+      "Theorem witness_lt_of_dvd_factorial_add_one: any witness m of p | m!+1 (p prime) satisfies m < p — if p ≤ m then p | m!, forcing p | 1",
+      "Theorem witness_ne_pred / witness_add_two_le: combining m < p with the Wilson-witness exclusion m ≠ p-1 confines every Pillai-prime witness to the finite window 1 ≤ m ≤ p-2 (m+2 ≤ p)",
+      "Theorem pillai_bounded_witness: membership in PillaiPrimes is witnessed by a bounded m, making per-prime membership a finite search",
+      "Theorem three_le_of_mem_pillai: every Pillai prime is ≥ 3 (structural lower bound from the witness window; the true minimum 23 needs computation)",
       "Open density conjectures documented (not asserted)"
     ],
     "axiomCount": 1,
-    "lineCount": 206,
+    "lineCount": 259,
     "assumptions": "0 axiom declarations and 0 sorries in the Lean source. The verified numeric examples (23 is a Pillai prime; 8, 9 are EHS numbers) are discharged by `native_decide`, so they depend on `Lean.ofReduceBool` (and `Lean.trustCompiler`); meta.axiomCount=1 records this per the project's axiom-integrity policy (leanFile.axiomCount remains 0 as there are no literal `axiom` declarations). The newly added structural theorems (Wilson connection, Wilson-witness exclusion, and the EHS/Pillai duality `mem_pillai_iff`) are fully proved and use only the foundational propext/Classical.choice/Quot.sound. The 'axiomatized' status reflects that the headline density questions remain OPEN and are not formalized as theorems.",
-    "theoremCount": 10,
+    "theoremCount": 15,
     "definitionCount": 2
   },
   "overview": {
@@ -88,7 +92,8 @@
       "**Chowla's Example:** 14! + 1 = 87,178,291,201 has factor 23, and 23 ≢ 1 (mod 14)",
       "**Density Mystery:** Why would EHS numbers have density 1? The condition seems restrictive",
       "**EHS/Pillai duality:** Pillai primes are exactly the primes that witness EHS numbers (mem_pillai_iff)",
-      "**Definition pitfall:** dropping `m ≥ 1` lets m=0 (modulus 0 ≡ equality) spuriously admit 2; the corrected definition matches OEIS A063980"
+      "**Definition pitfall:** dropping `m ≥ 1` lets m=0 (modulus 0 ≡ equality) spuriously admit 2; the corrected definition matches OEIS A063980",
+      "**Effective witness window:** p | m!+1 with p prime forces m < p (else p | m!), and the non-congruence rules out m = p-1, so any Pillai-prime witness lies in 1 ≤ m ≤ p-2 — a finite per-prime search and the source of the structural bound p ≥ 3"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -136,6 +141,14 @@
       "startLine": 117,
       "endLine": 146,
       "mathContext": "Do the asymptotic densities exist?"
+    },
+    {
+      "id": "effective-bounds",
+      "title": "Effective Witness Bounds",
+      "summary": "Witness window 1 ≤ m ≤ p-2 and the lower bound p ≥ 3 for Pillai primes",
+      "startLine": 158,
+      "endLine": 209,
+      "mathContext": "p | m!+1 forces m < p; excluding the Wilson witness m=p-1 gives 1 ≤ m ≤ p-2, hence every Pillai prime is ≥ 3"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Erdős #1074 — EHS Numbers and Pillai Primes

Adds a new **Effective Witness Bounds** section to `Proofs/Erdos1074Problem.lean`: 5 structural theorems that confine the witness of a Pillai prime to a finite window, proved with **no axioms and no sorries** (uses `omega` + `Nat.dvd_factorial`, **no `native_decide`**).

### New theorems
- `witness_lt_of_dvd_factorial_add_one` — for prime `p`, `p ∣ m! + 1 ⟹ m < p` (if `p ≤ m` then `p ∣ m!`, forcing `p ∣ 1`).
- `witness_ne_pred` — the non-congruence condition `¬ p ≡ 1 [MOD m]` rules out the Wilson witness `m = p - 1`.
- `witness_add_two_le` — every Pillai-prime witness satisfies `1 ≤ m ≤ p - 2` (`m + 2 ≤ p`).
- `pillai_bounded_witness` — membership in `PillaiPrimes` is witnessed by a bounded `m`, so per-prime membership reduces to a **finite search**.
- `three_le_of_mem_pillai` — every Pillai prime is `≥ 3` (first structural lower bound; the true minimum `23` requires computation).

### Significance
This makes precise why `PillaiPrimes` membership is effectively decidable per prime, and gives the first structural lower bound on the set, complementing the existing Wilson-connection and EHS/Pillai-duality lemmas.

### Status (unchanged)
The headline **density questions remain OPEN**. The file's `axiomatized` status reflects the existing `native_decide` numeric examples (`Lean.ofReduceBool`); the new content is fully axiom-free.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos1074Problem` → **Build succeeded** (3059 jobs)
- 0 sorries, 0 `axiom` declarations
- `meta.json` updated: `theoremCount` 10→15, `lineCount` 206→259, new section + contributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)