### PR TITLE
research(collatz-structured-oq-01): Syracuse accelerated-map equivalence [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ01.lean
+++ b/proofs/Proofs/CollatzStructuredOQ01.lean
@@ -175,9 +175,173 @@ theorem collatz_counterexample_odd
   obtain ⟨n, hn, hnot⟩ := h
   exact hnot (collatz_reduces_to_odd.mpr (fun m hm hodd => hc m hm hodd) n hn)
 
+/-!
+## The Syracuse (accelerated odd) map
+
+The standard *accelerated* Collatz map acts on odd numbers by `n ↦ (3n+1)/2^v₂(3n+1)`,
+i.e. it does the `3n+1` step and then strips **all** the resulting powers of two in one
+move, landing on the next odd number in the trajectory. Concretely
+
+    `syracuse n = oddPart (3 n + 1)`.
+
+We show this map is realised by finitely many ordinary Collatz steps, that its reaching
+set is *exactly* the Collatz reaching set on odd inputs, and hence that the Collatz
+conjecture is **equivalent** to "every odd `m ≥ 1` reaches 1 under `syracuse`". This is
+the second item on the file's research agenda (equireachability for the accelerated map).
+-/
+
+/-- The Syracuse / accelerated odd map: `n ↦ (3n+1)` with all factors of two stripped. -/
+def syracuse (n : ℕ) : ℕ := oddPart (3 * n + 1)
+
+/-- The Syracuse map always lands on an odd number (`3n+1 ≥ 1`, so its odd part is odd). -/
+theorem syracuse_odd (n : ℕ) : syracuse n % 2 = 1 :=
+  oddPart_odd (by omega)
+
+/-- **Halving a pure power-of-two multiple.** Applying `collatz` `i ≤ v` times to
+    `2^v · q` strips `i` factors of two: `collatz^[i] (2^v · q) = 2^(v-i) · q`. -/
+theorem collatz_iter_pow_two_mul_le (q : ℕ) :
+    ∀ i v, i ≤ v → collatz^[i] (2 ^ v * q) = 2 ^ (v - i) * q := by
+  intro i
+  induction i with
+  | zero => intro v _; simp
+  | succ j ih =>
+    intro v hv
+    have hv1 : 1 ≤ v := by omega
+    rw [Function.iterate_succ_apply]
+    have hsplit : 2 ^ v * q = 2 * (2 ^ (v - 1) * q) := by
+      rw [← mul_assoc]
+      congr 1
+      rw [← pow_succ']
+      congr 1
+      omega
+    rw [hsplit, collatz_two_mul, ih (v - 1) (by omega)]
+    have hexp : v - 1 - j = v - (j + 1) := by omega
+    rw [hexp]
+
+/-- **Collatz realises Syracuse.** From an odd `n`, exactly `v₂(3n+1) + 1` ordinary
+    Collatz steps reach `syracuse n` (the `3n+1` step plus the halvings). -/
+theorem collatz_iter_eq_syracuse {n : ℕ} (hodd : n % 2 = 1) :
+    collatz^[(3 * n + 1).factorization 2 + 1] n = syracuse n := by
+  set v := (3 * n + 1).factorization 2 with hvdef
+  have hfac : 2 ^ v * syracuse n = 3 * n + 1 := by
+    rw [hvdef]; unfold syracuse; exact pow_factorization_mul_oddPart (3 * n + 1)
+  rw [Function.iterate_succ_apply, collatz_odd hodd, ← hfac,
+      collatz_iter_pow_two_mul_le _ v v (le_refl v)]
+  simp
+
+/-- **Per-step equireachability.** For odd `n`, `syracuse n` reaches 1 iff `n` does. -/
+theorem reachesOne_syracuse_iff {n : ℕ} (hodd : n % 2 = 1) :
+    ReachesOne (syracuse n) ↔ ReachesOne n := by
+  unfold syracuse
+  rw [reachesOne_oddPart_iff (n := 3 * n + 1) (by omega), ← collatz_odd hodd]
+  exact reachesOne_collatz_iff n
+
+/-- Iterating the Syracuse map preserves oddness. -/
+theorem syracuseIter_odd {n : ℕ} (hodd : n % 2 = 1) (k : ℕ) :
+    (syracuse^[k] n) % 2 = 1 := by
+  cases k with
+  | zero => simpa using hodd
+  | succ j => rw [Function.iterate_succ_apply']; exact syracuse_odd _
+
+/-- **Iterated equireachability.** For odd `n`, any Syracuse iterate `syracuse^[k] n`
+    reaches 1 iff `n` does. -/
+theorem reachesOne_syracuseIter_iff {n : ℕ} (hodd : n % 2 = 1) (k : ℕ) :
+    ReachesOne (syracuse^[k] n) ↔ ReachesOne n := by
+  induction k with
+  | zero => simp
+  | succ j ih =>
+    rw [Function.iterate_succ_apply', reachesOne_syracuse_iff (syracuseIter_odd hodd j), ih]
+
+/-!
+## The Syracuse reaching predicate and full equivalence
+
+`SyrReachesOne n` means some *Syracuse* iterate of `n` equals 1. For odd inputs this is
+**equivalent** to the ordinary Collatz reaching predicate `ReachesOne`.
+-/
+
+/-- `n` reaches 1 under the Syracuse map. -/
+def SyrReachesOne (n : ℕ) : Prop := ∃ k : ℕ, syracuse^[k] n = 1
+
+/-- **Forward direction.** If an odd `n` reaches 1 under Syracuse, it reaches 1 under
+    ordinary Collatz (each accelerated step is a block of ordinary steps). -/
+theorem reachesOne_of_syrReachesOne {n : ℕ} (hodd : n % 2 = 1)
+    (h : SyrReachesOne n) : ReachesOne n := by
+  obtain ⟨k, hk⟩ := h
+  have h1 : ReachesOne (syracuse^[k] n) := by rw [hk]; exact one_reaches_one
+  exact (reachesOne_syracuseIter_iff hodd k).mp h1
+
+/-- Auxiliary for the converse: strong induction on the Collatz step count. -/
+theorem syrReaches_aux : ∀ k n, n % 2 = 1 → collatz^[k] n = 1 → SyrReachesOne n := by
+  intro k
+  induction k using Nat.strong_induction_on with
+  | _ k ih =>
+    intro n hodd hk
+    by_cases hn1 : n = 1
+    · subst hn1; exact ⟨0, rfl⟩
+    · have hn_gt1 : n > 1 := by omega
+      set v := (3 * n + 1).factorization 2 with hvdef
+      have hfac : 2 ^ v * syracuse n = 3 * n + 1 := by
+        rw [hvdef]; unfold syracuse; exact pow_factorization_mul_oddPart (3 * n + 1)
+      -- `v + 1` Collatz steps realise one Syracuse step.
+      have hreal : collatz^[v + 1] n = syracuse n := by
+        rw [Function.iterate_succ_apply, collatz_odd hodd, ← hfac,
+            collatz_iter_pow_two_mul_le _ v v (le_refl v)]
+        simp
+      -- The trajectory cannot reach 1 before step `v + 1`, so `v + 1 ≤ k`.
+      have hsle : v + 1 ≤ k := by
+        rcases Nat.lt_or_ge k (v + 1) with hlt | hge
+        · exfalso
+          rcases Nat.eq_zero_or_pos k with hk0 | hkpos
+          · subst hk0; simp only [Function.iterate_zero_apply] at hk; omega
+          · obtain ⟨i, rfl⟩ : ∃ i, k = i + 1 := ⟨k - 1, by omega⟩
+            have hval : collatz^[i + 1] n = 2 ^ (v - i) * syracuse n := by
+              rw [Function.iterate_succ_apply, collatz_odd hodd, ← hfac,
+                  collatz_iter_pow_two_mul_le _ i v (by omega)]
+            rw [hval] at hk
+            have hdvd : 2 ∣ 2 ^ (v - i) * syracuse n :=
+              (dvd_pow_self 2 (by omega : v - i ≠ 0)).mul_right _
+            rw [hk] at hdvd
+            omega
+        · exact hge
+      -- Recurse on the smaller residual count for `syracuse n`.
+      have hk' : collatz^[k - (v + 1)] (syracuse n) = 1 := by
+        have hcomp : collatz^[k - (v + 1)] (collatz^[v + 1] n) = 1 := by
+          rw [← Function.iterate_add_apply, Nat.sub_add_cancel hsle]; exact hk
+        rwa [hreal] at hcomp
+      have hlt' : k - (v + 1) < k := by omega
+      obtain ⟨t, ht⟩ := ih _ hlt' _ (syracuse_odd n) hk'
+      exact ⟨t + 1, by rw [Function.iterate_succ_apply, ht]⟩
+
+/-- **Converse direction.** If an odd `n` reaches 1 under ordinary Collatz, it reaches 1
+    under the accelerated Syracuse map. -/
+theorem syrReachesOne_of_reachesOne {n : ℕ} (hodd : n % 2 = 1)
+    (h : ReachesOne n) : SyrReachesOne n := by
+  obtain ⟨k, hk⟩ := h
+  simp only [collatzIter] at hk
+  exact syrReaches_aux k n hodd hk
+
+/-- **Full equireachability (headline).** For odd `n`, the Syracuse and Collatz reaching
+    predicates coincide. -/
+theorem reachesOne_iff_syrReachesOne {n : ℕ} (hodd : n % 2 = 1) :
+    SyrReachesOne n ↔ ReachesOne n :=
+  ⟨reachesOne_of_syrReachesOne hodd, syrReachesOne_of_reachesOne hodd⟩
+
+/-- **The Collatz conjecture is equivalent to its Syracuse form.** Every positive integer
+    reaches 1 under Collatz iff every odd positive integer reaches 1 under the accelerated
+    Syracuse map. This refines `collatz_reduces_to_odd` from the slow map to the fast one. -/
+theorem collatz_iff_syracuse :
+    (∀ n, n ≥ 1 → ReachesOne n) ↔ (∀ m, m ≥ 1 → m % 2 = 1 → SyrReachesOne m) := by
+  rw [collatz_reduces_to_odd]
+  constructor
+  · intro H m hm hodd; exact (reachesOne_iff_syrReachesOne hodd).mpr (H m hm hodd)
+  · intro H m hm hodd; exact (reachesOne_iff_syrReachesOne hodd).mp (H m hm hodd)
+
 #check @collatz_reduces_to_odd
 #check @reachesOne_collatz_iff
+#check @collatz_iff_syracuse
+#check @reachesOne_iff_syrReachesOne
 #print axioms collatz_reduces_to_odd
 #print axioms reachesOne_pow_two_mul_iff
+#print axioms collatz_iff_syracuse
 
 end Collatz

--- a/research/problems/collatz-structured-oq-01/knowledge.md
+++ b/research/problems/collatz-structured-oq-01/knowledge.md
@@ -38,15 +38,37 @@ odd numbers (the standard textbook reduction) was not formalized.
 - `Function.iterate_succ_apply`, `Function.iterate_zero_apply`
 - parent: `pow_two_reaches_one`, `reaches_one_double`, `collatz_two_mul`, `collatz_one`
 
+## What was added (session 2, 2026-06-30 — Syracuse map, VERIFIED 0-axiom)
+
+Next-steps items #1/#2 (accelerated odd map) now done. New content in
+CollatzStructuredOQ01.lean (now 347 lines, 22 thm, 3 defs, still 0 axioms /
+0 sorries; `#print axioms collatz_iff_syracuse` = propext/Classical.choice/Quot.sound):
+
+- `syracuse n := oddPart (3*n+1)` (the accelerated odd map); `syracuse_odd`.
+- `collatz_iter_pow_two_mul_le q : ∀ i v, i ≤ v → collatz^[i] (2^v*q) = 2^(v-i)*q`
+  — halving lemma, induction on i generalizing v (key fix: rewrite the exponent
+  `v-1-j = v-(j+1)` rather than `congr+omega`, which can't equate `2^a = 2^b`).
+- `collatz_iter_eq_syracuse (hodd) : collatz^[(3n+1).factorization 2 + 1] n = syracuse n`
+  — the accelerated step is exactly v₂(3n+1)+1 ordinary steps. Used `set v := …`
+  to abstract the exponent so `← hfac` rewrites only the argument 3n+1.
+- `reachesOne_syracuse_iff` (per-step), `reachesOne_syracuseIter_iff` (iterated)
+  — biconditional equireachability for odd n.
+- `SyrReachesOne n := ∃ k, syracuse^[k] n = 1`; `reachesOne_of_syrReachesOne`
+  (forward, easy) and `syrReachesOne_of_reachesOne` (converse, strong induction
+  on collatz step count via `syrReaches_aux`: the odd trajectory cannot hit 1
+  before step v+1, giving s ≤ k, then recurse on k-(v+1) < k).
+- Headlines: `reachesOne_iff_syrReachesOne` (full equireachability) and
+  `collatz_iff_syracuse` (Collatz ⟺ Syracuse form).
+
 ## Honest status
 
 The Collatz conjecture is **not** solved. New content = the invariance/reduction
-machinery, which is folklore but was previously unformalized in the gallery.
-Verified, axiom-free. Build pending (Docker host down this session; all Mathlib
-lemmas de-risked by source grep).
+machinery + the Syracuse-map equivalence, folklore but previously unformalized.
+VERIFIED axiom-free (Docker build succeeded session 2).
 
 ## Next steps
 
-1. Reduce further to n ≡ 3 (mod 4) or to the Syracuse odd map.
-2. Prove equireachability for the accelerated map n ↦ (3n+1)/2^v₂(3n+1).
-3. Residue-class invariants compatible with the reduction.
+1. Reduce further to n ≡ 3 (mod 4) residue classes.
+2. Residue-class invariants compatible with the reduction.
+3. Quantitative: relate Syracuse step count to v₂(3n+1) sums (stopping-time link
+   to collatz-structured-oq-03).

--- a/src/data/proofs/collatz-structured-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "collatz-structured-oq-01",
   "title": "Collatz Conjecture: Reduction to Odd Inputs",
   "slug": "collatz-structured-oq-01",
-  "description": "Proves, axiom-free, the structural reduction of the Collatz conjecture to odd numbers: every n ≥ 1 reaches 1 iff every odd n ≥ 1 does. Built on one-step invariance of the reaching set (ReachesOne (collatz n) ↔ ReachesOne n) and doubling invariance (ReachesOne (2^m·n) ↔ ReachesOne n). The conjecture itself remains open; this organizes the search space.",
+  "description": "Proves, axiom-free, the structural reduction of the Collatz conjecture to odd numbers: every n ≥ 1 reaches 1 iff every odd n ≥ 1 does. Built on one-step invariance of the reaching set (ReachesOne (collatz n) ↔ ReachesOne n) and doubling invariance (ReachesOne (2^m·n) ↔ ReachesOne n). Strengthened to the accelerated Syracuse map n ↦ (3n+1)/2^v₂(3n+1): for odd n the Syracuse and Collatz reaching predicates coincide (reachesOne_iff_syrReachesOne), so the conjecture is equivalent to its Syracuse form (collatz_iff_syracuse). The conjecture itself remains open; this organizes the search space.",
   "meta": {
     "status": "verified",
     "proofRepoPath": "Proofs/CollatzStructuredOQ01.lean",
@@ -21,10 +21,10 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 183,
-    "theoremCount": 11,
-    "definitionCount": 1,
-    "assumptions": "None. 0 axioms, 0 sorries. The file imports Proofs.CollatzStructured (which declares the conjecture as an axiom) but no theorem here uses that axiom — every result is proved from the sInf-free dynamical definitions and Mathlib's 2-adic factorization API (ordCompl/ordProj). #print axioms collatz_reduces_to_odd reports only propext / Classical.choice / Quot.sound. The Collatz conjecture itself is NOT proved; the reduction is an equivalence between two open statements.",
+    "lineCount": 347,
+    "theoremCount": 22,
+    "definitionCount": 3,
+    "assumptions": "None. 0 axioms, 0 sorries. The file imports Proofs.CollatzStructured (which declares the conjecture as an axiom) but no theorem here uses that axiom — every result is proved from the sInf-free dynamical definitions and Mathlib's 2-adic factorization API (ordCompl/ordProj). #print axioms collatz_reduces_to_odd and #print axioms collatz_iff_syracuse both report only propext / Classical.choice / Quot.sound (no sorryAx, no custom axiom). The Collatz conjecture itself is NOT proved; the reduction is an equivalence between two open statements.",
     "dateAdded": "2026-06-26",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Collatz_conjecture",
@@ -56,7 +56,11 @@
       "reachesOne_two_mul_iff / reachesOne_pow_two_mul_iff: doubling invariance as an equivalence (the parent file had only the forward closure direction)",
       "oddPart and its lemmas: oddPart n = ordCompl[2] n is odd and positive for n ≥ 1, with the factorization 2^v₂(n)·oddPart n = n",
       "collatz_reduces_to_odd: the headline equivalence — the Collatz conjecture for all n ≥ 1 holds iff it holds for all odd n ≥ 1",
-      "collatz_counterexample_odd: contrapositive — any Collatz counterexample implies an odd counterexample"
+      "collatz_counterexample_odd: contrapositive — any Collatz counterexample implies an odd counterexample",
+      "syracuse n = oddPart (3n+1): the accelerated odd map, always landing on an odd number (syracuse_odd)",
+      "collatz_iter_eq_syracuse: the accelerated step is realised by exactly v₂(3n+1)+1 ordinary Collatz steps (via collatz_iter_pow_two_mul_le, the power-of-two halving lemma)",
+      "reachesOne_iff_syrReachesOne: full equireachability — for odd n, the Syracuse reaching predicate SyrReachesOne coincides with the Collatz ReachesOne (forward = block of ordinary steps; converse = strong induction on the step count showing the trajectory cannot reach 1 before the accelerated step)",
+      "collatz_iff_syracuse: the headline — the Collatz conjecture is equivalent to 'every odd m ≥ 1 reaches 1 under the accelerated Syracuse map', refining the reduction from the slow map to the fast one"
     ]
   },
   "overview": {
@@ -109,6 +113,14 @@
       "startLine": 170,
       "endLine": 183,
       "mathContext": "The conjecture for all n ≥ 1 is equivalent to the conjecture for odd n ≥ 1; counterexamples may be taken odd."
+    },
+    {
+      "id": "syracuse",
+      "title": "The Syracuse (accelerated odd) map and full equivalence",
+      "summary": "syracuse n = oddPart (3n+1); collatz_iter_eq_syracuse realises it in v₂(3n+1)+1 steps; reachesOne_iff_syrReachesOne and collatz_iff_syracuse",
+      "startLine": 184,
+      "endLine": 338,
+      "mathContext": "The accelerated odd map does the 3n+1 step and strips all resulting powers of two at once. It is realised by finitely many ordinary Collatz steps, and for odd inputs its reaching predicate coincides exactly with the Collatz one (per-step, iterated, and full equivalence). Hence the Collatz conjecture is equivalent to its Syracuse form. The converse direction (Collatz-reaching ⟹ Syracuse-reaching) is proved by strong induction on the Collatz step count, using that the trajectory of an odd n > 1 cannot reach 1 before the accelerated step."
     }
   ],
   "conclusion": {
@@ -144,6 +156,18 @@
       "type": "core",
       "description": "Any Collatz counterexample implies an odd counterexample",
       "leanType": "(∃ n, n ≥ 1 ∧ ¬ ReachesOne n) → ∃ m, m ≥ 1 ∧ m % 2 = 1 ∧ ¬ ReachesOne m"
+    },
+    {
+      "name": "reachesOne_iff_syrReachesOne",
+      "type": "supporting",
+      "description": "For odd n, the Syracuse and Collatz reaching predicates coincide",
+      "leanType": "∀ {n}, n % 2 = 1 → (SyrReachesOne n ↔ ReachesOne n)"
+    },
+    {
+      "name": "collatz_iff_syracuse",
+      "type": "core",
+      "description": "The Collatz conjecture is equivalent to its accelerated Syracuse form: every n ≥ 1 reaches 1 iff every odd m ≥ 1 reaches 1 under n ↦ (3n+1)/2^v₂(3n+1)",
+      "leanType": "(∀ n, n ≥ 1 → ReachesOne n) ↔ (∀ m, m ≥ 1 → m % 2 = 1 → SyrReachesOne m)"
     }
   ],
   "crossReferences": [
@@ -181,10 +205,10 @@
     ],
     "opens": [],
     "namespace": "Collatz",
-    "lineCount": 183,
+    "lineCount": 347,
     "axiomCount": 0,
-    "theoremCount": 11,
-    "definitionCount": 1,
+    "theoremCount": 22,
+    "definitionCount": 3,
     "sorries": 0,
     "additionalFiles": [
       "Proofs/CollatzStructured.lean"


### PR DESCRIPTION
## Summary

Extends the **Collatz odd-reduction** entry (`collatz-structured-oq-01`) with the
**accelerated Syracuse map** `n ↦ (3n+1)/2^v₂(3n+1)` and proves the Collatz
conjecture is **equivalent** to its Syracuse form. Completes the file's own
next-steps items #1/#2.

**VERIFIED, axiom-free** — Docker build succeeds; `#print axioms collatz_iff_syracuse`
reports only `propext / Classical.choice / Quot.sound` (no `sorryAx`, no custom axiom).

## New content (183 → 347 lines, 11 → 22 theorems, 1 → 3 defs; still 0 axioms / 0 sorries)

- `syracuse n := oddPart (3n+1)` — the accelerated odd map; `syracuse_odd` (always lands on an odd number)
- `collatz_iter_pow_two_mul_le : collatz^[i] (2^v·q) = 2^(v-i)·q` for `i ≤ v` — the power-of-two halving lemma
- `collatz_iter_eq_syracuse` — one accelerated step is realised by exactly `v₂(3n+1)+1` ordinary Collatz steps
- `reachesOne_syracuse_iff` / `reachesOne_syracuseIter_iff` — per-step and iterated biconditional equireachability for odd `n`
- `SyrReachesOne`, with `reachesOne_of_syrReachesOne` (forward) and `syrReachesOne_of_reachesOne` (converse, by strong induction on the Collatz step count: the trajectory of an odd `n>1` cannot reach 1 before the accelerated step, so the residual count strictly decreases)
- `reachesOne_iff_syrReachesOne` — full equireachability for odd inputs
- **`collatz_iff_syracuse`** (headline) — `(∀ n≥1, ReachesOne n) ↔ (∀ odd m≥1, SyrReachesOne m)`, refining the slow-map reduction to the fast map

## Honesty

The Collatz conjecture itself remains **OPEN**. This is a structural *equivalence*
between two open statements (slow ↔ accelerated dynamics); it organizes the search
space and does not lower the difficulty of the conjecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)