### PR TITLE
Fix: realign szemeredi-counting lineCount (1196→1231) and theoremCount (14→13)

### DIFF
--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -54,10 +54,10 @@
       "Triangle counting and subgraph enumeration",
       "Roth's theorem on 3-term arithmetic progressions"
     ],
-    "lineCount": 1196,
+    "lineCount": 1231,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 7
   },
   "overview": {
@@ -181,9 +181,9 @@
       "Szemeredi.Core"
     ],
     "namespace": "Szemeredi.Counting",
-    "lineCount": 1196,
+    "lineCount": 1231,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 7,
     "path": "Proofs/SzemerediCounting.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

`szemeredi-counting` meta.json drifted from its Lean source after growth. Realigned both `leanFile` and `meta` blocks.

## Evidence

**Before**: lineCount=1196, theoremCount=14
**After**: lineCount=1231, theoremCount=13

Ground truth via canonical extractor (`scripts/research/enrich-research.ts`). axiomCount=0, definitionCount=7, sorries=0 unchanged.

---
Automated fix by lean-mechanic agent.