### PR TITLE
research(van-der-waerden-first-moment-oq-01-oq-01): exact fitting AP count via injectivity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/VanDerWaerdenFirstMomentOQ01OQ01.lean
+++ b/proofs/Proofs/VanDerWaerdenFirstMomentOQ01OQ01.lean
@@ -1,0 +1,178 @@
+/-
+  Exact enumeration of the fitting van der Waerden AP family
+  (open question van-der-waerden-first-moment-oq-01-oq-01)
+
+  The sibling entry `Proofs.VanDerWaerdenFirstMomentOQ01` sharpens the base
+  first-moment count: it bounds the length-`k` AP family by the exact parameter
+  sum
+
+        |vdwFamily n k|  ≤  ∑_{d=1}^{n} (n - (k-1)·d)         (`card_vdwFamily_le_sum`)
+
+  via `Finset.card_image_le` — the family is the *image* of the fitting parameter
+  box `{(a,d) : a + (k-1)d < n}` under `(a,d) ↦ vdwAP n a d k`, and an image can
+  only shrink the count.  The open question this file answers: **is that inequality
+  an equality?**  Equivalently, is the parametrization `(a, d) ↦ AP` injective on
+  the fitting box — does every fitting `(a, d)` give a *distinct* progression?
+
+  It does, for `k ≥ 2`.  A fitting AP `{a, a+d, …, a+(k-1)d}` has no wraparound in
+  `Fin n` (all terms are `< n`), so reading off its **least** element recovers the
+  first term `a`, and its **greatest** element recovers `a + (k-1)d`; with `k ≥ 2`
+  the factor `k-1 ≥ 1` then recovers the step `d`.  Hence the map is injective and
+
+        |vdwFamily n k|  =  ∑_{d=1}^{n} (n - (k-1)·d)         (`card_vdwFamily_eq_sum`)
+
+  — the sibling's upper bound is **tight**.  This is the matching *lower* bound the
+  gallery previously lacked: the family has *exactly* the triangular parameter
+  count, not merely at most it.  A clean closed-form consequence is the lower bound
+  `n - (k-1) ≤ |vdwFamily n k|` (`card_vdwFamily_ge`), the `d = 1` slice of length-`k`
+  intervals.
+
+  The recovery is phrased without `Finset.min'`/`max'` machinery: an element is the
+  least exactly when it is a member below every member, a property transported
+  across the equality of two AP sets directly.
+
+  Status: 0 sorries, 0 axioms, no `native_decide`.  #print axioms reports only
+  `propext, Classical.choice, Quot.sound`.
+-/
+import Mathlib
+import Proofs.VanDerWaerdenFirstMoment
+import Proofs.VanDerWaerdenFirstMomentOQ01
+
+namespace ProbMethod.VanDerWaerden
+
+open Finset
+open scoped BigOperators
+open scoped Fin.NatCast
+
+variable {n : ℕ} [NeZero n]
+
+/-! ## Endpoint recovery for a fitting arithmetic progression
+
+A fitting AP (`a + (k-1)d < n`) has all terms below `n`, so casting to `Fin n`
+introduces no wraparound and the `Fin n` order coincides with the natural order on
+the terms.  We isolate the two endpoints: the first term `a` is a member below
+every member, and the last term `a + (k-1)d` is a member above every member. -/
+
+/-- The first term `a` is a member of the AP (the `i = 0` term). -/
+private theorem vdwAP_fst_mem {a d k : ℕ} (hk : 1 ≤ k) :
+    (Nat.cast a : Fin n) ∈ vdwAP n a d k := by
+  rw [vdwAP, Finset.mem_image]
+  exact ⟨0, Finset.mem_range.mpr hk, by simp⟩
+
+/-- The first term `a` is `≤` every member of a fitting AP: each term `a + i·d`
+is a natural `< n`, so the `Fin n` casts compare as naturals. -/
+private theorem vdwAP_fst_le {a d k : ℕ} (hk : 1 ≤ k) (hbound : a + (k - 1) * d < n) :
+    ∀ y ∈ vdwAP n a d k, (Nat.cast a : Fin n) ≤ y := by
+  intro y hy
+  rw [vdwAP, Finset.mem_image] at hy
+  obtain ⟨i, hi, rfl⟩ := hy
+  rw [Finset.mem_range] at hi
+  have hbi : a + i * d < n := by
+    have : i * d ≤ (k - 1) * d := Nat.mul_le_mul_right d (by omega)
+    omega
+  have han : a < n := by
+    have : a ≤ a + (k - 1) * d := Nat.le_add_right _ _
+    omega
+  rw [Fin.le_def, Fin.val_cast_of_lt han, Fin.val_cast_of_lt hbi]
+  omega
+
+/-- The last term `a + (k-1)d` is a member of the AP (the `i = k-1` term). -/
+private theorem vdwAP_last_mem {a d k : ℕ} (hk : 1 ≤ k) :
+    (Nat.cast (a + (k - 1) * d) : Fin n) ∈ vdwAP n a d k := by
+  rw [vdwAP, Finset.mem_image]
+  exact ⟨k - 1, Finset.mem_range.mpr (by omega), rfl⟩
+
+/-- The last term `a + (k-1)d` is `≥` every member of a fitting AP. -/
+private theorem vdwAP_last_ge {a d k : ℕ} (hbound : a + (k - 1) * d < n) :
+    ∀ y ∈ vdwAP n a d k, y ≤ (Nat.cast (a + (k - 1) * d) : Fin n) := by
+  intro y hy
+  rw [vdwAP, Finset.mem_image] at hy
+  obtain ⟨i, hi, rfl⟩ := hy
+  rw [Finset.mem_range] at hi
+  have hile : i ≤ k - 1 := by omega
+  have hbi : a + i * d < n := by
+    have : i * d ≤ (k - 1) * d := Nat.mul_le_mul_right d hile
+    omega
+  have hid : i * d ≤ (k - 1) * d := Nat.mul_le_mul_right d hile
+  rw [Fin.le_def, Fin.val_cast_of_lt hbi, Fin.val_cast_of_lt hbound]
+  omega
+
+/-! ## Injectivity of the parametrization on the fitting box -/
+
+/-- **The fitting parametrization is injective.** On the parameter box
+`{(a, d) ∈ [0,n) × [1,n] : a + (k-1)d < n}`, the map `(a, d) ↦ vdwAP n a d k` is
+injective for `k ≥ 2`: from the AP set one recovers its least element `a` and its
+greatest element `a + (k-1)d`, and `k - 1 ≥ 1` then recovers `d`. -/
+private theorem vdwAP_injOn (k : ℕ) (hk : 2 ≤ k) :
+    Set.InjOn (fun p : ℕ × ℕ => vdwAP n p.1 p.2 k)
+      ↑(((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+          (fun p => p.1 + (k - 1) * p.2 < n)) := by
+  intro p hp q hq hpq
+  rw [Finset.mem_coe, Finset.mem_filter, Finset.mem_product, Finset.mem_range,
+    Finset.mem_Icc] at hp hq
+  obtain ⟨⟨hpa, _hpd1, _⟩, hpb⟩ := hp
+  obtain ⟨⟨hqa, _hqd1, _⟩, hqb⟩ := hq
+  have hk1 : 1 ≤ k := by omega
+  change vdwAP n p.1 p.2 k = vdwAP n q.1 q.2 k at hpq
+  -- Recover the first term: `↑p.1 = ↑q.1`.
+  have hqa_in_p : (Nat.cast q.1 : Fin n) ∈ vdwAP n p.1 p.2 k := by
+    rw [hpq]; exact vdwAP_fst_mem hk1
+  have hpa_in_q : (Nat.cast p.1 : Fin n) ∈ vdwAP n q.1 q.2 k := by
+    rw [← hpq]; exact vdwAP_fst_mem hk1
+  have h1 : (Nat.cast p.1 : Fin n) ≤ (Nat.cast q.1 : Fin n) := vdwAP_fst_le hk1 hpb _ hqa_in_p
+  have h2 : (Nat.cast q.1 : Fin n) ≤ (Nat.cast p.1 : Fin n) := vdwAP_fst_le hk1 hqb _ hpa_in_q
+  have hfa : (Nat.cast p.1 : Fin n) = (Nat.cast q.1 : Fin n) := le_antisymm h1 h2
+  have ha : p.1 = q.1 := by
+    have := congrArg Fin.val hfa
+    rwa [Fin.val_cast_of_lt hpa, Fin.val_cast_of_lt hqa] at this
+  -- Recover the last term: `↑(p.1+(k-1)p.2) = ↑(q.1+(k-1)q.2)`.
+  have hql_in_p : (Nat.cast (q.1 + (k - 1) * q.2) : Fin n) ∈ vdwAP n p.1 p.2 k := by
+    rw [hpq]; exact vdwAP_last_mem hk1
+  have hpl_in_q : (Nat.cast (p.1 + (k - 1) * p.2) : Fin n) ∈ vdwAP n q.1 q.2 k := by
+    rw [← hpq]; exact vdwAP_last_mem hk1
+  have h3 : (Nat.cast (p.1 + (k - 1) * p.2) : Fin n) ≤ (Nat.cast (q.1 + (k - 1) * q.2) : Fin n) :=
+    vdwAP_last_ge hqb _ hpl_in_q
+  have h4 : (Nat.cast (q.1 + (k - 1) * q.2) : Fin n) ≤ (Nat.cast (p.1 + (k - 1) * p.2) : Fin n) :=
+    vdwAP_last_ge hpb _ hql_in_p
+  have hfl : (Nat.cast (p.1 + (k - 1) * p.2) : Fin n) = (Nat.cast (q.1 + (k - 1) * q.2) : Fin n) :=
+    le_antisymm h3 h4
+  have hl : p.1 + (k - 1) * p.2 = q.1 + (k - 1) * q.2 := by
+    have := congrArg Fin.val hfl
+    rwa [Fin.val_cast_of_lt hpb, Fin.val_cast_of_lt hqb] at this
+  -- Combine: equal first terms + equal last terms + `k-1 ≥ 1` ⟹ equal steps.
+  have hd2 : p.2 = q.2 := by
+    have hmul : (k - 1) * p.2 = (k - 1) * q.2 := by omega
+    exact Nat.eq_of_mul_eq_mul_left (by omega) hmul
+  exact Prod.ext ha hd2
+
+/-! ## Exact count -/
+
+/-- **Exact enumeration of the fitting AP family.** For `k ≥ 2`, the number of
+length-`k` arithmetic progressions fitting in `[n]` is *exactly* the triangular
+parameter sum:
+`|vdwFamily n k| = ∑_{d=1}^{n} (n - (k-1)·d)`.
+
+This upgrades the sibling `card_vdwFamily_le_sum`'s upper bound to an equality: the
+parametrization `(a, d) ↦ AP` is injective (`vdwAP_injOn`), so the image has the
+same cardinality as the fitting box, whose size is the triangular sum
+(`vdwFilter_card_eq_sum`). -/
+theorem card_vdwFamily_eq_sum (k : ℕ) (hk : 2 ≤ k) :
+    (vdwFamily n k).card = ∑ d ∈ Finset.Icc 1 n, (n - (k - 1) * d) := by
+  rw [vdwFamily, Finset.card_image_of_injOn (vdwAP_injOn k hk)]
+  exact vdwFilter_card_eq_sum n k
+
+/-- **Closed-form lower bound on the family size.** Taking just the `d = 1` slice
+(the length-`k` intervals `[a, a+k-1]`) shows at least `n - (k-1)` length-`k` APs
+fit in `[n]`. Combined with the sibling factor-2 upper bound
+`2(k-1)·|family| ≤ n²`, the family size is pinned between `n-(k-1)` and
+`n²/(2(k-1))`. -/
+theorem card_vdwFamily_ge (k : ℕ) (hk : 2 ≤ k) :
+    n - (k - 1) ≤ (vdwFamily n k).card := by
+  rw [card_vdwFamily_eq_sum k hk]
+  have h1 : (1 : ℕ) ∈ Finset.Icc 1 n :=
+    Finset.mem_Icc.mpr ⟨le_refl 1, Nat.one_le_iff_ne_zero.mpr (NeZero.ne n)⟩
+  have := Finset.single_le_sum (f := fun d => n - (k - 1) * d)
+    (fun i _ => Nat.zero_le _) h1
+  simpa using this
+
+end ProbMethod.VanDerWaerden

--- a/research/problems/van-der-waerden-first-moment-oq-01-oq-01/knowledge.md
+++ b/research/problems/van-der-waerden-first-moment-oq-01-oq-01/knowledge.md
@@ -1,0 +1,63 @@
+# Knowledge Base: van-der-waerden-first-moment-oq-01-oq-01
+
+Exact enumeration of the fitting van der Waerden AP family.
+
+---
+
+## Problem
+
+The sibling entry `van-der-waerden-first-moment-oq-01` proves the upper bound
+`|vdwFamily n k| ≤ ∑_{d=1}^{n} (n - (k-1)d)` (`card_vdwFamily_le_sum`) via
+`Finset.card_image_le`: the family is the image of the fitting parameter box
+`{(a,d) : a + (k-1)d < n}` under `(a,d) ↦ vdwAP n a d k`. The open question:
+**is that bound an equality** — i.e. is the parametrization injective on the box?
+
+---
+
+## Insights
+
+- **Yes, for `k ≥ 2`.** A fitting AP has no wraparound in `Fin n` (all terms
+  `a + i·d < n`), so `Fin.val_cast_of_lt` reads off the underlying naturals and
+  the `Fin n` order matches the natural order on the terms.
+- Injectivity needs only the **two endpoints**: the least element recovers `a`,
+  the greatest recovers `a + (k-1)d`; with `k ≥ 2` the factor `k-1 ≥ 1` recovers
+  `d`. No need to reconstruct the entire set.
+- Extremum-by-membership ("`x` is least ⟺ `x` is a member `≤` all members")
+  transports across the equality of two AP sets directly, avoiding
+  `Finset.min'`/`max'` dependent-proof juggling.
+
+---
+
+## Built (Proofs/VanDerWaerdenFirstMomentOQ01OQ01.lean, namespace ProbMethod.VanDerWaerden)
+
+- `card_vdwFamily_eq_sum (k) (hk : 2 ≤ k)` :
+  `(vdwFamily n k).card = ∑ d ∈ Icc 1 n, (n - (k-1)*d)` — exact count (0 sorry).
+- `vdwAP_injOn (k) (hk : 2 ≤ k)` : the fitting parametrization is `Set.InjOn`.
+- `card_vdwFamily_ge (k) (hk : 2 ≤ k)` : `n - (k-1) ≤ (vdwFamily n k).card`,
+  the closed-form lower bound from the `d=1` interval slice.
+- Endpoint helpers `vdwAP_fst_mem / vdwAP_fst_le / vdwAP_last_mem / vdwAP_last_ge`.
+
+Reuses the sibling's `vdwFilter_card_eq_sum` (exact box count) and the base
+entry's `vdwAP` / `vdwFamily`.
+
+---
+
+## Status
+
+PROGRESS → exact count established. 0 sorries, 0 axioms (only
+`propext`/`Classical.choice`/`Quot.sound`), no `native_decide`.
+
+## Next Steps
+
+- Combine with the sibling `card_vdwFamily_two_mul_le` to bracket the family size
+  in `[n-(k-1), n²/(2(k-1))]`.
+- State the exact Gauss closed form of the triangular sum with cutoff
+  `D = ⌊(n-1)/(k-1)⌋`.
+
+---
+
+## Dead Ends
+
+- `Finset.min'`/`max'` recovery works but entangles the `Nonempty` proof in
+  dependent rewrites across the set equality; the membership-extremum phrasing
+  is cleaner.

--- a/src/data/proofs/van-der-waerden-first-moment-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-01-oq-01/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "vdw-oq0101-ann-header",
+    "proofId": "van-der-waerden-first-moment-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "concept",
+    "title": "Goal: Is the Family Bound Tight?",
+    "content": "The sibling entry van-der-waerden-first-moment-oq-01 bounds the number of length-k APs fitting in [n] ABOVE by the triangular sum ∑_{d=1}^{n}(n-(k-1)d), via Finset.card_image_le — the family is the image of the fitting (a,d) box under (a,d) ↦ vdwAP n a d k. This file answers the natural follow-up: is that inequality an equality? Equivalently, is the parametrization injective on the box — does every fitting (a,d) give a distinct progression? It does, for k ≥ 2, giving the EXACT count.",
+    "mathContext": "Sibling: $|\\mathrm{vdwFamily}\\,n\\,k| \\le \\sum_{d=1}^{n}(n-(k-1)d)$. This entry: equality, via injectivity of $(a,d)\\mapsto\\{a,a+d,\\dots,a+(k-1)d\\}$."
+  },
+  {
+    "id": "vdw-oq0101-ann-endpoints",
+    "proofId": "van-der-waerden-first-moment-oq-01-oq-01",
+    "range": { "startLine": 47, "endLine": 99 },
+    "type": "technique",
+    "title": "Endpoint Recovery Without min'/max'",
+    "content": "A fitting AP (a+(k-1)d < n) has all terms < n, so casting ℕ → Fin n is wraparound-free (Fin.val_cast_of_lt) and the Fin n order matches the natural order on the terms. The first term a is isolated as a member ≤ every member (vdwAP_fst_mem, vdwAP_fst_le); the last term a+(k-1)d as a member ≥ every member (vdwAP_last_mem, vdwAP_last_ge). Phrasing the extrema by membership (rather than Finset.min'/max') lets them transport across an equality of two AP sets by plain ≤-antisymmetry, dodging the dependent Nonempty proof that min'/max' carry.",
+    "mathContext": "For $m < n$: $(\\uparrow m : \\mathrm{Fin}\\,n).\\mathrm{val} = m$, so $\\uparrow x \\le \\uparrow y \\iff x \\le y$ on the AP's terms."
+  },
+  {
+    "id": "vdw-oq0101-ann-injectivity",
+    "proofId": "van-der-waerden-first-moment-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 157 },
+    "type": "key-step",
+    "title": "Injectivity of the Parametrization",
+    "content": "vdwAP_injOn: given two fitting pairs with equal AP sets, the least element of each lies in the other, so by antisymmetry a = a'; likewise the greatest gives a+(k-1)d = a'+(k-1)d'. Reading off Fin values turns these into natural-number equalities, and cancelling k-1 > 0 (needs k ≥ 2) recovers d = d'. Hence (a,d) ↦ vdwAP n a d k is Set.InjOn the fitting box.",
+    "mathContext": "$\\min S = a$, $\\max S = a+(k-1)d$; from $S=S'$: $a=a'$ and $a+(k-1)d = a'+(k-1)d'$, so $d=d'$ since $k-1\\ge 1$."
+  },
+  {
+    "id": "vdw-oq0101-ann-exact",
+    "proofId": "van-der-waerden-first-moment-oq-01-oq-01",
+    "range": { "startLine": 158, "endLine": 178 },
+    "type": "key-step",
+    "title": "Exact Count and Lower Bound",
+    "content": "card_vdwFamily_eq_sum: Finset.card_image_of_injOn turns the sibling's image bound into an equality, and the sibling's vdwFilter_card_eq_sum supplies the box count, giving |vdwFamily n k| = ∑_{d=1}^{n}(n-(k-1)d). card_vdwFamily_ge: the single d=1 term n-(k-1) of the sum is ≤ the whole sum (Finset.single_le_sum), so n-(k-1) ≤ |vdwFamily n k| — combined with the sibling's 2(k-1)·|family| ≤ n² this brackets the family size in [n-(k-1), n²/(2(k-1))].",
+    "mathContext": "$|\\mathrm{vdwFamily}\\,n\\,k| = \\sum_{d=1}^{n}(n-(k-1)d)$ and $n-(k-1) \\le |\\mathrm{vdwFamily}\\,n\\,k| \\le \\frac{n^2}{2(k-1)}$."
+  }
+]

--- a/src/data/proofs/van-der-waerden-first-moment-oq-01-oq-01/meta.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-01-oq-01/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "van-der-waerden-first-moment-oq-01-oq-01",
+  "title": "The Fitting van der Waerden AP Count is Exact: |vdwFamily n k| = ∑(n − (k−1)d)",
+  "slug": "van-der-waerden-first-moment-oq-01-oq-01",
+  "description": "The sibling entry van-der-waerden-first-moment-oq-01 bounds the number of length-k arithmetic progressions fitting in [n] ABOVE by the triangular parameter sum ∑_{d=1}^{n}(n-(k-1)d) (card_vdwFamily_le_sum), via Finset.card_image_le: the family vdwFamily n k is the image of the fitting parameter box {(a,d) : a+(k-1)d < n} under (a,d) ↦ vdwAP n a d k, and an image can only shrink the count. This entry answers the natural follow-up — is that inequality an equality? — by proving the parametrization is INJECTIVE on the fitting box (vdwAP_injOn), hence the family has EXACTLY the triangular count: |vdwFamily n k| = ∑_{d=1}^{n}(n-(k-1)d) for k ≥ 2 (card_vdwFamily_eq_sum). This is the matching lower bound the gallery previously lacked: the count is pinned, not merely bounded above. The injectivity is elementary: a fitting AP {a, a+d, …, a+(k-1)d} has no wraparound in Fin n (all terms < n), so reading off its LEAST element recovers the first term a and its GREATEST element recovers a+(k-1)d; with k ≥ 2 the factor k-1 ≥ 1 then recovers the step d. The two endpoints are isolated as a member ≤/≥ every member (vdwAP_fst_mem/vdwAP_fst_le/vdwAP_last_mem/vdwAP_last_ge), so the recovery transports across the equality of two AP sets without Finset.min'/max' dependent-proof machinery. A clean corollary is the closed-form lower bound n - (k-1) ≤ |vdwFamily n k| (card_vdwFamily_ge), the d=1 slice of length-k intervals; combined with the sibling's factor-2 upper bound 2(k-1)·|family| ≤ n² it brackets the family size in [n-(k-1), n²/(2(k-1))]. HONESTY: this is elementary lattice-point counting layered on the sibling's exact box count (vdwFilter_card_eq_sum) and the base entry's vdwAP/vdwFamily; it strengthens the family bound from ≤ to =, and does not touch the probabilistic core. #print axioms reports only propext, Classical.choice, Quot.sound; 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Lean Genius researcher-7",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VanDerWaerdenFirstMomentOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 178,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The only hypothesis is k ≥ 2 (needed to recover the step d from the two endpoints; for k ≤ 1 a 'length-k AP' has at most one point and the parametrization is not injective). It is an input to the statements, not a standing assumption. #print axioms reports only propext, Classical.choice, Quot.sound. Reuses the sibling van-der-waerden-first-moment-oq-01's vdwFilter_card_eq_sum (exact (a,d)-box count) and the base van-der-waerden-first-moment's vdwAP/vdwFamily, both verified. Badged 'original' because the exact family count and its injectivity are new content on a verified base, not a Mathlib headline theorem.",
+    "tags": [
+      "combinatorics",
+      "van-der-waerden",
+      "arithmetic-progressions",
+      "lattice-point-counting",
+      "injectivity",
+      "exact-enumeration",
+      "open-question"
+    ],
+    "dateAdded": "2026-06-30",
+    "originalContributions": [
+      "card_vdwFamily_eq_sum: |vdwFamily n k| = ∑_{d=1}^{n}(n-(k-1)d) for k ≥ 2 — upgrades the sibling's upper bound card_vdwFamily_le_sum to an EXACT equality by proving the parametrization injective, supplying the matching lower bound on the AP family count",
+      "vdwAP_injOn: the fitting parametrization (a,d) ↦ vdwAP n a d k is Set.InjOn the box {(a,d) : a+(k-1)d < n} for k ≥ 2 — the least term recovers a, the greatest recovers a+(k-1)d, and k-1 ≥ 1 recovers d",
+      "card_vdwFamily_ge: n - (k-1) ≤ |vdwFamily n k| — closed-form lower bound from the d=1 interval slice, bracketing the family size in [n-(k-1), n²/(2(k-1))] together with the sibling's factor-2 upper bound",
+      "vdwAP_fst_mem/vdwAP_fst_le/vdwAP_last_mem/vdwAP_last_ge: the least and greatest elements of a fitting AP as a member below/above every member — endpoint extraction without Finset.min'/max' dependent-proof juggling, transported across the equality of two AP sets"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "the family is the image of the fitting (a,d) box under an injective-on-the-box map, so its cardinality equals the exact box count — the key step turning ≤ into =.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Fin.val_cast_of_lt",
+        "description": "for m < n the cast ℕ → Fin n recovers m (no wraparound), so a fitting AP's Fin n terms compare as the underlying naturals — the basis of the least/greatest endpoint recovery.",
+        "module": "Mathlib.Data.Fin.Basic"
+      },
+      {
+        "theorem": "Finset.single_le_sum",
+        "description": "the d=1 term n-(k-1) of the triangular sum is ≤ the whole sum, giving the closed-form lower bound card_vdwFamily_ge.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_left",
+        "description": "cancels k-1 > 0 from a+(k-1)d = a'+(k-1)d' (after a = a') to recover the step d, completing injectivity.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/VanDerWaerdenFirstMomentOQ01OQ01.lean",
+    "namespace": "ProbMethod.VanDerWaerden",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 178,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The first-moment (union-bound) lower bound on van der Waerden numbers counts the length-k arithmetic progressions fitting in [n]. The base entry van-der-waerden-first-moment uses the loose count n²; the sibling oq-01 sharpens this to the exact parameter box ∑_{d=1}^{n}(n-(k-1)d) and bounds the AP FAMILY above by it via card_image_le. Whether that family bound is tight — whether distinct (a,d) give distinct APs — was left open.",
+    "problemStatement": "Is the sibling's family bound |vdwFamily n k| ≤ ∑_{d=1}^{n}(n-(k-1)d) an equality? Equivalently, is the parametrization (a,d) ↦ vdwAP n a d k injective on the fitting box?",
+    "proofStrategy": "Prove injectivity of (a,d) ↦ vdwAP n a d k on the fitting box for k ≥ 2. A fitting AP has all terms < n, so casting to Fin n is wraparound-free (Fin.val_cast_of_lt) and the Fin n order matches the natural order on the terms. Isolate the two endpoints by membership: the first term ↑a is a member ≤ every member (vdwAP_fst_mem, vdwAP_fst_le) and the last term ↑(a+(k-1)d) is a member ≥ every member (vdwAP_last_mem, vdwAP_last_ge). Given two fitting pairs with equal AP sets, transport these across the equality: each set's least element lies in the other, so ↑a = ↑a' and (with k ≥ 2) ↑(a+(k-1)d) = ↑(a'+(k-1)d'); reading off Fin values gives a = a' and a+(k-1)d = a'+(k-1)d', and cancelling k-1 > 0 gives d = d'. Then Finset.card_image_of_injOn turns the sibling's image bound into an equality, and vdwFilter_card_eq_sum supplies the box count.",
+    "keyInsights": [
+      "A fitting AP (a+(k-1)d < n) never wraps in Fin n, so the cast is a bijection onto its image of naturals and order is preserved — injectivity reduces to recovering a and d from the term set.",
+      "Only the two endpoints are needed: least = a, greatest = a+(k-1)d, and k-1 ≥ 1 recovers d. There is no need to reconstruct the whole progression.",
+      "Phrasing 'least element' as 'a member ≤ all members' (rather than Finset.min') lets the recovery transport across set equality with a plain ≤-antisymmetry, dodging the dependent Nonempty proof that min'/max' carry.",
+      "The exact count gives the matching lower bound: the family size is pinned at the triangular sum, bracketed with the sibling's factor-2 upper bound into [n-(k-1), n²/(2(k-1))]."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview and Scope",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "States the goal: upgrade the sibling's family upper bound ≤ ∑(n-(k-1)d) to an equality by proving the fitting parametrization injective. Notes the no-wraparound observation and the membership-based endpoint recovery."
+    },
+    {
+      "id": "endpoints",
+      "title": "Endpoint Recovery for a Fitting AP",
+      "startLine": 47,
+      "endLine": 99,
+      "summary": "vdwAP_fst_mem/vdwAP_fst_le: the first term ↑a is a member ≤ every member. vdwAP_last_mem/vdwAP_last_ge: the last term ↑(a+(k-1)d) is a member ≥ every member. All via Fin.val_cast_of_lt on the wraparound-free terms."
+    },
+    {
+      "id": "injectivity",
+      "title": "Injectivity of the Parametrization",
+      "startLine": 100,
+      "endLine": 157,
+      "summary": "vdwAP_injOn: from equal AP sets, transport the least/greatest endpoints across the equality to recover a = a' and a+(k-1)d = a'+(k-1)d', then cancel k-1 > 0 to get d = d'."
+    },
+    {
+      "id": "exact-count",
+      "title": "Exact Count and Lower Bound",
+      "startLine": 158,
+      "endLine": 178,
+      "summary": "card_vdwFamily_eq_sum: Finset.card_image_of_injOn + the sibling's vdwFilter_card_eq_sum give |vdwFamily n k| = ∑_{d=1}^{n}(n-(k-1)d). card_vdwFamily_ge: the d=1 term yields n-(k-1) ≤ |vdwFamily n k|."
+    }
+  ],
+  "conclusion": {
+    "summary": "7 theorems, 0 definitions, 0 sorries, 0 axioms, no native_decide. The number of length-k arithmetic progressions fitting in [n] is computed EXACTLY as ∑_{d=1}^{n}(n-(k-1)d) for k ≥ 2 — the sibling's upper bound is tight because the parametrization (a,d) ↦ AP is injective on the fitting box. A closed-form lower bound n-(k-1) ≤ |vdwFamily n k| follows from the d=1 slice.",
+    "implications": "Closes the gap left by the sibling van-der-waerden-first-moment-oq-01: the AP family count is pinned, not merely bounded above. Together with the sibling's 2(k-1)·|family| ≤ n² the family size is bracketed in [n-(k-1), n²/(2(k-1))]. Demonstrates that the fitting-AP enumeration is exact inside Lean by an elementary endpoint-recovery injectivity argument.",
+    "openQuestions": [
+      "State the exact Gauss closed form of the triangular sum ∑_{d=1}^{n}(n-(k-1)d) with the floor cutoff D = ⌊(n-1)/(k-1)⌋, giving |vdwFamily n k| as a single arithmetic expression rather than a sum.",
+      "Generalise the exact count to length-k APs in higher-dimensional grids [n]^m, where the fitting region is a polytope and the count becomes an Ehrhart-type quasi-polynomial."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "van-der-waerden-first-moment-oq-01",
+      "relationship": "parent — this entry upgrades that entry's family upper bound card_vdwFamily_le_sum (≤) to an equality by proving injectivity, and reuses its exact box count vdwFilter_card_eq_sum"
+    },
+    {
+      "targetId": "van-der-waerden-first-moment",
+      "relationship": "grandparent — supplies the vdwAP / vdwFamily definitions whose parametrization is shown injective here"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/van-der-waerden-first-moment-oq-01-oq-01.json
+++ b/src/data/research/problems/van-der-waerden-first-moment-oq-01-oq-01.json
@@ -1,0 +1,69 @@
+{
+  "slug": "van-der-waerden-first-moment-oq-01-oq-01",
+  "title": "The fitting van der Waerden AP count is exact, not just bounded: |vdwFamily n k| = ∑(n−(k−1)d)",
+  "phase": "ACT",
+  "status": "completed",
+  "tier": "tractable",
+  "path": "Proofs/VanDerWaerdenFirstMomentOQ01OQ01.lean",
+  "problemStatement": {
+    "formal": "\\left| \\mathrm{vdwFamily}(n, k) \\right| \\;=\\; \\sum_{d=1}^{n} \\bigl(n - (k-1)d\\bigr), \\qquad k \\ge 2,",
+    "plain": "The sibling entry van-der-waerden-first-moment-oq-01 bounds the number of length-k arithmetic progressions fitting in [n] ABOVE by the triangular parameter sum ∑_{d=1}^{n}(n-(k-1)d), via Finset.card_image_le — the family is the image of the fitting (a,d) box under (a,d) ↦ AP, and an image can only shrink the count. The open question: is that inequality an equality? Equivalently, is the parametrization (a,d) ↦ AP injective on the fitting box — does every fitting (a,d) give a DISTINCT progression?",
+    "whyMatters": [
+      "Turns the sibling's one-sided upper bound on the AP family into an exact enumeration — the matching lower bound the gallery previously lacked.",
+      "Confirms the loose-vs-exact gap between the base entry's n² overcount and the true count is closed on BOTH sides, not just from above."
+    ]
+  },
+  "knownResults": {
+    "summary": "For k ≥ 2 the parametrization (a,d) ↦ vdwAP n a d k is injective on the fitting box, so the family has exactly the triangular parameter count."
+  },
+  "currentState": {
+    "phase": "DONE",
+    "since": "2026-06-30",
+    "iteration": 1,
+    "focus": "Injectivity of the fitting parametrization, hence exact family count.",
+    "blockers": [],
+    "nextAction": "Complete — proof verified 0-axiom; PR opened.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: proved the exact count card_vdwFamily_eq_sum (= triangular sum) by establishing injectivity of (a,d) ↦ AP on the fitting box, upgrading the sibling's ≤ to =. Plus the closed-form lower bound card_vdwFamily_ge (n-(k-1) ≤ |family|).",
+    "builtItems": [
+      "ProbMethod.VanDerWaerden.card_vdwFamily_eq_sum (k) (hk : 2 ≤ k) : (vdwFamily n k).card = ∑ d ∈ Icc 1 n, (n-(k-1)*d). 0 sorry. Upgrades the sibling card_vdwFamily_le_sum's ≤ to =.",
+      "ProbMethod.VanDerWaerden.vdwAP_injOn (k) (hk : 2 ≤ k) : Set.InjOn ((a,d) ↦ vdwAP n a d k) on the fitting box — recovers a (least term) and a+(k-1)d (greatest term), then d via k-1 ≥ 1. 0 sorry.",
+      "ProbMethod.VanDerWaerden.card_vdwFamily_ge (k) (hk : 2 ≤ k) : n-(k-1) ≤ (vdwFamily n k).card (the d=1 interval slice). 0 sorry.",
+      "Endpoint helper lemmas vdwAP_fst_mem/vdwAP_fst_le/vdwAP_last_mem/vdwAP_last_ge — least/greatest element of a fitting AP without min'/max' machinery."
+    ],
+    "insights": [
+      "A fitting AP (a+(k-1)d<n) has no wraparound in Fin n: every term a+i*d is < n, so Fin.val_cast_of_lt recovers the natural and the Fin n order coincides with the natural order on the terms.",
+      "Injectivity needs only the two ENDPOINTS: the least element is a, the greatest is a+(k-1)d; with k≥2 the factor k-1≥1 then recovers d. No need to reconstruct the whole set.",
+      "Membership-based extremum (an element is the least exactly when it is a member ≤ all members) transports cleanly across the equality of two AP sets, avoiding Finset.min'/max' dependent-proof juggling."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Combine with the sibling card_vdwFamily_two_mul_le to pin the family size in [n-(k-1), n²/(2(k-1))].",
+      "State the exact closed form of the triangular sum (Gauss with the floor cutoff D = ⌊(n-1)/(k-1)⌋) to get an exact |family|, not just = ∑."
+    ]
+  },
+  "tags": [
+    "combinatorics",
+    "van-der-waerden",
+    "arithmetic-progressions",
+    "lattice-point-counting",
+    "injectivity",
+    "exact-enumeration",
+    "open-question"
+  ],
+  "relatedProofs": [
+    "van-der-waerden-first-moment-oq-01",
+    "van-der-waerden-first-moment"
+  ],
+  "references": {},
+  "started": "2026-06-30",
+  "leanFiles": [
+    "Proofs/VanDerWaerdenFirstMomentOQ01OQ01.lean"
+  ]
+}


### PR DESCRIPTION
## Summary

Upgrades the sibling **van-der-waerden-first-moment-oq-01**'s family *upper* bound to an **exact equality** by proving the fitting parametrization injective.

The sibling bounds the number of length-`k` arithmetic progressions fitting in `[n]` above:
`|vdwFamily n k| ≤ ∑_{d=1}^{n}(n-(k-1)d)` (`card_vdwFamily_le_sum`), via `Finset.card_image_le` — the family is the *image* of the fitting `(a,d)` box under `(a,d) ↦ vdwAP n a d k`. This entry answers the natural follow-up: **is that inequality an equality?** It is, for `k ≥ 2` — the parametrization is injective on the box.

## Key results

- `card_vdwFamily_eq_sum` : `|vdwFamily n k| = ∑_{d=1}^{n}(n-(k-1)d)` for `k ≥ 2` — the matching lower bound the gallery previously lacked.
- `card_vdwFamily_ge` : `n - (k-1) ≤ |vdwFamily n k|` — closed-form lower bound (the `d=1` interval slice). With the sibling's factor-2 upper bound this brackets the family size in `[n-(k-1), n²/(2(k-1))]`.
- `vdwAP_injOn` : injectivity of `(a,d) ↦ vdwAP n a d k` on the fitting box.

## Method

A fitting AP (`a+(k-1)d < n`) has all terms `< n`, so casting `ℕ → Fin n` is wraparound-free (`Fin.val_cast_of_lt`) and the `Fin n` order matches the natural order. The **least** element recovers the first term `a`, the **greatest** recovers `a+(k-1)d`, and `k-1 ≥ 1` recovers the step `d`. Endpoints are isolated by *membership* (a member `≤`/`≥` every member), so they transport across an equality of two AP sets by plain `≤`-antisymmetry — no `Finset.min'`/`max'` dependent-proof machinery.

## Verification

- 7 theorems, 0 definitions, **0 sorries, 0 axioms**, no `native_decide`.
- `#print axioms` reports only `propext, Classical.choice, Quot.sound` for both main theorems.
- Verified on host via `lake env lean` (Docker unavailable this session).

Reuses the verified sibling's `vdwFilter_card_eq_sum` (exact box count) and the base entry's `vdwAP`/`vdwFamily`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)