### PR TITLE
Enrich Erdős #191 triple-log divergence: complete section coverage

### DIFF
--- a/src/data/proofs/erdos-191-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-191-incomplete-01/meta.json
@@ -55,12 +55,28 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Imports, motivation, and namespace",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Import Mathlib; docstring explaining that the parent erdos-191 entry carries tripleLog_unbounded as one of four axioms, that this fact is elementary (not deep), and that this file retires it by proving log(log(log n)) → ∞ axiom-free. Open Filter/Real, declare the namespace.",
+      "mathContext": "Goal: eliminate the parents axiom $\\texttt{tripleLog\\_unbounded}: \\forall M,\\exists N,\\forall n\\ge N,\\ \\log\\log\\log n > M$ by proving it."
+    },
+    {
+      "id": "definition",
+      "title": "The tripleLog scale",
+      "startLine": 37,
+      "endLine": 39,
+      "summary": "tripleLog n := log(log(log n)), the natural scale of Erdős #191, restated to match the parent definition.",
+      "mathContext": "$\\mathrm{tripleLog}(n) = \\log(\\log(\\log n))$."
+    },
+    {
       "id": "divergence",
       "title": "Triple-log divergence and the ε–N form",
-      "startLine": 39,
+      "startLine": 41,
       "endLine": 62,
-      "summary": "tripleLog n := log(log(log n)). tripleLog_tendsto_atTop: Tendsto (fun n => tripleLog n) atTop atTop, via Real.tendsto_log_atTop composed three times over tendsto_natCast_atTop_atTop. tripleLog_unbounded: the ∀ M ∃ N ∀ n ≥ N form, matching the parent's axiom.",
-      "mathContext": "$\\log\\log\\log n \\to \\infty$, hence $\\forall M\\, \\exists N\\, \\forall n \\geq N,\\ \\log\\log\\log n > M$."
+      "summary": "tripleLog_tendsto_atTop: the cast ℕ→ℝ tends to atTop and Real.log preserves atTop, so the threefold composition tends to atTop. tripleLog_unbounded then re-expresses Tendsto … atTop as the ∀M ∃N ∀n≥N, tripleLog n > M form matching the parents axiom.",
+      "mathContext": "$\\log\\log\\log n \\to \\infty$, hence $\\forall M,\\exists N,\\forall n\\ge N,\\ \\mathrm{tripleLog}(n) > M$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-191-incomplete-01` (passes: 0, quality: 85).

## Gap addressed: incomplete `sections`
`sections` had a single entry (`divergence` 39–62), leaving the imports, motivation docstring, and the `tripleLog` definition unmapped. Restructured into 3 sections covering the full 62-line file, each with a LaTeX `mathContext`:

| Section | Lines | Content |
|---------|-------|---------|
| setup | 1–35 | imports + motivation (retiring the parent's axiom) + namespace |
| definition | 37–39 | `tripleLog n := log(log(log n))` |
| divergence | 41–62 | `tripleLog_tendsto_atTop` + `tripleLog_unbounded` (ε–N form) |

## Axiom integrity
This file's purpose is to **prove**, axiom-free, the elementary fact `log(log(log n)) → ∞` that the parent `erdos-191` entry carries as the `tripleLog_unbounded` axiom. Confirmed: 0 `axiom` declarations, 0 sorries, no structure-encoded assumptions — `status: verified` / `axiomCount: 0` is accurate.

## Left as-is
`index.ts`, `overview`, `conclusion`, and all 4 annotations (with `mathContext`/`significance`/`relatedConcepts`) are already complete. meta.json is 8 KB, well under caps.