### PR TITLE
Enrich θ ∼ x ⟺ π ∼ x/log x (Chebyshev–PNT form): add index.ts + annotations

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-03-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-cb0301-overview",
+    "proofId": "chebyshev-bounds-oq-03-oq-01",
+    "range": { "startLine": 6, "endLine": 39 },
+    "type": "concept",
+    "title": "The θ–π Form of the Prime Number Theorem",
+    "content": "PNT has three classical equivalent forms: ψ(x) ∼ x, θ(x) ∼ x, and π(x) ∼ x/log x, where θ(x) = Σ_{p≤x} log p, ψ(x) = Σ_{p^k≤x} log p, and π(x) counts primes ≤ x. The parent entry proved ψ ∼ θ; this file closes its first open question, the link θ(x) ∼ x ⟺ π(x) ∼ x/log x between a log-weighted prime sum and a plain prime count. Crucially it avoids Abel/partial summation in favour of the elementary two-inequality argument (Apostol Thm 4.4), which formalizes far more cleanly and uses only Chebyshev-level estimates — no zeta function, no contour integration.",
+    "mathContext": "$\\psi(x)\\sim x \\iff \\theta(x)\\sim x \\iff \\pi(x)\\sim \\dfrac{x}{\\log x}$, with $\\theta(x)=\\sum_{p\\le x}\\log p$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Prime Number Theorem", "Chebyshev functions θ and ψ", "prime-counting function π", "asymptotic equivalence", "elementary number theory"],
+    "prerequisites": ["Chebyshev's prime-sum functions", "asymptotic equivalence f/g → 1", "the parent ψ ∼ θ result"]
+  },
+  {
+    "id": "ann-cb0301-bridge",
+    "proofId": "chebyshev-bounds-oq-03-oq-01",
+    "range": { "startLine": 46, "endLine": 63 },
+    "type": "definition",
+    "title": "Identifying θ's Support with the Primes π Counts",
+    "content": "primeCountingReal x casts Mathlib's Nat.primeCounting ⌊x⌋₊ to a real so θ and π live in the same ordered field. theta_eq_sum rewrites Chebyshev.theta as an explicit sum of log p over the primes in (0, ⌊x⌋]. card_filter_prime_Ioc is the structural bridge: the cardinality of (Ioc 0 n).filter Prime equals Nat.primeCounting n, proved by transporting through primesBelow_card_eq_primeCounting' and matching the membership predicates p ≤ n ∧ p prime. This lets the log-weighted sum (θ) and the count (π) be compared term-for-term on a common index set.",
+    "mathContext": "$\\#\\big((0,n]\\cap\\mathbb{P}\\big) = \\pi(n),\\qquad \\theta(x)=\\sum_{p\\in(0,\\lfloor x\\rfloor]\\cap\\mathbb{P}}\\log p.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.primeCounting", "primesBelow", "Finset.filter", "floor function ⌊x⌋₊"],
+    "prerequisites": ["Mathlib Chebyshev/PrimeCounting API", "Finset cardinality", "real casts of naturals"]
+  },
+  {
+    "id": "ann-cb0301-lemma-a",
+    "proofId": "chebyshev-bounds-oq-03-oq-01",
+    "range": { "startLine": 65, "endLine": 81 },
+    "type": "theorem",
+    "title": "Lemma A — The Easy Inequality θ(x) ≤ π(x)·log x",
+    "content": "theta_le_primeCounting_mul_log: bounding each summand log p ≤ log x (since every prime p ≤ x) and summing over the π(x) primes gives θ(x) ≤ π(x)·log x for x ≥ 1. The Lean proof uses Finset.sum_le_sum with the per-term bound Real.log_le_log, then collapses the constant sum via sum_const / nsmul_eq_mul. This is the trivial half of the sandwich — the entire mathematical content lives in the reverse inequality (Lemma B).",
+    "mathContext": "$\\theta(x)=\\sum_{p\\le x}\\log p \\le \\sum_{p\\le x}\\log x = \\pi(x)\\log x.$",
+    "significance": "key",
+    "relatedConcepts": ["monotonicity of log", "Finset.sum_le_sum", "constant-term sum", "upper bracketing"],
+    "prerequisites": ["Real.log_le_log", "summing a constant over a Finset"]
+  },
+  {
+    "id": "ann-cb0301-lemma-b",
+    "proofId": "chebyshev-bounds-oq-03-oq-01",
+    "range": { "startLine": 83, "endLine": 155 },
+    "type": "theorem",
+    "title": "Lemma B — The Hard Inequality via Splitting at x^α",
+    "content": "primeCounting_le: for 0 < α < 1, π(x) ≤ x^α + θ(x)/(α·log x). The primes in (0, ⌊x⌋] are split at m = ⌊x^α⌋ into a head (Ioc 0 m) and tail (Ioc m N), disjoint with union the whole set (Ioc_union_Ioc_eq_Ioc). The head is bounded crudely: at most m ≤ x^α primes. For the tail, each prime p > x^α has log p > log(x^α) = α·log x (the key step, via Real.log_rpow and log monotonicity), so multiplying the tail count by α·log x is dominated by Σ log p over the tail ≤ θ(x); dividing (le_div_iff₀) bounds the tail count by θ(x)/(α·log x). Adding head and tail and casting (push_cast) yields the inequality. This is where the splitting parameter α first appears — it trades head size (x^α) against the log-threshold (α·log x).",
+    "mathContext": "$\\pi(x)=\\underbrace{\\pi(x^\\alpha)}_{\\le\\, x^\\alpha} + \\#\\{x^\\alpha<p\\le x\\},\\quad \\#\\{x^\\alpha<p\\le x\\}\\cdot(\\alpha\\log x)\\le\\theta(x).$",
+    "significance": "critical",
+    "relatedConcepts": ["dyadic-style splitting", "Real.log_rpow", "Finset.Ioc partition", "le_div_iff₀", "head/tail decomposition"],
+    "prerequisites": ["rpow and log_rpow", "disjoint Finset unions", "Finset.sum_le_sum_of_subset_of_nonneg"]
+  },
+  {
+    "id": "ann-cb0301-error-decay",
+    "proofId": "chebyshev-bounds-oq-03-oq-01",
+    "range": { "startLine": 171, "endLine": 200 },
+    "type": "insight",
+    "title": "The Error Term log x · x^(α−1) → 0 and the Sandwich",
+    "content": "Dividing both lemmas by x and writing f(x) = θ(x)/x, g(x) = π(x)·log x/x gives f ≤ g ≤ E_α + (1/α)·f, where E_α(x) = log x · x^α / x = log x · x^(α−1). The single analytic input is E_α → 0, proved from isLittleO_log_rpow_atTop with exponent 1−α > 0 (log x = o(x^(1−α))) via tendsto_div_nhds_zero and an rpow_sub rewrite. So the two normalized counting functions are trapped within a multiplicative factor 1/α of each other, with a vanishing additive error — the sandwich that the limit α → 1 will collapse.",
+    "mathContext": "$f\\le g\\le \\underbrace{\\log x\\cdot x^{\\alpha-1}}_{\\to 0} + \\tfrac1\\alpha f,\\qquad \\log x = o(x^{1-\\alpha}).$",
+    "significance": "key",
+    "relatedConcepts": ["little-o asymptotics", "log grows slower than any power", "isLittleO_log_rpow_atTop", "bracketing within factor 1/α"],
+    "prerequisites": ["Asymptotics.IsLittleO", "Filter.Tendsto", "rpow_sub"]
+  },
+  {
+    "id": "ann-cb0301-main",
+    "proofId": "chebyshev-bounds-oq-03-oq-01",
+    "range": { "startLine": 201, "endLine": 248 },
+    "type": "theorem",
+    "title": "Main Theorem — Taking α → 1 via the Order Topology",
+    "content": "theta_asymp_iff_primeCounting_asymp proves both directions of θ(x)/x → 1 ⟺ π(x)·log x/x → 1. The crux is the limit α → 1, handled not by limsup/liminf bookkeeping but by tendsto_order: a function tends to 1 iff it eventually exceeds every b < 1 and stays below every b > 1. For each target neighbourhood the proof picks a single α: the forward (upper) direction uses α = 2/(1+b) so that 1/α < b, the reverse (lower) direction uses α = (max 0 b + 1)/2 so that b < α. Each choice makes the factor 1/α close enough to 1 that the sandwich forces the second function past the threshold b, closing as lt_of_le_of_lt / nlinarith. This bracketing-with-a-chosen-α is the formalization-friendly substitute for 'let α → 1'.",
+    "mathContext": "$f\\to 1 \\iff \\big(\\forall b<1,\\ f\\text{ eventually}>b\\big)\\wedge\\big(\\forall b>1,\\ f\\text{ eventually}<b\\big)$; pick $\\alpha=\\tfrac{2}{1+b}$ or $\\tfrac{\\max(0,b)+1}{2}$.",
+    "significance": "critical",
+    "relatedConcepts": ["order-topology limits", "tendsto_order", "two-sided bracketing", "choosing α per neighbourhood", "nlinarith closing"],
+    "prerequisites": ["tendsto_order in a linear order topology", "Filter.eventually / filter_upwards", "limit arithmetic (const_mul, add, sub)"]
+  }
+]

--- a/src/data/proofs/chebyshev-bounds-oq-03-oq-01/index.ts
+++ b/src/data/proofs/chebyshev-bounds-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevBoundsOQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevBoundsOq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevBoundsOq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevBoundsOq03Oq01Data: ProofData = {
+  proof: chebyshevBoundsOq03Oq01Proof,
+  annotations: chebyshevBoundsOq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `chebyshev-bounds-oq-03-oq-01`.

## Gaps addressed
Rich `meta.json` (13 KB, within caps) but **missing both `index.ts` and `annotations.json`** — without `index.ts` the proof page renders "proof not found" on the live site.

## Changes
- **Created `index.ts`** (required Vite entry point) so the page loads.
- **Created `annotations.json`** with 6 substantive annotations spanning the full Lean file:
  1. Overview — the three equivalent PNT forms and the elementary (Apostol Thm 4.4) route
  2. `card_filter_prime_Ioc` / `theta_eq_sum` — identifying θ's support with the primes π counts
  3. Lemma A `theta_le_primeCounting_mul_log` — the easy inequality $\theta \le \pi\log x$
  4. Lemma B `primeCounting_le` — the hard inequality via splitting the primes at $x^\alpha$
  5. The error term $\log x\cdot x^{\alpha-1}\to 0$ and the resulting sandwich
  6. Main theorem `theta_asymp_iff_primeCounting_asymp` — the $\alpha\to 1$ limit via `tendsto_order`
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
- `meta.json` size check: within all caps.
- `annotations:build` validator: entry is clean (0 errors).
- JSON parses; schema matches `Annotation` type.
- (Full `tsc`/`vite build` blocked in-worktree by a `better-sqlite3` native-build incompatibility with node v26 — environment issue, unrelated to this change.)

Dedicated per-target branch to avoid clobbering sibling enrichment PRs.