### PR TITLE
Fix: resolve conflict markers corrupting audit-tracker.json

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25966,181 +25966,109 @@
     },
     "alternating-series-boole-summation": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:14:22Z",
-=======
       "lastAudited": "2026-07-01T01:39:28Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "cramers-rule-oq-02-oq-01-oq-01": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:32Z",
-=======
       "lastAudited": "2026-07-01T01:39:28Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "erdos-1-wip-01-oq-02": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:32Z",
-=======
       "lastAudited": "2026-07-01T01:39:29Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "erdos-100-oq-05-oq-01": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:32Z",
-=======
       "lastAudited": "2026-07-01T01:39:29Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "erdos-100-oq-05-oq-01-oq-01": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:33Z",
-=======
       "lastAudited": "2026-07-01T01:39:29Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "erdos-100-oq-05-oq-03": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:33Z",
-=======
       "lastAudited": "2026-07-01T01:39:29Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "erdos-1008-oq-02": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:33Z",
-=======
       "lastAudited": "2026-07-01T01:39:30Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "erdos-101-oq-02": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:33Z",
-=======
       "lastAudited": "2026-07-01T01:39:30Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "erdos-1011-oq-03": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:34Z",
-=======
       "lastAudited": "2026-07-01T01:39:30Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "erdos-1018-oq-01": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:34Z",
-=======
       "lastAudited": "2026-07-01T01:39:30Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "hilbert-17-oq-01-oq-01-oq-01": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:34Z",
-=======
       "lastAudited": "2026-07-01T01:39:30Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "platonic-solids-oq-03": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:34Z",
-=======
       "lastAudited": "2026-07-01T01:39:30Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "property-b-first-moment-oq-03-oq-04": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:34Z",
-=======
       "lastAudited": "2026-07-01T01:39:31Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "spherical-law-of-cosines-oq-04": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:34Z",
-=======
       "lastAudited": "2026-07-01T01:39:31Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "stars-and-bars-weak-compositions-oq-01-oq-01": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:35Z",
-=======
       "lastAudited": "2026-07-01T01:39:31Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "stars-and-bars-weak-compositions-oq-04": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:35Z",
-=======
       "lastAudited": "2026-07-01T01:39:31Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "van-der-waerden-first-moment-oq-01-oq-01": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:35Z",
-=======
       "lastAudited": "2026-07-01T01:39:31Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },
     "van-der-waerden-first-moment-oq-03": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "lastAudited": "2026-07-01T01:16:35Z",
-=======
       "lastAudited": "2026-07-01T01:39:31Z",
->>>>>>> Stashed changes
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Problem

The committed \`src/data/proofs/audit-tracker.json\` on \`main\` contains **18 unresolved git stash conflict markers** (lines 25969–26143):

\`\`\`
<<<<<<< Updated upstream
      "lastAudited": "2026-07-01T01:14:22Z",
=======
      "lastAudited": "2026-07-01T01:39:28Z",
>>>>>>> Stashed changes
\`\`\`

Each block is a single \`lastAudited\` timestamp diff (from a bad stash pop). The markers make the JSON **unparseable**, so \`scripts/auditor/find-targets.ts\` silently falls back to reporting **0/4206 audited** — effectively wiping the entire audit history from the queue.

## Fix

Resolved all 18 conflict blocks, keeping the later \`Stashed changes\` timestamps. The file is now valid JSON and the full audit history is restored:

\`\`\`
Before fix: Audited 0 / 4206   (parse failure)
After fix:  Audited 4199 / 4206
\`\`\`

Only whitespace/marker lines and duplicate timestamp lines were removed — no audit results were altered.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)