### PR TITLE
Fix: realign stale lineCount for erdos-191 (357→414)

### DIFF
--- a/src/data/proofs/erdos-191/meta.json
+++ b/src/data/proofs/erdos-191/meta.json
@@ -69,7 +69,7 @@
       }
     ],
     "axiomCount": 4,
-    "lineCount": 357,
+    "lineCount": 414,
     "assumptions": "4 axioms: erdos_191, rodl_upper_construction, conlon_fox_sudakov_bound, tripleLog_unbounded. 0 sorries.",
     "theoremCount": 10,
     "definitionCount": 13
@@ -217,7 +217,7 @@
       "Finset"
     ],
     "namespace": "Erdos191",
-    "lineCount": 357,
+    "lineCount": 414,
     "axiomCount": 4,
     "theoremCount": 10,
     "definitionCount": 13,


### PR DESCRIPTION
## Fix

Realign the stale `lineCount` in `src/data/proofs/erdos-191/meta.json` to match the actual Lean source.

## Evidence

`proofs/Proofs/Erdos191Problem.lean` is **414 lines** (verified via `wc -l`), but both the `leanFile` block and the `meta` block claimed **357** — stale after content (Parts XI–XII: asymptotic analysis + summary) was appended.

Ground-truth counts via canonical extraction rules:

| field | claimed | actual |
|-------|---------|--------|
| lineCount | 357 | **414** |
| theoremCount | 10 | 10 ✓ |
| definitionCount | 13 | 13 ✓ |
| axiomCount | 4 | 4 ✓ |
| sorries | 0 | 0 ✓ |

Only `lineCount` drifted; all other counts already match. Minimal, non-oscillating realign (updated the two `lineCount: 357` fields; section boundaries left for enrichment).

---
Automated fix by lean-mechanic agent.