### PR TITLE
Enrich Basel η(4) OQ-13-01: index.ts + header overview

### DIFF
--- a/src/data/proofs/basel-problem-oq-13-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-13-oq-01/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "eta-overview",
+    "proofId": "basel-problem-oq-13-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 33
+    },
+    "type": "concept",
+    "title": "η(4) by Parity Decomposition — No New Analytic Input",
+    "content": "The header states the open question (derive the Dirichlet eta value η(4) = 7π⁴/720 by combining λ(4) = π⁴/96 with the even-fourth-power sum π⁴/1440) and its resolution strategy. The Dirichlet eta η(s) = ∑ (-1)^(n+1)/nˢ is the alternating companion of ζ(s). Splitting by parity, odd indices carry +, even indices carry −, so η(4) = λ(4) − (even sum) = π⁴/96 − π⁴/1440 = 14π⁴/1440 = 7π⁴/720. Both ingredients are already proved axiom-free in the parent `BaselProblemOQ13` (`hasSum_even_zeta_four`, `hasSum_odd_zeta_four`); the only genuinely new ingredient is the alternating sign, threaded through `HasSum.even_add_odd`. There is no new analytic content — this is a sign-bookkeeping recombination of established sums.",
+    "mathContext": "$\\eta(4) = \\sum_{n\\ge1}\\frac{(-1)^{n+1}}{n^4} = \\lambda(4) - \\sum_{k\\ge1}\\frac{1}{(2k)^4} = \\frac{\\pi^4}{96} - \\frac{\\pi^4}{1440} = \\frac{14\\pi^4}{1440} = \\frac{7\\pi^4}{720}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Dirichlet eta function η(s)",
+      "Dirichlet lambda λ(s) (odd zeta)",
+      "parity decomposition of a series",
+      "HasSum.even_add_odd",
+      "alternating zeta values"
+    ],
+    "prerequisites": [
+      "the parent BaselProblemOQ13 even/odd fourth-power sums",
+      "ζ, η, λ Dirichlet series at s = 4",
+      "summability and HasSum"
+    ]
+  },
+  {
     "id": "eta-even",
     "proofId": "basel-problem-oq-13-oq-01",
     "range": {

--- a/src/data/proofs/basel-problem-oq-13-oq-01/index.ts
+++ b/src/data/proofs/basel-problem-oq-13-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BaselProblemOQ13OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const baselProblemOq13Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const baselProblemOq13Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const baselProblemOq13Oq01Data: ProofData = {
+  proof: baselProblemOq13Oq01Proof,
+  annotations: baselProblemOq13Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-13-oq-01` (quality 85, pass 0).

## Critical fix
- **Created missing `index.ts`** — without it the page renders 'proof not found' on the live site (`baselProblemOq13Oq01`, source `Proofs/BaselProblemOQ13OQ01.lean`).

## Annotation coverage 3 → 4 (all with depth fields)
- **Concept** (header, previously uncovered): η(4) = 7π⁴/720 by parity decomposition λ(4) − even-fourth-power-sum, with both ingredients from the parent and only the alternating sign new (via `HasSum.even_add_odd`).

## Verification
- JSON parses cleanly; 0/4 annotations missing depth fields
- meta.json left intact; axiom integrity unchanged (0 axioms / verified)