### PR TITLE
fix(meta): normalize stale proofRepoPath prefix (collatz-cycles-oq-02, buffons-needle)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-05/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-05/meta.json
@@ -8,7 +8,7 @@
     "sourceUrl": "",
     "date": "2026-06-25",
     "status": "verified",
-    "proofRepoPath": "proofs/Proofs/BuffonsNeedleOQ01OQ01OQ05.lean",
+    "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01OQ05.lean",
     "tags": [
       "integral-geometry",
       "buffon-barbier",

--- a/src/data/proofs/collatz-cycles-oq-02/meta.json
+++ b/src/data/proofs/collatz-cycles-oq-02/meta.json
@@ -8,7 +8,7 @@
     "sourceUrl": "",
     "date": "2026-06-25",
     "status": "verified",
-    "proofRepoPath": "proofs/Proofs/CollatzCyclesOQ02.lean",
+    "proofRepoPath": "Proofs/CollatzCyclesOQ02.lean",
     "tags": [
       "number-theory",
       "collatz",


### PR DESCRIPTION
## Problem

Two verified gallery entries store `proofRepoPath` with an erroneous leading `proofs/` prefix, contradicting their own `leanFile.path` field **and** the canonical convention used by all 4213 other verified entries (`proofRepoPath` is relative to the `proofs/` project root, i.e. `Proofs/Xxx.lean`).

| slug | proofRepoPath (before) | leanFile.path (canonical) |
|------|------------------------|---------------------------|
| collatz-cycles-oq-02 | `proofs/Proofs/CollatzCyclesOQ02.lean` | `Proofs/CollatzCyclesOQ02.lean` |
| buffons-needle-oq-01-oq-01-oq-05 | `proofs/Proofs/BuffonsNeedleOQ01OQ01OQ05.lean` | `Proofs/BuffonsNeedleOQ01OQ01OQ05.lean` |

Any tooling that resolves a Lean file via `proofs/${proofRepoPath}` would double-prefix to `proofs/proofs/Proofs/...` and read the file as missing.

## Fix

Strip the leading `proofs/` so `proofRepoPath` matches `leanFile.path` and the repo-wide convention. Metadata-only, 2 lines changed, both files remain valid JSON. The referenced `.lean` files exist and are unchanged (verified, 0 sorries, 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)