### PR TITLE
research(erdos-1207-oq-03): explicit base-3 lower bound P₁(3ᵏ) ≥ 2ᵏ for the 1-D isosceles-free problem [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1207OQ03.lean
+++ b/proofs/Proofs/Erdos1207OQ03.lean
@@ -1,0 +1,188 @@
+/-
+Erdős Problem #1207 — follow-up (OQ-03): an explicit quantitative lower bound
+for the one-dimensional case, via the base-3 "no digit 2" construction.
+
+The parent entry `Proofs/Erdos1207Problem.lean` reduces the `d = 1` case of
+Erdős #1207 to the midpoint-free / 3-term-arithmetic-progression-free problem
+through the bridge `Erdos1207.isoscelesFree_iff_midpointFree`. Its open question
+OQ-03 asks whether that bridge can be combined with quantitative 3-AP-free
+bounds to pin down `P_1(n)`.
+
+This file supplies the **classical elementary lower bound**. Consider the
+numbers whose base-3 representation uses only the digits `0` and `1`:
+
+    S_k = { ∑_{i<k} bᵢ · 3ⁱ : bᵢ ∈ {0,1} } ⊆ {0, 1, …, 3ᵏ − 1}.
+
+We prove, with no `axiom` and no `sorry`:
+
+  * `toNat` is injective on `Fin k → Fin 2` (base-3 digit uniqueness), so
+    `|S_k| = 2ᵏ`  (`card_image_base3`, `ncard_range_embR`).
+  * `S_k` is **midpoint-free** (`midpointFree_range_embR`): no element is the
+    average of two distinct elements — i.e. `S_k` contains no nontrivial
+    3-term arithmetic progression. The heart is a carry-free base-3 argument
+    (`toNat_two_mul_eq`): if `2·toNat d = toNat b + toNat c` then
+    `toNat b = toNat c`.
+  * Hence, through the parent bridge, `S_k` is **isosceles-free**
+    (`isoscelesFree_range_embR`).
+  * Packaged bound (`exists_isoscelesFree_pow`): for every `k` there is an
+    isosceles-free `S ⊆ [0, 3ᵏ)` with `|S| = 2ᵏ`.
+
+Since `2ᵏ = (3ᵏ)^{log₃ 2}` with `log₃ 2 ≈ 0.6309`, this gives
+`P_1(3ᵏ) ≥ 2ᵏ`, a constructive `n^{log₃ 2}` lower bound. It is weaker than the
+Behrend bound `n / exp(O(√log n))` but is fully explicit and machine-checked,
+and it is optimal among the "restricted digit" constructions.
+
+Reference: https://erdosproblems.com/1207
+-/
+
+import Mathlib
+import Proofs.Erdos1207Problem
+
+namespace Erdos1207OQ03
+
+open Finset
+
+/- ## The base-3 digit map -/
+
+/-- The natural number whose base-3 digits (from least significant) are the
+values of `b : Fin k → Fin 2`. All digits are `0` or `1`. -/
+def toNat (k : ℕ) (b : Fin k → Fin 2) : ℕ :=
+  ∑ i : Fin k, (b i : ℕ) * 3 ^ (i : ℕ)
+
+@[simp] theorem toNat_zero (b : Fin 0 → Fin 2) : toNat 0 b = 0 := by
+  simp [toNat]
+
+/-- Peeling off the least significant digit: `toNat (k+1) b = b₀ + 3·toNat k (tail b)`. -/
+theorem toNat_succ {k : ℕ} (b : Fin (k + 1) → Fin 2) :
+    toNat (k + 1) b = (b 0 : ℕ) + 3 * toNat k (Fin.tail b) := by
+  unfold toNat
+  rw [Fin.sum_univ_succ]
+  simp only [Fin.val_zero, pow_zero, mul_one, Fin.val_succ, Fin.tail]
+  rw [Finset.mul_sum]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [pow_succ]
+  ring
+
+/-- A single digit is at most `1`. -/
+theorem digit_le_one {k : ℕ} (b : Fin k → Fin 2) (i : Fin k) : (b i : ℕ) ≤ 1 :=
+  Nat.lt_succ_iff.mp (b i).is_lt
+
+/- ## Injectivity (base-3 digit uniqueness) -/
+
+/-- `toNat` is injective: distinct `{0,1}`-digit strings give distinct numbers.
+This is base-3 representation uniqueness, restricted to digits `0,1`. -/
+theorem toNat_injective (k : ℕ) : Function.Injective (toNat k) := by
+  induction k with
+  | zero =>
+      intro b c _
+      funext i; exact i.elim0
+  | succ k ih =>
+      intro b c h
+      rw [toNat_succ, toNat_succ] at h
+      have hb0 : (b 0 : ℕ) ≤ 1 := digit_le_one b 0
+      have hc0 : (c 0 : ℕ) ≤ 1 := digit_le_one c 0
+      -- least significant digit is `toNat … % 3`; the higher part is `… / 3`.
+      have hdig : (b 0 : ℕ) = (c 0 : ℕ) ∧ toNat k (Fin.tail b) = toNat k (Fin.tail c) := by
+        constructor <;> omega
+      have htail : Fin.tail b = Fin.tail c := ih hdig.2
+      -- reconstruct `b = c` from equal head digit and equal tail
+      funext i
+      refine Fin.cases ?_ ?_ i
+      · exact Fin.val_injective hdig.1
+      · intro j
+        have := congrFun htail j
+        simpa [Fin.tail] using this
+
+/- ## Carry-free base-3 arithmetic: the midpoint obstruction -/
+
+/-- **Core carry-free lemma.** If `2 · toNat d = toNat b + toNat c` for
+`{0,1}`-digit strings, then `toNat b = toNat c`. In base 3 there are no carries
+(digit sums stay below `3`), so the digits must agree pairwise. -/
+theorem toNat_two_mul_eq (k : ℕ) (b c d : Fin k → Fin 2)
+    (h : 2 * toNat k d = toNat k b + toNat k c) : toNat k b = toNat k c := by
+  induction k with
+  | zero => simp [toNat_zero]
+  | succ k ih =>
+      rw [toNat_succ, toNat_succ, toNat_succ] at h
+      have hb0 : (b 0 : ℕ) ≤ 1 := digit_le_one b 0
+      have hc0 : (c 0 : ℕ) ≤ 1 := digit_le_one c 0
+      have hd0 : (d 0 : ℕ) ≤ 1 := digit_le_one d 0
+      -- Split the single equation into the digit part and the higher part.
+      have hsplit : (b 0 : ℕ) = (c 0 : ℕ) ∧
+          2 * toNat k (Fin.tail d) = toNat k (Fin.tail b) + toNat k (Fin.tail c) := by
+        constructor <;> omega
+      have htail := ih (Fin.tail b) (Fin.tail c) (Fin.tail d) hsplit.2
+      rw [toNat_succ, toNat_succ, hsplit.1, htail]
+
+/- ## The real-valued embedding and the set `S_k` -/
+
+/-- The base-3 digit map, valued in `ℝ`. Its range is `S_k`. -/
+def embR (k : ℕ) (b : Fin k → Fin 2) : ℝ := (toNat k b : ℝ)
+
+theorem embR_injective (k : ℕ) : Function.Injective (embR k) := by
+  intro b c h
+  simp only [embR] at h
+  exact toNat_injective k (by exact_mod_cast h)
+
+/-- Every element of `S_k` lies in `[0, 3ᵏ)`. -/
+theorem toNat_lt_pow (k : ℕ) (b : Fin k → Fin 2) : toNat k b < 3 ^ k := by
+  induction k with
+  | zero => simp [toNat_zero]
+  | succ k ih =>
+      rw [toNat_succ]
+      have hb0 : (b 0 : ℕ) ≤ 1 := digit_le_one b 0
+      have hih := ih (Fin.tail b)
+      have h3 : (0 : ℕ) < 3 ^ k := by positivity
+      calc (b 0 : ℕ) + 3 * toNat k (Fin.tail b)
+          ≤ 1 + 3 * (3 ^ k - 1) := by omega
+        _ < 3 ^ (k + 1) := by rw [pow_succ]; omega
+
+theorem embR_mem_Ico (k : ℕ) (b : Fin k → Fin 2) :
+    embR k b ∈ Set.Ico (0 : ℝ) (3 ^ k) := by
+  constructor
+  · simp only [embR]; positivity
+  · have : (toNat k b : ℝ) < ((3 ^ k : ℕ) : ℝ) := by exact_mod_cast toNat_lt_pow k b
+    simpa [embR] using this
+
+/- ## `S_k` is midpoint-free, hence isosceles-free -/
+
+/-- `S_k = range (embR k)` is midpoint-free: no element is the average of two
+distinct elements (no nontrivial 3-term arithmetic progression). -/
+theorem midpointFree_range_embR (k : ℕ) :
+    Erdos1207.MidpointFree (Set.range (embR k)) := by
+  rintro x ⟨b, rfl⟩ y ⟨d, rfl⟩ z ⟨c, rfl⟩ hxz hap
+  -- `hap : 2 * embR d = embR b + embR c`, real equation; push to ℕ.
+  have hnat : 2 * toNat k d = toNat k b + toNat k c := by
+    have : ((2 * toNat k d : ℕ) : ℝ) = ((toNat k b + toNat k c : ℕ) : ℝ) := by
+      push_cast [embR] at hap ⊢; linarith
+    exact_mod_cast this
+  have : toNat k b = toNat k c := toNat_two_mul_eq k b c d hnat
+  exact hxz (by simp [embR, this])
+
+/-- Through the parent one-dimensional bridge, `S_k` is isosceles-free. -/
+theorem isoscelesFree_range_embR (k : ℕ) :
+    Erdos1207.IsoscelesFree (Set.range (embR k)) :=
+  (Erdos1207.isoscelesFree_iff_midpointFree _).2 (midpointFree_range_embR k)
+
+/- ## Cardinality: `|S_k| = 2ᵏ` -/
+
+theorem ncard_range_embR (k : ℕ) : (Set.range (embR k)).ncard = 2 ^ k := by
+  rw [Set.ncard_range_of_injective (embR_injective k), Nat.card_fun]
+  simp [Nat.card_eq_fintype_card]
+
+/- ## Packaged quantitative lower bound -/
+
+/-- **Explicit `n^{log₃ 2}` lower bound for `P_1`.** For every `k` there is an
+isosceles-free set `S ⊆ [0, 3ᵏ)` of real numbers with exactly `2ᵏ` elements.
+Equivalently `P_1(3ᵏ) ≥ 2ᵏ`: the base-3 "no digit 2" set realises the classical
+elementary lower bound for the one-dimensional case of Erdős #1207. -/
+theorem exists_isoscelesFree_pow (k : ℕ) :
+    ∃ S : Set ℝ, Erdos1207.IsoscelesFree S ∧ S ⊆ Set.Ico (0 : ℝ) (3 ^ k) ∧
+      S.ncard = 2 ^ k := by
+  refine ⟨Set.range (embR k), isoscelesFree_range_embR k, ?_, ncard_range_embR k⟩
+  rintro x ⟨b, rfl⟩
+  exact embR_mem_Ico k b
+
+end Erdos1207OQ03

--- a/src/data/proofs/erdos-1207-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1207-oq-03/annotations.json
@@ -1,0 +1,129 @@
+[
+  {
+    "id": "ann-1207-oq03-header",
+    "proofId": "erdos-1207-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Base-3 lower bound for the 1-D case",
+    "content": "The parent entry reduces the one-dimensional case of Erdős #1207 to the midpoint-free (3-term-AP-free) problem. This file answers the lower-bound side of open question OQ-03 with the classical base-3 'no digit 2' construction: the numbers whose base-3 digits are all 0 or 1 form a midpoint-free set, giving an explicit isosceles-free subset of {0,…,3ᵏ−1} of size 2ᵏ, i.e. P₁(3ᵏ) ≥ 2ᵏ = (3ᵏ)^{log₃2}.",
+    "mathContext": "2ᵏ out of 3ᵏ is an n^{log₃2} ≈ n^{0.63} lower bound — explicit and verified, but weaker than Behrend.",
+    "significance": "key",
+    "relatedConcepts": [
+      "3-AP-free sets",
+      "base-3 representation",
+      "Behrend construction"
+    ],
+    "prerequisites": [
+      "positional representation",
+      "arithmetic progressions"
+    ]
+  },
+  {
+    "id": "ann-1207-oq03-tonat",
+    "proofId": "erdos-1207-oq-03",
+    "range": {
+      "startLine": 49,
+      "endLine": 70
+    },
+    "type": "definition",
+    "title": "The base-3 digit map and its recursion",
+    "content": "toNat k b = ∑_{i<k} bᵢ·3ⁱ encodes a digit string b : Fin k → Fin 2 (digits 0 or 1) as a natural number. The key structural fact is toNat_succ: peeling the least significant digit gives toNat (k+1) b = b₀ + 3·toNat k (tail b). This single recursion drives every subsequent induction.",
+    "mathContext": "Obtained from Finset.sum_univ_succ after factoring 3 out of the higher-order terms; digit_le_one bounds each digit by 1.",
+    "significance": "important",
+    "relatedConcepts": [
+      "positional representation",
+      "Finset.sum_univ_succ"
+    ],
+    "prerequisites": [
+      "finite sums over Fin n"
+    ]
+  },
+  {
+    "id": "ann-1207-oq03-injective",
+    "proofId": "erdos-1207-oq-03",
+    "range": {
+      "startLine": 76,
+      "endLine": 96
+    },
+    "type": "theorem",
+    "title": "Digit uniqueness (injectivity)",
+    "content": "toNat_injective: distinct {0,1}-digit strings encode distinct numbers. This is base-3 representation uniqueness restricted to digits 0,1, and it makes |S_k| = 2ᵏ. The proof inducts with toNat_succ: the units digit is determined modulo 3 (all digits < 3), the higher part by division, and Fin.cases reassembles equality of the strings.",
+    "mathContext": "The single linear equation b₀ + 3·B' = c₀ + 3·C' with b₀,c₀ ≤ 1 forces b₀ = c₀ and B' = C'; omega decides it.",
+    "significance": "important",
+    "relatedConcepts": [
+      "base-3 uniqueness",
+      "injectivity"
+    ],
+    "prerequisites": [
+      "induction",
+      "modular arithmetic"
+    ]
+  },
+  {
+    "id": "ann-1207-oq03-core",
+    "proofId": "erdos-1207-oq-03",
+    "range": {
+      "startLine": 103,
+      "endLine": 117
+    },
+    "type": "theorem",
+    "title": "Carry-free core: the midpoint obstruction",
+    "content": "toNat_two_mul_eq is the heart of the file: if 2·toNat d = toNat b + toNat c for {0,1}-digit strings, then toNat b = toNat c. Because digit sums stay below the base 3, base-3 addition never carries, so the digits must match pairwise. Reading the hypothesis modulo 3 gives 2d₀ = b₀+c₀; with b₀,c₀ ∈ {0,1} this forces b₀ = c₀, and dividing by 3 recurses on the tails.",
+    "mathContext": "After toNat_succ, the goal splits (via omega) into the units identity 2d₀ = b₀+c₀ and the tail identity 2D' = B'+C', closed by the induction hypothesis.",
+    "significance": "key",
+    "relatedConcepts": [
+      "carry-free addition",
+      "3-AP-free",
+      "midpoint condition"
+    ],
+    "prerequisites": [
+      "induction",
+      "modular arithmetic"
+    ]
+  },
+  {
+    "id": "ann-1207-oq03-midpointfree",
+    "proofId": "erdos-1207-oq-03",
+    "range": {
+      "startLine": 151,
+      "endLine": 167
+    },
+    "type": "theorem",
+    "title": "S_k is midpoint-free, hence isosceles-free",
+    "content": "midpointFree_range_embR casts the real average equation 2y = x+z back to ℕ and applies the carry-free core to conclude x = z — so no element of S_k is the midpoint of two distinct elements. isoscelesFree_range_embR then composes with the parent bridge isoscelesFree_iff_midpointFree to upgrade this to isosceles-freeness on ℝ.",
+    "mathContext": "The bridge (parent entry) turns 'midpoint-free on ℝ' into 'isosceles-free', since on a line the apex of an isosceles triangle must be the midpoint.",
+    "significance": "key",
+    "relatedConcepts": [
+      "midpoint-free",
+      "isosceles-free",
+      "one-dimensional bridge"
+    ],
+    "prerequisites": [
+      "casting ℕ ↔ ℝ"
+    ]
+  },
+  {
+    "id": "ann-1207-oq03-headline",
+    "proofId": "erdos-1207-oq-03",
+    "range": {
+      "startLine": 169,
+      "endLine": 188
+    },
+    "type": "theorem",
+    "title": "The explicit lower bound P₁(3ᵏ) ≥ 2ᵏ",
+    "content": "ncard_range_embR shows |S_k| = 2ᵏ (injectivity + Nat.card of Fin k → Fin 2), and toNat_lt_pow places S_k in {0,…,3ᵏ−1}. exists_isoscelesFree_pow packages the result: for every k there is an isosceles-free S ⊆ [0, 3ᵏ) with exactly 2ᵏ elements — a constructive n^{log₃2} lower bound for the one-dimensional case.",
+    "mathContext": "2ᵏ = (3ᵏ)^{log₃2}; the bound is explicit and machine-checked but strictly weaker than Behrend's n·exp(−O(√log n)).",
+    "significance": "key",
+    "relatedConcepts": [
+      "lower bound",
+      "cardinality",
+      "Set.ncard"
+    ],
+    "prerequisites": [
+      "counting the range of an injective map"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1207-oq-03/meta.json
+++ b/src/data/proofs/erdos-1207-oq-03/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "erdos-1207-oq-03",
+  "title": "Erdős #1207 (OQ-03): Explicit base-3 lower bound P₁(3ᵏ) ≥ 2ᵏ",
+  "slug": "erdos-1207-oq-03",
+  "description": "A quantitative follow-up to Erdős #1207. The parent entry reduces the one-dimensional case to the midpoint-free / 3-term-arithmetic-progression-free problem. Its open question OQ-03 asks whether that bridge can be combined with quantitative 3-AP-free bounds. This entry supplies the classical elementary lower bound: the set of numbers whose base-3 digits are all 0 or 1 is midpoint-free (3-AP-free), giving an explicit isosceles-free subset of {0,…,3ᵏ−1} of size 2ᵏ, i.e. P₁(3ᵏ) ≥ 2ᵏ = (3ᵏ)^{log₃2}. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Erdős (Er80); formalization by researcher-5",
+    "sourceUrl": "https://erdosproblems.com/1207",
+    "date": "1980",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1207OQ03.lean",
+    "tags": [
+      "erdos",
+      "combinatorial-geometry",
+      "discrete-geometry",
+      "arithmetic-progressions",
+      "3-ap-free",
+      "midpoint-free",
+      "base-3",
+      "lower-bound",
+      "open"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 1207,
+    "erdosUrl": "https://erdosproblems.com/1207",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_univ_succ",
+        "description": "Peeling the first term off a sum over Fin (n+1)",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      },
+      {
+        "theorem": "Set.ncard_range_of_injective",
+        "description": "The range of an injective map has ncard equal to the domain's Nat.card",
+        "module": "Mathlib.Data.Set.Card"
+      },
+      {
+        "theorem": "Nat.card_fun",
+        "description": "Nat.card (α → β) = Nat.card β ^ Nat.card α for finite α",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      }
+    ],
+    "originalContributions": [
+      "toNat (definition): the natural number with base-3 digits given by b : Fin k → Fin 2 — the restricted-digit encoding underlying the construction",
+      "toNat_succ (verified, 0-axiom): least-significant-digit recursion toNat (k+1) b = b₀ + 3·toNat k (tail b), the workhorse for every induction",
+      "toNat_injective (verified, 0-axiom): base-3 digit uniqueness restricted to digits 0,1 — distinct digit strings give distinct numbers, so |S_k| = 2ᵏ",
+      "toNat_two_mul_eq (verified, 0-axiom): THE CARRY-FREE CORE — if 2·toNat d = toNat b + toNat c for {0,1}-digit strings then toNat b = toNat c; in base 3 the digit sums stay below 3 so there are no carries and the digits must agree",
+      "toNat_lt_pow (verified, 0-axiom): every element of S_k is < 3ᵏ, placing S_k inside {0,…,3ᵏ−1}",
+      "midpointFree_range_embR (verified, 0-axiom): S_k is midpoint-free — it contains no nontrivial 3-term arithmetic progression",
+      "isoscelesFree_range_embR (verified, 0-axiom): through the parent bridge isoscelesFree_iff_midpointFree, S_k is isosceles-free",
+      "ncard_range_embR (verified, 0-axiom): |S_k| = 2ᵏ, via injectivity and Nat.card of the function space Fin k → Fin 2",
+      "exists_isoscelesFree_pow (verified, 0-axiom): THE HEADLINE — for every k there is an isosceles-free S ⊆ [0, 3ᵏ) with |S| = 2ᵏ, i.e. the explicit lower bound P₁(3ᵏ) ≥ 2ᵏ"
+    ],
+    "axiomCount": 0,
+    "lineCount": 188,
+    "assumptions": "None. All declarations are fully machine-checked: 0 axiom declarations, 0 structure-encoded assumptions, 0 sorries. The construction gives a constructive n^{log₃2} lower bound for the one-dimensional case; it does not resolve the open growth question for P_d(n), and it is deliberately weaker than the Behrend bound (which this elementary digit construction cannot reach).",
+    "theoremCount": 12,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "**Erdős #1207, one-dimensional case.** The parent formalization proves that on the real line an isosceles-free set is exactly a midpoint-free (3-term-AP-free) set. Estimating the largest guaranteed such subset, P₁(n), is then the classical Behrend/Roth extremal problem for progression-free sets. The oldest lower bound is the *restricted-digit* construction: numbers whose base-3 expansion avoids the digit 2 form a 3-AP-free set. It predates Behrend's stronger bound and remains the cleanest explicit family.",
+    "problemStatement": "**OQ-03 (from the parent).** Can the one-dimensional bridge be combined with quantitative 3-AP-free bounds to pin down P₁(n)? This entry answers the lower-bound side with the elementary base-3 construction: exhibit, for each k, an explicit isosceles-free subset of {0,…,3ᵏ−1} of size 2ᵏ.",
+    "text": "Take S_k = { ∑_{i<k} bᵢ·3ⁱ : bᵢ ∈ {0,1} } ⊆ {0,…,3ᵏ−1}. Because base-3 addition of digit-{0,1} numbers never carries, no element is the average of two distinct elements, so S_k is midpoint-free hence isosceles-free; and the digits are unique, so |S_k| = 2ᵏ. This gives P₁(3ᵏ) ≥ 2ᵏ = (3ᵏ)^{log₃2}.",
+    "proofStrategy": "**Carry-free base-3 argument.**\n\n1. **Encoding.** toNat k b = ∑_{i<k} bᵢ·3ⁱ for b : Fin k → Fin 2, with the recursion toNat (k+1) b = b₀ + 3·toNat k (tail b).\n\n2. **Core lemma (no carries).** If 2·toNat d = toNat b + toNat c then, reading the equation modulo 3, the units digits satisfy 2d₀ = b₀+c₀ (all terms < 3, so no wraparound); dividing by 3 recurses on the tails. Since b₀,c₀ ∈ {0,1}, 2d₀ = b₀+c₀ forces b₀ = c₀. Induction gives toNat b = toNat c.\n\n3. **Midpoint-free ⇒ isosceles-free.** Casting to ℝ, the core lemma says no element of S_k is the average of two distinct elements; the parent bridge isoscelesFree_iff_midpointFree upgrades this to isosceles-free.\n\n4. **Cardinality.** The same mod-3 recursion proves toNat injective, so |S_k| = |Fin k → Fin 2| = 2ᵏ; and toNat k b < 3ᵏ places S_k in {0,…,3ᵏ−1}.",
+    "prerequisites": [
+      "Positional (base-b) representation of natural numbers and digit uniqueness",
+      "Arithmetic progressions and the midpoint/average condition on ℝ",
+      "The parent entry's one-dimensional bridge isoscelesFree_iff_midpointFree",
+      "Counting the range of an injective map from a finite function space"
+    ],
+    "keyInsights": [
+      "**No carries in base 3.** Digits drawn from {0,1} keep every digit sum below the base 3, so addition is carry-free and the base-3 representation is rigid — this is the whole reason the set is progression-free.",
+      "**One induction, two payloads.** The least-significant-digit recursion toNat (k+1) b = b₀ + 3·toNat k (tail b) drives both injectivity (⇒ size 2ᵏ) and the midpoint obstruction (⇒ 3-AP-free).",
+      "**omega finishes the digit step.** Once the recursion is unfolded, the split '2d₀ = b₀+c₀ and 2·tail = tail+tail' from a single linear equation with digit bounds ≤ 1 is exactly what omega decides.",
+      "**Honest strength.** 2ᵏ out of 3ᵏ is n^{log₃2} ≈ n^{0.63} — explicit and verified, but strictly weaker than Behrend's n/exp(O(√log n)); the digit construction provably cannot reach Behrend."
+    ]
+  },
+  "sections": [
+    {
+      "id": "encoding",
+      "title": "The base-3 digit map",
+      "summary": "toNat encodes b : Fin k → Fin 2 as ∑ bᵢ·3ⁱ, with the least-significant-digit recursion toNat_succ.",
+      "startLine": 45,
+      "endLine": 70,
+      "mathContext": "toNat k b := ∑ i, (b i)·3^i. toNat_succ: toNat (k+1) b = b₀ + 3·toNat k (Fin.tail b), obtained from Finset.sum_univ_succ; digit_le_one bounds each digit by 1."
+    },
+    {
+      "id": "injectivity",
+      "title": "Injectivity (digit uniqueness)",
+      "summary": "toNat_injective: distinct {0,1}-digit strings give distinct numbers — base-3 representation uniqueness restricted to digits 0,1.",
+      "startLine": 72,
+      "endLine": 96,
+      "mathContext": "By induction on k using toNat_succ: the units digit is determined mod 3 (digits < 3), the higher part by division; omega splits the single linear equation, then Fin.cases reassembles equality of the two digit strings."
+    },
+    {
+      "id": "carry-free-core",
+      "title": "Carry-free core: the midpoint obstruction",
+      "summary": "toNat_two_mul_eq: if 2·toNat d = toNat b + toNat c then toNat b = toNat c. In base 3 there are no carries, so digits agree pairwise.",
+      "startLine": 98,
+      "endLine": 117,
+      "mathContext": "Induction on k: toNat_succ turns the hypothesis into 2(d₀+3·D') = (b₀+3·B') + (c₀+3·C') with all digits ≤ 1; omega extracts b₀ = c₀ and 2D' = B'+C', and the IH closes the tails."
+    },
+    {
+      "id": "embedding-and-bound",
+      "title": "Real embedding, midpoint-freeness, and the bound",
+      "summary": "embR (ℝ-valued encoding), toNat_lt_pow (S_k ⊆ [0,3ᵏ)), midpointFree/isoscelesFree of S_k, |S_k| = 2ᵏ, and the packaged lower bound.",
+      "startLine": 119,
+      "endLine": 188,
+      "mathContext": "midpointFree_range_embR pushes the real average equation to ℕ and applies the core lemma; isoscelesFree_range_embR composes with the parent bridge; ncard_range_embR = 2ᵏ via Set.ncard_range_of_injective and Nat.card_fun; exists_isoscelesFree_pow packages an isosceles-free S ⊆ [0,3ᵏ) of size 2ᵏ."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the lower-bound side of Erdős #1207's OQ-03 for the one-dimensional case. Via the parent bridge, isosceles-free on ℝ = 3-AP-free, and the classical base-3 'no digit 2' construction gives, for every k, an explicit isosceles-free subset of {0,…,3ᵏ−1} of size 2ᵏ. Hence P₁(3ᵏ) ≥ 2ᵏ = (3ᵏ)^{log₃2}. Everything is machine-checked with no axioms or sorries.",
+    "implications": "**Significance**\n\n1. **Concrete lower bound.** Turns the parent's qualitative reduction into a quantitative, fully explicit family, realising an n^{log₃2} lower bound for P₁.\n2. **Reusable carry-free toolkit.** The least-significant-digit recursion toNat_succ plus omega gives a clean, general pattern for base-b digit arguments (injectivity and progression-freeness) that other 3-AP-free formalizations can reuse.\n3. **Honest framing.** States plainly that the elementary digit bound is weaker than Behrend and does not settle the open growth question.",
+    "openQuestions": [
+      "Can Behrend's stronger bound r₃(n) ≥ n·exp(−O(√log n)) be formalized to improve the exponent beyond log₃2?",
+      "Is there a matching upper bound P₁(n) ≤ r₃(n) making the reduction to 3-AP-free tight, and can it be formalized via the worst-case arithmetic-progression configuration?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1207",
+      "relationship": "parent",
+      "description": "Parent problem: the definitions and the one-dimensional bridge isoscelesFree_iff_midpointFree that this entry builds on."
+    },
+    {
+      "targetId": "erdos-1",
+      "relationship": "related",
+      "description": "Erdős #1: the distinct-distances circle of problems surrounding equal-distance and isosceles configurations."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "P. Erdős"
+      ],
+      "title": "Some combinatorial problems in geometry",
+      "venue": "Geometry and Differential Geometry (Lecture Notes in Math. 792)",
+      "year": "1980",
+      "pages": "46–53",
+      "note": "Source of Problem #1207."
+    },
+    {
+      "authors": [
+        "F. A. Behrend"
+      ],
+      "title": "On sets of integers which contain no three terms in arithmetical progression",
+      "venue": "Proc. Nat. Acad. Sci. U.S.A.",
+      "year": "1946",
+      "volume": "32",
+      "pages": "331–332",
+      "note": "The stronger 3-AP-free lower bound; the base-3 digit construction formalized here is the classical elementary predecessor."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos1207Problem"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1207OQ03",
+    "lineCount": 188,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1207OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A quantitative follow-up to **Erdős Problem #1207** (isosceles-free subsets). The parent entry `erdos-1207` proves the *one-dimensional bridge* `isoscelesFree_iff_midpointFree`: on ℝ, a set is isosceles-free iff it is midpoint-free (3-term-AP-free). Its open question **OQ-03** asks whether that bridge can be combined with quantitative 3-AP-free bounds to pin down P₁(n).

This entry answers the **lower-bound side** with the classical elementary construction: the numbers whose base-3 digits are all `0` or `1`,
```
S_k = { ∑_{i<k} bᵢ·3ⁱ : bᵢ ∈ {0,1} } ⊆ {0,…,3ᵏ−1},
```
form a midpoint-free (hence, via the parent bridge, isosceles-free) set of size `2ᵏ`. Therefore
```
P₁(3ᵏ) ≥ 2ᵏ = (3ᵏ)^{log₃2}  (≈ n^{0.63}).
```

## What's proved (`Proofs/Erdos1207OQ03.lean`, 188 lines, 12 theorems, 2 defs)

- **`toNat_succ`** — least-significant-digit recursion `toNat (k+1) b = b₀ + 3·toNat k (tail b)`, the workhorse for every induction.
- **`toNat_two_mul_eq`** (carry-free core) — `2·toNat d = toNat b + toNat c ⟹ toNat b = toNat c`. In base 3 the digit sums stay below 3, so there are no carries and the digits must agree pairwise.
- **`toNat_injective`** — base-3 digit uniqueness (digits 0,1) ⇒ `|S_k| = 2ᵏ`.
- **`midpointFree_range_embR`** / **`isoscelesFree_range_embR`** — `S_k` is midpoint-free, then isosceles-free through the parent bridge.
- **`exists_isoscelesFree_pow`** (headline) — for every `k`, an isosceles-free `S ⊆ [0, 3ᵏ)` with `|S| = 2ᵏ`.

## Verification

- Builds under `./proofs/scripts/docker-build.sh Proofs.Erdos1207OQ03` (exit 0).
- `#print axioms` on all key results: `[propext, Classical.choice, Quot.sound]` only — **0 axioms, 0 sorries, status `verified`**.

## Honest framing

The base-3 digit construction realises an `n^{log₃2}` lower bound — explicit and machine-checked, but **strictly weaker than Behrend's** `n·exp(−O(√log n))`, which this elementary construction provably cannot reach. The open growth question for P_d(n) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)