### PR TITLE
Enrich A Continuous Partition of Unity from Distance-to-Complement Bumps (oq-02-oq-02)

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/annotations.json
@@ -70,5 +70,52 @@
       "reindexing sums over a Finset via its attach/coe-sort",
       "dependent if-then-else (dite)"
     ]
+  },
+  {
+    "id": "bump-subordinate-lemma",
+    "proofId": "compactness-finite-subcover-oq-02-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 103
+    },
+    "type": "technique",
+    "title": "Subordination Is the Contrapositive of infDist_zero_of_mem",
+    "content": "bump_subordinate is the precise support guarantee: bump U i x ≠ 0 ⟹ x ∈ U i. The proof is a clean case split on whether (U i)ᶜ is empty. In the degenerate case (U i = univ) every x lies in U i automatically. Otherwise it argues by contradiction: if x ∉ U i then x ∈ (U i)ᶜ, so infDist_zero_of_mem forces bump U i x = infDist x (U i)ᶜ = 0, contradicting the hypothesis. This is exactly the contrapositive of the metric fact that distance to a set vanishes on the set, and it is what makes ψ subordinate to the cover.",
+    "mathContext": "$\\mathrm{bump}_i(x)\\neq 0 \\implies x\\in U_i,\\qquad x\\in (U_i)^c \\implies d(x,(U_i)^c)=0.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "subordination",
+      "contrapositive",
+      "support of a function",
+      "infDist vanishing on a set"
+    ],
+    "prerequisites": [
+      "proof by contradiction",
+      "infDist_zero_of_mem",
+      "complement membership"
+    ]
+  },
+  {
+    "id": "headline-finite-cover",
+    "proofId": "compactness-finite-subcover-oq-02-oq-02",
+    "range": {
+      "startLine": 141,
+      "endLine": 156
+    },
+    "type": "theorem",
+    "title": "The Headline: Partition of Unity for a Finite Open Cover",
+    "content": "exists_partition_of_unity packages the whole construction: for any finite open cover of a metric space there exist functions ψ that are continuous, nonnegative, subordinate (ψ i x ≠ 0 ⟹ x ∈ U i), and sum to 1 everywhere. The proof is a single anonymous constructor bundling psi_continuous, psi_nonneg, psi_subordinate, and psi_sum_eq_one — note that the only hypotheses are openness and that the U i cover X; compactness is entirely absent, which is the structural point the entry isolates. The compact-space corollary that follows is then just a reduction to this theorem after a finite subcover is extracted.",
+    "mathContext": "$\\exists\\, \\psi: \\iota\\to X\\to\\mathbb{R},\\ \\forall i\\ \\text{Continuous}(\\psi_i),\\ 0\\le\\psi_i,\\ (\\psi_i(x)\\neq 0\\Rightarrow x\\in U_i),\\ \\textstyle\\sum_i \\psi_i(x)=1.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "partition of unity",
+      "subordinate cover",
+      "anonymous constructor",
+      "finite open cover"
+    ],
+    "prerequisites": [
+      "existential bundling of properties",
+      "continuity, nonnegativity, subordination, summation to one"
+    ]
   }
 ]

--- a/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/index.ts
+++ b/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CompactnessFiniteSubcoverOq02Oq02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const compactnessFiniteSubcoverOq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const compactnessFiniteSubcoverOq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const compactnessFiniteSubcoverOq02Oq02Data: ProofData = {
+  proof: compactnessFiniteSubcoverOq02Oq02Proof,
+  annotations: compactnessFiniteSubcoverOq02Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `compactness-finite-subcover-oq-02-oq-02`.

## Changes
- **Created missing `index.ts`** — without it Vite's `import.meta.glob` can't discover the proof and the page shows 'proof not found' on the live site. This was the critical gap.
- **Added 2 annotations** (now 5 total): `bump_subordinate` as the contrapositive of `infDist_zero_of_mem`, and the headline `exists_partition_of_unity` theorem — filling the previously-uncovered support lemma and finite-cover headline.

## Verification
- `pnpm build` passes.
- meta.json is 15 KB — well under the 60 KB size cap.
- The already-rich overview, keyInsights, sections, openQuestions, crossReferences, and references were left intact.

Axiom integrity unchanged: status `verified`, badge `original`, axiomCount 0 (explicit metric construction; only the cited infDist/compactness facts come from Mathlib).