### PR TITLE
Enrich Buffon's Noodle additivity: openQuestions + annotation coverage

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -23,6 +23,28 @@
     ]
   },
   {
+    "id": "ann-bnoq3oq2-degenerate",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 84,
+      "endLine": 88
+    },
+    "type": "technique",
+    "title": "Degenerate Interval: A Point Noodle Has No Crossings",
+    "content": "`expectedCrossings_self` records the base case: over an empty parameter interval [a, a] the functional is 0, since ∫_a^a = 0 (`integral_same`) and the 1/(πd) factor then multiplies zero (`mul_zero`). Tagging it `@[simp]` lets the simplifier discharge degenerate pieces automatically — a partition point that coincides with its neighbour drops out of any sum without manual bookkeeping. It is the additive identity that makes the concatenation lemmas well-behaved at trivial splits.",
+    "mathContext": "$E(\\gamma, a, a, d) = \\frac{1}{\\pi d}\\int_a^a \\text{angularIntegrand}\\,dt = 0.$",
+    "significance": "technical",
+    "relatedConcepts": [
+      "intervalIntegral.integral_same",
+      "simp lemma",
+      "additive identity",
+      "degenerate interval"
+    ],
+    "prerequisites": [
+      "intervalIntegral.integral_same"
+    ]
+  },
+  {
     "id": "ann-bnoq3oq2-outer-additivity",
     "proofId": "buffons-needle-oq-01-oq-01-oq-01-oq-02",
     "range": {
@@ -65,6 +87,29 @@
     ],
     "prerequisites": [
       "Continuous.intervalIntegrable"
+    ]
+  },
+  {
+    "id": "ann-bnoq3oq2-two-splits",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 113,
+      "endLine": 123
+    },
+    "type": "technique",
+    "title": "Two Splits by Composition (Three-Piece Noodle)",
+    "content": "`expectedCrossings_additive3` shows the single-split lemma composes: a three-piece noodle [a,c₁]∪[c₁,c₂]∪[c₂,b] splits by applying `expectedCrossings_additive` twice — first at c₁, whose right-hand integrability hypothesis on [c₁,b] is assembled from the two sub-pieces via `IntervalIntegrable.trans`, then at c₂ — and closing with `ring` to reassociate the three-term sum. This is the n = 3 instance of the general partition lemma, spelled out explicitly because the `trans` composition of integrability across the merged right interval is exactly the reusable pattern the `Finset`-indexed version generalizes.",
+    "mathContext": "$E(\\gamma,a,b,d) = E(\\gamma,a,c_1,d) + E(\\gamma,c_1,c_2,d) + E(\\gamma,c_2,b,d)$, obtained by nesting two one-split additivities; `IntervalIntegrable.trans` supplies integrability on $[c_1,b]$ from that on $[c_1,c_2]$ and $[c_2,b]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "IntervalIntegrable.trans",
+      "expectedCrossings_additive",
+      "ring",
+      "iterated additivity"
+    ],
+    "prerequisites": [
+      "IntervalIntegrable.trans",
+      "one-split additivity"
     ]
   },
   {

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -109,7 +109,11 @@
   "conclusion": {
     "summary": "Proves the Buffon family's missing structural lemma: the concrete expected-crossing functional is additive over concatenation of the parameter interval, from a single split point up to an arbitrary n-piece partition. Combined with the parent's shape-independence result it gives the 'noodle = Σ needles' decomposition that underlies Barbier's heuristic. 0 axioms, 0 sorries; host-verified against Mathlib 4.26.0.",
     "implications": "Additivity is the algebraic skeleton of Barbier's theorem: once expected crossings are additive over pieces and proportional to length on each short needle, shape-independence of the constant 2/(πd) follows. Stating it for the exact functional the family uses, with explicit integrability hypotheses, makes the partition step of the Barbier argument fully machine-checkable rather than heuristic.",
-    "openQuestions": []
+    "openQuestions": [
+      "Can the partition additivity proved here be combined with the parent's per-needle value to formalize the full Buffon–Barbier theorem $E = 2L/(\\pi d)$ for an arbitrary C¹ noodle — i.e. take the limit of the polygonal-chain approximation and show it converges to the arc-length functional?",
+      "The functional is defined for C¹ curves via the velocity $\\gamma'$. Does additivity extend to merely rectifiable curves parametrized by arc length, where $\\gamma'$ exists only almost everywhere, so that the 'noodle = Σ needles' decomposition covers the full generality of Barbier's original statement?",
+      "Does the same additive-over-partition structure carry to the higher-dimensional Cauchy–Crofton setting (expected intersections of a surface with a family of planes in $\\mathbb{R}^3$), or does the orientation bookkeeping that oriented interval integrals handle for free in 1D require genuinely new machinery there?"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Enrichment pass for `buffons-needle-oq-01-oq-01-oq-01-oq-02`

Already a strong entry (full structured overview, 5 sections). Two genuine gaps filled:

### 1. Empty `conclusion.openQuestions`
Added 3 mathematically substantive extensions:
- Combining this partition additivity with the parent's per-needle value to formalize the **full Buffon–Barbier** $E = 2L/(\pi d)$ via the polygonal-chain limit
- Extending additivity from C¹ to merely **rectifiable** (arc-length-parametrized) curves — Barbier's original generality
- Whether the additive-over-partition structure carries to the **Cauchy–Crofton** setting in $\mathbb{R}^3$

### 2. Annotation coverage (4 → 6)
Added annotations for the two previously-uncovered theorems:
- `expectedCrossings_self` — the degenerate $[a,a]$ base case / additive identity (`@[simp]`)
- `expectedCrossings_additive3` — the three-piece noodle by composing two single splits via `IntervalIntegrable.trans`

All content verified against `Proofs/BuffonsNeedleOQ01OQ01OQ01OQ02.lean`. meta.json 12.7 → 13.7 KB (under caps); `pnpm build` passes. No Lean/status/count changes.