### PR TITLE
Enrich Topologist's Sine Curve Connectedness (connected-space-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/connected-space-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/connected-space-oq-01-oq-02/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-connoq0102-1",
     "proofId": "connected-space-oq-01-oq-02",
-    "range": { "startLine": 3, "endLine": 35 },
+    "range": {
+      "startLine": 3,
+      "endLine": 35
+    },
     "type": "concept",
     "title": "A Concrete Dense-Skeleton Space",
     "content": "**Module framing.** The parent entry proves that connectedness survives closure, and the sharper 'bark and tree' corollary: any set $t$ with $s \\subseteq t \\subseteq \\overline{s}$ for connected $s$ is itself connected. Its open question asks to deploy this on a concrete space built from a dense connected skeleton. The canonical such space is the **topologist's sine curve** $T = \\{(x, \\sin x^{-1}) : x > 0\\} \\cup (\\{0\\} \\times [-1,1])$ — the textbook witness that *connected* does not imply *path-connected*. This file formalizes the connectedness half, exactly what the corollary delivers.",
@@ -17,45 +20,114 @@
       "Connectedness and the closure operator",
       "The graph of an oscillatory function near a singularity"
     ],
-    "tags": ["module-header", "framing", "topology"]
+    "tags": [
+      "module-header",
+      "framing",
+      "topology"
+    ]
+  },
+  {
+    "id": "ann-connoq0102-defs",
+    "proofId": "connected-space-oq-01-oq-02",
+    "range": {
+      "startLine": 41,
+      "endLine": 48
+    },
+    "type": "definition",
+    "title": "The Three Pieces: Graph, Segment, Curve",
+    "content": "The space is assembled from three explicit sets. `sineCurve` is the graph (x, sin x⁻¹) over the open ray Ioi 0 — the oscillating part that packs infinitely many wiggles as x → 0⁺. `limitSegment` is the vertical segment {0} × [−1,1] onto which those oscillations accumulate. `topologistSineCurve` is their union T = sineCurve ∪ limitSegment. Keeping the graph and the segment as separate named definitions is what lets the proof treat the graph as the connected 'skeleton' s and the whole space as the sandwiched t with s ⊆ t ⊆ closure s.",
+    "mathContext": "$\\mathrm{sineCurve}=\\{(x,\\sin x^{-1}):x>0\\}$, $\\ \\mathrm{limitSegment}=\\{0\\}\\times[-1,1]$, $\\ T=\\mathrm{sineCurve}\\cup\\mathrm{limitSegment}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "image of a set under a map",
+      "product of sets (×ˢ)",
+      "union of sets"
+    ],
+    "prerequisites": [
+      "Set.image",
+      "Set.prod"
+    ]
   },
   {
     "id": "ann-connoq0102-2",
     "proofId": "connected-space-oq-01-oq-02",
-    "range": { "startLine": 50, "endLine": 63 },
-    "type": "tactic",
+    "range": {
+      "startLine": 50,
+      "endLine": 63
+    },
+    "type": "technique",
     "title": "The Graph Is a Connected Skeleton",
     "content": "**Continuous image of a ray.** The oscillating graph $G = \\{(x, \\sin x^{-1}) : x > 0\\}$ is the image of the connected ray $(0,\\infty)$ (`isConnected_Ioi`) under the parametrization $x \\mapsto (x, \\sin x^{-1})$, which is continuous on $(0,\\infty)$ — there $x^{-1}$ is continuous (`ContinuousOn.inv₀`, since $x \\neq 0$), $\\sin$ is continuous, and the pairing is `ContinuousOn.prodMk`. By `IsConnected.image`, $G$ is connected. This is the dense skeleton the rest of the argument hangs on.",
     "mathContext": "$G = (x \\mapsto (x,\\sin x^{-1}))(\\,(0,\\infty)\\,)$ is connected.",
-    "significance": "critical",
-    "relatedConcepts": ["Continuous image of connected is connected", "Continuity away from a singularity"],
-    "prerequisites": ["isConnected_Ioi", "IsConnected.image", "ContinuousOn.inv₀"],
-    "tags": ["connectedness", "continuous-image"]
+    "significance": "key",
+    "relatedConcepts": [
+      "Continuous image of connected is connected",
+      "Continuity away from a singularity"
+    ],
+    "prerequisites": [
+      "isConnected_Ioi",
+      "IsConnected.image",
+      "ContinuousOn.inv₀"
+    ],
+    "tags": [
+      "connectedness",
+      "continuous-image"
+    ]
   },
   {
     "id": "ann-connoq0102-3",
     "proofId": "connected-space-oq-01-oq-02",
-    "range": { "startLine": 65, "endLine": 90 },
+    "range": {
+      "startLine": 65,
+      "endLine": 90
+    },
     "type": "insight",
     "title": "The Segment Lies in the Closure",
     "content": "**Exact-height approximants.** The heart of the proof: every $(0,y)$ with $y \\in [-1,1]$ is a limit of graph points. Set $a_n = \\arcsin y + n\\cdot 2\\pi$; then $\\sin a_n = \\sin(\\arcsin y) = y$ *exactly* (2π-periodicity via `Real.sin_add_nat_mul_two_pi`, plus `Real.sin_arcsin`), and $a_n > 0$ because $\\arcsin y \\ge -\\pi/2$ (`Real.arcsin_mem_Icc`). So $(a_n^{-1}, \\sin a_n) = (a_n^{-1}, y)$, and an Archimedean choice (`exists_nat_gt`) makes $a_n^{-1} < \\varepsilon$. The product distance to $(0,y)$ collapses (`Prod.dist_eq`, second coordinate equal) to $a_n^{-1}$, which is $< \\varepsilon$ by `inv_lt_comm₀`. `Metric.mem_closure_iff` then places $(0,y)$ in $\\overline{G}$.",
     "mathContext": "$(0,y) = \\lim_n (a_n^{-1}, y)$, $a_n = \\arcsin y + 2\\pi n$.",
-    "significance": "critical",
-    "relatedConcepts": ["ε-characterization of closure", "2π-periodicity of sin", "Archimedean property", "Product metric"],
-    "prerequisites": ["Metric.mem_closure_iff", "Real.sin_add_nat_mul_two_pi", "Real.sin_arcsin", "inv_lt_comm₀"],
-    "tags": ["closure", "approximation", "main-step"]
+    "significance": "key",
+    "relatedConcepts": [
+      "ε-characterization of closure",
+      "2π-periodicity of sin",
+      "Archimedean property",
+      "Product metric"
+    ],
+    "prerequisites": [
+      "Metric.mem_closure_iff",
+      "Real.sin_add_nat_mul_two_pi",
+      "Real.sin_arcsin",
+      "inv_lt_comm₀"
+    ],
+    "tags": [
+      "closure",
+      "approximation",
+      "main-step"
+    ]
   },
   {
     "id": "ann-connoq0102-4",
     "proofId": "connected-space-oq-01-oq-02",
-    "range": { "startLine": 92, "endLine": 104 },
-    "type": "theorem",
+    "range": {
+      "startLine": 92,
+      "endLine": 104
+    },
+    "type": "concept",
     "title": "Connectedness via Bark and Tree",
     "content": "**Closing the argument.** With $G$ connected and $G \\subseteq T \\subseteq \\overline{G}$ (the first inclusion trivial, the second from `subset_closure` on the graph and the segment-in-closure step), the parent's bark-and-tree corollary `IsConnected.subset_closure` gives `IsConnected T` directly — no separation argument needed. `isPreconnected_topologistSineCurve` records the preconnected consequence. Path-connectedness, by contrast, fails for $T$ (left as a follow-up).",
     "mathContext": "$G \\subseteq T \\subseteq \\overline{G} \\Rightarrow T \\text{ connected}$.",
-    "significance": "critical",
-    "relatedConcepts": ["Bark-and-tree corollary", "Connected but not path-connected"],
-    "prerequisites": ["IsConnected.subset_closure", "subset_closure"],
-    "tags": ["result", "connectedness", "counterexample"]
+    "significance": "key",
+    "relatedConcepts": [
+      "Bark-and-tree corollary",
+      "Connected but not path-connected"
+    ],
+    "prerequisites": [
+      "IsConnected.subset_closure",
+      "subset_closure"
+    ],
+    "tags": [
+      "result",
+      "connectedness",
+      "counterexample"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `connected-space-oq-01-oq-02` (the topologist's sine curve is connected, via the parent's bark-and-tree corollary).

## Changes
- **Fixed off-schema annotation values**: `significance: "critical"` → `"key"` (×3), `type: "tactic"` → `"technique"`, `type: "theorem"` → `"concept"` (enums are key/supporting/technical/context and concept/definition/technique/insight/context).
- **Added a 5th annotation** covering the three set definitions (`sineCurve`, `limitSegment`, `topologistSineCurve`, lines 41–48) that were previously unannotated — explaining how keeping graph and segment separate enables the s ⊆ t ⊆ closure(s) sandwich.

## Notes
- Already had `index.ts` and a rich `meta.json` (4 keyInsights, 4 sections, conclusion with implications + 3 string-form openQuestions) — left intact. 14.7 KB, under caps.
- JSON validated (5 annotations, all schema-valid).