### PR TITLE
research(divisibility-by-3-oq-02-oq-02): weighted digit-sum divisibility for composite moduli [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DivisibilityBy3OQ02OQ02.lean
+++ b/proofs/Proofs/DivisibilityBy3OQ02OQ02.lean
@@ -1,0 +1,225 @@
+import Mathlib
+
+/-
+# Weighted Digit-Sum Divisibility Rules for Composite Moduli (OQ-02-OQ-02)
+
+## The Open Question
+The parent file `DivisibilityBy3OQ02` proves the classical digit-sum rule
+`d ∣ n ↔ d ∣ digitSum_b(n)` **only when `d ∣ (b − 1)`** (casting out nines and
+its generalizations). Its second open question asks:
+
+> Can the theory extend to composite moduli **not** dividing `(b − 1)`?
+> E.g. divisibility by 7 in base 10 requires a *weighted* digit sum, since `7 ∤ 9`.
+
+This file answers that question in full generality.
+
+## What This Proves
+For an *arbitrary* modulus `m` and base `b`, define the **weighted digit sum**
+`W_{b,m}(n) = Σᵢ dᵢ · (bⁱ mod m)`, where `dᵢ` are the base-`b` digits of `n`.
+The positional weight `wᵢ = bⁱ mod m` is periodic in `i`. Then:
+
+* `weighted_modEq`  :  `n ≡ W_{b,m}(n)  [MOD m]`   (for every `b`, `m`, `n`)
+* `dvd_iff_dvd_weighted` :  `m ∣ n ↔ m ∣ W_{b,m}(n)`
+* `mod_eq_weighted_mod`  :  `n % m = W_{b,m}(n) % m`
+
+The classical `(b−1)`-rule is the special case where every weight collapses to `1`
+(because `b ≡ 1 (mod m)` forces `bⁱ ≡ 1`).  Here **no** hypothesis relating `m` to
+`b − 1` is needed — the weights carry the full modular information.
+
+## Key Specializations
+* **Divisibility by 7 in base 10** — weights `10ⁱ mod 7` cycle `[1,3,2,6,4,5]`
+  with period 6 (since `10⁶ ≡ 1 (mod 7)`, a Fermat consequence).
+* **Divisibility by 11 in base 10** — weights `10ⁱ mod 11` cycle `[1,10,1,10,…]`,
+  recovering the alternating digit-sum rule (parent open question 1).
+
+## Key Mathematical Insight
+`n = Σᵢ dᵢ bⁱ` exactly (`Nat.ofDigits_eq_sum_mapIdx`).  Reducing each positional
+weight `bⁱ` modulo `m` changes the sum only within its residue class mod `m`, so
+the divisibility test is preserved.  The reduction `bⁱ ↦ bⁱ mod m` is what makes
+the test *finite/periodic* even when `b ≢ 1 (mod m)`.
+
+## Mathlib Dependencies
+- `Nat.ofDigits_digits`        : `ofDigits b (digits b n) = n`
+- `Nat.ofDigits_eq_sum_mapIdx` : `ofDigits b L = (L.mapIdx fun i a => a * b^i).sum`
+- `Nat.modEq_zero_iff_dvd`, `Nat.mod_modEq`, `List.mapIdx_cons`
+-/
+
+namespace DivisibilityBy3OQ02OQ02
+
+open Nat List
+
+-- ============================================================
+-- Part I: A congruence lemma for indexed list sums
+-- ============================================================
+
+/-- If two indexed weight functions agree modulo `m` at every position, then the
+    `mapIdx`-sums they produce agree modulo `m`.  Proved by induction on the list,
+    generalizing over the functions so the index shift in `mapIdx_cons` is handled. -/
+theorem mapIdx_sum_modEq {m : ℕ} (f g : ℕ → ℕ → ℕ)
+    (h : ∀ i d, f i d ≡ g i d [MOD m]) :
+    ∀ L : List ℕ, (L.mapIdx f).sum ≡ (L.mapIdx g).sum [MOD m]
+  | [] => by
+      simp only [List.mapIdx_nil, List.sum_nil]
+      exact Nat.ModEq.refl 0
+  | a :: t => by
+      simp only [List.mapIdx_cons, List.sum_cons]
+      exact (h 0 a).add
+        (mapIdx_sum_modEq (fun i => f (i + 1)) (fun i => g (i + 1))
+          (fun i d => h (i + 1) d) t)
+
+-- ============================================================
+-- Part II: The weighted digit sum and the universal rule
+-- ============================================================
+
+/-- The **weighted digit sum** of `n` in base `b` relative to modulus `m`:
+    `Σᵢ dᵢ · (bⁱ mod m)` where `dᵢ = (Nat.digits b n)`.
+    The weights `bⁱ mod m` are periodic in `i`. -/
+def weightedDigitSum (b m n : ℕ) : ℕ :=
+  ((Nat.digits b n).mapIdx fun i d => d * (b ^ i % m)).sum
+
+/-- **Universal weighted rule.** For *any* base `b` and modulus `m`, a number is
+    congruent modulo `m` to its weighted digit sum.  No relation between `m` and
+    `b − 1` is required — the weights `bⁱ mod m` encode everything. -/
+theorem weighted_modEq (b m n : ℕ) :
+    n ≡ weightedDigitSum b m n [MOD m] := by
+  unfold weightedDigitSum
+  -- n = Σᵢ dᵢ · bⁱ  (exact identity), then reduce each weight bⁱ modulo m.
+  have hn : ((Nat.digits b n).mapIdx fun i d => d * b ^ i).sum = n := by
+    rw [← Nat.ofDigits_eq_sum_mapIdx, Nat.ofDigits_digits]
+  calc n = ((Nat.digits b n).mapIdx fun i d => d * b ^ i).sum := hn.symm
+    _ ≡ ((Nat.digits b n).mapIdx fun i d => d * (b ^ i % m)).sum [MOD m] :=
+        mapIdx_sum_modEq _ _
+          (fun i d => Nat.ModEq.mul_left d (Nat.mod_modEq _ _).symm) _
+
+/-- **Weighted divisibility test.** `m ∣ n` iff `m` divides the weighted digit sum.
+    This is the requested extension to composite moduli not dividing `b − 1`. -/
+theorem dvd_iff_dvd_weighted (b m n : ℕ) :
+    m ∣ n ↔ m ∣ weightedDigitSum b m n := by
+  rw [← Nat.modEq_zero_iff_dvd, ← Nat.modEq_zero_iff_dvd]
+  exact ⟨fun h => (weighted_modEq b m n).symm.trans h,
+         fun h => (weighted_modEq b m n).trans h⟩
+
+/-- The remainder of `n` mod `m` equals that of its weighted digit sum. -/
+theorem mod_eq_weighted_mod (b m n : ℕ) :
+    n % m = weightedDigitSum b m n % m :=
+  weighted_modEq b m n
+
+-- ============================================================
+-- Part III: The (b−1) rule is the collapsed special case
+-- ============================================================
+
+/-- When `m ∣ (b − 1)` (so `b ≡ 1 mod m`), every weight `bⁱ mod m` equals `1`,
+    and the weighted digit sum collapses to the ordinary digit sum.  This shows the
+    parent's `(b−1)`-rule is precisely the constant-weight specialization. -/
+theorem weight_eq_one_of_dvd_pred (b m : ℕ) (hm : 2 ≤ m) (hb : 2 ≤ b)
+    (hdiv : m ∣ (b - 1)) (i : ℕ) : b ^ i % m = 1 := by
+  have hb1 : b % m = 1 := by
+    obtain ⟨k, hk⟩ := hdiv
+    have : b = m * k + 1 := by omega
+    rw [this, show m * k + 1 = 1 + m * k from by omega,
+      Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt (by omega)]
+  have hpow : b ^ i % m = (b % m) ^ i % m := by rw [Nat.pow_mod]
+  rw [hpow, hb1, one_pow, Nat.mod_eq_of_lt (by omega)]
+
+-- ============================================================
+-- Part IV: Divisibility by 7 in base 10  (the motivating case)
+-- ============================================================
+
+/-- **Divisibility by 7, base 10.** `7 ∤ 9`, so no ordinary digit-sum rule exists;
+    the weighted rule with periodic weights `10ⁱ mod 7` supplies the test. -/
+theorem seven_dvd_iff (n : ℕ) :
+    7 ∣ n ↔ 7 ∣ weightedDigitSum 10 7 n :=
+  dvd_iff_dvd_weighted 10 7 n
+
+/-- The base-10 weights for modulus 7 are `[1,3,2,6,4,5]`, repeating with period 6.
+    The period is governed by `10⁶ ≡ 1 (mod 7)` (Fermat: `7` prime, `7 ∤ 10`). -/
+theorem weights_seven_period : ∀ i, 10 ^ (i + 6) % 7 = 10 ^ i % 7 := by
+  intro i
+  have h6 : (10 : ℕ) ^ 6 % 7 = 1 := by decide
+  calc 10 ^ (i + 6) % 7 = (10 ^ i % 7) * (10 ^ 6 % 7) % 7 := by
+          rw [pow_add, Nat.mul_mod]
+    _ = (10 ^ i % 7) * 1 % 7 := by rw [h6]
+    _ = 10 ^ i % 7 := by rw [mul_one, Nat.mod_mod]
+
+/-- The first six weights, exhibiting the cycle `[1,3,2,6,4,5]`. -/
+example : List.map (fun i => 10 ^ i % 7) [0,1,2,3,4,5] = [1,3,2,6,4,5] := by decide
+
+/-- `1001 = 7 · 11 · 13`.  Digits `[1,0,0,1]`, weighted sum `1·1 + 1·6 = 7`. -/
+example : 7 ∣ 1001 := by rw [seven_dvd_iff]; native_decide
+
+/-- `1000` is not divisible by 7: weighted sum `1·6 = 6`, and `7 ∤ 6`. -/
+example : ¬ (7 ∣ 1000) := by rw [seven_dvd_iff]; native_decide
+
+/-- A larger witness: `123452 = 7 · 17636`. -/
+example : 7 ∣ 123452 := by rw [seven_dvd_iff]; native_decide
+
+/-- Remainder form: `n % 7` is computable from the weighted digit sum. -/
+theorem seven_mod_eq (n : ℕ) : n % 7 = weightedDigitSum 10 7 n % 7 :=
+  mod_eq_weighted_mod 10 7 n
+
+-- ============================================================
+-- Part V: Divisibility by 11 — recovering the alternating rule
+-- ============================================================
+
+/-- **Divisibility by 11, base 10.**  Here `11 ∣ (10 + 1)`, and the weights
+    `10ⁱ mod 11` cycle `[1,10,1,10,…]`; since `10 ≡ −1 (mod 11)` this is exactly
+    the classical alternating digit-sum test (parent open question 1). -/
+theorem eleven_dvd_iff (n : ℕ) :
+    11 ∣ n ↔ 11 ∣ weightedDigitSum 10 11 n :=
+  dvd_iff_dvd_weighted 10 11 n
+
+/-- The base-10 weights for modulus 11 alternate `[1,10,1,10,…]` with period 2. -/
+theorem weights_eleven_period : ∀ i, 10 ^ (i + 2) % 11 = 10 ^ i % 11 := by
+  intro i
+  have h2 : (10 : ℕ) ^ 2 % 11 = 1 := by decide
+  calc 10 ^ (i + 2) % 11 = (10 ^ i % 11) * (10 ^ 2 % 11) % 11 := by
+          rw [pow_add, Nat.mul_mod]
+    _ = (10 ^ i % 11) * 1 % 11 := by rw [h2]
+    _ = 10 ^ i % 11 := by rw [mul_one, Nat.mod_mod]
+
+/-- The first weights exhibit the alternating pattern `[1,10,1,10,1,10]`. -/
+example : List.map (fun i => 10 ^ i % 11) [0,1,2,3,4,5] = [1,10,1,10,1,10] := by decide
+
+/-- `2728 = 11 · 248`.  Alternating (weighted) sum works. -/
+example : 11 ∣ 2728 := by rw [eleven_dvd_iff]; native_decide
+
+/-- `2729` is not divisible by 11. -/
+example : ¬ (11 ∣ 2729) := by rw [eleven_dvd_iff]; native_decide
+
+-- ============================================================
+-- Part VI: Divisibility by 13 — another non-(b−1) modulus
+-- ============================================================
+
+/-- **Divisibility by 13, base 10.**  `13 ∤ 9`; weights `10ⁱ mod 13` cycle with
+    period 6 as well (`10⁶ ≡ 1 mod 13`). -/
+theorem thirteen_dvd_iff (n : ℕ) :
+    13 ∣ n ↔ 13 ∣ weightedDigitSum 10 13 n :=
+  dvd_iff_dvd_weighted 10 13 n
+
+/-- `10⁶ ≡ 1 (mod 13)`, so the base-10 weights for 13 also have period 6. -/
+theorem weights_thirteen_period : ∀ i, 10 ^ (i + 6) % 13 = 10 ^ i % 13 := by
+  intro i
+  have h6 : (10 : ℕ) ^ 6 % 13 = 1 := by decide
+  calc 10 ^ (i + 6) % 13 = (10 ^ i % 13) * (10 ^ 6 % 13) % 13 := by
+          rw [pow_add, Nat.mul_mod]
+    _ = (10 ^ i % 13) * 1 % 13 := by rw [h6]
+    _ = 10 ^ i % 13 := by rw [mul_one, Nat.mod_mod]
+
+/-- `1001 = 7 · 11 · 13`, so `13 ∣ 1001` too. -/
+example : 13 ∣ 1001 := by rw [thirteen_dvd_iff]; native_decide
+
+-- ============================================================
+-- Part VII: Consistency with the parent digit-sum rule
+-- ============================================================
+
+/-- Sanity check: for `m = 9` (which *does* divide `10 − 1`), all weights are `1`,
+    so the weighted rule reduces to the parent's plain digit-sum rule for 9. -/
+theorem nine_weights_all_one (i : ℕ) : 10 ^ i % 9 = 1 :=
+  weight_eq_one_of_dvd_pred 10 9 (by omega) (by omega) ⟨1, by omega⟩ i
+
+/-- Consequently `9 ∣ n ↔ 9 ∣ weightedDigitSum 10 9 n`, matching casting-out-nines. -/
+theorem nine_dvd_iff (n : ℕ) :
+    9 ∣ n ↔ 9 ∣ weightedDigitSum 10 9 n :=
+  dvd_iff_dvd_weighted 10 9 n
+
+end DivisibilityBy3OQ02OQ02

--- a/src/data/proofs/divisibility-by-3-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/divisibility-by-3-oq-02-oq-02/annotations.json
@@ -1,0 +1,145 @@
+[
+  {
+    "id": "ann-div3oq02oq02-mapidx-modeq",
+    "proofId": "divisibility-by-3-oq-02-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 71
+    },
+    "type": "technique",
+    "title": "Lifting Termwise Congruence to Indexed Sums",
+    "content": "`mapIdx_sum_modEq` is the workhorse lemma: if two positional weight functions $f, g : \\mathbb{N} \\to \\mathbb{N} \\to \\mathbb{N}$ satisfy $f\\,i\\,d \\equiv g\\,i\\,d \\pmod m$ at every index $i$, then the sums $\\sum \\mathrm{mapIdx}\\,f\\,L$ and $\\sum \\mathrm{mapIdx}\\,g\\,L$ agree modulo $m$. It is proved by induction on $L$ **generalizing over $f$ and $g$**: the cons case uses `List.mapIdx_cons`, which rewrites $\\mathrm{mapIdx}\\,f\\,(a::t)$ to $f\\,0\\,a :: \\mathrm{mapIdx}\\,(\\lambda i \\Rightarrow f(i+1))\\,t$, so the induction hypothesis must apply to the *shifted* weight functions. Generalizing the functions makes this automatic.",
+    "mathContext": "$(\\forall i\\,d,\\ f\\,i\\,d \\equiv g\\,i\\,d \\ [\\mathrm{MOD}\\ m]) \\implies (\\mathrm{mapIdx}\\,f\\,L).\\mathrm{sum} \\equiv (\\mathrm{mapIdx}\\,g\\,L).\\mathrm{sum} \\ [\\mathrm{MOD}\\ m]$",
+    "significance": "key",
+    "relatedConcepts": [
+      "list induction",
+      "generalizing the induction hypothesis",
+      "Nat.ModEq.add"
+    ]
+  },
+  {
+    "id": "ann-div3oq02oq02-weighted-def",
+    "proofId": "divisibility-by-3-oq-02-oq-02",
+    "range": {
+      "startLine": 73,
+      "endLine": 79
+    },
+    "type": "concept",
+    "title": "The Weighted Digit Sum",
+    "content": "`weightedDigitSum b m n = Σᵢ dᵢ · (bⁱ mod m)` where $d_i$ are the base-$b$ digits of $n$. Unlike the ordinary digit sum (which weights every digit by 1), each digit is scaled by the *periodic* positional weight $w_i = b^i \\bmod m$. This weight is precisely what the unweighted digit sum throws away when $b \\not\\equiv 1 \\pmod m$. For divisibility by 7 in base 10 the weights cycle $[1,3,2,6,4,5]$; for 11 they cycle $[1,10,1,10,\\dots]$.",
+    "mathContext": "$W_{b,m}(n) = \\sum_i d_i\\,(b^i \\bmod m)$, weights $w_i = b^i \\bmod m$ periodic in $i$",
+    "significance": "central",
+    "relatedConcepts": [
+      "positional notation",
+      "Nat.digits",
+      "modular periodicity"
+    ]
+  },
+  {
+    "id": "ann-div3oq02oq02-weighted-modeq",
+    "proofId": "divisibility-by-3-oq-02-oq-02",
+    "range": {
+      "startLine": 81,
+      "endLine": 92
+    },
+    "type": "concept",
+    "title": "The Universal Weighted Rule (Main Theorem)",
+    "content": "`weighted_modEq`: for **every** base $b$ and modulus $m$, $n \\equiv W_{b,m}(n) \\pmod m$. The proof is a two-line congruence chain. First, Mathlib's `Nat.ofDigits_eq_sum_mapIdx` gives the *exact* identity $n = \\mathrm{ofDigits}\\,b\\,(\\mathrm{digits}\\,b\\,n) = \\sum_i d_i b^i$ (via `ofDigits_digits`). Then `mapIdx_sum_modEq` reduces each weight $b^i$ to $b^i \\bmod m$, justified termwise by $b^i \\equiv b^i \\bmod m \\pmod m$ (`Nat.mod_modEq`) scaled by the digit. Crucially, **no hypothesis relates $m$ to $b-1$** — this is exactly the generalization the parent open question requested.",
+    "mathContext": "$n = \\sum_i d_i b^i \\equiv \\sum_i d_i (b^i \\bmod m) = W_{b,m}(n) \\pmod m$, for all $b, m, n$",
+    "significance": "central",
+    "relatedConcepts": [
+      "Nat.ofDigits_eq_sum_mapIdx",
+      "Nat.ofDigits_digits",
+      "Nat.mod_modEq"
+    ]
+  },
+  {
+    "id": "ann-div3oq02oq02-dvd-iff",
+    "proofId": "divisibility-by-3-oq-02-oq-02",
+    "range": {
+      "startLine": 94,
+      "endLine": 99
+    },
+    "type": "concept",
+    "title": "Weighted Divisibility Test",
+    "content": "`dvd_iff_dvd_weighted`: $m \\mid n \\iff m \\mid W_{b,m}(n)$. This is the practical divisibility rule for composite moduli not dividing $b-1$ (e.g. 7 in base 10). It follows from the main congruence by rewriting both sides with `Nat.modEq_zero_iff_dvd` and transporting the congruence $n \\equiv W(n)$ across $0$.",
+    "mathContext": "$m \\mid n \\iff m \\mid W_{b,m}(n)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.modEq_zero_iff_dvd",
+      "Nat.ModEq.trans"
+    ]
+  },
+  {
+    "id": "ann-div3oq02oq02-collapse",
+    "proofId": "divisibility-by-3-oq-02-oq-02",
+    "range": {
+      "startLine": 112,
+      "endLine": 120
+    },
+    "type": "concept",
+    "title": "Recovering the Parent's (b−1) Rule",
+    "content": "`weight_eq_one_of_dvd_pred`: when $m \\mid (b-1)$, so $b \\equiv 1 \\pmod m$, every positional weight satisfies $b^i \\bmod m = 1$ (via `Nat.pow_mod` and $1^i = 1$). Thus $W_{b,m}(n) = \\sum_i d_i \\cdot 1 = \\text{ordinary digit sum}$, and the weighted rule degenerates to the parent's classical $(b-1)$-rule. This pinpoints casting-out-nines as the constant-weight special case of the weighted theory.",
+    "mathContext": "$m \\mid (b-1) \\implies b^i \\bmod m = 1 \\implies W_{b,m}(n) = \\sum_i d_i$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.pow_mod",
+      "casting out nines",
+      "degenerate case"
+    ]
+  },
+  {
+    "id": "ann-div3oq02oq02-seven",
+    "proofId": "divisibility-by-3-oq-02-oq-02",
+    "range": {
+      "startLine": 128,
+      "endLine": 152
+    },
+    "type": "example",
+    "title": "Divisibility by 7 in Base 10",
+    "content": "The motivating case: $7 \\nmid 9$, so **no** unweighted digit-sum rule exists. The weighted rule `seven_dvd_iff` supplies $7 \\mid n \\iff 7 \\mid W_{10,7}(n)$ with weights $10^i \\bmod 7$ cycling $[1,3,2,6,4,5]$. `weights_seven_period` proves period 6 from $10^6 \\equiv 1 \\pmod 7$ (Fermat's little theorem, $7$ prime). Worked witness: $1001 = 7 \\cdot 11 \\cdot 13$ has digits $[1,0,0,1]$, weighted sum $1\\cdot 1 + 1 \\cdot 6 = 7$, and $7 \\mid 7$. The non-example $1000$ gives weighted sum $6$, and $7 \\nmid 6$.",
+    "mathContext": "Weights $10^i \\bmod 7 = [1,3,2,6,4,5]$, period 6; $1001$: $1\\cdot1 + 0 + 0 + 1\\cdot6 = 7$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fermat's little theorem",
+      "multiplicative order",
+      "native_decide"
+    ]
+  },
+  {
+    "id": "ann-div3oq02oq02-eleven",
+    "proofId": "divisibility-by-3-oq-02-oq-02",
+    "range": {
+      "startLine": 165,
+      "endLine": 188
+    },
+    "type": "concept",
+    "title": "Divisibility by 11 — The Alternating Rule",
+    "content": "`eleven_dvd_iff` specializes the weighted rule to $m = 11$, where the weights $10^i \\bmod 11$ cycle $[1,10,1,10,\\dots]$ with period 2 (`weights_eleven_period`). Since $10 \\equiv -1 \\pmod{11}$, weighting by $[1,10,1,10,\\dots]$ is congruent to the classical *alternating* digit sum $d_0 - d_1 + d_2 - \\cdots$. This answers the parent's **first** open question (the $b+1$ alternating rule) as a corollary of the general weighted framework, rather than as a separate development.",
+    "mathContext": "$10 \\equiv -1 \\pmod{11}$; weights $[1,10,1,10,\\dots] \\equiv [1,-1,1,-1,\\dots]$ = alternating digit sum",
+    "significance": "key",
+    "relatedConcepts": [
+      "alternating digit sum",
+      "b+1 divisibility rule",
+      "parent open question 1"
+    ]
+  },
+  {
+    "id": "ann-div3oq02oq02-thirteen-nine",
+    "proofId": "divisibility-by-3-oq-02-oq-02",
+    "range": {
+      "startLine": 193,
+      "endLine": 221
+    },
+    "type": "example",
+    "title": "Divisibility by 13, and Consistency with Casting-Out-Nines",
+    "content": "`thirteen_dvd_iff` gives a second non-$(b-1)$ modulus: weights $10^i \\bmod 13$ have period 6 ($10^6 \\equiv 1 \\pmod{13}$), witnessed by $13 \\mid 1001$. At the other extreme, `nine_weights_all_one` shows every base-10 weight for $m = 9$ is $1$ (since $9 \\mid (10-1)$), so `nine_dvd_iff` reduces the weighted rule to casting-out-nines — confirming continuity with the parent proof across the full range of moduli.",
+    "mathContext": "$13$: period 6 ($10^6 \\equiv 1 \\bmod 13$); $9$: all weights $1$ (recovers digit-sum rule)",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicative order",
+      "casting out nines",
+      "consistency check"
+    ]
+  }
+]

--- a/src/data/proofs/divisibility-by-3-oq-02-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-02-oq-02/meta.json
@@ -1,0 +1,250 @@
+{
+  "id": "divisibility-by-3-oq-02-oq-02",
+  "title": "Weighted Digit-Sum Divisibility Rules for Composite Moduli",
+  "slug": "divisibility-by-3-oq-02-oq-02",
+  "description": "Answers the parent's open question on composite moduli not dividing (b−1). For arbitrary base b and modulus m, defines the weighted digit sum W(n) = Σᵢ dᵢ·(bⁱ mod m) and proves m ∣ n ↔ m ∣ W(n) — no relation between m and b−1 required. Specializes to divisibility by 7 (weights [1,3,2,6,4,5]), 11 (alternating), and 13 in base 10. Verified, 0 axioms.",
+  "meta": {
+    "author": "Weighted digit-sum divisibility (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Divisibility_rule",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "modular-arithmetic",
+      "divisibility",
+      "digit-sums",
+      "research",
+      "open-problem"
+    ],
+    "proofRepoPath": "Proofs/DivisibilityBy3OQ02OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "prerequisites": [
+      "modular arithmetic",
+      "digit representation",
+      "geometric periodicity of bⁱ mod m"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.ofDigits_eq_sum_mapIdx",
+        "description": "ofDigits b L = (L.mapIdx fun i a => a * b^i).sum — the exact positional expansion",
+        "module": "Mathlib.Data.Nat.Digits.Lemmas"
+      },
+      {
+        "theorem": "Nat.ofDigits_digits",
+        "description": "ofDigits b (digits b n) = n — recovers n from its base-b digits",
+        "module": "Mathlib.Data.Nat.Digits.Defs"
+      },
+      {
+        "theorem": "Nat.mod_modEq",
+        "description": "a % n ≡ a [MOD n] — reducing a weight modulo m preserves its residue class",
+        "module": "Mathlib.Data.Nat.ModCast"
+      },
+      {
+        "theorem": "List.mapIdx_cons",
+        "description": "mapIdx f (a :: l) = f 0 a :: mapIdx (fun i => f (i+1)) l — index-shift for the induction",
+        "module": "Init.Data.List.MapIdx"
+      }
+    ],
+    "originalContributions": [
+      "mapIdx_sum_modEq: termwise congruence lifts to indexed list sums (mapIdx), proved by induction generalizing the weight functions",
+      "weightedDigitSum b m n = Σᵢ dᵢ·(bⁱ mod m): the general weighted digit sum with periodic positional weights",
+      "weighted_modEq: n ≡ weightedDigitSum b m n [MOD m] for EVERY base b and modulus m — no hypothesis relating m to b−1",
+      "dvd_iff_dvd_weighted: m ∣ n ↔ m ∣ weightedDigitSum b m n, the requested composite-modulus divisibility test",
+      "weight_eq_one_of_dvd_pred: when m ∣ (b−1) all weights collapse to 1, recovering the parent's constant-weight (b−1)-rule",
+      "Divisibility-by-7 in base 10 with weights [1,3,2,6,4,5] and period-6 lemma (10⁶ ≡ 1 mod 7)",
+      "Divisibility-by-11 recovering the alternating digit-sum rule (weights [1,10,1,10,…], period 2) — answers parent open question 1",
+      "Divisibility-by-13 with period-6 weights (10⁶ ≡ 1 mod 13)"
+    ],
+    "dateAdded": "2026-06-30",
+    "axiomCount": 0,
+    "lineCount": 225,
+    "theoremCount": 14,
+    "relatedProblems": [
+      {
+        "id": "divisibility-by-3-oq-02",
+        "relationship": "Parent: proves the digit-sum rule only when d | (b−1); this child removes that restriction via weighted digit sums for arbitrary moduli"
+      }
+    ],
+    "assumptions": "0 axioms, 0 sorries. The general weighted rule is derived from Mathlib's exact positional expansion Nat.ofDigits_eq_sum_mapIdx together with a termwise modular reduction. Numerical witnesses use native_decide, which depends on Lean.ofReduceBool; the substantive theorems (weighted_modEq, dvd_iff_dvd_weighted, the period lemmas) are proved without it.",
+    "mathlib_version": "4.27.0",
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The classical digit-sum divisibility tests (casting out nines, base-10 divisibility by 3 and 9) all rest on the coincidence $b \\equiv 1 \\pmod{d}$, which forces every positional weight $b^i$ to equal $1$ modulo $d$. This breaks down for moduli that do not divide $b-1$: there is no unweighted digit-sum test for divisibility by 7 in base 10, because $7 \\nmid 9$. The historical fix — used in mental-arithmetic tricks and known since Gauss's treatment of positional congruences — is to attach a *periodic weight* $w_i = b^i \\bmod m$ to each digit. For 7 in base 10 these weights cycle $[1,3,2,6,4,5]$ with period 6, governed by Fermat's little theorem ($10^6 \\equiv 1 \\pmod 7$). This formalization proves the general weighted rule and recovers the classical unweighted and alternating rules as special cases.",
+    "problemStatement": "**Weighted digit-sum divisibility (parent open question 2):**\n\nFor any base $b$, modulus $m$, and $n \\in \\mathbb{N}$ with base-$b$ digits $d_i$, define the weighted digit sum\n$$W_{b,m}(n) = \\sum_i d_i \\, (b^i \\bmod m).$$\nThen\n$$n \\equiv W_{b,m}(n) \\pmod{m}, \\qquad m \\mid n \\iff m \\mid W_{b,m}(n).$$\nNo relation between $m$ and $b-1$ is assumed; the periodic weights $b^i \\bmod m$ carry the full modular information.",
+    "text": "A 225-line formalization answering the parent's second open question: extending digit-sum divisibility tests to composite moduli not dividing $b-1$. The core is a single general theorem `weighted_modEq`: for every base $b$ and modulus $m$, a number is congruent modulo $m$ to its weighted digit sum $W_{b,m}(n) = \\sum_i d_i\\,(b^i \\bmod m)$. The proof combines Mathlib's exact positional expansion `Nat.ofDigits_eq_sum_mapIdx` (giving $n = \\sum_i d_i b^i$ exactly) with a reusable lemma `mapIdx_sum_modEq` showing that termwise congruences lift to indexed list sums — proved by induction generalizing over the weight functions to absorb the index shift in `mapIdx_cons`. The divisibility form `dvd_iff_dvd_weighted` follows immediately. `weight_eq_one_of_dvd_pred` shows the parent's $(b-1)$-rule is exactly the degenerate case where all weights collapse to $1$. Three worked specializations demonstrate the theory: divisibility by 7 in base 10 (weights $[1,3,2,6,4,5]$, period 6 via $10^6 \\equiv 1 \\bmod 7$), by 11 (weights $[1,10,1,10,\\dots]$, recovering the alternating digit-sum rule and answering the parent's first open question), and by 13 (period 6). Numerical witnesses ($7 \\mid 1001$, $11 \\mid 2728$, $13 \\mid 1001$) are checked with `native_decide`.",
+    "proofStrategy": "Exact expansion then modular reduction. Step 1: $n = \\mathrm{ofDigits}\\,b\\,(\\mathrm{digits}\\,b\\,n) = \\sum_i d_i b^i$ exactly (Mathlib). Step 2: reduce each positional weight $b^i \\mapsto b^i \\bmod m$; since $b^i \\equiv b^i \\bmod m \\pmod m$, each term changes only within its residue class, so the whole sum is unchanged modulo $m$. The lifting of termwise congruence to the `mapIdx`-indexed sum is the lemma `mapIdx_sum_modEq`, proved by list induction with the weight functions generalized. Periodicity of the weights (used to make the test finite) follows from $b^{\\mathrm{ord}} \\equiv 1$, checked by `decide` for the concrete moduli.",
+    "keyInsights": [
+      "The exact identity n = Σᵢ dᵢ·bⁱ (Mathlib's ofDigits_eq_sum_mapIdx) is the right starting point — reducing weights mod m afterwards is a pure congruence step",
+      "No hypothesis linking m to b−1 is needed: the periodic weights bⁱ mod m encode exactly the modular information the unweighted digit sum discards",
+      "The parent's (b−1)-rule is the constant-weight degeneration: m | (b−1) ⟹ every weight is 1",
+      "Divisibility by 7 in base 10 uses the period-6 weight cycle [1,3,2,6,4,5], a Fermat consequence (10⁶ ≡ 1 mod 7)",
+      "Divisibility by 11 gives weights [1,10,1,10,…]; since 10 ≡ −1 (mod 11) this is exactly the classical alternating digit-sum test, answering the parent's first open question as a corollary",
+      "mapIdx_sum_modEq is a reusable congruence-lifting lemma for any positionally-weighted digit statistic"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "digit representation",
+      "geometric periodicity of bⁱ mod m"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Documentation",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Imports Mathlib, states the parent open question (composite moduli not dividing b−1), and documents the weighted digit-sum approach: W(n) = Σᵢ dᵢ·(bⁱ mod m) with periodic weights.",
+      "mathContext": "The weighted rule generalizes casting-out-nines: when b ≢ 1 (mod m) the positional weights bⁱ mod m are non-constant but periodic, and n ≡ Σᵢ dᵢ (bⁱ mod m) (mod m)."
+    },
+    {
+      "id": "mapidx-congruence",
+      "title": "Part I: A congruence lemma for indexed list sums",
+      "startLine": 56,
+      "endLine": 72,
+      "summary": "mapIdx_sum_modEq: if two indexed weight functions agree modulo m at every position, their mapIdx-sums agree modulo m. Proved by list induction generalizing over the functions so the index shift in mapIdx_cons is handled.",
+      "mathContext": "Termwise congruence f i d ≡ g i d [MOD m] lifts to (mapIdx f L).sum ≡ (mapIdx g L).sum [MOD m]."
+    },
+    {
+      "id": "universal-rule",
+      "title": "Part II: The weighted digit sum and the universal rule",
+      "startLine": 73,
+      "endLine": 103,
+      "summary": "Defines weightedDigitSum b m n and proves weighted_modEq (n ≡ W(n) [MOD m]), dvd_iff_dvd_weighted (m | n ↔ m | W(n)), and mod_eq_weighted_mod (n % m = W(n) % m). The main theorem needs no relation between m and b−1.",
+      "mathContext": "n = Σᵢ dᵢ bⁱ (exact) ≡ Σᵢ dᵢ (bⁱ mod m) (mod m) = W(n)."
+    },
+    {
+      "id": "collapse",
+      "title": "Part III: The (b−1) rule as the collapsed special case",
+      "startLine": 104,
+      "endLine": 120,
+      "summary": "weight_eq_one_of_dvd_pred: when m | (b−1) every weight bⁱ mod m equals 1, so the weighted sum collapses to the ordinary digit sum, recovering the parent's rule.",
+      "mathContext": "m | (b−1) ⟹ b ≡ 1 (mod m) ⟹ bⁱ ≡ 1 ⟹ W(n) = digit sum."
+    },
+    {
+      "id": "seven",
+      "title": "Part IV: Divisibility by 7 in base 10",
+      "startLine": 121,
+      "endLine": 158,
+      "summary": "seven_dvd_iff (7 | n ↔ 7 | W₁₀,₇(n)), weights_seven_period (10^(i+6) ≡ 10^i mod 7), the explicit cycle [1,3,2,6,4,5], and native_decide witnesses (7 | 1001, 7 ∤ 1000, 7 | 123452).",
+      "mathContext": "7 ∤ 9 so no unweighted rule exists; weights 10ⁱ mod 7 cycle [1,3,2,6,4,5] with period 6 (Fermat: 10⁶ ≡ 1 mod 7)."
+    },
+    {
+      "id": "eleven",
+      "title": "Part V: Divisibility by 11 — the alternating rule",
+      "startLine": 159,
+      "endLine": 191,
+      "summary": "eleven_dvd_iff, weights_eleven_period (period 2), the alternating pattern [1,10,1,10,…], and native_decide witnesses. Recovers the classical alternating digit-sum test, answering the parent's first open question.",
+      "mathContext": "10 ≡ −1 (mod 11), so weights 10ⁱ mod 11 = [1,10,1,10,…]; the weighted sum is the alternating digit sum modulo 11."
+    },
+    {
+      "id": "thirteen",
+      "title": "Part VI: Divisibility by 13",
+      "startLine": 192,
+      "endLine": 212,
+      "summary": "thirteen_dvd_iff, weights_thirteen_period (10⁶ ≡ 1 mod 13, period 6), and the witness 13 | 1001. A second non-(b−1) modulus.",
+      "mathContext": "13 ∤ 9; weights 10ⁱ mod 13 have period 6 (10⁶ ≡ 1 mod 13)."
+    },
+    {
+      "id": "consistency",
+      "title": "Part VII: Consistency with the parent",
+      "startLine": 213,
+      "endLine": 223,
+      "summary": "nine_weights_all_one (all base-10 weights for 9 are 1) and nine_dvd_iff, confirming the weighted rule reduces to casting-out-nines when m | (b−1).",
+      "mathContext": "9 | (10−1), so every weight 10ⁱ mod 9 = 1 and the weighted sum equals the plain digit sum."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete formalization of weighted digit-sum divisibility rules for arbitrary moduli, with 0 axioms and 0 sorries. The weighted digit sum W(n) = Σᵢ dᵢ·(bⁱ mod m) satisfies m | n ↔ m | W(n) for every base b and modulus m, removing the parent's restriction that m divide b−1. Divisibility by 7, 11, and 13 in base 10 follow as specializations.",
+    "implications": "Any modulus admits a periodic-weight digit test, not just divisors of b−1. The unweighted (b−1)-rule and the alternating (b+1)-rule are the two simplest degenerations (all weights 1, weights ±1). This unifies the classical divisibility tricks under one theorem.",
+    "openQuestions": [
+      "Can the period of the weight sequence bⁱ mod m be characterized as the multiplicative order of b modulo m/gcd, and formalized to bound the test's length?",
+      "Does the weighted rule specialize cleanly to a signed (balanced) digit sum when 2·(bⁱ mod m) > m, minimizing the weighted sum's magnitude?",
+      "Can Korselt's criterion for Carmichael numbers be connected to the weighted digit-sum framework across all residues (parent open question 3)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "divisibility-by-3-oq-02",
+      "relationship": "extends",
+      "description": "The parent proves the digit-sum rule only when d | (b−1); this child removes that restriction entirely via weighted digit sums, and recovers the parent's rule as the constant-weight special case (weight_eq_one_of_dvd_pred)"
+    },
+    {
+      "targetId": "divisibility-by-3",
+      "relationship": "related",
+      "description": "The base-10 divisibility-by-3 rule is the m | (b−1) degeneration where all weights are 1; this file's weighted framework subsumes it and adds the 7, 11, 13 tests"
+    },
+    {
+      "targetId": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "Both formalize modular arithmetic; the weighted digit sum reduces n mod m via the periodic weights bⁱ mod m, complementary to CRT's combination of coprime congruences"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition",
+      "note": "Chapter 9 treats divisibility tests via positional congruences, including the weighted/periodic weights bⁱ mod m for moduli not dividing b−1"
+    },
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "venue": "Leipzig",
+      "note": "Foundational treatment of positional congruences bⁱ mod m and their periodicity, underlying weighted digit-sum divisibility tests"
+    },
+    {
+      "authors": "Dickson, Leonard Eugene",
+      "title": "History of the Theory of Numbers, Vol. I: Divisibility and Primality",
+      "year": "1919",
+      "venue": "Carnegie Institution of Washington",
+      "note": "Surveys classical divisibility criteria including weighted digit-sum tests for 7, 11, 13 in base 10"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "List"
+    ],
+    "namespace": "DivisibilityBy3OQ02OQ02",
+    "lineCount": 225,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "weighted_modEq",
+        "type": "original",
+        "description": "Universal weighted rule: n ≡ Σᵢ dᵢ·(bⁱ mod m) [MOD m] for every base b and modulus m",
+        "leanType": "(b m n : ℕ) → n ≡ weightedDigitSum b m n [MOD m]"
+      },
+      {
+        "name": "dvd_iff_dvd_weighted",
+        "type": "original",
+        "description": "Weighted divisibility test for composite moduli: m ∣ n ↔ m ∣ weightedDigitSum b m n",
+        "leanType": "(b m n : ℕ) → m ∣ n ↔ m ∣ weightedDigitSum b m n"
+      },
+      {
+        "name": "seven_dvd_iff",
+        "type": "application",
+        "description": "Divisibility by 7 in base 10 via weighted digit sum (weights [1,3,2,6,4,5])",
+        "leanType": "(n : ℕ) → 7 ∣ n ↔ 7 ∣ weightedDigitSum 10 7 n"
+      },
+      {
+        "name": "eleven_dvd_iff",
+        "type": "application",
+        "description": "Divisibility by 11 via weighted digit sum, recovering the alternating rule (weights [1,10,1,10,…])",
+        "leanType": "(n : ℕ) → 11 ∣ n ↔ 11 ∣ weightedDigitSum 10 11 n"
+      }
+    ],
+    "path": "Proofs/DivisibilityBy3OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question 2** of the parent *Base-b Divisibility Rules* (`divisibility-by-3-oq-02`):

> Can the theory extend to composite moduli **not** dividing (b−1)? E.g. divisibility by 7 in base 10 requires a weighted digit sum since 7 ∤ 9.

The parent proves `d ∣ n ↔ d ∣ digitSum_b(n)` **only when `d ∣ (b−1)`** (casting out nines). This child removes that restriction entirely.

## What's proved (`Proofs/DivisibilityBy3OQ02OQ02.lean`, 225 lines, 14 theorems, 1 def, 0 sorries, 0 axioms)

- **`weightedDigitSum b m n = Σᵢ dᵢ·(bⁱ mod m)`** — digits weighted by the *periodic* positional weights `bⁱ mod m`.
- **`weighted_modEq`** (main): `n ≡ weightedDigitSum b m n [MOD m]` for **every** base `b` and modulus `m` — no hypothesis relating `m` to `b−1`.
- **`dvd_iff_dvd_weighted`**: `m ∣ n ↔ m ∣ weightedDigitSum b m n` — the requested composite-modulus test.
- **`weight_eq_one_of_dvd_pred`**: when `m ∣ (b−1)` every weight collapses to `1`, recovering the parent's `(b−1)`-rule as the constant-weight special case.

### Specializations in base 10
- **Divisibility by 7** — weights cycle `[1,3,2,6,4,5]`, period 6 (`10⁶ ≡ 1 mod 7`). Witnesses: `7 ∣ 1001`, `7 ∤ 1000`, `7 ∣ 123452`.
- **Divisibility by 11** — weights `[1,10,1,10,…]`, recovering the classical **alternating** digit-sum rule (also answers parent open question 1).
- **Divisibility by 13** — period-6 weights (`10⁶ ≡ 1 mod 13`), witness `13 ∣ 1001`.
- **Consistency**: for `m = 9` all weights are `1`, reducing to casting-out-nines.

## Proof idea

`n = Σᵢ dᵢ bⁱ` exactly (Mathlib's `Nat.ofDigits_eq_sum_mapIdx`); reduce each weight `bⁱ ↦ bⁱ mod m` — a pure congruence step justified termwise by `Nat.mod_modEq` and lifted to the indexed `mapIdx` sum by the reusable lemma `mapIdx_sum_modEq` (list induction generalizing the weight functions).

## Verification
- Builds cleanly via `./proofs/scripts/docker-build.sh Proofs.DivisibilityBy3OQ02OQ02` (7743 jobs, success).
- 0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. Numerical witnesses use `native_decide` (`Lean.ofReduceBool`); all substantive theorems are proved without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)