### PR TITLE
Enrich Erdős #396 sharp Catalan asymptotic: add index.ts + sections

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01Data: ProofData = {
+  proof: erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01Proof,
+  annotations: erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01Annotations,
+}

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -76,5 +76,63 @@
       "description": "Root problem. The Catalan numbers Cₙ = C(2n,n)/(n+1) are a central object whose exact growth rate 4ⁿ/(√π·n^{3/2}) is established here."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Statement, method, imports",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Docstring fusing the two #396 sub-threads — the exponent thread (Cₙ/4ⁿ ∼ n^{−3/2}) and the constant thread (C(2n,n)·√n/4ⁿ → 1/√π) — into the single sharp Catalan asymptotic; outlines the square-root-free Stirling bridge method. Import Mathlib; open Nat/Filter/Topology/Finset/Real/Stirling; namespace.",
+      "mathContext": "Target: $C_n \\sim \\dfrac{4^n}{\\sqrt\\pi\\, n^{3/2}}$, fusing exponent $3/2$ and constant $1/\\sqrt\\pi$."
+    },
+    {
+      "id": "factorial-identity",
+      "title": "The factorial identity (2n)! = C(2n,n)·(n!)²",
+      "startLine": 51,
+      "endLine": 61,
+      "summary": "two_mul_factorial_eq: casts Nat.choose_mul_factorial_mul_factorial to ℝ as (2n)! = C(2n,n)·(n!)², the algebraic seed of the bridge.",
+      "mathContext": "$(2n)! = \\binom{2n}{n}\\,(n!)^2$."
+    },
+    {
+      "id": "bridge",
+      "title": "The square-root-free bridge identity",
+      "startLine": 63,
+      "endLine": 97,
+      "summary": "cb_sq_identity: for n ≥ 1, C(2n,n)²·n/16ⁿ = stirlingSeq(2n)²/stirlingSeq(n)⁴. Squaring removes all square roots; proved by expanding both Stirling sequences and field_simp.",
+      "mathContext": "$\\dfrac{\\binom{2n}{n}^2 n}{16^n} = \\dfrac{\\mathrm{stirlingSeq}(2n)^2}{\\mathrm{stirlingSeq}(n)^4}$."
+    },
+    {
+      "id": "central-binomial",
+      "title": "The central-binomial Wallis limit (engine)",
+      "startLine": 99,
+      "endLine": 131,
+      "summary": "centralBinom_mul_sqrt_div_tendsto: C(2n,n)·√n/4ⁿ → 1/√π. The squared sequence tends to π/π² = 1/π via tendsto_stirlingSeq_sqrt_pi and the bridge; a final square root transports to 1/√π.",
+      "mathContext": "$\\binom{2n}{n}\\dfrac{\\sqrt n}{4^n} \\to \\dfrac{1}{\\sqrt\\pi}$."
+    },
+    {
+      "id": "weight",
+      "title": "The Catalan weight n/(n+1) → 1",
+      "startLine": 133,
+      "endLine": 144,
+      "summary": "div_succ_tendsto_one: n/(n+1) → 1, written as 1 − 1/(n+1) → 1 − 0; the factor relating Cₙ to C(2n,n).",
+      "mathContext": "$\\dfrac{n}{n+1} \\to 1$."
+    },
+    {
+      "id": "catalan-asymptotic",
+      "title": "The sharp Catalan asymptotic",
+      "startLine": 146,
+      "endLine": 166,
+      "summary": "catalan_mul_pow_sqrt_div_tendsto: Cₙ·(n·√n)/4ⁿ → 1/√π via the identity (n+1)·Cₙ = C(2n,n) and Tendsto.mul with n/(n+1)→1. The extra factor n over √n carries the 1/2 ↦ 3/2 exponent jump.",
+      "mathContext": "$C_n\\dfrac{n\\sqrt n}{4^n} \\to \\dfrac{1}{\\sqrt\\pi}$, i.e. $C_n \\sim \\dfrac{4^n}{\\sqrt\\pi\\,n^{3/2}}$."
+    },
+    {
+      "id": "consequences",
+      "title": "Equivalent normalisations and constant identity",
+      "startLine": 168,
+      "endLine": 192,
+      "summary": "catalan_mul_sqrt_pi_div_tendsto_one (Cₙ·√π·n√n/4ⁿ → 1) and catalan_constant_eq_centralBinom_constant (the Catalan and central-binomial limits share the constant 1/√π; only the exponent shifts).",
+      "mathContext": "$C_n\\dfrac{\\sqrt\\pi\\,n\\sqrt n}{4^n} \\to 1$; same constant $1/\\sqrt\\pi$ as the central binomial."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01-oq-01` (passes: 0, quality: 85).

## Primary fix: missing `index.ts`
The entry had **no `index.ts`**, so Vite's `import.meta.glob` could not discover it — the page rendered **'proof not found'**. Added via the standard template.

## Added `sections` (was no key)
A 7-entry `sections` array now maps the full 192-line Lean file, each with a LaTeX `mathContext`:

| Section | Lines | Theorem |
|---------|-------|---------|
| setup | 1–50 | docstring + method + imports |
| factorial-identity | 51–61 | `two_mul_factorial_eq` |
| bridge | 63–97 | `cb_sq_identity` (√-free) |
| central-binomial | 99–131 | `centralBinom_mul_sqrt_div_tendsto` (→ 1/√π) |
| weight | 133–144 | `div_succ_tendsto_one` |
| catalan-asymptotic | 146–166 | `catalan_mul_pow_sqrt_div_tendsto` |
| consequences | 168–192 | normalisation + constant-identity |

## Left as-is
`overview`, `conclusion`, and all 4 annotations (with `mathContext`/`significance`/`relatedConcepts`) are complete. meta.json is 15.8 KB, under caps — no accretion.

JSON validates. Axiom integrity unchanged: `status: verified`, 0 axioms, 0 sorries (reproved self-contained via Mathlib's `stirlingSeq`; no hand-rolled Stirling estimate).