### PR TITLE
research(erdos-1110-oq-01): give minSummandBound base content — minSummandBound 1 = 1 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1110Problem.lean
+++ b/proofs/Proofs/Erdos1110Problem.lean
@@ -1014,6 +1014,48 @@ noncomputable def minSummandBound (n : ℕ) : ℝ :=
   sSup {f : ℝ | ∃ S : Finset ℕ, (∀ s ∈ S, IsPowerForm 3 2 s ∧ (s : ℝ) > f) ∧
     NoOneDividesAnother S ∧ S.sum id = n}
 
+/--
+**Base value `minSummandBound 1 = 1`.**  Gives the scaffolding definition `minSummandBound`
+concrete content at `n = 1`.  The only antichain of power-forms summing to `1` is `{1}`
+itself: every power-form `3ᵏ2ˡ ≥ 1`, so a subset summing to `1` must be the singleton `{1}`.
+Hence the witness set `{f | ∃ S, … ∧ ∑S = 1}` is exactly `{f | f < 1} = Iio 1` (the strict
+bound `s > f` becomes `1 > f`), whose supremum is `1` by `csSup_Iio`.  So the largest
+summand-size threshold achievable at `n = 1` is the value of the unique summand, `1`. -/
+theorem minSummandBound_one : minSummandBound 1 = 1 := by
+  have heq : minSummandBound 1 = sSup (Set.Iio (1 : ℝ)) := by
+    unfold minSummandBound
+    congr 1
+    ext f
+    simp only [Set.mem_setOf_eq, Set.mem_Iio]
+    constructor
+    · rintro ⟨S, hpow, _, hsum⟩
+      -- the witness sums to 1, so it is nonempty and contains a power-form ≤ 1, forcing 1
+      have hne : S.Nonempty := by
+        rw [Finset.nonempty_iff_ne_empty]; rintro rfl; simp at hsum
+      obtain ⟨s, hs⟩ := hne
+      have h1le : 1 ≤ s := by
+        obtain ⟨k, l, hkl⟩ := (hpow s hs).1
+        rw [hkl]
+        have : 0 < 3 ^ k * 2 ^ l := by positivity
+        omega
+      have hle1 : s ≤ 1 := by
+        have hsingle : id s ≤ S.sum id :=
+          Finset.single_le_sum (f := id) (fun i _ => Nat.zero_le i) hs
+        rw [hsum] at hsingle
+        simpa using hsingle
+      have hs1 : s = 1 := le_antisymm hle1 h1le
+      have hgt := (hpow s hs).2
+      rw [hs1] at hgt; simpa using hgt
+    · intro hf
+      refine ⟨{1}, ?_, ?_, ?_⟩
+      · intro s hs
+        rw [Finset.mem_singleton] at hs; subst hs
+        exact ⟨⟨0, 0, by norm_num⟩, by simpa using hf⟩
+      · intro a ha b hb hab
+        rw [Finset.mem_singleton] at ha hb; subst ha; subst hb; exact absurd rfl hab
+      · simp
+  rw [heq, csSup_Iio]
+
 /-
 **Yu-Chen bounds (2022):**
 n / (log n)^{log₂ 3} ≪ f(n) ≪ n / log n

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -61,12 +61,13 @@
       "Yu-Chen coprime infinite theorem",
       "Minimum summand bounds (Yu-Chen, Yang-Zhao)",
       "example_1_representable theorem with constructive proof",
-      "Connections to Problems #123, #845, #246"
+      "Connections to Problems #123, #845, #246",
+      "minSummandBound_one: minSummandBound 1 = 1 (0-axiom) — gives the previously-unused minSummandBound scaffolding concrete content; the only power-form antichain summing to 1 is {1}, so the witness set is Iio 1 with supremum 1 (csSup_Iio)"
     ],
     "axiomCount": 1,
-    "lineCount": 951,
+    "lineCount": 1139,
     "assumptions": "1 axiom: erdos_lewin_infinite (Erdős-Lewin 1996, deep forward direction: {p,q}≠{2,3} ⟹ infinitely many non-representable numbers). The backward direction ({2,3} ⟹ finite, in fact NonRepresentable = {0}) is proved unconditionally (finite_nonRepresentable_of_two_three), and the EXISTENCE of a positive non-representable for every other coprime pair is also proved unconditionally (exists_positive_nonRepresentable_of_ne_two_three) — only the infinitude itself remains axiomatized.",
-    "theoremCount": 39,
+    "theoremCount": 40,
     "definitionCount": 7
   },
   "overview": {
@@ -262,9 +263,9 @@
       "Finset"
     ],
     "namespace": "Erdos1110",
-    "lineCount": 1090,
+    "lineCount": 1139,
     "axiomCount": 1,
-    "theoremCount": 51,
+    "theoremCount": 52,
     "definitionCount": 7,
     "path": "Proofs/Erdos1110Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1110-oq-01.json
+++ b/src/data/research/problems/erdos-1110-oq-01.json
@@ -33,7 +33,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S6): proved multiplicative closure of representability (×p, ×q, ×p^a q^b) and downward non-rep propagation, 0-axiom — structural generalization of the {2,3} doubling. Deep axiom erdos_lewin_infinite unchanged (closure is downward, cannot give infinitude).",
+    "progressSummary": "2026-06-30 (researcher-3): gave the unused minSummandBound scaffolding concrete content — proved minSummandBound_one (minSummandBound 1 = 1, 0-axiom): the only power-form antichain summing to 1 is {1}, so the witness set is Iio 1 with supremum 1 (csSup_Iio). File 0-sorry, 1-axiom (erdos_lewin_infinite unchanged). PR pending. PROGRESS (S6): proved multiplicative closure of representability (×p, ×q, ×p^a q^b) and downward non-rep propagation, 0-axiom — structural generalization of the {2,3} doubling. Deep axiom erdos_lewin_infinite unchanged (closure is downward, cannot give infinitude).",
     "builtItems": [
       "add_one_nonRepresentable_iff (iter 5, researcher-8, 0-axiom): sharp criterion for the canonical candidate q+1. For every p>q>=2, q+1 (always in the window [q,2q)) is non-representable EXACTLY when q+1 is not a power of p: (q+1) in NonRepresentable p q <-> not exists k, q+1 = p^k. Forced via the window characterization isRepresentable_iff_isPowerForm_window: the only power form q+1 can be is a pure power of p, since a q^l factor with l>=1 gives q | q+1 hence q | 1. For q=2 this isolates {2,3} as the unique q=2 exception (3 = 3^1 is a power form exactly when p=3).",
       "add_one_nonRepresentable_of_lt (iter 5, researcher-8, 0-axiom): if q>=2 and q+1 < p (i.e. p >= q+2) then q+1 is non-representable, because q+1 can be no power p^k (p^0=1<q+1, p^k>=p>q+1 for k>=1). Trivially-checkable explicit witness for every pair with p>=q+2; verified instance 3 in NonRepresentable 5 2.",
@@ -54,7 +54,8 @@
       "isRepresentable_mul_base_left/right: representability closed under ×p and ×q (Erdos1110Problem.lean) — scale antichain by a base, 0-axiom",
       "isRepresentable_mul_powerForm: representable set closed under ×(p^a q^b), the full power-form monoid action generalizing the {2,3} doubling step, 0-axiom",
       "nonRepresentable_of_mul_powerForm: non-representability propagates DOWNWARD to power-form divisors (contrapositive of closure), 0-axiom",
-      "Helpers noOneDividesAnother_image_mul_const / mul_const_injOn / sum_image_mul_const: c>0 generalizations of the c=2 doubling helpers"
+      "Helpers noOneDividesAnother_image_mul_const / mul_const_injOn / sum_image_mul_const: c>0 generalizations of the c=2 doubling helpers",
+      "minSummandBound_one: minSummandBound 1 = 1 (0-axiom) via witness-set = Iio 1 + csSup_Iio (Erdos1110Problem.lean)"
     ],
     "insights": [
       "The deep infinitude axiom has an elementary EXISTENCE shadow: every non-{2,3} coprime pair has a SMALL universal non-representable witness — 2 when q>=3, 3 when q=2. The witness is forced purely by which power forms lie below it: below 2 only 1 exists (both bases>=3), below 3 only {1,2} (q=2, p>=4), and neither lets an antichain hit the target. The (3,2) pair is exactly the exception because there 3=3^1 IS a power form.",
@@ -75,7 +76,7 @@
     ],
     "nextSteps": [
       "Deep direction erdos_lewin_infinite (Erdos-Lewin 1996) remains the sole axiom; confirmed across 6 sessions as not session-sized and genuinely upward (closure cannot help).",
-      "minSummandBound is still unused scaffolding — give it content (e.g. minSummandBound 1 = 1 via sSup of Iio 1) or remove it.",
+      "minSummandBound now has base content: minSummandBound_one (minSummandBound 1 = 1, 0-axiom) proves the witness set at n=1 is Iio 1 (only {1} sums to 1) with sSup 1 via csSup_Iio. Next: a general lower bound minSummandBound n ≥ 1 for n ≥ 1, or the Yu-Chen asymptotic f(n) ≍ n/log n (deep).",
       "Consider whether multiplicative closure + window characterization combine to characterize representability on higher windows [q·p^j, ...)."
     ]
   },
@@ -97,14 +98,14 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.134Z",
-  "lastUpdate": "2026-06-28T11:10:00.000Z",
+  "lastUpdate": "2026-06-30T00:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1110Problem.lean",
       "filename": "Erdos1110Problem.lean",
-      "lineCount": 1097,
+      "lineCount": 1139,
       "theoremCount": 34,
       "axiomCount": 1,
       "defCount": 7,


### PR DESCRIPTION
## Summary

The `minSummandBound` definition in the Erdős #1110 formalization was flagged across several sessions as **unused scaffolding** (next-step: "give it content or remove it"). This PR gives it concrete content at the base case:

```lean
theorem minSummandBound_one : minSummandBound 1 = 1
```

## Why it holds

`minSummandBound n = sSup {f | ∃ S, (∀ s ∈ S, IsPowerForm 3 2 s ∧ s > f) ∧ NoOneDividesAnother S ∧ ∑S = n}`.

At `n = 1`: every power-form `3ᵏ2ˡ ≥ 1`, and any element of a Finset is `≤` its sum (`Finset.single_le_sum`), so a subset summing to `1` must consist of a single element equal to `1` — the witness `S = {1}`. The strict threshold `s > f` then reads `1 > f`, so the witness set is exactly `Set.Iio 1`, whose supremum is `1` (`csSup_Iio`). Interpretation: the largest summand-size threshold achievable at `n = 1` is the value of the unique summand.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos1110Problem` → **Build succeeded** (Mathlib 4.26).
- The new lemma is **0-axiom** (uses `csSup_Iio`, `Finset.single_le_sum`). File status unchanged: **0 sorries, 1 axiom** (`erdos_lewin_infinite`, the deep Erdős–Lewin 1996 input — untouched).

Gallery `meta.json` (line count + theorem count + contribution) and the research problem registry (`nextSteps`, `builtItems`, `progressSummary`) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)