### PR TITLE
Fix British Flag Theorem metadata accuracy (line counts, imports, ranges)

### DIFF
--- a/src/data/proofs/british-flag-theorem-oq-01/annotations.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "british-flag-theorem-oq-01",
     "range": {
       "startLine": 1,
-      "endLine": 30
+      "endLine": 26
     },
     "type": "concept",
     "title": "Statement and Coordinate Setup",
@@ -49,8 +49,8 @@
     "id": "ann-sqdist",
     "proofId": "british-flag-theorem-oq-01",
     "range": {
-      "startLine": 32,
-      "endLine": 36
+      "startLine": 31,
+      "endLine": 32
     },
     "type": "definition",
     "title": "Squared Distance",
@@ -68,8 +68,8 @@
     "id": "ann-main",
     "proofId": "british-flag-theorem-oq-01",
     "range": {
-      "startLine": 38,
-      "endLine": 58
+      "startLine": 34,
+      "endLine": 48
     },
     "type": "theorem",
     "title": "The British Flag Identity",

--- a/src/data/proofs/british-flag-theorem-oq-01/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01/meta.json
@@ -5,11 +5,11 @@
   "description": "For any point P in the plane of a rectangle ABCD, the sums of squared distances to opposite corners are equal: PA² + PC² = PB² + PD².",
   "leanFile": {
     "imports": [
-      "Mathlib"
+      "Mathlib.Tactic"
     ],
     "opens": [],
     "namespace": "BritishFlagTheorem",
-    "lineCount": 60,
+    "lineCount": 48,
     "axiomCount": 0,
     "theoremCount": 1,
     "definitionCount": 1,
@@ -39,7 +39,7 @@
     ],
     "dateAdded": "2026-06-16",
     "axiomCount": 0,
-    "lineCount": 60,
+    "lineCount": 48,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The rectangle is encoded by the parallelogram closure C = B + D − A and the orthogonality of edges B − A and D − A.",
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
@@ -74,16 +74,16 @@
     {
       "id": "setup",
       "title": "Coordinate Setup and Squared Distance",
-      "startLine": 32,
-      "endLine": 36,
+      "startLine": 28,
+      "endLine": 32,
       "summary": "Model planar points as ℝ × ℝ and define sqDist P Q = (P.1 − Q.1)² + (P.2 − Q.2)².",
       "mathContext": "The squared Euclidean distance between $(p_1,p_2)$ and $(q_1,q_2)$ is $(p_1-q_1)^2 + (p_2-q_2)^2$. Using squared distance avoids square roots entirely, since the theorem is an identity among squared lengths."
     },
     {
       "id": "main",
       "title": "The British Flag Identity",
-      "startLine": 38,
-      "endLine": 58,
+      "startLine": 34,
+      "endLine": 48,
       "summary": "Substitute the parallelogram closure and reduce the goal to twice the orthogonality form, discharged by linear_combination.",
       "mathContext": "With $u = B - A$, $v = D - A$, expansion gives $(PA^2 + PC^2) - (PB^2 + PD^2) = 2(u_1 v_1 + u_2 v_2)$, which is zero by the right-angle hypothesis $u \\cdot v = 0$."
     }


### PR DESCRIPTION
Accuracy-only pass for `british-flag-theorem-oq-01`, rebased on **current main** (which already has `index.ts` and 5 annotations from a sibling enricher — this PR does not touch those except to correct line ranges).

The Lean source `Proofs/BritishFlagTheorem.lean` is **48 lines** and imports `Mathlib.Tactic`, but the metadata was stale:

| Field | Was | Now |
|-------|-----|-----|
| `leanFile.imports` | `Mathlib` | `Mathlib.Tactic` |
| `leanFile.lineCount` / `meta.lineCount` | `60` | `48` |
| section `setup` | `32–36` | `28–32` |
| section `main` | `38–58` | `34–48` |
| `ann-intro` | `1–30` | `1–26` |
| `ann-sqdist` | `32–36` | `31–32` |
| `ann-main` | `38–58` | `34–48` |

`ann-pt` (28–29) and `ann-tactic` (44–46) were already accurate and are unchanged. The `main` section and `ann-main` previously pointed past the end of a 48-line file (line 58). All 5 annotations and their content (`mathContext`/`significance`/`relatedConcepts`) are preserved.

Supersedes the closed #31582 (which conflicted on `index.ts` and would have regressed annotations 5→3). Build validates with no errors for this entry. Axiom integrity unchanged (`verified`, 0 axioms, 0 sorries).