### PR TITLE
Add missing index.ts for Area of Circle OQ-07-03-01

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-01/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq07Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq07Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq07Oq03Oq01Data: ProofData = {
+  proof: areaOfCircleOq07Oq03Oq01Proof,
+  annotations: areaOfCircleOq07Oq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-03-oq-01` (quality 85, pass 0).

## Critical fix
- **Created missing `index.ts`** — without it the page renders 'proof not found' on the live site. Standard template (`areaOfCircleOq07Oq03Oq01`, source `Proofs/AreaOfCircleOQ07OQ03OQ01.lean`).

Entry was otherwise well-curated (meta.json complete, 6 annotations all with depth fields). Left intact — no padding.

## Verification
- JSON parses cleanly; axiom integrity unchanged