### PR TITLE
research(area-of-circle-oq-03-oq-02-oq-01): matching Θ(1/m²) lower bound for Archimedes doubling [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ03OQ02OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ03OQ02OQ01.lean
@@ -307,6 +307,63 @@ theorem pi_sub_halfPerimeter_le_sharp_factored {m : ℕ} (hm : 4 ≤ m) :
     field_simp; ring
   exact h.trans_eq heq
 
+/-- **Matching `Ω(1/m²)` lower bound on the error.**  The inscribed half-perimeter
+underestimates π by at least a quadratic amount: `π - p(m) ≥ (1/12)·π³/m²` for every
+`m ≥ 4`.  Together with `pi_sub_halfPerimeter_le` this pins the convergence rate to
+*exactly* order `1/m²` (see `pi_sub_halfPerimeter_bounds`): the doubling method gains
+about two binary digits of π per doubling — no faster, no slower.
+
+Proof: with `x = π/m ≤ 1`, Mathlib's Taylor estimate `Real.sin_bound` gives the *upper*
+bound `sin x ≤ x - x³/6 + (5/96)x⁴`.  The quartic correction is dominated by the cubic
+because `x ≤ 1`: `(5/96)x⁴ ≤ (5/96)x³ ≤ (1/12)x³`, leaving `sin x ≤ x - (1/12)x³`.
+Multiplying by `m` and using `m·x = π`, `m·x³ = π³/m²` gives `p(m) ≤ π - (1/12)π³/m²`. -/
+theorem pi_sub_halfPerimeter_ge {m : ℕ} (hm : 4 ≤ m) :
+    1 / 12 * (Real.pi ^ 3 / (m : ℝ) ^ 2) ≤ Real.pi - halfPerimeter m := by
+  have hπ := Real.pi_pos
+  have hm' : (4 : ℝ) ≤ (m : ℝ) := by exact_mod_cast hm
+  have hmpos : (0 : ℝ) < (m : ℝ) := by linarith
+  have hmne : (m : ℝ) ≠ 0 := ne_of_gt hmpos
+  have hπlt : Real.pi < 4 := Real.pi_lt_four
+  set x := Real.pi / (m : ℝ) with hx
+  have hxpos : 0 < x := by rw [hx]; positivity
+  have hx1 : x ≤ 1 := by rw [hx, div_le_one hmpos]; linarith
+  have hbound := Real.sin_bound (x := x) (by rw [abs_of_pos hxpos]; exact hx1)
+  rw [abs_of_pos hxpos] at hbound
+  have hup : Real.sin x ≤ x - x ^ 3 / 6 + x ^ 4 * (5 / 96) := by
+    have := (abs_le.mp hbound).2; linarith
+  have hmx : (m : ℝ) * x = Real.pi := by rw [hx]; field_simp
+  have hmx3 : (m : ℝ) * x ^ 3 = Real.pi ^ 3 / (m : ℝ) ^ 2 := by rw [hx]; field_simp
+  have hx43 : x ^ 4 ≤ x ^ 3 := by
+    nlinarith [mul_nonneg (pow_nonneg hxpos.le 3) (by linarith : (0 : ℝ) ≤ 1 - x)]
+  have hquartic : (m : ℝ) * x ^ 4 ≤ (m : ℝ) * x ^ 3 := mul_le_mul_of_nonneg_left hx43 hmpos.le
+  have hP0 : (0 : ℝ) ≤ (m : ℝ) * x ^ 3 := mul_nonneg hmpos.le (pow_nonneg hxpos.le 3)
+  have hexp : (m : ℝ) * (x - x ^ 3 / 6 + x ^ 4 * (5 / 96))
+      = Real.pi - 1 / 6 * ((m : ℝ) * x ^ 3) + 5 / 96 * ((m : ℝ) * x ^ 4) := by
+    have h : (m : ℝ) * (x - x ^ 3 / 6 + x ^ 4 * (5 / 96))
+        = (m : ℝ) * x - 1 / 6 * ((m : ℝ) * x ^ 3) + 5 / 96 * ((m : ℝ) * x ^ 4) := by ring
+    rw [h, hmx]
+  have h1 : (m : ℝ) * Real.sin x
+      ≤ Real.pi - 1 / 6 * ((m : ℝ) * x ^ 3) + 5 / 96 * ((m : ℝ) * x ^ 4) := by
+    have := mul_le_mul_of_nonneg_left hup hmpos.le
+    rwa [hexp] at this
+  have hsin_scaled : (m : ℝ) * Real.sin x ≤ Real.pi - 1 / 12 * ((m : ℝ) * x ^ 3) := by
+    linarith [h1, hquartic, hP0]
+  simp only [halfPerimeter]
+  rw [← hx, ← hmx3]
+  linarith [hsin_scaled]
+
+/-- **The doubling-method error is `Θ(1/m²)`.**  Combining the upper bound
+`pi_sub_halfPerimeter_le` and the matching lower bound `pi_sub_halfPerimeter_ge`,
+for every `m ≥ 4` the approximation error is sandwiched between two constant multiples
+of `π³/m²`:
+    `(1/12)·π³/m² ≤ π - p(m) ≤ (7/32)·π³/m²`.
+So the convergence rate of Archimedes' method is *exactly* quadratic in `1/m` — over the
+doubling sequence `m = 6·2ᵏ` this is the sharp `π - p(6·2ᵏ) = Θ(4⁻ᵏ)`. -/
+theorem pi_sub_halfPerimeter_bounds {m : ℕ} (hm : 4 ≤ m) :
+    1 / 12 * (Real.pi ^ 3 / (m : ℝ) ^ 2) ≤ Real.pi - halfPerimeter m ∧
+    Real.pi - halfPerimeter m ≤ 7 / 32 * Real.pi ^ 3 / (m : ℝ) ^ 2 :=
+  ⟨pi_sub_halfPerimeter_ge hm, pi_sub_halfPerimeter_le hm⟩
+
 -- ============================================================
 -- PART VI: Summary
 -- ============================================================

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
@@ -62,7 +62,8 @@
       "Convergence: p(m) → π as m → ∞, by squeezing π·cos(π/m) ≤ p(m) < π (fully proved)",
       "Explicit convergence rate: π − p(m) ≤ (7/32)·π³/m² for m ≥ 4 (quadratic in 1/m), proved from the sin Taylor estimate Real.sin_bound by absorbing the quartic remainder into the cubic term — gives π − p(2ᵏ) = O(4⁻ᵏ) (fully proved)",
       "Sharp 1/6 leading-constant rate (pi_sub_halfPerimeter_le_sharp): keeping the quartic Taylor remainder separate instead of absorbing it gives π − p(m) ≤ π³/(6m²) + (5/96)·π⁴/m³ for m ≥ 4, with the EXACT second-order Taylor coefficient 1/6 (not 7/32); answers the entry's second open question",
-      "Factored form pi_sub_halfPerimeter_le_sharp_factored: π − p(m) ≤ (π³/(6m²))·(1 + 5π/(16m)), exhibiting leading constant 1/6 with a relative correction 5π/(16m) → 0; for m ≥ 4 it collapses to the earlier 7/32 bound since 1/6 + 5/96 = 7/32"
+      "Factored form pi_sub_halfPerimeter_le_sharp_factored: π − p(m) ≤ (π³/(6m²))·(1 + 5π/(16m)), exhibiting leading constant 1/6 with a relative correction 5π/(16m) → 0; for m ≥ 4 it collapses to the earlier 7/32 bound since 1/6 + 5/96 = 7/32",
+      "Matching Θ(1/m²) convergence rate for Archimedes' doubling method (0-axiom): pi_sub_halfPerimeter_ge proves the lower error bound π - p(m) ≥ (1/12)·π³/m² for m ≥ 4 (Real.sin_bound Taylor UPPER estimate, quartic absorbed into cubic via x=π/m≤1), the matching lower bound to the existing upper bounds pi_sub_halfPerimeter_le/_le_sharp; pi_sub_halfPerimeter_bounds packages the sharp sandwich (1/12)π³/m² ≤ π−p(m) ≤ (7/32)π³/m², upgrading the rate from O to Θ."
     ],
     "dateAdded": "2026-06-28",
     "axiomCount": 0,
@@ -196,9 +197,9 @@
       "Topology"
     ],
     "namespace": "AreaOfCircleOQ03OQ02OQ01",
-    "lineCount": 329,
+    "lineCount": 386,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 1,
     "mainTheorems": [
       "archimedes_sin_doubling",


### PR DESCRIPTION
## Summary

The file `Proofs/AreaOfCircleOQ03OQ02OQ01.lean` (Archimedes half-angle doubling method) already
proves **upper** bounds on the convergence error `π − p(m)` (`pi_sub_halfPerimeter_le`,
`pi_sub_halfPerimeter_le_sharp`, `_sharp_factored`). This PR adds the **matching lower bound**,
making the `O(1/m²)` rate sharp (`Θ(1/m²)`):

- `pi_sub_halfPerimeter_ge` (0-axiom): `π − p(m) ≥ (1/12)·π³/m²` for `m ≥ 4`. Uses the Taylor
  **upper** estimate `sin x ≤ x − x³/6 + (5/96)x⁴` from `Real.sin_bound`; the quartic correction
  collapses into the cubic since `x = π/m ≤ 1` (`(5/96)x⁴ ≤ (5/96)x³ ≤ (1/12)x³`), then scale by `m`.
- `pi_sub_halfPerimeter_bounds` (0-axiom): packages the sharp sandwich
  `(1/12)·π³/m² ≤ π − p(m) ≤ (7/32)·π³/m²`, i.e. the doubling-method error is `Θ(1/m²)` — exactly
  two binary digits of π per doubling.

## Verification

- Branched off current `main`; only adds two theorems + a meta count update. 0-axiom, 0-sorry.
- Docker was down at authoring time (daemon crashed); verified via host `bin/lake env lean` on the
  full file → **exit 0, no diagnostics**. The identical proof previously built green under the
  docker wrapper (`Build completed successfully`) on the researcher branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)