### PR TITLE
Fix: realign stale leanFile counts for markov-equation

### DIFF
--- a/src/data/proofs/markov-equation/meta.json
+++ b/src/data/proofs/markov-equation/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-06-21",
-    "lineCount": 237,
+    "lineCount": 344,
     "originalContributions": [
       "IsMarkov predicate and markov_one: the singular solution (1,1,1)",
       "markov_vieta: the Vieta jump z ↦ 3xy − z preserves Markov triples (with positivity)",
@@ -33,8 +33,8 @@
       "markov_all_eq: (t,t,t) is Markov iff t = 1 (uniqueness of the singular solution)"
     ],
     "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound. No native_decide is used.",
-    "theoremCount": 17,
-    "definitionCount": 3
+    "theoremCount": 21,
+    "definitionCount": 2
   },
   "sections": [
     {
@@ -121,12 +121,12 @@
     ]
   },
   "leanFile": {
-    "lineCount": 274,
+    "lineCount": 344,
     "axiomCount": 0,
     "path": "Proofs/MarkovEquation.lean",
     "sorries": 0,
-    "definitionCount": 3,
-    "theoremCount": 18
+    "definitionCount": 2,
+    "theoremCount": 21
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

The count blocks in `src/data/proofs/markov-equation/meta.json` were stale after research PRs #30586 and #30631 (Vieta geometric-growth engine) grew the main Lean file. Both the `meta` sub-block and the nested `leanFile` block were realigned.

## Evidence

Canonical counts for `Proofs/MarkovEquation.lean` per `scripts/research/enrich-research.ts` (col-0 `theorem`/`lemma`; col-0 `def`/`noncomputable def`/`opaque def`):

| field | meta old | leanFile old | new |
|-------|----------|--------------|-----|
| lineCount | 237 | 274 | **344** |
| theoremCount | 17 | 18 | **21** |
| definitionCount | 3 | 3 | **2** |
| axiomCount | 0 | 0 | 0 |
| sorries | — | 0 | 0 |

`definitionCount` drops to 2 because the extractor counts only `def`/`noncomputable def`/`opaque def` (lines 32, 233); the `inductive Step` at line 227 was previously miscounted as a definition.

Metadata-only change. Entry remains `verified`, 0-axiom, 0-sorry; no Lean source modified. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)