### PR TITLE
Fix: normalize 6 malformed leanFile blocks in gallery meta.json

### DIFF
--- a/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/meta.json
@@ -4,7 +4,10 @@
   "title": "Vajda's Identity: the bilinear master identity for Fibonacci numbers",
   "leanFile": {
     "path": "Proofs/CassiniIdentityOQ01OQ01OQ01.lean",
+    "lineCount": 156,
     "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
     "sorryCount": 0
   },
   "sorries": [],
@@ -151,7 +154,7 @@
     ],
     "dateAdded": "2026-06-28",
     "axiomCount": 0,
-    "lineCount": 148,
+    "lineCount": 156,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The proof uses only Mathlib's Fibonacci lemmas (Nat.fib_add, Nat.fib_add_two), the imported Cassini core cassini_sub (itself a three-line induction), exact_mod_cast, linear_combination, simp, and ring; no native_decide and no structure-encoded hypotheses. #print axioms reports only the foundational propext / Classical.choice / Quot.sound, none of which counts as an assumption.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,

--- a/src/data/proofs/cassini-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01/meta.json
@@ -4,7 +4,10 @@
   "title": "Catalan's Identity: the r-step generalization of Cassini",
   "leanFile": {
     "path": "Proofs/CassiniIdentityOQ01OQ01.lean",
+    "lineCount": 114,
     "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
     "sorryCount": 0
   },
   "sorries": [],

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01-oq-01-oq-02/meta.json
@@ -4,7 +4,10 @@
   "title": "Chebyshev substitution as an algebra-endomorphism homomorphism (ℤ, ·) → (R[X] →ₐ R[X], ∘)",
   "leanFile": {
     "path": "Proofs/DeMoivreOQ01OQ03OQ01OQ01OQ02.lean",
+    "lineCount": 175,
     "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
     "sorryCount": 0
   },
   "sorries": [],

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-01-oq-02/meta.json
@@ -111,7 +111,10 @@
   ],
   "leanFile": {
     "path": "Proofs/EulerCriterionSquaresOQ01OQ01OQ02.lean",
+    "lineCount": 131,
     "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
     "sorryCount": 0
   },
   "mainTheorems": [

--- a/src/data/proofs/pell-equation-oq-07-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01/meta.json
@@ -3,7 +3,14 @@
   "title": "Binet and Companion-Matrix Closed Forms for Pell Coordinate Sequences",
   "slug": "pell-equation-oq-07-oq-01",
   "description": "The parent entry (pell-equation-oq-07) extracts the second-order linear recurrence uₙ₊₂ = 2x₁·uₙ₊₁ − N(a)·uₙ that the coordinate sequences of the power sequence aⁿ of a generator a = ⟨x₁,y₁⟩ ∈ ℤ[√d] satisfy — the recurrence is the additive shadow of the multiplicative power structure. This entry answers the parent's own first open question by supplying the two closed forms the recurrence is the shadow of: a Binet form expressing each coordinate of aⁿ in terms of the conjugate roots x₁ ± y₁√d of the characteristic polynomial t² − 2x₁·t + N(a), and a companion-matrix power form Mⁿ. The mechanism is that Galois conjugation x + y√d ↦ x − y√d is exactly Mathlib's ring involution star on ℤ[√d], which commutes with powers (star_pow); reading the real and √d parts of aⁿ ± (star a)ⁿ isolates the two coordinate sequences as aⁿ + (star a)ⁿ = ⟨2·re(aⁿ),0⟩ and aⁿ − (star a)ⁿ = ⟨0,2·im(aⁿ)⟩. Mapping these into ℝ through the ring hom Zsqrtd.lift √d (defined for d ≥ 0), which sends a and star a to the conjugate reals x₁ ± y₁√d, yields Binet's formulas re(aⁿ) = ((x₁+y₁√d)ⁿ + (x₁−y₁√d)ⁿ)/2 and 2·im(aⁿ)·√d = (x₁+y₁√d)ⁿ − (x₁−y₁√d)ⁿ. The companion matrix M = ⟨⟨x₁, d·y₁⟩, ⟨y₁, x₁⟩⟩ of multiplication-by-a on the basis {1,√d} has Mⁿ = ⟨⟨re(aⁿ), d·im(aⁿ)⟩, ⟨im(aⁿ), re(aⁿ)⟩⟩, with trace 2x₁ and determinant N(a) — the coefficients of the characteristic polynomial whose roots are the conjugate units, made explicit (eigenvalue picture).",
-  "leanFile": "Proofs/PellEquationOQ07OQ01.lean",
+  "leanFile": {
+    "path": "Proofs/PellEquationOQ07OQ01.lean",
+    "lineCount": 232,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "sorryCount": 0
+  },
   "sorries": 0,
   "meta": {
     "author": "Lean Genius (Binet/companion-matrix closed forms via conjugation = star in ℤ[√d]); Binet / Lagrange (classical closed-form Pell theory)",

--- a/src/data/proofs/pell-equation-oq-07/meta.json
+++ b/src/data/proofs/pell-equation-oq-07/meta.json
@@ -3,7 +3,14 @@
   "title": "The Cayley–Hamilton Linear Recurrence of Pell Solutions: uₙ₊₂ = 2x₁·uₙ₊₁ − uₙ",
   "slug": "pell-equation-oq-07",
   "description": "The root entry classifies the solutions of x² − Dy² = 1 multiplicatively — every solution is a power of the fundamental solution (x₁ + y₁√D) in ℤ[√D]. This entry extracts the additive shadow that classification leaves implicit: each coordinate of the power sequence satisfies a second-order linear recurrence, with coefficients fixed by the characteristic polynomial of the generating quadratic integer. Working in Mathlib's Zsqrtd d for arbitrary d, every a ∈ ℤ[√d] satisfies its Cayley–Hamilton relation a² = (2·re a)·a − N(a) — the trace 2·re a = a + ā and determinant N(a) = a·ā of multiplication by a. Multiplying by aⁿ yields aⁿ⁺² = (2·re a)·aⁿ⁺¹ − N(a)·aⁿ, and reading off the two coordinates gives uₙ₊₂ = (2·re a)·uₙ₊₁ − N(a)·uₙ for both x and y. For a Pell solution N(a) = 1, collapsing to uₙ₊₂ = (2·x₁)·uₙ₊₁ − uₙ: the coefficient is twice the first coordinate of the generator. This is the general-D explanation of the D = 2 coefficient 6 in pell-equation-oq-06-oq-03, since the norm-+1 generator there is 3 + 2√2 = ⟨3,2⟩ and 2·3 = 6.",
-  "leanFile": "Proofs/PellEquationOQ07.lean",
+  "leanFile": {
+    "path": "Proofs/PellEquationOQ07.lean",
+    "lineCount": 231,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "sorryCount": 0
+  },
   "sorries": 0,
   "meta": {
     "author": "Lean Genius (Cayley–Hamilton recurrence in ℤ[√d]); Brahmagupta / Lagrange (classical Pell theory)",


### PR DESCRIPTION
## Fix

Normalize six gallery `meta.json` entries whose top-level `leanFile` block was incomplete or malformed, so they match the schema used by the other 4112 well-formed entries and by the enrich-research extractor.

## Evidence

A drift scan of `leanFile.lineCount` vs actual `wc -l` surfaced 6 entries whose blocks lacked count fields:

| slug | defect | fix |
|------|--------|-----|
| cassini-identity-oq-01-oq-01 | missing lineCount/theoremCount/definitionCount | +114/6/0 |
| cassini-identity-oq-01-oq-01-oq-01 | missing counts; stale meta.lineCount 148 | +156/6/0, meta.lineCount→156 |
| de-moivre-oq-01-oq-03-oq-01-oq-01-oq-02 | missing counts | +175/8/1 |
| euler-criterion-squares-oq-01-oq-01-oq-02 | missing counts | +131/12/1 |
| pell-equation-oq-07 | `leanFile` was a bare **string** | →object 231/11/0 |
| pell-equation-oq-07-oq-01 | `leanFile` was a bare **string** | →object 232/10/2 |

**Before**: 4 blocks missing `lineCount`/`theoremCount`/`definitionCount`; 2 `leanFile` fields were plain strings (schema violation — breaks `meta.leanFile.path` consumers).
**After**: all 6 blocks are complete objects; `lineCount = wc -l`, count fields mirror each entry's `meta` block. All JSON parses; drift scan clean for these slugs.

No Lean source changed. Pure metadata realignment.

---
Automated fix by lean-mechanic agent.