### PR TITLE
research(stars-and-bars-weak-compositions-oq-04): convolution law + negative-binomial Vandermonde [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/StarsAndBarsWeakCompositionsOQ04.lean
+++ b/proofs/Proofs/StarsAndBarsWeakCompositionsOQ04.lean
@@ -1,0 +1,106 @@
+import Mathlib.RingTheory.PowerSeries.WellKnown
+import Mathlib.Tactic
+import Proofs.StarsAndBarsWeakCompositions
+import Proofs.StarsAndBarsWeakCompositionsOQ01
+
+/-
+# The Convolution Law for Weak-Composition Generating Functions
+
+## (stars-and-bars-weak-compositions-oq-04)
+
+The sibling entry `StarsAndBarsWeakCompositionsOQ01` identified the ordinary generating
+function of the weak-composition counts,
+
+  `W k = ∑ₙ #{f : Fin k → ℕ // ∑ᵢ f i = n} · Xⁿ ∈ S⟦X⟧`,
+
+with Mathlib's algebraic series `invOneSubPow S k = 1/(1 − X)ᵏ`. That entry stopped at the
+single-exponent statement `W k = (1 − X)⁻ᵏ`. This file records the **multiplicative**
+structure of the family `k ↦ W k` and reads off its enumerative shadow.
+
+## What this adds
+
+* **Convolution / exponent-additivity** (`weakCompositionGenFun_mul`):
+  `W k₁ · W k₂ = W (k₁ + k₂)`  for `k₁, k₂ > 0`.
+  Combinatorially this is *concatenation*: gluing a weak composition into `k₁` parts onto one
+  into `k₂` parts produces a weak composition into `k₁ + k₂` parts, and the bookkeeping of the
+  total `n` is exactly the Cauchy product of the two generating functions. Algebraically it is
+  the exponent-additivity of `(1 − X)⁻ᵏ`, i.e. Mathlib's `invOneSubPow_add`.
+
+* **Power law** (`weakCompositionGenFun_eq_pow`): `W k = (W 1)ᵏ` for `k > 0`. A single part has
+  generating function `W 1 = 1/(1 − X) = 1 + X + X² + ⋯`, and `k` independent parts multiply,
+  so `W k = (W 1)ᵏ`.
+
+* **Negative-binomial Vandermonde convolution** (`weakComposition_convolution`): reading off the
+  coefficient of `Xᵗ` in the product law gives the purely combinatorial identity
+
+  `∑_{(i,j) ∈ antidiagonal t} C(i + k₁ − 1, i) · C(j + k₂ − 1, j) = C(t + (k₁ + k₂) − 1, t)`.
+
+  This is the "stars and bars" / negative-binomial form of the Chu–Vandermonde convolution
+  (distinct from the standard `C(m + n, r) = ∑ C(m, i)·C(n, r − i)`); it is *not* recorded in
+  Mathlib. The generating-function bridge of OQ01 turns the analytic product law into this
+  finite binomial identity for free.
+
+## Status
+
+0 `sorry`, 0 `axiom`. Everything is a machine-checked consequence of the OQ01 bridge and the
+Mathlib `invOneSubPow` / `coeff_mul` API.
+-/
+
+open Finset PowerSeries
+open scoped BigOperators
+
+namespace StarsAndBarsGenFun
+
+variable (S : Type*) [CommRing S]
+
+/-- The coefficient of `Xⁿ` in `W k` spelled out as the negative-binomial number
+`C(n + k − 1, n)` (combining `coeff_weakCompositionGenFun` with the parent's
+`card_weakComposition`). Holds for every `k` (no positivity needed). -/
+theorem coeff_weakCompositionGenFun_eq_choose (k n : ℕ) :
+    coeff n (weakCompositionGenFun S k) = ((n + k - 1).choose n : S) := by
+  rw [coeff_weakCompositionGenFun, StarsAndBars.card_weakComposition]
+
+/-- **Convolution law / exponent-additivity.** For positive `k₁, k₂`, the generating function
+of weak compositions is multiplicative in the number of parts:
+`W k₁ · W k₂ = W (k₁ + k₂)`. This is the Cauchy-product incarnation of concatenating a weak
+composition into `k₁` parts with one into `k₂` parts, and on the algebraic side it is the
+exponent-additivity of `1/(1 − X)ᵏ` (`invOneSubPow_add`). -/
+theorem weakCompositionGenFun_mul (k₁ k₂ : ℕ) (h1 : 0 < k₁) (h2 : 0 < k₂) :
+    weakCompositionGenFun S k₁ * weakCompositionGenFun S k₂
+      = weakCompositionGenFun S (k₁ + k₂) := by
+  rw [weakCompositionGenFun_eq_invOneSubPow S k₁ h1,
+    weakCompositionGenFun_eq_invOneSubPow S k₂ h2,
+    weakCompositionGenFun_eq_invOneSubPow S (k₁ + k₂) (by omega),
+    invOneSubPow_add, Units.val_mul]
+
+/-- **Power law.** For positive `k`, `W k = (W 1)ᵏ`: a weak composition into `k` parts is `k`
+independent single parts, each with generating function `W 1 = 1/(1 − X)`, so the generating
+functions multiply. -/
+theorem weakCompositionGenFun_eq_pow (k : ℕ) (hk : 0 < k) :
+    weakCompositionGenFun S k = (weakCompositionGenFun S 1) ^ k := by
+  have hu : invOneSubPow S k = (invOneSubPow S 1) ^ k := by
+    rw [invOneSubPow_eq_inv_one_sub_pow, invOneSubPow_eq_inv_one_sub_pow, pow_one]
+  rw [weakCompositionGenFun_eq_invOneSubPow S k hk,
+    weakCompositionGenFun_eq_invOneSubPow S 1 one_pos, hu, Units.val_pow_eq_pow_val]
+
+/-- **Negative-binomial Vandermonde convolution.** Reading off the coefficient of `Xᵗ` in the
+product law `W k₁ · W k₂ = W (k₁ + k₂)` yields the finite binomial identity
+
+`∑_{(i,j) ∈ antidiagonal t} C(i + k₁ − 1, i) · C(j + k₂ − 1, j) = C(t + (k₁ + k₂) − 1, t)`.
+
+This is the stars-and-bars / negative-binomial form of the Chu–Vandermonde convolution; it is
+not in Mathlib. The proof passes through the generating-function bridge of OQ01 over `ℤ` and
+casts the resulting power-series coefficient identity back to `ℕ`. -/
+theorem weakComposition_convolution (k₁ k₂ : ℕ) (h1 : 0 < k₁) (h2 : 0 < k₂) (t : ℕ) :
+    ∑ ij ∈ antidiagonal t,
+        (ij.1 + k₁ - 1).choose ij.1 * (ij.2 + k₂ - 1).choose ij.2
+      = (t + (k₁ + k₂) - 1).choose t := by
+  -- Coefficient of `Xᵗ` on both sides of the product law, computed over `ℤ`.
+  have key : (coeff t) (weakCompositionGenFun ℤ k₁ * weakCompositionGenFun ℤ k₂)
+      = (coeff t) (weakCompositionGenFun ℤ (k₁ + k₂)) := by
+    rw [weakCompositionGenFun_mul ℤ k₁ k₂ h1 h2]
+  rw [coeff_mul] at key
+  simp only [coeff_weakCompositionGenFun_eq_choose] at key
+  exact_mod_cast key
+
+end StarsAndBarsGenFun

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-04/annotations.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-04/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Multiplicative structure of the weak-composition generating function",
+    "content": "OQ-01 identified the enumerative generating function W k = ∑ₙ #{f : Fin k → ℕ // ∑ᵢ f i = n}·Xⁿ with Mathlib's algebraic series invOneSubPow S k = 1/(1−X)ᵏ but stopped at a single exponent. This entry records how the family k ↦ W k multiplies: the convolution law W k₁·W k₂ = W (k₁+k₂), the power law W k = (W 1)ᵏ, and — reading off coefficients — the negative-binomial Vandermonde convolution ∑_{i+j=t} C(i+k₁−1,i)·C(j+k₂−1,j) = C(t+k₁+k₂−1, t). Combinatorially the first is concatenation of weak compositions, the second is 'k independent single parts', and the third is the coefficient bookkeeping of the Cauchy product.",
+    "mathContext": "$W_{k_1}\\cdot W_{k_2}=W_{k_1+k_2},\\quad W_k=(W_1)^k,\\quad \\sum_{i+j=t}\\binom{i+k_1-1}{i}\\binom{j+k_2-1}{j}=\\binom{t+k_1+k_2-1}{t}.$",
+    "significance": "central",
+    "relatedConcepts": [
+      "generating function",
+      "Cauchy product / convolution",
+      "negative-binomial series",
+      "Chu–Vandermonde identity",
+      "invOneSubPow"
+    ],
+    "prerequisites": [
+      "OQ-01 identification W k = invOneSubPow.val",
+      "formal power series over a ring",
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-coeff-formula",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 56,
+      "endLine": 61
+    },
+    "type": "technique",
+    "title": "Coefficient reader: [Xⁿ] W k = C(n+k−1, n)",
+    "content": "coeff_weakCompositionGenFun_eq_choose chains two imported facts: OQ-01's coeff_weakCompositionGenFun says the n-th coefficient of W k is the cast of the count #{f : Fin k → ℕ // ∑ f = n}, and the grandparent's StarsAndBars.card_weakComposition says that count is C(n+k−1, n). The rewrite goes straight under the Nat.cast wrapper, so no positivity is required (card_weakComposition is unrestricted in k). This lemma is the reusable bridge that lets the coefficient-extraction step of the convolution turn each power-series coefficient into a binomial number.",
+    "mathContext": "$[X^n]\\,W_k = \\bigl(\\tbinom{n+k-1}{n} : S\\bigr).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "PowerSeries.coeff",
+      "card_weakComposition",
+      "Nat.cast"
+    ],
+    "prerequisites": [
+      "coeff_weakCompositionGenFun (OQ-01)",
+      "card_weakComposition (parent)"
+    ]
+  },
+  {
+    "id": "ann-convolution-law",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 63,
+      "endLine": 74
+    },
+    "type": "key-step",
+    "title": "Convolution law via invOneSubPow_add",
+    "content": "weakCompositionGenFun_mul is the exponent-additivity of W. For positive k₁, k₂ the three generating functions are rewritten through OQ-01's weakCompositionGenFun_eq_invOneSubPow into vals of invOneSubPow (the exponent k₁+k₂ > 0 is discharged by omega). Mathlib's invOneSubPow_add factors invOneSubPow S (k₁+k₂) as invOneSubPow S k₁ · invOneSubPow S k₂ in the unit group, and Units.val_mul distributes the value coercion, leaving both sides syntactically equal. The point: because OQ-01 proved an equality of power series, the unit-level multiplicativity of invOneSubPow transfers verbatim — no combinatorial concatenation argument is needed.",
+    "mathContext": "$\\tfrac{1}{(1-X)^{k_1}}\\cdot\\tfrac{1}{(1-X)^{k_2}}=\\tfrac{1}{(1-X)^{k_1+k_2}}.$",
+    "significance": "central",
+    "relatedConcepts": [
+      "invOneSubPow_add",
+      "Units.val_mul",
+      "exponent additivity"
+    ],
+    "prerequisites": [
+      "weakCompositionGenFun_eq_invOneSubPow (OQ-01)",
+      "units of a commutative ring"
+    ]
+  },
+  {
+    "id": "ann-power-law",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 76,
+      "endLine": 84
+    },
+    "type": "key-step",
+    "title": "Power law W k = (W 1)ᵏ — answering OQ-01's open question",
+    "content": "weakCompositionGenFun_eq_pow exhibits the whole family as powers of the single-part series. The unit equality invOneSubPow S k = (invOneSubPow S 1)^k is obtained by rewriting both sides through invOneSubPow_eq_inv_one_sub_pow — which presents invOneSubPow S d as the d-th power of the fixed unit (1−X)⁻¹ — and simplifying the inner pow_one. Transporting to generating functions via weakCompositionGenFun_eq_invOneSubPow and Units.val_pow_eq_pow_val gives W k = (W 1)ᵏ. Since W 1 = 1/(1−X) = ∑ₙ Xⁿ, this is the geometric-series factorization flagged as OQ-01's first open question: a weak composition into k parts is an independent choice of one nonnegative integer per part.",
+    "mathContext": "$W_k=(W_1)^k,\\qquad W_1=\\tfrac{1}{1-X}=\\sum_n X^n.$",
+    "significance": "central",
+    "relatedConcepts": [
+      "invOneSubPow_eq_inv_one_sub_pow",
+      "Units.val_pow_eq_pow_val",
+      "geometric series"
+    ],
+    "prerequisites": [
+      "weakCompositionGenFun_eq_invOneSubPow (OQ-01)",
+      "powers in the unit group"
+    ]
+  },
+  {
+    "id": "ann-vandermonde",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 86,
+      "endLine": 106
+    },
+    "type": "key-step",
+    "title": "Negative-binomial Vandermonde convolution by coefficient extraction",
+    "content": "weakComposition_convolution turns the analytic product law into a finite binomial identity. Over S = ℤ, take the coefficient of Xᵗ on both sides of weakCompositionGenFun_mul: PowerSeries.coeff_mul rewrites the left coefficient as ∑_{(i,j) ∈ antidiagonal t} coeff i (W k₁)·coeff j (W k₂), then simp with coeff_weakCompositionGenFun_eq_choose replaces every coefficient by its binomial cast. The resulting ℤ-equation is the cast of a ℕ-identity, so exact_mod_cast lands ∑_{i+j=t} C(i+k₁−1,i)·C(j+k₂−1,j) = C(t+k₁+k₂−1, t). No bijection is built — the convolution is a free consequence of the Cauchy product. This is the negative-binomial form of Chu–Vandermonde, not present in Mathlib.",
+    "mathContext": "$\\sum_{i+j=t}\\binom{i+k_1-1}{i}\\binom{j+k_2-1}{j}=\\binom{t+k_1+k_2-1}{t}.$",
+    "significance": "central",
+    "relatedConcepts": [
+      "PowerSeries.coeff_mul",
+      "Finset.antidiagonal",
+      "Nat.cast injectivity",
+      "Chu–Vandermonde identity"
+    ],
+    "prerequisites": [
+      "coeff_weakCompositionGenFun_eq_choose",
+      "weakCompositionGenFun_mul",
+      "exact_mod_cast / push_cast"
+    ]
+  }
+]

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-04/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-04/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "stars-and-bars-weak-compositions-oq-04",
+  "title": "The Convolution Law for Weak Compositions: W(k₁)·W(k₂) = W(k₁+k₂) and the Negative-Binomial Vandermonde Identity",
+  "slug": "stars-and-bars-weak-compositions-oq-04",
+  "description": "The sibling entry stars-and-bars-weak-compositions-oq-01 identified the ordinary generating function of the weak-composition counts, W k = ∑ₙ #{f : Fin k → ℕ // ∑ᵢ f i = n} · Xⁿ ∈ S⟦X⟧, with Mathlib's algebraic series invOneSubPow S k = 1/(1−X)ᵏ, but stopped at the single-exponent statement. This entry records the MULTIPLICATIVE structure of the family k ↦ W k and reads off its enumerative shadow. (1) Convolution / exponent-additivity (weakCompositionGenFun_mul): W k₁ · W k₂ = W (k₁+k₂) for k₁,k₂ > 0 — combinatorially the concatenation of a weak composition into k₁ parts with one into k₂ parts, algebraically the exponent-additivity invOneSubPow_add of (1−X)⁻ᵏ. (2) Power law (weakCompositionGenFun_eq_pow): W k = (W 1)ᵏ for k > 0 — k independent single parts, each with generating function W 1 = 1/(1−X), multiply. This directly answers the first open question of OQ-01. (3) Negative-binomial Vandermonde convolution (weakComposition_convolution): reading off the coefficient of Xᵗ in the product law gives the finite binomial identity ∑_{(i,j) ∈ antidiagonal t} C(i+k₁−1, i)·C(j+k₂−1, j) = C(t+(k₁+k₂)−1, t), the stars-and-bars / negative-binomial form of the Chu–Vandermonde convolution (distinct from the standard C(m+n,r)=∑C(m,i)C(n,r−i)), which is not recorded in Mathlib. The generating-function bridge of OQ-01 turns the analytic product law into this finite combinatorial identity for free.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.PowerSeries.WellKnown",
+      "Mathlib.Tactic",
+      "Proofs.StarsAndBarsWeakCompositions",
+      "Proofs.StarsAndBarsWeakCompositionsOQ01"
+    ],
+    "opens": [
+      "Finset",
+      "PowerSeries"
+    ],
+    "namespace": "StarsAndBarsGenFun",
+    "lineCount": 106,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/StarsAndBarsWeakCompositionsOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Vandermonde%27s_identity",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StarsAndBarsWeakCompositionsOQ04.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "generating-functions",
+      "stars-and-bars",
+      "weak-compositions",
+      "power-series",
+      "negative-binomial-series",
+      "binomial-coefficients",
+      "vandermonde-convolution",
+      "counting"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "relatedProblems": [
+      {
+        "id": "stars-and-bars-weak-compositions-oq-01",
+        "relationship": "Direct parent. OQ-01 identified the enumerative generating function W k of the weak-composition counts with Mathlib's algebraic series invOneSubPow S k = 1/(1−X)ᵏ. This entry builds on that identification to establish the multiplicative law W k₁ · W k₂ = W (k₁+k₂) and the power law W k = (W 1)ᵏ, the latter answering OQ-01's first listed open question (the geometric-series factorization of invOneSubPow as a k-fold product, re-deriving the count via coeff_mul). It then extracts the negative-binomial Vandermonde convolution by reading off coefficients."
+      },
+      {
+        "id": "stars-and-bars-weak-compositions",
+        "relationship": "Grandparent. The base entry supplies card_weakComposition (the count C(n+k−1, n)) and the Fintype instance on the summing subtype, reused here at the coefficient level to convert each power-series coefficient into a binomial number before casting the product identity back to ℕ."
+      },
+      {
+        "id": "stars-and-bars-weak-compositions-oq-02",
+        "relationship": "Sibling refinement (bounded parts). OQ-02 multiplies the 1/(1−X)ᵏ denominator by the numerator (1−X^{b+1})ᵏ to bound each part by b. The convolution law proved here is the unbounded-part archetype: the same multiplicativity W k₁·W k₂ = W (k₁+k₂) governs how the bounded family composes when the bounds agree."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 106,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All four public theorems — coeff_weakCompositionGenFun_eq_choose, weakCompositionGenFun_mul (W k₁·W k₂ = W (k₁+k₂)), weakCompositionGenFun_eq_pow (W k = (W 1)ᵏ), and weakComposition_convolution (the negative-binomial Vandermonde identity) — were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The multiplicative laws require 0 < k₁, 0 < k₂ (resp. 0 < k), inherited from OQ-01's identification W k = invOneSubPow.val, which is stated for positive exponents (the k = 0 case is the constant series 1, a separate degenerate branch). The new content beyond Mathlib and the imported parents is twofold: (i) the multiplicative/power structure of the family k ↦ W k, obtained by transporting Mathlib's invOneSubPow_add and invOneSubPow_eq_inv_one_sub_pow through OQ-01's identification; and (ii) the resulting finite binomial identity ∑_{i+j=t} C(i+k₁−1,i)·C(j+k₂−1,j) = C(t+k₁+k₂−1,t), proved by taking the coefficient of Xᵗ over ℤ via PowerSeries.coeff_mul and casting back to ℕ with exact_mod_cast. This negative-binomial convolution is not in Mathlib. Sanity check: at k₁ = k₂ = 1 it reads ∑_{i+j=t} 1·1 = t+1 = C(t+1, t), the t+1 ways to split t = i + j.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The ordinary generating function (1−x)⁻ᵏ = ∑ₙ C(n+k−1, n) xⁿ is the k-fold product of the geometric series 1/(1−x), reflecting that a weak composition of n into k parts is an independent choice of one geometric factor per part. Multiplying generating functions corresponds to convolving coefficient sequences (the Cauchy product), so the identity (1−x)^{-k₁}·(1−x)^{-k₂} = (1−x)^{-(k₁+k₂)} — itself just the exponent law for powers — encodes, coefficient by coefficient, the convolution ∑_{i+j=t} C(i+k₁−1, i)·C(j+k₂−1, j) = C(t+k₁+k₂−1, t). This is the negative-binomial sibling of the Chu–Vandermonde identity C(m+n, r) = ∑ᵢ C(m, i)·C(n, r−i): both are coefficient extractions from a multiplicative law for generating functions, the former from (1−x)⁻ᵏ and the latter from (1+x)ᵏ. The combinatorial reading is concatenation: a weak composition into k₁+k₂ parts of total t splits uniquely, at the boundary between the first k₁ parts and the last k₂, into a weak composition of some i into k₁ parts and one of t−i into k₂ parts.",
+    "problemStatement": "Establish the multiplicative structure of the weak-composition generating function family: prove W(k₁)·W(k₂) = W(k₁+k₂) and W(k) = W(1)ᵏ in S⟦X⟧, and extract the resulting finite binomial identity ∑_{(i,j) ∈ antidiagonal t} C(i+k₁−1, i)·C(j+k₂−1, j) = C(t+(k₁+k₂)−1, t).",
+    "text": "The parent entry OQ-01 proved weakCompositionGenFun_eq_invOneSubPow: for 0 < k, the enumerative generating function W k of weak-composition counts equals (invOneSubPow S k).val, Mathlib's algebraic series 1/(1−X)ᵏ. Mathlib also proves invOneSubPow_add : invOneSubPow S (d+e) = invOneSubPow S d · invOneSubPow S e and invOneSubPow_eq_inv_one_sub_pow exhibiting invOneSubPow S d as a d-th power of the unit (1−X)⁻¹. Transporting these two algebraic facts through OQ-01's identification gives the convolution law and the power law for W. PowerSeries.coeff_mul then expands the coefficient of Xᵗ in a product as a sum over antidiagonal t, and OQ-01's coefficient formula turns each factor into a negative-binomial number; working over ℤ and casting back to ℕ yields the convolution identity as a statement about natural numbers.",
+    "proofStrategy": "coeff_weakCompositionGenFun_eq_choose combines OQ-01's coeff_weakCompositionGenFun with the parent's card_weakComposition to give coeff n (W k) = (C(n+k−1, n) : S) for every k (no positivity needed: card_weakComposition is unrestricted). weakCompositionGenFun_mul rewrites all three generating functions via weakCompositionGenFun_eq_invOneSubPow (each needing its exponent positive, with k₁+k₂ > 0 by omega), then closes with Mathlib's invOneSubPow_add and Units.val_mul. weakCompositionGenFun_eq_pow first shows invOneSubPow S k = (invOneSubPow S 1)^k by rewriting both sides through invOneSubPow_eq_inv_one_sub_pow and pow_one, then transports to W via Units.val_pow_eq_pow_val. weakComposition_convolution takes the coefficient of Xᵗ on both sides of weakCompositionGenFun_mul over S = ℤ: PowerSeries.coeff_mul expands the left side as ∑_{(i,j) ∈ antidiagonal t} coeff i (W k₁) · coeff j (W k₂), simp [coeff_weakCompositionGenFun_eq_choose] rewrites every coefficient as a binomial cast, and exact_mod_cast strips the ℤ-casts to land the identity in ℕ.",
+    "keyInsights": [
+      "**Multiplicativity is inherited, not reproved**: the convolution law W k₁·W k₂ = W (k₁+k₂) is not a fresh combinatorial argument — it is Mathlib's invOneSubPow_add (the exponent law for (1−X)⁻ᵏ) pulled back across OQ-01's identification of the enumerative series with the algebraic one. This is the payoff of having proved an *equality of power series* in OQ-01 rather than a mere coefficientwise numeric agreement: every algebraic identity for invOneSubPow transfers verbatim.",
+      "**The power law answers OQ-01's open question**: weakCompositionGenFun_eq_pow (W k = (W 1)ᵏ) is exactly the geometric-series factorization flagged as the first open question of OQ-01. A weak composition into k parts is an independent choice of one nonnegative integer per part, and W 1 = 1/(1−X) = ∑ₙ Xⁿ is the generating function of a single part, so the k parts multiply.",
+      "**Coefficient extraction is the bridge from analysis to combinatorics**: the finite identity ∑_{i+j=t} C(i+k₁−1,i)·C(j+k₂−1,j) = C(t+k₁+k₂−1,t) is a purely combinatorial statement, but it is obtained with no combinatorial bijection — only PowerSeries.coeff_mul applied to the analytic product law and a cast back to ℕ. The generating-function formalism does the convolution bookkeeping automatically.",
+      "**Negative-binomial, not ordinary, Vandermonde**: this convolution is the (1−x)⁻ᵏ form, distinct from Mathlib's setting around (1+x)ᵏ. Mathlib has the ordinary binomial theorem and add_pow_le-type results but does not record this negative-binomial convolution; it is the natural identity living on the weak-composition side and is new content.",
+      "**Working over ℤ is a convenience, not a restriction**: the multiplicative laws hold over an arbitrary commutative ring (they are formal), but the convolution identity is a statement about natural numbers, so the proof specializes to S = ℤ — an integral domain where Nat.cast is injective — and casts back. Any infinite characteristic-zero ring would do equally well."
+    ],
+    "prerequisites": [
+      "The OQ-01 identification weakCompositionGenFun_eq_invOneSubPow (W k = (invOneSubPow S k).val for 0 < k) and its coefficient reader coeff_weakCompositionGenFun",
+      "The grandparent count StarsAndBars.card_weakComposition : #{f : Fin k → ℕ // ∑ f = n} = C(n+k−1, n)",
+      "Mathlib's invOneSubPow_add (invOneSubPow S (d+e) = invOneSubPow S d · invOneSubPow S e) and invOneSubPow_eq_inv_one_sub_pow (invOneSubPow as a power of the unit (1−X)⁻¹)",
+      "The unit coercions Units.val_mul and Units.val_pow_eq_pow_val turning unit products/powers into power-series products/powers",
+      "PowerSeries.coeff_mul : coeff n (φ·ψ) = ∑_{p ∈ antidiagonal n} coeff p.1 φ · coeff p.2 ψ, and Nat.cast injectivity (via exact_mod_cast) to descend from ℤ to ℕ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-and-coefficient-formula",
+      "title": "Setup and the Coefficient Formula",
+      "startLine": 1,
+      "endLine": 61,
+      "mathContext": "$[X^n]\\,W_k = \\binom{n+k-1}{n}$ in $S$.",
+      "summary": "The module docstring states the three results — the convolution law, the power law, and the negative-binomial Vandermonde identity — and locates the new content relative to OQ-01 and Mathlib. coeff_weakCompositionGenFun_eq_choose is the reusable coefficient reader: chaining OQ-01's coeff_weakCompositionGenFun (coefficient = cast of the count) with the grandparent's card_weakComposition (count = C(n+k−1, n)) gives coeff n (W k) = (C(n+k−1, n) : S) for every k, with no positivity hypothesis."
+    },
+    {
+      "id": "convolution-law",
+      "title": "The Convolution Law W(k₁)·W(k₂) = W(k₁+k₂)",
+      "startLine": 63,
+      "endLine": 74,
+      "mathContext": "$W_{k_1}\\cdot W_{k_2} = W_{k_1+k_2}$.",
+      "summary": "weakCompositionGenFun_mul is the exponent-additivity of the generating function. For positive k₁, k₂ (hence positive k₁+k₂), all three series are rewritten via OQ-01's weakCompositionGenFun_eq_invOneSubPow into vals of invOneSubPow; Mathlib's invOneSubPow_add factors invOneSubPow S (k₁+k₂) as a unit product, and Units.val_mul distributes the val over it, matching the left-hand side. Combinatorially this is concatenation of weak compositions; algebraically it is (1−X)^{-k₁}·(1−X)^{-k₂} = (1−X)^{-(k₁+k₂)}."
+    },
+    {
+      "id": "power-law",
+      "title": "The Power Law W(k) = W(1)ᵏ",
+      "startLine": 76,
+      "endLine": 84,
+      "mathContext": "$W_k = (W_1)^k = \\bigl(1/(1-X)\\bigr)^k$.",
+      "summary": "weakCompositionGenFun_eq_pow answers OQ-01's first open question. The unit identity invOneSubPow S k = (invOneSubPow S 1)^k follows by rewriting both sides through invOneSubPow_eq_inv_one_sub_pow (each invOneSubPow is a power of the unit (1−X)⁻¹) and pow_one; transporting it to the generating functions via weakCompositionGenFun_eq_invOneSubPow and Units.val_pow_eq_pow_val gives W k = (W 1)ᵏ. This is the geometric-series factorization: a weak composition into k parts is k independent single-part choices, and W 1 = 1/(1−X)."
+    },
+    {
+      "id": "vandermonde-corollary",
+      "title": "The Negative-Binomial Vandermonde Convolution",
+      "startLine": 86,
+      "endLine": 106,
+      "mathContext": "$\\sum_{i+j=t}\\binom{i+k_1-1}{i}\\binom{j+k_2-1}{j} = \\binom{t+k_1+k_2-1}{t}$.",
+      "summary": "weakComposition_convolution extracts the finite binomial identity from the product law. Taking the coefficient of Xᵗ on both sides of weakCompositionGenFun_mul over S = ℤ, PowerSeries.coeff_mul expands the left coefficient as ∑_{(i,j) ∈ antidiagonal t} coeff i (W k₁)·coeff j (W k₂); simp with coeff_weakCompositionGenFun_eq_choose turns each coefficient into a binomial cast, and exact_mod_cast descends the resulting ℤ-equation to the natural-number identity ∑ C(i+k₁−1,i)·C(j+k₂−1,j) = C(t+k₁+k₂−1, t). No combinatorial bijection is constructed; the convolution is a free consequence of the Cauchy product."
+    }
+  ],
+  "conclusion": {
+    "summary": "The multiplicative structure of the weak-composition generating function is formalized sorry-free and axiom-free. W k₁·W k₂ = W (k₁+k₂) (weakCompositionGenFun_mul) and W k = (W 1)ᵏ (weakCompositionGenFun_eq_pow) are obtained by transporting Mathlib's invOneSubPow_add and invOneSubPow_eq_inv_one_sub_pow through OQ-01's identification of the enumerative series with the algebraic one. Reading off the coefficient of Xᵗ in the product law yields the negative-binomial Vandermonde convolution ∑_{(i,j) ∈ antidiagonal t} C(i+k₁−1, i)·C(j+k₂−1, j) = C(t+(k₁+k₂)−1, t) (weakComposition_convolution), a finite binomial identity not in Mathlib.",
+    "implications": "The convolution law is the structural backbone of the entire stars-and-bars/composition family: it says the negative-binomial sequences C(·+k−1, ·) form a multiplicative monoid under convolution indexed by the number of parts, and the power law exhibits the whole family as powers of the single geometric sequence (1,1,1,…). Because the laws are proved as equalities of power series, they compose with the bounded-parts (OQ-02) and positive-parts siblings, which differ only by polynomial numerators. The convolution identity itself is a candidate Mathlib contribution (Nat.choose convolution for the negative-binomial / multichoose numbers), filling the gap left by Mathlib's (1+x)ᵏ-side Vandermonde results.",
+    "openQuestions": [
+      "Generalize the convolution law to a finite product W(k₁)·W(k₂)·⋯·W(k_m) = W(∑ kᵢ) over a list of positive part-counts, and read off the multinomial negative-binomial convolution ∑ C(i₁+k₁−1, i₁)·⋯·C(i_m+k_m−1, i_m) = C(t+∑kⱼ−1, t) summed over compositions i₁+⋯+i_m = t.",
+      "Extend the convolution identity to the k = 0 boundary by proving W 0 = 1 directly (the constant series, from the unique empty weak composition), removing the positivity hypotheses and giving the identity for all k₁, k₂ ≥ 0."
+    ]
+  },
+  "crossReferences": [
+    "stars-and-bars-weak-compositions-oq-01",
+    "stars-and-bars-weak-compositions",
+    "stars-and-bars-weak-compositions-oq-02"
+  ]
+}

--- a/src/data/research/problems/stars-and-bars-weak-compositions-oq-04.json
+++ b/src/data/research/problems/stars-and-bars-weak-compositions-oq-04.json
@@ -1,0 +1,28 @@
+{
+  "id": "stars-and-bars-weak-compositions-oq-04",
+  "title": "The Convolution Law for Weak Compositions and the Negative-Binomial Vandermonde Identity",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "knowledge": {
+    "progressSummary": "COMPLETE (verified, 0-axiom): proved the multiplicative structure of the weak-composition generating function family on top of OQ-01's identification W k = invOneSubPow.val. Three results, all #print-axioms-clean (propext/Classical.choice/Quot.sound only).",
+    "insights": [
+      "OQ-01 having proved an EQUALITY OF POWER SERIES (W k = invOneSubPow.val), not just coefficientwise numeric agreement, is what makes the convolution law free: Mathlib's unit-level invOneSubPow_add transports verbatim to give W k₁·W k₂ = W (k₁+k₂).",
+      "The power law W k = (W 1)ᵏ is exactly OQ-01's first open question (geometric-series factorization). Proved via invOneSubPow_eq_inv_one_sub_pow (invOneSubPow S d = unit (1−X)⁻¹ to the d) + Units.val_pow_eq_pow_val.",
+      "The negative-binomial Vandermonde convolution ∑_{i+j=t} C(i+k₁−1,i)·C(j+k₂−1,j) = C(t+k₁+k₂−1, t) falls out of coeff_mul on the product law over ℤ + exact_mod_cast — no combinatorial bijection. It is the (1−x)⁻ᵏ analogue of Chu–Vandermonde and is NOT in Mathlib.",
+      "coeff_weakCompositionGenFun_eq_choose (coeff n (W k) = (C(n+k−1,n):S)) needs no positivity — card_weakComposition is unrestricted; the rewrite goes under the Nat.cast wrapper."
+    ],
+    "builtItems": [
+      "StarsAndBarsGenFun.coeff_weakCompositionGenFun_eq_choose : coeff n (W S k) = ((n+k-1).choose n : S) (Proofs/StarsAndBarsWeakCompositionsOQ04.lean:59)",
+      "StarsAndBarsGenFun.weakCompositionGenFun_mul : W S k₁ * W S k₂ = W S (k₁+k₂) for 0<k₁,0<k₂ (OQ04.lean:68)",
+      "StarsAndBarsGenFun.weakCompositionGenFun_eq_pow : W S k = (W S 1)^k for 0<k (OQ04.lean:79)",
+      "StarsAndBarsGenFun.weakComposition_convolution : ∑ ij ∈ antidiagonal t, (ij.1+k₁-1).choose ij.1 * (ij.2+k₂-1).choose ij.2 = (t+(k₁+k₂)-1).choose t (OQ04.lean:94)"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the (1+x)ᵏ-side binomial theorem but does not record the negative-binomial (multichoose) convolution ∑ C(i+k₁−1,i)·C(j+k₂−1,j) = C(t+k₁+k₂−1, t). Candidate upstream contribution as a Nat.choose convolution lemma."
+    ],
+    "nextSteps": [
+      "Generalize weakCompositionGenFun_mul to a finite product over a list of positive part-counts → multinomial negative-binomial convolution.",
+      "Prove W 0 = 1 directly (unique empty weak composition) to drop the positivity hypotheses and cover k = 0."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

A verified follow-up to **stars-and-bars-weak-compositions-oq-01**, which identified the weak-composition generating function `W k = ∑ₙ #{f : Fin k → ℕ // ∑ᵢ f i = n}·Xⁿ` with Mathlib's algebraic series `invOneSubPow S k = 1/(1−X)ᵏ`. That entry stopped at a single exponent; this one records the **multiplicative structure** of the family `k ↦ W k` and reads off its enumerative shadow.

Three results (`Proofs/StarsAndBarsWeakCompositionsOQ04.lean`, 106 lines):

- **`weakCompositionGenFun_mul`** — `W k₁ · W k₂ = W (k₁+k₂)` for `k₁,k₂ > 0`. Combinatorially the concatenation of weak compositions; algebraically the exponent-additivity of `(1−X)⁻ᵏ` (Mathlib's `invOneSubPow_add`), transported verbatim because OQ-01 proved an *equality of power series*.
- **`weakCompositionGenFun_eq_pow`** — `W k = (W 1)ᵏ` for `k > 0`. This is exactly **OQ-01's first listed open question** (the geometric-series factorization: a weak composition into `k` parts is `k` independent single-part choices, `W 1 = 1/(1−X)`).
- **`weakComposition_convolution`** — the finite binomial identity
  `∑_{(i,j) ∈ antidiagonal t} C(i+k₁−1, i)·C(j+k₂−1, j) = C(t+(k₁+k₂)−1, t)`,
  the negative-binomial / multichoose form of Chu–Vandermonde. Extracted from the product law by `PowerSeries.coeff_mul` over ℤ + `exact_mod_cast`; **not present in Mathlib** (which has the `(1+x)ᵏ`-side Vandermonde, not this one).

## Verification

`#print axioms` on all four public theorems reports only the foundational `propext / Classical.choice / Quot.sound` — **0 sorry, 0 axiom, no `native_decide`**. Built with the host `lake env lean` against cached Mathlib (Docker daemon was unavailable this session); toolchain `leanprover/lean4:v4.26.0`.

## Gallery

New entry `src/data/proofs/stars-and-bars-weak-compositions-oq-04/` (meta + annotations) and research-problem knowledge file. Sanity check baked into `assumptions`: at `k₁=k₂=1` the convolution reads `∑_{i+j=t} 1·1 = t+1 = C(t+1, t)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)