### PR TITLE
Enrich Complex and Hyperbolic Multiple-Angle Formulas via Chebyshev

### DIFF
--- a/src/data/proofs/de-moivre-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-dm-complex-dict",
+    "proofId": "de-moivre-oq-01-oq-02",
+    "range": { "startLine": 46, "endLine": 65 },
+    "type": "definition",
+    "title": "The complex Chebyshev–De Moivre dictionary",
+    "content": "Four wrapper theorems lift the real dictionary to $\\mathbb{C}$. `cos_intMul_eq_eval_T` gives $\\cos(nz) = T_n(\\cos z)$ and `sin_succMul_eq_eval_U` gives $\\sin((n+1)z) = U_n(\\cos z)\\sin z$, each just the symmetric form of Mathlib's `T_complex_cos` / `U_complex_cos`. The hyperbolic versions `cosh_intMul_eq_eval_T` and `sinh_succMul_eq_eval_U` use the *same* Chebyshev polynomials — the key observation, with no real-analytic analogue, that the circular and hyperbolic angle maps share one polynomial engine.",
+    "mathContext": "$\\cos(nz) = T_n(\\cos z),\\quad \\sin((n+1)z) = U_n(\\cos z)\\sin z,\\quad \\cosh(nz) = T_n(\\cosh z),\\quad \\sinh((n+1)z) = U_n(\\cosh z)\\sinh z.$",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev polynomials", "De Moivre's theorem", "complex trigonometry", "hyperbolic functions"],
+    "prerequisites": ["complex exponential", "Chebyshev T and U", "cos(iw) = cosh w"]
+  },
+  {
+    "id": "ann-dm-existence",
+    "proofId": "de-moivre-oq-01-oq-02",
+    "range": { "startLine": 71, "endLine": 80 },
+    "type": "concept",
+    "title": "Existence: cos(nz) and cosh(nz) are polynomial",
+    "content": "`cos_intMul_isPolyInCos` and `cosh_intMul_isPolyInCosh` record the qualitative fact that for every $n$, $\\cos(nz)$ is a fixed polynomial in $\\cos z$ and $\\cosh(nz)$ the same fixed polynomial in $\\cosh z$. Both are one-line existence proofs witnessing $T_n$. This separates the structural claim ('it is a polynomial') from the computational one ('here is the polynomial') addressed in Parts 3–5, and emphasizes that the *same* witness $T_n$ serves both the circular and hyperbolic cases.",
+    "mathContext": "$\\forall n,\\ \\exists P \\in \\mathbb{C}[X],\\ \\forall z,\\ P(\\cos z) = \\cos(nz),$ with $P = T_n$ working simultaneously for $\\cosh$.",
+    "significance": "supporting",
+    "relatedConcepts": ["polynomial existence", "Chebyshev polynomials", "uniform witness"],
+    "prerequisites": ["polynomial evaluation", "existential witnesses"]
+  },
+  {
+    "id": "ann-dm-explicit-cheb",
+    "proofId": "de-moivre-oq-01-oq-02",
+    "range": { "startLine": 86, "endLine": 114 },
+    "type": "technique",
+    "title": "Computing T₃–T₅ and U₃–U₄ via the recurrence",
+    "content": "The explicit Chebyshev polynomials are derived over $\\mathbb{C}$ from the three-term recurrence $T_{n+2} = 2X\\,T_{n+1} - T_n$ (and the identical $U$ recurrence). Each proof instantiates `T_add_two` at the right index, rewrites the integer-index arithmetic with `decide`, substitutes the two previous polynomials, and closes with `ring`. These closed forms ($T_4 = 8X^4 - 8X^2 + 1$, $T_5 = 16X^5 - 20X^3 + 5X$, etc.) are the algebraic payload evaluated in the next two parts.",
+    "mathContext": "$T_3 = 4X^3 - 3X,\\ T_4 = 8X^4 - 8X^2 + 1,\\ T_5 = 16X^5 - 20X^3 + 5X,\\ U_3 = 8X^3 - 4X,\\ U_4 = 16X^4 - 12X^2 + 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["three-term recurrence", "Chebyshev recurrence", "polynomial arithmetic", "ring tactic"],
+    "prerequisites": ["Chebyshev recurrences", "polynomial ring"]
+  },
+  {
+    "id": "ann-dm-explicit-circular",
+    "proofId": "de-moivre-oq-01-oq-02",
+    "range": { "startLine": 121, "endLine": 155 },
+    "type": "insight",
+    "title": "Degree-4 and degree-5 circular formulas (new beyond Mathlib)",
+    "content": "Mathlib stops at degree 3; these theorems supply the degree-4 and degree-5 explicit multiple-angle formulas for $\\cos$ and $\\sin$ over $\\mathbb{C}$. The pattern is uniform: take the Mathlib evaluation lemma, rewrite by the explicit polynomial, reduce the `Polynomial.eval` with a targeted `simp` (`eval_add`, `eval_mul`, `eval_pow`, `eval_ofNat`, …), normalize the $\\mathbb{Z}\\to\\mathbb{C}$ cast on the index, and discharge with `linear_combination -h`. The cast normalization is the one subtle step — Mathlib states the lemma with $\\uparrow n$ while the goal uses the numeral.",
+    "mathContext": "$\\cos(4z) = 8\\cos^4 z - 8\\cos^2 z + 1,\\quad \\cos(5z) = 16\\cos^5 z - 20\\cos^3 z + 5\\cos z,\\quad \\sin(4z) = (8\\cos^3 z - 4\\cos z)\\sin z.$",
+    "significance": "key",
+    "relatedConcepts": ["multiple-angle formula", "linear_combination tactic", "polynomial evaluation", "cast normalization"],
+    "prerequisites": ["trigonometric identities", "Lean simp and linear_combination"]
+  },
+  {
+    "id": "ann-dm-explicit-hyperbolic",
+    "proofId": "de-moivre-oq-01-oq-02",
+    "range": { "startLine": 162, "endLine": 198 },
+    "type": "insight",
+    "title": "Hyperbolic formulas from the same polynomials",
+    "content": "The degree-4/5 hyperbolic formulas `cosh_four_mul`, `cosh_five_mul`, `sinh_four_mul`, `sinh_five_mul` reuse the *identical* Chebyshev polynomials $T_4, T_5, U_3, U_4$, now evaluated at $\\cosh z$ via Mathlib's `T_complex_cosh` / `U_complex_cosh`. The proofs are line-for-line the circular ones with `cos`$\\to$`cosh`. This is the concrete payoff of the unification: one polynomial computation discharges two families of identities, because $\\cos(iw) = \\cosh w$.",
+    "mathContext": "$\\cosh(4z) = 8\\cosh^4 z - 8\\cosh^2 z + 1,\\quad \\sinh(5z) = (16\\cosh^4 z - 12\\cosh^2 z + 1)\\sinh z.$",
+    "significance": "key",
+    "relatedConcepts": ["hyperbolic multiple-angle", "unification", "cos(iw) = cosh w", "Chebyshev polynomials"],
+    "prerequisites": ["hyperbolic functions", "complex analysis basics"]
+  },
+  {
+    "id": "ann-dm-composition",
+    "proofId": "de-moivre-oq-01-oq-02",
+    "range": { "startLine": 204, "endLine": 222 },
+    "type": "insight",
+    "title": "Unification theorem and De Moivre composition law",
+    "content": "`T_eval_cos_and_cosh` packages the whole point into one statement: for every $n$, $T_n$ evaluates to $\\cos(nz)$ at $\\cos z$ and to $\\cosh(nz)$ at $\\cosh z$. The composition theorems `cos_mul_eq_T_comp` and `cosh_mul_eq_T_comp` express $\\cos(mn\\cdot z) = T_m(T_n(\\cos z))$ — the analytic shadow of the algebraic identity $T_{mn} = T_m \\circ T_n$ (`T_mul`) combined with `eval_comp`. This is the complex De Moivre composition law, capturing how iterating angle multiplication corresponds to composing Chebyshev polynomials.",
+    "mathContext": "$\\cos(mn\\cdot z) = T_m\\big(T_n(\\cos z)\\big),\\qquad T_{mn} = T_m \\circ T_n.$",
+    "significance": "key",
+    "relatedConcepts": ["polynomial composition", "T_mul", "iterated angle multiplication", "semigroup of Chebyshev polynomials"],
+    "prerequisites": ["polynomial composition", "Chebyshev composition law"]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-01-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-02/meta.json
@@ -3,6 +3,128 @@
   "title": "Complex and Hyperbolic Multiple-Angle Formulas via Chebyshev",
   "slug": "de-moivre-oq-01-oq-02",
   "description": "Lifts the Chebyshev-De Moivre dictionary cos(nθ) = T_n(cos θ), sin((n+1)θ) = U_n(cos θ)·sin θ from the real to the complex setting, and exploits a feature with no real-analytic analogue: the SAME Chebyshev polynomial T_n simultaneously governs the circular multiple-angle map (at cos z) AND the hyperbolic one (at cosh z), since cos(iw) = cosh w. One polynomial computation T_4 = 8X⁴-8X²+1 yields both cos(4z) = 8cos⁴z-8cos²z+1 and cosh(4z) = 8cosh⁴z-8cosh²z+1. Adds the degree-4 and degree-5 explicit formulas (circular and hyperbolic) absent from Mathlib, plus the complex De Moivre composition law cos(mn·z) = T_m(T_n(cos z)).",
+  "overview": {
+    "historicalContext": "**From Real to Complex De Moivre**\n\nThe parent formalization (`de-moivre-oq-01`) established the real Chebyshev-De Moivre dictionary $\\cos(n\\theta) = T_n(\\cos\\theta)$ and $\\sin((n+1)\\theta) = U_n(\\cos\\theta)\\sin\\theta$. A natural open question asked whether this extends to the complex setting.\n\nMathlib already proves the analytic core over $\\mathbb{C}$ ($T_n(\\cos z) = \\cos(nz)$, and likewise for $\\cosh$). The genuinely *new* phenomenon the complex setting unlocks is a unification: because $\\cos(iw) = \\cosh w$, the **same** Chebyshev polynomial $T_n$ governs both the circular and the hyperbolic $n$-fold angle maps. A single polynomial identity therefore produces two families of explicit formulas at once.",
+    "problemStatement": "**The Open Question (parent OQ #2)**\n\nCan the Chebyshev-De Moivre connection be extended to the complex setting: do $T_n$ and $U_n$ evaluated at $\\cos z$ reproduce $\\cos(nz)$ and the sine ratio for complex $z$?\n\n**Answer: YES, and more.** Over $\\mathbb{C}$ the dictionary holds verbatim, and the *same* $T_n$, $U_n$ simultaneously yield the hyperbolic multiple-angle formulas via $\\cos(iw)=\\cosh w$.",
+    "text": "Lifts the Chebyshev-De Moivre dictionary to ℂ and shows the same polynomial T_n governs both circular (cos) and hyperbolic (cosh) multiple-angle maps, deriving explicit degree-4 and degree-5 formulas for cos, sin, cosh, sinh and the De Moivre composition law.",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Complex/hyperbolic dictionary** (`cos_intMul_eq_eval_T`, `sin_succMul_eq_eval_U`, `cosh_intMul_eq_eval_T`, `sinh_succMul_eq_eval_U`): thin wrappers around Mathlib's `T_complex_cos`/`U_complex_cos`/`T_complex_cosh`/`U_complex_cosh`.\n\n2. **Existence** (`cos_intMul_isPolyInCos`, `cosh_intMul_isPolyInCosh`): witness the Chebyshev polynomial $T_n$, emphasizing that the *same* witness serves both the circular and hyperbolic cases.\n\n3. **Explicit polynomials** (`T_three`–`T_five`, `U_three`, `U_four`): computed over $\\mathbb{C}$ via the recurrence $T_{n+2} = 2X\\,T_{n+1} - T_n$.\n\n4. **Degree-4/5 formulas** (`cos_four_mul`, `cos_five_mul`, `sin_four_mul`, `sin_five_mul` and the four `cosh`/`sinh` analogues): obtained by evaluating the explicit polynomial at $\\cos z$ (resp. $\\cosh z$), reducing the polynomial `eval` with `simp`, normalizing the integer cast, and closing with `linear_combination`.\n\n5. **Unification and composition** (`T_eval_cos_and_cosh`, `cos_mul_eq_T_comp`, `cosh_mul_eq_T_comp`): the single-polynomial-two-trigonometries statement, and the De Moivre composition $\\cos(mn\\cdot z) = T_m(T_n(\\cos z))$ from `T_mul` and `eval_comp`.",
+    "keyInsights": [
+      "**One polynomial, two trigonometries**: Since $\\cos(iw) = \\cosh w$, the polynomial $T_n$ gives $\\cos(nz)$ at $\\cos z$ and $\\cosh(nz)$ at $\\cosh z$. The hyperbolic formulas come for free from the circular ones — a unification with no real-only analogue.",
+      "**Mathlib has the core, not the explicit forms**: Mathlib carries the analytic identities and degree ≤ 3 multiple-angle formulas, but degree-4 and degree-5 explicit forms (circular and hyperbolic) are new here.",
+      "**Composition = T_mul**: The De Moivre composition law $\\cos(mn\\cdot z) = T_m(T_n(\\cos z))$ is the trigonometric shadow of the algebraic identity $T_{mn} = T_m \\circ T_n$.",
+      "**Cast discipline**: Mathlib states the complex lemmas with $\\uparrow n$ (an `ℤ`-to-`ℂ` cast); matching the numeral `4 : ℂ` requires normalizing $\\uparrow(4:\\mathbb{Z})$ before `linear_combination` closes the goal.",
+      "**Existence vs. explicit form**: `cos_intMul_isPolyInCos` and `cosh_intMul_isPolyInCosh` record the *qualitative* fact that $\\cos(nz)$ and $\\cosh(nz)$ are polynomials in $\\cos z$ resp. $\\cosh z$ for every $n$ — exhibiting the same witness $T_n$ — while the degree-4/5 theorems give the *quantitative* closed forms. The proof of existence is a one-line packaging of Mathlib's evaluation lemma, underscoring that the structural claim and the computational one are cleanly separated."
+    ],
+    "prerequisites": [
+      "De Moivre's theorem and the real Chebyshev-De Moivre dictionary (parent de-moivre-oq-01)",
+      "Complex trigonometric and hyperbolic functions; the identity cos(iw) = cosh w",
+      "Chebyshev polynomials T_n, U_n and their recurrences and composition law over a commutative ring",
+      "Polynomial evaluation and the linear_combination tactic"
+    ]
+  },
+  "sections": [
+    {
+      "title": "Header and Open Question",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "States the parent's open question — does the real Chebyshev–De Moivre dictionary extend to $\\mathbb{C}$? — and the answer: it does, and over $\\mathbb{C}$ a single $T_n$ governs both the circular ($\\cos z$) and hyperbolic ($\\cosh z$) maps because $\\cos(iw)=\\cosh w$."
+    },
+    {
+      "title": "Part 1 — Complex Chebyshev–De Moivre dictionary",
+      "startLine": 42,
+      "endLine": 65,
+      "summary": "Thin wrappers around Mathlib's analytic cores: `cos_intMul_eq_eval_T` ($\\cos(nz)=T_n(\\cos z)$), `sin_succMul_eq_eval_U`, and their hyperbolic twins `cosh_intMul_eq_eval_T`, `sinh_succMul_eq_eval_U` — the same $T_n,U_n$ in both settings."
+    },
+    {
+      "title": "Part 2 — Existence: cos(nz), cosh(nz) are polynomial",
+      "startLine": 67,
+      "endLine": 80,
+      "summary": "`cos_intMul_isPolyInCos` / `cosh_intMul_isPolyInCosh` witness the Chebyshev polynomial $T_n$ as the explicit polynomial expressing $\\cos(nz)$ in $\\cos z$ (resp. $\\cosh$), with the *same* witness serving both."
+    },
+    {
+      "title": "Part 3 — Explicit Chebyshev polynomials over ℂ",
+      "startLine": 82,
+      "endLine": 114,
+      "summary": "Computes $T_3,T_4,T_5$ and $U_3,U_4$ over $\\mathbb{C}$ from the recurrence $T_{n+2}=2X\\,T_{n+1}-T_n$ (and the $U$ analogue), the polynomials feeding the explicit angle formulas."
+    },
+    {
+      "title": "Part 4 — Explicit complex multiple-angle formulas (deg 4,5)",
+      "startLine": 116,
+      "endLine": 155,
+      "summary": "`cos_four_mul`, `cos_five_mul`, `sin_four_mul`, `sin_five_mul`: evaluate the explicit polynomial at $\\cos z$, reduce with `simp`, normalize the $\\mathbb{Z}\\to\\mathbb{C}$ cast, and close with `linear_combination`. Degrees 4–5 are absent from Mathlib (which stops at 3)."
+    },
+    {
+      "title": "Part 5 — Explicit hyperbolic multiple-angle formulas",
+      "startLine": 157,
+      "endLine": 198,
+      "summary": "`cosh_four_mul`,`cosh_five_mul`,`sinh_four_mul`,`sinh_five_mul`: the same polynomials $T_4,T_5,U_3,U_4$ evaluated at $\\cosh z$ — the hyperbolic formulas come essentially for free from the circular ones."
+    },
+    {
+      "title": "Part 6 — Unification and De Moivre composition",
+      "startLine": 200,
+      "endLine": 222,
+      "summary": "`T_eval_cos_and_cosh`: one polynomial realizes both trigonometries. `cos_mul_eq_T_comp` / `cosh_mul_eq_T_comp`: the composition law $\\cos(mn\\cdot z)=T_m(T_n(\\cos z))$, the analytic shadow of $T_{mn}=T_m\\circ T_n$ (`T_mul`)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The open question is answered affirmatively: the Chebyshev-De Moivre dictionary holds over ℂ, and the complex setting reveals that a single Chebyshev polynomial T_n governs both the circular and hyperbolic multiple-angle maps. The file is complete with 22 theorems, 0 sorries, 0 axioms (standard foundational only), proving complex/hyperbolic extraction, the unification theorem, the new degree-4/5 explicit formulas, and the De Moivre composition law.",
+    "implications": "**1. Unification**: cos and cosh multiple-angle formulas are two evaluations of one polynomial family — the relation cos(iw)=cosh w makes Chebyshev polynomials a common engine.\n\n**2. New explicit formulas**: degree-4 and degree-5 closed forms for cos, sin, cosh, sinh over ℂ that are not in Mathlib.\n\n**3. Composition**: the iterate/composition structure cos(mn·z) = T_m(T_n(cos z)) is recorded as a complex De Moivre statement.",
+    "openQuestions": [
+      "Can the degree-n explicit complex/hyperbolic formulas be packaged as a single induction-generated family rather than degree-by-degree?",
+      "Does the same unification extend to U_n: a single statement giving both sin and sinh ratios from one polynomial identity?"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-01",
+      "relationship": "Direct parent: this lifts the parent's real Chebyshev-De Moivre dictionary and explicit multiple-angle formulas to the complex and hyperbolic settings."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-01",
+      "relationship": "extends",
+      "description": "Extends the parent real Chebyshev-De Moivre dictionary to ℂ, adding the hyperbolic unification cos(iw)=cosh w and the new degree-4/5 explicit formulas"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "Built on De Moivre's theorem (cos θ + i sin θ)^n = cos(nθ) + i sin(nθ), whose complex form underlies the Chebyshev evaluation identities used here"
+    }
+  ],
+  "references": [
+    {
+      "authors": "A. de Moivre",
+      "title": "Miscellanea Analytica de Seriebus et Quadraturis",
+      "year": "1730",
+      "venue": "London",
+      "note": "First systematic treatment of (cos θ + i sin θ)^n = cos(nθ) + i sin(nθ)"
+    },
+    {
+      "authors": "P. L. Chebyshev",
+      "title": "Théorie des mécanismes connus sous le nom de parallélogrammes",
+      "year": "1853",
+      "venue": "Mémoires des Savants étrangers présentés à l'Académie de Saint-Pétersbourg",
+      "note": "Introduced T_n and U_n polynomials capturing the multiple-angle structure"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Polynomial.Chebyshev",
+      "Complex"
+    ],
+    "namespace": "DeMoivreOQ01OQ02",
+    "lineCount": 222,
+    "axiomCount": 0,
+    "theoremCount": 22,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ01OQ02.lean",
+    "sorries": 0
+  },
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/De_Moivre%27s_formula",
@@ -69,82 +191,5 @@
     "theoremCount": 22,
     "definitionCount": 0
   },
-  "overview": {
-    "historicalContext": "**From Real to Complex De Moivre**\n\nThe parent formalization (`de-moivre-oq-01`) established the real Chebyshev-De Moivre dictionary $\\cos(n\\theta) = T_n(\\cos\\theta)$ and $\\sin((n+1)\\theta) = U_n(\\cos\\theta)\\sin\\theta$. A natural open question asked whether this extends to the complex setting.\n\nMathlib already proves the analytic core over $\\mathbb{C}$ ($T_n(\\cos z) = \\cos(nz)$, and likewise for $\\cosh$). The genuinely *new* phenomenon the complex setting unlocks is a unification: because $\\cos(iw) = \\cosh w$, the **same** Chebyshev polynomial $T_n$ governs both the circular and the hyperbolic $n$-fold angle maps. A single polynomial identity therefore produces two families of explicit formulas at once.",
-    "problemStatement": "**The Open Question (parent OQ #2)**\n\nCan the Chebyshev-De Moivre connection be extended to the complex setting: do $T_n$ and $U_n$ evaluated at $\\cos z$ reproduce $\\cos(nz)$ and the sine ratio for complex $z$?\n\n**Answer: YES, and more.** Over $\\mathbb{C}$ the dictionary holds verbatim, and the *same* $T_n$, $U_n$ simultaneously yield the hyperbolic multiple-angle formulas via $\\cos(iw)=\\cosh w$.",
-    "text": "Lifts the Chebyshev-De Moivre dictionary to ℂ and shows the same polynomial T_n governs both circular (cos) and hyperbolic (cosh) multiple-angle maps, deriving explicit degree-4 and degree-5 formulas for cos, sin, cosh, sinh and the De Moivre composition law.",
-    "proofStrategy": "**Formalization Strategy**\n\n1. **Complex/hyperbolic dictionary** (`cos_intMul_eq_eval_T`, `sin_succMul_eq_eval_U`, `cosh_intMul_eq_eval_T`, `sinh_succMul_eq_eval_U`): thin wrappers around Mathlib's `T_complex_cos`/`U_complex_cos`/`T_complex_cosh`/`U_complex_cosh`.\n\n2. **Existence** (`cos_intMul_isPolyInCos`, `cosh_intMul_isPolyInCosh`): witness the Chebyshev polynomial $T_n$, emphasizing that the *same* witness serves both the circular and hyperbolic cases.\n\n3. **Explicit polynomials** (`T_three`–`T_five`, `U_three`, `U_four`): computed over $\\mathbb{C}$ via the recurrence $T_{n+2} = 2X\\,T_{n+1} - T_n$.\n\n4. **Degree-4/5 formulas** (`cos_four_mul`, `cos_five_mul`, `sin_four_mul`, `sin_five_mul` and the four `cosh`/`sinh` analogues): obtained by evaluating the explicit polynomial at $\\cos z$ (resp. $\\cosh z$), reducing the polynomial `eval` with `simp`, normalizing the integer cast, and closing with `linear_combination`.\n\n5. **Unification and composition** (`T_eval_cos_and_cosh`, `cos_mul_eq_T_comp`, `cosh_mul_eq_T_comp`): the single-polynomial-two-trigonometries statement, and the De Moivre composition $\\cos(mn\\cdot z) = T_m(T_n(\\cos z))$ from `T_mul` and `eval_comp`.",
-    "keyInsights": [
-      "**One polynomial, two trigonometries**: Since $\\cos(iw) = \\cosh w$, the polynomial $T_n$ gives $\\cos(nz)$ at $\\cos z$ and $\\cosh(nz)$ at $\\cosh z$. The hyperbolic formulas come for free from the circular ones — a unification with no real-only analogue.",
-      "**Mathlib has the core, not the explicit forms**: Mathlib carries the analytic identities and degree ≤ 3 multiple-angle formulas, but degree-4 and degree-5 explicit forms (circular and hyperbolic) are new here.",
-      "**Composition = T_mul**: The De Moivre composition law $\\cos(mn\\cdot z) = T_m(T_n(\\cos z))$ is the trigonometric shadow of the algebraic identity $T_{mn} = T_m \\circ T_n$.",
-      "**Cast discipline**: Mathlib states the complex lemmas with $\\uparrow n$ (an `ℤ`-to-`ℂ` cast); matching the numeral `4 : ℂ` requires normalizing $\\uparrow(4:\\mathbb{Z})$ before `linear_combination` closes the goal."
-    ],
-    "prerequisites": [
-      "De Moivre's theorem and the real Chebyshev-De Moivre dictionary (parent de-moivre-oq-01)",
-      "Complex trigonometric and hyperbolic functions; the identity cos(iw) = cosh w",
-      "Chebyshev polynomials T_n, U_n and their recurrences and composition law over a commutative ring",
-      "Polynomial evaluation and the linear_combination tactic"
-    ]
-  },
-  "conclusion": {
-    "summary": "The open question is answered affirmatively: the Chebyshev-De Moivre dictionary holds over ℂ, and the complex setting reveals that a single Chebyshev polynomial T_n governs both the circular and hyperbolic multiple-angle maps. The file is complete with 22 theorems, 0 sorries, 0 axioms (standard foundational only), proving complex/hyperbolic extraction, the unification theorem, the new degree-4/5 explicit formulas, and the De Moivre composition law.",
-    "implications": "**1. Unification**: cos and cosh multiple-angle formulas are two evaluations of one polynomial family — the relation cos(iw)=cosh w makes Chebyshev polynomials a common engine.\n\n**2. New explicit formulas**: degree-4 and degree-5 closed forms for cos, sin, cosh, sinh over ℂ that are not in Mathlib.\n\n**3. Composition**: the iterate/composition structure cos(mn·z) = T_m(T_n(cos z)) is recorded as a complex De Moivre statement.",
-    "openQuestions": [
-      "Can the degree-n explicit complex/hyperbolic formulas be packaged as a single induction-generated family rather than degree-by-degree?",
-      "Does the same unification extend to U_n: a single statement giving both sin and sinh ratios from one polynomial identity?"
-    ]
-  },
-  "relatedProblems": [
-    {
-      "id": "de-moivre-oq-01",
-      "relationship": "Direct parent: this lifts the parent's real Chebyshev-De Moivre dictionary and explicit multiple-angle formulas to the complex and hyperbolic settings."
-    }
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "opens": [
-      "Polynomial",
-      "Polynomial.Chebyshev",
-      "Complex"
-    ],
-    "namespace": "DeMoivreOQ01OQ02",
-    "lineCount": 222,
-    "axiomCount": 0,
-    "theoremCount": 22,
-    "definitionCount": 0,
-    "path": "Proofs/DeMoivreOQ01OQ02.lean",
-    "sorries": 0
-  },
-  "references": [
-    {
-      "authors": "A. de Moivre",
-      "title": "Miscellanea Analytica de Seriebus et Quadraturis",
-      "year": "1730",
-      "venue": "London",
-      "note": "First systematic treatment of (cos θ + i sin θ)^n = cos(nθ) + i sin(nθ)"
-    },
-    {
-      "authors": "P. L. Chebyshev",
-      "title": "Théorie des mécanismes connus sous le nom de parallélogrammes",
-      "year": "1853",
-      "venue": "Mémoires des Savants étrangers présentés à l'Académie de Saint-Pétersbourg",
-      "note": "Introduced T_n and U_n polynomials capturing the multiple-angle structure"
-    }
-  ],
-  "crossReferences": [
-    {
-      "targetId": "de-moivre-oq-01",
-      "relationship": "extends",
-      "description": "Extends the parent real Chebyshev-De Moivre dictionary to ℂ, adding the hyperbolic unification cos(iw)=cosh w and the new degree-4/5 explicit formulas"
-    },
-    {
-      "targetId": "de-moivre",
-      "relationship": "foundational",
-      "description": "Built on De Moivre's theorem (cos θ + i sin θ)^n = cos(nθ) + i sin(nθ), whose complex form underlies the Chebyshev evaluation identities used here"
-    }
-  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-01-oq-02` (quality 33, passes 0).

## Gaps addressed
The entry had a rich `overview`, `conclusion`, and `crossReferences` but **no `sections`** and **no `annotations.json`**.

## Changes
- **sections**: 7 sections with `startLine`/`endLine` covering the header and the file's 6 parts (complex dictionary, existence, explicit Chebyshev polynomials, circular degree-4/5 formulas, hyperbolic degree-4/5 formulas, unification + De Moivre composition).
- **annotations.json**: 6 substantive annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` — covering the dictionary wrappers, the existence theorems, the recurrence-based polynomial computation, the new degree-4/5 circular formulas, the hyperbolic reuse, and the composition law.
- **keyInsights**: added a 5th distinguishing the qualitative existence results from the quantitative explicit forms.

Axiom integrity verified against the Lean source: imports only Mathlib, 0 sorries, 0 axioms (foundational only), no `native_decide`; `status: verified` / `badge: mathlib` accurate (Mathlib cores + original degree-4/5 derivations).

`pnpm build` passes.