### PR TITLE
Add index.ts + overview annotation for Hilbert 5 OQ-02

### DIFF
--- a/src/data/proofs/hilbert-5-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-5-oq-02/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-h5oq02-overview",
+    "proofId": "hilbert-5-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 49
+    },
+    "type": "concept",
+    "title": "The Exponential Bridge from Lie Algebra to Lie Group",
+    "content": "Hilbert's 5th problem asks when a merely topological group secretly carries a smooth (Lie) structure; the Gleason–Montgomery–Zippin solution is far out of present-day Mathlib's reach, so the parent entry only axiomatizes its deep theorems. This file instead formalizes the genuine analytic/algebraic content that sits UNDERNEATH the Lie correspondence and IS in Mathlib: the Lie bracket of an associative algebra (⁅X,Y⁆ = X·Y − Y·X) and the Banach-algebra exponential map exp ℝ : 𝔸 → 𝔸. The exponential is the concrete bridge — an algebra element X is an infinitesimal generator (tangent vector at the identity) and t ↦ exp(t•X) is the one-parameter subgroup it generates. Everything holds in any real Banach algebra (NormedRing + NormedAlgebra ℝ + CompleteSpace), which includes bounded operators / real matrices — the setting of matrix Lie groups. Fully verified: 0 sorries, 0 axioms, no native_decide.",
+    "mathContext": "Generator $X \\in \\mathfrak{g}$, one-parameter subgroup $t \\mapsto \\exp(tX)$; the exponential map realizes the (local) Lie-algebra-to-Lie-group correspondence in any real Banach algebra.",
+    "significance": "supporting",
+    "relatedConcepts": ["Hilbert's fifth problem", "Lie correspondence", "exponential map", "Banach algebra", "matrix Lie groups"],
+    "prerequisites": ["the parent hilbert-5 entry", "Lie algebras and Lie groups", "Banach algebras"]
+  },
+  {
     "id": "ann-h5oq02-bracket",
     "proofId": "hilbert-5-oq-02",
     "range": {

--- a/src/data/proofs/hilbert-5-oq-02/index.ts
+++ b/src/data/proofs/hilbert-5-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Hilbert5OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hilbert5Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hilbert5Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hilbert5Oq02Data: ProofData = {
+  proof: hilbert5Oq02Proof,
+  annotations: hilbert5Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `hilbert-5-oq-02`.

## Gaps addressed
The entry had `meta.json` and 3 complete annotations but **no `index.ts`**, so the proof page rendered "proof not found" on the live site. The conceptual docstring (lines 3-49) was unannotated.

## Changes
- **Created `index.ts`** (required Vite entry point) so the page loads.
- **Added a 4th annotation** covering the docstring: Hilbert's 5th problem, why the deep Gleason–Montgomery–Zippin theorems are axiomatized in the parent, and how this file formalizes the in-Mathlib exponential bridge (Lie bracket + Banach-algebra `exp`) from Lie algebra to Lie group. Now 4/4 annotations carry `significance` + `mathContext` + `relatedConcepts` + `prerequisites`.

## Verification
- `meta.json` size check: within all caps.
- `annotations:build`: clean (no errors for this entry).
- JSON parses; schema matches `Annotation` type.
- (Full `tsc`/`vite build` blocked in-worktree by a `better-sqlite3` native-build incompatibility with node v26 — environment issue.)

Dedicated per-target branch to avoid clobbering sibling enrichment PRs.