### PR TITLE
research(hilbert-17): Fejér–Riesz sharpness + asymmetric normal form + real-root multiplicity + coprime normalization [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Hilbert17OQ01OQ01CoprimeNormalization.lean
+++ b/proofs/Proofs/Hilbert17OQ01OQ01CoprimeNormalization.lean
@@ -1,0 +1,169 @@
+/-
+  Hilbert's 17th problem, univariate case — COPRIME NORMALIZATION of a real sum of
+  two squares.
+
+  The sharpness file `Proofs/Hilbert17OQ01OQ01OQ01.lean` pins down the *degree* of the
+  summands in a representation `p = u² + v²`, and the companion
+  `Proofs/Hilbert17OQ01OQ01RootMultiplicity.lean` pins down the *multiplicity* of the
+  real roots.  This file answers that entry's remaining open question: the
+  **coprime (primitive) normalization** of a real 2-SOS.
+
+  Two facts drive everything:
+
+    * **Bézout at a point.**  If `u` and `v` are coprime (`IsCoprime u v`) then they
+      have no common real root: evaluating a Bézout identity `a·u + b·v = 1` at any
+      point `t` gives `1 = 0` the moment both `u(t) = v(t) = 0`.  Combined with the
+      pointwise non-cancellation `u(t)² + v(t)² = 0 ⟺ u(t) = v(t) = 0`, this makes a
+      coprime 2-SOS **positive definite**:  `u² + v² > 0` everywhere on `ℝ`, so it has
+      no real roots at all.
+
+    * **Divide out the gcd.**  For any `(u, v) ≠ (0, 0)`, writing `d = gcd(u, v)` and
+      `u = d·u₁`, `v = d·v₁`, the cofactors `u₁, v₁` are coprime (cancel `d` in the
+      Bézout identity for `d`), giving the factorisation
+
+          u² + v² = d² · (u₁² + v₁²),   with  u₁² + v₁²  positive definite.
+
+  So every real 2-SOS splits as `(square of the gcd) · (positive-definite primitive
+  2-SOS)`.  All real zeros live in the `d²` factor, recovering
+  `rootMultiplicity r (u² + v²) = 2 · rootMultiplicity r (gcd u v)` — the exact link
+  between the root multiplicities of the parent entry and the gcd of the summands.
+
+  Finally we settle the *uniqueness* half of the open question **negatively**: the
+  primitive part is **not** an invariant of `p`.  Concretely `(X² + 1)²` is
+  simultaneously the non-coprime square `(X² + 1)² + 0²` (primitive part `1`) and the
+  coprime sum `(X² − 1)² + (2X)²` (primitive part `p` itself).  Coprimality of the
+  summands is not preserved across different 2-SOS decompositions of the same `p`.
+
+  Fully elementary and 0-axiom, like the parent.
+
+  Results:
+    * `no_common_root_of_isCoprime` — coprime summands share no real root (Bézout).
+    * `sq_add_sq_pos_of_isCoprime`  — a coprime 2-SOS is positive definite.
+    * `not_isRoot_of_isCoprime`     — hence has no real roots.
+    * `exists_primitive_factorization` — `p = (gcd u v)² · (primitive 2-SOS)`.
+    * `rootMultiplicity_two_sos`    — `rootMult r p = 2 · rootMult r (gcd u v)`.
+    * `coprimality_not_invariant`   — the primitive part is not determined by `p`.
+-/
+import Mathlib
+import Proofs.Hilbert17OQ01OQ01RootMultiplicity
+
+namespace Hilbert17OQ01OQ01CoprimeNorm
+
+open Polynomial
+open Hilbert17OQ01OQ01RootMult (eval_sq_add_sq_eq_zero_iff)
+
+/-- **Coprime polynomials have no common real root.**  From a Bézout identity
+`a·u + b·v = 1`, evaluating at any point `t` where `u(t) = v(t) = 0` gives `1 = 0`. -/
+theorem no_common_root_of_isCoprime {u v : ℝ[X]} (h : IsCoprime u v) (t : ℝ) :
+    ¬ (u.eval t = 0 ∧ v.eval t = 0) := by
+  rintro ⟨hu, hv⟩
+  obtain ⟨a, b, hab⟩ := h
+  have hev := congrArg (eval t) hab
+  simp only [eval_add, eval_mul, hu, hv, mul_zero, add_zero, eval_one] at hev
+  exact one_ne_zero hev.symm
+
+/-- **A coprime sum of two squares is positive definite.**  It is `≥ 0` pointwise and
+never `0` (that would force a common root, impossible for coprime summands), hence
+strictly positive everywhere. -/
+theorem sq_add_sq_pos_of_isCoprime {u v : ℝ[X]} (h : IsCoprime u v) (t : ℝ) :
+    0 < (u ^ 2 + v ^ 2).eval t := by
+  have hne : (u ^ 2 + v ^ 2).eval t ≠ 0 := fun hc =>
+    no_common_root_of_isCoprime h t (eval_sq_add_sq_eq_zero_iff.mp hc)
+  have hge : 0 ≤ (u ^ 2 + v ^ 2).eval t := by
+    simp only [eval_add, eval_pow]; positivity
+  exact lt_of_le_of_ne hge (Ne.symm hne)
+
+/-- **A coprime 2-SOS has no real roots.**  Immediate from positive definiteness. -/
+theorem not_isRoot_of_isCoprime {u v : ℝ[X]} (h : IsCoprime u v) (t : ℝ) :
+    ¬ (u ^ 2 + v ^ 2).IsRoot t :=
+  fun hroot => (sq_add_sq_pos_of_isCoprime h t).ne' hroot
+
+/-- **Coprime cofactors.**  Dividing `u` and `v` by their gcd `d` yields coprime
+polynomials: cancel `d` in the Bézout identity `d = u·gcdA + v·gcdB`. -/
+theorem isCoprime_cofactors {u v u₁ v₁ : ℝ[X]} (h : ¬ (u = 0 ∧ v = 0))
+    (hu : u = EuclideanDomain.gcd u v * u₁) (hv : v = EuclideanDomain.gcd u v * v₁) :
+    IsCoprime u₁ v₁ := by
+  have hd0 : EuclideanDomain.gcd u v ≠ 0 := by
+    rw [Ne, EuclideanDomain.gcd_eq_zero_iff]; exact h
+  have hbez := EuclideanDomain.gcd_eq_gcd_ab u v
+  set d := EuclideanDomain.gcd u v with hd
+  set A := EuclideanDomain.gcdA u v with hA
+  set B := EuclideanDomain.gcdB u v with hB
+  rw [hu, hv] at hbez
+  have hfac : d * 1 = d * (u₁ * A + v₁ * B) := by linear_combination hbez
+  have hone : (1 : ℝ[X]) = u₁ * A + v₁ * B := mul_left_cancel₀ hd0 hfac
+  exact ⟨A, B, by linear_combination -hone⟩
+
+/-- **Coprime (primitive) normalisation of a real 2-SOS.**  For `(u, v) ≠ (0, 0)`,
+writing `d = gcd(u, v)` and `u = d·u₁`, `v = d·v₁`, the cofactors are coprime and
+
+    u² + v² = d² · (u₁² + v₁²),
+
+where the primitive part `u₁² + v₁²` is positive definite.  So every real 2-SOS is a
+perfect square (`d²`) times a strictly positive polynomial. -/
+theorem exists_primitive_factorization {u v : ℝ[X]} (h : ¬ (u = 0 ∧ v = 0)) :
+    ∃ u₁ v₁ : ℝ[X],
+      u = EuclideanDomain.gcd u v * u₁ ∧ v = EuclideanDomain.gcd u v * v₁ ∧
+      IsCoprime u₁ v₁ ∧
+      u ^ 2 + v ^ 2 = (EuclideanDomain.gcd u v) ^ 2 * (u₁ ^ 2 + v₁ ^ 2) ∧
+      ∀ t, 0 < (u₁ ^ 2 + v₁ ^ 2).eval t := by
+  obtain ⟨u₁, hu₁⟩ := EuclideanDomain.gcd_dvd_left u v
+  obtain ⟨v₁, hv₁⟩ := EuclideanDomain.gcd_dvd_right u v
+  have hcop : IsCoprime u₁ v₁ := isCoprime_cofactors h hu₁ hv₁
+  set d := EuclideanDomain.gcd u v with hd
+  refine ⟨u₁, v₁, hu₁, hv₁, hcop, ?_, ?_⟩
+  · rw [hu₁, hv₁]; ring
+  · exact fun t => sq_add_sq_pos_of_isCoprime hcop t
+
+/-- **Root multiplicity is carried entirely by the gcd.**  Since the primitive part is
+positive definite it contributes no real zeros, so in `p = d² · (primitive)` every
+real root of `p` comes from `d²`:
+
+    rootMultiplicity r (u² + v²) = 2 · rootMultiplicity r (gcd u v).
+
+This makes the parent entry's `2·min` formula transparent: the multiplicity of `r` in
+the gcd is exactly `min (rootMultiplicity r u) (rootMultiplicity r v)`. -/
+theorem rootMultiplicity_two_sos {u v : ℝ[X]} (h : ¬ (u = 0 ∧ v = 0)) (r : ℝ) :
+    rootMultiplicity r (u ^ 2 + v ^ 2)
+      = 2 * rootMultiplicity r (EuclideanDomain.gcd u v) := by
+  obtain ⟨u₁, v₁, _, _, _, hfac, hpos⟩ := exists_primitive_factorization h
+  set d := EuclideanDomain.gcd u v with hd
+  have hd0 : d ≠ 0 := by rw [hd, Ne, EuclideanDomain.gcd_eq_zero_iff]; exact h
+  have hq0 : u₁ ^ 2 + v₁ ^ 2 ≠ 0 := by
+    intro hc; have hp := hpos r; rw [hc] at hp; simp at hp
+  have hqnr : rootMultiplicity r (u₁ ^ 2 + v₁ ^ 2) = 0 := by
+    apply rootMultiplicity_eq_zero
+    intro hroot
+    have hp := hpos r
+    rw [IsRoot.def] at hroot
+    rw [hroot] at hp
+    exact lt_irrefl 0 hp
+  rw [hfac, rootMultiplicity_mul (mul_ne_zero (pow_ne_zero 2 hd0) hq0), hqnr, add_zero,
+    pow_two, rootMultiplicity_mul (mul_ne_zero hd0 hd0)]
+  ring
+
+/-- **The primitive part is not an invariant of `p`.**  Coprimality of the summands is
+*not* preserved across different 2-SOS decompositions of the same polynomial, so the
+"primitive part" of the previous theorem depends on the chosen decomposition, not on
+`p` alone.  Witness: `(X² + 1)²` equals both the non-coprime square `(X² + 1)² + 0²`
+and the coprime sum `(X² − 1)² + (2X)²`.  This settles the uniqueness half of the open
+question negatively. -/
+theorem coprimality_not_invariant :
+    ∃ p u v s t : ℝ[X],
+      p = u ^ 2 + v ^ 2 ∧ p = s ^ 2 + t ^ 2 ∧ IsCoprime u v ∧ ¬ IsCoprime s t := by
+  refine ⟨(X ^ 2 + 1) ^ 2, X ^ 2 - 1, 2 * X, X ^ 2 + 1, 0, by ring, by ring, ?_, ?_⟩
+  · -- IsCoprime (X² − 1) (2X):  (-1)·(X² − 1) + (½·X)·(2X) = 1
+    refine ⟨C (-1), C (1 / 2) * X, ?_⟩
+    apply Polynomial.funext
+    intro x
+    simp only [eval_add, eval_mul, eval_sub, eval_pow, eval_C, eval_X, eval_one,
+      eval_ofNat]
+    ring
+  · -- ¬ IsCoprime (X² + 1) 0:  X² + 1 is not a unit (it has degree 2)
+    rw [isCoprime_zero_right]
+    intro hu
+    have h0 : (X ^ 2 + 1 : ℝ[X]).natDegree = 0 := natDegree_eq_zero_of_isUnit hu
+    rw [← C_1, natDegree_X_pow_add_C] at h0
+    exact absurd h0 (by norm_num)
+
+end Hilbert17OQ01OQ01CoprimeNorm

--- a/proofs/Proofs/Hilbert17OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/Hilbert17OQ01OQ01OQ01.lean
@@ -31,6 +31,21 @@
     * `univariate_psd_two_sos_degree_exact` — strengthens the parent existence
       theorem: the witnesses can be taken with `2·max(deg u, deg v) = deg p`.
 
+  Finally, the representation can be put into an **asymmetric normal form**.  The
+  sharpness result only says the *larger* square hits `½·deg p`; it leaves open
+  whether the *other* square can always be pushed strictly below.  It can:
+
+    * `two_sos_rotate_normalize` — a constant orthogonal rotation
+      `(u, v) ↦ (αu+βv, -βu+αv)` with `α²+β²=1` preserves `u²+v²` (it is the
+      polynomial avatar of multiplying the Gaussian factor by a unit complex
+      number).  Aligning the rotation with the top coefficients kills the leading
+      term of the second component, giving `u'² + v'²` with `deg u' = n` and
+      `deg v' < n` (`n = max(deg u, deg v)`).  No complex factorization is used —
+      just a `2×2` rotation of the coefficient pair.
+    * `univariate_psd_two_sos_normalized` — consequently every PSD `p` of degree
+      `≥ 2` is `u² + v²` with `2·deg u = deg p` and `2·deg v < deg p`: one square
+      of degree *exactly* `½·deg p`, the other *strictly* smaller.
+
   Fully elementary and 0-axiom, like the parent.
 -/
 import Mathlib
@@ -112,5 +127,99 @@ theorem univariate_psd_two_sos_degree_exact (p : ℝ[X]) (hp : p ≠ 0) (h : IsP
     ∃ u v : ℝ[X], p = u ^ 2 + v ^ 2 ∧ 2 * max u.natDegree v.natDegree = p.natDegree := by
   obtain ⟨u, v, huv, _, _⟩ := Hilbert17OQ01OQ01.univariate_psd_is_two_sos_deg p h
   exact ⟨u, v, huv, two_sos_max_degree_eq hp huv⟩
+
+/-- **Constant orthogonal rotation of a two-squares pair (asymmetric normal form).**
+
+The pair `(u, v)` and the rotated pair `(αu+βv, -βu+αv)` produce the *same* sum of
+two squares whenever `α² + β² = 1` — this is the polynomial avatar of multiplying
+the complex factor `u + iv` by a unit `α - iβ`.  Choosing the rotation that aligns
+with the top coefficients `(a, b) = (uₙ, vₙ)`, namely `α = a/s`, `β = b/s` with
+`s = √(a²+b²)`, sends the leading coefficient of the second component to
+`-βa + αb = 0` while that of the first becomes `αa + βb = s ≠ 0`.
+
+Hence any two-squares pair whose larger degree `n = max(deg u, deg v)` is positive
+can be normalized to `u'² + v'² = u² + v²` with `deg u' = n` and `deg v' < n`. -/
+theorem two_sos_rotate_normalize (u v : ℝ[X])
+    (hn : 1 ≤ max u.natDegree v.natDegree) :
+    ∃ u' v' : ℝ[X], u' ^ 2 + v' ^ 2 = u ^ 2 + v ^ 2 ∧
+      u'.natDegree = max u.natDegree v.natDegree ∧
+      v'.natDegree < max u.natDegree v.natDegree := by
+  set n := max u.natDegree v.natDegree with hn_def
+  set a := u.coeff n with ha_def
+  set b := v.coeff n with hb_def
+  -- the top coefficient achieving the max is nonzero, so `a² + b² > 0`
+  have habpos : 0 < a ^ 2 + b ^ 2 := by
+    rcases max_choice u.natDegree v.natDegree with hmx | hmx
+    · have hun : u.natDegree = n := by rw [hn_def, hmx]
+      have hu0 : u ≠ 0 := by intro h0; rw [h0, natDegree_zero] at hun; omega
+      have ha0 : a ≠ 0 := by
+        rw [ha_def, ← hun]; exact leadingCoeff_ne_zero.mpr hu0
+      nlinarith [sq_nonneg b, pow_two_pos_of_ne_zero ha0]
+    · have hvn : v.natDegree = n := by rw [hn_def, hmx]
+      have hv0 : v ≠ 0 := by intro h0; rw [h0, natDegree_zero] at hvn; omega
+      have hb0 : b ≠ 0 := by
+        rw [hb_def, ← hvn]; exact leadingCoeff_ne_zero.mpr hv0
+      nlinarith [sq_nonneg a, pow_two_pos_of_ne_zero hb0]
+  set s := Real.sqrt (a ^ 2 + b ^ 2) with hs_def
+  have hspos : 0 < s := Real.sqrt_pos.mpr habpos
+  have hs2 : s ^ 2 = a ^ 2 + b ^ 2 := Real.sq_sqrt habpos.le
+  set α := a / s with hα_def
+  set β := b / s with hβ_def
+  have habs : α ^ 2 + β ^ 2 = 1 := by
+    rw [hα_def, hβ_def, div_pow, div_pow, ← add_div, ← hs2,
+      div_self (pow_ne_zero 2 hspos.ne')]
+  refine ⟨C α * u + C β * v, C (-β) * u + C α * v, ?_, ?_, ?_⟩
+  · -- rotation preserves the sum of two squares
+    have key : (C α * u + C β * v) ^ 2 + (C (-β) * u + C α * v) ^ 2
+        = ((C α) ^ 2 + (C β) ^ 2) * (u ^ 2 + v ^ 2) := by
+      simp only [map_neg]; ring
+    have hone : (C α) ^ 2 + (C β) ^ 2 = 1 := by
+      rw [← C_pow, ← C_pow, ← C_add, habs, C_1]
+    rw [key, hone, one_mul]
+  · -- first component has degree exactly `n`: its `n`-th coefficient is `s ≠ 0`
+    have hule : (C α * u + C β * v).natDegree ≤ n := by
+      refine le_trans (natDegree_add_le _ _) (max_le ?_ ?_)
+      · exact le_trans (natDegree_C_mul_le α u) (le_max_left _ _)
+      · exact le_trans (natDegree_C_mul_le β v) (le_max_right _ _)
+    have hcoeff : (C α * u + C β * v).coeff n = s := by
+      rw [coeff_add, coeff_C_mul, coeff_C_mul, ← ha_def, ← hb_def, hα_def, hβ_def]
+      field_simp
+      nlinarith [hs2]
+    exact le_antisymm hule (le_natDegree_of_ne_zero (by rw [hcoeff]; exact hspos.ne'))
+  · -- second component has degree `< n`: its `n`-th coefficient vanishes
+    have hvle : (C (-β) * u + C α * v).natDegree ≤ n := by
+      refine le_trans (natDegree_add_le _ _) (max_le ?_ ?_)
+      · exact le_trans (natDegree_C_mul_le (-β) u) (le_max_left _ _)
+      · exact le_trans (natDegree_C_mul_le α v) (le_max_right _ _)
+    have hcoeff : (C (-β) * u + C α * v).coeff n = 0 := by
+      rw [coeff_add, coeff_C_mul, coeff_C_mul, ← ha_def, ← hb_def, hα_def, hβ_def]
+      field_simp
+      ring
+    rcases eq_or_lt_of_le hvle with heq | hlt
+    · exfalso
+      have hlc : (C (-β) * u + C α * v).leadingCoeff = 0 := by
+        rw [leadingCoeff, heq, hcoeff]
+      rw [leadingCoeff_eq_zero.mp hlc, natDegree_zero] at heq
+      omega
+    · exact hlt
+
+/-- **Asymmetric Fejér–Riesz normal form.**  Every PSD univariate polynomial of
+degree at least `2` is a sum of two squares `u² + v²` in which one square has
+degree *exactly* `½·deg p` and the other has degree *strictly* less.  (For the
+larger square the bound is forced by `two_sos_max_degree_eq`; the strict gap on
+the smaller square is achieved by the rotation `two_sos_rotate_normalize`.) -/
+theorem univariate_psd_two_sos_normalized (p : ℝ[X]) (hp : 2 ≤ p.natDegree)
+    (h : IsPSD p) :
+    ∃ u v : ℝ[X], p = u ^ 2 + v ^ 2 ∧
+      2 * u.natDegree = p.natDegree ∧ 2 * v.natDegree < p.natDegree := by
+  have hp0 : p ≠ 0 := by intro h0; rw [h0, natDegree_zero] at hp; omega
+  obtain ⟨u, v, huv, _, _⟩ := Hilbert17OQ01OQ01.univariate_psd_is_two_sos_deg p h
+  have hmax : 2 * max u.natDegree v.natDegree = p.natDegree := two_sos_max_degree_eq hp0 huv
+  have hn : 1 ≤ max u.natDegree v.natDegree := by omega
+  obtain ⟨u', v', hpres, hu'deg, hv'deg⟩ := two_sos_rotate_normalize u v hn
+  refine ⟨u', v', ?_, ?_, ?_⟩
+  · rw [huv, ← hpres]
+  · rw [hu'deg]; exact hmax
+  · omega
 
 end Hilbert17OQ01OQ01OQ01

--- a/proofs/Proofs/Hilbert17OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/Hilbert17OQ01OQ01OQ01.lean
@@ -1,0 +1,116 @@
+/-
+  Hilbert's 17th problem, univariate case — SHARPNESS of the Fejér–Riesz degree
+  bound.
+
+  The parent file `Proofs/Hilbert17OQ01OQ01.lean` proves the degree-sharp
+  *existence* statement (Fejér–Riesz):
+
+      every PSD `p : ℝ[X]` is `u² + v²` with `2·deg u ≤ deg p` and
+      `2·deg v ≤ deg p`.
+
+  That is an UPPER bound on the certificate degree.  This file proves the
+  matching SHARPNESS / converse: the bound is achieved exactly, in *every*
+  sum-of-two-squares representation — not just the one the existence proof
+  happens to produce.
+
+  The crux is a leading-term non-cancellation fact special to the reals:
+
+      `natDegree (u² + v²) = 2 · max (natDegree u) (natDegree v)`   (u, v not both 0).
+
+  Two real squares can never cancel in top degree: when `deg u = deg v` the top
+  coefficient of `u² + v²` is `(lc u)² + (lc v)²`, a sum of two real squares that
+  vanishes only if both `u, v` vanish.  (Over ℂ this fails: `X² + (iX)² = 0`.)
+
+  Consequences pinned down here:
+
+    * `two_sos_max_degree_eq`  — in ANY `p = u² + v²` with `p ≠ 0`, the larger
+      summand has degree *exactly* `½·deg p`.  So the Fejér–Riesz upper bound
+      `2·deg u ≤ deg p` cannot be improved: equality holds for `max(u, v)`.
+    * `natDegree_two_sos_even` — the degree of any nonzero sum of two real
+      squares is even (an immediate structural corollary).
+    * `univariate_psd_two_sos_degree_exact` — strengthens the parent existence
+      theorem: the witnesses can be taken with `2·max(deg u, deg v) = deg p`.
+
+  Fully elementary and 0-axiom, like the parent.
+-/
+import Mathlib
+import Proofs.Hilbert17OQ01OQ01
+
+namespace Hilbert17OQ01OQ01OQ01
+
+open Polynomial
+open Hilbert17UnivariatePSDSOS (IsPSD)
+
+/-- **Leading-term non-cancellation for real sums of two squares.**
+
+The degree of `u² + v²` is exactly twice the larger of `deg u`, `deg v`.  The
+only nontrivial case is `deg u = deg v`, where the top coefficient is
+`(lc u)² + (lc v)²`; over an ordered field this is `0` only when both leading
+coefficients vanish, i.e. both polynomials are zero. -/
+theorem natDegree_sq_add_sq {u v : ℝ[X]} (h : u ≠ 0 ∨ v ≠ 0) :
+    (u ^ 2 + v ^ 2).natDegree = 2 * max u.natDegree v.natDegree := by
+  rcases lt_trichotomy u.natDegree v.natDegree with hlt | heq | hgt
+  · -- `deg u < deg v`: the `v²` term strictly dominates.
+    have hd : (u ^ 2).natDegree < (v ^ 2).natDegree := by
+      rw [natDegree_pow, natDegree_pow]; omega
+    rw [natDegree_add_eq_right_of_natDegree_lt hd, natDegree_pow, max_eq_right hlt.le]
+  · -- `deg u = deg v`: the top coefficients are `(lc u)²` and `(lc v)²`; no
+    -- cancellation since `(lc u)² + (lc v)² = 0 → u = v = 0`.
+    set a := u.natDegree with ha
+    have hnu : (u ^ 2).natDegree = 2 * a := by rw [natDegree_pow]
+    have hnv : (v ^ 2).natDegree = 2 * a := by rw [natDegree_pow, ← heq]
+    -- upper bound on the degree of the sum
+    have hub : (u ^ 2 + v ^ 2).natDegree ≤ 2 * a := by
+      refine le_trans (natDegree_add_le _ _) ?_
+      rw [hnu, hnv, max_self]
+    -- the coefficient at degree `2a` is `(lc u)² + (lc v)²`
+    have e1 : (u ^ 2).coeff (2 * a) = u.leadingCoeff ^ 2 := by
+      have : (u ^ 2).coeff (2 * a) = (u ^ 2).leadingCoeff := by rw [← hnu]; rfl
+      rw [this, leadingCoeff_pow]
+    have e2 : (v ^ 2).coeff (2 * a) = v.leadingCoeff ^ 2 := by
+      have : (v ^ 2).coeff (2 * a) = (v ^ 2).leadingCoeff := by rw [← hnv]; rfl
+      rw [this, leadingCoeff_pow]
+    have hne : (u ^ 2 + v ^ 2).coeff (2 * a) ≠ 0 := by
+      rw [coeff_add, e1, e2]
+      rcases h with hu | hv
+      · have hpos := pow_two_pos_of_ne_zero (leadingCoeff_ne_zero.mpr hu)
+        nlinarith [sq_nonneg v.leadingCoeff]
+      · have hpos := pow_two_pos_of_ne_zero (leadingCoeff_ne_zero.mpr hv)
+        nlinarith [sq_nonneg u.leadingCoeff]
+    have hlb : 2 * a ≤ (u ^ 2 + v ^ 2).natDegree := le_natDegree_of_ne_zero hne
+    have hmax : max a v.natDegree = a := by rw [← heq, max_self]
+    rw [hmax]; omega
+  · -- `deg u > deg v`: symmetric to the first case.
+    have hd : (v ^ 2).natDegree < (u ^ 2).natDegree := by
+      rw [natDegree_pow, natDegree_pow]; omega
+    rw [natDegree_add_eq_left_of_natDegree_lt hd, natDegree_pow, max_eq_left hgt.le]
+
+/-- **Sharpness of the Fejér–Riesz degree bound.**
+
+In *any* representation of a nonzero polynomial as a sum of two real squares, the
+larger summand has degree *exactly* `½·deg p`.  Combined with the parent's upper
+bound `2·deg u ≤ deg p`, this shows the bound is attained and cannot be lowered. -/
+theorem two_sos_max_degree_eq {p u v : ℝ[X]} (hp : p ≠ 0) (huv : p = u ^ 2 + v ^ 2) :
+    2 * max u.natDegree v.natDegree = p.natDegree := by
+  have h : u ≠ 0 ∨ v ≠ 0 := by
+    by_contra hc
+    push_neg at hc
+    exact hp (by rw [huv, hc.1, hc.2]; ring)
+  rw [huv, natDegree_sq_add_sq h]
+
+/-- The degree of any nonzero sum of two real squares is even.  (Structural
+corollary of the exact-degree formula: `deg p = 2 · max(deg u, deg v)`.) -/
+theorem natDegree_two_sos_even {p u v : ℝ[X]} (hp : p ≠ 0) (huv : p = u ^ 2 + v ^ 2) :
+    Even p.natDegree :=
+  ⟨max u.natDegree v.natDegree, by rw [← two_sos_max_degree_eq hp huv]; ring⟩
+
+/-- **Degree-exact Fejér–Riesz.**  Strengthening the parent existence theorem:
+every nonzero PSD univariate polynomial is a sum of two squares whose larger
+summand has degree *exactly* `½·deg p` (so the certificate degree is forced, not
+merely bounded above). -/
+theorem univariate_psd_two_sos_degree_exact (p : ℝ[X]) (hp : p ≠ 0) (h : IsPSD p) :
+    ∃ u v : ℝ[X], p = u ^ 2 + v ^ 2 ∧ 2 * max u.natDegree v.natDegree = p.natDegree := by
+  obtain ⟨u, v, huv, _, _⟩ := Hilbert17OQ01OQ01.univariate_psd_is_two_sos_deg p h
+  exact ⟨u, v, huv, two_sos_max_degree_eq hp huv⟩
+
+end Hilbert17OQ01OQ01OQ01

--- a/proofs/Proofs/Hilbert17OQ01OQ01RootMultiplicity.lean
+++ b/proofs/Proofs/Hilbert17OQ01OQ01RootMultiplicity.lean
@@ -1,0 +1,175 @@
+/-
+  Hilbert's 17th problem, univariate case — ROOT-MULTIPLICITY structure of a real
+  sum of two squares.
+
+  The sharpness file `Proofs/Hilbert17OQ01OQ01OQ01.lean` pins down the *degree* of
+  the summands in a representation `p = u² + v²`.  This file pins down the
+  *root-multiplicity* structure: how the real zeros of `p` are distributed, and how
+  their multiplicities are forced by the multiplicities in the two summands.  This
+  answers the parent entry's remaining open question linking the smaller summand to
+  the root multiplicity.
+
+  The governing principle is again real non-cancellation, now at a *point* instead
+  of at top degree: for a real number `t`,
+
+      u(t)² + v(t)² = 0  ⟺  u(t) = 0  ∧  v(t) = 0.
+
+  So the real roots of `p = u² + v²` are *exactly* the common real roots of `u` and
+  `v`.  Tracking multiplicities through the local factorisation gives the exact
+  formula
+
+      rootMultiplicity r (u² + v²) = 2 · min (rootMultiplicity r u) (rootMultiplicity r v)
+
+  (for `u, v ≠ 0`).  In particular **every real root of a real 2-SOS has even
+  multiplicity** — a structural obstruction: a polynomial with any simple real root
+  is never a sum of two squares.  Combined with the PSD ⟹ 2-SOS existence theorem of
+  the parent, this recovers the classical fact that a nonnegative univariate
+  polynomial touches the axis only with even order of contact.
+
+  Results:
+
+    * `eval_sq_add_sq_eq_zero_iff` — real roots of `u² + v²` are the common roots.
+    * `rootMultiplicity_sq_add_sq` — the exact `2·min` multiplicity formula.
+    * `even_rootMultiplicity_sq_add_sq` — every real root of a nonzero 2-SOS has
+      even multiplicity (also covers the degenerate `u = 0` / `v = 0` cases).
+    * `IsPSD.even_rootMultiplicity` — every real root of a nonzero PSD univariate
+      polynomial has even multiplicity.
+
+  Fully elementary and 0-axiom, like the parent.
+-/
+import Mathlib
+import Proofs.Hilbert17OQ01OQ01
+
+namespace Hilbert17OQ01OQ01RootMult
+
+open Polynomial
+open Hilbert17UnivariatePSDSOS (IsPSD)
+
+/-- A real sum of two squares is the zero polynomial only if a summand forces it:
+if `u ≠ 0` then `u² + v² ≠ 0`.  (A nonzero `u` evaluates to something nonzero
+somewhere, and there `u² + v² ≥ u² > 0`, so the polynomial is not identically `0`.) -/
+theorem sq_add_sq_ne_zero {u v : ℝ[X]} (h : u ≠ 0) : u ^ 2 + v ^ 2 ≠ 0 := by
+  intro hc
+  apply h
+  apply Polynomial.funext
+  intro x
+  have hx : (u ^ 2 + v ^ 2).eval x = 0 := by rw [hc]; simp
+  simp only [eval_add, eval_pow, eval_zero] at hx ⊢
+  nlinarith [sq_nonneg (u.eval x), sq_nonneg (v.eval x)]
+
+/-- **Real roots of a 2-SOS are the common roots.**  Since a sum of two real
+squares vanishes only when both vanish, `t` is a root of `u² + v²` iff it is a
+common root of `u` and `v`. -/
+theorem eval_sq_add_sq_eq_zero_iff {u v : ℝ[X]} {t : ℝ} :
+    (u ^ 2 + v ^ 2).eval t = 0 ↔ u.eval t = 0 ∧ v.eval t = 0 := by
+  constructor
+  · intro h
+    simp only [eval_add, eval_pow] at h
+    exact ⟨by nlinarith [sq_nonneg (u.eval t), sq_nonneg (v.eval t)],
+           by nlinarith [sq_nonneg (u.eval t), sq_nonneg (v.eval t)]⟩
+  · rintro ⟨hu, hv⟩
+    simp only [eval_add, eval_pow, hu, hv]; ring
+
+/-- Extract the local factorisation at a root: `u = (X - r)^(mult) · u₁` with
+`u₁(r) ≠ 0`, where `mult = rootMultiplicity r u`. -/
+private theorem factor_at_root (r : ℝ) (u : ℝ[X]) (hu0 : u ≠ 0) :
+    ∃ u₁ : ℝ[X], u = (X - C r) ^ (rootMultiplicity r u) * u₁ ∧ u₁.eval r ≠ 0 := by
+  obtain ⟨u₁, hu₁⟩ := pow_rootMultiplicity_dvd u r
+  refine ⟨u₁, hu₁, ?_⟩
+  intro hev
+  obtain ⟨w, hw⟩ := dvd_iff_isRoot.mpr hev
+  have huw : u = (X - C r) ^ (rootMultiplicity r u + 1) * w := by
+    rw [pow_succ, mul_assoc, ← hw]; exact hu₁
+  exact pow_rootMultiplicity_not_dvd hu0 r ⟨w, huw⟩
+
+/-- Helper for the multiplicity formula assuming the multiplicities are ordered:
+when `rootMultiplicity r u ≤ rootMultiplicity r v`, the smaller one dominates and
+`rootMultiplicity r (u² + v²) = 2 · rootMultiplicity r u`. -/
+private theorem rootMultiplicity_sq_add_sq_of_le (r : ℝ) {u v : ℝ[X]}
+    (hu0 : u ≠ 0) (hv0 : v ≠ 0)
+    (hab : rootMultiplicity r u ≤ rootMultiplicity r v) :
+    rootMultiplicity r (u ^ 2 + v ^ 2) = 2 * rootMultiplicity r u := by
+  set a := rootMultiplicity r u with ha
+  set b := rootMultiplicity r v with hb
+  obtain ⟨u₁, hu₁, hu₁r⟩ := factor_at_root r u hu0
+  obtain ⟨v₁, hv₁, hv₁r⟩ := factor_at_root r v hv0
+  -- factor out `(X - r)^(2a)`
+  set q : ℝ[X] := u₁ ^ 2 + (X - C r) ^ (2 * (b - a)) * v₁ ^ 2 with hq
+  have key : u ^ 2 + v ^ 2 = (X - C r) ^ (2 * a) * q := by
+    have hbexp : (X - C r) ^ (2 * b)
+        = (X - C r) ^ (2 * a) * (X - C r) ^ (2 * (b - a)) := by
+      rw [← pow_add]; congr 1; omega
+    have e1 : ((X - C r) ^ a * u₁) ^ 2 = (X - C r) ^ (2 * a) * u₁ ^ 2 := by
+      rw [mul_pow, ← pow_mul]; ring_nf
+    have e2 : ((X - C r) ^ b * v₁) ^ 2 = (X - C r) ^ (2 * b) * v₁ ^ 2 := by
+      rw [mul_pow, ← pow_mul]; ring_nf
+    rw [hq, hu₁, hv₁, e1, e2, hbexp]; ring
+  -- `q(r) ≠ 0`: the surviving term is `u₁(r)² > 0`
+  have hqr : q.eval r ≠ 0 := by
+    rw [hq]
+    rcases eq_or_lt_of_le hab with heq | hlt
+    · -- `a = b`: `q(r) = u₁(r)² + v₁(r)²`
+      simp only [eval_add, eval_pow, show b - a = 0 by omega, Nat.mul_zero,
+        pow_zero, one_mul]
+      nlinarith [sq_nonneg (v₁.eval r), pow_two_pos_of_ne_zero hu₁r]
+    · -- `a < b`: the `v₁` term carries a positive power of `(X - r)`, so `q(r) = u₁(r)²`
+      simp only [eval_add, eval_mul, eval_pow, eval_sub, eval_X, eval_C, sub_self]
+      rw [zero_pow (by omega)]
+      simpa using pow_ne_zero 2 hu₁r
+  have hp0 : (X - C r) ^ (2 * a) * q ≠ 0 := by rw [← key]; exact sq_add_sq_ne_zero hu0
+  rw [key, rootMultiplicity_mul hp0, rootMultiplicity_X_sub_C_pow,
+      rootMultiplicity_eq_zero (by simpa [IsRoot] using hqr), add_zero]
+
+/-- **Exact root-multiplicity formula for a real 2-SOS.**
+
+For nonzero `u, v`, the multiplicity of any real number `r` as a root of `u² + v²`
+is *exactly twice* the smaller of its multiplicities in `u` and `v`:
+
+  `rootMultiplicity r (u² + v²) = 2 · min (rootMultiplicity r u) (rootMultiplicity r v)`.
+
+Two real squares cannot cancel at a point any more than at top degree: at the
+common order of vanishing `m = min(a,b)`, factoring out `(X - r)^{2m}` leaves a
+polynomial whose value at `r` is a *positive* sum of squares. -/
+theorem rootMultiplicity_sq_add_sq (r : ℝ) {u v : ℝ[X]} (hu0 : u ≠ 0) (hv0 : v ≠ 0) :
+    rootMultiplicity r (u ^ 2 + v ^ 2)
+      = 2 * min (rootMultiplicity r u) (rootMultiplicity r v) := by
+  rcases le_total (rootMultiplicity r u) (rootMultiplicity r v) with hab | hba
+  · rw [min_eq_left hab, rootMultiplicity_sq_add_sq_of_le r hu0 hv0 hab]
+  · rw [min_eq_right hba, add_comm (u ^ 2),
+      rootMultiplicity_sq_add_sq_of_le r hv0 hu0 hba]
+
+/-- **Every real root of a real 2-SOS has even multiplicity.**
+
+A real polynomial that is a sum of two squares (and is nonzero) can only meet the
+real axis with even order of contact.  Equivalently: a polynomial with even degree
+is necessary but a polynomial with *any* simple real root is *never* a sum of two
+squares.  The degenerate cases `u = 0` and `v = 0` (where `p` is a single square)
+are included. -/
+theorem even_rootMultiplicity_sq_add_sq {p u v : ℝ[X]} (hp0 : p ≠ 0)
+    (huv : p = u ^ 2 + v ^ 2) (r : ℝ) : Even (rootMultiplicity r p) := by
+  by_cases hu0 : u = 0
+  · -- `p = v²`
+    have hv0 : v ≠ 0 := by intro h; rw [huv, hu0, h] at hp0; simp at hp0
+    have : p = v * v := by rw [huv, hu0]; ring
+    rw [this, rootMultiplicity_mul (by rw [← this]; exact hp0)]
+    exact ⟨rootMultiplicity r v, rfl⟩
+  · by_cases hv0 : v = 0
+    · -- `p = u²`
+      have : p = u * u := by rw [huv, hv0]; ring
+      rw [this, rootMultiplicity_mul (by rw [← this]; exact hp0)]
+      exact ⟨rootMultiplicity r u, rfl⟩
+    · -- both nonzero: the `2·min` formula is manifestly even
+      rw [huv, rootMultiplicity_sq_add_sq r hu0 hv0]
+      exact ⟨min (rootMultiplicity r u) (rootMultiplicity r v), two_mul _⟩
+
+/-- **Even order of contact for nonnegative polynomials.**  Every real root of a
+nonzero PSD univariate polynomial has even multiplicity: a nonnegative real
+polynomial touches the axis only to even order (it cannot cross it).  This combines
+the parent's PSD ⟹ sum-of-two-squares theorem with the even-multiplicity
+obstruction above. -/
+theorem IsPSD.even_rootMultiplicity {p : ℝ[X]} (hp0 : p ≠ 0) (h : IsPSD p) (r : ℝ) :
+    Even (rootMultiplicity r p) := by
+  obtain ⟨u, v, huv, _, _⟩ := Hilbert17OQ01OQ01.univariate_psd_is_two_sos_deg p h
+  exact even_rootMultiplicity_sq_add_sq hp0 huv r
+
+end Hilbert17OQ01OQ01RootMult

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-h17-coprime-bezout-point",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 74
+    },
+    "type": "concept",
+    "title": "Bézout at a point ⟹ positive-definiteness",
+    "content": "Coprimality of u and v is an algebraic statement (∃ a b, a·u + b·v = 1), but it has an immediate pointwise consequence: evaluate the Bézout identity at any real t. If u(t) and v(t) were both 0 the left side would be 0, contradicting the right side 1 (no_common_root_of_isCoprime). Feeding this into the parent file's non-cancellation lemma eval_sq_add_sq_eq_zero_iff (u(t)² + v(t)² = 0 ⟺ u(t) = v(t) = 0) shows the coprime sum u² + v² is never zero; combined with u(t)² + v(t)² ≥ 0 (positivity) it is strictly positive at every point (sq_add_sq_pos_of_isCoprime), hence root-free. This is the strict, primitive-case form of Fejér–Riesz nonnegativity."
+  },
+  {
+    "id": "ann-h17-coprime-cofactors",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 81,
+      "endLine": 95
+    },
+    "type": "technique",
+    "title": "Coprime cofactors by cancelling the gcd in its own Bézout identity",
+    "content": "Mathlib has no ready lemma that u/gcd and v/gcd are coprime for a general Euclidean domain (unlike Nat.coprime_div_gcd_div_gcd), so this is proved by hand in four lines. Take the Bézout identity for the gcd itself, d = u·gcdA + v·gcdB (EuclideanDomain.gcd_eq_gcd_ab). Substitute u = d·u₁, v = d·v₁ to get d = d·(u₁·gcdA + v₁·gcdB), then cancel d — nonzero exactly when (u,v) ≠ (0,0), via gcd_eq_zero_iff and mul_left_cancel₀ — to obtain 1 = u₁·gcdA + v₁·gcdB, a Bézout certificate for IsCoprime u₁ v₁. Implementation note: the gcd, gcdA, gcdB are frozen with `set` (after the Bézout hypothesis is created) so that `rw [hu, hv]` rewrites only the standalone u, v and never descends into `gcd u v`; and the cancellation goal is closed with `linear_combination` rather than `rw` to avoid rewriting every copy of d at once."
+  },
+  {
+    "id": "ann-h17-coprime-factorisation",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 97,
+      "endLine": 143
+    },
+    "type": "key-step",
+    "title": "p = (gcd u v)² · (positive-definite primitive 2-SOS)",
+    "content": "Assembling the pieces: with u = d·u₁ and v = d·v₁ (d = gcd u v), u² + v² = d²·(u₁² + v₁²) by ring, the cofactors are coprime (previous step), and the primitive part u₁² + v₁² is positive definite (Bézout-at-a-point step). So exists_primitive_factorization exhibits every real 2-SOS as a perfect square times a strictly positive polynomial. The root-multiplicity corollary rootMultiplicity_two_sos then splits rootMult r (d²·q) = rootMult r (d²) + rootMult r q via rootMultiplicity_mul; rootMult r q = 0 because q is positive definite (rootMultiplicity_eq_zero on the not-a-root fact), leaving 2·rootMult r d. Since rootMult r (gcd u v) = min(rootMult r u, rootMult r v), this re-derives the parent's 2·min multiplicity formula directly from the factorisation."
+  },
+  {
+    "id": "ann-h17-coprime-nonuniqueness",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 145,
+      "endLine": 167
+    },
+    "type": "concept",
+    "title": "The primitive part is not an invariant of p",
+    "content": "The natural uniqueness conjecture — that a real 2-SOS has a well-defined primitive part — is FALSE. The single polynomial (X²+1)² admits two 2-SOS decompositions of opposite character: the non-coprime square (X²+1)² + 0², whose gcd is X²+1 and primitive part is the constant 1; and the coprime sum (X²−1)² + (2X)² (the real and imaginary parts of (X+i)²), whose gcd is a unit and primitive part is (X²+1)² itself. So coprimality of the summands is not preserved across decompositions, and 'primitive normalisation' is a property of a chosen (u,v), not a canonical operation on p (coprimality_not_invariant). The coprime witness a·(X²−1) + b·(2X) = 1 with a = −1, b = ½X is checked by Polynomial.funext (evaluation over the infinite field ℝ) to avoid ring's inability to simplify C(½)·2 = 1; the non-coprimality of (X²+1, 0) reduces via isCoprime_zero_right to X²+1 not being a unit, refuted by its degree (natDegree_X_pow_add_C)."
+  }
+]

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,221 @@
+{
+  "id": "hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "title": "Coprime Normalization of a Real Sum of Two Squares: p = (gcd u v)² · (positive-definite primitive 2-SOS)",
+  "slug": "hilbert-17-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert17OQ01OQ01CoprimeNormalization.lean",
+    "tags": [
+      "real-algebra",
+      "sum-of-squares",
+      "hilbert-17",
+      "fejer-riesz",
+      "coprime",
+      "positive-definite",
+      "gcd",
+      "bezout",
+      "univariate-polynomials",
+      "euclidean-domain"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "EuclideanDomain.gcd_eq_gcd_ab",
+        "description": "Bézout identity gcd a b = a * gcdA a b + b * gcdB a b in a Euclidean domain. Cancelling the gcd factor d from this identity turns d = d·u₁·A + d·v₁·B into 1 = u₁·A + v₁·B, i.e. the cofactors u₁, v₁ are coprime.",
+        "module": "Mathlib.Algebra.EuclideanDomain.Basic"
+      },
+      {
+        "theorem": "EuclideanDomain.gcd_dvd_left",
+        "description": "gcd a b ∣ a (and the symmetric gcd_dvd_right). Provides the factorisations u = d·u₁, v = d·v₁ used to divide out the common factor.",
+        "module": "Mathlib.Algebra.EuclideanDomain.Basic"
+      },
+      {
+        "theorem": "EuclideanDomain.gcd_eq_zero_iff",
+        "description": "gcd a b = 0 ↔ a = 0 ∧ b = 0. Supplies d ≠ 0 whenever (u, v) ≠ (0, 0), the hypothesis needed to cancel d.",
+        "module": "Mathlib.Algebra.EuclideanDomain.Basic"
+      },
+      {
+        "theorem": "mul_left_cancel₀",
+        "description": "d ≠ 0 → d * a = d * b → a = b in a domain. The cancellation of the gcd from the scaled Bézout identity that produces the coprimality certificate.",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      },
+      {
+        "theorem": "Polynomial.rootMultiplicity_mul",
+        "description": "rootMultiplicity x (p * q) = rootMultiplicity x p + rootMultiplicity x q for p*q ≠ 0. Splits rootMult r (d² · primitive) into 2·rootMult r d + 0 once the primitive part is shown root-free.",
+        "module": "Mathlib.Algebra.Polynomial.RingDivision"
+      },
+      {
+        "theorem": "Polynomial.rootMultiplicity_eq_zero",
+        "description": "¬ p.IsRoot x → rootMultiplicity x p = 0. Zeroes out the primitive part's contribution, since it is positive definite and hence has no real root.",
+        "module": "Mathlib.Algebra.Polynomial.RingDivision"
+      },
+      {
+        "theorem": "Polynomial.natDegree_X_pow_add_C",
+        "description": "natDegree (X^n + C a) = n. Shows X² + 1 has degree 2, contradicting IsUnit (degree 0) in the non-uniqueness witness.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Lemmas"
+      },
+      {
+        "theorem": "Polynomial.funext",
+        "description": "Two polynomials over an infinite integral domain agreeing at every point are equal. Discharges the Bézout coefficient identity C(-1)·(X²−1) + (C(½)·X)·(2X) = 1 by evaluation, sidestepping C-arithmetic in ring.",
+        "module": "Mathlib.Algebra.Polynomial.Eval"
+      }
+    ],
+    "originalContributions": [
+      "no_common_root_of_isCoprime: coprime real polynomials share no real root — evaluating a Bézout identity a·u + b·v = 1 at a common zero gives 1 = 0. The one-line analytic bridge from the algebraic gcd to the pointwise behaviour.",
+      "sq_add_sq_pos_of_isCoprime: a coprime sum of two squares is positive definite (u² + v² > 0 everywhere on ℝ), hence has no real roots (not_isRoot_of_isCoprime). Combines Bézout-at-a-point with the parent's pointwise non-cancellation.",
+      "isCoprime_cofactors: dividing u and v by their gcd yields coprime cofactors, proved by cancelling d in its own Bézout identity (a self-contained substitute for the Nat.coprime_div_gcd analogue, which Mathlib lacks for a general Euclidean domain).",
+      "exists_primitive_factorization: every real 2-SOS factors as p = (gcd u v)² · (u₁² + v₁²) with coprime u₁, v₁ and the primitive part u₁² + v₁² positive definite — a perfect square times a strictly positive polynomial. This answers the coprime-normalization open question of the parent root-multiplicity entry.",
+      "rootMultiplicity_two_sos: rootMultiplicity r (u² + v²) = 2 · rootMultiplicity r (gcd u v) — all real zeros of a 2-SOS are carried by the gcd, making the parent entry's 2·min formula transparent (the gcd multiplicity is the min of the two summand multiplicities).",
+      "coprimality_not_invariant: settles the uniqueness half of the open question NEGATIVELY. (X²+1)² is simultaneously the non-coprime square (X²+1)² + 0² (primitive part 1) and the coprime sum (X²−1)² + (2X)² (primitive part p itself), so the primitive part is not an invariant of p."
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "The Euclidean-domain / Bézout API for ℝ[X]: gcd_dvd_left/right for the cofactor factorisations, gcd_eq_gcd_ab for the Bézout identity, gcd_eq_zero_iff for d ≠ 0, and domain cancellation (mul_left_cancel₀).",
+      "The pointwise non-cancellation lemma eval_sq_add_sq_eq_zero_iff from the parent root-multiplicity entry (u(t)² + v(t)² = 0 ⟺ u(t) = v(t) = 0).",
+      "rootMultiplicity additivity (rootMultiplicity_mul) and vanishing (rootMultiplicity_eq_zero) for the gcd-carries-all-roots corollary."
+    ],
+    "lineCount": 169,
+    "relatedProblems": [
+      {
+        "id": "hilbert-17-oq-01-oq-01-oq-01-oq-01",
+        "relationship": "Parent: characterises the real roots of a 2-SOS and their multiplicities (rootMult(u²+v²) = 2·min(rootMult u, rootMult v)) and asks, as its second open question, to factor any real 2-SOS as d²·(primitive 2-SOS) with d = gcd(u,v) and to determine whether the primitive part is unique. This entry proves that factorisation (with the primitive part positive definite) and answers the uniqueness question negatively."
+      },
+      {
+        "id": "hilbert-17-oq-01-oq-01-oq-01",
+        "relationship": "Grandparent: pins down the DEGREE of the summands (Fejér–Riesz sharpness and asymmetric normal form). The coprime normalisation here is the multiplicative counterpart on the ROOT side: p is a square (of the gcd) times a strictly positive primitive factor."
+      },
+      {
+        "id": "hilbert-17-oq-01-oq-01",
+        "relationship": "Great-grandparent: proves the Fejér–Riesz existence/upper bound (PSD ⟹ u² + v²). The positive-definiteness of a coprime 2-SOS here is the strict form of nonnegativity for the primitive part."
+      },
+      {
+        "id": "hilbert-17",
+        "relationship": "Root ancestor: Hilbert's 17th problem and Artin's theorem. The univariate strand now has existence, exact certificate degree, exact real-root multiplicities, AND the coprime (square-times-positive-definite) normal form."
+      }
+    ],
+    "assumptions": "0 axioms. #print axioms on the public theorems (sq_add_sq_pos_of_isCoprime, exists_primitive_factorization, rootMultiplicity_two_sos, coprimality_not_invariant) reports only propext, Classical.choice, Quot.sound. No sorryAx, no native_decide / Lean.ofReduceBool. Reuses only the 0-axiom pointwise non-cancellation lemma from the parent file.",
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "leanFile": {
+    "lineCount": 169,
+    "namespace": "Hilbert17OQ01OQ01CoprimeNorm",
+    "opens": [
+      "Polynomial"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 6,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": [
+      "Mathlib",
+      "Proofs.Hilbert17OQ01OQ01RootMultiplicity"
+    ],
+    "path": "Proofs/Hilbert17OQ01OQ01CoprimeNormalization.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "description": "The parent entry (hilbert-17-oq-01-oq-01-oq-01-oq-01) characterises the real roots of a two-squares decomposition p = u² + v² and asks, as its second open question, to factor any real 2-SOS as d²·q with d = gcd(u,v) and q a PRIMITIVE 2-SOS (coprime summands, no real roots), and to decide whether q is unique. This entry answers both parts. Two facts drive it. First, Bézout at a point: if u and v are coprime (IsCoprime u v) then evaluating a·u + b·v = 1 at any t forces the summands not to vanish simultaneously, so together with the parent's pointwise non-cancellation the coprime sum u² + v² is POSITIVE DEFINITE — strictly positive everywhere, hence root-free (sq_add_sq_pos_of_isCoprime, not_isRoot_of_isCoprime). Second, dividing out the gcd: writing d = gcd(u,v), u = d·u₁, v = d·v₁, the cofactors are coprime (cancel d in its own Bézout identity — isCoprime_cofactors), giving exists_primitive_factorization: u² + v² = d²·(u₁² + v₁²) with the primitive part positive definite. So every real 2-SOS is a perfect square times a strictly positive polynomial, and every real zero of p is carried by d²: rootMultiplicity r (u² + v²) = 2·rootMultiplicity r (gcd u v) (rootMultiplicity_two_sos), which makes the parent's 2·min formula transparent. The uniqueness half is answered NEGATIVELY (coprimality_not_invariant): (X²+1)² is both the non-coprime square (X²+1)² + 0² and the coprime sum (X²−1)² + (2X)², so the primitive part depends on the chosen decomposition, not on p alone. Fully elementary, 0 axioms.",
+  "overview": {
+    "historicalContext": "Hilbert's 1888 result writes a nonnegative univariate real polynomial as a sum of two squares; the classical analytic proof factors p over ℂ into conjugate-paired roots. The parent strand formalised the algebraic root structure of a real 2-SOS (real roots = common roots; multiplicity = 2·min). This entry adds the multiplicative normal form. The theme is the classical square-free/primitive decomposition specialised to sums of squares: pull out the greatest common factor d = gcd(u,v) of the summands, and what remains is a coprime pair whose sum of squares can never touch the real axis. The only non-elementary ingredient is the Euclidean structure of ℝ[X] (Bézout), used twice — once at a point to force positive-definiteness of the coprime part, once globally to divide out the gcd.",
+    "problemStatement": "Given a real 2-SOS p = u² + v², can one factor it as p = d²·q with d = gcd(u,v) and q a primitive 2-SOS (coprime summands) that is positive definite? And is the primitive part q determined by p, or does it depend on the chosen decomposition (u,v)?",
+    "proofStrategy": "Positive-definiteness first: from IsCoprime u v obtain a Bézout pair a, b with a·u + b·v = 1; evaluating at t rules out u(t) = v(t) = 0, so by the parent's eval_sq_add_sq_eq_zero_iff the sum u² + v² is never zero, and being ≥ 0 (positivity) it is > 0 everywhere. For the factorisation, set d = gcd(u,v); gcd_dvd_left/right give u = d·u₁, v = d·v₁. Substituting into the Bézout identity for d, d = d·u₁·gcdA + d·v₁·gcdB, and cancelling d (nonzero since (u,v) ≠ (0,0)) yields 1 = u₁·gcdA + v₁·gcdB, i.e. IsCoprime u₁ v₁. Then u² + v² = d²·(u₁² + v₁²) by ring, and the primitive part is positive definite by the first step. The root-multiplicity corollary splits rootMult r (d²·q) via rootMultiplicity_mul into 2·rootMult r d + rootMult r q, and rootMult r q = 0 because q is root-free. Non-uniqueness is exhibited concretely on (X²+1)²: the coprime witness (X²−1, 2X) is checked by Polynomial.funext (evaluation avoids C-arithmetic), and ¬ IsCoprime (X²+1) 0 follows from isCoprime_zero_right and the degree of X²+1.",
+    "keyInsights": [
+      "Bézout at a point is the whole bridge: coprime summands cannot share a real root because a·u + b·v = 1 evaluates to 1, not 0, at every point. This upgrades the parent's 'roots are common roots' to 'coprime ⟹ no roots at all'.",
+      "A coprime 2-SOS is positive definite. This is the strict, primitive-case form of the Fejér–Riesz nonnegativity: the primitive factor of any real 2-SOS never meets the axis.",
+      "Dividing out the gcd needs no library lemma about cofactor coprimality — it falls straight out of cancelling d in d's own Bézout identity, four lines of Euclidean-domain algebra.",
+      "The gcd carries every real zero: rootMult r (u² + v²) = 2·rootMult r (gcd u v). Since rootMult r (gcd u v) = min(rootMult r u, rootMult r v), this re-derives the parent's 2·min formula from the factorisation.",
+      "The primitive part is NOT an invariant of p. The same (X²+1)² is a non-coprime square (primitive part 1) and a coprime sum (primitive part itself). So 'primitive normalisation' is a property of a decomposition, not a canonical operation on the polynomial — the natural uniqueness conjecture is false."
+    ]
+  },
+  "sections": [
+    {
+      "id": "bezout-at-a-point",
+      "title": "Bézout at a point and positive-definiteness",
+      "startLine": 55,
+      "endLine": 78,
+      "summary": "no_common_root_of_isCoprime: a Bézout identity a·u + b·v = 1 evaluated at t rules out a common zero (1 ≠ 0). sq_add_sq_pos_of_isCoprime: hence a coprime u² + v² is > 0 everywhere (never zero by the parent's non-cancellation, and ≥ 0 by positivity). not_isRoot_of_isCoprime: it therefore has no real roots."
+    },
+    {
+      "id": "coprime-cofactors",
+      "title": "Coprime cofactors by cancelling the gcd",
+      "startLine": 81,
+      "endLine": 95,
+      "summary": "isCoprime_cofactors: writing u = d·u₁, v = d·v₁ with d = gcd(u,v), substitute into the Bézout identity d = u·gcdA + v·gcdB to get d = d·(u₁·gcdA + v₁·gcdB); cancel d (nonzero since (u,v) ≠ (0,0)) to obtain 1 = u₁·gcdA + v₁·gcdB, i.e. IsCoprime u₁ v₁. Freezing gcdA, gcdB with set prevents rewrites from descending into the gcd."
+    },
+    {
+      "id": "primitive-factorisation",
+      "title": "The square-times-positive-definite normal form",
+      "startLine": 97,
+      "endLine": 143,
+      "summary": "exists_primitive_factorization: u² + v² = (gcd u v)²·(u₁² + v₁²) with coprime, positive-definite primitive part. rootMultiplicity_two_sos: rootMult r (u² + v²) = 2·rootMult r (gcd u v), splitting the product multiplicity and using that the primitive part is root-free."
+    },
+    {
+      "id": "non-uniqueness",
+      "title": "The primitive part is not an invariant",
+      "startLine": 145,
+      "endLine": 167,
+      "summary": "coprimality_not_invariant: (X²+1)² = (X²+1)² + 0² (non-coprime, primitive part 1) = (X²−1)² + (2X)² (coprime, primitive part p). The coprime witness is verified by Polynomial.funext; ¬ IsCoprime (X²+1) 0 uses isCoprime_zero_right and natDegree_X_pow_add_C. So the primitive part depends on the decomposition, not on p."
+    }
+  ],
+  "conclusion": {
+    "summary": "A 169-line, 0-sorry, 0-axiom companion to the Fejér–Riesz root-multiplicity entry, giving the multiplicative normal form of a real sum of two squares. Bézout evaluated at a point shows a coprime 2-SOS is positive definite; dividing out the gcd d = gcd(u,v) factors any real 2-SOS as p = d²·(u₁² + v₁²) with the primitive part u₁² + v₁² strictly positive, so every real zero of p is carried by d² and rootMultiplicity r (u² + v²) = 2·rootMultiplicity r (gcd u v). The concrete example (X²+1)² = (X²+1)² + 0² = (X²−1)² + (2X)² shows the primitive part is not determined by p.",
+    "implications": "Answers the second open question of the parent entry in full: the d²·(primitive) factorisation exists with the primitive part positive definite, and the primitive part is NOT unique (coprimality of the summands is not preserved across decompositions). Positive-definiteness of the coprime part is the strict form of Fejér–Riesz nonnegativity, and the gcd-carries-all-roots identity re-derives the 2·min multiplicity formula. Isolates the Euclidean-domain (Bézout) content of the two-squares normal form, complementing the ordered-field content of the root-multiplicity entry.",
+    "openQuestions": [
+      "Complex/gcd side still open: characterise the multiplicity structure of the NON-real (complex) roots of a 2-SOS in terms of the two summands, completing the great-grandparent's first open question; relate the degree gap in the normalized representation to the complex root data.",
+      "Canonical choice: although the primitive part is not unique, is there a canonical 2-SOS decomposition minimising deg(gcd u v) (equivalently maximising the primitive part), and is THAT primitive part unique up to the rotation/reflection symmetry?"
+    ]
+  },
+  "references": [
+    {
+      "title": "Hilbert's seventeenth problem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem"
+    },
+    {
+      "title": "Fejér–Riesz theorem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Fej%C3%A9r%E2%80%93Riesz_theorem"
+    },
+    {
+      "title": "B. Reznick, Some concrete aspects of Hilbert's 17th problem (1996)",
+      "url": "https://www.ams.org/books/conm/253/"
+    }
+  ],
+  "crossReferences": [],
+  "mainTheorems": [
+    {
+      "name": "sq_add_sq_pos_of_isCoprime",
+      "type": "theorem",
+      "description": "A coprime sum of two squares is positive definite: if IsCoprime u v then u² + v² is strictly positive at every real point. Combines a Bézout-at-a-point argument (coprime summands share no real root) with the parent's pointwise non-cancellation.",
+      "leanType": "{u v : ℝ[X]} → IsCoprime u v → (t : ℝ) → 0 < (u ^ 2 + v ^ 2).eval t"
+    },
+    {
+      "name": "exists_primitive_factorization",
+      "type": "theorem",
+      "description": "Coprime (primitive) normalisation: for (u,v) ≠ (0,0), writing d = gcd(u,v) and u = d·u₁, v = d·v₁, the cofactors are coprime and u² + v² = d²·(u₁² + v₁²) with the primitive part u₁² + v₁² positive definite. Every real 2-SOS is a perfect square times a strictly positive polynomial.",
+      "leanType": "{u v : ℝ[X]} → ¬(u = 0 ∧ v = 0) → ∃ u₁ v₁, u = EuclideanDomain.gcd u v * u₁ ∧ v = EuclideanDomain.gcd u v * v₁ ∧ IsCoprime u₁ v₁ ∧ u ^ 2 + v ^ 2 = EuclideanDomain.gcd u v ^ 2 * (u₁ ^ 2 + v₁ ^ 2) ∧ ∀ t, 0 < (u₁ ^ 2 + v₁ ^ 2).eval t"
+    },
+    {
+      "name": "rootMultiplicity_two_sos",
+      "type": "theorem",
+      "description": "The gcd carries every real root: rootMultiplicity r (u² + v²) = 2 · rootMultiplicity r (gcd u v). The positive-definite primitive part contributes no real zeros, so all of p's root multiplicity comes from the d² factor — making the parent's 2·min formula transparent.",
+      "leanType": "{u v : ℝ[X]} → ¬(u = 0 ∧ v = 0) → (r : ℝ) → rootMultiplicity r (u ^ 2 + v ^ 2) = 2 * rootMultiplicity r (EuclideanDomain.gcd u v)"
+    },
+    {
+      "name": "coprimality_not_invariant",
+      "type": "theorem",
+      "description": "The primitive part is not an invariant of p: coprimality of the summands is not preserved across 2-SOS decompositions. Witness: (X²+1)² is both the non-coprime square (X²+1)² + 0² and the coprime sum (X²−1)² + (2X)². Settles the uniqueness half of the open question negatively.",
+      "leanType": "∃ p u v s t : ℝ[X], p = u ^ 2 + v ^ 2 ∧ p = s ^ 2 + t ^ 2 ∧ IsCoprime u v ∧ ¬ IsCoprime s t"
+    }
+  ]
+}

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-h17-rootmult-common-roots",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 73
+    },
+    "type": "concept",
+    "title": "Pointwise non-cancellation: real roots are common roots",
+    "content": "The pointwise twin of the parent file's top-degree non-cancellation. For a real number t, u(t)² + v(t)² is a sum of two real squares, so it is 0 only when both u(t) and v(t) are 0 (sq_nonneg on each, closed by nlinarith). Hence eval_sq_add_sq_eq_zero_iff: the real roots of u² + v² are EXACTLY the common real roots of u and v. The same positivity also shows sq_add_sq_ne_zero: if u ≠ 0 then u² + v² ≠ 0 — were it the zero polynomial it would vanish at every point (Polynomial.funext over the infinite field ℝ), forcing u(x)² ≤ u(x)² + v(x)² = 0 and hence u = 0. These two facts make the entire root set of p computable from u and v and underwrite the nonvanishing side-conditions in the multiplicity argument."
+  },
+  {
+    "id": "ann-h17-rootmult-factor-at-root",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 86
+    },
+    "type": "technique",
+    "title": "Local factorisation u = (X−r)^a·u₁ with u₁(r) ≠ 0",
+    "content": "factor_at_root extracts the exact local structure at a root. The factor (X − C r)^(rootMultiplicity r u) ∣ u comes for free from pow_rootMultiplicity_dvd. The point is the cofactor u₁ does NOT vanish at r: if it did, dvd_iff_isRoot would give (X − C r) ∣ u₁, and then u = (X−r)^a·u₁ would be divisible by (X − C r)^(a+1), contradicting pow_rootMultiplicity_not_dvd (which says a is the LARGEST such power). A subtle Lean point: when proving (X−r)^(a+1) ∣ u one must avoid rewriting the bare u, because u also appears inside the index rootMultiplicity r u; the proof builds the witness equation u = (X−r)^(a+1)·w by pow_succ, mul_assoc and ← hw without touching the exponent."
+  },
+  {
+    "id": "ann-h17-rootmult-exact-formula",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 88,
+      "endLine": 146
+    },
+    "type": "concept",
+    "title": "The exact multiplicity is 2·min(a, b)",
+    "content": "rootMultiplicity_sq_add_sq_of_le proves the ordered case a = rootMult r u ≤ b = rootMult r v. Factor u² + v² = (X−r)^{2a}·q with q = u₁² + (X−r)^{2(b−a)}·v₁²; the only delicate algebra is the power split (X−r)^{2b} = (X−r)^{2a}·(X−r)^{2(b−a)}, a single ← pow_add with the exponent identity discharged by omega. The crux is q(r) ≠ 0: evaluating, the (X−r)^{2(b−a)} factor becomes 0^{positive} = 0 when a < b (zero_pow), leaving u₁(r)² ≠ 0; when a = b the exponent is 0, leaving u₁(r)² + v₁(r)², strictly positive. Either way the cofactor survives, so rootMultiplicity_mul splits rootMult r ((X−r)^{2a}·q) = 2a (by rootMultiplicity_X_sub_C_pow) + 0 (by rootMultiplicity_eq_zero on q). rootMultiplicity_sq_add_sq then drops the ordering hypothesis using le_total and add_comm (u² + v² = v² + u²), giving the symmetric 2·min(a,b). Note min, not sum: the summand vanishing to the LOWER order dominates the local behaviour."
+  },
+  {
+    "id": "ann-h17-rootmult-even-order",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 148,
+      "endLine": 175
+    },
+    "type": "concept",
+    "title": "Even multiplicity: an obstruction to being a sum of two squares",
+    "content": "even_rootMultiplicity_sq_add_sq packages the headline structural fact: every real root of a nonzero real 2-SOS has even multiplicity. When both summands are nonzero this is immediate from the 2·min formula (Even n unfolds to ∃ r, n = r + r, witnessed by min with two_mul); the degenerate single-square cases u = 0 (p = v·v) and v = 0 (p = u·u) use rootMultiplicity_mul to get 2·rootMult directly. The contrapositive is the useful obstruction: a polynomial with ANY simple real root — anything that changes sign, like X itself — is never u² + v² over ℝ. IsPSD.even_rootMultiplicity specialises to nonnegative polynomials by feeding the grandparent's PSD ⟹ two-squares existence theorem into this obstruction, recovering the classical even-order-of-contact statement from ordered-field algebra alone, with no appeal to the complex factorisation. This strictly strengthens the grandparent's sq_dvd_of_psd_root, which only gave (X−r)² ∣ p."
+  }
+]

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,210 @@
+{
+  "id": "hilbert-17-oq-01-oq-01-oq-01-oq-01",
+  "title": "Root Multiplicities of a Real Sum of Two Squares: rootMult(u²+v²) = 2·min(rootMult u, rootMult v)",
+  "slug": "hilbert-17-oq-01-oq-01-oq-01-oq-01",
+  "description": "The parent entry (hilbert-17-oq-01-oq-01-oq-01) pins down the DEGREE of the summands in a real two-squares decomposition p = u² + v² and asks, as its first open question, to relate the smaller summand to the multiplicity structure of the roots of p. This entry answers the root-multiplicity half. The governing principle is real non-cancellation at a point (the local analogue of the parent's top-degree non-cancellation): for a real number t, u(t)² + v(t)² = 0 ⟺ u(t) = 0 ∧ v(t) = 0, so the real roots of p = u² + v² are EXACTLY the common real roots of u and v (eval_sq_add_sq_eq_zero_iff). Tracking multiplicities through the local factorisation u = (X−r)^a·u₁, v = (X−r)^b·v₁ with u₁(r), v₁(r) ≠ 0 gives the exact formula rootMultiplicity r (u² + v²) = 2·min(rootMultiplicity r u, rootMultiplicity r v) for u, v ≠ 0 (rootMultiplicity_sq_add_sq): after factoring out (X−r)^{2·min(a,b)} the leftover polynomial evaluates at r to a POSITIVE sum of squares, so it does not vanish there and the multiplicity is pinned exactly. The headline structural consequence: EVERY real root of a nonzero real 2-SOS has even multiplicity (even_rootMultiplicity_sq_add_sq) — a polynomial with any simple real root is never a sum of two squares — and this includes the degenerate single-square cases u = 0 or v = 0. Combined with the grandparent's PSD ⟹ two-squares theorem, this recovers the classical fact that a nonnegative univariate polynomial touches the axis only to even order (IsPSD.even_rootMultiplicity). Fully elementary, 0 axioms.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert17OQ01OQ01RootMultiplicity.lean",
+    "tags": [
+      "real-algebra",
+      "sum-of-squares",
+      "hilbert-17",
+      "fejer-riesz",
+      "root-multiplicity",
+      "even-multiplicity",
+      "univariate-polynomials",
+      "non-negativity",
+      "ordered-fields"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.rootMultiplicity_mul",
+        "description": "rootMultiplicity x (p * q) = rootMultiplicity x p + rootMultiplicity x q for p*q ≠ 0. The additivity used to split rootMult r ((X−r)^{2m}·q) into 2m + rootMult r q once q(r) ≠ 0.",
+        "module": "Mathlib.Algebra.Polynomial.RingDivision"
+      },
+      {
+        "theorem": "Polynomial.rootMultiplicity_X_sub_C_pow",
+        "description": "rootMultiplicity a ((X − C a) ^ n) = n. Evaluates the multiplicity of the factored-out power (X−r)^{2·min(a,b)} as exactly 2·min(a,b).",
+        "module": "Mathlib.Algebra.Polynomial.RingDivision"
+      },
+      {
+        "theorem": "Polynomial.pow_rootMultiplicity_dvd",
+        "description": "(X − C a) ^ rootMultiplicity a p ∣ p. Supplies the local factor u = (X−r)^a·u₁ from which the cofactor u₁ with u₁(r) ≠ 0 is extracted.",
+        "module": "Mathlib.Algebra.Polynomial.RingDivision"
+      },
+      {
+        "theorem": "Polynomial.pow_rootMultiplicity_not_dvd",
+        "description": "¬ (X − C a)^(rootMultiplicity a p + 1) ∣ p for p ≠ 0. Forces u₁(r) ≠ 0: if (X−r) divided u₁ then (X−r)^{a+1} would divide u, contradicting the multiplicity.",
+        "module": "Mathlib.Algebra.Polynomial.RingDivision"
+      },
+      {
+        "theorem": "Polynomial.rootMultiplicity_eq_zero",
+        "description": "¬ p.IsRoot x → rootMultiplicity x p = 0. Zeroes out the cofactor's contribution once it is shown not to vanish at r.",
+        "module": "Mathlib.Algebra.Polynomial.RingDivision"
+      },
+      {
+        "theorem": "Polynomial.funext",
+        "description": "Two polynomials over an infinite integral domain agreeing at every point are equal. Used to prove u² + v² ≠ 0 from u ≠ 0 (otherwise it would vanish identically, forcing u(x)² ≤ 0 hence u = 0).",
+        "module": "Mathlib.Algebra.Polynomial.Eval"
+      },
+      {
+        "theorem": "pow_two_pos_of_ne_zero",
+        "description": "a ≠ 0 → 0 < a ^ 2 in an ordered field. The positive-sum-of-squares fact that makes the post-factoring polynomial nonzero at r and forbids further cancellation.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "eval_sq_add_sq_eq_zero_iff: the real roots of u² + v² are exactly the common real roots of u and v — pointwise non-cancellation (u(t)² + v(t)² = 0 ⟺ u(t) = v(t) = 0), the local analogue of the parent's top-degree non-cancellation.",
+      "rootMultiplicity_sq_add_sq: the exact root-multiplicity formula rootMultiplicity r (u² + v²) = 2·min(rootMultiplicity r u, rootMultiplicity r v) for u, v ≠ 0, proved by factoring out (X−r)^{2·min} and showing the cofactor evaluates to a positive sum of squares at r.",
+      "even_rootMultiplicity_sq_add_sq: every real root of a nonzero real 2-SOS has even multiplicity — a structural obstruction (any polynomial with a simple real root is never a sum of two squares), covering the degenerate single-square cases u = 0 and v = 0.",
+      "IsPSD.even_rootMultiplicity: every real root of a nonzero PSD univariate polynomial has even multiplicity, recovering even order of contact with the axis by composing the grandparent's PSD ⟹ two-squares theorem with the even-multiplicity obstruction.",
+      "Answers the first open question of the parent sharpness entry (relating the smaller summand to the root/multiplicity structure of p) on the root-multiplicity side, with a self-contained argument that strengthens the existing sq_dvd_of_psd_root lemma (which only gives (X−r)² ∣ p) to the exact multiplicity."
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Mathlib rootMultiplicity API: pow_rootMultiplicity_dvd / pow_rootMultiplicity_not_dvd characterise the multiplicity by divisibility, rootMultiplicity_mul is additive on products, rootMultiplicity_X_sub_C_pow evaluates powers of (X − C r).",
+      "The order-field fact that a sum of two squares vanishes only when both terms do (pow_two_pos_of_ne_zero), used both pointwise (common-root characterisation) and after factoring (cofactor nonvanishing).",
+      "The PSD ⟹ sum-of-two-squares existence theorem from the grandparent entry (for the PSD even-order corollary)."
+    ],
+    "lineCount": 175,
+    "relatedProblems": [
+      {
+        "id": "hilbert-17-oq-01-oq-01-oq-01",
+        "relationship": "Parent: pins down the DEGREE of the two summands (sharpness and asymmetric normal form) and asks, as its first open question, to relate the smaller summand to the multiplicity structure of the roots of p. This entry answers the root-multiplicity half: the exact 2·min formula and even-multiplicity of every real root."
+      },
+      {
+        "id": "hilbert-17-oq-01-oq-01",
+        "relationship": "Grandparent: proves the Fejér–Riesz existence/upper-bound (PSD ⟹ u² + v²) and contains sq_dvd_of_psd_root ((X−r)² ∣ p at a PSD root). This entry strengthens that divisibility fact to the exact root multiplicity for any real 2-SOS, not only PSD ones."
+      },
+      {
+        "id": "hilbert-17",
+        "relationship": "Great-great-grandparent: Hilbert's 17th problem and Artin's theorem. The univariate strand is now characterised by existence, exact certificate degree, AND exact real-root multiplicities (even order of contact)."
+      }
+    ],
+    "assumptions": "0 axioms. #print axioms on the public theorems (eval_sq_add_sq_eq_zero_iff, rootMultiplicity_sq_add_sq, even_rootMultiplicity_sq_add_sq, IsPSD.even_rootMultiplicity) reports only propext, Classical.choice, Quot.sound. No sorryAx, no native_decide / Lean.ofReduceBool. The PSD corollary reuses only the 0-axiom existence theorem from the grandparent file.",
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "leanFile": {
+    "lineCount": 175,
+    "namespace": "Hilbert17OQ01OQ01RootMult",
+    "opens": [
+      "Polynomial"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 5,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": [
+      "Mathlib",
+      "Proofs.Hilbert17OQ01OQ01"
+    ],
+    "path": "Proofs/Hilbert17OQ01OQ01RootMultiplicity.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "eval_sq_add_sq_eq_zero_iff",
+      "type": "theorem",
+      "description": "The real roots of u² + v² are exactly the common real roots of u and v: a sum of two real squares vanishes at t iff both summands vanish at t.",
+      "leanType": "{u v : ℝ[X]} → {t : ℝ} → ((u ^ 2 + v ^ 2).eval t = 0 ↔ u.eval t = 0 ∧ v.eval t = 0)"
+    },
+    {
+      "name": "rootMultiplicity_sq_add_sq",
+      "type": "theorem",
+      "description": "Exact root-multiplicity formula: for nonzero u, v the multiplicity of any real r as a root of u² + v² is exactly twice the smaller of its multiplicities in u and v. Proved by factoring out (X−r)^{2·min(a,b)}; the leftover is a positive sum of squares at r and so does not vanish there.",
+      "leanType": "(r : ℝ) → {u v : ℝ[X]} → u ≠ 0 → v ≠ 0 → rootMultiplicity r (u ^ 2 + v ^ 2) = 2 * min (rootMultiplicity r u) (rootMultiplicity r v)"
+    },
+    {
+      "name": "even_rootMultiplicity_sq_add_sq",
+      "type": "theorem",
+      "description": "Every real root of a nonzero real sum of two squares has even multiplicity — so a polynomial with any simple real root is never a 2-SOS. The degenerate single-square cases u = 0 and v = 0 are included.",
+      "leanType": "{p u v : ℝ[X]} → p ≠ 0 → p = u ^ 2 + v ^ 2 → (r : ℝ) → Even (rootMultiplicity r p)"
+    },
+    {
+      "name": "IsPSD.even_rootMultiplicity",
+      "type": "theorem",
+      "description": "Even order of contact: every real root of a nonzero PSD univariate polynomial has even multiplicity, recovered by composing the grandparent's PSD ⟹ two-squares theorem with the even-multiplicity obstruction.",
+      "leanType": "{p : ℝ[X]} → p ≠ 0 → IsPSD p → (r : ℝ) → Even (rootMultiplicity r p)"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Hilbert's 1888 classification shows nonnegative univariate real polynomials are sums of two squares, and the analytic input to the existence proof is the factorisation of p over ℂ into conjugate-paired roots: real roots of a nonnegative polynomial must occur to even order, or the polynomial would change sign. The parent strand formalised the DEGREE side of the two-squares certificate (Fejér–Riesz sharpness and the asymmetric normal form). This entry formalises the dual ROOT side. The unifying theme is that two real squares cannot cancel: at top degree the obstruction is (lc u)² + (lc v)² > 0 (the parent), and at a point r it is u(r)² + v(r)² ≥ 0 with equality only when both vanish (this entry). The pointwise version controls the local order of vanishing and recovers the classical even-order-of-contact statement from purely algebraic, ordered-field reasoning — no appeal to the complex factorisation or the fundamental theorem of algebra.",
+    "problemStatement": "In a representation p = u² + v² of a real polynomial as a sum of two squares, how are the real roots of p and their multiplicities determined by u and v? Concretely: are the real roots exactly the common roots of u and v, and is the multiplicity of each forced — in particular always even?",
+    "proofStrategy": "Pointwise non-cancellation (eval_sq_add_sq_eq_zero_iff) is immediate from sq_nonneg and nlinarith: u(t)² + v(t)² = 0 forces u(t) = v(t) = 0. For the exact formula, reduce by symmetry (le_total on the two multiplicities) to the case a = rootMult r u ≤ b = rootMult r v. Extract local factors u = (X−r)^a·u₁ and v = (X−r)^b·v₁ with u₁(r), v₁(r) ≠ 0 (pow_rootMultiplicity_dvd to get the factor; pow_rootMultiplicity_not_dvd to force the cofactor nonvanishing). Factor (X−r)^{2a} out of u² + v² = (X−r)^{2a}·q with q = u₁² + (X−r)^{2(b−a)}·v₁²; the power split is a single ← pow_add with an omega side-goal. Evaluate q at r: when a < b the (X−r)-power kills the second term, leaving u₁(r)² ≠ 0; when a = b it leaves u₁(r)² + v₁(r)² > 0. Either way q(r) ≠ 0, so rootMultiplicity_mul + rootMultiplicity_X_sub_C_pow + rootMultiplicity_eq_zero give rootMult r p = 2a + 0 = 2·min(a,b). Evenness follows since 2·min is even; the single-square cases u = 0 / v = 0 use rootMultiplicity_mul on p = v·v (resp. u·u).",
+    "keyInsights": [
+      "Real roots of a 2-SOS are the common roots: u(t)² + v(t)² = 0 ⟺ u(t) = v(t) = 0. This is the pointwise twin of the parent's top-degree non-cancellation, and it makes the root set of p computable from u and v.",
+      "The multiplicity is pinned exactly, not just bounded: after factoring out the common order of vanishing (X−r)^{2·min(a,b)}, the leftover polynomial evaluates at r to a POSITIVE sum of squares, so no further cancellation can raise the multiplicity. The answer is 2·min(a,b).",
+      "Every real root has even multiplicity. This is a genuine obstruction to being a sum of two squares: a polynomial with any simple real root (e.g. X itself, or any p that changes sign) cannot be written as u² + v² over ℝ. It strengthens the grandparent's sq_dvd_of_psd_root, which only secured (X−r)² ∣ p.",
+      "The argument is independent of the complex factorisation and of nonnegativity: it holds for ANY real 2-SOS. Specialising to PSD polynomials (via the existence theorem) then recovers the classical even-order-of-contact fact, separating its ordered-field algebraic content from the analytic FTA input.",
+      "min, not sum: the multiplicity in p is twice the SMALLER of the two summand multiplicities, because the summand vanishing to lower order dominates the local behaviour — the higher-order summand contributes a strictly higher power of (X−r) that cannot interfere at the critical degree."
+    ]
+  },
+  "conclusion": {
+    "summary": "A 175-line, 0-sorry, 0-axiom companion to the Fejér–Riesz sharpness entry, characterising the real roots of a sum of two squares. Pointwise non-cancellation (u(t)² + v(t)² = 0 ⟺ u(t) = v(t) = 0) makes the real roots of p = u² + v² exactly the common roots of u and v, and tracking the local factorisation gives the exact multiplicity rootMultiplicity r (u² + v²) = 2·min(rootMultiplicity r u, rootMultiplicity r v). The structural payoff is that every real root of a nonzero real 2-SOS has even multiplicity, so any polynomial with a simple real root is never a sum of two squares; specialising through the grandparent's existence theorem recovers even order of contact for nonnegative polynomials.",
+    "implications": "The result answers the root-multiplicity half of the parent entry's first open question and upgrades the grandparent's sq_dvd_of_psd_root ((X−r)² ∣ p) to the exact multiplicity for arbitrary real 2-SOS. It isolates the purely algebraic, ordered-field content of even order of contact, independent of the complex factorisation, and supplies a clean necessary condition for two-squares representability (no simple real roots).",
+    "openQuestions": [
+      "Complex/gcd side: the gcd(u, v) and the multiplicity structure of the NON-real (complex) roots of p remain to be characterised, completing the parent's first open question; relate the degree gap n − deg v of the normalized representation to these data.",
+      "Coprime normalization: factor any real 2-SOS as p = d²·q with d = gcd(u, v) and q a PRIMITIVE 2-SOS (coprime summands, no real roots), and determine whether the primitive part q is unique up to the rotation/reflection symmetry."
+    ]
+  },
+  "references": [
+    {
+      "title": "Hilbert's seventeenth problem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem"
+    },
+    {
+      "title": "Fejér–Riesz theorem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Fej%C3%A9r%E2%80%93Riesz_theorem"
+    },
+    {
+      "title": "B. Reznick, Some concrete aspects of Hilbert's 17th problem (1996)",
+      "url": "https://www.ams.org/books/conm/253/"
+    }
+  ],
+  "crossReferences": [],
+  "sections": [
+    {
+      "id": "pointwise-non-cancellation",
+      "title": "Nonzero 2-SOS and the common-root characterisation",
+      "startLine": 51,
+      "endLine": 73,
+      "summary": "sq_add_sq_ne_zero: u ≠ 0 ⟹ u² + v² ≠ 0, via Polynomial.funext (a nonzero polynomial cannot vanish identically, and u(x)² ≤ u(x)² + v(x)² = 0 would force u = 0). eval_sq_add_sq_eq_zero_iff: the real roots of u² + v² are exactly the common roots of u and v, from sq_nonneg + nlinarith in both directions."
+    },
+    {
+      "id": "local-factorisation",
+      "title": "Local factorisation at a root",
+      "startLine": 75,
+      "endLine": 86,
+      "summary": "factor_at_root: extract u = (X − C r)^(rootMultiplicity r u)·u₁ with u₁(r) ≠ 0. The factor comes from pow_rootMultiplicity_dvd; the cofactor nonvanishing is forced because u₁(r) = 0 would give (X − C r) ∣ u₁ hence (X − C r)^(mult+1) ∣ u, contradicting pow_rootMultiplicity_not_dvd."
+    },
+    {
+      "id": "exact-multiplicity",
+      "title": "The exact 2·min multiplicity formula",
+      "startLine": 88,
+      "endLine": 146,
+      "summary": "rootMultiplicity_sq_add_sq_of_le handles a ≤ b: factor u² + v² = (X−r)^{2a}·q with q = u₁² + (X−r)^{2(b−a)}·v₁² (power split by ← pow_add and omega), show q(r) ≠ 0 (a < b leaves u₁(r)² after zero_pow; a = b leaves u₁(r)² + v₁(r)² > 0), then rootMultiplicity_mul + rootMultiplicity_X_sub_C_pow + rootMultiplicity_eq_zero give 2a. rootMultiplicity_sq_add_sq removes the ordering assumption by le_total and add_comm, yielding the symmetric 2·min(a,b)."
+    },
+    {
+      "id": "even-multiplicity",
+      "title": "Even multiplicity and even order of contact",
+      "startLine": 148,
+      "endLine": 175,
+      "summary": "even_rootMultiplicity_sq_add_sq: 2·min is manifestly even; the degenerate u = 0 / v = 0 cases use rootMultiplicity_mul on p = v·v (resp. u·u). IsPSD.even_rootMultiplicity composes the grandparent's PSD ⟹ two-squares existence theorem with the even-multiplicity obstruction to recover even order of contact for nonnegative polynomials."
+    }
+  ]
+}

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/annotations.json
@@ -3,8 +3,8 @@
     "id": "ann-h17-oq010101-noncancel",
     "proofId": "hilbert-17-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 42,
-      "endLine": 86
+      "startLine": 65,
+      "endLine": 101
     },
     "type": "concept",
     "title": "Leading-term non-cancellation for real sums of two squares",
@@ -14,8 +14,8 @@
     "id": "ann-h17-oq010101-sharpness",
     "proofId": "hilbert-17-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 88,
-      "endLine": 107
+      "startLine": 103,
+      "endLine": 121
     },
     "type": "concept",
     "title": "Sharpness and evenness corollaries",
@@ -25,11 +25,22 @@
     "id": "ann-h17-oq010101-exact-existence",
     "proofId": "hilbert-17-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 109,
-      "endLine": 115
+      "startLine": 122,
+      "endLine": 130
     },
     "type": "concept",
     "title": "Degree-exact strengthening of the existence theorem",
     "content": "univariate_psd_two_sos_degree_exact composes the parent's degree-sharp witnesses (univariate_psd_is_two_sos_deg) with the sharpness theorem two_sos_max_degree_eq. The parent guarantees a representation with both summands of degree ≤ ½·deg p; sharpness then pins the larger summand's degree to exactly ½·deg p. The net effect is to upgrade the parent existence theorem from an upper degree bound to an exact one for nonzero PSD polynomials, answering the parent entry's first open question for the larger summand. Because the sharpness engine is self-contained (only natDegree/leadingCoeff arithmetic), the result needs no extra analytic input beyond what the parent already supplies."
+  },
+  {
+    "id": "ann-h17-oq010101-normal-form",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 131,
+      "endLine": 225
+    },
+    "type": "concept",
+    "title": "Asymmetric normal form via a constant orthogonal rotation",
+    "content": "Sharpness pins the LARGER square's degree but says nothing about the smaller one — both could a priori sit at degree n = max(deg u, deg v). two_sos_rotate_normalize shows the smaller one can always be pushed strictly below n, by rotating the coefficient pair. The key algebraic identity is that for any α, β the pair (αu+βv, -βu+αv) satisfies (αu+βv)² + (-βu+αv)² = (α²+β²)(u²+v²); with α²+β²=1 this is just u²+v² (proved by ring after turning (C α)²+(C β)² into C(α²+β²)=C 1=1). This is the polynomial avatar of |e^{-iθ}(u+iv)|² = |u+iv|²: rotating the Gaussian factor by a unit complex number leaves the sum of squares unchanged. To NORMALIZE, pick the rotation aligned with the top coefficients a = uₙ, b = vₙ: take s = √(a²+b²) (positive because the degree-n component is the leadingCoeff of whichever polynomial achieves the max, hence nonzero), α = a/s, β = b/s. Then the n-th coefficient of the first component is αa+βb = (a²+b²)/s = s ≠ 0 (so deg u' = n, the ≤ n side coming from natDegree_C_mul_le and natDegree_add_le), while that of the second is -βa+αb = 0. A vanishing top coefficient at the maximal possible degree forces a strict drop: if deg v' were still n its leading coefficient would be its n-th coefficient, which is 0 — impossible for a nonzero polynomial, and v' = 0 is excluded since n ≥ 1. Hence deg v' < n. Feeding the parent's witnesses through two_sos_max_degree_eq (larger summand = ½·deg p) and then this rotation, univariate_psd_two_sos_normalized gives, for any PSD p of degree ≥ 2, a representation u² + v² with 2·deg u = deg p and 2·deg v < deg p — the asymmetric Fejér–Riesz form, with no complex factorization machinery anywhere in the proof."
   }
 ]

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-h17-oq010101-noncancel",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 42,
+      "endLine": 86
+    },
+    "type": "concept",
+    "title": "Leading-term non-cancellation for real sums of two squares",
+    "content": "natDegree_sq_add_sq is the engine of the whole file: natDegree(u² + v²) = 2·max(deg u, deg v) whenever u, v are not both zero. The proof is a trichotomy on deg u vs deg v. In the two unequal branches one square strictly dominates (natDegree_pow turns deg(u²) into 2·deg u, and 2a ≠ 2b), so natDegree_add_eq_right/left_of_natDegree_lt reads off the answer. The equal branch deg u = deg v = a is the crux: the coefficient of u² + v² at degree 2a equals (lc u)² + (lc v)² (using that leadingCoeff is the coefficient at natDegree, and leadingCoeff_pow). Over an ordered field this sum of two squares is zero only when both leading coefficients vanish — and leadingCoeff_ne_zero turns the not-both-zero hypothesis into positivity (pow_two_pos_of_ne_zero on the nonzero one, sq_nonneg on the other). So the top coefficient survives, le_natDegree_of_ne_zero forces natDegree ≥ 2a, natDegree_add_le gives ≤ 2a, and omega closes equality. The contrast with ℂ is the whole point: X² + (iX)² = 0, so complex squares can cancel in top degree and carry no degree information."
+  },
+  {
+    "id": "ann-h17-oq010101-sharpness",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 88,
+      "endLine": 107
+    },
+    "type": "concept",
+    "title": "Sharpness and evenness corollaries",
+    "content": "two_sos_max_degree_eq substitutes p = u² + v² into the identity to conclude that, for any nonzero p, the larger summand has degree exactly ½·deg p. The required not-both-zero side condition is extracted from p ≠ 0 by push_neg and a ring computation. This is exactly the sharpness statement: the parent's upper bound 2·deg u ≤ deg p holds for both summands, but for whichever has the larger degree it holds with equality, so no representation can lower the certificate degree. natDegree_two_sos_even then reads deg p = max + max directly off the identity, recording that the degree of any nonzero real sum of two squares is even — the ordered-field content of univariate nonnegativity, isolated from the analytic FTA input used to prove existence."
+  },
+  {
+    "id": "ann-h17-oq010101-exact-existence",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 109,
+      "endLine": 115
+    },
+    "type": "concept",
+    "title": "Degree-exact strengthening of the existence theorem",
+    "content": "univariate_psd_two_sos_degree_exact composes the parent's degree-sharp witnesses (univariate_psd_is_two_sos_deg) with the sharpness theorem two_sos_max_degree_eq. The parent guarantees a representation with both summands of degree ≤ ½·deg p; sharpness then pins the larger summand's degree to exactly ½·deg p. The net effect is to upgrade the parent existence theorem from an upper degree bound to an exact one for nonzero PSD polynomials, answering the parent entry's first open question for the larger summand. Because the sharpness engine is self-contained (only natDegree/leadingCoeff arithmetic), the result needs no extra analytic input beyond what the parent already supplies."
+  }
+]

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "hilbert-17-oq-01-oq-01-oq-01",
+  "title": "Sharpness of the Fejér–Riesz Bound: Every Real 2-SOS Has Degree Exactly 2·max(deg u, deg v)",
+  "slug": "hilbert-17-oq-01-oq-01-oq-01",
+  "description": "The parent entry (Hilbert17OQ01OQ01.lean) proves the Fejér–Riesz UPPER bound: every nonnegative real univariate polynomial p is u² + v² with 2·deg u ≤ deg p and 2·deg v ≤ deg p. This entry proves the matching SHARPNESS / converse, answering the parent's own first open question. The crux is a leading-term non-cancellation fact special to ordered fields: natDegree(u² + v²) = 2·max(deg u, deg v) for u, v not both zero. When deg u = deg v the top coefficient of u² + v² is (lc u)² + (lc v)², a sum of two real squares that vanishes only when both polynomials vanish — so two real squares can never cancel in top degree (contrast X² + (iX)² = 0 over ℂ). Consequences: in ANY representation p = u² + v² of a nonzero p, the larger summand has degree EXACTLY ½·deg p (two_sos_max_degree_eq), so the parent's upper bound is attained and cannot be lowered; the degree of any nonzero sum of two real squares is even (natDegree_two_sos_even); and the parent existence theorem strengthens to give witnesses with 2·max(deg u, deg v) = deg p exactly (univariate_psd_two_sos_degree_exact). Fully elementary, 0 axioms.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert17OQ01OQ01OQ01.lean",
+    "tags": [
+      "real-algebra",
+      "sum-of-squares",
+      "hilbert-17",
+      "fejer-riesz",
+      "degree-bound",
+      "sharpness",
+      "univariate-polynomials",
+      "leading-coefficient",
+      "ordered-fields"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.natDegree_add_eq_right_of_natDegree_lt",
+        "description": "If p.natDegree < q.natDegree then (p + q).natDegree = q.natDegree. Handles the deg u < deg v branch where the v² term strictly dominates the sum.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Operations"
+      },
+      {
+        "theorem": "Polynomial.leadingCoeff_pow",
+        "description": "(p ^ n).leadingCoeff = p.leadingCoeff ^ n. Identifies the top coefficient of u² as (lc u)², the source of the non-cancellation in the equal-degree branch.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Lemmas"
+      },
+      {
+        "theorem": "Polynomial.le_natDegree_of_ne_zero",
+        "description": "If p.coeff n ≠ 0 then n ≤ p.natDegree. Supplies the lower bound on natDegree(u² + v²) once the coefficient at 2·max is shown nonzero.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Definitions"
+      },
+      {
+        "theorem": "Polynomial.leadingCoeff_ne_zero",
+        "description": "p.leadingCoeff ≠ 0 ↔ p ≠ 0. Converts the not-both-zero hypothesis into positivity of (lc u)² + (lc v)².",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Definitions"
+      },
+      {
+        "theorem": "pow_two_pos_of_ne_zero",
+        "description": "a ≠ 0 → 0 < a ^ 2 in an ordered field. Drives the sum-of-two-real-squares positivity that forbids leading-term cancellation.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "natDegree_sq_add_sq: the leading-term non-cancellation theorem — natDegree(u² + v²) = 2·max(deg u, deg v) for u, v not both zero, via a trichotomy on deg u vs deg v with the equal case discharged by (lc u)² + (lc v)² ≠ 0.",
+      "two_sos_max_degree_eq: sharpness of the Fejér–Riesz bound — in ANY representation p = u² + v² with p ≠ 0, the larger summand has degree exactly ½·deg p, so the parent's upper bound 2·deg u ≤ deg p is attained and cannot be improved.",
+      "natDegree_two_sos_even: the degree of any nonzero sum of two real squares is even, an immediate structural corollary of the exact-degree formula.",
+      "univariate_psd_two_sos_degree_exact: strengthens the parent existence theorem from an upper bound to an exact one — every nonzero PSD univariate polynomial is u² + v² with 2·max(deg u, deg v) = deg p exactly.",
+      "Answers the parent entry's own first open question (degree-exact normalization) for the larger summand, using a self-contained real-coefficient argument that needs no Hilbert-17 induction infrastructure."
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "natDegree arithmetic in Mathlib: natDegree_pow, natDegree_add_le, natDegree_add_eq_left/right_of_natDegree_lt.",
+      "leadingCoeff as the coefficient at natDegree, and leadingCoeff_pow.",
+      "The order-field fact that a sum of two squares vanishes only when both terms do (pow_two_pos_of_ne_zero).",
+      "The Fejér–Riesz degree upper bound from the parent entry (for the existence-strengthening corollary)."
+    ],
+    "lineCount": 116,
+    "relatedProblems": [
+      {
+        "id": "hilbert-17-oq-01-oq-01",
+        "relationship": "Parent: proves the Fejér–Riesz UPPER bound 2·deg u ≤ deg p, 2·deg v ≤ deg p. This entry proves the matching sharpness (the larger summand's degree is forced to be exactly ½·deg p), answering the parent's first stated open question."
+      },
+      {
+        "id": "hilbert-17-oq-01",
+        "relationship": "Grandparent: the Pfister bound on the minimum number of squares. The univariate case fixes that number at two; this entry pins down the exact degree of the two summands."
+      },
+      {
+        "id": "hilbert-17",
+        "relationship": "Great-grandparent: Hilbert's 17th problem and Artin's theorem. The univariate strand is now characterized not just by existence and an upper degree bound but by the exact certificate degree."
+      }
+    ],
+    "assumptions": "0 axioms. #print axioms on all four theorems (natDegree_sq_add_sq, two_sos_max_degree_eq, natDegree_two_sos_even, univariate_psd_two_sos_degree_exact) reports only propext, Classical.choice, Quot.sound. No sorryAx, no native_decide / Lean.ofReduceBool. The existence-strengthening corollary reuses only the 0-axiom degree-sharp theorem from the parent file.",
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "leanFile": {
+    "lineCount": 116,
+    "namespace": "Hilbert17OQ01OQ01OQ01",
+    "opens": [
+      "Polynomial"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "substantiveTheoremCount": 4,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": [
+      "Mathlib",
+      "Proofs.Hilbert17OQ01OQ01"
+    ],
+    "path": "Proofs/Hilbert17OQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "natDegree_sq_add_sq",
+      "type": "theorem",
+      "description": "Leading-term non-cancellation for real sums of two squares: the degree of u² + v² is exactly twice the larger of deg u, deg v. The only nontrivial case deg u = deg v has top coefficient (lc u)² + (lc v)², nonzero whenever u, v are not both zero.",
+      "leanType": "{u v : ℝ[X]} → (u ≠ 0 ∨ v ≠ 0) → (u ^ 2 + v ^ 2).natDegree = 2 * max u.natDegree v.natDegree"
+    },
+    {
+      "name": "two_sos_max_degree_eq",
+      "type": "theorem",
+      "description": "Sharpness of the Fejér–Riesz degree bound: in any representation p = u² + v² of a nonzero polynomial, the larger summand has degree exactly ½·deg p, so the parent's upper bound 2·deg u ≤ deg p is attained and cannot be lowered.",
+      "leanType": "{p u v : ℝ[X]} → p ≠ 0 → p = u ^ 2 + v ^ 2 → 2 * max u.natDegree v.natDegree = p.natDegree"
+    },
+    {
+      "name": "natDegree_two_sos_even",
+      "type": "theorem",
+      "description": "The degree of any nonzero sum of two real squares is even, an immediate structural corollary of deg p = 2·max(deg u, deg v).",
+      "leanType": "{p u v : ℝ[X]} → p ≠ 0 → p = u ^ 2 + v ^ 2 → Even p.natDegree"
+    },
+    {
+      "name": "univariate_psd_two_sos_degree_exact",
+      "type": "theorem",
+      "description": "Degree-exact Fejér–Riesz: every nonzero PSD univariate polynomial is a sum of two squares whose larger summand has degree exactly ½·deg p, strengthening the parent existence theorem from an upper bound to an equality.",
+      "leanType": "(p : ℝ[X]) → p ≠ 0 → IsPSD p → ∃ u v, p = u ^ 2 + v ^ 2 ∧ 2 * max u.natDegree v.natDegree = p.natDegree"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Hilbert's 1888 classification shows nonnegative univariate real polynomials are sums of two squares; the Fejér–Riesz theorem (1916) sharpens this to a degree-controlled certificate p = u² + v² with deg u, deg v ≤ ½·deg p, the algebraic shadow of representing a nonnegative trigonometric polynomial as |g|² with g of the same degree. The parent entry formalizes that upper bound. The question of sharpness — whether the bound is actually attained or could be lowered — is what determines the true cost of a univariate SOS certificate. The answer is that two real squares cannot cancel in top degree: the leading coefficient of u² + v² is a sum of two real squares (lc u)² + (lc v)², which is positive unless both polynomials vanish. This ordered-field phenomenon is exactly what fails over ℂ, where X² + (iX)² = 0, and it is the algebraic heart of why nonnegativity over ℝ forces an even degree.",
+    "problemStatement": "Determine whether the Fejér–Riesz upper bound 2·deg u ≤ deg p, 2·deg v ≤ deg p on a univariate sum-of-two-squares certificate is sharp. Concretely: in any representation p = u² + v² of a nonzero real polynomial, what is the exact degree of the summands, and is the degree of p forced to be even?",
+    "proofStrategy": "The whole result rests on one degree identity: natDegree(u² + v²) = 2·max(deg u, deg v) for u, v not both zero. Prove it by trichotomy on deg u vs deg v. If the degrees differ, the larger square strictly dominates and natDegree_add_eq_left/right_of_natDegree_lt gives the answer directly (natDegree_pow turns deg(u²) into 2·deg u). If deg u = deg v = a, bound natDegree(u² + v²) ≤ 2a by natDegree_add_le, then show the coefficient at 2a is nonzero: it equals (lc u)² + (lc v)² (using leadingCoeff = coeff at natDegree and leadingCoeff_pow), which is positive because the not-both-zero hypothesis makes at least one leading coefficient nonzero (leadingCoeff_ne_zero), so pow_two_pos_of_ne_zero plus sq_nonneg of the other term gives strict positivity. le_natDegree_of_ne_zero then forces natDegree ≥ 2a, and omega closes equality. Sharpness (two_sos_max_degree_eq) substitutes p = u² + v² into the identity; evenness (natDegree_two_sos_even) reads off deg p = max + max; the degree-exact existence theorem composes the identity with the parent's degree-sharp witnesses.",
+    "keyInsights": [
+      "Two real squares can never cancel in top degree: when deg u = deg v the leading coefficient of u² + v² is (lc u)² + (lc v)², a sum of two real squares, nonzero unless both polynomials are zero. This is the single fact that turns the parent's upper bound into an exact one.",
+      "The phenomenon is specific to ordered fields. Over ℂ it fails — X² + (iX)² = 0 — which is precisely why complex sums of squares carry no degree information while real ones do.",
+      "The exact-degree identity makes the Fejér–Riesz upper bound visibly sharp: 2·deg u ≤ deg p holds for both summands, but equality is forced for whichever summand has the larger degree, so no representation can do better.",
+      "Evenness of deg p for any nonzero 2-SOS falls out for free: deg p = 2·max(deg u, deg v). The same convention deg 0 = 0 that makes the parent's upper bound uniform also makes max(deg u, deg v) the correct half-degree even when one summand vanishes.",
+      "The sharpness argument is self-contained — it needs no Hilbert-17 induction machinery, only natDegree and leadingCoeff arithmetic — so it applies to any real 2-SOS, not just those arising from PSD polynomials."
+    ]
+  },
+  "conclusion": {
+    "summary": "A 116-line, 0-sorry, 0-axiom companion to the degree-sharp univariate Hilbert 17 entry, proving the Fejér–Riesz bound is sharp. The engine is natDegree(u² + v²) = 2·max(deg u, deg v): two real squares cannot cancel in top degree because the leading coefficient is the sum of two real squares (lc u)² + (lc v)². Consequences: in any p = u² + v² the larger summand has degree exactly ½·deg p, the degree of any nonzero real 2-SOS is even, and the parent existence theorem upgrades to a degree-exact one. This answers the parent entry's first open question for the larger summand.",
+    "implications": "Sharpness closes the loop on the univariate certificate: the parent's degree cap is not just an upper bound but the precise degree of the larger square, so a univariate SOS solver's Gram matrix size is tight, not merely bounded. The non-cancellation argument also isolates the ordered-field content of univariate nonnegativity (evenness of the degree), separating it cleanly from the analytic FTA/even-multiplicity input used to prove existence.",
+    "openQuestions": [
+      "Strict normalization: for p ≠ 0 of degree 2n, show one square can be taken of degree exactly n and the other of degree strictly less than n (the asymmetric Fejér–Riesz form), refining the symmetric max-degree statement proved here.",
+      "Quantify the smaller summand: characterize when both squares can have degree n simultaneously (deg u = deg v) versus when the representation forces deg u ≠ deg v, in terms of the boundary behavior of p."
+    ]
+  },
+  "references": [
+    {
+      "title": "Hilbert's seventeenth problem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem"
+    },
+    {
+      "title": "Fejér–Riesz theorem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Fej%C3%A9r%E2%80%93Riesz_theorem"
+    },
+    {
+      "title": "B. Reznick, Some concrete aspects of Hilbert's 17th problem (1996)",
+      "url": "https://www.ams.org/books/conm/253/"
+    }
+  ],
+  "crossReferences": [],
+  "sections": [
+    {
+      "id": "non-cancellation",
+      "title": "Leading-term non-cancellation for real sums of two squares",
+      "startLine": 42,
+      "endLine": 86,
+      "summary": "natDegree_sq_add_sq: trichotomy on deg u vs deg v. The two unequal branches use natDegree_add_eq_left/right_of_natDegree_lt after natDegree_pow. The equal branch bounds the degree above by natDegree_add_le and below by showing the coefficient at 2·deg u equals (lc u)² + (lc v)² (via leadingCoeff_pow), which is nonzero because at least one leading coefficient is nonzero (leadingCoeff_ne_zero, pow_two_pos_of_ne_zero), closing with le_natDegree_of_ne_zero and omega."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness and evenness corollaries",
+      "startLine": 88,
+      "endLine": 107,
+      "summary": "two_sos_max_degree_eq substitutes p = u² + v² into the identity to conclude the larger summand has degree exactly ½·deg p (the not-both-zero side condition follows from p ≠ 0). natDegree_two_sos_even reads deg p = max + max off the same identity."
+    },
+    {
+      "id": "degree-exact-existence",
+      "title": "Degree-exact strengthening of the existence theorem",
+      "startLine": 109,
+      "endLine": 115,
+      "summary": "univariate_psd_two_sos_degree_exact composes the parent's degree-sharp witnesses (univariate_psd_is_two_sos_deg) with two_sos_max_degree_eq, upgrading the parent existence theorem from an upper degree bound to an exact one for nonzero PSD polynomials."
+    }
+  ]
+}

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "hilbert-17-oq-01-oq-01-oq-01",
   "title": "Sharpness of the Fejér–Riesz Bound: Every Real 2-SOS Has Degree Exactly 2·max(deg u, deg v)",
   "slug": "hilbert-17-oq-01-oq-01-oq-01",
-  "description": "The parent entry (Hilbert17OQ01OQ01.lean) proves the Fejér–Riesz UPPER bound: every nonnegative real univariate polynomial p is u² + v² with 2·deg u ≤ deg p and 2·deg v ≤ deg p. This entry proves the matching SHARPNESS / converse, answering the parent's own first open question. The crux is a leading-term non-cancellation fact special to ordered fields: natDegree(u² + v²) = 2·max(deg u, deg v) for u, v not both zero. When deg u = deg v the top coefficient of u² + v² is (lc u)² + (lc v)², a sum of two real squares that vanishes only when both polynomials vanish — so two real squares can never cancel in top degree (contrast X² + (iX)² = 0 over ℂ). Consequences: in ANY representation p = u² + v² of a nonzero p, the larger summand has degree EXACTLY ½·deg p (two_sos_max_degree_eq), so the parent's upper bound is attained and cannot be lowered; the degree of any nonzero sum of two real squares is even (natDegree_two_sos_even); and the parent existence theorem strengthens to give witnesses with 2·max(deg u, deg v) = deg p exactly (univariate_psd_two_sos_degree_exact). Fully elementary, 0 axioms.",
+  "description": "The parent entry (Hilbert17OQ01OQ01.lean) proves the Fejér–Riesz UPPER bound: every nonnegative real univariate polynomial p is u² + v² with 2·deg u ≤ deg p and 2·deg v ≤ deg p. This entry proves the matching SHARPNESS / converse, answering the parent's own first open question. The crux is a leading-term non-cancellation fact special to ordered fields: natDegree(u² + v²) = 2·max(deg u, deg v) for u, v not both zero. When deg u = deg v the top coefficient of u² + v² is (lc u)² + (lc v)², a sum of two real squares that vanishes only when both polynomials vanish — so two real squares can never cancel in top degree (contrast X² + (iX)² = 0 over ℂ). Consequences: in ANY representation p = u² + v² of a nonzero p, the larger summand has degree EXACTLY ½·deg p (two_sos_max_degree_eq), so the parent's upper bound is attained and cannot be lowered; the degree of any nonzero sum of two real squares is even (natDegree_two_sos_even); and the parent existence theorem strengthens to give witnesses with 2·max(deg u, deg v) = deg p exactly (univariate_psd_two_sos_degree_exact). The entry then resolves its own stated open question by establishing the ASYMMETRIC normal form: a constant orthogonal rotation (u, v) ↦ (αu+βv, -βu+αv) with α²+β²=1 — the polynomial avatar of multiplying the Gaussian factor u+iv by a unit complex number — preserves u²+v² and, when aligned with the top coefficients, kills the leading term of the second component (two_sos_rotate_normalize). So every PSD p of degree ≥ 2 is u²+v² with one square of degree exactly ½·deg p and the other strictly smaller (univariate_psd_two_sos_normalized), with no complex factorization machinery. Fully elementary, 0 axioms.",
   "meta": {
     "author": "lean-genius researcher",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem",
@@ -49,6 +49,16 @@
         "theorem": "pow_two_pos_of_ne_zero",
         "description": "a ≠ 0 → 0 < a ^ 2 in an ordered field. Drives the sum-of-two-real-squares positivity that forbids leading-term cancellation.",
         "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "0 ≤ x → (√x)² = x. Used to normalize the rotation: with s = √(a²+b²) the coefficients α = a/s, β = b/s satisfy α²+β² = 1 and αa+βb = s, the two facts that make the rotation orthogonal and align it with the top coefficients.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      },
+      {
+        "theorem": "Polynomial.natDegree_C_mul_le",
+        "description": "(C a * p).natDegree ≤ p.natDegree. Bounds the degrees of the rotated components C α·u + C β·v and C(-β)·u + C α·v by max(deg u, deg v), the upper half of the deg u' = n argument.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Lemmas"
       }
     ],
     "originalContributions": [
@@ -56,7 +66,9 @@
       "two_sos_max_degree_eq: sharpness of the Fejér–Riesz bound — in ANY representation p = u² + v² with p ≠ 0, the larger summand has degree exactly ½·deg p, so the parent's upper bound 2·deg u ≤ deg p is attained and cannot be improved.",
       "natDegree_two_sos_even: the degree of any nonzero sum of two real squares is even, an immediate structural corollary of the exact-degree formula.",
       "univariate_psd_two_sos_degree_exact: strengthens the parent existence theorem from an upper bound to an exact one — every nonzero PSD univariate polynomial is u² + v² with 2·max(deg u, deg v) = deg p exactly.",
-      "Answers the parent entry's own first open question (degree-exact normalization) for the larger summand, using a self-contained real-coefficient argument that needs no Hilbert-17 induction infrastructure."
+      "Answers the parent entry's own first open question (degree-exact normalization) for the larger summand, using a self-contained real-coefficient argument that needs no Hilbert-17 induction infrastructure.",
+      "two_sos_rotate_normalize: the asymmetric normal form — a constant orthogonal rotation (u, v) ↦ (αu+βv, -βu+αv) with α²+β²=1 preserves u²+v² (the polynomial avatar of multiplying the Gaussian factor u+iv by a unit α-iβ); aligning α=a/s, β=b/s with the top coefficients a=uₙ, b=vₙ (s=√(a²+b²), n=max(deg u, deg v)) sends the leading coefficient of the second component to -βa+αb=0 while the first becomes αa+βb=s≠0, yielding deg u'=n and deg v'<n. No complex factorization — just a 2×2 rotation of the coefficient pair.",
+      "univariate_psd_two_sos_normalized: every PSD p of degree ≥ 2 is u²+v² with 2·deg u = deg p and 2·deg v < deg p — one square of degree exactly ½·deg p, the other strictly smaller. Resolves the entry's own stated open question (the asymmetric Fejér–Riesz normalization), combining the sharpness identity with the rotation."
     ],
     "axiomCount": 0,
     "prerequisites": [
@@ -65,7 +77,7 @@
       "The order-field fact that a sum of two squares vanishes only when both terms do (pow_two_pos_of_ne_zero).",
       "The Fejér–Riesz degree upper bound from the parent entry (for the existence-strengthening corollary)."
     ],
-    "lineCount": 116,
+    "lineCount": 225,
     "relatedProblems": [
       {
         "id": "hilbert-17-oq-01-oq-01",
@@ -80,21 +92,21 @@
         "relationship": "Great-grandparent: Hilbert's 17th problem and Artin's theorem. The univariate strand is now characterized not just by existence and an upper degree bound but by the exact certificate degree."
       }
     ],
-    "assumptions": "0 axioms. #print axioms on all four theorems (natDegree_sq_add_sq, two_sos_max_degree_eq, natDegree_two_sos_even, univariate_psd_two_sos_degree_exact) reports only propext, Classical.choice, Quot.sound. No sorryAx, no native_decide / Lean.ofReduceBool. The existence-strengthening corollary reuses only the 0-axiom degree-sharp theorem from the parent file.",
-    "theoremCount": 4,
+    "assumptions": "0 axioms. #print axioms on the headline theorems (natDegree_sq_add_sq, two_sos_max_degree_eq, natDegree_two_sos_even, univariate_psd_two_sos_degree_exact, two_sos_rotate_normalize, univariate_psd_two_sos_normalized) reports only propext, Classical.choice, Quot.sound. No sorryAx, no native_decide / Lean.ofReduceBool. The rotation uses Real.sqrt only to normalize a real coefficient pair (s=√(a²+b²)); the existence-strengthening corollaries reuse only the 0-axiom degree-sharp theorem from the parent file.",
+    "theoremCount": 6,
     "definitionCount": 0,
     "additionalFiles": []
   },
   "leanFile": {
-    "lineCount": 116,
+    "lineCount": 225,
     "namespace": "Hilbert17OQ01OQ01OQ01",
     "opens": [
       "Polynomial"
     ],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 4,
-    "substantiveTheoremCount": 4,
+    "theoremCount": 6,
+    "substantiveTheoremCount": 6,
     "computationalVerifications": 0,
     "lemmaCount": 0,
     "imports": [
@@ -131,6 +143,18 @@
       "type": "theorem",
       "description": "Degree-exact Fejér–Riesz: every nonzero PSD univariate polynomial is a sum of two squares whose larger summand has degree exactly ½·deg p, strengthening the parent existence theorem from an upper bound to an equality.",
       "leanType": "(p : ℝ[X]) → p ≠ 0 → IsPSD p → ∃ u v, p = u ^ 2 + v ^ 2 ∧ 2 * max u.natDegree v.natDegree = p.natDegree"
+    },
+    {
+      "name": "two_sos_rotate_normalize",
+      "type": "theorem",
+      "description": "Constant orthogonal rotation of a two-squares pair: when max(deg u, deg v) ≥ 1, the rotated pair (αu+βv, -βu+αv) with α=uₙ/s, β=vₙ/s (s=√(uₙ²+vₙ²)) gives the same u²+v² but with the first square of degree exactly n=max(deg u, deg v) and the second of degree strictly less. The polynomial avatar of rotating the Gaussian factor by a unit complex number; no complex factorization is invoked.",
+      "leanType": "(u v : ℝ[X]) → 1 ≤ max u.natDegree v.natDegree → ∃ u' v', u' ^ 2 + v' ^ 2 = u ^ 2 + v ^ 2 ∧ u'.natDegree = max u.natDegree v.natDegree ∧ v'.natDegree < max u.natDegree v.natDegree"
+    },
+    {
+      "name": "univariate_psd_two_sos_normalized",
+      "type": "theorem",
+      "description": "Asymmetric Fejér–Riesz normal form: every PSD univariate polynomial of degree ≥ 2 is a sum of two squares in which one square has degree exactly ½·deg p and the other has degree strictly less. Resolves the entry's own stated open question by combining the sharpness identity (larger summand forced to ½·deg p) with the normalizing rotation (smaller summand pushed strictly below).",
+      "leanType": "(p : ℝ[X]) → 2 ≤ p.natDegree → IsPSD p → ∃ u v, p = u ^ 2 + v ^ 2 ∧ 2 * u.natDegree = p.natDegree ∧ 2 * v.natDegree < p.natDegree"
     }
   ],
   "overview": {
@@ -142,15 +166,16 @@
       "The phenomenon is specific to ordered fields. Over ℂ it fails — X² + (iX)² = 0 — which is precisely why complex sums of squares carry no degree information while real ones do.",
       "The exact-degree identity makes the Fejér–Riesz upper bound visibly sharp: 2·deg u ≤ deg p holds for both summands, but equality is forced for whichever summand has the larger degree, so no representation can do better.",
       "Evenness of deg p for any nonzero 2-SOS falls out for free: deg p = 2·max(deg u, deg v). The same convention deg 0 = 0 that makes the parent's upper bound uniform also makes max(deg u, deg v) the correct half-degree even when one summand vanishes.",
-      "The sharpness argument is self-contained — it needs no Hilbert-17 induction machinery, only natDegree and leadingCoeff arithmetic — so it applies to any real 2-SOS, not just those arising from PSD polynomials."
+      "The sharpness argument is self-contained — it needs no Hilbert-17 induction machinery, only natDegree and leadingCoeff arithmetic — so it applies to any real 2-SOS, not just those arising from PSD polynomials.",
+      "The asymmetric normal form needs no complex factorization: a constant 2×2 orthogonal rotation of the coefficient pair (αu+βv, -βu+αv) with α²+β²=1 preserves u²+v² (the algebraic shadow of |e^{-iθ}(u+iv)|² = u²+v²), and choosing the rotation that aligns with the top coefficients (a, b) = (uₙ, vₙ) sends -βa+αb to 0 while αa+βb = √(a²+b²) stays nonzero — so the larger square keeps degree n and the smaller drops strictly below."
     ]
   },
   "conclusion": {
-    "summary": "A 116-line, 0-sorry, 0-axiom companion to the degree-sharp univariate Hilbert 17 entry, proving the Fejér–Riesz bound is sharp. The engine is natDegree(u² + v²) = 2·max(deg u, deg v): two real squares cannot cancel in top degree because the leading coefficient is the sum of two real squares (lc u)² + (lc v)². Consequences: in any p = u² + v² the larger summand has degree exactly ½·deg p, the degree of any nonzero real 2-SOS is even, and the parent existence theorem upgrades to a degree-exact one. This answers the parent entry's first open question for the larger summand.",
+    "summary": "A 225-line, 0-sorry, 0-axiom companion to the degree-sharp univariate Hilbert 17 entry, proving the Fejér–Riesz bound is sharp and admits an asymmetric normal form. The engine is natDegree(u² + v²) = 2·max(deg u, deg v): two real squares cannot cancel in top degree because the leading coefficient is the sum of two real squares (lc u)² + (lc v)². Consequences: in any p = u² + v² the larger summand has degree exactly ½·deg p, the degree of any nonzero real 2-SOS is even, and the parent existence theorem upgrades to a degree-exact one. A constant orthogonal rotation (u, v) ↦ (αu+βv, -βu+αv) with α²+β²=1 — the polynomial avatar of multiplying the Gaussian factor by a unit complex number — then normalizes the representation so one square has degree exactly ½·deg p and the other strictly less, resolving the entry's own stated open question with no complex factorization machinery.",
     "implications": "Sharpness closes the loop on the univariate certificate: the parent's degree cap is not just an upper bound but the precise degree of the larger square, so a univariate SOS solver's Gram matrix size is tight, not merely bounded. The non-cancellation argument also isolates the ordered-field content of univariate nonnegativity (evenness of the degree), separating it cleanly from the analytic FTA/even-multiplicity input used to prove existence.",
     "openQuestions": [
-      "Strict normalization: for p ≠ 0 of degree 2n, show one square can be taken of degree exactly n and the other of degree strictly less than n (the asymmetric Fejér–Riesz form), refining the symmetric max-degree statement proved here.",
-      "Quantify the smaller summand: characterize when both squares can have degree n simultaneously (deg u = deg v) versus when the representation forces deg u ≠ deg v, in terms of the boundary behavior of p."
+      "Quantify the smaller summand: now that the asymmetric normal form is established (deg v < n is always achievable), pin down the exact degree of the smaller square in terms of p — e.g. relate n - deg v to the multiplicity structure of the complex roots of p, or to gcd(u, v).",
+      "Coprime normalization: can the rotated witnesses always be taken with gcd(u', v') = 1 (a primitive certificate), and is the resulting (u', v') unique up to the residual sign/reflection symmetry of the rotation that fixes the leading term?"
     ]
   },
   "references": [
@@ -172,23 +197,30 @@
     {
       "id": "non-cancellation",
       "title": "Leading-term non-cancellation for real sums of two squares",
-      "startLine": 42,
-      "endLine": 86,
+      "startLine": 65,
+      "endLine": 101,
       "summary": "natDegree_sq_add_sq: trichotomy on deg u vs deg v. The two unequal branches use natDegree_add_eq_left/right_of_natDegree_lt after natDegree_pow. The equal branch bounds the degree above by natDegree_add_le and below by showing the coefficient at 2·deg u equals (lc u)² + (lc v)² (via leadingCoeff_pow), which is nonzero because at least one leading coefficient is nonzero (leadingCoeff_ne_zero, pow_two_pos_of_ne_zero), closing with le_natDegree_of_ne_zero and omega."
     },
     {
       "id": "sharpness",
       "title": "Sharpness and evenness corollaries",
-      "startLine": 88,
-      "endLine": 107,
+      "startLine": 103,
+      "endLine": 121,
       "summary": "two_sos_max_degree_eq substitutes p = u² + v² into the identity to conclude the larger summand has degree exactly ½·deg p (the not-both-zero side condition follows from p ≠ 0). natDegree_two_sos_even reads deg p = max + max off the same identity."
     },
     {
       "id": "degree-exact-existence",
       "title": "Degree-exact strengthening of the existence theorem",
-      "startLine": 109,
-      "endLine": 115,
+      "startLine": 122,
+      "endLine": 130,
       "summary": "univariate_psd_two_sos_degree_exact composes the parent's degree-sharp witnesses (univariate_psd_is_two_sos_deg) with two_sos_max_degree_eq, upgrading the parent existence theorem from an upper degree bound to an exact one for nonzero PSD polynomials."
+    },
+    {
+      "id": "asymmetric-normal-form",
+      "title": "Asymmetric normal form via a constant orthogonal rotation",
+      "startLine": 131,
+      "endLine": 225,
+      "summary": "two_sos_rotate_normalize: with n = max(deg u, deg v) ≥ 1, set a = uₙ, b = vₙ (at least one nonzero, so a²+b² > 0 by pow_two_pos_of_ne_zero), s = √(a²+b²), α = a/s, β = b/s. The rotated pair (C α·u + C β·v, C(-β)·u + C α·v) satisfies u'²+v'² = (α²+β²)(u²+v²) = u²+v² by ring (using (C α)²+(C β)² = C(α²+β²) = 1). Its n-th coefficients are αa+βb = s ≠ 0 and -βa+αb = 0 (coeff_C_mul, field_simp), so deg u' = n (le_natDegree_of_ne_zero + the ≤ n bound from natDegree_C_mul_le/natDegree_add_le) and deg v' < n (its leading coefficient at n vanishes, forcing strict drop). univariate_psd_two_sos_normalized then feeds the parent's witnesses through two_sos_max_degree_eq and the rotation to give, for deg p ≥ 2, a representation with 2·deg u = deg p and 2·deg v < deg p."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Three layers of structural results on the **univariate Hilbert-17 / Fejér–Riesz** two-squares certificate `p = u² + v²`, all elementary and 0-axiom. Layers 1–2 (degree side) live in `Hilbert17OQ01OQ01OQ01.lean`; layer 3 (root side) is a **new self-contained file + gallery entry** answering the parent sharpness entry's first open question.

The unifying theme: **two real squares cannot cancel** — at top degree (the obstruction is `(lc u)²+(lc v)² > 0`) and at a point (the obstruction is `u(t)²+v(t)² ≥ 0`, `=0` only when both vanish).

## Layer 1–2 — degree sharpness (`Hilbert17OQ01OQ01OQ01.lean`)

- `natDegree_sq_add_sq` — `deg(u²+v²) = 2·max(deg u, deg v)` (real non-cancellation in top degree).
- `two_sos_max_degree_eq` — in any `p = u²+v²`, the larger summand has degree exactly `½·deg p`.
- `univariate_psd_two_sos_degree_exact` / `univariate_psd_two_sos_normalized` — degree-exact and asymmetric normal form (one square `½·deg p`, the other strictly less) via a constant orthogonal rotation.

## Layer 3 — real-root multiplicity (NEW: `Hilbert17OQ01OQ01RootMultiplicity.lean`, entry `hilbert-17-oq-01-oq-01-oq-01-oq-01`)

Answers the **root-multiplicity half** of the parent entry's first open question (relate the summands to the root/multiplicity structure of `p`).

- **`eval_sq_add_sq_eq_zero_iff`** — real roots of `u²+v²` are exactly the common roots of `u` and `v`.
- **`rootMultiplicity_sq_add_sq`** — `rootMult r (u²+v²) = 2·min(rootMult r u, rootMult r v)` for `u,v ≠ 0`. Factor out `(X−r)^{2·min}`; the cofactor evaluates at `r` to a *positive* sum of squares, pinning the multiplicity exactly.
- **`even_rootMultiplicity_sq_add_sq`** — every real root of a nonzero real 2-SOS has **even multiplicity**; equivalently, any polynomial with a simple real root is never a sum of two squares.
- **`IsPSD.even_rootMultiplicity`** — even order of contact for nonnegative polynomials, strengthening the grandparent's `sq_dvd_of_psd_root` (`(X−r)²∣p`) to the exact multiplicity.

## Verification

- 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions.
- `#print axioms` on all public theorems reports only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`.
- Host-verified with `lake env lean` (Docker daemon down this session); reuses only 0-axiom theorems from the parent/grandparent files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)