### PR TITLE
research(prob-method-expectation-oq-04): reduce Erdős <1 bound to a pure power inequality [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ProbMethodExpectationOQ04.lean
+++ b/proofs/Proofs/ProbMethodExpectationOQ04.lean
@@ -80,4 +80,50 @@ theorem first_moment_le (hs : s.Nonempty) (havg : (s.sum f) / s.card ≤ t) :
   obtain ⟨a, ha, hfa⟩ := exists_le_average hs
   exact ⟨a, ha, le_trans hfa havg⟩
 
+/-! ## Application: strengthening `expected_mono_cliques` toward Erdős 1947
+
+The parent gallery lemma `expected_mono_cliques` only records that the expected
+number of monochromatic `k`-cliques in a uniformly random 2-colouring of the edges
+of `Kₙ`, namely `E(n,k) = C(n,k)·2^{1−C(k,2)}`, is `≥ 0`.  The open question OQ-04
+asks to strengthen this to `E(n,k) < 1` — which, by the (strict) first moment
+principle, exhibits a 2-colouring with **no** monochromatic `k`-clique, i.e. the
+Erdős 1947 lower bound `R(k,k) > n`.
+
+This section makes two verified reductions toward that goal: it removes the integer
+`zpow` by reducing `E < 1` to a clean `ℕ`-power inequality, and it records the
+first-moment upper bound `E ≤ (nᵏ/k!)·2^{1−C(k,2)}` (via `Nat.choose_le_pow_div`),
+the quantity Erdős's counting argument actually bounds below `1`. -/
+
+/-- The expected number of monochromatic `k`-cliques in a uniformly random
+2-colouring of `Kₙ`'s edges: `C(n,k) · 2^{1 − C(k,2)}` (matching the parent
+`expected_mono_cliques`). -/
+noncomputable def expectedMonoCliques (n k : ℕ) : ℚ :=
+  (n.choose k : ℚ) * (2 : ℚ) ^ (1 - (k.choose 2 : ℤ))
+
+/-- **Reduction of the Erdős strict bound to a pure power inequality.**  The
+expected count is `< 1` *exactly* when `C(n,k)·2 < 2^{C(k,2)}` — a statement
+entirely in `ℕ`-powers, with the integer `zpow` eliminated.  This is the clean
+target a later session (or `Aristotle`) must discharge to answer OQ-04. -/
+theorem expectedMonoCliques_lt_one_iff (n k : ℕ) :
+    expectedMonoCliques n k < 1 ↔ (n.choose k : ℚ) * 2 < 2 ^ (k.choose 2) := by
+  unfold expectedMonoCliques
+  have hpow_pos : (0 : ℚ) < (2 : ℚ) ^ (k.choose 2) := by positivity
+  rw [sub_eq_add_neg, zpow_add₀ (by norm_num : (2 : ℚ) ≠ 0), zpow_one, zpow_neg,
+    zpow_natCast,
+    show (n.choose k : ℚ) * (2 * ((2 : ℚ) ^ (k.choose 2))⁻¹)
+        = ((n.choose k : ℚ) * 2) / (2 : ℚ) ^ (k.choose 2) from by rw [div_eq_mul_inv]; ring,
+    div_lt_one hpow_pos]
+
+/-- **First-moment upper bound on the expected count.**  Since `C(n,k) ≤ nᵏ/k!`
+(`Nat.choose_le_pow_div`), the expected number of monochromatic `k`-cliques is at
+most `(nᵏ/k!) · 2^{1 − C(k,2)}`.  Isolating this quantity reduces OQ-04 to the
+elementary estimate `nᵏ · 2 < k! · 2^{C(k,2)}`. -/
+theorem expectedMonoCliques_le (n k : ℕ) :
+    expectedMonoCliques n k
+      ≤ ((n : ℚ) ^ k / (k.factorial : ℚ)) * (2 : ℚ) ^ (1 - (k.choose 2 : ℤ)) := by
+  unfold expectedMonoCliques
+  apply mul_le_mul_of_nonneg_right _ (zpow_nonneg (by norm_num : (0 : ℚ) ≤ 2) _)
+  have h := Nat.choose_le_pow_div k n (α := ℚ)
+  simpa using h
+
 end ProbMethod.ExpectationOQ04

--- a/research/problems/prob-method-expectation-oq-04/knowledge.md
+++ b/research/problems/prob-method-expectation-oq-04/knowledge.md
@@ -15,3 +15,39 @@
 ## Promising Leads
 
 (None yet.)
+
+## Session 2026-06-28 (researcher-3) — Erdős <1 reduction stepping stones [OBSERVE/ORIENT]
+
+**Mode**: OBSERVE→ORIENT. The problem.md question is the Erdős 1947 strengthening
+("strengthen `expected_mono_cliques` to show the count is `< 1` for `n < 2^(k/2)`"); the
+parent `ProbMethodExpectation.expected_mono_cliques` only proves the count `≥ 0` (trivial)
+and `erdos_ramsey_lower_bound` is a VACUOUS existence (`∃ n, n ≥ 2^(k/2)`), not the
+probabilistic-method bound. The full `< 1` proof is a hard multi-session formalization
+(needs `C(n,k) ≤ n^k/k!`, a `k!` growth bound, and exponent arithmetic complicated by the
+ℕ floor division in `2^(k/2)`). This session delivered verified **reductions**, not the
+full bound.
+
+### Delivered (in `ProbMethodExpectationOQ04.lean`, 83→129 L, 0-axiom)
+- `expectedMonoCliques (n k) := (n.choose k : ℚ) * 2^(1 - (k.choose 2 : ℤ))` — names the
+  parent's expected count.
+- **`expectedMonoCliques_lt_one_iff`**: `E(n,k) < 1 ↔ (n.choose k : ℚ)*2 < 2^(k.choose 2)`.
+  Eliminates the integer `zpow`; the RHS is a clean ℕ-power inequality — the exact target a
+  future session / Aristotle must discharge.
+- **`expectedMonoCliques_le`**: `E(n,k) ≤ (n^k/k!)·2^(1-C(k,2))` via `Nat.choose_le_pow_div`.
+  Reduces OQ-04 to the elementary estimate `n^k·2 < k!·2^{C(k,2)}`.
+
+### Key Mathlib API found
+- `Nat.choose_le_pow_div (r n : ℕ) : (n.choose r : α) ≤ (n^r : α)/r!` (ordered field α).
+- zpow split: `zpow_add₀ (h : a ≠ 0)`, `zpow_one`, `zpow_neg`, `zpow_natCast`; then
+  `div_lt_one (hpos)` to turn `X/Y < 1` into `X < Y`.
+
+### Remaining (the real crux)
+Prove `(n.choose k : ℚ)*2 < 2^(k.choose 2)` (equiv. `n^k·2 < k!·2^{k(k-1)/2}`) under
+`n < 2^(k/2)`, `k ≥ 3`. The crude `C(n,k) ≤ n^k` is too weak (fails for even k); must use
+`C(n,k) ≤ n^k/k!` and `k! > 2^{1+k/2}`. Watch: `2^(k/2)` uses ℕ floor division → `n^k <
+2^{k·⌊k/2⌋}`, NOT `2^{k²/2}`. Good Aristotle candidate once stated purely in ℕ.
+
+### Note
+The json `formalStatement` (non-strict averaging "some outcome meets the mean") was ALREADY
+fully proved & 0-axiom in this file (exists_ge_average etc.); the problem.md Ramsey question
+is the genuinely open one and is what this session targets.


### PR DESCRIPTION
## Summary

OQ-04 asks to strengthen the gallery lemma `expected_mono_cliques` — which currently only proves the expected monochromatic-`k`-clique count is `≥ 0` — to the **Erdős 1947** statement that the count is `< 1` for `n < 2^(k/2)` (yielding `R(k,k) > n` by the first moment method). The full bound is a substantial multi-session formalization (it needs `C(n,k) ≤ nᵏ/k!`, a factorial growth bound, and exponent arithmetic complicated by the ℕ floor division in `2^(k/2)`). This PR delivers two **verified reductions** toward it, on a problem that previously had no recorded facts.

## What's new (`proofs/Proofs/ProbMethodExpectationOQ04.lean`, 83 → 129 L)

- **`expectedMonoCliques (n k) := (n.choose k : ℚ) * 2^(1 − (k.choose 2 : ℤ))`** — names the parent's expected count.
- **`expectedMonoCliques_lt_one_iff`** — `E(n,k) < 1  ↔  (n.choose k : ℚ)·2 < 2^(k.choose 2)`. Eliminates the integer `zpow`; the RHS is a clean **ℕ-power inequality** — the exact target a later session (or Aristotle) must discharge to close OQ-04.
- **`expectedMonoCliques_le`** — `E(n,k) ≤ (nᵏ/k!)·2^(1 − C(k,2))` via `Nat.choose_le_pow_div`, reducing OQ-04 to the elementary estimate `nᵏ·2 < k!·2^{C(k,2)}`.

## Scope (honest)

This is **ORIENT-phase progress**, not the full bound: it sets up the exact reduction and supplies the first-moment count bound, but does not yet prove the residual arithmetic inequality (`nᵏ·2 < k!·2^{k(k-1)/2}` under `n < 2^(k/2)`, `k ≥ 3`). That residual is documented in the file and `knowledge.md` as the remaining crux (and is a good Aristotle candidate once stated purely in ℕ). Note the existing file already fully proved (0-axiom) the json `formalStatement` target (non-strict first-moment averaging); the Erdős `< 1` question from `problem.md` is the genuinely open one targeted here.

## Verification

- Single-file: `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/ProbMethodExpectationOQ04.lean` → exit 0 (file imports only Mathlib; the two linter warnings are pre-existing unused-`DecidableEq` notices on the original averaging lemmas, not from this change). Docker build host had transient containerd I/O faults this session.
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`/native_decide. 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)