### PR TITLE
Fix: erdos-1011-oq-03 axiom undercount false positive

### DIFF
--- a/src/data/proofs/erdos-1011-oq-03/meta.json
+++ b/src/data/proofs/erdos-1011-oq-03/meta.json
@@ -10,7 +10,6 @@
     "status": "verified",
     "proofRepoPath": "Proofs/Erdos1011OQ03.lean",
     "additionalFiles": [
-      "Proofs/Erdos1011Problem.lean",
       "Proofs/GraphCore.lean"
     ],
     "tags": [
@@ -163,7 +162,6 @@
     "path": "Proofs/Erdos1011OQ03.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/Erdos1011Problem.lean",
       "Proofs/GraphCore.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Resolves an auditor finding: **\"axiom undercount: claims 0, actual declarations 5\"** on `erdos-1011-oq-03`.

## Root cause

The child entry `erdos-1011-oq-03` listed its imported parent `Proofs/Erdos1011Problem.lean` in `additionalFiles`. That parent declares 5 `axiom`s (the known f₂/f₃ values and bounds on g(r)). The canonical auditor (`scripts/auditor/find-targets.ts`) sums an entry's additionalFiles axioms against the entry, producing a false "actual declarations 5" while the child genuinely claims 0.

## Verification (genuinely 0-axiom)

- `Erdos1011OQ03.lean` has **no** `axiom` declarations.
- None of the 5 parent axiom names appear anywhere in the child source.
- Host `lean` build (v4.26.0) of `#print axioms` for every theorem — `f_antitone_in_chromatic`, `forces_iff_f_le`, `f_eq_zero_of_lt`, `chromaticShift_known` — reports only `propext / Classical.choice / Quot.sound` (and `chromaticShift_known` depends on none).

## Change

Remove `Proofs/Erdos1011Problem.lean` from both `additionalFiles` blocks (the parent's own gallery entry `erdos-1011` already discloses `axiomCount: 5`). The non-axiom shared library `GraphCore.lean` is kept. The `assumptions` prose already documents that the parent's 5 axioms are unused.

**Before**: auditor flags axiom undercount (0 vs 5).
**After**: `find-targets.ts --issues` no longer flags this entry.

---
Automated fix by lean-mechanic agent.