### PR TITLE
Enrich partition-theorem-oq-02: fix annotation styling + axiom-check note

### DIFF
--- a/src/data/proofs/partition-theorem-oq-02/annotations.json
+++ b/src/data/proofs/partition-theorem-oq-02/annotations.json
@@ -2,12 +2,12 @@
   {
     "id": "ann-docstring",
     "proofId": "partition-theorem-oq-02",
-    "range": { "startLine": 3, "endLine": 58 },
+    "range": { "startLine": 3, "endLine": 59 },
     "type": "context",
     "title": "Glaisher as a Bridge, Not a Target",
     "content": "Euler's theorem (#odd = #distinct) is the m=2 case of Glaisher's theorem: the number of partitions of n with no part divisible by m equals the number in which no part is used m or more times. Mathlib records both. This file uses Glaisher to study how A_m(n) := #(partitions with no part divisible by m) varies with the modulus m. The divisibility-restricted families are pairwise incomparable as sets, so monotonicity in m cannot be read off directly — it must be transported to the other side of Glaisher.",
     "mathContext": "$A_m(n)=\\#\\{\\lambda\\vdash n: m\\nmid \\lambda_i\\ \\forall i\\},\\quad B_m(n)=\\#\\{\\lambda\\vdash n: \\operatorname{mult}_\\lambda(i)<m\\ \\forall i\\},\\quad A_m(n)=B_m(n)$",
-    "significance": "context",
+    "significance": "supporting",
     "relatedConcepts": [
       "Euler partition theorem",
       "Glaisher's theorem",
@@ -22,12 +22,12 @@
   {
     "id": "ann-countRestricted-mono",
     "proofId": "partition-theorem-oq-02",
-    "range": { "startLine": 65, "endLine": 78 },
+    "range": { "startLine": 65, "endLine": 74 },
     "type": "lemma",
     "title": "The Repetition Family Is Nested",
     "content": "countRestricted_mono is the one genuine set containment in the file: if each part of a partition is used fewer than m times and m ≤ m', then each part is used fewer than m' times, so countRestricted n m ⊆ countRestricted n m'. Unfolding the filter definition reduces this to lt_of_lt_of_le on the per-part counts. All monotonicity downstream is borrowed from this nesting through Glaisher.",
     "mathContext": "$m\\le m' \\;\\Rightarrow\\; \\{\\lambda: \\operatorname{mult}_\\lambda(i)<m\\}\\subseteq\\{\\lambda: \\operatorname{mult}_\\lambda(i)<m'\\}$",
-    "significance": "high",
+    "significance": "key",
     "relatedConcepts": [
       "finset inclusion",
       "multiplicity",
@@ -41,12 +41,12 @@
   {
     "id": "ann-main",
     "proofId": "partition-theorem-oq-02",
-    "range": { "startLine": 80, "endLine": 95 },
+    "range": { "startLine": 76, "endLine": 92 },
     "type": "theorem",
     "title": "Modulus Monotonicity of the Divisibility Count",
     "content": "card_restricted_not_dvd_mono is the main result: for 0 < m ≤ m', A_m(n) ≤ A_{m'}(n). The proof rewrites both sides through Glaisher's equality card_restricted_eq_card_countRestricted to the repetition counts B_m(n), B_{m'}(n), then applies Finset.card_le_card to the nesting from countRestricted_mono. The striking point is that the divisibility families {no part divisible by m} are incomparable for different m — neither contains the other — so the inequality has no direct combinatorial witness; Glaisher's theorem is the indispensable bridge.",
     "mathContext": "$0<m\\le m'\\;\\Rightarrow\\; A_m(n)=B_m(n)\\le B_{m'}(n)=A_{m'}(n)$",
-    "significance": "high",
+    "significance": "critical",
     "relatedConcepts": [
       "Glaisher's theorem",
       "cardinality monotonicity",
@@ -61,12 +61,12 @@
   {
     "id": "ann-m3",
     "proofId": "partition-theorem-oq-02",
-    "range": { "startLine": 97, "endLine": 104 },
+    "range": { "startLine": 94, "endLine": 99 },
     "type": "theorem",
     "title": "The Named m = 3 Glaisher Case",
     "content": "card_not_dvd_three_eq_card_lt_three_repeats records the first classical generalization of Euler beyond the gallery's m=2 entry: partitions of n with no part divisible by 3 are equinumerous with partitions in which no part is used three or more times. It is the m=3 instance of Glaisher's theorem.",
     "mathContext": "$\\#\\{\\lambda\\vdash n: 3\\nmid\\lambda_i\\}=\\#\\{\\lambda\\vdash n:\\operatorname{mult}_\\lambda(i)<3\\}$",
-    "significance": "medium",
+    "significance": "supporting",
     "relatedConcepts": [
       "Glaisher's theorem",
       "modulus 3"
@@ -78,12 +78,12 @@
   {
     "id": "ann-euler-corollaries",
     "proofId": "partition-theorem-oq-02",
-    "range": { "startLine": 106, "endLine": 122 },
+    "range": { "startLine": 101, "endLine": 121 },
     "type": "theorem",
     "title": "Euler's Count Bounded by the No-Multiple-of-3 Count",
     "content": "card_odds_le_card_not_dvd_three specializes the monotonicity at 2 ≤ 3: since partitions into odd parts are exactly partitions avoiding multiples of 2 (odds = restricted (¬ 2 ∣ ·) via even_iff_two_dvd), their count is at most A_3(n). card_distincts_le_card_not_dvd_three restates this on the distinct-parts side using Euler's theorem #(odds n) = #(distincts n).",
     "mathContext": "$\\#(\\text{odd-part}) = \\#(\\text{distinct-part}) \\le A_3(n)$",
-    "significance": "medium",
+    "significance": "supporting",
     "relatedConcepts": [
       "Euler partition theorem",
       "odd parts",
@@ -92,6 +92,25 @@
     "prerequisites": [
       "Euler's partition theorem",
       "even_iff_two_dvd"
+    ]
+  },
+  {
+    "id": "ann-axiom-check",
+    "proofId": "partition-theorem-oq-02",
+    "range": { "startLine": 129, "endLine": 152 },
+    "type": "context",
+    "title": "Axiom-Free Certification",
+    "content": "The closing `#print axioms` commands certify the 0-axiom claim: the main monotonicity card_restricted_not_dvd_mono and the distinct-parts corollary card_distincts_le_card_not_dvd_three depend only on Lean's three foundational axioms (propext, Classical.choice, Quot.sound). Crucially there is no Lean.ofReduceBool (so no native_decide shortcut) and no sorryAx, so the entry's badge of original/verified is honest. The norm_num calls discharging 0 < 3 and 2 ≤ 3 reduce inside the kernel and add nothing to the axiom set.",
+    "mathContext": "$\\text{axioms} = \\{\\texttt{propext},\\ \\texttt{Classical.choice},\\ \\texttt{Quot.sound}\\}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "axiom integrity",
+      "kernel verification",
+      "Classical.choice"
+    ],
+    "prerequisites": [
+      "Lean 4 kernel",
+      "foundational axioms"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for **partition-theorem-oq-02** (annotations.json only; complements the meta.json enrichment already merged in #31475).

## Changes

1. **Fixed unstyled significance badges.** Three of five annotations used non-canonical `significance` values (`context`, `high`, `medium`). `AnnotationPanel`/`ProofLine` only style `critical | key | supporting` — other values fall through to an empty, unstyled badge (no label, no color). Normalized to `supporting`/`key`/`critical`/`supporting`/`supporting`.

2. **Tightened annotation line ranges** so each `startLine` lands on a real Lean construct (e.g. the main-theorem annotation now starts at its `/--` docstring, line 76, instead of mid-comment line 80). Verified with `pnpm annotations:validate --strict`: this entry reports **0 "No Lean construct" errors**.

3. **Added `ann-axiom-check`** documenting the closing `#print axioms` 0-axiom certification (only `propext` / `Classical.choice` / `Quot.sound`; no `Lean.ofReduceBool`, no `sorryAx`).

## Verification
- `pnpm gallery:check-size partition-theorem-oq-02` → within caps (~10 KB).
- `pnpm annotations:validate` (strict) → this entry clean.
- Only annotations.json changed; meta.json untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)