### PR TITLE
research(godel-second-incompleteness-oq02-oq-03): internalize the Löb boundary one box deep [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/GodelSecondIncompletenessOQ02OQ03.lean
+++ b/proofs/Proofs/GodelSecondIncompletenessOQ02OQ03.lean
@@ -92,7 +92,62 @@ theorem second_incompleteness (hcon : ¬ GL_proves GLFormula.falsum) :
   fun h => hcon (consistency_boundary.mp h)
 
 -- ============================================================
--- PART III: Summary
+-- PART III: The internalized (box-level) Löb boundary
+-- ============================================================
+
+/-! The boundary of Part I is *external*: it characterizes which reflection
+sentences GL proves about itself, viewed from the meta-level. A sharper question
+is whether GL *certifies that boundary internally* — i.e. whether the equivalence
+"`□A → A` is necessary ⟺ `A` is necessary" is itself a GL theorem. The answer is
+yes, at the box level: GL proves `□(□A → A) → □A` (its defining Löb axiom) and the
+converse `□A → □(□A → A)`, so it internalizes the boundary one box deep. The
+external `lob_theorem` then factors through this internal equivalence: necessitate
+the hypothesis, apply the box-level boundary to land on `□A`, and discharge with the
+hypothesis. -/
+
+/-- **GL internally certifies "provable ⟹ reflection".** GL proves
+    `□A → □(□A → A)`: whenever `A` is necessary, the reflection principle `□A → A`
+    is itself necessary. Derivation: `A → (□A → A)` is the propositional axiom `k1`;
+    necessitate it (`nec`) and distribute the box with the modal `K` axiom, then
+    modus ponens. This direction needs **no Löb axiom** — it holds already in `K`. -/
+theorem box_provable_imp_box_reflection (A : GLFormula) :
+    GL_proves (.impl (.box A) (.box (.impl (.box A) A))) :=
+  GL_proves.mp (GL_proves.k A (.impl (.box A) A))
+    (GL_proves.nec (GL_proves.taut (PropAxiom.k1 A (.box A))))
+
+/-- **GL internally certifies "reflection ⟹ provable".** GL proves
+    `□(□A → A) → □A`. This is exactly Löb's axiom `lob`; it is named here as the
+    converse of `box_provable_imp_box_reflection`, making the box-level boundary
+    symmetric. The fact that *this* direction is the one requiring the Löb axiom
+    (while the other holds in plain `K`) is precisely what makes GL the logic of
+    provability. -/
+theorem box_reflection_imp_box_provable (A : GLFormula) :
+    GL_proves (.impl (.box (.impl (.box A) A)) (.box A)) :=
+  GL_proves.lob A
+
+/-- **The internalized Löb boundary.** GL proves `□(□A → A)` if and only if GL
+    proves `□A`. This is the *necessitated* form of `reflection_iff_provable`: GL
+    certifies the necessity of the reflection principle exactly when it certifies the
+    necessity of `A`. Forward is Löb's axiom; backward is
+    `box_provable_imp_box_reflection`. Unlike the external boundary, both directions
+    here live one box deep, so this is a statement GL makes about its own provability
+    predicate rather than a meta-level observation about GL. -/
+theorem box_reflection_iff_box_provable (A : GLFormula) :
+    GL_proves (.box (.impl (.box A) A)) ↔ GL_proves (.box A) :=
+  ⟨fun h => GL_proves.mp (box_reflection_imp_box_provable A) h,
+   fun h => GL_proves.mp (box_provable_imp_box_reflection A) h⟩
+
+/-- **Internal form of Gödel's Second Incompleteness.** The `A = ⊥` instance of the
+    internalized boundary: GL proves `□Con = □(□⊥ → ⊥)` if and only if GL proves
+    `□⊥`. In words, GL *provably-proves* its own consistency exactly when it
+    *provably-proves* `⊥` — the box-level analogue of `consistency_boundary`. -/
+theorem box_consistency_boundary :
+    GL_proves (.box consistencyGL) ↔ GL_proves (.box GLFormula.falsum) := by
+  unfold consistencyGL GLFormula.not
+  exact box_reflection_iff_box_provable GLFormula.falsum
+
+-- ============================================================
+-- PART IV: Summary
 -- ============================================================
 
 /-- **Summary.** The Löb boundary, formalized end to end: GL proves `□A → A` iff it
@@ -103,5 +158,18 @@ theorem lob_boundary_verified :
     (GL_proves consistencyGL ↔ GL_proves GLFormula.falsum) ∧
     (¬ GL_proves GLFormula.falsum → ¬ GL_proves consistencyGL) :=
   ⟨reflection_iff_provable, consistency_boundary, second_incompleteness⟩
+
+/-- **Summary (internalized boundary).** The box-level Löb boundary, formalized end
+    to end: GL proves both implications of `□(□A → A) ↔ □A`, so GL proves
+    `□(□A → A)` iff it proves `□A`; specialised to `⊥`, GL proves `□Con` iff it
+    proves `□⊥`. GL therefore certifies its own Löb boundary internally, one box
+    deep. 0 axioms, 0 sorries. -/
+theorem internal_lob_boundary_verified :
+    (∀ A : GLFormula, GL_proves (.impl (.box A) (.box (.impl (.box A) A)))) ∧
+    (∀ A : GLFormula, GL_proves (.impl (.box (.impl (.box A) A)) (.box A))) ∧
+    (∀ A : GLFormula, GL_proves (.box (.impl (.box A) A)) ↔ GL_proves (.box A)) ∧
+    (GL_proves (.box consistencyGL) ↔ GL_proves (.box GLFormula.falsum)) :=
+  ⟨box_provable_imp_box_reflection, box_reflection_imp_box_provable,
+   box_reflection_iff_box_provable, box_consistency_boundary⟩
 
 end GodelSecondIncompletenessOQ02OQ03

--- a/src/data/proofs/godel-second-incompleteness-oq02-oq-03/meta.json
+++ b/src/data/proofs/godel-second-incompleteness-oq02-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "godel-second-incompleteness-oq02-oq-03",
   "title": "The Löb Boundary: GL Proves □A→A Exactly When It Proves A",
   "slug": "godel-second-incompleteness-oq02-oq-03",
-  "description": "A precise 'Löb boundary' theorem in the provability logic GL: the reflection principle □A → A is GL-provable if and only if A itself is GL-provable. Specializing to A = ⊥ recovers Gödel's Second Incompleteness theorem (GL proves its own consistency iff it is inconsistent). Purely syntactic on the GL Hilbert system; 0 sorries, 0 axioms.",
+  "description": "A precise 'Löb boundary' theorem in the provability logic GL: the reflection principle □A → A is GL-provable if and only if A itself is GL-provable. Specializing to A = ⊥ recovers Gödel's Second Incompleteness theorem (GL proves its own consistency iff it is inconsistent). The boundary is also internalized one box deep — GL proves □(□A → A) ↔ □A, certifying its own Löb boundary about its provability predicate. Purely syntactic on the GL Hilbert system; 0 sorries, 0 axioms.",
   "meta": {
     "author": "M.H. Löb (1955), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/L%C3%B6b%27s_theorem",
@@ -27,27 +27,33 @@
       "The Löb boundary: GL ⊢ (□A → A) ↔ GL ⊢ A — the precise characterization of which reflection-sentences GL proves about itself (fully proved)",
       "Consistency boundary (Gödel's Second, modal form): GL ⊢ Con ↔ GL ⊢ ⊥, where Con = ¬□⊥ (fully proved)",
       "Second Incompleteness contrapositive: GL consistent ⟹ GL ⊬ Con (fully proved)",
-      "Bundled summary theorem lob_boundary_verified"
+      "Bundled summary theorem lob_boundary_verified",
+      "Internalized boundary (forward): GL ⊢ □A → □(□A → A), holding already in K via nec(k1) + the K axiom (fully proved)",
+      "Internalized boundary (converse): GL ⊢ □(□A → A) → □A — exactly the Löb axiom, named for symmetry (fully proved)",
+      "The internalized Löb boundary: GL ⊢ □(□A → A) ↔ GL ⊢ □A — GL certifies its own boundary one box deep, as a statement about its provability predicate (fully proved)",
+      "Internal Second Incompleteness: GL ⊢ □Con ↔ GL ⊢ □⊥, the A = ⊥ box-level instance (fully proved)",
+      "Bundled summary theorem internal_lob_boundary_verified"
     ],
     "dateAdded": "2026-06-28",
     "axiomCount": 0,
-    "assumptions": "Fully verified: 0 axioms, 0 sorries. Results are purely syntactic, derived only from the GL_proves constructors (taut, k, lob, mp, nec) of the companion GL syntax file.",
-    "lineCount": 107,
+    "assumptions": "Fully verified: 0 axioms, 0 sorries. Results are purely syntactic, derived only from the GL_proves constructors (taut, k, lob, mp, nec) of the companion GL syntax file. All four new internalized-boundary theorems confirmed via `#print axioms` to depend on no axioms.",
+    "lineCount": 175,
     "mathlib_version": "4.26.0",
-    "theoremCount": 6,
+    "theoremCount": 11,
     "definitionCount": 1
   },
   "overview": {
     "historicalContext": "In 1955 Martin Löb solved a problem of Leon Henkin by proving what is now called Löb's theorem: a formal system F proves the reflection sentence 'if A is provable then A' only when F already proves A outright. This sharpened Gödel's Second Incompleteness theorem (1931), which is the special case A = ⊥: a consistent system cannot prove its own consistency. The provability logic GL (Gödel–Löb) of Boolos, Solovay, and others abstracts exactly the provability behaviour of arithmetic into a propositional modal logic whose box □ reads 'is provable', with Löb's axiom □(□A → A) → □A as its defining schema. This entry answers the parent's third open question — whether there is a precise 'Löb boundary' characterizing which sentences about a system's own provability the system proves — by formalizing, purely inside GL's Hilbert calculus, the biconditional GL ⊢ (□A → A) ↔ GL ⊢ A, and deriving the modal form of Gödel's Second Incompleteness theorem as its A = ⊥ instance.",
     "problemStatement": "Is there a precise 'Löb boundary' theorem characterizing which sentences about a system's own provability are provable in the system itself? Answer (in GL): $\\text{GL} \\vdash (\\Box A \\to A) \\iff \\text{GL} \\vdash A$.",
-    "text": "A 107-line, purely syntactic formalization built on the companion GL Hilbert system (GodelSecondIncompletenessOQ02GLSyntax). Part I proves Löb's theorem in derived-rule form — GL ⊢ (□A → A) ⟹ GL ⊢ A, by necessitating the hypothesis, applying the Löb axiom □(□A→A)→□A to get □A, and one more modus ponens — together with the easy converse via the propositional axiom k1, giving the boundary biconditional GL ⊢ (□A → A) ↔ GL ⊢ A. Part II specializes to A = ⊥: with Con := ¬□⊥ = (□⊥ → ⊥), the boundary reads GL ⊢ Con ↔ GL ⊢ ⊥, and contrapositively a consistent GL does not prove its own consistency — Gödel's Second Incompleteness theorem in modal form. Part III bundles everything. No arithmetic, no Kripke semantics, no Mathlib, 0 axioms, 0 sorries.",
+    "text": "A 175-line, purely syntactic formalization built on the companion GL Hilbert system (GodelSecondIncompletenessOQ02GLSyntax). Part I proves Löb's theorem in derived-rule form — GL ⊢ (□A → A) ⟹ GL ⊢ A, by necessitating the hypothesis, applying the Löb axiom □(□A→A)→□A to get □A, and one more modus ponens — together with the easy converse via the propositional axiom k1, giving the boundary biconditional GL ⊢ (□A → A) ↔ GL ⊢ A. Part II specializes to A = ⊥: with Con := ¬□⊥ = (□⊥ → ⊥), the boundary reads GL ⊢ Con ↔ GL ⊢ ⊥, and contrapositively a consistent GL does not prove its own consistency — Gödel's Second Incompleteness theorem in modal form. Part III internalizes the boundary one box deep: GL proves □A → □(□A→A) (already in K, via nec(k1) + the K axiom) and its converse □(□A→A) → □A (exactly the Löb axiom), so GL ⊢ □(□A→A) ↔ □A; the A = ⊥ instance gives GL ⊢ □Con ↔ □⊥. This shows GL does not merely satisfy the boundary externally but certifies it internally, as a statement about its own provability predicate. Part IV bundles everything. No arithmetic, no Kripke semantics, no Mathlib, 0 axioms, 0 sorries.",
     "proofStrategy": "Everything reduces to four GL_proves constructors. Löb's derived rule: from h : GL ⊢ □A→A, take nec h : GL ⊢ □(□A→A); the Löb axiom lob A : GL ⊢ □(□A→A)→□A; modus ponens gives GL ⊢ □A; a final modus ponens with h gives GL ⊢ A. The converse uses taut (k1 A □A) : GL ⊢ A→(□A→A) and modus ponens. The boundary biconditional packages the two directions. The consistency boundary is literally the A = ⊥ instance after unfolding Con = ¬□⊥ = (□⊥→⊥), and Second Incompleteness is its contrapositive. The proof is constructive and elementary once the GL calculus is in hand.",
     "keyInsights": [
       "Löb's theorem needs no fixed-point gymnastics at the modal level: in GL the diagonalization is already absorbed into the single axiom □(□A→A)→□A, so the derived rule GL⊢(□A→A) ⟹ GL⊢A is three constructor steps (nec, lob, mp) plus one more mp.",
       "The biconditional GL ⊢ (□A → A) ↔ GL ⊢ A is the sharp 'Löb boundary': a system proves a reflection fact about its own provability exactly at, and never beyond, the boundary of its own theorems.",
       "Gödel's Second Incompleteness theorem is not a separate result but the A = ⊥ instance of the boundary, since the consistency statement Con = ¬□⊥ is precisely the reflection sentence □⊥ → ⊥.",
       "Because the GL Hilbert system is an ordinary inductive predicate with no axioms, the whole development is `verified` (0 axioms) rather than `axiomatized` — the modal abstraction lets Second Incompleteness be machine-checked without modelling PA's proof predicate.",
-      "Soundness (the companion Soundness file) transfers these GL facts to PA: each GL theorem here translates to a genuine arithmetical theorem, so the modal Second Incompleteness corresponds to the arithmetical one."
+      "Soundness (the companion Soundness file) transfers these GL facts to PA: each GL theorem here translates to a genuine arithmetical theorem, so the modal Second Incompleteness corresponds to the arithmetical one.",
+      "The boundary internalizes: GL proves □(□A→A) ↔ □A, so GL certifies its own Löb boundary one box deep — not just a meta-level fact about GL, but a theorem GL states about its provability predicate. The asymmetry of the two directions is illuminating: □A → □(□A→A) holds already in plain K (it is nec of the propositional axiom k1 distributed by the K axiom), whereas the converse □(□A→A) → □A IS the Löb axiom. The single non-trivial modal commitment of GL is exactly the half of the internal boundary that K cannot supply."
     ],
     "prerequisites": [
       "Propositional and modal logic (Hilbert systems, modus ponens, necessitation)",
@@ -97,20 +103,29 @@
       "mathContext": "$\\text{GL consistent} \\;\\Rightarrow\\; \\text{GL} \\nvdash \\text{Con}$ — Gödel's Second Incompleteness theorem in modal form."
     },
     {
+      "id": "internalized-boundary",
+      "title": "The Internalized (Box-Level) Löb Boundary",
+      "summary": "GL proves □A → □(□A→A) (in plain K, via nec(k1) + the K axiom) and the converse □(□A→A) → □A (the Löb axiom), hence GL ⊢ □(□A→A) ↔ □A. The A = ⊥ instance gives GL ⊢ □Con ↔ □⊥. GL certifies its own boundary one box deep.",
+      "startLine": 94,
+      "endLine": 147,
+      "mathContext": "$\\text{GL}\\vdash \\Box(\\Box A\\to A) \\iff \\text{GL}\\vdash \\Box A$; the forward direction holds in $K$, the converse is Löb's axiom. At $A=\\bot$: $\\text{GL}\\vdash\\Box\\text{Con} \\iff \\text{GL}\\vdash\\Box\\bot$."
+    },
+    {
       "id": "summary",
-      "title": "Summary Theorem",
-      "summary": "Bundles the boundary biconditional, the consistency boundary, and Second Incompleteness into one statement.",
-      "startLine": 101,
-      "endLine": 107,
-      "mathContext": "$\\forall A,\\ \\text{GL}\\vdash(\\Box A\\to A)\\iff\\text{GL}\\vdash A$; $\\text{GL}\\vdash\\text{Con}\\iff\\text{GL}\\vdash\\bot$; consistent $\\Rightarrow \\nvdash\\text{Con}$."
+      "title": "Summary Theorems",
+      "summary": "Bundles the external boundary biconditional, the consistency boundary, and Second Incompleteness (lob_boundary_verified), and separately the internalized box-level boundary (internal_lob_boundary_verified).",
+      "startLine": 149,
+      "endLine": 175,
+      "mathContext": "$\\forall A,\\ \\text{GL}\\vdash(\\Box A\\to A)\\iff\\text{GL}\\vdash A$; $\\text{GL}\\vdash\\text{Con}\\iff\\text{GL}\\vdash\\bot$; and the box-level $\\forall A,\\ \\text{GL}\\vdash\\Box(\\Box A\\to A)\\iff\\text{GL}\\vdash\\Box A$."
     }
   ],
   "conclusion": {
-    "summary": "This entry answers the parent's third open question affirmatively with a precise Löb boundary theorem: in the provability logic GL, the reflection principle □A → A is provable exactly when A is provable. Gödel's Second Incompleteness theorem follows as the A = ⊥ instance. The development is purely syntactic over the GL Hilbert calculus, fully machine-checked with 0 axioms and 0 sorries.",
-    "implications": "Demonstrates that the self-referential heart of the incompleteness phenomena can be captured cleanly and axiom-freely at the modal level: once Löb's axiom is taken as the defining schema of GL, both Löb's theorem and Gödel's Second Incompleteness are short constructor-level derivations. The companion Soundness file lifts these modal facts to genuine arithmetical theorems about PA.",
+    "summary": "This entry answers the parent's third open question affirmatively with a precise Löb boundary theorem: in the provability logic GL, the reflection principle □A → A is provable exactly when A is provable. Gödel's Second Incompleteness theorem follows as the A = ⊥ instance. A later addition internalizes the boundary one box deep — GL proves □(□A → A) ↔ □A — showing GL certifies its own boundary as a statement about its provability predicate, with the internal Second Incompleteness GL ⊢ □Con ↔ □⊥ as the A = ⊥ case. The development is purely syntactic over the GL Hilbert calculus, fully machine-checked with 0 axioms and 0 sorries.",
+    "implications": "Demonstrates that the self-referential heart of the incompleteness phenomena can be captured cleanly and axiom-freely at the modal level: once Löb's axiom is taken as the defining schema of GL, both Löb's theorem and Gödel's Second Incompleteness are short constructor-level derivations. The internalized boundary further isolates GL's single non-trivial modal commitment: of the two halves of □(□A→A) ↔ □A, the forward direction □A → □(□A→A) already holds in plain K, while the converse □(□A→A) → □A is precisely the Löb axiom. The companion Soundness file lifts these modal facts to genuine arithmetical theorems about PA.",
     "openQuestions": [
       "Can the GL boundary be matched by a Kripke-semantic proof (the S5 ACT stage), giving forces_of_GL_proves and a semantic derivation of the same biconditional?",
-      "Can a quantitative 'boundary width' be formalized — e.g. characterizing the sentences A for which GL proves neither □A → A nor its negation — sharpening the qualitative boundary into an undecidability statement?"
+      "Does GL prove the transitivity schema 4 (□A → □□A)? If so, the internalized boundary would iterate to arbitrary box-depth: GL ⊢ □ⁿ(□A → A) ↔ □ⁿ A for all n. (The standard derivation of 4 from Löb's axiom requires conjunction-level propositional reasoning, hence a small deduction-theorem layer over the current Hilbert calculus.)",
+      "Can a quantitative 'boundary width' be formalized — e.g. characterizing the sentences A for which GL proves neither □A → A nor its negation — sharpening the qualitative boundary into an undecidability statement (which would require the semantic models of the first open question to establish non-provability)?"
     ]
   },
   "crossReferences": [
@@ -133,9 +148,9 @@
       "GodelSecondGLSyntax"
     ],
     "namespace": "GodelSecondIncompletenessOQ02OQ03",
-    "lineCount": 107,
+    "lineCount": 175,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 11,
     "definitionCount": 1,
     "mainTheorems": [
       "lob_theorem",
@@ -143,7 +158,12 @@
       "reflection_iff_provable",
       "consistency_boundary",
       "second_incompleteness",
-      "lob_boundary_verified"
+      "lob_boundary_verified",
+      "box_provable_imp_box_reflection",
+      "box_reflection_imp_box_provable",
+      "box_reflection_iff_box_provable",
+      "box_consistency_boundary",
+      "internal_lob_boundary_verified"
     ],
     "path": "Proofs/GodelSecondIncompletenessOQ02OQ03.lean",
     "sorries": 0

--- a/src/data/research/problems/godel-second-incompleteness-oq02-oq-03.json
+++ b/src/data/research/problems/godel-second-incompleteness-oq02-oq-03.json
@@ -17,41 +17,49 @@
   },
   "currentState": {
     "phase": "COMPLETED",
-    "iteration": 1,
-    "focus": "Solved: Löb boundary GL ⊢ (□A→A) ↔ GL ⊢ A formalized over the GL Hilbert system; Second Incompleteness as the A=⊥ instance. 0 axioms, 0 sorries.",
+    "iteration": 2,
+    "focus": "Extended: internalized the Löb boundary one box deep — GL ⊢ □(□A→A) ↔ □A, with internal Second Incompleteness GL ⊢ □Con ↔ □⊥. 4 new theorems + bundle, all 0-axiom (verified via #print axioms). 0 axioms, 0 sorries.",
     "blockers": [],
-    "nextAction": "Entry complete; PR opened.",
+    "nextAction": "Entry strengthened with box-level boundary; PR opened. Next directions: Kripke S5 ACT semantic proof; GL ⊢ 4 (□A→□□A) to iterate the internal boundary to arbitrary depth.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Löb boundary theorem GL ⊢ (□A→A) ↔ GL ⊢ A proved purely syntactically on the existing GL_proves Hilbert system; Gödel's Second Incompleteness (GL ⊢ Con ↔ GL ⊢ ⊥) recovered as the A=⊥ instance. VERIFIED, 0 axioms, 0 sorries.",
+    "progressSummary": "COMPLETE + EXTENDED: (1) External Löb boundary GL ⊢ (□A→A) ↔ GL ⊢ A and Second Incompleteness GL ⊢ Con ↔ GL ⊢ ⊥ (A=⊥ instance), proved purely syntactically on GL_proves. (2) NEW: internalized one box deep — GL ⊢ □(□A→A) ↔ □A, with internal Second Incompleteness GL ⊢ □Con ↔ □⊥. All 0-axiom (confirmed via #print axioms), 0 sorries. 11 theorems / 175 lines.",
     "builtItems": [
       "lob_theorem: GL_proves(□A→A) → GL_proves A via nec+lob+mp (Proofs/GodelSecondIncompletenessOQ02OQ03.lean:49)",
       "provable_imp_reflection: GL_proves A → GL_proves(□A→A) via taut(k1) (:58)",
-      "reflection_iff_provable: GL_proves(□A→A) ↔ GL_proves A — the Löb boundary (:66)",
+      "reflection_iff_provable: GL_proves(□A→A) ↔ GL_proves A — the external Löb boundary (:66)",
       "consistencyGL def = ¬□⊥ (:75)",
       "consistency_boundary: GL_proves Con ↔ GL_proves ⊥ (:81)",
       "second_incompleteness: ¬GL_proves ⊥ → ¬GL_proves Con (:90)",
-      "lob_boundary_verified: bundled summary (:101)"
+      "lob_boundary_verified: bundled external summary (:156)",
+      "box_provable_imp_box_reflection: GL ⊢ □A → □(□A→A) via nec(k1)+K+mp; holds in plain K (:113)",
+      "box_reflection_imp_box_provable: GL ⊢ □(□A→A) → □A = the Löb axiom (:124)",
+      "box_reflection_iff_box_provable: GL ⊢ □(□A→A) ↔ GL ⊢ □A — the internalized boundary (:135)",
+      "box_consistency_boundary: GL ⊢ □Con ↔ GL ⊢ □⊥ — internal Second Incompleteness (:144)",
+      "internal_lob_boundary_verified: bundled box-level summary (:167)"
     ],
     "insights": [
       "In GL, Löb's theorem needs no modal fixed point: diagonalization is absorbed into the axiom □(□A→A)→□A, so the derived rule is nec+lob+mp+mp.",
       "GL ⊢ (□A→A) ↔ GL ⊢ A is the sharp Löb boundary: a system proves a reflection sentence about its own provability exactly for its own theorems.",
       "Gödel's Second Incompleteness is the A=⊥ instance, since Con=¬□⊥ is the reflection sentence for ⊥.",
-      "The GL Hilbert system is an axiom-free inductive predicate, so the whole development is 'verified' (0 axioms), unlike the PA-modelling parent which is 'axiomatized'."
+      "The GL Hilbert system is an axiom-free inductive predicate, so the whole development is 'verified' (0 axioms), unlike the PA-modelling parent which is 'axiomatized'.",
+      "The boundary internalizes one box deep: GL ⊢ □(□A→A) ↔ □A. GL does not merely satisfy the boundary externally — it certifies it as a theorem about its own provability predicate.",
+      "Asymmetry of the internal boundary pins down GL's single non-trivial modal commitment: □A → □(□A→A) already holds in plain K (nec of the propositional k1 distributed by the K axiom), while the converse □(□A→A) → □A IS the Löb axiom."
     ],
     "mathlibGaps": [
       "None — built entirely on the existing companion GodelSecondIncompletenessOQ02GLSyntax (GL_proves constructors taut/k/lob/mp/nec); no Mathlib needed."
     ],
     "nextSteps": [
       "Follow-up: Kripke-semantic (S5 ACT) proof of the same boundary via forces_of_GL_proves.",
-      "Follow-up: characterize sentences A for which GL proves neither □A→A nor its negation (boundary width / undecidability)."
+      "Follow-up: prove GL ⊢ 4 (□A→□□A) — would let the internal boundary iterate to arbitrary box-depth □ⁿ(□A→A) ↔ □ⁿA; standard derivation from Löb needs conjunction-level propositional reasoning (a small deduction-theorem layer).",
+      "Follow-up: characterize sentences A for which GL proves neither □A→A nor its negation (boundary width / undecidability) — needs semantic models for non-provability."
     ],
-    "markdown": "# Knowledge Base: godel-second-incompleteness-oq02-oq-03\n\nSolved: the Löb boundary GL ⊢ (□A→A) ↔ GL ⊢ A, with Gödel's Second Incompleteness as the A=⊥ instance. Purely syntactic over the GL_proves Hilbert system; 0 axioms, 0 sorries. See Proofs/GodelSecondIncompletenessOQ02OQ03.lean.\n"
+    "markdown": "# Knowledge Base: godel-second-incompleteness-oq02-oq-03\n\nSolved + extended: the external Löb boundary GL ⊢ (□A→A) ↔ GL ⊢ A (with Gödel's Second Incompleteness as the A=⊥ instance), and the internalized box-level boundary GL ⊢ □(□A→A) ↔ □A (with internal Second Incompleteness GL ⊢ □Con ↔ □⊥). Purely syntactic over the GL_proves Hilbert system; 0 axioms, 0 sorries, 11 theorems. See Proofs/GodelSecondIncompletenessOQ02OQ03.lean.\n"
   },
   "tags": [
     "logic",


### PR DESCRIPTION
## Summary

Strengthens the existing **Löb Boundary** entry (`godel-second-incompleteness-oq02-oq-03`). The current entry proves the boundary *externally*:

$$\text{GL} \vdash (\Box A \to A) \iff \text{GL} \vdash A$$

This PR adds the **internalized (box-level) boundary**, showing GL does not merely satisfy the boundary as a meta-level fact but **certifies it internally**, as a theorem about its own provability predicate:

| Theorem | Statement | Proof |
|---|---|---|
| `box_provable_imp_box_reflection` | `GL ⊢ □A → □(□A → A)` | `nec(k1)` distributed by the `K` axiom — holds already in plain **K** |
| `box_reflection_imp_box_provable` | `GL ⊢ □(□A → A) → □A` | exactly **Löb's axiom** |
| `box_reflection_iff_box_provable` | `GL ⊢ □(□A → A) ↔ □A` | the internalized boundary |
| `box_consistency_boundary` | `GL ⊢ □Con ↔ □⊥` | `A = ⊥` instance — internal Second Incompleteness |
| `internal_lob_boundary_verified` | bundle of the above | |

## Why it matters

The two halves of the internal equivalence are asymmetric, and the asymmetry isolates **GL's single non-trivial modal commitment**: the forward direction `□A → □(□A→A)` already holds in plain **K**, whereas the converse `□(□A→A) → □A` *is* the Löb axiom. So the internalized boundary makes precise exactly which half of "reflection ⟺ provability" requires GL's defining schema.

## Verification

- Purely syntactic over the existing `GL_proves` Hilbert system (`GodelSecondIncompletenessOQ02GLSyntax`); **no Mathlib**.
- All four new theorems confirmed **0-axiom** via `#print axioms` (`does not depend on any axioms`).
- Compiled cleanly with the project toolchain (lean v4.26.0): the file and its (import-free) companion compile standalone with exit 0, 0 sorries.
- **6 → 11** theorems, **107 → 175** lines. Status remains `verified` (0 axioms, 0 sorries).
- Gallery `meta.json` and research `knowledge` updated (new section, contributions, insights, open questions).

## Follow-up directions recorded

- Kripke-semantic (S5) proof of the same boundary.
- Prove `GL ⊢ 4` (`□A → □□A`) to iterate the internal boundary to arbitrary box-depth `□ⁿ(□A→A) ↔ □ⁿA` (needs a small deduction-theorem layer for conjunction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)