### PR TITLE
Enrich Erdős #396 Wallis-constant bracket: sections + references

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02/meta.json
@@ -65,6 +65,40 @@
     "proofStrategy": "Cast the recurrence to ℝ and square it once (cb_rec, cb_rec_sq). Prove the two squared integer bounds by induction, each step pre-multiplying the squared recurrence by the relevant linear factor so nlinarith only has to verify a polynomial nonnegativity. Take square roots (comparing squares of nonnegative reals) to obtain the explicit real bracket (1/2)·4^n/√n ≤ C(2n,n) ≤ (1/√3)·4^n/√n. Finally bracket 1/√π between 1/2 and 1/√3 via 3 < π < 4.",
     "text": "The parent's logarithmic telescoping fixed the exponent 1/2 but discarded the constant. Squaring the target asymptotic turns the √n into an integer relation, and the central-binomial recurrence — squared — drives a two-line induction that bounds C(2n,n)^2 between explicit rational multiples of 16^n. Square roots restore the √n and produce honest constants 1/2 and 1/√3. The genuine asymptotic constant 1/√π sits strictly inside this elementary bracket, and that fact is nothing more than 3 < π < 4: the recurrence does all the work up to identifying the single number π, which is where (and only where) an analytic input is required."
   },
+  "sections": [
+    {
+      "id": "recurrence",
+      "title": "The Recurrence over ℝ",
+      "startLine": 60,
+      "endLine": 83,
+      "summary": "`cb_rec` casts Mathlib's `Nat.succ_mul_centralBinom_succ` — $(n+1)C(2(n+1),n+1)=2(2n+1)C(2n,n)$ — to ℝ; `cb_rec_sq` squares it to $(n+1)^2C(2(n+1),n+1)^2=4(2n+1)^2C(2n,n)^2$, the single identity every induction below consumes.",
+      "mathContext": "$(n+1)^2\\,C(2(n+1),n+1)^2 = 4(2n+1)^2\\,C(2n,n)^2$."
+    },
+    {
+      "id": "squared-bounds",
+      "title": "The Two Squared Integer Bounds",
+      "startLine": 85,
+      "endLine": 144,
+      "summary": "`centralBinom_sq_upper`: $(3n+1)C(2n,n)^2 \\le 16^n$ (induction step certificate $16(3n+1)(n+1)^2-4(3n+4)(2n+1)^2=4n\\ge0$). `centralBinom_sq_lower`: $16^n \\le 4n\\,C(2n,n)^2$ for $n\\ge1$ (step certificate $(2n+1)^2-4n(n+1)=1$). Each pre-multiplies the squared recurrence by a linear factor so `nlinarith` verifies only a polynomial nonnegativity.",
+      "mathContext": "$16^n \\le 4n\\,C(2n,n)^2$ and $(3n+1)\\,C(2n,n)^2 \\le 16^n$."
+    },
+    {
+      "id": "real-bracket",
+      "title": "The Explicit Real Bracket 1/2 … 1/√3",
+      "startLine": 146,
+      "endLine": 208,
+      "summary": "`cb_pos`, `pow16_eq` ($16^n=4^n\\cdot4^n$), then `centralBinom_lower_const` and `centralBinom_upper_const` take square roots by comparing squares of nonnegatives, assembled in `centralBinom_bracket`: $(1/2)4^n/\\sqrt n \\le C(2n,n) \\le (1/\\sqrt3)4^n/\\sqrt n$. These are the constants $c_1=1/2$, $c_2=1/\\sqrt3$ the parent's open question requested — Stirling-free.",
+      "mathContext": "$\\tfrac12\\cdot\\tfrac{4^n}{\\sqrt n} \\le C(2n,n) \\le \\tfrac{1}{\\sqrt3}\\cdot\\tfrac{4^n}{\\sqrt n}$."
+    },
+    {
+      "id": "wallis-bracket",
+      "title": "The Wallis Constant 1/√π is Bracketed",
+      "startLine": 210,
+      "endLine": 249,
+      "summary": "`sqrt_four`, `half_lt_inv_sqrt_pi` ($\\Leftrightarrow\\pi<4$), `inv_sqrt_pi_lt_inv_sqrt_three` ($\\Leftrightarrow 3<\\pi$), and `wallis_constant_bracketed`: the true leading constant $1/\\sqrt\\pi$ of $C(2n,n)\\sim4^n/\\sqrt{\\pi n}$ lies strictly inside the elementary bracket, $\\tfrac12 < 1/\\sqrt\\pi < \\tfrac1{\\sqrt3}$ — which is exactly $3<\\pi<4$ via `Real.pi_gt_three`/`Real.pi_lt_four`.",
+      "mathContext": "$\\tfrac12 < \\tfrac{1}{\\sqrt\\pi} < \\tfrac{1}{\\sqrt3} \\iff 3 < \\pi < 4$."
+    }
+  ],
   "conclusion": {
     "summary": "Two squared integer bounds derived by induction from the central-binomial recurrence — 16^n ≤ 4n·C(2n,n)^2 (n ≥ 1) and (3n+1)·C(2n,n)^2 ≤ 16^n — yield, after taking square roots, the explicit two-sided estimate (1/2)·4^n/√n ≤ C(2n,n) ≤ (1/√3)·4^n/√n. This answers the parent's open question with the elementary constants c₁ = 1/2 and c₂ = 1/√3, obtained directly from the recurrence with no Stirling or Wallis input. The true leading constant 1/√π of C(2n,n) ∼ 4^n/√(πn) is then shown to lie strictly between them: 1/2 < 1/√π < 1/√3, equivalently 3 < π < 4. All thirteen theorems are fully machine-checked with no axioms or sorries.",
     "implications": "The entry sharpens the parent's order-only 1/2 exponent into honest explicit constants and isolates exactly where analysis is unavoidable. The squared-bound technique — replace the √n asymptotic by an integer inequality, prove it by induction on the squared recurrence, then take roots — is reusable for any sequence with a two-term hypergeometric recurrence whose constant one wants to bracket without Stirling. The dichotomy is sharp: the recurrence pins the constant to the open interval (1/2, 1/√3) ≈ (0.500, 0.577), and the genuine value 1/√π ≈ 0.564 is recovered only by the analytic comparison 3 < π < 4.",
@@ -93,6 +127,29 @@
       "targetId": "erdos-396",
       "relationship": "ancestor",
       "description": "Root problem: descending factorials dividing central binomial coefficients. C(2n,n) is the root object; this entry gives explicit two-sided control on its growth."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Wallis, J.",
+      "title": "Arithmetica Infinitorum",
+      "year": "1656",
+      "venue": "Oxford",
+      "note": "Wallis product for π/2; source of the analytic constant 1/√π that the elementary bracket (1/2, 1/√3) contains but cannot name."
+    },
+    {
+      "authors": "de Moivre, A.; Stirling, J.",
+      "title": "Stirling's approximation n! ∼ √(2πn)(n/e)^n",
+      "year": "1730",
+      "venue": "Classical",
+      "note": "Yields C(2n,n) ∼ 4^n/√(πn); the standard route to the leading constant 1/√π, deliberately avoided here in favour of the recurrence."
+    },
+    {
+      "authors": "Erdős, P.",
+      "title": "Problem #396: descending factorials dividing central binomial coefficients",
+      "year": "",
+      "venue": "erdosproblems.com/396",
+      "note": "Root problem of this descendant chain; C(2n,n) is the central object."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02` (0 prior passes, quality 88).

## Changes
- **Added `sections`** (was absent): a 4-entry array covering the full Lean file — the recurrence over ℝ, the two squared integer bounds, the explicit real bracket (constants 1/2, 1/√3), and the Wallis-constant bracket — each with a summary and `mathContext`. Line ranges match the `/-! ## -/` divisions in `Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean`.
- **Added `references`** (was absent): Wallis (1656), Stirling/de Moivre (1730), Erdős #396.

## Not changed
- Annotations already carry `mathContext`, `significance`, `prerequisites`, `relatedConcepts` on all 6 entries.
- Verified meta claims against source: status `verified`, 0 axioms/sorries, no `native_decide` — accurate.

meta.json 10.0 → 13.3 KB (well under the 60 KB cap). `pnpm build` passes.