### PR TITLE
research(erdos-1018-oq-01-oq-01 +oq-01-oq-01): degeneracy edge bound is sharp AND χ ≤ k+1 with tight split-graph witnesses [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1018OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1018OQ01OQ01.lean
@@ -1,0 +1,246 @@
+/-
+Erdős Problem #1018 — Open Question OQ-01, follow-up OQ-01-OQ-01:
+Sharpness of the degeneracy / density edge threshold.
+
+The parent entry (`Erdos1018OQ01`, Kostochka–Pyber first reduction) proves the
+**density ⟹ dense-subgraph** extraction lemma:
+
+  > if a finite graph has more than `k · n` edges, then some nonempty vertex set
+  > induces a subgraph of minimum degree `> k`.
+
+Its docstring *asserts* that the linear constant `k` is best possible —
+"`k`-degenerate graphs have `≤ k·n` edges and no such subgraph" — but does not
+prove it. This file supplies the two missing halves.
+
+**1. Converse edge bound (`degenerate_edge_bound`).** If a graph is
+`k`-degenerate (every nonempty vertex set induces a vertex of within-degree
+`≤ k`), then it has at most `k · n` edges. This is the exact contrapositive of
+the extraction theorem, and pins the *upper* side of the threshold.
+
+**2. Extremal witness (`splitGraph_sharp`).** The complete split graph
+`S_{n,k} = K_k ∨ \overline{K_{n-k}}` — the first `k` vertices universal, the rest
+an independent set — is `k`-degenerate and has exactly `k·n − C(k+1,2)` edges.
+So the coefficient `k` cannot be lowered, and the additive slack between the
+proven bound `k·n` and the true extremal count is exactly `C(k+1,2)`.
+
+Together: the degeneracy edge bound `≤ k·n` is optimal in its linear coefficient,
+with a `C(k+1,2)` additive gap that the split graph realises. The witness needs
+no vertex ordering (unlike a `k`-tree): its `k`-degeneracy is a direct degree
+computation, which keeps the whole argument elementary and finite.
+
+**Status**: VERIFIED, 0 axioms. Self-contained (builds on `Erdos1018OQ01`).
+Reference: https://erdosproblems.com/1018
+-/
+
+import Mathlib
+import Proofs.Erdos1018OQ01
+
+open Finset
+open Erdos1018OQ01 (degOn)
+
+namespace Erdos1018OQ01OQ01
+
+/-! ### Part 1 — the converse edge bound (upper side of the threshold) -/
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+variable (G : SimpleGraph V) [DecidableRel G.Adj]
+
+/-- A finite graph is **`k`-degenerate** when every nonempty vertex set induces a
+subgraph with a vertex of within-degree `≤ k`. Equivalently: no nonempty induced
+subgraph has minimum degree `> k`. This is exactly the negation of the conclusion
+of the extraction theorem. -/
+def IsKDegenerate (k : ℕ) : Prop :=
+  ∀ T : Finset V, T.Nonempty → ∃ v ∈ T, degOn G T v ≤ k
+
+/-- **Converse edge bound.** A `k`-degenerate graph has at most `k · n` edges
+(`n = |V|`). Contrapositive of `Erdos1018OQ01.exists_dense_induced_subgraph`:
+more than `k·n` edges would force a nonempty induced subgraph of minimum degree
+`> k`, contradicting `k`-degeneracy. -/
+theorem degenerate_edge_bound {k : ℕ} (h : IsKDegenerate G k) :
+    G.edgeFinset.card ≤ k * Fintype.card V := by
+  by_contra hcon
+  push_neg at hcon
+  obtain ⟨T, hTne, hTmin⟩ := Erdos1018OQ01.exists_dense_induced_subgraph G hcon
+  obtain ⟨v, hvT, hvle⟩ := h T hTne
+  have := hTmin v hvT
+  omega
+
+/-! ### Part 2 — the extremal witness (complete split graph) -/
+
+/-- The **complete split graph** `S_{n,k}` on `Fin n`: the first `k` vertices
+(those with value `< k`) are universal, the remaining `n − k` form an independent
+set. Two vertices are adjacent iff they differ and at least one lies in the
+universal part. This is the extremal `k`-degenerate graph. -/
+def splitGraph (n k : ℕ) : SimpleGraph (Fin n) where
+  Adj i j := i ≠ j ∧ ((i : ℕ) < k ∨ (j : ℕ) < k)
+  symm := by rintro i j ⟨hij, h⟩; exact ⟨hij.symm, h.symm⟩
+  loopless := by rintro i ⟨h, _⟩; exact h rfl
+
+@[simp] lemma splitGraph_adj (n k : ℕ) (i j : Fin n) :
+    (splitGraph n k).Adj i j ↔ i ≠ j ∧ ((i : ℕ) < k ∨ (j : ℕ) < k) := Iff.rfl
+
+instance splitGraph_decidableAdj (n k : ℕ) : DecidableRel (splitGraph n k).Adj :=
+  fun i j => decidable_of_iff _ (splitGraph_adj n k i j).symm
+
+/-- The universal part `{w : w.val < k}` has at most `k` vertices (exactly
+`min n k`). Proof: `Fin.val` injects it into `range k`. -/
+lemma card_lt_le (n k : ℕ) :
+    (univ.filter (fun w : Fin n => (w : ℕ) < k)).card ≤ k := by
+  have hsub : (univ.filter (fun w : Fin n => (w : ℕ) < k)).image (Fin.val)
+            ⊆ Finset.range k := by
+    intro m hm
+    simp only [mem_image, mem_filter, mem_univ, true_and] at hm
+    obtain ⟨w, hw, rfl⟩ := hm
+    exact Finset.mem_range.mpr hw
+  calc (univ.filter (fun w : Fin n => (w : ℕ) < k)).card
+      = ((univ.filter (fun w : Fin n => (w : ℕ) < k)).image (Fin.val)).card :=
+        (Finset.card_image_of_injective _ Fin.val_injective).symm
+    _ ≤ (Finset.range k).card := Finset.card_le_card hsub
+    _ = k := Finset.card_range k
+
+/-- When `k ≤ n` the universal part has exactly `k` vertices. -/
+lemma card_lt_eq (n k : ℕ) (hk : k ≤ n) :
+    (univ.filter (fun w : Fin n => (w : ℕ) < k)).card = k := by
+  rw [← Finset.card_image_of_injective _ Fin.val_injective]
+  have himg : (univ.filter (fun w : Fin n => (w : ℕ) < k)).image (Fin.val)
+            = Finset.range k := by
+    ext m
+    simp only [mem_image, mem_filter, mem_univ, true_and, Finset.mem_range]
+    constructor
+    · rintro ⟨w, hw, rfl⟩; exact hw
+    · intro hm; exact ⟨⟨m, lt_of_lt_of_le hm hk⟩, hm, rfl⟩
+  rw [himg, Finset.card_range]
+
+/-- Degree of a universal vertex (`i.val < k`) is `n − 1`: it is adjacent to
+every other vertex. -/
+lemma degree_universal (n k : ℕ) (i : Fin n) (hi : (i : ℕ) < k) :
+    (splitGraph n k).degree i = n - 1 := by
+  rw [SimpleGraph.degree, SimpleGraph.neighborFinset_eq_filter]
+  have : univ.filter ((splitGraph n k).Adj i) = univ.erase i := by
+    ext w
+    simp only [mem_filter, mem_univ, true_and, and_true, mem_erase, splitGraph_adj]
+    constructor
+    · rintro ⟨hne, _⟩; exact Ne.symm hne
+    · intro hwi; exact ⟨Ne.symm hwi, Or.inl hi⟩
+  rw [this, card_erase_of_mem (mem_univ i), card_univ, Fintype.card_fin]
+
+/-- Degree of an independent-part vertex (`k ≤ i.val`) is `k`: it is adjacent to
+exactly the `k` universal vertices. -/
+lemma degree_independent (n k : ℕ) (hk : k ≤ n) (i : Fin n) (hi : k ≤ (i : ℕ)) :
+    (splitGraph n k).degree i = k := by
+  rw [SimpleGraph.degree, SimpleGraph.neighborFinset_eq_filter]
+  have : univ.filter ((splitGraph n k).Adj i)
+       = univ.filter (fun w : Fin n => (w : ℕ) < k) := by
+    ext w
+    simp only [mem_filter, mem_univ, true_and, splitGraph_adj]
+    constructor
+    · rintro ⟨_, hor⟩; rcases hor with h | h
+      · omega
+      · exact h
+    · intro hw
+      refine ⟨?_, Or.inr hw⟩
+      intro heq; rw [heq] at hi; omega
+  rw [this, card_lt_eq n k hk]
+
+/-- **Handshake / edge count.** For `k ≤ n` the split graph satisfies
+`2·|E| + k(k+1) = 2kn`, i.e. `|E| = k·n − C(k+1,2)`. Proved by summing degrees:
+`k` universal vertices of degree `n − 1` and `n − k` independent vertices of
+degree `k`. -/
+lemma splitGraph_two_mul_edges (n k : ℕ) (hk : k ≤ n) :
+    2 * (splitGraph n k).edgeFinset.card + k * (k + 1) = 2 * (k * n) := by
+  have hcardA : (univ.filter (fun v : Fin n => (v : ℕ) < k)).card = k :=
+    card_lt_eq n k hk
+  have htot : (univ.filter (fun v : Fin n => (v : ℕ) < k)).card
+            + (univ.filter (fun v : Fin n => ¬ (v : ℕ) < k)).card = n := by
+    rw [Finset.filter_card_add_filter_neg_card_eq_card, card_univ, Fintype.card_fin]
+  have hcardB : (univ.filter (fun v : Fin n => ¬ (v : ℕ) < k)).card = n - k := by
+    omega
+  have hA : ∑ v ∈ univ.filter (fun v : Fin n => (v : ℕ) < k), (splitGraph n k).degree v
+          = (univ.filter (fun v : Fin n => (v : ℕ) < k)).card * (n - 1) := by
+    rw [Finset.sum_congr rfl fun v hv => degree_universal n k v (mem_filter.mp hv).2,
+        Finset.sum_const, smul_eq_mul]
+  have hB : ∑ v ∈ univ.filter (fun v : Fin n => ¬ (v : ℕ) < k), (splitGraph n k).degree v
+          = (univ.filter (fun v : Fin n => ¬ (v : ℕ) < k)).card * k := by
+    rw [Finset.sum_congr rfl fun v hv =>
+          degree_independent n k hk v (by have := (mem_filter.mp hv).2; omega),
+        Finset.sum_const, smul_eq_mul]
+  have hsplit : ∑ v, (splitGraph n k).degree v
+      = ∑ v ∈ univ.filter (fun v : Fin n => (v : ℕ) < k), (splitGraph n k).degree v
+      + ∑ v ∈ univ.filter (fun v : Fin n => ¬ (v : ℕ) < k), (splitGraph n k).degree v :=
+    (Finset.sum_filter_add_sum_filter_not univ (fun v : Fin n => (v : ℕ) < k)
+        (fun v => (splitGraph n k).degree v)).symm
+  have h2E : 2 * (splitGraph n k).edgeFinset.card = k * (n - 1) + (n - k) * k := by
+    rw [← (splitGraph n k).sum_degrees_eq_twice_card_edges, hsplit, hA, hB, hcardA, hcardB]
+  rw [h2E]
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le hk
+  cases k with
+  | zero => simp
+  | succ k' =>
+    have e1 : k' + 1 + m - 1 = k' + m := by omega
+    have e2 : k' + 1 + m - (k' + 1) = m := by omega
+    rw [e1, e2]; ring
+
+/-- The split graph `S_{n,k}` is `k`-degenerate. Any independent-part vertex in a
+set `T` has within-degree `≤ k` (its only neighbours are the `≤ k` universal
+vertices); if `T` is contained in the universal part then `|T| ≤ k` and any
+vertex has within-degree `≤ |T| − 1 ≤ k`. -/
+lemma splitGraph_kDegenerate (n k : ℕ) : IsKDegenerate (splitGraph n k) k := by
+  intro T hTne
+  by_cases hB : ∃ v ∈ T, k ≤ (v : ℕ)
+  · obtain ⟨v, hvT, hv⟩ := hB
+    refine ⟨v, hvT, ?_⟩
+    have hsub : T.filter (fun w => (splitGraph n k).Adj v w)
+             ⊆ univ.filter (fun w : Fin n => (w : ℕ) < k) := by
+      intro w hw
+      simp only [mem_filter, mem_univ, true_and] at hw ⊢
+      obtain ⟨_, hadj⟩ := hw
+      rw [splitGraph_adj] at hadj
+      obtain ⟨_, hor⟩ := hadj
+      rcases hor with h | h
+      · omega
+      · exact h
+    calc degOn (splitGraph n k) T v
+        = (T.filter (fun w => (splitGraph n k).Adj v w)).card := rfl
+      _ ≤ (univ.filter (fun w : Fin n => (w : ℕ) < k)).card := Finset.card_le_card hsub
+      _ ≤ k := card_lt_le n k
+  · push_neg at hB
+    obtain ⟨v, hvT⟩ := hTne
+    refine ⟨v, hvT, ?_⟩
+    have hTsub : T ⊆ univ.filter (fun w : Fin n => (w : ℕ) < k) := by
+      intro w hw
+      simp only [mem_filter, mem_univ, true_and]
+      have := hB w hw; omega
+    have hTcard : T.card ≤ k := le_trans (Finset.card_le_card hTsub) (card_lt_le n k)
+    have hdeg : degOn (splitGraph n k) T v ≤ T.card - 1 := by
+      have hsub : T.filter (fun w => (splitGraph n k).Adj v w) ⊆ T.erase v := by
+        intro w hw
+        simp only [mem_filter] at hw
+        rw [mem_erase]
+        obtain ⟨hwT, hadj⟩ := hw
+        rw [splitGraph_adj] at hadj
+        exact ⟨Ne.symm hadj.1, hwT⟩
+      calc degOn (splitGraph n k) T v
+          = (T.filter (fun w => (splitGraph n k).Adj v w)).card := rfl
+        _ ≤ (T.erase v).card := Finset.card_le_card hsub
+        _ = T.card - 1 := by rw [card_erase_of_mem hvT]
+    omega
+
+/-- **Sharpness of the degeneracy edge bound.** The complete split graph
+`S_{n,k}` (for `k ≤ n`) is `k`-degenerate and has exactly `k·n − C(k+1,2)` edges
+(here in the division-free form `2·|E| + k(k+1) = 2kn`). Combined with
+`degenerate_edge_bound` (`k`-degenerate ⟹ `|E| ≤ k·n`), this shows the linear
+coefficient `k` in the density threshold of Erdős #1018 is optimal, with additive
+slack exactly `C(k+1,2)`. -/
+theorem splitGraph_sharp (n k : ℕ) (hk : k ≤ n) :
+    IsKDegenerate (splitGraph n k) k ∧
+      2 * (splitGraph n k).edgeFinset.card + k * (k + 1) = 2 * (k * n) :=
+  ⟨splitGraph_kDegenerate n k, splitGraph_two_mul_edges n k hk⟩
+
+/-- Closed form for the extremal edge count: `|E(S_{n,k})| = k·n − C(k+1,2)`. -/
+theorem splitGraph_edge_count (n k : ℕ) (hk : k ≤ n) :
+    (splitGraph n k).edgeFinset.card = k * n - k * (k + 1) / 2 := by
+  have h := splitGraph_two_mul_edges n k hk
+  obtain ⟨t, ht⟩ := Nat.even_mul_succ_self k
+  omega
+
+end Erdos1018OQ01OQ01

--- a/proofs/Proofs/Erdos1018OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1018OQ01OQ01OQ01.lean
@@ -1,0 +1,160 @@
+/-
+Erdős Problem #1018 — OQ-01 → OQ-01-OQ-01 → OQ-01-OQ-01-OQ-01:
+Degeneracy bounds the chromatic number (greedy colouring), and the split-graph
+witness makes the bound tight.
+
+The grandparent (`Erdos1018OQ01`) extracts a dense induced subgraph from an edge
+count; the parent (`Erdos1018OQ01OQ01`) pins the *edge* side of the degeneracy
+threshold (`k`-degenerate ⟹ `≤ k·n` edges, sharp via the complete split graph
+`S_{n,k}`). This file turns the same degeneracy hypothesis into the classical
+*colouring* consequence, on the other structural axis:
+
+**1. Greedy colouring (`degenerate_colorable`).** Every `k`-degenerate graph is
+`(k+1)`-colourable. Proof by strong induction on the vertex set using exactly the
+degeneracy hypothesis: pick a vertex `v` of within-degree `≤ k`, colour the rest
+by induction, then `v` sees at most `k` colours among its `≤ k` neighbours, so one
+of the `k+1` colours is free. No degeneracy ordering is materialised — the
+low-degree vertex is produced afresh from `IsKDegenerate` at each step, and the
+colouring is built as a single global function `V → Fin (k+1)`.
+
+**2. Tightness (`splitGraph_not_colorable`, `splitGraph_chromatic`).** For
+`k < n` the split graph `S_{n,k}` — which is `k`-degenerate (parent file) — is
+**not** `k`-colourable: its `k` universal vertices together with any one
+independent vertex form a `(k+1)`-clique, and a `(k+1)`-clique blocks any
+`k`-colouring (pigeonhole). Hence `S_{n,k}` is `(k+1)`-colourable but not
+`k`-colourable, so the greedy bound `χ ≤ k+1` is attained exactly.
+
+Together with the parent's edge bound this gives the full sharp picture of Erdős
+#1018's degeneracy parameter: `k`-degenerate ⟹ `≤ k·n` edges **and** `χ ≤ k+1`,
+both realised simultaneously by `S_{n,k}`.
+
+**Status**: VERIFIED, 0 axioms. Builds on `Erdos1018OQ01OQ01`.
+Reference: https://erdosproblems.com/1018
+-/
+
+import Mathlib
+import Proofs.Erdos1018OQ01OQ01
+
+open Finset
+open Erdos1018OQ01 (degOn)
+open Erdos1018OQ01OQ01 (IsKDegenerate splitGraph splitGraph_adj splitGraph_kDegenerate
+  card_lt_le card_lt_eq)
+
+namespace Erdos1018OQ01OQ01OQ01
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+variable (G : SimpleGraph V) [DecidableRel G.Adj]
+
+/-! ### Part 1 — greedy colouring: `k`-degenerate ⟹ `(k+1)`-colourable -/
+
+/-- **Core greedy step.** For every vertex set `T` there is a global colouring
+`c : V → Fin (k+1)` that is proper on `T` (adjacent vertices of `T` get distinct
+colours). Strong induction on `T`: extract a within-degree-`≤ k` vertex `v` of
+`T`, colour `T.erase v` by induction, and give `v` a colour avoided by its
+(at most `k`) neighbours in `T`. -/
+theorem exists_proper_coloring_on {k : ℕ} (h : IsKDegenerate G k) :
+    ∀ T : Finset V, ∃ c : V → Fin (k + 1),
+      ∀ u ∈ T, ∀ w ∈ T, G.Adj u w → c u ≠ c w := by
+  intro T
+  induction T using Finset.strongInduction with
+  | _ T ih =>
+    rcases T.eq_empty_or_nonempty with hT | hT
+    · exact ⟨fun _ => 0, by intro u hu; rw [hT] at hu; exact absurd hu (notMem_empty u)⟩
+    · obtain ⟨v, hvT, hvdeg⟩ := h T hT
+      obtain ⟨c', hc'⟩ := ih (T.erase v) (Finset.erase_ssubset hvT)
+      -- colours used by `v`'s neighbours inside `T`
+      set N : Finset V := T.filter (fun w => G.Adj v w) with hN
+      set forbidden : Finset (Fin (k + 1)) := N.image c' with hforb
+      have hforb_card : forbidden.card ≤ k :=
+        le_trans Finset.card_image_le hvdeg
+      -- a free colour exists: `forbidden` cannot exhaust `Fin (k+1)`
+      have hne : forbidden ≠ (univ : Finset (Fin (k + 1))) := by
+        intro he
+        rw [he, Finset.card_univ, Fintype.card_fin] at hforb_card
+        omega
+      obtain ⟨col, _, hcol⟩ :=
+        Finset.exists_of_ssubset
+          (Finset.ssubset_iff_subset_ne.mpr ⟨forbidden.subset_univ, hne⟩)
+      -- extend the colouring by giving `v` the free colour `col`
+      refine ⟨fun x => if x = v then col else c' x, ?_⟩
+      intro u hu w hw hadj
+      have huw : u ≠ w := G.ne_of_adj hadj
+      by_cases huv : u = v
+      · -- `u = v`, so `w ≠ v`; `w` is a neighbour of `v` in `T`, colour ≠ `col`
+        have hwv : w ≠ v := fun h => huw (huv.trans h.symm)
+        have hvw : G.Adj v w := huv ▸ hadj
+        have hwN : w ∈ N := mem_filter.mpr ⟨hw, hvw⟩
+        have hwf : c' w ∈ forbidden := mem_image_of_mem c' hwN
+        simp only [if_pos huv, if_neg hwv]
+        intro h; apply hcol; rw [h]; exact hwf
+      · by_cases hwv : w = v
+        · -- symmetric: `w = v`, `u` is a neighbour of `v` in `T`
+          have hvu : G.Adj v u := hwv ▸ G.symm hadj
+          have huN : u ∈ N := mem_filter.mpr ⟨hu, hvu⟩
+          have huf : c' u ∈ forbidden := mem_image_of_mem c' huN
+          simp only [if_neg huv, if_pos hwv]
+          intro h; apply hcol; rw [← h]; exact huf
+        · -- both `≠ v`: fall back to the inductive colouring on `T.erase v`
+          simp only [if_neg huv, if_neg hwv]
+          exact hc' u (mem_erase.mpr ⟨huv, hu⟩) w (mem_erase.mpr ⟨hwv, hw⟩) hadj
+
+/-- **Greedy bound.** A `k`-degenerate graph is `(k+1)`-colourable, i.e.
+`χ(G) ≤ k+1`. This is the colouring counterpart of the parent's edge bound
+`|E| ≤ k·n`, obtained from the same `IsKDegenerate` hypothesis. -/
+theorem degenerate_colorable {k : ℕ} (h : IsKDegenerate G k) : G.Colorable (k + 1) := by
+  obtain ⟨c, hc⟩ := exists_proper_coloring_on G h univ
+  exact ⟨SimpleGraph.Coloring.mk c (fun {u w} hadj => hc u (mem_univ u) w (mem_univ w) hadj)⟩
+
+/-! ### Part 2 — tightness: the split graph needs exactly `k+1` colours -/
+
+/-- The `k` universal vertices `{w : w.val < k}` of `S_{n,k}` together with a
+single independent vertex `p` (`k ≤ p.val`) form a `(k+1)`-clique. -/
+lemma splitGraph_isClique {n k : ℕ} (p : Fin n) (hp : k ≤ (p : ℕ)) :
+    (splitGraph n k).IsClique
+      (insert p (univ.filter (fun w : Fin n => (w : ℕ) < k)) : Finset (Fin n)) := by
+  intro a ha b hb hab
+  simp only [coe_insert, coe_filter, mem_univ, true_and, Set.mem_insert_iff,
+    Set.mem_setOf_eq] at ha hb
+  rw [splitGraph_adj]
+  refine ⟨hab, ?_⟩
+  -- at least one of `a`, `b` lies in the universal part (value `< k`)
+  rcases ha with rfl | ha
+  · rcases hb with rfl | hb
+    · exact absurd rfl hab
+    · exact Or.inr hb
+  · exact Or.inl ha
+
+/-- The `(k+1)`-clique above genuinely has `k+1` vertices: `p` is not in the
+universal part, and the universal part has exactly `k` vertices (needs `k ≤ n`). -/
+lemma splitGraph_clique_card {n k : ℕ} (hk : k < n) (p : Fin n) (hp : k ≤ (p : ℕ)) :
+    (insert p (univ.filter (fun w : Fin n => (w : ℕ) < k)) : Finset (Fin n)).card = k + 1 := by
+  have hpnotmem : p ∉ (univ.filter (fun w : Fin n => (w : ℕ) < k)) := by
+    simp only [mem_filter, mem_univ, true_and]; omega
+  rw [card_insert_of_notMem hpnotmem, card_lt_eq n k (le_of_lt hk)]
+
+/-- **Tightness (lower bound).** For `k < n` the split graph `S_{n,k}` is *not*
+`k`-colourable: it contains a `(k+1)`-clique, and a `(k+1)`-clique cannot be
+`k`-coloured (two of its `k+1` vertices would share a colour by pigeonhole, yet
+they are adjacent). -/
+theorem splitGraph_not_colorable {n k : ℕ} (hk : k < n) :
+    ¬ (splitGraph n k).Colorable k := by
+  -- pick the independent-part vertex `⟨k, hk⟩`
+  have hp : k ≤ ((⟨k, hk⟩ : Fin n) : ℕ) := le_rfl
+  have hclique := splitGraph_isClique ⟨k, hk⟩ hp
+  have hcard := splitGraph_clique_card hk ⟨k, hk⟩ hp
+  intro hcol
+  -- a `(k+1)`-clique forces the chromatic number to be `≥ k+1`
+  have : k + 1 ≤ k :=
+    hcard ▸ (hclique.card_le_of_colorable hcol)
+  omega
+
+/-- **Chromatic number of the split graph.** For `k < n`, `S_{n,k}` is
+`(k+1)`-colourable (it is `k`-degenerate, Part 1) but not `k`-colourable
+(Part 2). So `χ(S_{n,k}) = k+1` exactly, and the greedy bound
+`degenerate_colorable` is sharp. -/
+theorem splitGraph_chromatic {n k : ℕ} (hk : k < n) :
+    (splitGraph n k).Colorable (k + 1) ∧ ¬ (splitGraph n k).Colorable k :=
+  ⟨degenerate_colorable (splitGraph n k) (splitGraph_kDegenerate n k),
+    splitGraph_not_colorable hk⟩
+
+end Erdos1018OQ01OQ01OQ01

--- a/src/data/proofs/erdos-1018-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "erdos-1018-oq-01-oq-01-oq-01",
+  "slug": "erdos-1018-oq-01-oq-01-oq-01",
+  "title": "Degeneracy Bounds the Chromatic Number: Greedy Colouring and its Tight Split-Graph Witness",
+  "description": "An axiom-free proof that a k-degenerate graph is (k+1)-colourable (greedy colouring), and that the bound is tight. Turns the same degeneracy hypothesis behind Erdős #1018 OQ-01's edge bound into the colouring axis: (1) every k-degenerate graph has chromatic number ≤ k+1, proved by strong induction on the vertex set that gives each low-degree vertex a colour avoided by its ≤ k neighbours; (2) the complete split graph S_{n,k} (k-degenerate, from the parent) contains a (k+1)-clique for k < n, so it is not k-colourable — hence χ(S_{n,k}) = k+1 exactly and the greedy bound is attained.",
+  "meta": {
+    "author": "Research (follow-up open question from Erdős 1018 OQ-01-OQ-01)",
+    "sourceUrl": "https://erdosproblems.com/1018",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1018OQ01OQ01OQ01.lean",
+    "tags": [
+      "graph-theory",
+      "extremal-combinatorics",
+      "degeneracy",
+      "graph-colouring",
+      "chromatic-number",
+      "greedy-colouring",
+      "split-graph",
+      "clique",
+      "sharpness",
+      "erdos",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 160,
+    "assumptions": "None. 0 axioms, 0 sorries (verified by `#print axioms`: degenerate_colorable, splitGraph_not_colorable, and splitGraph_chromatic each depend only on propext, Classical.choice, Quot.sound — the standard foundational axioms, no sorryAx or Lean.ofReduceBool). Builds on the parent entry Erdos1018OQ01OQ01 (imported for the IsKDegenerate definition, the split graph splitGraph and its k-degeneracy splitGraph_kDegenerate, and the universal-part cardinality lemmas). Verified with the Docker Lean harness against pinned Mathlib 4.26.0.",
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.Coloring.mk",
+        "description": "Builds a graph colouring from a colouring function together with a proof that adjacent vertices receive distinct colours; packages the greedily constructed function V → Fin (k+1)",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Coloring"
+      },
+      {
+        "theorem": "SimpleGraph.IsClique.card_le_of_colorable",
+        "description": "A clique of size s in an n-colourable graph satisfies s ≤ n; the (k+1)-clique in the split graph forces ¬ Colorable k",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Coloring"
+      },
+      {
+        "theorem": "Finset.strongInduction",
+        "description": "Strong induction on a Finset over the strict-subset order; drives the greedy colouring, colouring T from a colouring of T.erase v",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.exists_of_ssubset",
+        "description": "A strict subset misses some element of the ambient set; produces a free colour once the forbidden set is a proper subset of Fin (k+1)",
+        "module": "Mathlib.Data.Finset.Defs"
+      },
+      {
+        "theorem": "Finset.card_image_le",
+        "description": "#(s.image f) ≤ #s; bounds the number of forbidden colours by the number of neighbours (≤ k) of the low-degree vertex",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_insert_of_notMem",
+        "description": "Counts the (k+1)-clique: inserting the independent-part vertex (not universal) into the k universal vertices gives k+1 vertices",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "exists_proper_coloring_on: for every vertex set T there is a global colouring c : V → Fin (k+1) proper on T. Proved by Finset.strongInduction — extract a within-degree-≤ k vertex v of T (directly from IsKDegenerate), colour T.erase v inductively, and assign v a colour not among the ≤ k colours of its neighbours in T. No degeneracy ordering is materialised; the colouring is a single global function and the free colour is produced from a proper-subset argument over Fin (k+1).",
+      "degenerate_colorable: every k-degenerate graph is (k+1)-colourable (χ ≤ k+1), the colouring counterpart of the parent's edge bound |E| ≤ k·n obtained from the identical IsKDegenerate hypothesis.",
+      "splitGraph_isClique: the k universal vertices of the complete split graph S_{n,k} together with any single independent-part vertex form a clique, since every pair contains a universal endpoint.",
+      "splitGraph_clique_card: that clique has exactly k+1 vertices (the independent-part vertex is not universal, and the universal part has exactly k vertices when k ≤ n).",
+      "splitGraph_not_colorable: for k < n the split graph is not k-colourable, because IsClique.card_le_of_colorable applied to the (k+1)-clique would force k+1 ≤ k.",
+      "splitGraph_chromatic: combining the greedy bound with the clique lower bound, S_{n,k} is (k+1)-colourable but not k-colourable for k < n, so χ(S_{n,k}) = k+1 exactly and degenerate_colorable is sharp."
+    ],
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos1018OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Erdos1018OQ01",
+      "Erdos1018OQ01OQ01"
+    ],
+    "namespace": "Erdos1018OQ01OQ01OQ01",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1018OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős problem #1018 (Kostochka–Pyber, 1988) concerns non-planar subgraphs in dense graphs; the degeneracy (= colouring number) of a graph is the extremal invariant behind the first reduction step, which the ancestor entry Erdos1018OQ01 formalises as a density-to-min-degree extraction. Degeneracy controls two classical parameters simultaneously: the number of edges and the chromatic number. The parent entry Erdos1018OQ01OQ01 pinned the edge axis (k-degenerate ⟹ ≤ k·n edges, sharp via the complete split graph). The other, equally classical, consequence of k-degeneracy is that the chromatic number is at most k+1 — the textbook greedy-colouring theorem: colour vertices in a degeneracy elimination order, and each vertex sees at most k already-coloured neighbours, so a colour is always free. This entry supplies that colouring bound and shows the same split graph makes it tight.",
+    "problemStatement": "Prove, from the same k-degeneracy hypothesis used for the edge bound, that (i) every k-degenerate graph is (k+1)-colourable, and (ii) the complete split graph S_{n,k} — which is k-degenerate — is not k-colourable when k < n, so the greedy bound χ ≤ k+1 is attained exactly.",
+    "proofStrategy": "Part 1 proves a strengthened statement by strong induction on the vertex set T (Finset.strongInduction over the strict-subset order): for every T there is a global function c : V → Fin (k+1) proper on T. In the inductive step, IsKDegenerate produces a vertex v ∈ T with within-degree degOn T v ≤ k; the inductive hypothesis colours T.erase v; the colours used by v's neighbours in T form a set of size ≤ degOn T v ≤ k, a proper subset of the k+1 available colours, so Finset.exists_of_ssubset yields a free colour col; extend the colouring by sending v to col (as an if-then-else update), and check properness by a three-way case split on whether the endpoints equal v. Taking T = univ and packaging with SimpleGraph.Coloring.mk gives Colorable (k+1). Part 2 exhibits, for k < n, the (k+1)-clique consisting of the k universal vertices of S_{n,k} plus one independent-part vertex (every pair has a universal endpoint, hence is adjacent), counts it to exactly k+1 vertices, and applies IsClique.card_le_of_colorable: k-colourability would give k+1 ≤ k, a contradiction. splitGraph_chromatic bundles the two directions.",
+    "keyInsights": [
+      "Degeneracy bounds edges and chromatic number by the same mechanism (a low-degree vertex in every induced subgraph); this entry runs that mechanism on the colouring axis, complementing the parent's edge axis under an identical hypothesis.",
+      "The greedy colouring needs no explicit elimination ordering: strong induction on the vertex set regenerates a low-degree vertex from IsKDegenerate at each step, and the colouring is carried as a single global function V → Fin (k+1) rather than a partial map.",
+      "The free-colour step is a pure counting fact: the forbidden colours are the image of ≤ k neighbours, so they cannot exhaust the k+1 colours — Finset.exists_of_ssubset turns 'proper subset' directly into an unused colour.",
+      "Tightness reuses the parent's split graph verbatim: its k universal vertices are mutually adjacent and each is adjacent to any independent-part vertex, giving a (k+1)-clique and hence the exact lower bound χ ≥ k+1.",
+      "Together with the parent, the complete split graph S_{n,k} simultaneously realises both extremal facts of Erdős #1018's degeneracy parameter: ≈ k·n edges and chromatic number exactly k+1."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Header and Overview",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "States the follow-up — the colouring consequence of k-degeneracy and its tightness — and situates it against the parent's edge bound on the same hypothesis.",
+      "mathContext": "Parent: k-degenerate ⟹ ≤ k·n edges. Here: k-degenerate ⟹ χ ≤ k+1, tight via the split graph's (k+1)-clique."
+    },
+    {
+      "id": "greedy",
+      "title": "Greedy Colouring: k-Degenerate ⟹ (k+1)-Colourable",
+      "startLine": 48,
+      "endLine": 106,
+      "summary": "exists_proper_coloring_on builds a global colouring proper on any set T by strong induction, giving each extracted low-degree vertex a colour free among its ≤ k neighbours. degenerate_colorable specialises to T = univ and packages a SimpleGraph.Coloring into Colorable (k+1).",
+      "mathContext": "For every T, ∃ c : V → Fin (k+1) proper on T; hence G.Colorable (k+1), i.e. χ(G) ≤ k+1."
+    },
+    {
+      "id": "clique",
+      "title": "The (k+1)-Clique in the Split Graph",
+      "startLine": 108,
+      "endLine": 133,
+      "summary": "splitGraph_isClique shows the k universal vertices plus one independent-part vertex are pairwise adjacent (each pair has a universal endpoint); splitGraph_clique_card counts this set to exactly k+1 vertices when k ≤ n.",
+      "mathContext": "{p} ∪ {w : w.val < k} is a clique of size k+1 in S_{n,k} for k ≤ p.val and k < n."
+    },
+    {
+      "id": "tightness",
+      "title": "Tightness: the Split Graph Needs k+1 Colours",
+      "startLine": 135,
+      "endLine": 160,
+      "summary": "splitGraph_not_colorable derives ¬ Colorable k for k < n from the (k+1)-clique via IsClique.card_le_of_colorable. splitGraph_chromatic combines this with degenerate_colorable (the split graph is k-degenerate) to pin χ(S_{n,k}) = k+1.",
+      "mathContext": "S_{n,k} is (k+1)-colourable but not k-colourable for k < n, so χ(S_{n,k}) = k+1 and the greedy bound is sharp."
+    }
+  ],
+  "conclusion": {
+    "summary": "The degeneracy hypothesis behind Erdős #1018 OQ-01 bounds the chromatic number as well as the edge count: every k-degenerate graph is (k+1)-colourable (degenerate_colorable), proved by a greedy strong induction that needs no explicit elimination ordering, and this is sharp — the complete split graph S_{n,k} contains a (k+1)-clique for k < n, so it is not k-colourable (splitGraph_not_colorable) while being (k+1)-colourable, giving χ(S_{n,k}) = k+1 exactly (splitGraph_chromatic). All results are axiom-free.",
+    "implications": "1. **Colouring axis of the degeneracy bound**: complements the parent's edge bound |E| ≤ k·n with the chromatic bound χ ≤ k+1, both from the same IsKDegenerate hypothesis and both realised by the same split graph.\n\n2. **Ordering-free greedy colouring**: records a reusable formalisation of the greedy-colouring theorem that extracts low-degree vertices on the fly from degeneracy rather than materialising an elimination order, keeping the colouring a single global function.\n\n3. **Exact chromatic number of complete split graphs**: χ(K_k ∨ K̄_{n-k}) = k+1 for k < n is now machine-checked, a clean tight example for colouring lower bounds via cliques.\n\n4. **Reusable clique-versus-colouring pattern**: the (k+1)-clique lower bound through IsClique.card_le_of_colorable transfers to other extremal colouring arguments.",
+    "openQuestions": [
+      "Does k-degeneracy give the stronger online/list-colouring bound (k+1)-choosability, and is the split graph still tight for the list chromatic number?",
+      "Among k-degenerate graphs on n vertices with chromatic number exactly k+1, is the complete split graph extremal for edge count, tying the colouring and edge axes together?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1018-oq-01-oq-01",
+      "relationship": "parent-problem",
+      "description": "Parent entry: sharpness of the degeneracy edge bound (k-degenerate ⟹ ≤ k·n edges, tight via the split graph). This entry reuses the IsKDegenerate definition, the split graph, and its k-degeneracy to prove the analogous colouring bound χ ≤ k+1 and its tightness."
+    },
+    {
+      "targetId": "erdos-1018-oq-01",
+      "relationship": "ancestor-problem",
+      "description": "Grandparent entry: the density-to-min-degree extraction lemma. Degeneracy is the invariant controlling both its edge threshold and the chromatic number bounded here."
+    },
+    {
+      "targetId": "erdos-1018",
+      "relationship": "ancestor-problem",
+      "description": "Root problem: non-planar subgraphs in dense graphs (Kostochka–Pyber 1988)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Kostochka, A. V.; Pyber, L. — Small topological complete subgraphs of dense graphs (Combinatorica, 1988)",
+      "url": "https://doi.org/10.1007/BF02122556"
+    },
+    {
+      "title": "Erdős Problem #1018",
+      "url": "https://erdosproblems.com/1018"
+    },
+    {
+      "title": "Graph degeneracy, colouring number, and the greedy bound χ ≤ degeneracy + 1",
+      "url": "https://en.wikipedia.org/wiki/Degeneracy_(graph_theory)"
+    },
+    {
+      "title": "Split graph — complete split graph K_k ∨ K̄_{n-k} and its chromatic number",
+      "url": "https://en.wikipedia.org/wiki/Split_graph"
+    }
+  ],
+  "sorries": []
+}

--- a/src/data/proofs/erdos-1018-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-01-oq-01/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "erdos-1018-oq-01-oq-01",
+  "slug": "erdos-1018-oq-01-oq-01",
+  "title": "The Degeneracy Edge Bound is Sharp: Converse and Extremal Split-Graph Witness",
+  "description": "An axiom-free proof that the density threshold of Erdős #1018 OQ-01 has optimal linear constant. Two halves the parent only asserted: (1) the converse edge bound — every k-degenerate graph has at most k·n edges (contrapositive of the extraction lemma); (2) an explicit extremal witness — the complete split graph S_{n,k} = K_k ∨ K̄_{n-k} is k-degenerate with exactly k·n − C(k+1,2) edges, so the coefficient k cannot be lowered and the additive slack is exactly C(k+1,2).",
+  "meta": {
+    "author": "Research (follow-up open question from Erdős 1018 OQ-01)",
+    "sourceUrl": "https://erdosproblems.com/1018",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1018OQ01OQ01.lean",
+    "tags": [
+      "graph-theory",
+      "extremal-combinatorics",
+      "degeneracy",
+      "minimum-degree",
+      "split-graph",
+      "sharpness",
+      "handshake-lemma",
+      "kostochka-pyber",
+      "erdos",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 246,
+    "assumptions": "None. 0 axioms, 0 sorries (verified by `#print axioms`: splitGraph_sharp, degenerate_edge_bound, and splitGraph_edge_count each depend only on propext, Classical.choice, Quot.sound — the standard foundational axioms, no sorryAx or Lean.ofReduceBool). Builds on the parent entry Erdos1018OQ01 (imported for the extraction lemma exists_dense_induced_subgraph and the degOn definition). The topological step of Kostochka–Pyber is not claimed; only the sharpness of the density-to-min-degree reduction is proved. Verified with the Docker Lean harness against pinned Mathlib 4.26.0.",
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.sum_degrees_eq_twice_card_edges",
+        "description": "Handshake lemma ∑ v, degree v = 2·#edges; converts the summed vertex degrees of the split graph into its edge count",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      },
+      {
+        "theorem": "SimpleGraph.neighborFinset_eq_filter",
+        "description": "neighborFinset v = univ.filter (G.Adj v); used to compute the degree of universal and independent-part vertices",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Finite"
+      },
+      {
+        "theorem": "Finset.sum_filter_add_sum_filter_not",
+        "description": "Splits a sum over univ into the universal part (value < k) and its complement; the two blocks carry constant degrees",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.card_image_of_injective",
+        "description": "Cardinality is preserved under an injective image; with Fin.val_injective it counts the universal part via range k",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.filter_card_add_filter_neg_card_eq_card",
+        "description": "#(filter p) + #(filter ¬p) = #univ; gives the independent part size n − k from the universal part size k",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.even_mul_succ_self",
+        "description": "k(k+1) is even; lets the division-free identity 2|E| + k(k+1) = 2kn collapse to the closed form |E| = kn − k(k+1)/2 via omega",
+        "module": "Mathlib.Algebra.Parity"
+      }
+    ],
+    "originalContributions": [
+      "Converse edge bound degenerate_edge_bound: every k-degenerate graph (every nonempty induced subgraph has a vertex of within-degree ≤ k) has at most k·n edges. Obtained as the exact contrapositive of the parent's exists_dense_induced_subgraph, pinning the upper side of the density threshold.",
+      "Explicit extremal witness: the complete split graph splitGraph n k = K_k ∨ K̄_{n-k} on Fin n (first k vertices universal), defined with a decidable adjacency and a @[simp] adjacency lemma.",
+      "splitGraph_kDegenerate: the split graph is k-degenerate, proved by a direct case split — any independent-part vertex in a set T has at most k neighbours (only the universal vertices), and an all-universal T has ≤ k vertices so within-degree ≤ |T|−1. No vertex ordering is needed (unlike a k-tree).",
+      "splitGraph_two_mul_edges / splitGraph_edge_count: the exact edge count |E(S_{n,k})| = k·n − C(k+1,2) via the handshake lemma (k universal vertices of degree n−1, n−k independent vertices of degree k), stated first in the division-free form 2|E| + k(k+1) = 2kn.",
+      "Sharpness conclusion splitGraph_sharp: combining the witness with degenerate_edge_bound shows the linear coefficient k in Erdős #1018 OQ-01's threshold >k·n is optimal, and the additive gap between the proven bound k·n and the true extremal count is exactly C(k+1,2)."
+    ],
+    "theoremCount": 10,
+    "definitionCount": 2
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos1018OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Erdos1018OQ01"
+    ],
+    "namespace": "Erdos1018OQ01OQ01",
+    "lineCount": 246,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1018OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős problem #1018 (Kostochka–Pyber, 1988) shows every graph on n vertices with at least n^{1+ε} edges contains a small non-planar subgraph. Open question OQ-01 asks for the optimal dependence of the constant C_ε on ε. The parent entry Erdos1018OQ01 proves the first, purely combinatorial reduction — density forces a dense induced subgraph — and states, without proof, that its linear constant k is best possible because 'k-degenerate graphs have ≤ k·n edges and no subgraph of minimum degree > k'. Degeneracy (equivalently the colouring number) is the classical extremal-graph-theory invariant governing this reduction; the extremal k-degenerate graphs are the k-trees, and among them the complete split graph K_k ∨ K̄_{n-k} is the simplest with the maximum edge count k·n − C(k+1,2).",
+    "problemStatement": "Prove the two claims the parent only asserted, thereby certifying that the density threshold >k·n is optimal: (i) the converse edge bound — a k-degenerate graph has at most k·n edges; and (ii) an explicit extremal witness attaining k·n − C(k+1,2) edges while remaining k-degenerate, so no smaller linear coefficient than k can force a dense induced subgraph and the additive slack is exactly C(k+1,2).",
+    "proofStrategy": "Part 1 is the contrapositive of the parent's extraction theorem: if a k-degenerate graph had more than k·n edges, exists_dense_induced_subgraph would produce a nonempty induced subgraph in which every vertex has within-degree > k, contradicting the definition of k-degeneracy (some vertex has within-degree ≤ k). Part 2 constructs splitGraph n k on Fin n with Adj i j := i ≠ j ∧ (i.val < k ∨ j.val < k). Its k-degeneracy is a direct case split: if a set T contains any independent-part vertex v (v.val ≥ k), its neighbours inside T are among the ≤ k universal vertices, so degOn T v ≤ k; otherwise every vertex of T is universal, hence |T| ≤ k and any vertex has degOn ≤ |T|−1 ≤ k. The edge count comes from the handshake lemma: the k universal vertices have degree n−1 and the n−k independent vertices have degree k, so ∑ deg = k(n−1) + (n−k)k = 2kn − k − k², giving 2|E| + k(k+1) = 2kn and the closed form |E| = k·n − C(k+1,2). Cardinalities of the universal part (= k for k ≤ n) are computed by injecting Fin.val into range k.",
+    "keyInsights": [
+      "The optimal constant claimed by the parent is genuinely two statements — an upper bound (k-degenerate ⟹ ≤ k·n edges) and its attainment (a graph with ≈ k·n edges that is k-degenerate) — and only together do they certify sharpness.",
+      "The converse edge bound is literally the contrapositive of the extraction lemma, so no new combinatorial work is needed for the upper side: k-degeneracy is exactly the negation of 'some nonempty induced subgraph has minimum degree > k'.",
+      "The complete split graph is the cleanest extremal witness because its k-degeneracy needs no elimination ordering: independent-part vertices already have degree exactly k, and any all-universal set is small; this sidesteps the k-tree recursion entirely.",
+      "The exact extremal count k·n − C(k+1,2) is recovered division-free from the handshake lemma as 2|E| + k(k+1) = 2kn, keeping the arithmetic omega-friendly; the additive term C(k+1,2) is precisely the edges among the k universal vertices that the loose bound k·n over-counts.",
+      "The proven bound k·n and the extremal value k·n − C(k+1,2) differ by exactly C(k+1,2), so the threshold in Erdős #1018 OQ-01 is optimal in its coefficient and known to within an explicit additive constant."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Header and Overview",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "States the follow-up question — sharpness of the parent's density threshold — and the two halves supplied here: the converse edge bound and the extremal split-graph witness.",
+      "mathContext": "Parent: >k·n edges ⟹ induced subgraph of min-degree ≥ k+1. Here: k-degenerate ⟹ ≤ k·n edges, attained up to C(k+1,2) by K_k ∨ K̄_{n-k}."
+    },
+    {
+      "id": "converse",
+      "title": "The Converse Edge Bound",
+      "startLine": 43,
+      "endLine": 66,
+      "summary": "IsKDegenerate defines k-degeneracy (every nonempty vertex set induces a vertex of within-degree ≤ k). degenerate_edge_bound proves such graphs have ≤ k·n edges, as the contrapositive of the parent's exists_dense_induced_subgraph.",
+      "mathContext": "k-degenerate ⟹ #E ≤ k·n; negating the extraction lemma's conclusion is exactly k-degeneracy."
+    },
+    {
+      "id": "split-graph",
+      "title": "The Complete Split Graph and Universal-Part Counts",
+      "startLine": 68,
+      "endLine": 112,
+      "summary": "splitGraph n k := K_k ∨ K̄_{n-k} with decidable adjacency and a simp adjacency lemma. card_lt_le and card_lt_eq count the universal part {w : w.val < k} (≤ k always, = k when k ≤ n) by injecting Fin.val into range k.",
+      "mathContext": "Adj i j ⟺ i ≠ j ∧ (i.val < k ∨ j.val < k); #{w : w.val < k} = min(n, k)."
+    },
+    {
+      "id": "degrees-edges",
+      "title": "Degrees and the Exact Edge Count",
+      "startLine": 114,
+      "endLine": 185,
+      "summary": "degree_universal (= n−1) and degree_independent (= k) compute the two vertex types. splitGraph_two_mul_edges sums them via the handshake lemma to get 2|E| + k(k+1) = 2kn.",
+      "mathContext": "∑ deg = k(n−1) + (n−k)k = 2kn − k − k²; hence 2|E| + k(k+1) = 2kn."
+    },
+    {
+      "id": "sharpness",
+      "title": "k-Degeneracy of the Witness and the Sharpness Theorem",
+      "startLine": 187,
+      "endLine": 246,
+      "summary": "splitGraph_kDegenerate shows the witness is k-degenerate by a case split on whether a set contains an independent-part vertex. splitGraph_sharp bundles k-degeneracy with the edge count; splitGraph_edge_count gives the closed form k·n − C(k+1,2).",
+      "mathContext": "S_{n,k} is k-degenerate with #E = k·n − C(k+1,2), witnessing that the coefficient k in the threshold >k·n is optimal."
+    }
+  ],
+  "conclusion": {
+    "summary": "The degeneracy edge bound behind Erdős #1018 OQ-01 is proved sharp, axiom-free. The converse (degenerate_edge_bound) shows every k-degenerate graph has at most k·n edges, and the complete split graph S_{n,k} = K_k ∨ K̄_{n-k} (splitGraph_sharp) is k-degenerate with exactly k·n − C(k+1,2) edges. Hence the linear coefficient k in the density threshold >k·n that forces a dense induced subgraph cannot be lowered, and the additive gap between the proven bound and the true extremal count is exactly C(k+1,2).",
+    "implications": "1. **Completes the parent's sharpness claim**: the parent entry asserted but did not prove that its constant is optimal; both halves (upper bound and attaining witness) are now machine-checked.\n\n2. **Explicit extremal graph**: the complete split graph is recorded as a reusable, ordering-free extremal k-degenerate example, simpler than the general k-tree construction.\n\n3. **Localizes C_ε slack**: since the density-to-min-degree reduction is now provably tight to within an explicit additive constant, any remaining looseness in the optimal C_ε for Erdős #1018 must originate in the topological (min-degree ⟹ K₅-subdivision) step.\n\n4. **Reusable counting patterns**: the handshake-based exact edge count of a split graph and the Fin.val-into-range cardinality computation transfer to other extremal constructions.",
+    "openQuestions": [
+      "Can the upper bound be sharpened from k·n to the exact extremal value k·n − C(k+1,2) — i.e. prove that every k-degenerate graph has at most k·n − C(k+1,2) edges — matching the split-graph witness exactly?",
+      "Is the complete split graph the unique extremal k-degenerate graph on n vertices, or do other (e.g. k-tree) constructions attain k·n − C(k+1,2) edges?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1018-oq-01",
+      "relationship": "parent-problem",
+      "description": "Parent entry: the density-to-min-degree extraction lemma (>k·n edges ⟹ induced min-degree ≥ k+1) whose optimal-constant claim this entry proves, supplying both the converse edge bound and the extremal witness."
+    },
+    {
+      "targetId": "erdos-1018",
+      "relationship": "ancestor-problem",
+      "description": "Root problem: non-planar subgraphs in dense graphs (Kostochka–Pyber 1988). This entry certifies that the combinatorial reduction step contributes no slack to the optimal constant C_ε."
+    }
+  ],
+  "references": [
+    {
+      "title": "Kostochka, A. V.; Pyber, L. — Small topological complete subgraphs of dense graphs (Combinatorica, 1988)",
+      "url": "https://doi.org/10.1007/BF02122556"
+    },
+    {
+      "title": "Erdős Problem #1018",
+      "url": "https://erdosproblems.com/1018"
+    },
+    {
+      "title": "Graph degeneracy and the colouring number (extremal k-degenerate graphs)",
+      "url": "https://en.wikipedia.org/wiki/Degeneracy_(graph_theory)"
+    },
+    {
+      "title": "Split graph — complete split graph K_k ∨ K̄_{n-k}",
+      "url": "https://en.wikipedia.org/wiki/Split_graph"
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
Two coherent, axiom-free follow-ups to the Erdős #1018 OQ-01 degeneracy reduction, both certifying sharpness of the degeneracy parameter and both realised by the **same** complete split graph `S_{n,k} = K_k ∨ K̄_{n-k}`.

## Entry 1 — `erdos-1018-oq-01-oq-01`: the edge bound is sharp (`Erdos1018OQ01OQ01.lean`)
The parent only *asserted* its linear constant `k` is optimal. This supplies both halves:
- **`degenerate_edge_bound`** — every `k`-degenerate graph has `≤ k·n` edges (contrapositive of the extraction lemma).
- **`splitGraph_sharp` / `splitGraph_edge_count`** — `S_{n,k}` is `k`-degenerate with exactly `k·n − C(k+1,2)` edges (handshake lemma, no vertex ordering).

## Entry 2 — `erdos-1018-oq-01-oq-01-oq-01`: degeneracy ⟹ χ ≤ k+1, tight (`Erdos1018OQ01OQ01OQ01.lean`)
Turns the identical `IsKDegenerate` hypothesis onto the colouring axis:
- **`degenerate_colorable`** — every `k`-degenerate graph is `(k+1)`-colourable, by strong induction on the vertex set (greedy colouring with no materialised elimination order; a free colour is produced by a proper-subset argument over `Fin (k+1)`).
- **`splitGraph_not_colorable` / `splitGraph_chromatic`** — `S_{n,k}` contains a `(k+1)`-clique for `k < n`, so it is not `k`-colourable; combined with the greedy bound, `χ(S_{n,k}) = k+1` exactly.

Together: the complete split graph simultaneously realises both extremal facts of #1018's degeneracy parameter — `≈ k·n` edges **and** chromatic number exactly `k+1`.

## Verification
- **0 axioms** (each result depends only on `propext, Classical.choice, Quot.sound` — verified by `#print axioms`; no `sorryAx`, no `Lean.ofReduceBool`), **0 sorries**.
- Built with the Docker Lean harness against pinned Mathlib 4.26.0.
- Entry 2 builds on Entry 1 (imports `Proofs.Erdos1018OQ01OQ01`), so the two are stacked in one PR to guarantee they compile as a unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)