### PR TITLE
Enrich Lagrange OQ-02-01-02: stabilizer-sum — index.ts + coverage

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/annotations.json
@@ -34,5 +34,17 @@
     "significance": "key",
     "relatedConcepts": ["Fintype.card_congr", "Fintype.card_sigma", "Fintype.card_prod", "Burnside twin identity"],
     "prerequisites": ["cardinality of sigma and product types", "cardinality is a bijection invariant"]
+  },
+  {
+    "id": "lagrange-oq020102-representatives",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 51, "endLine": 64 },
+    "type": "technique",
+    "title": "Why the equivalence is noncomputable: choosing orbit representatives",
+    "content": "The equivalence is marked `noncomputable` for a structural reason worth highlighting: it indexes each orbit by a chosen representative `ω.out`, where `ω : Ω = Quotient (orbitRel α β)` and `Quotient.out` selects a preimage of the quotient class. That choice is justified by `Classical.choice`, so the construction is non-constructive even though both sides are finite. The orbit-level steps then all reduce to the representative: `stabilizerEquivStabilizerOfOrbitRel hb` transports a point's stabilizer to `Stab(ω.out)` along the orbit relation `hb`, and `orbitProdStabilizerEquivGroup α ω.out` is the orbit-stabilizer equivalence anchored at `ω.out`. The cardinality identity is unaffected — `Fintype.card_congr` only needs the bijection to exist, not to compute — which is exactly why a noncomputable equivalence still yields a clean, axiom-free counting theorem (only the foundational `Classical.choice`).",
+    "mathContext": "$\\omega \\in \\Omega = X/G$, $\\ \\omega.\\mathrm{out} \\in X$ a representative; $\\mathrm{Stab}(x) \\cong \\mathrm{Stab}(\\omega.\\mathrm{out})$ for $x$ in the orbit of $\\omega.\\mathrm{out}$.",
+    "significance": "technical",
+    "relatedConcepts": ["Quotient.out", "orbit representatives", "Classical.choice", "noncomputable definitions", "card_congr needs only existence"],
+    "prerequisites": ["quotient types and Quotient.out", "the axiom of choice in Lean", "noncomputable vs computable definitions"]
   }
 ]

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/index.ts
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LagrangeTheoremOQ02OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeTheoremOq02Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeTheoremOq02Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lagrangeTheoremOq02Oq01Oq02Data: ProofData = {
+  proof: lagrangeTheoremOq02Oq01Oq02Proof,
+  annotations: lagrangeTheoremOq02Oq01Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-02-oq-01-oq-02` (quality 83, pass 0).

## Critical fix
- **Created missing `index.ts`** — without it the page renders 'proof not found' on the live site (`lagrangeTheoremOq02Oq01Oq02`).

## Annotation coverage 3 → 4 (all with depth fields)
The 3 existing annotations already cover the file deeply (header, the `calc` equivalence chain step-by-step, the cardinality theorem). Rather than pad, I added one genuinely-new **technique** annotation: why `sigmaStabilizerEquivOrbitsProdGroup` is `noncomputable` (orbit representatives via `Quotient.out` / `Classical.choice`), and why `Fintype.card_congr` needing only existence keeps the counting theorem axiom-free.

## Verification
- JSON parses cleanly; 0/4 annotations missing depth fields; meta within size caps
- meta.json left intact; axiom integrity unchanged (0 axioms / verified)