### PR TITLE
research(factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01): full failure profile of the ordinary-derivative test over 𝔽_q [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FactorRemainderTheoremOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/FactorRemainderTheoremOQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,210 @@
+import Mathlib
+
+/-
+# Factor–remainder theorem OQ-01-OQ-01-OQ-01-OQ-01:
+# the full failure profile of the ordinary-derivative test over 𝔽_q
+
+Problem id: `factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01`
+(child of `factor-remainder-theorem-oq-01-oq-01-oq-01`).
+
+## Background
+
+The parent entry (`FactorRemainderTheoremOQ01OQ01OQ01`) exhibited the canonical
+positive-characteristic discrepancy with the single witness `f = Xᵖ` over the
+*prime* field `𝔽ₚ = ZMod p`: the ordinary-derivative multiplicity test collapses
+(`derivative (Xᵖ) = 0` identically, so every derivative condition holds vacuously
+and the test would falsely certify `Xᵏ ∣ Xᵖ` for all `k`), while the
+characteristic-free coefficient/Taylor test stays sharp (`Xᵏ ∣ Xᵖ ↔ k ≤ p`).
+
+Its open question asks to **generalise the witness to `f = X^{pᵉ}` and to an
+arbitrary finite field `𝔽_q`**, giving the *complete* failure profile of the test.
+Since every finite field `𝔽_q` (`q = pᵈ`) is a field of characteristic `p`, we
+work over an arbitrary `[Field K] [CharP K p]`; the results specialise to every
+`𝔽_q` and to `ZMod p` at once.
+
+## What is new here versus the sibling dichotomy
+
+The sibling entry `factor-remainder-hasse-derivative-fq-oq-01` already proved the
+*eval-level* dichotomy for a **general** polynomial (true multiplicity `m < p` ⟹
+exact, `m ≥ p` ⟹ unbounded overcount).  `X^{pᵉ}` lands in the overcount regime,
+so its ordinary collapse is a corollary of that work.
+
+The genuinely new content is a **sharper, whole-polynomial statement specific to
+the `p`-power witnesses**, driven by Kummer's theorem on binomial coefficients:
+
+* For `X^{pᵉ}` even the **Hasse derivatives themselves vanish identically** at
+  *every* intermediate order `0 < j < pᵉ` — not merely their values at `0`.  This
+  is because `hasseDeriv j (X^{pᵉ}) = (C(pᵉ, j) : K)·X^{pᵉ − j}` and, over
+  characteristic `p`, `p ∣ C(pᵉ, j)` for `0 < j < pᵉ`
+  (`Nat.Prime.dvd_choose_pow`).
+* The Hasse derivative therefore survives **only at the two extreme orders**:
+  `hasseDeriv j (X^{pᵉ}) ≠ 0 ↔ j = 0 ∨ j = pᵉ`
+  (`hasseDeriv_X_pe_ne_zero_iff`), using the exact criterion
+  `Nat.Prime.dvd_choose_pow_iff`.
+
+Contrast with the sibling's generic `f`, whose Hasse derivative first *fires* at
+the true multiplicity: the `p`-power witnesses have the extra rigidity that the
+Hasse derivative is dead throughout the open interval `(0, pᵉ)`.
+
+## Main results
+
+* `derivative_X_pe_eq_zero` — the ordinary derivative of `X^{pᵉ}` is `0` (`e ≥ 1`).
+* `ordinary_criterion_vacuous` — every ordinary derivative condition holds at `0`:
+  the ordinary test cannot bound the multiplicity (it certifies `Xᵏ ∣ X^{pᵉ}` for
+  all `k`).
+* `coeff_criterion_correct` — the characteristic-free test is exact:
+  `Xᵏ ∣ X^{pᵉ} ↔ k ≤ pᵉ`; the true multiplicity is `pᵉ` (`multiplicity_eq_pe`).
+* `hasseDeriv_X_pe` — closed form `hasseDeriv j (X^{pᵉ}) = monomial (pᵉ−j) C(pᵉ,j)`.
+* `hasseDeriv_intermediate_eq_zero` — **the Kummer collapse**: the Hasse derivative
+  vanishes identically for all `0 < j < pᵉ`.
+* `hasseDeriv_X_pe_ne_zero_iff` — **the sharp profile**: the Hasse derivative is
+  nonzero *iff* `j = 0` or `j = pᵉ`.
+* `ordinary_collapses_hasse_survives` — the capstone contrast: the ordinary test
+  is blind at every order while the Hasse derivative survives at `pᵉ`, and the
+  true multiplicity is exactly `pᵉ`.
+* `factorial_annihilates_hasseDeriv` — the obstruction is the factorial:
+  `(pᵉ)! • hasseDeriv pᵉ (X^{pᵉ}) = 0` because `(pᵉ)! ≡ 0 (mod p)`.
+
+All results are `0`-axiom, `0`-sorry, over every field of characteristic `p`.
+-/
+
+namespace FactorRemainderTheoremOQ01OQ01OQ01OQ01
+
+open Polynomial
+
+variable {K : Type*} [Field K] {p : ℕ} [hp : Fact p.Prime] [CharP K p] (e : ℕ)
+
+/-! ## The ordinary-derivative test collapses over `𝔽_q` -/
+
+/-- `(pᵉ : K) = 0` for `e ≥ 1`, since `p ∣ pᵉ` and `K` has characteristic `p`. -/
+theorem pe_cast_eq_zero (he : 1 ≤ e) : ((p ^ e : ℕ) : K) = 0 := by
+  rw [CharP.cast_eq_zero_iff K p]
+  exact dvd_pow_self p (by omega)
+
+/-- **The ordinary derivative of `X^{pᵉ}` vanishes identically** over a field of
+characteristic `p` (`e ≥ 1`): `derivative (X^{pᵉ}) = C(pᵉ)·X^{pᵉ−1} = 0` because
+`pᵉ ≡ 0 (mod p)`.  This is the higher Frobenius analogue of the parent's
+`derivative (Xᵖ) = 0`. -/
+theorem derivative_X_pe_eq_zero (he : 1 ≤ e) :
+    derivative ((X : K[X]) ^ (p ^ e)) = 0 := by
+  rw [derivative_X_pow, pe_cast_eq_zero e he, map_zero, zero_mul]
+
+/-- Consequently *every* iterated derivative of `X^{pᵉ}` of positive order is `0`. -/
+theorem iterate_derivative_X_pe_eq_zero (he : 1 ≤ e) {j : ℕ} (hj : 1 ≤ j) :
+    (derivative^[j]) ((X : K[X]) ^ (p ^ e)) = 0 := by
+  obtain ⟨j, rfl⟩ : ∃ j', j = j' + 1 := ⟨j - 1, by omega⟩
+  rw [Function.iterate_succ_apply, derivative_X_pe_eq_zero e he, iterate_derivative_zero]
+
+/-- **The ordinary-derivative criterion is vacuous.** *Every* derivative condition
+`(derivative^[j] (X^{pᵉ})).eval 0 = 0` holds — for `j = 0` because `X^{pᵉ}`
+evaluates to `0` at `0`, and for `j ≥ 1` because the derivative is `0`.  The
+criterion therefore certifies *no* finite multiplicity: it would (falsely) assert
+`Xᵏ ∣ X^{pᵉ}` for every `k`. -/
+theorem ordinary_criterion_vacuous (he : 1 ≤ e) (j : ℕ) :
+    ((derivative^[j]) ((X : K[X]) ^ (p ^ e))).eval 0 = 0 := by
+  rcases Nat.eq_zero_or_pos j with rfl | hj
+  · simp only [Function.iterate_zero, id_eq, eval_pow, eval_X]
+    exact zero_pow (pow_pos hp.out.pos e).ne'
+  · rw [iterate_derivative_X_pe_eq_zero e he hj, eval_zero]
+
+/-! ## The coefficient / Taylor test stays sharp -/
+
+/-- **The characteristic-free coefficient criterion gives the right multiplicity.**
+`Xᵏ ∣ X^{pᵉ} ↔ k ≤ pᵉ`, via `X_pow_dvd_iff` (the `a = 0` Taylor-coefficient test):
+the true multiplicity `pᵉ` of the root `0` is detected exactly, in every
+characteristic. -/
+theorem coeff_criterion_correct (k : ℕ) :
+    (X : K[X]) ^ k ∣ (X : K[X]) ^ (p ^ e) ↔ k ≤ p ^ e := by
+  rw [X_pow_dvd_iff]
+  constructor
+  · intro h
+    by_contra hk
+    push_neg at hk
+    have hc := h (p ^ e) (by omega)
+    rw [coeff_X_pow, if_pos rfl] at hc
+    exact one_ne_zero hc
+  · intro hk d hd
+    rw [coeff_X_pow, if_neg (by omega)]
+
+/-- The true multiplicity of the root `0` is exactly `pᵉ`: `X^{pᵉ} ∣ X^{pᵉ}` but
+`X^{pᵉ+1} ∤ X^{pᵉ}` — in flat contradiction with the vacuous ordinary certificate. -/
+theorem multiplicity_eq_pe :
+    (X : K[X]) ^ (p ^ e) ∣ (X : K[X]) ^ (p ^ e) ∧
+      ¬ (X : K[X]) ^ (p ^ e + 1) ∣ (X : K[X]) ^ (p ^ e) :=
+  ⟨dvd_refl _, by rw [coeff_criterion_correct]; omega⟩
+
+/-! ## The Hasse profile: survival only at the two extreme orders -/
+
+/-- **Closed form for the Hasse derivatives of `X^{pᵉ}`.**
+`hasseDeriv j (X^{pᵉ}) = monomial (pᵉ − j) (C(pᵉ, j) : K)`, from
+`Polynomial.hasseDeriv_monomial`. -/
+theorem hasseDeriv_X_pe (j : ℕ) :
+    hasseDeriv j ((X : K[X]) ^ (p ^ e)) = monomial (p ^ e - j) (((p ^ e).choose j : K)) := by
+  rw [X_pow_eq_monomial, hasseDeriv_monomial, mul_one]
+
+/-- **The sharp Hasse profile.** Over a field of characteristic `p`, the `j`-th Hasse
+derivative of `X^{pᵉ}` is nonzero **exactly** at the two extreme orders `j = 0` and
+`j = pᵉ`.  The proof reads off the monomial coefficient `(C(pᵉ, j) : K)`, which is
+zero iff `p ∣ C(pᵉ, j)` (`CharP.cast_eq_zero_iff`), and `Nat.Prime.dvd_choose_pow_iff`
+says this happens iff `j ≠ 0 ∧ j ≠ pᵉ`. -/
+theorem hasseDeriv_X_pe_ne_zero_iff (j : ℕ) :
+    hasseDeriv j ((X : K[X]) ^ (p ^ e)) ≠ 0 ↔ j = 0 ∨ j = p ^ e := by
+  rw [hasseDeriv_X_pe, Ne, monomial_eq_zero_iff, CharP.cast_eq_zero_iff K p,
+    hp.out.dvd_choose_pow_iff]
+  omega
+
+/-- **The Kummer collapse.** For *every* intermediate order `0 < j < pᵉ` the Hasse
+derivative of `X^{pᵉ}` vanishes identically (as a polynomial), because
+`p ∣ C(pᵉ, j)`.  This is strictly stronger than the eval-level vanishing that the
+ordinary test sees. -/
+theorem hasseDeriv_intermediate_eq_zero {j : ℕ} (hj0 : 0 < j) (hjn : j < p ^ e) :
+    hasseDeriv j ((X : K[X]) ^ (p ^ e)) = 0 := by
+  by_contra h
+  rcases (hasseDeriv_X_pe_ne_zero_iff e j).mp h with h0 | hpe <;> omega
+
+/-- **The Hasse derivative survives at the top order.**
+`hasseDeriv pᵉ (X^{pᵉ}) = 1` (its only nonzero coefficient is `C(pᵉ, pᵉ) = 1`),
+even though the `pᵉ`-th *ordinary* derivative is `0`. -/
+theorem hasseDeriv_pe_eq_one :
+    hasseDeriv (p ^ e) ((X : K[X]) ^ (p ^ e)) = 1 := by
+  rw [hasseDeriv_X_pe, Nat.sub_self, Nat.choose_self, Nat.cast_one, monomial_zero_left, C_1]
+
+/-! ## Capstone: ordinary collapses, Hasse survives -/
+
+/-- **The full failure profile (capstone).** Over any field of characteristic `p`,
+for the witness `X^{pᵉ}` (`e ≥ 1`):
+
+* the ordinary-derivative test is **blind at every order** — `(derivative^[j]
+  (X^{pᵉ})).eval 0 = 0` for all `j`, so it certifies every multiplicity; yet
+* the Hasse derivative **survives at order `pᵉ`** (`hasseDeriv pᵉ (X^{pᵉ}) ≠ 0`);
+  and
+* the true multiplicity is **exactly `pᵉ`** (`X^{pᵉ} ∣ X^{pᵉ}`, `X^{pᵉ+1} ∤
+  X^{pᵉ}`).
+
+This is the arbitrary-finite-field, `p`-power-witness generalisation of the
+parent's `Xᵖ`-over-`𝔽ₚ` discrepancy. -/
+theorem ordinary_collapses_hasse_survives (he : 1 ≤ e) :
+    (∀ j, ((derivative^[j]) ((X : K[X]) ^ (p ^ e))).eval 0 = 0) ∧
+      hasseDeriv (p ^ e) ((X : K[X]) ^ (p ^ e)) ≠ 0 ∧
+      ((X : K[X]) ^ (p ^ e) ∣ (X : K[X]) ^ (p ^ e) ∧
+        ¬ (X : K[X]) ^ (p ^ e + 1) ∣ (X : K[X]) ^ (p ^ e)) :=
+  ⟨ordinary_criterion_vacuous e he,
+    by rw [hasseDeriv_pe_eq_one]; exact one_ne_zero,
+    multiplicity_eq_pe e⟩
+
+/-- **The factorial is exactly the obstruction.** The bridge
+`derivative^[k] f = k! • hasseDeriv k f` (`Polynomial.factorial_smul_hasseDeriv`)
+makes the discrepancy quantitative: the `pᵉ`-th Hasse derivative is nonzero
+(`hasseDeriv_pe_eq_one`), yet scaling it by the factorial annihilates it —
+`(pᵉ)! • hasseDeriv pᵉ (X^{pᵉ}) = derivative^[pᵉ] (X^{pᵉ}) = 0` — precisely because
+`(pᵉ)! ≡ 0 (mod p)`.  This pinpoints the characteristic-zero hypothesis `k! ≠ 0`
+as the exact input the ordinary-derivative test needs and the Hasse test does not. -/
+theorem factorial_annihilates_hasseDeriv (he : 1 ≤ e) :
+    Nat.factorial (p ^ e) • hasseDeriv (p ^ e) ((X : K[X]) ^ (p ^ e)) = 0 := by
+  have h := congrFun (factorial_smul_hasseDeriv (R := K) (k := p ^ e))
+    ((X : K[X]) ^ (p ^ e))
+  rw [LinearMap.smul_apply] at h
+  rw [h]
+  exact iterate_derivative_X_pe_eq_zero e he (pow_pos hp.out.pos e)
+
+end FactorRemainderTheoremOQ01OQ01OQ01OQ01

--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "frt01010101-overview",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 69 },
+    "type": "concept",
+    "title": "From Xᵖ over 𝔽ₚ to X^(pᵉ) over any 𝔽_q",
+    "content": "The module docstring frames the generalisation. The parent used the single witness Xᵖ over the prime field 𝔽ₚ; here the witness is the whole p-power family X^(pᵉ) and the ground field is an arbitrary field of characteristic p — which covers every finite field 𝔽_q (q = pᵈ) at once, since 𝔽_q has characteristic p. The docstring also isolates precisely what is new versus the sibling eval-level dichotomy: a whole-polynomial vanishing of the Hasse derivatives across the entire interval (0, pᵉ), driven by Kummer's theorem on binomial coefficients.",
+    "mathContext": "Every $\\mathbb{F}_q$ with $q = p^d$ satisfies $\\operatorname{CharP}\\,\\mathbb{F}_q\\,p$, so results over an arbitrary char-$p$ field specialise to all $\\mathbb{F}_q$.",
+    "significance": "key",
+    "relatedConcepts": ["root multiplicity", "positive characteristic", "Hasse derivative", "Kummer's theorem", "finite field 𝔽_q", "Frobenius"],
+    "prerequisites": ["polynomial derivatives", "characteristic of a ring", "binomial coefficients mod p"]
+  },
+  {
+    "id": "frt01010101-collapse",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 88, "endLine": 109 },
+    "type": "theorem",
+    "title": "The ordinary-derivative test is vacuous on X^(pᵉ)",
+    "content": "derivative(X^(pᵉ)) = C(pᵉ)·X^(pᵉ−1) = 0 because (pᵉ : K) = 0 (p ∣ pᵉ for e ≥ 1, via CharP.cast_eq_zero_iff). Hence every iterated derivative of positive order vanishes, and every condition (derivative^[j] X^(pᵉ)).eval 0 = 0 holds — at j = 0 because X^(pᵉ) evaluates to 0, at j ≥ 1 because the derivative is already 0. The ordinary test therefore certifies Xᵏ ∣ X^(pᵉ) for every k, an unbounded overcount.",
+    "mathContext": "$\\tfrac{d}{dX}X^{p^e} = p^e X^{p^e-1} = 0$ in characteristic $p$.",
+    "significance": "standard",
+    "relatedConcepts": ["formal derivative", "characteristic p", "iterated derivative"],
+    "prerequisites": ["derivative_X_pow", "CharP.cast_eq_zero_iff"]
+  },
+  {
+    "id": "frt01010101-sharp",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 116, "endLine": 135 },
+    "type": "theorem",
+    "title": "The coefficient/Taylor test is exact",
+    "content": "The characteristic-free criterion X_pow_dvd_iff (Xⁿ ∣ f ↔ the first n coefficients of f vanish) is exactly the a = 0 Taylor-coefficient test. Applied to X^(pᵉ) via coeff_X_pow it gives Xᵏ ∣ X^(pᵉ) ↔ k ≤ pᵉ, so the true multiplicity pᵉ of the root 0 is detected exactly — in flat contradiction with the ordinary test's vacuous certificate.",
+    "mathContext": "$X^k \\mid X^{p^e} \\iff k \\le p^e$, valid in every characteristic.",
+    "significance": "standard",
+    "relatedConcepts": ["Taylor coefficients", "divisibility of monomials"],
+    "prerequisites": ["X_pow_dvd_iff", "coeff_X_pow"]
+  },
+  {
+    "id": "frt01010101-hasse-profile",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 141, "endLine": 171 },
+    "type": "theorem",
+    "title": "The sharp Kummer Hasse profile (main new result)",
+    "content": "The closed form hasseDeriv j (X^(pᵉ)) = monomial (pᵉ−j) (C(pᵉ,j) : K) reduces everything to the coefficient (C(pᵉ,j) : K), which is 0 iff p ∣ C(pᵉ,j) (CharP.cast_eq_zero_iff). Kummer's exact criterion Nat.Prime.dvd_choose_pow_iff says p ∣ (pᵉ).choose j ↔ j ≠ 0 ∧ j ≠ pᵉ. Combining, hasseDeriv j (X^(pᵉ)) ≠ 0 ↔ j = 0 ∨ j = pᵉ: the Hasse derivative vanishes identically at every intermediate order 0 < j < pᵉ and survives only at the two extremes. This whole-polynomial vanishing across the interval is strictly stronger than the eval-level vanishing seen by the ordinary test, and is the phenomenon specific to pure p-power witnesses.",
+    "mathContext": "$p \\mid \\binom{p^e}{j}$ for $0 < j < p^e$ (Kummer: one carry in base $p$), so $\\mathrm{hasse}_j(X^{p^e}) \\equiv 0$; only $j \\in \\{0, p^e\\}$ survive.",
+    "significance": "key",
+    "relatedConcepts": ["Hasse derivative", "Kummer's theorem", "binomial coefficients mod p", "monomial"],
+    "prerequisites": ["hasseDeriv_monomial", "Nat.Prime.dvd_choose_pow_iff", "monomial_eq_zero_iff"]
+  },
+  {
+    "id": "frt01010101-capstone",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 186, "endLine": 209 },
+    "type": "theorem",
+    "title": "Capstone and the factorial obstruction",
+    "content": "ordinary_collapses_hasse_survives packages the profile: the ordinary test is blind at every order, the Hasse derivative survives at pᵉ (hasseDeriv pᵉ (X^(pᵉ)) = 1), and the true multiplicity is exactly pᵉ. factorial_annihilates_hasseDeriv makes the discrepancy quantitative via the bridge derivative^[k] = k! • hasseDeriv k: (pᵉ)! • hasseDeriv pᵉ (X^(pᵉ)) = derivative^[pᵉ](X^(pᵉ)) = 0 even though hasseDeriv pᵉ (X^(pᵉ)) = 1, precisely because (pᵉ)! ≡ 0 (mod p). This pinpoints the characteristic-zero input k! ≠ 0 as the exact hypothesis the ordinary test needs and the Hasse/Taylor test does not.",
+    "mathContext": "$\\partial^{[p^e]} = (p^e)!\\cdot\\mathrm{hasse}_{p^e}$; $\\mathrm{hasse}_{p^e}(X^{p^e}) = 1$ but $(p^e)! \\equiv 0$, so $\\partial^{[p^e]}(X^{p^e}) = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Hasse derivative", "factorial", "positive characteristic", "multiplicity test"],
+    "prerequisites": ["factorial_smul_hasseDeriv", "LinearMap.smul_apply"]
+  }
+]

--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01",
+  "title": "The Full Failure Profile of the Ordinary-Derivative Multiplicity Test over 𝔽_q",
+  "slug": "factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01",
+  "description": "Generalises the parent's Xᵖ-over-𝔽ₚ discrepancy to the witness family X^(pᵉ) over an arbitrary field of characteristic p (hence every finite field 𝔽_q). The ordinary-derivative test collapses (derivative(X^(pᵉ))=0 identically, so every derivative condition holds vacuously) while the characteristic-free coefficient/Taylor test is exact (Xᵏ ∣ X^(pᵉ) ↔ k ≤ pᵉ). The new content is a sharper Kummer-theoretic profile specific to the p-power witnesses: even the Hasse derivatives vanish identically at every intermediate order 0 < j < pᵉ, so the Hasse derivative survives EXACTLY at the two extreme orders — hasseDeriv j (X^(pᵉ)) ≠ 0 ↔ j = 0 ∨ j = pᵉ (via Nat.Prime.dvd_choose_pow_iff). The factorial (pᵉ)! ≡ 0 (mod p) is the obstruction. 12 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FactorRemainderTheoremOQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "factor-remainder-theorem",
+      "polynomial",
+      "multiplicity",
+      "hasse-derivative",
+      "taylor-coefficient",
+      "positive-characteristic",
+      "finite-field",
+      "kummer-theorem",
+      "binomial-coefficient",
+      "counterexample"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 210,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "assumptions": "None. All 12 theorems proved, 0 axioms. Verified axiom-free: #print axioms reports only propext, Classical.choice, Quot.sound. Results hold over any [Field K] [CharP K p] with p prime — every finite field 𝔽_q and ZMod p.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.derivative_X_pow",
+        "description": "derivative (X^n) = C(n)·X^(n-1); with n = pᵉ over a char-p field the coefficient C(pᵉ) = 0",
+        "module": "Mathlib.Algebra.Polynomial.Derivative"
+      },
+      {
+        "theorem": "CharP.cast_eq_zero_iff",
+        "description": "(a : K) = 0 ↔ p ∣ a in a ring of characteristic p — turns pᵉ ≡ 0 and the Kummer divisibility into vanishing coefficients",
+        "module": "Mathlib.Algebra.CharP.Defs"
+      },
+      {
+        "theorem": "Polynomial.hasseDeriv_monomial",
+        "description": "hasseDeriv k (monomial n r) = monomial (n-k) (C(n,k)·r); gives hasseDeriv j (X^(pᵉ)) = monomial (pᵉ-j) C(pᵉ,j)",
+        "module": "Mathlib.Algebra.Polynomial.HasseDeriv"
+      },
+      {
+        "theorem": "Nat.Prime.dvd_choose_pow_iff",
+        "description": "p ∣ (pⁿ).choose k ↔ k ≠ 0 ∧ k ≠ pⁿ — Kummer's exact criterion, the engine of the sharp Hasse profile",
+        "module": "Mathlib.Data.Nat.Multiplicity"
+      },
+      {
+        "theorem": "Polynomial.X_pow_dvd_iff",
+        "description": "X^n ∣ f ↔ ∀ d < n, f.coeff d = 0 — the characteristic-free (Taylor-at-0) coefficient criterion",
+        "module": "Mathlib.Algebra.Polynomial.Div"
+      },
+      {
+        "theorem": "Polynomial.factorial_smul_hasseDeriv",
+        "description": "k! • hasseDeriv k = derivative^[k]; the quantitative bridge whose factorial factor is the obstruction in characteristic p",
+        "module": "Mathlib.Algebra.Polynomial.HasseDeriv"
+      }
+    ],
+    "dateAdded": "2026-06-30"
+  },
+  "overview": {
+    "historicalContext": "Over a characteristic-zero field the multiplicity of a root is detected by ordinary derivatives: (X−a)^k ∣ p iff p(a)=p′(a)=⋯=p^{(k−1)}(a)=0. In positive characteristic this fails on pure p-th powers, where ordinary derivatives of order ≥ p vanish identically. The parent entry made this explicit with the single witness Xᵖ over the prime field 𝔽ₚ. Its open question asked to generalise both the witness — to the family X^(pᵉ) — and the ground field — to an arbitrary finite field 𝔽_q — and to give the complete failure profile. Since every 𝔽_q (q = pᵈ) has characteristic p, the natural setting is an arbitrary field K of characteristic p.",
+    "problemStatement": "For the witness family f = X^(pᵉ) over an arbitrary field of characteristic p, describe the complete failure profile of the ordinary-derivative multiplicity test, and pinpoint the precise arithmetic obstruction relating the ordinary and Hasse/Taylor tests.",
+    "proofStrategy": "Work over [Field K] [CharP K p] (p prime), witness X^(pᵉ). (1) Collapse: derivative(X^(pᵉ)) = C(pᵉ)·X^(pᵉ−1) = 0 because (pᵉ : K) = 0 (p ∣ pᵉ, CharP.cast_eq_zero_iff); hence every iterated derivative of positive order is 0 and every condition (derivative^[j] f).eval 0 = 0 holds — the test is vacuous. (2) Sharpness: X_pow_dvd_iff is characteristic-free, so Xᵏ ∣ X^(pᵉ) ↔ k ≤ pᵉ; the true multiplicity pᵉ is detected exactly. (3) The Kummer profile: hasseDeriv j (X^(pᵉ)) = monomial (pᵉ−j) (C(pᵉ,j) : K); the coefficient is (C(pᵉ,j) : K), which vanishes iff p ∣ C(pᵉ,j), and Nat.Prime.dvd_choose_pow_iff says this holds iff j ≠ 0 ∧ j ≠ pᵉ. Hence the Hasse derivative vanishes identically for all intermediate 0 < j < pᵉ and survives exactly at j ∈ {0, pᵉ}. (4) Obstruction: factorial_smul_hasseDeriv gives (pᵉ)! • hasseDeriv pᵉ (X^(pᵉ)) = derivative^[pᵉ](X^(pᵉ)) = 0 with hasseDeriv pᵉ (X^(pᵉ)) = 1, so (pᵉ)! ≡ 0 (mod p) is exactly the obstruction.",
+    "keyInsights": [
+      "**The p-power witnesses have a rigid Kummer profile.** For f = X^(pᵉ), the Hasse derivative is not merely 'the first nonzero order equals the multiplicity' — it is dead throughout the entire open interval (0, pᵉ) and alive only at the two endpoints 0 and pᵉ, because p ∣ C(pᵉ,j) for 0 < j < pᵉ (dvd_choose_pow_iff). This is strictly stronger than the eval-level vanishing the ordinary test detects.",
+      "**Whole-polynomial vanishing vs eval vanishing.** The sibling dichotomy (factor-remainder-hasse-derivative-fq-oq-01) works at the level of values (derivative^[j] f).eval a. Here the Hasse derivatives vanish as polynomials on the whole interval, a phenomenon special to pure p-power monomials.",
+      "**The coefficient/Taylor test is characteristic-free and exact.** X_pow_dvd_iff detects the true multiplicity pᵉ in every characteristic; the ordinary test, by contrast, is completely blind (certifies every k).",
+      "**The factorial is the single obstruction.** (pᵉ)! • hasseDeriv pᵉ (X^(pᵉ)) = derivative^[pᵉ](X^(pᵉ)) = 0 while hasseDeriv pᵉ (X^(pᵉ)) = 1, so (pᵉ)! ≡ 0 (mod p) pinpoints the characteristic-zero input k! ≠ 0 that the ordinary test needs and the Hasse/Taylor test does not."
+    ]
+  },
+  "sections": [
+    {
+      "id": "collapse",
+      "title": "The ordinary-derivative test collapses over 𝔽_q",
+      "startLine": 77,
+      "endLine": 109,
+      "summary": "pe_cast_eq_zero: (pᵉ : K) = 0 for e ≥ 1. derivative_X_pe_eq_zero: derivative(X^(pᵉ)) = 0. iterate_derivative_X_pe_eq_zero: every positive-order iterated derivative is 0. ordinary_criterion_vacuous: every condition (derivative^[j] X^(pᵉ)).eval 0 = 0 holds.",
+      "mathContext": "$\\mathrm{d}/\\mathrm{d}X(X^{p^e}) = p^e X^{p^e-1} = 0$ in characteristic $p$; all higher derivatives vanish, so the criterion is uninformative."
+    },
+    {
+      "id": "sharp",
+      "title": "The coefficient / Taylor test stays sharp",
+      "startLine": 110,
+      "endLine": 135,
+      "summary": "coeff_criterion_correct: Xᵏ ∣ X^(pᵉ) ↔ k ≤ pᵉ (X_pow_dvd_iff + coeff_X_pow). multiplicity_eq_pe: X^(pᵉ) ∣ X^(pᵉ) but X^(pᵉ+1) ∤ X^(pᵉ) — the true multiplicity is exactly pᵉ.",
+      "mathContext": "$X^k \\mid X^{p^e} \\iff k \\leq p^e$, characteristic-free; the multiplicity $p^e$ is detected exactly."
+    },
+    {
+      "id": "hasse-profile",
+      "title": "The Hasse profile: survival only at the two extreme orders",
+      "startLine": 136,
+      "endLine": 171,
+      "summary": "hasseDeriv_X_pe: hasseDeriv j (X^(pᵉ)) = monomial (pᵉ−j) C(pᵉ,j). hasseDeriv_X_pe_ne_zero_iff: nonzero ↔ j = 0 ∨ j = pᵉ (Kummer via dvd_choose_pow_iff). hasseDeriv_intermediate_eq_zero: identically 0 for 0 < j < pᵉ. hasseDeriv_pe_eq_one: hasseDeriv pᵉ (X^(pᵉ)) = 1.",
+      "mathContext": "$p \\mid \\binom{p^e}{j}$ for $0 < j < p^e$ (Kummer), so $\\mathrm{hasse}_j(X^{p^e}) = 0$ there; only $j \\in \\{0, p^e\\}$ survive."
+    },
+    {
+      "id": "capstone",
+      "title": "Capstone: ordinary collapses, Hasse survives, factorial is the obstruction",
+      "startLine": 172,
+      "endLine": 210,
+      "summary": "ordinary_collapses_hasse_survives: ordinary test blind at every order, hasseDeriv pᵉ ≠ 0, true multiplicity exactly pᵉ. factorial_annihilates_hasseDeriv: (pᵉ)! • hasseDeriv pᵉ (X^(pᵉ)) = derivative^[pᵉ](X^(pᵉ)) = 0, so (pᵉ)! ≡ 0 (mod p) is the obstruction.",
+      "mathContext": "$\\partial^{[p^e]} = (p^e)!\\cdot \\mathrm{hasse}_{p^e}$; $\\mathrm{hasse}_{p^e}(X^{p^e}) = 1$ but $(p^e)!\\equiv 0$, so $\\partial^{[p^e]}(X^{p^e})=0$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The positive-characteristic failure of the ordinary-derivative multiplicity test is described in full for the witness family X^(pᵉ) over an arbitrary field of characteristic p (every 𝔽_q): the ordinary test is vacuous, the coefficient/Taylor test is exact (multiplicity pᵉ), and — the new content — the Hasse derivative satisfies a sharp Kummer profile, vanishing identically at every intermediate order 0 < j < pᵉ and surviving exactly at j ∈ {0, pᵉ}. The factorial (pᵉ)! ≡ 0 (mod p) is the single obstruction. 12 theorems, 0 sorries, 0 axioms.",
+    "implications": "Generalises the parent's prime-field, single-monomial discrepancy to an arbitrary finite field and the full p-power family, and isolates a phenomenon (whole-polynomial Hasse vanishing across an interval, driven by Kummer's theorem) invisible to the eval-level sibling dichotomy.",
+    "openQuestions": [
+      "Characterise the Hasse profile of a general additive polynomial ∑ cᵢ X^(pⁱ) (a 𝔽_q-linear map): which orders survive, and how does the profile compose under the Frobenius twist?",
+      "Quantify the ordinary-vs-Hasse gap for X^n with p ≤ n not a p-power, using the base-p carry structure of C(n,j) (Kummer/Lucas), to interpolate between the exact regime n < p and the p-power collapse."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "FactorRemainderTheoremOQ01OQ01OQ01OQ01",
+    "lineCount": 210,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/FactorRemainderTheoremOQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "factor-remainder-theorem-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent made the characteristic-p discrepancy explicit with Xᵖ over the prime field 𝔽ₚ; this file generalises the witness to X^(pᵉ) and the ground field to any 𝔽_q, and adds the sharp Kummer Hasse profile"
+    },
+    {
+      "targetId": "factor-remainder-hasse-derivative-fq-oq-01",
+      "relationship": "related",
+      "description": "Sibling eval-level dichotomy for a general polynomial (m < p exact, m ≥ p unbounded overcount); the p-power witness lands in the overcount regime, and this file strengthens the analysis to whole-polynomial Hasse vanishing across the interval (0, pᵉ)"
+    },
+    {
+      "targetId": "factor-remainder-theorem-oq-01",
+      "relationship": "ancestor",
+      "description": "OQ-01 gave the ordinary-derivative multiplicity test over a characteristic-zero field, the criterion shown here to fail on X^(pᵉ) in characteristic p"
+    },
+    {
+      "targetId": "factor-remainder-theorem",
+      "relationship": "ancestor",
+      "description": "Root Factor Theorem (X − a) ∣ p ↔ p(a) = 0"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "hasseDeriv_X_pe_ne_zero_iff",
+      "type": "core",
+      "statement": "hasseDeriv j (X^(pᵉ)) ≠ 0 ↔ j = 0 ∨ j = pᵉ  (over any field of characteristic p)",
+      "description": "The sharp Kummer profile: the Hasse derivative of a pure p-power monomial survives exactly at the two extreme orders and vanishes identically in between.",
+      "significance": "The genuinely new content — a whole-polynomial vanishing phenomenon on the interval (0, pᵉ), stronger than the sibling's eval-level dichotomy"
+    },
+    {
+      "name": "ordinary_collapses_hasse_survives",
+      "type": "core",
+      "statement": "(∀ j, (derivative^[j] X^(pᵉ)).eval 0 = 0) ∧ hasseDeriv pᵉ (X^(pᵉ)) ≠ 0 ∧ (multiplicity is exactly pᵉ)",
+      "description": "The full failure profile: the ordinary test is blind at every order while the Hasse derivative survives at pᵉ and the true multiplicity is exactly pᵉ.",
+      "significance": "The arbitrary-𝔽_q, p-power-witness generalisation of the parent's Xᵖ-over-𝔽ₚ discrepancy"
+    },
+    {
+      "name": "coeff_criterion_correct",
+      "type": "core",
+      "statement": "Xᵏ ∣ X^(pᵉ) ↔ k ≤ pᵉ  (over any field of characteristic p)",
+      "description": "The characteristic-free coefficient/Taylor criterion detects the true multiplicity pᵉ.",
+      "significance": "Shows the Hasse/Taylor test succeeds where the ordinary-derivative test is vacuous"
+    },
+    {
+      "name": "factorial_annihilates_hasseDeriv",
+      "type": "core",
+      "statement": "(pᵉ)! • hasseDeriv pᵉ (X^(pᵉ)) = 0, with hasseDeriv pᵉ (X^(pᵉ)) = 1",
+      "description": "The factorial (pᵉ)! ≡ 0 (mod p) annihilates the nonzero Hasse derivative — the exact obstruction.",
+      "significance": "Quantifies where the characteristic-zero hypothesis k! ≠ 0 is needed"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01** — answers the parent (`factor-remainder-theorem-oq-01-oq-01-oq-01`) open question to *generalise the positive-characteristic discrepancy witness to `X^(pᵉ)` and to an arbitrary finite field `𝔽_q`, giving the full failure profile of the ordinary-derivative multiplicity test.*

Everything is proved over an arbitrary `[Field K] [CharP K p]` with `p` prime — this covers **every** finite field `𝔽_q` (`q = pᵈ`) and `ZMod p` at once.

## Results (12 theorems, 0 sorries, 0 axioms)

- **Ordinary test collapses** — `derivative (X^(pᵉ)) = 0` identically (`(pᵉ : K) = 0`), so every condition `(derivative^[j] X^(pᵉ)).eval 0 = 0` holds vacuously: the test would certify `Xᵏ ∣ X^(pᵉ)` for *all* `k`.
- **Coefficient/Taylor test is exact** — `Xᵏ ∣ X^(pᵉ) ↔ k ≤ pᵉ`; the true multiplicity `pᵉ` is detected exactly.
- **The sharp Kummer Hasse profile (main new content)** — `hasseDeriv j (X^(pᵉ)) ≠ 0 ↔ j = 0 ∨ j = pᵉ`. Even the *Hasse* derivatives vanish **identically as polynomials** at every intermediate order `0 < j < pᵉ`, because `p ∣ C(pᵉ, j)` there (`Nat.Prime.dvd_choose_pow_iff`). This is strictly stronger than the eval-level dichotomy in the sibling `factor-remainder-hasse-derivative-fq-oq-01`, and is a rigidity special to pure `p`-power monomials.
- **The factorial is the obstruction** — `(pᵉ)! • hasseDeriv pᵉ (X^(pᵉ)) = derivative^[pᵉ](X^(pᵉ)) = 0` with `hasseDeriv pᵉ (X^(pᵉ)) = 1`, precisely because `(pᵉ)! ≡ 0 (mod p)`.

## Verification

- Built with `./proofs/scripts/docker-build.sh Proofs.FactorRemainderTheoremOQ01OQ01OQ01OQ01` — succeeds (only harmless unused-section-variable linter warnings).
- `#print axioms` on the capstone theorems reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely 0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)