### PR TITLE
research(cauchy-schwarz-lp-duality): S15 — dual-norm attainment (sup is a max) + reflexive norming form [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualityIngredients.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualityIngredients.lean
@@ -42,6 +42,13 @@ characterization** that is the analytic core of `Lᵖ`-duality:
 * `lpDualNorm_eq` — the **unconditional** dual-norm identity
   `lpDualNorm p g = (∫⁻ gᵠ)^{1/q} = ‖g‖_q` for a σ-finite measure and any
   measurable `g` (no integrability hypothesis).
+* `exists_lpDualNorm_eq` — **attainment**: for `g ∈ Lᵠ` the defining supremum is a
+  genuine *maximum*, realized by an explicit extremal `f` in the `Lᵖ` unit ball
+  (`f = 0` if `‖g‖_q = 0`, else the normalized extremizer). Existence of a norming
+  function for the pairing functional `f ↦ ∫⁻ f·g`.
+* `eLpNorm_eq_lpDualNorm` — the **reflexive** norming form
+  `‖f‖_p = lpDualNorm q f`: the original `Lᵖ`-norm is recovered by testing against
+  the `Lᵠ` unit ball (the `p ↔ q` mirror of `lpDualNorm_eq_eLpNorm`).
 -/
 
 import Mathlib
@@ -619,6 +626,82 @@ theorem memLp_ofReal_iff_lpDualNorm_lt_top [SigmaFinite μ] {p q : ℝ}
     MemLp g (ENNReal.ofReal q) μ ↔ lpDualNorm p μ g < ∞ := by
   rw [lpDualNorm_eq_eLpNorm hpq hg]
   exact ⟨fun h => h.2, fun h => ⟨hg.aestronglyMeasurable, h⟩⟩
+
+/-! ## Attainment: the dual norm is a genuine maximum (`g ∈ Lᵠ`)
+
+`lpDualNorm` is defined as a supremum over the `Lᵖ` unit ball. The dual-norm
+identity `lpDualNorm_eq_of_lintegral_ne_top` shows the supremum *value* equals
+`‖g‖_q`, but the standard "converse Hölder" statement is stronger: for
+`g ∈ Lᵠ` the supremum is **attained** by an explicit extremal function — the
+supremum is a maximum. The witness is the normalized extremizer
+`(∫⁻ gᵠ)^{-1/p}·g^{q-1}` (when `‖g‖_q ≠ 0`) or the zero function (when
+`‖g‖_q = 0`, where `g = 0` a.e. and every pairing vanishes). This is exactly the
+existence of a *norming function* for the pairing functional `f ↦ ∫⁻ f·g`. -/
+
+/-- **The `Lᵖ`-dual norm is attained for `g ∈ Lᵠ` (converse Hölder, existence
+    form).** For Hölder-conjugate `p, q` and measurable `g` with `∫⁻ gᵠ ≠ ∞`,
+    there is an admissible `f` (`∫⁻ fᵖ ≤ 1`) whose pairing against `g` realizes
+    the dual norm exactly:
+
+      `∃ f, ‖f‖_p ≤ 1  ∧  ∫⁻ f·g = lpDualNorm p g  (= ‖g‖_q)`.
+
+    So the defining supremum is a genuine *maximum*: the pairing functional
+    `f ↦ ∫⁻ f·g` is normed by an explicit extremal element of the unit ball. When
+    `‖g‖_q = 0` the witness is `f = 0`; otherwise it is the normalized extremizer
+    `(∫⁻ gᵠ)^{-1/p}·g^{q-1}`, which lies on the unit sphere and pairs to `‖g‖_q`. -/
+theorem exists_lpDualNorm_eq {p q : ℝ} (hpq : p.HolderConjugate q)
+    (hg : Measurable g) (hItop : (∫⁻ x, (g x) ^ q ∂μ) ≠ ∞) :
+    ∃ f : α → ℝ≥0∞, AEMeasurable f μ ∧ (∫⁻ x, (f x) ^ p ∂μ) ≤ 1 ∧
+      ∫⁻ x, f x * g x ∂μ = lpDualNorm p μ g := by
+  have hp : (0 : ℝ) < p := lt_trans one_pos hpq.lt
+  have hq : (0 : ℝ) < q := lt_trans one_pos hpq.symm.lt
+  rw [lpDualNorm_eq_of_lintegral_ne_top hpq hg hItop]
+  set I := ∫⁻ x, (g x) ^ q ∂μ with hIdef
+  rcases eq_or_ne I 0 with hI0 | hI0
+  · -- ‖g‖_q = 0 (`g = 0` a.e.): the zero function attains the value `0 = I^{1/q}`
+    refine ⟨0, aemeasurable_const, ?_, ?_⟩
+    · simp [ENNReal.zero_rpow_of_pos hp]
+    · rw [hI0, ENNReal.zero_rpow_of_pos (one_div_pos.2 hq)]
+      simp
+  · -- 0 < ‖g‖_q < ∞: the normalized extremizer lies on the unit sphere and
+    -- pairs to exactly `I^{1/q}`, realizing the supremum
+    have hIpos : (0 : ℝ≥0∞) < I := lt_of_le_of_ne (zero_le _) (Ne.symm hI0)
+    have hIp0 : I ^ (1 / p) ≠ 0 := (ENNReal.rpow_pos hIpos hItop).ne'
+    have hc_ne_top : ((I ^ (1 / p))⁻¹ : ℝ≥0∞) ≠ ∞ := ENNReal.inv_ne_top.2 hIp0
+    have hcp : ((I ^ (1 / p))⁻¹ : ℝ≥0∞) ^ p = I⁻¹ := by
+      rw [ENNReal.inv_rpow, ← ENNReal.rpow_mul, one_div_mul_cancel hp.ne', ENNReal.rpow_one]
+    have hcp_ne_top : ((I ^ (1 / p))⁻¹ : ℝ≥0∞) ^ p ≠ ∞ := by
+      rw [hcp]; exact ENNReal.inv_ne_top.2 hI0
+    have hf_norm : ∫⁻ x, (normalizedExtremizer p q μ g x) ^ p ∂μ = 1 := by
+      simp only [normalizedExtremizer, ← hIdef]
+      rw [lintegral_scaled_extremizer_rpow hpq hcp_ne_top, ← hIdef, hcp,
+        ENNReal.inv_mul_cancel hI0 hItop]
+    have hexp : -(1 / p) + 1 = 1 / q := by
+      have h := hpq.inv_add_inv_eq_one
+      simp only [one_div]; linarith
+    have hcI : ((I ^ (1 / p))⁻¹ : ℝ≥0∞) * I = I ^ (1 / q) := by
+      rw [← hexp, ENNReal.rpow_add _ _ hI0 hItop, ENNReal.rpow_neg, ENNReal.rpow_one]
+    have hf_pair : ∫⁻ x, normalizedExtremizer p q μ g x * g x ∂μ = I ^ (1 / q) := by
+      simp only [normalizedExtremizer, ← hIdef]
+      rw [lintegral_scaled_extremizer_mul hpq.symm.lt.le hc_ne_top, ← hIdef, hcI]
+    exact ⟨normalizedExtremizer p q μ g, (measurable_normalizedExtremizer hg).aemeasurable,
+      hf_norm.le, hf_pair⟩
+
+/-- **Reflexive norming form of `Lᵖ`-duality (σ-finite `μ`).** For Hölder-conjugate
+    `p, q`, a σ-finite measure `μ`, and measurable `f`, the genuine `Lᵖ`-seminorm of
+    `f` is recovered as the dual norm of `f` over the `Lᵠ` unit ball:
+
+      `‖f‖_p = eLpNorm f (ENNReal.ofReal p) μ = lpDualNorm q μ f = ⨆_{‖h‖_q ≤ 1} ∫⁻ h·f`.
+
+    This is the symmetric ("double duality" / reflexivity) companion of
+    `lpDualNorm_eq_eLpNorm`: not only is the dual of `Lᵖ` the space `Lᵠ`, but the
+    original norm is itself recovered by testing against the dual ball. It is the
+    `p ↔ q` mirror image, obtained by feeding the conjugacy the other way round
+    (`hpq.symm`). -/
+theorem eLpNorm_eq_lpDualNorm [SigmaFinite μ] {p q : ℝ} (hpq : p.HolderConjugate q)
+    {f : α → ℝ≥0∞} (hf : Measurable f) :
+    eLpNorm f (ENNReal.ofReal p) μ = lpDualNorm q μ f :=
+  (lpDualNorm_eq_eLpNorm hpq.symm hf).symm
 
 end RieszLpDualityIngredients
 

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -153,6 +153,36 @@ removes the only open *mathematical* question that was gating the elimination pl
 
 ## Session log
 
+### 2026-06-30 (Session 15, researcher-8) — ACT (dual-norm layer completed)
+
+**Mode:** REVISIT (rolling PR #31646). **Outcome:** progress — 0-axiom.
+
+- The σ-finite dual-norm identity `lpDualNorm p g = ‖g‖_q` was already unconditional
+  (both `g ∈ Lᵠ` and `g ∉ Lᵠ` regimes closed in S13/S14) plus the `eLpNorm`/`MemLp`
+  bridges. Added the two remaining *structural* statements that upgrade it from an
+  identity of values to a full duality package:
+  - **`exists_lpDualNorm_eq`** — attainment: for `g ∈ Lᵠ` (`∫⁻ gᵠ ≠ ∞`) the defining
+    supremum is a genuine **maximum**, realized by an explicit admissible `f`
+    (`∫⁻ fᵖ ≤ 1`, `∫⁻ f·g = lpDualNorm p g`). Witness: `f = 0` when `‖g‖_q = 0`
+    (then `g = 0` a.e. and every pairing vanishes), else the normalized extremizer
+    `(∫⁻ gᵠ)^{-1/p}·g^{q-1}` (unit sphere, pairs to `‖g‖_q`). This is the existence
+    of a *norming function* for the pairing functional — the converse-Hölder
+    extremal-function statement, distinct from the value identity.
+  - **`eLpNorm_eq_lpDualNorm`** — reflexive norming form `‖f‖_p = lpDualNorm q f`:
+    the original `Lᵖ`-norm is recovered by testing against the `Lᵠ` unit ball
+    (the `p ↔ q` mirror of `lpDualNorm_eq_eLpNorm`, via `hpq.symm`).
+- Both verified 0-axiom (`propext`/`Classical.choice`/`Quot.sound` only) via host
+  `bin/lake env lean` against the v4.26 Mathlib olean cache (Docker unavailable in the
+  /tmp worktree — no local Mathlib cache, re-clones).
+- **Recipe reused:** the normalized-extremizer unit-sphere/pairing derivation
+  (`lintegral_scaled_extremizer_rpow/_mul`, `hcp`/`hcI`, `-(1/p)+1 = 1/q` via
+  `hpq.inv_add_inv_eq_one`) transplanted cleanly from `lpDualNorm_eq_of_lintegral_ne_top`
+  into the existence proof; the `I = 0` branch just uses `f = 0` with
+  `ENNReal.zero_rpow_of_pos`.
+- **Status unchanged (blocked):** the parent goal (eliminate `riesz_lp_surjective` for
+  *arbitrary* measures) still waits on the `Incomplete01.lean` Mathlib-drift repair and
+  the σ-finite→arbitrary lift. The σ-finite dual-norm layer is now feature-complete.
+
 ### 2026-06-13 (Session 1, researcher-9) — OBSERVE → ORIENT
 
 **Mode:** FRESH. **Outcome:** surveyed (no build possible — verification blackout).


### PR DESCRIPTION
Follow-up to merged #31646, extending the σ-finite `Lᵖ`-duality dual-norm layer in `CauchySchwarzIntegralLpDualityIngredients.lean`.

The unconditional identity `lpDualNorm p g = ‖g‖_q` (both `g∈Lᵠ` and `g∉Lᵠ` regimes) plus the `eLpNorm`/`MemLp` bridges were completed in #31646. This adds the two remaining **structural** statements that upgrade it from an identity of *values* to a full duality package:

- **`exists_lpDualNorm_eq`** — *attainment*: for `g∈Lᵠ` (`∫⁻ gᵠ ≠ ∞`) the supremum defining `lpDualNorm` is a genuine **maximum**, realized by an explicit admissible `f` (`∫⁻ fᵖ ≤ 1` with `∫⁻ f·g = lpDualNorm p g`). Witness: `f = 0` when `‖g‖_q = 0` (then `g = 0` a.e.), else the normalized extremizer `(∫⁻ gᵠ)^{-1/p}·g^{q-1}`. This is the converse-Hölder *existence* / norming-function statement, distinct from the value identity.
- **`eLpNorm_eq_lpDualNorm`** — *reflexive* norming form `‖f‖_p = lpDualNorm q f`: the original `Lᵖ`-norm recovered by testing against the `Lᵠ` unit ball (the `p↔q` mirror of `lpDualNorm_eq_eLpNorm`).

Both **verified 0-axiom** (`propext`/`Classical.choice`/`Quot.sound` only), checked with host `lake env lean` against the pinned v4.26 Mathlib cache.

Parent goal (eliminate the arbitrary-measure `riesz_lp_surjective` axiom) is unchanged — still blocked on the `Incomplete01.lean` Mathlib-drift repair. The σ-finite dual-norm layer is now feature-complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)