### PR TITLE
Fix: realign erdos-138 lineCount (852→878), definitionCount (13→12)

### DIFF
--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -56,11 +56,11 @@
     "erdosProblemStatus": "open",
     "erdosPrizeValue": "$500",
     "axiomCount": 8,
-    "lineCount": 852,
+    "lineCount": 878,
     "assumptions": "8 axiom(s) and 1 sorry(s). Axioms: W_is_nonempty (van der Waerden's theorem — pinned-Mathlib v4.26.0 lacks Combinatorics.exists_mono_homothetic_copy, so this is a foundational assumption); berlekamp_lower_bound, gowers_upper_bound, kozik_shabanov_lower_bound (literature bounds); W_three=9, W_four=35, W_five=178, W_six=1132 (exact small values from exhaustive search / SAT). The lone sorry is the main_conjecture_implies_exponential filter-limit implication. The bound W(k+1) − W(k) ≥ k underlying the difference-variant result is proven from W_is_nonempty without further assumptions, via the AlphaProof Nexus coloring-extension argument.",
     "mathlib_version": "4.26.0",
     "theoremCount": 23,
-    "definitionCount": 13,
+    "definitionCount": 12,
     "additionalFiles": [
       "Proofs/Stubs/Erdos138Aristotle.lean"
     ]
@@ -156,10 +156,10 @@
       "Finset"
     ],
     "namespace": "Erdos138",
-    "lineCount": 852,
+    "lineCount": 878,
     "axiomCount": 8,
     "theoremCount": 23,
-    "definitionCount": 13,
+    "definitionCount": 12,
     "path": "Proofs/Erdos138Problem.lean",
     "sorries": 0,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

`erdos-138` meta.json drifted from its Lean source. Realigned both `leanFile` and `meta` blocks.

## Evidence

**Before**: lineCount=852, definitionCount=13
**After**: lineCount=878, definitionCount=12 (canonical `^(def|noncomputable def|opaque def) ` count)

axiomCount=8 kept as-is: the file has 8 real `axiom` declarations; a naive regex reports 9 due to a docstring line beginning "axiom can be replaced…" (prose false positive). theoremCount=23, sorries=0 unchanged.

---
Automated fix by lean-mechanic agent.