### PR TITLE
ci(proofs): diff-based guard against new orphaned proofs (#31454)

### DIFF
--- a/.github/workflows/check-proofs-imports.yml
+++ b/.github/workflows/check-proofs-imports.yml
@@ -2,16 +2,45 @@ name: Check Proofs.lean sync
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'proofs/Proofs/**'
+      - 'proofs/Proofs.lean'
+      - '.lean/scripts/generate-proofs-imports.sh'
+      - '.lean/scripts/check-new-proofs-registered.sh'
+      - '.github/workflows/check-proofs-imports.yml'
 
 permissions:
   contents: read
 
 jobs:
-  check-sync:
+  # Manual full-sync check (the entire directory must match Proofs.lean).
+  # Runs on demand only; the repo currently carries a known orphan backlog
+  # (issue #31454) that would otherwise make this fail on every PR.
+  check-full-sync:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Check Proofs.lean is in sync
+      - name: Check Proofs.lean is fully in sync
         run: ./.lean/scripts/generate-proofs-imports.sh --check
+
+  # Regression guard for PRs: only newly added proof files must be registered.
+  # This prevents the orphan backlog from regrowing without blocking PRs on the
+  # pre-existing orphans tracked in #31454.
+  check-new-proofs:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure base ref is available
+        run: git fetch --no-tags origin "${{ github.base_ref }}"
+
+      - name: Check newly added proofs are registered
+        run: ./.lean/scripts/check-new-proofs-registered.sh "origin/${{ github.base_ref }}"

--- a/.lean/scripts/check-new-proofs-registered.sh
+++ b/.lean/scripts/check-new-proofs-registered.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# check-new-proofs-registered.sh - Fail if a PR adds a proofs/Proofs/*.lean file
+# that is NOT registered in proofs/Proofs.lean.
+#
+# Usage: ./.lean/scripts/check-new-proofs-registered.sh [BASE_REF]
+#
+#   BASE_REF   git ref to diff against (default: origin/main)
+#
+# Rationale (issue #31454): proofs/Proofs.lean is auto-generated and must list
+# every file under proofs/Proofs/. A large pre-existing orphan backlog means a
+# full `generate-proofs-imports.sh --check` would fail on every PR, so this
+# guard is intentionally DIFF-BASED: it only flags *newly added* proof files
+# that are missing their import line. This prevents the backlog from regrowing
+# without blocking PRs on the historical orphans (tracked separately in #31454).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PROOFS_LEAN="$REPO_ROOT/proofs/Proofs.lean"
+BASE_REF="${1:-origin/main}"
+
+if [[ ! -f "$PROOFS_LEAN" ]]; then
+    echo "Error: $PROOFS_LEAN does not exist" >&2
+    exit 1
+fi
+
+# Determine the merge-base so we only look at files this branch introduces.
+if ! MERGE_BASE="$(git -C "$REPO_ROOT" merge-base "$BASE_REF" HEAD 2>/dev/null)"; then
+    echo "Warning: could not compute merge-base against '$BASE_REF'; comparing directly." >&2
+    MERGE_BASE="$BASE_REF"
+fi
+
+# Newly ADDED .lean files directly under proofs/Proofs/.
+ADDED_FILES="$(git -C "$REPO_ROOT" diff --name-only --diff-filter=A "$MERGE_BASE" HEAD -- 'proofs/Proofs/*.lean' \
+    | grep -E '^proofs/Proofs/[^/]+\.lean$' || true)"
+
+if [[ -z "$ADDED_FILES" ]]; then
+    echo "No newly added proofs/Proofs/*.lean files; nothing to check."
+    exit 0
+fi
+
+MISSING=()
+while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    module="$(basename "$file" .lean)"
+    if ! grep -qxF "import Proofs.$module" "$PROOFS_LEAN"; then
+        MISSING+=("$module")
+    fi
+done <<< "$ADDED_FILES"
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+    echo "Error: the following newly added proof file(s) are not registered in proofs/Proofs.lean:" >&2
+    for m in "${MISSING[@]}"; do
+        echo "  - proofs/Proofs/$m.lean  (missing: import Proofs.$m)" >&2
+    done
+    echo "" >&2
+    echo "Regenerate the import list and commit it:" >&2
+    echo "  ./.lean/scripts/generate-proofs-imports.sh" >&2
+    exit 1
+fi
+
+echo "All newly added proof files are registered in proofs/Proofs.lean."
+exit 0


### PR DESCRIPTION
## Summary

Partially addresses #31454 (orphan-proof backlog). This is the **regression-prevention** piece (part 2 of the issue's recommended fix) — a CI guard so the backlog cannot keep regrowing. It requires **no Docker/Lean builds**.

### Problem
- `proofs/Proofs.lean` is auto-generated and must list every `proofs/Proofs/*.lean` file, but the backlog of unregistered files has grown from **599 → ~670**.
- The existing `check-proofs-imports.yml` only triggered on `workflow_dispatch`, so nothing caught new proofs landing unregistered on PRs.
- A naive `generate-proofs-imports.sh --check` on `pull_request` **can't** work: `main` itself is ~670 entries out of sync, so it would fail *every* PR.

### Fix
- New `.lean/scripts/check-new-proofs-registered.sh`: a **diff-based** guard that fails only when a PR *adds* a `proofs/Proofs/*.lean` file whose `import Proofs.<Module>` line is missing from `proofs/Proofs.lean`. It ignores the pre-existing backlog (computes against the merge-base), so it never blocks PRs on historical orphans.
- `check-proofs-imports.yml` now:
  - runs the diff-based `check-new-proofs` job on `pull_request`
  - keeps the full-sync `generate-proofs-imports.sh --check` on `workflow_dispatch` (manual)

### Testing (local)
- No added files → pass ("nothing to check").
- Added unregistered proof file → **fail** (exit 1), naming the missing module + remediation command.
- Same file then registered in `Proofs.lean` → pass.

### Out of scope (still tracked by #31454)
- Draining the existing ~670 orphans (part 1) and quarantining any that fail to build (part 3) require per-file Docker build-verification and are left to incremental work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)