### PR TITLE
research(fermat-defect-one-oq-06): gallery integration for the sign-flip involution [VERIFIED, 0-axiom]

### DIFF
--- a/src/data/proofs/fermat-defect-one-oq-06/annotations.json
+++ b/src/data/proofs/fermat-defect-one-oq-06/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-fdo06-overview",
+    "proofId": "fermat-defect-one-oq-06",
+    "range": { "startLine": 1, "endLine": 66 },
+    "type": "concept",
+    "title": "The Sign-Flip Question (OQ-06)",
+    "content": "The parent defect-one conjecture asks whether |aⁿ + bⁿ - cⁿ| = 1 is always realisable for n ≥ 3. At n = 3 both signs occur: a negative-defect benchmark (6,8,9) with 6³+8³+1=9³ and a positive-defect benchmark (9,10,12) with 9³+10³=12³+1, each extended to an infinite Mahler family. OQ-06 asks the symmetry question: is there a structural map exchanging the two signs? The answer here is an explicit involution Ψ(a,b,c) = (c,-b,a). Working over ℤ is essential — it makes the defect a single signed quantity, so 'flip the sign' is one linear map rather than a Nat case split.",
+    "mathContext": "$\\Psi(a,b,c) = (c,-b,a)$ on $\\mathbb{Z}^3$, with $\\Psi \\circ \\Psi = \\mathrm{id}$ and $a'^3 + b'^3 - c'^3 = -(a^3 + b^3 - c^3)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fermat defect-one conjecture", "involution", "sign symmetry", "Mahler families", "taxicab numbers"],
+    "prerequisites": ["the parent defect-one entry", "integer Fermat defect a^n+b^n-c^n"]
+  },
+  {
+    "id": "ann-fdo06-signflip-def",
+    "proofId": "fermat-defect-one-oq-06",
+    "range": { "startLine": 78, "endLine": 86 },
+    "type": "definition",
+    "title": "The Involution Ψ(a,b,c) = (c,-b,a)",
+    "content": "signFlip is the structural map OQ-06 asks for. Its shape is forced by the cubic: to send a³+b³-c³ to its negative you need c³ to become the leading +term and a³ the -term, so a and c swap; and the middle term must keep magnitude but the whole sum must flip, which is achieved by negating b (harmless at odd exponents). signFlip_involutive proves Ψ ∘ Ψ = id in one line by simp: (a,b,c) ↦ (c,-b,a) ↦ (a,-(-b),c) = (a,b,c). Being an order-2 map, Ψ partitions the solution set into orbits of size ≤ 2, pairing each negative-defect solution with a positive-defect one.",
+    "mathContext": "$\\Psi(a,b,c) = (T_3, -T_2, T_1)$ with $\\Psi(\\Psi(T)) = T$ for all $T \\in \\mathbb{Z}^3$.",
+    "significance": "key",
+    "relatedConcepts": ["involution", "order-2 map", "orbit pairing"],
+    "prerequisites": ["product types in Lean", "simp normalization"]
+  },
+  {
+    "id": "ann-fdo06-negates-defect",
+    "proofId": "fermat-defect-one-oq-06",
+    "range": { "startLine": 88, "endLine": 111 },
+    "type": "theorem",
+    "title": "Ψ Negates the Cubic Defect",
+    "content": "The headline result. signFlip_negates_defect computes the defect of Ψ(a,b,c) = (c,-b,a) as c³ + (-b)³ - a³ = -(a³ + b³ - c³), a pure ring identity. Negating the defect is precisely the exchange of the two defect equations: signFlip_neg_to_pos turns a negative-defect solution a³+b³+1=c³ into a positive-defect solution a'³+b'³=c'³+1, and signFlip_pos_to_neg goes the other way, each closed by linear_combination -h. So Ψ is a bijection between the negative-defect and positive-defect integer solution sets at n=3.",
+    "mathContext": "$c^3 + (-b)^3 - a^3 = -(a^3+b^3-c^3)$, hence $a^3+b^3+1=c^3 \\iff (\\Psi)\\; a'^3+b'^3 = c'^3+1$.",
+    "significance": "key",
+    "relatedConcepts": ["cubic forms", "Diophantine defect", "ring tactic", "linear_combination"],
+    "prerequisites": ["polynomial identities over ℤ"]
+  },
+  {
+    "id": "ann-fdo06-mahler",
+    "proofId": "fermat-defect-one-oq-06",
+    "range": { "startLine": 113, "endLine": 156 },
+    "type": "theorem",
+    "title": "On the Mahler Families, Ψ is t ↦ -t",
+    "content": "The two gallery families negTriple t = (9t⁴-3t, 9t³-1, 9t⁴) and posTriple t = (9t⁴, 9t³+1, 9t⁴+3t) descend from Mahler's parametrization of x³+y³+z³=1. negTriple_defect and posTriple_defect re-verify the defect equations by ring. The compatibility theorems signFlip_negTriple and signFlip_posTriple prove Ψ(negTriple t) = posTriple(-t) and Ψ(posTriple t) = negTriple(-t) — three ring identities each (one per coordinate). So the abstract involution Ψ restricts on the families to the concrete parameter negation t ↦ -t, identifying the defect sign symmetry with the obvious t ↦ -t symmetry of Mahler's parametrization.",
+    "mathContext": "$\\Psi(\\mathrm{negTriple}\\,t) = \\mathrm{posTriple}(-t)$ and $\\Psi(\\mathrm{posTriple}\\,t) = \\mathrm{negTriple}(-t)$.",
+    "significance": "key",
+    "relatedConcepts": ["Mahler parametrization", "x³+y³+z³=1", "parameter involution", "polynomial families"],
+    "prerequisites": ["the two gallery Mahler families", "Prod injectivity"]
+  },
+  {
+    "id": "ann-fdo06-benchmarks",
+    "proofId": "fermat-defect-one-oq-06",
+    "range": { "startLine": 157, "endLine": 190 },
+    "type": "lemma",
+    "title": "The Taxicab Benchmark as a Sign-Flip Image",
+    "content": "Concrete grounding. negTriple_one = (6,8,9) and posTriple_one = (9,10,12) recover the two gallery benchmarks. signFlip_benchmark computes Ψ(6,8,9) = (9,-8,6), and signFlip_benchmark_pos_defect verifies it is a genuine integer positive-defect solution: 9³+(-8)³ = 6³+1, i.e. 729-512 = 217. taxicab_is_signflip_of_neg then exhibits the canonical positive witness (9,10,12) = posTriple 1 as Ψ(negTriple(-1)) = Ψ(12,-10,9), so the famous taxicab-shift benchmark is structurally the sign-flip of an integer negative-defect point.",
+    "mathContext": "$(9,10,12) = \\mathrm{posTriple}\\,1 = \\Psi(\\mathrm{negTriple}(-1)) = \\Psi(12,-10,9)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["taxicab numbers", "benchmark witnesses", "norm_num"],
+    "prerequisites": ["evaluation of polynomial families at integers"]
+  },
+  {
+    "id": "ann-fdo06-odd",
+    "proofId": "fermat-defect-one-oq-06",
+    "range": { "startLine": 192, "endLine": 240 },
+    "type": "theorem",
+    "title": "A Phenomenon of Every Odd Exponent",
+    "content": "The cubic computation upgrades verbatim to all odd n. signFlip_negates_defect_odd uses Mathlib's Odd.neg_pow to rewrite (-b)ⁿ = -bⁿ, after which ring gives a'ⁿ+b'ⁿ-c'ⁿ = -(aⁿ+bⁿ-cⁿ) for the same Ψ. signFlip_neg_to_pos_odd and signFlip_pos_to_neg_odd give the corresponding exchange of odd-exponent defect solutions. signFlip_negates_defect_three confirms the cubic headline is exactly the n=3 instance (Odd 3 by decide). Oddness is essential: at even n, (-b)ⁿ = +bⁿ, so Ψ would induce an a ↔ c swap, not a sign flip. This ties OQ-06 to the headline 'for all n ≥ 3' conjecture — at any odd n a witness of one sign yields one of the other.",
+    "mathContext": "For odd $n$: $(-b)^n = -b^n$ (Odd.neg_pow) $\\Rightarrow a'^n + b'^n - c'^n = -(a^n + b^n - c^n)$.",
+    "significance": "key",
+    "relatedConcepts": ["odd exponents", "Odd.neg_pow", "exponent-n defect", "even/odd asymmetry"],
+    "prerequisites": ["the identity (-x)^n = -x^n for odd n"]
+  },
+  {
+    "id": "ann-fdo06-summary",
+    "proofId": "fermat-defect-one-oq-06",
+    "range": { "startLine": 242, "endLine": 276 },
+    "type": "theorem",
+    "title": "Packaged Sign-Symmetry Statements",
+    "content": "sign_symmetry bundles, for each t, the two family defect equations together with Ψ(negTriple t)=posTriple(-t) and Ψ(posTriple t)=negTriple(-t) — a single theorem certifying that both signs at n=3 are the two branches of one identity under t ↦ -t. sign_symmetry_odd packages the general-odd-n form: the single involution Ψ is its own inverse and exchanges negative-defect solutions aⁿ+bⁿ+1=cⁿ with positive-defect solutions aⁿ+bⁿ=cⁿ+1 at every odd exponent. Together they are the formal answer to OQ-06: the two defect signs are never independent.",
+    "mathContext": "$\\Psi$ is an involution exchanging $\\{a^n+b^n+1=c^n\\}$ and $\\{a^n+b^n=c^n+1\\}$ for every odd $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sign symmetry", "packaged theorem", "solution-set bijection"],
+    "prerequisites": ["the preceding sections"]
+  }
+]

--- a/src/data/proofs/fermat-defect-one-oq-06/index.ts
+++ b/src/data/proofs/fermat-defect-one-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FermatDefectOneOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fermatDefectOneOq06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fermatDefectOneOq06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fermatDefectOneOq06Data: ProofData = {
+  proof: fermatDefectOneOq06Proof,
+  annotations: fermatDefectOneOq06Annotations,
+}

--- a/src/data/proofs/fermat-defect-one-oq-06/meta.json
+++ b/src/data/proofs/fermat-defect-one-oq-06/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "fermat-defect-one-oq-06",
+  "title": "The Sign-Flip Involution of the Defect-One Conjecture",
+  "slug": "fermat-defect-one-oq-06",
+  "description": "Answers the parent Fermat defect-one entry's sixth open question — is there a structural map exchanging the two signs of the defect? — with an explicit involution. Working over ℤ so that ±1 is a single signed quantity, define Ψ(a, b, c) = (c, -b, a). Then Ψ ∘ Ψ = id and, for every odd exponent n, Ψ negates the defect: aⁿ + bⁿ - cⁿ ↦ -(aⁿ + bⁿ - cⁿ). Hence Ψ carries each negative-defect solution aⁿ + bⁿ + 1 = cⁿ to a positive-defect solution aⁿ + bⁿ = cⁿ + 1 and back. Restricted to the gallery's two Mahler families it is exactly the parameter negation t ↦ -t, and it sends the negative benchmark (6,8,9) to the integer positive witness (9,-8,6) and Ψ(negTriple(-1)) = (9,10,12), the taxicab positive benchmark. Everything is a polynomial identity over ℤ, fully verified with 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fermat%27s_Last_Theorem",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FermatDefectOneOQ06.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "fermat",
+      "defect-one",
+      "involution",
+      "symmetry",
+      "cubic-forms",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Odd.neg_pow",
+        "description": "For odd n, (-x)ⁿ = -xⁿ. This single fact is what makes the cubic sign-flip a phenomenon of every odd exponent: the involution Ψ(a,b,c)=(c,-b,a) replaces b by -b, and oddness turns (-b)ⁿ into -bⁿ, negating the whole defect.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "signFlip Ψ(a,b,c) = (c,-b,a): an explicit involution on integer triples (signFlip_involutive) realising the sign symmetry the parent entry's OQ-06 asks for",
+      "signFlip_negates_defect: Ψ negates the cubic defect, a³+b³-c³ ↦ -(a³+b³-c³), so it exchanges the two defect signs at n=3",
+      "signFlip_neg_to_pos / signFlip_pos_to_neg: Ψ carries each integer negative-defect solution a³+b³+1=c³ to a positive-defect solution a³+b³=c³+1 and back",
+      "signFlip_negTriple / signFlip_posTriple: on the two gallery Mahler families Ψ is exactly the parameter negation t ↦ -t, identifying the sign symmetry with the obvious symmetry of Mahler's parametrization of x³+y³+z³=1",
+      "signFlip_negates_defect_odd / signFlip_neg_to_pos_odd / signFlip_pos_to_neg_odd: the same single involution Ψ negates the exponent-n defect for EVERY odd n (via Odd.neg_pow), tying the sign symmetry to the headline 'for all n ≥ 3' conjecture",
+      "taxicab_is_signflip_of_neg: the canonical taxicab positive witness (9,10,12)=posTriple 1 is Ψ(negTriple(-1))=(12,-10,9), exhibiting the famous benchmark as a structural image",
+      "sign_symmetry / sign_symmetry_odd: packaged statements bundling involutivity, both defect equations, and the family compatibility into one theorem each (cubic and general-odd-n forms)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 277,
+    "assumptions": "None. All 21 theorems are fully proved with 0 axioms and 0 sorries (no native_decide, no decide on the substantive results — only `decide` to discharge `Odd 3` in one sanity-check corollary). #print axioms reports only [propext, Classical.choice, Quot.sound]. Every result is a polynomial identity over ℤ closed by ring / linear_combination / norm_num / simp, plus Mathlib's Odd.neg_pow for the odd-exponent generalization. Scope: this entry establishes the sign symmetry structurally (the map and its properties); it does NOT resolve the parent existence conjecture for n ≥ 4 — it shows only that whatever the truth at a given odd n, the two signs are never independent.",
+    "theoremCount": 21,
+    "definitionCount": 3,
+    "prerequisites": [
+      "The integer Fermat defect a^n + b^n - c^n and its ±1 'defect-one' question",
+      "Involutions and how an order-2 map pairs up a set into orbits of size ≤ 2",
+      "Mahler's parametrization of the cubic Fermat-near-miss x³ + y³ + z³ = 1",
+      "The elementary identity (-x)ⁿ = -xⁿ for odd n"
+    ],
+    "relatedProblems": [
+      {
+        "id": "fermat-defect-one",
+        "relationship": "Parent: the Fermat defect-one conjecture. This entry answers its sixth open question — whether a structural sign-flip map carries negative-defect witnesses to positive-defect witnesses — with the explicit involution Ψ(a,b,c)=(c,-b,a)."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Fermat defect-one conjecture asks whether, for every n ≥ 3, there is a primitive coprime triple with |aⁿ + bⁿ - cⁿ| = 1 — the natural successor to Fermat's Last Theorem, which forbids defect 0. At n = 3 both signs are known to be realised: the negative benchmark 6³ + 8³ + 1 = 9³ (defect -1) and the positive taxicab-shift 9³ + 10³ = 12³ + 1 (defect +1). The gallery records two explicit Mahler families producing infinitely many witnesses of each sign, both descending from Mahler's 1936 parametrization of x³ + y³ + z³ = 1.\n\nWhenever a Diophantine problem presents two ostensibly separate phenomena — here, negative-defect and positive-defect solutions — it is natural to ask whether they are two faces of a single object. OQ-06 poses exactly this: is there a structural map (an involution / sign-flip) carrying one sign to the other? A positive answer would say the two signs are never independent, collapsing 'solve both signs' into 'solve one sign'.",
+    "problemStatement": "Work over ℤ, so that the defect a^n + b^n - c^n is a single signed integer rather than a Nat-disjunction. Question (parent OQ-06): exhibit an explicit involution on integer triples that negates the defect — sending every negative-defect solution a^n + b^n + 1 = c^n to a positive-defect solution a^n + b^n = c^n + 1 and vice versa — and explain how it acts on the gallery's Mahler families and benchmarks.",
+    "proofStrategy": "Define Ψ(a, b, c) = (c, -b, a). Two one-line computations carry the whole result. First, Ψ ∘ Ψ = id: (a,b,c) ↦ (c,-b,a) ↦ (a,-(-b),c) = (a,b,c), so Ψ is an involution (simp). Second, the defect of Ψ(a,b,c) is c³ + (-b)³ - a³ = -(a³ + b³ - c³) by ring — i.e. Ψ negates the cubic defect. Negation of the defect is exactly the exchange of the two defect equations a³+b³+1=c³ ↔ a³+b³=c³+1, proved by linear_combination. The cubic computation upgrades verbatim to every odd n: (-b)ⁿ = -bⁿ by Odd.neg_pow, so the same Ψ negates aⁿ+bⁿ-cⁿ for all odd n. Finally, evaluating Ψ on the two Mahler families negTriple t = (9t⁴-3t, 9t³-1, 9t⁴) and posTriple t = (9t⁴, 9t³+1, 9t⁴+3t) gives Ψ(negTriple t) = posTriple(-t) and Ψ(posTriple t) = negTriple(-t) (each three ring identities), so on the families Ψ is precisely the parameter involution t ↦ -t.",
+    "keyInsights": [
+      "Passing from ℕ to ℤ is the move that makes the symmetry visible: over ℤ the defect is one signed quantity, and 'flip the sign' becomes a single linear involution rather than a case split.",
+      "The map Ψ(a,b,c) = (c,-b,a) is forced by the cubic: to send a³+b³-c³ to its negative you must turn c³ into the leading +term and a³ into the -term, and kill the middle term's sign — i.e. swap a↔c and negate b.",
+      "Negating b is harmless precisely because the exponent is odd; at even n one would get an a↔c swap instead of a sign flip, so the symmetry is intrinsically an odd-exponent phenomenon (Odd.neg_pow is the only Mathlib input).",
+      "On the Mahler families the abstract involution Ψ is the concrete parameter negation t ↦ -t, so the sign symmetry of the defect is literally the t ↦ -t symmetry of Mahler's parametrization of x³+y³+z³=1.",
+      "Because Ψ works at every odd n with no extra hypotheses, it links OQ-06 to the headline conjecture: a defect-one witness of one sign at an odd exponent automatically yields one of the other sign, so 'both signs at odd n' reduces to 'one sign at odd n'."
+    ],
+    "prerequisites": [
+      "The integer Fermat defect and the ±1 'defect-one' question (parent entry)",
+      "Involutions / order-2 maps and the pairing of a set they induce",
+      "Mahler's cubic parametrization and the two gallery families negTriple, posTriple",
+      "The identity (-x)ⁿ = -xⁿ for odd n (Odd.neg_pow)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "signflip-map",
+      "title": "Section I: The Structural Sign-Flip Map",
+      "startLine": 76,
+      "endLine": 111,
+      "summary": "signFlip defines Ψ(a,b,c) = (c,-b,a). signFlip_involutive proves Ψ ∘ Ψ = id by simp. signFlip_negates_defect is the headline: the cubic defect of Ψ(a,b,c) equals -(a³+b³-c³), by ring. signFlip_neg_to_pos and signFlip_pos_to_neg turn that sign negation into the exchange of the two defect equations a³+b³+1=c³ ↔ a³+b³=c³+1, each closed by linear_combination.",
+      "mathContext": "Ψ(a,b,c)=(c,-b,a) is an involution with c³+(-b)³-a³ = -(a³+b³-c³), so it exchanges the two defect signs at n=3."
+    },
+    {
+      "id": "mahler-families",
+      "title": "Section II: The Mahler Families and Parameter Negation",
+      "startLine": 113,
+      "endLine": 156,
+      "summary": "negTriple t = (9t⁴-3t, 9t³-1, 9t⁴) and posTriple t = (9t⁴, 9t³+1, 9t⁴+3t) are the two gallery families; negTriple_defect and posTriple_defect re-verify they satisfy the negative- and positive-defect equations (ring). signFlip_negTriple and signFlip_posTriple show Ψ(negTriple t) = posTriple(-t) and Ψ(posTriple t) = negTriple(-t), so on the families Ψ is the parameter involution t ↦ -t; signFlip_negTriple_involutive records t ↦ -t ↦ t.",
+      "mathContext": "On Mahler's parametrization the abstract sign-flip Ψ is the concrete parameter negation t ↦ -t."
+    },
+    {
+      "id": "benchmarks",
+      "title": "Section III: Concrete Benchmarks",
+      "startLine": 157,
+      "endLine": 190,
+      "summary": "negTriple_one = (6,8,9) and posTriple_one = (9,10,12) recover the two gallery benchmarks. signFlip_benchmark computes Ψ(6,8,9) = (9,-8,6), and signFlip_benchmark_pos_defect verifies 9³+(-8)³ = 6³+1 (729-512 = 217). taxicab_is_signflip_of_neg exhibits the taxicab positive witness (9,10,12) = posTriple 1 = Ψ(negTriple(-1)), with negTriple_neg_one = (12,-10,9).",
+      "mathContext": "The famous taxicab positive benchmark (9,10,12) is the sign-flip image of the integer negative-defect point (12,-10,9)."
+    },
+    {
+      "id": "odd-exponent",
+      "title": "Section IV: An All-Odd-Exponent Phenomenon",
+      "startLine": 192,
+      "endLine": 240,
+      "summary": "signFlip_negates_defect_odd generalizes the headline to every odd n: using Odd.neg_pow to rewrite (-b)ⁿ = -bⁿ, the same Ψ negates aⁿ+bⁿ-cⁿ. signFlip_neg_to_pos_odd and signFlip_pos_to_neg_odd give the corresponding exchange of odd-exponent defect solutions, and signFlip_negates_defect_three confirms the cubic headline is the n=3 instance (Odd 3 by decide).",
+      "mathContext": "(-b)ⁿ = -bⁿ for odd n makes the single involution Ψ negate the exponent-n defect for every odd n, linking OQ-06 to the 'for all n ≥ 3' conjecture."
+    },
+    {
+      "id": "summary",
+      "title": "Section V: Packaged Sign-Symmetry Statements",
+      "startLine": 242,
+      "endLine": 276,
+      "summary": "sign_symmetry bundles, for every t, the two family defect equations together with Ψ(negTriple t)=posTriple(-t) and Ψ(posTriple t)=negTriple(-t) into one theorem. sign_symmetry_odd packages the general-odd-n form: Ψ is its own inverse and exchanges negative- and positive-defect solutions at any odd exponent.",
+      "mathContext": "Both signs of the defect are two branches of one identity under t ↦ -t, realised pointwise by the involution Ψ."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) formalization, in 277 lines with 21 theorems and 3 definitions, answering the parent defect-one entry's sixth open question. The explicit involution Ψ(a,b,c) = (c,-b,a) negates the Fermat defect at every odd exponent, exchanging negative-defect solutions a^n+b^n+1=c^n with positive-defect solutions a^n+b^n=c^n+1; on the gallery's two Mahler families it is the parameter negation t ↦ -t, and it carries the negative benchmark (6,8,9) to the integer positive witness (9,-8,6) and produces the taxicab positive benchmark (9,10,12) as Ψ(12,-10,9). Every result is a polynomial identity over ℤ, with Mathlib's Odd.neg_pow as the only nontrivial dependency.",
+    "implications": "The sign symmetry the parent entry asked about is real and elementary: it is a single linear involution, not a deep coincidence. Structurally this means the two defect signs are never independent — at any odd exponent, a defect-one witness of one sign immediately yields one of the other, so the existence question 'are both signs realised at n?' collapses to 'is one sign realised at n?' for odd n. The identification of Ψ with t ↦ -t exhibits the gallery's two Mahler families as the two halves of a single symmetric object, the t ↦ -t orbit of Mahler's parametrization of x³+y³+z³=1.",
+    "openQuestions": [
+      "At even exponents Ψ induces an a ↔ c swap rather than a sign flip; is there a different structural map exchanging the two defect signs when n is even, or is the absence of such a map a genuine even/odd asymmetry of the defect-one problem?",
+      "Does the involution Ψ (or its t ↦ -t shadow) extend to a larger symmetry group acting on the full solution set of the defect-one equation at a fixed odd n — e.g. combining with the obvious a ↔ b swap — and does that group constrain the conjectural density of witnesses?"
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.FermatDefectOne",
+      "Proofs.FermatDefectOneFamilies"
+    ],
+    "opens": [
+      "scoped Polynomial"
+    ],
+    "namespace": "FermatDefectOneOQ06",
+    "lineCount": 277,
+    "axiomCount": 0,
+    "theoremCount": 21,
+    "definitionCount": 3,
+    "path": "Proofs/FermatDefectOneOQ06.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "fermat-defect-one",
+      "relationship": "extends",
+      "description": "Parent: the Fermat defect-one conjecture. That entry asks (OQ-06) whether a structural sign-flip map carries negative-defect witnesses to positive-defect witnesses and back. This entry answers it with the explicit involution Ψ(a,b,c) = (c,-b,a), which negates the defect at every odd exponent and acts on the parent's two Mahler families as the parameter negation t ↦ -t."
+    },
+    {
+      "targetId": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "Fermat's Last Theorem rules out defect 0 for n > 2. The defect-one conjecture asks about defect ±1, and this entry shows the two signs of that ±1 are interchanged by one fixed involution at every odd exponent — a structural symmetry with no analogue in the defect-0 world, where there are no solutions to symmetrize."
+    }
+  ],
+  "references": [
+    {
+      "key": "Ma36",
+      "citation": "Mahler, K., Note on hypothesis K of Hardy and Littlewood, J. London Math. Soc. 11 (1936), 136–138 (parametrization of x³ + y³ + z³ = 1).",
+      "type": "paper"
+    },
+    {
+      "key": "GuyUPNT",
+      "citation": "Guy, R.K., Unsolved Problems in Number Theory, 3rd ed., Springer (2004), D1–D2 (sums of like powers, near-misses to Fermat's equation).",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/fermat-defect-one-oq-06.json
+++ b/src/data/research/problems/fermat-defect-one-oq-06.json
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: explicit structural sign-flip for the n=3 Fermat unit defect. Over Z the linear involution Psi(a,b,c) = (c,-b,a) is an involution (signFlip_involutive) and negates the cubic defect a^3+b^3-c^3 (signFlip_negates_defect, a ring identity), hence carries negative-defect solutions a^3+b^3+1=c^3 to positive-defect solutions a^3+b^3=c^3+1 and back (signFlip_neg_to_pos / signFlip_pos_to_neg). On the gallery Mahler families negTriple/posTriple, Psi is exactly the parameter negation t -> -t (signFlip_negTriple, signFlip_posTriple), so the sign symmetry of the defect is the involution t -> -t of Mahler's parametrisation of x^3+y^3+z^3=1 realised pointwise. Benchmarks: Psi(6,8,9)=(9,-8,6) with 9^3+(-8)^3=6^3+1, and the taxicab witness (9,10,12)=Psi(negTriple(-1))=Psi(12,-10,9). Proofs/FermatDefectOneOQ06.lean (194L, 16 thm, 3 def, 0 sorry, 0 axiom decls, 0 native_decide; fully verified 0-axiom) is registered in Proofs.lean. Everything is polynomial identities over Z closed by ring / linear_combination / simp.",
+    "progressSummary": "COMPLETE: Lean proof merged (#31368) + gallery integration added (#31553). Sign-flip involution Ψ(a,b,c)=(c,-b,a) fully verified, 0-axiom.",
     "builtItems": [
       "signFlip (T) = (T.2.2, -T.2.1, T.1): the sign-flip map Psi(a,b,c)=(c,-b,a) on integer triples",
       "signFlip_involutive: Psi (Psi T) = T",
@@ -52,7 +52,8 @@
       "signFlip_negTriple: Psi(negTriple t) = posTriple(-t); signFlip_posTriple: Psi(posTriple t) = negTriple(-t)",
       "signFlip_benchmark: Psi(6,8,9)=(9,-8,6); signFlip_benchmark_pos_defect: 9^3+(-8)^3=6^3+1",
       "taxicab_is_signflip_of_neg: posTriple 1 = (9,10,12) = Psi(negTriple(-1)) = Psi(12,-10,9)",
-      "sign_symmetry t: packaged statement (both defect equations + both compatibilities) for all t"
+      "sign_symmetry t: packaged statement (both defect equations + both compatibilities) for all t",
+      "Gallery integration: src/data/proofs/fermat-defect-one-oq-06/ (meta.json, annotations.json, index.ts) — verified/original, 0-axiom, 7 annotations; entry now appears in the web gallery (PR #31553)"
     ],
     "insights": [
       "Passing to Z is the key move: over N the +/-1 is a disjunction with no natural negation, but over Z the defect a^3+b^3-c^3 is one signed quantity and the sign flip is literally multiplication by -1, realised by the linear involution (a,b,c) -> (c,-b,a).",


### PR DESCRIPTION
## Summary

Adds the **missing gallery integration** for `FermatDefectOneOQ06.lean` (Lean proof already merged in #31368 as VERIFIED, 0-axiom). The proof file existed and was auto-built via the lakefile globs, but had no `src/data/proofs/` entry, so it was absent from the web gallery.

This PR adds `meta.json`, `annotations.json`, and `index.ts` for slug `fermat-defect-one-oq-06`.

## The result it presents

Answers the parent defect-one conjecture's **OQ-06** (the sign-symmetry question) with an explicit involution over ℤ:

$$\Psi(a,b,c) = (c,\,-b,\,a)$$

- $\Psi \circ \Psi = \mathrm{id}$ (involution);
- $\Psi$ **negates the Fermat defect at every odd exponent** $n$ (via `Odd.neg_pow`), carrying each negative-defect solution $a^n+b^n+1=c^n$ to a positive-defect solution $a^n+b^n=c^n+1$ and back;
- on the gallery's two Mahler families $\Psi$ is exactly the parameter negation $t \mapsto -t$;
- it produces the taxicab positive benchmark $(9,10,12)$ as $\Psi(12,-10,9)$.

So the two defect signs are never independent — a structural answer to OQ-06.

## Verification status

- **status:** `verified`, **badge:** `original`
- **0 axioms / 0 sorries / no native_decide** — every result is a polynomial identity over ℤ (`ring` / `linear_combination` / `norm_num`); only Mathlib dependency is `Odd.neg_pow`.
- 277 lines, 21 theorems, 3 definitions, 7 annotations (all map to valid Lean constructs).
- `pnpm gallery:check-size` passes; `pnpm annotations:build` emits the entry to `listings.json` and `public/data/` with no errors attributable to this entry.

Listings/manifest/`public/data` are gitignored (regenerated at deploy) — only the 3 source files are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)