### PR TITLE
research(hilbert-17-oq-01-oq-01-oq-02): constructive strict asymmetric Fejér–Riesz normalization + PSD leading-coeff positivity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Hilbert17OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/Hilbert17OQ01OQ01OQ02.lean
@@ -1,0 +1,284 @@
+/-
+  Hilbert's 17th problem, univariate case — ASYMMETRIC degree normalization
+  (strict Fejér–Riesz).
+
+  The sibling file `Proofs/Hilbert17OQ01OQ01.lean` proves the *symmetric*
+  Fejér–Riesz degree bound: every non-negative real univariate polynomial `p`
+  is a sum of two squares `p = u² + v²` with **both** summands of degree at most
+  `½·deg p`,
+
+      2·deg u ≤ deg p   and   2·deg v ≤ deg p.
+
+  That bound is symmetric in `u` and `v`, so it does not say which of the two
+  squares carries the top degree.  The classical complex-factorization picture
+  is sharper: writing `p = q · q̄` for a complex polynomial `q` of degree
+  `n = ½·deg p` with *real* leading coefficient gives `p = (Re q)² + (Im q)²`
+  with `deg (Re q) = n` and `deg (Im q) < n`.  That is, one summand attains the
+  full half-degree exactly and the other is **strictly** smaller.
+
+  This file proves that strict asymmetric normalization, working entirely inside
+  the real strong-induction engine of the sibling file (no complex factorization
+  in the proof itself — only the existence of complex roots, already used to
+  extract real linear / quadratic factors).  The invariant carried through the
+  induction is
+
+      2·deg u = deg p   and   v.degree < u.degree,
+
+  using the `WithBot ℕ`-valued `Polynomial.degree` so that the zero polynomial
+  (`degree 0 = ⊥`) is uniformly the strictly-smaller summand.  This pins down
+  that for a non-zero PSD polynomial:
+
+    * `deg p` is even (it equals `2·deg u`);
+    * the *leading* square `u²` has degree exactly `deg p`, while the auxiliary
+      square `v²` has strictly smaller degree.
+
+  Both steps of the induction preserve the invariant:
+
+    * real root `r`: `u ↦ (X - C r)·u`, `v ↦ (X - C r)·v`; multiplying both by
+      the same degree-1 factor preserves `deg v < deg u` and bumps `2·deg u` by 2.
+    * non-real root: Brahmagupta gives `u ↦ (X-C re)·u − (C im)·v`,
+      `v ↦ (X-C re)·v + (C im)·u`.  The new `u` keeps top degree `deg u + 1`
+      (the `(C im)·v` correction has strictly smaller degree), while the new `v`
+      has degree `≤ deg u < deg u + 1`, so strictness is preserved.
+
+  Fully elementary and 0-axiom, like the sibling file.
+-/
+import Mathlib
+import Proofs.Hilbert17UnivariatePSDSOS
+
+namespace Hilbert17OQ01OQ01OQ02
+
+open Polynomial Filter Topology
+open Hilbert17UnivariatePSDSOS (IsPSD sq_dvd_of_psd_root nonneg_of_forall_gt)
+
+/-- `WithBot ℕ` addition is strictly monotone on the right summand provided the
+    larger left summand is not `⊥` (which would absorb).  Used to compare
+    polynomial degrees through the inductive construction. -/
+private lemma wb_add_lt {a b c d : WithBot ℕ} (h1 : a ≤ b) (h2 : c < d)
+    (hb : b ≠ ⊥) : a + c < b + d := by
+  lift b to ℕ using hb with bn
+  lift d to ℕ using (by rintro rfl; exact not_lt_bot h2) with dn
+  cases a with
+  | bot =>
+    rw [WithBot.bot_add]; exact bot_lt_iff_ne_bot.mpr (by simp [WithBot.add_eq_bot])
+  | coe an =>
+    cases c with
+    | bot =>
+      rw [WithBot.add_bot]; exact bot_lt_iff_ne_bot.mpr (by simp [WithBot.add_eq_bot])
+    | coe cn =>
+      have han : an ≤ bn := WithBot.coe_le_coe.mp h1
+      have hcn : cn < dn := WithBot.coe_lt_coe.mp h2
+      rw [← WithBot.coe_add, ← WithBot.coe_add, WithBot.coe_lt_coe]; omega
+
+/-- In `WithBot ℕ`, `a < b` upgrades to `1 + a ≤ b` (the successor bound). -/
+private lemma wb_one_add_le {a b : WithBot ℕ} (h : a < b) : 1 + a ≤ b := by
+  cases a with
+  | bot => rw [WithBot.add_bot]; exact bot_le
+  | coe an =>
+    cases b with
+    | bot => exact absurd h not_lt_bot
+    | coe bn =>
+      have : an < bn := WithBot.coe_lt_coe.mp h
+      rw [← WithBot.coe_one, ← WithBot.coe_add, WithBot.coe_le_coe]; omega
+
+/-- **Strict asymmetric strong-induction engine.**  Every *non-zero* PSD
+    polynomial of degree `d` is a sum of two squares `u² + v²` with
+    `2·deg u = deg p` (so `u²` carries the full degree) and `v.degree < u.degree`
+    (the auxiliary square is strictly smaller). -/
+theorem psd_asym_aux :
+    ∀ (d : ℕ) (p : ℝ[X]), p.natDegree = d → p ≠ 0 → IsPSD p →
+      ∃ u v : ℝ[X], p = u ^ 2 + v ^ 2 ∧
+        2 * u.natDegree = p.natDegree ∧ v.degree < u.degree := by
+  intro d
+  induction d using Nat.strongRecOn with
+  | ind d ih =>
+    intro p hpd hp0 hnn
+    by_cases hdeg : p.natDegree = 0
+    · -- constant non-zero polynomial `p = C c` with `c > 0`
+      have hpc : p = C (p.coeff 0) := eq_C_of_natDegree_eq_zero hdeg
+      have hc : 0 ≤ p.coeff 0 := by
+        have := hnn 0; rwa [← coeff_zero_eq_eval_zero] at this
+      have hcpos : 0 < p.coeff 0 := by
+        rcases hc.lt_or_eq with h | h
+        · exact h
+        · exact absurd (by rw [hpc, ← h]; simp) hp0
+      have hsqrt : Real.sqrt (p.coeff 0) ≠ 0 := (Real.sqrt_pos.mpr hcpos).ne'
+      refine ⟨C (Real.sqrt (p.coeff 0)), 0, ?_, ?_, ?_⟩
+      · conv_lhs => rw [hpc]
+        rw [← C_pow, Real.sq_sqrt hc]; ring
+      · rw [natDegree_C, hdeg]
+      · rw [degree_zero, degree_C hsqrt]
+        exact bot_lt_iff_ne_bot.mpr (by simp)
+    · -- `deg p ≥ 1`: a complex root exists by the FTA
+      have hdpos : 0 < (p.map (algebraMap ℝ ℂ)).degree := by
+        rw [degree_map, Polynomial.degree_eq_natDegree hp0]
+        exact_mod_cast Nat.pos_of_ne_zero hdeg
+      obtain ⟨z, hz⟩ := Complex.exists_root hdpos
+      have haeval : aeval z p = 0 := by
+        rw [aeval_def, ← eval_map]; exact hz
+      by_cases him : z.im = 0
+      · -- real root `r = z.re`
+        have hzr : z = algebraMap ℝ ℂ z.re := by
+          rw [Complex.coe_algebraMap]; apply Complex.ext <;> simp [him]
+        have hpr : p.eval z.re = 0 := by
+          have h2 := haeval
+          rw [hzr, aeval_algebraMap_apply_eq_algebraMap_eval, Complex.coe_algebraMap] at h2
+          exact_mod_cast h2
+        set r := z.re with hr_def
+        obtain ⟨q, hq⟩ := sq_dvd_of_psd_root hp0 hnn hpr
+        have hq0 : q ≠ 0 := fun h => hp0 (by rw [hq, h, mul_zero])
+        have hqnn : IsPSD q := by
+          intro x
+          by_cases hx : x = r
+          · subst hx
+            refine nonneg_of_forall_gt q.continuousAt (fun y hy => ?_)
+            have hsq : (0 : ℝ) < (y - r) ^ 2 :=
+              lt_of_le_of_ne (sq_nonneg _)
+                (Ne.symm (pow_ne_zero 2 (sub_ne_zero.mpr (ne_of_gt hy))))
+            have hpy := hnn y
+            rw [hq] at hpy
+            simp only [eval_mul, eval_pow, eval_sub, eval_X, eval_C] at hpy
+            exact (mul_nonneg_iff_of_pos_left hsq).mp hpy
+          · have hsq : (0 : ℝ) < (x - r) ^ 2 :=
+              lt_of_le_of_ne (sq_nonneg _)
+                (Ne.symm (pow_ne_zero 2 (sub_ne_zero.mpr hx)))
+            have hpx := hnn x
+            rw [hq] at hpx
+            simp only [eval_mul, eval_pow, eval_sub, eval_X, eval_C] at hpx
+            exact (mul_nonneg_iff_of_pos_left hsq).mp hpx
+        have hpdeg : p.natDegree = q.natDegree + 2 := by
+          rw [hq, natDegree_mul (pow_ne_zero 2 (X_sub_C_ne_zero r)) hq0, natDegree_pow,
+            natDegree_X_sub_C]; omega
+        have hlt : q.natDegree < d := by omega
+        obtain ⟨u, v, huv, hud, hvd⟩ := ih q.natDegree hlt q rfl hq0 hqnn
+        have hu0 : u ≠ 0 := by
+          rintro rfl; rw [degree_zero] at hvd; exact not_lt_bot hvd
+        refine ⟨(X - C r) * u, (X - C r) * v, by rw [hq, huv]; ring, ?_, ?_⟩
+        · -- `2·deg((X-r)·u) = deg p`
+          rw [natDegree_mul (X_sub_C_ne_zero r) hu0, natDegree_X_sub_C, hpdeg]
+          omega
+        · -- `deg((X-r)·v) < deg((X-r)·u)`
+          rw [degree_mul, degree_mul, degree_X_sub_C]
+          exact wb_add_lt le_rfl hvd (by simp)
+      · -- non-real root: pull out a positive real quadratic factor
+        obtain ⟨q, hq⟩ := quadratic_dvd_of_aeval_eq_zero_im_ne_zero p haeval him
+        set Q : ℝ[X] := X ^ 2 - C (2 * z.re) * X + C (‖z‖ ^ 2) with hQ_def
+        have hns : ‖z‖ ^ 2 = z.re ^ 2 + z.im ^ 2 := by
+          rw [← Complex.normSq_eq_norm_sq, Complex.normSq_apply]; ring
+        have hQpos : ∀ x, 0 < Q.eval x := by
+          intro x
+          have hQval : Q.eval x = (x - z.re) ^ 2 + z.im ^ 2 := by
+            rw [hQ_def]
+            simp only [eval_add, eval_sub, eval_mul, eval_pow, eval_X, eval_C]
+            rw [hns]; ring
+          rw [hQval]
+          have him2 : (0 : ℝ) < z.im ^ 2 :=
+            lt_of_le_of_ne (sq_nonneg _) (Ne.symm (pow_ne_zero 2 him))
+          nlinarith [sq_nonneg (x - z.re), him2]
+        have hq0 : q ≠ 0 := fun h => hp0 (by rw [hq, h, mul_zero])
+        have hqnn : IsPSD q := by
+          intro x
+          have hpx := hnn x
+          rw [hq, eval_mul] at hpx
+          exact (mul_nonneg_iff_of_pos_left (hQpos x)).mp hpx
+        have hQne : Q ≠ 0 := fun h => by simpa [h] using hQpos 0
+        have hQdeg : Q.natDegree = 2 := by rw [hQ_def]; compute_degree!
+        have hpdeg : p.natDegree = q.natDegree + 2 := by
+          rw [hq, natDegree_mul hQne hq0, hQdeg]; omega
+        have hlt : q.natDegree < d := by omega
+        obtain ⟨u, v, huv, hud, hvd⟩ := ih q.natDegree hlt q rfl hq0 hqnn
+        have hu0 : u ≠ 0 := by
+          rintro rfl; rw [degree_zero] at hvd; exact not_lt_bot hvd
+        have hudeg_ne : u.degree ≠ ⊥ := mt degree_eq_bot.mp hu0
+        have hQpoly : Q = (X - C z.re) ^ 2 + (C z.im) ^ 2 := by
+          rw [hQ_def]
+          have hC : (C (‖z‖ ^ 2) : ℝ[X]) = C (z.re ^ 2 + z.im ^ 2) := by rw [hns]
+          rw [hC]; simp only [C_add, C_pow, C_mul, map_ofNat]; ring
+        set U := (X - C z.re) * u - (C z.im) * v with hU
+        set V := (X - C z.re) * v + (C z.im) * u with hV
+        -- degree of `(X - C re)·u` is `deg u + 1`
+        have hXu : ((X - C z.re) * u).degree = u.degree + 1 := by
+          rw [degree_mul, degree_X_sub_C, add_comm]
+        -- the correction `(C im)·v` is strictly below `(X - C re)·u`
+        have hle1 : u.degree ≤ u.degree + 1 := by
+          cases hu : u.degree with
+          | bot => simp
+          | coe n => rw [← WithBot.coe_one, ← WithBot.coe_add, WithBot.coe_le_coe]; omega
+        have hcorr_u : ((C z.im) * v).degree < ((X - C z.re) * u).degree := by
+          rw [hXu, degree_mul, degree_C him, zero_add]
+          exact lt_of_lt_of_le hvd hle1
+        have hU_deg : U.degree = u.degree + 1 := by
+          rw [hU, sub_eq_add_neg,
+            degree_add_eq_left_of_degree_lt (by rw [degree_neg]; exact hcorr_u), hXu]
+        have hU_nd : U.natDegree = u.natDegree + 1 := by
+          have hsome : U.degree = (↑(u.natDegree + 1) : WithBot ℕ) := by
+            rw [hU_deg, degree_eq_natDegree hu0]; norm_cast
+          exact natDegree_eq_of_degree_eq_some hsome
+        refine ⟨U, V, by rw [hq, huv, hQpoly, hU, hV]; ring, ?_, ?_⟩
+        · -- `2·deg U = deg p`
+          rw [hU_nd, hpdeg]; omega
+        · -- `deg V < deg U = deg u + 1`
+          rw [hU_deg]
+          have h1 : ((X - C z.re) * v).degree ≤ u.degree := by
+            rw [degree_mul, degree_X_sub_C]; exact wb_one_add_le hvd
+          have h2 : ((C z.im) * u).degree ≤ u.degree :=
+            le_of_eq (by rw [degree_mul, degree_C him, zero_add])
+          have hV_le : V.degree ≤ u.degree :=
+            le_trans (degree_add_le _ _) (max_le h1 h2)
+          exact lt_of_le_of_lt hV_le (by
+            cases hu : u.degree with
+            | bot => exact absurd hu hudeg_ne
+            | coe n =>
+                rw [← WithBot.coe_one, ← WithBot.coe_add, WithBot.coe_lt_coe]; omega)
+
+/-- **Univariate Hilbert 17, strict asymmetric Fejér–Riesz normalization.**
+    Every non-zero non-negative real univariate polynomial `p` is a sum of two
+    squares `p = u² + v²` in which the *leading* square `u²` has degree exactly
+    `deg p` (so `2·deg u = deg p`, and in particular `deg p` is even) while the
+    auxiliary square `v²` has strictly smaller degree (`v.degree < u.degree`). -/
+theorem univariate_psd_two_sos_asym (p : ℝ[X]) (hp : p ≠ 0) (h : IsPSD p) :
+    ∃ u v : ℝ[X], p = u ^ 2 + v ^ 2 ∧
+      2 * u.natDegree = p.natDegree ∧ v.degree < u.degree :=
+  psd_asym_aux p.natDegree p rfl hp h
+
+/-- The degree of a non-zero PSD univariate polynomial is **even** — the leading
+    square `u²` from the asymmetric normalization has degree `2·deg u = deg p`. -/
+theorem natDegree_even_of_psd (p : ℝ[X]) (hp : p ≠ 0) (h : IsPSD p) :
+    Even p.natDegree := by
+  obtain ⟨u, _, _, hud, _⟩ := univariate_psd_two_sos_asym p hp h
+  exact ⟨u.natDegree, by omega⟩
+
+/-- In the asymmetric normalization the *leading* square attains the full
+    degree: `u²` has degree exactly `deg p`, while `v²` is strictly below. -/
+theorem leading_square_full_degree (p : ℝ[X]) (hp : p ≠ 0) (h : IsPSD p) :
+    ∃ u v : ℝ[X], p = u ^ 2 + v ^ 2 ∧
+      (u ^ 2).natDegree = p.natDegree ∧ (v ^ 2).degree < (u ^ 2).degree := by
+  obtain ⟨u, v, huv, hud, hvd⟩ := univariate_psd_two_sos_asym p hp h
+  have hu0 : u ≠ 0 := by
+    rintro rfl; rw [degree_zero] at hvd; exact not_lt_bot hvd
+  refine ⟨u, v, huv, ?_, ?_⟩
+  · rw [natDegree_pow]; omega
+  · rw [pow_two, pow_two, degree_mul, degree_mul]
+    exact wb_add_lt (le_of_lt hvd) hvd (mt degree_eq_bot.mp hu0)
+
+/-- **Leading coefficient of a non-zero PSD polynomial is positive.**  In the
+    asymmetric normal form the top coefficient comes entirely from the leading
+    square `u²` (the auxiliary square `v²` has strictly smaller degree), so
+    `leadingCoeff p = (leadingCoeff u)² > 0`.  This is the polynomial counterpart
+    of the elementary fact that a non-negative real polynomial cannot tend to
+    `−∞`; it is not implied by the symmetric Fejér–Riesz bound, which leaves the
+    sign of the top coefficient undetermined. -/
+theorem leadingCoeff_pos_of_psd (p : ℝ[X]) (hp : p ≠ 0) (h : IsPSD p) :
+    0 < p.leadingCoeff := by
+  obtain ⟨u, v, huv, hud, hvd⟩ := univariate_psd_two_sos_asym p hp h
+  have hu0 : u ≠ 0 := by
+    rintro rfl; rw [degree_zero] at hvd; exact not_lt_bot hvd
+  have hdeg : (v ^ 2).degree < (u ^ 2).degree := by
+    rw [pow_two, pow_two, degree_mul, degree_mul]
+    exact wb_add_lt (le_of_lt hvd) hvd (mt degree_eq_bot.mp hu0)
+  have hlc : p.leadingCoeff = (u ^ 2).leadingCoeff := by
+    rw [huv, add_comm, leadingCoeff_add_of_degree_lt hdeg]
+  rw [hlc, leadingCoeff_pow]
+  exact pow_two_pos_of_ne_zero (leadingCoeff_ne_zero.mpr hu0)
+
+end Hilbert17OQ01OQ01OQ02

--- a/research/registry.json
+++ b/research/registry.json
@@ -29468,11 +29468,11 @@
     },
     {
       "slug": "hilbert-17-oq-01-oq-01",
-      "phase": "NEW",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-24T23:25:31.615Z",
-      "status": "blocked",
-      "lastUpdate": "2026-06-24T23:25:31.615Z"
+      "status": "active",
+      "lastUpdate": "2026-06-30T16:30:00-07:00"
     },
     {
       "slug": "abundant-number-oq-01-oq-04",

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-h17-oq010102-helpers",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 51,
+      "endLine": 86
+    },
+    "type": "concept",
+    "title": "WithBot ℕ order lemmas: working around ⊥-absorption",
+    "content": "Polynomial.degree is valued in WithBot ℕ, with degree 0 = ⊥. This is exactly the right home for the asymmetric invariant v.degree < u.degree, because the auxiliary square may be the zero polynomial (degree ⊥), and ⊥ is genuinely below every finite degree — no v = 0 case exception is needed. The price is that WithBot ℕ is not strictly monotone under addition: ⊥ + x = ⊥ absorbs, so the generic 'add_lt_add_left' instance does not fire. The two helper lemmas wb_add_lt (a ≤ b, c < d, b ≠ ⊥ ⟹ a + c < b + d) and wb_one_add_le (a < b ⟹ 1 + a ≤ b) discharge precisely the degree comparisons that arise when multiplying a polynomial by the degree-1 factor (X − C r), via explicit case splits on whether each operand is ⊥."
+  },
+  {
+    "id": "ann-h17-oq010102-realroot",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 122,
+      "endLine": 158
+    },
+    "type": "technique",
+    "title": "Real-root branch: strictness is preserved by a common factor",
+    "content": "When the FTA root r is real, even multiplicity (sq_dvd_of_psd_root, reused verbatim from the parent) gives p = (X − C r)²·q with q PSD of degree deg p − 2. The induction hypothesis yields q = u'² + v'² with 2·deg u' = deg q and v'.degree < u'.degree. The new pair is (X − C r)·u', (X − C r)·v' — both summands multiplied by the SAME degree-1 factor. Strictness is preserved automatically: degree_mul turns v'.degree < u'.degree into ((X − C r)·v').degree < ((X − C r)·u').degree (this is exactly wb_add_lt with the common left summand degree (X − C r) = 1), and 2·deg u jumps from deg q to deg q + 2 = deg p."
+  },
+  {
+    "id": "ann-h17-oq010102-nonreal",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 159,
+      "endLine": 237
+    },
+    "type": "technique",
+    "title": "Non-real-root branch: Brahmagupta keeps the imaginary part strictly lower",
+    "content": "For a non-real root the positive quadratic Q = (X − C re)² + (C im)² divides p, with quotient q PSD of degree deg p − 2. The Brahmagupta–Fibonacci identity turns Q·(u'² + v'²) into U² + V² with U = (X − C re)·u' − (C im)·v' and V = (X − C re)·v' + (C im)·u'. The key is that the correction (C im)·v' has degree v'.degree < u'.degree + 1, so degree_add_eq_left_of_degree_lt pins deg U = deg u' + 1 exactly. For V, both (X − C re)·v' (degree ≤ deg u', since deg v' < deg u') and (C im)·u' (degree deg u') stay ≤ deg u' < deg u' + 1 = deg U, so V.degree < U.degree. Strictness survives the combination even though V mixes u' and v'."
+  },
+  {
+    "id": "ann-h17-oq010102-leadingcoeff",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 270,
+      "endLine": 284
+    },
+    "type": "insight",
+    "title": "Leading-coefficient positivity falls out of the asymmetry",
+    "content": "leadingCoeff_pos_of_psd is the genuinely new structural statement of this entry. Once the normal form gives p = u² + v² with v² strictly lower degree than u², the leading coefficient of the sum collapses (leadingCoeff_add_of_degree_lt) to that of the dominant square: leadingCoeff p = (u²).leadingCoeff = (u.leadingCoeff)². Since u ≠ 0, its leading coefficient is a nonzero real, and its square is strictly positive. This recovers the elementary fact that a nonnegative real polynomial cannot have negative leading coefficient (it cannot tend to −∞) — but as a clean algebraic corollary of the certificate's shape, something the symmetric ½·deg p bound, which says nothing about which square dominates, cannot deliver."
+  }
+]

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,205 @@
+{
+  "id": "hilbert-17-oq-01-oq-01-oq-02",
+  "title": "Strict Asymmetric Fejér–Riesz Normalization, Constructively: One Square of Degree Exactly ½·deg p, the Other Strictly Smaller",
+  "slug": "hilbert-17-oq-01-oq-01-oq-02",
+  "description": "The sibling entry hilbert-17-oq-01-oq-01 proves the symmetric Fejér–Riesz bound — every nonnegative real univariate polynomial p is p = u² + v² with both summands of degree at most ½·deg p — and leaves as its open question #1 the strict asymmetric normalization: one square of degree exactly n = ½·deg p, the other strictly smaller. This entry answers that question by a *constructive* route: rather than first producing a symmetric decomposition and then rotating it (the post-hoc 2×2 rotation argument of the concurrent sibling hilbert-17-oq-01-oq-01-oq-01, PR #31649), it strengthens the strong-induction engine itself so the asymmetry is threaded through the certificate as it is built. The invariant carried is 2·deg u = deg p together with v.degree < u.degree, using the WithBot ℕ-valued Polynomial.degree so the zero polynomial (degree ⊥) is uniformly the strictly-smaller summand and the degree-0 constant case needs no exception (the rotation form requires deg p ≥ 2). The genuinely new structural payload is leadingCoeff_pos_of_psd: a nonzero PSD univariate polynomial has strictly positive leading coefficient, because in the asymmetric normal form the top coefficient comes entirely from the leading square u² and equals (leadingCoeff u)² > 0 — a fact the symmetric bound leaves undetermined. Fully elementary, 0 axioms.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert17OQ01OQ01OQ02.lean",
+    "tags": [
+      "real-algebra",
+      "sum-of-squares",
+      "hilbert-17",
+      "fejer-riesz",
+      "degree-bound",
+      "univariate-polynomials",
+      "leading-coefficient",
+      "fundamental-theorem-of-algebra",
+      "inequalities"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.exists_root",
+        "description": "The fundamental theorem of algebra: a complex polynomial of positive degree has a root. Supplies, for deg p ≥ 1, a (possibly non-real) root z of p, the engine of the induction step.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Polynomials"
+      },
+      {
+        "theorem": "quadratic_dvd_of_aeval_eq_zero_im_ne_zero",
+        "description": "If a real polynomial has a non-real complex root z, the real quadratic (X − re z)² + (im z)² divides it. Pulls out the positive quadratic factor in the non-real-root branch.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Circle"
+      },
+      {
+        "theorem": "degree_add_eq_left_of_degree_lt",
+        "description": "If deg q < deg p then deg (p + q) = deg p. Pins the degree of the new leading square U = (X − C re)·u − (C im)·v to deg((X − C re)·u) = deg u + 1, since the correction term has strictly smaller degree.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Operations"
+      },
+      {
+        "theorem": "leadingCoeff_add_of_degree_lt",
+        "description": "If deg p < deg q then (p + q).leadingCoeff = q.leadingCoeff. Used to read the leading coefficient of p = u² + v² off the dominant square u², giving leadingCoeff p = (leadingCoeff u)².",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Lemmas"
+      },
+      {
+        "theorem": "Nat.strongRecOn",
+        "description": "Strong recursion on ℕ. The induction is on the degree d of p, with the smaller-degree quotient handled by the strong induction hypothesis.",
+        "module": "Mathlib.Init.Data.Nat.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "psd_asym_aux: the strict asymmetric strong-induction engine — every nonzero PSD polynomial of degree d is u² + v² with 2·deg u = deg p (so u² carries the full degree) and v.degree < u.degree, threading the asymmetry through the same real-root / non-real-root induction tree used by the parent.",
+      "univariate_psd_two_sos_asym: the public asymmetric normal form, with no degree restriction (the constructive WithBot-degree invariant covers the deg-0 constant case for free, where the rotation-based sibling requires deg p ≥ 2).",
+      "leadingCoeff_pos_of_psd: a nonzero PSD univariate polynomial has strictly positive leading coefficient — a structural corollary not implied by the symmetric Fejér–Riesz bound, obtained because the asymmetric form forces the top coefficient to equal (leadingCoeff u)² > 0.",
+      "natDegree_even_of_psd: the degree of a nonzero PSD univariate polynomial is even (2·deg u = deg p), recovered directly from the asymmetric engine.",
+      "leading_square_full_degree: repackaging of the normal form at the level of the squares themselves — (u²).natDegree = deg p while (v²).degree < (u²).degree.",
+      "wb_add_lt / wb_one_add_le: two small WithBot ℕ order lemmas isolating the only subtlety in the construction — ⊥ absorbs addition, so strict monotonicity of degree under multiplication by (X − C r) must be argued by hand rather than via a generic AddLeftStrictMono instance."
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "The symmetric Fejér–Riesz degree bound (sibling entry hilbert-17-oq-01-oq-01) and the parent existence theorem (Hilbert17UnivariatePSDSOS.lean).",
+      "The fundamental theorem of algebra and conjugate-pair factorization of real polynomials.",
+      "Even multiplicity of real roots of a nonnegative polynomial (the parent's analytic crux sq_dvd_of_psd_root).",
+      "The Brahmagupta–Fibonacci identity (a·c − b·d)² + (a·d + b·c)² = (a² + b²)(c² + d²).",
+      "Polynomial.degree as a WithBot ℕ value, with degree 0 = ⊥ and degree_mul over the integral domain ℝ[X]."
+    ],
+    "lineCount": 284,
+    "relatedProblems": [
+      {
+        "id": "hilbert-17-oq-01-oq-01",
+        "relationship": "Parent: proves the symmetric Fejér–Riesz bound 2·deg u ≤ deg p, 2·deg v ≤ deg p and poses the strict asymmetric normalization as its open question #1. This entry answers that question constructively and adds the leading-coefficient sign corollary."
+      },
+      {
+        "id": "hilbert-17-oq-01-oq-01-oq-01",
+        "relationship": "Sibling (concurrent, PR #31649): obtains the same asymmetric normal form by a post-hoc constant 2×2 rotation of an existing two-squares pair, for deg p ≥ 2. This entry gives an independent constructive derivation that threads the asymmetry through the induction (no degree restriction) and contributes the distinct leadingCoeff_pos_of_psd structural corollary."
+      },
+      {
+        "id": "hilbert-17",
+        "relationship": "Grandparent: states Hilbert's 17th and Artin's theorem. Its univariate strand is discharged by Hilbert17UnivariatePSDSOS.lean; this entry pins down the exact degree split and the sign of the leading coefficient of the certificate."
+      }
+    ],
+    "assumptions": "0 axioms. #print axioms univariate_psd_two_sos_asym / natDegree_even_of_psd / leading_square_full_degree / leadingCoeff_pos_of_psd reports only propext, Classical.choice, Quot.sound. No sorryAx, no native_decide / Lean.ofReduceBool. Reuses only 0-axiom theorems from the parent file Hilbert17UnivariatePSDSOS.lean.",
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "leanFile": {
+    "lineCount": 284,
+    "namespace": "Hilbert17OQ01OQ01OQ02",
+    "opens": [
+      "Polynomial",
+      "Filter",
+      "Topology"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 4,
+    "computationalVerifications": 0,
+    "lemmaCount": 2,
+    "imports": [
+      "Mathlib",
+      "Proofs.Hilbert17UnivariatePSDSOS"
+    ],
+    "path": "Proofs/Hilbert17OQ01OQ01OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "psd_asym_aux",
+      "type": "theorem",
+      "description": "Strict asymmetric strong-induction engine: every nonzero PSD polynomial of degree d is u² + v² with 2·deg u = deg p and v.degree < u.degree.",
+      "leanType": "∀ (d : ℕ) (p : ℝ[X]), p.natDegree = d → p ≠ 0 → IsPSD p → ∃ u v, p = u ^ 2 + v ^ 2 ∧ 2 * u.natDegree = p.natDegree ∧ v.degree < u.degree"
+    },
+    {
+      "name": "univariate_psd_two_sos_asym",
+      "type": "theorem",
+      "description": "Univariate Hilbert 17, strict asymmetric Fejér–Riesz normalization: every nonzero PSD polynomial is u² + v² with the leading square u² of degree exactly deg p (so deg p is even) and v² strictly smaller.",
+      "leanType": "(p : ℝ[X]) → p ≠ 0 → IsPSD p → ∃ u v, p = u ^ 2 + v ^ 2 ∧ 2 * u.natDegree = p.natDegree ∧ v.degree < u.degree"
+    },
+    {
+      "name": "leadingCoeff_pos_of_psd",
+      "type": "theorem",
+      "description": "A nonzero PSD univariate polynomial has strictly positive leading coefficient, equal to (leadingCoeff u)² in the asymmetric normal form.",
+      "leanType": "(p : ℝ[X]) → p ≠ 0 → IsPSD p → 0 < p.leadingCoeff"
+    },
+    {
+      "name": "natDegree_even_of_psd",
+      "type": "theorem",
+      "description": "The degree of a nonzero PSD univariate polynomial is even (it equals 2·deg u for the leading square u²).",
+      "leanType": "(p : ℝ[X]) → p ≠ 0 → IsPSD p → Even p.natDegree"
+    },
+    {
+      "name": "leading_square_full_degree",
+      "type": "theorem",
+      "description": "Square-level form of the normalization: (u²).natDegree = deg p while (v²).degree < (u²).degree.",
+      "leanType": "(p : ℝ[X]) → p ≠ 0 → IsPSD p → ∃ u v, p = u ^ 2 + v ^ 2 ∧ (u ^ 2).natDegree = p.natDegree ∧ (v ^ 2).degree < (u ^ 2).degree"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Hilbert classified in 1888 the cases where a nonnegative real polynomial is already a sum of polynomial squares; the univariate case is the most classical and is the algebraic shadow of the Fejér–Riesz theorem (1916). Over ℂ a real polynomial p ≥ 0 of degree 2n factors through one root of each conjugate pair as p = q·q̄ for a complex polynomial q of degree n with real leading coefficient; writing q = u + i·v gives p = u² + v² with deg u = n and deg v < n — the leading coefficient of q, being real, contributes only to u, so the imaginary part is strictly lower degree. This strict asymmetric form is what a complex spectral factorization actually returns, and it is the natural normalization that the symmetric ½·deg p bound stops just short of. The sign of the leading coefficient — necessarily positive, since p cannot tend to −∞ — is the most elementary structural invariant of a PSD polynomial and falls straight out of the asymmetric form.",
+    "problemStatement": "Answer open question #1 of the sibling entry: for p ∈ ℝ[x] nonzero with p(x) ≥ 0 for all real x, produce u, v with p = u² + v², 2·deg u = deg p (the leading square attains the full half-degree, forcing deg p even), and v.degree < u.degree (the auxiliary square is strictly smaller). Do so constructively, by strengthening the strong-induction certificate rather than rotating a finished decomposition, and read off the leading-coefficient sign of a PSD polynomial as a corollary.",
+    "proofStrategy": "Strong induction on d = deg p carrying the invariant 2·deg u = deg p ∧ v.degree < u.degree, with degree taken in WithBot ℕ so the zero polynomial (degree ⊥) is uniformly the strictly-smaller summand. Constant base case: u = C√c (c = p(0) > 0), v = 0, and ⊥ < 0. Real-root branch: even multiplicity gives p = (X − C r)²·q; multiplying the IH pair (u', v') by the same degree-1 factor (X − C r) preserves strictness (deg v' < deg u' ⟹ deg((X − C r)v') < deg((X − C r)u')) and raises 2·deg u by 2. Non-real-root branch: the positive quadratic Q = (X − C re)² + (C im)² divides p; Brahmagupta gives U = (X − C re)·u' − (C im)·v', V = (X − C re)·v' + (C im)·u'. The correction (C im)·v' has degree deg v' < deg u' + 1, so deg U = deg u' + 1 (via degree_add_eq_left_of_degree_lt); and since deg v' < deg u' forces deg((X − C re)·v') ≤ deg u', both summands of V stay ≤ deg u' < deg u' + 1 = deg U, preserving strictness. The WithBot order steps are isolated into two helper lemmas because ⊥ absorbs addition. The leading-coefficient corollary reads leadingCoeff p off the dominant square u² (leadingCoeff_add_of_degree_lt), giving (leadingCoeff u)² > 0.",
+    "keyInsights": [
+      "Strictness is preserved by the induction because both branches multiply the asymmetric pair by a common factor whose square root has degree 1: deg v < deg u is stable under (u, v) ↦ ((X − C r)·u, (X − C r)·v), and in the Brahmagupta branch the imaginary correction is always strictly below the dominant real term.",
+      "Using WithBot ℕ degree rather than natDegree with a v = 0 disjunction makes the deg-0 constant case (where v = 0 has degree ⊥) uniform — this is exactly why the constructive form needs no deg p ≥ 2 hypothesis, unlike the rotation form.",
+      "The only friction is that WithBot ℕ is not an AddLeftStrictMono structure (⊥ + x = ⊥ absorbs), so '1 + a < 1 + b from a < b' must be proved by a case split on ⊥; isolating this into wb_add_lt / wb_one_add_le keeps the main induction clean.",
+      "Leading-coefficient positivity is a genuine consequence of the asymmetry, not of mere decomposability: only once v² is known to be strictly lower degree does leadingCoeff p collapse to (leadingCoeff u)², which is a nonzero real square and hence positive.",
+      "This is an independent, constructive proof of a normal form also obtained concurrently by a 2×2 coefficient rotation (sibling oq-01-oq-01-oq-01); the two derivations are complementary — rotation post-processes any decomposition, induction builds the normalized one directly."
+    ]
+  },
+  "conclusion": {
+    "summary": "A 284-line, 0-sorry, 0-axiom answer to open question #1 of hilbert-17-oq-01-oq-01: a constructive strict asymmetric Fejér–Riesz normalization in which the leading square u² has degree exactly deg p (forcing deg p even) and the auxiliary square v² is strictly smaller, valid with no degree restriction. The genuinely new structural payload is that a nonzero PSD univariate polynomial has strictly positive leading coefficient.",
+    "implications": "The asymmetric form is the normalization a complex spectral factorization returns, and proving it constructively shows the parent's elementary real induction is strong enough to produce it without any complex factorization in the proof. The leading-coefficient sign theorem is a reusable structural fact about PSD polynomials that the symmetric degree bound alone cannot supply.",
+    "openQuestions": [
+      "Bound the bit-size / height of the coefficients of u and v in the asymmetric normal form in terms of p, toward a complexity-aware univariate certificate.",
+      "Characterize the freedom in the normalization: the asymmetric pair is unique only up to the choice of one root per conjugate pair (a finite 2^k ambiguity); make that ambiguity precise at the level of u, v.",
+      "Transport the leading-coefficient positivity statement to the multivariate setting as a necessary condition feeding back into SOS-certificate search."
+    ]
+  },
+  "references": [
+    {
+      "title": "Hilbert's seventeenth problem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem"
+    },
+    {
+      "title": "Fejér–Riesz theorem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Fej%C3%A9r%E2%80%93Riesz_theorem"
+    },
+    {
+      "title": "B. Reznick, Some concrete aspects of Hilbert's 17th problem (1996)",
+      "url": "https://www.ams.org/books/conm/253/"
+    }
+  ],
+  "crossReferences": [],
+  "sections": [
+    {
+      "id": "withbot-helpers",
+      "title": "WithBot ℕ order lemmas for degree bookkeeping",
+      "startLine": 51,
+      "endLine": 86,
+      "summary": "wb_add_lt and wb_one_add_le isolate the only subtlety of the construction: in WithBot ℕ the bottom element ⊥ absorbs addition, so the strict monotonicity 'a < b ⟹ 1 + a ≤ b' and 'a + c < b + d' needed to compare degrees through multiplication by (X − C r) are proved by explicit case splits on ⊥ rather than via a generic ordered-monoid instance."
+    },
+    {
+      "id": "engine",
+      "title": "The strict asymmetric induction engine",
+      "startLine": 88,
+      "endLine": 237,
+      "summary": "psd_asym_aux: strong induction on deg p carrying 2·deg u = deg p ∧ v.degree < u.degree. The constant base case gives u = C√c, v = 0; the real-root branch multiplies the IH pair by (X − C r); the non-real-root branch combines them by Brahmagupta, using degree_add_eq_left_of_degree_lt to pin deg U = deg u + 1 and the helper lemmas to keep deg V strictly below."
+    },
+    {
+      "id": "public",
+      "title": "Public normal form, even degree, and leading-coefficient sign",
+      "startLine": 239,
+      "endLine": 284,
+      "summary": "univariate_psd_two_sos_asym instantiates the engine; natDegree_even_of_psd and leading_square_full_degree repackage it; leadingCoeff_pos_of_psd reads the leading coefficient of p off the dominant square u² via leadingCoeff_add_of_degree_lt, giving (leadingCoeff u)² > 0."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers **open question #1** of `hilbert-17-oq-01-oq-01` (the symmetric Fejér–Riesz degree-bound entry): every nonzero PSD real univariate polynomial `p = u² + v²` can be put in the **strict asymmetric normal form** where the leading square `u²` has degree *exactly* `½·deg p` (forcing `deg p` even) and the auxiliary square `v²` is *strictly* smaller (`v.degree < u.degree`).

## What is new here vs. the concurrent sibling #31649

The sibling `hilbert-17-oq-01-oq-01-oq-01` (PR #31649, open) obtains the *same* normal form by a **post-hoc 2×2 rotation** of an already-finished two-squares pair, for `deg p ≥ 2`. This entry is **independent and complementary**:

- **Constructive route.** It strengthens the parent's strong-induction *engine* so the asymmetry is threaded through the certificate as it is built — carrying the invariant `2·deg u = deg p ∧ v.degree < u.degree` (degree in `WithBot ℕ`, so the zero polynomial's `⊥` is uniformly the smaller summand). No complex factorization appears in the proof, only the existence of complex roots already used by the parent.
- **No degree restriction.** The `WithBot`-degree formulation handles the `deg-0` constant case for free; the rotation form needs `deg p ≥ 2`.
- **New structural payload.** `leadingCoeff_pos_of_psd`: a nonzero PSD univariate polynomial has **strictly positive leading coefficient**, equal to `(leadingCoeff u)²` in the normal form. This is *not* implied by the symmetric ½·deg p bound (which says nothing about which square dominates), and is absent from the sibling.

The two derivations are genuinely different proofs of the same normalization; this is stated plainly in the entry's `relatedProblems` and overview.

## Theorems (`Proofs/Hilbert17OQ01OQ01OQ02.lean`, namespace `Hilbert17OQ01OQ01OQ02`)

- `psd_asym_aux` — strict asymmetric strong-induction engine.
- `univariate_psd_two_sos_asym` — public asymmetric normal form (no degree hypothesis).
- `leadingCoeff_pos_of_psd` — PSD ⟹ positive leading coefficient.
- `natDegree_even_of_psd` — PSD ⟹ even degree.
- `leading_square_full_degree` — square-level repackaging: `(u²).natDegree = deg p`, `(v²).degree < (u²).degree`.
- `wb_add_lt`, `wb_one_add_le` — two small `WithBot ℕ` order lemmas (⊥ absorbs addition, so strict monotonicity of degree under multiplication by `(X − C r)` is argued by hand).

## Verification

- **0 sorries, 0 axioms.** `#print axioms` on all public theorems reports only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`).
- 284 lines; builds against Mathlib + `Proofs.Hilbert17UnivariatePSDSOS` (host `lake env lean`, exit 0).
- Reuses only 0-axiom theorems from the parent file; the analytic crux (even multiplicity of real roots) and Brahmagupta identity are inherited verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)