### PR TITLE
research(erdos-100-oq-05-oq-01-oq-01): integer 4-simplex in ℝ⁴ with ten distinct-integer edges [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos100OQ05OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos100OQ05OQ01OQ01.lean
@@ -1,0 +1,234 @@
+/-
+Erdős Problem #100, OQ-05, follow-up chain OQ-01 → OQ-01:
+An integer-coordinate 4-simplex in ℝ⁴ whose ten edge lengths are ten DISTINCT
+positive integers.
+
+Parent problem (Erdős #100): a point set `A` is required to have all pairwise
+distances POSITIVE INTEGERS and, in the "restricted-distance" form, all distances
+DISTINCT (any two distinct distances differ by ≥ 1).  The parent open question
+OQ-05 asks whether the phenomenon changes qualitatively in higher dimensions
+ℝ^d for d ≥ 3.
+
+The first follow-up (`Erdos100OQ05OQ01.lean`) answered the d = 3 case: an explicit
+integer-coordinate *tetrahedron* (4 points, 6 edges) whose six edge lengths are the
+six consecutive integers 6,…,11 — all distinct.  This file pushes the theme one
+dimension further, to d = 4.
+
+We exhibit the explicit five-point set
+
+    P₀ = (0,0,0,0), P₁ = (0,2,4,4), P₂ = (4,1,0,8),
+    P₃ = (8,4,0,8), P₄ = (12,9,8,0)                         ⊂ ℤ⁴
+
+whose ten pairwise distances are
+
+    |P₀P₁| = 6,  |P₀P₂| = 9,  |P₀P₃| = 12, |P₀P₄| = 17,
+    |P₁P₂| = 7,  |P₁P₃| = 10, |P₁P₄| = 15,
+    |P₂P₃| = 5,  |P₂P₄| = 16, |P₃P₄| = 13,
+
+i.e. the ten DISTINCT integers {5, 6, 7, 9, 10, 12, 13, 15, 16, 17}.  In particular:
+
+* all ten distances are positive integers (an integer-distance / "perfect"
+  4-simplex with integer coordinates);
+* all ten distances are pairwise DISTINCT, so the configuration meets the genuine
+  restricted-distance hypothesis of Erdős #100 in four dimensions;
+* the simplex is non-degenerate: the four edge vectors out of `P₀` have
+  determinant `-768 ≠ 0`, so the five points are genuinely 4-dimensional and
+  affinely independent (they do not lie in any hyperplane).
+
+Together with the d = 3 example, this shows the distinct-integer-distance
+construction persists into ℝ⁴, and the same recipe (place a new vertex off the
+current hyperplane at integer distance from all existing vertices) evidently
+continues into higher dimensions — the parent's "does the problem change
+qualitatively in d ≥ 3" is answered on the *existence* side by an unbroken family
+of full-dimensional distinct-integer-distance simplices.
+
+Reference: https://erdosproblems.com/100
+
+**Status**: fully verified (0 sorries, 0 axioms, no `native_decide`).  The parent
+diameter conjecture itself remains OPEN.
+-/
+
+import Mathlib
+
+open scoped BigOperators
+
+namespace Erdos100OQ05OQ01OQ01
+
+/-! ## The five vertices -/
+
+/-- The five vertices of the 4-simplex, in `EuclideanSpace ℝ (Fin 4)`. -/
+def P0 : EuclideanSpace ℝ (Fin 4) := !₂[0, 0, 0, 0]
+def P1 : EuclideanSpace ℝ (Fin 4) := !₂[0, 2, 4, 4]
+def P2 : EuclideanSpace ℝ (Fin 4) := !₂[4, 1, 0, 8]
+def P3 : EuclideanSpace ℝ (Fin 4) := !₂[8, 4, 0, 8]
+def P4 : EuclideanSpace ℝ (Fin 4) := !₂[12, 9, 8, 0]
+
+/-! ## Part 1: the ten pairwise distances are ten distinct positive integers -/
+
+theorem dist_P0_P1 : dist P0 P1 = 6 := by
+  rw [P0, P1, EuclideanSpace.dist_eq, Fin.sum_univ_four]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.cons_val_three, Matrix.tail_cons, Real.dist_eq]
+  rw [show |(0:ℝ) - 0| ^ 2 + |(0:ℝ) - 2| ^ 2 + |(0:ℝ) - 4| ^ 2 + |(0:ℝ) - 4| ^ 2 = 6 ^ 2 by
+    norm_num, Real.sqrt_sq (by norm_num)]
+
+theorem dist_P0_P2 : dist P0 P2 = 9 := by
+  rw [P0, P2, EuclideanSpace.dist_eq, Fin.sum_univ_four]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.cons_val_three, Matrix.tail_cons, Real.dist_eq]
+  rw [show |(0:ℝ) - 4| ^ 2 + |(0:ℝ) - 1| ^ 2 + |(0:ℝ) - 0| ^ 2 + |(0:ℝ) - 8| ^ 2 = 9 ^ 2 by
+    norm_num, Real.sqrt_sq (by norm_num)]
+
+theorem dist_P0_P3 : dist P0 P3 = 12 := by
+  rw [P0, P3, EuclideanSpace.dist_eq, Fin.sum_univ_four]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.cons_val_three, Matrix.tail_cons, Real.dist_eq]
+  rw [show |(0:ℝ) - 8| ^ 2 + |(0:ℝ) - 4| ^ 2 + |(0:ℝ) - 0| ^ 2 + |(0:ℝ) - 8| ^ 2 = 12 ^ 2 by
+    norm_num, Real.sqrt_sq (by norm_num)]
+
+theorem dist_P0_P4 : dist P0 P4 = 17 := by
+  rw [P0, P4, EuclideanSpace.dist_eq, Fin.sum_univ_four]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.cons_val_three, Matrix.tail_cons, Real.dist_eq]
+  rw [show |(0:ℝ) - 12| ^ 2 + |(0:ℝ) - 9| ^ 2 + |(0:ℝ) - 8| ^ 2 + |(0:ℝ) - 0| ^ 2 = 17 ^ 2 by
+    norm_num, Real.sqrt_sq (by norm_num)]
+
+theorem dist_P1_P2 : dist P1 P2 = 7 := by
+  rw [P1, P2, EuclideanSpace.dist_eq, Fin.sum_univ_four]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.cons_val_three, Matrix.tail_cons, Real.dist_eq]
+  rw [show |(0:ℝ) - 4| ^ 2 + |(2:ℝ) - 1| ^ 2 + |(4:ℝ) - 0| ^ 2 + |(4:ℝ) - 8| ^ 2 = 7 ^ 2 by
+    norm_num, Real.sqrt_sq (by norm_num)]
+
+theorem dist_P1_P3 : dist P1 P3 = 10 := by
+  rw [P1, P3, EuclideanSpace.dist_eq, Fin.sum_univ_four]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.cons_val_three, Matrix.tail_cons, Real.dist_eq]
+  rw [show |(0:ℝ) - 8| ^ 2 + |(2:ℝ) - 4| ^ 2 + |(4:ℝ) - 0| ^ 2 + |(4:ℝ) - 8| ^ 2 = 10 ^ 2 by
+    norm_num, Real.sqrt_sq (by norm_num)]
+
+theorem dist_P1_P4 : dist P1 P4 = 15 := by
+  rw [P1, P4, EuclideanSpace.dist_eq, Fin.sum_univ_four]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.cons_val_three, Matrix.tail_cons, Real.dist_eq]
+  rw [show |(0:ℝ) - 12| ^ 2 + |(2:ℝ) - 9| ^ 2 + |(4:ℝ) - 8| ^ 2 + |(4:ℝ) - 0| ^ 2 = 15 ^ 2 by
+    norm_num, Real.sqrt_sq (by norm_num)]
+
+theorem dist_P2_P3 : dist P2 P3 = 5 := by
+  rw [P2, P3, EuclideanSpace.dist_eq, Fin.sum_univ_four]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.cons_val_three, Matrix.tail_cons, Real.dist_eq]
+  rw [show |(4:ℝ) - 8| ^ 2 + |(1:ℝ) - 4| ^ 2 + |(0:ℝ) - 0| ^ 2 + |(8:ℝ) - 8| ^ 2 = 5 ^ 2 by
+    norm_num, Real.sqrt_sq (by norm_num)]
+
+theorem dist_P2_P4 : dist P2 P4 = 16 := by
+  rw [P2, P4, EuclideanSpace.dist_eq, Fin.sum_univ_four]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.cons_val_three, Matrix.tail_cons, Real.dist_eq]
+  rw [show |(4:ℝ) - 12| ^ 2 + |(1:ℝ) - 9| ^ 2 + |(0:ℝ) - 8| ^ 2 + |(8:ℝ) - 0| ^ 2 = 16 ^ 2 by
+    norm_num, Real.sqrt_sq (by norm_num)]
+
+theorem dist_P3_P4 : dist P3 P4 = 13 := by
+  rw [P3, P4, EuclideanSpace.dist_eq, Fin.sum_univ_four]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.cons_val_three, Matrix.tail_cons, Real.dist_eq]
+  rw [show |(8:ℝ) - 12| ^ 2 + |(4:ℝ) - 9| ^ 2 + |(0:ℝ) - 8| ^ 2 + |(8:ℝ) - 0| ^ 2 = 13 ^ 2 by
+    norm_num, Real.sqrt_sq (by norm_num)]
+
+/-- **All ten pairwise distances are positive integers.** -/
+theorem all_distances_integer :
+    dist P0 P1 = 6 ∧ dist P0 P2 = 9 ∧ dist P0 P3 = 12 ∧ dist P0 P4 = 17 ∧
+    dist P1 P2 = 7 ∧ dist P1 P3 = 10 ∧ dist P1 P4 = 15 ∧
+    dist P2 P3 = 5 ∧ dist P2 P4 = 16 ∧ dist P3 P4 = 13 :=
+  ⟨dist_P0_P1, dist_P0_P2, dist_P0_P3, dist_P0_P4, dist_P1_P2, dist_P1_P3,
+    dist_P1_P4, dist_P2_P3, dist_P2_P4, dist_P3_P4⟩
+
+/-! ## Part 2: the ten distances are pairwise DISTINCT
+
+We record this in three equivalent ways: as the underlying set of ten distinct
+numerals, as a `card = 10` count, and as a `List.Nodup` fact. -/
+
+/-- The ten pairwise distances, as a `Finset ℝ`, are exactly the ten distinct
+integers `{5, 6, 7, 9, 10, 12, 13, 15, 16, 17}`. -/
+theorem distance_set_eq :
+    ({dist P0 P1, dist P0 P2, dist P0 P3, dist P0 P4, dist P1 P2, dist P1 P3,
+        dist P1 P4, dist P2 P3, dist P2 P4, dist P3 P4} : Finset ℝ) =
+      {6, 9, 12, 17, 7, 10, 15, 5, 16, 13} := by
+  rw [dist_P0_P1, dist_P0_P2, dist_P0_P3, dist_P0_P4, dist_P1_P2, dist_P1_P3,
+    dist_P1_P4, dist_P2_P3, dist_P2_P4, dist_P3_P4]
+
+/-- **All ten pairwise distances are distinct**, phrased as a cardinality: the
+`Finset` of the ten distances has exactly ten elements, so no two edges of the
+simplex have equal length. -/
+theorem distances_card_ten :
+    ({dist P0 P1, dist P0 P2, dist P0 P3, dist P0 P4, dist P1 P2, dist P1 P3,
+        dist P1 P4, dist P2 P3, dist P2 P4, dist P3 P4} : Finset ℝ).card = 10 := by
+  rw [distance_set_eq]
+  norm_num
+
+/-- The ten pairwise distances, listed, have no repeats. -/
+theorem distances_nodup :
+    ([dist P0 P1, dist P0 P2, dist P0 P3, dist P0 P4, dist P1 P2, dist P1 P3,
+        dist P1 P4, dist P2 P3, dist P2 P4, dist P3 P4] : List ℝ).Nodup := by
+  rw [dist_P0_P1, dist_P0_P2, dist_P0_P3, dist_P0_P4, dist_P1_P2, dist_P1_P3,
+    dist_P1_P4, dist_P2_P3, dist_P2_P4, dist_P3_P4]
+  norm_num [List.nodup_cons]
+
+/-- The five vertices are pairwise distinct (immediate from the positive
+distances). -/
+theorem vertices_distinct :
+    P0 ≠ P1 ∧ P0 ≠ P2 ∧ P0 ≠ P3 ∧ P0 ≠ P4 ∧ P1 ≠ P2 ∧ P1 ≠ P3 ∧ P1 ≠ P4 ∧
+    P2 ≠ P3 ∧ P2 ≠ P4 ∧ P3 ≠ P4 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    intro h <;>
+    first
+      | (have := dist_P0_P1; rw [h, dist_self] at this; norm_num at this)
+      | (have := dist_P0_P2; rw [h, dist_self] at this; norm_num at this)
+      | (have := dist_P0_P3; rw [h, dist_self] at this; norm_num at this)
+      | (have := dist_P0_P4; rw [h, dist_self] at this; norm_num at this)
+      | (have := dist_P1_P2; rw [h, dist_self] at this; norm_num at this)
+      | (have := dist_P1_P3; rw [h, dist_self] at this; norm_num at this)
+      | (have := dist_P1_P4; rw [h, dist_self] at this; norm_num at this)
+      | (have := dist_P2_P3; rw [h, dist_self] at this; norm_num at this)
+      | (have := dist_P2_P4; rw [h, dist_self] at this; norm_num at this)
+      | (have := dist_P3_P4; rw [h, dist_self] at this; norm_num at this)
+
+/-! ## Part 3: non-degeneracy — the simplex is genuinely 4-dimensional
+
+The four edge vectors out of `P₀` are
+  `v₁ = P₁ - P₀ = (0,2,4,4)`, `v₂ = P₂ - P₀ = (4,1,0,8)`,
+  `v₃ = P₃ - P₀ = (8,4,0,8)`, `v₄ = P₄ - P₀ = (12,9,8,0)`.
+Their `4 × 4` coordinate matrix has determinant `-768 ≠ 0`, so the vectors are
+linearly independent and the five points are affinely independent (not contained
+in any hyperplane of ℝ⁴). -/
+
+/-- The matrix whose rows are the four edge vectors of the simplex. -/
+def edgeMatrix : Matrix (Fin 4) (Fin 4) ℝ :=
+  !![0, 2, 4, 4;
+     4, 1, 0, 8;
+     8, 4, 0, 8;
+     12, 9, 8, 0]
+
+/-- The edge matrix has determinant `-768`, in particular nonzero.  (Since Mathlib
+provides an explicit closed form only up to `3 × 3`, we expand the top row via
+`Matrix.det_succ_row_zero` and evaluate the four `3 × 3` minors with
+`Matrix.det_fin_three`.) -/
+theorem edgeMatrix_det : edgeMatrix.det = -768 := by
+  rw [edgeMatrix, Matrix.det_succ_row_zero, Fin.sum_univ_four]
+  simp only [Matrix.det_fin_three, Matrix.submatrix_apply, Matrix.of_apply,
+    Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.cons_val_three, Matrix.tail_cons, Matrix.empty_val',
+    Matrix.cons_val_fin_one, Fin.succAbove, Fin.castSucc, Fin.castAdd,
+    Fin.castLE, Fin.lt_def, Fin.succ]
+  norm_num
+
+/-- **Non-degeneracy.**  The four edge vectors of the simplex are linearly
+independent; equivalently, the five points span a 4-dimensional affine subspace and
+are therefore not contained in any hyperplane.  Together with `distances_card_ten`
+this gives a full-dimensional integer-coordinate point set in ℝ⁴ all of whose
+pairwise distances are *distinct* integers — the restricted-distance regime of
+Erdős #100, now realized in four dimensions. -/
+theorem edges_linearIndependent : LinearIndependent ℝ (fun i ↦ edgeMatrix i) :=
+  Matrix.linearIndependent_rows_of_det_ne_zero (by rw [edgeMatrix_det]; norm_num)
+
+end Erdos100OQ05OQ01OQ01

--- a/src/data/proofs/erdos-100-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-05-oq-01-oq-01/meta.json
@@ -1,0 +1,238 @@
+{
+  "id": "erdos-100-oq-05-oq-01-oq-01",
+  "title": "Erdős #100 in ℝ⁴: An Integer 4-Simplex with Ten Distinct-Integer Edges",
+  "slug": "erdos-100-oq-05-oq-01-oq-01",
+  "description": "Pushes the distinct-integer-distance construction of the parent (a scalene tetrahedron in ℝ³) one dimension further, to ℝ⁴, answering the higher-dimensional open question OQ-05 of Erdős #100 on the existence side. Exhibits the explicit integer-coordinate point set P₀=(0,0,0,0), P₁=(0,2,4,4), P₂=(4,1,0,8), P₃=(8,4,0,8), P₄=(12,9,8,0) in EuclideanSpace ℝ (Fin 4) whose ten pairwise distances are |P₀P₁|=6, |P₀P₂|=9, |P₀P₃|=12, |P₀P₄|=17, |P₁P₂|=7, |P₁P₃|=10, |P₁P₄|=15, |P₂P₃|=5, |P₂P₄|=16, |P₃P₄|=13 — the ten DISTINCT integers {5,6,7,9,10,12,13,15,16,17}. Hence (i) all ten distances are positive integers; (ii) they are pairwise DISTINCT (distances_card_ten: the Finset of distances has card 10; distances_nodup), meeting the restricted-distance regime; (iii) the 4×4 edge-vector matrix has determinant −768 ≠ 0 (edges_linearIndependent), so the five points are affinely independent / genuinely 4-dimensional (not contained in any hyperplane). Together with the ℝ³ parent this shows the distinct-integer-distance simplex construction persists into ℝ⁴. Verified, 0 axioms, 0 sorries, no native_decide. The parent diameter conjecture remains OPEN.",
+  "meta": {
+    "author": "Researcher (Lean Genius), building on Erdős #100 OQ-05 / OQ-05-OQ-01 and the theory of perfect (integer-distance) simplices",
+    "sourceUrl": "https://erdosproblems.com/100",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos100OQ05OQ01OQ01.lean",
+    "tags": [
+      "erdos",
+      "discrete-geometry",
+      "integer-distance-sets",
+      "euclidean-space",
+      "perfect-simplex",
+      "distinct-distances",
+      "higher-dimensions",
+      "linear-independence"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "EuclideanSpace.dist_eq",
+        "description": "dist x y = √(∑ i, dist (x i) (y i) ^ 2) for x y : EuclideanSpace 𝕜 n. Workhorse for evaluating each of the ten pairwise distances: reduces it to √(sum of four coordinate-difference squares), each a perfect square equal to the claimed integer.",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Real.sqrt_sq",
+        "description": "0 ≤ a → √(a ^ 2) = a. Finishes each distance computation once the sum of squared coordinate differences is written as k² (e.g. 289 = 17²), yielding dist = k.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Matrix.det_succ_row_zero",
+        "description": "Cofactor (Laplace) expansion of an (n+1)×(n+1) determinant along the top row: det A = ∑ j (−1)^j · A 0 j · det(minor). Mathlib provides a closed form only up to 3×3, so this expands the 4×4 edge matrix into four signed 3×3 minors, each then evaluated by Matrix.det_fin_three; the result is det = −768.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_fin_three",
+        "description": "Closed-form Sarrus expansion of a 3×3 determinant; applied to each of the four minors produced by the top-row cofactor expansion of the 4×4 edge matrix.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.linearIndependent_rows_of_det_ne_zero",
+        "description": "A.det ≠ 0 → LinearIndependent R (fun i ↦ A i) over an integral domain. Converts the determinant −768 ≠ 0 of the 4×4 edge matrix into linear independence of the four edge vectors, certifying the 4-simplex is non-degenerate (spans 4 dimensions).",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      }
+    ],
+    "originalContributions": [
+      "dist_P0_P1 … dist_P3_P4 / all_distances_integer: a fully computed, 0-axiom verification that the explicit integer-coordinate 4-simplex P₀=(0,0,0,0), P₁=(0,2,4,4), P₂=(4,1,0,8), P₃=(8,4,0,8), P₄=(12,9,8,0) in EuclideanSpace ℝ (Fin 4) has its ten pairwise distances equal to the ten distinct positive integers {5,6,7,9,10,12,13,15,16,17}",
+      "distances_card_ten: the Finset of the ten pairwise distances has cardinality exactly 10, i.e. all ten edge lengths are pairwise distinct — the restricted-distance hypothesis of Erdős #100 realized in four dimensions",
+      "distances_nodup: a List.Nodup certificate for the same distinctness, complementing the cardinality statement",
+      "distance_set_eq: the set of ten distances equals exactly {5,6,7,9,10,12,13,15,16,17}",
+      "edgeMatrix_det / edges_linearIndependent: the non-degeneracy certificate — the 4×4 matrix of edge vectors (0,2,4,4),(4,1,0,8),(8,4,0,8),(12,9,8,0) has determinant −768 ≠ 0 (computed via top-row cofactor expansion + Matrix.det_fin_three, since Mathlib has no det_fin_four), so the five points are affinely independent and span ℝ⁴",
+      "vertices_distinct: the five vertices are pairwise distinct, derived from the positive pairwise distances"
+    ],
+    "dateAdded": "2026-06-30",
+    "relatedProblems": [
+      {
+        "id": "erdos-100-oq-05-oq-01",
+        "relationship": "Direct follow-up: the parent gives a scalene integer tetrahedron in ℝ³ (6 distinct-integer edges); this entry extends the same distinct-integer-distance construction one dimension up to a non-degenerate integer 4-simplex in ℝ⁴ (10 distinct-integer edges)."
+      },
+      {
+        "id": "erdos-100-oq-05",
+        "relationship": "Answers the higher-dimensional open question OQ-05 ('does the problem change qualitatively in ℝ^d for d ≥ 3?') on the existence side by exhibiting a full-dimensional distinct-integer-distance simplex in d = 4."
+      },
+      {
+        "id": "erdos-100",
+        "relationship": "Contributes to the original integer-distance problem by realizing its restricted-distance (all-distinct) regime with an explicit non-degenerate 4-simplex in ℝ⁴."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 234,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only the foundational propext, Classical.choice, Quot.sound — no sorryAx, no Lean.ofReduceBool. HONEST SCOPE: this entry formalizes one explicit configuration (a non-degenerate integer-coordinate 4-simplex in ℝ⁴ with ten distinct-integer edges) and its distinctness / non-degeneracy; the parent diameter lower-bound conjecture for Erdős #100 (and its higher-dimensional analogues) remains OPEN and is not addressed here. The specific 4-simplex is one explicit witness found by computer search; no minimality is claimed.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 17,
+    "definitionCount": 6
+  },
+  "overview": {
+    "historicalContext": "Erdős #100 asks whether n points with all pairwise distances positive integers (in the restricted form, all distinct, so any two differ by ≥ 1) must have large diameter. Its open question OQ-05 asks whether the phenomenon changes qualitatively in ℝ^d for d ≥ 3. A first follow-up realized the all-distinct-integer regime in ℝ³ with a scalene tetrahedron (six consecutive-integer edges). Simplices with integer coordinates and all edges distinct integers are 'scalene perfect simplices'; the present configuration is a four-dimensional one.",
+    "problemStatement": "Does the distinct-integer-distance construction of Erdős #100 persist into ℝ⁴? This entry exhibits an explicit integer-coordinate 4-simplex (five points in EuclideanSpace ℝ (Fin 4)) whose ten pairwise distances are the distinct integers {5,6,7,9,10,12,13,15,16,17} and which is non-degenerate (edge determinant −768 ≠ 0).",
+    "text": "The five vertices (0,0,0,0),(0,2,4,4),(4,1,0,8),(8,4,0,8),(12,9,8,0) have ten pairwise distances 6,9,12,17,7,10,15,5,16,13 — exactly the distinct set {5,6,7,9,10,12,13,15,16,17}. The 4×4 edge-vector matrix has determinant −768 ≠ 0, so the five points span ℝ⁴ (they are affinely independent, not contained in any hyperplane).",
+    "proofStrategy": "Each vertex is an EuclideanSpace ℝ (Fin 4) literal !₂[a,b,c,d]. For each of the ten pairs, EuclideanSpace.dist_eq rewrites the distance as √(∑_{i<4} |xᵢ−yᵢ|²); Fin.sum_univ_four and the cons-vector simp lemmas (through cons_val_three) evaluate the coordinates; the sum of squares is rewritten to k² and Real.sqrt_sq returns the integer k. all_distances_integer bundles the ten values. distances_card_ten rewrites the ten distances to numerals and computes that the resulting Finset has card 10 (hence all distinct); distances_nodup gives the same via List.Nodup; distance_set_eq identifies the distance set with {5,…,17}. Non-degeneracy: edgeMatrix is the 4×4 matrix of edge vectors; since Mathlib provides no det_fin_four, edgeMatrix_det expands the top row with Matrix.det_succ_row_zero + Fin.sum_univ_four, evaluates the four 3×3 minors by Matrix.det_fin_three (resolving the Fin.succAbove index shuffles by simp), and norm_num gives det = −768; Matrix.linearIndependent_rows_of_det_ne_zero then yields linear independence. vertices_distinct follows because a coincidence would force a distance to 0.",
+    "keyInsights": [
+      "**The construction climbs dimensions.** Extending from the ℝ³ tetrahedron (6 distinct-integer edges) to an ℝ⁴ 4-simplex (10 distinct-integer edges) shows the distinct-integer-distance phenomenon of Erdős #100 is not special to low dimension — it persists, answering OQ-05 on the existence side",
+      "**Off-hyperplane placement is the recipe.** A new full-dimensional vertex is obtained by placing a point off the current hyperplane at integer distance from every existing vertex; the same idea evidently continues into higher dimensions",
+      "**Distances are perfect-square roots.** Choosing integer coordinates whose squared coordinate differences sum to a perfect square makes each distance a provable integer via Real.sqrt_sq",
+      "**No det_fin_four in Mathlib.** Non-degeneracy of the 4×4 edge matrix is obtained by one top-row cofactor expansion (Matrix.det_succ_row_zero) reducing to four Matrix.det_fin_three minors — a reusable pattern for explicit 4×4 real determinants"
+    ],
+    "prerequisites": [
+      "Euclidean distance in EuclideanSpace ℝ (Fin n) and the formula dist = √(Σ coordinate differences²)",
+      "Integer-distance (perfect) simplices and the distinct-distance form of Erdős #100",
+      "Cofactor (Laplace) expansion of determinants and the det ≠ 0 ⇒ linear independence criterion",
+      "Affine independence / non-degeneracy of a simplex as linear independence of its edge vectors"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and Scope",
+      "startLine": 1,
+      "endLine": 57,
+      "mathContext": "Erdős #100 restricted-distance form in ℝ⁴: an integer 4-simplex with ten distinct-integer edges",
+      "summary": "Frames the follow-up: the ℝ³ parent gives a distinct-integer-distance tetrahedron; this file pushes the construction to ℝ⁴. States the explicit five-point set, its ten distinct integer distances, and the honest scope (the parent diameter conjecture stays open; no minimality claimed)."
+    },
+    {
+      "id": "vertices",
+      "title": "The Five Vertices",
+      "startLine": 59,
+      "endLine": 64,
+      "mathContext": "$P_0=(0,0,0,0),\\ P_1=(0,2,4,4),\\ P_2=(4,1,0,8),\\ P_3=(8,4,0,8),\\ P_4=(12,9,8,0)$",
+      "summary": "Defines the five integer-coordinate vertices as EuclideanSpace ℝ (Fin 4) literals !₂[·,·,·,·]."
+    },
+    {
+      "id": "distances",
+      "title": "The Ten Pairwise Distances Are Distinct Integers",
+      "startLine": 66,
+      "endLine": 151,
+      "mathContext": "$\\{|P_iP_j|\\} = \\{5,6,7,9,10,12,13,15,16,17\\}$",
+      "summary": "Each distance is computed via EuclideanSpace.dist_eq + Fin.sum_univ_four, reducing to √(perfect square) closed by Real.sqrt_sq. all_distances_integer bundles all ten values."
+    },
+    {
+      "id": "distinct-distances",
+      "title": "The Ten Distances Are Pairwise Distinct",
+      "startLine": 152,
+      "endLine": 177,
+      "mathContext": "card of the distance set $= 10$; List.Nodup",
+      "summary": "distance_set_eq identifies the distance set with {5,6,7,9,10,12,13,15,16,17}; distances_card_ten proves the Finset has cardinality 10 (all distinct); distances_nodup gives the List.Nodup certificate."
+    },
+    {
+      "id": "vertices-distinct",
+      "title": "The Vertices Are Pairwise Distinct",
+      "startLine": 179,
+      "endLine": 203,
+      "mathContext": "$P_i \\ne P_j$ for all $i \\ne j$",
+      "summary": "vertices_distinct: equality of two vertices would force their distance to 0, contradicting the positive integer values."
+    },
+    {
+      "id": "nondegeneracy",
+      "title": "Non-Degeneracy: the Simplex Spans 4 Dimensions",
+      "startLine": 205,
+      "endLine": 234,
+      "mathContext": "$\\det\\begin{pmatrix}0&2&4&4\\\\4&1&0&8\\\\8&4&0&8\\\\12&9&8&0\\end{pmatrix} = -768 \\ne 0$",
+      "summary": "edgeMatrix is the 4×4 matrix of edge vectors; edgeMatrix_det computes det = −768 by top-row cofactor expansion (Matrix.det_succ_row_zero) plus four Matrix.det_fin_three minors; edges_linearIndependent applies Matrix.linearIndependent_rows_of_det_ne_zero, certifying the five points span ℝ⁴."
+    }
+  ],
+  "conclusion": {
+    "summary": "An explicit integer-coordinate 4-simplex in ℝ⁴ whose ten pairwise distances are the distinct integers {5,6,7,9,10,12,13,15,16,17} and whose 4×4 edge-vector determinant is −768 ≠ 0. It realizes the restricted-distance (all-distinct) hypothesis of Erdős #100 in four dimensions, extending the ℝ³ scalene-tetrahedron parent. 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Full-dimensional integer-distance sets meeting the distinct-distance condition exist in ℝ⁴ as well as ℝ³, so Erdős #100's higher-dimensional restricted-distance problem is non-vacuous in these dimensions. The genuine difficulty — the diameter lower bound — is unaffected by such examples and remains open in every dimension; the example only certifies existence on the small-distance side.",
+    "openQuestions": [
+      "Generalize the off-hyperplane construction to a uniform theorem: for every d there is a non-degenerate integer-coordinate d-simplex in ℝ^d with all C(d+1,2) pairwise distances distinct integers. Formalize the inductive step (add a vertex off the current hyperplane at integer distance from all existing vertices).",
+      "Find and formalize the smallest (minimal largest edge, or minimal diameter) integer 4-simplex with ten distinct-integer edges, mirroring the minimality investigation of the ℝ³ parent."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-100-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Extends the parent's ℝ³ scalene integer tetrahedron (6 distinct-integer edges) to a non-degenerate integer 4-simplex in ℝ⁴ (10 distinct-integer edges), one dimension higher."
+    },
+    {
+      "targetId": "erdos-100-oq-05",
+      "relationship": "extends",
+      "description": "Answers the higher-dimensional open question OQ-05 on the existence side with a full-dimensional distinct-integer-distance simplex in d = 4."
+    },
+    {
+      "targetId": "erdos-100",
+      "relationship": "extends",
+      "description": "Realizes the restricted-distance (all-distinct) regime of the original integer-distance problem with an explicit non-degenerate 4-simplex in ℝ⁴."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/Erdos100OQ05OQ01OQ01.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators"
+    ],
+    "namespace": "Erdos100OQ05OQ01OQ01",
+    "lineCount": 234,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 6,
+    "theoremCount": 17
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "Erdős Problem #100 (point sets with restricted/integer distances)",
+      "year": "",
+      "venue": "erdosproblems.com/100",
+      "note": "The parent problem: must n points with distinct integer pairwise distances have diameter ≫ n? OQ-05 asks about the analogue in ℝ^d, d ≥ 3."
+    },
+    {
+      "authors": "Anning, Norman H.; Erdős, Paul",
+      "title": "Integral distances",
+      "year": "1945",
+      "venue": "Bulletin of the American Mathematical Society 51, 598–600",
+      "note": "Any infinite set of points with pairwise integer distances is collinear — valid in every dimension; finite full-dimensional integer-distance simplices such as this one are the non-degenerate counterpart."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "all_distances_integer",
+      "type": "core",
+      "description": "The explicit integer-coordinate 4-simplex P₀,…,P₄ in ℝ⁴ has its ten pairwise distances equal to the distinct positive integers {5,6,7,9,10,12,13,15,16,17}.",
+      "leanType": "dist P0 P1 = 6 ∧ dist P0 P2 = 9 ∧ dist P0 P3 = 12 ∧ dist P0 P4 = 17 ∧ dist P1 P2 = 7 ∧ dist P1 P3 = 10 ∧ dist P1 P4 = 15 ∧ dist P2 P3 = 5 ∧ dist P2 P4 = 16 ∧ dist P3 P4 = 13"
+    },
+    {
+      "name": "distances_card_ten",
+      "type": "core",
+      "description": "The Finset of the ten pairwise distances has cardinality 10 — i.e. all ten edge lengths are pairwise distinct, so the simplex satisfies the distinct-distance hypothesis of Erdős #100 in four dimensions.",
+      "leanType": "({dist P0 P1, dist P0 P2, dist P0 P3, dist P0 P4, dist P1 P2, dist P1 P3, dist P1 P4, dist P2 P3, dist P2 P4, dist P3 P4} : Finset ℝ).card = 10"
+    },
+    {
+      "name": "distance_set_eq",
+      "type": "core",
+      "description": "The set of ten pairwise distances equals exactly {5,6,7,9,10,12,13,15,16,17}.",
+      "leanType": "({dist P0 P1, …, dist P3 P4} : Finset ℝ) = {6, 9, 12, 17, 7, 10, 15, 5, 16, 13}"
+    },
+    {
+      "name": "edges_linearIndependent",
+      "type": "core",
+      "description": "The four edge vectors of the 4-simplex are linearly independent (edge-matrix determinant −768 ≠ 0), so the five points are affinely independent and span ℝ⁴ — the configuration is genuinely 4-dimensional.",
+      "leanType": "LinearIndependent ℝ (fun i ↦ edgeMatrix i)"
+    },
+    {
+      "name": "edgeMatrix_det",
+      "type": "supporting",
+      "description": "The 4×4 matrix of edge vectors has determinant −768 (computed via top-row cofactor expansion and four 3×3 minors, as Mathlib lacks det_fin_four), the nonzero value certifying non-degeneracy.",
+      "leanType": "edgeMatrix.det = -768"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Extends the distinct-integer-distance construction of Erdős #100 one dimension higher — from the ℝ³ scalene tetrahedron (parent `erdos-100-oq-05-oq-01`, 6 distinct-integer edges) to a **non-degenerate integer 4-simplex in ℝ⁴** with **ten distinct-integer edges**. This answers the parent's higher-dimensional open question **OQ-05** ("does the problem change qualitatively in ℝ^d for d ≥ 3?") on the *existence* side: the phenomenon persists into d = 4.

### The configuration
Explicit five-point set in `EuclideanSpace ℝ (Fin 4)`:

```
P₀ = (0,0,0,0)  P₁ = (0,2,4,4)  P₂ = (4,1,0,8)  P₃ = (8,4,0,8)  P₄ = (12,9,8,0)
```

Ten pairwise distances:

```
|P₀P₁|=6  |P₀P₂|=9  |P₀P₃|=12 |P₀P₄|=17
|P₁P₂|=7  |P₁P₃|=10 |P₁P₄|=15
|P₂P₃|=5  |P₂P₄|=16 |P₃P₄|=13
```

= the ten **distinct** integers `{5,6,7,9,10,12,13,15,16,17}`. The 4×4 edge-vector matrix has determinant **−768 ≠ 0**, so the five points are affinely independent and span ℝ⁴ (not contained in any hyperplane).

### Results (`Proofs/Erdos100OQ05OQ01OQ01.lean`, 234 lines / 17 thm / 6 def)
- `all_distances_integer` — the ten pairwise distances are the claimed distinct positive integers (each via `EuclideanSpace.dist_eq` + `Fin.sum_univ_four` + `Real.sqrt_sq`).
- `distances_card_ten` / `distances_nodup` / `distance_set_eq` — the ten distances are pairwise distinct (Finset card = 10; List.Nodup; explicit set).
- `edgeMatrix_det` (= −768) / `edges_linearIndependent` — non-degeneracy. Since Mathlib has no `det_fin_four`, the 4×4 determinant is computed by a single top-row cofactor expansion (`Matrix.det_succ_row_zero`) reducing to four `Matrix.det_fin_three` minors — a reusable pattern.
- `vertices_distinct` — the five vertices are pairwise distinct.

### Verification
- **0 axioms, 0 sorries, no `native_decide`.** `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.
- Compiles clean under Mathlib 4.26.0 (`bin/lake env lean`).

### Honest scope
This formalizes one explicit witness (found by computer search; no minimality claimed). The parent diameter lower-bound conjecture for Erdős #100 and its higher-dimensional analogues remains **OPEN** and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)