### PR TITLE
research(pascals-hexagon-incomplete-01-oq-01): conic QF depends only on symmetric part [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PascalsHexagon.lean
+++ b/proofs/Proofs/PascalsHexagon.lean
@@ -132,6 +132,53 @@ def Conic.nondegenerate (C : Conic) : Prop := C.det ≠ 0
 /-- A conic is symmetric (Cᵢⱼ = Cⱼᵢ). We work with symmetric conics. -/
 def Conic.symmetric (C : Conic) : Prop := ∀ i j, C i j = C j i
 
+/-- **The conic quadratic form depends only on the symmetric part of `C`.**  Because
+`pᵀ C p` is a scalar it equals `pᵀ Cᵀ p` (swap the summation indices), so averaging gives
+`conicQuadraticForm C p = conicQuadraticForm (½·(C + Cᵀ)) p`.  Hence every conic has the
+*same zero set* (`pointOnConic`) as its symmetrization `½·(C + Cᵀ)`, which is genuinely
+symmetric (`symmetrizedConic_symmetric`).
+
+This discharges the "same zero set" half of step 1 of the roadmap to eliminating the
+`conic_implies_pascal_constraint` axiom (reduce an asymmetric conic to a symmetric one):
+the projective/zero-locus content transfers for free, leaving only the transfer of the
+`det`-based non-degeneracy from `C` to `½·(C + Cᵀ)`. -/
+theorem conicQuadraticForm_eq_symmetrized (C : Conic) (p : ProjPoint) :
+    conicQuadraticForm C p = conicQuadraticForm ((1 / 2 : ℝ) • (C + Cᵀ)) p := by
+  have hswap : (∑ i, ∑ j, C j i * p i * p j) = ∑ i, ∑ j, C i j * p i * p j := by
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  simp only [conicQuadraticForm, Matrix.smul_apply, Matrix.add_apply, Matrix.transpose_apply,
+    smul_eq_mul]
+  have h1 : (∑ i, ∑ j, (1 : ℝ) / 2 * (C i j * p i * p j))
+      = 1 / 2 * ∑ i, ∑ j, C i j * p i * p j := by
+    rw [Finset.mul_sum]; refine Finset.sum_congr rfl fun i _ => ?_; rw [Finset.mul_sum]
+  have h2 : (∑ i, ∑ j, (1 : ℝ) / 2 * (C j i * p i * p j))
+      = 1 / 2 * ∑ i, ∑ j, C j i * p i * p j := by
+    rw [Finset.mul_sum]; refine Finset.sum_congr rfl fun i _ => ?_; rw [Finset.mul_sum]
+  have hsplit : (∑ i, ∑ j, 1 / 2 * (C i j + C j i) * p i * p j)
+      = (∑ i, ∑ j, (1 : ℝ) / 2 * (C i j * p i * p j))
+        + (∑ i, ∑ j, (1 : ℝ) / 2 * (C j i * p i * p j)) := by
+    rw [← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    rw [← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl fun j _ => by ring
+  rw [hsplit, h1, h2, hswap]; ring
+
+/-- The symmetrization `½·(C + Cᵀ)` of any conic is symmetric. -/
+theorem symmetrizedConic_symmetric (C : Conic) :
+    ((1 / 2 : ℝ) • (C + Cᵀ)).symmetric := by
+  intro i j
+  simp only [Matrix.smul_apply, Matrix.add_apply, Matrix.transpose_apply, smul_eq_mul]
+  ring
+
+/-- **A point lies on a conic iff it lies on its symmetrization.**  Direct corollary of
+`conicQuadraticForm_eq_symmetrized`: passing to the symmetric representative `½·(C + Cᵀ)`
+preserves the conic's point set exactly. -/
+theorem pointOnConic_iff_symmetrized (C : Conic) (p : ProjPoint) :
+    pointOnConic p C ↔ pointOnConic p ((1 / 2 : ℝ) • (C + Cᵀ)) := by
+  unfold pointOnConic
+  exact iff_of_eq (by rw [conicQuadraticForm_eq_symmetrized C p])
+
 -- ============================================================
 -- PART 5: Hexagon Inscribed in Conic
 -- ============================================================

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -42,14 +42,15 @@
       "Cross-product-based line-through and intersection operations",
       "Hexagon inscribed in conic structure with validity conditions",
       "Pascal line construction via opposite-side intersections",
-      "Formalization of Brianchon's dual theorem structures"
+      "Formalization of Brianchon's dual theorem structures",
+      "conicQuadraticForm_eq_symmetrized / pointOnConic_iff_symmetrized / symmetrizedConic_symmetric (0-axiom): the conic quadratic form depends only on the symmetric part of C, so any conic has the same zero set as its symmetrization ½·(C+Cᵀ) — discharges the 'same zero set' half of step 1 of the roadmap to eliminating the conic_implies_pascal_constraint axiom"
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 1,
-    "lineCount": 1633,
+    "lineCount": 1680,
     "assumptions": "1 axiom (conic_implies_pascal_constraint), retained only for the asymmetric/degenerate conic case. The Sylvester's-law reduction for the standard conic is now fully proved (0 sorries).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 46,
+    "theoremCount": 49,
     "definitionCount": 28
   },
   "overview": {
@@ -314,10 +315,10 @@
   ],
   "leanFile": {
     "path": "Proofs/PascalsHexagon.lean",
-    "lineCount": 1633,
+    "lineCount": 1680,
     "axiomCount": 1,
     "sorries": 0,
-    "theoremCount": 46,
+    "theoremCount": 49,
     "definitionCount": 28,
     "imports": [
       "import Mathlib.Data.Real.Basic",


### PR DESCRIPTION
## Summary

The Pascal's-theorem formalization retains one axiom, `conic_implies_pascal_constraint`, for the asymmetric/degenerate conic case. The file's documented roadmap to eliminating it has as **step 1**: "handle asymmetric `C` by replacing it with its symmetrization `½·(C + Cᵀ)` (same zero set)."

This PR proves the **"same zero set" half** of that step — three 0-axiom lemmas:

| Lemma | Statement |
|---|---|
| `conicQuadraticForm_eq_symmetrized` | `conicQuadraticForm C p = conicQuadraticForm (½·(C + Cᵀ)) p` |
| `symmetrizedConic_symmetric` | `(½·(C + Cᵀ)).symmetric` |
| `pointOnConic_iff_symmetrized` | `pointOnConic p C ↔ pointOnConic p (½·(C + Cᵀ))` |

## Why it holds

`conicQuadraticForm C p = ∑ᵢⱼ Cᵢⱼ pᵢ pⱼ` is a scalar, so it equals its own transpose `∑ᵢⱼ Cⱼᵢ pᵢ pⱼ` (swap the summation indices via `Finset.sum_comm`). Averaging the two equal expressions gives the symmetrized matrix `½·(C + Cᵀ)`, which is genuinely symmetric. Hence every conic has the **same point set** as its symmetric representative — the projective/zero-locus content transfers for free.

What remains for full axiom elimination: transferring the `det`-based non-degeneracy from `C` to `½·(C + Cᵀ)`, plus the degenerate case. (The oq-01 `IsometryEquiv→matrix` bridge — `exists_scaledCongr_stdConic_of_isotropic` / `sylvester_stdConic_of_isotropic` — was already complete in-file; this PR builds the next roadmap layer on top.)

## Verification

`./proofs/scripts/docker-build.sh Proofs.PascalsHexagon` → **Build succeeded** (Mathlib 4.26).
- New lemmas are **0-axiom, 0-sorry**. File axiom count unchanged (1, `conic_implies_pascal_constraint`).

`meta.json`: `theoremCount` 46→49, `lineCount` 1633→1680, new contribution entry (`sorries: 0` preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)