### PR TITLE
Fix: realign erdos-1017-oq-03 count metadata to Lean source

### DIFF
--- a/src/data/proofs/erdos-1017-oq-03/meta.json
+++ b/src/data/proofs/erdos-1017-oq-03/meta.json
@@ -8,14 +8,14 @@
     ],
     "opens": [],
     "namespace": "Erdos1017OQ03",
-    "lineCount": 145,
+    "lineCount": 200,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 10,
     "definitionCount": 1,
     "path": "Proofs/Erdos1017OQ03.lean",
     "sorries": 0
   },
-  "description": "Supplies the explicit parity-split closed forms, strict growth, and two-sided real envelope of the Turán extremal bound T(n) = floor(n^2/4) underlying Erdős Problem #1017 (clique partition of dense graphs: f(n,k) = min complete subgraphs to edge-partition an n-vertex k-edge graph, with the Erdős-Goodman-Pósa bound f <= floor(n^2/4) and extremal complete bipartite graph). The companion file Erdos1017OQ01.lean records the product form T(n) = floor(n/2)(n - floor(n/2)) and non-strict monotonicity; this sibling adds: T(2m) = m^2 (K_{m,m} has m^2 edges), T(2m+1) = m(m+1) (K_{m,m+1} has m(m+1) edges), the exact one-step increment T(n+1) - T(n) = floor((n+1)/2), STRICT monotonicity T(n) < T(n+1) for n >= 1, the upper real envelope T(n) <= n^2/4, the exact integer identity 4*T(n) = n^2 - (n mod 2) (equivalently n^2 mod 4 = n mod 2), and the matching lower real envelope (n^2 - 1)/4 <= T(n) — together sandwiching T(n) as (n^2 - 1)/4 <= T(n) <= n^2/4, pinning it within 1/4 of the exact quarter-square. Self-contained (re-declares T, depends only on Mathlib). 7 theorems, 1 definition, 0 sorries, 0 axioms.",
+  "description": "Supplies the explicit parity-split closed forms, strict growth, and two-sided real envelope of the Turán extremal bound T(n) = floor(n^2/4) underlying Erdős Problem #1017 (clique partition of dense graphs: f(n,k) = min complete subgraphs to edge-partition an n-vertex k-edge graph, with the Erdős-Goodman-Pósa bound f <= floor(n^2/4) and extremal complete bipartite graph). The companion file Erdos1017OQ01.lean records the product form T(n) = floor(n/2)(n - floor(n/2)) and non-strict monotonicity; this sibling adds: T(2m) = m^2 (K_{m,m} has m^2 edges), T(2m+1) = m(m+1) (K_{m,m+1} has m(m+1) edges), the exact one-step increment T(n+1) - T(n) = floor((n+1)/2), STRICT monotonicity T(n) < T(n+1) for n >= 1, the upper real envelope T(n) <= n^2/4, the exact integer identity 4*T(n) = n^2 - (n mod 2) (equivalently n^2 mod 4 = n mod 2), and the matching lower real envelope (n^2 - 1)/4 <= T(n) — together sandwiching T(n) as (n^2 - 1)/4 <= T(n) <= n^2/4, pinning it within 1/4 of the exact quarter-square. A further layer records the algebraic structure of T: the quarter-square multiplication identity T(m+n) - T(m-n) = m*n, the exact second difference Δ²T(n) = (n+1) mod 2, and the resulting discrete convexity 2*T(n+1) <= T(n+2) + T(n). Self-contained (re-declares T, depends only on Mathlib). 10 theorems, 1 definition, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "date": "formalized 2026",
@@ -34,8 +34,8 @@
     "dateAdded": "2026-06-22",
     "axiomCount": 0,
     "assumptions": "Machine-checked: `./proofs/scripts/docker-build.sh Proofs.Erdos1017OQ03` builds green (Lean v4.26.0, Mathlib pin, 7743 jobs). 0 sorries, 0 axiom declarations, no native_decide; only the standard foundational axioms via Mathlib. Self-contained: the Turán bound T(n) = n^2/4 is re-declared (the companion Erdos1017OQ01.lean carries 2 axioms egp_theorem and k4free_partition_number, which are not imported or used here). Honest scope: elementary closed-form, monotonicity, and envelope arithmetic of the extremal bound, not the open clique-partition question itself.",
-    "lineCount": 145,
-    "theoremCount": 7,
+    "lineCount": 200,
+    "theoremCount": 10,
     "definitionCount": 1,
     "originalContributions": [
       "turanBound_two_mul: even closed form T(2m) = m^2 (the extremal K_{m,m} has m^2 edges)",
@@ -44,7 +44,10 @@
       "turanBound_strictMono: STRICT monotonicity T(n) < T(n+1) for n >= 1, sharpening the companion's non-strict bound",
       "turanBound_le_sq_div_four: the upper real-valued envelope T(n) <= n^2/4 (the floor never exceeds the exact quarter-square)",
       "turanBound_four_mul: the exact integer identity 4*T(n) = n^2 - (n mod 2), i.e. n^2 mod 4 = n mod 2 — the floor discards exactly the parity bit",
-      "turanBound_ge_sq_sub_one_div_four: the lower real envelope (n^2 - 1)/4 <= T(n), which together with the upper envelope sandwiches T(n) within 1/4 of n^2/4 and yields T(n) ~ n^2/4"
+      "turanBound_ge_sq_sub_one_div_four: the lower real envelope (n^2 - 1)/4 <= T(n), which together with the upper envelope sandwiches T(n) within 1/4 of n^2/4 and yields T(n) ~ n^2/4",
+      "turanBound_quarter_square: the quarter-square multiplication identity T(m+n) - T(m-n) = m*n for n <= m (the classical device turning quarter-square tables into multiplication tables; the ±n shift about m adds exactly m*n edges to the balanced bipartite graph)",
+      "turanBound_second_diff: the exact discrete second difference T(n+2) + T(n) = 2*T(n+1) + (n+1) mod 2, i.e. Δ²T(n) equals 1 at even n and 0 at odd n",
+      "turanBound_convex: discrete convexity 2*T(n+1) <= T(n+2) + T(n) — the extremal quarter-square edge count is a convex integer sequence with no concave dips"
     ]
   },
   "overview": {
@@ -83,6 +86,14 @@
       "startLine": 94,
       "endLine": 121,
       "mathContext": "Parity case-split gives n^2 mod 4 = n mod 2; Nat.div_add_mod + omega give the identity; casting n^2 <= 4*T(n)+1 to R and linarith give the lower envelope."
+    },
+    {
+      "id": "algebraic-structure",
+      "title": "Multiplication Identity, Second Difference, and Convexity",
+      "summary": "turanBound_quarter_square (T(m+n) - T(m-n) = m*n), turanBound_second_diff (Δ²T(n) = (n+1) mod 2), and turanBound_convex (2*T(n+1) <= T(n+2) + T(n)).",
+      "startLine": 129,
+      "endLine": 170,
+      "mathContext": "The quarter-square multiplication identity follows from turanBound_four_mul plus the matching parity bits of m+n and m-n (they differ by 2n); the second difference is the increment of the increment floor((n+1)/2), discharged by omega; convexity is the non-negativity of that second difference."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Drift-realignment for `erdos-1017-oq-03`. Merged research PR #31642 (quarter-square multiplication identity + discrete convexity) grew `proofs/Proofs/Erdos1017OQ03.lean` but the gallery meta.json was never regenerated.

Ground truth (canonical extractor): `wc -l` = **200**, **10** col-0 theorems, **1** definition, **0** sorries, **0** axioms.

## Changes (`src/data/proofs/erdos-1017-oq-03/meta.json`)

- `leanFile.lineCount` 145 → 200, `leanFile.theoremCount` 7 → 10
- `meta.lineCount` 145 → 200, `meta.theoremCount` 7 → 10
- Description prose "7 theorems" → "10 theorems" (+ one sentence on the new algebraic-structure layer)
- Added 3 entries to `originalContributions` (`turanBound_quarter_square`, `turanBound_second_diff`, `turanBound_convex`)
- Added an `algebraic-structure` section (lines 129–170)

No Lean source change; still `verified` / 0-axiom. Metadata-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)