### PR TITLE
Fix: realign stale leanFile counts for central-limit-theorem-oq-02-oq-03

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02-oq-03/meta.json
@@ -36,9 +36,9 @@
       "Doukhan, P. *Mixing: Properties and Examples*. Lecture Notes in Statistics 85, Springer, 1994."
     ]
   },
-  "description": "Fully verified (0-axiom, 0-sorry) formalization of the finite-range dependence case of the dependent-variable CLT. Defines MDependent μ σ_k m (events separated by gap > m are independent) and proves the headline mDependent_alpha_zero: the parent file's α-mixing coefficient vanishes at every lag n > m. The m = 0 case recovers the parent's independent_implies_zero_mixing. Two structural consequences make Ibragimov's mixing CLT apply for free: mixing decay α(n) → 0 holds trivially (coefficients eventually zero), and the Ibragimov series ∑ₙ α(n)^θ converges for every exponent θ > 0 (finite sum). Includes the reusable analytic lemma summable_rpow_of_eventually_zero. 6 theorems, 1 definition, 0 axioms, 0 sorries; reuses alphaMixingCoeff from the parent. Also adds alphaMixingCoeff_le_one (the α-mixing coefficient is ≤ 1 on a probability space — the upper bound the parent file explicitly omits) and mDependent_mono (m-dependence is monotone in m, so the finite-range dependence classes nest upward).",
+  "description": "Fully verified (0-axiom, 0-sorry) formalization of the finite-range dependence case of the dependent-variable CLT. Defines MDependent μ σ_k m (events separated by gap > m are independent) and proves the headline mDependent_alpha_zero: the parent file's α-mixing coefficient vanishes at every lag n > m. The m = 0 case recovers the parent's independent_implies_zero_mixing. Two structural consequences make Ibragimov's mixing CLT apply for free: mixing decay α(n) → 0 holds trivially (coefficients eventually zero), and the Ibragimov series ∑ₙ α(n)^θ converges for every exponent θ > 0 (finite sum). Includes the reusable analytic lemma summable_rpow_of_eventually_zero. 7 theorems, 1 definition, 0 axioms, 0 sorries; reuses alphaMixingCoeff from the parent. Also adds alphaMixingCoeff_le_one (the α-mixing coefficient is ≤ 1 on a probability space — the upper bound the parent file explicitly omits) and mDependent_mono (m-dependence is monotone in m, so the finite-range dependence classes nest upward).",
   "conclusion": {
-    "summary": "This file generalizes the parent's independence endpoint to the full finite-range (m-dependent) family. The headline mDependent_alpha_zero proves the α-mixing coefficient vanishes at every lag n > m; independence is recovered as m = 0. Two consequences — eventual mixing decay and summability of the Ibragimov series for every exponent — show that any m-dependent stationary sequence with finite variance satisfies Ibragimov's mixing CLT (OQ-02-OQ-04) with no constraint on the mixing rate. All 6 theorems are machine-checked with only the foundational axioms (propext, Classical.choice, Quot.sound).",
+    "summary": "This file generalizes the parent's independence endpoint to the full finite-range (m-dependent) family. The headline mDependent_alpha_zero proves the α-mixing coefficient vanishes at every lag n > m; independence is recovered as m = 0. Two consequences — eventual mixing decay and summability of the Ibragimov series for every exponent — show that any m-dependent stationary sequence with finite variance satisfies Ibragimov's mixing CLT (OQ-02-OQ-04) with no constraint on the mixing rate. All 7 theorems are machine-checked with only the foundational axioms (propext, Classical.choice, Quot.sound).",
     "implications": "m-dependence is the canonical first step beyond independence in the dependent-CLT hierarchy and the natural model for finite-order moving averages (MA(q) is q-dependent) and one-step functions of finite-state Markov chains. Establishing α(n) = 0 for n > m in Lean gives a reusable, axiom-free bridge from finite-range dependence directly into the parent's α-mixing API: it discharges every rate/moment hypothesis of the mixing CLT trivially. The analytic helper summable_rpow_of_eventually_zero is generic and could support other eventually-zero-rate arguments.",
     "openQuestions": [
       "Quantitative CLT for m-dependent sequences: derive an explicit Berry–Esseen rate O(n^{-1/2}) for the m-dependent CLT, with the constant depending on m and the (2+δ)-th moment — the finite-range structure should give a clean Stein-method bound.",
@@ -71,9 +71,9 @@
       "CentralLimitTheoremOQ02"
     ],
     "namespace": "CentralLimitTheoremOQ02OQ03",
-    "lineCount": 208,
+    "lineCount": 256,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 1,
     "path": "Proofs/CentralLimitTheoremOQ02OQ03.lean",
     "sorries": 0
@@ -96,8 +96,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 252,
-    "assumptions": "None. All 6 theorems are machine-checked; #print axioms reports only the foundational axioms propext, Classical.choice, Quot.sound (no sorryAx, no custom axioms, no Lean.ofReduceBool). The file reuses the definition alphaMixingCoeff from the parent CentralLimitTheoremOQ02.lean; that parent definition is axiom-free (the parent's single axiom martingale_clt is unrelated and not referenced here).",
+    "lineCount": 256,
+    "assumptions": "None. All 7 theorems are machine-checked; #print axioms reports only the foundational axioms propext, Classical.choice, Quot.sound (no sorryAx, no custom axioms, no Lean.ofReduceBool). The file reuses the definition alphaMixingCoeff from the parent CentralLimitTheoremOQ02.lean; that parent definition is axiom-free (the parent's single axiom martingale_clt is unrelated and not referenced here).",
     "mathlib_version": "4.26.0",
     "historicalContext": "m-dependence was introduced by Hoeffding and Robbins (1948) as the first tractable dependence structure beyond independence admitting a CLT. It is the finite-range special case of Rosenblatt's (1956) α-mixing, with α(n) = 0 for n > m. Finite-order moving averages MA(q) are exactly q-dependent, and one-step functions of finite-state Markov chains are 1-dependent.",
     "proofStrategy": "Reuse the parent's nested-supremum-collapse: at lag n > m, m-dependence forces each term of the defining ⨆ to 0 (ENNReal.toReal_mul), and the Prop-indexed all-zero nested supremum over ℝ collapses via a Nonempty/IsEmpty case split. Derive the m = 0 (independence) recovery, eventual mixing decay (tendsto_atTop_of_eventually_const), and Ibragimov-series summability for every exponent (summable_of_ne_finset_zero + Real.zero_rpow).",


### PR DESCRIPTION
## Fix

The `leanFile` metadata block for `central-limit-theorem-oq-02-oq-03` drifted from the actual Lean source after two theorems (`alphaMixingCoeff_le_one`, `mDependent_mono`) were added.

## Evidence

Ground truth from `proofs/Proofs/CentralLimitTheoremOQ02OQ03.lean`:
- `wc -l` = 256
- col-0 `theorem`/`lemma` = 7 (all genuine, none in docstrings)
- col-0 `def` = 1
- `sorry` = 0, `axiom` = 0

**Before**: leanFile block `lineCount: 208`, `theoremCount: 6`; meta block `lineCount: 252`; prose "6 theorems" (×4).
**After**: leanFile `lineCount: 256`, `theoremCount: 7`; meta `lineCount: 256`; prose "7 theorems".

`definitionCount` (1), `axiomCount` (0), `sorries` (0), and `status`/`badge` (verified/original) are unchanged. Metadata-only change.

---
Automated fix by lean-mechanic agent.