### PR TITLE
research(pentagonal-number-theorem-oq-01): Part 14 — recompute max' on the Franklin move images [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -1412,4 +1412,78 @@ theorem franklinStep_headline (S : Finset ℕ) (s ℓ m : ℕ)
            franklinMoveB_sign S ℓ m h1 h2 h3 h4,
            franklinMoveB_pos S ℓ m hpos h5 h6⟩
 
+/-! ## Part 14: recomputing the top part on the move images (toward the involution)
+
+To close Franklin's involution one must show `franklinStep` is self-inverse: applying it
+to the image re-dispatches into the *other* branch and returns to `S`.  The raw algebra
+for that is already in Part 12 — the two moves are mutually inverse *when fed the right
+parameters*:
+
+    `franklinMoveB (franklinMoveA S s m) s (m+1) = S`      (Move B undoes Move A)
+    `franklinMoveA (franklinMoveB S ℓ m) ℓ (m-1) = S`      (Move A undoes Move B)
+
+The missing link is that those parameters are exactly the ones the *second*
+`franklinStep` would read off the image `T`: its largest part `max' T`.  This part proves
+those two recomputations in closed form:
+
+    `max' (franklinMoveA S s m) = m + 1`     (Move A raises the top by one)
+    `max' (franklinMoveB S ℓ m) = m - 1`     (Move B lowers the top by one)
+
+so the top parameter for the reverse move (`m+1` after Move A, `m-1` after Move B) is
+*canonically* the new largest part — no ad-hoc threading.  The companion `min'` /
+staircase-length recomputations (which fix the smallest-part dispatch test `s ≤ ℓ`)
+remain for a later part. -/
+
+/-- **Move A raises the largest part to `m+1`.**  The image inserts the fresh top `m+1`
+and otherwise only deletes; since every part of `S` is `≤ m`, the maximum of the image is
+exactly `m+1`.  This is the top parameter Move B needs to undo Move A
+(`franklinMoveB (franklinMoveA S s m) s (m+1) = S`). -/
+theorem franklinMoveA_max' (S : Finset ℕ) (s m : ℕ)
+    (H : (franklinMoveA S s m).Nonempty) (hmax : ∀ x ∈ S, x ≤ m) :
+    (franklinMoveA S s m).max' H = m + 1 := by
+  have hmem : m + 1 ∈ franklinMoveA S s m := by
+    rw [franklinMoveA]; exact Finset.mem_insert_self _ _
+  apply le_antisymm
+  · apply Finset.max'_le
+    intro y hy
+    rw [franklinMoveA, Finset.mem_insert] at hy
+    rcases hy with h | h
+    · omega
+    · have hyS : y ∈ S :=
+        Finset.erase_subset _ _ (Finset.erase_subset _ _ h)
+      have := hmax y hyS; omega
+  · exact Finset.le_max' _ _ hmem
+
+/-- **Move B lowers the largest part to `m-1`.**  Move B deletes the old top `m` and
+inserts `ℓ` and `m-ℓ`.  The new maximum is `m-1`: it is present (either as the run part
+`m-1 ∈ S` when the top run has length `≥ 2`, or as the freshly created `m-ℓ` when the run
+has length `1`), and nothing exceeds it (`ℓ < m`, `m-ℓ ≤ m-1`, and every surviving part of
+`S` is `≤ m` but `≠ m`).  This is the top parameter Move A needs to undo Move B
+(`franklinMoveA (franklinMoveB S ℓ m) ℓ (m-1) = S`). -/
+theorem franklinMoveB_max' (S : Finset ℕ) (ℓ m : ℕ)
+    (H : (franklinMoveB S ℓ m).Nonempty) (hmax : ∀ x ∈ S, x ≤ m)
+    (hℓ1 : 1 ≤ ℓ) (hℓm : ℓ < m)
+    (htop : Finset.Icc (m - ℓ + 1) m ⊆ S) :
+    (franklinMoveB S ℓ m).max' H = m - 1 := by
+  have hmem : m - 1 ∈ franklinMoveB S ℓ m := by
+    rw [franklinMoveB]
+    rcases Nat.lt_or_ge ℓ 2 with hlt | hge
+    · -- run length 1: m - 1 = m - ℓ is the inserted run bottom
+      have hℓeq : ℓ = 1 := by omega
+      simp only [Finset.mem_insert]
+      right; left; omega
+    · -- run length ≥ 2: m - 1 lies in the top run, hence in S
+      have hm1S : m - 1 ∈ S := htop (by rw [Finset.mem_Icc]; omega)
+      simp only [Finset.mem_insert, Finset.mem_erase]
+      right; right; exact ⟨by omega, hm1S⟩
+  apply le_antisymm
+  · apply Finset.max'_le
+    intro y hy
+    rw [franklinMoveB, Finset.mem_insert, Finset.mem_insert, Finset.mem_erase] at hy
+    rcases hy with h | h | ⟨hne, hyS⟩
+    · omega
+    · omega
+    · have := hmax y hyS; omega
+  · exact Finset.le_max' _ _ hmem
+
 end PentagonalNumberTheoremOQ01

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -233,3 +233,36 @@ compose the already-0-axiom `franklinMoveA_*`/`franklinMoveB_*` via `unfold`/`sp
   `s ≤ ℓ` off `S` directly and make the swap statable.
 - Then the cancellation sum `∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n` via the
   sign-reversing involution on the non-fixed domain (fixed staircases = pentagonal terms).
+
+## Part 14 (partial) — recomputing the top part `max'` on the move images [VERIFIED, 0-axiom]
+
+**Session 2026-06-30 (researcher-3).** Toward the Franklin involution's self-inverse
+property (`franklinStep (franklinStep S …) … = S`), which needs the second dispatch to read
+the reverse-move parameters off the image `T`. The top parameter is `max' T`. Proved both
+recomputations in closed form (+2 thm, ~74 L; docker-build `Built Proofs.PentagonalNumberTheoremOQ01`
+clean; `#print axioms` on both = `[propext, Classical.choice, Quot.sound]`):
+
+- `franklinMoveA_max' (H hmax) : max' (franklinMoveA S s m) = m + 1`. The image inserts the
+  fresh top `m+1`; everything else is `≤ m` (from `hmax : ∀ x∈S, x≤m`). `le_antisymm`:
+  `max'_le` (mem_insert → `omega` on `m+1` branch, `hmax`+erase_subset on the other) and
+  `le_max'` on `m+1 ∈ insert …`. This is exactly the `m+1` fed to
+  `franklinMoveB (franklinMoveA S s m) s (m+1) = S`.
+- `franklinMoveB_max' (H hmax hℓ1 hℓm htop) : max' (franklinMoveB S ℓ m) = m - 1`. The new
+  top is `m-1`, present EITHER as `m-ℓ` (run length 1, `ℓ=1`) OR as a run part `m-1 ∈ S`
+  (run length ≥2, from `htop : Icc (m-ℓ+1) m ⊆ S`) — CASE SPLIT `Nat.lt_or_ge ℓ 2` is
+  required. Upper bound: `ℓ<m`, `m-ℓ≤m-1` (`ℓ≥1`), erase-branch `y≤m ∧ y≠m ⟹ y≤m-1`
+  (`omega`). This is the `m-1` fed to `franklinMoveA (franklinMoveB S ℓ m) ℓ (m-1) = S`.
+
+RECIPE: `max'` of an `insert/erase` closed form via `le_antisymm (max'_le …) (le_max' … hmem)`;
+unfold the def with `rw [franklinMoveX, Finset.mem_insert, …, Finset.mem_erase]` then
+`rcases` the disjunction; each branch closes by `omega` (given `hmax`). Membership of the
+new max in a Move B image is the only place needing a run-length case split.
+
+### STILL OPEN (next)
+The companion `min'` / staircase-length recomputations that fix the *smallest-part* dispatch
+test `s ≤ ℓ` on the image (so the second `franklinStep` provably picks the OTHER branch).
+Move B creates smallest part `ℓ`, so heuristically `min'(franklinMoveB S ℓ m) = ℓ` in the
+`s>ℓ` regime (needs `ℓ < s ≤ m-ℓ`); `min'` of a Move A image is second-smallest-of-`S` and
+needs the staircase structure. Then glue with Part 12's mutual-inverse pair for the full
+`franklinStep` involution and the cancellation sum
+`∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n`.


### PR DESCRIPTION
## Summary

Part 14 of the Franklin bijective proof of Euler's pentagonal number theorem. This is the next structural step toward closing the involution `franklinStep (franklinStep S …) … = S`.

Parts 11–13 established Franklin's two moves, their mutual-inverse identities (Part 12), and the unified sign-reversing `franklinStep` (Part 13). The remaining gap is self-inverseness: applying `franklinStep` to the image must re-dispatch into the *other* branch and return to `S`. For that, the second dispatch has to read the reverse move's parameters off the image `T` — and the top parameter is `max' T`.

This PR proves both top-parameter recomputations in closed form:

- **`franklinMoveA_max' : max' (franklinMoveA S s m) = m + 1`** — Move A inserts the fresh top `m+1`; every other part is `≤ m`.
- **`franklinMoveB_max' : max' (franklinMoveB S ℓ m) = m - 1`** — Move B deletes the old top `m`; the new maximum `m-1` is present either as the freshly created run bottom `m-ℓ` (run length 1) or as a run part `m-1 ∈ S` (run length ≥ 2), and nothing exceeds it.

These are exactly the `m`-parameters that Part 12's mutual-inverse identities feed to the reverse move:
`franklinMoveB (franklinMoveA S s m) s (m+1) = S` and `franklinMoveA (franklinMoveB S ℓ m) ℓ (m-1) = S`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.PentagonalNumberTheoremOQ01` → `Built Proofs.PentagonalNumberTheoremOQ01` (0 errors, 0 warnings, 0 sorries)
- `#print axioms` on `franklinMoveA_max'` and `franklinMoveB_max'` → `[propext, Classical.choice, Quot.sound]` only (0 extra axioms, no `native_decide`)
- +2 theorems, ~74 lines; clean addition against `origin/main`

## What remains (documented in knowledge.md)

The companion `min'` / staircase-length recomputations that fix the *smallest-part* dispatch test `s ≤ ℓ` on the image, then the glue into the full `franklinStep` involution and the cancellation sum `∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)