### PR TITLE
Enrich Euler Totient Periodicity Beyond the Coprime Case

### DIFF
--- a/src/data/proofs/euler-totient-oq-08/annotations.json
+++ b/src/data/proofs/euler-totient-oq-08/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-et08-headline",
+    "proofId": "euler-totient-oq-08",
+    "range": { "startLine": 39, "endLine": 61 },
+    "type": "insight",
+    "title": "Headline: a^(k+φ(p^e)) ≡ a^k for every base",
+    "content": "pow_add_totient_modEq_primePow drops Mathlib's coprimality hypothesis for prime-power moduli by a single by_cases on p ∣ a. If p ∤ a, then a is coprime to p^e and Euler's theorem (Nat.ModEq.pow_totient) gives a^φ(p^e) ≡ 1, so a^(k+φ(p^e)) = a^k · a^φ(p^e) ≡ a^k. If p ∣ a, then p^e ∣ a^e ∣ a^k (using k ≥ e), so both a^k and a^(k+φ(p^e)) are ≡ 0 mod p^e, hence congruent. The hypothesis k ≥ e is exactly what the divisible branch needs.",
+    "mathContext": "$a^{k+\\varphi(p^e)} \\equiv a^k \\pmod{p^e}\\quad(p\\ \\text{prime},\\ 1\\le e\\le k,\\ \\text{any}\\ a)$",
+    "significance": "key",
+    "relatedConcepts": ["Euler–Fermat theorem", "modular exponentiation", "case analysis", "p-adic valuation"],
+    "prerequisites": ["Euler's theorem", "divisibility of powers", "Nat.ModEq"]
+  },
+  {
+    "id": "ann-et08-divisible-branch",
+    "proofId": "euler-totient-oq-08",
+    "range": { "startLine": 45, "endLine": 53 },
+    "type": "technique",
+    "title": "The pre-period collapse p^e ∣ a^k",
+    "content": "The non-coprime branch is the genuinely new content. When p ∣ a, raising to the e-th power gives p^e ∣ a^e (pow_dvd_pow_of_dvd), and since e ≤ k, a^e ∣ a^k (pow_dvd_pow), so p^e ∣ a^k — the power has already collapsed to 0 mod p^e. The same holds for the longer exponent k + φ(p^e), so both sides are ≡ 0 and the congruence is immediate via Nat.modEq_zero_iff_dvd. This is the 'pre-period': for a base sharing the factor p, all powers from a^e onward are 0.",
+    "mathContext": "$p\\mid a,\\ e\\le k \\implies p^e \\mid a^e \\mid a^k \\implies a^k \\equiv 0 \\pmod{p^e}$",
+    "significance": "key",
+    "relatedConcepts": ["nilpotency mod p^e", "pre-period", "divisibility of powers", "non-invertible base"],
+    "prerequisites": ["divisibility", "prime powers"]
+  },
+  {
+    "id": "ann-et08-multiperiod",
+    "proofId": "euler-totient-oq-08",
+    "range": { "startLine": 62, "endLine": 77 },
+    "type": "concept",
+    "title": "Multi-period form by induction on the period count",
+    "content": "pow_add_mul_totient_modEq_primePow shows adding any multiple l·φ(p^e) to the exponent is invisible mod p^e. The proof inducts on l: the base case l = 0 is reflexivity, and the successor step chains one single-period application (the headline) with the inductive hypothesis. The hypothesis k ≥ e propagates through the induction since k + l·φ(p^e) ≥ k ≥ e at every stage. This is the non-coprime counterpart of Mathlib's Nat.pow_add_mul_totient_mod_eq.",
+    "mathContext": "$a^{k + l\\,\\varphi(p^e)} \\equiv a^k \\pmod{p^e}\\quad\\text{for all}\\ l\\in\\mathbb{N}$",
+    "significance": "supporting",
+    "relatedConcepts": ["mathematical induction", "period of a sequence", "modular congruence", "transitivity of ≡"],
+    "prerequisites": ["induction", "Nat.ModEq composition"]
+  },
+  {
+    "id": "ann-et08-fullreduction",
+    "proofId": "euler-totient-oq-08",
+    "range": { "startLine": 78, "endLine": 98 },
+    "type": "insight",
+    "title": "Full exponent reduction with an e-length pre-period",
+    "content": "pow_modEq_primePow is the computational payoff: a^k ≡ a^(e + (k−e) mod φ(p^e)). The division algorithm Nat.mod_add_div' splits k−e into remainder + quotient·φ(p^e), rewriting k as (e + (k−e) mod φ(p^e)) + (quotient)·φ(p^e); the multi-period theorem then strips the quotient·φ(p^e) term. Unlike Mathlib's coprime pow_totient_mod (which reduces to k mod φ(n) with no offset), the leading e is an irreducible pre-period — the transient before the sequence becomes purely periodic.",
+    "mathContext": "$a^k \\equiv a^{\\,e + ((k-e)\\bmod \\varphi(p^e))} \\pmod{p^e}$",
+    "significance": "key",
+    "relatedConcepts": ["division algorithm", "eventual periodicity", "exponent reduction", "transient vs steady state"],
+    "prerequisites": ["division algorithm", "modular arithmetic"]
+  },
+  {
+    "id": "ann-et08-examples",
+    "proofId": "euler-totient-oq-08",
+    "range": { "startLine": 99, "endLine": 116 },
+    "type": "context",
+    "title": "Worked examples on non-invertible bases",
+    "content": "The examples exercise bases Euler's coprime theorem cannot touch. For 2^k mod 8 (p = 2, e = 3) the powers are constant ≡ 0 from k = 3, checked both via the theorem and by kernel decide (2^7 ≡ 2^3 ≡ 0). For 6^k mod 16 (6 = 2·3, e = 4, φ(16) = 8) the full reduction collapses a huge exponent: 6^100 ≡ 6^(4 + (96 mod 8)) = 6^4 ≡ 0, verified by decide. These use kernel reduction (not native_decide), so they introduce no extra axioms.",
+    "mathContext": "$6^{100} \\equiv 6^{4 + (96 \\bmod 8)} = 6^4 \\equiv 0 \\pmod{16}$",
+    "significance": "context",
+    "relatedConcepts": ["worked example", "kernel decide", "non-coprime base", "last-digit computation"],
+    "prerequisites": ["modular exponentiation", "decidable evaluation"]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-08/meta.json
+++ b/src/data/proofs/euler-totient-oq-08/meta.json
@@ -89,7 +89,8 @@
       "**Coprimality is only needed to avoid the pre-period.** The single hypothesis k ≥ e replaces gcd(a, p^e) = 1: it guarantees that bases divisible by p have already collapsed to 0, so the same period φ(p^e) governs both invertible and non-invertible bases.",
       "**Two regimes, one period.** A unit base cycles through a^φ(p^e) ≡ 1; a base divisible by p is eventually 0. In both cases shifting the exponent by φ(p^e) (for k ≥ e) is invisible mod p^e — the proof is a clean two-branch case analysis.",
       "**Eventual vs. pure periodicity.** Mathlib's coprime `pow_totient_mod` reduces to k mod φ(n) with no offset; the non-coprime reduction keeps an e-length pre-period, reducing to e + (k−e) mod φ(p^e). The offset e is exactly the length of the transient before the sequence becomes periodic.",
-      "**Prime powers are the right granularity.** For p ∣ a the valuation argument needs a single prime, so the clean statement lives at prime-power moduli; the general composite modulus follows by CRT but already reduces to this prime-power core."
+      "**Prime powers are the right granularity.** For p ∣ a the valuation argument needs a single prime, so the clean statement lives at prime-power moduli; the general composite modulus follows by CRT but already reduces to this prime-power core.",
+      "**This is eventual periodicity made exact.** Modular exponentiation of any base is eventually periodic; the contribution here is the explicit pre-period length (e) and period (φ(p^e)) for prime-power moduli, turning a qualitative dynamical-systems fact into a closed-form exponent-reduction usable for computation."
     ],
     "prerequisites": [
       "Euler's totient φ and the Fermat–Euler theorem (coprime case)",
@@ -112,29 +113,36 @@
       "id": "header-overview",
       "title": "Module Overview, Imports, and Namespace",
       "startLine": 1,
-      "endLine": 52,
-      "summary": "Module docstring framing the goal — extend Euler's exponent reduction to the non-coprime case for prime-power moduli, quoting Mathlib's own TODO — with imports (`Mathlib`), the main-results list, and the `EulerTotientOQ08` namespace (with `φ` denoting `Nat.totient`)."
+      "endLine": 37,
+      "summary": "Module docstring framing the goal — extend Euler's exponent reduction to the non-coprime case for prime-power moduli, quoting Mathlib's own TODO — with imports, the main-results list, and the EulerTotientOQ08 namespace (φ = Nat.totient)."
     },
     {
       "id": "headline-periodicity",
       "title": "Non-Coprime Prime-Power Periodicity",
-      "startLine": 53,
-      "endLine": 75,
-      "summary": "`pow_add_totient_modEq_primePow`: the headline `a^(k + φ(p^e)) ≡ a^k [MOD p^e]` for any base, by `by_cases p ∣ a` — the divisible branch shows both sides `≡ 0` via `p^e ∣ a^k`, the coprime branch invokes `Nat.ModEq.pow_totient`."
+      "startLine": 39,
+      "endLine": 61,
+      "summary": "pow_add_totient_modEq_primePow: the headline a^(k + φ(p^e)) ≡ a^k [MOD p^e] for any base, by by_cases p ∣ a — the divisible branch shows both sides ≡ 0 via p^e ∣ a^k (pow_dvd_pow_of_dvd, pow_dvd_pow), the coprime branch invokes Nat.ModEq.pow_totient."
     },
     {
       "id": "multi-period",
       "title": "The Multi-Period Form",
-      "startLine": 76,
-      "endLine": 92,
-      "summary": "`pow_add_mul_totient_modEq_primePow`: adding any multiple `l · φ(p^e)` to the exponent leaves `a^k` unchanged mod `p^e`, proved by induction on `l` chaining the headline single-period step."
+      "startLine": 62,
+      "endLine": 77,
+      "summary": "pow_add_mul_totient_modEq_primePow: adding any multiple l · φ(p^e) to the exponent leaves a^k unchanged mod p^e, proved by induction on l chaining the headline single-period step."
     },
     {
       "id": "full-reduction",
       "title": "Full Exponent Reduction",
-      "startLine": 93,
-      "endLine": 115,
-      "summary": "`pow_modEq_primePow`: the non-coprime analogue of `Nat.pow_totient_mod`, `a^k ≡ a^(e + (k−e) mod φ(p^e))`, via the division algorithm `Nat.mod_add_div'`; plus worked `decide`/instantiation examples on `2^k mod 8` and `6^k mod 16`."
+      "startLine": 78,
+      "endLine": 98,
+      "summary": "pow_modEq_primePow: the non-coprime analogue of Nat.pow_totient_mod, a^k ≡ a^(e + (k−e) mod φ(p^e)), splitting k−e by the division algorithm Nat.mod_add_div' into remainder + quotient·period and applying the multi-period form."
+    },
+    {
+      "id": "worked-examples",
+      "title": "Worked Examples (non-coprime bases)",
+      "startLine": 99,
+      "endLine": 117,
+      "summary": "Genuinely non-coprime data outside Euler's coprime theorem: 2^k mod 8 (constant ≡ 0 from k = e = 3), the decide check 2^7 ≡ 2^3 ≡ 0, and 6^k mod 16 (e = 4, φ(16) = 8) with the collapse 6^100 ≡ 6^4 ≡ 0 verified by decide."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-08` (quality 41 → 100).

Already had a strong overview, conclusion, well-formed crossReferences, and mathlibDependencies; gaps were inline annotations and section granularity.

- **annotations.json** (new): 5 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering the headline $a^{k+\varphi(p^e)}\equiv a^k$ for every base, the pre-period collapse $p^e\mid a^k$, the multi-period induction, the full exponent reduction with its $e$-length pre-period, and the worked non-invertible-base examples.
- **sections**: split 4 → 5 (full reduction vs worked examples) for complete line coverage.
- Added a 5th keyInsight (eventual periodicity made exact: explicit pre-period $e$, period $\varphi(p^e)$).

`pnpm build` passes.