### PR TITLE
Enrich Hilbert 17 minimal-denominator Artin: index.ts + annotation depth + sections

### DIFF
--- a/src/data/proofs/hilbert-17-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-04/annotations.json
@@ -10,7 +10,17 @@
     "title": "Motzkin and the minimal classical denominator",
     "content": "motzkin is defined exactly as in the parent entries: M = x⁴y² + x²y⁴ − 3x²y² + 1, the canonical polynomial nonnegative on ℝ² yet not a polynomial sum of squares. denom = x²+y²+1 is the minimal classical denominator: it is strictly positive, it is itself a sum of three squares (1² + x² + y²), and it is the degree-minimal SOS multiplier for Motzkin in the Reznick/Pfister theory. The sibling entry hilbert-17-oq-03-oq-01 used the inflated multiplier 4·(x²+y²+1); the whole point here is to reach the minimal x²+y²+1.",
     "mathContext": "$M(x,y) = x^4y^2 + x^2y^4 - 3x^2y^2 + 1,\\qquad D(x,y) = x^2 + y^2 + 1 = 1^2 + x^2 + y^2.$",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Motzkin polynomial",
+      "sum of squares (SOS)",
+      "Reznick/Pfister theory",
+      "minimal SOS denominator"
+    ],
+    "prerequisites": [
+      "multivariate polynomials",
+      "nonnegative polynomials vs SOS"
+    ]
   },
   {
     "id": "ann-h17-oq0104-cleared-certificate",
@@ -23,7 +33,17 @@
     "title": "The cleared integer SOS certificate",
     "content": "Working with the minimal denominator forces half-integer coefficients in the square roots, so the identity is first stated cleared of its common factor 4, where every coefficient is an integer and Lean's ring tactic closes it outright: 4·(x²+y²+1)·M = 3·(2xy−x³y−xy³)² + (x³y−xy³)² + (2x−2xy²)² + (2y−2x²y)² + (2−2x²y²)². The five generators come from the rank-5 boundary Gram matrix of Motzkin at the minimal denominator.",
     "mathContext": "$4(x^2+y^2+1)\\,M = 3(2xy-x^3y-xy^3)^2 + (x^3y-xy^3)^2 + (2x-2xy^2)^2 + (2y-2x^2y)^2 + (2-2x^2y^2)^2.$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "SOS certificate",
+      "Gram matrix",
+      "ring tactic",
+      "integer clearing of denominators"
+    ],
+    "prerequisites": [
+      "polynomial identities over ℝ",
+      "positive-semidefinite Gram representation"
+    ]
   },
   {
     "id": "ann-h17-oq0104-denom-sos",
@@ -36,7 +56,15 @@
     "title": "The minimal denominator is a sum of squares",
     "content": "denom_isSumOfSquares records that x²+y²+1 = 1² + x² + y² is itself a sum of three squares. This is what lets the polynomial certificate be promoted to a rational-function SOS for M alone: a product of two sums of squares is again a sum of squares, so multiplying (x²+y²+1)·M = Σ pᵢ² by (x²+y²+1) = Σ dⱼ² isolates M as a quotient of an SOS by the square of the denominator.",
     "mathContext": "$x^2+y^2+1 = 1^2 + x^2 + y^2.$",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sum of squares",
+      "product of SOS is SOS",
+      "rational-function SOS"
+    ],
+    "prerequisites": [
+      "sum-of-squares closure under multiplication"
+    ]
   },
   {
     "id": "ann-h17-oq0104-minimal-certificate",
@@ -49,7 +77,17 @@
     "title": "The minimal-denominator certificate",
     "content": "The headline identity, now in the field of rational functions ℝ(x,y): dividing the cleared identity by 4 (handled by linear_combination) gives (x²+y²+1)·M = 3·(xy − ½(x³y+xy³))² + (½(x³y−xy³))² + (x − xy²)² + (y − x²y)² + (1 − x²y²)², a sum of seven squares whose multiplier is exactly the minimal classical denominator. Over ℝ the three repeated squares merge into one (√3·…)², giving the rank-5 count.",
     "mathContext": "$(x^2+y^2+1)\\,M = 3\\!\\left(xy - \\tfrac{x^3y+xy^3}{2}\\right)^2 + \\left(\\tfrac{x^3y-xy^3}{2}\\right)^2 + (x-xy^2)^2 + (y-x^2y)^2 + (1-x^2y^2)^2.$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "field of rational functions ℝ(x,y)",
+      "linear_combination tactic",
+      "rank-5 SOS",
+      "half-integer coefficients"
+    ],
+    "prerequisites": [
+      "rational function fields",
+      "linear_combination over a hypothesis"
+    ]
   },
   {
     "id": "ann-h17-oq0104-ratfunc",
@@ -62,6 +100,17 @@
     "title": "Minimal-denominator Artin for Motzkin",
     "content": "motzkin_isSOS_ratFunc_minimalDenom is the constructive, 0-axiom realization of Artin's theorem for the canonical example with the minimal denominator. From the 21-term product identity Σ(qᵢdⱼ)² = (4·(x²+y²+1)·M)·(x²+y²+1) and the nonvanishing of the denominator, M = Σ (qᵢ·dⱼ / (2·(x²+y²+1)))² — a sum of squares of rational functions whose common denominator is exactly x²+y²+1. Pfister's bound guarantees four squares suffice in the plane; this explicit minimal-denominator witness uses five (rank 5), leaving the gap to the optimum as a concrete open question.",
     "mathContext": "$M = \\sum_{i,j} \\left(\\frac{q_i\\,d_j}{2(x^2+y^2+1)}\\right)^2,\\qquad \\text{denominator } = x^2+y^2+1.$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "Artin theorem (Hilbert 17)",
+      "Pfister bound",
+      "SOS of rational functions",
+      "minimal denominator"
+    ],
+    "prerequisites": [
+      "Hilbert 17th problem",
+      "Artin/Pfister theory",
+      "quotients of SOS"
+    ]
   }
 ]

--- a/src/data/proofs/hilbert-17-oq-01-oq-04/index.ts
+++ b/src/data/proofs/hilbert-17-oq-01-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Hilbert17OQ01OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hilbert17OQ01OQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hilbert17OQ01OQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hilbert17OQ01OQ04Data: ProofData = {
+  proof: hilbert17OQ01OQ04Proof,
+  annotations: hilbert17OQ01OQ04Annotations,
+}

--- a/src/data/proofs/hilbert-17-oq-01-oq-04/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-04/meta.json
@@ -182,6 +182,14 @@
   "crossReferences": [],
   "sections": [
     {
+      "id": "setup",
+      "title": "Module framing, imports, and setup",
+      "startLine": 1,
+      "endLine": 89,
+      "summary": "Docstring framing the goal: realize Artin/Hilbert-17 for the Motzkin polynomial with the MINIMAL classical denominator x²+y²+1 (the sibling hilbert-17-oq-03-oq-01 used the inflated 4·(x²+y²+1)). Imports and setup for working in ℝ[x,y] and the rational-function field ℝ(x,y).",
+      "mathContext": "Goal: $M = \\sum_{i,j}\\big(q_i d_j/(2(x^2+y^2+1))\\big)^2$ with minimal denominator $x^2+y^2+1$."
+    },
+    {
       "id": "definitions",
       "title": "Motzkin, the minimal denominator, and the SOS predicates",
       "startLine": 90,


### PR DESCRIPTION
Enrichment pass for `hilbert-17-oq-01-oq-04` (passes: 0, quality: 86). Three gaps addressed:

## 1. Missing `index.ts` (critical)
The entry had **no `index.ts`**, so the page rendered **'proof not found'**. Added via the standard template.

## 2. Annotation depth
All 5 annotations had `content`/`mathContext`/`significance` but no `relatedConcepts` or `prerequisites`. Added both arrays to each (Motzkin/SOS/Reznick–Pfister, Gram matrix, rational-function field, Artin/Pfister bound, etc.).

## 3. Section coverage
`sections` started at line 90, leaving the docstring + imports (1–89) unmapped. Prepended a `setup` section (1–89) with a LaTeX `mathContext`, so sections now cover the full 227-line file: setup 1–89, definitions 90–128, certificate 130–174, rational-corollary 176–227.

## Axiom integrity
0 proof sorries, 0 axioms — the certificate is closed by `ring`/`linear_combination`. `status: verified` is accurate. meta.json is 18 KB, under caps. JSON validates.