### PR TITLE
Enrich Directed Handshake Lemma & Tournament Score Sums (erdos-1012-oq-03-oq-02)

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1012-oq-03-oq-02/annotations.json
@@ -2,73 +2,147 @@
   {
     "id": "dh-digraph-defs",
     "proofId": "erdos-1012-oq-03-oq-02",
-    "range": { "startLine": 55, "endLine": 78 },
+    "range": {
+      "startLine": 55,
+      "endLine": 78
+    },
     "type": "definition",
     "title": "Digraph, Degrees, and Arc Count",
     "content": "A Digraph is a loopless arc relation arc : V → V → Prop (no v → v). outDegree v counts targets u with v → u; inDegree v counts sources u with u → v; arcCount is the total number of ordered arc pairs. These mirror the companion file Erdos1012OQ03 verbatim so this file stands alone and is machine-checked end to end. Decidability of the arc relation is supplied classically (Classical.decPred), which is why the degree definitions are noncomputable.",
     "mathContext": "$d^+(v) = \\#\\{u : v \\to u\\},\\quad d^-(v) = \\#\\{u : u \\to v\\},\\quad |A| = \\#\\{(u,v) : u \\to v\\}$",
     "significance": "supporting",
-    "prerequisites": ["directed graphs / digraphs", "Fintype.card of a subtype", "Classical.decPred"],
-    "relatedConcepts": ["out-degree / in-degree", "loopless relation", "tournament", "arc count"]
+    "prerequisites": [
+      "directed graphs / digraphs",
+      "Fintype.card of a subtype",
+      "Classical.decPred"
+    ],
+    "relatedConcepts": [
+      "out-degree / in-degree",
+      "loopless relation",
+      "tournament",
+      "arc count"
+    ]
   },
   {
     "id": "dh-filter-reformulation",
     "proofId": "erdos-1012-oq-03-oq-02",
-    "range": { "startLine": 80, "endLine": 97 },
-    "type": "lemma",
+    "range": {
+      "startLine": 80,
+      "endLine": 97
+    },
+    "type": "technique",
     "title": "Degrees and Arc Count as Filter Cardinalities",
     "content": "outDegree_eq_card_filter, inDegree_eq_card_filter, and arcCount_eq_card_filter rewrite each subtype-cardinality as the cardinality of a Finset.filter over univ (resp. univ ×ˢ univ). This bridges the definitional Fintype.card {u // arc v u} with the Finset world where Fubini-style sum manipulations (sum_product, sum_comm) are available — the technical move that makes the handshake counting go through.",
     "mathContext": "$d^+(v) = |\\{u \\in V : v \\to u\\}|,\\quad |A| = |\\{(u,v) : u \\to v\\}|$",
     "significance": "supporting",
-    "prerequisites": ["Fintype.card_subtype", "Finset.filter", "Finset.card"],
-    "relatedConcepts": ["cardinality as filtered count", "subtype vs Finset", "indicator counting"]
+    "prerequisites": [
+      "Fintype.card_subtype",
+      "Finset.filter",
+      "Finset.card"
+    ],
+    "relatedConcepts": [
+      "cardinality as filtered count",
+      "subtype vs Finset",
+      "indicator counting"
+    ]
   },
   {
     "id": "dh-handshake",
     "proofId": "erdos-1012-oq-03-oq-02",
-    "range": { "startLine": 99, "endLine": 123 },
-    "type": "theorem",
+    "range": {
+      "startLine": 99,
+      "endLine": 123
+    },
+    "type": "insight",
     "title": "The Directed Handshake Lemma: ∑ d⁺ = |A| = ∑ d⁻",
     "content": "The central result. sum_outDegree_eq_arcCount: summing out-degrees counts every arc exactly once, recovering arcCount — proved by expanding to filter cardinalities and applying Finset.sum_product over univ ×ˢ univ. sum_inDegree_eq_arcCount is the same with an extra Finset.sum_comm (swap the order of the double sum). Together (sum_outDegree_eq_sum_inDegree) they give conservation of degree: total out-degree = total in-degree, the directed analogue of Euler's handshake lemma — each arc leaves exactly one vertex and enters exactly one.",
     "mathContext": "$\\sum_{v} d^+(v) = |A| = \\sum_{v} d^-(v)$",
-    "significance": "critical",
-    "prerequisites": ["Finset.sum_product (Fubini for double sums)", "Finset.sum_comm", "Finset.univ_product_univ"],
-    "relatedConcepts": ["handshake lemma", "Euler degree-sum", "double counting", "conservation of flow"]
+    "significance": "key",
+    "prerequisites": [
+      "Finset.sum_product (Fubini for double sums)",
+      "Finset.sum_comm",
+      "Finset.univ_product_univ"
+    ],
+    "relatedConcepts": [
+      "handshake lemma",
+      "Euler degree-sum",
+      "double counting",
+      "conservation of flow"
+    ]
   },
   {
     "id": "dh-tournament-degree",
     "proofId": "erdos-1012-oq-03-oq-02",
-    "range": { "startLine": 125, "endLine": 156 },
-    "type": "theorem",
+    "range": {
+      "startLine": 125,
+      "endLine": 156
+    },
+    "type": "concept",
     "title": "Tournament Local Identity: d⁺(v) + d⁻(v) = n − 1",
     "content": "tournament_outDegree_add_inDegree: in a tournament each vertex either beats or loses to every other vertex, so its out- and in-neighborhoods are disjoint and their union is univ.erase v. Hence d⁺(v) + d⁻(v) = |univ.erase v| = n − 1. The proof shows disjointness from the tournament's exactly-one-arc property and identifies the union with the complement of {v} via the same dichotomy.",
     "mathContext": "$D \\text{ tournament} \\;\\Rightarrow\\; d^+(v) + d^-(v) = n - 1$",
     "significance": "key",
-    "prerequisites": ["Finset.card_union_of_disjoint", "Finset.card_erase_of_mem", "tournament dichotomy", "Finset.disjoint_left"],
-    "relatedConcepts": ["tournament", "round-robin", "complete digraph orientation", "score sequence"]
+    "prerequisites": [
+      "Finset.card_union_of_disjoint",
+      "Finset.card_erase_of_mem",
+      "tournament dichotomy",
+      "Finset.disjoint_left"
+    ],
+    "relatedConcepts": [
+      "tournament",
+      "round-robin",
+      "complete digraph orientation",
+      "score sequence"
+    ]
   },
   {
     "id": "dh-landau",
     "proofId": "erdos-1012-oq-03-oq-02",
-    "range": { "startLine": 158, "endLine": 173 },
-    "type": "theorem",
+    "range": {
+      "startLine": 158,
+      "endLine": 173
+    },
+    "type": "concept",
     "title": "Landau's Score-Sum Identity: 2·∑ d⁺ = n(n−1)",
     "content": "Summing the local identity d⁺(v) + d⁻(v) = n − 1 over all vertices and using ∑ d⁺ = ∑ d⁻ = |A| gives 2·|A| = n(n−1) (tournament_two_mul_arcCount) — a tournament on n vertices has exactly n(n−1)/2 = C(n,2) arcs, one per unordered pair. Restated for scores, 2·∑ d⁺(v) = n(n−1): the score sequence sums to C(n,2). Everything is kept multiplicative (2·X = …) to stay in ℕ and avoid division.",
     "mathContext": "$2|A| = n(n-1), \\qquad 2\\sum_v d^+(v) = n(n-1) = 2\\binom{n}{2}$",
     "significance": "key",
-    "prerequisites": ["the handshake lemma", "the tournament local identity", "Finset.sum_const", "ℕ multiplicative bookkeeping"],
-    "relatedConcepts": ["Landau's theorem", "score sequence", "binomial coefficient C(n,2)", "Erdős–Gallai-type counting"]
+    "prerequisites": [
+      "the handshake lemma",
+      "the tournament local identity",
+      "Finset.sum_const",
+      "ℕ multiplicative bookkeeping"
+    ],
+    "relatedConcepts": [
+      "Landau's theorem",
+      "score sequence",
+      "binomial coefficient C(n,2)",
+      "Erdős–Gallai-type counting"
+    ]
   },
   {
     "id": "dh-averaging",
     "proofId": "erdos-1012-oq-03-oq-02",
-    "range": { "startLine": 175, "endLine": 190 },
-    "type": "theorem",
+    "range": {
+      "startLine": 175,
+      "endLine": 190
+    },
+    "type": "technique",
     "title": "Averaging / Pigeonhole: Some Vertex Beats the Average",
     "content": "exists_outDegree_ge_average: some vertex v has n·d⁺(v) ≥ |A|, i.e. d⁺(v) is at least the average out-degree |A|/n. Take the vertex of maximum out-degree (univ.exists_max_image); then ∑_u d⁺(u) ≤ ∑_u d⁺(v) = n·d⁺(v), and the left side is |A| by the handshake lemma. This elementary averaging step is exactly what opens degree-threshold Hamiltonicity arguments (Ghouila–Houri, Moon–Moser) in the companion file.",
     "mathContext": "$\\exists v,\\ n \\cdot d^+(v) \\ge |A| \\quad (\\text{i.e. } d^+(v) \\ge \\text{average})$",
     "significance": "key",
-    "prerequisites": ["Finset.exists_max_image", "Finset.sum_le_sum", "the handshake lemma", "averaging / pigeonhole"],
-    "relatedConcepts": ["pigeonhole principle", "max ≥ average", "degree-threshold Hamiltonicity", "Ghouila–Houri theorem"]
+    "prerequisites": [
+      "Finset.exists_max_image",
+      "Finset.sum_le_sum",
+      "the handshake lemma",
+      "averaging / pigeonhole"
+    ],
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "max ≥ average",
+      "degree-threshold Hamiltonicity",
+      "Ghouila–Houri theorem"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-1012-oq-03-oq-02/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03-oq-02/meta.json
@@ -124,7 +124,15 @@
   ],
   "conclusion": {
     "summary": "The directed handshake lemma (∑ outDegree = arcCount = ∑ inDegree, hence total out-degree = total in-degree) and its tournament specialisations (out + in = n − 1, 2·arcCount = n(n−1), Landau's score sum, and the averaging bound) furnish the degree-counting foundation that the companion's Hamiltonicity theorems use implicitly. Everything is proved from first principles, sorry-free and 0-axiom.",
-    "futureWork": "Build toward Landau's theorem (a non-decreasing sequence is the score sequence of a tournament iff the partial sums dominate the triangular numbers with equality at the end), and repair/replace the companion oq-03 file so the handshake lemmas can be cited there directly."
+    "implications": [
+      "Supplies the degree-counting foundation the companion Hamiltonicity theorems (Rédei, Moon–Moser, Ghouila–Houri, arc-count threshold) rest on but never state: the directed handshake lemma ∑ d⁺ = arcCount = ∑ d⁻ is the directed analogue of Euler's handshake lemma, and its tournament specialisations pin the global statistics exactly.",
+      "The Landau score-sum identity 2·∑ d⁺ = n(n−1) (scores sum to C(n,2)) and the averaging bound 'some vertex beats the average' are the elementary entry points to tournament degree-threshold arguments, now available sorry-free and 0-axiom for reuse.",
+      "Re-declaring the digraph definitions verbatim makes the file self-contained and end-to-end machine-checked, decoupling the counting layer from the (separately maintained) companion so the identities can be cited independently."
+    ],
+    "openQuestions": [
+      "Build toward Landau's theorem: a non-decreasing sequence is the score sequence of a tournament iff its partial sums dominate the triangular numbers with equality at the end (the majorization characterisation of realisable score sequences).",
+      "Repair or replace the companion oq-03 file so its Hamiltonicity proofs cite these handshake and tournament-score lemmas directly instead of re-deriving the degree counting implicitly."
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
Enrichment pass for `erdos-1012-oq-03-oq-02` (directed handshake lemma ∑d⁺ = arcCount = ∑d⁻ and tournament score-sum identities).

## Gaps closed
- **conclusion schema**: used a non-standard `futureWork` string and was **missing the required `implications`** (and had no `openQuestions`). Added 3 `implications` (the counting foundation under the companion Hamiltonicity theorems; Landau score-sum + averaging as tournament entry points) and converted `futureWork` into 2 schema-correct `openQuestions` (Landau's theorem; refactor the companion to cite these lemmas).
- **Annotation schema**: fixed `type: "lemma"`/`"theorem"` → `technique`/`insight`/`concept` and `significance: "critical"` → `"key"`.

## Notes
- Already had `index.ts` and a rich `meta.json` (5 keyInsights, 4 sections, 6 annotations) — left intact. 15 KB, under caps.
- JSON validated.