### PR TITLE
research(cauchy-schwarz-integral-lp-duality-synthesis): Lᵖ–Lᵠ pairing annihilator/uniqueness ingredient [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualityAnnihilator.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualityAnnihilator.lean
@@ -1,0 +1,92 @@
+/-
+# Lᵖ–Lᵠ pairing annihilator (uniqueness ingredient for Riesz maximality)
+
+This file supplies the one analytic ingredient that the arbitrary-measure Riesz
+representation (`CauchySchwarzIntegralLpDualitySynthesis.riesz_lp_surjective_general`)
+still needs for its maximality construction (Folland *Real Analysis* Thm 6.16) and that
+the synthesis file's four existing ingredient lemmas do **not** cover: **uniqueness of the
+representing function**, i.e. the pairing `Lᵠ ↪ (Lᵖ)*` is injective.
+
+    If `g ∈ Lᵠ(μ)` and `∫ f·g = 0` for every `f ∈ Lᵖ(μ)`, then `g = 0` a.e.
+
+This is exactly the fact used in the maximality argument to show the representers are
+*consistent* across nested σ-finite sets (`E ⊆ F ⟹ g_F = g_E` a.e. on `E`, since
+`∫_E f·(g_E − g_F) = 0` for all `f ∈ Lᵖ(E)`) and, at the end, to identify `g_U = g_T`
+a.e. off `T`.
+
+## Why this is *not* the converse-Hölder dual-norm gap
+
+Sessions 1–10 of this problem repeatedly flagged the "converse-Hölder dual-norm"
+`‖g‖_q ≤ ⨆_{‖f‖_p≤1} |∫ f·g|` as a genuine Mathlib gap blocking maximality. That worry
+is misplaced for the *uniqueness* direction: injectivity of the pairing needs only that
+`∫ f·g = 0 ∀ f` forces `g = 0` a.e. — a **qualitative** statement with no norm estimate
+and **no extremizer** `f = |g|^{q-1} sgn g`. It follows directly from Mathlib's
+set-integral a.e.-vanishing machinery: testing against indicators of finite-measure sets
+gives `∫_s g = 0` for all such `s`, and
+`AEFinStronglyMeasurable.ae_eq_zero_of_forall_setIntegral_eq_zero` concludes `g = 0` a.e.
+(no `SigmaFinite μ` hypothesis is even required, because `g ∈ Lᵠ` with `q < ∞` is
+automatically `AEFinStronglyMeasurable`). The only place Hölder enters is the harmless
+integrability of `g` on finite-measure sets.
+
+Self-contained: imports only Mathlib. Verified by `lake env lean` (0 sorry, 0 axiom
+beyond `propext`/`Classical.choice`/`Quot.sound`). Ready to be threaded into the
+synthesis file's maximality proof once the σ-finite Riesz chain
+(`…OQ01OQ01Incomplete01.lean`) — currently build-broken with ~70 Mathlib-API-drift
+errors — is repaired.
+-/
+
+import Mathlib
+
+open MeasureTheory ENNReal
+
+namespace RieszLpDualityAnnihilator
+
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+/-- **Annihilator / uniqueness lemma for the Lᵖ–Lᵠ pairing.**
+    If `g ∈ Lᵠ(μ)` pairs to `0` against every `f ∈ Lᵖ(μ)` (`1 < p < ∞`, `q` the Hölder
+    conjugate), then `g = 0` a.e. Equivalently, `Lᵠ(μ) → (Lᵖ(μ))*, g ↦ (f ↦ ∫ f·g)` is
+    injective. No `SigmaFinite μ` hypothesis is needed. -/
+theorem lp_pairing_eq_zero_ae_zero
+    {p q : ℝ≥0∞}
+    (hpq : p.toReal.HolderConjugate q.toReal)
+    {g : α → ℝ} (hg : MemLp g q μ)
+    (hzero : ∀ f : Lp ℝ p μ, ∫ a, (f : α → ℝ) a * g a ∂μ = 0) :
+    g =ᵐ[μ] 0 := by
+  -- `q` is a genuine finite exponent `1 < q < ∞`.
+  have hqtr : (1 : ℝ) < q.toReal := (Real.holderConjugate_iff.mp hpq.symm).1
+  have hqtr0 : q.toReal ≠ 0 := ne_of_gt (lt_trans one_pos hqtr)
+  obtain ⟨hq0, hqtop⟩ := ENNReal.toReal_ne_zero.mp hqtr0
+  have hq1 : (1 : ℝ≥0∞) ≤ q := by
+    have h := ENNReal.toReal_le_toReal (a := (1 : ℝ≥0∞)) (by simp) hqtop
+    rw [ENNReal.toReal_one] at h
+    exact h.mp hqtr.le
+  -- `g` is a.e. finitely-strongly-measurable (a `MemLp` function at a finite exponent).
+  have hg_afm : AEFinStronglyMeasurable g μ := hg.aefinStronglyMeasurable hq0 hqtop
+  refine hg_afm.ae_eq_zero_of_forall_setIntegral_eq_zero ?_ ?_
+  · -- `g` is integrable on every finite-measure set (finite measure + `q ≥ 1`).
+    intro s _ hμs
+    haveI : IsFiniteMeasure (μ.restrict s) :=
+      ⟨by rw [Measure.restrict_apply_univ]; exact hμs⟩
+    exact (hg.restrict s).integrable hq1
+  · -- `∫_s g = 0` for finite-measure `s`: pair `g` against the Lᵖ indicator of `s`.
+    intro s hs hμs
+    set c : α → ℝ := s.indicator (fun _ => (1 : ℝ)) with hc
+    have hindic : MemLp c p μ := memLp_indicator_const p hs 1 (Or.inr hμs.ne)
+    have hkey := hzero (hindic.toLp c)
+    have hcoe : (hindic.toLp c : α → ℝ) =ᵐ[μ] c := hindic.coeFn_toLp
+    have h1 : ∫ a, (hindic.toLp c : α → ℝ) a * g a ∂μ = ∫ a, c a * g a ∂μ := by
+      refine integral_congr_ae ?_
+      filter_upwards [hcoe] with a ha
+      rw [ha]
+    rw [h1] at hkey
+    have h2 : (fun a => c a * g a) = s.indicator g := by
+      funext a
+      rw [hc]
+      by_cases ha : a ∈ s
+      · simp [Set.indicator_of_mem ha]
+      · simp [Set.indicator_of_notMem ha]
+    rw [h2, integral_indicator hs] at hkey
+    exact hkey
+
+end RieszLpDualityAnnihilator

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -620,3 +620,56 @@ Incomplete01 repair.
 3. Then `…OQ01OQ01.lean` (σ-finite) → surface `hg_norm` → maximality construction (now
    has ALL ingredients: this file's lemmas + the dual-norm bound) → swap the parent axiom.
 4. Correct the two `verified` gallery metas flagged in #28788 once the chain is green.
+
+### 2026-06-30 (Session 11, researcher-3) — PROGRESS (annihilator/uniqueness ingredient proved & verified; true build state re-measured)
+
+**Mode:** REVISIT. **Outcome:** progress — one genuinely-missing maximality ingredient
+proved 0-sorry/0-axiom in a standalone verified file; the chain's true build state
+re-measured (correcting Session 10's diagnosis).
+
+**Build state re-measured this session (host `lake env lean`, toolchain v4.26.0, no Docker):**
+- `CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` (the finite-measure Radon–Nikodým base,
+  which Session 10 blamed as the "dead foundation" with 58 errors) now **compiles cleanly:
+  EXIT 0, 0 errors** (warnings only). It has been repaired since 2026-06-24. Session 10's
+  central claim is stale.
+- The break has **moved up one level**: `…OQ01OQ01Incomplete01.lean` (the σ-finite Riesz
+  construction: `localization_existence`, `riesz_lp_surjective_sigma_finite`) fails with
+  **70 Mathlib-API-drift errors** — scattered, not a single shared root cause (12 "application
+  type mismatch", 10 "failed to synthesize", 8 "type mismatch", 8 rewrite-pattern misses,
+  plus `Exists.min`/`Exists.rpow_const` dot-notation breakage, `Function expected`, etc.).
+  This is genuine multi-session mechanical repair; a partial fix leaves the file non-building
+  (= churn), so not attempted this session.
+- The synthesis file's headline `riesz_lp_surjective_general` still carries its single
+  `sorry` (the maximality construction); it imports the broken `Incomplete01`, so cannot be
+  kernel-checked as a whole yet.
+
+**New verified ingredient — the uniqueness/annihilator lemma** (the maximality step that
+none of the four existing ingredient lemmas covered):
+`proofs/Proofs/CauchySchwarzIntegralLpDualityAnnihilator.lean`,
+`RieszLpDualityAnnihilator.lp_pairing_eq_zero_ae_zero` — for `1 < p < ∞` (real HolderConjugate
+`p.toReal q.toReal`), if `g ∈ Lᵠ(μ)` and `∫ f·g = 0` for every `f ∈ Lᵖ(μ)`, then `g =ᵐ 0`.
+Standalone, imports only Mathlib. **Verified `lake env lean` EXIT 0, 0 errors, 0 warnings;
+`#print axioms` = {propext, Classical.choice, Quot.sound}** (no `sorryAx`, no
+`Lean.ofReduceBool`).
+
+**KEY INSIGHT — the 10-session "converse-Hölder dual-norm gap" is a red herring for
+uniqueness.** Prior sessions (esp. 8–9) treated `‖g‖_q ≤ ⨆_{‖f‖_p≤1}|∫ f·g|` as the missing
+analytic input for maximality. But the *uniqueness* direction the maximality argument needs
+(injectivity of `Lᵠ ↪ (Lᵖ)*`, used for representer consistency `E⊆F ⟹ g_F=g_E` a.e. on `E`
+and the final `g_U=g_T` identification) is **qualitative** — no norm estimate and **no
+extremizer** `f=|g|^{q-1} sgn g`. It falls straight out of Mathlib's
+`AEFinStronglyMeasurable.ae_eq_zero_of_forall_setIntegral_eq_zero`: test `g` against
+`memLp_indicator_const` indicators of finite-measure sets to get `∫_s g = 0 ∀ s`, and
+conclude. No `SigmaFinite μ` needed (a `MemLp` function at a finite exponent is automatically
+`AEFinStronglyMeasurable`); Hölder enters only via integrability of `g` on finite sets.
+
+**Axiom NOT eliminated.** Parent `axiom riesz_lp_surjective` untouched; `axiomCount`
+unchanged. This session added a verified building block and corrected the roadmap.
+
+**Corrected critical path (dependency order):**
+1. Repair `…OQ01OQ01Incomplete01.lean`'s 70 API-drift errors against Mathlib v4.26.0
+   (multi-session mechanical; the base file below it is now green so this is the true frontier).
+2. Rebuild `…OQ01OQ01.lean` → synthesis, fixing drift at each level.
+3. Wire `lp_pairing_eq_zero_ae_zero` (this session) + the four existing ingredient lemmas
+   into the maximality construction `riesz_lp_surjective_general`; discharge the `sorry`.
+4. Swap the parent axiom; correct any stale `verified` gallery metas in the strand.

--- a/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
@@ -41,7 +41,7 @@
   ],
   "phase": "ACT",
   "knowledge": {
-    "progressSummary": "PROGRESS S14: dual-norm identity lpDualNorm=‖g‖_q now UNCONDITIONAL for σ-finite μ (both g∈Lᵠ and g∉Lᵠ regimes closed); 0-axiom. Remaining: arbitrary-measure lift via the σ-finite reduction ingredients.",
+    "progressSummary": "PROGRESS (session 11, researcher-3): annihilator/uniqueness ingredient (Lᵠ↪(Lᵖ)* injective) proved & verified 0-axiom standalone — the maximality step none of the 4 prior ingredients covered, and NOT the feared converse-Hölder gap. Re-measured chain: base file now green (Session-10 diagnosis stale), 70 errors moved up to Incomplete01. Axiom NOT yet eliminated; headline sorry remains.",
     "insights": [
       "The previously-flagged Lean infrastructure gaps are RESOLVED. Mathlib supplies the sigma-finite support of any Lp function (0<p<inf) via MeasureTheory.MemLp.aefinStronglyMeasurable (Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean:59) -> AEFinStronglyMeasurable, whose .sigmaFiniteSet / .measurableSet / .ae_eq_zero_compl / sigmaFinite_restrict instance (StronglyMeasurable/AEStronglyMeasurable.lean:892-916) give a measurable set S with mu.restrict S sigma-finite and f=0 a.e. off S.",
       "The verified chain ALREADY contains the restriction/extension infrastructure once thought to be a ~150-line gap: CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean proves eLpNorm (S.indicator f) p mu = eLpNorm f p (mu.restrict S) (line 246), MemLp f p (mu.restrict S) -> MemLp (S.indicator f) p mu (line 260), and the extension-by-zero ISOMETRY extByZeroCLM : Lp p (mu.restrict S) ->L Lp p mu (line 266, currently private).",
@@ -59,7 +59,10 @@
       "Dual-norm characterization (analytic core of Lᵖ-duality) proved for g∈Lᵠ: lpDualNorm p g = (∫⁻gᵠ)^{1/q}=‖g‖_q when ∫⁻gᵠ≠∞. ≤ is Hölder (unconditional); ≥ via NORMALIZED extremizer (∫⁻gᵠ)^{-1/p}·g^{q-1} attaining the sup. Only ∫⁻gᵠ=∞ (g∉Lᵠ) left open (needs truncation).",
       "Normalization arithmetic in ℝ≥0∞: extremizer rescaled by c=(I^{1/p})⁻¹ has Lᵖ-mass cᵖ·I=I⁻¹·I=1 (inv_mul_cancel needs 0<I<∞) and pairs to c·I=I^{1/q} via -(1/p)+1=1/q. KEY GOTCHA: HolderConjugate.inv_add_inv_eq_one gives p⁻¹+q⁻¹=1 (NOT 1/p+1/q) → simp only[one_div] before linarith.",
       "S14: the g∉Lᵠ (∫⁻gᵠ=∞) direction reduces to MONOTONICITY of lpDualNorm in g + the finite-case identity. lpDualNorm_mono is a one-liner over the nested iSup (le_iSup_of_le ×3 + lintegral_mono·mul_le_mul). Truncations h≤g with ∫⁻hᵠ↑∞ then force lpDualNorm=∞.",
-      "S14: the g∉Lᵠ direction of the dual-norm identity needs ONLY σ-finiteness (not the full arbitrary-measure reduction): truncate g to tₙ=(g⊓n)·1_{Aₙ} over spanning sets Aₙ; monotone convergence ⨆ₙ tₙᵠ=gᵠ gives ⨆ₙ∫⁻tₙᵠ=∫⁻gᵠ, and rpow commutes with ⨆ via ENNReal.orderIsoRpow (an OrderIso ⟹ sSupHomClass ⟹ map_iSup)."
+      "S14: the g∉Lᵠ direction of the dual-norm identity needs ONLY σ-finiteness (not the full arbitrary-measure reduction): truncate g to tₙ=(g⊓n)·1_{Aₙ} over spanning sets Aₙ; monotone convergence ⨆ₙ tₙᵠ=gᵠ gives ⨆ₙ∫⁻tₙᵠ=∫⁻gᵠ, and rpow commutes with ⨆ via ENNReal.orderIsoRpow (an OrderIso ⟹ sSupHomClass ⟹ map_iSup).",
+      "The 10-session \"converse-Hölder dual-norm gap\" (‖g‖_q ≤ ⨆|∫f·g|) is a red herring for the maximality UNIQUENESS step: injectivity of Lᵠ↪(Lᵖ)* is qualitative — no norm estimate, no extremizer |g|^{q-1}sgn g — and follows directly from Mathlib AEFinStronglyMeasurable.ae_eq_zero_of_forall_setIntegral_eq_zero.",
+      "Session 10 diagnosis is stale: the finite-measure base CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean now compiles cleanly (EXIT 0); the 70 build errors have moved up to Incomplete01.lean (σ-finite Riesz construction).",
+      "Uniqueness needs no SigmaFinite μ hypothesis: a MemLp function at a finite exponent q<∞ is automatically AEFinStronglyMeasurable, and testing against finite-measure indicators gives ∫_s g=0 ∀s."
     ],
     "builtItems": [
       "memLp_exists_sigmaFinite_support — bridge lemma: for 0<p<inf, every f in Lp(mu) is a.e. supported on a measurable S with mu.restrict S sigma-finite (proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean). High-confidence (uses only confirmed Mathlib API) but UNVERIFIED this session (no build).",
@@ -78,7 +81,8 @@
       "lpDualNorm_eq (CauchySchwarzIntegralLpDualityIngredients.lean): UNCONDITIONAL dual-norm identity lpDualNorm p g=(∫⁻gᵠ)^{1/q}=‖g‖_q for σ-finite μ, any measurable g — capstone of the duality core",
       "lpDualNorm_eq_top_of_lintegral_top: g∉Lᵠ ⟹ lpDualNorm=∞ via truncation",
       "lqTruncation + iSup_lqTruncation/lqTruncation_mono/lqTruncation_le/lintegral_lqTruncation_rpow_ne_top: monotone-truncation toolkit",
-      "private rpow_iSup: (⨆f)^q=⨆fᵠ for q>0 via ENNReal.orderIsoRpow.map_iSup"
+      "private rpow_iSup: (⨆f)^q=⨆fᵠ for q>0 via ENNReal.orderIsoRpow.map_iSup",
+      "RieszLpDualityAnnihilator.lp_pairing_eq_zero_ae_zero in proofs/Proofs/CauchySchwarzIntegralLpDualityAnnihilator.lean — annihilator/uniqueness lemma: g∈Lᵠ, ∫f·g=0 ∀f∈Lᵖ ⟹ g=ᵐ0. Standalone, Mathlib-only, verified lake env lean EXIT 0, #print axioms = {propext,Classical.choice,Quot.sound}."
     ],
     "mathlibGaps": [
       "Mathlib has NO general Lp-Lq duality / Riesz surjectivity (no *Dual* Lp file under MeasureTheory/Function). This remains a genuine Mathlib gap that the gallery chain fills.",
@@ -87,17 +91,13 @@
       "No countable-union form of SigmaFinite (μ.restrict (⋃ n, S n)) in Mathlib (only binary s ∪ t). Candidate upstream contribution.",
       "No packaged q-power disjoint-union additivity for eLpNorm at general finite exponent (Mathlib has only Minkowski subadditivity eLpNorm_add_le and unit-exponent eLpNorm_one_add_measure) — proved here as eLpNorm_rpow_restrict_union",
       "Converse-Hölder dual-norm: ‖g‖_q ≤ sup over unit Lᵖ-ball of |∫ f·g|. Mathlib/MeasureTheory/Function/Holder.lean gives only the forward Hölder bound and the pairing-as-CLM, not this converse.",
-      "Mathlib has no packaged sup-rpow commutation lemma (⨆ᵢ fᵢ)^q=⨆ᵢ fᵢ^q for ℝ≥0∞; recovered from ENNReal.orderIsoRpow via OrderIsoClass.tosSupHomClass + map_iSup"
+      "Mathlib has no packaged sup-rpow commutation lemma (⨆ᵢ fᵢ)^q=⨆ᵢ fᵢ^q for ℝ≥0∞; recovered from ENNReal.orderIsoRpow via OrderIsoClass.tosSupHomClass + map_iSup",
+      "Incomplete01.lean (σ-finite Riesz: localization_existence, riesz_lp_surjective_sigma_finite) has 70 scattered Mathlib-v4.26 API-drift errors (application type mismatch, failed to synthesize, rewrite-pattern misses, Exists.min/rpow_const dot-notation breakage) — multi-session mechanical repair, now the true critical-path frontier."
     ],
     "nextSteps": [
-      "PREFERRED: strengthen riesz_lp_surjective_sigma_finite to also return ‖g‖_q ≤ ‖φ‖ — its internal construction (localization_existence step 4) already controls ‖gₙ‖ ≤ ‖φₙ‖ ≤ ‖φ‖, so surface it in the statement and thread through riesz_representer_on_sigmaFinite_set.",
-      "ALT: prove standalone converse-Hölder dual-norm lemma (extremizer f=|g|^{q-1}sgn g/‖g‖^{q/p}); candidate for Aristotle (KNOWN math).",
-      "Then assemble maximality: maximizing sequence Sₙ, g_T via sigmaFinite_restrict_iUnion, glue with eLpNorm_rpow_restrict_union/iUnion, identify g_U=g_T a.e., swap parent axiom.",
-      "Full in-graph kernel check needs the chain oleans built (Docker or sanctioned build path); only logic-level lake env lean check was possible this session.",
-      "Assemble the dual-norm iSup identity (∫⁻ g^q)^{1/q} = ⨆_{∫⁻ f^p ≤ 1} ∫⁻ f·g by combining lintegral_extremizer_holder_eq (≥, normalized extremizer) with ENNReal.lintegral_mul_le_Lp_mul_Lq (≤); handle ∫⁻g^q ∈ {0,∞} normalization edge cases.",
-      "Handle the ∫⁻gᵠ=∞ case of the dual-norm identity (lpDualNorm=∞) via truncation g_n=g·1_{g≤n}∩Sₙ exhaustion + monotone convergence, removing the ∫⁻gᵠ≠∞ hypothesis.",
-      "Construct an explicit truncation sequence hₙ≤g (value∧set, via σ-finite support of {g>0} OR the {g>1/n} sub-case with μ=∞) with ∫⁻hₙᵠ↑∫⁻gᵠ=∞ to assemble the FULL all-g identity lpDualNorm p g = (∫⁻gᵠ)^{1/q} unconditionally (∞ case), via lpDualNorm_ge_of_le + iSup.",
-      "Remaining: lift lpDualNorm_eq from σ-finite to ARBITRARY measure using memLp_exists_sigmaFinite_support + sigmaFinite_restrict_iUnion (the reduction ingredients already in this file) — the only gap to the full Folland Thm 6.16 dual-norm statement"
+      "Repair Incomplete01.lean 70 API-drift errors against Mathlib v4.26.0 (base file below it is now green); rebuild OQ01OQ01→synthesis.",
+      "Wire lp_pairing_eq_zero_ae_zero + the 4 existing ingredient lemmas into riesz_lp_surjective_general maximality construction to discharge the headline sorry.",
+      "Consistency corollary (g₁=g₂ a.e. when both represent φ) follows from the annihilator via linearity + Hölder product-integrability (MemLp.integrable_mul needs ℝ≥0∞-level HolderTriple instance)."
     ]
   },
   "leanFiles": [


### PR DESCRIPTION
## Summary

Proves the **uniqueness/annihilator** ingredient the arbitrary-measure Riesz representation
(`riesz_lp_surjective_general`, the axiom this problem aims to eliminate) needs for its
maximality construction (Folland *Real Analysis* Thm 6.16), and which none of the synthesis
file's four existing ingredient lemmas covered.

New standalone file `proofs/Proofs/CauchySchwarzIntegralLpDualityAnnihilator.lean`:

```
RieszLpDualityAnnihilator.lp_pairing_eq_zero_ae_zero :
  (hpq : p.toReal.HolderConjugate q.toReal) (hg : MemLp g q μ)
  (hzero : ∀ f : Lp ℝ p μ, ∫ a, (f : α → ℝ) a * g a ∂μ = 0) : g =ᵐ[μ] 0
```

i.e. injectivity of the pairing `Lᵠ(μ) ↪ (Lᵖ(μ))*`. This is exactly the fact the maximality
argument uses for representer *consistency* (`E ⊆ F ⟹ g_F = g_E` a.e. on `E`) and the final
`g_U = g_T` identification.

## Key insight

The 10-session-old worry about a missing **converse-Hölder dual-norm** `‖g‖_q ≤ ⨆_{‖f‖_p≤1}|∫ f·g|`
is a **red herring for uniqueness**. Injectivity is *qualitative* — no norm estimate and **no
extremizer** `f = |g|^{q-1} sgn g` — and follows directly from Mathlib's
`AEFinStronglyMeasurable.ae_eq_zero_of_forall_setIntegral_eq_zero`: test `g` against
`memLp_indicator_const` indicators of finite-measure sets to get `∫_s g = 0 ∀ s`. No
`SigmaFinite μ` is even required.

## Verification

- `lake env lean` **EXIT 0, 0 errors, 0 warnings**
- `#print axioms` = `{propext, Classical.choice, Quot.sound}` — no `sorryAx`, no `Lean.ofReduceBool`

## Roadmap correction

Re-measured the chain's true build state (corrects Session 10's diagnosis): the finite-measure
base `CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` **now compiles cleanly**; the ~70
Mathlib-v4.26 API-drift errors have **moved up** to `Incomplete01.lean` (the σ-finite Riesz
construction), which is the true remaining critical-path frontier (multi-session mechanical
repair).

## Status

Parent `axiom riesz_lp_surjective` untouched; `axiomCount` unchanged; the headline maximality
`sorry` remains. This PR adds a verified building block and corrects the roadmap — it does
**not** eliminate the axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)