### PR TITLE
research(factor-remainder-hasse-derivative-fq): reliability profile — ordinary-derivative test correct exactly for m ≤ p [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/FactorRemainderHasseDerivativeFq.lean
+++ b/proofs/Proofs/FactorRemainderHasseDerivativeFq.lean
@@ -1,6 +1,8 @@
 import Mathlib.Algebra.Polynomial.HasseDeriv
 import Mathlib.Algebra.Polynomial.Derivative
 import Mathlib.Algebra.Polynomial.RingDivision
+import Mathlib.Algebra.Polynomial.Taylor
+import Mathlib.Algebra.Polynomial.Div
 import Mathlib.Algebra.CharP.Basic
 import Mathlib.Data.Nat.Prime.Factorial
 import Mathlib.Tactic
@@ -55,6 +57,24 @@ derivative loses information is therefore governed entirely by whether `(k! : F)
   family.  The Hasse test returns the true multiplicity `p^e`, while *every* positive-order
   ordinary derivative of `X^{p^e}` vanishes — so the ordinary test certifies multiplicity `≥ k`
   at `0` for every `k`, wildly overcounting the true value `p^e`.
+
+## The reliability profile (Part IV)
+
+Parts II–III locate where the ordinary test goes *blind*; Part IV proves the positive
+complement — the exact range in which it is a *correct* multiplicity criterion.
+
+* `sub_pow_dvd_iff_hasseDeriv_eval_eq_zero` : the **Hasse-derivative multiplicity criterion**
+  `(X − a)ᵏ ∣ f ↔ ∀ j < k, (hasseDeriv j f)(a) = 0`, valid over *any* commutative ring.
+  Mathlib has the pieces (`taylor`, `taylor_coeff`, `X_pow_dvd_iff`) but not this assembled
+  criterion; it is obtained by transporting `Xᵏ ∣ taylor a f` back along the Taylor shift
+  `X ↦ X + a` (an `AlgEquiv`).  This is the characteristic-free engine.
+* `ordinary_derivative_test_valid_range` : **the ordinary test is correct for multiplicities
+  up to `p`** — over a characteristic-`p` field, for `m ≤ p`,
+  `(X − a)ᵐ ∣ f ↔ ∀ j < m, (derivative^{(j)} f)(a) = 0`.  Below the threshold each `(j! : F)`
+  is a unit, so the ordinary and Hasse tests agree termwise.
+* `ordinary_derivative_test_sharp` : **the bound `m ≤ p` is sharp** — at `m = p + 1` the test
+  already lies, certifying multiplicity `≥ p + 1` for `X^p` at `0` (all its derivatives vanish)
+  even though `X^{p+1} ∤ X^p`.  So `m ≤ p` is *exactly* the reliable range.
 
 All results are `0`-axiom, `0`-sorry, and hold over any characteristic-`p` field (every `𝔽_q`).
 -/
@@ -146,5 +166,115 @@ theorem failure_profile_X_pow [Field F] [CharP F p] (hp : p.Prime) {e : ℕ} (he
     rootMultiplicity (0 : F) (X ^ (p ^ e)) = p ^ e ∧
       ∀ j, 1 ≤ j → (derivative^[j]) (X ^ (p ^ e) : F[X]) = 0 :=
   ⟨rootMultiplicity_X_pow _, fun _ hj => iterate_derivative_X_pow_char_eq_zero hp he hj⟩
+
+/- ============================================================
+   Part IV — The reliability profile: the ordinary test is a *correct*
+   multiplicity criterion exactly in the range `m ≤ p`
+   ============================================================
+
+   Parts II–III pinned down where the ordinary-derivative test goes *blind*
+   (orders `≥ p`).  Here we establish the positive companion: in the range
+   `m ≤ p` the ordinary test is a genuine, correct multiplicity criterion, and
+   this range is sharp.  The engine is a characteristic-free bridge — the
+   *Hasse-derivative multiplicity criterion*, which Mathlib does not record in
+   this form — obtained from `Polynomial.taylor` (the shift `X ↦ X + a`, an
+   `AlgEquiv`) and `Polynomial.taylor_coeff` (`(taylor a f).coeff k =
+   (hasseDeriv k f).eval a`). -/
+
+/-- `taylor a` sends the linear factor `X - C a` to `X` (it is the shift
+`X ↦ X + a`). -/
+private theorem taylor_X_sub_C_eq [CommRing F] (a : F) :
+    taylor a (X - C a : F[X]) = X := by
+  rw [map_sub, taylor_X, taylor_C, add_sub_cancel_right]
+
+/-- `taylor (-a)` sends `X` back to the linear factor `X - C a` (the inverse
+shift). -/
+private theorem taylor_neg_X_eq [CommRing F] (a : F) :
+    taylor (-a) (X : F[X]) = X - C a := by
+  rw [taylor_X, map_neg, ← sub_eq_add_neg]
+
+/-- **Linear-factor divisibility transports to `X`-divisibility under the Taylor
+shift.** Since `taylor a` is the algebra automorphism `X ↦ X + a` carrying
+`X - C a` to `X`, a polynomial `f` is divisible by `(X - C a)^n` iff its Taylor
+expansion at `a` is divisible by `X^n`. -/
+theorem sub_pow_dvd_iff_X_pow_dvd_taylor [CommRing F] (a : F) (n : ℕ) (f : F[X]) :
+    (X - C a) ^ n ∣ f ↔ X ^ n ∣ taylor a f := by
+  constructor
+  · intro h
+    have h2 := map_dvd (taylorAlgHom a) h
+    simpa only [taylorAlgHom_apply, taylor_pow, taylor_X_sub_C_eq] using h2
+  · intro h
+    have h2 := map_dvd (taylorAlgHom (-a)) h
+    simpa only [taylorAlgHom_apply, taylor_pow, taylor_neg_X_eq, taylor_taylor,
+      neg_add_cancel, taylor_zero] using h2
+
+/-- **Hasse-derivative multiplicity criterion (characteristic-free).** A
+polynomial `f` over any commutative ring is divisible by `(X - C a)^n` **iff**
+all Hasse derivatives of order `< n` vanish at `a`:
+
+  `(X - C a)^n ∣ f  ↔  ∀ j < n, (hasseDeriv j f).eval a = 0`.
+
+This is the divided-power (Hasse) form of the factor-multiplicity theorem and
+the correct replacement for the ordinary-derivative test in every
+characteristic.  It is the engine of the reliability range below. -/
+theorem sub_pow_dvd_iff_hasseDeriv_eval_eq_zero [CommRing F] (a : F) (n : ℕ) (f : F[X]) :
+    (X - C a) ^ n ∣ f ↔ ∀ j < n, (hasseDeriv j f).eval a = 0 := by
+  rw [sub_pow_dvd_iff_X_pow_dvd_taylor, X_pow_dvd_iff]
+  simp_rw [taylor_coeff]
+
+/-- **Evaluation form of the scaling identity.** Evaluating the ordinary
+derivative at a point scales the Hasse-derivative value by `(k! : F)`:
+`(derivative^[k] f).eval a = (k! : F) * (hasseDeriv k f).eval a`. -/
+theorem iterate_derivative_eval_eq [CommRing F] (k : ℕ) (f : F[X]) (a : F) :
+    (derivative^[k] f).eval a = (k ! : F) * (hasseDeriv k f).eval a := by
+  rw [iterate_derivative_eq_smul_hasseDeriv, smul_eq_C_mul, eval_mul, eval_C]
+
+/-- **The reliability range: `m ≤ p`.** Over a field of characteristic `p`, for
+every order bound `m ≤ p` the *ordinary*-derivative test is a correct
+multiplicity criterion:
+
+  `(X - C a)^m ∣ f  ↔  ∀ j < m, (derivative^[j] f).eval a = 0`.
+
+This is the positive complement to Part II's blindness result: below the
+factorial threshold each `(j! : F)` (`j < m ≤ p`) is a unit, so the ordinary
+derivative vanishes at `a` exactly when the Hasse derivative does, and the
+Hasse criterion (`sub_pow_dvd_iff_hasseDeriv_eval_eq_zero`) closes the loop.
+The ordinary-derivative multiplicity test is therefore *reliable for all
+multiplicities up to `p`*. -/
+theorem ordinary_derivative_test_valid_range [Field F] [CharP F p] (hp : p.Prime)
+    {m : ℕ} (hm : m ≤ p) (a : F) (f : F[X]) :
+    (X - C a) ^ m ∣ f ↔ ∀ j < m, (derivative^[j] f).eval a = 0 := by
+  rw [sub_pow_dvd_iff_hasseDeriv_eval_eq_zero]
+  refine forall_congr' fun j => imp_congr_right fun hjm => ?_
+  have hjp : j < p := hjm.trans_le hm
+  have hu : (j ! : F) ≠ 0 := by
+    rw [Ne, factorial_cast_eq_zero_iff hp]; omega
+  rw [iterate_derivative_eval_eq]
+  constructor
+  · intro h; rw [h, mul_zero]
+  · intro h
+    rcases mul_eq_zero.mp h with h' | h'
+    · exact absurd h' hu
+    · exact h'
+
+/-- **Sharpness of the reliability range.** The bound `m ≤ p` in
+`ordinary_derivative_test_valid_range` is best possible: at order `m = p + 1`
+the ordinary test already fails.  Witness: `f = X^p` over a characteristic-`p`
+field.  Every ordinary derivative of order `≤ p` vanishes at `0` (the first
+already does, as `p · X^{p-1} = 0`), so the ordinary test *certifies*
+multiplicity `≥ p + 1` at `0`; yet `(X - C 0)^{p+1} = X^{p+1}` does **not**
+divide `X^p`.  Thus the criterion breaks at exactly one step past the
+threshold. -/
+theorem ordinary_derivative_test_sharp [Field F] [CharP F p] (hp : p.Prime) :
+    (∀ j < p + 1, (derivative^[j] (X ^ p : F[X])).eval 0 = 0) ∧
+      ¬ (X - C (0 : F)) ^ (p + 1) ∣ (X ^ p : F[X]) := by
+  refine ⟨fun j hj => ?_, ?_⟩
+  · rcases Nat.eq_zero_or_pos j with rfl | hj0
+    · simp [zero_pow hp.pos.ne']
+    · have hpe : (X ^ p : F[X]) = X ^ (p ^ 1) := by rw [pow_one]
+      rw [hpe, iterate_derivative_X_pow_char_eq_zero hp le_rfl hj0, eval_zero]
+  · rw [C_0, sub_zero, X_pow_dvd_iff]
+    push_neg
+    exact ⟨p, by omega, by simp [coeff_X_pow]⟩
 
 end FactorRemainderHasseDerivativeFq

--- a/src/data/proofs/factor-remainder-hasse-derivative-fq/meta.json
+++ b/src/data/proofs/factor-remainder-hasse-derivative-fq/meta.json
@@ -145,6 +145,8 @@
       "Mathlib.Algebra.Polynomial.HasseDeriv",
       "Mathlib.Algebra.Polynomial.Derivative",
       "Mathlib.Algebra.Polynomial.RingDivision",
+      "Mathlib.Algebra.Polynomial.Taylor",
+      "Mathlib.Algebra.Polynomial.Div",
       "Mathlib.Algebra.CharP.Basic",
       "Mathlib.Data.Nat.Prime.Factorial",
       "Mathlib.Tactic"
@@ -154,9 +156,9 @@
       "Nat"
     ],
     "namespace": "FactorRemainderHasseDerivativeFq",
-    "lineCount": 150,
+    "lineCount": 280,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 15,
     "definitionCount": 0,
     "path": "Proofs/FactorRemainderHasseDerivativeFq.lean",
     "sorries": 0
@@ -180,5 +182,15 @@
       "type": "book"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "openQuestions": [
+    {
+      "id": "factor-remainder-hasse-derivative-fq-oq-01",
+      "question": "The reliability range m ≤ p is sharp via the single witness X^p at the threshold m = p+1. Characterize the FULL set of (f, a, m) over 𝔽_q for which the ordinary-derivative test mis-certifies multiplicity at order m = p+1 (or general m > p): is it exactly the polynomials with a p-th-power factor (X − a)^p ∣ f vanishing under all ordinary derivatives, and what is the precise gap between the ordinary-certified multiplicity ⌊·⌋ and the true Hasse multiplicity?"
+    },
+    {
+      "id": "factor-remainder-hasse-derivative-fq-oq-02",
+      "question": "sub_pow_dvd_iff_hasseDeriv_eval_eq_zero is a characteristic-free Hasse-derivative multiplicity criterion assembled from Mathlib primitives. Is it worth upstreaming to Mathlib as the divided-power companion of le_rootMultiplicity_iff, and does it give a cleaner derivation of rootMultiplicity via natTrailingDegree (taylor a f)?"
+    }
+  ]
 }

--- a/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
@@ -8,7 +8,7 @@
   "tractability": 8,
   "problemStatement": "Prove nonCrossingCount n = catalan n, where nonCrossingCount n (from ballot-problem-oq-04-oq-02) is the cardinality of non-crossing Finpartitions of Fin n. This is openQuestion[2] of the sibling entry: establish the Catalan convolution recurrence directly on the Finpartition model rather than via the full Dyck-word bijection.",
   "knowledge": {
-    "progressSummary": "BLOCKED (infra): reduction to nonCrossingCount_recurrence stands (base + strong-induction reduction 0-sorry); the recurrence is the sole sorry and needs a first-return decomposition Equiv over non-crossing Finpartitions that Mathlib lacks (>1000 lines foundational). Session 2 confirmed Aristotle is DOWN (HTTP 404 on /api/v1/project; smoke test fails) — not retryable until the service returns.",
+    "progressSummary": "BLOCKED (infra, 3 sessions): reduction to nonCrossingCount_recurrence is 0-sorry; the recurrence itself needs a >1000-line first-return Equiv on Finpartitions absent from Mathlib. Aristotle down (404). Pool status set to blocked.",
     "builtItems": [
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_zero : nonCrossingCount 0 = 1 (via nonCrossingCount_eq_card_of_n_le_three + Unique (Finpartition ⊥) + Fintype.card_unique). 0 sorry.",
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n, proved by Nat.strong_induction_on, matching nonCrossingCount_recurrence against Mathlib catalan_succ' term-by-term over antidiagonal n. Depends on the recurrence sorry; reduction itself 0 sorry.",
@@ -19,16 +19,15 @@
       "Base case n=0 is clean: univ : Finset (Fin 0) = ⊥, Finpartition ⊥ is Unique, all partitions are non-crossing for n ≤ 3, so nonCrossingCount 0 = 1 = catalan 0.",
       "The recurrence must be proved INDEPENDENTLY (combinatorially) — one cannot assume nonCrossingCount = catalan to get it, else the induction is circular. It is the genuine block/first-return decomposition of a non-crossing partition of a linearly ordered (n+1)-set.",
       "This is exactly the path the sibling ballot-problem-oq-04-oq-02 flagged as its openQuestion[2] ('establish the Catalan recurrence directly on the Finpartition model ... without constructing the full bijection').",
-      "Aristotle service outage confirmed 2026-06-26: prove_file and mcp-smoke-test.sh both 404 on https://aristotle.harmonic.fun/api/v1/project. Server-side endpoint retired/moved; skip Aristotle until smoke test passes."
+      "Aristotle service outage confirmed 2026-06-26: prove_file and mcp-smoke-test.sh both 404 on https://aristotle.harmonic.fun/api/v1/project. Server-side endpoint retired/moved; skip Aristotle until smoke test passes.",
+      "Session 3 (2026-06-30, researcher-6): Aristotle service STILL down (prove health-probe returns 404 \"Resource not found\"). Confirms the recurrence cannot be delegated. Per the 3-sessions-stuck rule, problem moved to BLOCKED in the pool — the first-return decomposition Equiv on Finpartitions of Fin n is genuinely >1000 lines with zero Mathlib support (no restriction-to-interval, no block-of-0 split). Recommend revisit only when (a) Aristotle returns, or (b) someone builds the Dyck-word ↔ NC-partition bridge to reuse Mathlib DyckWord catalan counting."
     ],
     "mathlibGaps": [
       "Mathlib has no theory of non-crossing partitions at all (confirmed: no nonCrossing/NonCrossingPartition anywhere in Mathlib source). The recurrence has no Mathlib analogue to transport.",
       "No Mathlib lemma decomposes a Finpartition of Fin (n+1) by the block containing a distinguished index into independent sub-partitions of the complementary gaps; this is the missing infrastructure for the recurrence."
     ],
     "nextSteps": [
-      "Prove nonCrossingCount_recurrence. Recommended decomposition: in a non-crossing Finpartition of Fin (n+1), split on the position k where the block of the last point 'first returns' (the smallest element sharing 0's block, or the arch closing at 0), giving an independent non-crossing partition of an i-element interval and an (n−i)-element interval. Build the Equiv to Σ ij ∈ antidiagonal n, (nc partitions of Fin i) × (nc partitions of Fin j) and take Fintype.card.",
-      "Alternative: construct the explicit Dyck-word ↔ non-crossing-partition bijection (sibling ballot-problem-oq-04-oq-01) and transport DyckWord.card_dyckWord_semilength_eq_catalan; heavier but reuses Mathlib's Dyck side.",
-      "Aristotle submission of the recurrence sorry was attempted but the MCP endpoint returned 'Resource not found' (service unavailable this session); retry the async submission next session."
+      "BLOCKED — do not re-attempt the bare recurrence without new infrastructure. Two viable unblock routes: (1) submit nonCrossingCount_recurrence to Aristotle once its endpoint is back; (2) build the explicit DyckWord ↔ non-crossing-Finpartition bijection (sibling ballot-problem-oq-04-oq-01) and transport Mathlib DyckWord catalan-count — heavier but reuses Mathlib."
     ]
   },
   "currentState": {

--- a/src/data/research/problems/factor-remainder-hasse-derivative-fq.json
+++ b/src/data/research/problems/factor-remainder-hasse-derivative-fq.json
@@ -1,0 +1,39 @@
+{
+  "id": "factor-remainder-hasse-derivative-fq",
+  "slug": "factor-remainder-hasse-derivative-fq",
+  "title": "Full Failure (and Reliability) Profile of the Ordinary-Derivative Multiplicity Test over 𝔽_q",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "significance": 5,
+  "tractability": 6,
+  "tags": ["polynomials", "hasse-derivative", "positive-characteristic", "finite-fields", "multiplicity"],
+  "problemStatement": "Pin down exactly where the ordinary iterated-derivative multiplicity test (X-a)^k ∣ p ↔ p,p',...,p^(k-1) vanish at a) breaks down over a characteristic-p field, and — the reliability complement added 2026-06-30 — exactly where it remains CORRECT.",
+  "relatedProofs": ["factor-remainder-theorem-oq-01-oq-02", "factor-remainder-theorem"],
+  "leanFiles": ["proofs/Proofs/FactorRemainderHasseDerivativeFq.lean"],
+  "lastUpdate": "2026-06-30",
+  "currentState": "VERIFIED 0-axiom, 0-sorry. Original failure profile (orders ≥ p blind; X^{p^e} overcount) plus new Part IV reliability profile shipped in PR #31634.",
+  "knowledge": {
+    "progressSummary": "COMPLETE+EXTENDED: original entry verified; added Part IV (reliability profile) 2026-06-30, VERIFIED 0-axiom, PR #31634.",
+    "insights": [
+      "The factorial threshold (k!:F)=0 ↔ p≤k governs everything: ordinary derivative = Hasse derivative scaled by k!, so the ordinary test is blind for k≥p and faithful for k<p.",
+      "Session 2026-06-30 (researcher-6): the entry was already SOLVED, so worked OUTWARD. The natural extension is the POSITIVE complement of the failure profile — the exact range m≤p in which the ordinary-derivative multiplicity test is a CORRECT criterion, plus a sharpness witness at m=p+1 (X^p).",
+      "Key reusable engine assembled from Mathlib primitives (taylor as AlgEquiv X↦X+a, taylor_coeff, X_pow_dvd_iff): the characteristic-free Hasse-derivative multiplicity criterion (X-C a)^n ∣ f ↔ ∀ j<n, (hasseDeriv j f).eval a = 0. Mathlib has the pieces but not this assembled criterion.",
+      "Bridge technique: (X-C a)^n ∣ f ↔ X^n ∣ taylor a f, proved by transporting divisibility through taylorAlgHom a (forward) and taylorAlgHom (-a) (reverse, via taylor_taylor + neg_add_cancel + taylor_zero). taylorAlgHom is @[simps!] so taylorAlgHom_apply (NOT coe_taylorAlgHom) is the function-level simp lemma that fires under map_dvd's coercion."
+    ],
+    "builtItems": [
+      "FactorRemainderHasseDerivativeFq.sub_pow_dvd_iff_X_pow_dvd_taylor : (X-C a)^n ∣ f ↔ X^n ∣ taylor a f (Taylor-shift transport).",
+      "FactorRemainderHasseDerivativeFq.sub_pow_dvd_iff_hasseDeriv_eval_eq_zero : characteristic-free Hasse multiplicity criterion (Mathlib-gap filler).",
+      "FactorRemainderHasseDerivativeFq.iterate_derivative_eval_eq : (derivative^[k] f).eval a = (k!:F) * (hasseDeriv k f).eval a (eval form of scaling identity).",
+      "FactorRemainderHasseDerivativeFq.ordinary_derivative_test_valid_range : over char-p field, m≤p ⟹ (X-C a)^m ∣ f ↔ ∀ j<m, (derivative^[j] f).eval a = 0 (ordinary test correct up to order p).",
+      "FactorRemainderHasseDerivativeFq.ordinary_derivative_test_sharp : m≤p is sharp — X^p witness mis-certified at m=p+1."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no assembled Hasse/Taylor-derivative multiplicity criterion (le_rootMultiplicity_iff exists for the (X-C a)^n ∣ p side, but nothing connects it to vanishing of hasseDeriv/taylor coefficients). sub_pow_dvd_iff_hasseDeriv_eval_eq_zero fills this — candidate for upstreaming."
+    ],
+    "nextSteps": [
+      "OQ-01: characterize the full set of (f,a,m) over 𝔽_q where the ordinary test mis-certifies at m>p, and the gap between ordinary-certified and true Hasse multiplicity.",
+      "OQ-02: upstream sub_pow_dvd_iff_hasseDeriv_eval_eq_zero to Mathlib as the divided-power companion of le_rootMultiplicity_iff; explore rootMultiplicity = natTrailingDegree (taylor a f)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Extends the **Full Failure Profile of the Ordinary-Derivative Multiplicity Test over 𝔽_q** entry (`factor-remainder-hasse-derivative-fq`) with its positive complement — **Part IV: the reliability profile**. The existing entry pinned down where the ordinary-derivative test goes *blind* (orders ≥ p); this PR proves the exact range in which it is a **correct** multiplicity criterion, and that the range is **sharp**.

All new results are **0-axiom** (`propext`/`Classical.choice`/`Quot.sound` only — verified via `#print axioms`), **0-sorry**, over any characteristic-`p` field (every 𝔽_q).

## New theorems

- **`sub_pow_dvd_iff_hasseDeriv_eval_eq_zero`** — characteristic-free **Hasse-derivative multiplicity criterion**:
  `(X - C a)^n ∣ f ↔ ∀ j < n, (hasseDeriv j f).eval a = 0`.
  Mathlib has the primitives (`taylor`, `taylor_coeff`, `X_pow_dvd_iff`) but not this assembled criterion. Engine: transport `X^n ∣ taylor a f` back along the Taylor shift `X ↦ X + a` (an `AlgEquiv`), via the new `sub_pow_dvd_iff_X_pow_dvd_taylor`.
- **`ordinary_derivative_test_valid_range`** — the headline char-`p` result: for `m ≤ p`,
  `(X - C a)^m ∣ f ↔ ∀ j < m, (derivative^[j] f).eval a = 0`.
  Below the factorial threshold each `(j! : F)` is a unit, so the ordinary and Hasse tests agree termwise. **The ordinary-derivative multiplicity test is reliable for all multiplicities up to p.**
- **`ordinary_derivative_test_sharp`** — `m ≤ p` is best possible: at `m = p+1` the test already mis-certifies multiplicity `≥ p+1` for `X^p` at `0` (all its derivatives vanish) even though `X^{p+1} ∤ X^p`.

Together with the existing "blind for k ≥ p" and `X^{p^e}` overcounting results, the entry now has both halves: *reliable exactly up to order p, useless from order p on.*

## Verification

`#print axioms` clean (0-axiom) on all three headline theorems; full file elaborates with no errors. Docker daemon was down this session, so verification used the host `lake env lean` workaround against the prebuilt Mathlib (no `lake build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)