### PR TITLE
research(van-der-waerden-first-moment-oq-03): fix broken W bridge + sharpened verified W lower bound [VERIFIED host]

### DIFF
--- a/proofs/Proofs/Erdos138FirstMomentBridge.lean
+++ b/proofs/Proofs/Erdos138FirstMomentBridge.lean
@@ -16,26 +16,39 @@
   (`contains_mono_ap_imp`, `not_in_guarantee_lt_sInf`) to obtain a **machine-checked
   lower bound on `W k` itself**:
 
-      `firstMoment_W_lower_bound : N² < 2^(k-1) → N < W k`            (no new axioms)
-      `firstMoment_W_pow_lower   : 2^((k-2)/2) < W k`  (a clean power corollary)
+      `firstMoment_W_lower_bound       : N² < 2^(k-1)         → N < W k`
+      `firstMoment_W_lower_bound_sharp : N² < 2·(k-1)·2^(k-1) → N < W k`
+      `firstMoment_W_pow_lower         : 2^((k-2)/2) < W k`   (power corollary)
+      `firstMoment_W_pow_lower_sharp   : 2^((k-1)/2) < W k`   (sharper corollary)
 
   This is the first *verified* (rather than axiomatized) lower bound on `W` in the
-  erdos-138 development.
+  erdos-138 development.  All four route through the shared engine
+  `W_lower_of_no_mono` (which turns any monochromatic-AP-free `Fin N` colouring into
+  `N < W k`); the `*_sharp` pair feeds the sharpened AP count
+  `2(k-1)·|family| ≤ n²` from `van-der-waerden-first-moment-oq-01`
+  (`vdw_lower_bound_sharp`) rather than the loose `n²`, widening the admissible `N`
+  by a `√(2(k-1))` factor and lifting the clean power floor from `2^((k-2)/2)` to
+  `2^((k-1)/2)`.
 
-  HONEST STRENGTH GAP (important).  The elementary bound only gives
-  `W(k) ≳ 2^((k-1)/2)`, which is asymptotically *negligible* against the
-  axiomatized bounds `kozik_shabanov_lower_bound` (`W(k) ≳ c·2^k`) and
-  `berlekamp_lower_bound`.  It therefore **does not eliminate** any existing
-  erdos-138 axiom — it *supplements* them with a proven bound for the elementary
-  regime.  The negligibility is itself recorded formally as
+  HONEST STRENGTH GAP (important).  Even sharpened, the elementary bound only gives
+  `W(k) ≳ √(2(k-1))·2^((k-1)/2) = 2^(k/2+o(k))`, which is asymptotically *negligible*
+  against the axiomatized bounds `kozik_shabanov_lower_bound` (`W(k) ≳ c·2^k`) and
+  `berlekamp_lower_bound`: the `√k` gain is polynomial and does not touch the
+  `2^{k/2}` vs `2^k` exponential gap.  It therefore **does not eliminate** any
+  existing erdos-138 axiom — it *supplements* them with a proven bound for the
+  elementary regime.  The negligibility is recorded formally as
   `firstMoment_bound_negligible` (the ratio of the two bounds' magnitudes → 0).
 
-  Status: 0 sorries, 0 new axioms.  (`W` is still defined via erdos-138's
-  axiomatized `W_is_nonempty`, inherited through the bridge lemma
-  `not_in_guarantee_lt_sInf`; no axiom is introduced *here*.)
+  Status: 0 sorries, 0 new axioms.  The `W` lower bounds depend on erdos-138's
+  axiom `W_is_nonempty` (which makes `W` well-defined as an `sInf`), inherited
+  through `not_in_guarantee_lt_sInf`; `#print axioms` reports
+  `[propext, Classical.choice, W_is_nonempty, Quot.sound]`.  No axiom is introduced
+  *here*, and the underlying union-bound mathematics
+  (`vdw_lower_bound` / `vdw_lower_bound_sharp`) is fully axiom-free.
 -/
 import Mathlib
 import Proofs.VanDerWaerdenFirstMoment
+import Proofs.VanDerWaerdenFirstMomentOQ01
 import Proofs.Erdos138Problem
 
 namespace Erdos138
@@ -52,40 +65,40 @@ theorem boolToFin2_injective : Function.Injective boolToFin2 := by decide
 
 /-- Transport a `Fin N` colouring to a colouring of `{1,…,N} ⊆ ℕ` via the index
 shift `v ↦ v - 1` (mapping `{1,…,N}` onto `{0,…,N-1} = Fin N`). -/
-def shiftColoring (N : ℕ) (c : Fin N → Bool) (x : Finset.Icc 1 N) : Fin 2 :=
+def shiftColoring (N : ℕ) [NeZero N] (c : Fin N → Bool) (x : Finset.Icc 1 N) : Fin 2 :=
   boolToFin2 (c ((Nat.cast (x.1 - 1)) : Fin N))
 
-/-- **Verified first-moment lower bound on the van der Waerden number `W`.**
+/-- **`W k` is positive for `k ≥ 2`.**  A colouring of the empty ground set
+`{1,…,0}` cannot contain a length-`k` AP (which needs a base point `≥ 1`), so
+`0 ∉ monoAP_guarantee_set 2 k` and `not_in_guarantee_lt_sInf` gives `0 < W k`. -/
+theorem W_pos {k : ℕ} (hk : 2 ≤ k) : 0 < W k := by
+  apply not_in_guarantee_lt_sInf
+  intro hmem
+  -- A coloring of the empty set {1,…,0} can have no length-`k` (k ≥ 2) AP.
+  have hcontains : ContainsMonoAPofLength
+      (fun _ : Finset.Icc 1 0 => (0 : Fin 2)) k := hmem _
+  have hhas :
+      HasMonoAP (extend_coloring 0 (fun _ : Finset.Icc 1 0 => (0 : Fin 2))) 0 k :=
+    contains_mono_ap_imp 0 k (by omega) _ hcontains
+  obtain ⟨a, d, _, ha1, han, _⟩ := hhas
+  -- a ≥ 1 but a + (k-1)·d ≤ 0 forces a = 0, contradiction.
+  omega
 
-If `N² < 2^(k-1)` (so `N < 2^((k-1)/2)`) and `k ≥ 2`, then `N < W k`.
+/-- **Bridge core.**  Any `Fin N` colouring (`N > 0`) with *no* monochromatic
+length-`k` `vdwAP` certifies `N < W k`.
 
-The proof bridges the two gallery files.  From `vdw_lower_bound` we obtain a
-2-colouring `c : Fin N → Bool` of the ground set with no monochromatic length-`k`
-AP.  We transport it to a colouring of `{1,…,N}` via `shiftColoring`.  erdos-138's
-`contains_mono_ap_imp` says any monochromatic AP for that colouring would lift to a
-function-form monochromatic AP of `extend_coloring N (shiftColoring N c)`; we show
-that AP, shifted back by one, would be a monochromatic `vdwAP` for `c`,
-contradicting the first-moment guarantee.  Hence `N ∉ monoAP_guarantee_set 2 k`,
-and `not_in_guarantee_lt_sInf` gives `N < W k`. -/
-theorem firstMoment_W_lower_bound {k N : ℕ} (hk : 2 ≤ k)
-    (hNk : N * N < 2 ^ (k - 1)) : N < W k := by
-  -- N = 0 is immediate: 0 < W k whenever the (nonempty) guarantee set excludes 0.
-  rcases Nat.eq_zero_or_pos N with hN0 | hNpos
-  · subst hN0
-    apply not_in_guarantee_lt_sInf
-    intro hmem
-    -- A coloring of the empty set {1,…,0} can have no length-`k` (k ≥ 2) AP.
-    have hcontains : ContainsMonoAPofLength
-        (fun _ : Finset.Icc 1 0 => (0 : Fin 2)) k := hmem _
-    have hhas :
-        HasMonoAP (extend_coloring 0 (fun _ : Finset.Icc 1 0 => (0 : Fin 2))) 0 k :=
-      contains_mono_ap_imp 0 k (by omega) _ hcontains
-    obtain ⟨a, d, _, ha1, han, _⟩ := hhas
-    -- a ≥ 1 but a + (k-1)·d ≤ 0 forces a = 0, contradiction.
-    omega
-  -- Main case: N > 0.
-  haveI : NeZero N := ⟨by omega⟩
-  obtain ⟨c, hc⟩ := vdw_lower_bound (n := N) hk hNk
+This is the engine shared by every first-moment lower bound: it is independent of
+*why* the colouring has no monochromatic AP (the loose `n²` count, the sharpened
+`n²/(2(k-1))` count, …).  We transport `c` to a colouring of `{1,…,N}` via
+`shiftColoring`; erdos-138's `contains_mono_ap_imp` says any monochromatic AP for
+that colouring would lift to a function-form monochromatic AP of
+`extend_coloring N (shiftColoring N c)`, which shifted back by one is a
+monochromatic `vdwAP` for `c` — contradicting `hc`.  Hence
+`N ∉ monoAP_guarantee_set 2 k`, and `not_in_guarantee_lt_sInf` gives `N < W k`. -/
+theorem W_lower_of_no_mono {k N : ℕ} [NeZero N] (hk : 2 ≤ k)
+    (c : Fin N → Bool)
+    (hc : ∀ a d : ℕ, 1 ≤ d → a + (k - 1) * d < N → ¬ Mono (vdwAP N a d k) c) :
+    N < W k := by
   -- Evaluation of the extended ℕ-coloring on points of {1,…,N}.
   have eval : ∀ y : ℕ, y ∈ Finset.Icc 1 N →
       extend_coloring N (shiftColoring N c) y
@@ -123,6 +136,38 @@ theorem firstMoment_W_lower_bound {k N : ℕ} (hk : 2 ≤ k)
     exact hcc
   exact hc (a - 1) d (by omega) (by omega) hMono
 
+/-- **Verified first-moment lower bound on the van der Waerden number `W`.**
+
+If `N² < 2^(k-1)` (so `N < 2^((k-1)/2)`) and `k ≥ 2`, then `N < W k`.  Feeds the
+loose `n²` AP count (`vdw_lower_bound`) through the bridge core
+`W_lower_of_no_mono`. -/
+theorem firstMoment_W_lower_bound {k N : ℕ} (hk : 2 ≤ k)
+    (hNk : N * N < 2 ^ (k - 1)) : N < W k := by
+  rcases Nat.eq_zero_or_pos N with hN0 | hNpos
+  · subst hN0; exact W_pos hk
+  haveI : NeZero N := ⟨by omega⟩
+  obtain ⟨c, hc⟩ := vdw_lower_bound (n := N) hk hNk
+  exact W_lower_of_no_mono hk c hc
+
+/-- **Sharpened verified first-moment lower bound on `W`.**
+
+If `N² < 2·(k-1)·2^(k-1)` and `k ≥ 2`, then `N < W k`.  This is strictly stronger
+than `firstMoment_W_lower_bound`: it admits `N` up to `≈ √(2(k-1))·2^((k-1)/2)`, a
+`√(2(k-1))` factor wider, by feeding the sharpened AP count `2(k-1)·|family| ≤ n²`
+(`vdw_lower_bound_sharp`, entry `van-der-waerden-first-moment-oq-01`) through the
+same bridge core.  The witness it delivers is `W(k) ≳ √(2(k-1))·2^((k-1)/2)`.
+
+(It still does not approach the axiomatized `kozik_shabanov_lower_bound`
+`W(k) ≳ c·2^k`: a polynomial-in-`k` gain leaves the `2^{k/2}` vs `2^k` exponential
+gap — recorded in `firstMoment_bound_negligible` — untouched.) -/
+theorem firstMoment_W_lower_bound_sharp {k N : ℕ} (hk : 2 ≤ k)
+    (hNk : N ^ 2 < 2 * (k - 1) * 2 ^ (k - 1)) : N < W k := by
+  rcases Nat.eq_zero_or_pos N with hN0 | hNpos
+  · subst hN0; exact W_pos hk
+  haveI : NeZero N := ⟨by omega⟩
+  obtain ⟨c, hc⟩ := vdw_lower_bound_sharp (n := N) hk hNk
+  exact W_lower_of_no_mono hk c hc
+
 /-- **Clean power-of-two corollary.** For `k ≥ 2`, `2^((k-2)/2) < W k`.
 
 Instantiates `firstMoment_W_lower_bound` at `N = 2^((k-2)/2)`: then
@@ -141,6 +186,28 @@ theorem firstMoment_W_pow_lower {k : ℕ} (hk : 2 ≤ k) :
     have hpos : 0 < 2 ^ (k - 2) := by positivity
     omega
   exact lt_of_le_of_lt hle hstep
+
+/-- **Sharpened power-of-two corollary.** For `k ≥ 2`, `2^((k-1)/2) < W k`.
+
+Instantiates `firstMoment_W_lower_bound_sharp` at `N = 2^((k-1)/2)`: then
+`N² = 2^(2⌊(k-1)/2⌋) ≤ 2^(k-1) < 2·(k-1)·2^(k-1)`.  This improves the exponent
+floor of `firstMoment_W_pow_lower` from `(k-2)/2` to `(k-1)/2` — a direct dividend
+of the sharpened AP count. -/
+theorem firstMoment_W_pow_lower_sharp {k : ℕ} (hk : 2 ≤ k) :
+    2 ^ ((k - 1) / 2) < W k := by
+  apply firstMoment_W_lower_bound_sharp hk
+  have hsq : (2 ^ ((k - 1) / 2)) ^ 2 = 2 ^ (2 * ((k - 1) / 2)) := by
+    rw [← pow_mul]; congr 1; ring
+  rw [hsq]
+  have hle : 2 ^ (2 * ((k - 1) / 2)) ≤ 2 ^ (k - 1) :=
+    Nat.pow_le_pow_right (by norm_num) (by omega)
+  have hlt : 2 ^ (k - 1) < 2 * (k - 1) * 2 ^ (k - 1) := by
+    have hpos : 0 < 2 ^ (k - 1) := by positivity
+    have hk2 : 2 ≤ 2 * (k - 1) := by omega
+    have hmul : 2 * 2 ^ (k - 1) ≤ 2 * (k - 1) * 2 ^ (k - 1) :=
+      Nat.mul_le_mul_right (2 ^ (k - 1)) hk2
+    omega
+  exact lt_of_le_of_lt hle hlt
 
 /-- **Honest strength gap (formal).** The first-moment lower bound has magnitude
 `≈ 2^((k-1)/2)`; the axiomatized Kozik–Shabanov bound has magnitude `≈ 2^k`.

--- a/src/data/proofs/van-der-waerden-first-moment-oq-03/annotations.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "vdw-oq03-ann-header",
+    "proofId": "van-der-waerden-first-moment-oq-03",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "concept",
+    "title": "Goal: Lift the Verified First-Moment Colouring into erdos-138's W",
+    "content": "erdos-138 defines W(k) as an sInf and axiomatizes its growth lower bounds; van-der-waerden-first-moment proves — axiom-free — that a small AP family forces a monochromatic-AP-free colouring of Fin n. This file bridges the two, turning the verified Fin n colouring into a machine-checked lower bound on erdos-138's own W. It exposes four W bounds (a loose and a sharpened pair) and is explicit that, even sharpened, the elementary bound is exponentially too weak to eliminate any erdos-138 axiom — it supplements them."
+  },
+  {
+    "id": "vdw-oq03-ann-transport",
+    "proofId": "van-der-waerden-first-moment-oq-03",
+    "range": { "startLine": 54, "endLine": 69 },
+    "type": "technique",
+    "title": "Colour Transport via the Index Shift v ↦ v-1",
+    "content": "boolToFin2 embeds the Bool colour alphabet into Fin 2 (injective, by decide). shiftColoring carries a colouring c : Fin N → Bool to a colouring of {1,…,N} by sending x to c(cast(x-1)). The cast ℕ → Fin N only exists for [NeZero N] — the instance shiftColoring now carries. The file as first committed lacked this and failed to compile ('failed to synthesize NatCast (Fin N)'); adding [NeZero N] and using the colouring only in the N > 0 branch repairs it."
+  },
+  {
+    "id": "vdw-oq03-ann-core",
+    "proofId": "van-der-waerden-first-moment-oq-03",
+    "range": { "startLine": 71, "endLine": 137 },
+    "type": "key-step",
+    "title": "The Reusable Bridge Core W_lower_of_no_mono",
+    "content": "W_pos handles the corner N = 0 (an empty-ground-set colouring cannot contain a length-k≥2 AP, which needs a base point ≥ 1). W_lower_of_no_mono is the engine: given ANY colouring c : Fin N → Bool (N > 0) with no monochromatic vdwAP, it shows N < W k. If N were in the guarantee set, contains_mono_ap_imp lifts a monochromatic AP of the shifted colouring to a function-form AP; shifted back by one this is a monochromatic vdwAP for c, contradicting the hypothesis. Crucially the core does not care WHY c avoids monochromatic APs — so every first-moment count can reuse it."
+  },
+  {
+    "id": "vdw-oq03-ann-bounds",
+    "proofId": "van-der-waerden-first-moment-oq-03",
+    "range": { "startLine": 139, "endLine": 169 },
+    "type": "key-step",
+    "title": "Verified and Sharpened Lower Bounds on W(k)",
+    "content": "firstMoment_W_lower_bound feeds the base entry's loose count (vdw_lower_bound, n² < 2^(k-1)) through the core: N² < 2^(k-1) → N < W k — the first VERIFIED lower bound on erdos-138's W. firstMoment_W_lower_bound_sharp feeds the sibling oq-01's sharpened count (vdw_lower_bound_sharp, 2(k-1)|family| ≤ n²) through the SAME core: N² < 2·(k-1)·2^(k-1) → N < W k, a √(2(k-1)) factor widening giving W(k) ≳ √(2(k-1))·2^((k-1)/2)."
+  },
+  {
+    "id": "vdw-oq03-ann-corollaries",
+    "proofId": "van-der-waerden-first-moment-oq-03",
+    "range": { "startLine": 171, "endLine": 210 },
+    "type": "observation",
+    "title": "Clean Power-of-Two Floors",
+    "content": "firstMoment_W_pow_lower instantiates the loose bound at N = 2^((k-2)/2): 2^((k-2)/2) < W k. firstMoment_W_pow_lower_sharp instantiates the sharpened bound at N = 2^((k-1)/2): since N² = 2^(2⌊(k-1)/2⌋) ≤ 2^(k-1) < 2(k-1)·2^(k-1), it gives 2^((k-1)/2) < W k — improving the exponent floor by half a power of two, a direct dividend of the sharpened AP count."
+  },
+  {
+    "id": "vdw-oq03-ann-negligible",
+    "proofId": "van-der-waerden-first-moment-oq-03",
+    "range": { "startLine": 212, "endLine": 234 },
+    "type": "concept",
+    "title": "Honest Strength Gap: Why No Axiom Is Eliminated",
+    "content": "firstMoment_bound_negligible proves the ratio 2^(k-1)/4^k → 0: the elementary first-moment magnitude (≈ 2^(k/2)) is asymptotically negligible against the axiomatized Kozik–Shabanov bound (≈ 2^k). The sharpening's √k gain is polynomial and leaves the 2^{k/2} vs 2^k exponential gap untouched. So this bridge supplements — but cannot eliminate — erdos-138's kozik_shabanov_lower_bound and berlekamp_lower_bound. Reaching 2^k needs the Lovász Local Lemma, not a tighter first-moment count."
+  }
+]

--- a/src/data/proofs/van-der-waerden-first-moment-oq-03/index.ts
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos138FirstMomentBridge.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const vanDerWaerdenFirstMomentOQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const vanDerWaerdenFirstMomentOQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const vanDerWaerdenFirstMomentOQ03Data: ProofData = {
+  proof: vanDerWaerdenFirstMomentOQ03Proof,
+  annotations: vanDerWaerdenFirstMomentOQ03Annotations,
+}

--- a/src/data/proofs/van-der-waerden-first-moment-oq-03/meta.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-03/meta.json
@@ -1,0 +1,145 @@
+{
+  "id": "van-der-waerden-first-moment-oq-03",
+  "title": "Bridging the Verified First-Moment Bound into erdos-138: a Machine-Checked (Sharpened) Lower Bound on W(k)",
+  "slug": "van-der-waerden-first-moment-oq-03",
+  "description": "The erdos-138 entry defines the van der Waerden number W(k) = sInf { N | every 2-colouring of {1,…,N} has a monochromatic k-AP } and axiomatizes ALL of its growth lower bounds (berlekamp_lower_bound, kozik_shabanov_lower_bound). Separately, the verified entry van-der-waerden-first-moment proves — axiom-free — the elementary first-moment bound vdw_lower_bound: if n² < 2^(k-1) then some 2-colouring of Fin n has no monochromatic length-k AP. This entry connects the two: it transports the verified Fin N colouring to a colouring of {1,…,N} (shiftColoring, via the index shift v ↦ v-1) and feeds it through erdos-138's own reduction lemmas (contains_mono_ap_imp, not_in_guarantee_lt_sInf) to obtain the first MACHINE-CHECKED (rather than axiomatized) lower bound on W(k) itself: firstMoment_W_lower_bound : N² < 2^(k-1) → N < W k. The whole pipeline is funnelled through a single reusable engine W_lower_of_no_mono — any monochromatic-AP-free Fin N colouring yields N < W k, independent of WHY the colouring exists. That reuse pays off immediately: feeding the SHARPENED AP count 2(k-1)·|family| ≤ n² from the sibling van-der-waerden-first-moment-oq-01 (vdw_lower_bound_sharp) through the same engine gives the strictly stronger firstMoment_W_lower_bound_sharp : N² < 2·(k-1)·2^(k-1) → N < W k, a √(2(k-1)) factor widening, and lifts the clean power-of-two floor from 2^((k-2)/2) (firstMoment_W_pow_lower) to 2^((k-1)/2) (firstMoment_W_pow_lower_sharp). HONESTY (central to this entry): even sharpened, the elementary bound only gives W(k) ≳ 2^(k/2 + o(k)), which is asymptotically NEGLIGIBLE against the axiomatized kozik_shabanov_lower_bound (W(k) ≳ c·2^k) — the √k gain is polynomial and leaves the 2^{k/2} vs 2^k EXPONENTIAL gap untouched. So this bridge does NOT eliminate any erdos-138 growth axiom (the original goal of the open question); it SUPPLEMENTS them with a proven bound for the elementary regime. The negligibility is itself recorded formally as firstMoment_bound_negligible (the ratio of the two magnitudes → 0). #print axioms reports [propext, Classical.choice, W_is_nonempty, Quot.sound]: the W lower bounds inherit erdos-138's axiom W_is_nonempty (which makes W well-defined as an sInf), introduced upstream not here; the underlying union-bound mathematics (vdw_lower_bound / vdw_lower_bound_sharp) is fully axiom-free.",
+  "meta": {
+    "author": "Lean Genius researcher-4",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos138FirstMomentBridge.lean",
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "lineCount": 234,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "assumptions": "0 sorries, 0 native_decide, and NO axiom declared in this file (leanFile.axiomCount = 0). The headline W lower bounds (firstMoment_W_lower_bound, firstMoment_W_lower_bound_sharp, firstMoment_W_pow_lower, firstMoment_W_pow_lower_sharp) nonetheless DEPEND on one inherited assumption — erdos-138's axiom W_is_nonempty, which asserts the monochromatic-AP guarantee set is nonempty and so makes W k well-defined as an sInf; it enters through the bridge lemma not_in_guarantee_lt_sInf. #print axioms reports exactly [propext, Classical.choice, W_is_nonempty, Quot.sound] for all four. Hence meta.axiomCount = 1 (the one substantive assumption W_is_nonempty; the foundational propext/Classical.choice/Quot.sound are not counted). The assumption is introduced UPSTREAM in erdos-138, not in this file, and the union-bound combinatorics it sits on top of — vdw_lower_bound (base entry) and vdw_lower_bound_sharp (oq-01) — are themselves 0-axiom. firstMoment_bound_negligible is pure analysis and is 0-axiom. Badged 'axiom' because the entry's central deliverable, a lower bound on the axiomatically-defined W, is conditional on W_is_nonempty.",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "first-moment-method",
+      "van-der-waerden",
+      "arithmetic-progressions",
+      "axiom-elimination",
+      "open-question"
+    ],
+    "dateAdded": "2026-06-30",
+    "originalContributions": [
+      "firstMoment_W_lower_bound: the first VERIFIED (rather than axiomatized) lower bound on the van der Waerden number W in the erdos-138 development — N² < 2^(k-1) → N < W k — obtained by transporting the base entry's axiom-free Fin N colouring through erdos-138's own reduction lemmas (the file was previously committed BUILD-UNVERIFIED and in fact failed to compile; this entry repairs the NatCast (Fin N) synthesis failure by giving shiftColoring a [NeZero N] instance and re-verifies it)",
+      "W_lower_of_no_mono: the reusable bridge core — ANY monochromatic-AP-free colouring c : Fin N → Bool (N > 0) certifies N < W k, independent of why the colouring has no monochromatic AP — which lets every first-moment count (loose or sharpened) drive a W lower bound through one shared engine",
+      "firstMoment_W_lower_bound_sharp: the SHARPENED W lower bound N² < 2·(k-1)·2^(k-1) → N < W k, feeding the sibling oq-01's count 2(k-1)·|family| ≤ n² through W_lower_of_no_mono; a √(2(k-1)) factor widening of the admissible N over firstMoment_W_lower_bound, giving W(k) ≳ √(2(k-1))·2^((k-1)/2)",
+      "firstMoment_W_pow_lower_sharp: the clean power-of-two corollary 2^((k-1)/2) < W k, improving the exponent floor of firstMoment_W_pow_lower from (k-2)/2 to (k-1)/2 — a direct dividend of the sharpened count",
+      "firstMoment_bound_negligible: a formal certificate that the elementary first-moment magnitude is asymptotically negligible against the axiomatized Kozik–Shabanov bound (the ratio 2^(k-1)/4^k → 0), making precise that this verified bridge SUPPLEMENTS rather than ELIMINATES the erdos-138 growth axioms"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Fin.instNatCast (NatCast (Fin n) for [NeZero n])",
+        "description": "the index shift v ↦ v-1 maps {1,…,N} to {0,…,N-1} = Fin N via Nat.cast; this instance only exists for NeZero N, which is why shiftColoring carries a [NeZero N] argument and the colouring is built only in the N > 0 branch.",
+        "module": "Mathlib.Data.Fin.Basic"
+      },
+      {
+        "theorem": "tendsto_pow_atTop_nhds_zero_of_lt_one / squeeze_zero",
+        "description": "drives firstMoment_bound_negligible: ((1/2)^k) → 0 squeezes the ratio 2^(k-1)/4^k to 0, certifying asymptotic negligibility of the elementary bound.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "Nat.pow_le_pow_right / pow_mul",
+        "description": "the power corollaries: (2^((k-1)/2))² = 2^(2⌊(k-1)/2⌋) ≤ 2^(k-1), so N = 2^((k-1)/2) satisfies the sharpened smallness hypothesis.",
+        "module": "Mathlib.Algebra.GroupPower.Order"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/Erdos138FirstMomentBridge.lean",
+    "namespace": "Erdos138",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 234,
+    "theoremCount": 8,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The classical first-moment (union-bound) lower bound on van der Waerden numbers W(k) colours [n] uniformly at random; a fixed length-k AP is monochromatic with probability 2^(1-k), so if fewer than 2^(k-1) APs fit then some colouring avoids them all, witnessing W(k) > n. The gallery's erdos-138 entry defines W(k) as an sInf and axiomatizes its growth lower bounds; the verified van-der-waerden-first-moment entry proves the elementary first-moment colouring exists, and its open question oq-01 sharpens the AP count from the loose n² to 2(k-1)·|family| ≤ n². What was missing was the LIFT: turning the verified Fin n colouring into a statement about erdos-138's own W symbol. Open question oq-03 asks to make that bridge and, ambitiously, to use it to eliminate an erdos-138 growth axiom.",
+    "problemStatement": "Connect the axiom-free first-moment colouring (over Fin N) to erdos-138's axiomatically-defined van der Waerden number W (over {1,…,N}), producing a machine-checked lower bound on W k; and assess honestly whether the elementary bound is strong enough to discharge any of erdos-138's axiomatized growth lower bounds.",
+    "proofStrategy": "Transport and reduce. boolToFin2 embeds the Bool colour alphabet into Fin 2; shiftColoring (needing [NeZero N] for the Nat.cast : ℕ → Fin N) carries a Fin N colouring to a colouring of {1,…,N} by v ↦ v-1. The reusable core W_lower_of_no_mono takes any colouring c : Fin N → Bool with no monochromatic vdwAP and shows N < W k: if N were in the guarantee set, contains_mono_ap_imp would lift a monochromatic AP of the shifted colouring to a function-form AP, which shifted back by one is a monochromatic vdwAP for c — contradicting the hypothesis; then not_in_guarantee_lt_sInf gives N < W k. The N = 0 corner is isolated as W_pos (an empty-ground-set colouring cannot contain a length-k≥2 AP). firstMoment_W_lower_bound feeds the base entry's vdw_lower_bound (loose n² count) into the core; firstMoment_W_lower_bound_sharp feeds oq-01's vdw_lower_bound_sharp (2(k-1)|family| ≤ n²) into the SAME core, winning a √(2(k-1)) factor. The power corollaries instantiate N at a power of two. Finally firstMoment_bound_negligible squeezes 2^(k-1)/4^k → 0 to certify the elementary bound cannot match the axiomatized 2^k growth — so no axiom is eliminated.",
+    "keyInsights": [
+      "The bridge factors cleanly: W_lower_of_no_mono is agnostic to WHY a colouring avoids monochromatic APs, so the loose and sharpened first-moment counts drive W lower bounds through one shared engine — adding the sharpened bound costs only a one-line re-derivation, not a second copy of the transport argument.",
+      "The colour transport needs [NeZero N]: Nat.cast : ℕ → Fin N exists only for nonzero N. The file as first committed (BUILD-UNVERIFIED) lacked this and failed to compile with 'failed to synthesize NatCast (Fin N)'. Giving shiftColoring a [NeZero N] instance and confining its use to the N > 0 branch (with N = 0 handled by W_pos) repairs it.",
+      "Sharpening the AP count propagates verbatim through the bridge: 2(k-1)·|family| ≤ n² widens the admissible N from n² < 2^(k-1) to n² < 2(k-1)·2^(k-1) — a √(2(k-1)) factor — and lifts the clean exponent floor from 2^((k-2)/2) to 2^((k-1)/2).",
+      "Honest ceiling, stated formally: even the sharpened bridge gives only W(k) ≳ 2^(k/2+o(k)). The axiomatized Kozik–Shabanov bound is 2^k. The ratio 2^(k-1)/4^k → 0 (firstMoment_bound_negligible) proves the elementary method is exponentially short — so this bridge supplements, but cannot eliminate, the erdos-138 growth axioms.",
+      "The W lower bounds are not 0-axiom: they depend on erdos-138's W_is_nonempty (W well-defined as an sInf), inherited through not_in_guarantee_lt_sInf. No axiom is introduced here, and the union-bound combinatorics underneath are axiom-free — but the headline statements are honestly conditional on W_is_nonempty."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview and Scope",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "States the goal — lift the verified Fin n first-moment colouring to a lower bound on erdos-138's axiomatic W — lists the four W bounds, and is explicit about the honest strength gap and the inherited W_is_nonempty axiom."
+    },
+    {
+      "id": "transport",
+      "title": "Colour Transport Fin N → {1,…,N}",
+      "startLine": 54,
+      "endLine": 69,
+      "summary": "boolToFin2 embeds the Bool colours into Fin 2 (injective by decide); shiftColoring transports a Fin N colouring to {1,…,N} via the index shift v ↦ v-1, requiring [NeZero N] for the Nat.cast : ℕ → Fin N (the fix to the previously non-compiling file)."
+    },
+    {
+      "id": "core",
+      "title": "The Shared Bridge Core",
+      "startLine": 70,
+      "endLine": 137,
+      "summary": "W_pos: W k > 0 for k ≥ 2 (an empty-ground-set colouring has no length-k AP). W_lower_of_no_mono: the reusable engine — any monochromatic-AP-free colouring c : Fin N → Bool (N > 0) certifies N < W k, by lifting a hypothetical monochromatic AP through contains_mono_ap_imp and shifting it back to a vdwAP that contradicts the hypothesis."
+    },
+    {
+      "id": "bounds",
+      "title": "Verified and Sharpened W Lower Bounds",
+      "startLine": 139,
+      "endLine": 169,
+      "summary": "firstMoment_W_lower_bound: N² < 2^(k-1) → N < W k, feeding the base entry's loose count through the core. firstMoment_W_lower_bound_sharp: N² < 2·(k-1)·2^(k-1) → N < W k, feeding oq-01's sharpened count through the SAME core — a √(2(k-1)) factor widening, W(k) ≳ √(2(k-1))·2^((k-1)/2)."
+    },
+    {
+      "id": "corollaries",
+      "title": "Clean Power-of-Two Corollaries",
+      "startLine": 171,
+      "endLine": 210,
+      "summary": "firstMoment_W_pow_lower: 2^((k-2)/2) < W k. firstMoment_W_pow_lower_sharp: 2^((k-1)/2) < W k, improving the exponent floor by instantiating the sharpened bound at N = 2^((k-1)/2) (N² = 2^(2⌊(k-1)/2⌋) ≤ 2^(k-1) < 2(k-1)·2^(k-1))."
+    },
+    {
+      "id": "negligible",
+      "title": "Honest Strength Gap (Formal)",
+      "startLine": 212,
+      "endLine": 234,
+      "summary": "firstMoment_bound_negligible: the ratio 2^(k-1)/4^k → 0, certifying that the elementary first-moment magnitude (≈ 2^(k/2)) is asymptotically negligible against the axiomatized Kozik–Shabanov 2^k — so the bridge supplements but cannot eliminate the erdos-138 growth axioms."
+    }
+  ],
+  "conclusion": {
+    "summary": "8 theorems, 2 definitions, 0 sorries, no native_decide; the file (previously committed BUILD-UNVERIFIED and non-compiling) is repaired and re-verified on host. It delivers the first machine-checked lower bound on erdos-138's van der Waerden number W: firstMoment_W_lower_bound (N² < 2^(k-1) → N < W k) and, by routing the sibling oq-01's sharpened AP count through a shared bridge core, the strictly stronger firstMoment_W_lower_bound_sharp (N² < 2·(k-1)·2^(k-1) → N < W k) with the clean corollary 2^((k-1)/2) < W k. The W bounds depend on erdos-138's W_is_nonempty axiom (inherited, not introduced); the union-bound mathematics is axiom-free.",
+    "implications": "Demonstrates that the gallery's two verified van der Waerden artifacts — the first-moment colouring and erdos-138's axiomatic W — can be soundly connected inside Lean, yielding a proven (sharpened) lower bound on W rather than an axiomatized one. It also answers the harder half of the open question honestly and in the negative: firstMoment_bound_negligible proves the elementary bound is exponentially too weak to discharge kozik_shabanov_lower_bound or berlekamp_lower_bound, so axiom elimination via the first-moment method is not available — sharply scoping what a genuine elimination would require.",
+    "openQuestions": [
+      "Eliminating an erdos-138 growth axiom requires a verified bound of order 2^k (Lovász Local Lemma form W(k) ≳ 2^k/(ek)) or the Kozik–Shabanov 2^k·poly; the first-moment method cannot reach it, so a verified LLL with a bound on the AP-hypergraph overlap degree is the genuine next step.",
+      "State the exact threshold: vdwFilter_card_eq_sum (oq-01) is an equality, so the (N - (k-1)m)² remainder dropped in the telescoping bound could be tracked to pin the optimal first-moment constant in W k, not just the ≤ inequality.",
+      "Bridge the lower bound to the two-sided picture by combining with an upper-bound colouring-existence statement, narrowing the verified window around W k in the elementary regime."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "van-der-waerden-first-moment-oq-01",
+      "relationship": "engine — feeds its sharpened AP count vdw_lower_bound_sharp (2(k-1)·|family| ≤ n²) through this entry's bridge core W_lower_of_no_mono to obtain the sharpened W lower bound"
+    },
+    {
+      "targetId": "van-der-waerden-first-moment",
+      "relationship": "engine — the base entry's axiom-free vdw_lower_bound (loose n² count) is the input to firstMoment_W_lower_bound; its vdwAP/vdwFamily/Mono are reused throughout"
+    },
+    {
+      "targetId": "erdos-138",
+      "relationship": "parent — this entry lifts the verified first-moment colouring into erdos-138's W via its own reduction lemmas (contains_mono_ap_imp, not_in_guarantee_lt_sInf), inheriting the W_is_nonempty axiom; it supplements but does not eliminate the axiomatized growth bounds"
+    },
+    {
+      "targetId": "property-b-first-moment",
+      "relationship": "foundation — the probabilistic core (Erdős 1963 Property B via the first moment method) ultimately underlies the colourings consumed here, through the base van-der-waerden-first-moment entry"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Open question `van-der-waerden-first-moment-oq-03` asks to bridge the verified, axiom-free first-moment van der Waerden bound into the `erdos-138` framework and, ideally, eliminate an axiomatized growth bound.

This PR does two things:

### 1. Fixes a broken file (the real gap)
`Erdos138FirstMomentBridge.lean` was committed **BUILD-UNVERIFIED** in #31490 (Docker was down) and in fact **did not compile**: `shiftColoring` used `Nat.cast : ℕ → Fin N` without `[NeZero N]`, so `failed to synthesize NatCast (Fin N)`. Fixed by giving `shiftColoring` a `[NeZero N]` instance (it is only ever used in the `N > 0` branch; `N = 0` is handled by the new `W_pos`).

### 2. Adds a strictly sharper verified bound
Refactored the proof into a reusable engine `W_lower_of_no_mono` (any monochromatic-AP-free `Fin N` colouring ⟹ `N < W k`, independent of *why*), then fed the sibling `van-der-waerden-first-moment-oq-01`'s sharpened AP count `2(k-1)·|family| ≤ n²` (`vdw_lower_bound_sharp`) through it:

| theorem | statement |
|---|---|
| `firstMoment_W_lower_bound` | `N² < 2^(k-1) → N < W k` |
| **`firstMoment_W_lower_bound_sharp`** (new) | `N² < 2·(k-1)·2^(k-1) → N < W k` |
| `firstMoment_W_pow_lower` | `2^((k-2)/2) < W k` |
| **`firstMoment_W_pow_lower_sharp`** (new) | `2^((k-1)/2) < W k` |

The sharp pair widens the admissible `N` by a `√(2(k-1))` factor (W(k) ≳ √(2(k-1))·2^((k-1)/2)) and lifts the clean exponent floor from `(k-2)/2` to `(k-1)/2`.

## Honesty
Even sharpened, the elementary bound gives only `W(k) ≳ 2^(k/2+o(k))`, exponentially short of the axiomatized `kozik_shabanov_lower_bound` (`≳ 2^k`). The `√k` gain is polynomial and leaves the `2^{k/2}` vs `2^k` gap untouched — so this **does NOT eliminate any erdos-138 axiom** (the open question's ambitious goal); it supplements them. This is recorded formally in `firstMoment_bound_negligible` (`2^(k-1)/4^k → 0`).

## Axiom status
`#print axioms` on all four W bounds: `[propext, Classical.choice, W_is_nonempty, Quot.sound]`. The substantive assumption `W_is_nonempty` (erdos-138's sInf-wellfoundedness axiom) is **inherited, not introduced here**; the underlying union-bound math (`vdw_lower_bound`/`vdw_lower_bound_sharp`) is 0-axiom. Gallery entry classified `status=axiomatized`, `badge=axiom`, `meta.axiomCount=1`, `leanFile.axiomCount=0`.

## Verification
Built on host via `lake env lean` (Docker daemon down this session): **EXIT 0, 0 sorries**. 8 theorems, 234 lines. Gallery entry (meta + annotations + index.ts) validated by `pnpm annotations:build` with no errors for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)