### PR TITLE
Fix: realign erdos-357 lineCount (137→164), theoremCount (0→1), definitionCount (8→9)

### DIFF
--- a/src/data/proofs/erdos-357/meta.json
+++ b/src/data/proofs/erdos-357/meta.json
@@ -56,9 +56,9 @@
     ],
     "axiomCount": 3,
     "assumptions": "3 axioms: weisenberg_lower_bound (f(n) ≥ (2+o(1))√n via B₂ sequences), hegyvari_bounds ((1/3+o(1))n ≤ g(n) ≤ (2/3+o(1))n, Hegyvári 1986), infinite_set_lower_density_zero (proved: any infinite A with distinct consecutive sums has lower density 0). 0 sorries.",
-    "lineCount": 137,
-    "theoremCount": 0,
-    "definitionCount": 8,
+    "lineCount": 164,
+    "theoremCount": 1,
+    "definitionCount": 9,
     "additionalFiles": [
       "Proofs/Stubs/Erdos357Aristotle.lean"
     ]
@@ -203,10 +203,10 @@
       "Real"
     ],
     "namespace": "Erdos357",
-    "lineCount": 137,
+    "lineCount": 164,
     "axiomCount": 3,
-    "theoremCount": 0,
-    "definitionCount": 8,
+    "theoremCount": 1,
+    "definitionCount": 9,
     "path": "Proofs/Erdos357Problem.lean",
     "sorries": 0,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

`erdos-357` meta.json drifted from its Lean source. Realigned both `leanFile` and `meta` blocks.

## Evidence

**Before**: lineCount=137, theoremCount=0, definitionCount=8
**After**: lineCount=164, theoremCount=1 (conjecture_equiv), definitionCount=9

Ground truth via canonical extractor (`scripts/research/enrich-research.ts`). axiomCount=3 (3 real axiom decls), sorries=0 unchanged.

---
Automated fix by lean-mechanic agent.