### PR TITLE
Enrich Non-autonomous Picard–Lindelöf packaging

### DIFF
--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-pl010101-setup",
+    "proofId": "banach-fixed-point-oq-01-oq-01-oq-01",
+    "range": { "startLine": 43, "endLine": 43 },
+    "type": "context",
+    "title": "Complete normed space — the home of the contraction",
+    "content": "The state space E is a complete normed ℝ-vector space (Banach space). Completeness is not incidental: the whole Picard–Lindelöf theorem is an application of the Banach fixed-point theorem to the Picard integral operator on the complete metric space of continuous curves, and the contraction's fixed point exists precisely because Cauchy sequences of approximations converge. The field F : ℝ → E → E is genuinely time-dependent (non-autonomous), the distinguishing feature of this entry versus the autonomous parent.",
+    "mathContext": "$y'(t) = F(t, y(t)),\\quad y(t_0) = x_0,\\qquad E\\ \\text{a Banach space}$",
+    "significance": "context",
+    "relatedConcepts": ["Banach space", "completeness", "contraction mapping", "non-autonomous ODE"],
+    "prerequisites": ["normed vector spaces", "metric space completeness"]
+  },
+  {
+    "id": "ann-pl010101-packaging",
+    "proofId": "banach-fixed-point-oq-01-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 60 },
+    "type": "technique",
+    "title": "Packaging IsPicardLindelof from named hypotheses (OQ 1)",
+    "content": "isPicardLindelof_of_box builds Mathlib's opaque four-field IsPicardLindelof structure directly. Choosing the ball radius r = 0 (the initial point itself) makes the geometric condition L·max(tmax−t₀, t₀−tmin) ≤ a−r collapse to ≤ a, so the structure's four fields are exactly the three analytic hypotheses (lipschitzOnWith, continuousOn, norm_le) plus the box inequality (mul_max_le, closed by `simpa`). The `omit` of NormedSpace/CompleteSpace records that this packaging step is purely combinatorial and needs no analysis.",
+    "mathContext": "$\\text{IsPicardLindelof}\\,F\\,\\langle t_0\\rangle\\,x_0\\,a\\,0\\,L\\,K \\iff \\begin{cases}K\\text{-Lipschitz in }y\\\\ \\text{continuous in }t\\\\ \\|F\\|\\le L\\\\ L\\cdot\\max(\\cdots)\\le a\\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["IsPicardLindelof", "Lipschitz condition", "structure constructor", "box inequality"],
+    "prerequisites": ["Lipschitz functions", "Mathlib ODE API"]
+  },
+  {
+    "id": "ann-pl010101-existence-diff",
+    "proofId": "banach-fixed-point-oq-01-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 74 },
+    "type": "concept",
+    "title": "Local existence in differential form (OQ 1)",
+    "content": "exists_local_solution_Icc feeds the packaged bundle to Mathlib's existence engine IsPicardLindelof.exists_eq_forall_mem_Icc_hasDerivWithinAt₀, producing an integral curve α on the closed interval [tmin, tmax] with α t₀ = x₀ and α'(t) = F(t, α t) expressed as HasDerivWithinAt (the within-set derivative appropriate to a closed interval whose endpoints have one-sided derivatives). The existence engine itself is solved internally by the FunSpace contraction — the Banach fixed point applied to curves.",
+    "mathContext": "$\\exists\\,\\alpha,\\ \\alpha(t_0)=x_0 \\ \\wedge\\ \\forall t\\in[t_{\\min},t_{\\max}],\\ \\alpha'(t)=F(t,\\alpha(t))$",
+    "significance": "key",
+    "relatedConcepts": ["integral curve", "HasDerivWithinAt", "local existence", "Cauchy–Lipschitz"],
+    "prerequisites": ["derivatives", "closed intervals", "existence theorems"]
+  },
+  {
+    "id": "ann-pl010101-existence-integral",
+    "proofId": "banach-fixed-point-oq-01-oq-01-oq-01",
+    "range": { "startLine": 76, "endLine": 90 },
+    "type": "insight",
+    "title": "The Picard integral operator and its fixed point (OQ 2)",
+    "content": "exists_local_solution_integral exhibits the very same solution as a fixed point of the Picard integral operator (P α)(t) = x₀ + ∫_{t₀}^{t} F(τ, α(τ)) dτ, obtained from exists_eq_forall_mem_Icc_eq_picard at the centre x₀ and unfolding ODE.picard via picard_apply. This is the operator whose iterated images P⁰, P¹, P²,… are the classical Picard successive approximations; the integral and differential forms are equivalent by the fundamental theorem of calculus, but the integral form is the one to which the contraction principle applies directly.",
+    "mathContext": "$\\alpha = P\\alpha,\\qquad (P\\alpha)(t) = x_0 + \\int_{t_0}^{t} F(\\tau, \\alpha(\\tau))\\,d\\tau$",
+    "significance": "key",
+    "relatedConcepts": ["Picard iteration", "integral equation", "fixed point", "fundamental theorem of calculus"],
+    "prerequisites": ["Bochner integral", "fixed-point theory"]
+  },
+  {
+    "id": "ann-pl010101-estimate",
+    "proofId": "banach-fixed-point-oq-01-oq-01-oq-01",
+    "range": { "startLine": 92, "endLine": 114 },
+    "type": "insight",
+    "title": "Open-interval existence with the explicit estimate ε = a/L (OQ 3)",
+    "content": "exists_local_solution makes the classical interval-of-existence estimate explicit. Setting the half-width ε = a/L, the box condition L·max(ε, ε) = L·ε = a holds with equality (mul_div_cancel₀, using L > 0), so the closed-interval solution exists on [t₀−ε, t₀+ε]; converting HasDerivWithinAt to the genuine two-sided HasDerivAt on the open interval (t₀−ε, t₀+ε) uses Icc_mem_nhds, since interior points of the Icc lie in its neighbourhood filter. This realises the classical lower bound ε ≥ a/L with equality: the larger the spatial box a or the smaller the velocity bound L, the longer the guaranteed existence time.",
+    "mathContext": "$\\varepsilon = \\frac{a}{L},\\qquad y'=F(t,y),\\ y(t_0)=x_0\\ \\text{solvable on}\\ (t_0-\\tfrac{a}{L},\\ t_0+\\tfrac{a}{L})$",
+    "significance": "key",
+    "relatedConcepts": ["interval of existence", "a-priori estimate", "HasDerivAt", "neighbourhood filter"],
+    "prerequisites": ["interval arithmetic", "open vs closed intervals"]
+  },
+  {
+    "id": "ann-pl010101-uniqueness",
+    "proofId": "banach-fixed-point-oq-01-oq-01-oq-01",
+    "range": { "startLine": 116, "endLine": 131 },
+    "type": "concept",
+    "title": "Uniqueness via Grönwall's inequality",
+    "content": "solution_unique gives the uniqueness half: two integral curves f, g of y' = F(t, y) on an open interval that agree at one interior point t₀ agree everywhere, provided F is globally K-Lipschitz in y on each time slice. It is the set ≡ univ specialization of Mathlib's ODE_solution_unique_of_mem_Ioo, a consequence of Grönwall's inequality (the difference ‖f−g‖ satisfies a linear differential inequality with zero initial value, forcing it to vanish). LipschitzWith.lipschitzOnWith supplies the on-univ Lipschitz hypothesis from the global constant.",
+    "mathContext": "$f(t_0)=g(t_0)\\ \\wedge\\ \\|F(t,u)-F(t,v)\\|\\le K\\|u-v\\| \\implies f\\equiv g\\ \\text{on}\\ (a,b)$",
+    "significance": "supporting",
+    "relatedConcepts": ["Grönwall's inequality", "uniqueness", "Lipschitz continuity", "comparison principle"],
+    "prerequisites": ["differential inequalities", "Lipschitz functions"]
+  }
+]

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01-oq-01/meta.json
@@ -67,7 +67,8 @@
       "**The hypothesis bundle is the content.** Mathlib's IsPicardLindelof packs four conditions into one structure; exposing them as named analytic hypotheses (Lipschitz in y, continuous in t, bounded, plus a single box inequality) is what makes the non-autonomous theorem usable, and is precisely the parent's first open question.",
       "**One box inequality fixes the interval.** Choosing the ball radius r = 0 collapses the interval condition to L·ε ≤ a; taking ε = a/L meets it with equality, which is exactly the classical existence-interval estimate ε ≥ a/L.",
       "**Existence has two faces.** The same fixed point is delivered in differential form (HasDerivWithinAt α (F t (α t))) and in Picard-integral form (α t = x₀ + ∫ F(τ, α τ) dτ); the latter is the successive-approximation operator whose iterates converge to the solution.",
-      "**Uniqueness is Grönwall, time-dependence and all.** The non-autonomous uniqueness statement is the set = univ specialization of Mathlib's general Grönwall comparison, requiring only a Lipschitz-in-y bound on each time slice."
+      "**Uniqueness is Grönwall, time-dependence and all.** The non-autonomous uniqueness statement is the set = univ specialization of Mathlib's general Grönwall comparison, requiring only a Lipschitz-in-y bound on each time slice.",
+      "**Choosing the ball radius r = 0 is the simplifying trick.** Mathlib's IsPicardLindelof carries a ball radius r; specializing to r = 0 (the initial point itself) collapses the geometric condition L·max(...) ≤ a − r to L·max(...) ≤ a and lets the analytic hypotheses be stated on the single ball closedBall x₀ a, which is what makes the packaging clean."
     ],
     "exampleSections": [
       {
@@ -104,12 +105,14 @@
   ],
   "crossReferences": [
     {
-      "id": "banach-fixed-point-oq-01-oq-01",
-      "reason": "The parent entry: the autonomous Picard–Lindelöf packaging y' = f(y). This entry answers its open questions by treating the non-autonomous y' = F(t, y) and quantifying the existence interval."
+      "proofId": "banach-fixed-point-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry: the autonomous Picard–Lindelöf packaging y' = f(y). This entry answers its open questions by treating the non-autonomous y' = F(t, y) and quantifying the existence interval."
     },
     {
-      "id": "banach-fixed-point-oq-01",
-      "reason": "The grandparent: the Banach contraction mapping theorem, of which Picard–Lindelöf is the canonical application."
+      "proofId": "banach-fixed-point-oq-01",
+      "relationship": "related",
+      "description": "The grandparent: the Banach contraction mapping theorem, of which Picard–Lindelöf is the canonical application."
     }
   ],
   "conclusion": {
@@ -137,5 +140,49 @@
     "path": "Proofs/PicardLindelofOQ01OQ01OQ01.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup: Banach space and the non-autonomous field",
+      "startLine": 38,
+      "endLine": 43,
+      "summary": "Opens the namespace over a complete normed ℝ-vector space E (the completeness needed for Banach's fixed point) and prepares to treat the time-dependent field F : ℝ → E → E for y'(t) = F(t, y(t))."
+    },
+    {
+      "id": "packaging",
+      "title": "Packaging IsPicardLindelof from explicit hypotheses (OQ 1)",
+      "startLine": 45,
+      "endLine": 60,
+      "summary": "isPicardLindelof_of_box assembles Mathlib's four-field IsPicardLindelof bundle at the initial point (r = 0) from three named analytic hypotheses (K-Lipschitz in y, continuous in t, norm bound L) plus the explicit box inequality L·max(tmax−t₀, t₀−tmin) ≤ a."
+    },
+    {
+      "id": "existence-differential",
+      "title": "Local existence in differential form (OQ 1)",
+      "startLine": 62,
+      "endLine": 74,
+      "summary": "exists_local_solution_Icc feeds the packaged bundle to Mathlib's existence engine to produce an integral curve α on [tmin,tmax] with α t₀ = x₀ and α'(t) = F(t, α t) in HasDerivWithinAt form."
+    },
+    {
+      "id": "existence-integral",
+      "title": "The Picard integral fixed-point form (OQ 2)",
+      "startLine": 76,
+      "endLine": 90,
+      "summary": "exists_local_solution_integral exhibits the same solution as a fixed point of the Picard operator: α t = x₀ + ∫_{t₀}^{t} F(τ, α τ) dτ, the successive-approximation form, by rewriting ODE.picard via picard_apply."
+    },
+    {
+      "id": "open-interval-estimate",
+      "title": "Open-interval existence with ε = a/L (OQ 3)",
+      "startLine": 92,
+      "endLine": 114,
+      "summary": "exists_local_solution sets the half-width ε = a/L, meets the box condition L·ε = a with equality via mul_div_cancel₀, and converts the closed-interval HasDerivWithinAt solution to HasDerivAt on the open interval (t₀−a/L, t₀+a/L) using Icc_mem_nhds — realising the classical estimate ε ≥ a/L."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Grönwall uniqueness (non-autonomous)",
+      "startLine": 116,
+      "endLine": 131,
+      "summary": "solution_unique derives uniqueness from ODE_solution_unique_of_mem_Ioo with set ≡ univ: two integral curves on an open interval agreeing at one interior point coincide, for a field globally K-Lipschitz in y on each time slice, via Grönwall's inequality."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `banach-fixed-point-oq-01-oq-01-oq-01` (quality 33 → 100).

The entry already had a strong overview, conclusion, and references but lacked inline annotations and sections, and its `crossReferences` were malformed.

- **annotations.json** (new): 6 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering the Banach-space setting, the `isPicardLindelof_of_box` packaging (OQ 1), local existence in differential form, the Picard integral fixed-point form (OQ 2), the explicit $\varepsilon = a/L$ existence estimate (OQ 3), and Grönwall uniqueness.
- **sections[]** (6): full line-range coverage of the 132-line Lean file.
- Added a 5th keyInsight (the $r = 0$ ball-radius simplification).
- **Fixed malformed crossReferences**: they used `id`/`reason` keys, which don't match the `CrossReference` interface (`proofId`|`targetId` + required `relationship` + optional `description` per `src/types/proof.ts`), so the parent/grandparent links would not render. Converted to `proofId`/`relationship`/`description`.

`pnpm build` passes.