### PR TITLE
research(erdos-1003-oq-03): upper-density (limsup) layer — positive limsup ⇒ infinite [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1003OQ03.lean
+++ b/proofs/Proofs/Erdos1003OQ03.lean
@@ -35,6 +35,15 @@ exact logical relationships that pin down what an eventual answer must supply.
      infinite worlds, and any *positive* density is equivalent to a strong form of
      the open #1003 conjecture.
 
+  5. **The upper density is the unconditional carrier**: the natural-density
+     *limit* may fail to exist (existence is itself open), but the upper density
+     `upperDensity = limsup_N count(N)/(N+1)` always exists for our bounded
+     sequence.  We show it lies in `[0,1]`, agrees with the natural density when
+     the latter exists, vanishes on finite solution sets, and — most usefully —
+     that a *positive upper density* already forces infinitude
+     (`infinite_of_pos_upperDensity`).  This strengthens (3): one no longer needs
+     the limit to exist, only its limsup to be positive.
+
 These are fully machine-checked (0 sorry, 0 axiom) consequences of the
 definitions.  The definitions agree verbatim with the parent #1003 entry
 (`Proofs.Erdos1003Problem`) and the sibling OQ-02 file.
@@ -45,6 +54,7 @@ Reference: https://erdosproblems.com/1003
 import Mathlib.Data.Nat.Totient
 import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Topology.Algebra.Order.LiminfLimsup
 
 open Nat Set Filter Topology
 
@@ -173,5 +183,74 @@ theorem infinite_of_pos_density {d : ℝ} (hd : 0 < d)
   have h0 : HasNaturalDensity 0 := hasNaturalDensity_zero_of_finite hfin
   have : d = 0 := tendsto_nhds_unique h h0
   exact absurd this (ne_of_gt hd)
+
+/-- The natural density, when it exists, is unique. -/
+theorem hasNaturalDensity_unique {d₁ d₂ : ℝ}
+    (h₁ : HasNaturalDensity d₁) (h₂ : HasNaturalDensity d₂) : d₁ = d₂ :=
+  tendsto_nhds_unique h₁ h₂
+
+/-- The natural density, when it exists, lies in `[0, 1]`. -/
+theorem hasNaturalDensity_mem_Icc {d : ℝ} (h : HasNaturalDensity d) :
+    d ∈ Set.Icc (0 : ℝ) 1 := by
+  refine ⟨ge_of_tendsto' h density_ratio_nonneg, ?_⟩
+  exact le_of_tendsto h (by filter_upwards with N using density_ratio_le_one N)
+
+/-! ## Upper density (the unconditional object)
+
+The natural-density *limit* may fail to exist (its existence is itself open).
+The *upper density* — the `limsup` of the same ratios — always exists for our
+bounded sequence and is the right unconditional carrier of OQ-03. -/
+
+/-- The upper density of the solution set: the `limsup` of the counting ratios
+`count(N)/(N+1)`.  Unlike the natural density, this always exists (the sequence
+is bounded in `[0,1]`). -/
+noncomputable def upperDensity : ℝ :=
+  limsup (fun N : ℕ => (countConsecutiveEqual N : ℝ) / (N + 1)) atTop
+
+/-- The ratio sequence is bounded above (by `1`); used to feed the `limsup`
+order lemmas. -/
+theorem isBoundedUnder_ratio :
+    IsBoundedUnder (· ≤ ·) atTop
+      (fun N : ℕ => (countConsecutiveEqual N : ℝ) / (N + 1)) :=
+  ⟨1, Filter.eventually_map.mpr (by filter_upwards with N using density_ratio_le_one N)⟩
+
+/-- The ratio sequence is cobounded above (witness `0`, since it is `≥ 0`); used
+to feed the `limsup` order lemmas. -/
+theorem isCoboundedUnder_ratio :
+    IsCoboundedUnder (· ≤ ·) atTop
+      (fun N : ℕ => (countConsecutiveEqual N : ℝ) / (N + 1)) :=
+  isCoboundedUnder_le_of_le atTop density_ratio_nonneg
+
+/-- The upper density is nonnegative. -/
+theorem upperDensity_nonneg : 0 ≤ upperDensity :=
+  Filter.le_limsup_of_le isBoundedUnder_ratio
+    (by filter_upwards with N using density_ratio_nonneg N)
+
+/-- The upper density never exceeds `1`. -/
+theorem upperDensity_le_one : upperDensity ≤ 1 :=
+  Filter.limsup_le_of_le isCoboundedUnder_ratio
+    (by filter_upwards with N using density_ratio_le_one N)
+
+/-- When the natural density exists it coincides with the upper density (the
+`limsup` of a convergent sequence is its limit). -/
+theorem upperDensity_eq_of_hasNaturalDensity {d : ℝ} (h : HasNaturalDensity d) :
+    upperDensity = d :=
+  h.limsup_eq
+
+/-- If the solution set is finite, its upper density is `0`. -/
+theorem upperDensity_zero_of_finite
+    (hfin : ConsecutiveEqualTotients.Finite) : upperDensity = 0 :=
+  (hasNaturalDensity_zero_of_finite hfin).limsup_eq
+
+/-- A *positive upper density* already forces the solution set to be infinite —
+strengthening `infinite_of_pos_density`, since the upper density always exists
+whereas the natural-density limit may not.  (Proof: a finite set has upper
+density `0`.) -/
+theorem infinite_of_pos_upperDensity (h : 0 < upperDensity) :
+    ConsecutiveEqualTotients.Infinite := by
+  by_contra hfin
+  rw [Set.not_infinite] at hfin
+  rw [upperDensity_zero_of_finite hfin] at h
+  exact lt_irrefl 0 h
 
 end Erdos1003.OQ03

--- a/src/data/proofs/erdos-1003-oq-03/meta.json
+++ b/src/data/proofs/erdos-1003-oq-03/meta.json
@@ -20,9 +20,9 @@
     "badge": "verified",
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 177,
-    "theoremCount": 8,
-    "definitionCount": 3,
+    "lineCount": 256,
+    "theoremCount": 17,
+    "definitionCount": 4,
     "dateAdded": "2026-06-28",
     "assumptions": "0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound, the foundational Lean axioms). Fully machine-verified; no native_decide. Does NOT resolve the open question — it formalizes the logical scaffolding of the density question and its exact relationship to the (open) infinitude conjecture.",
     "originalContributions": [
@@ -30,7 +30,8 @@
       "infinite_of_pos_density: a positive natural density resolves #1003. If HasNaturalDensity d with d > 0, then the set is infinite. Proof: a finite set has density 0 (next item), so uniqueness of limits would force d = 0, a contradiction. Hence one cannot demonstrate any positive density without first proving the open infinitude conjecture — locating the difficulty of OQ-03 precisely.",
       "hasNaturalDensity_zero_of_finite: finiteness forces density 0. If the solution set is finite, countConsecutiveEqual N is uniformly bounded by its total cardinality C, so the ratio count/(N+1) is squeezed between 0 and C/(N+1) → 0. Consequence: the conjectured answer (density 0) is exactly the value any finite solution set would have, so 'density 0' alone is strictly weaker information than the infinitude conjecture.",
       "countConsecutiveEqual_monotone and countConsecutiveEqual_le: the counting function is monotone and bounded by N+1, and density_ratio_nonneg / density_ratio_le_one confine the density ratio to [0,1] — the elementary well-definedness facts underpinning the density predicate.",
-      "mem_filter_iff: the counted finset over Finset.range (N+1) is exactly the set of solutions ≤ N, the bookkeeping lemma threading the membership ↔ (is-a-solution ∧ ≤ N) correspondence through every proof."
+      "mem_filter_iff: the counted finset over Finset.range (N+1) is exactly the set of solutions ≤ N, the bookkeeping lemma threading the membership ↔ (is-a-solution ∧ ≤ N) correspondence through every proof.",
+      "infinite_of_pos_upperDensity (with upperDensity := limsup count(N)/(N+1)): a strengthening of infinite_of_pos_density. Since the natural-density LIMIT may fail to exist (its existence is itself part of the open question), the upper density (limsup) is the right unconditional carrier — it always exists for the bounded ratio sequence. We prove it lies in [0,1] (upperDensity_nonneg, upperDensity_le_one via the bounded/cobounded ratio lemmas), coincides with the natural density when the latter exists (upperDensity_eq_of_hasNaturalDensity, the limsup of a convergent sequence), and vanishes on finite solution sets (upperDensity_zero_of_finite). Hence a positive UPPER density already forces infinitude, with no need to assume the limit exists. Also hasNaturalDensity_unique (limit uniqueness) and hasNaturalDensity_mem_Icc (the density, when it exists, lies in [0,1])."
     ],
     "mathlibDependencies": [
       {
@@ -146,7 +147,8 @@
     "imports": [
       "Mathlib.Data.Nat.Totient",
       "Mathlib.Data.Set.Finite.Basic",
-      "Mathlib.Analysis.SpecificLimits.Basic"
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Topology.Algebra.Order.LiminfLimsup"
     ],
     "opens": [
       "Nat",
@@ -155,10 +157,10 @@
       "Topology"
     ],
     "namespace": "Erdos1003.OQ03",
-    "lineCount": 177,
+    "lineCount": 256,
     "axiomCount": 0,
-    "theoremCount": 8,
-    "definitionCount": 3,
+    "theoremCount": 17,
+    "definitionCount": 4,
     "path": "Proofs/Erdos1003OQ03.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/erdos-1003-oq-03.json
+++ b/src/data/research/problems/erdos-1003-oq-03.json
@@ -1,0 +1,116 @@
+{
+  "slug": "erdos-1003-oq-03",
+  "title": "What is the true asymptotic density of solutions",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "What is the true asymptotic density of solutions? | Open question (extension) from gallery proof 'erdos-1003'.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-06-28T00:58:16.003Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS (VERIFIED 0-axiom): added the upper-density (limsup) layer — the unconditional carrier of OQ-03, since the natural-density limit is not known to exist. Key strengthening infinite_of_pos_upperDensity (positive limsup ⇒ infinite) + density uniqueness/[0,1] range. OQ itself still open (needs EPS sparsity bound).",
+    "builtItems": [
+      "Erdos1003OQ03.lean: infinite_iff_count_unbounded, infinite_of_pos_density, hasNaturalDensity_zero_of_finite, count monotone/le, density ratio bounds, mem_filter_iff, def HasNaturalDensity — 177 lines, 8 thms, 3 defs, 0 sorry/0 axiom VERIFIED.",
+      "Gallery entry src/data/proofs/erdos-1003-oq-03 (meta + 5 annotations).",
+      "Erdos1003OQ03.lean (now 256 lines, 17 thm, 4 def, 0 sorry/0 axiom VERIFIED): added upperDensity (limsup) def + isBoundedUnder_ratio/isCoboundedUnder_ratio, upperDensity_nonneg, upperDensity_le_one, upperDensity_eq_of_hasNaturalDensity (=h.limsup_eq), upperDensity_zero_of_finite, infinite_of_pos_upperDensity, plus hasNaturalDensity_unique and hasNaturalDensity_mem_Icc."
+    ],
+    "insights": [
+      "OQ-03 (true asymptotic density of {n | φ(n)=φ(n+1)}) is open: set conjectured infinite (#1003, open even base case), density conjectured 0 (EPS bound x/exp((log x)^{1/3})).",
+      "Bridge: solution set infinite IFF counting function count(N)=#{n≤N: φ(n)=φ(n+1)} unbounded — connects density view to infinitude view of #1003/OQ-02.",
+      "Positive natural density ⇒ infinite (uniqueness of limits vs finite-set density-0), so OQ-03 positive regime is at least as hard as #1003.",
+      "Finiteness ⇒ density 0 (squeeze 0 ≤ count/(N+1) ≤ C/(N+1) → 0); conjectured value 0 is the finiteness baseline, strictly weaker than infinitude.",
+      "Upper density (limsup of count(N)/(N+1)) is the correct UNCONDITIONAL object for OQ-03: the natural-density LIMIT is not known to exist, but the limsup always exists for the bounded ratio sequence. This sharpens infinite_of_pos_density to infinite_of_pos_upperDensity — positive limsup forces infinitude without assuming convergence."
+    ],
+    "mathlibGaps": [
+      "EPS upper bound #{n≤x: φ(n)=φ(n+1)} ≤ x/exp((log x)^{1/3}) absent from Mathlib; cited as external input, not formalized."
+    ],
+    "nextSteps": [
+      "Formalize EPS sparsity bound for unconditional limsup density 0.",
+      "Formalize upper-density (limsup) vs limit; density existence is itself open.",
+      "Relate upperDensity = 0 to o(N) growth of countConsecutiveEqual (limsup characterisation), the unconditional restatement of the conjectured density-0 answer; EPS sparsity bound would then give upperDensity = 0 unconditionally — still the sole hard external input."
+    ]
+  },
+  "tags": [
+    "erdos",
+    "number-theory",
+    "totient-function",
+    "consecutive-values",
+    "asymptotic-density",
+    "open-problem"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-100",
+    "erdos-1003",
+    "erdos-1003-oq-02",
+    "erdos-1003-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-28T00:58:16.003Z",
+  "lastUpdate": "2026-06-28",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1003OQ02.lean",
+      "filename": "Erdos1003OQ02.lean",
+      "lineCount": 159,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos1003OQ03.lean",
+      "filename": "Erdos1003OQ03.lean",
+      "lineCount": 178,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003OQ03.lean"
+    },
+    {
+      "path": "Proofs/Erdos1003Problem.lean",
+      "filename": "Erdos1003Problem.lean",
+      "lineCount": 262,
+      "theoremCount": 0,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003Problem.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extends the Erdős #1003 OQ-03 density scaffolding (`Proofs.Erdos1003OQ03`) with the **upper density** — the unconditional carrier of the open question. The natural-density *limit* is not known to exist (its existence is itself part of OQ-03), so the `limsup` of the counting ratios `count(N)/(N+1)` is the correct object to reason about unconditionally.

## New results (0 sorry, 0 axiom, docker-verified)

| theorem | content |
|---|---|
| `upperDensity` | `limsup_N count(N)/(N+1)` — always exists (bounded sequence) |
| `upperDensity_nonneg`, `upperDensity_le_one` | upper density lies in `[0,1]` |
| `upperDensity_eq_of_hasNaturalDensity` | coincides with natural density when the limit exists (limsup of a convergent sequence) |
| `upperDensity_zero_of_finite` | finite solution set ⇒ upper density 0 |
| **`infinite_of_pos_upperDensity`** | **positive upper density ⇒ infinite** — strengthens `infinite_of_pos_density`: no need to assume the limit exists, only its limsup is positive |
| `hasNaturalDensity_unique`, `hasNaturalDensity_mem_Icc` | the natural density, when it exists, is unique and lies in `[0,1]` |

## Why this is progress

`infinite_of_pos_density` (existing) requires the density *limit* to exist and be positive. But existence of that limit is open. `infinite_of_pos_upperDensity` removes the existence hypothesis: since the `limsup` always exists, a positive *upper* density is a strictly weaker — hence more useful — sufficient condition for the (open) infinitude conjecture #1003.

## Honesty

Does **NOT** resolve OQ-03. The true density still requires the Erdős–Pomerance–Sárközy sparsity bound `#{n≤x: φ(n)=φ(n+1)} ≤ x/exp((log x)^{1/3})`, which is absent from Mathlib and cited only as external input. Only the standard foundational axioms (`propext`/`Classical.choice`/`Quot.sound`); no `native_decide`.

Lean file: 177 → 256 lines, 8 → 17 theorems, 3 → 4 defs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)