### PR TITLE
research(abel-ruffini-oq-07-discriminant-oq-01-oq-01): discriminant structural properties + the discriminant–derivative formula [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ07DiscriminantOQ01OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniOQ07DiscriminantOQ01OQ01.lean
@@ -1,0 +1,183 @@
+/-
+  Structural Properties of the Discriminant, and the Discriminant–Derivative Formula
+    (Open Question OQ-01 of `abel-ruffini-oq-07-discriminant-oq-01`)
+
+  ## Background
+  The parent entry `AbelRuffiniOQ07DiscriminantOQ01.lean` introduced the difference
+  product `δ = ∏_{i<j}(rⱼ − rᵢ)` (as the Vandermonde determinant `diffProd`), proved
+  its sign transformation `diffProd (r ∘ σ) = sign σ • diffProd r`, and used it to
+  establish the Galois criterion `disc = δ² is a square ⟺ Gal ⊆ Aₙ`.
+
+  That file left the *structural* properties of the discriminant `disc = δ²` itself
+  unexamined.  This file records them, over an arbitrary commutative ring (and an
+  integral domain where separability is discussed):
+
+    * **Symmetry.**  `disc` is a symmetric function of the family: `disc (r ∘ σ) = disc r`.
+      This is the conceptual foundation of the whole theory — being permutation-invariant,
+      the discriminant is a polynomial in the elementary symmetric functions of the
+      roots, hence in the coefficients.
+    * **Antisymmetry of δ.**  A transposition negates the difference product,
+      `diffProd (r ∘ swap i j) = − diffProd r`.
+    * **Separability.**  Over a domain, `disc r = 0 ⟺ the family is not injective`
+      (two roots coincide) — the discriminant detects repeated roots.
+    * **Translation invariance.**  `disc` is unchanged by a common shift of all roots,
+      `diffProd (r + c) = diffProd r`; this is the algebraic content of the reduction
+      of a polynomial to depressed form.
+
+  ## The centerpiece: the discriminant–derivative formula
+  The classical identity connecting the discriminant to the derivative of the
+  associated polynomial is
+
+      δ² = (−1)^{n(n−1)/2} · ∏ᵢ ∏_{j ≠ i} (rᵢ − rⱼ).
+
+  The inner product `∏_{j ≠ i}(rᵢ − rⱼ)` is exactly `f'(rᵢ)` for the monic polynomial
+  `f = ∏ⱼ (X − rⱼ)`, so this is the standard bridge `disc = (−1)^{C(n,2)} ∏ᵢ f'(rᵢ)`
+  from which one derives `disc = (−1)^{C(n,2)} Res(f, f')` (up to the leading coefficient).
+  We prove it here purely as a Finset product identity, valid over any commutative ring.
+
+  All results are fully machine-checked with 0 sorries and 0 axioms.
+-/
+import Proofs.AbelRuffiniOQ07DiscriminantOQ01
+import Mathlib.Tactic
+
+open Matrix Equiv Equiv.Perm Finset
+open AbelRuffiniDiscriminantSquare
+
+namespace AbelRuffiniDiscriminantStructure
+
+variable {R : Type*} [CommRing R]
+
+/-- The **discriminant** `disc r = δ²`, the square of the difference product. -/
+noncomputable def disc {n : ℕ} (r : Fin n → R) : R := diffProd r ^ 2
+
+theorem disc_eq_sq {n : ℕ} (r : Fin n → R) : disc r = diffProd r ^ 2 := rfl
+
+/-! ## Symmetry of the discriminant -/
+
+/-- **The discriminant is a symmetric function.**  Permuting the family leaves the
+discriminant unchanged, because the difference product only changes by the sign of the
+permutation and the sign squares to `1`.  This is the reason `disc` is a polynomial in
+the coefficients of the associated polynomial. -/
+theorem disc_comp_perm {n : ℕ} (r : Fin n → R) (σ : Equiv.Perm (Fin n)) :
+    disc (r ∘ σ) = disc r := by
+  simp only [disc, diffProd_comp_perm, zsmul_eq_mul, mul_pow]
+  rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with h | h <;> rw [h] <;> simp
+
+/-- **A transposition negates the difference product.**  For `i ≠ j`, swapping the two
+entries `rᵢ` and `rⱼ` flips the sign of `δ` — the antisymmetry of the Vandermonde
+determinant, specialized to a transposition. -/
+theorem diffProd_swap {n : ℕ} (r : Fin n → R) {i j : Fin n} (hij : i ≠ j) :
+    diffProd (r ∘ Equiv.swap i j) = - diffProd r := by
+  rw [diffProd_comp_perm, Equiv.Perm.sign_swap hij]
+  simp
+
+/-! ## Translation invariance -/
+
+/-- **Translation invariance of the difference product.**  Adding a common constant `c`
+to every entry leaves `δ` unchanged, since it cancels in every difference `rⱼ − rᵢ`.
+This is the algebraic heart of the reduction of a polynomial to depressed form. -/
+theorem diffProd_add_const {n : ℕ} (r : Fin n → R) (c : R) :
+    diffProd (fun k => r k + c) = diffProd r := by
+  simp only [diffProd_eq_prod]
+  refine Finset.prod_congr rfl (fun i _ => Finset.prod_congr rfl (fun j _ => ?_))
+  ring
+
+/-- **Translation invariance of the discriminant.** -/
+theorem disc_add_const {n : ℕ} (r : Fin n → R) (c : R) :
+    disc (fun k => r k + c) = disc r := by
+  simp only [disc, diffProd_add_const]
+
+/-! ## Separability: the discriminant detects repeated roots -/
+
+section Domain
+variable {R : Type*} [CommRing R] [IsDomain R]
+
+/-- The difference product is nonzero iff the family is injective (over a domain). -/
+theorem diffProd_ne_zero_iff {n : ℕ} (r : Fin n → R) :
+    diffProd r ≠ 0 ↔ Function.Injective r := by
+  rw [diffProd]; exact Matrix.det_vandermonde_ne_zero_iff
+
+/-- **The discriminant detects repeated roots.**  Over an integral domain, `disc r = 0`
+exactly when two entries of the family coincide (the family is not injective).  This is
+the separability criterion: a polynomial has a repeated root iff its discriminant
+vanishes. -/
+theorem disc_eq_zero_iff {n : ℕ} (r : Fin n → R) :
+    disc r = 0 ↔ ¬ Function.Injective r := by
+  rw [disc, pow_eq_zero_iff (two_ne_zero), ← diffProd_ne_zero_iff, not_not]
+
+end Domain
+
+/-! ## The discriminant–derivative formula -/
+
+/-- The **off-diagonal product** `∏ᵢ ∏_{j ≠ i}(rᵢ − rⱼ)`.  Its inner factor
+`∏_{j ≠ i}(rᵢ − rⱼ)` is `f'(rᵢ)` for `f = ∏ⱼ(X − rⱼ)`, so this equals `∏ᵢ f'(rᵢ)`. -/
+noncomputable def offDiagProd {n : ℕ} (r : Fin n → R) : R :=
+  ∏ i : Fin n, ∏ j ∈ univ.erase i, (r i - r j)
+
+/-- For a fixed `i`, the punctured index set `univ.erase i` splits as the disjoint union
+of the strictly-smaller and strictly-larger indices. -/
+theorem erase_eq_Iio_union_Ioi {n : ℕ} (i : Fin n) :
+    univ.erase i = Iio i ∪ Ioi i := by
+  ext x
+  simp only [mem_erase, mem_union, mem_Iio, mem_Ioi, mem_univ, and_true]
+  constructor
+  · intro h; exact lt_or_gt_of_ne h
+  · rintro (h | h)
+    · exact ne_of_lt h
+    · exact (ne_of_lt h).symm
+
+/-- `Iio i` and `Ioi i` are disjoint. -/
+theorem disjoint_Iio_Ioi {n : ℕ} (i : Fin n) : Disjoint (Iio i) (Ioi i) := by
+  simp only [Finset.disjoint_left, mem_Iio, mem_Ioi]
+  intro x hx hx'; exact absurd (hx.trans hx') (lt_irrefl x)
+
+/-- The number of ordered upper-triangular pairs: `∑ᵢ #(Ioi i) = C(n, 2)`. -/
+theorem sum_card_Ioi (n : ℕ) : ∑ i : Fin n, (Ioi i).card = n.choose 2 := by
+  simp only [Fin.card_Ioi]
+  rw [Fin.sum_univ_eq_sum_range (fun k => n - 1 - k) n,
+      show (∑ k ∈ Finset.range n, (n - 1 - k)) = ∑ k ∈ Finset.range n, k from
+        Finset.sum_range_reflect (fun k => k) n,
+      Finset.sum_range_id, Nat.choose_two_right]
+
+/-- **The discriminant–derivative formula.**  The off-diagonal product equals
+`(−1)^{C(n,2)}` times the discriminant:
+
+    ∏ᵢ ∏_{j ≠ i}(rᵢ − rⱼ)  =  (−1)^{n(n−1)/2} · δ².
+
+Pairing the ordered off-diagonal pairs `(i, j)` and `(j, i)` turns each unordered pair
+into `(rᵢ − rⱼ)(rⱼ − rᵢ) = −(rⱼ − rᵢ)²`; collecting the `C(n,2)` signs and the squares
+gives the result.  Since `∏_{j ≠ i}(rᵢ − rⱼ) = f'(rᵢ)` for `f = ∏ⱼ(X − rⱼ)`, this is the
+classical `disc = (−1)^{C(n,2)} ∏ᵢ f'(rᵢ)`. -/
+theorem offDiagProd_eq_sign_mul_disc {n : ℕ} (r : Fin n → R) :
+    offDiagProd r = (-1) ^ (n.choose 2) * disc r := by
+  -- Split each punctured product into its lower and upper parts.
+  have hAB : offDiagProd r
+      = (∏ i, ∏ j ∈ Iio i, (r i - r j)) * (∏ i, ∏ j ∈ Ioi i, (r i - r j)) := by
+    unfold offDiagProd
+    rw [← Finset.prod_mul_distrib]
+    exact Finset.prod_congr rfl fun i _ => by
+      rw [erase_eq_Iio_union_Ioi, Finset.prod_union (disjoint_Iio_Ioi i)]
+  -- The lower-triangular product is `δ` itself (transpose the index of summation).
+  have hA : (∏ i : Fin n, ∏ j ∈ Iio i, (r i - r j)) = diffProd r := by
+    rw [diffProd_eq_prod]
+    apply Finset.prod_comm'
+    intro i j
+    simp [mem_Iio, mem_Ioi]
+  -- The upper-triangular product is `(−1)^{C(n,2)} · δ` (negate each factor).
+  have hB : (∏ i : Fin n, ∏ j ∈ Ioi i, (r i - r j)) = (-1 : R) ^ (n.choose 2) * diffProd r := by
+    have hneg : ∀ i : Fin n, (∏ j ∈ Ioi i, (r i - r j))
+        = (-1 : R) ^ (Ioi i).card * ∏ j ∈ Ioi i, (r j - r i) := fun i => by
+      rw [← Finset.prod_const, ← Finset.prod_mul_distrib]
+      exact Finset.prod_congr rfl fun j _ => by ring
+    rw [Finset.prod_congr rfl fun i _ => hneg i, Finset.prod_mul_distrib,
+        Finset.prod_pow_eq_pow_sum, sum_card_Ioi, diffProd_eq_prod]
+  rw [hAB, hA, hB, disc]; ring
+
+/-- **The discriminant as a signed off-diagonal product.**  The mirror form of
+`offDiagProd_eq_sign_mul_disc`: `δ² = (−1)^{C(n,2)} · ∏ᵢ ∏_{j ≠ i}(rᵢ − rⱼ)`. -/
+theorem disc_eq_sign_mul_offDiagProd {n : ℕ} (r : Fin n → R) :
+    disc r = (-1) ^ (n.choose 2) * offDiagProd r := by
+  rw [offDiagProd_eq_sign_mul_disc, ← mul_assoc, ← pow_add, ← two_mul,
+      pow_mul, neg_one_sq, one_pow, one_mul]
+
+end AbelRuffiniDiscriminantStructure

--- a/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-aro07doq01oq01-header",
+    "proofId": "abel-ruffini-oq-07-discriminant-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "Structural Properties of the Discriminant",
+    "content": "The docstring lays out the goal: with the difference product δ = diffProd r and discriminant disc r = δ² inherited from the parent entry, record the structural laws of the discriminant — symmetry disc(r∘σ) = disc(r), antisymmetry of δ under a transposition, separability disc = 0 ⟺ repeated root, and translation invariance — and prove the discriminant–derivative formula δ² = (−1)^{n(n−1)/2} ∏ᵢ ∏_{j≠i}(rᵢ − rⱼ). The inner product ∏_{j≠i}(rᵢ − rⱼ) is f′(rᵢ) for f = ∏ⱼ(X − rⱼ), so the formula is the classical bridge disc = (−1)^{C(n,2)} ∏ᵢ f′(rᵢ) toward the resultant Res(f, f′).",
+    "mathContext": "$\\operatorname{disc} r = \\delta^2$, $\\delta = \\prod_{i<j}(r_j-r_i)$; $\\prod_i\\prod_{j\\neq i}(r_i-r_j) = \\prod_i f'(r_i)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Discriminant", "Difference product", "Off-diagonal product", "Resultant"],
+    "prerequisites": ["The Vandermonde difference product", "Discriminant of a polynomial"]
+  },
+  {
+    "id": "ann-aro07doq01oq01-symmetry",
+    "proofId": "abel-ruffini-oq-07-discriminant-oq-01-oq-01",
+    "range": { "startLine": 50, "endLine": 76 },
+    "type": "theorem",
+    "title": "The Discriminant is a Symmetric Function",
+    "content": "disc r := diffProd r ^ 2. The theorem disc_comp_perm proves disc(r∘σ) = disc(r) for every permutation σ: rewriting with the parent's sign transformation gives (sign σ · δ)², and since sign σ ∈ {±1} squares to 1, the sign disappears. This permutation-invariance is the conceptual foundation of the whole theory — being symmetric, disc is a polynomial in the elementary symmetric functions of the roots, hence in the coefficients. diffProd_swap records the complementary antisymmetry of δ itself: a transposition swap i j (sign −1) sends δ to −δ.",
+    "mathContext": "$\\operatorname{disc}(r\\circ\\sigma) = (\\operatorname{sign}\\sigma)^2\\,\\delta^2 = \\delta^2$; $\\delta(r\\circ\\mathrm{swap}\\,i\\,j) = -\\delta$.",
+    "significance": "key",
+    "relatedConcepts": ["Symmetric function", "Sign of a permutation", "Antisymmetry"],
+    "prerequisites": ["diffProd_comp_perm (parent)", "Equiv.Perm.sign_swap", "Int.units_eq_one_or"]
+  },
+  {
+    "id": "ann-aro07doq01oq01-translation",
+    "proofId": "abel-ruffini-oq-07-discriminant-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 88 },
+    "type": "theorem",
+    "title": "Translation Invariance",
+    "content": "diffProd_add_const proves diffProd(fun k ↦ r k + c) = diffProd r by passing to the product form ∏ᵢ ∏_{j∈Ioi i}(rⱼ − rᵢ) and observing that a common shift cancels in each difference: (rⱼ + c) − (rᵢ + c) = rⱼ − rᵢ, closed factorwise by ring. disc_add_const is the immediate square. This is the algebraic content of the reduction of a polynomial to depressed form — shifting the variable to eliminate the sub-leading coefficient leaves the discriminant unchanged.",
+    "mathContext": "$\\prod_{i<j}((r_j+c)-(r_i+c)) = \\prod_{i<j}(r_j-r_i)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Translation invariance", "Depressed form", "Difference product"],
+    "prerequisites": ["diffProd_eq_prod (parent)", "Finset.prod_congr"]
+  },
+  {
+    "id": "ann-aro07doq01oq01-separability",
+    "proofId": "abel-ruffini-oq-07-discriminant-oq-01-oq-01",
+    "range": { "startLine": 89, "endLine": 111 },
+    "type": "theorem",
+    "title": "Separability: the Discriminant Detects Repeated Roots",
+    "content": "Over an integral domain, diffProd_ne_zero_iff restates Matrix.det_vandermonde_ne_zero_iff: δ ≠ 0 ⟺ the family r is injective. disc_eq_zero_iff then concludes disc r = 0 ⟺ ¬Function.Injective r, using pow_eq_zero_iff to reduce disc = δ² = 0 to δ = 0. This is the separability criterion in its cleanest form: the discriminant vanishes exactly when two roots coincide, so a separable polynomial (distinct roots in a splitting field) has nonzero discriminant.",
+    "mathContext": "$\\operatorname{disc} r = 0 \\iff \\lnot\\,\\mathrm{Injective}\\,r$ (over an integral domain).",
+    "significance": "key",
+    "relatedConcepts": ["Separability", "Repeated root", "Vandermonde determinant"],
+    "prerequisites": ["Matrix.det_vandermonde_ne_zero_iff", "pow_eq_zero_iff", "IsDomain"]
+  },
+  {
+    "id": "ann-aro07doq01oq01-derivative-formula",
+    "proofId": "abel-ruffini-oq-07-discriminant-oq-01-oq-01",
+    "range": { "startLine": 112, "endLine": 183 },
+    "type": "theorem",
+    "title": "The Discriminant–Derivative Formula",
+    "content": "The off-diagonal product offDiagProd r = ∏ᵢ ∏_{j≠i}(rᵢ − rⱼ). Each punctured index set univ.erase i splits disjointly into the strictly-smaller Iio i and strictly-larger Ioi i (erase_eq_Iio_union_Ioi, disjoint_Iio_Ioi), so offDiagProd = (lower) · (upper). The lower-triangular product ∏ᵢ ∏_{j<i}(rᵢ − rⱼ) equals δ once the order of the double product is transposed (Finset.prod_comm', matching the strictly-lower and strictly-upper triangles). The upper-triangular product ∏ᵢ ∏_{j>i}(rᵢ − rⱼ) equals (−1)^{C(n,2)}·δ: extract (−1) from each factor (prod_const, prod_mul_distrib), collect the exponents (prod_pow_eq_pow_sum), and count ∑ᵢ #(Ioi i) = C(n,2) via Fin.card_Ioi and a range reflection (sum_card_Ioi). The product is offDiagProd_eq_sign_mul_disc: offDiagProd r = (−1)^{C(n,2)} · disc r. disc_eq_sign_mul_offDiagProd is the mirror form δ² = (−1)^{C(n,2)} ∏ᵢ ∏_{j≠i}(rᵢ − rⱼ). Since ∏_{j≠i}(rᵢ − rⱼ) = f′(rᵢ), this is the classical disc = (−1)^{C(n,2)} ∏ᵢ f′(rᵢ).",
+    "mathContext": "$\\prod_i\\prod_{j\\neq i}(r_i-r_j) = (-1)^{n(n-1)/2}\\,\\delta^2$; pairing $(i,j),(j,i)$ gives $(r_i-r_j)(r_j-r_i) = -(r_j-r_i)^2$.",
+    "significance": "key",
+    "relatedConcepts": ["Discriminant–derivative formula", "Resultant", "Off-diagonal product", "Finset.prod_comm'"],
+    "prerequisites": ["Finset.prod_comm'", "Finset.prod_pow_eq_pow_sum", "Fin.card_Ioi", "Finset.sum_range_reflect", "Nat.choose_two_right"]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01-oq-01/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ07DiscriminantOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniOQ07DiscriminantOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniOQ07DiscriminantOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOQ07DiscriminantOQ01OQ01Data: ProofData = {
+  proof: abelRuffiniOQ07DiscriminantOQ01OQ01Proof,
+  annotations: abelRuffiniOQ07DiscriminantOQ01OQ01Annotations,
+}

--- a/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-07-discriminant-oq-01-oq-01/meta.json
@@ -1,0 +1,272 @@
+{
+  "id": "abel-ruffini-oq-07-discriminant-oq-01-oq-01",
+  "title": "Structural Properties of the Discriminant and the Discriminant–Derivative Formula",
+  "slug": "abel-ruffini-oq-07-discriminant-oq-01-oq-01",
+  "description": "A machine-verified account of the structural properties of the polynomial discriminant disc = δ² (δ = ∏_{i<j}(rⱼ−rᵢ) the Vandermonde difference product), building on the parent entry abel-ruffini-oq-07-discriminant-oq-01 which introduced δ and its sign transformation. Four foundational facts are recorded over an arbitrary commutative ring (and an integral domain where separability is discussed): (1) the discriminant is a symmetric function of the roots, disc(r∘σ) = disc(r) — the reason it is a polynomial in the coefficients; (2) a transposition negates δ, diffProd(r∘swap i j) = −diffProd(r); (3) over a domain disc(r) = 0 ⟺ the family is not injective — the discriminant detects repeated roots (separability); (4) translation invariance disc(r + c) = disc(r), the algebraic content of reducing a polynomial to depressed form. The centerpiece is the discriminant–derivative formula δ² = (−1)^{n(n−1)/2} · ∏ᵢ ∏_{j≠i}(rᵢ−rⱼ): since the inner product ∏_{j≠i}(rᵢ−rⱼ) equals f′(rᵢ) for f = ∏ⱼ(X−rⱼ), this is the classical bridge disc = (−1)^{C(n,2)} ∏ᵢ f′(rᵢ) toward the resultant Res(f, f′). Proved purely as a Finset product identity by pairing the ordered off-diagonal pairs (i,j) and (j,i). Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lagrange; Gauss; folklore (discriminant–derivative formula, Lang Algebra Ch. IV/VI)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Discriminant#Definition",
+    "date": "1770",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ07DiscriminantOQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "discriminant",
+      "vandermonde",
+      "symmetric-function",
+      "separability",
+      "resultant",
+      "finset-product",
+      "abel-ruffini"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "This file records structural properties of the difference product δ = diffProd r and the discriminant disc r = δ² over an arbitrary commutative ring R (the separability criterion additionally assumes R is an integral domain, and uses Matrix.det_vandermonde_ne_zero_iff). No further hypotheses are imposed: symmetry, antisymmetry under transposition, translation invariance, and the discriminant–derivative formula hold for every finite family r : Fin n → R. Every theorem is fully machine-checked with 0 sorries and 0 axioms (only propext, Classical.choice, Quot.sound; no native_decide, no Lean.ofReduceBool).",
+    "dateAdded": "2026-06-30",
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.det_vandermonde_ne_zero_iff",
+        "description": "The Vandermonde determinant is nonzero iff the family is injective — the separability criterion disc = 0 ⟺ repeated root",
+        "module": "Mathlib.LinearAlgebra.Vandermonde"
+      },
+      {
+        "theorem": "Finset.prod_comm'",
+        "description": "Swaps the order of a double product whose inner Finset depends on the outer variable — turns the lower-triangular product into δ",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Sigma"
+      },
+      {
+        "theorem": "Finset.prod_pow_eq_pow_sum",
+        "description": "∏ᵢ a^{f i} = a^{∑ᵢ f i} — collects the C(n,2) sign factors into a single (−1)^{C(n,2)}",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Fin.card_Ioi",
+        "description": "#(Ioi i) = n − 1 − i for i : Fin n — the per-row count of upper pairs",
+        "module": "Mathlib.Order.Interval.Finset.Fin"
+      },
+      {
+        "theorem": "Finset.sum_range_reflect",
+        "description": "∑_{j<n} f(n−1−j) = ∑_{j<n} f(j) — the reflection giving ∑ᵢ #(Ioi i) = ∑_{k<n} k",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Nat.choose_two_right",
+        "description": "choose n 2 = n(n−1)/2 — identifies the sign exponent as the binomial coefficient C(n,2)",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "disc_comp_perm: the discriminant is a symmetric function — disc(r∘σ) = disc(r) for every permutation σ — obtained from the parent's sign transformation and sign² = 1. This is the conceptual foundation for expressing disc as a polynomial in the coefficients.",
+      "disc_eq_zero_iff: over an integral domain, disc(r) = 0 iff the family r is not injective (two roots coincide) — the separability criterion, connecting a vanishing discriminant to a repeated root.",
+      "diffProd_add_const / disc_add_const: translation invariance of the difference product and discriminant under a common shift of all roots — the algebraic heart of reducing a polynomial to depressed form.",
+      "offDiagProd_eq_sign_mul_disc and disc_eq_sign_mul_offDiagProd: the discriminant–derivative formula δ² = (−1)^{C(n,2)} ∏ᵢ ∏_{j≠i}(rᵢ−rⱼ), proved as a Finset product identity by splitting each punctured product into its lower and upper triangular parts, recognizing the lower part as δ (Finset.prod_comm') and the upper part as (−1)^{C(n,2)}·δ, with the sign count ∑ᵢ #(Ioi i) = C(n,2) established via Fin.card_Ioi and a range reflection. The inner factor ∏_{j≠i}(rᵢ−rⱼ) is f′(rᵢ), giving the classical disc = (−1)^{C(n,2)} ∏ᵢ f′(rᵢ)."
+    ],
+    "prerequisites": [
+      "The Vandermonde difference product δ = ∏_{i<j}(rⱼ − rᵢ) and its sign transformation (parent entry)",
+      "Discriminant of a polynomial as δ²; symmetric functions",
+      "Finset big-operator API: products over intervals, prod_comm', prod_pow_eq_pow_sum",
+      "The derivative of a split polynomial ∏ⱼ(X − rⱼ) and the resultant Res(f, f′)",
+      "Lean 4 and Mathlib Finset/Vandermonde API"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 183,
+    "relatedProblems": [
+      "abel-ruffini-oq-07-discriminant-oq-01",
+      "abel-ruffini-oq-07-discriminant",
+      "abel-ruffini-oq-07",
+      "solution-of-cubic-oq-01-oq-01"
+    ],
+    "theoremCount": 12,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The discriminant Δ = ∏_{i<j}(rᵢ − rⱼ)² is the simplest symmetric function of the roots detecting a repeated root, studied by Lagrange and Gauss. Two of its features make it a workhorse of algebra. First, being symmetric, it is a polynomial in the elementary symmetric functions, hence in the coefficients — this is why one can speak of 'the discriminant of a polynomial' at all. Second, it factors through the derivative: Δ = (−1)^{n(n−1)/2} ∏ᵢ f′(rᵢ), and ∏ᵢ f′(rᵢ) is (up to the leading coefficient) the resultant Res(f, f′), giving the coordinate-free, root-free formula for Δ used in computation. The parent entry realized δ = √Δ as a Vandermonde determinant and proved its sign transformation; this entry records the structural consequences and the derivative formula.",
+    "problemStatement": "Establish, over an arbitrary commutative ring, the structural properties of the difference product δ and the discriminant disc = δ²: symmetry disc(r∘σ) = disc(r), antisymmetry of δ under a transposition, translation invariance, the separability criterion disc = 0 ⟺ repeated root (over a domain), and the discriminant–derivative formula δ² = (−1)^{C(n,2)} ∏ᵢ ∏_{j≠i}(rᵢ − rⱼ).",
+    "text": "The difference product δ = diffProd r and discriminant disc r = δ² are inherited from the parent. Symmetry disc(r∘σ) = disc(r) is immediate from the sign transformation δ(r∘σ) = sign(σ)·δ and sign(σ)² = 1. A transposition swap i j has sign −1, so diffProd(r∘swap i j) = −diffProd r. Translation invariance follows from the product form: each factor (rⱼ + c) − (rᵢ + c) = rⱼ − rᵢ is unchanged. Over an integral domain the separability criterion disc = 0 ⟺ ¬Injective r comes from Matrix.det_vandermonde_ne_zero_iff together with disc = δ². The centerpiece is the discriminant–derivative formula: writing the off-diagonal product ∏ᵢ ∏_{j≠i}(rᵢ − rⱼ), each punctured index set univ.erase i splits disjointly into Iio i and Ioi i. The lower-triangular product ∏ᵢ ∏_{j<i}(rᵢ − rⱼ) equals δ after transposing the order of the double product (Finset.prod_comm'); the upper-triangular product ∏ᵢ ∏_{j>i}(rᵢ − rⱼ) equals (−1)^{C(n,2)}·δ after negating each of its C(n,2) factors. Their product is (−1)^{C(n,2)}·δ².",
+    "proofStrategy": "(1) disc_comp_perm: rewrite with diffProd_comp_perm, then case-split sign σ ∈ {±1} and simplify, using (±1)² = 1. (2) diffProd_swap: diffProd_comp_perm with σ = swap i j and Equiv.Perm.sign_swap. (3) diffProd_add_const: rewrite to the product form and close each factor by ring. (4) disc_eq_zero_iff: pow_eq_zero_iff reduces disc = 0 to diffProd = 0, then Matrix.det_vandermonde_ne_zero_iff. (5) offDiagProd_eq_sign_mul_disc: split erase i = Iio i ∪ Ioi i (disjoint), giving offDiagProd = (lower) · (upper); prove lower = δ by Finset.prod_comm' matching the strictly-lower and strictly-upper triangles; prove upper = (−1)^{C(n,2)}·δ by extracting (−1) from each factor (prod_const, prod_mul_distrib), collecting the exponents (prod_pow_eq_pow_sum) and counting ∑ᵢ #(Ioi i) = C(n,2) via Fin.card_Ioi and sum_range_reflect; conclude by ring. (6) disc_eq_sign_mul_offDiagProd: multiply by (−1)^{C(n,2)}, using (−1)^{2k} = 1.",
+    "keyInsights": [
+      "Symmetry of the discriminant is a one-line consequence of the parent's sign transformation: sign(σ)² = 1, so squaring δ kills the sign. This is the abstract reason Δ is a polynomial in the coefficients.",
+      "The discriminant–derivative formula is a pure combinatorial identity about products over the off-diagonal of Fin n × Fin n: pairing (i,j) with (j,i) turns each unordered pair into (rᵢ−rⱼ)(rⱼ−rᵢ) = −(rⱼ−rᵢ)², producing C(n,2) signs and the square δ².",
+      "The lower-triangular half of the off-diagonal product is δ itself once the order of summation is transposed (Finset.prod_comm'); no re-indexing of the ring elements is needed, only of the index pairs.",
+      "The sign exponent is exactly the number of ordered upper pairs ∑ᵢ #(Ioi i), which equals ∑_{k<n} k = C(n,2) by a range reflection — recovering the classical (−1)^{n(n−1)/2}.",
+      "The inner factor ∏_{j≠i}(rᵢ − rⱼ) is precisely f′(rᵢ) for the split polynomial f = ∏ⱼ(X − rⱼ), so the formula is the elementary route from the difference product to the resultant Res(f, f′)."
+    ],
+    "prerequisites": [
+      "The Vandermonde difference product and its sign transformation (parent entry)",
+      "Symmetric functions and the discriminant of a polynomial",
+      "Finset big operators: products over Iio/Ioi, prod_comm', prod_pow_eq_pow_sum",
+      "Derivative of a split polynomial and the resultant",
+      "Lean 4 and Mathlib Finset API"
+    ],
+    "relatedConcepts": [
+      "discriminant of a polynomial",
+      "symmetric function",
+      "separability",
+      "resultant Res(f, f′)",
+      "Vandermonde difference product"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Statement and Structural Overview",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Documents the goal: the structural properties of the discriminant disc = δ² (symmetry, antisymmetry of δ, separability, translation invariance) and the centerpiece discriminant–derivative formula δ² = (−1)^{C(n,2)} ∏ᵢ ∏_{j≠i}(rᵢ − rⱼ), building on the parent's difference product diffProd and its sign transformation. Imports the parent and opens the Finset and permutation namespaces.",
+      "mathContext": "disc r = δ²; δ(r∘σ) = sign(σ)·δ (parent); the off-diagonal product ∏ᵢ∏_{j≠i}(rᵢ−rⱼ) = ∏ᵢ f′(rᵢ).",
+      "relatedConcepts": [
+        "discriminant",
+        "difference product",
+        "off-diagonal product"
+      ]
+    },
+    {
+      "id": "symmetry",
+      "title": "The Discriminant and its Symmetry",
+      "startLine": 50,
+      "endLine": 76,
+      "summary": "Defines disc r := diffProd r ^ 2. disc_comp_perm proves the discriminant is a symmetric function — disc(r∘σ) = disc(r) — from the parent's sign transformation and sign² = 1, the reason disc is a polynomial in the coefficients. diffProd_swap records the antisymmetry of δ under a transposition: diffProd(r∘swap i j) = −diffProd r.",
+      "mathContext": "disc(r∘σ) = disc(r); diffProd(r∘swap i j) = −diffProd r via sign(swap) = −1.",
+      "relatedConcepts": [
+        "symmetric function",
+        "sign of a permutation",
+        "antisymmetry"
+      ]
+    },
+    {
+      "id": "translation",
+      "title": "Translation Invariance",
+      "startLine": 77,
+      "endLine": 88,
+      "summary": "diffProd_add_const and disc_add_const: adding a common constant c to every root leaves δ and disc unchanged, since c cancels in every difference rⱼ − rᵢ. This is the algebraic content of the reduction of a polynomial to depressed form (eliminating the sub-leading coefficient by a shift of the variable).",
+      "mathContext": "diffProd(fun k ↦ r k + c) = diffProd r; disc(r + c) = disc r.",
+      "relatedConcepts": [
+        "translation invariance",
+        "depressed form",
+        "difference product"
+      ]
+    },
+    {
+      "id": "separability",
+      "title": "Separability: Detecting Repeated Roots",
+      "startLine": 89,
+      "endLine": 111,
+      "summary": "Over an integral domain, diffProd_ne_zero_iff (from Matrix.det_vandermonde_ne_zero_iff) states δ ≠ 0 ⟺ the family is injective, and disc_eq_zero_iff concludes disc r = 0 ⟺ the family is not injective — the discriminant vanishes exactly when two roots coincide, the separability criterion.",
+      "mathContext": "disc r = 0 ⟺ ¬Function.Injective r (over an integral domain).",
+      "relatedConcepts": [
+        "separability",
+        "repeated root",
+        "Vandermonde determinant"
+      ]
+    },
+    {
+      "id": "derivative-formula",
+      "title": "The Discriminant–Derivative Formula",
+      "startLine": 112,
+      "endLine": 183,
+      "summary": "Defines the off-diagonal product offDiagProd r = ∏ᵢ ∏_{j≠i}(rᵢ − rⱼ). erase_eq_Iio_union_Ioi and disjoint_Iio_Ioi split each punctured index set; sum_card_Ioi counts ∑ᵢ #(Ioi i) = C(n,2). offDiagProd_eq_sign_mul_disc is the main theorem — offDiagProd r = (−1)^{C(n,2)} · disc r — proved by identifying the lower-triangular half with δ (Finset.prod_comm') and the upper-triangular half with (−1)^{C(n,2)}·δ. disc_eq_sign_mul_offDiagProd is the mirror form δ² = (−1)^{C(n,2)} · ∏ᵢ ∏_{j≠i}(rᵢ − rⱼ), the classical bridge disc = (−1)^{C(n,2)} ∏ᵢ f′(rᵢ) toward the resultant.",
+      "mathContext": "∏ᵢ ∏_{j≠i}(rᵢ − rⱼ) = (−1)^{n(n−1)/2} · δ²; the inner factor is f′(rᵢ).",
+      "relatedConcepts": [
+        "discriminant–derivative formula",
+        "resultant",
+        "off-diagonal product"
+      ]
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "offDiagProd_eq_sign_mul_disc",
+      "type": "core",
+      "description": "The discriminant–derivative formula: ∏ᵢ ∏_{j≠i}(rᵢ − rⱼ) = (−1)^{C(n,2)} · disc r over any commutative ring. Since the inner product ∏_{j≠i}(rᵢ − rⱼ) equals f′(rᵢ) for the split polynomial f = ∏ⱼ(X − rⱼ), this is the classical disc = (−1)^{C(n,2)} ∏ᵢ f′(rᵢ), the elementary route to the resultant Res(f, f′). Proved as a Finset product identity by pairing the ordered off-diagonal pairs."
+    },
+    {
+      "name": "disc_eq_sign_mul_offDiagProd",
+      "type": "core",
+      "description": "The mirror form δ² = (−1)^{C(n,2)} · ∏ᵢ ∏_{j≠i}(rᵢ − rⱼ): the discriminant as a signed off-diagonal product of root differences."
+    },
+    {
+      "name": "disc_comp_perm",
+      "type": "proved",
+      "description": "The discriminant is a symmetric function: disc(r∘σ) = disc(r) for every permutation σ, from the parent's sign transformation and sign(σ)² = 1. This is why the discriminant is a polynomial in the elementary symmetric functions of the roots, hence in the coefficients."
+    },
+    {
+      "name": "disc_eq_zero_iff",
+      "type": "proved",
+      "description": "The separability criterion: over an integral domain, disc r = 0 if and only if the family r is not injective (two roots coincide). Derived from Matrix.det_vandermonde_ne_zero_iff and disc = δ²."
+    },
+    {
+      "name": "diffProd_add_const",
+      "type": "proved",
+      "description": "Translation invariance: diffProd(fun k ↦ r k + c) = diffProd r, since a common shift cancels in every difference. The algebraic content of reducing a polynomial to depressed form."
+    },
+    {
+      "name": "diffProd_swap",
+      "type": "proved",
+      "description": "A transposition negates the difference product: diffProd(r∘swap i j) = −diffProd r for i ≠ j — the antisymmetry of the Vandermonde determinant specialized to a swap."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry complements the parent's Galois criterion with the structural backbone of the discriminant: it is a symmetric function of the roots (disc_comp_perm), it detects repeated roots over a domain (disc_eq_zero_iff), it is invariant under a common shift of the roots (diffProd_add_const), and — the centerpiece — it factors through the derivative, δ² = (−1)^{C(n,2)} ∏ᵢ ∏_{j≠i}(rᵢ − rⱼ) (offDiagProd_eq_sign_mul_disc). All results hold over an arbitrary commutative ring (a domain for separability) and are fully machine-checked with 0 sorries and 0 axioms.",
+    "implications": "1. Symmetry is the abstract justification that 'the discriminant of a polynomial' is well defined as a function of the coefficients — the parent's Galois criterion presupposes this without stating it.\n\n2. The discriminant–derivative formula δ² = (−1)^{C(n,2)} ∏ᵢ f′(rᵢ) is the standard elementary bridge to the resultant Res(f, f′); this makes the connection between the root-difference discriminant and the coefficient discriminant (already computed for the cubic in solution-of-cubic) explicit at general degree.\n\n3. The separability criterion disc = 0 ⟺ repeated root is the exact statement used throughout Galois theory to guarantee a separable polynomial has nonzero discriminant.\n\n4. All infrastructure is stated over an arbitrary commutative ring and is independent of the Galois application, making it a reusable building block for any polynomial-discriminant formalization.",
+    "openQuestions": [
+      "Identify offDiagProd r with ∏ᵢ (derivative (∏ⱼ (X − r j))).eval (r i) explicitly in Mathlib, turning the discriminant–derivative formula into a statement about Polynomial.derivative and eval.",
+      "Connect disc_eq_sign_mul_offDiagProd to the resultant Res(f, f′) via Mathlib's Polynomial.resultant, giving disc = (−1)^{C(n,2)} Res(f, f′)/leadingCoeff — the coefficient formula for the discriminant at general degree.",
+      "Prove the homogeneity law diffProd(a • r) = a^{C(n,2)} · diffProd r, completing the elementary scaling/translation calculus of the difference product."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-07-discriminant-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry introduced the difference product diffProd and its sign transformation and used them for the Galois criterion Gal ⊆ Aₙ ⟺ disc a square. This entry records the structural properties of disc = δ² that the parent presupposed (symmetry, separability) and adds the discriminant–derivative formula."
+    },
+    {
+      "targetId": "abel-ruffini-oq-07-discriminant",
+      "relationship": "complementary",
+      "description": "The grandparent entry supplies the concrete quintic discriminant computation; this entry provides the general structural laws (symmetry, separability, derivative formula) underlying any such computation."
+    },
+    {
+      "targetId": "solution-of-cubic-oq-01-oq-01",
+      "relationship": "complementary",
+      "description": "That entry proves the cubic discriminant root form Δ = a⁴ ∏_{i<j}(xᵢ − xⱼ)² and the resultant relation Res(f, f′) = −a·Δ for degree three; the discriminant–derivative formula here is the general-degree analogue of the same root-difference / derivative bridge."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.AbelRuffiniOQ07DiscriminantOQ01",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix",
+      "Equiv",
+      "Equiv.Perm",
+      "Finset",
+      "AbelRuffiniDiscriminantSquare"
+    ],
+    "namespace": "AbelRuffiniDiscriminantStructure",
+    "lineCount": 183,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/AbelRuffiniOQ07DiscriminantOQ01OQ01.lean"
+  },
+  "references": [
+    {
+      "key": "Lang",
+      "citation": "Lang, S., Algebra (3rd ed.), Springer (2002). Chapter IV §6 and Chapter VI: the discriminant, the difference product, the derivative formula disc = (−1)^{n(n−1)/2} ∏ᵢ f′(rᵢ), and the resultant.",
+      "type": "book"
+    },
+    {
+      "key": "DummitFoote",
+      "citation": "Dummit, D. S. and Foote, R. M., Abstract Algebra (3rd ed.), Wiley (2004). §14.6: the discriminant as a symmetric function and its vanishing criterion.",
+      "type": "book"
+    },
+    {
+      "key": "GKZ",
+      "citation": "Gelfand, I. M., Kapranov, M. M., Zelevinsky, A. V., Discriminants, Resultants, and Multidimensional Determinants, Birkhäuser (1994). The discriminant–resultant relation and the derivative formula.",
+      "type": "book"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A machine-verified child of the just-merged **abel-ruffini-oq-07-discriminant-oq-01** (#31742). The parent introduced the Vandermonde difference product `δ = ∏_{i<j}(rⱼ−rᵢ)` (`diffProd`), its sign transformation, and the Galois criterion `Gal ⊆ Aₙ ⟺ disc a square`. This entry imports the parent and records the **structural properties of the discriminant `disc = δ²`** that the criterion presupposes but never states, plus the classical **discriminant–derivative formula**.

All results hold over an arbitrary commutative ring (an integral domain for separability). **0 sorries, 0 axioms.** `AbelRuffiniOQ07DiscriminantOQ01OQ01.lean` — 183 lines, 12 theorems, 2 definitions.

## Results

- **`disc_comp_perm`** — the discriminant is a *symmetric function*: `disc(r∘σ) = disc(r)`, from the parent's sign transformation and `sign σ² = 1`. This is the abstract reason `disc` is a polynomial in the coefficients.
- **`diffProd_swap`** — a transposition negates `δ`.
- **`diffProd_add_const` / `disc_add_const`** — *translation invariance* (the algebraic content of reducing a polynomial to depressed form).
- **`disc_eq_zero_iff`** — over a domain, `disc r = 0 ⟺ ¬Injective r`: the *separability* criterion (the discriminant detects repeated roots), via `Matrix.det_vandermonde_ne_zero_iff`.
- **`offDiagProd_eq_sign_mul_disc`** (centerpiece) — the *discriminant–derivative formula*
  `∏ᵢ ∏_{j≠i}(rᵢ−rⱼ) = (−1)^{C(n,2)} · δ²`.
  Since `∏_{j≠i}(rᵢ−rⱼ) = f′(rᵢ)` for `f = ∏ⱼ(X−rⱼ)`, this is the classical `disc = (−1)^{C(n,2)} ∏ᵢ f′(rᵢ)`, the elementary route to the resultant `Res(f, f′)`. Proved as a Finset product identity: split each punctured product `univ.erase i = Iio i ∪ Ioi i`, identify the lower-triangular half with `δ` (`Finset.prod_comm'`) and the upper-triangular half with `(−1)^{C(n,2)}·δ`, counting `∑ᵢ #(Ioi i) = C(n,2)` via `Fin.card_Ioi` and a range reflection.
- **`disc_eq_sign_mul_offDiagProd`** — the mirror form `δ² = (−1)^{C(n,2)} ∏ᵢ ∏_{j≠i}(rᵢ−rⱼ)`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.AbelRuffiniOQ07DiscriminantOQ01OQ01` → `✔ Built` (0 sorries, 0 axioms; only `propext`/`Classical.choice`/`Quot.sound`, no `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)