### PR TITLE
Enrich Erdős #211 Steiner Triple System Line Count (erdos-211-incomplete-01)

### DIFF
--- a/src/data/proofs/erdos-211-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-211-incomplete-01/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "erdos211-inc01-ann-header",
     "proofId": "erdos-211-incomplete-01",
-    "range": { "startLine": 1, "endLine": 60 },
+    "range": {
+      "startLine": 1,
+      "endLine": 60
+    },
     "type": "concept",
     "title": "Erdős #211 and the Extremal 1/6 Constant",
     "content": "Erdős Problem #211 ($100, awarded) asks how many lines n points in the plane determine when at most n-k lie on any line; Beck (1983) and Szemerédi–Trotter (1983) proved the count is ≫ k·n. Erdős conjectured the sharp constant is 1/6, attained when every determined line carries exactly three points. Such a configuration is a Steiner triple system S(2,3,n): a family of 3-point lines on V in which every pair of points lies on exactly one line. IsLineCover V L packages exactly this — an honest antecedent (a predicate), not an assumed existence — so every theorem below is conditional on it and the file remains 0-axiom.",
@@ -15,54 +18,106 @@
       "Szemerédi–Trotter theorem",
       "extremal configurations"
     ],
-    "prerequisites": ["Finset basics", "powersetCard", "binomial coefficients"]
+    "prerequisites": [
+      "Finset basics",
+      "powersetCard",
+      "binomial coefficients"
+    ]
   },
   {
     "id": "erdos211-inc01-ann-local",
     "proofId": "erdos-211-incomplete-01",
-    "range": { "startLine": 61, "endLine": 110 },
-    "type": "tactic",
+    "range": {
+      "startLine": 61,
+      "endLine": 110
+    },
+    "type": "technique",
     "title": "The Two Fiber Counts: 3 Pairs per Line, 1 Line per Pair",
     "content": "The double count rests on two elementary fiber cardinalities. card_pairs_of_line: a 3-element line contains exactly C(3,2)=3 pairs, via Finset.card_powersetCard. powersetCard_two_eq_filter: for a line l ⊆ V, the pairs inside l are exactly the pairs of V that l contains, l.powersetCard 2 = (V.powersetCard 2).filter (· ⊆ l) — proved by set extensionality using that p ⊆ l and l ⊆ V give p ⊆ V. card_lines_through_pair: the unique-cover hypothesis (∃! line through each pair) makes the filter of lines through a fixed pair a singleton, so its cardinality is 1, via Finset.card_eq_one.",
     "mathContext": "$|\\{p:\\ p\\subseteq l,\\ |p|=2\\}| = \\binom{3}{2} = 3,\\qquad |\\{l\\in L:\\ p\\subseteq l\\}| = 1$",
     "significance": "key",
-    "relatedConcepts": ["fiber counting", "Finset.card_powersetCard", "Finset.card_eq_one", "ExistsUnique"],
-    "prerequisites": ["powersetCard", "Finset.filter"]
+    "relatedConcepts": [
+      "fiber counting",
+      "Finset.card_powersetCard",
+      "Finset.card_eq_one",
+      "ExistsUnique"
+    ],
+    "prerequisites": [
+      "powersetCard",
+      "Finset.filter"
+    ]
   },
   {
     "id": "erdos211-inc01-ann-doublecount",
     "proofId": "erdos-211-incomplete-01",
-    "range": { "startLine": 111, "endLine": 140 },
+    "range": {
+      "startLine": 111,
+      "endLine": 140
+    },
     "type": "insight",
     "title": "Counting Incidences Both Ways",
     "content": "incidence_double_count is the symmetric heart of the argument. The flags are pairs (l, p) with l ∈ L, p a pair of V, and p ⊆ l. Grouped by line, the count is ∑_{l∈L} |pairs of l|; grouped by pair, it is ∑_{p} |lines through p|. The proof rewrites the line-grouped sum into a double indicator sum (using powersetCard_two_eq_filter and Finset.card_filter), applies Finset.sum_comm to interchange the order of summation, and re-folds into the pair-grouped filter cardinalities. This single swap is the whole content of 'counting two ways'.",
     "mathContext": "$\\sum_{l\\in L}\\binom{3}{2} = |\\{(l,p): p\\subseteq l\\}| = \\sum_{p}1$",
-    "significance": "critical",
-    "relatedConcepts": ["double counting", "Finset.sum_comm", "Fubini for finite sums", "bipartite incidence"],
-    "prerequisites": ["Finset.sum_comm", "Finset.card_filter"]
+    "significance": "key",
+    "relatedConcepts": [
+      "double counting",
+      "Finset.sum_comm",
+      "Fubini for finite sums",
+      "bipartite incidence"
+    ],
+    "prerequisites": [
+      "Finset.sum_comm",
+      "Finset.card_filter"
+    ]
   },
   {
     "id": "erdos211-inc01-ann-main",
     "proofId": "erdos-211-incomplete-01",
-    "range": { "startLine": 141, "endLine": 176 },
-    "type": "theorem",
+    "range": {
+      "startLine": 141,
+      "endLine": 176
+    },
+    "type": "insight",
     "title": "Exactly n(n-1)/6 Lines, and the Forced Divisibility",
     "content": "Combining the two fiber counts through the double count gives the main theorem three_mul_card_lines: 3·L.card = C(n,2). Two corollaries follow immediately: three_dvd_choose_two reads off the necessary divisibility 3 ∣ C(n,2) (one half of the classical n ≡ 1,3 mod 6 existence condition for Steiner triple systems), and card_lines_real converts the count to the explicit real value (L.card : ℝ) = n(n-1)/6 — Erdős's 1/6 constant made literal — using Nat.choose_two_right and the parity of n(n-1). Numerical checks confirm the identity for the Fano plane (n=7, 7 lines), the affine plane AG(2,3) (n=9, 12 lines), and S(2,3,13) (n=13, 26 lines).",
     "mathContext": "$3\\,|L| = \\binom{n}{2}\\ \\Longrightarrow\\ |L| = \\frac{n(n-1)}{6}\\quad\\text{and}\\quad 3\\mid\\binom{n}{2}$",
-    "significance": "critical",
-    "relatedConcepts": ["Steiner triple system", "necessary divisibility condition", "Kirkman's condition", "Fano plane", "affine plane AG(2,3)"],
-    "prerequisites": ["Nat.choose_two_right", "binomial coefficients"]
+    "significance": "key",
+    "relatedConcepts": [
+      "Steiner triple system",
+      "necessary divisibility condition",
+      "Kirkman's condition",
+      "Fano plane",
+      "affine plane AG(2,3)"
+    ],
+    "prerequisites": [
+      "Nat.choose_two_right",
+      "binomial coefficients"
+    ]
   },
   {
     "id": "erdos211-inc01-ann-islinecover",
     "proofId": "erdos-211-incomplete-01",
-    "range": { "startLine": 43, "endLine": 53 },
+    "range": {
+      "startLine": 43,
+      "endLine": 53
+    },
     "type": "definition",
     "title": "IsLineCover: An Honest Antecedent, Not an Assumed Configuration",
     "content": "The whole entry turns on what IsLineCover is — and is not. It is a three-part Prop bundling the axioms of a Steiner triple system S(2,3,n): every line has exactly three points (hcard), every line sits inside the point set V (hsub), and every 2-element subset of V lies on exactly one line (hcover, the ∃! cover condition). This is a *hypothesis*, quantified universally: every theorem below reads 'for all V and L, if IsLineCover V L then …'. Crucially it is **not** an axiom asserting such an L exists. That distinction is the 'incomplete-01' framing: the entry rigorously proves the combinatorial consequence (the n(n-1)/6 line count) of being such a system, while the geometric question — for which n and via which planar point sets such a system is *realised* — is deliberately left to the classical Kirkman/Steiner existence theory. Trading existence for an honest antecedent is exactly what keeps the file 0-axiom while still extracting the rigorous heart of Erdős's 1/6.",
     "mathContext": "$\\mathrm{IsLineCover}\\,V\\,L \\;:=\\; \\bigl(\\forall l\\in L,\\,|l|=3\\bigr)\\;\\wedge\\;\\bigl(\\forall l\\in L,\\,l\\subseteq V\\bigr)\\;\\wedge\\;\\bigl(\\forall p\\in \\binom{V}{2},\\,\\exists!\\,l\\in L,\\ p\\subseteq l\\bigr)$. The $\\exists!$ ('exactly one') is the $\\lambda=1$ of a $2$-design $S(2,3,n)$; weakening it to $\\exists$ would break the per-pair fiber count of $1$ that the double count needs.",
     "significance": "key",
-    "relatedConcepts": ["Steiner triple system S(2,3,n)", "2-design", "ExistsUnique", "honest antecedent vs. axiom", "conditional theorem", "design realizability"],
-    "prerequisites": ["Prop and predicates in Lean", "Finset.powersetCard", "ExistsUnique (∃!)"]
+    "relatedConcepts": [
+      "Steiner triple system S(2,3,n)",
+      "2-design",
+      "ExistsUnique",
+      "honest antecedent vs. axiom",
+      "conditional theorem",
+      "design realizability"
+    ],
+    "prerequisites": [
+      "Prop and predicates in Lean",
+      "Finset.powersetCard",
+      "ExistsUnique (∃!)"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-211-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-211-incomplete-01/meta.json
@@ -141,7 +141,15 @@
   ],
   "conclusion": {
     "summary": "A machine-verified, axiom-free proof that any Steiner triple system S(2,3,n) — the 3-uniform extremal configuration of Erdős #211 — has exactly n(n-1)/6 lines, via a two-way incidence count (3 pairs per line, 1 line per pair). This isolates the rigorous source of Erdős's conjectured sharp constant 1/6 and the divisibility 3 ∣ C(n,2) it forces, supplying the combinatorial heart that the parent entry records only as unproved hypotheses.",
-    "futureWork": "The complementary question — for which n, and via which point configurations, such systems are realised in the plane (the Kirkman/Steiner existence theory, and the Burr–Grünbaum–Sloane / Füredi–Palásti geometric constructions) — remains a separate, deeper problem outside this combinatorial count."
+    "implications": [
+      "Isolates and proves the rigorous combinatorial core of Erdős #211's conjectured sharp constant 1/6: in a Steiner triple system S(2,3,n) every line has exactly 3 points and every pair lies on exactly one line, so the incidence double count forces exactly n(n−1)/6 lines — the 'honest source' of the 1/6 the parent entry records only as an unproved hypothesis.",
+      "The count immediately yields the divisibility 3 ∣ C(n,2), the arithmetic necessary condition (n ≡ 1 or 3 mod 6) behind Kirkman/Steiner existence — obtained here purely from counting, with no geometry or existence theory.",
+      "IsLineCover is stated as an honest antecedent (a hypothesis on the configuration), not an assumed constant, so the theorem is a genuine implication about any such system rather than a restatement — a template for extracting the provable combinatorial kernel of a geometric extremal conjecture."
+    ],
+    "openQuestions": [
+      "For which n, and via which explicit point configurations, are Steiner triple systems realised in the plane? This is the Kirkman/Steiner existence theory together with the Burr–Grünbaum–Sloane and Füredi–Palásti geometric constructions — a separate, deeper problem than the combinatorial count.",
+      "Can the double-count kernel be extended from 3-uniform S(2,3,n) to the general S(2,k,n) line-count C(n,2)/C(k,2), and does the same 'honest antecedent' formalization strategy carry the k-uniform divisibility conditions?"
+    ]
   },
   "sorries": []
 }


### PR DESCRIPTION
Enrichment pass for `erdos-211-incomplete-01` (axiom-free double count: an S(2,3,n) has exactly n(n−1)/6 lines — the combinatorial core of Erdős #211's 1/6 constant).

## Gaps closed
- **conclusion schema**: used a non-standard `futureWork` string and was **missing the required `implications`** (and had no `openQuestions`). Added 3 `implications` (the 1/6 kernel; the forced 3 ∣ C(n,2) divisibility; the honest-antecedent framing) and converted `futureWork` into 2 schema-correct `openQuestions` (geometric realizability; generalization to S(2,k,n)).
- **Annotation schema**: fixed `type: "tactic"`/`"theorem"` → `technique`/`insight` and `significance: "critical"` → `"key"`.

## Axiom integrity
Slug says "incomplete-01" but meta claims `status: verified, sorries: 0, axiomCount: 0`. **Verified accurate**: `grep` finds 0 `sorry`/`axiom`. "incomplete" refers to this being the provable combinatorial kernel of a larger open *geometric* problem (planar realizability), not to sorries here.

## Notes
- Already had `index.ts` and rich `meta.json` (6 keyInsights, 4 sections, 5 annotations) — left intact. 15 KB, under caps. JSON validated.