### PR TITLE
Enrich Erdős #100 ℝ⁴ integer 4-simplex (OQ-05-OQ-01-OQ-01)

### DIFF
--- a/src/data/proofs/erdos-100-oq-05-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-100-oq-05-oq-01-oq-01/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "ann-e100-oq050101-vertices",
+    "proofId": "erdos-100-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 64
+    },
+    "type": "concept",
+    "title": "The five integer-coordinate vertices in ℝ⁴",
+    "content": "The 4-simplex is fixed by five explicit points P₀=(0,0,0,0), P₁=(0,2,4,4), P₂=(4,1,0,8), P₃=(8,4,0,8), P₄=(12,9,8,0), each an EuclideanSpace ℝ (Fin 4) literal !₂[a,b,c,d]. With P₀ at the origin, the four edge vectors out of P₀ are just P₁, P₂, P₃, P₄, which is exactly the matrix whose determinant later certifies full 4-dimensionality. The coordinates were found by computer search so that all ten pairwise squared-distance sums are perfect squares.",
+    "mathContext": "$P_0=(0,0,0,0),\\ P_1=(0,2,4,4),\\ P_2=(4,1,0,8),\\ P_3=(8,4,0,8),\\ P_4=(12,9,8,0)\\in\\mathbb{Z}^4.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Integer-coordinate (lattice) point sets",
+      "EuclideanSpace ℝ (Fin n) and !₂[...] literals",
+      "Perfect (integer-distance) simplices",
+      "Anchoring a vertex at the origin to expose edge vectors"
+    ]
+  },
+  {
+    "id": "ann-e100-oq050101-distcompute",
+    "proofId": "erdos-100-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 136
+    },
+    "type": "theorem",
+    "title": "Each of the ten distances is an integer via √(perfect square)",
+    "content": "The ten theorems dist_P0_P1 … dist_P3_P4 all share one pattern: EuclideanSpace.dist_eq rewrites the distance as √(∑_{i<4} |xᵢ−yᵢ|²), Fin.sum_univ_four plus cons-vector simp lemmas (through cons_val_three) evaluate the four coordinate differences, the sum of squares is rewritten to a single k² by norm_num (e.g. 144+81+64+0 = 289 = 17²), and Real.sqrt_sq closes it to the integer k. The four-coordinate version differs from the ℝ³ parent only in carrying an extra squared term.",
+    "mathContext": "$\\mathrm{dist}(x,y)=\\sqrt{\\textstyle\\sum_{i<4}|x_i-y_i|^2};\\quad |P_0P_4|=\\sqrt{12^2+9^2+8^2+0^2}=\\sqrt{289}=17.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euclidean distance formula (EuclideanSpace.dist_eq)",
+      "Real.sqrt_sq for integer square roots",
+      "Sums of four squares equal to a perfect square",
+      "Fin.sum_univ_four coordinate expansion"
+    ]
+  },
+  {
+    "id": "ann-e100-oq050101-alldist",
+    "proofId": "erdos-100-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 138,
+      "endLine": 144
+    },
+    "type": "theorem",
+    "title": "All ten distances are the distinct integers {5,…,17}",
+    "content": "all_distances_integer bundles the ten computations: the pairwise distances are 6, 9, 12, 17, 7, 10, 15, 5, 16, 13 — the ten distinct integers {5,6,7,9,10,12,13,15,16,17}. This certifies the configuration is an integer-distance (perfect) 4-simplex. Unlike the ℝ³ parent, the edges are not consecutive (8, 11, and 14 are skipped) and no minimality is claimed — this is one explicit witness, not the smallest.",
+    "mathContext": "$\\{|P_iP_j|\\}=\\{5,6,7,9,10,12,13,15,16,17\\}\\subset\\mathbb{Z}_{>0}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Integer-distance point sets",
+      "Perfect 4-simplices",
+      "Distinct (non-consecutive) integer edge lengths",
+      "Computer-search witnesses without minimality"
+    ]
+  },
+  {
+    "id": "ann-e100-oq050101-distinct",
+    "proofId": "erdos-100-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 151,
+      "endLine": 175
+    },
+    "type": "insight",
+    "title": "Distinctness three ways: set equality, card = 10, and Nodup",
+    "content": "The restricted-distance hypothesis of Erdős #100 — all pairwise distances distinct — is recorded in three equivalent forms. distance_set_eq identifies the Finset of ten distances with {5,6,7,9,10,12,13,15,16,17} after rewriting each distance to its numeral. distances_card_ten then reads off that this Finset has cardinality exactly 10, i.e. no two edges coincide. distances_nodup gives the same fact as a List.Nodup certificate. Redundant phrasings make the entry convenient to cite regardless of which distinctness formulation a downstream result needs.",
+    "mathContext": "$\\#\\{|P_iP_j|\\}=10 \\iff \\text{all }\\binom{5}{2}=10\\text{ edges have distinct lengths}.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Distinct-distance (restricted-distance) hypothesis of Erdős #100",
+      "Finset cardinality as a distinctness certificate",
+      "List.Nodup",
+      "Equivalent encodings of the same combinatorial fact"
+    ]
+  },
+  {
+    "id": "ann-e100-oq050101-vdistinct",
+    "proofId": "erdos-100-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 177,
+      "endLine": 194
+    },
+    "type": "theorem",
+    "title": "The five vertices are pairwise distinct",
+    "content": "vertices_distinct establishes that all ten pairs of vertices differ. The proof is uniform: if two vertices coincided, dist_self would force their distance to 0, contradicting the positive integer value already computed for that pair. The first combinator tries each of the ten distance lemmas until one closes the goal. Distinctness of the vertices is a prerequisite for treating the five points as a genuine 4-simplex rather than a degenerate multiset.",
+    "mathContext": "$P_i=P_j\\Rightarrow \\mathrm{dist}(P_i,P_j)=0,\\ \\text{contradicting } \\mathrm{dist}(P_i,P_j)\\ge 5.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "dist_self and the identity of indiscernibles",
+      "Recovering distinct points from positive distances",
+      "Vertices of a non-degenerate simplex",
+      "Uniform tactic combinators (first | …)"
+    ]
+  },
+  {
+    "id": "ann-e100-oq050101-nondegen",
+    "proofId": "erdos-100-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 205,
+      "endLine": 232
+    },
+    "type": "insight",
+    "title": "Non-degeneracy in ℝ⁴: a 4×4 determinant without det_fin_four",
+    "content": "edgeMatrix is the 4×4 matrix whose rows are the edge vectors v₁=(0,2,4,4), v₂=(4,1,0,8), v₃=(8,4,0,8), v₄=(12,9,8,0) out of P₀. Because Mathlib provides a closed determinant form only up to 3×3, edgeMatrix_det expands the top row via Matrix.det_succ_row_zero + Fin.sum_univ_four, producing four signed 3×3 minors each evaluated by Matrix.det_fin_three; the Fin.succAbove index shuffles are resolved by simp and norm_num yields det = −768. Since −768 ≠ 0, Matrix.linearIndependent_rows_of_det_ne_zero gives edges_linearIndependent: the four edges are linearly independent, so the five points are affinely independent and span ℝ⁴, lying in no hyperplane. This top-row-cofactor pattern is a reusable recipe for explicit 4×4 real determinants.",
+    "mathContext": "$\\det\\!\\begin{pmatrix}0&2&4&4\\\\4&1&0&8\\\\8&4&0&8\\\\12&9&8&0\\end{pmatrix}=-768\\neq0\\ \\Rightarrow\\ \\text{affinely independent, spans }\\mathbb{R}^4.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cofactor (Laplace) expansion (Matrix.det_succ_row_zero)",
+      "Matrix.det_fin_three minors and Fin.succAbove indexing",
+      "det ≠ 0 ⇒ linear independence of rows",
+      "Affine independence / full-dimensional simplices"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-100-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-05-oq-01-oq-01/meta.json
@@ -87,7 +87,8 @@
       "**The construction climbs dimensions.** Extending from the ℝ³ tetrahedron (6 distinct-integer edges) to an ℝ⁴ 4-simplex (10 distinct-integer edges) shows the distinct-integer-distance phenomenon of Erdős #100 is not special to low dimension — it persists, answering OQ-05 on the existence side",
       "**Off-hyperplane placement is the recipe.** A new full-dimensional vertex is obtained by placing a point off the current hyperplane at integer distance from every existing vertex; the same idea evidently continues into higher dimensions",
       "**Distances are perfect-square roots.** Choosing integer coordinates whose squared coordinate differences sum to a perfect square makes each distance a provable integer via Real.sqrt_sq",
-      "**No det_fin_four in Mathlib.** Non-degeneracy of the 4×4 edge matrix is obtained by one top-row cofactor expansion (Matrix.det_succ_row_zero) reducing to four Matrix.det_fin_three minors — a reusable pattern for explicit 4×4 real determinants"
+      "**No det_fin_four in Mathlib.** Non-degeneracy of the 4×4 edge matrix is obtained by one top-row cofactor expansion (Matrix.det_succ_row_zero) reducing to four Matrix.det_fin_three minors — a reusable pattern for explicit 4×4 real determinants",
+      "**Distinctness recorded three ways.** The all-distinct hypothesis is certified redundantly as a Finset equality {5,…,17}, a card = 10 count, and a List.Nodup fact; the three encodings make the witness convenient to cite whichever distinctness form a downstream diameter estimate happens to need, without re-deriving it"
     ],
     "prerequisites": [
       "Euclidean distance in EuclideanSpace ℝ (Fin n) and the formula dist = √(Σ coordinate differences²)",


### PR DESCRIPTION
Enrichment pass for `erdos-100-oq-05-oq-01-oq-01`.

**Quality: 43 → 100**

- Created `annotations.json` (previously missing — the dominant gap) with 6 annotations, each carrying `mathContext` (LaTeX), `significance`, and `relatedConcepts`: the five vertices, the ten √(perfect-square) distance computations, `all_distances_integer`, the threefold distinctness (set equality / card = 10 / Nodup), vertex-distinctness, and the 4×4 top-row-cofactor determinant (−768) non-degeneracy certificate. Line ranges verified against the Lean source.
- Added a 5th `keyInsight` on the redundant distinctness encodings.
- meta.json ~18.8 KB → 19.2 KB, well under the ~60 KB cap.
- `pnpm build` passes.