### PR TITLE
research(erdos-1090-incomplete-01): Ramsey-property monotonicity lemmas [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -375,6 +375,32 @@ theorem hasRamseyProperty_card_ge (A : Finset Point) (k : ℕ)
   exact le_trans hSk (Finset.card_le_card hSA)
 
 /--
+**Monotonicity in the configuration:**
+Enlarging the point set preserves the Ramsey property: if `A ⊆ B` and `A` has the
+Ramsey property for `k`, then so does `B`.  For any 2-coloring, a monochromatic
+`k`-collinear subset of `A` is *a fortiori* a subset of `B`.  This makes
+`ramseyNumber k` a genuine threshold and is the structural basis for "minimum set
+size" being well-defined.
+-/
+theorem hasRamseyProperty_mono {A B : Finset Point} (hAB : A ⊆ B) {k : ℕ}
+    (hA : HasRamseyProperty A k) : HasRamseyProperty B k := by
+  intro c
+  obtain ⟨S, hSA, hScol, hSmono⟩ := hA c
+  exact ⟨S, hSA.trans hAB, hScol, hSmono⟩
+
+/--
+**Monotonicity in `k` (downward):**
+Requiring fewer monochromatic collinear points is easier.  If `A` has the Ramsey
+property for `k` and `k' ≤ k`, then `A` has it for `k'`: the same monochromatic
+`k`-collinear subset already has `≥ k ≥ k'` points on a common line.
+-/
+theorem hasRamseyProperty_antitone {A : Finset Point} {k k' : ℕ} (hk : k' ≤ k)
+    (hA : HasRamseyProperty A k) : HasRamseyProperty A k' := by
+  intro c
+  obtain ⟨S, hSA, ⟨hSk, hline⟩, hSmono⟩ := hA c
+  exact ⟨S, hSA, ⟨le_trans hk hSk, hline⟩, hSmono⟩
+
+/--
 **Trivial Lower Bound:**
 R(k) ≥ k since we need at least k points to have k collinear.
 

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -61,12 +61,13 @@
       "IsMonochromatic, IsKCollinear, MonochromaticKCollinear, HasRamseyProperty, Erdos1090Question statements",
       "erdos_1090_affirmative, erdos_1090, erdos_1090_summary: main results, now axiom-free",
       "hasRamseyProperty_card_ge, ramsey_lower_bound: size lower bounds",
-      "SylvesterGallai, HellyProperty, Erdos1090Generalized, Erdos1090HigherDim: related/generalized statements"
+      "SylvesterGallai, HellyProperty, Erdos1090Generalized, Erdos1090HigherDim: related/generalized statements",
+      "hasRamseyProperty_mono / hasRamseyProperty_antitone (0-axiom): the Ramsey property is upward-closed under superset (A ⊆ B) and downward-closed in k (k' ≤ k), the structural monotonicities that make ramseyNumber k a well-defined threshold"
     ],
     "axiomCount": 0,
-    "lineCount": 487,
+    "lineCount": 513,
     "assumptions": "None. 0 axiom declarations, 0 sorries. Both former axioms (graham_selfridge, hunter_observation) are now theorems proved from Mathlib's Hales-Jewett theorem. #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound]; no sorryAx, no Lean.ofReduceBool. The Line structure's `nonzero` field is constructive data (a witnessed direction), not an assumption.",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 17
   },
   "overview": {
@@ -102,9 +103,9 @@
       "Finset"
     ],
     "namespace": "Erdos1090",
-    "lineCount": 487,
+    "lineCount": 513,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 17,
     "path": "Proofs/Erdos1090Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The Erdős #1090 entry (monochromatic collinear points) defines `ramseyNumber k` as the minimum size of a configuration with the Ramsey property for `k`. This PR adds the two **structural monotonicities** that make that notion well-behaved:

| Lemma | Statement |
|---|---|
| `hasRamseyProperty_mono` | `A ⊆ B → HasRamseyProperty A k → HasRamseyProperty B k` |
| `hasRamseyProperty_antitone` | `k' ≤ k → HasRamseyProperty A k → HasRamseyProperty A k'` |

- **Superset (upward-closed):** for any 2-coloring, a monochromatic `k`-collinear subset of `A` is *a fortiori* a subset of `B` (`⊆`-transitivity).
- **Downward in `k`:** the same monochromatic subset already has `≥ k ≥ k'` points on a common line (the collinearity witness in `IsKCollinear` is `k`-independent).

Together these are the basis for `ramseyNumber k` being a genuine threshold (every larger configuration containing a witness inherits the property) and complement the existing `hasRamseyProperty_card_ge` / `ramsey_lower_bound`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos1090Problem` → **Build succeeded** (Mathlib 4.26). **11 theorems, 0 sorries, 0 axioms** (status `verified` preserved).

`meta.json`: `theoremCount` 9→11, `lineCount` 487→513, new contribution entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)