### PR TITLE
Add index.ts + overview annotation for Property B recoloring OQ-03-OQ-02

### DIFF
--- a/src/data/proofs/property-b-first-moment-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-pbfm-oq03oq02-overview",
+    "proofId": "property-b-first-moment-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "concept",
+    "title": "Recoloring: the Deterministic Core of the Alteration Method",
+    "content": "Property B asks whether a k-uniform hypergraph is 2-colorable; Erdős's 1963 first-moment bound (the parent) guarantees it when there are < 2^(k-1) edges. Two strengthenings exist. The DELETION method (the sibling OQ-03) discards the monochromatic edges of a near-good coloring, exposing a 2-colorable SUBfamily. The harder RECOLORING method (this file) instead REPAIRS each bad edge by flipping a single vertex, achieving FULL 2-colorability of the whole family. Radhakrishnan–Srinivasan recolor probabilistically precisely because, in general, monochromatic edges share vertices, so flipping one edge's vertex can break another. This entry isolates the clean deterministic regime where that dependency vanishes: each monochromatic edge owns a PRIVATE vertex (in no other edge). Flipping the private vertices repairs every bad edge and disturbs nothing else. The remaining gap to full RS is exactly the removal of this privacy hypothesis via randomness — the analytic step the knowledge base scopes for later.",
+    "mathContext": "Deletion $\\to$ 2-colorable subfamily; recoloring (flip a private vertex per bad edge) $\\to$ full 2-colorability. Privacy hypothesis = deterministic shadow of the RS probabilistic alteration.",
+    "significance": "supporting",
+    "relatedConcepts": ["Property B", "alteration / recoloring method", "deletion method", "Radhakrishnan–Srinivasan", "first moment method"],
+    "prerequisites": ["Erdős's first-moment bound (parent)", "2-coloring of hypergraphs", "the deletion-method sibling"]
+  },
+  {
     "id": "ann-pbfm-oq03oq02-recoloring",
     "proofId": "property-b-first-moment-oq-03-oq-02",
     "range": { "startLine": 54, "endLine": 117 },

--- a/src/data/proofs/property-b-first-moment-oq-03-oq-02/index.ts
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PropertyBFirstMomentRecoloring.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const propertyBFirstMomentOq03Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const propertyBFirstMomentOq03Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const propertyBFirstMomentOq03Oq02Data: ProofData = {
+  proof: propertyBFirstMomentOq03Oq02Proof,
+  annotations: propertyBFirstMomentOq03Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `property-b-first-moment-oq-03-oq-02`.

## Gaps addressed
The entry had `meta.json` and 3 complete annotations but **no `index.ts`**, so the proof page rendered "proof not found" on the live site. The conceptual docstring (lines 1-28) was also unannotated.

## Changes
- **Created `index.ts`** (required Vite entry point) so the page loads.
- **Added a 4th annotation** covering the docstring: deletion vs recoloring, the deterministic alteration core, the private-vertex hypothesis, and the remaining gap to the full Radhakrishnan–Srinivasan probabilistic argument. Now 4/4 annotations carry `significance` + `mathContext` + `relatedConcepts` + `prerequisites`.

## Verification
- `meta.json` size check: within all caps.
- `annotations:build`: clean (no errors for this entry).
- JSON parses; schema matches `Annotation` type.
- (Full `tsc`/`vite build` blocked in-worktree by a `better-sqlite3` native-build incompatibility with node v26 — environment issue.)

Dedicated per-target branch to avoid clobbering sibling enrichment PRs.