### PR TITLE
research(cramers-rule-oq-02-oq-01): additions/subtractions + full ~2n³/3 flop count [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CramersRuleOQ02OQ01.lean
+++ b/proofs/Proofs/CramersRuleOQ02OQ01.lean
@@ -130,4 +130,66 @@ theorem gauss_exact_summary :
   ⟨gaussExactOps_closed, gaussExactOps_eq_div, gaussExactOps_le_cube,
    fun _ h => gaussExactOps_lt_cube h, fun _ h => gaussExact_beats_cramer h⟩
 
+-- ============================================================
+-- Additions/subtractions and the full ~2n³/3 flop total (OQ-01)
+-- ============================================================
+
+/-- Exact **subtraction** count of forward elimination: clearing a column with `j` rows
+    beneath the pivot updates, in each of those `j` rows, `j` trailing entries via
+    `a := a − mult·pivotEntry` — one subtraction each, `j²` per step, summed over `j < n`.
+    (Equivalently the number of multiply–subtract pairs in the trailing-submatrix update.) -/
+def gaussExactSubs (n : ℕ) : ℕ := ∑ j ∈ range n, j ^ 2
+
+/-- Unfolding one elimination step for the subtraction count. -/
+lemma gaussExactSubs_succ (n : ℕ) :
+    gaussExactSubs (n + 1) = gaussExactSubs n + n ^ 2 := by
+  unfold gaussExactSubs; rw [Finset.sum_range_succ]
+
+/-- **Closed form for the subtraction count (subtraction-free over ℕ).**
+    `6·gaussExactSubs n + 3·n² = 2·n³ + n`, i.e. `gaussExactSubs n = (2n³ − 3n² + n)/6` —
+    the classic `∑_{j<n} j²`, asymptotically `n³/3` (matching the `≈ n³/3` additions of the
+    `2n³/3`-flop headline). -/
+theorem gaussExactSubs_closed (n : ℕ) :
+    6 * gaussExactSubs n + 3 * n ^ 2 = 2 * n ^ 3 + n := by
+  induction n with
+  | zero => simp [gaussExactSubs]
+  | succ m ih =>
+    calc 6 * gaussExactSubs (m + 1) + 3 * (m + 1) ^ 2
+        = (6 * gaussExactSubs m + 3 * m ^ 2) + (6 * m ^ 2 + 6 * m + 3) := by
+          rw [gaussExactSubs_succ]; ring
+      _ = (2 * m ^ 3 + m) + (6 * m ^ 2 + 6 * m + 3) := by rw [ih]
+      _ = 2 * (m + 1) ^ 3 + (m + 1) := by ring
+
+/-- The full leading **flop** count of forward elimination: multiplications + divisions
+    (`gaussExactOps`) together with the equal number of subtractions (`gaussExactSubs`). -/
+def gaussExactFlops (n : ℕ) : ℕ := gaussExactOps n + gaussExactSubs n
+
+/-- **Closed form for the total flop count (subtraction-free).**
+    `6·gaussExactFlops n + 3·n² + n = 4·n³`, i.e. `gaussExactFlops n = (4n³ − 3n² − n)/6`,
+    asymptotically `2n³/3` — the textbook leading flop count for dense Gaussian elimination
+    / LU factorization (`≈ n³/3` multiplications + `≈ n³/3` additions). -/
+theorem gaussExactFlops_closed (n : ℕ) :
+    6 * gaussExactFlops n + 3 * n ^ 2 + n = 4 * n ^ 3 := by
+  have h1 := gaussExactOps_closed n
+  have h2 := gaussExactSubs_closed n
+  unfold gaussExactFlops
+  omega
+
+/-- The total flop count dominates the multiplication+division count: the subtractions are
+    genuine extra work. `gaussExactOps n ≤ gaussExactFlops n`. -/
+theorem gaussExactOps_le_flops (n : ℕ) : gaussExactOps n ≤ gaussExactFlops n := by
+  unfold gaussExactFlops; exact Nat.le_add_right _ _
+
+/-- Concrete total flop counts (multiplications+divisions plus subtractions):
+    `n=2 ↦ 3`, `n=3 ↦ 13`, `n=4 ↦ 34`, `n=5 ↦ 70`. -/
+lemma gaussExactFlops_small :
+    gaussExactFlops 2 = 3 ∧ gaussExactFlops 3 = 13 ∧
+    gaussExactFlops 4 = 34 ∧ gaussExactFlops 5 = 70 := by
+  have h2 := gaussExactFlops_closed 2
+  have h3 := gaussExactFlops_closed 3
+  have h4 := gaussExactFlops_closed 4
+  have h5 := gaussExactFlops_closed 5
+  norm_num at h2 h3 h4 h5
+  omega
+
 end CramersComplexityExact

--- a/src/data/proofs/cramers-rule-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01/meta.json
@@ -38,15 +38,17 @@
       "Subtraction-free closed form gaussExactOps_closed: 3·gaussExactOps n + n = n³, proved by induction with a ℕ-semiring calc (ring + Finset.sum_range_succ), no truncated subtraction",
       "Division form gaussExactOps_eq_div: gaussExactOps n = (n³ − n)/3, the textbook n³/3 flop count, recovered via Nat.mul_div_cancel_left",
       "Tightening witnesses: gaussExactOps_le_cube (≤ n³, consistency with parent) and gaussExactOps_lt_cube (strict for n ≥ 2, the factor-3 gap is real)",
-      "Comparison preserved: gaussExact_beats_cramer shows the tighter exact model still beats Cramer's rule for n ≥ 4 a fortiori, via the parent's gauss_beats_cramer"
+      "Comparison preserved: gaussExact_beats_cramer shows the tighter exact model still beats Cramer's rule for n ≥ 4 a fortiori, via the parent's gauss_beats_cramer",
+      "Additions/subtractions count gaussExactSubs n = ∑_{j<n} j² (one multiply–subtract pair per trailing-entry update) with subtraction-free closed form gaussExactSubs_closed: 6·gaussExactSubs n + 3·n² = 2·n³ + n, i.e. (2n³−3n²+n)/6 ≈ n³/3",
+      "Full leading flop count gaussExactFlops n = gaussExactOps n + gaussExactSubs n with closed form gaussExactFlops_closed: 6·gaussExactFlops n + 3·n² + n = 4·n³, i.e. (4n³−3n²−n)/6 — the textbook ≈ 2n³/3 flops (≈ n³/3 mults + ≈ n³/3 adds); plus gaussExactOps_le_flops and concrete small-n checks"
     ],
     "dateAdded": "2026-06-26",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 133,
+    "lineCount": 195,
     "assumptions": "None. Fully kernel-checked: 0 sorries, 0 axiom declarations, 0 assumption-carrying structures, and no native_decide (the small concrete counts gaussExactOps_small are derived from the closed form via omega rather than native_decide, so Lean.ofReduceBool is NOT used). The single dependency on the parent file (CramersComplexity.gauss_beats_cramer, cramersRuleMuls) is through native_decide-free declarations only.",
-    "theoremCount": 8,
-    "definitionCount": 1
+    "theoremCount": 13,
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "**The n³/3 Flop Count**\n\nEvery numerical-linear-algebra textbook states that solving an n×n linear system by Gaussian elimination (equivalently LU factorization) costs about n³/3 multiplications/divisions — one third the naive n³ estimate. The parent entry (cramers-rule-oq-02) compared Cramer's rule against Gaussian elimination but used the deliberately loose upper model gaussMuls n = n³, leaving the precise leading constant unformalized. This entry supplies the exact count.\n\n**Where the n³/3 Comes From**\n\nForward elimination runs in steps k = 1, …, n−1. At step k the pivot is at (k,k) and there are n−k rows beneath it. For each such row we compute one multiplier (a division) and update its n−k trailing entries (a multiplication each), for (n−k) + (n−k)² operations. Summing over k and substituting j = n−k gives ∑_{j=1}^{n−1} (j² + j) = (n−1)·n·(n+1)/3 = (n³ − n)/3.",
@@ -112,7 +114,7 @@
     "summary": "This entry pins down the exact leading cost of Gaussian elimination — (n³ − n)/3 multiplications and divisions — that the parent Cramer-vs-Gauss comparison only bounded by n³. The closed form 3·gaussExactOps n + n = n³ is proved by a short subtraction-free induction in the ℕ semiring, its (n³ − n)/3 division form follows in one line, and omega supplies both the consistency bound (≤ n³) and the strict tightening (< n³ for n ≥ 2). The whole file is axiom-free (no sorries, no native_decide), upgrading the parent's axiomatized model to a fully kernel-checked exact count.",
     "implications": "Because a smaller cost can only strengthen a comparison the winner already led, the headline verdict — Gaussian elimination beats Cramer's rule for n ≥ 4 — carries over to the exact model for free, with no re-proof needed. More broadly, the entry demonstrates a reusable pattern for formalizing exact flop counts: state the polynomial identity in subtraction-free additive form (k·sum + remainder = closed form) so the induction stays in the ℕ semiring and closes by ring, then recover the conventional division form as a one-line corollary. The same template applies to the ~2n³/3 LU-factorization count, the n²/2 back-substitution count, and other textbook complexity figures that are usually quoted asymptotically but rarely formalized exactly.",
     "openQuestions": [
-      "Can the back-substitution phase (≈ n²/2 operations) and the full solve cost (forward elimination + back-substitution) be formalized with the same subtraction-free closed-form technique and composed with this result?",
+      "The additions/subtractions count (≈ n³/3) and the full forward-elimination flop total (≈ 2n³/3) are now formalized (gaussExactSubs_closed, gaussExactFlops_closed). Remaining: formalize the back-substitution phase (≈ n²/2 operations) and compose it for the complete solve cost.",
       "Does the exact count extend to blocked/partial-pivoting LU factorization, where row interchanges add a lower-order term but the leading (n³ − n)/3 multiplication count is unchanged?",
       "Can a matching lower bound be formalized — that no elimination-based dense solver uses asymptotically fewer than n³/3 multiplications — to complement this exact upper count?"
     ]
@@ -147,9 +149,9 @@
     "path": "Proofs/CramersRuleOQ02OQ01.lean",
     "axiomCount": 0,
     "sorryCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 13,
     "definitionCount": 1,
-    "lineCount": 133
+    "lineCount": 195
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

This entry proves the exact `(n³ − n)/3` multiplication+division count (`gaussExactOps`) for forward Gaussian elimination. Its **first open question** asked to count additions/subtractions and assemble the full `~2n³/3` flop total. This PR does both:

| Declaration | Statement |
|---|---|
| `gaussExactSubs n = ∑_{j<n} j²` | subtraction count (one multiply–subtract pair per trailing-entry update) |
| `gaussExactSubs_closed` | `6·gaussExactSubs n + 3·n² = 2·n³ + n` — i.e. `(2n³−3n²+n)/6 ≈ n³/3` |
| `gaussExactFlops n = gaussExactOps n + gaussExactSubs n` | total leading flop count |
| `gaussExactFlops_closed` | `6·gaussExactFlops n + 3·n² + n = 4·n³` — i.e. `(4n³−3n²−n)/6 ≈ 2n³/3` |
| `gaussExactOps_le_flops` | `gaussExactOps n ≤ gaussExactFlops n` |
| `gaussExactFlops_small` | `n=2..5 ↦ 3, 13, 34, 70` |

This recovers the **textbook `2n³/3` flop headline** (`≈ n³/3` multiplications + `≈ n³/3` additions) as an exact, subtraction-free closed form.

## Proof technique

Mirrors the file's existing style: induction with a ℕ-semiring `calc` (`ring` + `Finset.sum_range_succ`), staying subtraction-free so everything lives in `ℕ`; the flop closed form composes the two summand closed forms via `omega`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.CramersRuleOQ02OQ01` → **Build succeeded** (Mathlib 4.26). **0 sorries, 0 axioms.**

`meta.json`: `theoremCount` 8→13, `definitionCount` 1→3, `lineCount` 133→195; OQ1 narrowed to the remaining back-substitution phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)