### PR TITLE
Enrich Erdős #1011 OQ-03 (f₅): annotation depth fields

### DIFF
--- a/src/data/proofs/erdos-1011-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1011-oq-03/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 47 },
     "type": "concept",
     "title": "What is open, and what this file actually proves",
-    "content": "OQ-03 of Erdős #1011 asks to compute f_5(n): the least number of edges forcing a triangle in an n-vertex graph of chromatic number ≥ 5. This is genuinely open — f_4(n) was only settled in 2024. The file is deliberately honest about that: it does NOT compute f_5(n). It proves the unconditional scaffolding (antitonicity of f, the shift pattern) with zero axioms, and records the open value as a Prop. The honesty note in the header makes the boundary explicit."
+    "content": "OQ-03 of Erdős #1011 asks to compute f_5(n): the least number of edges forcing a triangle in an n-vertex graph of chromatic number ≥ 5. This is genuinely open — f_4(n) was only settled in 2024. The file is deliberately honest about that: it does NOT compute f_5(n). It proves the unconditional scaffolding (antitonicity of f, the shift pattern) with zero axioms, and records the open value as a Prop. The honesty note in the header makes the boundary explicit.",
+    "mathContext": "$f_r(n) = \\min\\{m : \\text{every } G \\text{ on } n \\text{ vertices with } \\chi(G)\\ge r,\\ e(G)\\ge m \\text{ has a triangle}\\}$; known for $r\\le 4$, open for $r=5$.",
+    "significance": "context",
+    "relatedConcepts": ["chromatic number", "triangle-forcing threshold", "open problem framing", "Erdős problems"],
+    "prerequisites": ["chromatic number χ(G)", "edge count e(G)", "extremal graph theory basics"]
   },
   {
     "id": "ann-erdos1011oq03-forces",
@@ -13,7 +17,11 @@
     "range": { "startLine": 56, "endLine": 76 },
     "type": "tactic",
     "title": "Factoring the sInf and proving nonemptiness",
-    "content": "f r n is sInf of the set of edge counts that force a triangle. To reason about it cleanly, the membership predicate is named `Forces r n m`. The defining set is nonempty because any m greater than C(n,2) is unreachable — a simple graph on n vertices has at most C(n,2) edges (Mathlib's `card_edgeFinset_le_card_choose_two`), so `edgeCount G ≥ m` is false and the implication holds vacuously. Nonemptiness is what guarantees the infimum is actually attained."
+    "content": "f r n is sInf of the set of edge counts that force a triangle. To reason about it cleanly, the membership predicate is named `Forces r n m`. The defining set is nonempty because any m greater than C(n,2) is unreachable — a simple graph on n vertices has at most C(n,2) edges (Mathlib's `card_edgeFinset_le_card_choose_two`), so `edgeCount G ≥ m` is false and the implication holds vacuously. Nonemptiness is what guarantees the infimum is actually attained.",
+    "mathContext": "$f(r,n) = \\inf\\{m : \\mathrm{Forces}(r,n,m)\\}$; nonempty since $m = \\binom{n}{2}+1$ forces vacuously as $e(G) \\le \\binom{n}{2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["infimum over ℕ (Nat.sInf)", "vacuous implication", "edge-count upper bound C(n,2)", "attainment of infimum"],
+    "prerequisites": ["Nat.sInf_mem / Nat.sInf_le", "card_edgeFinset_le_card_choose_two", "nonempty subsets of ℕ have a least element"]
   },
   {
     "id": "ann-erdos1011oq03-antitone",
@@ -21,7 +29,11 @@
     "range": { "startLine": 89, "endLine": 107 },
     "type": "insight",
     "title": "Antitonicity: the one real theorem",
-    "content": "The crux. For r ≤ r', the defining set for r sits inside that for r', because χ ≥ r' implies χ ≥ r — so every graph constrained at level r' is already covered by the level-r forcing property at the SAME threshold f r n. Hence f r n itself forces triangles for the r'-constrained graphs, giving f r' n ≤ f r n by `f_le_of_forces`. No extremal graph theory is used; it is pure monotonicity of sInf over nested sets, with the chromatic weakening `le_trans h hchrom` doing the work."
+    "content": "The crux. For r ≤ r', the defining set for r sits inside that for r', because χ ≥ r' implies χ ≥ r — so every graph constrained at level r' is already covered by the level-r forcing property at the SAME threshold f r n. Hence f r n itself forces triangles for the r'-constrained graphs, giving f r' n ≤ f r n by `f_le_of_forces`. No extremal graph theory is used; it is pure monotonicity of sInf over nested sets, with the chromatic weakening `le_trans h hchrom` doing the work.",
+    "mathContext": "$r \\le r' \\implies \\{m : \\mathrm{Forces}(r,n,m)\\} \\subseteq \\{m : \\mathrm{Forces}(r',n,m)\\}$, and $\\inf$ reverses inclusion, so $f(r',n) \\le f(r,n)$.",
+    "significance": "key",
+    "relatedConcepts": ["antitone (order-reversing) map", "sInf monotonicity over nested sets", "monotonicity of chromatic hypothesis", "set inclusion ⟹ inf inequality"],
+    "prerequisites": ["χ ≥ r' ⟹ χ ≥ r (le_trans)", "f_le_of_forces / f_forces", "order theory: A ⊆ B ⟹ inf B ≤ inf A"]
   },
   {
     "id": "ann-erdos1011oq03-corollary",
@@ -29,7 +41,11 @@
     "range": { "startLine": 109, "endLine": 119 },
     "type": "insight",
     "title": "Why f₅(n) ≤ f₄(n) matters",
-    "content": "Antitonicity instantiated at r=4, r'=5 gives f₅(n) ≤ f₄(n). Because f₄(n) = ⌊(n-3)²/4⌋ + 6 (n ≥ 150) is now known, this is an unconditional, explicit upper bound on the open value f₅(n). Each time a higher case of Erdős #1011 is solved, it automatically caps the still-open larger-r thresholds — a small but genuine piece of leverage on the open problem."
+    "content": "Antitonicity instantiated at r=4, r'=5 gives f₅(n) ≤ f₄(n). Because f₄(n) = ⌊(n-3)²/4⌋ + 6 (n ≥ 150) is now known, this is an unconditional, explicit upper bound on the open value f₅(n). Each time a higher case of Erdős #1011 is solved, it automatically caps the still-open larger-r thresholds — a small but genuine piece of leverage on the open problem.",
+    "mathContext": "$f_5(n) \\le f_4(n) = \\left\\lfloor \\tfrac{(n-3)^2}{4}\\right\\rfloor + 6$ for $n \\ge 150$ (Ren–Wang–Wang–Yang 2024) — an unconditional upper bound on the open value.",
+    "significance": "key",
+    "relatedConcepts": ["upper bound on an open value", "Ren–Wang–Wang–Yang f₄ formula", "transfer of solved cases to open cases", "Turán-type threshold"],
+    "prerequisites": ["f_antitone_in_chromatic at r=4,r'=5", "the known f₄(n) closed form"]
   },
   {
     "id": "ann-erdos1011oq03-shift",
@@ -37,7 +53,11 @@
     "range": { "startLine": 121, "endLine": 152 },
     "type": "insight",
     "title": "The vertex-shift fingerprint C(r-1,2)",
-    "content": "The known formulas use a shifted Turán term ⌊(n - s)²/4⌋ with s = 0, 1, 3 for r = 2, 3, 4. These are exactly the triangular numbers C(r-1,2) = (r-1)(r-2)/2, so the pattern predicts shift C(4,2) = 6 for r = 5 — a conjectured leading term ⌊(n-6)²/4⌋. `chromaticShift_known` certifies the match by decision procedure; `chromaticShift_mono` and `chromaticShift_eq` record monotonicity and the closed form. The additive constants 1, 2, 6, by contrast, have no identified closed form and are the heart of what remains open."
+    "content": "The known formulas use a shifted Turán term ⌊(n - s)²/4⌋ with s = 0, 1, 3 for r = 2, 3, 4. These are exactly the triangular numbers C(r-1,2) = (r-1)(r-2)/2, so the pattern predicts shift C(4,2) = 6 for r = 5 — a conjectured leading term ⌊(n-6)²/4⌋. `chromaticShift_known` certifies the match by decision procedure; `chromaticShift_mono` and `chromaticShift_eq` record monotonicity and the closed form. The additive constants 1, 2, 6, by contrast, have no identified closed form and are the heart of what remains open.",
+    "mathContext": "$s(r) = \\binom{r-1}{2} = \\tfrac{(r-1)(r-2)}{2}$: $s(2,3,4) = 0,1,3$ and $s(5) = 6$, matching the $\\lfloor (n-s)^2/4 \\rfloor$ shifts.",
+    "significance": "supporting",
+    "relatedConcepts": ["triangular numbers C(r-1,2)", "Turán density ⌊n²/4⌋", "pattern extrapolation", "Nat.choose_two_right closed form"],
+    "prerequisites": ["binomial coefficient (r-1 choose 2)", "decide / Nat.choose_le_choose", "the known ⌊(n-s)²/4⌋ formulas for r=2,3,4"]
   },
   {
     "id": "ann-erdos1011oq03-conjecture",
@@ -45,6 +65,10 @@
     "range": { "startLine": 154, "endLine": 174 },
     "type": "concept",
     "title": "Recording the open question precisely",
-    "content": "`shiftConjecture` (general r) and `f5Conjecture` (the r=5 specialization) are stated as Props and left unproved — the formalization is explicit that these are conjectures, not theorems. `shiftConjecture_imp_f5` shows the general statement specializes to the concrete f₅ question, so any future proof of the pattern immediately resolves this entry's open goal."
+    "content": "`shiftConjecture` (general r) and `f5Conjecture` (the r=5 specialization) are stated as Props and left unproved — the formalization is explicit that these are conjectures, not theorems. `shiftConjecture_imp_f5` shows the general statement specializes to the concrete f₅ question, so any future proof of the pattern immediately resolves this entry's open goal.",
+    "mathContext": "$\\mathrm{shiftConjecture}: \\forall r\\ge 2,\\ \\exists c, n_0,\\ \\forall n\\ge n_0,\\ f_r(n) = \\lfloor (n - \\binom{r-1}{2})^2/4\\rfloor + c$; it specializes to $f_5(n) = \\lfloor (n-6)^2/4 \\rfloor + c$.",
+    "significance": "context",
+    "relatedConcepts": ["conjecture stated as a Prop", "universal-to-specific specialization", "eventual (large-n) behavior", "open additive constant c₅"],
+    "prerequisites": ["Prop-valued formalization of conjectures", "existential over (c, n₀)", "specialization r := 5"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1011-oq-03` (quality 68, pass 0).

## Gap addressed
The 6 annotations had substantive `content` but were **missing every depth field**. Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 6, grounded in the Lean source: Forces/sInf nonemptiness via $e(G)\le\binom n2$; antitonicity $f(r',n)\le f(r,n)$; corollary $f_5(n)\le f_4(n)=\lfloor(n-3)^2/4\rfloor+6$; the $\binom{r-1}2=0,1,3,6$ shift fingerprint; and the recorded conjecture Props.

## Verification
- JSON parses cleanly; 0/6 annotations missing depth fields; meta within all size caps
- meta.json already rich — left intact; axiom integrity unchanged (0 axioms / verified; parent-file axioms provably unused)