### PR TITLE
Fix: realign stale counts for inverse-galois-a5 / inverse-galois-oq-06

### DIFF
--- a/src/data/proofs/inverse-galois-a5/meta.json
+++ b/src/data/proofs/inverse-galois-a5/meta.json
@@ -34,9 +34,9 @@
       "gal_not_solvable: Gal(q/ℚ) is not solvable (transfers non-solvability through the isomorphism)"
     ],
     "dateAdded": "2026-05-04",
-    "lineCount": 2067,
-    "theoremCount": 84,
-    "definitionCount": 12,
+    "lineCount": 2106,
+    "theoremCount": 65,
+    "definitionCount": 7,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -80,10 +80,10 @@
       "Mathlib"
     ],
     "namespace": "InverseGaloisA5",
-    "lineCount": 2067,
+    "lineCount": 2106,
     "axiomCount": 1,
-    "theoremCount": 84,
-    "definitionCount": 12,
+    "theoremCount": 65,
+    "definitionCount": 7,
     "path": "Proofs/InverseGaloisA5.lean",
     "sorries": 0
   },

--- a/src/data/proofs/inverse-galois-oq-06/meta.json
+++ b/src/data/proofs/inverse-galois-oq-06/meta.json
@@ -21,9 +21,9 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 2,
     "assumptions": "2 axioms. (1) three_dvd_gal_card — 3 divides |Gal(q/ℚ)|. This follows from Dedekind's theorem applied to q mod 7 (which factors as (1-cycle)(1-cycle)(3-cycle)), implying the Galois group contains an element of order divisible by 3. Axiomatized because Mathlib lacks Dedekind's theorem for polynomial Galois groups. (2) Lean.ofReduceBool — several credited theorems are discharged by `native_decide` (perm_fin5_order5_order3_not_commute, perm_fin5_no_order_15, a5_card, resolvent_no_positive_root, resolvent_no_negative_root, resolvent_at_zero, and the Sylow subgroup-cardinality steps), which trusts the Lean compiler's kernel reduction (#print axioms lists Lean.ofReduceBool); these results are free of mathematical axioms but not axiom-free in the strict sense.",
-    "lineCount": 2067,
-    "theoremCount": 84,
-    "definitionCount": 12,
+    "lineCount": 2106,
+    "theoremCount": 65,
+    "definitionCount": 7,
     "originalContributions": [
       "q: the polynomial x⁵-5x⁴+10x³-10x²+25x-5 (translate of x⁵+20x+16)",
       "q_eisenstein: q satisfies Eisenstein's criterion at p=5 (PROVED, hence irreducible over ℚ)",
@@ -85,10 +85,10 @@
   },
   "leanFile": {
     "namespace": "InverseGaloisA5",
-    "lineCount": 2067,
+    "lineCount": 2106,
     "axiomCount": 1,
-    "theoremCount": 84,
-    "definitionCount": 12,
+    "theoremCount": 65,
+    "definitionCount": 7,
     "path": "Proofs/InverseGaloisA5.lean",
     "sorries": 0,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Two gallery entries (`inverse-galois-a5`, `inverse-galois-oq-06`) both reference the shared Lean source `Proofs/InverseGaloisA5.lean`. Their stored counts had drifted from the canonical extractor (`scripts/research/enrich-research.ts`).

## Evidence

Ground truth from the actual file (col-0 regex, matching the extractor):

| field | stored | actual |
|-------|--------|--------|
| lineCount | 2067 | 2106 |
| theoremCount | 84 | 65 |
| definitionCount | 12 | 7 |

`grep -cE '^(theorem|lemma) '` = 65, `grep -cE '^(def|noncomputable def|opaque def) '` = 7, `wc -l` = 2105 (split('\n') = 2106).

Updated both the `leanFile.*` and `meta.*` blocks in each meta.json. axiomCount/sorries left unchanged (still accurate). No Lean code changed.

---
Automated fix by lean-mechanic agent.