### PR TITLE
Enrich Multiquadratic Field ℚ(√2,√3,√5) Minimal Polynomial (sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04)

### DIFF
--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04/annotations.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04/annotations.json
@@ -2,10 +2,10 @@
   {
     "id": "ann-sqrt2357-oq04-even-trick",
     "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04",
-    "range": { "startLine": 1, "endLine": 56 },
+    "range": { "startLine": 1, "endLine": 65 },
     "type": "concept",
     "title": "One Lemma for All Eight Sign-Conjugates",
-    "content": "The minimal polynomial p(x) = x⁸ − 40x⁶ + 352x⁴ − 960x² + 576 of α = √2+√3+√5 involves only even powers of x. The eight Galois conjugates of α are the sign-combinations ε₁√2 + ε₂√3 + ε₃√5 with εᵢ ∈ {±1}. Writing such a conjugate as u+v+w with u = ε₁√2, v = ε₂√3, w = ε₃√5, the three relations u² = 2, v² = 3, w² = 5 hold regardless of the signs. The proof therefore quantifies over arbitrary reals u,v,w satisfying those squares and proves p(u+v+w) = 0 once — covering all eight conjugates simultaneously, rather than eight separate computations. This is the structural pay-off of the polynomial being even.",
+    "content": "The minimal polynomial p(x) = x⁸ − 40x⁶ + 352x⁴ − 960x² + 576 of α = √2+√3+√5 involves only even powers of x. The eight Galois conjugates of α are the sign-combinations ε₁√2 + ε₂√3 + ε₃√5 with εᵢ ∈ {±1}. Writing such a conjugate as a+b+c with a = ε₁√2, b = ε₂√3, c = ε₃√5, the three relations a² = 2, b² = 3, c² = 5 hold regardless of the signs. The proof therefore quantifies over arbitrary reals a,b,c satisfying those squares (theorem `key`) and proves p(a+b+c) = 0 once — covering all eight conjugates simultaneously, rather than eight separate computations. This is the structural pay-off of the polynomial being even.",
     "mathContext": "For a multiquadratic primitive element α = √d₁ + ⋯ + √dₖ, the minimal polynomial is the product ∏ (x − ∑ εᵢ√dᵢ) over ε ∈ {±1}ᵏ. Closure under ε ↦ −ε forces every odd-degree coefficient to vanish, so the minimal polynomial is even and a single square-relation lemma annihilates the entire conjugate orbit.",
     "significance": "key",
     "relatedConcepts": [
@@ -23,10 +23,10 @@
     "id": "ann-sqrt2357-oq04-squaring-chain",
     "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04",
     "range": { "startLine": 67, "endLine": 89 },
-    "type": "tactic",
+    "type": "technique",
     "title": "Successive-Squaring Chain via linear_combination",
-    "content": "conjugate_root derives p(α) = 0 (where α = u+v+w) by three squarings that eliminate one radical at a time. Step 1: α² − 2αu − 6 = 2vw, a direct linear combination of u²=2, v²=3, w²=5. Step 2: squaring and using u²=2 gives A² + 8α² − 60 = 4αu·A with A = α² − 6 (the odd-in-u term is isolated on the right). Step 3: squaring again and using u²=2 once more gives (A² + 8α² − 60)² = 32α²A², which expands as a pure polynomial in α to exactly p(α) = 0. Each equation is closed by `linear_combination` over the square relations, so the entire proof is a chain of polynomial identities verified by `ring` — no minimal-polynomial search, no numerical certificate, and no native_decide. The explicit cofactors keep every step low-degree, avoiding the unwieldy degree-6 cofactors a single-shot linear_combination would require.",
-    "mathContext": "Constructing the minimal polynomial of a sum of square roots by repeated squaring is classical (it realizes the resultant / norm form). Casting each squaring as a `linear_combination` of the defining relations uᵢ² = dᵢ turns the algebra into machine-checkable ring identities and sidesteps the large Gröbner-basis cofactors of a direct ideal-membership certificate.",
+    "content": "Theorem `key` derives p(σ) = 0 (where σ = a+b+c) by three squarings that eliminate one radical at a time. Step e1: σ² = 2σc + 2ab, a direct linear combination of a²=2, b²=3, c²=5 (using a²+b²−c²=0). Step e2: squaring and using c²=5, (ab)²=6 gives σ⁴ − 20σ² − 24 = 8σ·(abc), isolating the odd-in-radical term on the right. Final step: squaring again and using (abc)²=30 collapses to a pure polynomial in σ equal to p(σ) = 0. Each equation is closed by `linear_combination` over the square relations, so the whole proof is a chain of polynomial identities verified by `ring` — no minimal-polynomial search, no numerical certificate, no native_decide. The explicit cofactors keep every step low-degree, avoiding the unwieldy degree-6 cofactors a single-shot linear_combination would require.",
+    "mathContext": "Constructing the minimal polynomial of a sum of square roots by repeated squaring is classical (it realizes the resultant / norm form). Casting each squaring as a `linear_combination` of the defining relations aᵢ² = dᵢ turns the algebra into machine-checkable ring identities and sidesteps the large Gröbner-basis cofactors of a direct ideal-membership certificate.",
     "significance": "key",
     "relatedConcepts": [
       "resultant",
@@ -40,13 +40,33 @@
     ]
   },
   {
+    "id": "ann-sqrt2357-oq04-sign-orbit",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04",
+    "range": { "startLine": 91, "endLine": 107 },
+    "type": "concept",
+    "title": "The (ℤ/2ℤ)³ Sign-Flip Orbit of Roots",
+    "content": "`alpha_isRoot` instantiates `key` at a=√2, b=√3, c=√5 (via `Real.sq_sqrt`), giving p(α) = 0. `sign_orbit_isRoot` then handles an arbitrary sign vector: encoding each εᵢ ∈ {±1} as εᵢ² = 1, it rewrites (εᵢ√dᵢ)² = εᵢ²·dᵢ = dᵢ so the square hypotheses of `key` are met regardless of sign, and concludes p(ε₁√2 + ε₂√3 + ε₃√5) = 0. The eight sign choices are exactly the orbit of α under the conjectured Galois group (ℤ/2ℤ)³, so p factors as ∏_{ε} (x − (ε₁√2+ε₂√3+ε₃√5)) — the full root set exhibited without any Galois machinery.",
+    "mathContext": "Each of the 8 vectors (ε₁,ε₂,ε₃) ∈ {±1}³ yields a root; (εᵢ√dᵢ)² = εᵢ² dᵢ = dᵢ since εᵢ² = 1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Galois orbit",
+      "(ℤ/2ℤ)³ symmetry",
+      "conjugate roots",
+      "sign flip"
+    ],
+    "prerequisites": [
+      "Real.sq_sqrt",
+      "elementary symmetry"
+    ]
+  },
+  {
     "id": "ann-sqrt2357-oq04-maximality",
     "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04",
-    "range": { "startLine": 120, "endLine": 158 },
+    "range": { "startLine": 109, "endLine": 141 },
     "type": "concept",
     "title": "Evenness, ±-Pairing, and Strict Maximality",
-    "content": "Three structural corollaries package the symmetry of the conjugate orbit. minPoly8_even (p(−x) = p(x)) and root_neg (r a root ⟹ −r a root) record that roots come in ±r pairs — the analytic shadow of the sign flip √k ↦ −√k that generates one ℤ/2ℤ factor of the Galois group. conjugate_lt_alpha shows the all-plus conjugate α = √2+√3+√5 strictly dominates every other sign-conjugate: flipping any sign to a coefficient < 1 strictly lowers that term (since √2,√3,√5 > 0) while the rest cannot exceed their plus-values. Hence alpha_ne_proper_conjugate: α differs from each of its seven proper conjugates, so α is a simple root of p. Full pairwise distinctness of all eight (and irreducibility of p) needs ℚ-linear independence of {√2,√3,√5} and is the entry's stated open content.",
-    "mathContext": "An algebraic number is a simple root of its minimal polynomial iff the minimal polynomial is separable; for a primitive element of a Galois extension the conjugates are exactly the distinct roots. Here positivity of the radicals already separates α from its conjugates, giving simplicity of the all-plus root without the full separability argument.",
+    "content": "Three structural corollaries package the symmetry of the conjugate orbit. `p_even` (p(−x) = p(x), by `ring`) and `neg_isRoot` (x a root ⟹ −x a root) record that roots come in ±x pairs — the analytic shadow of the sign flip √k ↦ −√k that generates one ℤ/2ℤ factor of the Galois group. `alpha_strict_max` shows the all-plus conjugate α = √2+√3+√5 strictly dominates every other sign-conjugate: from εᵢ² = 1 it factors (εᵢ−1)(εᵢ+1) = 0 to split εᵢ = ±1, then a `<;>`-driven case sweep with `nlinarith` (using √2,√3,√5 > 0) shows flipping any sign to −1 strictly lowers the value. Hence α is a *simple* root and the largest root of p. Full pairwise distinctness of all eight roots (and irreducibility of p) needs ℚ-linear independence of {√2,√3,√5} and is the entry's stated open content.",
+    "mathContext": "An algebraic number is a simple root of its minimal polynomial iff the polynomial is separable. Here positivity of the radicals already separates α from its conjugates, giving simplicity of the all-plus root without the full separability argument.",
     "significance": "supporting",
     "relatedConcepts": [
       "separable polynomial",
@@ -57,6 +77,27 @@
     "prerequisites": [
       "ordering of real numbers",
       "positivity of square roots"
+    ]
+  },
+  {
+    "id": "ann-sqrt2357-oq04-finrank",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04",
+    "range": { "startLine": 143, "endLine": 190 },
+    "type": "insight",
+    "title": "Verified Upper Bound [ℚ(α) : ℚ] ≤ 8",
+    "content": "The elementary root fact is upgraded into genuine field theory. `annihilatorPoly : ℚ[X]` re-expresses p over ℚ; `annihilatorPoly_monic` (`monicity!`) and `annihilatorPoly_natDegree` (`compute_degree!`) certify it is monic of degree 8. Then `finrank_le_eight` transfers the real identity p(α) = 0 to `aeval α annihilatorPoly = 0`, so α is integral over ℚ with minpoly ℚ α ∣ annihilatorPoly. `Polynomial.natDegree_le_of_dvd` plus `IntermediateField.adjoin.finrank` gives Module.finrank ℚ ℚ⟮α⟯ = (minpoly ℚ α).natDegree ≤ 8. This is a fully verified upper bound on the extension degree — the matching lower bound = 8 (irreducibility of p) is the genuinely open part needing the multiquadratic-tower API Mathlib lacks, and is scoped out.",
+    "mathContext": "$[\\mathbb{Q}(\\sqrt2+\\sqrt3+\\sqrt5):\\mathbb{Q}] = \\deg(\\mathrm{minpoly}) \\le \\deg(p) = 8$; equality $=8$ is open.",
+    "significance": "key",
+    "relatedConcepts": [
+      "minimal polynomial divides annihilator",
+      "extension degree",
+      "IsIntegral",
+      "IntermediateField.adjoin.finrank"
+    ],
+    "prerequisites": [
+      "minpoly.dvd",
+      "Module.finrank",
+      "monicity! / compute_degree!"
     ]
   }
 ]

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04/index.ts
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const sqrt2PlusSqrt3PlusSqrt5IrrationalOq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const sqrt2PlusSqrt3PlusSqrt5IrrationalOq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const sqrt2PlusSqrt3PlusSqrt5IrrationalOq04Data: ProofData = {
+  proof: sqrt2PlusSqrt3PlusSqrt5IrrationalOq04Proof,
+  annotations: sqrt2PlusSqrt3PlusSqrt5IrrationalOq04Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04`.

## Gaps closed
- **Created `index.ts`** (was **missing** — without it the page shows *'proof not found'* on the live site). camelCase `sqrt2PlusSqrt3PlusSqrt5IrrationalOq04`, Lean file `Sqrt2PlusSqrt3PlusSqrt5IrrationalOQ04`.
- **Fixed a content-accuracy bug**: the maximality annotation referenced four theorem names that do **not exist** in the Lean file (`minPoly8_even`, `root_neg`, `conjugate_lt_alpha`, `alpha_ne_proper_conjugate`) — rewritten to the actual names `p_even`, `neg_isRoot`, `alpha_strict_max`, with a corrected line range and an accurate description of the `(εᵢ−1)(εᵢ+1)=0` sign-split + `nlinarith` sweep.
- **Fixed off-schema** `type: "tactic"` → `"technique"`.
- **Added 2 annotations** covering previously-unannotated code: `sign_orbit_isRoot` (the (ℤ/2ℤ)³ root orbit) and the field-theory section `finrank_le_eight` — the verified upper bound [ℚ(α):ℚ] ≤ 8 via `minpoly.dvd` + `IntermediateField.adjoin.finrank`. Annotations 3 → 5.

## Notes
- `meta.json` already rich (16.6 KB, under caps) — left unchanged; confirmed it does not carry the stale theorem names.
- JSON validated (5 annotations). Full `pnpm build` can't run in the worktree (`better-sqlite3` gyp build fails under node v26); enrichment-generation step ran cleanly.
- Axiom integrity: entry correctly scopes irreducibility/Galois-group as open; the verified content (root orbit + finrank ≤ 8) is 0-sorry, 0-axiom beyond foundational — matches the Lean source.