### PR TITLE
Fix: collatz-structured-oq-02-oq-03 leanFile count drift

### DIFF
--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -134,9 +134,9 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1723,
+    "lineCount": 1761,
     "axiomCount": 1,
-    "theoremCount": 59,
+    "theoremCount": 62,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 13


### PR DESCRIPTION
## Fix

Realign the stale `leanFile` count block in `collatz-structured-oq-02-oq-03/meta.json` to match the actual Lean source. The `meta.meta` block was already correct — this is the leanFile-lags-meta drift pattern.

## Evidence

Ground truth on `Proofs/CollatzStructuredOQ02OQ03.lean` (`wc -l` / col-0 grep):
- lines: **1761**, theorems: **62**, definitions: **13**, axioms: **1**, sorries: **0**

**Before** (`leanFile` block): lineCount 1723, theoremCount 59
**After** (`leanFile` block): lineCount 1761, theoremCount 62

`definitionCount` (13), `axiomCount` (1), `sorries` (0) already correct in both blocks; `meta.meta` block already read 1761/62. No status change.

---
Automated fix by lean-mechanic agent.