### PR TITLE
research(erdos-100-oq-05-oq-03): equilateral point sets — sharp dimensional bound d+1 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos100OQ05OQ03.lean
+++ b/proofs/Proofs/Erdos100OQ05OQ03.lean
@@ -1,0 +1,203 @@
+/-
+Erdős Problem #100, Open Question 05, follow-up 03:
+Equilateral point sets in ℝ^d — the sharp dimensional bound.
+
+Parent problem (Erdős #100).  For a set A ⊆ ℝ² of n points with all pairwise
+distances positive integers, how large must its diameter be?  The parent
+gallery entry `erdos-100-oq-05` studies the *qualitative* higher-dimensional
+picture (does the problem change in ℝ^d, d ≥ 3?).  Its two existing follow-ups
+look at configurations with MANY distinct distances (explicit Heronian
+simplices) and at the packing lower bound diam ≳ n^{1/d}.
+
+This file studies the OPPOSITE extreme: point sets with a SINGLE distinct
+distance — *equilateral sets* (a.k.a. equidistant sets, the vertex sets of
+regular simplices).  Here the qualitative change with dimension is starkest and
+completely clean.
+
+## Main results
+
+* `affineIndependent_of_equilateral` — in ANY real inner product space, a
+  family of points that is `s`-equilateral (all pairwise distances equal to a
+  fixed `s > 0`) is affinely independent.  This is the non-obvious extremal
+  direction, proved by a short elementary inner-product argument (no Gram-matrix
+  positive-definiteness machinery required).
+
+* `equilateral_card_le_finrank_succ` — consequently, in a finite-dimensional
+  real inner product space `E`, an equilateral set has at most
+  `finrank ℝ E + 1` points.
+
+* `equilateral_card_le_euclidean` — specialised to `EuclideanSpace ℝ (Fin d)`:
+  an equilateral set has at most `d + 1` points.
+
+* `equilateral_plane_card_le_three` — the planar (`d = 2`) case: at most `3`
+  mutually equidistant points in ℝ² (the equilateral triangle is maximal).
+
+* `stdSimplex_equilateral` / `exists_large_equilateral` — the `n` standard basis
+  vectors of `EuclideanSpace ℝ (Fin n)` form an equilateral (distance `√2`),
+  affinely independent set of `n` points.  Hence equilateral sets of size `n`
+  exist in dimension `n` for every `n`.
+
+## Qualitative answer to OQ-05
+
+The maximum size of an equilateral set in `EuclideanSpace ℝ (Fin d)` lies in
+`{d, d+1}` (lower bound `d` from the basis above; upper bound `d+1`).  In
+particular it GROWS WITHOUT BOUND with the dimension.  This is a genuine
+qualitative change from the plane, where at most `3` points can be mutually
+equidistant.  Unlike the packing / distinct-distance phenomena, the equilateral
+bound is dimension-free in statement and sharp up to the additive `±1`.
+
+All results are fully verified, self-contained, and axiom-free.
+-/
+import Mathlib
+
+open Finset
+open scoped RealInnerProductSpace
+
+namespace Erdos100OQ05Equilateral
+
+/-- A family of points `p : ι → E` is **`s`-equilateral** if every two distinct
+points are at distance exactly `s`. -/
+def Equilateral {ι E : Type*} [PseudoMetricSpace E] (p : ι → E) (s : ℝ) : Prop :=
+  ∀ i j, i ≠ j → dist (p i) (p j) = s
+
+section InnerProduct
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- **Equilateral sets are affinely independent.**
+
+In a real inner product space, if all pairwise distances of a family `p` equal a
+fixed `s > 0`, then `p` is affinely independent.
+
+Proof sketch.  Suppose `∑ w i = 0` and `∑ w i • p i = 0` over a finite index set
+`t`.  For each `j ∈ t`, polarisation together with the two vanishing sums gives
+`∑ i, w i * ‖p i - p j‖² = ∑ i, w i * ‖p i‖²` (call the common value `Q`), while
+the equilateral hypothesis makes the left side `-s² * w j`.  Thus `-s² w j = Q`
+for every `j`; summing this over `t` yields `card t * Q = 0`, so `Q = 0`, whence
+`w j = 0`.  This is exactly the criterion `affineIndependent_iff`. -/
+theorem affineIndependent_of_equilateral {ι : Type*} {p : ι → E} {s : ℝ}
+    (hs : 0 < s) (h : Equilateral p s) : AffineIndependent ℝ p := by
+  classical
+  rw [affineIndependent_iff]
+  intro t w hw hwp e he
+  -- the "energy" that will be forced to vanish
+  set Q : ℝ := ∑ i ∈ t, w i * ‖p i‖ ^ 2 with hQ
+  -- key per-index identity: `-s² * w j = Q` for every `j ∈ t`
+  have key : ∀ j ∈ t, -s ^ 2 * w j = Q := by
+    intro j hj
+    -- cross term ⟪∑ w i • p i, p j⟫ = 0
+    have hcross : ∑ i ∈ t, w i * ⟪p i, p j⟫ = 0 := by
+      have hrw : ⟪∑ i ∈ t, w i • p i, p j⟫ = ∑ i ∈ t, w i * ⟪p i, p j⟫ := by
+        rw [sum_inner]
+        exact Finset.sum_congr rfl (fun i _ => by rw [real_inner_smul_left])
+      rw [hwp, inner_zero_left] at hrw
+      exact hrw.symm
+    -- polarisation identity: LHS = Q
+    have e1 : ∑ i ∈ t, w i * ‖p i - p j‖ ^ 2 = Q := by
+      have hstep : ∑ i ∈ t, w i * ‖p i - p j‖ ^ 2
+          = ∑ i ∈ t, (w i * ‖p i‖ ^ 2 - 2 * (w i * ⟪p i, p j⟫) + w i * ‖p j‖ ^ 2) := by
+        refine Finset.sum_congr rfl (fun i _ => ?_)
+        rw [norm_sub_sq_real]; ring
+      rw [hstep, Finset.sum_add_distrib, Finset.sum_sub_distrib, ← Finset.mul_sum,
+        ← Finset.sum_mul, hcross, hw]
+      simp [hQ]
+    -- equilateral evaluation: LHS = -s² * w j
+    have e2 : ∑ i ∈ t, w i * ‖p i - p j‖ ^ 2 = -s ^ 2 * w j := by
+      rw [← Finset.add_sum_erase t (fun i => w i * ‖p i - p j‖ ^ 2) hj]
+      have hz : w j * ‖p j - p j‖ ^ 2 = 0 := by simp
+      rw [hz, zero_add]
+      have hcongr : ∑ i ∈ t.erase j, w i * ‖p i - p j‖ ^ 2
+          = ∑ i ∈ t.erase j, s ^ 2 * w i := by
+        refine Finset.sum_congr rfl (fun i hi => ?_)
+        have hij : i ≠ j := Finset.ne_of_mem_erase hi
+        have hd : ‖p i - p j‖ = s := by rw [← dist_eq_norm]; exact h i j hij
+        rw [hd]; ring
+      have hwerase : ∑ i ∈ t.erase j, w i = -w j := by
+        have hae := Finset.add_sum_erase t w hj
+        rw [hw] at hae; linarith
+      rw [hcongr, ← Finset.mul_sum, hwerase]; ring
+    -- combine
+    rw [e2] at e1; exact e1
+  -- sum `key` over `t`: `card t * Q = 0`
+  have hsum : ∑ j ∈ t, (-s ^ 2 * w j) = ∑ j ∈ t, Q :=
+    Finset.sum_congr rfl (fun j hj => key j hj)
+  rw [← Finset.mul_sum, hw, mul_zero, Finset.sum_const, nsmul_eq_mul] at hsum
+  -- hsum : 0 = card t * Q
+  have hcard : (0 : ℝ) < (t.card : ℝ) := by
+    exact_mod_cast Finset.card_pos.mpr ⟨e, he⟩
+  have hQ0 : Q = 0 := by
+    rcases mul_eq_zero.mp hsum.symm with hc | hq
+    · exact absurd hc (ne_of_gt hcard)
+    · exact hq
+  -- finally `-s² * w e = Q = 0` forces `w e = 0`
+  have hfin := key e he
+  rw [hQ0] at hfin
+  have hs2 : s ^ 2 ≠ 0 := by positivity
+  have : -s ^ 2 ≠ 0 := by simpa using hs2
+  rcases mul_eq_zero.mp hfin with hne | hwe
+  · exact absurd hne this
+  · exact hwe
+
+/-- **Dimensional upper bound.**  In a finite-dimensional real inner product
+space, an equilateral set has at most `finrank + 1` points. -/
+theorem equilateral_card_le_finrank_succ [FiniteDimensional ℝ E] {ι : Type*}
+    [Fintype ι] {p : ι → E} {s : ℝ} (hs : 0 < s) (h : Equilateral p s) :
+    Fintype.card ι ≤ Module.finrank ℝ E + 1 := by
+  have hai := affineIndependent_of_equilateral hs h
+  calc Fintype.card ι
+      ≤ Module.finrank ℝ (vectorSpan ℝ (Set.range p)) + 1 := hai.card_le_finrank_succ
+    _ ≤ Module.finrank ℝ E + 1 := by gcongr; exact Submodule.finrank_le _
+
+end InnerProduct
+
+section Euclidean
+
+/-- **Equilateral sets in ℝ^d have at most `d + 1` points.** -/
+theorem equilateral_card_le_euclidean {d : ℕ} {ι : Type*} [Fintype ι]
+    {p : ι → EuclideanSpace ℝ (Fin d)} {s : ℝ} (hs : 0 < s) (h : Equilateral p s) :
+    Fintype.card ι ≤ d + 1 := by
+  have hb := equilateral_card_le_finrank_succ hs h
+  rwa [finrank_euclideanSpace_fin] at hb
+
+/-- **Planar case.**  At most three points in the plane can be mutually
+equidistant — the equilateral triangle is the maximal equilateral set. -/
+theorem equilateral_plane_card_le_three {ι : Type*} [Fintype ι]
+    {p : ι → EuclideanSpace ℝ (Fin 2)} {s : ℝ} (hs : 0 < s) (h : Equilateral p s) :
+    Fintype.card ι ≤ 3 :=
+  equilateral_card_le_euclidean hs h
+
+/-- The `n` standard basis vectors of `EuclideanSpace ℝ (Fin n)`. -/
+noncomputable def stdSimplex (n : ℕ) : Fin n → EuclideanSpace ℝ (Fin n) :=
+  fun i => EuclideanSpace.single i (1 : ℝ)
+
+/-- The standard basis vectors are pairwise at distance `√2`: an equilateral set
+of `n` points realising the lower end of the dimensional bound. -/
+theorem stdSimplex_equilateral (n : ℕ) : Equilateral (stdSimplex n) (Real.sqrt 2) := by
+  intro i j hij
+  rw [dist_eq_norm]
+  have h2 : ‖(stdSimplex n i) - stdSimplex n j‖ ^ 2 = 2 := by
+    rw [← real_inner_self_eq_norm_sq]
+    simp only [stdSimplex, inner_sub_left, inner_sub_right,
+      EuclideanSpace.inner_single_left, EuclideanSpace.single_apply, map_one, one_mul]
+    rw [if_neg hij, if_neg (Ne.symm hij)]
+    norm_num
+  rw [← Real.sqrt_sq (norm_nonneg (stdSimplex n i - stdSimplex n j)), h2]
+
+/-- The standard basis vectors are affinely independent (a non-degenerate
+regular simplex), a direct corollary of the equilateral criterion. -/
+theorem stdSimplex_affineIndependent (n : ℕ) :
+    AffineIndependent ℝ (stdSimplex n) :=
+  affineIndependent_of_equilateral (Real.sqrt_pos.mpr (by norm_num)) (stdSimplex_equilateral n)
+
+/-- **Unbounded equilateral sets.**  For every `n`, `EuclideanSpace ℝ (Fin n)`
+contains an equilateral, affinely independent set of `n` points.  Hence the
+maximum equilateral-set size grows without bound with the dimension — the
+qualitative contrast with the plane's bound of `3`. -/
+theorem exists_large_equilateral (n : ℕ) :
+    ∃ p : Fin n → EuclideanSpace ℝ (Fin n),
+      Equilateral p (Real.sqrt 2) ∧ AffineIndependent ℝ p :=
+  ⟨stdSimplex n, stdSimplex_equilateral n, stdSimplex_affineIndependent n⟩
+
+end Euclidean
+
+end Erdos100OQ05Equilateral

--- a/src/data/proofs/erdos-100-oq-05-oq-03/annotations.json
+++ b/src/data/proofs/erdos-100-oq-05-oq-03/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "erdos100-oq05-oq03-ann-header",
+    "proofId": "erdos-100-oq-05-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 55
+    },
+    "type": "concept",
+    "title": "The single-distance extreme of OQ-05",
+    "content": "Erdős #100 asks whether $n$ points in the plane with all pairwise distances positive integers must have diameter $\\gg n$; open question OQ-05 asks whether the picture changes qualitatively in $\\mathbb{R}^d$ for $d \\ge 3$. Two sibling follow-ups study configurations with MANY distinct distances (explicit Heronian simplices) and the packing lower bound $D \\gtrsim n^{1/d}$. This entry takes the OPPOSITE extreme: point sets with a SINGLE distinct distance, the equilateral (equidistant) sets that are the vertex sets of regular simplices. Here the dimensional dependence is cleanest and sharp: the maximum equilateral-set size in $\\mathbb{R}^d$ is $d+1$ (up to an additive $\\pm 1$ in what is formalized), growing without bound, versus the plane's bound of $3$.",
+    "mathContext": "Equilateral / equidistant sets in $\\mathbb{R}^d$; regular simplices.",
+    "significance": "key",
+    "relatedConcepts": [
+      "equilateral sets",
+      "regular simplex",
+      "affine independence",
+      "equilateral dimension"
+    ],
+    "prerequisites": [
+      "Euclidean distance",
+      "inner product spaces",
+      "discrete geometry"
+    ]
+  },
+  {
+    "id": "erdos100-oq05-oq03-ann-def",
+    "proofId": "erdos-100-oq-05-oq-03",
+    "range": {
+      "startLine": 56,
+      "endLine": 62
+    },
+    "type": "definition",
+    "title": "The Equilateral predicate",
+    "content": "$\\texttt{Equilateral}\\;p\\;s$ says every two distinct points of the family $p$ are at distance exactly $s$. When $s > 0$ this forces the points to be distinct, and (as the next theorem shows) affinely independent — so an $s$-equilateral family of $m+1$ points is exactly the vertex set of a regular $m$-simplex of edge length $s$.",
+    "mathContext": "$\\forall i\\,j,\\; i \\ne j \\to \\operatorname{dist}(p_i, p_j) = s$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "equidistant set",
+      "regular simplex edge length"
+    ],
+    "prerequisites": [
+      "pseudometric space"
+    ]
+  },
+  {
+    "id": "erdos100-oq05-oq03-ann-affine",
+    "proofId": "erdos-100-oq-05-oq-03",
+    "range": {
+      "startLine": 63,
+      "endLine": 139
+    },
+    "type": "technique",
+    "title": "Equilateral ⟹ affinely independent, by polarisation",
+    "content": "The extremal theorem, valid in ANY real inner product space. Using the module characterisation $\\texttt{affineIndependent\\_iff}$, assume weights $w$ on a finite set $t$ with $\\sum_i w_i = 0$ and $\\sum_i w_i \\cdot p_i = 0$. For each $j$, polarisation $\\lVert p_i - p_j\\rVert^2 = \\lVert p_i\\rVert^2 - 2\\langle p_i, p_j\\rangle + \\lVert p_j\\rVert^2$ gives $\\sum_i w_i \\lVert p_i - p_j\\rVert^2 = \\sum_i w_i\\lVert p_i\\rVert^2 =: Q$, because the cross term $\\sum_i w_i\\langle p_i, p_j\\rangle = \\langle \\sum_i w_i p_i, p_j\\rangle = \\langle 0, p_j\\rangle = 0$ and $\\lVert p_j\\rVert^2 \\sum_i w_i = 0$. But the equilateral hypothesis makes $\\lVert p_i - p_j\\rVert^2 = s^2$ for $i \\ne j$ and $0$ for $i = j$, so the same sum equals $s^2(\\sum_i w_i - w_j) = -s^2 w_j$. Hence $-s^2 w_j = Q$ for every $j \\in t$. Summing over $t$: $-s^2\\sum_j w_j = |t|\\,Q$, i.e. $0 = |t|\\,Q$, so $Q = 0$; then $-s^2 w_j = 0$ with $s \\ne 0$ forces every $w_j = 0$. No Gram-matrix positive-definiteness is needed.",
+    "mathContext": "$\\langle \\cdot, \\cdot\\rangle$-argument discharging $\\texttt{affineIndependent\\_iff}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polarisation identity",
+      "affineIndependent_iff",
+      "Gram matrix (avoided)",
+      "affine independence"
+    ],
+    "prerequisites": [
+      "inner product linearity",
+      "affine combinations"
+    ]
+  },
+  {
+    "id": "erdos100-oq05-oq03-ann-bound",
+    "proofId": "erdos-100-oq-05-oq-03",
+    "range": {
+      "startLine": 141,
+      "endLine": 167
+    },
+    "type": "theorem",
+    "title": "The sharp d+1 bound and the planar corollary",
+    "content": "Affine independence bounds cardinality: $\\texttt{AffineIndependent.card\\_le\\_finrank\\_succ}$ gives $|\\iota| \\le \\operatorname{finrank}(\\operatorname{vectorSpan}) + 1 \\le \\operatorname{finrank}\\mathbb{R}\\,E + 1$. Specialising through $\\operatorname{finrank}\\,\\mathbb{R}\\,(\\texttt{EuclideanSpace}\\,\\mathbb{R}\\,(\\texttt{Fin}\\,d)) = d$ yields: an equilateral set in $\\mathbb{R}^d$ has at most $d+1$ points. The $d = 2$ case is the classical fact that at most $3$ points in the plane can be mutually equidistant — the equilateral triangle is maximal.",
+    "mathContext": "$\\operatorname{card} \\le d+1$; planar case $\\le 3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "finrank",
+      "vectorSpan",
+      "equilateral dimension",
+      "equilateral triangle"
+    ],
+    "prerequisites": [
+      "finite-dimensional vector spaces",
+      "affine independence"
+    ]
+  },
+  {
+    "id": "erdos100-oq05-oq03-ann-construction",
+    "proofId": "erdos-100-oq-05-oq-03",
+    "range": {
+      "startLine": 169,
+      "endLine": 203
+    },
+    "type": "construction",
+    "title": "The standard basis: equilateral sets grow with dimension",
+    "content": "The $n$ standard basis vectors $\\texttt{single}\\,i\\,1$ of $\\texttt{EuclideanSpace}\\,\\mathbb{R}\\,(\\texttt{Fin}\\,n)$ are pairwise at distance $\\sqrt 2$: for $i \\ne j$, $\\lVert \\texttt{single}\\,i\\,1 - \\texttt{single}\\,j\\,1\\rVert^2 = \\langle \\cdot, \\cdot\\rangle = 1 - 0 - 0 + 1 = 2$ using $\\texttt{inner\\_single\\_left}$ and $(\\texttt{single}\\,j\\,1)_i = [i = j]$. Affine independence then follows for FREE from the equilateral criterion above. So $\\texttt{exists\\_large\\_equilateral}$ packages, for every $n$, an equilateral affinely independent $n$-point set in $\\mathbb{R}^n$. Combined with the $d+1$ upper bound, the maximum equilateral-set size in $\\mathbb{R}^d$ lies in $\\{d, d+1\\}$ — unbounded in the dimension, the decisive qualitative contrast with the plane's bound of $3$. (The tight value $d+1$, realised by a regular $d$-simplex, is left as a stated open follow-up.)",
+    "mathContext": "$\\operatorname{dist}(\\texttt{single}\\,i\\,1, \\texttt{single}\\,j\\,1) = \\sqrt 2$; $n$ points in $\\mathbb{R}^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "standard basis",
+      "regular simplex",
+      "EuclideanSpace.single",
+      "equilateral dimension"
+    ],
+    "prerequisites": [
+      "orthonormal basis",
+      "norm from inner product"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-100-oq-05-oq-03/meta.json
+++ b/src/data/proofs/erdos-100-oq-05-oq-03/meta.json
@@ -1,0 +1,205 @@
+{
+  "id": "erdos-100-oq-05-oq-03",
+  "slug": "erdos-100-oq-05-oq-03",
+  "title": "Erdős #100 in Higher Dimensions: Equilateral Point Sets and the Sharp Dimensional Bound d+1",
+  "description": "Answers the parent entry's open question OQ-05 ('does the restricted-distance problem change qualitatively in ℝ^d for d ≥ 3?') from the OPPOSITE extreme to its existing follow-ups: point sets with a SINGLE distinct distance — equilateral sets (vertex sets of regular simplices). The headline is the non-obvious extremal direction: in any real inner product space, an s-equilateral family (all pairwise distances equal to a fixed s > 0) is affinely independent, proved by a short elementary inner-product / polarisation argument with no Gram-matrix positive-definiteness machinery. Consequently an equilateral set in EuclideanSpace ℝ (Fin d) has at most d+1 points, specialising to at most 3 mutually equidistant points in the plane. The n standard basis vectors of ℝ^n give an equilateral (distance √2), affinely independent set of n points, so equilateral sets grow without bound with dimension — a genuine qualitative change from the plane's bound of 3.",
+  "leanFile": {
+    "path": "Proofs/Erdos100OQ05OQ03.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "RealInnerProductSpace"
+    ],
+    "namespace": "Erdos100OQ05Equilateral",
+    "lineCount": 203,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 7
+  },
+  "meta": {
+    "author": "Researcher (Lean Genius), building on Erdős #100 and the theory of equilateral/equidistant sets",
+    "sourceUrl": "https://erdosproblems.com/100",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos100OQ05OQ03.lean",
+    "tags": [
+      "erdos",
+      "discrete-geometry",
+      "equilateral-sets",
+      "equidistant-sets",
+      "regular-simplex",
+      "euclidean-space",
+      "higher-dimensions",
+      "affine-independence",
+      "inner-product-space",
+      "distance-geometry"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "affineIndependent_iff",
+        "description": "For a family p : ι → V in a module viewed as an affine space over itself, AffineIndependent ℝ p ↔ for every finite s and weights w with ∑ w = 0 and ∑ w • p = 0, all w vanish. This is the exact criterion discharged by the polarisation argument.",
+        "module": "Mathlib.LinearAlgebra.AffineSpace.Independent"
+      },
+      {
+        "theorem": "norm_sub_sq_real",
+        "description": "‖x - y‖² = ‖x‖² - 2⟪x,y⟫_ℝ + ‖y‖². The polarisation identity that expands each ‖p i - p j‖² and, combined with the two vanishing sums, collapses the cross term ⟪∑ w i • p i, p j⟫ to zero.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "sum_inner",
+        "description": "⟪∑ i, f i, x⟫ = ∑ i, ⟪f i, x⟫. Used with real_inner_smul_left to rewrite ∑ w i ⟪p i, p j⟫ as ⟪∑ w i • p i, p j⟫ = ⟪0, p j⟫ = 0.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "AffineIndependent.card_le_finrank_succ",
+        "description": "An affinely independent family over a fintype has Fintype.card ι ≤ finrank ℝ (vectorSpan …) + 1. Combined with Submodule.finrank_le it yields card ≤ finrank ℝ E + 1, the dimensional upper bound.",
+        "module": "Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional"
+      },
+      {
+        "theorem": "finrank_euclideanSpace_fin",
+        "description": "finrank ℝ (EuclideanSpace ℝ (Fin n)) = n. Specialises the abstract finrank bound to the concrete statement 'at most d+1 equilateral points in ℝ^d'.",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "EuclideanSpace.inner_single_left",
+        "description": "⟪EuclideanSpace.single i a, v⟫ = conj a * v i. Powers the √2 computation for the standard basis: ⟪single i 1, single j 1⟫ = (single j 1) i = [i = j], giving ‖single i 1 - single j 1‖² = 2 for i ≠ j.",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      }
+    ],
+    "originalContributions": [
+      "affineIndependent_of_equilateral: the extremal theorem — in ANY real inner product space, an s-equilateral family (0 < s) is affinely independent. Proof by an elementary self-contained argument: polarisation plus the two vanishing sums (∑ w = 0, ∑ w • p = 0) show ∑ w i ‖p i − p j‖² is independent of j (= ∑ w i ‖p i‖² =: Q); the equilateral hypothesis makes it −s²·w j; so −s²·w j = Q for all j; summing over the index set gives card·Q = 0, hence Q = 0 and every weight vanishes. No Gram-matrix positive-definiteness, no linear-algebra black boxes.",
+      "equilateral_card_le_finrank_succ / equilateral_card_le_euclidean: the sharp dimensional upper bound — an equilateral set in a finite-dimensional real inner product space has at most finrank + 1 points, i.e. at most d+1 points in EuclideanSpace ℝ (Fin d).",
+      "equilateral_plane_card_le_three: the planar corollary (d = 2) — at most 3 points in the plane can be mutually equidistant, recovering the fact that the equilateral triangle is the maximal planar equilateral configuration.",
+      "stdSimplex / stdSimplex_equilateral / stdSimplex_affineIndependent: the n standard basis vectors of EuclideanSpace ℝ (Fin n) are pairwise at distance √2 and affinely independent — an explicit equilateral, non-degenerate n-point configuration in dimension n, with affine independence obtained for free from the equilateral criterion.",
+      "exists_large_equilateral: for every n, ℝ^n contains an equilateral, affinely independent set of n points. Hence the maximum equilateral-set size grows without bound with the dimension — the qualitative contrast with the plane's bound of 3, and the clean answer to OQ-05 for the single-distance extreme."
+    ],
+    "dateAdded": "2026-06-30",
+    "relatedProblems": [
+      {
+        "id": "erdos-100",
+        "relationship": "Answers the parent's open question OQ-05 ('does the problem change qualitatively in higher dimensions ℝ^d, d ≥ 3?') for the single-distance extreme, complementing the two sibling follow-ups (explicit Heronian simplices with MANY distinct distances; and the packing lower bound diam ≳ n^{1/d}). The equilateral bound is dimension-free in statement and sharp up to an additive ±1: the maximum equilateral-set size in ℝ^d lies in {d, d+1}, growing without bound, versus the plane's bound of 3."
+      },
+      {
+        "id": "erdos-100-oq-05",
+        "relationship": "Direct follow-up to the parent OQ-05 entry, adding the equilateral (single-distance) extreme to its treatment of the many-distance and packing regimes."
+      }
+    ],
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only the foundational propext, Classical.choice, Quot.sound — no sorryAx, no Lean.ofReduceBool. HONEST SCOPE: the file proves the sharp dimensional upper bound (equilateral set in ℝ^d has ≤ d+1 points) and exhibits n-point equilateral sets in ℝ^n (standard basis), establishing the qualitative 'grows without bound with dimension' answer to OQ-05. The exact maximum is d+1 (the regular simplex realises the upper bound), of which this entry proves the lower bound d via the basis; the tightening from d to d+1 (a regular d-simplex on d+1 vertices in ℝ^d) is not formalized here. The parent Erdős #100 diameter conjecture diam ≫ n remains OPEN and is unrelated to this single-distance extreme.",
+    "mathlib_version": "4.26.0",
+    "lineCount": 203,
+    "theoremCount": 7,
+    "definitionCount": 2
+  },
+  "mainTheorems": [
+    {
+      "name": "affineIndependent_of_equilateral",
+      "type": "core",
+      "description": "In any real inner product space, an s-equilateral family of points (all pairwise distances equal to a fixed s > 0) is affinely independent. The non-obvious extremal direction, proved by an elementary polarisation argument.",
+      "leanType": "(hs : 0 < s) → (h : Equilateral p s) → AffineIndependent ℝ p"
+    },
+    {
+      "name": "equilateral_card_le_euclidean",
+      "type": "core",
+      "description": "An equilateral set in EuclideanSpace ℝ (Fin d) has at most d+1 points — the sharp dimensional upper bound.",
+      "leanType": "(hs : 0 < s) → (h : Equilateral p s) → Fintype.card ι ≤ d + 1"
+    },
+    {
+      "name": "equilateral_plane_card_le_three",
+      "type": "corollary",
+      "description": "At most 3 points in the plane ℝ² can be mutually equidistant — the equilateral triangle is the maximal planar equilateral set.",
+      "leanType": "(hs : 0 < s) → (h : Equilateral p s) → Fintype.card ι ≤ 3"
+    },
+    {
+      "name": "stdSimplex_equilateral",
+      "type": "construction",
+      "description": "The n standard basis vectors of EuclideanSpace ℝ (Fin n) are pairwise at distance √2 — an explicit equilateral n-point configuration in dimension n.",
+      "leanType": "Equilateral (stdSimplex n) (Real.sqrt 2)"
+    },
+    {
+      "name": "exists_large_equilateral",
+      "type": "consequence",
+      "description": "For every n, ℝ^n contains an equilateral, affinely independent set of n points; hence equilateral sets grow without bound with dimension, unlike the plane's bound of 3.",
+      "leanType": "∃ p : Fin n → EuclideanSpace ℝ (Fin n), Equilateral p (Real.sqrt 2) ∧ AffineIndependent ℝ p"
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and Scope",
+      "startLine": 1,
+      "endLine": 55,
+      "mathContext": "Erdős #100 in ℝ^d: the single-distance (equilateral) extreme of OQ-05.",
+      "summary": "Frames the equilateral extreme as the opposite of the parent's many-distance and packing follow-ups. States the main results (affine independence of equilateral sets; the ≤ d+1 bound; the planar ≤ 3 corollary; the √2 basis construction) and the honest scope: the max equilateral-set size in ℝ^d lies in {d, d+1} and grows without bound, versus 3 in the plane."
+    },
+    {
+      "id": "equilateral-def",
+      "title": "The Equilateral Predicate",
+      "startLine": 56,
+      "endLine": 62,
+      "mathContext": "A single-distance family in a pseudometric space.",
+      "summary": "Defines Equilateral p s := every two distinct points of p are at distance exactly s — the vertex configuration of a regular simplex when the points are affinely independent."
+    },
+    {
+      "id": "affine-independence",
+      "title": "Equilateral Sets Are Affinely Independent",
+      "startLine": 63,
+      "endLine": 139,
+      "mathContext": "The extremal direction, in an arbitrary real inner product space.",
+      "summary": "affineIndependent_of_equilateral. Via affineIndependent_iff, assume ∑ w = 0 and ∑ w • p = 0. Polarisation (norm_sub_sq_real) plus the vanishing of the cross term ⟪∑ w • p, p j⟫ = 0 gives ∑ w i ‖p i − p j‖² = ∑ w i ‖p i‖² =: Q, independent of j. The equilateral hypothesis evaluates the same sum to −s²·w j (splitting off the diagonal term with add_sum_erase). Hence −s²·w j = Q for all j; summing over the index set forces card·Q = 0, so Q = 0 and every weight vanishes."
+    },
+    {
+      "id": "dimensional-bound",
+      "title": "The Dimensional Upper Bound",
+      "startLine": 141,
+      "endLine": 160,
+      "mathContext": "From affine independence to a cardinality bound.",
+      "summary": "equilateral_card_le_finrank_succ combines affineIndependent_of_equilateral with AffineIndependent.card_le_finrank_succ and Submodule.finrank_le to bound an equilateral set by finrank ℝ E + 1. equilateral_card_le_euclidean specialises via finrank_euclideanSpace_fin to at most d+1 points in ℝ^d."
+    },
+    {
+      "id": "plane-and-construction",
+      "title": "Planar Corollary and the Standard-Basis Construction",
+      "startLine": 162,
+      "endLine": 203,
+      "mathContext": "Sharpness contrast: the plane vs. growing dimension.",
+      "summary": "equilateral_plane_card_le_three: the d = 2 case bounds mutually equidistant planar points by 3. stdSimplex_equilateral computes the pairwise distance of the n standard basis vectors as √2 (‖single i 1 − single j 1‖² = 2 via inner_single_left); stdSimplex_affineIndependent gets non-degeneracy for free from the equilateral criterion; exists_large_equilateral packages an n-point equilateral affinely independent set in ℝ^n, establishing unbounded growth with dimension."
+    }
+  ],
+  "sorries": [],
+  "crossReferences": [
+    {
+      "targetId": "erdos-100",
+      "relationship": "extends",
+      "description": "Answers the parent's OQ-05 for the single-distance (equilateral) extreme: the sharp dimensional bound d+1 and unbounded growth with dimension, versus the plane's bound of 3."
+    },
+    {
+      "targetId": "erdos-100-oq-05",
+      "relationship": "extends",
+      "description": "Complements the parent OQ-05 entry's many-distance Heronian simplices and packing bound with the opposite, single-distance extreme."
+    }
+  ],
+  "conclusion": {
+    "status": "verified",
+    "verified": true,
+    "openQuestions": [
+      "Formalize the tight lower bound: an explicit regular d-simplex on d+1 vertices in EuclideanSpace ℝ (Fin d), closing the gap between the proved lower bound d (standard basis) and the upper bound d+1.",
+      "Characterise the equality case: when an equilateral set in ℝ^d attains exactly d+1 points, is it necessarily (up to isometry and scaling) the regular simplex?"
+    ]
+  },
+  "references": [
+    {
+      "title": "Erdős Problem #100",
+      "url": "https://erdosproblems.com/100"
+    },
+    {
+      "title": "Equilateral sets and the maximum size of equilateral sets in normed and Euclidean spaces (background)",
+      "url": "https://en.wikipedia.org/wiki/Equilateral_dimension"
+    }
+  ],
+  "overview": "Erdős #100 asks how large the diameter of a planar point set with integer pairwise distances must be. Its open question OQ-05 asks whether the picture changes qualitatively in higher dimensions ℝ^d, d ≥ 3. Two existing follow-ups study configurations with many distinct distances (explicit Heronian simplices) and the packing lower bound diam ≳ n^{1/d}. This entry takes the opposite extreme — point sets with a single distinct distance, i.e. equilateral sets — where the dimensional dependence is cleanest. The main theorem, valid in any real inner product space, is that an equilateral family is affinely independent, proved by an elementary polarisation argument that avoids Gram-matrix positive-definiteness. It follows that an equilateral set in ℝ^d has at most d+1 points (at most 3 in the plane), while the n standard basis vectors give an equilateral affinely independent set of n points in ℝ^n. Thus the maximum equilateral-set size grows without bound with the dimension — a genuine qualitative change from the plane. All results are fully machine-checked and axiom-free."
+}


### PR DESCRIPTION
## Summary

New child entry of `erdos-100-oq-05` answering the parent's **OQ-05** ('does the restricted-distance problem change qualitatively in ℝ^d, d ≥ 3?') from the **single-distance extreme** — *equilateral* (equidistant) sets, the vertex sets of regular simplices. This is complementary to the two existing follow-ups (many-distance Heronian simplices; the packing bound diam ≳ n^{1/d}).

## Results (all VERIFIED, 0-axiom)

- **`affineIndependent_of_equilateral`** — in *any* real inner product space, an `s`-equilateral family (all pairwise distances equal to a fixed `s > 0`) is affinely independent. The non-obvious extremal direction, via a short elementary **polarisation** argument: with ∑ w = 0 and ∑ w·p = 0, the sum ∑ wᵢ‖pᵢ − pⱼ‖² is both independent of j (= ∑ wᵢ‖pᵢ‖² =: Q) and equal to −s²·wⱼ; summing over the index set forces card·Q = 0, so Q = 0 and every weight vanishes. **No Gram-matrix positive-definiteness machinery.**
- **`equilateral_card_le_euclidean`** — an equilateral set in `EuclideanSpace ℝ (Fin d)` has at most **d + 1** points.
- **`equilateral_plane_card_le_three`** — the planar (d = 2) corollary: at most **3** mutually equidistant points (the equilateral triangle is maximal).
- **`stdSimplex_equilateral` / `exists_large_equilateral`** — the n standard basis vectors of ℝ^n are pairwise at distance √2 and affinely independent, so equilateral sets of size n exist in dimension n.

## Qualitative answer to OQ-05

The maximum equilateral-set size in ℝ^d lies in {d, d+1} and **grows without bound with the dimension** — a genuine qualitative change from the plane's bound of 3. Dimension-free in statement and sharp up to an additive ±1.

## Files

- `proofs/Proofs/Erdos100OQ05OQ03.lean` — 203 lines, 7 theorems, 2 defs, namespace `Erdos100OQ05Equilateral`.
- `src/data/proofs/erdos-100-oq-05-oq-03/` — gallery meta + annotations.

## Verification

`#print axioms` on all main theorems reports only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Compiles clean against Mathlib v4.26.0.

**Honest scope:** proves the upper bound (≤ d+1) and the lower bound d (basis); tightening to d+1 (a regular d-simplex on d+1 vertices in ℝ^d) is recorded as a stated open follow-up. The parent Erdős #100 diameter conjecture remains open and is unrelated to this single-distance extreme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)