### PR TITLE
research(sperner-ndim-oq-02): total door-graph neighbour map gridNeighbor [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -1701,4 +1701,72 @@ theorem onFace_miss_imp_last (s : SpernerGrid.GridSimplex d N) (m : Fin (d + 1))
   by_contra hm
   exact absurd h (Nat.pos_iff_ne_zero.mp (miss_coord_pos_of_ne_last s m hm))
 
+/-!
+## The total door-graph neighbour map
+
+The interior/boundary dichotomy (`isInteriorFacet_or_boundary`,
+`not_isInteriorFacet_iff`) and the interior-facet existence datum
+(`exists_neighbor_of_isInteriorFacet`) are assembled here into a single
+`Option`-valued neighbour function on Freudenthal cells: an interior Kuhn facet `k`
+is sent to its glued pivot partner, and the two geometric boundary facets
+`0`, `Fin.last d` are sent to `none`.
+
+This is the concrete `adj`-shaped datum the abstract door-counting argument
+consumes.  Its `= none` fibre is *exactly* `{0, Fin.last d}`
+(`gridNeighbor_eq_none_iff`), so the index-level `boundary_face` bookkeeping reads
+off the facet index directly; on every interior facet it returns a genuine glued,
+distinct, facet-sharing neighbour (`gridNeighbor_spec`).  (The remaining content
+of `adj` — that a chain-boundary facet interior to `Δ_N` is glued *across* Kuhn
+chains — is the cross-chain frontier flagged in the module header and is not
+produced by `pivotSimplex`; this map records the within-chain pivot structure.)
+All 0-sorry; only the standard `Classical.choice` is used (to select the partner).
+-/
+
+/-- **Total neighbour map of the Freudenthal door graph.**  An interior facet `k`
+is sent to its glued pivot partner (chosen via `exists_neighbor_of_isInteriorFacet`);
+a boundary facet (`0` or `Fin.last d`) is sent to `none`. -/
+noncomputable def gridNeighbor (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    Option (SpernerGrid.GridSimplex d N) :=
+  if hk : IsInteriorFacet k then
+    some (Classical.choose (exists_neighbor_of_isInteriorFacet s hk))
+  else none
+
+/-- **The `none` fibre is exactly the geometric boundary.**  `gridNeighbor s k`
+returns `none` precisely at the two boundary facets `k ∈ {0, Fin.last d}`. -/
+theorem gridNeighbor_eq_none_iff (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    gridNeighbor s k = none ↔ IsBoundaryFacet k := by
+  unfold gridNeighbor
+  by_cases hk : IsInteriorFacet k
+  · simp only [dif_pos hk]
+    constructor
+    · intro h; exact absurd h (by simp)
+    · intro h; exact absurd hk (not_isInteriorFacet_of_boundary h)
+  · simp only [dif_neg hk]
+    exact iff_of_true trivial ((not_isInteriorFacet_iff k).mp hk)
+
+/-- **Interior facets get a genuine glued partner.**  On an interior facet `k` the
+neighbour map returns `some t` where `t` is a distinct cell glued to `s` and
+sharing the facet `k`. -/
+theorem gridNeighbor_spec (s : SpernerGrid.GridSimplex d N) {k : Fin (d + 1)}
+    (hk : IsInteriorFacet k) :
+    ∃ t : SpernerGrid.GridSimplex d N, gridNeighbor s k = some t ∧
+      GridGlued s t ∧ t ≠ s ∧ gridFacet t k = gridFacet s k := by
+  refine ⟨Classical.choose (exists_neighbor_of_isInteriorFacet s hk), ?_,
+    Classical.choose_spec (exists_neighbor_of_isInteriorFacet s hk)⟩
+  unfold gridNeighbor; rw [dif_pos hk]
+
+/-- A boundary facet is sent to `none` (the convenient direction of
+`gridNeighbor_eq_none_iff`). -/
+theorem gridNeighbor_boundary (s : SpernerGrid.GridSimplex d N) {k : Fin (d + 1)}
+    (hk : IsBoundaryFacet k) : gridNeighbor s k = none :=
+  (gridNeighbor_eq_none_iff s k).mpr hk
+
+/-- The neighbour map is defined (returns `some`) at exactly the interior facets. -/
+theorem gridNeighbor_isSome_iff (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    (gridNeighbor s k).isSome ↔ IsInteriorFacet k := by
+  rw [Option.isSome_iff_ne_none, ne_eq, gridNeighbor_eq_none_iff]
+  constructor
+  · intro h; exact (isInteriorFacet_or_boundary k).resolve_right h
+  · intro h hb; exact not_isInteriorFacet_of_boundary hb h
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1770,3 +1770,50 @@ no warnings (dep oleans SpernerNDim/SpernerGridBase in symlinked `.lake`).
    `GridGlued_symm`, `gridFacet_unique_neighbor`, `gridFacet_card`; supply `boundary_face` from
    `not_isInteriorFacet_zero/last`. Handle `d ≤ 1` base cases separately (orientation doubling).
 3. Phase 2: last-face door oddness by induction on `d`; apply `sperner_ndim`.
+
+## Session 2026-06-28 (researcher-3) — total door-graph neighbour map
+
+**Mode**: ACT (CONTINUE — executed next-step #1 "Define a total neighbour map on
+GridSimplex: interior facets → exists_neighbor_of_isInteriorFacet, boundary → none").
+**Outcome**: verified increment, no extra axioms. `SpernerNDimOQ02.lean` 1704→1772 L,
++1 noncomputable def +4 theorems. Single-file `LAKE_UNSAFE=1 ./bin/lake env lean
+Proofs/SpernerNDimOQ02.lean` → exit 0, no warnings. `#print axioms` on all four new
+theorems = `[propext, Classical.choice, Quot.sound]` (Classical.choice already pervades the
+file; no sorryAx, no Lean.ofReduceBool).
+
+### Delivered
+- **`gridNeighbor (s) (k) : Option (GridSimplex d N)`** — `if IsInteriorFacet k then
+  some (Classical.choose (exists_neighbor_of_isInteriorFacet s hk)) else none`. The concrete
+  `adj`-shaped within-chain neighbour datum.
+- **`gridNeighbor_eq_none_iff`** — the `none` fibre is *exactly* `{0, Fin.last d}` (via
+  `not_isInteriorFacet_iff` / `IsBoundaryFacet`). This is the index-level `boundary_face`
+  bookkeeping the door count needs.
+- **`gridNeighbor_spec`** — on an interior facet it returns `some t` with
+  `GridGlued s t ∧ t ≠ s ∧ gridFacet t k = gridFacet s k` (genuine distinct facet-sharing
+  partner), reusing `Classical.choose_spec`.
+- **`gridNeighbor_boundary`**, **`gridNeighbor_isSome_iff`** (defined ↔ interior).
+
+### Gotchas
+- In `gridNeighbor_eq_none_iff`, after `simp only [dif_neg hk]` the LHS `none = none`
+  defeq-reduces to `True`, so `iff_of_true rfl …` fails ("rfl has type ?=? expected True").
+  Use `iff_of_true trivial …` (robust to either `none = none` or `True`).
+- For `gridNeighbor_isSome_iff`, rewriting through `gridNeighbor_eq_none_iff` leaves
+  `¬ IsBoundaryFacet k ↔ IsInteriorFacet k`, NOT `¬ IsInteriorFacet k`, so a further
+  `rw [not_isInteriorFacet_iff]` can't fire. Discharge directly with the dichotomy:
+  `(isInteriorFacet_or_boundary k).resolve_right h` (→) and
+  `fun h hb => not_isInteriorFacet_of_boundary hb h` (←).
+- `gridNeighbor` must be `noncomputable` (uses `Classical.choose`).
+
+### Scope honesty
+This packages the **within-chain (pivot)** neighbour structure only. The genuine remaining
+frontier — a chain-boundary facet `k ∈ {0, Fin.last d}` that is interior to `Δ_N` is glued
+*across* Kuhn chains, which `pivotSimplex` does not produce — is unchanged (flagged in the
+module header). `gridNeighbor` sends every boundary facet to `none`; turning that into the
+true `adj` still needs the cross-chain gluing (or a proof such facets lie on `∂Δ_N`).
+
+### Next steps
+1. **(crux, unchanged)** Cross-chain gluing for boundary facets interior to `Δ_N`, OR prove
+   such facets lie on `∂Δ_N`; then `boundary_face` via `boundary_face_iff_coords_zero`.
+2. Discharge the abstract door-graph `adj` fields for `d ≥ 2` using `gridNeighbor_spec` +
+   `GridGlued.{ne,shares_facet}`, `GridGlued_symm`, `gridFacet_unique_neighbor`.
+3. Phase 2: last-face door oddness induction on `d`; apply `sperner_ndim`.


### PR DESCRIPTION
## Summary

Continues the multidimensional Sperner / Freudenthal door-counting program for `sperner-ndim-oq-02`. This PR executes the standing next-step #1 — *"define a total neighbour map on `GridSimplex`: interior facets → `exists_neighbor_of_isInteriorFacet`, boundary facets → `none`"* — assembling the existing interior/boundary dichotomy and the interior-facet existence datum into a single `Option`-valued neighbour function.

## What's new (`proofs/Proofs/SpernerNDimOQ02.lean`, 1704 → 1772 L)

- **`gridNeighbor (s) (k) : Option (GridSimplex d N)`** — an interior Kuhn facet `k` is sent to its glued pivot partner (selected via `Classical.choose (exists_neighbor_of_isInteriorFacet s hk)`); a boundary facet (`0` or `Fin.last d`) is sent to `none`.
- **`gridNeighbor_eq_none_iff`** — the `= none` fibre is *exactly* the two geometric boundary facets `{0, Fin.last d}` (the index-level `boundary_face` bookkeeping the door count consumes).
- **`gridNeighbor_spec`** — on an interior facet it returns `some t` with `GridGlued s t ∧ t ≠ s ∧ gridFacet t k = gridFacet s k` (a genuine distinct, facet-sharing neighbour).
- **`gridNeighbor_boundary`**, **`gridNeighbor_isSome_iff`** (defined ↔ interior).

## Scope (honest)

This records the **within-chain (pivot)** neighbour structure only. The genuine remaining frontier — a chain-boundary facet `k ∈ {0, Fin.last d}` that is interior to `Δ_N` is glued *across* Kuhn chains, which `pivotSimplex` does not produce — is **unchanged** and flagged in the module header. `gridNeighbor` sends every boundary facet to `none`; converting it into the true `adj` still requires the cross-chain gluing (or a proof that such facets lie on `∂Δ_N`).

## Verification

- Single-file: `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/SpernerNDimOQ02.lean` → exit 0, no warnings (Docker build host had transient containerd I/O faults this session; verified via the single-file path used by prior sessions, dep oleans `SpernerNDim`/`SpernerGridBase` present).
- `#print axioms` on all four new theorems: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`/native_decide. `Classical.choice` already pervades the file; 0 new axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)