### PR TITLE
Fix: realign bounded-prime-gaps-oq-02 lineCount (623→662), theoremCount (36→38)

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
@@ -87,10 +87,10 @@
       "EHAtLevel_discrepancySum_up_arith: the explicit EQUIPARTITION instantiation of the finite-chain ascent at the arithmetic level sequence L k = θ₀ + k·δ (δ ≥ 0) — EH at base θ₀ plus an EH-type bound on each equal step lifts EH to θ₀ + n·δ; choosing δ = (θ-θ₀)/n reaches any target θ ≥ θ₀ in n equal modulus blocks, with Monotone L discharged from δ ≥ 0",
       "EHAtLevel_vonMangoldt_up_arith: the equipartition ascent for the genuine von-Mangoldt sum — bounding the real worst-case discrepancy on each equal step θ₀ + k·δ → θ₀ + (k+1)·δ raises the genuine level of distribution to θ₀ + n·δ, the concrete equipartition form of the dyadic attack on Elliott–Halberstam"
     ],
-    "lineCount": 623,
+    "lineCount": 662,
     "erdosUrl": null,
     "dateAdded": "2026-06-27",
-    "theoremCount": 36,
+    "theoremCount": 38,
     "definitionCount": 12
   },
   "overview": {
@@ -203,9 +203,9 @@
       "Real"
     ],
     "namespace": "BoundedPrimeGapsOQ02",
-    "lineCount": 623,
+    "lineCount": 662,
     "axiomCount": 0,
-    "theoremCount": 36,
+    "theoremCount": 38,
     "definitionCount": 12,
     "path": "Proofs/BoundedPrimeGapsOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

`bounded-prime-gaps-oq-02` meta.json drifted from its Lean source. Realigned both `leanFile` and `meta` blocks.

## Evidence

**Before**: lineCount=623, theoremCount=36
**After**: lineCount=662, theoremCount=38 (all 38 are genuine `theorem` declarations)

sorries=0 kept as-is: the two `sorry` tokens in the file are prose in docstrings ("No `axiom`, no `sorry`, no `native_decide`") — not tactic sorries. axiomCount=0, definitionCount=12 unchanged.

---
Automated fix by lean-mechanic agent.