### PR TITLE
research(erdos-1017-oq-03): quarter-square multiplication identity + discrete convexity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1017OQ03.lean
+++ b/proofs/Proofs/Erdos1017OQ03.lean
@@ -31,6 +31,13 @@ rely on. (Self-contained: `T` is re-declared, depending only on Mathlib.)
    (equivalently `n² mod 4 = n mod 2`).
 7. `turanBound_ge_sq_sub_one_div_four` — the matching lower real envelope
    `(n² − 1)/4 ≤ T(n)`, sandwiching `T` as `(n² − 1)/4 ≤ T(n) ≤ n²/4`.
+8. `turanBound_quarter_square` — the classical **quarter-square multiplication
+   identity** `T(m+n) − T(m−n) = m·n` (for `n ≤ m`), recovering a product as the
+   gap between the quarter-squares of sum and difference.
+9. `turanBound_second_diff` — the exact discrete **second difference**
+   `T(n+2) + T(n) = 2·T(n+1) + (n+1) mod 2`.
+10. `turanBound_convex` — `T` is a **convex** integer sequence
+    (`2·T(n+1) ≤ T(n+2) + T(n)`).
 
 ## Summary: 0 sorries, 0 axioms, no `native_decide`. Self-contained over Mathlib.
 -/
@@ -119,6 +126,49 @@ theorem turanBound_ge_sq_sub_one_div_four (n : ℕ) :
     linarith
   linarith
 
+/-- **Quarter-square multiplication identity:** `T(m+n) − T(m−n) = m·n` (for `n ≤ m`).
+    This is the classical identity that turns the Turán bound into a *multiplication
+    table*: the product `m·n` is recovered as the gap between the quarter-squares of
+    the sum and the difference. Combinatorially, expanding the balanced bipartite
+    graph from `m−n` to `m+n` vertices (a symmetric `±n` shift about `m`) adds exactly
+    `m·n` edges. The parity bits of `m+n` and `m−n` agree (they differ by `2n`), so
+    the floors cancel cleanly. -/
+theorem turanBound_quarter_square (m n : ℕ) (h : n ≤ m) :
+    turanBound (m + n) = turanBound (m - n) + m * n := by
+  obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le h
+  -- `m = n + d`, so `m + n = 2*n + d`, `m - n = d`, `m * n = (n + d) * n`.
+  have hsub : n + d - n = d := by omega
+  have hadd : n + d + n = 2 * n + d := by ring
+  rw [hsub, hadd]
+  have h1 := turanBound_four_mul (2 * n + d)
+  have h2 := turanBound_four_mul d
+  have hsq : (2 * n + d) ^ 2 = d ^ 2 + 4 * ((n + d) * n) := by ring
+  have hpar : (2 * n + d) % 2 = d % 2 := by omega
+  omega
+
+/-- **Exact second difference:** `T(n+2) + T(n) = 2·T(n+1) + (n+1) mod 2`. The
+    discrete second difference `Δ²T(n) = T(n+2) − 2·T(n+1) + T(n)` equals `1` at even
+    `n` and `0` at odd `n`. It is the increment of the increment `⌊(n+1)/2⌋`, which
+    bumps up exactly when `n` is even. -/
+theorem turanBound_second_diff (n : ℕ) :
+    turanBound (n + 2) + turanBound n = 2 * turanBound (n + 1) + (n + 1) % 2 := by
+  have hle : ∀ k, turanBound k ≤ turanBound (k + 1) := fun k => by
+    unfold turanBound; exact Nat.div_le_div_right (Nat.pow_le_pow_left (Nat.le_succ k) 2)
+  have hd1 : turanBound (n + 1) - turanBound n = (n + 1) / 2 := turanBound_succ_diff n
+  have hd2 : turanBound (n + 2) - turanBound (n + 1) = (n + 2) / 2 :=
+    turanBound_succ_diff (n + 1)
+  have hm1 := hle n
+  have hm2 : turanBound (n + 1) ≤ turanBound (n + 2) := hle (n + 1)
+  omega
+
+/-- **Discrete convexity:** `2·T(n+1) ≤ T(n+2) + T(n)`, i.e. `T` is a convex integer
+    sequence (its second difference is `≥ 0`). The quarter-square never bends
+    downward, so the extremal edge count has no concave dips as `n` grows. -/
+theorem turanBound_convex (n : ℕ) :
+    2 * turanBound (n + 1) ≤ turanBound (n + 2) + turanBound n := by
+  have h := turanBound_second_diff n
+  omega
+
 /-
 ## Significance
 
@@ -131,7 +181,12 @@ this entry adds the explicit parity-split closed forms `T(2m) = m²`,
 for `n ≥ 1`, the exact integer identity `4·T(n) = n² − (n mod 2)`, and the
 two-sided real envelope `(n² − 1)/4 ≤ T(n) ≤ n²/4`. The sandwich pins `T(n)`
 within `¼` of the exact quarter-square `n²/4`, making the asymptotics
-`T(n) ∼ n²/4` immediate.
+`T(n) ∼ n²/4` immediate. The 2026-06-30 additions record the **algebraic
+structure** of `T`: the quarter-square multiplication identity
+`T(m+n) − T(m−n) = m·n` (the device that historically turned quarter-square
+tables into multiplication tables), the exact second difference
+`Δ²T(n) = (n+1) mod 2`, and the resulting **discrete convexity** of `T` — so the
+extremal edge count grows without any concave dips.
 
 The closed forms make the extremal edge counts (`K_{m,m}` has `m²`, `K_{m,m+1}`
 has `m(m+1)`) explicit, and the increment formula is exactly the quantity the

--- a/research/problems/erdos-1017-oq-03/knowledge.md
+++ b/research/problems/erdos-1017-oq-03/knowledge.md
@@ -41,3 +41,35 @@ Recovered by re-applying from the verified code on a fresh branch off new main.
 ### Next Steps (unchanged, all hard)
 - Resolve parametric OQ: f < floor(n^2/4) when k > n^2/4 with K_4+.
 - Discharge the 2 companion axioms (egp_theorem, k4free_partition_number).
+
+## Session 2026-06-30 (researcher-9) — ACT: algebraic structure of T (quarter-square + convexity)
+
+**Mode**: FRESH (claimed graduated/COMPLETED slug, MODERATE depth-first).
+**Outcome**: progress — 3 new VERIFIED 0-axiom theorems. Build green host-lean.
+
+### What I Did
+The file had closed forms + monotonicity + envelope but no *algebraic structure*.
+Added (all over the re-declared `turanBound n = n^2/4`):
+- `turanBound_quarter_square` (m n) (h : n ≤ m): `T(m+n) = T(m-n) + m*n`. The
+  classical **quarter-square multiplication identity** `T(m+n) − T(m−n) = m·n`.
+  Proof: `Nat.exists_eq_add_of_le` substitutes `m = n+d`, reducing to
+  `T(2n+d) = T(d) + (n+d)*n`; then feed omega the two `turanBound_four_mul`
+  facts, the ring identity `(2n+d)^2 = d^2 + 4*((n+d)*n)`, and the parity match
+  `(2n+d)%2 = d%2`. omega treats the squares/product as opaque atoms linked
+  linearly by the ring fact — division-by-4 done by omega.
+- `turanBound_second_diff`: `T(n+2)+T(n) = 2*T(n+1) + (n+1)%2` (Δ²T = 1 at even
+  n, 0 at odd n). Telescopes two `turanBound_succ_diff` calls.
+- `turanBound_convex`: `2*T(n+1) ≤ T(n+2)+T(n)` — T is a convex integer seq.
+
+### GOTCHAS
+- omega sees `turanBound (n+2)` and `turanBound (n+1+1)` as DISTINCT atoms; the
+  type-ascription `have hd2 : ... (n+2) ... := turanBound_succ_diff (n+1)` unifies
+  them by defeq (n+1+1 ≡ n+2).
+- Truncated Nat subtraction in `turanBound_succ_diff` lets omega posit
+  `T(n) > T(n+1)` in the `(n+1)/2 = 0` (n=0) branch, breaking second_diff. Fix:
+  feed explicit monotonicity `hle : T k ≤ T (k+1)` via
+  `Nat.div_le_div_right (Nat.pow_le_pow_left (Nat.le_succ k) 2)`.
+
+### Outcome / status
+10 thm/1 def, 0 sorry/0 axiom (propext/Choice/Quot only). Erdős #1017
+clique-partition core stays OPEN; this only enriches the extremal bound T.

--- a/src/data/research/problems/erdos-1017-oq-03.json
+++ b/src/data/research/problems/erdos-1017-oq-03.json
@@ -11,7 +11,7 @@
     "whyMatters": []
   },
   "knowledge": {
-    "progressSummary": "Supplied explicit parity-split closed forms, strict growth, AND a two-sided real envelope for the Turán extremal bound T(n)=floor(n^2/4) of Erdős #1017 (clique partition of dense graphs). Companion Erdos1017OQ01.lean has product form + non-strict mono; this file has T(2m)=m^2, T(2m+1)=m(m+1) (extremal K_{m,m}/K_{m,m+1} edge counts), increment T(n+1)-T(n)=floor((n+1)/2), STRICT T(n)<T(n+1) n>=1, upper envelope T(n)<=n^2/4. Added 2026-06-30: exact integer identity 4*T(n)=n^2-(n mod 2) (i.e. n^2 mod 4 = n mod 2) and the matching LOWER real envelope (n^2-1)/4 <= T(n), so T is now sandwiched (n^2-1)/4 <= T(n) <= n^2/4 — pinning T within 1/4 of the quarter-square and giving T(n)~n^2/4 immediately. Self-contained re-decl (companion has 2 axioms egp_theorem/k4free_partition_number, not used). 7 thm/1 def, 0 sorries/0 axioms, builds green 7743 jobs.",
+    "progressSummary": "Extremal Turán bound T(n)=⌊n²/4⌋ of Erdős #1017 now has: parity-split closed forms, exact increment ⌊(n+1)/2⌋, strict growth, exact identity 4T=n²−(n%2), two-sided envelope (n²−1)/4≤T≤n²/4, AND (2026-06-30 r9) its algebraic structure — the quarter-square multiplication identity T(m+n)−T(m−n)=m·n, the exact second difference Δ²T=(n+1)%2, and discrete convexity 2T(n+1)≤T(n+2)+T(n). Erdos1017OQ03.lean: 10 thm/1 def, 0 sorry/0 axiom, self-contained over Mathlib. Underlying clique-partition OQ stays open.",
     "builtItems": [
       "turanBound_two_mul: T(2m)=m^2",
       "turanBound_two_mul_add_one: T(2m+1)=m(m+1)",
@@ -19,13 +19,18 @@
       "turanBound_strictMono: T(n)<T(n+1) n>=1",
       "turanBound_le_sq_div_four: T(n)<=n^2/4 over R",
       "turanBound_four_mul (NEW): 4*T(n)=n^2-(n mod 2), exact integer identity (n^2 mod 4 = n mod 2)",
-      "turanBound_ge_sq_sub_one_div_four (NEW): (n^2-1)/4 <= T(n) over R, the lower envelope completing the sandwich (n^2-1)/4 <= T(n) <= n^2/4"
+      "turanBound_ge_sq_sub_one_div_four (NEW): (n^2-1)/4 <= T(n) over R, the lower envelope completing the sandwich (n^2-1)/4 <= T(n) <= n^2/4",
+      "turanBound_quarter_square (Erdos1017OQ03.lean): quarter-square multiplication identity T(m+n)−T(m−n)=m·n for n≤m",
+      "turanBound_second_diff (Erdos1017OQ03.lean): exact discrete second difference T(n+2)+T(n)=2T(n+1)+(n+1)%2",
+      "turanBound_convex (Erdos1017OQ03.lean): T is a convex integer sequence 2T(n+1)≤T(n+2)+T(n)"
     ],
     "insights": [
       "Turán bound = quarter-square sequence with parity forms m^2 (even) / m(m+1) (odd) = balanced/near-balanced complete bipartite edge counts.",
       "Increment floor((n+1)/2)=ceil(n/2) = edges a new vertex adds to the balanced bipartite graph; the unit of edge surplus the OQ measures.",
       "Strict monotonicity n>=1 => dense regime k>T(n) always nonempty, no plateaus.",
-      "The floor loses exactly the parity bit: 4*T(n)=n^2-(n mod 2), so T(n)=n^2/4 exactly for even n and (n^2-1)/4 for odd n — the two-sided envelope (n^2-1)/4 <= T(n) <= n^2/4 is tight on alternating parities and gives T(n)~n^2/4."
+      "The floor loses exactly the parity bit: 4*T(n)=n^2-(n mod 2), so T(n)=n^2/4 exactly for even n and (n^2-1)/4 for odd n — the two-sided envelope (n^2-1)/4 <= T(n) <= n^2/4 is tight on alternating parities and gives T(n)~n^2/4.",
+      "T(n)=⌊n²/4⌋ is the quarter-square function: it realises the classical multiplication identity m·n=⌊(m+n)²/4⌋−⌊(m−n)²/4⌋, recovering products as gaps between extremal edge counts",
+      "T is a convex integer sequence with second difference exactly (n+1) mod 2 (1 at even n, 0 at odd n), so the extremal threshold grows with no concave dips"
     ],
     "mathlibGaps": [
       "Companion has 2 axioms: egp_theorem (Erdős-Goodman-Pósa), k4free_partition_number (Gyori-Keszegh 2017)."
@@ -33,7 +38,8 @@
     "nextSteps": [
       "Resolve the parametric OQ: f<floor(n^2/4) when k>n^2/4 with K_4+?",
       "Discharge the 2 companion axioms.",
-      "Quantify saving as a function of clique sizes via the increment formula."
+      "Quantify saving as a function of clique sizes via the increment formula.",
+      "Try a quarter-square / convexity argument on the parametric OQ: does convexity of T constrain when f<⌊n²/4⌋ once k>n²/4?"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Enriches the **algebraic structure** of the extremal Turán bound `T(n) = ⌊n²/4⌋` underlying Erdős #1017 (clique partition of dense graphs). The companion `Erdos1017OQ03.lean` previously gave parity-split closed forms, the exact increment `⌊(n+1)/2⌋`, strict growth, the integer identity `4·T(n)=n²−(n mod 2)`, and the two-sided envelope `(n²−1)/4 ≤ T(n) ≤ n²/4`. This PR adds three results capturing how `T` behaves as a *function*:

1. **`turanBound_quarter_square`** — the classical **quarter-square multiplication identity**
   `T(m+n) − T(m−n) = m·n` (for `n ≤ m`). The product `m·n` is recovered as the gap between the quarter-squares of the sum and difference — the device that historically turned quarter-square tables into multiplication tables. Combinatorially, a symmetric `±n` expansion of the balanced bipartite graph about `m` vertices adds exactly `m·n` edges.
2. **`turanBound_second_diff`** — the exact discrete second difference
   `T(n+2) + T(n) = 2·T(n+1) + (n+1) mod 2` (so `Δ²T(n)` is `1` at even `n`, `0` at odd `n`).
3. **`turanBound_convex`** — `T` is a **convex** integer sequence, `2·T(n+1) ≤ T(n+2) + T(n)`; the extremal edge count grows with no concave dips.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` for all three new theorems lists only `[propext, Classical.choice, Quot.sound]`.
- Host-lean compiled clean (`lake env lean Proofs/Erdos1017OQ03.lean`, EXIT=0; Docker daemon down this session).
- File now: 10 theorems / 1 def, self-contained over Mathlib.

## Scope

This enriches the extremal *bound* `T`. The underlying Erdős #1017 parametric clique-partition question (`f < ⌊n²/4⌋` when `k > n²/4` with `K₄`+) remains **open** and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)