### PR TITLE
Enrich Abel–Ruffini GaloisExt OQ-02 (Fundamental Theorem of Galois Theory): cross-references

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-02/meta.json
@@ -163,6 +163,23 @@
       "Refine `quintic_card_intermediateField_eq_card_subgroup` to a concrete count by transporting the subgroup count across OQ-01's `galEquivS5` and computing the number of subgroups of S₅ (there are 156), giving the exact number of intermediate fields of the splitting field of X⁵ − 4X + 2."
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-galois-extensions-oq-01",
+      "relationship": "extends",
+      "description": "Concrete witness: OQ-01 builds the isomorphism (X⁵ − 4X + 2).Gal ≃* S₅. This entry's final section imports it and instantiates the Galois correspondence on that quintic's splitting field, so the subfield ↔ subgroup dictionary applies to a concrete unsolvable quintic."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions",
+      "relationship": "extends",
+      "description": "Parent: the Abel–Ruffini program rests on 'solvable by radicals ⟺ solvable Galois group'. The Galois correspondence packaged here is the structural backbone of that equivalence — how subextensions of a radical tower become a subnormal series of the Galois group."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "ancestor",
+      "description": "Root entry: the Abel–Ruffini theorem. The intermediate-field ↔ subgroup bijection formalized here is the tool that translates radical solvability of a polynomial into solvability of its Galois group."
+    }
+  ],
   "references": [
     {
       "authors": "Galois, É.",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-galois-extensions-oq-02` (never previously enriched).

## Changes
- **Added top-level `crossReferences`** (was absent): the concrete witness `abel-ruffini-galois-extensions-oq-01` (X⁵−4X+2 splitting field on which the correspondence is instantiated), the parent `abel-ruffini-galois-extensions`, and the root `abel-ruffini`. The gallery ProofPage renders `crossReferences`; the pre-existing `meta.relatedProblems` (which feeds ResearchProblemPage) covered the same links but the ProofPage field was empty.

## Not changed
- 6 annotations (full fields), 4 sections, 5 keyInsights, 4 references, mainTheorems, full conclusion already present. status verified / 0 axioms / 0 sorries.

meta.json 20.8 → 22.0 KB (under cap). `pnpm build` passes.