### PR TITLE
Enrich Erdős #100 ℝ³ scalene tetrahedron (OQ-05-OQ-01)

### DIFF
--- a/src/data/proofs/erdos-100-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/erdos-100-oq-05-oq-01/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "ann-e100-oq0501-vertices",
+    "proofId": "erdos-100-oq-05-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 59
+    },
+    "type": "concept",
+    "title": "The four integer-coordinate vertices",
+    "content": "The tetrahedron is fixed by four explicit points P₀=(0,0,0), P₁=(0,0,6), P₂=(0,8,6), P₃=(6,2,9), each written as an EuclideanSpace ℝ (Fin 3) literal !₂[a,b,c]. Anchoring P₀ at the origin means the three edge vectors out of P₀ are just P₁, P₂, P₃ themselves, which simplifies the later non-degeneracy determinant. Everything downstream — the six distances, their distinctness, and the spanning property — is a computation on these four literals.",
+    "mathContext": "$P_0=(0,0,0),\\ P_1=(0,0,6),\\ P_2=(0,8,6),\\ P_3=(6,2,9) \\in \\mathbb{Z}^3 \\subset \\mathrm{EuclideanSpace}\\ \\mathbb{R}\\ (\\mathrm{Fin}\\ 3).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Integer-coordinate (lattice) point sets",
+      "EuclideanSpace ℝ (Fin n) and the !₂[...] literal notation",
+      "Placing a vertex at the origin to simplify edge vectors",
+      "Perfect / Heronian tetrahedra"
+    ]
+  },
+  {
+    "id": "ann-e100-oq0501-distcompute",
+    "proofId": "erdos-100-oq-05-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "Each pairwise distance is an integer via √(perfect square)",
+    "content": "The six theorems dist_P0_P1 … dist_P1_P3 each follow the identical pattern: EuclideanSpace.dist_eq rewrites the distance as √(∑_{i<3} |xᵢ−yᵢ|²), Fin.sum_univ_three plus the cons-vector simp lemmas evaluate the three coordinate differences, the sum of squares is rewritten to a single k² by norm_num (e.g. 0+0+36 = 6², 36+4+81 = 121 = 11²), and Real.sqrt_sq closes it to the integer k. The coordinates were chosen precisely so that every one of these six sums is a perfect square, which is what makes each distance a provable integer.",
+    "mathContext": "$\\mathrm{dist}(x,y)=\\sqrt{\\textstyle\\sum_{i<3}|x_i-y_i|^2};\\quad |P_0P_3|=\\sqrt{6^2+2^2+9^2}=\\sqrt{121}=11.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euclidean distance formula (EuclideanSpace.dist_eq)",
+      "Real.sqrt_sq for extracting integer square roots",
+      "Sums of three squares equal to a perfect square",
+      "Fin.sum_univ_three coordinate expansion"
+    ]
+  },
+  {
+    "id": "ann-e100-oq0501-alldist",
+    "proofId": "erdos-100-oq-05-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 109
+    },
+    "type": "theorem",
+    "title": "All six distances are the consecutive integers 6…11",
+    "content": "all_distances_integer bundles the six individual computations into one statement: the pairwise distances are 6, 8, 9, 10, 11, 7 — i.e. exactly the six consecutive integers {6,7,8,9,10,11}. This certifies the configuration is an integer-distance (perfect) tetrahedron. That the six values are consecutive is the extremal feature: an exhaustive search over integer tetrahedra with a vertex at the origin and coordinates in [0,10]³ shows 11 is the least possible largest edge of a scalene one, forcing the edge set down to exactly {6,…,11}.",
+    "mathContext": "$\\{|P_0P_1|,\\dots,|P_1P_3|\\}=\\{6,7,8,9,10,11\\},\\ \\text{six consecutive integers}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Integer-distance point sets",
+      "Extremal / smallest-diameter configurations",
+      "Consecutive-integer edge lengths",
+      "Exhaustive computer search certificates"
+    ]
+  },
+  {
+    "id": "ann-e100-oq0501-distinct",
+    "proofId": "erdos-100-oq-05-oq-01",
+    "range": {
+      "startLine": 114,
+      "endLine": 127
+    },
+    "type": "insight",
+    "title": "Pairwise distinctness: the hypothesis the parent example fails",
+    "content": "distances_pairwise_distinct asserts all fifteen inequalities among the six distances. Since the distances take six different values, the proof simply rewrites each to its numeric value and discharges the inequalities by norm_num. This is the crux of the entry: the parent OQ-05 Heronian tetrahedron has distances {6,7,7,8,9,10} where 7 repeats, so it does NOT meet Erdős #100's restricted-distance hypothesis (all distances distinct). By taking six distinct — indeed consecutive — values, this configuration genuinely instantiates the distinct-distance regime, with the minimal spacing of exactly 1 between adjacent edges.",
+    "mathContext": "$\\forall\\, e\\neq f\\ \\text{edges},\\ |e|\\neq|f|;\\ \\text{here }|e|-|f|\\in\\mathbb{Z}\\setminus\\{0\\},\\ \\min|\\,|e|-|f|\\,|=1.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Distinct-distance (restricted-distance) hypothesis of Erdős #100",
+      "Scalene vs. Heronian tetrahedra",
+      "Repairing a repeated-distance defect in a parent construction",
+      "norm_num discharging finite systems of inequalities"
+    ]
+  },
+  {
+    "id": "ann-e100-oq0501-seteq",
+    "proofId": "erdos-100-oq-05-oq-01",
+    "range": {
+      "startLine": 129,
+      "endLine": 151
+    },
+    "type": "theorem",
+    "title": "Distance set equals {6,…,11}; vertices are distinct",
+    "content": "distance_set_eq identifies the Finset of six distances with {6,7,8,9,10,11} by extensionality plus a membership simp and tauto, giving the exact edge-length set rather than just its cardinality. vertices_distinct then derives that the four points are pairwise distinct: if two coincided, their distance would be 0 by dist_self, contradicting the positive integer values already computed. Distinctness of the vertices is a prerequisite for speaking of a genuine four-point simplex.",
+    "mathContext": "$\\{|P_iP_j|\\}=\\{6,7,8,9,10,11\\};\\quad P_i=P_j\\Rightarrow \\mathrm{dist}(P_i,P_j)=0,\\ \\text{contradiction}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset extensionality and membership reasoning",
+      "dist_self and the identity of indiscernibles for a metric",
+      "Recovering distinct points from positive distances",
+      "Edge-length multisets of a simplex"
+    ]
+  },
+  {
+    "id": "ann-e100-oq0501-nondegen",
+    "proofId": "erdos-100-oq-05-oq-01",
+    "range": {
+      "startLine": 160,
+      "endLine": 179
+    },
+    "type": "insight",
+    "title": "Non-degeneracy: determinant −288 ≠ 0 certifies full 3-dimensionality",
+    "content": "edgeMatrix is the 3×3 matrix whose rows are the edge vectors v₁=(0,0,6), v₂=(0,8,6), v₃=(6,2,9) out of P₀. edgeMatrix_det computes its determinant as −288 via Matrix.det_fin_three (Sarrus) closed by norm_num. Because −288 ≠ 0, Matrix.linearIndependent_rows_of_det_ne_zero yields edges_linearIndependent: the three edges are linearly independent, so the four vertices are non-coplanar and span a genuinely 3-dimensional affine subspace. This is the essential 'ℝ³' content — three points are always coplanar, so authentic higher-dimensional structure first appears at four points — and together with distinctness it realizes Erdős #100's restricted-distance regime in three dimensions.",
+    "mathContext": "$\\det\\!\\begin{pmatrix}0&0&6\\\\0&8&6\\\\6&2&9\\end{pmatrix}=-288\\neq 0 \\ \\Rightarrow\\ v_1,v_2,v_3\\ \\text{lin. indep.}\\ \\Rightarrow\\ \\text{non-coplanar}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "3×3 determinants (Matrix.det_fin_three, Sarrus rule)",
+      "det ≠ 0 ⇒ linear independence of rows",
+      "Coplanarity as linear dependence of edge vectors",
+      "Affine dimension / non-degenerate simplices"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-100-oq-05-oq-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-05-oq-01/meta.json
@@ -77,7 +77,8 @@
       "**Distinctness is the missing hypothesis.** Erdős #100's restricted-distance form needs the pairwise distances DISTINCT; the parent's Heronian example repeats 7, so a scalene replacement is required to genuinely instantiate the problem in ℝ³",
       "**Consecutive integers are extremal.** Among integer-coordinate tetrahedra with a vertex at the origin and coordinates in [0,10]³, the least possible largest edge of a scalene one is 11 — forcing the six edges to be precisely the consecutive integers 6,…,11, the tightest possible distinct-distance spread",
       "**Distances are perfect-square roots.** Choosing integer coordinates whose squared coordinate differences sum to a perfect square makes each distance a provable integer via Real.sqrt_sq, exactly as in the parent",
-      "**Non-coplanarity = nonzero edge determinant.** Reducing 'not coplanar' to det ≠ 0 of the 3×3 edge matrix is discharged by Matrix.det_fin_three + norm_num and certifies genuine 3-dimensionality"
+      "**Non-coplanarity = nonzero edge determinant.** Reducing 'not coplanar' to det ≠ 0 of the 3×3 edge matrix is discharged by Matrix.det_fin_three + norm_num and certifies genuine 3-dimensionality",
+      "**Four points are the first dimension where the problem has content.** Any three points are automatically coplanar, so a genuine ℝ³ integer-distance witness must be a full tetrahedron; the determinant certificate is exactly what upgrades 'four labelled points with integer distances' to 'a non-degenerate 3-simplex', separating this entry from the planar parent"
     ],
     "prerequisites": [
       "Euclidean distance in EuclideanSpace ℝ (Fin n) and the formula dist = √(Σ coordinate differences²)",


### PR DESCRIPTION
Enrichment pass for `erdos-100-oq-05-oq-01`.

**Quality: 43 → 100**

- Created `annotations.json` (previously missing entirely — the dominant gap) with 6 annotations, each carrying `mathContext` (LaTeX), `significance`, and `relatedConcepts`: the four vertices, the six √(perfect-square) distance computations, `all_distances_integer`, the pairwise-distinctness theorem (the property the parent Heronian example fails), the distance-set / vertex-distinctness pair, and the determinant −288 non-degeneracy certificate. Line ranges verified against the Lean source.
- Added a 5th `keyInsight` on why four points is the first dimension where the restricted-distance problem has genuine content.
- meta.json 17.8 KB → 18.2 KB, well under the ~60 KB cap.
- `pnpm build` passes.