### PR TITLE
Fix: realign pentagonal-number-theorem-oq-01 lineCount (1415→1489), theoremCount (86→88)

### DIFF
--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -13,9 +13,9 @@
       "PowerSeries.WithPiTopology"
     ],
     "namespace": "PentagonalNumberTheoremOQ01",
-    "lineCount": 1415,
+    "lineCount": 1489,
     "axiomCount": 0,
-    "theoremCount": 86,
+    "theoremCount": 88,
     "definitionCount": 12,
     "path": "Proofs/PentagonalNumberTheoremOQ01.lean",
     "sorries": 0
@@ -90,9 +90,9 @@
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,
-    "lineCount": 1415,
+    "lineCount": 1489,
     "assumptions": "None counted: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. pentSeriesCoeff is a noncomputable def using Classical.choice (a foundational axiom that the project's axiom policy does not count toward axiomCount). The genFun bridges genFun_pent_eq_tprod, coeff_genFun_pent and the two composed tprod headlines coeff_tprod_pent, coeff_tprod_pent_eq_evenOdd_diff each #print axioms to [propext, Classical.choice, Quot.sound] \u2014 only the standard foundational axioms, none counted. Machine-verified \u2014 the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, 7743 jobs, exit 0).",
-    "theoremCount": 86,
+    "theoremCount": 88,
     "definitionCount": 12
   },
   "overview": {


### PR DESCRIPTION
## Fix

Realign stale `leanFile` and `meta.meta` counts for `pentagonal-number-theorem-oq-01` after the source file grew (merged Part 7 / genFun enrichment).

## Evidence

`proofs/Proofs/PentagonalNumberTheoremOQ01.lean` (current `origin/main`):
- **lineCount**: stored 1415 → actual `wc -l` = **1489**
- **theoremCount**: stored 86 → canonical col-0 `^(theorem|lemma) ` count = **88** (all 88 verified real declarations, no docstring-prose false positives)
- definitionCount 12 and axiomCount 0 unchanged (already correct)

Both the `leanFile` block and the `meta.meta` block carried the stale 1415/86; both updated.

Drift found via leanFile lineCount scan. The only other ≥15 drift entries (puiseux-theorem-oq-03, erdos-1020-oq-02, erdos-1090) have in-flight research PRs and were skipped.

---
Automated fix by lean-mechanic agent.