### PR TITLE
Fix: align brouwer-fixed-point-oq-01-oq-02-oq-01 title + badge with reduction scope

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "brouwer-fixed-point-oq-01-oq-02-oq-01",
-  "title": "No-Retraction via the Analytic (Measure-Theoretic) Route",
+  "title": "No-Retraction (Analytic Route): Measure-Theoretic Scaffolding + Reduction to Volume-Preservation",
   "slug": "brouwer-fixed-point-oq-01-oq-02-oq-01",
   "description": "Replaces the singular-homology axioms of the No-Retraction Theorem with Mathlib analysis tools, following Milnor's measure-theoretic argument. Proves, with 0 axioms and 0 sorries, every ingredient of the obstruction that Mathlib already supports — the sphere S^{n-1} is Lebesgue-null, the ball B^n has positive finite volume, a retraction surjects B^n onto S^{n-1} and so collapses positive volume to zero — and isolates the entire remaining content into a single explicit analytic hypothesis (volume-preservation), reducing the homology apparatus to one statement Milnor's Jacobian/degree computation supplies.",
   "meta": {
@@ -18,7 +18,7 @@
       "analysis"
     ],
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ01OQ02OQ01.lean",
-    "badge": "verified",
+    "badge": "infrastructure",
     "sorries": 0,
     "axiomCount": 0
   },


### PR DESCRIPTION
## Fix

The gallery entry `brouwer-fixed-point-oq-01-oq-02-oq-01` paired a famous-theorem title ("No-Retraction via the Analytic (Measure-Theoretic) Route") with a green `verified` badge, implying the No-Retraction Theorem itself was proved. The Lean file is genuinely 0-axiom / 0-sorry, but its headline result `no_retraction_of_volume_preserved` is an honestly-named **conditional** — it takes the unproved analytic fact `hvol : volume (r '' B^n) = volume (B^n)` as an explicit hypothesis. The file proves the measure-theoretic **scaffolding + a reduction**, not the theorem.

This aligns the public-facing fields with the (already honest) description.

## Evidence

**Before**:
- `title`: "No-Retraction via the Analytic (Measure-Theoretic) Route" — names the famous theorem with no scope qualifier.
- `badge`: `"verified"` — green pill next to the famous-theorem name (and `"verified"` is not even a member of the `ProofBadge` union in `src/types/proof.ts`).

**After**:
- `title`: "No-Retraction (Analytic Route): Measure-Theoretic Scaffolding + Reduction to Volume-Preservation" — scope is explicit.
- `badge`: `"infrastructure"` (🧱, neutral) — signals supporting scaffolding/reduction rather than a completed famous theorem, matching the honest `description`/`conclusion`. A valid `ProofBadge` value.

`status` remains `"verified"` because the Lean content is genuinely machine-checked (0-axiom, 0-sorry); with the qualified title the verified scope now reads as the scaffolding + reduction, which is exactly what is checked. `axiomCount: 0` was already correct (the condition is a theorem hypothesis, not an axiom or assumption-carrying structure).

Validated: meta.json parses; the `pnpm build` data-enrichment pipeline (which loads every meta.json) processed the entry cleanly. Diff is 2 lines.

Closes #31459

---
Automated fix by lean-mechanic agent.