### PR TITLE
Enrich Interval/Vector Tietze (Urysohn OQ-01): per-theorem annotations

### DIFF
--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -24,51 +24,121 @@
     ]
   },
   {
-    "id": "ann-interval-constrained",
+    "id": "ann-interval-icc",
     "proofId": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
     "range": {
       "startLine": 56,
-      "endLine": 104
+      "endLine": 97
     },
     "type": "theorem",
-    "title": "Tietze into an Arbitrary Closed Interval",
-    "content": "`tietze_extension_Icc` is the classical order form of the Tietze extension theorem: a continuous `f : s → [a,b]` on a closed set `s` of a normal space extends to a continuous `G : X → [a,b]` with the same, possibly asymmetric, two-sided bound `a ≤ G y ≤ b`. The parent series only supplied the symmetric bound `|G| ≤ M`; the asymmetric interval is reached by conjugating with an affine shift. Setting `c = (a+b)/2` and `r = (b−a)/2 ≥ 0`, the recentred data `f' = f − c` satisfies `|f' x| ≤ r` (by `abs_le` and `linarith` from `a ≤ f x ≤ b`), so the parent's `tietze_extension_via_tsum` applied to `f'` with `M = r` returns `G'` with `G' = f'` on `s` and `|G' y| ≤ r`. The extension `G := G'.toContinuousMap + const c` then restricts to `f` on `s` (since `G' x + c = (f x − c) + c`) and lands in `[c−r, c+r] = [a, b]` everywhere, again by `linarith`. `tietze_extension_unitInterval` is the `a=0, b=1` instance, the shape used to build partitions of unity. No new analytic content is needed — only that the parent construction is equivariant under constant shifts, because adding a constant is a sup-norm isometry.",
-    "mathContext": "$a \\le f \\le b \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ a \\le G \\le b,\\qquad c=\\tfrac{a+b}2,\\ r=\\tfrac{b-a}2.$",
+    "title": "tietze_extension_Icc — the Order Form via Affine Recentring",
+    "content": "`tietze_extension_Icc` is the classical *order* form of the Tietze extension theorem: a continuous `f : s → [a,b]` on a closed set `s` of a normal space extends to a continuous `G : X → [a,b]` retaining the same, possibly asymmetric, two-sided bound `a ≤ G y ≤ b`. The parent series only supplied the *symmetric* bound `|G| ≤ M`, so the interval is reached by conjugating the parent construction with an affine shift. The proof sets `c = (a+b)/2` (the midpoint) and `r = (b−a)/2 ≥ 0` (the radius), forms the recentred data `f' = f − c`, and derives `|f' x| ≤ r` from the membership `a ≤ f x ≤ b` using `abs_le` and `linarith`. Feeding `f'` and `M = r` to the parent's `tietze_extension_via_tsum` returns `G'` with `G' = f'` on `s` and `|G' y| ≤ r`. The final extension `G := G'.toContinuousMap + const c` restricts to `f` on `s` because `G' x + c = (f x − c) + c = f x`, and lands in `[c−r, c+r] = [a, b]` everywhere — the two `linarith` calls at the end discharge the lower and upper bounds from `|G' y| ≤ r`. The only structural fact used is that adding a constant is a sup-norm isometry, so the parent construction is equivariant under constant shifts.",
+    "mathContext": "$a \\le f \\le b \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ a \\le G \\le b,\\qquad c=\\tfrac{a+b}2,\\ r=\\tfrac{b-a}2,\\ G = G' + c.$",
     "significance": "key",
     "relatedConcepts": [
       "order form of the Tietze extension theorem",
       "affine recentring of an interval",
-      "partitions of unity",
-      "constant-shift isometry of the sup-norm"
+      "constant-shift isometry of the sup-norm",
+      "abs_le / linarith bound extraction"
     ],
     "prerequisites": [
       "tietze_extension_via_tsum",
       "abs_le",
-      "ContinuousMap.const"
+      "ContinuousMap.const",
+      "BoundedContinuousFunction.toContinuousMap"
     ]
   },
   {
-    "id": "ann-vector-valued",
+    "id": "ann-unit-interval",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "tietze_extension_unitInterval — the [0,1] Specialisation",
+    "content": "`tietze_extension_unitInterval` is the `a = 0, b = 1` instance of `tietze_extension_Icc`, proved in a single line: `tietze_extension_Icc hs f (by norm_num) hf`, where `norm_num` discharges `0 ≤ 1`. This `[0,1]`-valued form is the workhorse behind *partitions of unity*: given a locally finite cover, one extends each bump function from a closed piece to a continuous `[0,1]`-valued function on the whole space, then normalises the sum to `1`. Isolating it as a named lemma makes the downstream partition-of-unity construction read directly, and records that the gallery's hand-built Urysohn series — not Mathlib's `TietzeExtension` — is sufficient for this canonical application.",
+    "mathContext": "$0 \\le f \\le 1 \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ 0 \\le G \\le 1.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "unit interval [0,1]",
+      "partitions of unity",
+      "bump functions",
+      "specialisation of a general lemma"
+    ],
+    "prerequisites": [
+      "tietze_extension_Icc"
+    ]
+  },
+  {
+    "id": "ann-pi-sup",
     "proofId": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
     "range": {
       "startLine": 106,
-      "endLine": 160
+      "endLine": 127
     },
     "type": "theorem",
-    "title": "Finite-Dimensional Vector-Valued Tietze with Preserved ℓ∞ Bound",
-    "content": "`tietze_extension_pi_sup` extends finite-dimensional vector data `f : s → (ι → ℝ)` (`ι` finite) by running the parent series on each scalar component `x ↦ f x i` against the COMMON bound `M`. Because every component obeys `|f x i| ≤ M`, each component extension `Gi` obeys `|Gi y| ≤ M`, and the assembled map `y ↦ (i ↦ Gi y)` — continuous by `continuous_pi` — preserves the joint componentwise bound `|G y i| ≤ M` while restricting to `f` on `s` (`funext`). `tietze_extension_pi_norm` repackages this with the genuine `ℓ∞` norm on the finite-dimensional Banach space `ι → ℝ`: `pi_norm_le_iff_of_nonneg` identifies `‖x‖ ≤ M` with `∀ i, ‖x i‖ ≤ M`, so the componentwise bound becomes `‖G y‖ ≤ M`. `tietze_extension_pi_norm_sharp` records that `G` extends `f` and shares every uniform `ℓ∞` bound, so specialising to the least bound `M = ‖f‖` gives the norm-preserving equality `‖G‖ = ‖f‖` on finite-dimensional codomains — the vector analogue of the parent's sharp scalar result. Using a common bound (rather than each component's own sup) is exactly what keeps the assembled extension inside the `ℓ∞` ball of radius `M`; this is the finite-dimensional shadow of a vector Urysohn step.",
-    "mathContext": "$\\|f x\\|_\\infty \\le M \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ \\forall y,\\ \\|G y\\|_\\infty = \\max_i |G y\\,i| \\le M.$",
+    "title": "tietze_extension_pi_sup — Componentwise Extension Against a Common Bound",
+    "content": "`tietze_extension_pi_sup` extends finite-dimensional vector data `f : s → (ι → ℝ)` (`ι` a `Fintype`) with the *joint componentwise* bound `|f x i| ≤ M` preserved. The proof runs the parent series on each scalar component separately: for each `i : ι` it builds `fi : C(s, ℝ) := ⟨fun x => f x i, (continuous_apply i).comp f.continuous⟩` (continuous because projection `continuous_apply i` composes with `f.continuous`), notes `|fi x| ≤ M` from the hypothesis, and applies `tietze_extension_via_tsum` with the **common** bound `M` to obtain a component extension `Gi` with `|Gi y| ≤ M`. `choose` collects these into functions `Gi, hext, hbd` indexed by `i`, and `continuous_pi fun i => (Gi i).continuous` assembles the map `y ↦ (i ↦ Gi i y)` into a single `C(X, ι → ℝ)`. Restriction to `f` on `s` is `funext` over `i`, and the componentwise bound is immediate. The crux is the shared `M`: extending each component against its own sup would only give `|G y i| ≤ Mᵢ`, but a common `M` keeps the whole vector inside the `ℓ∞` ball of radius `M`.",
+    "mathContext": "$(\\forall x\\,i,\\ |f x\\,i| \\le M) \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ \\forall y\\,i,\\ |G y\\,i| \\le M.$",
     "significance": "key",
     "relatedConcepts": [
-      "vector-valued Tietze extension",
-      "ℓ∞ norm on a finite product",
       "componentwise extension against a common bound",
-      "finite-dimensional Banach codomain"
+      "continuous_apply / continuous_pi",
+      "choose (axiom of choice over a Fintype)",
+      "finite-dimensional shadow of a vector Urysohn step"
     ],
     "prerequisites": [
       "tietze_extension_via_tsum",
+      "continuous_pi",
+      "continuous_apply",
+      "Classical.choose"
+    ]
+  },
+  {
+    "id": "ann-pi-norm",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 129,
+      "endLine": 147
+    },
+    "type": "theorem",
+    "title": "tietze_extension_pi_norm — Packaging with the Genuine ℓ∞ Norm",
+    "content": "`tietze_extension_pi_norm` repackages `tietze_extension_pi_sup` in terms of the actual sup-norm on the finite-dimensional Banach space `ι → ℝ`. The bridge is `pi_norm_le_iff_of_nonneg`, which for `0 ≤ M` and `Fintype ι` states `‖x‖ ≤ M ↔ ∀ i, ‖x i‖ ≤ M`, together with `Real.norm_eq_abs` turning `‖x i‖` into `|x i|`. Forward: the hypothesis `‖f x‖ ≤ M` yields the componentwise `|f x i| ≤ M` needed to invoke `tietze_extension_pi_sup`. Backward: the resulting componentwise bound `|G y i| ≤ M` is repackaged into `‖G y‖ ≤ M` via the same iff. The theorem carries no new analytic content — it is purely the `ℓ∞`-norm-versus-componentwise dictionary — but it is what lets the vector Tietze statement be phrased in the natural normed-space language `‖G y‖ ≤ M`, matching the parent's scalar `‖G‖ ≤ M`.",
+    "mathContext": "$\\|f x\\|_\\infty \\le M \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ \\forall y,\\ \\|G y\\|_\\infty \\le M,\\qquad \\|x\\|_\\infty = \\max_i |x i|.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "ℓ∞ / sup-norm on a finite product",
       "pi_norm_le_iff_of_nonneg",
-      "continuous_pi"
+      "Real.norm_eq_abs",
+      "finite-dimensional Banach codomain ι → ℝ"
+    ],
+    "prerequisites": [
+      "tietze_extension_pi_sup",
+      "pi_norm_le_iff_of_nonneg",
+      "Real.norm_eq_abs"
+    ]
+  },
+  {
+    "id": "ann-pi-norm-sharp",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 148,
+      "endLine": 159
+    },
+    "type": "theorem",
+    "title": "tietze_extension_pi_norm_sharp — Norm Preservation on Finite-Dimensional Codomains",
+    "content": "`tietze_extension_pi_norm_sharp` records the sharpness of the vector extension. It restates `tietze_extension_pi_norm` and adds the on-`s` bound `∀ x : s, ‖G (x : X)‖ ≤ M`, obtained trivially from the extension property: `rw [hext x]` rewrites `G (x : X)` to `f x`, and the data bound `hf x` finishes. The point of carrying both `∀ y : X, ‖G y‖ ≤ M` and `∀ x : s, ‖G x‖ ≤ M` is that `G` shares *every* uniform `ℓ∞` bound of `f`. Specialising to the least such bound `M = ‖f‖` therefore forces `‖G‖ = ‖f‖`: the extension can be no larger than the data (upper bound) and agrees with it on `s` (so it is no smaller). This is the vector, finite-dimensional analogue of the parent's sharp scalar equality `‖G‖ = ‖f‖` — the strongest form of the norm-preserving Tietze reachable from the scalar engine.",
+    "mathContext": "$M = \\|f\\| \\ \\Rightarrow\\ \\|G\\| = \\|f\\|;\\qquad G \\text{ shares every uniform } \\ell^\\infty \\text{ bound of } f.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "norm-preserving extension ‖G‖ = ‖f‖",
+      "sharpness via the least bound M = ‖f‖",
+      "sup-norm on a finite-dimensional Banach space",
+      "vector analogue of the parent's sharp scalar result"
+    ],
+    "prerequisites": [
+      "tietze_extension_pi_norm"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `urysohns-lemma-oq-01-oq-01-oq-02-oq-01`.

## What changed
The entry's `meta.json` is already rich (well under the size cap), but its `annotations.json` had only **3 coarse blocks** — two of which lumped multiple theorems together. This refactors it into **6 per-theorem annotations**, giving accurate line-range coverage of the 160-line source:

| Annotation | Range | Result |
|---|---|---|
| ann-setup | 1–55 | imports, parent series, working hypotheses |
| ann-interval-icc | 56–97 | `tietze_extension_Icc` (order form via affine recentring) |
| ann-unit-interval | 98–105 | `tietze_extension_unitInterval` ([0,1] specialisation) |
| ann-pi-sup | 106–127 | `tietze_extension_pi_sup` (componentwise, common bound) |
| ann-pi-norm | 129–147 | `tietze_extension_pi_norm` (ℓ∞ packaging) |
| ann-pi-norm-sharp | 148–159 | `tietze_extension_pi_norm_sharp` (norm preservation) |

Each annotation gains a focused proof-level `content`, sharpened `mathContext`, and tuned `relatedConcepts` / `prerequisites`. No `meta.json` change (already meets quality targets; deepening further would risk the size guardrails).

## Validation
- JSON validated; 6 annotations parse cleanly.
- Line ranges in-bounds (≤160) and non-overlapping/ascending.
- Enum values (`type`, `significance`) within schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)