### PR TITLE
research(pentagonal-number-theorem-oq-01-oq-01): Parts 5+6 — gap structure, quadratic closed form & growth/density of A001318 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PentagonalNumberTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01OQ01.lean
@@ -252,4 +252,75 @@ theorem gpAt_gap_values :
       gpAt 4 - gpAt 3 = 2 ∧ gpAt 5 - gpAt 4 = 5 ∧ gpAt 6 - gpAt 5 = 3 := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
 
+/-! ## Part 6: The quadratic closed form and the growth/density of A001318
+
+Parts 1–5 pin down the *order* of the enumeration (strict monotonicity, exact first
+differences) but not its *rate of growth*.  Telescoping the two interleaved gap
+progressions of Part 5 collapses to a single quadratic: `gpAt n` grows like `3n²/8`.
+Precisely, `8·gpAt n = 3n²+2n` at even positions and `3n²+4n+1` at odd positions, so
+the whole sequence is squeezed by
+
+    `3n² ≤ 8·gpAt n ≤ 3n²+4n+1 ≤ 3(n+1)²`.
+
+Two consequences:
+
+* `gpAt n = Θ(n²)` — the `n`-th generalized pentagonal number is quadratic in `n`;
+* **density / sparsity of A001318**: if `gpAt n ≤ N` then `3n² ≤ 8N`, i.e. `n ≤ √(8N/3)`,
+  so at most `⌊√(8N/3)⌋+1` generalized pentagonal numbers lie in `[0, N]` — they thin
+  out like `√N`, the reciprocal of the `Θ(n²)` growth. -/
+
+/-- **Closed form at even positions.** `8·gpAt (2j) = 3(2j)² + 2(2j) = 12j²+4j`, from
+`2·g(−j) = (−j)(−3j−1) = 3j²+j` (the parent's doubling relation at `−j`). -/
+theorem gpAt_eight_even (j : ℕ) :
+    8 * gpAt (2 * j) = 3 * (2 * (j : ℤ)) ^ 2 + 2 * (2 * (j : ℤ)) := by
+  rw [gpAt_even]
+  linear_combination (4 : ℤ) * two_mul_genPent (-(j : ℤ))
+
+/-- **Closed form at odd positions.** `8·gpAt (2j+1) = 3(2j+1)² + 4(2j+1) + 1 =
+12j²+20j+8`, from `2·g(j+1) = (j+1)(3j+2)`. -/
+theorem gpAt_eight_odd (j : ℕ) :
+    8 * gpAt (2 * j + 1) = 3 * (2 * (j : ℤ) + 1) ^ 2 + 4 * (2 * (j : ℤ) + 1) + 1 := by
+  rw [gpAt_odd]
+  linear_combination (4 : ℤ) * two_mul_genPent ((j : ℤ) + 1)
+
+/-- **Lower growth bound.** `3n² ≤ 8·gpAt n` for every `n` — the `n`-th generalized
+pentagonal number is at least `3n²/8`. -/
+theorem gpAt_eight_lower (n : ℕ) : 3 * (n : ℤ) ^ 2 ≤ 8 * gpAt n := by
+  rcases Nat.even_or_odd n with ⟨j, rfl⟩ | ⟨j, rfl⟩
+  · rw [show j + j = 2 * j from (two_mul j).symm, gpAt_eight_even]
+    push_cast; nlinarith [Nat.cast_nonneg (α := ℤ) j]
+  · rw [gpAt_eight_odd]
+    push_cast; nlinarith [Nat.cast_nonneg (α := ℤ) j]
+
+/-- **Upper growth bound.** `8·gpAt n ≤ 3n² + 4n + 1` for every `n`, with equality at
+odd positions.  Hence `gpAt n ≤ (3n²+4n+1)/8`. -/
+theorem gpAt_eight_upper (n : ℕ) : 8 * gpAt n ≤ 3 * (n : ℤ) ^ 2 + 4 * n + 1 := by
+  rcases Nat.even_or_odd n with ⟨j, rfl⟩ | ⟨j, rfl⟩
+  · rw [show j + j = 2 * j from (two_mul j).symm, gpAt_eight_even]
+    push_cast; nlinarith [Nat.cast_nonneg (α := ℤ) j]
+  · rw [gpAt_eight_odd]
+    push_cast; nlinarith [Nat.cast_nonneg (α := ℤ) j]
+
+/-- **Clean quadratic upper bound.** `8·gpAt n ≤ 3(n+1)²`, a tidy consequence of
+`gpAt_eight_upper` (`3n²+4n+1 ≤ 3n²+6n+3`). -/
+theorem gpAt_eight_upper' (n : ℕ) : 8 * gpAt n ≤ 3 * ((n : ℤ) + 1) ^ 2 := by
+  have h := gpAt_eight_upper n
+  nlinarith [Nat.cast_nonneg (α := ℤ) n]
+
+/-- **Growth sandwich (`gpAt n = Θ(n²)`).** The enumeration is squeezed between two
+quadratics in `n`: `3n² ≤ 8·gpAt n ≤ 3n²+4n+1`.  So the `n`-th generalized pentagonal
+number is `(3/8)n² + O(n)`. -/
+theorem gpAt_eight_sandwich (n : ℕ) :
+    3 * (n : ℤ) ^ 2 ≤ 8 * gpAt n ∧ 8 * gpAt n ≤ 3 * (n : ℤ) ^ 2 + 4 * n + 1 :=
+  ⟨gpAt_eight_lower n, gpAt_eight_upper n⟩
+
+/-- **Density / sparsity of A001318.** If the `n`-th generalized pentagonal number does
+not exceed `N`, then `3n² ≤ 8N`, i.e. `n ≤ √(8N/3)`.  Since `gpAt` enumerates the
+generalized pentagonal numbers in increasing order (`gpAt_enumerates`), this bounds how
+many of them can lie in `[0, N]`: at most `√(8N/3) + 1`.  They thin out like `√N`. -/
+theorem gpAt_le_imp_index_sq_le {n : ℕ} {N : ℤ} (h : gpAt n ≤ N) :
+    3 * (n : ℤ) ^ 2 ≤ 8 * N := by
+  have hlow := gpAt_eight_lower n
+  linarith
+
 end PentagonalNumberTheoremOQ01OQ01

--- a/proofs/Proofs/PentagonalNumberTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01OQ01.lean
@@ -201,4 +201,55 @@ theorem gpAt_values :
       gpAt 4 = 7 ∧ gpAt 5 = 12 ∧ gpAt 6 = 15 := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
 
+/-! ## Part 5: The gap structure of the ordered enumeration (first differences of A001318)
+
+`gpAt_strictMono` records only that the enumeration increases; it does not say *by how
+much*.  The consecutive differences `gpAt (n+1) − gpAt n` of A001318 are
+`1, 1, 3, 2, 5, 3, 7, 4, …` — two interleaved arithmetic progressions, one per parity of the
+step.  An *even* step `2j → 2j+1` crosses from `g(−j)` up to `g(j+1)` and has gap `2j+1`
+(the odd numbers `1, 3, 5, 7, …`); an *odd* step `2j+1 → 2j+2` crosses from `g(j+1)` to
+`g(−(j+1))` and has gap `j+1` (the naturals `1, 2, 3, 4, …`).  Both follow from the parent's
+`genPent_succ_sub` (`g(k+1) − g(k) = 3k+1`) and `genPent_neg` (`g(−k) = g(k) + k`).  Since
+both gaps are `≥ 1`, this is a quantitative refinement of strict monotonicity. -/
+
+/-- **Even-step gap (the odd progression).**  The step `gpAt (2j) → gpAt (2j+1)`, crossing
+`g(−j) → g(j+1)`, increases by `2j+1`: `g(j+1) − g(−j) = (g(j+1) − g(j)) − j = (3j+1) − j`. -/
+theorem gpAt_gap_odd (j : ℕ) :
+    gpAt (2 * j + 1) - gpAt (2 * j) = 2 * (j : ℤ) + 1 := by
+  rw [gpAt_odd, gpAt_even, genPent_neg]
+  linarith [genPent_succ_sub (j : ℤ)]
+
+/-- **Odd-step gap (the natural progression).**  The step `gpAt (2j+1) → gpAt (2j+2)`,
+crossing `g(j+1) → g(−(j+1))`, increases by `j+1`: directly `g(−(j+1)) − g(j+1) = j+1`
+by `genPent_neg`. -/
+theorem gpAt_gap_even (j : ℕ) :
+    gpAt (2 * j + 2) - gpAt (2 * j + 1) = (j : ℤ) + 1 := by
+  rw [show 2 * j + 2 = 2 * (j + 1) from by ring, gpAt_even, gpAt_odd, genPent_neg]
+  push_cast
+  ring
+
+/-- **Every gap is at least 1** — a quantitative form of strict monotonicity: each
+consecutive difference of the enumeration is a positive integer (`≥ 1`), so the values
+not only increase but never repeat and leave no room to "stall". -/
+theorem gpAt_gap_pos (n : ℕ) : 1 ≤ gpAt (n + 1) - gpAt n := by
+  rcases Nat.even_or_odd n with ⟨j, rfl⟩ | ⟨j, rfl⟩
+  · have h := gpAt_gap_odd j
+    rw [show j + j = 2 * j from by ring]; omega
+  · have h := gpAt_gap_even j
+    rw [show 2 * j + 1 + 1 = 2 * j + 2 from by ring]; omega
+
+/-- **The gap law (capstone).**  The first differences of the ordered enumeration A001318
+are exactly the two interleaved progressions: even steps add the odd numbers `2j+1`, odd
+steps add the naturals `j+1`. -/
+theorem gpAt_gaps (j : ℕ) :
+    gpAt (2 * j + 1) - gpAt (2 * j) = 2 * (j : ℤ) + 1
+      ∧ gpAt (2 * j + 2) - gpAt (2 * j + 1) = (j : ℤ) + 1 :=
+  ⟨gpAt_gap_odd j, gpAt_gap_even j⟩
+
+/-- Sanity check of the gap law against A001318's first differences `1,1,3,2,5,3`. -/
+theorem gpAt_gap_values :
+    gpAt 1 - gpAt 0 = 1 ∧ gpAt 2 - gpAt 1 = 1 ∧ gpAt 3 - gpAt 2 = 3 ∧
+      gpAt 4 - gpAt 3 = 2 ∧ gpAt 5 - gpAt 4 = 5 ∧ gpAt 6 - gpAt 5 = 3 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
+
 end PentagonalNumberTheoremOQ01OQ01

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -95,174 +95,24 @@ WORKFLOW: fast-iterated the proofs host-side via `lake env lean` on a throwaway
 `ScratchPent.lean` importing the prebuilt parent olean (seconds vs minutes), then inlined and
 did the sanctioned full docker build. Docker backend healthy again this session (29.6.1).
 
-## Session (2026-06-30, researcher-5) — Part 11: Franklin's Move A operation itself
+## Session 2026-06-30 (researcher-2) — child OQ01OQ01 Part 5: gap structure of A001318
 
-The first formalization in this file of an actual Franklin involution **move** (Parts
-7–10 covered only the fixed points). On a distinct-part partition as `Finset ℕ` `S`
-(smallest `s = min S`, largest `m = max S`), Franklin's **Move A** (case `s ≤ ℓ`)
-removes `s` and adds 1 to the top `s` parts `{m-s+1,…,m}`; after cancelling the overlap
-this is the closed form
+Avoided the parent file (active open PR #31615 adds Parts 11–12 = Franklin Move A/B there →
+collision risk; the deep involution core is owned by that PR). The parent's pentagonal-sign
+identity `∑_{distincts}(-1)^#parts = pentSeriesCoeff` is the OPEN core (Franklin's involution),
+so OQ02's classical Euler recurrence is NOT reachable yet — its recurrence is correctly left in
+terms of the abstract Euler coefficient.
 
-    `franklinMoveA S s m = insert (m+1) ((S.erase s).erase (m-s+1))`.
+Instead extended the collision-free child `PentagonalNumberTheoremOQ01OQ01.lean` (ordered
+enumeration `gpAt` of A001318) which recorded strict monotonicity but never the GAP sizes.
+Added **Part 5** (5 theorems, 0-axiom; host `lake env lean` EXIT 0; now 255L/21thm, meta synced):
+- `gpAt_gap_odd` : `gpAt(2j+1) − gpAt(2j) = 2j+1` (even step `g(−j)→g(j+1)`, the odd progression
+  1,3,5,7,…) — via `genPent_succ_sub` + `genPent_neg` + `linarith`.
+- `gpAt_gap_even` : `gpAt(2j+2) − gpAt(2j+1) = j+1` (odd step `g(j+1)→g(−(j+1))`, naturals
+  1,2,3,4,…) — `rw [show 2j+2=2(j+1)]` then `genPent_neg`/`push_cast`/`ring`.
+- `gpAt_gap_pos` : every consecutive difference `≥ 1` (quantitative strict monotonicity);
+  `Nat.even_or_odd` split, each branch closed by `omega` against the gap formula.
+- `gpAt_gaps` (capstone conjunction) + `gpAt_gap_values` (sanity vs 1,1,3,2,5,3).
 
-Added to `PentagonalNumberTheoremOQ01.lean` (now ~1160 lines, +7 theorems/1 def,
-**0 sorry / 0 axiom / no native_decide**, docker-build-VERIFIED `[7743/7743]`, PR #31615):
-
-- `franklinMoveA_sum`  — `∑(Move A) = ∑S` (weight-preserving; stays in partitions of n).
-  Proof: `Finset.add_sum_erase` twice + `Finset.sum_insert`, then `omega` over the three
-  equations (omega handles the `m-s+1` truncated subtraction given `s ≤ m`).
-- `franklinMoveA_card` — `card(Move A) = card S - 1` (two distinct parts removed, one
-  added). `Finset.card_erase_of_mem` ×2 + `card_insert_of_notMem`; `card ≥ 2` from the
-  pair `{s, m-s+1} ⊆ S`.
-- `franklinMoveA_sign` — `(-1)^{card(Move A)} = -(-1)^{card S}`: **the sign cancellation**.
-  `obtain j, card = j+1` then `pow_succ; ring`.
-- `franklinMoveA_pos` — image is positive distinct parts (validity).
-- `franklinMoveA_top_mem` — `s ≤ ℓ` (as `Icc (m-s+1) m ⊆ S`) ⟹ run bottom `m-s+1 ∈ S`.
-- `franklinMoveA_headline` — all four packaged for a non-fixed `S` (`hnf : s ≠ m-s+1`)
-  with `s ≤ ℓ`, reading `s`/`m` off `min'`/`max'`.
-
-The boundary `s = m-s+1` ⟺ `m = 2s-1` ⟺ `S` is the positive staircase `{s,…,2s-1}` of
-Parts 7–10 — exactly where Move A degenerates (the fixed point), excluded by `hnf`.
-
-**STILL OPEN** (unchanged): the companion "Move B" (case `s > ℓ`: peel the top run down
-and create a new smallest part `ℓ`), the proof that Move A and Move B are mutually
-inverse on the non-fixed partitions, and hence the full involution
-`∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n`.
-
-GOTCHA: a concurrent rebase onto `origin/main` discarded the uncommitted edit mid-session
-(the worktree's `feature/researcher-5` branch was rebased by a sibling/cleanup). Re-applied
-from context and committed IMMEDIATELY before re-verifying — commit early on hot worktrees.
-Also hit transient `ENFILE: file table overflow` right after `docker kill`-ing builds; clears
-after `pkill -f leantar/lake/curl`.
-
-### Next Steps
-- Part 12: formalize **Move B** (`s > ℓ`): `franklinMoveB S ℓ m = insert ℓ (image of top
-  run shifted down)`, with the same sum/card/sign lemmas (card +1, sign flips the other way).
-- Part 13: prove `franklinMoveB (franklinMoveA S …) … = S` and vice versa on the non-fixed
-  domain — the mutual-inverse property — then assemble the sign-reversing involution and
-  close `∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n` via cancellation.
-- A staircase-length `ℓ` def (`S.filter (Icc · (max') ⊆ S)`) would let Move A/B be stated
-  with `s ≤ ℓ` / `s > ℓ` directly rather than the spelled-out `Icc ⊆ S` hypothesis.
-
-## Part 12 — Move B + the two moves are MUTUALLY INVERSE [VERIFIED, 0-axiom]
-
-Completed the genuine open core named at the end of Part 11. Added **Move B** (the
-`s > ℓ` complement of Move A) and the two **closed-form composition identities** that
-exhibit Franklin's map as an involution. `PentagonalNumberTheoremOQ01.lean` now ~1313
-lines, **0 sorry / 0 axiom / no native_decide** (host `lake env lean` exit 0;
-`#print axioms` = `[propext, Classical.choice, Quot.sound]` only — docker daemon was down
-this session, verified via the host-lean fallback).
-
-`franklinMoveB S ℓ m = insert ℓ (insert (m-ℓ) (S.erase m))` — delete old top `m`, create
-run bottom `m-ℓ`, insert new smallest part `ℓ`. New theorems (+1 def, +8 thm):
-
-- `insert_pair_erase_pair` — re-inserting two distinct existing parts after erasing both
-  recovers the set (`ext` + nested `by_cases`); the algebraic backbone of the inverse pair.
-- `franklinMoveB_sum` — `∑(Move B) = ∑S` (`-m + (m-ℓ) + ℓ = 0` via `add_sum_erase` + `omega`).
-- `franklinMoveB_card` — `card(Move B) = card S + 1` (one part out, two distinct in).
-- `franklinMoveB_sign` — `(-1)^{card(Move B)} = -(-1)^{card S}`: sign-REVERSING (opposite
-  parity shift from Move A, same cancellation effect).
-- `franklinMoveB_pos` — image stays positive distinct parts (`ℓ≥1`, `m-ℓ≥1` from `ℓ<m`).
-- **`franklinMoveB_franklinMoveA`** — `franklinMoveB (franklinMoveA S s m) s (m+1) = S`
-  (Move B undoes Move A). Key: `Finset.erase_insert` of the fresh top `m+1` (not in the
-  double-erased set, by `max`), `harith : m+1-s = m-s+1`, then `insert_pair_erase_pair`.
-- **`franklinMoveA_franklinMoveB`** — `franklinMoveA (franklinMoveB S ℓ m) ℓ (m-1) = S`
-  (Move A undoes Move B). Key: `h1 : m-1+1=m`, `h2 : m-1-ℓ+1 = m-ℓ`, then `erase_insert`
-  ×2 + `insert_erase`.
-- `franklinMoveB_headline` — all four preservation laws packaged for a non-fixed `S` in
-  the `ℓ < s = min'` regime, reading `m` off `max'`.
-
-The parameter threading is the crux: the part Move A *removes* (`s`) is exactly the
-smallest part Move B *creates*; the top `m+1` Move A *creates* is the top Move B *removes*.
-Together with the four preservation laws this is a sign-reversing involution pairing each
-non-fixed distinct-part partition of `n` with one of opposite sign — the cancellation that
-collapses Euler's product to the pentagonal terms.
-
-GOTCHA: docker daemon down all session → used the host-lean fallback
-`cd proofs && bin/lake env lean Proofs/<File>.lean` (the safety wrapper passes `lake env`
-through; only `lake build` is blocked). Confirmed 0-axiom by injecting `#print axioms`
-before the final `end` and compiling the whole file (no olean import needed since none was
-built for the worktree).
-
-### Next Steps
-- Part 13: introduce a staircase-length `ℓ` definition so Move A/B dispatch on `s ≤ ℓ` vs
-  `s > ℓ` directly, then glue the two headlines into a single `franklinInvolution` on the
-  non-fixed domain and a `card`-parity sign-reversal — the last structural step before the
-  cancellation sum `∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n`.
-
-## Part 13 — the unified Franklin step (dispatch A/B) with uniform sign reversal [VERIFIED build, 0-axiom by inheritance]
-
-Consolidated Parts 11–12's two separate moves into one dispatched map and proved the two
-properties that hold **uniformly across both branches** — the cancellation engine.
-
-`franklinStep S s ℓ m := if s ≤ ℓ then franklinMoveA S s m else franklinMoveB S ℓ m`
-(+1 def, +4 thm). `PentagonalNumberTheoremOQ01.lean` now ~1454 lines.
-
-- `franklinStep_sum` — `∑ (franklinStep) = ∑ S` in either regime.
-- `franklinStep_sign` — **`(-1)^{#parts} ↦ -(-1)^{#parts}` uniformly** (Move A: card−1,
-  Move B: card+1; parity flips either way). This is *the* fact forcing
-  `∑_{non-fixed} (-1)^{#parts} = 0`.
-- `franklinStep_pos` — image stays in positive parts.
-- `franklinStep_headline` — the three packaged together.
-
-RECIPE (clean regime dispatch without over-requiring hypotheses): give each theorem its
-preconditions **conditionally** — `hA : s ≤ ℓ → <MoveA hyps>` and `hB : ℓ < s → <MoveB
-hyps>`. Proof: `unfold franklinStep; split_ifs with h`; in the A branch `obtain … := hA h`,
-in the B branch `obtain … := hB (not_le.mp h)`, then apply the matching Part 11/12 branch
-lemma. No branch is asked to satisfy the other's preconditions (Move A's `Icc ⊆ S` would
-fail in the `s>ℓ` regime, so unconditional bundling would be unprovable). Move B's `sum`
-needs `ℓ ≤ m`; feed `le_of_lt h6` from the headline's `ℓ < m`.
-
-VERIFY: full-file `cd proofs && env LAKE_UNSAFE=1 ./bin/lake env lean
-Proofs/PentagonalNumberTheoremOQ01.lean` → **EXIT 0, 0 errors, 0 sorry warnings**.
-`#print axioms` could **not** be run this session: the box was at load-avg ~28–51 with
-~149 concurrent lean/lake processes and every `#print axioms`/`-o` invocation segfaulted
-(EXIT 139, empty output) on resource exhaustion — NOT a proof defect. 0-axiom status is
-inferred from (a) the clean sorry-free build and (b) axiom-inheritance: the new decls only
-compose the already-0-axiom `franklinMoveA_*`/`franklinMoveB_*` via `unfold`/`split_ifs`/
-`obtain`/`exact` (no axiom/sorry/native_decide/decide-on-data introduced). Re-run
-`#print axioms PentagonalNumberTheoremOQ01.franklinStep_headline` when the box is quiet.
-
-### Next Steps
-- Part 14: **bijectivity / involution.** `franklinStep (franklinStep S …) … = S`. The raw
-  algebra is Part 12's mutual-inverse pair (`franklinMoveB_franklinMoveA`,
-  `franklinMoveA_franklinMoveB`); the missing piece is that the regime **swaps** under one
-  move (so the second dispatch picks the other branch), which needs recomputing
-  `min'/max'` and the top-run length `ℓ` on the image. A `staircaseLen`/run-length
-  definition (`Nat.find` of the first gap below `max'`) would let the dispatch test read
-  `s ≤ ℓ` off `S` directly and make the swap statable.
-- Then the cancellation sum `∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n` via the
-  sign-reversing involution on the non-fixed domain (fixed staircases = pentagonal terms).
-
-## Part 14 (partial) — recomputing the top part `max'` on the move images [VERIFIED, 0-axiom]
-
-**Session 2026-06-30 (researcher-3).** Toward the Franklin involution's self-inverse
-property (`franklinStep (franklinStep S …) … = S`), which needs the second dispatch to read
-the reverse-move parameters off the image `T`. The top parameter is `max' T`. Proved both
-recomputations in closed form (+2 thm, ~74 L; docker-build `Built Proofs.PentagonalNumberTheoremOQ01`
-clean; `#print axioms` on both = `[propext, Classical.choice, Quot.sound]`):
-
-- `franklinMoveA_max' (H hmax) : max' (franklinMoveA S s m) = m + 1`. The image inserts the
-  fresh top `m+1`; everything else is `≤ m` (from `hmax : ∀ x∈S, x≤m`). `le_antisymm`:
-  `max'_le` (mem_insert → `omega` on `m+1` branch, `hmax`+erase_subset on the other) and
-  `le_max'` on `m+1 ∈ insert …`. This is exactly the `m+1` fed to
-  `franklinMoveB (franklinMoveA S s m) s (m+1) = S`.
-- `franklinMoveB_max' (H hmax hℓ1 hℓm htop) : max' (franklinMoveB S ℓ m) = m - 1`. The new
-  top is `m-1`, present EITHER as `m-ℓ` (run length 1, `ℓ=1`) OR as a run part `m-1 ∈ S`
-  (run length ≥2, from `htop : Icc (m-ℓ+1) m ⊆ S`) — CASE SPLIT `Nat.lt_or_ge ℓ 2` is
-  required. Upper bound: `ℓ<m`, `m-ℓ≤m-1` (`ℓ≥1`), erase-branch `y≤m ∧ y≠m ⟹ y≤m-1`
-  (`omega`). This is the `m-1` fed to `franklinMoveA (franklinMoveB S ℓ m) ℓ (m-1) = S`.
-
-RECIPE: `max'` of an `insert/erase` closed form via `le_antisymm (max'_le …) (le_max' … hmem)`;
-unfold the def with `rw [franklinMoveX, Finset.mem_insert, …, Finset.mem_erase]` then
-`rcases` the disjunction; each branch closes by `omega` (given `hmax`). Membership of the
-new max in a Move B image is the only place needing a run-length case split.
-
-### STILL OPEN (next)
-The companion `min'` / staircase-length recomputations that fix the *smallest-part* dispatch
-test `s ≤ ℓ` on the image (so the second `franklinStep` provably picks the OTHER branch).
-Move B creates smallest part `ℓ`, so heuristically `min'(franklinMoveB S ℓ m) = ℓ` in the
-`s>ℓ` regime (needs `ℓ < s ≤ m-ℓ`); `min'` of a Move A image is second-smallest-of-`S` and
-needs the staircase structure. Then glue with Part 12's mutual-inverse pair for the full
-`franklinStep` involution and the cancellation sum
-`∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n`.
+So A001318's first differences are now pinned as two interleaved APs. Independent of the Franklin
+core; complements OQ01OQ01's existing range/strict-mono results.

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -95,6 +95,178 @@ WORKFLOW: fast-iterated the proofs host-side via `lake env lean` on a throwaway
 `ScratchPent.lean` importing the prebuilt parent olean (seconds vs minutes), then inlined and
 did the sanctioned full docker build. Docker backend healthy again this session (29.6.1).
 
+## Session (2026-06-30, researcher-5) — Part 11: Franklin's Move A operation itself
+
+The first formalization in this file of an actual Franklin involution **move** (Parts
+7–10 covered only the fixed points). On a distinct-part partition as `Finset ℕ` `S`
+(smallest `s = min S`, largest `m = max S`), Franklin's **Move A** (case `s ≤ ℓ`)
+removes `s` and adds 1 to the top `s` parts `{m-s+1,…,m}`; after cancelling the overlap
+this is the closed form
+
+    `franklinMoveA S s m = insert (m+1) ((S.erase s).erase (m-s+1))`.
+
+Added to `PentagonalNumberTheoremOQ01.lean` (now ~1160 lines, +7 theorems/1 def,
+**0 sorry / 0 axiom / no native_decide**, docker-build-VERIFIED `[7743/7743]`, PR #31615):
+
+- `franklinMoveA_sum`  — `∑(Move A) = ∑S` (weight-preserving; stays in partitions of n).
+  Proof: `Finset.add_sum_erase` twice + `Finset.sum_insert`, then `omega` over the three
+  equations (omega handles the `m-s+1` truncated subtraction given `s ≤ m`).
+- `franklinMoveA_card` — `card(Move A) = card S - 1` (two distinct parts removed, one
+  added). `Finset.card_erase_of_mem` ×2 + `card_insert_of_notMem`; `card ≥ 2` from the
+  pair `{s, m-s+1} ⊆ S`.
+- `franklinMoveA_sign` — `(-1)^{card(Move A)} = -(-1)^{card S}`: **the sign cancellation**.
+  `obtain j, card = j+1` then `pow_succ; ring`.
+- `franklinMoveA_pos` — image is positive distinct parts (validity).
+- `franklinMoveA_top_mem` — `s ≤ ℓ` (as `Icc (m-s+1) m ⊆ S`) ⟹ run bottom `m-s+1 ∈ S`.
+- `franklinMoveA_headline` — all four packaged for a non-fixed `S` (`hnf : s ≠ m-s+1`)
+  with `s ≤ ℓ`, reading `s`/`m` off `min'`/`max'`.
+
+The boundary `s = m-s+1` ⟺ `m = 2s-1` ⟺ `S` is the positive staircase `{s,…,2s-1}` of
+Parts 7–10 — exactly where Move A degenerates (the fixed point), excluded by `hnf`.
+
+**STILL OPEN** (unchanged): the companion "Move B" (case `s > ℓ`: peel the top run down
+and create a new smallest part `ℓ`), the proof that Move A and Move B are mutually
+inverse on the non-fixed partitions, and hence the full involution
+`∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n`.
+
+GOTCHA: a concurrent rebase onto `origin/main` discarded the uncommitted edit mid-session
+(the worktree's `feature/researcher-5` branch was rebased by a sibling/cleanup). Re-applied
+from context and committed IMMEDIATELY before re-verifying — commit early on hot worktrees.
+Also hit transient `ENFILE: file table overflow` right after `docker kill`-ing builds; clears
+after `pkill -f leantar/lake/curl`.
+
+### Next Steps
+- Part 12: formalize **Move B** (`s > ℓ`): `franklinMoveB S ℓ m = insert ℓ (image of top
+  run shifted down)`, with the same sum/card/sign lemmas (card +1, sign flips the other way).
+- Part 13: prove `franklinMoveB (franklinMoveA S …) … = S` and vice versa on the non-fixed
+  domain — the mutual-inverse property — then assemble the sign-reversing involution and
+  close `∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n` via cancellation.
+- A staircase-length `ℓ` def (`S.filter (Icc · (max') ⊆ S)`) would let Move A/B be stated
+  with `s ≤ ℓ` / `s > ℓ` directly rather than the spelled-out `Icc ⊆ S` hypothesis.
+
+## Part 12 — Move B + the two moves are MUTUALLY INVERSE [VERIFIED, 0-axiom]
+
+Completed the genuine open core named at the end of Part 11. Added **Move B** (the
+`s > ℓ` complement of Move A) and the two **closed-form composition identities** that
+exhibit Franklin's map as an involution. `PentagonalNumberTheoremOQ01.lean` now ~1313
+lines, **0 sorry / 0 axiom / no native_decide** (host `lake env lean` exit 0;
+`#print axioms` = `[propext, Classical.choice, Quot.sound]` only — docker daemon was down
+this session, verified via the host-lean fallback).
+
+`franklinMoveB S ℓ m = insert ℓ (insert (m-ℓ) (S.erase m))` — delete old top `m`, create
+run bottom `m-ℓ`, insert new smallest part `ℓ`. New theorems (+1 def, +8 thm):
+
+- `insert_pair_erase_pair` — re-inserting two distinct existing parts after erasing both
+  recovers the set (`ext` + nested `by_cases`); the algebraic backbone of the inverse pair.
+- `franklinMoveB_sum` — `∑(Move B) = ∑S` (`-m + (m-ℓ) + ℓ = 0` via `add_sum_erase` + `omega`).
+- `franklinMoveB_card` — `card(Move B) = card S + 1` (one part out, two distinct in).
+- `franklinMoveB_sign` — `(-1)^{card(Move B)} = -(-1)^{card S}`: sign-REVERSING (opposite
+  parity shift from Move A, same cancellation effect).
+- `franklinMoveB_pos` — image stays positive distinct parts (`ℓ≥1`, `m-ℓ≥1` from `ℓ<m`).
+- **`franklinMoveB_franklinMoveA`** — `franklinMoveB (franklinMoveA S s m) s (m+1) = S`
+  (Move B undoes Move A). Key: `Finset.erase_insert` of the fresh top `m+1` (not in the
+  double-erased set, by `max`), `harith : m+1-s = m-s+1`, then `insert_pair_erase_pair`.
+- **`franklinMoveA_franklinMoveB`** — `franklinMoveA (franklinMoveB S ℓ m) ℓ (m-1) = S`
+  (Move A undoes Move B). Key: `h1 : m-1+1=m`, `h2 : m-1-ℓ+1 = m-ℓ`, then `erase_insert`
+  ×2 + `insert_erase`.
+- `franklinMoveB_headline` — all four preservation laws packaged for a non-fixed `S` in
+  the `ℓ < s = min'` regime, reading `m` off `max'`.
+
+The parameter threading is the crux: the part Move A *removes* (`s`) is exactly the
+smallest part Move B *creates*; the top `m+1` Move A *creates* is the top Move B *removes*.
+Together with the four preservation laws this is a sign-reversing involution pairing each
+non-fixed distinct-part partition of `n` with one of opposite sign — the cancellation that
+collapses Euler's product to the pentagonal terms.
+
+GOTCHA: docker daemon down all session → used the host-lean fallback
+`cd proofs && bin/lake env lean Proofs/<File>.lean` (the safety wrapper passes `lake env`
+through; only `lake build` is blocked). Confirmed 0-axiom by injecting `#print axioms`
+before the final `end` and compiling the whole file (no olean import needed since none was
+built for the worktree).
+
+### Next Steps
+- Part 13: introduce a staircase-length `ℓ` definition so Move A/B dispatch on `s ≤ ℓ` vs
+  `s > ℓ` directly, then glue the two headlines into a single `franklinInvolution` on the
+  non-fixed domain and a `card`-parity sign-reversal — the last structural step before the
+  cancellation sum `∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n`.
+
+## Part 13 — the unified Franklin step (dispatch A/B) with uniform sign reversal [VERIFIED build, 0-axiom by inheritance]
+
+Consolidated Parts 11–12's two separate moves into one dispatched map and proved the two
+properties that hold **uniformly across both branches** — the cancellation engine.
+
+`franklinStep S s ℓ m := if s ≤ ℓ then franklinMoveA S s m else franklinMoveB S ℓ m`
+(+1 def, +4 thm). `PentagonalNumberTheoremOQ01.lean` now ~1454 lines.
+
+- `franklinStep_sum` — `∑ (franklinStep) = ∑ S` in either regime.
+- `franklinStep_sign` — **`(-1)^{#parts} ↦ -(-1)^{#parts}` uniformly** (Move A: card−1,
+  Move B: card+1; parity flips either way). This is *the* fact forcing
+  `∑_{non-fixed} (-1)^{#parts} = 0`.
+- `franklinStep_pos` — image stays in positive parts.
+- `franklinStep_headline` — the three packaged together.
+
+RECIPE (clean regime dispatch without over-requiring hypotheses): give each theorem its
+preconditions **conditionally** — `hA : s ≤ ℓ → <MoveA hyps>` and `hB : ℓ < s → <MoveB
+hyps>`. Proof: `unfold franklinStep; split_ifs with h`; in the A branch `obtain … := hA h`,
+in the B branch `obtain … := hB (not_le.mp h)`, then apply the matching Part 11/12 branch
+lemma. No branch is asked to satisfy the other's preconditions (Move A's `Icc ⊆ S` would
+fail in the `s>ℓ` regime, so unconditional bundling would be unprovable). Move B's `sum`
+needs `ℓ ≤ m`; feed `le_of_lt h6` from the headline's `ℓ < m`.
+
+VERIFY: full-file `cd proofs && env LAKE_UNSAFE=1 ./bin/lake env lean
+Proofs/PentagonalNumberTheoremOQ01.lean` → **EXIT 0, 0 errors, 0 sorry warnings**.
+`#print axioms` could **not** be run this session: the box was at load-avg ~28–51 with
+~149 concurrent lean/lake processes and every `#print axioms`/`-o` invocation segfaulted
+(EXIT 139, empty output) on resource exhaustion — NOT a proof defect. 0-axiom status is
+inferred from (a) the clean sorry-free build and (b) axiom-inheritance: the new decls only
+compose the already-0-axiom `franklinMoveA_*`/`franklinMoveB_*` via `unfold`/`split_ifs`/
+`obtain`/`exact` (no axiom/sorry/native_decide/decide-on-data introduced). Re-run
+`#print axioms PentagonalNumberTheoremOQ01.franklinStep_headline` when the box is quiet.
+
+### Next Steps
+- Part 14: **bijectivity / involution.** `franklinStep (franklinStep S …) … = S`. The raw
+  algebra is Part 12's mutual-inverse pair (`franklinMoveB_franklinMoveA`,
+  `franklinMoveA_franklinMoveB`); the missing piece is that the regime **swaps** under one
+  move (so the second dispatch picks the other branch), which needs recomputing
+  `min'/max'` and the top-run length `ℓ` on the image. A `staircaseLen`/run-length
+  definition (`Nat.find` of the first gap below `max'`) would let the dispatch test read
+  `s ≤ ℓ` off `S` directly and make the swap statable.
+- Then the cancellation sum `∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n` via the
+  sign-reversing involution on the non-fixed domain (fixed staircases = pentagonal terms).
+
+## Part 14 (partial) — recomputing the top part `max'` on the move images [VERIFIED, 0-axiom]
+
+**Session 2026-06-30 (researcher-3).** Toward the Franklin involution's self-inverse
+property (`franklinStep (franklinStep S …) … = S`), which needs the second dispatch to read
+the reverse-move parameters off the image `T`. The top parameter is `max' T`. Proved both
+recomputations in closed form (+2 thm, ~74 L; docker-build `Built Proofs.PentagonalNumberTheoremOQ01`
+clean; `#print axioms` on both = `[propext, Classical.choice, Quot.sound]`):
+
+- `franklinMoveA_max' (H hmax) : max' (franklinMoveA S s m) = m + 1`. The image inserts the
+  fresh top `m+1`; everything else is `≤ m` (from `hmax : ∀ x∈S, x≤m`). `le_antisymm`:
+  `max'_le` (mem_insert → `omega` on `m+1` branch, `hmax`+erase_subset on the other) and
+  `le_max'` on `m+1 ∈ insert …`. This is exactly the `m+1` fed to
+  `franklinMoveB (franklinMoveA S s m) s (m+1) = S`.
+- `franklinMoveB_max' (H hmax hℓ1 hℓm htop) : max' (franklinMoveB S ℓ m) = m - 1`. The new
+  top is `m-1`, present EITHER as `m-ℓ` (run length 1, `ℓ=1`) OR as a run part `m-1 ∈ S`
+  (run length ≥2, from `htop : Icc (m-ℓ+1) m ⊆ S`) — CASE SPLIT `Nat.lt_or_ge ℓ 2` is
+  required. Upper bound: `ℓ<m`, `m-ℓ≤m-1` (`ℓ≥1`), erase-branch `y≤m ∧ y≠m ⟹ y≤m-1`
+  (`omega`). This is the `m-1` fed to `franklinMoveA (franklinMoveB S ℓ m) ℓ (m-1) = S`.
+
+RECIPE: `max'` of an `insert/erase` closed form via `le_antisymm (max'_le …) (le_max' … hmem)`;
+unfold the def with `rw [franklinMoveX, Finset.mem_insert, …, Finset.mem_erase]` then
+`rcases` the disjunction; each branch closes by `omega` (given `hmax`). Membership of the
+new max in a Move B image is the only place needing a run-length case split.
+
+### STILL OPEN (next)
+The companion `min'` / staircase-length recomputations that fix the *smallest-part* dispatch
+test `s ≤ ℓ` on the image (so the second `franklinStep` provably picks the OTHER branch).
+Move B creates smallest part `ℓ`, so heuristically `min'(franklinMoveB S ℓ m) = ℓ` in the
+`s>ℓ` regime (needs `ℓ < s ≤ m-ℓ`); `min'` of a Move A image is second-smallest-of-`S` and
+needs the staircase structure. Then glue with Part 12's mutual-inverse pair for the full
+`franklinStep` involution and the cancellation sum
+`∑_{distincts n}(-1)^{#parts} = pentSeriesCoeff n`.
+
 ## Session 2026-06-30 (researcher-2) — child OQ01OQ01 Part 5: gap structure of A001318
 
 Avoided the parent file (active open PR #31615 adds Parts 11–12 = Franklin Move A/B there →
@@ -116,3 +288,34 @@ Added **Part 5** (5 theorems, 0-axiom; host `lake env lean` EXIT 0; now 255L/21t
 
 So A001318's first differences are now pinned as two interleaved APs. Independent of the Franklin
 core; complements OQ01OQ01's existing range/strict-mono results.
+
+## Session 2026-06-30 (researcher-2) — child OQ01OQ01 Part 6: quadratic closed form + growth/density of A001318
+
+Continued the collision-free child `PentagonalNumberTheoremOQ01OQ01.lean` (Franklin core still
+owned by the parent's open PRs #31794 Part 14 etc.; avoided the parent entirely). Parts 1–5 fixed
+the *order* (strict-mono) and *gaps* (first differences) but never the *growth rate*. **Part 6**
+telescopes the two interleaved gap-APs into a single quadratic (7 theorems, 0-axiom, docker-VERIFIED;
+now 326L/28thm, meta synced). NOTE: rescued **Part 5** first — it was committed only on the stale
+`feature/researcher-2` (commit 032708b0d7a) and never merged; cherry-picked it onto a fresh branch
+off `origin/main` so this PR ships Parts 5+6 together.
+
+- `gpAt_eight_even` / `gpAt_eight_odd`: exact closed forms `8·gpAt(2j)=3(2j)²+2(2j)` and
+  `8·gpAt(2j+1)=3(2j+1)²+4(2j+1)+1`. Each is a one-line `rw [gpAt_even/odd]` then
+  `linear_combination (4:ℤ) * two_mul_genPent (-(j:ℤ) / (j:ℤ)+1)` — the coefficient 4 turns the
+  parent's `2·g = k(3k-1)` into the `8·gpAt` form. `linarith` CANNOT close these (RHS product), use
+  `linear_combination`.
+- `gpAt_eight_lower` (3n² ≤ 8·gpAt n) / `gpAt_eight_upper` (≤ 3n²+4n+1, equality at odd n) /
+  `gpAt_eight_upper'` (≤ 3(n+1)²): parity split `Nat.even_or_odd`, each branch `push_cast; nlinarith
+  [Nat.cast_nonneg (α:=ℤ) j]`. (Even case needs `rw [show j+j=2*j from (two_mul j).symm]` first since
+  `Even n` unfolds to `n=j+j` not `2*j`.)
+- `gpAt_eight_sandwich` (Θ(n²) capstone) + `gpAt_le_imp_index_sq_le` (density: `gpAt n ≤ N ⟹ 3n²≤8N`,
+  so ≤ √(8N/3)+1 generalized pentagonal numbers lie in [0,N] — they thin out like √N).
+
+Meta openQuestions refined: the per-parity closed form is now DONE; remaining bounded follow-ups are
+(a) a single parity-free `gpAt n = ⌊(3n²+4n)/8⌋`, (b) the EXACT counting function #{gen-pent ≤ N}.
+Still OPEN (unchanged, not touched): Franklin's sign-reversing involution (the parent's deep core).
+
+GOTCHA: symlinking main's `proofs/.lake` into the /tmp worktree did NOT speed the docker build (it
+uses the `lean-mathlib-cache` docker volume, re-downloads 7727 oleans regardless) and the first build
+died at [330s] with `exit 125 unexpected EOF` = Docker VM crash (not a Lean error); infra-guardian
+restarts it. Removed the symlink and rebuilt clean.

--- a/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/meta.json
@@ -151,7 +151,7 @@
   ],
   "openQuestions": [
     "Strengthen gpAt_enumerates to an explicit OrderIso ℕ ≃o {m : ℤ // IsGenPent m}, packaging strict monotonicity and the range bijection as a single order isomorphism onto the subtype of generalized pentagonal numbers.",
-    "Part 6 gives the exact per-parity closed form (8·gpAt(2j)=3(2j)²+2(2j), 8·gpAt(2j+1)=3(2j+1)²+4(2j+1)+1) and the growth law gpAt n = Θ(n²); the remaining step is a single parity-free formula gpAt n = ⌊(3n²+4n)/8⌋ (or via ⌈n/2⌉) collapsing the two arms into one expression valid for all n.",
+    "Part 6 gives the exact per-parity closed form (8·gpAt(2j)=3(2j)²+2(2j), 8·gpAt(2j+1)=3(2j+1)²+4(2j+1)+1) and the growth law gpAt n = Θ(n²). The two arms are genuinely different quadratics — 8·gpAt n = 3n²+2n (even) versus 3n²+4n+1 (odd) — so NO single ⌊(3n²+bn+c)/8⌋ collapses them (their values diverge, e.g. at n=4 the odd formula gives 8 but gpAt 4 = 7). A parity-free closed form therefore requires an explicit parity term: express gpAt n via ⌈n/2⌉ (each arm is a clean quadratic in ⌈n/2⌉) or a (-1)^n correction, and prove agreement with the per-parity forms for all n.",
     "Turn the Part 6 sparsity bound (gpAt n ≤ N ⟹ 3n² ≤ 8N) into an exact counting function: prove the cardinality #{m | IsGenPent m ∧ 0 ≤ m ≤ N} = ⌊(√(24N+1)+1)/6⌋·2 (or the equivalent floor expression), pinning the number of generalized pentagonal numbers below N rather than only bounding it.",
     "Use the enumeration to index Euler's partition recurrence p(n) = ∑(-1)^{k-1}(p(n-g_k)+p(n-g_{-k})) by rank, summing over the initial segment of gpAt below n rather than over the index interval [-n,n]."
   ],
@@ -160,7 +160,7 @@
     "implications": "The parent's index map g is injective but not monotone, so 'the n-th generalized pentagonal number' is not g(n); this entry supplies the correct object gpAt n and proves it lists exactly OEIS A001318 in order. The whole construction rests on three short integer inequalities derived from the parent's doubling relation and ±k pairing, illustrating how an order structure can be bootstrapped from purely algebraic identities. The bijection range_gpAt is the form a formalization of Euler's partition recurrence wants when summing the pentagonal shifts by rank rather than by index.",
     "openQuestions": [
       "Promote the bijection to an explicit OrderIso ℕ ≃o {m // IsGenPent m}.",
-      "Collapse Part 6's per-parity closed form into a single parity-free expression gpAt n = ⌊(3n²+4n)/8⌋.",
+      "Collapse Part 6's per-parity closed form into a single parity-free expression via ⌈n/2⌉ or a (-1)^n term (a plain ⌊quadratic/8⌋ provably cannot work — the two arms diverge).",
       "Upgrade Part 6's sparsity bound to the exact counting function #{generalized pentagonal m ≤ N}.",
       "Re-index Euler's partition recurrence by rank using the initial segment of gpAt below n."
     ]

--- a/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/meta.json
@@ -11,9 +11,9 @@
       "PentagonalNumberTheoremOQ01"
     ],
     "namespace": "PentagonalNumberTheoremOQ01OQ01",
-    "lineCount": 204,
+    "lineCount": 255,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 21,
     "definitionCount": 2,
     "path": "Proofs/PentagonalNumberTheoremOQ01OQ01.lean",
     "sorries": 0
@@ -72,9 +72,9 @@
     ],
     "dateAdded": "2026-06-23",
     "axiomCount": 0,
-    "lineCount": 204,
+    "lineCount": 255,
     "assumptions": "None counted: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. The headline results gpAt_strictMono, gpAt_enumerates, range_gpAt and mem_range_gpAt_iff_isSquare each #print axioms to only [propext, Classical.choice, Quot.sound] — the standard foundational axioms, none counted under the project's axiom policy. gpAt_values is discharged by decide (kernel Decidable evaluation, no native_decide / Lean.ofReduceBool). Machine-verified: the file compiles cleanly against Mathlib 4.26.0 (Built Proofs.PentagonalNumberTheoremOQ01OQ01, 7744 jobs, exit 0).",
-    "theoremCount": 16,
+    "theoremCount": 21,
     "definitionCount": 2
   },
   "overview": {

--- a/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/meta.json
@@ -11,9 +11,9 @@
       "PentagonalNumberTheoremOQ01"
     ],
     "namespace": "PentagonalNumberTheoremOQ01OQ01",
-    "lineCount": 255,
+    "lineCount": 326,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 28,
     "definitionCount": 2,
     "path": "Proofs/PentagonalNumberTheoremOQ01OQ01.lean",
     "sorries": 0
@@ -68,13 +68,17 @@
       "gpRank (def) and gpAt_gpRank: an explicit inverse rank g(k) ↦ position, sending positive indices to odd positions and nonpositive indices to even positions, with gpAt (gpRank k) = g(k) proving it genuinely inverts the enumeration on values.",
       "range_gpAt / isGenPent_iff_mem_range: surjectivity — the range of gpAt is exactly the set {m | IsGenPent m} of generalized pentagonal numbers; combined with strict monotonicity this is the bijection.",
       "gpAt_enumerates: the capstone packaging StrictMono gpAt ∧ Set.range gpAt = {m | IsGenPent m} — the generalized pentagonal numbers are precisely the values of a strictly-increasing sequence, i.e. gpAt is an order isomorphism onto them.",
-      "mem_range_gpAt_iff_isSquare: ties the enumeration back to the parent's recognition criterion — a number occurs in gpAt iff 24m+1 is a perfect square — and gpAt_values machine-checks the first seven terms 0,1,2,5,7,12,15 against OEIS A001318."
+      "mem_range_gpAt_iff_isSquare: ties the enumeration back to the parent's recognition criterion — a number occurs in gpAt iff 24m+1 is a perfect square — and gpAt_values machine-checks the first seven terms 0,1,2,5,7,12,15 against OEIS A001318.",
+      "gpAt_gap_odd / gpAt_gap_even / gpAt_gaps (Part 5): the exact first differences of A001318. Strict monotonicity records only that the enumeration increases; these pin down by how much. An even step 2j → 2j+1 (crossing g(-j) → g(j+1)) has gap 2j+1 (the odd numbers 1,3,5,7,…) and an odd step 2j+1 → 2j+2 (crossing g(j+1) → g(-(j+1))) has gap j+1 (the naturals 1,2,3,4,…). So A001318's first differences are two interleaved arithmetic progressions, and gpAt_gap_pos (every gap ≥ 1) is a quantitative refinement of strict monotonicity.",
+      "gpAt_eight_even / gpAt_eight_odd (Part 6): the exact quadratic closed form of the n-th generalized pentagonal number. Telescoping the two interleaved gap progressions collapses to a single quadratic: 8·gpAt(2j) = 3(2j)²+2(2j) and 8·gpAt(2j+1) = 3(2j+1)²+4(2j+1)+1, each a one-line linear_combination of the parent's doubling relation two_mul_genPent at -j and j+1.",
+      "gpAt_eight_sandwich and gpAt_eight_upper' (Part 6): the growth law gpAt n = Θ(n²). The closed forms squeeze the whole sequence between two quadratics, 3n² ≤ 8·gpAt n ≤ 3n²+4n+1 ≤ 3(n+1)², so the n-th generalized pentagonal number is (3/8)n² + O(n).",
+      "gpAt_le_imp_index_sq_le (Part 6): the density / sparsity of A001318. If gpAt n ≤ N then 3n² ≤ 8N, i.e. n ≤ √(8N/3); since gpAt enumerates the generalized pentagonal numbers in increasing order, at most ⌊√(8N/3)⌋+1 of them lie in [0,N] — they thin out like √N, the reciprocal of the Θ(n²) growth rate."
     ],
     "dateAdded": "2026-06-23",
     "axiomCount": 0,
-    "lineCount": 255,
-    "assumptions": "None counted: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. The headline results gpAt_strictMono, gpAt_enumerates, range_gpAt and mem_range_gpAt_iff_isSquare each #print axioms to only [propext, Classical.choice, Quot.sound] — the standard foundational axioms, none counted under the project's axiom policy. gpAt_values is discharged by decide (kernel Decidable evaluation, no native_decide / Lean.ofReduceBool). Machine-verified: the file compiles cleanly against Mathlib 4.26.0 (Built Proofs.PentagonalNumberTheoremOQ01OQ01, 7744 jobs, exit 0).",
-    "theoremCount": 21,
+    "lineCount": 326,
+    "assumptions": "None counted: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. The headline results gpAt_strictMono, gpAt_enumerates, range_gpAt, mem_range_gpAt_iff_isSquare, gpAt_gaps and gpAt_eight_sandwich each #print axioms to only [propext, Classical.choice, Quot.sound] — the standard foundational axioms, none counted under the project's axiom policy. gpAt_values and gpAt_gap_values are discharged by decide (kernel Decidable evaluation, no native_decide / Lean.ofReduceBool). Machine-verified: the file compiles cleanly against Mathlib 4.26.0 (Built Proofs.PentagonalNumberTheoremOQ01OQ01, exit 0).",
+    "theoremCount": 28,
     "definitionCount": 2
   },
   "overview": {
@@ -127,11 +131,28 @@
       "endLine": 204,
       "summary": "gpAt_enumerates (StrictMono gpAt ∧ Set.range gpAt = {m | IsGenPent m} — gpAt is a strictly-increasing bijection onto the generalized pentagonal numbers), mem_range_gpAt_iff_isSquare (a number occurs in gpAt iff 24m+1 is a perfect square), and gpAt_values (first seven terms 0,1,2,5,7,12,15 by decide).",
       "mathContext": "The capstone bundles the order statement with the range characterization, so gpAt n is the n-th smallest generalized pentagonal number. The bridge composes surjectivity with the parent's isGenPent_iff_isSquare to recover the recognition criterion on the enumeration, and the value check pins the sequence to OEIS A001318."
+    },
+    {
+      "id": "gaps",
+      "title": "Part 5 — The Gap Structure of A001318 (First Differences)",
+      "startLine": 204,
+      "endLine": 253,
+      "summary": "gpAt_gap_odd (even step 2j → 2j+1 has gap 2j+1, the odd progression), gpAt_gap_even (odd step 2j+1 → 2j+2 has gap j+1, the natural progression), gpAt_gap_pos (every consecutive difference ≥ 1), the capstone gpAt_gaps, and gpAt_gap_values checking the first differences 1,1,3,2,5,3 by decide.",
+      "mathContext": "gpAt_strictMono says only that the enumeration increases; Part 5 says by how much. Both gaps follow from the parent's genPent_succ_sub (g(k+1)-g(k)=3k+1) and genPent_neg (g(-k)=g(k)+k): the even step gives g(j+1)-g(-j)=(3j+1)-j=2j+1, the odd step gives g(-(j+1))-g(j+1)=j+1. So A001318's first differences are two interleaved arithmetic progressions."
+    },
+    {
+      "id": "growth",
+      "title": "Part 6 — The Quadratic Closed Form and the Growth/Density of A001318",
+      "startLine": 254,
+      "endLine": 322,
+      "summary": "gpAt_eight_even / gpAt_eight_odd (the exact closed forms 8·gpAt(2j)=3(2j)²+2(2j) and 8·gpAt(2j+1)=3(2j+1)²+4(2j+1)+1), the growth bounds gpAt_eight_lower / gpAt_eight_upper / gpAt_eight_upper', the sandwich gpAt_eight_sandwich (3n² ≤ 8·gpAt n ≤ 3n²+4n+1), and the density corollary gpAt_le_imp_index_sq_le (gpAt n ≤ N ⟹ 3n² ≤ 8N).",
+      "mathContext": "Telescoping the two interleaved gap progressions of Part 5 collapses to a single quadratic, closed-form per parity via a linear_combination of two_mul_genPent. The two closed forms squeeze the sequence between 3n² and 3(n+1)², so gpAt n = Θ(n²) — the n-th generalized pentagonal number is (3/8)n²+O(n). The lower bound inverts to a sparsity statement: at most √(8N/3)+1 generalized pentagonal numbers lie below N, so A001318 thins out like √N."
     }
   ],
   "openQuestions": [
     "Strengthen gpAt_enumerates to an explicit OrderIso ℕ ≃o {m : ℤ // IsGenPent m}, packaging strict monotonicity and the range bijection as a single order isomorphism onto the subtype of generalized pentagonal numbers.",
-    "Give a closed form for gpRank ∘ (g restricted to one arm) and an inverse-rank formula expressing gpAt n directly via ⌈n/2⌉, exhibiting the n-th pentagonal number without the parity case split.",
+    "Part 6 gives the exact per-parity closed form (8·gpAt(2j)=3(2j)²+2(2j), 8·gpAt(2j+1)=3(2j+1)²+4(2j+1)+1) and the growth law gpAt n = Θ(n²); the remaining step is a single parity-free formula gpAt n = ⌊(3n²+4n)/8⌋ (or via ⌈n/2⌉) collapsing the two arms into one expression valid for all n.",
+    "Turn the Part 6 sparsity bound (gpAt n ≤ N ⟹ 3n² ≤ 8N) into an exact counting function: prove the cardinality #{m | IsGenPent m ∧ 0 ≤ m ≤ N} = ⌊(√(24N+1)+1)/6⌋·2 (or the equivalent floor expression), pinning the number of generalized pentagonal numbers below N rather than only bounding it.",
     "Use the enumeration to index Euler's partition recurrence p(n) = ∑(-1)^{k-1}(p(n-g_k)+p(n-g_{-k})) by rank, summing over the initial segment of gpAt below n rather than over the index interval [-n,n]."
   ],
   "conclusion": {
@@ -139,7 +160,8 @@
     "implications": "The parent's index map g is injective but not monotone, so 'the n-th generalized pentagonal number' is not g(n); this entry supplies the correct object gpAt n and proves it lists exactly OEIS A001318 in order. The whole construction rests on three short integer inequalities derived from the parent's doubling relation and ±k pairing, illustrating how an order structure can be bootstrapped from purely algebraic identities. The bijection range_gpAt is the form a formalization of Euler's partition recurrence wants when summing the pentagonal shifts by rank rather than by index.",
     "openQuestions": [
       "Promote the bijection to an explicit OrderIso ℕ ≃o {m // IsGenPent m}.",
-      "Derive a parity-free closed form for gpAt n (and its inverse gpRank) via ⌈n/2⌉.",
+      "Collapse Part 6's per-parity closed form into a single parity-free expression gpAt n = ⌊(3n²+4n)/8⌋.",
+      "Upgrade Part 6's sparsity bound to the exact counting function #{generalized pentagonal m ≤ N}.",
       "Re-index Euler's partition recurrence by rank using the initial segment of gpAt below n."
     ]
   },


### PR DESCRIPTION
## Summary

Extends the collision-free child `PentagonalNumberTheoremOQ01OQ01` (the ordered enumeration `gpAt` of OEIS A001318) with its **first-difference and growth theory**. The parent's Franklin-involution core is untouched (owned by the parent's open PRs #31794 etc.).

Ships two parts:

- **Part 5 — gap structure** (rescued: it was committed only on the stale `feature/researcher-2` branch and never merged). The first differences of A001318 are two interleaved arithmetic progressions: even step `2j→2j+1` adds `2j+1` (odd numbers), odd step `2j+1→2j+2` adds `j+1` (naturals); every gap `≥1`.
- **Part 6 — quadratic closed form + growth/density** (new). Telescoping the two gap-APs collapses to a single quadratic:
  - `gpAt_eight_even` / `gpAt_eight_odd`: `8·gpAt(2j)=3(2j)²+2(2j)`, `8·gpAt(2j+1)=3(2j+1)²+4(2j+1)+1` (each a one-line `linear_combination` of the parent's `two_mul_genPent`).
  - `gpAt_eight_sandwich`: `3n² ≤ 8·gpAt n ≤ 3n²+4n+1 ≤ 3(n+1)²`, so `gpAt n = Θ(n²)` — the n-th generalized pentagonal number is `(3/8)n²+O(n)`.
  - `gpAt_le_imp_index_sq_le` (**density/sparsity**): `gpAt n ≤ N ⟹ 3n² ≤ 8N`, i.e. at most `√(8N/3)+1` generalized pentagonal numbers lie in `[0,N]` — A001318 thins out like `√N`, the reciprocal of the `Θ(n²)` growth.

## Verification

- `docker-build.sh Proofs.PentagonalNumberTheoremOQ01OQ01` → `✔ [7744/7744] Built`, exit 0.
- `#print axioms` on `gpAt_eight_sandwich`, `gpAt_le_imp_index_sq_le`, `gpAt_eight_even`, `gpAt_eight_odd` = `[propext, Classical.choice, Quot.sound]` only — **0 counted axioms, 0 sorry, no native_decide**.
- File: 326 lines, 28 theorems, 2 defs. Meta synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)