### PR TITLE
Enrich Triangular ⟺ 8n+1 Square (Waring g2 OQ-03-01-02): cover the header

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "overview-hierarchy",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "concept",
+    "title": "The Rank-1 Base Case of the Triangular-Rank Hierarchy",
+    "content": "The module docstring places this file as the *one-summand* base case of a triangular-rank hierarchy already in the gallery: rank 3 is Gauss's Eureka theorem (every natural is a sum of three triangular numbers, `ThreeSquaresGaussEureka`), rank 2 is the two-triangle characterization (`TwoTrianglesTwoSquares`, n = T + T ⟺ 4n+1 is a sum of two squares), and rank 1 — this file — characterizes when n is *itself* triangular: n = T(k) for some k ⟺ 8n+1 is a perfect square. The whole proof turns on one algebraic identity, (2k+1)² = 8·T(k)+1: forward gives a square from a triangular number; backward uses that 8n+1 is odd, so any root r = 2k+1, and the identity run in reverse pins n = T(k). Because k is recovered exactly and T is strictly monotone, the representation is unique. Since '8n+1 is a perfect square' is decidable, this upgrades IsTriangular to a DecidablePred — a constant-cost triangular-number test. No sorry, axiom, or native_decide.",
+    "mathContext": "$n = T(k) = \\tfrac{k(k+1)}2 \\ \\text{for some } k \\iff 8n+1 \\ \\text{is a perfect square};\\quad (2k+1)^2 = 8\\,T(k)+1.$",
+    "significance": "key",
+    "relatedConcepts": ["triangular-rank hierarchy", "Gauss Eureka theorem", "figurate numbers", "decidable characterization"],
+    "prerequisites": ["triangular numbers", "perfect squares", "parity of 8n+1"]
+  },
+  {
     "id": "tri-defs",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02",
     "range": { "startLine": 44, "endLine": 59 },

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02/meta.json
@@ -29,6 +29,14 @@
   },
   "sections": [
     {
+      "id": "overview-hierarchy",
+      "title": "Overview: The Triangular-Rank Hierarchy",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring placing this file as the rank-1 base case of the triangular-rank hierarchy (rank 3 = Gauss's Eureka theorem, rank 2 = the two-triangle characterization). States the main result n = T(k) ⟺ 8n+1 is a perfect square, the driving identity (2k+1)² = 8·T(k)+1, uniqueness of the recovered index, and the decidability upgrade to a DecidablePred. Imports Mathlib and opens the TriangularSingle namespace with tri and IsTriangular.",
+      "mathContext": "n = T(k) ⟺ 8n+1 is a perfect square; (2k+1)² = 8·T(k)+1."
+    },
+    {
       "id": "triangular-setup",
       "title": "Triangular Numbers and the Defining Identity",
       "startLine": 44,


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02`.

## What changed
The entry already had 5 valid annotations and a 2-section `sections` array, but the 117-line source's **header docstring (lines 1–43)** — the context placing this as the rank-1 base case of the triangular-rank hierarchy (rank 3 = Gauss Eureka, rank 2 = two-triangle characterization) and stating the main iff — was covered by **neither an annotation nor a section**. Added both:

- **annotation** `overview-hierarchy` (1–43): the hierarchy context, the driving identity (2k+1)² = 8·T(k)+1, index uniqueness, and the `DecidablePred` upgrade.
- **section** `overview-hierarchy` (1–43) matching it.

Result: **6 annotations** and **3 sections** giving full 1–116 coverage. The 5 existing (already-valid) annotations are unchanged; `meta.json` stays at 11.6 KB.

Re-verified against `origin/main` immediately before pushing (still 5 anns / 2 sections, no open PR for this slug).

## Validation
- Both JSON files parse.
- All annotation `type`/`significance` values within schema.
- Annotation and section ranges in-bounds (≤117), non-overlapping, ascending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)