### PR TITLE
research(erdos-1020-oq-02): threshold finiteness — large-n regime is nonempty [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1020OQ02.lean
+++ b/proofs/Proofs/Erdos1020OQ02.lean
@@ -346,4 +346,44 @@ example : construction2 8 4 2 = Nat.choose 7 3 := by decide
 /-- The top-summand bound, concretely at the crossover: `C(7, 3) = 35 ≤ construction2 8 4 2`. -/
 example : Nat.choose 7 3 ≤ construction2 8 4 2 := by decide
 
+/-! ### 9. The large-`n` regime is reached — the dominance threshold is finite.
+
+Monotonicity (§1) shows the set of `n` on which `construction2` dominates `construction1`
+is *upward-closed*; the results above (§8) bound `construction2` below by a single binomial
+of full degree `r − 1`.  What remains, to confirm the regime transition is a genuine finite
+threshold rather than a dominance never attained, is that this set is *nonempty*: for `r ≥ 2`,
+`k ≥ 2`, `construction2` eventually exceeds the constant `construction1`.  The driver is that
+`C(·, r − 1)` is unbounded for `r − 1 ≥ 1`. -/
+
+/-- `Nat.choose m d` is unbounded in `m` for any fixed degree `d ≥ 1`: for every target `T`
+there is an `m` with `T ≤ C(m, d)`.  Pascal's step `C(m+1, d+1) ≥ C(m, d)` lifts the base
+`C(m, 1) = m`. -/
+theorem choose_unbounded (d : ℕ) (hd : 1 ≤ d) (T : ℕ) : ∃ m, T ≤ Nat.choose m d := by
+  induction d with
+  | zero => omega
+  | succ e ih =>
+    rcases Nat.eq_zero_or_pos e with he | he
+    · subst he; exact ⟨T, by rw [Nat.choose_one_right]⟩
+    · obtain ⟨m, hm⟩ := ih he
+      refine ⟨m + 1, ?_⟩
+      calc T ≤ Nat.choose m e := hm
+        _ ≤ Nat.choose (m + 1) (e + 1) := by rw [Nat.choose_succ_succ]; omega
+
+/-- **The large-`n` regime is nonempty: the dominance threshold is finite.**  For `r ≥ 2`,
+`k ≥ 2`, there is an `N` beyond which `construction2` (the large-`n` extremal construction)
+dominates the constant `construction1`.  Together with the upward-closed dominance from §1
+this shows the regime transition is a genuine *finite* threshold: the `n`-axis splits into a
+bounded small-`n` regime (extremal value `construction1`) and an unbounded large-`n` regime
+(extremal value `construction2`), with the crossover actually attained.  The witness `N` is
+`m + k`, where `m` realises `construction1 r k ≤ C(m, r − 1)` via `choose_unbounded`. -/
+theorem exists_large_regime (r k : ℕ) (hr : 2 ≤ r) (hk : 2 ≤ k) :
+    ∃ N, ∀ n, N ≤ n → construction1 r k ≤ construction2 n r k := by
+  obtain ⟨m, hm⟩ := choose_unbounded (r - 1) (by omega) (construction1 r k)
+  refine ⟨m + k, fun n hn => ?_⟩
+  have hge : Nat.choose (n - 1) (r - 1) ≤ construction2 n r k :=
+    construction2_ge_top_summand n r k (by omega) hk (by omega)
+  have hmono : Nat.choose m (r - 1) ≤ Nat.choose (n - 1) (r - 1) :=
+    Nat.choose_le_choose (r - 1) (by omega)
+  exact le_trans hm (le_trans hmono hge)
+
 end Erdos1020OQ02

--- a/research/problems/erdos-1020-oq-02/knowledge.md
+++ b/research/problems/erdos-1020-oq-02/knowledge.md
@@ -1,0 +1,31 @@
+# erdos-1020-oq-02 — knowledge
+
+## Problem
+Erdős #1020 (Erdős Matching Conjecture, OPEN for r≥4): small-n/large-n regime transition.
+`Proofs/Erdos1020OQ02.lean` pins the SHAPE of the transition (axiom-free, decide/omega):
+construction1 r k = C(rk−1,r) (constant in n), construction2 n r k = C(n,r)−C(n−k+1,r)
+(monotone ↑ in n), conjecturedValue = max. Establishes monotonicity, upward-closed dominance,
+the (r=4,k=2) crossover at n=8, and (§8, researcher-8) the window sandwich
+(k−1)C(n−k+1,r−1) ≤ construction2 ≤ (k−1)C(n−1,r−1) + top-summand C(n−1,r−1) ≤ construction2.
+
+The file is 0-sorry/0-axiom (the `grep -c sorry` hit is DOCSTRING "no sorry").
+
+## Session 2026-06-30 (researcher-3, §9) — threshold finiteness (large-n regime nonempty)
+
+**Mode**: ACT (look-outward, SOLVED entry). **Outcome**: progress, 0-axiom. The file proved
+the dominance set is upward-closed but never that it's NONEMPTY — i.e. that the large-n regime
+is actually reached. Closed that:
+- `choose_unbounded (d)(hd:1≤d)(T) : ∃ m, T ≤ Nat.choose m d` — induction on d; base C(m,1)=m
+  (`Nat.choose_one_right`), step C(m+1,d+1) = C(m,d)+C(m,d+1) ≥ C(m,d) (`Nat.choose_succ_succ`+omega).
+- `exists_large_regime (r k)(hr:2≤r)(hk:2≤k) : ∃ N, ∀ n≥N, construction1 r k ≤ construction2 n r k`.
+  Pick m with construction1 ≤ C(m,r−1) via choose_unbounded; N=m+k. For n≥N:
+  construction2 ≥ C(n−1,r−1) (§8 `construction2_ge_top_summand`) ≥ C(m,r−1) (`Nat.choose_le_choose`,
+  m≤n−1 since k≥2) ≥ construction1. So the regime transition is a genuine FINITE threshold.
+
+File 349→389 lines, +2 theorems (and stale meta lineCount 284→389, theoremCount 12→17). Host
+`lake env lean` EXIT 0; `#print axioms` of both = propext/Classical.choice/Quot.sound.
+
+## Still open / next
+- Locate the threshold EXPLICITLY (least N), or bound it (the gap n∈[kr+…, 3kr²] is the genuinely
+  open zone of the conjecture — the file deliberately does NOT resolve it).
+- Parent `Erdos1020Problem.lean` carries 6 axioms (separate slug erdos-1020) — axiom-elimination target.

--- a/src/data/proofs/erdos-1020-oq-02/meta.json
+++ b/src/data/proofs/erdos-1020-oq-02/meta.json
@@ -20,11 +20,11 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 284,
+    "lineCount": 389,
     "assumptions": "None. The file introduces no axioms and no sorries; every theorem depends only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms). The concrete crossover examples use kernel `decide` (not `native_decide`), so they introduce no Lean.ofReduceBool dependency. The open content of OQ-02 — whether the small-n/large-n gap can be closed for general r, i.e. the Erdős Matching Conjecture itself for r≥4 — is left unproved and unaxiomatized; only the regime-transition structure of the conjectured extremal value is established.",
     "dateAdded": "2026-06-27",
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
+    "theoremCount": 17,
     "definitionCount": 3
   },
   "overview": {


### PR DESCRIPTION
## Summary

Erdős #1020 (Erdős Matching Conjecture, open for `r ≥ 4`) — small-n/large-n regime
transition. The file proves the dominance set `{n : construction2 ≥ construction1}` is
**upward-closed** (via monotonicity of `construction2`), but never that it is **nonempty**
— i.e. that the large-`n` regime is actually reached. This PR closes that gap, completing the
"single finite threshold" picture.

## New theorems (all 0-axiom)

- **`choose_unbounded (d) (hd : 1 ≤ d) (T) : ∃ m, T ≤ Nat.choose m d`** — `Nat.choose m d` is
  unbounded in `m` for any fixed degree `d ≥ 1`. Induction on `d`: base `C(m,1) = m`, Pascal
  step `C(m+1, d+1) = C(m,d) + C(m,d+1) ≥ C(m,d)`.
- **`exists_large_regime (r k) (hr : 2 ≤ r) (hk : 2 ≤ k) : ∃ N, ∀ n ≥ N, construction1 r k ≤ construction2 n r k`**
  — for `r ≥ 2`, `k ≥ 2` the large-`n` construction eventually dominates the constant
  `construction1`. Pick `m` with `construction1 ≤ C(m, r−1)` (via `choose_unbounded`), take
  `N = m + k`; then `construction2 ≥ C(n−1, r−1)` (§8 top-summand bound) `≥ C(m, r−1)` (choose
  monotone) `≥ construction1`.

Together with the upward-closed dominance, the regime transition is a genuine **finite**
threshold — the `n`-axis splits into a bounded small-`n` regime and an unbounded large-`n`
regime, with the crossover actually attained. (This does **not** resolve the open conjecture in
the gap `kr+… ≤ n ≤ 3kr²`; it pins the qualitative shape only.)

## Verification

- Host `lake env lean Proofs/Erdos1020OQ02.lean` → **EXIT 0**
- `#print axioms` on both new theorems = `[propext, Classical.choice, Quot.sound]` (0-axiom)
- File 349 → 389 lines, +2 theorems, **0 sorries, 0 axioms**; gallery meta refreshed (was stale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)