### PR TITLE
research(erdos-101-oq-02): extremal four-point-line configs are Steiner systems ⇒ n ≡ 1,4 (mod 12) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos101OQ02.lean
+++ b/proofs/Proofs/Erdos101OQ02.lean
@@ -1,0 +1,314 @@
+/-
+# Erdős Problem #101 — Extremal Four-Point-Line Configurations are Steiner Systems
+
+Follow-up to Erdős Problem #101 (`Erdos101Problem.lean`), open question OQ-02:
+*"Can the Solymosi–Stojaković construction be improved to Ω(n² / polylog(n)),
+or is there a barrier?"*
+
+The parent file proves the sharp **pair-packing upper bound**
+
+    fourPointLineCount P ≤ n(n-1)/12      (`improved_upper_bound`)
+
+for any planar point set `P` on `n` points with no five collinear.  This bound is
+attained exactly when the four-point lines **perfectly cover** the pairs of points,
+i.e. when every 2-element subset of `P` lies on a (necessarily unique) four-point
+line.  Such a configuration is precisely a **Steiner system `S(2,4,n)`** realized in
+the plane.
+
+This file records the classical **necessary conditions** that any such extremal
+configuration must satisfy — a genuine arithmetic *barrier*:
+
+* `extremal_covers_all_pairs` : attaining the bound ⇒ every pair of points lies on a
+  four-point line (existence half of the Steiner property);
+* `extremal_pair_covered_uniquely` : that line is unique (Steiner `S(2,4,n)`);
+* `twelve_dvd_of_extremal`      : `12 ∣ n(n-1)`  (integrality of the block count);
+* `three_dvd_of_extremal`       : `3 ∣ (n-1)`    (integrality of the replication number);
+* **`extremal_forces_mod_twelve`** : `n ≡ 1 or 4 (mod 12)`.
+
+These are exactly the divisibility conditions for the existence of a Steiner system
+`S(2,4,n)` (Hanani).  So a plane configuration meeting the `n(n-1)/12` bound can only
+exist for `n ≡ 1, 4 (mod 12)`; for all other `n` there is a hard combinatorial
+obstruction *before* any geometry is invoked.
+
+The extremal hypothesis is phrased as `6 * fourPointLineCount P = n.choose 2`, i.e.
+the `6` pairs contributed by each four-point line exactly exhaust the `C(n,2)` pairs.
+
+All results are axiom-free (0 sorries, 0 axioms).
+-/
+
+import Mathlib
+import Proofs.Erdos101Problem
+
+namespace Erdos101ExtremalSteiner
+
+open Classical
+
+/-! ## Part C — the pure arithmetic core
+
+Given `3 ∣ (n-1)` (replication integer) and `12 ∣ n(n-1)` (block-count integer),
+the residue of `n` mod `12` is forced to `1` or `4`.  Everything reduces mod `12`;
+the nonlinear product `n(n-1)` is handled by `Nat.mul_mod` followed by a finite
+residue case-split. -/
+
+/-- If `3 ∣ (n-1)` and `12 ∣ n(n-1)` for `n ≥ 1`, then `n ≡ 1 or 4 (mod 12)`. -/
+lemma mod12_of_extremal (n : ℕ) (hn : 1 ≤ n)
+    (h3 : 3 ∣ (n - 1)) (h12 : 12 ∣ n * (n - 1)) :
+    n % 12 = 1 ∨ n % 12 = 4 := by
+  -- `n(n-1) ≡ 0 (mod 12)` as a plain modular fact.
+  have e0 : n * (n - 1) % 12 = 0 := by omega
+  -- Reduce the product modulo 12.
+  have e1 : n * (n - 1) % 12 = (n % 12) * ((n - 1) % 12) % 12 := Nat.mul_mod _ _ _
+  rw [e0] at e1
+  -- Express `(n-1) mod 12` through `n mod 12`.
+  have hb : (n - 1) % 12 = (n % 12 + 11) % 12 := by omega
+  rw [hb] at e1
+  -- The replication constraint modulo 3.
+  have h3r : (n % 12) % 3 = 1 := by omega
+  set r := n % 12 with hr
+  have hrlt : r < 12 := by rw [hr]; exact Nat.mod_lt _ (by norm_num)
+  -- Finite check over the 12 residues.
+  interval_cases r <;> omega
+
+/-! ## Part A — block-count integrality: `12 ∣ n(n-1)`
+
+Each four-point line accounts for `C(4,2) = 6` pairs, so attaining the bound means
+`6 · L = C(n,2) = n(n-1)/2`, whence `n(n-1) = 12 · L`. -/
+
+/-- If the four-point lines attain the pair-packing bound `6·L = C(n,2)`, then
+`12 ∣ n(n-1)`; the number of lines `L` is the block count of a `2-(n,4,1)` design. -/
+lemma twelve_dvd_of_extremal (P : PlanarPointSet)
+    (hExt : 6 * fourPointLineCount P = P.points.card.choose 2) :
+    12 ∣ P.points.card * (P.points.card - 1) := by
+  set n := P.points.card with hn_def
+  have hchoose : n.choose 2 = n * (n - 1) / 2 := Nat.choose_two_right n
+  -- `n(n-1)` is even.
+  have heven : 2 ∣ n * (n - 1) := by
+    rcases Nat.even_or_odd n with he | ho
+    · exact he.two_dvd.mul_right _
+    · have h1 : 2 ∣ (n - 1) := by
+        rcases ho with ⟨k, hk⟩; omega
+      exact h1.mul_left _
+  -- `2 · C(n,2) = n(n-1)`.
+  have h2 : 2 * n.choose 2 = n * (n - 1) := by
+    rw [hchoose]; omega
+  -- `n(n-1) = 2·(6L) = 12L`.
+  refine ⟨fourPointLineCount P, ?_⟩
+  rw [← h2, ← hExt]; ring
+
+/-! ## Steiner property: attaining the bound perfectly covers the pairs
+
+Rebuild the disjoint pair-packing of the parent's `improved_upper_bound`; when
+`6·L = C(n,2)` the packing is *perfect*, so its blocks (the four-point lines)
+cover every 2-subset of the point set. -/
+
+/-- Membership unfolding for `fourCollinearFamily`. -/
+private lemma mem_family_iff (P : PlanarPointSet) (S : Finset (ℝ × ℝ)) :
+    S ∈ fourCollinearFamily P ↔
+      S ⊆ P.points ∧ S.card = 4 ∧
+      ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧ ∀ p ∈ S, collinear a b p := by
+  unfold fourCollinearFamily
+  simp only [Finset.mem_filter, Finset.mem_powerset]
+
+/-- **Extremal ⇒ every pair covered.**  If `6·L = C(n,2)`, then every 2-element
+subset of `P.points` is contained in some four-point line.  (Existence half of the
+Steiner `S(2,4,n)` property.) -/
+theorem extremal_covers_all_pairs (P : PlanarPointSet) (hP : NoFiveCollinear P)
+    (hExt : 6 * fourPointLineCount P = P.points.card.choose 2)
+    (T : Finset (ℝ × ℝ)) (hT : T ∈ P.points.powersetCard 2) :
+    ∃ S ∈ fourCollinearFamily P, T ⊆ S := by
+  set F := fourCollinearFamily P with hF_def
+  -- pair-set of each block
+  set pairSet : Finset (ℝ × ℝ) → Finset (Finset (ℝ × ℝ)) :=
+    fun S => S.powersetCard 2 with hps
+  -- each block contributes exactly 6 pairs
+  have hpair_card : ∀ S ∈ F, (pairSet S).card = 6 := by
+    intro S hS
+    have hprop := (mem_family_iff P S).mp hS
+    show (S.powersetCard 2).card = 6
+    rw [Finset.card_powersetCard, hprop.2.1]; decide
+  -- pair-sets are pairwise disjoint (distinct blocks share ≤ 1 point)
+  have hpair_disj : ∀ S₁ ∈ F, ∀ S₂ ∈ F, S₁ ≠ S₂ →
+      Disjoint (pairSet S₁) (pairSet S₂) := by
+    intro S₁ hS₁ S₂ hS₂ hne
+    obtain ⟨hsub₁, hc₁, a₁, b₁, ha₁, hb₁, hab₁, hcol₁⟩ := (mem_family_iff P S₁).mp hS₁
+    obtain ⟨hsub₂, hc₂, a₂, b₂, ha₂, hb₂, hab₂, hcol₂⟩ := (mem_family_iff P S₂).mp hS₂
+    apply powersetCard2_disjoint
+    exact four_collinear_overlap_small P hP S₁ S₂ hsub₁ hsub₂ hc₁ hc₂ hne
+      a₁ b₁ hab₁ ha₁ hb₁ hcol₁ a₂ b₂ hab₂ ha₂ hb₂ hcol₂
+  -- the union of pair-sets sits inside all 2-subsets of P.points
+  have hbU_sub : F.biUnion pairSet ⊆ P.points.powersetCard 2 := by
+    intro U hU
+    rw [Finset.mem_biUnion] at hU
+    obtain ⟨S, hS, hU_S⟩ := hU
+    have hsub := (mem_family_iff P S).mp hS |>.1
+    have h2 := Finset.mem_powersetCard.mp hU_S
+    exact Finset.mem_powersetCard.mpr ⟨h2.1.trans hsub, h2.2⟩
+  -- cardinalities
+  have hbU_card : (F.biUnion pairSet).card = 6 * F.card := by
+    rw [Finset.card_biUnion (fun S hS T hT hne => hpair_disj S hS T hT hne),
+        Finset.sum_const_nat (fun S hS => hpair_card S hS)]
+    ring
+  have hLF : F.card = fourPointLineCount P := (fourPointLineCount_eq_family P).symm
+  have hpc_card : (P.points.powersetCard 2).card = P.points.card.choose 2 :=
+    Finset.card_powersetCard 2 P.points
+  -- perfect packing: the union is *all* 2-subsets
+  have hunion : F.biUnion pairSet = P.points.powersetCard 2 := by
+    apply Finset.eq_of_subset_of_card_le hbU_sub
+    rw [hpc_card, hbU_card, hLF, hExt]
+  -- extract the covering block for T
+  have hT' : T ∈ F.biUnion pairSet := by rw [hunion]; exact hT
+  rw [Finset.mem_biUnion] at hT'
+  obtain ⟨S, hS, hT_S⟩ := hT'
+  exact ⟨S, hS, (Finset.mem_powersetCard.mp hT_S).1⟩
+
+/-- **Extremal ⇒ each pair covered by a unique block** — the configuration is a
+Steiner system `S(2,4,n)`. -/
+theorem extremal_pair_covered_uniquely (P : PlanarPointSet) (hP : NoFiveCollinear P)
+    (hExt : 6 * fourPointLineCount P = P.points.card.choose 2)
+    (T : Finset (ℝ × ℝ)) (hT : T ∈ P.points.powersetCard 2) :
+    ∃! S, S ∈ fourCollinearFamily P ∧ T ⊆ S := by
+  obtain ⟨S, hS, hTS⟩ := extremal_covers_all_pairs P hP hExt T hT
+  refine ⟨S, ⟨hS, hTS⟩, ?_⟩
+  rintro S' ⟨hS', hTS'⟩
+  by_contra hne
+  -- T ⊆ S ∩ S' with |T| = 2 forces the blocks to share ≥ 2 points
+  obtain ⟨hsub, hc, a, b, ha, hb, hab, hcol⟩ := (mem_family_iff P S).mp hS
+  obtain ⟨hsub', hc', a', b', ha', hb', hab', hcol'⟩ := (mem_family_iff P S').mp hS'
+  have hTcard : T.card = 2 := (Finset.mem_powersetCard.mp hT).2
+  have hle := four_collinear_overlap_small P hP S' S hsub' hsub hc' hc
+    hne a' b' hab' ha' hb' hcol' a b hab ha hb hcol
+  have hTsub : T ⊆ S' ∩ S := Finset.subset_inter hTS' hTS
+  have : (2 : ℕ) ≤ (S' ∩ S).card := hTcard ▸ Finset.card_le_card hTsub
+  omega
+
+/-! ## Part B — replication integrality: `3 ∣ (n-1)`
+
+Fix a point `p`.  The pairs `{p,q}` (for `q ≠ p`) are perfectly covered, so the
+`n-1` points `q ≠ p` are partitioned into the three-point sets `S \ {p}` ranging
+over the four-point lines `S` through `p`.  Hence `3 ∣ (n-1)`. -/
+
+/-- If the four-point lines attain the bound, then `3 ∣ (n-1)`: the replication
+number `(n-1)/3` (four-point lines through any fixed point) is an integer. -/
+theorem three_dvd_of_extremal (P : PlanarPointSet) (hP : NoFiveCollinear P)
+    (hExt : 6 * fourPointLineCount P = P.points.card.choose 2) :
+    3 ∣ (P.points.card - 1) := by
+  -- pick a point p
+  obtain ⟨p, hp⟩ := Finset.card_pos.mp P.size_pos
+  set FP := fourCollinearThrough P p with hFP
+  set eraseMap : Finset (ℝ × ℝ) → Finset (ℝ × ℝ) := fun S => S.erase p with hem
+  -- membership facts for FP
+  have hFP_prop : ∀ S ∈ FP, S ⊆ P.points ∧ S.card = 4 ∧ p ∈ S ∧
+      ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧ ∀ q ∈ S, collinear a b q := by
+    intro S hS
+    rw [hFP] at hS
+    unfold fourCollinearThrough at hS
+    rw [Finset.mem_filter, Finset.mem_powerset] at hS
+    exact ⟨hS.1, hS.2.1, hS.2.2.1, hS.2.2.2⟩
+  -- each block through p, minus p, has 3 points
+  have herase_card : ∀ S ∈ FP, (eraseMap S).card = 3 := by
+    intro S hS
+    obtain ⟨_, hcard, hpS, _⟩ := hFP_prop S hS
+    show (S.erase p).card = 3
+    rw [Finset.card_erase_of_mem hpS, hcard]
+  -- images land in P.points.erase p
+  have herase_sub : ∀ S ∈ FP, eraseMap S ⊆ P.points.erase p := by
+    intro S hS x hx
+    obtain ⟨hsub, _, _, _⟩ := hFP_prop S hS
+    have hxS := Finset.mem_of_mem_erase hx
+    have hxne := Finset.ne_of_mem_erase hx
+    exact Finset.mem_erase.mpr ⟨hxne, hsub hxS⟩
+  -- pairwise disjoint (two lines through p sharing another point share ≥ 2 points)
+  have herase_disj : ∀ S₁ ∈ FP, ∀ S₂ ∈ FP, S₁ ≠ S₂ →
+      Disjoint (eraseMap S₁) (eraseMap S₂) := by
+    intro S₁ hS₁ S₂ hS₂ hne
+    rw [Finset.disjoint_left]
+    intro x hx₁ hx₂
+    have hxne : x ≠ p := Finset.ne_of_mem_erase hx₁
+    have hxS₁ := Finset.mem_of_mem_erase hx₁
+    have hxS₂ := Finset.mem_of_mem_erase hx₂
+    obtain ⟨hsub₁, hc₁, hp₁, a₁, b₁, ha₁, hb₁, hab₁, hcol₁⟩ := hFP_prop S₁ hS₁
+    obtain ⟨hsub₂, hc₂, hp₂, a₂, b₂, ha₂, hb₂, hab₂, hcol₂⟩ := hFP_prop S₂ hS₂
+    have hge : 2 ≤ (S₁ ∩ S₂).card := by
+      have hpx : p ≠ x := fun h => hxne h.symm
+      have hpair : ({p, x} : Finset (ℝ × ℝ)).card = 2 := Finset.card_pair hpx
+      have hsub : ({p, x} : Finset (ℝ × ℝ)) ⊆ S₁ ∩ S₂ := by
+        intro y hy
+        simp only [Finset.mem_insert, Finset.mem_singleton] at hy
+        rcases hy with rfl | rfl
+        · exact Finset.mem_inter.mpr ⟨hp₁, hp₂⟩
+        · exact Finset.mem_inter.mpr ⟨hxS₁, hxS₂⟩
+      calc (2 : ℕ) = ({p, x} : Finset (ℝ × ℝ)).card := hpair.symm
+        _ ≤ (S₁ ∩ S₂).card := Finset.card_le_card hsub
+    have hle := four_collinear_overlap_small P hP S₁ S₂ hsub₁ hsub₂ hc₁ hc₂ hne
+      a₁ b₁ hab₁ ha₁ hb₁ hcol₁ a₂ b₂ hab₂ ha₂ hb₂ hcol₂
+    omega
+  -- coverage: every q ≠ p is reached (this is where extremality is used)
+  have hcover : P.points.erase p ⊆ FP.biUnion eraseMap := by
+    intro x hx
+    have hxne : x ≠ p := Finset.ne_of_mem_erase hx
+    have hxP : x ∈ P.points := Finset.mem_of_mem_erase hx
+    -- the pair {p, x}
+    have hpair_card : ({p, x} : Finset (ℝ × ℝ)).card = 2 :=
+      Finset.card_pair (fun h => hxne h.symm)
+    have hpair_sub : ({p, x} : Finset (ℝ × ℝ)) ⊆ P.points := by
+      intro y hy
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hy
+      rcases hy with rfl | rfl
+      · exact hp
+      · exact hxP
+    have hpair_mem : ({p, x} : Finset (ℝ × ℝ)) ∈ P.points.powersetCard 2 :=
+      Finset.mem_powersetCard.mpr ⟨hpair_sub, hpair_card⟩
+    obtain ⟨S, hS, hTS⟩ := extremal_covers_all_pairs P hP hExt _ hpair_mem
+    have hpS : p ∈ S := hTS (by simp)
+    have hxS : x ∈ S := hTS (by simp)
+    have hS_FP : S ∈ FP := mem_fourCollinearThrough_of_mem_family P S hS p hpS
+    rw [Finset.mem_biUnion]
+    exact ⟨S, hS_FP, Finset.mem_erase.mpr ⟨hxne, hxS⟩⟩
+  -- assemble: (n-1) = |P.points.erase p| = 3 * |FP|
+  have hunion : FP.biUnion eraseMap = P.points.erase p := by
+    apply Finset.Subset.antisymm _ hcover
+    intro x hx
+    rw [Finset.mem_biUnion] at hx
+    obtain ⟨S, hS, hxS⟩ := hx
+    exact herase_sub S hS hxS
+  have hcard_biU : (FP.biUnion eraseMap).card = 3 * FP.card := by
+    rw [Finset.card_biUnion (fun S hS T hT hne => herase_disj S hS T hT hne),
+        Finset.sum_const_nat (fun S hS => herase_card S hS)]
+    ring
+  have herase_p : (P.points.erase p).card = P.points.card - 1 :=
+    Finset.card_erase_of_mem hp
+  have hkey : P.points.card - 1 = 3 * FP.card := by
+    rw [← herase_p, ← hunion, hcard_biU]
+  exact ⟨FP.card, hkey⟩
+
+/-! ## Main theorem -/
+
+/-- **Extremal configurations satisfy the Steiner divisibility conditions.**
+
+If a planar point set `P` on `n` points with no five collinear attains the sharp
+pair-packing bound `fourPointLineCount P = n(n-1)/12` — equivalently
+`6 · fourPointLineCount P = C(n,2)`, i.e. every pair of points lies on a four-point
+line — then
+
+    n ≡ 1  or  n ≡ 4   (mod 12).
+
+These are exactly Hanani's necessary conditions for the existence of a Steiner
+system `S(2,4,n)`.  Hence the `n(n-1)/12` upper bound is *unattainable* whenever
+`n ≢ 1, 4 (mod 12)` — an arithmetic barrier that holds before any geometric input. -/
+theorem extremal_forces_mod_twelve (P : PlanarPointSet) (hP : NoFiveCollinear P)
+    (hExt : 6 * fourPointLineCount P = P.points.card.choose 2) :
+    P.points.card % 12 = 1 ∨ P.points.card % 12 = 4 :=
+  mod12_of_extremal _ P.size_pos
+    (three_dvd_of_extremal P hP hExt) (twelve_dvd_of_extremal P hExt)
+
+/-- Contrapositive convenience form: for `n ≢ 1, 4 (mod 12)` no no-five-collinear
+configuration meets the pair-packing bound. -/
+theorem not_extremal_of_mod_twelve (P : PlanarPointSet) (hP : NoFiveCollinear P)
+    (hmod : P.points.card % 12 ≠ 1 ∧ P.points.card % 12 ≠ 4) :
+    6 * fourPointLineCount P ≠ P.points.card.choose 2 := by
+  intro hExt
+  rcases extremal_forces_mod_twelve P hP hExt with h | h
+  · exact hmod.1 h
+  · exact hmod.2 h
+
+end Erdos101ExtremalSteiner

--- a/src/data/proofs/erdos-101-oq-02/annotations.json
+++ b/src/data/proofs/erdos-101-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-header-extremal",
+    "proofId": "erdos-101-oq-02",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "The extremal case of the pair-packing bound",
+    "content": "The parent entry (Erdős #101) proves $\\mathrm{fourPointLineCount}(P) \\le \\tfrac{n(n-1)}{12}$: each four-point line contributes $\\binom{4}{2}=6$ pairs, distinct lines share at most one point, so the pair-sets are disjoint and pack into the $\\binom{n}{2}$ available pairs. This file characterises equality. Attaining the bound means the $6L$ packed pairs exhaust all $\\binom{n}{2}$ pairs, i.e. every pair of points lies on a (unique) four-point line — a Steiner system $S(2,4,n)$ realised in the plane. The hypothesis is phrased as $6\\cdot\\mathrm{fourPointLineCount}(P) = \\binom{n}{2}$.",
+    "mathContext": "$6L = \\binom{n}{2} \\iff$ four-point lines perfectly cover the pairs",
+    "significance": "key",
+    "relatedConcepts": [
+      "Steiner system S(2,4,n)",
+      "balanced incomplete block design",
+      "pair-packing / covering",
+      "extremal combinatorics"
+    ],
+    "prerequisites": [
+      "Parent Erdős #101 framework (PlanarPointSet, NoFiveCollinear, fourPointLineCount)",
+      "improved_upper_bound (pair-packing ≤ n(n-1)/12)"
+    ]
+  },
+  {
+    "id": "ann-mod12-core",
+    "proofId": "erdos-101-oq-02",
+    "range": { "startLine": 43, "endLine": 76 },
+    "type": "proof-technique",
+    "title": "Reducing $n(n-1)$ modulo 12",
+    "content": "The arithmetic heart: given $3 \\mid (n-1)$ (replication integer) and $12 \\mid n(n-1)$ (block-count integer), conclude $n \\equiv 1$ or $4 \\pmod{12}$. The obstacle is that $n(n-1)$ is nonlinear, so `omega` cannot see it directly. The fix is `Nat.mul_mod`, rewriting $n(n-1) \\bmod 12 = (n \\bmod 12)\\cdot((n-1)\\bmod 12) \\bmod 12$; expressing $(n-1)\\bmod 12$ through $n \\bmod 12$; then `interval_cases` on the residue $r = n\\bmod 12$ turns every product into a literal, and `omega` closes each of the 12 branches (residues $7,10$ die on the block-count constraint, non-$1\\bmod 3$ residues die on the replication constraint).",
+    "mathContext": "$3\\mid(n-1) \\land 12\\mid n(n-1) \\Rightarrow n\\equiv 1,4 \\pmod{12}$",
+    "significance": "important",
+    "relatedConcepts": [
+      "Nat.mul_mod residue reduction",
+      "interval_cases finite dispatch",
+      "omega linear arithmetic"
+    ],
+    "prerequisites": ["Modular arithmetic in ℕ"]
+  },
+  {
+    "id": "ann-perfect-cover",
+    "proofId": "erdos-101-oq-02",
+    "range": { "startLine": 105, "endLine": 190 },
+    "type": "proof-technique",
+    "title": "Perfect packing ⇒ every pair covered (and uniquely)",
+    "content": "The disjoint pair-packing of `improved_upper_bound` is rebuilt as a biUnion of the per-line pair-sets $S \\mapsto \\binom{S}{2}$, with cardinality $6L$ and contained in $\\binom{P}{2}$ (size $\\binom{n}{2}$). Under $6L = \\binom{n}{2}$ the containment is an equality of finsets (`Finset.eq_of_subset_of_card_le`), so every 2-subset appears in the union — existence of a covering line. Uniqueness follows because a pair lying in two distinct four-point lines would force them to share $\\ge 2$ points, contradicting `four_collinear_overlap_small`. Together: a Steiner system $S(2,4,n)$.",
+    "mathContext": "$\\bigcup_{S} \\binom{S}{2} = \\binom{P}{2}$ when $6L=\\binom{n}{2}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.eq_of_subset_of_card_le",
+      "Finset.card_biUnion (disjoint)",
+      "four_collinear_overlap_small"
+    ],
+    "prerequisites": ["Finset cardinality and biUnion"]
+  },
+  {
+    "id": "ann-replication",
+    "proofId": "erdos-101-oq-02",
+    "range": { "startLine": 192, "endLine": 296 },
+    "type": "proof-technique",
+    "title": "Replication number: $3 \\mid (n-1)$ from a per-point partition",
+    "content": "Fixing a point $p$, the four-point lines through $p$ have their $p$-erased 3-element parts $S\\setminus\\{p\\}$ pairwise disjoint (two lines through $p$ sharing another point would share $\\ge 2$ points) and — by perfect covering — collectively equal to $P\\setminus\\{p\\}$. Hence $n-1 = 3\\cdot(\\text{lines through } p)$, i.e. $3 \\mid (n-1)$ and the replication number $(n-1)/3$ is an integer. This reuses the parent's `fourCollinearThrough` machinery, adding the surjectivity (coverage) direction that the parent's one-sided bound lacked.",
+    "mathContext": "$P\\setminus\\{p\\} = \\biguplus_{S \\ni p}\\ (S\\setminus\\{p\\}),\\quad |S\\setminus\\{p\\}| = 3$",
+    "significance": "key",
+    "relatedConcepts": [
+      "replication number of a design",
+      "partition / disjoint biUnion",
+      "fourCollinearThrough"
+    ],
+    "prerequisites": ["Finset.erase, Finset.card_biUnion"]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "erdos-101-oq-02",
+    "range": { "startLine": 298, "endLine": 314 },
+    "type": "concept",
+    "title": "Main theorem: the mod-12 barrier",
+    "content": "extremal_forces_mod_twelve assembles the two integrality facts into $n \\equiv 1,4 \\pmod{12}$ — exactly Hanani's necessary conditions for a Steiner system $S(2,4,n)$. The contrapositive not_extremal_of_mod_twelve states that for $n \\not\\equiv 1,4 \\pmod{12}$ no no-five-collinear configuration attains the pair-packing bound. This is an arithmetic barrier at the extreme end of the four-point-line spectrum; it does not address the open $\\Omega(n^2)$ growth question of OQ-02, which lives well below the extremal ceiling.",
+    "mathContext": "$6\\cdot\\mathrm{fourPointLineCount}(P) = \\binom{n}{2} \\Rightarrow n \\equiv 1,4 \\pmod{12}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hanani divisibility conditions",
+      "extremal characterisation",
+      "arithmetic obstruction"
+    ],
+    "prerequisites": ["The two integrality lemmas above"]
+  }
+]

--- a/src/data/proofs/erdos-101-oq-02/meta.json
+++ b/src/data/proofs/erdos-101-oq-02/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "erdos-101-oq-02",
+  "slug": "erdos-101-oq-02",
+  "title": "Erdős #101 OQ-02: Extremal Four-Point-Line Configurations are Steiner Systems ($n \\equiv 1,4 \\bmod 12$)",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos101Problem"
+    ],
+    "opens": [
+      "Classical"
+    ],
+    "namespace": "Erdos101ExtremalSteiner",
+    "lineCount": 314,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos101OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Erdős",
+    "erdosNumber": 101,
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos101OQ02.lean",
+    "tags": [
+      "erdos",
+      "combinatorial-geometry",
+      "incidence-geometry",
+      "design-theory",
+      "steiner-system",
+      "extremal-combinatorics",
+      "collinearity",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/101",
+    "erdosUrl": "https://erdosproblems.com/101",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-06-30",
+    "axiomCount": 0,
+    "lineCount": 314,
+    "assumptions": "None. 0 sorries, 0 axioms — every theorem depends only on the foundational axioms propext / Classical.choice / Quot.sound (verified by #print axioms). The result is an unconditional structural theorem about the extremal case of the parent's pair-packing bound.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "substantiveTheoremCount": 6
+  },
+  "description": "A structural / arithmetic barrier for the extremal case of Erdős Problem #101. The parent entry proves the sharp pair-packing upper bound $\\mathrm{fourPointLineCount}(P) \\le \\tfrac{n(n-1)}{12}$ for any $n$-point planar set with no five collinear. This follow-up characterises the equality case: a configuration attains the bound exactly when its four-point lines perfectly cover the pairs of points — i.e. it realises a Steiner system $S(2,4,n)$ in the plane — and derives the classical Hanani divisibility conditions $n \\equiv 1$ or $4 \\pmod{12}$ that any such configuration must satisfy.",
+  "overview": "Erdős #101 OQ-02 asks whether the Solymosi–Stojaković $\\Omega(n^{2-o(1)})$ lower-bound construction can be pushed to $\\Omega(n^2/\\mathrm{polylog}\\,n)$, or whether there is a barrier. The pair-packing bound $\\tfrac{n(n-1)}{12}$ is the natural elementary ceiling ($\\binom{4}{2}=6$ disjoint pairs per line, packed into $\\binom{n}{2}$ pairs). This entry pins down precisely when that ceiling is met: it is attained iff every 2-subset of points lies on a (unique) four-point line, which is exactly a Steiner system $S(2,4,n)$. Counting the block count ($12 \\mid n(n-1)$) and the replication number ($3 \\mid n-1$) forces $n \\equiv 1, 4 \\pmod{12}$. Consequently the $\\tfrac{n(n-1)}{12}$ bound is unattainable for all other residues — a hard arithmetic obstruction that precedes any geometric input. This does not resolve OQ-02 (which concerns $\\Omega(n^2)$ growth, well below the extremal ceiling), but it exactly delimits the extreme end of the packing spectrum.",
+  "sections": [
+    {
+      "id": "arithmetic-core",
+      "title": "Arithmetic core: residues mod 12",
+      "startLine": 43,
+      "endLine": 76,
+      "summary": "mod12_of_extremal: from 3 ∣ (n-1) and 12 ∣ n(n-1) with n ≥ 1, the residue n mod 12 is forced to 1 or 4. The nonlinear product n(n-1) is reduced via Nat.mul_mod and dispatched by a 12-way residue case split (interval_cases + omega).",
+      "mathContext": "$3 \\mid (n-1) \\land 12 \\mid n(n-1) \\Rightarrow n \\equiv 1,4 \\pmod{12}$"
+    },
+    {
+      "id": "block-count",
+      "title": "Block-count integrality: $12 \\mid n(n-1)$",
+      "startLine": 78,
+      "endLine": 103,
+      "summary": "twelve_dvd_of_extremal: attaining the bound means 6·L = C(n,2) = n(n-1)/2, so n(n-1) = 12·L. L is the block count of the underlying 2-(n,4,1) design.",
+      "mathContext": "$6L = \\binom{n}{2} \\Rightarrow n(n-1) = 12L$"
+    },
+    {
+      "id": "steiner-property",
+      "title": "Extremal ⇒ Steiner system $S(2,4,n)$",
+      "startLine": 105,
+      "endLine": 190,
+      "summary": "extremal_covers_all_pairs rebuilds the disjoint pair-packing (each line = 6 pairs, distinct lines share ≤ 1 point) and uses card equality to show the packing is perfect: every 2-subset of P.points lies in some four-point line. extremal_pair_covered_uniquely upgrades this to uniqueness — precisely a Steiner system.",
+      "mathContext": "$6L=\\binom{n}{2} \\Rightarrow \\forall\\, \\{p,q\\}\\subseteq P,\\ \\exists!\\ \\text{line } S \\ni p,q$"
+    },
+    {
+      "id": "replication",
+      "title": "Replication integrality: $3 \\mid (n-1)$",
+      "startLine": 192,
+      "endLine": 296,
+      "summary": "three_dvd_of_extremal: fix a point p; perfect covering partitions the n−1 remaining points into the 3-element sets S∖{p} over four-point lines S through p. Hence 3 ∣ (n−1), i.e. the replication number (n−1)/3 is an integer.",
+      "mathContext": "$n-1 = 3\\cdot |\\{\\text{four-point lines through } p\\}|$"
+    },
+    {
+      "id": "main",
+      "title": "Main theorem and contrapositive",
+      "startLine": 298,
+      "endLine": 314,
+      "summary": "extremal_forces_mod_twelve combines the two integrality facts: an extremal configuration forces n ≡ 1 or 4 (mod 12). not_extremal_of_mod_twelve is the contrapositive: for n ≢ 1,4 (mod 12) no no-five-collinear set attains the pair-packing bound.",
+      "mathContext": "$n \\equiv 1,4 \\pmod{12}$"
+    }
+  ],
+  "conclusion": {
+    "summary": "The extremal case of Erdős #101's pair-packing bound $\\tfrac{n(n-1)}{12}$ is exactly a plane-realised Steiner system $S(2,4,n)$, and therefore obeys Hanani's necessary conditions $n \\equiv 1, 4 \\pmod{12}$. All results are axiom-free (0 sorries, 0 axioms).",
+    "implications": "The bound $\\tfrac{n(n-1)}{12}$ is unattainable whenever $n \\not\\equiv 1,4 \\pmod{12}$ — a purely arithmetic barrier at the extreme end of the four-point-line spectrum, established before any geometric obstruction is invoked. It cleanly separates the 'perfect packing' regime (design theory) from the open $\\Omega(n^2)$ growth question of OQ-02.",
+    "openQuestions": [
+      "For which $n \\equiv 1,4 \\pmod{12}$ can a Steiner system $S(2,4,n)$ actually be realised in $\\mathbb{R}^2$ with no five collinear (the geometric realisation question, far stronger than the arithmetic necessary condition proved here)?",
+      "Is there an analogous exact equality characterisation, with matching divisibility constraints, for $k$-point-line packings ($k \\ge 5$) under a no-$(k+1)$-collinear hypothesis?"
+    ]
+  },
+  "crossReferences": [
+    "erdos-101",
+    "erdos-101-oq-01"
+  ],
+  "references": [
+    {
+      "title": "Erdős Problem #101",
+      "url": "https://erdosproblems.com/101"
+    },
+    {
+      "title": "H. Hanani, The existence and construction of balanced incomplete block designs, Ann. Math. Statist. 32 (1961)",
+      "url": "https://doi.org/10.1214/aoms/1177704711"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-101-oq-02.json
+++ b/src/data/research/problems/erdos-101-oq-02.json
@@ -1,0 +1,54 @@
+{
+  "slug": "erdos-101-oq-02",
+  "title": "Erdős #101 OQ-02: Extremal Four-Point-Line Configurations are Steiner Systems",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "tractability": 7,
+  "significance": 6,
+  "started": "2026-06-30T17:00:00Z",
+  "lastUpdate": "2026-06-30T17:30:00Z",
+  "path": "proofs/Proofs/Erdos101OQ02.lean",
+  "problemStatement": "OQ-02 of Erdős #101 asks whether the Solymosi–Stojaković Ω(n^{2-o(1)}) lower-bound construction can be improved to Ω(n²/polylog n), or whether there is a barrier. This entry addresses the extreme end of the four-point-line spectrum: characterise exactly when the parent's sharp pair-packing bound fourPointLineCount(P) ≤ n(n-1)/12 is attained, and record the resulting arithmetic obstruction.",
+  "knownResults": [
+    "Parent Erdős #101 proves the pair-packing bound fourPointLineCount(P) ≤ n(n-1)/12 (improved_upper_bound) and a per-point bound ≤ (n-1)/3 (fourCollinearThrough_bound).",
+    "Hanani (1961): a Steiner system S(2,4,n) exists iff n ≡ 1 or 4 (mod 12)."
+  ],
+  "leanFiles": ["proofs/Proofs/Erdos101OQ02.lean"],
+  "relatedProofs": ["erdos-101", "erdos-101-oq-01"],
+  "references": [
+    "https://erdosproblems.com/101",
+    "H. Hanani, The existence and construction of balanced incomplete block designs, Ann. Math. Statist. 32 (1961)"
+  ],
+  "tags": ["erdos", "combinatorial-geometry", "design-theory", "steiner-system", "extremal-combinatorics"],
+  "significanceNote": "Exactly delimits the extremal ceiling of Erdős #101: attaining n(n-1)/12 four-point lines is equivalent to realising a Steiner system S(2,4,n) in the plane, which forces n ≡ 1,4 (mod 12). Separates the perfect-packing (design) regime from OQ-02's open Ω(n²)-growth question.",
+  "currentState": "COMPLETE. New file Erdos101OQ02.lean (314 lines, 8 theorems/lemmas, 0 defs). 0 sorries, 0 axioms (#print axioms shows only propext/Classical.choice/Quot.sound). Main theorem extremal_forces_mod_twelve verified.",
+  "tractability_note": "Fully tractable: built on the parent's existing 0-axiom pair-packing and per-point infrastructure; the only genuinely new components are the perfect-covering (equality) argument and an elementary mod-12 residue dispatch.",
+  "knowledge": {
+    "progressSummary": "COMPLETE (researcher-7, 2026-06-30): Characterised the equality case of the n(n-1)/12 pair-packing bound as a plane-realised Steiner system S(2,4,n) and derived the Hanani necessary conditions n ≡ 1,4 (mod 12). New file Erdos101OQ02.lean, VERIFIED 0-axiom, 0 sorries.",
+    "builtItems": [
+      "proofs/Proofs/Erdos101OQ02.lean: mod12_of_extremal (3∣(n-1) ∧ 12∣n(n-1) ⇒ n≡1,4 mod 12; Nat.mul_mod + interval_cases + omega)",
+      "proofs/Proofs/Erdos101OQ02.lean: twelve_dvd_of_extremal (6L=C(n,2) ⇒ 12∣n(n-1), block-count integrality)",
+      "proofs/Proofs/Erdos101OQ02.lean: extremal_covers_all_pairs (perfect packing ⇒ every 2-subset on a four-point line)",
+      "proofs/Proofs/Erdos101OQ02.lean: extremal_pair_covered_uniquely (Steiner S(2,4,n): unique covering line)",
+      "proofs/Proofs/Erdos101OQ02.lean: three_dvd_of_extremal (per-point partition ⇒ 3∣(n-1), replication integrality)",
+      "proofs/Proofs/Erdos101OQ02.lean: extremal_forces_mod_twelve (MAIN: attaining the bound ⇒ n≡1,4 mod 12)",
+      "proofs/Proofs/Erdos101OQ02.lean: not_extremal_of_mod_twelve (contrapositive barrier)",
+      "src/data/proofs/erdos-101-oq-02/: gallery entry (meta.json + 5 annotations)"
+    ],
+    "insights": [
+      "The equality case 6·fourPointLineCount(P) = C(n,2) is exactly perfect pair-covering: rebuild the disjoint biUnion of per-line pair-sets and use Finset.eq_of_subset_of_card_le, since |biUnion| = 6L and |C(n,2)-set| = C(n,2).",
+      "Uniqueness of the covering line follows directly from four_collinear_overlap_small (a pair in two lines ⇒ they share ≥2 points).",
+      "Replication 3∣(n-1) comes from partitioning P∖{p} into the 3-sets S∖{p} over lines S through a fixed p — the coverage/surjectivity direction that the parent's one-sided per-point bound never needed.",
+      "The mod-12 dispatch avoids the nonlinear n(n-1) by Nat.mul_mod residue reduction + interval_cases on n%12; residues 7,10 fail the block-count constraint, non-1-mod-3 residues fail replication.",
+      "This is an arithmetic barrier at the extreme end only; it does not touch OQ-02's Ω(n²) growth question, which sits far below the n(n-1)/12 ceiling."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no Steiner-system / 2-design existence API; the Hanani necessary conditions were derived from first principles via the pair-packing and replication counts."
+    ],
+    "nextSteps": [
+      "Geometric realisation: for which n ≡ 1,4 (mod 12) does a plane no-five-collinear S(2,4,n) actually exist? (Far stronger than the arithmetic necessary condition.)",
+      "Generalise to k-point-line packings under no-(k+1)-collinear, seeking the analogous divisibility characterisation."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to **Erdős Problem #101** (four-point lines from planar point sets), open question **OQ-02**: *"Can the Solymosi–Stojaković construction be improved to Ω(n²/polylog n), or is there a barrier?"*

The parent entry proves the sharp **pair-packing bound** `fourPointLineCount(P) ≤ n(n-1)/12` for any `n`-point set with no five collinear. This PR characterises the **equality case** and extracts a hard arithmetic barrier:

> A no-five-collinear configuration attains `n(n-1)/12` four-point lines **iff** its lines perfectly cover the pairs of points — a **Steiner system `S(2,4,n)`** realised in the plane — and this forces **`n ≡ 1` or `4 (mod 12)`** (Hanani's necessary conditions).

Hence the `n(n-1)/12` ceiling is **unattainable** whenever `n ≢ 1,4 (mod 12)`, an obstruction that holds *before any geometry is invoked*. (This does not resolve OQ-02, which concerns `Ω(n²)` growth well below the extremal ceiling — it delimits the extreme end.)

## Contents — `proofs/Proofs/Erdos101OQ02.lean` (314 lines, 8 lemmas/theorems)

| Result | Statement |
|--------|-----------|
| `extremal_covers_all_pairs` | attaining the bound ⇒ every pair lies on a four-point line |
| `extremal_pair_covered_uniquely` | that line is unique (Steiner `S(2,4,n)`) |
| `twelve_dvd_of_extremal` | `12 ∣ n(n-1)` (block-count integrality) |
| `three_dvd_of_extremal` | `3 ∣ (n-1)` (replication integrality) |
| **`extremal_forces_mod_twelve`** | **`n ≡ 1,4 (mod 12)`** |
| `not_extremal_of_mod_twelve` | contrapositive barrier |

## Techniques
- **Perfect covering** from card equality: rebuild the disjoint biUnion of per-line pair-sets (`|biUnion| = 6L`), then `Finset.eq_of_subset_of_card_le` against all `C(n,2)` pairs.
- **Replication** `3 ∣ (n-1)`: partition `P∖{p}` into the 3-sets `S∖{p}` over lines through a fixed `p` (adds the coverage direction the parent's one-sided bound lacked).
- **Mod-12 dispatch**: `Nat.mul_mod` residue reduction + `interval_cases` + `omega` (sidesteps the nonlinear `n(n-1)`).

Reuses the parent's existing 0-axiom `four_collinear_overlap_small`, `improved_upper_bound`, `fourCollinearThrough`, `powersetCard2_disjoint`.

## Verification
- **0 sorries, 0 axioms.** `#print axioms` on all theorems lists only `propext`, `Classical.choice`, `Quot.sound`.
- Compiled against `Proofs.Erdos101Problem` on Lean `v4.26.0` / Mathlib `4.26.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)