### PR TITLE
Fix: realign stale meta for puiseux-theorem (lineCount 471→540, theoremCount 8→9, assumptions)

### DIFF
--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -51,10 +51,10 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 471,
-    "assumptions": "No axiom declarations. 5 True-stub theorems that prove trivial True placeholders instead of actual mathematical content: puiseux_theorem, puiseux_is_algebraic_closure, newton_puiseux_terminates, square_root_puiseux, cusp_parameterization.",
+    "lineCount": 540,
+    "assumptions": "No axiom declarations. 2 True-stub theorems remain that prove trivial True placeholders instead of actual mathematical content: puiseux_theorem, puiseux_is_algebraic_closure. Previously-stubbed square_root_puiseux and cusp_parameterization now carry genuine Hahn-series proofs (x^(1/2) and x^(3/2) roots), and newton_puiseux_terminates was reduced to a prose comment.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 2
   },
   "overview": {
@@ -169,9 +169,9 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 471,
+    "lineCount": 540,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 2,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Realigns stale `meta.json` counts and the `assumptions` text for **puiseux-theorem** to match the current Lean source (`Proofs/PuiseuxTheorem.lean`). The source grew in PR #30441 ("prove 2 of 5 True-stubs + ramification lemma") but the gallery metadata was never regenerated.

## Evidence

Ground truth from `proofs/Proofs/PuiseuxTheorem.lean`:
- `wc -l` = **540** (both meta blocks said 471)
- `theorem`/`lemma` declarations = **9** (both blocks said 8)
- `def`/`noncomputable def`/`opaque def` = 2 (already correct)
- `axiom` = 0, tactic `sorry` = 0 (already correct)

**assumptions field** — was: "5 True-stub theorems … puiseux_theorem, puiseux_is_algebraic_closure, newton_puiseux_terminates, square_root_puiseux, cusp_parameterization."

Current reality:
- `puiseux_theorem`, `puiseux_is_algebraic_closure` — still `True`-stubs (2 remain)
- `square_root_puiseux`, `cusp_parameterization` — now carry genuine Hahn-series proofs (x^(1/2), x^(3/2) roots)
- `newton_puiseux_terminates` — reduced to a prose comment (no longer a theorem)

`status` (`axiomatized`) and `badge` (`wip`) remain correct — the entry does not overclaim.

**After**: lineCount 540, theoremCount 9 (both blocks), assumptions text reflects the 2 remaining stubs.

JSON validated with `json.load`.

---
Automated fix by lean-mechanic agent.