### PR TITLE
research(pascals-hexagon-incomplete-01-oq-01): Pascal for asymmetric conics via symmetrization [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/PascalsHexagon.lean
+++ b/proofs/Proofs/PascalsHexagon.lean
@@ -1675,6 +1675,38 @@ theorem proof_sketch_conic_implies_pascal (C : Conic)
   -- Step F: Pull back via projective invariance
   exact (pascalConstraint_projTransform M hM_det hex.A hex.B hex.C' hex.D hex.E hex.F).mp hStd
 
+/-- **Pascal for asymmetric conics, via symmetrization (0-sorry).**
+
+    Strengthens `proof_sketch_conic_implies_pascal` by *dropping the `C.symmetric`
+    hypothesis*. Every conic `C` shares its zero set with its symmetrization
+    `S := ½·(C + Cᵀ)` (`pointOnConic_iff_symmetrized`), which is genuinely symmetric
+    (`symmetrizedConic_symmetric`). Thus an inscribed hexagon in `C` is, vertex for vertex,
+    an inscribed hexagon in `S`, and `pascalConstraint` depends only on those vertices —
+    so it transfers back verbatim. The sole extra hypothesis is that the symmetrization
+    remains non-degenerate (`S.det ≠ 0`); this is the natural notion of non-degeneracy for
+    a possibly-asymmetric conic, since the conic's entire geometric content lives in `S`.
+
+    This discharges **step 1** of the roadmap to eliminating the
+    `conic_implies_pascal_constraint` axiom (the asymmetric reduction), narrowing the
+    axiom's residual scope to the genuinely *degenerate* case (`S.det = 0`, pairs of
+    lines / Pappus). -/
+theorem proof_sketch_conic_implies_pascal_of_symmetrization
+    (C : Conic) (hS_nd : Conic.nondegenerate ((1 / 2 : ℝ) • (C + Cᵀ)))
+    (hex : InscribedHexagon C) :
+    pascalConstraint hex.A hex.B hex.C' hex.D hex.E hex.F := by
+  -- Re-view the same six vertices as inscribed in the symmetric representative `S`.
+  have conv : ∀ p, pointOnConic p C → pointOnConic p ((1 / 2 : ℝ) • (C + Cᵀ)) :=
+    fun p hp => (pointOnConic_iff_symmetrized C p).mp hp
+  let hexS : InscribedHexagon ((1 / 2 : ℝ) • (C + Cᵀ)) :=
+    { A := hex.A, B := hex.B, C' := hex.C', D := hex.D, E := hex.E, F := hex.F,
+      hA := conv _ hex.hA, hB := conv _ hex.hB, hC := conv _ hex.hC,
+      hD := conv _ hex.hD, hE := conv _ hex.hE, hF := conv _ hex.hF,
+      hAvalid := hex.hAvalid, hBvalid := hex.hBvalid, hCvalid := hex.hCvalid,
+      hDvalid := hex.hDvalid, hEvalid := hex.hEvalid, hFvalid := hex.hFvalid }
+  -- Pascal holds for `S` (symmetric + non-degenerate); the vertices coincide with `hex`'s.
+  exact proof_sketch_conic_implies_pascal _ (symmetrizedConic_symmetric C) hS_nd hexS
+
 #check @pascal_std_conic
 #check @pascal_std_conic_normalized
 #check @proof_sketch_conic_implies_pascal
+#check @proof_sketch_conic_implies_pascal_of_symmetrization

--- a/research/problems/pascals-hexagon-incomplete-01-oq-01/knowledge.md
+++ b/research/problems/pascals-hexagon-incomplete-01-oq-01/knowledge.md
@@ -6,6 +6,38 @@ real point is projectively equivalent to `stdConic = diag(1,1,-1)`. This is the 
 on the `proof_sketch_conic_implies_pascal` path (Pascal's theorem for general symmetric
 non-degenerate conics).
 
+## Session 2026-06-30 (researcher-2) — original `sorry` is GONE; asymmetric reduction landed
+
+**Mode:** ACT (axiom-narrowing). **Outcome:** PROGRESS.
+- **State change**: the `sorry` that this whole knowledge file targets
+  (`sylvester_stdConic_of_isotropic` / `exists_scaledCongr_stdConic_of_isotropic`) is
+  **already discharged on `main`** — `PascalsHexagon.lean` is now **0-sorry** (researcher-10
+  closed the Sylvester isometry→matrix bridge manually). The file carries **1 axiom**,
+  `conic_implies_pascal_constraint`, retained ONLY for the asymmetric + degenerate cases.
+- **This session**: added **`proof_sketch_conic_implies_pascal_of_symmetrization`** —
+  Pascal for *asymmetric* non-degenerate conics, dropping the `C.symmetric` hypothesis of
+  `proof_sketch_conic_implies_pascal`. Proof: pass to the symmetric representative
+  `S := ½·(C + Cᵀ)` (zero set preserved by the pre-existing `pointOnConic_iff_symmetrized`;
+  `S` symmetric by `symmetrizedConic_symmetric`), rebuild the inscribed hexagon vertex-for-
+  vertex in `S`, apply the symmetric theorem; `pascalConstraint` depends only on the shared
+  vertices so it transfers back by `exact`. Sole extra hypothesis: `S.det ≠ 0` (the correct
+  notion of non-degeneracy for an asymmetric conic — all geometric content lives in `S`).
+  **Verified 0-axiom** (`#print axioms = [propext, Classical.choice, Quot.sound]`),
+  host `lake env lean` EXIT 0 and docker build 3065 jobs OK.
+- This discharges **step 1** of the axiom-elimination roadmap (asymmetric→symmetric).
+  Residual axiom scope is now just the **degenerate** case (`S.det = 0`: pairs of lines /
+  Pappus-type), which `proof_sketch_conic_implies_pascal_of_symmetrization` cannot reach.
+- **GOTCHA (re-confirmed)**: edit/Write in the WORKTREE path, not the main repo checkout —
+  a first edit applied to `/Users/.../lean-genius/proofs/...` (and `research/.../knowledge.md`)
+  was clobbered by a concurrent main operation within seconds. Use
+  `.loom/worktrees/researcher-2/...`.
+
+### Next steps
+1. The degenerate case (`S.det = 0`) is the only thing keeping the axiom. It is genuinely
+   harder (Cayley–Bacharach / Pappus for line-pairs) and likely not a single-session item.
+2. Optionally: prove `det(½·(C+Cᵀ)) ≠ 0 ← (some condition on C)` to phrase the asymmetric
+   theorem directly in terms of `C` rather than its symmetrization.
+
 ## Summary of state
 - The theorem statement is TRUE (Sylvester's law of inertia; the real-point hypothesis is
   essential and rules out the definite case).


### PR DESCRIPTION
## Summary

The `sorry` this problem originally targeted (`sylvester_stdConic_of_isotropic`) is **already discharged on `main`** — `PascalsHexagon.lean` is now 0-sorry. The file retains a single `axiom conic_implies_pascal_constraint`, used only for the **asymmetric** and **degenerate** cases. This PR discharges the **asymmetric** half.

## New theorem

`proof_sketch_conic_implies_pascal_of_symmetrization` — Pascal's constraint for an inscribed hexagon in an **asymmetric** non-degenerate conic, dropping the `C.symmetric` hypothesis of `proof_sketch_conic_implies_pascal`.

**Proof.** Pass to the symmetric representative `S := ½·(C + Cᵀ)`:
- zero set is preserved by the pre-existing `pointOnConic_iff_symmetrized`,
- `S` is symmetric by `symmetrizedConic_symmetric`,
- rebuild the inscribed hexagon vertex-for-vertex in `S`,
- apply the symmetric theorem; `pascalConstraint` depends only on the (shared) vertices, so it transfers back by `exact`.

Sole extra hypothesis: `S.det ≠ 0` — the natural notion of non-degeneracy for a possibly-asymmetric conic, since all of the conic's geometric content lives in its symmetric part `S`.

## Significance (honest)

Incremental but real: this discharges **step 1 (asymmetric → symmetric)** of the documented roadmap to eliminating `conic_implies_pascal_constraint`. The axiom's residual scope is now just the genuinely **degenerate** case (`S.det = 0`: pairs of lines / Pappus-type). It reuses existing infrastructure (`pointOnConic_iff_symmetrized`, `symmetrizedConic_symmetric`) — the contribution is the clean hexagon-transfer wrapper, not new heavy lemmas.

## Verification

- `#print axioms proof_sketch_conic_implies_pascal_of_symmetrization = [propext, Classical.choice, Quot.sound]` → **0-axiom**
- Host `lake env lean Proofs/PascalsHexagon.lean` → EXIT 0 (only pre-existing unused-simp warnings)
- `./proofs/scripts/docker-build.sh Proofs.PascalsHexagon` → Build succeeded (3065 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)