### PR TITLE
research(van-der-waerden-first-moment-oq-03): verified first-moment W lower bound bridged into erdos-138 [BUILD-UNVERIFIED]

### DIFF
--- a/proofs/Proofs/Erdos138FirstMomentBridge.lean
+++ b/proofs/Proofs/Erdos138FirstMomentBridge.lean
@@ -1,0 +1,167 @@
+/-
+  Bridging the Verified First-Moment Bound into the erdos-138 Framework
+
+  `erdos-138` (`Erdos138Problem.lean`) defines the van der Waerden number
+
+      W(k) = sInf { N | every 2-colouring of {1,…,N} has a monochromatic k-AP }
+
+  and axiomatizes *all* of its growth lower bounds (`berlekamp_lower_bound`,
+  `kozik_shabanov_lower_bound`).  Separately, `van-der-waerden-first-moment`
+  (`VanDerWaerdenFirstMoment.lean`) proves — fully, axiom-free — the elementary
+  first-moment (union-bound) bound `vdw_lower_bound`: if `n² < 2^(k-1)` then some
+  2-colouring of the ground set `Fin n` has no monochromatic length-`k` AP.
+
+  This file connects the two.  It turns the verified `Fin n` colouring into a
+  colouring of `{1,…,N}` and feeds it through erdos-138's own reduction lemmas
+  (`contains_mono_ap_imp`, `not_in_guarantee_lt_sInf`) to obtain a **machine-checked
+  lower bound on `W k` itself**:
+
+      `firstMoment_W_lower_bound : N² < 2^(k-1) → N < W k`            (no new axioms)
+      `firstMoment_W_pow_lower   : 2^((k-2)/2) < W k`  (a clean power corollary)
+
+  This is the first *verified* (rather than axiomatized) lower bound on `W` in the
+  erdos-138 development.
+
+  HONEST STRENGTH GAP (important).  The elementary bound only gives
+  `W(k) ≳ 2^((k-1)/2)`, which is asymptotically *negligible* against the
+  axiomatized bounds `kozik_shabanov_lower_bound` (`W(k) ≳ c·2^k`) and
+  `berlekamp_lower_bound`.  It therefore **does not eliminate** any existing
+  erdos-138 axiom — it *supplements* them with a proven bound for the elementary
+  regime.  The negligibility is itself recorded formally as
+  `firstMoment_bound_negligible` (the ratio of the two bounds' magnitudes → 0).
+
+  Status: 0 sorries, 0 new axioms.  (`W` is still defined via erdos-138's
+  axiomatized `W_is_nonempty`, inherited through the bridge lemma
+  `not_in_guarantee_lt_sInf`; no axiom is introduced *here*.)
+-/
+import Mathlib
+import Proofs.VanDerWaerdenFirstMoment
+import Proofs.Erdos138Problem
+
+namespace Erdos138
+
+open ProbMethod.VanDerWaerden
+open ProbMethod.PropertyB (Mono)
+open Finset Filter
+open scoped Fin.NatCast
+
+/-- Embed `Bool` into `Fin 2` (the colour alphabet used by erdos-138). -/
+def boolToFin2 (b : Bool) : Fin 2 := if b then 1 else 0
+
+theorem boolToFin2_injective : Function.Injective boolToFin2 := by decide
+
+/-- Transport a `Fin N` colouring to a colouring of `{1,…,N} ⊆ ℕ` via the index
+shift `v ↦ v - 1` (mapping `{1,…,N}` onto `{0,…,N-1} = Fin N`). -/
+def shiftColoring (N : ℕ) (c : Fin N → Bool) (x : Finset.Icc 1 N) : Fin 2 :=
+  boolToFin2 (c ((Nat.cast (x.1 - 1)) : Fin N))
+
+/-- **Verified first-moment lower bound on the van der Waerden number `W`.**
+
+If `N² < 2^(k-1)` (so `N < 2^((k-1)/2)`) and `k ≥ 2`, then `N < W k`.
+
+The proof bridges the two gallery files.  From `vdw_lower_bound` we obtain a
+2-colouring `c : Fin N → Bool` of the ground set with no monochromatic length-`k`
+AP.  We transport it to a colouring of `{1,…,N}` via `shiftColoring`.  erdos-138's
+`contains_mono_ap_imp` says any monochromatic AP for that colouring would lift to a
+function-form monochromatic AP of `extend_coloring N (shiftColoring N c)`; we show
+that AP, shifted back by one, would be a monochromatic `vdwAP` for `c`,
+contradicting the first-moment guarantee.  Hence `N ∉ monoAP_guarantee_set 2 k`,
+and `not_in_guarantee_lt_sInf` gives `N < W k`. -/
+theorem firstMoment_W_lower_bound {k N : ℕ} (hk : 2 ≤ k)
+    (hNk : N * N < 2 ^ (k - 1)) : N < W k := by
+  -- N = 0 is immediate: 0 < W k whenever the (nonempty) guarantee set excludes 0.
+  rcases Nat.eq_zero_or_pos N with hN0 | hNpos
+  · subst hN0
+    apply not_in_guarantee_lt_sInf
+    intro hmem
+    -- A coloring of the empty set {1,…,0} can have no length-`k` (k ≥ 2) AP.
+    have hcontains : ContainsMonoAPofLength
+        (fun _ : Finset.Icc 1 0 => (0 : Fin 2)) k := hmem _
+    have hhas :
+        HasMonoAP (extend_coloring 0 (fun _ : Finset.Icc 1 0 => (0 : Fin 2))) 0 k :=
+      contains_mono_ap_imp 0 k (by omega) _ hcontains
+    obtain ⟨a, d, _, ha1, han, _⟩ := hhas
+    -- a ≥ 1 but a + (k-1)·d ≤ 0 forces a = 0, contradiction.
+    omega
+  -- Main case: N > 0.
+  haveI : NeZero N := ⟨by omega⟩
+  obtain ⟨c, hc⟩ := vdw_lower_bound (n := N) hk hNk
+  -- Evaluation of the extended ℕ-coloring on points of {1,…,N}.
+  have eval : ∀ y : ℕ, y ∈ Finset.Icc 1 N →
+      extend_coloring N (shiftColoring N c) y
+        = boolToFin2 (c ((Nat.cast (y - 1)) : Fin N)) := by
+    intro y hy
+    simp only [extend_coloring, dif_pos hy, shiftColoring]
+  apply not_in_guarantee_lt_sInf
+  intro hmem
+  have hcontains : ContainsMonoAPofLength (shiftColoring N c) k := hmem _
+  have hhas : HasMonoAP (extend_coloring N (shiftColoring N c)) N k :=
+    contains_mono_ap_imp N k (by omega) _ hcontains
+  obtain ⟨a, d, hd, ha1, han, hmono⟩ := hhas
+  -- Build a monochromatic `vdwAP` for `c`, contradicting the first-moment bound.
+  have hMono : Mono (vdwAP N (a - 1) d k) c := by
+    refine ⟨c ((Nat.cast (a - 1)) : Fin N), ?_⟩
+    intro x hx
+    simp only [vdwAP, Finset.mem_image, Finset.mem_range] at hx
+    obtain ⟨i, hi, hfi⟩ := hx
+    -- membership of the relevant ℕ points in {1,…,N}
+    have hidd : i * d ≤ (k - 1) * d := Nat.mul_le_mul_right d (by omega)
+    have hmem_i : a + i * d ∈ Finset.Icc 1 N := by
+      rw [Finset.mem_Icc]; omega
+    have hmem_a : a ∈ Finset.Icc 1 N := by
+      rw [Finset.mem_Icc]; omega
+    -- the monochromaticity hypothesis at index i (base point a = a + 0·d)
+    have hmi := hmono i hi
+    rw [eval _ hmem_i, eval _ hmem_a] at hmi
+    -- cancel boolToFin2 and align the index shift (a + i·d) - 1 = (a-1) + i·d
+    have hcc :
+        c ((Nat.cast (a + i * d - 1)) : Fin N) = c ((Nat.cast (a - 1)) : Fin N) :=
+      boolToFin2_injective hmi
+    have hshift : a + i * d - 1 = a - 1 + i * d := by omega
+    rw [hshift] at hcc
+    rw [← hfi]
+    exact hcc
+  exact hc (a - 1) d (by omega) (by omega) hMono
+
+/-- **Clean power-of-two corollary.** For `k ≥ 2`, `2^((k-2)/2) < W k`.
+
+Instantiates `firstMoment_W_lower_bound` at `N = 2^((k-2)/2)`: then
+`N² = 2^(2⌊(k-2)/2⌋) ≤ 2^(k-2) < 2^(k-1)`. -/
+theorem firstMoment_W_pow_lower {k : ℕ} (hk : 2 ≤ k) :
+    2 ^ ((k - 2) / 2) < W k := by
+  apply firstMoment_W_lower_bound hk
+  have hsq : 2 ^ ((k - 2) / 2) * 2 ^ ((k - 2) / 2) = 2 ^ (2 * ((k - 2) / 2)) := by
+    rw [← pow_add]; congr 1; ring
+  rw [hsq]
+  have hle : 2 ^ (2 * ((k - 2) / 2)) ≤ 2 ^ (k - 2) :=
+    Nat.pow_le_pow_right (by norm_num) (by omega)
+  have hstep : 2 ^ (k - 2) < 2 ^ (k - 1) := by
+    have hk1 : k - 1 = (k - 2) + 1 := by omega
+    rw [hk1, pow_succ]
+    have hpos : 0 < 2 ^ (k - 2) := by positivity
+    omega
+  exact lt_of_le_of_lt hle hstep
+
+/-- **Honest strength gap (formal).** The first-moment lower bound has magnitude
+`≈ 2^((k-1)/2)`; the axiomatized Kozik–Shabanov bound has magnitude `≈ 2^k`.
+Comparing squares (to stay in clean integer exponents), `2^(k-1) / (2^k)² = 2^(k-1)/4^k`
+tends to `0`.  This certifies that the elementary first-moment bound is
+asymptotically negligible against the axiomatized bounds — hence it cannot
+eliminate `kozik_shabanov_lower_bound` or `berlekamp_lower_bound`; it only
+supplements them. -/
+theorem firstMoment_bound_negligible :
+    Tendsto (fun k : ℕ => ((2 : ℝ) ^ (k - 1)) / 4 ^ k) atTop (nhds 0) := by
+  apply squeeze_zero (fun k => by positivity) ?_
+    (tendsto_pow_atTop_nhds_zero_of_lt_one
+      (by norm_num : (0 : ℝ) ≤ 1 / 2) (by norm_num : (1 : ℝ) / 2 < 1))
+  intro k
+  have h1 : (2 : ℝ) ^ (k - 1) ≤ 2 ^ k :=
+    pow_le_pow_right₀ (by norm_num) (by omega)
+  have h4 : (0 : ℝ) < 4 ^ k := by positivity
+  rw [div_le_iff₀ h4]
+  have hmul : ((1 : ℝ) / 2) ^ k * 4 ^ k = 2 ^ k := by
+    rw [← mul_pow]; norm_num
+  rw [hmul]
+  exact h1
+
+end Erdos138

--- a/research/problems/van-der-waerden-first-moment-oq-03/knowledge.md
+++ b/research/problems/van-der-waerden-first-moment-oq-03/knowledge.md
@@ -1,0 +1,84 @@
+# Knowledge Base: van-der-waerden-first-moment-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+Goal: connect the **verified, axiom-free** first-moment bound `vdw_lower_bound`
+(in `VanDerWaerdenFirstMoment.lean`, namespace `ProbMethod.VanDerWaerden`) to the
+**axiom-heavy** `Erdos138Problem.lean` (namespace `Erdos138`), producing a
+machine-checked lower bound on `W k` and honestly documenting the strength gap to
+the axiomatized bounds.
+
+Key object reconciliation:
+- erdos-138 `W k = monoAPNumber 2 k = sInf (monoAP_guarantee_set 2 k)`, where
+  `monoAP_guarantee_set 2 k = { N | ∀ coloring : Finset.Icc 1 N → Fin 2,
+  ContainsMonoAPofLength coloring k }`. APs are the *set*-theoretic
+  `Set.IsAPOfLength` over the subtype `Finset.Icc 1 N`.
+- first-moment file works with `Fin n → Bool` colorings, `Mono` (monochromatic
+  Finset), and `vdwAP n a d k = (range k).image (i ↦ ((a + i·d : ℕ) : Fin n))`.
+
+## Insights
+
+- **The bridge machinery already exists inside erdos-138** — this was the crux
+  discovery. Two existing lemmas do the heavy lifting:
+  - `contains_mono_ap_imp (N k) (hk : k>0) (c : Finset.Icc 1 N → Fin 2) :
+    ContainsMonoAPofLength c k → HasMonoAP (extend_coloring N c) N k`
+    (set/subtype form ⇒ function form over ℕ). Its **contrapositive** turns
+    "no function-form mono AP" into "no set-form mono AP".
+  - `not_in_guarantee_lt_sInf (k N) : N ∉ monoAP_guarantee_set 2 k → N < W k`
+    (directly yields the `W` lower bound; internally uses `W_is_nonempty` +
+    `guarantee_upward_closed`).
+  So the whole task reduces to: produce a `Finset.Icc 1 N → Fin 2` coloring with
+  no function-form monochromatic AP, which is exactly what the first-moment
+  coloring gives after an index shift.
+
+- **The index shift is the only real "definitional friction".** erdos-138 uses
+  1-based `{1,…,N}` (`HasMonoAP` requires `a ≥ 1`); the first-moment file uses
+  0-based `Fin n`. Bridge: `shiftColoring N c v = boolToFin2 (c ((v-1 : ℕ) : Fin N))`.
+  A ℕ-AP `a + m·d` (a≥1, a+(k-1)d ≤ N) maps to `vdwAP N (a-1) d k` since
+  `(a + m·d) - 1 = (a-1) + m·d`, and the first-moment hypothesis
+  `(a-1) + (k-1)d < N` follows from `a + (k-1)d ≤ N` with `a ≥ 1`, `N > 0`.
+  Monochromaticity transfers via injectivity of `boolToFin2 : Bool → Fin 2`.
+
+- **Result delivered** (`Erdos138FirstMomentBridge.lean`, namespace `Erdos138`):
+  - `firstMoment_W_lower_bound : k ≥ 2 → N² < 2^(k-1) → N < W k`  — the first
+    *verified* (no new axioms) lower bound on `W` in the erdos-138 development.
+  - `firstMoment_W_pow_lower : k ≥ 2 → 2^((k-2)/2) < W k`  (clean corollary).
+  - `firstMoment_bound_negligible : Tendsto (k ↦ 2^(k-1)/4^k) atTop (𝓝 0)` —
+    the formal strength gap.
+
+- **No axiom is eliminated (honest).** The elementary bound `W(k) ≳ 2^((k-1)/2)`
+  is asymptotically dominated by the axiomatized `kozik_shabanov_lower_bound`
+  (`W(k) ≳ c·2^k`) and `berlekamp_lower_bound`. Comparing squares,
+  `2^(k-1)/(2^k)² = 2^(k-1)/4^k → 0`. So the contribution **supplements** the
+  axioms (adds a proven bound for the elementary regime) but cannot replace them.
+  This is the "approach B" outcome anticipated in problem.md, with the gap proved
+  rather than merely asserted.
+
+## Dead Ends
+
+- Attempting to reconcile `Set.IsAPOfLength` (with `ENat.card`, set images) with
+  `vdwAP` directly would be painful. **Do not** re-derive it: route through the
+  function-form `HasMonoAP` using `contains_mono_ap_imp`, which already contains
+  that reconciliation.
+
+## Verification Status (IMPORTANT — honest)
+
+- The Lean file `Erdos138FirstMomentBridge.lean` is written and has been
+  carefully reviewed by hand, but **was NOT machine-verified this session**:
+  the Docker build environment was unavailable — the host disk had filled to 100%
+  and Docker Desktop's containerd content store became corrupted (a referenced
+  blob went missing; `docker images`/`docker system df`/`prune` all fail with an
+  input/output error). `lake build` must never be run directly (memory blowup),
+  so Docker is the only sanctioned build path.
+- **Next action for whoever picks this up:** once Docker Desktop is restarted /
+  repaired, run `./proofs/scripts/docker-build.sh Proofs.Erdos138FirstMomentBridge`
+  and fix any lemma-name drift. Lower-risk core: `firstMoment_W_lower_bound`
+  (standard tactics + the source file's own idioms). Higher-risk: the analytic
+  `firstMoment_bound_negligible` (depends on names `pow_le_pow_right₀`,
+  `div_le_iff₀`, `tendsto_pow_atTop_nhds_zero_of_lt_one`, `squeeze_zero`).
+- The file is intentionally **NOT** registered in `Proofs.lean` until it builds
+  (keeps the safe aggregate build green).

--- a/research/problems/van-der-waerden-first-moment-oq-03/problem.md
+++ b/research/problems/van-der-waerden-first-moment-oq-03/problem.md
@@ -1,0 +1,133 @@
+# Problem: Integrate the Verified First-Moment van der Waerden Lower Bound into the erdos-138 Framework (Reduce Axiomatized Growth Statements)
+
+**Slug**: van-der-waerden-first-moment-oq-03
+**Created**: 2026-06-28T10:47:36-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The gallery proof `van-der-waerden-first-moment` establishes the *elementary*
+first-moment (union-bound) lower bound for van der Waerden numbers: roughly
+$$
+W(k) \gtrsim 2^{(k-1)/2},
+$$
+formalized as `vdw_lower_bound : n*n < 2^(k-1) → (good 2-coloring exists)` in
+`proofs/Proofs/VanDerWaerdenFirstMoment.lean` — a fully verified, axiom-free statement.
+Meanwhile `erdos-138` (`Erdos138Problem.lean`) axiomatizes **all** of its growth bounds,
+including `kozik_shabanov_lower_bound` ($W(k) \ge c\,2^k$) and `berlekamp_lower_bound`
+($W(p+1) \ge p\,2^p$). Goal: connect the verified first-moment bound to erdos-138 and
+replace reliance on an axiom by a machine-checked lower bound wherever the elementary
+bound is strong enough to do so.
+
+### Plain Language
+
+erdos-138 currently *assumes* (as axioms) every lower bound on how fast van der Waerden
+numbers grow. We already have a fully *proven* elementary lower bound in a separate file.
+This task is to plug that proven bound into the erdos-138 development so that at least one
+growth statement there stops being an axiom and becomes a theorem.
+
+### Why This Matters
+
+It reduces the axiom surface of a flagship gallery entry (erdos-138 has 8 axioms) by
+contributing a verified growth statement. Even a weaker-but-proven bound improves
+integrity over a stronger-but-axiomatized one for the regime it covers.
+
+## Known Results
+
+### What's Already Proven
+
+- `van-der-waerden-first-moment` — verified `vdw_lower_bound` (elementary $\sim 2^{k/2}$), axiom-free.
+- Mathlib `Combinatorics` van der Waerden existence (`Combinatorics.exists_mono_in_...`-style results).
+
+### What's Still Open / Honest Constraint
+
+- The elementary first-moment bound ($\sim 2^{k/2}$) is **weaker** than erdos-138's
+  axiomatized lower bounds (`kozik_shabanov_lower_bound` $\sim 2^k$, `berlekamp_lower_bound`).
+  It therefore **cannot** eliminate those specific stronger axioms.
+- The tractable target is to add a *verified* lower-bound theorem to erdos-138's
+  namespace (replacing the need to axiomatize the elementary regime) and to document
+  precisely the strength gap to the remaining axiomatized bounds.
+
+### Our Goal
+
+1. State and prove, inside / importable by `Erdos138Problem.lean`, a verified lower bound
+   on `W k` derived from `vdw_lower_bound` (no new axioms).
+2. Identify whether any existing erdos-138 axiom is subsumed by it; if none is, downgrade
+   the claim to "supplements" rather than "eliminates" and record the comparison.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| van-der-waerden-first-moment | Source of the verified bound | First-moment / union bound, `Finset` counting |
+| erdos-138 | Target framework with axiomatized growth bounds | Axioms `kozik_shabanov_lower_bound`, `berlekamp_lower_bound` |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — direct import**: Re-express `vdw_lower_bound` in terms of erdos-138's
+   `W` definition and add it as a theorem in that namespace.
+   - Why it might work: Both are about the same object `W k`; mostly a definitional bridge.
+   - Risk: Definitional mismatch between the two files' formulations of `W`.
+
+2. **Approach B — honest negative result**: If the verified bound subsumes no existing
+   axiom, prove the strength gap formally ($2^{k/2} = o(2^k)$) and document that the
+   axiomatized bounds remain necessary, contributing the verified bound as a new theorem.
+   - Why it might work: Always yields a publishable, honest outcome.
+   - Risk: Lower "wow" value, but high integrity.
+
+### Key Difficulties
+
+- Reconciling the two files' definitions of $W$ and of "valid coloring".
+- Avoiding overclaiming: the elementary bound does not match the axiomatized exponents.
+
+### What Would a Proof Need?
+
+- Key lemma 1: bridge `vdw_lower_bound`'s coloring-existence statement to a numeric lower bound on `W k`.
+- Key lemma 2: a definitional-equivalence lemma between the two `W` formulations.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The hard analytic content (the first-moment bound) is already verified.
+- Remaining work is a bridging/integration formalization with a guaranteed honest outcome.
+- Risk is definitional friction, not deep mathematics.
+
+**Estimated Effort**:
+- Exploration: 1 day
+- If tractable: 3–5 days
+- If hard: 1–2 weeks (definitional reconciliation)
+
+## References
+
+### Papers
+- Graham, Rothschild, Spencer, *Ramsey Theory* — van der Waerden number bounds.
+- Erdős, probabilistic (first-moment) lower bounds for Ramsey-type numbers.
+
+### Online Resources
+- Mathlib docs: `Mathlib.Combinatorics.vanDerWaerden` and related.
+
+### Mathlib
+- `Finset` counting / first-moment infrastructure already used in the source file.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - van-der-waerden
+  - first-moment
+  - axiom-elimination
+related_proofs:
+  - van-der-waerden-first-moment
+  - erdos-138
+difficulty: medium
+source: gallery-gap
+created: 2026-06-28T10:47:36-07:00
+```

--- a/research/problems/van-der-waerden-first-moment-oq-03/state.md
+++ b/research/problems/van-der-waerden-first-moment-oq-03/state.md
@@ -1,0 +1,37 @@
+# Research State: van-der-waerden-first-moment-oq-03
+
+## Current State
+**Phase**: ACT (proof drafted; verification blocked by infra)
+**Path**: full
+**Since**: 2026-06-28
+**Iteration**: 2
+
+## Current Focus
+Bridge `vdw_lower_bound` (verified, axiom-free) into the `Erdos138` namespace as a
+machine-checked lower bound on `W k`, and formally record the strength gap to the
+axiomatized bounds.
+
+## Active Approach
+Approach A (direct bridge) succeeded at the design level by reusing erdos-138's own
+`contains_mono_ap_imp` + `not_in_guarantee_lt_sInf`, combined with Approach B's
+honest strength-gap statement (`firstMoment_bound_negligible`). New file:
+`proofs/Proofs/Erdos138FirstMomentBridge.lean` (namespace `Erdos138`).
+
+## Attempt Count
+- Total attempts: 1 (this session)
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Blockers
+- **INFRA (not mathematical):** Docker build unavailable this session — host disk
+  filled to 100% and Docker Desktop's containerd content store corrupted (missing
+  blob; `docker images`/`prune` error out). Could not machine-verify. `lake build`
+  is forbidden directly. Needs a Docker Desktop restart to verify.
+
+## Next Action
+1. Restart/repair Docker Desktop.
+2. `./proofs/scripts/docker-build.sh Proofs.Erdos138FirstMomentBridge`.
+3. Fix any lemma-name drift (esp. in the analytic `firstMoment_bound_negligible`).
+4. Once green: register in `Proofs.lean` and, if desired, surface the verified
+   `W` lower bound in a short note on the `erdos-138` / `van-der-waerden-first-moment`
+   gallery entries (status stays `axiomatized` for erdos-138 — no axiom removed).


### PR DESCRIPTION
## Summary

Connects the **verified, axiom-free** first-moment bound `vdw_lower_bound`
(gallery entry `van-der-waerden-first-moment`) to the **axiom-heavy** `erdos-138`
development, producing the first *machine-checked* lower bound on the van der
Waerden number `W` inside the `Erdos138` namespace.

New file: `proofs/Proofs/Erdos138FirstMomentBridge.lean`

```
firstMoment_W_lower_bound : k ≥ 2 → N² < 2^(k-1) → N < W k        -- no new axioms
firstMoment_W_pow_lower   : k ≥ 2 → 2^((k-2)/2) < W k             -- clean corollary
firstMoment_bound_negligible : Tendsto (k ↦ 2^(k-1)/4^k) atTop (𝓝 0)  -- strength gap
```

## How it works

The bridge machinery already exists inside `erdos-138`:
- `contains_mono_ap_imp` — set/subtype-form mono AP ⇒ function-form `HasMonoAP`
  (its contrapositive lifts "no function-form AP" to "no set-form AP");
- `not_in_guarantee_lt_sInf` — `N ∉ monoAP_guarantee_set 2 k → N < W k`.

So the only new content is reconciling the 1-based `{1,…,N}` world with the
0-based `Fin n` world via `shiftColoring N c v = boolToFin2 (c ((v-1 : ℕ) : Fin N))`,
plus injectivity of `boolToFin2 : Bool → Fin 2`. A ℕ-AP `a + m·d` (`a ≥ 1`,
`a + (k-1)d ≤ N`) maps to `vdwAP N (a-1) d k`, contradicting the first-moment
guarantee.

## Honesty / scope

- **Eliminates NO existing axiom.** The elementary bound `W(k) ≳ 2^((k-1)/2)` is
  asymptotically dominated by `kozik_shabanov_lower_bound` (`~c·2^k`) and
  `berlekamp_lower_bound`. The new theorem **supplements** them with a proven
  bound for the elementary regime; the gap is itself proved
  (`firstMoment_bound_negligible`). This is the "approach B" outcome anticipated
  in the problem statement, with the gap formalized rather than asserted.
- `erdos-138` status stays **axiomatized** — unchanged by this PR.

## ⚠️ Verification status — BUILD-UNVERIFIED

This proof was **hand-reviewed but NOT machine-verified** this session: the host
disk hit 100% and Docker Desktop's containerd content store became corrupted
(referenced blob missing; `docker images` / `docker system df` / `prune` all fail
with input/output error). Per repo policy `lake build` must never be run directly,
so Docker is the only sanctioned build path and it is currently down.

**Before merge:** restart/repair Docker, then
`./proofs/scripts/docker-build.sh Proofs.Erdos138FirstMomentBridge` and fix any
lemma-name drift. Lowest-risk: `firstMoment_W_lower_bound` (standard tactics +
the source file's own idioms). Highest-risk: the analytic
`firstMoment_bound_negligible` (relies on `pow_le_pow_right₀`, `div_le_iff₀`,
`tendsto_pow_atTop_nhds_zero_of_lt_one`, `squeeze_zero`).

The file is intentionally **NOT** registered in `Proofs.lean` until it builds, to
keep the safe aggregate build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)