### PR TITLE
Fix: realign stale leanFile counts for erdos-1074

### DIFF
--- a/src/data/proofs/erdos-1074/meta.json
+++ b/src/data/proofs/erdos-1074/meta.json
@@ -250,9 +250,9 @@
       "Set"
     ],
     "namespace": "Erdos1074",
-    "lineCount": 206,
+    "lineCount": 259,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 15,
     "definitionCount": 2,
     "path": "Proofs/Erdos1074Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Realign the stale `leanFile` count block for `erdos-1074`. The top-level `meta` block was already correct (259/15/2); only the `leanFile` mirror lagged behind after the Lean file grew.

## Evidence

Ground truth from `proofs/Proofs/Erdos1074Problem.lean`:
- `wc -l` → **259** (leanFile claimed 206; meta already 259 ✓)
- col-0 `theorem`/`lemma` → **15** (leanFile claimed 10; meta already 15 ✓) — all 15 are genuine declarations, no docstring-prose false positives
- col-0 `def` → 2 ✓, `axiom` → 0 ✓, tactic `sorry` → 0 ✓

**Before**: `leanFile.lineCount: 206`, `leanFile.theoremCount: 10`.
**After**: `leanFile.lineCount: 259`, `leanFile.theoremCount: 15` (now matches the `meta` block).

Numeric metadata only; still verified, 0-axiom, 0-sorry.

---
Automated fix by lean-mechanic agent.