### PR TITLE
Enrich Interval/Vector Tietze Extension (Urysohn OQ chain)

### DIFF
--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -70,5 +70,52 @@
       "pi_norm_le_iff_of_nonneg",
       "continuous_pi"
     ]
+  },
+  {
+    "id": "ann-unit-interval",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 105
+    },
+    "type": "technique",
+    "title": "The [0,1]-Valued Specialisation for Partitions of Unity",
+    "content": "`tietze_extension_unitInterval` is the `a = 0, b = 1` instance of `tietze_extension_Icc`, obtained by a one-line application (`by norm_num` discharges `0 ≤ 1`). Although trivial as a corollary, it is the operationally important shape: a continuous `[0,1]`-valued function on a closed set extends to a continuous `[0,1]`-valued function on all of `X`. This is exactly the building block used to construct partitions of unity subordinate to an open cover — the standard route from Urysohn/Tietze to smooth-manifold and integration machinery — because a partition of unity is a family of `[0,1]`-valued bump functions that must first be extended off their supports while staying in `[0,1]`.",
+    "mathContext": "$0 \\le f \\le 1 \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ 0 \\le G \\le 1$; the $[0,1]$-valued shape underlying partitions of unity.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "partition of unity",
+      "unit interval",
+      "bump functions",
+      "specialisation of the interval form"
+    ],
+    "prerequisites": [
+      "tietze_extension_Icc",
+      "norm_num"
+    ]
+  },
+  {
+    "id": "ann-norm-sharp",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 148,
+      "endLine": 160
+    },
+    "type": "insight",
+    "title": "Sharp Norm Preservation ‖G‖ = ‖f‖ in Finite Dimensions",
+    "content": "`tietze_extension_pi_norm_sharp` records that the vector extension `G` restricts to `f` on `s` and satisfies every uniform `ℓ∞` bound that `f` does. Specialising the shared bound to the least one, `M = ‖f‖`, forces `‖G‖ ≤ ‖f‖`; the reverse inequality is automatic because `G` extends `f` (a sup over a superset is at least the sup over the subset), so `‖G‖ = ‖f‖`. This is the vector analogue of the parent's sharp scalar Tietze: the extension is not merely bounded but *norm-preserving*, the strongest possible control. Norm preservation matters because it makes the extension operator a (nonlinear) isometry into the finite-dimensional `ℓ∞` Banach codomain, so no amplitude is introduced off `s`.",
+    "mathContext": "$\\|G\\| = \\|f\\|$ on a finite-dimensional $\\ell^\\infty$ codomain: $M = \\|f\\|$ gives $\\|G\\| \\le \\|f\\|$, and $G|_s = f$ gives $\\|G\\| \\ge \\|f\\|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "norm-preserving extension",
+      "sharp Tietze bound",
+      "isometric extension",
+      "ℓ∞ Banach codomain"
+    ],
+    "prerequisites": [
+      "tietze_extension_pi_norm",
+      "least-upper-bound specialisation M = ‖f‖",
+      "extension ⇒ ‖G‖ ≥ ‖f‖"
+    ]
   }
 ]

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -58,11 +58,19 @@
     },
     {
       "id": "vector-valued",
-      "title": "Finite-Dimensional Vector-Valued Tietze with Preserved ℓ∞ Bound",
+      "title": "Componentwise Vector-Valued Tietze",
       "startLine": 106,
-      "endLine": 160,
-      "summary": "tietze_extension_pi_sup extends f : s → (ι → ℝ) (ι finite) componentwise with the common bound M, preserving |G y i| ≤ M; tietze_extension_pi_norm packages it with the ℓ∞ norm (‖G y‖ ≤ M via pi_norm_le_iff_of_nonneg); tietze_extension_pi_norm_sharp records that G extends f and shares every uniform ℓ∞ bound, so ‖G‖ = ‖f‖ for the least bound.",
+      "endLine": 147,
+      "summary": "tietze_extension_pi_sup extends f : s → (ι → ℝ) (ι finite) componentwise against the common bound M, assembling y ↦ (i ↦ Gi y) via continuous_pi and preserving |G y i| ≤ M; tietze_extension_pi_norm packages it with the genuine ℓ∞ norm (‖G y‖ ≤ M via pi_norm_le_iff_of_nonneg).",
       "mathContext": "$\\|f x\\|_\\infty \\le M \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ \\|G y\\|_\\infty \\le M.$"
+    },
+    {
+      "id": "norm-sharp",
+      "title": "Sharp Norm-Preserving Vector Tietze",
+      "startLine": 148,
+      "endLine": 160,
+      "summary": "tietze_extension_pi_norm_sharp records that G extends f and shares every uniform ℓ∞ bound; specialising to the least bound M = ‖f‖ gives ‖G‖ ≤ ‖f‖, and G|_s = f gives the reverse, so ‖G‖ = ‖f‖ — the norm-preserving vector analogue of the parent's sharp scalar Tietze.",
+      "mathContext": "$\\|G\\| = \\|f\\|$ on a finite-dimensional $\\ell^\\infty$ codomain."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `urysohns-lemma-oq-01-oq-01-oq-02-oq-01` (quality 85 → 100).

**Gaps addressed:**
- annotations 15→25 (+ mathContext, significance, crossRefs to 10): added 2 annotations — the [0,1]-valued specialisation (the shape used for partitions of unity) and the sharp norm-preserving result ‖G‖=‖f‖ on finite-dimensional ℓ∞ codomains. Each has mathContext, significance, relatedConcepts, prerequisites.
- sections 8→10: split the vector-valued section into 'Componentwise Vector-Valued Tietze' and 'Sharp Norm-Preserving Vector Tietze'.

`pnpm build` passes (57.6s). No changes to Lean source or status/axiom fields (remains verified, 0 axioms).