### PR TITLE
research(erdos-490-incomplete-01): eliminate optimal_has_distinct_products axiom (3→2) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos490Problem.lean
+++ b/proofs/Proofs/Erdos490Problem.lean
@@ -59,7 +59,40 @@ def ProductMapInjective (A B : Finset ℕ) : Prop :=
   ∀ a₁ a₂ b₁ b₂, a₁ ∈ A → a₂ ∈ A → b₁ ∈ B → b₂ ∈ B →
     a₁ * b₁ = a₂ * b₂ → (a₁ = a₂ ∧ b₁ = b₂)
 
-/- The two definitions `HasDistinctProducts` and `ProductMapInjective` are equivalent. -/
+/-- The product set `A·B` is exactly the image of the product map `(a, b) ↦ a·b`
+on `A ×ˢ B`. -/
+theorem productSet_eq_image (A B : Finset ℕ) :
+    productSet A B = (A ×ˢ B).image (fun p : ℕ × ℕ => p.1 * p.2) := by
+  ext n
+  simp only [productSet, Finset.mem_biUnion, Finset.mem_image, Finset.mem_product]
+  constructor
+  · rintro ⟨a, ha, b, hb, rfl⟩; exact ⟨(a, b), ⟨ha, hb⟩, rfl⟩
+  · rintro ⟨⟨a, b⟩, ⟨ha, hb⟩, rfl⟩; exact ⟨a, ha, b, hb, rfl⟩
+
+/-- **`HasDistinctProducts` is injectivity of the product map.**  The cardinality
+condition `|A·B| = |A||B|` holds iff `(a, b) ↦ a·b` is injective on `A ×ˢ B`
+(via `Finset.card_image_iff`). -/
+theorem hasDistinctProducts_iff_injOn (A B : Finset ℕ) :
+    HasDistinctProducts A B ↔ Set.InjOn (fun p : ℕ × ℕ => p.1 * p.2) ↑(A ×ˢ B) := by
+  rw [HasDistinctProducts, productSet_eq_image, ← Finset.card_product A B,
+    Finset.card_image_iff]
+
+/-- **The two distinctness notions agree.**  `ProductMapInjective` (the elementwise
+quantified form) is equivalent to `HasDistinctProducts` (the cardinality form). -/
+theorem productMapInjective_iff_hasDistinctProducts (A B : Finset ℕ) :
+    ProductMapInjective A B ↔ HasDistinctProducts A B := by
+  rw [hasDistinctProducts_iff_injOn]
+  constructor
+  · intro h
+    rintro ⟨a₁, b₁⟩ hx ⟨a₂, b₂⟩ hy hfxy
+    rw [Finset.mem_coe, Finset.mem_product] at hx hy
+    have := h a₁ a₂ b₁ b₂ hx.1 hy.1 hx.2 hy.2 hfxy
+    rw [Prod.mk.injEq]; exact this
+  · intro h a₁ a₂ b₁ b₂ ha₁ ha₂ hb₁ hb₂ heq
+    have hx : ((a₁, b₁) : ℕ × ℕ) ∈ A ×ˢ B := Finset.mem_product.mpr ⟨ha₁, hb₁⟩
+    have hy : ((a₂, b₂) : ℕ × ℕ) ∈ A ×ˢ B := Finset.mem_product.mpr ⟨ha₂, hb₂⟩
+    have := h (Finset.mem_coe.mpr hx) (Finset.mem_coe.mpr hy) heq
+    rw [Prod.mk.injEq] at this; exact this
 /-
 ## Part II: The Erdős Question
 -/
@@ -125,9 +158,9 @@ def optimalA (N : ℕ) : Finset ℕ :=
 def optimalB (N : ℕ) : Finset ℕ :=
   Finset.filter (fun p => Nat.Prime p ∧ N / 2 < p ∧ p ≤ N) (Finset.range (N + 1))
 
-/-- The optimal example has distinct products. -/
-axiom optimal_has_distinct_products (N : ℕ) (hN : N ≥ 4) :
-  HasDistinctProducts (optimalA N) (optimalB N)
+/- The optimal example has distinct products.  **Proved** (0-axiom) as
+`optimal_has_distinct_products` below, once the elementwise distinctness lemma
+`optimal_works_because_primes` is available; placed there to respect dependency order. -/
 
 /-- The first half is exactly `Icc 1 (N/2)`, so it has `⌊N/2⌋` elements. -/
 theorem optimalA_card (N : ℕ) : (optimalA N).card = N / 2 := by
@@ -219,6 +252,24 @@ theorem optimal_works_because_primes (a₁ a₂ : ℕ) (p₁ p₂ : ℕ)
   have hp₁_pos : 0 < p₁ := hp₁.pos
   have : a₁ * p₁ = a₂ * p₁ := by rw [heq, hp₁p₂]
   exact Nat.eq_of_mul_eq_mul_right hp₁_pos this
+
+/-- **The optimal example has distinct products** (0-axiom).  Formerly an axiom;
+now derived from `optimal_works_because_primes` via the
+`ProductMapInjective ↔ HasDistinctProducts` bridge.  Every `a ∈ optimalA N` lies in
+`[1, N/2]` (so `1 ≤ a` and `a ≤ N/2`) and every `p ∈ optimalB N` is a prime in
+`(N/2, N]`, exactly the hypotheses of `optimal_works_because_primes`. -/
+theorem optimal_has_distinct_products (N : ℕ) (hN : N ≥ 4) :
+    HasDistinctProducts (optimalA N) (optimalB N) := by
+  rw [← productMapInjective_iff_hasDistinctProducts]
+  intro a₁ a₂ b₁ b₂ ha₁ ha₂ hb₁ hb₂ heq
+  simp only [optimalA, Finset.mem_filter, Finset.mem_range] at ha₁ ha₂
+  simp only [optimalB, Finset.mem_filter, Finset.mem_range] at hb₁ hb₂
+  obtain ⟨_, ha₁1, ha₁2⟩ := ha₁
+  obtain ⟨_, ha₂1, ha₂2⟩ := ha₂
+  obtain ⟨_, hb₁p, hb₁lt, _⟩ := hb₁
+  obtain ⟨_, hb₂p, hb₂lt, _⟩ := hb₂
+  exact optimal_works_because_primes a₁ a₂ b₁ b₂ ha₁1 ha₂1 ha₁2 ha₂2
+    hb₁p hb₂p hb₁lt hb₂lt heq
 
 /-
 ## Part V: The Limit Question (Open)

--- a/research/problems/erdos-490-incomplete-01/knowledge.md
+++ b/research/problems/erdos-490-incomplete-01/knowledge.md
@@ -131,3 +131,46 @@ theoremCount→13, assumptions rewritten, stale "sorried" section prose correcte
   `π(N)−π(N/2)` built from Mathlib's Bertrand/`centralBinom` machinery — a multi-session
   infrastructure effort, not a single sorry. Optional bridge:
   `(optimalB N).card = N.primeCounting − (N/2).primeCounting`.
+
+## Session 2026-06-30 (researcher-3) — AXIOM ELIMINATED: optimal_has_distinct_products (3 → 2 axioms)
+
+**Mode**: ACT (axiom hunt). **Outcome**: progress — eliminated the axiom
+`optimal_has_distinct_products`, proving it 0-axiom from existing lemmas. Axiom
+count 3 → 2 (only `szemeredi_theorem` and `primes_upper_half_lower_bound` remain,
+both genuinely deep/analytic).
+
+### What I Did (verified, 0-axiom)
+The file already contained `optimal_works_because_primes` (the elementwise fact:
+`a₁p₁ = a₂p₂` with `aᵢ∈[1,N/2]`, `pᵢ` prime `>N/2` ⟹ `a₁=a₂ ∧ p₁=p₂`, via prime
+divisibility). The axiom `optimal_has_distinct_products` was just the packaged
+`HasDistinctProducts (optimalA N) (optimalB N)` form of that. Bridged them:
+- `productSet_eq_image`: `productSet A B = (A ×ˢ B).image (·.1 * ·.2)`.
+- `hasDistinctProducts_iff_injOn`: `HasDistinctProducts A B ↔ Set.InjOn (·.1*·.2) ↑(A×ˢB)`
+  — one `rw` chain: `HasDistinctProducts, productSet_eq_image, ← card_product, card_image_iff`.
+- `productMapInjective_iff_hasDistinctProducts`: the elementwise `ProductMapInjective`
+  def (which was defined but never used!) equals `HasDistinctProducts`.
+- `optimal_has_distinct_products` (now a theorem): `rw [← productMapInjective_iff_…]`,
+  unfold `optimalA`/`optimalB` filter membership, feed `optimal_works_because_primes`.
+
+`#print axioms optimal_has_distinct_products = [propext, Classical.choice, Quot.sound]`.
+
+### Gotchas / API
+- `Finset.card_image_iff : #(s.image f) = #s ↔ Set.InjOn f ↑s` is the clean bridge
+  (same one `distinct_minimal_energy` used internally — I extracted it as a reusable lemma).
+- `Set.InjOn f ↑s` unpacks with `rintro ⟨a₁,b₁⟩ hx ⟨a₂,b₂⟩ hy hfxy` then
+  `Finset.mem_coe, Finset.mem_product` on the hyps; conclude with `Prod.mk.injEq`.
+- A placeholder comment left where the `axiom` was MUST be a plain `/- -/` block, not
+  `/-- -/` doc-comment — an unattached doc-comment gives `unexpected token '/--'; expected lemma`.
+- `optimal_works_because_primes` has auto-bound implicit `{N}`; it unifies from the
+  `aᵢ ≤ N/2` hypotheses, so no explicit `N` arg needed.
+
+### Status
+File 506 → 557 lines, axioms 3 → 2, theorems 14 → 16, sorries 0. Host
+`lake env lean Proofs/Erdos490Problem.lean` EXIT 0. Gallery meta updated
+(axiomCount 3→2, lineCount, theoremCount, originalContributions).
+
+### Still open (NOT done here)
+- `szemeredi_theorem` (Szemerédi 1976 upper bound) — deep, correctly axiomatized.
+- `primes_upper_half_lower_bound` (Chebyshev π(N)−π(N/2) ≳ N/log N) — needs central-binomial
+  infrastructure absent from the Mathlib pin (only an UPPER prime-count bound exists);
+  multi-session build. `optimalB_card_eq_primeCounting` already pins it to `Nat.primeCounting`.

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -60,7 +60,6 @@
       "ErdosQuestion490: formal ∃C, |A||B| ≤ CN²/log N",
       "szemeredi_theorem axiom: Szemerédi's 1976 upper bound",
       "optimalA, optimalB: extremal construction with primes > N/2",
-      "optimal_has_distinct_products axiom: construction is valid",
       "optimal_works_because_primes: divisibility argument (proved)",
       "optimalA_card: |optimalA N| = ⌊N/2⌋ (0-axiom, proved)",
       "optimalB_card_eq_primeCounting: |optimalB N| = π(N) − π(N/2) via Mathlib's Nat.primeCounting (0-axiom, proved) — pins the Chebyshev axiom to Mathlib's prime-counting API",
@@ -68,7 +67,11 @@
       "productRatio, LimitQuestion: open limit formalization",
       "IsMultiplicativeSidon: A = B special case",
       "multiplicativeEnergy: counting quadruples a₁b₁ = a₂b₂",
-      "bound_is_optimal: matching lower bound (proved from the 3 axioms, 0 sorries)"
+      "bound_is_optimal: matching lower bound (proved from the 3 axioms, 0 sorries)",
+      "optimal_has_distinct_products: PROVED 0-axiom (formerly an axiom) — the optimal construction A=[1,N/2], B=primes in (N/2,N] has distinct products, derived from optimal_works_because_primes via the ProductMapInjective↔HasDistinctProducts bridge",
+      "hasDistinctProducts_iff_injOn: HasDistinctProducts A B ↔ injectivity of (a,b)↦a·b on A×ˢB (via Finset.card_image_iff)",
+      "productMapInjective_iff_hasDistinctProducts: the two distinctness notions agree",
+      "productSet_eq_image: productSet A B = image of product map on A×ˢB"
     ],
     "axiomCount": 3,
     "lineCount": 506,
@@ -205,9 +208,9 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 506,
-    "axiomCount": 3,
-    "theoremCount": 14,
+    "lineCount": 557,
+    "axiomCount": 2,
+    "theoremCount": 16,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-490-incomplete-01.json
+++ b/src/data/research/problems/erdos-490-incomplete-01.json
@@ -26,7 +26,7 @@
         ]
     },
     "currentState": {
-        "summary": "DONE (build-repair + full sorry elimination). File builds against Mathlib 4.26 with 0 sorries and 3 axioms (szemeredi_theorem, optimal_has_distinct_products, primes_upper_half_lower_bound). All tractable sorries discharged; the only remaining assumptions are the three deep/analytic axioms, each explicitly stated and documented. The Chebyshev prime-counting axiom is the single irreducible analytic input absent from the current Mathlib pin.",
+        "summary": "DONE (build-repair + full sorry elimination + axiom reduction). File builds against Mathlib 4.26 with 0 sorries and 2 axioms (szemeredi_theorem, primes_upper_half_lower_bound). The former axiom optimal_has_distinct_products is now PROVED 0-axiom from optimal_works_because_primes via a ProductMapInjective↔HasDistinctProducts bridge. The two remaining axioms are the deep Szemerédi upper bound and the irreducible Chebyshev prime-counting lower bound absent from the current Mathlib pin.",
         "outcome": "progress"
     },
     "knowledge": {
@@ -36,14 +36,18 @@
             "distinct_minimal_energy is a real iff but needs fiber-counting (energy = ∑ r(p)², |A||B| = ∑ r(p)); deferred.",
             "the lower bound in bound_is_optimal needs π(N) − π(N/2) ~ N/(2 log N), a Chebyshev/PNT estimate; deferred.",
             "bound_is_optimal cannot use a fixed lower-bound constant: the product ratio |A||B|·log N/N² dips to ≈0.115 at N=10, so only the ∃c>0 form is true; the file's old hardcoded 1/3 was false.",
-            "optimalA N = Finset.Icc 1 (N/2), so |optimalA N| = N/2 exactly (proved 0-axiom via Finset.ext + Nat.card_Icc + omega)."
+            "optimalA N = Finset.Icc 1 (N/2), so |optimalA N| = N/2 exactly (proved 0-axiom via Finset.ext + Nat.card_Icc + omega).",
+            "optimal_has_distinct_products is NOT a real axiom: it follows from optimal_works_because_primes (already proved) once you bridge the elementwise ProductMapInjective definition to the cardinality-based HasDistinctProducts via Finset.card_image_iff. Eliminated 2026-06-30, axioms 3→2."
         ],
         "builtItems": [
             "Build repair: Nat.card_Icc, open scoped Classical, orphan-comment fixes (Erdos490Problem.lean)",
             "optimal_works_because_primes: proved (Erdos490Problem.lean)",
             "two IsSubsetUpTo subgoals in bound_is_optimal: proved",
             "primes_products_determine_pair: new correct lemma replacing false primes_sidon",
-            "optimalB_card_eq_primeCounting: |optimalB N| = N.primeCounting - (N/2).primeCounting (0-axiom) — bridges the Chebyshev axiom to Mathlib's Nat.primeCounting API"
+            "optimalB_card_eq_primeCounting: |optimalB N| = N.primeCounting - (N/2).primeCounting (0-axiom) — bridges the Chebyshev axiom to Mathlib's Nat.primeCounting API",
+            "hasDistinctProducts_iff_injOn: HasDistinctProducts A B ↔ Set.InjOn (·.1*·.2) on A×ˢB (0-axiom bridge)",
+            "productMapInjective_iff_hasDistinctProducts + productSet_eq_image (0-axiom)",
+            "optimal_has_distinct_products: converted axiom→theorem (0-axiom, derived from optimal_works_because_primes)"
         ],
         "mathlibGaps": [
             "No prime-counting lower bound (π(N) − π(N/2)) readily available for the optimal-example lower bound."
@@ -52,7 +56,7 @@
             "Eliminate primes_upper_half_lower_bound by proving a Chebyshev lower bound π(N)−π(N/2) ≳ N/log N from Mathlib primitives (Bertrand/centralBinom machinery) — a multi-session infrastructure effort; Mathlib's Nat.primeCounting currently has only an upper bound. With optimalB_card_eq_primeCounting in place, the axiom can be restated purely against Nat.primeCounting: ∃ c>0, c*N/log N ≤ ↑(N.primeCounting - (N/2).primeCounting).",
             "DONE (2026-06-30): proved (optimalB N).card = N.primeCounting - (N/2).primeCounting (optimalB_card_eq_primeCounting), bridging the axiom to Mathlib's primeCounting API."
         ],
-        "progressSummary": "2026-06-30 (researcher-3): added optimalB_card_eq_primeCounting — the 0-axiom combinatorial half of primes_upper_half_lower_bound, proving |optimalB N| = π(N)−π(N/2) in Mathlib's Nat.primeCounting API (partition primes ≤ N by exceeding N/2 via Finset.filter_card_add_filter_neg_card_eq_card; Nat.count_eq_card_filter_range). Axiom count unchanged (3), 0 sorries, builds against Mathlib 4.26. PR #31517. EARLIER 2026-06-28 (researcher-3): eliminated the last sorry — proved optimalA_card (|optimalA N| = ⌊N/2⌋, 0-axiom) and discharged the bound_is_optimal lower bound by isolating the one irreducible Chebyshev prime-counting input as the axiom primes_upper_half_lower_bound; switched bound_is_optimal to its honest ∃c>0 form (the previously hardcoded 1/3 is FALSE at small N, e.g. N=10 product ratio ≈0.115)."
+        "progressSummary": "2026-06-30 (researcher-3): AXIOM ELIMINATED — proved optimal_has_distinct_products (formerly an axiom) 0-axiom by bridging the elementwise ProductMapInjective definition to the cardinality HasDistinctProducts (hasDistinctProducts_iff_injOn via Finset.card_image_iff) and feeding the existing optimal_works_because_primes. Axioms 3→2 (szemeredi_theorem, primes_upper_half_lower_bound remain — both deep/analytic). File 506→557 lines, 14→16 theorems, 0 sorries, builds against Mathlib 4.26. 2026-06-30 (researcher-3): added optimalB_card_eq_primeCounting — the 0-axiom combinatorial half of primes_upper_half_lower_bound, proving |optimalB N| = π(N)−π(N/2) in Mathlib's Nat.primeCounting API (partition primes ≤ N by exceeding N/2 via Finset.filter_card_add_filter_neg_card_eq_card; Nat.count_eq_card_filter_range). Axiom count unchanged (3), 0 sorries, builds against Mathlib 4.26. PR #31517. EARLIER 2026-06-28 (researcher-3): eliminated the last sorry — proved optimalA_card (|optimalA N| = ⌊N/2⌋, 0-axiom) and discharged the bound_is_optimal lower bound by isolating the one irreducible Chebyshev prime-counting input as the axiom primes_upper_half_lower_bound; switched bound_is_optimal to its honest ∃c>0 form (the previously hardcoded 1/3 is FALSE at small N, e.g. N=10 product ratio ≈0.115)."
     },
     "knownResults": {
         "established": [
@@ -74,9 +78,9 @@
         {
             "path": "Proofs/Erdos490Problem.lean",
             "filename": "Erdos490Problem.lean",
-            "lineCount": 506,
-            "theoremCount": 14,
-            "axiomCount": 3,
+            "lineCount": 557,
+            "theoremCount": 16,
+            "axiomCount": 2,
             "defCount": 15,
             "sorryCount": 0,
             "isAristotle": false,


### PR DESCRIPTION
## Summary

Erdős #490 (distinct products, |A||B| ≪ N²/log N). **Axiom elimination**: the former
axiom `optimal_has_distinct_products` — the optimal construction A = [1, N/2],
B = primes in (N/2, N] has distinct products — is now a **0-axiom theorem**, derived
from the already-proven `optimal_works_because_primes`.

Axiom count **3 → 2**. The two remaining axioms (`szemeredi_theorem`,
`primes_upper_half_lower_bound`) are genuinely deep/analytic and correctly axiomatized.

## What changed

The elementwise distinctness fact (`a₁p₁ = a₂p₂`, `aᵢ ∈ [1,N/2]`, `pᵢ` prime `> N/2`
⟹ `a₁=a₂ ∧ p₁=p₂`, via prime divisibility) was already proven as
`optimal_works_because_primes`. The axiom was merely its packaged `HasDistinctProducts`
form. Bridged the two:

- `productSet_eq_image`: `productSet A B = (A ×ˢ B).image (·.1 * ·.2)`
- `hasDistinctProducts_iff_injOn`: `HasDistinctProducts A B ↔ Set.InjOn (·.1*·.2) ↑(A ×ˢ B)`
  (one `rw` chain through `Finset.card_image_iff`)
- `productMapInjective_iff_hasDistinctProducts`: the elementwise `ProductMapInjective`
  definition (previously defined but unused) equals the cardinality-based `HasDistinctProducts`
- `optimal_has_distinct_products`: now a theorem, `rw [← productMapInjective_iff_…]` +
  unfold `optimalA`/`optimalB` membership + `optimal_works_because_primes`

## Verification

- Host `lake env lean Proofs/Erdos490Problem.lean` → **EXIT 0** (pre-existing unused-var warnings only)
- `#print axioms optimal_has_distinct_products` = `[propext, Classical.choice, Quot.sound]` (0-axiom)
- File 506 → 557 lines, 14 → 16 theorems, **0 sorries**, axioms **3 → 2**
- Gallery meta + problem JSON + knowledge.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)