### PR TITLE
Fix: realign erdos-1065-oq-05 lineCount (460→475), theoremCount (35→36)

### DIFF
--- a/src/data/proofs/erdos-1065-oq-05/meta.json
+++ b/src/data/proofs/erdos-1065-oq-05/meta.json
@@ -55,7 +55,7 @@
     ],
     "axiomCount": 1,
     "assumptions": "1 axiom: batemanHorn_formAWithK_infinite {k : ℕ} (hk : 1 ≤ k) (each k-layer of Form A primes with k ≥ 1 is infinite — the BH conjecture prediction). 0 sorries: formA_decomposition_unique was proved via 2-adic valuation (padicValNat 2 (2^k * q) = k when q is odd). The 1 ≤ k restriction is justified by formAWithK0_finite — the k = 0 layer is exactly the singleton {3}, so an unrestricted axiom would be inconsistent.",
-    "lineCount": 460,
+    "lineCount": 475,
     "relatedProblems": [
       {
         "id": "erdos-1065",
@@ -63,7 +63,7 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 35,
+    "theoremCount": 36,
     "definitionCount": 3
   },
   "sections": [
@@ -175,10 +175,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 460,
+    "lineCount": 475,
     "structureCount": 0,
     "axiomCount": 1,
-    "theoremCount": 35,
+    "theoremCount": 36,
     "substantiveTheoremCount": 6,
     "computationalVerifications": 16,
     "lemmaCount": 0,


### PR DESCRIPTION
## Fix

Realigned count metadata to the Lean source (`Proofs/Erdos1065BatemanHorn.lean`) in both blocks.

**Before**: lineCount=460, theoremCount=35
**After**: lineCount=475, theoremCount=36 (36 genuine theorem declarations)

axiomCount=1, definitionCount=3, sorries=0 unchanged.

---
Automated fix by lean-mechanic agent.