### PR TITLE
research(cube-root-3-irrational-oq-02-oq-04): Eisenstein for squarefree radicands + sharp boundary [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ02OQ04.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ02OQ04.lean
@@ -1,0 +1,201 @@
+/-
+# Eisenstein Irreducibility for Squarefree Radicands: X^n − m and ⁿ√m
+
+**Open Question OQ-04** (of `cube-root-3-irrational-oq-02`):
+The parent gives an Eisenstein proof that X³ − 3 is irreducible over ℚ.
+Does the Eisenstein approach extend to **non-prime** radicands? The seeker note asks:
+X^n − 6 is Eisenstein-irreducible (at p = 2 or 3), X^n − 30 at p = 2, 3, or 5 —
+does *any squarefree* m give an Eisenstein-irreducible X^n − m?
+
+## Answer: YES — squarefree is sufficient (but not necessary)
+
+The dependency `CubeRoot2IrrationalOQ03` already proves the *criterion form*:
+if m has a prime factor p with p ∣ m but p² ∤ m, then X^n − m is irreducible over ℚ.
+This file connects that criterion to Mathlib's `Squarefree` predicate and draws the
+sharp boundary the open question is fishing for.
+
+1. **Squarefree ⟹ Eisenstein prime exists.** For squarefree m ≥ 2, *every* prime
+   divisor p satisfies p² ∤ m (that is the definition of squarefree), and m ≥ 2
+   guarantees at least one prime divisor exists. So the criterion always applies.
+
+2. **Irreducibility.** Hence `Squarefree m → 2 ≤ m → 2 ≤ n → Irreducible (Xⁿ − m)` over ℚ.
+
+3. **Irrationality.** An irreducible polynomial of degree ≥ 2 has no rational root,
+   so `Squarefree m → 2 ≤ m → 2 ≤ n → Irrational (ⁿ√m)`. This generalizes the
+   parent's ∛3 result to *every* squarefree radicand and *every* root degree.
+
+4. **Field degree.** `[ℚ(ⁿ√m) : ℚ] = n` for squarefree m ≥ 2 (via the parent's degree
+   machinery), reproving cbrt6 / cbrt10 / fourthrt30 as instances of one clean hypothesis.
+
+5. **Sharp boundary — sufficient, NOT necessary.** Squarefreeness is *not* required:
+   m = 12 = 2²·3 is not squarefree, yet X^n − 12 is still Eisenstein-irreducible at
+   p = 3 (since 3 ∥ 12). The true criterion is "some prime exactly divides m", which is
+   strictly weaker than squarefree. We witness this explicitly.
+
+## Status: 0 sorries, axiom-free (relative to Mathlib)
+-/
+
+import Proofs.CubeRoot2IrrationalOQ03
+import Mathlib.NumberTheory.Real.Irrational
+
+open Polynomial IntermediateField CubeRoot2IrrationalOQ03
+
+namespace CubeRoot3IrrationalOQ02OQ04
+
+-- ============================================================
+-- PART 1: Squarefree radicands admit an Eisenstein prime
+-- ============================================================
+
+/-- For a squarefree `m ≥ 2` there is a prime `p` with `p ∣ m` but `p² ∤ m`.
+
+Existence of a prime divisor comes from `m ≠ 1`. Squarefreeness upgrades it to an
+*Eisenstein* prime: if `p² ∣ m` then `p * p ∣ m`, so `Squarefree m` would force
+`IsUnit p`, impossible for a prime. Thus `p ∥ m` (p exactly divides m). -/
+theorem sqfree_exists_eisenstein_prime {m : ℕ} (hsf : Squarefree m) (hm : 2 ≤ m) :
+    ∃ p, p.Prime ∧ p ∣ m ∧ ¬ p ^ 2 ∣ m := by
+  obtain ⟨p, hp, hpd⟩ := Nat.exists_prime_and_dvd (by omega : m ≠ 1)
+  refine ⟨p, hp, hpd, ?_⟩
+  intro hp2
+  have hpp : p * p ∣ m := by rw [← pow_two]; exact hp2
+  exact hp.one_lt.ne' (Nat.isUnit_iff.mp (hsf p hpp))
+
+-- ============================================================
+-- PART 2: Irreducibility of X^n − m for squarefree m
+-- ============================================================
+
+/-- **Main irreducibility result.** For squarefree `m ≥ 2` and `n ≥ 2`, the polynomial
+`Xⁿ − m` is irreducible over ℚ. Every squarefree radicand yields an Eisenstein-irreducible
+`Xⁿ − m`, answering the open question. -/
+theorem X_pow_sub_C_irreducible_of_squarefree {m : ℕ} (hsf : Squarefree m) (hm : 2 ≤ m)
+    {n : ℕ} (hn : 2 ≤ n) : Irreducible (X ^ n - C (m : ℚ) : ℚ[X]) := by
+  obtain ⟨p, hp, hpd, hpnd⟩ := sqfree_exists_eisenstein_prime hsf hm
+  exact eisenstein_X_pow_sub_of_sqfree_factor n m p hn hp hpd hpnd (by omega)
+
+-- ============================================================
+-- PART 3: No rational roots ⟹ irrationality of ⁿ√m
+-- ============================================================
+
+/-- An irreducible polynomial over ℚ of natDegree ≥ 2 has no rational root.
+
+If `q` were a root then `(X − C q) ∣ P`; write `P = (X − C q) · R`. Irreducibility forces
+one factor to be a unit. `X − C q` is not a unit (natDegree 1), and if `R` is a unit then
+`natDegree P = 1`, contradicting `natDegree P ≥ 2`. -/
+theorem no_rat_root_of_irreducible {P : ℚ[X]} (hirr : Irreducible P)
+    (hdeg : 2 ≤ P.natDegree) (q : ℚ) : P.eval q ≠ 0 := by
+  intro hroot
+  have hdvd : (X - C q) ∣ P := dvd_iff_isRoot.mpr hroot
+  obtain ⟨R, hR⟩ := hdvd
+  rcases hirr.isUnit_or_isUnit hR with h | h
+  · -- X − C q is a unit: impossible, natDegree = 1
+    have h0 : (X - C q : ℚ[X]).natDegree = 0 := natDegree_eq_zero_of_isUnit h
+    rw [natDegree_X_sub_C] at h0
+    exact one_ne_zero h0
+  · -- R is a unit: then natDegree P = 1, contradiction with hdeg
+    have hRu : R.natDegree = 0 := natDegree_eq_zero_of_isUnit h
+    have hP_ne : P ≠ 0 := hirr.ne_zero
+    have hXq_ne : (X - C q : ℚ[X]) ≠ 0 := X_sub_C_ne_zero q
+    have hR_ne : R ≠ 0 := by
+      intro h0; exact hP_ne (by rw [hR, h0, mul_zero])
+    have hP1 : P.natDegree = 1 := by
+      rw [hR, natDegree_mul hXq_ne hR_ne, natDegree_X_sub_C, hRu]
+    omega
+
+/-- **Irrationality from irreducibility.** If `Xⁿ − m` is irreducible over ℚ with `n ≥ 2`
+and `m ≠ 0`, then the real `n`-th root `m^(1/n)` is irrational.
+
+`m^(1/n)` is a root of `Xⁿ − m` (its `n`-th power is `m`); if it were rational it would be
+a rational root of an irreducible degree-`n ≥ 2` polynomial, which is impossible. -/
+theorem irrational_nthRoot_of_irreducible {m n : ℕ} (hn : 2 ≤ n) (hm : m ≠ 0)
+    (hirr : Irreducible (X ^ n - C (m : ℚ) : ℚ[X])) :
+    Irrational ((m : ℝ) ^ ((1 : ℝ) / n)) := by
+  rintro ⟨q, hq⟩
+  -- q^n = m over ℝ, hence over ℚ
+  have hqn_real : (q : ℝ) ^ n = m := by
+    rw [hq, ← Real.rpow_natCast ((m : ℝ) ^ ((1 : ℝ) / n)) n,
+        ← Real.rpow_mul (by positivity : (0 : ℝ) ≤ (m : ℝ)), one_div,
+        inv_mul_cancel₀ (Nat.cast_ne_zero.mpr (by omega : n ≠ 0)), Real.rpow_one]
+  have hqn : q ^ n = (m : ℚ) := by exact_mod_cast hqn_real
+  have heval : (X ^ n - C (m : ℚ) : ℚ[X]).eval q = 0 := by
+    simp [hqn]
+  have hdeg : (X ^ n - C (m : ℚ) : ℚ[X]).natDegree = n :=
+    natDegree_X_pow_sub_nat_eq (by omega) hm
+  exact no_rat_root_of_irreducible hirr (by rw [hdeg]; exact hn) q heval
+
+/-- **Irrationality for squarefree radicands.** For squarefree `m ≥ 2` and `n ≥ 2`, the
+`n`-th root `ⁿ√m` is irrational. Generalizes the parent's ∛3 to any squarefree radicand
+and any root degree. -/
+theorem irrational_nthRoot_of_squarefree {m n : ℕ} (hsf : Squarefree m) (hm : 2 ≤ m)
+    (hn : 2 ≤ n) : Irrational ((m : ℝ) ^ ((1 : ℝ) / n)) :=
+  irrational_nthRoot_of_irreducible hn (by omega)
+    (X_pow_sub_C_irreducible_of_squarefree hsf hm hn)
+
+-- ============================================================
+-- PART 4: Field extension degree for squarefree radicands
+-- ============================================================
+
+/-- **Field degree.** `[ℚ(ⁿ√m) : ℚ] = n` for squarefree `m ≥ 2` and `n ≥ 2`.
+The parent proves this for numbers with an exact-prime-power factor; here the hypothesis
+is the single clean condition `Squarefree m`. -/
+theorem adjoin_nthRoot_squarefree_finrank {m n : ℕ} (hsf : Squarefree m) (hm : 2 ≤ m)
+    (hn : 2 ≤ n) : Module.finrank ℚ ℚ⟮(m : ℝ) ^ ((1 : ℝ) / (n : ℝ))⟯ = n := by
+  obtain ⟨p, hp, hpd, hpnd⟩ := sqfree_exists_eisenstein_prime hsf hm
+  exact adjoin_nthRoot_finrank n m p hn hp hpd hpnd (by omega)
+
+-- ============================================================
+-- PART 5: Sharp boundary — squarefree is SUFFICIENT, not NECESSARY
+-- ============================================================
+
+/-- `12 = 2² · 3` is not squarefree: `2 * 2 = 4 ∣ 12` but `2` is not a unit. -/
+theorem not_squarefree_twelve : ¬ Squarefree 12 := by
+  intro h
+  have h2 : IsUnit (2 : ℕ) := h 2 (by norm_num)
+  rw [Nat.isUnit_iff] at h2
+  norm_num at h2
+
+/-- Yet `Xⁿ − 12` is Eisenstein-irreducible at `p = 3` (since `3 ∥ 12`: `3 ∣ 12` but `9 ∤ 12`).
+This witnesses that squarefreeness of the radicand is **sufficient but not necessary** — the
+genuine criterion is "some prime exactly divides `m`", which is strictly weaker. -/
+theorem X_pow_sub_C_twelve_irreducible {n : ℕ} (hn : 2 ≤ n) :
+    Irreducible (X ^ n - C (12 : ℚ) : ℚ[X]) :=
+  eisenstein_X_pow_sub_of_sqfree_factor n 12 3 hn (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num)
+
+/-- `ⁿ√12` is irrational for every `n ≥ 2`, even though `12` is not squarefree. -/
+theorem irrational_nthRoot_twelve {n : ℕ} (hn : 2 ≤ n) :
+    Irrational (((12 : ℕ) : ℝ) ^ ((1 : ℝ) / n)) :=
+  irrational_nthRoot_of_irreducible hn (by norm_num) (X_pow_sub_C_twelve_irreducible hn)
+
+-- ============================================================
+-- PART 6: Concrete instances of the squarefree theorem
+-- ============================================================
+
+/-- `6 = 2·3` is squarefree. -/
+theorem squarefree_six : Squarefree 6 := by
+  rw [show (6 : ℕ) = 2 * 3 by norm_num, Nat.squarefree_mul_iff]
+  exact ⟨by norm_num, Nat.prime_two.prime.squarefree,
+         (by norm_num : Nat.Prime 3).prime.squarefree⟩
+
+/-- `15 = 3·5` is squarefree. -/
+theorem squarefree_fifteen : Squarefree 15 := by
+  rw [show (15 : ℕ) = 3 * 5 by norm_num, Nat.squarefree_mul_iff]
+  exact ⟨by norm_num, (by norm_num : Nat.Prime 3).prime.squarefree,
+         (by norm_num : Nat.Prime 5).prime.squarefree⟩
+
+/-- `30 = 2·3·5` is squarefree. -/
+theorem squarefree_thirty : Squarefree 30 := by
+  rw [show (30 : ℕ) = 2 * 15 by norm_num, Nat.squarefree_mul_iff]
+  exact ⟨by norm_num, Nat.prime_two.prime.squarefree, squarefree_fifteen⟩
+
+/-- `√6` is irrational (`6 = 2·3` is squarefree). -/
+theorem irrational_sqrt_six : Irrational (((6 : ℕ) : ℝ) ^ ((1 : ℝ) / 2)) :=
+  irrational_nthRoot_of_squarefree squarefree_six (by norm_num) (by norm_num)
+
+/-- `√30` is irrational (`30 = 2·3·5` is squarefree). -/
+theorem irrational_sqrt_thirty : Irrational (((30 : ℕ) : ℝ) ^ ((1 : ℝ) / 2)) :=
+  irrational_nthRoot_of_squarefree squarefree_thirty (by norm_num) (by norm_num)
+
+/-- `∛30` is irrational. -/
+theorem irrational_cbrt_thirty : Irrational (((30 : ℕ) : ℝ) ^ ((1 : ℝ) / 3)) :=
+  irrational_nthRoot_of_squarefree squarefree_thirty (by norm_num) (by norm_num)
+
+end CubeRoot3IrrationalOQ02OQ04

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-04/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-04/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "cube-root-3-irrational-oq-02-oq-04",
+  "slug": "cube-root-3-irrational-oq-02-oq-04",
+  "title": "Eisenstein for Squarefree Radicands: Xⁿ − m and the ⁿ√m Irrationality Family",
+  "description": "The parent gives an Eisenstein proof that X³ − 3 is irreducible. Open Question OQ-04 asks whether the Eisenstein approach extends to non-prime radicands — is every squarefree m enough? This entry answers YES by bridging Mathlib's `Squarefree` predicate to the criterion, deducing irrationality of ⁿ√m for every squarefree m ≥ 2 and every n ≥ 2, and then drawing the sharp boundary: squarefreeness is sufficient but NOT necessary (witnessed by m = 12).",
+  "leanFile": {
+    "lineCount": 201,
+    "path": "Proofs/CubeRoot3IrrationalOQ02OQ04.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 15
+  },
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Every squarefree m ≥ 2 makes Xⁿ − m Eisenstein-irreducible over ℚ (for n ≥ 2), so ⁿ√m is irrational. Squarefreeness is sufficient but not necessary — m = 12 is a counterexample to necessity. 15 theorems, 0 sorries, 0 axioms.",
+    "implications": "**From one prime to all squarefree radicands**: the parent's dependency proves Xⁿ − m irreducible whenever *some* prime p exactly divides m (p ∣ m, p² ∤ m). This entry closes the gap the open question names: for a squarefree m, *every* prime divisor exactly divides m (that is the definition of squarefree), and m ≥ 2 guarantees at least one exists. So the single hypothesis `Squarefree m` mechanically supplies the Eisenstein prime — no case analysis on m.\n\n**A whole family of irrationalities**: `irrational_nthRoot_of_squarefree` generalizes the parent's ∛3 result along two axes at once — arbitrary squarefree radicand and arbitrary root degree n ≥ 2. Instances √6, √30, ∛30 are one-liners.\n\n**Sharp boundary (sufficient ≠ necessary)**: the natural guess that Eisenstein needs a squarefree radicand is FALSE. m = 12 = 2²·3 is not squarefree, yet Xⁿ − 12 is Eisenstein-irreducible at p = 3 because 3 ∥ 12. The genuine criterion is the strictly weaker 'some prime exactly divides m'. Making both the positive theorem and its counterexample-to-necessity explicit is the entry's main contribution.",
+    "openQuestions": [
+      "Characterize exactly which m admit an Eisenstein prime (a prime p with p ∥ m). This is 'm is not of the form where every prime divisor appears with exponent ≥ 2', i.e. m is not powerful. Formalizing the powerful-number boundary would complete the classification of the Eisenstein-reachable radicands.",
+      "For a powerful but non-perfect-power m (e.g. m = 8, m = 72), Eisenstein at every prime fails, yet ⁿ√m can still be irrational. What alternative criterion (e.g. the general X^n − C a irreducibility of Vahlen–Capelli / Kummer) governs these cases, and how does it interact with the 4 ∣ n exceptional clause?",
+      "Does the squarefree-radicand irreducibility extend verbatim to Xⁿ − m over other number fields, or does the ramification of the chosen prime p obstruct the Gauss-lemma transfer?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cube-root-3-irrational-oq-02",
+      "relationship": "extends",
+      "description": "Parent: Eisenstein proof that X³ − 3 is irreducible over ℚ. This entry generalizes the radicand 3 to every squarefree m ≥ 2 (and every root degree)."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Computes [ℚ(∛3):ℚ] = 3 via the shared helper CubeRoot2IrrationalOQ03; this entry proves the analogous [ℚ(ⁿ√m):ℚ] = n for squarefree m as a corollary of the same machinery."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Linear independence of {1, ∛3, (∛3)²} over ℚ — another consequence of the degree-3 extension whose radicand-generalization this entry supplies."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-setup",
+      "title": "Setup: Imports and Namespace",
+      "startLine": 37,
+      "endLine": 45,
+      "summary": "Imports the parametric n-th root file CubeRoot2IrrationalOQ03 and opens Polynomial, IntermediateField, and CubeRoot2IrrationalOQ03. IntermediateField is required for the ℚ⟮α⟯ adjoin notation.",
+      "mathContext": "Built on the dependency's Eisenstein criterion for $X^n - m$ with an exactly-dividing prime factor, and its field-degree lemmas."
+    },
+    {
+      "id": "sec-eisenstein-prime",
+      "title": "PART 1: Squarefree Radicands Admit an Eisenstein Prime",
+      "startLine": 47,
+      "endLine": 66,
+      "summary": "sqfree_exists_eisenstein_prime: for squarefree m ≥ 2 there is a prime p with p ∣ m but p² ∤ m. A prime divisor exists because m ≠ 1; squarefreeness upgrades it to exact division since p² ∣ m would force IsUnit p.",
+      "mathContext": "Uses `Nat.exists_prime_and_dvd` and the definition of `Squarefree` ($\\forall x,\\ x\\cdot x \\mid m \\to \\text{IsUnit } x$)."
+    },
+    {
+      "id": "sec-irreducible",
+      "title": "PART 2: Irreducibility of Xⁿ − m for Squarefree m",
+      "startLine": 68,
+      "endLine": 76,
+      "summary": "X_pow_sub_C_irreducible_of_squarefree: the headline positive result. For squarefree m ≥ 2 and n ≥ 2, Xⁿ − m is irreducible over ℚ, obtained by feeding the Eisenstein prime into the dependency's criterion.",
+      "mathContext": "Applies `eisenstein_X_pow_sub_of_sqfree_factor` with the prime produced in Part 1."
+    },
+    {
+      "id": "sec-irrationality",
+      "title": "PART 3: No Rational Roots ⟹ Irrationality of ⁿ√m",
+      "startLine": 78,
+      "endLine": 132,
+      "summary": "no_rat_root_of_irreducible (irreducible degree ≥ 2 ⟹ no rational root), irrational_nthRoot_of_irreducible (irrationality from irreducibility), and irrational_nthRoot_of_squarefree (the family theorem: ⁿ√m irrational for squarefree m ≥ 2, n ≥ 2).",
+      "mathContext": "A rational root gives a linear factor $(X - C q)$; irreducibility forces natDegree $= 1 \\neq n$. The real $n$-th power identity uses `Real.rpow_natCast` / `Real.rpow_mul`."
+    },
+    {
+      "id": "sec-field-degree",
+      "title": "PART 4: Field Extension Degree",
+      "startLine": 134,
+      "endLine": 143,
+      "summary": "adjoin_nthRoot_squarefree_finrank: [ℚ(ⁿ√m):ℚ] = n for squarefree m ≥ 2 and n ≥ 2, the degree statement under the single clean Squarefree hypothesis.",
+      "mathContext": "Specializes the dependency's `adjoin_nthRoot_finrank` to the squarefree case."
+    },
+    {
+      "id": "sec-boundary",
+      "title": "PART 5: Sharp Boundary — Sufficient, NOT Necessary",
+      "startLine": 145,
+      "endLine": 163,
+      "summary": "not_squarefree_twelve (12 is not squarefree, via 2·2 ∣ 12), X_pow_sub_C_twelve_irreducible (Xⁿ − 12 still irreducible via 3 ∥ 12), and irrational_nthRoot_twelve. Witnesses that squarefreeness is sufficient but not necessary.",
+      "mathContext": "The true criterion is 'some prime exactly divides m', strictly weaker than `Squarefree m`."
+    },
+    {
+      "id": "sec-instances",
+      "title": "PART 6: Concrete Instances",
+      "startLine": 165,
+      "endLine": 200,
+      "summary": "squarefree_six / squarefree_fifteen / squarefree_thirty (via Nat.squarefree_mul_iff and Prime.squarefree), then irrational_sqrt_six, irrational_sqrt_thirty, irrational_cbrt_thirty as one-line corollaries.",
+      "mathContext": "Squarefreeness of small radicands is established multiplicatively rather than by `decide`, which cannot reduce the well-founded `Nat.minSqFac`."
+    }
+  ],
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "author": "Formalized in Lean 4 with Mathlib",
+    "date": "2026-06-30",
+    "dateAdded": "2026-06-30",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 201,
+    "definitionCount": 0,
+    "theoremCount": 15,
+    "proofRepoPath": "Proofs/CubeRoot3IrrationalOQ02OQ04.lean",
+    "assumptions": "None beyond Mathlib. All 15 theorems depend only on the standard foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms) — no sorryAx, no Lean.ofReduceBool. Depends on CubeRoot2IrrationalOQ03 for the Eisenstein criterion and field-degree lemmas.",
+    "tags": [
+      "irrationality",
+      "eisenstein",
+      "irreducibility",
+      "squarefree",
+      "nth-roots",
+      "field-extensions",
+      "polynomials",
+      "algebraic-numbers"
+    ],
+    "originalContributions": [
+      "sqfree_exists_eisenstein_prime: Squarefree m ∧ 2 ≤ m ⟹ ∃ prime p, p ∣ m ∧ p² ∤ m — the bridge from Mathlib's Squarefree predicate to the Eisenstein criterion",
+      "X_pow_sub_C_irreducible_of_squarefree: Xⁿ − m irreducible over ℚ for squarefree m ≥ 2, n ≥ 2 (the open question's positive answer)",
+      "no_rat_root_of_irreducible: reusable lemma — an irreducible ℚ[X] of natDegree ≥ 2 has no rational root",
+      "irrational_nthRoot_of_squarefree: ⁿ√m irrational for every squarefree m ≥ 2 and every n ≥ 2 — generalizes the parent's ∛3 in both radicand and degree",
+      "adjoin_nthRoot_squarefree_finrank: [ℚ(ⁿ√m):ℚ] = n for squarefree m ≥ 2 under the single Squarefree hypothesis",
+      "not_squarefree_twelve + X_pow_sub_C_twelve_irreducible: sharp boundary — squarefreeness is sufficient but NOT necessary (m = 12 = 2²·3 is not squarefree yet Xⁿ − 12 is Eisenstein-irreducible at 3 ∥ 12)",
+      "irrational_sqrt_six / irrational_sqrt_thirty / irrational_cbrt_thirty: concrete squarefree instances"
+    ]
+  }
+}


### PR DESCRIPTION
## Open Question OQ-04 (of `cube-root-3-irrational-oq-02`)

The parent gives an Eisenstein proof that `X³ − 3` is irreducible over ℚ. OQ-04 asks: **does the Eisenstein approach extend to non-prime radicands?** The seeker note observes `Xⁿ − 6` is Eisenstein-irreducible at p=2 or 3, `Xⁿ − 30` at p=2,3,5 — is *any squarefree* m enough?

## Answer: YES — squarefree is sufficient (but not necessary)

The dependency `CubeRoot2IrrationalOQ03` already proves the *criterion form*: `Xⁿ − m` is irreducible whenever some prime `p` exactly divides `m` (`p ∣ m`, `p² ∤ m`). This entry connects that to Mathlib's `Squarefree` predicate and draws the sharp boundary the question is fishing for.

### New results (15 theorems, 0 sorries)
- **`sqfree_exists_eisenstein_prime`** — bridges `Squarefree m ∧ 2 ≤ m` to `∃ prime p, p ∣ m ∧ p² ∤ m`. Every prime divisor of a squarefree number exactly divides it (that *is* squarefreeness), and `m ≥ 2` guarantees one exists.
- **`X_pow_sub_C_irreducible_of_squarefree`** — `Xⁿ − m` irreducible over ℚ for squarefree `m ≥ 2`, `n ≥ 2` (the positive answer).
- **`no_rat_root_of_irreducible`** — reusable: an irreducible `ℚ[X]` of natDegree ≥ 2 has no rational root.
- **`irrational_nthRoot_of_squarefree`** — `ⁿ√m` irrational for every squarefree `m ≥ 2` and every `n ≥ 2`. Generalizes the parent's `∛3` in *both* radicand and degree.
- **`adjoin_nthRoot_squarefree_finrank`** — `[ℚ(ⁿ√m):ℚ] = n` for squarefree `m` under the single `Squarefree` hypothesis.
- **Sharp boundary** — `not_squarefree_twelve` + `X_pow_sub_C_twelve_irreducible`: `12 = 2²·3` is *not* squarefree, yet `Xⁿ − 12` is Eisenstein-irreducible at `p = 3` (since `3 ∥ 12`). Squarefreeness is **sufficient but not necessary**; the true criterion is the strictly weaker "some prime exactly divides m".
- **Concrete instances** — `√6`, `√30`, `∛30` irrational.

### Verification
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ02OQ04` (7744 jobs).
- `#print axioms` on all headline theorems: only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Status `verified`, `axiomCount: 0`.

### Note
`Squarefree n` and gcd-based coprimality are proved via `Nat.squarefree_mul_iff` / `Prime.squarefree` / `norm_num`, not `decide` — the kernel cannot reduce the well-founded `Nat.minSqFac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)