### PR TITLE
research(pentagonal-number-theorem-oq-01): Part 8 — staircases as genuine Nat.Partition/distincts members [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -702,4 +702,108 @@ axioms, that the staircases `{k, …, 2k-1}` and `{k+1, …, 2k}` are partitions
 arithmetically; what remains genuinely open is the *involution on the non-fixed
 partitions* witnessing the cancellation of all other terms. -/
 
+/-! ## Part 8: The staircase fixed points as genuine `Nat.Partition` / `distincts` members
+
+Part 7 records the staircases `{k,…,2k-1}` and `{k+1,…,2k}` arithmetically, as
+`Finset.Ico` sums.  Here we promote each to an honest element of Mathlib's
+`Nat.Partition` type and show it lies in `Nat.Partition.distincts` — the very Finset
+that the Part-6 bridges `coeff_genFun_pent` / `coeff_tprod_pent` sum over.  This
+closes the bookkeeping gap between Part 7's fixed-point data and Part 6's
+generating-function coefficient: the pentagonal staircases are *literally* among the
+distinct-part partitions whose signed count is `[Xⁿ]∏(1-Xᵐ)`, each contributing
+exactly `pentSign (±k)`.  (Showing they are the *only* surviving contributors — i.e.
+evaluating the whole signed sum — is Franklin's involution, still the open core.) -/
+
+/-- The natural-number value of the positive staircase `{k,…,2k-1}`; equals `g(k)`. -/
+def genPentNat (k : ℕ) : ℕ := ∑ i ∈ Finset.Ico k (2 * k), i
+
+/-- The natural-number value of the negative staircase `{k+1,…,2k}`; equals `g(-k)`. -/
+def genPentNatNeg (k : ℕ) : ℕ := ∑ i ∈ Finset.Ico (k + 1) (2 * k + 1), i
+
+@[simp] theorem genPentNat_cast (k : ℕ) : (genPentNat k : ℤ) = genPent (k : ℤ) := by
+  rw [genPentNat, Nat.cast_sum]; exact staircase_sum_eq_genPent k
+
+@[simp] theorem genPentNatNeg_cast (k : ℕ) :
+    (genPentNatNeg k : ℤ) = genPent (-(k : ℤ)) := by
+  rw [genPentNatNeg, Nat.cast_sum]; exact staircase_sum_eq_genPent_neg k
+
+/-- The positive staircase `{k,…,2k-1}` as a genuine `Nat.Partition` of `g(k)`.
+Positivity holds for every `k` (`0 ∉ Ico k (2k)`); `parts_sum` is the very definition
+of `genPentNat`. -/
+def staircasePartition (k : ℕ) : Nat.Partition (genPentNat k) where
+  parts := (Finset.Ico k (2 * k)).val
+  parts_pos := by
+    intro i hi
+    simp only [Finset.mem_val, Finset.mem_Ico] at hi
+    omega
+  parts_sum := by
+    rw [genPentNat, Finset.sum, Multiset.map_id']
+
+/-- The negative staircase `{k+1,…,2k}` as a genuine `Nat.Partition` of `g(-k)`. -/
+def staircasePartitionNeg (k : ℕ) : Nat.Partition (genPentNatNeg k) where
+  parts := (Finset.Ico (k + 1) (2 * k + 1)).val
+  parts_pos := by
+    intro i hi
+    simp only [Finset.mem_val, Finset.mem_Ico] at hi
+    omega
+  parts_sum := by
+    rw [genPentNatNeg, Finset.sum, Multiset.map_id']
+
+/-- The positive staircase partition has **distinct** parts (a `Finset`'s parts are
+`Nodup`), so it is a genuine member of `Nat.Partition.distincts (g k)`. -/
+theorem staircasePartition_mem_distincts (k : ℕ) :
+    staircasePartition k ∈ Nat.Partition.distincts (genPentNat k) := by
+  rw [Nat.Partition.distincts, Finset.mem_filter]
+  exact ⟨Finset.mem_univ _, (Finset.Ico k (2 * k)).nodup⟩
+
+/-- The negative staircase partition is a member of `Nat.Partition.distincts (g (-k))`. -/
+theorem staircasePartitionNeg_mem_distincts (k : ℕ) :
+    staircasePartitionNeg k ∈ Nat.Partition.distincts (genPentNatNeg k) := by
+  rw [Nat.Partition.distincts, Finset.mem_filter]
+  exact ⟨Finset.mem_univ _, (Finset.Ico (k + 1) (2 * k + 1)).nodup⟩
+
+@[simp] theorem staircasePartition_card (k : ℕ) :
+    (staircasePartition k).parts.card = k := by
+  show Multiset.card (Finset.Ico k (2 * k)).val = k
+  rw [← Finset.card_def, Nat.card_Ico]; omega
+
+@[simp] theorem staircasePartitionNeg_card (k : ℕ) :
+    (staircasePartitionNeg k).parts.card = k := by
+  show Multiset.card (Finset.Ico (k + 1) (2 * k + 1)).val = k
+  rw [← Finset.card_def, Nat.card_Ico]; omega
+
+/-- The signed weight `(-1)^{#parts}` of the positive staircase partition is exactly
+the pentagonal sign `pentSign k`. -/
+theorem staircasePartition_sign (k : ℕ) :
+    (-1 : ℤ) ^ (staircasePartition k).parts.card = pentSign (k : ℤ) := by
+  rw [staircasePartition_card, pentSign, Int.natAbs_natCast]
+
+/-- The signed weight of the negative staircase partition is `pentSign (-k)`. -/
+theorem staircasePartitionNeg_sign (k : ℕ) :
+    (-1 : ℤ) ^ (staircasePartitionNeg k).parts.card = pentSign (-(k : ℤ)) := by
+  rw [staircasePartitionNeg_card, pentSign, Int.natAbs_neg, Int.natAbs_natCast]
+
+/-- **Headline (positive arm).** The positive staircase is a genuine element of
+`Nat.Partition.distincts (g k)` with exactly `k` parts, signed weight `pentSign k`,
+and underlying value `g(k)`.  This places Part 7's fixed point inside the exact Finset
+`coeff_genFun_pent`/`coeff_tprod_pent` range over. -/
+theorem franklin_fixed_point_isPartition (k : ℕ) :
+    staircasePartition k ∈ Nat.Partition.distincts (genPentNat k) ∧
+    (staircasePartition k).parts.card = k ∧
+    (-1 : ℤ) ^ (staircasePartition k).parts.card = pentSign (k : ℤ) ∧
+    (genPentNat k : ℤ) = genPent (k : ℤ) :=
+  ⟨staircasePartition_mem_distincts k, staircasePartition_card k,
+   staircasePartition_sign k, genPentNat_cast k⟩
+
+/-- **Headline (negative arm).** The negative staircase is a genuine element of
+`Nat.Partition.distincts (g (-k))` with exactly `k` parts, signed weight
+`pentSign (-k)`, and underlying value `g(-k)`. -/
+theorem franklin_fixed_point_isPartition_neg (k : ℕ) :
+    staircasePartitionNeg k ∈ Nat.Partition.distincts (genPentNatNeg k) ∧
+    (staircasePartitionNeg k).parts.card = k ∧
+    (-1 : ℤ) ^ (staircasePartitionNeg k).parts.card = pentSign (-(k : ℤ)) ∧
+    (genPentNatNeg k : ℤ) = genPent (-(k : ℤ)) :=
+  ⟨staircasePartitionNeg_mem_distincts k, staircasePartitionNeg_card k,
+   staircasePartitionNeg_sign k, genPentNatNeg_cast k⟩
+
 end PentagonalNumberTheoremOQ01

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -61,3 +61,36 @@ is the deep multi-file development.
 GOTCHA: `Int.natAbs_ofNat` is gone in 4.26 — use `Int.natAbs_natCast`. The assigned
 `feature/researcher-2` worktree predates main; worked on a fresh branch off
 `origin/main` (`research/pentagonal-staircase`) with `proofs/.lake` symlinked.
+
+## Session (2026-06-30, researcher-2) — Part 8: staircases as genuine `Nat.Partition` / `distincts` members
+
+Closed the **bookkeeping gap** the prior sessions flagged as the one tractable item
+below Franklin's involution: Part 7 recorded the staircases only as `Finset.Ico`
+*sums*, never as elements of Mathlib's `Nat.Partition` type, so they were not literally
+inside the `Nat.Partition.distincts n` Finset that the Part-6 bridges
+(`coeff_genFun_pent`, `coeff_tprod_pent`) sum over. Part 8 promotes them.
+
+Added to `PentagonalNumberTheoremOQ01.lean` (now 809 lines, 61 thm / 10 def,
+**0 sorry / 0 axiom / no native_decide**, docker-build-VERIFIED `[7743/7743]`):
+
+- `genPentNat k := ∑ i ∈ Ico k (2k), i` and `genPentNatNeg k := ∑ i ∈ Ico (k+1) (2k+1), i`,
+  with `genPentNat_cast : (genPentNat k : ℤ) = genPent k` (and neg arm) via `Nat.cast_sum`
+  + the Part-7 `staircase_sum_eq_genPent[_neg]`.
+- `staircasePartition k : Nat.Partition (genPentNat k)` (and neg arm): the staircase Finset's
+  underlying multiset as an honest partition. `parts_pos` holds for **all** k (`0 ∉ Ico k (2k)`,
+  closed by `omega`); `parts_sum` is `rw [genPentNat, Finset.sum, Multiset.map_id']` (definitional).
+- `staircasePartition_mem_distincts`: membership in `Nat.Partition.distincts` — the parts are
+  `Nodup` because they come from a `Finset` (`(Finset.Ico …).nodup`).
+- `staircasePartition_card = k` (`← Finset.card_def`, `Nat.card_Ico`, omega) and
+  `staircasePartition_sign : (-1)^{#parts} = pentSign (±k)`.
+- Headlines `franklin_fixed_point_isPartition[_neg]`: the staircase IS an element of
+  `distincts (g(±k))` with exactly k parts, signed weight `pentSign(±k)`, value `g(±k)`.
+
+So Part 7's fixed points are now *literally* among the distinct-part partitions whose signed
+count is `[Xⁿ]∏(1-Xᵐ)`, each contributing exactly `pentSign(±k)`. **STILL OPEN** (unchanged):
+evaluating the whole signed `distincts` sum — i.e. proving the staircases are the *only*
+surviving contributors — which is Franklin's sign-reversing involution itself.
+
+WORKFLOW: fast-iterated the proofs host-side via `lake env lean` on a throwaway
+`ScratchPent.lean` importing the prebuilt parent olean (seconds vs minutes), then inlined and
+did the sanctioned full docker build. Docker backend healthy again this session (29.6.1).

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -13,10 +13,10 @@
       "PowerSeries.WithPiTopology"
     ],
     "namespace": "PentagonalNumberTheoremOQ01",
-    "lineCount": 705,
+    "lineCount": 809,
     "axiomCount": 0,
-    "theoremCount": 51,
-    "definitionCount": 6,
+    "theoremCount": 61,
+    "definitionCount": 10,
     "path": "Proofs/PentagonalNumberTheoremOQ01.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/pentagonal-number-theorem-oq-01.json
+++ b/src/data/research/problems/pentagonal-number-theorem-oq-01.json
@@ -11,7 +11,8 @@
       "Mathlib's 2025 Partition.GenFun (Weiyi Wang) already provides the formal power-series infinite product: genFun f = ∏'_i (1 + ∑'_j f(i+1)(j+1)·X^{(i+1)(j+1)}) (genFun_eq_tprod) with coeff_genFun giving the n-th coefficient as ∑_{p:n.Partition} ∏_i f(i,#i). distincts/odds live in Partition.Basic. Only Franklin's involution is still missing.",
       "Euler's partition recurrence is a FINITE sum because the pentagonal value grows quadratically in its index: k² ≤ g(k) (since 2g(k)-2k² = k(k-1) ≥ 0), hence |k| ≤ g(k) and only finitely many g(k) ≤ n (the contributing indices lie in [-n,n]). This finiteness is the prerequisite that lets the recurrence p(n)=∑(-1)^{k-1}p(n-g_k) be evaluated/inducted on.",
       "Instantiating the genFun character f i c = (if c=1 then (-1:ℤ) else 0) yields inner term 1 - X^{i+1}, so genFun f = ∏_{m≥1}(1-Xᵐ) (product side, free) while coeff_genFun evaluates the same series to ∑_{p∈distincts n}(-1)^{p.parts.card} = p_even(n)-p_odd(n) (coefficient side, free). Both ends of Euler's identity are thus in Mathlib; the whole open core collapses to the single Franklin identity ∑_{p∈distincts n}(-1)^{p.parts.card} = pentSeriesCoeff (n:ℤ).",
-      "Session 2026-06-28 (researcher-2): formalized the FIXED POINTS of Franklin's involution (Part 7, 0-axiom). The staircases {k,…,2k-1} and {k+1,…,2k} sum to g(k) and g(-k) (staircase_sum_eq_genPent[_neg]) and are partitions into exactly k distinct positive parts with sign (-1)^k = pentSign (franklin_fixed_point[_neg]). Only the involution on the NON-fixed partitions remains open."
+      "Session 2026-06-28 (researcher-2): formalized the FIXED POINTS of Franklin's involution (Part 7, 0-axiom). The staircases {k,…,2k-1} and {k+1,…,2k} sum to g(k) and g(-k) (staircase_sum_eq_genPent[_neg]) and are partitions into exactly k distinct positive parts with sign (-1)^k = pentSign (franklin_fixed_point[_neg]). Only the involution on the NON-fixed partitions remains open.",
+      "Session 2026-06-30 (researcher-2), Part 8: the Part-7 staircases are now promoted to genuine `Nat.Partition` objects (`staircasePartition`/`staircasePartitionNeg`) and PROVED to lie in `Nat.Partition.distincts (g(±k))` with exactly k parts and signed weight `pentSign(±k)` (`franklin_fixed_point_isPartition[_neg]`, 0-axiom, docker-verified). This closes the bookkeeping gap between Part 7's fixed-point arithmetic and Part 6's `coeff_genFun_pent` sum over `distincts n`: the pentagonal staircases are now literally elements of that Finset. Constructing them needs no `k≥1` hypothesis — `0∉Ico k (2k)` gives positivity for all k, and `Nodup` is free from the Finset. Only the involution evaluating the whole signed sum remains open."
     ],
     "builtItems": [
       "genPent, IsGenPent (def): generalized pentagonal number value and the doubling-relation membership predicate [PentagonalNumberTheoremOQ01.lean]",
@@ -40,10 +41,10 @@
     {
       "path": "Proofs/PentagonalNumberTheoremOQ01.lean",
       "filename": "PentagonalNumberTheoremOQ01.lean",
-      "lineCount": 595,
-      "theoremCount": 42,
+      "lineCount": 809,
+      "theoremCount": 61,
       "axiomCount": 0,
-      "defCount": 5,
+      "defCount": 10,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PentagonalNumberTheoremOQ01.lean"


### PR DESCRIPTION
## Summary

Closes the one tractable bookkeeping gap that prior sessions flagged below Franklin's involution. **Part 7** recorded the pentagonal staircases `{k,…,2k-1}` and `{k+1,…,2k}` only as `Finset.Ico` *sums*; they were never elements of Mathlib's `Nat.Partition` type, so they did not literally live in the `Nat.Partition.distincts n` Finset that the **Part 6** bridges (`coeff_genFun_pent`, `coeff_tprod_pent`) sum over. **Part 8** promotes them.

## What's new (Part 8 — all 0 sorry / 0 axiom / no `native_decide`)

- `genPentNat`/`genPentNatNeg` (ℕ value of each staircase) + `genPentNat[Neg]_cast` tying them to `genPent (±k)` via `Nat.cast_sum` and the Part-7 `staircase_sum_eq_genPent[_neg]`.
- `staircasePartition`/`staircasePartitionNeg`: the staircase Finset's multiset as an honest `Nat.Partition`. Positivity holds for **all** `k` (`0 ∉ Ico k (2k)`); `parts_sum` is definitional.
- `staircasePartition[Neg]_mem_distincts`: membership in `Nat.Partition.distincts` — parts are `Nodup` because they come from a `Finset`.
- `staircasePartition[Neg]_card = k` and `staircasePartition[Neg]_sign : (-1)^{#parts} = pentSign (±k)`.
- Headlines `franklin_fixed_point_isPartition[_neg]`: each staircase **is** an element of `distincts (g(±k))` with exactly `k` parts, signed weight `pentSign(±k)`, value `g(±k)`.

So Part 7's fixed points are now *literally* among the distinct-part partitions whose signed count is `[Xⁿ]∏(1-Xᵐ)`, each contributing exactly `pentSign(±k)`.

## Still open (unchanged)

Evaluating the whole signed `distincts` sum — i.e. proving the staircases are the **only** surviving contributors — is Franklin's sign-reversing involution itself, the deep multi-file development still absent from Mathlib.

## Verification

`./proofs/scripts/docker-build.sh Proofs.PentagonalNumberTheoremOQ01` → `✔ [7743/7743] Built` (64s), 0 errors. Parent now 809 lines / 61 thm / 10 def, 0 axiom / 0 sorry / no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)