### PR TITLE
Fix: realign pascals-hexagon count metadata to Lean source

### DIFF
--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -47,11 +47,11 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 1,
-    "lineCount": 1680,
+    "lineCount": 1713,
     "assumptions": "1 axiom (conic_implies_pascal_constraint), retained only for the asymmetric/degenerate conic case. The Sylvester's-law reduction for the standard conic is now fully proved (0 sorries).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 49,
-    "definitionCount": 28
+    "theoremCount": 30,
+    "definitionCount": 24
   },
   "overview": {
     "historicalContext": "Blaise Pascal discovered this theorem in 1639, at age 16, calling it the *Hexagrammum Mysticum* (Mystic Hexagram). His original proof, presented to the Académie Parisienne, was lost, but its statement was recorded by Leibniz, who found it among Pascal's papers. Pascal claimed to derive over 400 corollaries from this single result.\n\nThe theorem became a cornerstone of projective geometry, which was systematically developed by Jean-Victor Poncelet in his 1822 *Traité des propriétés projectives des figures*. Charles-Julien Brianchon discovered the dual theorem in 1806 as a student at the École Polytechnique: if a hexagon is circumscribed about a conic, the three main diagonals are concurrent.\n\nThe configuration of 60 Pascal lines arising from permutations of six points on a conic — the *Hexagrammum Mysticum* configuration — attracted major attention from Jakob Steiner (1828), Thomas Kirkman (1849), Arthur Cayley (1849), and George Salmon (1852), who discovered its remarkable incidence properties: 20 Steiner points, 60 Kirkman points, and 15 Plücker lines.\n\nPascal's theorem appears as #28 in Freek Wiedijk's list of 100 greatest theorems. The formalization here uses projective coordinates in $\\mathbb{R}^3$ with the cross product serving double duty for line-through and line-intersection, and the key algebraic identity axiomatized via the Cayley-Bacharach / Bézout argument.",
@@ -315,11 +315,11 @@
   ],
   "leanFile": {
     "path": "Proofs/PascalsHexagon.lean",
-    "lineCount": 1680,
+    "lineCount": 1713,
     "axiomCount": 1,
     "sorries": 0,
-    "theoremCount": 49,
-    "definitionCount": 28,
+    "theoremCount": 30,
+    "definitionCount": 24,
     "imports": [
       "import Mathlib.Data.Real.Basic",
       "import Mathlib.LinearAlgebra.Matrix.Determinant.Basic",


### PR DESCRIPTION
## Fix

`pascals-hexagon` meta.json overstated its theorem/definition counts. Realigned both `leanFile` and `meta` blocks to the canonical extractor values.

## Evidence

**Before**: lineCount=1680, theoremCount=49, definitionCount=28
**After**: lineCount=1713, theoremCount=30, definitionCount=24

Ground truth via canonical extractor (`scripts/research/enrich-research.ts`): 30 genuine `theorem`/`lemma` declarations, 24 `def`/`noncomputable def`/`opaque def` declarations. All 30 theorems verified as real Lean declarations (not docstring prose).

axiomCount=1 (real `axiom conic_implies_pascal_constraint`, line 255), sorries=0 (the `sorry` tokens present are prose in docstrings), status=axiomatized unchanged.

---
Automated fix by lean-mechanic agent.