### PR TITLE
Add index.ts + overview annotation for Law of Cosines OQ-07 (Apollonius)

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-07/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-07/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-loc07-overview",
+    "proofId": "law-of-cosines-oq-07",
+    "range": { "startLine": 3, "endLine": 38 },
+    "type": "concept",
+    "title": "Apollonius in Coordinate-Free Metric Form",
+    "content": "This OQ states Apollonius's median theorem directly over an arbitrary real inner-product affine space (a NormedAddTorsor over an InnerProductSpace ℝ) and derives the parallelogram law from it — no coordinates, no scalar side-length parametrization. Three results are packaged: apollonius (the median identity dist² a b + dist² a c = 2(median² + (½·bc)²)), median_length (the explicit rearrangement 4mₐ² = 2b² + 2c² − a²), and parallelogram_law (‖x+y‖² + ‖x−y‖² = 2(‖x‖²+‖y‖²) as a vector-space special case, since a parallelogram's diagonals bisect each other at a common midpoint). It is deliberately DISTINCT from the sibling law-of-cosines-oq-04, whose median formula is a scalar identity in ℝ-valued side lengths from Stewart's algebra — here the objects are genuine points and midpoints.",
+    "mathContext": "Apollonius (metric): $\\mathrm{dist}(a,b)^2+\\mathrm{dist}(a,c)^2=2\\big(\\mathrm{dist}(a,\\mathrm{mid}(b,c))^2+(\\tfrac12\\mathrm{dist}(b,c))^2\\big)$; parallelogram law follows.",
+    "significance": "supporting",
+    "relatedConcepts": ["Apollonius's theorem", "median identity", "parallelogram law", "inner-product affine space", "coordinate-free geometry"],
+    "prerequisites": ["NormedAddTorsor / affine spaces", "inner product spaces", "midpoints"]
+  },
+  {
     "id": "ann-apollonius",
     "proofId": "law-of-cosines-oq-07",
     "range": {

--- a/src/data/proofs/law-of-cosines-oq-07/index.ts
+++ b/src/data/proofs/law-of-cosines-oq-07/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LawOfCosinesOQ07.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lawOfCosinesOq07Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lawOfCosinesOq07Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lawOfCosinesOq07Data: ProofData = {
+  proof: lawOfCosinesOq07Proof,
+  annotations: lawOfCosinesOq07Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `law-of-cosines-oq-07`.

## Gaps addressed
The entry had `meta.json` and 3 complete annotations but **no `index.ts`**, so the proof page rendered "proof not found" on the live site. The docstring (lines 3-38) was unannotated.

## Changes
- **Created `index.ts`** (required Vite entry point) so the page loads.
- **Added a 4th annotation** covering the docstring: Apollonius's coordinate-free metric median theorem over a real inner-product affine space, the three packaged results (median identity, explicit median length, parallelogram law), and the contrast with the scalar sibling `law-of-cosines-oq-04`. Now 4/4 annotations carry `significance` + `mathContext` + `relatedConcepts` + `prerequisites`.

## Verification
- `meta.json` size check: within all caps.
- `annotations:build`: clean for this exact entry (a build note on the sibling `law-of-cosines-oq-07-oq-02` is pre-existing and unrelated).
- (Full `tsc`/`vite build` blocked in-worktree by a `better-sqlite3` native-build incompatibility with node v26 — environment issue.)

Dedicated per-target branch to avoid clobbering sibling enrichment PRs.