### PR TITLE
Fix: collatz-structured-oq-01 axiom double-count (parent in additionalFiles)

### DIFF
--- a/src/data/proofs/collatz-structured-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-01/meta.json
@@ -6,9 +6,7 @@
   "meta": {
     "status": "verified",
     "proofRepoPath": "Proofs/CollatzStructuredOQ01.lean",
-    "additionalFiles": [
-      "Proofs/CollatzStructured.lean"
-    ],
+    "additionalFiles": [],
     "tags": [
       "number-theory",
       "collatz",
@@ -210,9 +208,7 @@
     "theoremCount": 22,
     "definitionCount": 3,
     "sorries": 0,
-    "additionalFiles": [
-      "Proofs/CollatzStructured.lean"
-    ]
+    "additionalFiles": []
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Remove the axiom-bearing parent `CollatzStructured.lean` from `collatz-structured-oq-01`'s `additionalFiles`, eliminating a spurious axiom double-count.

## Evidence

**Before**: `additionalFiles` listed `Proofs/CollatzStructured.lean`, which contains `axiom collatz_conjecture`. The auditor (`scripts/auditor/find-targets.ts --issues`) followed `additionalFiles` and reported **"axiom undercount: claims 0, actual declarations 1"** for this `verified`/0-axiom entry.

**After**: Parent cleared from both `meta.additionalFiles` and `leanFile.additionalFiles` (now `[]`). Auditor re-run no longer flags this entry.

The main file `CollatzStructuredOQ01.lean` has **0** `axiom` declarations and explicitly documents that it avoids the parent's `collatz_conjecture` axiom. The parent is an independent gallery entry that discloses its own axiom; per the sibling convention (`collatz-structured-oq-02`/`-oq-03` don't list it), children don't enumerate the parent. The genuine Lean import remains in `leanFile.imports`.

---
Automated fix by lean-mechanic agent.