### PR TITLE
research(cauchy-schwarz-integral-lp-duality-synthesis): maximality gluing lemma — representer vanishes off the hull [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualityGluing.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualityGluing.lean
@@ -1,0 +1,106 @@
+/-
+# Lᵖ-duality synthesis — the maximality *gluing* lemma
+
+This file supplies the one step of the Folland-6.16 maximality construction that the
+existing standalone ingredients (`CauchySchwarzIntegralLpDualityIngredients.lean`,
+`CauchySchwarzIntegralLpDualityAnnihilator.lean`) did not yet package: the step that
+*forces the representer to vanish off the maximizing hull*.
+
+Setup recap (see `CauchySchwarzIntegralLpDualitySynthesis.lean`). To represent an
+arbitrary functional `φ ∈ (Lᵖ(μ))*` one exhausts `μ` by σ-finite sets, obtains a
+representer `g_S ∈ Lᵠ(μ.restrict S)` on each with `‖g_S‖_q ≤ ‖φ‖`, and realizes the
+supremum `c = ⨆_S ‖g_S‖_q` on a countable-union hull `T`. For any larger σ-finite
+`U ⊇ T` the representer `g_U` agrees a.e. with `g_T` on `T` (uniqueness — the
+annihilator lemma), so `‖g_U‖_{q, T} = ‖g_T‖_{q, T} = c`, while maximality gives
+`‖g_U‖_{q, U} ≤ c`. Combined with the automatic monotonicity `‖g_U‖_{q, T} ≤ ‖g_U‖_{q, U}`
+the two seminorms are equal, and the `q`-power additivity over `U = T ⊔ (U \ T)` then
+pins the leftover mass on `U \ T` to zero — i.e. `g_U = 0` a.e. off `T`. That is the
+content below.
+
+Concretely, `eLpNorm_ae_zero_on_diff_of_le` says: for a single `g ∈ Lᵠ(μ.restrict U)`
+and a measurable `T ⊆ U`, if `‖g‖_{q, U} ≤ ‖g‖_{q, T}` then `g = 0` a.e. on `U \ T`.
+In the maximality application `g = g_U` and the hypothesis is exactly
+`‖g_U‖_{q, U} ≤ ‖g_U‖_{q, T}` (the last equal to `‖g_T‖_{q, T}` via consistency), so
+the lemma applies directly. It is the qualitative heart of step 3.
+
+The proof combines the already-verified `q`-power additivity/monotonicity over a set
+difference (`RieszLpDualityIngredients.eLpNorm_rpow_restrict_{diff,mono}`) with the
+finiteness `‖g‖_{q, U} < ∞` (`MemLp`) to cancel the `U`-mass and read off
+`‖g‖_{q, U \ T}^q = 0`, then `eLpNorm_eq_zero_iff`.
+
+**Standalone / verified.** Imports only Mathlib and the Mathlib-only ingredients file;
+does *not* touch the build-broken σ-finite Riesz chain (`…Incomplete01.lean`). It is a
+kernel-checked building block for the eventual maximality construction, not itself the
+axiom elimination.
+-/
+
+import Mathlib
+import Proofs.CauchySchwarzIntegralLpDualityIngredients
+
+noncomputable section
+
+open MeasureTheory ENNReal
+
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+namespace RieszLpDualityGluing
+
+/-- **Maximality gluing lemma.** For `1 ≤ ... `, more precisely for a finite nonzero
+    exponent `q` (`q ≠ 0`, `q ≠ ∞`), a function `g ∈ Lᵠ(μ.restrict U)` and a measurable
+    `T ⊆ U`, if the Lᵠ-seminorm of `g` over `U` does not exceed its seminorm over the
+    subset `T`, then `g` vanishes a.e. on the difference `U \ T`.
+
+    This is the "maximality forces vanishing off the hull" step of the Riesz
+    representation reduction: monotonicity always gives `‖g‖_{q, T} ≤ ‖g‖_{q, U}`, so the
+    hypothesis `‖g‖_{q, U} ≤ ‖g‖_{q, T}` upgrades to equality, and the `q`-power
+    additivity `‖g‖_{q, U}^q = ‖g‖_{q, T}^q + ‖g‖_{q, U \ T}^q` (finite, since `g ∈ Lᵠ`)
+    forces the `U \ T` contribution to `0`. -/
+theorem eLpNorm_ae_zero_on_diff_of_le
+    {g : α → ℝ} {T U : Set α} (hT : MeasurableSet T) (hU : MeasurableSet U)
+    (hTU : T ⊆ U) {q : ℝ≥0∞} (hq0 : q ≠ 0) (hqtop : q ≠ ∞)
+    (hg : MemLp g q (μ.restrict U))
+    (hle : eLpNorm g q (μ.restrict U) ≤ eLpNorm g q (μ.restrict T)) :
+    g =ᵐ[μ.restrict (U \ T)] 0 := by
+  set r := q.toReal with hr_def
+  have hr : 0 < r := ENNReal.toReal_pos hq0 hqtop
+  -- `q`-power additivity over the disjoint decomposition `U = T ⊔ (U \ T)`.
+  have hadd :
+      eLpNorm g q (μ.restrict U) ^ r
+        = eLpNorm g q (μ.restrict T) ^ r
+          + eLpNorm g q (μ.restrict (U \ T)) ^ r :=
+    RieszLpDualityIngredients.eLpNorm_rpow_restrict_diff hT hU hTU hq0 hqtop
+  -- Monotonicity: `‖g‖_{q, T}^r ≤ ‖g‖_{q, U}^r`.
+  have hmono :
+      eLpNorm g q (μ.restrict T) ^ r ≤ eLpNorm g q (μ.restrict U) ^ r :=
+    RieszLpDualityIngredients.eLpNorm_rpow_restrict_mono hT hU hTU hq0 hqtop
+  -- Hypothesis raised to the `r`-th power: `‖g‖_{q, U}^r ≤ ‖g‖_{q, T}^r`.
+  have hle_r :
+      eLpNorm g q (μ.restrict U) ^ r ≤ eLpNorm g q (μ.restrict T) ^ r :=
+    ENNReal.rpow_le_rpow hle hr.le
+  -- Hence the two `r`-th powers are equal.
+  have heq : eLpNorm g q (μ.restrict U) ^ r = eLpNorm g q (μ.restrict T) ^ r :=
+    le_antisymm hle_r hmono
+  -- Finiteness of the `T`-mass, from `g ∈ Lᵠ(μ.restrict U)` and the norm equality.
+  have hfinU : eLpNorm g q (μ.restrict U) ^ r ≠ ⊤ :=
+    ENNReal.rpow_ne_top_of_nonneg hr.le hg.2.ne
+  have hTfin : eLpNorm g q (μ.restrict T) ^ r ≠ ⊤ := heq ▸ hfinU
+  -- From additivity + equality: `T^r + diff = T^r`, so `diff = 0` (cancel `T^r ≠ ⊤`).
+  have hcollapse :
+      eLpNorm g q (μ.restrict T) ^ r + eLpNorm g q (μ.restrict (U \ T)) ^ r
+        = eLpNorm g q (μ.restrict T) ^ r := by
+    rw [← hadd]; exact heq
+  have hdiff0 : eLpNorm g q (μ.restrict (U \ T)) ^ r = 0 :=
+    (ENNReal.add_right_inj hTfin).mp (hcollapse.trans (add_zero _).symm)
+  -- `x ^ r = 0` with `r > 0` gives `x = 0`.
+  have hzero : eLpNorm g q (μ.restrict (U \ T)) = 0 := by
+    rcases (ENNReal.rpow_eq_zero_iff.mp hdiff0) with ⟨h, _⟩ | ⟨_, hlt⟩
+    · exact h
+    · exact absurd hlt (not_lt.mpr hr.le)
+  -- Zero seminorm ⇒ a.e. zero.
+  have haesm : AEStronglyMeasurable g (μ.restrict (U \ T)) :=
+    hg.1.mono_measure (Measure.restrict_mono Set.diff_subset le_rfl)
+  exact (eLpNorm_eq_zero_iff haesm hq0).mp hzero
+
+end RieszLpDualityGluing
+
+end

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -752,3 +752,56 @@ unverifiable churn — the file can't build, so nothing in it is kernel-checkabl
 repair simply removes one more false `verified`-strand build breakage (integrity issue
 #28788) and keeps the entry that *hosts* the target axiom green so the eventual
 `axiom → theorem` swap has a compiling home.
+
+### 2026-06-30 (Session 13, researcher-3) — PROGRESS: maximality *gluing* lemma proved & verified standalone
+
+**Mode:** REVISIT. **Outcome:** progress — the one remaining qualitative step of the
+Folland-6.16 maximality construction ("representer vanishes off the hull") proved
+0-sorry/0-axiom in a new Mathlib-only file.
+
+**Build state re-measured (host `lake env lean`, toolchain v4.26.0, no Docker):**
+- `…OQ01OQ01Incomplete01.lean` still fails with **70 Mathlib-API-drift errors** (measured
+  this session): 12 application-type-mismatch, 10 failed-synthesize, 8 type-mismatch, 8
+  rewrite-pattern-not-found, 7 unsolved-goals, 6 simp-no-progress, 5 function-expected,
+  plus `Real.HolderTriple.one_lt_of_lt` gone (2 sites) and `Exists.{min,rpow_const}`
+  dot-notation breakage. Genuinely scattered, all-or-nothing (the file kernel-checks
+  nothing until every error clears), so a partial repair is unverifiable churn — not
+  attempted. It remains the true critical path to eliminating the axiom.
+
+**New verified ingredient — the maximality gluing lemma:**
+`proofs/Proofs/CauchySchwarzIntegralLpDualityGluing.lean`,
+`RieszLpDualityGluing.eLpNorm_ae_zero_on_diff_of_le`. For a finite nonzero exponent
+`q` (`q ≠ 0`, `q ≠ ∞`), `g ∈ Lᵠ(μ.restrict U)`, and measurable `T ⊆ U`:
+`eLpNorm g q (μ.restrict U) ≤ eLpNorm g q (μ.restrict T)  ⟹  g =ᵐ[μ.restrict (U \ T)] 0`.
+Standalone; imports only Mathlib + the Mathlib-only ingredients file (`_diff`/`_mono`).
+**Verified: `lake env lean` EXIT 0, 0 errors, 0 warnings.** (The confirmatory `#print
+axioms` rerun was blocked by concurrent shared-`.lake` churn — another agent was
+mid-`lake build`, so Mathlib data files were transiently missing — but the file fully
+elaborates and contains no `sorry`, no `axiom`, no `native_decide`; it inherits the
+`{propext, Classical.choice, Quot.sound}` profile of its dependencies, all of which are
+prior-verified axiom-free.)
+
+**Why this is the missing piece.** Steps 1–2 of the maximality argument were packaged in
+earlier sessions (`riesz_representer_on_sigmaFinite_set` with norm bound;
+`sigmaFinite_restrict_iUnion`; the `q`-power additivity/monotonicity lemmas
+`eLpNorm_rpow_restrict_{union,iUnion,diff,mono}`; the uniqueness/annihilator lemma
+`lp_pairing_eq_zero_ae_zero`). What none of them supplied is the qualitative *forcing*
+step: on a larger σ-finite `U ⊇` the hull `T`, the representer `g_U` — which agrees a.e.
+with `g_T` on `T` (annihilator) and has `‖g_U‖_{q,U} ≤ c = ‖g_T‖_{q,T} = ‖g_U‖_{q,T}` —
+must vanish on `U \ T`. That is exactly `eLpNorm_ae_zero_on_diff_of_le` (with `g = g_U`).
+Proof: monotonicity gives `‖·‖_{q,T} ≤ ‖·‖_{q,U}`, so the hypothesis upgrades to equality;
+`q`-power additivity `‖·‖_{q,U}^q = ‖·‖_{q,T}^q + ‖·‖_{q,U\T}^q` with finiteness (`MemLp`)
+cancels to `‖·‖_{q,U\T}^q = 0`, then `rpow_eq_zero_iff` + `eLpNorm_eq_zero_iff`.
+
+**Axiom NOT eliminated.** Parent `axiom riesz_lp_surjective` untouched; `axiomCount`
+unchanged. This session added the final qualitative ingredient of the maximality glue.
+
+**Corrected critical path (dependency order):**
+1. Repair `…OQ01OQ01Incomplete01.lean`'s 70 API-drift errors (multi-session mechanical;
+   the base file below it is green, so this is the true frontier).
+2. Rebuild `…OQ01OQ01.lean` → synthesis, fixing drift at each level.
+3. Assemble the maximality construction `riesz_lp_surjective_general` from the now-complete
+   ingredient set — step-1 representer+bound, `sigmaFinite_restrict_iUnion`, the `q`-power
+   additivity lemmas, `lp_pairing_eq_zero_ae_zero` (uniqueness), and this session's
+   `eLpNorm_ae_zero_on_diff_of_le` (vanishing off the hull) — discharge the `sorry`.
+4. Swap the parent axiom; correct any stale `verified` gallery metas in the strand (#28788).


### PR DESCRIPTION
## Summary

Adds `RieszLpDualityGluing.eLpNorm_ae_zero_on_diff_of_le` in a new standalone file `proofs/Proofs/CauchySchwarzIntegralLpDualityGluing.lean`:

> For a finite nonzero exponent `q` (`q ≠ 0`, `q ≠ ∞`), `g ∈ Lᵠ(μ.restrict U)`, and measurable `T ⊆ U`:
> `eLpNorm g q (μ.restrict U) ≤ eLpNorm g q (μ.restrict T)  ⟹  g =ᵐ[μ.restrict (U \ T)] 0`.

This is the last **qualitative** step of the Folland-6.16 maximality construction that reduces the arbitrary-measure Riesz representation `(Lᵖ)* ≅ Lᵠ` to the σ-finite case: on a larger σ-finite set `U ⊇` the maximizing hull `T`, the representer must vanish on `U \ T`. It is exactly the piece none of the earlier standalone ingredients supplied (step-1 representer+bound, `sigmaFinite_restrict_iUnion`, the `q`-power additivity/monotonicity lemmas, and the uniqueness/annihilator lemma).

**Proof:** monotonicity `‖·‖_{q,T} ≤ ‖·‖_{q,U}` upgrades the hypothesis to equality; `q`-power additivity `‖·‖_{q,U}^q = ‖·‖_{q,T}^q + ‖·‖_{q,U\T}^q` with `MemLp` finiteness cancels the `U`-mass to `‖·‖_{q,U\T}^q = 0`; then `rpow_eq_zero_iff` + `eLpNorm_eq_zero_iff`.

## Verification
- Standalone file: imports only Mathlib + the Mathlib-only ingredients file (reuses `eLpNorm_rpow_restrict_diff`/`_mono`). Does **not** touch the build-broken σ-finite Riesz chain (`…Incomplete01.lean`).
- Full `lake env lean` elaboration: **EXIT 0, 0 errors, 0 warnings.**
- No `sorry`, no `axiom`, no `native_decide` — inherits the `{propext, Classical.choice, Quot.sound}` profile of its dependencies. (The confirmatory `#print axioms` rerun was transiently blocked by concurrent shared-`.lake` churn from another agent's `lake build`; the file's full elaboration passed.)
- Auto-discovered by the `Proofs.*` lakefile glob, so CI compiles it.

**Axiom NOT eliminated** — the parent `axiom riesz_lp_surjective` is untouched; this adds the final maximality-glue ingredient. The remaining critical path is the multi-session repair of `Incomplete01.lean`'s 70 Mathlib-API-drift errors (documented in `knowledge.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)