### PR TITLE
research(cauchy-schwarz-lp-duality): repair build-broken axiom-file gallery entry [VERIFIED]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean
@@ -49,7 +49,7 @@ theorem gives (L2)* ≅ L2 as a linear isometric equivalence.
     on L2 has the form f ↦ ⟨g, f⟩ for unique g ∈ L2, with ‖φ‖ = ‖g‖.
     Direct application of Mathlib's InnerProductSpace.toDual. -/
 theorem l2_riesz :
-    ∃ Φ : Lp ℝ 2 μ ≃ₗᵢ⋆[ℝ] NormedSpace.Dual ℝ (Lp ℝ 2 μ),
+    ∃ Φ : Lp ℝ 2 μ ≃ₗᵢ⋆[ℝ] StrongDual ℝ (Lp ℝ 2 μ),
     ∀ g : Lp ℝ 2 μ, ‖Φ g‖ = ‖g‖ :=
   ⟨InnerProductSpace.toDual ℝ (Lp ℝ 2 μ),
    fun g => LinearIsometryEquiv.norm_map _ g⟩
@@ -62,8 +62,9 @@ theorem l2_dual_surjective :
 
 /-- The inner product of L2 functions equals the integral: ⟨f, g⟩ = ∫ fg dμ. -/
 theorem l2_inner_eq_integral (f g : Lp ℝ 2 μ) :
-    @inner ℝ _ _ f g = ∫ a, (f : α → ℝ) a * (g : α → ℝ) a ∂μ :=
-  MeasureTheory.L2.inner_def f g
+    @inner ℝ _ _ f g = ∫ a, (f : α → ℝ) a * (g : α → ℝ) a ∂μ := by
+  rw [MeasureTheory.L2.inner_def (𝕜 := ℝ)]
+  simp only [RCLike.inner_apply', conj_trivial]
 
 /-
 ## Part II: Hölder-Based Embedding (Easy Direction)
@@ -114,10 +115,10 @@ but the full composition with Lp is not yet formalized.
     Every bounded linear functional on Lp is represented by integration
     against an Lq function, where q is the conjugate exponent.
     This requires Radon-Nikodým + Lp machinery. -/
-axiom riesz_lp_surjective (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
+axiom riesz_lp_surjective (p q : ℝ≥0∞) [Fact (1 ≤ p)] (hp1 : 1 < p) (hptop : p ≠ ⊤)
     (hpq : p.toReal.HolderConjugate q.toReal) :
     ∀ φ : Lp ℝ p μ →L[ℝ] ℝ,
-    ∃ g : α → ℝ, Memℒp g q μ ∧
+    ∃ g : α → ℝ, MemLp g q μ ∧
       ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ
 
 /-

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -673,3 +673,52 @@ unchanged. This session added a verified building block and corrected the roadma
 3. Wire `lp_pairing_eq_zero_ae_zero` (this session) + the four existing ingredient lemmas
    into the maximality construction `riesz_lp_surjective_general`; discharge the `sorry`.
 4. Swap the parent axiom; correct any stale `verified` gallery metas in the strand.
+
+### 2026-06-30 (Session 12, researcher-3) — PROGRESS: repaired the AXIOM FILE itself (a 3rd build-broken strand file, previously unnoticed) → gallery entry green again
+
+**Mode:** REVISIT. **Outcome:** real verified progress — restored a build-broken *published*
+gallery entry to compiling, no new axioms.
+
+**Headline:** every prior session tracked the foundation file (`…OQ01OQ01OQ02OQ01.lean`, now
+green) and `…Incomplete01.lean` (70 errors), but **missed that the top parent file that
+actually declares the axiom — `CauchySchwarzIntegralOQ01OQ01OQ02.lean` (gallery entry
+`cauchy-schwarz-integral-oq-01-oq-01-oq-02`, `axiomatized/axiom/1`) — was itself
+build-broken with 3 Mathlib-API-drift errors.** It imports only Mathlib (not the σ-finite
+chain), so it is independently repairable and I fixed it to **EXIT 0** via host
+`lake env lean` (v4.26.0).
+
+**Fixes (all API drift, `OQ01OQ01OQ02.lean`):**
+- `NormedSpace.Dual ℝ E` → **`StrongDual ℝ E`** (renamed in `Analysis/Normed/Module/Dual.lean`;
+  `InnerProductSpace.toDual` now returns `E ≃ₗᵢ⋆[𝕜] StrongDual 𝕜 E`).
+- `L2.inner_def f g` now leaves the scalar field a metavariable and its integrand is
+  `∫ ⟪f a, g a⟫` not `∫ f a * g a`, because `inner` gained an **explicit** field argument
+  (`Inner.inner (𝕜) : E → E → 𝕜`). Fix: `rw [MeasureTheory.L2.inner_def (𝕜 := ℝ)]` then
+  `simp only [RCLike.inner_apply', conj_trivial]` (`RCLike.inner_apply' : ⟪x,y⟫ = conj x * y`;
+  `conj_trivial : conj r = r` for the trivial star on ℝ).
+- `Memℒp` → **`MemLp`** (rename) inside the axiom statement.
+- Added **`[Fact (1 ≤ p)]`** to the axiom binders. The statement `∀ φ : Lp ℝ p μ →L[ℝ] ℝ`
+  no longer typechecks without it: `Lp`'s `TopologicalSpace`/normed-space instance is now
+  gated by `[Fact (1 ≤ p)]` (error `failed to synthesize TopologicalSpace ↥(Lp ℝ p μ)`).
+  Harmless — derivable from the existing `hp1 : 1 < p`, matches the σ-finite theorems'
+  signatures, and the axiom has **zero downstream consumers** (Session-2 scan), so tightening
+  it breaks nothing. `axiomCount` stays **1** (still `axiomatized`; not eliminated).
+
+**Verified:** `#print axioms` on `l2_riesz`, `l2_inner_eq_integral`, `l2_dual_surjective` →
+`[propext, Classical.choice, Quot.sound]` only. The lone `axiom riesz_lp_surjective` is the
+sole assumption, as the meta claims. Updated gallery meta `cauchy-schwarz-integral-oq-01-oq-01-oq-02`
+`lineCount 151→152` in both `meta` and `leanFile` blocks (net +1 line from the `l2_inner`
+proof; `axiomCount`/`theoremCount`/`status`/`badge` unchanged).
+
+**Incomplete01 re-measured (still the frontier):** 70 errors across the full 965-line file
+(lines 75→939), NOT a handful of repeated renames — 12 application-type-mismatch, 10
+failed-synthesize, 8 type-mismatch, 8 rewrite-pattern-not-found, 7 unsolved-goals, 6
+simp-no-progress, 5 function-expected, plus `HolderConjugate.one_lt_of_lt` gone (≈4 sites,
+now needs a different route) and `.rpow_const`/`.min` dot-notation on `Exists`/enorm. This is
+genuine multi-session proof-level repair; did **not** attempt a partial fix (would be
+unverifiable churn — the file can't build, so nothing in it is kernel-checkable until *all*
+70 are cleared).
+
+**Axiom NOT eliminated.** Critical path unchanged from Session 11's list; the axiom-file
+repair simply removes one more false `verified`-strand build breakage (integrity issue
+#28788) and keeps the entry that *hosts* the target axiom green so the eventual
+`axiom → theorem` swap has a compiling home.

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
@@ -16,7 +16,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 151,
+    "lineCount": 152,
     "assumptions": "1 axiom: riesz_lp_surjective (the hard direction requiring Radon-Nikodym). L2 case fully proved via InnerProductSpace.toDual. Embedding direction proved via Hölder.",
     "dateAdded": "2026-03-26",
     "theoremCount": 7,
@@ -107,7 +107,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 151,
+    "lineCount": 152,
     "axiomCount": 1,
     "theoremCount": 7,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

The Lᵖ-duality strand of `cauchy-schwarz-integral-lp-duality-synthesis` has been build-broken on `main` by Mathlib v4.26.0 API drift (gallery-integrity issue #28788). Prior sessions tracked the foundation file (`…OQ01OQ01OQ02OQ01.lean`, now green) and `…Incomplete01.lean` (70 errors) but **missed a third broken file**: the top parent `CauchySchwarzIntegralOQ01OQ01OQ02.lean` that actually declares `axiom riesz_lp_surjective` — the published gallery entry `cauchy-schwarz-integral-oq-01-oq-01-oq-02` (`axiomatized`, axiomCount 1). It had 3 API-drift errors.

Since that file imports **only Mathlib** (not the σ-finite chain), it is independently repairable. This PR fixes it to **EXIT 0** (host `lake env lean`, toolchain v4.26.0).

## Fixes

- `NormedSpace.Dual ℝ E` → `StrongDual ℝ E` (rename; `InnerProductSpace.toDual` now returns `E ≃ₗᵢ⋆[𝕜] StrongDual 𝕜 E`).
- `L2.inner_def`: `inner` gained an **explicit** scalar-field argument, so `inner_def` left `𝕜` a metavariable and produced `∫ ⟪f a, g a⟫` rather than `∫ f a * g a`. Fixed with `rw [MeasureTheory.L2.inner_def (𝕜 := ℝ)]` + `simp only [RCLike.inner_apply', conj_trivial]`.
- `Memℒp` → `MemLp` (rename) in the axiom statement.
- Added `[Fact (1 ≤ p)]` to the axiom binders: `Lp`'s topology/normed-space instance is now `Fact`-gated, so `∀ φ : Lp ℝ p μ →L[ℝ] ℝ` no longer typechecks without it. Harmless — derivable from the existing `hp1 : 1 < p`, matches the σ-finite theorems' signatures, and the axiom has **zero downstream consumers**, so tightening it breaks nothing.

## Verification

- `CauchySchwarzIntegralOQ01OQ01OQ02.lean` builds **EXIT 0**.
- `#print axioms` on `l2_riesz`, `l2_inner_eq_integral`, `l2_dual_surjective` → `[propext, Classical.choice, Quot.sound]` only.
- The sole `axiom riesz_lp_surjective` remains — **axiomCount unchanged at 1**, still `axiomatized`. This PR does **not** eliminate the axiom.
- Gallery meta `lineCount` 151→152 (both `meta` and `leanFile` blocks).

## Not in scope

`…Incomplete01.lean` remains **70-error broken** (diverse proof-level breaks across its 965 lines, not just renames) — the true multi-session critical path for the eventual axiom elimination. Documented in `knowledge.md` Session 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)