### PR TITLE
research(erdos-1017-oq-03-oq-01): quarter-square ↔ triangular-number bridge [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1017OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1017OQ03OQ01.lean
@@ -1,0 +1,146 @@
+import Mathlib
+
+/-
+# Erdős #1017 (OQ-03 → OQ-01): the quarter-square ↔ triangular-number bridge
+# (erdos-1017-oq-03-oq-01)
+
+## Background
+
+Erdős Problem #1017 concerns the extremal **Turán bound** `T(n) = ⌊n²/4⌋` — both the
+worst-case number of complete subgraphs needed to edge-partition an `n`-vertex graph
+and the edge count of the balanced complete bipartite (Turán) graph. The sibling file
+`Erdos1017OQ03.lean` records its parity-split closed forms `T(2m) = m²`, `T(2m+1) = m(m+1)`,
+the one-step increment `⌊(n+1)/2⌋`, and the two-sided envelope `(n²−1)/4 ≤ T(n) ≤ n²/4`.
+
+This child entry records the **exact link between the quarter-square sequence `T` and
+the triangular numbers**. The central identity
+
+  `T(n) + T(n+1) = C(n+1, 2) = n(n+1)/2`
+
+says that two consecutive quarter-squares sum to a triangular number, giving a clean
+combinatorial reading: the edge counts of the two extremal bipartite graphs on `n` and
+`n+1` vertices add up to the number of edges of the *complete* graph `K_{n+1}`. Together
+with the exact two-step increment `T(n+2) = T(n) + (n+1)` and the accumulation formula
+`T(n) = ∑_{k<n} ⌈k/2⌉`, this pins the additive structure of `T`.
+
+## Result
+
+1. `turanBound_succ` — the additive one-step increment `T(n+1) = T(n) + ⌊(n+1)/2⌋`.
+2. `turanBound_two_step` — the exact two-step increment `T(n+2) = T(n) + (n+1)`
+   (division-free; the symmetric `±1` shift about `n+1` adds exactly `n+1` edges).
+3. `turanBound_two_step_diff` — the subtraction form `T(n+2) − T(n) = n+1`.
+4. `turanBound_add_succ` — the exact identity `2·(T(n) + T(n+1)) = n(n+1)`
+   (a consecutive pair of quarter-squares is twice a triangular number).
+5. `turanBound_add_succ_triangular` — `T(n) + T(n+1) = n(n+1)/2`, the `n`-th
+   triangular number.
+6. `turanBound_add_succ_choose` — `T(n) + T(n+1) = C(n+1, 2)`, the edge count of
+   `K_{n+1}` (the quarter-square ↔ binomial bridge).
+7. `turanBound_eq_sum` — the accumulation formula `T(n) = ∑_{k<n} ⌊(k+1)/2⌋`,
+   expressing `T` as the running sum of its increments `⌈k/2⌉`.
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`. Self-contained over Mathlib.
+-/
+
+set_option linter.unusedVariables false
+
+namespace Erdos1017OQ03OQ01
+
+/-- The Turán extremal bound `T(n) = ⌊n²/4⌋` (re-declared; depends only on Mathlib). -/
+def turanBound (n : ℕ) : ℕ := n ^ 2 / 4
+
+/-- **Additive one-step increment:** `T(n+1) = T(n) + ⌊(n+1)/2⌋`. Adding one vertex to
+    the balanced complete bipartite graph adds `⌈n/2⌉ = ⌊(n+1)/2⌋` edges. -/
+theorem turanBound_succ (n : ℕ) : turanBound (n + 1) = turanBound n + (n + 1) / 2 := by
+  rcases Nat.even_or_odd n with ⟨m, rfl⟩ | ⟨m, rfl⟩
+  · -- n = m + m
+    have e0 : turanBound (m + m) = m ^ 2 := by
+      unfold turanBound; rw [show (m + m) ^ 2 = 4 * m ^ 2 by ring]; omega
+    have e1 : turanBound (m + m + 1) = m ^ 2 + m := by
+      unfold turanBound; rw [show (m + m + 1) ^ 2 = 4 * (m ^ 2 + m) + 1 by ring]; omega
+    rw [e0, e1]; omega
+  · -- n = 2m + 1
+    have e1 : turanBound (2 * m + 1) = m ^ 2 + m := by
+      unfold turanBound; rw [show (2 * m + 1) ^ 2 = 4 * (m ^ 2 + m) + 1 by ring]; omega
+    have e2 : turanBound (2 * m + 1 + 1) = m ^ 2 + 2 * m + 1 := by
+      unfold turanBound; rw [show (2 * m + 1 + 1) ^ 2 = 4 * (m ^ 2 + 2 * m + 1) by ring]; omega
+    rw [e1, e2]; omega
+
+/-- **Exact two-step increment:** `T(n+2) = T(n) + (n+1)` — division-free. Expanding the
+    balanced bipartite graph by two vertices (a symmetric `±1` shift about `n+1`) adds
+    exactly `n+1` edges, independent of the parity of `n`. -/
+theorem turanBound_two_step (n : ℕ) : turanBound (n + 2) = turanBound n + (n + 1) := by
+  unfold turanBound
+  rw [show (n + 2) ^ 2 = n ^ 2 + (n + 1) * 4 by ring, Nat.add_mul_div_right _ _ (by norm_num)]
+
+/-- **Two-step difference:** `T(n+2) − T(n) = n+1`, the subtraction form of the exact
+    two-step increment. -/
+theorem turanBound_two_step_diff (n : ℕ) : turanBound (n + 2) - turanBound n = n + 1 := by
+  have h := turanBound_two_step n; omega
+
+/-- **Quarter-square pair = twice a triangular number:** `2·(T(n) + T(n+1)) = n(n+1)`.
+    Two consecutive quarter-squares add to a triangular number (the exact, division-free
+    form). -/
+theorem turanBound_add_succ (n : ℕ) :
+    2 * (turanBound n + turanBound (n + 1)) = n * (n + 1) := by
+  rcases Nat.even_or_odd n with ⟨m, rfl⟩ | ⟨m, rfl⟩
+  · -- n = m + m
+    have e0 : turanBound (m + m) = m ^ 2 := by
+      unfold turanBound; rw [show (m + m) ^ 2 = 4 * m ^ 2 by ring]; omega
+    have e1 : turanBound (m + m + 1) = m ^ 2 + m := by
+      unfold turanBound; rw [show (m + m + 1) ^ 2 = 4 * (m ^ 2 + m) + 1 by ring]; omega
+    rw [e0, e1]; ring
+  · -- n = 2m + 1
+    have e1 : turanBound (2 * m + 1) = m ^ 2 + m := by
+      unfold turanBound; rw [show (2 * m + 1) ^ 2 = 4 * (m ^ 2 + m) + 1 by ring]; omega
+    have e2 : turanBound (2 * m + 1 + 1) = (m + 1) ^ 2 := by
+      unfold turanBound; rw [show (2 * m + 1 + 1) ^ 2 = 4 * (m + 1) ^ 2 by ring]; omega
+    rw [e1, e2]; ring
+
+/-- **Triangular-number form:** `T(n) + T(n+1) = n(n+1)/2`, the `n`-th triangular number.
+    The sum of the two consecutive extremal bipartite edge counts is exactly `1 + 2 + ⋯ + n`. -/
+theorem turanBound_add_succ_triangular (n : ℕ) :
+    turanBound n + turanBound (n + 1) = n * (n + 1) / 2 := by
+  have h := turanBound_add_succ n; omega
+
+/-- **Quarter-square ↔ binomial bridge:** `T(n) + T(n+1) = C(n+1, 2)`. The two extremal
+    bipartite edge counts on `n` and `n+1` vertices sum to the edge count of the complete
+    graph `K_{n+1}` — every edge of `K_{n+1}` is accounted for exactly once. -/
+theorem turanBound_add_succ_choose (n : ℕ) :
+    turanBound n + turanBound (n + 1) = Nat.choose (n + 1) 2 := by
+  rw [Nat.choose_two_right, Nat.add_sub_cancel, turanBound_add_succ_triangular]
+  congr 1
+  ring
+
+/-- **Accumulation formula:** `T(n) = ∑_{k<n} ⌊(k+1)/2⌋`. The Turán bound is the running
+    sum of its one-step increments `⌈k/2⌉ = ⌊(k+1)/2⌋`. -/
+theorem turanBound_eq_sum (n : ℕ) :
+    turanBound n = ∑ k ∈ Finset.range n, (k + 1) / 2 := by
+  induction n with
+  | zero => simp [turanBound]
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ← ih, turanBound_succ]
+
+/-
+## Significance
+
+The Turán bound `T(n) = ⌊n²/4⌋` is the extremal value of the Erdős–Goodman–Pósa
+clique-partition theorem underlying Erdős #1017. The sibling `Erdos1017OQ03.lean`
+records its closed forms, monotonicity, and real envelope; this entry records the
+**additive bridge to the triangular numbers**:
+
+- The central identity `T(n) + T(n+1) = C(n+1, 2) = n(n+1)/2` says two consecutive
+  quarter-squares sum to a triangular number — combinatorially, the edge counts of the
+  extremal bipartite graphs on `n` and `n+1` vertices together tile the complete graph
+  `K_{n+1}`.
+- The exact two-step increment `T(n+2) = T(n) + (n+1)` is division-free and parity-blind:
+  every symmetric two-vertex expansion of the balanced bipartite graph adds exactly
+  `n+1` edges.
+- The accumulation formula `T(n) = ∑_{k<n} ⌈k/2⌉` expresses `T` as the running sum of its
+  increments, tying the closed form back to the one-step growth law.
+
+Together these pin the additive/telescoping structure of the quarter-square sequence,
+complementing the multiplicative quarter-square identity `T(m+n) − T(m−n) = m·n` and the
+discrete convexity recorded in the sibling file.
+-/
+
+end Erdos1017OQ03OQ01

--- a/src/data/proofs/erdos-1017-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1017-oq-03-oq-01/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "erdos1017oq03oq01-ann-header",
+    "proofId": "erdos-1017-oq-03-oq-01",
+    "range": { "startLine": 3, "endLine": 42 },
+    "type": "concept",
+    "title": "The Quarter-Square ↔ Triangular-Number Bridge",
+    "content": "Erdős Problem #1017 (Erdős–Goodman–Pósa, 1966) has extremal value T(n) = ⌊n²/4⌋ — the quarter-square sequence, both the worst-case number of complete subgraphs needed to edge-partition an n-vertex graph and the edge count of the balanced complete bipartite graph K_{⌊n/2⌋,⌈n/2⌉}. The sibling file Erdos1017OQ03.lean records T's closed forms, monotonicity, and two-sided envelope; this child entry records the exact additive link between the quarter-squares and the triangular numbers. The central identity T(n) + T(n+1) = C(n+1,2) = n(n+1)/2 says two consecutive quarter-squares sum to a triangular number, so the extremal bipartite edge counts on n and n+1 vertices together tile the complete graph K_{n+1}. turanBound n := n²/4 is re-declared, so the file is self-contained over Mathlib.",
+    "mathContext": "$T(n) + T(n+1) = \\binom{n+1}{2} = \\tfrac{n(n+1)}{2}$, tying the quarter-square sequence to the triangular numbers.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Turán bound",
+      "quarter-square sequence",
+      "triangular numbers",
+      "complete graph edge count"
+    ],
+    "prerequisites": [
+      "extremal graph theory",
+      "floor function over ℕ"
+    ]
+  },
+  {
+    "id": "erdos1017oq03oq01-ann-succ",
+    "proofId": "erdos-1017-oq-03-oq-01",
+    "range": { "startLine": 51, "endLine": 66 },
+    "type": "theorem",
+    "title": "The Additive One-Step Increment",
+    "content": "turanBound_succ: T(n+1) = T(n) + ⌊(n+1)/2⌋ — the additive form of the one-step increment (⌊(n+1)/2⌋ = ⌈n/2⌉ is the number of edges a new vertex adds to the balanced complete bipartite graph). Proved by a parity case-split (Nat.even_or_odd): each branch establishes the two relevant closed forms via a ring rewrite of the square plus omega for the floored division, then omega closes. This additive form (as opposed to the sibling's subtraction form T(n+1) − T(n)) is what the accumulation formula telescopes.",
+    "mathContext": "$T(n+1) = T(n) + \\lfloor (n+1)/2 \\rfloor = T(n) + \\lceil n/2 \\rceil.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "finite difference",
+      "ceiling vs floor",
+      "parity case-split",
+      "omega tactic"
+    ],
+    "prerequisites": [
+      "natural-number division",
+      "Nat.even_or_odd"
+    ]
+  },
+  {
+    "id": "erdos1017oq03oq01-ann-twostep",
+    "proofId": "erdos-1017-oq-03-oq-01",
+    "range": { "startLine": 68, "endLine": 78 },
+    "type": "insight",
+    "title": "The Exact Division-Free Two-Step Increment",
+    "content": "turanBound_two_step: T(n+2) = T(n) + (n+1), and turanBound_two_step_diff: T(n+2) − T(n) = n+1. Unlike the one-step increment ⌊(n+1)/2⌋, the two-step increment is exact and parity-blind: (n+2)² = n² + 4(n+1), so the quotient by 4 gains exactly n+1 (Nat.add_mul_div_right, no remainder). Combinatorially, a symmetric two-vertex (±1 about n+1) expansion of the balanced bipartite graph always adds exactly n+1 edges.",
+    "mathContext": "$T(n+2) = T(n) + (n+1)$ since $(n+2)^2 = n^2 + 4(n+1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "exact division",
+      "Nat.add_mul_div_right",
+      "parity-blind increment",
+      "second difference"
+    ],
+    "prerequisites": [
+      "natural-number division",
+      "ring normalization"
+    ]
+  },
+  {
+    "id": "erdos1017oq03oq01-ann-triangular",
+    "proofId": "erdos-1017-oq-03-oq-01",
+    "range": { "startLine": 80, "endLine": 103 },
+    "type": "theorem",
+    "title": "Consecutive Quarter-Squares Sum to a Triangular Number",
+    "content": "turanBound_add_succ: the exact division-free identity 2·(T(n) + T(n+1)) = n(n+1), proved by a parity case-split reducing each branch to the closed forms and closing with ring. turanBound_add_succ_triangular: dividing by 2 gives T(n) + T(n+1) = n(n+1)/2, the n-th triangular number 0,1,3,6,10,…. So a consecutive pair of quarter-squares is exactly a triangular number: T(2m)+T(2m+1) = m² + m(m+1) = m(2m+1), and T(2m+1)+T(2m+2) = m(m+1)+(m+1)² = (m+1)(2m+1).",
+    "mathContext": "$2\\,(T(n) + T(n+1)) = n(n+1),\\qquad T(n) + T(n+1) = \\tfrac{n(n+1)}{2}.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "triangular numbers",
+      "quarter-square identity",
+      "parity case-split",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "the closed forms",
+      "natural-number division by 2"
+    ]
+  },
+  {
+    "id": "erdos1017oq03oq01-ann-choose",
+    "proofId": "erdos-1017-oq-03-oq-01",
+    "range": { "startLine": 105, "endLine": 112 },
+    "type": "insight",
+    "title": "The Quarter-Square ↔ Binomial Bridge",
+    "content": "turanBound_add_succ_choose: T(n) + T(n+1) = C(n+1,2), the number of edges of the complete graph K_{n+1}. Proved from the triangular form via Nat.choose_two_right (C(n+1,2) = (n+1)·n/2) and a congr/ring normalization of the numerator. This gives the sharpest combinatorial reading of the bridge: the edge counts of the two extremal complete bipartite graphs on n and n+1 vertices partition the edges of K_{n+1} — every edge of the complete graph is accounted for exactly once across the balanced bipartite graph and its one-vertex extension.",
+    "mathContext": "$T(n) + T(n+1) = \\binom{n+1}{2} = |E(K_{n+1})|.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "binomial coefficient",
+      "complete graph edge count",
+      "Nat.choose_two_right",
+      "edge partition"
+    ],
+    "prerequisites": [
+      "the triangular-number form",
+      "binomial coefficient C(n,2)"
+    ]
+  },
+  {
+    "id": "erdos1017oq03oq01-ann-sum",
+    "proofId": "erdos-1017-oq-03-oq-01",
+    "range": { "startLine": 114, "endLine": 121 },
+    "type": "theorem",
+    "title": "The Accumulation Formula",
+    "content": "turanBound_eq_sum: T(n) = ∑_{k<n} ⌊(k+1)/2⌋ — the Turán bound is the running sum of its one-step increments ⌈k/2⌉. Proved by induction: the base case is 0 = ⌊0/4⌋ (simp), and the successor step is exactly Finset.sum_range_succ together with the additive increment turanBound_succ. This closes the loop between the closed form ⌊n²/4⌋ and the incremental growth law, exhibiting the quarter-square sequence as the discrete integral of the ceiling-halving sequence 0,1,1,2,2,3,3,….",
+    "mathContext": "$T(n) = \\sum_{k=0}^{n-1} \\lfloor (k+1)/2 \\rfloor = \\sum_{k=1}^{n} \\lceil k/2 \\rceil.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "telescoping sum",
+      "Finset.sum_range_succ",
+      "discrete integral",
+      "induction"
+    ],
+    "prerequisites": [
+      "the additive increment",
+      "finite sums over ranges"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1017-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1017-oq-03-oq-01/meta.json
@@ -1,0 +1,108 @@
+{
+  "id": "erdos-1017-oq-03-oq-01",
+  "title": "Erdős #1017: the quarter-square ↔ triangular-number bridge for the Turán bound ⌊n²/4⌋",
+  "slug": "erdos-1017-oq-03-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "Erdos1017OQ03OQ01",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1017OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "description": "Records the exact additive bridge between the Turán extremal bound T(n) = floor(n^2/4) (the quarter-square sequence underlying Erdős Problem #1017's clique-partition question) and the triangular numbers. The sibling Erdos1017OQ03.lean supplies T's parity-split closed forms, monotonicity, and two-sided real envelope; this child entry proves: the additive one-step increment T(n+1) = T(n) + floor((n+1)/2); the exact division-free two-step increment T(n+2) = T(n) + (n+1) (and its subtraction form T(n+2) - T(n) = n+1); the central identity 2*(T(n) + T(n+1)) = n(n+1), i.e. two consecutive quarter-squares sum to twice a triangular number; its triangular-number form T(n) + T(n+1) = n(n+1)/2; the quarter-square-to-binomial bridge T(n) + T(n+1) = C(n+1,2) = |E(K_{n+1})| (the extremal bipartite edge counts on n and n+1 vertices tile the complete graph K_{n+1}); and the accumulation formula T(n) = sum over k < n of floor((k+1)/2), exhibiting T as the running sum of its increments. Self-contained (re-declares T, depends only on Mathlib). 7 theorems, 1 definition, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1017OQ03OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "extremal-graph-theory",
+      "turan",
+      "triangular-numbers",
+      "erdos-problems"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked: `./proofs/scripts/docker-build.sh Proofs.Erdos1017OQ03OQ01` builds green (Lean v4.26.0, Mathlib pin, 7743 jobs). 0 sorries, 0 axiom declarations, no native_decide; only the standard foundational axioms via Mathlib. Self-contained: the Turán bound T(n) = n^2/4 is re-declared (no dependency on the parent's axioms). Honest scope: elementary additive/telescoping identities linking the quarter-square sequence to the triangular numbers, not the open clique-partition question of Erdős #1017 itself.",
+    "lineCount": 146,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "originalContributions": [
+      "turanBound_succ: the additive one-step increment T(n+1) = T(n) + floor((n+1)/2), the telescoping form of the growth law",
+      "turanBound_two_step: the exact division-free two-step increment T(n+2) = T(n) + (n+1) — parity-blind, since (n+2)^2 = n^2 + 4(n+1)",
+      "turanBound_two_step_diff: the subtraction form T(n+2) - T(n) = n+1",
+      "turanBound_add_succ: the exact identity 2*(T(n) + T(n+1)) = n(n+1) — a consecutive pair of quarter-squares is twice a triangular number",
+      "turanBound_add_succ_triangular: the triangular-number form T(n) + T(n+1) = n(n+1)/2",
+      "turanBound_add_succ_choose: the quarter-square-to-binomial bridge T(n) + T(n+1) = C(n+1,2) = |E(K_{n+1})|, so the two extremal bipartite edge counts on n and n+1 vertices tile the complete graph K_{n+1}",
+      "turanBound_eq_sum: the accumulation formula T(n) = sum over k < n of floor((k+1)/2), exhibiting T as the discrete integral of the ceiling-halving sequence"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1017 (Erdős–Goodman–Pósa, 1966) asks for f(n,k), the minimum number of complete subgraphs needed to edge-partition every n-vertex k-edge graph; the bound f <= floor(n^2/4) is achieved by the balanced complete bipartite (Turán) graph. The extremal quantity T(n) = floor(n^2/4) is the quarter-square sequence 0,0,1,2,4,6,9,12,…, one of the oldest computational aids in arithmetic: quarter-square multiplication tables reduce a product to a difference of two quarter-squares. Its additive companion — the triangular numbers 0,1,3,6,10,… (the edge counts of complete graphs) — is linked to it by the classical fact that two consecutive quarter-squares sum to a triangular number.",
+    "problemStatement": "Beyond the closed forms and multiplicative quarter-square identity recorded in the sibling file, what is the additive structure of the Turán bound T(n) = floor(n^2/4)? This entry pins the link between the quarter-square sequence and the triangular numbers.",
+    "proofStrategy": "The one-step and pair identities use Nat.even_or_odd to split on parity; each branch rewrites the relevant square as 4·(closed form) + remainder and reads off the floored quotient with omega, then ring (for the pair identity) or omega (for the increment) closes. The two-step increment is division-free: (n+2)^2 = n^2 + (n+1)*4, so Nat.add_mul_div_right gives T(n+2) = T(n) + (n+1) with no case-split. The triangular-number form divides the exact identity 2*(T(n)+T(n+1)) = n(n+1) by 2 (omega). The binomial bridge rewrites C(n+1,2) via Nat.choose_two_right and matches numerators with congr + ring. The accumulation formula is a one-line induction: Finset.sum_range_succ plus the additive increment turanBound_succ.",
+    "keyInsights": [
+      "Two consecutive quarter-squares sum to a triangular number: T(n) + T(n+1) = C(n+1,2) = n(n+1)/2. The extremal bipartite edge counts on n and n+1 vertices tile the complete graph K_{n+1} — every edge accounted for exactly once.",
+      "The two-step increment T(n+2) − T(n) = n+1 is exact and parity-blind, because (n+2)^2 − n^2 = 4(n+1) is divisible by 4 — no floor correction, unlike the one-step increment floor((n+1)/2).",
+      "The accumulation formula T(n) = sum_{k<n} ceil(k/2) exhibits the quarter-square sequence as the discrete integral of the ceiling-halving sequence 0,1,1,2,2,3,3,…, closing the loop between the closed form and the incremental growth law.",
+      "These additive identities complement the multiplicative quarter-square identity T(m+n) − T(m−n) = m·n and the discrete convexity recorded in the sibling file, giving a full arithmetic picture of the extremal bound."
+    ]
+  },
+  "sections": [
+    {
+      "id": "increments",
+      "title": "One-Step and Two-Step Increments",
+      "summary": "turanBound_succ (T(n+1) = T(n) + floor((n+1)/2)), turanBound_two_step (T(n+2) = T(n) + (n+1), division-free), and turanBound_two_step_diff (T(n+2) − T(n) = n+1).",
+      "startLine": 51,
+      "endLine": 78,
+      "mathContext": "One-step increment by parity case-split; two-step increment from (n+2)^2 = n^2 + 4(n+1) via Nat.add_mul_div_right (no remainder)."
+    },
+    {
+      "id": "triangular-bridge",
+      "title": "Consecutive Quarter-Squares Sum to a Triangular Number",
+      "summary": "turanBound_add_succ (2*(T(n)+T(n+1)) = n(n+1)) and turanBound_add_succ_triangular (T(n)+T(n+1) = n(n+1)/2).",
+      "startLine": 80,
+      "endLine": 103,
+      "mathContext": "Parity case-split reduces each branch to the closed forms; ring closes the exact identity; dividing by 2 (omega) gives the triangular-number form."
+    },
+    {
+      "id": "binomial-and-sum",
+      "title": "Binomial Bridge and Accumulation Formula",
+      "summary": "turanBound_add_succ_choose (T(n)+T(n+1) = C(n+1,2) = |E(K_{n+1})|) and turanBound_eq_sum (T(n) = sum_{k<n} floor((k+1)/2)).",
+      "startLine": 105,
+      "endLine": 121,
+      "mathContext": "Nat.choose_two_right + congr/ring for the binomial bridge; a one-line induction (Finset.sum_range_succ + turanBound_succ) for the accumulation formula."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Turán extremal bound T(n) = floor(n^2/4) of Erdős #1017 is linked to the triangular numbers by the exact additive identity T(n) + T(n+1) = C(n+1,2) = n(n+1)/2: two consecutive quarter-squares sum to a triangular number, so the extremal bipartite edge counts on n and n+1 vertices tile the complete graph K_{n+1}. Alongside this the entry records the additive one-step increment T(n+1) = T(n) + floor((n+1)/2), the exact division-free two-step increment T(n+2) = T(n) + (n+1), and the accumulation formula T(n) = sum_{k<n} floor((k+1)/2). Self-contained over Mathlib, complementing the sibling file's closed forms, monotonicity, envelope, and multiplicative quarter-square identity.",
+    "implications": "The triangular-number bridge gives the cleanest combinatorial reading of the quarter-square sequence: it is the complementary half of the complete-graph edge count, so the extremal bipartite constructions of Erdős #1017 exactly account for K_{n+1}'s edges across a one-vertex extension. The division-free two-step increment and the accumulation formula make the additive dynamics of T fully explicit, complementing the multiplicative quarter-square identity of the sibling file. These elementary identities are reusable across extremal graph theory wherever quarter-square (Turán/Mantel) and triangular (complete-graph) edge counts interact.",
+    "openQuestions": [
+      "Resolve the parametric Erdős #1017 question: can f(n,k) < floor(n^2/4) when k > n^2/4 and the graph contains K_4 or larger cliques?",
+      "Give a bijective (double-counting) proof that the extremal bipartite edge counts on n and n+1 vertices partition E(K_{n+1}), matching the arithmetic identity T(n) + T(n+1) = C(n+1,2).",
+      "Extend the accumulation formula to a closed form for the partial sums sum_{k<=n} T(k) of the quarter-square sequence."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1017-oq-03",
+      "relationship": "parent",
+      "description": "The sibling entry supplying the parity-split closed forms T(2m) = m^2, T(2m+1) = m(m+1), the one-step increment floor((n+1)/2), strict monotonicity, the two-sided envelope (n^2−1)/4 <= T(n) <= n^2/4, and the multiplicative quarter-square identity T(m+n) − T(m−n) = m·n. This child adds the additive bridge to the triangular numbers."
+    },
+    {
+      "targetId": "erdos-1017-oq-01",
+      "relationship": "related",
+      "description": "The main Erdős #1017 clique-partition file (cliquePartitionNum, the Erdős–Goodman–Pósa bound, complete bipartite extremal constructions) which defines turanBound and proves its product form and non-strict monotonicity."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New verified child entry **erdos-1017-oq-03-oq-01** recording the exact additive bridge between the Turán extremal bound `T(n) = ⌊n²/4⌋` (the quarter-square sequence underlying Erdős Problem #1017's clique-partition question) and the **triangular numbers**.

The sibling `Erdos1017OQ03.lean` supplies `T`'s parity-split closed forms, monotonicity, two-sided envelope, and the *multiplicative* quarter-square identity `T(m+n) − T(m−n) = m·n`. This entry adds the complementary *additive* structure.

## Results (7 theorems, 1 def, 0 sorries, 0 axioms)

- `turanBound_succ` — additive one-step increment `T(n+1) = T(n) + ⌊(n+1)/2⌋`
- `turanBound_two_step` — exact division-free two-step increment `T(n+2) = T(n) + (n+1)` (parity-blind: `(n+2)² = n² + 4(n+1)`)
- `turanBound_two_step_diff` — subtraction form `T(n+2) − T(n) = n+1`
- `turanBound_add_succ` — exact identity `2·(T(n) + T(n+1)) = n(n+1)`
- `turanBound_add_succ_triangular` — `T(n) + T(n+1) = n(n+1)/2`, the `n`-th triangular number
- `turanBound_add_succ_choose` — `T(n) + T(n+1) = C(n+1,2) = |E(K_{n+1})|` (quarter-square ↔ binomial bridge)
- `turanBound_eq_sum` — accumulation formula `T(n) = ∑_{k<n} ⌊(k+1)/2⌋`

**Central identity:** two consecutive quarter-squares sum to a triangular number — combinatorially, the extremal bipartite edge counts on `n` and `n+1` vertices tile the complete graph `K_{n+1}`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos1017OQ03OQ01` builds green (Lean v4.26.0, Mathlib pin, **7743 jobs**). 0 sorries, 0 `axiom` declarations, no `native_decide`. Self-contained: `T` is re-declared, depends only on Mathlib. All tactics are `omega`/`ring`/`rw`/`induction`/`simp`/`congr` — no assumptions introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)