### PR TITLE
Enrich Abel–Ruffini OQ-03 (abelian inverse Galois): references

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-03/meta.json
@@ -123,5 +123,28 @@
       "description": "Root entry: the Abel–Ruffini theorem and the solvability of S_n. This entry continues the Galois-theoretic thread by addressing which groups are realized over ℚ, for the abelian case."
     }
   ],
+  "references": [
+    {
+      "authors": "Kronecker, L.; Weber, H.",
+      "title": "Kronecker–Weber theorem",
+      "year": "1886",
+      "venue": "Classical",
+      "note": "Every finite abelian extension of ℚ lies in a cyclotomic field ℚ(ζₙ); the reason the family (ZMod n)ˣ realized here is the building block of all abelian Galois groups over ℚ."
+    },
+    {
+      "authors": "Dirichlet, P. G. L.",
+      "title": "Beweis des Satzes, dass jede unbegrenzte arithmetische Progression … unendlich viele Primzahlen enthält",
+      "year": "1837",
+      "venue": "Abhandlungen der Königlich Preußischen Akademie der Wissenschaften",
+      "note": "Primes in arithmetic progressions; the classical input (not asserted here) used to choose n so that a given finite abelian group is a quotient of (ZMod n)ˣ."
+    },
+    {
+      "authors": "Shafarevich, I. R.",
+      "title": "Construction of fields of algebraic numbers with given solvable Galois group",
+      "year": "1954",
+      "venue": "Izv. Akad. Nauk SSSR Ser. Mat. 18:525–578",
+      "note": "Every finite solvable group is Gal(L/ℚ); the abelian case verified here is a special case, proved directly via cyclotomic fields rather than assumed."
+    }
+  ],
   "sorries": []
 }


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-03` (never previously enriched).

## Changes
- **Added `references`** (was absent): Kronecker–Weber (1886), Dirichlet (1837), Shafarevich (1954) — the classical results behind the cyclotomic realization and the two named-but-unasserted reductions to an arbitrary finite abelian group.

## Verified
- Axiom integrity checked against `Proofs/AbelRuffiniOQ03.lean`: `RealizationOverRat` is a data-bundle structure that is actually *instantiated* (`unitsZModRealization`), not an assumption-carrying structure — so `status: verified`, `axiomCount: 0`, `sorries: 0` is accurate. No `native_decide`.

## Not changed
- 5 annotations (all with mathContext/significance/relatedConcepts/prerequisites), 5 sections, 4 keyInsights, full conclusion + crossReferences already present.

meta.json 15.2 → 16.5 KB (well under cap). `pnpm build` passes.