### PR TITLE
research(van-der-waerden-first-moment-oq-03): sharpen the verified W lower bound via the bridge [0 new axioms]

### DIFF
--- a/proofs/Proofs/Erdos138FirstMomentBridge.lean
+++ b/proofs/Proofs/Erdos138FirstMomentBridge.lean
@@ -19,11 +19,19 @@
       `firstMoment_W_lower_bound : N² < 2^(k-1) → N < W k`            (no new axioms)
       `firstMoment_W_pow_lower   : 2^((k-2)/2) < W k`  (a clean power corollary)
 
+  It also imports the *sharpened* first-moment count (`vdw_lower_bound_sharp`,
+  which uses `2·(k-1)·|family| ≤ n²` instead of the loose `|family| ≤ n²`) to
+  obtain the textbook bound, widening the admissible range by a `√(2(k-1))` factor:
+
+      `firstMoment_W_lower_bound_sharp : N² < 2·(k-1)·2^(k-1) → N < W k`
+      `firstMoment_W_pow_lower_sharp   : 2^((k-1)/2) < W k`  (gains 1 in the
+                                          exponent for every odd `k`)
+
   This is the first *verified* (rather than axiomatized) lower bound on `W` in the
   erdos-138 development.
 
-  HONEST STRENGTH GAP (important).  The elementary bound only gives
-  `W(k) ≳ 2^((k-1)/2)`, which is asymptotically *negligible* against the
+  HONEST STRENGTH GAP (important).  Even the sharpened bound only gives
+  `W(k) ≳ √(2(k-1))·2^((k-1)/2)`, which is asymptotically *negligible* against the
   axiomatized bounds `kozik_shabanov_lower_bound` (`W(k) ≳ c·2^k`) and
   `berlekamp_lower_bound`.  It therefore **does not eliminate** any existing
   erdos-138 axiom — it *supplements* them with a proven bound for the elementary
@@ -36,6 +44,7 @@
 -/
 import Mathlib
 import Proofs.VanDerWaerdenFirstMoment
+import Proofs.VanDerWaerdenFirstMomentOQ01
 import Proofs.Erdos138Problem
 
 namespace Erdos138
@@ -51,8 +60,12 @@ def boolToFin2 (b : Bool) : Fin 2 := if b then 1 else 0
 theorem boolToFin2_injective : Function.Injective boolToFin2 := by decide
 
 /-- Transport a `Fin N` colouring to a colouring of `{1,…,N} ⊆ ℕ` via the index
-shift `v ↦ v - 1` (mapping `{1,…,N}` onto `{0,…,N-1} = Fin N`). -/
-def shiftColoring (N : ℕ) (c : Fin N → Bool) (x : Finset.Icc 1 N) : Fin 2 :=
+shift `v ↦ v - 1` (mapping `{1,…,N}` onto `{0,…,N-1} = Fin N`).
+
+The `[NeZero N]` instance is what the `ℕ → Fin N` coercion
+(`open scoped Fin.NatCast`) requires; every caller already establishes it (the
+`N = 0` regime is handled separately, before any colouring is transported). -/
+def shiftColoring (N : ℕ) [NeZero N] (c : Fin N → Bool) (x : Finset.Icc 1 N) : Fin 2 :=
   boolToFin2 (c ((Nat.cast (x.1 - 1)) : Fin N))
 
 /-- **Verified first-moment lower bound on the van der Waerden number `W`.**
@@ -141,6 +154,91 @@ theorem firstMoment_W_pow_lower {k : ℕ} (hk : 2 ≤ k) :
     have hpos : 0 < 2 ^ (k - 2) := by positivity
     omega
   exact lt_of_le_of_lt hle hstep
+
+/-- **Sharpened verified first-moment lower bound on `W`.**
+
+If `N² < 2·(k-1)·2^(k-1)` and `k ≥ 2`, then `N < W k`.
+
+This is the textbook first-moment bound: instead of the loose `n²` count of
+length-`k` APs used by `firstMoment_W_lower_bound`, it consumes the sharpened
+family count `2·(k-1)·|family| ≤ n²` (`card_vdwFamily_two_mul_le`, packaged as
+`vdw_lower_bound_sharp`), which fits `≈ n²/(2(k-1))` APs.  The admissible range
+of `N` therefore widens by a factor `√(2(k-1))`, giving the verified witness
+`W(k) ≳ √(2(k-1))·2^((k-1)/2)`.
+
+The bridging argument is identical to `firstMoment_W_lower_bound`: the only change
+is feeding `vdw_lower_bound_sharp` (rather than `vdw_lower_bound`) at the start —
+both produce the same `Fin N` colouring interface, so the transport to `{1,…,N}`
+and the `not_in_guarantee_lt_sInf` step are unchanged. -/
+theorem firstMoment_W_lower_bound_sharp {k N : ℕ} (hk : 2 ≤ k)
+    (hNk : N ^ 2 < 2 * (k - 1) * 2 ^ (k - 1)) : N < W k := by
+  -- N = 0 is immediate (independent of the count): 0 < W k.
+  rcases Nat.eq_zero_or_pos N with hN0 | hNpos
+  · subst hN0
+    apply not_in_guarantee_lt_sInf
+    intro hmem
+    have hcontains : ContainsMonoAPofLength
+        (fun _ : Finset.Icc 1 0 => (0 : Fin 2)) k := hmem _
+    have hhas :
+        HasMonoAP (extend_coloring 0 (fun _ : Finset.Icc 1 0 => (0 : Fin 2))) 0 k :=
+      contains_mono_ap_imp 0 k (by omega) _ hcontains
+    obtain ⟨a, d, _, ha1, han, _⟩ := hhas
+    omega
+  haveI : NeZero N := ⟨by omega⟩
+  obtain ⟨c, hc⟩ := vdw_lower_bound_sharp (n := N) hk hNk
+  have eval : ∀ y : ℕ, y ∈ Finset.Icc 1 N →
+      extend_coloring N (shiftColoring N c) y
+        = boolToFin2 (c ((Nat.cast (y - 1)) : Fin N)) := by
+    intro y hy
+    simp only [extend_coloring, dif_pos hy, shiftColoring]
+  apply not_in_guarantee_lt_sInf
+  intro hmem
+  have hcontains : ContainsMonoAPofLength (shiftColoring N c) k := hmem _
+  have hhas : HasMonoAP (extend_coloring N (shiftColoring N c)) N k :=
+    contains_mono_ap_imp N k (by omega) _ hcontains
+  obtain ⟨a, d, hd, ha1, han, hmono⟩ := hhas
+  have hMono : Mono (vdwAP N (a - 1) d k) c := by
+    refine ⟨c ((Nat.cast (a - 1)) : Fin N), ?_⟩
+    intro x hx
+    simp only [vdwAP, Finset.mem_image, Finset.mem_range] at hx
+    obtain ⟨i, hi, hfi⟩ := hx
+    have hidd : i * d ≤ (k - 1) * d := Nat.mul_le_mul_right d (by omega)
+    have hmem_i : a + i * d ∈ Finset.Icc 1 N := by
+      rw [Finset.mem_Icc]; omega
+    have hmem_a : a ∈ Finset.Icc 1 N := by
+      rw [Finset.mem_Icc]; omega
+    have hmi := hmono i hi
+    rw [eval _ hmem_i, eval _ hmem_a] at hmi
+    have hcc :
+        c ((Nat.cast (a + i * d - 1)) : Fin N) = c ((Nat.cast (a - 1)) : Fin N) :=
+      boolToFin2_injective hmi
+    have hshift : a + i * d - 1 = a - 1 + i * d := by omega
+    rw [hshift] at hcc
+    rw [← hfi]
+    exact hcc
+  exact hc (a - 1) d (by omega) (by omega) hMono
+
+/-- **Sharpened power-of-two corollary.** For `k ≥ 2`, `2^((k-1)/2) < W k`.
+
+Strictly improves the loose corollary `firstMoment_W_pow_lower` (`2^((k-2)/2) < W k`)
+— the exponent gains `1` for every odd `k` — and is the integer-exponent shadow of
+the `√(2(k-1))·2^((k-1)/2)` witness.  Instantiate
+`firstMoment_W_lower_bound_sharp` at `N = 2^((k-1)/2)`: then
+`N² = 2^(2⌊(k-1)/2⌋) ≤ 2^(k-1) < 2·(k-1)·2^(k-1)` (the last step uses `k ≥ 2`,
+so `2·(k-1) ≥ 2 > 1`). -/
+theorem firstMoment_W_pow_lower_sharp {k : ℕ} (hk : 2 ≤ k) :
+    2 ^ ((k - 1) / 2) < W k := by
+  apply firstMoment_W_lower_bound_sharp hk
+  have hsq : (2 ^ ((k - 1) / 2)) ^ 2 = 2 ^ ((k - 1) / 2 * 2) :=
+    (pow_mul 2 ((k - 1) / 2) 2).symm
+  rw [hsq]
+  have hle : 2 ^ ((k - 1) / 2 * 2) ≤ 2 ^ (k - 1) :=
+    Nat.pow_le_pow_right (by norm_num) (by omega)
+  have hpos : 0 < 2 ^ (k - 1) := by positivity
+  have hge : 2 * 2 ^ (k - 1) ≤ 2 * (k - 1) * 2 ^ (k - 1) := by
+    gcongr
+    omega
+  omega
 
 /-- **Honest strength gap (formal).** The first-moment lower bound has magnitude
 `≈ 2^((k-1)/2)`; the axiomatized Kozik–Shabanov bound has magnitude `≈ 2^k`.

--- a/src/data/proofs/van-der-waerden-first-moment-oq-03/annotations.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "vdw-oq03-ann-header",
+    "proofId": "van-der-waerden-first-moment-oq-03",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "concept",
+    "title": "Goal: Sharpen the Verified W-Bound, Re-Confirm No Axiom Falls",
+    "content": "erdos-138 axiomatizes every growth lower bound on the van der Waerden number W(k). Open question oq-03 asks whether the verified first-moment bound can ELIMINATE one of those axioms. The bridge already answered no for the loose form (the bound is asymptotically negligible) and gave the first verified lower bound on W. This entry routes the sibling oq-01's SHARPENED AP-count into the bridge, upgrading W(k) ≳ 2^((k-1)/2) to W(k) ≳ √(2(k-1))·2^((k-1)/2), while the negligibility theorem still certifies that the literal axiom-elimination goal is unattainable by this method.",
+    "mathContext": "Loose: $N^2 < 2^{k-1} \\Rightarrow N < W(k)$. Sharp: $N^2 < 2(k-1)\\,2^{k-1} \\Rightarrow N < W(k)$, i.e. $W(k) \\gtrsim \\sqrt{2(k-1)}\\,2^{(k-1)/2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["first-moment method", "van der Waerden number", "axiom elimination", "Property B"],
+    "prerequisites": ["van-der-waerden-first-moment", "van-der-waerden-first-moment-oq-01", "erdos-138"]
+  },
+  {
+    "id": "vdw-oq03-ann-shiftcoloring",
+    "proofId": "van-der-waerden-first-moment-oq-03",
+    "range": { "startLine": 62, "endLine": 81 },
+    "type": "tactic",
+    "title": "shiftColoring [NeZero N]: the Fin N → {1,…,N} Transport",
+    "content": "shiftColoring transports a Fin N colouring to {1,…,N} via the index shift v ↦ v-1. Under current Mathlib the ℕ → Fin N coercion (open scoped Fin.NatCast) is the scoped instance Fin.instAddMonoidWithOne, which requires [NeZero N]; carrying that instance on shiftColoring is what lets the definition elaborate. Every caller already establishes NeZero N before transporting a colouring, and the N = 0 regime is dispatched separately by an empty-colouring contradiction, so the instance is free at every use site.",
+    "mathContext": "Coercion $\\mathbb{N} \\to \\mathrm{Fin}\\,N$ needs $N \\neq 0$; the transport sends point $v \\in \\{1,\\dots,N\\}$ to colour $c(\\overline{v-1})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fin.NatCast", "NeZero", "index shift", "colouring transport"],
+    "prerequisites": ["Fin coercions", "scoped instances"]
+  },
+  {
+    "id": "vdw-oq03-ann-sharpbridge",
+    "proofId": "van-der-waerden-first-moment-oq-03",
+    "range": { "startLine": 173, "endLine": 227 },
+    "type": "theorem",
+    "title": "firstMoment_W_lower_bound_sharp: the Textbook W-Bound",
+    "content": "The core new result: if N² < 2(k-1)·2^(k-1) and k ≥ 2 then N < W k. The proof is identical to the loose firstMoment_W_lower_bound except it opens with vdw_lower_bound_sharp (the sibling oq-01 existence theorem built on 2(k-1)·|family| ≤ n²) rather than vdw_lower_bound. Both produce the same Fin N colouring interface, so the transport to {1,…,N} and the not_in_guarantee_lt_sInf step are unchanged. The widened smallness hypothesis gives a factor √(2(k-1)) more admissible N, hence W(k) ≳ √(2(k-1))·2^((k-1)/2). This bound is CONDITIONAL on van der Waerden's theorem, inherited as the axiom W_is_nonempty.",
+    "mathContext": "$N^2 < 2(k-1)\\,2^{k-1} \\wedge k \\ge 2 \\Rightarrow N < W(k)$; admissible range widened by $\\sqrt{2(k-1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["first-moment method", "union bound", "vdw_lower_bound_sharp", "not_in_guarantee_lt_sInf"],
+    "prerequisites": ["the loose bridge firstMoment_W_lower_bound", "the sharpened count vdw_lower_bound_sharp"]
+  },
+  {
+    "id": "vdw-oq03-ann-powcor",
+    "proofId": "van-der-waerden-first-moment-oq-03",
+    "range": { "startLine": 229, "endLine": 247 },
+    "type": "theorem",
+    "title": "firstMoment_W_pow_lower_sharp: a Clean Power Corollary",
+    "content": "For k ≥ 2, 2^((k-1)/2) < W k. Instantiate firstMoment_W_lower_bound_sharp at N = 2^(⌊(k-1)/2⌋): then N² = 2^(2⌊(k-1)/2⌋) ≤ 2^(k-1) < 2(k-1)·2^(k-1), the last inequality needing only k ≥ 2 (so 2(k-1) ≥ 2 > 1). This strictly improves the loose firstMoment_W_pow_lower (2^((k-2)/2) < W k): for every odd k, ⌊(k-1)/2⌋ = ⌊(k-2)/2⌋ + 1, so the exponent gains a full unit.",
+    "mathContext": "$2^{\\lfloor (k-1)/2 \\rfloor} < W(k)$ for $k \\ge 2$; strictly beats $2^{\\lfloor (k-2)/2 \\rfloor} < W(k)$ at odd $k$.",
+    "significance": "key",
+    "relatedConcepts": ["power-of-two witness", "pow_mul", "Nat.pow_le_pow_right"],
+    "prerequisites": ["firstMoment_W_lower_bound_sharp", "ℕ exponent arithmetic"]
+  },
+  {
+    "id": "vdw-oq03-ann-negligible",
+    "proofId": "van-der-waerden-first-moment-oq-03",
+    "range": { "startLine": 249, "endLine": 264 },
+    "type": "concept",
+    "title": "Honesty: the Bound is Still Negligible",
+    "content": "firstMoment_bound_negligible proves the ratio of the first-moment magnitude to the axiomatized 2^k bounds tends to 0. Since √(2(k-1))·2^((k-1)/2) is still o(2^k), the sharpened bound — like the loose one — cannot eliminate kozik_shabanov_lower_bound or berlekamp_lower_bound. oq-03's literal goal is therefore provably unattainable by the first-moment method; this entry sharpens the supplementary verified bound, it does not remove any axiom.",
+    "mathContext": "$\\sqrt{2(k-1)}\\,2^{(k-1)/2} = o(2^k)$, so the gap to the axiomatized bounds is unbounded.",
+    "significance": "supporting",
+    "relatedConcepts": ["asymptotic negligibility", "Lovász Local Lemma", "Berlekamp lower bound"],
+    "prerequisites": ["limits of sequences", "squeeze theorem"]
+  }
+]

--- a/src/data/proofs/van-der-waerden-first-moment-oq-03/meta.json
+++ b/src/data/proofs/van-der-waerden-first-moment-oq-03/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "van-der-waerden-first-moment-oq-03",
+  "title": "Bridging the Sharpened First-Moment Bound into the van der Waerden Number W",
+  "slug": "van-der-waerden-first-moment-oq-03",
+  "description": "The gallery axiomatizes every growth lower bound on the van der Waerden number W(k) inside erdos-138 (berlekamp_lower_bound, kozik_shabanov_lower_bound). Open question oq-03 asked whether the verified first-moment bound could ELIMINATE one of those axioms. The Erdos138FirstMomentBridge already settled that negatively for the loose form (firstMoment_bound_negligible: the elementary bound 2^((k-1)/2) is asymptotically negligible against the axiomatized 2^k bounds, so it cannot replace them) and gave the first machine-checked lower bound on W itself, firstMoment_W_lower_bound (N² < 2^(k-1) ⟹ N < W k), via the loose n² AP-count. This entry upgrades the BRIDGE to consume the sibling oq-01's sharpened count 2(k-1)·|family| ≤ n² (vdw_lower_bound_sharp) instead of the loose n²: it produces firstMoment_W_lower_bound_sharp (N² < 2·(k-1)·2^(k-1) ⟹ N < W k), widening the admissible N range by a factor √(2(k-1)) and giving the verified witness W(k) ≳ √(2(k-1))·2^((k-1)/2), together with the clean power corollary firstMoment_W_pow_lower_sharp (2^((k-1)/2) < W k), which gains one full unit in the exponent over the loose firstMoment_W_pow_lower (2^((k-2)/2) < W k) for every odd k. The transport argument is unchanged (the same Fin N → {1,…,N} index shift and the same not_in_guarantee_lt_sInf step); the only change is feeding the sharper coloring existence at the start. A side fix makes the whole bridge elaborate under current Mathlib: the ℕ → Fin N coercion (open scoped Fin.NatCast) now requires [NeZero N], so shiftColoring carries that instance (every caller already establishes it; the N = 0 regime is handled separately). HONESTY: even the sharpened bound is asymptotically negligible against the axiomatized 2^k bounds, so oq-03's literal goal (axiom elimination) remains unattainable by the first-moment method — this entry sharpens the SUPPLEMENTARY verified bound, it does not remove any axiom. The W-bounds are conditional on van der Waerden's theorem, inherited as the axiom Erdos138.W_is_nonempty (no NEW axiom is introduced; the file declares none).",
+  "meta": {
+    "author": "Lean Genius researcher-7",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos138FirstMomentBridge.lean",
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "lineCount": 265,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "assumptions": "0 sorries, 0 axiom declarations in this file, no native_decide. The lower bounds on W are CONDITIONAL on van der Waerden's theorem, inherited as the axiom Erdos138.W_is_nonempty (which makes W well-defined / the monochromatic-AP guarantee set nonempty). #print axioms reports [propext, Classical.choice, Erdos138.W_is_nonempty, Quot.sound] for both firstMoment_W_lower_bound_sharp and firstMoment_W_pow_lower_sharp — no sorryAx, no Lean.ofReduceBool. Per the project Axiom Integrity Policy this is 'axiomatized' (badge 'axiom', axiomCount 1) because the result depends on the assumption axiom W_is_nonempty; the entry introduces NO new axiom over the existing erdos-138 framework. The probabilistic/combinatorial core (the sharpened count vdw_lower_bound_sharp and the Property-B engine) is verified and axiom-free in the sibling entries van-der-waerden-first-moment and van-der-waerden-first-moment-oq-01, consumed here as black boxes. The hypotheses k ≥ 2 and N² < 2(k-1)·2^(k-1) are inputs to the statements, not standing assumptions.",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "first-moment-method",
+      "van-der-waerden",
+      "arithmetic-progressions",
+      "axiom-elimination",
+      "open-question"
+    ],
+    "dateAdded": "2026-06-30",
+    "originalContributions": [
+      "firstMoment_W_lower_bound_sharp: if N² < 2·(k-1)·2^(k-1) and k ≥ 2 then N < W k — the textbook first-moment lower bound on the van der Waerden number, bridging the sibling oq-01's sharpened AP-count (vdw_lower_bound_sharp, 2(k-1)·|family| ≤ n²) into the erdos-138 W framework; widens the admissible N range by √(2(k-1)) over the loose firstMoment_W_lower_bound, giving the verified witness W(k) ≳ √(2(k-1))·2^((k-1)/2)",
+      "firstMoment_W_pow_lower_sharp: for k ≥ 2, 2^((k-1)/2) < W k — the clean power-of-two shadow of the sharpened bound, instantiating N = 2^(⌊(k-1)/2⌋); strictly improves the loose firstMoment_W_pow_lower (2^((k-2)/2) < W k) by a full unit in the exponent (a factor 2) for every odd k, since 2^(k-1) < 2·(k-1)·2^(k-1) needs only k ≥ 2",
+      "shiftColoring [NeZero N] fix: the ℕ → Fin N coercion (open scoped Fin.NatCast) requires [NeZero N] under current Mathlib; carrying that instance on shiftColoring makes the whole bridge file elaborate without disturbing any caller (each establishes NeZero N before transporting a colouring; the N = 0 regime is handled by a separate empty-colouring argument)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "pow_mul",
+        "description": "(2^((k-1)/2))² = 2^((k-1)/2·2), reducing the power corollary to a clean exponent inequality discharged by omega and Nat.pow_le_pow_right.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.pow_le_pow_right",
+        "description": "monotonicity 2^(2⌊(k-1)/2⌋) ≤ 2^(k-1) in the exponent, the key step turning the witness N = 2^(⌊(k-1)/2⌋) into a valid input for firstMoment_W_lower_bound_sharp.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/Erdos138FirstMomentBridge.lean",
+    "namespace": "Erdos138",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 265,
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "overview": {
+    "problemStatement": "Open question oq-03 of the van der Waerden first-moment entry asks: can the verified elementary first-moment bound eliminate one of erdos-138's axiomatized growth lower bounds on W(k)? The existing bridge proved this impossible for the loose form (the bound is asymptotically negligible against the 2^k axioms). This entry sharpens the SUPPLEMENTARY verified bound to its textbook form by routing the sibling oq-01's sharpened AP-count through the bridge, and re-records the negligibility, leaving the literal axiom-elimination goal provably out of reach for the first-moment method.",
+    "historicalContext": "The classical first-moment (union-bound) lower bound W(k) ≳ 2^(k/2) is the oldest lower bound on van der Waerden numbers (Erdős). The √(2(k-1)) refinement comes from counting length-k APs in [n] by ≈ n²/(2(k-1)) rather than n². Stronger lower bounds — Berlekamp's W(p+1) ≥ p·2^p (1968) and the Lovász-Local-Lemma form W(k) ≳ 2^k/(ek) (Kozik–Shabanov 2016) — dominate it and remain axiomatized in the gallery's erdos-138 entry.",
+    "proofStrategy": "Reuse the bridge transport verbatim. From vdw_lower_bound_sharp obtain a 2-colouring c : Fin N → Bool of the ground set with no monochromatic length-k AP under the sharpened smallness hypothesis N² < 2(k-1)·2^(k-1). Transport c to a colouring of {1,…,N} via the index shift v ↦ v-1 (shiftColoring), feed it through erdos-138's contains_mono_ap_imp and not_in_guarantee_lt_sInf to conclude N ∉ monoAP_guarantee_set, hence N < W k. The power corollary instantiates N = 2^(⌊(k-1)/2⌋), checking N² ≤ 2^(k-1) < 2(k-1)·2^(k-1) for k ≥ 2.",
+    "keyInsights": [
+      "The bridge transport is agnostic to WHICH first-moment existence theorem feeds it: vdw_lower_bound and vdw_lower_bound_sharp share the exact same colouring interface, so swapping in the sharper one upgrades the W-bound for free.",
+      "The sharpening lives entirely in the smallness hypothesis: n² < 2^(k-1) becomes n² < 2(k-1)·2^(k-1), a factor 2(k-1) more room, i.e. √(2(k-1)) more N.",
+      "The power corollary's improvement is visible at the integer level: ⌊(k-1)/2⌋ exceeds ⌊(k-2)/2⌋ by 1 for every odd k, so 2^((k-1)/2) < W k strictly beats 2^((k-2)/2) < W k there.",
+      "Honesty is preserved formally: even √(2(k-1))·2^((k-1)/2) is o(2^k), so firstMoment_bound_negligible still certifies that no axiom is eliminated — oq-03's literal goal is unattainable by this method.",
+      "The [NeZero N] instance on shiftColoring is exactly what current Mathlib's open scoped Fin.NatCast coercion demands; the fix is invisible to callers and makes the file robust to the Mathlib bump."
+    ]
+  },
+  "sections": [
+    {
+      "id": "transport",
+      "title": "Colouring transport (shared infrastructure)",
+      "startLine": 48,
+      "endLine": 81,
+      "summary": "boolToFin2 embeds Bool into the Fin 2 colour alphabet; shiftColoring [NeZero N] transports a Fin N colouring to {1,…,N} via v ↦ v-1. The [NeZero N] instance supplies the ℕ → Fin N coercion under current Mathlib."
+    },
+    {
+      "id": "loose-bridge",
+      "title": "Loose bridge (existing): W(k) ≳ 2^((k-1)/2)",
+      "startLine": 83,
+      "endLine": 171,
+      "summary": "firstMoment_W_lower_bound (N² < 2^(k-1) ⟹ N < W k) and its power corollary firstMoment_W_pow_lower, built on the loose n² AP-count."
+    },
+    {
+      "id": "sharp-bridge",
+      "title": "Sharpened bridge (new): W(k) ≳ √(2(k-1))·2^((k-1)/2)",
+      "startLine": 173,
+      "endLine": 247,
+      "summary": "firstMoment_W_lower_bound_sharp (N² < 2(k-1)·2^(k-1) ⟹ N < W k), routing vdw_lower_bound_sharp through the same transport, and firstMoment_W_pow_lower_sharp (2^((k-1)/2) < W k), gaining a unit in the exponent for odd k."
+    },
+    {
+      "id": "negligibility",
+      "title": "Formal honesty: the bound is still negligible",
+      "startLine": 249,
+      "endLine": 264,
+      "summary": "firstMoment_bound_negligible certifies that the first-moment magnitude is o(2^k), so neither the loose nor the sharpened bound can eliminate the axiomatized growth bounds."
+    }
+  ],
+  "conclusion": {
+    "summary": "The verified lower bound on the van der Waerden number W now uses the sharpened first-moment AP-count, giving W(k) ≳ √(2(k-1))·2^((k-1)/2) and the strictly improved power corollary 2^((k-1)/2) < W k. No new axiom is introduced; the W-bounds remain conditional on van der Waerden's theorem (W_is_nonempty). oq-03's literal axiom-elimination goal is provably unattainable by the first-moment method, as the (re-recorded) negligibility shows.",
+    "implications": "This is the strongest verified (rather than axiomatized) lower bound on W in the gallery's erdos-138 development. To actually eliminate an axiomatized growth bound one must formalize a method matching the 2^k regime — the Lovász Local Lemma (Kozik–Shabanov) or Berlekamp's finite-field colouring — which the first-moment method cannot reach.",
+    "openQuestions": [
+      "Formalize the Lovász Local Lemma lower bound W(k) ≳ 2^k/(ek) (Kozik–Shabanov), which WOULD eliminate kozik_shabanov_lower_bound and dominate Berlekamp asymptotically.",
+      "Formalize Berlekamp's finite-field construction W(p+1) ≥ p·2^p directly to discharge berlekamp_lower_bound."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "van-der-waerden-first-moment",
+      "relationship": "Base entry providing the verified Property-B engine and the loose first-moment bound this entry bridges."
+    },
+    {
+      "targetId": "van-der-waerden-first-moment-oq-01",
+      "relationship": "Sibling providing the sharpened AP-count vdw_lower_bound_sharp consumed here to upgrade the W-bound."
+    },
+    {
+      "targetId": "erdos-138",
+      "relationship": "Host framework defining W and axiomatizing its growth bounds; this entry supplies a verified (conditional) lower bound that supplements those axioms."
+    }
+  ]
+}

--- a/src/data/research/problems/van-der-waerden-first-moment-oq-03.json
+++ b/src/data/research/problems/van-der-waerden-first-moment-oq-03.json
@@ -1,0 +1,65 @@
+{
+  "id": "van-der-waerden-first-moment-oq-03",
+  "slug": "van-der-waerden-first-moment-oq-03",
+  "title": "Eliminate an erdos-138 growth axiom using the verified van der Waerden first-moment bound",
+  "status": "progress",
+  "phase": "ACT",
+  "tier": "B",
+  "started": "2026-06-30",
+  "path": "Proofs/Erdos138FirstMomentBridge.lean",
+  "problemStatement": "erdos-138 axiomatizes every growth lower bound on the van der Waerden number W(k) (berlekamp_lower_bound, kozik_shabanov_lower_bound). Can the gallery's verified elementary first-moment bound eliminate one of those axioms?",
+  "currentState": "RESOLVED NEGATIVELY for the first-moment method, with a verified sharpening as the positive deliverable. The pre-existing Erdos138FirstMomentBridge already proved the loose first-moment bound is asymptotically negligible against the axiomatized 2^k bounds (firstMoment_bound_negligible) and gave the first verified lower bound on W (firstMoment_W_lower_bound). This session upgraded the bridge to consume the sibling oq-01's SHARPENED AP-count (vdw_lower_bound_sharp) instead of the loose n² count, producing firstMoment_W_lower_bound_sharp (N² < 2(k-1)·2^(k-1) ⟹ N < W k) and the clean corollary firstMoment_W_pow_lower_sharp (2^((k-1)/2) < W k). Even the sharpened bound √(2(k-1))·2^((k-1)/2) is o(2^k), so no axiom is eliminated — the literal oq-03 goal is unattainable by the first-moment method.",
+  "knownResults": [
+    "First-moment lower bound: W(k) ≳ 2^(k/2) (Erdős).",
+    "Sharpened first-moment: counting ≈ n²/(2(k-1)) length-k APs gives W(k) ≳ √(2(k-1))·2^((k-1)/2).",
+    "Berlekamp (1968): W(p+1) ≥ p·2^p for prime p.",
+    "Kozik–Shabanov (2016): W(k) ≳ 2^k/(ek) via the Lovász Local Lemma.",
+    "All three of the last bounds dominate the first-moment bound asymptotically."
+  ],
+  "leanFiles": [
+    "Proofs/Erdos138FirstMomentBridge.lean",
+    "Proofs/VanDerWaerdenFirstMomentOQ01.lean",
+    "Proofs/Erdos138Problem.lean"
+  ],
+  "relatedProofs": [
+    "van-der-waerden-first-moment",
+    "van-der-waerden-first-moment-oq-01",
+    "erdos-138"
+  ],
+  "references": [
+    "Graham, Rothschild, Spencer — Ramsey Theory (first-moment vdW lower bound).",
+    "Kozik, Shabanov (2016) — Improved lower bounds for van der Waerden numbers via the Lovász Local Lemma.",
+    "Berlekamp (1968) — A construction for partitions which avoid long arithmetic progressions."
+  ],
+  "tags": [
+    "combinatorics",
+    "van-der-waerden",
+    "first-moment",
+    "axiom-elimination",
+    "probabilistic-method",
+    "research"
+  ],
+  "knowledge": {
+    "progressSummary": "PROGRESS: sharpened the verified W-bound to W(k) ≳ √(2(k-1))·2^((k-1)/2); axiom elimination proven unattainable by this method (negligibility).",
+    "insights": [
+      "The bridge transport (Fin N → {1,…,N} index shift + not_in_guarantee_lt_sInf) is agnostic to WHICH first-moment existence theorem feeds it: vdw_lower_bound and vdw_lower_bound_sharp share an identical colouring interface, so swapping in the sharper one upgrades the W-bound with zero extra transport work.",
+      "The sharpening lives entirely in the smallness hypothesis: n² < 2^(k-1) becomes n² < 2(k-1)·2^(k-1), a factor 2(k-1) more room, i.e. a √(2(k-1)) factor more N.",
+      "The power corollary's improvement is visible at the integer level: ⌊(k-1)/2⌋ = ⌊(k-2)/2⌋ + 1 for every odd k, so 2^((k-1)/2) < W k strictly beats the loose 2^((k-2)/2) < W k there.",
+      "oq-03's literal axiom-elimination goal is provably unattainable by the first-moment method: even the sharpened bound is o(2^k), so firstMoment_bound_negligible still rules out replacing the axiomatized 2^k bounds.",
+      "Under current Mathlib the ℕ → Fin N coercion (open scoped Fin.NatCast = Fin.instAddMonoidWithOne) requires [NeZero N]; the bridge's shiftColoring def used a bare N and no longer elaborated. main's olean was stale from an older Mathlib where the scoped instance was unconditional."
+    ],
+    "builtItems": [
+      "firstMoment_W_lower_bound_sharp (Erdos138FirstMomentBridge.lean): N² < 2(k-1)·2^(k-1) ∧ k ≥ 2 ⟹ N < W k — the textbook first-moment lower bound on the van der Waerden number, bridging vdw_lower_bound_sharp into erdos-138.",
+      "firstMoment_W_pow_lower_sharp (Erdos138FirstMomentBridge.lean): 2^((k-1)/2) < W k for k ≥ 2 — clean power corollary, strictly improves the loose firstMoment_W_pow_lower for odd k.",
+      "shiftColoring [NeZero N] fix (Erdos138FirstMomentBridge.lean): makes the whole bridge file elaborate under current Mathlib; backward compatible (callers establish NeZero N before transport)."
+    ],
+    "mathlibGaps": [
+      "The Lovász Local Lemma symmetric form (needed to formalize the Kozik–Shabanov W(k) ≳ 2^k/(ek) bound and actually eliminate kozik_shabanov_lower_bound) is not available in a directly usable form in the gallery's setup."
+    ],
+    "nextSteps": [
+      "Formalize the Lovász Local Lemma lower bound W(k) ≳ 2^k/(ek) (Kozik–Shabanov) — the only first-moment-adjacent route that reaches the 2^k regime and could eliminate kozik_shabanov_lower_bound.",
+      "Formalize Berlekamp's finite-field discrete-log construction W(p+1) ≥ p·2^p directly to discharge berlekamp_lower_bound."
+    ],
+    "markdown": ""
+  }
+}


### PR DESCRIPTION
## Summary

Open question **oq-03** of the van der Waerden first-moment entry asks: *can the verified elementary first-moment bound eliminate one of erdos-138's axiomatized growth lower bounds on W(k)?*

The pre-existing `Erdos138FirstMomentBridge` already settled this **negatively** for the loose form (the bound is asymptotically negligible) and gave the first machine-checked lower bound on `W`. This PR **sharpens the supplementary verified bound** by routing the sibling oq-01's sharpened AP-count through the same bridge:

| Theorem | Statement |
|---|---|
| `firstMoment_W_lower_bound_sharp` | `N² < 2·(k-1)·2^(k-1) ∧ k ≥ 2 → N < W k` |
| `firstMoment_W_pow_lower_sharp` | `2^((k-1)/2) < W k`  (k ≥ 2) |

The first widens the admissible `N` range by a factor `√(2(k-1))` over the loose `firstMoment_W_lower_bound`, giving **W(k) ≳ √(2(k-1))·2^((k-1)/2)**. The power corollary strictly improves the loose `firstMoment_W_pow_lower` (`2^((k-2)/2) < W k`) by a full unit in the exponent for every odd `k`.

The transport argument is **identical** to the loose bridge — the only change is feeding `vdw_lower_bound_sharp` at the start; both share the same `Fin N` colouring interface.

## Honesty

oq-03's **literal** goal (axiom elimination) is **unattainable by the first-moment method**: even `√(2(k-1))·2^((k-1)/2)` is `o(2^k)`, so the pre-existing `firstMoment_bound_negligible` still rules out replacing the axiomatized `2^k` bounds (Kozik–Shabanov, Berlekamp). This entry sharpens the supplementary verified bound; it does **not** remove any axiom.

## Axiom status

The `W`-bounds are **conditional on van der Waerden's theorem**, inherited as the axiom `Erdos138.W_is_nonempty`. This PR introduces **NO new axiom** (the file declares none). Per the Axiom Integrity Policy the gallery entry is classified `axiomatized` (`axiomCount: 1` = inherited `W_is_nonempty`).

`#print axioms` for both new theorems: `[propext, Classical.choice, Erdos138.W_is_nonempty, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`. 0 sorries.

## Side fix

Under current Mathlib the `ℕ → Fin N` coercion (`open scoped Fin.NatCast` = `Fin.instAddMonoidWithOne`) requires `[NeZero N]`; the bridge's `shiftColoring` used a bare `N` and no longer elaborated (main's olean was stale from an older Mathlib where the scoped instance was unconditional). `shiftColoring` now carries `[NeZero N]`, making the whole file elaborate again. **Backward compatible**: every caller establishes `NeZero N` before transporting a colouring; the `N = 0` regime is handled separately.

## Verification

Verified on host via `lake env lean` (Docker daemon down this session). Full file compiles with exit 0; axioms printed as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)