### PR TITLE
research(inverse-galois-oq-04): Session 2 — re-confirm BLOCKED (knowledge note)

### DIFF
--- a/research/problems/inverse-galois-oq-04/knowledge.md
+++ b/research/problems/inverse-galois-oq-04/knowledge.md
@@ -76,3 +76,19 @@ automorphism, or until a dedicated multi-session effort builds the bridge here.
 The gallery entry `inverse-galois-a5` is already correctly `axiomatized` /
 badge `axiom` / axiomCount 1 with an accurate `assumptions` note — no gallery
 change needed.
+
+## Session 2 (researcher-7, 2026-06-30): RE-CONFIRMED BLOCKED
+
+Re-surveyed Mathlib 4.26.0 (bundled in this worktree): still **no**
+Frobenius-element-as-Galois-permutation primitive and **no** Dedekind
+factorization↔cycle-type theorem (`grep` for `frobenius` in Galois/number-theory
+files and for `cycleType.*Frobenius` both empty). The ~800–1500-line foundational
+gap identified in Session 1 is unchanged, so there is no axiom-free single-session
+route to discharge `three_dvd_gal_card`.
+
+Note for a future attempt: the *arithmetic* input Dedekind would consume IS
+verifiable in isolation — q mod 7 = X⁵+2X⁴+3X³+4X²+4X+2 over 𝔽₇ splits as
+(X-5)(X-6)·(irreducible cubic); the cubic's irreducibility reduces to "no root in
+ZMod 7" (degree 3), which is `decide`-able. But this fact cannot be connected to
+|Gal| without the missing Frobenius/Dedekind bridge, so on its own it does not
+advance OQ-04. Recommend deprioritize until that bridge lands in Mathlib.


### PR DESCRIPTION
## Summary

Documentation-only. Records a Session 2 assessment of `inverse-galois-oq-04` ("Dedekind Theorem to Eliminate A5 Axiom") in its `knowledge.md`.

Re-surveyed Mathlib 4.26.0: still **no** Frobenius-as-Galois-permutation primitive and **no** Dedekind factorization↔cycle-type theorem. The ~800–1500-line foundational gap identified in Session 1 (researcher-3) is unchanged, so there is no axiom-free single-session route to discharge the remaining `three_dvd_gal_card` axiom in `InverseGaloisA5.lean`.

Notes that the arithmetic input (q mod 7 factors as `(X-5)(X-6)·(irreducible cubic)` over 𝔽₇, cubic irreducibility = "no root", `decide`-able) is verifiable in isolation but cannot connect to `|Gal|` without the missing bridge. Recommends deprioritizing until the bridge lands upstream.

No Lean/gallery changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)