### PR TITLE
research(erdos-1-oq-02): DISCHARGE anticoncentration_bound axiom — Erdős #1 DFX bound now fully VERIFIED (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos1OQ02.lean
+++ b/proofs/Proofs/Erdos1OQ02.lean
@@ -110,8 +110,9 @@ This step requires probability theory (Berry–Esseen theorem or direct
 anticoncentration bounds) which is axiomatized here.
 -/
 
-/-- **Chebyshev anticoncentration bound** [Axiom]: If A has n elements with
-    distinct subset sums and Q = Σaᵢ², then:
+/-! **Chebyshev anticoncentration bound** (formerly an axiom; now the THEOREM
+    `anticoncentration_bound`, proved below from the verified ingredients).
+    If A has n elements with distinct subset sums and Q = Σaᵢ², then:
       2ⁿ ≤ 3·√Q + 2
 
     This is the rigorous (Chebyshev) form of the Dubroff–Fox–Xu anticoncentration
@@ -134,10 +135,10 @@ anticoncentration bounds) which is axiomatized here.
     (Chebyshev) plus the variance computation for the {0,aᵢ} sum. The earlier
     formulation `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was FALSE (e.g. A = {1,2} gives 4 ≤ 2.85);
     this corrected statement holds for every distinct-subset-sums set, including
-    the asymptotic extremal (powers of two). -/
-axiom anticoncentration_bound (A : Finset ℕ) (hDSS : hasDistinctSubsetSums A)
-    (hpos : 0 < A.card) :
-    (2 : ℝ) ^ A.card ≤ 3 * Real.sqrt (↑(A.sum (fun a => a ^ 2))) + 2
+    the asymptotic extremal (powers of two).
+
+    **This is now proved (0 axioms) as `anticoncentration_bound` below**, after the
+    verified ingredients it is assembled from. -/
 
 /-! ## Verified ingredients toward discharging `anticoncentration_bound`
 
@@ -292,6 +293,152 @@ theorem card_le_of_sameParity_interval (V : Finset ℤ) (p L : ℤ) (hL : 0 ≤ 
   have : (V.card : ℤ) ≤ ((L + 1).toNat : ℤ) := by exact_mod_cast hcard
   rw [Int.toNat_of_nonneg (by omega)] at this
   exact this
+
+/-- **Discrete tail count over any index type (0 axioms).**  The `Finset ℕ`-indexed
+`card_mul_le_second_moment` generalised to an arbitrary index type — needed to count the
+far integer deviations `v ∈ V ⊆ ℤ`.  Same elementary proof. -/
+theorem card_mul_le_sum_of_nonneg {ι : Type*} (s : Finset ι) (g : ι → ℤ)
+    (hg : ∀ i ∈ s, 0 ≤ g i) (t : ℤ) :
+    ((s.filter (fun i => t ≤ g i)).card : ℤ) * t ≤ ∑ i ∈ s, g i := by
+  calc ((s.filter (fun i => t ≤ g i)).card : ℤ) * t
+      = ∑ _i ∈ s.filter (fun i => t ≤ g i), t := by
+        rw [Finset.sum_const, nsmul_eq_mul]
+    _ ≤ ∑ i ∈ s.filter (fun i => t ≤ g i), g i :=
+        Finset.sum_le_sum (fun i hi => (Finset.mem_filter.mp hi).2)
+    _ ≤ ∑ i ∈ s, g i :=
+        Finset.sum_le_sum_of_subset_of_nonneg (Finset.filter_subset _ _)
+          (fun i hi _ => hg i hi)
+
+/-- **Chebyshev anticoncentration bound (0 axioms).**  For a distinct-subset-sums set `A`
+with `n = |A| ≥ 1` and `Q = Σaᵢ²`, the count of subsets satisfies `2ⁿ ≤ 3√Q + 2`.
+
+This **discharges the former `anticoncentration_bound` axiom** by assembling the verified
+ingredients above, with no probability theory:
+
+* the `2ⁿ` doubled deviations `dₜ = 2·Σ_{i∈T} i − S` are `2ⁿ` **distinct integers**
+  (`card_doubledDrop_image_of_distinct`) all of one **parity** (`≡ S mod 2`), with second
+  moment `Σ dₜ² = 2ⁿ·Q` (`second_moment_identity`);
+* split them at a radius `L + 1 = ⌈2√Q⌉`: the central band `|dₜ| ≤ L` holds `≤ L + 1` of them
+  (`card_le_of_sameParity_interval`, the parity count), while the tail `|dₜ| ≥ L + 1` holds
+  `≤ 2ⁿQ/(L+1)²` of them (`card_mul_le_sum_of_nonneg`, discrete Chebyshev);
+* with `(L+1)² ≥ 4Q` the tail is `≤ 2ⁿ/4`, so `(3/4)·2ⁿ ≤ L + 1 ≤ 2√Q + 1`, giving
+  `2ⁿ ≤ (8√Q + 4)/3 ≤ 3√Q + 2`. -/
+theorem anticoncentration_bound (A : Finset ℕ) (hDSS : hasDistinctSubsetSums A)
+    (hpos : 0 < A.card) :
+    (2 : ℝ) ^ A.card ≤ 3 * Real.sqrt (↑(A.sum (fun a => a ^ 2))) + 2 := by
+  classical
+  set S : ℤ := ∑ i ∈ A, (i : ℤ) with hSdef
+  set f : Finset ℕ → ℤ := fun T => 2 * (∑ i ∈ T, (i : ℤ)) - S with hfdef
+  set V : Finset ℤ := A.powerset.image f with hVdef
+  set Q : ℤ := ∑ i ∈ A, (i : ℤ) ^ 2 with hQdef
+  -- (1) `f` is injective on the powerset; `|V| = 2^n`.
+  have hinj : Set.InjOn f (A.powerset : Set (Finset ℕ)) := by
+    rw [hfdef]; exact doubledDrop_injOn_of_distinct hDSS
+  have hVcard : V.card = 2 ^ A.card := by
+    rw [hVdef, hfdef]; exact card_doubledDrop_image_of_distinct hDSS
+  -- (2) second moment of the deviations: `Σ_{v∈V} v² = 2^n · Q`.
+  have hsum : ∑ v ∈ V, v ^ 2 = 2 ^ A.card * Q := by
+    rw [hVdef, Finset.sum_image hinj, hfdef]
+    exact second_moment_identity A
+  -- (3) every deviation has parity `S mod 2`.
+  have hVpar : ∀ v ∈ V, v % 2 = S % 2 := by
+    intro v hv
+    rw [hVdef, Finset.mem_image] at hv
+    obtain ⟨T, _, rfl⟩ := hv
+    simp only [hfdef]; omega
+  -- (4) `Q ≥ 1`: distinct subset sums force `0 ∉ A`, so some element is `≥ 1`.
+  have h0 : (0 : ℕ) ∉ A := by
+    intro h0A
+    have : (∅ : Finset ℕ) = {0} :=
+      hDSS ∅ {0} (Finset.empty_subset _)
+        (by simpa [Finset.singleton_subset_iff] using h0A) (by simp)
+    simp at this
+  obtain ⟨a, haA⟩ := Finset.card_pos.mp hpos
+  have ha1 : 1 ≤ a := Nat.one_le_iff_ne_zero.mpr (fun h => h0 (h ▸ haA))
+  have hQ1 : (1 : ℤ) ≤ Q := by
+    rw [hQdef]
+    calc (1 : ℤ) ≤ (a : ℤ) ^ 2 := by
+            have : (1 : ℤ) ≤ (a : ℤ) := by exact_mod_cast ha1
+            nlinarith
+      _ ≤ ∑ i ∈ A, (i : ℤ) ^ 2 :=
+            Finset.single_le_sum (fun i _ => sq_nonneg _) haA
+  have hQpos : (0 : ℝ) < (Q : ℝ) := by
+    have h1 : (1 : ℝ) ≤ (Q : ℝ) := by exact_mod_cast hQ1
+    linarith
+  -- rewrite the goal's `Q` (over ℕ→ℝ) as `(Q : ℝ)`.
+  have hQcast : ((A.sum (fun a => a ^ 2) : ℕ) : ℝ) = (Q : ℝ) := by
+    rw [hQdef]; push_cast; rfl
+  rw [hQcast]
+  -- abbreviations on the real side
+  have hsqrtQ_nonneg : (0 : ℝ) ≤ Real.sqrt (Q : ℝ) := Real.sqrt_nonneg _
+  have hsqrtQ_ge_one : (1 : ℝ) ≤ Real.sqrt (Q : ℝ) := by
+    rw [show (1 : ℝ) = Real.sqrt 1 by simp]
+    exact Real.sqrt_le_sqrt (by exact_mod_cast hQ1)
+  have hsqQ : Real.sqrt (Q : ℝ) ^ 2 = (Q : ℝ) := Real.sq_sqrt (le_of_lt hQpos)
+  -- (5) split radius `L + 1 = ⌈2√Q⌉`.
+  set L : ℤ := ⌈2 * Real.sqrt (Q : ℝ)⌉ - 1 with hLdef
+  have hceil_ge : 2 * Real.sqrt (Q : ℝ) ≤ ((⌈2 * Real.sqrt (Q : ℝ)⌉ : ℤ) : ℝ) :=
+    Int.le_ceil _
+  have hLnn : 0 ≤ L := by
+    have h2 : (2 : ℝ) ≤ ((⌈2 * Real.sqrt (Q : ℝ)⌉ : ℤ) : ℝ) := by
+      have : (2 : ℝ) ≤ 2 * Real.sqrt (Q : ℝ) := by nlinarith [hsqrtQ_ge_one]
+      linarith [hceil_ge]
+    have h2z : (2 : ℤ) ≤ ⌈2 * Real.sqrt (Q : ℝ)⌉ := by exact_mod_cast h2
+    omega
+  have hLr1 : 2 * Real.sqrt (Q : ℝ) ≤ (L : ℝ) + 1 := by
+    rw [hLdef]; push_cast; linarith [hceil_ge]
+  have hLr2 : (L : ℝ) + 1 ≤ 2 * Real.sqrt (Q : ℝ) + 1 := by
+    rw [hLdef]; push_cast; linarith [Int.ceil_lt_add_one (2 * Real.sqrt (Q : ℝ))]
+  have hw4 : 4 * (Q : ℝ) ≤ ((L : ℝ) + 1) ^ 2 := by
+    nlinarith [hLr1, hsqQ, hsqrtQ_nonneg]
+  -- (6) the central / tail split of `V`.
+  have hsplit :
+      (V.filter (fun v => -L ≤ v ∧ v ≤ L)).card
+        + (V.filter (fun v => ¬ (-L ≤ v ∧ v ≤ L))).card = V.card :=
+    Finset.filter_card_add_filter_neg_card_eq_card _
+  -- central band: parity count `≤ L + 1`.
+  have hnear : ((V.filter (fun v => -L ≤ v ∧ v ≤ L)).card : ℤ) ≤ L + 1 :=
+    card_le_of_sameParity_interval (V.filter (fun v => -L ≤ v ∧ v ≤ L)) S L hLnn
+      (fun v hv => hVpar v (Finset.mem_filter.mp hv).1)
+      (fun v hv => (Finset.mem_filter.mp hv).2)
+  -- tail ⊆ `{(L+1)² ≤ v²}`.
+  have hfar_sub :
+      V.filter (fun v => ¬ (-L ≤ v ∧ v ≤ L))
+        ⊆ V.filter (fun v => (L + 1) ^ 2 ≤ v ^ 2) := by
+    intro v hv
+    obtain ⟨hvV, hnp⟩ := Finset.mem_filter.mp hv
+    refine Finset.mem_filter.mpr ⟨hvV, ?_⟩
+    have hcases : v ≤ -(L + 1) ∨ L + 1 ≤ v := by omega
+    rcases hcases with h | h <;> nlinarith [hLnn]
+  -- discrete Chebyshev on the tail.
+  have htail :
+      ((V.filter (fun v => (L + 1) ^ 2 ≤ v ^ 2)).card : ℤ) * (L + 1) ^ 2
+        ≤ 2 ^ A.card * Q := by
+    have := card_mul_le_sum_of_nonneg V (fun v => v ^ 2) (fun v _ => sq_nonneg v) ((L + 1) ^ 2)
+    rwa [hsum] at this
+  -- (7) integer assembly: `2^n ≤ (L+1) + far`, and `far·(L+1)² ≤ 2^n·Q`.
+  set farc : ℤ := ((V.filter (fun v => (L + 1) ^ 2 ≤ v ^ 2)).card : ℤ) with hfarc
+  have hI : (2 ^ A.card : ℤ) ≤ (L + 1) + farc := by
+    have hsplitz :
+        ((V.filter (fun v => -L ≤ v ∧ v ≤ L)).card : ℤ)
+          + ((V.filter (fun v => ¬ (-L ≤ v ∧ v ≤ L))).card : ℤ)
+          = (V.card : ℤ) := by exact_mod_cast hsplit
+    have hnegfar :
+        ((V.filter (fun v => ¬ (-L ≤ v ∧ v ≤ L))).card : ℤ) ≤ farc := by
+      rw [hfarc]; exact_mod_cast Finset.card_le_card hfar_sub
+    have hVz : (V.card : ℤ) = (2 ^ A.card : ℤ) := by exact_mod_cast hVcard
+    rw [hVz] at hsplitz
+    linarith [hnear, hnegfar, hsplitz]
+  have hII : farc * (L + 1) ^ 2 ≤ (2 ^ A.card : ℤ) * Q := by rw [hfarc]; exact htail
+  -- (8) cast to ℝ and finish.
+  have hI_r : (2 : ℝ) ^ A.card ≤ ((L : ℝ) + 1) + (farc : ℝ) := by exact_mod_cast hI
+  have hII_r : (farc : ℝ) * ((L : ℝ) + 1) ^ 2 ≤ (2 : ℝ) ^ A.card * (Q : ℝ) := by
+    exact_mod_cast hII
+  have hfcnn : (0 : ℝ) ≤ (farc : ℝ) := by rw [hfarc]; positivity
+  have key : (4 * (farc : ℝ)) * (Q : ℝ) ≤ (2 : ℝ) ^ A.card * (Q : ℝ) := by
+    nlinarith [hII_r, hw4, hfcnn, mul_nonneg hfcnn (show (0 : ℝ) ≤ ((L : ℝ) + 1) ^ 2 - 4 * (Q : ℝ) by linarith [hw4])]
+  have hfc4 : 4 * (farc : ℝ) ≤ (2 : ℝ) ^ A.card := le_of_mul_le_mul_right key hQpos
+  nlinarith [hI_r, hLr2, hfc4, hsqrtQ_nonneg]
 
 /-- **DFX Lower Bound Statement** (Chebyshev constant): If A ⊆ {1,...,N} has n ≥ 1
     elements with distinct subset sums, then:

--- a/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1-oq-02-incomplete-01/knowledge.md
@@ -153,3 +153,35 @@ Added `card_le_of_sameParity_interval` (0-axiom): a `Finset ℤ` whose elements 
 - src/data/proofs/erdos-1-oq-02/meta.json (counts 367/13 → 399/14 + highlight)
 
 ### Status: IN-PROGRESS (axiom not yet discharged; only the sqrt assembly remains).
+
+## Session 2026-06-30 (researcher-2) — AXIOM DISCHARGED: anticoncentration_bound is now a THEOREM (0-axiom)
+
+**Completed the multi-session axiom-elimination.** All four ingredients were in place
+(second_moment_identity, card_mul_le_second_moment, card_doubledDrop_image_of_distinct,
+card_le_of_sameParity_interval). This session wrote the **combine** and deleted the axiom:
+
+`Erdos1OQ02.lean` is now **0 axioms / 0 sorries / 0 native_decide**, 399→546 lines,
+docker `[7744]` VERIFIED. Gallery entry `erdos-1-oq-02` flipped **axiomatized → verified**.
+
+### The discharge (theorem anticoncentration_bound, ~110 lines)
+For distinct-subset-sums `A`, `n=|A|≥1`, `Q=Σaᵢ²`: `2ⁿ ≤ 3√Q + 2`.
+- `V := image (T ↦ 2·Σ_T − S) A.powerset` — the 2ⁿ doubled deviations; `|V|=2ⁿ`
+  (card_doubledDrop_image), `ΣV v² = 2ⁿ·Q` (sum_image hinj + second_moment_identity), all `≡ S (mod 2)`.
+- `Q ≥ 1`: distinct subset sums ⇒ `0∉A` (else ∅,{0} collide) ⇒ some `a≥1` ⇒ `Q ≥ a² ≥ 1`.
+- Split radius `L+1 = ⌈2√Q⌉` (so `(L+1)² ≥ 4Q` via `Int.le_ceil` + `Real.sq_sqrt`, and
+  `L+1 ≤ 2√Q+1` via `Int.ceil_lt_add_one`; `L≥0` since `2√Q≥2`).
+- Central band `|v|≤L`: `≤ L+1` (card_le_of_sameParity_interval, parity).
+- Tail `|v|≥L+1` ⊆ `{(L+1)²≤v²}`: discrete Chebyshev `far·(L+1)² ≤ ΣV v² = 2ⁿQ`
+  (new `card_mul_le_sum_of_nonneg`, the ℤ-indexed generalization of card_mul_le_second_moment).
+- `filter_card_add_filter_neg_card_eq_card` ⇒ `2ⁿ ≤ (L+1) + far`; with `4·far ≤ 2ⁿ`
+  (from tail ÷ (L+1)²≥4Q, `le_of_mul_le_mul_right`) ⇒ `(3/4)2ⁿ ≤ L+1 ≤ 2√Q+1` ⇒ `2ⁿ ≤ (8√Q+4)/3 ≤ 3√Q+2`.
+
+### GOTCHAs
+- `simp only [hfdef]` (NOT `rw [hfdef]`) before `omega` for the parity goal — rw leaves an
+  unreduced β-redex `(fun T => …) T` that omega treats as an opaque atom.
+- Integer→real casts of `2^n` inequalities: `exact_mod_cast hI` works directly; the manual
+  `rw [←hmcast]; push_cast` route fights push_cast (it re-normalizes `((2^n:ℤ):ℝ)`→`(2:ℝ)^n`).
+- `have h : P := by exact_mod_cast x; linarith` is a bug — the `;` runs linarith on the
+  already-closed goal ("no goals"); split into two `have`s.
+
+STATUS: COMPLETE. The axiom-discharge goal of this slug is fully achieved; `erdos-1-oq-02` is verified.

--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -2,12 +2,12 @@
   "id": "erdos-1-oq-02",
   "title": "Dubroff–Fox–Xu Subset Sum Lower Bound Framework",
   "slug": "erdos-1-oq-02",
-  "description": "Formalizes the algebraic framework for the Dubroff–Fox–Xu (2021) lower bound N ≥ √(2/π) · 2ⁿ/√n for the distinct subset sums problem (Erdős #1). Proves variance bounds (sum of squares ≤ n·N², sum ≤ n·N) and axiomatizes the anticoncentration step from Berry–Esseen.",
+  "description": "Formalizes the Dubroff–Fox–Xu (2021) lower bound N = Ω(2ⁿ/√n) for the distinct subset sums problem (Erdős #1). Proves variance bounds (Σaᵢ² ≤ n·N², Σaᵢ ≤ n·N) and the Chebyshev anticoncentration step 2ⁿ ≤ 3√Q + 2 — formerly axiomatized, now PROVED in-file (0 axioms) via a probability-free discharge: second-moment identity over the powerset + parity-aware central-interval count + discrete Chebyshev tail.",
   "meta": {
     "author": "Dubroff, Fox, Xu (2021); framework formalized 2026",
     "sourceUrl": "https://erdosproblems.com/1",
     "date": "2021",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1OQ02.lean",
     "tags": [
       "additive-combinatorics",
@@ -17,11 +17,11 @@
       "anticoncentration",
       "berry-esseen"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
-    "axiomCount": 1,
-    "lineCount": 399,
-    "assumptions": "One axiom: anticoncentration_bound (Berry-Esseen anticoncentration for subset sums). dfx_lower_bound and pow2_dss proved in 2026-04-26 commit. sum_sq_cauchy_schwarz proved via induction in Z.",
+    "axiomCount": 0,
+    "lineCount": 546,
+    "assumptions": "0 axioms. The former anticoncentration_bound axiom (2^n ≤ 3√Q + 2 for distinct-subset-sums sets) is now PROVED in-file (theorem anticoncentration_bound) by an elementary, probability-free discharge: the second-moment identity over the powerset, a parity-aware central-interval count, and a discrete Chebyshev tail. dfx_lower_bound and pow2_dss proved; sum_sq_cauchy_schwarz proved. Fully machine-checked, 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -211,16 +211,17 @@
       "Mathlib"
     ],
     "namespace": "Erdos1OQ02",
-    "lineCount": 399,
-    "axiomCount": 1,
-    "theoremCount": 14,
+    "lineCount": 546,
+    "axiomCount": 0,
+    "theoremCount": 16,
     "definitionCount": 0,
     "path": "Proofs/Erdos1OQ02.lean",
     "sorries": 0
   },
   "sorries": 0,
-  "assumptions": "One axiom: anticoncentration_bound — the Chebyshev anticoncentration bound 2ⁿ ≤ 3·√(Σaᵢ²) + 2 for distinct-subset-sum sets. It is unconditionally true (Chebyshev's inequality applied to X = Σ εᵢaᵢ, plus the distinctness counting argument) and in principle dischargeable from Mathlib's `ProbabilityTheory` Chebyshev lemmas. dfx_lower_bound and the variance/Cauchy–Schwarz lemmas are fully proved (0 sorries). NOTE: the earlier axiom `2ⁿ ≤ √(2/π)·2(S+1)/√Q` was FALSE and has been corrected. Progress (2026-06-28): the probability-free core of the axiom's discharge is now proved in-file with 0 axioms — second_moment_identity (∑_{T⊆A}(2·ΣT−S)² = 2^|A|·Σaᵢ²) and card_mul_le_second_moment (discrete Chebyshev tail count). The only remaining step to eliminate the axiom is the same-parity distinct-integer central-interval count.",
+  "assumptions": "None — the file is fully verified (0 axioms, 0 sorries). The anticoncentration bound is now a proved theorem.",
   "highlights": [
+    "Anticoncentration axiom DISCHARGED (0-axiom, fully verified): the former anticoncentration_bound axiom 2^n <= 3*sqrt(Q)+2 is now a proved theorem. Combine: the 2^n doubled deviations are 2^n distinct same-parity integers with second moment 2^n*Q; splitting at radius ceil(2*sqrt Q) the central-interval count bounds the near band by L+1 and discrete Chebyshev bounds the tail by 2^n/4, giving (3/4)2^n <= 2*sqrt(Q)+1 <= 3*sqrt(Q)+2. The entry is now status=verified.",
     "Central-interval count landed (card_le_of_sameParity_interval, 0-axiom): a finite set of integers all of one parity confined to [-L,L] has <= L+1 elements (via v |-> (v+L)/2 injecting into Icc 0 L). This is the LAST combinatorial input to discharging anticoncentration_bound with the sharp constant 3 -- joins second_moment_identity, the 2^|A|-distinct-integers image, and the Chebyshev tail. Only the real-sqrt optimization assembly remains.",
     "Verified inputs toward discharging the anticoncentration axiom (0-axiom): subset sums are injective on the powerset for a distinct-subset-sums set (subsetSum_injOn_of_distinct), hence the 2^|A| doubled deviations 2*Sum_T - S are 2^|A| DISTINCT integers (card_doubledDrop_image_of_distinct) -- the precise 'distinct integers' input to the central-interval count that recovers the sharp constant 3. Joins second_moment_identity + card_mul_le_second_moment; only the parity-aware interval count + real-sqrt combine remain."
   ]

--- a/src/data/research/problems/erdos-1-oq-02-incomplete-01.json
+++ b/src/data/research/problems/erdos-1-oq-02-incomplete-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-1-oq-02-incomplete-01",
   "title": "erdos-1-oq-02-incomplete-01",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "VERIFIED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -40,7 +40,8 @@
       "anticoncentration_bound was mathematically FALSE: `2ⁿ ≤ √(2/π)·2(S+1)/√Q` fails for A={1,2} (asserts 4 ≤ 2.85) and for essentially all distinct-subset-sum sets. A false axiom makes the file logically unsound.",
       "Replaced with the rigorous Chebyshev anticoncentration bound `2ⁿ ≤ 3·√(Σaᵢ²)+2`, verified true on all test sets incl. the asymptotic extremal (powers of two: 256 ≤ 445).",
       "The file had ALSO broken on the Mathlib 4.26 bump (toolchain v4.26.0): div_le_iff→div_le_iff₀, a simp recursion in sum_sq_le_card_mul_max_sq (Finset.card_eq_sum_ones loop), an nlinarith cast-atom mismatch in sum_sq_cauchy_schwarz (ih not push_cast'd), and omega on the nonlinear n<n*n.",
-      "dfx_lower_bound re-derived via Σaᵢ²≤n·N² (sum_sq_le_card_mul_max_sq) → √Q≤√n·N → 2ⁿ≤3·√n·N+2; dropped the now-unnecessary hN/hA_pos hypotheses (the +2 slack covers small n)."
+      "dfx_lower_bound re-derived via Σaᵢ²≤n·N² (sum_sq_le_card_mul_max_sq) → √Q≤√n·N → 2ⁿ≤3·√n·N+2; dropped the now-unnecessary hN/hA_pos hypotheses (the +2 slack covers small n).",
+      "Session 2026-06-30 (researcher-2): AXIOM DISCHARGED. The anticoncentration_bound axiom (2^n ≤ 3√Q+2) is now a proved theorem in Erdos1OQ02.lean (0 axioms / 0 sorries, docker-verified [7744]); gallery entry erdos-1-oq-02 flipped axiomatized→verified. Combine of the prior ingredients: V = 2^n distinct same-parity doubled deviations with ΣV v²=2^n Q; split at ⌈2√Q⌉ — central-interval parity count ≤ L+1, discrete Chebyshev tail (new ℤ-indexed card_mul_le_sum_of_nonneg) ≤ 2^n/4 — gives (3/4)2^n ≤ 2√Q+1 ⇒ 2^n ≤ 3√Q+2. Q≥1 from distinct-subset-sums forcing 0∉A."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

**Eliminates the last axiom** of `Erdos1OQ02.lean`, completing a multi-session axiom-elimination effort. The former `anticoncentration_bound` axiom

```
2^n ≤ 3·√Q + 2     (Q = Σaᵢ², A distinct-subset-sums, n = |A| ≥ 1)
```

is now a **proved theorem**, via an elementary, probability-free combine of the four verified ingredients prior sessions had landed. The gallery entry `erdos-1-oq-02` flips **axiomatized → verified**.

## The discharge (theorem `anticoncentration_bound`, ~110 lines, 0 axioms)

- `V := image (T ↦ 2·Σ_T − S) A.powerset` is **2ⁿ distinct same-parity integers** (`card_doubledDrop_image_of_distinct`, parity `≡ S mod 2`), with second moment `Σ_{v∈V} v² = 2ⁿ·Q` (`Finset.sum_image` of the injectivity + `second_moment_identity`).
- `Q ≥ 1`: distinct subset sums force `0 ∉ A` (else `∅` and `{0}` collide), so some `aᵢ ≥ 1` and `Q ≥ aᵢ² ≥ 1`.
- Split at radius `L + 1 = ⌈2√Q⌉` — so `(L+1)² ≥ 4Q` (`Int.le_ceil` + `Real.sq_sqrt`) and `L+1 ≤ 2√Q + 1` (`Int.ceil_lt_add_one`):
  - **central band** `|v| ≤ L`: at most `L + 1` deviations (`card_le_of_sameParity_interval`, the parity count);
  - **tail** `|v| ≥ L+1 ⊆ {(L+1)² ≤ v²}`: discrete Chebyshev `far·(L+1)² ≤ Σ_V v² = 2ⁿQ` (new ℤ-indexed `card_mul_le_sum_of_nonneg`).
- `filter_card_add_filter_neg_card_eq_card` ⇒ `2ⁿ ≤ (L+1) + far`; with `4·far ≤ 2ⁿ` (tail ÷ `(L+1)²≥4Q`) ⇒ `(3/4)·2ⁿ ≤ L+1 ≤ 2√Q+1` ⇒ `2ⁿ ≤ (8√Q+4)/3 ≤ 3√Q + 2`.

## Status change

This was the file's only axiom and there are no structure-encoded assumptions, so per the Axiom Integrity Policy the entry is now **`status: verified`, `badge: verified`, `axiomCount: 0`** (0 sorries, no `native_decide`). `meta.assumptions`/`description`/`highlights` updated accordingly.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos1OQ02` → `Build completed successfully (7744 jobs)`, 0 errors. File 399→546 lines / 16 thm, 0 axiom / 0 sorry. (Pre-existing simp-lint warnings at lines 88/234/513 are untouched and unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)