### PR TITLE
Enrich No-Retraction via the Analytic Route (brouwer-fixed-point-oq-01-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 8, "endLine": 81 },
     "type": "concept",
     "title": "Replacing homology with analysis: Milnor's measure-theoretic route",
-    "content": "The companion file proves No-Retraction via singular homology with three homology axioms. This file pursues Milnor's 1978 argument, which never mentions homology: a smooth retraction r : B^n → S^{n-1} would map the positive-volume ball onto the measure-zero sphere, while a Jacobian/degree computation forces it to preserve volume — a contradiction. The header lays out exactly which ingredients Mathlib already supports and which single analytic fact remains, then commits to honesty: the file proves the scaffolding and the reduction, not no-retraction itself."
+    "content": "The companion file proves No-Retraction via singular homology with three homology axioms. This file pursues Milnor's 1978 argument, which never mentions homology: a smooth retraction r : B^n → S^{n-1} would map the positive-volume ball onto the measure-zero sphere, while a Jacobian/degree computation forces it to preserve volume — a contradiction. The header lays out exactly which ingredients Mathlib already supports and which single analytic fact remains, then commits to honesty: the file proves the scaffolding and the reduction, not no-retraction itself.",
+    "mathContext": "A retraction is a continuous $r : B^n \\to S^{n-1}$ with $r|_{S^{n-1}} = \\mathrm{id}$. Milnor's contradiction pits $\\mathrm{vol}(B^n) > 0 = \\mathrm{vol}(S^{n-1})$ against the degree-forced equality $\\mathrm{vol}(r(B^n)) = \\mathrm{vol}(B^n)$.",
+    "significance": "key",
+    "relatedConcepts": ["singular homology", "Lebesgue measure", "no-retraction theorem", "Brouwer fixed-point theorem", "degree theory"],
+    "prerequisites": ["measure theory", "algebraic topology", "real analysis"]
   },
   {
     "id": "ann-defs",
@@ -13,7 +17,11 @@
     "range": { "startLine": 92, "endLine": 113 },
     "type": "definition",
     "title": "Ball, sphere, retraction (interoperable with the homology companion)",
-    "content": "ClosedBall and UnitSphere are defined as Metric.closedBall 0 1 and Metric.sphere 0 1 in EuclideanSpace ℝ (Fin n), matching the homology file so results can be cross-applied. The Retraction structure bundles continuity, mapping the ball into the sphere, and fixing the sphere pointwise. unitSphere_subset_closedBall records S^{n-1} ⊆ B^n, used to show a retraction's image hits every sphere point."
+    "content": "ClosedBall and UnitSphere are defined as Metric.closedBall 0 1 and Metric.sphere 0 1 in EuclideanSpace ℝ (Fin n), matching the homology file so results can be cross-applied. The Retraction structure bundles continuity, mapping the ball into the sphere, and fixing the sphere pointwise. unitSphere_subset_closedBall records S^{n-1} ⊆ B^n, used to show a retraction's image hits every sphere point.",
+    "mathContext": "$B^n = \\overline{B}(0,1)$ and $S^{n-1} = \\{x : \\lVert x\\rVert = 1\\}$ in $\\mathrm{EuclideanSpace}\\ \\mathbb{R}\\ (\\mathrm{Fin}\\ n)$; the $\\mathtt{Retraction}$ structure encodes $r(B^n) \\subseteq S^{n-1}$ together with $r|_{S^{n-1}} = \\mathrm{id}$, and $S^{n-1} \\subseteq B^n$ since $\\lVert x\\rVert = 1 \\le 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["retraction", "closed ball", "unit sphere", "Euclidean space"],
+    "prerequisites": ["metric spaces", "continuity"]
   },
   {
     "id": "ann-nontrivial",
@@ -21,7 +29,11 @@
     "range": { "startLine": 120, "endLine": 125 },
     "type": "technique",
     "title": "Nontriviality from positive finrank",
-    "content": "Measure.addHaar_sphere requires the ambient space to be Nontrivial. For n ≥ 1 this follows from finrank ℝ (EuclideanSpace ℝ (Fin n)) = n > 0 via Module.nontrivial_of_finrank_pos and finrank_euclideanSpace_fin — a clean way to discharge the typeclass without hand-constructing distinct points."
+    "content": "Measure.addHaar_sphere requires the ambient space to be Nontrivial. For n ≥ 1 this follows from finrank ℝ (EuclideanSpace ℝ (Fin n)) = n > 0 via Module.nontrivial_of_finrank_pos and finrank_euclideanSpace_fin — a clean way to discharge the typeclass without hand-constructing distinct points.",
+    "mathContext": "$\\dim_{\\mathbb{R}} \\mathbb{R}^n = n \\ge 1 \\Rightarrow \\mathbb{R}^n$ is nontrivial. Formally $\\mathrm{finrank}\\ \\mathbb{R}\\ (\\mathrm{EuclideanSpace}\\ \\mathbb{R}\\ (\\mathrm{Fin}\\ n)) = n > 0$, and positive rank implies a nontrivial module.",
+    "significance": "technical",
+    "relatedConcepts": ["finite-dimensional vector space", "rank", "typeclass inference"],
+    "prerequisites": ["linear algebra"]
   },
   {
     "id": "ann-sphere-null",
@@ -29,7 +41,11 @@
     "range": { "startLine": 129, "endLine": 137 },
     "type": "theorem",
     "title": "The sphere is Lebesgue-null (analytic replacement for sphere_singularHomology_nonzero)",
-    "content": "unitSphere_volume_zero: vol(S^{n-1}) = 0 for n ≥ 1, directly from Mathlib's Measure.addHaar_sphere (spheres have zero additive-Haar measure). Where the homology route asserts the sphere is 'detected' by a nonzero homology group, the analytic route captures the sphere's thinness as measure zero — and this is already a theorem in Mathlib, not an axiom."
+    "content": "unitSphere_volume_zero: vol(S^{n-1}) = 0 for n ≥ 1, directly from Mathlib's Measure.addHaar_sphere (spheres have zero additive-Haar measure). Where the homology route asserts the sphere is 'detected' by a nonzero homology group, the analytic route captures the sphere's thinness as measure zero — and this is already a theorem in Mathlib, not an axiom.",
+    "mathContext": "$\\mathrm{vol}(S^{n-1}) = 0$: the sphere is an $(n-1)$-dimensional hypersurface, hence Lebesgue-null in $\\mathbb{R}^n$. Mathlib's $\\mathtt{Measure.addHaar\\_sphere}$ gives this for the additive Haar measure, which coincides with volume.",
+    "significance": "key",
+    "relatedConcepts": ["Lebesgue measure", "Haar measure", "null set", "hypersurface"],
+    "prerequisites": ["measure theory"]
   },
   {
     "id": "ann-ball-pos",
@@ -37,7 +53,11 @@
     "range": { "startLine": 139, "endLine": 150 },
     "type": "theorem",
     "title": "The ball has positive (and finite) volume",
-    "content": "closedBall_volume_pos: 0 < vol(B^n) via measure_closedBall_pos; closedBall_volume_lt_top: vol(B^n) < ∞ via measure_closedBall_lt_top. Together with the sphere being null, these are the two opposing poles of Milnor's contradiction — the analytic counterpart of 'the ball is contractible, its homology vanishes'."
+    "content": "closedBall_volume_pos: 0 < vol(B^n) via measure_closedBall_pos; closedBall_volume_lt_top: vol(B^n) < ∞ via measure_closedBall_lt_top. Together with the sphere being null, these are the two opposing poles of Milnor's contradiction — the analytic counterpart of 'the ball is contractible, its homology vanishes'.",
+    "mathContext": "$0 < \\mathrm{vol}(B^n) < \\infty$: a nondegenerate closed ball (radius $1 > 0$) carries positive measure, and is bounded/compact hence of finite measure. Provided by $\\mathtt{measure\\_closedBall\\_pos}$ and $\\mathtt{measure\\_closedBall\\_lt\\_top}$.",
+    "significance": "key",
+    "relatedConcepts": ["Lebesgue measure", "positive measure", "finite measure", "compactness"],
+    "prerequisites": ["measure theory"]
   },
   {
     "id": "ann-image-sphere",
@@ -45,7 +65,11 @@
     "range": { "startLine": 152, "endLine": 168 },
     "type": "theorem",
     "title": "A retraction surjects the ball onto the sphere, collapsing its volume",
-    "content": "retraction_image_eq_sphere shows r '' B^n = S^{n-1} exactly: ⊆ is maps_to_sphere, ⊇ holds because r fixes the sphere (which lies in the ball). retraction_image_volume_zero then gives vol(r '' B^n) = 0. So a retraction sends a positive-volume set onto a null set — the geometric heart of the obstruction."
+    "content": "retraction_image_eq_sphere shows r '' B^n = S^{n-1} exactly: ⊆ is maps_to_sphere, ⊇ holds because r fixes the sphere (which lies in the ball). retraction_image_volume_zero then gives vol(r '' B^n) = 0. So a retraction sends a positive-volume set onto a null set — the geometric heart of the obstruction.",
+    "mathContext": "$r(B^n) = S^{n-1}$: $\\subseteq$ is the mapping property, $\\supseteq$ holds because for $y \\in S^{n-1} \\subseteq B^n$ we have $r(y) = y$. Hence $\\mathrm{vol}(r(B^n)) = \\mathrm{vol}(S^{n-1}) = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["image of a set", "surjection", "null set"],
+    "prerequisites": ["set theory", "measure theory"]
   },
   {
     "id": "ann-reduction",
@@ -53,7 +77,11 @@
     "range": { "startLine": 170, "endLine": 196 },
     "type": "insight",
     "title": "The reduction: the only gap is volume-preservation",
-    "content": "retraction_collapses_volume packages 'ball positive, image null'. By itself this is NOT a contradiction — a continuous map can collapse volume. no_retraction_of_volume_preserved makes the frontier precise: a retraction is impossible the moment one supplies vol(r '' B^n) = vol(B^n). That hypothesis is exactly what Milnor's smooth degree/Jacobian computation yields, and it is an explicit hypothesis rather than an axiom — so the whole file is genuinely 0-axiom while isolating the entire remaining analytic content into one statement."
+    "content": "retraction_collapses_volume packages 'ball positive, image null'. By itself this is NOT a contradiction — a continuous map can collapse volume. no_retraction_of_volume_preserved makes the frontier precise: a retraction is impossible the moment one supplies vol(r '' B^n) = vol(B^n). That hypothesis is exactly what Milnor's smooth degree/Jacobian computation yields, and it is an explicit hypothesis rather than an axiom — so the whole file is genuinely 0-axiom while isolating the entire remaining analytic content into one statement.",
+    "mathContext": "From the gap $h_{\\mathrm{vol}} : \\mathrm{vol}(r(B^n)) = \\mathrm{vol}(B^n)$ together with $\\mathrm{vol}(r(B^n)) = 0$ and $\\mathrm{vol}(B^n) > 0$ one derives $0 = \\mathrm{vol}(B^n) > 0$, a contradiction. The reduction makes $h_{\\mathrm{vol}}$ an explicit hypothesis, not an axiom.",
+    "significance": "key",
+    "relatedConcepts": ["proof by contradiction", "degree theory", "change of variables", "Jacobian determinant"],
+    "prerequisites": ["measure theory", "differential topology"]
   },
   {
     "id": "ann-homotopy",
@@ -61,6 +89,10 @@
     "range": { "startLine": 198, "endLine": 224 },
     "type": "concept",
     "title": "Milnor's straight-line homotopy f_t = (1-t)·id + t·r",
-    "content": "straightLine records the family Milnor integrates: continuous for each t (straightLine_continuous), with f_0 = id and f_1 = r (straightLine_zero/one), and fixing the sphere for all t (straightLine_fixes_sphere). The remaining analytic work is to show t ↦ vol(f_t(B^n)) is polynomial in t (the integral of the polynomial determinant det Df_t), forcing vol(f_1(B^n)) = vol(B^n) — the hypothesis discharged above. Mathlib's MeasureTheory.Function.Jacobian supplies the change-of-variables engine for this step."
+    "content": "straightLine records the family Milnor integrates: continuous for each t (straightLine_continuous), with f_0 = id and f_1 = r (straightLine_zero/one), and fixing the sphere for all t (straightLine_fixes_sphere). The remaining analytic work is to show t ↦ vol(f_t(B^n)) is polynomial in t (the integral of the polynomial determinant det Df_t), forcing vol(f_1(B^n)) = vol(B^n) — the hypothesis discharged above. Mathlib's MeasureTheory.Function.Jacobian supplies the change-of-variables engine for this step.",
+    "mathContext": "$f_t = (1-t)\\,\\mathrm{id} + t\\,r$ with $f_0 = \\mathrm{id}$, $f_1 = r$, and $f_t|_{S^{n-1}} = \\mathrm{id}$ for all $t$ (since $(1-t)x + tx = x$). Milnor shows $t \\mapsto \\mathrm{vol}(f_t(B^n)) = \\int_{B^n} \\det Df_t$ is polynomial in $t$, hence constant, forcing $\\mathrm{vol}(f_1(B^n)) = \\mathrm{vol}(B^n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["homotopy", "affine combination", "polynomial in t", "change of variables", "Jacobian determinant"],
+    "prerequisites": ["real analysis", "multivariable calculus"]
   }
 ]

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-01/meta.json
@@ -24,42 +24,67 @@
   },
   "overview": {
     "historicalContext": "The companion entry brouwer-fixed-point-oq-01-oq-02 proves the No-Retraction Theorem via singular homology, but at the cost of three homology axioms standing in for Mathlib gaps (H_{n-1}(S^{n-1}) ≅ ℤ and the contractibility/prism vanishing). John Milnor's 1978 note *Analytic proof of the 'hairy ball' theorem and the Brouwer fixed-point theorem* (Amer. Math. Monthly 85, 521–524) gives a proof that never mentions homology: it is pure real analysis and measure theory. The contradiction is that a smooth retraction r : B^n → S^{n-1} would map the positive-volume ball onto the measure-zero sphere, while a Jacobian/degree (change-of-variables) computation forces such a map to preserve the ball's volume. This entry transcribes that route into Lean and pins down exactly which ingredients Mathlib already supports.",
-    "keyInsight": "Mathlib *already* has the two measure-theoretic poles of Milnor's contradiction: spheres are Lebesgue-null (Measure.addHaar_sphere) and balls have positive finite volume (measure_closedBall_pos). A retraction's image is exactly the sphere, so it collapses positive volume to zero. The single missing ingredient — that a retraction nonetheless preserves the ball's volume — is captured here as an explicit hypothesis (not an axiom), making the file 0-axiom while precisely locating the analytic frontier."
+    "problemStatement": "Can the three singular-homology axioms used by the companion No-Retraction proof be discharged using only Mathlib's analysis library? Concretely: formalize Milnor's measure-theoretic obstruction to a retraction $r : B^n \\to S^{n-1}$ — that $\\mathrm{vol}(B^n) > 0$ while $\\mathrm{vol}(r(B^n)) = \\mathrm{vol}(S^{n-1}) = 0$ — and pin down the single analytic fact $\\mathrm{vol}(r(B^n)) = \\mathrm{vol}(B^n)$ that completes the contradiction.",
+    "proofStrategy": "Define the ball, sphere, and a Retraction structure interoperable with the homology companion. Prove the two poles of Milnor's contradiction directly from Mathlib: the sphere is Lebesgue-null (Measure.addHaar_sphere) and the ball has positive finite volume (measure_closedBall_pos, measure_closedBall_lt_top). Show a retraction's image is exactly the sphere, so it collapses positive volume to zero. Then reduce no-retraction to a single explicit hypothesis hvol : vol(r '' B^n) = vol(B^n), which Milnor's degree/Jacobian change-of-variables supplies for smooth maps. Finally record the straight-line homotopy f_t = (1-t)·id + t·r whose volume-polynomiality discharges hvol, laying out the analytic program end to end.",
+    "keyInsights": [
+      "Mathlib *already* has the two measure-theoretic poles of Milnor's contradiction: spheres are Lebesgue-null (Measure.addHaar_sphere) and balls have positive finite volume (measure_closedBall_pos). A retraction's image is exactly the sphere, so it collapses positive volume to zero. The single missing ingredient — that a retraction nonetheless preserves the ball's volume — is captured here as an explicit hypothesis (not an axiom), making the file 0-axiom while precisely locating the analytic frontier.",
+      "The sphere being 'detected' by a nonzero homology group in the topological proof is replaced, in the analytic proof, by the sphere being Lebesgue-null: thinness measured by dimension becomes thinness measured by volume. This is the conceptual translation that lets Mathlib's measure theory stand in for its missing homology.",
+      "Where the homology route needs three axioms diffusely standing in for Mathlib gaps, the analytic route needs exactly one explicit hypothesis, $\\mathrm{vol}(r(B^n)) = \\mathrm{vol}(B^n)$. The missing mathematics becomes precise and quantifiable — a single named statement — rather than a cluster of opaque topological facts.",
+      "Continuity alone cannot manufacture the contradiction: a continuous surjection $B^n \\twoheadrightarrow S^{n-1}$ that collapses volume is not forbidden. The essential extra input is smoothness, entering through the Jacobian/degree computation. The file is scrupulously honest that this is the true frontier, and does not overclaim a no-retraction proof.",
+      "Milnor's straight-line homotopy $f_t = (1-t)\\,\\mathrm{id} + t\\,r$ converts the qualitative obstruction into a quantitative one: the volume $t \\mapsto \\mathrm{vol}(f_t(B^n))$ is a polynomial in $t$ that is simultaneously forced to be constant near $0$ (it is a diffeomorphism there) and to drop to $0$ at $t = 1$ (the image is the null sphere) — impossible for a nonzero polynomial."
+    ]
   },
   "sections": [
     {
       "id": "geometry",
       "title": "Geometry: ball, sphere, and retractions",
+      "startLine": 90,
+      "endLine": 113,
       "summary": "Defines the closed unit ball and unit sphere in EuclideanSpace ℝ (Fin n) (matching the homology companion for interoperability), the Retraction structure, and the inclusion S^{n-1} ⊆ B^n.",
       "mathContext": "The Retraction structure bundles continuity, mapping the ball into the sphere, and fixing the sphere pointwise — a definition, not an assumption that any claimed result depends on."
     },
     {
       "id": "nontriviality",
       "title": "Nontriviality of ℝⁿ for n ≥ 1",
+      "startLine": 115,
+      "endLine": 125,
       "summary": "nontrivial_euclidean: for n ≥ 1, EuclideanSpace ℝ (Fin n) is Nontrivial, via finrank = n > 0. Needed to invoke Measure.addHaar_sphere.",
       "mathContext": "Module.nontrivial_of_finrank_pos composed with finrank_euclideanSpace_fin."
     },
     {
       "id": "measure-obstruction",
       "title": "The measure-theoretic obstruction",
+      "startLine": 127,
+      "endLine": 175,
       "summary": "unitSphere_volume_zero (sphere is null), closedBall_volume_pos / closedBall_volume_lt_top (ball positive and finite), retraction_image_eq_sphere (a retraction surjects B^n onto S^{n-1}), retraction_image_volume_zero and retraction_collapses_volume (hence it maps positive volume onto a null set).",
       "mathContext": "These are the analytic replacements for the homology axioms sphere_singularHomology_nonzero and contractible_singularHomology_zero."
     },
     {
       "id": "reduction",
       "title": "The reduction: one analytic gap",
+      "startLine": 177,
+      "endLine": 188,
       "summary": "no_retraction_of_volume_preserved: a retraction cannot exist once one supplies vol(r '' B^n) = vol(B^n). This isolates the whole remaining content of the analytic route into a single explicit hypothesis — exactly what Milnor's degree/Jacobian computation provides for smooth maps. The hypothesis is not an axiom, so the file remains 0-axiom.",
       "mathContext": "Continuity alone does not forbid a volume-collapsing surjection; the contradiction genuinely needs the smooth volume-preservation input. The file is honest that it does not prove no-retraction outright."
     },
     {
       "id": "homotopy",
       "title": "Milnor's straight-line homotopy",
+      "startLine": 190,
+      "endLine": 225,
       "summary": "straightLine f_t = (1-t)·id + t·r with continuous endpoints (f_0 = id, f_1 = r) and the fact that f_t fixes the sphere for every t. This is the family whose volume t ↦ vol(f_t(B^n)) Milnor proves is polynomial in t.",
       "mathContext": "Lays out the analytic program end to end; the polynomiality/degree bookkeeping is the remaining gap named in no_retraction_of_volume_preserved."
     }
   ],
   "conclusion": {
-    "summary": "The homology axioms of the No-Retraction Theorem can be replaced by Mathlib analysis tools along Milnor's measure-theoretic route. This entry proves, 0-axiom and 0-sorry, the sphere-is-null and ball-has-positive-volume poles of the contradiction and the fact that a retraction collapses positive volume to zero, then reduces the entire remaining argument to one explicit analytic hypothesis: that a retraction preserves the ball's volume. Discharging that hypothesis is precisely Milnor's smooth degree/Jacobian computation, for which Mathlib already has the change-of-variables engine (MeasureTheory.Function.Jacobian); the open work is the polynomiality/degree bookkeeping plus a smoothing step. The file does not claim to prove no-retraction — it maps out and machine-checks the analytic scaffolding and the precise frontier."
+    "summary": "The homology axioms of the No-Retraction Theorem can be replaced by Mathlib analysis tools along Milnor's measure-theoretic route. This entry proves, 0-axiom and 0-sorry, the sphere-is-null and ball-has-positive-volume poles of the contradiction and the fact that a retraction collapses positive volume to zero, then reduces the entire remaining argument to one explicit analytic hypothesis: that a retraction preserves the ball's volume. Discharging that hypothesis is precisely Milnor's smooth degree/Jacobian computation, for which Mathlib already has the change-of-variables engine (MeasureTheory.Function.Jacobian); the open work is the polynomiality/degree bookkeeping plus a smoothing step. The file does not claim to prove no-retraction — it maps out and machine-checks the analytic scaffolding and the precise frontier.",
+    "implications": "The result reframes a celebrated topological theorem in purely analytic terms, showing the obstruction to a retraction is a *volume* phenomenon, not merely a *homotopy* one. It demonstrates that Mathlib's measure theory already carries most of Milnor's argument, and it quantifies exactly what is missing — a polynomiality/degree computation plus a smoothing step — turning a vague 'Mathlib gap' into a concrete, well-defined formalization target. More broadly it illustrates a recurring theme in formalization: invariants from algebraic topology (here, that $S^{n-1}$ is not a retract of $B^n$) often admit analytic shadows (measure, degree, integration) that are more amenable to a library whose strengths lie in analysis rather than homological algebra.",
+    "openQuestions": [
+      "Can the volume-preservation hypothesis hvol be discharged in Lean by formalizing the polynomiality of $t \\mapsto \\mathrm{vol}(f_t(B^n))$ via Mathlib's MeasureTheory.Function.Jacobian change-of-variables theorem?",
+      "What is the cleanest smoothing step $r \\mapsto r_{\\mathrm{smooth}}$ that reduces the continuous no-retraction statement to the smooth case Milnor's degree argument handles?",
+      "Does the same measure-theoretic scaffolding extend to formalize the hairy-ball theorem (the companion result in Milnor's 1978 note), and how much of it does Mathlib already support?",
+      "Can the full Brouwer fixed-point theorem be obtained 0-axiom in Mathlib by combining this analytic no-retraction route with the standard 'a fixed-point-free self-map yields a retraction' reduction?"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
Enrichment pass for `brouwer-fixed-point-oq-01-oq-02-oq-01` (quality 50→, passes 0, well under the ~60 KB cap at 11.7 KB).

## Changes
- **Annotations (all 8):** added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` — previously absent (quality breakdown mathContext 0, significance 0).
- **Overview:** converted `keyInsight` (singular string) → `keyInsights` array of 5 substantive insights; added `problemStatement` and `proofStrategy`.
- **Sections:** added `startLine`/`endLine` ranges to all 5 sections (geometry, nontriviality, measure-obstruction, reduction, homotopy), grounded against the 229-line Lean source.
- **Conclusion:** added `implications` and 4 `openQuestions` (discharging hvol via Jacobian change-of-variables, smoothing step, hairy-ball extension, full Brouwer 0-axiom).

## Verification
- `pnpm build` passes (exit 0).
- Annotation resolver: 0 'No Lean construct' errors; all ranges land on Lean constructs (module docstring, def/theorem doc-comments).
- All content is grounded in the actual Lean file; no axiom/status changes (remains verified, 0-axiom, 0-sorry — accurate per the source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)