### PR TITLE
Fix: realign stale counts for central-limit-theorem-oq-02-oq-03

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02-oq-03/meta.json
@@ -71,9 +71,9 @@
       "CentralLimitTheoremOQ02"
     ],
     "namespace": "CentralLimitTheoremOQ02OQ03",
-    "lineCount": 208,
+    "lineCount": 256,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 1,
     "path": "Proofs/CentralLimitTheoremOQ02OQ03.lean",
     "sorries": 0
@@ -96,8 +96,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 252,
-    "assumptions": "None. All 6 theorems are machine-checked; #print axioms reports only the foundational axioms propext, Classical.choice, Quot.sound (no sorryAx, no custom axioms, no Lean.ofReduceBool). The file reuses the definition alphaMixingCoeff from the parent CentralLimitTheoremOQ02.lean; that parent definition is axiom-free (the parent's single axiom martingale_clt is unrelated and not referenced here).",
+    "lineCount": 256,
+    "assumptions": "None. All 7 theorems are machine-checked; #print axioms reports only the foundational axioms propext, Classical.choice, Quot.sound (no sorryAx, no custom axioms, no Lean.ofReduceBool). The file reuses the definition alphaMixingCoeff from the parent CentralLimitTheoremOQ02.lean; that parent definition is axiom-free (the parent's single axiom martingale_clt is unrelated and not referenced here).",
     "mathlib_version": "4.26.0",
     "historicalContext": "m-dependence was introduced by Hoeffding and Robbins (1948) as the first tractable dependence structure beyond independence admitting a CLT. It is the finite-range special case of Rosenblatt's (1956) α-mixing, with α(n) = 0 for n > m. Finite-order moving averages MA(q) are exactly q-dependent, and one-step functions of finite-state Markov chains are 1-dependent.",
     "proofStrategy": "Reuse the parent's nested-supremum-collapse: at lag n > m, m-dependence forces each term of the defining ⨆ to 0 (ENNReal.toReal_mul), and the Prop-indexed all-zero nested supremum over ℝ collapses via a Nonempty/IsEmpty case split. Derive the m = 0 (independence) recovery, eventual mixing decay (tendsto_atTop_of_eventually_const), and Ibragimov-series summability for every exponent (summable_of_ne_finset_zero + Real.zero_rpow).",


### PR DESCRIPTION
## Fix

Both the `meta.meta` and `leanFile` count blocks in `central-limit-theorem-oq-02-oq-03/meta.json` lagged behind the source after research PR #31251 added a 7th theorem (α-mixing coefficient ≤ 1 + m-monotonicity) and grew the file.

## Evidence

`wc -l Proofs/CentralLimitTheoremOQ02OQ03.lean` = **256**; 7 col-0 `theorem` declarations (all genuine, none in docstrings); 1 `def`; 0 sorry; 0 axiom.

**Before**: leanFile block 208 lines / 6 theorems; meta.meta lineCount 252; assumptions prose said "All 6 theorems".
**After**: 256 lines / 7 theorems in both blocks; assumptions prose updated to "All 7 theorems".

definitionCount (1), sorries (0), axiomCount (0) unchanged. Still VERIFIED / 0-axiom.

---
Automated fix by lean-mechanic agent.