### PR TITLE
Enrich Erdős #1018 K₅ planar threshold: add cross-references

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/meta.json
@@ -108,6 +108,21 @@
       "targetId": "erdos-1018-oq-04-incomplete-01",
       "relationship": "extends",
       "description": "Parent: the axiomatized topological completion whose planar edge-bound sorry this entry's threshold makes precise and verifies."
+    },
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "foundation",
+      "description": "Source of the bound: Euler's V − E + F = 2 yields |E| ≤ 3n − 6 for simple planar graphs, the exact inequality this entry shows Kₙ violates for n ≥ 5."
+    },
+    {
+      "targetId": "erdos-1018",
+      "relationship": "ancestor",
+      "description": "Root of the problem chain: Erdős #1018 asks when dense graphs must contain non-planar subgraphs; the Kₙ edge-count threshold proved here is the elementary first-moment core of the OQ-04 density argument."
+    },
+    {
+      "targetId": "four-color-theorem",
+      "relationship": "related",
+      "description": "Companion planarity result: the four-colour theorem concerns colourings of planar graphs, while this entry concerns the edge-count certificate (|E| > 3n − 6) that detects non-planarity — K₅ being the first complete graph it rules out."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass for `erdos-1018-oq-04-incomplete-01-oq-01`

Already comprehensive (structured overview, 6 sections, 5 annotations, 2 open questions). The one under-filled field was `crossReferences` (only the parent). Added 3 genuine links:

- **euler-polyhedral-formula** — source of the $|E| \le 3n-6$ bound this entry shows $K_n$ violates for $n \ge 5$ (the parent leaves it as a sorry)
- **erdos-1018** — root of the problem chain (non-planar subgraphs in dense graphs)
- **four-color-theorem** — planarity context (colouring vs. the edge-count non-planarity certificate)

All targets verified to exist on origin/main. meta.json 9.8 → 10.8 KB (under caps); `pnpm build` passes. No Lean/status/count changes.