### PR TITLE
research(birthday-problem-oq-02-oq-01-oq-03): strict monotonicity + pigeonhole certainty [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/BirthdayProblemOQ02OQ01OQ03.lean
@@ -133,4 +133,80 @@ theorem collisionProb_le_one {k d : ℕ} (hd : 0 < d) (hk : k ≤ d + 1) :
   have := birthdayProduct_nonneg hd hk
   linarith
 
+/-! ## Strict monotonicity and the pigeonhole certainty
+
+The monotonicity above is non-strict.  In the genuinely interesting range
+`1 ≤ k ≤ d` the all-distinct probability is in fact **strictly** positive and
+**strictly** decreasing: each added person multiplies by a factor `1 − k/d` that
+is strictly below `1`, so the collision probability strictly increases.  Past the
+pigeonhole threshold (`k > d`) a collision is *certain*: the factor `1 − d/d = 0`
+kills the product, giving `collisionProb = 1`. -/
+
+/-- Each factor `1 − i/d` is **strictly** positive when `i < d`. -/
+theorem factor_pos {d : ℕ} (hd : 0 < d) {i : ℕ} (hi : i < d) :
+    0 < 1 - (i : ℝ) / d := by
+  have hd' : (0 : ℝ) < d := by exact_mod_cast hd
+  have : (i : ℝ) / d < 1 := by rw [div_lt_one hd']; exact_mod_cast hi
+  linarith
+
+/-- `P(all distinct)` is **strictly positive** while there are no more people than
+days (`k ≤ d`): every factor `1 − i/d` with `i < k ≤ d` is strictly positive. -/
+theorem birthdayProduct_pos {k d : ℕ} (hd : 0 < d) (hk : k ≤ d) :
+    0 < birthdayProduct k d := by
+  apply Finset.prod_pos
+  intro i hi
+  rw [Finset.mem_range] at hi
+  exact factor_pos hd (by omega)
+
+/-- **One-step strict monotonicity.** For `0 < k ≤ d`, adding one more person
+*strictly* lowers `P(all distinct)`: `P(k+1) < P(k)` (the factor `1 − k/d < 1`
+multiplies a strictly positive quantity). -/
+theorem birthdayProduct_step_lt {k d : ℕ} (hd : 0 < d) (hk0 : 0 < k) (hk : k ≤ d) :
+    birthdayProduct (k + 1) d < birthdayProduct k d := by
+  rw [birthdayProduct_succ]
+  have hpos : 0 < birthdayProduct k d := birthdayProduct_pos hd hk
+  have hkr : (0 : ℝ) < k := by exact_mod_cast hk0
+  have hdr : (0 : ℝ) < d := by exact_mod_cast hd
+  have hfac : 1 - (k : ℝ) / d < 1 := by
+    have : 0 < (k : ℝ) / d := div_pos hkr hdr
+    linarith
+  calc birthdayProduct k d * (1 - (k : ℝ) / d)
+      < birthdayProduct k d * 1 := mul_lt_mul_of_pos_left hfac hpos
+    _ = birthdayProduct k d := mul_one _
+
+/-- **`P(all distinct)` is strictly decreasing** on `1 ≤ · ≤ d`: if `0 < j < k ≤ d`
+then `P(k) < P(j)`. -/
+theorem birthdayProduct_strict_lt {d : ℕ} (hd : 0 < d) {j k : ℕ}
+    (hj : 0 < j) (hjk : j < k) (hk : k ≤ d) :
+    birthdayProduct k d < birthdayProduct j d :=
+  lt_of_le_of_lt
+    (birthdayProduct_antitone hd hjk hk)
+    (birthdayProduct_step_lt hd hj (by omega))
+
+/-- **The strict monotone birthday paradox.** For `0 < j < k ≤ d` the collision
+probability *strictly* increases with the number of people:
+`collisionProb j d < collisionProb k d`. -/
+theorem collisionProb_strict_lt {d : ℕ} (hd : 0 < d) {j k : ℕ}
+    (hj : 0 < j) (hjk : j < k) (hk : k ≤ d) :
+    collisionProb j d < collisionProb k d := by
+  unfold collisionProb
+  have := birthdayProduct_strict_lt hd hj hjk hk
+  linarith
+
+/-- **Pigeonhole.** With more people than days (`d < k`), `P(all distinct) = 0`:
+the factor `1 − d/d = 0` occurs in the product. -/
+theorem birthdayProduct_eq_zero_of_gt {k d : ℕ} (hd : 0 < d) (hk : d < k) :
+    birthdayProduct k d = 0 := by
+  unfold birthdayProduct
+  have hdr : (d : ℝ) ≠ 0 := by exact_mod_cast hd.ne'
+  refine Finset.prod_eq_zero (i := d) (Finset.mem_range.mpr hk) ?_
+  rw [div_self hdr]; ring
+
+/-- **Pigeonhole certainty.** With more people than days (`d < k`) a collision is
+*certain*: `collisionProb k d = 1`. -/
+theorem collisionProb_eq_one_of_gt {k d : ℕ} (hd : 0 < d) (hk : d < k) :
+    collisionProb k d = 1 := by
+  unfold collisionProb
+  rw [birthdayProduct_eq_zero_of_gt hd hk]; ring
+
 end BirthdayProblemOQ02OQ01OQ03

--- a/research/problems/birthday-problem-oq-02-oq-01-oq-03/knowledge.md
+++ b/research/problems/birthday-problem-oq-02-oq-01-oq-03/knowledge.md
@@ -41,3 +41,36 @@ antitone. Globalize by `Nat.le_induction`. Complement gives collision monotone.
 - Attempted to import the parent for the exponential bound: blocked (parent does
   not compile). Self-contained monotonicity needs only the product recurrence, so
   the dependency was unnecessary.
+
+## Session 2026-06-28 (researcher-3) — strict monotonicity + pigeonhole certainty
+
+**Mode**: ACT. The headline (non-strict monotonicity, boundary, well-formedness) was already
+complete & 0-axiom, so this session added the two classic facts the file lacked. **Outcome**:
+verified increment. `BirthdayProblemOQ02OQ01OQ03.lean` 136→212 L, +7 theorems, 0-axiom
+(`#print axioms` = propext/Classical.choice/Quot.sound). Single-file `lake env lean` exit 0.
+File imports only Mathlib (no project dep oleans needed).
+
+### Delivered
+- `factor_pos` (i < d → 0 < 1 − i/d) and `birthdayProduct_pos` (k ≤ d → 0 < P): P(all
+  distinct) is strictly positive in the meaningful range.
+- `birthdayProduct_step_lt` (0 < k ≤ d → P(k+1) < P(k)) — strict one-step via
+  `mul_lt_mul_of_pos_left` (factor < 1 on a strictly positive product).
+- `birthdayProduct_strict_lt` (0 < j < k ≤ d → P(k) < P(j)) — glued from the non-strict
+  `birthdayProduct_antitone` (j+1 ≤ k) and the strict step at j: `lt_of_le_of_lt`.
+- `collisionProb_strict_lt` — **strict** monotone birthday paradox (strengthens the existing
+  non-strict `collisionProb_monotone`).
+- `birthdayProduct_eq_zero_of_gt` (d < k → P = 0) via `Finset.prod_eq_zero` at i = d
+  (`1 − d/d = 0`, `div_self`); `collisionProb_eq_one_of_gt` (d < k → collision = 1) —
+  **pigeonhole certainty**.
+
+### Gotchas
+- `birthdayProduct_antitone` expects `j + 1 ≤ k`; pass `(by omega)` from `j < k` rather than
+  relying on Nat.lt defeq.
+- `positivity` will NOT prove `0 < (k:ℝ)/d` from `0 < k` (ℕ) — cast first
+  (`exact_mod_cast`) then `div_pos`.
+
+### Status
+Formal target (monotonicity + boundary + well-formedness) was already fully proved; this
+strengthens it to strict and adds the pigeonhole-certain regime. Problem is essentially
+complete; remaining directions would be the exponential two-sided estimates (parent
+OQ-02-OQ-01 file, which is BROKEN vs current Mathlib — deprecated `div_le_iff` etc.).


### PR DESCRIPTION
## Summary

The non-strict *monotone birthday paradox* (`collisionProb_monotone`) together with the boundary and well-formedness facts was already complete and 0-axiom in this file. This PR adds the two classic facts it lacked, both verified and 0-axiom.

## What's new (`proofs/Proofs/BirthdayProblemOQ02OQ01OQ03.lean`, 136 → 212 L)

**Strict monotonicity** (strengthening the existing non-strict result):
- `factor_pos` / `birthdayProduct_pos` — `P(all distinct)` is *strictly* positive while `k ≤ d`.
- `birthdayProduct_step_lt` — for `0 < k ≤ d`, one more person *strictly* lowers `P(all distinct)` (the factor `1 − k/d < 1` multiplies a strictly positive product).
- `birthdayProduct_strict_lt` — `P(all distinct)` is strictly decreasing on `1 ≤ · ≤ d`.
- `collisionProb_strict_lt` — **the strict monotone birthday paradox**: for `0 < j < k ≤ d`, `collisionProb j d < collisionProb k d`.

**Pigeonhole certainty** (the regime past `k = d`):
- `birthdayProduct_eq_zero_of_gt` — with more people than days (`d < k`), `P(all distinct) = 0` (the factor `1 − d/d = 0` occurs in the product).
- `collisionProb_eq_one_of_gt` — hence a collision is *certain*: `collisionProb k d = 1`.

These round out the monotonicity story end-to-end: strictly increasing collision risk on `[1, d]`, then identically `1` once the pigeonhole threshold is crossed.

## Verification

- Single-file: `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/BirthdayProblemOQ02OQ01OQ03.lean` → exit 0 (file imports only Mathlib; Docker build host had transient containerd I/O faults this session, so verified via the single-file path against the prebuilt Mathlib cache).
- `#print axioms` on the new theorems: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`/native_decide. 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)