### PR TITLE
Enrich Galois extensions oq-02-oq-01 & oq-03: add crossReferences

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/meta.json
@@ -162,6 +162,28 @@
       "note": "John Wiley & Sons. §14.2, Theorem 14 (the Fundamental Theorem), part (ii): the correspondence between normal subgroups and Galois subextensions."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-galois-extensions-oq-02",
+      "relationship": "extends",
+      "description": "Parent. OQ-02 packages the full Galois correspondence and, in Part VI, only the one-way normal refinement (isGalois_fixedField_of_normal, normalQuotientEquiv). This entry imports it and completes the refinement into the biconditional IsGalois F K ↔ K.fixingSubgroup.Normal, restricting the bijection to Galois subextensions ↔ normal subgroups."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions-oq-01",
+      "relationship": "instantiated on",
+      "description": "Concrete witness (transitively). OQ-01 builds (X⁵ − 4X + 2).Gal ≃* S₅; via OQ-02's IsGalois ℚ (X⁵−4X+2).SplittingField instance, the final section instantiates the normal correspondence on this quintic — its Galois subextensions biject with the normal subgroups of S₅."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions",
+      "relationship": "part of",
+      "description": "Grandparent file for the Abel–Ruffini Galois program. The normal-subgroup ↔ Galois-subextension bijection proved here is the exact piece that makes each quotient in a solvable series itself the Galois group of a subextension."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "underpins",
+      "description": "The abstract Abel–Ruffini obstruction. Solvability by radicals is read off a subnormal series with abelian quotients; the normal-subgroup half of the correspondence formalized here is precisely what guarantees each such quotient is again a Galois group, so the series lives on the field side too."
+    }
+  ],
   "mainTheorems": [
     {
       "name": "isGalois_iff_fixingSubgroup_normal",

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-03/meta.json
@@ -164,6 +164,23 @@
       "note": "Provides `alternatingGroup.isSimpleGroup_five` and the general-n converse machinery (`IsThreeCycle.alternating_normalClosure`, `isThreeCycle_isConj`, `closure_three_cycles_eq_alternating`) on which this reduction builds."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-galois-extensions",
+      "relationship": "extends",
+      "description": "Parent file. It develops the abstract Abel–Ruffini theory (Sₙ solvable ⟺ n ≤ 4; A₅ simple; a non-solvable Galois group blocks radical solvability). This entry generalizes the A₅-simplicity input to all n ≥ 5 and isolates its genuine combinatorial content in the 3-cycle-containment criterion."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions-oq-01",
+      "relationship": "related",
+      "description": "Sibling, constructive direction. OQ-01 exhibits an explicit quintic X⁵ − 4X + 2 with Gal ≅ S₅ (hence non-solvable). Where OQ-01 produces a concrete non-solvable group, this entry supplies the general structural reason such groups exist for n ≥ 5: the simplicity of Aₙ."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "underpins",
+      "description": "The abstract Abel–Ruffini theorem. Non-solvability of Sₙ for n ≥ 5 rests entirely on Aₙ being simple and non-abelian; this entry pins that simplicity to the single 3-cycle-containment criterion, exposing the exact combinatorial fact the whole obstruction depends on."
+    }
+  ],
   "mainTheorems": [
     {
       "name": "isSimpleGroup_alternating_iff",


### PR DESCRIPTION
Enrichment pass adding the missing top-level `crossReferences` to two Abel–Ruffini Galois-extensions entries. Both had populated `relatedProblems` (ResearchProblemPage) but empty `crossReferences` (ProofPage), so their cross-reference sections rendered blank on the live site.

### `abel-ruffini-galois-extensions-oq-02-oq-01` — Normal Refinement (normal subgroups ↔ Galois subextensions)
4 links: parent `oq-02`, transitive witness `oq-01`, grandparent `abel-ruffini-galois-extensions`, and `abel-ruffini` (the normal-subgroup half is what keeps each solvable-series quotient a Galois group).

### `abel-ruffini-galois-extensions-oq-03` — Simplicity of Aₙ via the 3-cycle criterion
3 links: parent `abel-ruffini-galois-extensions`, sibling `oq-01` (constructive direction), and `abel-ruffini` (Aₙ-simplicity is the exact fact non-solvability of Sₙ for n≥5 depends on).

All target slugs verified to exist; no content removed; both files under the 60 KB cap (`check-meta-size.ts` passes); `pnpm build` succeeds.