### PR TITLE
research(derangements-oq-04-oq-01): fixed-point generating-function identity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DerangementsOQ04OQ01.lean
+++ b/proofs/Proofs/DerangementsOQ04OQ01.lean
@@ -119,6 +119,33 @@ theorem card_perms_with_kfixed_zero_closed_form
   have h := card_perms_with_kfixed_closed_form 𝕜 n 0 (Nat.zero_le n)
   simpa using h
 
+/-- **Fixed-point generating function.**  Grouping the permutations of `Fin n` by
+their number of fixed points turns the polynomial `∑_{k=0}^{n} S(n,k) x^k` into the
+statistic-generating sum `∑_{σ} x^{#fix σ}` over all permutations, for any element
+`x` of a commutative ring.  This is the "vertical" companion of the closed form: the
+closed form evaluates each coefficient `S(n,k)`, while this identity packages all
+coefficients into the fixed-point statistic.  It holds over *any* commutative ring —
+no characteristic hypothesis — because it is a pure regrouping of a finite sum. -/
+theorem sum_kfixed_smul_pow (R : Type*) [CommRing R] (n : ℕ) (x : R) :
+    ∑ k ∈ range (n + 1),
+        ((univ.filter (fun σ : Equiv.Perm (Fin n) =>
+            (univ.filter (fun p => σ p = p)).card = k)).card : R) * x ^ k
+      = ∑ σ : Equiv.Perm (Fin n), x ^ (univ.filter (fun p => σ p = p)).card := by
+  -- regroup the permutation sum over the fibres of the fixed-point-count map
+  rw [← Finset.sum_fiberwise_of_maps_to (s := (univ : Finset (Equiv.Perm (Fin n))))
+      (t := range (n + 1))
+      (g := fun σ => (univ.filter (fun p => σ p = p)).card)
+      (f := fun σ => x ^ (univ.filter (fun p => σ p = p)).card)
+      (fun σ _ => Finset.mem_range.mpr
+        (Nat.lt_succ_of_le (by simpa using Finset.card_filter_le (univ : Finset (Fin n)) _)))]
+  -- on each fibre `#fix σ = k`, every term is `x ^ k`, so the fibre sums to `card • x^k`
+  refine Finset.sum_congr rfl fun k _ => ?_
+  have hfib : ∀ σ ∈ univ.filter (fun σ : Equiv.Perm (Fin n) =>
+      (univ.filter (fun p => σ p = p)).card = k),
+      x ^ (univ.filter (fun p => σ p = p)).card = x ^ k :=
+    fun σ hσ => by rw [(Finset.mem_filter.mp hσ).2]
+  rw [Finset.sum_congr rfl hfib, Finset.sum_const, nsmul_eq_mul]
+
 /-- Sanity check for `S(4,1)`.  A permutation of `4` elements with exactly one
 fixed point chooses that fixed point (`C(4,1) = 4` ways) and deranges the other
 `3` (`D_3 = 2` ways), so `S(4,1) = 4·2 = 8`.  The closed form

--- a/src/data/proofs/derangements-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/derangements-oq-04-oq-01/annotations.json
@@ -70,7 +70,7 @@
     "proofId": "derangements-oq-04-oq-01",
     "range": {
       "startLine": 114,
-      "endLine": 124
+      "endLine": 120
     },
     "type": "theorem",
     "title": "k = 0 Recovers the Derangement Closed Form",
@@ -86,11 +86,35 @@
     ]
   },
   {
+    "id": "ann-generating-function",
+    "proofId": "derangements-oq-04-oq-01",
+    "range": {
+      "startLine": 122,
+      "endLine": 151
+    },
+    "type": "theorem",
+    "title": "Fixed-Point Generating Function",
+    "content": "**Theorem** `sum_kfixed_smul_pow`: for any element `x` of a commutative ring `R`,\n```\n∑_{k=0}^{n} S(n,k) · x^k = ∑_{σ ∈ Perm (Fin n)} x^{#fix σ}.\n```\nWhere the closed form evaluates each *coefficient* `S(n,k)`, this identity packages all coefficients into the *fixed-point statistic* `x^{#fix σ}` summed over permutations. It is a pure regrouping of a finite sum — no characteristic hypothesis — so it holds over **any** commutative ring.\n\nProof: rewrite the permutation sum by `Finset.sum_fiberwise_of_maps_to`, grouping `σ` by the value `k = #fix σ` (the fixed-point-count map lands in `range (n+1)` since `#fix σ ≤ #(Fin n) = n`). On each fibre `#fix σ = k`, every term `x^{#fix σ}` equals `x^k`, so the fibre sum collapses via `Finset.sum_const`/`nsmul_eq_mul` to `(card of fibre) · x^k = S(n,k) · x^k`.\n\nSetting `x = 0` recovers `S(n,0) = D_n` (derangements as the `x^0` coefficient); `x = 1` gives `∑_k S(n,k) = n!` (every permutation has some fixed-point count).",
+    "mathContext": "\\sum_{k=0}^{n} S(n,k)\\,x^k = \\sum_{\\sigma} x^{\\#\\mathrm{fix}\\,\\sigma}",
+    "significance": "central",
+    "relatedConcepts": [
+      "generating function",
+      "fixed-point statistic",
+      "fibrewise summation",
+      "permutation statistics"
+    ],
+    "prerequisites": [
+      "Finset.sum_fiberwise_of_maps_to",
+      "Finset.sum_const / nsmul_eq_mul",
+      "S(n,k) = card of permutations with exactly k fixed points"
+    ]
+  },
+  {
     "id": "ann-sanity-check",
     "proofId": "derangements-oq-04-oq-01",
     "range": {
-      "startLine": 126,
-      "endLine": 131
+      "startLine": 153,
+      "endLine": 158
     },
     "type": "example",
     "title": "Sanity Check: S(4,1) = 8",

--- a/src/data/proofs/derangements-oq-04-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-04-oq-01/meta.json
@@ -44,14 +44,15 @@
       "card_perms_with_kfixed_closed_form: (S(n,k) : 𝕜) = (n!/k!)·∑_{j=0}^{n-k} (-1)^j/j! over any characteristic-zero field, obtained by bridging the combinatorial count S(n,k)=C(n,k)·D(n-k) (derangements-oq-02) with the field derangement closed form (derangements-oq-04) via Nat.choose_mul_factorial_mul_factorial",
       "card_perms_with_kfixed_eq_factorial_mul_trunc: the same identity phrased with the truncated exponential DerangementsOQ04.truncExpNegOne 𝕜 (n-k+1)",
       "card_perms_with_kfixed_closed_form_rat / _real: specializations to ℚ and ℝ",
-      "card_perms_with_kfixed_zero_closed_form: k=0 specialization recovering the parent derangement closed form D(n) = n!·∑_{j≤n}(-1)^j/j!, confirming consistency"
+      "card_perms_with_kfixed_zero_closed_form: k=0 specialization recovering the parent derangement closed form D(n) = n!·∑_{j≤n}(-1)^j/j!, confirming consistency",
+      "sum_kfixed_smul_pow: the fixed-point generating-function identity ∑_{k=0}^{n} S(n,k)·x^k = ∑_{σ∈Perm(Fin n)} x^{#fix σ} over any commutative ring (no characteristic hypothesis), packaging all the closed-form coefficients into the fixed-point statistic by regrouping the permutation sum over the fibres of the fixed-point-count map (Finset.sum_fiberwise_of_maps_to)"
     ],
     "dateAdded": "2026-06-30",
     "axiomCount": 0,
-    "lineCount": 132,
-    "assumptions": "None. Fully verified with 0 axioms (only Lean/Mathlib foundations propext, Classical.choice, Quot.sound) and 0 sorries. The field is required to have characteristic zero so that factorials are invertible.",
+    "lineCount": 159,
+    "assumptions": "None. Fully verified with 0 axioms (only Lean/Mathlib foundations propext, Classical.choice, Quot.sound) and 0 sorries. The main closed form requires the field to have characteristic zero so that factorials are invertible; the generating-function identity sum_kfixed_smul_pow holds over any commutative ring.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0
   },
   "overview": {
@@ -101,17 +102,25 @@
       "id": "section-iii",
       "title": "k = 0 Consistency and Sanity Check",
       "startLine": 113,
-      "endLine": 132,
-      "summary": "card_perms_with_kfixed_zero_closed_form: setting k=0 recovers the parent derangement closed form D(n) = n!·∑_{j≤n}(-1)^j/j! (via simpa). Example: S(4,1)=8 reproduced by the closed form over ℚ.",
-      "mathContext": "k=0 recovers D(n) = n!·∑_{j≤n}(-1)^j/j!; sanity check S(4,1)=8."
+      "endLine": 121,
+      "summary": "card_perms_with_kfixed_zero_closed_form: setting k=0 recovers the parent derangement closed form D(n) = n!·∑_{j≤n}(-1)^j/j! (via simpa).",
+      "mathContext": "k=0 recovers D(n) = n!·∑_{j≤n}(-1)^j/j!."
+    },
+    {
+      "id": "section-iv",
+      "title": "Fixed-Point Generating Function and Sanity Check",
+      "startLine": 122,
+      "endLine": 159,
+      "summary": "sum_kfixed_smul_pow: ∑_{k=0}^{n} S(n,k)·x^k = ∑_{σ∈Perm(Fin n)} x^{#fix σ} over any commutative ring, packaging all closed-form coefficients into the fixed-point statistic by regrouping the permutation sum over the fibres of the fixed-point-count map (Finset.sum_fiberwise_of_maps_to; each fibre contributes card·x^k via Finset.sum_const/nsmul_eq_mul). No characteristic hypothesis. Example: S(4,1)=8 reproduced by the closed form over ℚ.",
+      "mathContext": "∑_k S(n,k)·x^k = ∑_σ x^{#fix σ} over any comm ring; sanity check S(4,1)=8."
     }
   ],
   "conclusion": {
-    "summary": "The rencontres-number closed form S(n,k) = (n!/k!)·∑_{j=0}^{n-k}(-1)^j/j! is proved over an arbitrary characteristic-zero field with 0 sorries and 0 axioms. It answers the parent open question (derangements-oq-04) on partial derangements by bridging the combinatorial identity S(n,k)=C(n,k)·D(n-k) (derangements-oq-02) with the parent's field derangement closed form via Nat.choose_mul_factorial_mul_factorial. Truncated-exponential phrasing, ℚ/ℝ specializations, and a k=0 consistency corollary (recovering D(n)) are included, and S(4,1)=8 is verified.",
+    "summary": "The rencontres-number closed form S(n,k) = (n!/k!)·∑_{j=0}^{n-k}(-1)^j/j! is proved over an arbitrary characteristic-zero field with 0 sorries and 0 axioms. It answers the parent open question (derangements-oq-04) on partial derangements by bridging the combinatorial identity S(n,k)=C(n,k)·D(n-k) (derangements-oq-02) with the parent's field derangement closed form via Nat.choose_mul_factorial_mul_factorial. Truncated-exponential phrasing, ℚ/ℝ specializations, and a k=0 consistency corollary (recovering D(n)) are included, and S(4,1)=8 is verified. A companion generating-function identity ∑_k S(n,k)·x^k = ∑_{σ∈Perm(Fin n)} x^{#fix σ} (sum_kfixed_smul_pow) — proved over any commutative ring by regrouping the permutation sum over the fibres of the fixed-point-count map — packages all the coefficients into the fixed-point statistic.",
     "implications": "**Significance**\n\n1. **Answers a stated open question**: the second open question of derangements-oq-04 asked whether the field-level derangement closed form extends to partial derangements. It does, and the extension is a clean algebraic bridge over the two existing entries rather than a fresh induction.\n\n2. **A reusable rencontres closed form**: neither the rencontres numbers nor their field closed form are in Mathlib. Exposing S(n,k) = (n!/k!)·∑(-1)^j/j! makes the finite identity behind the k-fixed-point statistics directly available, generalizing the D(n)/n! → 1/e story to fixed-point counts.\n\n3. **Uniform over any characteristic-zero field**: because the proof uses only the count, the derangement closed form, and factorial arithmetic, it holds over ℚ, ℝ, ℂ, or any characteristic-zero field.",
     "openQuestions": [
       "Divide by n! to obtain the fixed-point-count distribution S(n,k)/n! = (1/k!)·∑_{j=0}^{n-k}(-1)^j/j!, and take n → ∞ to show it converges to the Poisson(1) probability e^{-1}/k! — the classical limiting distribution of the number of fixed points of a random permutation.",
-      "Does the closed form extend to a generating-function identity ∑_k S(n,k) x^k = ∑ over permutations of x^{#fixed points}, recovering the exponential formula for the fixed-point statistic?"
+      "The finite generating-function identity ∑_k S(n,k)·x^k = ∑_{σ} x^{#fix σ} is now proved (sum_kfixed_smul_pow); does it lift to the bivariate exponential generating function ∑_n (∑_k S(n,k) x^k) t^n/n! = e^{(x-1)t}/(1-t), the two-variable form of the exponential formula for the fixed-point statistic?"
     ]
   },
   "leanFile": {
@@ -124,9 +133,9 @@
       "Finset"
     ],
     "namespace": "DerangementsOQ04OQ01",
-    "lineCount": 132,
+    "lineCount": 159,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/DerangementsOQ04OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Follow-up to #31792 (merged). Adds one theorem to the `derangements-oq-04-oq-01` gallery entry: the **fixed-point generating-function identity**
$$ \sum_{k=0}^{n} S(n,k)\, x^k = \sum_{\sigma \in \mathrm{Perm}(\mathrm{Fin}\,n)} x^{\#\mathrm{fix}\,\sigma}, $$
valid over **any commutative ring** (no characteristic hypothesis). This answers the entry's own generating-function open question.

Where the merged closed form evaluates each *coefficient* $S(n,k) = (n!/k!)\sum_{j\le n-k}(-1)^j/j!$, this identity packages *all* coefficients into the fixed-point statistic $x^{\#\mathrm{fix}\,\sigma}$.

## Proof

Pure regrouping of the permutation sum over the fibres of the fixed-point-count map:
- `Finset.sum_fiberwise_of_maps_to` groups $\sigma$ by $k = \#\mathrm{fix}\,\sigma$ (the count lands in `range (n+1)` since $\#\mathrm{fix}\,\sigma \le \#(\mathrm{Fin}\,n) = n$);
- on each fibre $\#\mathrm{fix}\,\sigma = k$, every term $x^{\#\mathrm{fix}\,\sigma}$ is $x^k$, so the fibre collapses via `Finset.sum_const`/`nsmul_eq_mul` to $S(n,k)\cdot x^k$.

Specializations: $x=0$ recovers $S(n,0)=D_n$; $x=1$ gives $\sum_k S(n,k) = n!$.

## Verification

Built via `docker-build.sh`; `#print axioms sum_kfixed_smul_pow` reports only `{propext, Classical.choice, Quot.sound}` — **0 sorries, 0 axioms** beyond Mathlib's foundations. Gallery metadata updated: `theoremCount` 5→6, `lineCount` 132→159, new `section-iv` + annotation, generating-function open question marked answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)