### PR TITLE
Enrich HGCD Unimodular Cofactor GCD-Invariance (binary-gcd-oq-03-oq-02-incomplete-01)

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-unimodular-overview",
     "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
-    "range": { "startLine": 1, "endLine": 77 },
+    "range": {
+      "startLine": 1,
+      "endLine": 77
+    },
     "type": "concept",
     "title": "GCD Preservation as the Shadow of a Unimodular Group Action",
     "content": "Every fast GCD scheme — Lehmer, Schönhage's recursive half-GCD, GMP's `mpn_hgcd` — accumulates a **cofactor matrix** $M$ and reduces a pair $(a,b)$ by evaluating $M\\cdot(a,b)^T$. Correctness hinges on one algebraic fact: $M$ lies in $\\mathrm{GL}_2(\\mathbb{Z})$, the **unimodular group** of $2\\times 2$ integer matrices with $\\det = \\pm 1$, and the unimodular group acts on $\\mathbb{Z}^2$ by lattice automorphisms that fix the generated ideal — hence the GCD.\n\nThe parent entry formalizes the recursive algorithm and proves $\\det = \\pm 1$ together with one-directional GCD preservation, but several of its credited facts use `native_decide` (so it carries `Lean.ofReduceBool`). This companion isolates the **group structure** instead: it defines a fresh `HGCDMatrix` type, gives the explicit inverse, proves $M\\cdot M^{-1}=M^{-1}\\cdot M = I$ for unimodular $M$, shows the induced action on $\\mathbb{Z}^2$ is a bijection, and deduces two-directional GCD and ideal invariance — all with **0 axioms** and no `native_decide`.",
@@ -25,61 +28,115 @@
   {
     "id": "ann-ring-identities",
     "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
-    "range": { "startLine": 79, "endLine": 100 },
-    "type": "tactic",
+    "range": {
+      "startLine": 79,
+      "endLine": 100
+    },
+    "type": "technique",
     "title": "Determinant Multiplicativity and the Composition Law",
     "content": "Two identities power everything downstream. **Determinant multiplicativity** `det_mul` ($\\det(MN) = \\det M \\cdot \\det N$) is the engine of the $\\det = \\pm 1$ invariant: it is what makes $\\pm 1$ a *closed* condition under products. The **composition law** `apply_mul` states that the action of a product is the composition of the actions — $(M\\cdot N)$ applied to $(a,b)$ equals $M$ applied to $N$'s output. This is the algebraic glue that lets Schönhage's two recursive calls chain into one correct reduction, and here it is exactly what turns the matrix inverse into a left/right inverse on pairs.",
     "mathContext": "For $2\\times 2$ matrices both facts are polynomial identities closed by `ring` after unfolding the definitions; `apply_mul` is proved componentwise via `Prod.ext_iff`.",
     "significance": "key",
-    "relatedConcepts": ["determinant", "matrix-vector action", "functoriality of the action"],
-    "prerequisites": ["matrix multiplication", "ring identities"]
+    "relatedConcepts": [
+      "determinant",
+      "matrix-vector action",
+      "functoriality of the action"
+    ],
+    "prerequisites": [
+      "matrix multiplication",
+      "ring identities"
+    ]
   },
   {
     "id": "ann-inverse-group",
     "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
-    "range": { "startLine": 102, "endLine": 158 },
+    "range": {
+      "startLine": 102,
+      "endLine": 158
+    },
     "type": "insight",
     "title": "The Explicit Inverse and the Group Axioms",
     "content": "The heart of the file. The adjugate satisfies $M\\,\\operatorname{adj}(M) = \\operatorname{adj}(M)\\,M = (\\det M)\\,I$ (`mul_adj`, `adj_mul`), pure ring identities. Scaling the adjugate by $\\det M$ defines `inv`, and `mul_inv_scalar`/`inv_mul_scalar` show $M\\cdot M^{-1} = (\\det M)^2\\,I$ — again pure `ring`. Combining with $(\\det M)^2 = 1$ (`det_sq_eq_one`) gives the two-sided inverse laws `mul_inv` and `inv_mul`. Finally `det_inv` (the inverse is unimodular with the same determinant) and `det_mul_unimodular` (a product of unimodulars is unimodular) are the **group axioms** restricted to the $\\det = \\pm 1$ condition: the cofactor matrices form a group.",
     "mathContext": "Factoring through the scalar-matrix identity $M\\cdot M^{-1} = \\det^2\\cdot I$ keeps every algebraic step a pure ring identity; only the final collapse $\\det^2 = 1$ uses the unimodularity hypothesis. `det_inv` is read off from $\\det M \\cdot \\det(M^{-1}) = \\det(I) = 1$.",
     "significance": "key",
-    "relatedConcepts": ["adjugate", "two-sided inverse", "GL₂(ℤ) group axioms", "unimodularity"],
-    "prerequisites": ["adjugate identity", "determinant multiplicativity"]
+    "relatedConcepts": [
+      "adjugate",
+      "two-sided inverse",
+      "GL₂(ℤ) group axioms",
+      "unimodularity"
+    ],
+    "prerequisites": [
+      "adjugate identity",
+      "determinant multiplicativity"
+    ]
   },
   {
     "id": "ann-bijection",
     "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
-    "range": { "startLine": 160, "endLine": 190 },
+    "range": {
+      "startLine": 160,
+      "endLine": 190
+    },
     "type": "insight",
     "title": "The HGCD Action is a Bijection of ℤ²",
     "content": "Lifting the matrix inverse to the action: `act_inv_act` and `act_act_inv` show that applying $M^{-1}$ undoes applying $M$ on pairs (each a one-line consequence of `apply_mul` + the inverse laws + `apply_id`). Packaged by `Function.bijective_iff_has_inverse`, this yields `act_bijective`: **a unimodular cofactor matrix permutes the integer lattice $\\mathbb{Z}^2$, with $M^{-1}$ as its inverse permutation.** This is the structural reason GCD preservation holds — and why it holds in *both* directions.",
     "mathContext": "A linear map $\\mathbb{Z}^2\\to\\mathbb{Z}^2$ is bijective iff its matrix is in $\\mathrm{GL}_2(\\mathbb{Z})$. The explicit inverse furnishes both the left and right inverse simultaneously.",
     "significance": "key",
-    "relatedConcepts": ["bijection", "lattice automorphism", "left/right inverse", "permutation of ℤ²"],
-    "prerequisites": ["composition law apply_mul", "two-sided inverse laws"]
+    "relatedConcepts": [
+      "bijection",
+      "lattice automorphism",
+      "left/right inverse",
+      "permutation of ℤ²"
+    ],
+    "prerequisites": [
+      "composition law apply_mul",
+      "two-sided inverse laws"
+    ]
   },
   {
     "id": "ann-gcd-both-directions",
     "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
-    "range": { "startLine": 192, "endLine": 243 },
+    "range": {
+      "startLine": 192,
+      "endLine": 243
+    },
     "type": "insight",
     "title": "Two-Directional GCD Preservation for ℤ Pairs",
     "content": "The arithmetic payoff. `dvd_apply_of_dvd` transfers a common divisor of $(a,b)$ forward to the output (linear combinations). `dvd_apply_iff` upgrades this to an **equivalence**: the converse comes *for free* by applying the forward lemma to $M^{-1}$ and rewriting via `act_inv_act` — no separate Cramer computation. From the equal common-divisor sets, `gcd_apply_eq` proves $\\gcd(M\\cdot(a,b)) = \\gcd(a,b)$ in **both directions** for $\\mathbb{Z}$ pairs (the parent states only one direction, for $\\mathbb{N}$), by `Nat.dvd_antisymm` plus `Int.dvd_gcd` and `Int.gcd_dvd_left/right`.",
     "mathContext": "Common divisors are preserved exactly because the action is invertible: $d\\mid a, d\\mid b \\iff d\\mid u, d\\mid v$ where $(u,v) = M\\cdot(a,b)$. Equal divisor sets force equal gcds by mutual divisibility.",
     "significance": "key",
-    "relatedConcepts": ["gcd preservation", "common divisors", "Bézout/ideal", "antisymmetry of divisibility"],
-    "prerequisites": ["bijective action", "Int.gcd lemmas"]
+    "relatedConcepts": [
+      "gcd preservation",
+      "common divisors",
+      "Bézout/ideal",
+      "antisymmetry of divisibility"
+    ],
+    "prerequisites": [
+      "bijective action",
+      "Int.gcd lemmas"
+    ]
   },
   {
     "id": "ann-ideal-invariance",
     "proofId": "binary-gcd-oq-03-oq-02-incomplete-01",
-    "range": { "startLine": 244, "endLine": 284 },
+    "range": {
+      "startLine": 244,
+      "endLine": 284
+    },
     "type": "concept",
     "title": "Ideal Invariance: (a,b) = (u,v)",
     "content": "The cleanest statement of the invariant: `span_apply_eq` proves the generated ideals are equal, $(u,v) = (a,b)$ in $\\mathbb{Z}$, where $(u,v) = M\\cdot(a,b)$. The forward inclusion holds because $u,v$ are linear combinations of $a,b$; the reverse inclusion is supplied by the inverse matrix (recovering $a,b$ as linear combinations of $u,v$). Over $\\mathbb{Z}$ this is equivalent to GCD preservation, but the ideal form is symmetric by construction and generalizes verbatim to any commutative ring — exhibiting Schönhage's HGCD invariant in its most structural form.",
     "mathContext": "In a PID, $\\langle a,b\\rangle = \\langle \\gcd(a,b)\\rangle$, so ideal invariance and gcd invariance coincide over $\\mathbb{Z}$. The proof uses `Ideal.span_le`, `Ideal.subset_span`, and the module closure lemmas `Ideal.mul_mem_left`/`Ideal.add_mem`.",
     "significance": "key",
-    "relatedConcepts": ["ideal span", "principal ideal domain", "Bézout identity", "module closure"],
-    "prerequisites": ["ideals over ℤ", "the inverse matrix"]
+    "relatedConcepts": [
+      "ideal span",
+      "principal ideal domain",
+      "Bézout identity",
+      "module closure"
+    ],
+    "prerequisites": [
+      "ideals over ℤ",
+      "the inverse matrix"
+    ]
   }
 ]

--- a/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01/index.ts
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BinaryGcdOQ03OQ02Incomplete01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const binaryGcdOq03Oq02Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const binaryGcdOq03Oq02Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const binaryGcdOq03Oq02Incomplete01Data: ProofData = {
+  proof: binaryGcdOq03Oq02Incomplete01Proof,
+  annotations: binaryGcdOq03Oq02Incomplete01Annotations,
+}

--- a/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02-incomplete-01/meta.json
@@ -113,13 +113,20 @@
       "id": "oq-01",
       "question": "Can this unimodular cofactor group be identified with a Mathlib `Matrix.GeneralLinearGroup (Fin 2) ℤ` (or `Matrix.SpecialLinearGroup` for the det = 1 subgroup), transporting the bijective action to Mathlib's `Matrix.toLin` machinery?",
       "difficulty": "medium",
-      "tags": ["mathlib-bridge", "GL2", "group-theory"]
+      "tags": [
+        "mathlib-bridge",
+        "GL2",
+        "group-theory"
+      ]
     },
     {
       "id": "oq-02",
       "question": "Does the bijective-action viewpoint give a cleaner route to a CONDITIONAL size-reduction bound for the parent's recursive HGCD, by tracking how the unimodular action moves the ℤ-lattice norm rather than individual entries?",
       "difficulty": "hard",
-      "tags": ["size-reduction", "quotient-stability"]
+      "tags": [
+        "size-reduction",
+        "quotient-stability"
+      ]
     }
   ],
   "leanFile": {
@@ -133,7 +140,16 @@
     "additionalFiles": []
   },
   "conclusion": {
-    "summary": "This companion isolates the algebraic invariant behind Schönhage's recursive HGCD: the accumulated cofactor matrices form the unimodular group GL₂(ℤ)±1, whose action on ℤ² is a bijection. From the explicit inverse alone follow two-directional GCD preservation and ideal invariance for ℤ pairs — the converse the parent omits — entirely axiom-free and with no native_decide. It makes precise that GCD-preservation is forced by group theory, so the only genuinely hard part of formalizing HGCD is the (still-open) size-reduction bound."
+    "summary": "This companion isolates the algebraic invariant behind Schönhage's recursive HGCD: the accumulated cofactor matrices form the unimodular group GL₂(ℤ)±1, whose action on ℤ² is a bijection. From the explicit inverse alone follow two-directional GCD preservation and ideal invariance for ℤ pairs — the converse the parent omits — entirely axiom-free and with no native_decide. It makes precise that GCD-preservation is forced by group theory, so the only genuinely hard part of formalizing HGCD is the (still-open) size-reduction bound.",
+    "implications": [
+      "Pins down exactly which part of formalizing Schönhage's half-GCD (HGCD) is easy and which is hard: the GCD-preservation invariant is *forced* by the group structure of GL₂(ℤ) (unimodular cofactor matrices act bijectively on ℤ²), so the only genuinely difficult obligation left is the size-reduction / bit-complexity bound.",
+      "Supplies the two-directional converse (GCD preservation and ideal invariance in *both* directions) that the parent entry omits, entirely axiom-free — the self-contained HGCDMatrix type sidesteps the parent's native_decide, so #print axioms shows only propext/Classical.choice/Quot.sound.",
+      "The reusable moral 'GCD-preservation is the shadow of a bijection' transfers to any lattice-reduction or continued-fraction algorithm whose step matrices are unimodular: exhibiting the single inverse M⁻¹ = adj(M)/det discharges the converse divisor transfer, bijectivity, and reverse ideal inclusion at once."
+    ],
+    "openQuestions": [
+      "Formalize the still-open size-reduction bound: that each HGCD step shrinks the bit-length of the pair by a controlled amount, giving the O(M(n) log n) complexity that makes recursive HGCD asymptotically faster than the binary/Euclidean GCD.",
+      "Connect the concrete HGCDMatrix type to Mathlib's general `Matrix.GeneralLinearGroup` / `Matrix.SpecialLinearGroup` (ℤ), transporting these determinant-±1 closure lemmas to the library's group-theoretic API instead of a bespoke 2×2 structure."
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
Enrichment pass for `binary-gcd-oq-03-oq-02-incomplete-01` (GCD preservation as the group action of GL₂(ℤ) unimodular cofactor matrices behind Schönhage's HGCD).

## Gaps closed
- **Created `index.ts`** (was **missing** — page shows *'proof not found'* on the live site).
- **Completed the `conclusion`**: it had only `summary` (missing the required `implications` and any `openQuestions`). Added 3 implications and 2 open questions — including the still-open size-reduction/bit-complexity bound the entry itself identifies as the hard remaining part.
- **Fixed off-schema annotation type** `"tactic"` → `"technique"`.

## Axiom integrity
The slug says "incomplete-01" but meta claims `status: verified, sorries: 0, axiomCount: 0`. **Verified this is accurate**: `grep` finds no `sorry`/`axiom` in the Lean file, and #print axioms (per the entry) shows only propext/Classical.choice/Quot.sound. "incomplete" refers to this being a companion that isolates the GCD-invariance piece of a larger open HGCD problem — not to sorries in this file.

## Notes
- meta.json 14.1 KB, under caps; kept the 4 rich keyInsights and 5 sections intact (no padding). JSON validated.