### PR TITLE
Enrich Derived-Length Gap A₄ vs A₅ (abel-ruffini-oq-04-oq-02-oq-02-oq-06)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-06/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-06/annotations.json
@@ -2,12 +2,15 @@
   {
     "id": "ann-gap-header",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-06",
-    "range": { "startLine": 1, "endLine": 37 },
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
     "type": "concept",
     "title": "The Derived-Length Gap: Motivation",
     "content": "The parent entry proves the *qualitative* fact that $A_n$ is solvable iff $n \\leq 4$. This entry asks the *quantitative* question: how big is the jump at $n = 5$? Solvability is measured by the **derived (solvable) length** — the number of steps the derived series $G \\trianglerighteq G' \\trianglerighteq G'' \\trianglerighteq \\cdots$ takes to reach the trivial subgroup, where each term is the commutator subgroup of the previous, $D^{k+1} = \\lbrack D^k, D^k\\rbrack$.\n\nFor the alternating groups the answer is sharp and explicit:\n$$A_3 \\rightsquigarrow 1, \\quad A_4 \\rightsquigarrow 2, \\quad A_5 \\rightsquigarrow \\infty.$$\n$A_4$ reaches $\\{e\\}$ in exactly two steps through the Klein four-group $V_4 = \\lbrack A_4, A_4\\rbrack$; $A_5$ never reaches $\\{e\\}$ because it is **perfect** — equal to its own commutator subgroup. The derived length jumps from $2$ to infinity precisely at the Abel–Ruffini boundary, giving a numerical invariant in place of a yes/no classification.",
     "mathContext": "A group $G$ is solvable iff its derived series terminates at $\\{e\\}$; the least number of steps is its derived length. Abelian groups have derived length $\\leq 1$; $G$ with derived length exactly $2$ is solvable but non-abelian (it is metabelian). A group with $G = G'$ (perfect) has constant derived series and is non-solvable unless trivial. $A_5$ is the smallest non-abelian simple group and the smallest non-trivial perfect group.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "derived series",
       "derived (solvable) length",
@@ -28,12 +31,15 @@
   {
     "id": "ann-a4-length-two",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-06",
-    "range": { "startLine": 43, "endLine": 100 },
+    "range": {
+      "startLine": 43,
+      "endLine": 100
+    },
     "type": "insight",
     "title": "Part I — A₄ Has Derived Length Exactly 2",
     "content": "Two bounds pin the length. **Lower bound** (`a4_derived1_ne_bot`): $D^1(A_4) = \\lbrack A_4, A_4\\rbrack \\neq \\bot$, because $A_4$ is non-abelian. The proof exhibits non-commuting elements $a, b$ (`a4_non_abelian`, by `decide` over the 12-element group), forms the commutator $\\lbrack a, b\\rbrack \\in D^1(A_4)$ via `Subgroup.commutator_mem_commutator`, and observes that if $D^1 = \\bot$ then $\\lbrack a, b\\rbrack = 1$, i.e. $a, b$ commute — a contradiction, packaged by `commutatorElement_eq_one_iff_commute`.\n\n**Upper bound** (`a4_derived2_eq_bot`): $D^2(A_4) = \\bot$. This is reused verbatim from the parent's `a4_derivedSeries_two_eq_bot`, which identifies $\\lbrack A_4, A_4\\rbrack$ with the Klein four-group $V_4$ (every generator $\\lbrack a, b\\rbrack$ has order dividing $2$, by `decide`) and notes $V_4$ is abelian, so $\\lbrack V_4, V_4\\rbrack = \\bot$. Together (`a4_solvability_class_two`, `a4_exact_derived_length`) these give derived length exactly $2$.",
     "mathContext": "The derived series of $A_4$ is $A_4 \\trianglerighteq V_4 \\trianglerighteq \\{e\\}$. $V_4 = \\{e, (12)(34), (13)(24), (14)(23)\\}$ is the unique normal subgroup of order $4$, with exponent $2$ (hence abelian). The two-step termination is the defining feature of a *metabelian* group: solvable of derived length $2$.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "commutator subgroup",
       "Klein four-group V₄",
@@ -51,12 +57,15 @@
   {
     "id": "ann-a5-perfect",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-06",
-    "range": { "startLine": 106, "endLine": 147 },
+    "range": {
+      "startLine": 106,
+      "endLine": 147
+    },
     "type": "insight",
     "title": "Part II — A₅ Is Perfect, So Its Derived Series Is Constant",
     "content": "The crux is `a5_perfect`: $\\lbrack A_5, A_5\\rbrack = A_5$. The commutator subgroup is always normal, so by the simplicity of $A_5$ it is either $\\bot$ or $\\top$ (`Subgroup.Normal.eq_bot_or_eq_top` under the `IsSimpleGroup` instance). It cannot be $\\bot$: that would make $A_5$ abelian and hence solvable, contradicting the parent's `a5_not_solvable`. Therefore it is $\\top$ — $A_5$ equals its own commutator subgroup.\n\nPerfection then propagates through the entire derived series. `IsSimpleGroup.derivedSeries_succ` says that for a simple group *every* successor term $D^{n+1}$ equals the commutator subgroup, which is $\\top$; so `a5_derived_succ_eq_top` gives $D^{n+1}(A_5) = \\top$ for all $n$, and `a5_derived_never_bot` concludes that no term — including $D^0 = \\top$ — is ever $\\bot$. $A_5$ has no finite derived length.",
     "mathContext": "A perfect group is one equal to its own commutator subgroup ($G = G'$); its derived series is the constant sequence $G, G, G, \\dots$, so it is solvable only if trivial. Non-abelian simple groups are automatically perfect, since $G'$ is a non-trivial (the group is non-abelian) normal subgroup, forced to be all of $G$. $A_5$, order $60$, is the smallest such group.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "perfect group",
       "simple group",
@@ -75,7 +84,10 @@
   {
     "id": "ann-the-gap",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-06",
-    "range": { "startLine": 160, "endLine": 202 },
+    "range": {
+      "startLine": 160,
+      "endLine": 202
+    },
     "type": "concept",
     "title": "Part III — The Gap and the Phase-Transition Profile",
     "content": "`derived_length_gap` states the contrast as one proposition: $A_4$'s derived series reaches $\\bot$ ($\\exists n,\\ D^n(A_4) = \\bot$, witnessed by $n = 2$) while $A_5$'s never does ($\\forall n,\\ D^n(A_5) \\neq \\bot$). `derived_length_sequence` records the full profile across the small alternating groups:\n$$\\underbrace{0, 0, 0}_{A_0, A_1, A_2}, \\underbrace{1}_{A_3}, \\underbrace{2}_{A_4}, \\underbrace{\\infty}_{A_5, A_6, \\dots}$$\nThe $A_3$ entry ($D^1(A_3) = \\bot$) is the abelian case: $A_3 \\cong \\mathbb{Z}/3$, so all elements commute (by `decide`), giving $\\lbrack A_3, A_3\\rbrack = \\bot$ via `commutatorElement_eq_one_iff_commute`. The discontinuity between the finite values $1, 2$ and the infinite tail is the exact location of the Abel–Ruffini threshold $n = 5$.",
@@ -97,8 +109,11 @@
   {
     "id": "ann-verification-method",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-06",
-    "range": { "startLine": 203, "endLine": 230 },
-    "type": "tactic",
+    "range": {
+      "startLine": 203,
+      "endLine": 230
+    },
+    "type": "technique",
     "title": "Verification: One Logical Bridge, Genuine 0-Axiom Status",
     "content": "All three parts of the proof turn on a single Mathlib lemma, `commutatorElement_eq_one_iff_commute` ($\\lbrack a, b\\rbrack = 1 \\iff \\text{Commute } a\\, b$), used in two opposite directions. To prove a derived subgroup is **non-trivial** ($A_4$ lower bound), it converts a known non-commuting pair into a non-identity commutator; to prove one is **trivial** ($A_3$ abelian, and inside the parent's $V_4$ computation), it converts universal commutativity into $\\lbrack G, G\\rbrack = \\bot$. The $A_5$ side adds the contrapositive of `isSolvable_of_comm` (all-commute $\\Rightarrow$ solvable) to manufacture non-commuting elements from non-solvability.\n\nEvery finite check — `a4_non_abelian`, the $A_3$ all-commute fact, and the parent's order-dividing-2 computation identifying $V_4$ — uses **kernel `decide`**, not `native_decide`. This matters for axiom integrity: `native_decide` would inject `Lean.ofReduceBool` and forfeit the 0-axiom claim. Because the heaviest decidable instance ranges over the 12-element group $A_4$ (not the 60-element $A_5$), kernel reduction stays tractable. `#print axioms` on the headline theorems reports only `propext`, `Classical.choice`, `Quot.sound` — the standard foundational triple, with no `sorryAx` and no `Lean.ofReduceBool`.",
     "mathContext": "Kernel `decide` reduces a `Decidable` instance to `isTrue`/`isFalse` inside Lean's trusted kernel, so the resulting proof term carries no extra axiom. `native_decide` instead compiles the instance to native code and trusts its output via `Lean.ofReduceBool`, which counts as an assumption. For a 12-element group the kernel computation of `∀ a b : A₄, a * b = b * a → False`-style predicates is feasible; pushing the same approach to $A_5$ ($|A_5| = 60$, $3600$ pairs) is where one would be tempted to reach for `native_decide` — avoided here by using the simplicity/perfection argument instead of brute force.",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-06/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-06/meta.json
@@ -139,7 +139,12 @@
   ],
   "conclusion": {
     "summary": "The derived length of A₄ is exactly 2 (a4_exact_derived_length: D²(A₄) = ⊥ but D¹(A₄) ≠ ⊥) while A₅ is perfect (a5_perfect: commutator A₅ = ⊤), so its derived series is constant at ⊤ and never reaches ⊥ (a5_derived_never_bot). The headline derived_length_gap states the contrast as a single proposition, and derived_length_sequence records the full transition profile 0,0,0,1,2,∞ across A₀…A₅. The D²(A₄) = ⊥ step reuses the parent's Klein-four-group identification of ⁅A₄, A₄⁆ verbatim. 232 lines, 11 theorems, 0 definitions, 0 sorries, 0 axioms; all finite checks use kernel `decide`, no native_decide.",
-    "futureDirections": [
+    "implications": [
+      "The jump from derived length 2 (A₄) to a non-terminating derived series (A₅ perfect) is the group-theoretic heart of the Abel–Ruffini theorem: solvability by radicals corresponds to a solvable Galois group, i.e. a derived series reaching ⊥, so A₅'s perfection is exactly why the general quintic has no radical solution.",
+      "Perfection of A₅ (⁅A₅,A₅⁆ = ⊤) makes it the smallest non-abelian simple group and pins the derived series constant at ⊤, giving a clean machine-checked boundary between the solvable regime (n ≤ 4) and the unsolvable one (n ≥ 5).",
+      "The transition profile 0,0,0,1,2,∞ across A₀…A₅ packages the whole solvable/unsolvable dichotomy as a single computable sequence, and the D²(A₄)=⊥ step's reuse of the parent's Klein-four identification shows the derived-length computation is modular over the composition structure."
+    ],
+    "openQuestions": [
       "Compute the derived length of Sₙ for n ≤ 4 (S₃ has length 2, S₄ has length 3) and contrast with the alternating profile via the sign quotient.",
       "Show the derived length of Aₙ for n ≥ 5 is 'infinite' uniformly by transporting A₅'s perfection along the embedding A₅ ↪ Aₙ.",
       "Relate the V₄ = ⁅A₄, A₄⁆ identification to the explicit composition series A₄ ⊵ V₄ ⊵ C₂ ⊵ {e} and its Jordan–Hölder factors."
@@ -153,7 +158,9 @@
       "Mathlib.Tactic",
       "Proofs.AbelRuffiniOQ04OQ02OQ02"
     ],
-    "opens": ["Equiv"],
+    "opens": [
+      "Equiv"
+    ],
     "namespace": "AbelRuffiniOQ04OQ02OQ02OQ06",
     "lineCount": 232,
     "axiomCount": 0,
@@ -216,28 +223,36 @@
   ],
   "references": [
     {
-      "authors": ["É. Galois"],
+      "authors": [
+        "É. Galois"
+      ],
       "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
       "year": "1846",
       "venue": "Journal de Mathématiques Pures et Appliquées (published posthumously)",
       "note": "Polynomial solvable by radicals iff Galois group solvable; A₅ simple is the quintic obstruction."
     },
     {
-      "authors": ["C. Jordan"],
+      "authors": [
+        "C. Jordan"
+      ],
       "title": "Traité des substitutions et des équations algébriques",
       "year": "1870",
       "venue": "Gauthier-Villars, Paris",
       "note": "Derived and composition series; Aₙ simple for n ≥ 5, hence perfect."
     },
     {
-      "authors": ["D. J. S. Robinson"],
+      "authors": [
+        "D. J. S. Robinson"
+      ],
       "title": "A Course in the Theory of Groups",
       "year": "1996",
       "venue": "Springer GTM 80, 2nd edition",
       "note": "Derived series, solvable length, and perfect groups (G = G')."
     },
     {
-      "authors": ["The mathlib Community"],
+      "authors": [
+        "The mathlib Community"
+      ],
       "title": "The Lean Mathematical Library — GroupTheory.Solvable",
       "year": "2020",
       "venue": "Lean 4 / Mathlib",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-02-oq-06`.

## Gaps closed
- **conclusion schema**: the entry used a non-standard `futureDirections` field and was **missing the required `implications`** (and had no `openQuestions`, so the quality scorer saw 0). Added 3 substantive `implications` connecting the A₄→A₅ derived-length jump to the Abel–Ruffini theorem (solvable Galois group ⟺ derived series reaching ⊥; A₅ perfect ⟹ unsolvable quintic), and converted the 3 `futureDirections` into schema-correct `openQuestions` (now rendered on the site).
- **Annotation schema**: fixed off-schema `significance: "critical"` → `"key"` (×3) and `type: "tactic"` → `"technique"` (enums are key/supporting/technical/context and concept/definition/technique/insight/context).

## Notes
- Verified all theorem names referenced in the conclusion (`a4_exact_derived_length`, `a5_perfect`, `a5_derived_never_bot`, `derived_length_gap`, `derived_length_sequence`) exist in the Lean source.
- Left the already-rich content intact (index.ts, 7 keyInsights, 4 sections). meta.json 21.6 KB, under caps.
- JSON validated.