### PR TITLE
research(erdos-1017-oq-03): two-sided real envelope + exact parity identity for the Turán bound ⌊n²/4⌋

### DIFF
--- a/proofs/Proofs/Erdos1017OQ03.lean
+++ b/proofs/Proofs/Erdos1017OQ03.lean
@@ -27,6 +27,10 @@ rely on. (Self-contained: `T` is re-declared, depending only on Mathlib.)
 4. `turanBound_strictMono` — `T` is **strictly increasing** for `n ≥ 1`
    (`T(n) < T(n+1)`), sharpening the file's non-strict monotonicity.
 5. `turanBound_le_sq_div_four` — the real-valued envelope `T(n) ≤ n²/4`.
+6. `turanBound_four_mul` — the exact integer identity `4·T(n) = n² − (n mod 2)`
+   (equivalently `n² mod 4 = n mod 2`).
+7. `turanBound_ge_sq_sub_one_div_four` — the matching lower real envelope
+   `(n² − 1)/4 ≤ T(n)`, sandwiching `T` as `(n² − 1)/4 ≤ T(n) ≤ n²/4`.
 
 ## Summary: 0 sorries, 0 axioms, no `native_decide`. Self-contained over Mathlib.
 -/
@@ -84,6 +88,37 @@ theorem turanBound_le_sq_div_four (n : ℕ) :
   calc ((n ^ 2 / 4 : ℕ) : ℝ) ≤ ((n ^ 2 : ℕ) : ℝ) / 4 := h
     _ = (n : ℝ) ^ 2 / 4 := by push_cast; ring
 
+/-- **Exact integer identity:** `4·T(n) = n² − (n mod 2)`. The quarter-square loses
+    exactly the parity bit: nothing for even `n`, one unit for odd `n`. Equivalently
+    `n² mod 4 = n mod 2`, so the floor `⌊n²/4⌋` is `n²/4` rounded down by `0` or `¼`. -/
+theorem turanBound_four_mul (n : ℕ) : 4 * turanBound n = n ^ 2 - n % 2 := by
+  unfold turanBound
+  have hmod : n ^ 2 % 4 = n % 2 := by
+    rcases Nat.even_or_odd n with ⟨m, rfl⟩ | ⟨m, rfl⟩
+    · rw [show (m + m) ^ 2 = 4 * m ^ 2 by ring]; omega
+    · rw [show (2 * m + 1) ^ 2 = 4 * (m ^ 2 + m) + 1 by ring]; omega
+  have hsplit := Nat.div_add_mod (n ^ 2) 4
+  omega
+
+/-- **Lower real envelope:** `(n² − 1)/4 ≤ T(n)` over `ℝ`. Together with
+    `turanBound_le_sq_div_four` this sandwiches the Turán bound,
+    `(n² − 1)/4 ≤ T(n) ≤ n²/4`, with equality on the right for even `n` and on the
+    left for odd `n` (the floor discards at most `¼`). -/
+theorem turanBound_ge_sq_sub_one_div_four (n : ℕ) :
+    ((n : ℝ) ^ 2 - 1) / 4 ≤ (turanBound n : ℝ) := by
+  unfold turanBound
+  have hmod : n ^ 2 % 4 ≤ 1 := by
+    rcases Nat.even_or_odd n with ⟨m, rfl⟩ | ⟨m, rfl⟩
+    · rw [show (m + m) ^ 2 = 4 * m ^ 2 by ring]; omega
+    · rw [show (2 * m + 1) ^ 2 = 4 * (m ^ 2 + m) + 1 by ring]; omega
+  have hsplit := Nat.div_add_mod (n ^ 2) 4
+  have hint : (n : ℝ) ^ 2 ≤ 4 * ((n ^ 2 / 4 : ℕ) : ℝ) + 1 := by
+    have hnat : n ^ 2 ≤ 4 * (n ^ 2 / 4) + 1 := by omega
+    have hcast := (Nat.cast_le (α := ℝ)).mpr hnat
+    push_cast at hcast
+    linarith
+  linarith
+
 /-
 ## Significance
 
@@ -93,7 +128,10 @@ of complete subgraphs needed and the edge count of the extremal complete
 bipartite graph. The companion file records its product form and monotonicity;
 this entry adds the explicit parity-split closed forms `T(2m) = m²`,
 `T(2m+1) = m(m+1)`, the exact one-step increment `⌊(n+1)/2⌋`, the strict growth
-for `n ≥ 1`, and the real envelope `T(n) ≤ n²/4`.
+for `n ≥ 1`, the exact integer identity `4·T(n) = n² − (n mod 2)`, and the
+two-sided real envelope `(n² − 1)/4 ≤ T(n) ≤ n²/4`. The sandwich pins `T(n)`
+within `¼` of the exact quarter-square `n²/4`, making the asymptotics
+`T(n) ∼ n²/4` immediate.
 
 The closed forms make the extremal edge counts (`K_{m,m}` has `m²`, `K_{m,m+1}`
 has `m(m+1)`) explicit, and the increment formula is exactly the quantity the

--- a/research/problems/erdos-1017-oq-03/knowledge.md
+++ b/research/problems/erdos-1017-oq-03/knowledge.md
@@ -8,3 +8,36 @@ turanBound_strictMono, turanBound_le_sq_div_four) + gallery entry, but the Lean 
 Registered `import Proofs.Erdos1017OQ03` (LC_ALL=C sorted: between Erdos1017OQ01 and
 Erdos1017Problem). Host-lean verified EXIT=0; #print axioms = [propext, Classical.choice,
 Quot.sound] only. No new math; Erdős #1017 clique-partition stays open.
+
+## Session 2026-06-30 (researcher-1) — ACT: two-sided envelope + exact parity identity
+
+**Mode**: REVISIT (pool re-served COMPLETED slug, MODERATE depth-first).
+**Outcome**: progress — new math, VERIFIED 0-axiom green build. PR #31532.
+
+### What I Did
+The file had only the upper real envelope T(n) <= n^2/4. Added:
+- `turanBound_four_mul`: `4*T(n) = n^2 - (n % 2)` (i.e. `n^2 % 4 = n % 2`) — the
+  floor discards exactly the parity bit. Proof: parity rcases on n
+  ((m+m)^2=4m^2, (2m+1)^2=4(m^2+m)+1) -> `n^2%4 = n%2` by omega; then
+  `Nat.div_add_mod (n^2) 4` + omega.
+- `turanBound_ge_sq_sub_one_div_four`: lower envelope `(n^2-1)/4 <= T(n)`. Cast the
+  integer bound `n^2 <= 4*T(n)+1` (from `n^2%4 <= 1`) to R, close with `linarith`.
+
+Now sandwiched: `(n^2-1)/4 <= T(n) <= n^2/4`, T(n) ~ n^2/4 immediate.
+7 thm/1 def, 0 sorry/0 axiom.
+
+### GOTCHA
+`div_le_iff` is GONE in this Mathlib pin (renamed; `div_le_iff0` exists). For a
+goal `x/4 <= y` just use `linarith` directly — it handles division by a numeric
+literal. Avoid the rewrite entirely.
+
+### DEPLOYER RACE GOTCHA (important)
+Mid-session the deployer rebase-merged my other PR (#31513) which reset THIS
+worktree's HEAD and silently discarded my uncommitted edits to this file.
+Lesson: in researcher-N worktrees, COMMIT each file's work promptly — an
+autonomous deployer merge on a sibling branch can `reset --hard` the worktree.
+Recovered by re-applying from the verified code on a fresh branch off new main.
+
+### Next Steps (unchanged, all hard)
+- Resolve parametric OQ: f < floor(n^2/4) when k > n^2/4 with K_4+.
+- Discharge the 2 companion axioms (egp_theorem, k4free_partition_number).

--- a/src/data/proofs/erdos-1017-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1017-oq-03/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "erdos1017oq03-ann-header",
     "proofId": "erdos-1017-oq-03",
-    "range": { "startLine": 1, "endLine": 39 },
+    "range": { "startLine": 1, "endLine": 44 },
     "type": "concept",
     "title": "The Turán Bound T(n) = ⌊n²/4⌋ as the Quarter-Square Sequence",
     "content": "Erdős Problem #1017 (Erdős–Goodman–Pósa, 1966) has extremal value T(n) = ⌊n²/4⌋ — both the worst-case number of complete subgraphs needed to edge-partition an n-vertex graph and the edge count of the balanced complete bipartite extremal graph K_{⌊n/2⌋,⌈n/2⌉}. The companion file gives T's product form and non-strict monotonicity; this sibling supplies the explicit even/odd closed forms, exact increment, strict growth, and real envelope. turanBound n := n²/4 is re-declared so the file is self-contained (the parent's two axioms are not imported). T(n) is the quarter-square sequence 0,0,1,2,4,6,9,12,… central to extremal graph theory.",
@@ -22,7 +22,7 @@
   {
     "id": "erdos1017oq03-ann-closedforms",
     "proofId": "erdos-1017-oq-03",
-    "range": { "startLine": 41, "endLine": 51 },
+    "range": { "startLine": 43, "endLine": 57 },
     "type": "theorem",
     "title": "Parity-Split Closed Forms",
     "content": "turanBound_two_mul: T(2m) = m², proved by (2m)² = 4m² and exact division Nat.mul_div_cancel_left. turanBound_two_mul_add_one: T(2m+1) = m(m+1), proved by (2m+1)² = 4·m(m+1) + 1 (remainder 1 < 4) and omega for the floor division. These are exactly the edge counts of the extremal graphs: K_{m,m} has m² edges, K_{m,m+1} has m(m+1) edges — the balanced and near-balanced complete bipartite graphs.",
@@ -42,7 +42,7 @@
   {
     "id": "erdos1017oq03-ann-increment",
     "proofId": "erdos-1017-oq-03",
-    "range": { "startLine": 53, "endLine": 67 },
+    "range": { "startLine": 59, "endLine": 74 },
     "type": "insight",
     "title": "The Exact One-Step Increment",
     "content": "turanBound_succ_diff: T(n+1) − T(n) = ⌊(n+1)/2⌋ = ⌈n/2⌉ — exactly the number of edges a new vertex adds to the balanced complete bipartite graph (it joins to the larger side). The proof splits on parity of n (Nat.even_or_odd) and reduces each case to the closed forms plus a ring identity (m(m+1) = m²+m for even n, (m+1)² = m(m+1)+(m+1) for odd n) fed to omega. This increment is the unit of 'edge surplus' the parametric Erdős #1017 question measures against.",
@@ -63,7 +63,7 @@
   {
     "id": "erdos1017oq03-ann-strictmono",
     "proofId": "erdos-1017-oq-03",
-    "range": { "startLine": 69, "endLine": 76 },
+    "range": { "startLine": 76, "endLine": 82 },
     "type": "theorem",
     "title": "Strict Monotonicity for n ≥ 1",
     "content": "turanBound_strictMono: T(n) < T(n+1) for n ≥ 1, sharpening the companion's non-strict bound. Immediate from the increment formula: ⌊(n+1)/2⌋ > 0 once n ≥ 1, so the difference is positive (omega). Strictness certifies the extremal threshold grows without plateaus, so the dense regime k > T(n) — where the open clique-partition question lives — is always nonempty.",
@@ -82,9 +82,9 @@
   {
     "id": "erdos1017oq03-ann-envelope",
     "proofId": "erdos-1017-oq-03",
-    "range": { "startLine": 78, "endLine": 107 },
+    "range": { "startLine": 84, "endLine": 92 },
     "type": "insight",
-    "title": "The Real-Valued Envelope T(n) ≤ n²/4",
+    "title": "The Upper Real-Valued Envelope T(n) ≤ n²/4",
     "content": "turanBound_le_sq_div_four: over ℝ, ⌊n²/4⌋ ≤ n²/4 — the integer floor never exceeds the exact quarter-square. Proved via Nat.cast_div_le (the cast of a floored quotient is ≤ the real quotient) and a push_cast/ring normalization. This is the bridge between the discrete extremal value and the asymptotic n²/4 that names the Turán/Mantel threshold, and the gap n²/4 − ⌊n²/4⌋ ∈ {0, 1/4} records the parity correction.",
     "mathContext": "$\\lfloor n^2/4 \\rfloor \\le n^2/4$ over $\\mathbb{R}$; the gap is $0$ (even $n$) or $1/4$ (odd $n$).",
     "significance": "supporting",
@@ -97,6 +97,27 @@
     "prerequisites": [
       "casting ℕ to ℝ",
       "floor division bound"
+    ]
+  },
+  {
+    "id": "erdos1017oq03-ann-sandwich",
+    "proofId": "erdos-1017-oq-03",
+    "range": { "startLine": 94, "endLine": 121 },
+    "type": "theorem",
+    "title": "Exact Parity Identity and the Two-Sided Sandwich",
+    "content": "turanBound_four_mul: the exact integer identity 4·T(n) = n² − (n mod 2), equivalently n² mod 4 = n mod 2 — the floor ⌊n²/4⌋ discards exactly the parity bit (nothing for even n, one unit for odd n). Proved by a parity case-split ((m+m)² = 4m², (2m+1)² = 4(m²+m)+1) for n² mod 4 = n mod 2, then Nat.div_add_mod + omega. turanBound_ge_sq_sub_one_div_four: the matching lower real envelope (n²−1)/4 ≤ T(n), obtained by casting the integer bound n² ≤ 4·T(n)+1 (from n² mod 4 ≤ 1) to ℝ and closing with linarith. Together with the upper envelope this sandwiches T(n) as (n²−1)/4 ≤ T(n) ≤ n²/4 — tight on alternating parities, and an immediate proof that T(n) ∼ n²/4.",
+    "mathContext": "$4T(n) = n^2 - (n \\bmod 2);\\quad \\frac{n^2-1}{4} \\le T(n) \\le \\frac{n^2}{4}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "exact floor identity",
+      "two-sided envelope",
+      "quarter-square asymptotics",
+      "Nat.div_add_mod"
+    ],
+    "prerequisites": [
+      "parity case-split",
+      "Nat.div_add_mod",
+      "casting ℕ to ℝ"
     ]
   }
 ]

--- a/src/data/proofs/erdos-1017-oq-03/meta.json
+++ b/src/data/proofs/erdos-1017-oq-03/meta.json
@@ -8,14 +8,14 @@
     ],
     "opens": [],
     "namespace": "Erdos1017OQ03",
-    "lineCount": 107,
+    "lineCount": 145,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 1,
     "path": "Proofs/Erdos1017OQ03.lean",
     "sorries": 0
   },
-  "description": "Supplies the explicit parity-split closed forms and strict growth of the Turán extremal bound T(n) = floor(n^2/4) underlying Erdős Problem #1017 (clique partition of dense graphs: f(n,k) = min complete subgraphs to edge-partition an n-vertex k-edge graph, with the Erdős-Goodman-Pósa bound f <= floor(n^2/4) and extremal complete bipartite graph). The companion file Erdos1017OQ01.lean records the product form T(n) = floor(n/2)(n - floor(n/2)) and non-strict monotonicity; this sibling adds: T(2m) = m^2 (K_{m,m} has m^2 edges), T(2m+1) = m(m+1) (K_{m,m+1} has m(m+1) edges), the exact one-step increment T(n+1) - T(n) = floor((n+1)/2), STRICT monotonicity T(n) < T(n+1) for n >= 1, and the real envelope T(n) <= n^2/4. Self-contained (re-declares T, depends only on Mathlib). 5 theorems, 1 definition, 0 sorries, 0 axioms.",
+  "description": "Supplies the explicit parity-split closed forms, strict growth, and two-sided real envelope of the Turán extremal bound T(n) = floor(n^2/4) underlying Erdős Problem #1017 (clique partition of dense graphs: f(n,k) = min complete subgraphs to edge-partition an n-vertex k-edge graph, with the Erdős-Goodman-Pósa bound f <= floor(n^2/4) and extremal complete bipartite graph). The companion file Erdos1017OQ01.lean records the product form T(n) = floor(n/2)(n - floor(n/2)) and non-strict monotonicity; this sibling adds: T(2m) = m^2 (K_{m,m} has m^2 edges), T(2m+1) = m(m+1) (K_{m,m+1} has m(m+1) edges), the exact one-step increment T(n+1) - T(n) = floor((n+1)/2), STRICT monotonicity T(n) < T(n+1) for n >= 1, the upper real envelope T(n) <= n^2/4, the exact integer identity 4*T(n) = n^2 - (n mod 2) (equivalently n^2 mod 4 = n mod 2), and the matching lower real envelope (n^2 - 1)/4 <= T(n) — together sandwiching T(n) as (n^2 - 1)/4 <= T(n) <= n^2/4, pinning it within 1/4 of the exact quarter-square. Self-contained (re-declares T, depends only on Mathlib). 7 theorems, 1 definition, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "date": "formalized 2026",
@@ -33,27 +33,30 @@
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,
-    "assumptions": "Machine-checked: `./proofs/scripts/docker-build.sh Proofs.Erdos1017OQ03` builds green (Lean v4.26.0, Mathlib pin, 7743 jobs). 0 sorries, 0 axiom declarations, no native_decide; only the standard foundational axioms via Mathlib. Self-contained: the Turán bound T(n) = n^2/4 is re-declared (the companion Erdos1017OQ01.lean carries 2 axioms egp_theorem and k4free_partition_number, which are not imported or used here). Honest scope: elementary closed-form and monotonicity arithmetic of the extremal bound, not the open clique-partition question itself.",
-    "lineCount": 107,
-    "theoremCount": 5,
+    "assumptions": "Machine-checked: `./proofs/scripts/docker-build.sh Proofs.Erdos1017OQ03` builds green (Lean v4.26.0, Mathlib pin, 7743 jobs). 0 sorries, 0 axiom declarations, no native_decide; only the standard foundational axioms via Mathlib. Self-contained: the Turán bound T(n) = n^2/4 is re-declared (the companion Erdos1017OQ01.lean carries 2 axioms egp_theorem and k4free_partition_number, which are not imported or used here). Honest scope: elementary closed-form, monotonicity, and envelope arithmetic of the extremal bound, not the open clique-partition question itself.",
+    "lineCount": 145,
+    "theoremCount": 7,
     "definitionCount": 1,
     "originalContributions": [
       "turanBound_two_mul: even closed form T(2m) = m^2 (the extremal K_{m,m} has m^2 edges)",
       "turanBound_two_mul_add_one: odd closed form T(2m+1) = m(m+1) (the extremal K_{m,m+1} has m(m+1) edges)",
       "turanBound_succ_diff: the exact one-step increment T(n+1) - T(n) = floor((n+1)/2)",
       "turanBound_strictMono: STRICT monotonicity T(n) < T(n+1) for n >= 1, sharpening the companion's non-strict bound",
-      "turanBound_le_sq_div_four: the real-valued envelope T(n) <= n^2/4 (the floor never exceeds the exact quarter-square)"
+      "turanBound_le_sq_div_four: the upper real-valued envelope T(n) <= n^2/4 (the floor never exceeds the exact quarter-square)",
+      "turanBound_four_mul: the exact integer identity 4*T(n) = n^2 - (n mod 2), i.e. n^2 mod 4 = n mod 2 — the floor discards exactly the parity bit",
+      "turanBound_ge_sq_sub_one_div_four: the lower real envelope (n^2 - 1)/4 <= T(n), which together with the upper envelope sandwiches T(n) within 1/4 of n^2/4 and yields T(n) ~ n^2/4"
     ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #1017 (Erdős-Goodman-Pósa, 1966) asks for f(n,k), the minimum number of complete subgraphs needed to edge-partition every n-vertex k-edge graph. The bound f <= floor(n^2/4) is achieved by the balanced complete bipartite (Turán) graph K_{floor(n/2),ceil(n/2)}, which is triangle-free and thus needs each of its floor(n^2/4) edges as a separate clique. The open question is whether f < floor(n^2/4) is possible once k > n^2/4 and large cliques (K_4 or bigger) are present; the K_4-free case is resolved by Gyori-Keszegh (2017). The Turán quantity floor(n^2/4) is the quarter-square sequence, central to extremal graph theory.",
     "problemStatement": "The extremal bound governing Erdős #1017 is T(n) = floor(n^2/4). The companion file gives its product form and monotonicity; this entry supplies its explicit even/odd closed forms, exact increment, strict growth, and real envelope.",
-    "proofStrategy": "For the closed forms, expand the square: (2m)^2 = 4m^2 so T(2m) = m^2 by exact division, and (2m+1)^2 = 4(m(m+1)) + 1 so T(2m+1) = m(m+1) by floor division (remainder 1 < 4), discharged by omega after a ring rewrite. The increment splits on parity of n via Nat.even_or_odd, reducing each case to the closed forms plus a ring identity (m(m+1) = m^2 + m, (m+1)^2 = m(m+1) + (m+1)) fed to omega. Strict monotonicity follows since the increment floor((n+1)/2) is positive for n >= 1. The real envelope is Nat.cast_div_le.",
+    "proofStrategy": "For the closed forms, expand the square: (2m)^2 = 4m^2 so T(2m) = m^2 by exact division, and (2m+1)^2 = 4(m(m+1)) + 1 so T(2m+1) = m(m+1) by floor division (remainder 1 < 4), discharged by omega after a ring rewrite. The increment splits on parity of n via Nat.even_or_odd, reducing each case to the closed forms plus a ring identity (m(m+1) = m^2 + m, (m+1)^2 = m(m+1) + (m+1)) fed to omega. Strict monotonicity follows since the increment floor((n+1)/2) is positive for n >= 1. The upper envelope is Nat.cast_div_le. For the parity identity, a case-split shows n^2 mod 4 = n mod 2 (even: (m+m)^2 = 4m^2; odd: (2m+1)^2 = 4(m^2+m)+1), then Nat.div_add_mod + omega give 4*T(n) = n^2 - (n mod 2); the lower envelope casts the integer bound n^2 <= 4*T(n) + 1 to R (via n^2 mod 4 <= 1) and closes by linarith.",
     "keyInsights": [
       "The Turán bound is the quarter-square sequence, with clean parity-split forms m^2 (even) and m(m+1) (odd) — exactly the edge counts of the balanced and near-balanced complete bipartite extremal graphs.",
       "The one-step increment T(n+1) - T(n) = floor((n+1)/2) = ceil(n/2) is the number of edges a new vertex adds to the balanced complete bipartite graph.",
       "That increment is the exact unit of 'edge surplus' the parametric question measures against: each edge above T(n) is what a K_4-or-larger clique might convert into a partition saving.",
-      "Strict monotonicity for n >= 1 guarantees the extremal threshold grows without plateaus, so the dense regime k > T(n) is always nonempty."
+      "Strict monotonicity for n >= 1 guarantees the extremal threshold grows without plateaus, so the dense regime k > T(n) is always nonempty.",
+      "The floor loses exactly the parity bit: 4*T(n) = n^2 - (n mod 2), so T(n) = n^2/4 exactly for even n and (n^2-1)/4 for odd n. The two-sided envelope (n^2-1)/4 <= T(n) <= n^2/4 is tight on alternating parities and makes T(n) ~ n^2/4 immediate."
     ]
   },
   "sections": [
@@ -61,22 +64,30 @@
       "id": "closed-forms",
       "title": "Even/Odd Closed Forms",
       "summary": "turanBound_two_mul (T(2m) = m^2) and turanBound_two_mul_add_one (T(2m+1) = m(m+1)).",
-      "startLine": 1,
-      "endLine": 55,
+      "startLine": 43,
+      "endLine": 57,
       "mathContext": "Expand the square and divide: (2m)^2/4 = m^2 exactly; (2m+1)^2/4 = (4 m(m+1)+1)/4 = m(m+1) by floor."
     },
     {
       "id": "growth",
-      "title": "Increment, Strict Growth, and Real Envelope",
+      "title": "Increment, Strict Growth, and Upper Envelope",
       "summary": "turanBound_succ_diff (increment floor((n+1)/2)), turanBound_strictMono (strict for n >= 1), turanBound_le_sq_div_four (T(n) <= n^2/4 over R).",
-      "startLine": 56,
-      "endLine": 107,
-      "mathContext": "Parity case-split for the increment; positivity of the increment for strict monotonicity; Nat.cast_div_le for the real bound."
+      "startLine": 59,
+      "endLine": 92,
+      "mathContext": "Parity case-split for the increment; positivity of the increment for strict monotonicity; Nat.cast_div_le for the real upper bound."
+    },
+    {
+      "id": "envelope",
+      "title": "Exact Parity Identity and Lower Envelope (the Sandwich)",
+      "summary": "turanBound_four_mul (4*T(n) = n^2 - (n mod 2), i.e. n^2 mod 4 = n mod 2) and turanBound_ge_sq_sub_one_div_four ((n^2-1)/4 <= T(n)), which with the upper envelope sandwiches T(n) as (n^2-1)/4 <= T(n) <= n^2/4.",
+      "startLine": 94,
+      "endLine": 121,
+      "mathContext": "Parity case-split gives n^2 mod 4 = n mod 2; Nat.div_add_mod + omega give the identity; casting n^2 <= 4*T(n)+1 to R and linarith give the lower envelope."
     }
   ],
   "conclusion": {
-    "summary": "The extremal Turán bound T(n) = floor(n^2/4) of the Erdős-Goodman-Pósa clique-partition theorem is given explicit parity-split closed forms T(2m) = m^2 and T(2m+1) = m(m+1) — the edge counts of the balanced and near-balanced complete bipartite extremal graphs — together with the exact increment floor((n+1)/2), strict monotonicity for n >= 1, and the real envelope T(n) <= n^2/4. Self-contained over Mathlib, complementing the companion file's product form and non-strict monotonicity.",
-    "implications": "The closed forms and increment make the extremal arithmetic of Erdős #1017 fully explicit, expressing the threshold against which the open question (can f < T(n) once k > T(n)?) is posed: each unit of edge surplus above T(n) is a candidate saving for a large clique. Strict monotonicity certifies the dense regime is always nonempty. The quarter-square closed forms are reusable across extremal graph theory (Turán/Mantel and complete-bipartite edge counts).",
+    "summary": "The extremal Turán bound T(n) = floor(n^2/4) of the Erdős-Goodman-Pósa clique-partition theorem is given explicit parity-split closed forms T(2m) = m^2 and T(2m+1) = m(m+1) — the edge counts of the balanced and near-balanced complete bipartite extremal graphs — together with the exact increment floor((n+1)/2), strict monotonicity for n >= 1, the exact integer identity 4*T(n) = n^2 - (n mod 2), and the two-sided real envelope (n^2-1)/4 <= T(n) <= n^2/4. Self-contained over Mathlib, complementing the companion file's product form and non-strict monotonicity.",
+    "implications": "The closed forms, increment, and two-sided envelope make the extremal arithmetic of Erdős #1017 fully explicit, expressing the threshold against which the open question (can f < T(n) once k > T(n)?) is posed: each unit of edge surplus above T(n) is a candidate saving for a large clique. The sandwich (n^2-1)/4 <= T(n) <= n^2/4 pins T(n) within 1/4 of the quarter-square (tight on alternating parities), giving T(n) ~ n^2/4. Strict monotonicity certifies the dense regime is always nonempty. The quarter-square closed forms and envelope are reusable across extremal graph theory (Turán/Mantel and complete-bipartite edge counts).",
     "openQuestions": [
       "Resolve the parametric Erdős #1017 question: can f(n,k) < floor(n^2/4) when k > n^2/4 and the graph contains K_4 or larger cliques?",
       "Discharge the companion file's two axioms (egp_theorem, the Gyori-Keszegh k4free_partition_number) to make the clique-partition bounds fully proved.",

--- a/src/data/research/problems/erdos-1017-oq-03.json
+++ b/src/data/research/problems/erdos-1017-oq-03.json
@@ -11,18 +11,21 @@
     "whyMatters": []
   },
   "knowledge": {
-    "progressSummary": "Supplied explicit parity-split closed forms + strict growth of the Turán extremal bound T(n)=floor(n^2/4) of Erdős #1017 (clique partition of dense graphs). Companion Erdos1017OQ01.lean has product form + non-strict mono; added T(2m)=m^2, T(2m+1)=m(m+1) (extremal K_{m,m}/K_{m,m+1} edge counts), increment T(n+1)-T(n)=floor((n+1)/2), STRICT T(n)<T(n+1) n>=1, real envelope T(n)<=n^2/4. Self-contained re-decl (companion has 2 axioms egp_theorem/k4free_partition_number, not used). 5 thm/1 def, 0 sorries/0 axioms, builds green 7743 jobs.",
+    "progressSummary": "Supplied explicit parity-split closed forms, strict growth, AND a two-sided real envelope for the Turán extremal bound T(n)=floor(n^2/4) of Erdős #1017 (clique partition of dense graphs). Companion Erdos1017OQ01.lean has product form + non-strict mono; this file has T(2m)=m^2, T(2m+1)=m(m+1) (extremal K_{m,m}/K_{m,m+1} edge counts), increment T(n+1)-T(n)=floor((n+1)/2), STRICT T(n)<T(n+1) n>=1, upper envelope T(n)<=n^2/4. Added 2026-06-30: exact integer identity 4*T(n)=n^2-(n mod 2) (i.e. n^2 mod 4 = n mod 2) and the matching LOWER real envelope (n^2-1)/4 <= T(n), so T is now sandwiched (n^2-1)/4 <= T(n) <= n^2/4 — pinning T within 1/4 of the quarter-square and giving T(n)~n^2/4 immediately. Self-contained re-decl (companion has 2 axioms egp_theorem/k4free_partition_number, not used). 7 thm/1 def, 0 sorries/0 axioms, builds green 7743 jobs.",
     "builtItems": [
       "turanBound_two_mul: T(2m)=m^2",
       "turanBound_two_mul_add_one: T(2m+1)=m(m+1)",
       "turanBound_succ_diff: T(n+1)-T(n)=floor((n+1)/2)",
       "turanBound_strictMono: T(n)<T(n+1) n>=1",
-      "turanBound_le_sq_div_four: T(n)<=n^2/4 over R"
+      "turanBound_le_sq_div_four: T(n)<=n^2/4 over R",
+      "turanBound_four_mul (NEW): 4*T(n)=n^2-(n mod 2), exact integer identity (n^2 mod 4 = n mod 2)",
+      "turanBound_ge_sq_sub_one_div_four (NEW): (n^2-1)/4 <= T(n) over R, the lower envelope completing the sandwich (n^2-1)/4 <= T(n) <= n^2/4"
     ],
     "insights": [
       "Turán bound = quarter-square sequence with parity forms m^2 (even) / m(m+1) (odd) = balanced/near-balanced complete bipartite edge counts.",
       "Increment floor((n+1)/2)=ceil(n/2) = edges a new vertex adds to the balanced bipartite graph; the unit of edge surplus the OQ measures.",
-      "Strict monotonicity n>=1 => dense regime k>T(n) always nonempty, no plateaus."
+      "Strict monotonicity n>=1 => dense regime k>T(n) always nonempty, no plateaus.",
+      "The floor loses exactly the parity bit: 4*T(n)=n^2-(n mod 2), so T(n)=n^2/4 exactly for even n and (n^2-1)/4 for odd n — the two-sided envelope (n^2-1)/4 <= T(n) <= n^2/4 is tight on alternating parities and gives T(n)~n^2/4."
     ],
     "mathlibGaps": [
       "Companion has 2 axioms: egp_theorem (Erdős-Goodman-Pósa), k4free_partition_number (Gyori-Keszegh 2017)."
@@ -66,8 +69,8 @@
     {
       "path": "Proofs/Erdos1017OQ03.lean",
       "filename": "Erdos1017OQ03.lean",
-      "lineCount": 108,
-      "theoremCount": 5,
+      "lineCount": 145,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Two arithmetic facts about the Turán extremal bound $T(n) = \lfloor n^2/4 \rfloor$ (the governing quantity of Erdős Problem #1017, clique-partition of dense graphs). They complete the file's analytic content into a **tight two-sided sandwich**:

- **`turanBound_four_mul`** — the exact integer identity $4\,T(n) = n^2 - (n \bmod 2)$, equivalently $n^2 \bmod 4 = n \bmod 2$. The floor $\lfloor n^2/4\rfloor$ discards exactly the parity bit: nothing for even $n$, one unit for odd $n$.
- **`turanBound_ge_sq_sub_one_div_four`** — the matching **lower** real envelope $(n^2-1)/4 \le T(n)$. Together with the existing upper envelope `turanBound_le_sq_div_four` ($T(n) \le n^2/4$), this sandwiches the bound:

$$\frac{n^2-1}{4} \;\le\; T(n) \;\le\; \frac{n^2}{4},$$

tight on alternating parities (equality on the right for even $n$, on the left for odd $n$), and an immediate proof that $T(n) \sim n^2/4$.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1017OQ03` builds **green** (Lean v4.26.0, Mathlib pin).
- `#print axioms` of both new theorems = `[propext, Classical.choice, Quot.sound]` only — **0-axiom**, no `sorry`, no `native_decide`.

## Scope (honest)

These are elementary closed-form/envelope facts about the extremal *value*, not progress on the open clique-partition question $f(n,k) < \lfloor n^2/4\rfloor$ itself. They round out the self-contained `Erdos1017OQ03` helper alongside its closed forms, increment, and strict-monotonicity lemmas. Gallery `meta.json`/`annotations.json` and the research record updated (5→7 theorems, 107→145 lines; +1 section, +1 annotation, realigned ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)