### PR TITLE
Fix: realign stale leanFile/sorry counts for erdos-895

### DIFF
--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -49,8 +49,8 @@
     "lineCount": 544,
     "assumptions": "No axioms. 2 sorries remain: the genuinely-open positive direction `barber_theorem` (Barber's SAT-verified n ≥ 18 result) and its dependent `erdos895_sat_verified`. The previously-listed third sorry, `counterexample_17` over Fin 17, was FALSE under the file's loose additive-triple predicate (Z3 exhaustive UNSAT) and has been replaced by the machine-verified, 0-axiom distinct-vertex counterexample `counterexample_fin18` over Fin 18 (re-exported from the companion `Erdos895CounterexampleFin18.lean`, proven by kernel `decide`).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 18,
-    "definitionCount": 15,
+    "theoremCount": 13,
+    "definitionCount": 13,
     "additionalFiles": [
       "Proofs/Erdos895Aristotle.lean",
       "Proofs/Erdos895ProblemAristotle.lean"
@@ -184,11 +184,11 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 462,
+    "lineCount": 544,
     "axiomCount": 0,
-    "theoremCount": 18,
-    "definitionCount": 14,
-    "sorries": 3,
+    "theoremCount": 13,
+    "definitionCount": 13,
+    "sorries": 2,
     "path": "Proofs/Erdos895Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos895Aristotle.lean",
@@ -212,5 +212,5 @@
       "description": "Related Erdős problem sharing themes: graph-theory, ramsey-theory"
     }
   ],
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

`erdos-895`'s `leanFile` block and top-level `sorries` were stale, and the `meta` block's theorem/definition counts were overstated. Realigned all count fields in `Erdos895Problem.lean` to reality using the canonical `extractLeanMetadata` conventions.

## Evidence

Authoritative counts for `proofs/Proofs/Erdos895Problem.lean`:
- `wc -l` → 544
- `^(theorem|lemma) ` → 13
- `^(def|noncomputable def|opaque def) ` → 13 (the 2 `private def` are excluded by the canonical regex)
- `^axiom ` → 0
- real tactic `sorry` (bare `sorry` lines) → 2 (the `\bsorry\b` raw regex also matches 7 prose mentions of the word in doc comments, which are not proof gaps)

| field | before | after |
|-------|--------|-------|
| `meta.theoremCount` | 18 | 13 |
| `meta.definitionCount` | 15 | 13 |
| `leanFile.lineCount` | 462 | 544 |
| `leanFile.theoremCount` | 18 | 13 |
| `leanFile.definitionCount` | 14 | 13 |
| `leanFile.sorries` | 3 | 2 |
| top-level `sorries` | 3 | 2 |

`meta.lineCount` (544), `meta.sorries` (2), and both `axiomCount` (0) were already correct. The `sorries=2` value matches the curated `meta.sorries` and the `assumptions` prose ("2 sorries remain: `barber_theorem` and its dependent `erdos895_sat_verified`"). Status/badge remain `formalized`/`wip`.

---
Automated fix by lean-mechanic agent.