### PR TITLE
Enrich Banach-Steinhaus resonance principle: add index.ts + setup sections

### DIFF
--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FourierDivergenceResonance.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const banachSteinhausTheoremOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const banachSteinhausTheoremOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const banachSteinhausTheoremOQ01OQ01Data: ProofData = {
+  proof: banachSteinhausTheoremOQ01OQ01Proof,
+  annotations: banachSteinhausTheoremOQ01OQ01Annotations,
+}

--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/meta.json
@@ -69,6 +69,22 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Target, scope, and status",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Import Mathlibs Banach-Steinhaus; docstring framing the target (a continuous 2pi-periodic function whose Fourier series diverges at a point) and the scope: this file isolates and verifies the FUNCTIONAL-ANALYSIS CORE (the resonance principle), ready to apply once the analytic input the Lebesgue constant tends to infinity is available; honest status note that the full Fourier-divergence theorem is not claimed.",
+      "mathContext": "Partial-sum functionals $S_n f = (S_n f)(0) = \\int f\\,D_n$, $\\|S_n\\| = \\|D_n\\|_{L^1}$ (Lebesgue constants) $\\to \\infty$; uniform boundedness forces a resonance point."
+    },
+    {
+      "id": "setup",
+      "title": "Opens, namespace, and Banach-space variables",
+      "startLine": 50,
+      "endLine": 58,
+      "summary": "Open Filter/Topology/Set; namespace; declare a complete normed space E over a nontrivially normed field and a normed space F - the abstract setting for the resonance principle.",
+      "mathContext": "$E$ Banach over $\\mathbb{K}$, $F$ normed; $g_i : E \\to_{L} F$ continuous linear maps."
+    },
+    {
       "id": "resonance-core",
       "title": "Resonance principle (contrapositive of uniform boundedness)",
       "startLine": 60,


### PR DESCRIPTION
Enrichment pass for `banach-steinhaus-theorem-oq-01-oq-01` (passes: 0, quality: 87).

## Primary fix: missing `index.ts`
The entry had **no `index.ts`**, so the page rendered **'proof not found'**. Added via the standard template (`FourierDivergenceResonance.lean` source import).

## Section coverage completed
`sections` started at line 60, leaving the docstring + opens + namespace + variables (1–58) unmapped. Added `overview` (1–49) and `setup` (50–58) sections with LaTeX `mathContext`, so sections now cover the full 95-line file: overview 1–49, setup 50–58, resonance-core 60–84, sequential-corollary 85–95.

## Axiom integrity (checked)
`grep sorry` matches twice, but both are **docstring prose** ('no `sorry`, no `axiom`'). The two theorems are complete. The entry honestly scopes itself to the **functional-analysis core** (resonance principle) — it does not claim the full Fourier-divergence theorem (which needs the still-missing Lebesgue-constant estimate). `status: verified` / `axiomCount: 0` is accurate.

## Left as-is
`overview`, `conclusion`, and all 4 annotations (with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`) are complete. meta.json is 10 KB. JSON validates.