### PR TITLE
Enrich Degeneracy Bounds the List Chromatic Number: add annotations.json

### DIFF
--- a/src/data/proofs/erdos-1018-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1018-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,127 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "From colouring to list colouring: the strongest natural axis",
+    "content": "The parent entry proves the classical greedy degeneracy bound $k$-degenerate $\\Rightarrow$ $(k+1)$-colourable, tight on the complete split graph $S_{n,k}$. This file strengthens the *upper* half of that statement to **list colouring** (choosability). A graph is $k$-choosable if for **every** assignment of a palette $L(v)$ of $\\ge k$ colours to each vertex, one can pick $c(v)\\in L(v)$ making $c$ proper. Choosability is strictly stronger than colourability ($\\chi_\\ell(G)\\ge\\chi(G)$, with arbitrarily large gaps), so a bound that survives the passage to lists is genuinely deeper. The header lays out the two results: (1) degeneracy still bounds $\\chi_\\ell$, and (2) the same split graph keeps it tight. The imports pull in the ancestor machinery: `IsKDegenerate`, `splitGraph`, and `splitGraph_kDegenerate` from the grandparent, and `splitGraph_not_colorable` from the parent.",
+    "mathContext": "$\\chi_\\ell(G) \\ge \\chi(G)$; parent: $k$-degenerate $\\Rightarrow \\chi \\le k+1$. Here: $k$-degenerate $\\Rightarrow \\chi_\\ell \\le k+1$, tight via $S_{n,k}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "list colouring / choosability",
+      "list chromatic number",
+      "graph degeneracy",
+      "Erdős #1018 degeneracy chain"
+    ],
+    "prerequisites": [
+      "proper graph colouring",
+      "chromatic number",
+      "graph degeneracy"
+    ]
+  },
+  {
+    "id": "ann-ischoosable",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 54, "endLine": 63 },
+    "type": "definition",
+    "title": "IsChoosable: choosability from scratch (Mathlib has none)",
+    "content": "`IsChoosable G k` says: for every colour type $\\alpha$ and every palette assignment $L : V \\to \\text{Finset}\\ \\alpha$ with $|L(v)| \\ge k$ for all $v$, there is a proper colouring $c$ with $c(v)\\in L(v)$. Two design points make this the right formalisation. First, the palette $L$ is **adversarial** — choosability must hold for *every* such $L$, which is exactly what makes it stronger than $k$-colourability (the constant palette $L(v)\\equiv\\{0,\\dots,k-1\\}$ recovers ordinary colouring). Second, $\\alpha$ ranges over an arbitrary type inside the definition, so the colour identities are never pinned down. Mathlib has no notion of list colouring, so this compact, reusable definition is an original contribution of the entry.",
+    "mathContext": "$G$ is $k$-choosable $\\iff \\forall L\\ (\\forall v,\\ |L(v)|\\ge k)\\ \\exists c\\ (\\forall v,\\ c(v)\\in L(v)) \\wedge (\\forall u\\sim w,\\ c(u)\\ne c(w)).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "choosability / k-choosable",
+      "adversarial palette",
+      "Finset.card",
+      "proper colouring predicate"
+    ],
+    "prerequisites": [
+      "Finset",
+      "SimpleGraph.Adj",
+      "universally quantified definitions"
+    ]
+  },
+  {
+    "id": "ann-greedy-core",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 131 },
+    "type": "technique",
+    "title": "The greedy list-colouring core by strong induction",
+    "content": "`exists_list_coloring_on` is the engine: for a palette with $|L(v)|\\ge k+1$ everywhere and any vertex set $T$, it builds a global $c : V\\to\\alpha$ proper on $T$ and palette-respecting on $T$. The proof is `Finset.strongInduction` on $T$. Empty $T$: both requirements are vacuous. Nonempty $T$: `IsKDegenerate` extracts a vertex $v\\in T$ with within-$T$ degree $\\le k$; the inductive hypothesis colours $T.\\text{erase}\\ v$. The colours used by $v$'s neighbours form `forbidden` $= N.\\text{image}\\ c'$ with $|\\text{forbidden}| \\le k$ (via `card_image_le` then the degree bound). Since $|L(v)| \\ge k+1 > k \\ge |\\text{forbidden}|$, the set $L(v)\\setminus\\text{forbidden}$ is nonempty (`sdiff_nonempty` plus a cardinality contradiction closed by `omega`), yielding a free colour `col` $\\in L(v)$. The colouring is extended by `fun x => if x = v then col else c' x`, and properness is verified by the same three-way case split as the parent ($u=v$, $w=v$, or both $\\ne v$). Crucially, only the *size* $\\ge k+1$ of the palette is ever used — never the identity of its colours — which is why the adversarial palette costs nothing.",
+    "mathContext": "$|\\text{forbidden}| \\le k < k+1 \\le |L(v)| \\ \\Rightarrow\\ L(v)\\setminus\\text{forbidden} \\ne \\varnothing$, giving a free colour inside $L(v)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.strongInduction",
+      "Finset.sdiff_nonempty",
+      "Finset.card_image_le",
+      "greedy colouring",
+      "if-then-else colouring update"
+    ],
+    "prerequisites": [
+      "strong induction on Finsets",
+      "degeneracy vertex-extraction",
+      "cardinality arguments (omega)"
+    ]
+  },
+  {
+    "id": "ann-degenerate-choosable",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 133, "endLine": 142 },
+    "type": "theorem",
+    "title": "degenerate_choosable: k-degenerate ⟹ (k+1)-choosable",
+    "content": "The headline upper bound: every $k$-degenerate graph is $(k+1)$-choosable, i.e. $\\chi_\\ell(G)\\le k+1$. It is the greedy core specialised to $T = \\text{univ}$: unfold `IsChoosable`, take any adversarial palette $L$ with $|L(v)|\\ge k+1$, apply `exists_list_coloring_on` at $T=\\text{univ}$, and discharge the universal membership obligations with `mem_univ`. This is a strict strengthening of the parent's `degenerate_colorable` ($\\chi\\le k+1$): the same strong induction works against an arbitrary per-vertex palette because the argument consumes only the count $\\ge k+1$ of available colours, never their identity.",
+    "mathContext": "$k\\text{-degenerate}(G) \\Rightarrow \\text{IsChoosable}\\ G\\ (k+1)$, i.e. $\\chi_\\ell(G)\\le k+1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "list chromatic number",
+      "degeneracy bound",
+      "Finset.mem_univ",
+      "strengthening of χ ≤ k+1"
+    ],
+    "prerequisites": [
+      "the greedy core exists_list_coloring_on",
+      "graph degeneracy"
+    ]
+  },
+  {
+    "id": "ann-colorable-of-choosable",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 144, "endLine": 151 },
+    "type": "theorem",
+    "title": "colorable_of_choosable: χ ≤ χ_ℓ, certifying a genuine strengthening",
+    "content": "Every $k$-choosable graph is $k$-colourable. The proof instantiates the adversarial palette with the *constant* $k$-element set $L(v)\\equiv(\\text{univ}:\\text{Finset}\\ (\\text{Fin}\\ k))$, whose cardinality is $k$ (closed by `simp`); the resulting palette-respecting proper function is packaged into a `SimpleGraph.Colorable k` via `SimpleGraph.Coloring.mk`. This establishes $\\chi(G)\\le\\chi_\\ell(G)$ and, applied to `degenerate_choosable`, confirms that lifting $\\chi\\le k+1$ to $\\chi_\\ell\\le k+1$ is a real theory-level strengthening rather than an incomparable variant. It is also the bridge used for tightness: any obstruction to $k$-colouring is automatically an obstruction to $k$-choosing.",
+    "mathContext": "$\\text{IsChoosable}\\ G\\ k \\Rightarrow G.\\text{Colorable}\\ k$, hence $\\chi(G)\\le\\chi_\\ell(G)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "SimpleGraph.Coloring.mk",
+      "constant palette Fin k",
+      "χ ≤ χ_ℓ",
+      "colourability from choosability"
+    ],
+    "prerequisites": [
+      "SimpleGraph.Colorable",
+      "Fin k as a palette"
+    ]
+  },
+  {
+    "id": "ann-tightness",
+    "proofId": "erdos-1018-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 153, "endLine": 171 },
+    "type": "insight",
+    "title": "Tightness: χ_ℓ(S_{n,k}) = k+1 on the same split-graph witness",
+    "content": "The bound is sharp with no new geometry. `splitGraph_not_choosable`: for $k<n$, the split graph $S_{n,k}$ is not $k$-choosable — it is not even $k$-colourable (parent `splitGraph_not_colorable`, via its $(k+1)$-clique), and by `colorable_of_choosable` any $k$-choosable graph is $k$-colourable, so the clique obstruction transfers to the list setting for free. `splitGraph_choosability` then bundles both halves: $S_{n,k}$ is $(k+1)$-choosable (it is $k$-degenerate by the grandparent's `splitGraph_kDegenerate`, so `degenerate_choosable` applies) but not $k$-choosable, pinning $\\chi_\\ell(S_{n,k}) = k+1$ exactly. Across the four-entry chain the single graph $S_{n,k}$ simultaneously realises all three extremal facts of Erdős #1018's degeneracy parameter: $\\approx k\\cdot n$ edges, $\\chi = k+1$, and now $\\chi_\\ell = k+1$.",
+    "mathContext": "$S_{n,k}$ is $(k+1)$-choosable but not $k$-choosable for $k<n$, so $\\chi_\\ell(S_{n,k}) = k+1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complete split graph S_{n,k}",
+      "sharpness / tight witness",
+      "(k+1)-clique obstruction",
+      "splitGraph_kDegenerate"
+    ],
+    "prerequisites": [
+      "colorable_of_choosable",
+      "parent splitGraph_not_colorable",
+      "grandparent splitGraph_kDegenerate"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-1018-oq-01-oq-01-oq-01-oq-01` (degeneracy ⟹ (k+1)-choosability, with tight split-graph witness).

**Gap addressed:** the entry had a rich `meta.json` (overview, sections, conclusion, cross-refs) but **no `annotations.json`**, so the proof page rendered with zero inline annotation coverage. This is prime pass-1 work.

**Added 6 annotations** covering the full 174-line Lean file, line ranges aligned to the actual source, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`:

1. Header/overview — the colouring → list-colouring axis
2. `IsChoosable` — choosability defined from scratch (Mathlib has none)
3. `exists_list_coloring_on` — the greedy strong-induction core (free colour inside $L(v)\setminus\text{forbidden}$)
4. `degenerate_choosable` — $k$-degenerate ⟹ $(k+1)$-choosable
5. `colorable_of_choosable` — $\chi \le \chi_\ell$, certifying a genuine strengthening
6. Tightness — $\chi_\ell(S_{n,k}) = k+1$ on the same split-graph witness

No meta.json changes; axiom integrity unchanged (status verified / 0 axioms). `pnpm build` passes.