### PR TITLE
Enrich The Off-Diagonal First-Moment Ramsey Bound

### DIFF
--- a/src/data/proofs/prob-method-expectation-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/prob-method-expectation-oq-02-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-edges-coloring",
+    "proofId": "prob-method-expectation-oq-02-oq-02",
+    "range": { "startLine": 43, "endLine": 51 },
+    "type": "definition",
+    "title": "Edges and 2-colorings of Kₙ",
+    "content": "The sample space is built explicitly rather than through a probability measure. `Edges n` is the set of 2-element subsets of `Fin n` — the edges of the complete graph $K_n$ — and `card_Edges` confirms there are exactly $\\binom{n}{2}$ of them. A `Coloring n` is a function assigning a `Bool` to each edge (`true` = red, `false` = blue), so the space of all colorings is $\\mathrm{Bool}^{E(K_n)}$ with exactly $2^{\\binom{n}{2}}$ elements. Working with genuine functions on edges (not an abstract measure) is what makes the union-bound argument a finite count.",
+    "mathContext": "$|E(K_n)| = \\binom{n}{2}$, and the number of 2-colorings is $|\\mathrm{Bool}^{E(K_n)}| = 2^{\\binom{n}{2}}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["complete graph", "edge coloring", "powersetCard", "finite sample space"],
+    "prerequisites": ["finite combinatorics", "Finset", "graph theory basics"]
+  },
+  {
+    "id": "ann-edgesin",
+    "proofId": "prob-method-expectation-oq-02-oq-02",
+    "range": { "startLine": 53, "endLine": 79 },
+    "type": "technique",
+    "title": "Induced clique edges biject with 2-subsets",
+    "content": "`EdgesIn n K` collects the edges contained in a vertex set $K$. The lemma `card_EdgesIn` shows these are in bijection with the 2-element subsets of $K$, hence number $\\binom{|K|}{2}$. The proof maps the subtype of induced edges injectively to `K.powersetCard 2` and counts the image. This count is the exponent bookkeeping that later distinguishes the red $s$-cliques (each with $\\binom{s}{2}$ forced edges) from the blue $t$-cliques (each with $\\binom{t}{2}$).",
+    "mathContext": "$|\\{e \\in E(K_n) : e \\subseteq K\\}| = \\binom{|K|}{2}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["induced subgraph", "binomial coefficient", "injective image cardinality", "powersetCard"],
+    "prerequisites": ["Finset.card_image_of_injective", "bijections"]
+  },
+  {
+    "id": "ann-monocolor",
+    "proofId": "prob-method-expectation-oq-02-oq-02",
+    "range": { "startLine": 81, "endLine": 89 },
+    "type": "definition",
+    "title": "Color-fixed monochromatic cliques",
+    "content": "`MonoColor c K col` says every induced edge of $K$ has the fixed color `col`. Crucially the color is a parameter: `MonoColor c K true` means $K$ is a *red* clique and `MonoColor c K false` means $K$ is a *blue* clique. This is the structural source of the off-diagonal asymmetry — the diagonal proof asks only whether a clique is monochromatic in *some* color, whereas here red $s$-cliques and blue $t$-cliques are counted as two distinct, color-pinned families.",
+    "mathContext": "$\\mathrm{MonoColor}\\,c\\,K\\,\\mathrm{col} \\iff \\forall e \\subseteq K,\\ c(e) = \\mathrm{col}.$",
+    "significance": "key",
+    "relatedConcepts": ["monochromatic clique", "Ramsey property", "two-color asymmetry"],
+    "prerequisites": ["edge colorings", "decidable predicates"]
+  },
+  {
+    "id": "ann-crux-count",
+    "proofId": "prob-method-expectation-oq-02-oq-02",
+    "range": { "startLine": 91, "endLine": 131 },
+    "type": "insight",
+    "title": "The union-bound term has no factor of 2",
+    "content": "`card_monoColor_le` is the heart of the count: the colorings constant of a *fixed* color on a fixed clique $K$ number at most $2^{\\binom{n}{2} - \\binom{|K|}{2}}$. The proof builds an injection sending such a coloring to its restriction to the off-clique edges — the clique edges are forced to `col`, so they carry no information. Because the color is fixed in advance there is **no factor of 2**, exactly half of the diagonal entry's per-clique term (which sums over both colors). This halving is precisely what lets the two off-diagonal families be weighted independently.",
+    "mathContext": "$\\#\\{c : \\mathrm{MonoColor}\\,c\\,K\\,\\mathrm{col}\\} \\le 2^{\\binom{n}{2} - \\binom{|K|}{2}}$, via the injection $c \\mapsto c|_{E(K_n)\\setminus E(K)}$.",
+    "significance": "key",
+    "relatedConcepts": ["injection counting", "Fintype.card_le_of_injective", "first moment", "forced coordinates"],
+    "prerequisites": ["cardinality of function types", "subtype cardinality"]
+  },
+  {
+    "id": "ann-first-moment",
+    "proofId": "prob-method-expectation-oq-02-oq-02",
+    "range": { "startLine": 133, "endLine": 245 },
+    "type": "insight",
+    "title": "Off-diagonal first-moment bound, subtraction-free",
+    "content": "`first_moment_offdiagonal` assembles the argument. The bad set is the union of `BadRed` (colorings with some red $s$-clique) and `BadBlue` (some blue $t$-clique); `Finset.card_biUnion_le` is the union bound, giving $\\#\\text{bad} \\le \\binom{n}{s}2^{\\binom{n}{2}-\\binom{s}{2}} + \\binom{n}{t}2^{\\binom{n}{2}-\\binom{t}{2}}$. To show this is below the total $2^{\\binom{n}{2}}$, the proof multiplies through by $2^{\\binom{s}{2}+\\binom{t}{2}}$ (keys `key1`/`key2` turn the differences into sums via `omega`), reducing the goal to the hypothesis $\\binom{n}{s}2^{\\binom{t}{2}} + \\binom{n}{t}2^{\\binom{s}{2}} < 2^{\\binom{s}{2}+\\binom{t}{2}}$. A coloring outside the bad set then witnesses $R(s,t) > n$. No $s,t \\ge 2$ hypothesis is needed — the bound is self-correcting.",
+    "mathContext": "$\\#\\text{bad} < 2^{\\binom{n}{2}}$ whenever $\\binom{n}{s}2^{\\binom{t}{2}} + \\binom{n}{t}2^{\\binom{s}{2}} < 2^{\\binom{s}{2}+\\binom{t}{2}}$, hence $\\exists c$ with no red $K_s$, no blue $K_t$.",
+    "significance": "key",
+    "relatedConcepts": ["union bound", "first moment method", "Ramsey lower bound", "pigeonhole on cardinality", "natural-number subtraction"],
+    "prerequisites": ["Finset.card_biUnion_le", "monotone exponentials", "omega"]
+  },
+  {
+    "id": "ann-witnesses",
+    "proofId": "prob-method-expectation-oq-02-oq-02",
+    "range": { "startLine": 247, "endLine": 287 },
+    "type": "context",
+    "title": "Diagonal recovery and a true off-diagonal instance",
+    "content": "`ramsey_offdiagonal_gt` restates the result in witness form (every $s$-clique has a blue edge, every $t$-clique has a red edge). Two concrete instances are then discharged by `by decide` (not `native_decide`, preserving axiom-freeness): `ramsey_four_four_gt_six` recovers the diagonal $R(4,4) > 6$ through the off-diagonal formula ($\\binom{6}{4}2^6 + \\binom{6}{4}2^6 = 1920 < 4096$), and `ramsey_three_four_gt_four` gives a genuinely asymmetric $R(3,4) > 4$ ($\\binom{4}{3}2^6 + \\binom{4}{4}2^3 = 264 < 512$).",
+    "mathContext": "$R(4,4) > 6$: $1920 < 2^{12}$. $\\quad R(3,4) > 4$: $264 < 2^{9}$.",
+    "significance": "context",
+    "relatedConcepts": ["small Ramsey numbers", "decidability", "diagonal vs off-diagonal", "concrete witnesses"],
+    "prerequisites": ["Ramsey numbers", "decide tactic"]
+  }
+]

--- a/src/data/proofs/prob-method-expectation-oq-02-oq-02/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-02-oq-02/meta.json
@@ -1,28 +1,19 @@
 {
   "id": "prob-method-expectation-oq-02-oq-02",
-  "slug": "prob-method-expectation-oq-02-oq-02",
   "title": "The Off-Diagonal First-Moment Ramsey Bound",
-  "sorries": 0,
+  "slug": "prob-method-expectation-oq-02-oq-02",
   "description": "The off-diagonal Erdős union-bound criterion for Ramsey numbers, formalized over genuine edge 2-colorings of the complete graph: if C(n,s)·2^(C(t,2)) + C(n,t)·2^(C(s,2)) < 2^(C(s,2)+C(t,2)) then there is a 2-coloring of K_n with no red K_s and no blue K_t, hence R(s,t) > n. This is the s ≠ t generalization of the diagonal bound, answering open question #2 of the parent entry prob-method-expectation-oq-02.",
-  "overview": "The diagonal first-moment bound (parent entry prob-method-expectation-oq-02) counts cliques that are monochromatic in *either* color. For the off-diagonal Ramsey number R(s,t) the two colors play asymmetric roles: we must avoid a *red* clique of size s and a *blue* clique of size t. This entry runs the union bound over two families simultaneously.\n\nThe sample space is the set of all 2-colorings `c : Edges n → Bool` of the C(n,2) edges of the complete graph on `Fin n` (`true` = red, `false` = blue); there are exactly 2^(C(n,2)) of them. The crux lemma `card_monoColor_le` bounds the number of colorings constant of a *fixed* color on a fixed k-clique by 2^(C(n,2)−C(k,2)) — note there is no factor of 2 here (unlike the diagonal count), because the color is fixed in advance. Summing 2^(C(n,2)−C(s,2)) over the C(n,s) potential red s-cliques and 2^(C(n,2)−C(t,2)) over the C(n,t) potential blue t-cliques gives the total number of 'bad' colorings, which is strictly below 2^(C(n,2)) exactly when C(n,s)·2^(C(t,2)) + C(n,t)·2^(C(s,2)) < 2^(C(s,2)+C(t,2)) — the integer (cleared-denominator) form of the textbook criterion C(n,s)·2^(−C(s,2)) + C(n,t)·2^(−C(t,2)) < 1. A coloring outside the bad set witnesses R(s,t) > n.\n\nThe arithmetic crux is handled without case-splitting on whether C(n,2) ≥ C(s,2)+C(t,2): the inequality is established by multiplying through by 2^(C(s,2)+C(t,2)) and using only C(s,2), C(t,2) ≤ C(n,2) (from s, t ≤ n), which keeps every exponent subtraction well-defined.",
-  "conclusion": {
-    "summary": "Formalizes the off-diagonal union-bound (first moment) Ramsey lower bound over real colorings: whenever C(n,s)·2^(C(t,2)) + C(n,t)·2^(C(s,2)) < 2^(C(s,2)+C(t,2)), the complete graph K_n admits a 2-coloring with no red K_s and no blue K_t, so the off-diagonal Ramsey number satisfies R(s,t) > n. This directly answers open question #2 of the parent entry.",
-    "implications": "**1. Asymmetric union bound.** Where the diagonal proof counted either-color monochromatic cliques with a factor of 2, the off-diagonal proof counts a fixed color on each of two clique families separately; the per-clique term loses the factor of 2 precisely because the target color is fixed.\n\n**2. Recovers the diagonal bound.** Setting s = t = k the criterion becomes 2·C(n,k)·2^(C(k,2)) < 2^(2·C(k,2)), i.e. 2·C(n,k) < 2^(C(k,2)) — exactly the parent's diagonal threshold. The witness ramsey_four_four_gt_six re-derives R(4,4) > 6 through the off-diagonal formula.\n\n**3. Subtraction-free arithmetic.** The strict inequality #bad < 2^(C(n,2)) is proved by clearing denominators (multiplying by 2^(C(s,2)+C(t,2))), so the bound holds for all s, t ≤ n with no auxiliary hypothesis on the relative sizes of the binomial coefficients.\n\n**4. No probability measure.** As with the diagonal case the entire argument is a finite ℕ counting / union bound, making the 'expected number of monochromatic cliques < 1' heuristic fully rigorous and machine-checkable.",
-    "openQuestions": [
-      "Derive the explicit off-diagonal asymptotic R(s,t) ≳ (t/log t)^((s+1)/2) for fixed s by estimating both binomial terms and optimizing n, the off-diagonal analogue of the diagonal 2^(k/2) growth.",
-      "Combine with the alteration / deletion method to obtain the stronger off-diagonal lower bounds that beat the pure union bound for unbalanced s, t."
+  "overview": {
+    "historicalContext": "The probabilistic method was born in Paul Erdős's 1947 three-page note *Some remarks on the theory of graphs*, where he proved $R(k,k) > 2^{k/2}$ by the strikingly simple observation that if the expected number of monochromatic $K_k$ in a uniformly random 2-coloring of $K_n$ is below $1$, then some coloring has none at all. This non-constructive existence argument — counting rather than building the object — opened an entire field, later codified in Alon and Spencer's *The Probabilistic Method*. The diagonal bound was the historical seed; the off-diagonal Ramsey numbers $R(s,t)$ with $s \\neq t$ are the natural and much harder relatives. Here the two colors play asymmetric roles: one forbids a *red* clique of size $s$ and a *blue* clique of size $t$, and the union bound must be run over two families with different per-clique weights. The off-diagonal regime has driven major 20th- and 21st-century combinatorics — Kim's 1995 determination of $R(3,t) = \\Theta(t^2/\\log t)$ (a Fulkerson Prize result) and the recent breakthroughs on $R(4,t)$ — all of which take the first-moment lower bound formalized here as their classical baseline.",
+    "problemStatement": "Color the $C(n,2)$ edges of the complete graph $K_n$ with two colors. The claim, formalized over genuine edge 2-colorings $c : E(K_n) \\to \\{\\text{red},\\text{blue}\\}$, is: if $\\binom{n}{s}\\,2^{\\binom{t}{2}} + \\binom{n}{t}\\,2^{\\binom{s}{2}} < 2^{\\binom{s}{2}+\\binom{t}{2}}$ and $s,t \\le n$, then there exists a 2-coloring of $K_n$ with no red $K_s$ and no blue $K_t$, hence the off-diagonal Ramsey number satisfies $R(s,t) > n$. The hypothesis is the cleared-denominator (subtraction-free) form of the textbook first-moment criterion $\\binom{n}{s} 2^{-\\binom{s}{2}} + \\binom{n}{t} 2^{-\\binom{t}{2}} < 1$.",
+    "proofStrategy": "The diagonal first-moment bound (parent entry prob-method-expectation-oq-02) counts cliques that are monochromatic in *either* color. For the off-diagonal Ramsey number R(s,t) the two colors play asymmetric roles: we must avoid a *red* clique of size s and a *blue* clique of size t. This entry runs the union bound over two families simultaneously.\n\nThe sample space is the set of all 2-colorings `c : Edges n → Bool` of the C(n,2) edges of the complete graph on `Fin n` (`true` = red, `false` = blue); there are exactly 2^(C(n,2)) of them. The crux lemma `card_monoColor_le` bounds the number of colorings constant of a *fixed* color on a fixed k-clique by 2^(C(n,2)−C(k,2)) — note there is no factor of 2 here (unlike the diagonal count), because the color is fixed in advance. Summing 2^(C(n,2)−C(s,2)) over the C(n,s) potential red s-cliques and 2^(C(n,2)−C(t,2)) over the C(n,t) potential blue t-cliques gives the total number of 'bad' colorings, which is strictly below 2^(C(n,2)) exactly when C(n,s)·2^(C(t,2)) + C(n,t)·2^(C(s,2)) < 2^(C(s,2)+C(t,2)) — the integer (cleared-denominator) form of the textbook criterion C(n,s)·2^(−C(s,2)) + C(n,t)·2^(−C(t,2)) < 1. A coloring outside the bad set witnesses R(s,t) > n.\n\nThe arithmetic crux is handled without case-splitting on whether C(n,2) ≥ C(s,2)+C(t,2): the inequality is established by multiplying through by 2^(C(s,2)+C(t,2)) and using only C(s,2), C(t,2) ≤ C(n,2) (from s, t ≤ n), which keeps every exponent subtraction well-defined.",
+    "keyInsights": [
+      "The off-diagonal union bound runs over **two** clique families with **asymmetric weights**: the expected number of red $K_s$ is $\\binom{n}{s}2^{-\\binom{s}{2}}$ and of blue $K_t$ is $\\binom{n}{t}2^{-\\binom{t}{2}}$, and one demands their *sum* be below $1$. The diagonal proof's single family with a factor of $2$ is the special case $s=t$.",
+      "The crux count `card_monoColor_le` has **no factor of 2**. Fixing the target color in advance, a coloring monochromatic of that color on a clique $K$ is completely determined by its values on the off-clique edges, giving an injection into $(\\text{off-clique edges} \\to \\mathrm{Bool})$ and the bound $2^{\\binom{n}{2}-\\binom{k}{2}}$ — exactly half of the diagonal term, which counts *either* color.",
+      "The strict inequality $\\#\\text{bad} < 2^{\\binom{n}{2}}$ is proved **subtraction-free**: multiplying through by $2^{\\binom{s}{2}+\\binom{t}{2}}$ turns the exponent differences $\\binom{n}{2}-\\binom{s}{2}$ into sums, so the argument needs only $\\binom{s}{2},\\binom{t}{2} \\le \\binom{n}{2}$ (from $s,t\\le n$) and never case-splits on the sign of an exponent — the natural way to dodge truncated $\\mathbb{N}$-subtraction in Lean.",
+      "Setting $s=t=k$ collapses the criterion to $2\\binom{n}{k} < 2^{\\binom{k}{2}}$, recovering the parent entry's diagonal threshold exactly; the example `ramsey_four_four_gt_six` re-derives $R(4,4) > 6$ through the off-diagonal formula, and `ramsey_three_four_gt_four` exhibits a genuinely asymmetric instance $R(3,4) > 4$.",
+      "No probability measure appears anywhere: the whole proof is a finite counting argument over $\\mathbb{N}$ via `Finset.card_biUnion_le` (the union bound) and `Finset.card_le_card`. This makes the heuristic 'expected count $< 1$ $\\Rightarrow$ existence' fully rigorous and machine-checkable, and the result is verified with **0 axioms and 0 `sorry`s** (and no `native_decide` — the concrete witnesses use `by decide`)."
     ]
-  },
-  "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Finset"],
-    "namespace": "ProbMethod.RamseyOffDiagonal",
-    "lineCount": 287,
-    "axiomCount": 0,
-    "theoremCount": 7,
-    "definitionCount": 4,
-    "path": "Proofs/RamseyFirstMomentOffDiagonal.lean",
-    "sorries": 0
   },
   "mainTheorems": [
     {
@@ -57,22 +48,93 @@
     }
   ],
   "sections": [
-    { "title": "Edges and Colorings", "description": "Edges of K_n as 2-element subsets of Fin n (card C(n,2)); a coloring assigns a Bool to each edge (true = red, false = blue)." },
-    { "title": "Induced Clique Edges", "description": "The C(k,2) edges contained in a vertex set K, in bijection with the 2-subsets of K." },
-    { "title": "Color-Fixed Monochromatic Cliques", "description": "MonoColor c K col holds when every induced edge of K has the fixed color col; this separates red cliques (true) from blue cliques (false)." },
-    { "title": "Crux Count (Union-Bound Term)", "description": "Colorings constant of a fixed color on a fixed clique number at most 2^(C(n,2)−C(k,2)) — no factor of 2 — by an explicit injection into (off-clique edges → Bool)." },
-    { "title": "Off-Diagonal First-Moment Bound", "description": "Union bound over the C(n,s) red s-cliques and C(n,t) blue t-cliques yields a good coloring whenever C(n,s)·2^(C(t,2)) + C(n,t)·2^(C(s,2)) < 2^(C(s,2)+C(t,2))." },
-    { "title": "Ramsey Number Lower Bound and Concrete Witnesses", "description": "Witness form R(s,t) > n; the diagonal recovery R(4,4) > 6 and the off-diagonal instance R(3,4) > 4." }
+    {
+      "title": "Edges and Colorings",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Edges of K_n as 2-element subsets of Fin n (card C(n,2)); a coloring assigns a Bool to each edge (true = red, false = blue)."
+    },
+    {
+      "title": "Induced Clique Edges",
+      "startLine": 49,
+      "endLine": 79,
+      "summary": "The C(k,2) edges contained in a vertex set K, in bijection with the 2-subsets of K."
+    },
+    {
+      "title": "Color-Fixed Monochromatic Cliques",
+      "startLine": 81,
+      "endLine": 89,
+      "summary": "MonoColor c K col holds when every induced edge of K has the fixed color col; this separates red cliques (true) from blue cliques (false)."
+    },
+    {
+      "title": "Crux Count (Union-Bound Term)",
+      "startLine": 91,
+      "endLine": 131,
+      "summary": "Colorings constant of a fixed color on a fixed clique number at most 2^(C(n,2)−C(k,2)) — no factor of 2 — by an explicit injection into (off-clique edges → Bool)."
+    },
+    {
+      "title": "Off-Diagonal First-Moment Bound",
+      "startLine": 133,
+      "endLine": 245,
+      "summary": "Union bound over the C(n,s) red s-cliques and C(n,t) blue t-cliques yields a good coloring whenever C(n,s)·2^(C(t,2)) + C(n,t)·2^(C(s,2)) < 2^(C(s,2)+C(t,2))."
+    },
+    {
+      "title": "Ramsey Number Lower Bound and Concrete Witnesses",
+      "startLine": 247,
+      "endLine": 287,
+      "summary": "Witness form R(s,t) > n; the diagonal recovery R(4,4) > 6 and the off-diagonal instance R(3,4) > 4."
+    }
   ],
+  "conclusion": {
+    "summary": "Formalizes the off-diagonal union-bound (first moment) Ramsey lower bound over real colorings: whenever C(n,s)·2^(C(t,2)) + C(n,t)·2^(C(s,2)) < 2^(C(s,2)+C(t,2)), the complete graph K_n admits a 2-coloring with no red K_s and no blue K_t, so the off-diagonal Ramsey number satisfies R(s,t) > n. This directly answers open question #2 of the parent entry.",
+    "implications": "**1. Asymmetric union bound.** Where the diagonal proof counted either-color monochromatic cliques with a factor of 2, the off-diagonal proof counts a fixed color on each of two clique families separately; the per-clique term loses the factor of 2 precisely because the target color is fixed.\n\n**2. Recovers the diagonal bound.** Setting s = t = k the criterion becomes 2·C(n,k)·2^(C(k,2)) < 2^(2·C(k,2)), i.e. 2·C(n,k) < 2^(C(k,2)) — exactly the parent's diagonal threshold. The witness ramsey_four_four_gt_six re-derives R(4,4) > 6 through the off-diagonal formula.\n\n**3. Subtraction-free arithmetic.** The strict inequality #bad < 2^(C(n,2)) is proved by clearing denominators (multiplying by 2^(C(s,2)+C(t,2))), so the bound holds for all s, t ≤ n with no auxiliary hypothesis on the relative sizes of the binomial coefficients.\n\n**4. No probability measure.** As with the diagonal case the entire argument is a finite ℕ counting / union bound, making the 'expected number of monochromatic cliques < 1' heuristic fully rigorous and machine-checkable.",
+    "openQuestions": [
+      "Derive the explicit off-diagonal asymptotic R(s,t) ≳ (t/log t)^((s+1)/2) for fixed s by estimating both binomial terms and optimizing n, the off-diagonal analogue of the diagonal 2^(k/2) growth.",
+      "Combine with the alteration / deletion method to obtain the stronger off-diagonal lower bounds that beat the pure union bound for unbalanced s, t."
+    ]
+  },
   "crossReferences": [
-    { "slug": "prob-method-expectation-oq-02", "relation": "parent", "description": "Answers open question #2 ('formalize the off-diagonal version giving lower bounds on R(s,t) for s ≠ t via the same union bound'); generalizes its diagonal first_moment_ramsey." },
-    { "slug": "prob-method-expectation", "relation": "ancestor", "description": "Grandparent entry on the first-moment / expectation method whose Ramsey placeholder the parent and this entry replace with genuine content." },
-    { "slug": "prob-method-alteration", "relation": "related", "description": "The alteration / deletion method improves on the pure off-diagonal union bound proved here, especially for unbalanced s, t." }
+    {
+      "slug": "prob-method-expectation-oq-02",
+      "relation": "parent",
+      "description": "Answers open question #2 ('formalize the off-diagonal version giving lower bounds on R(s,t) for s ≠ t via the same union bound'); generalizes its diagonal first_moment_ramsey."
+    },
+    {
+      "slug": "prob-method-expectation",
+      "relation": "ancestor",
+      "description": "Grandparent entry on the first-moment / expectation method whose Ramsey placeholder the parent and this entry replace with genuine content."
+    },
+    {
+      "slug": "prob-method-alteration",
+      "relation": "related",
+      "description": "The alteration / deletion method improves on the pure off-diagonal union bound proved here, especially for unbalanced s, t."
+    }
   ],
   "references": [
-    { "label": "Erdős 1947", "citation": "P. Erdős, Some remarks on the theory of graphs, Bull. Amer. Math. Soc. 53 (1947), 292–294." },
-    { "label": "Alon–Spencer", "citation": "N. Alon, J. H. Spencer, The Probabilistic Method, Ch. 1 (the first moment / union bound and the off-diagonal Ramsey lower bounds)." }
+    {
+      "label": "Erdős 1947",
+      "citation": "P. Erdős, Some remarks on the theory of graphs, Bull. Amer. Math. Soc. 53 (1947), 292–294."
+    },
+    {
+      "label": "Alon–Spencer",
+      "citation": "N. Alon, J. H. Spencer, The Probabilistic Method, Ch. 1 (the first moment / union bound and the off-diagonal Ramsey lower bounds)."
+    }
   ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ProbMethod.RamseyOffDiagonal",
+    "lineCount": 287,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 4,
+    "path": "Proofs/RamseyFirstMomentOffDiagonal.lean",
+    "sorries": 0
+  },
   "meta": {
     "status": "verified",
     "badge": "original",
@@ -86,7 +148,15 @@
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
     "sorries": 0,
-    "tags": ["probabilistic-method", "combinatorics", "ramsey-theory", "union-bound", "graph-coloring", "off-diagonal", "intermediate"],
+    "tags": [
+      "probabilistic-method",
+      "combinatorics",
+      "ramsey-theory",
+      "union-bound",
+      "graph-coloring",
+      "off-diagonal",
+      "intermediate"
+    ],
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on the foundational axioms propext, Classical.choice, Quot.sound; no sorryAx, no native_decide / Lean.ofReduceBool).",
     "originalContributions": [
       "card_monoColor_le: the off-diagonal union-bound term — colorings constant of a fixed color on a fixed clique number at most 2^(C(n,2)−C(k,2)) (no factor of 2, since the target color is fixed) — proved by an explicit injection into (off-clique edges → Bool).",
@@ -95,5 +165,6 @@
       "ramsey_offdiagonal_gt: witness reformulation as 'every s-clique has a blue edge and every t-clique has a red edge'.",
       "ramsey_four_four_gt_six: the diagonal R(4,4) > 6 re-derived through the off-diagonal formula, and ramsey_three_four_gt_four: a genuinely off-diagonal instance R(3,4) > 4."
     ]
-  }
+  },
+  "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `prob-method-expectation-oq-02-oq-02` (quality 25, passes 0).

## Problem found
`overview` was stored as a **JSON-encoded string**, so the scorer read 0 for historicalContext and keyInsights even though prose existed. There was also no `annotations.json`.

## Changes
- **Structure fix**: convert `overview` from a string to an object with `historicalContext` (Erdős's 1947 birth of the probabilistic method; off-diagonal Ramsey history through Kim's $R(3,t)=\Theta(t^2/\log t)$), `problemStatement`, `proofStrategy` (the existing prose, preserved), and 5 `keyInsights`.
- **annotations.json**: 6 substantive annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` — covering edges/colorings, induced clique edges, `MonoColor`, the factor-of-2-free crux count, the subtraction-free union bound, and the concrete $R(4,4)>6$ / $R(3,4)>4$ witnesses.
- **sections**: added `startLine`/`endLine` ranges to the 6 existing sections.

Axiom integrity verified against the Lean source: imports only Mathlib, 0 sorries, 0 axioms; the concrete witnesses use `by decide` (not `native_decide`), so `status: verified` / `badge: original` and the "0 axioms" claim are accurate.

`pnpm build` passes.