### PR TITLE
Fix: erdos-10-oq-02 metadata — declare 3-file stack, correct counts

### DIFF
--- a/src/data/proofs/erdos-10-oq-02/meta.json
+++ b/src/data/proofs/erdos-10-oq-02/meta.json
@@ -9,6 +9,10 @@
     "date": "2026",
     "status": "verified",
     "proofRepoPath": "Proofs/Erdos10OQ02.lean",
+    "additionalFiles": [
+      "Proofs/Erdos10OQ02Decidable.lean",
+      "Proofs/Erdos10OQ02Popcount.lean"
+    ],
     "tags": [
       "number-theory",
       "erdos",
@@ -25,7 +29,7 @@
     "assumptions": "0 axioms, 0 sorries. The Granville–Soundararajan k=3 (odd) conjecture itself is OPEN and is formalized only as a Prop definition (GranvilleSoundararajanOdd), not assumed. The stack proves the supporting infrastructure (reduction lemma, exponent/prime bounds, popcount characterization, decision procedure). Docker-verified green (2026-06-15, 3066 jobs): all three files — Erdos10OQ02, Erdos10OQ02Decidable, Erdos10OQ02Popcount — kernel-check at the v4.26.0 pin, including the native_decide witnesses (e.g. 906 ∉ S_3). Two Mathlib-drift fixes were needed: a stray omega after a now-self-closing simp (Erdos10OQ02:133) and a rw chain that no longer auto-closes a defeq powSum goal (Erdos10OQ02Popcount:83, closed with rfl).",
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 14,
     "definitionCount": 8
   },
   "overview": {
@@ -148,12 +152,16 @@
       "Mathlib.Data.Nat.Prime.Basic"
     ],
     "namespace": "Erdos10OQ02",
-    "lineCount": 542,
+    "lineCount": 188,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 6,
     "path": "Proofs/Erdos10OQ02.lean",
     "sorries": 0,
-    "definitionCount": 8
+    "definitionCount": 5,
+    "additionalFiles": [
+      "Proofs/Erdos10OQ02Decidable.lean",
+      "Proofs/Erdos10OQ02Popcount.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-10-oq-02/meta.json
+++ b/src/data/proofs/erdos-10-oq-02/meta.json
@@ -30,7 +30,7 @@
     "dateAdded": "2026-06-15",
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
-    "definitionCount": 8
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Erdős Problem #10 asks whether there is a finite k such that every integer is a prime plus at most k powers of 2. The question grew out of de Polignac's 1849 conjecture that every odd number is a prime plus a single power of 2, which Erdős (1950) refuted with covering congruences, exhibiting an entire arithmetic progression of odd counterexamples — motivating the relaxation to k powers. Granville and Soundararajan (1998) refined the question into a parity split, conjecturing k=3 powers suffice for odd integers and k=4 for even — both still open. The conjecture connects to the multiplicative order of 2 modulo p². Romanoff (1934) had shown the representable set has positive lower density; Crocker (1971) ruled out k=2 unconditionally; Gallagher (1975) showed that density approaches 1.",


### PR DESCRIPTION
## Fix

The `erdos-10-oq-02` entry describes a **"three-file stack"** (`Erdos10OQ02` + `Erdos10OQ02Decidable` + `Erdos10OQ02Popcount`) but declared **no `additionalFiles`**, and its count blocks told three inconsistent stories.

## Evidence

**Before**
- `meta`/`leanFile` both read `lineCount 542`, `theoremCount 16`, `definitionCount 8`.
- The single main file `Erdos10OQ02.lean` is only **188 lines / 6 thm / 5 def** — so `leanFile` (which by convention describes the *main* file, cf. `erdos-741`) was overstating it ~3×.
- The counts were mutually inconsistent: `lineCount 542` = 3-file aggregate (188+201+153); `theoremCount 16` = 4-file (includes the unclaimed `Bridge.lean`'s 2 thms); `definitionCount 8` = 3-file aggregate. No single file-set explains all three.
- `additionalFiles` absent → the auditor could not scan the companions where all `native_decide` witnesses live.

**After** (faithful to the entry's own stated 3-file model + gallery convention)
- `meta.*` = aggregate over the 3 declared files: **542 / 14 / 8** (fixed `theoremCount` 16→14).
- `leanFile.*` = main-file only: **188 / 6 / 5**.
- Both blocks now declare `additionalFiles: [Decidable, Popcount]`.

**Status unchanged (`verified` / 0-axiom).** With the companions now visible, `scripts/auditor/find-targets.ts --issues` still reports **0 issues** for this entry — all `native_decide` calls are in throwaway `example`s, not named declarations, so `Lean.ofReduceBool` is not incurred by any headline result.

---
Automated fix by lean-mechanic agent.