### PR TITLE
Add index.ts + overview annotation for Shannon BEC coding OQ-02

### DIFF
--- a/src/data/proofs/shannon-channel-coding-bec-oq-02/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
     {
+        "id": "ann-bec-oq02-overview",
+        "proofId": "shannon-channel-coding-bec-oq-02",
+        "range": { "startLine": 1, "endLine": 51 },
+        "type": "concept",
+        "title": "From Information-Theoretic to Operational BEC Capacity (Honestly Axiomatized)",
+        "content": "The base entry proves the binary erasure channel's INFORMATION-theoretic capacity axiom-free: channelCapacity(bec p) = (1−p)·log 2 nats = (1−p) bits, a supremum of mutual informations over input distributions. That says nothing about codes. This OQ bridges to the OPERATIONAL layer — rates achievable by block codes with vanishing error, plus a matching converse forbidding reliable communication above capacity. It does so by specialising the gallery's abstract discrete-memoryless-channel theorems channel_coding_achievability and channel_coding_converse to the concrete BEC, substituting the proved capacity value. Crucially those two abstract theorems are AXIOMS in this gallery (the deep random-coding / Fano arguments are taken as given), so every operational result here is honestly axiomatized: status 'axiomatized', badge 'axiom', axiomCount 2. The BEC capacity value itself remains axiom-free. The four results (achievability/converse, each in nats and bits) together pin the BEC's operational capacity to exactly (1−p)·log 2.",
+        "mathContext": "$\\mathrm{channelCapacity}(\\mathrm{bec}\\,p) = (1-p)\\log 2$ nats $= (1-p)$ bits; operational achievability for $R < C$ and converse for $R > C$ inherited from the axiomatized abstract coding theorems.",
+        "significance": "supporting",
+        "relatedConcepts": ["binary erasure channel", "Shannon channel coding theorem", "operational vs information-theoretic capacity", "achievability and converse", "random coding / Fano"],
+        "prerequisites": ["the base BEC capacity entry", "discrete memoryless channels", "block codes and rate"]
+    },
+    {
         "id": "ann-bec-achievability",
         "proofId": "shannon-channel-coding-bec-oq-02",
         "range": {

--- a/src/data/proofs/shannon-channel-coding-bec-oq-02/index.ts
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ShannonChannelCodingBECOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const shannonChannelCodingBecOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const shannonChannelCodingBecOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const shannonChannelCodingBecOq02Data: ProofData = {
+  proof: shannonChannelCodingBecOq02Proof,
+  annotations: shannonChannelCodingBecOq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `shannon-channel-coding-bec-oq-02`.

## Gaps addressed
The entry had `meta.json` and 4 complete annotations but **no `index.ts`**, so the proof page rendered "proof not found" on the live site. The docstring (lines 1-51) was unannotated.

## Changes
- **Created `index.ts`** (required Vite entry point) so the page loads.
- **Added a 5th annotation** covering the docstring: the bridge from information-theoretic BEC capacity $(1-p)\log 2$ to the operational layer, and an explicit note that the entry is **honestly axiomatized** (it inherits the abstract `channel_coding_achievability`/`channel_coding_converse` axioms, `axiomCount: 2`).

## Axiom integrity
Verified meta is accurate: `status: axiomatized`, `badge: axiom`, `axiomCount: 2`, with `assumptions` documenting the two inherited abstract coding theorems. The BEC capacity value itself is axiom-free. No overclaiming. Now 5/5 annotations carry `significance` + `mathContext` + `relatedConcepts` + `prerequisites`.

## Verification
- `meta.json` size check: within all caps.
- `annotations:build`: clean for this entry.
- (Full `tsc`/`vite build` blocked in-worktree by a `better-sqlite3` native-build incompatibility with node v26 — environment issue.)

Dedicated per-target branch to avoid clobbering sibling enrichment PRs.