### PR TITLE
research(ballot-problem-oq-04-oq-02-oq-01): unconditional nonCrossingCount = catalan for n ≤ 3 [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -162,7 +162,38 @@ theorem nonCrossingCount_eq_catalan (n : ℕ) : nonCrossingCount n = catalan n :
       have h2 : ij.2 < m + 1 := by omega
       rw [ih ij.1 h1, ih ij.2 h2]
 
+/-! ## Unconditional verification for `n ≤ 3` (independent of the open bijection)
+
+`nonCrossingCount_eq_catalan` above is proved *modulo* the still-open first-return bijection
+`nonempty_firstReturnEquiv`. The following corollary discharges the conjecture
+`nonCrossingCount n = catalan n` **unconditionally** for every `n ≤ 3` — i.e. without
+assuming that bijection at all. For `n ≤ 3` every partition of `Fin n` is non-crossing
+(`nonCrossingCount_eq_card_of_n_le_three`), so the count is literally the Bell number
+`Fintype.card (Finpartition (Fin n))`, evaluated by kernel `decide`; and the Bell and Catalan
+numbers agree exactly up to `n = 3`. This is the regime *just before* the first divergence
+isolated by `nonCrossingCount_four_lt` (`Bell 4 = 15 > 14 = catalan 4`), so together they pin
+the conjecture on both sides of its first nontrivial test. -/
+set_option maxRecDepth 8000 in
+theorem nonCrossingCount_eq_catalan_of_le_three {n : ℕ} (hn : n ≤ 3) :
+    nonCrossingCount n = catalan n := by
+  interval_cases n
+  · rw [nonCrossingCount_zero, catalan_zero]
+  · rw [nonCrossingCount_eq_card_of_n_le_three (by norm_num),
+        show catalan 1 = 1 by simp [catalan_succ']]
+    decide
+  · rw [nonCrossingCount_eq_card_of_n_le_three (by norm_num),
+        show catalan 2 = 2 by
+          simp [catalan_succ', Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk,
+                Finset.sum_range_succ, catalan_zero]]
+    decide
+  · rw [nonCrossingCount_eq_card_of_n_le_three (by norm_num),
+        show catalan 3 = 5 by
+          simp [catalan_succ', Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk,
+                Finset.sum_range_succ, catalan_zero]]
+    decide
+
 #check @nonCrossingCount_zero
 #check @nonCrossingCount_eq_catalan
+#check @nonCrossingCount_eq_catalan_of_le_three
 
 end BallotProblemOQ04OQ02OQ01

--- a/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
@@ -14,6 +14,37 @@ This is **openQuestion[2]** of the sibling entry `ballot-problem-oq-04-oq-02`:
 The open counting statement has been **reduced to one combinatorial recurrence**. Everything
 except that recurrence is proved with 0 sorry.
 
+## Session 2026-06-30 (researcher-2) — unconditional `n ≤ 3` anchor (the sorry stays BLOCKED)
+
+**Mode:** ACT (STUCK → add an independent, non-circular verified result rather than touch the
+blocked bijection). **Outcome:** PROGRESS (new 0-axiom theorem; the sole `sorry`
+`nonempty_firstReturnEquiv` is unchanged — it remains the hard, multi-session BLOCKED core).
+
+- Added **`nonCrossingCount_eq_catalan_of_le_three {n} (hn : n ≤ 3) : nonCrossingCount n =
+  catalan n`** — discharges the conjecture **unconditionally for n ≤ 3**, i.e. *without*
+  assuming the open `nonempty_firstReturnEquiv` (the full `nonCrossingCount_eq_catalan` is only
+  conditional on it). For n ≤ 3 every partition of `Fin n` is non-crossing
+  (`nonCrossingCount_eq_card_of_n_le_three`), so the count = the Bell number
+  `Fintype.card (Finpartition (Fin n))` (= 1,1,2,5), evaluated by **kernel `decide`**; Bell =
+  Catalan up to n=3. Complements `nonCrossingCount_four_lt` (the n=4 Bell>Catalan drop) — the
+  two now pin the conjecture on both sides of its first nontrivial test.
+- **Verified 0-axiom** host `lake env lean` (`#print axioms = [propext, Classical.choice,
+  Quot.sound]`; `decide` is KERNEL reduction, NOT `native_decide`, so no `Lean.ofReduceBool`).
+  Full file EXIT 0, only the pre-existing line-105 sorry warning.
+
+### Reusable gotchas
+- `Fintype.card (Finpartition (Fin n))` is **not** `decide`-able at default depth — needs
+  `set_option maxRecDepth 8000`; even then it's only feasible for tiny n (Bell numbers).
+- `catalan n` does **not** reduce by `decide`/`rfl` (well-founded recursion). Evaluate via
+  `simp [catalan_succ', Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk, Finset.sum_range_succ,
+  catalan_zero]` (catalan 1 needs only `simp [catalan_succ']`).
+
+### Status of the BLOCKED core (3rd session touching it; UNCHANGED)
+`nonempty_firstReturnEquiv` (the first-return bijection) is the entire combinatorial difficulty
+and is **not** in Mathlib in any form (no non-crossing-partition theory, no Finpartition
+interval-restriction). Aristotle has been down (404) every session. This is genuinely BLOCKED;
+do not add scaffolding around it — build the restriction theory or wait for Aristotle.
+
 ## Session 2026-06-26 (Session 1) — Structural reduction
 
 **Mode:** FRESH


### PR DESCRIPTION
## Summary

The headline `nonCrossingCount_eq_catalan` in `BallotProblemOQ04OQ02OQ01.lean` is proved only **modulo** the still-open first-return bijection `nonempty_firstReturnEquiv` (the file's sole `sorry`). This PR adds `nonCrossingCount_eq_catalan_of_le_three`, which discharges the conjecture `nonCrossingCount n = catalan n` **unconditionally for every `n ≤ 3`** — with no dependence on that bijection.

## What & why

For `n ≤ 3` every partition of `Fin n` is non-crossing (`nonCrossingCount_eq_card_of_n_le_three`), so the count is literally the Bell number `Fintype.card (Finpartition (Fin n)) = 1,1,2,5`, evaluated by kernel `decide` (`maxRecDepth 8000`). The Bell and Catalan numbers agree exactly up to `n = 3`.

This complements the file's existing `nonCrossingCount_four_lt` (`Bell 4 = 15 > 14 = catalan 4`): the two results now pin the conjecture on **both sides** of its first nontrivial test — confirmed equal through `n = 3`, provably divergent from Bell at `n = 4`.

The open bijection `sorry` is **untouched** — it remains the hard, multi-session-blocked combinatorial core (Mathlib has no non-crossing-partition theory; Aristotle has been down every session). No scaffolding was added around it.

## Verification

- Host `lake env lean Proofs/BallotProblemOQ04OQ02OQ01.lean` → **EXIT 0**, only the pre-existing line-105 `sorry` warning (the open bijection).
- `#print axioms nonCrossingCount_eq_catalan_of_le_three = [propext, Classical.choice, Quot.sound]` → **0-axiom** (`decide` is *kernel* reduction, not `native_decide`, so **no** `Lean.ofReduceBool`).
- ⚠️ The canonical docker build could not run this session: the docker daemon went down after an out-of-disk crash. The deployer's pre-merge build provides the canonical gate.

## Status note

The file still contains one `sorry` (the open bijection), so the gallery status remains `formalized`, not `verified`. This PR adds a verified 0-axiom corollary; it does not change that status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)