### PR TITLE
Enrich British Flag Theorem: add missing index.ts + accuracy fixes

### DIFF
--- a/src/data/proofs/british-flag-theorem-oq-01/annotations.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "british-flag-theorem-oq-01",
     "range": {
       "startLine": 1,
-      "endLine": 30
+      "endLine": 24
     },
     "type": "concept",
     "title": "Statement and Coordinate Setup",
@@ -27,8 +27,8 @@
     "id": "ann-sqdist",
     "proofId": "british-flag-theorem-oq-01",
     "range": {
-      "startLine": 32,
-      "endLine": 36
+      "startLine": 26,
+      "endLine": 32
     },
     "type": "definition",
     "title": "Squared Distance",
@@ -46,8 +46,8 @@
     "id": "ann-main",
     "proofId": "british-flag-theorem-oq-01",
     "range": {
-      "startLine": 38,
-      "endLine": 58
+      "startLine": 34,
+      "endLine": 48
     },
     "type": "theorem",
     "title": "The British Flag Identity",

--- a/src/data/proofs/british-flag-theorem-oq-01/index.ts
+++ b/src/data/proofs/british-flag-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BritishFlagTheorem.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const britishFlagTheoremOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const britishFlagTheoremOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const britishFlagTheoremOQ01Data: ProofData = {
+  proof: britishFlagTheoremOQ01Proof,
+  annotations: britishFlagTheoremOQ01Annotations,
+}

--- a/src/data/proofs/british-flag-theorem-oq-01/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/meta.json
@@ -5,11 +5,11 @@
   "description": "For any point P in the plane of a rectangle ABCD, the sums of squared distances to opposite corners are equal: PA² + PC² = PB² + PD².",
   "leanFile": {
     "imports": [
-      "Mathlib"
+      "Mathlib.Tactic"
     ],
     "opens": [],
     "namespace": "BritishFlagTheorem",
-    "lineCount": 60,
+    "lineCount": 48,
     "axiomCount": 0,
     "theoremCount": 1,
     "definitionCount": 1,
@@ -39,7 +39,7 @@
     ],
     "dateAdded": "2026-06-16",
     "axiomCount": 0,
-    "lineCount": 60,
+    "lineCount": 48,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The rectangle is encoded by the parallelogram closure C = B + D − A and the orthogonality of edges B − A and D − A.",
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
@@ -74,16 +74,16 @@
     {
       "id": "setup",
       "title": "Coordinate Setup and Squared Distance",
-      "startLine": 32,
-      "endLine": 36,
-      "summary": "Model planar points as ℝ × ℝ and define sqDist P Q = (P.1 − Q.1)² + (P.2 − Q.2)².",
+      "startLine": 26,
+      "endLine": 32,
+      "summary": "Open the BritishFlagTheorem namespace, model planar points as Pt = ℝ × ℝ, and define sqDist P Q = (P.1 − Q.1)² + (P.2 − Q.2)².",
       "mathContext": "The squared Euclidean distance between $(p_1,p_2)$ and $(q_1,q_2)$ is $(p_1-q_1)^2 + (p_2-q_2)^2$. Using squared distance avoids square roots entirely, since the theorem is an identity among squared lengths."
     },
     {
       "id": "main",
       "title": "The British Flag Identity",
-      "startLine": 38,
-      "endLine": 58,
+      "startLine": 34,
+      "endLine": 48,
       "summary": "Substitute the parallelogram closure and reduce the goal to twice the orthogonality form, discharged by linear_combination.",
       "mathContext": "With $u = B - A$, $v = D - A$, expansion gives $(PA^2 + PC^2) - (PB^2 + PD^2) = 2(u_1 v_1 + u_2 v_2)$, which is zero by the right-angle hypothesis $u \\cdot v = 0$."
     }


### PR DESCRIPTION
Enrichment pass for `british-flag-theorem-oq-01` (passes: 0, quality: 76).

## Primary fix: missing `index.ts`
The entry had **no `index.ts`**, so Vite's `import.meta.glob` could not discover it — the page rendered **'proof not found'** on the live site despite appearing in the gallery listing. Added it following the standard template (`britishFlagTheoremOQ01Proof` / `…Annotations` / `…Data`).

## Accuracy fixes (grounded in the actual Lean file)
The Lean source is **48 lines** and imports `Mathlib.Tactic`; the metadata was stale:
- `leanFile.imports`: `Mathlib` → `Mathlib.Tactic`
- `lineCount`: `60` → `48` (both `leanFile` and `meta`)
- Section ranges retargeted to real lines: setup `26–32`, main `34–48` (previously overshot to line 58 in a 48-line file)
- Annotation ranges retargeted: `1–24` / `26–32` / `34–48`

## Already strong (left as-is)
All 3 annotations already carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`; `overview`, `conclusion`, cross-references and references are complete. meta.json is 7.9 KB — well under caps. No content inflation; this pass is correctness + the missing entry point.

Axiom integrity unchanged: `status: verified`, `axiomCount: 0`, 0 sorries — matches the Lean (`linear_combination`, no axioms).