### PR TITLE
Enrich Spectral Consequences of Sylvester's Interpolation Formula

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-02-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-ch020201-setup",
+    "proofId": "cayley-hamilton-oq-02-oq-02-oq-01",
+    "range": { "startLine": 45, "endLine": 46 },
+    "type": "context",
+    "title": "Diagonalizable setting over a commutative ring",
+    "content": "The file works with a matrix presented in already-diagonalized form A = U · diagonal d · V, where U and V are mutually inverse (U V = V U = 1) and d : n → 𝕜 lists the diagonal entries (eigenvalues). Crucially the scalars 𝕜 form only a CommRing, not a field: no division, determinants, or characteristic-polynomial machinery is used. Everything is purely algebraic manipulation of the Frobenius covariants Z_μ = frobeniusCovariant U V d μ inherited from the parent file. Working over a ring keeps the results applicable to integer and modular matrices, not just over ℝ or ℂ.",
+    "mathContext": "$A = U\\,\\operatorname{diag}(d)\\,V,\\qquad UV = VU = I,\\qquad \\mathbb{k}\\ \\text{a commutative ring}$",
+    "significance": "context",
+    "relatedConcepts": ["diagonalizable matrix", "similarity transformation", "commutative ring", "spectral projection"],
+    "prerequisites": ["linear algebra", "matrix algebra", "commutative ring"]
+  },
+  {
+    "id": "ann-ch020201-spectral-decomp",
+    "proofId": "cayley-hamilton-oq-02-oq-02-oq-01",
+    "range": { "startLine": 52, "endLine": 60 },
+    "type": "insight",
+    "title": "Spectral decomposition A = ∑ μ·Z_μ",
+    "content": "Specializing the parent's Sylvester formula aeval A p = ∑_μ p.eval(μ)·Z_μ to the polynomial p = X collapses it to the spectral decomposition of A itself: since aeval A X = A and X.eval(μ) = μ, the matrix equals the eigenvalue-weighted sum of its own Frobenius covariants. The entire proof is `have h := sylvester ... X; simpa using h` — the content lives in the parent; this entry reads off what the formula says about A. The sum ranges over Finset.univ.image d, i.e. the distinct eigenvalues, so repeated eigenvalues are pooled into a single projection.",
+    "mathContext": "$A = \\sum_{\\mu \\in \\operatorname{spec}(A)} \\mu\\, Z_\\mu,\\qquad Z_\\mu = U\\,E_\\mu\\,V$",
+    "significance": "key",
+    "relatedConcepts": ["spectral decomposition", "Frobenius covariants", "eigenvalue", "Sylvester interpolation"],
+    "prerequisites": ["eigenvalues and eigenvectors", "polynomial evaluation"]
+  },
+  {
+    "id": "ann-ch020201-pow",
+    "proofId": "cayley-hamilton-oq-02-oq-02-oq-01",
+    "range": { "startLine": 62, "endLine": 70 },
+    "type": "insight",
+    "title": "Spectral mapping for powers Aᵏ = ∑ μᵏ·Z_μ",
+    "content": "Taking p = Xᵏ in Sylvester's formula yields the spectral mapping theorem for powers: raising A to the k-th power re-weights the same fixed projections Z_μ by μᵏ, without changing the projections themselves. The proof adds only `map_pow` to rewrite aeval A (Xᵏ) = (aeval A X)ᵏ = Aᵏ. This is the discrete heart of the holomorphic functional calculus: any polynomial (indeed any power series that converges on the spectrum) acts on A by acting scalar-wise on the eigenvalues while the covariants stay rigid.",
+    "mathContext": "$A^k = \\sum_{\\mu} \\mu^{k}\\, Z_\\mu,\\qquad f(A) = \\sum_\\mu f(\\mu)\\, Z_\\mu$",
+    "significance": "key",
+    "relatedConcepts": ["spectral mapping theorem", "functional calculus", "matrix powers", "Frobenius covariants"],
+    "prerequisites": ["polynomial functional calculus", "eigenvalues"]
+  },
+  {
+    "id": "ann-ch020201-interp-unique",
+    "proofId": "cayley-hamilton-oq-02-oq-02-oq-01",
+    "range": { "startLine": 76, "endLine": 86 },
+    "type": "insight",
+    "title": "Interpolation uniqueness: f(A) depends only on f on the spectrum",
+    "content": "If two polynomials p and q agree at every eigenvalue (p.eval μ = q.eval μ for all μ ∈ image d), then aeval A p = aeval A q. The proof rewrites both sides by Sylvester and applies Finset.sum_congr termwise, replacing p.eval μ with q.eval μ under the hypothesis. This is the algebraic shadow of Lagrange interpolation: the functional calculus factors through the restriction map 𝕜[X] → (functions on the spectrum), so the minimal polynomial — the lowest-degree representative of each spectral value-vector — already determines every polynomial in A.",
+    "mathContext": "$\\bigl(\\forall \\mu \\in \\operatorname{spec}(A),\\ p(\\mu) = q(\\mu)\\bigr) \\implies p(A) = q(A)$",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange interpolation", "minimal polynomial", "functional calculus", "spectrum"],
+    "prerequisites": ["polynomial interpolation", "minimal polynomial"]
+  },
+  {
+    "id": "ann-ch020201-coordproj-diag",
+    "proofId": "cayley-hamilton-oq-02-oq-02-oq-01",
+    "range": { "startLine": 92, "endLine": 100 },
+    "type": "technique",
+    "title": "Right multiplication of a coordinate projection by the diagonal",
+    "content": "The technical lemma E_μ · diagonal d = μ · E_μ, where E_μ = coordProj d μ is the diagonal 0/1 projection onto coordinates with d i = μ. Because diagonal matrices commute, multiplying the projection by diagonal d on the right scales it by μ exactly as on the left. The proof uses diagonal_mul_diagonal to collapse the product, then a pointwise case split on whether d i = μ: where it holds the entry is μ, where it fails the projection already kills the entry. This commutativity is what makes the covariants two-sided eigen-projections in the next theorem.",
+    "mathContext": "$E_\\mu\\,\\operatorname{diag}(d) = \\mu\\, E_\\mu,\\qquad (E_\\mu)_{ii} = [\\,d_i = \\mu\\,]$",
+    "significance": "technical",
+    "relatedConcepts": ["diagonal matrices", "idempotent", "coordinate projection", "commuting matrices"],
+    "prerequisites": ["matrix multiplication", "diagonal matrices"]
+  },
+  {
+    "id": "ann-ch020201-eigen-right",
+    "proofId": "cayley-hamilton-oq-02-oq-02-oq-01",
+    "range": { "startLine": 102, "endLine": 112 },
+    "type": "definition",
+    "title": "Right eigen-relation Z_μ·A = μ·Z_μ",
+    "content": "The covariants are right eigen-projections, the companion to the parent's left relation A·Z_μ = μ·Z_μ. The calc block conjugates the coordinate-projection lemma through U and V: expand Z_μ A = U E_μ V · U diag d V, slide the inner V·U = 1 together (noncomm_ring), apply E_μ diag d = μ E_μ, then pull the scalar μ out of the conjugation. The single hypothesis used is V U = 1; U V = 1 is not needed for this direction. This is the missing right-hand half of the spectral projector algebra.",
+    "mathContext": "$Z_\\mu\\, A = \\mu\\, Z_\\mu \\quad\\text{(compare parent's } A\\,Z_\\mu = \\mu\\, Z_\\mu\\text{)}$",
+    "significance": "supporting",
+    "relatedConcepts": ["eigen-projection", "Frobenius covariants", "conjugation", "spectral projector"],
+    "prerequisites": ["matrix conjugation", "eigenvalues"]
+  },
+  {
+    "id": "ann-ch020201-commute",
+    "proofId": "cayley-hamilton-oq-02-oq-02-oq-01",
+    "range": { "startLine": 114, "endLine": 119 },
+    "type": "insight",
+    "title": "Each covariant commutes with A",
+    "content": "Combining the left relation A·Z_μ = μ·Z_μ (from the parent, frobenius_eigen) and the right relation Z_μ·A = μ·Z_μ (frobenius_eigen_right) gives A·Z_μ = Z_μ·A: every Frobenius covariant commutes with A, both products equalling μ·Z_μ. Commutation certifies that the Z_μ are intrinsic spectral data of A rather than artifacts of the chosen diagonalizing factors U, V — they belong to the commutant of A and decompose the identity into A-invariant idempotents.",
+    "mathContext": "$A\\, Z_\\mu = Z_\\mu\\, A = \\mu\\, Z_\\mu,\\qquad \\textstyle\\sum_\\mu Z_\\mu = I,\\ Z_\\mu Z_\\nu = \\delta_{\\mu\\nu} Z_\\mu$",
+    "significance": "key",
+    "relatedConcepts": ["commuting matrices", "commutant", "invariant subspace", "spectral projection"],
+    "prerequisites": ["commuting matrices", "idempotents"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-02-oq-01/meta.json
@@ -16,12 +16,12 @@
     "namespace": "CayleyHamiltonOQ02OQ02OQ01",
     "lineCount": 140,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/CayleyHamiltonOQ02OQ02OQ01.lean",
     "sorries": 0
   },
-  "description": "Draws out the spectral consequences of Sylvester's interpolation formula for a diagonalizable matrix A = U * diagonal d * V. The parent entry cayley-hamilton-oq-02-oq-02 proves Sylvester's formula aeval A p = sum over distinct eigenvalues mu of p.eval(mu) * Z_mu (Z_mu the Frobenius covariants / spectral projections) plus the projection algebra (Z_mu^2 = Z_mu, Z_mu Z_nu = 0, sum Z_mu = 1, A Z_mu = mu Z_mu), but never records what the formula says about A itself. This entry reads those off: (1) spectral_decomposition A = sum mu * Z_mu (Sylvester at p = X); (2) pow_eq_sum_frobenius A^k = sum mu^k * Z_mu, the spectral mapping theorem for powers (Sylvester at p = X^k); (3) aeval_eq_of_eval_eq, interpolation uniqueness \u2014 aeval A p depends on p only through its values on the eigenvalues; (4) frobenius_eigen_right Z_mu A = mu Z_mu and frobenius_commute A Z_mu = Z_mu A, showing the covariants are two-sided eigen-projections that commute with A. 5 theorems, 0 sorries, 0 axioms.",
+  "description": "Draws out the spectral consequences of Sylvester's interpolation formula for a diagonalizable matrix A = U * diagonal d * V. The parent entry cayley-hamilton-oq-02-oq-02 proves Sylvester's formula aeval A p = sum over distinct eigenvalues mu of p.eval(mu) * Z_mu (Z_mu the Frobenius covariants / spectral projections) plus the projection algebra (Z_mu^2 = Z_mu, Z_mu Z_nu = 0, sum Z_mu = 1, A Z_mu = mu Z_mu), but never records what the formula says about A itself. This entry reads those off: (1) spectral_decomposition A = sum mu * Z_mu (Sylvester at p = X); (2) pow_eq_sum_frobenius A^k = sum mu^k * Z_mu, the spectral mapping theorem for powers (Sylvester at p = X^k); (3) aeval_eq_of_eval_eq, interpolation uniqueness — aeval A p depends on p only through its values on the eigenvalues; (4) frobenius_eigen_right Z_mu A = mu Z_mu and frobenius_commute A Z_mu = Z_mu A, showing the covariants are two-sided eigen-projections that commute with A. 6 theorems, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "date": "formalized 2026",
@@ -40,27 +40,91 @@
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,
-    "assumptions": "BUILD PENDING \u2014 NOT YET MACHINE-VERIFIED. The proof is complete by source inspection (0 sorries, 0 axiom declarations, no native_decide; a clean polynomial specialization of the verified, axiom-free parent CayleyHamiltonOQ02OQ02), but the Docker build could not be executed: the host build environment suffered Docker storage corruption (containerd I/O errors, snapshot-not-found) and repeated worktree deletion during this session. Requires `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonOQ02OQ02OQ01` to pass before promotion to verified.",
+    "assumptions": "BUILD PENDING — NOT YET MACHINE-VERIFIED. The proof is complete by source inspection (0 sorries, 0 axiom declarations, no native_decide; a clean polynomial specialization of the verified, axiom-free parent CayleyHamiltonOQ02OQ02), but the Docker build could not be executed: the host build environment suffered Docker storage corruption (containerd I/O errors, snapshot-not-found) and repeated worktree deletion during this session. Requires `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonOQ02OQ02OQ01` to pass before promotion to verified.",
     "lineCount": 140,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [
       "spectral_decomposition: A = sum over distinct eigenvalues mu of mu * Z_mu, the matrix as the eigenvalue-weighted sum of its own Frobenius covariants (Sylvester's formula specialized to p = X)",
-      "pow_eq_sum_frobenius: A^k = sum mu^k * Z_mu, the spectral mapping theorem for powers \u2014 raising A to a power re-weights the same fixed spectral projections by mu^k (Sylvester at p = X^k)",
-      "aeval_eq_of_eval_eq: interpolation uniqueness \u2014 the functional calculus aeval A p depends on p only through its values p.eval(mu) on the eigenvalues, so two polynomials agreeing on the spectrum give the same matrix",
+      "pow_eq_sum_frobenius: A^k = sum mu^k * Z_mu, the spectral mapping theorem for powers — raising A to a power re-weights the same fixed spectral projections by mu^k (Sylvester at p = X^k)",
+      "aeval_eq_of_eval_eq: interpolation uniqueness — the functional calculus aeval A p depends on p only through its values p.eval(mu) on the eigenvalues, so two polynomials agreeing on the spectrum give the same matrix",
       "coordProj_mul_diag and frobenius_eigen_right: the right-hand eigen-relation Z_mu * A = mu * Z_mu (companion to the parent's left-hand A * Z_mu = mu * Z_mu)",
       "frobenius_commute: each Frobenius covariant commutes with A (A Z_mu = Z_mu A), confirming they are intrinsic two-sided spectral projections"
     ]
   },
   "overview": {
-    "historicalContext": "Sylvester's interpolation formula (1883) expresses any function f of a diagonalizable matrix A as f(A) = sum over eigenvalues lambda of f(lambda) Z_lambda, where the Frobenius covariants Z_lambda are the spectral projections onto the eigenspaces \u2014 the matrix analogue of Lagrange interpolation and the algebraic core of the holomorphic functional calculus. The covariants are intrinsic to A and independent of f, so f(A) is obtained by re-weighting the fixed projections by the scalars f(lambda).",
-    "problemStatement": "The parent entry proves Sylvester's formula and the projection algebra of the Frobenius covariants, but does not record what the formula says about A itself. What are the spectral consequences \u2014 the decomposition of A and its powers, the dependence of the functional calculus on the spectrum, and the two-sidedness of the eigen-projections?",
+    "historicalContext": "Sylvester's interpolation formula (1883) expresses any function f of a diagonalizable matrix A as f(A) = sum over eigenvalues lambda of f(lambda) Z_lambda, where the Frobenius covariants Z_lambda are the spectral projections onto the eigenspaces — the matrix analogue of Lagrange interpolation and the algebraic core of the holomorphic functional calculus. The covariants are intrinsic to A and independent of f, so f(A) is obtained by re-weighting the fixed projections by the scalars f(lambda). The projections Z_lambda are named for Georg Frobenius, who systematized the matrix functional calculus in the late 19th century; the value-only interpolation viewpoint goes back to Sylvester and Lagrange, while the modern operator-theoretic generalization to non-diagonalizable operators is the Riesz–Dunford holomorphic functional calculus, where the Z_lambda become contour integrals of the resolvent (1/(2 pi i)) oint (zI - A)^{-1} dz. This entry isolates the finite-dimensional, purely algebraic kernel of that theory, valid over any commutative ring rather than only over the complex field.",
+    "problemStatement": "The parent entry proves Sylvester's formula and the projection algebra of the Frobenius covariants, but does not record what the formula says about A itself. What are the spectral consequences — the decomposition of A and its powers, the dependence of the functional calculus on the spectrum, and the two-sidedness of the eigen-projections?",
     "proofStrategy": "Specialize the parent's Sylvester formula. For the spectral decomposition take p = X (so aeval A X = A and X.eval mu = mu) and simplify; for the power formula take p = X^k (aeval A (X^k) = A^k, (X^k).eval mu = mu^k). Interpolation uniqueness rewrites both sides by Sylvester and applies Finset.sum_congr term by term. The right eigen-relation mirrors the parent's left one: prove coordProj * diagonal d = mu * coordProj (diagonal matrices commute) and conjugate, then commutation follows from the two one-sided relations.",
     "keyInsights": [
       "Sylvester's formula at p = X gives the spectral decomposition A = sum mu Z_mu; at p = X^k it gives A^k = sum mu^k Z_mu, the spectral mapping theorem for powers.",
       "The functional calculus depends on the polynomial only through its eigenvalue samples: polynomials agreeing on the spectrum produce identical matrices (the algebraic shadow of Lagrange interpolation).",
       "Because diagonal matrices commute, the coordinate projection satisfies coordProj * diagonal d = mu * coordProj on the right as well as the left, so each Frobenius covariant is a two-sided eigen-projection that commutes with A.",
+      "The covariants commuting with A means they lie in the commutant of A: they are intrinsic spectral data of the matrix, not artifacts of the particular diagonalizing factors U and V chosen to present it.",
       "Everything reduces to the parent's verified results by polynomial specialization, with no new axioms."
     ]
-  }
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup: diagonalizable form over a commutative ring",
+      "startLine": 38,
+      "endLine": 46,
+      "summary": "Opens the parent namespace and fixes the diagonalizable presentation A = U * diagonal d * V with U V = V U = 1 over an arbitrary commutative ring 𝕜, reusing the Frobenius covariants Z_μ defined in CayleyHamiltonOQ02OQ02."
+    },
+    {
+      "id": "spectral-decomposition",
+      "title": "Part 1a: spectral decomposition A = ∑ μ·Z_μ",
+      "startLine": 48,
+      "endLine": 60,
+      "summary": "Specializes Sylvester's formula to p = X (aeval A X = A, X.eval μ = μ) to express A as the eigenvalue-weighted sum of its own Frobenius covariants over the distinct eigenvalues."
+    },
+    {
+      "id": "spectral-mapping-powers",
+      "title": "Part 1b: spectral mapping for powers Aᵏ = ∑ μᵏ·Z_μ",
+      "startLine": 62,
+      "endLine": 70,
+      "summary": "Specializes Sylvester's formula to p = Xᵏ (via map_pow) to obtain the spectral mapping theorem for powers: A^k re-weights the same fixed projections by μᵏ."
+    },
+    {
+      "id": "interpolation-uniqueness",
+      "title": "Part 2: interpolation uniqueness of the functional calculus",
+      "startLine": 72,
+      "endLine": 86,
+      "summary": "Proves aeval A p depends on p only through its eigenvalue samples p.eval μ: two polynomials agreeing on the spectrum give the same matrix, by rewriting both sides with Sylvester and Finset.sum_congr."
+    },
+    {
+      "id": "two-sided-eigenprojections",
+      "title": "Part 3: covariants are two-sided eigen-projections",
+      "startLine": 88,
+      "endLine": 140,
+      "summary": "Establishes the right eigen-relation Z_μ A = μ Z_μ (via the diagonal-commutation lemma coordProj_mul_diag conjugated through U, V) and combines it with the parent's left relation to show each Z_μ commutes with A."
+    }
+  ],
+  "conclusion": {
+    "summary": "Five theorems read the spectral content of A off the parent's Sylvester interpolation formula. Specializing aeval A p = ∑_μ p.eval(μ)·Z_μ to p = X gives the spectral decomposition A = ∑_μ μ·Z_μ; to p = Xᵏ gives the spectral mapping theorem for powers A^k = ∑_μ μᵏ·Z_μ. Interpolation uniqueness shows the polynomial functional calculus depends on a polynomial only through its values on the eigenvalues. Finally the Frobenius covariants are shown to be two-sided eigen-projections (Z_μ A = μ Z_μ as well as A Z_μ = μ Z_μ) that commute with A. Everything is derived by polynomial specialization from the verified, axiom-free parent, with 0 sorries and 0 axioms.",
+    "implications": "Together these results exhibit the Frobenius covariants as the intrinsic spectral resolution of a diagonalizable matrix: a fixed family of commuting idempotents that resolve the identity, onto which every polynomial (and, over ℂ, every holomorphic function) in A acts by simple scalar re-weighting f(A) = ∑_μ f(μ)·Z_μ. This is the finite-dimensional, purely algebraic core of the spectral theorem and the holomorphic functional calculus, valid over any commutative ring rather than just an algebraically closed field. The interpolation-uniqueness principle is the bridge to the minimal polynomial: f(A) is determined by the residues of f modulo the spectrum, so the minimal polynomial captures the full algebra generated by A.",
+    "openQuestions": [
+      "How do the Frobenius covariants and the spectral decomposition degrade for non-diagonalizable matrices, where they are replaced by the Jordan/Riesz projections and the functional calculus must sample derivatives f'(μ), f''(μ), … as well as values?",
+      "Can the value-only interpolation uniqueness be sharpened to a Hermite-interpolation statement giving the exact dependence of f(A) on the jet of f at each eigenvalue when eigenvalues are repeated with non-trivial Jordan structure?",
+      "Over a commutative ring with zero divisors or non-distinct d-values that collide, what hypotheses on 𝕜 guarantee the covariants remain well-defined orthogonal idempotents?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "The parent entry: proves Sylvester's interpolation formula aeval A p = ∑_μ p.eval(μ)·Z_μ and the projection algebra of the Frobenius covariants (Z_μ² = Z_μ, Z_μ Z_ν = 0, ∑ Z_μ = 1, A Z_μ = μ Z_μ). This entry specializes that formula to read off the spectral consequences for A."
+    },
+    {
+      "targetId": "cayley-hamilton-oq-02",
+      "relationship": "related",
+      "description": "The grandparent that posed Sylvester's formula as an open question and supplies the Cayley–Hamilton polynomial-reduction context in which the functional calculus lives."
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "The Cayley–Hamilton theorem underpins the polynomial functional calculus that Sylvester's formula makes explicit on the spectrum, bounding the degree at which polynomials in A become linearly dependent."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-oq-02-oq-02-oq-01`.

This entry had a strong overview but was missing inline annotations, sections, conclusion, and cross-references (quality 15/100). Improvements:

- **annotations.json** (new): 7 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering the diagonalizable setup, the spectral decomposition $A=\sum\mu Z_\mu$, the spectral mapping theorem for powers, interpolation uniqueness, the diagonal-commutation lemma, the right eigen-relation $Z_\mu A=\mu Z_\mu$, and covariant commutation.
- **sections[]** (5): full line-range coverage of the Lean file.
- **conclusion**: summary, implications, and 3 open questions (non-diagonalizable/Jordan generalization, Hermite interpolation, ring hypotheses).
- **crossReferences**: parent `cayley-hamilton-oq-02-oq-02`, grandparent `cayley-hamilton-oq-02`, root `cayley-hamilton`.
- Added a 5th keyInsight (covariants lie in the commutant of A); extended historicalContext with the Frobenius/Sylvester/Riesz–Dunford lineage.
- Fixed `theoremCount` 5 → 6 (the file has 6 `theorem` declarations).

Quality score 15 → 100. `pnpm build` passes.