### PR TITLE
Enrich Rational Three Squares (Davenport-Cassels): add Serre Hasse-Minkowski reference

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/meta.json
@@ -159,6 +159,13 @@
       "year": "1798",
       "venue": "Three-square theorem",
       "description": "n = x²+y²+z² is solvable over ℤ iff n ≠ 4^a(8b+7). This entry establishes the unconditional half of the analogous characterization over ℚ and shows the two characterizations coincide."
+    },
+    {
+      "title": "A Course in Arithmetic",
+      "author": "Jean-Pierre Serre",
+      "year": "1973",
+      "venue": "Graduate Texts in Mathematics 7, Chapter IV",
+      "description": "The canonical modern reference for the Hasse–Minkowski local–global principle and its application to the three-square theorem: n is a sum of three rational squares iff it is one over every completion ℝ, ℚ_p. This is exactly the solvability input (ThreeSquaresRationalSolvability) that this entry isolates as the one remaining open hypothesis."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Enrichment pass — lagrange-four-squares-waring-g2-oq-03-oq-06

This research-tier entry was already excellent (5 keyInsights, 2 well-crafted openQuestions, 3 crossReferences, 4 fully-fielded annotations, sections covering the full file). Under all size caps.

Single targeted gap: the entry discusses the **Hasse–Minkowski local–global principle** throughout — it is the one open input (`ThreeSquaresRationalSolvability`) the entry isolates — but cited no reference for it.

- **+1 reference** (2 → 3, cap 25): Serre, *A Course in Arithmetic* (GTM 7, Ch. IV) — the canonical modern source for Hasse–Minkowski and its application to the three-square theorem.

No content removed; `pnpm build` passes.