### PR TITLE
Enrich partition of unity (finite cover): add index.ts + setup section

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/index.ts
+++ b/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CompactnessFiniteSubcoverOq02Oq02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const compactnessFiniteSubcoverOq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const compactnessFiniteSubcoverOq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const compactnessFiniteSubcoverOq02Oq02Data: ProofData = {
+  proof: compactnessFiniteSubcoverOq02Oq02Proof,
+  annotations: compactnessFiniteSubcoverOq02Oq02Annotations,
+}

--- a/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/meta.json
@@ -91,6 +91,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Imports, statement, and construction overview",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Import Mathlib; docstring laying out the goal (a continuous partition of unity ψ_i subordinate to a finite open cover), the distance-to-complement bump construction, and why compactness is not needed once the cover is finite. Open Set/Metric, BigOperators/Classical; declare the MetricSpace X and Fintype ι variables.",
+      "mathContext": "For a finite open cover $U:\\iota\\to\\mathrm{Set}\\,X$ with $\\bigcup_i U_i = X$: build $\\psi_i$ continuous, $\\psi_i \\ge 0$, $\\psi_i(x)\\ne 0 \\Rightarrow x\\in U_i$, $\\sum_i \\psi_i(x) = 1$."
+    },
+    {
       "id": "bump-construction",
       "title": "The Distance-to-Complement Bump",
       "startLine": 61,


### PR DESCRIPTION
Enrichment pass for `compactness-finite-subcover-oq-02-oq-02` (passes: 0, quality: 85).

## Primary fix: missing `index.ts`
The entry had **no `index.ts`**, so Vite's `import.meta.glob` could not discover it — the page rendered **'proof not found'** despite appearing in the gallery. Added via the standard template.

## Section coverage completed
The existing `sections` started at line 61, leaving the first 60 lines (imports, docstring, opens, variable declarations) unmapped. Added a `setup` section (1–60) with a LaTeX `mathContext` stating the partition-of-unity goal, so sections now cover the full 203-line file: setup 1–60, bump-construction 61–103, normalization 105–139, finite-cover-headline 141–156, compact-corollary 158–203.

## Left as-is
`overview`, `conclusion`, and all 3 annotations (already with `mathContext`/`significance`/`relatedConcepts`) are complete. meta.json is 16 KB, under caps — no accretion.

JSON validates. Axiom integrity unchanged: `status: verified`, 0 axioms, 0 sorries.