### PR TITLE
Fix: clear stale 'issues-found' on 4 audit entries (orphan obsolete after #31501)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25767,14 +25767,18 @@
     "erdos-1002-oq-04": {
       "auditCount": 1,
       "lastAudited": "2026-06-28T18:46:29Z",
-      "result": "issues-found",
-      "issues": []
+      "result": "issues-fixed",
+      "issues": [
+        "Orphan-from-Proofs.lean finding (2026-06-28) obsolete: PR #31501 (f4b5b2e3b26) migrated proofs/ to Lake glob discovery (lakefile.toml globs=[\"Proofs\",\"Proofs.*\"]); module is in the aggregate build. Per-file integrity clean: 0 sorry, 0 axiom, counts match meta.json."
+      ]
     },
     "erdos-1003-oq-03": {
       "auditCount": 1,
       "lastAudited": "2026-06-28T18:46:29Z",
-      "result": "issues-found",
-      "issues": []
+      "result": "issues-fixed",
+      "issues": [
+        "Orphan-from-Proofs.lean finding (2026-06-28) obsolete: PR #31501 (f4b5b2e3b26) migrated proofs/ to Lake glob discovery (lakefile.toml globs=[\"Proofs\",\"Proofs.*\"]); module is in the aggregate build. Per-file integrity clean: 0 sorry, 0 axiom, counts match meta.json."
+      ]
     },
     "erdos-1018-oq-04-incomplete-01-oq-01": {
       "auditCount": 1,
@@ -25785,8 +25789,10 @@
     "erdos-1100-oq-02": {
       "auditCount": 1,
       "lastAudited": "2026-06-28T18:46:29Z",
-      "result": "issues-found",
-      "issues": []
+      "result": "issues-fixed",
+      "issues": [
+        "Orphan-from-Proofs.lean finding (2026-06-28) obsolete: PR #31501 (f4b5b2e3b26) migrated proofs/ to Lake glob discovery (lakefile.toml globs=[\"Proofs\",\"Proofs.*\"]); module is in the aggregate build. Per-file integrity clean: 0 sorry, 0 axiom, counts match meta.json."
+      ]
     },
     "picks-theorem-oq-04": {
       "auditCount": 1,
@@ -25797,8 +25803,10 @@
     "property-b-first-moment-oq-03-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-06-28T18:46:29Z",
-      "result": "issues-found",
-      "issues": []
+      "result": "issues-fixed",
+      "issues": [
+        "Orphan-from-Proofs.lean finding (2026-06-28) obsolete: PR #31501 (f4b5b2e3b26) migrated proofs/ to Lake glob discovery (lakefile.toml globs=[\"Proofs\",\"Proofs.*\"]); module is in the aggregate build. Per-file integrity clean: 0 sorry, 0 axiom, counts match meta.json."
+      ]
     },
     "factor-remainder-hasse-derivative-fq": {
       "auditCount": 1,


### PR DESCRIPTION
## Fix

Reset 4 audit-tracker entries from `issues-found` → `issues-fixed`; their only defect (orphaned from `proofs/Proofs.lean`) was made obsolete by the glob migration.

## Evidence

The 2026-06-28 audit marked 6 entries `issues-found` for one shared reason (auditor log): they *"pass per-file integrity checks but are orphaned from `proofs/Proofs.lean` (excluded from the aggregate build)."* This was the systemic finding in #31454.

**Root cause resolved**: PR #31501 (`f4b5b2e3b26`) replaced the hand-maintained import list with Lake glob discovery — `proofs/lakefile.toml` now has `globs = ["Proofs", "Proofs.*"]`, so every module under `proofs/Proofs/` is in the aggregate build. `proofs/Proofs.lean` is intentionally empty, and `.lean/scripts/check-new-proofs-registered.sh` is a deprecated no-op. Issue #31454 was closed today as resolved by #31501.

**Per-file re-verification** of the 4 reset entries (meta.json vs `.lean` source): 0 sorry, 0 axiom, theoremCount/lineCount match.

| entry | module | result |
|-------|--------|--------|
| erdos-1002-oq-04 | Erdos1002OQ04.lean | clean → issues-fixed |
| erdos-1003-oq-03 | Erdos1003OQ03.lean | clean → issues-fixed |
| erdos-1100-oq-02 | Erdos1100OQ02.lean | clean → issues-fixed |
| property-b-first-moment-oq-03-oq-01 | PropertyBFirstMomentAsymmetric.lean | clean → issues-fixed |

**Left flagged** (genuine pending count drift, addressed by open PR #31641, not this PR):
- `erdos-1018-oq-04-incomplete-01-oq-01` (theoremCount 6→7)
- `picks-theorem-oq-04` (lineCount 308→313, theoremCount 13→14)

Scope: `src/data/proofs/audit-tracker.json` only (auditor state; not consumed by the website build). JSON validated.

---
Automated fix by lean-mechanic agent.