### PR TITLE
research(erdos-1005-oq-02): §29 — equality locus of the product ceiling [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -2811,4 +2811,84 @@ theorem continuant_prod_bounds_example :
   refine continuant_prod_bounds [3, 3] ?_
   intro k hk; fin_cases hk <;> norm_num
 
+/-! ## §29: The equality locus of the product ceiling — strictness beyond length 1
+
+§28's upper bound `Continuant ks ≤ ks.prod` is tight only at the two trivial depths:
+`K([]) = 1 = ∏[]` and `K([k]) = k = ∏[k]`.  As soon as the run carries two or more
+quotients the single-step minus-continuant recurrence `K(k::rest) = k·K(rest) − secondCont rest`
+subtracts a *strictly positive* trailing continuant — by §22 `secondCont_cons`,
+`secondCont (j::rest') = K(rest') ≥ 1` (§17 `continuant_pos`) — so the ceiling is never
+attained: `Continuant ks < ks.prod` for `|ks| ≥ 2`.
+
+The engine is a **quantitative deficit**: at each head step the product overshoots the
+continuant by *at least* the trailing continuant of the tail,
+`secondCont rest ≤ (k::rest).prod − Continuant (k::rest)`, because the residual
+`k·(∏rest − K(rest))` is nonnegative by §28's `continuant_le_prod`.  Summed along the run
+this says the §28 ceiling overshoots by the accumulated trailing continuants — the exact
+multiplicative "loss" the minus-continuant pays relative to the naive product.
+
+This pins the equality locus of the §28 sandwich's upper half (a sharp-boundary companion to
+§20's sharpness of the linear floor) and is, like everything in this regime, silent at the
+density bottleneck `d = 2`: the strictness is real but the overshoot it measures lives in the
+large-quotient tail that carries negligible mass toward the open `1/12`–`1/4` constant. -/
+
+/-- **Product-ceiling deficit.**  For a nonempty large-quotient run `k :: rest`, the product
+overshoots the continuant by at least the trailing continuant of the tail:
+`secondCont rest ≤ (k :: rest).prod − Continuant (k :: rest)`.  Unfolding the head step
+`K(k::rest) = k·K(rest) − secondCont rest`, the deficit is `secondCont rest + k·(∏rest − K rest)`,
+and the residual `k·(∏rest − K rest) ≥ 0` by §28 `continuant_le_prod` with `k ≥ 0`. -/
+theorem continuant_prod_deficit {k : ℤ} {rest : List ℤ} (hk : (2 : ℤ) ≤ k)
+    (h : ∀ x ∈ rest, (2 : ℤ) ≤ x) :
+    secondCont rest ≤ (k :: rest).prod - Continuant (k :: rest) := by
+  have hle : Continuant rest ≤ rest.prod := continuant_le_prod rest h
+  rw [continuant_cons, List.prod_cons]
+  nlinarith [mul_nonneg (show (0 : ℤ) ≤ k by linarith)
+    (show (0 : ℤ) ≤ rest.prod - Continuant rest from sub_nonneg.mpr hle)]
+
+/-- **Strict product ceiling for length ≥ 2.**  Once a large-quotient run has two or more
+quotients, the continuant is *strictly* below the product of its quotients,
+`Continuant ks < ks.prod`.  The deficit (`continuant_prod_deficit`) is at least the trailing
+continuant `secondCont (j::rest') = K(rest') ≥ 1` (§17 `continuant_pos`), which is strictly
+positive — so the §28 ceiling is never attained beyond depth `1`. -/
+theorem continuant_lt_prod {ks : List ℤ} (h : ∀ k ∈ ks, (2 : ℤ) ≤ k)
+    (hlen : 2 ≤ ks.length) : Continuant ks < ks.prod := by
+  rcases ks with _ | ⟨k, _ | ⟨j, rest⟩⟩
+  · exact absurd hlen (by decide)
+  · simp only [List.length_cons, List.length_nil] at hlen; omega
+  · have hk : (2 : ℤ) ≤ k := h k (by simp)
+    have hrest : ∀ x ∈ (j :: rest), (2 : ℤ) ≤ x :=
+      fun x hx => h x (List.mem_cons_of_mem k hx)
+    have hrest' : ∀ x ∈ rest, (2 : ℤ) ≤ x :=
+      fun x hx => hrest x (List.mem_cons_of_mem j hx)
+    have hscpos : 1 ≤ secondCont (j :: rest) := by
+      rw [secondCont_cons]; exact continuant_pos rest hrest'
+    have hdef : secondCont (j :: rest) ≤ (k :: j :: rest).prod - Continuant (k :: j :: rest) :=
+      continuant_prod_deficit hk hrest
+    linarith
+
+/-- **Equality locus of the product ceiling.**  In the large-quotient regime the §28 ceiling
+`Continuant ks ≤ ks.prod` is an *equality* exactly at the two trivial depths `|ks| ≤ 1`
+(`K[] = 1 = ∏[]`, `K[k] = k = ∏[k]`); for every deeper run it is strict.  The product ceiling
+is attained only before the minus-continuant recurrence has had a chance to subtract a
+trailing continuant. -/
+theorem continuant_eq_prod_iff {ks : List ℤ} (h : ∀ k ∈ ks, (2 : ℤ) ≤ k) :
+    Continuant ks = ks.prod ↔ ks.length ≤ 1 := by
+  constructor
+  · intro heq
+    by_contra hlen
+    exact absurd heq (ne_of_lt (continuant_lt_prod h (by omega)))
+  · intro hlen
+    rcases ks with _ | ⟨k, _ | ⟨j, rest⟩⟩
+    · simp [continuant_nil]
+    · simp [continuant_one]
+    · simp only [List.length_cons] at hlen; omega
+
+/-- **Concrete strictness.**  For `[3, 3]` the product ceiling overshoots strictly:
+`K[3,3] = 8 < 9 = ∏ kᵢ`, and the deficit `9 − 8 = 1` matches the trailing continuant
+`secondCont [3] = K[] = 1`.  Discharged through the general strict bound. -/
+theorem continuant_lt_prod_example :
+    Continuant [3, 3] < ([3, 3] : List ℤ).prod := by
+  refine continuant_lt_prod (ks := [3, 3]) ?_ (by decide)
+  intro k hk; fin_cases hk <;> norm_num
+
 end Erdos1005OQ02

--- a/src/data/research/problems/erdos-1005-oq-02.json
+++ b/src/data/research/problems/erdos-1005-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: §24 suffix transfer of the §23 period-6 leading-1 law via the §16 reversal bridge; 1-run boundaries of a general quotient word now period-6 classified at both ends. Open 1/12 constant: interior junction aggregation still the hard step.",
+    "progressSummary": "PROGRESS: §29 pins the equality locus of §28 product ceiling — strict K < ∏kᵢ for length ≥ 2, equality ⟺ length ≤ 1, with a quantitative deficit ≥ trailing continuant. Sharp-boundary companion to §20. Open 1/12 constant still governed by the small-quotient (d=2) regime, untouched.",
     "builtItems": [
       "unimodular_iterate_left/right (Erdos1005ProblemOQ02.lean §6): k-fold one-sided mediant insertion stays unimodular, a/b<(k·a+c)/(k·b+d); proved by scale-invariance of bc=ad+1 (no induction)",
       "denom_ge_iterate_left/right (Erdos1005ProblemOQ02.lean §6): depth-k interior denominator bound q ≥ (k+1)·b+d, LINEAR in depth",
@@ -61,7 +61,11 @@
       "§23 continuant_replicate_one_append_period/_six_mul/_mod — period-6 corollaries, K(1ʲ++ks) depends only on j%6 for every tail",
       "§23 continuant_replicate_one_append_orbit — full if-then-else closed form by j%6 selecting [K,K−s,−s,−K,s−K,s]; generalises continuant_replicate_one_mod",
       "§23 continuant_replicate_one_append_pos_iff / _ne_zero — sign classification on nonempty all-≥2 tail: >0 iff j%6∈{0,1,5}, never 0. [verified, 0-axiom]",
-      "§24 continuant_append_replicate_one_orbit/_pos_iff/_ne_zero (Erdos1005ProblemOQ02.lean §24): trailing-1 period-6 law via §16 reversal bridge — K(ks++1ʲ)=K(1ʲ++ks.reverse), same j≡0,1,5(mod6) positivity residues as §23, reversal-invariant membership"
+      "§24 continuant_append_replicate_one_orbit/_pos_iff/_ne_zero (Erdos1005ProblemOQ02.lean §24): trailing-1 period-6 law via §16 reversal bridge — K(ks++1ʲ)=K(1ʲ++ks.reverse), same j≡0,1,5(mod6) positivity residues as §23, reversal-invariant membership",
+      "continuant_prod_deficit (Erdos1005ProblemOQ02.lean §29): secondCont rest ≤ (k::rest).prod − Continuant(k::rest) for all-≥2",
+      "continuant_lt_prod (§29): |ks|≥2 ∧ all-≥2 ⟹ Continuant ks < ks.prod (strict §28 ceiling)",
+      "continuant_eq_prod_iff (§29): all-≥2 ⟹ (Continuant ks = ks.prod ⟺ ks.length ≤ 1)",
+      "continuant_lt_prod_example (§29): K[3,3]=8 < 9, deficit 1 = secondCont[3]"
     ],
     "insights": [
       "CORRECTION: the roadmap heuristic that the order-n cap forces O(log n) refinement depth is FALSE for arbitrary mediant chains. The one-sided chain 0/1,1/2,1/3,…,1/n fits Θ(n) levels under q≤n with only LINEAR denominator growth (k+1)·b+d.",
@@ -82,7 +86,9 @@
       "§23 orbit closed form: K(1ʲ++ks) cycles through [K, K−s, −s, −K, s−K, s] (s=secondCont ks) by j%6. Substituting ks=[] (K=1,s=0) recovers §21 orbit 1,1,0,−1,−1,0 EXACTLY; j%6=1,2 recover the §22 closed forms — §21 and §22 are the two specialisations of one periodic law.",
       "§23 sign law (nonempty all-≥2 tail): the §17 invariant 0<secondCont ks<K(ks) fixes every orbit sign — K(1ʲ++ks)>0 iff j≡0,1,5 (mod 6), <0 iff j≡2,3,4, NEVER 0. §22 (at most one leading 1 stays positive) is the j≤2 window of this period-6 alternation; the empty-tail zeros of §21 are an artefact of ks=[].",
       "The period-6 leading-1 rotation (§23) brackets a large-quotient block on BOTH ends identically: trailing 1s reduce to leading 1s on the reversed tail via continuant_reverse, transferring the entire orbit and the IDENTICAL sign classification at zero arithmetic cost",
-      "Session 2026-06-30 (researcher-2): §26 quotient-weighted continuant growth. continuant_ge_length_weighted (d≥2, entries≥d): (d-1)|ks|+1 ≤ Continuant ks — sharpens §17's slope-1 bound to slope (d-1). Corollary continuant_run_length_le: a continuant ceiling N caps run length at |ks| ≤ (N-1)/(d-1), the targeted O(n/d) bound (first d-sensitive run-length cap). Integrality (secondCont+1 ≤ Continuant) is essential — equality is attained. 0-axiom docker-verified [3058/3058]. Still open: the order-n continuant ceiling + admissible-list count (the 1/12-1/4 density step)."
+      "Session 2026-06-30 (researcher-2): §26 quotient-weighted continuant growth. continuant_ge_length_weighted (d≥2, entries≥d): (d-1)|ks|+1 ≤ Continuant ks — sharpens §17's slope-1 bound to slope (d-1). Corollary continuant_run_length_le: a continuant ceiling N caps run length at |ks| ≤ (N-1)/(d-1), the targeted O(n/d) bound (first d-sensitive run-length cap). Integrality (secondCont+1 ≤ Continuant) is essential — equality is attained. 0-axiom docker-verified [3058/3058]. Still open: the order-n continuant ceiling + admissible-list count (the 1/12-1/4 density step).",
+      "§29: The §28 product ceiling K ≤ ∏kᵢ is tight ONLY at depths |ks| ≤ 1 (K[]=1=∏[], K[k]=k=∏[k]); strict for |ks| ≥ 2. Equality locus characterized: continuant_eq_prod_iff ⟺ length ≤ 1.",
+      "§29: Quantitative deficit — the product overshoots the continuant by AT LEAST the trailing continuant of the tail: secondCont rest ≤ (k::rest).prod − Continuant(k::rest), since residual k·(∏rest−K rest) ≥ 0 by §28 continuant_le_prod. The minus-continuant pays an accumulated-trailing-continuant loss vs the naive product."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## §29: The equality locus of the §28 product ceiling

§28 established the two-sided sandwich ∏(kᵢ−1) ≤ K(ks) ≤ ∏kᵢ on all-≥2 minus-continuants. §29 pins **exactly when the upper half is tight** and quantifies the slack everywhere else.

### Results (all 0-axiom, docker-verified)

- **`continuant_prod_deficit`** — for a nonempty large-quotient run, the product overshoots the continuant by *at least* the trailing continuant of the tail:
  `secondCont rest ≤ (k :: rest).prod − Continuant (k :: rest)`.
  Unfolds the head step `K(k::rest) = k·K(rest) − secondCont rest`; the residual `k·(∏rest − K rest) ≥ 0` by §28 `continuant_le_prod`.
- **`continuant_lt_prod`** — once a run carries two or more quotients the ceiling is **strict**: `|ks| ≥ 2 ∧ all-≥2 ⟹ Continuant ks < ks.prod`. The deficit is at least `secondCont (j::rest) = K(rest) ≥ 1` (§17 `continuant_pos`).
- **`continuant_eq_prod_iff`** — the equality locus: `Continuant ks = ks.prod ⟺ ks.length ≤ 1` (i.e. only `K[]=1=∏[]` and `K[k]=k=∏[k]`).
- **`continuant_lt_prod_example`** — concrete: `K[3,3] = 8 < 9 = ∏`, deficit `1 = secondCont[3]`.

### Significance & honest scope
A sharp-boundary companion to §20's sharpness of the linear floor: §28's product ceiling is attained *only* before the minus-continuant recurrence has subtracted a trailing continuant. Like everything in this regime it is **silent at the `d=2` density bottleneck** — the strict overshoot it measures lives in the large-quotient tail that carries negligible mass toward the open `1/12`–`1/4` constant.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos1005ProblemOQ02` → ✔ [3058/3058]
- 0 sorries, 0 `axiom` declarations, no `native_decide`. 172 theorems / 2894 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)