### PR TITLE
research(puiseux-theorem-oq-03): full ramified-root family + ℚ value group [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -1204,4 +1204,57 @@ theorem puiseuxVal_not_integer :
   have h2 : (2 * n : ℤ) = 1 := by exact_mod_cast hcast
   omega
 
+/-! ### The full ramified-root family and the ℚ value group
+
+The `Y² − x` brick above realizes a *single* ramified root (`x^{1/2}`, ramification index 2).
+The monomial calculus `HahnSeries.single` enjoys (`single_pow`, `single_mul_single`) lets us
+state the whole picture at once: every ramification index occurs, and the value group is all
+of `ℚ`. All results stay **0 sorry / 0 axiom**. -/
+
+/-- A Puiseux monomial raised to a natural power scales its exponent: `(x^q)ⁿ = x^{n·q}`. -/
+theorem puiseuxMonomial_pow (q : ℚ) (n : ℕ) :
+    (puiseuxMonomial (K := K) q) ^ n = puiseuxMonomial (K := K) (n • q) := by
+  simp only [puiseuxMonomial, HahnSeries.single_pow, one_pow]
+
+/-- Puiseux monomials multiply by adding exponents: `x^p · x^q = x^{p+q}` — so `q ↦ x^q` is a
+monoid hom `(ℚ, +) → (PuiseuxSeries K, ·)`, exhibiting `ℚ` inside the multiplicative monomials. -/
+theorem puiseuxMonomial_mul (p q : ℚ) :
+    puiseuxMonomial (K := K) p * puiseuxMonomial (K := K) q
+      = puiseuxMonomial (K := K) (p + q) := by
+  simp only [puiseuxMonomial, HahnSeries.single_mul_single, one_mul]
+
+/-- **Every ramification index is realized.** For each `n ≥ 1` the monomial `x^{1/n}` is an
+`n`-th root of the base `x = x^1`, generalizing the `n = 2` case `sqrt_x_sq`. -/
+theorem nthRoot_x (n : ℕ) (hn : 0 < n) :
+    (puiseuxMonomial (K := K) (1 / n)) ^ n = puiseuxMonomial (K := K) 1 := by
+  have hn' : (n : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  rw [puiseuxMonomial_pow]
+  congr 1
+  rw [nsmul_eq_mul, mul_one_div, div_self hn']
+
+/-- The `n`-th ramified root carries valuation `1/n`. -/
+theorem nthRoot_valuation (n : ℕ) :
+    HahnSeries.addVal ℚ K (puiseuxMonomial (K := K) (1 / n)) = ((1 / n : ℚ) : WithTop ℚ) :=
+  puiseuxVal_monomial (1 / n)
+
+/-- **The full ramified-root family.** For every `n ≥ 1` there is a Puiseux element `t` with
+`tⁿ = x` and `v(t) = 1/n`.  The `n = 2` instance is `ysqMinusX_root_valuation`; the family
+shows every ramification index `n` is attained in `HahnSeries ℚ K`. -/
+theorem exists_nthRoot_of_x (n : ℕ) (hn : 0 < n) :
+    ∃ t : PuiseuxSeries K,
+      t ^ n = puiseuxMonomial (K := K) 1 ∧
+      HahnSeries.addVal ℚ K t = ((1 / n : ℚ) : WithTop ℚ) :=
+  ⟨puiseuxMonomial (1 / n), nthRoot_x n hn, nthRoot_valuation n⟩
+
+/-- **The value group is all of `ℚ`.** For every rational `q` the monomial `x^q` has valuation
+exactly `q`.  This is the precise sense in which the Puiseux field is *fully ramified* over the
+Laurent base `K⸨x⸩`: its value group is `ℚ`, whereas `K⸨x⸩` has value group `ℤ`
+(cf. `puiseuxVal_not_integer`, a single witness of a non-integer value). -/
+theorem puiseuxVal_surjective (q : ℚ) :
+    ∃ t : PuiseuxSeries K, HahnSeries.addVal ℚ K t = (q : WithTop ℚ) :=
+  ⟨puiseuxMonomial q, puiseuxVal_monomial q⟩
+
+#print axioms exists_nthRoot_of_x
+#print axioms puiseuxVal_surjective
+
 end PuiseuxTheoremOQ03

--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -447,3 +447,31 @@ foundational but now with a concrete target to build toward. Phase: ACT (advance
 
 WORKFLOW: fast host-`lake env lean` scratch (pure Mathlib import) to nail the API, then inlined
 + sanctioned docker build. Docker healthy (29.6.1).
+
+---
+
+## Session (2026-06-30, researcher-2, S08): full ramified-root family + ℚ value group
+
+Built directly on S07's valued-Puiseux-field brick (PuiseuxSeries K := HahnSeries ℚ K +
+addVal). S07 realized only the single ramification index 2 (Y²−x, x^{1/2}). Generalized
+to the whole family — VERIFIED 0-axiom (docker `[3071/3071]`, `#print axioms` of both
+headlines = propext/Classical.choice/Quot.sound). File 1207→1260 lines, +6 theorems.
+
+- `puiseuxMonomial_pow`: (x^q)^n = x^{n·q}  (HahnSeries.single_pow + one_pow).
+- `puiseuxMonomial_mul`: x^p·x^q = x^{p+q}  (single_mul_single + one_mul) — q ↦ x^q embeds (ℚ,+).
+- `nthRoot_x (n) (0<n)`: (x^{1/n})^n = x  — generalizes sqrt_x_sq. Key step:
+  `rw [puiseuxMonomial_pow]; congr 1; rw [nsmul_eq_mul, mul_one_div, div_self hn']`
+  with `hn' : (n:ℚ)≠0 := Nat.cast_ne_zero.mpr hn.ne'`.
+- `nthRoot_valuation (n)`: v(x^{1/n}) = 1/n  (instance of puiseuxVal_monomial).
+- `exists_nthRoot_of_x (n) (0<n)`: ∃ t, tⁿ=x ∧ v(t)=1/n — every ramification index realized.
+- `puiseuxVal_surjective (q)`: ∃ t, v(t)=q — value group is ALL of ℚ (vs ℤ for the Laurent
+  base); the precise structural statement of full ramification.
+
+GOTCHA: `1/n` in `puiseuxMonomial (1/n)` elaborates in ℚ (arg type ℚ ⇒ n coerced), so it's
+rational division 1/↑n, NOT ℕ-division 0 — confirmed it works. API de-risked via fast host
+`LAKE_UNSAFE=1 ./bin/lake env lean /tmp/scratch.lean` (pure Mathlib) before docker.
+
+STILL OPEN (the genuine >1000-line part, unchanged): the ramified embedding K⸨x⸩ ↪
+HahnSeries ℚ K and the GENERAL edgeSlope = −v(root) bridge for arbitrary P ∈ K⸨x⸩[Y]. This
+session strengthens the target-field theory (monomial calculus + value group) but does not
+build the embedding. Phase: ACT.

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -51,11 +51,14 @@
       "zipWith_edgeSlopes_edgeWidths: along a chain of lower edges the elementwise product of the edgeSlopes and edgeWidths lists equals the edgeDrops list — the list-level coupling of valuations and multiplicities",
       "sum_slope_mul_width: CAPSTONE bookkeeping identity — Σ (edgeSlopeᵢ · widthᵢ) telescopes to the total vertical drop (last).2 − (first).2 across the polygon",
       "neg_sum_slope_mul_width: Σ (root valuationᵢ · multiplicityᵢ) = v(constant) − v(leading) — the valuation of the product of all roots, read off the two endpoints; the multiplicative counterpart of sum_edgeWidths_eq_degree",
-      "Worked three-vertex example: zipWith products [-2,1] sum to -1 = drop from (0,2) to (3,1) (threeVertex_sum_slope_mul_width)"
+      "Worked three-vertex example: zipWith products [-2,1] sum to -1 = drop from (0,2) to (3,1) (threeVertex_sum_slope_mul_width)",
+      "Analytic-bridge layer (PuiseuxSeries K := HahnSeries ℚ K + addVal): puiseuxMonomial/puiseuxVal_monomial (v(x^q)=q), the Y²−x worked ramified root (ysqMinusX_root_valuation, v(x^{1/2})=½ matching the polygon edge slope), and puiseuxVal_not_integer (the ramification is real — ½ ∉ ℤ)",
+      "Full ramified-root family: puiseuxMonomial_pow ((x^q)^n = x^{n·q}) and puiseuxMonomial_mul (x^p·x^q = x^{p+q}, so q ↦ x^q embeds (ℚ,+)); nthRoot_x + nthRoot_valuation + exists_nthRoot_of_x — for EVERY n ≥ 1, x^{1/n} is an n-th root of x with valuation 1/n, generalizing the n=2 instance to every ramification index",
+      "puiseuxVal_surjective: the value group is all of ℚ — every rational q is the valuation of the monomial x^q; the precise sense in which HahnSeries ℚ K is fully ramified over the Laurent base K⸨x⸩ (value group ℤ)"
     ],
     "dateAdded": "2026-06-27",
-    "lineCount": 684,
-    "theoremCount": 39,
+    "lineCount": 1260,
+    "theoremCount": 66,
     "definitionCount": 8,
     "mathlib_version": "4.26.0"
   },
@@ -245,9 +248,9 @@
       "Mathlib.Data.List.Sort"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 1207,
+    "lineCount": 1260,
     "axiomCount": 0,
-    "theoremCount": 60,
+    "theoremCount": 66,
     "definitionCount": 11,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Generalizes the prior session's single `Y²−x` ramified root (ramification index 2) to the
**whole ramified-root family** in the valued Puiseux field `PuiseuxSeries K := HahnSeries ℚ K`,
and pins down the **value group as all of `ℚ`** — the precise sense in which the Puiseux field
is fully ramified over the unramified Laurent base `K⸨x⸩` (value group `ℤ`).

**VERIFIED, 0-axiom** — Docker build `[3071/3071]`; `#print axioms` of both headlines reports
only `propext / Classical.choice / Quot.sound`.

## New content (1207 → 1260 lines, +6 theorems; still 0 axioms / 0 sorries)

- `puiseuxMonomial_pow` — `(x^q)^n = x^{n·q}`
- `puiseuxMonomial_mul` — `x^p·x^q = x^{p+q}` (so `q ↦ x^q` embeds `(ℚ, +)`)
- `nthRoot_x`, `nthRoot_valuation`, `exists_nthRoot_of_x` — for **every** `n ≥ 1`, `x^{1/n}`
  is an `n`-th root of `x` with valuation `1/n`: every ramification index is realized
  (the `n = 2` instance is the prior `ysqMinusX_root_valuation`)
- `puiseuxVal_surjective` — the value group is all of `ℚ`: every rational `q` is the valuation
  of the monomial `x^q`

## Honesty / scope

The genuine open part is **unchanged**: the ramified embedding `K⸨x⸩ ↪ HahnSeries ℚ K` and the
**general** correspondence `edgeSlope = −v(root)` for an arbitrary `P ∈ K⸨x⸩[Y]` remain a
>1000-line foundational build. This session strengthens the *target-field* theory (monomial
calculus + value group); it does not construct the embedding. The Newton-polygon combinatorial
side was already complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)