### PR TITLE
Fix: remove vacuous ScissorsCongruent placeholder (dissection-of-cubes-oq-02)

### DIFF
--- a/proofs/Proofs/DissectionOfCubesOQ02.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ02.lean
@@ -50,18 +50,18 @@ open Real
 -- Part I: Scissors Congruence
 -- ========================================================================
 
-/-- Two polyhedra are scissors congruent if one can be cut into finitely
-many polyhedral pieces that reassemble into the other. -/
-def ScissorsCongruent (P Q : Type*) : Prop :=
-  ∃ (n : ℕ), True -- Placeholder: n pieces partition P and reassemble to Q
-
-/-- Scissors congruence is reflexive. -/
-theorem scissors_congruent_refl (P : Type*) : ScissorsCongruent P P :=
-  ⟨1, trivial⟩
-
-theorem scissors_congruent_symm {P Q : Type*} (h : ScissorsCongruent P Q) :
-    ScissorsCongruent Q P :=
-  let ⟨n, _⟩ := h; ⟨n, trivial⟩
+/-
+Scissors congruence ("P can be cut into finitely many polyhedral pieces that
+reassemble into Q") is not formalized here as a standalone predicate. The
+impossibility result below is stated and proved entirely through the Dehn
+invariant obstruction (`hilbert_third_problem`, `dehn_obstruction`): if the
+cube and tetrahedron were scissors congruent, Dehn's theorem would force their
+Dehn invariants to agree, which `tetrahedron_dehn_nonzero` rules out.
+A prior revision carried a vacuous `ScissorsCongruent P Q := ∃ n, True`
+placeholder definition together with two trivial reflexivity/symmetry lemmas.
+That predicate held for every pair of types regardless of geometry and was
+load-bearing for nothing in the development, so it has been removed.
+-/
 
 -- ========================================================================
 -- Part II: Dihedral Angles of Common Polyhedra

--- a/src/data/proofs/dissection-of-cubes-oq-02/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/annotations.json
@@ -1,49 +1,5 @@
 [
   {
-    "id": "ann-scissors-def",
-    "proofId": "dissection-of-cubes-oq-02",
-    "range": {
-      "startLine": 53,
-      "endLine": 56
-    },
-    "type": "definition",
-    "title": "Scissors Congruence",
-    "content": "Defines the scissors congruence relation between polyhedra. Two polyhedra P and Q are scissors congruent if P can be decomposed into finitely many polyhedral pieces that can be rearranged (via rigid motions) to form Q. This is the central equivalence relation studied in Hilbert's Third Problem. The formalization uses a simplified placeholder requiring only the existence of n pieces.",
-    "mathContext": "Two polyhedra $P$ and $Q$ are scissors congruent ($P \\sim_{\\mathrm{sc}} Q$) if there exist polyhedra $P_1, \\ldots, P_n$ and isometries $\\sigma_1, \\ldots, \\sigma_n$ such that $P = \\bigcup P_i$ and $Q = \\bigcup \\sigma_i(P_i)$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "equivalence relation",
-      "polyhedral decomposition",
-      "rigid motion",
-      "congruence"
-    ],
-    "prerequisites": [
-      "basic topology",
-      "Euclidean geometry"
-    ]
-  },
-  {
-    "id": "ann-scissors-props",
-    "proofId": "dissection-of-cubes-oq-02",
-    "range": {
-      "startLine": 58,
-      "endLine": 64
-    },
-    "type": "concept",
-    "title": "Reflexivity and Symmetry of Scissors Congruence",
-    "content": "Proves that scissors congruence is reflexive (any polyhedron is scissors congruent to itself via the trivial 1-piece decomposition) and symmetric (if P can be cut and reassembled into Q, then Q can be cut and reassembled into P by reversing the rigid motions). Transitivity also holds but is omitted here.",
-    "mathContext": "Reflexivity: $P \\sim_{\\mathrm{sc}} P$ via the identity decomposition. Symmetry: if $P \\sim_{\\mathrm{sc}} Q$ via isometries $\\sigma_i$, then $Q \\sim_{\\mathrm{sc}} P$ via $\\sigma_i^{-1}$.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "equivalence relation",
-      "group action",
-      "isometry group"
-    ],
-    "prerequisites": [
-      "basic algebra"
-    ]
-  },
-  {
     "id": "ann-cube-angle",
     "proofId": "dissection-of-cubes-oq-02",
     "range": {

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -41,10 +41,10 @@
     ],
     "lineCount": 379,
     "axiomCount": 0,
-    "assumptions": "0 axioms, 0 sorries. Note: `ScissorsCongruent (P Q : Type*) := ∃ (n : ℕ), True` (line 55-56) is a stub placeholder definition — not an axiom declaration or structure-encoded assumption. Dehn’s theorem is taken as an explicit hypothesis in `hilbert_third_problem`, not as an axiom declaration. The core number-theoretic result (arccos(1/3)/π is irrational via Chebyshev recurrence) is fully proved.",
+    "assumptions": "0 axioms, 0 sorries. Dehn’s theorem is taken as an explicit hypothesis in `hilbert_third_problem`, not as an axiom declaration. The core number-theoretic result (arccos(1/3)/π is irrational via Chebyshev recurrence) is fully proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 20,
-    "definitionCount": 7
+    "theoremCount": 16,
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Hilbert's Third Problem, posed by David Hilbert in 1900 as the third of his famous 23 problems, asked whether two polyhedra of equal volume are always scissors congruent — that is, whether one can always be cut into finitely many polyhedral pieces and reassembled into the other. In 2D, the Bolyai-Gerwien theorem (proved independently by Farkas Bolyai and Paul Gerwien around 1833, with earlier work by William Wallace in 1807) shows the answer is yes: any two equal-area polygons are scissors congruent. Hilbert suspected the 3D case would be different. Max Dehn, Hilbert's student, confirmed this in 1900 by introducing an algebraic invariant — now called the Dehn invariant — that is preserved under polyhedral dissection. Since the cube and regular tetrahedron have different Dehn invariants (zero vs nonzero), they cannot be scissors congruent despite having equal volume. This made Hilbert's Third the first of the 23 problems to be solved. The story was completed in 1965 when Jean-Pierre Sydler proved the converse: volume and Dehn invariant are the complete set of scissors congruence invariants in 3D.",
@@ -70,8 +70,8 @@
       "title": "Scissors Congruence",
       "startLine": 47,
       "endLine": 65,
-      "summary": "Defines the ScissorsCongruent relation (existence of a finite polyhedral decomposition) and proves reflexivity and symmetry, establishing it as a pre-equivalence relation on polyhedra.",
-      "mathContext": "Formal definition: Defines the ScissorsCongruent relation (existence of a finite polyhedral decomposition) and proves reflexivity and symmetry, establishing it as a pre-equivalence relation on polyhedra."
+      "summary": "Explains why scissors congruence is not formalized as a standalone predicate: the impossibility result below is carried entirely by the Dehn invariant obstruction (hilbert_third_problem, dehn_obstruction). A prior vacuous placeholder definition (ScissorsCongruent := ∃ n, True) with two trivial reflexivity/symmetry lemmas held for every pair of types and was load-bearing for nothing, so it has been removed.",
+      "mathContext": "No formal ScissorsCongruent predicate is defined; scissors congruence enters only informally. The formal negative answer runs through the Dehn invariant separation."
     },
     {
       "id": "angles",
@@ -188,8 +188,8 @@
     "namespace": "DissectionOfCubesOQ02",
     "lineCount": 379,
     "axiomCount": 0,
-    "theoremCount": 20,
-    "definitionCount": 7,
+    "theoremCount": 16,
+    "definitionCount": 6,
     "opens": [
       "Real"
     ],

--- a/src/data/proofs/dissection-of-cubes-oq-02/review.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/review.json
@@ -3,7 +3,6 @@
   "proofId": "dissection-of-cubes-oq-02",
   "reviewDate": "2026-03-25T00:00:00Z",
   "reviewer": "peer-reviewer",
-
   "overallAssessment": {
     "grade": "C+",
     "oneLiner": "Contains a genuinely impressive Niven's theorem proof via Chebyshev recurrence, but the surrounding Hilbert's Third Problem framework is scaffolding with placeholder definitions and hypothesis-encoded assumptions, while meta.json misrepresents this as a fully verified unconditional result.",
@@ -35,7 +34,6 @@
       "assessment": "The file has a strong proved core (Niven's theorem, ~150 lines of original number theory) surrounded by scaffolding that looks like content but adds no mathematical substance; the narrative in meta.json blurs this boundary by presenting the whole entry as uniformly verified."
     }
   },
-
   "findings": [
     {
       "severity": "positive",
@@ -122,7 +120,6 @@
       "recommendation": "Qualify as: 'Among the Platonic solids, the cube is the only one whose dihedral angle is a rational multiple of π — this file proves it for the tetrahedron; the other cases follow from Niven's theorem.'"
     }
   ],
-
   "actionItems": [
     {
       "id": "ai-1",
@@ -171,10 +168,10 @@
       "priority": "low",
       "target": "researcher",
       "description": "Replace placeholder ScissorsCongruent definition (∃ n, True) with a meaningful axiomatized definition, or remove it entirely if the entry is reframed around the Niven's theorem contribution rather than Hilbert's Third Problem.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Removed the vacuous placeholder definition and its two trivial reflexivity/symmetry lemmas. The entry is reframed around the Dehn invariant obstruction (which already carries hilbert_third_problem); scissors congruence is explained in a source comment and section note rather than a formal predicate. Annotations ann-scissors-def / ann-scissors-props removed; counts updated."
     }
   ],
-
   "qualityScores": {
     "mathematicalSubstance": 7,
     "originalityAccuracy": 6,
@@ -185,6 +182,5 @@
     "epistemicCoherence": 6,
     "overall": 6.1
   },
-
   "suggestedBestFraming": "Formalizes a complete proof that arccos(1/3)/π is irrational via Chebyshev polynomial recurrence (Niven's theorem), establishing that the cube and regular tetrahedron have different simplified Dehn invariants — the core number-theoretic obstruction in Hilbert's Third Problem. The connection to scissors congruence via Dehn's theorem is stated as a conditional result."
 }


### PR DESCRIPTION
## Fix

Removes the vacuous `ScissorsCongruent (P Q : Type*) := ∃ n, True` placeholder definition (and its two trivially-true reflexivity/symmetry lemmas) from `DissectionOfCubesOQ02.lean`, resolving the open peer-review action item for this entry.

## Evidence

**Before:** `ScissorsCongruent P Q := ∃ n, True` held for *every* pair of types regardless of geometry. `scissors_congruent_refl` / `scissors_congruent_symm` were therefore vacuous. The peer review (`review.json`, findings on lines 72/173) flagged this: the annotations described it as "the central equivalence relation studied in Hilbert's Third Problem," but the definition encoded none of that content.

**Key observation:** the placeholder was load-bearing for nothing. The impossibility result `hilbert_third_problem` (and `dehn_obstruction`) derives `False` purely from the Dehn invariant obstruction — `grep` confirms `ScissorsCongruent` is referenced by no substantive theorem, and by no other file in `proofs/` or `src/`.

**After:** the reviewer's suggested resolution ("remove it entirely if the entry is reframed around the Dehn/Niven contribution") is applied. The def + two lemmas are replaced by an explanatory design-note comment. Gallery data synced:
- `theoremCount` 20→16, `definitionCount` 7→6 (both `meta.*` and `leanFile.*` blocks; 20 was pre-existing drift — actual col-0 count is now 16)
- stale `assumptions` note about the placeholder dropped
- section `scissors` summary/mathContext rewritten
- orphaned annotations `ann-scissors-def` / `ann-scissors-props` removed (12→10)
- `review.json` action item marked resolved (0 open items remain)

**Line parity preserved (379 lines)** so all downstream annotation and section line-ranges stay aligned.

## Validation

- `lean DissectionOfCubesOQ02.lean` → exit 0, 0 sorries, 0 axioms (only a pre-existing `push_cast` unused-tactic warning).
- All gallery JSON validated with `jq`.

---
Automated fix by lean-mechanic agent.