### PR TITLE
research(erdos-95-oq-04): Cauchy–Schwarz bridge linking ∑f(uᵢ)² to the distinct-distance count [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos95OQ04.lean
+++ b/proofs/Proofs/Erdos95OQ04.lean
@@ -1,0 +1,259 @@
+/-
+Erdős Problem #95 — Follow-up: The elementary Cauchy–Schwarz bridge between
+the sum of squared distance multiplicities and the number of distinct distances.
+
+Source problem: https://erdosproblems.com/95   (SOLVED, Guth–Katz 2015)
+
+Erdős #95 asks to bound the second moment `∑ᵢ f(uᵢ)²` of the distance
+multiplicities of `n` points in ℝ², where `f(u)` counts the ordered pairs at
+distance `u`.  The first moment is the trivial identity `∑ᵢ f(uᵢ) = n(n-1)`;
+the deep Guth–Katz theorem (2015) gives `∑ᵢ f(uᵢ)² ≪ n³ log n`.
+
+This file records the elementary — and genuinely informative — bound sitting
+between those two: the Cauchy–Schwarz (Chebyshev) inequality relating the
+second moment to the number `t = |{distinct distances}|`.  With `f(uᵢ)` the
+multiplicity of the i-th distance,
+
+      ( ∑ᵢ f(uᵢ) )²  ≤  t · ∑ᵢ f(uᵢ)² ,
+
+so together with `∑ᵢ f(uᵢ) = n(n-1)` we obtain the two dual consequences
+
+  * a LOWER bound on the second moment in terms of the distinct-distance count
+        ∑ᵢ f(uᵢ)²  ≥  (n(n-1))² / t ,
+  * the equivalent LOWER bound on the number of distinct distances in terms of
+    an UPPER bound on the second moment
+        t  ≥  (n(n-1))² / ∑ᵢ f(uᵢ)² .
+
+The second inequality is exactly the logical shape used in the Guth–Katz
+programme: an upper bound on `∑ f²` (distances not too concentrated) forces
+many distinct distances.  This is the elementary reason Erdős Problem #95 and
+the distinct-distances problem (#94) are two faces of the same coin.
+
+We also record the elementary two-sided sandwich
+
+        (n(n-1))² / t   ≤   ∑ᵢ f(uᵢ)²   ≤   (n(n-1))² ,
+
+both ends of which are proved here from scratch.  Only the Guth–Katz refinement
+of the upper end (to `n³ log n`) is genuinely deep.
+
+This file is self-contained (it re-develops the small amount of Erdős #95
+scaffolding it needs) and is fully machine-checked with no additional axioms
+beyond Lean/Mathlib's foundations (no incomplete proofs, no axiom declarations,
+and no reliance on `native_decide` / `Lean.ofReduceBool`).
+-/
+
+import Mathlib.Analysis.InnerProductSpace.EuclideanDist
+import Mathlib.Algebra.Order.Chebyshev
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Real.Basic
+
+set_option maxHeartbeats 400000
+
+namespace Erdos95CauchySchwarz
+
+open Finset
+
+/-!
+## Part I: Configurations, distances, and multiplicities
+
+We reproduce the minimal Erdős #95 scaffolding (points, distance set, and
+multiplicity) needed to state the second-moment bounds.
+-/
+
+/-- A point in the Euclidean plane ℝ². -/
+abbrev Point := EuclideanSpace ℝ (Fin 2)
+
+/-- The Euclidean distance between two points (irreducible: whnf must not
+    descend into the norm during the structural counting proofs). -/
+@[irreducible] noncomputable def dist (p q : Point) : ℝ := ‖p - q‖
+
+/-- A finite point configuration in ℝ² with at least one point. -/
+structure PointConfig where
+  points : Finset Point
+  card_pos : points.card > 0
+
+variable (P : PointConfig)
+
+/-- The set of all pairwise distances between *distinct* points of the
+    configuration, ranging over ordered pairs `(p, q)` with `p ≠ q`. -/
+noncomputable def distanceSet (P : PointConfig) : Finset ℝ :=
+  (P.points.offDiag).image (fun pq => dist pq.1 pq.2)
+
+/-- The multiplicity `f(d)` of a distance `d`: the number of ordered pairs
+    `(p, q)` of distinct points with `dist p q = d`. -/
+noncomputable def multiplicity (P : PointConfig) (d : ℝ) : ℕ :=
+  ((P.points.offDiag).filter (fun pq => dist pq.1 pq.2 = d)).card
+
+/-- The sum of squared multiplicities `∑ᵢ f(uᵢ)²` — the quantity Erdős #95
+    asks to bound. -/
+noncomputable def sumSquaredMultiplicities (P : PointConfig) : ℕ :=
+  (distanceSet P).sum (fun d => (multiplicity P d) ^ 2)
+
+/-- The number of *distinct* distances `t = |{u₁,…,uₜ}|` determined by the
+    configuration.  This is the quantity Erdős Problem #94 asks to bound. -/
+noncomputable def distinctDistances (P : PointConfig) : ℕ := (distanceSet P).card
+
+/-!
+## Part II: First moment (fibre decomposition)
+
+`∑ᵢ f(uᵢ) = n(n-1)`: each ordered pair of distinct points contributes to exactly
+one distance value, so the fibre sizes over the distance set sum to `|offDiag|`.
+-/
+
+/-- **First moment:** `∑_{d} f(d) = n(n-1)`. -/
+theorem sum_multiplicities :
+    (distanceSet P).sum (multiplicity P) = P.points.card * (P.points.card - 1) := by
+  classical
+  have hmem : Set.MapsTo (fun pq : Point × Point => dist pq.1 pq.2)
+      ↑P.points.offDiag ↑(distanceSet P) := by
+    intro pq hpq
+    exact Finset.mem_image_of_mem (fun pq : Point × Point => dist pq.1 pq.2) hpq
+  have hcard : P.points.offDiag.card
+      = ∑ b ∈ distanceSet P,
+          (P.points.offDiag.filter (fun a => dist a.1 a.2 = b)).card :=
+    Finset.card_eq_sum_card_fiberwise hmem
+  -- Convert `multiplicity` (a definition) to the fibre filter card by a cheap
+  -- per-element `rfl`, avoiding an expensive whnf unification of the two forms.
+  have hstep : (distanceSet P).sum (multiplicity P)
+      = ∑ d ∈ distanceSet P,
+          (P.points.offDiag.filter (fun pq => dist pq.1 pq.2 = d)).card := by
+    apply Finset.sum_congr rfl
+    intro d _
+    rfl
+  rw [hstep, ← hcard, Finset.offDiag_card]
+  cases h : P.points.card with
+  | zero => simp
+  | succ n =>
+    have hrw : (n + 1) * (n + 1) = (n + 1) * n + (n + 1) := by ring
+    simp only [Nat.succ_sub_one]
+    omega
+
+/-!
+## Part III: First and second moments over ℝ
+
+Real-valued restatements so we can feed them into the real Cauchy–Schwarz lemma.
+-/
+
+/-- `∑_{d} f(d) = n(n-1)` as an identity of real numbers. -/
+theorem sum_multiplicities_real :
+    ∑ d ∈ distanceSet P, (multiplicity P d : ℝ)
+      = ((P.points.card * (P.points.card - 1) : ℕ) : ℝ) := by
+  rw [← Nat.cast_sum]
+  exact_mod_cast congrArg (Nat.cast : ℕ → ℝ) (sum_multiplicities P)
+
+/-- `∑_{d} f(d)² = sumSquaredMultiplicities P` as an identity of real numbers. -/
+theorem sumSquaredMultiplicities_real :
+    ∑ d ∈ distanceSet P, (multiplicity P d : ℝ) ^ 2
+      = ((sumSquaredMultiplicities P : ℕ) : ℝ) := by
+  rw [sumSquaredMultiplicities, Nat.cast_sum]
+  push_cast
+  rfl
+
+/-!
+## Part IV: The Cauchy–Schwarz bridge
+
+`(∑ f)² ≤ t · ∑ f²`, specialised via the first-moment identity to
+`(n(n-1))² ≤ t · ∑ f²`.
+-/
+
+/-- **Cauchy–Schwarz / Chebyshev bridge.**
+    `(n(n-1))² ≤ t · ∑ᵢ f(uᵢ)²`, where `t = |distanceSet|`. -/
+theorem cauchy_schwarz_bound :
+    ((P.points.card * (P.points.card - 1) : ℕ) : ℝ) ^ 2
+      ≤ ((distanceSet P).card : ℝ) * (sumSquaredMultiplicities P : ℝ) := by
+  have hcs := sq_sum_le_card_mul_sum_sq (s := distanceSet P)
+      (f := fun d => (multiplicity P d : ℝ))
+  rw [sum_multiplicities_real, sumSquaredMultiplicities_real] at hcs
+  exact hcs
+
+/-!
+## Part V: Dual consequences
+
+Dividing the bridge inequality either way.
+-/
+
+/-- **Lower bound on the second moment** in terms of the distinct-distance
+    count: `∑ᵢ f(uᵢ)² ≥ (n(n-1))² / t`.  Concentration of distances (small `t`)
+    forces a large second moment. -/
+theorem sumSquared_ge_of_distinct (h : 0 < (distanceSet P).card) :
+    ((P.points.card * (P.points.card - 1) : ℕ) : ℝ) ^ 2 / ((distanceSet P).card : ℝ)
+      ≤ (sumSquaredMultiplicities P : ℝ) := by
+  have hpos : (0 : ℝ) < ((distanceSet P).card : ℝ) := by exact_mod_cast h
+  rw [div_le_iff₀ hpos, mul_comm (sumSquaredMultiplicities P : ℝ) _]
+  exact cauchy_schwarz_bound P
+
+/-- **Lower bound on the number of distinct distances** in terms of an upper
+    bound on the second moment: `t ≥ (n(n-1))² / ∑ᵢ f(uᵢ)²`.
+
+    This is the direction used in the Guth–Katz programme: an upper bound on the
+    second moment `∑ f²` yields a *lower* bound on the number of distinct
+    distances (Problem #94).  Erdős #95 and #94 are dual through this line. -/
+theorem distinctDistances_ge_of_secondMoment (h : 0 < sumSquaredMultiplicities P) :
+    ((P.points.card * (P.points.card - 1) : ℕ) : ℝ) ^ 2 / (sumSquaredMultiplicities P : ℝ)
+      ≤ ((distanceSet P).card : ℝ) := by
+  have hpos : (0 : ℝ) < (sumSquaredMultiplicities P : ℝ) := by exact_mod_cast h
+  rw [div_le_iff₀ hpos]
+  exact cauchy_schwarz_bound P
+
+/-!
+## Part VI: Elementary upper bound
+
+Each multiplicity is at most `n(n-1)`, so the second moment is at most
+`(n(n-1))²`.  This is the trivial end of the sandwich; Guth–Katz sharpen it all
+the way to `n³ log n`.
+-/
+
+/-- Each distance multiplicity is at most the number of ordered pairs of
+    distinct points, `n(n-1)`. -/
+theorem multiplicity_le (d : ℝ) :
+    multiplicity P d ≤ P.points.card * (P.points.card - 1) := by
+  have h1 : multiplicity P d ≤ (P.points.offDiag).card := by
+    rw [multiplicity]; exact Finset.card_filter_le _ _
+  rw [Finset.offDiag_card] at h1
+  have h2 : P.points.card * P.points.card - P.points.card
+      = P.points.card * (P.points.card - 1) := by
+    cases hn : P.points.card with
+    | zero => simp
+    | succ n => simp [Nat.succ_mul, Nat.mul_succ]
+  rwa [h2] at h1
+
+/-- **Trivial second-moment upper bound**: `∑ᵢ f(uᵢ)² ≤ (n(n-1))²`. -/
+theorem sumSquared_le :
+    sumSquaredMultiplicities P ≤ (P.points.card * (P.points.card - 1)) ^ 2 := by
+  rw [sumSquaredMultiplicities]
+  calc
+    ∑ d ∈ distanceSet P, (multiplicity P d) ^ 2
+        ≤ ∑ d ∈ distanceSet P,
+            (multiplicity P d) * (P.points.card * (P.points.card - 1)) := by
+          apply Finset.sum_le_sum
+          intro d _
+          rw [sq]
+          exact Nat.mul_le_mul (le_refl _) (multiplicity_le P d)
+    _ = (∑ d ∈ distanceSet P, multiplicity P d)
+          * (P.points.card * (P.points.card - 1)) := by rw [Finset.sum_mul]
+    _ = (P.points.card * (P.points.card - 1))
+          * (P.points.card * (P.points.card - 1)) := by rw [sum_multiplicities]
+    _ = (P.points.card * (P.points.card - 1)) ^ 2 := by rw [sq]
+
+/-!
+## Part VII: The elementary sandwich
+-/
+
+/-- **Elementary two-sided bound** for the sum of squared multiplicities:
+
+        (n(n-1))² / t   ≤   ∑ᵢ f(uᵢ)²   ≤   (n(n-1))² .
+
+    The lower bound is the Cauchy–Schwarz bridge; the upper bound is trivial.
+    Guth–Katz sharpen the upper end to `O(n³ log n)`. -/
+theorem sumSquared_sandwich (h : 0 < (distanceSet P).card) :
+    ((P.points.card * (P.points.card - 1) : ℕ) : ℝ) ^ 2 / ((distanceSet P).card : ℝ)
+        ≤ (sumSquaredMultiplicities P : ℝ)
+      ∧ (sumSquaredMultiplicities P : ℝ)
+        ≤ ((P.points.card * (P.points.card - 1) : ℕ) : ℝ) ^ 2 := by
+  refine ⟨sumSquared_ge_of_distinct P h, ?_⟩
+  have hle := sumSquared_le P
+  calc (sumSquaredMultiplicities P : ℝ)
+      ≤ (((P.points.card * (P.points.card - 1)) ^ 2 : ℕ) : ℝ) := by exact_mod_cast hle
+    _ = ((P.points.card * (P.points.card - 1) : ℕ) : ℝ) ^ 2 := by push_cast; ring
+
+end Erdos95CauchySchwarz

--- a/src/data/proofs/erdos-95-oq-04/annotations.json
+++ b/src/data/proofs/erdos-95-oq-04/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-header-cs",
+    "proofId": "erdos-95-oq-04",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "Why #95 and #94 are two faces of one coin",
+    "content": "Erdős #95 concerns the second moment $\\sum_i f(u_i)^2$ of the distance multiplicities of $n$ planar points; Erdős #94 concerns $t$, the number of distinct distances. Cauchy–Schwarz applied to the multiplicity vector $(f(u_1),\\dots,f(u_t))$ against the all-ones vector gives $(\\sum_i f(u_i))^2 \\le t\\cdot\\sum_i f(u_i)^2$. Since the first moment is the trivial identity $\\sum_i f(u_i) = n(n-1)$, this becomes $(n(n-1))^2 \\le t\\cdot\\sum_i f(u_i)^2$ — a single inequality that bounds each of the two quantities in terms of the other. This file proves that bridge and both of its dual divisions with no axioms, supplying the elementary content beneath the parent entry's axiomatized Guth–Katz bound.",
+    "mathContext": "$(n(n-1))^2 \\le t\\cdot\\sum_i f(u_i)^2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy–Schwarz / Chebyshev sum inequality",
+      "distance multiplicities",
+      "distinct distances (Erdős #94)",
+      "second moment method"
+    ],
+    "prerequisites": [
+      "Euclidean plane EuclideanSpace ℝ (Fin 2)",
+      "Finset.offDiag, image, filter"
+    ]
+  },
+  {
+    "id": "ann-first-moment",
+    "proofId": "erdos-95-oq-04",
+    "range": { "startLine": 97, "endLine": 131 },
+    "type": "proof-technique",
+    "title": "First moment by fibre decomposition",
+    "content": "sum_multiplicities proves $\\sum_d f(d) = n(n-1)$. The map $(p,q)\\mapsto \\mathrm{dist}(p,q)$ sends every ordered pair of distinct points (an element of offDiag) into the distance set, and $f(d)$ is by definition the size of the fibre over $d$. So `Finset.card_eq_sum_card_fiberwise` (fed a `Set.MapsTo`) rewrites $|\\mathrm{offDiag}|$ as $\\sum_d f(d)$, and `Finset.offDiag_card` evaluates $|\\mathrm{offDiag}| = n\\cdot n - n = n(n-1)$. The distance function is marked `irreducible` so the fibre-matching stays structural and does not unfold into the Euclidean norm.",
+    "mathContext": "$\\sum_d f(d) = |\\mathrm{offDiag}| = n(n-1)$",
+    "significance": "standard",
+    "relatedConcepts": [
+      "fibrewise counting",
+      "Finset.card_eq_sum_card_fiberwise",
+      "Finset.offDiag_card"
+    ],
+    "prerequisites": [
+      "double counting"
+    ]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "erdos-95-oq-04",
+    "range": { "startLine": 153, "endLine": 169 },
+    "type": "proof-technique",
+    "title": "The Cauchy–Schwarz bridge",
+    "content": "cauchy_schwarz_bound instantiates Mathlib's `sq_sum_le_card_mul_sum_sq` — the Chebyshev/Cauchy–Schwarz inequality $(\\sum_{i\\in s} g_i)^2 \\le |s|\\cdot\\sum_{i\\in s} g_i^2$ — with $s$ the distance set and $g_d = (f(d):\\mathbb{R})$. Rewriting the left side by the real first-moment identity and the right sum by the real second-moment identity yields $(n(n-1))^2 \\le t\\cdot\\sum_i f(u_i)^2$. Working over $\\mathbb{R}$ (rather than $\\mathbb{N}$) is required because the Chebyshev lemma needs an ordered ring with subtraction.",
+    "mathContext": "$(n(n-1))^2 \\le t\\cdot\\sum_i f(u_i)^2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "sq_sum_le_card_mul_sum_sq",
+      "Chebyshev's sum inequality",
+      "Nat.cast_sum / push_cast bridges"
+    ],
+    "prerequisites": [
+      "Cauchy–Schwarz inequality"
+    ]
+  },
+  {
+    "id": "ann-dual",
+    "proofId": "erdos-95-oq-04",
+    "range": { "startLine": 170, "endLine": 198 },
+    "type": "insight",
+    "title": "Dual consequences: the Guth–Katz direction",
+    "content": "Dividing the bridge two ways gives dual bounds. sumSquared_ge_of_distinct: $\\sum_i f(u_i)^2 \\ge (n(n-1))^2/t$ — few distinct distances (small $t$) force a large second moment. distinctDistances_ge_of_secondMoment: $t \\ge (n(n-1))^2/\\sum_i f(u_i)^2$ — this is the direction the Guth–Katz programme runs, deriving a lower bound on the number of distinct distances from an upper bound on the second moment. This is precisely why solving #95 (bounding $\\sum f^2$) resolves #94 (bounding $t$ below).",
+    "mathContext": "$t \\ge \\dfrac{(n(n-1))^2}{\\sum_i f(u_i)^2}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "distinct distances lower bound",
+      "second moment ⇒ distinct-distance count",
+      "div_le_iff₀"
+    ],
+    "prerequisites": [
+      "rearranging inequalities by division"
+    ]
+  },
+  {
+    "id": "ann-upper",
+    "proofId": "erdos-95-oq-04",
+    "range": { "startLine": 199, "endLine": 238 },
+    "type": "proof-technique",
+    "title": "Trivial upper bound and the sandwich",
+    "content": "multiplicity_le shows each $f(d)$ is at most the $n(n-1)$ ordered pairs (its defining filter is a subset of offDiag). Hence sumSquared_le: $\\sum_d f(d)^2 \\le \\sum_d f(d)\\cdot n(n-1) = (n(n-1))\\cdot\\sum_d f(d) = (n(n-1))^2$. sumSquared_sandwich collects this with the Cauchy–Schwarz lower bound into $(n(n-1))^2/t \\le \\sum_i f(u_i)^2 \\le (n(n-1))^2$. The Guth–Katz theorem is exactly the deep sharpening of this trivial $\\approx n^4$ upper end down to $n^3\\log n$.",
+    "mathContext": "$\\tfrac{(n(n-1))^2}{t} \\le \\sum_i f(u_i)^2 \\le (n(n-1))^2$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.card_filter_le",
+      "Finset.sum_le_sum",
+      "Guth–Katz sharpening"
+    ],
+    "prerequisites": [
+      "monotonicity of finite sums"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-95-oq-04/meta.json
+++ b/src/data/proofs/erdos-95-oq-04/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "erdos-95-oq-04",
+  "slug": "erdos-95-oq-04",
+  "title": "Erdős #95 Follow-up: The Cauchy–Schwarz Bridge Linking $\\sum f(u_i)^2$ to the Distinct-Distance Count",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.EuclideanDist",
+      "Mathlib.Algebra.Order.Chebyshev",
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Data.Real.Basic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos95CauchySchwarz",
+    "lineCount": 259,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 7,
+    "path": "Proofs/Erdos95OQ04.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Erdős",
+    "erdosNumber": 95,
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos95OQ04.lean",
+    "tags": [
+      "erdos",
+      "discrete-geometry",
+      "distinct-distances",
+      "incidence-geometry",
+      "cauchy-schwarz",
+      "second-moment",
+      "extremal-combinatorics",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/95",
+    "erdosUrl": "https://erdosproblems.com/95",
+    "erdosProblemStatus": "solved",
+    "dateAdded": "2026-06-30",
+    "axiomCount": 0,
+    "lineCount": 259,
+    "assumptions": "None. 0 sorries, 0 axioms — #print axioms confirms every result depends only on the foundational axioms propext / Classical.choice / Quot.sound. Unlike the parent entry (which axiomatizes the deep Guth–Katz bound), all results here are elementary and proved unconditionally. No native_decide / Lean.ofReduceBool.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 7,
+    "substantiveTheoremCount": 5
+  },
+  "description": "An elementary, fully verified bridge between the two Erdős distance problems. For $n$ points in $\\mathbb{R}^2$ determining distinct distances $u_1,\\dots,u_t$ with multiplicities $f(u_i)$, the Cauchy–Schwarz (Chebyshev) inequality gives $(\\sum_i f(u_i))^2 \\le t \\cdot \\sum_i f(u_i)^2$. Combined with the trivial first moment $\\sum_i f(u_i) = n(n-1)$, this yields the sharp elementary lower bound $\\sum_i f(u_i)^2 \\ge (n(n-1))^2/t$ (Problem #95) and, dually, $t \\ge (n(n-1))^2/\\sum_i f(u_i)^2$ (the distinct-distance count, Problem #94). Together with the trivial upper bound $\\sum_i f(u_i)^2 \\le (n(n-1))^2$ this sandwiches the second moment. The parent entry only axiomatizes the deep Guth–Katz refinement; this follow-up supplies the elementary structural content beneath it, with zero axioms.",
+  "overview": "The parent entry for Erdős #95 proves the trivial first moment $\\sum_i f(u_i) = n(n-1)$ and then *axiomatizes* the deep Guth–Katz second-moment bound $\\sum f(u_i)^2 \\ll n^3\\log n$. This follow-up fills the elementary gap between them — the reason Problems #95 (second moment of distance multiplicities) and #94 (number of distinct distances) are two faces of one coin. Cauchy–Schwarz applied to the multiplicity vector against the all-ones vector gives $(\\sum_i f(u_i))^2 \\le t\\cdot\\sum_i f(u_i)^2$ where $t$ is the number of distinct distances. Feeding in the first-moment identity produces the bridge $(n(n-1))^2 \\le t\\cdot\\sum_i f(u_i)^2$, which divides two ways: a lower bound on the second moment in terms of $t$ (concentration of distances forces a large second moment), and — the direction the Guth–Katz programme actually uses — a lower bound on the number of distinct distances in terms of an upper bound on the second moment (few concentrated distances force many distinct values). A trivial matching upper bound $\\sum f(u_i)^2 \\le (n(n-1))^2$ (each multiplicity is at most the $n(n-1)$ ordered pairs) completes an elementary sandwich $(n(n-1))^2/t \\le \\sum_i f(u_i)^2 \\le (n(n-1))^2$. Only the Guth–Katz sharpening of the upper end to $n^3\\log n$ is genuinely deep; everything here is proved from scratch with no axioms. The file is self-contained, re-developing the small amount of #95 scaffolding it needs (this also side-steps the parent file's reliance on the axiomatized machinery). It does not resolve the literal open question about *formalizing the Guth–Katz polynomial method* — that remains far out of reach — but it records the elementary theory that surrounds and motivates it.",
+  "sections": [
+    {
+      "id": "scaffolding",
+      "title": "Configurations, distances, and multiplicities",
+      "startLine": 57,
+      "endLine": 96,
+      "summary": "Self-contained Erdős #95 setup: Point = EuclideanSpace ℝ (Fin 2), an (irreducible) distance function, PointConfig, the distance set, the multiplicity f(d) (number of ordered pairs of distinct points at distance d), the second moment sumSquaredMultiplicities, and the distinct-distance count t = |distanceSet|.",
+      "mathContext": "$f(d) = |\\{(p,q) : p\\neq q,\\ \\mathrm{dist}(p,q)=d\\}|,\\quad t = |\\{u_1,\\dots,u_t\\}|$"
+    },
+    {
+      "id": "first-moment",
+      "title": "First moment: $\\sum_d f(d) = n(n-1)$",
+      "startLine": 97,
+      "endLine": 131,
+      "summary": "sum_multiplicities: each ordered pair of distinct points contributes to exactly one distance value, so the fibre sizes over the distance set sum to |offDiag| = n(n-1). Proved via Finset.card_eq_sum_card_fiberwise (with the distance function kept opaque/irreducible so the counting stays structural) and Finset.offDiag_card.",
+      "mathContext": "$\\sum_{d} f(d) = |\\mathrm{offDiag}| = n(n-1)$"
+    },
+    {
+      "id": "moments-real",
+      "title": "Moments over ℝ",
+      "startLine": 132,
+      "endLine": 152,
+      "summary": "sum_multiplicities_real and sumSquaredMultiplicities_real: real-valued restatements of the first and second moments (via Nat.cast_sum / push_cast) so they can be fed into the real Cauchy–Schwarz lemma.",
+      "mathContext": "$\\sum_d (f(d):\\mathbb{R}) = n(n-1),\\quad \\sum_d (f(d):\\mathbb{R})^2 = \\sum_i f(u_i)^2$"
+    },
+    {
+      "id": "bridge",
+      "title": "The Cauchy–Schwarz bridge",
+      "startLine": 153,
+      "endLine": 169,
+      "summary": "cauchy_schwarz_bound: from Mathlib's sq_sum_le_card_mul_sum_sq (Chebyshev/Cauchy–Schwarz, (∑ f)² ≤ |s|·∑ f²) specialised via the first-moment identity to (n(n-1))² ≤ t · ∑ᵢ f(uᵢ)².",
+      "mathContext": "$(n(n-1))^2 \\le t\\cdot\\sum_i f(u_i)^2$"
+    },
+    {
+      "id": "dual",
+      "title": "Dual consequences",
+      "startLine": 170,
+      "endLine": 198,
+      "summary": "sumSquared_ge_of_distinct: ∑ f² ≥ (n(n-1))²/t (concentration forces a large second moment). distinctDistances_ge_of_secondMoment: t ≥ (n(n-1))²/∑ f² — the Guth–Katz direction, where an upper bound on the second moment yields a lower bound on the number of distinct distances (#94).",
+      "mathContext": "$\\sum_i f(u_i)^2 \\ge \\tfrac{(n(n-1))^2}{t}\\quad\\Longleftrightarrow\\quad t \\ge \\tfrac{(n(n-1))^2}{\\sum_i f(u_i)^2}$"
+    },
+    {
+      "id": "upper",
+      "title": "Elementary upper bound",
+      "startLine": 199,
+      "endLine": 238,
+      "summary": "multiplicity_le: each multiplicity is at most the n(n-1) ordered pairs (fibre ⊆ offDiag). sumSquared_le: hence ∑ f² ≤ (∑ f)·max f ≤ (n(n-1))² — the trivial end of the sandwich, which Guth–Katz sharpen to O(n³ log n).",
+      "mathContext": "$\\sum_i f(u_i)^2 \\le (n(n-1))^2$"
+    },
+    {
+      "id": "sandwich",
+      "title": "The elementary sandwich",
+      "startLine": 239,
+      "endLine": 259,
+      "summary": "sumSquared_sandwich: collects the Cauchy–Schwarz lower bound and the trivial upper bound into (n(n-1))²/t ≤ ∑ᵢ f(uᵢ)² ≤ (n(n-1))², both ends axiom-free.",
+      "mathContext": "$\\tfrac{(n(n-1))^2}{t} \\le \\sum_i f(u_i)^2 \\le (n(n-1))^2$"
+    }
+  ],
+  "conclusion": {
+    "summary": "The elementary Cauchy–Schwarz inequality links the second moment of distance multiplicities (Erdős #95) to the number of distinct distances (Erdős #94): $(n(n-1))^2 \\le t\\cdot\\sum_i f(u_i)^2$. This yields a two-sided elementary bound $(n(n-1))^2/t \\le \\sum_i f(u_i)^2 \\le (n(n-1))^2$, all proved with 0 sorries and 0 axioms.",
+    "implications": "This exposes the elementary theory beneath the parent entry's axiomatized Guth–Katz bound. The dual form $t \\ge (n(n-1))^2/\\sum_i f(u_i)^2$ is exactly the logic used to derive distinct-distance lower bounds from second-moment upper bounds — making explicit why #95 and #94 are inseparable. The Guth–Katz theorem is precisely the deep sharpening of the trivial upper end (from $(n(n-1))^2 \\approx n^4$ down to $n^3\\log n$); the elementary lower end proved here cannot be improved without further hypotheses on $t$.",
+    "openQuestions": [
+      "Can the trivial upper bound $\\sum_i f(u_i)^2 \\le (n(n-1))^2$ be improved to the Guth–Katz $O(n^3\\log n)$ by an elementary (polynomial-method-free) argument, at least in special cases such as convex position (the Fishburn/Altman $O(n^3)$ case)?",
+      "Is there a matching lower bound $\\sum_i f(u_i)^2 = \\Omega(n^3/\\text{polylog})$ realised by an explicit configuration (e.g. the $\\sqrt n \\times \\sqrt n$ integer grid), certifying that the Guth–Katz exponent 3 is sharp?"
+    ]
+  },
+  "crossReferences": [
+    "erdos-95"
+  ],
+  "references": [
+    {
+      "title": "Erdős Problem #95",
+      "url": "https://erdosproblems.com/95"
+    },
+    {
+      "title": "L. Guth and N. H. Katz, On the Erdős distinct distances problem in the plane, Annals of Mathematics 181 (2015)",
+      "url": "https://annals.math.princeton.edu/2015/181-1/p03"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **erdos-95-oq-04** — an elementary, fully verified bridge between the two Erdős distance problems (#95 and #94).

The parent entry for **Erdős #95** (Sum of Squared Distance Multiplicities) proves the trivial first moment $\sum_i f(u_i) = n(n-1)$ and then *axiomatizes* the deep Guth–Katz second-moment bound $\sum f(u_i)^2 \ll n^3\log n$. This follow-up supplies the **elementary content sitting between them**.

Cauchy–Schwarz (Chebyshev) applied to the multiplicity vector against the all-ones vector gives $(\sum_i f(u_i))^2 \le t\cdot\sum_i f(u_i)^2$ where $t$ is the number of distinct distances. Combined with the first-moment identity this is the **bridge**
$$(n(n-1))^2 \le t\cdot\sum_i f(u_i)^2,$$
which divides two ways:

- $\sum_i f(u_i)^2 \ge (n(n-1))^2/t$ — concentration of distances (small $t$) forces a large second moment;
- $t \ge (n(n-1))^2/\sum_i f(u_i)^2$ — the **Guth–Katz direction**: an upper bound on the second moment yields a lower bound on the number of distinct distances (#94).

A trivial matching upper bound $\sum_i f(u_i)^2 \le (n(n-1))^2$ completes the elementary sandwich
$$\tfrac{(n(n-1))^2}{t} \le \sum_i f(u_i)^2 \le (n(n-1))^2.$$
Only the Guth–Katz sharpening of the upper end (to $n^3\log n$) is genuinely deep. This makes explicit why Erdős #95 and the distinct-distances problem #94 are two faces of one coin.

## Contents

- `proofs/Proofs/Erdos95OQ04.lean` — 259 lines, 9 theorems, 7 definitions, **0 axioms**, 0 sorries. Self-contained (re-develops the small amount of #95 scaffolding it needs; the distance function is `irreducible` so the fibre-counting stays structural).
- `src/data/proofs/erdos-95-oq-04/{meta.json,annotations.json}` — gallery entry.

## Verification

- Compiles under the pinned toolchain (**lean4 v4.26.0 + Mathlib**) via `bin/lake env lean` — exit 0, no errors, no sorry warnings.
- `#print axioms` on `sum_multiplicities`, `cauchy_schwarz_bound`, `sumSquared_sandwich`, `distinctDistances_ge_of_secondMoment` reports dependence only on `[propext, Classical.choice, Quot.sound]` — genuinely **0-axiom** (no `sorryAx`, no `Lean.ofReduceBool`).

Note: verified via host `bin/lake env lean` because the Docker build path was intermittently unavailable this session (mathlib cache/permission churn); the host uses the identical pinned toolchain and Mathlib revision, so the kernel check is equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)