### PR TITLE
Enrich Basel OQ-12 ζ(6)=π⁶/945: add index.ts + setup section

### DIFF
--- a/src/data/proofs/basel-problem-oq-12/index.ts
+++ b/src/data/proofs/basel-problem-oq-12/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BaselProblemOQ12.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const baselProblemOQ12Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const baselProblemOQ12Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const baselProblemOQ12Data: ProofData = {
+  proof: baselProblemOQ12Proof,
+  annotations: baselProblemOQ12Annotations,
+}

--- a/src/data/proofs/basel-problem-oq-12/meta.json
+++ b/src/data/proofs/basel-problem-oq-12/meta.json
@@ -74,6 +74,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Statement, Euler formula, and imports",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Docstring: ζ(6) = π⁶/945, the next Euler zeta value after ζ(2),ζ(4). Euler general formula ζ(2k) = (−1)^{k+1}·2^{2k−1}·π^{2k}·B_{2k}/(2k)! is Mathlibs hasSum_zeta_nat; at k=3 it reduces to the single Bernoulli number B₆=1/42 that Mathlib lacks (it stops at bernoulli_four). Import ZetaValues/Bernoulli/Tactic; open Real; namespace.",
+      "mathContext": "$\\zeta(6) = \\sum_{n\\ge 1} n^{-6} = (-1)^4\\,2^5\\,\\pi^6\\,B_6/6! = 32\\pi^6(1/42)/720 = \\pi^6/945$."
+    },
+    {
       "id": "bernoulli-six",
       "title": "The Bernoulli Number B₆ = 1/42",
       "startLine": 41,


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-12` (passes: 0, quality: 87).

## Primary fix: missing `index.ts`
The entry had **no `index.ts`**, so the page rendered **'proof not found'**. Added via the standard template (`BaselProblemOQ12.lean` source import).

## Section coverage completed
`sections` started at line 41, leaving the docstring (statement, Euler's ζ(2k) formula, the B₆ gap in Mathlib) and imports (1–36) unmapped. Prepended a `setup` section (1–36) with a LaTeX `mathContext`, so sections now cover the file: setup 1–36, bernoulli-six 41–56, zeta-six 58–76.

## Left as-is
`overview`, `conclusion`, and all 4 annotations (with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`) are complete. The genuine new content is `bernoulli'_six : bernoulli' 6 = 1/42` (Mathlib stops at `bernoulli'_four`), feeding `hasSum_zeta_nat`.

## Axiom integrity
0 sorries, 0 axioms — `status: verified` is accurate. meta.json is 9.1 KB. JSON validates.