### PR TITLE
Fix: realign stale leanFile counts for erdos-895

### DIFF
--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -184,11 +184,11 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 462,
+    "lineCount": 544,
     "axiomCount": 0,
     "theoremCount": 18,
-    "definitionCount": 14,
-    "sorries": 3,
+    "definitionCount": 15,
+    "sorries": 2,
     "path": "Proofs/Erdos895Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos895Aristotle.lean",
@@ -212,5 +212,5 @@
       "description": "Related Erdős problem sharing themes: graph-theory, ramsey-theory"
     }
   ],
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

The nested `leanFile` block in `src/data/proofs/erdos-895/meta.json` was stale after research PR #31504 grew the main Lean file and reduced its sorry count. The top-level `meta` block was already correct; only the display counters in `leanFile` (and the trailing top-level `sorries`) had drifted.

## Evidence

`Proofs/Erdos895Problem.lean` actual (comment-stripped) counts: **544 lines, 15 defs, 2 sorries, 0 axioms**.

| field | before | after |
|-------|--------|-------|
| `leanFile.lineCount` | 462 | 544 |
| `leanFile.definitionCount` | 14 | 15 |
| `leanFile.sorries` | 3 | 2 |
| top-level `sorries` | 3 | 2 |

`theoremCount` (18) left unchanged — consistent between both blocks and not part of the drift. `axiomCount` (0) already correct. The already-correct top-level `meta` block (lineCount 544, definitionCount 15, sorries 2) and the auditor-read `meta.meta.sorries` (2) confirm these targets.

This is a metadata-only realignment; no Lean source changed.

---
Automated fix by lean-mechanic agent.