### PR TITLE
Enrich ℤ[√d] irreducible-norm dichotomy: complete section coverage

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01/meta.json
@@ -77,6 +77,14 @@
   ],
   "sections": [
     {
+      "id": "setup",
+      "title": "Statement, strategy, and imports",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Docstring: classify irreducibles of ℤ[√d] by norm for −2 ≤ d < 0. The parent proved the SUFFICIENT half (prime-absolute-value norm ⇒ irreducible/prime); this file proves the NECESSARY half — an irreducible z has |N(z)| equal to a rational prime p or its square p² (split/ramified vs inert). Engine: z prime divides N(z)=z·z̄ ⇒ divides some ↑p ⇒ p²=|N(z)|·|N(w)| ⇒ |N(z)| ∣ p². Import the parent file; open Zsqrtd; namespace; variable d.",
+      "mathContext": "For $-2 \\le d < 0$: $z$ irreducible in $\\mathbb{Z}[\\sqrt d] \\Rightarrow |N(z)| \\in \\{p, p^2\\}$ for a rational prime $p$."
+    },
+    {
       "id": "sec-exists-prime-dvd",
       "title": "A prime element divides the image of a rational prime",
       "startLine": 46,


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01` (passes: 0, quality: 87).

## Gap addressed: incomplete `sections`
`sections` started at line 46, leaving the docstring (statement + strategy), imports, and namespace (1–45) unmapped. Prepended a `setup` section (1–45) with a LaTeX `mathContext` stating the dichotomy $|N(z)| \in \{p, p^2\}$, so sections now cover the full 130-line file: setup 1–45, sec-exists-prime-dvd 46–81, sec-norm-dichotomy 82–130.

## Left as-is
`index.ts`, `overview`, `conclusion`, and all 4 annotations (with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`) are complete. meta.json is 10.5 KB, under caps.

## Axiom integrity
0 sorries, 0 axioms — `status: verified` is accurate. JSON validates.