### PR TITLE
Fix: realign stale counts for pascals-hexagon-incomplete-01-oq-03-oq-01

### DIFF
--- a/src/data/proofs/pascals-hexagon-incomplete-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-incomplete-01-oq-03-oq-01/meta.json
@@ -20,9 +20,9 @@
     "badge": "original",
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 181,
-    "theoremCount": 8,
-    "definitionCount": 8,
+    "lineCount": 364,
+    "theoremCount": 16,
+    "definitionCount": 7,
     "originalContributions": [
       "qform_stdConic_rescale: the diagonal rescaling diag(√a,√b,√(-c)) pulls stdConic's quadratic form back exactly onto the form of diag(a,b,c) for a,b ≥ 0, c ≤ 0, as an identity of reals — the algebraic heart of the construction.",
       "det_rescale / det_rescale_ne_zero: the rescaling matrix has determinant √a·√b·√(-c), nonzero precisely when a,b > 0 and c < 0, certifying it as an invertible projective transformation.",
@@ -121,10 +121,10 @@
       "Matrix"
     ],
     "namespace": "PascalsHexagonIncomplete01OQ03OQ01",
-    "lineCount": 181,
+    "lineCount": 364,
     "axiomCount": 0,
-    "theoremCount": 8,
-    "definitionCount": 8,
+    "theoremCount": 16,
+    "definitionCount": 7,
     "mainTheorems": [
       {
         "name": "diagConic_indefinite_projEquiv_stdConic",


### PR DESCRIPTION
## Fix

Metadata count fields for `pascals-hexagon-incomplete-01-oq-03-oq-01` were stale after the Lean file was extended; realigned both the `meta` and `leanFile` blocks to the actual source.

## Evidence

`proofs/Proofs/PascalsHexagonIncomplete01OQ03OQ01.lean` (single-file entry, no additionalFiles):

| field | claimed | actual |
|-------|---------|--------|
| lineCount | 181 | 364 |
| theoremCount | 8 | 16 |
| definitionCount | 8 | 7 |

Actuals verified with canonical regexes: `wc -l`, `^(theorem|lemma) `, `^(def|noncomputable def|opaque def) `. Both the `meta.*` and `leanFile.*` blocks carried the stale values; both updated identically (aggregate == main since there are no companion files).

Entry remains genuinely `verified` / 0-axiom: no `axiom` declarations, and the only `sorry` token is inside a prose comment (line 24), not a proof. No `.lean` change, so annotation/section line ranges are unaffected.

---
Automated fix by lean-mechanic agent.