### PR TITLE
Enrich Sum of Squares of the First n Odd Numbers (odd-squares-sum-oq-01)

### DIFF
--- a/src/data/proofs/odd-squares-sum-oq-01/annotations.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/annotations.json
@@ -2,49 +2,117 @@
   {
     "id": "ann-overview",
     "proofId": "odd-squares-sum-oq-01",
-    "range": { "startLine": 4, "endLine": 34 },
+    "range": {
+      "startLine": 4,
+      "endLine": 34
+    },
     "type": "concept",
     "title": "The odd-indexed companion of the square-pyramidal sum",
     "content": "The header states open question OQ-01: the squares of the first $n$ odd numbers $1^2+3^2+\\cdots+(2n-1)^2$ sum to $n(2n-1)(2n+1)/3$. Indexing the $k$-th odd number as $2k+1$ for $k=0,\\dots,n-1$ gives $\\sum_{k<n}(2k+1)^2$. This is the odd-indexed sibling of the *square-pyramidal* identity $\\sum_{k\\le n}k^2 = n(n+1)(2n+1)/6$, recoverable as $\\sum_{j<2n}j^2 - 4\\sum_{k<n}k^2$. Mathlib provides the square-pyramidal sum but not this odd variant, so the file supplies both an exact $\\mathbb{N}$ form (`three_mul_sum_odd_squares`) and the rational closed form (`sum_odd_squares_rat`), each by a short induction.",
     "mathContext": "$\\sum_{k<n}(2k+1)^2 = \\dfrac{n(2n-1)(2n+1)}{3} \\;=\\; \\sum_{j<2n} j^2 \\;-\\; 4\\sum_{k<n} k^2.$",
     "significance": "supporting",
-    "prerequisites": ["Mathematical induction", "Finite sums over Finset.range", "Figurate / square-pyramidal numbers"],
-    "relatedConcepts": ["Square-pyramidal number", "Odd numbers 2k+1", "Power sums", "Closed-form summation"]
+    "prerequisites": [
+      "Mathematical induction",
+      "Finite sums over Finset.range",
+      "Figurate / square-pyramidal numbers"
+    ],
+    "relatedConcepts": [
+      "Square-pyramidal number",
+      "Odd numbers 2k+1",
+      "Power sums",
+      "Closed-form summation"
+    ]
   },
   {
     "id": "ann-integer-form",
     "proofId": "odd-squares-sum-oq-01",
-    "range": { "startLine": 46, "endLine": 62 },
-    "type": "theorem",
+    "range": {
+      "startLine": 46,
+      "endLine": 62
+    },
+    "type": "insight",
     "title": "Division-free integer form: 3·∑(2k+1)² + n = 4n³",
     "content": "The exact identity over $\\mathbb{N}$. Clearing the denominator in $\\sum (2k+1)^2 = (4n^3-n)/3$ and moving the linear term left gives $3\\sum(2k+1)^2 + n = 4n^3$ — additive, with no subtraction, so `ring` never meets a truncated $\\mathbb{N}$ difference. The base case is `simp` (empty sum). In the step, `sum_range_succ` peels off $(2m+1)^2$; a single `have key` reassociates the goal so the inductive hypothesis $3\\sum + m = 4m^3$ appears verbatim, after which `rw [key, ih]; ring` verifies $4m^3 + 3(2m+1)^2 + 1 = 4(m+1)^3$.",
     "mathContext": "$3\\sum_{k<n}(2k+1)^2 + n = 4n^3$.",
-    "significance": "critical",
-    "prerequisites": ["Mathematical induction", "Finset.sum_range_succ"],
-    "relatedConcepts": ["Power sums", "Truncated natural subtraction", "ring tactic", "Denominator clearing"]
+    "significance": "key",
+    "prerequisites": [
+      "Mathematical induction",
+      "Finset.sum_range_succ"
+    ],
+    "relatedConcepts": [
+      "Power sums",
+      "Truncated natural subtraction",
+      "ring tactic",
+      "Denominator clearing"
+    ]
   },
   {
     "id": "ann-reassociation",
     "proofId": "odd-squares-sum-oq-01",
-    "range": { "startLine": 53, "endLine": 61 },
+    "range": {
+      "startLine": 53,
+      "endLine": 61
+    },
     "type": "insight",
     "title": "Reassociating so the hypothesis appears verbatim",
     "content": "After `sum_range_succ` the goal is $3(\\sum_{k<m} + (2m+1)^2) + (m+1) = 4(m+1)^3$. The inductive hypothesis is about the *clustered* term $3\\sum_{k<m} + m$, which is not yet syntactically present. The `key` step regroups the left side by `ring` into $(3\\sum_{k<m} + m) + (3(2m+1)^2 + 1)$, exposing the hypothesis cluster exactly; rewriting by `ih` replaces it with $4m^3$ and a final `ring` finishes. This 'shape the goal to fit the hypothesis' move is what keeps the proof to two `ring` calls.",
     "mathContext": "$3\\sum_{k<m+1}(2k+1)^2 + (m+1) = (3\\sum_{k<m}(2k+1)^2 + m) + (3(2m+1)^2 + 1)$.",
     "significance": "supporting",
-    "prerequisites": ["Mathematical induction", "Associativity / commutativity of +,·", "ring tactic"],
-    "relatedConcepts": ["Inductive hypothesis matching", "Associativity", "ring tactic"]
+    "prerequisites": [
+      "Mathematical induction",
+      "Associativity / commutativity of +,·",
+      "ring tactic"
+    ],
+    "relatedConcepts": [
+      "Inductive hypothesis matching",
+      "Associativity",
+      "ring tactic"
+    ]
   },
   {
     "id": "ann-rational-form",
     "proofId": "odd-squares-sum-oq-01",
-    "range": { "startLine": 64, "endLine": 72 },
-    "type": "theorem",
+    "range": {
+      "startLine": 64,
+      "endLine": 72
+    },
+    "type": "insight",
     "title": "Rational closed form: ∑(2k+1)² = n(2n−1)(2n+1)/3",
     "content": "The classical closed form, stated over $\\mathbb{Q}$ where division by $3$ is genuine. The base case is `simp`. The inductive step peels the top term with `sum_range_succ`, rewrites the sum by the hypothesis, and then `push_cast` normalizes the cast $\\uparrow(m+1) = \\uparrow m + 1$ while `ring` verifies the field identity $\\frac{m(2m-1)(2m+1)}{3} + (2m+1)^2 = \\frac{(m+1)(2m+1)(2m+3)}{3}$. Proving it directly over $\\mathbb{Q}$ avoids any natural-number division artifact.",
     "mathContext": "$\\sum_{k<n}(2k+1)^2 = \\frac{n(2n-1)(2n+1)}{3}$ over $\\mathbb{Q}$.",
-    "significance": "critical",
-    "prerequisites": ["Mathematical induction", "Field arithmetic over ℚ", "push_cast"],
-    "relatedConcepts": ["Closed-form power sums", "Square-pyramidal number", "ℕ→ℚ casting"]
+    "significance": "key",
+    "prerequisites": [
+      "Mathematical induction",
+      "Field arithmetic over ℚ",
+      "push_cast"
+    ],
+    "relatedConcepts": [
+      "Closed-form power sums",
+      "Square-pyramidal number",
+      "ℕ→ℚ casting"
+    ]
+  },
+  {
+    "id": "ann-dual-proof",
+    "proofId": "odd-squares-sum-oq-01",
+    "range": {
+      "startLine": 40,
+      "endLine": 72
+    },
+    "type": "technique",
+    "title": "Why prove it twice: exact ℕ form and honest ℚ division",
+    "content": "The file deliberately states the result in two forms because natural-number division is truncating and would corrupt a direct ℕ statement of $n(2n-1)(2n+1)/3$. `three_mul_sum_odd_squares` keeps everything exact in $\\mathbb{N}$ by clearing the denominator ($3\\sum + n = 4n^3$), giving a machine-checkable integer identity with no rounding. `sum_odd_squares_rat` then delivers the familiar quotient form over $\\mathbb{Q}$, where $/3$ is a genuine field operation. Downstream users pick the ring that matches their needs: the exact integer identity for further ℕ reasoning, the rational closed form when the division must be literal.",
+    "mathContext": "$\\mathbb{N}$: $3\\sum(2k+1)^2 + n = 4n^3$ (exact) $\\;\\Longleftrightarrow\\;$ $\\mathbb{Q}$: $\\sum(2k+1)^2 = \\tfrac{n(2n-1)(2n+1)}{3}$.",
+    "significance": "key",
+    "prerequisites": [
+      "Natural-number vs field division",
+      "Denominator clearing"
+    ],
+    "relatedConcepts": [
+      "Truncated ℕ division",
+      "Exact identities",
+      "ℕ→ℚ casting",
+      "Reusable lemma design"
+    ]
   }
 ]

--- a/src/data/proofs/odd-squares-sum-oq-01/index.ts
+++ b/src/data/proofs/odd-squares-sum-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/OddSquaresSum.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const oddSquaresSumOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const oddSquaresSumOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const oddSquaresSumOq01Data: ProofData = {
+  proof: oddSquaresSumOq01Proof,
+  annotations: oddSquaresSumOq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `odd-squares-sum-oq-01`.

## Gaps closed
- **Created `index.ts`** (was **missing** — without it the proof page shows *'proof not found'* on the live site). Standard gallery template; camelCase `oddSquaresSumOq01`, Lean file `OddSquaresSum`.
- **Fixed off-schema annotation values**: `type: "theorem"` → `"insight"` and `significance: "critical"` → `"key"` (the type enum is concept/definition/technique/insight/context; significance is key/supporting/technical/context).
- **Added a 5th annotation** explaining the deliberate dual-proof design: an exact ℕ identity (`3∑+n=4n³`, no truncating division) plus the honest ℚ closed form `n(2n−1)(2n+1)/3`.

## Notes
- `meta.json` already rich (8.7 KB, well under caps; full overview, keyInsights, conclusion, crossReferences) — left unchanged.
- JSON validated (5 annotations). Full `pnpm build` can't run in the worktree (`better-sqlite3` native gyp build fails under node v26); enrichment-generation step ran cleanly.
- Axiom integrity: status verified, 0 axioms/0 sorries — matches the Lean source.