### PR TITLE
research(erdos-1207): isosceles-free subsets + 1-D bridge to 3-AP-free [0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1612,6 +1612,7 @@ import Proofs.Erdos1201Problem
 import Proofs.Erdos1202Problem
 import Proofs.Erdos1205Problem
 import Proofs.Erdos1206Problem
+import Proofs.Erdos1207Problem
 import Proofs.Erdos1208Problem
 import Proofs.Erdos120Problem
 import Proofs.Erdos1210Problem

--- a/proofs/Proofs/Erdos1207Problem.lean
+++ b/proofs/Proofs/Erdos1207Problem.lean
@@ -1,0 +1,150 @@
+/-
+Erdős Problem #1207: Isosceles-free subsets of point sets
+
+Let `P_d(n)` be the largest integer such that every set of `n` points in `ℝ^d`
+contains `P_d(n)` points, no three of which form an isosceles triangle.
+Erdős asks to estimate `P_d(n)`; in particular, whether `P_2(n) < n^ε` for every
+`ε > 0` (i.e. whether the largest guaranteed isosceles-free subset is only of
+subpolynomial size).
+
+**Status**: OPEN — the growth rate of `P_d(n)` is not known.
+
+**This file (OBSERVE phase).** No prior formalization existed. We supply:
+
+  * Clean, reusable definitions: `IsoscelesTriangle` (three pairwise-distinct
+    points, one of which is equidistant from the other two) and `IsoscelesFree`
+    for an arbitrary `PseudoMetricSpace`.
+  * The structural facts that make `P_d(n)` well defined: isosceles-freeness is
+    monotone under taking subsets, and every set with at most two points is
+    isosceles-free (a triangle needs three distinct points).
+  * **The one-dimensional bridge** (`isoscelesFree_iff_midpointFree`): on the
+    real line, a set is isosceles-free **iff** it contains no nontrivial
+    3-term arithmetic progression (no point is the midpoint of two distinct
+    others). This identifies the `d = 1` case of Erdős #1207 with the
+    extensively studied midpoint-free / 3-AP-free (Behrend-type) problem.
+  * Concrete sanity checks exercising the definitions: `{0,1,2}` is *not*
+    isosceles-free (1 is the apex), while `{0,1,3}` is.
+
+All results are fully verified with no `axiom` declarations and no `sorry`.
+
+Reference: https://erdosproblems.com/1207  (Er80, PaTa02, BMP05)
+-/
+
+import Mathlib
+
+namespace Erdos1207
+
+variable {P : Type*} [PseudoMetricSpace P]
+
+/- ## Definitions -/
+
+/-- Three points form an **isosceles triangle** when they are pairwise distinct
+and one of them is equidistant from the other two (the *apex*). The three
+disjuncts correspond to `a`, `b`, or `c` being the apex. -/
+def IsoscelesTriangle (a b c : P) : Prop :=
+  a ≠ b ∧ a ≠ c ∧ b ≠ c ∧
+    (dist a b = dist a c ∨ dist b a = dist b c ∨ dist c a = dist c b)
+
+/-- A set is **isosceles-free** when no three of its points form an isosceles
+triangle. This is the property whose largest guaranteed size, over all `n`-point
+configurations, Erdős #1207 asks to estimate. -/
+def IsoscelesFree (S : Set P) : Prop :=
+  ∀ a ∈ S, ∀ b ∈ S, ∀ c ∈ S, ¬ IsoscelesTriangle a b c
+
+/- ## Structural properties -/
+
+/-- Isosceles-freeness is monotone: any subset of an isosceles-free set is
+isosceles-free. This is what makes "the largest isosceles-free subset" a
+sensible quantity to optimize. -/
+theorem IsoscelesFree.mono {S T : Set P} (hT : IsoscelesFree T) (h : S ⊆ T) :
+    IsoscelesFree S :=
+  fun a ha b hb c hc => hT a (h ha) b (h hb) c (h hc)
+
+/-- The empty set is isosceles-free. -/
+theorem isoscelesFree_empty : IsoscelesFree (∅ : Set P) := by
+  intro a ha; exact absurd ha (Set.notMem_empty a)
+
+/-- Every singleton is isosceles-free. -/
+theorem isoscelesFree_singleton (p : P) : IsoscelesFree ({p} : Set P) := by
+  rintro a ha b hb c hc ⟨hab, _, _, _⟩
+  rw [Set.mem_singleton_iff] at ha hb
+  exact hab (ha.trans hb.symm)
+
+/-- Every two-point set is isosceles-free: an isosceles triangle requires three
+pairwise-distinct points, but `{p, q}` has only two. -/
+theorem isoscelesFree_pair (p q : P) : IsoscelesFree ({p, q} : Set P) := by
+  rintro a ha b hb c hc ⟨hab, hac, hbc, _⟩
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at ha hb hc
+  rcases ha with rfl | rfl <;> rcases hb with rfl | rfl <;> rcases hc with rfl | rfl <;>
+    simp_all
+
+/- ## The one-dimensional bridge
+
+On the real line, isosceles-freeness coincides with the absence of nontrivial
+3-term arithmetic progressions. This connects the `d = 1` case of Erdős #1207 to
+the classical midpoint-free / 3-AP-free problem. -/
+
+/-- A set of reals is **midpoint-free** when no point is the midpoint of two
+distinct points of the set, i.e. it contains no nontrivial 3-term arithmetic
+progression with middle term in the set. -/
+def MidpointFree (S : Set ℝ) : Prop :=
+  ∀ x ∈ S, ∀ y ∈ S, ∀ z ∈ S, x ≠ z → 2 * y ≠ x + z
+
+/-- **One-dimensional bridge for Erdős #1207.** A set of real numbers is
+isosceles-free precisely when it is midpoint-free (3-AP-free). Hence estimating
+`P_1(n)` is exactly the problem of the largest guaranteed 3-AP-free subset of an
+`n`-element set of reals. -/
+theorem isoscelesFree_iff_midpointFree (S : Set ℝ) :
+    IsoscelesFree S ↔ MidpointFree S := by
+  constructor
+  · -- isosceles-free ⇒ midpoint-free
+    intro hIso x hx y hy z hz hxz hap
+    -- `y` is the midpoint of `x ≠ z`, so `(y, x, z)` is an isosceles triangle.
+    have hyx : y ≠ x := by rintro rfl; apply hxz; linarith
+    have hyz : y ≠ z := by rintro rfl; apply hxz; linarith
+    refine hIso y hy x hx z hz ⟨hyx, hyz, hxz, Or.inl ?_⟩
+    rw [Real.dist_eq, Real.dist_eq]
+    rw [abs_eq_abs]
+    right; linarith
+  · -- midpoint-free ⇒ isosceles-free
+    intro hMid a ha b hb c hc ⟨hab, hac, hbc, hd⟩
+    rcases hd with h | h | h
+    · -- `a` is the apex: `|a-b| = |a-c|` with `b ≠ c` forces `a` a midpoint.
+      rw [Real.dist_eq, Real.dist_eq, abs_eq_abs] at h
+      rcases h with h | h
+      · exact hbc (by linarith)
+      · exact hMid b hb a ha c hc hbc (by linarith)
+    · -- `b` is the apex.
+      rw [Real.dist_eq, Real.dist_eq, abs_eq_abs] at h
+      rcases h with h | h
+      · exact hac (by linarith)
+      · exact hMid a ha b hb c hc hac (by linarith)
+    · -- `c` is the apex.
+      rw [Real.dist_eq, Real.dist_eq, abs_eq_abs] at h
+      rcases h with h | h
+      · exact hab (by linarith)
+      · exact hMid a ha c hc b hb hab (by linarith)
+
+/- ## Concrete sanity checks
+
+These exercise the definitions on small configurations and confirm the bridge is
+usable in practice. -/
+
+/-- `{0, 1, 2}` is **not** isosceles-free: `1` is equidistant from `0` and `2`. -/
+theorem not_isoscelesFree_zero_one_two :
+    ¬ IsoscelesFree ({0, 1, 2} : Set ℝ) := by
+  intro h
+  refine h 1 (by simp) 0 (by simp) 2 (by simp) ⟨?_, ?_, ?_, Or.inl ?_⟩ <;>
+    norm_num [Real.dist_eq]
+
+/-- `{0, 1, 3}` **is** isosceles-free: it contains no nontrivial 3-term
+arithmetic progression. Proved through the one-dimensional bridge. -/
+theorem isoscelesFree_zero_one_three :
+    IsoscelesFree ({0, 1, 3} : Set ℝ) := by
+  rw [isoscelesFree_iff_midpointFree]
+  rintro x hx y hy z hz hxz
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx hy hz
+  rcases hx with rfl | rfl | rfl <;> rcases hy with rfl | rfl | rfl <;>
+    rcases hz with rfl | rfl | rfl <;> revert hxz <;> norm_num
+
+end Erdos1207

--- a/src/data/proofs/erdos-1207/annotations.json
+++ b/src/data/proofs/erdos-1207/annotations.json
@@ -1,0 +1,169 @@
+[
+  {
+    "id": "ann-1207-header",
+    "proofId": "erdos-1207",
+    "range": {
+      "startLine": 1,
+      "endLine": 31
+    },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "Erdős Problem #1207: P_d(n) is the largest number of points guaranteed isosceles-free inside every n-point set of ℝ^d. Estimating P_d(n) — even deciding whether P_2(n) is subpolynomial — is open. This file formalizes the problem and proves the foundational, fully-verified facts: clean definitions, monotonicity, and the one-dimensional reduction to the midpoint-free (3-AP-free) problem.",
+    "mathContext": "Worst-case extremal quantity over all n-point configurations; the integer grid is the canonical hard instance.",
+    "significance": "key",
+    "relatedConcepts": [
+      "combinatorial geometry",
+      "isosceles triangles",
+      "arithmetic progressions"
+    ],
+    "prerequisites": [
+      "metric spaces",
+      "discrete geometry",
+      "arithmetic progressions"
+    ]
+  },
+  {
+    "id": "ann-1207-isosceles-triangle",
+    "proofId": "erdos-1207",
+    "range": {
+      "startLine": 41,
+      "endLine": 48
+    },
+    "type": "definition",
+    "title": "Isosceles Triangle",
+    "content": "Three points form an isosceles triangle when they are pairwise distinct and one of them (the apex) is equidistant from the other two. The three disjuncts in the definition cover which of a, b, c is the apex. Working in an arbitrary PseudoMetricSpace makes the predicate apply in every dimension at once.",
+    "mathContext": "IsoscelesTriangle a b c := a≠b ∧ a≠c ∧ b≠c ∧ (dist a b = dist a c ∨ dist b a = dist b c ∨ dist c a = dist c b)",
+    "significance": "key",
+    "relatedConcepts": [
+      "equal distances",
+      "pseudometric space"
+    ],
+    "prerequisites": [
+      "distance function"
+    ]
+  },
+  {
+    "id": "ann-1207-isosceles-free",
+    "proofId": "erdos-1207",
+    "range": {
+      "startLine": 49,
+      "endLine": 52
+    },
+    "type": "definition",
+    "title": "Isosceles-Free Set",
+    "content": "A set is isosceles-free when no three of its points form an isosceles triangle. P_d(n) is the largest size of such a subset guaranteed inside every n-point configuration of ℝ^d — the quantity Erdős #1207 asks to estimate.",
+    "mathContext": "IsoscelesFree S := ∀ a b c ∈ S, ¬ IsoscelesTriangle a b c",
+    "significance": "key",
+    "relatedConcepts": [
+      "extremal set",
+      "guaranteed subset"
+    ],
+    "prerequisites": [
+      "isosceles triangle"
+    ]
+  },
+  {
+    "id": "ann-1207-mono",
+    "proofId": "erdos-1207",
+    "range": {
+      "startLine": 56,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "Monotonicity",
+    "content": "Any subset of an isosceles-free set is isosceles-free. This subset-closure is exactly what makes 'the largest isosceles-free subset' a well-posed optimization, and hence what makes P_d(n) meaningful.",
+    "mathContext": "IsoscelesFree.mono : IsoscelesFree T → S ⊆ T → IsoscelesFree S",
+    "significance": "important",
+    "relatedConcepts": [
+      "monotonicity",
+      "hereditary property"
+    ],
+    "prerequisites": [
+      "isosceles-free set"
+    ]
+  },
+  {
+    "id": "ann-1207-small-sets",
+    "proofId": "erdos-1207",
+    "range": {
+      "startLine": 63,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "Small Sets Are Free",
+    "content": "The empty set, every singleton, and every two-point set are isosceles-free: an isosceles triangle requires three pairwise-distinct points, so any set with at most two points is vacuously free. These pin down the trivial lower end P_d(n) ≥ 2.",
+    "mathContext": "isoscelesFree_empty, isoscelesFree_singleton, isoscelesFree_pair — proved by ruling out three distinct points in a ≤ 2-element set.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "degenerate cases",
+      "pigeonhole"
+    ],
+    "prerequisites": [
+      "isosceles triangle"
+    ]
+  },
+  {
+    "id": "ann-1207-midpoint-free",
+    "proofId": "erdos-1207",
+    "range": {
+      "startLine": 86,
+      "endLine": 92
+    },
+    "type": "definition",
+    "title": "Midpoint-Free (3-AP-Free)",
+    "content": "A set of reals is midpoint-free when no point is the midpoint of two distinct points of the set — equivalently, it contains no nontrivial 3-term arithmetic progression with its middle term in the set. This is the classical Behrend/Roth-type object.",
+    "mathContext": "MidpointFree S := ∀ x y z ∈ S, x ≠ z → 2*y ≠ x + z",
+    "significance": "key",
+    "relatedConcepts": [
+      "arithmetic progression",
+      "Behrend sets"
+    ],
+    "prerequisites": [
+      "arithmetic progressions"
+    ]
+  },
+  {
+    "id": "ann-1207-bridge",
+    "proofId": "erdos-1207",
+    "range": {
+      "startLine": 93,
+      "endLine": 126
+    },
+    "type": "theorem",
+    "title": "The One-Dimensional Bridge",
+    "content": "On the real line, a set is isosceles-free if and only if it is midpoint-free (3-AP-free). The reason a line is special: the apex equation |a−b| = |a−c| with b ≠ c forces a−b = −(a−c), so the apex a must be the midpoint, 2a = b+c. This identifies the d=1 case of Erdős #1207 exactly with the largest-guaranteed-3-AP-free-subset problem, the tractable entry point to the whole question.",
+    "mathContext": "isoscelesFree_iff_midpointFree (S : Set ℝ) : IsoscelesFree S ↔ MidpointFree S — proved via Real.dist_eq and abs_eq_abs in both directions.",
+    "significance": "key",
+    "relatedConcepts": [
+      "dimension reduction",
+      "3-AP-free sets",
+      "absolute value"
+    ],
+    "prerequisites": [
+      "isosceles-free set",
+      "midpoint-free set",
+      "abs_eq_abs"
+    ]
+  },
+  {
+    "id": "ann-1207-sanity",
+    "proofId": "erdos-1207",
+    "range": {
+      "startLine": 128,
+      "endLine": 150
+    },
+    "type": "example",
+    "title": "Concrete Sanity Checks",
+    "content": "{0,1,2} is not isosceles-free — the point 1 is equidistant from 0 and 2. {0,1,3} is isosceles-free, proved through the bridge by exhausting the finite midpoint check. Together they confirm the definitions have teeth and the bridge is usable in practice.",
+    "mathContext": "not_isoscelesFree_zero_one_two and isoscelesFree_zero_one_three (the latter via isoscelesFree_iff_midpointFree + norm_num).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked example",
+      "verification"
+    ],
+    "prerequisites": [
+      "isosceles-free set",
+      "the one-dimensional bridge"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1207/meta.json
+++ b/src/data/proofs/erdos-1207/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "erdos-1207",
+  "title": "Erdős Problem #1207: Isosceles-Free Subsets of Point Sets",
+  "slug": "erdos-1207",
+  "description": "Let P_d(n) be the largest number such that every n-point set in ℝ^d contains P_d(n) points with no three forming an isosceles triangle. Erdős asks to estimate P_d(n) (in particular whether P_2(n) is subpolynomial). This OBSERVE-phase formalization supplies clean definitions, the structural facts making P_d well defined, and a verified one-dimensional bridge identifying the d=1 case with the classical midpoint-free (3-AP-free) problem.",
+  "meta": {
+    "author": "Erdős (Er80); formalization by researcher-1",
+    "sourceUrl": "https://erdosproblems.com/1207",
+    "date": "1980",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1207Problem.lean",
+    "tags": [
+      "erdos",
+      "combinatorial-geometry",
+      "discrete-geometry",
+      "isosceles-triangles",
+      "arithmetic-progressions",
+      "open"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 1207,
+    "erdosUrl": "https://erdosproblems.com/1207",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-06-28",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "dist",
+        "description": "Distance in a pseudometric space",
+        "module": "Mathlib.Topology.MetricSpace.Pseudo.Defs"
+      },
+      {
+        "theorem": "Real.dist_eq",
+        "description": "Distance on ℝ equals the absolute value of the difference",
+        "module": "Mathlib.Analysis.Normed.Order.Lattice"
+      },
+      {
+        "theorem": "abs_eq_abs",
+        "description": "|a| = |b| ↔ a = b ∨ a = -b",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      }
+    ],
+    "originalContributions": [
+      "IsoscelesTriangle definition: three pairwise-distinct points of a PseudoMetricSpace, one equidistant from the other two (apex), via a three-way disjunction over which vertex is the apex",
+      "IsoscelesFree definition: a set no three of whose points form an isosceles triangle — the property whose largest guaranteed subset size over all n-point configurations is P_d(n)",
+      "IsoscelesFree.mono (verified, 0-axiom): isosceles-freeness is closed under taking subsets — the monotonicity that makes 'largest isosceles-free subset' a well-defined optimization",
+      "isoscelesFree_empty / isoscelesFree_singleton / isoscelesFree_pair (verified, 0-axiom): every set of at most two points is isosceles-free, since a triangle needs three distinct points",
+      "MidpointFree definition: a set of reals with no nontrivial 3-term arithmetic progression whose middle term lies in the set (no point is the midpoint of two distinct others)",
+      "isoscelesFree_iff_midpointFree (verified, 0-axiom): THE ONE-DIMENSIONAL BRIDGE — on the real line a set is isosceles-free iff it is midpoint-free (3-AP-free). This identifies the d=1 case of Erdős #1207 with the extensively studied Behrend-type midpoint-free problem; the apex condition |a−b|=|a−c| on ℝ forces, via abs_eq_abs, the apex to be the midpoint 2a=b+c",
+      "not_isoscelesFree_zero_one_two (verified, 0-axiom): {0,1,2} ⊂ ℝ is NOT isosceles-free (1 is equidistant from 0 and 2) — confirms the definition has teeth",
+      "isoscelesFree_zero_one_three (verified, 0-axiom): {0,1,3} ⊂ ℝ IS isosceles-free, proved through the bridge by exhausting the finite midpoint check — confirms the bridge is usable in practice"
+    ],
+    "axiomCount": 0,
+    "lineCount": 150,
+    "assumptions": "None. All declarations are fully machine-checked: 0 axiom declarations, 0 structure-encoded assumptions, 0 sorries. The file does not resolve the open problem (the growth rate of P_d(n) is unknown); it formalizes the problem and proves foundational, fully-verified facts about isosceles-free sets and the one-dimensional reduction.",
+    "theoremCount": 7,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "**Erdős Problem #1207: Isosceles-free subsets**\n\nPosed by Erdős (Er80) in his work on combinatorial geometry, this is a worst-case extremal question: across *all* configurations of n points, how large an isosceles-free subset is *guaranteed*? Write P_d(n) for that guaranteed size. The d-dimensional integer grid {1,…,n^{1/d}}^d is the canonical hard instance: it is rich in equal distances, so its largest isosceles-free subset is believed to be small.\n\n**Related work:** Pach–Tardos (PaTa02) and the Brass–Moser–Pach (BMP05) monograph survey isosceles and equal-distance problems. The one-dimensional case connects directly to the Behrend / Roth lineage on progression-free sets.",
+    "problemStatement": "**Problem Statement (OPEN)**\n\nLet P_d(n) be the largest integer such that every set of n points in ℝ^d contains P_d(n) points, no three of which form an isosceles triangle. Estimate P_d(n); in particular, is P_2(n) only of subpolynomial size (P_2(n) < n^ε for every ε > 0)?\n\nThe growth rate of P_d(n) is not known.",
+    "text": "Every n-point set in ℝ^d contains some isosceles-free subset; P_d(n) is the size guaranteed in the worst case. Estimating P_d(n) — even deciding whether P_2(n) grows polynomially — is open.",
+    "proofStrategy": "**Formalization Approach (OBSERVE phase)**\n\n1. **Definitions:** IsoscelesTriangle and IsoscelesFree over an arbitrary PseudoMetricSpace, so the predicate applies in every dimension.\n\n2. **Well-definedness:** Prove monotonicity (subsets of isosceles-free sets stay isosceles-free) and that ≤ 2-point sets are free — the facts that make 'the largest isosceles-free subset' meaningful.\n\n3. **One-dimensional bridge:** Prove that on ℝ, isosceles-free = midpoint-free (3-AP-free), identifying P_1(n) with the largest-guaranteed-progression-free-subset problem.\n\n4. **Sanity checks:** Confirm the definitions bite on {0,1,2} (not free) and {0,1,3} (free).",
+    "prerequisites": [
+      "Metric and pseudometric spaces; the distance function and its basic identities",
+      "Elementary combinatorial geometry: equal-distance configurations and isosceles triangles",
+      "Arithmetic progressions and midpoint (average) conditions on the real line",
+      "Absolute-value algebra: |a| = |b| ↔ a = b ∨ a = −b"
+    ],
+    "keyInsights": [
+      "**Worst-case quantity:** P_d(n) measures what is *guaranteed* across all configurations, so the hard instances are the most regular point sets (grids), not random ones.",
+      "**Apex viewpoint:** An isosceles triangle is exactly three distinct points one of which is equidistant from the other two — 'no isosceles triangle' = 'no point equidistant from two others'.",
+      "**Monotonicity:** Isosceles-freeness is subset-closed, which is precisely what lets 'largest isosceles-free subset' be optimized.",
+      "**The 1-D reduction:** On a line the apex must be the *midpoint*, so isosceles-free collapses exactly to midpoint-free (no nontrivial 3-AP) — tying P_1(n) to Behrend-type extremal problems.",
+      "**Degenerate cases are clean:** Sets of at most two points are automatically free, since a triangle needs three distinct points."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions",
+      "summary": "IsoscelesTriangle (three pairwise-distinct points, one equidistant from the other two) and IsoscelesFree (no three points form one), over an arbitrary PseudoMetricSpace.",
+      "startLine": 39,
+      "endLine": 52,
+      "mathContext": "IsoscelesTriangle a b c := a≠b ∧ a≠c ∧ b≠c ∧ (dist a b = dist a c ∨ dist b a = dist b c ∨ dist c a = dist c b); the three disjuncts are the apex being a, b, or c. IsoscelesFree S := no triple from S is an isosceles triangle."
+    },
+    {
+      "id": "structural",
+      "title": "Structural Properties",
+      "summary": "IsoscelesFree.mono (subset-closed) plus the empty set, singletons, and two-point sets being isosceles-free — the facts that make P_d(n) well defined.",
+      "startLine": 54,
+      "endLine": 79,
+      "mathContext": "Verified (0-axiom): IsoscelesFree.mono (monotonicity under ⊆), isoscelesFree_empty, isoscelesFree_singleton, isoscelesFree_pair. A triangle needs three distinct points, so any set with at most two points is vacuously free."
+    },
+    {
+      "id": "one-dimensional-bridge",
+      "title": "The One-Dimensional Bridge",
+      "summary": "MidpointFree (no nontrivial 3-AP with middle term in the set) and isoscelesFree_iff_midpointFree: on ℝ, isosceles-free ⟺ midpoint-free, identifying the d=1 case with the 3-AP-free problem.",
+      "startLine": 81,
+      "endLine": 126,
+      "mathContext": "Verified (0-axiom): MidpointFree S := ∀ x y z ∈ S, x ≠ z → 2y ≠ x+z. The equivalence isoscelesFree_iff_midpointFree uses Real.dist_eq and abs_eq_abs: on the line |a−b| = |a−c| with b ≠ c forces a−b = −(a−c), i.e. the apex a is the midpoint 2a = b+c, so an isosceles triangle is exactly a nontrivial 3-term arithmetic progression."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Concrete Sanity Checks",
+      "summary": "not_isoscelesFree_zero_one_two ({0,1,2} is not free, apex 1) and isoscelesFree_zero_one_three ({0,1,3} is free), the latter via the bridge.",
+      "startLine": 128,
+      "endLine": 150,
+      "mathContext": "Verified (0-axiom): {0,1,2} fails (dist 1 0 = dist 1 2 = 1); {0,1,3} holds, proved by rewriting through isoscelesFree_iff_midpointFree and exhausting the finite midpoint check with norm_num."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős Problem #1207 asks for the growth of P_d(n), the largest isosceles-free subset guaranteed in every n-point set of ℝ^d — an open problem. This OBSERVE-phase formalization establishes the definitions over a general pseudometric space, proves the monotonicity and small-set facts that make P_d(n) well defined, and proves the one-dimensional bridge identifying the d=1 case with the classical midpoint-free (3-AP-free) problem. All results are fully verified with no axioms or sorries; the open growth question itself is untouched.",
+    "implications": "**Significance**\n\n1. **Reusable scaffolding:** dimension-agnostic IsoscelesFree predicate and its monotonicity give later work a clean base on which to state and attack bounds on P_d(n).\n2. **A precise reduction:** the 1-D bridge turns the d=1 case into a statement about 3-AP-free sets, where Behrend/Roth-type results live, making P_1(n) the tractable entry point.\n3. **Honest framing:** the formalization separates what is provable now (definitions, structure, the reduction) from the genuinely open estimate, avoiding any overclaim.",
+    "openQuestions": [
+      "What is the growth rate of P_2(n) — is it subpolynomial (P_2(n) < n^ε for every ε > 0) or does it grow polynomially?",
+      "What is the right order of P_d(n) for d ≥ 2, and what is the extremal configuration (the grid)?",
+      "Can the 1-D bridge be combined with quantitative 3-AP-free bounds (Behrend) to pin P_1(n)?",
+      "Does forbidding only non-degenerate (non-collinear) isosceles triangles change the asymptotics?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1",
+      "relationship": "related",
+      "description": "Erdős #1: distinct-distances circle of problems — the equal-distance structure underlying isosceles configurations."
+    },
+    {
+      "targetId": "erdos-12",
+      "relationship": "related",
+      "description": "Erdős #12: a combinatorial-geometry neighbor on point configurations and distances."
+    },
+    {
+      "targetId": "erdos-120",
+      "relationship": "related",
+      "description": "Erdős #120: related extremal point-configuration problem."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "P. Erdős"
+      ],
+      "title": "Some combinatorial problems in geometry",
+      "venue": "Geometry and Differential Geometry (Lecture Notes in Math. 792)",
+      "year": "1980",
+      "pages": "46–53",
+      "note": "Source of Problem #1207: estimating the largest isosceles-free subset guaranteed in every n-point set."
+    },
+    {
+      "authors": [
+        "J. Pach",
+        "G. Tardos"
+      ],
+      "title": "Isosceles triangles determined by a planar point set",
+      "venue": "Graphs and Combinatorics",
+      "year": "2002",
+      "volume": "18",
+      "pages": "769–779",
+      "note": "Bounds on isosceles triangles spanned by planar point sets; part of the surrounding literature (PaTa02)."
+    },
+    {
+      "authors": [
+        "P. Brass",
+        "W. Moser",
+        "J. Pach"
+      ],
+      "title": "Research Problems in Discrete Geometry",
+      "venue": "Springer",
+      "year": "2005",
+      "note": "Monograph (BMP05) surveying equal-distance and isosceles-triangle problems, including the context for P_d(n)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "Erdos1207",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1207Problem.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős Problem #1207 — Isosceles-free subsets of point sets (OPEN)

Estimate $P_d(n)$: the largest integer such that every $n$-point set in $\mathbb{R}^d$ contains $P_d(n)$ points, no three forming an isosceles triangle. No prior formalization existed; this is an **OBSERVE-phase** formalization.

### Contributions (all 0-sorry, 0-axiom)
- `IsoscelesTriangle` / `IsoscelesFree` for an arbitrary `PseudoMetricSpace` (apex = vertex equidistant from the other two).
- `IsoscelesFree.mono` + `empty`/`singleton`/`pair` base cases — the monotonicity and small-set facts that make "largest isosceles-free subset" well defined.
- **`isoscelesFree_iff_midpointFree` — the one-dimensional bridge.** On $\mathbb{R}$, a set is isosceles-free **iff** it is midpoint-free (contains no nontrivial 3-term AP). This identifies the $d=1$ case of #1207 with the classical Behrend-type 3-AP-free problem; the apex condition $|a-b|=|a-c|$ forces, via `abs_eq_abs`, the midpoint relation $2a=b+c$.
- `not_isoscelesFree_zero_one_two` and `isoscelesFree_zero_one_three` — sanity checks confirming the definitions and bridge are usable in practice.

7 theorems, 3 definitions, 150 lines.

### Status
`verified` / 0-axiom per the prior-iteration build.

⚠️ **Build note for auditor:** A re-verification `docker-build` could not be run in this session — the host disk (`/System/Volumes/Data`) was at 100% and the Docker containerd store was throwing I/O errors (system-wide, affecting all concurrent agents). The proof uses only standard, low-risk tactics (`linarith`, `norm_num`, `abs_eq_abs`, `Real.dist_eq`) and the prior iteration's meta records a clean 0-axiom build. Please re-confirm the docker build once disk pressure clears before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)