### PR TITLE
Enrich Erdős #1018 OQ-01 density forces dense subgraph

### DIFF
--- a/src/data/proofs/erdos-1018-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1018-oq-01/annotations.json
@@ -6,7 +6,14 @@
     "type": "definition",
     "title": "Within-Set Degree and Doubled Edge Count",
     "content": "degOn G S v is the number of neighbours of v that lie inside the vertex set S — the degree of v in the subgraph induced on S. edgeSum G S = ∑_{v∈S} degOn G S v counts each internal edge twice (once from each endpoint), so it equals 2·e(S). Working with the doubled count keeps every quantity a natural number and avoids division throughout the argument.",
-    "mathContext": "$\\deg_S(v) = \\#\\{w \\in S : v \\sim w\\}$, $\\ \\mathrm{edgeSum}(S) = \\sum_{v\\in S}\\deg_S(v) = 2\\,e(S)$."
+    "mathContext": "$\\deg_S(v) = \\#\\{w \\in S : v \\sim w\\}$, $\\ \\mathrm{edgeSum}(S) = \\sum_{v\\in S}\\deg_S(v) = 2\\,e(S)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Induced subgraph degree",
+      "Doubled edge count / handshake identity",
+      "Avoiding division by working with 2·e(S)",
+      "Finset-indexed degree sums"
+    ]
   },
   {
     "id": "ann-e1018oq01-degon-erase",
@@ -15,7 +22,14 @@
     "type": "lemma",
     "title": "Per-Vertex Erase Identity",
     "content": "Deleting a vertex v from the ambient set changes the within-set degree of any other vertex u by exactly the indicator [u ~ v]: degOn S u = degOn (S.erase v) u + (if G.Adj u v then 1 else 0). Proved by rewriting the filtered neighbour set of u over S.erase v as the erase of its filtered neighbour set over S, then case-splitting on whether u is adjacent to v.",
-    "mathContext": "$\\deg_S(u) = \\deg_{S\\setminus\\{v\\}}(u) + [u \\sim v]$."
+    "mathContext": "$\\deg_S(u) = \\deg_{S\\setminus\\{v\\}}(u) + [u \\sim v]$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Finset.erase and neighbour-set filtering",
+      "Adjacency indicator [u ~ v]",
+      "Case split on adjacency",
+      "Per-vertex bookkeeping under vertex deletion"
+    ]
   },
   {
     "id": "ann-e1018oq01-edgesum-erase",
@@ -24,7 +38,14 @@
     "type": "lemma",
     "title": "Edge-Deletion Identity",
     "content": "The heart of the double count: removing a vertex v ∈ S decreases the doubled edge count by exactly twice the within-set degree of v, edgeSum S = edgeSum (S.erase v) + 2·degOn S v. The v-term is peeled off with Finset.sum_erase_add; each remaining term is rewritten by the per-vertex identity; and the resulting incidence sum ∑_{u∈S\\{v}} [u ~ v] collapses back to degOn S v using card_filter and the symmetry/looplessness of adjacency. This exact identity is what makes the vertex-deletion invariant self-propagating.",
-    "mathContext": "$\\mathrm{edgeSum}(S) = \\mathrm{edgeSum}(S\\setminus\\{v\\}) + 2\\deg_S(v)$, where $\\sum_{u\\in S\\setminus\\{v\\}}[u\\sim v] = \\deg_S(v)$ by symmetry."
+    "mathContext": "$\\mathrm{edgeSum}(S) = \\mathrm{edgeSum}(S\\setminus\\{v\\}) + 2\\deg_S(v)$, where $\\sum_{u\\in S\\setminus\\{v\\}}[u\\sim v] = \\deg_S(v)$ by symmetry.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Double counting of edges under vertex deletion",
+      "Finset.sum_erase_add term peeling",
+      "Symmetry and looplessness of adjacency",
+      "Self-propagating vertex-deletion invariant"
+    ]
   },
   {
     "id": "ann-e1018oq01-edgesum-univ",
@@ -33,7 +54,14 @@
     "type": "lemma",
     "title": "Handshake Lemma for edgeSum",
     "content": "Over the whole vertex set, degOn univ v is just Mathlib's degree v (neighborFinset_eq_filter), so edgeSum univ = ∑_v degree v = 2·#E(G) by the handshake lemma sum_degrees_eq_twice_card_edges. This bridges the abstract density hypothesis k·n < #E to the internal invariant used by the induction.",
-    "mathContext": "$\\mathrm{edgeSum}(\\mathrm{univ}) = \\sum_v \\deg(v) = 2\\,\\#E(G)$."
+    "mathContext": "$\\mathrm{edgeSum}(\\mathrm{univ}) = \\sum_v \\deg(v) = 2\\,\\#E(G)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Handshake lemma (sum_degrees_eq_twice_card_edges)",
+      "neighborFinset_eq_filter identification",
+      "Bridging global density to the induction invariant",
+      "Total edge count of a finite graph"
+    ]
   },
   {
     "id": "ann-e1018oq01-extraction",
@@ -42,7 +70,14 @@
     "type": "lemma",
     "title": "Min-Degree Extraction (Set Form)",
     "content": "By strong induction on S ordered by strict inclusion: if every vertex of S already has within-degree > k, return T = S (nonempty because 2·(k·|S|) < edgeSum S forces edgeSum S > 0). Otherwise pick a vertex v with degOn S v ≤ k and delete it; the edge-deletion identity gives edgeSum (S.erase v) ≥ edgeSum S − 2k > 2k(|S|−1) = 2k·|S.erase v|, so the density invariant 2·(k·|·|) < edgeSum is preserved on the strictly smaller set and the inductive hypothesis applies. The only nonlinear input is the identity k·|S| = k·(|S|−1) + k; the rest is omega-friendly.",
-    "mathContext": "Invariant $2\\,(k\\,|S|) < \\mathrm{edgeSum}(S)$ survives deleting a vertex of within-degree $\\le k$ and certifies nonemptiness; peeling terminates at a min-degree-$(k{+}1)$ core."
+    "mathContext": "Invariant $2\\,(k\\,|S|) < \\mathrm{edgeSum}(S)$ survives deleting a vertex of within-degree $\\le k$ and certifies nonemptiness; peeling terminates at a min-degree-$(k{+}1)$ core.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Strong induction on Finset strict inclusion",
+      "Greedy low-degree vertex peeling",
+      "Density invariant preservation",
+      "k-degeneracy and dense-core extraction"
+    ]
   },
   {
     "id": "ann-e1018oq01-main",
@@ -51,6 +86,13 @@
     "type": "theorem",
     "title": "Density Forces a Dense Induced Subgraph",
     "content": "The headline result: if G has more than k·n edges (n = |V|), there is a nonempty vertex set T in which every vertex has more than k neighbours inside T — equivalently, average degree > 2k forces an induced subgraph of minimum degree ≥ k+1. Obtained by feeding S = univ to the extraction lemma, using the handshake identity to turn k·n < #E into 2·(k·n) < edgeSum univ. This is the optimal-constant first step of Kostochka–Pyber for Erdős #1018 OQ-01; the bound is best possible since k-degenerate graphs have ≤ k·n edges and no such subgraph.",
-    "mathContext": "$k\\cdot n < \\#E(G) \\ \\Rightarrow\\ \\exists\\, T \\neq \\varnothing,\\ \\forall v \\in T,\\ \\deg_T(v) > k$ (induced $\\delta \\ge k+1$)."
+    "mathContext": "$k\\cdot n < \\#E(G) \\ \\Rightarrow\\ \\exists\\, T \\neq \\varnothing,\\ \\forall v \\in T,\\ \\deg_T(v) > k$ (induced $\\delta \\ge k+1$).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Average degree > 2k forces min-degree-(k+1) subgraph",
+      "Kostochka–Pyber optimal-constant first step",
+      "Sharpness via k-degenerate graphs",
+      "Erdős #1018 OQ-01 dense-subgraph question"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1018-oq-01`.

**Quality: 80 → 100**

- Added `significance` and `relatedConcepts` (4 apiece) to all 6 annotations. They previously had `content` and `mathContext` but neither field, scoring 0 for both the significance and crossRefs buckets.
- Content grounded in the existing annotations: degOn/edgeSum double-counting, the per-vertex erase identity, the edge-deletion identity, the handshake bridge, the min-degree extraction induction, and the Kostochka–Pyber optimal-constant main theorem.
- overview/conclusion already objects; `pnpm build` passes.