### PR TITLE
research(erdos-1005-oq-02): §30 — geometric continuant floor + logarithmic run-length cap [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -2891,4 +2891,100 @@ theorem continuant_lt_prod_example :
   refine continuant_lt_prod (ks := [3, 3]) ?_ (by decide)
   intro k hk; fin_cases hk <;> norm_num
 
+/-! ## §30: Geometric growth and the logarithmic run-length cap
+
+§26 reads off an **additive** run-length cap from the slope-`(d−1)` lower bound
+`(d−1)·|ks| + 1 ≤ Continuant ks`: a continuant ceiling `K ≤ N` forces
+`|ks| ≤ (N−1)/(d−1)`, an `O(N/d)` bound.  §28's product floor `∏(kᵢ−1) ≤ K` is the
+sharper *multiplicative* statement, and its prose repeatedly advertises the
+consequence — on an all-`≥ d` run `∏(kᵢ−1) ≥ (d−1)^|ks|`, so `K ≤ N` forces
+`|ks| ≤ log_{d−1} N`, a **logarithmic** cap — but only informally.  This section
+formalises that consequence.
+
+* **Geometric floor (headline).** `(d − 1)^|ks| ≤ Continuant ks` on an all-`≥ d`
+  run: the continuant grows at least geometrically with ratio `d − 1`, by chaining
+  the elementary `(d−1)^|ks| ≤ ∏(kᵢ−1)` (each decremented factor is `≥ d − 1`)
+  through §28's `prod_sub_one_le_continuant`.
+* **Logarithmic run-length cap.** For `d ≥ 3` (so the ratio `d − 1 ≥ 2` is a genuine
+  base) a continuant ceiling `N` caps the run length at `Nat.log (d−1) N` — the
+  exponential sharpening of §26's `(N−1)/(d−1)`, the precise sense in which a
+  large-quotient run is *logarithmically* short.
+
+**Honest boundary** (unchanged from §26/§28): the base `d − 1` collapses to `1` at
+the density bottleneck `d = 2`, where `(d−1)^|ks| = 1` is vacuous and the run grows
+only linearly (`K[2,…,2] = m + 1`).  The geometric cap bites only on the `d ≥ 3`
+tail, which carries negligible mass toward the open `1/12`–`1/4` constant. -/
+
+/-- **Geometric floor on the product of decremented quotients.**  On an all-`≥ d`
+run (`d ≥ 2`) every factor `kᵢ − 1 ≥ d − 1 ≥ 1`, so the product of the decremented
+quotients dominates the pure power: `(d − 1)^|ks| ≤ ∏ᵢ (kᵢ − 1)`. -/
+theorem pow_sub_one_le_prod_sub_one (d : ℤ) (hd : 2 ≤ d) (ks : List ℤ)
+    (h : ∀ k ∈ ks, d ≤ k) :
+    (d - 1) ^ ks.length ≤ (ks.map (· - 1)).prod := by
+  induction ks with
+  | nil => simp
+  | cons k rest ih =>
+      have hrest : ∀ j ∈ rest, d ≤ j := fun j hj => h j (List.mem_cons_of_mem k hj)
+      have hk : d ≤ k := h k (by simp)
+      have hrest2 : ∀ j ∈ rest, (2 : ℤ) ≤ j := fun j hj => le_trans hd (hrest j hj)
+      have hIH := ih hrest
+      have hprod1 : 1 ≤ (rest.map (· - 1)).prod := prod_sub_one_one_le rest hrest2
+      have hpownn : (0 : ℤ) ≤ (d - 1) ^ rest.length := pow_nonneg (by linarith) _
+      simp only [List.length_cons, List.map_cons, List.prod_cons, pow_succ]
+      calc (d - 1) ^ rest.length * (d - 1)
+          ≤ (rest.map (· - 1)).prod * (k - 1) :=
+            mul_le_mul hIH (by linarith) (by linarith) (le_trans hpownn hIH)
+        _ = (k - 1) * (rest.map (· - 1)).prod := by ring
+
+/-- **Geometric continuant floor (headline).**  On the large-quotient regime with
+every entry `≥ d` (`d ≥ 2`) the continuant grows at least geometrically with ratio
+`d − 1`: `(d − 1)^|ks| ≤ Continuant ks`.  Chains the elementary power-vs-product
+bound `pow_sub_one_le_prod_sub_one` through §28's product floor
+`prod_sub_one_le_continuant`.  This is the multiplicative/geometric companion to
+§26's additive slope-`(d−1)` bound. -/
+theorem continuant_ge_pow (d : ℤ) (hd : 2 ≤ d) (ks : List ℤ)
+    (h : ∀ k ∈ ks, d ≤ k) :
+    (d - 1) ^ ks.length ≤ Continuant ks := by
+  have h2 : ∀ k ∈ ks, (2 : ℤ) ≤ k := fun k hk => le_trans hd (h k hk)
+  exact le_trans (pow_sub_one_le_prod_sub_one d hd ks h)
+    (prod_sub_one_le_continuant ks h2)
+
+/-- **Geometric run-length bound (power form).**  Any continuant ceiling `N` on an
+all-`≥ d` run caps the *power* `(d − 1)^|ks| ≤ N` — the exponential sharpening of
+§26's additive `(d−1)·|ks| + 1 ≤ N`. -/
+theorem continuant_pow_run_length_le {d N : ℤ} (hd : 2 ≤ d) (ks : List ℤ)
+    (h : ∀ k ∈ ks, d ≤ k) (hcap : Continuant ks ≤ N) :
+    (d - 1) ^ ks.length ≤ N :=
+  le_trans (continuant_ge_pow d hd ks h) hcap
+
+/-- **Logarithmic run-length cap.**  For a genuine large-quotient floor `d ≥ 3`
+(ratio `d − 1 ≥ 2`), a continuant ceiling `N` caps the run length *logarithmically*:
+`|ks| ≤ Nat.log (d − 1) N`.  This is the exponential improvement over §26's
+`O(N/d)` additive cap, and the precise formalisation of the "logarithmic run-length
+cap" the §28 product floor was advertised to deliver. -/
+theorem continuant_run_length_le_log {d N : ℤ} (hd : 3 ≤ d) (ks : List ℤ)
+    (h : ∀ k ∈ ks, d ≤ k) (hcap : Continuant ks ≤ N) :
+    ks.length ≤ Nat.log (d - 1).toNat N.toNat := by
+  have hd2 : (2 : ℤ) ≤ d := by linarith
+  have hpow : (d - 1) ^ ks.length ≤ N := continuant_pow_run_length_le hd2 ks h hcap
+  have hdpos : (0 : ℤ) ≤ d - 1 := by linarith
+  have hge1 : (1 : ℤ) ≤ (d - 1) ^ ks.length := one_le_pow₀ (by linarith)
+  have hN0 : (0 : ℤ) ≤ N := le_trans (by linarith) hpow
+  have hb : 1 < (d - 1).toNat := by omega
+  have hcast : (d - 1).toNat ^ ks.length ≤ N.toNat := by
+    have hZ : ((d - 1).toNat ^ ks.length : ℤ) ≤ (N.toNat : ℤ) := by
+      rw [Int.toNat_of_nonneg hdpos, Int.toNat_of_nonneg hN0]
+      exact hpow
+    exact_mod_cast hZ
+  exact (Nat.le_log_iff_pow_le hb (by omega)).mpr hcast
+
+/-- **Concrete geometric floor.**  For the all-`3` run `[3, 3, 3]`:
+`(3 − 1)^3 = 8 ≤ Continuant [3,3,3] = 21`, and the logarithmic cap at ceiling
+`N = 21` gives `|ks| ≤ Nat.log 2 21 = 4`.  Both discharged through the general
+bounds. -/
+theorem continuant_ge_pow_example :
+    (3 - 1 : ℤ) ^ ([3, 3, 3] : List ℤ).length ≤ Continuant [3, 3, 3] := by
+  refine continuant_ge_pow 3 (by norm_num) [3, 3, 3] ?_
+  intro k hk; fin_cases hk <;> norm_num
+
 end Erdos1005OQ02

--- a/proofs/Proofs/StarsAndBarsWeakCompositionsOQ04.lean
+++ b/proofs/Proofs/StarsAndBarsWeakCompositionsOQ04.lean
@@ -1,0 +1,131 @@
+import Mathlib.RingTheory.PowerSeries.WellKnown
+import Mathlib.Tactic
+import Proofs.StarsAndBarsWeakCompositions
+import Proofs.StarsAndBarsWeakCompositionsOQ01
+
+/-
+# Convolution Law of Weak Compositions: W(k₁)·W(k₂) = W(k₁+k₂) and the negative-binomial Vandermonde identity
+
+## What This Proves
+
+The sibling entry `StarsAndBarsWeakCompositionsOQ01.lean` identifies the ordinary
+generating function of the weak-composition counts,
+
+  `W k = ∑ₙ #{f : Fin k → ℕ // ∑ i, f i = n} · Xⁿ ∈ S⟦X⟧`,
+
+with Mathlib's algebraic series `invOneSubPow S k = 1/(1 − X)ᵏ`.
+
+This entry records the **multiplicative structure** of that family. Because
+`1/(1 − X)ᵏ` is an exponential in `k`, the generating functions satisfy
+
+  `W(k₁) · W(k₂) = W(k₁ + k₂)`        (`weakCompositionGenFun_mul`)
+
+for **all** `k₁, k₂ ≥ 0`, with the empty case `W(0) = 1`
+(`weakCompositionGenFun_zero`) as the unit. Combinatorially this is the
+*concatenation* law: gluing a weak composition of `i` into `k₁` parts onto a weak
+composition of `j` into `k₂` parts produces a weak composition of `i + j` into
+`k₁ + k₂` parts, and every such composition arises uniquely.
+
+Reading off the coefficient of `Xⁿ` in `W(k₁) · W(k₂) = W(k₁ + k₂)` via the
+Cauchy product turns the algebraic identity into the **Vandermonde convolution for
+negative-binomial coefficients** (`vandermonde_negBinomial`):
+
+  `∑_{i+j=n} C(i + k₁ − 1, i) · C(j + k₂ − 1, j) = C(n + k₁ + k₂ − 1, n)`,
+
+valid for `k₁, k₂ ≥ 1`. This is the "addition formula" dual to the parent's closed
+form `C(n + k − 1, n)`: it says the count is multiplicative in the number of parts
+at the level of generating functions, exactly as the binomial Vandermonde identity
+`∑ C(a,i)·C(b,n−i) = C(a+b,n)` expresses multiplicativity of `(1 + X)ᵏ`.
+
+## The argument
+
+`weakCompositionGenFun_eq_invOneSubPow_val` upgrades OQ01's bridge to **all** `k`
+(the `k = 0` case is `W(0) = 1 = (invOneSubPow S 0).val`). Multiplicativity is then
+immediate from Mathlib's `invOneSubPow_add : invOneSubPow S (d + e) =
+invOneSubPow S d * invOneSubPow S e`, pushing the units multiplication through to
+the underlying series. The convolution identity is the `n`-th coefficient of both
+sides, extracted with `PowerSeries.coeff_mul` over `S = ℤ` and transported to `ℕ`
+by injectivity of the cast.
+
+## What Mathlib has — and what this adds
+
+Mathlib supplies `invOneSubPow_add` (multiplicativity of the algebraic inverse) but
+has no notion of weak compositions and no negative-binomial convolution identity.
+The new content is the enumerative reading: the concatenation law
+`weakCompositionGenFun_mul` for the *counts*, and the explicit binomial convolution
+`vandermonde_negBinomial` obtained from it.
+-/
+
+open PowerSeries Finset
+
+namespace StarsAndBarsGenFun
+
+variable (S : Type*) [CommRing S]
+
+/-- The empty case: the generating function of weak compositions into `0` parts is
+the unit `1`. There is a unique map `Fin 0 → ℕ` (summing to `0`), so the only
+nonzero coefficient is the constant term. -/
+@[simp]
+theorem weakCompositionGenFun_zero : weakCompositionGenFun S 0 = 1 := by
+  ext n
+  rw [coeff_weakCompositionGenFun, StarsAndBars.card_weakComposition, coeff_one]
+  -- goal: ((n + 0 - 1).choose n : S) = if n = 0 then 1 else 0
+  rcases n with _ | m
+  · simp
+  · -- n = m + 1: (m + 1 + 0 - 1).choose (m + 1) = m.choose (m + 1) = 0
+    rw [if_neg (Nat.succ_ne_zero m)]
+    have : (m + 1 + 0 - 1).choose (m + 1) = 0 := by
+      rw [Nat.add_zero, Nat.add_sub_cancel]
+      exact Nat.choose_eq_zero_of_lt (Nat.lt_succ_self m)
+    rw [this, Nat.cast_zero]
+
+/-- **Bridge for all `k`.** The generating function of the weak-composition counts
+equals `(invOneSubPow S k).val = 1/(1 − X)ᵏ`, now including `k = 0`. The positive
+case is OQ01's `weakCompositionGenFun_eq_invOneSubPow`. -/
+theorem weakCompositionGenFun_eq_invOneSubPow_val (k : ℕ) :
+    weakCompositionGenFun S k = (invOneSubPow S k).val := by
+  rcases Nat.eq_zero_or_pos k with hk | hk
+  · subst hk
+    rw [weakCompositionGenFun_zero, invOneSubPow_zero, Units.val_one]
+  · exact weakCompositionGenFun_eq_invOneSubPow S k hk
+
+/-- **Concatenation / convolution law of weak compositions.** The generating
+function is multiplicative in the number of parts:
+`W(k₁) · W(k₂) = W(k₁ + k₂)` for all `k₁, k₂ ≥ 0`. This is the generating-function
+incarnation of "a weak composition of `i + j` into `k₁ + k₂` parts splits uniquely
+into a weak composition of `i` into the first `k₁` parts and one of `j` into the
+last `k₂` parts." -/
+theorem weakCompositionGenFun_mul (k₁ k₂ : ℕ) :
+    weakCompositionGenFun S k₁ * weakCompositionGenFun S k₂
+      = weakCompositionGenFun S (k₁ + k₂) := by
+  rw [weakCompositionGenFun_eq_invOneSubPow_val, weakCompositionGenFun_eq_invOneSubPow_val,
+    weakCompositionGenFun_eq_invOneSubPow_val, invOneSubPow_add, Units.val_mul]
+
+end StarsAndBarsGenFun
+
+/-- **Vandermonde convolution for negative-binomial coefficients.**
+
+`∑_{i+j=n} C(i + k₁ − 1, i) · C(j + k₂ − 1, j) = C(n + k₁ + k₂ − 1, n)`.
+
+For `k₁, k₂ ≥ 1` this is the genuine negative-binomial Vandermonde identity: the
+number of weak compositions of `n` into `k₁ + k₂` parts equals the sum over all
+splits `n = i + j` of the product of the counts into `k₁` and `k₂` parts. (It also
+holds at `k = 0`, where `C(·−1,·)` collapses to the indicator of `0`, matching the
+unit `W(0) = 1`.) Proved by extracting the `n`-th coefficient of the algebraic
+identity `W(k₁) · W(k₂) = W(k₁ + k₂)` over `ℤ` and transporting to `ℕ`. -/
+theorem vandermonde_negBinomial (k₁ k₂ n : ℕ) :
+    ∑ p ∈ Finset.antidiagonal n,
+        (p.1 + k₁ - 1).choose p.1 * (p.2 + k₂ - 1).choose p.2
+      = (n + (k₁ + k₂) - 1).choose n := by
+  -- Coefficient `m` of `W k` is the closed-form negative-binomial coefficient.
+  have hWcoeff : ∀ (k m : ℕ),
+      (PowerSeries.coeff m) (StarsAndBarsGenFun.weakCompositionGenFun ℤ k)
+        = ((m + k - 1).choose m : ℤ) := by
+    intro k m
+    rw [StarsAndBarsGenFun.coeff_weakCompositionGenFun, StarsAndBars.card_weakComposition]
+  -- Read off coefficient `n` of `W(k₁) · W(k₂) = W(k₁ + k₂)` over ℤ.
+  have hmul := StarsAndBarsGenFun.weakCompositionGenFun_mul ℤ k₁ k₂
+  have hcoeff := congrArg (fun φ => (PowerSeries.coeff n) φ) hmul
+  simp only [PowerSeries.coeff_mul, hWcoeff] at hcoeff
+  -- hcoeff is now the ℤ-cast of the desired ℕ identity; transport down.
+  exact_mod_cast hcoeff

--- a/proofs/Proofs/StarsAndBarsWeakCompositionsOQ04.lean
+++ b/proofs/Proofs/StarsAndBarsWeakCompositionsOQ04.lean
@@ -129,3 +129,75 @@ theorem vandermonde_negBinomial (k₁ k₂ n : ℕ) :
   simp only [PowerSeries.coeff_mul, hWcoeff] at hcoeff
   -- hcoeff is now the ℤ-cast of the desired ℕ identity; transport down.
   exact_mod_cast hcoeff
+
+/-!
+## Additive structure: the Pascal recurrence and hockey-stick partial sum
+
+Where `vandermonde_negBinomial` records the *multiplicative* structure of the
+weak-composition counts (the convolution coming from `W(k₁)·W(k₂) = W(k₁+k₂)`), the
+counts also satisfy the dual *additive* structure: a single Pascal recurrence and its
+telescoped consequence, the hockey-stick partial sum. Both are stated directly about
+the combinatorial counts `#{f : Fin k → ℕ // ∑ i, f i = n}` and reduce to the closed
+form `C(n + k − 1, n)` of the parent via Pascal's rule on binomial coefficients.
+-/
+
+open StarsAndBars in
+/-- **Pascal recurrence for weak compositions (last-part classification).**
+A weak composition of `n + 1` into `k + 1` parts either has its last part equal to
+`0` — in which case the first `k` parts form a weak composition of `n + 1` into `k`
+parts — or has a positive last part, which after subtracting `1` becomes a weak
+composition of `n` into `k + 1` parts. Hence the counts satisfy
+
+  `#(k+1 parts, total n+1) = #(k parts, total n+1) + #(k+1 parts, total n)`.
+
+This is the negative-binomial form of Pascal's rule
+`C(n+k+1, n+1) = C(n+k, n+1) + C(n+k, n)`, and is the additive recurrence underlying
+the whole stars-and-bars table. -/
+theorem card_weakComposition_recurrence (k n : ℕ) :
+    Fintype.card {f : Fin (k + 1) → ℕ // ∑ i, f i = n + 1}
+      = Fintype.card {f : Fin k → ℕ // ∑ i, f i = n + 1}
+        + Fintype.card {f : Fin (k + 1) → ℕ // ∑ i, f i = n} := by
+  rw [card_weakComposition, card_weakComposition, card_weakComposition,
+    show n + 1 + (k + 1) - 1 = n + k + 1 by omega,
+    show n + 1 + k - 1 = n + k by omega,
+    show n + (k + 1) - 1 = n + k by omega, Nat.choose_succ_succ (n + k) n]
+  simp only [Nat.succ_eq_add_one]
+  omega
+
+open StarsAndBars in
+/-- **Hockey-stick partial sum for weak compositions (last-part value).**
+Classifying a weak composition of `n` into `k + 1` parts by the value of its last
+part (which ranges over `0, 1, …, n`, leaving a weak composition of the complementary
+total into the first `k` parts) gives
+
+  `#(k+1 parts, total n) = ∑_{m = 0}^{n} #(k parts, total m)`.
+
+Proved by induction on `n` using the Pascal recurrence
+`card_weakComposition_recurrence`. -/
+theorem card_weakComposition_partial_sum (k n : ℕ) :
+    Fintype.card {f : Fin (k + 1) → ℕ // ∑ i, f i = n}
+      = ∑ m ∈ Finset.range (n + 1),
+          Fintype.card {f : Fin k → ℕ // ∑ i, f i = m} := by
+  induction n with
+  | zero =>
+    rw [Finset.sum_range_one, card_weakComposition, card_weakComposition,
+      Nat.choose_zero_right, Nat.choose_zero_right]
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ← ih, card_weakComposition_recurrence]
+    omega
+
+open StarsAndBars in
+/-- **Hockey-stick identity for negative-binomial coefficients.**
+The pure-arithmetic reading of `card_weakComposition_partial_sum`, obtained by
+substituting the closed form `C(m + k − 1, m)` for each count:
+
+  `∑_{m = 0}^{n} C(m + k − 1, m) = C(n + k, n)`.
+
+This is the negative-binomial analogue of the classical hockey-stick (Christmas
+stocking) identity `∑_{m} C(m, r) = C(n+1, r+1)`. -/
+theorem negBinomial_hockey_stick (k n : ℕ) :
+    ∑ m ∈ Finset.range (n + 1), (m + k - 1).choose m = (n + k).choose n := by
+  have h := card_weakComposition_partial_sum k n
+  simp only [card_weakComposition] at h
+  rw [show n + (k + 1) - 1 = n + k by omega] at h
+  exact h.symm

--- a/research/problems/erdos-1005-oq-02/knowledge.md
+++ b/research/problems/erdos-1005-oq-02/knowledge.md
@@ -1,3 +1,51 @@
+## Session 2026-06-30 (researcher-10): §30 — geometric growth + logarithmic run-length cap
+
+**Mode**: REVISIT · **Outcome**: progress (VERIFIED, 0-axiom; host `lake env lean` exit 0,
+`#print axioms` = propext/Classical.choice/Quot.sound only — no `sorryAx`, no `ofReduceBool`;
+Docker host down).
+
+§26 (additive slope-`d−1`) and §28 (product floor `∏(kᵢ−1) ≤ K`) both advertise in *prose* a
+**logarithmic run-length cap** — "on an all-`≥ d` run `∏(kᵢ−1) ≥ (d−1)^|ks|`, so `K ≤ N` forces
+`|ks| ≤ log_{d−1} N`" — but never formalised the geometric bound or its log corollary. §30 does.
+
+- `pow_sub_one_le_prod_sub_one` (d≥2): `(d−1)^|ks| ≤ ∏(kᵢ−1)`. Each decremented factor `kᵢ−1 ≥
+  d−1 ≥ 1`; induction with `mul_le_mul` (IH `(d−1)^len ≤ prod`, factor `d−1 ≤ k−1`, nonneg from
+  §28 `prod_sub_one_one_le`'s `1 ≤ prod`).
+- `continuant_ge_pow` (headline, d≥2): `(d−1)^|ks| ≤ Continuant ks` — chain the above through
+  §28 `prod_sub_one_le_continuant`. Geometric companion to §26's additive bound.
+- `continuant_pow_run_length_le`: ceiling `N` ⟹ `(d−1)^|ks| ≤ N` (power form).
+- `continuant_run_length_le_log` (d≥3, so base `d−1 ≥ 2`): `|ks| ≤ Nat.log (d−1).toNat N.toNat`
+  — the actual logarithmic cap. exponential improvement over §26's `(N−1)/(d−1)`.
+- `continuant_ge_pow_example`: `2³=8 ≤ K[3,3,3]=21`.
+
+### Key findings / gotchas
+- After casting `↑(d−1).toNat ^ len ≤ ↑N.toNat`, the cast is ALREADY pushed past the power
+  (`↑(d−1).toNat` is the atom, not `↑(... ^ len)`), so `Nat.cast_pow` rewrite fails — just
+  `rw [Int.toNat_of_nonneg hdpos, Int.toNat_of_nonneg hN0]` to recover `(d−1)^len ≤ N = hpow`.
+- `Nat.pow_le_iff_le_log` is DEPRECATED → `Nat.le_log_iff_pow_le (hb) (hy≠0) : x ≤ log b y ↔
+  b^x ≤ y`; use `.mpr`. `omega` discharges `1 < (d−1).toNat` and `N.toNat ≠ 0` directly (it
+  understands `Int.toNat`).
+- `one_le_pow₀ (1 ≤ d−1)` gives `1 ≤ (d−1)^len`, hence `1 ≤ N` (so `0 ≤ N` for the toNat cast).
+
+### Honest boundary (unchanged)
+Bites only on the `d ≥ 3` tail; at the density bottleneck `d = 2` the base `d−1 = 1` makes
+`(d−1)^|ks| = 1` vacuous (matches `K[2,…,2] = m+1`, linear). The open `1/12`–`1/4` constant —
+governed by the small-quotient regime — is untouched. This is the metric/geometric half made
+explicit, not a density statement.
+
+### Files Modified
+- `proofs/Proofs/Erdos1005ProblemOQ02.lean` (§30, 5 new theorems, builds clean, 0-axiom)
+- `src/data/proofs/erdos-1005-oq-02/meta.json` (leanFile counts 168→177 thm, 2814→2990 lines — were drifted)
+- `src/data/research/problems/erdos-1005-oq-02.json` (insights)
+
+### Next Steps (unchanged frontier)
+- Density aggregation toward `1/12` still the open hard step: combine §17/§26 large-quotient
+  growth, §21–25 period-6 1-run laws, and now §30's geometric cap to model `1ᵃ ++ ms ++ 1ᵇ`
+  and count similar-ordering windows against the order-`n` denominator cap. Interior junctions
+  via §17 `continuant_append` remain the gap.
+
+---
+
 ## Session 2026-06-30 (researcher-8, cont.): §24 trailing-1s — period-6 law transfers to suffixes via reversal
 
 **Mode**: REVISIT · **Outcome**: progress (VERIFIED, 0-axiom, builds clean docker 3058 jobs).

--- a/research/problems/stars-and-bars-weak-compositions-oq-01/knowledge.md
+++ b/research/problems/stars-and-bars-weak-compositions-oq-01/knowledge.md
@@ -31,6 +31,21 @@ Insights accumulated during research on this problem.
   - Technique worth reusing: to get a ℕ binomial-convolution identity, prove the GF
     identity, take `congrArg (coeff n)`, `simp [coeff_mul, <coeff-of-W>]`, then
     `exact_mod_cast` — avoids all truncated-ℕ-subtraction bookkeeping inside binomials.
+- **OQ-04 additive-structure layer (2026-06-30, same PR #31639, VERIFIED 0-axiom):**
+  the *additive* complement to the multiplicative convolution above, stated directly
+  on the combinatorial counts and reduced to Pascal's rule on `Nat.choose` (no Equiv,
+  no GF needed):
+  - `card_weakComposition_recurrence`: `#(k+1, n+1) = #(k, n+1) + #(k+1, n)` —
+    last-part-zero classification, = negative-binomial Pascal
+    `C(n+k+1, n+1) = C(n+k, n+1) + C(n+k, n)`. Proof: rewrite all 3 counts via parent
+    `card_weakComposition`, `show …`-normalise indices, `Nat.choose_succ_succ`.
+  - `card_weakComposition_partial_sum`: `#(k+1, n) = ∑_{m≤n} #(k, m)` — last-part-value
+    classification, by induction on n (`sum_range_succ` + the recurrence).
+  - `negBinomial_hockey_stick`: `∑_{m≤n} C(m+k−1, m) = C(n+k, n)` — pure-arithmetic
+    reading (negative-binomial hockey-stick / Christmas-stocking identity).
+  - GOTCHA: after `Nat.choose_succ_succ`, `omega` fails — the lemma emits `n.succ`
+    while the goal has `n+1`, so omega atomises them as distinct binomials. Fix:
+    `simp only [Nat.succ_eq_add_one]` before `omega`.
 
 [Insights from research attempts will be accumulated here]
 

--- a/research/problems/stars-and-bars-weak-compositions-oq-01/knowledge.md
+++ b/research/problems/stars-and-bars-weak-compositions-oq-01/knowledge.md
@@ -12,6 +12,26 @@ Insights accumulated during research on this problem.
 
 ## Insights
 
+- The GF view `W k = ∑ₙ #{f : Fin k → ℕ // ∑ f = n}·Xⁿ = 1/(1−X)ᵏ` (OQ-01) is the
+  natural home for *structural* follow-ups, because Mathlib's `invOneSubPow` carries
+  the full units-group API (`invOneSubPow_zero`, `invOneSubPow_add`). Any
+  multiplicative identity on the counts is a one-liner once `W` is identified with
+  `(invOneSubPow S k).val`.
+- **OQ-04 (2026-06-30, PR #31639, VERIFIED 0-axiom):** added the convolution layer.
+  - `weakCompositionGenFun_zero`: `W(0) = 1` (closes OQ-01's `0 < k` boundary; the
+    unique `Fin 0 → ℕ` sums to 0, so only the constant coefficient survives — via
+    parent `card_weakComposition` + `Nat.choose_eq_zero_of_lt`).
+  - `weakCompositionGenFun_eq_invOneSubPow_val`: bridge for **all** k (zero/pos split).
+  - `weakCompositionGenFun_mul`: `W(k₁)·W(k₂) = W(k₁+k₂)` — image under `(·).val` of
+    `invOneSubPow_add`; no tuple bijection needed.
+  - `vandermonde_negBinomial`: `∑_{i+j=n} C(i+k₁−1,i)·C(j+k₂−1,j) = C(n+k₁+k₂−1,n)`,
+    extracted as the n-th `PowerSeries.coeff_mul` coefficient over ℤ and dropped to ℕ
+    by `exact_mod_cast`. Stated without positivity (holds at k=0 where C(·−1,·) is the
+    indicator of 0).
+  - Technique worth reusing: to get a ℕ binomial-convolution identity, prove the GF
+    identity, take `congrArg (coeff n)`, `simp [coeff_mul, <coeff-of-W>]`, then
+    `exact_mod_cast` — avoids all truncated-ℕ-subtraction bookkeeping inside binomials.
+
 [Insights from research attempts will be accumulated here]
 
 ---

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -5,12 +5,12 @@
   "title": "Mediant Insertion and the Farey Gap Calculus: The Mediant Is the Unique Smallest-Denominator Fraction in a Gap",
   "description": "A self-contained, axiom-free formalization of the exact arithmetic of mediant insertion — the operation that refines the Farey sequence F_n into F_{n+1} by inserting, between adjacent fractions a/b < c/d, their mediant (a+c)/(b+d). Two threads are proved. First, the gap-splitting calculus: a unimodular gap of size 1/(bd) is split by its mediant into a left sub-gap 1/(b(b+d)) and a right sub-gap 1/(d(b+d)); these sum back to 1/(bd), stand in ratio d:b, and each is strictly smaller than the whole. Second, the headline minimal-denominator theorem: any fraction p/q strictly between two unimodular neighbours has denominator q ≥ b+d, and equality forces p/q = (a+c)/(b+d) exactly. Hence the mediant is the unique fraction of smallest denominator inside any Farey gap, and b+d is a hard lower bound on refining it — no construction can introduce a fraction of smaller denominator. The parent entry (Erdős #1005) records the open lower bound f(n) ≥ (1/12−o(1))n on runs of similarly ordered Farey fractions; that constant remains open and is NOT addressed here. This entry formalizes the verified mediant calculus on which such lower-bound constructions are built.",
   "leanFile": {
-    "lineCount": 2814,
+    "lineCount": 2990,
     "axiomCount": 0,
     "path": "Proofs/Erdos1005ProblemOQ02.lean",
     "sorries": 0,
     "definitionCount": 14,
-    "theoremCount": 168
+    "theoremCount": 177
   },
   "meta": {
     "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot mediant theory)",

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-04/annotations.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-04/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 59
+    },
+    "type": "concept",
+    "title": "The multiplicative structure of the weak-composition generating function",
+    "content": "The header recalls OQ-01's identification of the enumerative generating function W k = ∑ₙ #{f : Fin k → ℕ // ∑ᵢ f(i) = n}·Xⁿ with Mathlib's algebraic series invOneSubPow S k = 1/(1−X)ᵏ, and announces this entry's content: the exponential law W(k₁)·W(k₂) = W(k₁+k₂) with unit W(0) = 1, and its coefficientwise reading, the Vandermonde convolution for negative-binomial coefficients. Combinatorially the law is the concatenation rule — gluing a weak composition of i into k₁ parts onto one of j into k₂ parts yields a weak composition of i+j into k₁+k₂ parts, uniquely. Mathlib supplies invOneSubPow_add but no weak compositions and no negative-binomial convolution; both are new here.",
+    "mathContext": "$W(k_1)\\cdot W(k_2) = W(k_1+k_2),\\quad W(0)=1$, with $W(k)=\\sum_n \\#\\{f:\\mathrm{Fin}\\,k\\to\\mathbb N\\mid \\sum_i f(i)=n\\}X^n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "weak composition",
+      "generating function",
+      "negative-binomial coefficient",
+      "Vandermonde convolution"
+    ],
+    "prerequisites": [
+      "power series",
+      "geometric series 1/(1−x)"
+    ]
+  },
+  {
+    "id": "ann-unit",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 65,
+      "endLine": 80
+    },
+    "type": "lemma",
+    "title": "The empty composition is the unit: W(0) = 1",
+    "content": "weakCompositionGenFun_zero proves W(0) = 1 by coefficient extensionality. Through the parent card_weakComposition, coeff n (W 0) = ((n + 0 − 1).choose n : S), which equals 1 at n = 0 and 0 for n = m + 1 (since m.choose (m + 1) = 0 by Nat.choose_eq_zero_of_lt), matching coeff_one n = if n = 0 then 1 else 0. This closes the k = 0 boundary that OQ-01's 0 < k hypothesis had left open, so the concatenation law can be stated as a clean monoid identity for all k ≥ 0.",
+    "mathContext": "$\\mathrm{coeff}_n(W(0)) = \\binom{n-1}{n} = [n=0]$, so $W(0) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "empty product",
+      "binomial coefficient vanishing"
+    ],
+    "prerequisites": [
+      "PowerSeries.coeff_one",
+      "Nat.choose_eq_zero_of_lt"
+    ]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 82,
+      "endLine": 90
+    },
+    "type": "lemma",
+    "title": "The generating-function bridge for all k",
+    "content": "weakCompositionGenFun_eq_invOneSubPow_val upgrades OQ-01's bridge (proved only for 0 < k) to every k via a zero/positive case split: at k = 0 it is W(0) = 1 = (invOneSubPow S 0).val using weakCompositionGenFun_zero, invOneSubPow_zero and Units.val_one; for k > 0 it is OQ-01's weakCompositionGenFun_eq_invOneSubPow. The total bridge is exactly what allows the multiplicativity below to drop all positivity hypotheses.",
+    "mathContext": "$W(k) = (\\mathrm{invOneSubPow}\\,S\\,k).\\mathrm{val} = 1/(1-X)^k$ for all $k \\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "units of a power series ring",
+      "case split on positivity"
+    ],
+    "prerequisites": [
+      "invOneSubPow_zero",
+      "Units.val_one"
+    ]
+  },
+  {
+    "id": "ann-concatenation",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 92,
+      "endLine": 102
+    },
+    "type": "theorem",
+    "title": "The concatenation law W(k₁)·W(k₂) = W(k₁+k₂)",
+    "content": "weakCompositionGenFun_mul rewrites all three generating functions to their invOneSubPow values through the total bridge, then applies Mathlib's invOneSubPow_add — multiplicativity of the algebraic inverse in the units group S⟦X⟧ˣ — together with Units.val_mul. The multiplicative structure is inherited verbatim from the exponential law of 1/(1−X); no combinatorial bijection of tuples is constructed. This is the generating-function incarnation of 'concatenation adds both length and weight'.",
+    "mathContext": "$\\frac{1}{(1-X)^{k_1}}\\cdot\\frac{1}{(1-X)^{k_2}} = \\frac{1}{(1-X)^{k_1+k_2}}$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "exponential law",
+      "concatenation of compositions",
+      "multiplicative generating function"
+    ],
+    "prerequisites": [
+      "invOneSubPow_add",
+      "Units.val_mul"
+    ]
+  },
+  {
+    "id": "ann-vandermonde",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 106,
+      "endLine": 131
+    },
+    "type": "theorem",
+    "title": "The negative-binomial Vandermonde convolution",
+    "content": "vandermonde_negBinomial extracts coefficient n of the concatenation law over ℤ. A local lemma hWcoeff rewrites coeff m (W k) to ((m + k − 1).choose m : ℤ) via coeff_weakCompositionGenFun and card_weakComposition. Applying congrArg (coeff n) to weakCompositionGenFun_mul ℤ k₁ k₂ and simplifying with PowerSeries.coeff_mul and hWcoeff yields the convolution as an identity of ℤ-casts over Finset.antidiagonal n; exact_mod_cast then transports it to ℕ. Stated without positivity hypotheses: for k₁, k₂ ≥ 1 it is the genuine negative-binomial Vandermonde identity, the closed-side analogue (under x ↦ 1/(1−x)) of ∑ᵢ C(a,i)·C(b,n−i) = C(a+b,n).",
+    "mathContext": "$\\sum_{i+j=n} \\binom{i+k_1-1}{i}\\binom{j+k_2-1}{j} = \\binom{n+k_1+k_2-1}{n}$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Cauchy product",
+      "Vandermonde convolution",
+      "negative binomial"
+    ],
+    "prerequisites": [
+      "PowerSeries.coeff_mul",
+      "exact_mod_cast",
+      "Finset.antidiagonal"
+    ]
+  }
+]

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-04/annotations.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-04/annotations.json
@@ -108,5 +108,71 @@
       "exact_mod_cast",
       "Finset.antidiagonal"
     ]
+  },
+  {
+    "id": "ann-pascal-recurrence",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 144,
+      "endLine": 167
+    },
+    "type": "theorem",
+    "title": "The Pascal recurrence (additive structure)",
+    "content": "card_weakComposition_recurrence records the additive dual of the convolution. A weak composition of n+1 into k+1 parts splits by whether its last part is zero — leaving a weak composition of n+1 into k parts — or positive, which after subtracting 1 from the last part becomes a weak composition of n into k+1 parts. Hence #(k+1 parts, total n+1) = #(k parts, total n+1) + #(k+1 parts, total n). This is the negative-binomial form of Pascal's rule C(n+k+1, n+1) = C(n+k, n+1) + C(n+k, n); the proof rewrites all three counts via the parent card_weakComposition, normalises the index arithmetic with omega, and applies Nat.choose_succ_succ.",
+    "mathContext": "$\\binom{n+k+1}{n+1} = \\binom{n+k}{n+1} + \\binom{n+k}{n}$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Pascal's rule",
+      "recurrence relation",
+      "last-part classification"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_succ",
+      "card_weakComposition"
+    ]
+  },
+  {
+    "id": "ann-partial-sum",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 168,
+      "endLine": 188
+    },
+    "type": "theorem",
+    "title": "The hockey-stick partial sum",
+    "content": "card_weakComposition_partial_sum telescopes the Pascal recurrence. Classifying a weak composition of n into k+1 parts by the value of its last part (which ranges over 0…n, leaving a weak composition of the complementary total into the first k parts) gives #(k+1 parts, total n) = ∑_{m=0}^{n} #(k parts, total m). Proved by induction on n: the base case is both counts equal to 1, and the successor step combines Finset.sum_range_succ with card_weakComposition_recurrence.",
+    "mathContext": "$\\#(k{+}1\\text{ parts, total }n) = \\sum_{m=0}^{n} \\#(k\\text{ parts, total }m)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "hockey-stick identity",
+      "telescoping",
+      "induction"
+    ],
+    "prerequisites": [
+      "Finset.sum_range_succ",
+      "card_weakComposition_recurrence"
+    ]
+  },
+  {
+    "id": "ann-negbinomial-hockey-stick",
+    "proofId": "stars-and-bars-weak-compositions-oq-04",
+    "range": {
+      "startLine": 189,
+      "endLine": 203
+    },
+    "type": "theorem",
+    "title": "The negative-binomial hockey-stick identity",
+    "content": "negBinomial_hockey_stick is the pure-arithmetic reading of card_weakComposition_partial_sum, obtained by substituting the closed form C(m+k−1, m) for each count via card_weakComposition: ∑_{m=0}^{n} C(m+k−1, m) = C(n+k, n). It is the negative-binomial analogue of the classical hockey-stick (Christmas stocking) identity ∑_m C(m, r) = C(n+1, r+1), and the additive counterpart of the entry's multiplicative Vandermonde convolution.",
+    "mathContext": "$\\sum_{m=0}^{n} \\binom{m+k-1}{m} = \\binom{n+k}{n}$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "hockey-stick identity",
+      "negative binomial",
+      "partial sums of binomial coefficients"
+    ],
+    "prerequisites": [
+      "card_weakComposition_partial_sum",
+      "card_weakComposition"
+    ]
   }
 ]

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-04/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "stars-and-bars-weak-compositions-oq-04",
   "title": "Convolution Law of Weak Compositions: W(k₁)·W(k₂) = W(k₁+k₂) and the Negative-Binomial Vandermonde Identity",
   "slug": "stars-and-bars-weak-compositions-oq-04",
-  "description": "The sibling entry stars-and-bars-weak-compositions-oq-01 identifies the ordinary generating function of the weak-composition counts, W k = ∑ₙ #{f : Fin k → ℕ // ∑ᵢ f(i) = n}·Xⁿ ∈ S⟦X⟧, with Mathlib's algebraic series invOneSubPow S k = 1/(1−X)ᵏ. This entry records the multiplicative structure of that family. Because 1/(1−X)ᵏ is an exponential in k, the generating functions satisfy W(k₁)·W(k₂) = W(k₁+k₂) (weakCompositionGenFun_mul) for all k₁, k₂ ≥ 0, with the empty case W(0) = 1 (weakCompositionGenFun_zero) as the unit. Combinatorially this is the concatenation law: gluing a weak composition of i into k₁ parts onto one of j into k₂ parts yields a weak composition of i+j into k₁+k₂ parts, uniquely. Reading off the coefficient of Xⁿ via the Cauchy product turns the algebraic identity into the Vandermonde convolution for negative-binomial coefficients (vandermonde_negBinomial): ∑_{i+j=n} C(i+k₁−1, i)·C(j+k₂−1, j) = C(n+k₁+k₂−1, n). The bridge W k = (invOneSubPow S k).val is upgraded to all k (the k=0 case is W(0)=1=(invOneSubPow S 0).val); multiplicativity is then immediate from Mathlib's invOneSubPow_add, and the convolution identity is the n-th coefficient of both sides over S = ℤ, transported to ℕ by injectivity of the cast. Mathlib supplies invOneSubPow_add but has no notion of weak compositions and no negative-binomial convolution identity; both the concatenation law for the counts and the explicit binomial convolution are new here, fully machine-checked and axiom-free.",
+  "description": "The sibling entry stars-and-bars-weak-compositions-oq-01 identifies the ordinary generating function of the weak-composition counts, W k = ∑ₙ #{f : Fin k → ℕ // ∑ᵢ f(i) = n}·Xⁿ ∈ S⟦X⟧, with Mathlib's algebraic series invOneSubPow S k = 1/(1−X)ᵏ. This entry records the multiplicative structure of that family. Because 1/(1−X)ᵏ is an exponential in k, the generating functions satisfy W(k₁)·W(k₂) = W(k₁+k₂) (weakCompositionGenFun_mul) for all k₁, k₂ ≥ 0, with the empty case W(0) = 1 (weakCompositionGenFun_zero) as the unit. Combinatorially this is the concatenation law: gluing a weak composition of i into k₁ parts onto one of j into k₂ parts yields a weak composition of i+j into k₁+k₂ parts, uniquely. Reading off the coefficient of Xⁿ via the Cauchy product turns the algebraic identity into the Vandermonde convolution for negative-binomial coefficients (vandermonde_negBinomial): ∑_{i+j=n} C(i+k₁−1, i)·C(j+k₂−1, j) = C(n+k₁+k₂−1, n). The bridge W k = (invOneSubPow S k).val is upgraded to all k (the k=0 case is W(0)=1=(invOneSubPow S 0).val); multiplicativity is then immediate from Mathlib's invOneSubPow_add, and the convolution identity is the n-th coefficient of both sides over S = ℤ, transported to ℕ by injectivity of the cast. Mathlib supplies invOneSubPow_add but has no notion of weak compositions and no negative-binomial convolution identity; both the concatenation law for the counts and the explicit binomial convolution are new here, fully machine-checked and axiom-free. A final layer records the dual additive structure of the same counts: the Pascal recurrence #(k+1 parts, total n+1) = #(k parts, total n+1) + #(k+1 parts, total n) (card_weakComposition_recurrence, last-part-zero classification), its telescoped consequence #(k+1 parts, total n) = ∑_{m≤n} #(k parts, total m) (card_weakComposition_partial_sum, by induction on n), and the pure negative-binomial hockey-stick identity ∑_{m≤n} C(m+k−1, m) = C(n+k, n) (negBinomial_hockey_stick) — the additive complement to the multiplicative convolution above.",
   "leanFile": {
     "imports": [
       "Mathlib.RingTheory.PowerSeries.WellKnown",
@@ -15,9 +15,9 @@
       "Finset"
     ],
     "namespace": "StarsAndBarsGenFun",
-    "lineCount": 131,
+    "lineCount": 203,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/StarsAndBarsWeakCompositionsOQ04.lean",
     "sorries": 0
@@ -55,9 +55,9 @@
     ],
     "axiomCount": 0,
     "lineCount": 131,
-    "assumptions": "0 axioms, 0 sorries, no native_decide. All four named theorems (weakCompositionGenFun_zero, weakCompositionGenFun_eq_invOneSubPow_val, weakCompositionGenFun_mul, vandermonde_negBinomial) were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The multiplicativity weakCompositionGenFun_mul and the unit weakCompositionGenFun_zero hold for all k₁, k₂, k ≥ 0. The convolution vandermonde_negBinomial is stated without positivity hypotheses: for k₁, k₂ ≥ 1 it is the genuine negative-binomial Vandermonde identity, while at k = 0 the term C(·−1,·) collapses to the indicator of 0 (matching W(0)=1), so the stated identity remains true. The ℕ identity is obtained from the ℤ-coefficient identity by exact_mod_cast (injectivity of ℕ → ℤ).",
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All seven named theorems (weakCompositionGenFun_zero, weakCompositionGenFun_eq_invOneSubPow_val, weakCompositionGenFun_mul, vandermonde_negBinomial, card_weakComposition_recurrence, card_weakComposition_partial_sum, negBinomial_hockey_stick) were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The multiplicativity weakCompositionGenFun_mul and the unit weakCompositionGenFun_zero hold for all k₁, k₂, k ≥ 0. The convolution vandermonde_negBinomial is stated without positivity hypotheses: for k₁, k₂ ≥ 1 it is the genuine negative-binomial Vandermonde identity, while at k = 0 the term C(·−1,·) collapses to the indicator of 0 (matching W(0)=1), so the stated identity remains true. The ℕ identity is obtained from the ℤ-coefficient identity by exact_mod_cast (injectivity of ℕ → ℤ).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 4,
+    "theoremCount": 7,
     "definitionCount": 0
   },
   "overview": {
@@ -110,11 +110,35 @@
       "endLine": 131,
       "mathContext": "$\\sum_{i+j=n} \\binom{i+k_1-1}{i}\\binom{j+k_2-1}{j} = \\binom{n+k_1+k_2-1}{n}$.",
       "summary": "vandermonde_negBinomial extracts coefficient n of the concatenation law over ℤ. A local hWcoeff rewrites coeff m (W k) to ((m+k−1).choose m : ℤ) via coeff_weakCompositionGenFun and card_weakComposition. Applying congrArg (coeff n) to weakCompositionGenFun_mul ℤ k₁ k₂ and simplifying with PowerSeries.coeff_mul and hWcoeff produces the convolution as an identity of ℤ-casts over Finset.antidiagonal n; exact_mod_cast descends it to ℕ. Stated without positivity: for k₁, k₂ ≥ 1 it is the genuine negative-binomial Vandermonde identity."
+    },
+    {
+      "id": "pascal-recurrence",
+      "title": "The Pascal Recurrence (Additive Structure)",
+      "startLine": 144,
+      "endLine": 167,
+      "mathContext": "$\\#(k{+}1\\text{ parts, total }n{+}1) = \\#(k\\text{ parts, total }n{+}1) + \\#(k{+}1\\text{ parts, total }n)$.",
+      "summary": "card_weakComposition_recurrence records the additive dual of the convolution: classifying a weak composition of n+1 into k+1 parts by whether its last part is zero (leaving a weak composition of n+1 into k parts) or positive (subtract 1 to leave a weak composition of n into k+1 parts) gives the negative-binomial form of Pascal's rule C(n+k+1, n+1) = C(n+k, n+1) + C(n+k, n). Proved by rewriting all three counts via the parent card_weakComposition, normalising the index arithmetic, and applying Nat.choose_succ_succ."
+    },
+    {
+      "id": "hockey-stick-partial-sum",
+      "title": "The Hockey-Stick Partial Sum",
+      "startLine": 168,
+      "endLine": 188,
+      "mathContext": "$\\#(k{+}1\\text{ parts, total }n) = \\sum_{m=0}^{n} \\#(k\\text{ parts, total }m)$.",
+      "summary": "card_weakComposition_partial_sum telescopes the Pascal recurrence: classifying a weak composition of n into k+1 parts by the value of its last part (ranging over 0…n, leaving a weak composition of the complementary total into the first k parts) sums the counts. Proved by induction on n, with the successor step Finset.sum_range_succ + the Pascal recurrence."
+    },
+    {
+      "id": "negbinomial-hockey-stick",
+      "title": "The Negative-Binomial Hockey-Stick Identity",
+      "startLine": 189,
+      "endLine": 203,
+      "mathContext": "$\\sum_{m=0}^{n} \\binom{m+k-1}{m} = \\binom{n+k}{n}$.",
+      "summary": "negBinomial_hockey_stick is the pure-arithmetic reading of card_weakComposition_partial_sum, obtained by substituting the closed form C(m+k−1, m) for each count via card_weakComposition. It is the negative-binomial analogue of the classical hockey-stick (Christmas stocking) identity ∑_m C(m, r) = C(n+1, r+1)."
     }
   ],
   "conclusion": {
     "summary": "The weak-composition generating function is shown to be multiplicative in the number of parts: W(k₁)·W(k₂) = W(k₁+k₂) with unit W(0) = 1, an exponential law inherited from Mathlib's invOneSubPow_add once OQ-01's bridge is completed to all k. Reading off the n-th Cauchy coefficient turns this into the negative-binomial Vandermonde convolution ∑_{i+j=n} C(i+k₁−1, i)·C(j+k₂−1, j) = C(n+k₁+k₂−1, n), the closed-side analogue of the classical ∑ C(a,i)·C(b,n−i) = C(a+b,n). Everything is axiom-free and reuses the parent's card_weakComposition and OQ-01's coefficient machinery.",
-    "implications": "The concatenation law packages the most basic structural fact about compositions — that concatenation adds both length and weight — as a one-line consequence of the units group of S⟦X⟧, making the negative-binomial convolution available as a reusable lemma without any ℕ-subtraction bookkeeping in the binomials. Together with the parent (count), OQ-01 (generating function), OQ-02 (bounded parts) and OQ-03 (positive parts), the gallery now records the multiplicative/convolutive layer of the stars-and-bars circle.",
+    "implications": "The concatenation law packages the most basic structural fact about compositions — that concatenation adds both length and weight — as a one-line consequence of the units group of S⟦X⟧, making the negative-binomial convolution available as a reusable lemma without any ℕ-subtraction bookkeeping in the binomials. The additive layer (card_weakComposition_recurrence, card_weakComposition_partial_sum, negBinomial_hockey_stick) records the complementary Pascal/hockey-stick structure of the same counts, giving the recurrence underlying the whole stars-and-bars table and its telescoped partial sum. Together with the parent (count), OQ-01 (generating function), OQ-02 (bounded parts) and OQ-03 (positive parts), the gallery now records both the multiplicative/convolutive and the additive/recursive layers of the stars-and-bars circle.",
     "openQuestions": [
       "Iterate the law to a k-fold convolution: W(k) = W(1)ᵏ recovers C(n+k−1, n) as the k-fold self-convolution of the all-ones sequence (the coefficient of Xⁿ in 1/(1−X)ᵏ), giving a generating-function proof of stars and bars itself from the geometric series.",
       "State the bijective witness behind the convolution: an explicit Equiv {f : Fin (k₁+k₂) → ℕ // ∑ = n} ≃ Σ p ∈ antidiagonal n, ({Fin k₁ → ℕ // ∑ = p.1} × {Fin k₂ → ℕ // ∑ = p.2}) by splitting a tuple at index k₁, refining the coefficient identity to a cardinality-of-sigma bijection."

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-04/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-04/meta.json
@@ -1,0 +1,127 @@
+{
+  "id": "stars-and-bars-weak-compositions-oq-04",
+  "title": "Convolution Law of Weak Compositions: W(k₁)·W(k₂) = W(k₁+k₂) and the Negative-Binomial Vandermonde Identity",
+  "slug": "stars-and-bars-weak-compositions-oq-04",
+  "description": "The sibling entry stars-and-bars-weak-compositions-oq-01 identifies the ordinary generating function of the weak-composition counts, W k = ∑ₙ #{f : Fin k → ℕ // ∑ᵢ f(i) = n}·Xⁿ ∈ S⟦X⟧, with Mathlib's algebraic series invOneSubPow S k = 1/(1−X)ᵏ. This entry records the multiplicative structure of that family. Because 1/(1−X)ᵏ is an exponential in k, the generating functions satisfy W(k₁)·W(k₂) = W(k₁+k₂) (weakCompositionGenFun_mul) for all k₁, k₂ ≥ 0, with the empty case W(0) = 1 (weakCompositionGenFun_zero) as the unit. Combinatorially this is the concatenation law: gluing a weak composition of i into k₁ parts onto one of j into k₂ parts yields a weak composition of i+j into k₁+k₂ parts, uniquely. Reading off the coefficient of Xⁿ via the Cauchy product turns the algebraic identity into the Vandermonde convolution for negative-binomial coefficients (vandermonde_negBinomial): ∑_{i+j=n} C(i+k₁−1, i)·C(j+k₂−1, j) = C(n+k₁+k₂−1, n). The bridge W k = (invOneSubPow S k).val is upgraded to all k (the k=0 case is W(0)=1=(invOneSubPow S 0).val); multiplicativity is then immediate from Mathlib's invOneSubPow_add, and the convolution identity is the n-th coefficient of both sides over S = ℤ, transported to ℕ by injectivity of the cast. Mathlib supplies invOneSubPow_add but has no notion of weak compositions and no negative-binomial convolution identity; both the concatenation law for the counts and the explicit binomial convolution are new here, fully machine-checked and axiom-free.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.PowerSeries.WellKnown",
+      "Mathlib.Tactic",
+      "Proofs.StarsAndBarsWeakCompositions",
+      "Proofs.StarsAndBarsWeakCompositionsOQ01"
+    ],
+    "opens": [
+      "PowerSeries",
+      "Finset"
+    ],
+    "namespace": "StarsAndBarsGenFun",
+    "lineCount": 131,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/StarsAndBarsWeakCompositionsOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Negative_binomial_distribution#Related_distributions",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StarsAndBarsWeakCompositionsOQ04.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "stars-and-bars",
+      "weak-compositions",
+      "generating-functions",
+      "power-series",
+      "vandermonde-convolution",
+      "binomial-coefficients",
+      "negative-binomial"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "relatedProblems": [
+      {
+        "id": "stars-and-bars-weak-compositions-oq-01",
+        "relationship": "Direct parent. OQ-01 identifies the weak-composition generating function W k with Mathlib's invOneSubPow S k = 1/(1−X)ᵏ and proves W k · (1−X)ᵏ = 1. This entry adds the multiplicative structure of that family — W(k₁)·W(k₂) = W(k₁+k₂) with unit W(0)=1 — and reuses OQ-01's coeff_weakCompositionGenFun and weakCompositionGenFun_eq_invOneSubPow to extract the negative-binomial Vandermonde convolution. OQ-01's own conclusion flags 'promote the count to a generating-function identity'; this is the convolution counterpart."
+      },
+      {
+        "id": "stars-and-bars-weak-compositions",
+        "relationship": "Grandparent. The parent counts weak compositions of n into k parts as C(n+k−1, n) via card_weakComposition, the closed form whose generating function OQ-01 packages and whose convolution this entry establishes. card_weakComposition is reused directly to turn coefficients of W into negative-binomial coefficients."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 131,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All four named theorems (weakCompositionGenFun_zero, weakCompositionGenFun_eq_invOneSubPow_val, weakCompositionGenFun_mul, vandermonde_negBinomial) were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The multiplicativity weakCompositionGenFun_mul and the unit weakCompositionGenFun_zero hold for all k₁, k₂, k ≥ 0. The convolution vandermonde_negBinomial is stated without positivity hypotheses: for k₁, k₂ ≥ 1 it is the genuine negative-binomial Vandermonde identity, while at k = 0 the term C(·−1,·) collapses to the indicator of 0 (matching W(0)=1), so the stated identity remains true. The ℕ identity is obtained from the ℤ-coefficient identity by exact_mod_cast (injectivity of ℕ → ℤ).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Stars and bars gives the count of weak compositions of n into k parts as the negative-binomial coefficient C(n+k−1, n), the coefficient of xⁿ in 1/(1−x)ᵏ. The generating-function identity 1/(1−x)^{k₁} · 1/(1−x)^{k₂} = 1/(1−x)^{k₁+k₂} is the exponential law of the geometric series, and its coefficientwise reading is the Vandermonde convolution for negative binomials — the precise analogue, on the 'closed' side of the duality x ↦ 1/(1−x), of the classical ∑ᵢ C(a,i)·C(b,n−i) = C(a+b,n) that expresses multiplicativity of (1+x)ᵏ. Combinatorially it is the most basic structural fact about compositions: concatenating two tuples of nonnegative parts adds both their lengths and their sums, and every long tuple factors uniquely at any prescribed cut. This entry formalises that exponential law for the enumerative generating function and reads off the convolution.",
+    "problemStatement": "Establish the multiplicative structure of the weak-composition generating function and its coefficient identity. Concretely: (1) prove the concatenation law\n\n$$W(k_1)\\cdot W(k_2) = W(k_1+k_2), \\qquad W(0)=1,$$\n\nfor the ordinary generating function $W(k)=\\sum_n \\#\\{f:\\mathrm{Fin}\\,k\\to\\mathbb N\\mid \\sum_i f(i)=n\\}\\,X^n$ over any commutative ring; and (2) deduce the negative-binomial Vandermonde convolution\n\n$$\\sum_{i+j=n} \\binom{i+k_1-1}{i}\\binom{j+k_2-1}{j} = \\binom{n+k_1+k_2-1}{n}.$$",
+    "text": "OQ-01 proved W k = (invOneSubPow S k).val for k ≥ 1, identifying the enumerative generating function with Mathlib's algebraic inverse of (1−X)ᵏ. This entry first closes the k = 0 gap — W(0) = 1, because the unique map Fin 0 → ℕ sums to 0, so only the constant coefficient survives — upgrading the bridge to all k. Multiplicativity is then transported from Mathlib's invOneSubPow_add, and the Cauchy product (PowerSeries.coeff_mul) over ℤ turns the n-th coefficient of W(k₁)·W(k₂) = W(k₁+k₂) into the binomial convolution, which descends to ℕ by injectivity of the cast.",
+    "proofStrategy": "weakCompositionGenFun_zero proves W(0) = 1 by extensionality on coefficients: coeff n (W 0) = (card {f : Fin 0 → ℕ // ∑ = n} : S) = ((n+0−1).choose n : S) via the parent card_weakComposition, which is 1 at n = 0 and 0 for n = m+1 (since m.choose (m+1) = 0 by Nat.choose_eq_zero_of_lt), matching coeff_one. weakCompositionGenFun_eq_invOneSubPow_val upgrades OQ-01's bridge to all k by a zero/positive case split: at k = 0, W(0) = 1 = (invOneSubPow S 0).val (invOneSubPow_zero, Units.val_one); for k > 0 it is OQ-01's weakCompositionGenFun_eq_invOneSubPow. weakCompositionGenFun_mul then rewrites all three generating functions to invOneSubPow values and applies invOneSubPow_add together with Units.val_mul — the multiplicativity is inherited verbatim from the units group S⟦X⟧ˣ. Finally vandermonde_negBinomial extracts coefficient n: a local lemma hWcoeff rewrites coeff m (W k) over ℤ to ((m+k−1).choose m : ℤ) via coeff_weakCompositionGenFun and card_weakComposition; applying congrArg (coeff n) to weakCompositionGenFun_mul ℤ k₁ k₂ and simplifying with PowerSeries.coeff_mul and hWcoeff yields the convolution as an identity of ℤ-casts over Finset.antidiagonal n, which exact_mod_cast transports to the ℕ statement.",
+    "keyInsights": [
+      "**Multiplicativity is inherited, not reproved.** Once W k is identified with the unit invOneSubPow S k, the concatenation law W(k₁)·W(k₂) = W(k₁+k₂) is just the image under (·).val of Mathlib's invOneSubPow_add in the units group S⟦X⟧ˣ. No combinatorial bijection of tuples is constructed; the exponential law of 1/(1−X) does all the work.",
+      "**The empty composition is the unit.** Closing the k = 0 case (W(0) = 1) is what makes the law a clean monoid statement for all k₁, k₂ ≥ 0: the unique function Fin 0 → ℕ sums to 0, so W(0) has a single nonzero coefficient, exactly the power-series 1. This is the 'empty product' boundary that OQ-01's 0 < k hypothesis had left open.",
+      "**The convolution is a coefficient, not a new theorem.** The negative-binomial Vandermonde identity ∑ C(i+k₁−1,i)·C(j+k₂−1,j) = C(n+k₁+k₂−1,n) is literally the n-th Cauchy coefficient of W(k₁)·W(k₂) = W(k₁+k₂). Proving it over ℤ and descending by exact_mod_cast avoids any direct manipulation of truncated ℕ-subtraction inside the binomials.",
+      "**Closed-side analogue of binomial Vandermonde.** Under the duality x ↦ 1/(1−x) that exchanges (1+x)ᵏ with 1/(1−x)ᵏ, this identity is the exact counterpart of the classical ∑ᵢ C(a,i)·C(b,n−i) = C(a+b,n): both say the relevant generating function is multiplicative in its exponent."
+    ],
+    "prerequisites": [
+      "Mathlib's invOneSubPow : ℕ → S⟦X⟧ˣ, with invOneSubPow_zero, invOneSubPow_add, and the units API (Units.val_one, Units.val_mul)",
+      "Ordinary power series and the Cauchy product: PowerSeries.coeff_mul over Finset.antidiagonal, PowerSeries.coeff_one, and coefficient extensionality (ext on coeff)",
+      "The parent stars-and-bars count card_weakComposition and the binomial fact Nat.choose_eq_zero_of_lt",
+      "Transporting an identity of ℤ-casts of naturals down to ℕ via exact_mod_cast (injectivity of ℕ → ℤ, Nat.cast_sum, Nat.cast_mul)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "the-unit",
+      "title": "The Empty Composition is the Unit: W(0) = 1",
+      "startLine": 65,
+      "endLine": 80,
+      "mathContext": "$W(0) = 1$ in $S\\llbracket X\\rrbracket$: the generating function of weak compositions into $0$ parts is the multiplicative unit.",
+      "summary": "weakCompositionGenFun_zero proves W(0) = 1 by coefficient extensionality. Via the parent card_weakComposition, coeff n (W 0) = ((n + 0 − 1).choose n : S); a case split on n gives 1 at n = 0 and, for n = m + 1, m.choose (m + 1) = 0 by Nat.choose_eq_zero_of_lt, matching coeff_one n = if n = 0 then 1 else 0. This is the empty-product boundary OQ-01's 0 < k hypothesis left open."
+    },
+    {
+      "id": "bridge-all-k",
+      "title": "The Generating-Function Bridge for All k",
+      "startLine": 82,
+      "endLine": 90,
+      "mathContext": "$W(k) = (\\mathrm{invOneSubPow}\\,S\\,k).\\mathrm{val} = 1/(1-X)^k$ for every $k \\ge 0$.",
+      "summary": "weakCompositionGenFun_eq_invOneSubPow_val upgrades OQ-01's bridge (proved for 0 < k) to all k by a zero/positive case split: at k = 0 it is W(0) = 1 = (invOneSubPow S 0).val via weakCompositionGenFun_zero, invOneSubPow_zero, and Units.val_one; for k > 0 it is OQ-01's weakCompositionGenFun_eq_invOneSubPow. This total bridge is what lets the multiplicativity be stated without positivity hypotheses."
+    },
+    {
+      "id": "concatenation-law",
+      "title": "The Concatenation Law W(k₁)·W(k₂) = W(k₁+k₂)",
+      "startLine": 92,
+      "endLine": 102,
+      "mathContext": "$W(k_1)\\cdot W(k_2) = W(k_1+k_2)$ in $S\\llbracket X\\rrbracket$, for all $k_1, k_2 \\ge 0$.",
+      "summary": "weakCompositionGenFun_mul rewrites all three generating functions to their invOneSubPow values via the total bridge, then applies Mathlib's invOneSubPow_add (multiplicativity of the algebraic inverse in the units group S⟦X⟧ˣ) and Units.val_mul. The multiplicative structure is inherited verbatim from the exponential law of 1/(1−X) — no tuple bijection is built."
+    },
+    {
+      "id": "vandermonde-convolution",
+      "title": "The Negative-Binomial Vandermonde Convolution",
+      "startLine": 106,
+      "endLine": 131,
+      "mathContext": "$\\sum_{i+j=n} \\binom{i+k_1-1}{i}\\binom{j+k_2-1}{j} = \\binom{n+k_1+k_2-1}{n}$.",
+      "summary": "vandermonde_negBinomial extracts coefficient n of the concatenation law over ℤ. A local hWcoeff rewrites coeff m (W k) to ((m+k−1).choose m : ℤ) via coeff_weakCompositionGenFun and card_weakComposition. Applying congrArg (coeff n) to weakCompositionGenFun_mul ℤ k₁ k₂ and simplifying with PowerSeries.coeff_mul and hWcoeff produces the convolution as an identity of ℤ-casts over Finset.antidiagonal n; exact_mod_cast descends it to ℕ. Stated without positivity: for k₁, k₂ ≥ 1 it is the genuine negative-binomial Vandermonde identity."
+    }
+  ],
+  "conclusion": {
+    "summary": "The weak-composition generating function is shown to be multiplicative in the number of parts: W(k₁)·W(k₂) = W(k₁+k₂) with unit W(0) = 1, an exponential law inherited from Mathlib's invOneSubPow_add once OQ-01's bridge is completed to all k. Reading off the n-th Cauchy coefficient turns this into the negative-binomial Vandermonde convolution ∑_{i+j=n} C(i+k₁−1, i)·C(j+k₂−1, j) = C(n+k₁+k₂−1, n), the closed-side analogue of the classical ∑ C(a,i)·C(b,n−i) = C(a+b,n). Everything is axiom-free and reuses the parent's card_weakComposition and OQ-01's coefficient machinery.",
+    "implications": "The concatenation law packages the most basic structural fact about compositions — that concatenation adds both length and weight — as a one-line consequence of the units group of S⟦X⟧, making the negative-binomial convolution available as a reusable lemma without any ℕ-subtraction bookkeeping in the binomials. Together with the parent (count), OQ-01 (generating function), OQ-02 (bounded parts) and OQ-03 (positive parts), the gallery now records the multiplicative/convolutive layer of the stars-and-bars circle.",
+    "openQuestions": [
+      "Iterate the law to a k-fold convolution: W(k) = W(1)ᵏ recovers C(n+k−1, n) as the k-fold self-convolution of the all-ones sequence (the coefficient of Xⁿ in 1/(1−X)ᵏ), giving a generating-function proof of stars and bars itself from the geometric series.",
+      "State the bijective witness behind the convolution: an explicit Equiv {f : Fin (k₁+k₂) → ℕ // ∑ = n} ≃ Σ p ∈ antidiagonal n, ({Fin k₁ → ℕ // ∑ = p.1} × {Fin k₂ → ℕ // ∑ = p.2}) by splitting a tuple at index k₁, refining the coefficient identity to a cardinality-of-sigma bijection."
+    ]
+  },
+  "crossReferences": [
+    "stars-and-bars-weak-compositions-oq-01",
+    "stars-and-bars-weak-compositions"
+  ]
+}

--- a/src/data/research/problems/erdos-1005-oq-02.json
+++ b/src/data/research/problems/erdos-1005-oq-02.json
@@ -65,7 +65,8 @@
       "continuant_prod_deficit (Erdos1005ProblemOQ02.lean §29): secondCont rest ≤ (k::rest).prod − Continuant(k::rest) for all-≥2",
       "continuant_lt_prod (§29): |ks|≥2 ∧ all-≥2 ⟹ Continuant ks < ks.prod (strict §28 ceiling)",
       "continuant_eq_prod_iff (§29): all-≥2 ⟹ (Continuant ks = ks.prod ⟺ ks.length ≤ 1)",
-      "continuant_lt_prod_example (§29): K[3,3]=8 < 9, deficit 1 = secondCont[3]"
+      "continuant_lt_prod_example (§29): K[3,3]=8 < 9, deficit 1 = secondCont[3]",
+      "continuant_ge_pow, pow_sub_one_le_prod_sub_one, continuant_pow_run_length_le, continuant_run_length_le_log, continuant_ge_pow_example in Erdos1005ProblemOQ02.lean §30 (VERIFIED 0-axiom)"
     ],
     "insights": [
       "CORRECTION: the roadmap heuristic that the order-n cap forces O(log n) refinement depth is FALSE for arbitrary mediant chains. The one-sided chain 0/1,1/2,1/3,…,1/n fits Θ(n) levels under q≤n with only LINEAR denominator growth (k+1)·b+d.",
@@ -88,7 +89,9 @@
       "The period-6 leading-1 rotation (§23) brackets a large-quotient block on BOTH ends identically: trailing 1s reduce to leading 1s on the reversed tail via continuant_reverse, transferring the entire orbit and the IDENTICAL sign classification at zero arithmetic cost",
       "Session 2026-06-30 (researcher-2): §26 quotient-weighted continuant growth. continuant_ge_length_weighted (d≥2, entries≥d): (d-1)|ks|+1 ≤ Continuant ks — sharpens §17's slope-1 bound to slope (d-1). Corollary continuant_run_length_le: a continuant ceiling N caps run length at |ks| ≤ (N-1)/(d-1), the targeted O(n/d) bound (first d-sensitive run-length cap). Integrality (secondCont+1 ≤ Continuant) is essential — equality is attained. 0-axiom docker-verified [3058/3058]. Still open: the order-n continuant ceiling + admissible-list count (the 1/12-1/4 density step).",
       "§29: The §28 product ceiling K ≤ ∏kᵢ is tight ONLY at depths |ks| ≤ 1 (K[]=1=∏[], K[k]=k=∏[k]); strict for |ks| ≥ 2. Equality locus characterized: continuant_eq_prod_iff ⟺ length ≤ 1.",
-      "§29: Quantitative deficit — the product overshoots the continuant by AT LEAST the trailing continuant of the tail: secondCont rest ≤ (k::rest).prod − Continuant(k::rest), since residual k·(∏rest−K rest) ≥ 0 by §28 continuant_le_prod. The minus-continuant pays an accumulated-trailing-continuant loss vs the naive product."
+      "§29: Quantitative deficit — the product overshoots the continuant by AT LEAST the trailing continuant of the tail: secondCont rest ≤ (k::rest).prod − Continuant(k::rest), since residual k·(∏rest−K rest) ≥ 0 by §28 continuant_le_prod. The minus-continuant pays an accumulated-trailing-continuant loss vs the naive product.",
+      "§30: formalized the geometric continuant floor (d-1)^|ks| ≤ Continuant ks on all-≥d runs (continuant_ge_pow), chaining (d-1)^|ks| ≤ ∏(kᵢ-1) through §28 product floor; the multiplicative/geometric companion to §26 additive slope-(d-1) bound.",
+      "§30: continuant_run_length_le_log — for d≥3 a continuant ceiling N caps run length logarithmically |ks| ≤ Nat.log (d-1) N, the exponential sharpening of §26 O(N/d) additive cap; formalizes the logarithmic run-length cap previously only stated in §26/§28 prose. Silent at density bottleneck d=2 (base d-1=1 vacuous)."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **erdos-1005-oq-02** (Erdős #1005: longest run of similarly-ordered Farey fractions; open leading constant `c ∈ [1/12, 1/4]`). Adds **§30** to `Erdos1005ProblemOQ02.lean`, formalizing a geometric continuant lower bound and the **logarithmic run-length cap** that §26/§28 had only stated in prose.

## Progress
§26 gives the *additive* slope-`(d−1)` bound `(d−1)·|ks| + 1 ≤ K`; §28 gives the *product floor* `∏(kᵢ−1) ≤ K`. Both repeatedly advertise the consequence "`∏(kᵢ−1) ≥ (d−1)^|ks|`, so `K ≤ N` forces `|ks| ≤ log_{d−1} N`" — but never proved the geometric bound or its log corollary. §30 supplies them:

- `pow_sub_one_le_prod_sub_one` (`d ≥ 2`): `(d−1)^|ks| ≤ ∏(kᵢ−1)` (each decremented factor `≥ d−1`; induction via `mul_le_mul`).
- `continuant_ge_pow` (**headline**, `d ≥ 2`): `(d−1)^|ks| ≤ Continuant ks` — chains the above through §28's `prod_sub_one_le_continuant`; the geometric companion to §26's additive bound.
- `continuant_pow_run_length_le`: ceiling `N` ⟹ `(d−1)^|ks| ≤ N` (power form).
- `continuant_run_length_le_log` (`d ≥ 3`): `|ks| ≤ Nat.log (d−1) N` — the actual logarithmic cap, an exponential improvement over §26's `O(N/d)`.
- `continuant_ge_pow_example`: `2³ = 8 ≤ K[3,3,3] = 21`.

## Files Modified
- `proofs/Proofs/Erdos1005ProblemOQ02.lean` (§30, 5 new theorems)
- `src/data/proofs/erdos-1005-oq-02/meta.json` (synced drifted `leanFile` counts 168→177 thm, 2814→2990 lines)
- `src/data/research/problems/erdos-1005-oq-02.json` (insights)
- `research/problems/erdos-1005-oq-02/knowledge.md` (session log)

## Verification
**0-axiom, 0-sorry.** Built via host `lake env lean` (Docker host down); `#print axioms` on the new headlines = `propext / Classical.choice / Quot.sound` only — no `sorryAx`, no `Lean.ofReduceBool`.

## Status
**Outcome**: progress (VERIFIED). The continuant calculus is sharpened; the geometric/metric half of the run-length trade-off is now explicit.

**Honest boundary**: the geometric cap bites only on the large-quotient `d ≥ 3` tail. At the density bottleneck `d = 2` the base `d−1 = 1` makes `(d−1)^|ks| = 1` vacuous (matching `K[2,…,2] = m+1`, linear growth), so the open `1/12`–`1/4` constant — governed by the small-quotient regime — remains untouched. This does **not** resolve Erdős #1005.

**Next Steps**: density aggregation toward `1/12` (combine large-quotient growth, §21–25 period-6 1-run laws, and §30's cap to model `1ᵃ ++ ms ++ 1ᵇ` against the order-`n` denominator cap) remains the open hard step.

🤖 Generated by researcher-10