### PR TITLE
research(erdos-490-incomplete-01): bridge |optimalB N| to Mathlib's Nat.primeCounting [0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -31,6 +31,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Order.Interval.Finset.Nat
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.NumberTheory.Primorial
+import Mathlib.NumberTheory.PrimeCounting
 
 open Finset Real
 open scoped Classical
@@ -152,6 +153,43 @@ lower-bound derivation (`bound_is_optimal`) is fully verified from it. -/
 axiom primes_upper_half_lower_bound :
   ∃ c : ℝ, c > 0 ∧ ∀ N : ℕ, N ≥ 4 →
     c * N / Real.log N ≤ ((optimalB N).card : ℝ)
+
+/-- **Bridge to Mathlib's prime-counting function** (0-axiom). The optimal `B` is exactly
+the set of primes in `(N/2, N]`, so its cardinality is `π(N) − π(N/2)`, where
+`π = Nat.primeCounting` counts the primes `≤ ·`. This pins the analytic axiom
+`primes_upper_half_lower_bound` to Mathlib's `Nat.primeCounting` API: eliminating the axiom
+is now *exactly* the problem of supplying a Chebyshev-strength lower bound for
+`π(N) − π(N/2)`, with the combinatorial cardinality identity already discharged here. -/
+theorem optimalB_card_eq_primeCounting (N : ℕ) :
+    (optimalB N).card = N.primeCounting - (N / 2).primeCounting := by
+  -- `π m` as the cardinality of the prime-filtered range `[0, m]`.
+  have hπ : ∀ m : ℕ, m.primeCounting
+      = ((Finset.range (m + 1)).filter Nat.Prime).card := by
+    intro m
+    unfold Nat.primeCounting Nat.primeCounting'
+    rw [Nat.count_eq_card_filter_range]
+  -- `optimalB` drops the `p ≤ N` conjunct, which is automatic inside `range (N + 1)`.
+  have hB : optimalB N
+      = (Finset.range (N + 1)).filter (fun p => Nat.Prime p ∧ N / 2 < p) := by
+    ext p
+    simp only [optimalB, Finset.mem_filter, Finset.mem_range]
+    constructor
+    · rintro ⟨hr, hp, hlt, _⟩; exact ⟨hr, hp, hlt⟩
+    · rintro ⟨hr, hp, hlt⟩; exact ⟨hr, hp, hlt, by omega⟩
+  -- The primes `≤ N/2` are exactly the prime-filtered range `[0, N/2]`.
+  have hlow : (Finset.range (N + 1)).filter (fun p => Nat.Prime p ∧ ¬ N / 2 < p)
+      = (Finset.range (N / 2 + 1)).filter Nat.Prime := by
+    ext p
+    simp only [Finset.mem_filter, Finset.mem_range]
+    constructor
+    · rintro ⟨_, hp, hle⟩; exact ⟨by omega, hp⟩
+    · rintro ⟨hlt, hp⟩; exact ⟨by omega, hp, by omega⟩
+  -- Partition the primes `≤ N` by whether they exceed `N/2`.
+  have hpart := Finset.filter_card_add_filter_neg_card_eq_card
+    (s := (Finset.range (N + 1)).filter Nat.Prime) (p := fun p => N / 2 < p)
+  rw [Finset.filter_filter, Finset.filter_filter, ← hB, hlow] at hpart
+  rw [hπ N, hπ (N / 2)]
+  omega
 
 /- The optimal example achieves |A||B| ~ N²/(2 log N). -/
 /-- Why it works: products `a·p` are distinct because each prime `p > N/2` exceeds

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -63,6 +63,7 @@
       "optimal_has_distinct_products axiom: construction is valid",
       "optimal_works_because_primes: divisibility argument (proved)",
       "optimalA_card: |optimalA N| = ⌊N/2⌋ (0-axiom, proved)",
+      "optimalB_card_eq_primeCounting: |optimalB N| = π(N) − π(N/2) via Mathlib's Nat.primeCounting (0-axiom, proved) — pins the Chebyshev axiom to Mathlib's prime-counting API",
       "primes_upper_half_lower_bound axiom: Chebyshev lower bound π(N)−π(N/2) ≳ N/log N",
       "productRatio, LimitQuestion: open limit formalization",
       "IsMultiplicativeSidon: A = B special case",
@@ -70,9 +71,9 @@
       "bound_is_optimal: matching lower bound (proved from the 3 axioms, 0 sorries)"
     ],
     "axiomCount": 3,
-    "lineCount": 468,
-    "assumptions": "3 axioms, 0 sorries. Axioms: szemeredi_theorem (Szemerédi 1976 upper bound, deep); optimal_has_distinct_products (the optimal example has distinct products, deep); primes_upper_half_lower_bound (Chebyshev-type lower bound — the count of primes in (N/2,N] is ≳ N/log N; isolated as an axiom because Mathlib's Nat.primeCounting provides only an upper bound, no lower bound on π(N)−π(N/2)). Progression: researcher-8 (2026-06-28) repaired the build against the current Mathlib pin and eliminated 4 sorries with 0-axiom proofs (optimal_works_because_primes, the two IsSubsetUpTo subgoals, primes_products_determine_pair). researcher-3 (2026-06-28) then proved distinct_minimal_energy (HasDistinctProducts ↔ multiplicative energy = |A||B|) 0-axiom via the diagonal-subset argument, and in a follow-up session eliminated the last sorry: proved optimalA_card (|optimalA N| = ⌊N/2⌋, 0-axiom) and discharged the bound_is_optimal lower bound from the isolated Chebyshev axiom (note: the previously hardcoded constant 1/3 was false at small N, e.g. N=10 where the product ratio dips to ≈0.115, so the theorem is now in its honest ∃c>0 form).",
-    "theoremCount": 13,
+    "lineCount": 506,
+    "assumptions": "3 axioms, 0 sorries. Axioms: szemeredi_theorem (Szemerédi 1976 upper bound, deep); optimal_has_distinct_products (the optimal example has distinct products, deep); primes_upper_half_lower_bound (Chebyshev-type lower bound — the count of primes in (N/2,N] is ≳ N/log N; isolated as an axiom because Mathlib's Nat.primeCounting provides only an upper bound, no lower bound on π(N)−π(N/2); the bridge lemma optimalB_card_eq_primeCounting now proves |optimalB N| = π(N)−π(N/2) in Mathlib's API, 0-axiom, so the axiom is reduced to exactly a Chebyshev lower bound for π(N)−π(N/2)). Progression: researcher-8 (2026-06-28) repaired the build against the current Mathlib pin and eliminated 4 sorries with 0-axiom proofs (optimal_works_because_primes, the two IsSubsetUpTo subgoals, primes_products_determine_pair). researcher-3 (2026-06-28) then proved distinct_minimal_energy (HasDistinctProducts ↔ multiplicative energy = |A||B|) 0-axiom via the diagonal-subset argument, and in a follow-up session eliminated the last sorry: proved optimalA_card (|optimalA N| = ⌊N/2⌋, 0-axiom) and discharged the bound_is_optimal lower bound from the isolated Chebyshev axiom (note: the previously hardcoded constant 1/3 was false at small N, e.g. N=10 where the product ratio dips to ≈0.115, so the theorem is now in its honest ∃c>0 form).",
+    "theoremCount": 14,
     "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
@@ -204,9 +205,9 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 468,
+    "lineCount": 506,
     "axiomCount": 3,
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-490-incomplete-01.json
+++ b/src/data/research/problems/erdos-490-incomplete-01.json
@@ -1,85 +1,86 @@
 {
-  "slug": "erdos-490-incomplete-01",
-  "title": "Erdős #490 (distinct products): build repair + sorry reduction",
-  "status": "progress",
-  "phase": "ACT",
-  "path": "fast",
-  "tier": "B",
-  "significance": 5,
-  "tractability": 6,
-  "started": "2026-06-28T00:00:00.000Z",
-  "lastUpdate": "2026-06-28T00:00:00.000Z",
-  "tags": [
-    "number-theory",
-    "combinatorics",
-    "erdos",
-    "multiplicative-energy",
-    "szemeredi",
-    "completion"
-  ],
-  "problemStatement": {
-    "formal": "A,B \\subseteq \\{1,\\dots,N\\} \\text{ with all products } ab \\text{ distinct} \\Rightarrow |A||B| \\ll N^2/\\log N \\text{ (Szemerédi 1976).}",
-    "plain": "Erdős #490: if A, B ⊆ {1,...,N} have all products ab distinct, then |A||B| ≪ N²/log N. The Lean file formalizes the statement, the optimal example, and supporting lemmas; Szemerédi's theorem itself and the optimal-example distinct-products fact are axiomatized. This task repairs the build and discharges tractable sorries.",
-    "whyMatters": [
-      "Keeps a committed gallery file building against the current Mathlib pin.",
-      "Eliminates sorries that were tractable (and corrects two mis-stated lemmas), improving the file's integrity."
+    "slug": "erdos-490-incomplete-01",
+    "title": "Erdős #490 (distinct products): build repair + sorry reduction",
+    "status": "progress",
+    "phase": "ACT",
+    "path": "fast",
+    "tier": "B",
+    "significance": 5,
+    "tractability": 6,
+    "started": "2026-06-28T00:00:00.000Z",
+    "lastUpdate": "2026-06-30T00:00:00.000Z",
+    "tags": [
+        "number-theory",
+        "combinatorics",
+        "erdos",
+        "multiplicative-energy",
+        "szemeredi",
+        "completion"
+    ],
+    "problemStatement": {
+        "formal": "A,B \\subseteq \\{1,\\dots,N\\} \\text{ with all products } ab \\text{ distinct} \\Rightarrow |A||B| \\ll N^2/\\log N \\text{ (Szemerédi 1976).}",
+        "plain": "Erdős #490: if A, B ⊆ {1,...,N} have all products ab distinct, then |A||B| ≪ N²/log N. The Lean file formalizes the statement, the optimal example, and supporting lemmas; Szemerédi's theorem itself and the optimal-example distinct-products fact are axiomatized. This task repairs the build and discharges tractable sorries.",
+        "whyMatters": [
+            "Keeps a committed gallery file building against the current Mathlib pin.",
+            "Eliminates sorries that were tractable (and corrects two mis-stated lemmas), improving the file's integrity."
+        ]
+    },
+    "currentState": {
+        "summary": "DONE (build-repair + full sorry elimination). File builds against Mathlib 4.26 with 0 sorries and 3 axioms (szemeredi_theorem, optimal_has_distinct_products, primes_upper_half_lower_bound). All tractable sorries discharged; the only remaining assumptions are the three deep/analytic axioms, each explicitly stated and documented. The Chebyshev prime-counting axiom is the single irreducible analytic input absent from the current Mathlib pin.",
+        "outcome": "progress"
+    },
+    "knowledge": {
+        "insights": [
+            "optimal_works_because_primes was false without positivity (a₁=a₂=0 ⇒ 0=0 for distinct primes); fixed by requiring 1 ≤ aᵢ.",
+            "primes_sidon was false: ordered HasDistinctProducts P P (card = |P|²) fails because p·q = q·p collapses in the product set; the correct statement is primes_products_determine_pair.",
+            "distinct_minimal_energy is a real iff but needs fiber-counting (energy = ∑ r(p)², |A||B| = ∑ r(p)); deferred.",
+            "the lower bound in bound_is_optimal needs π(N) − π(N/2) ~ N/(2 log N), a Chebyshev/PNT estimate; deferred.",
+            "bound_is_optimal cannot use a fixed lower-bound constant: the product ratio |A||B|·log N/N² dips to ≈0.115 at N=10, so only the ∃c>0 form is true; the file's old hardcoded 1/3 was false.",
+            "optimalA N = Finset.Icc 1 (N/2), so |optimalA N| = N/2 exactly (proved 0-axiom via Finset.ext + Nat.card_Icc + omega)."
+        ],
+        "builtItems": [
+            "Build repair: Nat.card_Icc, open scoped Classical, orphan-comment fixes (Erdos490Problem.lean)",
+            "optimal_works_because_primes: proved (Erdos490Problem.lean)",
+            "two IsSubsetUpTo subgoals in bound_is_optimal: proved",
+            "primes_products_determine_pair: new correct lemma replacing false primes_sidon",
+            "optimalB_card_eq_primeCounting: |optimalB N| = N.primeCounting - (N/2).primeCounting (0-axiom) — bridges the Chebyshev axiom to Mathlib's Nat.primeCounting API"
+        ],
+        "mathlibGaps": [
+            "No prime-counting lower bound (π(N) − π(N/2)) readily available for the optimal-example lower bound."
+        ],
+        "nextSteps": [
+            "Eliminate primes_upper_half_lower_bound by proving a Chebyshev lower bound π(N)−π(N/2) ≳ N/log N from Mathlib primitives (Bertrand/centralBinom machinery) — a multi-session infrastructure effort; Mathlib's Nat.primeCounting currently has only an upper bound. With optimalB_card_eq_primeCounting in place, the axiom can be restated purely against Nat.primeCounting: ∃ c>0, c*N/log N ≤ ↑(N.primeCounting - (N/2).primeCounting).",
+            "DONE (2026-06-30): proved (optimalB N).card = N.primeCounting - (N/2).primeCounting (optimalB_card_eq_primeCounting), bridging the axiom to Mathlib's primeCounting API."
+        ],
+        "progressSummary": "2026-06-30 (researcher-3): added optimalB_card_eq_primeCounting — the 0-axiom combinatorial half of primes_upper_half_lower_bound, proving |optimalB N| = π(N)−π(N/2) in Mathlib's Nat.primeCounting API (partition primes ≤ N by exceeding N/2 via Finset.filter_card_add_filter_neg_card_eq_card; Nat.count_eq_card_filter_range). Axiom count unchanged (3), 0 sorries, builds against Mathlib 4.26. PR #31517. EARLIER 2026-06-28 (researcher-3): eliminated the last sorry — proved optimalA_card (|optimalA N| = ⌊N/2⌋, 0-axiom) and discharged the bound_is_optimal lower bound by isolating the one irreducible Chebyshev prime-counting input as the axiom primes_upper_half_lower_bound; switched bound_is_optimal to its honest ∃c>0 form (the previously hardcoded 1/3 is FALSE at small N, e.g. N=10 product ratio ≈0.115)."
+    },
+    "knownResults": {
+        "established": [
+            "Szemerédi (1976): |A||B| ≪ N²/log N for distinct-product sets.",
+            "Optimal example A = [1,N/2], B = primes in (N/2,N] achieves ~ N²/(2 log N)."
+        ]
+    },
+    "references": {
+        "papers": [
+            "Erdős problem #490: https://www.erdosproblems.com/490",
+            "Szemerédi, On a problem of P. Erdős, J. Number Theory (1976)."
+        ]
+    },
+    "relatedProofs": [
+        "erdos-490",
+        "erdos-490-oq-01"
+    ],
+    "leanFiles": [
+        {
+            "path": "Proofs/Erdos490Problem.lean",
+            "filename": "Erdos490Problem.lean",
+            "lineCount": 506,
+            "theoremCount": 14,
+            "axiomCount": 3,
+            "defCount": 15,
+            "sorryCount": 0,
+            "isAristotle": false,
+            "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos490Problem.lean"
+        }
     ]
-  },
-  "currentState": {
-    "summary": "DONE (build-repair + full sorry elimination). File builds against Mathlib 4.26 with 0 sorries and 3 axioms (szemeredi_theorem, optimal_has_distinct_products, primes_upper_half_lower_bound). All tractable sorries discharged; the only remaining assumptions are the three deep/analytic axioms, each explicitly stated and documented. The Chebyshev prime-counting axiom is the single irreducible analytic input absent from the current Mathlib pin.",
-    "outcome": "progress"
-  },
-  "knowledge": {
-    "insights": [
-      "optimal_works_because_primes was false without positivity (a₁=a₂=0 ⇒ 0=0 for distinct primes); fixed by requiring 1 ≤ aᵢ.",
-      "primes_sidon was false: ordered HasDistinctProducts P P (card = |P|²) fails because p·q = q·p collapses in the product set; the correct statement is primes_products_determine_pair.",
-      "distinct_minimal_energy is a real iff but needs fiber-counting (energy = ∑ r(p)², |A||B| = ∑ r(p)); deferred.",
-      "the lower bound in bound_is_optimal needs π(N) − π(N/2) ~ N/(2 log N), a Chebyshev/PNT estimate; deferred.",
-      "bound_is_optimal cannot use a fixed lower-bound constant: the product ratio |A||B|·log N/N² dips to ≈0.115 at N=10, so only the ∃c>0 form is true; the file's old hardcoded 1/3 was false.",
-      "optimalA N = Finset.Icc 1 (N/2), so |optimalA N| = N/2 exactly (proved 0-axiom via Finset.ext + Nat.card_Icc + omega)."
-    ],
-    "builtItems": [
-      "Build repair: Nat.card_Icc, open scoped Classical, orphan-comment fixes (Erdos490Problem.lean)",
-      "optimal_works_because_primes: proved (Erdos490Problem.lean)",
-      "two IsSubsetUpTo subgoals in bound_is_optimal: proved",
-      "primes_products_determine_pair: new correct lemma replacing false primes_sidon"
-    ],
-    "mathlibGaps": [
-      "No prime-counting lower bound (π(N) − π(N/2)) readily available for the optimal-example lower bound."
-    ],
-    "nextSteps": [
-      "Eliminate primes_upper_half_lower_bound by proving a Chebyshev lower bound π(N)−π(N/2) ≳ N/log N from Mathlib primitives (Bertrand/centralBinom machinery) — a multi-session infrastructure effort; Mathlib's Nat.primeCounting currently has only an upper bound.",
-      "Optionally prove (optimalB N).card = N.primeCounting - (N/2).primeCounting to bridge the axiom to Mathlib's primeCounting API."
-    ],
-    "progressSummary": "DONE 2026-06-28 (researcher-3): eliminated the last sorry. Proved optimalA_card (|optimalA N| = ⌊N/2⌋, 0-axiom) and discharged the bound_is_optimal lower bound by isolating the one irreducible Chebyshev prime-counting input (|optimalB N| = π(N)−π(N/2) ≳ N/log N) as an explicit axiom `primes_upper_half_lower_bound`. File now 0 sorries, 3 axioms. Switched bound_is_optimal to its honest ∃c>0 form: the previously hardcoded 1/3 is FALSE at small N (e.g. N=10, product ratio ≈0.115)."
-  },
-  "knownResults": {
-    "established": [
-      "Szemerédi (1976): |A||B| ≪ N²/log N for distinct-product sets.",
-      "Optimal example A = [1,N/2], B = primes in (N/2,N] achieves ~ N²/(2 log N)."
-    ]
-  },
-  "references": {
-    "papers": [
-      "Erdős problem #490: https://www.erdosproblems.com/490",
-      "Szemerédi, On a problem of P. Erdős, J. Number Theory (1976)."
-    ]
-  },
-  "relatedProofs": [
-    "erdos-490",
-    "erdos-490-oq-01"
-  ],
-  "leanFiles": [
-    {
-      "path": "Proofs/Erdos490Problem.lean",
-      "filename": "Erdos490Problem.lean",
-      "lineCount": 468,
-      "theoremCount": 13,
-      "axiomCount": 3,
-      "defCount": 15,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos490Problem.lean"
-    }
-  ]
 }


### PR DESCRIPTION
## Summary

Erdős #490's optimal-example lower bound rests on the axiom `primes_upper_half_lower_bound` (a Chebyshev-strength bound on the number of primes in `(N/2, N]`). This PR discharges the **0-axiom combinatorial half** of that axiom, pinning it to Mathlib's prime-counting API:

```lean
theorem optimalB_card_eq_primeCounting (N : ℕ) :
    (optimalB N).card = N.primeCounting - (N / 2).primeCounting
```

i.e. `|optimalB N| = π(N) − π(N/2)` where `π = Nat.primeCounting` counts primes `≤ ·`.

## Proof

1. Drop the redundant `p ≤ N` conjunct from `optimalB` (automatic inside `range (N+1)`).
2. Partition the primes `≤ N` by whether they exceed `N/2`, via `Finset.filter_card_add_filter_neg_card_eq_card`.
3. Identify the `≤ N/2` piece with the prime-filtered range `[0, N/2]`.
4. Rewrite each `π` as a filtered-range cardinality with `Nat.count_eq_card_filter_range`; `omega` closes the Nat-subtraction.

## Effect

The analytic axiom is now reduced to *exactly* a Chebyshev lower bound for `π(N) − π(N/2)` — the cardinality bookkeeping that previously sat inside the axiom's content is fully verified. This is the tractable step toward eventually eliminating the axiom (the remaining piece, `π(N) − π(N/2) ≳ N/log N`, is genuine Chebyshev/Bertrand infrastructure not yet in the Mathlib pin).

- **Axiom count unchanged: still 3** (`szemeredi_theorem`, `optimal_has_distinct_products`, `primes_upper_half_lower_bound`). 0 sorries.
- New import: `Mathlib.NumberTheory.PrimeCounting`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos490Problem` → **Build succeeded** (Mathlib 4.26). Remaining warnings are pre-existing unused-variable lints, untouched by this change.

`meta.json` updated: `theoremCount` 13→14, `lineCount` 468→506, new `originalContributions` entry, refined `assumptions` note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)