### PR TITLE
Enrich Univariate Hilbert 17 exact normalization (OQ-01-OQ-01-OQ-01)

### DIFF
--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
@@ -192,11 +192,18 @@
       "summary": "natDegree_sq_add_sq: deg(u² + v²) = 2·max(deg u, deg v). A symmetric helper handles the maximal-degree polynomial; the lower bound exhibits a nonzero coefficient (a positive sum of squares) at index 2·max via le_natDegree_of_ne_zero, the upper bound is natDegree_add_le."
     },
     {
-      "id": "structural",
-      "title": "Even degree and positive leading coefficient",
+      "id": "even-degree",
+      "title": "A nonzero PSD polynomial has even degree",
       "startLine": 101,
+      "endLine": 106,
+      "summary": "IsPSD.natDegree_even: from a two-squares decomposition p = u² + v², natDegree_sq_add_sq gives deg p = 2·max(deg u, deg v), which is even — the classical parity fact obtained algebraically."
+    },
+    {
+      "id": "leading-positive",
+      "title": "A nonzero PSD polynomial has positive leading coefficient",
+      "startLine": 108,
       "endLine": 122,
-      "summary": "IsPSD.natDegree_even and IsPSD.leadingCoeff_pos: from a two-squares decomposition, deg p = 2·max is even and leadingCoeff p = (u.coeff n)² + (v.coeff n)² is a nonzero sum of squares, hence positive."
+      "summary": "IsPSD.leadingCoeff_pos: at n = ½·deg p the leading coefficient of p = u² + v² equals (u.coeff n)² + (v.coeff n)² via coeff_sq_two — a sum of squares that is ≥ 0 and nonzero since p ≠ 0, hence strictly positive."
     },
     {
       "id": "exact-normalization",


### PR DESCRIPTION
Enrichment pass for `hilbert-17-oq-01-oq-01-oq-01`.

**Quality: 43 → 100**

- Created `annotations.json` (previously missing — the dominant gap) with 6 annotations, each carrying `mathContext` (LaTeX), `significance`, and `relatedConcepts`: the `coeff_sq_two` engine, the no-collapse identity `deg(u²+v²) = 2·max`, the even-degree and positive-leading-coefficient corollaries, the orthogonal-rotation construction, and the exact-degree conclusion. Line ranges verified against the Lean source.
- Split the `structural` section into `even-degree` and `leading-positive` (4 → 5 sections).
- meta.json ~15.9 KB → 16.5 KB, well under the ~60 KB cap.
- `pnpm build` passes.