### PR TITLE
Add missing index.ts for British Flag Theorem OQ-01

### DIFF
--- a/src/data/proofs/british-flag-theorem-oq-01/index.ts
+++ b/src/data/proofs/british-flag-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BritishFlagTheorem.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const britishFlagTheoremOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const britishFlagTheoremOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const britishFlagTheoremOq01Data: ProofData = {
+  proof: britishFlagTheoremOq01Proof,
+  annotations: britishFlagTheoremOq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `british-flag-theorem-oq-01`.

## Gap addressed
The entry had `meta.json` and 3 complete annotations (each with `significance` + `mathContext`) but **no `index.ts`**, so the proof page rendered "proof not found" on the live site (Vite's `import.meta.glob` could not discover it).

## Changes
- **Created `index.ts`** (required Vite entry point) so the page loads.
- No annotation changes needed — the 3 existing annotations already cover the full single-theorem file (statement/coordinate setup, squared-distance definition, the British Flag identity).

## Verification
- `meta.json` size check: within all caps.
- Confirmed meta exposes `id`/`slug`/`meta`/`sections` the entry point relies on.
- (Full `tsc`/`vite build` blocked in-worktree by a `better-sqlite3` native-build incompatibility with node v26 — environment issue.)

Dedicated per-target branch to avoid clobbering sibling enrichment PRs.