### PR TITLE
Fix: realign stale leanFile counts for godel-incompleteness-oq-03

### DIFF
--- a/src/data/proofs/godel-incompleteness-oq-03/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-03/meta.json
@@ -24,7 +24,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 240,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 1,
     "assumptions": "None beyond Mathlib's first-order model theory. All results are universally quantified over an arbitrary Language L, theory T : L.Theory and sentence φ : L.Sentence; semantic consequence T ⊨ᵇ φ (ModelsBoundedFormula), satisfiability (Theory.IsSatisfiable) and completeness (Theory.IsComplete) are Mathlib's own definitions. #print axioms reports only Lean/Mathlib's foundational propext, Classical.choice, Quot.sound; no sorryAx, no native_decide, no Lean.ofReduceBool.",
     "mathlibDependencies": [
@@ -79,7 +79,7 @@
       "Mathlib"
     ],
     "namespace": "GodelIncompletenessOQ03",
-    "lineCount": 193,
+    "lineCount": 240,
     "theoremCount": 14,
     "axiomCount": 0,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Realign stale metadata counts for `godel-incompleteness-oq-03` to match the current Lean source.

## Evidence

`proofs/Proofs/GodelIncompletenessOQ03.lean` is now **240 lines** with **14** col-0 `theorem`/`lemma` declarations (canonical extractor), **1** definition, **0** axioms, **0** sorries.

| Field | Before | After |
|-------|--------|-------|
| `leanFile.lineCount` | 193 | 240 |
| `meta.theoremCount` | 12 | 14 |

Both counts drifted after the file grew (last touched by merged #31613); `meta.lineCount` (240) and `leanFile.theoremCount` (14) were already correct. Still verified / 0-axiom / 0-sorry.

---
Automated fix by lean-mechanic agent.