### PR TITLE
Enrich Ky Fan Trace Interlacing: compression-setup annotation + operator-theoretic insight

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-compression-setup",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 4, "endLine": 57 },
+    "type": "context",
+    "title": "The Abstract Orthogonal-Compression Framework Inherited from the Parent",
+    "content": "The entire variable block sets up the Poincaré separation hypotheses at the operator level, not the matrix level: `T` is a symmetric operator on an `(n+m)`-dimensional inner product space over any `RCLike` field `𝕜` (real OR complex), with an orthonormal eigenbasis `b` and descending eigenvalues `lam` (`Antitone lam`); `H` is a codimension-`m` subspace of dimension `n` carrying its own symmetric operator `TH` with eigenbasis `bH` and descending eigenvalues `mu`. The crucial link is `hRayleigh`: the Rayleigh quotient of `TH` on `H` agrees with that of `T` — this is exactly what makes `TH` the *orthogonal compression* `P_H T|_H` without ever writing a projection. Carrying the eigenvalues as free functions `lam`, `mu` (rather than extracting them from a matrix) is what lets the summed bounds be stated over an arbitrary index set.",
+    "mathContext": "$T = T^*$ on $V$, $\\dim V = n+m$; $H \\le V$, $\\dim H = n$; compression means $\\dfrac{\\langle TH\\,y, y\\rangle}{\\|y\\|^2} = \\dfrac{\\langle T y, y\\rangle}{\\|y\\|^2}$ for all $0 \\ne y \\in H$.",
+    "significance": "supporting",
+    "relatedConcepts": ["orthogonal compression", "Rayleigh quotient", "symmetric operator", "orthonormal eigenbasis", "RCLike field"],
+    "prerequisites": ["inner product spaces", "spectral theorem for symmetric operators", "subspace codimension"]
+  },
+  {
     "id": "ann-arbitrary-index-set",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-01",
     "range": { "startLine": 63, "endLine": 76 },

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
@@ -77,7 +77,8 @@
     "keyInsights": [
       "Stating the Ky Fan bounds over an arbitrary index set s : Finset (Fin n) — rather than only over Finset.univ — lets a single pair of theorems subsume both the trace estimate and every top-j partial sum, so the weak-majorization statement is a one-line specialisation with no Fin-interval bookkeeping",
       "The full mathematical weight sits in the parent Poincaré separation theorem; the Ky Fan content is exactly the monotonicity of finite sums, which is honest to record as a Finset.sum_le_sum wrapper rather than dressed up as new spectral theory",
-      "Because the eigenvalues are carried as the free functions λ and μ with the index map k ↦ ⟨k+m⟩ / k ↦ ⟨k⟩, the lower bound automatically references the n SMALLEST eigenvalues of T (indices m … n+m-1) and the upper bound the n LARGEST (indices 0 … n-1), making the trace trapping read off directly"
+      "Because the eigenvalues are carried as the free functions λ and μ with the index map k ↦ ⟨k+m⟩ / k ↦ ⟨k⟩, the lower bound automatically references the n SMALLEST eigenvalues of T (indices m … n+m-1) and the upper bound the n LARGEST (indices 0 … n-1), making the trace trapping read off directly",
+      "The whole development is operator-theoretic over an arbitrary RCLike field (real or complex), never touching matrices: the compression is characterised purely by the Rayleigh-quotient agreement hypothesis hRayleigh, so the Ky Fan trace and majorization bounds hold for compressions of Hermitian operators on any finite-dimensional inner product space, not just symmetric real matrices"
     ],
     "prerequisites": [
       "The Poincaré separation theorem (cauchy-interlacing-theorem-oq-01-oq-02 / CauchyInterlacingPoincare): termwise interlacing of compression eigenvalues",


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-02-oq-01`.

## Changes
- **Annotation coverage 4 → 5.** Added an annotation covering the abstract orthogonal-compression framework (variable block, lines 4–57): a symmetric operator over any `RCLike` field, the Rayleigh-quotient hypothesis `hRayleigh` that characterizes the compression without a projection, and the free eigenvalue functions `lam`/`mu` that make the arbitrary-index-set formulation possible. Now the header/setup, the two Ky Fan sum bounds, the weak-majorization prefix, the trace trapping, and the `include` directive are all annotated.
- **keyInsights 3 → 4.** Added an insight noting the development is matrix-free and holds for Hermitian operators over ℝ or ℂ, not just symmetric real matrices.

## Not changed
- `meta.json` stays at ~12.6 KB, well under the ~60 KB cap; `verified` / `axiomCount: 0` / `sorries: 0` accurately reflect the Lean source (content is the parent Poincaré separation theorem summed via `Finset.sum_le_sum`; no structure-encoded assumptions).

JSON validates; gallery data generation parses clean.