### PR TITLE
Enrich Univariate Hilbert 17 Exact Normalization

### DIFF
--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,125 @@
+[
+  {
+    "id": "ann-hilbert17-oq010101-docstring",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
+    "type": "concept",
+    "title": "From an Upper Bound to an Exact Certificate",
+    "content": "The parent file proves the symmetric upper bound 2·deg u ≤ deg p, 2·deg v ≤ deg p for a two-squares decomposition p = u² + v² of a nonnegative real univariate polynomial. This file sharpens that to an exact normalization by isolating one elementary fact the parent never states: a sum of two polynomial squares has no degree collapse, deg(u² + v²) = 2·max(deg u, deg v). Because the leading coefficient of any square w² is (leadingCoeff w)² ≥ 0, the top coefficients of u² and v² cannot cancel. From this single lemma flow three results: PSD ⟹ even degree, PSD ⟹ positive leading coefficient, and the exact Fejér–Riesz normalization deg v < deg u with 2·deg u = deg p. The setup imports the parent (Proofs.Hilbert17OQ01OQ01) and reuses its IsPSD predicate.",
+    "mathContext": "$p = u^2 + v^2$ with $\\deg(u^2+v^2) = 2\\max(\\deg u, \\deg v)$; leading coefficients of squares are nonnegative, so no cancellation at the top.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Hilbert's 17th problem",
+      "Fejér–Riesz theorem",
+      "sum of squares",
+      "positive semidefinite polynomial",
+      "degree bound"
+    ],
+    "prerequisites": [
+      "the parent two-squares existence theorem",
+      "polynomial degree over ℝ[X]",
+      "the IsPSD predicate"
+    ]
+  },
+  {
+    "id": "ann-hilbert17-oq010101-coeff-engine",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 39,
+      "endLine": 57
+    },
+    "type": "technique",
+    "title": "coeff_sq_two: Reading the Diagonal Term of a Square",
+    "content": "coeff_sq_two is the reusable engine: for deg w ≤ n, the coefficient of w² at index 2n is exactly (w.coeff n)². The proof splits on deg w < n versus deg w = n. In the strict case both sides vanish — the coefficient of w² above its degree is 0 (via natDegree_pow_le) and w.coeff n = 0. In the equality case it is precisely the leading coefficient: (w²).coeff(2n) = leadingCoeff(w²) = (leadingCoeff w)² = (w.coeff n)², using natDegree_mul and leadingCoeff_mul over the polynomial domain ℝ[X]. Uniformly capturing both cases as (w.coeff n)² is what lets the later lemmas read leading data off a sum of squares without case analysis.",
+    "mathContext": "$\\deg w \\le n \\implies (w^2)_{2n} = (w_n)^2$: for $\\deg w < n$ both sides are $0$; for $\\deg w = n$ it is $(\\operatorname{lc} w)^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "leading coefficient",
+      "polynomial multiplication degree",
+      "natDegree_mul",
+      "domain (no zero divisors)"
+    ],
+    "prerequisites": [
+      "Polynomial.natDegree_mul",
+      "Polynomial.leadingCoeff_mul",
+      "coeff_eq_zero_of_natDegree_lt"
+    ]
+  },
+  {
+    "id": "ann-hilbert17-oq010101-no-collapse",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 99
+    },
+    "type": "insight",
+    "title": "natDegree_sq_add_sq: No Degree Collapse",
+    "content": "The workhorse theorem: deg(u² + v²) = 2·max(deg u, deg v) over ℝ. A symmetric helper `key` handles the case where u carries the maximal degree; the general statement dispatches the zero cases and the two orderings of deg u, deg v by add_comm. The upper bound is natDegree_add_le. The lower bound is the crux: at index 2·max the coefficient is (u.coeff n)² + (v.coeff n)² by coeff_sq_two, a sum of squares that is ≥ 0 and strictly positive because the maximal-degree polynomial has nonzero leading coefficient — so le_natDegree_of_ne_zero forces the degree up to 2·max. This positivity is exactly why real squares (unlike signed terms) cannot cancel at the top.",
+    "mathContext": "$(u^2+v^2)_{2m} = (u_m)^2 + (v_m)^2 > 0$ where $m = \\max(\\deg u, \\deg v)$, so $\\deg(u^2+v^2) = 2m$ with no cancellation.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "sum of squares",
+      "leading coefficient nonnegativity",
+      "le_natDegree_of_ne_zero",
+      "positivity"
+    ],
+    "prerequisites": [
+      "coeff_sq_two",
+      "Polynomial.natDegree_add_le",
+      "Polynomial.le_natDegree_of_ne_zero"
+    ]
+  },
+  {
+    "id": "ann-hilbert17-oq010101-structural",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 101,
+      "endLine": 122
+    },
+    "type": "insight",
+    "title": "Even Degree and Positive Leading Coefficient",
+    "content": "Two structural corollaries any nonzero PSD univariate polynomial must satisfy. IsPSD.natDegree_even: from p = u² + v² and no-collapse, deg p = 2·max(deg u, deg v) is manifestly even. IsPSD.leadingCoeff_pos: at n = ½·deg p the leading coefficient is p.coeff(2n) = (u.coeff n)² + (v.coeff n)² by coeff_sq_two — simultaneously ≥ 0 (a sum of squares, via positivity) and ≠ 0 (because p ≠ 0 has nonzero leading coefficient), hence strictly positive. These are the classical necessary conditions for nonnegativity (a polynomial dipping to −∞ or with odd degree cannot be PSD), here derived directly from the certificate rather than from analysis.",
+    "mathContext": "$\\deg p = 2\\max(\\deg u,\\deg v)$ is even; $\\operatorname{lc} p = (u_n)^2 + (v_n)^2 \\ge 0$ and $\\neq 0$, so $\\operatorname{lc} p > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positive semidefinite polynomial",
+      "even degree",
+      "leading coefficient",
+      "necessary conditions for nonnegativity"
+    ],
+    "prerequisites": [
+      "natDegree_sq_add_sq",
+      "coeff_sq_two",
+      "leadingCoeff_ne_zero"
+    ]
+  },
+  {
+    "id": "ann-hilbert17-oq010101-rotation",
+    "proofId": "hilbert-17-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 124,
+      "endLine": 202
+    },
+    "type": "insight",
+    "title": "The Exact Normalization via an Orthogonal Rotation",
+    "content": "univariate_psd_two_sos_degree_exact answers the parent's open question: for p ≠ 0 there is p = u² + v² with deg v < deg u and 2·deg u = deg p. Starting from any decomposition p = a² + b², set n = max(deg a, deg b), la = a.coeff n, lb = b.coeff n, and r = √(la² + lb²) > 0 (positive because it is the leading coefficient of p). The rotation u = C(la/r)·a + C(lb/r)·b, v = C(la/r)·b − C(lb/r)·a with c = la/r, s = lb/r satisfies c² + s² = 1, so u² + v² = (c²+s²)(a²+b²) = p (proved by linear_combination against (C c)²+(C s)² = 1). By design u.coeff n = (c·la + s·lb) = r ≠ 0 (so deg u = n) while v.coeff n = c·lb − s·la = 0 (so deg v < n). This is exactly the geometric heart of Fejér–Riesz: rotating (a,b) in the plane preserves a²+b² and the angle tan θ = lb/la annihilates the top coefficient of the second square.",
+    "mathContext": "$(u,v) = (ca+sb,\\; cb-sa)$, $c^2+s^2=1$, $r=\\sqrt{l_a^2+l_b^2}$; $u_n = c l_a + s l_b = r \\neq 0$, $v_n = c l_b - s l_a = 0$, and $u^2+v^2 = (c^2+s^2)(a^2+b^2) = p$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "orthogonal rotation",
+      "Fejér–Riesz factorization",
+      "invariance of a²+b²",
+      "constructive proof",
+      "real square root"
+    ],
+    "prerequisites": [
+      "IsPSD.leadingCoeff_pos",
+      "Real.sq_sqrt / Real.sqrt_pos",
+      "Polynomial.coeff_C_mul",
+      "linear_combination"
+    ]
+  }
+]

--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
@@ -171,6 +171,13 @@
   "crossReferences": [],
   "sections": [
     {
+      "id": "header",
+      "title": "Module header, imports, and the structural idea",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Docstring framing the sharpening: the parent's symmetric upper bound 2·deg u, 2·deg v ≤ deg p versus the exact certificate pinned down here via the no-collapse fact deg(u²+v²) = 2·max(deg u, deg v). Imports Mathlib and the parent file Proofs.Hilbert17OQ01OQ01, opens Polynomial, and brings in the parent's IsPSD predicate."
+    },
+    {
       "id": "coeff-engine",
       "title": "Reading the leading data of a square",
       "startLine": 39,


### PR DESCRIPTION
Enrichment pass for `hilbert-17-oq-01-oq-01-oq-01` (quality 43 → 100).

**Gaps addressed:**
- annotations 0→25 (+ mathContext 10, significance 10, crossRefs 10): created annotations.json with 5 annotations tracing the proof — the structural no-collapse idea, the `coeff_sq_two` diagonal-coefficient engine, `natDegree_sq_add_sq` (no degree collapse), the even-degree/positive-leading-coefficient corollaries, and the exact Fejér–Riesz normalization via an explicit orthogonal rotation. Each has mathContext (LaTeX), significance, relatedConcepts, prerequisites.
- sections 8→10: added a header section so sections cover the full 203-line file.

meta.json 16.6 KB (under cap). `pnpm build` passes. No changes to Lean source or status/axiom fields (remains verified, 0 axioms).