### PR TITLE
Add missing index.ts for Antitone Integral Sum Comparison OQ-01-02

### DIFF
--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02/index.ts
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const antitoneIntegralSumComparisonOq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const antitoneIntegralSumComparisonOq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const antitoneIntegralSumComparisonOq01Oq02Data: ProofData = {
+  proof: antitoneIntegralSumComparisonOq01Oq02Proof,
+  annotations: antitoneIntegralSumComparisonOq01Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `antitone-integral-sum-comparison-oq-01-oq-02` (quality 85, pass 0).

## Critical fix
- **Created missing `index.ts`** — without it the page renders 'proof not found' on the live site. Standard template (`antitoneIntegralSumComparisonOq01Oq02`, source `Proofs/AntitoneIntegralSumComparisonOQ01OQ02.lean`).

Entry was otherwise well-curated: meta.json complete and 6 annotations (Euler–Mascheroni γ bracketing, bracket width → 0, numeric enclosures) covering the theorems, all with depth fields. Left intact — no padding.

## Verification
- JSON parses cleanly; axiom integrity unchanged