### PR TITLE
research(cramers-rule-oq-02-oq-01): back-substitution + full solve cost [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CramersRuleOQ02OQ01.lean
+++ b/proofs/Proofs/CramersRuleOQ02OQ01.lean
@@ -192,4 +192,142 @@ lemma gaussExactFlops_small :
   norm_num at h2 h3 h4 h5
   omega
 
+-- ============================================================
+-- Back-substitution cost and the full solve cost (OQ-01)
+-- ============================================================
+
+/-- Exact multiplication+division count of **back-substitution** on the
+    upper-triangular system `U x = b` produced by forward elimination.
+    Processing the rows from the bottom up, the row with `j` already-solved
+    unknowns to its right costs `j` multiplications (the dot product
+    `∑ U_{i,k}·x_k`) and `1` division (by the pivot `U_{i,i}`): `j + 1`
+    operations, summed as `j` ranges over `0, …, n−1`. -/
+def backSubOps (n : ℕ) : ℕ := ∑ j ∈ range n, (j + 1)
+
+/-- Exact **subtraction** count of back-substitution: the row with `j` solved
+    unknowns to its right subtracts the `j`-term dot product from `b_i`, one
+    subtraction per term. -/
+def backSubSubs (n : ℕ) : ℕ := ∑ j ∈ range n, j
+
+/-- Unfolding one back-substitution step (operations). -/
+lemma backSubOps_succ (n : ℕ) :
+    backSubOps (n + 1) = backSubOps n + (n + 1) := by
+  unfold backSubOps; rw [Finset.sum_range_succ]
+
+/-- Unfolding one back-substitution step (subtractions). -/
+lemma backSubSubs_succ (n : ℕ) :
+    backSubSubs (n + 1) = backSubSubs n + n := by
+  unfold backSubSubs; rw [Finset.sum_range_succ]
+
+/-- **Closed form for back-substitution operations.** `2 · backSubOps n = n² + n`,
+    i.e. `backSubOps n = n(n+1)/2` — the `O(n²)` multiplication/division cost of
+    back-substitution (lower order than the `~n³/3` of forward elimination). -/
+theorem backSubOps_closed (n : ℕ) : 2 * backSubOps n = n ^ 2 + n := by
+  induction n with
+  | zero => simp [backSubOps]
+  | succ m ih =>
+    calc 2 * backSubOps (m + 1)
+        = 2 * backSubOps m + 2 * (m + 1) := by rw [backSubOps_succ]; ring
+      _ = (m ^ 2 + m) + 2 * (m + 1) := by rw [ih]
+      _ = (m + 1) ^ 2 + (m + 1) := by ring
+
+/-- **Closed form for back-substitution subtractions.** `2 · backSubSubs n + n = n²`,
+    i.e. `backSubSubs n = n(n−1)/2`. -/
+theorem backSubSubs_closed (n : ℕ) : 2 * backSubSubs n + n = n ^ 2 := by
+  induction n with
+  | zero => simp [backSubSubs]
+  | succ m ih =>
+    calc 2 * backSubSubs (m + 1) + (m + 1)
+        = (2 * backSubSubs m + m) + (2 * m + 1) := by rw [backSubSubs_succ]; ring
+      _ = m ^ 2 + (2 * m + 1) := by rw [ih]
+      _ = (m + 1) ^ 2 := by ring
+
+/-- Total **back-substitution flop count**: operations (mult+div) plus subtractions. -/
+def backSubFlops (n : ℕ) : ℕ := backSubOps n + backSubSubs n
+
+/-- **The back-substitution flop count is exactly `n²`.**
+    The `n(n+1)/2` multiplications/divisions plus the `n(n−1)/2` subtractions sum to
+    `n²` exactly — a clean closed form with no truncated subtraction. -/
+theorem backSubFlops_eq (n : ℕ) : backSubFlops n = n ^ 2 := by
+  have h1 := backSubOps_closed n
+  have h2 := backSubSubs_closed n
+  unfold backSubFlops
+  omega
+
+/-- Concrete back-substitution flop counts: `n=2 ↦ 4`, `n=3 ↦ 9`, `n=4 ↦ 16`, `n=5 ↦ 25`. -/
+lemma backSubFlops_small :
+    backSubFlops 2 = 4 ∧ backSubFlops 3 = 9 ∧
+    backSubFlops 4 = 16 ∧ backSubFlops 5 = 25 := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> (rw [backSubFlops_eq]; norm_num)
+
+/-- Total cost to **solve** a dense `n × n` linear system by Gaussian elimination:
+    the forward-elimination flops (`gaussExactFlops`, `≈ 2n³/3`) together with the
+    `O(n²)` back-substitution flops. -/
+def fullSolveFlops (n : ℕ) : ℕ := gaussExactFlops n + backSubFlops n
+
+/-- **Closed form for the full solve cost (subtraction-free).**
+    `6 · fullSolveFlops n + n = 4n³ + 3n²`, i.e. `fullSolveFlops n = (4n³ + 3n² − n)/6`.
+    The leading term is `2n³/3`: back-substitution's `n²` is asymptotically negligible. -/
+theorem fullSolveFlops_closed (n : ℕ) :
+    6 * fullSolveFlops n + n = 4 * n ^ 3 + 3 * n ^ 2 := by
+  have h1 := gaussExactFlops_closed n
+  have h2 := backSubFlops_eq n
+  unfold fullSolveFlops
+  omega
+
+/-- Concrete full-solve flop counts (elimination + back-substitution):
+    `n=2 ↦ 7`, `n=3 ↦ 22`, `n=4 ↦ 50`, `n=5 ↦ 95`. -/
+lemma fullSolveFlops_small :
+    fullSolveFlops 2 = 7 ∧ fullSolveFlops 3 = 22 ∧
+    fullSolveFlops 4 = 50 ∧ fullSolveFlops 5 = 95 := by
+  have h2 := fullSolveFlops_closed 2
+  have h3 := fullSolveFlops_closed 3
+  have h4 := fullSolveFlops_closed 4
+  have h5 := fullSolveFlops_closed 5
+  norm_num at h2 h3 h4 h5
+  omega
+
+/-- Back-substitution is asymptotically negligible: for `n ≥ 3` its flop count is
+    dominated by the forward-elimination flop count. `backSubFlops n ≤ gaussExactFlops n`. -/
+theorem backSubFlops_le_gaussFlops {n : ℕ} (hn : 3 ≤ n) :
+    backSubFlops n ≤ gaussExactFlops n := by
+  have hF := gaussExactFlops_closed n
+  have hB := backSubFlops_eq n
+  have hcube : 3 * n ^ 2 ≤ n ^ 3 := by
+    calc 3 * n ^ 2 ≤ n * n ^ 2 := by gcongr
+      _ = n ^ 3 := by ring
+  have hsq : n ≤ n ^ 2 := by
+    have h := Nat.pow_le_pow_right (show 1 ≤ n by omega) (show (1 : ℕ) ≤ 2 by norm_num)
+    simpa using h
+  omega
+
+/-- With back-substitution included, the full solve cost still stays below the parent's
+    `n³` model for `n ≥ 2` (back-substitution only adds lower-order `n²` work). -/
+theorem fullSolveFlops_le_cube {n : ℕ} (hn : 2 ≤ n) : fullSolveFlops n ≤ n ^ 3 := by
+  have hfs := fullSolveFlops_closed n
+  have hc : 3 * n ^ 2 ≤ 2 * n ^ 3 := by
+    have e : 2 * n ^ 3 = (2 * n) * n ^ 2 := by ring
+    rw [e]; gcongr; omega
+  omega
+
+/-- With back-substitution included, solving an `n × n` system by Gaussian elimination
+    still beats Cramer's rule for `n ≥ 4` — a fortiori, since the full solve cost is
+    `≤ n³ = gaussMuls n` and the parent already proved `gaussMuls n < cramersRuleMuls n`. -/
+theorem fullSolve_beats_cramer {n : ℕ} (hn : 4 ≤ n) :
+    fullSolveFlops n < CramersComplexity.cramersRuleMuls n :=
+  lt_of_le_of_lt (fullSolveFlops_le_cube (by omega))
+    (CramersComplexity.gauss_beats_cramer hn)
+
+/-- Summary of the full solve-cost analysis: the back-substitution flop count is exactly
+    `n²`, the total solve cost has leading term `2n³/3` (`6·flops + n = 4n³ + 3n²`),
+    back-substitution is dominated by forward elimination for `n ≥ 3`, and the full
+    solve still beats Cramer's rule for `n ≥ 4`. -/
+theorem fullSolve_summary :
+    (∀ n : ℕ, backSubFlops n = n ^ 2) ∧
+    (∀ n : ℕ, 6 * fullSolveFlops n + n = 4 * n ^ 3 + 3 * n ^ 2) ∧
+    (∀ n : ℕ, 3 ≤ n → backSubFlops n ≤ gaussExactFlops n) ∧
+    (∀ n : ℕ, 4 ≤ n → fullSolveFlops n < CramersComplexity.cramersRuleMuls n) :=
+  ⟨backSubFlops_eq, fullSolveFlops_closed,
+   fun _ h => backSubFlops_le_gaussFlops h, fun _ h => fullSolve_beats_cramer h⟩
+
 end CramersComplexityExact

--- a/research/problems/cramers-rule-oq-02-oq-01/knowledge.md
+++ b/research/problems/cramers-rule-oq-02-oq-01/knowledge.md
@@ -6,16 +6,57 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Tighten the parent Cramer-vs-Gauss complexity comparison's loose `n³` Gaussian-elimination
+model to the exact textbook flop counts. The forward-elimination multiplication/division
+count `(n³ − n)/3`, the additions/subtractions `~n³/3`, and the full leading `~2n³/3` flop
+total were formalized in prior sessions (#31414, #31586). The remaining stated open item was
+the **back-substitution phase** and its composition into the complete solve cost.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **Back-substitution flop count is exactly `n²`** (clean, no truncated subtraction). Solving
+  the upper-triangular `U x = b` from the bottom up, the row with `j` solved unknowns to its
+  right costs `j` multiplications + `1` division (`backSubOps n = ∑_{j<n}(j+1)`,
+  `2·backSubOps = n²+n`) and `j` subtractions (`backSubSubs n = ∑_{j<n} j`,
+  `2·backSubSubs + n = n²`). The `n(n+1)/2` and `n(n−1)/2` sum to `n²` exactly
+  (`backSubFlops_eq`).
+- **Full solve cost** `fullSolveFlops n = gaussExactFlops n + backSubFlops n` has the
+  subtraction-free closed form `6·fullSolveFlops n + n = 4n³ + 3n²`, leading term `2n³/3`.
+- **Lower-order domination** `backSubFlops_le_gaussFlops` (n ≥ 3): proven by feeding `omega`
+  the two component closed forms plus two pre-proved nonlinear bridges as opaque atoms —
+  `3·n² ≤ n³` (via `calc … ≤ n·n² := by gcongr; _ = n³ := by ring`) and `n ≤ n²` (via
+  `Nat.pow_le_pow_right`). omega then does the purely linear combination over the atoms
+  `n, n², n³`.
+- **Comparison preserved**: `fullSolveFlops n ≤ n³` for `n ≥ 2` (needs the bridge
+  `3·n² ≤ 2·n³`, again `gcongr; omega`), so `fullSolve_beats_cramer` (n ≥ 4) follows a
+  fortiori from the parent's `gauss_beats_cramer` — exactly the same "smaller cost can't
+  overturn the verdict" pattern used for `gaussExact_beats_cramer`.
+
+## Reusable techniques
+
+- **Subtraction-free additive closed forms** (`k·sum + remainder = polynomial`) keep the
+  induction in the ℕ semiring so plain `ring` closes the successor step; the conventional
+  division form is a one-line corollary. Same recipe as the parent gaussExactOps work.
+- **omega + nonlinear bridges**: to compare cubic/quadratic quantities, pre-prove the
+  needed `a·n² ≤ b·n³` / `n ≤ n²` facts with `gcongr` (side goals discharged by `omega`/
+  assumption), then hand them to `omega`, which treats `n, n², n³` as independent atoms.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Trying to prove the domination/`≤ n³` inequalities with `omega` alone fails — omega cannot
+  relate `n²` and `n³` without an explicit bridge lemma. `nlinarith` is also unreliable here
+  because `n³` is an opaque atom unless the `n³ = n·n²` relation is supplied; `gcongr`+`ring`
+  is the robust route.
+
+---
+
+## Session log
+
+- **2026-06-30 (researcher-3)**: Added the back-substitution + full-solve section to
+  `CramersRuleOQ02OQ01.lean` (now 333 LOC, 25 thm/lemma, 7 def, 0 axiom, 0 sorry, no
+  native_decide). Completes the stated open item. Verified via host `lake env lean`
+  (docker down); `#print axioms` shows only propext/Classical.choice/Quot.sound.

--- a/src/data/proofs/cramers-rule-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01/meta.json
@@ -40,15 +40,17 @@
       "Tightening witnesses: gaussExactOps_le_cube (≤ n³, consistency with parent) and gaussExactOps_lt_cube (strict for n ≥ 2, the factor-3 gap is real)",
       "Comparison preserved: gaussExact_beats_cramer shows the tighter exact model still beats Cramer's rule for n ≥ 4 a fortiori, via the parent's gauss_beats_cramer",
       "Additions/subtractions count gaussExactSubs n = ∑_{j<n} j² (one multiply–subtract pair per trailing-entry update) with subtraction-free closed form gaussExactSubs_closed: 6·gaussExactSubs n + 3·n² = 2·n³ + n, i.e. (2n³−3n²+n)/6 ≈ n³/3",
-      "Full leading flop count gaussExactFlops n = gaussExactOps n + gaussExactSubs n with closed form gaussExactFlops_closed: 6·gaussExactFlops n + 3·n² + n = 4·n³, i.e. (4n³−3n²−n)/6 — the textbook ≈ 2n³/3 flops (≈ n³/3 mults + ≈ n³/3 adds); plus gaussExactOps_le_flops and concrete small-n checks"
+      "Full leading flop count gaussExactFlops n = gaussExactOps n + gaussExactSubs n with closed form gaussExactFlops_closed: 6·gaussExactFlops n + 3·n² + n = 4·n³, i.e. (4n³−3n²−n)/6 — the textbook ≈ 2n³/3 flops (≈ n³/3 mults + ≈ n³/3 adds); plus gaussExactOps_le_flops and concrete small-n checks",
+      "Back-substitution phase fully counted: backSubOps n = ∑_{j<n} (j+1) (mult+div) with backSubOps_closed: 2·backSubOps n = n²+n, and backSubSubs n = ∑_{j<n} j with backSubSubs_closed: 2·backSubSubs n + n = n²; their sum backSubFlops n is exactly n² (backSubFlops_eq), the clean O(n²) back-substitution flop count",
+      "Full solve cost fullSolveFlops n = gaussExactFlops n + backSubFlops n with subtraction-free closed form fullSolveFlops_closed: 6·fullSolveFlops n + n = 4n³ + 3n², i.e. (4n³+3n²−n)/6, leading term 2n³/3; back-substitution shown asymptotically negligible (backSubFlops_le_gaussFlops: backSubFlops n ≤ gaussExactFlops n for n ≥ 3) and the full solve still beats Cramer's rule for n ≥ 4 (fullSolve_beats_cramer), bundled in fullSolve_summary"
     ],
     "dateAdded": "2026-06-26",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 195,
-    "assumptions": "None. Fully kernel-checked: 0 sorries, 0 axiom declarations, 0 assumption-carrying structures, and no native_decide (the small concrete counts gaussExactOps_small are derived from the closed form via omega rather than native_decide, so Lean.ofReduceBool is NOT used). The single dependency on the parent file (CramersComplexity.gauss_beats_cramer, cramersRuleMuls) is through native_decide-free declarations only.",
-    "theoremCount": 13,
-    "definitionCount": 3
+    "lineCount": 333,
+    "assumptions": "None. Fully kernel-checked: 0 sorries, 0 axiom declarations, 0 assumption-carrying structures, and no native_decide (all concrete small-n counts are derived from the closed forms via omega/norm_num rather than native_decide, so Lean.ofReduceBool is NOT used). The single dependency on the parent file (CramersComplexity.gauss_beats_cramer, cramersRuleMuls) is through native_decide-free declarations only.",
+    "theoremCount": 25,
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "**The n³/3 Flop Count**\n\nEvery numerical-linear-algebra textbook states that solving an n×n linear system by Gaussian elimination (equivalently LU factorization) costs about n³/3 multiplications/divisions — one third the naive n³ estimate. The parent entry (cramers-rule-oq-02) compared Cramer's rule against Gaussian elimination but used the deliberately loose upper model gaussMuls n = n³, leaving the precise leading constant unformalized. This entry supplies the exact count.\n\n**Where the n³/3 Comes From**\n\nForward elimination runs in steps k = 1, …, n−1. At step k the pivot is at (k,k) and there are n−k rows beneath it. For each such row we compute one multiplier (a division) and update its n−k trailing entries (a multiplication each), for (n−k) + (n−k)² operations. Summing over k and substituting j = n−k gives ∑_{j=1}^{n−1} (j² + j) = (n−1)·n·(n+1)/3 = (n³ − n)/3.",
@@ -108,13 +110,21 @@
       "startLine": 117,
       "endLine": 133,
       "mathContext": "Since gaussExactOps n ≤ n³ = gaussMuls n and the parent proved gaussMuls n < cramersRuleMuls n for n ≥ 4, the tighter model beats Cramer's rule a fortiori — tightening the winner's cost cannot overturn the comparison."
+    },
+    {
+      "id": "back-substitution",
+      "title": "Back-Substitution and the Full Solve Cost",
+      "summary": "Counts the back-substitution phase: backSubOps n = ∑_{j<n}(j+1) mult/div (2·backSubOps = n²+n) and backSubSubs n = ∑_{j<n} j subtractions (2·backSubSubs + n = n²), summing to backSubFlops n = n² exactly (backSubFlops_eq). Composes the full solve cost fullSolveFlops n = gaussExactFlops n + backSubFlops n with closed form 6·fullSolveFlops n + n = 4n³ + 3n² (leading term 2n³/3), proves back-substitution is dominated by forward elimination for n ≥ 3 (backSubFlops_le_gaussFlops), the full solve stays ≤ n³ for n ≥ 2, and still beats Cramer's rule for n ≥ 4 (fullSolve_beats_cramer). Bundled in fullSolve_summary with concrete small-n checks.",
+      "startLine": 196,
+      "endLine": 332,
+      "mathContext": "Back-substitution on the upper-triangular system costs exactly n² flops (n(n+1)/2 mult/div + n(n−1)/2 subtractions), an O(n²) term negligible against the ~2n³/3 of forward elimination. The complete dense-solve cost is therefore (4n³ + 3n² − n)/6 ~ 2n³/3."
     }
   ],
   "conclusion": {
     "summary": "This entry pins down the exact leading cost of Gaussian elimination — (n³ − n)/3 multiplications and divisions — that the parent Cramer-vs-Gauss comparison only bounded by n³. The closed form 3·gaussExactOps n + n = n³ is proved by a short subtraction-free induction in the ℕ semiring, its (n³ − n)/3 division form follows in one line, and omega supplies both the consistency bound (≤ n³) and the strict tightening (< n³ for n ≥ 2). The whole file is axiom-free (no sorries, no native_decide), upgrading the parent's axiomatized model to a fully kernel-checked exact count.",
     "implications": "Because a smaller cost can only strengthen a comparison the winner already led, the headline verdict — Gaussian elimination beats Cramer's rule for n ≥ 4 — carries over to the exact model for free, with no re-proof needed. More broadly, the entry demonstrates a reusable pattern for formalizing exact flop counts: state the polynomial identity in subtraction-free additive form (k·sum + remainder = closed form) so the induction stays in the ℕ semiring and closes by ring, then recover the conventional division form as a one-line corollary. The same template applies to the ~2n³/3 LU-factorization count, the n²/2 back-substitution count, and other textbook complexity figures that are usually quoted asymptotically but rarely formalized exactly.",
     "openQuestions": [
-      "The additions/subtractions count (≈ n³/3) and the full forward-elimination flop total (≈ 2n³/3) are now formalized (gaussExactSubs_closed, gaussExactFlops_closed). Remaining: formalize the back-substitution phase (≈ n²/2 operations) and compose it for the complete solve cost.",
+      "The back-substitution phase is now formalized (backSubFlops_eq: exactly n²) and composed with forward elimination for the complete solve cost (fullSolveFlops_closed: 6·flops + n = 4n³ + 3n², leading term 2n³/3), with back-substitution shown asymptotically negligible and the full solve still beating Cramer's rule for n ≥ 4. Remaining: a refined model separating multiplications from divisions in the full solve, or accounting for multiple right-hand sides.",
       "Does the exact count extend to blocked/partial-pivoting LU factorization, where row interchanges add a lower-order term but the leading (n³ − n)/3 multiplication count is unchanged?",
       "Can a matching lower bound be formalized — that no elimination-based dense solver uses asymptotically fewer than n³/3 multiplications — to complement this exact upper count?"
     ]
@@ -143,15 +153,30 @@
       "name": "gaussExact_beats_cramer",
       "statement": "4 ≤ n → gaussExactOps n < CramersComplexity.cramersRuleMuls n",
       "description": "The tighter exact model still beats Cramer's rule for n ≥ 4, a fortiori from the parent comparison."
+    },
+    {
+      "name": "backSubFlops_eq",
+      "statement": "backSubFlops n = n ^ 2",
+      "description": "The back-substitution flop count is exactly n²: n(n+1)/2 multiplications/divisions plus n(n−1)/2 subtractions, a clean O(n²) closed form."
+    },
+    {
+      "name": "fullSolveFlops_closed",
+      "statement": "6 * fullSolveFlops n + n = 4 * n ^ 3 + 3 * n ^ 2",
+      "description": "Subtraction-free closed form for the complete solve cost (forward elimination + back-substitution); leading term 2n³/3, equivalently fullSolveFlops n = (4n³ + 3n² − n)/6."
+    },
+    {
+      "name": "fullSolve_beats_cramer",
+      "statement": "4 ≤ n → fullSolveFlops n < CramersComplexity.cramersRuleMuls n",
+      "description": "Even with back-substitution included, solving by Gaussian elimination beats Cramer's rule for n ≥ 4, since the full solve cost is ≤ n³ = gaussMuls n."
     }
   ],
   "leanFile": {
     "path": "Proofs/CramersRuleOQ02OQ01.lean",
     "axiomCount": 0,
     "sorryCount": 0,
-    "theoremCount": 13,
-    "definitionCount": 1,
-    "lineCount": 195
+    "theoremCount": 25,
+    "definitionCount": 7,
+    "lineCount": 333
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

Completes the last stated open item of the `cramers-rule-oq-02-oq-01` entry: the **back-substitution phase** and its composition into the **complete dense-solve cost**. Prior sessions (#31414, #31586) formalized the forward-elimination multiplication count `(n³−n)/3` and the full `~2n³/3` forward-elimination flop total; this PR adds the back-substitution count and the end-to-end solve cost.

## What's added (138 lines, pure additions to `Proofs/CramersRuleOQ02OQ01.lean`)

- `backSubOps n = ∑_{j<n}(j+1)` (mult+div) and `backSubSubs n = ∑_{j<n} j` (subtractions), with subtraction-free closed forms `2·backSubOps n = n²+n` and `2·backSubSubs n + n = n²`.
- `backSubFlops_eq : backSubFlops n = n²` — the clean O(n²) back-substitution flop count (n(n+1)/2 + n(n−1)/2 = n²).
- `fullSolveFlops n = gaussExactFlops n + backSubFlops n` with subtraction-free closed form `6·fullSolveFlops n + n = 4n³ + 3n²` (leading term 2n³/3).
- `backSubFlops_le_gaussFlops` (n≥3): back-substitution is asymptotically dominated by forward elimination.
- `fullSolveFlops_le_cube` (n≥2) and `fullSolve_beats_cramer` (n≥4): the Cramer-vs-Gauss verdict carries to the full solve a fortiori.
- `fullSolve_summary` bundling the results; concrete small-n sanity checks throughout.

## Verification

Docker daemon down this session → verified on host via `lake env lean`: **0 errors, exit 0**. `#print axioms` on all new capstones shows only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. File: 25 thm/lemma, 7 def, **0 axiom, 0 sorry, no native_decide**. Gallery `meta.json` counts and sections updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)