### PR TITLE
Enrich Hasse-derivative failure profile (factor-remainder-hasse-derivative-fq): add annotations.json

### DIFF
--- a/src/data/proofs/factor-remainder-hasse-derivative-fq/annotations.json
+++ b/src/data/proofs/factor-remainder-hasse-derivative-fq/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "factor-remainder-hasse-derivative-fq",
+    "range": { "startLine": 8, "endLine": 60 },
+    "type": "concept",
+    "title": "The ordinary-derivative multiplicity test and its characteristic-p breakdown",
+    "content": "Over a characteristic-0 field, (X − a)^k ∣ p iff p and its first k−1 ordinary derivatives vanish at a. In positive characteristic this fails: derivative(X^p) = 0 over 𝔽_p, so all ordinary derivatives can vanish while the multiplicity is large. Hasse's divided-power derivative repairs the test. This file pins down the FULL failure profile — the exact order at which the ordinary test goes blind, and the X^{p^e} family that overcounts without bound — over any characteristic-p field, hence every finite field 𝔽_q.",
+    "mathContext": "Characteristic 0: $(X-a)^k \\mid p \\iff p(a) = p'(a) = \\cdots = p^{(k-1)}(a) = 0$. The whole analysis rests on Mathlib's $\\mathrm{derivative}^{[k]} f = k!\\cdot \\mathrm{hasseDeriv}\\,k\\,f$.",
+    "significance": "context",
+    "relatedConcepts": ["factor theorem", "root multiplicity", "Hasse derivative", "positive characteristic", "finite fields"],
+    "prerequisites": ["polynomial derivatives", "characteristic of a ring", "root multiplicity"]
+  },
+  {
+    "id": "ann-threshold",
+    "proofId": "factor-remainder-hasse-derivative-fq",
+    "range": { "startLine": 72, "endLine": 77 },
+    "type": "theorem",
+    "title": "The exact factorial threshold: (k! : F) = 0 ↔ p ≤ k",
+    "content": "factorial_cast_eq_zero_iff is the algebraic heart of the file. Over a characteristic-p commutative ring, the cast factorial (k! : F) vanishes exactly when p ≤ k. The proof rewrites with CharP.cast_eq_zero_iff (turning (k! : F) = 0 into p ∣ k!) and Nat.Prime.dvd_factorial (turning p ∣ k! into p ≤ k). Because the ordinary derivative is the Hasse derivative scaled by k!, this single biconditional governs the entire failure profile.",
+    "mathContext": "$(k! : F) = 0 \\iff p \\mid k! \\iff p \\le k$ (for $p$ prime). The first step is $\\mathtt{CharP.cast\\_eq\\_zero\\_iff}$; the second is $\\mathtt{Nat.Prime.dvd\\_factorial}$ ($p \\mid k!$ iff some factor $\\le k$ equals $p$).",
+    "significance": "key",
+    "relatedConcepts": ["characteristic p", "factorial", "divisibility", "prime"],
+    "prerequisites": ["modular arithmetic", "CharP typeclass"]
+  },
+  {
+    "id": "ann-scaling",
+    "proofId": "factor-remainder-hasse-derivative-fq",
+    "range": { "startLine": 83, "endLine": 89 },
+    "type": "theorem",
+    "title": "Scaling identity: ordinary derivative = Hasse derivative × k!",
+    "content": "iterate_derivative_eq_smul_hasseDeriv repackages Mathlib's factorial_smul_hasseDeriv with the scalar pushed into the base field F: derivative^[k] f = (k! : F) • hasseDeriv k f. This is the engine — it shows the ordinary derivative carries exactly the Hasse information except for the multiplicative factor (k! : F), so all information loss is exactly the vanishing of that factor characterized in the threshold lemma.",
+    "mathContext": "$\\mathrm{derivative}^{[k]} f = (k! : F)\\cdot \\mathrm{hasseDeriv}\\,k\\,f$. Derived from $k!\\bullet \\mathrm{hasseDeriv}\\,k = \\mathrm{derivative}^{[k]}$ (as linear maps) by $\\mathtt{Nat.cast\\_smul\\_eq\\_nsmul}$ and $\\mathtt{LinearMap.smul\\_apply}$.",
+    "significance": "key",
+    "relatedConcepts": ["Hasse derivative", "iterated derivative", "linear map", "scalar multiplication"],
+    "prerequisites": ["divided-power derivatives", "module scalar action"]
+  },
+  {
+    "id": "ann-blind",
+    "proofId": "factor-remainder-hasse-derivative-fq",
+    "range": { "startLine": 91, "endLine": 97 },
+    "type": "theorem",
+    "title": "Above the threshold the ordinary test is blind",
+    "content": "iterate_derivative_eq_zero_of_char_le: for p ≤ k, the k-th iterated ordinary derivative of EVERY polynomial f is zero. Once the factorial scalar (k! : F) vanishes (by the threshold lemma), the scaling identity collapses to zero • hasseDeriv k f = 0. So at orders ≥ p the ordinary-derivative criterion carries no multiplicity information whatsoever — a total, uniform blindness, not a gradual decay.",
+    "mathContext": "$p \\le k \\Rightarrow (k! : F) = 0 \\Rightarrow \\mathrm{derivative}^{[k]} f = (k! : F)\\cdot \\mathrm{hasseDeriv}\\,k\\,f = 0$ for all $f$ (via $\\mathtt{zero\\_smul}$).",
+    "significance": "key",
+    "relatedConcepts": ["vanishing derivative", "characteristic p", "uniform failure"],
+    "prerequisites": ["the threshold lemma", "the scaling identity"]
+  },
+  {
+    "id": "ann-agree",
+    "proofId": "factor-remainder-hasse-derivative-fq",
+    "range": { "startLine": 99, "endLine": 111 },
+    "type": "theorem",
+    "title": "Below the threshold ordinary and Hasse tests agree",
+    "content": "iterate_derivative_eq_zero_iff_hasseDeriv_of_lt: over a FIELD of characteristic p, for k < p the ordinary derivative vanishes iff the Hasse derivative does. Here (k! : F) is a unit (nonzero by the threshold lemma, and over a field nonzero ⇒ unit), so multiplying by it preserves the zero/nonzero distinction (IsUnit.smul_eq_zero). Combined with the blindness result, this localizes the ordinary test's reliability exactly to orders 0, 1, …, p−1.",
+    "mathContext": "$k < p \\Rightarrow (k! : F) \\ne 0 \\Rightarrow (k! : F)$ is a unit (field), so $\\mathrm{derivative}^{[k]} f = 0 \\iff \\mathrm{hasseDeriv}\\,k\\,f = 0$ by $\\mathtt{IsUnit.smul\\_eq\\_zero}$.",
+    "significance": "key",
+    "relatedConcepts": ["unit element", "field", "Hasse derivative", "equivalence of tests"],
+    "prerequisites": ["units in a field", "isUnit_iff_ne_zero"]
+  },
+  {
+    "id": "ann-rootmult",
+    "proofId": "factor-remainder-hasse-derivative-fq",
+    "range": { "startLine": 117, "endLine": 121 },
+    "type": "theorem",
+    "title": "The Hasse test is correct on X^n: multiplicity n at 0",
+    "content": "rootMultiplicity_X_pow records the ground truth the Hasse test recovers: the root multiplicity of X^n at 0 is exactly n, in every characteristic. It is a thin wrapper over Mathlib's rootMultiplicity_X_sub_C_pow at a = 0. This is the value against which the ordinary-derivative test's overcounting is measured in Part III.",
+    "mathContext": "$\\mathrm{rootMultiplicity}_0(X^n) = n$, since $X^n = (X - 0)^n$ and $\\mathtt{rootMultiplicity\\_X\\_sub\\_C\\_pow}$ gives multiplicity $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["root multiplicity", "monomial", "ground truth"],
+    "prerequisites": ["root multiplicity"]
+  },
+  {
+    "id": "ann-deriv-vanish",
+    "proofId": "factor-remainder-hasse-derivative-fq",
+    "range": { "startLine": 123, "endLine": 139 },
+    "type": "technique",
+    "title": "Every positive-order ordinary derivative of X^{p^e} vanishes",
+    "content": "derivative_X_pow_char shows already the FIRST ordinary derivative of X^{p^e} (e ≥ 1) is zero: derivative(X^{p^e}) = C(p^e : F)·X^{p^e−1}, and (p^e : F) = 0 because p ∣ p^e. iterate_derivative_X_pow_char_eq_zero then bootstraps to all positive orders j ≥ 1 by writing j = m+1 and applying the first-derivative fact followed by iterate_derivative_zero. So the entire ordinary jet of X^{p^e} above order 0 is identically zero.",
+    "mathContext": "$\\mathrm{derivative}(X^{p^e}) = (p^e : F)\\,X^{p^e-1} = 0$ since $p \\mid p^e \\Rightarrow (p^e : F) = 0$. Then $\\mathrm{derivative}^{[m+1]} = \\mathrm{derivative}^{[m]} \\circ \\mathrm{derivative}$ kills all $j \\ge 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["derivative of monomial", "Frobenius", "characteristic p", "iterated derivative"],
+    "prerequisites": ["derivative_X_pow", "CharP.cast_eq_zero_iff"]
+  },
+  {
+    "id": "ann-profile",
+    "proofId": "factor-remainder-hasse-derivative-fq",
+    "range": { "startLine": 141, "endLine": 148 },
+    "type": "insight",
+    "title": "Full failure profile: true multiplicity p^e, ordinary test overcounts without bound",
+    "content": "failure_profile_X_pow assembles the climax: over any field of characteristic p with e ≥ 1, the true root multiplicity of X^{p^e} at 0 is p^e (the Hasse-recoverable truth), yet every positive-order ordinary derivative vanishes. So the naive ordinary-derivative criterion would certify multiplicity ≥ k at 0 for EVERY k, overcounting the true value p^e without any bound. This generalizes the single X^p / 𝔽_p witness of the sibling entry to the whole X^{p^e} family over every 𝔽_q, making the breakdown maximal and uniform.",
+    "mathContext": "$\\mathrm{rootMultiplicity}_0(X^{p^e}) = p^e$ while $\\mathrm{derivative}^{[j]}(X^{p^e}) = 0$ for all $j \\ge 1$. The ordinary test, seeing all derivatives vanish, certifies arbitrarily high multiplicity — unbounded overcounting of the true $p^e$.",
+    "significance": "key",
+    "relatedConcepts": ["counterexample family", "inseparability", "overcounting", "separable polynomial"],
+    "prerequisites": ["the rootMultiplicity and vanishing lemmas above"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `factor-remainder-hasse-derivative-fq` (quality 41, passes 0). The entry shipped with a thorough meta.json (overview, keyInsights, sections, conclusion, references) but **no annotations.json at all** — the dominant quality gap.

## Changes
Adds `annotations.json` with **8 inline annotations** spanning the full 150-line Lean file, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
- `ann-overview` — the characteristic-p breakdown of the ordinary-derivative multiplicity test
- `ann-threshold` — the exact threshold `(k! : F) = 0 ↔ p ≤ k` (CharP.cast_eq_zero_iff + Nat.Prime.dvd_factorial)
- `ann-scaling` — the engine `derivative^[k] f = (k! : F) • hasseDeriv k f`
- `ann-blind` / `ann-agree` — the blind-from-p and reliable-up-to-(p−1) regimes
- `ann-rootmult`, `ann-deriv-vanish`, `ann-profile` — the X^{p^e} family (true multiplicity p^e vs. all ordinary derivatives zero, unbounded overcounting)

## Verification
- `pnpm build` passes (exit 0); the public build emits all 8 annotations for this entry.
- Annotation resolver: 0 'No Lean construct' errors for this id (every startLine lands on the module docstring or a theorem doc-comment).
- All content grounded in the actual Lean theorems; no status/badge/axiom changes (remains verified, 0-axiom, 0-sorry — accurate per source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)