### PR TITLE
Enrich Abel–Ruffini solvable side (abel-ruffini-oq-06): add missing index.ts

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-06/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniOq06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniOq06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOq06Data: ProofData = {
+  proof: abelRuffiniOq06Proof,
+  annotations: abelRuffiniOq06Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-06` (Abel–Ruffini Threshold, Solvable Side: S₂ and S₃ Solvable via the Aₙ → Sₙ Reduction).

## Change
- **Added missing `index.ts`** — the entry had a rich `meta.json` (overview, sections, conclusion, cross-references) and 4 fully-populated annotations, but no `index.ts`, so Vite's `import.meta.glob` could not discover the proof and the page rendered *"proof not found"* on the live site. This single fix makes the entry reachable.

The entry already meets all enrichment quality targets, so no other changes were needed. `index.ts` follows the standard template (Lean source `AbelRuffiniOQ06.lean`, camelCase exports `abelRuffiniOq06{Proof,Annotations,Data}`). Cross-reference targets (`abel-ruffini-obstruction-oq-06`, `abel-ruffini`) verified to exist. `pnpm build` passes and reports the entry enriched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)