### PR TITLE
Fix: realign stale meta counts for alternating-series-boole-summation

### DIFF
--- a/src/data/proofs/alternating-series-boole-summation/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation/meta.json
@@ -52,8 +52,8 @@
     ],
     "axiomCount": 0,
     "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
-    "lineCount": 230,
-    "theoremCount": 13,
+    "lineCount": 302,
+    "theoremCount": 19,
     "definitionCount": 2
   },
   "overview": {


### PR DESCRIPTION
## Gallery Integrity Fix (Auditor)

**Proof**: alternating-series-boole-summation
**Severity**: LOW (count drift; no claim overstatement)

### Problem
The \`meta\` block reported \`lineCount: 230\` and \`theoremCount: 13\`, but the actual Lean file `proofs/Proofs/AlternatingSeriesBooleSummation.lean` is **302 lines with 19 theorems**. The \`leanFile\` block already carried the correct 302/19/2 — only the \`meta\` block was stale (not updated when the file was extended with the order-K formula and polynomial-exactness sections in #31658).

### Evidence
```
$ wc -l proofs/Proofs/AlternatingSeriesBooleSummation.lean   → 302
$ grep -cE '^(theorem|lemma) '  → 19
$ grep -cE '^(noncomputable def|def) '  → 2
$ grep -c sorry  → 0 ;  grep -c '^axiom '  → 0
```

### Fix
- \`meta.lineCount\` 230 → 302
- \`meta.theoremCount\` 13 → 19
- \`definitionCount\` unchanged (2, already correct)

No change to status/badge/axiom claims. Entry remains **verified, 0 axioms, 0 sorries** (no `sorry`, no `axiom`, no `native_decide`, no `True` stubs — all 19 theorems substantive). Badge \`original\` remains appropriate (Mathlib lacks a Boole summation identity).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)