### PR TITLE
Fix: realign stale counts for prob-method-lovasz-local

### DIFF
--- a/src/data/proofs/prob-method-lovasz-local/meta.json
+++ b/src/data/proofs/prob-method-lovasz-local/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 364,
+    "lineCount": 471,
     "prerequisites": [
       "Probabilistic method and independence of events",
       "Dependency graphs and near-independence",
@@ -53,8 +53,8 @@
     ],
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
-    "definitionCount": 3,
+    "theoremCount": 27,
+    "definitionCount": 2,
     "additionalFiles": [
       "Proofs/MoserTardos.lean"
     ]
@@ -215,10 +215,10 @@
     ],
     "opens": [],
     "namespace": "ProbMethod.LovaszLocal",
-    "lineCount": 364,
+    "lineCount": 471,
     "axiomCount": 0,
-    "theoremCount": 25,
-    "definitionCount": 3,
+    "theoremCount": 27,
+    "definitionCount": 2,
     "path": "Proofs/LovaszLocalLemma.lean",
     "sorries": 0,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

`LovaszLocalLemma.lean` grew from 364 to 471 lines (PR #30919 added threshold monotonicity), but the gallery `meta.json` counts were never regenerated — leaving stale `lineCount`, `theoremCount`, and `definitionCount` in both the meta-level and `leanFile` blocks.

## Evidence

Canonical regex counts (matching `scripts/research/enrich-research.ts`) on `proofs/Proofs/LovaszLocalLemma.lean`:

| Field | Before | After (actual) |
|-------|--------|--------|
| lineCount | 364 | 471 |
| theoremCount | 25 | 27 |
| definitionCount | 3 | 2 |
| axiomCount | 0 | 0 (unchanged) |
| sorries | 0 | 0 (unchanged) |

`definitionCount` uses the canonical `/^(def|noncomputable def|opaque def) /` convention (2 matches: `lllThreshold`, `HasMaxDegree`). Entry remains verified / 0-axiom. No Lean source changes.

---
Automated fix by lean-mechanic agent.