### PR TITLE
Enrich Property B: Independent Recoloring Cannot Beat Erdős — add index.ts + annotations

### DIFF
--- a/src/data/proofs/property-b-first-moment-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-pbir0303-overview",
+    "proofId": "property-b-first-moment-oq-03-oq-03",
+    "range": { "startLine": 3, "endLine": 52 },
+    "type": "concept",
+    "title": "Independent Recoloring Cannot Beat Erdős — an ORIENT Result",
+    "content": "Erdős's 1963 first-moment bound gives m(k) ≥ 2^(k-1) for Property B (the minimum number of edges in a non-2-colorable k-uniform hypergraph). The parent open question asks to sharpen this to the Radhakrishnan–Srinivasan bound Ω(2^k·√(k/log k)) via two ingredients: asymmetry and a recoloring repair. The sibling oq-03-oq-01 killed asymmetry; this file kills the naive independent (product-space) version of recoloring. Its purpose is structural ORIENT: it converts the informal observation 'the RS recoloring is not expressible by summing over a single product sample space V → Bool' into a theorem, thereby proving the genuine RS gain must come from the conditional, order-dependent recoloring of only the dangerous-edge vertices.",
+    "mathContext": "Erdős: $m(k) \\ge 2^{k-1}$. RS: $m(k) = \\Omega\\!\\big(2^k\\sqrt{k/\\log k}\\big)$. This entry: independent recoloring $\\Rightarrow$ threshold stays $2^{k-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Property B", "first-moment method", "Radhakrishnan–Srinivasan bound", "recoloring / alteration argument", "hypergraph 2-coloring"],
+    "prerequisites": ["the probabilistic method", "Erdős's first-moment bound", "independent vs conditional probability"]
+  },
+  {
+    "id": "ann-pbir0303-defs",
+    "proofId": "property-b-first-moment-oq-03-oq-03",
+    "range": { "startLine": 56, "endLine": 67 },
+    "type": "definition",
+    "title": "The Real-Valued First-Moment Model",
+    "content": "Three definitions encode the naive two-stage model as real-valued probabilities (the standard first-moment idiom of the sibling entries — no measure space needed for a negative result). vertexFinalProb p = (1/2)(1−p) + (1/2)p is the probability a single vertex ends on a fixed target color after a uniform first round followed by an independent Bernoulli(p) flip. monoIndep k p = 2·(vertexFinalProb p)^k is the monochromatic probability of a k-edge under independence across its k vertices (factor 2 for the two colors). monoOneStage k = 2·(1/2)^k is the one-round Erdős value used for comparison.",
+    "mathContext": "$\\mathrm{vertexFinalProb}(p) = \\tfrac12(1-p) + \\tfrac12 p,\\quad \\mathrm{monoIndep}(k,p) = 2\\,\\mathrm{vertexFinalProb}(p)^k,\\quad \\mathrm{monoOneStage}(k) = 2\\,(\\tfrac12)^k.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Bernoulli flip", "independence", "monochromatic probability", "two-stage coloring"],
+    "prerequisites": ["real-valued probability modeling", "independent events multiply"]
+  },
+  {
+    "id": "ann-pbir0303-uniform",
+    "proofId": "property-b-first-moment-oq-03-oq-03",
+    "range": { "startLine": 69, "endLine": 73 },
+    "type": "theorem",
+    "title": "XOR-with-Uniform Stays Uniform (The Collapse)",
+    "content": "The single algebraic fact from which all inertness follows. vertexFinalProb_eq_half proves (1/2)(1−p) + (1/2)p = 1/2 for every p, by ring: the +(1/2)p and −(1/2)p terms cancel. Probabilistically this is the principle that XOR-ing a uniform bit with ANY independent bit yields a uniform bit — the independent flip carries no information about the final color. It is marked @[simp] so the rest of the file rewrites monoIndep against the constant 1/2 automatically.",
+    "mathContext": "$\\mathrm{vertexFinalProb}(p) = \\tfrac12(1-p) + \\tfrac12 p = \\tfrac12,\\ \\forall p$. Uniform $\\oplus$ independent $=$ uniform.",
+    "significance": "critical",
+    "relatedConcepts": ["XOR with uniform distribution", "ring normalization", "Bernoulli independence", "information-free perturbation"],
+    "prerequisites": ["the ring tactic", "uniform distribution on Bool"]
+  },
+  {
+    "id": "ann-pbir0303-mono",
+    "proofId": "property-b-first-moment-oq-03-oq-03",
+    "range": { "startLine": 75, "endLine": 91 },
+    "type": "theorem",
+    "title": "Monochromatic Probability Is the Erdős Value, for Every p",
+    "content": "monoIndep_eq_oneStage is the central negative result: substituting vertexFinalProb p = 1/2 into monoIndep k p = 2·(vertexFinalProb p)^k collapses it to 2·(1/2)^k = monoOneStage k — identical to the one-round Erdős probability, for ALL flip rates p. monoOneStage_eq_zpow then exhibits this in closed form as the real integer power 2^(1-k) via zpow_add₀ / zpow_neg / zpow_natCast (recognizing 2^(1-k) = 2·2^(-k)). monoIndep_const records the immediate corollary that monoIndep is constant in p — no flip rate helps.",
+    "mathContext": "$\\mathrm{monoIndep}(k,p) = 2\\,(\\tfrac12)^k = 2^{\\,1-k} = \\mathrm{monoOneStage}(k),\\ \\forall p.$",
+    "significance": "critical",
+    "relatedConcepts": ["one-round Erdős probability", "integer power zpow", "constancy in p", "alteration is inert"],
+    "prerequisites": ["zpow real-power algebra", "substitution via simp lemma"]
+  },
+  {
+    "id": "ann-pbir0303-expmono",
+    "proofId": "property-b-first-moment-oq-03-oq-03",
+    "range": { "startLine": 93, "endLine": 97 },
+    "type": "theorem",
+    "title": "Expected Monochromatic-Edge Count Is Flip-Rate Invariant",
+    "content": "expMono_indep_const lifts constancy to the first-moment quantity itself: the expected number of monochromatic edges of an m-edge hypergraph, m·monoIndep k p, equals m·monoIndep k q for any two flip rates p, q. It is the bridge from the per-edge collapse to the global first-moment count that actually controls colorability — making explicit that the expectation a practitioner would try to drive below 1 is completely unaffected by the recoloring rate.",
+    "mathContext": "$m\\cdot\\mathrm{monoIndep}(k,p) = m\\cdot\\mathrm{monoIndep}(k,q),\\ \\forall p,q.$",
+    "significance": "key",
+    "relatedConcepts": ["first moment / expected count", "linearity of expectation", "union bound input"],
+    "prerequisites": ["monoIndep_const", "expectation of edge indicators"]
+  },
+  {
+    "id": "ann-pbir0303-threshold",
+    "proofId": "property-b-first-moment-oq-03-oq-03",
+    "range": { "startLine": 99, "endLine": 109 },
+    "type": "theorem",
+    "title": "The First-Moment Threshold Is Unmoved (Quantitative Punchline)",
+    "content": "threshold_indep makes the inertness quantitative and decisive: the first-moment success criterion m·monoIndep k p < 1 is equivalent to 2m < 2^k — i.e. exactly Erdős's m < 2^(k-1) — independent of p. The proof rewrites 2·(1/2)^k = 2/2^k, then applies div_lt_one (with 2^k > 0 from positivity) to turn the real inequality into the integer threshold, closing with linarith. No choice of flip rate p raises the bound above 2^(k-1), so any genuine Radhakrishnan–Srinivasan √(k/log k) gain must come from the conditional, order-dependent recoloring that this product model provably cannot express.",
+    "mathContext": "$m\\cdot\\mathrm{monoIndep}(k,p) < 1 \\iff 2m < 2^k \\iff m < 2^{k-1}.$",
+    "significance": "critical",
+    "relatedConcepts": ["first-moment threshold", "div_lt_one", "positivity", "Erdős m < 2^(k-1)", "isolating the conditional model"],
+    "prerequisites": ["div_lt_one", "linarith", "the threshold form of the probabilistic method"]
+  }
+]

--- a/src/data/proofs/property-b-first-moment-oq-03-oq-03/index.ts
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PropertyBFirstMomentIndepRecoloring.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const propertyBFirstMomentOq03Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const propertyBFirstMomentOq03Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const propertyBFirstMomentOq03Oq03Data: ProofData = {
+  proof: propertyBFirstMomentOq03Oq03Proof,
+  annotations: propertyBFirstMomentOq03Oq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `property-b-first-moment-oq-03-oq-03`.

## Gaps addressed
Rich `meta.json` (15 KB, within caps) but **missing both `index.ts` and `annotations.json`** — without `index.ts` the proof page renders "proof not found" on the live site.

## Changes
- **Created `index.ts`** (required Vite entry point) so the page loads.
- **Created `annotations.json`** with 6 substantive annotations spanning the full Lean file:
  1. Overview — the ORIENT framing (independent recoloring is provably inert)
  2. The real-valued first-moment model definitions (`vertexFinalProb`, `monoIndep`, `monoOneStage`)
  3. `vertexFinalProb_eq_half` — the XOR-with-uniform collapse
  4. `monoIndep_eq_oneStage` + `monoOneStage_eq_zpow` — monochromatic prob is the Erdős value $2^{1-k}$ for every $p$
  5. `expMono_indep_const` — flip-rate-invariant expected monochromatic-edge count
  6. `threshold_indep` — the quantitative punchline: threshold stays $m < 2^{k-1}$
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
- `meta.json` size check: within all caps.
- `annotations:build` validator: entry is clean (0 errors).
- JSON parses; schema matches `Annotation` type.
- (Full `tsc`/`vite build` blocked in-worktree by a `better-sqlite3` native-build incompatibility with node v26 — environment issue, unrelated to this change.)

Dedicated per-target branch (not the shared `feature/enricher-1`) to avoid clobbering sibling enrichment PR #31543.