### PR TITLE
research(cramers-rule-oq-02-oq-01-oq-01): split n³/3 flop count into multiplications vs divisions [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CramersRuleOQ02OQ01OQ01.lean
+++ b/proofs/Proofs/CramersRuleOQ02OQ01OQ01.lean
@@ -1,0 +1,194 @@
+import Mathlib
+
+/-
+# Splitting the Gaussian-Elimination Multiply Count: divisions vs multiplications (OQ-02-OQ-01-OQ-01)
+
+## Research Question
+
+The parent entry `CramersRuleOQ02OQ01` proves the exact forward-elimination
+multiplication+division count
+
+  `gaussExactOps n = ∑_{j<n} (j² + j) = (n³ − n)/3`
+
+as a *single lumped* quantity, and separately counts the subtractions
+`∑_{j<n} j² ≈ n³/3`. But the lumped `j² + j` per step mixes two different
+arithmetic operations: at the step that clears a column with `j` rows beneath
+the pivot we perform
+
+- `j` **divisions** (one multiplier per row below the pivot), and
+- `j²` **multiplications** (scaling the `j` trailing entries of each of the
+  `j` rows).
+
+Which of the two carries the `n³/3` headline, and how subdominant is the other?
+
+## Answer
+
+Splitting `gaussExactOps n = gaussMults n + gaussDivs n` where
+
+  `gaussMults n = ∑_{j<n} j²`  (multiplications)   and
+  `gaussDivs  n = ∑_{j<n} j`   (divisions),
+
+we prove:
+
+- `gaussMults n` carries the entire cubic term: `6·gaussMults n + 3n² = 2n³ + n`,
+  so `gaussMults n = (2n³ − 3n² + n)/6 ≈ n³/3`, and `6·gaussMults n ≤ 2n³`.
+- `gaussDivs n` is purely **quadratic**: `2·gaussDivs n + n = n²`, i.e.
+  `gaussDivs n = (n² − n)/2 = C(n,2)` — the triangular numbers, `Θ(n²)`.
+- Hence the divisions are asymptotically negligible:
+  `gaussDivs n ≤ gaussMults n` for all `n` (strict for `n ≥ 3`), and the whole
+  `n³/3` of `gaussExactOps` comes from the multiplications.
+
+This refines the "`n³/3` flops" headline: of the `(n³−n)/3` multiply/divide
+operations, the `Θ(n²)` divisions vanish into the lower-order terms and the
+cubic constant `1/3` is entirely a *multiplication* count.
+
+## What is proved here (no axioms, no sorry, no native_decide)
+
+- `gaussMults`, `gaussDivs` and the lumped `gaussOps = gaussMults + gaussDivs`.
+- `gaussOps_split` : `∑_{j<n} (j²+j) = gaussMults n + gaussDivs n`.
+- `gaussDivs_closed` : `2·gaussDivs n + n = n²` (triangular numbers).
+- `gaussDivs_eq_choose` : `gaussDivs n = n.choose 2`.
+- `gaussMults_closed` : `6·gaussMults n + 3n² = 2n³ + n`.
+- `gaussMults_le_third` : `6·gaussMults n ≤ 2n³` (the multiplications alone are `≤ n³/3`).
+- `gaussDivs_le_mults` : `gaussDivs n ≤ gaussMults n` (divisions subdominant);
+  `gaussDivs_lt_mults` strict for `n ≥ 3`.
+- `gaussOps_closed` : `3·gaussOps n + n = n³` (recovers the parent's `(n³−n)/3`).
+
+## Proof techniques
+
+- `Finset.sum_range_succ` for the inductive unfolding of each `∑`.
+- Subtraction-free `calc`/`ring` over the `ℕ` semiring for the closed forms.
+- `omega` to read off bounds from the linear closed-form identities (treating
+  `n²`, `n³` and the sums as opaque non-negative atoms).
+- `Finset.sum_le_sum` with the pointwise `j ≤ j²` for the dominance comparison.
+- `Nat.choose_two_right` to identify the divisions with the binomial `C(n,2)`.
+-/
+
+namespace CramersComplexityOpSplit
+
+open Finset
+
+/-- Exact **multiplication** count of forward elimination: at the step clearing a
+    column with `j` rows beneath the pivot, each of those `j` rows has `j` trailing
+    entries scaled by the multiplier — `j²` multiplications per step, summed over
+    `j < n`. -/
+def gaussMults (n : ℕ) : ℕ := ∑ j ∈ range n, j ^ 2
+
+/-- Exact **division** count of forward elimination: at the step clearing a column
+    with `j` rows beneath the pivot we form one multiplier per row — `j` divisions
+    per step, summed over `j < n`. -/
+def gaussDivs (n : ℕ) : ℕ := ∑ j ∈ range n, j
+
+/-- The lumped multiply/divide count of the parent entry, here exhibited as the
+    sum of its two constituent operations. -/
+def gaussOps (n : ℕ) : ℕ := ∑ j ∈ range n, (j ^ 2 + j)
+
+/-- Unfolding one elimination step for the multiplication count. -/
+lemma gaussMults_succ (n : ℕ) : gaussMults (n + 1) = gaussMults n + n ^ 2 := by
+  unfold gaussMults; rw [Finset.sum_range_succ]
+
+/-- Unfolding one elimination step for the division count. -/
+lemma gaussDivs_succ (n : ℕ) : gaussDivs (n + 1) = gaussDivs n + n := by
+  unfold gaussDivs; rw [Finset.sum_range_succ]
+
+/-- **The split.** The lumped multiply/divide count is exactly multiplications plus
+    divisions: `∑_{j<n} (j²+j) = gaussMults n + gaussDivs n`. -/
+theorem gaussOps_split (n : ℕ) : gaussOps n = gaussMults n + gaussDivs n := by
+  unfold gaussOps gaussMults gaussDivs
+  rw [← Finset.sum_add_distrib]
+
+/-- **Closed form for the divisions (subtraction-free).** `2·gaussDivs n + n = n²`,
+    i.e. `gaussDivs n = (n² − n)/2` — the triangular numbers, a purely `Θ(n²)` count. -/
+theorem gaussDivs_closed (n : ℕ) : 2 * gaussDivs n + n = n ^ 2 := by
+  induction n with
+  | zero => simp [gaussDivs]
+  | succ m ih =>
+    calc 2 * gaussDivs (m + 1) + (m + 1)
+        = (2 * gaussDivs m + m) + (2 * m + 1) := by rw [gaussDivs_succ]; ring
+      _ = m ^ 2 + (2 * m + 1) := by rw [ih]
+      _ = (m + 1) ^ 2 := by ring
+
+/-- The divisions are the binomial `C(n,2)`: `gaussDivs n = n.choose 2`. -/
+theorem gaussDivs_eq_choose (n : ℕ) : gaussDivs n = n.choose 2 := by
+  rw [Nat.choose_two_right]
+  have h : 2 * gaussDivs n = n * (n - 1) := by
+    have hc := gaussDivs_closed n
+    cases n with
+    | zero => simp [gaussDivs]
+    | succ k =>
+      have : (k + 1) ^ 2 = (k + 1) * ((k + 1) - 1) + (k + 1) := by
+        simp [pow_two]; ring
+      omega
+  rw [← h, Nat.mul_div_cancel_left _ (by norm_num : 0 < 2)]
+
+/-- **Closed form for the multiplications (subtraction-free).**
+    `6·gaussMults n + 3n² = 2n³ + n`, i.e. `gaussMults n = (2n³ − 3n² + n)/6 ≈ n³/3`. -/
+theorem gaussMults_closed (n : ℕ) : 6 * gaussMults n + 3 * n ^ 2 = 2 * n ^ 3 + n := by
+  induction n with
+  | zero => simp [gaussMults]
+  | succ m ih =>
+    calc 6 * gaussMults (m + 1) + 3 * (m + 1) ^ 2
+        = (6 * gaussMults m + 3 * m ^ 2) + (6 * m ^ 2 + 6 * m + 3) := by
+          rw [gaussMults_succ]; ring
+      _ = (2 * m ^ 3 + m) + (6 * m ^ 2 + 6 * m + 3) := by rw [ih]
+      _ = 2 * (m + 1) ^ 3 + (m + 1) := by ring
+
+/-- **The multiplications alone are `≤ n³/3`.** `6·gaussMults n ≤ 2n³`, the cubic-term
+    bound; together with `gaussMults_closed` it pins the leading constant of the
+    multiplication count at exactly `1/3`. -/
+theorem gaussMults_le_third (n : ℕ) : 6 * gaussMults n ≤ 2 * n ^ 3 := by
+  induction n with
+  | zero => simp [gaussMults]
+  | succ m ih =>
+    rw [gaussMults_succ]
+    nlinarith [ih]
+
+/-- **Divisions are subdominant.** `gaussDivs n ≤ gaussMults n` for every `n`,
+    since `j ≤ j²` term by term. -/
+theorem gaussDivs_le_mults (n : ℕ) : gaussDivs n ≤ gaussMults n := by
+  unfold gaussDivs gaussMults
+  apply Finset.sum_le_sum
+  intro j _
+  nlinarith [Nat.zero_le j]
+
+/-- The dominance is **strict** for `n ≥ 3`: by then the `j = 2` term already gives
+    `2 < 4`, so the multiplications strictly exceed the divisions. -/
+theorem gaussDivs_lt_mults {n : ℕ} (hn : 3 ≤ n) : gaussDivs n < gaussMults n := by
+  have hd := gaussDivs_closed n
+  have hm := gaussMults_closed n
+  nlinarith [hd, hm, hn]
+
+/-- **Recovers the parent's lumped closed form.** `3·gaussOps n + n = n³`, hence
+    `gaussOps n = (n³ − n)/3`, now seen as the sum of a cubic multiplication count
+    and a quadratic division count. -/
+theorem gaussOps_closed (n : ℕ) : 3 * gaussOps n + n = n ^ 3 := by
+  rw [gaussOps_split]
+  have hd := gaussDivs_closed n
+  have hm := gaussMults_closed n
+  nlinarith [hd, hm]
+
+/-- Concrete split counts (sanity check against the hand computation):
+    multiplications `n=2↦1, n=3↦5, n=4↦14, n=5↦30`;
+    divisions       `n=2↦1, n=3↦3, n=4↦6,  n=5↦10` (triangular). -/
+lemma split_small :
+    gaussMults 2 = 1 ∧ gaussMults 3 = 5 ∧ gaussMults 4 = 14 ∧ gaussMults 5 = 30 ∧
+    gaussDivs 2 = 1 ∧ gaussDivs 3 = 3 ∧ gaussDivs 4 = 6 ∧ gaussDivs 5 = 10 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    simp [gaussMults, gaussDivs, Finset.sum_range_succ]
+
+/-- Summary: the multiply/divide count splits into a cubic multiplication count and a
+    quadratic (triangular) division count; the multiplications carry the entire
+    `n³/3`, the divisions are `C(n,2) = Θ(n²)` and subdominant, and their sum recovers
+    the parent's `(n³ − n)/3`. -/
+theorem op_split_summary :
+    (∀ n : ℕ, gaussOps n = gaussMults n + gaussDivs n) ∧
+    (∀ n : ℕ, 2 * gaussDivs n + n = n ^ 2) ∧
+    (∀ n : ℕ, gaussDivs n = n.choose 2) ∧
+    (∀ n : ℕ, 6 * gaussMults n + 3 * n ^ 2 = 2 * n ^ 3 + n) ∧
+    (∀ n : ℕ, 6 * gaussMults n ≤ 2 * n ^ 3) ∧
+    (∀ n : ℕ, gaussDivs n ≤ gaussMults n) ∧
+    (∀ n : ℕ, 3 * gaussOps n + n = n ^ 3) :=
+  ⟨gaussOps_split, gaussDivs_closed, gaussDivs_eq_choose, gaussMults_closed,
+   gaussMults_le_third, gaussDivs_le_mults, gaussOps_closed⟩
+
+end CramersComplexityOpSplit

--- a/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,109 @@
+[
+  {
+    "id": "ann-cramer-oq020101-01-defs",
+    "proofId": "cramers-rule-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 90
+    },
+    "type": "concept",
+    "title": "Two Operations, Separated",
+    "content": "Defines the multiplication count `gaussMults n = ∑_{j<n} j²`, the division count `gaussDivs n = ∑_{j<n} j`, and the lumped `gaussOps n = ∑_{j<n} (j² + j)` of the parent entry. At the elimination step with `j` rows below the pivot, each of those `j` rows costs one division (forming the multiplier) and `j` multiplications (scaling its trailing entries) — `j` divisions and `j²` multiplications per step. The file imports only Mathlib and re-derives the lumped count locally, so it stands alone.",
+    "mathContext": "$\\texttt{gaussMults}\\,n = \\sum_{j<n} j^2$, $\\texttt{gaussDivs}\\,n = \\sum_{j<n} j$, $\\texttt{gaussOps}\\,n = \\sum_{j<n} (j^2+j)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gaussian-elimination",
+      "operation-count",
+      "finite-sums"
+    ],
+    "prerequisites": [
+      "Lean-imports",
+      "Mathlib"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq020101-02-split",
+    "proofId": "cramers-rule-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "The Split",
+    "content": "`gaussOps_split` shows the lumped count is exactly multiplications plus divisions: `∑_{j<n} (j²+j) = gaussMults n + gaussDivs n`, immediate from `Finset.sum_add_distrib`. Everything downstream analyses the two summands separately.",
+    "mathContext": "$\\sum_{j<n}(j^2+j) = \\sum_{j<n} j^2 + \\sum_{j<n} j$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_add_distrib",
+      "operation-count"
+    ],
+    "prerequisites": [
+      "finite-sums"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq020101-03-divisions",
+    "proofId": "cramers-rule-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 135
+    },
+    "type": "theorem",
+    "title": "Divisions are the Triangular Numbers C(n,2)",
+    "content": "`gaussDivs_closed` proves `2·gaussDivs n + n = n²` by a subtraction-free induction in the ℕ semiring (calc + ring), and `gaussDivs_eq_choose` matches it to `n.choose 2` via `Nat.choose_two_right` and `Nat.mul_div_cancel_left`. So the division count is `(n²−n)/2 = C(n,2)` — the triangular numbers, a purely Θ(n²) quantity.",
+    "mathContext": "$\\texttt{gaussDivs}\\,n = \\tfrac{n(n-1)}{2} = \\binom{n}{2}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "triangular-numbers",
+      "binomial-coefficients",
+      "Nat.choose_two_right"
+    ],
+    "prerequisites": [
+      "induction",
+      "binomial-coefficients"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq020101-04-multiplications",
+    "proofId": "cramers-rule-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 137,
+      "endLine": 162
+    },
+    "type": "theorem",
+    "title": "Multiplications Carry the n³/3",
+    "content": "`gaussMults_closed` proves `6·gaussMults n + 3n² = 2n³ + n` (so `gaussMults n = (2n³−3n²+n)/6 ≈ n³/3`), and `gaussMults_le_third` proves `6·gaussMults n ≤ 2n³` by induction with `nlinarith` on the successor expansion. Together they pin the leading constant of the multiplication count at exactly 1/3.",
+    "mathContext": "$\\texttt{gaussMults}\\,n = \\sum_{j<n} j^2 = \\tfrac{2n^3-3n^2+n}{6} \\sim \\tfrac{n^3}{3}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "square-pyramidal-number",
+      "asymptotic-leading-constant"
+    ],
+    "prerequisites": [
+      "induction",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq020101-05-dominance",
+    "proofId": "cramers-rule-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 164,
+      "endLine": 194
+    },
+    "type": "theorem",
+    "title": "Divisions Subdominant; Recovering the Lumped Count",
+    "content": "`gaussDivs_le_mults` proves `gaussDivs n ≤ gaussMults n` term by term (`Finset.sum_le_sum` with `j ≤ j²`), and `gaussDivs_lt_mults` strengthens it to strict for `n ≥ 3` via `nlinarith` on the two closed forms — the Θ(n²) divisions vanish beside the cubic multiplications. `gaussOps_closed` (`3·gaussOps n + n = n³`) then recovers the parent's `(n³ − n)/3` from the split.",
+    "mathContext": "$\\texttt{gaussDivs}\\,n \\le \\texttt{gaussMults}\\,n$, and $3\\,\\texttt{gaussOps}\\,n + n = n^3$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_le_sum",
+      "asymptotic-dominance",
+      "operation-count"
+    ],
+    "prerequisites": [
+      "finite-sums",
+      "nlinarith"
+    ]
+  }
+]

--- a/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CramersRuleOQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cramersRuleOq02Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cramersRuleOq02Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cramersRuleOq02Oq01Oq01Data: ProofData = {
+  proof: cramersRuleOq02Oq01Oq01Proof,
+  annotations: cramersRuleOq02Oq01Oq01Annotations,
+}

--- a/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "cramers-rule-oq-02-oq-01-oq-01",
+  "title": "Splitting the n³/3 Flop Count: Multiplications vs Divisions",
+  "slug": "cramers-rule-oq-02-oq-01-oq-01",
+  "description": "An axiom-free Lean 4 proof that the exact (n³ − n)/3 multiply/divide count of forward Gaussian elimination splits into a cubic multiplication count ∑_{j<n} j² (carrying the entire n³/3) and a quadratic division count ∑_{j<n} j = C(n,2) (the triangular numbers, Θ(n²) and subdominant). Refines the parent's lumped count by showing the 1/3 leading constant is purely a multiplication count.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_elimination#Computational_efficiency",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CramersRuleOQ02OQ01OQ01.lean",
+    "tags": [
+      "computational-complexity",
+      "linear-algebra",
+      "combinatorics",
+      "gaussian-elimination",
+      "cramer",
+      "algorithms",
+      "finset-sum",
+      "binomial-coefficients",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peeling the last term of a range sum: ∑_{x<n+1} f x = ∑_{x<n} f x + f n",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_add_distrib",
+        "description": "Distributing a sum over a pointwise addition: ∑ (f + g) = ∑ f + ∑ g",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_le_sum",
+        "description": "Monotonicity of a finite sum under a pointwise inequality of summands",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Nat.choose_two_right",
+        "description": "n.choose 2 = n * (n - 1) / 2 — the triangular-number form of the binomial",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel_left",
+        "description": "Exact division cancellation: 0 < b → b * a / b = a",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "Operation split gaussOps_split: the parent's lumped multiply/divide count ∑_{j<n} (j²+j) factors as gaussMults n + gaussDivs n, separating the j² multiplications from the j divisions performed at the step with j rows below the pivot",
+      "Division count is purely quadratic: gaussDivs_closed (2·gaussDivs n + n = n²) identifies the divisions with the triangular numbers (n²−n)/2, and gaussDivs_eq_choose proves gaussDivs n = C(n,2) via Nat.choose_two_right",
+      "Multiplication count carries the cubic term: gaussMults_closed (6·gaussMults n + 3n² = 2n³ + n), i.e. gaussMults n = (2n³−3n²+n)/6 ≈ n³/3, with gaussMults_le_third (6·gaussMults n ≤ 2n³) pinning the leading constant at exactly 1/3",
+      "Divisions are subdominant: gaussDivs_le_mults (gaussDivs n ≤ gaussMults n for all n, via Finset.sum_le_sum and the pointwise j ≤ j²) and gaussDivs_lt_mults (strict for n ≥ 3) show the Θ(n²) divisions vanish into the lower-order terms",
+      "Recovers the parent's lumped closed form gaussOps_closed: 3·gaussOps n + n = n³, now decomposed as a cubic multiplication count plus a quadratic division count",
+      "Concrete split counts split_small (multiplications 1,5,14,30 and divisions 1,3,6,10 for n=2..5) derived from the Finset sums, no native_decide"
+    ],
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 194,
+    "assumptions": "None. Fully kernel-checked: 0 sorries, 0 axiom declarations, 0 assumption-carrying structures, and no native_decide (#print axioms reports only propext, Classical.choice, Quot.sound; no Lean.ofReduceBool, no sorryAx). The file is self-contained — it imports only Mathlib and re-derives the lumped count locally, so it carries no dependency on the parent file.",
+    "theoremCount": 12,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "**Which operation carries the n³/3?**\n\nThe textbook 'n³/3 flop' figure for Gaussian elimination counts multiplications and divisions together. The parent entry (cramers-rule-oq-02-oq-01) formalized this lumped count as gaussExactOps n = ∑_{j<n} (j² + j) = (n³ − n)/3. But the per-step summand j² + j conflates two genuinely different arithmetic operations: j² multiplications (scaling trailing entries) and j divisions (forming multipliers). This entry asks which of the two is responsible for the cubic leading term — and how negligible the other is.",
+    "problemStatement": "**The Research Question (cramers-rule-oq-02-oq-01-oq-01)**\n\nSplit the lumped multiply/divide count gaussOps n = ∑_{j<n} (j² + j) into its multiplication part gaussMults n = ∑_{j<n} j² and division part gaussDivs n = ∑_{j<n} j, and determine the exact closed form and asymptotic role of each.\n\n**Answer:** The multiplications carry the entire n³/3, while the divisions are only Θ(n²):\n1. gaussMults n = (2n³ − 3n² + n)/6 ≈ n³/3, with 6·gaussMults n ≤ 2n³.\n2. gaussDivs n = (n² − n)/2 = C(n,2), the triangular numbers.\n3. gaussDivs n ≤ gaussMults n for all n (strict for n ≥ 3), so the divisions are subdominant; their sum recovers the parent's (n³ − n)/3.",
+    "text": "An axiom-free Lean 4 proof that the (n³ − n)/3 multiply/divide count of forward Gaussian elimination splits into a cubic ∑_{j<n} j² multiplication count (the whole n³/3) and a quadratic ∑_{j<n} j = C(n,2) division count, with the divisions provably subdominant.",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Definitions**: gaussMults n = ∑_{j∈range n} j² (multiplications), gaussDivs n = ∑_{j∈range n} j (divisions), and the lumped gaussOps n = ∑_{j∈range n} (j² + j).\n2. **Split**: gaussOps_split is immediate from Finset.sum_add_distrib.\n3. **One-step lemmas**: gaussMults_succ and gaussDivs_succ by Finset.sum_range_succ.\n4. **Closed forms by induction (subtraction-free, ℕ semiring)**: 2·gaussDivs n + n = n² and 6·gaussMults n + 3n² = 2n³ + n, each closing with a three-line calc + ring.\n5. **Binomial identity**: gaussDivs_eq_choose rewrites Nat.choose_two_right and matches the closed form via Nat.mul_div_cancel_left.\n6. **Cubic bound by induction**: gaussMults_le_third (6·gaussMults n ≤ 2n³) via nlinarith on the successor expansion.\n7. **Dominance**: gaussDivs_le_mults from Finset.sum_le_sum with the pointwise j ≤ j²; gaussDivs_lt_mults strict for n ≥ 3 via nlinarith on the two closed forms.\n8. **Recovery**: gaussOps_closed (3·gaussOps n + n = n³) from the split plus the two closed forms.",
+    "keyInsights": [
+      "**The 1/3 is a multiplication constant, not a multiply/divide constant**: gaussMults_closed plus gaussMults_le_third show ∑_{j<n} j² already carries the full n³/3; the divisions contribute nothing to the leading term.",
+      "**Divisions are exactly the triangular numbers**: gaussDivs n = C(n,2) = (n² − n)/2 is the clean binomial identity behind 'one division per row below each pivot', a purely Θ(n²) cost.",
+      "**Subtraction-free closed forms keep induction in ℕ**: stating 2·gaussDivs n + n = n² and 6·gaussMults n + 3n² = 2n³ + n (rather than the division forms) lets plain ring close each successor step in the ℕ semiring; the C(n,2) and /6 forms are corollaries.",
+      "**Pointwise domination gives the asymptotic comparison cheaply**: gaussDivs n ≤ gaussMults n follows term by term from j ≤ j² via Finset.sum_le_sum, no closed form needed — and nlinarith on the two closed forms upgrades it to strict for n ≥ 3.",
+      "**Axiom-free throughout**: the concrete small-n counts come from the Finset sums and the bounds from nlinarith/omega over the closed-form atoms, so the file uses no native_decide and #print axioms shows only the three foundational axioms."
+    ],
+    "prerequisites": [
+      "Numerical linear algebra (Gaussian elimination, multiplier/division vs trailing-entry multiplication)",
+      "Finite sums and their polynomial closed forms (∑ j, ∑ j², triangular and square-pyramidal numbers)",
+      "Binomial coefficients (C(n,2) as the triangular numbers) and elementary ℕ induction in Lean"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Definitions",
+      "summary": "Imports Mathlib and defines the multiplication count gaussMults n = ∑_{j<n} j², the division count gaussDivs n = ∑_{j<n} j, and the lumped gaussOps n = ∑_{j<n} (j² + j). Self-contained: no dependency on the parent file.",
+      "startLine": 1,
+      "endLine": 90,
+      "mathContext": "Separates the two arithmetic operations the parent entry counted together at each elimination step: j² multiplications and j divisions when j rows remain below the pivot."
+    },
+    {
+      "id": "split",
+      "title": "The Operation Split",
+      "summary": "gaussOps_split: ∑_{j<n} (j²+j) = gaussMults n + gaussDivs n, immediate from Finset.sum_add_distrib.",
+      "startLine": 91,
+      "endLine": 110,
+      "mathContext": "Exhibits the lumped multiply/divide count as the sum of its two constituent operation counts."
+    },
+    {
+      "id": "divisions",
+      "title": "Divisions: the Triangular Numbers C(n,2)",
+      "summary": "gaussDivs_closed (2·gaussDivs n + n = n²) and gaussDivs_eq_choose (gaussDivs n = n.choose 2) identify the division count with the triangular numbers, a purely Θ(n²) quantity.",
+      "startLine": 111,
+      "endLine": 140,
+      "mathContext": "One division per row below each pivot sums to ∑_{j<n} j = C(n,2) = (n²−n)/2."
+    },
+    {
+      "id": "multiplications",
+      "title": "Multiplications: the Cubic n³/3",
+      "summary": "gaussMults_closed (6·gaussMults n + 3n² = 2n³ + n) and gaussMults_le_third (6·gaussMults n ≤ 2n³) show the multiplications carry the entire n³/3 leading term.",
+      "startLine": 141,
+      "endLine": 165,
+      "mathContext": "∑_{j<n} j² = (2n³−3n²+n)/6 is the square-pyramidal closed form, asymptotically n³/3."
+    },
+    {
+      "id": "dominance",
+      "title": "Divisions are Subdominant; Recovery of the Lumped Count",
+      "summary": "gaussDivs_le_mults (≤ for all n) and gaussDivs_lt_mults (strict for n ≥ 3) show the Θ(n²) divisions are dominated by the cubic multiplications; gaussOps_closed (3·gaussOps n + n = n³) recovers the parent's (n³ − n)/3 from the split.",
+      "startLine": 166,
+      "endLine": 194,
+      "mathContext": "Term-by-term j ≤ j² gives the domination; summing the two closed forms returns the parent's lumped count."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry decomposes the parent's exact (n³ − n)/3 multiply/divide count of forward Gaussian elimination into its two constituent operations: the multiplications ∑_{j<n} j² = (2n³−3n²+n)/6 ≈ n³/3, which carry the entire cubic leading term, and the divisions ∑_{j<n} j = C(n,2) = (n²−n)/2, the triangular numbers, which are only Θ(n²). The closed forms are proved by short subtraction-free inductions in the ℕ semiring, the binomial identity via Nat.choose_two_right, the cubic bound by nlinarith, and the domination gaussDivs n ≤ gaussMults n term by term via Finset.sum_le_sum. The file is axiom-free (no sorries, no native_decide) and self-contained.",
+    "implications": "The refinement shows that the famous 1/3 leading constant of the Gaussian-elimination flop count is purely a multiplication constant — the divisions, though one per eliminated entry, sum only to the quadratic triangular number C(n,2) and disappear into the lower-order terms. This matters for cost models that weight multiplications and divisions differently (e.g. on hardware where division is far more expensive than multiplication): the division work is asymptotically negligible, so a high per-division cost still leaves the n³/3 multiplication term in charge. The subtraction-free 'k·sum + remainder = closed form' template again keeps every induction inside the ℕ semiring, reusable for any exact polynomial operation count.",
+    "openQuestions": [
+      "Weight the two operation classes by realistic hardware costs (division ≫ multiplication) and confirm the leading n³/3 term is unaffected once the Θ(n²) divisions are scaled.",
+      "Extend the multiplication/division split to the back-substitution phase (≈ n²/2) and to blocked/partial-pivoting LU, tracking how pivoting redistributes divisions without changing the cubic multiplication count.",
+      "Formalize the square-pyramidal identity ∑_{j<n} j² = C(n+1,2) + 2·C(n+1,3) to connect the multiplication count directly to binomial coefficients, paralleling the divisions = C(n,2) result."
+    ]
+  },
+  "relatedProblems": [
+    "cramers-rule-oq-02-oq-01",
+    "cramers-rule-oq-02",
+    "cramers-rule"
+  ],
+  "mainTheorems": [
+    {
+      "name": "gaussOps_split",
+      "statement": "gaussOps n = gaussMults n + gaussDivs n",
+      "description": "The lumped multiply/divide count splits into the multiplication count ∑_{j<n} j² and the division count ∑_{j<n} j."
+    },
+    {
+      "name": "gaussDivs_eq_choose",
+      "statement": "gaussDivs n = n.choose 2",
+      "description": "The division count equals the binomial C(n,2) — the triangular numbers, a purely Θ(n²) quantity."
+    },
+    {
+      "name": "gaussMults_le_third",
+      "statement": "6 * gaussMults n ≤ 2 * n ^ 3",
+      "description": "The multiplications alone are ≤ n³/3; with gaussMults_closed this pins the leading constant of the multiplication count at exactly 1/3."
+    },
+    {
+      "name": "gaussDivs_le_mults",
+      "statement": "gaussDivs n ≤ gaussMults n",
+      "description": "The divisions are subdominant: term by term j ≤ j², so the cubic multiplications dominate the quadratic divisions."
+    },
+    {
+      "name": "gaussOps_closed",
+      "statement": "3 * gaussOps n + n = n ^ 3",
+      "description": "Recovers the parent's lumped (n³ − n)/3 count from the split of a cubic multiplication count and a quadratic division count."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/CramersRuleOQ02OQ01OQ01.lean",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 3,
+    "lineCount": 194
+  },
+  "references": [
+    {
+      "title": "Gaussian elimination — Computational efficiency (operation count)",
+      "url": "https://en.wikipedia.org/wiki/Gaussian_elimination#Computational_efficiency"
+    },
+    {
+      "title": "Square pyramidal number — ∑ j² closed form",
+      "url": "https://en.wikipedia.org/wiki/Square_pyramidal_number"
+    },
+    {
+      "title": "Triangular number — ∑ j = C(n,2)",
+      "url": "https://en.wikipedia.org/wiki/Triangular_number"
+    }
+  ],
+  "crossReferences": [],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New child entry of `cramers-rule-oq-02-oq-01` that **decomposes** the parent's lumped multiply/divide count of forward Gaussian elimination into its two distinct arithmetic operations, and determines which one carries the textbook **n³/3** leading constant.

Parent: `gaussExactOps n = ∑_{j<n} (j²+j) = (n³−n)/3` (multiplications + divisions, lumped). At the step with `j` rows below the pivot we do `j` divisions (multipliers) and `j²` multiplications (trailing-entry scaling). This entry splits and analyses each.

## What's proved (new file `Proofs/CramersRuleOQ02OQ01OQ01.lean`, 194 LOC, pure addition)

- **`gaussOps_split`** — `∑_{j<n} (j²+j) = gaussMults n + gaussDivs n` (via `Finset.sum_add_distrib`).
- **Divisions are quadratic (triangular numbers):** `gaussDivs_closed : 2·gaussDivs n + n = n²` and `gaussDivs_eq_choose : gaussDivs n = n.choose 2`, i.e. `(n²−n)/2 = C(n,2) = Θ(n²)`.
- **Multiplications carry the cubic n³/3:** `gaussMults_closed : 6·gaussMults n + 3n² = 2n³ + n` (so `gaussMults n = (2n³−3n²+n)/6 ≈ n³/3`) and `gaussMults_le_third : 6·gaussMults n ≤ 2n³` pin the leading constant at exactly `1/3`.
- **Divisions subdominant:** `gaussDivs_le_mults` (`≤` for all `n`, term-by-term `j ≤ j²` via `Finset.sum_le_sum`) and `gaussDivs_lt_mults` (strict for `n ≥ 3`).
- **Recovery:** `gaussOps_closed : 3·gaussOps n + n = n³` returns the parent's `(n³ − n)/3` from the split.
- `split_small` concrete checks (mults 1,5,14,30; divs 1,3,6,10 for n=2..5); `op_split_summary` bundle.

**Takeaway:** the famous `1/3` constant of the Gaussian-elimination flop count is purely a *multiplication* constant — the one-per-eliminated-entry divisions sum only to the quadratic `C(n,2)` and vanish into the lower-order terms.

## Verification

Docker daemon down this session → verified on host via `lake env lean`: **0 errors, exit 0**. `#print axioms op_split_summary` → `propext, Classical.choice, Quot.sound` only (no `sorryAx`, no `Lean.ofReduceBool`). File: **12 thm/lemma, 3 def, 0 axiom, 0 sorry, no native_decide**. Self-contained (imports only Mathlib — no dependency on the parent file, so no collision with the concurrent back-substitution PR #31651 editing `CramersRuleOQ02OQ01.lean`).

Gallery entry `src/data/proofs/cramers-rule-oq-02-oq-01-oq-01` added (meta + annotations + index, status verified, badge original).

🤖 Generated with [Claude Code](https://claude.com/claude-code)