### PR TITLE
Enrich Univariate Hilbert 17, Degree-Sharp (Fejér–Riesz)

### DIFF
--- a/src/data/proofs/hilbert-17-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01/annotations.json
@@ -10,7 +10,13 @@
     "title": "Reusing the parent's elementary toolkit",
     "content": "The file opens the parent namespace Hilbert17UnivariatePSDSOS to reuse three ingredients verbatim: the PSD predicate IsPSD p := ∀ x, 0 ≤ p.eval x, the one-sided continuity helper nonneg_of_forall_gt, and — crucially — sq_dvd_of_psd_root, the analytic crux that a real root of a nonnegative polynomial has multiplicity ≥ 2. Because all the hard analysis is imported, the only new mathematical content of this entry is the degree bookkeeping layered on top of the existing induction.",
     "mathContext": "$\\mathrm{IsPSD}\\,p \\iff \\forall x \\in \\mathbb{R},\\ p(x) \\ge 0.$",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Positive semidefinite polynomials",
+      "Even multiplicity of real roots of a nonnegative polynomial",
+      "Polynomial divisibility and quotient degrees",
+      "Namespace reuse of a parent formalization"
+    ]
   },
   {
     "id": "ann-h17-oq0101-engine",
@@ -23,7 +29,13 @@
     "title": "The degree-sharp induction engine",
     "content": "psd_eq_sq_add_sq_deg_aux strengthens the parent's existence engine with two extra conclusions: 2·deg u ≤ deg p and 2·deg v ≤ deg p. This is the Fejér–Riesz degree bound — each of the two squares has degree at most half the degree of p. The statement is proved by strong induction on d = deg p, so the smaller-degree quotient produced at each step is handled by the induction hypothesis, which now also supplies degree bounds to propagate.",
     "mathContext": "$p \\ge 0 \\implies \\exists\\, u, v:\\ p = u^2 + v^2 \\ \\wedge\\ 2\\deg u \\le \\deg p \\ \\wedge\\ 2\\deg v \\le \\deg p.$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "Strong induction on polynomial degree (Nat.strongRecOn)",
+      "Fejér–Riesz degree bound",
+      "Sum-of-squares certificates",
+      "Loop invariants carried through an induction"
+    ]
   },
   {
     "id": "ann-h17-oq0101-realroot",
@@ -36,7 +48,13 @@
     "title": "Real-root branch: even multiplicity caps the degree growth",
     "content": "When the FTA root z is real (root r), sq_dvd_of_psd_root gives (X − C r)² ∣ p, so p = (X − C r)²·q with q again PSD of degree deg p − 2. The induction hypothesis returns q = u'² + v'² with 2·deg u' ≤ deg q, and the new squares are u = (X − C r)·u', v = (X − C r)·v'. The degree bound follows from natDegree_mul_le: deg((X − C r)·u') ≤ 1 + deg u', hence 2·deg u ≤ 2 + 2·deg u' ≤ 2 + deg q = deg p. Using the ≤ bound (not exact natDegree_mul) avoids any case split on u' = 0.",
     "mathContext": "$p = (X-r)^2 q,\\quad 2\\deg u = 2\\deg\\big((X-r)u'\\big) \\le 2(1+\\deg u') \\le 2 + \\deg q = \\deg p.$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "Fundamental theorem of algebra (Complex.exists_root)",
+      "Square-divisibility at a PSD real root (sq_dvd_of_psd_root)",
+      "natDegree_mul_le super-additivity bound",
+      "Avoiding case splits via inequality (not exact) degree lemmas"
+    ]
   },
   {
     "id": "ann-h17-oq0101-complexroot",
@@ -49,7 +67,13 @@
     "title": "Non-real-root branch: Brahmagupta keeps the squares in lockstep",
     "content": "When z is non-real, the positive real quadratic Q = (X − C re z)² + (C im z)² divides p with quotient q PSD of degree deg p − 2. The Brahmagupta–Fibonacci identity turns Q·(u'² + v'²) into u = (X − C re z)·u' − (C im z)·v' and v = (X − C re z)·v' + (C im z)·u'. Each has degree ≤ 1 + max(deg u', deg v') by natDegree_sub_le / natDegree_add_le and natDegree_C_mul_le, so 2·deg u ≤ 2 + 2·max(deg u', deg v') ≤ 2 + deg q = deg p. The max is resolved by le_total and the linear arithmetic closed by omega.",
     "mathContext": "$Q = (X - \\mathrm{re}\\,z)^2 + (\\mathrm{im}\\,z)^2,\\quad u = (X-\\mathrm{re}\\,z)u' - (\\mathrm{im}\\,z)v',\\ v = (X-\\mathrm{re}\\,z)v' + (\\mathrm{im}\\,z)u'.$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "Brahmagupta–Fibonacci two-square identity",
+      "Conjugate-pair factorization of real polynomials",
+      "Positive-definite real quadratic factors",
+      "natDegree_sub_le / natDegree_add_le and omega for max-splits"
+    ]
   },
   {
     "id": "ann-h17-oq0101-public",
@@ -62,6 +86,12 @@
     "title": "Public degree-sharp theorem and existence corollary",
     "content": "univariate_psd_is_two_sos_deg instantiates the engine at d = deg p, giving the headline Fejér–Riesz statement for any nonnegative univariate polynomial: a two-square certificate whose summands each have degree at most ½·deg p. univariate_psd_is_two_sos then forgets the two degree inequalities, recovering the parent file's plain two-square existence theorem — so the sharp result strictly subsumes the existence statement. #print axioms reports only propext, Classical.choice, Quot.sound: 0 axioms.",
     "mathContext": "$\\forall\\, p \\ge 0,\\ \\exists\\, u, v:\\ p = u^2 + v^2,\\ \\deg u \\le \\tfrac12\\deg p,\\ \\deg v \\le \\tfrac12\\deg p.$",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": [
+      "Hilbert's seventeenth problem and Artin's theorem",
+      "Deriving an existence corollary by forgetting bounds",
+      "Gram-matrix size in SOS/SDP solvers",
+      "0-axiom verification via #print axioms"
+    ]
   }
 ]

--- a/src/data/proofs/hilbert-17-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01/meta.json
@@ -175,10 +175,24 @@
     },
     {
       "id": "engine",
-      "title": "The degree-sharp induction engine",
+      "title": "Induction engine: statement and base cases",
       "startLine": 44,
-      "endLine": 173,
-      "summary": "psd_eq_sq_add_sq_deg_aux: strong induction on deg p. The p = 0 and constant base cases give degree-0 squares; the real-root branch factors out (X − C r)² and bounds 2·deg u ≤ 2 + deg q = deg p via natDegree_mul_le; the non-real-root branch pulls out the positive quadratic Q and uses Brahmagupta plus natDegree_sub_le / natDegree_add_le, closing the max-split degree arithmetic with omega."
+      "endLine": 72,
+      "summary": "psd_eq_sq_add_sq_deg_aux states the degree-sharp invariant and sets up strong induction on d = deg p (Nat.strongRecOn). The p = 0 case returns u = v = 0; the constant case p = C c (c ≥ 0) returns u = C √c, v = 0 with degree 0; and for deg p ≥ 1 the FTA (Complex.exists_root) supplies a complex root z, split next into the real (z.im = 0) and non-real branches."
+    },
+    {
+      "id": "real-root",
+      "title": "Real-root branch: even multiplicity caps degree growth",
+      "startLine": 73,
+      "endLine": 115,
+      "summary": "When z is real (r = z.re), sq_dvd_of_psd_root gives (X − C r)² ∣ p with quotient q PSD of degree deg p − 2; a continuity argument (nonneg_of_forall_gt) re-establishes IsPSD q. The induction hypothesis returns q = u'² + v'², and u = (X − C r)·u', v = (X − C r)·v' inherit the bound 2·deg u ≤ 2 + deg q = deg p via natDegree_mul_le, closed by omega."
+    },
+    {
+      "id": "non-real-root",
+      "title": "Non-real-root branch: Brahmagupta keeps the squares in lockstep",
+      "startLine": 116,
+      "endLine": 171,
+      "summary": "For a non-real root, quadratic_dvd_of_aeval_eq_zero_im_ne_zero extracts the positive quadratic Q = (X − C re z)² + (C im z)² dividing p with PSD quotient q of degree deg p − 2. The Brahmagupta–Fibonacci identity converts Q·(u'² + v'²) into u = (X − C re)·u' − (C im)·v' and v = (X − C re)·v' + (C im)·u', each of degree ≤ 1 + max(deg u', deg v'); natDegree_sub_le / natDegree_add_le / natDegree_C_mul_le and a le_total max-split closed by omega give 2·deg u, 2·deg v ≤ deg p."
     },
     {
       "id": "public",


### PR DESCRIPTION
Enrichment pass for `hilbert-17-oq-01-oq-01`.

**Quality: 86 → 100**

- Added `relatedConcepts` (4 apiece) to all 5 annotations — closes the `crossRefs` gap (0 → 10).
- Split the oversized 130-line `engine` section (44–173) into three meaningful sections with verified line ranges: statement + base cases (44–72), real-root branch (73–115), non-real-root branch (116–171). Sections 3 → 5 (6 → 10 pts).
- No content deleted; meta.json 15 KB → 16 KB, well under the ~60 KB cap.
- `pnpm build` passes (✓ built in 4m 8s).