### PR TITLE
Enrich Property B: Deterministic Recoloring — index.ts + coverage

### DIFF
--- a/src/data/proofs/property-b-first-moment-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-pbfm-oq03oq02-context",
+    "proofId": "property-b-first-moment-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "context",
+    "title": "Recoloring vs Deletion: the Alteration Method Toward Radhakrishnan–Srinivasan",
+    "content": "The header situates this file in the Property B program. The parent `PropertyBFirstMoment.lean` proves Erdős 1963 (a k-uniform family with `< 2^(k-1)` edges is 2-colorable) by the first moment. The deletion sibling `PropertyBFirstMomentOQ03.lean` *discards* monochromatic edges to expose a 2-colorable subfamily — it throws edges away. This file formalizes the complementary and harder half, *recoloring*: rather than delete a bad edge, *repair* it by flipping a vertex, yielding FULL 2-colorability. This is the deterministic core of the Radhakrishnan–Srinivasan (RS) alteration. RS must recolor *probabilistically* because, in general, monochromatic edges share vertices and flipping one edge's vertex can break another. The deterministic statement isolates the dependency-free case (each bad edge owns a private vertex); the remaining gap to RS is exactly removing the privacy hypothesis via randomness — the analytic step the open question targets.",
+    "mathContext": "Deletion: $E \\setminus M$ is 2-colorable (subfamily). Recoloring: flip private vertices to make all of $E$ 2-colorable. RS = recoloring + randomness to drop the privacy hypothesis.",
+    "significance": "context",
+    "relatedConcepts": ["alteration method", "deletion method", "Radhakrishnan–Srinivasan", "first-moment method", "probabilistic recoloring"],
+    "prerequisites": ["Erdős 1963 first-moment bound 2^(k-1)", "the deletion-method sibling", "monochromatic edge / 2-colorability (Property B)"]
+  },
+  {
     "id": "ann-pbfm-oq03oq02-recoloring",
     "proofId": "property-b-first-moment-oq-03-oq-02",
     "range": { "startLine": 54, "endLine": 117 },
@@ -34,5 +46,17 @@
     "significance": "supporting",
     "relatedConcepts": ["matching", "disjoint edges", "alteration baseline"],
     "prerequisites": ["the recoloring lemma"]
+  },
+  {
+    "id": "ann-pbfm-oq03oq02-construction",
+    "proofId": "property-b-first-moment-oq-03-oq-02",
+    "range": { "startLine": 62, "endLine": 70 },
+    "type": "technique",
+    "title": "The Explicit Repaired Coloring c' = flip-on-S",
+    "content": "The proof is constructive: it exhibits the witnessing coloring rather than arguing existence abstractly. `set M := E.filter (Mono · c)` names the monochromatic edges and `set S := M.image w` the finite set of their private vertices. The repaired coloring is the single `if`-expression `c' x = if x ∈ S then !c x else c x` — flip exactly the private vertices, leave everything else fixed. Everything downstream is `simp [hc'def, hxS]`-style case evaluation of this `if` at vertices in or out of `S`, using decidable membership `x ∈ S`. Naming `M` and `S` with `set` keeps the two membership characterizations (`memM`, `memS`) reusable across both branches of the `by_cases hmono` split.",
+    "mathContext": "$c'(x) = \\begin{cases}\\neg c(x) & x \\in S \\\\ c(x) & x \\notin S\\end{cases}$, $\\quad S = \\{w(e) : e \\in M\\}$, $\\quad M = \\{e \\in E : \\mathrm{Mono}(e,c)\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["constructive existence proof", "set tactic", "decidable membership", "if-then-else coloring"],
+    "prerequisites": ["Finset.filter / Finset.image", "DecidableEq for membership in S", "the set tactic"]
   }
 ]

--- a/src/data/proofs/property-b-first-moment-oq-03-oq-02/index.ts
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PropertyBFirstMomentRecoloring.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const propertyBFirstMomentOq03Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const propertyBFirstMomentOq03Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const propertyBFirstMomentOq03Oq02Data: ProofData = {
+  proof: propertyBFirstMomentOq03Oq02Proof,
+  annotations: propertyBFirstMomentOq03Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `property-b-first-moment-oq-03-oq-02` (quality 79, pass 0).

## Critical fix
- **Created missing `index.ts`** — without it the page renders 'proof not found' on the live site (`propertyBFirstMomentOq03Oq02`, source `Proofs/PropertyBFirstMomentRecoloring.lean`).

## Annotation coverage 3 → 5 (all with depth fields)
- **Context** (header): recoloring vs the deletion sibling, and how the deterministic private-vertex case is the dependency-free core of the Radhakrishnan–Srinivasan alteration
- **Technique**: the explicit constructive witness `c' x = if x∈S then !c x else c x`, `set M/S`, decidable membership

## Verification
- JSON parses cleanly; 0/5 annotations missing depth fields; meta within all size caps
- meta.json already rich — left intact; axiom integrity unchanged (0 axioms / verified, no native_decide)