### PR TITLE
Fix: erdos-1011-oq-03 axiom double-count (parent in additionalFiles)

### DIFF
--- a/src/data/proofs/erdos-1011-oq-03/meta.json
+++ b/src/data/proofs/erdos-1011-oq-03/meta.json
@@ -10,7 +10,6 @@
     "status": "verified",
     "proofRepoPath": "Proofs/Erdos1011OQ03.lean",
     "additionalFiles": [
-      "Proofs/Erdos1011Problem.lean",
       "Proofs/GraphCore.lean"
     ],
     "tags": [
@@ -163,7 +162,6 @@
     "path": "Proofs/Erdos1011OQ03.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/Erdos1011Problem.lean",
       "Proofs/GraphCore.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Remove the axiom-bearing parent `Erdos1011Problem.lean` from `erdos-1011-oq-03`'s `additionalFiles`, eliminating a spurious axiom double-count.

## Evidence

**Before**: `additionalFiles` listed `Proofs/Erdos1011Problem.lean` (5 axioms: `turan_theorem`, `erdos_gallai_theorem`, `simonovits_asymptotic`, `davies_illingworth_lower`, `hhkp_upper`). The auditor (`scripts/auditor/find-targets.ts --issues`) followed `additionalFiles` and reported **"axiom undercount: claims 0, actual declarations 5"** for this `verified`/0-axiom entry.

**After**: Parent removed from both `meta.additionalFiles` and `leanFile.additionalFiles`; the zero-axiom shared lib `GraphCore.lean` retained. Auditor re-run no longer flags this entry.

The entry's main file `Erdos1011OQ03.lean` has **0** `axiom` declarations and uses only the parent's `f` *definition* (not its axioms) — `#print axioms` on its theorems reports only `propext`/`Classical.choice`/`Quot.sound`. The parent is an independent gallery entry that discloses its own axioms; per the sibling convention (`erdos-1011-oq-01` does not list it), children don't enumerate the parent. The genuine Lean import remains in `leanFile.imports`.

---
Automated fix by lean-mechanic agent.