### PR TITLE
research(erdos-1005-oq-02): S23 — leading-1s on an arbitrary tail are the order-6 rotation [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -2108,4 +2108,223 @@ theorem continuant_one_one_cons_neg (ks : List ℤ) (hne : ks ≠ [])
   have := continuant_pos rest hrest
   linarith
 
+/-! ## §23: Leading `1`s on an arbitrary tail — the period-6 rotation, in full
+
+§22 read off the *boundary* of §17's positive cone from the two closed forms
+`K(1 :: ks) = K(ks) − secondCont ks` and `K(1 :: 1 :: ks) = − secondCont ks`,
+proving that **exactly one** leading `1` keeps a large-quotient tail positive.  §21
+established that the *pure* all-`1` list (`ks = []`) is period-6 with orbit
+`1, 1, 0, −1, −1, 0`.  This section unifies the two: prepending `j` leading `1`s to an
+**arbitrary** tail `ks` is the order-6 rotation `[[1,−1],[1,0]]` acting on the pair
+`(aⱼ, sⱼ) = (K(1ʲ ++ ks), secondCont(1ʲ ++ ks))`.
+
+Writing the §14 single-step recurrences with every leading quotient `= 1` gives the
+coupled system `aⱼ₊₁ = aⱼ − sⱼ`, `sⱼ₊₁ = aⱼ` — identical to §21's all-`1` system but now
+seeded at the arbitrary pair `(K(ks), secondCont ks)` rather than `(1, 0)`.  Its
+companion is the order-6 rotation, so the pair is **6-periodic in the prefix length**
+`j`, and the continuant runs through the explicit orbit
+
+  `K(ks), K(ks) − secondCont ks, − secondCont ks, − K(ks), secondCont ks − K(ks), secondCont ks`.
+
+Substituting `ks = []` (`K = 1`, `secondCont = 0`) recovers §21's `1, 1, 0, −1, −1, 0`
+exactly; `j = 1, 2` recover the §22 closed forms.  On a large-quotient tail the sign of
+each orbit value is then fixed by the §17 invariant `0 < secondCont ks < K(ks)`
+(`secondCont_lt_continuant` + `continuant_pos`): the continuant is `> 0` precisely for
+`j ≡ 0, 1, 5 (mod 6)` and `< 0` for `j ≡ 2, 3, 4`, never zero.  This is the full
+mixed leading-`1` / large-quotient sign classification — the §22 boundary promoted to a
+periodic law, the structural reason a leading run of small quotients can neither grow
+the continuant nor keep it one-signed.
+
+Depends only on the §14 recurrence `continuant_cons`, the §22 closed forms, and the §17
+invariant `secondCont_lt_continuant` / `continuant_pos`. -/
+
+/-- The trailing continuant of a cons is the continuant of the tail (definitional,
+named so it rewrites only explicit cons-form occurrences and leaves a bare
+`secondCont xs` on a variable list untouched). -/
+theorem secondCont_cons (k : ℤ) (ks : List ℤ) : secondCont (k :: ks) = Continuant ks :=
+  rfl
+
+/-- **Three leading `1`s (closed form).**  `K(1 :: 1 :: 1 :: ks) = − K(ks)`: the third
+consecutive `1` negates the tail continuant, the half-turn of the order-6 rotation. -/
+theorem continuant_three_ones_cons (ks : List ℤ) :
+    Continuant (1 :: 1 :: 1 :: ks) = - Continuant ks := by
+  rw [continuant_one_one_cons (1 :: ks), secondCont_cons]
+
+/-- **Four leading `1`s (closed form).**  `K(1⁴ :: ks) = secondCont ks − K(ks)`. -/
+theorem continuant_four_ones_cons (ks : List ℤ) :
+    Continuant (1 :: 1 :: 1 :: 1 :: ks) = secondCont ks - Continuant ks := by
+  rw [continuant_one_cons (1 :: 1 :: 1 :: ks), continuant_three_ones_cons,
+      secondCont_cons, continuant_one_one_cons]
+  ring
+
+/-- **Five leading `1`s (closed form).**  `K(1⁵ :: ks) = secondCont ks`; the sixth
+leading `1` returns to `K(ks)` (the period closes — see
+`continuant_secondCont_replicate_one_append`). -/
+theorem continuant_five_ones_cons (ks : List ℤ) :
+    Continuant (1 :: 1 :: 1 :: 1 :: 1 :: ks) = secondCont ks := by
+  rw [continuant_one_cons (1 :: 1 :: 1 :: 1 :: ks), continuant_four_ones_cons,
+      secondCont_cons, continuant_three_ones_cons]
+  ring
+
+/-- Trailing-continuant single step under a leading `1` on an arbitrary tail:
+`secondCont(1ʲ⁺¹ ++ ks) = K(1ʲ ++ ks)`.  Immediate from `secondCont (_ :: xs) = K(xs)`. -/
+theorem secondCont_replicate_one_append (j : ℕ) (ks : List ℤ) :
+    secondCont (List.replicate (j + 1) 1 ++ ks)
+      = Continuant (List.replicate j 1 ++ ks) := by
+  rw [List.replicate_succ, List.cons_append]; rfl
+
+/-- Continuant single step under a leading `1` on an arbitrary tail:
+`aⱼ₊₁ = aⱼ − sⱼ`, the §14 recurrence `continuant_cons` with the leading factor `= 1`. -/
+theorem continuant_replicate_one_succ_append (j : ℕ) (ks : List ℤ) :
+    Continuant (List.replicate (j + 1) 1 ++ ks)
+      = Continuant (List.replicate j 1 ++ ks)
+        - secondCont (List.replicate j 1 ++ ks) := by
+  rw [List.replicate_succ, List.cons_append, continuant_cons]; ring
+
+/-- **The leading-`1` pair is period-6 (joint headline).**  For *every* tail `ks` and
+prefix length `j`, both `aⱼ = K(1ʲ ++ ks)` and its companion `sⱼ = secondCont(1ʲ ++ ks)`
+satisfy `aⱼ₊₆ = aⱼ` and `sⱼ₊₆ = sⱼ`.  The coupled recurrence `aⱼ₊₁ = aⱼ − sⱼ`,
+`sⱼ₊₁ = aⱼ` is the order-6 rotation `[[1,−1],[1,0]]`, whose sixth power is the identity;
+unfolding six steps reduces the claim to linear integer arithmetic that `omega`
+discharges.  Specialising `ks = []` gives §21's `continuant_secondCont_replicate_one`. -/
+theorem continuant_secondCont_replicate_one_append (j : ℕ) (ks : List ℤ) :
+    Continuant (List.replicate (j + 6) 1 ++ ks)
+        = Continuant (List.replicate j 1 ++ ks)
+      ∧ secondCont (List.replicate (j + 6) 1 ++ ks)
+        = secondCont (List.replicate j 1 ++ ks) := by
+  have c1 : Continuant (List.replicate (j + 1) 1 ++ ks)
+      = Continuant (List.replicate j 1 ++ ks) - secondCont (List.replicate j 1 ++ ks) :=
+    continuant_replicate_one_succ_append j ks
+  have s1 : secondCont (List.replicate (j + 1) 1 ++ ks)
+      = Continuant (List.replicate j 1 ++ ks) :=
+    secondCont_replicate_one_append j ks
+  have c2 : Continuant (List.replicate (j + 2) 1 ++ ks)
+      = Continuant (List.replicate (j + 1) 1 ++ ks)
+        - secondCont (List.replicate (j + 1) 1 ++ ks) :=
+    continuant_replicate_one_succ_append (j + 1) ks
+  have s2 : secondCont (List.replicate (j + 2) 1 ++ ks)
+      = Continuant (List.replicate (j + 1) 1 ++ ks) :=
+    secondCont_replicate_one_append (j + 1) ks
+  have c3 : Continuant (List.replicate (j + 3) 1 ++ ks)
+      = Continuant (List.replicate (j + 2) 1 ++ ks)
+        - secondCont (List.replicate (j + 2) 1 ++ ks) :=
+    continuant_replicate_one_succ_append (j + 2) ks
+  have s3 : secondCont (List.replicate (j + 3) 1 ++ ks)
+      = Continuant (List.replicate (j + 2) 1 ++ ks) :=
+    secondCont_replicate_one_append (j + 2) ks
+  have c4 : Continuant (List.replicate (j + 4) 1 ++ ks)
+      = Continuant (List.replicate (j + 3) 1 ++ ks)
+        - secondCont (List.replicate (j + 3) 1 ++ ks) :=
+    continuant_replicate_one_succ_append (j + 3) ks
+  have s4 : secondCont (List.replicate (j + 4) 1 ++ ks)
+      = Continuant (List.replicate (j + 3) 1 ++ ks) :=
+    secondCont_replicate_one_append (j + 3) ks
+  have c5 : Continuant (List.replicate (j + 5) 1 ++ ks)
+      = Continuant (List.replicate (j + 4) 1 ++ ks)
+        - secondCont (List.replicate (j + 4) 1 ++ ks) :=
+    continuant_replicate_one_succ_append (j + 4) ks
+  have s5 : secondCont (List.replicate (j + 5) 1 ++ ks)
+      = Continuant (List.replicate (j + 4) 1 ++ ks) :=
+    secondCont_replicate_one_append (j + 4) ks
+  have c6 : Continuant (List.replicate (j + 6) 1 ++ ks)
+      = Continuant (List.replicate (j + 5) 1 ++ ks)
+        - secondCont (List.replicate (j + 5) 1 ++ ks) :=
+    continuant_replicate_one_succ_append (j + 5) ks
+  have s6 : secondCont (List.replicate (j + 6) 1 ++ ks)
+      = Continuant (List.replicate (j + 5) 1 ++ ks) :=
+    secondCont_replicate_one_append (j + 5) ks
+  constructor <;> omega
+
+/-- The leading-`1` continuant alone is period-6: `K(1ʲ⁺⁶ ++ ks) = K(1ʲ ++ ks)`. -/
+theorem continuant_replicate_one_append_period (j : ℕ) (ks : List ℤ) :
+    Continuant (List.replicate (j + 6) 1 ++ ks)
+      = Continuant (List.replicate j 1 ++ ks) :=
+  (continuant_secondCont_replicate_one_append j ks).1
+
+/-- Period-6 across any multiple of `6`: `K(1^(6q+r) ++ ks) = K(1ʳ ++ ks)`, by induction
+on the number of full turns `q` of the rotation orbit. -/
+theorem continuant_replicate_one_append_six_mul (q r : ℕ) (ks : List ℤ) :
+    Continuant (List.replicate (6 * q + r) 1 ++ ks)
+      = Continuant (List.replicate r 1 ++ ks) := by
+  induction q with
+  | zero => simp
+  | succ q ih =>
+    have hidx : 6 * (q + 1) + r = (6 * q + r) + 6 := by ring
+    rw [hidx, continuant_replicate_one_append_period, ih]
+
+/-- **Closed form via residue mod 6.**  `K(1ʲ ++ ks)` depends only on `j % 6` — the
+prefix length matters solely through its position on the order-6 orbit. -/
+theorem continuant_replicate_one_append_mod (j : ℕ) (ks : List ℤ) :
+    Continuant (List.replicate j 1 ++ ks)
+      = Continuant (List.replicate (j % 6) 1 ++ ks) := by
+  conv_lhs => rw [← Nat.div_add_mod j 6]
+  exact continuant_replicate_one_append_six_mul (j / 6) (j % 6) ks
+
+/-- **The full leading-`1` orbit (closed form).**  For every tail `ks`, the continuant
+`K(1ʲ ++ ks)` runs through the six explicit values of the order-6 rotation orbit seeded
+at `(K(ks), secondCont ks)`, selected by `j % 6`:
+`K, K − s, −s, −K, s − K, s` (with `s = secondCont ks`).  Substituting `ks = []`
+(`K = 1`, `s = 0`) yields §21's orbit `1, 1, 0, −1, −1, 0`; `j % 6 = 1, 2` are the §22
+closed forms `continuant_one_cons` / `continuant_one_one_cons`. -/
+theorem continuant_replicate_one_append_orbit (j : ℕ) (ks : List ℤ) :
+    Continuant (List.replicate j 1 ++ ks)
+      = (if j % 6 = 0 then Continuant ks
+         else if j % 6 = 1 then Continuant ks - secondCont ks
+         else if j % 6 = 2 then - secondCont ks
+         else if j % 6 = 3 then - Continuant ks
+         else if j % 6 = 4 then secondCont ks - Continuant ks
+         else secondCont ks) := by
+  rw [continuant_replicate_one_append_mod j ks]
+  have h6 : j % 6 < 6 := Nat.mod_lt _ (by norm_num)
+  set r := j % 6 with hr
+  clear_value r
+  interval_cases r
+  · simp
+  · simpa using continuant_one_cons ks
+  · simpa using continuant_one_one_cons ks
+  · simpa using continuant_three_ones_cons ks
+  · simpa using continuant_four_ones_cons ks
+  · simpa using continuant_five_ones_cons ks
+
+/-- **Sign classification (large-quotient tail).**  On a nonempty all-`≥ 2` tail the §17
+invariant `0 < secondCont ks < K(ks)` fixes the sign of every orbit value: the continuant
+`K(1ʲ ++ ks)` is strictly positive **iff** `j ≡ 0, 1, 5 (mod 6)`.  The complementary
+residues `j ≡ 2, 3, 4` give a strictly negative value (`continuant_replicate_one_append_ne_zero`),
+so the leading-`1` run alternates sign in a fixed period-6 pattern and is never zero —
+§22's "exactly one leading `1` preserves positivity" promoted to the full periodic law. -/
+theorem continuant_replicate_one_append_pos_iff (j : ℕ) (ks : List ℤ)
+    (hne : ks ≠ []) (h : ∀ k ∈ ks, (2 : ℤ) ≤ k) :
+    0 < Continuant (List.replicate j 1 ++ ks)
+      ↔ (j % 6 = 0 ∨ j % 6 = 1 ∨ j % 6 = 5) := by
+  rw [continuant_replicate_one_append_orbit]
+  have hpos : 0 < Continuant ks := continuant_pos ks h
+  have hsc : 0 < secondCont ks := by
+    obtain ⟨k, rest, rfl⟩ := List.exists_cons_of_ne_nil hne
+    simp only [secondCont]
+    exact continuant_pos rest (fun m hm => h m (List.mem_cons_of_mem k hm))
+  have hlt : secondCont ks < Continuant ks := (secondCont_lt_continuant ks h).2
+  have h6 : j % 6 < 6 := Nat.mod_lt _ (by norm_num)
+  set r := j % 6 with hr
+  clear_value r
+  interval_cases r <;> simp <;> omega
+
+/-- **The leading-`1` orbit never vanishes on a large-quotient tail.**  For a nonempty
+all-`≥ 2` tail, `K(1ʲ ++ ks) ≠ 0` for *every* prefix length `j`: the empty-tail zeros of
+§21's orbit (`K[1,1] = 0`, etc.) are an artefact of `ks = []`; any large-quotient tail
+pushes every orbit value strictly off zero. -/
+theorem continuant_replicate_one_append_ne_zero (j : ℕ) (ks : List ℤ)
+    (hne : ks ≠ []) (h : ∀ k ∈ ks, (2 : ℤ) ≤ k) :
+    Continuant (List.replicate j 1 ++ ks) ≠ 0 := by
+  rw [continuant_replicate_one_append_orbit]
+  have hpos : 0 < Continuant ks := continuant_pos ks h
+  have hsc : 0 < secondCont ks := by
+    obtain ⟨k, rest, rfl⟩ := List.exists_cons_of_ne_nil hne
+    simp only [secondCont]
+    exact continuant_pos rest (fun m hm => h m (List.mem_cons_of_mem k hm))
+  have hlt : secondCont ks < Continuant ks := (secondCont_lt_continuant ks h).2
+  have h6 : j % 6 < 6 := Nat.mod_lt _ (by norm_num)
+  set r := j % 6 with hr
+  clear_value r
+  interval_cases r <;> simp <;> omega
+
 end Erdos1005OQ02

--- a/research/problems/erdos-1005-oq-02/knowledge.md
+++ b/research/problems/erdos-1005-oq-02/knowledge.md
@@ -1,3 +1,45 @@
+## Session 2026-06-30 (researcher-8): §23 leading-1s on an arbitrary tail — period-6 rotation in full
+
+**Mode**: REVISIT · **Outcome**: progress (VERIFIED, 0-axiom). PR pending.
+
+Unified §21 (all-1, ks=[]) and §22 (j=1,2 leading-1 boundary) into one law:
+prepending `j` leading `1`s to an **arbitrary** tail `ks` is the order-6 rotation
+`[[1,−1],[1,0]]` acting on the pair `(aⱼ,sⱼ)=(K(1ʲ++ks), secondCont(1ʲ++ks))`.
+
+### What I Did
+- Proved the two coupled single-step append recurrences `sⱼ₊₁=aⱼ`,
+  `aⱼ₊₁=aⱼ−sⱼ` on a general tail (`secondCont_replicate_one_append`,
+  `continuant_replicate_one_succ_append`) — the §21 all-1 system seeded at
+  `(K(ks),secondCont ks)` instead of `(1,0)`.
+- Headline `continuant_secondCont_replicate_one_append`: joint period-6
+  `aⱼ₊₆=aⱼ ∧ sⱼ₊₆=sⱼ` for every `ks`, by 6-step `omega` (mirrors §21 with
+  explicit `j+k` type ascriptions so omega unifies the indices).
+- Period corollaries `_period/_six_mul/_mod`: `K(1ʲ++ks)` depends only on `j%6`.
+- Three new orbit base values `continuant_three/four/five_ones_cons`:
+  `K(1³::ks)=−K(ks)`, `K(1⁴::ks)=s−K`, `K(1⁵::ks)=s` (`s=secondCont ks`).
+- Full closed form `continuant_replicate_one_append_orbit`: `K(1ʲ++ks)` cycles
+  `[K, K−s, −s, −K, s−K, s]` by `j%6`. **ks=[] (K=1,s=0) recovers §21's orbit
+  `1,1,0,−1,−1,0` exactly**; `j%6=1,2` recover the §22 closed forms.
+- Sign law `continuant_replicate_one_append_pos_iff` / `_ne_zero` (nonempty
+  all-≥2 tail): `K(1ʲ++ks)>0 ⟺ j≡0,1,5 (mod 6)`, `<0` for `2,3,4`, **never 0**.
+
+### Key Findings
+- §21 and §22 are the two specialisations of a single period-6 leading-`1` law;
+  §22's "at most one leading `1` keeps positivity" is just the `j≤2` window of a
+  period-6 sign alternation, and §21's zeros are an artefact of `ks=[]`.
+- The §17 invariant `0<secondCont ks<K(ks)` is exactly what reads off all six
+  orbit signs — no new arithmetic input beyond §17.
+
+### Files Modified
+- `proofs/Proofs/Erdos1005ProblemOQ02.lean` (§23, 12 new theorems, builds clean)
+- `src/data/research/problems/erdos-1005-oq-02.json` (knowledge)
+
+### Next Steps
+- Density aggregation toward the open `1/12` constant (van Doorn `c∈[1/12,1/4]`)
+  still untouched — combine §17 large-quotient linear growth with §23 bounded
+  period-6 leading-`1` blocks to model a general quotient word and count its
+  similar-ordering windows against the order-`n` denominator cap.
+
 ## Session 2026-06-27 (researcher-2): §16 continuant matrix — Cassini + reversal
 
 PR #31083 (VERIFIED, 0-axiom). Realised both named nextSteps targets via an

--- a/research/problems/erdos-1005-oq-02/state.md
+++ b/research/problems/erdos-1005-oq-02/state.md
@@ -1,7 +1,7 @@
 # Current State
 
-**Phase**: FORMALIZED (verified infrastructure; open problem itself remains open)
-**Since**: 2026-06-25
+**Phase**: ACT
+**Since**: 2026-06-30T12:42:13-07:00
 **Iteration**: 16
 
 ## Current Focus

--- a/research/registry.json
+++ b/research/registry.json
@@ -9381,11 +9381,11 @@
     },
     {
       "slug": "erdos-1005-oq-02",
-      "phase": "OBSERVE",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-03-30T21:46:38.105Z",
       "status": "active",
-      "lastUpdate": "2026-06-28T12:29:05.794Z"
+      "lastUpdate": "2026-06-30T12:42:13-07:00"
     },
     {
       "slug": "erdos-1005-wip-01",

--- a/src/data/research/problems/erdos-1005-oq-02.json
+++ b/src/data/research/problems/erdos-1005-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: §22 added (verified, 0-axiom). Closes the named mixed-regime nextStep: the boundary between §17 positive cone (all-≥2 ⇒ K≥len+1) and §21 period-6 orbit (all-1 ⇒ |K|≤1) is SHARP — on an all-≥2 tail exactly one leading quotient may be 1 (K stays >0) but a second consecutive 1 forces K=−secondCont ks ≤0 (strict <0 for nonempty tail). Recovers §21 K([1,1])=0/K([1,1,1])=−1 witnesses. Density aggregation toward open 1/12 constant still untouched.",
+    "progressSummary": "PROGRESS: §23 added (verified, 0-axiom). UNIFIES §21+§22: prepending j leading 1s to ANY tail ks is the order-6 rotation on (K,secondCont), so K(1ʲ++ks) is period-6 in j with explicit orbit [K,K−s,−s,−K,s−K,s] (ks=[] recovers §21 1,1,0,−1,−1,0; j=1,2 recover §22). Sign law on nonempty all-≥2 tails: K>0 iff j≡0,1,5 mod 6, never 0. The §22 boundary promoted to the full periodic leading-1/large-quotient classification. Density aggregation toward open 1/12 constant still untouched.",
     "builtItems": [
       "unimodular_iterate_left/right (Erdos1005ProblemOQ02.lean §6): k-fold one-sided mediant insertion stays unimodular, a/b<(k·a+c)/(k·b+d); proved by scale-invariance of bc=ad+1 (no induction)",
       "denom_ge_iterate_left/right (Erdos1005ProblemOQ02.lean §6): depth-k interior denominator bound q ≥ (k+1)·b+d, LINEAR in depth",
@@ -53,7 +53,14 @@
       "§22 continuant_one_one_cons (:2068, KEY) — K(1::1::ks)=−secondCont ks; second leading 1 cancels leading continuant",
       "§22 continuant_one_cons_pos (:2078) — all-≥2 tail ⇒ 0<K(1::ks); one leading 1 stays in positive cone",
       "§22 continuant_one_one_cons_nonpos (:2088) — all-≥2 tail ⇒ K(1::1::ks)≤0; two leading 1s leave the cone",
-      "§22 continuant_one_one_cons_neg (:2101) — all-≥2 nonempty tail ⇒ K(1::1::ks)<0; K([1,1])=0 is the only zero-touch"
+      "§22 continuant_one_one_cons_neg (:2101) — all-≥2 nonempty tail ⇒ K(1::1::ks)<0; K([1,1])=0 is the only zero-touch",
+      "§23 secondCont_cons (Erdos1005ProblemOQ02.lean) — secondCont(k::ks)=Continuant ks rewrite lemma (rfl), rewrites only explicit cons-forms",
+      "§23 continuant_three/four/five_ones_cons — closed forms K(1³::ks)=−K(ks), K(1⁴::ks)=secondCont ks−K(ks), K(1⁵::ks)=secondCont ks (the three new orbit base values beyond §22)",
+      "§23 secondCont_replicate_one_append / continuant_replicate_one_succ_append — the two coupled single-step append recurrences sⱼ₊₁=aⱼ, aⱼ₊₁=aⱼ−sⱼ on a general tail",
+      "§23 continuant_secondCont_replicate_one_append (HEADLINE) — joint period-6 aⱼ₊₆=aⱼ ∧ sⱼ₊₆=sⱼ for every tail ks, 6-step omega; generalises §21 continuant_secondCont_replicate_one (ks=[] case). [verified, 0-axiom]",
+      "§23 continuant_replicate_one_append_period/_six_mul/_mod — period-6 corollaries, K(1ʲ++ks) depends only on j%6 for every tail",
+      "§23 continuant_replicate_one_append_orbit — full if-then-else closed form by j%6 selecting [K,K−s,−s,−K,s−K,s]; generalises continuant_replicate_one_mod",
+      "§23 continuant_replicate_one_append_pos_iff / _ne_zero — sign classification on nonempty all-≥2 tail: >0 iff j%6∈{0,1,5}, never 0. [verified, 0-axiom]"
     ],
     "insights": [
       "CORRECTION: the roadmap heuristic that the order-n cap forces O(log n) refinement depth is FALSE for arbitrary mediant chains. The one-sided chain 0/1,1/2,1/3,…,1/n fits Θ(n) levels under q≤n with only LINEAR denominator growth (k+1)·b+d.",
@@ -69,12 +76,15 @@
       "All-1 continuant K(1ⁿ) is period-6: every quotient =1 collapses continuant_cons to aₙ₊₁=aₙ−sₙ, sₙ₊₁=aₙ — the order-6 rotation [[1,−1],[1,0]], whose 6th power is the identity",
       "Quantitative §15/§17 dichotomy CLOSED on both extremes: all-2 ladder grows linearly (K=n+1) while all-1 orbit stays bounded (|K|≤1) — the order-side reason a similarly ordered run is never both long and metrically cheap",
       "§22 BOUNDARY characterised (sharp): on an all-≥2 (large-quotient) tail, EXACTLY ONE leading quotient may drop to 1 while K stays >0; a second consecutive 1 forces K=−secondCont ks ≤0 (strictly <0 for nonempty tail). This pins the crossing from §17 positive cone into the §21 period-6 orbit, recovering K([1,1])=0/K([1,1,1])=−1 as the all-2/empty-tail edges.",
-      "§22 mechanism: secondCont(1::ks)=Continuant ks defeq, so K(1::1::ks)=K(1::ks)−K(ks)=−secondCont ks — the leading continuant cancels exactly. The §17 invariant 0≤secondCont<Continuant then reads off both signs."
+      "§22 mechanism: secondCont(1::ks)=Continuant ks defeq, so K(1::1::ks)=K(1::ks)−K(ks)=−secondCont ks — the leading continuant cancels exactly. The §17 invariant 0≤secondCont<Continuant then reads off both signs.",
+      "§23: prepending j leading 1s to an ARBITRARY tail ks is the order-6 rotation [[1,−1],[1,0]] acting on the pair (aⱼ,sⱼ)=(K(1ʲ++ks),secondCont(1ʲ++ks)): aⱼ₊₁=aⱼ−sⱼ, sⱼ₊₁=aⱼ — the all-1 §21 coupled system but seeded at (K(ks),secondCont ks) instead of (1,0). Hence K(1ʲ++ks) is PERIOD-6 in j for every tail, not just ks=[].",
+      "§23 orbit closed form: K(1ʲ++ks) cycles through [K, K−s, −s, −K, s−K, s] (s=secondCont ks) by j%6. Substituting ks=[] (K=1,s=0) recovers §21 orbit 1,1,0,−1,−1,0 EXACTLY; j%6=1,2 recover the §22 closed forms — §21 and §22 are the two specialisations of one periodic law.",
+      "§23 sign law (nonempty all-≥2 tail): the §17 invariant 0<secondCont ks<K(ks) fixes every orbit sign — K(1ʲ++ks)>0 iff j≡0,1,5 (mod 6), <0 iff j≡2,3,4, NEVER 0. §22 (at most one leading 1 stays positive) is the j≤2 window of this period-6 alternation; the empty-tail zeros of §21 are an artefact of ks=[]."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Density aggregation: combine continuant_ge_length (large-quotient K≥len+1) with order-n cap stepSeq b d ks ≤ n to bound large-quotient run length by O(n/d) — first run-length upper bound vs n/4+5 (van Doorn c∈[1/12,1/4])",
-      "Generalise §22: count leading-1 prefixes of length j on an all-≥2 tail (period-6-like sign pattern from prepending 1s), giving the full mixed leading-1/large-quotient sign classification"
+      "Mixed-block aggregation: with §23 the sign/magnitude of any leading-1 block is now periodic and explicit — combine alternating large-quotient blocks (§17 linear growth) and leading-1 blocks (§23 bounded period-6) to model a general quotient word and its similar-ordering window count toward the 1/12 constant"
     ]
   },
   "tags": [


### PR DESCRIPTION
## §23: Leading `1`s on an arbitrary tail — the period-6 rotation, in full

**Problem**: Erdős #1005 OQ-02 (similar-ordering density of Farey/Stern–Brocot runs; open constant `c ∈ [1/12, 1/4]`, van Doorn 2025 arXiv:2509.00121).
**Phase**: ORIENT → ACT. **Status**: VERIFIED, 0 sorries / 0 axioms / no `native_decide`.

### Result

This section **unifies §21 and §22**. Prepending `j` leading `1`s to an *arbitrary* tail `ks` is the order-6 rotation `[[1,−1],[1,0]]` acting on the pair `(aⱼ, sⱼ) = (K(1ʲ++ks), secondCont(1ʲ++ks))`:

```
sⱼ₊₁ = aⱼ,   aⱼ₊₁ = aⱼ − sⱼ        (seed a₀ = K(ks), s₀ = secondCont ks)
```

— the §21 all-`1` coupled system, but seeded at the arbitrary pair instead of `(1,0)`. Its companion is the order-6 rotation, so `K(1ʲ++ks)` is **period-6 in j for every tail**, running through the explicit orbit

```
K,  K − s,  − s,  − K,  s − K,  s        (s = secondCont ks),  indexed by j % 6.
```

- Substituting `ks = []` (`K = 1`, `s = 0`) recovers **§21's orbit `1,1,0,−1,−1,0` exactly**.
- `j % 6 = 1, 2` recover the **§22 closed forms** `continuant_one_cons` / `continuant_one_one_cons`.

### Sign classification (nonempty all-`≥2` tail)

The §17 invariant `0 < secondCont ks < K(ks)` fixes every orbit sign:

```
K(1ʲ++ks) > 0  ⟺  j ≡ 0, 1, 5 (mod 6);    < 0  for  j ≡ 2, 3, 4;    never 0.
```

§22's "at most one leading `1` preserves positivity" is exactly the `j ≤ 2` window of this period-6 alternation; §21's zeros are an artefact of `ks = []`.

### New theorems (`proofs/Proofs/Erdos1005ProblemOQ02.lean`)

- `secondCont_cons` — cons rewrite lemma
- `continuant_three_ones_cons` / `_four_` / `_five_` — the three new orbit base values
- `secondCont_replicate_one_append`, `continuant_replicate_one_succ_append` — coupled single steps
- `continuant_secondCont_replicate_one_append` — **headline** joint period-6 (6-step `omega`)
- `continuant_replicate_one_append_period` / `_six_mul` / `_mod` — period corollaries
- `continuant_replicate_one_append_orbit` — full closed form by `j % 6`
- `continuant_replicate_one_append_pos_iff` / `_ne_zero` — sign classification

### Build

`./proofs/scripts/docker-build.sh Proofs.Erdos1005ProblemOQ02` → `✔ [3058/3058] Built` (docker 29.6.1). No `sorry`, no `axiom`, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)