### PR TITLE
research(erdos-1020-oq-02): §8 — window sandwich for construction2 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1020OQ02.lean
+++ b/proofs/Proofs/Erdos1020OQ02.lean
@@ -281,4 +281,69 @@ theorem construction2_sum_card (n k : ℕ) (hk : k ≥ 1) (hn : n ≥ k) :
   rw [Nat.card_Ico]
   omega
 
+/-! ### 8. Window sandwich: `construction2` between `k − 1` copies of its endpoint summands.
+
+The §7 closed form writes `construction2 n r k` as a sum of exactly `k − 1`
+binomials `C(j, r−1)` with `j` ranging over the window `[n−k+1, n)`
+(`construction2_eq_sum`, `construction2_sum_card`). Because `C(·, r−1)` is monotone
+in its first argument, every summand lies between the two window endpoints
+`C(n−k+1, r−1)` (smallest) and `C(n−1, r−1)` (largest). Summing the `k − 1` terms
+gives a clean two-sided bound,
+
+  `(k−1)·C(n−k+1, r−1) ≤ construction2 n r k ≤ (k−1)·C(n−1, r−1)`,
+
+which sandwiches the difference-of-binomials between equal-width multiples of its
+endpoint binomials. For `k ≥ 2` the window is nonempty, so the top summand alone
+already gives `C(n−1, r−1) ≤ construction2 n r k` — the degree-`(r−1)` polynomial
+growth in `n` that eventually drives `construction2` past the constant
+`construction1` and produces the large-`n` regime. -/
+
+/-- Lower half of the window sandwich: every summand is at least the smallest
+    endpoint `C(n−k+1, r−1)`, and there are `k − 1` of them. -/
+theorem construction2_window_lb (n r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 1) (hn : n ≥ k) :
+    (k - 1) * Nat.choose (n - k + 1) (r - 1) ≤ construction2 n r k := by
+  rw [construction2_eq_sum n r k hr hk hn]
+  have hcard : (Finset.Ico (n - k + 1) n).card = k - 1 := construction2_sum_card n k hk hn
+  have hmin : ∀ j ∈ Finset.Ico (n - k + 1) n,
+      Nat.choose (n - k + 1) (r - 1) ≤ Nat.choose j (r - 1) := by
+    intro j hj
+    rw [Finset.mem_Ico] at hj
+    exact Nat.choose_le_choose (r - 1) hj.1
+  have h := Finset.card_nsmul_le_sum _ _ _ hmin
+  rw [hcard] at h
+  simpa using h
+
+/-- Upper half of the window sandwich: every summand is at most the largest
+    endpoint `C(n−1, r−1)`, and there are `k − 1` of them. -/
+theorem construction2_window_ub (n r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 1) (hn : n ≥ k) :
+    construction2 n r k ≤ (k - 1) * Nat.choose (n - 1) (r - 1) := by
+  rw [construction2_eq_sum n r k hr hk hn]
+  have hcard : (Finset.Ico (n - k + 1) n).card = k - 1 := construction2_sum_card n k hk hn
+  have hmax : ∀ j ∈ Finset.Ico (n - k + 1) n,
+      Nat.choose j (r - 1) ≤ Nat.choose (n - 1) (r - 1) := by
+    intro j hj
+    rw [Finset.mem_Ico] at hj
+    exact Nat.choose_le_choose (r - 1) (by omega)
+  have h := Finset.sum_le_card_nsmul _ _ _ hmax
+  rw [hcard] at h
+  simpa using h
+
+/-- For `k ≥ 2` the window `[n−k+1, n)` contains its top point `n − 1`, so the
+    largest summand `C(n−1, r−1)` alone is a lower bound for `construction2`.
+    This is the degree-`(r−1)` growth driving the large-`n` regime: a single
+    binomial of full degree already sits below the conjectured extremal value. -/
+theorem construction2_ge_top_summand (n r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 2) (hn : n ≥ k) :
+    Nat.choose (n - 1) (r - 1) ≤ construction2 n r k := by
+  rw [construction2_eq_sum n r k hr (by omega) hn]
+  refine Finset.single_le_sum (f := fun j => Nat.choose j (r - 1)) (fun i _ => Nat.zero_le _) ?_
+  rw [Finset.mem_Ico]; omega
+
+/-- Worked instance `r = 4, k = 2`: the window has a single point (`k − 1 = 1`),
+    so the sandwich is tight — both bounds equal `C(n−1, 3) = construction2 n 4 2`.
+    At `n = 8` this is `C(7, 3) = 35`, the crossover value `construction1 4 2`. -/
+example : construction2 8 4 2 = Nat.choose 7 3 := by decide
+
+/-- The top-summand bound, concretely at the crossover: `C(7, 3) = 35 ≤ construction2 8 4 2`. -/
+example : Nat.choose 7 3 ≤ construction2 8 4 2 := by decide
+
 end Erdos1020OQ02

--- a/src/data/research/problems/erdos-1020-oq-02.json
+++ b/src/data/research/problems/erdos-1020-oq-02.json
@@ -29,11 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "VERIFIED (0-axiom). Created gallery entry erdos-1020-oq-02 + Proofs/Erdos1020OQ02.lean. Did NOT resolve the open gap (Erdős Matching Conjecture, OPEN r≥4); instead formalized the unconditional structure of the small-n/large-n regime transition of the conjectured value max(construction1, construction2): construction2 monotone in n (Pascal telescoping), dominance region upward-closed (single threshold), conjecturedValue monotone, collapse on each side. Worked instance r=4,k=2 crossover at n=8 by kernel decide. [Session 2] Added 3 verified theorems sharpening the transition: construction2_step_eq (EXACT step difference = C(n,r-1)-C(n-k+1,r-1), the equality behind the old inequality), construction2_strict_mono_step (strict refinement), and crossover_r4k2 — the SHARP crossover threshold for r=4,k=2: construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n (n₀=8). All 0-axiom (decide, not native_decide). File now 232 lines, 9 theorems.",
+    "progressSummary": "VERIFIED (0-axiom). §8 window sandwich: construction2 n r k between (k−1) copies of its endpoint binomial summands — (k−1)·C(n−k+1,r−1) ≤ construction2 ≤ (k−1)·C(n−1,r−1) — plus construction2_ge_top_summand (k≥2 ⟹ C(n−1,r−1) ≤ construction2, the degree-(r−1) growth driving the large-n regime). Builds on §7 closed form. Still OPEN: the Erdős Matching Conjecture middle band (r≥4).",
     "builtItems": [
       "Proofs/Erdos1020OQ02.lean (165 lines, 0 axioms, 0 sorries, verified): construction2_mono_step, construction2_mono, construction2_dominant_up, conjecturedValue_mono, conjecturedValue_large, conjecturedValue_small + 5 kernel-decide crossover examples.",
       "Gallery entry src/data/proofs/erdos-1020-oq-02/ (meta.json + annotations.json).",
-      "Proofs/Erdos1020OQ02.lean extended to 232 lines / 9 theorems (was 165/6): construction2_step_eq, construction2_strict_mono_step, crossover_r4k2 (exact threshold iff for r=4,k=2)."
+      "Proofs/Erdos1020OQ02.lean extended to 232 lines / 9 theorems (was 165/6): construction2_step_eq, construction2_strict_mono_step, crossover_r4k2 (exact threshold iff for r=4,k=2).",
+      "construction2_window_lb (Erdos1020OQ02.lean §8): (k−1)·C(n−k+1,r−1) ≤ construction2 n r k — Finset.card_nsmul_le_sum on the §7 sum, smallest endpoint summand",
+      "construction2_window_ub (§8): construction2 n r k ≤ (k−1)·C(n−1,r−1) — Finset.sum_le_card_nsmul, largest endpoint summand",
+      "construction2_ge_top_summand (§8): k≥2 ⟹ C(n−1,r−1) ≤ construction2 n r k — top window point n−1 via Finset.single_le_sum; degree-(r−1) growth lower bound"
     ],
     "insights": [
       "construction1 r k = C(rk-1,r) is constant in n; construction2 n r k = C(n,r)-C(n-k+1,r) is monotone nondecreasing in n. The gap is the band around their crossover.",
@@ -41,7 +44,8 @@
       "Monotonicity ⇒ the construction2-dominant region is upward-closed: a SINGLE threshold separates small-n and large-n regimes (no interleaving).",
       "conjecturedValue = max(const, monotone) is monotone in n; collapses to construction1 below threshold, construction2 at/above (max_eq_left/right).",
       "OQ-02 framed: regime boundary is a well-defined single threshold; the open difficulty is whether f attains the conjectured value across the gap band kr+... < n < 3kr² for r≥4.",
-      "The crossover threshold IS characterizable exactly in a worked instance: monotonicity converts two boundary evaluations into a complete iff (construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n), giving n₀(4,2)=8 — partial progress on the 'characterize exact threshold' next step."
+      "The crossover threshold IS characterizable exactly in a worked instance: monotonicity converts two boundary evaluations into a complete iff (construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n), giving n₀(4,2)=8 — partial progress on the 'characterize exact threshold' next step.",
+      "§8: the §7 closed form construction2 = Σ_{j∈[n−k+1,n)} C(j,r−1) has k−1 monotone summands, so it is sandwiched between (k−1)·C(n−k+1,r−1) and (k−1)·C(n−1,r−1). For k≥2 the top summand C(n−1,r−1) alone lower-bounds it — a single binomial of full degree r−1 already sits below the conjectured extremal value, exposing the polynomial growth behind the large-n regime."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## §8: Window sandwich for `construction2`

Continues the §7 closed form
`construction2 n r k = Σ_{j ∈ [n−k+1, n)} C(j, r−1)` (a sum of exactly `k − 1` binomial summands, by `construction2_eq_sum` / `construction2_sum_card`). Since `C(·, r−1)` is monotone in its first argument, every summand lies between the two window endpoints, giving a clean two-sided bound.

### Results (all 0-axiom, docker-verified)

- **`construction2_window_lb`** — `(k−1)·C(n−k+1, r−1) ≤ construction2 n r k` (smallest endpoint summand × window size, via `Finset.card_nsmul_le_sum`).
- **`construction2_window_ub`** — `construction2 n r k ≤ (k−1)·C(n−1, r−1)` (largest endpoint summand × window size, via `Finset.sum_le_card_nsmul`).
- **`construction2_ge_top_summand`** — for `k ≥ 2`, `C(n−1, r−1) ≤ construction2 n r k` (the top window point `n−1` is present; `Finset.single_le_sum`).

### Significance
The top-summand bound exposes the **degree-`(r−1)` polynomial growth in `n`**: a single binomial of full degree already sits below the conjectured extremal value, which is precisely what drives `construction2` past the constant `construction1` into the large-`n` regime. At the worked instance `r = 4, k = 2` the window is a single point, so the sandwich is tight: `construction2 8 4 2 = C(7,3) = 35 = construction1 4 2`.

This is a structural increment on the §1–§7 regime-transition analysis; it does **not** resolve the open Erdős Matching Conjecture (still open for `r ≥ 4` in the middle band).

### Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos1020OQ02` → ✔ [7743/7743]
- 0 sorries, 0 `axiom` declarations, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)