### PR TITLE
Enrich p-series tail remainder bound: add missing index.ts + sections

### DIFF
--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/meta.json
@@ -62,6 +62,56 @@
       "Specialize at integer p to explicit rational error bounds for ζ(2), ζ(4), … and compare against the exact values π²/6, π⁴/90"
     ]
   },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Imports, statement, and namespace",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Import Mathlib; docstring framing the open question (quantitative remainder rate vs. the parent's single uniform bound 1/(p−1)); open the namespace and the BigOperators / Finset / intervalIntegral scopes.",
+      "mathContext": "Target: $\\sum_{n>N} 1/n^p \\le \\int_N^\\infty x^{-p}\\,dx = N^{1-p}/(p-1)$ for $p>1$, $N\\ge 1$."
+    },
+    {
+      "id": "tail-partial",
+      "title": "The tail partial-sum bound",
+      "startLine": 39,
+      "endLine": 94,
+      "summary": "pseries_tail_partial_le: every finite tail ∑_{i<m} 1/(N+1+i)ᵖ is bounded by N^{1−p}/(p−1) uniformly in m, via AntitoneOn.sum_le_integral on [N, N+m], integral_rpow, and dropping the nonneg far-endpoint term.",
+      "mathContext": "$\\sum_{i<m} \\frac{1}{(N+1+i)^p} \\le \\int_N^{N+m} x^{-p}\\,dx = \\frac{N^{1-p}-(N+m)^{1-p}}{p-1} \\le \\frac{N^{1-p}}{p-1}$."
+    },
+    {
+      "id": "tail-tsum",
+      "title": "The tail bound (passing to the limit)",
+      "startLine": 96,
+      "endLine": 105,
+      "summary": "pseries_tail_tsum_le: feed the uniform partial-sum bound to Real.tsum_le_of_sum_range_le to bound the full tail tsum.",
+      "mathContext": "$\\sum'_{i} \\frac{1}{(N+1+i)^p} \\le \\frac{N^{1-p}}{p-1}$."
+    },
+    {
+      "id": "remainder",
+      "title": "The genuine remainder bound",
+      "startLine": 107,
+      "endLine": 127,
+      "summary": "pseries_remainder_le: Summable.sum_add_tsum_nat_add identifies the shifted tail with the truncation error (∑'_n − ∑_{i≤N}); summability from Real.summable_one_div_nat_rpow.",
+      "mathContext": "$\\left(\\sum'_n \\tfrac{1}{n^p}\\right) - \\left(\\sum_{i\\le N}\\tfrac{1}{i^p}\\right) \\le \\frac{N^{1-p}}{p-1}$."
+    },
+    {
+      "id": "explicit",
+      "title": "The explicit 1/((p−1)·N^{p−1}) form",
+      "startLine": 129,
+      "endLine": 142,
+      "summary": "pseries_tail_explicit: rewrite N^{1−p}/(p−1) as 1/((p−1)·N^{p−1}) via Real.rpow_neg and field_simp, exhibiting the O(N^{1−p}) decay.",
+      "mathContext": "$\\frac{N^{1-p}}{p-1} = \\frac{1}{(p-1)\\,N^{p-1}}$."
+    },
+    {
+      "id": "witnesses",
+      "title": "Worked witnesses (Basel exponent)",
+      "startLine": 144,
+      "endLine": 161,
+      "summary": "Two examples specialize p = 2: the rate ∑_{n>N} 1/n² ≤ 1/N, and a concrete truncation-error statement for ∑ 1/n² at N = 10.",
+      "mathContext": "$p=2$: $\\sum_{n>N} \\tfrac{1}{n^2} \\le \\tfrac{1}{N}$."
+    }
+  ],
   "leanFile": {
     "namespace": "AntitoneIntegralSumComparisonOQ01OQ01OQ02",
     "lineCount": 161,


### PR DESCRIPTION
Enrichment pass for `antitone-integral-sum-comparison-oq-01-oq-01-oq-02` (passes: 0, quality: 85).

## Primary fix: missing `index.ts`
The entry had **no `index.ts`**, so Vite's `import.meta.glob` could not discover it — the page rendered **'proof not found'** despite appearing in the gallery listing. Added it via the standard template.

## Added `sections` (was entirely absent)
A 6-entry `sections` array now maps the full 161-line Lean file, each with a LaTeX `mathContext`:
| Section | Lines | Theorem |
|---------|-------|---------|
| setup | 1–37 | imports + framing + namespace |
| tail-partial | 39–94 | `pseries_tail_partial_le` |
| tail-tsum | 96–105 | `pseries_tail_tsum_le` |
| remainder | 107–127 | `pseries_remainder_le` |
| explicit | 129–142 | `pseries_tail_explicit` |
| witnesses | 144–161 | Basel-exponent examples |

## Left as-is
`overview` (historicalContext, proofStrategy, 5 keyInsights), `conclusion`, and all 4 annotations (with `mathContext`/`significance`/`relatedConcepts`) are already complete and accurate. No accretion — meta.json is 10.3 KB, well under caps.

Build validates with no errors for this entry. Axiom integrity unchanged: `status: verified`, 0 axioms, 0 sorries (matches `#print axioms`: only propext/Classical.choice/Quot.sound).