### PR TITLE
Enrich Odd-Fourth-Power Zeta Sum λ(4) = π⁴/96 (basel-problem-oq-13)

### DIFF
--- a/src/data/proofs/basel-problem-oq-13/annotations.json
+++ b/src/data/proofs/basel-problem-oq-13/annotations.json
@@ -1,12 +1,35 @@
 [
   {
+    "id": "ann-basel-oq13-header",
+    "proofId": "basel-problem-oq-13",
+    "range": {
+      "startLine": 1,
+      "endLine": 25
+    },
+    "type": "context",
+    "title": "λ(4): the odd-indexed companion of ζ(4)",
+    "content": "Mathlib supplies ζ(4) = ∑ 1/n⁴ = π⁴/90 (`hasSum_zeta_four`) but not its odd-indexed sibling, the lambda value λ(4) = ∑_{k≥0} 1/(2k+1)⁴. The header records the classical identity λ(s) = (1 − 2^(−s)) ζ(s); at s = 4 this gives λ(4) = (15/16)(π⁴/90) = π⁴/96. The entire file adds no new analytic input — it only splits ζ(4) into even- and odd-indexed parts and solves for the odd one, making it a clean showcase of deriving a new closed form purely from an existing Mathlib zeta value.",
+    "mathContext": "$\\lambda(s)=\\sum_{k\\ge 0}\\frac{1}{(2k+1)^s}=(1-2^{-s})\\zeta(s)$; at $s=4$: $\\lambda(4)=\\tfrac{15}{16}\\cdot\\tfrac{\\pi^4}{90}=\\tfrac{\\pi^4}{96}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Riemann zeta at even integers",
+      "Dirichlet lambda function",
+      "parity split of a series",
+      "hasSum_zeta_four"
+    ],
+    "prerequisites": [
+      "Riemann zeta function",
+      "infinite series (HasSum/tsum)"
+    ]
+  },
+  {
     "id": "even-fourth",
     "proofId": "basel-problem-oq-13",
     "range": {
       "startLine": 34,
       "endLine": 43
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "Even Part: ∑ 1/(2k)⁴ = π⁴/1440 (a Sixteenth of ζ(4))",
     "content": "hasSum_even_zeta_four computes the even-indexed fourth-power sum. The scaling factor is 1/16, not 1/4 as in the second-power case: pulling 2 out of (2k)⁴ gives 2⁴ = 16 in the denominator, so 1/(2k)⁴ = (1/16)(1/k⁴). The pointwise identity is closed by `funext; push_cast; ring`, then HasSum.mul_left scales Mathlib's hasSum_zeta_four (ζ(4)=π⁴/90) by 1/16, yielding π⁴/1440. This sixteenth-scaling is the fourth-power analogue of the quarter-scaling used for ζ(2).",
     "mathContext": "$\\displaystyle\\sum_{k\\ge 1}\\frac{1}{(2k)^4} = \\frac{1}{16}\\sum_{k\\ge 1}\\frac{1}{k^4} = \\frac{1}{16}\\cdot\\frac{\\pi^4}{90} = \\frac{\\pi^4}{1440}.$",
@@ -29,7 +52,7 @@
       "startLine": 45,
       "endLine": 62
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Main Result: λ(4) = ∑ 1/(2k+1)⁴ = π⁴/96",
     "content": "hasSum_odd_zeta_four is the headline, obtained by the same even/odd-then-uniqueness idiom as the ζ(2) odd-square entry. The odd subseries is summable (injective reindexing k ↦ 2k+1, dispatched by `omega`); HasSum.even_add_odd reassembles ζ(4) = π⁴/1440 + (∑ odd); and HasSum.unique against hasSum_zeta_four forces ∑ odd = π⁴/90 − π⁴/1440 = π⁴/96 (a one-line `linarith`). The value is the s = 4 case of the Dirichlet lambda λ(s) = (1 − 2^{−s})ζ(s): (1 − 1/16)·π⁴/90 = (15/16)·π⁴/90 = π⁴/96.",
     "mathContext": "$\\lambda(4) = \\sum_{k\\ge 0}\\frac{1}{(2k+1)^4} = \\Big(1-\\tfrac{1}{16}\\Big)\\zeta(4) = \\frac{15}{16}\\cdot\\frac{\\pi^4}{90} = \\frac{\\pi^4}{96}.$",

--- a/src/data/proofs/basel-problem-oq-13/index.ts
+++ b/src/data/proofs/basel-problem-oq-13/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BaselProblemOQ13.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const baselProblemOq13Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const baselProblemOq13Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const baselProblemOq13Data: ProofData = {
+  proof: baselProblemOq13Proof,
+  annotations: baselProblemOq13Annotations,
+}

--- a/src/data/proofs/basel-problem-oq-13/meta.json
+++ b/src/data/proofs/basel-problem-oq-13/meta.json
@@ -62,7 +62,9 @@
       "Mathlib.NumberTheory.ZetaValues",
       "Mathlib.Tactic"
     ],
-    "opens": ["Real"],
+    "opens": [
+      "Real"
+    ],
     "namespace": "BaselOddZetaFour",
     "path": "Proofs/BaselProblemOQ13.lean",
     "lineCount": 85,
@@ -120,11 +122,8 @@
     "summary": "The odd-fourth-power zeta sum λ(4) = ∑ 1/(2k+1)⁴ = π⁴/96 is formalized with 0 axioms and 0 sorries, built from Mathlib's ζ(4) = π⁴/90 by the even/odd parity split. The proof packages the even-indexed fourth-power sum (π⁴/1440) and the odd-indexed lambda value (π⁴/96) as reusable HasSum lemmas plus a tsum corollary.",
     "implications": "Completes the fourth-power analogue of the odd-square Basel sum ∑ 1/(2k+1)² = π²/8 and demonstrates the HasSum.even_add_odd splitting idiom at exponent 4. The same template — even part = scaled ζ, odd part by uniqueness — applies directly to the Dirichlet eta value η(4) = 7π⁴/720 from ζ(4) = π⁴/90, and to higher even exponents via Mathlib's hasSum_zeta_nat.",
     "openQuestions": [
-      {
-        "id": "basel-problem-oq-13-oq-01",
-        "question": "Combine the odd-fourth-power sum λ(4) = π⁴/96 with the even-fourth-power sum π⁴/1440 to derive the Dirichlet eta value η(4) = ∑ (-1)^(n+1)/n⁴ = 7π⁴/720, mirroring the η(2) construction.",
-        "significance": "medium"
-      }
+      "Combine the odd-fourth-power sum λ(4) = π⁴/96 with the even-fourth-power sum π⁴/1440 to derive the Dirichlet eta value η(4) = ∑ (-1)^(n+1)/n⁴ = 7π⁴/720, mirroring the η(2) construction.",
+      "Generalize the parity-split template to the full lambda value λ(s) = (1 − 2^(−s)) ζ(s) for every even s, packaging λ(6) = π⁶/960 and λ(8) from Mathlib's `hasSum_zeta_nat` by the same even/odd HasSum decomposition."
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-13` (∑ 1/(2k+1)⁴ = π⁴/96).

## Gaps closed
- **Created `index.ts`** (was **missing** — page shows *'proof not found'* on the live site).
- **Fixed a broken conclusion render**: `openQuestions` used the object form `{id, question, significance}`, but `ProofConclusion.tsx` passes each item straight to `MarkdownMathInline` and the type is `string[]` — so object-form entries render as `[object Object]`. Converted to the string form used by 4140 entries (only 13 use the broken object form) and **added a 2nd open question** (generalizing the parity split to λ(s) for all even s).
- **Fixed 2 off-schema annotation types** `"theorem"` → `technique`/`insight`.
- **Added a 5th annotation** (header/context) framing λ(4) as the odd-indexed companion of ζ(4).

## Notes
- `meta.json` already had a rich overview (5 keyInsights), implications, sections, crossReferences — left intact. 9.7 KB, under caps.
- JSON validated; confirmed all openQuestions are now strings.