### PR TITLE
Enrich Law of Cosines OQ-07: cover Euclidean instantiation

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-07/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-07/annotations.json
@@ -76,5 +76,28 @@
       "norm and inner product",
       "module / norm_smul tactics"
     ]
+  },
+  {
+    "id": "ann-euclidean-instance",
+    "proofId": "law-of-cosines-oq-07",
+    "range": {
+      "startLine": 98,
+      "endLine": 104
+    },
+    "type": "context",
+    "title": "Sanity Check on the Standard Euclidean Plane",
+    "content": "A closing `example` instantiates the abstract `apollonius` theorem at the concrete model `EuclideanSpace ℝ (Fin 2)` — the standard Cartesian plane. Because the main theorem is stated over an arbitrary real inner-product space (a torsor `P` over a real inner-product space `V`), no new proof is needed: the term `apollonius a b c` *is* the witness, and typeclass resolution simply supplies the EuclideanSpace instances. This documents that the coordinate-free generalization genuinely subsumes the classical plane statement, and serves as a regression guard — if the abstract hypotheses were ever too weak to cover the motivating example, this line would fail to typecheck.",
+    "mathContext": "On $\\mathrm{EuclideanSpace}\\ \\mathbb{R}\\ (\\mathrm{Fin}\\ 2)$: $\\operatorname{dist}(a,b)^2 + \\operatorname{dist}(a,c)^2 = 2\\big(\\operatorname{dist}(a,\\operatorname{midpoint}(b,c))^2 + (\\operatorname{dist}(b,c)/2)^2\\big)$, witnessed verbatim by $\\mathtt{apollonius}\\ a\\ b\\ c$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "EuclideanSpace ℝ (Fin 2)",
+      "generalization subsumes the concrete model",
+      "typeclass instance resolution",
+      "regression / sanity check"
+    ],
+    "prerequisites": [
+      "EuclideanSpace and the standard plane",
+      "how abstract theorems instantiate via typeclasses"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `law-of-cosines-oq-07` (quality 83, pass 0).

Already had index.ts and 4 deep annotations (header + apollonius + median_length + parallelogram_law). The only genuine gap was the closing `example` on `EuclideanSpace ℝ (Fin 2)` (lines 98–104), which no annotation covered.

## Added (4 → 5, all with depth fields)
- **Sanity Check on the Standard Euclidean Plane**: the abstract coordinate-free Apollonius theorem subsumes the classical plane statement, witnessed verbatim by `apollonius a b c` via typeclass resolution — and doubles as a typecheck-time regression guard.

## Verification
- JSON parses cleanly; 0/5 annotations missing depth fields; meta within size caps
- meta.json left intact; axiom integrity unchanged (0 axioms / verified)