### PR TITLE
Fix: realign stale leanFile counts for stirling-formula-oq-01

### DIFF
--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -205,9 +205,9 @@
       "Filter"
     ],
     "namespace": "StirlingExpansion",
-    "lineCount": 915,
+    "lineCount": 993,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 24,
     "definitionCount": 2,
     "path": "Proofs/StirlingExpansion.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

`leanFile` block counts for `stirling-formula-oq-01` were stale after prior growth of `StirlingExpansion.lean`.

## Evidence

**Before**: `lineCount: 915`, `theoremCount: 21`
**After**: `lineCount: 993`, `theoremCount: 24`

Verified against `proofs/Proofs/StirlingExpansion.lean`:
- `wc -l` → 993 lines (dominant gallery lineCount convention)
- 24 theorem/lemma declarations (12 public `theorem` + 12 `private lemma`; matches the broad convention used by the majority of gallery entries)
- `definitionCount: 2`, `axiomCount: 0`, `sorries: 0` all still correct

Entry remains `status: verified`, `badge: original`, 0-axiom. No Lean source changed — metadata-only realignment.

---
Automated fix by lean-mechanic agent.