### PR TITLE
Fix: realign cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01 count metadata

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -16,11 +16,11 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 1077,
+    "lineCount": 1095,
     "buildStatus": "broken",
     "assumptions": "BUILD BROKEN (2026-06-24, issue #28788): this file does NOT currently compile against the pinned toolchain leanprover/lean4:v4.26.0 — Mathlib API drift produces 53 errors (`Real.HolderTriple.one_lt_of_lt` removed, `Function.sign` removed, `MeasureTheory.Measure.withDensityᵥ_apply` renamed, plus ~dozen unsolved-goals / application-type-mismatch sites). The file was last green ~2026-04 before a Mathlib bump; no automated gate built it, so the drift rotted silently. There are 0 literal `sorry` tactics and 0 `axiom` declarations, but the formalization is not currently machine-checked, so status was downgraded verified→formalized pending repair. Mathematical content (riesz_lp_surjective_from_rn via signedMeasureOfFunctional + holder_extremizer_lq_bound + rn_deriv_memLq_from_trunc + integral_representation) is unchanged; dead-path theorems (truncated_rn_deriv_lq_bound, rn_deriv_memLq) removed 2026-04-23.",
     "dateAdded": "2026-04-13",
-    "theoremCount": 18,
+    "theoremCount": 11,
     "definitionCount": 3
   },
   "overview": {
@@ -151,9 +151,9 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 1077,
+    "lineCount": 1095,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 11,
     "definitionCount": 3,
     "mainTheorems": [
       {


### PR DESCRIPTION
## Fix

Realigned metadata to the Lean source in both blocks. The theorem count was stale after the file's repair history (error reduction 44→11, PR #28788 series consolidated declarations).

**Before**: lineCount=1077, theoremCount=18
**After**: lineCount=1095, theoremCount=11 (11 genuine `theorem` declarations, canonical extractor)

axiomCount=0, definitionCount=3, sorries=0 unchanged (0 real tactic sorries; the `sorry` tokens present are docstring prose). status=formalized unchanged.

---
Automated fix by lean-mechanic agent.