### PR TITLE
Fix: realign stale lineCount metadata for sqrt2-irrational

### DIFF
--- a/src/data/proofs/sqrt2-irrational/meta.json
+++ b/src/data/proofs/sqrt2-irrational/meta.json
@@ -52,7 +52,7 @@
     "dateAdded": "2025-12-21",
     "wiedijkNumber": 1,
     "axiomCount": 0,
-    "lineCount": 222,
+    "lineCount": 233,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "theoremCount": 14,
     "definitionCount": 0
@@ -60,7 +60,7 @@
   "overview": {
     "historicalContext": "The discovery that $\\sqrt{2}$ is irrational is attributed to the ancient Greeks, possibly Hippasus of Metapontum around 500 BCE. The Pythagoreans had built their philosophy on the belief that all quantities could be expressed as ratios of whole numbers—\"all is number.\" The discovery that the diagonal of a unit square (which has length $\\sqrt{2}$ by the Pythagorean theorem) cannot be so expressed shattered this worldview.\n\nAccording to legend, Hippasus was drowned at sea for revealing this disturbing truth. Whether or not the legend is true, the mathematical crisis was real: it forced Greek mathematicians to distinguish between number (arithmetic) and magnitude (geometry), a distinction that would persist for two millennia until the rigorous construction of the real numbers in the 19th century.\n\nThis proof represents one of the earliest examples of proof by contradiction (reductio ad absurdum) in mathematics, and remains a cornerstone of mathematical education to this day.",
     "problemStatement": "The diagonal of a unit square has length $\\sqrt{2}$. The question is: can this length be expressed as a ratio of integers?\n\n$$\\text{Does there exist } \\frac{p}{q} = \\sqrt{2} \\text{ with } p, q \\in \\mathbb{Z}, q \\neq 0?$$\n\nEquivalently, squaring both sides: does there exist a solution to $p^2 = 2q^2$ in integers? The answer is no—$\\sqrt{2}$ is irrational.",
-    "text": "A 222-line formalization of $\\sqrt{2}$ irrationality (Wiedijk #1) with 19 declarations, 0 sorries, 0 axioms. The core `sqrt2_irrational` uses Mathlib's `Irrational` predicate and `irrational_sqrt_two`. Provides the classical parity-based proof `sqrt2_irrational_parity` (assume $p^2 = 2q^2$ in lowest terms, derive both $p$ and $q$ even, contradiction via `Nat.even_of_even_sq` and `Int.emod_two_eq_zero`). Generalizes to `sqrt_n_irrational` ($\\sqrt{n}$ irrational for non-perfect-square $n$) via `Nat.Prime.irrational_sqrt` and `Int.sq_eq_sq'`. Concrete examples verify $\\sqrt{3}, \\sqrt{5}, \\sqrt{6}, \\sqrt{7}$ are all irrational using `norm_num` and `Nat.sqrt` computation.",
+    "text": "A 233-line formalization of $\\sqrt{2}$ irrationality (Wiedijk #1) with 19 declarations, 0 sorries, 0 axioms. The core `sqrt2_irrational` uses Mathlib's `Irrational` predicate and `irrational_sqrt_two`. Provides the classical parity-based proof `sqrt2_irrational_parity` (assume $p^2 = 2q^2$ in lowest terms, derive both $p$ and $q$ even, contradiction via `Nat.even_of_even_sq` and `Int.emod_two_eq_zero`). Generalizes to `sqrt_n_irrational` ($\\sqrt{n}$ irrational for non-perfect-square $n$) via `Nat.Prime.irrational_sqrt` and `Int.sq_eq_sq'`. Concrete examples verify $\\sqrt{3}, \\sqrt{5}, \\sqrt{6}, \\sqrt{7}$ are all irrational using `norm_num` and `Nat.sqrt` computation.",
     "proofStrategy": "The proof proceeds by contradiction:\n\n1. Assume $\\sqrt{2} = p/q$ where $p, q$ are integers in lowest terms (no common factors)\n2. Square both sides: $p^2 = 2q^2$\n3. Parity argument: $p^2$ is even, so $p$ must be even (key lemma!)\n4. Substitute: Write $p = 2k$, then $4k^2 = 2q^2$, so $q^2 = 2k^2$\n5. Repeat: $q^2$ is even, so $q$ is even\n6. Contradiction: Both $p$ and $q$ are even, so they share factor 2—but we assumed lowest terms!",
     "keyInsights": [
       "The geometric origin: $\\sqrt{2}$ is the diagonal of a unit square, arising naturally from the Pythagorean theorem $1^2 + 1^2 = (\\sqrt{2})^2$.",
@@ -111,7 +111,7 @@
       "id": "generalization",
       "title": "Generalization: √n for Non-Squares",
       "startLine": 143,
-      "endLine": 222,
+      "endLine": 233,
       "summary": "The general theorem: √n is irrational iff n is not a perfect square. Includes √3, √5, √6, √7.",
       "mathContext": "The general theorem: $\\sqrt{n} \\in \\mathbb{Q} \\iff n$ is a perfect square. Applied to prove $\\sqrt{3}, \\sqrt{5}, \\sqrt{6}, \\sqrt{7} \\notin \\mathbb{Q}$ since $3, 5, 6, 7$ are not perfect squares. The proof generalizes: if $p$ is prime, $\\sqrt{p}$ is irrational (since $p$ is not a perfect square)."
     }
@@ -235,7 +235,7 @@
     ],
     "opens": [],
     "namespace": "Sqrt2Irrational",
-    "lineCount": 222,
+    "lineCount": 233,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Correct the stale `lineCount` metadata for `sqrt2-irrational` (222 → 233).

## Evidence

**Before**: `meta.json` claimed the Lean file was 222 lines, but `Sqrt2Irrational.lean` is 233 lines. The file grew (+11) after PR #25884 removed `native_decide`, and the gallery metadata was never regenerated.

**After**: All four line-count references updated to 233:
- `meta.lineCount`
- `leanFile.lineCount`
- the final section (`generalization`) `endLine` — its range (143–end) contains all the added lines, so it is the only section boundary affected
- the "222-line" prose in `overview.text`

All declaration counts were already correct and are unchanged (14 theorems, 0 definitions, 0 axioms, 0 sorries — verified against the source with the canonical `enrich-research.ts` regexes). The lines 1–142 decl positions still align exactly with the stored section boundaries, confirming the growth was confined to the last section. JSON validated.

---
Automated fix by lean-mechanic agent.