### PR TITLE
research(abel-ruffini-oq-07-discriminant-oq-01): general discriminant–square criterion Gal ⊆ Aₙ ⟺ disc a square [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ07DiscriminantOQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ07DiscriminantOQ01.lean
@@ -1,0 +1,207 @@
+/-
+  The Discriminant–Square Criterion:
+    Gal(f) ⊆ Aₙ  ⟺  disc(f) is a square in the base field
+  (Open Question OQ-01 of `abel-ruffini-oq-07-discriminant`)
+
+  ## Background
+  The parent entry `AbelRuffiniOQ07Discriminant.lean` reduces
+  `Gal(X⁵ − X − 1 / ℚ) ≅ S₅` to a discriminant assembler
+  (`gal_eq_top_of_transitive_threeCycle_odd`) that takes, as a *hypothesis*, the
+  existence of an odd permutation in the Galois group.  It supplies the arithmetic
+  fact `disc = 2869` is not a perfect square (`disc_not_square`) but leaves the
+  bridge
+
+      disc(f) is not a square in the base field  ⟹  Gal(f) contains an odd permutation
+
+  as an assumption, because Mathlib v4.26.0 has neither the polynomial discriminant
+  `∏_{i<j}(rⱼ − rᵢ)²` nor the classical criterion connecting it to the alternating
+  group.  This file formalizes that bridge in full generality.
+
+  ## The mathematical content
+  Let `E/F` be a finite Galois extension and `r : Fin n → E` a family of *distinct*
+  elements which the Galois group permutes (the roots of a separable polynomial).
+  Set
+
+      δ  :=  ∏_{i<j} (rⱼ − rᵢ)      (the Vandermonde difference product)
+      disc :=  δ²                    (the discriminant).
+
+  The two classical facts are:
+
+    * **Sign transformation.**  Any `φ ∈ Gal(E/F)` permutes the `rᵢ` by some
+      `σ ∈ Sₙ`, and then `φ(δ) = sign(σ) · δ`.  (Antisymmetry of the Vandermonde
+      determinant.)  Hence `φ` fixes `δ` iff `σ` is even.
+
+    * **Galois descent.**  `δ` lies in the base field `F` iff every `φ ∈ Gal(E/F)`
+      fixes it (`IsGalois.mem_range_algebraMap_iff_fixed`).
+
+  Combining, and using `disc = δ²` together with `δ ≠ 0` and `2 ≠ 0`:
+
+      disc is a square in F  ⟺  δ ∈ F  ⟺  every σ is even  ⟺  Gal(f) ⊆ Aₙ.
+
+  ## What this file verifies (0 sorry, 0 axiom)
+    * `diffProd` — the difference product `∏_{i<j}(rⱼ − rᵢ)`, as a Vandermonde
+      determinant, with `diffProd_eq_prod` giving the classical product form.
+    * `diffProd_comp_perm` — the **sign transformation**
+      `diffProd (r ∘ σ) = sign σ • diffProd r` (fills the Mathlib gap).
+    * `algEquiv_diffProd` — a Galois automorphism sends `δ` to the permuted `δ`.
+    * `algEquiv_fixes_diffProd_iff_sign_one` — `φ` fixes `δ` iff its permutation is even.
+    * `disc_isSquare_iff_gal_le_alternating` — **the criterion**:
+        disc is a square in F  ⟺  Gal(f) ⊆ Aₙ.
+    * `exists_odd_of_disc_not_square` — the exact form the parent needs:
+        disc not a square ⟹ some `φ` acts by an odd permutation.
+
+  Everything is fully machine-checked with 0 sorries and 0 axioms.
+-/
+import Mathlib.LinearAlgebra.Vandermonde
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.FieldTheory.Galois.Basic
+import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.Tactic
+
+open Matrix Equiv Equiv.Perm
+
+namespace AbelRuffiniDiscriminantSquare
+
+/-!
+## The difference product (square root of the discriminant)
+
+Over any commutative ring, the difference product `∏_{i<j}(rⱼ − rᵢ)` is the
+determinant of the Vandermonde matrix of the family.  We take this as the
+definition of `δ` and recover the product form from `Matrix.det_vandermonde`.
+-/
+
+variable {R : Type*} [CommRing R]
+
+/-- The **difference product** `δ = ∏_{i<j}(rⱼ − rᵢ)` of a finite family, realized
+as the Vandermonde determinant.  Its square is the discriminant. -/
+noncomputable def diffProd {n : ℕ} (r : Fin n → R) : R := (Matrix.vandermonde r).det
+
+/-- `δ` equals the classical difference product `∏_{i<j}(rⱼ − rᵢ)`. -/
+theorem diffProd_eq_prod {n : ℕ} (r : Fin n → R) :
+    diffProd r = ∏ i : Fin n, ∏ j ∈ Finset.Ioi i, (r j - r i) :=
+  Matrix.det_vandermonde r
+
+/-- Precomposing the family with a permutation `σ` is the same as permuting the rows
+of the Vandermonde matrix. -/
+theorem vandermonde_comp_perm {n : ℕ} (r : Fin n → R) (σ : Equiv.Perm (Fin n)) :
+    Matrix.vandermonde (r ∘ σ) = (Matrix.vandermonde r).submatrix σ id := by
+  ext i j
+  simp [Matrix.vandermonde_apply, Matrix.submatrix_apply]
+
+/-- **Sign transformation of the difference product.**  Permuting the family by `σ`
+multiplies the difference product by `sign σ`.  This is the antisymmetry of the
+Vandermonde determinant; it is the algebraic heart of the discriminant criterion. -/
+theorem diffProd_comp_perm {n : ℕ} (r : Fin n → R) (σ : Equiv.Perm (Fin n)) :
+    diffProd (r ∘ σ) = (Equiv.Perm.sign σ : ℤ) • diffProd r := by
+  unfold diffProd
+  rw [vandermonde_comp_perm, Matrix.det_permute]
+  rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with h | h <;> rw [h] <;> simp
+
+/-!
+## Galois action on the difference product
+
+From now on we work with a Galois automorphism of a field extension `E/F` that
+permutes a distinguished family `r : Fin n → E`.
+-/
+
+variable {F E : Type*} [Field F] [Field E] [Algebra F E]
+
+/-- A Galois automorphism `φ` which permutes `r` by `σ` sends `δ = diffProd r` to the
+difference product of the permuted family. -/
+theorem algEquiv_diffProd {n : ℕ} (r : Fin n → E) (f : E ≃ₐ[F] E)
+    {σ : Equiv.Perm (Fin n)} (hσ : ∀ i, f (r i) = r (σ i)) :
+    f (diffProd r) = diffProd (r ∘ σ) := by
+  unfold diffProd
+  rw [AlgEquiv.map_det]
+  congr 1
+  ext i j
+  simp only [AlgEquiv.mapMatrix_apply, Matrix.map_apply, Matrix.vandermonde_apply,
+    Function.comp_apply]
+  rw [map_pow, hσ]
+
+/-- **`φ` fixes `δ` iff its permutation is even.**  For distinct `r` in a field with
+`2 ≠ 0`, a Galois automorphism `φ` fixes the difference product exactly when the
+permutation `σ` it induces on `r` is even. -/
+theorem algEquiv_fixes_diffProd_iff_sign_one {n : ℕ} (r : Fin n → E)
+    (hr : Function.Injective r) (h2 : (2 : E) ≠ 0) (f : E ≃ₐ[F] E)
+    {σ : Equiv.Perm (Fin n)} (hσ : ∀ i, f (r i) = r (σ i)) :
+    f (diffProd r) = diffProd r ↔ Equiv.Perm.sign σ = 1 := by
+  have hne : diffProd r ≠ 0 := by
+    rw [diffProd]; exact Matrix.det_vandermonde_ne_zero_iff.mpr hr
+  rw [algEquiv_diffProd r f hσ, diffProd_comp_perm, zsmul_eq_mul]
+  rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with h | h <;> rw [h]
+  · simp
+  · simp only [Units.val_neg, Units.val_one, Int.cast_neg, Int.cast_one, neg_mul, one_mul]
+    constructor
+    · intro he
+      have h2δ : (2 : E) * diffProd r = 0 := by linear_combination -he
+      rcases mul_eq_zero.mp h2δ with hh | hh
+      · exact absurd hh h2
+      · exact absurd hh hne
+    · intro he; exact absurd he (by decide)
+
+/-!
+## The criterion
+-/
+
+variable {n : ℕ} (r : Fin n → E) [FiniteDimensional F E] [IsGalois F E]
+
+/-- The difference product lies in the base field iff it is fixed by the whole
+Galois group.  A direct instance of the Galois descent lemma. -/
+theorem diffProd_mem_range_iff_fixed :
+    diffProd r ∈ Set.range (algebraMap F E) ↔ ∀ f : E ≃ₐ[F] E, f (diffProd r) = diffProd r :=
+  IsGalois.mem_range_algebraMap_iff_fixed (diffProd r)
+
+/-- **The Discriminant–Square Criterion.**  Let `E/F` be a finite Galois extension,
+`r : Fin n → E` a family of distinct elements permuted by the Galois group, in a
+field where `2 ≠ 0`.  Then the discriminant `disc = δ²` is a square in the base
+field `F` if and only if every element of the Galois group acts on `r` by an even
+permutation (i.e. `Gal ⊆ Aₙ`). -/
+theorem disc_isSquare_iff_gal_le_alternating
+    (hr : Function.Injective r) (h2 : (2 : E) ≠ 0)
+    (hperm : ∀ f : E ≃ₐ[F] E, ∃ σ : Equiv.Perm (Fin n), ∀ i, f (r i) = r (σ i)) :
+    (∃ c : E, c ∈ Set.range (algebraMap F E) ∧ c ^ 2 = diffProd r ^ 2)
+      ↔ (∀ (f : E ≃ₐ[F] E) (σ : Equiv.Perm (Fin n)),
+            (∀ i, f (r i) = r (σ i)) → Equiv.Perm.sign σ = 1) := by
+  -- Step 1: `disc` is a square in `F`  ⟺  `δ ∈ F`.
+  have step1 :
+      (∃ c : E, c ∈ Set.range (algebraMap F E) ∧ c ^ 2 = diffProd r ^ 2)
+        ↔ diffProd r ∈ Set.range (algebraMap F E) := by
+    constructor
+    · rintro ⟨c, ⟨a, ha⟩, hc2⟩
+      -- `c² = δ²` ⟹ `(c − δ)(c + δ) = 0` ⟹ `δ = c` or `δ = −c`; both lie in `F`.
+      have h0 : (c - diffProd r) * (c + diffProd r) = 0 := by linear_combination hc2
+      rcases mul_eq_zero.mp h0 with h | h
+      · exact ⟨a, by rw [ha]; linear_combination h⟩
+      · exact ⟨-a, by rw [map_neg, ha]; linear_combination -h⟩
+    · rintro hδ
+      exact ⟨diffProd r, hδ, rfl⟩
+  -- Step 2: `δ ∈ F`  ⟺  every automorphism fixes `δ`.
+  rw [step1, diffProd_mem_range_iff_fixed]
+  -- Step 3: every automorphism fixes `δ`  ⟺  every induced permutation is even.
+  constructor
+  · intro hfix f σ hσ
+    exact (algEquiv_fixes_diffProd_iff_sign_one r hr h2 f hσ).mp (hfix f)
+  · intro heven f
+    obtain ⟨σ, hσ⟩ := hperm f
+    exact (algEquiv_fixes_diffProd_iff_sign_one r hr h2 f hσ).mpr (heven f σ hσ)
+
+/-- **The form the parent entry needs.**  If the discriminant `δ²` is *not* a square
+in the base field `F`, then some element of the Galois group acts on the roots by an
+*odd* permutation.  This discharges the odd-permutation hypothesis of the parent's
+assembler `gal_eq_top_of_transitive_threeCycle_odd` directly from a non-square
+discriminant. -/
+theorem exists_odd_of_disc_not_square
+    (hr : Function.Injective r) (h2 : (2 : E) ≠ 0)
+    (hperm : ∀ f : E ≃ₐ[F] E, ∃ σ : Equiv.Perm (Fin n), ∀ i, f (r i) = r (σ i))
+    (hns : ¬ ∃ c : E, c ∈ Set.range (algebraMap F E) ∧ c ^ 2 = diffProd r ^ 2) :
+    ∃ (f : E ≃ₐ[F] E) (σ : Equiv.Perm (Fin n)),
+      (∀ i, f (r i) = r (σ i)) ∧ σ ∉ alternatingGroup (Fin n) := by
+  by_contra hcon
+  push_neg at hcon
+  refine hns ((disc_isSquare_iff_gal_le_alternating r hr h2 hperm).mpr ?_)
+  intro f σ hσ
+  rw [← Equiv.Perm.mem_alternatingGroup]
+  exact hcon f σ hσ
+
+end AbelRuffiniDiscriminantSquare

--- a/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-aro07doq01-header",
+    "proofId": "abel-ruffini-oq-07-discriminant-oq-01",
+    "range": { "startLine": 1, "endLine": 63 },
+    "type": "concept",
+    "title": "The General Discriminant–Square Criterion",
+    "content": "The docstring states the classical criterion this file formalizes: for a finite Galois extension E/F whose Galois group permutes a family r of n distinct roots, the discriminant disc = δ² (with δ = ∏_{i<j}(rⱼ − rᵢ) the Vandermonde difference product) is a square in the base field F if and only if every automorphism acts by an even permutation — Gal(f) ⊆ Aₙ. This answers the first open question of the parent entry abel-ruffini-oq-07-discriminant, which left 'disc not a square ⟹ Gal contains an odd permutation' as a hypothesis. The two ingredients are the sign transformation φ(δ) = sign(σ)·δ (antisymmetry of the Vandermonde determinant) and Galois descent (δ ∈ F ⟺ fixed by the whole group).",
+    "mathContext": "$\\delta = \\prod_{i<j}(r_j - r_i)$, $\\operatorname{disc} = \\delta^2$; $\\mathrm{Gal} \\subseteq A_n \\iff \\delta \\in F \\iff \\operatorname{disc}$ is a square in $F$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Discriminant criterion", "Difference product", "Galois descent", "Alternating group"],
+    "prerequisites": ["Galois group as a permutation group on the roots", "Discriminant of a polynomial", "Vandermonde determinant"]
+  },
+  {
+    "id": "ann-aro07doq01-diffprod",
+    "proofId": "abel-ruffini-oq-07-discriminant-oq-01",
+    "range": { "startLine": 65, "endLine": 98 },
+    "type": "theorem",
+    "title": "The Difference Product and its Sign Transformation",
+    "content": "diffProd r := det(vandermonde r) defines δ over any commutative ring; diffProd_eq_prod recovers the classical form ∏_{i<j}(rⱼ − rᵢ) from Matrix.det_vandermonde. The key lemma vandermonde_comp_perm shows vandermonde(r∘σ) = (vandermonde r).submatrix σ id — precomposing the family with σ permutes the rows. diffProd_comp_perm then reads off the sign transformation diffProd(r∘σ) = sign(σ) • diffProd r directly from Matrix.det_permute (permuting rows scales the determinant by sign σ), case-splitting sign σ ∈ {1, −1} via Int.units_eq_one_or. This antisymmetry of the difference product is the algebraic heart of the criterion and is not present in Mathlib v4.26.0.",
+    "mathContext": "$\\mathrm{vandermonde}(r\\circ\\sigma) = (\\mathrm{vandermonde}\\,r).\\mathrm{submatrix}\\,\\sigma\\,\\mathrm{id}$, so $\\det \\Rightarrow \\delta(r\\circ\\sigma) = \\operatorname{sign}(\\sigma)\\,\\delta(r)$.",
+    "significance": "key",
+    "relatedConcepts": ["Vandermonde determinant", "Matrix.det_permute", "Sign of a permutation", "Antisymmetry"],
+    "prerequisites": ["Matrix.det_vandermonde", "Matrix.det_permute", "Int.units_eq_one_or"]
+  },
+  {
+    "id": "ann-aro07doq01-galois-action",
+    "proofId": "abel-ruffini-oq-07-discriminant-oq-01",
+    "range": { "startLine": 100, "endLine": 141 },
+    "type": "theorem",
+    "title": "Galois Action: φ Fixes δ ⟺ its Permutation is Even",
+    "content": "algEquiv_diffProd shows a Galois automorphism φ permuting r by σ sends δ = diffProd r to diffProd(r∘σ): φ commutes with the determinant (AlgEquiv.map_det), and entrywise f((rᵢ)ʲ) = (f rᵢ)ʲ = (r(σi))ʲ by map_pow and the permutation hypothesis. algEquiv_fixes_diffProd_iff_sign_one combines this with the sign transformation: φ(δ) = sign(σ)·δ, so φ fixes δ iff sign σ = 1. The characteristic hypothesis 2 ≠ 0 enters exactly here — if sign σ = −1 then −δ = δ, hence 2δ = 0, contradicting δ ≠ 0 (distinct roots, via det_vandermonde_ne_zero_iff).",
+    "mathContext": "$\\varphi(\\delta) = \\delta(r\\circ\\sigma) = \\operatorname{sign}(\\sigma)\\,\\delta$; $\\varphi(\\delta)=\\delta \\iff \\operatorname{sign}\\sigma = 1$, using $\\delta \\neq 0$ and $2 \\neq 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Field automorphism", "AlgEquiv.map_det", "Even permutation", "Vandermonde non-vanishing"],
+    "prerequisites": ["AlgEquiv.map_det", "map_pow", "Matrix.det_vandermonde_ne_zero_iff"]
+  },
+  {
+    "id": "ann-aro07doq01-criterion",
+    "proofId": "abel-ruffini-oq-07-discriminant-oq-01",
+    "range": { "startLine": 143, "endLine": 207 },
+    "type": "theorem",
+    "title": "The Criterion and the Parent-Facing Corollary",
+    "content": "diffProd_mem_range_iff_fixed instantiates Galois descent (IsGalois.mem_range_algebraMap_iff_fixed): δ lies in the base field iff every automorphism fixes it. disc_isSquare_iff_gal_le_alternating is the main theorem: disc = δ² is a square in F ⟺ Gal ⊆ Aₙ. Its proof chains three steps — (i) 'square in F ⟺ δ ∈ F', by factoring c² − δ² = (c−δ)(c+δ) so δ = ±c, both in the negation-closed base field; (ii) Galois descent; (iii) the fixed-iff-even lemma quantified over the whole group. exists_odd_of_disc_not_square is the contrapositive packaged exactly as the parent's assembler needs: a non-square discriminant yields an automorphism acting by an odd permutation.",
+    "mathContext": "$\\operatorname{disc}$ square in $F \\iff \\delta \\in F \\iff (\\forall\\varphi,\\ \\varphi\\delta=\\delta) \\iff (\\forall\\varphi,\\ \\text{its permutation is even}) \\iff \\mathrm{Gal} \\subseteq A_n$.",
+    "significance": "key",
+    "relatedConcepts": ["Galois descent", "Discriminant criterion", "Alternating group", "Contrapositive"],
+    "prerequisites": ["IsGalois.mem_range_algebraMap_iff_fixed", "Equiv.Perm.mem_alternatingGroup", "mul_eq_zero"]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ07DiscriminantOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniOQ07DiscriminantOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniOQ07DiscriminantOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOQ07DiscriminantOQ01Data: ProofData = {
+  proof: abelRuffiniOQ07DiscriminantOQ01Proof,
+  annotations: abelRuffiniOQ07DiscriminantOQ01Annotations,
+}

--- a/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01/meta.json
@@ -1,0 +1,266 @@
+{
+  "id": "abel-ruffini-oq-07-discriminant-oq-01",
+  "title": "The Discriminant–Square Criterion: Gal(f) ⊆ Aₙ ⟺ disc(f) is a Square",
+  "slug": "abel-ruffini-oq-07-discriminant-oq-01",
+  "description": "A general, machine-verified formalization of the classical discriminant criterion for the Galois group of a separable polynomial: for a finite Galois extension E/F whose Galois group permutes a family of n distinct elements r (the roots), the discriminant disc = δ² (where δ = ∏_{i<j}(rⱼ−rᵢ) is the Vandermonde difference product) is a square in the base field F if and only if every automorphism acts by an even permutation — i.e. Gal(f) ⊆ Aₙ. This answers the first open question of the parent entry abel-ruffini-oq-07-discriminant, which left the bridge 'disc not a square ⟹ Gal contains an odd permutation' as an explicit hypothesis because Mathlib v4.26.0 has neither the polynomial difference product ∏(rⱼ−rᵢ)² nor this criterion. The proof rests on two facts: the sign transformation φ(δ) = sign(σ)·δ (antisymmetry of the Vandermonde determinant, derived from Matrix.det_permute — a genuine Mathlib gap filled here), and Galois descent (δ ∈ F iff fixed by the whole Galois group, via IsGalois.mem_range_algebraMap_iff_fixed). The corollary exists_odd_of_disc_not_square delivers the exact odd-permutation input the parent's assembler consumes. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lagrange; Galois; folklore (discriminant criterion, Dummit–Foote §14.6)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Discriminant#Discriminant_of_a_polynomial",
+    "date": "1770",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ07DiscriminantOQ01.lean",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "field-theory",
+      "discriminant",
+      "alternating-group",
+      "symmetric-group",
+      "vandermonde",
+      "abel-ruffini"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "This file formalizes the general discriminant criterion 'Gal ⊆ Aₙ ⟺ disc is a square in the base field' for a finite Galois extension E/F whose Galois group permutes a distinguished family r : Fin n → E of distinct elements (a genuine hypothesis hperm, satisfied by the roots of a separable polynomial split by E). The central theorem disc_isSquare_iff_gal_le_alternating takes as hypotheses: injectivity of r (distinct roots), 2 ≠ 0 in E (characteristic ≠ 2, needed so that δ = −δ forces δ = 0), and that the Galois group permutes r. These are structural setup, not axioms. The Galois-descent step invokes Mathlib's IsGalois.mem_range_algebraMap_iff_fixed (requires [FiniteDimensional F E] [IsGalois F E]). Every theorem is fully machine-checked with 0 sorries and 0 axioms (only propext, Classical.choice, Quot.sound; no native_decide, no Lean.ofReduceBool).",
+    "dateAdded": "2026-06-30",
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.det_vandermonde",
+        "description": "The Vandermonde determinant equals the difference product ∏_{i<j}(vⱼ − vᵢ)",
+        "module": "Mathlib.LinearAlgebra.Vandermonde"
+      },
+      {
+        "theorem": "Matrix.det_vandermonde_ne_zero_iff",
+        "description": "The Vandermonde determinant is nonzero iff the family is injective (distinct roots ⟹ δ ≠ 0)",
+        "module": "Mathlib.LinearAlgebra.Vandermonde"
+      },
+      {
+        "theorem": "Matrix.det_permute",
+        "description": "Permuting the rows of a matrix by σ multiplies the determinant by sign σ — the source of the sign transformation",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "AlgEquiv.map_det",
+        "description": "An F-algebra automorphism commutes with the determinant: f(det M) = det(f.mapMatrix M)",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "IsGalois.mem_range_algebraMap_iff_fixed",
+        "description": "Galois descent: for a finite Galois extension, x lies in the base field iff it is fixed by every automorphism",
+        "module": "Mathlib.FieldTheory.Galois.Basic"
+      },
+      {
+        "theorem": "Equiv.Perm.mem_alternatingGroup",
+        "description": "σ ∈ alternatingGroup α ↔ sign σ = 1 (evenness as sign = 1)",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Alternating"
+      },
+      {
+        "theorem": "Int.units_eq_one_or",
+        "description": "A unit of ℤ is 1 or −1 — the case split that turns sign σ into ±1",
+        "module": "Mathlib.Algebra.Group.Int"
+      }
+    ],
+    "originalContributions": [
+      "diffProd_comp_perm: the sign transformation ∏_{i<j}(r(σj) − r(σi)) = sign(σ) · ∏_{i<j}(rⱼ − rᵢ) for an arbitrary permutation of an arbitrary family over a commutative ring, derived cleanly from Matrix.det_permute via the identity vandermonde (r∘σ) = (vandermonde r).submatrix σ id. This antisymmetry of the difference product is not in Mathlib v4.26.0.",
+      "algEquiv_fixes_diffProd_iff_sign_one: for distinct r in a field with 2 ≠ 0, a Galois automorphism fixes the difference product iff the permutation it induces on r is even.",
+      "disc_isSquare_iff_gal_le_alternating: the full discriminant–square criterion — disc = δ² is a square in the base field iff the Galois group acts by even permutations (Gal ⊆ Aₙ) — assembled from the sign transformation and Galois descent, in complete generality (any finite Galois extension, any n).",
+      "exists_odd_of_disc_not_square: the contrapositive packaged exactly as the parent entry's assembler needs — a non-square discriminant yields an automorphism acting by an odd permutation, discharging the parent's odd-permutation hypothesis."
+    ],
+    "prerequisites": [
+      "Symmetric and alternating groups; the sign homomorphism and its values ±1",
+      "The Vandermonde matrix and determinant; antisymmetry under row permutation",
+      "Galois theory: finite Galois extensions, the fixed field, and Galois descent",
+      "Discriminant of a polynomial as the square of the difference product",
+      "Lean 4 and Mathlib matrix/determinant/Galois API"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 207,
+    "relatedProblems": [
+      "abel-ruffini-oq-07-discriminant",
+      "abel-ruffini-oq-07",
+      "abel-ruffini-oq-04-oq-01",
+      "abel-ruffini"
+    ],
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The discriminant of a polynomial, Δ = ∏_{i<j}(rᵢ − rⱼ)², was studied by Lagrange and Gauss as the simplest symmetric function detecting repeated roots. Its square root δ = ∏_{i<j}(rⱼ − rᵢ) is not symmetric: a permutation of the roots multiplies it by the sign of the permutation. Galois theory turns this elementary observation into a decisive tool — the Galois group fixes δ (equivalently, δ lies in the base field, equivalently Δ is a square there) exactly when the group consists of even permutations. This is the standard first invariant used to locate a Galois group inside Aₙ versus Sₙ, and the classical route to the Galois group of a quintic (Dummit–Foote §14.6). The parent entry used it concretely for X⁵ − X − 1 (Δ = 2869, not a square, so Gal ⊄ A₅); this entry formalizes the criterion in general.",
+    "problemStatement": "Formalize, for a finite Galois extension E/F whose Galois group permutes a family r of n distinct elements, the equivalence: disc = (∏_{i<j}(rⱼ − rᵢ))² is a square in the base field F if and only if every automorphism of E over F acts on r by an even permutation (Gal ⊆ Aₙ).",
+    "text": "The difference product δ = ∏_{i<j}(rⱼ − rᵢ) is realized as the Vandermonde determinant det(vandermonde r), giving both the classical product form (diffProd_eq_prod) and, for free, its antisymmetry. The sign transformation diffProd_comp_perm states δ(r∘σ) = sign(σ)·δ(r) for any permutation σ, proved by recognizing vandermonde(r∘σ) as the row-permuted Vandermonde matrix and applying Matrix.det_permute. A Galois automorphism φ, being an F-algebra map, commutes with the determinant (AlgEquiv.map_det); if φ permutes r by σ then φ(δ) = δ(r∘σ) = sign(σ)·δ. With δ ≠ 0 (distinct roots) and 2 ≠ 0, φ fixes δ iff σ is even (algEquiv_fixes_diffProd_iff_sign_one). Galois descent (IsGalois.mem_range_algebraMap_iff_fixed) says δ ∈ F iff every φ fixes δ, and disc = δ² is a square in F iff δ ∈ F (since c² = δ² forces δ = ±c ∈ F). Chaining these gives the criterion.",
+    "proofStrategy": "(1) Define δ := det(vandermonde r) and recover the product form from Matrix.det_vandermonde. (2) Prove vandermonde(r∘σ) = (vandermonde r).submatrix σ id by entrywise computation, then diffProd_comp_perm := det_permute, case-splitting sign σ ∈ {1,−1}. (3) For a Galois automorphism φ with φ(rᵢ) = r(σ i), show φ(δ) = δ(r∘σ) via AlgEquiv.map_det and map_pow. (4) Deduce φ fixes δ ⟺ sign σ = 1: the sign = −1 case gives −δ = δ, hence 2δ = 0, contradicting δ ≠ 0 and 2 ≠ 0. (5) Show 'disc a square in F ⟺ δ ∈ F' by factoring c² − δ² = (c−δ)(c+δ); a root gives δ = ±c, and the base field (Set.range of the algebra map) is closed under negation. (6) Apply Galois descent to turn 'δ ∈ F' into 'fixed by all φ', and combine with step 4 quantified over the whole group. (7) The corollary exists_odd_of_disc_not_square is the contrapositive.",
+    "keyInsights": [
+      "The square root of the discriminant is literally the Vandermonde determinant, so its antisymmetry under permutations is Matrix.det_permute — no bespoke induction over pairs is needed.",
+      "A field automorphism commutes with the determinant because it is a ring homomorphism (AlgEquiv.map_det); this reduces 'how φ acts on δ' to 'how permuting the roots acts on δ', which is the sign.",
+      "The equivalence 'δ ∈ F ⟺ every automorphism fixes δ' is exactly Galois descent (IsGalois.mem_range_algebraMap_iff_fixed) — the one genuinely field-theoretic input, and Mathlib already has it.",
+      "'disc is a square in F' unpacks to 'δ ∈ F' with no characteristic hypothesis beyond 2 ≠ 0: from c² = δ² one factors (c−δ)(c+δ) = 0, so δ = ±c, and F is closed under negation.",
+      "The hypothesis 2 ≠ 0 enters exactly once — to conclude δ = 0 from −δ = δ — and is essential: in characteristic 2 the discriminant criterion genuinely fails (one uses the Berlekamp discriminant / Artin–Schreier invariant instead)."
+    ],
+    "prerequisites": [
+      "The sign homomorphism on permutations and the alternating group",
+      "Vandermonde determinant and its behavior under row permutation",
+      "Finite Galois extensions and Galois descent (fixed field = base field)",
+      "Discriminant of a polynomial",
+      "Lean 4 and Mathlib determinant/Galois API"
+    ],
+    "relatedConcepts": [
+      "discriminant of a polynomial",
+      "Vandermonde determinant",
+      "alternating group Aₙ",
+      "Galois descent",
+      "sign of a permutation"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Statement and Mathematical Content",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Documents the goal — the general criterion Gal(f) ⊆ Aₙ ⟺ disc(f) is a square in the base field — and how it discharges the odd-permutation hypothesis of the parent entry abel-ruffini-oq-07-discriminant. Records the two ingredients: the sign transformation φ(δ) = sign(σ)·δ and Galois descent, combined via disc = δ², δ ≠ 0, and 2 ≠ 0. Imports Vandermonde, determinant, Galois and alternating-group machinery.",
+      "mathContext": "δ = ∏_{i<j}(rⱼ − rᵢ), disc = δ²; Gal ⊆ Aₙ ⟺ δ ∈ F ⟺ disc a square in F.",
+      "relatedConcepts": [
+        "discriminant criterion",
+        "difference product",
+        "Galois descent"
+      ]
+    },
+    {
+      "id": "diffprod",
+      "title": "The Difference Product and its Sign Transformation",
+      "startLine": 65,
+      "endLine": 98,
+      "summary": "Defines diffProd r := det(vandermonde r) over any commutative ring, with diffProd_eq_prod giving the classical form ∏_{i<j}(rⱼ − rᵢ) via Matrix.det_vandermonde. vandermonde_comp_perm identifies vandermonde(r∘σ) with the row-permuted matrix (vandermonde r).submatrix σ id. diffProd_comp_perm then proves the sign transformation diffProd(r∘σ) = sign(σ) • diffProd r from Matrix.det_permute — the Mathlib gap this entry fills.",
+      "mathContext": "vandermonde(r∘σ) = (vandermonde r).submatrix σ id; det_permute ⟹ δ(r∘σ) = sign(σ)·δ(r).",
+      "relatedConcepts": [
+        "Vandermonde determinant",
+        "sign of a permutation",
+        "antisymmetry"
+      ]
+    },
+    {
+      "id": "galois-action",
+      "title": "Galois Action on the Difference Product",
+      "startLine": 100,
+      "endLine": 141,
+      "summary": "algEquiv_diffProd: a Galois automorphism φ permuting r by σ sends δ to the difference product of the permuted family, via AlgEquiv.map_det and map_pow. algEquiv_fixes_diffProd_iff_sign_one: for distinct r in a field with 2 ≠ 0, φ fixes δ exactly when σ is even — the sign = −1 case yields −δ = δ, hence 2δ = 0, contradicting δ ≠ 0.",
+      "mathContext": "φ(δ) = δ(r∘σ) = sign(σ)·δ; φ fixes δ ⟺ sign σ = 1, using δ ≠ 0 and 2 ≠ 0.",
+      "relatedConcepts": [
+        "field automorphism",
+        "determinant of a ring map",
+        "even permutation"
+      ]
+    },
+    {
+      "id": "criterion",
+      "title": "The Discriminant–Square Criterion",
+      "startLine": 143,
+      "endLine": 207,
+      "summary": "diffProd_mem_range_iff_fixed instantiates Galois descent: δ ∈ base field ⟺ fixed by all φ. disc_isSquare_iff_gal_le_alternating is the main theorem — disc = δ² is a square in F ⟺ every automorphism acts by an even permutation — proved by (i) 'square in F ⟺ δ ∈ F' via factoring c² − δ², (ii) Galois descent, (iii) the fixed-iff-even lemma quantified over the group. exists_odd_of_disc_not_square is the parent-facing contrapositive: a non-square discriminant supplies an odd permutation.",
+      "mathContext": "disc square in F ⟺ δ ∈ F ⟺ (∀φ, φ δ = δ) ⟺ (∀φ, its permutation is even) ⟺ Gal ⊆ Aₙ.",
+      "relatedConcepts": [
+        "discriminant criterion",
+        "Galois descent",
+        "alternating group"
+      ]
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "disc_isSquare_iff_gal_le_alternating",
+      "type": "core",
+      "description": "The general discriminant–square criterion: for a finite Galois extension E/F whose Galois group permutes a family r of distinct elements (2 ≠ 0 in E), the discriminant disc = (∏_{i<j}(rⱼ − rᵢ))² is a square in the base field F if and only if every automorphism of E over F acts on r by an even permutation — i.e. Gal(f) ⊆ Aₙ. Assembled from the sign transformation and Galois descent, 0 sorry / 0 axiom."
+    },
+    {
+      "name": "exists_odd_of_disc_not_square",
+      "type": "core",
+      "description": "The form the parent entry needs: if the discriminant δ² is not a square in the base field, some automorphism of E over F acts on the roots by an odd permutation. This discharges the odd-permutation hypothesis of the parent's assembler gal_eq_top_of_transitive_threeCycle_odd directly from a non-square discriminant."
+    },
+    {
+      "name": "diffProd_comp_perm",
+      "type": "proved",
+      "description": "The sign transformation of the difference product: diffProd(r∘σ) = sign(σ) • diffProd r for an arbitrary permutation σ of an arbitrary family over a commutative ring. Proved from Matrix.det_permute via vandermonde(r∘σ) = (vandermonde r).submatrix σ id. Fills a Mathlib v4.26.0 gap."
+    },
+    {
+      "name": "algEquiv_fixes_diffProd_iff_sign_one",
+      "type": "proved",
+      "description": "For distinct r in a field with 2 ≠ 0, a Galois automorphism fixes the difference product δ if and only if the permutation it induces on r is even (sign = 1). The characteristic hypothesis enters exactly here: sign = −1 gives −δ = δ, hence 2δ = 0, contradicting δ ≠ 0."
+    },
+    {
+      "name": "algEquiv_diffProd",
+      "type": "proved",
+      "description": "A Galois automorphism φ permuting r by σ sends δ = diffProd r to diffProd(r∘σ), because φ is a ring homomorphism and commutes with the determinant (AlgEquiv.map_det)."
+    },
+    {
+      "name": "diffProd_eq_prod",
+      "type": "proved",
+      "description": "The difference product realized as a Vandermonde determinant equals the classical form ∏_{i<j}(rⱼ − rᵢ) (Matrix.det_vandermonde)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry gives a general, axiom-free formalization of the classical discriminant criterion: for a finite Galois extension E/F whose Galois group permutes a family of distinct roots, the discriminant is a square in the base field exactly when the Galois group lies in the alternating group. The heart is the sign transformation of the Vandermonde difference product (diffProd_comp_perm, a Mathlib gap filled here) combined with Galois descent (IsGalois.mem_range_algebraMap_iff_fixed). The corollary exists_odd_of_disc_not_square packages the result precisely as the parent entry abel-ruffini-oq-07-discriminant requires, converting its odd-permutation hypothesis into a consequence of a non-square discriminant.",
+    "implications": "1. Discharges an open question: the parent entry left 'disc not a square ⟹ Gal contains an odd permutation' as a hypothesis; this entry proves it in full generality (any finite Galois extension, any degree), so a future revision of the parent can consume exists_odd_of_disc_not_square directly.\n\n2. Reusable infrastructure: diffProd and its sign transformation diffProd_comp_perm are stated over an arbitrary commutative ring and are independent of the Galois application — a clean building block for any polynomial-discriminant formalization.\n\n3. Isolates the one field-theoretic input: the only genuinely Galois-theoretic step is Galois descent, already in Mathlib; everything else is linear algebra and permutation combinatorics.\n\n4. Honest scope: the criterion is stated for a Galois group already presented as permuting a distinguished family r (the standard root setup); connecting r to the actual root multiset of a specific polynomial, and to Mathlib's Polynomial.Gal.galActionHom, remains the natural next step.",
+    "openQuestions": [
+      "Instantiate disc_isSquare_iff_gal_le_alternating with Mathlib's Polynomial.Gal and galActionHom, taking r to be the roots of a separable polynomial in its splitting field, so the hypothesis hperm becomes a theorem rather than an assumption.",
+      "Connect diffProd r ^ 2 to a Mathlib polynomial discriminant (e.g. via the resultant of f and f′), turning 'disc is a square in F' into a statement about the coefficients of f.",
+      "Extend the criterion to characteristic 2 using the Berlekamp/Artin–Schreier discriminant, where the naive square criterion fails.",
+      "Combine with a Dedekind–Frobenius cycle-type bridge to give a fully unconditional determination of the Galois group of X⁵ − X − 1 as S₅."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-07-discriminant",
+      "relationship": "answers",
+      "description": "The parent entry's assembler gal_eq_top_of_transitive_threeCycle_odd takes 'Gal contains an odd permutation' as a hypothesis and notes the bridge 'disc square ⟺ Gal ⊆ Aₙ' is absent from Mathlib. This entry formalizes exactly that bridge (disc_isSquare_iff_gal_le_alternating) and packages the odd-permutation direction (exists_odd_of_disc_not_square) the parent consumes, answering its first open question."
+    },
+    {
+      "targetId": "abel-ruffini-oq-07",
+      "relationship": "complementary",
+      "description": "The sibling transposition-route entry obtains a specific swap from the Frobenius element. The discriminant criterion formalized here supplies any odd permutation from a non-square discriminant, matching the more robust discriminant route."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "extends",
+      "description": "Provides the general Galois-theoretic tool (Gal ⊆ Aₙ ⟺ disc a square) underlying the identification of the Galois group of concrete Abel–Ruffini witness quintics."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.LinearAlgebra.Vandermonde",
+      "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",
+      "Mathlib.FieldTheory.Galois.Basic",
+      "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix",
+      "Equiv",
+      "Equiv.Perm"
+    ],
+    "namespace": "AbelRuffiniDiscriminantSquare",
+    "lineCount": 207,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/AbelRuffiniOQ07DiscriminantOQ01.lean"
+  },
+  "references": [
+    {
+      "key": "DummitFoote",
+      "citation": "Dummit, D. S. and Foote, R. M., Abstract Algebra (3rd ed.), Wiley (2004). §14.6: the discriminant and the criterion Gal ⊆ Aₙ ⟺ disc is a square.",
+      "type": "book"
+    },
+    {
+      "key": "Cox",
+      "citation": "Cox, D. A., Galois Theory (2nd ed.), Wiley (2012). Discriminant criterion and Galois groups of low-degree polynomials.",
+      "type": "book"
+    },
+    {
+      "key": "Lang",
+      "citation": "Lang, S., Algebra (3rd ed.), Springer (2002). Chapter VI: discriminants, the difference product, and its transformation under the Galois group.",
+      "type": "book"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes the classical **discriminant–square criterion** for the Galois group of a separable polynomial, in full generality:

> For a finite Galois extension `E/F` whose Galois group permutes a family `r : Fin n → E` of distinct roots, the discriminant `disc = δ²` (where `δ = ∏_{i<j}(rⱼ − rᵢ)` is the Vandermonde difference product) is a **square in the base field `F`** if and only if **every automorphism acts on `r` by an even permutation** — i.e. `Gal(f) ⊆ Aₙ`.

This is a new gallery entry `abel-ruffini-oq-07-discriminant-oq-01`, answering **OQ-01** of the parent `abel-ruffini-oq-07-discriminant`, which left the bridge *"disc not a square ⟹ Gal contains an odd permutation"* as an explicit hypothesis because Mathlib v4.26.0 has neither the polynomial difference product `∏(rⱼ−rᵢ)²` nor this criterion.

## Mathematical content

The proof rests on two facts:

1. **Sign transformation** — `φ(δ) = sign(σ)·δ`, the antisymmetry of the Vandermonde determinant. Derived cleanly from `Matrix.det_permute` via `vandermonde (r∘σ) = (vandermonde r).submatrix σ id`. This is a genuine **Mathlib gap** filled here (`diffProd_comp_perm`, stated over any commutative ring).
2. **Galois descent** — `δ ∈ F ⟺ δ` is fixed by the whole Galois group (`IsGalois.mem_range_algebraMap_iff_fixed`).

Chaining these with `disc = δ²`, `δ ≠ 0` (distinct roots), and `2 ≠ 0` gives the criterion.

## Theorems (0 sorry, 0 axiom)

- `diffProd_comp_perm` — sign transformation of the difference product
- `algEquiv_diffProd` — a Galois automorphism sends `δ` to the permuted `δ`
- `algEquiv_fixes_diffProd_iff_sign_one` — `φ` fixes `δ` ⟺ its permutation is even
- `disc_isSquare_iff_gal_le_alternating` — **the criterion**
- `exists_odd_of_disc_not_square` — the parent-facing corollary (non-square disc ⟹ odd permutation)

## Verification

- Built with `./proofs/scripts/docker-build.sh Proofs.AbelRuffiniOQ07DiscriminantOQ01` ✓
- `#print axioms` on the main theorems: only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`) → **0 axioms**
- 207 lines, 8 theorems, 1 definition, 0 sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)