### PR TITLE
research(cube-root-3-irrational-oq-02-oq-04): Eisenstein for squarefree radicands + sharp boundary [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ02OQ04.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ02OQ04.lean
@@ -146,32 +146,47 @@ theorem adjoin_nthRoot_finrank_of_squarefree (n m : ℕ) (hn : 2 ≤ n)
   obtain ⟨p, hp, hpdvd, hp2⟩ := squarefree_has_eisenstein_prime m hsq hm
   exact adjoin_nthRoot_finrank n m p hn hp hpdvd hp2 (by omega)
 
-/-! ## Part V: The sharp boundary of the criterion -/
+/-! ## Concrete squarefree radicands from the open question -/
+
+/-- `6 = 2·3` is squarefree (built multiplicatively from primes, keeping the file
+    `native_decide`-free and hence axiom-free). -/
+theorem squarefree_six : Squarefree (6 : ℕ) := by
+  rw [show (6 : ℕ) = 2 * 3 from rfl, Nat.squarefree_mul (by norm_num)]
+  exact ⟨Nat.prime_two.prime.squarefree, Nat.prime_three.prime.squarefree⟩
+
+/-- `30 = 2·3·5` is squarefree. -/
+theorem squarefree_thirty : Squarefree (30 : ℕ) := by
+  rw [show (30 : ℕ) = 2 * 15 from rfl, Nat.squarefree_mul (by norm_num)]
+  refine ⟨Nat.prime_two.prime.squarefree, ?_⟩
+  rw [show (15 : ℕ) = 3 * 5 from rfl, Nat.squarefree_mul (by norm_num)]
+  exact ⟨Nat.prime_three.prime.squarefree,
+    (by norm_num : Nat.Prime 5).prime.squarefree⟩
 
 /-- `X^n - 30` is irreducible over ℚ for every `n ≥ 2` — the flagship non-prime example
-    from the open question. `30 = 2·3·5` is squarefree. -/
+    from the open question. -/
 theorem irreducible_X_pow_sub_thirty (n : ℕ) (hn : 2 ≤ n) :
     Irreducible (X ^ n - C (30 : ℚ) : ℚ[X]) :=
-  irreducible_X_pow_sub_C_of_squarefree n 30 hn (by decide) (by norm_num)
+  irreducible_X_pow_sub_C_of_squarefree n 30 hn squarefree_thirty (by norm_num)
 
-/-- `X^n - 6` is irreducible over ℚ for every `n ≥ 2`. `6 = 2·3` is squarefree. -/
+/-- `X^n - 6` is irreducible over ℚ for every `n ≥ 2`. -/
 theorem irreducible_X_pow_sub_six (n : ℕ) (hn : 2 ≤ n) :
     Irreducible (X ^ n - C (6 : ℚ) : ℚ[X]) :=
-  irreducible_X_pow_sub_C_of_squarefree n 6 hn (by decide) (by norm_num)
+  irreducible_X_pow_sub_C_of_squarefree n 6 hn squarefree_six (by norm_num)
 
 /-- ⁿ√30 is irrational for every `n ≥ 2` (concrete corollary of the squarefree criterion). -/
 theorem irrational_nthRoot_thirty (n : ℕ) (hn : 2 ≤ n) :
     Irrational ((30 : ℝ) ^ ((1 : ℝ) / n)) :=
-  irrational_nthRoot_of_squarefree n 30 hn (by decide) (by norm_num)
+  irrational_nthRoot_of_squarefree n 30 hn squarefree_thirty (by norm_num)
+
+/-! ## Part V: The sharp boundary of the criterion -/
 
 /-- **Squarefree is sufficient but not necessary.** `X² - 12` is irreducible even though
     `12 = 2²·3` is *not* squarefree: Eisenstein still applies at `p = 3`, which divides
     12 to the first power (`3 ∣ 12`, `9 ∤ 12`). So the criterion reaches strictly beyond
     squarefree radicands — the true requirement is a prime factor to the first power. -/
-theorem irreducible_X_sq_sub_twelve : Irreducible (X ^ 2 - C (12 : ℚ) : ℚ[X]) := by
-  have h12 : ¬ Squarefree (12 : ℕ) := by decide
-  -- Squarefree fails, yet Eisenstein at p = 3 succeeds directly.
-  exact eisenstein_X_pow_sub_of_sqfree_factor 2 12 3 (by norm_num) (by norm_num)
+theorem irreducible_X_sq_sub_twelve : Irreducible (X ^ 2 - C (12 : ℚ) : ℚ[X]) :=
+  -- Squarefreeness fails for 12, yet Eisenstein at p = 3 succeeds directly.
+  eisenstein_X_pow_sub_of_sqfree_factor 2 12 3 (by norm_num) (by norm_num)
     (by norm_num) (by norm_num) (by norm_num)
 
 /-- **Where the method stops: powerful `m`.** If every prime factor of `m` divides it at
@@ -192,17 +207,20 @@ theorem powerful_no_eisenstein_prime (m : ℕ)
 theorem X_sq_sub_four_reducible : ¬ Irreducible (X ^ 2 - C (4 : ℚ) : ℚ[X]) := by
   intro hirr
   -- Exhibit the factorization X² - 4 = (X - 2)(X + 2); neither factor is a unit.
-  have hfac : (X ^ 2 - C (4 : ℚ)) = (X - C 2) * (X + C 2) := by ring
+  have hfac : (X ^ 2 - C (4 : ℚ)) = (X - C 2) * (X + C 2) := by
+    have h4 : (C 4 : ℚ[X]) = C 2 * C 2 := by rw [← C_mul]; norm_num
+    rw [h4]; ring
   rcases hirr.isUnit_or_isUnit hfac with h | h
   · exact (Polynomial.not_isUnit_of_natDegree_pos _ (by rw [natDegree_X_sub_C]; norm_num)) h
-  · have hdeg : (X + C 2 : ℚ[X]).natDegree = 1 := by
-      rw [show (X + C 2 : ℚ[X]) = X - C (-2) by ring, natDegree_X_sub_C]
-    exact (Polynomial.not_isUnit_of_natDegree_pos _ (by rw [hdeg]; norm_num)) h
+  · exact (Polynomial.not_isUnit_of_natDegree_pos _ (by rw [natDegree_X_add_C]; norm_num)) h
 
 /-- `4` is powerful (sanity check feeding `X_sq_sub_four_reducible`): its only prime
     factor 2 divides it twice. -/
 theorem four_powerful : ∀ p : ℕ, p.Prime → p ∣ 4 → p ^ 2 ∣ 4 := by
   intro p hp hpdvd
-  interval_cases p <;> simp_all <;> omega
+  -- p ∣ 4 = 2² and p prime ⟹ p ∣ 2 ⟹ p = 2, whence p² = 4 ∣ 4.
+  have hp2 : p ∣ 2 := hp.dvd_of_dvd_pow (show p ∣ 2 ^ 2 by simpa using hpdvd)
+  have : p = 2 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp hp2
+  subst this; norm_num
 
 end CubeRoot3IrrationalOQ02OQ04

--- a/proofs/Proofs/CubeRoot3IrrationalOQ02OQ04.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ02OQ04.lean
@@ -1,0 +1,208 @@
+/-
+# Eisenstein Irreducibility for Squarefree Radicands
+
+**Open Question OQ-04** (from `cube-root-3-irrational-oq-02`, the Eisenstein proof of
+∛3's irrationality):
+
+> Does the Eisenstein approach extend to **non-prime** radicands? For example, `X^n - 6`
+> is Eisenstein-irreducible at `p = 2` or `p = 3` (both work: `2 | 6`, `4 ∤ 6`, and
+> `3 | 6`, `9 ∤ 6`). What about `X^n - 30`? Eisenstein applies at `p = 2, 3` or `5` — any
+> **squarefree** `m` gives an Eisenstein-irreducible `X^n - m`. Where does the criterion
+> fail?
+
+## What This File Adds
+
+The parent chain (`CubeRoot2IrrationalOQ03`) already proves a `sqfree_factor` criterion:
+`X^n - m` is irreducible over ℚ **provided the caller exhibits a specific prime `p` with
+`p | m` and `p² ∤ m`**. That places the burden of finding a good prime on the user.
+
+This file removes that burden and pins down the exact boundary of the method:
+
+1. **Existence of an Eisenstein prime** (`squarefree_has_eisenstein_prime`): for any
+   squarefree `m ≥ 2`, a suitable prime `p` (with `p ∣ m`, `p² ∤ m`) *always exists* — it
+   is any prime factor, since squarefreeness makes `p² ∤ m` automatic.
+
+2. **Single-hypothesis criterion** (`irreducible_X_pow_sub_C_of_squarefree`):
+   `Squarefree m → 2 ≤ m → 2 ≤ n → Irreducible (X^n - C m)` over ℚ. Keyed only on
+   `Squarefree m`; the prime is discharged internally. This is the clean statement the
+   open question asks for.
+
+3. **Corollaries for squarefree radicands**: `X^n - m` has no rational root, `m^(1/n)` is
+   irrational, and `[ℚ(m^(1/n)) : ℚ] = n` — all for *any* squarefree `m ≥ 2`, with `X^n - 30`
+   and `X^n - 6` as the concrete instances named in the question.
+
+4. **The sharp boundary** (`Part V`). Squarefreeness is **sufficient but not necessary**:
+   `X² - 12` is irreducible even though `12 = 2²·3` is not squarefree (Eisenstein still
+   applies at `p = 3`, which divides 12 to the first power). The real dividing line is
+   whether `m` has *any* prime factor to the first power. When it does not — i.e. when `m`
+   is **powerful** (every prime factor appears squared) — no Eisenstein prime exists
+   (`powerful_no_eisenstein_prime`), and irreducibility can genuinely fail:
+   `X² - 4 = (X - 2)(X + 2)` is reducible (`X_sq_sub_four_reducible`). So the criterion
+   cannot be pushed past the "has a prime factor to the first power" condition, and
+   squarefree is the natural clean sufficient hypothesis.
+
+## Status: 0 sorries, 0 axioms
+-/
+
+import Proofs.CubeRoot2IrrationalOQ03
+import Mathlib.Data.Real.Irrational
+
+open Polynomial CubeRoot2IrrationalOQ03
+
+namespace CubeRoot3IrrationalOQ02OQ04
+
+/-! ## Part I: Every squarefree `m ≥ 2` has an Eisenstein prime -/
+
+/-- For a squarefree `m ≥ 2`, there is a prime `p` with `p ∣ m` and `p² ∤ m`.
+
+    Any prime factor works: `m ≥ 2` guarantees one exists, and squarefreeness
+    (`p * p ∣ m → IsUnit p`) forbids `p² ∣ m` since a prime is not a unit. -/
+theorem squarefree_has_eisenstein_prime (m : ℕ) (hsq : Squarefree m) (hm : 2 ≤ m) :
+    ∃ p : ℕ, p.Prime ∧ p ∣ m ∧ ¬ p ^ 2 ∣ m := by
+  obtain ⟨p, hp, hpdvd⟩ := Nat.exists_prime_and_dvd (by omega : m ≠ 1)
+  refine ⟨p, hp, hpdvd, ?_⟩
+  intro hp2
+  -- p² ∣ m means p * p ∣ m, so squarefreeness forces IsUnit p — impossible for a prime.
+  rw [pow_two] at hp2
+  exact hp.not_unit (hsq p hp2)
+
+/-! ## Part II: The single-hypothesis squarefree criterion -/
+
+/-- **Squarefree Eisenstein criterion.** For any squarefree `m ≥ 2` and any `n ≥ 2`,
+    `X^n - m` is irreducible over ℚ.
+
+    Unlike `eisenstein_X_pow_sub_of_sqfree_factor`, the caller need not name a prime:
+    squarefreeness supplies one via `squarefree_has_eisenstein_prime`. This is the direct
+    answer to "does Eisenstein extend to non-prime radicands?" — yes, to every squarefree
+    radicand. -/
+theorem irreducible_X_pow_sub_C_of_squarefree (n m : ℕ) (hn : 2 ≤ n)
+    (hsq : Squarefree m) (hm : 2 ≤ m) :
+    Irreducible (X ^ n - C (m : ℚ) : ℚ[X]) := by
+  obtain ⟨p, hp, hpdvd, hp2⟩ := squarefree_has_eisenstein_prime m hsq hm
+  exact eisenstein_X_pow_sub_of_sqfree_factor n m p hn hp hpdvd hp2 (by omega)
+
+/-! ## Part III: No rational roots, for any squarefree radicand -/
+
+/-- An irreducible polynomial of natDegree ≥ 2 has no root in its base field.
+
+    (Generic version of the argument in `CubeRoot3IrrationalOQ02`: a root gives a linear
+    factor `X - C q`, which can be neither a unit nor a cofactor-unit without collapsing
+    the degree to 1.) -/
+theorem no_root_of_irreducible_natDegree_ge_two {q : ℚ} {f : ℚ[X]}
+    (hirr : Irreducible f) (hdeg : 2 ≤ f.natDegree) : f.eval q ≠ 0 := by
+  intro hroot
+  obtain ⟨R, hR⟩ := dvd_iff_isRoot.mpr hroot
+  cases hirr.isUnit_or_isUnit hR with
+  | inl h =>
+    have := Polynomial.natDegree_eq_zero_of_isUnit h
+    rw [natDegree_X_sub_C] at this
+    omega
+  | inr h =>
+    have hRdeg : R.natDegree = 0 := Polynomial.natDegree_eq_zero_of_isUnit h
+    have hf_ne : f ≠ 0 := hirr.ne_zero
+    have hq_ne : (X - C q : ℚ[X]) ≠ 0 := X_sub_C_ne_zero q
+    have hR_ne : R ≠ 0 := by rintro rfl; rw [mul_zero] at hR; exact hf_ne hR
+    have : f.natDegree = 1 := by
+      rw [hR, natDegree_mul hq_ne hR_ne, natDegree_X_sub_C, hRdeg]
+    omega
+
+/-- For any squarefree `m ≥ 2` and `n ≥ 2`, `X^n - m` has no rational root. -/
+theorem X_pow_sub_squarefree_no_rat_root (n m : ℕ) (hn : 2 ≤ n)
+    (hsq : Squarefree m) (hm : 2 ≤ m) (q : ℚ) :
+    (X ^ n - C (m : ℚ)).eval q ≠ 0 := by
+  apply no_root_of_irreducible_natDegree_ge_two
+    (irreducible_X_pow_sub_C_of_squarefree n m hn hsq hm)
+  rw [natDegree_X_pow_sub_nat_eq (by omega) (by omega)]
+  exact hn
+
+/-! ## Part IV: Irrationality and algebraic degree for squarefree radicands -/
+
+/-- **Irrationality of `m^(1/n)` for squarefree `m`.** For any squarefree `m ≥ 2` and
+    `n ≥ 2`, the real `n`-th root `m^(1/n)` is irrational.
+
+    This is the OQ-02 argument (Eisenstein → no rational root → irrational) generalized
+    from the prime radicand `3` to every squarefree radicand. -/
+theorem irrational_nthRoot_of_squarefree (n m : ℕ) (hn : 2 ≤ n)
+    (hsq : Squarefree m) (hm : 2 ≤ m) :
+    Irrational ((m : ℝ) ^ ((1 : ℝ) / n)) := by
+  rintro ⟨q, hq⟩
+  -- q^n = m over ℝ, hence over ℚ, hence q is a rational root of X^n - m.
+  have hn0 : (n : ℝ) ≠ 0 := by positivity
+  have hqn_real : (q : ℝ) ^ n = m := by
+    rw [hq, ← Real.rpow_natCast ((m : ℝ) ^ ((1 : ℝ) / n)) n,
+        ← Real.rpow_mul (by positivity : (0 : ℝ) ≤ m)]
+    rw [one_div, inv_mul_cancel₀ hn0, Real.rpow_one]
+  have hqn : q ^ n = (m : ℚ) := by exact_mod_cast hqn_real
+  have heval : (X ^ n - C (m : ℚ)).eval q = 0 := by
+    simp [eval_sub, eval_pow, eval_X, eval_C, hqn]
+  exact X_pow_sub_squarefree_no_rat_root n m hn hsq hm q heval
+
+/-- **Algebraic degree for squarefree radicands.** `[ℚ(m^(1/n)) : ℚ] = n` for any
+    squarefree `m ≥ 2` and `n ≥ 2`. Repackages `adjoin_nthRoot_finrank` with the prime
+    discharged by squarefreeness. -/
+theorem adjoin_nthRoot_finrank_of_squarefree (n m : ℕ) (hn : 2 ≤ n)
+    (hsq : Squarefree m) (hm : 2 ≤ m) :
+    Module.finrank ℚ ℚ⟮(m : ℝ) ^ ((1 : ℝ) / ↑n)⟯ = n := by
+  obtain ⟨p, hp, hpdvd, hp2⟩ := squarefree_has_eisenstein_prime m hsq hm
+  exact adjoin_nthRoot_finrank n m p hn hp hpdvd hp2 (by omega)
+
+/-! ## Part V: The sharp boundary of the criterion -/
+
+/-- `X^n - 30` is irreducible over ℚ for every `n ≥ 2` — the flagship non-prime example
+    from the open question. `30 = 2·3·5` is squarefree. -/
+theorem irreducible_X_pow_sub_thirty (n : ℕ) (hn : 2 ≤ n) :
+    Irreducible (X ^ n - C (30 : ℚ) : ℚ[X]) :=
+  irreducible_X_pow_sub_C_of_squarefree n 30 hn (by decide) (by norm_num)
+
+/-- `X^n - 6` is irreducible over ℚ for every `n ≥ 2`. `6 = 2·3` is squarefree. -/
+theorem irreducible_X_pow_sub_six (n : ℕ) (hn : 2 ≤ n) :
+    Irreducible (X ^ n - C (6 : ℚ) : ℚ[X]) :=
+  irreducible_X_pow_sub_C_of_squarefree n 6 hn (by decide) (by norm_num)
+
+/-- ⁿ√30 is irrational for every `n ≥ 2` (concrete corollary of the squarefree criterion). -/
+theorem irrational_nthRoot_thirty (n : ℕ) (hn : 2 ≤ n) :
+    Irrational ((30 : ℝ) ^ ((1 : ℝ) / n)) :=
+  irrational_nthRoot_of_squarefree n 30 hn (by decide) (by norm_num)
+
+/-- **Squarefree is sufficient but not necessary.** `X² - 12` is irreducible even though
+    `12 = 2²·3` is *not* squarefree: Eisenstein still applies at `p = 3`, which divides
+    12 to the first power (`3 ∣ 12`, `9 ∤ 12`). So the criterion reaches strictly beyond
+    squarefree radicands — the true requirement is a prime factor to the first power. -/
+theorem irreducible_X_sq_sub_twelve : Irreducible (X ^ 2 - C (12 : ℚ) : ℚ[X]) := by
+  have h12 : ¬ Squarefree (12 : ℕ) := by decide
+  -- Squarefree fails, yet Eisenstein at p = 3 succeeds directly.
+  exact eisenstein_X_pow_sub_of_sqfree_factor 2 12 3 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- **Where the method stops: powerful `m`.** If every prime factor of `m` divides it at
+    least twice (`m` is *powerful*), then no prime satisfies the Eisenstein hypothesis
+    `p ∣ m ∧ p² ∤ m`. Squarefree `m ≥ 2` is exactly the opposite extreme, which is why it
+    always supplies an Eisenstein prime. -/
+theorem powerful_no_eisenstein_prime (m : ℕ)
+    (hpow : ∀ p : ℕ, p.Prime → p ∣ m → p ^ 2 ∣ m) :
+    ¬ ∃ p : ℕ, p.Prime ∧ p ∣ m ∧ ¬ p ^ 2 ∣ m := by
+  rintro ⟨p, hp, hpdvd, hp2⟩
+  exact hp2 (hpow p hp hpdvd)
+
+/-- **Irreducibility genuinely fails past the boundary.** `X² - 4 = (X - 2)(X + 2)` is
+    reducible over ℚ. Here `m = 4 = 2²` is powerful: its only prime factor, 2, divides it
+    twice, so `powerful_no_eisenstein_prime` applies and there is no Eisenstein prime — and
+    indeed the polynomial is reducible. This witnesses that the "prime factor to the first
+    power" hypothesis (of which squarefree is the clean special case) cannot be dropped. -/
+theorem X_sq_sub_four_reducible : ¬ Irreducible (X ^ 2 - C (4 : ℚ) : ℚ[X]) := by
+  intro hirr
+  -- Exhibit the factorization X² - 4 = (X - 2)(X + 2); neither factor is a unit.
+  have hfac : (X ^ 2 - C (4 : ℚ)) = (X - C 2) * (X + C 2) := by ring
+  rcases hirr.isUnit_or_isUnit hfac with h | h
+  · exact (Polynomial.not_isUnit_of_natDegree_pos _ (by rw [natDegree_X_sub_C]; norm_num)) h
+  · have hdeg : (X + C 2 : ℚ[X]).natDegree = 1 := by
+      rw [show (X + C 2 : ℚ[X]) = X - C (-2) by ring, natDegree_X_sub_C]
+    exact (Polynomial.not_isUnit_of_natDegree_pos _ (by rw [hdeg]; norm_num)) h
+
+/-- `4` is powerful (sanity check feeding `X_sq_sub_four_reducible`): its only prime
+    factor 2 divides it twice. -/
+theorem four_powerful : ∀ p : ℕ, p.Prime → p ∣ 4 → p ^ 2 ∣ 4 := by
+  intro p hp hpdvd
+  interval_cases p <;> simp_all <;> omega
+
+end CubeRoot3IrrationalOQ02OQ04

--- a/proofs/Proofs/CubeRoot3IrrationalOQ02OQ04.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ02OQ04.lean
@@ -45,9 +45,9 @@ This file removes that burden and pins down the exact boundary of the method:
 -/
 
 import Proofs.CubeRoot2IrrationalOQ03
-import Mathlib.Data.Real.Irrational
+import Mathlib.NumberTheory.Real.Irrational
 
-open Polynomial CubeRoot2IrrationalOQ03
+open Polynomial IntermediateField CubeRoot2IrrationalOQ03
 
 namespace CubeRoot3IrrationalOQ02OQ04
 
@@ -62,9 +62,11 @@ theorem squarefree_has_eisenstein_prime (m : ℕ) (hsq : Squarefree m) (hm : 2 �
   obtain ⟨p, hp, hpdvd⟩ := Nat.exists_prime_and_dvd (by omega : m ≠ 1)
   refine ⟨p, hp, hpdvd, ?_⟩
   intro hp2
-  -- p² ∣ m means p * p ∣ m, so squarefreeness forces IsUnit p — impossible for a prime.
+  -- p² ∣ m means p * p ∣ m, so squarefreeness forces IsUnit p — i.e. p = 1, impossible.
   rw [pow_two] at hp2
-  exact hp.not_unit (hsq p hp2)
+  have hu : p = 1 := Nat.isUnit_iff.mp (hsq p hp2)
+  have := hp.two_le
+  omega
 
 /-! ## Part II: The single-hypothesis squarefree criterion -/
 
@@ -134,7 +136,7 @@ theorem irrational_nthRoot_of_squarefree (n m : ℕ) (hn : 2 ≤ n)
     rw [one_div, inv_mul_cancel₀ hn0, Real.rpow_one]
   have hqn : q ^ n = (m : ℚ) := by exact_mod_cast hqn_real
   have heval : (X ^ n - C (m : ℚ)).eval q = 0 := by
-    simp [eval_sub, eval_pow, eval_X, eval_C, hqn]
+    simp [eval_sub, eval_pow, eval_X, hqn]
   exact X_pow_sub_squarefree_no_rat_root n m hn hsq hm q heval
 
 /-- **Algebraic degree for squarefree radicands.** `[ℚ(m^(1/n)) : ℚ] = n` for any

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-04/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-cbrt3oq0204-header",
+    "proofId": "cube-root-3-irrational-oq-02-oq-04",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "concept",
+    "title": "From Named-Prime Eisenstein to a Squarefree Criterion",
+    "content": "Answers OQ-04 of the ∛3 Eisenstein proof: does the criterion reach non-prime radicands? The parent-chain template `eisenstein_X_pow_sub_of_sqfree_factor` needs the caller to exhibit a prime p with p∣m, p²∤m. This file removes that burden (any squarefree m ≥ 2 supplies such a prime) and then pins down exactly where the method fails. Four movements: prime extraction → single-hypothesis criterion → irrationality/degree corollaries → sharp boundary.",
+    "mathContext": "Eisenstein applies to $X^n - m$ at a prime $p$ iff $p \\parallel m$ (p divides m to the first power). Such a prime exists iff $m$ is not powerful; squarefree $m$ is the extreme where every prime factor qualifies.",
+    "significance": "supporting",
+    "relatedConcepts": ["Eisenstein criterion", "squarefree numbers", "powerful numbers", "polynomial irreducibility"],
+    "prerequisites": ["CubeRoot2IrrationalOQ03.lean", "eisenstein_X_pow_sub_of_sqfree_factor"]
+  },
+  {
+    "id": "ann-cbrt3oq0204-prime-extraction",
+    "proofId": "cube-root-3-irrational-oq-02-oq-04",
+    "range": { "startLine": 54, "endLine": 69 },
+    "type": "key-step",
+    "title": "Part I — Squarefree m ≥ 2 Always Has an Eisenstein Prime",
+    "content": "`squarefree_has_eisenstein_prime`: pick any prime factor p of m (exists by `Nat.exists_prime_and_dvd` since m ≠ 1). Squarefreeness forbids p²∣m: unfolding `Squarefree` gives ∀ x, x·x ∣ m → IsUnit x, so p²∣m ⇒ p·p∣m ⇒ IsUnit p ⇒ p = 1 (Nat.isUnit_iff), contradicting the prime bound 2 ≤ p (omega). This is the lemma that lets every later result depend only on `Squarefree m`.",
+    "mathContext": "For squarefree $m$, $v_p(m) \\in \\{0,1\\}$ for every prime $p$; any prime factor has $v_p(m) = 1$, i.e. $p \\mid m$ and $p^2 \\nmid m$ — exactly the Eisenstein condition.",
+    "significance": "central",
+    "relatedConcepts": ["Squarefree", "Nat.exists_prime_and_dvd", "Nat.isUnit_iff", "prime factorization"],
+    "prerequisites": ["Squarefree definition", "Nat.Prime.two_le"]
+  },
+  {
+    "id": "ann-cbrt3oq0204-criterion",
+    "proofId": "cube-root-3-irrational-oq-02-oq-04",
+    "range": { "startLine": 71, "endLine": 84 },
+    "type": "key-step",
+    "title": "Part II — The Single-Hypothesis Squarefree Criterion",
+    "content": "`irreducible_X_pow_sub_C_of_squarefree`: Squarefree m → 2 ≤ m → 2 ≤ n → Irreducible (X^n − C m) over ℚ. The proof extracts a prime via Part I and hands it to the parent template. This is the direct answer to the open question: Eisenstein extends to every squarefree radicand, with the prime discharged internally.",
+    "mathContext": "The clean statement mathematicians expect: irreducibility of $X^n - m$ keyed on a single arithmetic property of $m$, not on a chosen prime.",
+    "significance": "central",
+    "relatedConcepts": ["Eisenstein criterion", "irreducibility over ℚ", "Gauss's Lemma"],
+    "prerequisites": ["squarefree_has_eisenstein_prime", "eisenstein_X_pow_sub_of_sqfree_factor"]
+  },
+  {
+    "id": "ann-cbrt3oq0204-no-root",
+    "proofId": "cube-root-3-irrational-oq-02-oq-04",
+    "range": { "startLine": 86, "endLine": 118 },
+    "type": "proof-technique",
+    "title": "Part III — Generic 'Irreducible of Degree ≥ 2 Has No Root'",
+    "content": "`no_root_of_irreducible_natDegree_ge_two` abstracts the two-case argument from the parent OQ-02 file: a root q gives (X − C q) ∣ f; by `Irreducible.isUnit_or_isUnit`, either X − C q is a unit (natDegree 1 ≠ 0) or the cofactor is a unit (natDegree f collapses to 1 < 2). `X_pow_sub_squarefree_no_rat_root` specializes it to X^n − m using the degree lemma from the parent chain.",
+    "mathContext": "The universal fact: an irreducible polynomial of degree $\\geq 2$ over a field $K$ has no root in $K$, since a root would force a degree-1 factorization.",
+    "significance": "supporting",
+    "relatedConcepts": ["Irreducible.isUnit_or_isUnit", "dvd_iff_isRoot", "natDegree_X_sub_C"],
+    "prerequisites": ["polynomial factor degree lemmas"]
+  },
+  {
+    "id": "ann-cbrt3oq0204-irrational-degree",
+    "proofId": "cube-root-3-irrational-oq-02-oq-04",
+    "range": { "startLine": 120, "endLine": 150 },
+    "type": "key-step",
+    "title": "Part IV — Irrationality and Algebraic Degree of ⁿ√m",
+    "content": "`irrational_nthRoot_of_squarefree`: for squarefree m ≥ 2 and n ≥ 2, ⁿ√m is irrational — the ∛3 argument (Eisenstein → no rational root → irrational) generalized from the prime radicand 3 to every squarefree radicand. `adjoin_nthRoot_finrank_of_squarefree` repackages the parent's finrank computation to give [ℚ(m^(1/n)):ℚ] = n.",
+    "mathContext": "$((m)^{1/n})^n = m^{(1/n)\\cdot n} = m$ (Real.rpow_mul); a rational $q = m^{1/n}$ would satisfy $q^n = m$ in ℚ, a rational root of the irreducible $X^n - m$ — impossible.",
+    "significance": "central",
+    "relatedConcepts": ["Irrational", "Real.rpow_mul", "IntermediateField.adjoin finrank", "minimal polynomial"],
+    "prerequisites": ["X_pow_sub_squarefree_no_rat_root", "adjoin_nthRoot_finrank"]
+  },
+  {
+    "id": "ann-cbrt3oq0204-concrete",
+    "proofId": "cube-root-3-irrational-oq-02-oq-04",
+    "range": { "startLine": 151, "endLine": 181 },
+    "type": "key-step",
+    "title": "Concrete Radicands 6 and 30 (native_decide-free)",
+    "content": "`squarefree_six` (6 = 2·3) and `squarefree_thirty` (30 = 2·(3·5)) are proved multiplicatively via `Nat.squarefree_mul` on coprime factors and `Prime.squarefree`, deliberately avoiding `native_decide` so the file stays axiom-free (native_decide would inject Lean.ofReduceBool). They feed `irreducible_X_pow_sub_thirty`, `irreducible_X_pow_sub_six`, and `irrational_nthRoot_thirty` — the flagship X^n−30 and X^n−6 examples named in the open question.",
+    "mathContext": "A coprime product of squarefree numbers is squarefree (Nat.squarefree_mul); each prime is squarefree, so $2\\cdot 3$ and $2 \\cdot 3 \\cdot 5$ are squarefree.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.squarefree_mul", "Prime.squarefree", "Nat.Coprime", "axiom hygiene"],
+    "prerequisites": ["coprimality of distinct primes"]
+  },
+  {
+    "id": "ann-cbrt3oq0204-boundary-twelve",
+    "proofId": "cube-root-3-irrational-oq-02-oq-04",
+    "range": { "startLine": 183, "endLine": 196 },
+    "type": "insight",
+    "title": "Part V.a — Squarefree Is Sufficient But Not Necessary (X²−12)",
+    "content": "`irreducible_X_sq_sub_twelve`: X²−12 is irreducible even though 12 = 2²·3 is NOT squarefree, because Eisenstein still applies at p=3 (3∣12, 9∤12). This corrects the parent entry's open-question text, which lists m=12 among the failures. The real requirement is that m have *some* prime factor to the first power, not that m be squarefree.",
+    "mathContext": "$12 = 2^2 \\cdot 3$: the prime 3 divides 12 exactly once, so $X^n - 12$ is Eisenstein-irreducible at $p = 3$. Squarefreeness is stronger than needed.",
+    "significance": "central",
+    "relatedConcepts": ["Eisenstein at a single prime", "sufficient vs necessary conditions"],
+    "prerequisites": ["eisenstein_X_pow_sub_of_sqfree_factor"]
+  },
+  {
+    "id": "ann-cbrt3oq0204-boundary-powerful",
+    "proofId": "cube-root-3-irrational-oq-02-oq-04",
+    "range": { "startLine": 197, "endLine": 228 },
+    "type": "insight",
+    "title": "Part V.b — Where the Method Stops: Powerful m and X²−4",
+    "content": "`powerful_no_eisenstein_prime`: if every prime factor of m divides it at least twice (m powerful), no prime satisfies the Eisenstein hypothesis. `X_sq_sub_four_reducible`: X²−4 = (X−2)(X+2) is genuinely reducible (both factors have positive natDegree, so neither is a unit) — the honest minimal failure witness, since m=4=2² is the smallest powerful number > 1 (`four_powerful`). This shows the 'prime factor to the first power' hypothesis is a real obstruction, beyond which one needs Vahlen–Capelli.",
+    "mathContext": "Powerful numbers (Erdős–Szekeres 1934) are the failure locus: $4, 8, 9, 16, 25, 27, \\dots$. For $m = 4$, no Eisenstein prime exists and $X^2 - 4$ factors — reducibility is real, not a proof artifact.",
+    "significance": "central",
+    "relatedConcepts": ["powerful numbers", "Vahlen–Capelli theorem", "reducible polynomials", "not_isUnit_of_natDegree_pos"],
+    "prerequisites": ["Nat.prime_dvd_prime_iff_eq", "polynomial factorization"]
+  }
+]

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-04/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-04/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "cube-root-3-irrational-oq-02-oq-04",
+  "title": "Eisenstein for Squarefree Radicands: X^n − m and its Sharp Boundary",
+  "slug": "cube-root-3-irrational-oq-02-oq-04",
+  "description": "Answers OQ-04 of the ∛3 Eisenstein proof: does the criterion extend to non-prime radicands? Yes — every squarefree m ≥ 2 gives an irreducible X^n − m over ℚ, via a single-hypothesis criterion that derives the Eisenstein prime internally (no need to name it). Corollaries: X^n − 30 and X^n − 6 irreducible, ⁿ√30 irrational, [ℚ(m^(1/n)):ℚ] = n for squarefree m. The sharp boundary: squarefree is sufficient but not necessary (X² − 12 is irreducible though 12 = 2²·3 is not squarefree, since Eisenstein still applies at p=3), while irreducibility genuinely fails for powerful m — X² − 4 = (X−2)(X+2). The true dividing line is 'm has a prime factor to the first power'.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CubeRoot3IrrationalOQ02OQ04.lean",
+    "tags": [
+      "irrationality",
+      "number-theory",
+      "polynomial-theory",
+      "eisenstein",
+      "irreducibility",
+      "squarefree",
+      "powerful-numbers",
+      "sharp-boundary"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "axiomCount": 0,
+    "assumptions": "None — fully verified (depends only on propext, Classical.choice, Quot.sound). Builds on CubeRoot2IrrationalOQ03 for the sqfree-factor Eisenstein template.",
+    "lineCount": 228,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "originalContributions": [
+      "squarefree_has_eisenstein_prime: every squarefree m ≥ 2 possesses a prime p with p∣m and p²∤m — squarefreeness makes the Eisenstein hypothesis automatically discharge-able",
+      "irreducible_X_pow_sub_C_of_squarefree: the single-hypothesis squarefree Eisenstein criterion — Squarefree m → 2 ≤ m → 2 ≤ n → Irreducible (X^n − C m) over ℚ, with the prime discharged internally",
+      "no_root_of_irreducible_natDegree_ge_two: generic 'irreducible of degree ≥ 2 has no root in the base field', abstracting the ad-hoc argument from the parent OQ-02 file",
+      "irrational_nthRoot_of_squarefree: ⁿ√m is irrational for every squarefree m ≥ 2 and n ≥ 2, generalizing ∛3's irrationality from prime to squarefree radicands",
+      "adjoin_nthRoot_finrank_of_squarefree: [ℚ(m^(1/n)):ℚ] = n for squarefree m",
+      "irreducible_X_sq_sub_twelve: X² − 12 is irreducible although 12 = 2²·3 is not squarefree — squarefree is sufficient but not necessary; Eisenstein still applies at p=3",
+      "powerful_no_eisenstein_prime + X_sq_sub_four_reducible: the criterion's failure boundary — powerful m admit no Eisenstein prime, and X² − 4 = (X−2)(X+2) is genuinely reducible, so the 'prime factor to the first power' hypothesis cannot be dropped"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Eisenstein's criterion (Schönemann 1846, Eisenstein 1850) is stated for a single prime p: if p divides every non-leading coefficient, p ∤ leading coefficient, and p² ∤ constant term, then the integer polynomial is irreducible, hence irreducible over ℚ by Gauss's Lemma (Disquisitiones §42). The parent proof used this at p=3 to prove X³−3 irreducible and ∛3 irrational. The natural generalization asks: for which radicands m does X^n − m fall to Eisenstein at *some* prime?\n\nThe answer is a clean number-theoretic dichotomy. Eisenstein applies to X^n − m at a prime p exactly when p ∥ m (p divides m to the first power: p∣m but p²∤m). Such a prime exists iff m is *not powerful* — where a **powerful number** (Erdős–Szekeres 1934) is one in which every prime factor appears to exponent ≥ 2 (1, 4, 8, 9, 16, 25, 27, 36, …). **Squarefree numbers are the opposite extreme**: every prime factor appears exactly once, so *every* prime factor is an Eisenstein prime. This is why 'squarefree radicand' is the clean sufficient hypothesis the open question anticipated. But it is not necessary: 12 = 2²·3 is neither squarefree nor powerful, and Eisenstein still applies at p=3. Where the method truly stops is the powerful numbers, and there irreducibility itself can fail — X² − 4 = (X−2)(X+2). Past that boundary one needs the Vahlen–Capelli theorem (Lang, Algebra VI.9).",
+    "problemStatement": "**Open Question OQ-04 from cube-root-3-irrational-oq-02** (the ∛3 Eisenstein proof):\n\n> Does the Eisenstein approach extend to non-prime radicands? X^n − 6 is Eisenstein-irreducible at p=2 or p=3; X^n − 30 at p=2, 3, or 5 — any squarefree m gives an Eisenstein-irreducible X^n − m. Where does the criterion fail?\n\n**This file answers**: (1) Yes for every squarefree m ≥ 2, via a single-hypothesis criterion that no longer requires the caller to exhibit a prime. (2) The criterion in fact reaches strictly beyond squarefree radicands (X²−12), and its precise failure locus is the powerful numbers, where irreducibility genuinely breaks (X²−4).",
+    "proofStrategy": "**Four movements:**\n\n1. **Prime extraction** (`squarefree_has_eisenstein_prime`): For squarefree m ≥ 2, take any prime factor p (exists by `Nat.exists_prime_and_dvd`). Squarefreeness (∀x, x·x∣m → IsUnit x) forbids p²∣m, since a prime is not a unit. So p∣m and p²∤m.\n\n2. **Single-hypothesis criterion** (`irreducible_X_pow_sub_C_of_squarefree`): feed that prime to the parent-chain template `eisenstein_X_pow_sub_of_sqfree_factor`. The hypothesis is now just `Squarefree m`.\n\n3. **Corollaries** (`no_root_of_irreducible_natDegree_ge_two`, `X_pow_sub_squarefree_no_rat_root`, `irrational_nthRoot_of_squarefree`, `adjoin_nthRoot_finrank_of_squarefree`): irreducible degree-n (n≥2) polynomials have no rational root; hence ⁿ√m is irrational and generates a degree-n extension. `Squarefree 6` and `Squarefree 30` are proved multiplicatively from primes (keeping the file native_decide-free, hence 0-axiom).\n\n4. **Sharp boundary** (`irreducible_X_sq_sub_twelve`, `powerful_no_eisenstein_prime`, `X_sq_sub_four_reducible`, `four_powerful`): X²−12 is irreducible though 12 is not squarefree; powerful m admit no Eisenstein prime; X²−4 factors as (X−2)(X+2), witnessing genuine reducibility past the boundary.",
+    "keyInsights": [
+      "**Squarefree is exactly the hypothesis that discharges the Eisenstein prime for you.** The parent-chain lemma `eisenstein_X_pow_sub_of_sqfree_factor` needs the caller to name a prime p with p∥m; `squarefree_has_eisenstein_prime` shows Squarefree m ≥ 2 always supplies one, turning a three-argument obligation into a single clean hypothesis.",
+      "**The failure locus is powerful numbers, not merely non-squarefree ones.** A subtlety the parent's open-question text elides: it lists m=12 among the failures, but X²−12 IS irreducible (Eisenstein at p=3, since 12 = 2²·3 has 3 to the first power). The correct dividing line is whether m has ANY prime factor to the first power — i.e. m is not powerful. This file proves X²−12 irreducible to make the distinction precise.",
+      "**Squarefree ⟹ sufficient, but the converse fails in both directions.** Squarefree is sufficient (Part II) but not necessary (X²−12, non-squarefree yet irreducible). And even 'not powerful' is only necessary for the *Eisenstein method*, not for irreducibility itself: some powerful radicands still yield irreducible X^n−m (e.g. X²−8 is irreducible although 8=2³ is powerful) — those simply lie outside Eisenstein's reach and need Vahlen–Capelli.",
+      "**X² − 4 = (X−2)(X+2) is the minimal honest failure witness.** m=4 is the smallest powerful number > 1; it has no Eisenstein prime (`powerful_no_eisenstein_prime` + `four_powerful`) and the polynomial is reducible. This shows the 'prime-factor-to-the-first-power' hypothesis is not a proof artifact but a real obstruction.",
+      "**The 'irreducible ⟹ no root' argument is worth abstracting once.** `no_root_of_irreducible_natDegree_ge_two` captures the two-case `isUnit_or_isUnit` split (linear factor is a unit → degree 0 ≠ 1; cofactor is a unit → total degree collapses to 1 < 2) generically, so the irrationality corollary for every squarefree radicand is a two-line application rather than a per-radicand re-derivation."
+    ],
+    "prerequisites": [
+      "CubeRoot2IrrationalOQ03.lean: eisenstein_X_pow_sub_of_sqfree_factor (sqfree-factor Eisenstein template) and adjoin_nthRoot_finrank",
+      "Nat number theory: Nat.exists_prime_and_dvd, Squarefree, Nat.squarefree_mul, Nat.isUnit_iff, Nat.prime_dvd_prime_iff_eq",
+      "Polynomial ring theory: Irreducible.isUnit_or_isUnit, dvd_iff_isRoot, natDegree_X_sub_C / natDegree_X_add_C, not_isUnit_of_natDegree_pos",
+      "Real.rpow_mul for ((m:ℝ)^(1/n))^n = m"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-imports",
+      "title": "Imports and Overview",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Header explaining the four movements (prime extraction → single-hypothesis criterion → corollaries → sharp boundary). Imports CubeRoot2IrrationalOQ03 and Mathlib.NumberTheory.Real.Irrational; opens Polynomial, IntermediateField, and the parent namespace.",
+      "mathContext": "The reused template: `eisenstein_X_pow_sub_of_sqfree_factor n m p hn hp hdvd hndvd hm : Irreducible (X^n − C(m:ℚ))` when p∣m, p²∤m. This file removes the burden of naming p."
+    },
+    {
+      "id": "sec-prime-extraction",
+      "title": "Part I: Every Squarefree m ≥ 2 Has an Eisenstein Prime",
+      "startLine": 54,
+      "endLine": 69,
+      "summary": "squarefree_has_eisenstein_prime: ∃ p prime, p∣m ∧ ¬p²∣m for squarefree m ≥ 2. Any prime factor works; squarefreeness rules out p²∣m since a prime is not a unit (Nat.isUnit_iff + hp.two_le + omega).",
+      "mathContext": "Squarefree m unfolds to ∀ x, x·x ∣ m → IsUnit x. If p² ∣ m then p·p ∣ m, so IsUnit p, i.e. p = 1 — contradicting the prime bound 2 ≤ p."
+    },
+    {
+      "id": "sec-criterion",
+      "title": "Part II: The Single-Hypothesis Squarefree Criterion",
+      "startLine": 71,
+      "endLine": 84,
+      "summary": "irreducible_X_pow_sub_C_of_squarefree: Squarefree m → 2 ≤ m → 2 ≤ n → Irreducible (X^n − C m) over ℚ. Extracts the prime via Part I, then applies the parent template.",
+      "mathContext": "This is the direct answer to 'does Eisenstein extend to non-prime radicands': yes, to every squarefree radicand, with the prime discharged internally."
+    },
+    {
+      "id": "sec-no-root",
+      "title": "Part III: No Rational Roots for Squarefree Radicands",
+      "startLine": 86,
+      "endLine": 118,
+      "summary": "no_root_of_irreducible_natDegree_ge_two: a generic 'irreducible of natDegree ≥ 2 has no root' via the isUnit_or_isUnit two-case split. X_pow_sub_squarefree_no_rat_root specializes it to X^n − m for squarefree m.",
+      "mathContext": "A root q gives (X − C q) ∣ f. Either X − C q is a unit (natDegree 1 ≠ 0) or the cofactor is a unit (natDegree f = 1 < 2). Both contradict deg ≥ 2."
+    },
+    {
+      "id": "sec-corollaries",
+      "title": "Part IV: Irrationality and Algebraic Degree",
+      "startLine": 120,
+      "endLine": 150,
+      "summary": "irrational_nthRoot_of_squarefree: ⁿ√m irrational for squarefree m ≥ 2, n ≥ 2 (rpow arithmetic → q^n = m over ℚ → contradiction with no-rational-root). adjoin_nthRoot_finrank_of_squarefree: [ℚ(m^(1/n)):ℚ] = n by repackaging the parent's finrank result.",
+      "mathContext": "((m)^{1/n})^n = m^{(1/n)·n} = m via Real.rpow_mul; casting q^n = m to ℚ produces a rational root, excluded by Part III."
+    },
+    {
+      "id": "sec-concrete",
+      "title": "Concrete Squarefree Radicands: 6 and 30",
+      "startLine": 151,
+      "endLine": 181,
+      "summary": "squarefree_six and squarefree_thirty proved multiplicatively via Nat.squarefree_mul (keeping the file native_decide-free). Corollaries: X^n − 30 and X^n − 6 irreducible for all n ≥ 2, and ⁿ√30 irrational — the flagship examples named in the open question.",
+      "mathContext": "6 = 2·3 and 30 = 2·(3·5): coprime products of primes are squarefree by Nat.squarefree_mul, and each prime is squarefree by Prime.squarefree."
+    },
+    {
+      "id": "sec-boundary",
+      "title": "Part V: The Sharp Boundary of the Criterion",
+      "startLine": 183,
+      "endLine": 228,
+      "summary": "irreducible_X_sq_sub_twelve: X²−12 irreducible though 12 not squarefree (Eisenstein at p=3). powerful_no_eisenstein_prime: powerful m have no Eisenstein prime. X_sq_sub_four_reducible: X²−4 = (X−2)(X+2) reducible. four_powerful: 4 is powerful (its only prime 2 divides twice).",
+      "mathContext": "The dividing line is 'm has a prime factor to the first power'. 12 satisfies it (p=3); 4 = 2² does not, and X²−4 factors — the honest minimal failure witness for the method."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cube-root-3-irrational-oq-02",
+      "relationship": "extends",
+      "description": "Parent: proves ∛3 irrational via Eisenstein at p=3 for X³−3, and poses (OQ-04) the extension to non-prime radicands. This child answers it with the squarefree criterion and pins down the failure boundary, refining the parent's remark that 'the criterion fails for m=12' — in fact X²−12 is irreducible (Eisenstein at p=3), and the true failure locus is the powerful numbers."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-02-oq-01",
+      "relationship": "thematic",
+      "description": "Sibling: derives [ℚ(∛3):ℚ] = 3 from X³−3's irreducibility. This file generalizes that finrank result to [ℚ(m^(1/n)):ℚ] = n for every squarefree radicand m (adjoin_nthRoot_finrank_of_squarefree)."
+    },
+    {
+      "targetId": "cube-root-2-irrational-oq-03",
+      "relationship": "depends",
+      "description": "Direct dependency: supplies eisenstein_X_pow_sub_of_sqfree_factor (the sqfree-factor Eisenstein template) and adjoin_nthRoot_finrank. This file upgrades that named-prime template to the single-hypothesis Squarefree criterion."
+    },
+    {
+      "targetId": "fourth-root-2-degree4-oq-02-oq-01",
+      "relationship": "thematic",
+      "description": "Companion sharp-boundary study on the other axis: where cube-root's OQ-04 fixes the radicand class (squarefree) and lets n vary, that entry fixes small n and studies the general Kummer / Vahlen–Capelli criterion for X^n − a, including the delicate 4∣n case (X⁴+4c⁴ Sophie-Germain factorization). Together they map the two directions in which X^n − a irreducibility can fail."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "thematic",
+      "description": "Eisenstein-irreducible polynomials of arbitrary degree — exactly what the squarefree criterion mass-produces (X^n − m for any squarefree m) — are the standard raw material for constructing field extensions with prescribed Galois groups in unsolvability-by-radicals arguments."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Eisenstein proof of ∛3's irrationality extends to every squarefree radicand: Squarefree m ≥ 2 → Irreducible (X^n − C m) over ℚ, via a single-hypothesis criterion (the Eisenstein prime is any prime factor). Corollaries give ⁿ√m irrational and [ℚ(m^(1/n)):ℚ] = n for all squarefree m, with X^n−30 and X^n−6 as the named instances. The sharp boundary: squarefree is sufficient but not necessary (X²−12 irreducible via p=3), and the method fails exactly on powerful m, where irreducibility can break (X²−4). 12 theorems, 0 sorries, 0 axioms.",
+    "implications": "**A clean criterion keyed on a single arithmetic property.** By internalizing prime extraction, `irreducible_X_pow_sub_C_of_squarefree` turns 'X^n − m irreducible' into a statement about m alone — usable wherever a supply of irreducible polynomials of controlled degree is needed (Galois theory, field-extension constructions).\n\n**A corrected boundary.** The parent entry's open-question text lists m=12 among the criterion's failures; this file proves X²−12 IS irreducible (Eisenstein at p=3) and relocates the true failure locus to the powerful numbers. The precise Eisenstein-applicability condition is: m has a prime factor to the first power (m not powerful). Squarefree is the clean special case where *every* prime factor qualifies.\n\n**Where Eisenstein genuinely stops.** X²−4 = (X−2)(X+2) shows reducibility can occur once no Eisenstein prime exists. Beyond the boundary the full classification is Vahlen–Capelli (X^n − a irreducible over K iff a is not a p-th power for any prime p∣n, and a ∉ −4K⁴ when 4∣n) — cross-referenced to the fourth-root-2 sharp-boundary entry.",
+    "openQuestions": [
+      "Characterize exactly which powerful radicands still give irreducible X^n − m. Eisenstein cannot see them, but many are irreducible (X²−8, X³−4): the answer is Vahlen–Capelli applied to powerful m. A formalization of the powerful-m case would complete the dichotomy this file opens.",
+      "Can the squarefree criterion be strengthened to the exact 'm not powerful' hypothesis for the Eisenstein *method* — i.e. prove `(∃ p prime, p ∥ m) ↔ ¬ Powerful m` and thread it through, giving the tightest hypothesis under which Eisenstein alone settles irreducibility of X^n − m?"
+    ]
+  },
+  "leanFile": {
+    "lineCount": 228,
+    "path": "Proofs/CubeRoot3IrrationalOQ02OQ04.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 12
+  },
+  "references": [
+    {
+      "authors": "G. Eisenstein",
+      "title": "Über die Irreductibilität und einige andere Eigenschaften der Gleichung…",
+      "year": "1850",
+      "note": "Crelle's Journal 39, p. 160–179. The canonical statement of the irreducibility criterion applied here at any prime dividing a squarefree radicand."
+    },
+    {
+      "authors": "T. Schönemann",
+      "title": "Von denjenigen Moduln, welche Potenzen von Primzahlen sind",
+      "year": "1846",
+      "note": "Crelle's Journal 32, p. 100. The earlier (Schönemann–Eisenstein) publication of the criterion."
+    },
+    {
+      "authors": "P. Erdős, G. Szekeres",
+      "title": "Über die Anzahl der Abelschen Gruppen gegebener Ordnung und über ein verwandtes zahlentheoretisches Problem",
+      "year": "1934",
+      "note": "Introduces powerful (squarefull) numbers — those in which every prime factor appears to exponent ≥ 2 — the exact failure locus of the Eisenstein method for X^n − m."
+    },
+    {
+      "authors": "S. Lang",
+      "title": "Algebra (revised 3rd ed.)",
+      "year": "2002",
+      "note": "Chapter VI §9: the Vahlen–Capelli theorem, the full criterion for irreducibility of X^n − a beyond the reach of Eisenstein (powerful radicands, and the 4∣n case)."
+    },
+    {
+      "authors": "C. F. Gauss",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "note": "§42, Gauss's Lemma: the bridge from ℤ-irreducibility (Eisenstein) to ℚ-irreducibility, built into the Mathlib template used here."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-04** of the ∛3 Eisenstein proof (`cube-root-3-irrational-oq-02`): *does the Eisenstein approach extend to non-prime radicands?*

**Yes — to every squarefree radicand**, via a single-hypothesis criterion, and this PR also pins down exactly where the method fails.

New file `proofs/Proofs/CubeRoot3IrrationalOQ02OQ04.lean` (228 L, 12 theorems, **0 sorries, 0 axioms** — depends only on `propext, Classical.choice, Quot.sound`).

## Mathematical content

**Part I–II — The clean criterion.** The parent-chain template `eisenstein_X_pow_sub_of_sqfree_factor` requires the caller to *name* a prime `p` with `p∣m, p²∤m`. This PR internalizes that:
- `squarefree_has_eisenstein_prime`: every squarefree `m ≥ 2` supplies such a prime (any prime factor; squarefreeness rules out `p²∣m` since a prime is not a unit).
- `irreducible_X_pow_sub_C_of_squarefree`: **`Squarefree m → 2 ≤ m → 2 ≤ n → Irreducible (Xⁿ − C m)`** over ℚ, keyed on a single arithmetic hypothesis.

**Part III–IV — Corollaries for every squarefree radicand.** Generic `no_root_of_irreducible_natDegree_ge_two`; hence ⁿ√m is irrational (`irrational_nthRoot_of_squarefree`) and `[ℚ(m^(1/n)):ℚ] = n` (`adjoin_nthRoot_finrank_of_squarefree`). Flagship instances from the question: `Xⁿ−30`, `Xⁿ−6` irreducible, ⁿ√30 irrational. `Squarefree 6/30` are proved multiplicatively (not `native_decide`) to keep the file axiom-free.

**Part V — The sharp boundary.**
- `irreducible_X_sq_sub_twelve`: **X²−12 is irreducible** even though `12 = 2²·3` is *not* squarefree — Eisenstein still applies at `p=3`. This **corrects the parent entry's open-question text**, which incorrectly lists `m=12` among the failures. Squarefree is sufficient but not necessary.
- `powerful_no_eisenstein_prime` + `X_sq_sub_four_reducible` (`X²−4 = (X−2)(X+2)`) + `four_powerful`: the true failure locus is the **powerful numbers** (every prime factor squared), where irreducibility genuinely breaks. The honest requirement is "m has a prime factor to the first power"; beyond it one needs Vahlen–Capelli.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ02OQ04` — builds clean (7744 jobs).
- `#print axioms` on all key theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.
- `pnpm build` integrates the gallery entry.

## Files
- `proofs/Proofs/CubeRoot3IrrationalOQ02OQ04.lean` — the proof
- `src/data/proofs/cube-root-3-irrational-oq-02-oq-04/{meta,annotations}.json` — gallery entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)