### PR TITLE
research(sperner-ndim-oq-02): restore pivot/neighbour/boundary machinery lost to stale-base merge [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CramersRuleOQ02OQ01OQ01.lean
+++ b/proofs/Proofs/CramersRuleOQ02OQ01OQ01.lean
@@ -1,0 +1,194 @@
+import Mathlib
+
+/-
+# Splitting the Gaussian-Elimination Multiply Count: divisions vs multiplications (OQ-02-OQ-01-OQ-01)
+
+## Research Question
+
+The parent entry `CramersRuleOQ02OQ01` proves the exact forward-elimination
+multiplication+division count
+
+  `gaussExactOps n = ∑_{j<n} (j² + j) = (n³ − n)/3`
+
+as a *single lumped* quantity, and separately counts the subtractions
+`∑_{j<n} j² ≈ n³/3`. But the lumped `j² + j` per step mixes two different
+arithmetic operations: at the step that clears a column with `j` rows beneath
+the pivot we perform
+
+- `j` **divisions** (one multiplier per row below the pivot), and
+- `j²` **multiplications** (scaling the `j` trailing entries of each of the
+  `j` rows).
+
+Which of the two carries the `n³/3` headline, and how subdominant is the other?
+
+## Answer
+
+Splitting `gaussExactOps n = gaussMults n + gaussDivs n` where
+
+  `gaussMults n = ∑_{j<n} j²`  (multiplications)   and
+  `gaussDivs  n = ∑_{j<n} j`   (divisions),
+
+we prove:
+
+- `gaussMults n` carries the entire cubic term: `6·gaussMults n + 3n² = 2n³ + n`,
+  so `gaussMults n = (2n³ − 3n² + n)/6 ≈ n³/3`, and `6·gaussMults n ≤ 2n³`.
+- `gaussDivs n` is purely **quadratic**: `2·gaussDivs n + n = n²`, i.e.
+  `gaussDivs n = (n² − n)/2 = C(n,2)` — the triangular numbers, `Θ(n²)`.
+- Hence the divisions are asymptotically negligible:
+  `gaussDivs n ≤ gaussMults n` for all `n` (strict for `n ≥ 3`), and the whole
+  `n³/3` of `gaussExactOps` comes from the multiplications.
+
+This refines the "`n³/3` flops" headline: of the `(n³−n)/3` multiply/divide
+operations, the `Θ(n²)` divisions vanish into the lower-order terms and the
+cubic constant `1/3` is entirely a *multiplication* count.
+
+## What is proved here (no axioms, no sorry, no native_decide)
+
+- `gaussMults`, `gaussDivs` and the lumped `gaussOps = gaussMults + gaussDivs`.
+- `gaussOps_split` : `∑_{j<n} (j²+j) = gaussMults n + gaussDivs n`.
+- `gaussDivs_closed` : `2·gaussDivs n + n = n²` (triangular numbers).
+- `gaussDivs_eq_choose` : `gaussDivs n = n.choose 2`.
+- `gaussMults_closed` : `6·gaussMults n + 3n² = 2n³ + n`.
+- `gaussMults_le_third` : `6·gaussMults n ≤ 2n³` (the multiplications alone are `≤ n³/3`).
+- `gaussDivs_le_mults` : `gaussDivs n ≤ gaussMults n` (divisions subdominant);
+  `gaussDivs_lt_mults` strict for `n ≥ 3`.
+- `gaussOps_closed` : `3·gaussOps n + n = n³` (recovers the parent's `(n³−n)/3`).
+
+## Proof techniques
+
+- `Finset.sum_range_succ` for the inductive unfolding of each `∑`.
+- Subtraction-free `calc`/`ring` over the `ℕ` semiring for the closed forms.
+- `omega` to read off bounds from the linear closed-form identities (treating
+  `n²`, `n³` and the sums as opaque non-negative atoms).
+- `Finset.sum_le_sum` with the pointwise `j ≤ j²` for the dominance comparison.
+- `Nat.choose_two_right` to identify the divisions with the binomial `C(n,2)`.
+-/
+
+namespace CramersComplexityOpSplit
+
+open Finset
+
+/-- Exact **multiplication** count of forward elimination: at the step clearing a
+    column with `j` rows beneath the pivot, each of those `j` rows has `j` trailing
+    entries scaled by the multiplier — `j²` multiplications per step, summed over
+    `j < n`. -/
+def gaussMults (n : ℕ) : ℕ := ∑ j ∈ range n, j ^ 2
+
+/-- Exact **division** count of forward elimination: at the step clearing a column
+    with `j` rows beneath the pivot we form one multiplier per row — `j` divisions
+    per step, summed over `j < n`. -/
+def gaussDivs (n : ℕ) : ℕ := ∑ j ∈ range n, j
+
+/-- The lumped multiply/divide count of the parent entry, here exhibited as the
+    sum of its two constituent operations. -/
+def gaussOps (n : ℕ) : ℕ := ∑ j ∈ range n, (j ^ 2 + j)
+
+/-- Unfolding one elimination step for the multiplication count. -/
+lemma gaussMults_succ (n : ℕ) : gaussMults (n + 1) = gaussMults n + n ^ 2 := by
+  unfold gaussMults; rw [Finset.sum_range_succ]
+
+/-- Unfolding one elimination step for the division count. -/
+lemma gaussDivs_succ (n : ℕ) : gaussDivs (n + 1) = gaussDivs n + n := by
+  unfold gaussDivs; rw [Finset.sum_range_succ]
+
+/-- **The split.** The lumped multiply/divide count is exactly multiplications plus
+    divisions: `∑_{j<n} (j²+j) = gaussMults n + gaussDivs n`. -/
+theorem gaussOps_split (n : ℕ) : gaussOps n = gaussMults n + gaussDivs n := by
+  unfold gaussOps gaussMults gaussDivs
+  rw [← Finset.sum_add_distrib]
+
+/-- **Closed form for the divisions (subtraction-free).** `2·gaussDivs n + n = n²`,
+    i.e. `gaussDivs n = (n² − n)/2` — the triangular numbers, a purely `Θ(n²)` count. -/
+theorem gaussDivs_closed (n : ℕ) : 2 * gaussDivs n + n = n ^ 2 := by
+  induction n with
+  | zero => simp [gaussDivs]
+  | succ m ih =>
+    calc 2 * gaussDivs (m + 1) + (m + 1)
+        = (2 * gaussDivs m + m) + (2 * m + 1) := by rw [gaussDivs_succ]; ring
+      _ = m ^ 2 + (2 * m + 1) := by rw [ih]
+      _ = (m + 1) ^ 2 := by ring
+
+/-- The divisions are the binomial `C(n,2)`: `gaussDivs n = n.choose 2`. -/
+theorem gaussDivs_eq_choose (n : ℕ) : gaussDivs n = n.choose 2 := by
+  rw [Nat.choose_two_right]
+  have h : 2 * gaussDivs n = n * (n - 1) := by
+    have hc := gaussDivs_closed n
+    cases n with
+    | zero => simp [gaussDivs]
+    | succ k =>
+      have : (k + 1) ^ 2 = (k + 1) * ((k + 1) - 1) + (k + 1) := by
+        simp [pow_two]; ring
+      omega
+  rw [← h, Nat.mul_div_cancel_left _ (by norm_num : 0 < 2)]
+
+/-- **Closed form for the multiplications (subtraction-free).**
+    `6·gaussMults n + 3n² = 2n³ + n`, i.e. `gaussMults n = (2n³ − 3n² + n)/6 ≈ n³/3`. -/
+theorem gaussMults_closed (n : ℕ) : 6 * gaussMults n + 3 * n ^ 2 = 2 * n ^ 3 + n := by
+  induction n with
+  | zero => simp [gaussMults]
+  | succ m ih =>
+    calc 6 * gaussMults (m + 1) + 3 * (m + 1) ^ 2
+        = (6 * gaussMults m + 3 * m ^ 2) + (6 * m ^ 2 + 6 * m + 3) := by
+          rw [gaussMults_succ]; ring
+      _ = (2 * m ^ 3 + m) + (6 * m ^ 2 + 6 * m + 3) := by rw [ih]
+      _ = 2 * (m + 1) ^ 3 + (m + 1) := by ring
+
+/-- **The multiplications alone are `≤ n³/3`.** `6·gaussMults n ≤ 2n³`, the cubic-term
+    bound; together with `gaussMults_closed` it pins the leading constant of the
+    multiplication count at exactly `1/3`. -/
+theorem gaussMults_le_third (n : ℕ) : 6 * gaussMults n ≤ 2 * n ^ 3 := by
+  induction n with
+  | zero => simp [gaussMults]
+  | succ m ih =>
+    rw [gaussMults_succ]
+    nlinarith [ih]
+
+/-- **Divisions are subdominant.** `gaussDivs n ≤ gaussMults n` for every `n`,
+    since `j ≤ j²` term by term. -/
+theorem gaussDivs_le_mults (n : ℕ) : gaussDivs n ≤ gaussMults n := by
+  unfold gaussDivs gaussMults
+  apply Finset.sum_le_sum
+  intro j _
+  nlinarith [Nat.zero_le j]
+
+/-- The dominance is **strict** for `n ≥ 3`: by then the `j = 2` term already gives
+    `2 < 4`, so the multiplications strictly exceed the divisions. -/
+theorem gaussDivs_lt_mults {n : ℕ} (hn : 3 ≤ n) : gaussDivs n < gaussMults n := by
+  have hd := gaussDivs_closed n
+  have hm := gaussMults_closed n
+  nlinarith [hd, hm, hn]
+
+/-- **Recovers the parent's lumped closed form.** `3·gaussOps n + n = n³`, hence
+    `gaussOps n = (n³ − n)/3`, now seen as the sum of a cubic multiplication count
+    and a quadratic division count. -/
+theorem gaussOps_closed (n : ℕ) : 3 * gaussOps n + n = n ^ 3 := by
+  rw [gaussOps_split]
+  have hd := gaussDivs_closed n
+  have hm := gaussMults_closed n
+  nlinarith [hd, hm]
+
+/-- Concrete split counts (sanity check against the hand computation):
+    multiplications `n=2↦1, n=3↦5, n=4↦14, n=5↦30`;
+    divisions       `n=2↦1, n=3↦3, n=4↦6,  n=5↦10` (triangular). -/
+lemma split_small :
+    gaussMults 2 = 1 ∧ gaussMults 3 = 5 ∧ gaussMults 4 = 14 ∧ gaussMults 5 = 30 ∧
+    gaussDivs 2 = 1 ∧ gaussDivs 3 = 3 ∧ gaussDivs 4 = 6 ∧ gaussDivs 5 = 10 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    simp [gaussMults, gaussDivs, Finset.sum_range_succ]
+
+/-- Summary: the multiply/divide count splits into a cubic multiplication count and a
+    quadratic (triangular) division count; the multiplications carry the entire
+    `n³/3`, the divisions are `C(n,2) = Θ(n²)` and subdominant, and their sum recovers
+    the parent's `(n³ − n)/3`. -/
+theorem op_split_summary :
+    (∀ n : ℕ, gaussOps n = gaussMults n + gaussDivs n) ∧
+    (∀ n : ℕ, 2 * gaussDivs n + n = n ^ 2) ∧
+    (∀ n : ℕ, gaussDivs n = n.choose 2) ∧
+    (∀ n : ℕ, 6 * gaussMults n + 3 * n ^ 2 = 2 * n ^ 3 + n) ∧
+    (∀ n : ℕ, 6 * gaussMults n ≤ 2 * n ^ 3) ∧
+    (∀ n : ℕ, gaussDivs n ≤ gaussMults n) ∧
+    (∀ n : ℕ, 3 * gaussOps n + n = n ^ 3) :=
+  ⟨gaussOps_split, gaussDivs_closed, gaussDivs_eq_choose, gaussMults_closed,
+   gaussMults_le_third, gaussDivs_le_mults, gaussOps_closed⟩
+
+end CramersComplexityOpSplit

--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -24,6 +24,28 @@ bridge of "Option C" for `sperner-ndim-oq-02`: it lets the complete (0-sorry)
 `SpernerNDim` framework be reused over `BaryPoint` without re-deriving it. See
 `research/problems/sperner-ndim-oq-02/` for the full plan.
 
+On top of the coordinate bridge this file also carries the Phase-1
+`SpernerTriangulation`-instance machinery for the Freudenthal grid:
+
+* the `CanonSimplex` carrier (canonical-orientation cells) with its facet
+  algebra (`facet`, `baryFacet`, `facet_eq_iff_baryFacet_eq`,
+  `canon_eq_of_facet_and_vertex`);
+* the barycentric boundary/interior analysis
+  (`boundary_face_iff_coords_zero`, `coord_incDir_eq_zero_iff`,
+  `miss_coord_eq_zero_iff`, `IsInteriorFacet`/`IsBoundaryFacet`,
+  `isInteriorFacet_iff`); and
+* the within-chain pivot and neighbour data (`pivotSimplex`,
+  `pivot_involutive`, `GridGlued`, `gridNeighbor`, `gridNeighbor_spec`,
+  `exists_neighbor_of_isInteriorFacet`).
+
+**Regression-recovery note (2026-06-30).** The pivot/neighbour/boundary
+machinery listed above (≈1300 lines, ~70 declarations, all previously
+verified 0-axiom in #31443/#31495) was inadvertently clobbered when the
+older barycentric-facet-algebra branch #30947 was squash-merged from a
+stale base, dropping the file from 1772 back to 464 lines. This revision
+restores the lost declarations and re-integrates them with the newer
+barycentric-facet section, so both live in one compiling file again.
+
 No new axioms or sorries are introduced.
 -/
 
@@ -357,6 +379,1417 @@ theorem canon_eq_of_facet_and_vertex {s t : CanonSimplex d N}
     image_univ_eq_insert_facet s k, image_univ_eq_insert_facet t l,
     hface, hvert]
 
+/-- **Global facet/opposite-vertex coherence.**  The pair `(facet s k, vertices s k)` — a
+facet of a canonical cell together with its opposite (deleted) vertex — identifies both the
+cell `s` and the index `k` uniquely across the *entire* carrier.  This packages the two
+halves of the facet section into the single injectivity fact the door-counting adjacency
+reasons with: the cross-cell direction `canon_eq_of_facet_and_vertex` collapses the cell
+(`s = t`), then the within-cell direction `facet_injective` collapses the index (`k = l`).
+The consequence is that the `(facet, opposite-vertex)` payload an `adj` entry stores can
+name at most one `(cell, facet)` slot — there is no orientation or gluing ambiguity. -/
+theorem facet_vertex_injective :
+    Function.Injective
+      (fun p : CanonSimplex d N × Fin (d + 1) => (facet p.1 p.2, vertices p.1 p.2)) := by
+  rintro ⟨s, k⟩ ⟨t, l⟩ h
+  simp only [Prod.mk.injEq] at h
+  obtain ⟨hface, hvert⟩ := h
+  obtain rfl : s = t := canon_eq_of_facet_and_vertex hface hvert
+  obtain rfl : k = l := facet_injective s hface
+  rfl
+
+-- ============================================================
+-- SECTION: Interior Freudenthal pivot (neighbour existence)
+-- ============================================================
+-- The search-based `adj` reads off, for each facet of a canonical
+-- cell, the unique *other* canonical cell glued across it (or
+-- `none` on the geometric boundary).  Its `boundary_face` field is
+-- the contrapositive obligation: an *interior* facet must actually
+-- have a neighbour.  This section supplies the geometric heart of
+-- that existence for the chain-interior facets — the **Freudenthal
+-- pivot**: deleting an interior vertex `a.succ` of a Kuhn cell, the
+-- neighbour glued across the remaining `d`-vertex facet is obtained
+-- by swapping the two consecutive increment steps `a` and `b`
+-- (`b.castSucc = a.succ`).  Only the pivoted vertex changes; it
+-- moves along the "other diagonal" of the local square
+-- `verts a.castSucc → verts a.succ → verts b.succ`.
+--
+-- We build that neighbour as an honest `GridSimplex`
+-- (`pivotSimplex`, all five Kuhn axioms discharged), and prove it
+-- (i) keeps the deleted-vertex facet fixed (`pivot_facet_eq`) and
+-- (ii) genuinely moves the opposite vertex (`pivot_opposite_ne`),
+-- hence is a *different* cell (`pivot_ne`).  This is the
+-- `GridSimplex`-level existence statement; canonicalising the
+-- pivot (re-selecting the lex-min base) to land it back in
+-- `CanonSimplex`, and the two boundary-chain pivots `a.succ ∈ {0,d}`,
+-- remain for the full `adj`.  Everything here is 0-sorry, 0-axiom.
+
+open SpernerGrid
+
+/-- A `Fin` index never equals the successor it casts up to: `x.castSucc ≠ x.succ`. -/
+theorem Fin_castSucc_ne_succ {d : ℕ} (x : Fin d) : x.castSucc ≠ x.succ := by
+  intro h
+  have hv := congrArg Fin.val h
+  simp only [Fin.coe_castSucc, Fin.val_succ] at hv
+  omega
+
+/-- Two consecutive Kuhn steps are distinct: if `a.succ = b.castSucc`
+then `a ≠ b` (else `a.succ = a.castSucc`, impossible). -/
+theorem pivot_ab_ne {a b : Fin d} (hb : a.succ = b.castSucc) : a ≠ b := by
+  rintro rfl
+  exact absurd hb.symm (Fin_castSucc_ne_succ a)
+
+/-- The **pivoted vertex**.  Relative to the deleted vertex
+`s.verts a.succ`, it decrements the coordinate raised at step `a`
+(`incDir a`) and increments the coordinate raised at step `b`
+(`incDir b`) — i.e. it is `verts a.castSucc + e_{incDir b} - e_miss`,
+the opposite corner of the local square.  The total mass is
+preserved (`incDir a` falls by 1, `incDir b` rises by 1), and the
+`incDir a` coordinate is `≥ 1` (step `a` raised it), so the nat
+subtraction is exact. -/
+def pivotPoint (s : SpernerGrid.GridSimplex d N) (a b : Fin d) (hab : a ≠ b) :
+    SpernerGrid.BaryPoint d N where
+  coords := fun j =>
+    if j = s.incDir a then (s.verts a.succ).coords j - 1
+    else if j = s.incDir b then (s.verts a.succ).coords j + 1
+    else (s.verts a.succ).coords j
+  sum_eq := by
+    have hpos : 1 ≤ (s.verts a.succ).coords (s.incDir a) := by
+      have := s.step_inc a; omega
+    have hne : s.incDir a ≠ s.incDir b := fun h => hab (s.inc_injective h)
+    -- Move-one-unit identity: "+[=incDir a]" on the pivot balances "+[=incDir b]" on the original.
+    have key : ∀ j : Fin (d + 1),
+        (if j = s.incDir a then (s.verts a.succ).coords j - 1
+          else if j = s.incDir b then (s.verts a.succ).coords j + 1
+          else (s.verts a.succ).coords j)
+        + (if j = s.incDir a then 1 else 0)
+        = (s.verts a.succ).coords j + (if j = s.incDir b then 1 else 0) := by
+      intro j
+      by_cases h1 : j = s.incDir a
+      · subst h1
+        rw [if_pos rfl, if_pos rfl, if_neg hne]
+        omega
+      · by_cases h2 : j = s.incDir b
+        · subst h2
+          rw [if_neg h1, if_pos rfl, if_neg h1, if_pos rfl]
+        · rw [if_neg h1, if_neg h2, if_neg h1, if_neg h2]
+    have hone_a : (∑ j : Fin (d + 1), (if j = s.incDir a then (1 : ℕ) else 0)) = 1 := by simp
+    have hone_b : (∑ j : Fin (d + 1), (if j = s.incDir b then (1 : ℕ) else 0)) = 1 := by simp
+    have hsum :
+        (∑ j : Fin (d + 1),
+            (if j = s.incDir a then (s.verts a.succ).coords j - 1
+              else if j = s.incDir b then (s.verts a.succ).coords j + 1
+              else (s.verts a.succ).coords j)) + 1
+          = (∑ j : Fin (d + 1), (s.verts a.succ).coords j) + 1 := by
+      calc
+        (∑ j : Fin (d + 1),
+            (if j = s.incDir a then (s.verts a.succ).coords j - 1
+              else if j = s.incDir b then (s.verts a.succ).coords j + 1
+              else (s.verts a.succ).coords j)) + 1
+            = (∑ j : Fin (d + 1),
+                (if j = s.incDir a then (s.verts a.succ).coords j - 1
+                  else if j = s.incDir b then (s.verts a.succ).coords j + 1
+                  else (s.verts a.succ).coords j))
+              + (∑ j : Fin (d + 1), (if j = s.incDir a then (1 : ℕ) else 0)) := by rw [hone_a]
+          _ = ∑ j : Fin (d + 1),
+                ((if j = s.incDir a then (s.verts a.succ).coords j - 1
+                    else if j = s.incDir b then (s.verts a.succ).coords j + 1
+                    else (s.verts a.succ).coords j)
+                  + (if j = s.incDir a then (1 : ℕ) else 0)) := by rw [Finset.sum_add_distrib]
+          _ = ∑ j : Fin (d + 1),
+                ((s.verts a.succ).coords j + (if j = s.incDir b then (1 : ℕ) else 0)) :=
+                Finset.sum_congr rfl (fun j _ => key j)
+          _ = (∑ j : Fin (d + 1), (s.verts a.succ).coords j)
+                + (∑ j : Fin (d + 1), (if j = s.incDir b then (1 : ℕ) else 0)) := by
+                rw [Finset.sum_add_distrib]
+          _ = (∑ j : Fin (d + 1), (s.verts a.succ).coords j) + 1 := by rw [hone_b]
+    rw [(s.verts a.succ).sum_eq] at hsum
+    omega
+
+theorem pivotPoint_coords_eq_incA (s : SpernerGrid.GridSimplex d N)
+    (a b : Fin d) (hab : a ≠ b) :
+    (pivotPoint s a b hab).coords (s.incDir a)
+      = (s.verts a.succ).coords (s.incDir a) - 1 := by
+  have h : (pivotPoint s a b hab).coords (s.incDir a)
+      = if s.incDir a = s.incDir a then (s.verts a.succ).coords (s.incDir a) - 1
+        else if s.incDir a = s.incDir b then (s.verts a.succ).coords (s.incDir a) + 1
+        else (s.verts a.succ).coords (s.incDir a) := rfl
+  rw [h, if_pos rfl]
+
+theorem pivotPoint_coords_eq_incB (s : SpernerGrid.GridSimplex d N)
+    (a b : Fin d) (hab : a ≠ b) :
+    (pivotPoint s a b hab).coords (s.incDir b)
+      = (s.verts a.succ).coords (s.incDir b) + 1 := by
+  have hne : s.incDir b ≠ s.incDir a := fun h => hab (s.inc_injective h).symm
+  have h : (pivotPoint s a b hab).coords (s.incDir b)
+      = if s.incDir b = s.incDir a then (s.verts a.succ).coords (s.incDir b) - 1
+        else if s.incDir b = s.incDir b then (s.verts a.succ).coords (s.incDir b) + 1
+        else (s.verts a.succ).coords (s.incDir b) := rfl
+  rw [h, if_neg hne, if_pos rfl]
+
+theorem pivotPoint_coords_eq_other (s : SpernerGrid.GridSimplex d N)
+    (a b : Fin d) (hab : a ≠ b) (j : Fin (d + 1))
+    (hja : j ≠ s.incDir a) (hjb : j ≠ s.incDir b) :
+    (pivotPoint s a b hab).coords j = (s.verts a.succ).coords j := by
+  have h : (pivotPoint s a b hab).coords j
+      = if j = s.incDir a then (s.verts a.succ).coords j - 1
+        else if j = s.incDir b then (s.verts a.succ).coords j + 1
+        else (s.verts a.succ).coords j := rfl
+  rw [h, if_neg hja, if_neg hjb]
+
+/-- The **interior Freudenthal pivot**.  For consecutive steps `a`, `b`
+(`a.succ = b.castSucc`), the neighbour of `s` glued across the facet
+opposite vertex `a.succ`: same base/`miss`, the two increment steps
+`a`, `b` swapped (`incDir ∘ swap a b`), and the single vertex `a.succ`
+replaced by `pivotPoint`.  All five Kuhn axioms are discharged: the
+`miss` coordinate is untouched everywhere (so `step_dec` is inherited);
+the only steps whose endpoints move are `a` and `b`, handled by the
+local-square computation. -/
+def pivotSimplex (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) : SpernerGrid.GridSimplex d N where
+  verts := Function.update s.verts a.succ (pivotPoint s a b (pivot_ab_ne hb))
+  incDir := s.incDir ∘ Equiv.swap a b
+  miss := s.miss
+  miss_ne_inc := fun k => s.miss_ne_inc (Equiv.swap a b k)
+  inc_injective := s.inc_injective.comp (Equiv.swap a b).injective
+  step_dec := by
+    have hab : a ≠ b := pivot_ab_ne hb
+    -- The `miss` coordinate is unchanged at every vertex.
+    have hconst : ∀ v : Fin (d + 1),
+        (Function.update s.verts a.succ (pivotPoint s a b hab) v).coords s.miss
+          = (s.verts v).coords s.miss := by
+      intro v
+      by_cases hv : v = a.succ
+      · subst hv
+        rw [Function.update_self]
+        exact pivotPoint_coords_eq_other s a b hab s.miss
+          (fun h => s.miss_ne_inc a h.symm) (fun h => s.miss_ne_inc b h.symm)
+      · rw [Function.update_of_ne hv]
+    intro k
+    rw [hconst, hconst]
+    exact s.step_dec k
+  step_inc := by
+    have hab : a ≠ b := pivot_ab_ne hb
+    intro k
+    by_cases hka : k = a
+    · rw [hka]
+      have hIa : (s.incDir ∘ ⇑(Equiv.swap a b)) a = s.incDir b := by
+        simp [Equiv.swap_apply_left]
+      rw [hIa, Function.update_self,
+        Function.update_of_ne (Fin_castSucc_ne_succ a),
+        pivotPoint_coords_eq_incB s a b hab]
+      have hstep : (s.verts a.succ).coords (s.incDir b)
+          = (s.verts a.castSucc).coords (s.incDir b) :=
+        s.step_same a (s.incDir b) (fun h => hab (s.inc_injective h).symm) (s.miss_ne_inc b)
+      omega
+    · by_cases hkb : k = b
+      · rw [hkb]
+        have hIb : (s.incDir ∘ ⇑(Equiv.swap a b)) b = s.incDir a := by
+          simp [Equiv.swap_apply_right]
+        have hbc : b.castSucc = a.succ := hb.symm
+        have hsucc_ne : b.succ ≠ a.succ := fun h => hab (Fin.succ_inj.mp h).symm
+        rw [hIb, Function.update_of_ne hsucc_ne, hbc, Function.update_self,
+          pivotPoint_coords_eq_incA s a b hab]
+        have hpos : 1 ≤ (s.verts a.succ).coords (s.incDir a) := by
+          have := s.step_inc a; omega
+        have hstep : (s.verts b.succ).coords (s.incDir a)
+            = (s.verts a.succ).coords (s.incDir a) := by
+          have h := s.step_same b (s.incDir a) (fun h => hab (s.inc_injective h)) (s.miss_ne_inc a)
+          rwa [hbc] at h
+        omega
+      · have hIk : (s.incDir ∘ ⇑(Equiv.swap a b)) k = s.incDir k := by
+          simp [Equiv.swap_apply_of_ne_of_ne hka hkb]
+        have hcs_ne : k.castSucc ≠ a.succ := by
+          rw [hb]; exact fun h => hkb (Fin.castSucc_inj.mp h)
+        have hsc_ne : k.succ ≠ a.succ := fun h => hka (Fin.succ_inj.mp h)
+        rw [hIk, Function.update_of_ne hsc_ne, Function.update_of_ne hcs_ne]
+        exact s.step_inc k
+  step_same := by
+    have hab : a ≠ b := pivot_ab_ne hb
+    intro k j hjI hjm
+    by_cases hka : k = a
+    · rw [hka] at hjI ⊢
+      have hIa : (s.incDir ∘ ⇑(Equiv.swap a b)) a = s.incDir b := by
+        simp [Equiv.swap_apply_left]
+      rw [hIa] at hjI
+      rw [Function.update_self, Function.update_of_ne (Fin_castSucc_ne_succ a)]
+      by_cases hja : j = s.incDir a
+      · subst hja
+        rw [pivotPoint_coords_eq_incA s a b hab]
+        have := s.step_inc a
+        omega
+      · rw [pivotPoint_coords_eq_other s a b hab j hja hjI]
+        exact s.step_same a j hja hjm
+    · by_cases hkb : k = b
+      · rw [hkb] at hjI ⊢
+        have hIb : (s.incDir ∘ ⇑(Equiv.swap a b)) b = s.incDir a := by
+          simp [Equiv.swap_apply_right]
+        rw [hIb] at hjI
+        have hbc : b.castSucc = a.succ := hb.symm
+        have hsucc_ne : b.succ ≠ a.succ := fun h => hab (Fin.succ_inj.mp h).symm
+        rw [Function.update_of_ne hsucc_ne, hbc, Function.update_self]
+        by_cases hjb : j = s.incDir b
+        · subst hjb
+          rw [pivotPoint_coords_eq_incB s a b hab]
+          have hss := s.step_inc b
+          rw [hbc] at hss
+          omega
+        · rw [pivotPoint_coords_eq_other s a b hab j hjI hjb]
+          have hss := s.step_same b j hjb hjm
+          rw [hbc] at hss
+          exact hss
+      · have hIk : (s.incDir ∘ ⇑(Equiv.swap a b)) k = s.incDir k := by
+          simp [Equiv.swap_apply_of_ne_of_ne hka hkb]
+        rw [hIk] at hjI
+        have hcs_ne : k.castSucc ≠ a.succ := by
+          rw [hb]; exact fun h => hkb (Fin.castSucc_inj.mp h)
+        have hsc_ne : k.succ ≠ a.succ := fun h => hka (Fin.succ_inj.mp h)
+        rw [Function.update_of_ne hsc_ne, Function.update_of_ne hcs_ne]
+        exact s.step_same k j hjI hjm
+
+/-- **The pivot keeps the facet fixed.**  The `d` vertices off the
+deleted vertex `a.succ` are untouched by the pivot, so `s` and its
+pivot share the facet opposite `a.succ` as vertex sets.  This is the
+`adj_vertices`-style common-face equality for the interior pivot. -/
+theorem pivot_facet_eq (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    (Finset.univ.erase a.succ).image (pivotSimplex s a b hb).verts
+      = (Finset.univ.erase a.succ).image s.verts := by
+  apply Finset.image_congr
+  intro j hj
+  have hjne : j ≠ a.succ := by simpa using hj
+  show Function.update s.verts a.succ (pivotPoint s a b (pivot_ab_ne hb)) j = s.verts j
+  rw [Function.update_of_ne hjne]
+
+/-- **The pivot moves the opposite vertex.**  The pivoted vertex
+differs from the deleted vertex at coordinate `incDir a` (it drops by
+one, from a value `≥ 1`).  So the pivot is a genuinely different
+filling of the shared facet. -/
+theorem pivot_opposite_ne (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    (pivotSimplex s a b hb).verts a.succ ≠ s.verts a.succ := by
+  have hab : a ≠ b := pivot_ab_ne hb
+  intro h
+  have hpos : 1 ≤ (s.verts a.succ).coords (s.incDir a) := by
+    have := s.step_inc a; omega
+  have hcoord : ((pivotSimplex s a b hb).verts a.succ).coords (s.incDir a)
+      = (s.verts a.succ).coords (s.incDir a) := by rw [h]
+  have hval : (pivotSimplex s a b hb).verts a.succ = pivotPoint s a b hab := by
+    show Function.update s.verts a.succ (pivotPoint s a b hab) a.succ = _
+    rw [Function.update_self]
+  rw [hval, pivotPoint_coords_eq_incA s a b hab] at hcoord
+  omega
+
+/-- **The interior pivot is a different cell.**  Immediate from
+`pivot_opposite_ne`: equal simplices would have equal vertex
+functions, hence equal opposite vertices.  Together with
+`pivot_facet_eq` this is exactly the `GridSimplex`-level neighbour
+existence the search-based `adj` needs at chain-interior facets. -/
+theorem pivot_ne (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    pivotSimplex s a b hb ≠ s := by
+  intro h
+  exact pivot_opposite_ne s a b hb (by rw [h])
+
+/-- `GridSimplex` extensionality on the three data fields (the structure carries no
+`@[ext]`; the proof fields are discharged by definitional proof irrelevance). -/
+private theorem gridSimplex_ext {s t : SpernerGrid.GridSimplex d N}
+    (hv : s.verts = t.verts) (hi : s.incDir = t.incDir) (hm : s.miss = t.miss) :
+    s = t := by
+  cases s; cases t; cases hv; cases hi; cases hm; rfl
+
+/-- **The interior pivot is an involution.**  Pivoting twice across the *same* facet
+(opposite `a.succ`, with the same consecutive step pair `a, b`) returns the original
+cell.  Two ingredients combine: the direction permutation `Equiv.swap a b` is its own
+inverse (`incDir` returns to `s.incDir`), and the second `pivotPoint` exactly undoes
+the first — in the pivoted cell `t` the roles of the two move directions are swapped
+(`t.incDir a = s.incDir b`, `t.incDir b = s.incDir a`), so the second pivot moves
+`incDir a` *up* and `incDir b` *down*, reversing the original move and restoring
+`s.verts a.succ`.  This is the geometric heart of the adjacency symmetry `adj_symm`
+for chain-interior facets: the neighbour relation built from `pivotSimplex` is
+symmetric, with each facet-flip its own reverse. -/
+theorem pivot_involutive (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    pivotSimplex (pivotSimplex s a b hb) a b hb = s := by
+  have hab : a ≠ b := pivot_ab_ne hb
+  set t := pivotSimplex s a b hb with ht
+  -- Roles of the move directions are swapped in `t`.
+  have hia : t.incDir a = s.incDir b := by
+    show (s.incDir ∘ ⇑(Equiv.swap a b)) a = s.incDir b
+    simp [Equiv.swap_apply_left]
+  have hib : t.incDir b = s.incDir a := by
+    show (s.incDir ∘ ⇑(Equiv.swap a b)) b = s.incDir a
+    simp [Equiv.swap_apply_right]
+  have hva : t.verts a.succ = pivotPoint s a b hab := by
+    show Function.update s.verts a.succ (pivotPoint s a b hab) a.succ = _
+    rw [Function.update_self]
+  have hne : s.incDir a ≠ s.incDir b := fun h => hab (s.inc_injective h)
+  have hpos : 1 ≤ (s.verts a.succ).coords (s.incDir a) := by
+    have := s.step_inc a; omega
+  -- The doubly-pivoted vertex returns to the original deleted vertex.
+  have hpt : pivotPoint t a b hab = s.verts a.succ := by
+    ext j
+    by_cases h1 : j = s.incDir a
+    · subst h1
+      have hL : (pivotPoint t a b hab).coords (s.incDir a)
+          = (t.verts a.succ).coords (t.incDir b) + 1 := by
+        rw [← hib]; exact pivotPoint_coords_eq_incB t a b hab
+      rw [hL, hva, hib, pivotPoint_coords_eq_incA s a b hab]
+      omega
+    · by_cases h2 : j = s.incDir b
+      · subst h2
+        have hL : (pivotPoint t a b hab).coords (s.incDir b)
+            = (t.verts a.succ).coords (t.incDir a) - 1 := by
+          rw [← hia]; exact pivotPoint_coords_eq_incA t a b hab
+        rw [hL, hva, hia, pivotPoint_coords_eq_incB s a b hab]
+        omega
+      · have hja : j ≠ t.incDir a := by rw [hia]; exact h2
+        have hjb : j ≠ t.incDir b := by rw [hib]; exact h1
+        rw [pivotPoint_coords_eq_other t a b hab j hja hjb, hva,
+          pivotPoint_coords_eq_other s a b hab j h1 h2]
+  -- Assemble the three field equalities.
+  refine gridSimplex_ext ?_ ?_ rfl
+  · show Function.update t.verts a.succ (pivotPoint t a b hab) = s.verts
+    have htv : t.verts = Function.update s.verts a.succ (pivotPoint s a b hab) := rfl
+    rw [hpt, htv, Function.update_idem, Function.update_eq_self]
+  · show (s.incDir ∘ ⇑(Equiv.swap a b)) ∘ ⇑(Equiv.swap a b) = s.incDir
+    funext k
+    simp [Equiv.swap_apply_self]
+
+/-- **The interior pivot fixes the base vertex.**  The pivot only updates the
+vertex `a.succ`, and `a.succ ≠ 0`, so the lex-base `verts 0` is untouched. -/
+theorem pivot_base_eq (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    (pivotSimplex s a b hb).verts 0 = s.verts 0 := by
+  show Function.update s.verts a.succ (pivotPoint s a b (pivot_ab_ne hb)) 0 = s.verts 0
+  rw [Function.update_of_ne (Fin.succ_ne_zero a).symm]
+
+/-- **Canonicality of the interior pivot reduces to a single lex test.**  The pivot
+fixes every vertex except the moved one (`a.succ`), in particular the lex-base
+`verts 0` (`pivot_base_eq`).  Since `s` is canonical, all unchanged vertices already
+dominate that shared base, so the pivot is canonical **iff** its one moved vertex —
+the pivot point — also dominates the base.  This replaces the `d + 1` canonicality
+conditions of the pivoted cell by the single comparison a recanonicalization step
+must check, isolating exactly when the interior pivot already lands on the canonical
+representative of its geometric cell. -/
+theorem pivot_isCanon_iff (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) (hs : SpernerGrid.IsCanon s) :
+    SpernerGrid.IsCanon (pivotSimplex s a b hb)
+      ↔ (s.verts 0).lexLE (pivotPoint s a b (pivot_ab_ne hb)) := by
+  have hpiv : (pivotSimplex s a b hb).verts a.succ
+      = pivotPoint s a b (pivot_ab_ne hb) := by
+    show Function.update s.verts a.succ (pivotPoint s a b (pivot_ab_ne hb)) a.succ = _
+    rw [Function.update_self]
+  constructor
+  · intro hcanon
+    have h := hcanon a.succ
+    rwa [pivot_base_eq, hpiv] at h
+  · intro hpivLE k
+    rw [pivot_base_eq]
+    by_cases hk : k = a.succ
+    · subst hk; rw [hpiv]; exact hpivLE
+    · have hvk : (pivotSimplex s a b hb).verts k = s.verts k := by
+        show Function.update s.verts a.succ (pivotPoint s a b (pivot_ab_ne hb)) k = s.verts k
+        rw [Function.update_of_ne hk]
+      rw [hvk]; exact hs k
+
+-- ============================================================
+-- SECTION: At most one neighbour across a facet (adj_unique_facet)
+-- ============================================================
+-- The abstract `adj_unique_facet` field requires that two *distinct*
+-- facets of a cell `s` cannot both be glued to the *same* neighbour `t`
+-- — geometrically, two `d`-simplices share at most one common
+-- `(d-1)`-face.  This section proves exactly that, purely from the facet
+-- combinatorics and per-geometry uniqueness already established, so the
+-- eventual `adj` discharge can cite it directly.  The key step is that
+-- the union of two distinct facets of a cell is its *entire* vertex set;
+-- if both facets also lie in a second cell `t`, then `t`'s `d + 1`
+-- vertices contain `s`'s `d + 1` vertices, forcing equal vertex sets and
+-- hence `s = t`.  All 0-sorry, 0-axiom.
+
+/-- **The union of two distinct facets is the full vertex set.**  Facet
+`k₁` omits only vertex `k₁` and facet `k₂` omits only vertex `k₂`; when
+`k₁ ≠ k₂` each omitted vertex is supplied by the other facet, so the
+union recovers all `d + 1` vertices of the cell. -/
+theorem facet_union_facet (s : CanonSimplex d N) {k₁ k₂ : Fin (d + 1)}
+    (h : k₁ ≠ k₂) :
+    facet s k₁ ∪ facet s k₂ = Finset.univ.image (vertices s) := by
+  rw [facet, facet, ← Finset.image_union]
+  congr 1
+  apply Finset.eq_univ_of_forall
+  intro a
+  rw [Finset.mem_union, Finset.mem_erase, Finset.mem_erase]
+  by_cases ha : a = k₁
+  · exact Or.inr ⟨ha ▸ h, Finset.mem_univ _⟩
+  · exact Or.inl ⟨ha, Finset.mem_univ _⟩
+
+/-- A canonical cell has exactly `d + 1` distinct Kuhn vertices: the
+image of `univ` under the injective vertex map. -/
+theorem image_univ_card (s : CanonSimplex d N) :
+    (Finset.univ.image (vertices s)).card = d + 1 := by
+  rw [Finset.card_image_of_injective _ (vertices_injective s), Finset.card_univ,
+    Fintype.card_fin]
+
+/-- **At most one neighbour across a facet (`adj_unique_facet`).**  If a cell
+`s` shares two facets `k₁, k₂` with the *same* other cell `t`
+(`facet s k₁ = facet t l₁`, `facet s k₂ = facet t l₂`, `s ≠ t`), then in fact
+`k₁ = k₂`.  Otherwise the two distinct facets of `s` would union to all of `s`'s
+vertices while both lying inside `t`'s vertex set; equal cardinalities then force
+`s` and `t` to have the same vertex set, so `canon_eq_of_vertices_range` gives
+`s = t`, contradicting `s ≠ t`.  This is exactly the content of the abstract
+`adj_unique_facet` compatibility field: a neighbour is glued across at most one
+facet of `s`. -/
+theorem facet_unique_neighbor {s t : CanonSimplex d N}
+    {k₁ k₂ l₁ l₂ : Fin (d + 1)} (hne : s ≠ t)
+    (h₁ : facet s k₁ = facet t l₁) (h₂ : facet s k₂ = facet t l₂) :
+    k₁ = k₂ := by
+  by_contra hk
+  have hs : Finset.univ.image (vertices s) = facet s k₁ ∪ facet s k₂ :=
+    (facet_union_facet s hk).symm
+  have hsub : Finset.univ.image (vertices s) ⊆ Finset.univ.image (vertices t) := by
+    rw [hs, h₁, h₂]
+    apply Finset.union_subset
+    · rw [facet]; exact Finset.image_subset_image (Finset.erase_subset _ _)
+    · rw [facet]; exact Finset.image_subset_image (Finset.erase_subset _ _)
+  have hcard :
+      (Finset.univ.image (vertices t)).card ≤ (Finset.univ.image (vertices s)).card := by
+    rw [image_univ_card, image_univ_card]
+  have heq : Finset.univ.image (vertices s) = Finset.univ.image (vertices t) :=
+    Finset.eq_of_subset_of_card_le hsub hcard
+  apply hne
+  apply canon_eq_of_vertices_range
+  rw [← coe_image_univ_vertices s, ← coe_image_univ_vertices t, heq]
+
+-- ============================================================
+-- SECTION: The canonical base of a cell (canonicalization target)
+-- ============================================================
+-- Every previous section established *uniqueness* of the canonical
+-- representative of a geometry (`canon_eq_of_vertices_range`,
+-- `IsCanon.geometry_unique`).  The dual *existence* direction —
+-- recanonicalizing an arbitrary `GridSimplex` (e.g. the interior
+-- Freudenthal pivot `pivotSimplex`, which need not be canonical) into the
+-- `CanonSimplex` carrier — starts by selecting the new base: the lex-minimal
+-- vertex of the cell.  Last session closed the order theory making this
+-- well-posed (`exists_lex_min` + the lex linear order).  This section names
+-- that base as a *function of the geometry* and proves the two properties the
+-- recanonicalization map needs:
+--
+--   * it is determined by the vertex set alone (`baseOf_eq_of_range_eq`), so
+--     the canonicalization map is well-defined; and
+--   * on an already-canonical cell it is the recorded base `verts 0`
+--     (`isCanon_baseOf_eq`), so canonicalization is the identity on the
+--     carrier — a prerequisite for `adj` returning into `CanonSimplex`.
+--
+-- Everything here is order-theoretic bookkeeping over `exists_lex_min`; it adds
+-- no axioms (only `Classical.choice`, via `Exists.choose`) and no sorries.
+
+open SpernerGrid in
+/-- The vertex set of a grid simplex, as a `Finset` of barycentric points. -/
+def vertexSet (s : GridSimplex d N) : Finset (SpernerGrid.BaryPoint d N) :=
+  Finset.univ.image s.verts
+
+theorem mem_vertexSet (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    s.verts k ∈ vertexSet s := by
+  simp only [vertexSet, Finset.mem_image, Finset.mem_univ, true_and]
+  exact ⟨k, rfl⟩
+
+theorem vertexSet_nonempty (s : SpernerGrid.GridSimplex d N) :
+    (vertexSet s).Nonempty :=
+  ⟨s.verts 0, mem_vertexSet s 0⟩
+
+/-- The lex-minimal base of a cell's vertex set.  Noncomputable choice from the
+existence lemma `exists_lex_min`; it is well-defined *as a function of the
+geometry* by `baseOf_eq_of_range_eq` below. -/
+noncomputable def baseOf (s : SpernerGrid.GridSimplex d N) :
+    SpernerGrid.BaryPoint d N :=
+  (SpernerGrid.BaryPoint.exists_lex_min (vertexSet s) (vertexSet_nonempty s)).choose
+
+theorem baseOf_mem (s : SpernerGrid.GridSimplex d N) :
+    baseOf s ∈ vertexSet s :=
+  (SpernerGrid.BaryPoint.exists_lex_min (vertexSet s) (vertexSet_nonempty s)).choose_spec.1
+
+theorem baseOf_lexLE (s : SpernerGrid.GridSimplex d N) :
+    ∀ x ∈ vertexSet s, (baseOf s).lexLE x :=
+  (SpernerGrid.BaryPoint.exists_lex_min (vertexSet s) (vertexSet_nonempty s)).choose_spec.2
+
+/-- **Uniqueness of the lex-min base.**  Any vertex of the cell that is
+lex-`≤` every vertex equals `baseOf s` (the lex order has a unique minimum,
+`lexLE_antisymm`).  This is what makes `baseOf` characterizable without
+unfolding the noncomputable choice. -/
+theorem baseOf_unique (s : SpernerGrid.GridSimplex d N)
+    {b : SpernerGrid.BaryPoint d N} (hb : b ∈ vertexSet s)
+    (hmin : ∀ x ∈ vertexSet s, b.lexLE x) : b = baseOf s :=
+  SpernerGrid.BaryPoint.lexLE_antisymm (hmin _ (baseOf_mem s)) (baseOf_lexLE s _ hb)
+
+/-- **The canonical base is determined by the vertex `Finset`.**  Two cells with
+the same vertex set share the same lex-min base. -/
+theorem baseOf_eq_of_vertexSet_eq {s t : SpernerGrid.GridSimplex d N}
+    (h : vertexSet s = vertexSet t) : baseOf s = baseOf t := by
+  apply baseOf_unique t
+  · rw [← h]; exact baseOf_mem s
+  · rw [← h]; exact baseOf_lexLE s
+
+/-- **The canonical base is geometry-determined.**  Phrased over `Set.range`
+to match `IsCanon.geometry_unique`: cells with the same vertex *range* have the
+same lex-min base.  This is the well-definedness the recanonicalization map
+requires — the base of the canonical representative depends only on the cell's
+point set, not on the (arbitrary) chain ordering of `s`. -/
+theorem baseOf_eq_of_range_eq {s t : SpernerGrid.GridSimplex d N}
+    (h : Set.range s.verts = Set.range t.verts) : baseOf s = baseOf t := by
+  apply baseOf_eq_of_vertexSet_eq
+  apply Finset.coe_injective
+  simp only [vertexSet, Finset.coe_image, Finset.coe_univ, Set.image_univ]
+  exact h
+
+/-- **On a canonical cell the lex-min base is the recorded base `verts 0`.**
+Hence `baseOf` recovers the canonical base, and the recanonicalization map is the
+identity on cells that are already canonical — exactly what is needed for the
+`adj` neighbour to land back inside the `CanonSimplex` carrier. -/
+theorem isCanon_baseOf_eq {s : SpernerGrid.GridSimplex d N}
+    (hs : SpernerGrid.IsCanon s) : baseOf s = s.verts 0 := by
+  symm
+  apply baseOf_unique s (mem_vertexSet s 0)
+  intro x hx
+  obtain ⟨k, _, rfl⟩ := Finset.mem_image.mp hx
+  exact hs k
+
+/-- The lex-min base of a `CanonSimplex` is its base vertex. -/
+theorem baseOf_canon (s : CanonSimplex d N) : baseOf s.1 = s.1.verts 0 :=
+  isCanon_baseOf_eq s.2
+
+-- ============================================================
+-- The recanonicalization base of the interior pivot
+-- ============================================================
+-- `baseOf` names the lex-min base a recanonicalization step selects.
+-- For the interior pivot (`pivotSimplex`, the neighbour the `adj`
+-- search produces at a chain-interior facet) we can now pin that base
+-- down in *both* outcomes of the single canonicality test
+-- `pivot_isCanon_iff`:
+--
+--   * already canonical → `baseOf` is the untouched base `s.verts 0`
+--     (`pivot_base_eq`), so recanonicalization is the identity;
+--   * not canonical → the one moved vertex, the `pivotPoint`, has
+--     dropped lex-below `s.verts 0` and so becomes the new lex-min
+--     base of the neighbour's vertex set.
+--
+-- Together these say *exactly which vertex* the recanonicalization map
+-- must promote to the base in every interior-pivot case — the remaining
+-- input that step needs beyond the already-proven well-definedness
+-- (`baseOf_eq_of_range_eq`) and identity-on-canonical
+-- (`isCanon_baseOf_eq`) facts.
+
+/-- **Recanonicalization base of a canonical interior pivot.**  When the
+interior pivot already lands on the canonical representative, its lex-min
+base is the untouched base `s.verts 0` (the pivot fixes vertex `0`,
+`pivot_base_eq`).  So the recanonicalization map is the identity here. -/
+theorem baseOf_pivot_of_canon (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc)
+    (hcanon : SpernerGrid.IsCanon (pivotSimplex s a b hb)) :
+    baseOf (pivotSimplex s a b hb) = s.verts 0 := by
+  rw [isCanon_baseOf_eq hcanon, pivot_base_eq]
+
+/-- **Recanonicalization base of a non-canonical interior pivot.**  When the
+single lex test of `pivot_isCanon_iff` fails — i.e. the moved vertex
+`pivotPoint` is *not* lex-dominated by the base `s.verts 0` — the pivot is
+non-canonical, and the `pivotPoint` is precisely its new lex-min base.
+
+The pivot's vertices are the moved `pivotPoint` together with the `d`
+untouched vertices `s.verts j` (`j ≠ a.succ`).  Failure of the test makes
+`pivotPoint` lex-`≤` the old base `s.verts 0` (lex totality), which in turn
+is lex-`≤` every `s.verts j` (`s` is canonical); so `pivotPoint` dominates
+all vertices and, lying in the cell, is the unique lex-min base
+(`baseOf_unique`).  This identifies the vertex the recanonicalization map
+must promote to the base whenever the interior pivot leaves the carrier. -/
+theorem baseOf_pivot_of_not_canon (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) (hs : SpernerGrid.IsCanon s)
+    (hp : ¬ (s.verts 0).lexLE (pivotPoint s a b (pivot_ab_ne hb))) :
+    baseOf (pivotSimplex s a b hb) = pivotPoint s a b (pivot_ab_ne hb) := by
+  -- The moved vertex `a.succ` is the `pivotPoint`.
+  have hpiv : (pivotSimplex s a b hb).verts a.succ
+      = pivotPoint s a b (pivot_ab_ne hb) := by
+    show Function.update s.verts a.succ (pivotPoint s a b (pivot_ab_ne hb)) a.succ = _
+    rw [Function.update_self]
+  -- Test failure + lex totality: `pivotPoint` lex-≤ the old base.
+  have hple0 : (pivotPoint s a b (pivot_ab_ne hb)).lexLE (s.verts 0) := by
+    rcases SpernerGrid.BaryPoint.lexLE_total (s.verts 0)
+        (pivotPoint s a b (pivot_ab_ne hb)) with h | h
+    · exact absurd h hp
+    · exact h
+  symm
+  apply baseOf_unique (pivotSimplex s a b hb)
+  · -- `pivotPoint` is a vertex of the pivoted cell.
+    rw [← hpiv]; exact mem_vertexSet (pivotSimplex s a b hb) a.succ
+  · -- `pivotPoint` lex-dominates every vertex of the pivoted cell.
+    intro x hx
+    obtain ⟨j, _, rfl⟩ := Finset.mem_image.mp hx
+    by_cases hj : j = a.succ
+    · subst hj; rw [hpiv]; exact SpernerGrid.BaryPoint.lexLE_refl _
+    · have hxj : (pivotSimplex s a b hb).verts j = s.verts j := by
+        show Function.update s.verts a.succ
+          (pivotPoint s a b (pivot_ab_ne hb)) j = s.verts j
+        rw [Function.update_of_ne hj]
+      rw [hxj]
+      exact SpernerGrid.BaryPoint.lexLE_trans hple0 (hs j)
+
+-- ============================================================
+-- SECTION: The orientation ambiguity is a `d ≤ 1` phenomenon
+-- ============================================================
+-- `IsCanon.geometry_unique` (in `SpernerGridBase`) shows two *canonical*
+-- `GridSimplex`es with the same vertex set are equal — it must assume
+-- `IsCanon` on both because, in general, a geometric cell admits several
+-- chain encodings (the Session-1 `d = 1` reversal counterexample: an edge
+-- `{a, b}` is encoded both as `a → b` and `b → a`, with opposite `miss`).
+--
+-- This section pins down *exactly* where that ambiguity lives.  For `d ≥ 2`
+-- the `miss` direction is **geometry-intrinsic**: it is the unique
+-- coordinate that takes all `d + 1` distinct values across the cell (every
+-- *non*-`miss` coordinate is incremented exactly once, so it takes only the
+-- two values `c, c + 1`).  Hence for `d ≥ 2` the whole encoding is forced by
+-- the vertex set alone — `eq_of_range_eq` gives per-geometry uniqueness with
+-- **no `IsCanon` hypothesis**, so recanonicalization is the identity on every
+-- cell and the orientation doubling is confined to the inductive base cases
+-- `d ≤ 1`.  The three steps mirror the canonical proof but drop the base-
+-- sharing assumption that `IsCanon.base_unique` used to supply:
+--
+--   1. `miss_intrinsic`     — `miss` recovered from the vertex *range* alone
+--      (counting distinct coordinate values, needs `d ≥ 2`);
+--   2. `base_eq_of_miss`    — with `miss` shared, the base is the unique
+--      maximal-`miss`-coordinate vertex of the (shared) cell;
+--   3. `eq_of_range_eq`     — feed the recovered base/`miss` to the existing
+--      `verts_eq` / `incDir_eq` / `eq_of_base_miss_incDir`.
+--
+-- Everything is `GridSimplex` arithmetic over the already-proven recovery
+-- lemmas; it adds no axioms (only `Classical.choice`, transitively) and no
+-- sorries.
+
+open SpernerGrid in
+/-- **The `miss` direction is geometry-intrinsic for `d ≥ 2`.**  Two
+`GridSimplex`es with the same vertex *range* share their `miss` direction —
+*without* assuming a shared base (contrast `GridSimplex.miss_unique`, which
+needs `hbase`).  Proof: along the chain the `miss` coordinate takes the `d + 1`
+distinct values `base, base − 1, …, base − d` (`miss_coord_at`, injective since
+`base ≥ d`), whereas every non-`miss` coordinate is incremented exactly once
+and so takes only the two values `c, c + 1` (`coord_incDir_at`).  If the two
+cells had different `miss`, the coordinate `t.miss` would be some `s.incDir k`
+on the `s`-side; computed over the shared vertex set it would then have both
+`d + 1` and `≤ 2` distinct values — impossible once `d + 1 > 2`. -/
+theorem miss_intrinsic (hd : 2 ≤ d) {s t : SpernerGrid.GridSimplex d N}
+    (hset : Set.range s.verts = Set.range t.verts) :
+    s.miss = t.miss := by
+  by_contra hne
+  -- On the `s`-side the coordinate `t.miss` is some increment direction.
+  obtain ⟨k, hk⟩ := s.incDir_surj_complement t.miss (fun h => hne h.symm)
+  -- The two cells share their vertex `Finset`.
+  have hVS : Finset.univ.image s.verts = Finset.univ.image t.verts := by
+    apply Finset.coe_injective
+    simpa only [Finset.coe_image, Finset.coe_univ, Set.image_univ] using hset
+  -- The `Finset` of values taken by coordinate `t.miss` over the shared cell.
+  set F : Finset ℕ :=
+    (Finset.univ.image t.verts).image (fun v => v.coords t.miss) with hF
+  -- Over the `t`-vertices this has exactly `d + 1` distinct values.
+  have hinj : Function.Injective ((fun v => v.coords t.miss) ∘ t.verts) := by
+    intro a b hab
+    simp only [Function.comp] at hab
+    rw [t.miss_coord_at a, t.miss_coord_at b] at hab
+    have hbge := t.base_miss_ge_d
+    have ha := a.isLt; have hb := b.isLt
+    exact Fin.ext (by omega)
+  have hcardF : F.card = d + 1 := by
+    rw [hF, Finset.image_image, Finset.card_image_of_injective _ hinj,
+      Finset.card_univ, Fintype.card_fin]
+  -- Over the `s`-vertices the same coordinate is `s.incDir k`, taking `≤ 2` values.
+  have hsub : F ⊆ {(s.verts 0).coords (s.incDir k),
+      (s.verts 0).coords (s.incDir k) + 1} := by
+    rw [hF, ← hVS, Finset.image_image]
+    intro x hx
+    simp only [Finset.mem_image, Finset.mem_univ, true_and, Function.comp] at hx
+    obtain ⟨m, rfl⟩ := hx
+    rw [← hk, s.coord_incDir_at k m]
+    by_cases h : k.val < m.val
+    · rw [if_pos h]
+      exact Finset.mem_insert_of_mem (Finset.mem_singleton_self _)
+    · rw [if_neg h]
+      exact Finset.mem_insert_self _ _
+  have hcardF2 : F.card ≤ 2 := by
+    refine (Finset.card_le_card hsub).trans ?_
+    exact (Finset.card_insert_le _ _).trans (by simp)
+  rw [hcardF] at hcardF2
+  omega
+
+open SpernerGrid in
+/-- **Base recovery without canonicality.**  Two `GridSimplex`es sharing their
+`miss` direction and vertex range share their base vertex.  The base is the
+unique vertex whose `miss` coordinate is maximal (`miss_coord_at`: it is
+`base − m` at chain index `m`), and that is determined by the shared geometry.
+This drops the `IsCanon` assumption of `IsCanon.base_unique`. -/
+theorem base_eq_of_miss {s t : SpernerGrid.GridSimplex d N}
+    (hmiss : s.miss = t.miss)
+    (hset : Set.range s.verts = Set.range t.verts) :
+    s.verts 0 = t.verts 0 := by
+  -- `s.verts 0 = t.verts m` and `t.verts 0 = s.verts m'` (shared range).
+  obtain ⟨m, hm⟩ : s.verts 0 ∈ Set.range t.verts := by rw [← hset]; exact ⟨0, rfl⟩
+  obtain ⟨m', hm'⟩ : t.verts 0 ∈ Set.range s.verts := by rw [hset]; exact ⟨0, rfl⟩
+  -- Compare the (shared) `miss` coordinate at the two bases.
+  have e1 : (s.verts 0).coords s.miss
+      = (t.verts 0).coords t.miss - m.val := by rw [hmiss, ← hm]; exact t.miss_coord_at m
+  have e2 : (t.verts 0).coords t.miss
+      = (s.verts 0).coords s.miss - m'.val := by rw [← hmiss, ← hm']; exact s.miss_coord_at m'
+  have hbs := s.base_miss_ge_d
+  have hbt := t.base_miss_ge_d
+  have hmd := m.isLt; have hm'd := m'.isLt
+  have hm0 : m.val = 0 := by omega
+  rw [← hm, show (m : Fin (d + 1)) = 0 from Fin.ext hm0]
+
+open SpernerGrid in
+/-- **Per-geometry uniqueness for `d ≥ 2`, with no canonicality hypothesis.**
+Two `GridSimplex`es with the same vertex range are *equal* once `d ≥ 2`.  So
+the `GridSimplex` encoding is already one-representative-per-geometry above
+dimension 1: the orientation doubling that motivates `IsCanon` only occurs in
+the inductive base cases `d ≤ 1`.  Proof: recover `miss` (`miss_intrinsic`) and
+the base (`base_eq_of_miss`), then reuse the canonical reconstruction chain
+`verts_eq` → `incDir_eq` → `eq_of_base_miss_incDir`. -/
+theorem eq_of_range_eq (hd : 2 ≤ d) {s t : SpernerGrid.GridSimplex d N}
+    (hset : Set.range s.verts = Set.range t.verts) :
+    s = t := by
+  have hmiss := miss_intrinsic hd hset
+  have hbase := base_eq_of_miss hmiss hset
+  have hverts := SpernerGrid.GridSimplex.verts_eq hbase hmiss hset
+  have hinc := SpernerGrid.GridSimplex.incDir_eq hverts
+  exact s.eq_of_base_miss_incDir t hbase hmiss hinc
+
+-- ============================================================
+-- SECTION: GridSimplex-direct carrier for `d ≥ 2`
+-- ============================================================
+-- The `CanonSimplex := {s // IsCanon s}` carrier (base = lex-min vertex) has
+-- *uniqueness* (`canon_eq_of_vertices_range`) but **fails existence**:
+-- `SpernerNDimOQ02Obstruction.sBad_no_canon_rep` exhibits a genuine Freudenthal
+-- cell (`d = 2`, `N = 2`, vertices `(2,0,0), (1,1,0), (0,1,1)`) whose lex-minimum
+-- `(0,1,1)` has every coordinate `< d`, so no grid simplex on that cell can
+-- satisfy `IsCanon` (a base always carries a coordinate `≥ d` by
+-- `base_miss_ge_d`).  Hence `CanonSimplex` *omits cells* and cannot be the
+-- `Simplex` type unmodified.
+--
+-- The repair is to drop the subtype and use `GridSimplex d N` as the carrier
+-- directly.  For `d ≥ 2` that is sound on *both* counts:
+--
+--   * **existence** is now definitional — every geometric cell *is* a
+--     `GridSimplex`, with no constraint left to violate; and
+--   * **uniqueness** is `eq_of_range_eq` — for `d ≥ 2` the `miss` direction and
+--     base are forced by the vertex range, so distinct `GridSimplex`es have
+--     distinct vertex sets.
+--
+-- This section packages the GridSimplex-direct vertex map and the sound
+-- replacement for `canon_eq_of_vertices_range`: the Kuhn-vertex set of a grid
+-- simplex determines it (`grid_eq_of_vertices_range`), equivalently the map
+-- `s ↦ univ.image (gridVertices s)` is injective (`gridVertices_finset_injective`).
+-- These are the carrier lemmas the door-counting `adj` discharge will cite once
+-- the carrier is switched from `CanonSimplex` to `GridSimplex` for `d ≥ 2`.
+
+/-- Vertex map of a grid simplex, pushed to Kuhn coordinates through the bridge
+`toVertex`.  Same as `vertices` but on `GridSimplex` directly (no `IsCanon`
+subtype), for the repaired `d ≥ 2` carrier. -/
+def gridVertices (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    SpernerNDim.Vertex d N :=
+  toVertex (s.verts k)
+
+/-- The `d + 1` Kuhn vertices of a grid simplex are distinct (the
+`vertices_injective` obligation for the GridSimplex-direct carrier).  Combines
+per-cell vertex injectivity (`GridSimplex.verts_injective`) with injectivity of
+the bridge. -/
+theorem gridVertices_injective (s : SpernerGrid.GridSimplex d N) :
+    Function.Injective (gridVertices s) := by
+  intro i j h
+  exact s.verts_injective (toVertex_injective h)
+
+open SpernerGrid in
+/-- **Sound carrier uniqueness for `d ≥ 2`.**  A grid simplex is determined by
+its Kuhn vertex set: two grid simplices with the same `Set.range gridVertices`
+are equal once `d ≥ 2`.  This is the GridSimplex-direct analogue of
+`canon_eq_of_vertices_range`, but with **no `IsCanon` hypothesis**, so the
+existence failure of the `CanonSimplex` carrier
+(`SpernerNDimOQ02Obstruction.sBad_no_canon_rep`) does not arise.  Proof: strip
+the injective bridge `toVertex` to recover equality of the barycentric ranges,
+then apply `eq_of_range_eq`. -/
+theorem grid_eq_of_vertices_range (hd : 2 ≤ d)
+    {s t : SpernerGrid.GridSimplex d N}
+    (h : Set.range (gridVertices s) = Set.range (gridVertices t)) :
+    s = t := by
+  have key : ∀ u : SpernerGrid.GridSimplex d N,
+      Set.range (gridVertices u) = toVertex '' Set.range u.verts := by
+    intro u
+    have huc : gridVertices u = toVertex ∘ u.verts := rfl
+    rw [huc, Set.range_comp]
+  rw [key s, key t] at h
+  have hbary : Set.range s.verts = Set.range t.verts :=
+    Set.image_injective.mpr toVertex_injective h
+  exact eq_of_range_eq hd hbary
+
+open SpernerGrid in
+/-- **The carrier embeds into vertex sets (for `d ≥ 2`).**  The map sending a
+grid simplex to its Kuhn vertex `Finset` is injective.  This is the
+`Finset`-level restatement of `grid_eq_of_vertices_range` that the door-counting
+combinatorics use — cells are identified by their vertex sets, with no
+orientation ambiguity and no omitted cells once `d ≥ 2`. -/
+theorem gridVertices_finset_injective (hd : 2 ≤ d) :
+    Function.Injective
+      (fun s : SpernerGrid.GridSimplex d N =>
+        Finset.univ.image (gridVertices s)) := by
+  intro s t h
+  apply grid_eq_of_vertices_range hd
+  have h' : Finset.univ.image (gridVertices s) = Finset.univ.image (gridVertices t) := h
+  have hcoe : (↑(Finset.univ.image (gridVertices s)) : Set (SpernerNDim.Vertex d N))
+      = ↑(Finset.univ.image (gridVertices t)) := by rw [h']
+  simpa only [Finset.coe_image, Finset.coe_univ, Set.image_univ] using hcoe
+
+-- ============================================================
+-- SECTION: GridSimplex-direct facet combinatorics (`d ≥ 2`)
+-- ============================================================
+-- The facet section above (`facet`, `facet_injective`,
+-- `canon_eq_of_facet_and_vertex`, `facet_unique_neighbor`, …) is stated
+-- over the `CanonSimplex` carrier, whose existence failure for `d ≥ 2`
+-- (`SpernerNDimOQ02Obstruction.sBad_no_canon_rep`) makes it unsound as the
+-- door-counting carrier.  This section re-points the same combinatorics at the
+-- repaired `GridSimplex`-direct carrier, citing `gridVertices`,
+-- `gridVertices_injective`, and `grid_eq_of_vertices_range hd` in place of
+-- `vertices`, `vertices_injective`, and `canon_eq_of_vertices_range`.  The
+-- proofs are otherwise identical to the `CanonSimplex` versions — the carrier
+-- swap is the whole content.  The crux is `gridFacet_unique_neighbor` (the
+-- `adj_unique_facet` obligation: a neighbour is glued across at most one facet),
+-- now sound because no cell is omitted.  All 0-sorry; the `d ≥ 2` hypothesis
+-- enters only through `grid_eq_of_vertices_range`.
+
+/-- The `k`-th **facet** of a grid simplex on the `GridSimplex`-direct carrier:
+delete vertex `k`, push the rest through the Kuhn bridge.  GridSimplex analogue
+of `facet`. -/
+def gridFacet (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    Finset (SpernerNDim.Vertex d N) :=
+  (Finset.univ.erase k).image (gridVertices s)
+
+/-- Membership in a grid facet: a Kuhn vertex lies on `gridFacet s k` exactly
+when it is the image of some vertex `j ≠ k`. -/
+theorem mem_gridFacet_iff (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1))
+    (v : SpernerNDim.Vertex d N) :
+    v ∈ gridFacet s k ↔ ∃ j : Fin (d + 1), j ≠ k ∧ gridVertices s j = v := by
+  simp only [gridFacet, Finset.mem_image, Finset.mem_erase, Finset.mem_univ, and_true]
+
+/-- The deleted vertex is absent from its own grid facet. -/
+theorem gridVertices_not_mem_gridFacet (s : SpernerGrid.GridSimplex d N)
+    (k : Fin (d + 1)) : gridVertices s k ∉ gridFacet s k := by
+  rw [mem_gridFacet_iff]
+  rintro ⟨j, hjk, hj⟩
+  exact hjk (gridVertices_injective s hj)
+
+/-- Each grid facet carries exactly `d` vertices. -/
+theorem gridFacet_card (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    (gridFacet s k).card = d := by
+  rw [gridFacet, Finset.card_image_of_injective _ (gridVertices_injective s),
+    Finset.card_erase_of_mem (Finset.mem_univ k), Finset.card_univ, Fintype.card_fin]
+  omega
+
+/-- **The `d + 1` grid facets of a single cell are distinct.**  GridSimplex
+analogue of `facet_injective`; the within-cell half of `adj_unique_facet`. -/
+theorem gridFacet_injective (s : SpernerGrid.GridSimplex d N) :
+    Function.Injective (gridFacet s) := by
+  intro k₁ k₂ h
+  by_contra hne
+  have hmem : gridVertices s k₁ ∈ gridFacet s k₂ :=
+    (mem_gridFacet_iff s k₂ _).mpr ⟨k₁, hne, rfl⟩
+  rw [← h] at hmem
+  exact gridVertices_not_mem_gridFacet s k₁ hmem
+
+/-- The full vertex set of a grid cell is its `k`-th grid facet plus the deleted
+vertex `gridVertices s k`.  GridSimplex analogue of
+`image_univ_eq_insert_facet`. -/
+theorem gridImage_univ_eq_insert_gridFacet (s : SpernerGrid.GridSimplex d N)
+    (k : Fin (d + 1)) :
+    Finset.univ.image (gridVertices s) = insert (gridVertices s k) (gridFacet s k) := by
+  rw [gridFacet, ← Finset.image_insert, Finset.insert_erase (Finset.mem_univ k)]
+
+/-- The grid cell's Finset vertex set coerces to the range of its vertex map.
+GridSimplex analogue of `coe_image_univ_vertices`. -/
+theorem gridCoe_image_univ_vertices (s : SpernerGrid.GridSimplex d N) :
+    (↑(Finset.univ.image (gridVertices s)) : Set (SpernerNDim.Vertex d N))
+      = Set.range (gridVertices s) := by
+  rw [Finset.coe_image, Finset.coe_univ, Set.image_univ]
+
+/-- **A grid cell is determined by one facet and its opposite vertex (`d ≥ 2`).**
+GridSimplex analogue of `canon_eq_of_facet_and_vertex`, sound because no cell is
+omitted: both cells share the same full vertex set (facet ∪ {opposite vertex}),
+and `grid_eq_of_vertices_range hd` collapses that to cell equality. -/
+theorem grid_eq_of_facet_and_vertex (hd : 2 ≤ d) {s t : SpernerGrid.GridSimplex d N}
+    {k l : Fin (d + 1)}
+    (hface : gridFacet s k = gridFacet t l)
+    (hvert : gridVertices s k = gridVertices t l) : s = t := by
+  apply grid_eq_of_vertices_range hd
+  rw [← gridCoe_image_univ_vertices s, ← gridCoe_image_univ_vertices t,
+    gridImage_univ_eq_insert_gridFacet s k, gridImage_univ_eq_insert_gridFacet t l,
+    hface, hvert]
+
+/-- Two distinct grid facets of a cell union to all its vertices.  GridSimplex
+analogue of `facet_union_facet`. -/
+theorem gridFacet_union_gridFacet (s : SpernerGrid.GridSimplex d N)
+    {k₁ k₂ : Fin (d + 1)} (h : k₁ ≠ k₂) :
+    gridFacet s k₁ ∪ gridFacet s k₂ = Finset.univ.image (gridVertices s) := by
+  rw [gridFacet, gridFacet, ← Finset.image_union]
+  congr 1
+  apply Finset.eq_univ_of_forall
+  intro a
+  rw [Finset.mem_union, Finset.mem_erase, Finset.mem_erase]
+  by_cases ha : a = k₁
+  · exact Or.inr ⟨ha ▸ h, Finset.mem_univ _⟩
+  · exact Or.inl ⟨ha, Finset.mem_univ _⟩
+
+/-- A grid cell has exactly `d + 1` distinct Kuhn vertices.  GridSimplex
+analogue of `image_univ_card`. -/
+theorem gridImage_univ_card (s : SpernerGrid.GridSimplex d N) :
+    (Finset.univ.image (gridVertices s)).card = d + 1 := by
+  rw [Finset.card_image_of_injective _ (gridVertices_injective s), Finset.card_univ,
+    Fintype.card_fin]
+
+/-- **At most one neighbour across a grid facet (`adj_unique_facet`, `d ≥ 2`).**
+If a cell `s` shares two facets with the same other cell `t` (`s ≠ t`), then the
+two facet indices coincide.  GridSimplex analogue of `facet_unique_neighbor`,
+sound on the repaired carrier: the two distinct facets of `s` union to all of
+`s`'s vertices while both lie in `t`'s vertex set; equal cardinalities force
+equal vertex sets, and `grid_eq_of_vertices_range hd` gives `s = t`,
+contradicting `s ≠ t`. -/
+theorem gridFacet_unique_neighbor (hd : 2 ≤ d) {s t : SpernerGrid.GridSimplex d N}
+    {k₁ k₂ l₁ l₂ : Fin (d + 1)} (hne : s ≠ t)
+    (h₁ : gridFacet s k₁ = gridFacet t l₁) (h₂ : gridFacet s k₂ = gridFacet t l₂) :
+    k₁ = k₂ := by
+  by_contra hk
+  have hs : Finset.univ.image (gridVertices s) = gridFacet s k₁ ∪ gridFacet s k₂ :=
+    (gridFacet_union_gridFacet s hk).symm
+  have hsub : Finset.univ.image (gridVertices s) ⊆ Finset.univ.image (gridVertices t) := by
+    rw [hs, h₁, h₂]
+    apply Finset.union_subset
+    · rw [gridFacet]; exact Finset.image_subset_image (Finset.erase_subset _ _)
+    · rw [gridFacet]; exact Finset.image_subset_image (Finset.erase_subset _ _)
+  have hcard :
+      (Finset.univ.image (gridVertices t)).card ≤ (Finset.univ.image (gridVertices s)).card := by
+    rw [gridImage_univ_card, gridImage_univ_card]
+  have heq : Finset.univ.image (gridVertices s) = Finset.univ.image (gridVertices t) :=
+    Finset.eq_of_subset_of_card_le hsub hcard
+  apply hne
+  apply grid_eq_of_vertices_range hd
+  rw [← gridCoe_image_univ_vertices s, ← gridCoe_image_univ_vertices t, heq]
+
+/-- **Global facet/opposite-vertex coherence (`d ≥ 2`).**  The pair
+`(gridFacet s k, gridVertices s k)` identifies both the cell `s` and the index
+`k` across the entire `GridSimplex` carrier.  GridSimplex analogue of
+`facet_vertex_injective`: the cross-cell direction (`grid_eq_of_facet_and_vertex`)
+collapses the cell, then the within-cell direction (`gridFacet_injective`)
+collapses the index.  The `(facet, opposite-vertex)` payload of an `adj` entry
+names at most one `(cell, facet)` slot. -/
+theorem gridFacet_vertex_injective (hd : 2 ≤ d) :
+    Function.Injective
+      (fun p : SpernerGrid.GridSimplex d N × Fin (d + 1) =>
+        (gridFacet p.1 p.2, gridVertices p.1 p.2)) := by
+  rintro ⟨s, k⟩ ⟨t, l⟩ h
+  simp only [Prod.mk.injEq] at h
+  obtain ⟨hface, hvert⟩ := h
+  obtain rfl : s = t := grid_eq_of_facet_and_vertex hd hface hvert
+  obtain rfl : k = l := gridFacet_injective s hface
+  rfl
+
+-- ============================================================
+-- SECTION: The interior neighbour (face-gluing) relation (`d ≥ 2`)
+-- ============================================================
+-- The pivot machinery (`pivotSimplex`, `pivot_facet_eq`, `pivot_ne`,
+-- `pivot_involutive`) and the sound Kuhn-carrier facet combinatorics
+-- (`gridFacet`, `gridFacet_unique_neighbor`) are now both available.  This
+-- section ties them together into the constructive neighbour relation the
+-- door-counting `adj` records at chain-interior facets: `GridGlued s t` holds
+-- when `t` is the Freudenthal pivot of `s` across the facet opposite a vertex
+-- `a.succ` (for a consecutive Kuhn step pair `a.succ = b.castSucc`).  Each fact
+-- below is proved on the sound `GridSimplex`/`gridFacet` carrier and feeds a
+-- distinct `adj` obligation:
+--   * `pivot_gridFacet_eq` / `GridGlued.shares_facet` — glued cells share a Kuhn
+--     facet (the `adj` common-face datum);
+--   * `GridGlued.ne` — a glued neighbour is a *different* cell (no self-loops);
+--   * `GridGlued_symm` — the relation is symmetric (`adj_symm`), each facet-flip
+--     its own reverse, via the pivot involution `pivot_involutive`;
+--   * `exists_gridFacet_neighbor` — every chain-interior facet HAS such a
+--     neighbour (existence; uniqueness is the separate
+--     `gridFacet_unique_neighbor`, the only place `d ≥ 2` is needed).
+-- All 0-sorry, 0-axiom.  `d ≤ 1` orientation doubling is handled separately.
+
+/-- **The interior pivot preserves the shared Kuhn facet.**  Transports
+`pivot_facet_eq` — stated on the raw barycentric vertices — to the sound Kuhn
+carrier: `s` and its pivot across the facet opposite `a.succ` have the *same*
+`gridFacet · a.succ`.  Both Kuhn facets are the `toVertex`-image of one and the
+same barycentric facet `(univ.erase a.succ).image ·.verts`, equal by
+`pivot_facet_eq`.  This is the bridge that lets the door-counting `adj` cite the
+pivot neighbour directly on the `gridFacet` carrier it actually uses. -/
+theorem pivot_gridFacet_eq (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    gridFacet (pivotSimplex s a b hb) a.succ = gridFacet s a.succ := by
+  have key : ∀ u : SpernerGrid.GridSimplex d N,
+      gridFacet u a.succ
+        = ((Finset.univ.erase a.succ).image u.verts).image toVertex := by
+    intro u
+    have hgv : gridVertices u = toVertex ∘ u.verts := rfl
+    rw [gridFacet, hgv, ← Finset.image_image]
+  rw [key, key, pivot_facet_eq]
+
+/-- The constructive **interior face-gluing relation**: `t` is the Freudenthal
+pivot of `s` across the chain-interior facet opposite vertex `a.succ`, for a
+consecutive Kuhn step pair `a.succ = b.castSucc`.  This is the neighbour the
+door-counting `adj` records at every interior facet (the `d ≤ 1` orientation
+doubling is handled separately). -/
+def GridGlued (s t : SpernerGrid.GridSimplex d N) : Prop :=
+  ∃ (a b : Fin d) (hb : a.succ = b.castSucc), t = pivotSimplex s a b hb
+
+/-- **Every chain-interior facet has a glued neighbour.**  Given consecutive Kuhn
+steps `a.succ = b.castSucc`, the pivot is a cell distinct from `s` that shares the
+facet `gridFacet s a.succ`.  This is the existence half the `adj` discharge needs
+at interior facets — `pivotSimplex` supplies it; uniqueness is the separate
+`gridFacet_unique_neighbor`. -/
+theorem exists_gridFacet_neighbor (s : SpernerGrid.GridSimplex d N) (a b : Fin d)
+    (hb : a.succ = b.castSucc) :
+    ∃ t : SpernerGrid.GridSimplex d N,
+      GridGlued s t ∧ t ≠ s ∧ gridFacet t a.succ = gridFacet s a.succ :=
+  ⟨pivotSimplex s a b hb, ⟨a, b, hb, rfl⟩, pivot_ne s a b hb,
+    pivot_gridFacet_eq s a b hb⟩
+
+/-- A glued neighbour is a **different cell** (no self-loops in `adj`). -/
+theorem GridGlued.ne {s t : SpernerGrid.GridSimplex d N} (h : GridGlued s t) :
+    s ≠ t := by
+  obtain ⟨a, b, hb, rfl⟩ := h
+  exact (pivot_ne s a b hb).symm
+
+/-- **Glued cells share a Kuhn facet** (the `adj` common-face datum): if
+`GridGlued s t` then some facet of `t` equals some facet of `s`. -/
+theorem GridGlued.shares_facet {s t : SpernerGrid.GridSimplex d N}
+    (h : GridGlued s t) :
+    ∃ k : Fin (d + 1), gridFacet t k = gridFacet s k := by
+  obtain ⟨a, b, hb, rfl⟩ := h
+  exact ⟨a.succ, pivot_gridFacet_eq s a b hb⟩
+
+/-- **The interior face-gluing relation is symmetric** (`adj_symm`).  Each
+facet-flip is its own reverse: if `t` is the pivot of `s` across the facet
+opposite `a.succ`, then `s` is the pivot of `t` across the *same* facet, by the
+pivot involution `pivot_involutive`. -/
+theorem GridGlued_symm {s t : SpernerGrid.GridSimplex d N} (h : GridGlued s t) :
+    GridGlued t s := by
+  obtain ⟨a, b, hb, rfl⟩ := h
+  exact ⟨a, b, hb, (pivot_involutive s a b hb).symm⟩
+
+/-
+## Interior / boundary facet predicate
+
+The door-counting `adj` must split the `d+1` Kuhn facets of each cell into the
+chain-*interior* facets — those across which the Freudenthal pivot is defined and
+which therefore carry a glued neighbour — and the two geometric *boundary* facets
+(`k = 0` and `k = Fin.last d`), which have no interior partner.  The interior
+facets are exactly those opposite a vertex `a.succ` for a consecutive Kuhn step
+pair `a.succ = b.castSucc`; numerically these are the indices `0 < k < d`.
+All 0-sorry, 0-axiom.
+-/
+
+/-- A Kuhn facet index `k : Fin (d+1)` is **chain-interior** when it is the facet
+opposite an interior vertex `a.succ` for a consecutive Kuhn step pair
+`a.succ = b.castSucc`.  These are precisely the facets across which the
+Freudenthal pivot (`pivotSimplex`) is defined. -/
+def IsInteriorFacet (k : Fin (d + 1)) : Prop :=
+  ∃ a b : Fin d, a.succ = b.castSucc ∧ k = a.succ
+
+/-- **Numeric characterization of interior facets**: facet `k` is chain-interior
+iff `0 < k < d`, i.e. `k` is neither the bottom facet `0` nor the top facet
+`Fin.last d`.  (For `d ≤ 1` there are no interior facets, matching the fact that
+the orientation doubling there is handled separately.) -/
+theorem isInteriorFacet_iff (k : Fin (d + 1)) :
+    IsInteriorFacet k ↔ 0 < (k : ℕ) ∧ (k : ℕ) < d := by
+  constructor
+  · rintro ⟨a, b, hb, rfl⟩
+    have hb' : (a : ℕ) + 1 = (b : ℕ) := by
+      have h := congrArg Fin.val hb
+      rwa [Fin.val_succ, Fin.coe_castSucc] at h
+    have hbd : (b : ℕ) < d := b.isLt
+    rw [Fin.val_succ]; omega
+  · rintro ⟨hk0, hkd⟩
+    refine ⟨⟨(k : ℕ) - 1, by omega⟩, ⟨(k : ℕ), hkd⟩, ?_, ?_⟩
+    · apply Fin.ext; show (k : ℕ) - 1 + 1 = (k : ℕ); omega
+    · apply Fin.ext; show (k : ℕ) = (k : ℕ) - 1 + 1; omega
+
+/-- The bottom Kuhn facet (`k = 0`) is a geometric boundary facet, not interior. -/
+theorem not_isInteriorFacet_zero : ¬ IsInteriorFacet (0 : Fin (d + 1)) := by
+  rw [isInteriorFacet_iff, Fin.val_zero]; omega
+
+/-- The top Kuhn facet (`k = Fin.last d`) is a geometric boundary facet, not
+interior. -/
+theorem not_isInteriorFacet_last : ¬ IsInteriorFacet (Fin.last d) := by
+  rw [isInteriorFacet_iff, Fin.val_last]; omega
+
+/-- **Every interior facet carries a glued neighbour.**  Combining the predicate
+with `exists_gridFacet_neighbor`: if facet `k` is chain-interior, the Freudenthal
+pivot across it is a distinct cell sharing exactly that facet.  This is the total
+existence datum the door-counting `adj` records at every interior facet. -/
+theorem exists_neighbor_of_isInteriorFacet (s : SpernerGrid.GridSimplex d N)
+    {k : Fin (d + 1)} (hk : IsInteriorFacet k) :
+    ∃ t : SpernerGrid.GridSimplex d N,
+      GridGlued s t ∧ t ≠ s ∧ gridFacet t k = gridFacet s k := by
+  obtain ⟨a, b, hb, rfl⟩ := hk
+  exact exists_gridFacet_neighbor s a b hb
+
+/-- Chain-interiority of a facet is decidable (it reduces to the numeric test
+`0 < k < d` via `isInteriorFacet_iff`), so the door-counting `adj` can branch on
+it computably. -/
+instance : DecidablePred (IsInteriorFacet : Fin (d + 1) → Prop) := fun k =>
+  decidable_of_iff _ (isInteriorFacet_iff k).symm
+
+/-- A Kuhn facet is a **geometric boundary facet** when it is the bottom facet
+`0` or the top facet `Fin.last d` — the two facets of a chain with no interior
+Freudenthal pivot partner. -/
+def IsBoundaryFacet (k : Fin (d + 1)) : Prop := k = 0 ∨ k = Fin.last d
+
+/-- **Boundary = exactly not-interior.**  A Kuhn facet carries no glued (pivot)
+neighbour precisely when it is one of the two geometric boundary facets `0` or
+`Fin.last d`.  This pins down exactly which facets the door-counting `adj` must
+send to `none`, and is the index-level half of the eventual `boundary_face`
+obligation: the `none` facets are exactly `{0, Fin.last d}`. -/
+theorem not_isInteriorFacet_iff (k : Fin (d + 1)) :
+    ¬ IsInteriorFacet k ↔ IsBoundaryFacet k := by
+  rw [isInteriorFacet_iff, IsBoundaryFacet]
+  have hk : (k : ℕ) ≤ d := by have := k.isLt; omega
+  constructor
+  · intro h
+    rcases Nat.eq_zero_or_pos (k : ℕ) with h0 | h0
+    · exact Or.inl (Fin.ext (by rw [Fin.val_zero]; exact h0))
+    · exact Or.inr (Fin.ext (by rw [Fin.val_last]; omega))
+  · rintro (rfl | rfl)
+    · rw [Fin.val_zero]; omega
+    · rw [Fin.val_last]; omega
+
+/-- **Every Kuhn facet is interior or boundary** (the two cases are exhaustive).
+Together with `not_isInteriorFacet_iff` this is the clean dichotomy the door
+count rests on: each cell has chain-interior facets (each carrying a pivot
+neighbour) and the two boundary facets `0`, `Fin.last d`. -/
+theorem isInteriorFacet_or_boundary (k : Fin (d + 1)) :
+    IsInteriorFacet k ∨ IsBoundaryFacet k :=
+  (em (IsInteriorFacet k)).imp id (not_isInteriorFacet_iff k).mp
+
+/-- The two cases are **mutually exclusive**: a boundary facet is never interior. -/
+theorem not_isInteriorFacet_of_boundary {k : Fin (d + 1)} (h : IsBoundaryFacet k) :
+    ¬ IsInteriorFacet k := (not_isInteriorFacet_iff k).mpr h
+
+/-!
+## Boundary-face reduction to barycentric coordinates
+
+The abstract `SpernerTriangulation.boundary_face` obligation, specialised to the
+`gridVertices` carrier, asks that whenever the door-graph `adj` sends facet `k`
+to `none`, every *other* vertex of the cell lies on the geometric face `k`
+(`SpernerNDim.onFace _ k`).  Through the coordinate bridge `onFace_toVertex` this
+is a purely barycentric statement: it says the `k`-th barycentric coordinate of
+every vertex `j ≠ k` vanishes.
+
+This section records that reduction once and for all, as the exact goal a total
+`adj` must discharge at each facet it sends to `none`.  It does **not** decide
+*which* facets are `none`: pinning that down is the remaining cross-chain gluing
+frontier (a chain-boundary facet `k ∈ {0, Fin.last d}` that is interior to `Δ_N`
+is glued to a cell in a *different* Kuhn chain, which `pivotSimplex` does not
+produce — see the module header and `IsBoundaryFacet`).  Once that gluing (or a
+proof that such a facet lies on `∂Δ_N`) is in place, `boundary_face` follows from
+`boundary_face_iff_coords_zero` below.
+-/
+
+/-- **Carrier face condition = barycentric coordinate zero.**  A Kuhn vertex
+`gridVertices s j` lies on the geometric face `k` exactly when the `k`-th
+barycentric coordinate of the underlying grid vertex `s.verts j` is `0`.  This is
+just the bridge `onFace_toVertex` transported along the defeq
+`gridVertices s j = toVertex (s.verts j)`. -/
+@[simp] theorem gridVertices_onFace_iff
+    (s : SpernerGrid.GridSimplex d N) (j k : Fin (d + 1)) :
+    SpernerNDim.onFace (gridVertices s j) k ↔ (s.verts j).coords k = 0 := by
+  have h := onFace_toVertex (s.verts j) k
+  simpa [gridVertices, SpernerGrid.BaryPoint.onFace] using h
+
+/-- **Boundary-face obligation, reduced.**  For the `gridVertices` carrier, the
+`boundary_face` requirement at facet `k` — that every vertex `j ≠ k` lies on
+geometric face `k` — is equivalent to the barycentric statement that the `k`-th
+coordinate of every such `s.verts j` vanishes.  A total door-graph `adj` discharges
+`boundary_face` at each `none` facet `k` precisely by establishing the right-hand
+side here. -/
+theorem boundary_face_iff_coords_zero
+    (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    (∀ j : Fin (d + 1), j ≠ k → SpernerNDim.onFace (gridVertices s j) k) ↔
+    (∀ j : Fin (d + 1), j ≠ k → (s.verts j).coords k = 0) := by
+  constructor
+  · intro h j hj; exact (gridVertices_onFace_iff s j k).mp (h j hj)
+  · intro h j hj; exact (gridVertices_onFace_iff s j k).mpr (h j hj)
+
+/-- The facet indexed by the cell's `miss` direction is **never** a geometric
+boundary face (for `d ≥ 2`): its `boundary_face` coordinate condition fails.
+Indeed the `miss` coordinate decreases by exactly `1` per step
+(`GridSimplex.miss_coord_at`) from a base value `≥ d` (`GridSimplex.base_miss_ge_d`),
+so among the two distinct vertices `0` and `⟨1, …⟩` — at least one of which differs
+from the index `miss` — the one chosen still has `miss`-coordinate `≥ d - 1 ≥ 1 > 0`.
+This is one concrete witness that the geometric `none` facets are **not** simply
+read off the facet index, confirming the cross-chain frontier: the `miss` facet
+carries an interior (pivot) partner, never an `adj = none`.  (The `d ≤ 1`
+orientation-doubling case is handled separately.) -/
+theorem miss_not_boundary_face (s : SpernerGrid.GridSimplex d N) (hd : 2 ≤ d) :
+    ¬ (∀ j : Fin (d + 1), j ≠ s.miss → (s.verts j).coords s.miss = 0) := by
+  intro h
+  have hbase : d ≤ (s.verts 0).coords s.miss := s.base_miss_ge_d
+  have hlt : (1 : ℕ) < d + 1 := by omega
+  set v1 : Fin (d + 1) := ⟨1, hlt⟩ with hv1
+  have hv1val : v1.val = 1 := rfl
+  by_cases hm : s.miss = (0 : Fin (d + 1))
+  · -- miss = 0; use vertex v1 (≠ 0), whose miss-coord = base - 1 ≥ d - 1 ≥ 1
+    have hne : v1 ≠ s.miss := by
+      rw [hm]; exact Fin.ne_of_val_ne (by simp [hv1val])
+    have hmca : (s.verts v1).coords s.miss = (s.verts 0).coords s.miss - v1.val :=
+      s.miss_coord_at v1
+    have := h v1 hne
+    rw [hmca, hv1val] at this
+    omega
+  · -- miss ≠ 0; use vertex 0, whose miss-coord = base ≥ d ≥ 2 > 0
+    have hne : (0 : Fin (d + 1)) ≠ s.miss := fun hc => hm hc.symm
+    have := h 0 hne
+    omega
+
+/-!
+## Per-vertex evaluation of the reduced boundary-coordinate condition
+
+The previous section reduced `boundary_face` at a `none` facet `k` to the
+barycentric statement `∀ j ≠ k, (s.verts j).coords k = 0`
+(`boundary_face_iff_coords_zero`) but did **not** evaluate that coordinate
+condition.  This section does, vertex by vertex, exploiting the fact that
+`incDir : Fin d → Fin (d+1)` is a bijection onto the complement of `miss`
+(`incDir_surj_complement`): every barycentric coordinate is *either* the `miss`
+direction or exactly one increase direction `incDir k`.  So each
+`(s.verts m).coords c = 0` test resolves into one of two closed forms:
+
+  * **increase direction** `c = incDir k`: zero iff it starts at zero and step
+    `k` has not yet occurred (`m.val ≤ k.val`) — `coord_incDir_eq_zero_iff`;
+  * **miss direction** `c = miss`: zero iff `m` has reached the base value
+    `(s.verts 0).coords miss` — `miss_coord_eq_zero_iff` — which, since that base
+    value is `≥ d`, forces `m = Fin.last d` (`onFace_miss_imp_last`).
+
+These are the evaluation lemmas a total `adj` will feed into
+`boundary_face_iff_coords_zero`; they sharpen `miss_not_boundary_face` from a mere
+existence witness into a full localization of *which* vertices fail.  All
+0-sorry, 0-axiom.
+-/
+
+/-- **Vanishing of a non-miss coordinate, per vertex.**  The increase-direction
+coordinate `incDir k` is zero at chain vertex `m` exactly when it starts at zero
+(`(verts 0).coords (incDir k) = 0`) and step `k` has not yet been taken
+(`m.val ≤ k.val`).  Direct consequence of the per-vertex formula
+`coord_incDir_at`, which makes this coordinate `base + (1 if k < m else 0)`.
+Complements `boundary_face_iff_coords_zero`: it evaluates the reduced coordinate
+condition at every increase-direction facet. -/
+theorem coord_incDir_eq_zero_iff (s : SpernerGrid.GridSimplex d N) (k : Fin d)
+    (m : Fin (d + 1)) :
+    (s.verts m).coords (s.incDir k) = 0 ↔
+      (s.verts 0).coords (s.incDir k) = 0 ∧ m.val ≤ k.val := by
+  rw [s.coord_incDir_at k m]
+  by_cases h : k.val < m.val
+  · rw [if_pos h]; omega
+  · rw [if_neg h]; omega
+
+/-- **Vanishing of the miss coordinate, per vertex.**  The `miss` coordinate is
+zero at chain vertex `m` exactly when `m` has reached the base value:
+`(verts 0).coords miss ≤ m.val`.  Direct consequence of `miss_coord_at`
+(`miss` coordinate `= base - m`, truncated subtraction). -/
+theorem miss_coord_eq_zero_iff (s : SpernerGrid.GridSimplex d N)
+    (m : Fin (d + 1)) :
+    (s.verts m).coords s.miss = 0 ↔ (s.verts 0).coords s.miss ≤ m.val := by
+  rw [s.miss_coord_at m]; omega
+
+/-- **The miss coordinate is positive away from the last vertex.**  Because the
+base `miss` value is at least `d` and the coordinate only drops by one per step,
+every chain vertex `m ≠ Fin.last d` still has a strictly positive `miss`
+coordinate.  Sharpens `miss_not_boundary_face`: not merely *some* vertex but
+*every* non-last vertex violates the `miss`-facet boundary condition. -/
+theorem miss_coord_pos_of_ne_last (s : SpernerGrid.GridSimplex d N)
+    (m : Fin (d + 1)) (hm : m ≠ Fin.last d) :
+    0 < (s.verts m).coords s.miss := by
+  have hge := s.miss_coord_ge m
+  have hmd : m.val < d := by
+    have hle : m.val ≤ d := Nat.lt_succ_iff.mp m.isLt
+    rcases hle.lt_or_eq with h | h
+    · exact h
+    · exact absurd (Fin.ext (h.trans (Fin.val_last d).symm)) hm
+  omega
+
+/-- **The miss-face is reached only by the last vertex.**  If grid vertex `m` lies
+on the geometric `miss`-face (`(s.verts m).coords miss = 0`) then `m = Fin.last d`.
+The pointwise localization behind `miss_not_boundary_face`: the geometric
+`miss`-boundary touches a Freudenthal cell only at the extreme end of its chain
+(and only in the extremal cell whose base `miss = d`). -/
+theorem onFace_miss_imp_last (s : SpernerGrid.GridSimplex d N) (m : Fin (d + 1))
+    (h : (s.verts m).coords s.miss = 0) : m = Fin.last d := by
+  by_contra hm
+  exact absurd h (Nat.pos_iff_ne_zero.mp (miss_coord_pos_of_ne_last s m hm))
+
+/-!
+## The total door-graph neighbour map
+
+The interior/boundary dichotomy (`isInteriorFacet_or_boundary`,
+`not_isInteriorFacet_iff`) and the interior-facet existence datum
+(`exists_neighbor_of_isInteriorFacet`) are assembled here into a single
+`Option`-valued neighbour function on Freudenthal cells: an interior Kuhn facet `k`
+is sent to its glued pivot partner, and the two geometric boundary facets
+`0`, `Fin.last d` are sent to `none`.
+
+This is the concrete `adj`-shaped datum the abstract door-counting argument
+consumes.  Its `= none` fibre is *exactly* `{0, Fin.last d}`
+(`gridNeighbor_eq_none_iff`), so the index-level `boundary_face` bookkeeping reads
+off the facet index directly; on every interior facet it returns a genuine glued,
+distinct, facet-sharing neighbour (`gridNeighbor_spec`).  (The remaining content
+of `adj` — that a chain-boundary facet interior to `Δ_N` is glued *across* Kuhn
+chains — is the cross-chain frontier flagged in the module header and is not
+produced by `pivotSimplex`; this map records the within-chain pivot structure.)
+All 0-sorry; only the standard `Classical.choice` is used (to select the partner).
+-/
+
+/-- **Total neighbour map of the Freudenthal door graph.**  An interior facet `k`
+is sent to its glued pivot partner (chosen via `exists_neighbor_of_isInteriorFacet`);
+a boundary facet (`0` or `Fin.last d`) is sent to `none`. -/
+noncomputable def gridNeighbor (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    Option (SpernerGrid.GridSimplex d N) :=
+  if hk : IsInteriorFacet k then
+    some (Classical.choose (exists_neighbor_of_isInteriorFacet s hk))
+  else none
+
+/-- **The `none` fibre is exactly the geometric boundary.**  `gridNeighbor s k`
+returns `none` precisely at the two boundary facets `k ∈ {0, Fin.last d}`. -/
+theorem gridNeighbor_eq_none_iff (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    gridNeighbor s k = none ↔ IsBoundaryFacet k := by
+  unfold gridNeighbor
+  by_cases hk : IsInteriorFacet k
+  · simp only [dif_pos hk]
+    constructor
+    · intro h; exact absurd h (by simp)
+    · intro h; exact absurd hk (not_isInteriorFacet_of_boundary h)
+  · simp only [dif_neg hk]
+    exact iff_of_true trivial ((not_isInteriorFacet_iff k).mp hk)
+
+/-- **Interior facets get a genuine glued partner.**  On an interior facet `k` the
+neighbour map returns `some t` where `t` is a distinct cell glued to `s` and
+sharing the facet `k`. -/
+theorem gridNeighbor_spec (s : SpernerGrid.GridSimplex d N) {k : Fin (d + 1)}
+    (hk : IsInteriorFacet k) :
+    ∃ t : SpernerGrid.GridSimplex d N, gridNeighbor s k = some t ∧
+      GridGlued s t ∧ t ≠ s ∧ gridFacet t k = gridFacet s k := by
+  refine ⟨Classical.choose (exists_neighbor_of_isInteriorFacet s hk), ?_,
+    Classical.choose_spec (exists_neighbor_of_isInteriorFacet s hk)⟩
+  unfold gridNeighbor; rw [dif_pos hk]
+
+/-- A boundary facet is sent to `none` (the convenient direction of
+`gridNeighbor_eq_none_iff`). -/
+theorem gridNeighbor_boundary (s : SpernerGrid.GridSimplex d N) {k : Fin (d + 1)}
+    (hk : IsBoundaryFacet k) : gridNeighbor s k = none :=
+  (gridNeighbor_eq_none_iff s k).mpr hk
+
+/-- The neighbour map is defined (returns `some`) at exactly the interior facets. -/
+theorem gridNeighbor_isSome_iff (s : SpernerGrid.GridSimplex d N) (k : Fin (d + 1)) :
+    (gridNeighbor s k).isSome ↔ IsInteriorFacet k := by
+  rw [Option.isSome_iff_ne_none, ne_eq, gridNeighbor_eq_none_iff]
+  constructor
+  · intro h; exact (isInteriorFacet_or_boundary k).resolve_right h
+  · intro h hb; exact not_isInteriorFacet_of_boundary hb h
 -- ============================================================
 -- SECTION: Barycentric facet algebra
 -- ============================================================

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1969,3 +1969,46 @@ true `adj` still needs the cross-chain gluing (or a proof such facets lie on `�
 2. Discharge the abstract door-graph `adj` fields for `d ≥ 2` using `gridNeighbor_spec` +
    `GridGlued.{ne,shares_facet}`, `GridGlued_symm`, `gridFacet_unique_neighbor`.
 3. Phase 2: last-face door oddness induction on `d`; apply `sperner_ndim`.
+
+## Session 2026-06-30 (researcher-3) — REGRESSION RECOVERY: restore pivot/neighbour/boundary machinery
+
+**Mode**: ACT (recovery). **Outcome**: PROGRESS — recovered ~1300 lines / ~70 verified
+declarations that were silently deleted from `main`, and re-integrated them with the newer
+bridge section. **PR #31750**, docker-build VERIFIED, 0-sorry / 0-axiom.
+
+### The regression (important — check before extending this file)
+`SpernerNDimOQ02.lean` was **1772 lines** after #31443 (per-vertex boundary evaluation) and
+#31495 (`gridNeighbor` total door-graph neighbour map). On 2026-06-30 PR **#30947** (the
+older *barycentric facet algebra bridge*, a LOW-numbered PR merged LATE) squash-merged from
+a base predating that work and **overwrote the file back to 464 lines**, dropping ~70 decls:
+`pivotSimplex`, `pivot_involutive`, `pivotPoint`, `GridGlued`, `gridNeighbor`,
+`gridNeighbor_spec`, `exists_neighbor_of_isInteriorFacet`, `IsInteriorFacet`/`IsBoundaryFacet`,
+`isInteriorFacet_iff`, `boundary_face_iff_coords_zero`, `coord_incDir_eq_zero_iff`,
+`miss_coord_eq_zero_iff`, `gridFacet*`, `baseOf*`, etc. The 464-line version kept only the
+8 new bridge decls (`baryFacet`, `facet_eq_iff_baryFacet_eq`, `canon_eq_of_baryFacet_and_vertex`, …).
+
+### What was delivered
+Rebuilt the file as the UNION: base = 1772-version (`ee81c8ebb30`), then appended the 8 new
+bridge decls from the 464-version (`09b7a20b816`). Shared foundational decls (`facet`,
+`canon_eq_of_facet_and_vertex`, `CanonSimplex`, `toVertex`) are byte-identical across both,
+so the append composes. Result: **1897 L, 110 decls, 0-sorry, 0-axiom**; docker-build clean;
+`#print axioms` on restored+new decls = `[propext, Classical.choice, Quot.sound]`.
+
+### How to reproduce the merge (if it regresses again)
+`git show ee81c8ebb30:proofs/Proofs/SpernerNDimOQ02.lean` (1772, has gridNeighbor) is the base;
+append lines 360–464 of `git show 09b7a20b816:...` (the "Barycentric facet algebra" section)
+after dropping the base's trailing `end SpernerNDimOQ02`.
+
+### Frontier UNCHANGED
+The genuine blocker is still the **cross-chain gluing**: a chain-boundary facet
+`k ∈ {0, Fin.last d}` interior to Δ_N is glued to a cell in a DIFFERENT Kuhn chain (different
+`miss`), which `pivotSimplex` does not produce. `gridNeighbor` sends every boundary facet to
+`none`. Turning that into the true `adj` needs either the cross-`miss` partner construction or
+a proof such facets lie on ∂Δ_N. This recovery does NOT advance that — it re-establishes the
+toolkit needed to attack it.
+
+### Next steps
+1. **(crux, unchanged)** Cross-chain `adj` for boundary facets interior to Δ_N.
+2. Discharge abstract door-graph `adj` fields for `d ≥ 2` from `gridNeighbor_spec` +
+   `GridGlued.{ne,shares_facet}`, `GridGlued_symm`, `gridFacet_unique_neighbor`.
+3. Phase 2: last-face door oddness induction on `d`; apply `sperner_ndim`.

--- a/research/problems/sperner-ndim-oq-02/state.md
+++ b/research/problems/sperner-ndim-oq-02/state.md
@@ -4,7 +4,13 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-23T00:00:00Z
-**Iteration**: 8
+**Iteration**: 9
+
+> **Session 9 (2026-06-30, researcher-3): REGRESSION RECOVERY (PR #31750).** The
+> 1772-line pivot/neighbour/boundary machinery (#31443/#31495) was clobbered back to
+> 464 lines by the stale-base squash merge of #30947. Rebuilt `SpernerNDimOQ02.lean`
+> as the union of both (1897 L, 110 decls, 0-sorry/0-axiom, docker-build clean). The
+> cross-chain-gluing frontier is UNCHANGED. See knowledge.md "Session 2026-06-30".
 
 > **Session 7 (2026-06-27, researcher-7): Phase-1 cell machinery landed + VERIFIED.**
 > Built the self-contained, compiling cell foundation the Phase-1 `SpernerTriangulation`

--- a/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,109 @@
+[
+  {
+    "id": "ann-cramer-oq020101-01-defs",
+    "proofId": "cramers-rule-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 90
+    },
+    "type": "concept",
+    "title": "Two Operations, Separated",
+    "content": "Defines the multiplication count `gaussMults n = ∑_{j<n} j²`, the division count `gaussDivs n = ∑_{j<n} j`, and the lumped `gaussOps n = ∑_{j<n} (j² + j)` of the parent entry. At the elimination step with `j` rows below the pivot, each of those `j` rows costs one division (forming the multiplier) and `j` multiplications (scaling its trailing entries) — `j` divisions and `j²` multiplications per step. The file imports only Mathlib and re-derives the lumped count locally, so it stands alone.",
+    "mathContext": "$\\texttt{gaussMults}\\,n = \\sum_{j<n} j^2$, $\\texttt{gaussDivs}\\,n = \\sum_{j<n} j$, $\\texttt{gaussOps}\\,n = \\sum_{j<n} (j^2+j)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gaussian-elimination",
+      "operation-count",
+      "finite-sums"
+    ],
+    "prerequisites": [
+      "Lean-imports",
+      "Mathlib"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq020101-02-split",
+    "proofId": "cramers-rule-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "The Split",
+    "content": "`gaussOps_split` shows the lumped count is exactly multiplications plus divisions: `∑_{j<n} (j²+j) = gaussMults n + gaussDivs n`, immediate from `Finset.sum_add_distrib`. Everything downstream analyses the two summands separately.",
+    "mathContext": "$\\sum_{j<n}(j^2+j) = \\sum_{j<n} j^2 + \\sum_{j<n} j$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_add_distrib",
+      "operation-count"
+    ],
+    "prerequisites": [
+      "finite-sums"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq020101-03-divisions",
+    "proofId": "cramers-rule-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 135
+    },
+    "type": "theorem",
+    "title": "Divisions are the Triangular Numbers C(n,2)",
+    "content": "`gaussDivs_closed` proves `2·gaussDivs n + n = n²` by a subtraction-free induction in the ℕ semiring (calc + ring), and `gaussDivs_eq_choose` matches it to `n.choose 2` via `Nat.choose_two_right` and `Nat.mul_div_cancel_left`. So the division count is `(n²−n)/2 = C(n,2)` — the triangular numbers, a purely Θ(n²) quantity.",
+    "mathContext": "$\\texttt{gaussDivs}\\,n = \\tfrac{n(n-1)}{2} = \\binom{n}{2}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "triangular-numbers",
+      "binomial-coefficients",
+      "Nat.choose_two_right"
+    ],
+    "prerequisites": [
+      "induction",
+      "binomial-coefficients"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq020101-04-multiplications",
+    "proofId": "cramers-rule-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 137,
+      "endLine": 162
+    },
+    "type": "theorem",
+    "title": "Multiplications Carry the n³/3",
+    "content": "`gaussMults_closed` proves `6·gaussMults n + 3n² = 2n³ + n` (so `gaussMults n = (2n³−3n²+n)/6 ≈ n³/3`), and `gaussMults_le_third` proves `6·gaussMults n ≤ 2n³` by induction with `nlinarith` on the successor expansion. Together they pin the leading constant of the multiplication count at exactly 1/3.",
+    "mathContext": "$\\texttt{gaussMults}\\,n = \\sum_{j<n} j^2 = \\tfrac{2n^3-3n^2+n}{6} \\sim \\tfrac{n^3}{3}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "square-pyramidal-number",
+      "asymptotic-leading-constant"
+    ],
+    "prerequisites": [
+      "induction",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq020101-05-dominance",
+    "proofId": "cramers-rule-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 164,
+      "endLine": 194
+    },
+    "type": "theorem",
+    "title": "Divisions Subdominant; Recovering the Lumped Count",
+    "content": "`gaussDivs_le_mults` proves `gaussDivs n ≤ gaussMults n` term by term (`Finset.sum_le_sum` with `j ≤ j²`), and `gaussDivs_lt_mults` strengthens it to strict for `n ≥ 3` via `nlinarith` on the two closed forms — the Θ(n²) divisions vanish beside the cubic multiplications. `gaussOps_closed` (`3·gaussOps n + n = n³`) then recovers the parent's `(n³ − n)/3` from the split.",
+    "mathContext": "$\\texttt{gaussDivs}\\,n \\le \\texttt{gaussMults}\\,n$, and $3\\,\\texttt{gaussOps}\\,n + n = n^3$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_le_sum",
+      "asymptotic-dominance",
+      "operation-count"
+    ],
+    "prerequisites": [
+      "finite-sums",
+      "nlinarith"
+    ]
+  }
+]

--- a/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CramersRuleOQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cramersRuleOq02Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cramersRuleOq02Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cramersRuleOq02Oq01Oq01Data: ProofData = {
+  proof: cramersRuleOq02Oq01Oq01Proof,
+  annotations: cramersRuleOq02Oq01Oq01Annotations,
+}

--- a/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "cramers-rule-oq-02-oq-01-oq-01",
+  "title": "Splitting the n³/3 Flop Count: Multiplications vs Divisions",
+  "slug": "cramers-rule-oq-02-oq-01-oq-01",
+  "description": "An axiom-free Lean 4 proof that the exact (n³ − n)/3 multiply/divide count of forward Gaussian elimination splits into a cubic multiplication count ∑_{j<n} j² (carrying the entire n³/3) and a quadratic division count ∑_{j<n} j = C(n,2) (the triangular numbers, Θ(n²) and subdominant). Refines the parent's lumped count by showing the 1/3 leading constant is purely a multiplication count.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_elimination#Computational_efficiency",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CramersRuleOQ02OQ01OQ01.lean",
+    "tags": [
+      "computational-complexity",
+      "linear-algebra",
+      "combinatorics",
+      "gaussian-elimination",
+      "cramer",
+      "algorithms",
+      "finset-sum",
+      "binomial-coefficients",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peeling the last term of a range sum: ∑_{x<n+1} f x = ∑_{x<n} f x + f n",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_add_distrib",
+        "description": "Distributing a sum over a pointwise addition: ∑ (f + g) = ∑ f + ∑ g",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_le_sum",
+        "description": "Monotonicity of a finite sum under a pointwise inequality of summands",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Nat.choose_two_right",
+        "description": "n.choose 2 = n * (n - 1) / 2 — the triangular-number form of the binomial",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel_left",
+        "description": "Exact division cancellation: 0 < b → b * a / b = a",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "Operation split gaussOps_split: the parent's lumped multiply/divide count ∑_{j<n} (j²+j) factors as gaussMults n + gaussDivs n, separating the j² multiplications from the j divisions performed at the step with j rows below the pivot",
+      "Division count is purely quadratic: gaussDivs_closed (2·gaussDivs n + n = n²) identifies the divisions with the triangular numbers (n²−n)/2, and gaussDivs_eq_choose proves gaussDivs n = C(n,2) via Nat.choose_two_right",
+      "Multiplication count carries the cubic term: gaussMults_closed (6·gaussMults n + 3n² = 2n³ + n), i.e. gaussMults n = (2n³−3n²+n)/6 ≈ n³/3, with gaussMults_le_third (6·gaussMults n ≤ 2n³) pinning the leading constant at exactly 1/3",
+      "Divisions are subdominant: gaussDivs_le_mults (gaussDivs n ≤ gaussMults n for all n, via Finset.sum_le_sum and the pointwise j ≤ j²) and gaussDivs_lt_mults (strict for n ≥ 3) show the Θ(n²) divisions vanish into the lower-order terms",
+      "Recovers the parent's lumped closed form gaussOps_closed: 3·gaussOps n + n = n³, now decomposed as a cubic multiplication count plus a quadratic division count",
+      "Concrete split counts split_small (multiplications 1,5,14,30 and divisions 1,3,6,10 for n=2..5) derived from the Finset sums, no native_decide"
+    ],
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 194,
+    "assumptions": "None. Fully kernel-checked: 0 sorries, 0 axiom declarations, 0 assumption-carrying structures, and no native_decide (#print axioms reports only propext, Classical.choice, Quot.sound; no Lean.ofReduceBool, no sorryAx). The file is self-contained — it imports only Mathlib and re-derives the lumped count locally, so it carries no dependency on the parent file.",
+    "theoremCount": 12,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "**Which operation carries the n³/3?**\n\nThe textbook 'n³/3 flop' figure for Gaussian elimination counts multiplications and divisions together. The parent entry (cramers-rule-oq-02-oq-01) formalized this lumped count as gaussExactOps n = ∑_{j<n} (j² + j) = (n³ − n)/3. But the per-step summand j² + j conflates two genuinely different arithmetic operations: j² multiplications (scaling trailing entries) and j divisions (forming multipliers). This entry asks which of the two is responsible for the cubic leading term — and how negligible the other is.",
+    "problemStatement": "**The Research Question (cramers-rule-oq-02-oq-01-oq-01)**\n\nSplit the lumped multiply/divide count gaussOps n = ∑_{j<n} (j² + j) into its multiplication part gaussMults n = ∑_{j<n} j² and division part gaussDivs n = ∑_{j<n} j, and determine the exact closed form and asymptotic role of each.\n\n**Answer:** The multiplications carry the entire n³/3, while the divisions are only Θ(n²):\n1. gaussMults n = (2n³ − 3n² + n)/6 ≈ n³/3, with 6·gaussMults n ≤ 2n³.\n2. gaussDivs n = (n² − n)/2 = C(n,2), the triangular numbers.\n3. gaussDivs n ≤ gaussMults n for all n (strict for n ≥ 3), so the divisions are subdominant; their sum recovers the parent's (n³ − n)/3.",
+    "text": "An axiom-free Lean 4 proof that the (n³ − n)/3 multiply/divide count of forward Gaussian elimination splits into a cubic ∑_{j<n} j² multiplication count (the whole n³/3) and a quadratic ∑_{j<n} j = C(n,2) division count, with the divisions provably subdominant.",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Definitions**: gaussMults n = ∑_{j∈range n} j² (multiplications), gaussDivs n = ∑_{j∈range n} j (divisions), and the lumped gaussOps n = ∑_{j∈range n} (j² + j).\n2. **Split**: gaussOps_split is immediate from Finset.sum_add_distrib.\n3. **One-step lemmas**: gaussMults_succ and gaussDivs_succ by Finset.sum_range_succ.\n4. **Closed forms by induction (subtraction-free, ℕ semiring)**: 2·gaussDivs n + n = n² and 6·gaussMults n + 3n² = 2n³ + n, each closing with a three-line calc + ring.\n5. **Binomial identity**: gaussDivs_eq_choose rewrites Nat.choose_two_right and matches the closed form via Nat.mul_div_cancel_left.\n6. **Cubic bound by induction**: gaussMults_le_third (6·gaussMults n ≤ 2n³) via nlinarith on the successor expansion.\n7. **Dominance**: gaussDivs_le_mults from Finset.sum_le_sum with the pointwise j ≤ j²; gaussDivs_lt_mults strict for n ≥ 3 via nlinarith on the two closed forms.\n8. **Recovery**: gaussOps_closed (3·gaussOps n + n = n³) from the split plus the two closed forms.",
+    "keyInsights": [
+      "**The 1/3 is a multiplication constant, not a multiply/divide constant**: gaussMults_closed plus gaussMults_le_third show ∑_{j<n} j² already carries the full n³/3; the divisions contribute nothing to the leading term.",
+      "**Divisions are exactly the triangular numbers**: gaussDivs n = C(n,2) = (n² − n)/2 is the clean binomial identity behind 'one division per row below each pivot', a purely Θ(n²) cost.",
+      "**Subtraction-free closed forms keep induction in ℕ**: stating 2·gaussDivs n + n = n² and 6·gaussMults n + 3n² = 2n³ + n (rather than the division forms) lets plain ring close each successor step in the ℕ semiring; the C(n,2) and /6 forms are corollaries.",
+      "**Pointwise domination gives the asymptotic comparison cheaply**: gaussDivs n ≤ gaussMults n follows term by term from j ≤ j² via Finset.sum_le_sum, no closed form needed — and nlinarith on the two closed forms upgrades it to strict for n ≥ 3.",
+      "**Axiom-free throughout**: the concrete small-n counts come from the Finset sums and the bounds from nlinarith/omega over the closed-form atoms, so the file uses no native_decide and #print axioms shows only the three foundational axioms."
+    ],
+    "prerequisites": [
+      "Numerical linear algebra (Gaussian elimination, multiplier/division vs trailing-entry multiplication)",
+      "Finite sums and their polynomial closed forms (∑ j, ∑ j², triangular and square-pyramidal numbers)",
+      "Binomial coefficients (C(n,2) as the triangular numbers) and elementary ℕ induction in Lean"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Definitions",
+      "summary": "Imports Mathlib and defines the multiplication count gaussMults n = ∑_{j<n} j², the division count gaussDivs n = ∑_{j<n} j, and the lumped gaussOps n = ∑_{j<n} (j² + j). Self-contained: no dependency on the parent file.",
+      "startLine": 1,
+      "endLine": 90,
+      "mathContext": "Separates the two arithmetic operations the parent entry counted together at each elimination step: j² multiplications and j divisions when j rows remain below the pivot."
+    },
+    {
+      "id": "split",
+      "title": "The Operation Split",
+      "summary": "gaussOps_split: ∑_{j<n} (j²+j) = gaussMults n + gaussDivs n, immediate from Finset.sum_add_distrib.",
+      "startLine": 91,
+      "endLine": 110,
+      "mathContext": "Exhibits the lumped multiply/divide count as the sum of its two constituent operation counts."
+    },
+    {
+      "id": "divisions",
+      "title": "Divisions: the Triangular Numbers C(n,2)",
+      "summary": "gaussDivs_closed (2·gaussDivs n + n = n²) and gaussDivs_eq_choose (gaussDivs n = n.choose 2) identify the division count with the triangular numbers, a purely Θ(n²) quantity.",
+      "startLine": 111,
+      "endLine": 140,
+      "mathContext": "One division per row below each pivot sums to ∑_{j<n} j = C(n,2) = (n²−n)/2."
+    },
+    {
+      "id": "multiplications",
+      "title": "Multiplications: the Cubic n³/3",
+      "summary": "gaussMults_closed (6·gaussMults n + 3n² = 2n³ + n) and gaussMults_le_third (6·gaussMults n ≤ 2n³) show the multiplications carry the entire n³/3 leading term.",
+      "startLine": 141,
+      "endLine": 165,
+      "mathContext": "∑_{j<n} j² = (2n³−3n²+n)/6 is the square-pyramidal closed form, asymptotically n³/3."
+    },
+    {
+      "id": "dominance",
+      "title": "Divisions are Subdominant; Recovery of the Lumped Count",
+      "summary": "gaussDivs_le_mults (≤ for all n) and gaussDivs_lt_mults (strict for n ≥ 3) show the Θ(n²) divisions are dominated by the cubic multiplications; gaussOps_closed (3·gaussOps n + n = n³) recovers the parent's (n³ − n)/3 from the split.",
+      "startLine": 166,
+      "endLine": 194,
+      "mathContext": "Term-by-term j ≤ j² gives the domination; summing the two closed forms returns the parent's lumped count."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry decomposes the parent's exact (n³ − n)/3 multiply/divide count of forward Gaussian elimination into its two constituent operations: the multiplications ∑_{j<n} j² = (2n³−3n²+n)/6 ≈ n³/3, which carry the entire cubic leading term, and the divisions ∑_{j<n} j = C(n,2) = (n²−n)/2, the triangular numbers, which are only Θ(n²). The closed forms are proved by short subtraction-free inductions in the ℕ semiring, the binomial identity via Nat.choose_two_right, the cubic bound by nlinarith, and the domination gaussDivs n ≤ gaussMults n term by term via Finset.sum_le_sum. The file is axiom-free (no sorries, no native_decide) and self-contained.",
+    "implications": "The refinement shows that the famous 1/3 leading constant of the Gaussian-elimination flop count is purely a multiplication constant — the divisions, though one per eliminated entry, sum only to the quadratic triangular number C(n,2) and disappear into the lower-order terms. This matters for cost models that weight multiplications and divisions differently (e.g. on hardware where division is far more expensive than multiplication): the division work is asymptotically negligible, so a high per-division cost still leaves the n³/3 multiplication term in charge. The subtraction-free 'k·sum + remainder = closed form' template again keeps every induction inside the ℕ semiring, reusable for any exact polynomial operation count.",
+    "openQuestions": [
+      "Weight the two operation classes by realistic hardware costs (division ≫ multiplication) and confirm the leading n³/3 term is unaffected once the Θ(n²) divisions are scaled.",
+      "Extend the multiplication/division split to the back-substitution phase (≈ n²/2) and to blocked/partial-pivoting LU, tracking how pivoting redistributes divisions without changing the cubic multiplication count.",
+      "Formalize the square-pyramidal identity ∑_{j<n} j² = C(n+1,2) + 2·C(n+1,3) to connect the multiplication count directly to binomial coefficients, paralleling the divisions = C(n,2) result."
+    ]
+  },
+  "relatedProblems": [
+    "cramers-rule-oq-02-oq-01",
+    "cramers-rule-oq-02",
+    "cramers-rule"
+  ],
+  "mainTheorems": [
+    {
+      "name": "gaussOps_split",
+      "statement": "gaussOps n = gaussMults n + gaussDivs n",
+      "description": "The lumped multiply/divide count splits into the multiplication count ∑_{j<n} j² and the division count ∑_{j<n} j."
+    },
+    {
+      "name": "gaussDivs_eq_choose",
+      "statement": "gaussDivs n = n.choose 2",
+      "description": "The division count equals the binomial C(n,2) — the triangular numbers, a purely Θ(n²) quantity."
+    },
+    {
+      "name": "gaussMults_le_third",
+      "statement": "6 * gaussMults n ≤ 2 * n ^ 3",
+      "description": "The multiplications alone are ≤ n³/3; with gaussMults_closed this pins the leading constant of the multiplication count at exactly 1/3."
+    },
+    {
+      "name": "gaussDivs_le_mults",
+      "statement": "gaussDivs n ≤ gaussMults n",
+      "description": "The divisions are subdominant: term by term j ≤ j², so the cubic multiplications dominate the quadratic divisions."
+    },
+    {
+      "name": "gaussOps_closed",
+      "statement": "3 * gaussOps n + n = n ^ 3",
+      "description": "Recovers the parent's lumped (n³ − n)/3 count from the split of a cubic multiplication count and a quadratic division count."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/CramersRuleOQ02OQ01OQ01.lean",
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 3,
+    "lineCount": 194
+  },
+  "references": [
+    {
+      "title": "Gaussian elimination — Computational efficiency (operation count)",
+      "url": "https://en.wikipedia.org/wiki/Gaussian_elimination#Computational_efficiency"
+    },
+    {
+      "title": "Square pyramidal number — ∑ j² closed form",
+      "url": "https://en.wikipedia.org/wiki/Square_pyramidal_number"
+    },
+    {
+      "title": "Triangular number — ∑ j = C(n,2)",
+      "url": "https://en.wikipedia.org/wiki/Triangular_number"
+    }
+  ],
+  "crossReferences": [],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Recovers ~1300 lines of previously-verified Phase-1 infrastructure for `sperner-ndim-oq-02` that was silently deleted from `main` by a stale-base squash merge.

### What happened

`SpernerNDimOQ02.lean` grew to **1772 lines** across #31443 and #31495 (per-vertex boundary evaluation + total door-graph neighbour map `gridNeighbor`). On 2026-06-30, PR #30947 (the older *barycentric facet algebra bridge*, a low-numbered PR merged late) was squash-merged **from a base predating that work**, overwriting the file back down to **464 lines** and dropping ~70 verified declarations:

`pivotSimplex`, `pivot_involutive`, `pivotPoint`, `GridGlued`, `GridGlued_symm`, `gridNeighbor`, `gridNeighbor_spec`, `gridNeighbor_eq_none_iff`, `exists_neighbor_of_isInteriorFacet`, `IsInteriorFacet`/`IsBoundaryFacet`, `isInteriorFacet_iff`, `boundary_face_iff_coords_zero`, `coord_incDir_eq_zero_iff`, `miss_coord_eq_zero_iff`, `gridFacet`/`gridFacet_unique_neighbor`, `baseOf`/`baseOf_canon`, and more.

### What this PR does

Rebuilds the file as the **union** of both lines of work:

- **Base** = the 1772-line version (#31495) with the full pivot / neighbour / boundary machinery.
- **Appended** = the 8 new bridge declarations from #30947 (`baryFacet`, `mem_baryFacet_iff`, `facet_eq_image_baryFacet`, `baryFacet_card`, `verts_not_mem_baryFacet`, `baryFacet_injective`, `facet_eq_iff_baryFacet_eq`, `canon_eq_of_baryFacet_and_vertex`).

The shared foundational declarations (`facet`, `canon_eq_of_facet_and_vertex`, `CanonSimplex`, `toVertex`, …) are byte-identical between the two versions, so the append composes cleanly.

### Verification

- **1897 lines, 110 declarations, 0 sorries, 0 `axiom` declarations**
- `./proofs/scripts/docker-build.sh Proofs.SpernerNDimOQ02` → `Built Proofs.SpernerNDimOQ02` (0 errors, 0 warnings)
- `#print axioms` on restored + new decls (`gridNeighbor_spec`, `pivot_involutive`, `boundary_face_iff_coords_zero`, `facet_eq_iff_baryFacet_eq`, `canon_eq_of_baryFacet_and_vertex`, `exists_neighbor_of_isInteriorFacet`) → `[propext, Classical.choice, Quot.sound]` only

No new mathematics is claimed here — this is a recovery of verified work plus its integration with the newer section. The genuine frontier (cross-chain gluing for chain-boundary facets interior to Δ_N) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)