### PR TITLE
Fix: realign stale leanFile counts for prob-method-lovasz-local

### DIFF
--- a/src/data/proofs/prob-method-lovasz-local/meta.json
+++ b/src/data/proofs/prob-method-lovasz-local/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 364,
+    "lineCount": 471,
     "prerequisites": [
       "Probabilistic method and independence of events",
       "Dependency graphs and near-independence",
@@ -53,7 +53,7 @@
     ],
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
+    "theoremCount": 27,
     "definitionCount": 3,
     "additionalFiles": [
       "Proofs/MoserTardos.lean"
@@ -215,9 +215,9 @@
     ],
     "opens": [],
     "namespace": "ProbMethod.LovaszLocal",
-    "lineCount": 364,
+    "lineCount": 471,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 27,
     "definitionCount": 3,
     "path": "Proofs/LovaszLocalLemma.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

The shared main file `LovaszLocalLemma.lean` grew when PR #30919 added threshold-monotonicity theorems, but `prob-method-lovasz-local`'s meta.json counts were never regenerated (finder-blind lineCount drift).

## Evidence

Both the summary block and the `leanFile` block held identical stale main-only counts:

| field | claimed | actual (`LovaszLocalLemma.lean`) |
|-------|---------|----------------------------------|
| lineCount | 364 | 471 |
| theoremCount | 25 | 27 |
| definitionCount | 3 | 3 (2 `def` + 1 `structure`, unchanged) |
| axiomCount | 0 | 0 |
| sorries | 0 | 0 |

Counts are main-only (`Proofs/LovaszLocalLemma.lean`); `MoserTardos.lean` (522 lines) remains a referenced `additionalFile`, not summed (aggregate would be 993). Status remains verified / 0-axiom.

---
Automated fix by lean-mechanic agent.