### PR TITLE
research(erdos-1020-oq-02): §10 — sharp closed-form crossover threshold for the r=2 family [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1020OQ02.lean
+++ b/proofs/Proofs/Erdos1020OQ02.lean
@@ -37,10 +37,13 @@
   The monotonicity (2) is a Pascal-telescoping identity:
     construction2 (n+1) − construction2 n  =  C(n, r−1) − C(n−k+1, r−1)  ≥ 0.
 
-  A worked instance (r = 4, k = 2) exhibits the crossover concretely at n = 8.
+  A worked instance (r = 4, k = 2) exhibits the crossover concretely at n = 8;
+  and for the entire r = 2 family the threshold is pinned down in closed form,
+  n₀(2, k) = ⌈(5k − 2)/2⌉ (§10), sharpening both the single point above and the
+  qualitative finiteness of §9.
 
-  All results are machine-checked with `decide` / `omega` only — no axioms,
-  no `native_decide`, no `sorry`.
+  All results are machine-checked with `omega`, `zify`/`ring` and `decide` only —
+  no axioms, no `native_decide`, no `sorry`.
 
   Tags: hypergraph-theory, matching, extremal-combinatorics, regime-transition
 -/
@@ -385,5 +388,90 @@ theorem exists_large_regime (r k : ℕ) (hr : 2 ≤ r) (hk : 2 ≤ k) :
   have hmono : Nat.choose m (r - 1) ≤ Nat.choose (n - 1) (r - 1) :=
     Nat.choose_le_choose (r - 1) (by omega)
   exact le_trans hm (le_trans hmono hge)
+
+/-! ### 10. Sharp crossover threshold for the `r = 2` family.
+
+Sections 6 and 9 locate the crossover only *qualitatively*: a single concrete
+point `n₀(4,2) = 8`, and the mere *existence* of a finite threshold for every
+`r, k ≥ 2`.  Here we compute the threshold *exactly and in closed form* for the
+entire `r = 2` family.  At `r = 2` both constructions are explicit quadratics:
+
+  `2·construction2 n 2 k = (k−1)·(2n−k)`,     `2·construction1 2 k = (2k−1)·(2k−2)`,
+
+so `construction2` reaches `construction1` precisely when `2n ≥ 5k − 2`, i.e. the
+threshold is `n₀(2,k) = ⌈(5k−2)/2⌉`.  Specialising `k = 2` recovers `n₀(2,2) = 4`.
+
+Everything stays inside `ℕ`: the doubled identities carry the polynomial content
+to `ℤ` (`zify` + `ring`) with subtraction side-conditions closed by `omega`, and
+the final cancellation of the common factor `k − 1` uses `Nat.le_of_mul_le_mul_left`. -/
+
+/-- Doubling a `choose _ 2` clears the division: `2·C(m, 2) = m·(m−1)`. -/
+theorem two_mul_choose_two (m : ℕ) : 2 * Nat.choose m 2 = m * (m - 1) := by
+  have hev : Even (m * (m - 1)) := by
+    rcases Nat.even_or_odd m with h | h
+    · exact h.mul_right _
+    · exact (Nat.Odd.sub_odd h odd_one).mul_left _
+  rw [Nat.choose_two_right, Nat.mul_div_cancel' hev.two_dvd]
+
+/-- Doubled closed form of `construction2` at `r = 2`:
+    `2·construction2 n 2 k = (k−1)·(2n−k)` — an explicit quadratic in `n`. -/
+theorem two_mul_construction2_r2 (n k : ℕ) (hk : 1 ≤ k) (hn : k ≤ n) :
+    2 * construction2 n 2 k = (k - 1) * (2 * n - k) := by
+  have hle : n - k + 1 ≤ n := by omega
+  have hmono : Nat.choose (n - k + 1) 2 ≤ Nat.choose n 2 := Nat.choose_le_choose 2 hle
+  have key : 2 * Nat.choose n 2
+      = 2 * Nat.choose (n - k + 1) 2 + (k - 1) * (2 * n - k) := by
+    rw [two_mul_choose_two n, two_mul_choose_two (n - k + 1)]
+    have e1 : n - k + 1 - 1 = n - k := by omega
+    rw [e1]
+    zify [hk, hn, show 1 ≤ n by omega, show k ≤ 2 * n by omega]
+    ring
+  unfold construction2
+  omega
+
+/-- Doubled closed form of `construction1` at `r = 2`:
+    `2·construction1 2 k = (2k−1)·(2k−2)` — the constant (in `n`) value. -/
+theorem two_mul_construction1_r2 (k : ℕ) :
+    2 * construction1 2 k = (2 * k - 1) * (2 * k - 2) := by
+  unfold construction1
+  rw [two_mul_choose_two]
+  have e1 : 2 * k - 1 - 1 = 2 * k - 2 := by omega
+  rw [e1]
+
+/-- **Sharp crossover threshold for `r = 2`.**  For all `k ≥ 2` and `n ≥ k`,
+`construction2` reaches `construction1` exactly when `2n ≥ 5k − 2`.  The threshold
+is therefore `n₀(2,k) = ⌈(5k−2)/2⌉` (e.g. `k = 2` gives `n₀ = 4`): the exact,
+closed-form counterpart — for the whole `r = 2` family — of the single worked
+point `crossover_r4k2` and of the qualitative `exists_large_regime`. -/
+theorem crossover_r2 (n k : ℕ) (hk : 2 ≤ k) (hn : k ≤ n) :
+    construction1 2 k ≤ construction2 n 2 k ↔ 5 * k - 2 ≤ 2 * n := by
+  have hc1 := two_mul_construction1_r2 k
+  have hc2v := two_mul_construction2_r2 n k (by omega) hn
+  -- Scaling by `2` is order-reflecting on `ℕ`, so pass to the doubled quantities.
+  have hdouble : construction1 2 k ≤ construction2 n 2 k
+      ↔ 2 * construction1 2 k ≤ 2 * construction2 n 2 k := by omega
+  rw [hdouble, hc1, hc2v]
+  -- Expose the common factor `k − 1` on the constant side.
+  have hlhs : (2 * k - 1) * (2 * k - 2) = (k - 1) * (4 * k - 2) := by
+    zify [show 1 ≤ k by omega, show 1 ≤ 2 * k by omega, show 2 ≤ 2 * k by omega,
+      show 2 ≤ 4 * k by omega]
+    ring
+  rw [hlhs]
+  -- Cancel the positive common factor `k − 1`.
+  constructor
+  · intro h
+    have hpos : 0 < k - 1 := by omega
+    have := Nat.le_of_mul_le_mul_left h hpos
+    omega
+  · intro h
+    have hstep : 4 * k - 2 ≤ 2 * n - k := by omega
+    exact Nat.mul_le_mul (le_refl (k - 1)) hstep
+
+/-- On the `r = 2` family the conjectured extremal value collapses to the
+large-`n` construction exactly on the threshold `2n ≥ 5k − 2`. -/
+theorem conjecturedValue_r2_large (n k : ℕ) (hk : 2 ≤ k) (hn : k ≤ n)
+    (hthr : 5 * k - 2 ≤ 2 * n) : conjecturedValue n 2 k = construction2 n 2 k := by
+  unfold conjecturedValue
+  exact max_eq_right ((crossover_r2 n k hk hn).2 hthr)
 
 end Erdos1020OQ02

--- a/src/data/proofs/erdos-1020-oq-02/meta.json
+++ b/src/data/proofs/erdos-1020-oq-02/meta.json
@@ -20,11 +20,11 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 389,
+    "lineCount": 477,
     "assumptions": "None. The file introduces no axioms and no sorries; every theorem depends only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms). The concrete crossover examples use kernel `decide` (not `native_decide`), so they introduce no Lean.ofReduceBool dependency. The open content of OQ-02 — whether the small-n/large-n gap can be closed for general r, i.e. the Erdős Matching Conjecture itself for r≥4 — is left unproved and unaxiomatized; only the regime-transition structure of the conjectured extremal value is established.",
     "dateAdded": "2026-06-27",
     "mathlib_version": "4.26.0",
-    "theoremCount": 17,
+    "theoremCount": 22,
     "definitionCount": 3
   },
   "overview": {
@@ -112,6 +112,13 @@
       "endLine": 283,
       "summary": "choose_add_sum_Ico proves the subtraction-free telescoping Pascal identity C(a,r) + Σ_{j∈[a,b)} C(j,r-1) = C(b,r) (a≤b, r≥1) by Nat.le_induction with Finset.sum_Ico_succ_top and a single Pascal step; construction2_eq_sum reads off construction2 n r k = Σ_{j=n-k+1}^{n-1} C(j,r-1); construction2_sum_card (via Nat.card_Ico) confirms the window holds exactly k-1 terms. The closed form makes the Section-1 monotonicity transparent (each summand is nondecreasing as the window slides) and exposes the combinatorial stratification of edges meeting the fixed (k-1)-set.",
       "mathContext": "$\\mathrm{construction2}\\,n\\,r\\,k=\\sum_{j=n-k+1}^{n-1}\\binom{j}{r-1}$, a sum of $k-1$ consecutive binomial coefficients; telescoping $\\binom{j}{r-1}=\\binom{j+1}{r}-\\binom{j}{r}$."
+    },
+    {
+      "id": "crossover-r2-threshold",
+      "title": "Sharp Crossover Threshold for the r = 2 Family",
+      "startLine": 390,
+      "endLine": 477,
+      "summary": "two_mul_choose_two clears the division in Nat.choose _ 2 (2·C(m,2)=m·(m-1), via Even (m·(m-1))). This gives the two explicit quadratics two_mul_construction2_r2 (2·construction2 n 2 k = (k-1)·(2n-k)) and two_mul_construction1_r2 (2·construction1 2 k = (2k-1)·(2k-2)), each proved by carrying the polynomial content to ℤ with zify+ring and discharging the subtraction side-conditions by omega. crossover_r2 then computes the threshold exactly: for k≥2, n≥k, construction2 reaches construction1 iff 2n ≥ 5k-2, i.e. n₀(2,k)=⌈(5k-2)/2⌉ (k=2 recovers n₀=4). The common factor k-1 is cancelled by Nat.le_of_mul_le_mul_left. conjecturedValue_r2_large reads off that the conjectured value collapses to construction2 on the threshold. This sharpens both the single worked point crossover_r4k2 (n₀(4,2)=8) and the qualitative finiteness exists_large_regime into an exact closed form for a whole infinite family."
     }
   ],
   "conclusion": {
@@ -162,9 +169,9 @@
       "Nat"
     ],
     "namespace": "Erdos1020OQ02",
-    "lineCount": 284,
+    "lineCount": 477,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 22,
     "path": "Proofs/Erdos1020OQ02.lean",
     "sorries": 0,
     "definitionCount": 3
@@ -175,6 +182,7 @@
     "construction2 has a closed-form sum representation (construction2_eq_sum): construction2 n r k = Σ_{j=n-k+1}^{n-1} C(j,r-1), a sum of exactly k-1 consecutive binomial coefficients (construction2_sum_card) — the structural source of its monotonicity, derived from a subtraction-free telescoping Pascal lemma (choose_add_sum_Ico).",
     "The region where the large-n construction dominates the constant small-n construction is upward-closed (construction2_dominant_up): the small-n and large-n regimes are separated by a single threshold, never interleaved.",
     "The conjectured extremal value max(construction1, construction2) is therefore monotone nondecreasing in n (conjecturedValue_mono) and collapses to the relevant construction on each side of the threshold (conjecturedValue_small / conjecturedValue_large).",
-    "The open content of OQ-02 — closing the gap between the Frankl and Huang–Loh–Sudakov regimes, i.e. the Erdős Matching Conjecture for r≥4 — is stated, not axiomatized; the file is fully verified (0 axioms, 0 sorries, kernel decide only)."
+    "The open content of OQ-02 — closing the gap between the Frankl and Huang–Loh–Sudakov regimes, i.e. the Erdős Matching Conjecture for r≥4 — is stated, not axiomatized; the file is fully verified (0 axioms, 0 sorries, kernel decide only).",
+    "For the entire r=2 family the crossover threshold is computed in closed form: construction2 overtakes construction1 exactly when 2n ≥ 5k-2, i.e. n₀(2,k)=⌈(5k-2)/2⌉ (crossover_r2) — an exact sharpening of the single point n₀(4,2)=8 and of §9's existence-only threshold."
   ]
 }


### PR DESCRIPTION
## Summary

Erdős Problem #1020 OQ-02 studies the small-*n*/large-*n* regime transition of the Erdős Matching Conjecture, where the conjectured extremal value is `max(construction1, construction2)` with

- `construction1 r k = C(rk−1, r)` (constant in *n*),
- `construction2 n r k = C(n, r) − C(n−k+1, r)` (monotone in *n*).

The file already pins the crossover down **qualitatively**: a single concrete point `n₀(4,2)=8` (`crossover_r4k2`) and the mere **existence** of a finite threshold for every `r,k≥2` (`exists_large_regime`, §9). This PR adds **§10**, which computes the threshold **exactly and in closed form for the entire `r=2` family**.

## Result

At `r=2` both constructions are explicit quadratics:

```
2·construction2 n 2 k = (k−1)·(2n−k)      2·construction1 2 k = (2k−1)·(2k−2)
```

so `construction2` reaches `construction1` **precisely when `2n ≥ 5k−2`**, i.e. the threshold is

```
n₀(2,k) = ⌈(5k−2)/2⌉      (k=2 recovers n₀(2,2)=4)
```

This is the exact, closed-form sharpening — over a whole infinite family — of the single worked point `n₀(4,2)=8` and of §9's existence-only finiteness.

## New declarations

| Theorem | Statement |
|---|---|
| `two_mul_choose_two` | `2·C(m,2) = m·(m−1)` (clears the `/2` in `Nat.choose _ 2`) |
| `two_mul_construction2_r2` | `2·construction2 n 2 k = (k−1)·(2n−k)` |
| `two_mul_construction1_r2` | `2·construction1 2 k = (2k−1)·(2k−2)` |
| `crossover_r2` | `construction1 2 k ≤ construction2 n 2 k ↔ 5k−2 ≤ 2n` (k≥2, n≥k) |
| `conjecturedValue_r2_large` | conjectured value collapses to `construction2` on the threshold |

## Method

Doubled identities carry the polynomial content to `ℤ` (`zify` + `ring`) with subtraction side-conditions discharged by `omega`; the final cancellation of the common factor `k−1` uses `Nat.le_of_mul_le_mul_left`. Everything stays inside `ℕ`.

## Verification

- Builds under Docker (`docker-build.sh Proofs.Erdos1020OQ02`), gallery `pnpm build` passes.
- `#print axioms` on the new theorems: `[propext, Classical.choice, Quot.sound]` only — **0 axioms**, no `native_decide`, no `sorry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)