### PR TITLE
Fix: realign stale meta counts for erdos-1077

### DIFF
--- a/src/data/proofs/erdos-1077/meta.json
+++ b/src/data/proofs/erdos-1077/meta.json
@@ -46,9 +46,9 @@
       "Connection to extremal graph theory"
     ],
     "axiomCount": 0,
-    "lineCount": 145,
+    "lineCount": 211,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
-    "theoremCount": 1,
+    "theoremCount": 6,
     "definitionCount": 4
   },
   "overview": {
@@ -105,9 +105,17 @@
       "id": "resolution",
       "title": "The Resolution",
       "startLine": 103,
-      "endLine": 145,
+      "endLine": 143,
       "summary": "Jiang-Longbrake's Θ(n^α) answer, upper/lower bounds, and main theorem.",
       "mathContext": "Jiang-Longbrake's Θ(n^α) answer, upper/lower bounds, and main theorem."
+    },
+    {
+      "id": "verified-results",
+      "title": "Verified Structural Results",
+      "startLine": 145,
+      "endLine": 211,
+      "summary": "Machine-checked lemmas on the balance predicates: minDegree ≤ maxDegree, the disjunctive IsBalanced is degenerate for D ≥ 1, IsBalanced' is monotone in D, and regular graphs are 1-balanced.",
+      "mathContext": "Machine-checked lemmas on the balance predicates: minDegree ≤ maxDegree, the disjunctive IsBalanced is degenerate for D ≥ 1, IsBalanced' is monotone in D, and regular graphs are 1-balanced."
     }
   ],
   "conclusion": {
@@ -218,9 +226,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos1077",
-    "lineCount": 145,
+    "lineCount": 211,
     "axiomCount": 0,
-    "theoremCount": 1,
+    "theoremCount": 6,
     "definitionCount": 4,
     "path": "Proofs/Erdos1077Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Realign stale metadata counts for `erdos-1077` (Balanced Subgraphs in Dense Graphs). Both the `meta` and `leanFile` blocks claimed the Lean file was 145 lines with 1 theorem, but it has grown to 211 lines / 6 theorems.

## Evidence

The Lean source `proofs/Proofs/Erdos1077Problem.lean` was last enriched in #30275 ("add 5 verified balanced-subgraph lemmas"), growing from 145 to 211 lines and from 1 to 6 theorems. The metadata was never regenerated.

**Before**: `lineCount: 145`, `theoremCount: 1` (both `meta` and `leanFile` blocks); last section stopped at line 145.
**After**: `lineCount: 211`, `theoremCount: 6`; added a `verified-results` section covering the new lemmas (145–211).

Verified against source (`wc -l` = 211; `grep -cE '^\s*(theorem|lemma)'` = 6; `def` count 4 unchanged; 0 axioms, 0 sorries — all other fields already correct).

No Lean code changed; metadata-only realignment.

---
Automated fix by lean-mechanic agent.