### PR TITLE
Enrich Pólya–Vinogradov geometric-sum bound: complete section coverage

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-wip-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-wip-01/meta.json
@@ -89,6 +89,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Statement, imports, and namespace",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Docstring: this file extracts the one clean, self-contained classical ingredient of Pólya–Vinogradov — the bound |∑ e^{2πiθn}| ≤ 1/|sin(πθ)| on a partial geometric exponential sum with unit-modulus ratio — and proves it fully machine-checked (the companion BoundedPrimeGapsOQ04OQ01 has analytic sorries and stale syntax). Import Mathlib; open Finset/Complex/Real; namespace.",
+      "mathContext": "Headline: $\\left|\\sum_{n=M+1}^{M+N} e^{2\\pi i\\theta n}\\right| \\le \\dfrac{1}{|\\sin(\\pi\\theta)|}$ for $\\theta\\notin\\mathbb{Z}$."
+    },
+    {
       "id": "helpers",
       "title": "Helper lemmas",
       "startLine": 43,


### PR DESCRIPTION
Enrichment pass for `bounded-prime-gaps-oq-04-oq-01-wip-01` (passes: 0, quality: 86).

## Gap addressed: incomplete `sections`
`sections` started at line 43, leaving the docstring, imports, and namespace (lines 1–42) unmapped. Prepended a `setup` section (1–41) with a LaTeX `mathContext` stating the headline bound $|\sum e^{2\pi i\theta n}| \le 1/|\sin(\pi\theta)|$, so sections now cover the full 130-line file: setup 1–41, helpers 43–79, main 81–123, corollary 124–129.

## Axiom integrity (checked)
The file name contains 'WIP' and `grep sorry` matches once — but that match is the **word in the docstring prose** ('four analytic `sorry`s' describing the *companion* file), not a proof `sorry`. The actual proofs are complete: 0 proof sorries, 0 axioms. `status: verified` / `sorries: 0` is accurate.

## Left as-is
`index.ts`, `overview`, `conclusion`, and all 6 annotations (with `mathContext`/`significance`/`relatedConcepts`) are complete. meta.json is 11.8 KB, under caps. JSON validates.