### PR TITLE
Fix: realign greens-theorem-oq-02 lineCount (518→534), definitionCount (6→4)

### DIFF
--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -55,10 +55,10 @@
       "19 supporting lemmas on Lipschitz curves, line integrals, L¹ fields, and consequences"
     ],
     "dateAdded": "2026-04-04",
-    "lineCount": 518,
+    "lineCount": 534,
     "assumptions": "1 axiom (greens_theorem_l1curl — Whitney's 1957 theorem). 19 theorems with 0 sorries. Supporting results are fully proved using Mathlib's LipschitzWith, MeasureTheory, and trigonometric libraries.",
     "theoremCount": 19,
-    "definitionCount": 6
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "**Classical Green's theorem** (George Green, 1828) requires:\n1. **C¹ boundary**: the curve γ must have a continuous derivative everywhere\n2. **C¹ vector field**: P and Q must have continuous partial derivatives\n\n**Hasbrouck Whitney (1957)** proved these conditions can be drastically weakened. His minimal regularity theorem shows Green's theorem holds when:\n1. The boundary is merely **Lipschitz** (derivative exists a.e. but may have jumps at corners)\n2. The curl is merely **L¹** (Lebesgue integrable, not necessarily continuous)\n\nThe key mechanism is **Rademacher's theorem** (1919): every Lipschitz function is differentiable at Lebesgue-almost-every point. This gives a well-defined a.e. tangent vector to any Lipschitz curve, making the line integral meaningful.\n\nThis generalization is practically important: the boundary of a square, polygon, or any piecewise-smooth domain is Lipschitz but NOT C¹ (corners cause derivative jumps).",
@@ -215,10 +215,10 @@
       "Real"
     ],
     "namespace": "GreensTheoremOQ02",
-    "lineCount": 518,
+    "lineCount": 534,
     "axiomCount": 1,
     "theoremCount": 19,
-    "definitionCount": 6,
+    "definitionCount": 4,
     "path": "Proofs/GreensTheoremOQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Realigned metadata to the Lean source in both blocks.

**Before**: lineCount=518, definitionCount=6
**After**: lineCount=534, definitionCount=4 (canonical `^(def|noncomputable def|opaque def) ` = 4; the other declarations are `structure`s, excluded from definitionCount)

theoremCount=19 intentionally **kept**: a naive `^(theorem|lemma) ` regex reports 21, but two of those are docstring prose ('theorem remains valid?', 'theorem to hold. Compared to…'), so the real count is 19. axiomCount=1, sorries=0 unchanged.

---
Automated fix by lean-mechanic agent.