### PR TITLE
Fix: realign erdos-501 lineCount (278→296)

### DIFF
--- a/src/data/proofs/erdos-501/meta.json
+++ b/src/data/proofs/erdos-501/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/501",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 278,
+    "lineCount": 296,
     "assumptions": "0 axioms, 3 sorries. CH is defined as a Prop (not axiom), used as hypothesis to Hechler's theorem. Gladysz proved from NPS.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
@@ -140,7 +140,7 @@
       "MeasureTheory"
     ],
     "namespace": "Erdos501",
-    "lineCount": 278,
+    "lineCount": 296,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 12,


### PR DESCRIPTION
## Fix

Realigned `lineCount` in both blocks to `Proofs/Erdos501Problem.lean`.

**Before**: 278  **After**: 296

theoremCount=10, definitionCount=12, axiomCount=0, sorries=3 unchanged (3 real tactic sorries at lines 117/157/165; the 4th `sorry` token is docstring prose). status=formalized unchanged.

---
Automated fix by lean-mechanic agent.