### PR TITLE
research(erdos-1011-oq-03): repair non-compiling parent + f boundary value & Forces↔f≤m characterization [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1011OQ03.lean
+++ b/proofs/Proofs/Erdos1011OQ03.lean
@@ -23,6 +23,15 @@
      `f_five_le_f_four : f 5 n ≤ f 4 n` — the open value f_5(n) is bounded above
      by the now-known f_4(n).
 
+  1b. `forces_iff_f_le` — a complete characterization of the threshold:
+     `Forces r n m ↔ f r n ≤ m`. The forcing predicate is an up-set in the edge
+     bound (`forces_mono`), so `f r n` is exactly its least element.
+
+  1c. `f_eq_zero_of_lt` — the left boundary of the table: once `r` exceeds the
+     vertex count `n`, no `n`-vertex graph attains `χ ≥ r` (every such graph is
+     `n`-colourable, `chromaticNumber_le_card`), so the forcing condition is
+     vacuous and `f r n = 0`. The antitone-in-`r` value has bottomed out.
+
   2. The **vertex-shift pattern**. The shifts in the formulas above are
      0, 1, 3 for r = 2, 3, 4 — exactly C(r-1, 2). The pattern predicts a shift
      of C(4,2) = 6 for r = 5, i.e. a conjectured leading term ⌊(n-6)²/4⌋.
@@ -56,7 +65,7 @@ clean facts (`f_mem`, `f_le_of_forces`).
 /-- The predicate defining membership in the set `{m | … }` whose `sInf` is
     `f r n`. -/
 def Forces (r n m : ℕ) : Prop :=
-  ∀ (V : Type*) [Fintype V] [DecidableEq V],
+  ∀ (V : Type) [Fintype V] [DecidableEq V],
     Fintype.card V = n →
     ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
       hasChromatic G r → edgeCount G ≥ m → HasTriangle G
@@ -67,7 +76,6 @@ def Forces (r n m : ℕ) : Prop :=
 theorem forces_nonempty (n r : ℕ) : {m | Forces r n m}.Nonempty := by
   refine ⟨n.choose 2 + 1, ?_⟩
   intro V instF instD hcard G instA _ hedge
-  haveI := instF; haveI := instD; haveI := instA
   exfalso
   have hb : edgeCount G ≤ n.choose 2 := by
     have h := G.card_edgeFinset_le_card_choose_two
@@ -86,6 +94,22 @@ theorem f_le_of_forces {n r m : ℕ} (hm : Forces r n m) : f r n ≤ m := by
   unfold f
   exact Nat.sInf_le hm
 
+/-- The forcing predicate is monotone (an up-set) in the edge bound: if `m`
+    edges force a triangle, so does any larger bound `m'`, because the
+    hypothesis `edgeCount G ≥ m'` is stronger than `edgeCount G ≥ m`. -/
+theorem forces_mono {r n m m' : ℕ} (hm : Forces r n m) (hmm : m ≤ m') :
+    Forces r n m' := by
+  intro V instF instD hcard G instA hchrom hedge
+  exact hm V hcard G hchrom (le_trans hmm hedge)
+
+/-- **Complete characterization of the threshold.** `m` forces a triangle iff
+    `m` is at least the threshold `f r n`. The forward direction is
+    `f_le_of_forces`; the reverse uses that `f r n` itself forces (`f_forces`)
+    together with up-set monotonicity (`forces_mono`). This pins down `f r n`
+    as exactly the least `m` in the up-set `{m | Forces r n m}`. -/
+theorem forces_iff_f_le {r n m : ℕ} : Forces r n m ↔ f r n ≤ m :=
+  ⟨f_le_of_forces, fun h => forces_mono (f_forces n r) h⟩
+
 /-
 ## Main structural theorem: antitonicity in the chromatic parameter
 
@@ -102,7 +126,6 @@ theorem f_antitone_in_chromatic {n r r' : ℕ} (h : r ≤ r') :
     f r' n ≤ f r n := by
   apply f_le_of_forces
   intro V instF instD hcard G instA hchrom hedge
-  haveI := instF; haveI := instD; haveI := instA
   have hchrom' : hasChromatic G r := le_trans h hchrom
   exact f_forces n r V hcard G hchrom' hedge
 
@@ -117,6 +140,36 @@ theorem f_chain (n : ℕ) : f 5 n ≤ f 4 n ∧ f 4 n ≤ f 3 n ∧ f 3 n ≤ f 
   ⟨f_antitone_in_chromatic (by norm_num),
    f_antitone_in_chromatic (by norm_num),
    f_antitone_in_chromatic (by norm_num)⟩
+
+/-
+## The degenerate regime: r > n forces the threshold to 0
+
+A graph on `n` vertices can be properly coloured with `n` colours (the identity
+colouring `V ≃ Fin n` is proper), so `χ(G) ≤ n`. Hence once `r > n` the
+hypothesis `χ(G) ≥ r` is unsatisfiable and the forcing implication holds
+vacuously for *every* edge bound — including `m = 0`. So `f r n = 0` there.
+This is the exact left boundary of the table: the antitone-in-`r` value
+`f r n` has already bottomed out at 0 by the time `r` exceeds the vertex count.
+-/
+
+/-- Any `n`-vertex graph is `n`-colourable, hence `χ(G) ≤ n`. The identity
+    bijection `V ≃ Fin (card V)` is a proper colouring because adjacent vertices
+    are distinct and the bijection is injective. -/
+theorem chromaticNumber_le_card {W : Type*} [Fintype W] [DecidableEq W]
+    (G : SimpleGraph W) : chromaticNumber G ≤ Fintype.card W :=
+  Nat.sInf_le ⟨Fintype.equivFin W, fun _ _ hadj heq =>
+    G.ne_of_adj hadj ((Fintype.equivFin W).injective heq)⟩
+
+/-- **Boundary value.** If the required chromatic number exceeds the vertex
+    count (`n < r`) then `f r n = 0`: no `n`-vertex graph attains `χ ≥ r`, so the
+    forcing condition is vacuous at every edge bound. -/
+theorem f_eq_zero_of_lt {r n : ℕ} (h : n < r) : f r n = 0 := by
+  refine Nat.le_antisymm (f_le_of_forces ?_) (Nat.zero_le _)
+  intro V instF instD hcard G instA hchrom _
+  exfalso
+  unfold hasChromatic at hchrom
+  have hle : chromaticNumber G ≤ n := hcard ▸ chromaticNumber_le_card G
+  omega
 
 /-
 ## The vertex-shift pattern
@@ -146,10 +199,7 @@ theorem chromaticShift_eq (r : ℕ) : chromaticShift r = (r - 1) * (r - 2) / 2 :
 theorem chromaticShift_mono : Monotone chromaticShift := by
   intro a b hab
   unfold chromaticShift
-  first
-    | exact Nat.choose_le_choose 2 (by omega)
-    | (gcongr; omega)
-    | exact Nat.choose_mono 2 (by omega)
+  exact Nat.choose_le_choose 2 (by omega)
 
 /-
 ## The open statements
@@ -175,6 +225,10 @@ theorem shiftConjecture_imp_f5 (h : shiftConjecture) : f5Conjecture := by
 
 #check f_antitone_in_chromatic
 #check f_five_le_f_four
+#check forces_iff_f_le
+#check f_eq_zero_of_lt
 #check chromaticShift_known
 #print axioms f_antitone_in_chromatic
+#print axioms forces_iff_f_le
+#print axioms f_eq_zero_of_lt
 #print axioms chromaticShift_known

--- a/proofs/Proofs/Erdos1011Problem.lean
+++ b/proofs/Proofs/Erdos1011Problem.lean
@@ -57,9 +57,14 @@ f_r(n) is minimal such that chromatic number ≥ r and ≥ f_r(n) edges implies 
 def hasChromatic (G : SimpleGraph V) (r : ℕ) : Prop :=
   chromaticNumber G ≥ r
 
-/-- The threshold function f_r(n) -/
+/-- The threshold function f_r(n). The vertex type is quantified over `Type`
+    (rather than `Type*`): since the predicate constrains `Fintype.card V = n`,
+    every finite vertex set is equivalent to one in `Type 0`, so the value is
+    unchanged while `f` stays universe-monomorphic — this prevents a free
+    universe parameter from leaking into the `Prop`-valued conjectures that
+    mention `f` (e.g. in `Proofs.Erdos1011OQ03`). -/
 noncomputable def f (r n : ℕ) : ℕ :=
-  sInf {m : ℕ | ∀ (V : Type*) [Fintype V] [DecidableEq V],
+  sInf {m : ℕ | ∀ (V : Type) [Fintype V] [DecidableEq V],
     Fintype.card V = n →
     ∀ G : SimpleGraph V, [DecidableRel G.Adj] →
     hasChromatic G r → edgeCount G ≥ m → HasTriangle G}
@@ -105,18 +110,24 @@ def f4Threshold (n : ℕ) : ℕ := (n - 3)^2 / 4 + 6
 f_r(n) = n²/4 - g(r)·n/2 + O(1)
 -/
 
-/-- g(r): vertices to remove from χ ≥ r triangle-free graph to make bipartite -/
+/-- g(r): vertices to remove from χ ≥ r triangle-free graph to make bipartite.
+    Existential type binders are written with anonymous instance hypotheses
+    `(_ : Fintype V)` (instance brackets `[…]` are not valid inside `∃`), and the
+    witness type is fixed to `Type` so `g` is universe-monomorphic — otherwise the
+    free universe parameter leaks into the `Prop`-valued conjectures below. `g`
+    only feeds the asymptotic axioms/conjectures; no verified theorem depends on
+    its precise value. -/
 noncomputable def g (r : ℕ) : ℕ :=
-  sSup {k : ℕ | ∃ (V : Type*) [Fintype V] [DecidableEq V],
-    ∃ G : SimpleGraph V, [DecidableRel G.Adj] →
+  sSup {k : ℕ | ∃ (V : Type) (_ : Fintype V) (_ : DecidableEq V)
+      (G : SimpleGraph V),
     ¬HasTriangle G ∧ hasChromatic G r ∧
-    ∀ S : Finset V, S.card < k → ¬∃ (W : Type*) [Fintype W],
-      ∃ H : SimpleGraph W, chromaticNumber H ≤ 2}
+    ∀ S : Finset V, S.card < k → ¬ ∃ (W : Type) (_ : Fintype W)
+      (H : SimpleGraph W), chromaticNumber H ≤ 2}
 
 /-- Simonovits asymptotic formula -/
 axiom simonovits_asymptotic :
   ∀ r ≥ 2, ∃ C : ℕ, ∀ n ≥ r,
-    |((f r n : ℤ) - n^2/4 + (g r : ℤ) * n / 2)| ≤ C
+    |((f r n : ℤ) - (n : ℤ) ^ 2 / 4 + (g r : ℤ) * (n : ℤ) / 2)| ≤ (C : ℤ)
 
 /-
 ## Bounds on g(r)

--- a/research/problems/erdos-1011-oq-03/knowledge.md
+++ b/research/problems/erdos-1011-oq-03/knowledge.md
@@ -44,11 +44,49 @@ triangle-free χ=r gadget grafted onto one side, the gadget occupying ~C(r-1,2)
 "shifted" vertices. The additive constants 1, 2, 6 are not yet identified with a
 closed form and are the genuinely open part for r = 5.
 
+## Session 2 (researcher-1): build repair + boundary value + characterization
+
+**Critical finding: the entry never actually compiled.** The parent
+`Erdos1011Problem.lean` (an `additionalFile`) had three independent build breaks
+on `main`, and `Erdos1011OQ03.lean` had two latent bugs that only surface once
+the parent builds:
+
+1. Parent `g` used instance binders inside `∃` (`∃ (V : Type*) [Fintype V]`),
+   invalid Lean 4 — `∃` does not take `[…]` binders (only `∀` does). Rewrote with
+   anonymous hypotheses `(_ : Fintype V)`, dropped the spurious `[DecidableRel] →`.
+2. Parent `simonovits_asymptotic` mixed ℤ/ℕ without coercions. Added `(n : ℤ)`,
+   `(C : ℤ)`.
+3. `f`/`g` were universe-polymorphic (`∀ (V : Type*)`), leaking a free universe
+   parameter into the `def … : Prop` conjectures → "universe level metavariables".
+   Quantified over `Type`; value unchanged (predicate fixes `card V = n`).
+4. OQ03 `forces_nonempty` / `f_antitone_in_chromatic` had redundant
+   `haveI := instF; …` after `intro`. The `intro`'d instance-implicit binders are
+   already local instances; the `haveI` duplicates shadowed them, so `rw [hcard]`
+   and the `f_forces` application saw a *different* `Fintype V` instance →
+   "pattern not found" / "instance not definitionally equal". Removing the `haveI`
+   lines fixed both. (Errored proofs were briefly replaced by `sorry`, which is
+   why `#print axioms` momentarily showed `sorryAx`.)
+
+**New mathematical content (0 axiom, verified):**
+- `forces_mono` + `forces_iff_f_le : Forces r n m ↔ f r n ≤ m` — the forcing
+  predicate is an up-set in the edge bound; `f r n` is exactly its least element.
+- `chromaticNumber_le_card : χ(G) ≤ card V` (identity colouring `V ≃ Fin (card V)`).
+- `f_eq_zero_of_lt : n < r → f r n = 0` — left boundary of the table: once `r`
+  exceeds the vertex count, no graph attains `χ ≥ r`, so forcing is vacuous. The
+  antitone-in-r value has bottomed out at 0.
+
+After repair: parent + OQ01 + OQ03 all build clean; every OQ03 theorem
+`#print axioms` reports only propext / Classical.choice / Quot.sound.
+14 theorems, 4 defs, 0 axiom, 0 sorry, 234 lines.
+
 ## Honest status
 
 The headline open problem (the value of f_5(n)) is **not solved**. The new
-mathematical content is the antitonicity theorem and its corollary upper bound;
-the rest organizes known data and the conjecture. Verified, axiom-free.
+mathematical content is the antitonicity theorem and its corollary upper bound,
+plus the up-set characterization (`forces_iff_f_le`) and the boundary value
+(`f_eq_zero_of_lt`); the rest organizes known data and the conjecture. Verified,
+axiom-free. Arguably the most consequential part of session 2 is the build
+repair: the entry was marked `verified` but did not actually compile until now.
 
 ## Next steps
 

--- a/src/data/proofs/erdos-1011-oq-03/meta.json
+++ b/src/data/proofs/erdos-1011-oq-03/meta.json
@@ -29,24 +29,26 @@
     "erdosUrl": "https://erdosproblems.com/1011",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 177,
-    "assumptions": "None. 0 axioms, 0 sorries. The theorems use only the sInf definition of f and Mathlib (Nat.sInf_le/mem, card_edgeFinset_le_card_choose_two). #print axioms reports only propext / Classical.choice / Quot.sound. The 5 axioms of the parent file Erdos1011Problem.lean (the known f₂,f₃ values and bounds on g(r)) are NOT used by any theorem in this file.",
+    "lineCount": 234,
+    "assumptions": "None. 0 axioms, 0 sorries. The theorems use only the sInf definition of f and Mathlib (Nat.sInf_le/mem, card_edgeFinset_le_card_choose_two, Nat.choose_le_choose, Fintype.equivFin). #print axioms reports only propext / Classical.choice / Quot.sound for every theorem (f_antitone_in_chromatic, forces_iff_f_le, f_eq_zero_of_lt). The 5 axioms of the parent file Erdos1011Problem.lean (the known f₂,f₃ values and bounds on g(r)) are NOT used by any theorem in this file. (The parent file and this one were repaired this session so they actually compile — see the proofStrategy note.)",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 14,
     "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Erdős Problem #1011 asks for f_r(n): the minimum number of edges such that every n-vertex graph with chromatic number at least r and at least f_r(n) edges contains a triangle. Turán (1941) solved r=2: f_2(n) = ⌊n²/4⌋ + 1. Erdős and Gallai (1962) gave f_3(n) = ⌊(n-1)²/4⌋ + 2. The case r=4 resisted for decades until Ren, Wang, Wang and Yang determined f_4(n) = ⌊(n-3)²/4⌋ + 6 (n ≥ 150) in 2024. Open question OQ-03 takes the natural next step: compute f_5(n), which is unknown.\n\nThis entry does not compute f_5(n) — that is the open problem. Instead it establishes the unconditional structure any answer must satisfy, with no axioms. The headline is that the threshold f_r(n) is antitone in r: imposing a higher chromatic number is a stronger hypothesis on the graph, so it can only lower the edge count needed to force a triangle. This pins f_5(n) ≤ f_4(n), giving an unconditional upper bound on the open value in terms of the freshly-solved one.",
     "problemStatement": "Let f_r(n) be minimal such that every n-vertex graph with at least f_r(n) edges and chromatic number at least r contains a triangle. The values for r = 2, 3, 4 are known; determine f_5(n).",
     "text": "f_r(n) = least m forcing a triangle when χ ≥ r and e(G) ≥ m. Known for r ≤ 4; f₅(n) open. Proved here (0 axioms): f antitone in r ⟹ f₅(n) ≤ f₄(n) = ⌊(n-3)²/4⌋+6 (n≥150); and the shift pattern C(r-1,2)=0,1,3,6.",
-    "proofStrategy": "The threshold f r n is sInf of the set of edge counts m that force a triangle whenever χ ≥ r. Factoring this set's membership predicate as `Forces r n m`, two clean facts follow: the set is nonempty (any m > C(n,2) forces vacuously, via card_edgeFinset_le_card_choose_two), so the infimum is attained (`f_forces`); and any forcing m bounds f from above (`f_le_of_forces`). Antitonicity is then immediate: for r ≤ r', the hypothesis χ ≥ r' implies χ ≥ r, so the forcing property at threshold f r n still holds when restricted to χ ≥ r' graphs — giving f r' n ≤ f r n directly. Separately, `chromaticShift r = C(r-1,2)` is shown to reproduce the known shifts 0,1,3 and predict 6 for r=5, with closed form (r-1)(r-2)/2 and monotonicity.",
+    "proofStrategy": "The threshold f r n is sInf of the set of edge counts m that force a triangle whenever χ ≥ r. Factoring this set's membership predicate as `Forces r n m`, two clean facts follow: the set is nonempty (any m > C(n,2) forces vacuously, via card_edgeFinset_le_card_choose_two), so the infimum is attained (`f_forces`); and any forcing m bounds f from above (`f_le_of_forces`). Antitonicity is then immediate: for r ≤ r', the hypothesis χ ≥ r' implies χ ≥ r, so the forcing property at threshold f r n still holds when restricted to χ ≥ r' graphs — giving f r' n ≤ f r n directly. The forcing predicate is also an up-set in the edge bound (`forces_mono`), which yields the exact characterization `forces_iff_f_le : Forces r n m ↔ f r n ≤ m`. At the left boundary, once r exceeds the vertex count n no n-vertex graph attains χ ≥ r (every such graph is n-colourable, `chromaticNumber_le_card` via the identity colouring V ≃ Fin n), so the forcing condition is vacuous and `f_eq_zero_of_lt : n < r → f r n = 0`. Separately, `chromaticShift r = C(r-1,2)` is shown to reproduce the known shifts 0,1,3 and predict 6 for r=5, with closed form (r-1)(r-2)/2 and monotonicity. Build note: this session repaired the parent `Erdos1011Problem.lean`, which did not compile (instance binders inside an `∃`, ℤ/ℕ coercion gaps in `simonovits_asymptotic`, and a universe parameter leaking from `f`/`g` into the Prop conjectures); `f`/`g` were made universe-monomorphic over `Type`, value-unchanged since the predicate fixes `card V = n`.",
     "keyInsights": [
       "f_r(n) is antitone in r: stronger chromatic hypothesis ⟹ lower triangle-forcing threshold",
       "Corollary: f₅(n) ≤ f₄(n) = ⌊(n-3)²/4⌋ + 6 (n ≥ 150) — an unconditional upper bound on the open value",
       "Antitonicity is pure sInf monotonicity over the defining sets; no extremal theory needed",
       "Nonemptiness of the defining set uses the edge bound e(G) ≤ C(n,2)",
       "Vertex-shift pattern: the ⌊(n-s)²/4⌋ shift is s = C(r-1,2) = 0,1,3 for r=2,3,4, predicting 6 for r=5",
-      "The additive constants 1, 2, 6 remain without an identified closed form — the genuinely open part"
+      "The additive constants 1, 2, 6 remain without an identified closed form — the genuinely open part",
+      "Complete characterization: Forces r n m ↔ f r n ≤ m — the forcing predicate is an up-set whose least element is exactly the threshold",
+      "Left boundary: f r n = 0 once r > n, since χ(G) ≤ n forbids χ ≥ r and the forcing condition becomes vacuous"
     ],
     "prerequisites": [
       "Graph theory (chromatic number, edges, triangles)",


### PR DESCRIPTION
## Summary

`erdos-1011-oq-03` (compute f₅(n), open) was marked **verified** but **did not actually compile**: its `additionalFile` parent `Erdos1011Problem.lean` had three independent build breaks on `main`, and `Erdos1011OQ03.lean` itself had two latent bugs that only surface once the parent builds. This PR repairs all of them and adds new 0-axiom content. Parent + OQ01 + OQ03 now build clean under Lean 4.26.0 / Mathlib.

## Build repairs (parent never parsed)

1. **`g`** used instance binders inside `∃` (`∃ (V : Type*) [Fintype V]`) — invalid Lean 4 (`∃` does not take `[…]` binders; only `∀` does). Rewrote with anonymous hypotheses `(_ : Fintype V)` and dropped a spurious `[DecidableRel] →`.
2. **`simonovits_asymptotic`** mixed ℤ and ℕ without coercions (`(f r n : ℤ) - n^2/4 + … * n / 2 ≤ C`). Added `(n : ℤ)`, `(C : ℤ)`.
3. **`f`/`g`** were universe-polymorphic (`∀ (V : Type*)`), leaking a free universe parameter into the `def … : Prop` conjectures (`shiftConjecture`, `f5Conjecture`) → *"universe level metavariables"*. Quantified over `Type`; **value unchanged** since the predicate fixes `Fintype.card V = n` (every finite vertex set is equivalent to one in `Type 0`).
4. **OQ03 `forces_nonempty` / `f_antitone_in_chromatic`** had redundant `haveI := instF; …` after `intro`. The `intro`'d instance-implicit binders are *already* local instances; the duplicates shadowed them, so `rw [hcard]` (and the `f_forces` application) saw a different `Fintype V` instance → *"pattern not found"* / *"instance not definitionally equal"*. Removing the `haveI` lines fixed both. (Those errored proofs were briefly replaced by `sorry`, the source of a transient `sorryAx`.)

## New mathematical content (0 axiom)

- `forces_mono` + **`forces_iff_f_le : Forces r n m ↔ f r n ≤ m`** — the forcing predicate is an up-set in the edge bound; `f r n` is exactly its least element. A complete characterization of the threshold.
- `chromaticNumber_le_card : χ(G) ≤ card V` — the identity colouring `V ≃ Fin (card V)` is proper.
- **`f_eq_zero_of_lt : n < r → f r n = 0`** — the left boundary of the table. Once `r` exceeds the vertex count, no `n`-vertex graph attains `χ ≥ r`, so the forcing condition is vacuous at every edge bound. Complements antitonicity-in-`r`: the value has bottomed out at 0 by the time `r > n`.

The headline open problem (the value of f₅(n)) remains **unsolved** — this entry only establishes unconditional structure.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1011OQ03` → builds clean (no errors/warnings).
- `Proofs.Erdos1011OQ01` and the parent `Proofs.Erdos1011Problem` also build.
- `#print axioms` for `f_antitone_in_chromatic`, `forces_iff_f_le`, `f_eq_zero_of_lt` → only `propext / Classical.choice / Quot.sound`. No `sorryAx`, no `Lean.ofReduceBool`.
- 14 theorems, 4 defs, 0 axiom, 0 sorry, 234 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)