### PR TITLE
Fix: realign lovasz-local-lemma-oq-02 lineCount (240→263)

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
     "assumptions": "9 sorries total: 1 in main file (lllThreshold_strict_maximum equality case — requires the AM-GM equality characterization, all terms equal iff x = 1/(d+1)) and 8 in the Aristotle companion file (LovaszLocalLemmaOQ02Aristotle.lean) targeting routine supporting lemmas. Proved: lllThreshold_is_maximum (general d) via Real.geom_mean_le_arith_mean2_weighted + rpow monotonicity (PR #11084).",
-    "lineCount": 240,
+    "lineCount": 263,
     "theoremCount": 13,
     "definitionCount": 0,
     "additionalFiles": [
@@ -134,7 +134,7 @@
       "ProbMethod.LovaszLocal"
     ],
     "namespace": "ProbMethod.LovaszLocal.OQ02",
-    "lineCount": 240,
+    "lineCount": 263,
     "axiomCount": 0,
     "theoremCount": 13,
     "substantiveTheoremCount": 10,


### PR DESCRIPTION
## Fix

Realigned `lineCount` in both blocks to the Lean source.

## Evidence

**Before**: lineCount=240
**After**: lineCount=263

theoremCount=13, definitionCount=0, axiomCount=0 unchanged. sorries=1 kept: exactly one real tactic `sorry` (line 229); other `sorry` tokens are prose. status=formalized/badge=wip unchanged.

---
Automated fix by lean-mechanic agent.