### PR TITLE
Enrich Hilbert 5 OQ-02: exponential bridge — index.ts + coverage

### DIFF
--- a/src/data/proofs/hilbert-5-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-5-oq-02/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-h5oq02-context",
+    "proofId": "hilbert-5-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 49
+    },
+    "type": "context",
+    "title": "What is axiomatized in the parent, and what is genuinely verified here",
+    "content": "This file answers the parent entry's open question: 'extend the formalization with actual Lie infrastructure to state the exponential map properties.' The parent `hilbert-5` states the Gleason–Montgomery–Zippin solution at the level of *axiomatized* deep theorems (no-small-subgroups, Montgomery–Zippin, von Neumann) that are out of reach of current Mathlib. This file deliberately does NOT axiomatize: it works entirely inside the analytic/algebraic content that already lives in Mathlib — the Lie bracket of an associative algebra and the Banach-algebra exponential `NormedSpace.exp ℝ` — and proves everything with 0 axioms. The conceptual payload: the exponential is the concrete bridge from the Lie algebra (an element `X` as an infinitesimal generator/tangent vector at the identity) to the Lie group (the one-parameter subgroup `t ↦ exp(t•X)`). Everything holds in any real Banach algebra, which includes bounded operators/matrices over ℝ — the setting of matrix Lie groups.",
+    "mathContext": "Setting: $\\mathbb{A}$ a real Banach algebra ($[\\mathrm{NormedRing}\\,\\mathbb{A}]\\,[\\mathrm{NormedAlgebra}\\,\\mathbb{R}\\,\\mathbb{A}]\\,[\\mathrm{CompleteSpace}\\,\\mathbb{A}]$); the exponential $\\exp_{\\mathbb{R}}:\\mathbb{A}\\to\\mathbb{A}$ converges on all of $\\mathbb{A}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Hilbert's fifth problem",
+      "Lie correspondence (algebra ↔ group)",
+      "axiomatized vs verified results",
+      "matrix Lie groups",
+      "Banach algebra"
+    ],
+    "prerequisites": [
+      "the parent hilbert-5 entry and its open questions",
+      "Lie groups and Lie algebras at a high level",
+      "the exponential map of a Banach algebra"
+    ]
+  },
+  {
     "id": "ann-h5oq02-bracket",
     "proofId": "hilbert-5-oq-02",
     "range": {
@@ -70,6 +95,29 @@
       "the Banach-algebra exponential",
       "scalar multiplication in an algebra",
       "one-parameter subgroups"
+    ]
+  },
+  {
+    "id": "ann-h5oq02-omit",
+    "proofId": "hilbert-5-oq-02",
+    "range": {
+      "startLine": 59,
+      "endLine": 73
+    },
+    "type": "technique",
+    "title": "omit: stating the bracket lemmas at maximal generality",
+    "content": "The `variable` line fixes a full real Banach algebra `[NormedRing 𝔸] [NormedAlgebra ℝ 𝔸] [CompleteSpace 𝔸]`, which the exponential results genuinely need. But the bracket↔commutator lemmas (`commute_of_lie_eq_zero`, `lie_eq_zero_of_commute`, `lie_eq_zero_iff_commute`) are *purely algebraic* — they hold in any (non-normed, incomplete) associative ring. Each is therefore prefixed with `omit [NormedAlgebra ℝ 𝔸] [CompleteSpace 𝔸] in`, which drops the unused instance arguments for that single declaration. This keeps each theorem's hypotheses as weak as its proof allows — honest about what is actually used — without splitting the file into separate sections with different `variable` contexts. The same `omit` appears on `oneParam_zero`, which needs the exponential but not completeness.",
+    "mathContext": "Generality discipline: the bracket identity $\\lbrack X,Y\\rbrack = 0 \\iff XY = YX$ requires only a (Lie-)ring structure, so the normed/complete instances are omitted.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "omit command",
+      "typeclass instance hypotheses",
+      "minimal hypotheses / generality",
+      "variable scoping in Lean"
+    ],
+    "prerequisites": [
+      "Lean variable and instance-implicit arguments",
+      "the omit command"
     ]
   }
 ]

--- a/src/data/proofs/hilbert-5-oq-02/index.ts
+++ b/src/data/proofs/hilbert-5-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Hilbert5OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hilbert5Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hilbert5Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hilbert5Oq02Data: ProofData = {
+  proof: hilbert5Oq02Proof,
+  annotations: hilbert5Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `hilbert-5-oq-02` (quality 83, pass 0).

## Critical fix
- **Created missing `index.ts`** — without it the page renders 'proof not found' on the live site (`hilbert5Oq02`, source `Proofs/Hilbert5OQ02.lean`).

## Annotation coverage 3 → 5 (all with depth fields)
- **Context** (header): the parent states Gleason–Montgomery–Zippin via *axiomatized* deep theorems; this file instead proves the genuine Mathlib-backed substrate (Lie bracket + Banach-algebra exponential) with 0 axioms, in any real Banach algebra (matrices/operators over ℝ)
- **Technique**: the `omit [NormedAlgebra ℝ 𝔸] [CompleteSpace 𝔸]` discipline stating the bracket↔commutator lemmas at maximal (pure-ring) generality

## Verification
- JSON parses cleanly; 0/5 annotations missing depth fields; meta within all size caps
- meta.json already rich — left intact; axiom integrity unchanged (0 axioms / verified, no native_decide; foundational propext/Classical.choice/Quot.sound only)