### PR TITLE
research(fourth-root-2-degree4-oq-02-oq-01): general-a Kummer criterion + Vahlen–Capelli sharp boundary [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/FourthRoot2Degree4OQ02OQ01.lean
+++ b/proofs/Proofs/FourthRoot2Degree4OQ02OQ01.lean
@@ -1,0 +1,196 @@
+/-
+  Fourth Root of 2, Degree 4 — OQ-02-OQ-01:
+  From `Xⁿ − p` (prime `p`) to `Xⁿ − a` (general `a`): the full Kummer /
+  Vahlen–Capelli criterion, and why it does NOT reduce to "not a perfect power".
+
+  Open question (generalization) from `FourthRoot2Degree4OQ02`:
+
+      Does the same packaging extend to `Xⁿ − a` for a general (non-prime) `a`,
+      e.g. via the full Kummer criterion that `Xⁿ − a` is irreducible iff `a` is
+      not a perfect `d`-th power for any prime `d ∣ n` (and `a ∉ −4·(fourth
+      powers)` when `4 ∣ n`)?
+
+  The parent file (`FourthRoot2Degree4OQ02`) packaged Eisenstein's criterion for
+  `Xⁿ − p` with `p` **prime**.  A prime `p` is *never* a nontrivial power, so the
+  irreducibility question there is answered by the single fact "`p` is prime".
+  For a **general** `a` the answer is more delicate, and splits into a part that
+  Mathlib already supplies and a part that it deliberately marks with `TODO`.
+
+  ## What Mathlib supplies (general `a`, restated as packaged lemmas)
+
+  Mathlib's `Mathlib/FieldTheory/KummerExtension.lean` proves the criterion for
+  arbitrary `a` in exactly two regimes:
+
+    * `X_pow_sub_C_irreducible_iff_of_odd`        — `n` odd:
+        `Irreducible (Xⁿ − a) ↔ ∀ d ∣ n, d ≠ 1 → ∀ b, bᵈ ≠ a`.
+    * `X_pow_sub_C_irreducible_iff_of_prime_pow`  — `n = pᵏ`, `p ≠ 2`:
+        `Irreducible (X^{pᵏ} − a) ↔ ∀ b, bᵖ ≠ a`.
+
+  In both regimes the criterion is *precisely* "`a` is not a perfect `d`-th power
+  for the relevant primes `d`".  We restate these as our own general-`a` lemmas.
+
+  ## Where the naive extension BREAKS (the mathematical heart)
+
+  The naive statement "`Xⁿ − a` irreducible ⟺ `a` is not a perfect `d`-th power
+  for any prime `d ∣ n`" is **false** once `4 ∣ n`.  The Vahlen–Capelli theorem
+  adds an exceptional clause `a ∉ −4·(fourth powers)`, and Mathlib leaves the
+  even case as a `TODO`.
+
+  We formalise the sharp witness with Sophie Germain's identity
+
+      X⁴ + 4c⁴ = (X² − 2cX + 2c²)(X² + 2cX + 2c²).
+
+  Taking `a = −4c⁴` gives a reducible `X⁴ − C a` even though `a` is **not a
+  perfect square** (indeed `a < 0`), so the only prime divisor `d = 2` of `4`
+  passes the "not a `d`-th power" test.  The capstone
+  `prime_divisor_criterion_insufficient` packages this as: there exists `a : ℚ`
+  which is not a square yet with `X⁴ − C a` reducible — the naive criterion is
+  provably insufficient for even exponents, which is exactly the phenomenon the
+  open question points at.
+
+  Results: 0 axioms, 0 sorries.
+-/
+
+import Mathlib
+
+open Polynomial
+
+namespace FourthRoot2Degree4OQ02OQ01
+
+/-! ## Part 1: The general-`a` criterion in the regimes Mathlib covers
+
+These two lemmas answer the "yes it extends" half of the open question: for a
+general element `a` of any field, irreducibility of `Xⁿ − a` is governed purely
+by whether `a` is a perfect power, provided `n` is odd or a `p ≠ 2` prime power.
+-/
+
+variable {K : Type*} [Field K]
+
+/-- **General `a`, odd exponent.**  For any field `K`, any odd `n`, and any
+`a : K`, `Xⁿ − a` is irreducible iff `a` is not a perfect `d`-th power for every
+divisor `1 ≠ d ∣ n`.  This is Mathlib's `X_pow_sub_C_irreducible_iff_of_odd`,
+repackaged as the general-`a` analogue of the parent's prime-only lemma. -/
+theorem irreducible_X_pow_sub_C_odd_iff {n : ℕ} (hn : Odd n) (a : K) :
+    Irreducible (X ^ n - C a) ↔ ∀ d, d ∣ n → d ≠ 1 → ∀ b : K, b ^ d ≠ a :=
+  X_pow_sub_C_irreducible_iff_of_odd hn
+
+/-- **General `a`, `p ≠ 2` prime-power exponent.**  For `n = pᵏ` with `p` an odd
+prime and `k ≥ 1`, `X^{pᵏ} − a` is irreducible iff `a` is not a perfect `p`-th
+power.  This is Mathlib's `X_pow_sub_C_irreducible_iff_of_prime_pow`. -/
+theorem irreducible_X_pow_sub_C_primePow_iff {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2)
+    {k : ℕ} (hk : k ≠ 0) (a : K) :
+    Irreducible (X ^ p ^ k - C a) ↔ ∀ b : K, b ^ p ≠ a :=
+  X_pow_sub_C_irreducible_iff_of_prime_pow hp hp2 hk
+
+/-! ## Part 2: Sophie Germain factorisations (the `4 ∣ n`, `a = −4c⁴` family)
+
+Pure ring identities.  Each exhibits a degree-4 polynomial `X⁴ − a` (with
+`a = −4c⁴ < 0`, so `a` is not a square) as a product of two quadratics. -/
+
+/-- Sophie Germain at `c = 1`: `X⁴ + 4 = (X² − 2X + 2)(X² + 2X + 2)`. -/
+theorem sophie_germain_4 :
+    (X ^ 2 - 2 * X + 2) * (X ^ 2 + 2 * X + 2) = (X ^ 4 + 4 : ℚ[X]) := by
+  ring
+
+/-- Sophie Germain at `c = 2`: `X⁴ + 64 = (X² − 4X + 8)(X² + 4X + 8)`,
+so `a = −64 = −4·2⁴`. -/
+theorem sophie_germain_64 :
+    (X ^ 2 - 4 * X + 8) * (X ^ 2 + 4 * X + 8) = (X ^ 4 + 64 : ℚ[X]) := by
+  ring
+
+/-! ## Part 3: Reducibility of the witnesses
+
+A quadratic factor has `natDegree = 2 ≠ 0`, hence is not a unit; a product of two
+non-units cannot be irreducible. -/
+
+/-- Helper: a rational polynomial of `natDegree 2` is not a unit. -/
+private theorem not_isUnit_of_natDegree_two {q : ℚ[X]} (hq : q.natDegree = 2) :
+    ¬ IsUnit q := by
+  intro hu
+  rw [natDegree_eq_zero_of_isUnit hu] at hq
+  exact absurd hq (by norm_num)
+
+/-- `X⁴ + 4` is reducible over `ℚ` (Sophie Germain), even though `−4` is not a
+square in `ℚ`. -/
+theorem X4_add_4_reducible : ¬ Irreducible (X ^ 4 + 4 : ℚ[X]) := by
+  intro h
+  rcases h.isUnit_or_isUnit sophie_germain_4.symm with hu | hu
+  · exact absurd hu (not_isUnit_of_natDegree_two (by compute_degree!))
+  · exact absurd hu (not_isUnit_of_natDegree_two (by compute_degree!))
+
+/-- `X⁴ + 64` is reducible over `ℚ`, the `c = 2` member of the family. -/
+theorem X4_add_64_reducible : ¬ Irreducible (X ^ 4 + 64 : ℚ[X]) := by
+  intro h
+  rcases h.isUnit_or_isUnit sophie_germain_64.symm with hu | hu
+  · exact absurd hu (not_isUnit_of_natDegree_two (by compute_degree!))
+  · exact absurd hu (not_isUnit_of_natDegree_two (by compute_degree!))
+
+/-! ## Part 4: Recasting into `Xⁿ − C a` form and the sharp boundary -/
+
+/-- `−4 : ℚ` is not a perfect square: the naive prime-divisor test for `n = 4`
+(whose only prime divisor is `2`) is *satisfied* by `a = −4`. -/
+theorem neg4_not_square : ∀ b : ℚ, b ^ 2 ≠ -4 := by
+  intro b h
+  nlinarith [sq_nonneg b]
+
+/-- `−64 : ℚ` is not a perfect square either. -/
+theorem neg64_not_square : ∀ b : ℚ, b ^ 2 ≠ -64 := by
+  intro b h
+  nlinarith [sq_nonneg b]
+
+/-- `X⁴ − C(−4)` is reducible over `ℚ`.  Rewriting `C(−4) = −4` turns the
+Kummer-form statement into the Sophie Germain witness. -/
+theorem X_pow_sub_C_neg4_reducible : ¬ Irreducible (X ^ 4 - C (-4 : ℚ)) := by
+  have hC : C (-4 : ℚ) = -4 := by simp
+  rw [hC]
+  have h : (X ^ 4 - (-4) : ℚ[X]) = X ^ 4 + 4 := by ring
+  rw [h]; exact X4_add_4_reducible
+
+/-- **The open question's crux, formalised.**  For the even exponent `n = 4`,
+the naive criterion "`X⁴ − a` irreducible ⟺ `a` is not a perfect `d`-th power for
+every prime `d ∣ 4`" is *insufficient*: there is a rational `a` (namely `−4`)
+that is not a perfect square — so it passes the only relevant test `d = 2` — yet
+`X⁴ − C a` is reducible.  This is exactly the `a ∈ −4·(fourth powers)` exceptional
+clause of Vahlen–Capelli that Mathlib leaves as a `TODO`, and it shows the
+parent's prime-`a` packaging does *not* naively extend to general `a` once
+`4 ∣ n`. -/
+theorem prime_divisor_criterion_insufficient :
+    ∃ a : ℚ, (∀ b : ℚ, b ^ 2 ≠ a) ∧ ¬ Irreducible (X ^ 4 - C a) :=
+  ⟨-4, neg4_not_square, X_pow_sub_C_neg4_reducible⟩
+
+/-! ## Part 5: A concrete positive general-`a` instance in the covered regime
+
+To confirm the "yes" half is usable, we instantiate the odd-exponent criterion.
+Over `ℚ`, `X³ − a` is irreducible iff `a` is not a cube.  The identity
+`(X − C b) ∣ (X³ − C (b³))` is the reducible boundary; here we simply record that
+the packaged iff-lemma specialises to the exponent `3`. -/
+
+/-- `X³ − a` (`a : K`) is irreducible iff `a` is not a perfect cube in `K`.
+The divisors of the prime `3` are `1` and `3`, so the general odd criterion
+collapses to a single cube test. -/
+theorem irreducible_X3_sub_C_iff (a : K) :
+    Irreducible (X ^ 3 - C a) ↔ ∀ b : K, b ^ 3 ≠ a := by
+  rw [irreducible_X_pow_sub_C_odd_iff (by norm_num : Odd 3)]
+  constructor
+  · intro H b; exact H 3 (dvd_refl 3) (by norm_num) b
+  · intro H d hd hd1 b
+    -- divisors of the prime `3` are `1` and `3`; `d ≠ 1` forces `d = 3`
+    obtain rfl : d = 3 := by
+      rcases (Nat.dvd_prime (by norm_num : Nat.Prime 3)).mp hd with h | h
+      · exact absurd h hd1
+      · exact h
+    exact H b
+
+end FourthRoot2Degree4OQ02OQ01
+
+/-! ## Axiom audit
+
+Confirms the headline results depend only on the foundational
+`propext` / `Classical.choice` / `Quot.sound` — no `sorryAx`, no
+`Lean.ofReduceBool` (i.e. no `native_decide`). -/
+
+#print axioms FourthRoot2Degree4OQ02OQ01.irreducible_X_pow_sub_C_odd_iff
+#print axioms FourthRoot2Degree4OQ02OQ01.irreducible_X_pow_sub_C_primePow_iff
+#print axioms FourthRoot2Degree4OQ02OQ01.X4_add_4_reducible
+#print axioms FourthRoot2Degree4OQ02OQ01.prime_divisor_criterion_insufficient
+#print axioms FourthRoot2Degree4OQ02OQ01.irreducible_X3_sub_C_iff

--- a/proofs/Proofs/FourthRoot2Degree4OQ02OQ01.lean
+++ b/proofs/Proofs/FourthRoot2Degree4OQ02OQ01.lean
@@ -141,7 +141,7 @@ theorem neg64_not_square : ∀ b : ℚ, b ^ 2 ≠ -64 := by
 /-- `X⁴ − C(−4)` is reducible over `ℚ`.  Rewriting `C(−4) = −4` turns the
 Kummer-form statement into the Sophie Germain witness. -/
 theorem X_pow_sub_C_neg4_reducible : ¬ Irreducible (X ^ 4 - C (-4 : ℚ)) := by
-  have hC : C (-4 : ℚ) = -4 := by simp
+  have hC : C (-4 : ℚ) = -4 := by rw [map_neg, map_ofNat]
   rw [hC]
   have h : (X ^ 4 - (-4) : ℚ[X]) = X ^ 4 + 4 := by ring
   rw [h]; exact X4_add_4_reducible

--- a/src/data/proofs/fourth-root-2-degree4-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/fourth-root-2-degree4-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-oq0201-general-a-odd",
+    "proofId": "fourth-root-2-degree4-oq-02-oq-01",
+    "range": { "startLine": 73, "endLine": 83 },
+    "type": "insight",
+    "title": "The general-a criterion, where Mathlib supplies it",
+    "content": "irreducible_X_pow_sub_C_odd_iff and irreducible_X_pow_sub_C_primePow_iff restate Mathlib's Kummer lemmas as the general-a analogues of the parent's prime-only packaging. For odd n, Xⁿ − a is irreducible over any field K iff a is not a perfect d-th power for every 1 ≠ d ∣ n. For n = pᵏ with p an odd prime, it reduces to a single p-th power test. These are the 'yes it extends to general a' half of the open question — and they hold for arbitrary a because the exceptional 4 ∣ n clause cannot bite in either regime.",
+    "mathContext": "$\\mathrm{Irreducible}(X^n - a) \\iff \\forall d \\mid n,\\ d \\neq 1 \\Rightarrow \\forall b,\\ b^d \\neq a$ (odd $n$).",
+    "significance": "central",
+    "relatedConcepts": ["Kummer extension", "Vahlen–Capelli criterion", "perfect powers"],
+    "prerequisites": ["field theory", "irreducible polynomials"]
+  },
+  {
+    "id": "ann-oq0201-sophie-germain",
+    "proofId": "fourth-root-2-degree4-oq-02-oq-01",
+    "range": { "startLine": 91, "endLine": 99 },
+    "type": "insight",
+    "title": "Sophie Germain's identity as the sharp witness",
+    "content": "sophie_germain_4 (X⁴ + 4 = (X² − 2X + 2)(X² + 2X + 2)) and sophie_germain_64 (its c = 2 member, a = −64 = −4·2⁴) are proved by a single `ring` call each — pure polynomial arithmetic with rational numeral coefficients. Reading X⁴ + 4c⁴ as X⁴ − a with a = −4c⁴, these exhibit reducible binomials whose constant is not a perfect square. This is the classical example showing 'no rational root' is strictly weaker than 'irreducible' for quartics.",
+    "mathContext": "$X^4 + 4c^4 = (X^2 - 2cX + 2c^2)(X^2 + 2cX + 2c^2)$; here $c = 1$ and $c = 2$.",
+    "significance": "central",
+    "relatedConcepts": ["Sophie Germain identity", "polynomial factorization", "quartic polynomials"],
+    "prerequisites": ["commutative ring arithmetic"]
+  },
+  {
+    "id": "ann-oq0201-reducible",
+    "proofId": "fourth-root-2-degree4-oq-02-oq-01",
+    "range": { "startLine": 107, "endLine": 126 },
+    "type": "tactic",
+    "title": "Refuting irreducibility with no root-finding",
+    "content": "To prove ¬Irreducible(X⁴ + 4) we never look for roots. not_isUnit_of_natDegree_two shows a degree-2 rational polynomial is not a unit (natDegree_eq_zero_of_isUnit forces natDegree 0 for units). Feeding the Sophie Germain factorization to Irreducible.isUnit_or_isUnit yields IsUnit of one quadratic factor, contradicted since compute_degree! certifies each factor has natDegree 2. This is the correct handle for quartics that factor into two irreducible quadratics.",
+    "mathContext": "A product of two non-units is reducible; units in $K[X]$ are exactly the nonzero constants (degree 0).",
+    "significance": "supporting",
+    "relatedConcepts": ["units in polynomial rings", "degree", "reducibility"],
+    "prerequisites": ["Irreducible.isUnit_or_isUnit", "compute_degree!"]
+  },
+  {
+    "id": "ann-oq0201-capstone",
+    "proofId": "fourth-root-2-degree4-oq-02-oq-01",
+    "range": { "startLine": 149, "endLine": 160 },
+    "type": "insight",
+    "title": "The prime-divisor criterion is provably insufficient",
+    "content": "prime_divisor_criterion_insufficient is the entry's answer to the open question: ∃ a : ℚ, (∀ b, b² ≠ a) ∧ ¬Irreducible(X⁴ − C a), witnessed by a = −4. Since −4 is not a perfect square (neg4_not_square, from sq_nonneg), it passes the only relevant prime-divisor test (d = 2 is the sole prime dividing 4), yet X⁴ − C(−4) = X⁴ + 4 is reducible. This is exactly the a ∈ −4·(fourth powers) exceptional clause of Vahlen–Capelli that Mathlib's Kummer API marks with a TODO — and it shows a prime a (as in the parent) can never trigger it.",
+    "mathContext": "$-4$ passes 'not a perfect square' yet $X^4 - C(-4)$ is reducible: the naive criterion fails for $4 \\mid n$.",
+    "significance": "central",
+    "relatedConcepts": ["Vahlen–Capelli criterion", "sharp boundary", "counterexample"],
+    "prerequisites": ["existential statements", "field theory"]
+  },
+  {
+    "id": "ann-oq0201-cube-iff",
+    "proofId": "fourth-root-2-degree4-oq-02-oq-01",
+    "range": { "startLine": 171, "endLine": 189 },
+    "type": "tactic",
+    "title": "The odd criterion in action: cubes",
+    "content": "irreducible_X3_sub_C_iff specializes the odd-exponent criterion to n = 3, collapsing it to a single cube test: X³ − a is irreducible over any field K iff a is not a perfect cube. The divisor bookkeeping uses Nat.dvd_prime — the divisors of the prime 3 are exactly 1 and 3, and d ≠ 1 forces d = 3. This confirms the positive half is directly usable for general a in the covered regime.",
+    "mathContext": "$\\mathrm{Irreducible}(X^3 - a) \\iff \\forall b,\\ b^3 \\neq a$.",
+    "significance": "supporting",
+    "relatedConcepts": ["cube roots", "prime divisors"],
+    "prerequisites": ["Nat.dvd_prime"]
+  }
+]

--- a/src/data/proofs/fourth-root-2-degree4-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fourth-root-2-degree4-oq-02-oq-01/meta.json
@@ -1,0 +1,111 @@
+{
+  "id": "fourth-root-2-degree4-oq-02-oq-01",
+  "slug": "fourth-root-2-degree4-oq-02-oq-01",
+  "title": "From Xⁿ − p to Xⁿ − a: the full Kummer criterion for general a, and why the 4 ∣ n clause is unavoidable (Vahlen–Capelli sharp boundary)",
+  "description": "Open-question generalization of fourth-root-2-degree4-oq-02, which packaged Eisenstein for Xⁿ − p with p prime. This entry asks whether the packaging extends to Xⁿ − a for a general (non-prime) a via the full Kummer / Vahlen–Capelli criterion. The answer has two halves. YES for the regimes Mathlib supplies: for odd n, and for prime-power exponents pᵏ with p ≠ 2, irreducibility of Xⁿ − a over any field is governed purely by whether a is a perfect power (restated as irreducible_X_pow_sub_C_odd_iff and irreducible_X_pow_sub_C_primePow_iff). But NOT naively once 4 ∣ n: the naive statement 'Xⁿ − a irreducible ⟺ a not a perfect d-th power for any prime d ∣ n' is provably FALSE. We formalize the sharp witness via Sophie Germain's identity X⁴ + 4c⁴ = (X² − 2cX + 2c²)(X² + 2cX + 2c²): taking a = −4c⁴ gives a reducible X⁴ − C a even though a < 0 is not a perfect square, so the only prime divisor d = 2 of 4 passes the 'not a d-th power' test. The capstone prime_divisor_criterion_insufficient packages this as ∃ a : ℚ, (∀ b, b² ≠ a) ∧ ¬Irreducible(X⁴ − C a) — exactly the a ∈ −4·(fourth powers) exceptional clause that Mathlib's Kummer API leaves as a TODO.",
+  "meta": {
+    "author": "Lean Genius (Researcher)",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FourthRoot2Degree4OQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "field-theory",
+      "irreducibility",
+      "kummer-extension",
+      "vahlen-capelli",
+      "sophie-germain-identity",
+      "polynomial-factorization",
+      "sharp-boundary",
+      "nth-roots"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "axiomCount": 0,
+    "assumptions": "None — fully machine-verified (0 axioms, 0 sorries; only the foundational propext / Classical.choice / Quot.sound, no native_decide). Uses Mathlib's Kummer-extension API (X_pow_sub_C_irreducible_iff_of_odd, X_pow_sub_C_irreducible_iff_of_prime_pow), Irreducible.isUnit_or_isUnit, natDegree_eq_zero_of_isUnit, and the compute_degree! tactic."
+  },
+  "overview": {
+    "historicalContext": "The irreducibility of the binomial $X^n - a$ over a field is completely settled by a theorem usually credited to Theodor **Vahlen** (1895) and Alfredo **Capelli** (1897): $X^n - a$ is irreducible over a field $K$ if and only if $a$ is not a perfect $p$-th power in $K$ for any prime $p \\mid n$, AND, in the exceptional case $4 \\mid n$, additionally $a \\notin -4K^4$. The last clause is genuinely necessary and is witnessed by **Sophie Germain's identity** $X^4 + 4 = (X^2 - 2X + 2)(X^2 + 2X + 2)$ (Marie-Sophie Germain, early 1800s), the classic example of a polynomial that factors despite having no rational root and a constant term ($4$, i.e. $a = -4$) that is not a perfect square.\n\nMathlib's `Mathlib/FieldTheory/KummerExtension.lean` proves the Vahlen–Capelli criterion for arbitrary $a$ only in the two regimes where the exceptional clause cannot bite — odd $n$ (`X_pow_sub_C_irreducible_iff_of_odd`) and prime-power exponents $p^k$ with $p \\neq 2$ (`X_pow_sub_C_irreducible_iff_of_prime_pow`) — and marks the even / $p = 2$ case with explicit TODO comments. The parent gallery entry sidestepped this by working with $X^n - p$ for a **prime** $a = p$, which is never a nontrivial power and never lies in $-4K^4$, so the subtlety never appears. This entry confronts general $a$ head-on.",
+    "problemStatement": "Does the parent's Eisenstein packaging for $X^n - p$ (prime $p$) extend to $X^n - a$ for a general element $a$, via the full Kummer criterion that $X^n - a$ is irreducible iff $a$ is not a perfect $d$-th power for any prime $d \\mid n$ (and $a \\notin -4 \\cdot (\\text{fourth powers})$ when $4 \\mid n$)? State the general-$a$ criterion in the regimes Mathlib supplies, and settle whether the extra $4 \\mid n$ clause is genuinely necessary or an artifact.",
+    "proofStrategy": "Two movements. (1) The 'yes' half: `irreducible_X_pow_sub_C_odd_iff` and `irreducible_X_pow_sub_C_primePow_iff` restate Mathlib's Kummer lemmas as general-$a$ criteria — for odd $n$, or $n = p^k$ with $p \\neq 2$, irreducibility of $X^n - a$ is exactly 'a is not a perfect power'. (2) The sharp boundary: the Sophie Germain identities `sophie_germain_4` ($X^4 + 4 = (X^2-2X+2)(X^2+2X+2)$) and `sophie_germain_64` ($X^4 + 64 = (X^2-4X+8)(X^2+4X+8)$, the $c=2$ member) are pure `ring` facts. Each quadratic factor has `natDegree = 2 \\neq 0`, hence is not a unit (`not_isUnit_of_natDegree_two` via `natDegree_eq_zero_of_isUnit`); `Irreducible.isUnit_or_isUnit` then refutes irreducibility (`X4_add_4_reducible`, `X4_add_64_reducible`). Recasting $X^4 + 4 = X^4 - C(-4)$ (via `map_neg`, `map_ofNat`) and observing $-4$ is not a square (`neg4_not_square`, from `sq_nonneg`) yields the capstone `prime_divisor_criterion_insufficient`: $\\exists a : \\mathbb{Q}$, not a square, with $X^4 - C\\,a$ reducible. Part 5 confirms the positive half is usable by specializing the odd criterion to $X^3 - a$ (`irreducible_X3_sub_C_iff`).",
+    "keyInsights": [
+      "The parent's prime-$a$ packaging hides the real difficulty. A prime $p$ is never a nontrivial perfect power and never lies in $-4K^4$, so for $X^n - p$ the Vahlen–Capelli criterion collapses to 'p is prime' and the exceptional $4 \\mid n$ clause is invisible. General $a$ exposes it.",
+      "For odd $n$, or $n = p^k$ with $p$ an odd prime, the criterion IS the naive one: $X^n - a$ is irreducible over a field iff $a$ is not a perfect $d$-th power for the relevant primes $d \\mid n$. Mathlib supplies both, and they hold for arbitrary $a$.",
+      "The naive criterion fails exactly when $4 \\mid n$. Sophie Germain's identity $X^4 + 4 = (X^2 - 2X + 2)(X^2 + 2X + 2)$ exhibits a reducible $X^4 - a$ with $a = -4$ — a value that is NOT a perfect square (indeed $a < 0$), so it passes the only relevant prime-divisor test $d = 2$.",
+      "The witnesses form a one-parameter family $a = -4c^4$: $X^4 + 4c^4 = (X^2 - 2cX + 2c^2)(X^2 + 2cX + 2c^2)$. The entry formalizes $c = 1$ ($a=-4$) and $c = 2$ ($a=-64$) with pure numeral `ring` identities, both reducible and both non-squares.",
+      "The reducibility proof needs no root-finding: a degree-4 polynomial can factor into two irreducible quadratics with no linear factor. 'Not a perfect square' (no root of $X^2 - a$) is therefore strictly weaker than 'irreducible' for quartics — the gap the $-4K^4$ clause fills.",
+      "The capstone `prime_divisor_criterion_insufficient` is a self-contained impossibility statement: it exhibits a rational $a$ passing every prime-divisor power test yet with $X^4 - C\\,a$ reducible, proving the parent's prime-only packaging cannot naively extend to general $a$ once $4 \\mid n$."
+    ]
+  },
+  "sections": [
+    {
+      "id": "general-a-covered-regimes",
+      "title": "The general-a criterion in the regimes Mathlib covers",
+      "startLine": 60,
+      "endLine": 83,
+      "summary": "irreducible_X_pow_sub_C_odd_iff restates X_pow_sub_C_irreducible_iff_of_odd: for any field K, odd n, and any a : K, Xⁿ − a is irreducible iff a is not a perfect d-th power for every divisor 1 ≠ d ∣ n. irreducible_X_pow_sub_C_primePow_iff restates X_pow_sub_C_irreducible_iff_of_prime_pow: for n = pᵏ with p an odd prime and k ≥ 1, irreducibility reduces to a single p-th power test. These are the 'yes it extends' half for general a."
+    },
+    {
+      "id": "sophie-germain-identities",
+      "title": "Sophie Germain factorisations (the 4 ∣ n, a = −4c⁴ family)",
+      "startLine": 85,
+      "endLine": 100,
+      "summary": "sophie_germain_4 (X⁴ + 4 = (X² − 2X + 2)(X² + 2X + 2)) and sophie_germain_64 (X⁴ + 64 = (X² − 4X + 8)(X² + 4X + 8), the c = 2 member with a = −64 = −4·2⁴) are pure numeral ring identities, each exhibiting X⁴ − a (a = −4c⁴ < 0, not a square) as a product of two quadratics."
+    },
+    {
+      "id": "reducibility-of-witnesses",
+      "title": "Reducibility of the witnesses",
+      "startLine": 101,
+      "endLine": 126,
+      "summary": "not_isUnit_of_natDegree_two: a rational polynomial of natDegree 2 is not a unit (via natDegree_eq_zero_of_isUnit). X4_add_4_reducible and X4_add_64_reducible: each quadratic factor has natDegree 2 (compute_degree!), so Irreducible.isUnit_or_isUnit applied to the Sophie Germain factorization is refuted — X⁴ + 4 and X⁴ + 64 are reducible over ℚ."
+    },
+    {
+      "id": "sharp-boundary-capstone",
+      "title": "Recasting into Xⁿ − C a form and the sharp boundary",
+      "startLine": 128,
+      "endLine": 160,
+      "summary": "neg4_not_square and neg64_not_square: −4 and −64 are not perfect squares in ℚ (via sq_nonneg), so they pass the only prime-divisor test for n = 4. X_pow_sub_C_neg4_reducible rewrites C(−4) = −4 to connect the Kummer-form X⁴ − C(−4) to the Sophie Germain witness X⁴ + 4. The capstone prime_divisor_criterion_insufficient: ∃ a : ℚ, (∀ b, b² ≠ a) ∧ ¬Irreducible(X⁴ − C a), formalizing that the naive prime-divisor criterion is insufficient for even exponents — the a ∈ −4·(fourth powers) clause Mathlib leaves as TODO."
+    },
+    {
+      "id": "positive-instance-cubes",
+      "title": "A concrete positive general-a instance in the covered regime",
+      "startLine": 161,
+      "endLine": 189,
+      "summary": "irreducible_X3_sub_C_iff specializes the odd-exponent criterion to n = 3: X³ − a is irreducible over any field K iff a is not a perfect cube in K. The divisors of the prime 3 are 1 and 3, so the general criterion collapses to a single cube test (via Nat.dvd_prime), confirming the positive half is directly usable for general a."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fourth-root-2-degree4-oq-02",
+      "relationship": "generalizes",
+      "description": "Parent entry. It packaged Eisenstein for Xⁿ − p with p prime; this entry addresses its open question about general (non-prime) a, showing the Kummer criterion extends for odd n and p ≠ 2 prime powers, but that the 4 ∣ n exceptional clause (a ∉ −4·fourth powers) is genuinely necessary — witnessed by Sophie Germain's X⁴ + 4."
+    },
+    {
+      "targetId": "fourth-root-2-irrational",
+      "relationship": "related",
+      "description": "Grandparent gallery entry ([ℚ(⁴√2):ℚ] = 4). The present entry explains why the parent had to restrict to prime a: for general a with 4 ∣ n, irreducibility of Xⁿ − a is strictly subtler than 'a is not a perfect power'."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent's Xⁿ − p packaging (prime p) extends to general a in the regimes Mathlib supplies — odd n and p ≠ 2 prime-power exponents — where irreducibility of Xⁿ − a is exactly 'a is not a perfect power' (irreducible_X_pow_sub_C_odd_iff, irreducible_X_pow_sub_C_primePow_iff, and the specialization irreducible_X3_sub_C_iff). But the naive extension to all n is FALSE: once 4 ∣ n the Vahlen–Capelli theorem requires the extra clause a ∉ −4·(fourth powers), and Sophie Germain's identity X⁴ + 4c⁴ = (X² − 2cX + 2c²)(X² + 2cX + 2c²) supplies reducible witnesses X⁴ − C a with a = −4c⁴ not a perfect square. The capstone prime_divisor_criterion_insufficient formalizes this as ∃ a : ℚ, (∀ b, b² ≠ a) ∧ ¬Irreducible(X⁴ − C a). All results are fully machine-checked with 0 sorries and 0 axioms (only foundational propext / Classical.choice / Quot.sound; no native_decide).",
+    "implications": "This answers the parent's open question precisely: the packaging extends for general a wherever Mathlib's Kummer API reaches (odd n, p ≠ 2 prime powers), but the 4 ∣ n case is not a rote generalization — it carries a genuine exceptional clause that a prime a can never trigger, which is exactly why the parent could safely restrict to Xⁿ − p. The Sophie Germain witnesses pin down the sharp boundary between 'not a perfect power' and 'irreducible' for even exponents.",
+    "openQuestions": [
+      "Can the full Vahlen–Capelli criterion for 4 ∣ n — Xⁿ − a irreducible iff a is neither a perfect d-th power (prime d ∣ n) nor of the form −4c⁴ — be formalized in Lean and contributed upstream to discharge the TODO in Mathlib/FieldTheory/KummerExtension.lean?",
+      "For which fields K does the −4K⁴ clause actually remove elements? Over ℝ every negative number is −4c⁴ for some c, whereas over ℚ the condition a ∈ −4ℚ⁴ is a thin sublattice; characterize the reducible locus of X⁴ − a as a function of K.",
+      "Is the family a = −4c⁴ the ONLY source of reducible X⁴ − a with a not a perfect square over ℚ, and does an analogous single-family description hold for X^{4m} − a?"
+    ]
+  },
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Polynomial"],
+    "namespace": "FourthRoot2Degree4OQ02OQ01",
+    "lineCount": 196,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/FourthRoot2Degree4OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question of **fourth-root-2-degree4-oq-02** (parent packaged Eisenstein for `Xⁿ − p`, *prime* p): *does the packaging extend to `Xⁿ − a` for general (non-prime) `a` via the full Kummer / Vahlen–Capelli criterion?*

The answer has two halves, both formalized:

- **YES where Mathlib reaches.** For odd `n`, and for prime-power exponents `pᵏ` with `p ≠ 2`, irreducibility of `Xⁿ − a` over any field is exactly "`a` is not a perfect power" — restated as `irreducible_X_pow_sub_C_odd_iff` and `irreducible_X_pow_sub_C_primePow_iff` (plus the concrete specialization `irreducible_X3_sub_C_iff`).
- **NOT naively once `4 ∣ n`.** The naive criterion "`Xⁿ − a` irreducible ⟺ `a` not a perfect `d`-th power for any prime `d ∣ n`" is **provably false**. Sophie Germain's identity `X⁴ + 4c⁴ = (X² − 2cX + 2c²)(X² + 2cX + 2c²)` gives reducible witnesses `X⁴ − C a` with `a = −4c⁴`, which is *not* a perfect square (it is negative) yet passes the only relevant prime-divisor test `d = 2`.

**Capstone** `prime_divisor_criterion_insufficient : ∃ a : ℚ, (∀ b : ℚ, b ^ 2 ≠ a) ∧ ¬ Irreducible (X ^ 4 - C a)` — formalizing exactly the `a ∈ −4·(fourth powers)` exceptional clause that Mathlib's Kummer API leaves as a `TODO`, and showing a prime `a` (as in the parent) can never trigger it.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.FourthRoot2Degree4OQ02OQ01` — builds clean.
- `#print axioms` on all headline results: `[propext, Classical.choice, Quot.sound]` only — **0 axioms, 0 sorries, no `native_decide`**.
- `pnpm build` — gallery entry validates.

## Files

- `proofs/Proofs/FourthRoot2Degree4OQ02OQ01.lean` (196 lines, 12 theorems, 0 defs)
- `src/data/proofs/fourth-root-2-degree4-oq-02-oq-01/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)