### PR TITLE
research(erdos-1020-oq-02): §9 — general crossover threshold for all r≥2 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1020OQ02.lean
+++ b/proofs/Proofs/Erdos1020OQ02.lean
@@ -346,4 +346,127 @@ example : construction2 8 4 2 = Nat.choose 7 3 := by decide
 /-- The top-summand bound, concretely at the crossover: `C(7, 3) = 35 ≤ construction2 8 4 2`. -/
 example : Nat.choose 7 3 ≤ construction2 8 4 2 := by decide
 
+/-! ### 9. The large-`n` regime exists for every `r ≥ 2`: an unconditional threshold.
+
+Sections 1–8 describe the *shape* of the transition, but for the actual *existence*
+of a crossover §6 handled only the worked instance `r = 4, k = 2`, by decidable
+evaluation. Here we prove the crossover exists for **every** `r ≥ 2`, `k ≥ 2`, with
+no case analysis — pinning down a single sharp threshold `n₀(r, k)`.
+
+The engine is a clean linear lower bound. The top-summand bound of §8
+(`construction2_ge_top_summand`) gives `C(n−1, r−1) ≤ construction2 n r k` for `k ≥ 2`,
+and a binomial grows at least linearly along its diagonal:
+`C(d + t, d) ≥ t + 1` for every `t` — each Pascal step
+`C(m+1, d) = C(m, d−1) + C(m, d)` adds the positive term `C(m, d−1) ≥ 1`. Chaining,
+
+  `construction2 n r k ≥ n − r + 1`   (`construction2_linear_lb`),
+
+which is unbounded in `n`. Since `construction1 r k` is *constant* in `n`,
+`construction2` must overtake it (`construction2_unbounded`,
+`construction2_eventually_dominant`) and — by the monotonicity of §1 — stay ahead.
+That yields a single threshold `n₀(r, k)` with
+
+  `construction1 r k ≤ construction2 n r k  ↔  n₀ ≤ n`   (for `n ≥ k`),
+
+the general form of `crossover_r4k2`. The hypothesis `r ≥ 2` is essential: for
+`r = 1`, `construction2 n 1 k = k − 1` is constant in `n` (`construction2_r1`), so the
+two constructions never strictly cross and no large-`n` regime exists. -/
+
+/-- A binomial coefficient grows at least linearly along its diagonal:
+    `C(d + t, d) ≥ t + 1` (here `d = c + 1 ≥ 1`). Each Pascal step
+    `C(m+1, d) = C(m, d−1) + C(m, d)` adds the positive term `C(m, d−1) ≥ 1`,
+    so the value climbs by at least one as `t` increases. -/
+theorem choose_diag_ge (c t : ℕ) : t + 1 ≤ Nat.choose (c + 1 + t) (c + 1) := by
+  induction t with
+  | zero => simp
+  | succ t ih =>
+    have h := Nat.choose_succ_succ (c + 1 + t) c
+    simp only [Nat.succ_eq_add_one] at h
+    have hpos : 1 ≤ Nat.choose (c + 1 + t) c := Nat.choose_pos (by omega)
+    have heq : c + 1 + (t + 1) = c + 1 + t + 1 := by omega
+    rw [heq, h]
+    omega
+
+/-- Linear lower bound: for `r ≥ 2`, `k ≥ 2` and `n` past both indices,
+    `construction2 n r k ≥ n − r + 1`. The §8 top-summand bound supplies
+    `C(n−1, r−1)`, and `choose_diag_ge` makes that binomial at least `n − r + 1`. -/
+theorem construction2_linear_lb (n r k : ℕ) (hr : r ≥ 2) (hk : k ≥ 2)
+    (hn : n ≥ r) (hnk : n ≥ k) :
+    n - r + 1 ≤ construction2 n r k := by
+  have htop : Nat.choose (n - 1) (r - 1) ≤ construction2 n r k :=
+    construction2_ge_top_summand n r k (by omega) hk hnk
+  have hdiag := choose_diag_ge (r - 2) (n - r)
+  have hidx : Nat.choose ((r - 2) + 1 + (n - r)) ((r - 2) + 1)
+      = Nat.choose (n - 1) (r - 1) := by
+    congr 1 <;> omega
+  rw [hidx] at hdiag
+  omega
+
+/-- `construction2` is unbounded in `n` (for `r ≥ 2`, `k ≥ 2`): it exceeds every `M`.
+    Immediate from the linear lower bound. -/
+theorem construction2_unbounded (r k : ℕ) (hr : r ≥ 2) (hk : k ≥ 2) (M : ℕ) :
+    ∃ n, M ≤ construction2 n r k := by
+  refine ⟨M + r + k, ?_⟩
+  have h := construction2_linear_lb (M + r + k) r k hr hk (by omega) (by omega)
+  omega
+
+/-- The large-`n` regime exists for every `r ≥ 2`, `k ≥ 2`: beyond some `N`,
+    `construction2` dominates the constant `construction1`. (Existence form;
+    `exists_threshold` upgrades this to a single sharp boundary.) -/
+theorem construction2_eventually_dominant (r k : ℕ) (hr : r ≥ 2) (hk : k ≥ 2) :
+    ∃ N, ∀ n, N ≤ n → construction1 r k ≤ construction2 n r k := by
+  refine ⟨construction1 r k + r + k, ?_⟩
+  intro n hn
+  have h := construction2_linear_lb n r k hr hk (by omega) (by omega)
+  omega
+
+/-- **General crossover threshold.** For every `r ≥ 2`, `k ≥ 2` there is a single
+    `n₀ ≥ k` such that, on the relevant range `n ≥ k`,
+    `construction1 r k ≤ construction2 n r k ↔ n₀ ≤ n`.
+    This is the general form of `crossover_r4k2` (which pins `n₀(4, 2) = 8`):
+    existence of the large-`n` regime (`construction2_eventually_dominant`) supplies
+    a least crossover point, and monotonicity (§1) makes the dominant region exactly
+    the up-set `[n₀, ∞)`. -/
+theorem exists_threshold (r k : ℕ) (hr : r ≥ 2) (hk : k ≥ 2) :
+    ∃ n₀, k ≤ n₀ ∧ ∀ n, k ≤ n →
+      (construction1 r k ≤ construction2 n r k ↔ n₀ ≤ n) := by
+  obtain ⟨N, hN⟩ := construction2_eventually_dominant r k hr hk
+  have hex : ∃ t, construction1 r k ≤ construction2 (k + t) r k :=
+    ⟨N, hN (k + N) (by omega)⟩
+  refine ⟨k + Nat.find hex, by omega, ?_⟩
+  intro n hn
+  obtain ⟨s, rfl⟩ : ∃ s, n = k + s := ⟨n - k, by omega⟩
+  constructor
+  · intro hP
+    have hfs : Nat.find hex ≤ s := Nat.find_min' hex hP
+    omega
+  · intro hle
+    have hfs : Nat.find hex ≤ s := by omega
+    have hspec : construction1 r k ≤ construction2 (k + Nat.find hex) r k :=
+      Nat.find_spec hex
+    have hmono : construction2 (k + Nat.find hex) r k ≤ construction2 (k + s) r k :=
+      construction2_mono (k + Nat.find hex) (k + s) r k (by omega) (by omega)
+        (by omega) (by omega)
+    exact le_trans hspec hmono
+
+/-! ### The `r = 1` boundary: no large-`n` regime.
+
+For `r = 1` the difference of binomials degenerates to a constant, so `construction2`
+never grows and the crossover analysis of §9 has no content — confirming that
+`r ≥ 2` is exactly the right hypothesis for the large-`n` regime. -/
+
+/-- For `r = 1`, `construction2 n 1 k = k − 1` is independent of `n`:
+    `C(n,1) − C(n−k+1,1) = n − (n−k+1) = k − 1`. -/
+theorem construction2_r1 (n k : ℕ) (hk : k ≥ 1) (hn : n ≥ k) :
+    construction2 n 1 k = k - 1 := by
+  unfold construction2
+  simp only [Nat.choose_one_right]
+  omega
+
+/-- Concrete linear lower bound at the crossover: `n − r + 1 = 5 ≤ 35 = construction2 8 4 2`. -/
+example : 8 - 4 + 1 ≤ construction2 8 4 2 := by decide
+
+/-- The `r = 1` degeneracy, concretely: `construction2 10 1 3 = k − 1 = 2`, constant in `n`. -/
+example : construction2 10 1 3 = 2 := by decide
+
 end Erdos1020OQ02

--- a/proofs/Proofs/Erdos1020OQ02.lean
+++ b/proofs/Proofs/Erdos1020OQ02.lean
@@ -281,4 +281,69 @@ theorem construction2_sum_card (n k : ℕ) (hk : k ≥ 1) (hn : n ≥ k) :
   rw [Nat.card_Ico]
   omega
 
+/-! ### 8. Window sandwich: `construction2` between `k − 1` copies of its endpoint summands.
+
+The §7 closed form writes `construction2 n r k` as a sum of exactly `k − 1`
+binomials `C(j, r−1)` with `j` ranging over the window `[n−k+1, n)`
+(`construction2_eq_sum`, `construction2_sum_card`). Because `C(·, r−1)` is monotone
+in its first argument, every summand lies between the two window endpoints
+`C(n−k+1, r−1)` (smallest) and `C(n−1, r−1)` (largest). Summing the `k − 1` terms
+gives a clean two-sided bound,
+
+  `(k−1)·C(n−k+1, r−1) ≤ construction2 n r k ≤ (k−1)·C(n−1, r−1)`,
+
+which sandwiches the difference-of-binomials between equal-width multiples of its
+endpoint binomials. For `k ≥ 2` the window is nonempty, so the top summand alone
+already gives `C(n−1, r−1) ≤ construction2 n r k` — the degree-`(r−1)` polynomial
+growth in `n` that eventually drives `construction2` past the constant
+`construction1` and produces the large-`n` regime. -/
+
+/-- Lower half of the window sandwich: every summand is at least the smallest
+    endpoint `C(n−k+1, r−1)`, and there are `k − 1` of them. -/
+theorem construction2_window_lb (n r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 1) (hn : n ≥ k) :
+    (k - 1) * Nat.choose (n - k + 1) (r - 1) ≤ construction2 n r k := by
+  rw [construction2_eq_sum n r k hr hk hn]
+  have hcard : (Finset.Ico (n - k + 1) n).card = k - 1 := construction2_sum_card n k hk hn
+  have hmin : ∀ j ∈ Finset.Ico (n - k + 1) n,
+      Nat.choose (n - k + 1) (r - 1) ≤ Nat.choose j (r - 1) := by
+    intro j hj
+    rw [Finset.mem_Ico] at hj
+    exact Nat.choose_le_choose (r - 1) hj.1
+  have h := Finset.card_nsmul_le_sum _ _ _ hmin
+  rw [hcard] at h
+  simpa using h
+
+/-- Upper half of the window sandwich: every summand is at most the largest
+    endpoint `C(n−1, r−1)`, and there are `k − 1` of them. -/
+theorem construction2_window_ub (n r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 1) (hn : n ≥ k) :
+    construction2 n r k ≤ (k - 1) * Nat.choose (n - 1) (r - 1) := by
+  rw [construction2_eq_sum n r k hr hk hn]
+  have hcard : (Finset.Ico (n - k + 1) n).card = k - 1 := construction2_sum_card n k hk hn
+  have hmax : ∀ j ∈ Finset.Ico (n - k + 1) n,
+      Nat.choose j (r - 1) ≤ Nat.choose (n - 1) (r - 1) := by
+    intro j hj
+    rw [Finset.mem_Ico] at hj
+    exact Nat.choose_le_choose (r - 1) (by omega)
+  have h := Finset.sum_le_card_nsmul _ _ _ hmax
+  rw [hcard] at h
+  simpa using h
+
+/-- For `k ≥ 2` the window `[n−k+1, n)` contains its top point `n − 1`, so the
+    largest summand `C(n−1, r−1)` alone is a lower bound for `construction2`.
+    This is the degree-`(r−1)` growth driving the large-`n` regime: a single
+    binomial of full degree already sits below the conjectured extremal value. -/
+theorem construction2_ge_top_summand (n r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 2) (hn : n ≥ k) :
+    Nat.choose (n - 1) (r - 1) ≤ construction2 n r k := by
+  rw [construction2_eq_sum n r k hr (by omega) hn]
+  refine Finset.single_le_sum (f := fun j => Nat.choose j (r - 1)) (fun i _ => Nat.zero_le _) ?_
+  rw [Finset.mem_Ico]; omega
+
+/-- Worked instance `r = 4, k = 2`: the window has a single point (`k − 1 = 1`),
+    so the sandwich is tight — both bounds equal `C(n−1, 3) = construction2 n 4 2`.
+    At `n = 8` this is `C(7, 3) = 35`, the crossover value `construction1 4 2`. -/
+example : construction2 8 4 2 = Nat.choose 7 3 := by decide
+
+/-- The top-summand bound, concretely at the crossover: `C(7, 3) = 35 ≤ construction2 8 4 2`. -/
+example : Nat.choose 7 3 ≤ construction2 8 4 2 := by decide
+
 end Erdos1020OQ02

--- a/src/data/research/problems/erdos-1020-oq-02.json
+++ b/src/data/research/problems/erdos-1020-oq-02.json
@@ -29,14 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "VERIFIED (0-axiom). §8 window sandwich: construction2 n r k between (k−1) copies of its endpoint binomial summands — (k−1)·C(n−k+1,r−1) ≤ construction2 ≤ (k−1)·C(n−1,r−1) — plus construction2_ge_top_summand (k≥2 ⟹ C(n−1,r−1) ≤ construction2, the degree-(r−1) growth driving the large-n regime). Builds on §7 closed form. Still OPEN: the Erdős Matching Conjecture middle band (r≥4).",
+    "progressSummary": "PROGRESS: §9 proves general unconditional crossover threshold exists for all r≥2,k≥2 (was only r=4,k=2). 0-axiom, PR #31622.",
     "builtItems": [
       "Proofs/Erdos1020OQ02.lean (165 lines, 0 axioms, 0 sorries, verified): construction2_mono_step, construction2_mono, construction2_dominant_up, conjecturedValue_mono, conjecturedValue_large, conjecturedValue_small + 5 kernel-decide crossover examples.",
       "Gallery entry src/data/proofs/erdos-1020-oq-02/ (meta.json + annotations.json).",
       "Proofs/Erdos1020OQ02.lean extended to 232 lines / 9 theorems (was 165/6): construction2_step_eq, construction2_strict_mono_step, crossover_r4k2 (exact threshold iff for r=4,k=2).",
       "construction2_window_lb (Erdos1020OQ02.lean §8): (k−1)·C(n−k+1,r−1) ≤ construction2 n r k — Finset.card_nsmul_le_sum on the §7 sum, smallest endpoint summand",
       "construction2_window_ub (§8): construction2 n r k ≤ (k−1)·C(n−1,r−1) — Finset.sum_le_card_nsmul, largest endpoint summand",
-      "construction2_ge_top_summand (§8): k≥2 ⟹ C(n−1,r−1) ≤ construction2 n r k — top window point n−1 via Finset.single_le_sum; degree-(r−1) growth lower bound"
+      "construction2_ge_top_summand (§8): k≥2 ⟹ C(n−1,r−1) ≤ construction2 n r k — top window point n−1 via Finset.single_le_sum; degree-(r−1) growth lower bound",
+      "choose_diag_ge, construction2_linear_lb (≥ n−r+1), construction2_unbounded, construction2_eventually_dominant, exists_threshold (Nat.find capstone: dominant region = up-set [n₀,∞) for n≥k), construction2_r1 (r=1 boundary = k−1 constant) in Erdos1020OQ02.lean §9. PR #31622, 0-axiom."
     ],
     "insights": [
       "construction1 r k = C(rk-1,r) is constant in n; construction2 n r k = C(n,r)-C(n-k+1,r) is monotone nondecreasing in n. The gap is the band around their crossover.",
@@ -45,14 +46,19 @@
       "conjecturedValue = max(const, monotone) is monotone in n; collapses to construction1 below threshold, construction2 at/above (max_eq_left/right).",
       "OQ-02 framed: regime boundary is a well-defined single threshold; the open difficulty is whether f attains the conjectured value across the gap band kr+... < n < 3kr² for r≥4.",
       "The crossover threshold IS characterizable exactly in a worked instance: monotonicity converts two boundary evaluations into a complete iff (construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n), giving n₀(4,2)=8 — partial progress on the 'characterize exact threshold' next step.",
-      "§8: the §7 closed form construction2 = Σ_{j∈[n−k+1,n)} C(j,r−1) has k−1 monotone summands, so it is sandwiched between (k−1)·C(n−k+1,r−1) and (k−1)·C(n−1,r−1). For k≥2 the top summand C(n−1,r−1) alone lower-bounds it — a single binomial of full degree r−1 already sits below the conjectured extremal value, exposing the polynomial growth behind the large-n regime."
+      "§8: the §7 closed form construction2 = Σ_{j∈[n−k+1,n)} C(j,r−1) has k−1 monotone summands, so it is sandwiched between (k−1)·C(n−k+1,r−1) and (k−1)·C(n−1,r−1). For k≥2 the top summand C(n−1,r−1) alone lower-bounds it — a single binomial of full degree r−1 already sits below the conjectured extremal value, exposing the polynomial growth behind the large-n regime.",
+      "§9: the large-n regime exists for ALL r≥2,k≥2 — not just the worked r=4,k=2 instance of §6. A constant (construction1) is eventually overtaken by a polynomial-growth difference of binomials (construction2).",
+      "Key engine: C(d+t,d) ≥ t+1 (choose_diag_ge) — binomials grow ≥ linearly along the diagonal via one Pascal step adding a positive term. Mathlib has no clean ℕ lower bound on choose (only real-valued pow_le_choose), so this 6-line induction fills the gap."
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "Mathlib lacks an elementary ℕ-valued lower bound on Nat.choose growing in the first argument (Bounds.lean only has real-valued pow_le_choose with fishy ℕ-subtraction). choose_diag_ge could be upstreamed."
+    ],
     "nextSteps": [
       "Open: prove the Erdős Matching Conjecture across the middle band (r≥4) — the actual gap closure.",
       "Decide whether extremal hypergraphs interpolate between the two constructions inside the gap.",
       "Generalize crossover_r4k2 to a closed-form threshold n₀(r,k) for all r,k (instance r=4,k=2 done).",
-      "Prove construction2 → ∞ (k≥2) to establish threshold EXISTENCE for general r,k, not just the worked instance."
+      "Prove construction2 → ∞ (k≥2) to establish threshold EXISTENCE for general r,k, not just the worked instance.",
+      "§10 candidate: extract the EXPLICIT threshold n₀(r,k) bound (exists_threshold gives existence via Nat.find but no closed value); e.g. show n₀ ≤ construction1 r k + r. Or: compare growth rates construction1 vs construction2 to bound n₀ above by a polynomial in r,k."
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-1020-oq-02.json
+++ b/src/data/research/problems/erdos-1020-oq-02.json
@@ -29,11 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "VERIFIED (0-axiom). Created gallery entry erdos-1020-oq-02 + Proofs/Erdos1020OQ02.lean. Did NOT resolve the open gap (Erdős Matching Conjecture, OPEN r≥4); instead formalized the unconditional structure of the small-n/large-n regime transition of the conjectured value max(construction1, construction2): construction2 monotone in n (Pascal telescoping), dominance region upward-closed (single threshold), conjecturedValue monotone, collapse on each side. Worked instance r=4,k=2 crossover at n=8 by kernel decide. [Session 2] Added 3 verified theorems sharpening the transition: construction2_step_eq (EXACT step difference = C(n,r-1)-C(n-k+1,r-1), the equality behind the old inequality), construction2_strict_mono_step (strict refinement), and crossover_r4k2 — the SHARP crossover threshold for r=4,k=2: construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n (n₀=8). All 0-axiom (decide, not native_decide). File now 232 lines, 9 theorems.",
+    "progressSummary": "VERIFIED (0-axiom). §8 window sandwich: construction2 n r k between (k−1) copies of its endpoint binomial summands — (k−1)·C(n−k+1,r−1) ≤ construction2 ≤ (k−1)·C(n−1,r−1) — plus construction2_ge_top_summand (k≥2 ⟹ C(n−1,r−1) ≤ construction2, the degree-(r−1) growth driving the large-n regime). Builds on §7 closed form. Still OPEN: the Erdős Matching Conjecture middle band (r≥4).",
     "builtItems": [
       "Proofs/Erdos1020OQ02.lean (165 lines, 0 axioms, 0 sorries, verified): construction2_mono_step, construction2_mono, construction2_dominant_up, conjecturedValue_mono, conjecturedValue_large, conjecturedValue_small + 5 kernel-decide crossover examples.",
       "Gallery entry src/data/proofs/erdos-1020-oq-02/ (meta.json + annotations.json).",
-      "Proofs/Erdos1020OQ02.lean extended to 232 lines / 9 theorems (was 165/6): construction2_step_eq, construction2_strict_mono_step, crossover_r4k2 (exact threshold iff for r=4,k=2)."
+      "Proofs/Erdos1020OQ02.lean extended to 232 lines / 9 theorems (was 165/6): construction2_step_eq, construction2_strict_mono_step, crossover_r4k2 (exact threshold iff for r=4,k=2).",
+      "construction2_window_lb (Erdos1020OQ02.lean §8): (k−1)·C(n−k+1,r−1) ≤ construction2 n r k — Finset.card_nsmul_le_sum on the §7 sum, smallest endpoint summand",
+      "construction2_window_ub (§8): construction2 n r k ≤ (k−1)·C(n−1,r−1) — Finset.sum_le_card_nsmul, largest endpoint summand",
+      "construction2_ge_top_summand (§8): k≥2 ⟹ C(n−1,r−1) ≤ construction2 n r k — top window point n−1 via Finset.single_le_sum; degree-(r−1) growth lower bound"
     ],
     "insights": [
       "construction1 r k = C(rk-1,r) is constant in n; construction2 n r k = C(n,r)-C(n-k+1,r) is monotone nondecreasing in n. The gap is the band around their crossover.",
@@ -41,7 +44,8 @@
       "Monotonicity ⇒ the construction2-dominant region is upward-closed: a SINGLE threshold separates small-n and large-n regimes (no interleaving).",
       "conjecturedValue = max(const, monotone) is monotone in n; collapses to construction1 below threshold, construction2 at/above (max_eq_left/right).",
       "OQ-02 framed: regime boundary is a well-defined single threshold; the open difficulty is whether f attains the conjectured value across the gap band kr+... < n < 3kr² for r≥4.",
-      "The crossover threshold IS characterizable exactly in a worked instance: monotonicity converts two boundary evaluations into a complete iff (construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n), giving n₀(4,2)=8 — partial progress on the 'characterize exact threshold' next step."
+      "The crossover threshold IS characterizable exactly in a worked instance: monotonicity converts two boundary evaluations into a complete iff (construction1 4 2 ≤ construction2 n 4 2 ⇔ 8 ≤ n), giving n₀(4,2)=8 — partial progress on the 'characterize exact threshold' next step.",
+      "§8: the §7 closed form construction2 = Σ_{j∈[n−k+1,n)} C(j,r−1) has k−1 monotone summands, so it is sandwiched between (k−1)·C(n−k+1,r−1) and (k−1)·C(n−1,r−1). For k≥2 the top summand C(n−1,r−1) alone lower-bounds it — a single binomial of full degree r−1 already sits below the conjectured extremal value, exposing the polynomial growth behind the large-n regime."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## §9 — The large-n regime exists for **every** r ≥ 2, k ≥ 2

Erdős Problem #1020 (Erdős Matching Conjecture), OQ-02: the small-n / large-n regime transition. The conjectured extremal value is `max(construction1 r k, construction2 n r k)`, with `construction1` constant in `n` and `construction2` the maximiser for large `n`.

§1–§8 pinned down the *shape* of the transition, but for the actual *existence* of a crossover, §6 handled only the worked instance `r = 4, k = 2` (by `decide`). **This section proves the crossover exists unconditionally for every `r ≥ 2`, `k ≥ 2`**, with no case analysis.

### New results
- **`choose_diag_ge`**: `C(d+t, d) ≥ t + 1` — a binomial grows at least linearly along its diagonal. Each Pascal step `C(m+1,d) = C(m,d−1) + C(m,d)` adds the positive term `C(m,d−1) ≥ 1`.
- **`construction2_linear_lb`**: `construction2 n r k ≥ n − r + 1`, chaining the §8 top-summand bound `C(n−1, r−1) ≤ construction2` with `choose_diag_ge`.
- **`construction2_unbounded`** / **`construction2_eventually_dominant`**: `construction2` is unbounded and eventually exceeds the constant `construction1`.
- **`exists_threshold`** (capstone): a single sharp `n₀ ≥ k` with
  `construction1 r k ≤ construction2 n r k ↔ n₀ ≤ n` for `n ≥ k` — the general form of `crossover_r4k2` (which pins `n₀(4,2) = 8`), via `Nat.find` + §1 monotonicity.
- **`construction2_r1`**: the `r = 1` boundary, `construction2 n 1 k = k − 1` (constant in `n`), confirming `r ≥ 2` is exactly the right hypothesis for the large-n regime.

### Verification
- **0-axiom**: `#print axioms` on `exists_threshold`, `construction2_linear_lb`, `choose_diag_ge` reports only `propext, Classical.choice, Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`. No `native_decide`, no `sorry`.
- The Docker daemon was down (host disk-full crashed it mid-session); verified instead via host `lake env lean Proofs/Erdos1020OQ02.lean` against the prebuilt mathlib olean cache (exit 0, zero errors). Re-run under docker once the daemon recovers.

Stacked on §8 (#31597); until that merges this diff also shows §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)