### PR TITLE
research(hilbert-17-oq-01-oq-01-oq-01): exact Fejér–Riesz normalization + PSD structural facts [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/Hilbert17OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/Hilbert17OQ01OQ01OQ01.lean
@@ -1,0 +1,203 @@
+/-
+  Hilbert's 17th problem, univariate case — STRUCTURAL sharpening of the
+  two-squares decomposition.
+
+  The parent file `Proofs/Hilbert17OQ01OQ01.lean` proves the degree-sharp
+  Fejér–Riesz statement: every nonnegative real univariate polynomial `p` is a
+  sum of two squares `p = u² + v²` with `2·deg u ≤ deg p` and `2·deg v ≤ deg p`.
+  That is an *upper* bound on the certificate size.
+
+  This file pins down the certificate exactly, via one elementary structural
+  fact that the parent never isolates:
+
+      a sum of two polynomial squares has NO degree collapse —
+      `deg (u² + v²) = 2 · max (deg u) (deg v)`.
+
+  The leading coefficients of `u²` and `v²` are both squares, hence nonnegative,
+  so they can never cancel.  Three consequences follow:
+
+    * `IsPSD.natDegree_even`     — a nonzero PSD polynomial has EVEN degree.
+    * `IsPSD.leadingCoeff_pos`   — its leading coefficient is strictly positive.
+    * `univariate_psd_two_sos_degree_exact` — the precise Fejér–Riesz
+        normalization (the parent file's own stated open question): for `p ≠ 0`
+        there is a decomposition `p = u² + v²` with `deg v < deg u` and
+        `2·deg u = deg p`, i.e. one square has degree exactly `½·deg p` and the
+        other strictly less.  The construction is an explicit orthogonal rotation
+        `(u,v) = (c·a + s·b, c·b − s·a)` (with `c² + s² = 1`) of any existing
+        decomposition `p = a² + b²`, chosen to kill the top coefficient of `v`.
+
+  Like the parent, this file is fully elementary and 0-axiom.
+-/
+import Mathlib
+import Proofs.Hilbert17OQ01OQ01
+
+namespace Hilbert17OQ01OQ01OQ01
+
+open Polynomial
+open Hilbert17UnivariatePSDSOS (IsPSD)
+
+/-- **Coefficient of a square at twice a degree ceiling.**  If `deg w ≤ n`, then
+the coefficient of `w²` at index `2n` is exactly `(w.coeff n)²` — it picks out the
+diagonal term and nothing else.  (For `deg w < n` both sides are `0`; for
+`deg w = n` it is the leading coefficient of `w²`.) -/
+theorem coeff_sq_two (w : ℝ[X]) (n : ℕ) (hw : w.natDegree ≤ n) :
+    (w ^ 2).coeff (2 * n) = (w.coeff n) ^ 2 := by
+  rcases lt_or_eq_of_le hw with hlt | heq
+  · -- deg w < n : both sides vanish
+    rw [coeff_eq_zero_of_natDegree_lt (lt_of_le_of_lt natDegree_pow_le (by omega)),
+      coeff_eq_zero_of_natDegree_lt hlt]
+    ring
+  · -- deg w = n : leading coefficient
+    rcases eq_or_ne w 0 with rfl | hw0
+    · simp
+    · have hnd2 : (w ^ 2).natDegree = 2 * n := by
+        rw [pow_two, natDegree_mul hw0 hw0, heq]; ring
+      rw [← hnd2, pow_two w,
+        show (w * w).coeff (w * w).natDegree = (w * w).leadingCoeff from rfl,
+        leadingCoeff_mul, show w.leadingCoeff = w.coeff w.natDegree from rfl, heq, pow_two]
+
+/-- **No degree collapse for a sum of two squares.**  Over `ℝ`,
+`deg (u² + v²) = 2 · max (deg u) (deg v)`: the leading coefficients of the two
+squares are nonnegative and cannot cancel. -/
+theorem natDegree_sq_add_sq (u v : ℝ[X]) :
+    (u ^ 2 + v ^ 2).natDegree = 2 * max u.natDegree v.natDegree := by
+  -- A symmetric helper handling the case where `u` carries the maximal degree.
+  have key : ∀ (p q : ℝ[X]), p ≠ 0 → q ≠ 0 → q.natDegree ≤ p.natDegree →
+      (p ^ 2 + q ^ 2).natDegree = 2 * p.natDegree := by
+    intro p q hp hq hqp
+    have hdp : (p ^ 2).natDegree = 2 * p.natDegree := by
+      rw [pow_two, natDegree_mul hp hp]; ring
+    have hdq : (q ^ 2).natDegree = 2 * q.natDegree := by
+      rw [pow_two, natDegree_mul hq hq]; ring
+    refine le_antisymm ?_ ?_
+    · calc (p ^ 2 + q ^ 2).natDegree
+          ≤ max (p ^ 2).natDegree (q ^ 2).natDegree := natDegree_add_le _ _
+        _ = 2 * p.natDegree := by rw [hdp, hdq, max_eq_left (by omega)]
+    · apply le_natDegree_of_ne_zero
+      have hcp : (p ^ 2).coeff (2 * p.natDegree) = (p.coeff p.natDegree) ^ 2 :=
+        coeff_sq_two p p.natDegree le_rfl
+      have hcq : 0 ≤ (q ^ 2).coeff (2 * p.natDegree) := by
+        rw [coeff_sq_two q p.natDegree hqp]; positivity
+      have hlc : p.coeff p.natDegree ≠ 0 := by
+        rw [show p.coeff p.natDegree = p.leadingCoeff from rfl]
+        exact leadingCoeff_ne_zero.mpr hp
+      have hpos : 0 < (p ^ 2 + q ^ 2).coeff (2 * p.natDegree) := by
+        rw [coeff_add, hcp]
+        have : 0 < (p.coeff p.natDegree) ^ 2 := by positivity
+        linarith
+      exact hpos.ne'
+  rcases eq_or_ne u 0 with rfl | hu
+  · rcases eq_or_ne v 0 with rfl | hv
+    · simp
+    · rw [zero_pow (two_ne_zero), zero_add, natDegree_zero, max_eq_right (Nat.zero_le _),
+        pow_two, natDegree_mul hv hv]; ring
+  rcases eq_or_ne v 0 with rfl | hv
+  · rw [zero_pow (two_ne_zero), add_zero, natDegree_zero, max_eq_left (Nat.zero_le _),
+      pow_two, natDegree_mul hu hu]; ring
+  rcases le_total v.natDegree u.natDegree with h | h
+  · rw [max_eq_left h]; exact key u v hu hv h
+  · rw [max_eq_right h, add_comm (u ^ 2) (v ^ 2)]; exact key v u hv hu h
+
+/-- **A nonzero PSD univariate polynomial has even degree.**  Immediate from the
+two-squares decomposition and the no-collapse lemma. -/
+theorem IsPSD.natDegree_even {p : ℝ[X]} (h : IsPSD p) : Even p.natDegree := by
+  obtain ⟨u, v, huv⟩ := Hilbert17OQ01OQ01.univariate_psd_is_two_sos p h
+  rw [huv, natDegree_sq_add_sq]
+  exact ⟨max u.natDegree v.natDegree, by ring⟩
+
+/-- **A nonzero PSD univariate polynomial has positive leading coefficient.**
+Writing `p = u² + v²`, the leading coefficient equals `(u.coeff n)² + (v.coeff n)²`
+at `n = ½·deg p`, which is nonnegative and nonzero because `p ≠ 0`. -/
+theorem IsPSD.leadingCoeff_pos {p : ℝ[X]} (hp : p ≠ 0) (h : IsPSD p) :
+    0 < p.leadingCoeff := by
+  obtain ⟨u, v, huv⟩ := Hilbert17OQ01OQ01.univariate_psd_is_two_sos p h
+  set n := max u.natDegree v.natDegree with hn
+  have hdeg : p.natDegree = 2 * n := by rw [huv, natDegree_sq_add_sq]
+  have hlc : p.leadingCoeff = (u.coeff n) ^ 2 + (v.coeff n) ^ 2 := by
+    rw [show p.leadingCoeff = p.coeff p.natDegree from rfl, hdeg, huv, coeff_add,
+      coeff_sq_two u n (le_max_left _ _), coeff_sq_two v n (le_max_right _ _)]
+  have hne : (u.coeff n) ^ 2 + (v.coeff n) ^ 2 ≠ 0 := by
+    rw [← hlc]; exact leadingCoeff_ne_zero.mpr hp
+  rw [hlc]
+  exact lt_of_le_of_ne (by positivity) (Ne.symm hne)
+
+/-- **Precise Fejér–Riesz normalization** — the parent file's own stated open
+question.  For a nonzero PSD polynomial `p` there is a two-squares decomposition
+`p = u² + v²` in which one square has degree exactly `½·deg p` and the other
+strictly less: `deg v < deg u` and `2·deg u = deg p`.
+
+The decomposition is an explicit orthogonal rotation `(u, v) = (c·a + s·b,
+c·b − s·a)` (with `c² + s² = 1`) of any existing decomposition `p = a² + b²`,
+with the angle chosen so that the top coefficient of the second square `v`
+vanishes while that of the first square `u` becomes `r = √(la² + lb²) > 0`. -/
+theorem univariate_psd_two_sos_degree_exact {p : ℝ[X]} (hp : p ≠ 0) (h : IsPSD p) :
+    ∃ u v : ℝ[X], p = u ^ 2 + v ^ 2 ∧ v.degree < u.degree ∧
+      2 * u.natDegree = p.natDegree := by
+  obtain ⟨a, b, hab⟩ := Hilbert17OQ01OQ01.univariate_psd_is_two_sos p h
+  set n := max a.natDegree b.natDegree with hn
+  have hpdeg : p.natDegree = 2 * n := by rw [hab, natDegree_sq_add_sq]
+  set la := a.coeff n with hla
+  set lb := b.coeff n with hlb
+  -- `la² + lb²` is the (positive) leading coefficient of `p`.
+  have hsum_pos : 0 < la ^ 2 + lb ^ 2 := by
+    have hlc : p.leadingCoeff = la ^ 2 + lb ^ 2 := by
+      rw [show p.leadingCoeff = p.coeff p.natDegree from rfl, hpdeg, hab, coeff_add,
+        coeff_sq_two a n (le_max_left _ _), coeff_sq_two b n (le_max_right _ _)]
+    have hpos := IsPSD.leadingCoeff_pos hp h
+    rwa [hlc] at hpos
+  -- rotation data
+  set r := Real.sqrt (la ^ 2 + lb ^ 2) with hr
+  have hr_pos : 0 < r := Real.sqrt_pos.mpr hsum_pos
+  have hr_ne : r ≠ 0 := ne_of_gt hr_pos
+  have hr_sq : r ^ 2 = la ^ 2 + lb ^ 2 := Real.sq_sqrt (le_of_lt hsum_pos)
+  set c := la / r with hc
+  set s := lb / r with hs
+  have hcs : c ^ 2 + s ^ 2 = 1 := by
+    rw [hc, hs, div_pow, div_pow, ← add_div, ← hr_sq, div_self (pow_ne_zero 2 hr_ne)]
+  -- coefficient at `n` of the rotated polynomials
+  have hu_coeff : (C c * a + C s * b).coeff n = r := by
+    have hval : c * la + s * lb = r := by
+      rw [hc, hs, div_mul_eq_mul_div, div_mul_eq_mul_div, ← add_div,
+        show la * la + lb * lb = r ^ 2 by rw [hr_sq]; ring, sq, mul_div_assoc,
+        div_self hr_ne, mul_one]
+    rw [coeff_add, coeff_C_mul, coeff_C_mul]; exact hval
+  have hv_coeff : (C c * b - C s * a).coeff n = 0 := by
+    have hval : c * lb - s * la = 0 := by
+      rw [hc, hs, div_mul_eq_mul_div, div_mul_eq_mul_div, div_sub_div_same,
+        show la * lb - lb * la = 0 by ring, zero_div]
+    rw [coeff_sub, coeff_C_mul, coeff_C_mul]; exact hval
+  -- degree bounds
+  have hu_le : (C c * a + C s * b).natDegree ≤ n :=
+    le_trans (natDegree_add_le _ _)
+      (max_le (le_trans (natDegree_C_mul_le _ _) (le_max_left _ _))
+        (le_trans (natDegree_C_mul_le _ _) (le_max_right _ _)))
+  have hv_le : (C c * b - C s * a).natDegree ≤ n :=
+    le_trans (natDegree_sub_le _ _)
+      (max_le (le_trans (natDegree_C_mul_le _ _) (le_max_right _ _))
+        (le_trans (natDegree_C_mul_le _ _) (le_max_left _ _)))
+  have hu_ne : C c * a + C s * b ≠ 0 := fun hz =>
+    hr_ne (by rw [← hu_coeff, hz, coeff_zero])
+  have hu_deg : (C c * a + C s * b).natDegree = n :=
+    le_antisymm hu_le (le_natDegree_of_ne_zero (by rw [hu_coeff]; exact hr_ne))
+  -- the rotation preserves the sum of squares
+  have hsum : p = (C c * a + C s * b) ^ 2 + (C c * b - C s * a) ^ 2 := by
+    have hCcs : (C c) ^ 2 + (C s) ^ 2 = 1 := by
+      rw [← C_pow, ← C_pow, ← C_add, hcs, map_one]
+    rw [hab]; linear_combination (-(a ^ 2 + b ^ 2)) * hCcs
+  -- the second square has strictly smaller degree
+  have hv_deg : (C c * b - C s * a).degree < (C c * a + C s * b).degree := by
+    rw [degree_eq_natDegree hu_ne, hu_deg]
+    rcases eq_or_ne (C c * b - C s * a) 0 with hz | hz
+    · rw [hz, degree_zero]; exact bot_lt_iff_ne_bot.mpr (by simp)
+    · rw [degree_eq_natDegree hz]
+      have hvne : (C c * b - C s * a).natDegree ≠ n := by
+        intro hcontra
+        have h0 : (C c * b - C s * a).leadingCoeff = 0 := by
+          rw [show (C c * b - C s * a).leadingCoeff
+              = (C c * b - C s * a).coeff (C c * b - C s * a).natDegree from rfl,
+            hcontra, hv_coeff]
+        rw [leadingCoeff_eq_zero] at h0; exact hz h0
+      exact_mod_cast lt_of_le_of_ne hv_le hvne
+  exact ⟨C c * a + C s * b, C c * b - C s * a, hsum, hv_deg, by rw [hu_deg, hpdeg]⟩
+
+end Hilbert17OQ01OQ01OQ01

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,202 @@
+{
+  "id": "hilbert-17-oq-01-oq-01-oq-01",
+  "title": "Univariate Hilbert 17, Exact Normalization: One Square of Degree ½·deg p, the Other Strictly Less (and PSD ⟹ Even Degree, Positive Leading Coefficient)",
+  "slug": "hilbert-17-oq-01-oq-01-oq-01",
+  "description": "The parent entry (Hilbert17OQ01OQ01.lean) proves the degree-sharp Fejér–Riesz statement: every nonnegative real univariate polynomial p is a sum of two squares p = u² + v² with 2·deg u ≤ deg p and 2·deg v ≤ deg p — an upper bound on the certificate size. This entry pins the certificate down exactly, via one elementary structural fact the parent never isolates: a sum of two polynomial squares has NO degree collapse, deg(u² + v²) = 2·max(deg u, deg v). The leading coefficients of u² and v² are both squares, hence nonnegative, so they can never cancel. Three consequences follow. (1) IsPSD.natDegree_even: a nonzero PSD univariate polynomial has even degree. (2) IsPSD.leadingCoeff_pos: its leading coefficient is strictly positive (equal to (u.coeff n)² + (v.coeff n)² at n = ½·deg p). (3) univariate_psd_two_sos_degree_exact — answering the parent file's own stated open question — for p ≠ 0 there is a decomposition p = u² + v² with deg v < deg u and 2·deg u = deg p, i.e. one square has degree exactly ½·deg p and the other strictly less. The construction is an explicit orthogonal rotation (u, v) = (c·a + s·b, c·b − s·a) with c² + s² = 1 of any existing decomposition p = a² + b², the angle chosen so the top coefficient of v vanishes while that of u becomes r = √(la² + lb²) > 0. Fully elementary, 0 axioms.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert17OQ01OQ01OQ01.lean",
+    "tags": [
+      "real-algebra",
+      "sum-of-squares",
+      "hilbert-17",
+      "fejer-riesz",
+      "degree-bound",
+      "univariate-polynomials",
+      "leading-coefficient",
+      "even-degree",
+      "orthogonal-rotation",
+      "inequalities"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.natDegree_mul",
+        "description": "Over a domain, (p·q).natDegree = p.natDegree + q.natDegree for p, q ≠ 0. The exact degree of a product (not just the ≤ bound) is what forces (w²).natDegree = 2·deg w and underlies the no-collapse computation.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Domain"
+      },
+      {
+        "theorem": "Polynomial.leadingCoeff_mul",
+        "description": "Over a domain, (p·q).leadingCoeff = p.leadingCoeff·q.leadingCoeff. Gives leadingCoeff(w²) = (leadingCoeff w)², the squared (nonnegative) leading coefficient that cannot cancel.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Domain"
+      },
+      {
+        "theorem": "Polynomial.le_natDegree_of_ne_zero",
+        "description": "If p.coeff n ≠ 0 then n ≤ p.natDegree. Provides the lower bound deg(u²+v²) ≥ 2·max(deg u, deg v) by exhibiting a nonzero coefficient at index 2·max, and deg u ≥ n for the rotated polynomial.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Definitions"
+      },
+      {
+        "theorem": "Polynomial.coeff_C_mul",
+        "description": "(C a · p).coeff n = a · p.coeff n. Computes the top coefficients of the rotated polynomials c·a + s·b and c·b − s·a, the crux of choosing the angle that annihilates v's leading term.",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      },
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "0 ≤ x → (√x)² = x. Supplies r² = la² + lb² for the rotation scalar r = √(la² + lb²), giving c² + s² = 1 and the unit-vector identity that makes the rotation orthogonal.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      }
+    ],
+    "originalContributions": [
+      "coeff_sq_two: for deg w ≤ n, the coefficient of w² at index 2n equals (w.coeff n)² — picks out the diagonal term and nothing else; the reusable engine for reading off leading data of a square.",
+      "natDegree_sq_add_sq: the no-collapse theorem deg(u² + v²) = 2·max(deg u, deg v) over ℝ. The leading coefficients of u² and v² are nonnegative squares, so the sum's top coefficient is a positive sum of squares and never vanishes.",
+      "IsPSD.natDegree_even: a nonzero PSD univariate polynomial has even degree, immediate from the two-squares decomposition and no-collapse.",
+      "IsPSD.leadingCoeff_pos: a nonzero PSD univariate polynomial has strictly positive leading coefficient, equal to (u.coeff n)² + (v.coeff n)² at n = ½·deg p.",
+      "univariate_psd_two_sos_degree_exact: the precise Fejér–Riesz normalization (the parent's stated open question) — for p ≠ 0, a decomposition p = u² + v² with deg v < deg u and 2·deg u = deg p, built by an explicit orthogonal rotation (c·a + s·b, c·b − s·a), c² + s² = 1, of any existing decomposition, chosen to kill the top coefficient of the second square."
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "The parent univariate two-squares theorem: a nonnegative real univariate polynomial is a sum of two squares (Hilbert17OQ01OQ01.univariate_psd_is_two_sos).",
+      "Exact degree and leading-coefficient arithmetic over a polynomial domain (natDegree_mul, leadingCoeff_mul).",
+      "The fact that a square has a nonnegative leading coefficient, so two squares cannot cancel at the top.",
+      "Basic properties of the real square root (Real.sq_sqrt, Real.sqrt_pos)."
+    ],
+    "lineCount": 203,
+    "relatedProblems": [
+      {
+        "id": "hilbert-17-oq-01-oq-01",
+        "relationship": "Parent: the degree-sharp Fejér–Riesz upper bound 2·deg u ≤ deg p. This entry answers that file's first stated open question by sharpening the symmetric ≤ bound to the exact normalization deg v < deg u, 2·deg u = deg p, and adds the structural even-degree and positive-leading-coefficient corollaries."
+      },
+      {
+        "id": "hilbert-17-oq-01",
+        "relationship": "Grandparent: the Pfister bound on the minimum number of squares. The univariate strand (two squares) is sharpened here from existence/upper-bound to an exact-degree certificate."
+      },
+      {
+        "id": "hilbert-17",
+        "relationship": "Great-grandparent: states Hilbert's 17th and Artin's theorem; the univariate case is the most classical exceptional case where polynomial squares already suffice."
+      }
+    ],
+    "assumptions": "0 axioms. #print axioms on natDegree_sq_add_sq, IsPSD.natDegree_even, IsPSD.leadingCoeff_pos, and univariate_psd_two_sos_degree_exact reports only propext, Classical.choice, Quot.sound. No sorryAx, no native_decide / Lean.ofReduceBool. Reuses only 0-axiom theorems from the parent files.",
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "leanFile": {
+    "lineCount": 203,
+    "namespace": "Hilbert17OQ01OQ01OQ01",
+    "opens": [
+      "Polynomial"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 4,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": [
+      "Mathlib",
+      "Proofs.Hilbert17OQ01OQ01"
+    ],
+    "path": "Proofs/Hilbert17OQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "natDegree_sq_add_sq",
+      "type": "theorem",
+      "description": "No degree collapse for a sum of two squares: deg(u² + v²) = 2·max(deg u, deg v). The leading coefficients of u² and v² are nonnegative and cannot cancel.",
+      "leanType": "(u v : ℝ[X]) → (u ^ 2 + v ^ 2).natDegree = 2 * max u.natDegree v.natDegree"
+    },
+    {
+      "name": "IsPSD.natDegree_even",
+      "type": "theorem",
+      "description": "A nonzero PSD univariate polynomial has even degree.",
+      "leanType": "IsPSD p → Even p.natDegree"
+    },
+    {
+      "name": "IsPSD.leadingCoeff_pos",
+      "type": "theorem",
+      "description": "A nonzero PSD univariate polynomial has strictly positive leading coefficient.",
+      "leanType": "p ≠ 0 → IsPSD p → 0 < p.leadingCoeff"
+    },
+    {
+      "name": "univariate_psd_two_sos_degree_exact",
+      "type": "theorem",
+      "description": "Precise Fejér–Riesz normalization: for p ≠ 0, a decomposition p = u² + v² with deg v < deg u and 2·deg u = deg p — one square of degree exactly ½·deg p, the other strictly less — via an explicit orthogonal rotation.",
+      "leanType": "p ≠ 0 → IsPSD p → ∃ u v, p = u ^ 2 + v ^ 2 ∧ v.degree < u.degree ∧ 2 * u.natDegree = p.natDegree"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Hilbert's 1888 classification singles out the univariate case as one of three where a nonnegative real polynomial is already a sum of polynomial squares. Its quantitative form is the Fejér–Riesz theorem (1916): a nonnegative trigonometric polynomial of degree n is |g|² for an analytic polynomial g of degree n, and the algebraic shadow is that a degree-2n nonnegative real polynomial factors through conjugate-pair roots as g·ḡ. Writing g = u + iv with the leading coefficient of g normalized to be real, the real part u has degree exactly n and the imaginary part v has degree < n. The parent formalization establishes the symmetric upper bound deg u, deg v ≤ n; the genuinely sharp Fejér–Riesz statement is the asymmetric normalization recovered here, plus the basic structural facts (even degree, positive leading coefficient) that any nonnegative polynomial must satisfy.",
+    "problemStatement": "Sharpen the univariate two-squares decomposition from the symmetric bound 2·deg u ≤ deg p, 2·deg v ≤ deg p to the exact normalization: for p ≠ 0, produce u, v with p = u² + v², deg v < deg u, and 2·deg u = deg p. Establish the structural corollaries that a nonzero PSD univariate polynomial has even degree and strictly positive leading coefficient.",
+    "proofStrategy": "The engine is coeff_sq_two: for deg w ≤ n, the coefficient of w² at index 2n is exactly (w.coeff n)². Summing over the two squares, the coefficient of u² + v² at 2·max(deg u, deg v) is (u.coeff n)² + (v.coeff n)², a sum of squares that is nonzero unless both polynomials vanish there — so the degree of u² + v² is exactly 2·max(deg u, deg v) (natDegree_sq_add_sq), with no cancellation. Even degree and positive leading coefficient then read off directly from a two-squares decomposition. For the exact normalization, start from any decomposition p = a² + b² (parent existence theorem); set n = max(deg a, deg b), la = a.coeff n, lb = b.coeff n, and r = √(la² + lb²) > 0 (positive because it is the leading coefficient of p). The orthogonal rotation u = C(la/r)·a + C(lb/r)·b, v = C(la/r)·b − C(lb/r)·a satisfies u² + v² = (c² + s²)(a² + b²) = p, has u.coeff n = r ≠ 0 (so deg u = n) and v.coeff n = (la·lb − lb·la)/r = 0 (so deg v < n). The conclusion deg v < deg u, 2·deg u = deg p follows.",
+    "keyInsights": [
+      "The single structural fact powering everything is that a square has a nonnegative leading coefficient, so the top coefficients of u² and v² add without cancellation — turning the ≤ bound of the parent into an exact equality for the degree of u² + v².",
+      "coeff_sq_two isolates the diagonal contribution to a square's coefficient: only the index pair (n, n) survives at level 2n when deg w ≤ n, giving (w.coeff n)² uniformly across the deg w < n (both sides 0) and deg w = n (leading coefficient) cases.",
+      "The leading coefficient of a nonzero PSD polynomial is literally a sum of two squares (u.coeff n)² + (v.coeff n)², which is simultaneously ≥ 0 and ≠ 0 — giving positivity for free.",
+      "The exact Fejér–Riesz normalization is an orthogonal change of basis in the (a, b) plane: any rotation preserves a² + b², and the unique angle with tan θ = lb/la sends the degree-n coefficient of the second square to zero, collapsing its degree below n while the first square keeps degree exactly n.",
+      "The result is 0-axiom and constructive: the rotation scalars are explicit real square roots, and #print axioms reports only propext, Classical.choice, Quot.sound."
+    ]
+  },
+  "conclusion": {
+    "summary": "A 203-line, 0-sorry, 0-axiom structural sharpening of the univariate case of Hilbert's 17th problem. Its workhorse is the no-collapse identity deg(u² + v²) = 2·max(deg u, deg v); from it follow that a nonzero PSD univariate polynomial has even degree and positive leading coefficient, and the precise Fejér–Riesz normalization p = u² + v² with deg v < deg u and 2·deg u = deg p (the parent file's stated open question), built by an explicit orthogonal rotation of any existing two-squares decomposition.",
+    "implications": "Moving from the parent's symmetric upper bound to the exact normalization removes the last slack in the univariate SOS certificate: one square is pinned to degree exactly ½·deg p and the other below it, which is the canonical form a Fejér–Riesz factorization returns. The no-collapse lemma and coeff_sq_two are reusable beyond this problem wherever the degree or leading coefficient of a sum of squares must be controlled.",
+    "openQuestions": [
+      "Uniqueness/parametrization: classify all exact-normalization pairs (u, v) for a fixed p — the rotation construction produces one; the full set is an orbit under multiplication of g = u + iv by a unit complex constant.",
+      "Carry the no-collapse principle to the quadratic-forms case (Hilbert17QuadraticGram.lean): bound the degrees/number of affine-linear squares using the same nonnegativity-of-leading-data argument."
+    ]
+  },
+  "references": [
+    {
+      "title": "Hilbert's seventeenth problem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem"
+    },
+    {
+      "title": "Fejér–Riesz theorem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Fej%C3%A9r%E2%80%93Riesz_theorem"
+    },
+    {
+      "title": "B. Reznick, Some concrete aspects of Hilbert's 17th problem (1996)",
+      "url": "https://www.ams.org/books/conm/253/"
+    }
+  ],
+  "crossReferences": [],
+  "sections": [
+    {
+      "id": "coeff-engine",
+      "title": "Reading the leading data of a square",
+      "startLine": 39,
+      "endLine": 57,
+      "summary": "coeff_sq_two: for deg w ≤ n, (w²).coeff (2n) = (w.coeff n)². Splits into deg w < n (both sides 0, via natDegree_pow_le) and deg w = n (the leading coefficient, via natDegree_mul / leadingCoeff_mul)."
+    },
+    {
+      "id": "no-collapse",
+      "title": "No degree collapse for a sum of two squares",
+      "startLine": 59,
+      "endLine": 99,
+      "summary": "natDegree_sq_add_sq: deg(u² + v²) = 2·max(deg u, deg v). A symmetric helper handles the maximal-degree polynomial; the lower bound exhibits a nonzero coefficient (a positive sum of squares) at index 2·max via le_natDegree_of_ne_zero, the upper bound is natDegree_add_le."
+    },
+    {
+      "id": "structural",
+      "title": "Even degree and positive leading coefficient",
+      "startLine": 101,
+      "endLine": 122,
+      "summary": "IsPSD.natDegree_even and IsPSD.leadingCoeff_pos: from a two-squares decomposition, deg p = 2·max is even and leadingCoeff p = (u.coeff n)² + (v.coeff n)² is a nonzero sum of squares, hence positive."
+    },
+    {
+      "id": "exact-normalization",
+      "title": "The precise Fejér–Riesz normalization (parent open question)",
+      "startLine": 124,
+      "endLine": 202,
+      "summary": "univariate_psd_two_sos_degree_exact: for p ≠ 0, the orthogonal rotation (c·a + s·b, c·b − s·a) with c = la/r, s = lb/r, r = √(la² + lb²), of an existing decomposition p = a² + b² gives p = u² + v² with deg v < deg u and 2·deg u = deg p — top coefficient of u is r ≠ 0, of v is 0."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **parent entry's own stated open question** (`hilbert-17-oq-01-oq-01`, openQuestions[0]): sharpen the univariate two-squares decomposition from the symmetric Fejér–Riesz *upper* bound `2·deg u ≤ deg p` to the **exact normalization** — for `p ≠ 0`, a decomposition `p = u² + v²` with `deg v < deg u` and `2·deg u = deg p` (one square of degree exactly `½·deg p`, the other strictly less).

New gallery entry `hilbert-17-oq-01-oq-01-oq-01`, new file `proofs/Proofs/Hilbert17OQ01OQ01OQ01.lean` (203 lines, 5 theorems, 0 defs).

## Results

- **`coeff_sq_two`** — for `deg w ≤ n`, `(w²).coeff (2n) = (w.coeff n)²` (reusable diagonal-coefficient engine).
- **`natDegree_sq_add_sq`** (workhorse) — *no degree collapse*: `deg(u²+v²) = 2·max(deg u, deg v)`. The squared leading coefficients are nonnegative and cannot cancel.
- **`IsPSD.natDegree_even`** — a nonzero PSD univariate polynomial has **even degree**.
- **`IsPSD.leadingCoeff_pos`** — its leading coefficient is **strictly positive** (a nonzero sum of two squares).
- **`univariate_psd_two_sos_degree_exact`** — the precise normalization, built by an explicit **orthogonal rotation** `(u,v) = (c·a + s·b, c·b − s·a)`, `c² + s² = 1`, of any existing decomposition `p = a² + b²`, with the angle chosen so the top coefficient of `v` vanishes (`= 0`) while that of `u` becomes `r = √(la² + lb²) > 0`.

## Verification

- 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions.
- `#print axioms` on all four public theorems reports only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`.
- Host-verified with `lake env lean` (Docker daemon down this session); reuses only 0-axiom theorems from the parent files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)