### PR TITLE
Enrich Conjugacy of Complements in Schur–Zassenhaus (Abelian Case): add index.ts + annotations

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/sylow-theorem-oq-03-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-szc0301-overview",
+    "proofId": "sylow-theorem-oq-03-oq-01",
+    "range": { "startLine": 6, "endLine": 51 },
+    "type": "concept",
+    "title": "The Conjugacy Half, Abelian Base Case",
+    "content": "Schur–Zassenhaus has two halves. Mathlib supplies only the existence half (Subgroup.exists_right_complement'_of_coprime): a normal N ⊴ G with gcd(|N|, [G:N]) = 1 has a complement K, so G = N ⋊ K. This file proves the harder conjugacy half in the abelian base case: when N is abelian, any two complements are conjugate, in fact by an element of N. This is exactly the inductive engine of the general solvable theorem — one peels off an abelian chief factor and applies this lemma at each step. The cohomological content is that H¹(G/N, N) = 0 in the coprime case, which Mathlib already encodes (without naming cohomology) as transitivity of the N-action on the transfer space N.QuotientDiff.",
+    "mathContext": "$N \\trianglelefteq G$ abelian, $\\gcd(|N|, [G:N]) = 1 \\Rightarrow$ all complements of $N$ form a single $N$-conjugacy class $\\;\\Longleftrightarrow\\; H^1(G/N, N) = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Schur–Zassenhaus theorem", "group complements", "semidirect product", "first group cohomology", "chief series"],
+    "prerequisites": ["normal subgroups and quotients", "coprime order and index", "the parent existence entry"]
+  },
+  {
+    "id": "ann-szc0301-transversal",
+    "proofId": "sylow-theorem-oq-03-oq-01",
+    "range": { "startLine": 63, "endLine": 69 },
+    "type": "definition",
+    "title": "A Complement as a Point of QuotientDiff",
+    "content": "Because K is a complement of N, every g ∈ G has a unique factorization g = nk with n ∈ N, k ∈ K; equivalently the underlying set of K meets each left coset of N exactly once, i.e. K is a left transversal of N. complementTransversal packages this (the proof is just h.symm, swapping the roles of N and K in IsComplement'). complementPoint then takes the class of that transversal in N.QuotientDiff — the quotient of all left transversals modulo Mathlib's 'diff' relation. This is the bridge from subgroup-theoretic data (a complement) to the action-theoretic arena (a point) where transitivity lives.",
+    "mathContext": "$K \\text{ complement} \\Rightarrow (K : \\mathrm{Set}\\,G) \\in N.\\mathrm{LeftTransversal} \\;\\rightsquigarrow\\; \\alpha_K := [K] \\in N.\\mathrm{QuotientDiff}.$",
+    "significance": "key",
+    "relatedConcepts": ["left transversal", "coset representatives", "IsComplement'", "QuotientDiff transfer space"],
+    "prerequisites": ["subgroup complements", "coset decomposition"]
+  },
+  {
+    "id": "ann-szc0301-le-stabilizer",
+    "proofId": "sylow-theorem-oq-03-oq-01",
+    "range": { "startLine": 71, "endLine": 87 },
+    "type": "lemma",
+    "title": "K Fixes Its Own Transversal Point",
+    "content": "The only step that uses that K is a subgroup rather than just a transversal. The N-action on QuotientDiff acts by right-translation of transversal sets (via the opposite group Gᵐᵒᵖ). For k ∈ K, right-translating the set K by k⁻¹ gives back K itself — precisely the closure of a subgroup under multiplication by its own elements: K·k⁻¹ = K. Hence k fixes the class α_K, giving K ≤ stabilizer G α_K. The Lean proof unfolds the opposite-group scalar action (op_smul_eq_mul), proves the set equality op(k⁻¹) • K = K by mutual inclusion using K.mul_mem / K.inv_mem, and lifts it through Quotient.mk''.",
+    "mathContext": "$k \\in K \\Rightarrow K \\cdot k^{-1} = K \\Rightarrow \\mathrm{op}(k^{-1}) \\bullet \\alpha_K = \\alpha_K$, so $K \\le \\mathrm{stab}_G(\\alpha_K).$",
+    "significance": "key",
+    "relatedConcepts": ["point stabilizer", "right translation action", "opposite group MulOpposite", "subgroup closure"],
+    "prerequisites": ["group actions on quotients", "MulOpposite scalar action", "stabilizer membership"]
+  },
+  {
+    "id": "ann-szc0301-stab-eq",
+    "proofId": "sylow-theorem-oq-03-oq-01",
+    "range": { "startLine": 95, "endLine": 111 },
+    "type": "theorem",
+    "title": "Every Complement IS a Point-Stabilizer (Cardinality Argument)",
+    "content": "The converse of Mathlib's Schur–Zassenhaus construction, and the crux of the whole file. Mathlib's isComplement'_stabilizer_of_coprime says each stabilizer G α is itself a complement of N; combined with the previous lemma's inclusion K ≤ stabilizer G α_K we get two complements, one inside the other. Both complements have order equal to the index [G:N] (IsComplement.card_right), so they have equal finite cardinality. Subgroup.eq_of_le_of_card_ge upgrades 'contained in and at least as large' to equality. No cohomology is re-proved here — the equality is forced purely by counting.",
+    "mathContext": "$K \\le \\mathrm{stab}_G(\\alpha_K),\\quad |K| = |\\mathrm{stab}_G(\\alpha_K)| = [G:N] \\;\\Rightarrow\\; \\mathrm{stab}_G(\\alpha_K) = K.$",
+    "significance": "critical",
+    "relatedConcepts": ["complement order equals index", "stabilizer is a complement", "Lagrange counting", "antisymmetry by cardinality"],
+    "prerequisites": ["isComplement'_stabilizer_of_coprime", "IsComplement.card_right", "finite subgroup cardinality"]
+  },
+  {
+    "id": "ann-szc0301-conjugacy",
+    "proofId": "sylow-theorem-oq-03-oq-01",
+    "range": { "startLine": 113, "endLine": 127 },
+    "type": "theorem",
+    "title": "Conjugacy of Complements (Main Result)",
+    "content": "The headline theorem. With both complements realized as point-stabilizers, conjugacy follows from a general action lemma. Transitivity of the N-action (exists_smul_eq, the cohomological core supplied by Mathlib) gives h ∈ N with h • α_{K₁} = α_{K₂}. Then stabilizer_smul_eq_stabilizer_map_conj — stabilizers of points in one orbit are conjugate by any element carrying one to the other — yields stab(α_{K₂}) = stab(h • α_{K₁}) = stab(α_{K₁}) conjugated by h. Substituting stab(α_{Kᵢ}) = Kᵢ gives K₂ = K₁^h with h ∈ N. The calc block makes each rewrite explicit.",
+    "mathContext": "$h \\bullet \\alpha_{K_1} = \\alpha_{K_2},\\ h \\in N \\;\\Rightarrow\\; K_2 = \\mathrm{stab}(\\alpha_{K_2}) = h\\,\\mathrm{stab}(\\alpha_{K_1})\\,h^{-1} = K_1^{\\,h}.$",
+    "significance": "critical",
+    "relatedConcepts": ["transitive action", "orbit–stabilizer", "conjugate stabilizers", "exists_smul_eq", "inner automorphism MulAut.conj"],
+    "prerequisites": ["transitivity on QuotientDiff", "stabilizer_smul_eq_stabilizer_map_conj", "conjugation of subgroups"]
+  },
+  {
+    "id": "ann-szc0301-exists-and-conj",
+    "proofId": "sylow-theorem-oq-03-oq-01",
+    "range": { "startLine": 129, "endLine": 137 },
+    "type": "theorem",
+    "title": "Full Abelian Schur–Zassenhaus: Existence + Uniqueness",
+    "content": "Packages both halves into one statement. Mathlib's existence half (exists_right_complement'_of_coprime) produces a witness complement K₀; the conjugacy theorem above then shows every complement K is N-conjugate to K₀. Together they say the complements of an abelian normal N of coprime order/index form exactly one N-conjugacy class — existence and uniqueness-up-to-N-conjugacy in a single result. This is the clean inductive hypothesis the general solvable proof consumes, and it gives uniqueness of the semidirect-product splitting G = N ⋊ K up to inner automorphism.",
+    "mathContext": "$\\exists K_0,\\ \\mathrm{IsComplement}'\\,N\\,K_0 \\;\\wedge\\; \\forall K \\text{ complement},\\ \\exists g \\in N,\\ K = K_0^{\\,g}.$",
+    "significance": "key",
+    "relatedConcepts": ["existence and uniqueness", "single conjugacy class", "semidirect product splitting", "inductive step"],
+    "prerequisites": ["exists_right_complement'_of_coprime", "the conjugacy theorem above"]
+  }
+]

--- a/src/data/proofs/sylow-theorem-oq-03-oq-01/index.ts
+++ b/src/data/proofs/sylow-theorem-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SchurZassenhausConjugacyAbelianOQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const sylowTheoremOq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const sylowTheoremOq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const sylowTheoremOq03Oq01Data: ProofData = {
+  proof: sylowTheoremOq03Oq01Proof,
+  annotations: sylowTheoremOq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `sylow-theorem-oq-03-oq-01`.

## Gaps addressed
This entry had a rich `meta.json` (14 KB, well within caps) but was **missing both `index.ts` and `annotations.json`** — without `index.ts` the proof page renders "proof not found" on the live site despite appearing in the gallery listing.

## Changes
- **Created `index.ts`** (the required Vite entry point) so the page loads.
- **Created `annotations.json`** with 6 substantive annotations spanning the full Lean file:
  1. Overview — the conjugacy half / abelian base case, framed as $H^1(G/N,N)=0$
  2. `complementTransversal` / `complementPoint` — the complement→QuotientDiff bridge
  3. `le_stabilizer_complementPoint` — the one step that uses subgroup-hood of K
  4. `stabilizer_complementPoint_eq` — the cardinality argument (the crux: every complement IS a point-stabilizer)
  5. `isComplement'_conj_of_isMulCommutative` — the main conjugacy theorem
  6. `exists_and_conj` — combined existence + uniqueness-up-to-N-conjugacy
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, accurately reflecting the actual Lean source.

## Verification
- `meta.json` size check: within all caps (file ≤ 60 KB).
- `annotations:build` validator: my entry is clean (0 errors).
- JSON parses; annotation schema matches `Annotation` type.
- Note: full `tsc`/`vite build` could not run in this worktree due to a `better-sqlite3` native-build incompatibility with node v26 (environment issue, unrelated to this change).

`status`/`badge`/`axiomCount` left unchanged — verified accurate against the Lean file (0 sorries, 0 axioms, abelian-case scope correctly disclosed).