### PR TITLE
Add index.ts + complete annotations for Cauchy Interlacing (dual Weyl) OQ-03-OQ-02

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-02/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "Setup: A Corollary File over the Subadditive Weyl Inequality",
     "content": "The single non-Mathlib import is `Proofs.CauchyInterlacingWeyl`, which supplies `weyl_add_le`: for `i + j ≤ k`, `ρ(k) ≤ μ(i) + ν(j)`, where μ, ν, ρ are the antitone (descending) eigenvalue enumerations of T, U, T+U — itself a 0-axiom/0-sorry corollary of the Courant–Fischer keystone. The whole dual inequality is assembled from `weyl_add_le` alone by the reflection T ↦ −T; no new spectral theory is re-derived. The file reuses the parent's `CauchyInterlacing.Weyl` namespace so that `weyl_add_ge` sits beside its dual `weyl_add_le`.",
-    "mathContext": "Imports `weyl_add_le : i+j \\le k \\Rightarrow \\rho_k \\le \\mu_i + \\nu_j` and builds its mirror `\\mu_i + \\nu_j \\le \\rho_k` for `k+(n-1) \\le i+j`."
+    "mathContext": "Imports `weyl_add_le : i+j \\le k \\Rightarrow \\rho_k \\le \\mu_i + \\nu_j` and builds its mirror `\\mu_i + \\nu_j \\le \\rho_k` for `k+(n-1) \\le i+j`.",
+    "significance": "supporting",
+    "relatedConcepts": ["Weyl inequalities", "Courant–Fischer min-max", "eigenvalue interlacing", "reflection T ↦ −T"],
+    "prerequisites": ["the parent weyl_add_le subadditive inequality", "antitone eigenvalue enumerations"]
   },
   {
     "id": "ann-dualweyl-oq0302-negation-eigen",
@@ -15,7 +18,10 @@
     "type": "tactic",
     "title": "Carrying the Spectrum Through Negation: neg_reindex_eigen",
     "content": "This lemma is the entire spectral content of the negation trick. A symmetric operator T with `T(b i) = μ i • b i` negates to −T, whose eigenvalues are −μ. But to present −T with a DESCENDING enumeration the eigenvalues must be read in reverse: the largest eigenvalue of −T is minus the smallest of T. So the eigenbasis is reindexed by `Fin.revPerm` (the order-reversing involution `i ↦ n−1−i`), giving the still-orthonormal basis `b.reindex Fin.revPerm` with `(b.reindex Fin.revPerm) t = b (Fin.rev t)` by `OrthonormalBasis.reindex_apply` (and `revPerm_symm = revPerm`). Then `LinearMap.neg_apply` turns `(−T)(b(rev t))` into `−(T(b(rev t))) = −(μ(rev t) • b(rev t))`, and `push_cast` + `neg_smul` repackage this as `(−μ(rev t)) • b(rev t)`. The result: −T is presented by the reversed basis and enumeration `t ↦ −μ(Fin.rev t)`.",
-    "mathContext": "The k-th largest eigenvalue of −T is `-\\mu_{n-1-k}`: negation flips sign AND reverses order, hence reindex by `\\mathrm{rev}` and negate."
+    "mathContext": "The k-th largest eigenvalue of −T is `-\\mu_{n-1-k}`: negation flips sign AND reverses order, hence reindex by `\\mathrm{rev}` and negate.",
+    "significance": "critical",
+    "relatedConcepts": ["spectrum of −T", "Fin.revPerm order reversal", "OrthonormalBasis.reindex", "eigenbasis reindexing"],
+    "prerequisites": ["orthonormal eigenbasis presentation", "LinearMap.neg_apply", "neg_smul"]
   },
   {
     "id": "ann-dualweyl-oq0302-antitone",
@@ -24,7 +30,10 @@
     "type": "tactic",
     "title": "Antitonicity Survives Both Reversals: antitone_neg_rev",
     "content": "`weyl_add_le` requires its eigenvalue enumerations to be `Antitone`, so the negated/reversed enumeration `t ↦ −μ(Fin.rev t)` must be shown antitone whenever μ is. The argument is a clean double reversal: for `a ≤ c`, `Fin.rev` reverses to `Fin.rev c ≤ Fin.rev a` (proved by rewriting through `Fin.val_rev : (Fin.rev x : ℕ) = n−(x+1)` and discharging with `omega`); applying the antitone μ gives `μ(Fin.rev a) ≤ μ(Fin.rev c)`; then `neg_le_neg` flips once more to `−μ(Fin.rev c) ≤ −μ(Fin.rev a)`. Two order reversals (the reindex and the negation) compose to the required antitone direction.",
-    "mathContext": "`\\mathrm{rev}` is order-reversing and `x \\mapsto -x` is order-reversing; their composite with the antitone μ is again antitone."
+    "mathContext": "`\\mathrm{rev}` is order-reversing and `x \\mapsto -x` is order-reversing; their composite with the antitone μ is again antitone.",
+    "significance": "key",
+    "relatedConcepts": ["Antitone monotonicity", "double order reversal", "Fin.val_rev", "neg_le_neg"],
+    "prerequisites": ["Antitone hypothesis on μ", "omega on Fin index arithmetic"]
   },
   {
     "id": "ann-dualweyl-oq0302-sum",
@@ -33,7 +42,10 @@
     "type": "insight",
     "title": "The Negated Sum Is the Sum of Negations",
     "content": "`weyl_add_le` is applied with first two operators `−T` and `−U`, so it forms their sum `(−T) + (−U)` and demands its eigen-presentation. The identity `(−T) + (−U) = −(T + U)` (proved by `LinearMap.ext` / `simp`) lets that presentation be read straight off the GIVEN presentation of `T + U`: applying `neg_reindex_eigen` to the operator `T + U` with basis d and enumeration ρ yields `(−(T+U))((d.reindex Fin.revPerm) t) = (−ρ(Fin.rev t)) • …`, which after the rewrite is exactly the presentation of the sum operator `weyl_add_le` sees. One lemma, `neg_reindex_eigen`, thus serves all three operators T, U, T+U.",
-    "mathContext": "`(-T)+(-U) = -(T+U)` so the reversed-negated presentation of the sum needs no separate spectral input."
+    "mathContext": "`(-T)+(-U) = -(T+U)` so the reversed-negated presentation of the sum needs no separate spectral input.",
+    "significance": "key",
+    "relatedConcepts": ["linearity of negation", "LinearMap.ext", "shared eigen-presentation", "additivity of spectra"],
+    "prerequisites": ["neg_reindex_eigen", "LinearMap arithmetic"]
   },
   {
     "id": "ann-dualweyl-oq0302-index-flip",
@@ -42,7 +54,10 @@
     "type": "insight",
     "title": "Index Reversal Produces the n−1 Defect",
     "content": "Here lies the entire arithmetic content of the dual bound. `weyl_add_le` needs `(Fin.rev i) + (Fin.rev j) ≤ (Fin.rev k)`. Rewriting each `(Fin.rev x : ℕ)` to `n−(x+1)` via `Fin.val_rev`, this is `(n−1−i) + (n−1−j) ≤ (n−1−k)`, which `omega` shows equivalent (using `i, j, k < n`) to the hypothesis `k + (n−1) ≤ i + j`. The characteristic `n−1` defect of the lower Weyl inequality appears precisely because reversing three indices in `[0, n)` injects three copies of `(n−1)` that omega collapses to one. No spectral fact is touched — only counting.",
-    "mathContext": "Reversing `i, j, k` turns `i'+j' \\le k'` into `k + (n-1) \\le i + j`: the lower-Weyl defect is an index-arithmetic artifact."
+    "mathContext": "Reversing `i, j, k` turns `i'+j' \\le k'` into `k + (n-1) \\le i + j`: the lower-Weyl defect is an index-arithmetic artifact.",
+    "significance": "critical",
+    "relatedConcepts": ["lower Weyl inequality defect", "index arithmetic", "Fin.val_rev", "omega decision procedure"],
+    "prerequisites": ["the reversed-index hypothesis k+(n−1) ≤ i+j", "i,j,k < n bounds"]
   },
   {
     "id": "ann-dualweyl-oq0302-finish",
@@ -51,6 +66,9 @@
     "type": "insight",
     "title": "Applying weyl_add_le and Unwinding the Reversal",
     "content": "With the three negated presentations, the three antitone facts, and the reversed-index hypothesis in hand, `weyl_add_le` is applied to `−T`, `−U` at the reversed indices `Fin.rev i, Fin.rev j, Fin.rev k`. Its conclusion is `(−ρ∘rev)(Fin.rev k) ≤ (−μ∘rev)(Fin.rev i) + (−ν∘rev)(Fin.rev j)`, i.e. `−ρ(rev(rev k)) ≤ −μ(rev(rev i)) − ν(rev(rev j))`. `simp [Fin.rev_rev]` collapses every `rev(rev x)` to `x`, leaving `−ρ(k) ≤ −μ(i) − ν(j)`, and `linarith` rearranges this to the goal `μ(i) + ν(j) ≤ ρ(k)`. The subadditive inequality, reflected, IS the superadditive one.",
-    "mathContext": "`\\mathrm{rev}\\,\\mathrm{rev}\\,x = x` collapses the doubly-reversed indices; `-\\rho_k \\le -\\mu_i-\\nu_j` is `\\mu_i+\\nu_j \\le \\rho_k`."
+    "mathContext": "`\\mathrm{rev}\\,\\mathrm{rev}\\,x = x` collapses the doubly-reversed indices; `-\\rho_k \\le -\\mu_i-\\nu_j` is `\\mu_i+\\nu_j \\le \\rho_k`.",
+    "significance": "key",
+    "relatedConcepts": ["Fin.rev_rev involution", "linarith rearrangement", "superadditive Weyl inequality", "reflection duality"],
+    "prerequisites": ["weyl_add_le", "the antitone facts and negated presentations above"]
   }
 ]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-02/index.ts
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchyInterlacingWeylDual.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchyInterlacingTheoremOq03Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchyInterlacingTheoremOq03Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchyInterlacingTheoremOq03Oq02Data: ProofData = {
+  proof: cauchyInterlacingTheoremOq03Oq02Proof,
+  annotations: cauchyInterlacingTheoremOq03Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-03-oq-02`.

## Gaps addressed
The entry had `meta.json` and 6 well-written annotations but **no `index.ts`**, so the proof page rendered "proof not found" on the live site (Vite's `import.meta.glob` could not discover it). The annotations were also **missing the required `significance` field** (0/6).

## Changes
- **Created `index.ts`** (required Vite entry point) so the page loads.
- **Completed all 6 annotations**: added the required `significance` field to each (e.g. `critical` for the negation-spectrum lemma and the n−1 index-defect insight; `key` for the antitonicity/sum/finish steps; `supporting` for setup), plus `relatedConcepts` and `prerequisites`. Existing `content` and `mathContext` preserved verbatim.

## Verification
- `meta.json` size check: within all caps.
- JSON parses; all 6 annotations now carry `significance` + `relatedConcepts` + `prerequisites`.
- `annotations:build`: the only remaining note is the known docstring/setup-range false positive on the `setup` annotation (it describes the import/namespace region, which has no theorem keyword) — non-strict, shared by ~3000 gallery annotations.
- (Full `tsc`/`vite build` blocked in-worktree by a `better-sqlite3` native-build incompatibility with node v26 — environment issue.)

Dedicated per-target branch to avoid clobbering sibling enrichment PRs.