### PR TITLE
Enrich Erdős #1011 (OQ-03): f₅(n) annotation depth

### DIFF
--- a/src/data/proofs/erdos-1011-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1011-oq-03/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 47 },
     "type": "concept",
     "title": "What is open, and what this file actually proves",
-    "content": "OQ-03 of Erdős #1011 asks to compute f_5(n): the least number of edges forcing a triangle in an n-vertex graph of chromatic number ≥ 5. This is genuinely open — f_4(n) was only settled in 2024. The file is deliberately honest about that: it does NOT compute f_5(n). It proves the unconditional scaffolding (antitonicity of f, the shift pattern) with zero axioms, and records the open value as a Prop. The honesty note in the header makes the boundary explicit."
+    "content": "OQ-03 of Erdős #1011 asks to compute f_5(n): the least number of edges forcing a triangle in an n-vertex graph of chromatic number ≥ 5. This is genuinely open — f_4(n) was only settled in 2024. The file is deliberately honest about that: it does NOT compute f_5(n). It proves the unconditional scaffolding (antitonicity of f, the shift pattern) with zero axioms, and records the open value as a Prop. The honesty note in the header makes the boundary explicit.",
+    "mathContext": "Known cases: $f_2(n)=\\lfloor n^2/4\\rfloor+1$ (Turán), $f_3(n)=\\lfloor (n-1)^2/4\\rfloor+2$ (Erdős–Gallai), $f_4(n)=\\lfloor (n-3)^2/4\\rfloor+6$ for $n\\ge 150$ (Ren–Wang–Wang–Yang 2024). The target $f_5(n)$ is unknown.",
+    "significance": "context",
+    "relatedConcepts": ["chromatic number", "triangle-forcing threshold", "extremal graph theory", "open problem"],
+    "prerequisites": ["graph theory", "chromatic number"]
   },
   {
     "id": "ann-erdos1011oq03-forces",
@@ -13,7 +17,11 @@
     "range": { "startLine": 56, "endLine": 76 },
     "type": "tactic",
     "title": "Factoring the sInf and proving nonemptiness",
-    "content": "f r n is sInf of the set of edge counts that force a triangle. To reason about it cleanly, the membership predicate is named `Forces r n m`. The defining set is nonempty because any m greater than C(n,2) is unreachable — a simple graph on n vertices has at most C(n,2) edges (Mathlib's `card_edgeFinset_le_card_choose_two`), so `edgeCount G ≥ m` is false and the implication holds vacuously. Nonemptiness is what guarantees the infimum is actually attained."
+    "content": "f r n is sInf of the set of edge counts that force a triangle. To reason about it cleanly, the membership predicate is named `Forces r n m`. The defining set is nonempty because any m greater than C(n,2) is unreachable — a simple graph on n vertices has at most C(n,2) edges (Mathlib's `card_edgeFinset_le_card_choose_two`), so `edgeCount G ≥ m` is false and the implication holds vacuously. Nonemptiness is what guarantees the infimum is actually attained.",
+    "mathContext": "$f(r,n)=\\inf\\{m \\mid \\mathrm{Forces}(r,n,m)\\}$. Nonemptiness witness: $m=\\binom{n}{2}+1$, since $e(G)\\le\\binom{n}{2}$ makes $e(G)\\ge m$ false, so the implication is vacuously true.",
+    "significance": "supporting",
+    "relatedConcepts": ["infimum over ℕ", "vacuous truth", "edge count bound", "Nat.sInf_mem"],
+    "prerequisites": ["order theory", "infimum of a set of naturals"]
   },
   {
     "id": "ann-erdos1011oq03-antitone",
@@ -21,7 +29,11 @@
     "range": { "startLine": 89, "endLine": 107 },
     "type": "insight",
     "title": "Antitonicity: the one real theorem",
-    "content": "The crux. For r ≤ r', the defining set for r sits inside that for r', because χ ≥ r' implies χ ≥ r — so every graph constrained at level r' is already covered by the level-r forcing property at the SAME threshold f r n. Hence f r n itself forces triangles for the r'-constrained graphs, giving f r' n ≤ f r n by `f_le_of_forces`. No extremal graph theory is used; it is pure monotonicity of sInf over nested sets, with the chromatic weakening `le_trans h hchrom` doing the work."
+    "content": "The crux. For r ≤ r', the defining set for r sits inside that for r', because χ ≥ r' implies χ ≥ r — so every graph constrained at level r' is already covered by the level-r forcing property at the SAME threshold f r n. Hence f r n itself forces triangles for the r'-constrained graphs, giving f r' n ≤ f r n by `f_le_of_forces`. No extremal graph theory is used; it is pure monotonicity of sInf over nested sets, with the chromatic weakening `le_trans h hchrom` doing the work.",
+    "mathContext": "If $r\\le r'$ then $\\{m\\mid\\mathrm{Forces}(r,n,m)\\}\\subseteq\\{m\\mid\\mathrm{Forces}(r',n,m)\\}$, and $\\inf$ reverses inclusion: $f(r',n)\\le f(r,n)$. The set inclusion comes from $\\chi(G)\\ge r' \\Rightarrow \\chi(G)\\ge r$.",
+    "significance": "key",
+    "relatedConcepts": ["monotonicity of infimum", "antitone function", "set inclusion reversal", "hypothesis strengthening"],
+    "prerequisites": ["order theory", "monotone/antitone maps"]
   },
   {
     "id": "ann-erdos1011oq03-corollary",
@@ -29,7 +41,11 @@
     "range": { "startLine": 109, "endLine": 119 },
     "type": "insight",
     "title": "Why f₅(n) ≤ f₄(n) matters",
-    "content": "Antitonicity instantiated at r=4, r'=5 gives f₅(n) ≤ f₄(n). Because f₄(n) = ⌊(n-3)²/4⌋ + 6 (n ≥ 150) is now known, this is an unconditional, explicit upper bound on the open value f₅(n). Each time a higher case of Erdős #1011 is solved, it automatically caps the still-open larger-r thresholds — a small but genuine piece of leverage on the open problem."
+    "content": "Antitonicity instantiated at r=4, r'=5 gives f₅(n) ≤ f₄(n). Because f₄(n) = ⌊(n-3)²/4⌋ + 6 (n ≥ 150) is now known, this is an unconditional, explicit upper bound on the open value f₅(n). Each time a higher case of Erdős #1011 is solved, it automatically caps the still-open larger-r thresholds — a small but genuine piece of leverage on the open problem.",
+    "mathContext": "$f_5(n)\\le f_4(n)=\\lfloor (n-3)^2/4\\rfloor+6$ for $n\\ge 150$. The full chain $f_5(n)\\le f_4(n)\\le f_3(n)\\le f_2(n)$ is recorded in `f_chain`.",
+    "significance": "key",
+    "relatedConcepts": ["upper bound", "antitone chain", "transfer of solved cases", "Ren–Wang–Wang–Yang 2024"],
+    "prerequisites": ["extremal graph theory"]
   },
   {
     "id": "ann-erdos1011oq03-shift",
@@ -37,7 +53,11 @@
     "range": { "startLine": 121, "endLine": 152 },
     "type": "insight",
     "title": "The vertex-shift fingerprint C(r-1,2)",
-    "content": "The known formulas use a shifted Turán term ⌊(n - s)²/4⌋ with s = 0, 1, 3 for r = 2, 3, 4. These are exactly the triangular numbers C(r-1,2) = (r-1)(r-2)/2, so the pattern predicts shift C(4,2) = 6 for r = 5 — a conjectured leading term ⌊(n-6)²/4⌋. `chromaticShift_known` certifies the match by decision procedure; `chromaticShift_mono` and `chromaticShift_eq` record monotonicity and the closed form. The additive constants 1, 2, 6, by contrast, have no identified closed form and are the heart of what remains open."
+    "content": "The known formulas use a shifted Turán term ⌊(n - s)²/4⌋ with s = 0, 1, 3 for r = 2, 3, 4. These are exactly the triangular numbers C(r-1,2) = (r-1)(r-2)/2, so the pattern predicts shift C(4,2) = 6 for r = 5 — a conjectured leading term ⌊(n-6)²/4⌋. `chromaticShift_known` certifies the match by decision procedure; `chromaticShift_mono` and `chromaticShift_eq` record monotonicity and the closed form. The additive constants 1, 2, 6, by contrast, have no identified closed form and are the heart of what remains open.",
+    "mathContext": "$s(r)=\\binom{r-1}{2}=\\tfrac{(r-1)(r-2)}{2}$ gives $s(2,3,4,5)=0,1,3,6$. Conjectured leading term for $r=5$: $\\lfloor (n-6)^2/4\\rfloor$. The closed form is proved via `Nat.choose_two_right`.",
+    "significance": "supporting",
+    "relatedConcepts": ["triangular numbers", "binomial coefficient C(r-1,2)", "Turán density", "pattern extrapolation"],
+    "prerequisites": ["binomial coefficients", "Turán-type extremal formulas"]
   },
   {
     "id": "ann-erdos1011oq03-conjecture",
@@ -45,6 +65,10 @@
     "range": { "startLine": 154, "endLine": 174 },
     "type": "concept",
     "title": "Recording the open question precisely",
-    "content": "`shiftConjecture` (general r) and `f5Conjecture` (the r=5 specialization) are stated as Props and left unproved — the formalization is explicit that these are conjectures, not theorems. `shiftConjecture_imp_f5` shows the general statement specializes to the concrete f₅ question, so any future proof of the pattern immediately resolves this entry's open goal."
+    "content": "`shiftConjecture` (general r) and `f5Conjecture` (the r=5 specialization) are stated as Props and left unproved — the formalization is explicit that these are conjectures, not theorems. `shiftConjecture_imp_f5` shows the general statement specializes to the concrete f₅ question, so any future proof of the pattern immediately resolves this entry's open goal.",
+    "mathContext": "$\\mathrm{shiftConjecture}:\\ \\forall r\\ge 2,\\ \\exists c,n_0,\\ \\forall n\\ge n_0,\\ f_r(n)=\\lfloor (n-s(r))^2/4\\rfloor+c$. Specialization at $r=5$ yields $f5\\mathrm{Conjecture}$: $f_5(n)=\\lfloor (n-6)^2/4\\rfloor+c$.",
+    "significance": "context",
+    "relatedConcepts": ["conjecture as Prop", "specialization of a universal statement", "asymptotic edge formula", "open additive constant"],
+    "prerequisites": ["first-order logic in Lean", "Prop vs proof"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1011-oq-03` (passes: 0, quality: 68).

## Changes
All 6 annotations previously had only `content`. Added the four depth fields to each:
- **`mathContext`** — LaTeX grounded in the actual Lean: the `Forces` predicate as $f(r,n)=\inf\{m\mid\mathrm{Forces}(r,n,m)\}$, the nonemptiness witness $\binom{n}{2}+1$, the antitone set-inclusion, the $\binom{r-1}{2}$ shift fingerprint (0,1,3,6), and the conjecture Props.
- **`significance`** — `key` for the antitonicity theorem and the f₅≤f₄ corollary; `supporting`/`context` elsewhere.
- **`relatedConcepts`** and **`prerequisites`** — per annotation.

## Axiom integrity
No status/badge/axiomCount changes. meta.json already documents (and the Lean `#print axioms` confirms) that the 5 parent-file axioms in `Erdos1011Problem.lean` are NOT used by any theorem here — consistent with the known cross-file false-positive audit pattern. `status: verified`, `axiomCount: 0` left intact.

meta.json is 9.4 KB — comfortably under all size caps; no trimming needed.