### PR TITLE
Enrich Erdős 895 Fin-18 counterexample: add index.ts, correct decide/axiom claims

### DIFF
--- a/src/data/proofs/erdos-895-counterexample-fin18/annotations.json
+++ b/src/data/proofs/erdos-895-counterexample-fin18/annotations.json
@@ -5,7 +5,7 @@
     "range": { "startLine": 1, "endLine": 43 },
     "type": "concept",
     "title": "The corrected sharp counterexample for Erdős #895",
-    "content": "Barber (2015) proved every triangle-free graph on {1,…,n} has an independent additive triple a, b, a+b for n ≥ 18, sharp at {1,…,17}. The sibling Erdos895Problem.lean states `counterexample_17` over Fin 17 with a predicate omitting `a ≠ b` — which is FALSE: an exhaustive Z3 search proves every triangle-free graph on Fin 17 has a (loose) triple. The genuine distinct-vertex counterexample lives on Fin 18 (vertex 0 isolated = {1,…,17}). This file builds and machine-verifies it; native_decide introduces the disclosed Lean.ofReduceBool assumption.",
+    "content": "Barber (2015) proved every triangle-free graph on {1,…,n} has an independent additive triple a, b, a+b for n ≥ 18, sharp at {1,…,17}. The sibling Erdos895Problem.lean states `counterexample_17` over Fin 17 with a predicate omitting `a ≠ b` — which is FALSE: an exhaustive Z3 search proves every triangle-free graph on Fin 17 has a (loose) triple. The genuine distinct-vertex counterexample lives on Fin 18 (vertex 0 isolated = {1,…,17}). This file builds and machine-verifies it by plain kernel `decide` — 0 axioms, with #print axioms listing only propext / Quot.sound (no Lean.ofReduceBool, since native_decide is deliberately avoided).",
     "mathContext": "Threshold n = 18 is sharp: a triangle-free graph on {1,…,17} has no independent additive triple in distinct vertices.",
     "significance": "critical",
     "relatedConcepts": ["Erdős 895", "Barber's theorem", "Schur triple", "triangle-free graph"],
@@ -14,10 +14,10 @@
   {
     "id": "ann-erdos895ce-predicate",
     "proofId": "erdos-895-counterexample-fin18",
-    "range": { "startLine": 44, "endLine": 57 },
+    "range": { "startLine": 45, "endLine": 59 },
     "type": "definition",
     "title": "IsDistinctAdditiveTriple — the distinctness fix",
-    "content": "The corrected additive-triple predicate adds `a ≠ b` to `a.val + b.val = c.val ∧ a > 0 ∧ b > 0`. This is precisely the constraint the sibling file's `IsAdditiveTriple` omits, admitting the degenerate (k, k, 2k) and flipping the answer. The triple of predicates is marked @[reducible] so native_decide's Decidable-instance synthesis sees through to the bounded quantifiers over Fin 18.",
+    "content": "The corrected additive-triple predicate adds `a ≠ b` to `a.val + b.val = c.val ∧ a > 0 ∧ b > 0`. This is precisely the constraint the sibling file's `IsAdditiveTriple` omits, admitting the degenerate (k, k, 2k) and flipping the answer. The triple of predicates is marked @[reducible] so `decide`'s Decidable-instance synthesis sees through to the bounded quantifiers over Fin 18.",
     "mathContext": "Barber's theorem is about three DISTINCT vertices a, b, a+b.",
     "significance": "key",
     "relatedConcepts": ["Schur triple", "distinct vertices", "decidability"],
@@ -29,7 +29,7 @@
     "range": { "startLine": 58, "endLine": 86 },
     "type": "definition",
     "title": "G895 — the explicit 42-edge witness graph",
-    "content": "ce895Pairs lists the 42 edges (ascending pairs on {1,…,17}) of researcher-1's Z3/Python-verified witness. ce895Adj is a symmetric Boolean adjacency via the ascending pair (min a b, max a b); ce895Adj_comm proves symmetry from Nat.min_comm/max_comm. G895 is the SimpleGraph structure (Adj := ce895Adj = true ∧ a ≠ b) with symmetry and looplessness, plus a clean DecidableRel instance — chosen over SimpleGraph.fromRel so adjacency is directly decidable for native_decide.",
+    "content": "ce895Pairs lists the 42 edges (ascending pairs on {1,…,17}) of researcher-1's Z3/Python-verified witness. ce895Adj is a symmetric Boolean adjacency via the ascending pair (min a b, max a b); ce895Adj_comm proves symmetry from Nat.min_comm/max_comm. G895 is the SimpleGraph structure (Adj := ce895Adj = true ∧ a ≠ b) with symmetry and looplessness, plus a clean DecidableRel instance — chosen over SimpleGraph.fromRel so adjacency is directly decidable for `decide`.",
     "mathContext": "Vertex 0 is isolated; the graph models {1,…,17}.",
     "significance": "key",
     "relatedConcepts": ["SimpleGraph", "DecidableRel", "symmetric relation"],
@@ -38,13 +38,13 @@
   {
     "id": "ann-erdos895ce-verified",
     "proofId": "erdos-895-counterexample-fin18",
-    "range": { "startLine": 87, "endLine": 111 },
+    "range": { "startLine": 90, "endLine": 111 },
     "type": "theorem",
-    "title": "native_decide verification of the counterexample",
-    "content": "ce895_triangleFree proves G895 has no triangle (exhaustive over Fin 18³). ce895_no_distinct_independent_additive_triple proves there is no independent additive triple in three distinct vertices. counterexample_fin18 packages both into the sharp-threshold witness — the corrected, machine-verified replacement for the false counterexample_17 (Fin 17). Both native_decide checks are exhaustive finite computations, cross-checked by an independent Z3 UNSAT proof and a pure-Python verifier.",
+    "title": "decide verification of the counterexample (0 axioms)",
+    "content": "ce895_triangleFree proves G895 has no triangle (exhaustive over Fin 18³). ce895_no_distinct_independent_additive_triple proves there is no independent additive triple in three distinct vertices (with `set_option maxRecDepth 10000` to let the kernel finish the search). counterexample_fin18 packages both into the sharp-threshold witness — the corrected, machine-verified replacement for the false counterexample_17 (Fin 17). Both checks use plain kernel `decide` (not native_decide), so the result is genuinely 0-axiom — #print axioms lists only propext / Quot.sound, no Lean.ofReduceBool. They are cross-checked by an independent Z3 UNSAT proof and a pure-Python verifier.",
     "mathContext": "Triangle-free and no distinct-vertex independent additive triple ⟹ the {1,…,17} counterexample, hence n = 18 sharp.",
     "significance": "critical",
-    "relatedConcepts": ["native_decide", "exhaustive verification", "Lean.ofReduceBool"],
+    "relatedConcepts": ["decide", "exhaustive kernel verification", "0-axiom proof", "maxRecDepth"],
     "prerequisites": ["decidable propositions", "Fintype quantifiers"]
   }
 ]

--- a/src/data/proofs/erdos-895-counterexample-fin18/index.ts
+++ b/src/data/proofs/erdos-895-counterexample-fin18/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos895CounterexampleFin18.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos895CounterexampleFin18Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos895CounterexampleFin18Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos895CounterexampleFin18Data: ProofData = {
+  proof: erdos895CounterexampleFin18Proof,
+  annotations: erdos895CounterexampleFin18Annotations,
+}

--- a/src/data/proofs/erdos-895-counterexample-fin18/meta.json
+++ b/src/data/proofs/erdos-895-counterexample-fin18/meta.json
@@ -123,6 +123,18 @@
       "note": "Origin of the independent-additive-triple / independent-Hindman-set questions; see erdosproblems.com/895."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-895",
+      "relationship": "parent",
+      "description": "The root problem entry: Barber's theorem that every triangle-free graph on {1,…,n} contains an independent additive triple for n ≥ 18. This entry supplies the corrected, machine-verified sharp counterexample at the threshold (Fin 18 = {1,…,17}), fixing the sibling formalization's false-as-stated counterexample_17."
+    },
+    {
+      "targetId": "erdos-895-oq-01",
+      "relationship": "related",
+      "description": "Hajnal's independent Hindman-set generalization (all finite sums of a base set) — the still-open extension of the independent-additive-triple question flagged in this entry's open questions."
+    }
+  ],
   "mainTheorems": [
     {
       "name": "counterexample_fin18",


### PR DESCRIPTION
Enrichment pass for `erdos-895-counterexample-fin18` (the sharp machine-verified counterexample for Erdős #895).

## Changes
- **Added missing `index.ts`** — the entry had `meta.json` + `annotations.json` but no `index.ts`, so Vite could not discover the proof and the page rendered *"proof not found"*.
- **Corrected an axiom-integrity accuracy bug in the annotations.** All four annotations repeatedly claimed the proof uses `native_decide` and "introduces the disclosed `Lean.ofReduceBool` assumption." This is false: both theorems use **plain kernel `decide`**, the entry is genuinely **0-axiom** (`axiomCount: 0`, `#print axioms` → only `propext`/`Quot.sound`), and the Lean source's own docstrings say *"plain kernel decide (0 axioms — no native_decide)"*. The annotations now match the meta.json and the source. Under the project's axiom-integrity policy this matters — the old text implied a compiler-trust axiom that isn't there.
- **Fixed two annotation line ranges** (44→45, 87→90) to land on real Lean constructs, resolving the *"No Lean construct found"* build warnings for this entry.
- **Added `crossReferences`** to `erdos-895` (root problem) and `erdos-895-oq-01` (Hajnal's independent-Hindman-set generalization) — both verified to exist.

`pnpm build` passes with the two prior warnings for this entry gone. Size 13 KB, under cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)