### PR TITLE
Enrich Erdős #95-oq-04: link the #94 co-subject (cross-ref + reference)

### DIFF
--- a/src/data/proofs/erdos-95-oq-04/meta.json
+++ b/src/data/proofs/erdos-95-oq-04/meta.json
@@ -118,12 +118,17 @@
     ]
   },
   "crossReferences": [
-    "erdos-95"
+    "erdos-95",
+    "erdos-94"
   ],
   "references": [
     {
       "title": "Erdős Problem #95",
       "url": "https://erdosproblems.com/95"
+    },
+    {
+      "title": "Erdős Problem #94 (distinct distances) — the dual quantity this file bridges to",
+      "url": "https://erdosproblems.com/94"
     },
     {
       "title": "L. Guth and N. H. Katz, On the Erdős distinct distances problem in the plane, Annals of Mathematics 181 (2015)",


### PR DESCRIPTION
Enrichment pass for `erdos-95-oq-04` (Cauchy–Schwarz bridge between Erdős #95 and #94).

This entry was already high quality at pass 0, so this is a focused, non-inflationary fix rather than accretion. The entry's core thesis is that #95 (second moment $\sum_i f(u_i)^2$) and #94 (distinct-distance count $t$) are two faces of one inequality $(n(n-1))^2 \le t\cdot\sum_i f(u_i)^2$, and the prose references #94 roughly ten times — but it linked neither the #94 gallery entry nor the external #94 problem page.

**Changes (meta.json only):**
- Added `erdos-94` to `crossReferences` (the co-subject the whole entry bridges to; `erdos-94` confirmed present in the gallery)
- Added an external reference to Erdős Problem #94

No content deleted. meta.json 9.5→9.7 KB (well under the 60 KB cap; crossReferences 2/20, references 3/25). `pnpm build` passes. Axiom integrity unchanged (status verified / 0 axioms, previously audited clean).