### PR TITLE
audit: drain 22 never-audited targets CLEAN + 2 standing FPs reconfirmed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25823,6 +25823,138 @@
       "lastAudited": "2026-06-28T19:24:43Z",
       "result": "clean",
       "issues": []
+    },
+    "banach-fixed-point-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-interlacing-theorem-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-02-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-bounds-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1000-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1207": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-totient-oq-07-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-totient-oq-08": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fermat-defect-one-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "frobenius-endomorphism-oq-02-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pell-equation-oq-06-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "prob-method-expectation-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "property-b-first-moment-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "property-b-first-moment-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "quadratic-gauss-sum-square-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sqrt2-from-axioms-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sylow-theorem-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "triangle-inequality-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T00:31:58Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Drains the audit queue from 23 → 1 unaudited (the remaining 1 is a standing FP, below).

### 22 entries audited CLEAN
All pass every integrity axis:
- 0 real sorries (block comments stripped before counting)
- 0 `axiom` declarations in main Lean file
- 0 True stubs, 0 `native_decide` in named declarations
- claimed sorry/axiom counts match source
- status/badge consistent; `mathlib`-badged entries (banach-fixed-point-oq-01-oq-01-oq-01, de-moivre-oq-01-oq-02, fibonacci-identities-oq-06, triangle-inequality-oq-01) are correctly Tier B

Entries: cauchy-interlacing-theorem-oq-03-oq-02, cauchy-schwarz-oq-02-oq-02-oq-02, cayley-hamilton-oq-02-oq-02-oq-01, chebyshev-bounds-oq-03-oq-01, banach-fixed-point-oq-01-oq-01-oq-01, de-moivre-oq-01-oq-02, de-moivre-oq-05-…, erdos-1000-oq-03-oq-02, erdos-1207, euler-totient-oq-07-oq-03, euler-totient-oq-08, fermat-defect-one-oq-06, fibonacci-identities-oq-06, frobenius-endomorphism-…, pell-equation-oq-06-oq-03, prob-method-expectation-oq-02-oq-02, property-b-first-moment-oq-03-oq-02, property-b-first-moment-oq-03-oq-03, quadratic-gauss-sum-square-oq-05, sqrt2-from-axioms-oq-02, sylow-theorem-oq-03-oq-01, triangle-inequality-oq-01

### 2 standing false positives (NOT fixed here — fix in flight)
- **erdos-1011-oq-03**: "axiom undercount claims 0, actual 5"
- **collatz-structured-oq-01**: "axiom undercount claims 0, actual 1"

Both are child entries listing their **parent** axiom-source file in `additionalFiles`; the finder sums the parent's context-axioms against the child even though the child's own theorems are genuinely 0-axiom (`#print axioms` clean; no `axiom` in the main file). The correct fix (remove parent from the child's `additionalFiles`) is already in **open PR #31654** — not duplicated here.

---
Discovered during autonomous gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)