### PR TITLE
Enrich Coprimality and gcd of a Finite Family of Totients

### DIFF
--- a/src/data/proofs/euler-totient-oq-07-oq-03/annotations.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-et-unital",
+    "proofId": "euler-totient-oq-07-oq-03",
+    "range": { "startLine": 51, "endLine": 58 },
+    "type": "definition",
+    "title": "The Unital predicate",
+    "content": "`Unital n := n = 1 ∨ n = 2` names the arguments whose totient is exactly 1, made decidable so it can drive `Finset.filter` and `decide`. The bridge `totient_eq_one_iff_unital` ($\\varphi n = 1 \\iff \\mathrm{Unital}\\,n$) is just Mathlib's `Nat.totient_eq_one_iff`. This single predicate is the organizing notion of the whole file: pairwise coprimality and family-gcd parity are both expressed by counting non-unital indices.",
+    "mathContext": "$\\mathrm{Unital}\\,n \\iff n \\in \\{1,2\\} \\iff \\varphi(n) = 1.$",
+    "significance": "key",
+    "relatedConcepts": ["Euler totient", "decidable predicate", "totient value 1", "Finset.filter"],
+    "prerequisites": ["Euler's totient", "decidability"]
+  },
+  {
+    "id": "ann-et-even",
+    "proofId": "euler-totient-oq-07-oq-03",
+    "range": { "startLine": 60, "endLine": 75 },
+    "type": "insight",
+    "title": "Non-unital ⟹ even totient (the basic obstruction)",
+    "content": "`two_dvd_totient_of_not_unital` proves $n \\notin \\{1,2\\} \\Rightarrow 2 \\mid \\varphi(n)$, unifying the two ways an argument can be non-unital: $n = 0$ (handled directly, $\\varphi 0 = 0$ is even) and $n \\ge 3$ (`Nat.totient_even`). Mathematically the factor 2 comes from $-1$ having order 2 in $(\\mathbb{Z}/n)^\\times$ for $n > 2$, so Lagrange forces $2 \\mid \\varphi(n)$. This shared factor 2 is the single obstruction to coprimality, restated through `Unital` so it scales uniformly to families. `coprime_totient_iff_unital` then repackages Mathlib's two-argument characterization.",
+    "mathContext": "$n \\notin \\{1,2\\} \\Rightarrow 2 \\mid \\varphi(n);\\qquad (\\varphi m).\\mathrm{Coprime}(\\varphi n) \\iff \\mathrm{Unital}\\,m \\vee \\mathrm{Unital}\\,n.$",
+    "significance": "key",
+    "relatedConcepts": ["parity of totient", "Lagrange's theorem", "order of −1", "Nat.totient_even"],
+    "prerequisites": ["group of units", "even numbers"]
+  },
+  {
+    "id": "ann-et-pairwise",
+    "proofId": "euler-totient-oq-07-oq-03",
+    "range": { "startLine": 77, "endLine": 107 },
+    "type": "insight",
+    "title": "Headline: pairwise coprime ⟺ ≤ 1 non-unital index",
+    "content": "`pairwise_coprime_totient_iff` is the main result: the family $\\{\\varphi(n_i)\\}_{i\\in s}$ is pairwise coprime iff the filtered set of non-unital indices has cardinality $\\le 1$. The forward direction derives a contradiction from two distinct non-unital indices (their totients share the factor 2); the backward direction notes that with at most one non-unital index every pair contains a unital member whose totient 1 is coprime to everything. The cardinality bound is encoded via `Finset.card_le_one`, turning a quantified pairwise statement into a clean counting condition.",
+    "mathContext": "$\\mathrm{Pairwise}_{i,j\\in s}\\,(\\varphi(n_i)\\perp\\varphi(n_j)) \\iff \\#\\{i\\in s : \\neg\\,\\mathrm{Unital}(n_i)\\} \\le 1.$",
+    "significance": "key",
+    "relatedConcepts": ["pairwise coprimality", "Finset.card_le_one", "filtered Finset", "counting obstructions"],
+    "prerequisites": ["pairwise relations", "Finset cardinality"]
+  },
+  {
+    "id": "ann-et-family-gcd",
+    "proofId": "euler-totient-oq-07-oq-03",
+    "range": { "startLine": 109, "endLine": 131 },
+    "type": "concept",
+    "title": "Family gcd: divisibility and lower bound",
+    "content": "`two_dvd_family_gcd_of_forall_not_unital` shows that if every argument is non-unital, 2 divides the gcd of the whole family — since 2 divides each member, `Finset.dvd_gcd` lifts it to the gcd. `two_le_family_gcd_of_forall_three_le` upgrades this to $\\gcd \\ge 2$ for a nonempty family with all arguments $\\ge 3$: positivity of the gcd comes from `Finset.gcd_eq_zero_iff` (one member is positive), and $2 \\mid \\gcd$ with positivity gives $\\gcd \\ge 2$ via `Nat.le_of_dvd`. This generalizes the parent's two-argument bound $2 \\le \\gcd(\\varphi m, \\varphi n)$.",
+    "mathContext": "$(\\forall i\\in s,\\ \\neg\\,\\mathrm{Unital}(n_i)) \\Rightarrow 2 \\mid \\gcd_i \\varphi(n_i);\\quad (s\\neq\\emptyset \\wedge \\forall i,\\ n_i\\ge 3) \\Rightarrow \\gcd_i \\varphi(n_i) \\ge 2.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.gcd", "divisibility lifting", "positivity", "lower bound"],
+    "prerequisites": ["gcd of a family", "Nat.le_of_dvd"]
+  },
+  {
+    "id": "ann-et-power-two",
+    "proofId": "euler-totient-oq-07-oq-03",
+    "range": { "startLine": 133, "endLine": 148 },
+    "type": "insight",
+    "title": "Power-of-two gcd from divisor-of-prime-power",
+    "content": "`family_gcd_isPowerOfTwo` settles the 'fixed power of 2' sub-question: if every $\\varphi(n_i)$ is a power of 2, so is the family gcd. The argument is purely a divisor-of-prime-power fact — the gcd divides any one member (`Finset.gcd_dvd`), and a divisor of $2^k$ is $2^K$ for some $K \\le k$ (`Nat.dvd_prime_pow`). No further arithmetic of the $n_i$ is needed. The natural source of such families is products of distinct Fermat primes, whose totients are always powers of 2 — the classical constructible-polygon numbers.",
+    "mathContext": "$(\\forall i,\\ \\exists k,\\ \\varphi(n_i) = 2^k) \\Rightarrow \\exists K,\\ \\gcd_i \\varphi(n_i) = 2^K.$",
+    "significance": "key",
+    "relatedConcepts": ["Fermat primes", "powers of two", "Nat.dvd_prime_pow", "constructible polygons"],
+    "prerequisites": ["prime powers", "divisors of prime powers"]
+  },
+  {
+    "id": "ann-et-examples",
+    "proofId": "euler-totient-oq-07-oq-03",
+    "range": { "startLine": 150, "endLine": 184 },
+    "type": "context",
+    "title": "Worked examples by kernel decide",
+    "content": "Four concrete tuples illustrate the theorems, all discharged by kernel `decide` (not `native_decide`, so no extra axioms): $(1,2,9)$ is pairwise coprime since only 9 is non-unital ($\\varphi = 1,1,6$); $(9,15)$ is NOT pairwise coprime as both are non-unital and $\\varphi9 = 6$, $\\varphi15 = 8$ share 2; $(5,7,9)$ with $\\varphi = 4,6,6$ has family gcd $\\ge 2$; and the Fermat primes $(3,5,17)$ with $\\varphi = 2,4,16$ give a power-of-2 family gcd.",
+    "mathContext": "$\\varphi(1,2,9) = (1,1,6),\\ \\varphi(9,15) = (6,8),\\ \\varphi(5,7,9) = (4,6,6),\\ \\varphi(3,5,17) = (2,4,16).$",
+    "significance": "context",
+    "relatedConcepts": ["decide tactic", "concrete evaluation", "Fermat primes", "kernel reduction"],
+    "prerequisites": ["decidable propositions", "computing the totient"]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-07-oq-03/meta.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-03/meta.json
@@ -103,7 +103,8 @@
       "**One notion controls everything: non-unitality.** An argument is non-unital (n ∉ {1,2}) exactly when φ(n) ≠ 1, and exactly then 2 ∣ φ(n). Pairwise coprimality and family-gcd parity both reduce to counting non-unital indices.",
       "**Pairwise coprime ⟺ at most one non-unital argument.** Coprimality is a property of pairs; the only obstruction is two non-unital arguments sharing the factor 2, so the whole family is pairwise coprime precisely when the non-unital indices number ≤ 1.",
       "**The n = 0 boundary merges with n ≥ 3.** φ(0) = 0 is even, so the clean statement is in terms of {1, 2} (the φ = 1 set), not in terms of a size threshold — covering 0 and all of n ≥ 3 uniformly.",
-      "**The power-of-2 question is a divisor-of-prime-power fact.** Once every φ(n_i) is a power of 2, the family gcd divides one of them and is therefore a power of 2 — no further arithmetic of the n_i is needed. This holds for products of distinct Fermat primes, where φ is always a power of 2."
+      "**The power-of-2 question is a divisor-of-prime-power fact.** Once every φ(n_i) is a power of 2, the family gcd divides one of them and is therefore a power of 2 — no further arithmetic of the n_i is needed. This holds for products of distinct Fermat primes, where φ is always a power of 2.",
+      "**`decide`, not `native_decide`, keeps the examples axiom-free.** The worked examples evaluate $\\varphi$ and `Finset.gcd` at concrete small tuples by kernel reduction (`decide`), which is checked by the Lean kernel itself and so introduces no extra axioms — unlike `native_decide`, which would pull in `Lean.ofReduceBool`. This is why the entry can honestly claim 0 axioms while still shipping fully computed examples."
     ],
     "prerequisites": [
       "Euler's totient φ and the unit group (ℤ/nℤ)ˣ",


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-07-oq-03` (quality 41, passes 0).

## Gaps addressed
This entry already had a structured `overview`, `conclusion`, and `sections` — the remaining gaps were **no `annotations.json`** and only 4 keyInsights.

## Changes
- **annotations.json**: 6 substantive annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` — covering the `Unital` predicate, the non-unital ⟹ even-totient obstruction, the headline pairwise characterization, the family-gcd divisibility/lower-bound, the power-of-two result, and the worked examples.
- **keyInsights**: added a 5th noting that the examples use kernel `decide` (not `native_decide`), preserving the 0-axiom claim.

Axiom integrity verified against the Lean source: 0 sorries, 0 axioms, no `native_decide`; `status: verified` / `badge: original` accurate.

`pnpm build` passes.