### PR TITLE
Enrich Arithmetico-Geometric Sum ∑ k·rᵏ (summation-by-parts-oq-01)

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01/annotations.json
+++ b/src/data/proofs/summation-by-parts-oq-01/annotations.json
@@ -36,7 +36,7 @@
       "startLine": 50,
       "endLine": 63
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "The closed form by induction",
     "content": "sum_range_mul_geom proves the identity by induction on n over an arbitrary field K (r ≠ 1 gives r − 1 ≠ 0). The base case is the empty sum (0 = 0/(r−1)²). The step uses Finset.sum_range_succ to add the new term m·rᵐ to the closed form at m; push_cast handles the ℕ→K casts of the index, field_simp clears the (r−1)² denominator (legal since r−1 ≠ 0), and ring discharges the resulting polynomial identity n·rⁿ(r−1)² = n·rⁿ⁺² − 2n·rⁿ⁺¹ + n·rⁿ.",
     "mathContext": "Inductive step: $\\frac{r - m r^m + (m-1)r^{m+1}}{(r-1)^2} + m r^m = \\frac{r - (m{+}1)r^{m+1} + m\\,r^{m+2}}{(r-1)^2}$, reduced to a $\\texttt{ring}$ identity after clearing denominators.",
@@ -58,5 +58,20 @@
     "significance": "key",
     "relatedConcepts": ["Abel summation", "Finset.sum_range_by_parts", "integration by parts analogue", "forward differences"],
     "prerequisites": ["summation by parts", "partial sums"]
+  },
+  {
+    "id": "ann-sbp-oq01-two-proofs",
+    "proofId": "summation-by-parts-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 81
+    },
+    "type": "insight",
+    "title": "Two independent derivations, one identity",
+    "content": "The file establishes the same weighted sum ∑ k·rᵏ by two logically independent routes: sum_range_mul_geom computes the fully-simplified rational closed form (r − n·rⁿ + (n−1)·rⁿ⁺¹)/(r−1)² by induction, while sum_range_mul_geom_eq_byParts leaves it in the structural Abel form (boundary term minus nested geometric sums). Neither is derived from the other — they are complementary views of the same object, so together they cross-validate the result: the elementary induction certifies the exact value, and the summation-by-parts form exposes WHY that value has denominator (r−1)² (each of the two summations over the geometric partial sums contributes one factor of (r−1)⁻¹). This mirrors the way a definite integral can be both evaluated by antiderivative and rearranged by integration by parts.",
+    "mathContext": "Closed form $\\dfrac{r - n r^n + (n-1)r^{n+1}}{(r-1)^2}$ (induction) $\\;=\\;(n-1)G_n - \\sum_{i<n-1} G_{i+1}$ (Abel), with $G_m=\\sum_{j<m}r^j=\\frac{r^m-1}{r-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["independent verification", "Abel summation", "closed form vs structural form", "integration by parts analogue"],
+    "prerequisites": ["geometric partial sums", "summation by parts"]
   }
 ]


### PR DESCRIPTION
Light-touch enrichment pass for `summation-by-parts-oq-01` (already had index.ts and a rich meta.json).

## Changes
- **Fixed off-schema annotation value**: `type: "tactic"` → `"technique"` (the type enum is concept/definition/technique/insight/context).
- **Added a 5th annotation** on the entry's two logically-independent derivations — the inductive closed form and the Abel summation-by-parts form — and how they cross-validate the identity and explain the `(r−1)²` denominator.

## Notes
- Did **not** inflate keyInsights (already 4, within the 4–12 range and genuinely rich, including the 'differentiating the geometric series' insight) — per the size-guardrail guidance, stopped at the minimum rather than padding.
- `meta.json` unchanged (9.7 KB, under caps).
- JSON validated (5 annotations, all schema-valid types/significance).