### PR TITLE
Fix: realign stale leanFile counts for birthday-problem-oq-02-oq-01-oq-03

### DIFF
--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/meta.json
@@ -48,10 +48,10 @@
     ],
     "dateAdded": "2026-06-25",
     "axiomCount": 0,
-    "lineCount": 136,
+    "lineCount": 212,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms on collisionProb_monotone and birthdayProduct_antitone reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide, no structure-encoded hypotheses. Self-contained: imports only Mathlib and restates the standard birthdayProduct of the OQ-02-OQ-01 lineage (whose source predates current Mathlib API), so it does not depend on any other project file.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 18,
     "definitionCount": 2
   },
   "overview": {
@@ -140,9 +140,9 @@
   ],
   "leanFile": {
     "namespace": "BirthdayProblemOQ02OQ01OQ03",
-    "lineCount": 136,
+    "lineCount": 212,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 18,
     "definitionCount": 2,
     "path": "Proofs/BirthdayProblemOQ02OQ01OQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

The count blocks in `src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/meta.json` were stale after research PR #31498 (strict monotonicity + pigeonhole certainty) grew the main Lean file from 136 to 212 lines and added theorems. Both the `meta` sub-block and the nested `leanFile` block were realigned.

## Evidence

Canonical counts for `Proofs/BirthdayProblemOQ02OQ01OQ03.lean` per the extractor conventions in `scripts/research/enrich-research.ts` (col-0 `theorem`/`lemma`; col-0 `def`/`noncomputable def`/`opaque def`):

| field | old | new |
|-------|-----|-----|
| lineCount | 136 | **212** |
| theoremCount | 9 | **18** |
| definitionCount | 2 | 2 (unchanged) |
| axiomCount | 0 | 0 (unchanged) |
| sorries | 0 | 0 (unchanged) |

Metadata-only change. Entry remains `verified`, 0-axiom, 0-sorry; no Lean source modified. JSON validated with `json.tool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)