### PR TITLE
research(lucas-sequence-degree2-identities-oq-01): general Lucas-sequence doubling formulas [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LucasSequenceDegree2IdentitiesOQ01.lean
+++ b/proofs/Proofs/LucasSequenceDegree2IdentitiesOQ01.lean
@@ -1,0 +1,133 @@
+import Mathlib.Tactic
+import Proofs.LucasSequenceDegree2Identities
+
+/-
+# General Lucas-Sequence Doubling Formulas
+
+## Open Question answered (parent OQ-01)
+
+The parent entry `LucasSequenceDegree2Identities` proves the master degree-2 identity
+`Vₙ² − D·Uₙ² = 4·Qⁿ` for the two-parameter Lucas sequences `Uₙ(P,Q)`, `Vₙ(P,Q)` and
+records, as its first open question, the *doubling* (index-halving) formulas
+
+  **`U₂ₙ = Uₙ·Vₙ`**   and   **`V₂ₙ = Vₙ² − 2·Qⁿ`**.
+
+These are the arithmetic heart of the theory: they express a Lucas number of index `2n`
+through its value at `n`, giving the `O(log n)` *fast-doubling* algorithm and the squaring
+step `Vₙ ↦ V₂ₙ = Vₙ² − 2·Qⁿ` of the Lucas–Lehmer primality test.
+
+## Proof architecture (no Binet closed form, no `√D`)
+
+1. `U_double_pair` — the **fast-doubling pair**
+   `U₂ₙ = Uₙ·Vₙ` and `U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ²`, proved by a single *simultaneous*
+   induction on `n`.  Pairing the two consecutive doubled indices `2n`, `2n+1` closes
+   the second-order recurrence `Uₘ₊₂ = P·Uₘ₊₁ − Q·Uₘ`; eliminating the companion value
+   through `V_eq` (`Vₖ = 2·Uₖ₊₁ − P·Uₖ`) collapses each step to a ring identity in `U`.
+
+2. `V_two_mul`, `V_two_mul_add_one` — the **companion doubling laws**
+   `V₂ₙ = Vₙ² − 2·Qⁿ` and `V₂ₙ₊₁ = Vₙ₊₁·Vₙ − P·Qⁿ`, with **no further induction**:
+   rewrite `V₂ₖ` through `V_eq`, insert the fast-doubling pair, eliminate `Vₙ` again by
+   `V_eq`, and discharge the residual `Qⁿ` with the parent's invariant quadratic form
+   `U_quad` (`Uₙ₊₁² − P·Uₙ·Uₙ₊₁ + Q·Uₙ² = Qⁿ`) via `linear_combination`.
+
+The whole development is uniform in `(P,Q)`: the Fibonacci/Lucas doubling
+`F₂ₙ = Fₙ·Lₙ`, `L₂ₙ = Lₙ² − 2·(−1)ⁿ` and the Pell doubling are the `(1,−1)` and
+`(2,−1)` instances.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace LucasSequenceDegree2Identities
+
+/-! ## Section I: The Fast-Doubling Pair -/
+
+/-- **Fast-doubling pair.** Simultaneously
+`U₂ₙ = Uₙ·Vₙ` and `U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ²`.
+
+Proved by one induction on `n`: the successor step expands the recurrence at the doubled
+index `2k`, feeds in the inductive pair, eliminates the companion values via `V_eq`, and
+closes each equality by `ring`.  Index normalization `2·(k+1) = 2k+2`,
+`2·(k+1)+1 = 2k+3` is handled definitionally by `show`. -/
+theorem U_double_pair (P Q : ℤ) (n : ℕ) :
+    U P Q (2 * n) = U P Q n * V P Q n ∧
+    U P Q (2 * n + 1) = (U P Q (n + 1)) ^ 2 - Q * (U P Q n) ^ 2 := by
+  induction n with
+  | zero => exact ⟨by simp, by simp⟩
+  | succ k ih =>
+    obtain ⟨ih1, ih2⟩ := ih
+    -- Recurrence at the doubled indices, with clean index forms.
+    have h22 : U P Q (2 * k + 2) = P * U P Q (2 * k + 1) - Q * U P Q (2 * k) :=
+      U_add_two P Q (2 * k)
+    have h23 : U P Q (2 * k + 3) = P * U P Q (2 * k + 2) - Q * U P Q (2 * k + 1) :=
+      U_add_two P Q (2 * k + 1)
+    -- Companion values in terms of `U`.
+    have hVk : V P Q k = 2 * U P Q (k + 1) - P * U P Q k := V_eq P Q k
+    have hUk2 : U P Q (k + 2) = P * U P Q (k + 1) - Q * U P Q k := U_add_two P Q k
+    refine ⟨?_, ?_⟩
+    · show U P Q (2 * k + 2) = U P Q (k + 1) * V P Q (k + 1)
+      rw [h22, ih2, ih1, hVk, V_eq P Q (k + 1), hUk2]
+      ring
+    · show U P Q (2 * k + 3) = (U P Q (k + 2)) ^ 2 - Q * (U P Q (k + 1)) ^ 2
+      rw [h23, h22, ih2, ih1, hVk, hUk2]
+      ring
+
+/-- **Fundamental doubling formula** `U₂ₙ = Uₙ·Vₙ` (the OQ-01 first target). -/
+theorem U_two_mul (P Q : ℤ) (n : ℕ) : U P Q (2 * n) = U P Q n * V P Q n :=
+  (U_double_pair P Q n).1
+
+/-- **Odd fast-doubling formula** `U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ²`. -/
+theorem U_two_mul_add_one (P Q : ℤ) (n : ℕ) :
+    U P Q (2 * n + 1) = (U P Q (n + 1)) ^ 2 - Q * (U P Q n) ^ 2 :=
+  (U_double_pair P Q n).2
+
+/-! ## Section II: Companion Doubling -/
+
+/-- **Companion doubling formula** `V₂ₙ = Vₙ² − 2·Qⁿ` (the OQ-01 second target).
+
+No induction: `V_eq` turns `V₂ₙ` into `2·U₂ₙ₊₁ − P·U₂ₙ`, the fast-doubling pair evaluates
+both `U`-terms, `V_eq` eliminates the remaining `Vₙ`, and the residual `Qⁿ` is supplied by
+the invariant quadratic form `U_quad` with coefficient `−2`. -/
+theorem V_two_mul (P Q : ℤ) (n : ℕ) :
+    V P Q (2 * n) = (V P Q n) ^ 2 - 2 * Q ^ n := by
+  have hV2 : V P Q (2 * n) = 2 * U P Q (2 * n + 1) - P * U P Q (2 * n) := V_eq P Q (2 * n)
+  rw [hV2, U_two_mul_add_one, U_two_mul, V_eq P Q n]
+  linear_combination (-2 : ℤ) * U_quad P Q n
+
+/-- **Odd companion doubling** `V₂ₙ₊₁ = Vₙ₊₁·Vₙ − P·Qⁿ`.
+
+Same shape: `V_eq` at `2n+1` needs `U₂ₙ₊₂ = U₂₍ₙ₊₁₎ = Uₙ₊₁·Vₙ₊₁` (fast-doubling pair at
+`n+1`) and `U₂ₙ₊₁`; eliminating the companion values and reducing `Qⁿ` by `U_quad`
+(coefficient `−P`) closes it. -/
+theorem V_two_mul_add_one (P Q : ℤ) (n : ℕ) :
+    V P Q (2 * n + 1) = V P Q (n + 1) * V P Q n - P * Q ^ n := by
+  have hV2 : V P Q (2 * n + 1) = 2 * U P Q (2 * n + 2) - P * U P Q (2 * n + 1) :=
+    V_eq P Q (2 * n + 1)
+  have hU2 : U P Q (2 * n + 2) = U P Q (n + 1) * V P Q (n + 1) :=
+    U_two_mul P Q (n + 1)
+  have hUn2 : U P Q (n + 2) = P * U P Q (n + 1) - Q * U P Q n := U_add_two P Q n
+  rw [hV2, hU2, U_two_mul_add_one, V_eq P Q (n + 1), V_eq P Q n, hUn2]
+  linear_combination (-P) * U_quad P Q n
+
+/-! ## Section III: Named Specializations and Numeric Checks -/
+
+/-- Fibonacci doubling `F₂ₙ = Fₙ·Lₙ`, the `(P,Q) = (1,−1)` instance. -/
+theorem fib_doubling (n : ℕ) : U 1 (-1) (2 * n) = U 1 (-1) n * V 1 (-1) n :=
+  U_two_mul 1 (-1) n
+
+/-- Lucas doubling `L₂ₙ = Lₙ² − 2·(−1)ⁿ`, the `(P,Q) = (1,−1)` instance. -/
+theorem lucas_doubling (n : ℕ) :
+    V 1 (-1) (2 * n) = (V 1 (-1) n) ^ 2 - 2 * (-1 : ℤ) ^ n :=
+  V_two_mul 1 (-1) n
+
+/-- Pell doubling `U₂ₙ = Uₙ·Vₙ`, the `(P,Q) = (2,−1)` instance. -/
+theorem pell_doubling (n : ℕ) : U 2 (-1) (2 * n) = U 2 (-1) n * V 2 (-1) n :=
+  U_two_mul 2 (-1) n
+
+/-- Numeric sanity check at `(1,−1)`, `n = 3`: `F₆ = 8 = F₃·L₃ = 2·4` and
+`L₆ = 18 = L₃² − 2·(−1)³ = 16 + 2`. -/
+example : U 1 (-1) 6 = 8 ∧ V 1 (-1) 6 = 18 ∧
+    U 1 (-1) 6 = U 1 (-1) 3 * V 1 (-1) 3 ∧
+    V 1 (-1) 6 = (V 1 (-1) 3) ^ 2 - 2 * (-1 : ℤ) ^ 3 := by
+  refine ⟨by decide, by decide, by decide, by decide⟩
+
+end LucasSequenceDegree2Identities

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-01/annotations.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-01/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "ann-programme",
+    "proofId": "lucas-sequence-degree2-identities-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 38
+    },
+    "type": "concept",
+    "title": "Doubling Formulas for Every Lucas-Sequence Pair",
+    "content": "The docstring states the target: the parent entry proved the master identity Vₙ² − D·Uₙ² = 4·Qⁿ and asked, as its first open question, for the general doubling formulas U₂ₙ = Uₙ·Vₙ and V₂ₙ = Vₙ² − 2·Qⁿ over arbitrary integer parameters (P,Q). This file answers it. The plan is two moves: a single simultaneous induction proving the fast-doubling pair (U₂ₙ = Uₙ·Vₙ together with U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ²), followed by pure algebra — no further induction — for the companion doubling laws V₂ₙ and V₂ₙ₊₁, using the parent's V_eq and U_quad. Everything stays over ℤ with no Binet closed form.",
+    "mathContext": "$U_{2n}=U_n V_n,\\ V_{2n}=V_n^2-2Q^n$; at $(P,Q)=(1,-1)$ these are $F_{2n}=F_n L_n,\\ L_{2n}=L_n^2-2(-1)^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lucas-sequence doubling formulas",
+      "fast doubling (O(log n) index computation)",
+      "Lucas–Lehmer squaring step V₂ₙ = Vₙ² − 2·Qⁿ",
+      "answering a parent open question"
+    ],
+    "prerequisites": [
+      "the general Lucas sequences Uₙ(P,Q), Vₙ(P,Q)",
+      "the master identity and its structural lemmas"
+    ]
+  },
+  {
+    "id": "ann-fast-doubling-pair",
+    "proofId": "lucas-sequence-degree2-identities-oq-01",
+    "range": {
+      "startLine": 42,
+      "endLine": 73
+    },
+    "type": "tactic",
+    "title": "The Fast-Doubling Pair by One Simultaneous Induction",
+    "content": "U_double_pair proves U₂ₙ = Uₙ·Vₙ and U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ² together, by induction on n. Pairing the two statements is essential: the recurrence Uₘ₊₂ = P·Uₘ₊₁ − Q·Uₘ is second-order, so computing U₂ₙ₊₂ (and U₂ₙ₊₃) from index n needs both consecutive doubled values 2n and 2n+1, which the paired hypothesis carries. In the successor step the doubled-index recurrences hU2 (at 2k) and hU3 (at 2k+1) expand the two goals; the inductive pair ih0, ih1 substitutes U₂ₖ and U₂ₖ₊₁; and V_eq (hVk, hVk1) plus the recurrence hUk2 eliminate every companion value, leaving a polynomial identity in Uₖ, Uₖ₊₁ that ring closes. Index normalization 2·(k+1) = 2k+2 and 2·(k+1)+1 = 2k+3 is done definitionally by `show`, so no arithmetic rewriting is needed.",
+    "mathContext": "Step at $n=k$: $U_{2k+2}=P\\,U_{2k+1}-Q\\,U_{2k}$ becomes $U_{k+1}V_{k+1}$ after substituting the pair and $V_k=2U_{k+1}-PU_k$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "simultaneous (paired) induction",
+      "second-order recurrence at a doubled index",
+      "definitional index normalization via `show`",
+      "eliminating V through V_eq"
+    ],
+    "prerequisites": [
+      "induction on a strengthened (paired) statement",
+      "the ring tactic over ℤ"
+    ]
+  },
+  {
+    "id": "ann-fundamental-doubling",
+    "proofId": "lucas-sequence-degree2-identities-oq-01",
+    "range": {
+      "startLine": 74,
+      "endLine": 82
+    },
+    "type": "insight",
+    "title": "U₂ₙ = Uₙ·Vₙ and the Odd Fast-Doubling Step",
+    "content": "The two components are extracted as named theorems: U_two_mul (U₂ₙ = Uₙ·Vₙ, the OQ-01 first target) and U_two_mul_add_one (U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ²). Together they are the classical fast-doubling identities: knowing (Uₙ, Uₙ₊₁) they produce (U₂ₙ, U₂ₙ₊₁), so U at any index is computed in O(log n) recurrence steps by walking the binary expansion of the index — the same trick as fast Fibonacci. U_two_mul also immediately yields the divisibility Uₙ ∣ U₂ₙ.",
+    "mathContext": "$U_{2n}=U_n V_n$, $U_{2n+1}=U_{n+1}^2-Q U_n^2$; Fibonacci: $F_6=8=F_3 L_3$, $F_7=13=F_4^2+F_3^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "fast-doubling algorithm",
+      "divisibility Uₙ ∣ U₂ₙ",
+      "Fibonacci fast doubling"
+    ],
+    "prerequisites": [
+      "the fast-doubling pair"
+    ]
+  },
+  {
+    "id": "ann-companion-doubling",
+    "proofId": "lucas-sequence-degree2-identities-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 110
+    },
+    "type": "tactic",
+    "title": "Companion Doubling with No Induction",
+    "content": "V_two_mul (V₂ₙ = Vₙ² − 2·Qⁿ) and V_two_mul_add_one (V₂ₙ₊₁ = Vₙ₊₁·Vₙ − P·Qⁿ) require no new induction. For V_two_mul: V_eq at the doubled index rewrites V₂ₙ = 2·U₂ₙ₊₁ − P·U₂ₙ; the fast-doubling pair evaluates both U-terms into Uₙ, Uₙ₊₁; V_eq at n eliminates the remaining Vₙ; and the residual Qⁿ is supplied by the invariant quadratic form U_quad. The whole identity then collapses under linear_combination (−2)·U_quad — the coefficient −2 is exactly the factor by which the leftover Uₙ₊₁² − P·Uₙ·Uₙ₊₁ + Q·Uₙ² block must be scaled to become 2·Qⁿ. V_two_mul_add_one is the same recipe (U₂ₙ₊₂ = U₂₍ₙ₊₁₎ = Uₙ₊₁·Vₙ₊₁ via U_two_mul at n+1) closed by linear_combination P·U_quad.",
+    "mathContext": "$V_{2n}=2U_{2n+1}-P U_{2n}=2(U_{n+1}^2-QU_n^2)-P U_n V_n$, then $-2\\,U\\_quad$ turns this into $V_n^2-2Q^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "V_eq elimination of the companion sequence",
+      "the invariant quadratic form U_quad",
+      "linear_combination over ℤ",
+      "Lucas–Lehmer squaring step"
+    ],
+    "prerequisites": [
+      "V_eq and U_quad from the parent entry",
+      "the fast-doubling pair"
+    ]
+  },
+  {
+    "id": "ann-specializations",
+    "proofId": "lucas-sequence-degree2-identities-oq-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 133
+    },
+    "type": "concept",
+    "title": "Fibonacci/Lucas and Pell Doubling as Instances",
+    "content": "The parameter-general theorems specialize with no extra work: fib_doubling gives F₂ₙ = Fₙ·Lₙ and lucas_doubling gives L₂ₙ = Lₙ² − 2·(−1)ⁿ at (P,Q) = (1,−1); pell_doubling gives the Pell doubling U₂ₙ = Uₙ·Vₙ at (2,−1). Two kernel-`decide` numeric checks (F₆ = 8 = F₃·L₃ = 2·4, and L₆ = 18 = L₃² − 2·(−1)³ = 16 + 2) confirm the definitions and formulas concretely without native_decide, keeping the file axiom-free.",
+    "mathContext": "$(P,Q)=(1,-1)$: $F_{2n}=F_n L_n$, $L_{2n}=L_n^2-2(-1)^n$; $(2,-1)$: Pell doubling.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fibonacci/Lucas special case",
+      "Pell/Pell-Lucas special case",
+      "kernel decide numeric verification"
+    ],
+    "prerequisites": [
+      "the general doubling theorems"
+    ]
+  }
+]

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-01/index.ts
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LucasSequenceDegree2IdentitiesOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lucasSequenceDegree2IdentitiesOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lucasSequenceDegree2IdentitiesOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lucasSequenceDegree2IdentitiesOQ01Data: ProofData = {
+  proof: lucasSequenceDegree2IdentitiesOQ01Proof,
+  annotations: lucasSequenceDegree2IdentitiesOQ01Annotations,
+}

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-01/meta.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-01/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "lucas-sequence-degree2-identities-oq-01",
+  "slug": "lucas-sequence-degree2-identities-oq-01",
+  "title": "General Lucas-Sequence Doubling Formulas: U₂ₙ = Uₙ·Vₙ and V₂ₙ = Vₙ² − 2·Qⁿ",
+  "status": "verified",
+  "badge": "original",
+  "description": "The doubling (index-halving) formulas for the general two-parameter Lucas sequences Uₙ(P,Q), Vₙ(P,Q) over ℤ, answering the parent entry's first open question. The engine is the fast-doubling pair U₂ₙ = Uₙ·Vₙ and U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ², proved by a single simultaneous induction on n: the two consecutive doubled indices 2n, 2n+1 feed the recurrence Uₘ₊₂ = P·Uₘ₊₁ − Q·Uₘ, and eliminating Vₙ via V_eq collapses each inductive step to a pure ring identity in Uₙ, Uₙ₊₁. The two companion doubling laws V₂ₙ = Vₙ² − 2·Qⁿ and V₂ₙ₊₁ = Vₙ₊₁·Vₙ − P·Qⁿ then follow with no further induction, by rewriting Vₖ through V_eq and reducing the residual Qⁿ with the invariant quadratic form U_quad. Specializes to the classical Fibonacci/Lucas doubling F₂ₙ = Fₙ·Lₙ, L₂ₙ = Lₙ² − 2·(−1)ⁿ and to Pell. Fully verified: 8 theorems, 0 definitions, 0 sorries, 0 axioms, kernel decide only (no native_decide).",
+  "overview": {
+    "historicalContext": "Doubling formulas are the arithmetic heart of Lucas sequences: they express Uₙ(P,Q), Vₙ(P,Q) at index 2n through their values at n, so a Lucas number of index n is computable in O(log n) recurrence steps by repeated squaring on the index — the 'fast doubling' method familiar from Fibonacci computation. The same identities drive the Lucas–Lehmer primality test (which iterates Vₙ ↦ V₂ₙ = Vₙ² − 2·Qⁿ) and the theory of Lucas pseudoprimes. For the Fibonacci/Lucas pair (P,Q) = (1,−1) they are the textbook F₂ₙ = Fₙ·Lₙ and L₂ₙ = Lₙ² − 2·(−1)ⁿ; this entry proves them once for every (P,Q).",
+    "problemStatement": "Prove, over ℤ for arbitrary parameters P, Q, the general doubling formulas U₂ₙ = Uₙ·Vₙ and V₂ₙ = Vₙ² − 2·Qⁿ for the fundamental and companion Lucas sequences, without a Binet closed form or √D. Recover the Fibonacci/Lucas and Pell doubling identities as instances.",
+    "proofStrategy": "Two moves: an induction for the fundamental sequence, then pure algebra for the companion. (1) U_double_pair: prove the fast-doubling pair U₂ₙ = Uₙ·Vₙ and U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ² simultaneously by induction on n. The successor step computes U₂ₙ₊₂ and U₂ₙ₊₃ from the recurrence Uₘ₊₂ = P·Uₘ₊₁ − Q·Uₘ at the doubled index, substitutes the inductive pair at n, and eliminates the companion value Vₖ via V_eq (Vₖ = 2·Uₖ₊₁ − P·Uₖ); both target equalities then reduce to polynomial identities in Uₖ, Uₖ₊₁ closed by ring. Index normalization 2·(k+1) = 2k+2, 2·(k+1)+1 = 2k+3 is handled by definitional `show`. (2) V_two_mul / V_two_mul_add_one: no new induction — rewrite V₂ₙ (resp. V₂ₙ₊₁) through V_eq at the doubled index, insert the fast-doubling pair, eliminate Vₙ by V_eq, and discharge the residual Qⁿ via the invariant quadratic form U_quad (Uₙ₊₁² − P·Uₙ·Uₙ₊₁ + Q·Uₙ² = Qⁿ) with linear_combination coefficient −2 (resp. P).",
+    "keyInsights": [
+      "One induction suffices for the whole fundamental-sequence doubling theory: pairing U₂ₙ with U₂ₙ₊₁ closes the second-order recurrence, because the step at n needs exactly the two consecutive doubled values 2n and 2n+1 that the pair carries.",
+      "The companion doubling formulas need no induction at all: V_eq turns V₂ₙ into 2·U₂ₙ₊₁ − P·U₂ₙ, the fast-doubling pair evaluates both U-terms, and U_quad supplies the Qⁿ — the entire content is a linear_combination over U_quad.",
+      "Eliminating V through V_eq is again the decisive reduction (as in the parent's master identity): every statement about two sequences becomes a ring identity in Uₙ, Uₙ₊₁ alone.",
+      "U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ² is the odd half of the fast-doubling step; with U₂ₙ = Uₙ·Vₙ it gives an O(log n) algorithm for any Lucas sequence, and specializes to the Fibonacci fast-doubling identities.",
+      "The reduction is uniform in (P,Q): the Fibonacci/Lucas doubling F₂ₙ = Fₙ·Lₙ, L₂ₙ = Lₙ² − 2·(−1)ⁿ and the Pell doubling are the (1,−1) and (2,−1) instances of a single parameter-general proof."
+    ],
+    "prerequisites": [
+      "The general Lucas sequences Uₙ(P,Q), Vₙ(P,Q) and their recurrence (parent entry)",
+      "The structural lemmas V_eq (Vₙ = 2·Uₙ₊₁ − P·Uₙ) and U_quad (invariant quadratic form) from the parent",
+      "Simultaneous (paired) induction to handle a second-order recurrence at a doubled index",
+      "Lean tactics linear_combination and ring for polynomial identities over ℤ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "fast-doubling-pair",
+      "title": "Section I: The Fast-Doubling Pair (U_double_pair)",
+      "startLine": 42,
+      "endLine": 82,
+      "summary": "U_double_pair: U₂ₙ = Uₙ·Vₙ and U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ² by one simultaneous induction on n; the successor step expands the recurrence at the doubled index, feeds in the inductive pair, eliminates Vₖ by V_eq, and closes by ring. U_two_mul and U_two_mul_add_one extract the two components.",
+      "mathContext": "$U_{2n}=U_n V_n,\\ U_{2n+1}=U_{n+1}^2-Q U_n^2$; e.g. Fibonacci $F_6=8=F_3 L_3=2\\cdot4$."
+    },
+    {
+      "id": "companion-doubling",
+      "title": "Section II: Companion Doubling (V_two_mul, V_two_mul_add_one)",
+      "startLine": 83,
+      "endLine": 110,
+      "summary": "V_two_mul: V₂ₙ = Vₙ² − 2·Qⁿ and V_two_mul_add_one: V₂ₙ₊₁ = Vₙ₊₁·Vₙ − P·Qⁿ, both derived with no further induction from V_eq, the fast-doubling pair, and U_quad via linear_combination (coefficients −2 and P).",
+      "mathContext": "$V_{2n}=V_n^2-2Q^n$; e.g. Lucas $L_6=18=L_3^2-2(-1)^3=16+2$."
+    },
+    {
+      "id": "specializations",
+      "title": "Section III: Named Specializations and Numeric Checks",
+      "startLine": 111,
+      "endLine": 133,
+      "summary": "fib_doubling F₂ₙ = Fₙ·Lₙ and lucas_doubling L₂ₙ = Lₙ² − 2·(−1)ⁿ at (1,−1), pell_doubling U₂ₙ = Uₙ·Vₙ at (2,−1), plus kernel-decide numeric sanity checks (F₆=8, L₆=18).",
+      "mathContext": "The (P,Q)=(1,−1) and (2,−1) instances of the general doubling laws."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, kernel decide only — no native_decide) 133-line file with 8 theorems establishing the general Lucas-sequence doubling formulas U₂ₙ = Uₙ·Vₙ, V₂ₙ = Vₙ² − 2·Qⁿ (and the odd companions U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ², V₂ₙ₊₁ = Vₙ₊₁·Vₙ − P·Qⁿ) for the two-parameter Lucas sequences over ℤ. The fundamental-sequence doubling is one simultaneous induction on the fast-doubling pair; the companion doubling needs no induction, following from V_eq and the invariant quadratic form U_quad by linear_combination. Fibonacci/Lucas (F₂ₙ=Fₙ·Lₙ, L₂ₙ=Lₙ²−2(−1)ⁿ) and Pell doubling are corollaries. #print axioms reports only [propext, Classical.choice, Quot.sound].",
+    "implications": "Answers the first open question of the parent master-identity entry. Combined with the parent's V_eq and U_quad, the doubling laws provide the O(log n) fast-doubling algorithm and the squaring step V₂ₙ = Vₙ² − 2·Qⁿ underlying the Lucas–Lehmer test, uniformly over (P,Q). The fast-doubling pair is reusable infrastructure for index-2ᵏ identities and for the bilinear addition laws (parent OQ-02), of which doubling is the diagonal m = n case.",
+    "openQuestions": [
+      "Prove the general index-tripling formulas U₃ₙ and V₃ₙ (e.g. U₃ₙ = Uₙ·(Vₙ² − Qⁿ) − ... ) as polynomials in Uₙ, Vₙ, Qⁿ, extending the doubling toolkit to arbitrary index multiplication.",
+      "Establish the divisibility Uₙ ∣ U₂ₙ (immediate from U₂ₙ = Uₙ·Vₙ) and more generally Uₙ ∣ U_{kn} for all k, the first step toward the strong divisibility property gcd(Uₘ,Uₙ) = U_gcd(m,n) of Lucas sequences."
+    ]
+  },
+  "references": [
+    {
+      "key": "Lucas1878",
+      "citation": "Lucas, É., Théorie des fonctions numériques simplement périodiques, American Journal of Mathematics 1 (1878), 184–240, 289–321.",
+      "type": "article"
+    },
+    {
+      "key": "Ribenboim",
+      "citation": "Ribenboim, P., The New Book of Prime Number Records, Springer (1996), Ch. on Lucas sequences U_n(P,Q), V_n(P,Q): doubling and addition formulas.",
+      "type": "book"
+    },
+    {
+      "key": "Williams",
+      "citation": "Williams, H. C., Édouard Lucas and Primality Testing, Canadian Mathematical Society Monographs, Wiley (1998).",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "lucas-sequence-degree2-identities",
+      "relation": "Parent entry: proves the master identity Vₙ² − (P²−4Q)·Uₙ² = 4·Qⁿ and supplies V_eq and U_quad; this entry answers its first open question (the doubling formulas)."
+    },
+    {
+      "proofId": "fibonacci-identities-oq-02-oq-01-oq-01",
+      "relation": "Specializes at (P,Q) = (1,−1) to the Fibonacci/Lucas doubling F₂ₙ = Fₙ·Lₙ, L₂ₙ = Lₙ² − 2·(−1)ⁿ."
+    },
+    {
+      "proofId": "pell-equation",
+      "relation": "The (P,Q) = (2,−1) instance gives the Pell / Pell-Lucas doubling formulas."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.LucasSequenceDegree2Identities"
+    ],
+    "opens": [],
+    "namespace": "LucasSequenceDegree2Identities",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/LucasSequenceDegree2IdentitiesOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_sequence",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LucasSequenceDegree2IdentitiesOQ01.lean",
+    "tags": [
+      "number-theory",
+      "lucas-sequences",
+      "fibonacci",
+      "pell",
+      "recurrence",
+      "doubling-formula",
+      "fast-doubling",
+      "induction",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "linear_combination",
+        "description": "Discharges the companion doubling formulas V_two_mul (coefficient −2·U_quad) and V_two_mul_add_one (coefficient P·U_quad) over ℤ",
+        "module": "Mathlib.Tactic.LinearCombination"
+      },
+      {
+        "theorem": "ring",
+        "description": "Closes the polynomial inductive step of the fast-doubling pair after the recurrences, inductive pair, and V_eq are substituted",
+        "module": "Mathlib.Tactic.Ring"
+      }
+    ],
+    "originalContributions": [
+      "U_double_pair: the fast-doubling pair U₂ₙ = Uₙ·Vₙ and U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ², proved by one simultaneous induction",
+      "U_two_mul, U_two_mul_add_one: the fundamental doubling and odd fast-doubling formulas (the OQ-01 first target)",
+      "V_two_mul: the companion doubling formula V₂ₙ = Vₙ² − 2·Qⁿ (the OQ-01 second target), with no induction",
+      "V_two_mul_add_one: the odd companion doubling V₂ₙ₊₁ = Vₙ₊₁·Vₙ − P·Qⁿ",
+      "fib_doubling, lucas_doubling, pell_doubling: the (1,−1) Fibonacci/Lucas and (2,−1) Pell specializations"
+    ],
+    "axiomCount": 0,
+    "lineCount": 133,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The two numeric checks use kernel `decide` (not `native_decide`), so #print axioms reports only [propext, Classical.choice, Quot.sound]. Compiled against Mathlib v4.26.0. The doubling formulas are classical (Lucas, 1878); the contribution is the parameter-general, axiom-free formalization answering the parent entry's first open question.",
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "prerequisites": [
+      "The general Lucas sequences Uₙ(P,Q), Vₙ(P,Q) and the structural lemmas V_eq, U_quad (parent entry)",
+      "Simultaneous (paired) induction for a second-order recurrence at a doubled index",
+      "Lean tactics linear_combination and ring over ℤ"
+    ],
+    "relatedProblems": [
+      "lucas-sequence-degree2-identities",
+      "fibonacci-identities-oq-02-oq-01-oq-01",
+      "pell-equation"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `lucas-sequence-degree2-identities` (the master degree-2 identity `Vₙ²−D·Uₙ²=4·Qⁿ`): the **doubling / index-halving formulas** for the two-parameter Lucas sequences `Uₙ(P,Q)`, `Vₙ(P,Q)` over ℤ, without a Binet closed form or √D.

## Results (`Proofs/LucasSequenceDegree2IdentitiesOQ01.lean`, 133 lines, 8 theorems)

- **`U_double_pair`** — the fast-doubling pair `U₂ₙ = Uₙ·Vₙ` and `U₂ₙ₊₁ = Uₙ₊₁² − Q·Uₙ²`, proved by a single *simultaneous* induction on `n`. Pairing the two consecutive doubled indices closes the second-order recurrence; eliminating the companion value via the parent's `V_eq` collapses each step to a ring identity.
- **`U_two_mul`, `U_two_mul_add_one`** — the fundamental doubling and odd fast-doubling formulas.
- **`V_two_mul`** — `V₂ₙ = Vₙ² − 2·Qⁿ` (the squaring step of the Lucas–Lehmer test), and **`V_two_mul_add_one`** — `V₂ₙ₊₁ = Vₙ₊₁·Vₙ − P·Qⁿ`, **with no further induction**: rewrite through `V_eq`, insert the fast-doubling pair, and discharge the residual `Qⁿ` with the parent's invariant quadratic form `U_quad` via `linear_combination`.
- **`fib_doubling`, `lucas_doubling`, `pell_doubling`** — the `(1,−1)` Fibonacci/Lucas (`F₂ₙ=Fₙ·Lₙ`, `L₂ₙ=Lₙ²−2·(−1)ⁿ`) and `(2,−1)` Pell specializations, plus a kernel-`decide` numeric check (`F₆=8`, `L₆=18`).

## Verification

- Built via `./proofs/scripts/docker-build.sh Proofs.LucasSequenceDegree2IdentitiesOQ01` — **success**.
- `#print axioms` on all theorems reports only `[propext, Classical.choice, Quot.sound]` — **0 custom axioms, 0 sorries, no native_decide**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)