### PR TITLE
research(ballot-problem-oq-04-oq-02-oq-01): prove counting half of Catalan recurrence; isolate open content to first-return bijection

### DIFF
--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -29,24 +29,30 @@ So `nonCrossingCount = catalan` follows by strong induction the moment we know
   `nonCrossingCount (n+1) = ∑ (i,j) ∈ antidiagonal n, nonCrossingCount i * nonCrossingCount j`.
   This is the genuine combinatorial content — the classical Catalan decomposition of a
   non-crossing partition of `{0,…,n}` according to the block structure around a distinguished
-  point — and is **not** in Mathlib in any form. It remains a `sorry` here (HARD,
-  bijection-level formalization; see `## Status` below).
+  point. It is split here into its *counting* and *combinatorial* halves (see below): the
+  counting half is proved, and the combinatorial half — a first-return **bijection** — is the
+  sole remaining `sorry`. The decomposition is **not** in Mathlib in any form.
 
-Given those two, `nonCrossingCount_eq_catalan` is a four-line strong induction matching the
-`antidiagonal` shape of `catalan_succ'`. The point of this file is that it isolates the
-*entire* difficulty of `nonCrossing = Catalan` into the one recurrence lemma: a reduction in
-the spirit of "one structural theorem in place of an explicit bijection".
+Given the base case and recurrence, `nonCrossingCount_eq_catalan` is a four-line strong
+induction matching the `antidiagonal` shape of `catalan_succ'`. The point of this file is that
+it isolates the *entire* difficulty of `nonCrossing = Catalan` into one explicit bijection: a
+reduction in the spirit of "one structural theorem in place of an explicit bijection".
 
 ## Status
 
-**Sorry count**: 1 (`nonCrossingCount_recurrence`). **Axiom count**: 0 literal `axiom`
-declarations; the reduction and base case use only the foundational
-`propext`/`Classical.choice`/`Quot.sound`. Because a `sorry` remains, the gallery status of
-this entry is `formalized`, not `verified`.
+**Sorry count**: 1 (`nonempty_firstReturnEquiv` — the first-return bijection). The numeric
+recurrence `nonCrossingCount_recurrence` and its counting reduction
+`nonCrossingCount_recurrence_of_equiv` are now **proved (0 `sorry`)**; the open content is
+exactly the existence of the bijection, with all cardinality arithmetic discharged.
 
-The outstanding recurrence is the natural target for proof search: it is *known* mathematics
-(the non-crossing-partition Catalan recurrence) requiring a delicate but standard
-decomposition, exactly the regime where automated formalization is appropriate.
+**Axiom count**: 0 literal `axiom` declarations; the proved results use only the foundational
+`propext`/`Classical.choice`/`Quot.sound` (the latter via `.some` on the bijection's
+`Nonempty`). Because a `sorry` remains, the gallery status of this entry is `formalized`, not
+`verified`.
+
+The outstanding bijection is the natural target for proof search: it is *known* mathematics
+(the non-crossing-partition Catalan decomposition) requiring a delicate but standard
+construction, exactly the regime where automated formalization is appropriate.
 -/
 
 import Mathlib
@@ -71,21 +77,69 @@ theorem nonCrossingCount_zero : nonCrossingCount 0 = 1 := by
   simp only [hbot]
   exact Fintype.card_unique
 
-/-! ## The combinatorial recurrence (HARD — outstanding `sorry`) -/
+/-! ## The combinatorial recurrence (HARD)
 
-/-- **Catalan recurrence for non-crossing partitions.** The non-crossing partitions of
-`Fin (n+1)` split — according to the classical "first return" / block decomposition of a
-non-crossing partition of a linearly ordered set — into pairs of independent non-crossing
-partitions whose sizes `(i, j)` run over `antidiagonal n`. Equivalently:
-`nonCrossingCount (n+1) = ∑ (i,j) ∈ antidiagonal n, nonCrossingCount i * nonCrossingCount j`.
+The recurrence is now split into two parts that separate its *counting* content from its
+*combinatorial* content:
 
-This is the same convolution that defines `catalan` (`catalan_succ'`); proving it for
-`nonCrossingCount` is the entire combinatorial content of `nonCrossing = Catalan`, and is not
-available in Mathlib. **Outstanding `sorry`** (HARD, bijection-level). -/
-theorem nonCrossingCount_recurrence (n : ℕ) :
+* `nonempty_firstReturnEquiv` — the genuine, still-open obligation: the existence of a
+  first-return bijection that decomposes a non-crossing partition of `Fin (n+1)` into a pair of
+  independent non-crossing partitions of sizes `(i, j) ∈ antidiagonal n`. This is the entire
+  combinatorial heart and the **sole outstanding `sorry`**.
+* `nonCrossingCount_recurrence_of_equiv` — the counting half, **proved here (0 `sorry`)**: any
+  such bijection already forces the Catalan convolution, by a pure cardinality computation
+  (`Fintype.card_congr` ∘ `card_sigma` ∘ `card_prod`).
+
+`nonCrossingCount_recurrence` is then a corollary of the two. -/
+
+/-- **First-return bijection (the sole open obligation).** A non-crossing partition of the
+linearly ordered set `Fin (n+1)` decomposes — via the classical "first return" of the block
+structure around a distinguished point — into an independent pair of non-crossing partitions of
+an `i`-element and a `j`-element interval, with `(i, j)` ranging over `antidiagonal n`. We
+record the decomposition as a bijection (existence suffices for the count).
+
+This is the genuine combinatorial content of `nonCrossing = Catalan`; the analogous
+decomposition is *not* available in Mathlib in any form (Mathlib has no theory of non-crossing
+partitions, nor of restricting a `Finpartition` of `Fin (n+1)` to the gaps cut out by a
+distinguished block). **Outstanding `sorry`** (HARD, bijection-level). -/
+theorem nonempty_firstReturnEquiv (n : ℕ) :
+    Nonempty ({P : Finpartition (univ : Finset (Fin (n + 1))) // IsNonCrossingFp P} ≃
+      Σ ij : (antidiagonal n : Finset (ℕ × ℕ)),
+        {P : Finpartition (univ : Finset (Fin ij.1.1)) // IsNonCrossingFp P} ×
+        {P : Finpartition (univ : Finset (Fin ij.1.2)) // IsNonCrossingFp P}) := by
+  sorry
+
+/-- **Counting half of the recurrence (proved, 0 `sorry`).** Any first-return bijection
+splitting the non-crossing partitions of `Fin (n+1)` over `antidiagonal n` already forces the
+Catalan convolution: it is a pure cardinality computation. This isolates the counting content
+of `nonCrossingCount_recurrence` from its combinatorial content (`nonempty_firstReturnEquiv`),
+and is the reusable bridge a future construction of the bijection plugs into. -/
+theorem nonCrossingCount_recurrence_of_equiv (n : ℕ)
+    (e : {P : Finpartition (univ : Finset (Fin (n + 1))) // IsNonCrossingFp P} ≃
+      Σ ij : (antidiagonal n : Finset (ℕ × ℕ)),
+        {P : Finpartition (univ : Finset (Fin ij.1.1)) // IsNonCrossingFp P} ×
+        {P : Finpartition (univ : Finset (Fin ij.1.2)) // IsNonCrossingFp P}) :
     nonCrossingCount (n + 1)
       = ∑ ij ∈ antidiagonal n, nonCrossingCount ij.1 * nonCrossingCount ij.2 := by
-  sorry
+  unfold nonCrossingCount
+  rw [Fintype.card_congr e, Fintype.card_sigma]
+  simp only [Fintype.card_prod]
+  exact Finset.sum_coe_sort (antidiagonal n)
+    (fun ij => Fintype.card {P : Finpartition (univ : Finset (Fin ij.1)) // IsNonCrossingFp P} *
+               Fintype.card {P : Finpartition (univ : Finset (Fin ij.2)) // IsNonCrossingFp P})
+
+/-- **Catalan recurrence for non-crossing partitions.** The non-crossing partitions of
+`Fin (n+1)` split into pairs of independent non-crossing partitions whose sizes `(i, j)` run
+over `antidiagonal n`:
+`nonCrossingCount (n+1) = ∑ (i,j) ∈ antidiagonal n, nonCrossingCount i * nonCrossingCount j`.
+
+This is the same convolution that defines `catalan` (`catalan_succ'`). It is now a corollary of
+the (still open) first-return bijection `nonempty_firstReturnEquiv` and the (proved) counting
+reduction `nonCrossingCount_recurrence_of_equiv`. -/
+theorem nonCrossingCount_recurrence (n : ℕ) :
+    nonCrossingCount (n + 1)
+      = ∑ ij ∈ antidiagonal n, nonCrossingCount ij.1 * nonCrossingCount ij.2 :=
+  nonCrossingCount_recurrence_of_equiv n (nonempty_firstReturnEquiv n).some
 
 /-! ## The counting theorem -/
 

--- a/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json
@@ -25,8 +25,8 @@
     "axiomCount": 0,
     "assumptions": "1 sorry: nonCrossingCount_recurrence (the combinatorial Catalan convolution recurrence for non-crossing Finpartitions; HARD, bijection-level, no Mathlib support). 0 literal `axiom` declarations. The proved parts (nonCrossingCount_zero, and the nonCrossingCount_eq_catalan reduction) depend only on the foundational axioms propext / Classical.choice / Quot.sound; no native_decide, no Lean.ofReduceBool. Because a sorry remains, this entry is `formalized`, not `verified` — the headline equality nonCrossingCount n = catalan n is proved CONDITIONAL on the outstanding recurrence.",
     "dateAdded": "2026-06-26",
-    "lineCount": 114,
-    "theoremCount": 3,
+    "lineCount": 168,
+    "theoremCount": 5,
     "definitionCount": 0,
     "mathlibDependencies": [
       {
@@ -53,6 +53,22 @@
         "theorem": "Finset.mem_antidiagonal",
         "description": "ij ∈ antidiagonal n ↔ ij.1 + ij.2 = n; used to bound both indices below n+1 so the IH applies",
         "module": "Mathlib.Algebra.BigOperators.NatAntidiagonal"
+      },
+      {
+        "theorem": "Fintype.card_congr",
+        "purpose": "transport the count along the first-return bijection"
+      },
+      {
+        "theorem": "Fintype.card_sigma",
+        "purpose": "card of the Sigma-indexed split equals the sum of fibre cards"
+      },
+      {
+        "theorem": "Fintype.card_prod",
+        "purpose": "card of each (i,j) fibre is the product of the two factor counts"
+      },
+      {
+        "theorem": "Finset.sum_coe_sort",
+        "purpose": "reindex the univ-sum over the antidiagonal subtype back to a Finset sum"
       }
     ],
     "originalContributions": [
@@ -138,12 +154,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 114,
+    "lineCount": 168,
     "path": "Proofs/BallotProblemOQ04OQ02OQ01.lean",
     "axiomCount": 0,
     "sorries": 1,
     "definitionCount": 0,
-    "theoremCount": 3
+    "theoremCount": 5
   },
   "sorries": 1
 }


### PR DESCRIPTION
## Summary

`nonCrossingCount n = catalan n` (non-crossing partitions of `Fin n` are Catalan-counted). The structural reduction was already in place; the entire remaining difficulty sat in one monolithic theorem-sorry, `nonCrossingCount_recurrence`, which conflated a routine cardinality computation with the genuine combinatorial bijection.

This PR **separates the two** and discharges the routine half:

| Declaration | Status |
|---|---|
| `nonCrossingCount_recurrence_of_equiv` | **PROVED (0 sorry)** — any first-return bijection `NC(n+1) ≃ Σ (i,j)∈antidiagonal n, NC(i)×NC(j)` forces the Catalan convolution, via `Fintype.card_congr ∘ card_sigma ∘ card_prod ∘ sum_coe_sort` |
| `nonempty_firstReturnEquiv` | **sole remaining `sorry`** — existence of that bijection (the real combinatorial content; Mathlib has no non-crossing-partition theory) |
| `nonCrossingCount_recurrence` | now a **0-sorry corollary** of the above |
| `nonCrossingCount_eq_catalan` | unchanged, still 0-sorry given the recurrence |

## Honest delta

- **Sorry count: unchanged (1).** This does *not* close the conjecture. What changed is the *shape* of the open obligation: it is now exactly "the first-return bijection exists," with **all** cardinality bookkeeping machine-checked, rather than a numeric identity that hid the bijection inside.
- **Axioms: 0** literal declarations; proved results use only the foundational `propext`/`Classical.choice`/`Quot.sound` (the last via `.some` on the `Nonempty` bijection). Status stays `formalized`, badge `wip`.
- Aristotle remains **down** this session (`prove` → 404 "Resource not found"), so the HARD bijection could not be delegated; the sharpened, self-contained target is queued for when it returns.

## Verification

Docker build clean — `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ04OQ02OQ01` → 7745 jobs, `Build succeeded`. The only `declaration uses 'sorry'` warning is `nonempty_firstReturnEquiv`, as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)