### PR TITLE
research(combinations-formula-oq-06-oq-02): uniform product closed forms for the figurate tower [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CombinationsFigurateClosedForm.lean
+++ b/proofs/Proofs/CombinationsFigurateClosedForm.lean
@@ -1,0 +1,154 @@
+import Mathlib
+
+/-
+# Uniform Product Closed Forms for the Figurate-Number Tower
+
+## Open Question (combinations-formula-oq-06, OQ-02)
+
+The sibling entry `combinations-formula-oq-06-oq-01` packaged the whole simplicial
+figurate ladder as a single parametrized family `S(k, n) = C(n+k-1, k) = multichoose n k`
+and proved the **tower identity** `∑_{m=1}^{n} S(k, m) = S(k+1, n)` uniformly in the
+dimension `k`.  It recovered the *closed form* only at the triangular rung,
+`S(2, n) = n(n+1)/2`, leaving the tetrahedral rung as the raw binomial `S(3, n) = C(n+2, 3)`.
+
+OQ-02 asks precisely: **can the closed forms for the higher figurate numbers (e.g. the
+tetrahedral `n(n+1)(n+2)/6`) be derived inside Lean without a separate induction, mirroring
+the `n(n+1)/2` closed form already obtained for the triangular case?**
+
+## Contribution
+
+Yes — and not just for the tetrahedral rung, but for *every* rung at once, with no
+induction whatsoever.  The engine is the single identity
+
+  `k ! · S(k, n) = n·(n+1)·⋯·(n+k-1) = ascFactorial n k`          (`factorial_mul_S`)
+
+which is nothing but the classical `choose ↔ ascending-factorial` bridge
+(`Nat.ascFactorial_eq_factorial_mul_choose'`) read through `S(k,n) = C(n+k-1, k)`.  This is a
+*uniform* statement covering the whole tower; its proof is a one-line rewrite, with no
+per-`k` induction.  The division form
+
+  `S(k, n) = ascFactorial n k / k !`                              (`S_closed`)
+
+is its immediate consequence.  Specializing `k`:
+
+* `k = 2` (triangular):  `2 · S(2, n) = n(n+1)`,        `S(2, n) = n(n+1)/2`
+* `k = 3` (tetrahedral): `6 · S(3, n) = n(n+1)(n+2)`,   `S(3, n) = n(n+1)(n+2)/6`
+* `k = 4` (pentatope):   `24 · S(4, n) = n(n+1)(n+2)(n+3)`, `S(4, n) = n(n+1)(n+2)(n+3)/24`
+
+The tetrahedral form is the exact object OQ-02 asked for; the pentatope rung is a genuinely
+new closed form beyond the sibling entry.  Each specialization is obtained by evaluating the
+finite product `ascFactorial n k` for a *concrete* `k` (`ascFactorial_two/three/four`, three
+`ascFactorial_succ` unfoldings closed by `ring`) — no induction on `n`, no induction on `k`.
+
+## Mathematical Context
+
+`S(k, n)` counts the `k`-multisets drawn from `{1, …, n}`, equivalently the lattice points of
+the `k`-dimensional simplex of side `n`; the product `n(n+1)⋯(n+k-1)/k!` is the ascending
+(rising-factorial) form of the binomial coefficient `C(n+k-1, k)`.  Reading the closed form
+off the ascending factorial is exactly the "no separate induction" phenomenon OQ-02 isolates:
+the induction that would normally establish each figurate closed form is absorbed once and for
+all into Mathlib's `ascFactorial ↔ choose` lemma.
+
+This entry is self-contained: it re-derives `S` from `Nat.multichoose` rather than importing the
+sibling file, so it stands alone while cross-referencing `combinations-formula-oq-06-oq-01`.
+-/
+
+namespace CombinationsFigurateClosedForm
+
+open Nat
+
+/-- The `k`-dimensional figurate number `S(k, n) = multichoose n k = C(n+k-1, k)`.
+`S(1, n) = n` (linear), `S(2, n)` triangular, `S(3, n)` tetrahedral, `S(4, n)` pentatope. -/
+def S (k n : ℕ) : ℕ := Nat.multichoose n k
+
+/-- `S(k, n) = C(n+k-1, k)`: the multiset coefficient as an ordinary binomial coefficient. -/
+theorem S_eq_choose (k n : ℕ) : S k n = (n + k - 1).choose k := by
+  rw [S, Nat.multichoose_eq]
+
+/-- **Uniform product closed form.** For every dimension `k`, `k! · S(k, n)` equals the
+ascending factorial `n(n+1)⋯(n+k-1)`.  A single statement covering the entire figurate tower;
+the proof is the `choose ↔ ascending-factorial` bridge, with no per-`k` induction. -/
+theorem factorial_mul_S (k n : ℕ) : k ! * S k n = n.ascFactorial k := by
+  rw [S_eq_choose]
+  exact (Nat.ascFactorial_eq_factorial_mul_choose' n k).symm
+
+/-- **Division form of the uniform closed form:** `S(k, n) = n(n+1)⋯(n+k-1) / k!`, for every
+dimension `k` simultaneously. -/
+theorem S_closed (k n : ℕ) : S k n = n.ascFactorial k / k ! := by
+  rw [S_eq_choose]
+  exact Nat.choose_eq_asc_factorial_div_factorial' n k
+
+/-!
+### Evaluating the finite product `ascFactorial n k` at concrete dimensions
+
+Each is three-or-fewer `ascFactorial_succ` unfoldings closed by `ring` — no induction. -/
+
+/-- `n(n+1)`: the ascending factorial at dimension 2. -/
+theorem ascFactorial_two (n : ℕ) : n.ascFactorial 2 = n * (n + 1) := by
+  have h2 : n.ascFactorial 2 = (n + 1) * n.ascFactorial 1 := Nat.ascFactorial_succ
+  have h1 : n.ascFactorial 1 = (n + 0) * n.ascFactorial 0 := Nat.ascFactorial_succ
+  rw [h2, h1, Nat.ascFactorial_zero]; ring
+
+/-- `n(n+1)(n+2)`: the ascending factorial at dimension 3. -/
+theorem ascFactorial_three (n : ℕ) : n.ascFactorial 3 = n * (n + 1) * (n + 2) := by
+  have h3 : n.ascFactorial 3 = (n + 2) * n.ascFactorial 2 := Nat.ascFactorial_succ
+  rw [h3, ascFactorial_two]; ring
+
+/-- `n(n+1)(n+2)(n+3)`: the ascending factorial at dimension 4. -/
+theorem ascFactorial_four (n : ℕ) : n.ascFactorial 4 = n * (n + 1) * (n + 2) * (n + 3) := by
+  have h4 : n.ascFactorial 4 = (n + 3) * n.ascFactorial 3 := Nat.ascFactorial_succ
+  rw [h4, ascFactorial_three]; ring
+
+/-!
+### Multiplied closed forms (division-free)
+
+The cleanest, most honest statements: no natural-number division truncation is involved. -/
+
+/-- Triangular rung: `2 · S(2, n) = n(n+1)`. -/
+theorem two_mul_S_two (n : ℕ) : 2 * S 2 n = n * (n + 1) := by
+  have h := factorial_mul_S 2 n
+  rwa [ascFactorial_two, show (2 : ℕ)! = 2 from rfl] at h
+
+/-- Tetrahedral rung: `6 · S(3, n) = n(n+1)(n+2)` — the object OQ-02 asked for, exact form. -/
+theorem six_mul_S_three (n : ℕ) : 6 * S 3 n = n * (n + 1) * (n + 2) := by
+  have h := factorial_mul_S 3 n
+  rwa [ascFactorial_three, show (3 : ℕ)! = 6 from rfl] at h
+
+/-- Pentatope rung: `24 · S(4, n) = n(n+1)(n+2)(n+3)` — a new closed form beyond oq-06-oq-01. -/
+theorem twentyfour_mul_S_four (n : ℕ) : 24 * S 4 n = n * (n + 1) * (n + 2) * (n + 3) := by
+  have h := factorial_mul_S 4 n
+  rwa [ascFactorial_four, show (4 : ℕ)! = 24 from rfl] at h
+
+/-!
+### Divided closed forms
+
+The familiar textbook shapes, recovered by dividing the multiplied forms. -/
+
+/-- Triangular closed form: `S(2, n) = n(n+1)/2`, mirroring the sibling's `S_two_closed`. -/
+theorem S_two_closed (n : ℕ) : S 2 n = n * (n + 1) / 2 :=
+  Nat.eq_div_of_mul_eq_right (by norm_num) (two_mul_S_two n)
+
+/-- **Tetrahedral closed form:** `S(3, n) = n(n+1)(n+2)/6`.  The exact answer to OQ-02. -/
+theorem S_three_closed (n : ℕ) : S 3 n = n * (n + 1) * (n + 2) / 6 :=
+  Nat.eq_div_of_mul_eq_right (by norm_num) (six_mul_S_three n)
+
+/-- Pentatope closed form: `S(4, n) = n(n+1)(n+2)(n+3)/24`. -/
+theorem S_four_closed (n : ℕ) : S 4 n = n * (n + 1) * (n + 2) * (n + 3) / 24 :=
+  Nat.eq_div_of_mul_eq_right (by norm_num) (twentyfour_mul_S_four n)
+
+/-!
+### The `k = 1` base rung and concrete sanity checks -/
+
+/-- Linear rung: `S(1, n) = n`. -/
+@[simp] theorem S_one (n : ℕ) : S 1 n = n := Nat.multichoose_one_right n
+
+/-- Tetrahedral number `S(3, 4) = 4·5·6/6 = 20`. -/
+example : S 3 4 = 20 := by rw [S_three_closed]
+
+/-- Pentatope number `S(4, 3) = 3·4·5·6/24 = 15`. -/
+example : S 4 3 = 15 := by rw [S_four_closed]
+
+/-- Triangular number `S(2, 5) = 5·6/2 = 15`. -/
+example : S 2 5 = 15 := by rw [S_two_closed]
+
+end CombinationsFigurateClosedForm

--- a/src/data/proofs/combinations-formula-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-06-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "figclosed-oq0602-header",
+    "proofId": "combinations-formula-oq-06-oq-02",
+    "range": { "startLine": 3, "endLine": 54 },
+    "type": "concept",
+    "title": "Deriving the higher figurate closed forms without a separate induction",
+    "content": "The header states the open question: the sibling entry combinations-formula-oq-06-oq-01 packaged the figurate tower S(k,n) = C(n+k−1,k) = multichoose n k and proved the tower identity uniformly in the dimension k, but recovered the closed form only at the triangular rung S(2,n) = n(n+1)/2, leaving the tetrahedral rung as the raw binomial C(n+2,3). The parent's open question (and the sibling's open question 0) asks whether the higher closed forms — tetrahedral n(n+1)(n+2)/6, pentatope n(n+1)(n+2)(n+3)/24, and in general the rising-factorial form — can be derived inside Lean uniformly in k without a fresh induction for each rung. This entry answers yes, via one identity that reads a single Mathlib lemma through the family object. 0 axioms, 0 sorries.",
+    "mathContext": "$S(k,n) = \\binom{n+k-1}{k};\\quad S(2,n)=\\tfrac{n(n+1)}{2},\\ S(3,n)=\\tfrac{n(n+1)(n+2)}{6},\\ S(4,n)=\\tfrac{n(n+1)(n+2)(n+3)}{24}$",
+    "significance": "supporting",
+    "relatedConcepts": ["figurate numbers", "closed form", "rising factorial", "multiset coefficient", "simplicial numbers"],
+    "prerequisites": ["binomial coefficients", "Nat.multichoose", "the sibling figurate-tower entry"]
+  },
+  {
+    "id": "figclosed-oq0602-family-object",
+    "proofId": "combinations-formula-oq-06-oq-02",
+    "range": { "startLine": 56, "endLine": 66 },
+    "type": "definition",
+    "title": "The figurate family object S(k,n) = C(n+k−1,k)",
+    "content": "S(k,n) := Nat.multichoose n k is the k-dimensional figurate number, taken directly as Mathlib's multiset coefficient. S_eq_choose rewrites it to the ordinary binomial C(n+k−1,k) via Nat.multichoose_eq. This is the same family object as the sibling entry, re-derived here so this entry is self-contained rather than importing the sibling file — avoiding any cross-file build coupling while still cross-referencing it.",
+    "mathContext": "$S(k,n) = \\mathrm{multichoose}(n,k) = \\binom{n+k-1}{k}$",
+    "significance": "foundational",
+    "relatedConcepts": ["multiset coefficient", "binomial coefficient", "figurate numbers"],
+    "prerequisites": ["Nat.multichoose", "Nat.multichoose_eq"]
+  },
+  {
+    "id": "figclosed-oq0602-uniform-closed-form",
+    "proofId": "combinations-formula-oq-06-oq-02",
+    "range": { "startLine": 68, "endLine": 80 },
+    "type": "key-step",
+    "title": "The uniform product closed form: k! · S(k,n) = ascFactorial n k",
+    "content": "This is the mathematical heart of the entry. factorial_mul_S states k! · S(k,n) = n·(n+1)·⋯·(n+k−1) = Nat.ascFactorial n k, a SINGLE identity valid for every dimension k with no per-k induction. Its proof is one rewrite: read Mathlib's Nat.ascFactorial_eq_factorial_mul_choose' (which says n.ascFactorial k = k! · C(n+k−1,k)) backwards through S_eq_choose. The 'no separate induction' phenomenon the open question isolates is therefore genuine — the induction that classically establishes each figurate closed form is pre-packaged in the choose ↔ ascending-factorial bridge, and reading it through S(k,n) = C(n+k−1,k) settles every rung at once. S_closed then gives the division form S(k,n) = ascFactorial n k / k! directly from Nat.choose_eq_asc_factorial_div_factorial'.",
+    "mathContext": "$k!\\cdot S(k,n) = \\prod_{i=0}^{k-1}(n+i) = n^{\\overline{k}};\\qquad S(k,n) = \\frac{n^{\\overline{k}}}{k!}$",
+    "significance": "central",
+    "relatedConcepts": ["ascending factorial", "rising factorial", "closed form", "Pochhammer symbol"],
+    "prerequisites": ["Nat.ascFactorial_eq_factorial_mul_choose'", "Nat.choose_eq_asc_factorial_div_factorial'"]
+  },
+  {
+    "id": "figclosed-oq0602-ascfactorial-evals",
+    "proofId": "combinations-formula-oq-06-oq-02",
+    "range": { "startLine": 81, "endLine": 101 },
+    "type": "technique",
+    "title": "Evaluating the finite ascending-factorial product without induction",
+    "content": "To exhibit the classical shapes, ascFactorial n k is evaluated at concrete dimensions. Because the second argument is a numeral, ascFactorial_two/three/four unfold Nat.ascFactorial_succ three-or-fewer times — each application peels off one factor (n+i) — down to ascFactorial n 0 = 1, and ring normalizes the product. This is fully elementary: no induction on n and no induction on k. The general mathematical content lives in factorial_mul_S; these evaluations are only the arithmetic of a fixed-length product.",
+    "mathContext": "$n^{\\overline{2}}=n(n+1),\\quad n^{\\overline{3}}=n(n+1)(n+2),\\quad n^{\\overline{4}}=n(n+1)(n+2)(n+3)$",
+    "significance": "supporting",
+    "relatedConcepts": ["ascending factorial", "finite products"],
+    "prerequisites": ["Nat.ascFactorial_succ", "Nat.ascFactorial_zero", "ring"]
+  },
+  {
+    "id": "figclosed-oq0602-multiplied-forms",
+    "proofId": "combinations-formula-oq-06-oq-02",
+    "range": { "startLine": 102, "endLine": 121 },
+    "type": "key-step",
+    "title": "Multiplied closed forms: the honest, division-free statements",
+    "content": "Combining factorial_mul_S with the ascFactorial evaluations and the numeric factorials 2! = 2, 3! = 6, 4! = 24 gives 2·S(2,n) = n(n+1), 6·S(3,n) = n(n+1)(n+2), and 24·S(4,n) = n(n+1)(n+2)(n+3). These are exact equations of natural numbers — no truncating division is involved — so they are the most faithful form of the closed forms. The tetrahedral case six_mul_S_three is precisely the object the open question named; twentyfour_mul_S_four is a pentatope rung that goes beyond the sibling entry.",
+    "mathContext": "$2\\,S(2,n)=n(n+1),\\quad 6\\,S(3,n)=n(n+1)(n+2),\\quad 24\\,S(4,n)=n(n+1)(n+2)(n+3)$",
+    "significance": "central",
+    "relatedConcepts": ["tetrahedral numbers", "pentatope numbers", "triangular numbers", "closed form"],
+    "prerequisites": ["factorial_mul_S", "Nat.factorial"]
+  },
+  {
+    "id": "figclosed-oq0602-divided-forms",
+    "proofId": "combinations-formula-oq-06-oq-02",
+    "range": { "startLine": 122, "endLine": 138 },
+    "type": "key-step",
+    "title": "Divided closed forms: the textbook shapes",
+    "content": "Dividing each multiplied identity by its factorial with Nat.eq_div_of_mul_eq_right yields the familiar textbook forms S(2,n) = n(n+1)/2, S(3,n) = n(n+1)(n+2)/6, and S(4,n) = n(n+1)(n+2)(n+3)/24. The divisibility needed for the natural-number quotient to be exact is supplied automatically by the multiplied identities themselves. S_three_closed is the exact tetrahedral answer the open question requested, mirroring the sibling's triangular S_two_closed one rung up.",
+    "mathContext": "$S(2,n)=\\tfrac{n(n+1)}{2},\\quad S(3,n)=\\tfrac{n(n+1)(n+2)}{6},\\quad S(4,n)=\\tfrac{n(n+1)(n+2)(n+3)}{24}$",
+    "significance": "central",
+    "relatedConcepts": ["tetrahedral numbers", "pentatope numbers", "closed form", "natural-number division"],
+    "prerequisites": ["Nat.eq_div_of_mul_eq_right", "the multiplied closed forms"]
+  },
+  {
+    "id": "figclosed-oq0602-base-and-checks",
+    "proofId": "combinations-formula-oq-06-oq-02",
+    "range": { "startLine": 139, "endLine": 154 },
+    "type": "example",
+    "title": "The linear base rung and concrete sanity checks",
+    "content": "S_one : S(1,n) = n gives the linear rung (the natural numbers) from Nat.multichoose_one_right. The concrete checks S(3,4) = 20 (the 4th tetrahedral number), S(4,3) = 15 (the 3rd pentatope number), and S(2,5) = 15 (the 5th triangular number) are closed by kernel reduction through the divided closed forms — using rfl, not native_decide, so the entry remains free of the Lean.ofReduceBool dependency.",
+    "mathContext": "$S(1,n)=n;\\quad S(3,4)=20,\\ S(4,3)=15,\\ S(2,5)=15$",
+    "significance": "supporting",
+    "relatedConcepts": ["tetrahedral numbers", "pentatope numbers", "triangular numbers"],
+    "prerequisites": ["Nat.multichoose_one_right", "kernel reduction"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-06-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-06-oq-02/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "combinations-formula-oq-06-oq-02",
+  "title": "Uniform Product Closed Forms for the Figurate-Number Tower",
+  "slug": "combinations-formula-oq-06-oq-02",
+  "description": "Answers the open question of whether the closed forms for higher figurate numbers (tetrahedral n(n+1)(n+2)/6, pentatope n(n+1)(n+2)(n+3)/24, and in general the rising-factorial form) can be derived inside Lean without a separate induction, mirroring the triangular n(n+1)/2 already obtained. The engine is one uniform identity, factorial_mul_S : k! · S(k,n) = ascFactorial n k = n(n+1)⋯(n+k-1), the choose ↔ ascending-factorial bridge read through S(k,n) = C(n+k-1,k); the division form S(k,n) = ascFactorial n k / k! is its immediate consequence. Both hold for every dimension k at once with no induction. Specializing k gives the triangular (2·S = n(n+1)), tetrahedral (6·S = n(n+1)(n+2)), and pentatope (24·S = n(n+1)(n+2)(n+3)) closed forms in both multiplied and divided shapes. The tetrahedral form is the exact object the parent open question requested; the pentatope rung is a new closed form beyond the sibling entry combinations-formula-oq-06-oq-01.",
+  "meta": {
+    "author": "Lean Genius researcher-6",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFigurateClosedForm.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 154,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "assumptions": "None. All identities hold for every natural number n and every dimension k and are fully machine-checked. The concrete sanity checks close by kernel reduction (rfl through the divided closed forms), not native_decide, so there is no Lean.ofReduceBool dependency; #print axioms reports only the foundational axioms propext, Classical.choice, Quot.sound.",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "figurate-numbers",
+      "simplicial-numbers",
+      "multiset-coefficients",
+      "ascending-factorial",
+      "rising-factorial",
+      "closed-form",
+      "tetrahedral-numbers",
+      "pentatope-numbers",
+      "triangular-numbers"
+    ],
+    "dateAdded": "2026-06-30",
+    "originalContributions": [
+      "factorial_mul_S: the uniform product closed form k! · S(k,n) = ascFactorial n k = n(n+1)⋯(n+k-1), a single statement covering the entire figurate tower with no per-k induction — obtained by reading Mathlib's choose ↔ ascending-factorial bridge (Nat.ascFactorial_eq_factorial_mul_choose') through S(k,n) = C(n+k-1,k); this is exactly the 'derive the higher closed forms uniformly in k without a separate induction' object the parent's open question (and the sibling oq-06-oq-01 open question 0) asked for",
+      "S_closed: the division form S(k,n) = ascFactorial n k / k! for every dimension k simultaneously, the rising-factorial closed form of the multiset coefficient",
+      "six_mul_S_three / S_three_closed: the tetrahedral closed forms 6·S(3,n) = n(n+1)(n+2) and S(3,n) = n(n+1)(n+2)/6 — the exact object the parent open question named, in both division-free and textbook shapes, subsuming the sibling's raw binomial S(3,n) = C(n+2,3)",
+      "twentyfour_mul_S_four / S_four_closed: the pentatope closed forms 24·S(4,n) = n(n+1)(n+2)(n+3) and S(4,n) = n(n+1)(n+2)(n+3)/24 — a genuinely new figurate rung beyond the sibling entry, obtained as the k=4 specialization",
+      "two_mul_S_two / S_two_closed: the triangular closed forms 2·S(2,n) = n(n+1) and S(2,n) = n(n+1)/2 recovered from the same uniform engine, mirroring (and re-deriving from a different route) the sibling's S_two_closed",
+      "ascFactorial_two / ascFactorial_three / ascFactorial_four: the finite ascending-factorial products n(n+1), n(n+1)(n+2), n(n+1)(n+2)(n+3) evaluated for concrete dimensions by three-or-fewer Nat.ascFactorial_succ unfoldings closed by ring — no induction on n and no induction on k"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFigurateClosedForm.lean",
+    "namespace": "CombinationsFigurateClosedForm",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 154,
+    "theoremCount": 12,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The figurate numbers — points arranged in geometric shapes of increasing dimension — were studied by the Pythagoreans and by Nicomachus of Gerasa (c. 100 AD): the natural numbers count points on a line, triangular numbers a triangle, tetrahedral a tetrahedron, pentatope a 4-simplex, and so on up the simplicial ladder. Each shape's count is the k-dimensional figurate number C(n+k-1,k), a diagonal of Pascal's triangle. The classical closed forms — triangular n(n+1)/2, tetrahedral n(n+1)(n+2)/6, pentatope n(n+1)(n+2)(n+3)/24 — are the rising-factorial values of these binomial coefficients. The sibling entry combinations-formula-oq-06-oq-01 packaged the whole tower as one Lean object S(k,n) = C(n+k-1,k) = multichoose n k and proved the tower identity uniformly in the dimension k, but recovered the closed form only at the triangular rung, leaving the tetrahedral rung as the raw binomial C(n+2,3). Its open question, and the parent's, asked whether the higher closed forms could be produced uniformly in k without a fresh induction for each figurate sequence.",
+    "problemStatement": "Open question (combinations-formula-oq-06, OQ-02; equivalently combinations-formula-oq-06-oq-01 open question 0): can the closed forms for the higher figurate numbers — the tetrahedral n(n+1)(n+2)/6, the pentatope n(n+1)(n+2)(n+3)/24, and in general the rising-factorial form C(n+k-1,k) = (∏_{i<k}(n+i))/k! — be derived inside Lean uniformly in the dimension k, without a separate induction for each rung, mirroring the n(n+1)/2 closed form already obtained for the triangular case?",
+    "proofStrategy": "Reuse the family object S(k,n) := Nat.multichoose n k, so S(k,n) = C(n+k-1,k) by Nat.multichoose_eq. The single engine is factorial_mul_S : k! · S(k,n) = ascFactorial n k, which is Mathlib's Nat.ascFactorial_eq_factorial_mul_choose' (n.ascFactorial k = k! · C(n+k-1,k)) read backwards through S_eq_choose — one rewrite, valid for every k, with no induction. Dividing by k! gives S_closed : S(k,n) = ascFactorial n k / k! directly from Nat.choose_eq_asc_factorial_div_factorial'. To exhibit the classical shapes, the finite product ascFactorial n k is evaluated at concrete dimensions k = 2,3,4 by unfolding Nat.ascFactorial_succ three-or-fewer times and closing with ring (ascFactorial_two/three/four); combined with factorial_mul_S and the numeric values 2! = 2, 3! = 6, 4! = 24 this yields the multiplied closed forms 2·S(2,n) = n(n+1), 6·S(3,n) = n(n+1)(n+2), 24·S(4,n) = n(n+1)(n+2)(n+3). Dividing each with Nat.eq_div_of_mul_eq_right gives the textbook forms n(n+1)/2, n(n+1)(n+2)/6, n(n+1)(n+2)(n+3)/24. Crucially, the induction that would classically prove each figurate closed form is absorbed once and for all into the Mathlib ascFactorial ↔ choose lemma; nothing here inducts on n or on k.",
+    "keyInsights": [
+      "The whole tower's closed form is a single Mathlib lemma in disguise: Nat.ascFactorial_eq_factorial_mul_choose' says k! · C(n+k-1,k) = n(n+1)⋯(n+k-1), which is exactly k! · S(k,n) = ascFactorial n k. So the 'no separate induction' phenomenon the open question isolates is real — the per-rung induction is pre-packaged in the choose ↔ ascending-factorial bridge, and reading it through S(k,n) = C(n+k-1,k) settles every dimension at once.",
+      "Stating the closed form in multiplied (division-free) shape k! · S(k,n) = ascFactorial n k is the honest form: no truncating natural-number division appears, so the identity is an exact equation of naturals. The familiar divided shapes n(n+1)/2, n(n+1)(n+2)/6, … are then a one-line corollary via Nat.eq_div_of_mul_eq_right, with the divisibility guaranteed by the multiplied identity itself.",
+      "Evaluating ascFactorial at a concrete dimension needs no induction: because the second argument is a literal, ascFactorial n k unfolds by k applications of Nat.ascFactorial_succ (each peeling one factor n+i) down to ascFactorial n 0 = 1, and ring finishes. This keeps the specializations (tetrahedral, pentatope) fully elementary while the general statement carries the mathematical content.",
+      "The pentatope rung S(4,n) = n(n+1)(n+2)(n+3)/24 is obtained with no extra machinery beyond the k=4 instance, illustrating that the uniform engine makes each additional figurate closed form a mechanical corollary rather than a fresh theorem to prove."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 3,
+      "endLine": 54,
+      "summary": "Header stating the open question (combinations-formula-oq-06 OQ-02 / sibling oq-06-oq-01 open question 0): derive the higher figurate closed forms — tetrahedral n(n+1)(n+2)/6, pentatope, and the general rising-factorial form — uniformly in the dimension k without a separate induction, mirroring the triangular n(n+1)/2."
+    },
+    {
+      "id": "family-object",
+      "title": "The Figurate Family Object",
+      "startLine": 56,
+      "endLine": 66,
+      "summary": "def S (k n) := Nat.multichoose n k, with S_eq_choose : S(k,n) = C(n+k-1,k) bridging to the binomial form via Nat.multichoose_eq — the same family object as the sibling entry, re-derived so this entry stands alone."
+    },
+    {
+      "id": "uniform-closed-form",
+      "title": "The Uniform Product Closed Form",
+      "startLine": 68,
+      "endLine": 80,
+      "summary": "factorial_mul_S : k! · S(k,n) = ascFactorial n k = n(n+1)⋯(n+k-1), the single statement covering the whole tower with no per-k induction (Nat.ascFactorial_eq_factorial_mul_choose'); and S_closed : S(k,n) = ascFactorial n k / k! its division form (Nat.choose_eq_asc_factorial_div_factorial')."
+    },
+    {
+      "id": "ascfactorial-evals",
+      "title": "Evaluating the Finite Product at Concrete Dimensions",
+      "startLine": 81,
+      "endLine": 101,
+      "summary": "ascFactorial_two/three/four : ascFactorial n k = n(n+1), n(n+1)(n+2), n(n+1)(n+2)(n+3) for k = 2,3,4, each three-or-fewer Nat.ascFactorial_succ unfoldings closed by ring — no induction on n or k."
+    },
+    {
+      "id": "multiplied-forms",
+      "title": "Multiplied Closed Forms (Division-Free)",
+      "startLine": 102,
+      "endLine": 121,
+      "summary": "two_mul_S_two : 2·S(2,n) = n(n+1); six_mul_S_three : 6·S(3,n) = n(n+1)(n+2) (the object OQ-02 named); twentyfour_mul_S_four : 24·S(4,n) = n(n+1)(n+2)(n+3) (a new pentatope rung) — exact natural-number equations, no truncating division."
+    },
+    {
+      "id": "divided-forms",
+      "title": "Divided Closed Forms",
+      "startLine": 122,
+      "endLine": 138,
+      "summary": "S_two_closed : S(2,n) = n(n+1)/2; S_three_closed : S(3,n) = n(n+1)(n+2)/6 (the exact tetrahedral answer to OQ-02); S_four_closed : S(4,n) = n(n+1)(n+2)(n+3)/24 — the textbook shapes via Nat.eq_div_of_mul_eq_right."
+    },
+    {
+      "id": "base-and-checks",
+      "title": "Base Rung and Sanity Checks",
+      "startLine": 139,
+      "endLine": 154,
+      "summary": "S_one : S(1,n) = n (the linear rung, Nat.multichoose_one_right); and concrete kernel checks S(3,4)=20 (tetrahedral), S(4,3)=15 (pentatope), S(2,5)=15 (triangular) routed through the divided closed forms."
+    }
+  ],
+  "conclusion": {
+    "summary": "12 theorems, 1 definition, 0 sorries, 0 axioms. The higher figurate closed forms are derived uniformly in the dimension k from one identity, factorial_mul_S : k! · S(k,n) = ascFactorial n k = n(n+1)⋯(n+k-1), the choose ↔ ascending-factorial bridge read through S(k,n) = C(n+k-1,k), with division form S(k,n) = ascFactorial n k / k!. Specializing k = 2,3,4 gives the triangular n(n+1)/2, tetrahedral n(n+1)(n+2)/6, and pentatope n(n+1)(n+2)(n+3)/24 closed forms in both multiplied and divided shapes. No induction on n or k appears anywhere: the per-rung induction is absorbed into Mathlib's ascFactorial ↔ choose lemma.",
+    "implications": "This closes the parent's second open question (and the sibling oq-06-oq-01's open question 0) for the whole family at once: rather than a fresh induction per figurate sequence, one Mathlib lemma about the ascending factorial supplies every closed form simultaneously. The multiplied, division-free statement k! · S(k,n) = ascFactorial n k is the reusable exact form; the tetrahedral and pentatope rungs demonstrate that each additional figurate closed form is now a mechanical k-specialization. Together with the sibling entry (tower identity uniformly in k) the two entries give a complete uniform account of the simplicial figurate hierarchy: how each rung is the partial-sum sequence of the one below (oq-06-oq-01) and what each rung's product closed form is (this entry).",
+    "openQuestions": [
+      "Does the rising-factorial closed form lift to a generating-function statement ∑_n S(k,n) x^n = x^0/(1-x)^{k+1} in Lean, exhibiting the k! · S(k,n) = ascFactorial n k identity as the numerator coefficients of a single rational generating function parametrized by the dimension k?",
+      "Can the same k! · S(k,n) = ascFactorial n k engine be pushed to the alternating / signed figurate identities (e.g. the falling-factorial descFactorial form on the diagonal (n-1).choose k), giving a uniform closed form for both the ascending and descending simplicial families at once?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-06-oq-01",
+      "relationship": "sibling / direct predecessor — packaged the figurate tower S(k,n) = C(n+k-1,k) and proved the tower identity uniformly in k, but recovered only the triangular closed form and left the tetrahedral rung as the raw binomial C(n+2,3); this entry answers its open question 0 by supplying the tetrahedral, pentatope, and general rising-factorial closed forms uniformly in k"
+    },
+    {
+      "targetId": "combinations-formula-oq-06",
+      "relationship": "parent — formalized the hockey-stick identity and read off the k=1,2 figurate instances by hand; this entry answers its second open question by deriving the higher closed forms without a separate per-rung induction"
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "ancestor — the base binomial-coefficient formula C(n,k) = n!/(k!(n-k)!); this entry gives the ascending-factorial closed form C(n+k-1,k) = n(n+1)⋯(n+k-1)/k! of the multiset coefficient"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **combinations-formula-oq-06's second open question** (equivalently the sibling `combinations-formula-oq-06-oq-01`'s open question 0): can the closed forms for the higher figurate numbers — tetrahedral `n(n+1)(n+2)/6`, pentatope `n(n+1)(n+2)(n+3)/24`, and in general the rising-factorial form — be derived inside Lean **uniformly in the dimension `k` without a separate per-rung induction**, mirroring the triangular `n(n+1)/2` already obtained?

**Yes**, via one identity:

```
factorial_mul_S : k ! * S(k, n) = ascFactorial n k = n(n+1)⋯(n+k-1)
```

where `S(k,n) = multichoose n k = C(n+k-1, k)`. This is Mathlib's `Nat.ascFactorial_eq_factorial_mul_choose'` read backwards through `S(k,n) = C(n+k-1,k)` — a **single statement for every dimension `k`, no induction**. The classical per-rung induction is absorbed once and for all into the `choose ↔ ascending-factorial` bridge. The division form `S_closed : S(k,n) = ascFactorial n k / k !` follows directly.

Specializing `k`:

| rung | multiplied (division-free) | divided |
|------|----------------------------|---------|
| triangular (k=2) | `2·S(2,n) = n(n+1)` | `S(2,n) = n(n+1)/2` |
| tetrahedral (k=3) | `6·S(3,n) = n(n+1)(n+2)` | `S(3,n) = n(n+1)(n+2)/6` ← the object asked for |
| pentatope (k=4) | `24·S(4,n) = n(n+1)(n+2)(n+3)` | `S(4,n) = n(n+1)(n+2)(n+3)/24` ← new rung |

## Verification

- **12 theorems, 1 definition, 0 sorries, 0 axioms.**
- Docker build green (`Proofs.CombinationsFigurateClosedForm`, 7743 jobs).
- No `native_decide`: concrete checks (`S(3,4)=20`, `S(4,3)=15`, `S(2,5)=15`) close by kernel `rfl` through the divided closed forms, so **no `Lean.ofReduceBool` dependency**. `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`.
- Self-contained: re-derives `S` from `Nat.multichoose` rather than importing the sibling file (no cross-file build coupling), while cross-referencing it.
- Gallery `pnpm build` passes; new entry `combinations-formula-oq-06-oq-02` renders.

## Relationship

Complements `combinations-formula-oq-06-oq-01` (the figurate *tower identity* uniformly in `k`): that entry says how each rung is the partial-sum sequence of the one below; this entry says what each rung's **product closed form** is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)