### PR TITLE
Enrich General Symmetric Beta Value B(s,1−s) = π/sin(πs)

### DIFF
--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-01-oq-01/annotations.json
@@ -70,5 +70,54 @@
       "Real.Gamma_mul_Gamma_one_sub",
       "sin(π/3) = √3/2"
     ]
+  },
+  {
+    "id": "ann-gamma-refl-oq010101-gamma-one-collapse",
+    "proofId": "gamma-reflection-formula-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 61
+    },
+    "type": "technique",
+    "title": "Why the Diagonal Works: the Γ(1) = 1 Collapse",
+    "content": "The whole derivation hinges on one arithmetic coincidence: on the diagonal t = 1−s the argument sum s + t equals 1, and Γ(1) = 1. In Lean this is the line `rw [show s + (1 - s) = 1 by ring, Complex.Gamma_one, one_mul]`, which turns the Beta–Gamma relation Γ(s)·Γ(1−s) = Γ(s+t)·B(s,t) into the bare equation Γ(s)·Γ(1−s) = B(s,1−s). The second positivity hypothesis `ht : 0 < (1 - s).re` — needed to apply the Beta–Gamma relation, whose both arguments must have positive real part — is exactly what forces the strip 0 < Re s < 1: 0 < Re(1−s) unfolds to Re s < 1. Only after the collapse does Euler's reflection formula enter, rewriting the surviving Gamma product as π/sin(πs). No other Gamma value is ever evaluated; the identity is 'Gamma-free' apart from Γ(1).",
+    "mathContext": "$s + (1-s) = 1$, so $\\Gamma(s+t) = \\Gamma(1) = 1$; the hypothesis $0 < \\operatorname{Re}(1-s)$ is equivalent to $\\operatorname{Re} s < 1$, pinning the strip $0 < \\operatorname{Re} s < 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Beta–Gamma relation",
+      "analytic strip of convergence",
+      "Gamma functional equation",
+      "positivity hypotheses"
+    ],
+    "prerequisites": [
+      "Complex.Gamma_one",
+      "positive real part of Beta integral arguments",
+      "Complex.sub_re / Complex.one_re"
+    ]
+  },
+  {
+    "id": "ann-gamma-refl-oq010101-transcendence",
+    "proofId": "gamma-reflection-formula-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 93
+    },
+    "type": "context",
+    "title": "A Rational Multiple of π from Transcendental Factors",
+    "content": "The concrete value Γ(1/3)·Γ(2/3) = 2π/√3 is more than a numeric check: it exhibits the reflection formula as a mechanism that tames individually wild numbers. By the Chudnovsky brothers' 1984 theorem, Γ(1/3) is transcendental and, together with π, algebraically independent, so no closed form expresses Γ(1/3) alone in elementary constants. Yet the complementary product Γ(1/3)·Γ(2/3) is the tame quantity 2π/√3 — algebraic multiple of π — because reflection pairs s with 1−s and collapses the two transcendental factors into a single sine value. The proof mirrors the midpoint case but with a non-trivial denominator: `Real.sin_pi_div_three` supplies sin(π/3) = √3/2, and `div_div_eq_mul_div` plus `ring` normalise π/(√3/2) to 2π/√3.",
+    "mathContext": "$\\Gamma(1/3)$ transcendental (Chudnovsky, 1984), yet $\\Gamma(1/3)\\,\\Gamma(2/3) = \\pi/\\sin(\\pi/3) = \\pi/(\\sqrt3/2) = 2\\pi/\\sqrt3$, a rational multiple of $\\pi$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "transcendence",
+      "Chudnovsky theorem",
+      "algebraic independence",
+      "special values of Gamma",
+      "Euler reflection formula"
+    ],
+    "prerequisites": [
+      "Real.sin_pi_div_three",
+      "transcendence of Γ(1/3)",
+      "field_simp / ring normalisation"
+    ]
   }
 ]

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-01-oq-01/meta.json
@@ -132,19 +132,43 @@
       "mathContext": "$B(s,1-s) = \\Gamma(s)\\Gamma(1-s)/\\Gamma(1) = \\pi/\\sin(\\pi s)$."
     },
     {
+      "id": "imports-setup",
+      "title": "Imports and Namespace Setup",
+      "startLine": 41,
+      "endLine": 46,
+      "summary": "Imports all of Mathlib, enters the namespace GammaReflectionFormulaOQ01OQ01OQ01, and brings `open scoped Real` into scope so that π denotes Real.pi and sin/Gamma resolve to the real special-function definitions used throughout.",
+      "mathContext": "Notation setup: $\\pi = $ `Real.pi`; `open scoped Real` exposes the real Gamma and sine used in the ratio-form theorems."
+    },
+    {
       "id": "general-value",
-      "title": "The General Symmetric Beta Value",
+      "title": "The General Symmetric Beta Value B(s,1−s)",
       "startLine": 47,
-      "endLine": 72,
-      "summary": "betaIntegral_one_sub_eq proves B(s,1−s) = π/sin(πs) for 0 < Re s < 1 from the Beta–Gamma relation (with Γ(1) = 1) and Euler's reflection formula. betaIntegral_half_half specializes to s = 1/2, where sin(π/2) = 1, recovering the parent's B(1/2,1/2) = π.",
+      "endLine": 61,
+      "summary": "betaIntegral_one_sub_eq proves B(s,1−s) = π/sin(πs) for 0 < Re s < 1. The complex-variable core: derive the auxiliary positivity ht : 0 < Re(1−s), apply the Beta–Gamma relation, collapse Γ(s+(1−s)) = Γ(1) = 1, then rewrite the Gamma product by Euler's complex reflection formula.",
       "mathContext": "$\\Gamma(s)\\Gamma(1-s) = \\Gamma(1)\\,B(s,1-s)$ with $\\Gamma(1)=1$ and $\\Gamma(s)\\Gamma(1-s)=\\pi/\\sin(\\pi s)$."
     },
     {
-      "id": "ratio-and-concrete",
-      "title": "Real Ratio Form and a Second Concrete Value",
+      "id": "recover-midpoint",
+      "title": "Recovering the Parent Value B(1/2,1/2) = π",
+      "startLine": 63,
+      "endLine": 72,
+      "summary": "betaIntegral_half_half specializes the general formula to s = 1/2. After rewriting 1 − 1/2 = 1/2, the value is π/sin(π/2); casting π·(1/2) through Complex.ofReal_sin and applying Real.sin_pi_div_two (sin(π/2) = 1) recovers exactly the parent entry's symmetric midpoint value B(1/2,1/2) = π.",
+      "mathContext": "At $s = 1/2$: $\\sin(\\pi/2) = 1$, so $B(1/2,1/2) = \\pi/1 = \\pi$ — the parent's value as a special case."
+    },
+    {
+      "id": "ratio-form",
+      "title": "The Real-Gamma Ratio Form",
       "startLine": 73,
+      "endLine": 81,
+      "summary": "beta_gamma_ratio_reflection records the textbook ratio form B(s,1−s) = Γ(s)Γ(1−s)/Γ(1) = π/sin(πs) over the real Gamma function. A one-line proof: Real.Gamma_one turns Γ(1) into 1, div_one clears the denominator, and Real.Gamma_mul_Gamma_one_sub supplies the reflection closed form.",
+      "mathContext": "$B(s,1-s) = \\Gamma(s)\\Gamma(1-s)/\\Gamma(1) = \\pi/\\sin(\\pi s)$ over $\\mathbb{R}$."
+    },
+    {
+      "id": "concrete-third",
+      "title": "A Second Concrete Value: Γ(1/3)·Γ(2/3) = 2π/√3",
+      "startLine": 82,
       "endLine": 95,
-      "summary": "beta_gamma_ratio_reflection records the textbook ratio form B(s,1−s) = Γ(s)Γ(1−s)/Γ(1) = π/sin(πs) over ℝ. gamma_one_third_mul_two_thirds evaluates the family at s = 1/3, giving Γ(1/3)·Γ(2/3) = π/(√3/2) = 2π/√3.",
+      "summary": "gamma_one_third_mul_two_thirds evaluates the family at s = 1/3. Euler's real reflection formula gives π/sin(π/3); Real.sin_pi_div_three (√3/2) and div_div_eq_mul_div followed by ring normalise the result to 2π/√3 — a non-trivial sine denominator, in contrast to the symmetric midpoint.",
       "mathContext": "$\\Gamma(1/3)\\Gamma(2/3) = \\pi/\\sin(\\pi/3) = \\pi/(\\sqrt3/2) = 2\\pi/\\sqrt3$."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `gamma-reflection-formula-oq-01-oq-01-oq-01`.

**Gaps addressed** (quality 83 → 100):
- annotations 15→25: added 2 annotations — the Γ(1)=1 collapse crux (why the diagonal y=1−s works, and how the positivity hypothesis pins the strip 0<Re s<1) and the transcendence contrast (Γ(1/3) transcendental by Chudnovsky, yet Γ(1/3)·Γ(2/3)=2π/√3 rational multiple of π). Each has mathContext, significance, relatedConcepts, prerequisites.
- sections 6→10: split into 5 sections covering the full 95-line file (imports/setup, general value, midpoint recovery, real ratio form, concrete 1/3 value).

meta.json 14.3 KB (under cap). `pnpm build` passes. No changes to Lean source or status/axiom fields (remains verified, 0 axioms).