### PR TITLE
Enrich Erdős #95 Cauchy–Schwarz Bridge (OQ-04): fix enums + full coverage

### DIFF
--- a/src/data/proofs/erdos-95-oq-04/annotations.json
+++ b/src/data/proofs/erdos-95-oq-04/annotations.json
@@ -20,14 +20,35 @@
     ]
   },
   {
+    "id": "ann-scaffolding",
+    "proofId": "erdos-95-oq-04",
+    "range": { "startLine": 57, "endLine": 96 },
+    "type": "definition",
+    "title": "The Self-Contained #95 Scaffolding",
+    "content": "The minimal Erdős #95 setup, re-developed here so the file needs none of the parent's axiomatized machinery. `Point := EuclideanSpace ℝ (Fin 2)`; the distance `dist p q := ‖p − q‖` is marked `@[irreducible]` on purpose — the fibre-counting proofs must not let `whnf` descend into the Euclidean norm, so the counting stays purely structural. A `PointConfig` bundles a nonempty `Finset Point`. From it: `distanceSet P` = the image of `offDiag` under `dist` (all pairwise distances between distinct points), `multiplicity P d` = f(d) = the size of the fibre `{(p,q) : dist p q = d}`, `sumSquaredMultiplicities P` = ∑_d f(d)² (the Erdős #95 quantity), and `distinctDistances P` = |distanceSet P| = t (the Erdős #94 quantity). These seven definitions are the entire vocabulary of the file.",
+    "mathContext": "$f(d) = |\\{(p,q)\\in\\mathrm{offDiag} : \\mathrm{dist}(p,q)=d\\}|,\\quad t = |\\mathrm{distanceSet}\\,P|.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "EuclideanSpace ℝ (Fin 2)",
+      "irreducible definitions",
+      "Finset.offDiag / image / filter",
+      "distance multiplicity function"
+    ],
+    "prerequisites": [
+      "Finset basics",
+      "Euclidean distance",
+      "fibre of a map"
+    ]
+  },
+  {
     "id": "ann-first-moment",
     "proofId": "erdos-95-oq-04",
     "range": { "startLine": 97, "endLine": 131 },
-    "type": "proof-technique",
+    "type": "tactic",
     "title": "First moment by fibre decomposition",
     "content": "sum_multiplicities proves $\\sum_d f(d) = n(n-1)$. The map $(p,q)\\mapsto \\mathrm{dist}(p,q)$ sends every ordered pair of distinct points (an element of offDiag) into the distance set, and $f(d)$ is by definition the size of the fibre over $d$. So `Finset.card_eq_sum_card_fiberwise` (fed a `Set.MapsTo`) rewrites $|\\mathrm{offDiag}|$ as $\\sum_d f(d)$, and `Finset.offDiag_card` evaluates $|\\mathrm{offDiag}| = n\\cdot n - n = n(n-1)$. The distance function is marked `irreducible` so the fibre-matching stays structural and does not unfold into the Euclidean norm.",
     "mathContext": "$\\sum_d f(d) = |\\mathrm{offDiag}| = n(n-1)$",
-    "significance": "standard",
+    "significance": "supporting",
     "relatedConcepts": [
       "fibrewise counting",
       "Finset.card_eq_sum_card_fiberwise",
@@ -38,10 +59,29 @@
     ]
   },
   {
+    "id": "ann-moments-real",
+    "proofId": "erdos-95-oq-04",
+    "range": { "startLine": 132, "endLine": 152 },
+    "type": "tactic",
+    "title": "Casting the Moments to ℝ",
+    "content": "The Cauchy–Schwarz lemma the bridge uses lives over an ordered ring with subtraction, so the ℕ-valued moments must first be restated over ℝ. `sum_multiplicities_real` casts the first moment ∑_d (f(d):ℝ) = n(n−1) by pulling the cast through the sum (`Nat.cast_sum`) and applying `congrArg` to the ℕ identity `sum_multiplicities`. `sumSquaredMultiplicities_real` casts the second moment ∑_d (f(d):ℝ)² = sumSquaredMultiplicities P by unfolding the definition, distributing the cast (`Nat.cast_sum`), and closing with `push_cast; rfl`. These two real restatements are exactly the two inputs the Cauchy–Schwarz step rewrites with.",
+    "mathContext": "$\\sum_d (f(d):\\mathbb{R}) = n(n-1),\\qquad \\sum_d (f(d):\\mathbb{R})^2 = \\big(\\mathrm{sumSquaredMultiplicities}\\,P : \\mathbb{R}\\big).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.cast_sum",
+      "push_cast",
+      "ℕ → ℝ coercion of finite sums"
+    ],
+    "prerequisites": [
+      "casting between ℕ and ℝ",
+      "the first-moment identity"
+    ]
+  },
+  {
     "id": "ann-bridge",
     "proofId": "erdos-95-oq-04",
     "range": { "startLine": 153, "endLine": 169 },
-    "type": "proof-technique",
+    "type": "tactic",
     "title": "The Cauchy–Schwarz bridge",
     "content": "cauchy_schwarz_bound instantiates Mathlib's `sq_sum_le_card_mul_sum_sq` — the Chebyshev/Cauchy–Schwarz inequality $(\\sum_{i\\in s} g_i)^2 \\le |s|\\cdot\\sum_{i\\in s} g_i^2$ — with $s$ the distance set and $g_d = (f(d):\\mathbb{R})$. Rewriting the left side by the real first-moment identity and the right sum by the real second-moment identity yields $(n(n-1))^2 \\le t\\cdot\\sum_i f(u_i)^2$. Working over $\\mathbb{R}$ (rather than $\\mathbb{N}$) is required because the Chebyshev lemma needs an ordered ring with subtraction.",
     "mathContext": "$(n(n-1))^2 \\le t\\cdot\\sum_i f(u_i)^2$",
@@ -77,7 +117,7 @@
     "id": "ann-upper",
     "proofId": "erdos-95-oq-04",
     "range": { "startLine": 199, "endLine": 238 },
-    "type": "proof-technique",
+    "type": "tactic",
     "title": "Trivial upper bound and the sandwich",
     "content": "multiplicity_le shows each $f(d)$ is at most the $n(n-1)$ ordered pairs (its defining filter is a subset of offDiag). Hence sumSquared_le: $\\sum_d f(d)^2 \\le \\sum_d f(d)\\cdot n(n-1) = (n(n-1))\\cdot\\sum_d f(d) = (n(n-1))^2$. sumSquared_sandwich collects this with the Cauchy–Schwarz lower bound into $(n(n-1))^2/t \\le \\sum_i f(u_i)^2 \\le (n(n-1))^2$. The Guth–Katz theorem is exactly the deep sharpening of this trivial $\\approx n^4$ upper end down to $n^3\\log n$.",
     "mathContext": "$\\tfrac{(n(n-1))^2}{t} \\le \\sum_i f(u_i)^2 \\le (n(n-1))^2$",
@@ -89,6 +129,26 @@
     ],
     "prerequisites": [
       "monotonicity of finite sums"
+    ]
+  },
+  {
+    "id": "ann-sandwich",
+    "proofId": "erdos-95-oq-04",
+    "range": { "startLine": 239, "endLine": 258 },
+    "type": "theorem",
+    "title": "The Elementary Sandwich, Both Ends Axiom-Free",
+    "content": "sumSquared_sandwich is the headline packaging: for a configuration with at least one distinct distance (0 < t), $(n(n-1))^2/t \\le \\sum_i f(u_i)^2 \\le (n(n-1))^2$. The lower bound is `sumSquared_ge_of_distinct` (the Cauchy–Schwarz bridge divided by t); the upper bound is `sumSquared_le` cast to ℝ (`exact_mod_cast` then `push_cast; ring` to line up the ℕ-power with the ℝ-power). Both ends are proved from scratch with 0 axioms — the entire non-elementary content of Erdős #95 is concentrated in sharpening the trivial upper end from ≈ n⁴ to the Guth–Katz n³log n, which this file deliberately does not attempt.",
+    "mathContext": "$\\dfrac{(n(n-1))^2}{t} \\le \\sum_i f(u_i)^2 \\le (n(n-1))^2,\\qquad 0 < t.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "two-sided bound (sandwich)",
+      "exact_mod_cast / push_cast",
+      "axiom-free elementary bound",
+      "Guth–Katz as the deep sharpening"
+    ],
+    "prerequisites": [
+      "the Cauchy–Schwarz lower bound",
+      "the trivial upper bound"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-95-oq-04` (a fresh research entry from PR #31765).

## What changed
Two concrete improvements to `annotations.json`:

**1. Fix invalid enum values** left over from the research draft:
- `type: "proof-technique"` → `"tactic"` (3 annotations)
- `significance: "standard"` → `"supporting"` (1 annotation)

These weren't valid `AnnotationType` / `AnnotationSignificance` values (canonical sets are `theorem|lemma|definition|tactic|concept|insight|warning` and `critical|key|supporting`).

**2. Close annotation coverage gaps** — the original 5 annotations left three of the file's seven sections unannotated. Added:

| Annotation | Range | Section |
|---|---|---|
| scaffolding (new) | 57–96 | `Point`/`dist`/`PointConfig`/`multiplicity` defs |
| moments over ℝ (new) | 132–152 | the ℕ→ℝ casts feeding Cauchy–Schwarz |
| sandwich (new) | 239–258 | the headline two-sided bound |

Result: **8 annotations**, one per section, full contiguous coverage of the 259-line source, all with canonical enums, proof-level `content`, `mathContext`, `relatedConcepts`, and `prerequisites`.

Re-verified against `origin/main` immediately before pushing — the merged version still has the old 5 annotations with the `proof-technique` enums, so this is unique. No `meta.json` change (already has full sections + conclusion).

## Validation
- JSON parses; 8 annotations.
- All `type`/`significance` values within schema (checked programmatically).
- Ranges in-bounds (≤259), non-overlapping, ascending, covering the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)