### PR TITLE
research(area-of-circle-oq-03-oq-02-oq-01): explicit O(1/m²) convergence rate for Archimedes doubling [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ03OQ02OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ03OQ02OQ01.lean
@@ -202,7 +202,60 @@ theorem halfPerimeter_tendsto_pi :
     exact le_of_lt (halfPerimeter_lt_pi hm)
 
 -- ============================================================
--- PART V: Summary
+-- PART V: Explicit convergence rate (quadratic in 1/m)
+-- ============================================================
+
+/-- **Explicit `O(1/m²)` convergence rate of the doubling method.**  The inscribed
+half-perimeter approximates π with error at most quadratic in `1/m`:
+`π - p(m) ≤ (7/32)·π³/m²` for every `m ≥ 4`.
+
+Proof: with `x = π/m ≤ 1`, Mathlib's Taylor estimate `Real.sin_bound` gives
+`sin x ≥ x - x³/6 - (5/96)x⁴`; absorbing `x⁴ ≤ x³` (valid since `x ≤ 1`) into the cubic
+term yields `sin x ≥ x - (7/32)x³` (note `1/6 + 5/96 = 7/32`).  Multiplying by `m` and
+using `m·x = π`, `m·x³ = π³/m²` gives `p(m) = m·sin x ≥ π - (7/32)π³/m²`.
+
+Since the doubling iteration runs over `m = 6·2ᵏ` (or any `m = c·2ᵏ`), this is exactly the
+`π - p(2ᵏ) = O(4⁻ᵏ)` rate of the second open question: each doubling quarters the error
+bound. -/
+theorem pi_sub_halfPerimeter_le {m : ℕ} (hm : 4 ≤ m) :
+    Real.pi - halfPerimeter m ≤ 7 / 32 * Real.pi ^ 3 / (m : ℝ) ^ 2 := by
+  have hπ := Real.pi_pos
+  have hm' : (4 : ℝ) ≤ (m : ℝ) := by exact_mod_cast hm
+  have hmpos : (0 : ℝ) < (m : ℝ) := by linarith
+  set x := Real.pi / (m : ℝ) with hx
+  have hxpos : 0 < x := by rw [hx]; positivity
+  have hπlt : Real.pi < 4 := Real.pi_lt_four
+  have hx1 : x ≤ 1 := by rw [hx, div_le_one hmpos]; linarith
+  -- Taylor lower bound on sin from Real.sin_bound
+  have hbound := Real.sin_bound (x := x) (by rw [abs_of_pos hxpos]; exact hx1)
+  rw [abs_of_pos hxpos] at hbound
+  have hlow : x - x ^ 3 / 6 - x ^ 4 * (5 / 96) ≤ Real.sin x := by
+    have := (abs_le.mp hbound).1; linarith
+  have hx43 : x ^ 4 ≤ x ^ 3 := by
+    calc x ^ 4 = x ^ 3 * x := by ring
+      _ ≤ x ^ 3 * 1 := mul_le_mul_of_nonneg_left hx1 (pow_nonneg hxpos.le 3)
+      _ = x ^ 3 := by ring
+  have hsin : x - 7 / 32 * x ^ 3 ≤ Real.sin x := by nlinarith [hlow, hx43]
+  -- clear the m-scaling: m·x = π and m·x³ = π³/m²
+  have hmx : (m : ℝ) * x = Real.pi := by rw [hx]; field_simp
+  have hmx3 : (m : ℝ) * x ^ 3 = Real.pi ^ 3 / (m : ℝ) ^ 2 := by
+    rw [hx]; field_simp
+  have hstep : (m : ℝ) * Real.sin x ≥ Real.pi - 7 / 32 * (Real.pi ^ 3 / (m : ℝ) ^ 2) := by
+    have h1 : (m : ℝ) * (x - 7 / 32 * x ^ 3) ≤ (m : ℝ) * Real.sin x :=
+      mul_le_mul_of_nonneg_left hsin hmpos.le
+    have h2 : (m : ℝ) * (x - 7 / 32 * x ^ 3)
+        = Real.pi - 7 / 32 * (Real.pi ^ 3 / (m : ℝ) ^ 2) := by
+      rw [mul_sub, hmx, show (m : ℝ) * (7 / 32 * x ^ 3) = 7 / 32 * ((m : ℝ) * x ^ 3) by ring,
+        hmx3]
+    linarith [h1, h2 ▸ h1]
+  have hgoal_rw : (7 : ℝ) / 32 * Real.pi ^ 3 / (m : ℝ) ^ 2
+      = 7 / 32 * (Real.pi ^ 3 / (m : ℝ) ^ 2) := by ring
+  simp only [halfPerimeter]
+  rw [← hx, hgoal_rw]
+  linarith [hstep]
+
+-- ============================================================
+-- PART VI: Summary
 -- ============================================================
 
 /-- **Summary.** Archimedes' half-angle doubling method, formalized constructively:

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "area-of-circle-oq-03-oq-02-oq-01",
   "title": "Archimedes' Half-Angle Doubling Method: Constructive Formalization",
   "slug": "area-of-circle-oq-03-oq-02-oq-01",
-  "description": "A constructive formalization of Archimedes' half-angle polygon-doubling method for computing π. The doubling identity sin(π/(2n)) = √((1−cos(π/n))/2) is derived, the inscribed half-perimeters m·sin(π/m) are shown to increase strictly under doubling while staying below π, and the sequence is proved to converge to π. Fully verified: 0 sorries, 0 axioms.",
+  "description": "A constructive formalization of Archimedes' half-angle polygon-doubling method for computing π. The doubling identity sin(π/(2n)) = √((1−cos(π/n))/2) is derived, the inscribed half-perimeters m·sin(π/m) are shown to increase strictly under doubling while staying below π, and the sequence is proved to converge to π. An explicit O(1/m²) convergence rate π − p(m) ≤ (7/32)·π³/m² is also proved (m ≥ 4), quantifying how fast doubling approaches π. Fully verified: 0 sorries, 0 axioms.",
   "meta": {
     "author": "Archimedes (c. 250 BCE), formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Approximations_of_%CF%80#Archimedes",
@@ -59,14 +59,15 @@
       "Nested-radical realization: p(2^(n+2)) = 2^(n+1)·√(2 − sqrtTwoAddSeries 0 n), a computable closed form (fully proved)",
       "Strict monotonicity under doubling: p(n) < p(2n) for all n ≥ 1 (fully proved)",
       "Upper bound: p(m) < π for all m ≥ 1 (fully proved)",
-      "Convergence: p(m) → π as m → ∞, by squeezing π·cos(π/m) ≤ p(m) < π (fully proved)"
+      "Convergence: p(m) → π as m → ∞, by squeezing π·cos(π/m) ≤ p(m) < π (fully proved)",
+      "Explicit convergence rate: π − p(m) ≤ (7/32)·π³/m² for m ≥ 4 (quadratic in 1/m), proved from the sin Taylor estimate Real.sin_bound by absorbing the quartic remainder into the cubic term — gives π − p(2ᵏ) = O(4⁻ᵏ) (fully proved)"
     ],
     "dateAdded": "2026-06-28",
     "axiomCount": 0,
     "assumptions": "Fully verified: 0 axioms, 0 sorries remain.",
-    "lineCount": 223,
+    "lineCount": 276,
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 1
   },
   "overview": {
@@ -129,11 +130,19 @@
       "mathContext": "Monotonicity: $p(n) = p(2n)\\cos(\\pi/2n) < p(2n)$ since $\\cos < 1$. Upper bound: $p(m) < \\pi$ from $\\sin x < x$. Convergence: $\\pi\\cos(\\pi/m) \\le p(m) < \\pi$ and $\\cos(\\pi/m) \\to 1$, so by the squeeze theorem $p(m) \\to \\pi$ — the method of exhaustion."
     },
     {
+      "id": "convergence-rate",
+      "title": "Explicit Convergence Rate",
+      "summary": "pi_sub_halfPerimeter_le: π − p(m) ≤ (7/32)·π³/m² for m ≥ 4, an explicit O(1/m²) error bound. Proved from Real.sin_bound (sin x ≥ x − x³/6 − (5/96)x⁴) by absorbing x⁴ ≤ x³ into the cubic term, then scaling by m.",
+      "startLine": 205,
+      "endLine": 257,
+      "mathContext": "With $x=\\pi/m\\le 1$, the Taylor estimate gives $\\sin x \\ge x - \\tfrac{7}{32}x^3$ (since $\\tfrac16+\\tfrac{5}{96}=\\tfrac{7}{32}$). Multiplying by $m$ and using $mx=\\pi$, $mx^3=\\pi^3/m^2$ yields $p(m)\\ge \\pi-\\tfrac{7}{32}\\pi^3/m^2$, i.e. the doubling error is $O(4^{-k})$ for $m=c\\,2^k$."
+    },
+    {
       "id": "summary",
       "title": "Summary Theorem",
       "summary": "Packaging theorem bundling the doubling identity, hexagon seed, monotonicity, upper bound, and convergence into one statement.",
-      "startLine": 205,
-      "endLine": 223,
+      "startLine": 258,
+      "endLine": 276,
       "mathContext": "The bundled result asserts the doubling radical holds for all $n \\ge 1$, $p(6) = 3$, $p(n) < p(2n)$, $p(m) < \\pi$, and $p(m) \\to \\pi$ — Archimedes' method, formalized end to end."
     }
   ],
@@ -142,7 +151,7 @@
     "implications": "Where the parent entry verified Archimedes' final numbers from Mathlib's precomputed π bounds, this entry formalizes the algorithm that generates them and proves its convergence — making the 2,300-year-old method of exhaustion a fully machine-checked, constructive computation of π.",
     "openQuestions": [
       "Can Archimedes' rational square-root bounds (how he approximated √3 and the nested radicals by hand) be formalized to recover his exact 223/71 bound purely from the doubling recurrence, without invoking Mathlib's pi_gt_d4?",
-      "Can an explicit rate of convergence be proved, e.g. π − p(2^k) = O(4^{-k}), quantifying how fast polygon doubling approaches π?"
+      "Sharpen the convergence-rate constant: the proved bound π − p(m) ≤ (7/32)·π³/m² is not tight (the true leading term is π³/(6m²)); can the (7/32) factor be reduced to 1/6 + o(1), matching the exact second-order Taylor coefficient?"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

This entry formalizes Archimedes' half-angle polygon-doubling method and proves the inscribed half-perimeters `p(m) = m·sin(π/m)` converge to π. Its **second open question** asked for an *explicit rate*: `π − p(2ᵏ) = O(4⁻ᵏ)`. This PR proves it:

```lean
theorem pi_sub_halfPerimeter_le {m : ℕ} (hm : 4 ≤ m) :
    Real.pi - halfPerimeter m ≤ 7 / 32 * Real.pi ^ 3 / (m : ℝ) ^ 2
```

i.e. `π − p(m) ≤ (7/32)·π³/m²` — an explicit quadratic-in-`1/m` error bound.

## Proof

With `x = π/m ≤ 1` (since `m ≥ 4 > π`):

1. Mathlib's Taylor estimate `Real.sin_bound` gives `|sin x − (x − x³/6)| ≤ (5/96)|x|⁴`, hence `sin x ≥ x − x³/6 − (5/96)x⁴`.
2. Absorb the quartic: `x⁴ ≤ x³` for `x ≤ 1`, so `sin x ≥ x − x³/6 − (5/96)x³ = x − (7/32)x³` (using `1/6 + 5/96 = 7/32`).
3. Scale by `m`: `p(m) = m·sin x ≥ m·x − (7/32)·m·x³ = π − (7/32)·π³/m²`, using `m·x = π` and `m·x³ = π³/m²`.

For the doubling iteration `m = c·2ᵏ`, the bound `(7/32)π³/m² = (7π³/32c²)·4⁻ᵏ` is exactly the **O(4⁻ᵏ)** rate — each doubling quarters the error bound.

## Verification

`./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ03OQ02OQ01` → **Build succeeded** (Mathlib 4.26).
- **9 theorems, 0 sorries, 0 axioms** (status `verified` preserved).

`meta.json` updated: `theoremCount` 8→9, `lineCount` 223→276, new "Explicit Convergence Rate" section, second open question resolved (replaced with a sharper follow-up on tightening the constant `7/32 → 1/6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)