### PR TITLE
Enrich rational three-square necessity: add index.ts + setup section

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/index.ts
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ThreeSquaresRationalNecessity.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeFourSquaresWaringG2OQ03OQ06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeFourSquaresWaringG2OQ03OQ06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lagrangeFourSquaresWaringG2OQ03OQ06Data: ProofData = {
+  proof: lagrangeFourSquaresWaringG2OQ03OQ06Proof,
+  annotations: lagrangeFourSquaresWaringG2OQ03OQ06Annotations,
+}

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/meta.json
@@ -36,6 +36,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Context, imports, and namespace",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Docstring: this file records the UNCONDITIONAL content of the rational three-square characterization, combining ThreeSquares (Legendre necessity) and ThreeSquaresDavenportCassels (rational⇒integral descent). The genuinely open piece — rational sufficiency (Hasse–Minkowski, absent from Mathlib) — is carried only as a hypothesis. Import Mathlib + the three companion files; open ThreeSquares / ThreeSquaresRationalBridge.",
+      "mathContext": "Davenport–Cassels: for $x^2+y^2+z^2$, rational representability $\\Leftrightarrow$ integral; the excluded family is $4^a(8b+7)$."
+    },
+    {
       "id": "iff",
       "title": "The Davenport–Cassels Iff and Rational Necessity",
       "startLine": 44,


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-06` (passes: 0, quality: 86).

## Primary fix: missing `index.ts`
The entry had **no `index.ts`**, so the page rendered **'proof not found'**. Added via the standard template (`ThreeSquaresRationalNecessity.lean` source import).

## Section coverage completed
`sections` started at line 44, leaving the docstring + imports + namespace (1–43) unmapped. Prepended a `setup` section (1–43) with a LaTeX `mathContext`, so sections now cover the full 115-line file: setup 1–43, iff 44–72, scaling 74–100, conditional 102–115.

## Axiom integrity (checked)
`grep sorry` matches once, but that match is the **docstring prose** 'No `axiom`, no `sorry`, no `native_decide`'. The unconditional theorems are axiom-free; the final `three_rat_sq_iff_not_excluded` carries the open Hasse–Minkowski sufficiency as a **hypothesis argument**, not an axiom. `status: verified` / `axiomCount: 0` is accurate.

## Left as-is
`overview`, `conclusion`, and all 4 annotations (with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`) are complete. meta.json is 17.3 KB, under caps. JSON validates.