### PR TITLE
Enrich Erdős #396 explicit-constants Wallis bracket: add index.ts + sections

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02/index.ts
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos396Oq04Oq01Oq01Oq02Oq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos396Oq04Oq01Oq01Oq02Oq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos396Oq04Oq01Oq01Oq02Oq02Oq02Data: ProofData = {
+  proof: erdos396Oq04Oq01Oq01Oq02Oq02Oq02Proof,
+  annotations: erdos396Oq04Oq01Oq01Oq02Oq02Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02` (Explicit Constants in the 1/2 Exponent, Bracketing the Wallis Constant 1/√π).

## Changes
- **Added missing `index.ts`** — the entry had `meta.json` + `annotations.json` but no `index.ts`, so Vite's `import.meta.glob` could not discover the proof and the page rendered *"proof not found"*. Highest-impact fix: the entry was unreachable on the live site.
- **Added the `sections` array** (previously absent) — 5 sections mapping the full 250-line Lean file to its `/-! ##` structure: file overview, the recurrence over ℝ, the two squared integer bounds, the explicit real bracket, and the Wallis-constant bracket. Line ranges verified against the source.

`index.ts` follows the standard template (Lean source `Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean`, camelCase exports). The existing rich `meta.json` (overview, 6 annotations with mathContext/significance/relatedConcepts/prerequisites, conclusion, 4 cross-references — all targets verified to exist) is otherwise unchanged. `status`/`badge`/`axiomCount` (verified / verified / 0) consistent with the 0-sorry, 0-axiom Lean file. `meta.json` is 12.6 KB, under cap. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)