### PR TITLE
Enrich cauchy-schwarz-oq-02-oq-02-oq-02: add annotations.json (Fourier/Legendre convergence rate)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-02-oq-02/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-02",
+    "range": { "startLine": 6, "endLine": 49 },
+    "type": "context",
+    "title": "From Bessel's inequality to convergence rates",
+    "content": "The parent entry (cauchy-schwarz-oq-02-oq-02) proves Bessel's inequality $\\sum_i \\|\\langle v_i,x\\rangle\\|^2 \\le \\|x\\|^2$ and that the coefficient series is summable. This file asks the quantitative question: how fast does the orthonormal partial sum $S\\,s = \\sum_{i\\in s} \\langle v_i,x\\rangle\\, v_i$ — the abstract Fourier/Legendre partial sum, equal to the orthogonal projection of $x$ onto $\\mathrm{span}\\{v_i : i \\in s\\}$ — converge to $x$? Every later result is a consequence of one identity that Mathlib proves but never exports.",
+    "mathContext": "$S\\,s = \\sum_{i\\in s}\\langle v_i,x\\rangle\\, v_i = \\mathrm{proj}_{\\,\\mathrm{span}\\{v_i\\}}\\,x$; goal: control $\\|x - S\\,s\\|$ as $s$ grows.",
+    "significance": "supporting",
+    "relatedConcepts": ["Bessel's inequality", "orthogonal projection", "Fourier series", "Parseval's identity"],
+    "prerequisites": ["inner product spaces", "orthonormal families", "infinite sums (tsum)"]
+  },
+  {
+    "id": "ann-partialsum-def",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-02",
+    "range": { "startLine": 61, "endLine": 66 },
+    "type": "definition",
+    "title": "The orthonormal partial sum",
+    "content": "`partialSum 𝕜 v x s` is $\\sum_{i\\in s} \\langle v_i,x\\rangle \\cdot v_i$, the orthogonal projection of $x$ onto the span of the chosen basis vectors. The field `𝕜` (ℝ or ℂ, via `RCLike`) is an explicit argument because the coefficients $\\langle v_i,x\\rangle$ live in `𝕜` while the sum lives in `E`, so `𝕜` cannot be inferred from the result type — a recurring subtlety when formalizing inner-product constructions over a general `RCLike` field.",
+    "mathContext": "$\\mathrm{partialSum}\\,\\mathbb{k}\\,v\\,x\\,s = \\sum_{i\\in s}\\langle v_i,x\\rangle\\cdot v_i \\in E$",
+    "significance": "supporting",
+    "relatedConcepts": ["orthogonal projection", "RCLike field", "finite sums over a Finset"],
+    "prerequisites": ["Finset.sum", "scalar multiplication in a module"]
+  },
+  {
+    "id": "ann-error-identity",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-02",
+    "range": { "startLine": 72, "endLine": 92 },
+    "type": "theorem",
+    "title": "The error identity Mathlib hides",
+    "content": "`norm_sub_partialSum_sq` is the keystone: $\\|x - S\\,s\\|^2 = \\|x\\|^2 - \\sum_{i\\in s}\\|\\langle v_i,x\\rangle\\|^2$. Mathlib proves exactly this as an unnamed `suffices` step buried inside `Orthonormal.sum_inner_products_le` (its proof of Bessel's inequality) but never names it. Extracting it converts every convergence-rate question into an elementary statement about the partial sums of the non-negative Bessel series. The proof expands $\\|x - S\\,s\\|^2$ via `norm_sub_sq`, collapses the orthonormality double sum with `Orthonormal.inner_left_right_finset`, and identifies $\\mathrm{re}(z\\,\\bar z) = \\|z\\|^2$.",
+    "mathContext": "$\\|x - S\\,s\\|^2 = \\|x\\|^2 - \\sum_{i\\in s}\\|\\langle v_i,x\\rangle\\|^2$",
+    "significance": "critical",
+    "relatedConcepts": ["polarization / norm_sub_sq", "orthonormality collapse", "Bessel series"],
+    "prerequisites": ["Orthonormal.inner_left_right_finset", "InnerProductSpace.norm_sq_eq_re_inner"]
+  },
+  {
+    "id": "ann-bessel-finite",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-02",
+    "range": { "startLine": 94, "endLine": 99 },
+    "type": "theorem",
+    "title": "Bessel's finite inequality, in one line",
+    "content": "`partialSum_isBestApprox_le` recovers the finite Bessel inequality $\\sum_{i\\in s}\\|\\langle v_i,x\\rangle\\|^2 \\le \\|x\\|^2$ as an immediate corollary of the error identity together with $\\|x - S\\,s\\|^2 \\ge 0$: the subtracted Bessel sum can never exceed $\\|x\\|^2$, since the difference is a squared norm. `nlinarith` closes it from the identity and `sq_nonneg`.",
+    "mathContext": "$\\sum_{i\\in s}\\|\\langle v_i,x\\rangle\\|^2 \\le \\|x\\|^2$ (finite Bessel)",
+    "significance": "supporting",
+    "relatedConcepts": ["Bessel's inequality", "norm non-negativity"],
+    "prerequisites": ["the error identity", "sq_nonneg"]
+  },
+  {
+    "id": "ann-monotone",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-02",
+    "range": { "startLine": 105, "endLine": 114 },
+    "type": "insight",
+    "title": "The approximation never regresses",
+    "content": "`sq_error_antitone`: for $s \\subseteq t$, the squared error over $t$ is at most that over $s$. Because every term $\\|\\langle v_i,x\\rangle\\|^2$ is non-negative, enlarging the index set only adds to the subtracted Bessel sum, so the error can only shrink — by exactly the squared coefficients of the freshly added basis vectors. This is the structural reason the orthonormal partial sum is a genuine best approximation that improves monotonically as the basis grows.",
+    "mathContext": "$s \\subseteq t \\Rightarrow \\|x - S\\,t\\|^2 \\le \\|x - S\\,s\\|^2$",
+    "significance": "key",
+    "relatedConcepts": ["monotone best approximation", "Finset.sum_le_sum_of_subset_of_nonneg"],
+    "prerequisites": ["the error identity", "monotonicity of finite sums"]
+  },
+  {
+    "id": "ann-tendsto-defect",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-02",
+    "range": { "startLine": 120, "endLine": 132 },
+    "type": "theorem",
+    "title": "Convergence to the Parseval defect",
+    "content": "`tendsto_sq_error`: along the directed set of finite index sets (the `atTop` filter on `Finset ι`), the squared error converges to the Parseval defect $\\|x\\|^2 - \\sum'_i \\|\\langle v_i,x\\rangle\\|^2$. The proof uses that the squared coefficients are summable (`Orthonormal.inner_products_summable`), so the partial Bessel sums tend to their `tsum`; subtracting from the constant $\\|x\\|^2$ via the error identity gives the limit. The defect is the irreducible squared error — the squared distance from $x$ to the closed span of the system.",
+    "mathContext": "$\\|x - S\\,s\\|^2 \\to \\|x\\|^2 - \\sum'_i \\|\\langle v_i,x\\rangle\\|^2$ as $s \\uparrow$",
+    "significance": "key",
+    "relatedConcepts": ["convergence along the finite-subsets filter", "Parseval defect", "HasSum"],
+    "prerequisites": ["Orthonormal.inner_products_summable", "Tendsto / atTop on Finset"]
+  },
+  {
+    "id": "ann-parseval-iff",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-02",
+    "range": { "startLine": 134, "endLine": 146 },
+    "type": "theorem",
+    "title": "Convergence ⟺ Parseval (completeness)",
+    "content": "`tendsto_partialSum_iff_parseval`: the partial sums converge to $x$ in norm if and only if Parseval's identity $\\sum'_i \\|\\langle v_i,x\\rangle\\|^2 = \\|x\\|^2$ holds — i.e. the orthonormal system is complete at $x$. The forward direction uses uniqueness of limits (`tendsto_nhds_unique`) against `tendsto_sq_error`: a defect of $0$ forces Parseval; conversely Parseval makes the defect vanish, so the error tends to $0$.",
+    "mathContext": "$\\|x - S\\,s\\|^2 \\to 0 \\iff \\sum'_i \\|\\langle v_i,x\\rangle\\|^2 = \\|x\\|^2$",
+    "significance": "key",
+    "relatedConcepts": ["Parseval's identity", "completeness of an orthonormal system", "uniqueness of limits"],
+    "prerequisites": ["tendsto_nhds_unique", "tendsto_sq_error"]
+  },
+  {
+    "id": "ann-tail-under-parseval",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-02",
+    "range": { "startLine": 154, "endLine": 163 },
+    "type": "insight",
+    "title": "Under Parseval the error is the coefficient tail",
+    "content": "`sq_error_eq_tail_of_parseval`: for an ℕ-indexed complete system, the squared error after the first $n$ terms equals the tail of the Bessel series, $\\sum'_k \\|\\langle v_{k+n},x\\rangle\\|^2$. This is the precise object a convergence rate bounds — it says the convergence rate of the partial sums is inherited verbatim from the decay rate of the coefficients. The proof splits the series into head and tail with `Summable.sum_add_tsum_nat_add` and substitutes Parseval.",
+    "mathContext": "$\\|x - S(\\mathrm{range}\\,n)\\|^2 = \\sum'_{k}\\|\\langle v_{k+n},x\\rangle\\|^2$ (under Parseval)",
+    "significance": "key",
+    "relatedConcepts": ["series head/tail split", "coefficient decay", "convergence rate"],
+    "prerequisites": ["Summable.sum_add_tsum_nat_add", "the error identity"]
+  },
+  {
+    "id": "ann-geometric-rate",
+    "proofId": "cauchy-schwarz-oq-02-oq-02-oq-02",
+    "range": { "startLine": 165, "endLine": 189 },
+    "type": "theorem",
+    "title": "Geometric decay ⇒ geometric convergence",
+    "content": "`geometric_rate` is the headline quantitative result: under Parseval, if the squared coefficients decay geometrically $\\|\\langle v_i,x\\rangle\\|^2 \\le C r^i$ with $0 \\le r < 1$, then $\\|x - S(\\mathrm{range}\\,n)\\|^2 \\le C r^n/(1-r)$. The tail (from the previous lemma) is dominated termwise (`Summable.tsum_le_tsum`) by the geometric series $\\sum_k C r^{k+n}$, whose closed value $C r^n (1-r)^{-1}$ comes from `tsum_geometric_of_lt_one`. This is the abstract reason analytic/smooth functions have exponentially convergent Fourier and Legendre expansions — geometric coefficient decay is the signature of analyticity.",
+    "mathContext": "$\\|\\langle v_i,x\\rangle\\|^2 \\le C r^i \\;(0\\le r<1) \\Rightarrow \\|x - S(\\mathrm{range}\\,n)\\|^2 \\le \\dfrac{C r^n}{1-r}$",
+    "significance": "critical",
+    "relatedConcepts": ["geometric series", "exponential convergence", "analytic functions", "Legendre/Chebyshev expansions"],
+    "prerequisites": ["Summable.tsum_le_tsum", "tsum_geometric_of_lt_one", "sq_error_eq_tail_of_parseval"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for **cauchy-schwarz-oq-02-oq-02-oq-02** — "Rate of Convergence for Orthonormal Expansions (Fourier, Legendre)" — a fresh research entry that shipped with a rich meta.json but **no annotations.json** (quality 43).

## Change
Adds `annotations.json` with **9 inline annotations**:
- module overview (Bessel → convergence rates)
- the `partialSum` definition (orthogonal projection; the explicit `𝕜` subtlety)
- `norm_sub_partialSum_sq` — the error identity Mathlib hides (critical)
- `partialSum_isBestApprox_le` — finite Bessel inequality
- `sq_error_antitone` — monotone improvement
- `tendsto_sq_error` — convergence to the Parseval defect
- `tendsto_partialSum_iff_parseval` — convergence ⟺ Parseval
- `sq_error_eq_tail_of_parseval` — error = coefficient tail
- `geometric_rate` — geometric decay ⇒ geometric convergence (critical)

Each annotation has `mathContext` (LaTeX), canonical `significance` (`critical|key|supporting`), `relatedConcepts`, and `prerequisites`.

## Verification
- JSON parses; 9 annotations.
- `pnpm annotations:validate` (strict): **0 "No Lean construct" errors** for this entry (every startLine lands on a docstring/def/theorem).
- meta.json untouched. No `index.ts` created (obsolete; this dir, like its siblings, uses the glob loader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)