### PR TITLE
audit: mark 2 fresh gallery entries clean (4199/4199 audited)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26071,6 +26071,18 @@
       "lastAudited": "2026-07-01T01:16:35Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1207-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T01:47:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lucas-sequence-degree2-identities-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T01:48:40Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 2 remaining unaudited gallery entries (both just-merged research PRs). Both **clean** — no integrity issues.

### erdos-1207-oq-03
- theoremCount 12 (11 col-0 + 1 `@[simp] theorem toNat_zero`) ✓, definitionCount 2 ✓, lineCount 188 ✓
- 0 axioms, 0 sorries (the "sorry" grep hit is docstring prose) ✓, no True stubs ✓
- status `verified` / badge `verified` appropriate: genuine carry-free base-3 proof; Mathlib deps (`sum_univ_succ`, `ncard_range_of_injective`, `card_fun`) are infrastructure, not the core result
- Honestly framed as a lower-bound follow-up (P₁(3ᵏ) ≥ 2ᵏ), not a solution to the open growth question

### lucas-sequence-degree2-identities-oq-02
- theoremCount 10 ✓, definitionCount 0 ✓, lineCount 183 ✓, 0 axioms, 0 sorries ✓, no True stubs ✓
- 3 numeric checks use kernel `decide` (0 `native_decide`) → no `Lean.ofReduceBool` → axiomCount 0 correct; assumptions field discloses this explicitly
- status `verified` / badge `original` appropriate: parameter-general formalization via induction + `linear_combination`, no Mathlib wrapper

Gallery status: **4199/4199 audited, 0 issues, 0 critical.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)