### PR TITLE
Enrich Cramer's Rule 2×2/3×3 closed forms: column-replacement setup annotation

### DIFF
--- a/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-setup-updatecol",
+    "proofId": "cramers-rule-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 46
+    },
+    "type": "context",
+    "title": "The Column-Replacement Setup Inherited from the Parent",
+    "content": "The file imports `Proofs.CramersRuleOQ04OQ01OQ01`, whose `cramer_solution` supplies the general scalar formula $x_i = \\det(A_i)/\\det A$ over a field with $\\det A \\neq 0$, where $A_i = A.\\mathrm{updateCol}\\ i\\ b$ is $A$ with its $i$-th column overwritten by the right-hand side $b$. The whole entry is the bookkeeping of that column replacement in the small cases: nothing new is assumed, and no fresh determinant theory is developed. `updateCol` replaces a column (acting on the second matrix index), which is why `updateCol_self` fires on the replaced column (returning $b$) and `updateCol_ne` on all others (returning the original $A$ entries). Everything reduces to `cramer_solution` composed with Mathlib's `det_fin_two` / `det_fin_three`.",
+    "mathContext": "$A_i = A.\\mathrm{updateCol}\\ i\\ b$, and $x_i = \\dfrac{\\det(A_i)}{\\det A}$ is the parent's `cramer_solution`; this file expands $\\det(A_i)$ and $\\det A$ for $n = 2, 3$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Matrix.updateCol",
+      "cramer_solution (parent)",
+      "determinant as a ratio",
+      "specialization of a general theorem"
+    ],
+    "prerequisites": [
+      "linear systems Ax = b",
+      "determinant of a matrix",
+      "column replacement"
+    ]
+  },
+  {
     "id": "ann-two-numerator",
     "proofId": "cramers-rule-oq-04-oq-01-oq-01-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `cramers-rule-oq-04-oq-01-oq-01-oq-01`.

## Changes
- **Annotation coverage 4 → 5.** Added an annotation covering the header/setup (lines 4–46): the parent import `cramer_solution` giving `xᵢ = det(Aᵢ)/det A`, the `updateCol` column-replacement mechanism, and the framing that the whole entry is bookkeeping over `det_fin_two`/`det_fin_three`. Previously the setup was the only unannotated region; now the 2×2 numerator, 2×2 closed form, 3×3 Sarrus expansion, and the "why no `ring`" note are all preceded by the context annotation.

## Not changed
- `meta.json` (~11 KB) already meets targets (4 keyInsights, rich historicalContext, sections with `mathContext`, conclusion with 2 open questions) and is well under the size cap.
- `badge: "mathlib"`, `verified`, `axiomCount: 0`, `sorries: 0` accurately reflect the Lean source (specialization of the parent via Mathlib determinant lemmas; no assumptions).

JSON validates; gallery data generation parses clean.