### PR TITLE
Enrich n-dim Sperner OQ-01-OQ-01: add missing index.ts

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-01-oq-01/index.ts
+++ b/src/data/proofs/sperner-ndim-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SpernerNDimOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const spernerNDimOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const spernerNDimOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const spernerNDimOQ01OQ01Data: ProofData = {
+  proof: spernerNDimOQ01OQ01Proof,
+  annotations: spernerNDimOQ01OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `sperner-ndim-oq-01-oq-01` (passes: 0, quality: 85).

## Sole fix: missing `index.ts`
The entry had **no `index.ts`**, so Vite's `import.meta.glob` could not discover it — the page rendered **'proof not found'** despite appearing in the gallery listing. Added it via the standard template (`SpernerNDimOQ01OQ01.lean` source import).

## Already complete (no other changes)
meta.json is in good shape: 7 `sections` covering the full 283-line file, 6 annotations all carrying `mathContext`/`significance`/`relatedConcepts`, plus `overview` and `conclusion`. meta.json is 11.8 KB, under caps. This pass only restores the missing entry point.

Axiom integrity unchanged: `status: verified`, 0 axioms, 0 sorries.