### PR TITLE
Enrich Gelfond-Schneider OQ-04 (log₂ 3 Transcendental)

### DIFF
--- a/src/data/proofs/gelfond-schneider-oq-04/meta.json
+++ b/src/data/proofs/gelfond-schneider-oq-04/meta.json
@@ -59,15 +59,29 @@
     "definitionCount": 0
   },
   "overview": {
-    "historicalContext": "The Gelfond-Schneider theorem (1934, resolving Hilbert's 7th problem) is best known for producing transcendental constants such as 2^√2 and e^π. Equally important is its consequence for logarithms: it forbids log_a b (for algebraic a, b) from being an irrational algebraic number. The gallery parent `gelfond-schneider` develops the constants and the transcendence of log a, but not this logarithm dichotomy.",
+    "historicalContext": "The Gelfond-Schneider theorem (1934, resolving Hilbert's 7th problem, proved independently by Aleksandr Gelfond and Theodor Schneider) states that a^b is transcendental whenever a is algebraic (≠ 0, 1) and b is an irrational algebraic number. It is best known for producing transcendental constants such as 2^√2 (the 'Hilbert number') and, via i^(−2i) = e^π, Gelfond's constant e^π. Equally important is its contrapositive consequence for logarithms: for algebraic a, b the ratio log b / log a cannot be an irrational algebraic number, because a raised to that ratio equals b — so an irrational algebraic exponent would make an algebraic number transcendental. This dichotomy (rational or transcendental, never irrational-algebraic) subsumes the classical irrationality/transcendence facts about logarithms of integers, a theme going back to Euler and Lambert and made effective much later by Baker's theorem (1966) on linear forms in logarithms. The gallery parent `gelfond-schneider` develops the transcendental constants and the transcendence of log a, but not this logarithm dichotomy or the concrete witness log₂ 3.",
     "problemStatement": "What can be said about log_a b = log b / log a when a and b are algebraic? In particular, can a base-a logarithm of an algebraic number be an irrational algebraic number — and is log₂ 3 transcendental?",
-    "text": "If log b / log a were algebraic and irrational, then a^(log b/log a) = exp(log b) = b would be transcendental by Gelfond-Schneider, contradicting that b is algebraic. Hence log b / log a is rational or transcendental. Applied to a = 2, b = 3 and combined with the (unconditional) irrationality of log 3 / log 2 — which would otherwise force the impossible identity 2^p = 3^d between an even and an odd number — this yields the transcendence of log₂ 3."
+    "text": "If log b / log a were algebraic and irrational, then a^(log b/log a) = exp(log b) = b would be transcendental by Gelfond-Schneider, contradicting that b is algebraic. Hence log b / log a is rational or transcendental. Applied to a = 2, b = 3 and combined with the (unconditional) irrationality of log 3 / log 2 — which would otherwise force the impossible identity 2^p = 3^d between an even and an odd number — this yields the transcendence of log₂ 3.",
+    "keyInsights": [
+      "The dichotomy is Gelfond-Schneider read *contrapositively*: the theorem's usual role is to *produce* transcendental constants a^b, but here the same statement *forbids* the exponent log b / log a from being an irrational algebraic number — otherwise a^(log b/log a) = b would be a transcendental algebraic number.",
+      "The bridge lemma a^(log b/log a) = b (from rpow_def_of_pos and exp_log) is what converts a question about a logarithm ratio into a question about a power, the only form Gelfond-Schneider can speak about.",
+      "Transcendence comes for free once irrationality is known: the dichotomy leaves only 'rational or transcendental', so ruling out rational (the easy, elementary half) immediately yields transcendental — no separate transcendence argument is needed.",
+      "The irrationality of log 3 / log 2 is fully elementary and unconditional: a rational value p/d cross-multiplies to 2^p = 3^d, an even number equal to an odd number — so this half of the result depends on NO axiom, only the parity lemma Nat.Prime.dvd_of_dvd_pow.",
+      "Honest axiom accounting: the file re-declares the full Gelfond-Schneider theorem as an `axiom` (badge 'axiom', axiomCount 1) rather than formalizing Siegel's lemma / auxiliary functions / zero estimates; the dichotomy and log₂ 3's transcendence rest on it, but the irrationality theorem is marked as independent of it."
+    ]
   },
   "sections": [
     {
+      "id": "header-and-axiom",
+      "title": "Module Header and the Gelfond-Schneider Assumption",
+      "summary": "Module docstring framing the logarithm dichotomy and the log₂ 3 witness; imports Mathlib, opens Real, enters the namespace, and re-declares the real Gelfond-Schneider theorem gelfond_schneider_real as an axiom exactly as in the parent (badge axiom, axiomCount 1).",
+      "startLine": 1,
+      "endLine": 55
+    },
+    {
       "id": "assumption-and-identity",
-      "title": "The Assumption and the Logarithm-to-Exponent Identity",
-      "summary": "States the Gelfond-Schneider theorem as an axiom (as in the parent) and proves the supporting identity a^(log b/log a) = b for positive a ≠ 1 and positive b, via rpow_def_of_pos and exp_log.",
+      "title": "The Logarithm-to-Exponent Identity",
+      "summary": "Proves the supporting identity a^(log b/log a) = b for positive a ≠ 1 and positive b, via rpow_def_of_pos and exp_log — the bridge that turns a statement about the logarithm ratio into a statement about a power a^exponent to which Gelfond-Schneider applies.",
       "startLine": 56,
       "endLine": 82
     },
@@ -76,14 +90,21 @@
       "title": "The Logarithm Dichotomy",
       "summary": "gelfond_schneider_logb_dichotomy: log b / log a is rational or transcendental. The proof splits on rationality; in the irrational case, an algebraic value would make a^(log b/log a) = b transcendental, contradicting that b is algebraic.",
       "startLine": 84,
-      "endLine": 106
+      "endLine": 105
     },
     {
-      "id": "log-two-three",
-      "title": "log₂ 3: Irrational, hence Transcendental",
-      "summary": "irrational_log_three_div_log_two proves log 3 / log 2 ∉ ℚ unconditionally via the parity of 2^p = 3^d; transcendental_log_three_div_log_two feeds this into the dichotomy at bases 2 and 3.",
-      "startLine": 108,
-      "endLine": 160
+      "id": "irrationality",
+      "title": "log 3 / log 2 is Irrational (Unconditional)",
+      "summary": "irrational_log_three_div_log_two: a rational value p/d would cross-multiply to N·log 2 = d·log 3, i.e. log(2^N) = log(3^d), so 2^N = 3^d in ℕ; then 2 ∣ 3^d ⟹ 2 ∣ 3 by Nat.Prime.dvd_of_dvd_pow — a parity contradiction. Depends on NO Gelfond-Schneider assumption.",
+      "startLine": 106,
+      "endLine": 144
+    },
+    {
+      "id": "transcendence",
+      "title": "hence log₂ 3 is Transcendental",
+      "summary": "transcendental_log_three_div_log_two feeds the unconditional irrationality into the dichotomy at the algebraic bases 2 and 3: the ratio is not rational, so the dichotomy forces it to be transcendental.",
+      "startLine": 146,
+      "endLine": 164
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `gelfond-schneider-oq-04` (quality 83 → 100).

**Gaps addressed:**
- keyInsights 0→10: the `overview.keyInsights` array was empty. Added 5 insights (Gelfond-Schneider read contrapositively as a dichotomy; the a^(log b/log a)=b bridge lemma; transcendence-for-free once irrationality is known; the unconditional parity proof of irrationality; honest axiom accounting for the re-declared GS axiom).
- historicalContext 7→10: extended past 500 chars with the 1934 Gelfond/Schneider background, the Hilbert number 2^√2, Gelfond's constant e^π, and Baker's effective theory.
- sections 6→10: split into 5 sections covering the full file (header/axiom, logarithm-to-exponent identity, dichotomy, unconditional irrationality, transcendence).

meta.json 12.4 KB (under cap). Data-only change; 2045 modules transformed clean in `pnpm build`. No changes to Lean source; remains axiomatized (axiomCount 1, badge axiom).