### PR TITLE
research(area-of-circle-oq-03-oq-02-oq-01): sharp 1/6 convergence-rate constant [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ03OQ02OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ03OQ02OQ01.lean
@@ -254,6 +254,59 @@ theorem pi_sub_halfPerimeter_le {m : ℕ} (hm : 4 ≤ m) :
   rw [← hx, hgoal_rw]
   linarith [hstep]
 
+/-- **Sharp `1/6` leading-constant convergence rate** (answers the second open
+question). The earlier `7/32` bound is lossy because it absorbs the quartic Taylor
+remainder `x⁴ ≤ x³` into the cubic term. Keeping the quartic remainder *separate*
+recovers the error with its **exact** second-order coefficient `1/6`:
+`π - p(m) ≤ π³/(6 m²) + (5/96)·π⁴/m³` for `m ≥ 4`.
+
+The leading term `π³/(6 m²)` matches the true Taylor coefficient `1/6` of
+`π - m·sin(π/m) = m(π/m)³/6 + O(m⁻³)`; the trailing `O(1/m³)` term carries the rest.
+(For `m ≥ 4` one has `π/m ≤ 1`, so `(5/96)π⁴/m³ ≤ (5/96)π³/m²` and the bound collapses
+back to `(1/6 + 5/96)π³/m² = (7/32)π³/m²`, recovering `pi_sub_halfPerimeter_le`.) -/
+theorem pi_sub_halfPerimeter_le_sharp {m : ℕ} (hm : 4 ≤ m) :
+    Real.pi - halfPerimeter m
+      ≤ Real.pi ^ 3 / (6 * (m : ℝ) ^ 2) + 5 / 96 * Real.pi ^ 4 / (m : ℝ) ^ 3 := by
+  have hπ := Real.pi_pos
+  have hm' : (4 : ℝ) ≤ (m : ℝ) := by exact_mod_cast hm
+  have hmpos : (0 : ℝ) < (m : ℝ) := by linarith
+  have hmne : (m : ℝ) ≠ 0 := ne_of_gt hmpos
+  set x := Real.pi / (m : ℝ) with hx
+  have hxpos : 0 < x := by rw [hx]; positivity
+  have hπlt : Real.pi < 4 := Real.pi_lt_four
+  have hx1 : x ≤ 1 := by rw [hx, div_le_one hmpos]; linarith
+  -- Taylor lower bound on sin from Real.sin_bound, keeping the quartic term
+  have hbound := Real.sin_bound (x := x) (by rw [abs_of_pos hxpos]; exact hx1)
+  rw [abs_of_pos hxpos] at hbound
+  have hlow : x - x ^ 3 / 6 - x ^ 4 * (5 / 96) ≤ Real.sin x := by
+    have := (abs_le.mp hbound).1; linarith
+  -- scale by m, using m·x = π, m·x³ = π³/m², m·x⁴ = π⁴/m³ (all in one ring step)
+  have key : (m : ℝ) * (x - x ^ 3 / 6 - x ^ 4 * (5 / 96))
+      = Real.pi - Real.pi ^ 3 / (6 * (m : ℝ) ^ 2) - 5 / 96 * Real.pi ^ 4 / (m : ℝ) ^ 3 := by
+    rw [hx]; field_simp
+  have hscaled : (m : ℝ) * (x - x ^ 3 / 6 - x ^ 4 * (5 / 96)) ≤ (m : ℝ) * Real.sin x :=
+    mul_le_mul_of_nonneg_left hlow hmpos.le
+  rw [key] at hscaled
+  simp only [halfPerimeter]
+  rw [← hx]
+  linarith [hscaled]
+
+/-- The sharp bound in factored "`1/6 + o(1)`" form:
+`π - p(m) ≤ (π³/(6 m²))·(1 + 5π/(16 m))`, exhibiting the leading constant `1/6`
+with a relative correction `5π/(16 m) → 0`. As `m → ∞` the bracket tends to `1`,
+so the second-order coefficient is exactly `1/6` (the true Taylor value), not `7/32`. -/
+theorem pi_sub_halfPerimeter_le_sharp_factored {m : ℕ} (hm : 4 ≤ m) :
+    Real.pi - halfPerimeter m
+      ≤ Real.pi ^ 3 / (6 * (m : ℝ) ^ 2) * (1 + 5 * Real.pi / (16 * (m : ℝ))) := by
+  have hm' : (4 : ℝ) ≤ (m : ℝ) := by exact_mod_cast hm
+  have hmpos : (0 : ℝ) < (m : ℝ) := by linarith
+  have hmne : (m : ℝ) ≠ 0 := ne_of_gt hmpos
+  have h := pi_sub_halfPerimeter_le_sharp hm
+  have heq : Real.pi ^ 3 / (6 * (m : ℝ) ^ 2) + 5 / 96 * Real.pi ^ 4 / (m : ℝ) ^ 3
+      = Real.pi ^ 3 / (6 * (m : ℝ) ^ 2) * (1 + 5 * Real.pi / (16 * (m : ℝ))) := by
+    field_simp; ring
+  exact h.trans_eq heq
+
 -- ============================================================
 -- PART VI: Summary
 -- ============================================================

--- a/research/problems/area-of-circle-oq-03-oq-02-oq-01/knowledge.md
+++ b/research/problems/area-of-circle-oq-03-oq-02-oq-01/knowledge.md
@@ -6,16 +6,55 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Archimedes' half-angle doubling method for computing π, formalized constructively in
+`Proofs/AreaOfCircleOQ03OQ02OQ01.lean`. Core entry (doubling radicals, hexagon seed,
+nested-radical realization, monotonicity/upper bound/convergence, and an explicit
+`O(1/m²)` rate) was already complete and 0-axiom. Two open questions remained: (1) recover
+the rational `223/71` bound from the doubling recurrence without `pi_gt_d4`; (2) sharpen the
+convergence-rate constant `7/32 → 1/6`.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **Open question 2 is resolved by NOT being lossy.** The existing `pi_sub_halfPerimeter_le`
+  proves `π − p(m) ≤ (7/32)π³/m²` by taking `Real.sin_bound`
+  (`sin x ≥ x − x³/6 − (5/96)x⁴`) and absorbing `x⁴ ≤ x³` into the cubic term
+  (`1/6 + 5/96 = 7/32`). Keeping the quartic remainder **separate** and scaling by `m`
+  (`m·x = π`, `m·x³ = π³/m²`, `m·x⁴ = π⁴/m³`) gives the sharp two-term bound
+  `π − p(m) ≤ π³/(6m²) + (5/96)·π⁴/m³` with the **exact** leading coefficient `1/6`
+  (`pi_sub_halfPerimeter_le_sharp`).
+- **Factored "1/6 + o(1)" form**: `π − p(m) ≤ (π³/(6m²))·(1 + 5π/(16m))`
+  (`pi_sub_halfPerimeter_le_sharp_factored`) — the bracket `→ 1`, so the second-order
+  coefficient is exactly `1/6`. Derived from the two-term bound by a single algebraic
+  identity (`field_simp; ring`) and `le.trans_eq`.
+- **Consistency**: for `m ≥ 4` one has `π/m ≤ 1`, so `(5/96)π⁴/m³ ≤ (5/96)π³/m²` and the
+  sharp bound collapses to the earlier `7/32` bound — the old result is the `m ≥ 4`
+  specialization of the new one.
+
+## Reusable techniques
+
+- **Don't pre-absorb Taylor remainders if you want the sharp constant.** Scaling each Taylor
+  term by `m` separately preserves the exact leading coefficient; absorbing `xⁿ⁺¹ ≤ xⁿ`
+  (valid for `x ≤ 1`) is only for a single-term bound and inflates the constant.
+- **`m`-scaling identities in one shot**: `have key : (m:ℝ)*(x - x³/6 - x⁴*(5/96)) = π - π³/(6m²) - (5/96)π⁴/m³ := by rw [hx]; field_simp`. With `x = π/m` and `m ≠ 0`, `field_simp` alone closes it (do NOT append `ring` — it errors with "No goals").
+- `Real.sin_bound (hx : |x| ≤ 1) : |sin x − (x − x³/6)| ≤ |x|⁴·(5/96)`; combine
+  `abs_of_pos` + `(abs_le.mp …).1` to extract the lower bound.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Appending `ring` after `field_simp` on the `key` `m`-scaling identity fails with
+  "No goals to be solved" — `field_simp` fully discharges that particular goal. (The
+  factored-form `heq` identity, by contrast, does need the trailing `ring`.)
+
+---
+
+## Session log
+
+- **2026-06-30 (researcher-3)**: Added `pi_sub_halfPerimeter_le_sharp` and
+  `pi_sub_halfPerimeter_le_sharp_factored` (answers open question 2). File now 329 LOC,
+  11 thm, 1 def, 0 axiom, 0 sorry. Slug is depth-3 (`-oq-03-oq-02-oq-01`) → no new OQ
+  children proposed; enriched the existing entry in place. Verified host `lake env lean`
+  (docker down), `#print axioms` = propext/Classical.choice/Quot.sound only.

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
@@ -60,14 +60,16 @@
       "Strict monotonicity under doubling: p(n) < p(2n) for all n ≥ 1 (fully proved)",
       "Upper bound: p(m) < π for all m ≥ 1 (fully proved)",
       "Convergence: p(m) → π as m → ∞, by squeezing π·cos(π/m) ≤ p(m) < π (fully proved)",
-      "Explicit convergence rate: π − p(m) ≤ (7/32)·π³/m² for m ≥ 4 (quadratic in 1/m), proved from the sin Taylor estimate Real.sin_bound by absorbing the quartic remainder into the cubic term — gives π − p(2ᵏ) = O(4⁻ᵏ) (fully proved)"
+      "Explicit convergence rate: π − p(m) ≤ (7/32)·π³/m² for m ≥ 4 (quadratic in 1/m), proved from the sin Taylor estimate Real.sin_bound by absorbing the quartic remainder into the cubic term — gives π − p(2ᵏ) = O(4⁻ᵏ) (fully proved)",
+      "Sharp 1/6 leading-constant rate (pi_sub_halfPerimeter_le_sharp): keeping the quartic Taylor remainder separate instead of absorbing it gives π − p(m) ≤ π³/(6m²) + (5/96)·π⁴/m³ for m ≥ 4, with the EXACT second-order Taylor coefficient 1/6 (not 7/32); answers the entry's second open question",
+      "Factored form pi_sub_halfPerimeter_le_sharp_factored: π − p(m) ≤ (π³/(6m²))·(1 + 5π/(16m)), exhibiting leading constant 1/6 with a relative correction 5π/(16m) → 0; for m ≥ 4 it collapses to the earlier 7/32 bound since 1/6 + 5/96 = 7/32"
     ],
     "dateAdded": "2026-06-28",
     "axiomCount": 0,
     "assumptions": "Fully verified: 0 axioms, 0 sorries remain.",
-    "lineCount": 276,
+    "lineCount": 329,
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 1
   },
   "overview": {
@@ -134,24 +136,32 @@
       "title": "Explicit Convergence Rate",
       "summary": "pi_sub_halfPerimeter_le: π − p(m) ≤ (7/32)·π³/m² for m ≥ 4, an explicit O(1/m²) error bound. Proved from Real.sin_bound (sin x ≥ x − x³/6 − (5/96)x⁴) by absorbing x⁴ ≤ x³ into the cubic term, then scaling by m.",
       "startLine": 205,
-      "endLine": 257,
+      "endLine": 266,
       "mathContext": "With $x=\\pi/m\\le 1$, the Taylor estimate gives $\\sin x \\ge x - \\tfrac{7}{32}x^3$ (since $\\tfrac16+\\tfrac{5}{96}=\\tfrac{7}{32}$). Multiplying by $m$ and using $mx=\\pi$, $mx^3=\\pi^3/m^2$ yields $p(m)\\ge \\pi-\\tfrac{7}{32}\\pi^3/m^2$, i.e. the doubling error is $O(4^{-k})$ for $m=c\\,2^k$."
+    },
+    {
+      "id": "sharp-rate",
+      "title": "Sharp 1/6 Leading-Constant Rate",
+      "summary": "pi_sub_halfPerimeter_le_sharp: keeping the quartic Taylor remainder separate (instead of absorbing x⁴ ≤ x³) gives π − p(m) ≤ π³/(6m²) + (5/96)·π⁴/m³ for m ≥ 4, with the EXACT second-order coefficient 1/6. The factored form pi_sub_halfPerimeter_le_sharp_factored writes this as (π³/(6m²))·(1 + 5π/(16m)), exhibiting 1/6 + o(1). Answers the entry's second open question.",
+      "startLine": 267,
+      "endLine": 310,
+      "mathContext": "The error $\\pi - m\\sin(\\pi/m) = m(\\pi/m)^3/6 + O(m^{-3})$ has true leading coefficient $\\tfrac16$. Multiplying $\\sin x \\ge x - x^3/6 - \\tfrac{5}{96}x^4$ by $m$ keeps both terms: $\\pi - p(m) \\le \\tfrac{\\pi^3}{6m^2} + \\tfrac{5}{96}\\tfrac{\\pi^4}{m^3}$. For $m\\ge4$, $\\pi/m\\le1$ collapses this to the earlier $\\tfrac{7}{32}\\pi^3/m^2$ bound (since $\\tfrac16+\\tfrac{5}{96}=\\tfrac{7}{32}$)."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
       "summary": "Packaging theorem bundling the doubling identity, hexagon seed, monotonicity, upper bound, and convergence into one statement.",
-      "startLine": 258,
-      "endLine": 276,
+      "startLine": 311,
+      "endLine": 329,
       "mathContext": "The bundled result asserts the doubling radical holds for all $n \\ge 1$, $p(6) = 3$, $p(n) < p(2n)$, $p(m) < \\pi$, and $p(m) \\to \\pi$ — Archimedes' method, formalized end to end."
     }
   ],
   "conclusion": {
     "summary": "This entry answers affirmatively the open question of whether Archimedes' half-angle doubling method can be formalized constructively. The doubling radical √((1−cos)/2) is derived for all n, the inscribed half-perimeters are exhibited as a computable nested radical, and they are proved to increase strictly under doubling, remain below π, and converge to π. Fully verified: 0 axioms, 0 sorries.",
-    "implications": "Where the parent entry verified Archimedes' final numbers from Mathlib's precomputed π bounds, this entry formalizes the algorithm that generates them and proves its convergence — making the 2,300-year-old method of exhaustion a fully machine-checked, constructive computation of π.",
+    "implications": "Where the parent entry verified Archimedes' final numbers from Mathlib's precomputed π bounds, this entry formalizes the algorithm that generates them and proves its convergence — making the 2,300-year-old method of exhaustion a fully machine-checked, constructive computation of π. The convergence rate is now pinned to its exact second-order Taylor coefficient: π − p(m) ≤ π³/(6m²) + (5/96)·π⁴/m³, with leading constant 1/6 (not the lossy 7/32), and the earlier 7/32 bound is recovered as the m ≥ 4 collapse of the sharp two-term estimate.",
     "openQuestions": [
       "Can Archimedes' rational square-root bounds (how he approximated √3 and the nested radicals by hand) be formalized to recover his exact 223/71 bound purely from the doubling recurrence, without invoking Mathlib's pi_gt_d4?",
-      "Sharpen the convergence-rate constant: the proved bound π − p(m) ≤ (7/32)·π³/m² is not tight (the true leading term is π³/(6m²)); can the (7/32) factor be reduced to 1/6 + o(1), matching the exact second-order Taylor coefficient?"
+      "RESOLVED (pi_sub_halfPerimeter_le_sharp): the convergence-rate leading constant is now the exact π³/(6m²) (coefficient 1/6), with an explicit O(1/m³) correction (5/96)·π⁴/m³, and the factored form (π³/(6m²))·(1 + 5π/(16m)) shows the 1/6 + o(1) behaviour directly. Remaining: a matching lower bound π − p(m) ≥ (1/6 − o(1))π³/m² to prove the rate is two-sided tight."
     ]
   },
   "crossReferences": [
@@ -186,9 +196,9 @@
       "Topology"
     ],
     "namespace": "AreaOfCircleOQ03OQ02OQ01",
-    "lineCount": 223,
+    "lineCount": 329,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 11,
     "definitionCount": 1,
     "mainTheorems": [
       "archimedes_sin_doubling",
@@ -198,6 +208,9 @@
       "halfPerimeter_doubling",
       "halfPerimeter_lt_pi",
       "halfPerimeter_tendsto_pi",
+      "pi_sub_halfPerimeter_le",
+      "pi_sub_halfPerimeter_le_sharp",
+      "pi_sub_halfPerimeter_le_sharp_factored",
       "archimedes_doubling_method_verified"
     ],
     "path": "Proofs/AreaOfCircleOQ03OQ02OQ01.lean",


### PR DESCRIPTION
## Summary

Answers the **second open question** of the `area-of-circle-oq-03-oq-02-oq-01` entry (Archimedes' half-angle doubling method): sharpen the convergence-rate leading constant from the lossy `7/32` to the exact Taylor value `1/6`.

## The improvement

The existing `pi_sub_halfPerimeter_le` proves `π − p(m) ≤ (7/32)·π³/m²` (m ≥ 4) by taking the Taylor estimate `Real.sin_bound` (`sin x ≥ x − x³/6 − (5/96)x⁴`) and **absorbing** `x⁴ ≤ x³` into the cubic term (`1/6 + 5/96 = 7/32`). That inflates the leading constant. Keeping the quartic remainder **separate** and scaling by m (`m·x = π`, `m·x³ = π³/m²`, `m·x⁴ = π⁴/m³`) recovers the exact coefficient:

- `pi_sub_halfPerimeter_le_sharp` (m ≥ 4): `π − p(m) ≤ π³/(6m²) + (5/96)·π⁴/m³` — leading constant exactly **1/6**, the true second-order Taylor coefficient of `π − m·sin(π/m)`.
- `pi_sub_halfPerimeter_le_sharp_factored`: `π − p(m) ≤ (π³/(6m²))·(1 + 5π/(16m))` — the explicit **1/6 + o(1)** form; the bracket → 1 as m → ∞.

**Consistency**: for m ≥ 4, `π/m ≤ 1` makes `(5/96)π⁴/m³ ≤ (5/96)π³/m²`, collapsing the sharp bound back to the earlier `7/32` bound — so the new estimate subsumes the old.

## Verification

Docker daemon down this session → verified on host via `lake env lean`: **0 errors, exit 0**. `#print axioms` on both new theorems shows only `propext, Classical.choice, Quot.sound`. File: 11 thm, 1 def, **0 axiom, 0 sorry**. 53 lines added (pure additions). Gallery `meta.json` counts, sections, and open-questions updated.

Note: the slug is a depth-3 OQ chain, so per the depth guard no new OQ child entries are proposed — this enriches the existing entry in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)