### PR TITLE
Fix: realign stale meta counts for alternating-series-boole-summation

### DIFF
--- a/src/data/proofs/alternating-series-boole-summation/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation/meta.json
@@ -52,8 +52,8 @@
     ],
     "axiomCount": 0,
     "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
-    "lineCount": 230,
-    "theoremCount": 13,
+    "lineCount": 302,
+    "theoremCount": 19,
     "definitionCount": 2
   },
   "overview": {


### PR DESCRIPTION
## Gallery integrity fix

**Proof**: alternating-series-boole-summation

The `meta` sub-block reported `lineCount: 230` / `theoremCount: 13`, but the Lean file `Proofs/AlternatingSeriesBooleSummation.lean` is actually **302 lines / 19 theorems** (matching the already-correct `leanFile` block). The entry grew across sessions and the meta counts were never regenerated.

## Verification
- `wc -l` = 302 (was 230)
- `grep -cE '^\\s*(theorem|lemma) '` = 19 (was 13)
- definitionCount = 2 (unchanged, correct)
- 0 sorries, 0 axiom declarations, no `native_decide` — status `verified` / badge `original` remain accurate

Integrity claims are all correct; only the stale counts are realigned.

---
Discovered during gallery integrity audit.