### PR TITLE
research(property-b-first-moment-oq-03): deterministic recoloring — finite core of the RS alteration [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3827,6 +3827,7 @@ import Proofs.ProductOfSegmentsOfChordsOQ03
 import Proofs.ProductOfSegmentsOfChordsOQ04
 import Proofs.PropertyBFirstMoment
 import Proofs.PropertyBFirstMomentRamsey
+import Proofs.PropertyBFirstMomentRecoloring
 import Proofs.PropertyBUpperBound
 import Proofs.PSeriesConvergenceOQ01
 import Proofs.PtolemysComplexProof

--- a/proofs/Proofs/PropertyBFirstMomentRecoloring.lean
+++ b/proofs/Proofs/PropertyBFirstMomentRecoloring.lean
@@ -1,0 +1,147 @@
+/-
+  OQ-03: Deterministic recoloring (the finite core of the alteration method)
+
+  Parent `PropertyBFirstMoment.lean` proves Erdős 1963 (a `k`-uniform family
+  with `< 2^(k-1)` edges is 2-colorable) via the first moment. Its sibling
+  `PropertyBFirstMomentOQ03.lean` carries that further to the *deletion* method:
+  from a coloring with few monochromatic edges, **discard** those edges to expose
+  a 2-colorable subfamily. Deletion throws edges away.
+
+  This file formalizes the complementary, harder half — **recoloring** — in its
+  clean deterministic regime: rather than deleting a monochromatic edge, *repair*
+  it by flipping a single vertex. This is the deterministic core of the
+  Radhakrishnan–Srinivasan alteration that OQ-03 ultimately targets. RS recolors
+  *probabilistically* precisely because, in general, the monochromatic edges share
+  vertices, so flipping one edge's vertex can break another edge. The deterministic
+  statement isolates the case where that dependency is absent: each monochromatic
+  edge owns a **private** vertex — one lying in no other edge of the family. Then
+  flipping the private vertices repairs every bad edge and disturbs nothing else,
+  giving *full* 2-colorability (not merely a subfamily, as deletion gives).
+
+  Note the privacy hypothesis is strictly weaker than "the monochromatic edges are
+  a matching": an edge needs only *one* private vertex, and may otherwise overlap
+  other edges arbitrarily (see `recoloring_example_overlap`). The remaining gap to
+  RS is exactly the removal of this privacy hypothesis via randomness — the
+  multi-session analytic step the knowledge base scopes.
+
+  Status: 0 sorries, 0 axioms. No `native_decide`.
+-/
+import Proofs.PropertyBFirstMoment
+
+namespace ProbMethod.PropertyB
+
+open Finset BigOperators
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- **Deterministic recoloring repairs Property B.** Fix a coloring `c` and let
+its monochromatic edges be `M = {e ∈ E | Mono e c}`. Suppose a vertex selector
+`w : Finset V → V` assigns to each monochromatic edge `e` a vertex `w e ∈ e` that
+is **private** to `e` (belongs to no other edge of `E`), and every monochromatic
+edge has at least two vertices. Then `E` has Property B.
+
+The repaired coloring `c'` flips exactly the private vertices `{w e | e ∈ M}`:
+
+* A monochromatic edge `e` was constant (say colour `b`). It has a second vertex
+  `u ≠ w e` (size `≥ 2`); `u` is not a private vertex of any edge (else privacy
+  would force that edge to be `e` and `u = w e`), so `u` keeps colour `b` while
+  `w e` flips to `!b` — `e` is now bichromatic.
+* A non-monochromatic edge contains *no* private vertex (privacy would force the
+  owning edge to coincide with it, making it monochromatic), so `c'` agrees with
+  `c` on it and it stays non-monochromatic.
+
+This is the deterministic alteration: flip a private vertex per bad edge. -/
+theorem property_b_of_recoloring
+    (E : Finset (Finset V)) (c : V → Bool) (w : Finset V → V)
+    (hmem : ∀ e ∈ E, Mono e c → w e ∈ e)
+    (hcard : ∀ e ∈ E, Mono e c → 2 ≤ e.card)
+    (hpriv : ∀ e ∈ E, Mono e c → ∀ e' ∈ E, w e ∈ e' → e' = e) :
+    ∃ c' : V → Bool, ∀ e ∈ E, ¬ Mono e c' := by
+  classical
+  -- monochromatic edges, and their private vertices
+  set M := E.filter (fun e => Mono e c) with hMdef
+  set S := M.image w with hSdef
+  have memM : ∀ e, e ∈ M ↔ e ∈ E ∧ Mono e c := by
+    intro e; rw [hMdef, mem_filter]
+  have memS : ∀ x, x ∈ S ↔ ∃ e ∈ M, w e = x := by
+    intro x; rw [hSdef, mem_image]
+  -- repaired coloring: flip exactly the private vertices
+  refine ⟨fun x => if x ∈ S then !c x else c x, ?_⟩
+  set c' : V → Bool := fun x => if x ∈ S then !c x else c x with hc'def
+  intro e he
+  by_cases hmono : Mono e c
+  · -- monochromatic edge: flipping its private vertex makes it bichromatic
+    have heM : e ∈ M := (memM e).mpr ⟨he, hmono⟩
+    obtain ⟨b, hb⟩ := hmono
+    have hwe : w e ∈ e := hmem e he ⟨b, hb⟩
+    have hweS : w e ∈ S := by rw [memS]; exact ⟨e, heM, rfl⟩
+    -- a second, unflipped vertex of `e`
+    have h1lt : 1 < e.card := by have := hcard e he ⟨b, hb⟩; omega
+    obtain ⟨u, hue, hune⟩ := Finset.exists_ne_of_one_lt_card h1lt (w e)
+    have huS : u ∉ S := by
+      rw [memS]
+      rintro ⟨e'', he''M, hwe''⟩
+      have he''E : e'' ∈ E := ((memM e'').mp he''M).1
+      have he''mono : Mono e'' c := ((memM e'').mp he''M).2
+      have hueE : w e'' ∈ e := by rw [hwe'']; exact hue
+      have heq : e = e'' := hpriv e'' he''E he''mono e he hueE
+      apply hune
+      rw [← hwe'', heq]
+    -- evaluate `c'` at the flipped and unflipped vertices
+    have e1 : c' (w e) = !c (w e) := by simp [hc'def, hweS]
+    have e2 : c' u = c u := by simp [hc'def, huS]
+    have cwe_b : c (w e) = b := hb (w e) hwe
+    have cu_b : c u = b := hb u hue
+    -- `e` cannot be monochromatic under `c'`
+    rintro ⟨b', hb'⟩
+    have hwe' : c' (w e) = b' := hb' (w e) hwe
+    have hu' : c' u = b' := hb' u hue
+    rw [e1, cwe_b] at hwe'
+    rw [e2, cu_b] at hu'
+    rw [← hu'] at hwe'
+    exact absurd hwe' (by cases b <;> decide)
+  · -- non-monochromatic edge: it contains no flipped vertex, so it is untouched
+    rintro ⟨b', hb'⟩
+    apply hmono
+    refine ⟨b', ?_⟩
+    intro x hx
+    have hxS : x ∉ S := by
+      rw [memS]
+      rintro ⟨e'', he''M, hwe''⟩
+      have he''E : e'' ∈ E := ((memM e'').mp he''M).1
+      have he''mono : Mono e'' c := ((memM e'').mp he''M).2
+      have hxe : w e'' ∈ e := by rw [hwe'']; exact hx
+      have heq : e = e'' := hpriv e'' he''E he''mono e he hxe
+      exact hmono (by rw [heq]; exact he''mono)
+    have hcx : c' x = c x := by simp [hc'def, hxS]
+    rw [← hcx]; exact hb' x hx
+
+/-- **Worked example — disjoint monochromatic edges.** Over `V = Fin 4` the
+all-true colouring makes both `{0,1}` and `{2,3}` monochromatic. They are disjoint,
+so vertices `0` and `2` are private; flipping them (`w` below) yields a proper
+2-colouring. This is the matching case of the deterministic alteration. -/
+theorem recoloring_example_disjoint :
+    ∃ c' : Fin 4 → Bool,
+      ∀ e ∈ ({{0, 1}, {2, 3}} : Finset (Finset (Fin 4))), ¬ Mono e c' := by
+  apply property_b_of_recoloring _ (fun _ => true)
+    (fun e => if (0 : Fin 4) ∈ e then 0 else 2)
+  · decide
+  · decide
+  · decide
+
+/-- **Worked example — overlapping monochromatic edges via private vertices.**
+Over `V = Fin 4`, under the all-true colouring both `{0,1}` and `{1,2,3}` are
+monochromatic and they *share* vertex `1`, so they are not a matching — yet each
+still owns a private vertex (`0` for `{0,1}`, `2` for `{1,2,3}`). The recoloring
+theorem applies, flipping `0` and `2` to a proper 2-colouring. This shows the
+privacy hypothesis is genuinely weaker than disjointness. -/
+theorem recoloring_example_overlap :
+    ∃ c' : Fin 4 → Bool,
+      ∀ e ∈ ({{0, 1}, {1, 2, 3}} : Finset (Finset (Fin 4))), ¬ Mono e c' := by
+  apply property_b_of_recoloring _ (fun _ => true)
+    (fun e => if (0 : Fin 4) ∈ e then 0 else 2)
+  · decide
+  · decide
+  · decide
+
+end ProbMethod.PropertyB

--- a/research/problems/property-b-first-moment-oq-03/knowledge.md
+++ b/research/problems/property-b-first-moment-oq-03/knowledge.md
@@ -94,7 +94,54 @@ to the recoloring step alone — confirming and sharpening the prior session's "
 the moonshot" verdict by formally excluding the asymmetry shortcut. No Mathlib gap for this
 sub-result (`convexOn_pow`/`strictConvexOn_pow` suffice).
 
+## Session (2026-06-28, researcher-7): deterministic recoloring — the finite core of RS alteration (POSITIVE)
+
+Addressed the **recoloring ingredient** of the RS program (the half the researcher-1 and
+researcher-4 sessions left as the moonshot) by formalizing its **deterministic core**.
+Where the merged oq-03 entry has the *deletion* method (discard each monochromatic edge →
+2-colorable *subfamily*), this session formalizes *recoloring* (repair each monochromatic
+edge by flipping a vertex → full 2-colorability) in the clean regime where the repairs do
+not interfere. Published as new gallery entry `property-b-first-moment-oq-03-oq-02`.
+
+New file `PropertyBFirstMomentRecoloring.lean` (147 lines, `ProbMethod.PropertyB`, imports
+`Proofs.PropertyBFirstMoment`, **0 sorries / 0 axioms**; the worked examples use `decide`,
+NOT `native_decide`, so no `Lean.ofReduceBool`):
+
+* `property_b_of_recoloring` (core) — fix a coloring `c` with monochromatic set
+  `M = E.filter (Mono · c)`. If every `e ∈ M` has `|e| ≥ 2` and owns a **private** vertex
+  `w e ∈ e` lying in no other edge of `E` (`hpriv : ∀ e ∈ E, Mono e c → ∀ e' ∈ E, w e ∈ e' → e' = e`),
+  then flipping `S = M.image w` yields a proper 2-coloring of **all** of `E`. Proof: case
+  split on `Mono e c`; a mono edge's private vertex flips (a second vertex from
+  `Finset.exists_ne_of_one_lt_card` keeps the original colour ⟹ bichromatic), a non-mono
+  edge contains no flipped vertex (privacy) ⟹ untouched.
+* `recoloring_example_disjoint` — disjoint `{0,1},{2,3}` over `Fin 4` (matching case).
+* `recoloring_example_overlap` — `{0,1},{1,2,3}` over `Fin 4` SHARE vertex 1 (not a matching)
+  yet each owns a private vertex (`0`, `2`); the theorem still applies. **Shows privacy is
+  strictly weaker than disjointness** — the entry's conceptual point.
+
+**Orphan note (deferred)**: `PropertyBFirstMomentOQ03.lean` (PR #31385) and
+`PropertyBFirstMomentAsymmetric.lean` (PR #31388) were committed to main but never imported
+into `Proofs.lean` (the orphan-backlog item, #31454). This PR registers ONLY the new
+Recoloring file in `Proofs.lean`; registering the two siblings is left for a follow-up that
+can re-run a build, per the one-at-a-time-after-build-verify rule.
+
+### Remaining gap to RS (now sharply isolated)
+With asymmetry ruled out (oq-03-oq-01) and the deterministic recoloring core in hand
+(this session), the sole missing ingredient for `m(k) = Ω(2^k·√(k/log k))` is the **removal
+of the privacy hypothesis via a probabilistic vertex-flip**: recolor each vertex of a
+surviving monochromatic edge with probability `p ≈ (log k)/k` and union-bound the failure.
+The deterministic lemma pinpoints, at each use of `hpriv`, exactly the shared-vertex
+dependency that randomness is introduced to handle. Mathlib gap unchanged: still needs a
+two-stage probability model + union bound + `p = log k/k` optimization (researcher-1's
+decomposition (1)–(3) stands).
+
 ## Verification
+researcher-7 recoloring file: built clean via
+`./proofs/scripts/docker-build.sh Proofs.PropertyBFirstMomentRecoloring` (Docker wrapper),
+0 sorries / 0 axioms. (An end-of-session re-verify could not run: the host Data volume hit
+100% and Docker's containerd store began returning I/O errors — an environmental blocker, not
+a proof issue. The clean build above predates the disk exhaustion.)
+
 `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PropertyBFirstMomentOQ03.lean`
 exits 0 (~45s, host toolchain, single-file against prebuilt Mathlib oleans). `#print axioms`
 checked by appending the print lines, `env lean`, then reverting. The researcher-4 asymmetry

--- a/src/data/proofs/property-b-first-moment-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-02/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-pbfm-oq03oq02-recoloring",
+    "proofId": "property-b-first-moment-oq-03-oq-02",
+    "range": { "startLine": 54, "endLine": 117 },
+    "type": "theorem",
+    "title": "Deterministic Recoloring Repairs Property B (property_b_of_recoloring)",
+    "content": "The crux. Fix a coloring `c` and let `M = E.filter (Mono · c)` be its monochromatic edges. If every `e ∈ M` has `|e| ≥ 2` and owns a PRIVATE vertex `w e ∈ e` (lying in no other edge of `E`, formalized by `hpriv : ∀ e ∈ E, Mono e c → ∀ e' ∈ E, w e ∈ e' → e' = e`), then flipping exactly the private vertices `S = M.image w` yields a proper 2-coloring `c' x = if x ∈ S then !c x else c x`. The proof splits each `e ∈ E` on `Mono e c`: a monochromatic edge (colour `b`) has its private vertex flipped to `!b` while a second vertex `u ≠ w e` (from `Finset.exists_ne_of_one_lt_card`, using `|e| ≥ 2`) stays colour `b` — because `u ∈ S` would, by privacy, force `u = w e`; so `e` becomes bichromatic. A non-monochromatic edge contains no flipped vertex at all (privacy would force its owning edge to coincide with it), so `c'` agrees with `c` on it. This REPAIRS the bad edges to full 2-colorability, unlike the deletion method which discards them for a mere subfamily.",
+    "mathContext": "$M=\\{e\\in E:\\mathrm{Mono}(e,c)\\}$, flip $S=\\{w(e):e\\in M\\}$; private vertex $w(e)\\to\\neg b$, witnessed $u\\to b$ ($|e|\\ge2$) $\\Rightarrow e$ bichromatic; non-mono edges untouched.",
+    "significance": "key",
+    "relatedConcepts": ["alteration method", "recoloring vs deletion", "private vertex", "monochromatic edge", "first moment method"],
+    "prerequisites": ["the parent Mono predicate", "Finset.exists_ne_of_one_lt_card", "Finset image/filter membership"]
+  },
+  {
+    "id": "ann-pbfm-oq03oq02-overlap",
+    "proofId": "property-b-first-moment-oq-03-oq-02",
+    "range": { "startLine": 132, "endLine": 145 },
+    "type": "example",
+    "title": "Privacy is Weaker than Disjointness (recoloring_example_overlap)",
+    "content": "Over `V = Fin 4`, under the all-true colouring both `{0,1}` and `{1,2,3}` are monochromatic and they SHARE vertex `1` — so the monochromatic edges do NOT form a matching. Yet each still owns a private vertex: `0` belongs only to `{0,1}` and `2` belongs only to `{1,2,3}`. The recoloring theorem therefore applies (with `w e = if 0 ∈ e then 0 else 2`), flipping `0` and `2` to the proper 2-colouring (F,T,F,T): `{0,1}` reads F,T and `{1,2,3}` reads T,F,T. This is the entry's conceptual highlight — the repair needs only ONE private vertex per bad edge, not global disjointness; the remaining (shared) vertices may overlap arbitrarily. The hypotheses `hmem`, `hcard`, `hpriv` are dispatched by `decide` (not `native_decide`).",
+    "mathContext": "$\\{0,1\\},\\{1,2,3\\}$ share vertex $1$ but have private vertices $0,2$; flip them: $(F,T,F,T)$ is proper.",
+    "significance": "key",
+    "relatedConcepts": ["private vertex vs matching", "overlapping edges", "deterministic repair", "decide"],
+    "prerequisites": ["the recoloring lemma", "decidability of Mono on concrete finsets"]
+  },
+  {
+    "id": "ann-pbfm-oq03oq02-disjoint",
+    "proofId": "property-b-first-moment-oq-03-oq-02",
+    "range": { "startLine": 119, "endLine": 130 },
+    "type": "example",
+    "title": "The Matching Case (recoloring_example_disjoint)",
+    "content": "The simplest instance: over `V = Fin 4` the all-true colouring makes the DISJOINT edges `{0,1}` and `{2,3}` monochromatic. Being disjoint, every vertex is private; the selector `w e = if 0 ∈ e then 0 else 2` picks `0` and `2`, and flipping them gives the proper 2-colouring. This is the matching regime of the alteration — no dependency between repairs — and serves as the baseline against which `recoloring_example_overlap` shows privacy is the genuinely weaker hypothesis. Hypotheses dispatched by `decide`.",
+    "mathContext": "$\\{0,1\\},\\{2,3\\}$ disjoint over $\\mathrm{Fin}\\,4$; flip private vertices $0,2$ to a proper 2-colouring.",
+    "significance": "supporting",
+    "relatedConcepts": ["matching", "disjoint edges", "alteration baseline"],
+    "prerequisites": ["the recoloring lemma"]
+  }
+]

--- a/src/data/proofs/property-b-first-moment-oq-03-oq-02/meta.json
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-02/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "property-b-first-moment-oq-03-oq-02",
+  "title": "Property B: Deterministic Recoloring — the Finite Core of the Alteration Method",
+  "slug": "property-b-first-moment-oq-03-oq-02",
+  "description": "Partial, constructive-direction answer to open question oq-03 of property-b-first-moment, which targets the Radhakrishnan–Srinivasan lower bound m(k) = Ω(2^k·√(k/log k)) via a random RECOLORING (alteration) repair of the first-moment coloring. The sibling entries already deliver the single-round first moment (the sharp criterion ∑ 2^(1-|e|) < 1), its quantitative few-bad-edges refinement, the DELETION method (discard the bad edges), and the negative asymmetry result (biasing the coloring never helps). This entry formalizes the complementary, harder half — RECOLORING — in its clean deterministic regime: instead of deleting a monochromatic edge, REPAIR it by flipping a single vertex. property_b_of_recoloring: if a coloring c leaves a set M of monochromatic edges, every e ∈ M has ≥ 2 vertices, and each e ∈ M owns a PRIVATE vertex w(e) ∈ e lying in no other edge of E, then flipping the private vertices yields a proper 2-coloring of ALL of E. The private vertices are exactly what RS removes via randomness: with private vertices the repair is deterministic and gains FULL 2-colorability (not merely a subfamily, as deletion gives). The privacy hypothesis is strictly weaker than 'the monochromatic edges form a matching' — an edge needs only one private vertex and may otherwise overlap arbitrarily (recoloring_example_overlap exhibits two overlapping monochromatic edges repaired via their private vertices). The remaining gap to RS is exactly the removal of this privacy hypothesis via a probabilistic vertex-flip. Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Lean Genius researcher (deterministic alteration core for the Radhakrishnan–Srinivasan / Property B program)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Property_B",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PropertyBFirstMomentRecoloring.lean",
+    "tags": [
+      "probabilistic-method",
+      "alteration-method",
+      "property-b",
+      "hypergraph-coloring",
+      "combinatorics",
+      "erdos",
+      "recoloring"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.exists_ne_of_one_lt_card",
+        "description": "From 1 < e.card produces a second vertex u ∈ e with u ≠ w e. This is what lets a repaired monochromatic edge (all colour b under c) become bichromatic: the private vertex w e flips to !b while the witnessed second vertex u keeps colour b.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.mem_image",
+        "description": "Characterizes membership in the flip set S = M.image w (the private vertices of the monochromatic edges): x ∈ S ↔ ∃ e ∈ M, w e = x. Used to decide, for each vertex, whether the repaired coloring flips it.",
+        "module": "Mathlib.Data.Finset.Image"
+      },
+      {
+        "theorem": "Finset.mem_filter",
+        "description": "Characterizes the monochromatic-edge set M = E.filter (Mono · c): e ∈ M ↔ e ∈ E ∧ Mono e c. Drives both the privacy bookkeeping and the case split on whether the edge under test is monochromatic.",
+        "module": "Mathlib.Data.Finset.Filter"
+      },
+      {
+        "theorem": "ProbMethod.PropertyB.Mono",
+        "description": "The parent file's monochromaticity predicate Mono e c := ∃ b, ∀ x ∈ e, c x = b, with its Decidable instance — reused verbatim so the recoloring statement speaks the same language as the criterion and deletion entries.",
+        "module": "Proofs.PropertyBFirstMoment"
+      }
+    ],
+    "originalContributions": [
+      "property_b_of_recoloring: a 0-axiom Lean proof of the deterministic recoloring (alteration) lemma — if a coloring c leaves monochromatic edges M, each with ≥ 2 vertices and each owning a private vertex w(e) (in no other edge of E), then flipping {w(e) : e ∈ M} properly 2-colors all of E. This is the finite, deterministic core of the Radhakrishnan–Srinivasan repair: REPAIR the bad edges (gaining full 2-colorability) rather than DELETE them (the elementary sibling formalized in oq-03's deletion method).",
+      "The privacy mechanism made precise: a private vertex flips to break its own monochromatic edge while, by privacy, lying in no other edge — so non-monochromatic edges contain no flipped vertex and stay non-monochromatic, and each monochromatic edge receives exactly one flip (its size ≥ 2 leaving a witnessed second vertex of the original colour, hence bichromatic). The proof isolates exactly why recoloring is delicate: shared vertices would couple the repairs, which is precisely the dependency RS handles probabilistically.",
+      "recoloring_example_disjoint: a worked instance over V = Fin 4 where the all-true colouring makes the disjoint edges {0,1} and {2,3} monochromatic; vertices 0 and 2 are private, so flipping them repairs both — the matching case of the alteration, hypotheses dispatched by decide (not native_decide).",
+      "recoloring_example_overlap: a worked instance over V = Fin 4 where {0,1} and {1,2,3} are monochromatic and SHARE vertex 1 (so they are not a matching) yet each still owns a private vertex (0 and 2); the theorem applies and repairs both. This demonstrates the privacy hypothesis is genuinely weaker than disjointness — the entry's key conceptual point.",
+      "An honest scoping of the remaining gap to oq-03: with asymmetry ruled out (sibling oq-03-oq-01) and the deterministic recoloring core in hand, the sole missing ingredient for the Radhakrishnan–Srinivasan m(k) = Ω(2^k·√(k/log k)) bound is the REMOVAL of the privacy hypothesis via a probabilistic vertex-flip (recolor each vertex of a surviving monochromatic edge with probability ≈ (log k)/k and union-bound the failure), the genuinely analytic multi-session step."
+    ],
+    "dateAdded": "2026-06-28",
+    "relatedProblems": [
+      {
+        "id": "property-b-first-moment-oq-03",
+        "relationship": "Partially answers oq-03 (formalize the Radhakrishnan–Srinivasan random recoloring). This entry supplies the deterministic core of the recoloring repair: when monochromatic edges own private vertices, flipping those vertices yields full 2-colorability. RS removes the privacy hypothesis via randomness to gain the √(k/log k) factor."
+      },
+      {
+        "id": "property-b-first-moment-oq-03-oq-01",
+        "relationship": "Companion sub-result. oq-03-oq-01 settles the asymmetry ingredient negatively (biasing never beats 2^(k-1)); this entry advances the recoloring ingredient positively (the deterministic repair). Together they isolate the remaining content as the probabilistic recoloring analysis alone."
+      },
+      {
+        "id": "property-b-first-moment",
+        "relationship": "Grandparent entry: Erdős' first-moment bound m(k) ≥ 2^(k-1). The recoloring lemma reuses its Mono predicate and is the repair half of the alteration method built atop that first moment."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 147,
+    "assumptions": "0 axioms, 0 sorries, no native_decide (the worked examples use decide, which depends only on the foundational kernel, not Lean.ofReduceBool). The hypotheses (edges of size ≥ 2; a private-vertex selector w) are inputs to the statement, not standing assumptions; V is an arbitrary Fintype with DecidableEq. #print axioms reports only propext, Classical.choice, Quot.sound for property_b_of_recoloring and both worked examples — no sorryAx, no Lean.ofReduceBool. This is the DETERMINISTIC core of the recoloring repair; the full Radhakrishnan–Srinivasan √(k/log k) improvement, which removes the privacy hypothesis via a probabilistic vertex-flip, is NOT formalized and is left open.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "A hypergraph has Property B if its vertices can be 2-colored with no monochromatic edge. Erdős (1963) proved every k-uniform hypergraph with fewer than 2^(k-1) edges has Property B via the first moment method, giving m(k) ≥ 2^(k-1) for the minimum number of edges in a non-2-colorable k-uniform hypergraph. The lower bound was improved by Beck (1978) and by Radhakrishnan–Srinivasan (2000) to m(k) = Ω(2^k·√(k/log k)) using the ALTERATION (recoloring) method: take a random 2-coloring, then repair the monochromatic edges by recoloring some of their vertices, bounding the chance any edge stays monochromatic. The alteration method has two elementary deterministic faces — DELETION (discard each bad edge) and RECOLORING (fix each bad edge by flipping a vertex). Deletion only yields a 2-colorable SUBFAMILY; recoloring can yield full 2-colorability but couples repairs through shared vertices, which is why RS introduces randomness. This entry formalizes the deterministic recoloring face in the regime where the coupling is absent — each bad edge owns a private vertex.",
+    "problemStatement": "Let V be a finite vertex set and E a finite family of edges. Fix a 2-coloring c : V → Bool and let M = {e ∈ E | Mono e c} be its monochromatic edges. Suppose every e ∈ M has |e| ≥ 2 and a vertex selector w assigns to each e ∈ M a PRIVATE vertex w(e) ∈ e that belongs to no other edge of E. Then E has Property B: flipping the colors of exactly the private vertices {w(e) : e ∈ M} produces a coloring c' under which no edge of E is monochromatic.",
+    "text": "Build c' by flipping exactly the private vertices S = {w(e) : e ∈ M}. A monochromatic edge e (all colour b) has its private vertex w(e) flipped to !b, while a second vertex u ≠ w(e) (it has ≥ 2) is not a private vertex of any edge — privacy would force that edge to be e itself and u = w(e) — so u keeps colour b; e is now bichromatic. A non-monochromatic edge contains no private vertex at all (privacy would force the owning edge to coincide with it, making it monochromatic), so c' agrees with c on it and it stays non-monochromatic. Hence c' properly 2-colors E. The argument is the deterministic alteration: one private flip per bad edge.",
+    "proofStrategy": "1. **Set up the flip.** M = E.filter (Mono · c); the flip set S = M.image w is the private vertices; the repaired coloring c' x = if x ∈ S then !c x else c x. Membership lemmas memM (mem_filter) and memS (mem_image) characterize M and S.\n\n2. **Case split on each edge e ∈ E by whether Mono e c.**\n\n3. **Monochromatic e (colour b).** Its private vertex w e ∈ e is in S, so c'(w e) = !b. By Finset.exists_ne_of_one_lt_card (|e| ≥ 2) pick u ∈ e, u ≠ w e; show u ∉ S, because u ∈ S would name an owning edge e'' with w e'' = u, and privacy (w e'' ∈ e) forces e = e'' hence u = w e, contradiction. So c' u = c u = b ≠ !b = c'(w e): e is not monochromatic under c'.\n\n4. **Non-monochromatic e.** Every x ∈ e satisfies x ∉ S: x ∈ S would name an owning edge e'' with w e'' = x, and privacy (w e'' ∈ e) forces e = e'', making e monochromatic — contradiction. So c' = c on e and Mono e c' would give Mono e c, contradiction.\n\n5. **Worked examples.** recoloring_example_disjoint (disjoint {0,1},{2,3}) and recoloring_example_overlap (overlapping {0,1},{1,2,3}) over Fin 4, hypotheses dispatched by decide.",
+    "keyInsights": [
+      "**Recoloring repairs; deletion discards.** The deletion method (sibling oq-03 entry) throws away each monochromatic edge to expose a 2-colorable subfamily; recoloring instead FLIPS a vertex to fix the edge, keeping the whole family. This is the qualitative jump the Radhakrishnan–Srinivasan alteration needs.",
+      "**Privacy, not disjointness, is the right hypothesis.** An edge needs only ONE vertex of its own (in no other edge) to be repairable without side effects; it may overlap other edges arbitrarily through its remaining vertices. recoloring_example_overlap shows two monochromatic edges sharing a vertex that are nonetheless both repaired.",
+      "**The proof pinpoints why recoloring is hard in general.** Each step where privacy is invoked is exactly a place where a SHARED flip vertex would break the argument — the dependency between repairs. Removing privacy is precisely what forces RS to flip vertices probabilistically and union-bound the failures.",
+      "**Size ≥ 2 is essential.** Flipping a vertex of a singleton edge leaves it monochromatic (it is trivially monochromatic — see the sibling sharpness result); the repair needs a surviving second vertex of the original colour, which |e| ≥ 2 guarantees."
+    ],
+    "prerequisites": [
+      "Erdős' Property B first-moment bound (grandparent entry property-b-first-moment) and its Mono predicate",
+      "The alteration (deletion/recoloring) method in the probabilistic method",
+      "The deletion-method sibling (oq-03 entry exists_two_colorable_subfamily), of which this is the recoloring counterpart",
+      "Elementary Finset reasoning: image, filter, and exists_ne_of_one_lt_card"
+    ]
+  },
+  "sections": [
+    {
+      "id": "recoloring-lemma",
+      "title": "Deterministic Recoloring Repairs Property B",
+      "startLine": 1,
+      "endLine": 117,
+      "mathContext": "$M=\\{e\\in E: \\mathrm{Mono}(e,c)\\},\\ |e|\\ge 2,\\ w(e)\\ \\text{private}\\ \\Rightarrow\\ \\exists c',\\ \\forall e\\in E,\\ \\neg\\,\\mathrm{Mono}(e,c')$",
+      "summary": "Module docstring contrasting recoloring (repair) with deletion (discard) and scoping the privacy hypothesis against the Radhakrishnan–Srinivasan target. property_b_of_recoloring: flip the private vertices S = M.image w; a monochromatic edge gets exactly one flip (its private vertex) and a surviving second vertex (exists_ne_of_one_lt_card) keeps the original colour, so it becomes bichromatic; a non-monochromatic edge contains no flipped vertex (privacy) and is untouched."
+    },
+    {
+      "id": "examples",
+      "title": "Worked Examples: Disjoint and Overlapping Monochromatic Edges",
+      "startLine": 119,
+      "endLine": 147,
+      "mathContext": "$\\{\\{0,1\\},\\{2,3\\}\\}\\ \\text{(disjoint)};\\quad \\{\\{0,1\\},\\{1,2,3\\}\\}\\ \\text{(share vertex 1, private 0 and 2)}\\subseteq 2^{\\mathrm{Fin}\\,4}$",
+      "summary": "recoloring_example_disjoint: the all-true colouring makes the disjoint {0,1},{2,3} monochromatic; private vertices 0,2 are flipped — the matching case. recoloring_example_overlap: {0,1},{1,2,3} are monochromatic and share vertex 1, yet each owns a private vertex (0,2), so the theorem still applies — privacy is strictly weaker than disjointness. Hypotheses dispatched by decide."
+    }
+  ],
+  "conclusion": {
+    "summary": "The deterministic core of the recoloring (alteration) method for Property B, formalized with zero sorries and zero axioms: when a coloring's monochromatic edges each have ≥ 2 vertices and own a private vertex, flipping the private vertices yields a proper 2-coloring of the entire family. This REPAIRS the bad edges (full 2-colorability) where the deletion method merely discards them (a subfamily). A disjoint example and an overlapping example show the privacy hypothesis is genuinely weaker than the monochromatic edges forming a matching.",
+    "implications": "Together with the sibling asymmetry result (oq-03-oq-01, which rules out biasing) and the deletion method (oq-03), this isolates the sole remaining ingredient of the Radhakrishnan–Srinivasan m(k) = Ω(2^k·√(k/log k)) bound: removing the privacy hypothesis via a probabilistic vertex-flip. The deterministic lemma also pinpoints, at each use of privacy, exactly the shared-vertex dependency that randomness is introduced to handle.",
+    "openQuestions": [
+      "Remove the privacy hypothesis probabilistically: recolor each vertex of a surviving monochromatic edge independently with probability p ≈ (log k)/k and union-bound the event that any edge remains (or becomes) monochromatic, recovering the Radhakrishnan–Srinivasan m(k) = Ω(2^k·√(k/log k)) lower bound. This is the genuine remaining content of oq-03, now isolated from the settled asymmetry question and built on this deterministic repair core.",
+      "Quantify the deterministic regime: characterize the families whose first-moment monochromatic edges necessarily admit private vertices (e.g. low-degree or locally sparse hypergraphs), where this lemma already gives full 2-colorability without any randomness."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "property-b-first-moment-oq-03",
+      "relationship": "extends",
+      "description": "Supplies the recoloring counterpart to oq-03's deletion method: instead of deleting monochromatic edges to expose a 2-colorable subfamily, repair them by flipping private vertices to 2-color the whole family."
+    },
+    {
+      "targetId": "property-b-first-moment-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Companion oq-03 sub-result: oq-03-oq-01 settles asymmetry negatively, this entry advances recoloring positively; together they isolate the probabilistic recoloring analysis as the remaining work."
+    },
+    {
+      "targetId": "property-b-first-moment",
+      "relationship": "extends",
+      "description": "Builds the recoloring (repair) half of the alteration method atop Erdős' first-moment bound, reusing its Mono predicate."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/PropertyBFirstMomentRecoloring.lean",
+    "imports": [
+      "Proofs.PropertyBFirstMoment"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "ProbMethod.PropertyB",
+    "lineCount": 147,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 3
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "On a combinatorial problem",
+      "year": "1963",
+      "venue": "Nordisk Matematisk Tidskrift 11, 5–10",
+      "note": "Introduces Property B and the first-moment lower bound m(k) ≥ 2^(k-1) on which the alteration method builds."
+    },
+    {
+      "authors": "Radhakrishnan, Jaikumar; Srinivasan, Aravind",
+      "title": "Improved bounds and algorithms for hypergraph 2-coloring",
+      "year": "2000",
+      "venue": "Random Structures & Algorithms 16(1), 4–32",
+      "note": "Proves m(k) = Ω(2^k·√(k/log k)) by random coloring plus recoloring. This entry formalizes the deterministic core of the recoloring repair; RS removes the privacy hypothesis via randomness."
+    },
+    {
+      "authors": "Alon, Noga; Spencer, Joel H.",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition",
+      "note": "Chapter 3 (The Deletion Method / alterations) frames deletion and recoloring as the two faces of the alteration method."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "property_b_of_recoloring",
+      "type": "core",
+      "description": "Deterministic recoloring: if a coloring's monochromatic edges each have ≥ 2 vertices and own a private vertex (in no other edge), flipping the private vertices properly 2-colors the whole family.",
+      "leanType": "(E : Finset (Finset V)) → (c : V → Bool) → (w : Finset V → V) → (∀ e ∈ E, Mono e c → w e ∈ e) → (∀ e ∈ E, Mono e c → 2 ≤ e.card) → (∀ e ∈ E, Mono e c → ∀ e' ∈ E, w e ∈ e' → e' = e) → ∃ c' : V → Bool, ∀ e ∈ E, ¬ Mono e c'"
+    },
+    {
+      "name": "recoloring_example_overlap",
+      "type": "supporting",
+      "description": "Two monochromatic edges {0,1},{1,2,3} over Fin 4 sharing vertex 1 (not a matching) are both repaired via their private vertices 0 and 2 — privacy is strictly weaker than disjointness.",
+      "leanType": "∃ c' : Fin 4 → Bool, ∀ e ∈ ({{0,1},{1,2,3}} : Finset (Finset (Fin 4))), ¬ Mono e c'"
+    },
+    {
+      "name": "recoloring_example_disjoint",
+      "type": "supporting",
+      "description": "The matching case: disjoint monochromatic edges {0,1},{2,3} over Fin 4 repaired by flipping private vertices 0 and 2.",
+      "leanType": "∃ c' : Fin 4 → Bool, ∀ e ∈ ({{0,1},{2,3}} : Finset (Finset (Fin 4))), ¬ Mono e c'"
+    }
+  ],
+  "sorries": 0,
+  "theoremCount": 3
+}


### PR DESCRIPTION
## Summary

New gallery entry **`property-b-first-moment-oq-03-oq-02`** — *Property B: Deterministic Recoloring, the Finite Core of the Alteration Method*.

Advances open question **oq-03** (formalize the Radhakrishnan–Srinivasan random recoloring) by formalizing its **deterministic core**. Where the merged oq-03 entry has the *deletion* method (discard each monochromatic edge → 2-colorable *subfamily*), this entry formalizes *recoloring* (repair each monochromatic edge by flipping a vertex → **full** 2-colorability) in the clean regime where the repairs do not interfere.

## Lean (`Proofs/PropertyBFirstMomentRecoloring.lean`, 147 lines, 0 sorries / 0 axioms)

- **`property_b_of_recoloring`** — fix coloring `c` with monochromatic set `M = E.filter (Mono · c)`. If every `e ∈ M` has `|e| ≥ 2` and owns a **private** vertex `w e ∈ e` (in no other edge of `E`), then flipping `S = M.image w` properly 2-colors **all** of `E`. Proof: case split on `Mono e c` — a mono edge's private vertex flips while a second vertex (from `Finset.exists_ne_of_one_lt_card`) keeps the original colour ⟹ bichromatic; a non-mono edge contains no flipped vertex (privacy) ⟹ untouched.
- **`recoloring_example_disjoint`** — `{0,1},{2,3}` over `Fin 4` (matching case).
- **`recoloring_example_overlap`** — `{0,1},{1,2,3}` **share** vertex 1 (not a matching) yet each owns a private vertex; theorem still applies. Shows privacy is strictly weaker than disjointness. Both examples use `decide` (not `native_decide`).

## Remaining gap to RS (now sharply isolated)

With asymmetry ruled out (oq-03-oq-01) and this deterministic core in hand, the sole missing ingredient for `m(k) = Ω(2^k·√(k/log k))` is **removing the privacy hypothesis via a probabilistic vertex-flip**.

## Verification

`Proofs.PropertyBFirstMomentRecoloring` built clean via the Docker wrapper earlier this session — 0 sorries / 0 axioms; `#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). Registers **only** the new file in `Proofs.lean`; the two sibling orphans (`PropertyBFirstMomentOQ03`/`Asymmetric`, #31385/#31388, tracked by #31454) are left for a build-verified follow-up per the one-at-a-time rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)