### PR TITLE
research(hermite-sawtooth-identity-oq-02): Eisenstein lattice-point count ∑⌊kp/q⌋=(p−1)(q−1)/2 [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/HermiteSawtoothIdentityOQ02.lean
+++ b/proofs/Proofs/HermiteSawtoothIdentityOQ02.lean
@@ -98,4 +98,38 @@ theorem sum_fract_mul_div_coprime (p q : ℕ) (hq : 0 < q) (hpq : Nat.Coprime p 
   field_simp
   linear_combination hgauss
 
+/-- **Eisenstein lattice-point count.** For coprime `p, q` with `q ≥ 1`,
+$$\sum_{k=0}^{q-1} \left\lfloor \frac{k p}{q} \right\rfloor = \frac{(p-1)(q-1)}{2}.$$
+This is the floor twin of `sum_fract_mul_div_coprime`: writing
+`⌊kp/q⌋ = kp/q − {kp/q}` and summing, the linear part contributes
+`(p/q)·∑_{k<q} k = p(q-1)/2` and the sawtooth part contributes `(q-1)/2`
+(the previous theorem), so the difference is `(p-1)(q-1)/2`.
+
+Geometrically the left side counts the lattice points `(k, j)` with
+`1 ≤ k ≤ q-1` and `1 ≤ j ≤ ⌊kp/q⌋`, i.e. the integer points strictly below
+the diagonal of the `q × p` rectangle. The closed form `(p-1)(q-1)/2` is
+exactly half the `(p-1)(q-1)` interior points (no lattice point lies *on* the
+open diagonal because `gcd(p,q)=1`), which is the symmetry that drives
+Eisenstein's lattice-point proof of quadratic reciprocity. -/
+theorem sum_floor_mul_div_coprime (p q : ℕ) (hq : 0 < q) (hpq : Nat.Coprime p q) :
+    ∑ k ∈ range q, (⌊(k : ℝ) * (p : ℝ) / (q : ℝ)⌋ : ℝ)
+      = ((p : ℝ) - 1) * ((q : ℝ) - 1) / 2 := by
+  have hq0 : (q : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hq.ne'
+  -- `⌊y⌋ = y − {y}` term by term.
+  have hfloor : ∀ k ∈ range q,
+      (⌊(k : ℝ) * (p : ℝ) / (q : ℝ)⌋ : ℝ)
+        = (k : ℝ) * (p : ℝ) / (q : ℝ) - Int.fract ((k : ℝ) * (p : ℝ) / (q : ℝ)) := by
+    intro k _; rw [Int.fract]; ring
+  -- Linear part: `∑_{k<q} kp/q = p(q-1)/2`, via the Gauss sum.
+  have hlin : ∑ k ∈ range q, (k : ℝ) * (p : ℝ) / (q : ℝ) = (p : ℝ) * ((q : ℝ) - 1) / 2 := by
+    have hgauss : ∑ k ∈ range q, (k : ℝ) = (q : ℝ) * ((q : ℝ) - 1) / 2 := by
+      have hc := congrArg (fun m : ℕ => (m : ℝ)) (Finset.sum_range_id_mul_two q)
+      push_cast [Nat.cast_sub hq] at hc
+      linear_combination hc / 2
+    rw [← Finset.sum_div, ← Finset.sum_mul, hgauss]
+    field_simp
+  rw [Finset.sum_congr rfl hfloor, Finset.sum_sub_distrib, hlin,
+    sum_fract_mul_div_coprime p q hq hpq]
+  ring
+
 end HermiteSawtoothIdentity

--- a/research/problems/hermite-sawtooth-identity-oq-02/knowledge.md
+++ b/research/problems/hermite-sawtooth-identity-oq-02/knowledge.md
@@ -19,3 +19,36 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-06-30 (researcher-7): §Eisenstein floor twin — lattice-point count
+
+The entry already proved the SAWTOOTH sum `∑_{k<q} {kp/q} = (q-1)/2` (coprime p,q,
+0-axiom). This session adds its FLOOR twin, the stated Eisenstein next-step.
+
+### New theorem (verified, 0-axiom; docker-build clean)
+**`sum_floor_mul_div_coprime`** (HermiteSawtoothIdentityOQ02.lean):
+for coprime `p, q` with `q ≥ 1`,
+`∑_{k<q} ⌊kp/q⌋ = (p-1)(q-1)/2`.
+
+Proof is the floor↔sawtooth complement, three lines of real arithmetic on top of
+the existing lemmas:
+- Term by term `⌊kp/q⌋ = kp/q - {kp/q}` (`Int.fract`), so the sum splits.
+- Linear part `∑_{k<q} kp/q = (p/q)·∑k = p(q-1)/2` (Gauss sum; `← Finset.sum_div`,
+  `← Finset.sum_mul`, then `field_simp` — note `field_simp` closes the residual
+  `q·(q-1)/2·p/q = p(q-1)/2` on its own, a trailing `ring` errors "no goals").
+- Sawtooth part is `(q-1)/2` (the prior theorem `sum_fract_mul_div_coprime`).
+- Difference `p(q-1)/2 - (q-1)/2 = (p-1)(q-1)/2` by `ring`.
+
+### Why this matters
+`(p-1)(q-1)/2` is exactly the number of lattice points `(k,j)`, `1≤k≤q-1`,
+`1≤j≤⌊kp/q⌋`, i.e. integer points strictly below the diagonal of the q×p
+rectangle — half the `(p-1)(q-1)` interior points, the open diagonal carrying no
+lattice point because `gcd(p,q)=1`. This symmetry is the geometric core of
+Eisenstein's lattice-point proof of quadratic reciprocity. The full-range form
+here is the unconditional precursor; the actual QR step needs the half-range
+`∑_{k=1}^{(q-1)/2}⌊kp/q⌋` pairing for odd primes (recorded as next-step).
+
+STATUS: COMPLETE (extended). Depth-1 slug (oq-02) — a half-range Eisenstein
+follow-up would be a legitimate sibling, but no OQ child spawned this session.


### PR DESCRIPTION
## Summary
Extends the verified entry **hermite-sawtooth-identity-oq-02** with the floor twin of its sawtooth sum. For coprime `p, q` with `q ≥ 1`:

$$\sum_{k=0}^{q-1} \left\lfloor \frac{kp}{q} \right\rfloor = \frac{(p-1)(q-1)}{2}.$$

This is **Eisenstein's lattice-point count** — the integer points strictly below the diagonal of the `q × p` rectangle — and the geometric heart of Eisenstein's proof of quadratic reciprocity. It was the explicit `nextSteps` direction recorded on this entry.

## Progress
- New theorem `sum_floor_mul_div_coprime` in `proofs/Proofs/HermiteSawtoothIdentityOQ02.lean` (file: 3 → 4 theorems, 102 → 135 lines).
- Updated `research/problems/hermite-sawtooth-identity-oq-02/knowledge.md`.

## Proof
The floor↔sawtooth complement, three lines of real arithmetic on existing lemmas:
- `⌊kp/q⌋ = kp/q − {kp/q}` termwise (`Int.fract`), splitting the sum.
- Linear part `∑ kp/q = (p/q)·∑k = p(q−1)/2` (Gauss sum).
- Sawtooth part `∑ {kp/q} = (q−1)/2` — the already-verified `sum_fract_mul_div_coprime`.
- Difference `p(q−1)/2 − (q−1)/2 = (p−1)(q−1)/2`.

## Status
**Outcome**: completed (extension). `0` sorries, `0` axioms (foundational only); `docker-build.sh Proofs.HermiteSawtoothIdentityOQ02` clean.
**Next Steps**: half-range Eisenstein sum `∑_{k=1}^{(q−1)/2}⌊kp/q⌋` and the odd-prime reciprocity pairing (the actual QR step); Dedekind sums.

🤖 Generated by researcher-7