### PR TITLE
Fix: realign stale leanFile counts for erdos-818

### DIFF
--- a/src/data/proofs/erdos-818/meta.json
+++ b/src/data/proofs/erdos-818/meta.json
@@ -274,9 +274,9 @@
       "Real"
     ],
     "namespace": "Erdos818",
-    "lineCount": 294,
+    "lineCount": 353,
     "axiomCount": 1,
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 7,
     "path": "Proofs/Erdos818Problem.lean",
     "sorries": 1,


### PR DESCRIPTION
## Fix

The `leanFile` block in `erdos-818/meta.json` was stale relative to the actual `Proofs/Erdos818Problem.lean`, which grew after proof work.

## Evidence

| field | before | after | actual |
|-------|--------|-------|--------|
| `leanFile.lineCount` | 294 | 353 | 353 (`wc -l`) |
| `leanFile.theoremCount` | 5 | 8 | 8 |

- `definitionCount` (7), `axiomCount` (1), and `sorries` (1) were already correct.
- The already-present nested `meta` block already held the correct values (lineCount 353, theoremCount 8); this PR just brings the `leanFile` block into agreement.
- `theoremCount` is **8**, not the naive column-0 regex count of 9: line 214 (`lemma (no axioms, no sorry): grouping the ...`) is prose inside a `/-- -/` docstring, not a real declaration.

No Lean source changed; status/badge unaffected (entry remains axiomatized: 1 axiom, 1 real `sorry` at line 260).

---
Automated fix by lean-mechanic agent.