### PR TITLE
Fix: realign erdos-564 lineCount (207→248)

### DIFF
--- a/src/data/proofs/erdos-564/meta.json
+++ b/src/data/proofs/erdos-564/meta.json
@@ -43,7 +43,7 @@
       "Tower function definitions and properties"
     ],
     "axiomCount": 3,
-    "lineCount": 207,
+    "lineCount": 248,
     "assumptions": "3 axioms: R, erdos_hajnal_rado_upper, erdos_hajnal_rado_lower. 0 sorries (bounds_gap_enormous fully proved as of #31293).",
     "theoremCount": 6,
     "definitionCount": 5
@@ -161,7 +161,7 @@
       "Filter"
     ],
     "namespace": "Erdos564",
-    "lineCount": 207,
+    "lineCount": 248,
     "axiomCount": 3,
     "theoremCount": 6,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

The `erdos-564` gallery `meta.json` reported `lineCount: 207` in both the `leanFile` and `meta` blocks, but `proofs/Proofs/Erdos564Problem.lean` is now 248 lines after merged research growth (#31568, #31329, #31293).

## Evidence

**Before**: `lineCount: 207` (both blocks)
**After**: `lineCount: 248` (matches actual `wc -l`)

Verified via canonical extractor logic (`scripts/research/enrich-research.ts`): theoremCount=6, definitionCount=5, axiomCount=3, sorries=0 all still accurate — only `lineCount` had drifted.

---
Automated fix by lean-mechanic agent.