### PR TITLE
Enrich 'Erdős #1100: Prime Powers Are the Extremal-Minimum Family for τ⊥' (erdos-1100-oq-02)

### DIFF
--- a/src/data/proofs/erdos-1100-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1100-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 41 },
     "type": "concept",
     "title": "Open Question and Answer",
-    "content": "**Which n minimize τ⊥, i.e. achieve τ⊥(n) = ω(n)?**\n\nErdős #1100 gives the bound τ⊥(n) ≥ ω(n), with equality known for primes (τ⊥(p) = 1 = ω(p)). This entry settles the **prime-power** case of the extremal-minimum question: every prime power pᵏ achieves equality, τ⊥(pᵏ) = ω(pᵏ) = 1.\n\nThe results are unconditional and exact, sitting strictly below the conjectural growth regime of the open Erdős–Hall / Erdős–Simonovits questions."
+    "content": "**Which n minimize τ⊥, i.e. achieve τ⊥(n) = ω(n)?**\n\nErdős #1100 gives the bound τ⊥(n) ≥ ω(n), with equality known for primes (τ⊥(p) = 1 = ω(p)). This entry settles the **prime-power** case of the extremal-minimum question: every prime power pᵏ achieves equality, τ⊥(pᵏ) = ω(pᵏ) = 1.\n\nThe results are unconditional and exact, sitting strictly below the conjectural growth regime of the open Erdős–Hall / Erdős–Simonovits questions.",
+    "mathContext": "$\\tau^{\\perp}(n) \\ge \\omega(n)$; this entry shows equality for all $n = p^k$, extending the prime case $\\tau^{\\perp}(p) = \\omega(p) = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős #1100", "coprime consecutive divisors", "extremal number theory", "Erdős–Hall divisor problems"],
+    "prerequisites": ["divisor functions", "ω(n) prime-counting", "the parent τ⊥ ≥ ω bound"]
   },
   {
     "id": "ann-e1100oq02-defs",
@@ -13,7 +17,11 @@
     "range": { "startLine": 43, "endLine": 57 },
     "type": "definition",
     "title": "τ⊥, ω, divisorList",
-    "content": "The definitions mirror the parent `Erdos1100Problem.lean`:\n\n- `divisorList n` — the divisors of n in increasing order (sort of {d ≤ n : d ∣ n}).\n- `omega n = |n.primeFactors|` — the number of distinct prime divisors ω(n).\n- `tauPerp n` — the count of indices i with gcd(dᵢ, dᵢ₊₁) = 1.\n\nKept self-contained (imports only Mathlib) so the entry verifies independently of the parent."
+    "content": "The definitions mirror the parent `Erdos1100Problem.lean`:\n\n- `divisorList n` — the divisors of n in increasing order (sort of {d ≤ n : d ∣ n}).\n- `omega n = |n.primeFactors|` — the number of distinct prime divisors ω(n).\n- `tauPerp n` — the count of indices i with gcd(dᵢ, dᵢ₊₁) = 1.\n\nKept self-contained (imports only Mathlib) so the entry verifies independently of the parent.",
+    "mathContext": "$1 = d_1 < d_2 < \\cdots < d_{\\tau(n)} = n$; $\\tau^{\\perp}(n) = \\#\\{i : \\gcd(d_i, d_{i+1}) = 1\\}$, $\\omega(n) = \\#\\{p \\text{ prime} : p \\mid n\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sorted divisor list", "primeFactors", "List.Chain / consecutive pairs", "self-contained restatement"],
+    "prerequisites": ["Nat.divisors", "List sorting", "gcd"]
   },
   {
     "id": "ann-e1100oq02-divlist",
@@ -21,7 +29,11 @@
     "range": { "startLine": 59, "endLine": 95 },
     "type": "proof",
     "title": "Sorted divisors of pᵏ are [1, p, …, pᵏ]",
-    "content": "`divisorList_prime_pow`: for prime p and k ≥ 1, the increasing divisor list of pᵏ is (List.range (k+1)).map (p ^ ·).\n\nProof: bridge the range-filtered divisor set to `Nat.divisors` (only 0 is dropped), rewrite via `Nat.divisors_prime_pow` to an image of `range`, then push the sort through the strictly-monotone embedding p ^ · using `Finset.map_sort` and `range_sort` ((range m).sort = List.range m)."
+    "content": "`divisorList_prime_pow`: for prime p and k ≥ 1, the increasing divisor list of pᵏ is (List.range (k+1)).map (p ^ ·).\n\nProof: bridge the range-filtered divisor set to `Nat.divisors` (only 0 is dropped), rewrite via `Nat.divisors_prime_pow` to an image of `range`, then push the sort through the strictly-monotone embedding p ^ · using `Finset.map_sort` and `range_sort` ((range m).sort = List.range m).",
+    "mathContext": "$\\operatorname{divisors}(p^k) = \\{p^0, p^1, \\ldots, p^k\\}$; since $i \\mapsto p^i$ is strictly increasing, the sorted list is $[1, p, p^2, \\ldots, p^k]$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.divisors_prime_pow", "Finset.map_sort", "strictly monotone embedding", "range_sort"],
+    "prerequisites": ["divisors of prime powers", "order-preserving maps and sorting"]
   },
   {
     "id": "ann-e1100oq02-tauperp",
@@ -29,7 +41,11 @@
     "range": { "startLine": 97, "endLine": 151 },
     "type": "proof",
     "title": "τ⊥(pᵏ) = 1 = ω(pᵏ)",
-    "content": "`tauPerp_prime_pow`: among consecutive pairs (pⁱ, pⁱ⁺¹), gcd = pⁱ, which equals 1 exactly when i = 0. So the unique coprime consecutive pair is (1, p), giving τ⊥(pᵏ) = 1. The filter predicate is reduced to `i = 0` and the single surviving index counted.\n\n`omega_prime_pow`: ω(pᵏ) = 1 via `Nat.primeFactors_prime_pow`."
+    "content": "`tauPerp_prime_pow`: among consecutive pairs (pⁱ, pⁱ⁺¹), gcd = pⁱ, which equals 1 exactly when i = 0. So the unique coprime consecutive pair is (1, p), giving τ⊥(pᵏ) = 1. The filter predicate is reduced to `i = 0` and the single surviving index counted.\n\n`omega_prime_pow`: ω(pᵏ) = 1 via `Nat.primeFactors_prime_pow`.",
+    "mathContext": "$\\gcd(p^i, p^{i+1}) = p^{\\min(i, i+1)} = p^i = 1 \\iff i = 0$; hence exactly one coprime consecutive pair, so $\\tau^{\\perp}(p^k) = 1 = \\omega(p^k)$.",
+    "significance": "key",
+    "relatedConcepts": ["gcd of prime powers", "Nat.primeFactors_prime_pow", "List.filter counting", "consecutive-pair predicate"],
+    "prerequisites": ["gcd(pⁱ, pⁱ⁺¹) = pⁱ", "counting filtered list indices"]
   },
   {
     "id": "ann-e1100oq02-family",
@@ -37,6 +53,10 @@
     "range": { "startLine": 153, "endLine": 169 },
     "type": "concept",
     "title": "The equality family",
-    "content": "`tauPerp_eq_omega_prime_pow`: τ⊥(pᵏ) = ω(pᵏ) for all prime powers. `tau_perp_equality_prime_powers`: equality holds at arbitrarily large n, realised by 2^(N+1) — a strict strengthening of the prime-only equality-infinitely-often statement.\n\n**Open**: characterize ALL minimizers (are they exactly the prime powers?), and prove the parent axiom τ⊥(n) ≥ ω(n) unconditionally."
+    "content": "`tauPerp_eq_omega_prime_pow`: τ⊥(pᵏ) = ω(pᵏ) for all prime powers. `tau_perp_equality_prime_powers`: equality holds at arbitrarily large n, realised by 2^(N+1) — a strict strengthening of the prime-only equality-infinitely-often statement.\n\n**Open**: characterize ALL minimizers (are they exactly the prime powers?), and prove the parent axiom τ⊥(n) ≥ ω(n) unconditionally.",
+    "mathContext": "$\\tau^{\\perp}(p^k) = \\omega(p^k) = 1$ for all primes $p$, $k \\ge 1$; taking $n = 2^{N+1}$ gives equality at arbitrarily large $n$.",
+    "significance": "key",
+    "relatedConcepts": ["extremal-minimum family", "equality infinitely often", "prime powers as minimizers", "open characterization"],
+    "prerequisites": ["the τ⊥(pᵏ) and ω(pᵏ) computations"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1100-oq-02` (quality 66, pass 0). The meta.json was already complete; the gap was annotation fields.

## Changes
- **Annotations (5)**: all five were missing the *required* `significance` field, plus `mathContext`, `relatedConcepts`, and `prerequisites`. Added all four to every annotation (the existing prose content is preserved). The annotations already covered all four Lean sections; this fills in the depth/required fields driving the quality score.

## Verification
- annotations.json valid; meta.json ~11 KB (under 60 KB cap); collections under caps.
- `pnpm build` passes (gallery size check, annotations/research build+enrich, tsc, vite).
- Axiom integrity unchanged: status `verified`, badge `verified`, axiomCount 0 — accurate (no native_decide).

Branch note: pushed to `enrichment/erdos-1100-oq-02` because shared `feature/enricher-2` is occupied by open PR #31455.