### PR TITLE
audit(abel-ruffini-galois-extensions-oq-01): badge original → mathlib

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-01/meta.json
@@ -18,7 +18,7 @@
       "advanced"
     ],
     "proofRepoPath": "Proofs/AbelRuffiniGaloisExtensionsOQ01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 272,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `abel-ruffini-galois-extensions-oq-01` (Explicit Quintic with Galois Group S₅ — X⁵ − 4X + 2)
**Severity**: MEDIUM (Mathlib wrapper claimed as `original`)

## Finding

The entry is badged `original` but its **core mathematical result** — the Galois group of `X⁵ − 4X + 2` acts as the *full* symmetric group on its five complex roots — is obtained by calling Mathlib's deep theorem `Polynomial.Gal.galActionHom_bijective_of_prime_degree'`. In addition, the entire `Φ = X⁵ − aX + b` development (irreducibility via Eisenstein, real-root ≤3 / ≥2 bounds, complex-root count, bijective action) is, by the file's own repeated admission, a reproduction of T. Browning's `Archive/Wiedijk100Theorems/AbelRuffini.lean` (reproduced only because Archive isn't importable downstream).

Per the auditor skill:
- **Tier A** (`original`/`verified`) requires "no imported deep theorem doing the core work" — not satisfied here.
- **Failure Mode 5** ("0 sorries with hidden imports"): main result via a deep Mathlib theorem ⇒ badge must be `mathlib`.
- **Severity table**: "Mathlib wrapper claimed as original" ⇒ MEDIUM, update badge.

**Consistency**: the grandparent `abel-ruffini` entry — which formalizes the *same* `X⁵ − 4X + 2` result — is badged `mathlib`, as are the Mathlib-reliant siblings (`abel-ruffini-oq-04`, `-oq-06`, `-oq-11`, …). `original` on OQ-01 is the outlier.

## Fix

`meta.badge`: `original` → `mathlib`.

Nothing else changes: `status` stays `verified` (the file genuinely has 0 sorries, 0 axioms — confirmed against the Lean source), and the narrative is already scrupulously honest (the module docstring, `description`, `mathlibDependencies`, `originalContributions`, and `assumptions` all disclose the Mathlib/Archive reliance and correctly scope the genuinely new content — `galEquivS5`, `permCongrMulEquiv`). Only the badge glyph was inconsistent with the disclosed reality.

## Verification
- `lineCount` 272 = `wc -l` ✓
- `theoremCount` 22, `definitionCount` 4 = source ✓
- 0 `sorry`, 0 `axiom`, 0 True-stubs in source ✓

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)