### PR TITLE
Fix: realign erdos-286 lineCount (236→264) and theoremCount (7→8)

### DIFF
--- a/src/data/proofs/erdos-286/meta.json
+++ b/src/data/proofs/erdos-286/meta.json
@@ -52,9 +52,9 @@
       "Defined IsEgyptianFraction and proved equivalence with IsUnitFractionSum"
     ],
     "axiomCount": 2,
-    "lineCount": 236,
+    "lineCount": 264,
     "assumptions": "2 axioms: croot_theorem, representation_monotone. 0 sorries.",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 7
   },
   "overview": {
@@ -164,9 +164,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos286",
-    "lineCount": 236,
+    "lineCount": 264,
     "axiomCount": 2,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 7,
     "path": "Proofs/Erdos286Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

`erdos-286` meta.json drifted from its Lean source. Realigned both `leanFile` and `meta` blocks.

## Evidence

**Before**: lineCount=236, theoremCount=7
**After**: lineCount=264, theoremCount=8

Ground truth via canonical extractor. axiomCount=2, definitionCount=7, sorries=0 unchanged.

---
Automated fix by lean-mechanic agent.