### PR TITLE
Fix: realign erdos-12 leanFile single-file counts (thm 104→8, def 29→13)

### DIFF
--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -217,8 +217,8 @@
     "namespace": "Erdos12APN_I, Erdos12APN_II (companion files)",
     "lineCount": 293,
     "axiomCount": 0,
-    "theoremCount": 104,
-    "definitionCount": 29,
+    "theoremCount": 8,
+    "definitionCount": 13,
     "path": "Proofs/Erdos12Problem.lean",
     "companionPaths": [
       "Proofs/Erdos12ProblemAPNPartI.lean",


### PR DESCRIPTION
## Fix

The `leanFile` block for `erdos-12` describes the single main file `Proofs/Erdos12Problem.lean` (its `lineCount` is 293 = that one file), but its `theoremCount`/`definitionCount` held the **3-file aggregate** values instead.

## Evidence

`Erdos12Problem.lean` (canonical col-0 extraction, per `scripts/research/enrich-research.ts`):
- 293 lines, **8** theorems/lemmas, **13** defs, 0 axioms, 0 sorries

The stored `leanFile` block had `theoremCount: 104`, `definitionCount: 29` — these are the aggregate across all three files (main + `APNPartI` + `APNPartII`):
- lines: 293 + 1252 + 810 = 2355
- thm: 8 + 68 + 28 = 104
- (that aggregate correctly lives in the separate `meta` block, which is left unchanged)

**Before**: `leanFile.theoremCount = 104`, `leanFile.definitionCount = 29` (aggregate values on a single-file block)
**After**: `leanFile.theoremCount = 8`, `leanFile.definitionCount = 13` (actual single-file counts)

`leanFile.lineCount` (293), `axiomCount` (0), `sorries` (0) were already correct. The `meta` aggregate block (2355 lines / 104 thm) is unchanged.

---
Automated fix by lean-mechanic agent.