### PR TITLE
research(stirling-first-kind-oq-01-oq-01-oq-01): Stirling matrix inversion — signed first-kind, falling-factorial, orthogonality [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/StirlingFirstKindOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/StirlingFirstKindOQ01OQ01OQ01.lean
@@ -164,3 +164,4 @@ theorem stirling_orthogonality (n m : ℕ) :
   rw [coeff_C_mul, coeff_descPochhammer_eq_stirlingFirst]
 
 end StirlingMatrixInversion
+

--- a/proofs/Proofs/StirlingFirstKindOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/StirlingFirstKindOQ01OQ01OQ01.lean
@@ -119,7 +119,7 @@ theorem X_pow_eq_sum_stirlingSecond_descPochhammer (n : ℕ) :
       simp only [Nat.cast_zero, Nat.cast_mul, C_eq_natCast, hz₁, mul_zero,
         map_zero, zero_mul, add_zero]
       refine Finset.sum_congr rfl (fun k _ => ?_)
-      simp only [map_add, map_mul, C_eq_natCast]
+      simp only [map_mul, C_eq_natCast]
       push_cast
       ring
     calc (X : R[X]) ^ (n + 1)
@@ -144,7 +144,7 @@ theorem X_pow_eq_sum_stirlingSecond_descPochhammer (n : ℕ) :
           simp only [Nat.stirlingSecond_succ_zero, Nat.cast_zero, map_zero, zero_mul, add_zero]
           refine Finset.sum_congr rfl (fun k _ => ?_)
           rw [Nat.stirlingSecond_succ_succ]
-          simp only [map_add, map_mul, C_eq_natCast]
+          simp only [C_eq_natCast]
           push_cast
           ring
 

--- a/proofs/Proofs/StirlingFirstKindOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/StirlingFirstKindOQ01OQ01OQ01.lean
@@ -1,0 +1,166 @@
+import Mathlib
+import Proofs.StirlingFirstKindOQ01OQ01
+
+/-
+# Signed Stirling numbers, the falling factorial, and Stirling matrix inversion (OQ-01)
+
+## What This Proves
+
+The parent entry `StirlingFirstKindOQ01OQ01` identifies the **unsigned** Stirling numbers of
+the first kind `c(n,k) = Nat.stirlingFirst n k` with the coefficients of the **rising**
+factorial `ascPochhammer R n`.  This file supplies the three companion facts that turn that
+single identity into the classical **duality between the two kinds of Stirling numbers**:
+
+1. **Companion coefficient identity** (`coeff_descPochhammer_eq_stirlingFirst`).  The
+   coefficients of the **falling** factorial `descPochhammer R n = x(x-1)⋯(x-n+1)` are the
+   **signed** Stirling numbers of the first kind:
+
+       `(descPochhammer R n).coeff k = (-1)^(n+k) · c(n,k)`,   i.e.  `= s(n,k)`.
+
+2. **Second-kind generating identity** (`X_pow_eq_sum_stirlingSecond_descPochhammer`).  The
+   monomial `xⁿ` expands in the falling-factorial basis with the Stirling numbers of the
+   **second** kind `S(n,k) = Nat.stirlingSecond n k` as coordinates:
+
+       `Xⁿ = ∑_{k=0}^{n} S(n,k) · descPochhammer R k`.
+
+3. **Matrix inversion / orthogonality** (`stirling_orthogonality`).  Substituting (1) into (2)
+   and comparing coefficients shows the signed first-kind matrix `[s(n,k)]` and the second-kind
+   matrix `[S(n,k)]` are mutually inverse:
+
+       `∑_{k} S(n,k) · s(k,m) = [n = m]`.
+
+## Context / Mathlib gap
+
+Mathlib defines both `Nat.stirlingFirst` and `Nat.stirlingSecond` with their recurrences, and
+both `ascPochhammer` / `descPochhammer`, but connects none of them.  The parent bridged the
+unsigned first kind to the rising factorial; this file completes the picture on the falling-
+factorial (signed) side and proves the headline structural fact that the two triangular
+integer matrices invert one another.
+
+## Approach
+
+(1) is an induction on `n` comparing coefficients through the falling-factorial recurrence
+`descPochhammer R (n+1) = descPochhammer R n · (X - n)`, the exact mirror of the parent's
+rising-factorial argument; the extra `(X - n)` factor is what introduces the alternating sign,
+which we carry as `(-1)^(n+k)` (an addition, avoiding truncated `ℕ`-subtraction).
+
+(2) is an induction on `n` driven by the single engine
+`X · descPochhammer R k = descPochhammer R (k+1) + k · descPochhammer R k`
+(`X_mul_descPochhammer`); multiplying `Xⁿ = ∑ S(n,k) descPochhammer R k` by `X`, reindexing, and
+using the second-kind recurrence `S(n+1,k+1) = S(n,k) + (k+1)·S(n,k+1)` reproduces row `n+1`.
+
+(3) reads off the coefficient of `Xᵐ` in `Xⁿ`, which is `[m = n]`; expanding `Xⁿ` by (2) and each
+falling factorial's coefficient by (1) turns the same coefficient into `∑_k S(n,k)·s(k,m)`.
+
+All results are `0`-axiom (kernel-checked, no `sorry`, no `native_decide`).
+-/
+
+open Polynomial Finset
+
+namespace StirlingMatrixInversion
+
+variable {R : Type*} [CommRing R]
+
+/-- **Signed first-kind coefficients.**  The coefficients of the falling factorial
+`descPochhammer R n = x(x-1)⋯(x-n+1)` are the *signed* Stirling numbers of the first kind
+`s(n,k) = (-1)^(n+k) c(n,k)`. -/
+theorem coeff_descPochhammer_eq_stirlingFirst (n k : ℕ) :
+    (descPochhammer R n).coeff k = (-1) ^ (n + k) * (Nat.stirlingFirst n k : R) := by
+  induction n generalizing k with
+  | zero =>
+    rw [descPochhammer_zero, coeff_one]
+    rcases k with _ | k
+    · simp
+    · simp
+  | succ n ih =>
+    rw [descPochhammer_succ_right, mul_sub, coeff_sub, ← C_eq_natCast, coeff_mul_C]
+    rcases k with _ | m
+    · -- constant term
+      rw [mul_coeff_zero, coeff_X_zero, mul_zero, zero_sub, ih]
+      rcases n with _ | t <;> simp
+    · -- coefficient of `Xᵐ⁺¹`: the falling-factorial / Stirling recurrence with a sign
+      rw [coeff_mul_X, ih m, ih (m + 1), Nat.stirlingFirst_succ_succ]
+      push_cast
+      ring
+
+/-- **Multiplication engine.**  Multiplying a falling factorial by `X` shifts it up one and adds
+a `k`-multiple of itself: `X · descPochhammer R k = descPochhammer R (k+1) + k · descPochhammer R k`.
+This is the falling-factorial analogue of `X·xᵏ = xᵏ⁺¹`, and drives the second-kind expansion. -/
+theorem X_mul_descPochhammer (k : ℕ) :
+    (X : R[X]) * descPochhammer R k
+      = descPochhammer R (k + 1) + (k : R[X]) * descPochhammer R k := by
+  rw [descPochhammer_succ_right]
+  ring
+
+/-- **Second-kind generating identity (headline).**  The monomial `Xⁿ` expands in the
+falling-factorial basis with the Stirling numbers of the second kind as coordinates:
+`Xⁿ = ∑_{k=0}^{n} S(n,k) · descPochhammer R k`. -/
+theorem X_pow_eq_sum_stirlingSecond_descPochhammer (n : ℕ) :
+    (X : R[X]) ^ n
+      = ∑ k ∈ range (n + 1), C (Nat.stirlingSecond n k : R) * descPochhammer R k := by
+  induction n with
+  | zero =>
+    rw [pow_zero, Finset.sum_range_one, descPochhammer_zero, mul_one]
+    simp
+  | succ n ih =>
+    -- reindexing fact: `∑ S(n,k)·(k · descPoch k) = ∑ (k+1)·S(n,k+1)·descPoch (k+1)`
+    have hB : (∑ k ∈ range (n + 1),
+                C (Nat.stirlingSecond n k : R) * ((k : R[X]) * descPochhammer R k))
+            = ∑ k ∈ range (n + 1),
+                C (((k + 1) * Nat.stirlingSecond n (k + 1) : ℕ) : R)
+                  * descPochhammer R (k + 1) := by
+      rw [Finset.sum_range_succ' (fun k =>
+            C (Nat.stirlingSecond n k : R) * ((k : R[X]) * descPochhammer R k)) n,
+          Finset.sum_range_succ (fun k =>
+            C (((k + 1) * Nat.stirlingSecond n (k + 1) : ℕ) : R)
+              * descPochhammer R (k + 1)) n]
+      have hz₁ : Nat.stirlingSecond n (n + 1) = 0 :=
+        Nat.stirlingSecond_eq_zero_of_lt (Nat.lt_succ_self n)
+      simp only [Nat.cast_zero, Nat.cast_mul, C_eq_natCast, hz₁, mul_zero,
+        map_zero, zero_mul, add_zero]
+      refine Finset.sum_congr rfl (fun k _ => ?_)
+      simp only [map_add, map_mul, C_eq_natCast]
+      push_cast
+      ring
+    calc (X : R[X]) ^ (n + 1)
+        = X * ∑ k ∈ range (n + 1), C (Nat.stirlingSecond n k : R) * descPochhammer R k := by
+          rw [pow_succ', ih]
+      _ = ∑ k ∈ range (n + 1),
+            (C (Nat.stirlingSecond n k : R) * descPochhammer R (k + 1)
+              + C (Nat.stirlingSecond n k : R) * ((k : R[X]) * descPochhammer R k)) := by
+          rw [Finset.mul_sum]
+          refine Finset.sum_congr rfl (fun k _ => ?_)
+          rw [← mul_assoc, mul_comm (X : R[X]) (C (Nat.stirlingSecond n k : R)), mul_assoc,
+            X_mul_descPochhammer, mul_add]
+      _ = (∑ k ∈ range (n + 1), C (Nat.stirlingSecond n k : R) * descPochhammer R (k + 1))
+            + ∑ k ∈ range (n + 1),
+                C (Nat.stirlingSecond n k : R) * ((k : R[X]) * descPochhammer R k) := by
+          rw [Finset.sum_add_distrib]
+      _ = ∑ k ∈ range (n + 1 + 1),
+            C (Nat.stirlingSecond (n + 1) k : R) * descPochhammer R k := by
+          rw [hB, ← Finset.sum_add_distrib,
+            Finset.sum_range_succ' (fun k =>
+              C (Nat.stirlingSecond (n + 1) k : R) * descPochhammer R k) (n + 1)]
+          simp only [Nat.stirlingSecond_succ_zero, Nat.cast_zero, map_zero, zero_mul, add_zero]
+          refine Finset.sum_congr rfl (fun k _ => ?_)
+          rw [Nat.stirlingSecond_succ_succ]
+          simp only [map_add, map_mul, C_eq_natCast]
+          push_cast
+          ring
+
+/-- **Matrix inversion / orthogonality (headline).**  Substituting the signed first-kind
+coefficients (1) into the second-kind expansion (2) and comparing the coefficient of `Xᵐ` on
+both sides of `Xⁿ = Xⁿ` shows the two Stirling triangles are mutually inverse:
+
+    `∑_{k=0}^{n} S(n,k) · s(k,m) = [m = n]`,
+
+where `s(k,m) = (-1)^(k+m) c(k,m)` is the signed first-kind entry. -/
+theorem stirling_orthogonality (n m : ℕ) :
+    (∑ k ∈ range (n + 1),
+        (Nat.stirlingSecond n k : R) * ((-1) ^ (k + m) * (Nat.stirlingFirst k m : R)))
+      = if m = n then 1 else 0 := by
+  rw [← coeff_X_pow n m, X_pow_eq_sum_stirlingSecond_descPochhammer, finset_sum_coeff]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  rw [coeff_C_mul, coeff_descPochhammer_eq_stirlingFirst]
+
+end StirlingMatrixInversion

--- a/src/data/proofs/stirling-first-kind-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/stirling-first-kind-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "stirling-first-kind-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 62 },
+    "type": "concept",
+    "title": "Goal: The Two Stirling Triangles Are Inverse",
+    "content": "The file imports `Mathlib` and the parent entry `Proofs.StirlingFirstKindOQ01OQ01`, opens `Polynomial` and `Finset`, and works over an arbitrary commutative ring `R`. The objective is the classical duality between the two kinds of Stirling numbers: the falling factorial `descPochhammer R n = X(X−1)⋯(X−n+1)` has coefficient of `Xᵏ` equal to the signed first-kind number `s(n,k) = (-1)^(n+k)·c(n,k)`; the monomial `Xⁿ` expands in the falling-factorial basis with the second-kind numbers `S(n,k) = Nat.stirlingSecond n k`; and the two resulting integer matrices are mutually inverse. Mathlib defines all four objects but connects none of them.",
+    "mathContext": "Targets: $(\\mathrm{descPochhammer}\\,R\\,n).\\mathrm{coeff}\\,k = (-1)^{n+k} c(n,k)$, $X^n = \\sum_k S(n,k)\\,x^{(k\\downarrow)}$, and $\\sum_k S(n,k)\\,s(k,m) = [m=n]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Stirling numbers of the first and second kind", "falling factorial", "change of basis"],
+    "prerequisites": ["polynomial coefficients", "Lean 4 module system"]
+  },
+  {
+    "id": "ann-signed-coeff",
+    "proofId": "stirling-first-kind-oq-01-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 84 },
+    "type": "tactic",
+    "title": "Signed First-Kind Coefficients via the (X − n) Factor",
+    "content": "`coeff_descPochhammer_eq_stirlingFirst` proves `(descPochhammer R n).coeff k = (-1)^(n+k)·c(n,k)` by induction on `n` generalizing `k`. The step rewrites `descPochhammer R (n+1) = descPochhammer R n * (X − n)` (`descPochhammer_succ_right`) and, after `mul_sub`/`coeff_sub`, reads the `·X` part as a shift (`coeff_mul_X`) and the `(−n)` part as a scaling (`coeff_mul_C` after `C_eq_natCast`). Applying the induction hypothesis twice and `Nat.stirlingFirst_succ_succ` gives the recurrence; `push_cast; ring` discharges the sign bookkeeping.",
+    "mathContext": "Multiplying $x^{(n\\downarrow)}$ by $(x-n)$ sends $\\mathrm{coeff}\\,k \\mapsto \\mathrm{coeff}\\,(k-1) - n\\,\\mathrm{coeff}\\,k$, matching $s(n+1,k) = s(n,k-1) - n\\,s(n,k)$.",
+    "significance": "critical",
+    "relatedConcepts": ["recurrence relation", "alternating sign", "induction"],
+    "prerequisites": ["descPochhammer_succ_right", "coeff_mul_X", "coeff_mul_C", "Nat.stirlingFirst_succ_succ"]
+  },
+  {
+    "id": "ann-sign-convention",
+    "proofId": "stirling-first-kind-oq-01-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 84 },
+    "type": "insight",
+    "title": "Why the Sign Is Carried as (-1)^(n+k), Not (-1)^(n−k)",
+    "content": "The signed first-kind number is `s(n,k) = (-1)^(n−k)·c(n,k)`, but over ℕ the exponent `n−k` truncates and breaks the algebra. Since `(-1)^(2k) = 1`, one has `(-1)^(n−k) = (-1)^(n+k)`, so the file carries the exponent additively as `(-1)^(n+k)`. This keeps every exponent an honest ℕ-addition, and the inductive step's exponent arithmetic `(n+1)+(k+1) = (n+k)+2` with `(-1)² = 1` is then handled uniformly by `ring`.",
+    "mathContext": "$(-1)^{n-k} = (-1)^{n+k}$ because $(-1)^{2k}=1$; the additive form avoids truncated $\\mathbb{N}$-subtraction.",
+    "significance": "supporting",
+    "relatedConcepts": ["signed Stirling numbers", "truncated subtraction", "parity"],
+    "prerequisites": ["properties of (-1)^n", "ring normalisation of exponents"]
+  },
+  {
+    "id": "ann-engine",
+    "proofId": "stirling-first-kind-oq-01-oq-01-oq-01",
+    "range": { "startLine": 86, "endLine": 93 },
+    "type": "concept",
+    "title": "The Multiply-by-X Engine for Falling Factorials",
+    "content": "`X_mul_descPochhammer` proves `X·descPochhammer R k = descPochhammer R (k+1) + k·descPochhammer R k` in one line: `descPochhammer_succ_right` unfolds `descPochhammer R (k+1) = descPochhammer R k·(X−k)`, and `ring` rearranges. This is the exact falling-factorial analogue of `X·Xᵏ = Xᵏ⁺¹` for monomials, and it is the sole engine driving the second-kind expansion — multiplying a falling factorial by `X` produces the next one plus a `k`-multiple of itself.",
+    "mathContext": "$x\\,x^{(k\\downarrow)} = x^{((k+1)\\downarrow)} + k\\,x^{(k\\downarrow)}$, since $x^{((k+1)\\downarrow)} = x^{(k\\downarrow)}(x-k)$.",
+    "significance": "critical",
+    "relatedConcepts": ["falling factorial recurrence", "operator viewpoint"],
+    "prerequisites": ["descPochhammer_succ_right", "ring"]
+  },
+  {
+    "id": "ann-second-kind",
+    "proofId": "stirling-first-kind-oq-01-oq-01-oq-01",
+    "range": { "startLine": 95, "endLine": 149 },
+    "type": "tactic",
+    "title": "Expanding Xⁿ in the Falling-Factorial Basis",
+    "content": "`X_pow_eq_sum_stirlingSecond_descPochhammer` proves `Xⁿ = ∑ S(n,k)·descPochhammer R k` by induction on `n`. Multiplying the row-`n` expansion by `X` and applying `X_mul_descPochhammer` term-by-term produces a `descPochhammer (k+1)` part and a `k·descPochhammer k` part. The helper `hB` reindexes the second part `∑ S(n,k)·(k·descPochhammer k)` into `∑ (k+1)·S(n,k+1)·descPochhammer (k+1)` using `Finset.sum_range_succ'` on the left (dropping the `k=0` zero) and `Finset.sum_range_succ` on the right (dropping the `k=n` term, since `S(n,n+1)=0`). Recombining and applying `Nat.stirlingSecond_succ_succ` yields row `n+1`.",
+    "mathContext": "$x\\sum_k S(n,k) x^{(k\\downarrow)} = \\sum_k S(n,k)\\big(x^{((k+1)\\downarrow)} + k\\,x^{(k\\downarrow)}\\big) = \\sum_k S(n+1,k) x^{(k\\downarrow)}$.",
+    "significance": "critical",
+    "relatedConcepts": ["reindexing finite sums", "second-kind recurrence", "generating identity"],
+    "prerequisites": ["Finset.sum_range_succ'", "Finset.sum_range_succ", "Nat.stirlingSecond_succ_succ", "Nat.stirlingSecond_eq_zero_of_lt"]
+  },
+  {
+    "id": "ann-orthogonality",
+    "proofId": "stirling-first-kind-oq-01-oq-01-oq-01",
+    "range": { "startLine": 151, "endLine": 165 },
+    "type": "insight",
+    "title": "Orthogonality from Reading Xⁿ = Xⁿ Two Ways",
+    "content": "`stirling_orthogonality` proves `∑_k S(n,k)·s(k,m) = [m=n]` with no determinant. The Kronecker delta is rewritten as the coefficient of `Xᵐ` in `Xⁿ` (`coeff_X_pow`, giving `if m = n then 1 else 0`). Expanding `Xⁿ` by the second-kind identity and distributing the coefficient over the sum (`finset_sum_coeff`), each term becomes `S(n,k)·(descPochhammer R k).coeff m` (`coeff_C_mul`), and the signed first-kind identity rewrites `(descPochhammer R k).coeff m = (-1)^(k+m)·c(k,m) = s(k,m)`. The comparison forces the orthogonality relation, i.e. the two Stirling matrices are inverse.",
+    "mathContext": "$[m=n] = (X^n).\\mathrm{coeff}\\,m = \\sum_k S(n,k)\\,(x^{(k\\downarrow)}).\\mathrm{coeff}\\,m = \\sum_k S(n,k)\\,s(k,m)$.",
+    "significance": "critical",
+    "relatedConcepts": ["matrix inversion", "coefficient extraction", "Kronecker delta"],
+    "prerequisites": ["coeff_X_pow", "finset_sum_coeff", "coeff_C_mul"]
+  }
+]

--- a/src/data/proofs/stirling-first-kind-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,228 @@
+{
+  "id": "stirling-first-kind-oq-01-oq-01-oq-01",
+  "slug": "stirling-first-kind-oq-01-oq-01-oq-01",
+  "title": "Stirling Matrix Inversion: Signed First-Kind Numbers and the Falling Factorial",
+  "description": "Answers the parent entry's open question by formalising the duality between the two kinds of Stirling numbers. Three companion facts to the parent's rising-factorial identity: (1) the coefficients of the falling factorial descPochhammer R n are the signed Stirling numbers of the first kind, (descPochhammer R n).coeff k = (-1)^(n+k)·c(n,k) = s(n,k); (2) the monomial Xⁿ expands in the falling-factorial basis with the second-kind numbers as coordinates, Xⁿ = ∑_{k=0}^{n} S(n,k)·descPochhammer R k; (3) combining (1) and (2) and comparing the coefficient of Xᵐ shows the signed first-kind matrix [s(n,k)] and the second-kind matrix [S(n,k)] are mutually inverse: ∑_k S(n,k)·s(k,m) = [m=n]. Mathlib defines Nat.stirlingFirst, Nat.stirlingSecond, ascPochhammer and descPochhammer but connects none of them.",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.StirlingFirstKindOQ01OQ01"
+    ],
+    "opens": [
+      "Polynomial",
+      "Finset"
+    ],
+    "namespace": "StirlingMatrixInversion",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "coeff_descPochhammer_eq_stirlingFirst",
+        "type": "original",
+        "description": "The coefficients of the falling factorial descPochhammer R n are the signed Stirling numbers of the first kind: (descPochhammer R n).coeff k = (-1)^(n+k)·c(n,k)",
+        "leanType": "(n k : ℕ) → (descPochhammer R n).coeff k = (-1) ^ (n + k) * (Nat.stirlingFirst n k : R)"
+      },
+      {
+        "name": "X_pow_eq_sum_stirlingSecond_descPochhammer",
+        "type": "original",
+        "description": "The monomial Xⁿ expands in the falling-factorial basis with the second-kind Stirling numbers as coordinates: Xⁿ = ∑_{k=0}^{n} S(n,k)·descPochhammer R k",
+        "leanType": "(n : ℕ) → (X : R[X]) ^ n = ∑ k ∈ Finset.range (n + 1), C (Nat.stirlingSecond n k : R) * descPochhammer R k"
+      },
+      {
+        "name": "stirling_orthogonality",
+        "type": "original",
+        "description": "Matrix inversion: the signed first-kind matrix and the second-kind matrix are mutually inverse, ∑_k S(n,k)·s(k,m) = [m=n]",
+        "leanType": "(n m : ℕ) → (∑ k ∈ Finset.range (n + 1), (Nat.stirlingSecond n k : R) * ((-1) ^ (k + m) * (Nat.stirlingFirst k m : R))) = if m = n then 1 else 0"
+      },
+      {
+        "name": "X_mul_descPochhammer",
+        "type": "original",
+        "description": "The multiplication engine driving the second-kind expansion: X·descPochhammer R k = descPochhammer R (k+1) + k·descPochhammer R k, the falling-factorial analogue of X·xᵏ = xᵏ⁺¹",
+        "leanType": "(k : ℕ) → (X : R[X]) * descPochhammer R k = descPochhammer R (k + 1) + (k : R[X]) * descPochhammer R k"
+      }
+    ],
+    "path": "Proofs/StirlingFirstKindOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StirlingFirstKindOQ01OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "polynomials",
+      "stirling-numbers",
+      "falling-factorial",
+      "matrix-inversion",
+      "generating-functions",
+      "algebra"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 166,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (each of the four theorems depends only on propext, Classical.choice, Quot.sound). The results connect four existing but previously unlinked Mathlib definitions — Nat.stirlingFirst, Nat.stirlingSecond, ascPochhammer, descPochhammer — using the falling-factorial recurrence descPochhammer_succ_right, both Stirling recurrences, and standard polynomial coefficient lemmas. Mathlib contains neither the signed-coefficient identity, the second-kind falling-factorial expansion, nor the orthogonality relation.",
+    "originalContributions": [
+      "coeff_descPochhammer_eq_stirlingFirst: (descPochhammer R n).coeff k = (-1)^(n+k)·c(n,k) — original, the signed first-kind companion to the parent's unsigned rising-factorial identity, proved by induction through descPochhammer_succ_right with the alternating sign carried as (-1)^(n+k)",
+      "X_pow_eq_sum_stirlingSecond_descPochhammer: Xⁿ = ∑ S(n,k)·descPochhammer R k — original second-kind generating identity, driven by the multiplication engine X_mul_descPochhammer and the second-kind recurrence",
+      "stirling_orthogonality: ∑_k S(n,k)·s(k,m) = [m=n] — original, the headline matrix-inversion / orthogonality relation obtained by extracting the coefficient of Xᵐ from Xⁿ two different ways",
+      "X_mul_descPochhammer: X·descPochhammer R k = descPochhammer R (k+1) + k·descPochhammer R k — original reusable engine, the falling-factorial analogue of multiply-by-X"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "descPochhammer_succ_right",
+        "description": "Falling factorial recurrence: descPochhammer R (n+1) = descPochhammer R n * (X - n)",
+        "module": "Mathlib.RingTheory.Polynomial.Pochhammer"
+      },
+      {
+        "theorem": "Nat.stirlingFirst_succ_succ",
+        "description": "Stirling first-kind recurrence: c(n+1,k+1) = c(n,k) + n·c(n,k+1)",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.stirlingSecond_succ_succ",
+        "description": "Stirling second-kind recurrence: S(n+1,k+1) = S(n,k) + (k+1)·S(n,k+1)",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Polynomial.coeff_mul_X",
+        "description": "(p * X).coeff (n+1) = p.coeff n — the multiply-by-X coefficient shift",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      },
+      {
+        "theorem": "Polynomial.coeff_X_pow",
+        "description": "(X^k).coeff n = if n = k then 1 else 0 — extracts the coefficient of Xᵐ in Xⁿ as the Kronecker delta [m=n]",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      }
+    ],
+    "dateAdded": "2026-06-30",
+    "prerequisites": [
+      "Stirling numbers of the first and second kind and their recurrences",
+      "The falling and rising factorials as polynomials (descPochhammer / ascPochhammer)",
+      "Polynomial coefficients and the coeff API in Mathlib",
+      "Induction comparing coefficients and reindexing Finset sums",
+      "Change of basis between the monomial and factorial bases",
+      "Familiarity with Lean 4 and Mathlib"
+    ],
+    "sourceUrl": "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind",
+    "date": "1730",
+    "relatedProblems": [
+      {
+        "id": "stirling-first-kind-oq-01-oq-01",
+        "relationship": "Answers this parent entry's first open question: prove the companion identity for the falling factorial using the signed first-kind numbers, and combine with the second-kind generating identity to formalise that the two Stirling matrices are inverse."
+      }
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "problemStatement": "The unsigned Stirling numbers of the first kind c(n,k) are the coefficients of the rising factorial (proved in the parent entry). Their signed counterparts s(n,k) = (-1)^(n+k)·c(n,k) should be the coefficients of the falling factorial x(x-1)⋯(x-n+1), and the Stirling numbers of the second kind S(n,k) should expand ordinary powers back in the falling-factorial basis. Are the two resulting integer triangles mutually inverse — i.e. ∑_k S(n,k)·s(k,m) = [m=n]? Mathlib defines all four objects (Nat.stirlingFirst, Nat.stirlingSecond, ascPochhammer, descPochhammer) but links none of them.",
+    "text": "This entry completes the classical picture of the two Stirling triangles as mutually inverse change-of-basis matrices between the monomial basis $x^k$ and the factorial bases. The parent entry showed the unsigned first-kind numbers are the coefficients of the rising factorial. Here the falling factorial $x^{(n\\downarrow)} = x(x-1)\\cdots(x-n+1)$, written `descPochhammer R n`, has the signed first-kind numbers $s(n,k) = (-1)^{n+k} c(n,k)$ as coefficients; the monomial $x^n$ expands as $\\sum_k S(n,k)\\,x^{(k\\downarrow)}$ with the second-kind numbers; and reading the coefficient of $x^m$ in $x^n$ two different ways yields the orthogonality relation $\\sum_k S(n,k)\\,s(k,m) = [m=n]$.",
+    "proofStrategy": "Three linked results. (1) coeff_descPochhammer_eq_stirlingFirst by induction on n comparing coefficients: descPochhammer_succ_right multiplies by (X − n), so coeff k ↦ coeff (k−1) − n·coeff k, matching c(n+1,k) via the first-kind recurrence once the alternating sign is carried as (-1)^(n+k) (an addition, avoiding truncated ℕ-subtraction); push_cast and ring close each step. (2) X_pow_eq_sum_stirlingSecond_descPochhammer by induction on n: multiply the row-n expansion by X, apply the engine X_mul_descPochhammer to each term, reindex the resulting k·descPochhammer k sum with Finset.sum_range_succ'/succ, and combine with the second-kind recurrence to obtain row n+1. (3) stirling_orthogonality reads coeff m of Xⁿ: coeff_X_pow gives the Kronecker delta [m=n], while expanding Xⁿ by (2) and each falling factorial's coefficient by (1) rewrites the same coefficient as ∑_k S(n,k)·s(k,m).",
+    "keyInsights": [
+      "The alternating sign of the signed first-kind numbers is exactly the (X − n) factor of the falling-factorial recurrence; carrying it as (-1)^(n+k) rather than (-1)^(n−k) keeps everything in an honest addition and lets ring finish each inductive step.",
+      "A single engine lemma X·descPochhammer k = descPochhammer (k+1) + k·descPochhammer k plays the role that X·xᵏ = xᵏ⁺¹ plays for monomials, turning the second-kind expansion into a one-line reindexing plus the S-recurrence.",
+      "Orthogonality needs no determinant or explicit inverse: it is the tautology Xⁿ = Xⁿ read coefficient-wise, with (1) and (2) supplying the two expansions whose comparison forces ∑_k S(n,k)·s(k,m) = [m=n].",
+      "All four Mathlib definitions were previously disconnected; the falling-factorial side plus the parent's rising-factorial side together realise both change-of-basis directions between monomials and factorials."
+    ],
+    "historicalContext": "Stirling numbers originate in James Stirling's Methodus Differentialis (1730), whose central concern was precisely the conversion between the monomial basis xᵏ and the factorial (falling/rising) bases. The signed first-kind numbers are the coefficients that expand the falling factorial in monomials; the second-kind numbers invert this, expanding monomials in falling factorials. That the two triangular matrices are inverse — the orthogonality relation formalised here — is the algebraic heart of the finite-difference calculus Stirling developed.",
+    "prerequisites": [
+      "Stirling numbers of the first and second kind",
+      "The falling and rising factorials (Pochhammer symbols)",
+      "Polynomial coefficients, evaluation, and change of basis"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-overview",
+      "title": "Module Overview and Imports",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Imports Mathlib and the parent entry Proofs.StirlingFirstKindOQ01OQ01, opens Polynomial and Finset, and works over an arbitrary commutative ring R. The docstring states the three companion facts, explains the Mathlib gap (none of Nat.stirlingFirst, Nat.stirlingSecond, ascPochhammer, descPochhammer are linked), and outlines the coefficient-comparison strategy.",
+      "mathContext": "Setting: over a CommRing R, relate the falling factorial $\\mathrm{descPochhammer}\\,R\\,n$ and the monomials $X^n$ to the two Stirling triangles."
+    },
+    {
+      "id": "signed-first-kind",
+      "title": "Signed First-Kind Coefficients of the Falling Factorial",
+      "startLine": 64,
+      "endLine": 84,
+      "summary": "Proves coeff_descPochhammer_eq_stirlingFirst: (descPochhammer R n).coeff k = (-1)^(n+k)·c(n,k) by induction on n generalizing k. The base uses coeff_one; the step rewrites descPochhammer_succ_right and splits the constant term from the general term, where coeff_mul_X and coeff_mul_C realise the first-kind recurrence with the sign carried additively as (-1)^(n+k).",
+      "mathContext": "Multiplying by $(X-n)$: $\\mathrm{coeff}\\,k \\mapsto \\mathrm{coeff}\\,(k-1) - n\\cdot\\mathrm{coeff}\\,k$, which matches $s(n+1,k) = s(n,k-1) - n\\,s(n,k)$."
+    },
+    {
+      "id": "multiplication-engine",
+      "title": "The Falling-Factorial Multiplication Engine",
+      "startLine": 86,
+      "endLine": 93,
+      "summary": "Proves X_mul_descPochhammer: X·descPochhammer R k = descPochhammer R (k+1) + k·descPochhammer R k, a one-line ring consequence of descPochhammer_succ_right. This is the falling-factorial analogue of X·xᵏ = xᵏ⁺¹ and is the sole engine of the second-kind induction.",
+      "mathContext": "$x\\cdot x^{(k\\downarrow)} = x^{((k+1)\\downarrow)} + k\\,x^{(k\\downarrow)}$, since $x^{((k+1)\\downarrow)} = x^{(k\\downarrow)}(x-k)$."
+    },
+    {
+      "id": "second-kind-expansion",
+      "title": "Second-Kind Expansion of Monomials",
+      "startLine": 95,
+      "endLine": 149,
+      "summary": "Proves X_pow_eq_sum_stirlingSecond_descPochhammer: Xⁿ = ∑ S(n,k)·descPochhammer R k by induction on n. A helper hB reindexes ∑ S(n,k)·(k·descPochhammer k) into ∑ (k+1)·S(n,k+1)·descPochhammer (k+1) via Finset.sum_range_succ'/succ and the vanishing S(n,n+1)=0. The calc multiplies the row-n identity by X, applies X_mul_descPochhammer term-by-term, splits and recombines the sums, and closes with the second-kind recurrence S(n+1,k+1) = S(n,k) + (k+1)·S(n,k+1).",
+      "mathContext": "$x\\cdot\\sum_k S(n,k) x^{(k\\downarrow)} = \\sum_k S(n,k)\\big(x^{((k+1)\\downarrow)} + k\\,x^{(k\\downarrow)}\\big) = \\sum_k S(n+1,k) x^{(k\\downarrow)}$."
+    },
+    {
+      "id": "orthogonality",
+      "title": "Matrix Inversion / Orthogonality",
+      "startLine": 151,
+      "endLine": 165,
+      "summary": "Proves stirling_orthogonality: ∑_k S(n,k)·s(k,m) = [m=n]. The proof rewrites the Kronecker delta as coeff m of Xⁿ (coeff_X_pow), expands Xⁿ by the second-kind identity, distributes the coefficient over the sum (finset_sum_coeff), and applies coeff_C_mul together with the signed first-kind identity to each term, turning the single coefficient into ∑_k S(n,k)·s(k,m).",
+      "mathContext": "$[m=n] = (X^n).\\mathrm{coeff}\\,m = \\sum_k S(n,k)\\,(x^{(k\\downarrow)}).\\mathrm{coeff}\\,m = \\sum_k S(n,k)\\,s(k,m)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The two Stirling triangles are mutually inverse change-of-basis matrices: the falling factorial's coefficients are the signed first-kind numbers s(n,k) = (-1)^(n+k)·c(n,k), the monomial Xⁿ expands in the falling-factorial basis with the second-kind numbers, and comparing the coefficient of Xᵐ in Xⁿ forces ∑_k S(n,k)·s(k,m) = [m=n]. All four results are verified over an arbitrary commutative ring with 0 axioms and 0 sorries, completing the parent entry's rising-factorial picture on the falling-factorial side.",
+    "implications": [
+      "Bridges four previously disconnected Mathlib definitions — Nat.stirlingFirst, Nat.stirlingSecond, ascPochhammer, descPochhammer — with the missing change-of-basis identities in both directions between monomials and factorials.",
+      "Supplies the orthogonality relation ∑_k S(n,k)·s(k,m) = [m=n] as reusable infrastructure for finite-difference calculus, Stirling-transform inversion, and umbral identities.",
+      "Demonstrates the coefficient-comparison method (Xⁿ = Xⁿ read two ways) as a determinant-free route to matrix-inversion facts."
+    ],
+    "openQuestions": [
+      "Formalise the dual orthogonality ∑_k s(n,k)·S(k,m) = [m=n] (the inverse product order) and package both directions as an explicit statement that the two triangular matrices are inverse in Matrix (Fin N) (Fin N) R.",
+      "Prove the Stirling-transform inversion pair: gₙ = ∑_k S(n,k) fₖ ⟺ fₙ = ∑_k s(n,k) gₖ, as a direct corollary of orthogonality.",
+      "Relate the signed first-kind coefficients to the elementary symmetric polynomials in {0,1,…,n−1} and derive log-concavity / unimodality of each Stirling row."
+    ]
+  },
+  "references": [
+    {
+      "title": "Stirling numbers of the first kind",
+      "url": "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind",
+      "description": "Signed and unsigned first-kind numbers as coefficients of the falling and rising factorials."
+    },
+    {
+      "title": "Stirling numbers of the second kind",
+      "url": "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind",
+      "description": "Second-kind numbers expanding monomials in the falling-factorial basis, and the orthogonality relation with the first kind."
+    },
+    {
+      "title": "Falling and rising factorials",
+      "url": "https://en.wikipedia.org/wiki/Falling_and_rising_factorials",
+      "description": "The Pochhammer symbols, their expansion in the monomial basis, and the Stirling change-of-basis matrices."
+    },
+    {
+      "title": "James Stirling, Methodus Differentialis (1730)",
+      "url": "https://en.wikipedia.org/wiki/Methodus_Differentialis",
+      "description": "Original source studying the conversion between monomial and factorial bases and the finite-difference calculus."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "stirling-first-kind-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent entry's first open question: the falling-factorial companion of its rising-factorial identity, plus the second-kind expansion and the orthogonality relation proving the two Stirling matrices are inverse."
+    },
+    {
+      "targetId": "stirling-first-kind-oq-01",
+      "relationship": "extends",
+      "description": "Continues the grandparent's development of first-kind Stirling numbers into the signed / falling-factorial regime and the inversion duality with the second kind."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New gallery entry `stirling-first-kind-oq-01-oq-01-oq-01` answering the **first open question** of the parent `stirling-first-kind-oq-01-oq-01` (rising-factorial generating identity): *"Prove the companion identity for the falling factorial using the signed first-kind numbers, and combine with the second-kind generating identity to formalise that the two Stirling matrices are inverse."*

`Proofs/StirlingFirstKindOQ01OQ01OQ01.lean` (166 lines, namespace `StirlingMatrixInversion`, imports the parent) proves three linked facts over an arbitrary `CommRing R`:

1. **`coeff_descPochhammer_eq_stirlingFirst`** — the coefficients of the falling factorial are the **signed** first-kind numbers:
   `(descPochhammer R n).coeff k = (-1)^(n+k) · c(n,k)`.
2. **`X_pow_eq_sum_stirlingSecond_descPochhammer`** — the monomial expands in the falling-factorial basis with the **second-kind** numbers:
   `Xⁿ = ∑_{k=0}^{n} S(n,k) · descPochhammer R k`.
3. **`stirling_orthogonality`** — reading the coefficient of `Xᵐ` in `Xⁿ` two ways gives the **matrix-inversion / orthogonality** relation:
   `∑_k S(n,k) · s(k,m) = [m = n]`.

Plus the reusable engine **`X_mul_descPochhammer`**: `X · descPochhammer R k = descPochhammer R (k+1) + k · descPochhammer R k`, the falling-factorial analogue of `X·Xᵏ = Xᵏ⁺¹`.

## Mathlib gap

Mathlib defines `Nat.stirlingFirst`, `Nat.stirlingSecond`, `ascPochhammer`, and `descPochhammer` but connects **none** of them. The parent bridged the unsigned first kind to the rising factorial; this entry completes the falling-factorial (signed) side and proves the headline structural fact that the two triangular integer matrices are mutually inverse.

## Verification

- **0 axioms, 0 sorries.** All four theorems depend only on `[propext, Classical.choice, Quot.sound]` (confirmed via `#print axioms`). No `native_decide`.
- Built with `./proofs/scripts/docker-build.sh Proofs.StirlingFirstKindOQ01OQ01OQ01` → **Build succeeded**.

## Files

- `proofs/Proofs/StirlingFirstKindOQ01OQ01OQ01.lean` — the proof (166 lines, 4 theorems, 0 definitions)
- `src/data/proofs/stirling-first-kind-oq-01-oq-01-oq-01/{meta.json,annotations.json}` — gallery integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)