### PR TITLE
Enrich Explicit Values of the Combinatorial Jordan Totient

### DIFF
--- a/src/data/proofs/erdos-1000-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-jc-def",
+    "proofId": "erdos-1000-oq-03-oq-02",
+    "range": { "startLine": 64, "endLine": 75 },
+    "type": "definition",
+    "title": "The combinatorial Jordan totient",
+    "content": "`jordanCount k n` is defined honestly as the number of $k$-tuples $a : \\mathrm{Fin}\\,k \\to \\{0,\\dots,n-1\\}$ whose entries are *setwise* coprime to $n$: $\\gcd(a_0,\\dots,a_{k-1},n) = 1$. The entrywise gcd is taken with Mathlib's `Finset.gcd` over `Fin k`, which makes the supporting algebra clean. The companion `gcd_smul` lemma states that scaling a tuple coordinatewise by $d$ multiplies its gcd by $d$ — a one-liner from `Finset.gcd_mul_left` that is the engine of the fibre bijection.",
+    "mathContext": "$\\mathrm{jordanCount}\\,k\\,n = \\#\\{a \\in \\{0,\\dots,n-1\\}^k : \\gcd(a_0,\\dots,a_{k-1},n)=1\\},\\qquad \\gcd(d\\cdot b) = d\\cdot\\gcd(b).$",
+    "significance": "key",
+    "relatedConcepts": ["Jordan totient", "setwise coprimality", "Finset.gcd", "Euler totient"],
+    "prerequisites": ["greatest common divisor", "Finset filtering"]
+  },
+  {
+    "id": "ann-jc-fiber",
+    "proofId": "erdos-1000-oq-03-oq-02",
+    "range": { "startLine": 77, "endLine": 148 },
+    "type": "technique",
+    "title": "The fibre bijection by rescaling",
+    "content": "`fiber_card` is the technical heart: for each divisor $d \\mid n$, the $k$-tuples in $\\{0,\\dots,n-1\\}$ with $\\gcd(\\gcd(a),n)=d$ biject with the coprime tuples in $\\{0,\\dots,n/d-1\\}$. The bijection is pure rescaling — forward $a_j \\mapsto a_j/d$ (well-defined because $d \\mid \\gcd(a) \\mid a_j$), backward $b_j \\mapsto d\\,b_j$ — implemented as a `Finset.card_bij'` with both inverse conditions discharged by `Nat.mul_div_cancel'`. The coprimality side condition transforms via `gcd_smul` and `Nat.gcd_mul_left`: $\\gcd(\\gcd(a),n)=d$ becomes $\\gcd(\\gcd(a/d), n/d) = 1$ after dividing out $d$.",
+    "mathContext": "$\\{a : \\gcd(\\gcd(a),n)=d\\} \\xrightarrow{\\;a_j \\mapsto a_j/d\\;} \\{b : \\gcd(\\gcd(b), n/d)=1\\},\\quad \\#\\text{fibre} = \\mathrm{jordanCount}\\,k\\,(n/d).$",
+    "significance": "key",
+    "relatedConcepts": ["bijective counting", "Finset.card_bij'", "divisor rescaling", "coprime reduction"],
+    "prerequisites": ["bijections", "divisibility", "Nat division lemmas"]
+  },
+  {
+    "id": "ann-jc-headline",
+    "proofId": "erdos-1000-oq-03-oq-02",
+    "range": { "startLine": 150, "endLine": 172 },
+    "type": "insight",
+    "title": "The geometric Gauss identity ∑ J_k(d) = nᵏ",
+    "content": "`jordan_count_divisor_sum` is the headline. Every one of the $n^k$ tuples in $\\{0,\\dots,n-1\\}^k$ is classified by the single divisor $d = \\gcd(\\gcd(a),n) \\in \\mathrm{divisors}(n)$, so `Finset.card_eq_sum_card_fiberwise` writes $n^k$ as the sum of fibre cardinalities; `fiber_card` replaces each by $\\mathrm{jordanCount}\\,k\\,(n/d)$, and `Nat.sum_div_divisors` reindexes $d \\mapsto n/d$ to give $\\sum_{d\\mid n}\\mathrm{jordanCount}\\,k\\,d = n^k$. This single identity carries the entire theory — every later value is a corollary.",
+    "mathContext": "$\\sum_{d \\mid n} \\mathrm{jordanCount}\\,k\\,d = n^k,\\qquad \\text{generalising Gauss's } \\sum_{d\\mid n}\\varphi(d)=n.$",
+    "significance": "key",
+    "relatedConcepts": ["Gauss divisor-sum identity", "fiberwise counting", "Dirichlet convolution", "divisor reindexing"],
+    "prerequisites": ["divisor sums", "partitioning a finite set"]
+  },
+  {
+    "id": "ann-jc-euler",
+    "proofId": "erdos-1000-oq-03-oq-02",
+    "range": { "startLine": 186, "endLine": 229 },
+    "type": "concept",
+    "title": "Euler recovery and Gauss's identity at k = 1",
+    "content": "At $k=1$ the entrywise-gcd condition on a length-one tuple $(a_0)$ collapses to $\\gcd(a_0,n)=1$ (`gcd_fin_one`), so `jordan_count_eq_totient` proves $\\mathrm{jordanCount}\\,1\\,n = \\varphi(n)$ by a trivial length-one `card_bij'` against `Nat.totient_eq_card_coprime`. Specialising the headline identity to $k=1$ and rewriting then yields `sum_totient_eq_self`, Gauss's classical $\\sum_{d\\mid n}\\varphi(d)=n$ — here obtained as a purely combinatorial corollary of the tuple count.",
+    "mathContext": "$\\mathrm{jordanCount}\\,1\\,n = \\varphi(n),\\qquad \\sum_{d\\mid n}\\varphi(d) = n.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler's totient", "Gauss's theorem", "specialization", "card_bij'"],
+    "prerequisites": ["Euler totient", "subsingleton types"]
+  },
+  {
+    "id": "ann-jc-le-pow",
+    "proofId": "erdos-1000-oq-03-oq-02",
+    "range": { "startLine": 174, "endLine": 184 },
+    "type": "context",
+    "title": "Trivial corollaries: J_k(1) and the bound",
+    "content": "Two short corollaries fall out of the divisor-sum identity. `jordan_count_one` ($J_k(1)=1$) follows by taking $n=1$. `jordan_count_le_pow` bounds $J_k(n) \\le n^k$: since $J_k(n)$ is one of the non-negative terms of $\\sum_{d\\mid n}J_k(d)=n^k$ (the $d=n$ term, via `Finset.single_le_sum`), it cannot exceed the total. The bound is sharp at prime $n$ in the limit and reflects that the coprime tuples are a subset of all $n^k$ tuples.",
+    "mathContext": "$J_k(1) = 1,\\qquad J_k(n) \\le n^k.$",
+    "significance": "context",
+    "relatedConcepts": ["bounds", "Finset.single_le_sum", "monotonicity"],
+    "prerequisites": ["finite sums", "non-negativity"]
+  },
+  {
+    "id": "ann-jc-prime-pow",
+    "proofId": "erdos-1000-oq-03-oq-02",
+    "range": { "startLine": 231, "endLine": 246 },
+    "type": "insight",
+    "title": "Prime-power closed form by telescoping",
+    "content": "`jordan_count_prime_pow` extracts the prime-power values without any induction on $J_k$ itself. The divisors of $p^{m+1}$ are $\\{p^0,\\dots,p^{m+1}\\}$, so `Nat.sum_divisors_prime_pow` turns the headline identity into a geometric-style sum; `Finset.sum_range_succ` peels off the top term and the identity for $p^m$ cancels the rest, leaving $J_k(p^{m+1}) + p^{mk} = p^{(m+1)k}$, closed by `omega`. `jordan_count_prime_pow_sub` rearranges to the closed form $J_k(p^{m+1}) = p^{(m+1)k} - p^{mk}$, which at $k=1$ is Euler's $\\varphi(p^{m+1}) = p^{m+1}-p^m$.",
+    "mathContext": "$J_k(p^{m+1}) = p^{(m+1)k} - p^{mk},\\qquad \\varphi(p^{m+1}) = p^{m+1} - p^m.$",
+    "significance": "key",
+    "relatedConcepts": ["prime powers", "telescoping sum", "Nat.sum_divisors_prime_pow", "multiplicative functions"],
+    "prerequisites": ["divisors of prime powers", "omega tactic"]
+  }
+]

--- a/src/data/proofs/erdos-1000-oq-03-oq-02/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-02/meta.json
@@ -2,45 +2,7 @@
   "id": "erdos-1000-oq-03-oq-02",
   "title": "Explicit Values of the Combinatorial Jordan Totient",
   "slug": "erdos-1000-oq-03-oq-02",
-  "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "opens": [
-      "Finset"
-    ],
-    "namespace": "Erdos1000OQ03OQ02",
-    "lineCount": 246,
-    "axiomCount": 0,
-    "theoremCount": 10,
-    "definitionCount": 1,
-    "path": "Proofs/Erdos1000OQ03OQ02.lean",
-    "sorries": 0
-  },
   "description": "Companion to the sibling erdos-1000-oq-03-oq-01, which establishes the combinatorial characterisation of Jordan's totient J_k as the count of setwise-coprime k-tuples. This entry focuses on the EXPLICIT ARITHMETIC VALUES of that count, all derived self-containedly from the geometric divisor-sum identity. Working with the same honest definition jordanCount k n = #{ a : Fin k -> {0,...,n-1} : gcd(a0,...,a_{k-1}, n) = 1 }, the headline jordan_count_divisor_sum proves the geometric Gauss identity sum_{d|n} jordanCount k d = n^k (every one of the n^k tuples is classified by the divisor gcd(a,n), and the fibre over each d rescales bijectively a -> (aj/d) to the coprime tuples mod n/d). The new explicit values are: the prime-power closed form jordan_count_prime_pow_sub, J_k(p^{m+1}) = p^{(m+1)k} - p^{mk} for p prime (telescoping the divisor sum over divisors(p^{m+1})={p^0,...,p^{m+1}} via Nat.sum_divisors_prime_pow), which at k=1 is Euler's phi(p^{m+1}) = p^{m+1} - p^m; the Euler recovery jordan_count_eq_totient (jordanCount 1 n = phi(n)); Gauss's classical sum_totient_eq_self (sum_{d|n} phi(d) = n) obtained as the k=1 corollary; and the sharp bound jordan_count_le_pow (J_k(n) <= n^k). The crux is fiber_card, a Finset.card_bij' with explicit scaling maps, the gcd of a coordinatewise-scaled tuple handled by Finset.gcd_mul_left. Fully machine-verified with no axioms and no sorries.",
-  "meta": {
-    "author": "Lean Genius",
-    "date": "2026-06-23",
-    "status": "verified",
-    "proofRepoPath": "Proofs/Erdos1000OQ03OQ02.lean",
-    "tags": [
-      "number-theory",
-      "jordan-totient",
-      "euler-totient",
-      "gauss-identity",
-      "divisor-sum",
-      "combinatorics",
-      "bijection",
-      "multiplicative-function"
-    ],
-    "badge": "original",
-    "sorries": 0,
-    "axiomCount": 0,
-    "lineCount": 246,
-    "theoremCount": 10,
-    "definitionCount": 1,
-    "assumptions": ""
-  },
   "overview": {
     "historicalContext": "Camille Jordan introduced the totient $J_k$ in 1870 as the count of $k$-tuples of residues mod $n$ that, together with $n$, are setwise coprime — equivalently, the number of points of $(\\mathbb{Z}/n)^k$ that generate the group, or the number of primitive vectors in the discrete torus. For $k=1$ it is Euler's $\\varphi$. The two faces of $J_k$ — the geometric tuple count and the analytic Dirichlet convolution $\\mu * \\mathrm{id}^k$ with Euler product $J_k(n) = n^k\\prod_{p\\mid n}(1-p^{-k})$ — are classically identified through the divisor-sum identity $\\sum_{d\\mid n} J_k(d) = n^k$, the exact generalisation of Gauss's $\\sum_{d\\mid n}\\varphi(d) = n$. The parent gallery entry built the convolution side; this entry builds the combinatorial side and recovers the same Gauss law directly from the geometry of the tuple count.",
     "problemStatement": "Define $\\mathrm{jordanCount}\\,k\\,n$ as the number of tuples $a : \\{0,\\dots,k-1\\} \\to \\{0,\\dots,n-1\\}$ with $\\gcd(a_0,\\dots,a_{k-1},n) = 1$. Prove the divisor-sum identity $\\sum_{d\\mid n}\\mathrm{jordanCount}\\,k\\,d = n^k$, deduce that $\\mathrm{jordanCount}\\,1\\,n = \\varphi(n)$ (recovering Euler's totient and Gauss's $\\sum_{d\\mid n}\\varphi(d)=n$), and compute the prime-power values $\\mathrm{jordanCount}\\,k\\,(p^{m+1}) = p^{(m+1)k} - p^{mk}$ — all without axioms.",
@@ -49,9 +11,60 @@
       "The single divisor-sum identity $\\sum_{d\\mid n} J_k(d) = n^k$ carries the whole theory: $J_k(1)=1$, the bound $J_k(n)\\le n^k$, the prime-power values, and (at $k=1$) Gauss's totient identity all drop out of it. The combinatorial proof of this one identity is therefore the entire content.",
       "The fibre bijection is pure rescaling: tuples with $\\gcd(a,n)=d$ are precisely $d$ times the tuples mod $n/d$ that are coprime to $n/d$. The gcd of a coordinatewise-scaled tuple equals $d$ times the gcd ($\\gcd(d\\,b)=d\\,\\gcd(b)$), which turns the divisibility condition into a clean coprimality condition one dimension down.",
       "Working with the entrywise gcd via Mathlib's `Finset.gcd` (over `Fin k`) rather than an ad-hoc fold makes the scaling lemma a one-liner (`Finset.gcd_mul_left`) and the divisor-membership of $\\gcd(a,n)$ immediate, keeping the bijection's side conditions elementary.",
-      "The result is the geometric mirror of the parent entry's convolution development: both define $J_k$ and both prove $\\sum_{d\\mid n} J_k(d) = n^k$, so the analytic $\\mu * \\mathrm{pow}\\,k$ and the geometric tuple count are shown to be the same arithmetic function — and both collapse to Euler's $\\varphi$ at $k=1$."
+      "The result is the geometric mirror of the parent entry's convolution development: both define $J_k$ and both prove $\\sum_{d\\mid n} J_k(d) = n^k$, so the analytic $\\mu * \\mathrm{pow}\\,k$ and the geometric tuple count are shown to be the same arithmetic function — and both collapse to Euler's $\\varphi$ at $k=1$.",
+      "**One identity, two routes to the same arithmetic function.** The prime-power closed form is extracted not by induction on $J_k$ but by *telescoping* the divisor-sum identity over $\\mathrm{divisors}(p^{m+1}) = \\{p^0,\\dots,p^{m+1}\\}$: subtracting the identity for $p^m$ from that for $p^{m+1}$ leaves a single term, giving $J_k(p^{m+1}) = p^{(m+1)k} - p^{mk}$ via a one-line `omega`. The same divisor-sum law thus yields both the global Gauss identity and the local prime-power values with no extra machinery."
     ]
   },
+  "sections": [
+    {
+      "title": "Header and Open Question",
+      "startLine": 1,
+      "endLine": 57,
+      "summary": "Frames the goal: take the honest combinatorial definition of Jordan's totient $J_k(n)$ as the count of $k$-tuples setwise coprime to $n$, and derive its explicit arithmetic values (divisor-sum identity, prime-power closed form, Euler/Gauss recovery) self-containedly from the geometry."
+    },
+    {
+      "title": "Definition and the scaling lemma",
+      "startLine": 64,
+      "endLine": 75,
+      "summary": "`jordanCount k n` filters $\\{0,\\dots,n-1\\}^k$ by the entrywise-gcd coprimality condition $\\gcd(\\gcd(a),n)=1$. `gcd_smul` records that scaling a tuple coordinatewise by $d$ multiplies its `Finset.gcd` by $d$ (from `Finset.gcd_mul_left`)."
+    },
+    {
+      "title": "The fibre bijection",
+      "startLine": 77,
+      "endLine": 148,
+      "summary": "`fiber_card`: a `Finset.card_bij'` with the mutually-inverse rescaling maps $a\\mapsto(a_j/d)$ and $b\\mapsto(d\\,b_j)$ proving that tuples with $\\gcd(\\gcd(a),n)=d$ biject with the coprime tuples mod $n/d$, so the fibre over $d$ has $\\mathrm{jordanCount}\\,k\\,(n/d)$ elements."
+    },
+    {
+      "title": "Headline: the geometric Gauss identity",
+      "startLine": 150,
+      "endLine": 172,
+      "summary": "`jordan_count_divisor_sum`: partitioning all $n^k$ tuples by $d=\\gcd(\\gcd(a),n)\\in\\mathrm{divisors}(n)$ via `card_eq_sum_card_fiberwise`, applying `fiber_card`, and reindexing with `Nat.sum_div_divisors` yields $\\sum_{d\\mid n}\\mathrm{jordanCount}\\,k\\,d = n^k$."
+    },
+    {
+      "title": "Immediate corollaries: J_k(1) and the bound",
+      "startLine": 174,
+      "endLine": 184,
+      "summary": "`jordan_count_one` ($J_k(1)=1$) and `jordan_count_le_pow` ($J_k(n)\\le n^k$, since one divisor term is bounded by the full sum) drop straight out of the headline identity."
+    },
+    {
+      "title": "Euler recovery at k = 1",
+      "startLine": 186,
+      "endLine": 219,
+      "summary": "`gcd_fin_one` (the gcd of a length-one tuple is its entry) and `jordan_count_eq_totient`: a length-one `card_bij'` identifying the coprimality condition with $\\gcd(a_0,n)=1$, proving $\\mathrm{jordanCount}\\,1\\,n = \\varphi(n)$."
+    },
+    {
+      "title": "Gauss's classical totient identity",
+      "startLine": 221,
+      "endLine": 229,
+      "summary": "`sum_totient_eq_self`: specialising the headline to $k=1$ and rewriting by the Euler recovery gives a combinatorial proof of Gauss's $\\sum_{d\\mid n}\\varphi(d) = n$."
+    },
+    {
+      "title": "Prime-power closed form",
+      "startLine": 231,
+      "endLine": 246,
+      "summary": "`jordan_count_prime_pow` telescopes the divisor sum over $\\{p^0,\\dots,p^{m+1}\\}$ (via `Nat.sum_divisors_prime_pow` and `sum_range_succ`); `jordan_count_prime_pow_sub` rearranges to $J_k(p^{m+1}) = p^{(m+1)k}-p^{mk}$, which is $\\varphi(p^{m+1})=p^{m+1}-p^m$ at $k=1$."
+    }
+  ],
   "conclusion": {
     "summary": "The combinatorial Jordan totient $\\mathrm{jordanCount}\\,k\\,n$ — the number of $k$-tuples of residues setwise coprime to $n$ — is machine-verified to satisfy the geometric Gauss identity $\\sum_{d\\mid n}\\mathrm{jordanCount}\\,k\\,d = n^k$, to bound $J_k(n)\\le n^k$, to equal Euler's $\\varphi$ at $k=1$ (whence $\\sum_{d\\mid n}\\varphi(d)=n$), and to take the prime-power values $J_k(p^{m+1}) = p^{(m+1)k} - p^{mk}$. No axioms and no sorries.",
     "implications": "This proves the combinatorial characterisation that the parent entry erdos-1000-oq-03 only asserts, so the analytic (Dirichlet convolution $\\mu*\\mathrm{pow}\\,k$) and geometric (coprime tuple count) definitions of Jordan's totient are now both formalised and shown to coincide via the shared divisor-sum law. The $k=1$ specialisation gives an independent, combinatorial proof of Gauss's $\\sum_{d\\mid n}\\varphi(d)=n$.",
@@ -76,5 +89,43 @@
       "relationship": "related",
       "description": "That entry poses the generalisation of Euler's product/prime-power formula to J_k; here the prime-power closed form J_k(p^{m+1})=p^{(m+1)k}-p^{mk} is obtained combinatorially."
     }
-  ]
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1000OQ03OQ02",
+    "lineCount": 246,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1000OQ03OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1000OQ03OQ02.lean",
+    "tags": [
+      "number-theory",
+      "jordan-totient",
+      "euler-totient",
+      "gauss-identity",
+      "divisor-sum",
+      "combinatorics",
+      "bijection",
+      "multiplicative-function"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 246,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "assumptions": ""
+  }
 }


### PR DESCRIPTION
Enrichment pass for `erdos-1000-oq-03-oq-02` (quality 33, passes 0).

## Gaps addressed
Rich `overview`/`conclusion`/`crossReferences` but **no `sections`** and **no `annotations.json`**.

## Changes
- **sections**: 8 sections with line ranges covering the header, the definition + scaling lemma, the fibre bijection (`fiber_card`), the headline divisor-sum identity, the trivial corollaries, the Euler/Gauss recovery at $k=1$, and the prime-power closed form.
- **annotations.json**: 6 substantive annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **keyInsights**: added a 5th on the telescoping route from the divisor-sum identity to the prime-power values.

Axiom integrity verified against the Lean source: imports only Mathlib, 0 sorries, 0 axioms, no `native_decide`; `status: verified` / `badge: original` accurate.

`pnpm build` passes.