### PR TITLE
Fix: realign stale leanFile counts for erdos-57

### DIFF
--- a/src/data/proofs/erdos-57/meta.json
+++ b/src/data/proofs/erdos-57/meta.json
@@ -102,8 +102,8 @@
     },
     {
       "id": "bipartite",
-      "title": "Bipartite Characterization (1 sorry)",
-      "summary": "bipartite_iff_no_odd_cycles: G.IsBipartite ↔ oddCycleLengths G = ∅ (forward direction proved via noOddCycles_of_boolColoring; reverse direction is the sole sorry). colorable_two_no_odd_cycles: IsColorable G 2 → empty odd cycles (fully proved). Classical foundation for the chromatic-cycle connection",
+      "title": "Bipartite Characterization (fully proved, 0 sorries)",
+      "summary": "bipartite_iff_no_odd_cycles: G.IsBipartite ↔ oddCycleLengths G = ∅ (both directions proved; the forward direction via noOddCycles_of_boolColoring, the reverse direction via the crux lemma exists_odd_cycle_of_odd_closed_walk). colorable_two_no_odd_cycles: IsColorable G 2 → empty odd cycles (fully proved). Classical foundation for the chromatic-cycle connection",
       "startLine": 143,
       "endLine": 154,
       "mathContext": "$G \\text{ bipartite} \\iff \\mathcal{C}_{\\text{odd}}(G) = \\emptyset \\iff \\chi(G) \\leq 2$. The classical König characterization."
@@ -118,7 +118,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #57 was SOLVED by Liu and Montgomery in 2020. The 167-line formalization axiomatizes the main result (∑ 1/aᵢ = ⊤ for χ(G) = ∞) and proves three supporting results: finite reciprocal sums are not ⊤, odd cycle lengths are positive, and the corollary that infinitely many odd cycle lengths exist. One sorry remains for the hard reverse direction of the bipartite characterization. Open density conjectures from Erdős (1981, 1995-96) are formalized but remain unresolved.",
+    "summary": "Erdős Problem #57 was SOLVED by Liu and Montgomery in 2020. The 343-line formalization axiomatizes the main result (∑ 1/aᵢ = ⊤ for χ(G) = ∞) and proves supporting results: finite reciprocal sums are not ⊤, odd cycle lengths are positive, and the corollary that infinitely many odd cycle lengths exist. The bipartite characterization is now fully proved in both directions (0 sorries); the only remaining assumption is the axiom erdos_57 (the open Liu-Montgomery main result). Open density conjectures from Erdős (1981, 1995-96) are formalized but remain unresolved.",
     "implications": "The result establishes a precise quantitative threshold for odd cycle richness: the reciprocal sum divergence is the exact boundary between what is proved and what remains open. The density conjectures would further strengthen the connection between chromatic complexity and cycle structure, potentially illuminating the broader question of which graph properties are forced by high chromatic number.",
     "openQuestions": [
       "Must odd cycle lengths have positive upper density when χ(G) = ∞? (Erdős 1981, OPEN)",
@@ -163,12 +163,12 @@
       "BigOperators"
     ],
     "namespace": "Erdos57",
-    "lineCount": 166,
+    "lineCount": 343,
     "axiomCount": 1,
-    "theoremCount": 5,
+    "theoremCount": 10,
     "definitionCount": 8,
     "path": "Proofs/Erdos57Problem.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos57Aristotle.lean",
       "Proofs/Erdos57ProblemAristotle.lean"
@@ -204,5 +204,5 @@
       "note": "High-girth constructions showing χ(G) = ∞ is compatible with lower density 0 for odd cycle lengths — demonstrating the reciprocal sum divergence in Problem #57 is precisely calibrated"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Realign the stale `leanFile` count block (and top-level `sorries`) in `erdos-57/meta.json` to match the current Lean source.

## Evidence

After the bipartite reverse-direction proof landed (crux lemma `exists_odd_cycle_of_odd_closed_walk`, closing the last sorry via #30770), `Proofs/Erdos57Problem.lean` grew from 166 → 343 lines. The nested `meta` block was regenerated (343/10/8/1/0) but the `leanFile` block, the top-level `sorries`, and two prose spots still asserted the old, pre-proof state.

Actual source counts (verified): **343 lines, 10 theorems, 8 defs, 1 axiom, 0 sorries.**

**Before**
- `leanFile.lineCount` = 166, `leanFile.theoremCount` = 5, `leanFile.sorries` = 1
- top-level `sorries` = 1
- `sections[bipartite].title` = "Bipartite Characterization (1 sorry)"
- `conclusion.summary` claims "167-line formalization … One sorry remains"

**After**
- `leanFile.lineCount` = 343, `leanFile.theoremCount` = 10, `leanFile.sorries` = 0
- top-level `sorries` = 0
- bipartite section + conclusion prose corrected to "fully proved, 0 sorries"

Status/badge unchanged (`axiomatized`/`axiom`) — the entry still carries the genuine `erdos_57` axiom (the open Liu–Montgomery main result), so the axiom count of 1 is correct.

This drift is invisible to the auditor finder (it does not check `leanFile.lineCount`/count drift); found via a single-file count-drift scan.

---
Automated fix by lean-mechanic agent.