### PR TITLE
Enrich Variance of the Squared-Binomial Law (combinations-formula-oq-07-oq-04-oq-02)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-04-oq-02/annotations.json
@@ -31,11 +31,11 @@
       "startLine": 61,
       "endLine": 105
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Cleared Variance Identity",
     "content": "centred_second_moment establishes (2n−1)·∑_{k=0}^{n} (2k−n)²·C(n,k)² = n²·C(2n,n) for n ≥ 1, entirely over ℤ. Expanding (2k−n)² = 4k² − 4nk + n² and distributing the sum reduces the left side to 4·∑ k²C² − 4n·∑ kC² + n²·∑ C²; casting the three ℕ moment closed forms (OQ-07 zeroth, OQ-03 first, OQ-04 second) to ℤ via exact_mod_cast turns it into 4n²·C(2n−2,n−1) − 4n²·C(2n−1,n−1) + n²·C(2n,n). With c = C(2n,n), a = C(2n−1,n−1), b = C(2n−2,n−1), the halving c = 2a and the recurrence n·c = 2(2n−1)·b collapse (2n−1)·(that) to n²·c in a single linear_combination.",
     "mathContext": "Centring on the integer deviation $2k-n$ (twice $k-n/2$) keeps everything in $\\mathbb{Z}$. The identity $(2n-1)\\sum_k (2k-n)^2\\binom{n}{k}^2 = n^2\\binom{2n}{n}$ is the variance cleared of denominators.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "centred second moment",
       "moment expansion (2k−n)² = 4k² − 4nk + n²",
@@ -56,7 +56,7 @@
       "startLine": 107,
       "endLine": 140
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "The Variance in Lowest Terms",
     "content": "variance_eq establishes (∑_{k=0}^{n} (k − n/2)²·C(n,k)²)/C(2n,n) = n²/(4(2n−1)) for n ≥ 1, over ℚ. It pushes the integer identity centred_second_moment into ℚ, rewrites the centred square (k − n/2)² = (2k − n)²/4 termwise inside the sum (Finset.sum_div), and clears denominators with field_simp and nlinarith using C(2n,n) ≠ 0 (Nat.choose_pos) and 2n−1 ≠ 0. The result is the variance of the squared-binomial law in reduced rational form — the hypergeometric variance n·(K/N)·(1−K/N)·(N−n)/(N−1) at N = 2n, K = n.",
     "mathContext": "$\\dfrac{\\sum_{k=0}^{n}(k-n/2)^2\\binom{n}{k}^2}{\\binom{2n}{n}} = \\dfrac{n^2}{4(2n-1)}$, with $(k-n/2)^2 = (2k-n)^2/4$.",
@@ -94,6 +94,29 @@
     "prerequisites": [
       "Finset.sum over an explicit range",
       "Nat.choose evaluation"
+    ]
+  },
+  {
+    "id": "ann-combo070402-technique",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-02",
+    "range": {
+      "startLine": 72,
+      "endLine": 105
+    },
+    "type": "technique",
+    "title": "Stay in ℤ: centre on 2k−n and expand into raw moments",
+    "content": "The reusable engine of the proof. Rather than compute the variance directly over ℚ (which drags in the mean n/2 and denominators), the deviation is doubled to 2k − n so it is an INTEGER, keeping the whole cleared identity (★) inside ℤ. Expanding (2k−n)² = 4k² − 4nk + n² (hexpand) turns the centred second moment into a linear combination of the family's three already-proved raw moments ∑C², ∑kC², ∑k²C² (hS0/hS1/hS2). The two central-binomial relations — halving C(2n,n)=2C(2n−1,n−1) and the recurrence n·C(2n,n)=2(2n−1)C(2n−2,n−1) — then collapse everything in a single `linear_combination`, so no new combinatorial identity is proved from scratch.",
+    "mathContext": "$\\sum (2k-n)^2 C(n,k)^2 = 4\\sum k^2C^2 - 4n\\sum kC^2 + n^2\\sum C^2$, closed by $c=2a$ and $nc=2(2n-1)b$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "method of moments",
+      "integer centering",
+      "linear_combination tactic",
+      "central binomial coefficient identities"
+    ],
+    "prerequisites": [
+      "raw moments of a distribution",
+      "Finset.sum manipulation"
     ]
   }
 ]

--- a/src/data/proofs/combinations-formula-oq-07-oq-04-oq-02/index.ts
+++ b/src/data/proofs/combinations-formula-oq-07-oq-04-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CombinationsFormulaOQ07OQ04OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const combinationsFormulaOq07Oq04Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const combinationsFormulaOq07Oq04Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const combinationsFormulaOq07Oq04Oq02Data: ProofData = {
+  proof: combinationsFormulaOq07Oq04Oq02Proof,
+  annotations: combinationsFormulaOq07Oq04Oq02Annotations,
+}

--- a/src/data/proofs/combinations-formula-oq-07-oq-04-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-04-oq-02/meta.json
@@ -119,7 +119,10 @@
   "conclusion": {
     "summary": "2 theorems, 0 sorries, 0 axioms. The cleared variance identity (2n−1)·∑_{k=0}^{n} (2k−n)²·C(n,k)² = n²·C(2n,n) (over ℤ, n ≥ 1) and its lowest-terms rational form (∑ (k−n/2)²·C(n,k)²)/C(2n,n) = n²/(4(2n−1)) (over ℚ) formalize the variance of the squared-binomial law C(n,k)²/C(2n,n). The whole proof expands the centred square into the family's three already-proved raw moments and collapses their combination via the central-binomial halving and recurrence in a single linear_combination.",
     "implications": "Completes the moment computation of the OQ-07-OQ-04 family by formalizing the variance the parent only stated verbally. The technique — centre on the integer deviation 2k − n to stay in ℤ, expand into known raw moments, and collapse via the two central-binomial relations — is a reusable route to variances of symmetric binomial-square sums. The value n²/(4(2n−1)) is the variance of the hypergeometric distribution H(2n,n,n), now derived inside Lean from the family's own identities rather than imported.",
-    "openQuestions": []
+    "openQuestions": [
+      "Extend the moment computation to the third and fourth central moments (skewness and kurtosis) of the squared-binomial law, using the same 'centre on the integer deviation 2k − n, expand into raw moments' route with the higher weighted sums ∑ k³·C(n,k)² and ∑ k⁴·C(n,k)².",
+      "Identify the distribution k ↦ C(n,k)²/C(2n,n) with the hypergeometric law H(2n,n,n) inside Mathlib and derive the variance n²/(4(2n−1)) as a corollary of a general hypergeometric-variance lemma, rather than from this family's bespoke identities."
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-07-oq-04-oq-02` (variance of the Vandermonde squared-binomial distribution, n²/(4(2n−1))).

## Gaps closed
- **Created `index.ts`** (was **missing** — page shows *'proof not found'* on the live site).
- **Added 2 `openQuestions`** (the array was empty): higher central moments (skewness/kurtosis) via the same moment route, and identifying the law with the hypergeometric H(2n,n,n) inside Mathlib.
- **Fixed off-schema annotation values**: `type: "theorem"` → `insight`/`technique`, `significance: "critical"` → `"key"`.
- **Added a 5th annotation** on the reusable technique (centre on the integer deviation 2k−n to stay in ℤ, expand into the family's three raw moments, collapse via the two central-binomial relations in one `linear_combination`).

## Notes
- `meta.json` already had a rich overview (5 keyInsights), implications, 4 sections, 4 crossReferences — left intact. 13 KB, under caps.
- Sanity checks use kernel `decide` (not `native_decide`), so the 0-axiom claim is correct. JSON validated.