### PR TITLE
Enrich Degeneracy Edge Bound Sharpness (Erdős 1018 OQ-01-01): add annotations

### DIFF
--- a/src/data/proofs/erdos-1018-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1018-oq-01-oq-01/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-erdos-1018-oq-01-oq-01-header",
+    "proofId": "erdos-1018-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 41
+    },
+    "type": "concept",
+    "title": "Sharpness of the Density Threshold: Two Halves",
+    "content": "The parent entry Erdos1018OQ01 proves the combinatorial reduction behind Erdős #1018 (Kostochka–Pyber): a graph with more than k·n edges contains a nonempty induced subgraph of minimum degree ≥ k+1. The parent ASSERTS its linear constant k is optimal but does not prove it. This file supplies the two halves that together certify optimality: (1) the CONVERSE edge bound — every k-degenerate graph has at most k·n edges (the upper side of the threshold) — and (2) an explicit EXTREMAL witness, the complete split graph K_k ∨ K̄_{n−k}, which is k-degenerate yet has exactly k·n − C(k+1,2) edges. Only together do an upper bound and an attaining example establish sharpness: the coefficient k cannot be lowered, and the additive slack is pinned to exactly C(k+1,2).",
+    "mathContext": "Parent: $\\#E > k\\,n \\Rightarrow \\exists$ induced subgraph of min-degree $\\ge k+1$. Here: $k$-degenerate $\\Rightarrow \\#E \\le k\\,n$, attained to within $\\binom{k+1}{2}$ by $K_k \\vee \\overline{K_{n-k}}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "graph degeneracy / colouring number",
+      "Kostochka–Pyber theorem",
+      "extremal sharpness (bound + witness)",
+      "Erdős problem #1018"
+    ],
+    "prerequisites": [
+      "the parent extraction lemma",
+      "minimum degree of a subgraph",
+      "extremal graph theory"
+    ]
+  },
+  {
+    "id": "ann-erdos-1018-oq-01-oq-01-converse",
+    "proofId": "erdos-1018-oq-01-oq-01",
+    "range": {
+      "startLine": 43,
+      "endLine": 66
+    },
+    "type": "theorem",
+    "title": "The Converse Edge Bound as a Contrapositive",
+    "content": "`IsKDegenerate G k := ∀ T : Finset V, T.Nonempty → ∃ v ∈ T, degOn G T v ≤ k` — every nonempty vertex set induces a vertex of within-degree ≤ k. This is exactly the negation of the extraction lemma's conclusion (that some induced subgraph has minimum within-degree > k). `degenerate_edge_bound` then shows a k-degenerate graph has at most k·n edges by pure contraposition: `by_contra` assumes > k·n edges, the parent's `exists_dense_induced_subgraph` produces a nonempty T with every within-degree > k, k-degeneracy yields a vertex v ∈ T with within-degree ≤ k, and `omega` closes the numeric contradiction. No new combinatorics is needed — the upper side of the threshold IS the extraction lemma read backwards.",
+    "mathContext": "$G$ is $k$-degenerate $\\iff \\lnot\\big(\\exists\\,T \\neq \\emptyset,\\ \\forall v \\in T,\\ \\deg_T(v) > k\\big)$; hence $k$-degenerate $\\Rightarrow \\#E \\le k\\,n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "k-degeneracy",
+      "contrapositive proof",
+      "within-degree degOn",
+      "exists_dense_induced_subgraph"
+    ],
+    "prerequisites": [
+      "the parent extraction lemma",
+      "by_contra / push_neg",
+      "omega"
+    ]
+  },
+  {
+    "id": "ann-erdos-1018-oq-01-oq-01-split-graph",
+    "proofId": "erdos-1018-oq-01-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 112
+    },
+    "type": "definition",
+    "title": "The Complete Split Graph and Its Universal Part",
+    "content": "`splitGraph n k` is defined on `Fin n` with `Adj i j := i ≠ j ∧ (i.val < k ∨ j.val < k)`: the first k vertices (value < k) are universal, the remaining n−k form an independent set. Symmetry and looplessness are immediate from the definition, adjacency is made decidable (`splitGraph_decidableAdj`), and a `@[simp]` lemma `splitGraph_adj` exposes the defining iff. The universal part {w : w.val < k} is counted by injecting `Fin.val` into `Finset.range k`: `card_lt_le` gives ≤ k always (image ⊆ range k, `card_image_of_injective` with `Fin.val_injective`), and `card_lt_eq` gives exactly k when k ≤ n (the image equals range k). This split graph is the extremal k-degenerate graph, and — crucially — needs no vertex elimination ordering, unlike a general k-tree.",
+    "mathContext": "$\\operatorname{Adj}(i,j) \\iff i \\neq j \\wedge (i < k \\vee j < k);\\quad \\#\\{w : w < k\\} = \\min(n,k),\\ = k \\text{ if } k \\le n.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "complete split graph K_k ∨ K̄_{n-k}",
+      "universal vs independent vertices",
+      "decidable adjacency relation",
+      "Fin.val injection into range"
+    ],
+    "prerequisites": [
+      "SimpleGraph on Fin n",
+      "Finset.card_image_of_injective",
+      "Finset.range"
+    ]
+  },
+  {
+    "id": "ann-erdos-1018-oq-01-oq-01-degrees-edges",
+    "proofId": "erdos-1018-oq-01-oq-01",
+    "range": {
+      "startLine": 114,
+      "endLine": 185
+    },
+    "type": "theorem",
+    "title": "Degrees and the Exact Edge Count via the Handshake Lemma",
+    "content": "The two vertex types have constant degree: `degree_universal` shows a universal vertex (value < k) is adjacent to every other vertex, so has degree n−1 (its neighbour filter is `univ.erase i`); `degree_independent` shows an independent vertex is adjacent only to the k universal vertices, so has degree k. Summing over all vertices with the handshake lemma `sum_degrees_eq_twice_card_edges` and splitting the sum into universal/independent blocks (`sum_filter_add_sum_filter_not`, with the block sizes k and n−k from `card_lt_eq` / `filter_card_add_filter_neg_card_eq_card`) gives ∑ deg = k(n−1) + (n−k)k = 2kn − k − k². `splitGraph_two_mul_edges` records this in the division-free form 2·|E| + k(k+1) = 2kn, keeping the arithmetic `omega`-friendly and avoiding any premature division.",
+    "mathContext": "$\\textstyle\\sum_v \\deg v = k(n-1) + (n-k)k = 2kn - k - k^2;\\quad 2\\,\\#E + k(k+1) = 2kn.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "handshake lemma",
+      "degree of universal / independent vertices",
+      "sum splitting over a filter",
+      "division-free arithmetic for omega"
+    ],
+    "prerequisites": [
+      "sum_degrees_eq_twice_card_edges",
+      "neighborFinset_eq_filter",
+      "Finset.sum_filter_add_sum_filter_not"
+    ]
+  },
+  {
+    "id": "ann-erdos-1018-oq-01-oq-01-sharpness",
+    "proofId": "erdos-1018-oq-01-oq-01",
+    "range": {
+      "startLine": 187,
+      "endLine": 246
+    },
+    "type": "theorem",
+    "title": "k-Degeneracy of the Witness and the Sharpness Theorem",
+    "content": "`splitGraph_kDegenerate` proves the witness is k-degenerate by a clean case split on a vertex set T. If T contains any independent-part vertex v (v.val ≥ k), then v's neighbours inside T are among the ≤ k universal vertices (the adjacency forces the OTHER endpoint into the universal part), so degOn T v ≤ k. Otherwise every vertex of T is universal, hence |T| ≤ k (via `card_lt_le`), and any vertex has within-degree ≤ |T|−1 ≤ k (neighbours ⊆ `T.erase v`, `card_erase_of_mem`). No elimination ordering is required. `splitGraph_sharp` bundles k-degeneracy with the edge identity 2|E| + k(k+1) = 2kn; combined with `degenerate_edge_bound` this certifies the coefficient k is optimal. `splitGraph_edge_count` extracts the closed form |E| = k·n − C(k+1,2) using `Nat.even_mul_succ_self` (k(k+1) is even) and `omega`.",
+    "mathContext": "$S_{n,k}$ is $k$-degenerate with $\\#E = k\\,n - \\binom{k+1}{2}$; with the converse bound $\\#E \\le k\\,n$ this pins the coefficient $k$ as optimal and the slack as exactly $\\binom{k+1}{2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "k-degeneracy without an ordering",
+      "case split on independent-part membership",
+      "sharpness = bound + witness",
+      "C(k+1,2) additive slack"
+    ],
+    "prerequisites": [
+      "the converse edge bound",
+      "the exact split-graph edge count",
+      "Nat.even_mul_succ_self / omega"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-1018-oq-01-oq-01`.

## What changed
This entry had **no `annotations.json`** at all (quality score 45 — the lowest served this session), so the proof page showed the source with zero inline commentary despite a rich `meta.json`. Created `annotations.json` from scratch: **5 annotations**, one per section of the 246-line source.

| Annotation | Range | Section |
|---|---|---|
| Header | 1–41 | sharpness = bound + witness |
| Converse edge bound | 43–66 | k-degenerate ⟹ ≤ k·n edges (contrapositive) |
| Split graph | 68–112 | `splitGraph` def + universal-part counts |
| Degrees & edges | 114–185 | handshake lemma → 2\|E\|+k(k+1)=2kn |
| Sharpness | 187–246 | ordering-free k-degeneracy + `splitGraph_sharp` |

Each annotation carries proof-level `content` (naming actual lemmas/tactics — `exists_dense_induced_subgraph`, `card_image_of_injective`, `sum_degrees_eq_twice_card_edges`, `Nat.even_mul_succ_self`), `mathContext` LaTeX, `relatedConcepts`, and `prerequisites`. All `type`/`significance` values use canonical enums.

Verified no concurrent enrichment on `origin/main` before working (last commit was the research PR #31707). No `meta.json` change (already comprehensive, under the size cap).

## Validation
- JSON parses; 5 annotations, all required fields present.
- Line ranges in-bounds (≤246), non-overlapping, ascending, covering the whole file.
- Enum values within schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)