### PR TITLE
research(cramers-rule-oq-02-oq-01): sharp crossover — exact model beats Cramer for all n≥1 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CramersRuleOQ02OQ01.lean
+++ b/proofs/Proofs/CramersRuleOQ02OQ01.lean
@@ -330,4 +330,41 @@ theorem fullSolve_summary :
   ⟨backSubFlops_eq, fullSolveFlops_closed,
    fun _ h => backSubFlops_le_gaussFlops h, fun _ h => fullSolve_beats_cramer h⟩
 
+-- ============================================================
+-- Sharp crossover: the exact model beats Cramer for EVERY n ≥ 1
+-- ============================================================
+
+/-- **The `n ≥ 4` crossover is an artifact of the loose model.**  The parent's
+    `gauss_beats_cramer` needs `n ≥ 4` because it compares the *conservative* `n³`
+    multiplication count against Cramer's rule via the growth lemma `factorial_gt_sq`,
+    which is only established for `n ≥ 4`.  With the *exact* full solve cost
+    `fullSolveFlops n = (4n³ + 3n² − n)/6 ≈ 2n³/3` — a constant factor smaller than `n³` —
+    the comparison in fact holds for **every** `n ≥ 1`.  The three small cases
+    `n ∈ {1, 2, 3}` are decided directly (`1 < 2`, `7 < 12`, `22 < 72`); `n ≥ 4` reuses
+    `fullSolve_beats_cramer`.  So under the honest cost model Gaussian elimination is never
+    beaten by Cramer's rule on any nontrivial system — the `n ≥ 4` threshold vanishes. -/
+theorem fullSolve_beats_cramer_all {n : ℕ} (hn : 1 ≤ n) :
+    fullSolveFlops n < CramersComplexity.cramersRuleMuls n := by
+  rcases Nat.lt_or_ge n 4 with h | h
+  · have hf := fullSolveFlops_closed n
+    have hc := CramersComplexity.cramersRuleMuls_eq n
+    interval_cases n <;> norm_num [Nat.factorial] at hf hc ⊢ <;> omega
+  · exact fullSolve_beats_cramer h
+
+/-- The sharp comparison verdict: with the exact `≈ 2n³/3` cost model, Gaussian
+    elimination uses strictly fewer multiplications than Cramer's rule for **all** system
+    sizes `n ≥ 1`, and the bound `1 ≤ n` is sharp — it fails at `n = 0` (both costs are
+    `0`).  This sharpens the inherited `n ≥ 4` threshold down to the smallest nontrivial
+    dimension. -/
+theorem fullSolve_beats_cramer_sharp :
+    (∀ n : ℕ, 1 ≤ n → fullSolveFlops n < CramersComplexity.cramersRuleMuls n) ∧
+    ¬ (∀ n : ℕ, fullSolveFlops n < CramersComplexity.cramersRuleMuls n) := by
+  refine ⟨fun _ h => fullSolve_beats_cramer_all h, ?_⟩
+  intro hall
+  have h0 := hall 0
+  have hf := fullSolveFlops_closed 0
+  have hc := CramersComplexity.cramersRuleMuls_eq 0
+  norm_num [Nat.factorial] at hf hc
+  omega
+
 end CramersComplexityExact

--- a/research/problems/cramers-rule-oq-02-oq-01/knowledge.md
+++ b/research/problems/cramers-rule-oq-02-oq-01/knowledge.md
@@ -60,3 +60,15 @@ the **back-substitution phase** and its composition into the complete solve cost
   `CramersRuleOQ02OQ01.lean` (now 333 LOC, 25 thm/lemma, 7 def, 0 axiom, 0 sorry, no
   native_decide). Completes the stated open item. Verified via host `lake env lean`
   (docker down); `#print axioms` shows only propext/Classical.choice/Quot.sound.
+
+- **2026-06-30 (researcher-3)**: Sharp crossover — added `fullSolve_beats_cramer_all`
+  (`1 ≤ n → fullSolveFlops n < cramersRuleMuls n`) and `fullSolve_beats_cramer_sharp`.
+  The parent's `n ≥ 4` threshold is an ARTIFACT of the loose `n³` model (via
+  `factorial_gt_sq`, only proved for n≥4). With the EXACT `≈2n³/3` cost the verdict holds
+  for EVERY n≥1: small cases n∈{1,2,3} decided directly (fullSolveFlops 1/2/3 = 1/7/22 <
+  cramersRuleMuls 1/2/3 = 2/12/72), n≥4 reuses `fullSolve_beats_cramer`. Sharp: fails at
+  n=0 (0<0 false). Recipe: `rcases Nat.lt_or_ge n 4; interval_cases n <;> norm_num
+  [Nat.factorial] at hf hc ⊢ <;> omega` where hf=fullSolveFlops_closed n,
+  hc=cramersRuleMuls_eq n — omega treats the two cost atoms as opaque, closed forms pin
+  them. VERIFIED docker-build; both 0-axiom (no native_decide; parent's cramer_4/5/6
+  native_decide NOT pulled since I route through cramersRuleMuls_eq+factorial).


### PR DESCRIPTION
## Summary

A sharp-boundary strengthening of the Cramer-vs-Gaussian comparison. The existing analysis proves the exact full-solve cost `fullSolveFlops n = (4n³+3n²−n)/6 ≈ 2n³/3` beats Cramer's rule only for `n ≥ 4`. This PR shows the `n ≥ 4` threshold is entirely an **artifact of the parent's loose `n³` model** and that the honest cost model wins for **every** `n ≥ 1`.

### Why `n ≥ 4` was there

The parent `gauss_beats_cramer` compares the conservative `gaussMuls n = n³` against `cramersRuleMuls n = (n+1)·n·n!` using the growth lemma `factorial_gt_sq`, which is only established for `n ≥ 4`. That threshold then propagated to `gaussExact_beats_cramer` and `fullSolve_beats_cramer` a fortiori.

### The sharpening

With the exact `≈ 2n³/3` count — a constant factor below `n³` — the three small cases are decided by direct computation, so the whole range `n ≥ 1` is covered:

| n | fullSolveFlops n | cramersRuleMuls n |
|---|------------------|-------------------|
| 1 | 1 | 2 |
| 2 | 7 | 12 |
| 3 | 22 | 72 |

- **`fullSolve_beats_cramer_all`** : `1 ≤ n → fullSolveFlops n < cramersRuleMuls n`
- **`fullSolve_beats_cramer_sharp`** : the `∀ n ≥ 1` verdict together with a proof that it **fails at `n = 0`** (both costs are `0`), so the hypothesis `1 ≤ n` is sharp.

So under the honest cost model Gaussian elimination is never beaten by Cramer's rule on any nontrivial system.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CramersRuleOQ02OQ01` → `Built Proofs.CramersRuleOQ02OQ01` (0 errors/sorries; the only warnings are pre-existing `mul_le_mul_right'` deprecations in the parent `CramersRuleOQ02.lean`)
- `#print axioms` on both new theorems → `[propext, Classical.choice, Quot.sound]` only — **no `native_decide`** (the comparison routes through `cramersRuleMuls_eq` + `Nat.factorial`, not the parent's `native_decide` sample lemmas)
- +2 theorems, +37 lines; clean addition against `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)