### PR TITLE
Enrich Spherical/Unified Law of Cosines OQ-04

### DIFF
--- a/src/data/proofs/spherical-law-of-cosines-oq-04/annotations.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-04/annotations.json
@@ -3,10 +3,22 @@
     "id": "ann-curvature-pythagorean",
     "proofId": "spherical-law-of-cosines-oq-04",
     "range": { "startLine": 133, "endLine": 157 },
-    "type": "theorem",
+    "type": "insight",
     "title": "Generalized Pythagorean identity cs_K² + K·sn_K² = 1",
     "content": "curvaturePythagorean proves cs_K(r)² + K·sn_K(r)² = 1 for all K, r by trichotomy on the sign of K: K>0 reduces to Real.sin_sq_add_cos_sq, K<0 to Real.cosh_sq_sub_sinh_sq, K=0 to 1+0=1. This single identity simultaneously encodes cos²+sin²=1 (K=1) and cosh²−sinh²=1 (K=−1), and it is exactly the statement that the model points lie on the curvature quadric.",
-    "mathContext": "$\\text{cs}_K(r)^2 + K\\,\\text{sn}_K(r)^2 = 1$ for all $K,r\\in\\mathbb{R}$."
+    "mathContext": "$\\text{cs}_K(r)^2 + K\\,\\text{sn}_K(r)^2 = 1$ for all $K,r\\in\\mathbb{R}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pythagorean identity",
+      "hyperbolic identity cosh²−sinh²=1",
+      "curvature-parametrized trig",
+      "quadric surface"
+    ],
+    "prerequisites": [
+      "Real.sin_sq_add_cos_sq",
+      "Real.cosh_sq_sub_sinh_sq",
+      "sign trichotomy on K"
+    ]
   },
   {
     "id": "ann-quadric-model",
@@ -15,42 +27,104 @@
     "type": "definition",
     "title": "The constant-curvature quadric model (bK, geoK, geoK_onQuadric)",
     "content": "The ambient form bK K u v = K(uₓvₓ+u_yv_y)+u_zv_z realizes the sphere (K=1, Euclidean dot product), the hyperboloid (K=−1, Minkowski up to sign), and the flat case (K=0) at once. The geodesic-polar point geoK K r θ=(sn_K r·cosθ, sn_K r·sinθ, cs_K r) lies on the quadric B_K(·,·)=1 (geoK_onQuadric), which is precisely the generalized Pythagorean identity, and B_K(apex, geoK r θ)=cs_K r (bK_apex_geoK) gives the metric relation cs_K(distance)=B_K.",
-    "mathContext": "$B_K(u,v)=K(u_xv_x+u_yv_y)+u_zv_z$; $B_K(\\text{geoK},\\text{geoK})=1$."
+    "mathContext": "$B_K(u,v)=K(u_xv_x+u_yv_y)+u_zv_z$; $B_K(\\text{geoK},\\text{geoK})=1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "bilinear form",
+      "hyperboloid model",
+      "geodesic polar coordinates",
+      "Minkowski vs Euclidean inner product",
+      "unified space-form model"
+    ],
+    "prerequisites": [
+      "the generalized Pythagorean identity",
+      "geodesic-polar parametrization",
+      "quadric membership"
+    ]
   },
   {
     "id": "ann-the-law",
     "proofId": "spherical-law-of-cosines-oq-04",
     "range": { "startLine": 212, "endLine": 218 },
-    "type": "theorem",
+    "type": "insight",
     "title": "The law of cosines from the ambient form (bK_geo_geo)",
     "content": "bK_geo_geo computes, by ring, that the ambient form of the two apex-sides P=geoK K a 0 and Q=geoK K b C equals B_K(P,Q)=cs_K(a)·cs_K(b)+K·sn_K(a)·sn_K(b)·cos C — the right-hand side of the unified law of cosines. This is the algebraic heart: the law is a direct computation in the curvature bilinear form, no per-geometry argument needed.",
-    "mathContext": "$B_K(P,Q)=\\text{cs}_K(a)\\,\\text{cs}_K(b)+K\\,\\text{sn}_K(a)\\,\\text{sn}_K(b)\\cos C$."
+    "mathContext": "$B_K(P,Q)=\\text{cs}_K(a)\\,\\text{cs}_K(b)+K\\,\\text{sn}_K(a)\\,\\text{sn}_K(b)\\cos C$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "law of cosines",
+      "bilinear-form computation",
+      "unified space forms",
+      "ring normalization"
+    ],
+    "prerequisites": [
+      "bK and geoK definitions",
+      "the ring tactic",
+      "angle-addition for the polar angle"
+    ]
   },
   {
     "id": "ann-reverse-cs",
     "proofId": "spherical-law-of-cosines-oq-04",
     "range": { "startLine": 268, "endLine": 298 },
-    "type": "theorem",
+    "type": "technique",
     "title": "Reverse Cauchy–Schwarz for K < 0 (rhs_ge_one_neg)",
     "content": "For K<0 and a,b≥0, rhs_ge_one_neg shows the law's right-hand side is ≥ cosh(√(−K)(a−b)) ≥ 1, so the opposite side c=arcosh(RHS)/√(−K) is a genuine distance. The proof rewrites the cross term K·sn_K(a)·sn_K(b) to −sinh(√(−K)a)·sinh(√(−K)b) (K_curvatureSin_mul_neg), then applies cosh_sub, Real.one_le_cosh and nlinarith. This mirrors mink_geo_ge_one in the Minkowski-model entry.",
-    "mathContext": "$\\text{cs}_K(a)\\text{cs}_K(b)+K\\,\\text{sn}_K(a)\\text{sn}_K(b)\\cos C \\ge \\cosh(\\sqrt{-K}(a-b)) \\ge 1$."
+    "mathContext": "$\\text{cs}_K(a)\\text{cs}_K(b)+K\\,\\text{sn}_K(a)\\text{sn}_K(b)\\cos C \\ge \\cosh(\\sqrt{-K}(a-b)) \\ge 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "reverse Cauchy–Schwarz (Minkowski)",
+      "cosh subtraction formula",
+      "well-defined arcosh distance",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "Real.cosh_sub / Real.one_le_cosh",
+      "K_curvatureSin_mul_neg",
+      "nlinarith"
+    ]
   },
   {
     "id": "ann-derived-law",
     "proofId": "spherical-law-of-cosines-oq-04",
     "range": { "startLine": 310, "endLine": 328 },
-    "type": "theorem",
+    "type": "insight",
     "title": "The derived unified law of cosines (removing the OQ05 assumption)",
     "content": "unified_law_derived_neg derives cs_K(c)=cs_K(a)cs_K(b)+K·sn_K(a)sn_K(b)cos C for K<0 UNCONDITIONALLY (a,b≥0), with c the genuine model distance; unified_law_derived_pos does the K>0 (non-degenerate) case. This is exactly the conclusion that LawOfCosinesOQ05.UnifiedTriangle.law assumes as a structure field — here it is a theorem (axiomCount 0 vs OQ05's 1), answering OQ05's stated open question of deriving the law from a geometric model.",
-    "mathContext": "$\\text{cs}_K(c)=\\text{cs}_K(a)\\,\\text{cs}_K(b)+K\\,\\text{sn}_K(a)\\,\\text{sn}_K(b)\\cos C$, derived."
+    "mathContext": "$\\text{cs}_K(c)=\\text{cs}_K(a)\\,\\text{cs}_K(b)+K\\,\\text{sn}_K(a)\\,\\text{sn}_K(b)\\cos C$, derived.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "discharging a structure-field assumption",
+      "axiom elimination",
+      "geometric model → theorem",
+      "answering an open question"
+    ],
+    "prerequisites": [
+      "bK_geo_geo",
+      "rhs_ge_one_neg",
+      "the OQ05 UnifiedTriangle structure"
+    ]
   },
   {
     "id": "ann-classical-laws",
     "proofId": "spherical-law-of-cosines-oq-04",
     "range": { "startLine": 339, "endLine": 366 },
-    "type": "theorem",
+    "type": "insight",
     "title": "Hyperbolic and spherical laws as K = ∓1 specializations",
     "content": "hyperbolic_law_of_cosines (K=−1) gives cosh c=cosh a·cosh b−sinh a·sinh b·cos C and spherical_law_of_cosines (K=+1) gives cos c=cos a·cos b+sin a·sin b·cos C, both from the single model via the @[simp] value lemmas and ring. hyperbolic_pythagoras specializes C=π/2 to cosh c=cosh a·cosh b. Hyperbolic geometry is thus exhibited as the literal K=−1 analogue of spherical geometry.",
-    "mathContext": "$K=-1$: $\\cosh c=\\cosh a\\cosh b-\\sinh a\\sinh b\\cos C$; $K=+1$: $\\cos c=\\cos a\\cos b+\\sin a\\sin b\\cos C$."
+    "mathContext": "$K=-1$: $\\cosh c=\\cosh a\\cosh b-\\sinh a\\sinh b\\cos C$; $K=+1$: $\\cos c=\\cos a\\cos b+\\sin a\\sin b\\cos C$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "spherical law of cosines",
+      "hyperbolic law of cosines",
+      "hyperbolic Pythagoras",
+      "curvature K = ±1 specialization",
+      "duality of the two geometries"
+    ],
+    "prerequisites": [
+      "the derived unified law",
+      "@[simp] value lemmas for cs_K/sn_K at K=±1",
+      "ring"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `spherical-law-of-cosines-oq-04` (quality 80 → 100).

**Gap addressed:**
- significance 0→10, crossRefs 0→10: the 6 annotations had `content` + `mathContext` but no `significance` or `relatedConcepts`. Added `significance`, `relatedConcepts`, and `prerequisites` to each (generalized Pythagorean identity, constant-curvature quadric model, ambient-form law of cosines, reverse Cauchy–Schwarz, the derived unified law removing the OQ05 assumption, and the K=±1 spherical/hyperbolic specializations).

`pnpm build` passes. No changes to Lean source or status/axiom fields (remains verified, 0 axioms).