### PR TITLE
research(erdos-1-wip-01-oq-02): second-moment lower bound via minimum variance of distinct integers [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1Wip01OQ02.lean
+++ b/proofs/Proofs/Erdos1Wip01OQ02.lean
@@ -1,0 +1,251 @@
+/-
+  Erdős Problem #1 (Distinct Subset Sums): the second-moment lower bound.
+
+  A finite set `A ⊆ ℕ` has *distinct subset sums* (DSS) if its `2^{|A|}` subsets
+  all have different sums.  Erdős' \$500 conjecture asks whether `max(A) ≥ c·2^n`
+  for an absolute constant `c`.  The gallery already formalises:
+
+    * the **counting bound** `max(A) ≥ 2^n / n`  (`erdos-1-oq-01`), and
+    * the **Dubroff–Fox–Xu entropy bound** `max(A) ≥ √(2/π)·2^n/√n`
+      (`erdos-1-oq-02`), whose probability-free core is the
+      *second-moment identity* `∑_{T⊆A}(2·Σ_T − S)² = 2^n·Σ_{i∈A} i²` already
+      proved in `Proofs.Erdos1OQ02`.
+
+  That file (`Erdos1OQ02.lean`, lines 168–171) explicitly flags a road **not**
+  taken: the *pure* second-moment route, which lower-bounds the spread of the
+  `2^n` distinct subset sums by `(M³−M)/12` (`M = 2^n`).  The missing ingredient
+  is a general extremal fact about distinct integers — not in Mathlib — which we
+  supply here:
+
+  ### The extremal minimum-variance lemma (general, reusable)
+
+  `distinct_int_variance_lower`: for **any** finite set `Y ⊆ ℤ` (its elements are
+  automatically distinct), with `M = |Y|`,
+
+      M²·(M² − 1)  ≤  12·( M·∑_{y∈Y} y²  −  (∑_{y∈Y} y)² ).
+
+  Equivalently `Var(Y) ≥ (M²−1)/12`: among `M` distinct integers, the consecutive
+  block `0,1,…,M−1` minimises the variance.  The proof is elementary:
+
+    * `pairwise_sq_eq`  — the identity `∑_{i,j} (f i − f j)² = 2(M·∑f² − (∑f)²)`;
+    * enumerate `Y` in increasing order via `Finset.orderEmbOfFin`, a strictly
+      monotone `e : Fin M ↪o ℤ`; for `i ≤ j` integers force a gap
+      `e j − e i ≥ j − i` (`strictMono_displacement`), so termwise
+      `(i − j)² ≤ (e i − e j)²` (`termwise`);
+    * summing, `∑_{i,j∈range M}(i−j)² ≤ ∑_{a,b∈Y}(a−b)²`, and the left side has the
+      exact value `M²(M²−1)/6` (`sum_range_id_int`, `sum_range_sq_int`).
+
+  ### Application to Erdős #1
+
+  Taking `Y` to be the `2^n` distinct *doubled deviations* `{2·Σ_T − S : T ⊆ A}`
+  (distinct because `A` is DSS), `∑_{y∈Y} y² = 2^n·Σ_{i∈A} i²`
+  (`second_moment_identity`), and since `(∑ y)² ≥ 0` the extremal lemma yields,
+  after dividing by `4^n > 0`,
+
+      `dss_sumsq_lower` :   4^n − 1  ≤  12·∑_{i∈A} i² .
+
+  Bounding `∑ i² ≤ n·N²` gives the max-element form
+
+      `dss_max_lower`  :   4^n  ≤  12·n·N² + 1 ,   i.e.  max(A) ≳ 2^n/√(12n).
+
+  This is a *self-contained, structurally independent* derivation of a `√n`
+  improvement over the counting bound `2^n/n`.  Its constant `1/√12 ≈ 0.289` is
+  weaker than DFX's `√(2/π) ≈ 0.798` (as the `Erdos1OQ02` note predicts), but the
+  route is completely elementary — no probability, no entropy — and the extremal
+  lemma is a general tool of independent interest.
+
+  Status: fully elementary, 0 sorries, 0 axioms beyond Mathlib's foundational
+  `propext`/`Classical.choice`/`Quot.sound`.
+-/
+import Proofs.Erdos1OQ02
+import Mathlib
+
+open Finset
+
+namespace Erdos1Wip01OQ02
+
+/-! ## Part I: Closed forms for the consecutive-block reference sums -/
+
+/-- Gauss' sum over `range M`, in `ℤ`: `2·∑_{i<M} i = M(M−1)`. -/
+lemma sum_range_id_int (M : ℕ) : 2 * ∑ i ∈ range M, (i : ℤ) = (M : ℤ) * ((M : ℤ) - 1) := by
+  induction M with
+  | zero => simp
+  | succ n ih => rw [Finset.sum_range_succ, mul_add, ih]; push_cast; ring
+
+/-- Square-pyramidal sum over `range M`, in `ℤ`: `6·∑_{i<M} i² = (M−1)·M·(2M−1)`. -/
+lemma sum_range_sq_int (M : ℕ) :
+    6 * ∑ i ∈ range M, (i : ℤ) ^ 2 = ((M : ℤ) - 1) * M * (2 * M - 1) := by
+  induction M with
+  | zero => simp
+  | succ n ih => rw [Finset.sum_range_succ, mul_add, ih]; push_cast; ring
+
+/-! ## Part II: The pairwise-difference identity -/
+
+/-- **Pairwise-square identity.**  For a function `f` on a finite set `s`,
+    `∑_{i,j∈s} (f i − f j)² = 2·( |s|·∑ f²  −  (∑ f)² )`.  (Twice the variance,
+    rescaled by `|s|`.) -/
+lemma pairwise_sq_eq {ι : Type*} (s : Finset ι) (f : ι → ℤ) :
+    ∑ i ∈ s, ∑ j ∈ s, (f i - f j) ^ 2
+      = 2 * ((s.card : ℤ) * (∑ i ∈ s, (f i) ^ 2) - (∑ i ∈ s, f i) ^ 2) := by
+  have inner : ∀ a ∈ s, ∑ j ∈ s, (f a - f j) ^ 2
+      = (s.card : ℤ) * (f a) ^ 2 - 2 * (f a) * (∑ j ∈ s, f j) + (∑ j ∈ s, (f j) ^ 2) := by
+    intro a _; simp_rw [sub_sq]
+    rw [Finset.sum_add_distrib, Finset.sum_sub_distrib, Finset.sum_const, nsmul_eq_mul,
+        ← Finset.mul_sum]
+  have hcross : ∑ a ∈ s, 2 * (f a) * (∑ j ∈ s, f j) = 2 * (∑ i ∈ s, f i) ^ 2 := by
+    rw [← Finset.sum_mul, ← Finset.mul_sum]; ring
+  rw [Finset.sum_congr rfl inner, Finset.sum_add_distrib, Finset.sum_sub_distrib,
+      ← Finset.mul_sum, Finset.sum_const, nsmul_eq_mul, hcross]; ring
+
+/-! ## Part III: Monotone enumeration and the termwise gap bound -/
+
+/-- Reindex a sum over `Y ⊆ ℤ` through its increasing enumeration
+    `Finset.orderEmbOfFin`. -/
+lemma reindex (Y : Finset ℤ) {M : ℕ} (h : Y.card = M) (F : ℤ → ℤ) :
+    ∑ i : Fin M, F (Y.orderEmbOfFin h i) = ∑ a ∈ Y, F a := by
+  have himg : (Finset.univ : Finset (Fin M)).image (Y.orderEmbOfFin h) = Y := by
+    apply Finset.eq_of_subset_of_card_le
+    · intro a ha; simp only [Finset.mem_image, Finset.mem_univ, true_and] at ha
+      obtain ⟨i, rfl⟩ := ha; exact Y.orderEmbOfFin_mem h i
+    · rw [Finset.card_image_of_injective _ (Y.orderEmbOfFin h).injective, Finset.card_univ,
+        Fintype.card_fin, h]
+  calc ∑ i : Fin M, F (Y.orderEmbOfFin h i)
+      = ∑ a ∈ (Finset.univ : Finset (Fin M)).image (Y.orderEmbOfFin h), F a :=
+        (Finset.sum_image (fun x _ y _ hxy => (Y.orderEmbOfFin h).injective hxy)).symm
+    _ = ∑ a ∈ Y, F a := by rw [himg]
+
+/-- A strictly monotone `ℤ`-valued map on `Fin M` moves by at least the index gap:
+    if `j = i + k` then `e j − e i ≥ k`.  (Distinct integers are spaced `≥ 1` apart.) -/
+lemma strictMono_displacement {M : ℕ} (e : Fin M → ℤ) (he : StrictMono e) :
+    ∀ k : ℕ, ∀ i j : Fin M, (j : ℕ) = (i : ℕ) + k → (k : ℤ) ≤ e j - e i := by
+  intro k
+  induction k with
+  | zero => intro i j hj; have : i = j := Fin.ext (by omega); simp [this]
+  | succ n ih =>
+    intro i j hj
+    have hlt : (i : ℕ) + n < M := by omega
+    let j' : Fin M := ⟨(i : ℕ) + n, by omega⟩
+    have h1 : (n : ℤ) ≤ e j' - e i := ih i j' rfl
+    have hj'j : j' < j := by rw [Fin.lt_def]; simp only [j']; omega
+    have h2 : e j' < e j := he hj'j
+    push_cast; omega
+
+/-- **Termwise gap domination.**  For a strictly monotone `e : Fin M → ℤ`,
+    `(i − j)² ≤ (e i − e j)²`: spreading distinct integers can only widen gaps. -/
+lemma termwise {M : ℕ} (e : Fin M → ℤ) (he : StrictMono e) (i j : Fin M) :
+    ((i : ℤ) - (j : ℤ)) ^ 2 ≤ (e i - e j) ^ 2 := by
+  rcases le_total (i : ℕ) (j : ℕ) with hij | hij
+  · have hd := strictMono_displacement e he ((j : ℕ) - (i : ℕ)) i j (by omega)
+    rw [Nat.cast_sub hij] at hd
+    have h0 : (0 : ℤ) ≤ (j : ℤ) - (i : ℤ) := by
+      have : (i : ℤ) ≤ (j : ℤ) := by exact_mod_cast hij
+      linarith
+    nlinarith [hd, h0]
+  · have hd := strictMono_displacement e he ((i : ℕ) - (j : ℕ)) j i (by omega)
+    rw [Nat.cast_sub hij] at hd
+    have h0 : (0 : ℤ) ≤ (i : ℤ) - (j : ℤ) := by
+      have : (j : ℤ) ≤ (i : ℤ) := by exact_mod_cast hij
+      linarith
+    nlinarith [hd, h0]
+
+/-! ## Part IV: The extremal minimum-variance lemma -/
+
+/-- **Minimum variance of `M` distinct integers (0 axioms).**  For any finite set
+    `Y ⊆ ℤ` with `M = |Y|`,
+
+      `M²·(M² − 1) ≤ 12·( M·∑_{y∈Y} y² − (∑_{y∈Y} y)² )`,
+
+    i.e. the variance of `M` distinct integers is at least `(M²−1)/12`, with equality
+    for a consecutive block.  Not currently in Mathlib. -/
+theorem distinct_int_variance_lower (Y : Finset ℤ) :
+    (Y.card : ℤ) ^ 2 * ((Y.card : ℤ) ^ 2 - 1)
+      ≤ 12 * ((Y.card : ℤ) * (∑ a ∈ Y, a ^ 2) - (∑ a ∈ Y, a) ^ 2) := by
+  obtain ⟨M, hM⟩ : ∃ M, Y.card = M := ⟨Y.card, rfl⟩
+  have he : StrictMono (⇑(Y.orderEmbOfFin hM)) := (Y.orderEmbOfFin hM).strictMono
+  have hPW : ∑ a ∈ Y, ∑ b ∈ Y, (a - b) ^ 2
+      = 2 * ((Y.card : ℤ) * (∑ a ∈ Y, a ^ 2) - (∑ a ∈ Y, a) ^ 2) := by
+    have := pairwise_sq_eq Y (fun x => x); simpa using this
+  have hV : 6 * (∑ i ∈ range M, ∑ j ∈ range M, ((i : ℤ) - (j : ℤ)) ^ 2)
+      = (M : ℤ) ^ 2 * ((M : ℤ) ^ 2 - 1) := by
+    have hpr := pairwise_sq_eq (range M) (fun n => (n : ℤ))
+    rw [Finset.card_range] at hpr
+    rw [hpr]; nlinarith [sum_range_id_int M, sum_range_sq_int M]
+  have hVle : (∑ i ∈ range M, ∑ j ∈ range M, ((i : ℤ) - (j : ℤ)) ^ 2)
+      ≤ ∑ a ∈ Y, ∑ b ∈ Y, (a - b) ^ 2 := by
+    have hRe : ∑ a ∈ Y, ∑ b ∈ Y, (a - b) ^ 2
+        = ∑ i : Fin M, ∑ j : Fin M, ((Y.orderEmbOfFin hM) i - (Y.orderEmbOfFin hM) j) ^ 2 := by
+      rw [← reindex Y hM (fun a => ∑ b ∈ Y, (a - b) ^ 2)]
+      apply Finset.sum_congr rfl; intro i _
+      rw [← reindex Y hM (fun b => ((Y.orderEmbOfFin hM) i - b) ^ 2)]
+    have hLe : ∑ i ∈ range M, ∑ j ∈ range M, ((i : ℤ) - (j : ℤ)) ^ 2
+        = ∑ i : Fin M, ∑ j : Fin M, ((i : ℤ) - (j : ℤ)) ^ 2 := by
+      rw [← Fin.sum_univ_eq_sum_range (fun i => ∑ j ∈ range M, ((i : ℤ) - (j : ℤ)) ^ 2)]
+      apply Finset.sum_congr rfl; intro i _
+      rw [← Fin.sum_univ_eq_sum_range (fun j => ((i : ℤ) - (j : ℤ)) ^ 2)]
+    rw [hRe, hLe]
+    apply Finset.sum_le_sum; intro i _
+    apply Finset.sum_le_sum; intro j _
+    exact termwise (⇑(Y.orderEmbOfFin hM)) he i j
+  rw [hM]
+  rw [hM] at hPW
+  rw [hPW] at hVle
+  linarith [hV, hVle]
+
+/-! ## Part V: The second-moment lower bound for Erdős #1 -/
+
+/-- **Second-moment sum-of-squares bound (0 axioms).**  Any distinct-subset-sums set
+    `A` of size `n` has `∑_{i∈A} i² ≥ (4^n − 1)/12`.  Proof: the `2^n` doubled
+    deviations are distinct integers with `∑ y² = 2^n·∑ i²`; the minimum-variance
+    lemma forces their spread, and dividing by `4^n` gives the bound. -/
+theorem dss_sumsq_lower (A : Finset ℕ) (hDSS : hasDistinctSubsetSums A) :
+    (4 : ℤ) ^ A.card - 1 ≤ 12 * ∑ i ∈ A, (i : ℤ) ^ 2 := by
+  set dev : Finset ℕ → ℤ := fun T => 2 * (∑ i ∈ T, (i : ℤ)) - ∑ i ∈ A, (i : ℤ) with hdev
+  set Y : Finset ℤ := A.powerset.image dev with hY
+  have hinj : Set.InjOn dev (A.powerset : Set (Finset ℕ)) :=
+    Erdos1OQ02.doubledDrop_injOn_of_distinct hDSS
+  have hcard : Y.card = 2 ^ A.card := by
+    rw [hY, Finset.card_image_of_injOn hinj, Finset.card_powerset]
+  have hsq : ∑ y ∈ Y, y ^ 2 = 2 ^ A.card * ∑ i ∈ A, (i : ℤ) ^ 2 := by
+    rw [hY, Finset.sum_image (fun x hx y hy h => hinj (by simpa using hx) (by simpa using hy) h)]
+    exact Erdos1OQ02.second_moment_identity A
+  have hext := distinct_int_variance_lower Y
+  rw [hcard, hsq] at hext
+  push_cast at hext
+  have hsumsq : (0 : ℤ) ≤ (∑ a ∈ Y, a) ^ 2 := sq_nonneg _
+  have hpos : (0 : ℤ) < 2 ^ A.card := by positivity
+  have h4 : ((2 : ℤ) ^ A.card) ^ 2 = 4 ^ A.card := by
+    rw [← pow_mul, mul_comm, pow_mul]; norm_num
+  nlinarith [hext, hsumsq, hpos, h4, sq_nonneg ((2 : ℤ) ^ A.card)]
+
+/-- **Max-element form (0 axioms).**  If every element of a distinct-subset-sums set
+    `A` of size `n` is `≤ N`, then `4^n ≤ 12·n·N² + 1`, i.e. `N = max(A) ≳ 2^n/√(12n)`
+    — a `√n` improvement over the counting bound `2^n/n`. -/
+theorem dss_max_lower (A : Finset ℕ) (N : ℕ) (hDSS : hasDistinctSubsetSums A)
+    (hN : ∀ a ∈ A, a ≤ N) :
+    (4 : ℤ) ^ A.card ≤ 12 * A.card * N ^ 2 + 1 := by
+  have hb := dss_sumsq_lower A hDSS
+  have hbound : ∑ i ∈ A, (i : ℤ) ^ 2 ≤ A.card * N ^ 2 := by
+    calc ∑ i ∈ A, (i : ℤ) ^ 2 ≤ ∑ _i ∈ A, ((N : ℤ)) ^ 2 := by
+          apply Finset.sum_le_sum; intro i hi
+          have : (i : ℤ) ≤ N := by exact_mod_cast hN i hi
+          have hi0 : (0 : ℤ) ≤ (i : ℤ) := by positivity
+          nlinarith [this, hi0]
+      _ = A.card * (N : ℤ) ^ 2 := by rw [Finset.sum_const, nsmul_eq_mul]
+  push_cast at hb ⊢
+  nlinarith [hb, hbound]
+
+/-- **The second-moment route beats counting.**  For `n ≥ 1` the second-moment bound
+    `∑ i² ≥ (4^n−1)/12` is genuinely a `√n`-type statement: combined with
+    `∑ i² ≤ n·max(A)²` it gives `12·n·max(A)² ≥ 4^n − 1`, whereas the counting bound
+    only gives `n·max(A) ≥ 2^n − 1`.  Here we record the clean comparison that the
+    bound is non-vacuous (positive right-hand growth) for every nonempty `A`. -/
+theorem dss_sumsq_lower_pos (A : Finset ℕ) (hDSS : hasDistinctSubsetSums A)
+    (hne : A.Nonempty) :
+    1 ≤ ∑ i ∈ A, (i : ℤ) ^ 2 := by
+  have hb := dss_sumsq_lower A hDSS
+  have hcard : 1 ≤ A.card := hne.card_pos
+  have h4 : (4 : ℤ) ^ A.card ≥ 4 ^ 1 := by
+    apply pow_le_pow_right₀ (by norm_num) hcard
+  nlinarith [hb, h4]
+
+end Erdos1Wip01OQ02

--- a/src/data/proofs/erdos-1-wip-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1-wip-01-oq-02/annotations.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "erdos-1-wip-01-oq-02",
+    "range": { "startLine": 1, "endLine": 66 },
+    "type": "concept",
+    "title": "Module Overview: The Pure Second-Moment Route",
+    "content": "This file carries out the second-moment lower bound for Erdős Problem #1 that the gallery's `Erdos1OQ02` entry explicitly left untaken (see its source note, lines 168–171). The development has two halves:\n\n- **A general extremal lemma (Parts I–IV)**: the variance of any M distinct integers is at least (M²−1)/12, with equality for a consecutive block — a statement about arbitrary finite Y ⊆ ℤ, not present in Mathlib.\n- **The Erdős application (Part V)**: applied to the 2ⁿ distinct doubled subset-sum deviations of a DSS set A, it gives 4ⁿ − 1 ≤ 12∑_{i∈A} i², hence max(A) ≥ 2ⁿ/√(12n).\n\nThe file imports `Proofs.Erdos1OQ02` to reuse the previously-verified second-moment identity ∑_{T⊆A}(2Σ_T−S)² = 2ⁿ∑i² and the injectivity of the doubled-deviation map. Everything is elementary: no probability, entropy, or Fourier analysis. 0 axioms, 0 sorries.",
+    "mathContext": "For an n-element set A, model a uniformly random subset sum X = ∑εᵢaᵢ. Its variance is ¼∑aᵢ², yet as 2ⁿ distinct integers the subset sums force variance ≥ (4ⁿ−1)/12. Equating gives ∑aᵢ² ≥ (4ⁿ−1)/12 and max(A) ≳ 2ⁿ/√(12n) — a √n improvement on the counting bound (2ⁿ−1)/n.",
+    "significance": "key",
+    "relatedConcepts": [
+      "distinct subset sums",
+      "Erdős Problem #1",
+      "second-moment method",
+      "variance lower bound",
+      "anticoncentration"
+    ],
+    "prerequisites": [
+      "Finset in Lean 4 / Mathlib",
+      "order embeddings (Finset.orderEmbOfFin)",
+      "elementary variance / second-moment method"
+    ]
+  },
+  {
+    "id": "ann-closed-forms",
+    "proofId": "erdos-1-wip-01-oq-02",
+    "range": { "startLine": 68, "endLine": 84 },
+    "type": "lemma",
+    "title": "Part I: Closed Forms for the Reference Block",
+    "content": "`sum_range_id_int` (2∑_{i<M}i = M(M−1)) and `sum_range_sq_int` (6∑_{i<M}i² = (M−1)M(2M−1)), both stated over ℤ and proved by a one-line induction (`Finset.sum_range_succ`, then `push_cast; ring`). Working in ℤ from the start avoids natural-number subtraction in the M(M−1) and (2M−1) factors.",
+    "mathContext": "Gauss' sum and the square-pyramidal sum. Together they give the exact pairwise value ∑_{i,j<M}(i−j)² = 2(M·∑i² − (∑i)²) = M²(M²−1)/6 for the consecutive block {0,…,M−1}, the unique variance-minimiser among M distinct integers.",
+    "significance": "standard",
+    "relatedConcepts": ["Gauss sum", "square-pyramidal numbers", "induction"],
+    "prerequisites": ["Finset.sum_range_succ", "ring/push_cast"]
+  },
+  {
+    "id": "ann-pairwise",
+    "proofId": "erdos-1-wip-01-oq-02",
+    "range": { "startLine": 85, "endLine": 102 },
+    "type": "lemma",
+    "title": "Part II: The Pairwise-Difference Identity",
+    "content": "`pairwise_sq_eq`: for any f : ι → ℤ on a finite set s, ∑_{i,j∈s}(f i − f j)² = 2(|s|·∑f² − (∑f)²). The proof expands (f i − f j)² = f i² − 2 f i f j + f j², computes the inner sum over j (a constant term |s|·f a², a linear term 2 f a·∑f, and ∑f²), then the outer sum, collapsing the cross term via ∑(2 f a·∑f) = 2(∑f)².",
+    "mathContext": "The right-hand side M∑f² − (∑f)² is the unnormalised variance; the identity expresses it as half the manifestly nonnegative, manifestly monotone sum of squared differences ∑_{i,j}(f i − f j)². This monotone form is what enables the termwise comparison in Part IV.",
+    "significance": "key",
+    "relatedConcepts": ["variance identity", "sum of squared differences", "Lagrange identity"],
+    "prerequisites": ["Finset.sum_add_distrib", "Finset.mul_sum", "sub_sq"]
+  },
+  {
+    "id": "ann-monotone",
+    "proofId": "erdos-1-wip-01-oq-02",
+    "range": { "startLine": 103, "endLine": 157 },
+    "type": "technique",
+    "title": "Part III: Monotone Enumeration and the Gap Bound",
+    "content": "Three lemmas. `reindex` transports a sum over Y ⊆ ℤ to a sum over Fin M through the increasing enumeration `Finset.orderEmbOfFin` (image-of-univ = Y by injectivity + cardinality, then `Finset.sum_image`). `strictMono_displacement` proves the crux: a strictly monotone e : Fin M → ℤ satisfies e j − e i ≥ j − i for j = i + k, by induction on k — each integer step is ≥ 1 (`Int.add_one_le_iff`). `termwise` concludes (i − j)² ≤ (e i − e j)² by casing on i ≤ j or j ≤ i and squaring the gap bound (`nlinarith`).",
+    "mathContext": "A strictly monotone integer-valued map cannot move slower than the identity: distinct integers are spaced ≥ 1 apart, so over an index gap of k they spread by ≥ k. Hence every pairwise gap of Y dominates the corresponding consecutive-block gap, termwise.",
+    "significance": "key",
+    "relatedConcepts": ["order embedding", "strict monotonicity", "distinct integer spacing", "Finset.orderEmbOfFin"],
+    "prerequisites": ["Finset.orderEmbOfFin", "Int.add_one_le_iff", "Nat.cast_sub"]
+  },
+  {
+    "id": "ann-extremal",
+    "proofId": "erdos-1-wip-01-oq-02",
+    "range": { "startLine": 158, "endLine": 198 },
+    "type": "theorem",
+    "title": "Part IV: Minimum Variance of M Distinct Integers",
+    "content": "`distinct_int_variance_lower`: for any finite Y ⊆ ℤ with M = |Y|, M²(M²−1) ≤ 12(M·∑y² − (∑y)²). Assembly: `pairwise_sq_eq` gives ∑_{a,b∈Y}(a−b)² = 2(M∑y² − (∑y)²); reindexing through `orderEmbOfFin` and the termwise gap bound give ∑_{i,j∈range M}(i−j)² ≤ ∑_{a,b∈Y}(a−b)²; and the closed forms give 6·∑_{range}(i−j)² = M²(M²−1). Combining with `linarith` yields the bound.",
+    "mathContext": "Equivalently Var(Y) ≥ (M²−1)/12 — the discrete dual of Popoviciu's variance inequality, specialised to distinct integers, with equality exactly for a consecutive block. Not present in Mathlib; of independent interest for any spacing/anticoncentration argument.",
+    "significance": "key",
+    "relatedConcepts": ["Popoviciu inequality", "variance lower bound", "extremal combinatorics", "rearrangement"],
+    "prerequisites": ["pairwise_sq_eq", "Fin.sum_univ_eq_sum_range", "Finset.sum_le_sum"]
+  },
+  {
+    "id": "ann-dss-app",
+    "proofId": "erdos-1-wip-01-oq-02",
+    "range": { "startLine": 199, "endLine": 251 },
+    "type": "theorem",
+    "title": "Part V: Second-Moment Bound for Erdős #1",
+    "content": "`dss_sumsq_lower`: 4ⁿ − 1 ≤ 12∑_{i∈A} i² for any n-element DSS set A. The doubled deviations {2Σ_T − S : T⊆A} are 2ⁿ distinct integers (`Erdos1OQ02.doubledDrop_injOn_of_distinct`) with second moment 2ⁿ∑i² (`Erdos1OQ02.second_moment_identity`). The extremal lemma plus (∑y)² ≥ 0 gives 4ⁿ(4ⁿ−1) ≤ 12·4ⁿ∑i²; dividing by 4ⁿ > 0 (via `nlinarith`) gives the bound. `dss_max_lower` then bounds ∑i² ≤ nN² to get 4ⁿ ≤ 12nN² + 1, i.e. max(A) ≳ 2ⁿ/√(12n); `dss_sumsq_lower_pos` records non-vacuity.",
+    "mathContext": "With M = 2ⁿ and ∑y² = 2ⁿ·Q (Q = ∑i²), the extremal inequality is (2ⁿ)²((2ⁿ)²−1) ≤ 12·2ⁿ·(2ⁿ·Q), i.e. 4ⁿ−1 ≤ 12Q after dividing by 4ⁿ. Crucially the first moment ∑y = 0 is never needed: (∑y)² ≥ 0 already makes the inequality usable. The result is a √n improvement over the counting bound n·max(A) ≥ 2ⁿ−1.",
+    "significance": "key",
+    "relatedConcepts": ["distinct subset sums", "second-moment method", "anticoncentration", "Dubroff-Fox-Xu bound"],
+    "prerequisites": ["Erdos1OQ02.second_moment_identity", "Erdos1OQ02.doubledDrop_injOn_of_distinct", "Finset.card_image_of_injOn"]
+  }
+]

--- a/src/data/proofs/erdos-1-wip-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-wip-01-oq-02/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "erdos-1-wip-01-oq-02",
+  "title": "Erdős #1: Second-Moment Lower Bound via Minimum Variance of Distinct Integers",
+  "slug": "erdos-1-wip-01-oq-02",
+  "description": "A self-contained, probability-free second-moment lower bound for Erdős Problem #1 (Distinct Subset Sums). The centerpiece is a general extremal lemma — not in Mathlib — that the variance of M distinct integers is at least (M²−1)/12 (minimised by a consecutive block): M²(M²−1) ≤ 12(M·∑y² − (∑y)²). Applied to the 2ⁿ distinct doubled subset-sum deviations of a DSS set A (whose second moment is 2ⁿ·∑i², already in Erdos1OQ02), it yields 4ⁿ − 1 ≤ 12·∑_{i∈A} i², hence max(A) ≥ 2ⁿ/√(12n) — a √n improvement over the counting bound 2ⁿ/n. This is the 'pure second-moment route' explicitly left untaken in the Erdos1OQ02 note (lines 168–171).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1Wip01OQ02.lean",
+    "tags": [
+      "erdos",
+      "additive-combinatorics",
+      "subset-sums",
+      "extremal-combinatorics",
+      "second-moment-method",
+      "variance",
+      "combinatorics",
+      "number-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All results are fully proved in Lean 4 with 0 axioms (only Mathlib's foundational propext/Classical.choice/Quot.sound) and 0 sorries. Imports Proofs.Erdos1OQ02 for the previously-verified second-moment identity and the injectivity of the doubled-deviation map on a DSS powerset.",
+    "lineCount": 251,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-30",
+    "originalContributions": [
+      "distinct_int_variance_lower: For any finite Y ⊆ ℤ with M = |Y|, M²(M²−1) ≤ 12(M·∑y² − (∑y)²) — the minimum variance of M distinct integers is (M²−1)/12, achieved by a consecutive block. A general extremal lemma not present in Mathlib.",
+      "pairwise_sq_eq: The pairwise-square identity ∑_{i,j∈s}(f i − f j)² = 2(|s|·∑f² − (∑f)²) for any function into ℤ (twice the variance rescaled by |s|).",
+      "strictMono_displacement: A strictly monotone ℤ-valued map on Fin M satisfies e j − e i ≥ j − i for i ≤ j (distinct integers are spaced ≥ 1 apart).",
+      "termwise: Termwise gap domination (i − j)² ≤ (e i − e j)² for strictly monotone e — spreading distinct integers widens gaps.",
+      "reindex: Sum reindexing through the increasing enumeration Finset.orderEmbOfFin.",
+      "sum_range_id_int / sum_range_sq_int: Closed forms 2∑_{i<M}i = M(M−1) and 6∑_{i<M}i² = (M−1)M(2M−1) over ℤ.",
+      "dss_sumsq_lower: 4ⁿ − 1 ≤ 12·∑_{i∈A} i² for any n-element distinct-subset-sums set A — the second-moment sum-of-squares bound.",
+      "dss_max_lower: 4ⁿ ≤ 12·n·N² + 1 when every element of an n-element DSS set is ≤ N, i.e. max(A) ≳ 2ⁿ/√(12n).",
+      "dss_sumsq_lower_pos: The bound is non-vacuous (∑i² ≥ 1) for every nonempty DSS set."
+    ],
+    "prerequisites": [
+      "Finset basics (Lean 4 / Mathlib)",
+      "Order embeddings (Finset.orderEmbOfFin) and monotone enumeration",
+      "Elementary second-moment / variance method",
+      "The second-moment identity from Erdos1OQ02"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1 (the \\$500 distinct-subset-sums problem, posed c. 1931) asks whether every n-element set $A$ with all $2^n$ subset sums distinct must satisfy $\\max(A) \\geq c \\cdot 2^n$ for an absolute constant $c$. The elementary **counting bound** gives only $\\max(A) \\geq (2^n-1)/n$. The first genuine improvement to a $\\sqrt{n}$ denominator comes from the **second-moment method**: model a uniformly random subset sum $X = \\sum_i \\varepsilon_i a_i$; its variance is $\\tfrac14\\sum a_i^2$, yet as $2^n$ distinct integers the subset sums must have variance at least $(4^n-1)/12$. Equating forces $\\sum a_i^2 \\geq (4^n-1)/12$ and hence $\\max(A) \\gtrsim 2^n/\\sqrt{12n}$. Dubroff–Fox–Xu (2021) later sharpened the constant to $\\sqrt{2/\\pi}$ via entropy/Fourier methods.\n\nThe gallery's `Erdos1OQ02` entry formalises the DFX framework and proves the exact **second-moment identity** $\\sum_{T\\subseteq A}(2\\,\\Sigma_T - S)^2 = 2^n\\sum_{i\\in A} i^2$. Its source note (lines 168–171) explicitly records that the *pure* second-moment route — lower-bounding the spread of the $2^n$ distinct subset sums by $(M^3-M)/12$ — was **not** carried out, because the parity-interval count gives a sharper constant. This entry supplies exactly that missing route, and with it the missing general extremal lemma about distinct integers.",
+    "problemStatement": "Provide a self-contained, probability-free derivation of a $\\sqrt{n}$-type lower bound for Erdős #1, by proving the general extremal fact that $M$ distinct integers have variance at least $(M^2-1)/12$ and applying it to the $2^n$ distinct subset-sum deviations of a DSS set.\n\nConcretely: (1) prove $M^2(M^2-1) \\leq 12\\big(M\\sum_{y\\in Y} y^2 - (\\sum_{y\\in Y} y)^2\\big)$ for every finite $Y \\subseteq \\mathbb{Z}$; (2) deduce $4^n - 1 \\leq 12\\sum_{i\\in A} i^2$ for every $n$-element distinct-subset-sums set $A$; (3) deduce $4^n \\leq 12\\,n\\,N^2 + 1$ when $\\max(A) \\leq N$.",
+    "proofStrategy": "The extremal lemma is proved by **monotone enumeration**. For $Y\\subseteq\\mathbb{Z}$ with $|Y|=M$, the pairwise identity $\\sum_{a,b\\in Y}(a-b)^2 = 2(M\\sum y^2 - (\\sum y)^2)$ converts variance into a sum of squared differences. Enumerate $Y$ in increasing order via `Finset.orderEmbOfFin`, giving a strictly monotone $e : \\mathrm{Fin}\\,M \\hookrightarrow \\mathbb{Z}$; because distinct integers are spaced at least $1$ apart, $e(j)-e(i) \\geq j-i$ for $i\\leq j$ (`strictMono_displacement`), so termwise $(i-j)^2 \\leq (e(i)-e(j))^2$ (`termwise`). Summing reduces the problem to the consecutive block $\\{0,1,\\dots,M-1\\}$, whose pairwise sum is the exact $M^2(M^2-1)/6$ (`sum_range_id_int`, `sum_range_sq_int`).\n\nFor the application, take $Y = \\{2\\,\\Sigma_T - S : T\\subseteq A\\}$, the $2^n$ doubled deviations, which are distinct because $A$ is DSS (`Erdos1OQ02.doubledDrop_injOn_of_distinct`). Their second moment is $2^n\\sum_{i\\in A} i^2$ (`Erdos1OQ02.second_moment_identity`). Since $(\\sum y)^2 \\geq 0$, the extremal lemma gives $M^2(M^2-1) \\leq 12\\,M\\sum y^2$; substituting $M=2^n$ and dividing by $4^n>0$ yields $4^n - 1 \\leq 12\\sum_{i\\in A} i^2$. Bounding $\\sum i^2 \\leq n\\,N^2$ gives the max-element form.",
+    "keyInsights": [
+      "**Variance of a random subset sum is purely combinatorial.** The slogan 'Var(X) = ¼∑aᵢ²' needs no probability: it is the powerset identity ∑_{T⊆A}(2Σ_T − S)² = 2ⁿ∑i² (proved in Erdos1OQ02). Distinctness of the subset sums then forces a *lower* bound on the same quantity.",
+      "**Minimum variance of distinct integers = consecutive block.** Among M distinct integers, the variance is minimised by 0,1,…,M−1, giving (M²−1)/12. The proof never sorts explicitly with inequalities on elements — it transports the whole comparison through a single order embedding and a termwise gap bound, so the only arithmetic is the closed form for the reference block.",
+      "**Spreading widens gaps.** The heart is one line: a strictly monotone integer map satisfies e(j) − e(i) ≥ j − i. Distinct integers cannot be packed tighter than the integers themselves, so every squared difference dominates its consecutive-block counterpart termwise.",
+      "**The (∑y)² term is free.** One does not need the first moment ∑y = 0: since (∑y)² ≥ 0, the extremal inequality M²(M²−1) ≤ 12(M∑y² − (∑y)²) already implies M²(M²−1) ≤ 12M∑y². The deviations being centred only sharpens what is not needed.",
+      "**Why the constant is 1/√12, not √(2/π).** This pure route yields 2ⁿ ≤ √(12Q + 1) ≈ 3.46√Q, weaker than DFX's 3√Q + 2 — exactly as the Erdos1OQ02 note predicts. The sharper DFX constant comes from a parity-interval count, not from the second moment alone. The value here is the *independence and generality* of the argument, and the reusable extremal lemma.",
+      "**A general tool, not just an Erdős application.** distinct_int_variance_lower is a statement about arbitrary finite Y ⊆ ℤ. It is the discrete Popoviciu/variance-lower-bound that Mathlib lacks, and applies anywhere distinct integers must spread (anticoncentration, Sidon-type spacing, additive energy lower bounds)."
+    ],
+    "prerequisites": [
+      "Finset basics (Lean 4 / Mathlib)",
+      "Order embeddings and monotone enumeration of finsets",
+      "Elementary second-moment / variance method",
+      "The second-moment identity from Erdos1OQ02"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Documentation and Imports",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "Module docstring placing the result against the counting bound (OQ01) and DFX bound (OQ02), and against the explicit 'road not taken' note in Erdos1OQ02 (lines 168–171). Imports Proofs.Erdos1OQ02 (for the second-moment identity and doubled-deviation injectivity) and Mathlib.",
+      "mathContext": "The pure second-moment route lower-bounds the spread of the 2ⁿ distinct subset sums by (M³−M)/12 with M = 2ⁿ, giving 2ⁿ ≤ √(12Q+1); the missing ingredient is the general minimum-variance lemma for distinct integers, supplied here."
+    },
+    {
+      "id": "closed-forms",
+      "title": "Part I: Closed Forms for the Consecutive-Block Reference Sums",
+      "startLine": 68,
+      "endLine": 84,
+      "summary": "sum_range_id_int (2∑_{i<M}i = M(M−1)) and sum_range_sq_int (6∑_{i<M}i² = (M−1)M(2M−1)), both over ℤ, by induction with push_cast/ring.",
+      "mathContext": "These are the Gauss and square-pyramidal sums. They pin down the exact pairwise sum ∑_{i,j<M}(i−j)² = M²(M²−1)/6 of the consecutive block, the unique minimiser of variance among M distinct integers."
+    },
+    {
+      "id": "pairwise-identity",
+      "title": "Part II: The Pairwise-Difference Identity",
+      "startLine": 85,
+      "endLine": 102,
+      "summary": "pairwise_sq_eq: ∑_{i,j∈s}(f i − f j)² = 2(|s|·∑f² − (∑f)²) for any f : ι → ℤ. Proved by expanding (f i − f j)² and distributing sums.",
+      "mathContext": "This is twice the (unnormalised) variance: M∑f² − (∑f)² = ½∑_{i,j}(f i − f j)². It converts the variance into a manifestly monotone sum of squared differences, enabling termwise comparison."
+    },
+    {
+      "id": "monotone-enumeration",
+      "title": "Part III: Monotone Enumeration and the Termwise Gap Bound",
+      "startLine": 103,
+      "endLine": 157,
+      "summary": "reindex (sum through Finset.orderEmbOfFin), strictMono_displacement (e j − e i ≥ j − i for i ≤ j, by induction on the gap forcing integer steps ≥ 1), and termwise ((i−j)² ≤ (e i − e j)²).",
+      "mathContext": "A strictly monotone ℤ-valued map cannot move slower than the identity: each successive value increases by at least 1 (Int.add_one_le_iff). Hence distinct integers dominate the consecutive block in every pairwise gap."
+    },
+    {
+      "id": "extremal-lemma",
+      "title": "Part IV: The Extremal Minimum-Variance Lemma",
+      "startLine": 158,
+      "endLine": 198,
+      "summary": "distinct_int_variance_lower: M²(M²−1) ≤ 12(M∑y² − (∑y)²) for any finite Y ⊆ ℤ. Assembles the pairwise identity over Y, the reindex to Fin M, the termwise bound, and the closed-form value of the reference block.",
+      "mathContext": "Equivalently Var(Y) ≥ (M²−1)/12. This is the discrete analogue of Popoviciu's inequality specialised to distinct integers, and is not present in Mathlib. Equality holds exactly for a consecutive block."
+    },
+    {
+      "id": "dss-application",
+      "title": "Part V: The Second-Moment Lower Bound for Erdős #1",
+      "startLine": 199,
+      "endLine": 251,
+      "summary": "dss_sumsq_lower (4ⁿ − 1 ≤ 12∑i²), dss_max_lower (4ⁿ ≤ 12nN² + 1, i.e. max(A) ≳ 2ⁿ/√(12n)), and dss_sumsq_lower_pos (non-vacuity). The doubled deviations form 2ⁿ distinct integers with second moment 2ⁿ∑i²; the extremal lemma plus (∑y)² ≥ 0 and division by 4ⁿ give the bound.",
+      "mathContext": "M = 2ⁿ, ∑y² = 2ⁿ·Q with Q = ∑_{i∈A} i². The extremal lemma gives 4ⁿ(4ⁿ−1) ≤ 12·4ⁿ·Q, so 4ⁿ−1 ≤ 12Q; with Q ≤ nN² this is 4ⁿ ≤ 12nN²+1, a √n improvement over the counting bound n·max(A) ≥ 2ⁿ−1."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry carries out the 'pure second-moment route' that the gallery's Erdos1OQ02 note explicitly left untaken, and in doing so supplies a general extremal lemma absent from Mathlib: the variance of M distinct integers is at least (M²−1)/12 (distinct_int_variance_lower). Applied to the 2ⁿ distinct doubled subset-sum deviations of a distinct-subset-sums set A — whose second moment 2ⁿ∑i² is the previously-verified second_moment_identity — it gives the fully elementary, probability-free lower bound 4ⁿ − 1 ≤ 12∑_{i∈A} i², hence max(A) ≥ 2ⁿ/√(12n). All 10 results are proved in 251 lines with 0 axioms and 0 sorries.",
+    "implications": "The bound is a √n improvement over the counting bound max(A) ≥ (2ⁿ−1)/n, matching the order of the Dubroff–Fox–Xu bound but with a weaker constant (1/√12 ≈ 0.289 versus √(2/π) ≈ 0.798). As the Erdos1OQ02 note predicts, the second moment alone cannot recover the sharper DFX constant — that requires the parity-interval count. The value here is twofold: a *structurally independent* derivation of the √n improvement that uses no probability, entropy, or Fourier analysis; and a *reusable* extremal lemma about distinct integers that applies to any anticoncentration or spacing problem.",
+    "openQuestions": [
+      "**Sharpen the constant within the second-moment framework.** Can a higher-moment (fourth-moment) or weighted variant of distinct_int_variance_lower close the gap between 1/√12 and √(2/π) without invoking the parity-interval count?",
+      "**Mathlib upstreaming.** distinct_int_variance_lower (minimum variance of M distinct integers) is a clean, general statement. Is the right Mathlib home a discrete Popoviciu inequality, stated for any Finset of a linearly ordered integral domain embeddable in ℤ?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1-wip-01",
+      "relationship": "extends",
+      "description": "The parent WIP entry proves the counting-bound precursor sum(A) ≥ 2ⁿ − 1 by pigeonhole. This entry adds the orthogonal second-moment bound ∑i² ≥ (4ⁿ−1)/12, a √n improvement, via the minimum-variance lemma."
+    },
+    {
+      "targetId": "erdos-1-oq-02",
+      "relationship": "extends",
+      "description": "OQ02 formalises the Dubroff–Fox–Xu framework and the second-moment identity ∑_{T⊆A}(2Σ_T−S)² = 2ⁿ∑i², and its source note (lines 168–171) explicitly flags the pure second-moment route as untaken. This entry carries out that route, reusing second_moment_identity and doubledDrop_injOn_of_distinct, and supplies the missing minimum-variance lemma."
+    },
+    {
+      "targetId": "erdos-1-oq-01",
+      "relationship": "related",
+      "description": "OQ01 formalises the counting bound max(A) ≥ (2ⁿ−1)/n. The second-moment bound here improves the denominator from n to √(12n), the first qualitative improvement over counting."
+    },
+    {
+      "targetId": "erdos-1",
+      "relationship": "related",
+      "description": "The main Erdős #1 entry states the \\$500 conjecture max(A) ≥ c·2ⁿ. The bound here contributes the elementary lower constant c ≥ 1/√(12n) toward that question."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "Problems in additive number theory",
+      "year": "1955",
+      "venue": "Proceedings of the International Congress of Mathematicians, Amsterdam"
+    },
+    {
+      "authors": "Dubroff, Quentin; Fox, Jacob; Xu, Max Wenqiang",
+      "title": "A note on the Erdős distinct subset sums problem",
+      "year": "2021",
+      "venue": "SIAM Journal on Discrete Mathematics",
+      "note": "Sharpens the second-moment √n lower bound to N ≥ √(2/π) · 2ⁿ/√n via entropy methods"
+    },
+    {
+      "authors": "Conway, John H.; Guy, Richard K.",
+      "title": "Solution of a problem of P. Erdős",
+      "year": "1968",
+      "venue": "Colloq. Math.",
+      "volume": "20",
+      "pages": "307-309",
+      "note": "Best known upper bound max(A) ≤ 0.22009 · 2ⁿ"
+    },
+    {
+      "authors": "Popoviciu, Tiberiu",
+      "title": "Sur les équations algébriques ayant toutes leurs racines réelles",
+      "year": "1935",
+      "venue": "Mathematica (Cluj)",
+      "note": "Variance bounds of the form Var ≤ (range)²/4; the discrete distinct-integer minimum-variance lemma here is the dual lower bound."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/Erdos1Wip01OQ02.lean",
+    "lineCount": 251,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "axiomCount": 0,
+    "sorries": 0
+  }
+}

--- a/src/data/research/problems/erdos-1-wip-01-oq-02.json
+++ b/src/data/research/problems/erdos-1-wip-01-oq-02.json
@@ -1,0 +1,55 @@
+{
+  "slug": "erdos-1-wip-01-oq-02",
+  "title": "Erdős #1: Second-Moment Lower Bound via Minimum Variance of Distinct Integers",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "significance": 6,
+  "started": "2026-06-30",
+  "path": "Proofs/Erdos1Wip01OQ02.lean",
+  "problemStatement": "Toward the optimal constant in Erdős Problem #1 (Distinct Subset Sums): give a self-contained, probability-free second-moment lower bound, by proving the general extremal fact that M distinct integers have variance ≥ (M²−1)/12 and applying it to the 2ⁿ distinct subset-sum deviations of a DSS set.",
+  "knowledge": {
+    "progressSummary": "COMPLETE (VERIFIED 0-axiom): new gallery entry erdos-1-wip-01-oq-02. Proved the general minimum-variance lemma for distinct integers (Mathlib gap) and used it for a self-contained √n lower bound 4ⁿ−1 ≤ 12∑i² ⟹ max(A) ≥ 2ⁿ/√(12n). Carries out the 'pure second-moment route' the Erdos1OQ02 note left untaken. The Erdős $500 conjecture (constant c independent of n) remains OPEN.",
+    "insights": [
+      "The variance of a uniformly random subset sum equals ¼∑aᵢ² and is purely combinatorial — it is the powerset second-moment identity ∑_{T⊆A}(2Σ_T−S)² = 2ⁿ∑i² (already in Erdos1OQ02). Distinctness then forces a LOWER bound on the same quantity.",
+      "The first moment ∑y=0 is NOT needed: since (∑y)² ≥ 0, the extremal inequality M²(M²−1) ≤ 12(M∑y² − (∑y)²) already implies M²(M²−1) ≤ 12M∑y², which is all the application uses.",
+      "The minimum-variance comparison is proved without explicit element inequalities: transport the whole pairwise-difference sum through a single order embedding Finset.orderEmbOfFin and a termwise gap bound e j − e i ≥ j − i; the only closed-form arithmetic is for the consecutive reference block.",
+      "The constant is 1/√12 ≈ 0.289, weaker than DFX's √(2/π) ≈ 0.798 — exactly as the Erdos1OQ02 note predicts: the second moment alone cannot recover the sharper constant (that needs the parity-interval count). The value is the structural independence and the reusable extremal lemma."
+    ],
+    "builtItems": [
+      "Erdos1Wip01OQ02.lean: distinct_int_variance_lower (general extremal min-variance for distinct integers, M²(M²−1) ≤ 12(M∑y²−(∑y)²)), pairwise_sq_eq, strictMono_displacement, termwise, reindex, sum_range_id_int, sum_range_sq_int, dss_sumsq_lower (4ⁿ−1 ≤ 12∑i²), dss_max_lower (4ⁿ ≤ 12nN²+1), dss_sumsq_lower_pos — 251 lines, 10 theorems, 0 def, 0 sorry, 0 axiom VERIFIED.",
+      "Gallery entry src/data/proofs/erdos-1-wip-01-oq-02 (meta + 6 annotations)."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks the minimum-variance lemma for distinct integers (discrete dual of Popoviciu): for any Finset Y ⊆ ℤ, Var(Y) ≥ (|Y|²−1)/12. distinct_int_variance_lower fills this locally and is a clean upstreaming candidate."
+    ],
+    "nextSteps": [
+      "Investigate whether a fourth-moment or weighted variant of distinct_int_variance_lower can close the gap between 1/√12 and √(2/π) without the parity-interval count.",
+      "Consider upstreaming distinct_int_variance_lower to Mathlib as a discrete Popoviciu / minimum-variance-of-distinct-integers lemma."
+    ],
+    "markdown": ""
+  },
+  "knownResults": [
+    "Counting bound max(A) ≥ (2ⁿ−1)/n (erdos-1-oq-01).",
+    "Dubroff–Fox–Xu entropy bound max(A) ≥ √(2/π)·2ⁿ/√n (erdos-1-oq-02).",
+    "Conway–Guy upper bound max(A) ≤ 0.22009·2ⁿ."
+  ],
+  "leanFiles": ["Proofs/Erdos1Wip01OQ02.lean"],
+  "relatedProofs": ["erdos-1-wip-01", "erdos-1-oq-01", "erdos-1-oq-02", "erdos-1"],
+  "references": [
+    "Erdős, Problems in additive number theory (1955)",
+    "Dubroff, Fox, Xu, A note on the Erdős distinct subset sums problem (2021)",
+    "Conway, Guy, Solution of a problem of P. Erdős (1968)"
+  ],
+  "currentState": "SOLVED (new verified gallery entry). The Erdős #1 $500 conjecture itself remains open.",
+  "tags": [
+    "erdos",
+    "additive-combinatorics",
+    "subset-sums",
+    "extremal-combinatorics",
+    "second-moment-method",
+    "variance",
+    "combinatorics",
+    "number-theory"
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **erdos-1-wip-01-oq-02** — a self-contained, probability-free **second-moment lower bound** for Erdős Problem #1 (Distinct Subset Sums), built on a general extremal lemma absent from Mathlib.

`Proofs/Erdos1Wip01OQ02.lean` — 251 lines, 10 theorems, **0 sorries, 0 axioms** (verified via `#print axioms`: only `propext`/`Classical.choice`/`Quot.sound`).

### What & why

The gallery's `Erdos1OQ02` entry formalises the Dubroff–Fox–Xu framework and the second-moment identity `∑_{T⊆A}(2Σ_T−S)² = 2ⁿ∑i²`. Its source note (lines 168–171) **explicitly records a road not taken**: the *pure* second-moment route, which needs a lower bound on the spread of the `2ⁿ` distinct subset sums. This PR carries out exactly that route and supplies the missing general fact:

> **`distinct_int_variance_lower`** — for any finite `Y ⊆ ℤ` with `M = |Y|`,
> `M²(M²−1) ≤ 12·(M·∑y² − (∑y)²)`, i.e. `Var(Y) ≥ (M²−1)/12`. The variance of `M` distinct integers is minimised by a consecutive block. *(Not in Mathlib — a clean upstreaming candidate, the discrete dual of Popoviciu.)*

**Proof** (elementary): the pairwise identity `∑_{i,j}(f i − f j)² = 2(M∑f² − (∑f)²)`; enumerate `Y` in increasing order via `Finset.orderEmbOfFin`; a strictly monotone integer map satisfies `e j − e i ≥ j − i`, so termwise `(i−j)² ≤ (e i − e j)²`; summing reduces to the consecutive block, whose value is the exact `M²(M²−1)/6` (Gauss + square-pyramidal closed forms).

### Application to Erdős #1

Taking `Y` = the `2ⁿ` distinct doubled deviations `{2Σ_T − S : T ⊆ A}` (distinct because `A` is DSS), with second moment `2ⁿ∑i²` (reusing `Erdos1OQ02.second_moment_identity` and `doubledDrop_injOn_of_distinct`), and using `(∑y)² ≥ 0` + division by `4ⁿ`:

- `dss_sumsq_lower : 4ⁿ − 1 ≤ 12·∑_{i∈A} i²`
- `dss_max_lower   : 4ⁿ ≤ 12·n·N² + 1`  — i.e. `max(A) ≳ 2ⁿ/√(12n)`

a **√n improvement** over the counting bound `n·max(A) ≥ 2ⁿ−1`, with no probability/entropy/Fourier.

### Honest scope

The constant `1/√12 ≈ 0.289` is **weaker** than DFX's `√(2/π) ≈ 0.798` — exactly as the `Erdos1OQ02` note predicts (the sharper constant needs the parity-interval count, not the second moment alone). The value is the **structural independence** of the derivation and the **reusable extremal lemma**. The Erdős #1 \$500 conjecture (constant `c` independent of `n`) remains **open**.

### Files
- `proofs/Proofs/Erdos1Wip01OQ02.lean` (new)
- `src/data/proofs/erdos-1-wip-01-oq-02/{meta,annotations}.json` (new gallery entry, 6 annotations)
- `src/data/research/problems/erdos-1-wip-01-oq-02.json` (new knowledge record)

### Verification
Built with host `lake env lean` (Docker daemon down this session); fresh compile exits 0, `#print axioms` confirms 0-axiom for all four headline theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)