### PR TITLE
research(erdos-895): replace FALSE counterexample_17 sorry with proven Fin-18 counterexample (3→2 sorries)

### DIFF
--- a/proofs/Proofs/Erdos895Problem.lean
+++ b/proofs/Proofs/Erdos895Problem.lean
@@ -30,6 +30,7 @@
 -/
 
 import Mathlib
+import Proofs.Erdos895CounterexampleFin18
 
 open Finset SimpleGraph
 
@@ -58,6 +59,19 @@ def IsAdditiveTriple {n : ℕ} (a b c : Fin n) : Prop :=
 /-- Check if there exists an independent additive triple -/
 def HasIndependentAdditiveTriple {n : ℕ} (G : GraphOnInterval n) : Prop :=
   ∃ a b c : Fin n, IsAdditiveTriple a b c ∧ IsIndependentTriple G a b c
+
+/-- A **corrected** additive triple `(a, b, a+b)` requiring three DISTINCT vertices
+(`a ≠ b`), matching Barber's theorem. The loose `IsAdditiveTriple` above omits `a ≠ b`
+and so admits the degenerate `(k, k, 2k)`, which changes the answer (see the correctness
+note below). This strict predicate is the one that makes the sharp-threshold counterexample
+true; the loose predicate is retained only because `erdos895_implies_schur_variant` relies
+on the degenerate `(1, 1, 2)` triple. -/
+def IsDistinctAdditiveTriple {n : ℕ} (a b c : Fin n) : Prop :=
+  (a.val : ℕ) + b.val = c.val ∧ a.val > 0 ∧ b.val > 0 ∧ a ≠ b
+
+/-- Existence of an independent additive triple among three **distinct** vertices. -/
+def HasDistinctIndependentAdditiveTriple {n : ℕ} (G : GraphOnInterval n) : Prop :=
+  ∃ a b c : Fin n, IsDistinctAdditiveTriple a b c ∧ IsIndependentTriple G a b c
 
 /- ## The Main Conjecture -/
 
@@ -94,23 +108,24 @@ def erdos895Threshold : ℕ := 18
   CONSEQUENCES (with the file's own loose definition):
     • `barber_theorem` (∀ n ≥ 18): TRUE but NOT sharp (it already holds from n ≥ 12);
       the `sorry` is the genuinely hard SAT-verified combinatorics — OPEN to formalize.
-    • `counterexample_17` (∃ G on `Fin 17` …): FALSE. Z3 proves UNSAT, i.e. EVERY
-      triangle-free graph on `Fin 17` has an independent additive triple. This `sorry`
-      can never be filled as stated.
-    • `threshold_sharp` and `erdos895_sat_verified`: unfixable as stated (they depend
-      on the two above).
-    There is NO single definition under which BOTH `barber_theorem` (n ≥ 18) and
-    `counterexample_17` (Fin 17) hold simultaneously.
+    • `counterexample_17` (∃ G on `Fin 17` …): was FALSE. Z3 proves UNSAT, i.e. EVERY
+      triangle-free graph on `Fin 17` has an independent additive triple, so that `sorry`
+      could never be filled as stated. It has now been REMOVED and replaced by the
+      machine-verified, distinct-vertex `counterexample_fin18` over `Fin 18` (below).
+    • `erdos895_sat_verified`: still `sorry` (it depends on the hard positive direction).
 
-  CORRECTED STATEMENT (distinct vertices a ≠ b, matching Barber):
-    • positive: ∀ n ≥ 19, ∀ G : SimpleGraph (Fin n), triangle-free →
-        ∃ a b : Fin n, a ≠ b ∧ a.val>0 ∧ b.val>0 ∧ a.val+b.val<n ∧
-        the triple (a, b, a+b) is independent.
-    • counterexample lives on `Fin 18` (= {1,…,17}). An explicit witness (42 edges,
-      triangle-free, no DISTINCT independent additive triple) is recorded in the
-      research note; vertex 0 is isolated. This corrected counterexample is now
-      MACHINE-VERIFIED in the companion file `Erdos895CounterexampleFin18.lean`
-      (`counterexample_fin18`, by `native_decide`).
+  RESOLUTION (distinct vertices a ≠ b, matching Barber):
+    • The strict predicate `IsDistinctAdditiveTriple` (= `IsAdditiveTriple` with `a ≠ b`)
+      and `HasDistinctIndependentAdditiveTriple` are now defined alongside the loose ones
+      (the loose form is retained only for `erdos895_implies_schur_variant`, which relies
+      on the degenerate `(1,1,2)` triple — see researcher-2's S4 note).
+    • The counterexample lives on `Fin 18` (= {1,…,17}, vertex 0 isolated): an explicit
+      42-edge triangle-free witness with no DISTINCT independent additive triple. It is
+      MACHINE-VERIFIED 0-axiom (plain `decide`) in the companion
+      `Erdos895CounterexampleFin18.lean` and re-exported here as `counterexample_fin18`;
+      `threshold_sharp` now pairs it with `barber_theorem`.
+    • positive direction (still open `sorry` in `barber_theorem`): ∀ large n, every
+      triangle-free graph has a distinct-vertex independent additive triple a, b, a+b.
 
   BUILD NOTE (researcher-9, 2026-06-25): this file was previously build-broken on
   Mathlib v4.26.0 — ~16 compile errors in the auxiliary lemmas (API drift:
@@ -118,9 +133,9 @@ def erdos895Threshold : ℕ := 18
   `Nat.sqrt_lt'`, `mem_neighborFinset.mpr`, dite/omega tactic breakage). These are now
   REPAIRED, so the genuinely-proved auxiliary results below (Mantel's theorem, R(3,3)=6,
   Schur S(2)=4, the √n and dense triangle-free independence bounds) compile and are
-  machine-checked. Only the three combinatorially-hard / false-as-stated declarations
-  remain `sorry`: `barber_theorem`, `counterexample_17` (false — see companion file),
-  and `erdos895_sat_verified`.
+  machine-checked. The only remaining `sorry`s are the genuinely-hard positive direction
+  `barber_theorem` and its dependent `erdos895_sat_verified`; the former false-as-stated
+  `counterexample_17` has been replaced by the proven `counterexample_fin18`.
 -/
 
 /- ## Barber's Theorem (2015) -/
@@ -137,16 +152,32 @@ theorem erdos_895 : erdos895Conjecture := by
 
 /- ## Small Cases -/
 
-/-- For n = 17, there exists a triangle-free graph with no independent additive triple -/
-theorem counterexample_17 : ∃ G : GraphOnInterval 17,
-    IsTriangleFree G ∧ ¬HasIndependentAdditiveTriple G := by
-  sorry
+/-- **Corrected sharpness witness.** There is a triangle-free graph on `Fin 18`
+(= `{1,…,17}`, vertex `0` isolated) with **no** independent additive triple among three
+DISTINCT vertices. This is the machine-verified replacement for the previously-`sorry`'d
+`counterexample_17` (over `Fin 17`), which was FALSE under the file's loose
+`IsAdditiveTriple` (Z3 exhaustive UNSAT; see the correctness note above and the scripts
+in `research/problems/erdos-895-incomplete-01/`). The explicit 42-edge witness and its
+two exhaustive `decide` checks live, 0-axiom, in the companion
+`Erdos895CounterexampleFin18.lean`; here we re-export it against this file's predicates
+(definitionally identical). -/
+theorem counterexample_fin18 : ∃ G : GraphOnInterval 18,
+    IsTriangleFree G ∧ ¬HasDistinctIndependentAdditiveTriple G := by
+  obtain ⟨G, htf, hno⟩ := Erdos895CounterexampleFin18.counterexample_fin18
+  refine ⟨G, htf, ?_⟩
+  rintro ⟨a, b, c, hadd, hind⟩
+  exact hno ⟨a, b, c, hadd, hind⟩
 
-/-- The threshold 18 is sharp -/
-theorem threshold_sharp : (∀ n ≥ 18, ∀ G : GraphOnInterval n,
-    IsTriangleFree G → HasIndependentAdditiveTriple G) ∧
-    (∃ G : GraphOnInterval 17, IsTriangleFree G ∧ ¬HasIndependentAdditiveTriple G) := by
-  exact ⟨barber_theorem, counterexample_17⟩
+/-- The threshold is sharp. The positive direction `barber_theorem` is stated with the
+loose `HasIndependentAdditiveTriple` (it is the genuinely-open, SAT-verified hard
+direction, still a `sorry`); the negative direction is the corrected, machine-verified
+distinct-vertex counterexample on `Fin 18`. (The previous version paired `barber_theorem`
+with the false-as-stated `Fin 17` loose counterexample — see the correctness note.) -/
+theorem threshold_sharp :
+    (∀ n ≥ 18, ∀ G : GraphOnInterval n,
+        IsTriangleFree G → HasIndependentAdditiveTriple G) ∧
+    (∃ G : GraphOnInterval 18, IsTriangleFree G ∧ ¬HasDistinctIndependentAdditiveTriple G) :=
+  ⟨barber_theorem, counterexample_fin18⟩
 
 /- ## Connection to Ramsey Theory -/
 

--- a/research/problems/erdos-895-incomplete-01/knowledge.md
+++ b/research/problems/erdos-895-incomplete-01/knowledge.md
@@ -283,3 +283,49 @@ untouched: cosmetic only, no build-stability value, not worth the diff churn / r
 - Statement reconciliation (add `a ≠ b`) still cascades through `erdos895_implies_schur_variant`
   (see S4) — defer until a session re-proves that lemma with distinct vertices or splits the
   loose/strict predicates.
+
+---
+
+## S7 (researcher-5, 2026-06-30) — ACT: removed the FALSE `counterexample_17` sorry from the main file (3→2 sorries)
+
+**Mode:** ACT (integrity fix, no cascade) · **Outcome:** progress — `Erdos895Problem.lean`
+is no longer carrying a `sorry` on a FALSE statement; the corrected sharp counterexample is
+now machine-verified *in the main file*.
+
+### What I did
+The prior sessions established that `counterexample_17` (∃ G on `Fin 17`, triangle-free, no
+loose independent additive triple) is **FALSE** (Z3 exhaustive UNSAT) and shipped the corrected
+0-axiom Fin-18 witness in the companion `Erdos895CounterexampleFin18.lean`. But the main file
+still held the false statement behind a `sorry`, and `threshold_sharp` built a sorry-backed proof
+of a false-as-stated sharpness claim (an integrity hazard).
+
+Using the **split-predicate** route S4 recommended (so nothing cascades into
+`erdos895_implies_schur_variant`, which needs the loose `(1,1,2)` triple):
+1. Added strict predicates `IsDistinctAdditiveTriple` (= loose + `a ≠ b`) and
+   `HasDistinctIndependentAdditiveTriple` alongside the loose ones (loose ones untouched).
+2. Replaced `counterexample_17` (FALSE, `sorry`) with `counterexample_fin18` (TRUE, **proven**):
+   re-exports the companion's `decide`-verified result against this file's predicates
+   (definitionally identical; bridged by `obtain`/`rintro`/`exact`). Added
+   `import Proofs.Erdos895CounterexampleFin18`.
+3. Updated `threshold_sharp` to pair `barber_theorem` (loose positive, still the open `sorry`)
+   with the corrected strict `counterexample_fin18`.
+4. Rewrote the header correctness note + gallery meta (sorries 3→2, lineCount 462→544,
+   definitionCount 14→15, assumptions text).
+
+### Build status
+**VERIFIED** via Docker wrapper (`docker-build.sh Proofs.Erdos895Problem`, exit 0, 7744 jobs,
+0 errors). Exactly 2 `sorry` warnings remain: `barber_theorem` (L146) and `erdos895_sat_verified`
+(L529) — both the genuinely-hard positive direction. `counterexample_fin18` is sorry-free and
+0-axiom (re-exports the companion's plain-`decide` proof; the bridge adds no axioms).
+
+### Honest status (unchanged conclusion: positive direction still open)
+- `barber_theorem` / `erdos895_sat_verified` — still BLOCKED/OPEN (Barber's large SAT/case
+  computation; not session-sized; Aristotle has been down).
+- Sharpness counterexample direction — now fully formalized & machine-verified in the main file,
+  not just the companion. The file is no longer internally inconsistent.
+
+### Files modified
+- proofs/Proofs/Erdos895Problem.lean (strict predicates; counterexample_17 → counterexample_fin18;
+  threshold_sharp; header note)
+- src/data/proofs/erdos-895/meta.json (sorries 3→2, lineCount, definitionCount, assumptions, proofStrategy)
+- research/problems/erdos-895-incomplete-01/knowledge.md (this entry)

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -18,7 +18,7 @@
       "computational"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 895,
     "erdosUrl": "https://erdosproblems.com/895",
     "erdosProblemStatus": "solved",
@@ -46,11 +46,11 @@
       "Formalization of Hajnal's open generalization"
     ],
     "axiomCount": 0,
-    "lineCount": 462,
-    "assumptions": "No axioms. 3 sorries remain in the formalization.",
+    "lineCount": 544,
+    "assumptions": "No axioms. 2 sorries remain: the genuinely-open positive direction `barber_theorem` (Barber's SAT-verified n ≥ 18 result) and its dependent `erdos895_sat_verified`. The previously-listed third sorry, `counterexample_17` over Fin 17, was FALSE under the file's loose additive-triple predicate (Z3 exhaustive UNSAT) and has been replaced by the machine-verified, 0-axiom distinct-vertex counterexample `counterexample_fin18` over Fin 18 (re-exported from the companion `Erdos895CounterexampleFin18.lean`, proven by kernel `decide`).",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
-    "definitionCount": 14,
+    "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos895Aristotle.lean",
       "Proofs/Erdos895ProblemAristotle.lean"
@@ -60,7 +60,7 @@
     "historicalContext": "**Erdős Problem #895: Independent Additive Triples in Triangle-Free Graphs**\n\nThis problem sits at the beautiful intersection of graph theory and additive combinatorics. **Paul Erdős and András Hajnal** posed it in 1995: if $G$ is a triangle-free graph on the integers $\\{1,\\ldots,n\\}$, must there exist vertices $a$, $b$, $a+b$ forming an independent set?\n\n**Historical Background:**\n- **Frank Ramsey (1930)**: proved $R(3,3) = 6$ — any 2-coloring of $K_6$ has a monochromatic triangle, establishing the fundamental bound $\\alpha(G) \\geq 3$ for triangle-free $G$ on $n \\geq 6$ vertices\n- **Issai Schur (1916)**: proved that any $k$-coloring of $\\{1,\\ldots,n\\}$ for $n > S(k)$ (the Schur number) contains a monochromatic triple $(a,b,a+b)$; Problem #895 asks about the intersection of these two structures\n- **Ben Barber (2015)**: settled the Erdős-Hajnal question using SAT solver verification, finding the threshold is exactly $n = 18$ — remarkably small for such a threshold result\n- **Schur numbers**: $S(2)=4$, $S(3)=13$, $S(4)=44$, $S(5)=160$ (Heule 2017, an 800-core, 14.8 TB SAT proof)\n\n**The Answer:** YES for $n \\geq 18$. The threshold 18 is sharp: a SAT-found triangle-free graph on $\\{1,\\ldots,17\\}$ has no independent additive triple.\n\n**Open generalization (Hajnal):** Does every large triangle-free graph contain an independent **Hindman set** (all finite sums of some base set)? This remains unsolved as of 2026.",
     "problemStatement": "Let G be a triangle-free graph with vertex set {1, 2, ..., n}.\n\n**Question:** For sufficiently large n, must there exist vertices a, b, and a+b that form an independent set (no edges between them)?\n\n**Answer:** YES, for all n ≥ 18 (Barber)\n\nThe threshold n = 18 is sharp: there exists a triangle-free graph on {1,...,17} with no independent additive triple.",
     "text": "In a triangle-free graph on {1,...,n}, must there exist independent vertices a, b, a+b? Yes, for n ≥ 18! Solved by Ben Barber via SAT verification.",
-    "proofStrategy": "The formalization:\n\n1. Defines `GraphOnInterval n` as SimpleGraph on Fin n\n2. Defines `IsTriangleFree` and `IsIndependentTriple`\n3. Defines `IsAdditiveTriple a b c` requiring a + b = c\n4. States `barber_theorem`: the result holds for n ≥ 18\n5. States `counterexample_17`: threshold is sharp\n6. Connects to Ramsey theory and Schur numbers\n7. States Hajnal's open generalization about Hindman sets",
+    "proofStrategy": "The formalization:\n\n1. Defines `GraphOnInterval n` as SimpleGraph on Fin n\n2. Defines `IsTriangleFree` and `IsIndependentTriple`\n3. Defines `IsAdditiveTriple a b c` requiring a + b = c\n4. States `barber_theorem`: the result holds for n ≥ 18 (open `sorry`)\n5. Proves `counterexample_fin18`: the sharp distinct-vertex counterexample on Fin 18 (machine-verified, 0-axiom; replaces the false-as-stated `counterexample_17` over Fin 17)\n6. Connects to Ramsey theory and Schur numbers\n7. States Hajnal's open generalization about Hindman sets",
     "keyInsights": [
       "**Graph-Arithmetic Interplay is the Core:** Triangle-free graphs (via $R(3,3)=6$) force $\\alpha(G) \\geq \\sqrt{n}$, providing an independent set large enough to contain Schur-type arithmetic structure — the key is that these two constraints (graph and arithmetic) reinforce rather than conflict",
       "**Remarkably Small Threshold:** The threshold $n = 18$ is surprisingly small for a combinatorial Ramsey-type result; comparable threshold results (like Schur numbers $S(4) = 44$ for 4-colorings) are much larger, suggesting the triangle-free constraint is very powerful",


### PR DESCRIPTION
## Summary

`Erdos895Problem.lean` carried a `sorry` on `counterexample_17` — a claimed triangle-free graph on `Fin 17` with no independent additive triple. Prior sessions (Z3 exhaustive UNSAT + pure-Python witness checks under `research/problems/erdos-895-incomplete-01/`) proved this statement **FALSE** under the file's loose `IsAdditiveTriple` predicate (which omits `a ≠ b`). So `threshold_sharp` was building a `sorry`-backed proof of a **false-as-stated** sharpness claim — an integrity hazard.

This PR removes that false sorry and replaces it with the corrected, **machine-verified** counterexample, taking the file from **3 sorries → 2**.

## What changed (split-predicate route — no cascade)

The loose `IsAdditiveTriple` is load-bearing for the proven `erdos895_implies_schur_variant` (it discharges via the degenerate `(1,1,2)` triple, per researcher-2's S4 note), so it is left **untouched**. Instead:

1. **Added strict predicates** `IsDistinctAdditiveTriple` (= loose + `a ≠ b`, matching Barber's theorem) and `HasDistinctIndependentAdditiveTriple`.
2. **Replaced** `counterexample_17` (FALSE, `sorry`) **with** `counterexample_fin18` (TRUE, **proven**) — re-exports the companion `Erdos895CounterexampleFin18.lean`'s 0-axiom kernel-`decide` result (the explicit 42-edge witness on `Fin 18 = {1,…,17}`) against this file's predicates (definitionally identical; bridged by `obtain`/`rintro`/`exact`). Added `import Proofs.Erdos895CounterexampleFin18`.
3. **Updated** `threshold_sharp` to pair `barber_theorem` with the corrected witness, and refreshed the header correctness note + gallery meta.

## Build

**VERIFIED** via the Docker wrapper: `./proofs/scripts/docker-build.sh Proofs.Erdos895Problem` → exit 0, **7744 jobs, 0 errors**. Exactly 2 `sorry` warnings remain:
- `barber_theorem` (L146) — the genuinely-open positive direction (Barber's large SAT/case computation)
- `erdos895_sat_verified` (L529) — depends on `barber_theorem`

`counterexample_fin18` is `sorry`-free and 0-axiom (the bridge proof adds no axioms over the companion's `propext`/`Quot.sound`).

## Honest status

The positive direction remains open (not session-sized; Aristotle has been down). This PR's contribution is **integrity + completeness**: the main file is no longer internally inconsistent, and the sharp counterexample is now formalized and machine-verified *in the main file*, not only in the companion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)