### PR TITLE
research(erdos-564-incomplete-01): triviality boundary of the Ramsey property [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos564Incomplete01.lean
+++ b/proofs/Proofs/Erdos564Incomplete01.lean
@@ -189,4 +189,71 @@ theorem hasHypergraphRamseyProperty_antitone_clique {k m n n' : ℕ} (hnn : n' �
   obtain ⟨T, hTsub, hTcard⟩ := Finset.le_card_iff_exists_subset_card.mp (hScard ▸ hnn)
   exact ⟨T, colour, hTcard, fun e hesub hecard => hSmono e (hesub.trans hTsub) hecard⟩
 
+/-! ## The triviality boundary of the Ramsey property
+
+The monotonicity lemmas above describe how the property *propagates*; this section pins
+down where it *starts* — the base cases the whole threshold picture rests on.  The property
+`HasHypergraphRamseyProperty k m n` is **trivially true whenever the target clique is no
+larger than the edge size**, `n ≤ k` (and `n ≤ m` so an `n`-set exists at all):
+
+* `n < k` — a clique on `< k` vertices has **no** `k`-subsets, so the monochromaticity
+  condition is vacuous (any `n`-set, any colour, works);
+* `n = k` — a clique on exactly `k` vertices has a **single** `k`-subset, namely itself, so
+  it is automatically monochromatic for the colour that the colouring already assigns it.
+
+Equivalently `R_k(n) = n` for `n ≤ k`: the Ramsey number is degenerate below the diagonal,
+and the genuine combinatorial content of `R₃(n)` (the Erdős #564 regime) only appears for
+`n > k = 3`.  All results are **0-axiom** (they never touch `R` or the EHR bounds). -/
+
+/-- The property holds vacuously for the empty clique (`n = 0`): take `S = ∅`, whose only
+subset is `∅` itself, monochromatic for the colour `c ∅`. -/
+theorem hasHypergraphRamseyProperty_clique_zero (k m : ℕ) :
+    HasHypergraphRamseyProperty k m 0 := by
+  intro c
+  refine ⟨∅, c ∅, Finset.card_empty, ?_⟩
+  intro e he _
+  rw [Finset.subset_empty.mp he]
+
+/-- **Sub-uniformity cliques are free.** If `n < k` then an `n`-clique has no `k`-subsets,
+so the monochromaticity condition is vacuous: any `n`-element vertex set (which exists since
+`n ≤ m`) witnesses the property, with an arbitrary colour. -/
+theorem hasHypergraphRamseyProperty_clique_lt_uniformity {k m n : ℕ}
+    (hn : n < k) (hnm : n ≤ m) : HasHypergraphRamseyProperty k m n := by
+  intro c
+  obtain ⟨S, _, hScard⟩ :=
+    Finset.le_card_iff_exists_subset_card.mp
+      (show n ≤ (Finset.univ : Finset (Fin m)).card by simpa using hnm)
+  refine ⟨S, true, hScard, ?_⟩
+  intro e he hecard
+  have hle : e.card ≤ n := hScard ▸ Finset.card_le_card he
+  omega
+
+/-- **Diagonal base case.** For `n = k` (and `k ≤ m`) the property holds: any `k`-element
+vertex set `S` has exactly one `k`-subset — itself — so colouring it the colour `c S` makes
+it monochromatic.  Hence `R_k(k) = k`. -/
+theorem hasHypergraphRamseyProperty_diagonal_base {k m : ℕ} (hkm : k ≤ m) :
+    HasHypergraphRamseyProperty k m k := by
+  intro c
+  obtain ⟨S, _, hScard⟩ :=
+    Finset.le_card_iff_exists_subset_card.mp
+      (show k ≤ (Finset.univ : Finset (Fin m)).card by simpa using hkm)
+  refine ⟨S, c S, hScard, ?_⟩
+  intro e he hecard
+  have heq : e = S :=
+    Finset.eq_of_subset_of_card_le he (le_of_eq (hScard.trans hecard.symm))
+  rw [heq]
+
+/-- **The triviality boundary, unified.** Whenever the target clique is no larger than the
+edge size, `n ≤ k`, and fits in the vertex set, `n ≤ m`, the Ramsey property holds.  This is
+the sharp statement that `R_k(n) = n` for all `n ≤ k`: the Ramsey number is degenerate on
+and below the diagonal, so the substance of Erdős #564 lives strictly above it (`n > k`). -/
+theorem hasHypergraphRamseyProperty_of_clique_le_uniformity {k m n : ℕ}
+    (hn : n ≤ k) (hnm : n ≤ m) : HasHypergraphRamseyProperty k m n := by
+  rcases lt_or_eq_of_le hn with h | h
+  · exact hasHypergraphRamseyProperty_clique_lt_uniformity h hnm
+  · subst h; exact hasHypergraphRamseyProperty_diagonal_base hnm
+
+#print axioms hasHypergraphRamseyProperty_of_clique_le_uniformity
+#print axioms hasHypergraphRamseyProperty_clique_zero
+
 end Erdos564.Incomplete01

--- a/research/problems/erdos-564-incomplete-01/knowledge.md
+++ b/research/problems/erdos-564-incomplete-01/knowledge.md
@@ -133,3 +133,28 @@ real EHR lower bound is `2^{cn²}` — a QUADRATIC exponent. Added the faithful 
 ### Verification
 - `#print axioms` on all three → foundational only; NONE of the parent's 3 axioms pulled in.
 - 13→16 theorems, 153→192 lines, 0 axioms, 0 sorries. The open conjecture ($500) stays out of reach.
+
+## Session (researcher-2, 2026-06-30): triviality boundary of the Ramsey property
+
+**Mode**: SOLVED→look-outward (sharp boundary). File 192→259 lines, 16→20 thm,
+still 0-axiom / 0-sorry (`#print axioms` of the new headline = propext/Classical.choice/
+Quot.sound; parent R/EHR axioms untouched). VERIFIED via docker-build.
+
+The monotonicity API (sessions 1–2) described how the property *propagates* but had **no
+base case**. Added the triviality boundary — `R_k(n) = n` for `n ≤ k`:
+- `hasHypergraphRamseyProperty_clique_zero` — n=0, S=∅, only subset ∅ monochromatic (c ∅).
+- `hasHypergraphRamseyProperty_clique_lt_uniformity (hn : n<k) (hnm : n≤m)` — n-clique has
+  no k-subsets ⟹ edge condition vacuous; witness any n-set, colour `true`. Edge contradiction
+  via `e.card ≤ S.card = n < k` + omega.
+- `hasHypergraphRamseyProperty_diagonal_base (hkm : k≤m)` — n=k, only k-subset of a k-set is
+  itself (`Finset.eq_of_subset_of_card_le`), colour := c S.
+- `hasHypergraphRamseyProperty_of_clique_le_uniformity (hn : n≤k) (hnm : n≤m)` — unified
+  via `rcases lt_or_eq_of_le hn`. The sharp statement that R₃(n) is degenerate for n ≤ 3,
+  so Erdős #564's content lives strictly above the diagonal.
+
+GOTCHAs: this Mathlib uses `Finset.le_card_iff_exists_subset_card` (n ≤ s.card ↔ ∃ t⊆s, card=n)
+to extract a fixed-size subset — NOT `exists_subset_card_eq`. Build `n ≤ univ.card` for Fin m
+by `simpa using hnm` (univ.card → Fintype.card (Fin m) → m). `Finset.eq_of_subset_of_card_le
+he (le_of_eq (hScard.trans hecard.symm))` for the n=k single-subset step.
+
+The open $500 conjecture (R₃(n) ≥ 2^{2^{cn}}) remains out of reach.

--- a/src/data/proofs/erdos-564-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-564-incomplete-01/meta.json
@@ -32,11 +32,14 @@
       "tower_two_eq: tower 2 n = 2 ^ (2 ^ n), the doubly-exponential height in both the EHR upper bound and the conjectured lower bound",
       "tower_one_lt_tower_two: THE CRUX of Erdős #564 made precise — the singly-exponential known lower bound (tower height 1) is strictly below the doubly-exponential conjectured lower bound (tower height 2) for every n; the exact height gap the open conjecture asks to close",
       "Concrete sanity checks: tower 2 3 = 256, tower 3 1 = 16, 5 ≤ tower 4 5",
-      "Parent fix: repaired six dangling /-- doc comments (lines 65, 66, 153, 154, 164, 186) in Erdos564Problem.lean that caused 'unexpected token /--; expected lemma' parse errors — the parent file did not compile at all on main"
+      "Parent fix: repaired six dangling /-- doc comments (lines 65, 66, 153, 154, 164, 186) in Erdos564Problem.lean that caused 'unexpected token /--; expected lemma' parse errors — the parent file did not compile at all on main",
+      "ehr_lower_lt_tower_two / nsq_lt_two_pow_self: the faithful QUADRATIC crux — the real EHR lower bound 2^{n²} (quadratic exponent) is still a whole tower level below the conjectured 2^{2^n}, since n² < 2^n for n ≥ 5",
+      "hasHypergraphRamseyProperty_mono / _antitone_clique: the first theory of the property predicate itself — vertex monotonicity (good-m set upward closed) and clique-size antitonicity (R k · monotone in clique size)",
+      "hasHypergraphRamseyProperty_clique_zero / _clique_lt_uniformity / _diagonal_base / _of_clique_le_uniformity: the TRIVIALITY BOUNDARY — the property is trivially true for n ≤ k (clique no larger than edge size): n < k makes the k-subset condition vacuous, n = k leaves a single self-monochromatic k-subset. Equivalently R_k(n) = n for n ≤ k, so the genuine content of R₃(n) lives strictly above the diagonal (n > 3)"
     ],
     "dateAdded": "2026-06-27",
-    "lineCount": 192,
-    "theoremCount": 11,
+    "lineCount": 259,
+    "theoremCount": 20,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
   },
@@ -86,6 +89,13 @@
     }
   ],
   "mainTheorems": [
+    {
+      "name": "hasHypergraphRamseyProperty_of_clique_le_uniformity",
+      "type": "theorem",
+      "statement": "$n \\le k \\to n \\le m \\to \\text{HasHypergraphRamseyProperty}\\,k\\,m\\,n$",
+      "significance": "The triviality boundary of the Ramsey property: it holds automatically whenever the target clique is no larger than the edge size (n ≤ k). Equivalently R_k(n) = n for n ≤ k — the Ramsey number is degenerate on and below the diagonal, so the genuine combinatorial content of R₃(n) (the Erdős #564 regime) appears only for n > 3. This is the base case the threshold/monotonicity picture rests on.",
+      "description": "Case split on n < k vs n = k. For n < k an n-clique has no k-subsets, so the monochromaticity condition is vacuous; for n = k the unique k-subset of a k-set is itself, monochromatic for the colour the colouring assigns it (c S)."
+    },
     {
       "name": "tower_lt_succ_height",
       "type": "theorem",
@@ -158,9 +168,9 @@
       "Proofs.Erdos564Problem"
     ],
     "namespace": "Erdos564.Incomplete01",
-    "lineCount": 192,
+    "lineCount": 259,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 20,
     "definitionCount": 0,
     "path": "Proofs/Erdos564Incomplete01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds the **base case** the existing monotonicity API (`…_mono`, `…_antitone_clique`) was
missing for the Erdős #564 entry: the `HasHypergraphRamseyProperty k m n` is **trivially
true whenever the target clique is no larger than the edge size**, `n ≤ k`. Equivalently
`R_k(n) = n` on and below the diagonal, so the genuine combinatorial content of `R₃(n)`
(the Erdős #564 regime) appears only for `n > k = 3`.

**VERIFIED, 0-axiom** — Docker build succeeds; `#print axioms` of the new headline reports
only `propext / Classical.choice / Quot.sound` (the parent's `R` / EHR axioms are untouched).

## New content (192 → 259 lines, 16 → 20 theorems; still 0 axioms / 0 sorries)

- `hasHypergraphRamseyProperty_clique_zero` — `n = 0` holds vacuously (`S = ∅`)
- `hasHypergraphRamseyProperty_clique_lt_uniformity` — `n < k` ⟹ an `n`-clique has no `k`-subsets ⟹ monochromaticity condition vacuous
- `hasHypergraphRamseyProperty_diagonal_base` — `n = k` ⟹ the unique `k`-subset of a `k`-set is itself, monochromatic for `c S`
- `hasHypergraphRamseyProperty_of_clique_le_uniformity` — unified `n ≤ k` boundary: the sharp statement `R_k(n) = n` for `n ≤ k`

## Honesty

The open `$500` conjecture (`R₃(n) ≥ 2^{2^{cn}}`) remains **out of reach**. This is the
trivial-boundary base case that makes the threshold/monotonicity picture of `R_k` precise;
it does not approach the conjecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)