### PR TITLE
research(van-der-waerden-first-moment-oq-01): exact AP count via parametrization injectivity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1011OQ03.lean
+++ b/proofs/Proofs/Erdos1011OQ03.lean
@@ -23,6 +23,15 @@
      `f_five_le_f_four : f 5 n ≤ f 4 n` — the open value f_5(n) is bounded above
      by the now-known f_4(n).
 
+  1b. `forces_iff_f_le` — a complete characterization of the threshold:
+     `Forces r n m ↔ f r n ≤ m`. The forcing predicate is an up-set in the edge
+     bound (`forces_mono`), so `f r n` is exactly its least element.
+
+  1c. `f_eq_zero_of_lt` — the left boundary of the table: once `r` exceeds the
+     vertex count `n`, no `n`-vertex graph attains `χ ≥ r` (every such graph is
+     `n`-colourable, `chromaticNumber_le_card`), so the forcing condition is
+     vacuous and `f r n = 0`. The antitone-in-`r` value has bottomed out.
+
   2. The **vertex-shift pattern**. The shifts in the formulas above are
      0, 1, 3 for r = 2, 3, 4 — exactly C(r-1, 2). The pattern predicts a shift
      of C(4,2) = 6 for r = 5, i.e. a conjectured leading term ⌊(n-6)²/4⌋.
@@ -56,7 +65,7 @@ clean facts (`f_mem`, `f_le_of_forces`).
 /-- The predicate defining membership in the set `{m | … }` whose `sInf` is
     `f r n`. -/
 def Forces (r n m : ℕ) : Prop :=
-  ∀ (V : Type*) [Fintype V] [DecidableEq V],
+  ∀ (V : Type) [Fintype V] [DecidableEq V],
     Fintype.card V = n →
     ∀ (G : SimpleGraph V) [DecidableRel G.Adj],
       hasChromatic G r → edgeCount G ≥ m → HasTriangle G
@@ -67,7 +76,6 @@ def Forces (r n m : ℕ) : Prop :=
 theorem forces_nonempty (n r : ℕ) : {m | Forces r n m}.Nonempty := by
   refine ⟨n.choose 2 + 1, ?_⟩
   intro V instF instD hcard G instA _ hedge
-  haveI := instF; haveI := instD; haveI := instA
   exfalso
   have hb : edgeCount G ≤ n.choose 2 := by
     have h := G.card_edgeFinset_le_card_choose_two
@@ -86,6 +94,22 @@ theorem f_le_of_forces {n r m : ℕ} (hm : Forces r n m) : f r n ≤ m := by
   unfold f
   exact Nat.sInf_le hm
 
+/-- The forcing predicate is monotone (an up-set) in the edge bound: if `m`
+    edges force a triangle, so does any larger bound `m'`, because the
+    hypothesis `edgeCount G ≥ m'` is stronger than `edgeCount G ≥ m`. -/
+theorem forces_mono {r n m m' : ℕ} (hm : Forces r n m) (hmm : m ≤ m') :
+    Forces r n m' := by
+  intro V instF instD hcard G instA hchrom hedge
+  exact hm V hcard G hchrom (le_trans hmm hedge)
+
+/-- **Complete characterization of the threshold.** `m` forces a triangle iff
+    `m` is at least the threshold `f r n`. The forward direction is
+    `f_le_of_forces`; the reverse uses that `f r n` itself forces (`f_forces`)
+    together with up-set monotonicity (`forces_mono`). This pins down `f r n`
+    as exactly the least `m` in the up-set `{m | Forces r n m}`. -/
+theorem forces_iff_f_le {r n m : ℕ} : Forces r n m ↔ f r n ≤ m :=
+  ⟨f_le_of_forces, fun h => forces_mono (f_forces n r) h⟩
+
 /-
 ## Main structural theorem: antitonicity in the chromatic parameter
 
@@ -102,7 +126,6 @@ theorem f_antitone_in_chromatic {n r r' : ℕ} (h : r ≤ r') :
     f r' n ≤ f r n := by
   apply f_le_of_forces
   intro V instF instD hcard G instA hchrom hedge
-  haveI := instF; haveI := instD; haveI := instA
   have hchrom' : hasChromatic G r := le_trans h hchrom
   exact f_forces n r V hcard G hchrom' hedge
 
@@ -117,6 +140,36 @@ theorem f_chain (n : ℕ) : f 5 n ≤ f 4 n ∧ f 4 n ≤ f 3 n ∧ f 3 n ≤ f 
   ⟨f_antitone_in_chromatic (by norm_num),
    f_antitone_in_chromatic (by norm_num),
    f_antitone_in_chromatic (by norm_num)⟩
+
+/-
+## The degenerate regime: r > n forces the threshold to 0
+
+A graph on `n` vertices can be properly coloured with `n` colours (the identity
+colouring `V ≃ Fin n` is proper), so `χ(G) ≤ n`. Hence once `r > n` the
+hypothesis `χ(G) ≥ r` is unsatisfiable and the forcing implication holds
+vacuously for *every* edge bound — including `m = 0`. So `f r n = 0` there.
+This is the exact left boundary of the table: the antitone-in-`r` value
+`f r n` has already bottomed out at 0 by the time `r` exceeds the vertex count.
+-/
+
+/-- Any `n`-vertex graph is `n`-colourable, hence `χ(G) ≤ n`. The identity
+    bijection `V ≃ Fin (card V)` is a proper colouring because adjacent vertices
+    are distinct and the bijection is injective. -/
+theorem chromaticNumber_le_card {W : Type*} [Fintype W] [DecidableEq W]
+    (G : SimpleGraph W) : chromaticNumber G ≤ Fintype.card W :=
+  Nat.sInf_le ⟨Fintype.equivFin W, fun _ _ hadj heq =>
+    G.ne_of_adj hadj ((Fintype.equivFin W).injective heq)⟩
+
+/-- **Boundary value.** If the required chromatic number exceeds the vertex
+    count (`n < r`) then `f r n = 0`: no `n`-vertex graph attains `χ ≥ r`, so the
+    forcing condition is vacuous at every edge bound. -/
+theorem f_eq_zero_of_lt {r n : ℕ} (h : n < r) : f r n = 0 := by
+  refine Nat.le_antisymm (f_le_of_forces ?_) (Nat.zero_le _)
+  intro V instF instD hcard G instA hchrom _
+  exfalso
+  unfold hasChromatic at hchrom
+  have hle : chromaticNumber G ≤ n := hcard ▸ chromaticNumber_le_card G
+  omega
 
 /-
 ## The vertex-shift pattern
@@ -146,10 +199,7 @@ theorem chromaticShift_eq (r : ℕ) : chromaticShift r = (r - 1) * (r - 2) / 2 :
 theorem chromaticShift_mono : Monotone chromaticShift := by
   intro a b hab
   unfold chromaticShift
-  first
-    | exact Nat.choose_le_choose 2 (by omega)
-    | (gcongr; omega)
-    | exact Nat.choose_mono 2 (by omega)
+  exact Nat.choose_le_choose 2 (by omega)
 
 /-
 ## The open statements
@@ -175,6 +225,10 @@ theorem shiftConjecture_imp_f5 (h : shiftConjecture) : f5Conjecture := by
 
 #check f_antitone_in_chromatic
 #check f_five_le_f_four
+#check forces_iff_f_le
+#check f_eq_zero_of_lt
 #check chromaticShift_known
 #print axioms f_antitone_in_chromatic
+#print axioms forces_iff_f_le
+#print axioms f_eq_zero_of_lt
 #print axioms chromaticShift_known

--- a/proofs/Proofs/Erdos1011Problem.lean
+++ b/proofs/Proofs/Erdos1011Problem.lean
@@ -57,9 +57,14 @@ f_r(n) is minimal such that chromatic number ≥ r and ≥ f_r(n) edges implies 
 def hasChromatic (G : SimpleGraph V) (r : ℕ) : Prop :=
   chromaticNumber G ≥ r
 
-/-- The threshold function f_r(n) -/
+/-- The threshold function f_r(n). The vertex type is quantified over `Type`
+    (rather than `Type*`): since the predicate constrains `Fintype.card V = n`,
+    every finite vertex set is equivalent to one in `Type 0`, so the value is
+    unchanged while `f` stays universe-monomorphic — this prevents a free
+    universe parameter from leaking into the `Prop`-valued conjectures that
+    mention `f` (e.g. in `Proofs.Erdos1011OQ03`). -/
 noncomputable def f (r n : ℕ) : ℕ :=
-  sInf {m : ℕ | ∀ (V : Type*) [Fintype V] [DecidableEq V],
+  sInf {m : ℕ | ∀ (V : Type) [Fintype V] [DecidableEq V],
     Fintype.card V = n →
     ∀ G : SimpleGraph V, [DecidableRel G.Adj] →
     hasChromatic G r → edgeCount G ≥ m → HasTriangle G}
@@ -105,18 +110,24 @@ def f4Threshold (n : ℕ) : ℕ := (n - 3)^2 / 4 + 6
 f_r(n) = n²/4 - g(r)·n/2 + O(1)
 -/
 
-/-- g(r): vertices to remove from χ ≥ r triangle-free graph to make bipartite -/
+/-- g(r): vertices to remove from χ ≥ r triangle-free graph to make bipartite.
+    Existential type binders are written with anonymous instance hypotheses
+    `(_ : Fintype V)` (instance brackets `[…]` are not valid inside `∃`), and the
+    witness type is fixed to `Type` so `g` is universe-monomorphic — otherwise the
+    free universe parameter leaks into the `Prop`-valued conjectures below. `g`
+    only feeds the asymptotic axioms/conjectures; no verified theorem depends on
+    its precise value. -/
 noncomputable def g (r : ℕ) : ℕ :=
-  sSup {k : ℕ | ∃ (V : Type*) [Fintype V] [DecidableEq V],
-    ∃ G : SimpleGraph V, [DecidableRel G.Adj] →
+  sSup {k : ℕ | ∃ (V : Type) (_ : Fintype V) (_ : DecidableEq V)
+      (G : SimpleGraph V),
     ¬HasTriangle G ∧ hasChromatic G r ∧
-    ∀ S : Finset V, S.card < k → ¬∃ (W : Type*) [Fintype W],
-      ∃ H : SimpleGraph W, chromaticNumber H ≤ 2}
+    ∀ S : Finset V, S.card < k → ¬ ∃ (W : Type) (_ : Fintype W)
+      (H : SimpleGraph W), chromaticNumber H ≤ 2}
 
 /-- Simonovits asymptotic formula -/
 axiom simonovits_asymptotic :
   ∀ r ≥ 2, ∃ C : ℕ, ∀ n ≥ r,
-    |((f r n : ℤ) - n^2/4 + (g r : ℤ) * n / 2)| ≤ C
+    |((f r n : ℤ) - (n : ℤ) ^ 2 / 4 + (g r : ℤ) * (n : ℤ) / 2)| ≤ (C : ℤ)
 
 /-
 ## Bounds on g(r)

--- a/proofs/Proofs/VanDerWaerdenFirstMomentOQ01.lean
+++ b/proofs/Proofs/VanDerWaerdenFirstMomentOQ01.lean
@@ -149,4 +149,125 @@ theorem vdw_lower_bound_sharp {k : ℕ} (hk : 2 ≤ k)
   have hdn : d ≤ (k - 1) * d := Nat.le_mul_of_pos_left d (by omega)
   exact ⟨⟨by omega, hd, by omega⟩, hb⟩
 
+/-! ## Exact AP count: the parametrization is injective on the fitting box
+
+The bounds above use `card_vdwFamily_le_sum`, the *inequality* `|family| ≤ ∑ …`,
+which only needs `Finset.card_image_le`.  In fact the parametrization
+`(a, d) ↦ vdwAP n a d k` is *injective* on the fitting box (for `k ≥ 2`): a length-`k`
+AP with positive step is an increasing list, so its first term `a` is the minimum of
+the set and its last term `a + (k-1)d` is the maximum.  From the set alone one recovers
+both extremes, hence `a` and (cancelling `k-1`) the step `d`.  Injectivity upgrades the
+image-cardinality inequality to an **exact count**:
+
+      |{length-`k` APs in [n]}|  =  ∑_{d=1}^{n} (n - (k-1)·d).      (card_vdwFamily_eq_sum)
+
+So the triangular sum is not merely an upper bound on the number of fitting APs — it is
+their exact number, and the factor-2 estimate `2(k-1)|family| ≤ n²` is the *exact* count
+fed through `two_mul_sum_sq_le`. -/
+
+/-- The first term `↑a` is a point of the AP (the `i = 0` term). -/
+theorem vdwAP_mem_first {a d k : ℕ} (hk : 1 ≤ k) :
+    (↑a : Fin n) ∈ vdwAP n a d k := by
+  rw [vdwAP, Finset.mem_image]
+  exact ⟨0, Finset.mem_range.2 (by omega), by simp⟩
+
+/-- The last term `↑(a + (k-1)d)` is a point of the AP (the `i = k-1` term). -/
+theorem vdwAP_mem_last {a d k : ℕ} (hk : 1 ≤ k) :
+    (↑(a + (k - 1) * d) : Fin n) ∈ vdwAP n a d k := by
+  rw [vdwAP, Finset.mem_image]
+  exact ⟨k - 1, Finset.mem_range.2 (by omega), rfl⟩
+
+/-- **`↑a` is the minimum.** Every point of a fitting AP is `≥ ↑a`: the `i`-th term has
+value `a + i·d ≥ a`, and both stay below `n` so the `Fin n` order matches ℕ order. -/
+theorem vdwAP_first_le {a d k : ℕ} (_hd : 1 ≤ d) (hbound : a + (k - 1) * d < n) :
+    ∀ x ∈ vdwAP n a d k, (↑a : Fin n) ≤ x := by
+  intro x hx
+  rw [vdwAP, Finset.mem_image] at hx
+  obtain ⟨i, hi, rfl⟩ := hx
+  rw [Finset.mem_range] at hi
+  have hidx : a + i * d < n := by
+    have : i * d ≤ (k - 1) * d := Nat.mul_le_mul_right d (by omega)
+    omega
+  rw [Fin.le_iff_val_le_val, Fin.val_cast_of_lt (by omega : a < n), Fin.val_cast_of_lt hidx]
+  omega
+
+/-- **`↑(a + (k-1)d)` is the maximum.** Every point of a fitting AP is `≤ ↑(a+(k-1)d)`:
+the `i`-th term has value `a + i·d ≤ a + (k-1)d`, both below `n`. -/
+theorem vdwAP_le_last {a d k : ℕ} (_hd : 1 ≤ d) (hbound : a + (k - 1) * d < n) :
+    ∀ x ∈ vdwAP n a d k, x ≤ (↑(a + (k - 1) * d) : Fin n) := by
+  intro x hx
+  rw [vdwAP, Finset.mem_image] at hx
+  obtain ⟨i, hi, rfl⟩ := hx
+  rw [Finset.mem_range] at hi
+  have hle : i * d ≤ (k - 1) * d := Nat.mul_le_mul_right d (by omega)
+  have hidx : a + i * d < n := by omega
+  rw [Fin.le_iff_val_le_val, Fin.val_cast_of_lt hidx, Fin.val_cast_of_lt hbound]
+  omega
+
+/-- **The parametrization is injective on the fitting box.**
+For `k ≥ 2`, distinct fitting pairs `(a, d)` give distinct APs.  Recover `a` as the set's
+minimum (`vdwAP_first_le` + `vdwAP_mem_first`) and `a + (k-1)d` as its maximum
+(`vdwAP_le_last` + `vdwAP_mem_last`); cancelling `k-1` recovers `d`. -/
+theorem vdwFamily_param_injOn {k : ℕ} (hk : 2 ≤ k) :
+    Set.InjOn (fun p : ℕ × ℕ => vdwAP n p.1 p.2 k)
+      (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+        (fun p => p.1 + (k - 1) * p.2 < n) : Finset (ℕ × ℕ)) := by
+  intro p hp q hq hpq
+  obtain ⟨a₁, d₁⟩ := p
+  obtain ⟨a₂, d₂⟩ := q
+  rw [Finset.mem_coe, Finset.mem_filter, Finset.mem_product, Finset.mem_Icc,
+    Finset.mem_range] at hp hq
+  obtain ⟨⟨ha1n, hd1lo, _⟩, hb1⟩ := hp
+  obtain ⟨⟨ha2n, hd2lo, _⟩, hb2⟩ := hq
+  simp only at hpq
+  -- Recover the first term `a` as the common minimum.
+  have hmem2_in_1 : (↑a₂ : Fin n) ∈ vdwAP n a₁ d₁ k := by
+    rw [hpq]; exact vdwAP_mem_first (by omega)
+  have hmem1_in_2 : (↑a₁ : Fin n) ∈ vdwAP n a₂ d₂ k := by
+    rw [← hpq]; exact vdwAP_mem_first (by omega)
+  have hcasta : (↑a₁ : Fin n) = ↑a₂ :=
+    le_antisymm (vdwAP_first_le hd1lo hb1 _ hmem2_in_1)
+      (vdwAP_first_le hd2lo hb2 _ hmem1_in_2)
+  have ha : a₁ = a₂ := by
+    have := congrArg Fin.val hcasta
+    rwa [Fin.val_cast_of_lt (by omega : a₁ < n), Fin.val_cast_of_lt (by omega : a₂ < n)] at this
+  -- Recover the last term `a + (k-1)d` as the common maximum.
+  have hmemL2_in_1 : (↑(a₂ + (k - 1) * d₂) : Fin n) ∈ vdwAP n a₁ d₁ k := by
+    rw [hpq]; exact vdwAP_mem_last (by omega)
+  have hmemL1_in_2 : (↑(a₁ + (k - 1) * d₁) : Fin n) ∈ vdwAP n a₂ d₂ k := by
+    rw [← hpq]; exact vdwAP_mem_last (by omega)
+  have hcastL : (↑(a₁ + (k - 1) * d₁) : Fin n) = ↑(a₂ + (k - 1) * d₂) :=
+    le_antisymm (vdwAP_le_last hd2lo hb2 _ hmemL1_in_2)
+      (vdwAP_le_last hd1lo hb1 _ hmemL2_in_1)
+  have hL : a₁ + (k - 1) * d₁ = a₂ + (k - 1) * d₂ := by
+    have := congrArg Fin.val hcastL
+    rwa [Fin.val_cast_of_lt (by omega), Fin.val_cast_of_lt (by omega)] at this
+  -- `a₁ = a₂` and equal last terms ⟹ `(k-1)d₁ = (k-1)d₂` ⟹ `d₁ = d₂`.
+  have hd : d₁ = d₂ := by
+    have hmul : (k - 1) * d₁ = (k - 1) * d₂ := by omega
+    exact Nat.eq_of_mul_eq_mul_left (by omega) hmul
+  rw [ha, hd]
+
+/-- **Exact count of length-`k` APs in `[n]`.** For `k ≥ 2` the family cardinality is
+*exactly* the triangular sum `∑_{d=1}^{n} (n - (k-1)d)` — not merely bounded by it.
+This is `card_vdwFamily_le_sum` made an equality via injectivity of the parametrization. -/
+theorem card_vdwFamily_eq_sum {k : ℕ} (hk : 2 ≤ k) :
+    (vdwFamily n k).card = ∑ d ∈ Finset.Icc 1 n, (n - (k - 1) * d) := by
+  rw [vdwFamily, Finset.card_image_of_injOn (vdwFamily_param_injOn hk)]
+  exact vdwFilter_card_eq_sum n k
+
+/-- **Crude exact lower bound.** Keeping only the step-`1` fiber (the `n - (k-1)` APs with
+common difference `1`) gives `n - (k-1) ≤ |family|`.  Paired with the factor-2 upper bound
+`2(k-1)|family| ≤ n²`, this shows the AP count is genuinely positive whenever `k - 1 < n`
+(so the union-bound regime is non-vacuous); the matching `Θ(n²/(k-1))` lower bound is left
+as a follow-up. -/
+theorem card_vdwFamily_ge {k : ℕ} (hk : 2 ≤ k) :
+    n - (k - 1) ≤ (vdwFamily n k).card := by
+  rw [card_vdwFamily_eq_sum hk]
+  have h1 : (1 : ℕ) ∈ Finset.Icc 1 n := by
+    rw [Finset.mem_Icc]; exact ⟨le_refl 1, NeZero.one_le⟩
+  calc n - (k - 1) = n - (k - 1) * 1 := by rw [Nat.mul_one]
+    _ ≤ ∑ d ∈ Finset.Icc 1 n, (n - (k - 1) * d) :=
+        Finset.single_le_sum (f := fun d => n - (k - 1) * d) (fun _ _ => Nat.zero_le _) h1
+
 end ProbMethod.VanDerWaerden

--- a/research/problems/erdos-1011-oq-03/knowledge.md
+++ b/research/problems/erdos-1011-oq-03/knowledge.md
@@ -44,11 +44,49 @@ triangle-free χ=r gadget grafted onto one side, the gadget occupying ~C(r-1,2)
 "shifted" vertices. The additive constants 1, 2, 6 are not yet identified with a
 closed form and are the genuinely open part for r = 5.
 
+## Session 2 (researcher-1): build repair + boundary value + characterization
+
+**Critical finding: the entry never actually compiled.** The parent
+`Erdos1011Problem.lean` (an `additionalFile`) had three independent build breaks
+on `main`, and `Erdos1011OQ03.lean` had two latent bugs that only surface once
+the parent builds:
+
+1. Parent `g` used instance binders inside `∃` (`∃ (V : Type*) [Fintype V]`),
+   invalid Lean 4 — `∃` does not take `[…]` binders (only `∀` does). Rewrote with
+   anonymous hypotheses `(_ : Fintype V)`, dropped the spurious `[DecidableRel] →`.
+2. Parent `simonovits_asymptotic` mixed ℤ/ℕ without coercions. Added `(n : ℤ)`,
+   `(C : ℤ)`.
+3. `f`/`g` were universe-polymorphic (`∀ (V : Type*)`), leaking a free universe
+   parameter into the `def … : Prop` conjectures → "universe level metavariables".
+   Quantified over `Type`; value unchanged (predicate fixes `card V = n`).
+4. OQ03 `forces_nonempty` / `f_antitone_in_chromatic` had redundant
+   `haveI := instF; …` after `intro`. The `intro`'d instance-implicit binders are
+   already local instances; the `haveI` duplicates shadowed them, so `rw [hcard]`
+   and the `f_forces` application saw a *different* `Fintype V` instance →
+   "pattern not found" / "instance not definitionally equal". Removing the `haveI`
+   lines fixed both. (Errored proofs were briefly replaced by `sorry`, which is
+   why `#print axioms` momentarily showed `sorryAx`.)
+
+**New mathematical content (0 axiom, verified):**
+- `forces_mono` + `forces_iff_f_le : Forces r n m ↔ f r n ≤ m` — the forcing
+  predicate is an up-set in the edge bound; `f r n` is exactly its least element.
+- `chromaticNumber_le_card : χ(G) ≤ card V` (identity colouring `V ≃ Fin (card V)`).
+- `f_eq_zero_of_lt : n < r → f r n = 0` — left boundary of the table: once `r`
+  exceeds the vertex count, no graph attains `χ ≥ r`, so forcing is vacuous. The
+  antitone-in-r value has bottomed out at 0.
+
+After repair: parent + OQ01 + OQ03 all build clean; every OQ03 theorem
+`#print axioms` reports only propext / Classical.choice / Quot.sound.
+14 theorems, 4 defs, 0 axiom, 0 sorry, 234 lines.
+
 ## Honest status
 
 The headline open problem (the value of f_5(n)) is **not solved**. The new
-mathematical content is the antitonicity theorem and its corollary upper bound;
-the rest organizes known data and the conjecture. Verified, axiom-free.
+mathematical content is the antitonicity theorem and its corollary upper bound,
+plus the up-set characterization (`forces_iff_f_le`) and the boundary value
+(`f_eq_zero_of_lt`); the rest organizes known data and the conjecture. Verified,
+axiom-free. Arguably the most consequential part of session 2 is the build
+repair: the entry was marked `verified` but did not actually compile until now.
 
 ## Next steps
 

--- a/research/problems/van-der-waerden-first-moment-oq-01/knowledge.md
+++ b/research/problems/van-der-waerden-first-moment-oq-01/knowledge.md
@@ -6,16 +6,51 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Sharpen the base entry's loose `n²` count of fitting length-`k` APs in `[n]` and feed
+the sharper count through the verified Property-B engine. The entry was already SOLVED
+(0 sorries, 0 axioms): exact parameter-box count `∑_{d=1}^{n}(n-(k-1)d)`, factor-2 bound
+`2(k-1)|family| ≤ n²` via telescoping-of-squares, widened lower bound `n² < 2(k-1)·2^(k-1)`.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **Exactness via injectivity (researcher-1, 06-30).** The prior `card_vdwFamily_le_sum`
+  was only `≤` (it used `Finset.card_image_le`). The parametrization `(a,d) ↦ vdwAP n a d k`
+  is in fact INJECTIVE on the fitting box for `k ≥ 2`, so the count is EXACT:
+  `card_vdwFamily_eq_sum : |family| = ∑_{d=1}^{n}(n-(k-1)d)`.
+  - Mechanism: a fitting positive-step AP is strictly increasing, so as a `Finset (Fin n)`
+    its minimum point is `↑a` and its maximum is `↑(a+(k-1)d)`. From the set one recovers
+    both extremes, hence `a` and (cancelling `k-1`) the step `d`.
+  - Lean recipe (avoids `min'`/`max'` machinery entirely): prove four small lemmas —
+    `↑a ∈ AP` (i=0 term), `↑(a+(k-1)d) ∈ AP` (i=k-1 term), `↑a ≤ x` for all `x∈AP`,
+    `x ≤ ↑(a+(k-1)d)` for all `x∈AP` — then in the `InjOn` proof use `rw [hpq]`/`rw [← hpq]`
+    to move a point of one AP into the other, and `le_antisymm` of the two ≤-facts gives
+    `↑a₁ = ↑a₂` and `↑(a₁+(k-1)d₁) = ↑(a₂+(k-1)d₂)`. `congrArg Fin.val` + `Fin.val_cast_of_lt`
+    drops to ℕ; `omega` + `Nat.eq_of_mul_eq_mul_left` finishes.
+  - Key API: `Fin.le_iff_val_le_val` (`a ≤ b ↔ (a:ℕ) ≤ b`), `Fin.val_cast_of_lt`
+    (`a < n → (↑a:Fin n).val = a`, needs `[NeZero n]`), `Finset.card_image_of_injOn`.
+- `card_vdwFamily_ge : n - (k-1) ≤ |family|` from `Finset.single_le_sum` on the `d=1`
+  fiber — crude but exact; shows the count is positive when `k-1 < n`.
+
+## Reusable techniques
+
+- To extract parameters from an injective `Finset`-valued parametrization, characterize
+  the min/max ELEMENT via membership + a universal ≤ bound, then `le_antisymm` instead of
+  invoking `Finset.min'`/`max'` (which drag dependent nonempty proofs through every rewrite).
+- `1 ≤ n` for `[NeZero n]` over ℕ: `NeZero.one_le`.
 
 ---
 
-## Dead Ends
+## Dead Ends / Deferred
 
-[Approaches known not to work will be documented here]
+- Matching `Θ(n²/(k-1))` LOWER bound on `|family|` (to certify the factor-2 upper bound is
+  order-sharp) was deferred: needs either a closed form of the truncated triangular sum
+  (entangles the floor `⌊(n-1)/(k-1)⌋`) or a reverse telescoping with a per-step correction.
+  Only the crude `n-(k-1)` lower bound was proved this session.
+
+## Infra notes
+
+- Docker daemon was DOWN this session. Host fallback worked:
+  `cd proofs && ./bin/lake env lean Proofs/VanDerWaerdenFirstMomentOQ01.lean`
+  (cache already populated). `#print axioms` confirmed only propext/Classical.choice/Quot.sound.

--- a/src/data/proofs/erdos-1011-oq-03/meta.json
+++ b/src/data/proofs/erdos-1011-oq-03/meta.json
@@ -29,24 +29,26 @@
     "erdosUrl": "https://erdosproblems.com/1011",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 177,
-    "assumptions": "None. 0 axioms, 0 sorries. The theorems use only the sInf definition of f and Mathlib (Nat.sInf_le/mem, card_edgeFinset_le_card_choose_two). #print axioms reports only propext / Classical.choice / Quot.sound. The 5 axioms of the parent file Erdos1011Problem.lean (the known f₂,f₃ values and bounds on g(r)) are NOT used by any theorem in this file.",
+    "lineCount": 234,
+    "assumptions": "None. 0 axioms, 0 sorries. The theorems use only the sInf definition of f and Mathlib (Nat.sInf_le/mem, card_edgeFinset_le_card_choose_two, Nat.choose_le_choose, Fintype.equivFin). #print axioms reports only propext / Classical.choice / Quot.sound for every theorem (f_antitone_in_chromatic, forces_iff_f_le, f_eq_zero_of_lt). The 5 axioms of the parent file Erdos1011Problem.lean (the known f₂,f₃ values and bounds on g(r)) are NOT used by any theorem in this file. (The parent file and this one were repaired this session so they actually compile — see the proofStrategy note.)",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 14,
     "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Erdős Problem #1011 asks for f_r(n): the minimum number of edges such that every n-vertex graph with chromatic number at least r and at least f_r(n) edges contains a triangle. Turán (1941) solved r=2: f_2(n) = ⌊n²/4⌋ + 1. Erdős and Gallai (1962) gave f_3(n) = ⌊(n-1)²/4⌋ + 2. The case r=4 resisted for decades until Ren, Wang, Wang and Yang determined f_4(n) = ⌊(n-3)²/4⌋ + 6 (n ≥ 150) in 2024. Open question OQ-03 takes the natural next step: compute f_5(n), which is unknown.\n\nThis entry does not compute f_5(n) — that is the open problem. Instead it establishes the unconditional structure any answer must satisfy, with no axioms. The headline is that the threshold f_r(n) is antitone in r: imposing a higher chromatic number is a stronger hypothesis on the graph, so it can only lower the edge count needed to force a triangle. This pins f_5(n) ≤ f_4(n), giving an unconditional upper bound on the open value in terms of the freshly-solved one.",
     "problemStatement": "Let f_r(n) be minimal such that every n-vertex graph with at least f_r(n) edges and chromatic number at least r contains a triangle. The values for r = 2, 3, 4 are known; determine f_5(n).",
     "text": "f_r(n) = least m forcing a triangle when χ ≥ r and e(G) ≥ m. Known for r ≤ 4; f₅(n) open. Proved here (0 axioms): f antitone in r ⟹ f₅(n) ≤ f₄(n) = ⌊(n-3)²/4⌋+6 (n≥150); and the shift pattern C(r-1,2)=0,1,3,6.",
-    "proofStrategy": "The threshold f r n is sInf of the set of edge counts m that force a triangle whenever χ ≥ r. Factoring this set's membership predicate as `Forces r n m`, two clean facts follow: the set is nonempty (any m > C(n,2) forces vacuously, via card_edgeFinset_le_card_choose_two), so the infimum is attained (`f_forces`); and any forcing m bounds f from above (`f_le_of_forces`). Antitonicity is then immediate: for r ≤ r', the hypothesis χ ≥ r' implies χ ≥ r, so the forcing property at threshold f r n still holds when restricted to χ ≥ r' graphs — giving f r' n ≤ f r n directly. Separately, `chromaticShift r = C(r-1,2)` is shown to reproduce the known shifts 0,1,3 and predict 6 for r=5, with closed form (r-1)(r-2)/2 and monotonicity.",
+    "proofStrategy": "The threshold f r n is sInf of the set of edge counts m that force a triangle whenever χ ≥ r. Factoring this set's membership predicate as `Forces r n m`, two clean facts follow: the set is nonempty (any m > C(n,2) forces vacuously, via card_edgeFinset_le_card_choose_two), so the infimum is attained (`f_forces`); and any forcing m bounds f from above (`f_le_of_forces`). Antitonicity is then immediate: for r ≤ r', the hypothesis χ ≥ r' implies χ ≥ r, so the forcing property at threshold f r n still holds when restricted to χ ≥ r' graphs — giving f r' n ≤ f r n directly. The forcing predicate is also an up-set in the edge bound (`forces_mono`), which yields the exact characterization `forces_iff_f_le : Forces r n m ↔ f r n ≤ m`. At the left boundary, once r exceeds the vertex count n no n-vertex graph attains χ ≥ r (every such graph is n-colourable, `chromaticNumber_le_card` via the identity colouring V ≃ Fin n), so the forcing condition is vacuous and `f_eq_zero_of_lt : n < r → f r n = 0`. Separately, `chromaticShift r = C(r-1,2)` is shown to reproduce the known shifts 0,1,3 and predict 6 for r=5, with closed form (r-1)(r-2)/2 and monotonicity. Build note: this session repaired the parent `Erdos1011Problem.lean`, which did not compile (instance binders inside an `∃`, ℤ/ℕ coercion gaps in `simonovits_asymptotic`, and a universe parameter leaking from `f`/`g` into the Prop conjectures); `f`/`g` were made universe-monomorphic over `Type`, value-unchanged since the predicate fixes `card V = n`.",
     "keyInsights": [
       "f_r(n) is antitone in r: stronger chromatic hypothesis ⟹ lower triangle-forcing threshold",
       "Corollary: f₅(n) ≤ f₄(n) = ⌊(n-3)²/4⌋ + 6 (n ≥ 150) — an unconditional upper bound on the open value",
       "Antitonicity is pure sInf monotonicity over the defining sets; no extremal theory needed",
       "Nonemptiness of the defining set uses the edge bound e(G) ≤ C(n,2)",
       "Vertex-shift pattern: the ⌊(n-s)²/4⌋ shift is s = C(r-1,2) = 0,1,3 for r=2,3,4, predicting 6 for r=5",
-      "The additive constants 1, 2, 6 remain without an identified closed form — the genuinely open part"
+      "The additive constants 1, 2, 6 remain without an identified closed form — the genuinely open part",
+      "Complete characterization: Forces r n m ↔ f r n ≤ m — the forcing predicate is an up-set whose least element is exactly the threshold",
+      "Left boundary: f r n = 0 once r > n, since χ(G) ≤ n forbids χ ≥ r and the forcing condition becomes vacuous"
     ],
     "prerequisites": [
       "Graph theory (chromatic number, edges, triangles)",

--- a/src/data/proofs/van-der-waerden-first-moment-oq-01/meta.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-01/meta.json
@@ -10,8 +10,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 152,
-    "theoremCount": 6,
+    "lineCount": 273,
+    "theoremCount": 13,
     "definitionCount": 0,
     "assumptions": "0 axioms, 0 sorries, no native_decide. The hypotheses (k ≥ 2 in the final lower bound, and the smallness bound n² < 2(k-1)·2^(k-1)) are inputs to the statements, not standing assumptions; the core sharpened count card_vdwFamily_two_mul_le needs no hypothesis on k at all. #print axioms reports only propext, Classical.choice, Quot.sound for vdw_lower_bound_sharp, card_vdwFamily_two_mul_le, and vdwFilter_card_eq_sum. The probabilistic core is the gallery's verified entry property-b-first-moment (via vdw_two_coloring_exists from the base van-der-waerden-first-moment entry), consumed as a black box; this entry contributes the exact triangular parameter count and the telescoping-of-squares bound on top of it. Badged 'original' because the exact-count and factor-2 sharpening are new content layered on a verified base entry, not a Mathlib headline theorem.",
     "tags": [
@@ -25,6 +25,8 @@
     ],
     "dateAdded": "2026-06-27",
     "originalContributions": [
+      "card_vdwFamily_eq_sum: the number of length-k APs in [n] equals EXACTLY the triangular sum ∑_{d=1}^{n}(n-(k-1)d) — not merely bounded by it. The base/prior bound card_vdwFamily_le_sum is upgraded from ≤ to = by proving vdwFamily_param_injOn: the parametrization (a,d) ↦ vdwAP n a d k is injective on the fitting box (k ≥ 2), since a fitting positive-step AP is increasing, so its set determines its minimum a (vdwAP_mem_first + vdwAP_first_le) and maximum a+(k-1)d (vdwAP_mem_last + vdwAP_le_last), and cancelling k-1 recovers the step d. This pins the parameter sum as the true count rather than an overestimate.",
+      "card_vdwFamily_ge: a crude exact lower bound n - (k-1) ≤ |family| (the step-1 fiber alone), confirming the AP count is positive — hence the union-bound regime non-vacuous — whenever k - 1 < n; the matching Θ(n²/(k-1)) lower bound is left as a follow-up.",
       "vdwFilter_card_eq_sum: the EXACT parameter count of fitting length-k APs equals the triangular sum ∑_{d=1}^{n} (n - (k-1)d) — fiberwise counting of admissible first terms a for each step d, with truncated ℕ-subtraction handling the d > (n-1)/(k-1) tail automatically; replaces the base entry's loose n² overcount with an equality",
       "card_vdwFamily_two_mul_le: 2·(k-1)·|family| ≤ n² with NO hypothesis on k — at most n²/(2(k-1)) length-k APs fit in [n], twice as sharp as the open question's requested n²/(k-1) and a factor 2(k-1) improvement on the base n² bound",
       "two_mul_sum_sq_le: the telescoping-of-squares engine 2c·∑_{d=1}^{m}(N - c·d) + (N - c·m)² ≤ N², the per-step bound 2c(N-cd) ≤ (N-c(d-1))² - (N-cd)² summed by induction — the elementary heart of the sharpening",
@@ -59,8 +61,8 @@
     "namespace": "ProbMethod.VanDerWaerden",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 152,
-    "theoremCount": 6,
+    "lineCount": 273,
+    "theoremCount": 13,
     "definitionCount": 0
   },
   "overview": {
@@ -110,10 +112,17 @@
       "startLine": 125,
       "endLine": 152,
       "summary": "vdw_lower_bound_sharp: if n² < 2(k-1)·2^(k-1), cancel 2(k-1) to get |family| < 2^(k-1), invoke the base entry's Property B engine, and verify each fitting AP is in the family — giving W(k) ≳ √(2(k-1))·2^((k-1)/2)."
+    },
+    {
+      "id": "exact-count",
+      "title": "Exact AP Count via Injectivity of the Parametrization",
+      "startLine": 152,
+      "endLine": 273,
+      "summary": "Upgrades the family-count inequality to an equality. vdwAP_mem_first/vdwAP_first_le show ↑a is the minimum point of a fitting AP; vdwAP_mem_last/vdwAP_le_last show ↑(a+(k-1)d) is the maximum. vdwFamily_param_injOn: the set determines both extremes, so (for k ≥ 2) it recovers a and (cancelling k-1) d — the parametrization is injective on the fitting box. card_vdwFamily_eq_sum: hence |family| = ∑_{d=1}^{n}(n-(k-1)d) exactly. card_vdwFamily_ge: the step-1 fiber gives the crude exact lower bound n-(k-1) ≤ |family|."
     }
   ],
   "conclusion": {
-    "summary": "6 theorems, 0 definitions, 0 sorries, 0 axioms, no native_decide. The number of length-k arithmetic progressions fitting in [n] is computed exactly as the triangular sum ∑_{d=1}^{n}(n - (k-1)d), and a telescoping-of-squares bound collapses it to 2(k-1)·|family| ≤ n² — at most n²/(2(k-1)) APs, twice as sharp as the base entry's open question asked. Feeding this through the verified Property B engine widens the van der Waerden lower bound's admissible range to n² < 2(k-1)·2^(k-1), giving W(k) ≳ √(2(k-1))·2^((k-1)/2).",
+    "summary": "13 theorems, 0 definitions, 0 sorries, 0 axioms, no native_decide. The number of length-k arithmetic progressions fitting in [n] is computed EXACTLY as the triangular sum ∑_{d=1}^{n}(n - (k-1)d) — the parameter-box count card_vdwFamily_le_sum is upgraded from ≤ to = (card_vdwFamily_eq_sum) by proving the parametrization (a,d) ↦ AP injective on the fitting box (vdwFamily_param_injOn: a fitting AP's minimum is a and maximum is a+(k-1)d, recovering both parameters). A telescoping-of-squares bound collapses the sum to 2(k-1)·|family| ≤ n² — at most n²/(2(k-1)) APs, twice as sharp as the base entry's open question asked. Feeding this through the verified Property B engine widens the van der Waerden lower bound's admissible range to n² < 2(k-1)·2^(k-1), giving W(k) ≳ √(2(k-1))·2^((k-1)/2).",
     "implications": "Resolves the base entry's open question oq-01 (sharpen the AP count to ~n²/(k-1)) and improves on it by a factor of 2 with an exact count. Demonstrates that the loose n² in the first-moment van der Waerden bound is genuinely improvable inside Lean by elementary lattice-point counting, and that the verified Property B engine accepts the sharper count unchanged.",
     "openQuestions": [
       "Track the lower-order term: vdwFilter_card_eq_sum is an equality, so the exact threshold (including the (N-cm)² remainder dropped in two_mul_sum_sq_le) could be stated, pinning the optimal constant rather than the ≤ n² bound.",


### PR DESCRIPTION
## Summary

The entry `van-der-waerden-first-moment-oq-01` was already SOLVED (0 sorries, 0 axioms): it computes the exact **parameter-box** count `∑_{d=1}^{n}(n-(k-1)d)` and the factor-2 bound `2(k-1)·|family| ≤ n²`. The family count itself, however, was only an **upper bound** (`card_vdwFamily_le_sum`, via `Finset.card_image_le`).

This PR closes that gap: the parametrization `(a,d) ↦ vdwAP n a d k` is **injective** on the fitting box for `k ≥ 2`, so the bound becomes an **equality**:

$$|\{\text{length-}k\text{ APs in }[n]\}| \;=\; \sum_{d=1}^{n}\,(n-(k-1)d) \qquad\text{(card\_vdwFamily\_eq\_sum)}$$

**Why injective.** A fitting positive-step AP is strictly increasing, so as a `Finset (Fin n)` it determines its minimum point `↑a` and its maximum point `↑(a+(k-1)d)`. From the set one recovers `a` (the min) and, cancelling `k-1`, the step `d` — distinct fitting pairs give distinct APs.

## New theorems (6 → 13)

- `vdwAP_mem_first` / `vdwAP_mem_last` — the `i=0` and `i=k-1` endpoints are points of the AP.
- `vdwAP_first_le` / `vdwAP_le_last` — `↑a` is the minimum and `↑(a+(k-1)d)` the maximum of a fitting AP.
- `vdwFamily_param_injOn` — the parametrization is `Set.InjOn` on the fitting box (`k ≥ 2`).
- `card_vdwFamily_eq_sum` — **exact** family count (upgrades `≤` to `=`).
- `card_vdwFamily_ge` — crude exact lower bound `n-(k-1) ≤ |family|` (the `d=1` fiber), confirming the count is positive when `k-1 < n`.

## Verification

- `0` sorries, `0` axioms, no `native_decide`.
- `#print axioms` for `card_vdwFamily_eq_sum`, `vdwFamily_param_injOn`, `card_vdwFamily_ge` reports only `propext, Classical.choice, Quot.sound`.
- Built with the host Lean fallback (`./bin/lake env lean ...`) — Docker daemon was down this session.

## Honesty

This is elementary lattice-point reasoning: it pins the triangular sum as the *true* AP count rather than an overestimate. It does not touch the union-bound method or the exponential base of `W(k)`. A matching `Θ(n²/(k-1))` lower bound on `|family|` (to certify order-sharpness of the factor-2 upper bound) is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)