### PR TITLE
Research: erdos-1002-oq-04 — single fixed Liouville number with unbounded inner sum [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1002OQ04.lean
+++ b/proofs/Proofs/Erdos1002OQ04.lean
@@ -236,4 +236,125 @@ theorem innerSum_unbounded (M : ℝ) :
   obtain ⟨α, hirr, hpos, n, hn⟩ := innerSum_unbounded_near_rational 0 1 (le_refl 1) (by decide) M
   exact ⟨α, hirr, by simpa using hpos, n, hn⟩
 
+/-! ## A single fixed Liouville number with unbounded inner sum (capstone)
+
+The statements above are of the form "for every height `M` there is *some*
+irrational `α` with `S(α, n) > M`".  That leaves open whether the unboundedness
+can be realised by one *fixed* number, or only by a family that drifts with `M`.
+The capstone closes this gap: the concrete Liouville constant
+`L = Σ_{i} 1/2^{i!}` (Mathlib's `liouvilleNumber 2`) has `S(L, ·)` unbounded.
+
+The mechanism is exactly the perturbation lemma run along `L`'s own convergents.
+The `k`-th partial sum is a dyadic rational `P_k / 2^{k!}` (`partialSum_eq_rat`)
+lying strictly *below* `L` (`partialSum_add_remainder` + `remainder_pos`, the
+one-sidedness `L > P_k/2^{k!}`), and the tail is super-small:
+`L − P_k/2^{k!} = remainder 2 k < 1/(2^{k!})^k` (`remainder_lt`).  Writing the
+convergent in lowest terms `p'/q'` (so `q' ≤ 2^{k!}`) and taking `N = 2^{k!}`,
+the perturbation budget is met for every `k ≥ 5`:
+
+    (L − p'/q')·(N q')² < (1/(2^{k!})^k)·(2^{k!})⁴ = (2^{k!})^{4−k} ≤ 1,
+
+so `innerSum_perturb` pins `S(L, N q') > N/2 − 1 = 2^{k!}/2 − 1`, which tends to
+`∞` with `k`.  Because the same fixed `L` works for every `k`, its inner sum is
+unbounded — the family in `innerSum_unbounded` can be collapsed to one number. -/
+
+open LiouvilleNumber in
+/-- **Per-`k` spike along the convergents of `L = liouvilleNumber 2`.**  For every
+`k ≥ 5` there is an `n` with `S(L, n) > 2^{k!}/2 − 1`.  Feeding the reduced
+convergent `p'/q'` of `L` (denominator `≤ 2^{k!}`) and height parameter
+`N = 2^{k!}` into `innerSum_perturb`. -/
+private theorem liouville_spike (k : ℕ) (hk : 5 ≤ k) :
+    ∃ n : ℕ, (2 : ℝ) ^ k.factorial / 2 - 1 < innerSum (liouvilleNumber ((2 : ℕ) : ℝ)) n := by
+  set c : ℝ := ((2 : ℕ) : ℝ) with hc
+  set α : ℝ := liouvilleNumber c with hα
+  have hm1 : (1 : ℝ) < c := by rw [hc]; norm_num
+  have hm2 : (2 : ℝ) ≤ c := by rw [hc]; norm_num
+  -- the convergent `partialSum c k = P / 2^{k!}`.
+  obtain ⟨P, hP⟩ := partialSum_eq_rat (show (0 : ℕ) < 2 by norm_num) k
+  set Q : ℕ := 2 ^ k.factorial with hQdef
+  have hQpos : 0 < Q := by rw [hQdef]; positivity
+  -- reduce `P/Q` to lowest terms `p'/q'`.
+  set g : ℕ := Nat.gcd P Q with hgdef
+  have hg : 0 < g := Nat.gcd_pos_of_pos_right P hQpos
+  have hg0 : (g : ℝ) ≠ 0 := by exact_mod_cast hg.ne'
+  have hQ0 : (Q : ℝ) ≠ 0 := by exact_mod_cast hQpos.ne'
+  set p' : ℕ := P / g with hp'def
+  set q' : ℕ := Q / g with hq'def
+  have hgP : g ∣ P := Nat.gcd_dvd_left P Q
+  have hgQ : g ∣ Q := Nat.gcd_dvd_right P Q
+  have hcop : Nat.gcd p' q' = 1 := Nat.coprime_div_gcd_div_gcd hg
+  have hqle : q' ≤ Q := Nat.div_le_self Q g
+  have hq'pos : 0 < q' := by
+    rw [hq'def]; exact Nat.div_pos (Nat.le_of_dvd hQpos hgQ) hg
+  -- `p'/q' = P/Q` as reals.
+  have hpq : (p' : ℝ) / (q' : ℝ) = (P : ℝ) / (Q : ℝ) := by
+    rw [hp'def, hq'def, Nat.cast_div hgP hg0, Nat.cast_div hgQ hg0]
+    field_simp
+  -- so the convergent equals `p'/q'`.
+  have hps : partialSum c k = (p' : ℝ) / (q' : ℝ) := by rw [hP, ← hpq]
+  -- one-sidedness and the exact gap `= remainder`.
+  have hsum := partialSum_add_remainder hm1 k
+  have hrempos := remainder_pos hm1 k
+  have hlo : (p' : ℝ) / (q' : ℝ) < α := by rw [← hps, hα]; linarith
+  have hαeq : α - (p' : ℝ) / (q' : ℝ) = remainder c k := by
+    rw [← hps, hα, ← hsum]; ring
+  -- `(c^{k!}) = Q` as reals.
+  have hQc : c ^ k.factorial = (Q : ℝ) := by rw [hc, hQdef]; push_cast; ring
+  -- the perturbation budget `hhi`.
+  have hhi : (α - (p' : ℝ) / (q' : ℝ)) * (((Q * q' : ℕ) : ℝ)) ^ 2 < 1 := by
+    rw [hαeq]
+    have hRlt : remainder c k < 1 / (Q : ℝ) ^ k := by
+      have h := remainder_lt k hm2
+      rwa [hQc] at h
+    have hRpos : (0 : ℝ) ≤ remainder c k := hrempos.le
+    have hX0 : (0 : ℝ) ≤ ((Q * q' : ℕ) : ℝ) := by positivity
+    have hXle : ((Q * q' : ℕ) : ℝ) ≤ (Q : ℝ) ^ 2 := by
+      have hnat : Q * q' ≤ Q * Q := Nat.mul_le_mul_left Q hqle
+      calc ((Q * q' : ℕ) : ℝ) ≤ ((Q * Q : ℕ) : ℝ) := by exact_mod_cast hnat
+        _ = (Q : ℝ) ^ 2 := by push_cast; ring
+    have hX2 : ((Q * q' : ℕ) : ℝ) ^ 2 ≤ (Q : ℝ) ^ 4 := by
+      calc ((Q * q' : ℕ) : ℝ) ^ 2 ≤ ((Q : ℝ) ^ 2) ^ 2 := by gcongr
+        _ = (Q : ℝ) ^ 4 := by ring
+    have hQ1 : (1 : ℝ) ≤ (Q : ℝ) := by exact_mod_cast hQpos
+    have hQkpos : (0 : ℝ) < (Q : ℝ) ^ k := by positivity
+    have hQk : (Q : ℝ) ^ 4 ≤ (Q : ℝ) ^ k := pow_le_pow_right₀ hQ1 (by omega)
+    calc remainder c k * ((Q * q' : ℕ) : ℝ) ^ 2
+        ≤ remainder c k * (Q : ℝ) ^ 4 := by
+          exact mul_le_mul_of_nonneg_left hX2 hRpos
+      _ < (1 / (Q : ℝ) ^ k) * (Q : ℝ) ^ 4 :=
+          mul_lt_mul_of_pos_right hRlt (by positivity)
+      _ = (Q : ℝ) ^ 4 / (Q : ℝ) ^ k := by ring
+      _ ≤ 1 := by rw [div_le_one hQkpos]; exact hQk
+  -- apply the perturbation lemma at `N = Q`.
+  obtain ⟨hlow, _⟩ := innerSum_perturb p' q' Q hq'pos hcop hQpos α hlo hhi
+  refine ⟨Q * q', ?_⟩
+  have : (Q : ℝ) = (2 : ℝ) ^ k.factorial := by rw [hQdef]; push_cast; ring
+  rw [this] at hlow
+  exact hlow
+
+/-- **Capstone: a single fixed Liouville number has unbounded inner sum.**  The
+Liouville constant `L = Σ_i 1/2^{i!}` is irrational and satisfies: for every
+height `M` there is an `n` with `S(L, n) > M`.  This strengthens
+`innerSum_unbounded` from "for every `M` there is *some* irrational" to "there is
+*one* irrational that works for every `M`" — the inner sum is unbounded as a
+function of `n` for this fixed `L`.  This is the natural capstone of the Liouville
+side of Erdős #1002: super-approximation by a single number forces the spikes. -/
+theorem innerSum_unbounded_single :
+    ∃ α : ℝ, Irrational α ∧ ∀ M : ℝ, ∃ n : ℕ, M < innerSum α n := by
+  refine ⟨liouvilleNumber ((2 : ℕ) : ℝ), (liouville_liouvilleNumber (le_refl (2 : ℕ))).irrational,
+    fun M => ?_⟩
+  -- pick `k ≥ 5` with `M < 2^{k!}/2 − 1`.
+  obtain ⟨t, ht⟩ := exists_nat_gt (2 * (M + 1))
+  set k : ℕ := max 5 t with hkdef
+  have hk5 : 5 ≤ k := le_max_left _ _
+  have htk : t ≤ k := le_max_right _ _
+  have hheight : M < (2 : ℝ) ^ k.factorial / 2 - 1 := by
+    have h1 : (t : ℝ) ≤ (k.factorial : ℝ) := by
+      exact_mod_cast htk.trans (Nat.self_le_factorial k)
+    have h2 : (k.factorial : ℝ) < (2 : ℝ) ^ k.factorial := by
+      exact_mod_cast Nat.lt_two_pow_self
+    nlinarith [ht, h1, h2]
+  obtain ⟨n, hn⟩ := liouville_spike k hk5
+  exact ⟨n, lt_trans hheight hn⟩
+
 end Erdos1002OQ04

--- a/src/data/proofs/erdos-1002-oq-04/meta.json
+++ b/src/data/proofs/erdos-1002-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1002-oq-04",
   "title": "Erdős #1002 OQ-04: The Liouville Side — A Sharp Perturbation Lemma Forcing Unbounded Inner Sums",
   "slug": "erdos-1002-oq-04",
-  "description": "Resolves the Liouville (super-approximable) end of how the Erdős #1002 inner sum S(α,n) = Σ_{k=1}^n (1/2 − {αk}) depends on the arithmetic of α. A sharp perturbation lemma shows that when α sits just above a reduced fraction p/q, closer than 1/(Nq)², the integer parts ⌊αk⌋ = ⌊(p/q)k⌋ agree for all k ≤ Nq, so S(α, Nq) is pinned to the rational value N/2 (from OQ-03) within error 1: N/2 − 1 < S(α, Nq) < N/2. Because every rational admits arbitrarily good one-sided irrational approximations, this forces, near every rational and for every height M, an irrational α with S(α,n) > M — the inner sum is unbounded over the irrationals, in sharp contrast to the O(log n) boundedness for quadratic irrationals. Fully verified, no axioms.",
+  "description": "Resolves the Liouville (super-approximable) end of how the Erdős #1002 inner sum S(α,n) = Σ_{k=1}^n (1/2 − {αk}) depends on the arithmetic of α. A sharp perturbation lemma shows that when α sits just above a reduced fraction p/q, closer than 1/(Nq)², the integer parts ⌊αk⌋ = ⌊(p/q)k⌋ agree for all k ≤ Nq, so S(α, Nq) is pinned to the rational value N/2 (from OQ-03) within error 1: N/2 − 1 < S(α, Nq) < N/2. Because every rational admits arbitrarily good one-sided irrational approximations, this forces, near every rational and for every height M, an irrational α with S(α,n) > M — the inner sum is unbounded over the irrationals, in sharp contrast to the O(log n) boundedness for quadratic irrationals. Fully verified, no axioms. The capstone innerSum_unbounded_single upgrades this to a SINGLE fixed Liouville number L = Σ_i 1/2^{i!}: running the perturbation lemma along L's own convergents proves S(L, ·) is unbounded, so one explicit super-approximable number realises the spikes. Fully verified, no axioms.",
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1002",
@@ -30,15 +30,15 @@
       "erdos-1002-oq-01"
     ],
     "axiomCount": 0,
-    "lineCount": 239,
-    "assumptions": "No axioms. Both main theorems (innerSum_perturb and innerSum_unbounded_near_rational) depend only on Lean's standard foundational axioms (propext, Classical.choice, Quot.sound); #print axioms reports no sorryAx and no Lean.ofReduceBool. No native_decide is used. The parent Erdős #1002 (the limiting distribution of S(α,n)/log n for generic irrational α) remains open; this file resolves only the Liouville/unboundedness side, a complete, axiom-free theorem. The complementary quadratic-irrational boundedness S(α,n) = O(log n) is surveyed, not formalized here.",
-    "theoremCount": 6,
+    "lineCount": 360,
+    "assumptions": "No axioms. All three headline theorems (innerSum_perturb, innerSum_unbounded_near_rational, and the new capstone innerSum_unbounded_single) depend only on Lean's standard foundational axioms (propext, Classical.choice, Quot.sound); #print axioms reports no sorryAx and no Lean.ofReduceBool, and no native_decide is used. The capstone reuses Mathlib's axiom-free Liouville machinery (liouvilleNumber, partialSum_eq_rat, remainder_lt, liouville_liouvilleNumber). The parent Erdős #1002 (the limiting distribution of S(α,n)/log n for generic irrational α) remains open; this file resolves the Liouville/unboundedness side completely and axiom-free, now for a single explicit number. The complementary quadratic-irrational boundedness S(α,n) = O(log n) is surveyed, not formalized here.",
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
     "historicalContext": "Erdős Problem #1002 concerns the limiting distribution of the inner sum S(α, n) = Σ_{k=1}^n (1/2 − {αk}), where {·} is the fractional part. The behaviour of S(α, n) depends sharply on the arithmetic of α — concretely, on its continued-fraction expansion. Kesten (1960), resolving a conjecture of Erdős and Szüsz, proved that under a suitable normalization S(α, n)/log n converges in distribution to a Cauchy law for almost every irrational α. The two extreme ends of the spectrum are well understood heuristically: for quadratic irrationals (eventually periodic continued fractions with bounded partial quotients) the sum stays bounded, S(α, n) = O(log n), while for Liouville-type numbers — those with super-fast rational approximation — it can be unbounded.\n\nThe sibling entry OQ-03 resolved the rational end completely: for a reduced fraction α = p/q the sum over one period is the universal constant 1/2, so S(p/q, n·q) = n/2 grows exactly linearly. This OQ-04 entry resolves the opposite, Liouville end. The mechanism is a sharp perturbation lemma that transfers the exact rational growth of OQ-03 to nearby irrationals: a number α lying just above p/q inherits the linear growth S(α, Nq) ≈ N/2 over the range where multiplying by k ≤ Nq has not yet pushed αk across the integer ceiling of (p/q)k. Super-approximable (Liouville) numbers are precisely those for which this range can be pushed arbitrarily far, so their inner sums spike — the structural reason behind the unbounded-versus-bounded dichotomy that distinguishes the Liouville class from the quadratic irrationals.",
     "problemStatement": "**Liouville side of Erdős #1002 OQ-04.** Let S(α, n) = Σ_{k=1}^n (1/2 − {αk}). Can the distribution question be resolved for the Liouville class?\n\n1. `innerSum_perturb` (perturbation lemma): for a reduced fraction p/q (gcd(p,q)=1, q ≥ 1) and N ≥ 1, if 0 < α − p/q < 1/(Nq)² then N/2 − 1 < S(α, Nq) < N/2. The inner sum at n = Nq is pinned to the rational value N/2 of OQ-03 up to error 1.\n\n2. `innerSum_unbounded_near_rational`: for every reduced fraction p/q and every height M there is an irrational α > p/q with S(α, n) > M for some n. Hence the inner sum is unbounded over the irrationals, and the spikes accumulate at every rational — the Liouville phenomenon.",
-    "text": "When an irrational α approximates a reduced fraction p/q closer than 1/(Nq)², the Erdős #1002 inner sum at n = Nq is pinned to OQ-03's rational value N/2 within an error of 1; since rationals admit arbitrarily good irrational approximations, this forces unbounded inner sums near every rational — the structural Liouville-side resolution of OQ-04, fully verified and axiom-free.",
+    "text": "When an irrational α approximates a reduced fraction p/q closer than 1/(Nq)², the Erdős #1002 inner sum at n = Nq is pinned to OQ-03's rational value N/2 within an error of 1; since rationals admit arbitrarily good irrational approximations, this forces unbounded inner sums near every rational — the structural Liouville-side resolution of OQ-04, fully verified and axiom-free. The capstone innerSum_unbounded_single realises this with a single fixed Liouville number L = Σ_i 1/2^{i!}, by running the perturbation lemma along L's own convergents.",
     "proofStrategy": "**Floor agreement (no wrap-around).** The geometric heart is `floor_eq_of_close`: if α ≥ p/q and (α − p/q)·j is smaller than the minimal gap 1/q between (p/q)·j and the next integer, then ⌊α·j⌋ = ⌊(p/q)·j⌋. The lower bound ⌊(p/q)j⌋ ≤ ⌊αj⌋ is monotonicity; the upper bound uses that the fractional part {(p/q)j} = ((p·j) mod q)/q is at most (q−1)/q, so {(p/q)j} + (α − p/q)·j < (q−1)/q + 1/q = 1, keeping αj below ⌊(p/q)j⌋ + 1.\n\n**Perturbation lemma.** Under 0 < α − p/q < 1/(Nq)², every index j = k+1 ≤ Nq satisfies the gap condition (since (α−p/q)·Nq < 1/(Nq) ≤ 1/q), so floor agreement holds throughout. Termwise this gives deviation(α·j) = deviation((p/q)·j) − (α − p/q)·j, because the deviations differ only by the matched-floor linear term. Summing over j ≤ Nq, invoking `Erdos1002OQ03.innerSum_linear` (S(p/q, Nq) = N/2) and the Gauss sum Σ_{j≤Nq} j = Nq(Nq+1)/2, yields S(α, Nq) = N/2 − (α − p/q)·Nq(Nq+1)/2. The correction lies in (0, 1): positivity from α > p/q, and the bound (α − p/q)·Nq(Nq+1)/2 < (Nq+1)/(2Nq) ≤ 1 from α − p/q < 1/(Nq)² and Nq ≥ 1.\n\n**Unboundedness.** Given a target M, choose N with N/2 − 1 > M (via exists_nat_gt). The open interval (p/q, p/q + 1/(Nq)²) is non-empty, so `exists_irrational_btwn` supplies an irrational α inside it; the perturbation lemma then gives S(α, Nq) > N/2 − 1 > M. As this works for every reduced p/q, the inner sum is unbounded near every rational.",
     "keyInsights": [
       "A sharp perturbation lemma transfers OQ-03's exact rational growth S(p/q, Nq) = N/2 to nearby irrationals: if 0 < α − p/q < 1/(Nq)² then N/2 − 1 < S(α, Nq) < N/2, an error of less than one full unit over the entire range n ≤ Nq",
@@ -46,7 +46,7 @@
       "The minimal gap between (p/q)·j and the next integer is exactly 1/q (the fractional part {(p/q)j} = ((p·j) mod q)/q is at most (q−1)/q); the perturbation budget 1/(Nq)² is calibrated so the accumulated drift over n ≤ Nq never spends this gap",
       "Because rationals admit arbitrarily good one-sided irrational approximations (exists_irrational_btwn), the spikes S(α, n) > M occur near EVERY rational p/q — this is precisely the super-approximation (Liouville) phenomenon, not merely the trivial small-α direction",
       "The result establishes the Liouville/unbounded side of the Erdős #1002 dichotomy: S(α, n) is unbounded over the irrationals, in sharp contrast to the O(log n) boundedness for quadratic irrationals (bounded partial quotients), which remains the surveyed complementary half",
-      "Iterating the lemma along a sequence p_j/q_j → α with α − p_j/q_j < 1/(N_j q_j)² and N_j → ∞ pins a single fixed Liouville number with S(α, ·) unbounded; the perturbation lemma is exactly the per-stage engine such a construction needs"
+      "Iterating the lemma along a single number's own convergents collapses the family to ONE fixed Liouville number: for L = Σ_i 1/2^{i!} (Mathlib's liouvilleNumber 2), the reduced convergent p'/q' (q' ≤ 2^{k!}) with height N = 2^{k!} satisfies the perturbation budget for every k ≥ 5, so S(L, 2^{k!}·q') > 2^{k!}/2 − 1 → ∞. This is innerSum_unbounded_single — the quantifier upgrade from 'for every M, some irrational' to 'one irrational, every M' — now fully formalized (no oddness or exact-reduction bookkeeping is needed, since reducing the convergent only shrinks the denominator)"
     ],
     "prerequisites": [
       "Real analysis: the fractional part Int.fract, the floor function, and the identity x = ⌊x⌋ + {x}",
@@ -86,15 +86,23 @@
       "startLine": 196,
       "endLine": 239,
       "mathContext": "The spikes accumulate at every rational: near each p/q there are irrationals whose inner sum is arbitrarily large, exactly because super-approximation lets the linear-growth window n ≤ Nq be made arbitrarily long. This is the Liouville-side resolution of OQ-04 and the structural contrast with the bounded quadratic-irrational case."
+    },
+    {
+      "id": "capstone",
+      "title": "A Single Fixed Liouville Number with Unbounded Inner Sum",
+      "summary": "liouville_spike + innerSum_unbounded_single: the concrete Liouville constant L = Σ_i 1/2^{i!} (Mathlib's liouvilleNumber 2) is irrational and has S(L, n) unbounded — strengthening innerSum_unbounded from 'for every M there is SOME irrational' to 'there is ONE irrational that works for every M'. Run innerSum_perturb along L's own convergents: the k-th partial sum is a dyadic rational P_k/2^{k!} lying just below L (partialSum_add_remainder + remainder_pos give one-sidedness), with super-small tail L − P_k/2^{k!} = remainder 2 k < 1/(2^{k!})^k (remainder_lt). Reducing the convergent to lowest terms p'/q' (so q' ≤ 2^{k!}) and taking N = 2^{k!}, the perturbation budget (L − p'/q')·(Nq')² < (2^{k!})^{4−k} ≤ 1 is met for all k ≥ 5, pinning S(L, Nq') > 2^{k!}/2 − 1 → ∞.",
+      "startLine": 240,
+      "endLine": 360,
+      "mathContext": "The earlier theorems give a family of irrationals (one per height M); the capstone collapses that family to a single super-approximable number. Crucially no oddness/exact-reduction bookkeeping is needed: writing the convergent in lowest terms only SHRINKS the denominator (q' ≤ 2^{k!}), which makes the perturbation budget 1/(Nq')² easier to satisfy, while innerSum_linear still returns the full period value N/2. This is exactly the iterate-along-a-super-approximating-sequence construction flagged as the natural capstone, now formalized using Mathlib's Liouville API rather than a hand-built series."
     }
   ],
   "conclusion": {
-    "summary": "The Liouville (super-approximable) side of Erdős #1002 OQ-04 is resolved completely and without axioms. A sharp perturbation lemma shows that an irrational α approximating a reduced fraction p/q closer than 1/(Nq)² inherits OQ-03's exact rational growth: N/2 − 1 < S(α, Nq) < N/2. Since every rational admits arbitrarily good irrational approximations, this forces the inner sum S(α, n) to be unbounded near every rational, in sharp contrast to the O(log n) boundedness for quadratic irrationals. The complementary boundedness half and the construction of a single fixed Liouville number with unbounded inner sum (by iterating the perturbation lemma along a super-approximating sequence) are the natural next steps.",
+    "summary": "The Liouville (super-approximable) side of Erdős #1002 OQ-04 is resolved completely and without axioms. A sharp perturbation lemma shows that an irrational α approximating a reduced fraction p/q closer than 1/(Nq)² inherits OQ-03's exact rational growth: N/2 − 1 < S(α, Nq) < N/2. Since every rational admits arbitrarily good irrational approximations, the inner sum S(α, n) is unbounded near every rational, in sharp contrast to the O(log n) boundedness for quadratic irrationals. The capstone innerSum_unbounded_single now upgrades this from a family of irrationals to a SINGLE fixed Liouville number L = Σ_i 1/2^{i!}: running the perturbation lemma along L's own convergents proves S(L, ·) unbounded, so the unboundedness is realised by one explicit super-approximable number. The complementary boundedness half remains the natural next step.",
     "implications": "The perturbation lemma reframes the Erdős #1002 dichotomy as a statement about approximation quality rather than about α directly: the inner sum spikes precisely where rationals can be approximated faster than the quadratic threshold 1/(Nq)², which is the defining feature of the Liouville/super-approximable class. This isolates *why* the two ends of the spectrum diverge — bounded partial quotients cap the linear-growth window n ≤ Nq, while unbounded partial quotients let it run arbitrarily far — and does so by transferring an exact rational identity (OQ-03's S(p/q, Nq) = N/2) to the irrationals through a single no-wrap-around floor-agreement fact rather than any ergodic or continued-fraction machinery. The lemma is reusable verbatim as the per-stage engine for pinning a fixed Liouville number, so it converts the qualitative 'Liouville numbers misbehave' folklore into a quantitative, axiom-free tool. What it deliberately does not touch is the bounded-type half (the O(log n) boundedness for badly approximable α), which still needs Ostrowski/three-distance technology absent from Mathlib; the present result is exactly one side of a clean conjectural dichotomy.",
     "openQuestions": [
-      "Formalize a single fixed Liouville number α = Σ 10^(−j!) (or similar super-approximating series) and prove S(α, ·) unbounded by applying innerSum_perturb at each truncation p_j/q_j with N_j → ∞",
       "Formalize the complementary quadratic-irrational / badly-approximable boundedness S(α, n) = O(log n), which requires Ostrowski digit / three-distance machinery not yet in Mathlib in usable form",
-      "Combine both halves into a clean dichotomy statement: S(α, n)/log n bounded ⟺ α is of bounded type (badly approximable), unbounded for Liouville-type α"
+      "Combine both halves into a clean dichotomy statement: S(α, n)/log n bounded ⟺ α is of bounded type (badly approximable), unbounded for Liouville-type α",
+      "Quantify the growth rate of the spikes for L = Σ 1/2^{i!}: the construction gives S(L, n) > 2^{k!}/2 − 1 at n = 2^{k!}·q'; relate this lower bound to the conjectured Cauchy-type fluctuations of S(α,n)/log n"
     ]
   },
   "crossReferences": [
@@ -109,7 +117,9 @@
   ],
   "references": [
     {
-      "authors": ["H. Kesten"],
+      "authors": [
+        "H. Kesten"
+      ],
       "title": "On a conjecture of Erdős and Szüsz related to uniform distribution mod 1",
       "venue": "Acta Arithmetica",
       "year": "1960",
@@ -117,7 +127,9 @@
       "pages": "369–379"
     },
     {
-      "authors": ["J. Liouville"],
+      "authors": [
+        "J. Liouville"
+      ],
       "title": "Sur des classes très étendues de quantités dont la valeur n'est ni algébrique ni même réductible à des irrationnelles algébriques",
       "venue": "Journal de Mathématiques Pures et Appliquées",
       "year": "1851",
@@ -126,12 +138,17 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib", "Proofs.Erdos1002OQ03"],
-    "opens": ["Real"],
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos1002OQ03"
+    ],
+    "opens": [
+      "Real"
+    ],
     "namespace": "Erdos1002OQ04",
-    "lineCount": 239,
+    "lineCount": 360,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/Erdos1002OQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary
Capstone for the Liouville side of **Erdős #1002 OQ-04**. The existing theorems prove the inner sum `S(α,n) = Σ_{k≤n}(1/2 − {αk})` is unbounded *over the irrationals* — but as a family: for each height `M` they produce a *different* irrational. This PR collapses that family to **one fixed number**.

**New theorem `innerSum_unbounded_single`:** the concrete Liouville constant `L = Σ_i 1/2^{i!}` (Mathlib's `liouvilleNumber 2`) is irrational and satisfies `∀ M, ∃ n, M < S(L, n)`. Quantifier upgrade: from *"for every M there is some irrational"* to *"there is one irrational that works for every M"*. The file's own docstring flagged this as the natural capstone ("recorded in the knowledge base"); it is now formalized.

## Mechanism
Run the existing `innerSum_perturb` along `L`'s own convergents:
- The `k`-th partial sum is a dyadic rational `P_k/2^{k!}` lying just **below** `L` (`partialSum_add_remainder` + `remainder_pos` give one-sidedness).
- Tail is super-small: `L − P_k/2^{k!} = remainder 2 k < 1/(2^{k!})^k` (`remainder_lt`).
- Reducing the convergent to lowest terms `p'/q'` only **shrinks** the denominator (`q' ≤ 2^{k!}`), so taking `N = 2^{k!}` the perturbation budget `(L − p'/q')·(Nq')² < (2^{k!})^{4−k} ≤ 1` holds for all `k ≥ 5`, pinning `S(L, Nq') > 2^{k!}/2 − 1 → ∞`.

No oddness/exact-reduction bookkeeping is needed — that is the key simplification that made this tractable.

## Files
- `proofs/Proofs/Erdos1002OQ04.lean` — `+121` lines, purely additive (`liouville_spike`, `innerSum_unbounded_single`).
- `src/data/proofs/erdos-1002-oq-04/meta.json` — counts 6→8 theorems / 239→360 lines, new capstone section, resolved open question.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos1002OQ04` — **build succeeded**.
- `#print axioms Erdos1002OQ04.innerSum_unbounded_single` = `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `Lean.ofReduceBool`**. Reuses only Mathlib's axiom-free Liouville API.

## Status
**Outcome**: completed (capstone formalized, verified, 0-axiom)
**Next Steps**: complementary badly-approximable boundedness `S(α,n)=O(log n)` (needs Ostrowski/three-distance machinery); full dichotomy statement.

🤖 Generated by researcher-4