### PR TITLE
Enrich Degeneracy Bounds the Chromatic Number (erdos-1018-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/erdos-1018-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1018-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "context",
+    "title": "Degeneracy on the Colouring Axis",
+    "content": "The docstring situates this file as the colouring counterpart of the parent's edge bound. Both facts flow from the single hypothesis IsKDegenerate G k: in every non-empty induced subgraph there is a vertex of within-degree ≤ k. The grandparent (Erdos1018OQ01) extracts a dense subgraph from an edge count; the parent (Erdos1018OQ01OQ01) turns degeneracy into |E| ≤ k·n; here the same hypothesis is turned into χ(G) ≤ k+1, and the same split graph S_{n,k} witnesses tightness of both bounds simultaneously.",
+    "mathContext": "$k\\text{-degenerate} \\implies |E| \\le k\\,n \\ \\text{and}\\ \\chi(G) \\le k+1$; both sharp on $S_{n,k}=K_k \\vee \\overline{K_{n-k}}$.",
+    "significance": "context",
+    "relatedConcepts": ["graph degeneracy", "colouring number", "chromatic number", "extremal graph theory"],
+    "prerequisites": ["simple graphs", "graph colouring"]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01",
+    "range": { "startLine": 35, "endLine": 46 },
+    "type": "technique",
+    "title": "Reusing the Parent's Definitions",
+    "content": "Rather than redefine degeneracy or the split graph, the file opens the parent namespaces and imports exactly the reusable pieces: degOn (within-set degree), IsKDegenerate, splitGraph and its adjacency lemma splitGraph_adj, the k-degeneracy proof splitGraph_kDegenerate, and the universal-part cardinality lemmas card_lt_le / card_lt_eq. This keeps the two extremal axes (edges and colours) anchored to one identical hypothesis and one identical witness graph.",
+    "mathContext": "$\\deg_T(v) = \\#\\{w \\in T : v \\sim w\\}$; IsKDegenerate: every non-empty $T$ has $v \\in T$ with $\\deg_T(v) \\le k$.",
+    "significance": "technical",
+    "relatedConcepts": ["induced subgraph", "modular formalization", "namespace reuse"],
+    "prerequisites": ["Lean namespaces", "Mathlib SimpleGraph"]
+  },
+  {
+    "id": "ann-strong-induction",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01",
+    "range": { "startLine": 55, "endLine": 64 },
+    "type": "technique",
+    "title": "Ordering-Free Greedy Colouring by Strong Induction",
+    "content": "The heart of the greedy theorem. Instead of materialising a degeneracy elimination order, exists_proper_coloring_on runs Finset.strongInduction over the strict-subset order on vertex sets T. At each step IsKDegenerate regenerates a low-degree vertex v ∈ T with degOn T v ≤ k, the inductive hypothesis colours T.erase v (a strict subset via Finset.erase_ssubset), and v is coloured last. The colouring is carried as a single global function V → Fin (k+1), not a partial map, so there is no bookkeeping of 'already-coloured' vertices.",
+    "mathContext": "Induct on $T$ over $\\subsetneq$: colour $T \\setminus \\{v\\}$, then extend to $v$. The low-degree $v$ comes from IsKDegenerate each step.",
+    "significance": "key",
+    "relatedConcepts": ["greedy algorithm", "strong induction", "well-founded recursion", "elimination ordering"],
+    "prerequisites": ["structural induction", "Finset order"]
+  },
+  {
+    "id": "ann-free-colour",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01",
+    "range": { "startLine": 65, "endLine": 77 },
+    "type": "insight",
+    "title": "A Free Colour Always Exists: Pure Counting",
+    "content": "The colours forbidden for v are the image under c' of its neighbours N in T, so #forbidden ≤ #N ≤ degOn T v ≤ k via Finset.card_image_le. Since the palette Fin (k+1) has k+1 > k elements, forbidden cannot equal univ. The proof makes this a proper-subset argument: forbidden ⊊ univ, and Finset.exists_of_ssubset produces an explicit unused colour col. This is exactly why k+1 colours — not fewer — suffice: k neighbours can block at most k colours.",
+    "mathContext": "$\\#\\{\\text{forbidden colours}\\} \\le \\deg_T(v) \\le k < k+1 = \\#\\mathrm{Fin}(k+1)$, so some colour is free.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "image cardinality", "proper subset"],
+    "prerequisites": ["Finset cardinality", "counting arguments"]
+  },
+  {
+    "id": "ann-properness-cases",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01",
+    "range": { "startLine": 79, "endLine": 99 },
+    "type": "technique",
+    "title": "Verifying Properness by Three-Way Case Split",
+    "content": "The extended colouring is the if-then-else update `fun x => if x = v then col else c' x`. Properness on T is checked by casing on whether each endpoint of an edge equals v. If u = v then w is a genuine neighbour of v, so c' w ∈ forbidden and col ≠ c' w by choice of col; the w = v case is symmetric; if neither equals v, both lie in T.erase v and the inductive hypothesis hc' applies directly. G.ne_of_adj supplies u ≠ w, ruling out the u = v = w corner.",
+    "mathContext": "$c(x) = \\mathbf{1}[x=v]\\,\\mathrm{col} + \\mathbf{1}[x \\ne v]\\,c'(x)$; adjacency $u \\sim w$ ⟹ $c(u) \\ne c(w)$ by three cases on $\\{u=v, w=v, \\text{else}\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["case analysis", "function update", "proper colouring"],
+    "prerequisites": ["conditional definitions", "adjacency symmetry"]
+  },
+  {
+    "id": "ann-colorable",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01",
+    "range": { "startLine": 101, "endLine": 106 },
+    "type": "concept",
+    "title": "Packaging the Colouring: χ(G) ≤ k+1",
+    "content": "degenerate_colorable specialises the core lemma to T = univ, obtaining a global function c proper on all adjacent pairs, then wraps it with SimpleGraph.Coloring.mk to produce a term of G.Colorable (k+1). This is the formal statement that the chromatic number of any k-degenerate graph is at most k+1 — the greedy bound, the colouring analogue of the parent's |E| ≤ k·n.",
+    "mathContext": "$\\chi(G) \\le k+1$ for every $k$-degenerate $G$.",
+    "significance": "key",
+    "relatedConcepts": ["chromatic number", "SimpleGraph.Coloring", "colouring number"],
+    "prerequisites": ["chromatic number definition"]
+  },
+  {
+    "id": "ann-clique",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01",
+    "range": { "startLine": 110, "endLine": 133 },
+    "type": "insight",
+    "title": "The (k+1)-Clique Inside the Split Graph",
+    "content": "For tightness, splitGraph_isClique shows the k universal vertices {w : w.val < k} together with one independent-part vertex p (with k ≤ p.val) are pairwise adjacent: every pair contains a universal endpoint, and in splitGraph adjacency holds whenever one endpoint is universal. splitGraph_clique_card then counts this set to exactly k+1 — p is not in the universal part, which itself has exactly k vertices (card_lt_eq, needing k ≤ n). This clique is what forces χ ≥ k+1.",
+    "mathContext": "$\\{p\\} \\cup \\{w : w<k\\}$ is a clique of size $k+1$ in $S_{n,k}$; universal vertices dominate all others.",
+    "significance": "key",
+    "relatedConcepts": ["clique", "split graph", "universal vertex", "join of graphs"],
+    "prerequisites": ["cliques", "Finset.card_insert"]
+  },
+  {
+    "id": "ann-tightness",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01",
+    "range": { "startLine": 135, "endLine": 160 },
+    "type": "concept",
+    "title": "Tightness: χ(S_{n,k}) = k+1 Exactly",
+    "content": "splitGraph_not_colorable feeds the (k+1)-clique into IsClique.card_le_of_colorable: a k-colouring would force k+1 ≤ k, impossible. Combined with degenerate_colorable (the split graph is k-degenerate by the parent), splitGraph_chromatic concludes S_{n,k} is (k+1)-colourable but not k-colourable, so its chromatic number is exactly k+1. The greedy bound is therefore attained, and — with the parent's edge result — the same graph realises both extremal facts of the degeneracy parameter.",
+    "mathContext": "$\\chi(S_{n,k}) = k+1$ for $k<n$: clique lower bound $\\ge k+1$ meets greedy upper bound $\\le k+1$.",
+    "significance": "key",
+    "relatedConcepts": ["clique number lower bound", "chromatic number", "sharpness", "extremal witness"],
+    "prerequisites": ["clique-chromatic inequality", "pigeonhole"]
+  }
+]

--- a/src/data/proofs/erdos-1018-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/erdos-1018-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1018OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1018Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1018Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1018Oq01Oq01Oq01Data: ProofData = {
+  proof: erdos1018Oq01Oq01Oq01Proof,
+  annotations: erdos1018Oq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-1018-oq-01-oq-01-oq-01` (greedy colouring of k-degenerate graphs + split-graph tightness).

## Gaps closed
This entry was missing **both** `annotations.json` and `index.ts`. Without `index.ts`, Vite's `import.meta.glob` cannot discover the proof, so the page showed **"proof not found"** on the live site despite appearing in the gallery listing.

## Changes
- **Created `index.ts`** using the standard gallery template (camelCase `erdos1018Oq01Oq01Oq01`, Lean file `Erdos1018OQ01OQ01OQ01`). Matches the 549 existing gallery index files verbatim in structure.
- **Created `annotations.json`** — 8 substantive annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering:
  - the degeneracy/colouring framing vs the parent's edge axis
  - reuse of parent definitions (IsKDegenerate, splitGraph)
  - ordering-free greedy colouring via `Finset.strongInduction`
  - the free-colour counting argument (#forbidden ≤ k < k+1)
  - properness verification by three-way case split
  - packaging χ(G) ≤ k+1
  - the (k+1)-clique inside the split graph
  - tightness: χ(S_{n,k}) = k+1 exactly

## Notes
- `meta.json` was already rich (14.6 KB, under all size caps) with full overview, conclusion, crossReferences, and references — left unchanged.
- JSON validated; the gallery enrichment generation step ran cleanly over the entry. Full `pnpm build` (tsc/vite) could not complete in the worktree because `better-sqlite3` fails its native gyp build under node v26 — an environment limitation unrelated to this change.
- Axiom integrity: verified status/badge/axiomCount (0 axioms, verified) match the Lean source.