### PR TITLE
Fix: stop child entries double-counting parent context-axioms

### DIFF
--- a/src/data/proofs/collatz-structured-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-01/meta.json
@@ -6,9 +6,7 @@
   "meta": {
     "status": "verified",
     "proofRepoPath": "Proofs/CollatzStructuredOQ01.lean",
-    "additionalFiles": [
-      "Proofs/CollatzStructured.lean"
-    ],
+    "additionalFiles": [],
     "tags": [
       "number-theory",
       "collatz",
@@ -210,9 +208,7 @@
     "theoremCount": 22,
     "definitionCount": 3,
     "sorries": 0,
-    "additionalFiles": [
-      "Proofs/CollatzStructured.lean"
-    ]
+    "additionalFiles": []
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1011-oq-03/meta.json
+++ b/src/data/proofs/erdos-1011-oq-03/meta.json
@@ -10,7 +10,6 @@
     "status": "verified",
     "proofRepoPath": "Proofs/Erdos1011OQ03.lean",
     "additionalFiles": [
-      "Proofs/Erdos1011Problem.lean",
       "Proofs/GraphCore.lean"
     ],
     "tags": [
@@ -163,7 +162,6 @@
     "path": "Proofs/Erdos1011OQ03.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/Erdos1011Problem.lean",
       "Proofs/GraphCore.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Remove parent axiom-source files from two child gallery entries' `additionalFiles`, so the integrity auditor stops counting the parents' **unused** context-axioms against the children.

## Evidence

The auditor (`scripts/auditor/find-targets.ts`) aggregates `axiom` declarations across every file listed in `additionalFiles`. Two child entries listed their parent file, importing the parent's axioms into the child's count:

| Entry | Listed parent | Parent's axioms | Auditor flag |
|-------|---------------|-----------------|--------------|
| `collatz-structured-oq-01` | `CollatzStructured.lean` | `collatz_conjecture` (1) | axiom undercount: claims 0, actual 1 |
| `erdos-1011-oq-03` | `Erdos1011Problem.lean` | Turán, Erdős–Gallai, Simonovits, Davies–Illingworth, HHKP (5) | axiom undercount: claims 0, actual 5 |

**Both children are genuinely 0-axiom:**
- The axiom names appear in **no theorem** — only a comment in OQ01, and entirely absent from OQ03.
- Each entry's `assumptions` field documents `#print axioms` reporting only `propext` / `Classical.choice` / `Quot.sound`.
- The children prove auxiliary results (Collatz *reduction to odd inputs*; *antitonicity* of f), not the open conjectures the parent axioms cite.

**No disclosure is lost:** the parent entries `collatz-structured` and `erdos-1011` already own and disclose these axioms (`status: axiomatized`, `badge: axiom`, `axiomCount: 1`/`5`). Sibling `erdos-1011-oq-01`, which has no `additionalFiles`, already follows this convention. `GraphCore.lean` (0 axioms) is retained on the erdos entry.

**Root cause:** `additionalFiles` was first added to the collatz child meta on 2026-06-30 (#30390), *after* its 2026-06-27 clean audit — introducing the double-count.

**Before:** `scripts/auditor/find-targets.ts --issues` → 2 entries flagged (axiom undercount).
**After:** `scripts/auditor/find-targets.ts --issues` → 0 issues. Parent files unchanged; both children still `import` the parents (build unaffected — `additionalFiles` only controls auditor aggregation and gallery display, not compilation).

---
Automated fix by lean-mechanic agent.