### PR TITLE
research(derangements-oq-04-oq-01): partial-derangement closed form over a field [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DerangementsOQ04OQ01.lean
+++ b/proofs/Proofs/DerangementsOQ04OQ01.lean
@@ -1,0 +1,132 @@
+import Proofs.DerangementsOQ02
+import Proofs.DerangementsOQ04
+import Mathlib.Tactic
+
+/-!
+# Partial derangements: the factorial-times-truncated-exponential closed form
+
+## What this proves
+
+Let `S(n, k)` be the number of permutations of an `n`-element set with **exactly
+`k` fixed points** (the *rencontres numbers* / partial-derangement numbers).  This
+entry gives the closed form of `S(n, k)`, over an **arbitrary characteristic-zero
+field** `𝕜`:
+
+$$ S(n,k) \;=\; \frac{n!}{k!}\,\sum_{j=0}^{n-k} \frac{(-1)^j}{j!}. $$
+
+The right-hand bracket is the order-`(n-k)` truncation of the exponential series of
+`e^{-1}`, so the identity reads `S(n,k) = (n!/k!) · (partial sum of e^{-1})`.  For
+`k = 0` it specialises to the classical derangement closed form
+`D_n = n! · ∑_{j≤n} (-1)^j/j!`.
+
+## How this answers the open question
+
+The parent entry `derangements-oq-04` proves the field-level derangement closed
+form
+`(numDerangements m : 𝕜) = m! · ∑_{j≤m} (-1)^j/j!`
+(`DerangementsOQ04.numDerangements_closed_form`) and asks (open question) whether the
+same single-induction technique yields a clean closed form for **partial
+derangements** (permutations with exactly `k` fixed points) over a field.
+
+This file answers it.  The bridge is purely algebraic: the sibling entry
+`derangements-oq-02` already establishes the combinatorial identity
+
+  `S(n,k) = C(n,k) · numDerangements (n-k)`   (`PartialDerangements.card_perms_with_kfixed`),
+
+so combining it with the parent's field closed form and the factorial identity
+`C(n,k) · k! · (n-k)! = n!` (`Nat.choose_mul_factorial_mul_factorial`) collapses the
+constant `C(n,k) · (n-k)!` to `n!/k!` inside `𝕜`.  Characteristic zero is exactly
+what makes `k!` invertible.
+
+## Main results
+
+* `card_perms_with_kfixed_closed_form` — the closed form over a char-zero field `𝕜`.
+* `card_perms_with_kfixed_eq_factorial_mul_trunc` — the truncated-`e^{-1}` phrasing,
+  reusing `DerangementsOQ04.truncExpNegOne`.
+* `card_perms_with_kfixed_closed_form_rat` / `_real` — specialisations to `ℚ` / `ℝ`.
+* `card_perms_with_kfixed_zero_closed_form` — for `k = 0` it recovers the parent
+  derangement closed form, confirming consistency.
+
+## Status
+- [x] Complete proof (0 sorries, 0 axioms beyond Mathlib's foundations).
+-/
+
+namespace DerangementsOQ04OQ01
+
+open Finset
+
+/-- **Closed form for partial derangements over a characteristic-zero field.**
+
+`S(n,k) = (n!/k!) · ∑_{j=0}^{n-k} (-1)^j/j!`, where `S(n,k)` is the number of
+permutations of `Fin n` with exactly `k` fixed points. -/
+theorem card_perms_with_kfixed_closed_form
+    (𝕜 : Type*) [Field 𝕜] [CharZero 𝕜] (n k : ℕ) (hk : k ≤ n) :
+    ((univ.filter (fun σ : Equiv.Perm (Fin n) =>
+        (univ.filter (fun x => σ x = x)).card = k)).card : 𝕜)
+      = (n.factorial : 𝕜) / (k.factorial : 𝕜)
+        * ∑ j ∈ range (n - k + 1), (-1 : 𝕜) ^ j / (j.factorial : 𝕜) := by
+  -- combinatorial identity S(n,k) = C(n,k) · D(n-k)  (sibling entry derangements-oq-02)
+  have hcard := PartialDerangements.card_perms_with_kfixed n k hk
+  -- field closed form for the derangement number D(n-k)  (parent entry derangements-oq-04)
+  have hD := DerangementsOQ04.numDerangements_closed_form 𝕜 (n - k)
+  -- k! is invertible in a characteristic-zero field
+  have hkfac : (k.factorial : 𝕜) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero k
+  -- the factorial identity C(n,k) · k! · (n-k)! = n!, cast into 𝕜
+  have hchoose : (n.choose k : 𝕜) * (k.factorial : 𝕜) * ((n - k).factorial : 𝕜)
+      = (n.factorial : 𝕜) := by
+    exact_mod_cast Nat.choose_mul_factorial_mul_factorial hk
+  rw [hcard]
+  push_cast
+  rw [hD, div_mul_eq_mul_div, eq_div_iff hkfac]
+  -- goal reduces to the factorial identity times the truncated sum; ring-closes via hchoose
+  linear_combination (∑ j ∈ range (n - k + 1), (-1 : 𝕜) ^ j / (j.factorial : 𝕜)) * hchoose
+
+/-- The truncated-`e^{-1}` phrasing of the same identity, reusing
+`DerangementsOQ04.truncExpNegOne`:
+`S(n,k) = (n!/k!) · truncExpNegOne 𝕜 (n-k+1)`. -/
+theorem card_perms_with_kfixed_eq_factorial_mul_trunc
+    (𝕜 : Type*) [Field 𝕜] [CharZero 𝕜] (n k : ℕ) (hk : k ≤ n) :
+    ((univ.filter (fun σ : Equiv.Perm (Fin n) =>
+        (univ.filter (fun x => σ x = x)).card = k)).card : 𝕜)
+      = (n.factorial : 𝕜) / (k.factorial : 𝕜)
+        * DerangementsOQ04.truncExpNegOne 𝕜 (n - k + 1) := by
+  rw [DerangementsOQ04.truncExpNegOne, card_perms_with_kfixed_closed_form 𝕜 n k hk]
+
+/-- Closed form over the rationals. -/
+theorem card_perms_with_kfixed_closed_form_rat (n k : ℕ) (hk : k ≤ n) :
+    ((univ.filter (fun σ : Equiv.Perm (Fin n) =>
+        (univ.filter (fun x => σ x = x)).card = k)).card : ℚ)
+      = (n.factorial : ℚ) / (k.factorial : ℚ)
+        * ∑ j ∈ range (n - k + 1), (-1 : ℚ) ^ j / (j.factorial : ℚ) :=
+  card_perms_with_kfixed_closed_form ℚ n k hk
+
+/-- Closed form over the reals. -/
+theorem card_perms_with_kfixed_closed_form_real (n k : ℕ) (hk : k ≤ n) :
+    ((univ.filter (fun σ : Equiv.Perm (Fin n) =>
+        (univ.filter (fun x => σ x = x)).card = k)).card : ℝ)
+      = (n.factorial : ℝ) / (k.factorial : ℝ)
+        * ∑ j ∈ range (n - k + 1), (-1 : ℝ) ^ j / (j.factorial : ℝ) :=
+  card_perms_with_kfixed_closed_form ℝ n k hk
+
+/-- **Consistency with the parent.**  Setting `k = 0` recovers the derangement
+closed form `D_n = n! · ∑_{j≤n} (-1)^j/j!`: with `0! = 1` the prefactor `n!/0!`
+is just `n!`, and `S(n,0) = D_n`. -/
+theorem card_perms_with_kfixed_zero_closed_form
+    (𝕜 : Type*) [Field 𝕜] [CharZero 𝕜] (n : ℕ) :
+    ((univ.filter (fun σ : Equiv.Perm (Fin n) =>
+        (univ.filter (fun x => σ x = x)).card = 0)).card : 𝕜)
+      = (n.factorial : 𝕜) * ∑ j ∈ range (n + 1), (-1 : 𝕜) ^ j / (j.factorial : 𝕜) := by
+  have h := card_perms_with_kfixed_closed_form 𝕜 n 0 (Nat.zero_le n)
+  simpa using h
+
+/-- Sanity check for `S(4,1)`.  A permutation of `4` elements with exactly one
+fixed point chooses that fixed point (`C(4,1) = 4` ways) and deranges the other
+`3` (`D_3 = 2` ways), so `S(4,1) = 4·2 = 8`.  The closed form
+`(4!/1!)·(1 - 1 + 1/2 - 1/6) = 24·(1/3) = 8` agrees. -/
+example : ((univ.filter (fun σ : Equiv.Perm (Fin 4) =>
+      (univ.filter (fun x => σ x = x)).card = 1)).card : ℚ)
+    = (Nat.factorial 4 : ℚ) / (Nat.factorial 1 : ℚ)
+      * ∑ j ∈ range 4, (-1 : ℚ) ^ j / (j.factorial : ℚ) :=
+  card_perms_with_kfixed_closed_form_rat 4 1 (by norm_num)
+
+end DerangementsOQ04OQ01

--- a/src/data/proofs/derangements-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/derangements-oq-04-oq-01/annotations.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "ann-main-closed-form",
+    "proofId": "derangements-oq-04-oq-01",
+    "range": {
+      "startLine": 62,
+      "endLine": 85
+    },
+    "type": "theorem",
+    "title": "Rencontres Closed Form Over a Field",
+    "content": "**Theorem** `card_perms_with_kfixed_closed_form`:\n```\n(S(n,k) : 𝕜) = (n!/k!) · ∑_{j=0}^{n-k} (-1)^j / j!\n```\nwhere `S(n,k)` is the number of `σ : Perm (Fin n)` with exactly `k` fixed points, over any characteristic-zero field `𝕜`.\n\nThe proof is a three-line algebraic bridge:\n1. `rw` the combinatorial count `S(n,k) = C(n,k)·D(n-k)` (from derangements-oq-02);\n2. `push_cast` and `rw` the field closed form `D(n-k) = (n-k)!·∑(-1)^j/j!` (from derangements-oq-04);\n3. clear the `k!` denominator with `div_mul_eq_mul_div`/`eq_div_iff` and close with `linear_combination (∑…) * hchoose`, where `hchoose : C(n,k)·k!·(n-k)! = n!`.",
+    "mathContext": "S(n,k) = \\frac{n!}{k!}\\sum_{j=0}^{n-k}\\frac{(-1)^j}{j!}",
+    "significance": "central",
+    "relatedConcepts": [
+      "rencontres numbers",
+      "partial derangements",
+      "fixed points",
+      "truncated exponential series"
+    ],
+    "prerequisites": [
+      "S(n,k) = C(n,k)·D(n-k) (combinatorial count)",
+      "D(m) = m!·∑(-1)^j/j! (field derangement closed form)",
+      "C(n,k)·k!·(n-k)! = n!"
+    ]
+  },
+  {
+    "id": "ann-factorial-collapse",
+    "proofId": "derangements-oq-04-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 78
+    },
+    "type": "technique",
+    "title": "Collapsing the Constant to n!/k!",
+    "content": "The prefactor of the closed form is `C(n,k)·(n-k)!`, and the entire arithmetic content is that this equals `n!/k!`. The identity comes from `Nat.choose_mul_factorial_mul_factorial hk : C(n,k)·k!·(n-k)! = n!`, cast into `𝕜` as `hchoose`. Dividing by the nonzero `k!` (needing only `CharZero 𝕜`) turns `C(n,k)·(n-k)!` into `n!/k!`. This is why the final answer has the clean shape `n!/k!` and not a three-factorial expression.",
+    "mathContext": "\\binom{n}{k}(n-k)! = \\frac{n!}{k!}",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "binomial coefficient",
+      "factorial identity",
+      "characteristic zero"
+    ],
+    "prerequisites": [
+      "Nat.choose_mul_factorial_mul_factorial",
+      "invertibility of k! in a characteristic-zero field"
+    ]
+  },
+  {
+    "id": "ann-trunc-phrasing",
+    "proofId": "derangements-oq-04-oq-01",
+    "range": {
+      "startLine": 87,
+      "endLine": 94
+    },
+    "type": "theorem",
+    "title": "Truncated-Exponential Phrasing",
+    "content": "**Theorem** `card_perms_with_kfixed_eq_factorial_mul_trunc`: the same identity written with the parent's truncated exponential,\n```\nS(n,k) = (n!/k!) · truncExpNegOne 𝕜 (n-k+1)\n```\nwhere `truncExpNegOne 𝕜 m = ∑_{j<m} (-1)^j/j!` is the order-`m` truncation of the series of `e^{-1}` (defined in derangements-oq-04). Since `truncExpNegOne 𝕜 (n-k+1)` is the partial sum through the `(-1)^{n-k}/(n-k)!` term, this matches the sum in the main theorem exactly; the proof simply unfolds the definition.",
+    "mathContext": "S(n,k) = \\frac{n!}{k!}\\,\\mathrm{truncExpNegOne}_{\\mathbb K}(n-k+1)",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "truncated exponential of e^{-1}",
+      "partial sums"
+    ],
+    "prerequisites": [
+      "DerangementsOQ04.truncExpNegOne"
+    ]
+  },
+  {
+    "id": "ann-k-zero-consistency",
+    "proofId": "derangements-oq-04-oq-01",
+    "range": {
+      "startLine": 114,
+      "endLine": 124
+    },
+    "type": "theorem",
+    "title": "k = 0 Recovers the Derangement Closed Form",
+    "content": "**Theorem** `card_perms_with_kfixed_zero_closed_form`: specializing the main theorem at `k = 0` yields\n```\nS(n,0) = n! · ∑_{j=0}^{n} (-1)^j/j!,\n```\nthe parent derangement closed form for `D(n)`. Here `n!/0! = n!` and the summation range `n-0+1 = n+1` match the parent verbatim, so `simpa` closes the goal. This is a consistency check confirming the generalization reduces correctly to its k=0 base case, where 'exactly 0 fixed points' is precisely 'derangement'.",
+    "mathContext": "S(n,0) = D_n = n!\\sum_{j=0}^n \\frac{(-1)^j}{j!}",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "derangements as k=0 rencontres numbers",
+      "consistency check"
+    ],
+    "prerequisites": [
+      "card_perms_with_kfixed_closed_form"
+    ]
+  },
+  {
+    "id": "ann-sanity-check",
+    "proofId": "derangements-oq-04-oq-01",
+    "range": {
+      "startLine": 126,
+      "endLine": 131
+    },
+    "type": "example",
+    "title": "Sanity Check: S(4,1) = 8",
+    "content": "The `example` verifies the closed form for `S(4,1)` over ℚ. Combinatorially, a permutation of 4 elements with exactly one fixed point chooses that point (`C(4,1)=4` ways) and deranges the other 3 (`D_3 = 2` ways), so `S(4,1) = 8`. The closed form gives `(4!/1!)·(1 - 1 + 1/2 - 1/6) = 24·(1/3) = 8`, matching. This anchors the abstract theorem against a concrete small value.",
+    "mathContext": "S(4,1) = \\binom{4}{1}D_3 = 8 = \\frac{4!}{1!}\\left(1-1+\\tfrac12-\\tfrac16\\right)",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "small-case verification"
+    ],
+    "prerequisites": [
+      "card_perms_with_kfixed_closed_form_rat"
+    ]
+  }
+]

--- a/src/data/proofs/derangements-oq-04-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-04-oq-01/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "derangements-oq-04-oq-01",
+  "title": "Partial Derangements: Factorial × Truncated-Exponential Closed Form Over a Field",
+  "slug": "derangements-oq-04-oq-01",
+  "description": "Proves the closed form S(n,k) = (n!/k!) · ∑_{j=0}^{n-k} (-1)^j/j! for the rencontres numbers (permutations of n elements with exactly k fixed points), over an arbitrary characteristic-zero field 𝕜. This answers the parent open question (derangements-oq-04) asking whether the field-level derangement closed form extends to partial derangements. The bridge is purely algebraic: the sibling entry derangements-oq-02 supplies the combinatorial identity S(n,k) = C(n,k)·D(n-k), the parent supplies the field closed form D(m) = m!·∑_{j≤m}(-1)^j/j!, and the factorial identity C(n,k)·k!·(n-k)! = n! collapses the constant C(n,k)·(n-k)! to n!/k! inside 𝕜. Includes the truncated-exponential phrasing (reusing DerangementsOQ04.truncExpNegOne), ℚ/ℝ specializations, and a k=0 consistency corollary recovering the parent derangement closed form.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib (classical result; rencontres numbers, Montmort/Euler)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Rencontres_numbers",
+    "date": "1708",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsOQ04OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "rencontres-numbers",
+      "partial-derangements",
+      "closed-form",
+      "factorial",
+      "exponential-series",
+      "field",
+      "research",
+      "open-problem"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "For k ≤ n, choose n k * k! * (n-k)! = n!; cast into 𝕜 to collapse C(n,k)·(n-k)! to n!/k!",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.factorial_ne_zero",
+        "description": "k! ≠ 0, cast to a characteristic-zero field to invert k!",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "eq_div_iff",
+        "description": "a = b / c ↔ a * c = b for c ≠ 0, clearing the k! denominator",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "card_perms_with_kfixed_closed_form: (S(n,k) : 𝕜) = (n!/k!)·∑_{j=0}^{n-k} (-1)^j/j! over any characteristic-zero field, obtained by bridging the combinatorial count S(n,k)=C(n,k)·D(n-k) (derangements-oq-02) with the field derangement closed form (derangements-oq-04) via Nat.choose_mul_factorial_mul_factorial",
+      "card_perms_with_kfixed_eq_factorial_mul_trunc: the same identity phrased with the truncated exponential DerangementsOQ04.truncExpNegOne 𝕜 (n-k+1)",
+      "card_perms_with_kfixed_closed_form_rat / _real: specializations to ℚ and ℝ",
+      "card_perms_with_kfixed_zero_closed_form: k=0 specialization recovering the parent derangement closed form D(n) = n!·∑_{j≤n}(-1)^j/j!, confirming consistency"
+    ],
+    "dateAdded": "2026-06-30",
+    "axiomCount": 0,
+    "lineCount": 132,
+    "assumptions": "None. Fully verified with 0 axioms (only Lean/Mathlib foundations propext, Classical.choice, Quot.sound) and 0 sorries. The field is required to have characteristic zero so that factorials are invertible.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**The Rencontres Numbers**\n\nThe *rencontres numbers* $S(n,k)$ (also called partial-derangement numbers) count the permutations of an $n$-element set having **exactly $k$ fixed points**. They generalize the derangement numbers $D_n = S(n,0)$ and were studied alongside them in the early combinatorial-probability literature (Montmort 1708, Euler 1751). The classical closed form is\n$$ S(n,k) = \\binom{n}{k} D_{n-k} = \\frac{n!}{k!}\\sum_{j=0}^{n-k}\\frac{(-1)^j}{j!}, $$\nchoosing which $k$ points are fixed and deranging the remaining $n-k$.\n\nMathlib records the derangement count `numDerangements` and its integer/asymptotic facts, but neither the rencontres numbers nor their closed form. The sibling gallery entry `derangements-oq-02` supplies the combinatorial identity $S(n,k) = \\binom{n}{k}D_{n-k}$, and the parent `derangements-oq-04` supplies the field closed form for $D_m$. This entry combines them into the field-level closed form for $S(n,k)$.",
+    "problemStatement": "**Open Question (derangements-oq-04, second open question)**: Does the same single-induction technique that gives the derangement closed form $D_n = n!\\sum_{k=0}^n(-1)^k/k!$ yield a clean closed form for **partial derangements** — permutations with exactly $k$ fixed points — over a general characteristic-zero field?\n\nThis entry answers it affirmatively: $S(n,k) = (n!/k!)\\sum_{j=0}^{n-k}(-1)^j/j!$ over any characteristic-zero field $\\mathbb{K}$, with truncated-exponential phrasing and $\\mathbb{Q}/\\mathbb{R}$ specializations.",
+    "text": "Proves S(n,k) = (n!/k!)·∑_{j=0}^{n-k} (-1)^j/j! for permutations of n with exactly k fixed points, over an arbitrary characteristic-zero field, by bridging the combinatorial count S(n,k)=C(n,k)·D(n-k) with the parent's field derangement closed form.",
+    "proofStrategy": "**Formalization Strategy**\n\nThe result is assembled from two already-formalized ingredients plus one factorial identity, with no new induction needed:\n\n1. **Combinatorial count** (`PartialDerangements.card_perms_with_kfixed`, sibling entry derangements-oq-02): the number of `σ : Perm (Fin n)` with exactly `k` fixed points equals $\\binom{n}{k}\\,\\mathrm{numDerangements}(n-k)$, proved there by partitioning permutations by their support and a support-fixing bijection to derangements of the complement.\n\n2. **Field derangement closed form** (`DerangementsOQ04.numDerangements_closed_form`, parent entry derangements-oq-04): $(\\mathrm{numDerangements}\\,m : \\mathbb{K}) = m!\\sum_{j\\le m}(-1)^j/j!$.\n\n3. **Factorial collapse**: `Nat.choose_mul_factorial_mul_factorial` gives $\\binom{n}{k}k!(n-k)! = n!$; cast into $\\mathbb{K}$ and dividing by the nonzero $k!$ turns the constant $\\binom{n}{k}(n-k)!$ into $n!/k!$.\n\nAfter `rw` of the count, `push_cast` distributes the coercion over the product, `rw` of the derangement closed form substitutes the truncated sum, and `div_mul_eq_mul_div`/`eq_div_iff` clear the $k!$ denominator. The residual goal is a ring identity closed by `linear_combination (truncated sum) * hchoose`. Characteristic zero enters exactly once, to make $k!$ invertible.",
+    "keyInsights": [
+      "**Reuse over re-proof**: the hard content — the combinatorial bijection giving $S(n,k)=\\binom{n}{k}D_{n-k}$ and the field closed form for $D_m$ — already exists in two sibling/parent entries. The open question is answered by an algebraic bridge, not a new induction.",
+      "**The constant collapses exactly**: $\\binom{n}{k}(n-k)! = n!/k!$ is the whole arithmetic content, and it is precisely `Nat.choose_mul_factorial_mul_factorial` divided by $k!$. This is why the prefactor is $n!/k!$ rather than something involving all three factorials.",
+      "**Characteristic zero is used once**: only to invert $k!$. Everything else — the count, the truncated sum — is uniform over any field.",
+      "**k = 0 is a consistency check, not a special case**: setting $k=0$ gives $n!/0! = n!$ and the range $n-0+1 = n+1$, recovering the parent's derangement closed form verbatim; `simpa` discharges it.",
+      "**Sanity anchor**: $S(4,1) = \\binom{4}{1}D_3 = 4\\cdot 2 = 8$, and the closed form $(4!/1!)(1-1+1/2-1/6) = 24\\cdot\\tfrac13 = 8$ agrees, verified over ℚ as an `example`."
+    ],
+    "prerequisites": [
+      "Combinatorics (permutations, fixed points, derangements)",
+      "Elementary field theory and characteristic zero",
+      "Binomial coefficients and the factorial identity C(n,k)·k!·(n-k)! = n!"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Overview of the rencontres-number closed form S(n,k) = (n!/k!)·∑_{j=0}^{n-k}(-1)^j/j! over a characteristic-zero field, how it answers the parent open question by bridging derangements-oq-02 (S(n,k)=C(n,k)·D(n-k)) with derangements-oq-04 (field D(m) closed form), and imports of both sibling files plus Mathlib.Tactic.",
+      "mathContext": "S(n,k) = (n!/k!)·∑_{j=0}^{n-k}(-1)^j/j!; assembled from S(n,k)=C(n,k)·D(n-k) and the field derangement closed form."
+    },
+    {
+      "id": "section-i",
+      "title": "The Closed Form Over a Field",
+      "startLine": 56,
+      "endLine": 86,
+      "summary": "card_perms_with_kfixed_closed_form: (S(n,k):𝕜) = (n!/k!)·∑_{j=0}^{n-k}(-1)^j/j! for k ≤ n over any characteristic-zero field. Proof rewrites the combinatorial count, push_casts, substitutes the derangement closed form, clears k! with eq_div_iff, and closes with linear_combination against Nat.choose_mul_factorial_mul_factorial.",
+      "mathContext": "card_perms_with_kfixed_closed_form: (S(n,k):𝕜) = (n!/k!)·∑_{j=0}^{n-k}(-1)^j/j!."
+    },
+    {
+      "id": "section-ii",
+      "title": "Truncated-Exponential Phrasing and ℚ/ℝ Specializations",
+      "startLine": 87,
+      "endLine": 112,
+      "summary": "card_perms_with_kfixed_eq_factorial_mul_trunc phrases the identity with DerangementsOQ04.truncExpNegOne 𝕜 (n-k+1). card_perms_with_kfixed_closed_form_rat and _real specialize the main theorem to ℚ and ℝ.",
+      "mathContext": "S(n,k) = (n!/k!)·truncExpNegOne 𝕜 (n-k+1), plus ℚ/ℝ specializations."
+    },
+    {
+      "id": "section-iii",
+      "title": "k = 0 Consistency and Sanity Check",
+      "startLine": 113,
+      "endLine": 132,
+      "summary": "card_perms_with_kfixed_zero_closed_form: setting k=0 recovers the parent derangement closed form D(n) = n!·∑_{j≤n}(-1)^j/j! (via simpa). Example: S(4,1)=8 reproduced by the closed form over ℚ.",
+      "mathContext": "k=0 recovers D(n) = n!·∑_{j≤n}(-1)^j/j!; sanity check S(4,1)=8."
+    }
+  ],
+  "conclusion": {
+    "summary": "The rencontres-number closed form S(n,k) = (n!/k!)·∑_{j=0}^{n-k}(-1)^j/j! is proved over an arbitrary characteristic-zero field with 0 sorries and 0 axioms. It answers the parent open question (derangements-oq-04) on partial derangements by bridging the combinatorial identity S(n,k)=C(n,k)·D(n-k) (derangements-oq-02) with the parent's field derangement closed form via Nat.choose_mul_factorial_mul_factorial. Truncated-exponential phrasing, ℚ/ℝ specializations, and a k=0 consistency corollary (recovering D(n)) are included, and S(4,1)=8 is verified.",
+    "implications": "**Significance**\n\n1. **Answers a stated open question**: the second open question of derangements-oq-04 asked whether the field-level derangement closed form extends to partial derangements. It does, and the extension is a clean algebraic bridge over the two existing entries rather than a fresh induction.\n\n2. **A reusable rencontres closed form**: neither the rencontres numbers nor their field closed form are in Mathlib. Exposing S(n,k) = (n!/k!)·∑(-1)^j/j! makes the finite identity behind the k-fixed-point statistics directly available, generalizing the D(n)/n! → 1/e story to fixed-point counts.\n\n3. **Uniform over any characteristic-zero field**: because the proof uses only the count, the derangement closed form, and factorial arithmetic, it holds over ℚ, ℝ, ℂ, or any characteristic-zero field.",
+    "openQuestions": [
+      "Divide by n! to obtain the fixed-point-count distribution S(n,k)/n! = (1/k!)·∑_{j=0}^{n-k}(-1)^j/j!, and take n → ∞ to show it converges to the Poisson(1) probability e^{-1}/k! — the classical limiting distribution of the number of fixed points of a random permutation.",
+      "Does the closed form extend to a generating-function identity ∑_k S(n,k) x^k = ∑ over permutations of x^{#fixed points}, recovering the exponential formula for the fixed-point statistic?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.DerangementsOQ02",
+      "Proofs.DerangementsOQ04",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "DerangementsOQ04OQ01",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Montmort, P. R.",
+      "title": "Essay d'analyse sur les jeux de hasard",
+      "year": "1708",
+      "venue": "Paris",
+      "note": "First systematic study of the problème des rencontres, including permutations with a prescribed number of coincidences"
+    },
+    {
+      "authors": "Euler, L.",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie des Sciences de Berlin",
+      "note": "Establishes D(n) = n! ∑_{k=0}^n (-1)^k/k!, the k=0 case of the rencontres closed form"
+    },
+    {
+      "authors": "Riordan, J.",
+      "title": "An Introduction to Combinatorial Analysis",
+      "year": "1958",
+      "venue": "Wiley",
+      "note": "Standard reference for the rencontres numbers S(n,k) = C(n,k) D(n-k)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-oq-04",
+      "relationship": "extends",
+      "description": "Parent entry: supplies the field derangement closed form D(m) = m!·∑_{j≤m}(-1)^j/j! and poses the partial-derangement open question answered here."
+    },
+    {
+      "targetId": "derangements-oq-02",
+      "relationship": "foundational",
+      "description": "Supplies the combinatorial identity S(n,k) = C(n,k)·numDerangements(n-k) (card_perms_with_kfixed) that this entry bridges to the field closed form."
+    },
+    {
+      "targetId": "derangements-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling open question on the sharp convergence rate |D(n)/n! - 1/e| ≤ 1/(n+1)!; both build on the truncated-exponential form of the derangement count."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves the **rencontres-number closed form** over an arbitrary characteristic-zero field $\mathbb{K}$:
$$ S(n,k) = \frac{n!}{k!}\sum_{j=0}^{n-k}\frac{(-1)^j}{j!} $$
where $S(n,k)$ counts permutations of `Fin n` with **exactly $k$ fixed points**.

This answers the **second open question of `derangements-oq-04`** — whether the field-level derangement closed form extends to partial derangements. It does, via a purely algebraic bridge over two existing gallery entries (no new induction):

- `derangements-oq-02` — $S(n,k) = \binom{n}{k} D(n-k)$ (combinatorial count)
- `derangements-oq-04` — $D(m) = m! \sum_{j\le m}(-1)^j/j!$ (field closed form)

collapsed by `Nat.choose_mul_factorial_mul_factorial` ($\binom{n}{k} k! (n-k)! = n!$). Characteristic zero enters exactly once, to invert $k!$.

## Contents (`Proofs/DerangementsOQ04OQ01.lean`, 132 lines, 5 theorems)

- `card_perms_with_kfixed_closed_form` — the closed form over any char-zero field
- `card_perms_with_kfixed_eq_factorial_mul_trunc` — truncated-$e^{-1}$ phrasing (reuses `DerangementsOQ04.truncExpNegOne`)
- `card_perms_with_kfixed_closed_form_rat` / `_real` — ℚ/ℝ specializations
- `card_perms_with_kfixed_zero_closed_form` — $k=0$ recovers the parent $D(n)$ closed form (consistency)
- `example`: sanity check $S(4,1) = 8$ over ℚ

## Verification

Built via `docker-build.sh`. `#print axioms` reports only the foundational `{propext, Classical.choice, Quot.sound}` — **0 sorries, 0 axioms** beyond Mathlib's foundations. Gallery meta.json + annotations.json included (`status: verified`, `badge: original`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)