### PR TITLE
Enrich Planar Edge-Count Threshold (erdos-1018-oq-04-incomplete-01-oq-01): add index.ts + annotation depth

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/annotations.json
@@ -7,7 +7,9 @@
     "title": "The two quantities being compared",
     "content": "completeEdges n = n.choose 2 is the edge count of the complete graph Kₙ; planarBound n = 3 * n − 6 is Euler's planar edge bound for a simple graph on n ≥ 3 vertices. The entire entry is about the gap between these two ℕ-valued functions. Note planarBound uses truncated ℕ subtraction, which is harmless here because every comparison is made at n ≥ 3 where 3n ≥ 6.",
     "mathContext": "$\\mathrm{completeEdges}(n)=\\binom{n}{2}$, $\\mathrm{planarBound}(n)=3n-6$.",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": ["complete graph Kₙ", "binomial coefficient", "planar graph", "Euler's polyhedral formula", "truncated ℕ subtraction"],
+    "prerequisites": ["binomial coefficients", "natural-number arithmetic"]
   },
   {
     "id": "ann-e1018oq04i01oq01-pascal",
@@ -17,7 +19,9 @@
     "title": "Pascal's rule linearizes the induction",
     "content": "completeEdges_succ proves C(n+1,2) = C(n,2) + n from Nat.choose_succ_succ (Pascal: C(n+1,2) = C(n,1) + C(n,2)) and Nat.choose_one_right (C(n,1) = n). The defeq 2 = 1+1 is forced by annotating the `have` with an explicit `2`-typed statement, so omega sees a single atom C(n,2) and closes. This recurrence is what turns the nonlinear inequality C(n,2) > 3n−6 into a step that omega can advance one n at a time.",
     "mathContext": "$\\binom{n+1}{2}=\\binom{n}{1}+\\binom{n}{2}=n+\\binom{n}{2}$.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["Pascal's rule", "Nat.choose_succ_succ", "linear recurrence", "omega tactic", "definitional equality"],
+    "prerequisites": ["Pascal's identity", "recurrence relations"]
   },
   {
     "id": "ann-e1018oq04i01oq01-exceeds",
@@ -27,7 +31,9 @@
     "title": "n ≥ 5 forces Kₙ over the bound",
     "content": "Kn_exceeds_planar_bound runs Nat.le_induction from the base n = 5 (where 3·5−6 = 9 < 10 = C(5,2), closed by decide). The successor step rewrites C(n+1,2) via the Pascal lemma and hands omega the inductive hypothesis 3n−6 < C(n,2) together with n ≥ 5; since adding n to the right side outpaces the +3 on the left, omega finishes. No quadratic reasoning is ever needed.",
     "mathContext": "$n\\ge 5 \\Rightarrow 3n-6 < \\binom{n}{2}$.",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": ["Nat.le_induction", "base case n = 5", "K₅ non-planarity", "first-moment bound", "omega tactic"],
+    "prerequisites": ["mathematical induction from a base point", "Euler's planar edge bound"]
   },
   {
     "id": "ann-e1018oq04i01oq01-threshold",
@@ -37,7 +43,9 @@
     "title": "The sharp biconditional — threshold exactly at 5",
     "content": "planar_obstruction_threshold packages both directions: for n ≥ 3, C(n,2) > 3n−6 ⟺ n ≥ 5. The forward direction assumes n < 5, hence n ∈ {3,4}, and derives C(n,2) ≤ 3n−6 from Kn_within_planar_bound (proved by interval_cases + decide), contradicting the strict inequality. The backward direction is exactly Kn_exceeds_planar_bound. The equality cases K₃ (3 = 3) and K₄ (6 = 6) are what make the threshold sharp rather than merely sufficient — the obstruction switches on at the smallest possible n.",
     "mathContext": "$n\\ge 3 \\Rightarrow \\big(\\binom{n}{2} > 3n-6 \\iff n\\ge 5\\big)$; $2\\big(\\binom{n}{2}-(3n-6)\\big)=(n-3)(n-4)$.",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": ["sharp threshold", "biconditional", "interval_cases", "proof by contradiction", "extremal boundary K₃/K₄"],
+    "prerequisites": ["case analysis on bounded naturals", "logical equivalences"]
   },
   {
     "id": "ann-e1018oq04i01oq01-axioms",
@@ -47,6 +55,8 @@
     "title": "Verified, zero axioms",
     "content": "Every theorem reduces over ℕ with no sorry, no axiom declaration, and no native_decide. The `decide` calls target closed numeric goals (binomial coefficients of literal constants ≤ 5), which the kernel evaluates directly — they do not invoke Lean.ofReduceBool. So per the project's axiom-integrity policy this is a genuine 0-axiom, fully machine-verified result, in contrast to the parent entry which axiomatizes Kostochka–Pyber (r = 2) and leaves Euler's edge bound as a sorry.",
     "mathContext": "Only propext / Classical.choice / Quot.sound are used; these are not counted as assumptions.",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": ["axiom-integrity policy", "decide tactic", "Lean.ofReduceBool", "native_decide", "kernel reduction"],
+    "prerequisites": ["Lean's foundational axioms", "kernel evaluation of decidable goals"]
   }
 ]

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/index.ts
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1018OQ04Incomplete01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1018Oq04Incomplete01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1018Oq04Incomplete01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1018Oq04Incomplete01Oq01Data: ProofData = {
+  proof: erdos1018Oq04Incomplete01Oq01Proof,
+  annotations: erdos1018Oq04Incomplete01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-1018-oq-04-incomplete-01-oq-01` (Planar Edge-Count Threshold: Kₙ Exceeds 3n − 6 iff n ≥ 5).

## Changes
- **Added missing `index.ts`** — the entry had `meta.json` and `annotations.json` but no `index.ts`, so Vite's `import.meta.glob` could not discover the proof and the page rendered as *"proof not found"* on the live site. This is the highest-impact fix: the entry was effectively unreachable.
- **Deepened all 5 annotations** — added `relatedConcepts` and `prerequisites` arrays to each (previously only `content`/`mathContext`/`significance`), meeting the role's per-annotation depth target.

The `index.ts` follows the standard template: Lean source `Erdos1018OQ04Incomplete01OQ01.lean`, camelCase exports `erdos1018Oq04Incomplete01Oq01{Proof,Annotations,Data}`. `meta.json` (10.8 KB) already meets all quality targets and was left unchanged; `status`/`badge`/`axiomCount` (verified / verified / 0) are consistent with the 0-sorry, 0-axiom Lean file. `pnpm build` passes and reports the entry enriched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)