### PR TITLE
Enrich De Moivre OQ: the DFT has order four (U⁴ = 1) — add index.ts + annotations

### DIFF
--- a/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-dm0301-overview",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "The DFT Has Order Four — Discrete Shadow of 𝓕⁴ = id",
+    "content": "One of the Fourier transform's most striking structural facts: suitably normalized, the continuous transform satisfies 𝓕⁴ = id with 𝓕² the parity operator f(x) ↦ f(−x). The discrete Fourier transform inherits this exactly. The grandparent entry built the normalized DFT matrix U(j,k) = exp(2πi·jk/n)/√n and proved it unitary; its third open question packaged U as an isometry of ℂⁿ. This entry computes U's order: U² = R (the index-reflection/reversal permutation R(j,l) = [j+l ≡ 0 mod n]) and R² = 1, hence U⁴ = 1. The order-four law forces the DFT spectrum into the fourth roots of unity {1, −1, i, −i} and underlies the discrete Hermite–Gaussian eigenbases of signal processing. The whole proof runs over the grandparent's sampling kernel char — no Mathlib Fourier or representation theory is used.",
+    "mathContext": "$U^2 = R,\\ U^4 = 1$ where $U(j,k)=\\dfrac{e^{2\\pi i jk/n}}{\\sqrt n}$ and $R(j,l)=[\\,j+l\\equiv 0 \\bmod n\\,]$; the discrete analogue of $\\mathcal F^4=\\mathrm{id}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["discrete Fourier transform", "order of a unitary", "parity / reversal operator", "fourth roots of unity", "Hermite eigenfunctions"],
+    "prerequisites": ["the grandparent unitary DFT matrix", "roots of unity", "permutation matrices"]
+  },
+  {
+    "id": "ann-dm0301-char-mul",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 51, "endLine": 60 },
+    "type": "theorem",
+    "title": "Kernel Multiplicativity char(j,k)·char(k,l) = char(j+l,k)",
+    "content": "char_mul: the sampling kernel char n j k = exp(2πi·jk/n) multiplies by adding exponents in the frequency index — exp(2πi·jk/n)·exp(2πi·kl/n) = exp(2πi·(j+l)k/n). This is the algebraic engine behind U² = R: when the (j,l) entry of U² is expanded as a sum over the intermediate index k, the two kernels char(j,k) and char(k,l) telescope into the single kernel char(j+l,k), reducing the double structure to one geometric sum. Proof: simp with exp_add, then push_cast + ring on the exponent.",
+    "mathContext": "$e^{2\\pi i jk/n}\\,e^{2\\pi i kl/n}=e^{2\\pi i (j+l)k/n}$, i.e. $\\mathrm{char}(j,k)\\,\\mathrm{char}(k,l)=\\mathrm{char}(j{+}l,k)$.",
+    "significance": "key",
+    "relatedConcepts": ["exponential addition law", "DFT sampling kernel", "telescoping the inner sum"],
+    "prerequisites": ["Complex.exp_add", "ring normalization of exponents"]
+  },
+  {
+    "id": "ann-dm0301-char-mod",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 62, "endLine": 82 },
+    "type": "theorem",
+    "title": "Kernel n-Periodicity from ζⁿ = 1",
+    "content": "char_mod: char(m,k) = char(m mod n, k). Writing char(m,k) = ζ^m for the root of unity ζ = exp(2πi·k/n), periodicity is exactly ζⁿ = exp(2πi·k) = 1 (Complex.exp_nat_mul_two_pi_mul_I). The Lean proof recasts char as a power via exp_nat_mul, splits the exponent m = n·(m/n) + m%n (Nat.div_add_mod), and kills the n·(m/n) part with ζⁿ = 1 (pow_mul + one_pow). This reduction to a residue is what makes the geometric sum below depend only on m mod n.",
+    "mathContext": "$\\mathrm{char}(m,k)=\\zeta^m,\\ \\zeta=e^{2\\pi i k/n},\\ \\zeta^n=e^{2\\pi i k}=1\\ \\Rightarrow\\ \\mathrm{char}(m,k)=\\mathrm{char}(m\\bmod n,k).$",
+    "significance": "key",
+    "relatedConcepts": ["n-th roots of unity", "ζⁿ = 1", "Euclidean division of the exponent", "periodicity"],
+    "prerequisites": ["Complex.exp_nat_mul", "Complex.exp_nat_mul_two_pi_mul_I", "Nat.div_add_mod"]
+  },
+  {
+    "id": "ann-dm0301-sum-char",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 84, "endLine": 99 },
+    "type": "theorem",
+    "title": "The Geometric / Orthogonality Sum ∑ char = n·[n ∣ m]",
+    "content": "sum_char: ∑_{k<n} char(m,k) = n if n ∣ m, else 0. When m ≡ 0 (mod n) the kernel is identically 1 and the sum is n; otherwise the n distinct n-th roots of unity sum to zero. Rather than re-prove the root-of-unity vanishing, this reuses the great-grandparent's character orthonormality char_inner specialised at the trivial character b = 0 (where conj(char(0,k)) = 1), after reducing m mod n via char_mod. This is the discrete orthogonality that collapses U²'s inner sum to the reflection condition.",
+    "mathContext": "$\\sum_{k<n}\\mathrm{char}(m,k)=\\begin{cases}n & n\\mid m\\\\ 0 & \\text{else}\\end{cases}$, from $\\mathrm{char\\_inner}$ at the trivial character.",
+    "significance": "critical",
+    "relatedConcepts": ["orthogonality of characters", "sum of roots of unity = 0", "trivial character specialization", "char_inner"],
+    "prerequisites": ["char_mod", "grandparent char_inner orthonormality"]
+  },
+  {
+    "id": "ann-dm0301-sq-refl",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 101, "endLine": 131 },
+    "type": "theorem",
+    "title": "U² Is the Index Reflection (U² = R)",
+    "content": "reflMatrix defines R(j,l) = [j+l ≡ 0 mod n], the permutation matrix of the reversal k ↦ −k mod n. dftMatrix_sq proves U·U = R: entry (j,l) is (1/n)∑_{k<n} char(j,k)·char(k,l); char_mul fuses the kernels into char(j+l,k), the two 1/√n normalizations combine to 1/n (Real.mul_self_sqrt), and sum_char collapses the sum to n·[j+l ≡ 0]/n = [j+l ≡ 0 mod n] = R(j,l). So applying the DFT twice reverses a sequence — the discrete parity operator.",
+    "mathContext": "$U^2(j,l)=\\tfrac1n\\sum_{k<n}\\mathrm{char}(j{+}l,k)=[\\,j+l\\equiv 0\\bmod n\\,]=R(j,l).$",
+    "significance": "critical",
+    "relatedConcepts": ["reversal permutation matrix", "Matrix.mul_apply", "1/√n normalization", "discrete parity"],
+    "prerequisites": ["char_mul", "sum_char", "Real.mul_self_sqrt", "Fin.sum_univ_eq_sum_range"]
+  },
+  {
+    "id": "ann-dm0301-refl-involution",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 133, "endLine": 157 },
+    "type": "theorem",
+    "title": "Reflection Is Involutive (R² = 1) via the Group Fin n",
+    "content": "reflMatrix_mul_self: reversing twice is the identity. The cleanest route avoids fiddly Nat.mod arithmetic by working in the additive group Fin n: the condition (j+m) % n = 0 is exactly m = −j (hcond, via Fin.val_add and neg_eq_of_add_eq_zero_right). So in the double sum (R·R)(j,l) = ∑_m R(j,m)·R(m,l) only the single term m = −j survives (Finset.sum_eq_single), and it contributes 1 iff (−j)+l ≡ 0, i.e. l = j — exactly the identity matrix. This reframing of a modular count as a group uniqueness statement is the key simplification.",
+    "mathContext": "$(j+m)\\equiv 0 \\bmod n \\iff m=-j$ in $\\mathrm{Fin}\\,n$; unique survivor $m=-j$ gives $R^2=1$.",
+    "significance": "key",
+    "relatedConcepts": ["involution", "additive group Fin n", "Finset.sum_eq_single", "permutation matrix square"],
+    "prerequisites": ["Fin.val_add", "neg_eq_of_add_eq_zero_right", "Finset.sum_eq_single"]
+  },
+  {
+    "id": "ann-dm0301-order-four",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 159, "endLine": 193 },
+    "type": "theorem",
+    "title": "Order Exactly Four: U⁴ = 1 and (n ≥ 3) U² ≠ 1",
+    "content": "dftMatrix_pow_four chains the pieces: U⁴ = (U²)² = R² = 1. Sharpness is genuine and needs n ≥ 3: reflMatrix_ne_one shows R(1,1) = [2 ≡ 0 mod n] = 0 ≠ 1 (since 2 < n), so dftMatrix_sq_ne_one gives U² ≠ 1 and the order is exactly four. The n ≥ 3 hypothesis is necessary — for n = 1 the DFT is the identity (order 1) and for n = 2 reversal fixes every index (R = 1, order 2). This completes the de-moivre DFT family: the order statement sitting beside unitarity and isometry, and the operator fact behind the DFT's four-element power cycle {1, U, R, UR}.",
+    "mathContext": "$U^4=(U^2)^2=R^2=1$; for $n\\ge 3$, $R(1,1)=[2\\equiv 0\\bmod n]=0\\ne 1\\Rightarrow U^2\\ne 1\\Rightarrow \\mathrm{ord}(U)=4.$",
+    "significance": "critical",
+    "relatedConcepts": ["order of a group element", "sharpness / nontriviality", "power cycle {1, U, R, UR}", "DFT spectrum"],
+    "prerequisites": ["dftMatrix_sq", "reflMatrix_mul_self", "pow_mul / pow_two", "Nat.mod_eq_of_lt"]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01/index.ts
+++ b/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DeMoivreOQ05OQ01OQ01OQ01OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const deMoivreOq05Oq01Oq01Oq01Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const deMoivreOq05Oq01Oq01Oq01Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const deMoivreOq05Oq01Oq01Oq01Oq03Oq01Data: ProofData = {
+  proof: deMoivreOq05Oq01Oq01Oq01Oq03Oq01Proof,
+  annotations: deMoivreOq05Oq01Oq01Oq01Oq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01`.

## Gaps addressed
Rich `meta.json` (17 KB, within caps) but **missing both `index.ts` and `annotations.json`** — without `index.ts` the proof page renders "proof not found" on the live site.

## Changes
- **Created `index.ts`** (required Vite entry point) so the page loads.
- **Created `annotations.json`** with 7 substantive annotations spanning the full Lean file:
  1. Overview — order four as the discrete shadow of $\mathcal F^4 = \mathrm{id}$
  2. `char_mul` — kernel multiplicativity, the engine that telescopes U²'s inner sum
  3. `char_mod` — n-periodicity from $\zeta^n = 1$
  4. `sum_char` — the geometric/orthogonality sum $\sum \mathrm{char} = n[n\mid m]$
  5. `dftMatrix_sq` — $U^2 = R$, the index reflection / discrete parity
  6. `reflMatrix_mul_self` — $R^2 = 1$ via the additive group $\mathrm{Fin}\,n$
  7. `dftMatrix_pow_four` + sharpness — order exactly four for $n \ge 3$
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
- `meta.json` size check: within all caps.
- `annotations:build` validator: entry is clean (0 errors).
- JSON parses; schema matches `Annotation` type.
- (Full `tsc`/`vite build` blocked in-worktree by a `better-sqlite3` native-build incompatibility with node v26 — environment issue, unrelated to this change.)

Dedicated per-target branch to avoid clobbering sibling enrichment PRs.