### PR TITLE
Fix: realign stale leanFile counts for erdos-1011-oq-03

### DIFF
--- a/src/data/proofs/erdos-1011-oq-03/meta.json
+++ b/src/data/proofs/erdos-1011-oq-03/meta.json
@@ -155,9 +155,9 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 177,
+    "lineCount": 234,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 14,
     "definitionCount": 4,
     "path": "Proofs/Erdos1011OQ03.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

The `leanFile` block in `erdos-1011-oq-03/meta.json` lagged behind the actual source and the (already-correct) `meta.meta` block after research PR #31589 grew `Proofs/Erdos1011OQ03.lean`.

## Evidence

`wc -l Proofs/Erdos1011OQ03.lean` = **234**; 14 col-0 `theorem/lemma` declarations (all genuine, none in docstrings); 4 `def`; 0 sorry; 0 axiom.

**Before** (leanFile block): lineCount 177, theoremCount 10
**After**: lineCount 234, theoremCount 14

`meta.meta` block was already correct (234/14/4/0/0); definitionCount (4), sorries (0), axiomCount (0) unchanged. Still VERIFIED / 0-axiom.

---
Automated fix by lean-mechanic agent.