### PR TITLE
Add missing index.ts for Lagrange Theorem OQ-02-OQ-01-OQ-02

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/index.ts
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LagrangeTheoremOQ02OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeTheoremOq02Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeTheoremOq02Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lagrangeTheoremOq02Oq01Oq02Data: ProofData = {
+  proof: lagrangeTheoremOq02Oq01Oq02Proof,
+  annotations: lagrangeTheoremOq02Oq01Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-02-oq-01-oq-02`.

## Gap addressed
The entry had `meta.json` and 3 complete annotations (each with `significance` + `mathContext`) covering the full 76-line file, but **no `index.ts`**, so the proof page rendered "proof not found" on the live site (Vite's `import.meta.glob` could not discover it).

## Changes
- **Created `index.ts`** (required Vite entry point) so the page loads. No annotation changes needed — the existing 3 annotations already cover the file (the Burnside-free point-side counting identity, the stabilizer half of the bijection, and the cardinality conclusion).

## Verification
- `meta.json` size check: within all caps.
- Confirmed the referenced Lean file exists and meta exposes `id`/`slug`/`meta`/`sections`.
- (Full `tsc`/`vite build` blocked in-worktree by a `better-sqlite3` native-build incompatibility with node v26 — environment issue.)

Dedicated per-target branch to avoid clobbering sibling enrichment PRs.