### PR TITLE
Enrich Weighted AM-GM Equality Case (amgm-inequality-oq-05-oq-02)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02/annotations.json
@@ -6,7 +6,7 @@
       "startLine": 44,
       "endLine": 50
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "log_prod_rpow: log(∏ xᵢ^{wᵢ}) = ∑ wᵢ·log xᵢ",
     "content": "The logarithmic bridge. For strictly positive xᵢ, the logarithm of the weighted geometric mean equals the weighted sum of logarithms. The proof applies Real.log_prod (each factor xᵢ^{wᵢ} is positive, hence nonzero, by Real.rpow_pos_of_pos) and then Real.log_rpow on each term to turn log(xᵢ^{wᵢ}) into wᵢ·log xᵢ. This is what linearises the multiplicative geometric mean into the additive form on which Jensen's inequality acts.",
     "mathContext": "$\\log\\!\\left(\\prod_i x_i^{w_i}\\right) = \\sum_i w_i \\log x_i$.",
@@ -29,7 +29,7 @@
       "startLine": 52,
       "endLine": 55
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "prod_rpow_pos: positivity of the geometric mean",
     "content": "The weighted geometric mean ∏ xᵢ^{wᵢ} of positive reals is positive, since it is a finite product of positive rpows (Finset.prod_pos with Real.rpow_pos_of_pos). Needed so that the geometric mean lies in the domain (0,∞) where log is injective.",
     "mathContext": "$\\prod_i x_i^{w_i} > 0$ when each $x_i > 0$.",
@@ -49,7 +49,7 @@
       "startLine": 58,
       "endLine": 65
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "mean_pos: positivity of the arithmetic mean",
     "content": "The weighted arithmetic mean ∑ wᵢxᵢ is positive: each summand wᵢxᵢ is a product of positive numbers, and the index set is nonempty, so Finset.sum_pos applies. Positivity places the arithmetic mean in the domain of log, the other endpoint of the bridge.",
     "mathContext": "$\\sum_i w_i x_i > 0$ over a nonempty index set with $w_i, x_i > 0$.",
@@ -69,7 +69,7 @@
       "startLine": 68,
       "endLine": 88
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "weighted_amgm_eq_iff: equality iff every xⱼ equals the mean",
     "content": "The headline result (canonical form). For positive weights summing to 1 and positive x, the weighted geometric mean equals the weighted arithmetic mean iff every xⱼ equals that common mean. Proof: the index set is nonempty (weights sum to 1 ≠ 0), so both means are positive; by injectivity of log on (0,∞) (Real.log_injOn_pos) the multiplicative equality is equivalent to the equality of logs; rewriting the geometric side by log_prod_rpow reduces this to the additive equality log(∑ wᵢxᵢ) = ∑ wᵢ·log xᵢ, which is exactly the equality case of Jensen for the strictly concave Real.log. Mathlib's StrictConcaveOn.map_sum_eq_iff applied to strictConcaveOn_log_Ioi, with smul = mul on ℝ, finishes the equivalence.",
     "mathContext": "$\\prod_i x_i^{w_i} = \\sum_i w_i x_i \\iff \\forall j,\\; x_j = \\sum_i w_i x_i$.",
@@ -93,7 +93,7 @@
       "startLine": 90,
       "endLine": 105
     },
-    "type": "theorem",
+    "type": "concept",
     "title": "weighted_amgm_eq_iff_pairwise: equality iff all xⱼ equal",
     "content": "The familiar phrasing. Equality in weighted AM-GM holds iff all the xⱼ are pairwise equal. Derived from the canonical form: if all xⱼ equal the mean they are pairwise equal; conversely, if the sequence is constant then its weighted mean (with weights summing to 1) equals that constant, so each xⱼ equals the mean. This recovers the textbook statement that the geometric and arithmetic means coincide exactly for constant data.",
     "mathContext": "$\\prod_i x_i^{w_i} = \\sum_i w_i x_i \\iff \\forall i\\,j,\\; x_i = x_j$.",
@@ -114,7 +114,7 @@
       "startLine": 107,
       "endLine": 113
     },
-    "type": "theorem",
+    "type": "concept",
     "title": "weighted_amgm_eq_of_const: the trivial direction",
     "content": "Recorded explicitly for completeness: if all xⱼ equal a common value c, the weighted geometric and arithmetic means coincide. Immediate from the pairwise equality characterisation.",
     "mathContext": "$(\\forall i,\\, x_i = c) \\implies \\prod_i x_i^{w_i} = \\sum_i w_i x_i$.",

--- a/src/data/proofs/amgm-inequality-oq-05-oq-02/index.ts
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AmgmInequalityOQ05OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const amgmInequalityOq05Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const amgmInequalityOq05Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const amgmInequalityOq05Oq02Data: ProofData = {
+  proof: amgmInequalityOq05Oq02Proof,
+  annotations: amgmInequalityOq05Oq02Annotations,
+}

--- a/src/data/proofs/amgm-inequality-oq-05-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02/meta.json
@@ -99,5 +99,35 @@
       "note": "Develops AM-GM, Jensen, and the role of strict convexity in equality cases."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: n-term AM-GM equality via strict concavity of log",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "States the goal — characterising when the weighted AM-GM inequality ∏ xᵢ^wᵢ ≤ ∑ wᵢxᵢ is an equality — and the strategy: take logs to convert the multiplicative equality into the additive Jensen equality for the strictly concave Real.log, then apply Mathlib's StrictConcaveOn.map_sum_eq_iff. Answers the parent's open question of upgrading the 2-variable Young equality case to n terms."
+    },
+    {
+      "id": "log-helpers",
+      "title": "Logarithmic and positivity helper lemmas",
+      "startLine": 42,
+      "endLine": 61,
+      "summary": "Three supporting facts: log_prod_rpow turns log of the weighted geometric mean into the weighted sum of logs (log ∏ xᵢ^wᵢ = ∑ wᵢ log xᵢ); prod_rpow_pos and mean_pos establish that the geometric and arithmetic means are strictly positive, which is what licenses applying log injectivity on (0,∞)."
+    },
+    {
+      "id": "main-equality",
+      "title": "The equality case (canonical form)",
+      "startLine": 63,
+      "endLine": 85,
+      "summary": "weighted_amgm_eq_iff: for positive weights summing to 1, the weighted geometric mean equals the weighted arithmetic mean iff every xⱼ equals that common mean. Proof injects the equality through log (both sides positive), rewrites via log_prod_rpow, and feeds strictConcaveOn_log_Ioi.map_sum_eq_iff — Mathlib's strict-Jensen equality characterisation."
+    },
+    {
+      "id": "pairwise-and-converse",
+      "title": "Pairwise form and the trivial converse",
+      "startLine": 87,
+      "endLine": 114,
+      "summary": "weighted_amgm_eq_iff_pairwise restates equality as 'all xⱼ over the weight support are equal', deriving the constant-mean condition from pairwise equality via ∑ wᵢxⱼ = xⱼ∑wᵢ = xⱼ. weighted_amgm_eq_of_const records the easy direction: if all xⱼ = c the two means coincide."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-05-oq-02` (n-term weighted AM-GM equality case via strict concavity of log).

## Gaps closed
- **Created `index.ts`** (was **missing** — page shows *'proof not found'* on the live site without it). camelCase `amgmInequalityOq05Oq02`, Lean file `AmgmInequalityOQ05OQ02`.
- **Added a `sections` array** (was empty/`null`) — 4 sections covering the overview & strategy, the log/positivity helper lemmas, the canonical equality case (`weighted_amgm_eq_iff`), and the pairwise form + trivial converse, with accurate line ranges over the 114-line file.
- **Fixed 6 off-schema annotation types**: `type: "theorem"` → `technique`/`insight`/`concept` (the type enum is concept/definition/technique/insight/context).

## Notes
- `meta.json` already had a rich overview (4 keyInsights), conclusion with implications + 2 openQuestions, and crossReferences — left intact. 12.7 KB, under caps.
- JSON validated.