### PR TITLE
Enrich British Flag Theorem: index.ts + annotation coverage

### DIFF
--- a/src/data/proofs/british-flag-theorem-oq-01/annotations.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/annotations.json
@@ -24,6 +24,28 @@
     "crossReferences": []
   },
   {
+    "id": "ann-pt",
+    "proofId": "british-flag-theorem-oq-01",
+    "range": {
+      "startLine": 28,
+      "endLine": 29
+    },
+    "type": "definition",
+    "title": "The Plane as ℝ × ℝ",
+    "content": "`Pt := ℝ × ℝ` models a planar point as an ordered pair of real coordinates. This deliberately coordinate-based (rather than `EuclideanSpace ℝ (Fin 2)`) representation keeps every quantity a concrete polynomial in `.1`/`.2` projections, so the final identity is reachable by pure `ring`/`linear_combination` reasoning with no inner-product API. The trade-off is that the result is stated for the coordinate plane specifically; the same algebra lifts verbatim to ℝⁿ for the box analogue.",
+    "mathContext": "$\\mathrm{Pt} = \\mathbb{R}\\times\\mathbb{R}$; a point $P$ has coordinates $(P_1, P_2)$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Cartesian coordinates",
+      "product type ℝ × ℝ",
+      "EuclideanSpace"
+    ],
+    "prerequisites": [
+      "ordered pairs / product types"
+    ],
+    "crossReferences": []
+  },
+  {
     "id": "ann-sqdist",
     "proofId": "british-flag-theorem-oq-01",
     "range": {
@@ -62,6 +84,30 @@
     "prerequisites": [
       "polynomial identities over ℝ",
       "dot product and orthogonality"
+    ],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-tactic",
+    "proofId": "british-flag-theorem-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 46
+    },
+    "type": "technique",
+    "title": "subst · simp · linear_combination",
+    "content": "The entire proof is three tactic lines. `subst hpar` eliminates `C` by replacing it everywhere with the parallelogram closure `B + D − A`, turning a four-point statement into one about `A, B, D, P` only. `simp only [sqDist]` unfolds the squared-distance definition so the goal becomes a raw polynomial equation in the eight coordinates. Finally `linear_combination (2 : ℝ) * hperp` certifies the goal: it asks Lean to verify that goal-minus-`2·hperp` is the zero polynomial (discharged internally by `ring`). The coefficient `2` is exactly the factor by which the orthogonality form appears in the squared-distance difference — making explicit that the theorem is `2·(u ⬝ v) = 0` in disguise.",
+    "mathContext": "Goal $-\\,2\\cdot\\mathrm{hperp}$ reduces to $0$ by `ring`; equivalently $(PA^2+PC^2)-(PB^2+PD^2) - 2(u\\cdot v) \\equiv 0$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "linear_combination tactic",
+      "subst",
+      "ring normalization",
+      "certificate-style proof"
+    ],
+    "prerequisites": [
+      "Lean tactic mode",
+      "linear_combination and how it calls ring"
     ],
     "crossReferences": []
   }

--- a/src/data/proofs/british-flag-theorem-oq-01/index.ts
+++ b/src/data/proofs/british-flag-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BritishFlagTheorem.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const britishFlagTheoremOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const britishFlagTheoremOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const britishFlagTheoremOq01Data: ProofData = {
+  proof: britishFlagTheoremOq01Proof,
+  annotations: britishFlagTheoremOq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `british-flag-theorem-oq-01` (quality 76, pass 0).

## Critical fix
- **Created missing `index.ts`** — without it the page renders 'proof not found' on the live site. Follows the standard template (`britishFlagTheoremOq01`, source `Proofs/BritishFlagTheorem.lean`).

## Annotation coverage 3 → 5 (all with mathContext/significance/relatedConcepts/prerequisites)
- `Pt := ℝ × ℝ` — why the coordinate model (not EuclideanSpace) keeps the proof pure `ring`/`linear_combination`
- the `subst hpar; simp only [sqDist]; linear_combination (2:ℝ)*hperp` tactic block — the coefficient 2 makes explicit that the theorem is $2(u\cdot v)=0$ in disguise

## Verification
- JSON parses cleanly; 0/5 annotations missing depth fields; meta within all size caps
- meta.json already rich (overview, sections, conclusion, crossRefs, refs, mainTheorems) — left intact; axiom integrity unchanged (0 axioms / verified)