### PR TITLE
research(algebraic-numbers-countable-oq-05-oq-04): algebraic elements countable IFF base field countable [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ05OQ04.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ05OQ04.lean
@@ -1,0 +1,140 @@
+import Mathlib
+
+/-
+# Countability of the Algebraic Elements is Governed by the Base Field
+
+## Open Question OQ-05-OQ-04
+
+The parent entry `AlgebraicNumbersCountableOQ05` proves, via Cantor's 1874 height
+function, that the real algebraic numbers `{x : ℝ | IsAlgebraic ℚ x}` are countable.  The
+open question asks whether this generalizes to algebraic numbers over *other* base fields:
+
+> Does the proof generalize to algebraic numbers over other fields — for example algebraic
+> numbers over `ℚ(√2)`, or algebraic `p`-adic numbers?
+
+## The subtlety, and the sharp answer
+
+The naive reading — "algebraic elements over any field are countable" — is **false**, and
+the phrase "algebraic `p`-adic numbers" is exactly where it breaks: the `p`-adic field
+`ℚ_p` is *uncountable*, and every one of its (uncountably many) elements is trivially
+algebraic over `ℚ_p`.  So the algebraic elements over `ℚ_p` are uncountable.
+
+What is actually true is a **sharp characterization**: for a field extension `L / K`,
+
+  `{x : L | IsAlgebraic K x}` is countable  ↔  the base field `K` is countable.
+
+The countability of the *ambient* field `L` is irrelevant; only the *base* field's
+cardinality matters.  This both confirms the parent's result (`ℚ` is countable) and
+explains precisely why the `p`-adic generalization fails (`ℚ_p` is not).
+
+## Contribution
+
+* `algebraic_setOf_countable`  — the **sufficient** direction (the parent's "yes"):
+  a countable base field has a countable set of algebraic elements in any extension.
+  This is Mathlib's `Algebraic.countable`, restated for field extensions.
+* `algebraMap_mem_algebraic`  — every element of the base field is algebraic over it, so
+  `K` embeds into the algebraic set through the injective `algebraMap`.
+* `countable_of_algebraic_setOf_countable`  — the **necessary** direction: if the algebraic
+  set is countable then the base field is countable (pull back the embedding).
+* `countable_algebraic_iff`  — the two directions assembled into the sharp
+  characterization `Countable {x | IsAlgebraic K x} ↔ Countable K`.
+* `not_countable_algebraic_of_uncountable_base`  — the contrapositive: an uncountable base
+  field forces uncountably many algebraic elements.  This is the general form of the
+  `p`-adic obstruction.
+* Worked instances: algebraic elements over `ℚ` and over a finite field `ZMod p` are
+  countable; algebraic elements over `ℝ` (inside `ℂ`) are **un**countable — the cautionary
+  example standing in for the `p`-adic case, needing no `p`-adic machinery.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace AlgebraicNumbersCountableOQ05OQ04
+
+open Set
+
+variable {K L : Type*} [Field K] [Field L] [Algebra K L]
+
+/-! ### Sufficient direction: countable base ⟹ countable algebraic set -/
+
+/-- **Sufficient direction (the parent's "yes").**  When the base field `K` is countable,
+    the set of elements of any field extension `L` that are algebraic over `K` is countable.
+    This is Mathlib's `Algebraic.countable` specialized to fields; the ambient field `L`
+    plays no role in the hypothesis. -/
+theorem algebraic_setOf_countable [Countable K] :
+    Set.Countable {x : L | IsAlgebraic K x} :=
+  Algebraic.countable K L
+
+/-! ### The base field embeds into the algebraic set -/
+
+/-- Every element of the base field is algebraic over it: `algebraMap K L k` is a root of the
+    linear polynomial `X - k`.  Hence the base field lands inside the algebraic set. -/
+theorem algebraMap_mem_algebraic (k : K) :
+    algebraMap K L k ∈ {x : L | IsAlgebraic K x} :=
+  isAlgebraic_algebraMap k
+
+/-! ### Necessary direction: countable algebraic set ⟹ countable base -/
+
+/-- **Necessary direction.**  If the set of elements algebraic over `K` is countable, then
+    the base field `K` itself is countable.  The map `k ↦ algebraMap K L k` is an injection
+    of `K` into the (now countable) algebraic set — `algebraMap` is injective because `K` is
+    a field and `L` is nontrivial — so `K` inherits countability. -/
+theorem countable_of_algebraic_setOf_countable
+    (h : Set.Countable {x : L | IsAlgebraic K x}) : Countable K := by
+  haveI : Countable {x : L | IsAlgebraic K x} := h.to_subtype
+  have hf : Function.Injective
+      (fun k : K => (⟨algebraMap K L k, isAlgebraic_algebraMap k⟩ :
+        {x : L | IsAlgebraic K x})) := by
+    intro a b hab
+    have hval : algebraMap K L a = algebraMap K L b := congrArg Subtype.val hab
+    exact FaithfulSMul.algebraMap_injective K L hval
+  exact hf.countable
+
+/-! ### The sharp characterization -/
+
+/-- **The sharp characterization.**  For a field extension `L / K`, the set of elements of
+    `L` algebraic over `K` is countable **iff** the base field `K` is countable.  Only the
+    base field's cardinality matters — the size of the ambient field `L` is irrelevant. -/
+theorem countable_algebraic_iff :
+    Set.Countable {x : L | IsAlgebraic K x} ↔ Countable K :=
+  ⟨countable_of_algebraic_setOf_countable, fun h => by
+    haveI := h
+    exact algebraic_setOf_countable⟩
+
+/-- **The `p`-adic obstruction, in general form.**  If the base field `K` is uncountable
+    then the algebraic elements over `K` are uncountable — indeed `K` alone already supplies
+    uncountably many of them.  This is why "algebraic `p`-adic numbers" are not countable:
+    `ℚ_p` is uncountable. -/
+theorem not_countable_algebraic_of_uncountable_base (h : ¬ Countable K) :
+    ¬ Set.Countable {x : L | IsAlgebraic K x} :=
+  fun hc => h (countable_of_algebraic_setOf_countable hc)
+
+/-! ### Worked instances
+
+Concrete base fields on both sides of the characterization. -/
+
+section Examples
+
+/-- Algebraic elements over `ℚ` (in any field extension) are countable — the classical case,
+    now recovered as a one-line instance of the general theorem rather than through Cantor's
+    height function. -/
+example {L : Type*} [Field L] [Algebra ℚ L] :
+    Set.Countable {x : L | IsAlgebraic ℚ x} :=
+  algebraic_setOf_countable
+
+/-- Algebraic elements over a finite field `ZMod p` are countable: `ZMod p` is finite, hence
+    countable, so the characterization applies.  (This is the function-field analogue of the
+    number-field case.) -/
+example (p : ℕ) [Fact p.Prime] {L : Type*} [Field L] [Algebra (ZMod p) L] :
+    Set.Countable {x : L | IsAlgebraic (ZMod p) x} :=
+  algebraic_setOf_countable
+
+/-- **The cautionary example** standing in for the `p`-adic case.  The base field `ℝ` is
+    uncountable, so the elements of `ℂ` algebraic over `ℝ` are uncountable — even though
+    `ℂ` is algebraic over `ℝ` of degree `2`.  No `p`-adic machinery is needed to see the
+    obstruction: uncountability of the base is enough. -/
+example : ¬ Set.Countable {x : ℂ | IsAlgebraic ℝ x} :=
+  not_countable_algebraic_of_uncountable_base not_countable
+
+end Examples
+
+end AlgebraicNumbersCountableOQ05OQ04

--- a/src/data/proofs/algebraic-numbers-countable-oq-05-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05-oq-04/meta.json
@@ -1,0 +1,120 @@
+{
+  "id": "algebraic-numbers-countable-oq-05-oq-04",
+  "title": "Countability of the Algebraic Elements is Governed by the Base Field",
+  "slug": "algebraic-numbers-countable-oq-05-oq-04",
+  "description": "Answers the parent's open question OQ-05-OQ-04 — does the countability of the algebraic numbers generalize to other base fields? — with a sharp characterization rather than a naive 'yes': for a field extension L/K, the set {x : L | IsAlgebraic K x} is countable if and only if the base field K is countable. Only the base field's cardinality matters; the ambient field L is irrelevant. The sufficient direction is Mathlib's Algebraic.countable; the necessary direction embeds K into the algebraic set via the injective algebraMap, so an uncountable base forces uncountably many algebraic elements. This corrects the open question's 'algebraic p-adic numbers' suggestion: ℚ_p is uncountable, so the algebraic elements over ℚ_p are uncountable — demonstrated concretely with the ℝ ⊆ ℂ analogue, which needs no p-adic machinery.",
+  "meta": {
+    "author": "Lean Genius researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicNumbersCountableOQ05OQ04.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 140,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None. The characterization holds for every field extension L/K and is fully machine-checked. Verified via #print axioms to depend only on the foundational axioms propext, Classical.choice, Quot.sound; no native_decide and no Lean.ofReduceBool dependency.",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "countability",
+      "algebraic-numbers",
+      "field-theory",
+      "field-extensions",
+      "p-adic-numbers",
+      "sharp-boundary",
+      "research"
+    ],
+    "dateAdded": "2026-06-30",
+    "originalContributions": [
+      "countable_algebraic_iff: the sharp characterization Set.Countable {x : L | IsAlgebraic K x} ↔ Countable K for any field extension L/K — the correct generalization of the classical 'algebraic numbers over ℚ are countable', showing that countability of the algebraic elements is controlled EXACTLY by the countability of the base field, with the ambient field L playing no role",
+      "countable_of_algebraic_setOf_countable: the necessary direction (new relative to Mathlib) — a countable algebraic set forces a countable base field, proved by embedding K into the algebraic set through k ↦ algebraMap K L k (injective since K is a field and L nontrivial, via FaithfulSMul.algebraMap_injective) and pulling back countability with Function.Injective.countable",
+      "not_countable_algebraic_of_uncountable_base: the p-adic obstruction in general form — an uncountable base field K yields uncountably many algebraic elements (K already supplies them), the precise reason the naive generalization to 'algebraic p-adic numbers' fails since ℚ_p is uncountable",
+      "algebraic_setOf_countable: the sufficient direction packaged for field extensions (Mathlib's Algebraic.countable), recovering the parent's ℚ result and the ZMod p (finite-field) case as one-line instances without Cantor's height function",
+      "Worked instances on both sides of the characterization: algebraic elements over ℚ and over a finite field ZMod p are countable, while the elements of ℂ algebraic over ℝ are uncountable — a concrete cautionary example standing in for the p-adic case and requiring no p-adic imports"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/AlgebraicNumbersCountableOQ05OQ04.lean",
+    "namespace": "AlgebraicNumbersCountableOQ05OQ04",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 140,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Cantor's 1874 paper proved the real algebraic numbers countable, giving the first proof that transcendental numbers exist (the reals being uncountable). The parent entry formalizes exactly this over the base field ℚ. A natural instinct is to declare the result 'about algebraic numbers in general' and expect it over any base field. But cardinality is unforgiving: the argument counts polynomials over the base field, and there are only countably many precisely when the base field is countable. The open question's own example — 'algebraic p-adic numbers' — is the trap, because the p-adic field ℚ_p is uncountable. The honest statement is therefore not an unconditional generalization but a biconditional pinning the phenomenon to the base field's cardinality.",
+    "problemStatement": "Open Question OQ-05-OQ-04: Does the countability proof for the algebraic numbers generalize to algebraic numbers over other fields — for example ℚ(√2), or algebraic p-adic numbers? Determine the precise condition on the base field under which the set of algebraic elements is countable.",
+    "proofStrategy": "Prove both directions of a biconditional over a field extension L/K. Sufficient (Countable K ⟹ countable algebraic set): this is Mathlib's Algebraic.countable K L, whose proof bounds the algebraic elements by the countably-many roots of the countably-many polynomials in K[X]. Necessary (countable algebraic set ⟹ Countable K): every element of the base field is algebraic over it (isAlgebraic_algebraMap), so k ↦ ⟨algebraMap K L k, _⟩ maps K into the algebraic set; this map is injective because algebraMap out of a field into a nontrivial ring is injective (FaithfulSMul.algebraMap_injective, available since a field forces NoZeroSMulDivisors hence FaithfulSMul); with the algebraic set countable (Set.Countable.to_subtype), Function.Injective.countable transfers countability back to K. Assembling the two gives countable_algebraic_iff; its contrapositive is not_countable_algebraic_of_uncountable_base. The concrete instances instantiate K at ℚ and ZMod p (countable, via the Fintype instance) and at ℝ (uncountable, via the Uncountable ℝ instance and not_countable).",
+    "keyInsights": [
+      "The correct generalization is a biconditional, not an unconditional 'yes': {x : L | IsAlgebraic K x} is countable ↔ K is countable. The temptation to state a one-directional generalization is exactly what the p-adic example punishes.",
+      "Only the BASE field's cardinality is relevant; the ambient field L can be as large as one likes (e.g. L = ℂ) without affecting the count. This is because the algebraic elements are pinned down by polynomials over K, of which there are #K-many.",
+      "The necessary direction is elementary and needs no cardinal arithmetic: the base field sits inside its own algebraic set (every k is a root of X − k), so an uncountable base field already exhibits uncountably many algebraic elements. The injectivity of algebraMap out of a field carries this through.",
+      "The 'algebraic p-adic numbers' phrase in the open question conflates two different base fields. Algebraic over ℚ (inside ℚ_p or anywhere) is countable; algebraic over ℚ_p is uncountable because ℚ_p itself is. The ℝ ⊆ ℂ example makes the same point with no p-adic machinery: every complex number is algebraic over ℝ, and ℝ is uncountable."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and the Sharp Answer",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Header stating OQ-05-OQ-04 and the resolution: the naive 'algebraic elements over any field are countable' is false (the p-adic field ℚ_p is uncountable), and the true statement is the biconditional 'countable algebraic set ↔ countable base field'. Lists the five named results and the worked instances."
+    },
+    {
+      "id": "sufficient",
+      "title": "Sufficient Direction: Countable Base ⟹ Countable Algebraic Set",
+      "startLine": 57,
+      "endLine": 65,
+      "summary": "algebraic_setOf_countable: when K is countable, {x : L | IsAlgebraic K x} is countable — Mathlib's Algebraic.countable restated for field extensions, the parent's 'yes' recovered without Cantor's height function."
+    },
+    {
+      "id": "embedding",
+      "title": "The Base Field Embeds Into the Algebraic Set",
+      "startLine": 67,
+      "endLine": 73,
+      "summary": "algebraMap_mem_algebraic: every element algebraMap K L k of (the image of) the base field is algebraic over K (a root of X − k), so K lands inside the algebraic set — the key fact powering the necessary direction."
+    },
+    {
+      "id": "necessary",
+      "title": "Necessary Direction: Countable Algebraic Set ⟹ Countable Base",
+      "startLine": 75,
+      "endLine": 90,
+      "summary": "countable_of_algebraic_setOf_countable: if the algebraic set is countable then K is countable. The injection k ↦ ⟨algebraMap K L k, _⟩ (injective by FaithfulSMul.algebraMap_injective) sends K into the countable subtype, and Function.Injective.countable transfers countability to K."
+    },
+    {
+      "id": "characterization",
+      "title": "The Sharp Characterization and the p-adic Obstruction",
+      "startLine": 92,
+      "endLine": 109,
+      "summary": "countable_algebraic_iff: Set.Countable {x : L | IsAlgebraic K x} ↔ Countable K, the two directions assembled; not_countable_algebraic_of_uncountable_base: the contrapositive, an uncountable base field forces uncountably many algebraic elements — the general form of the p-adic obstruction."
+    },
+    {
+      "id": "examples",
+      "title": "Worked Instances",
+      "startLine": 111,
+      "endLine": 138,
+      "summary": "Algebraic elements over ℚ and over a finite field ZMod p are countable (one-line instances of the general theorem); the elements of ℂ algebraic over ℝ are uncountable, the concrete cautionary example standing in for the p-adic case with no p-adic imports."
+    }
+  ],
+  "conclusion": {
+    "summary": "5 theorems, 0 sorries, 0 axioms. For a field extension L/K, the set of elements of L algebraic over K is countable if and only if the base field K is countable — a sharp biconditional. The sufficient direction is Mathlib's Algebraic.countable; the necessary direction embeds K into its algebraic set via the injective algebraMap. Worked instances confirm countability over ℚ and ZMod p and uncountability over ℝ.",
+    "implications": "The result replaces a tempting but false unconditional generalization with the exact condition, and pinpoints why the open question's 'algebraic p-adic numbers' example fails: countability is a property of the BASE field, and ℚ_p is uncountable. The proof pattern — a Mathlib upper bound for the easy direction, plus a base-field embedding for the converse — is the reusable idiom for turning a one-directional cardinality fact into a sharp characterization. It also cleanly separates 'algebraic over ℚ' (always countable, inside any extension) from 'algebraic over an uncountable field' (always uncountable).",
+    "openQuestions": [
+      "Can the characterization be upgraded to exact cardinality — #{x : L | IsAlgebraic K x} = max(#K, ℵ₀) whenever L contains the algebraic closure of K — recovering both the countable and uncountable regimes as the two cases of a single cardinal formula (Mathlib's Algebraic.cardinalMk_le_max gives one inequality)?",
+      "Does an analogous base-controlled characterization hold for the TRANSCENDENCE degree or for the set of transcendental elements {x : L | ¬ IsAlgebraic K x}, whose size is governed by #L rather than #K?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "algebraic-numbers-countable-oq-05",
+      "relationship": "parent — proves the real algebraic numbers over ℚ countable via Cantor's 1874 height function and poses this open question about other base fields; this entry gives the sharp base-field characterization that generalizes it"
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "ancestor — the core entry establishing countability of the algebraic numbers over ℚ"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent's open question **OQ-05-OQ-04** — *does the countability of the algebraic numbers generalize to other base fields (ℚ(√2), algebraic p-adic numbers)?* — with a **sharp characterization** rather than a naive "yes":

> For a field extension `L / K`, the set `{x : L | IsAlgebraic K x}` is countable **if and only if** the base field `K` is countable.

Only the **base** field's cardinality matters; the ambient field `L` is irrelevant. This confirms the parent's ℚ result and pinpoints exactly why the open question's "algebraic p-adic numbers" example fails: `ℚ_p` is **uncountable**, so the algebraic elements over `ℚ_p` are uncountable.

## Contribution (`Proofs/AlgebraicNumbersCountableOQ05OQ04.lean`, 5 theorems + 3 examples)

- `countable_algebraic_iff` — the sharp biconditional `Set.Countable {x : L | IsAlgebraic K x} ↔ Countable K`.
- `countable_of_algebraic_setOf_countable` — the **necessary** direction (new relative to Mathlib): `K` embeds into its own algebraic set via the injective `algebraMap`, so a countable algebraic set forces a countable base.
- `algebraic_setOf_countable` — the **sufficient** direction (Mathlib's `Algebraic.countable`), recovering ℚ and `ZMod p` as one-line instances.
- `not_countable_algebraic_of_uncountable_base` — the p-adic obstruction in general form.
- Worked instances: countable over `ℚ` and over `ZMod p`; **un**countable over `ℝ` (inside `ℂ`) — a concrete cautionary example standing in for the p-adic case, no p-adic imports needed.

## Verification

- Builds against pinned Mathlib (`./proofs/scripts/docker-build.sh Proofs.AlgebraicNumbersCountableOQ05OQ04`, 7743 jobs).
- **0 sorries, 0 axioms.** `#print axioms` reports only `propext, Classical.choice, Quot.sound`; no `native_decide`, no `Lean.ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)