### PR TITLE
research(burnside-counting-oq-05-oq-02): dihedral bracelet count for odd cycles [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ05OQ02.lean
+++ b/proofs/Proofs/BurnsideCountingOQ05OQ02.lean
@@ -1,0 +1,166 @@
+import Mathlib
+import Proofs.BurnsideCountingOQ03
+import Proofs.BurnsideCountingOQ05
+
+/-
+# Burnside Assembly: the Dihedral Bracelet Count for Odd Cycles
+
+`BurnsideCountingOQ03` counts the colorings of an `n`-cycle fixed by a **rotation**
+(`∑_{r} k^{gcd(r,n)}`, the Pólya sum, with divisor form `∑_{d∣n} φ(n/d) k^d`), and
+`BurnsideCountingOQ05` counts those fixed by a **reflection** of an odd cycle
+(`k^{(n+1)/2}` per reflection).  This file *assembles* the two pieces into the
+fixed-point total for the full **dihedral** group `D_n` (`n = 2m+1`) and reads off the
+number of inequivalent **bracelets** (dihedral necklaces) as the Burnside average
+`(rotation total + reflection total) / |D_n|`, `|D_n| = 2n`.
+
+For an odd cycle all `n` reflections are conjugate (each through one vertex) and fix
+`k^{m+1}` colorings, so the reflection total is `n · k^{m+1}`.  Hence
+
+  dihedral total  =  ∑_{r<n} k^{gcd(r,n)}  +  n · k^{m+1}
+                  =  ∑_{d∣n} φ(n/d) k^d   +  n · k^{m+1}
+
+and the bracelet count is this divided by `2n`.
+
+## Main results
+
+General (any odd `n = 2m+1`, any `k`):
+* `reflectionTotal_eq_card` — the reflection total is `n` copies of the OQ05 count.
+* `dihedralTotal_divisor_form` — the assembled total in divisor-sum closed form (via OQ03).
+
+Worked odd cases with fully closed forms in `k` (the polynomial `totals` by `ring`,
+the integral bracelet counts by an exact divisibility):
+* `dihedralTotal_three` / `bracelet_three` — `n = 3`: total `k(k+1)(k+2)`, bracelet count
+  the tetrahedral number `C(k+2,3)`.
+* `dihedralTotal_five` / `bracelet_five` — `n = 5`: total `k(k²+1)(k²+4)`, bracelet count
+  `k(k²+1)(k²+4)/10`.
+* numeric checks `bracelet_three_two = 4`, `bracelet_five_two = 8`, `bracelet_three_three = 10`.
+
+Everything is machine-checked with `ring`, `omega`, `decide`, and the two sibling
+identities — no axioms, no `native_decide`, no `sorry`.  The remaining step of
+identifying `braceletCount` with the literal orbit count of `DihedralGroup n` acting on
+colorings (Mathlib's `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`) is the
+natural next child.
+-/
+
+namespace BurnsideCountingOQ05OQ02
+
+open Finset
+
+/-- Total colorings fixed across all `n` rotations of an `n`-cycle (the Pólya sum). -/
+def rotationTotal (n k : ℕ) : ℕ := ∑ r : Fin n, k ^ Nat.gcd r.val n
+
+/-- Total colorings fixed across all `2m+1` reflections of an odd `(2m+1)`-cycle.  Each of
+the `2m+1` reflections fixes `k^(m+1)` colorings (`BurnsideCountingOQ05`). -/
+def reflectionTotal (m k : ℕ) : ℕ := (2 * m + 1) * k ^ (m + 1)
+
+/-- The Burnside fixed-point total for the dihedral group `D_n` (`n = 2m+1`) acting on
+`k`-colorings of the cycle: rotations plus reflections.  Dividing by `|D_n| = 2(2m+1)`
+gives the bracelet count. -/
+def dihedralTotal (m k : ℕ) : ℕ := rotationTotal (2 * m + 1) k + reflectionTotal m k
+
+/-- The number of inequivalent bracelets: the Burnside average over `|D_n| = 2(2m+1)`. -/
+def braceletCount (m k : ℕ) : ℕ := dihedralTotal m k / (2 * (2 * m + 1))
+
+/-- Provenance: the reflection total is exactly `2m+1` copies of the OQ05 reflection count
+`k^(m+1)` (`= Fintype.card` of the reflection-invariant colorings). -/
+theorem reflectionTotal_eq_card (m k : ℕ) :
+    reflectionTotal m k =
+      (2 * m + 1) * Fintype.card {c : ZMod (2 * m + 1) → Fin k // ∀ i, c (-i) = c i} := by
+  rw [reflectionTotal, BurnsideCountingOQ05.card_reflectionInvariant]
+
+/-- The assembled dihedral total, definitionally rotations plus reflections. -/
+theorem dihedralTotal_eq (m k : ℕ) :
+    dihedralTotal m k = rotationTotal (2 * m + 1) k + (2 * m + 1) * k ^ (m + 1) := rfl
+
+/-- **Assembled dihedral fixed-point total, divisor-sum closed form.**  Combining the OQ03
+Pólya divisor identity for the rotations with the OQ05 reflection count gives, for every
+odd `n = 2m+1` and every `k`,
+`dihedralTotal = ∑_{d∣n} φ(n/d) k^d + n · k^{m+1}`. -/
+theorem dihedralTotal_divisor_form (m k : ℕ) :
+    dihedralTotal m k =
+      (∑ d ∈ Nat.divisors (2 * m + 1), Nat.totient ((2 * m + 1) / d) * k ^ d)
+        + (2 * m + 1) * k ^ (m + 1) := by
+  rw [dihedralTotal_eq]
+  unfold rotationTotal
+  rw [BurnsideCountingOQ03.polya_sum_identity (2 * m + 1) k (by omega)]
+
+/-! ### Worked odd case `n = 3` (`m = 1`). -/
+
+/-- Rotation total for the triangle: `k^3 + 2k` (identity fixes `k^3`, the two nontrivial
+rotations fix `k` each). -/
+theorem rotationTotal_three (k : ℕ) : rotationTotal 3 k = k ^ 3 + 2 * k := by
+  simp only [rotationTotal, Fin.sum_univ_three]
+  norm_num [show Nat.gcd (0 : Fin 3).val 3 = 3 from rfl,
+    show Nat.gcd (1 : Fin 3).val 3 = 1 from rfl,
+    show Nat.gcd (2 : Fin 3).val 3 = 1 from rfl]
+  ring
+
+/-- Assembled dihedral total for the triangle: `k(k+1)(k+2)`. -/
+theorem dihedralTotal_three (k : ℕ) : dihedralTotal 1 k = k * (k + 1) * (k + 2) := by
+  rw [dihedralTotal_eq, rotationTotal_three]
+  ring
+
+/-- `6 = |D₃|` divides the triangle total (three consecutive integers), so the bracelet
+count is an integer. -/
+theorem bracelet_three_dvd (k : ℕ) : 6 ∣ dihedralTotal 1 k := by
+  rw [dihedralTotal_three]
+  have h6 : ∀ r : ZMod 6, r * (r + 1) * (r + 2) = 0 := by decide
+  have : ((k * (k + 1) * (k + 2) : ℕ) : ZMod 6) = 0 := by
+    push_cast; exact h6 (k : ZMod 6)
+  exact (ZMod.natCast_eq_zero_iff _ 6).mp this
+
+/-- **Bracelet count for the triangle.**  `6 · braceletCount = k(k+1)(k+2)`; the count is
+`k(k+1)(k+2)/6`, the tetrahedral number `C(k+2,3)`. -/
+theorem bracelet_three (k : ℕ) : 6 * braceletCount 1 k = dihedralTotal 1 k := by
+  have hd : (2 * (2 * 1 + 1)) = 6 := by norm_num
+  unfold braceletCount
+  rw [hd]
+  exact Nat.mul_div_cancel' (bracelet_three_dvd k)
+
+/-! ### Worked odd case `n = 5` (`m = 2`). -/
+
+/-- Rotation total for the pentagon: `k^5 + 4k`. -/
+theorem rotationTotal_five (k : ℕ) : rotationTotal 5 k = k ^ 5 + 4 * k := by
+  simp only [rotationTotal, Fin.sum_univ_five]
+  norm_num [show Nat.gcd (0 : Fin 5).val 5 = 5 from rfl,
+    show Nat.gcd (1 : Fin 5).val 5 = 1 from rfl,
+    show Nat.gcd (2 : Fin 5).val 5 = 1 from rfl,
+    show Nat.gcd (3 : Fin 5).val 5 = 1 from rfl,
+    show Nat.gcd (4 : Fin 5).val 5 = 1 from rfl]
+  ring
+
+/-- Assembled dihedral total for the pentagon: `k(k²+1)(k²+4) = k^5 + 5k^3 + 4k`. -/
+theorem dihedralTotal_five (k : ℕ) :
+    dihedralTotal 2 k = k * (k ^ 2 + 1) * (k ^ 2 + 4) := by
+  rw [dihedralTotal_eq, rotationTotal_five]
+  ring
+
+/-- `10` divides the pentagon total, so the bracelet count is an integer. -/
+theorem bracelet_five_dvd (k : ℕ) : 10 ∣ dihedralTotal 2 k := by
+  rw [dihedralTotal_five]
+  -- k(k²+1)(k²+4) ≡ 0 (mod 10) for all k, checked on residues mod 10.
+  have h10 : ∀ r : ZMod 10, r * (r ^ 2 + 1) * (r ^ 2 + 4) = 0 := by decide
+  have : ((k * (k ^ 2 + 1) * (k ^ 2 + 4) : ℕ) : ZMod 10) = 0 := by
+    push_cast
+    exact h10 (k : ZMod 10)
+  exact (ZMod.natCast_eq_zero_iff _ 10).mp this
+
+/-- **Bracelet count for the pentagon.**  `10 · braceletCount = k(k²+1)(k²+4)`. -/
+theorem bracelet_five (k : ℕ) : 10 * braceletCount 2 k = dihedralTotal 2 k := by
+  have hd : (2 * (2 * 2 + 1)) = 10 := by norm_num
+  unfold braceletCount
+  rw [hd]
+  exact Nat.mul_div_cancel' (bracelet_five_dvd k)
+
+/-! ### Numeric sanity checks (bracelet counts). -/
+
+/-- `4` binary bracelets of length `3`. -/
+theorem bracelet_three_two : braceletCount 1 2 = 4 := by decide
+
+/-- `10` ternary bracelets of length `3`. -/
+theorem bracelet_three_three : braceletCount 1 3 = 10 := by decide
+
+/-- `8` binary bracelets of length `5`. -/
+theorem bracelet_five_two : braceletCount 2 2 = 8 := by decide
+
+end BurnsideCountingOQ05OQ02

--- a/src/data/proofs/burnside-counting-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-05-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "burnside-counting-oq-05-oq-02",
+    "range": { "startLine": 5, "endLine": 43 },
+    "type": "concept",
+    "title": "Assembling the Dihedral Bracelet Count for Odd Cycles",
+    "content": "The dihedral group Dₙ on an n-cycle has 2n elements: n rotations and n reflections. The rotation fixed-point counts are the Pólya gcd-powers k^gcd(n,r) (oq-03), the reflection counts for odd n are k^((n+1)/2) each (oq-05). This file assembles both into dihedralTotal = ∑_{r<n} k^gcd(n,r) + n·k^(m+1) and reads off the bracelet count as the Burnside average dihedralTotal/|Dₙ|, |Dₙ| = 2n. Averaging in the reflections is exactly the step that turns necklaces into bracelets.",
+    "mathContext": "$\\mathrm{braceletCount} = \\dfrac{\\sum_{r<n} k^{\\gcd(n,r)} + n\\,k^{(n+1)/2}}{2n}$ for odd $n$.",
+    "significance": "key",
+    "relatedConcepts": ["Burnside's lemma", "Pólya enumeration", "dihedral group", "bracelet counting", "necklaces"],
+    "prerequisites": ["group actions", "ZMod n", "orbit counting"]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "burnside-counting-oq-05-oq-02",
+    "range": { "startLine": 49, "endLine": 73 },
+    "type": "definition",
+    "title": "The Four Burnside Quantities",
+    "content": "rotationTotal n k = ∑_{r:Fin n} k^gcd(r,n) is the total over all rotations; reflectionTotal m k = (2m+1)·k^(m+1) is the total over all reflections of an odd cycle; dihedralTotal = rotationTotal + reflectionTotal; braceletCount = dihedralTotal/(2(2m+1)). reflectionTotal_eq_card records that reflectionTotal is exactly 2m+1 copies of the oq-05 count Fintype.card{c // ∀ i, c(−i)=c i} = k^(m+1), and dihedralTotal_eq expands the assembly definitionally.",
+    "mathContext": "$\\mathrm{dihedralTotal}(m,k) = \\mathrm{rotationTotal}(2m{+}1,k) + (2m{+}1)k^{m+1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["fixed-point count", "dihedral group order 2n", "Burnside average"],
+    "prerequisites": ["finite sums over Fin n", "ZMod colorings"]
+  },
+  {
+    "id": "ann-divisor-form",
+    "proofId": "burnside-counting-oq-05-oq-02",
+    "range": { "startLine": 75, "endLine": 85 },
+    "type": "theorem",
+    "title": "General Divisor-Sum Closed Form",
+    "content": "dihedralTotal_divisor_form: for every odd n = 2m+1 and every k, the assembled total equals ∑_{d|n} φ(n/d) k^d + n·k^(m+1). The proof rewrites the rotation sum with the oq-03 Pólya divisor identity (polya_sum_identity); no new number theory is needed for the fixed-point total, which is fully general.",
+    "mathContext": "$\\mathrm{dihedralTotal} = \\sum_{d\\mid n} \\varphi(n/d)\\,k^{d} + n\\,k^{m+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler totient", "divisor sum", "Pólya enumeration"],
+    "prerequisites": ["Nat.divisors", "Euler's totient", "the oq-03 Pólya identity"]
+  },
+  {
+    "id": "ann-triangle",
+    "proofId": "burnside-counting-oq-05-oq-02",
+    "range": { "startLine": 87, "endLine": 118 },
+    "type": "theorem",
+    "title": "Worked Case n = 3: the Tetrahedral Bracelet Count",
+    "content": "rotationTotal_three = k^3+2k (identity fixes k^3, the two nontrivial rotations fix k each) and dihedralTotal_three = k(k+1)(k+2). bracelet_three_dvd proves 6 | total by checking r(r+1)(r+2) = 0 for all r : ZMod 6 (decide) and lifting via ZMod.natCast_eq_zero_iff; bracelet_three then gives 6·braceletCount = total, so B(3,k) = k(k+1)(k+2)/6 is the tetrahedral number C(k+2,3).",
+    "mathContext": "$B(3,k) = \\tfrac{k(k+1)(k+2)}{6} = \\binom{k+2}{3}$.",
+    "significance": "key",
+    "relatedConcepts": ["tetrahedral number", "binomial coefficient", "three consecutive integers"],
+    "prerequisites": ["Fin.sum_univ_three", "divisibility via residues", "ring arithmetic"]
+  },
+  {
+    "id": "ann-pentagon",
+    "proofId": "burnside-counting-oq-05-oq-02",
+    "range": { "startLine": 120, "endLine": 153 },
+    "type": "theorem",
+    "title": "Worked Case n = 5",
+    "content": "rotationTotal_five = k^5+4k and dihedralTotal_five = k(k²+1)(k²+4). bracelet_five_dvd proves 10 | total by checking r(r²+1)(r²+4) = 0 for all r : ZMod 10 (decide) and lifting; bracelet_five gives 10·braceletCount = total, so B(5,k) = k(k²+1)(k²+4)/10.",
+    "mathContext": "$B(5,k) = \\tfrac{k(k^2+1)(k^2+4)}{10}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["dihedral bracelets", "divisibility via residues"],
+    "prerequisites": ["Fin.sum_univ_five", "ZMod 10 decide", "ring arithmetic"]
+  },
+  {
+    "id": "ann-numeric",
+    "proofId": "burnside-counting-oq-05-oq-02",
+    "range": { "startLine": 155, "endLine": 164 },
+    "type": "theorem",
+    "title": "Numeric Bracelet Counts",
+    "content": "Kernel decide recovers concrete bracelet counts: 4 binary bracelets of length 3 (bracelet_three_two), 10 ternary bracelets of length 3 (bracelet_three_three), and 8 binary bracelets of length 5 (bracelet_five_two). These use decide (not native_decide), so they remain axiom-free.",
+    "mathContext": "$B(3,2)=4,\\quad B(3,3)=10,\\quad B(5,2)=8$.",
+    "significance": "supporting",
+    "relatedConcepts": ["kernel decide", "concrete enumeration"],
+    "prerequisites": ["decidable equality on ℕ"]
+  }
+]

--- a/src/data/proofs/burnside-counting-oq-05-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-05-oq-02/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "burnside-counting-oq-05-oq-02",
+  "title": "Assembling Rotations and Reflections: the Dihedral Bracelet Count for Odd Cycles",
+  "slug": "burnside-counting-oq-05-oq-02",
+  "description": "Assembles the rotation-fixed count k^gcd(n,r) (oq-03, with divisor form ∑_{d|n} φ(n/d) k^d) and the reflection-fixed count k^((n+1)/2) (oq-05) into the fixed-point total for the full dihedral group D_n (n = 2m+1) acting on k-colorings of a cycle, and reads off the number of inequivalent bracelets (dihedral necklaces) as the Burnside average total/|D_n|, |D_n| = 2n. For odd n all n reflections fix k^(m+1) colorings, so the assembled total is ∑_{r<n} k^gcd(n,r) + n·k^(m+1) = ∑_{d|n} φ(n/d) k^d + n·k^(m+1). The worked odd cases n = 3 and n = 5 give the closed-form totals k(k+1)(k+2) and k(k²+1)(k²+4), with |D_n| dividing the total (verified over residues), so the bracelet counts k(k+1)(k+2)/6 (the tetrahedral number C(k+2,3)) and k(k²+1)(k²+4)/10 are integers; numeric checks recover 4 binary triangle bracelets, 8 binary pentagon bracelets, and 10 ternary triangle bracelets.",
+  "meta": {
+    "author": "Burnside / Pólya theory; formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ05OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "group-action",
+      "burnside",
+      "polya-enumeration",
+      "dihedral-group",
+      "necklaces",
+      "bracelets",
+      "zmod",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(↑a : ZMod b) = 0 ↔ b ∣ a — lifts the residue-wise vanishing of the count polynomial (checked by decide on ZMod 6 / ZMod 10) to the divisibility |D_n| ∣ total that makes each bracelet count an integer",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel'",
+        "description": "a ∣ b → a * (b / a) = b — turns the divisibility |D_n| ∣ total into the exact identity |D_n| · braceletCount = total",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Fin.sum_univ_three / Fin.sum_univ_five",
+        "description": "expands the finite Pólya rotation sum over Fin 3 and Fin 5 into explicit terms k^gcd(r,n), evaluated with the gcd values",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      }
+    ],
+    "originalContributions": [
+      "rotationTotal / reflectionTotal / dihedralTotal / braceletCount: the four defining quantities of the dihedral Burnside average — the rotation Pólya sum, the reflection total n·k^(m+1), their sum, and the orbit-count quotient total/(2n)",
+      "reflectionTotal_eq_card: provenance identity showing reflectionTotal is exactly 2m+1 copies of the oq-05 reflection count k^(m+1)",
+      "dihedralTotal_divisor_form: the general (any odd n = 2m+1, any k) assembled fixed-point total in divisor-sum closed form ∑_{d|n} φ(n/d) k^d + n·k^(m+1), obtained by feeding the oq-03 Pólya divisor identity into the assembly",
+      "rotationTotal_three / dihedralTotal_three / bracelet_three: n = 3 case — rotation total k^3+2k, dihedral total k(k+1)(k+2), and 6 · braceletCount = total (bracelet count = tetrahedral number C(k+2,3))",
+      "rotationTotal_five / dihedralTotal_five / bracelet_five: n = 5 case — rotation total k^5+4k, dihedral total k(k²+1)(k²+4), and 10 · braceletCount = total",
+      "bracelet_three_dvd / bracelet_five_dvd: |D_n| divides the total, proved by checking the count polynomial vanishes on all residues mod 6 / mod 10 (decide) and lifting via ZMod.natCast_eq_zero_iff",
+      "bracelet_three_two / bracelet_three_three / bracelet_five_two: numeric bracelet counts 4, 10, 8 recovered by kernel decide"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide (the numeric checks use kernel decide, which depends only on the foundational axioms, not Lean.ofReduceBool). Builds on the sibling verified files BurnsideCountingOQ03 (rotation Pólya identity) and BurnsideCountingOQ05 (reflection count). #print axioms reports only propext, Classical.choice, Quot.sound for every theorem. The general assembly (dihedralTotal_divisor_form) is proved for all odd n; the exact integral bracelet count (total/(2n)) is proved for the worked cases n = 3 and n = 5. The remaining step of identifying braceletCount with the literal orbit count of DihedralGroup n acting on colorings (via Mathlib's MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group) is left open.",
+    "lineCount": 166,
+    "theoremCount": 14,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "The number of inequivalent colorings of a structure under a symmetry group is the Burnside (Cauchy–Frobenius) average of the per-symmetry fixed-point counts, refined by Pólya enumeration. For a cycle of n beads the dihedral group D_n has 2n elements — n rotations and n reflections. The rotation fixed-point counts are the gcd-powers k^gcd(n,r) (formalized in oq-03, with divisor form ∑_{d|n} φ(n/d) k^d), and the reflection fixed-point counts for odd n are k^((n+1)/2) each (formalized in oq-05). Averaging over D_n turns necklace counts (rotations only) into bracelet counts (rotations and reflections). This entry carries out the assembly step for odd cycles.",
+    "problemStatement": "Can the rotation and reflection fixed-point counts be assembled into a closed form for the number of inequivalent dihedral bracelets of an odd cycle?\n\n**Answer:** yes. For odd n = 2m+1 the dihedral fixed-point total is ∑_{r<n} k^gcd(n,r) + n·k^(m+1) = ∑_{d|n} φ(n/d) k^d + n·k^(m+1), and the bracelet count is this divided by |D_n| = 2n. Worked out: B(3,k) = k(k+1)(k+2)/6 = C(k+2,3) and B(5,k) = k(k²+1)(k²+4)/10.",
+    "text": "The odd-cycle dihedral bracelet count is the Burnside average of the rotation Pólya sum and the reflection total n·k^((n+1)/2).",
+    "proofStrategy": "Define rotationTotal n k = ∑_{r:Fin n} k^gcd(r,n), reflectionTotal m k = (2m+1)·k^(m+1), dihedralTotal = rotationTotal + reflectionTotal, and braceletCount = dihedralTotal / (2(2m+1)). Establish provenance (reflectionTotal_eq_card ties reflectionTotal to the oq-05 count) and the general divisor-sum form (dihedralTotal_divisor_form, by rewriting the rotation sum with the oq-03 Pólya divisor identity). For n = 3 and n = 5 evaluate the rotation sum by Fin.sum_univ_three/five and the gcd values, obtaining polynomial totals by ring; prove |D_n| divides the total by checking the polynomial vanishes on all residues (decide over ZMod 6 / ZMod 10) and lifting with ZMod.natCast_eq_zero_iff, then |D_n|·braceletCount = total by Nat.mul_div_cancel'. Numeric bracelet counts follow by kernel decide.",
+    "keyInsights": [
+      "Necklaces (rotation orbits) become bracelets (dihedral orbits) by averaging in the reflection fixed-point counts: dihedralTotal = rotationTotal + reflectionTotal, and for odd n every reflection contributes the same k^((n+1)/2)",
+      "The general assembled total has a clean divisor-sum closed form ∑_{d|n} φ(n/d) k^d + n·k^(m+1), inherited directly from the oq-03 Pólya identity — no new number theory is needed for the fixed-point total",
+      "Integrality of the bracelet count (that |D_n| divides the total) is a finite residue check: the count polynomial vanishes identically on ZMod 6 (n=3) and ZMod 10 (n=5), which decide settles and ZMod.natCast_eq_zero_iff lifts to ℕ",
+      "The triangle bracelet count is the tetrahedral number C(k+2,3) — three consecutive integers over 3! — linking dihedral necklace enumeration to the figurate-number tower"
+    ],
+    "prerequisites": [
+      "Group actions and the Burnside/Cauchy–Frobenius counting philosophy",
+      "The Pólya rotation count k^gcd(n,r) and its divisor form (oq-03)",
+      "The reflection count k^((n+1)/2) for odd cycles (oq-05)",
+      "Divisibility via residues: ZMod n and ZMod.natCast_eq_zero_iff"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "The Four Burnside Quantities",
+      "startLine": 49,
+      "endLine": 73,
+      "summary": "rotationTotal (Pólya sum), reflectionTotal = n·k^(m+1), dihedralTotal = rotationTotal + reflectionTotal, and braceletCount = dihedralTotal/(2n); reflectionTotal_eq_card ties the reflection total to the oq-05 count and dihedralTotal_eq expands the assembly.",
+      "mathContext": "$\\mathrm{dihedralTotal} = \\sum_{r<n} k^{\\gcd(n,r)} + n\\,k^{m+1}$, $\\ \\mathrm{braceletCount} = \\mathrm{dihedralTotal}/(2n)$."
+    },
+    {
+      "id": "divisor-form",
+      "title": "General Divisor-Sum Closed Form",
+      "startLine": 75,
+      "endLine": 85,
+      "summary": "dihedralTotal_divisor_form: for every odd n = 2m+1 and every k, the assembled total equals ∑_{d|n} φ(n/d) k^d + n·k^(m+1), by feeding the oq-03 Pólya divisor identity into the assembly.",
+      "mathContext": "$\\mathrm{dihedralTotal} = \\sum_{d\\mid n} \\varphi(n/d)\\,k^{d} + n\\,k^{m+1}$."
+    },
+    {
+      "id": "triangle",
+      "title": "Worked Case n = 3: the Tetrahedral Bracelet Count",
+      "startLine": 87,
+      "endLine": 118,
+      "summary": "rotationTotal_three = k^3+2k, dihedralTotal_three = k(k+1)(k+2); bracelet_three_dvd shows 6 | total (residues mod 6) and bracelet_three gives 6·braceletCount = total, so the count is C(k+2,3).",
+      "mathContext": "$B(3,k) = \\tfrac{k(k+1)(k+2)}{6} = \\binom{k+2}{3}$."
+    },
+    {
+      "id": "pentagon",
+      "title": "Worked Case n = 5",
+      "startLine": 120,
+      "endLine": 153,
+      "summary": "rotationTotal_five = k^5+4k, dihedralTotal_five = k(k²+1)(k²+4); bracelet_five_dvd shows 10 | total (residues mod 10) and bracelet_five gives 10·braceletCount = total.",
+      "mathContext": "$B(5,k) = \\tfrac{k(k^2+1)(k^2+4)}{10}$."
+    },
+    {
+      "id": "numeric",
+      "title": "Numeric Bracelet Counts",
+      "startLine": 155,
+      "endLine": 164,
+      "summary": "Kernel decide recovers 4 binary bracelets of length 3, 10 ternary bracelets of length 3, and 8 binary bracelets of length 5.",
+      "mathContext": "$B(3,2)=4,\\ B(3,3)=10,\\ B(5,2)=8$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Burnside, W.",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "note": "The orbit-counting (Cauchy–Frobenius) lemma underlying necklace and bracelet enumeration"
+    },
+    {
+      "authors": "Pólya, G.",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "note": "Enumeration under group actions; dihedral necklace and bracelet counts"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "burnside-counting-oq-05",
+      "relationship": "extends",
+      "description": "Answers the oq-05 open question by assembling its reflection count k^((n+1)/2) with the oq-03 rotation count into the dihedral bracelet total and its Burnside average."
+    },
+    {
+      "targetId": "burnside-counting-oq-03",
+      "relationship": "related",
+      "description": "Reuses the oq-03 Pólya rotation identity ∑_{r} k^gcd(r,n) = ∑_{d|n} φ(n/d) k^d as the rotation half of the assembled dihedral total."
+    }
+  ],
+  "conclusion": {
+    "summary": "For odd n = 2m+1 the dihedral fixed-point total assembles as ∑_{d|n} φ(n/d) k^d + n·k^(m+1) (proved for all odd n from the oq-03 Pólya identity and the oq-05 reflection count), and the bracelet count is this divided by |D_n| = 2n. The worked cases give B(3,k) = k(k+1)(k+2)/6 = C(k+2,3) and B(5,k) = k(k²+1)(k²+4)/10, with |D_n| dividing the total verified by a residue check and lifted to integrality; numeric checks recover 4, 10, and 8 bracelets. Fully verified, 0 axioms, 0 sorries.",
+    "implications": "Completes the dihedral half of the Burnside/Pólya necklace program for odd cycles in verified form, reusing the rotation and reflection counts rather than re-deriving them, and exhibits the tetrahedral-number identity B(3,k) = C(k+2,3) as a dihedral bracelet count.",
+    "openQuestions": [
+      "Can braceletCount be identified with the literal orbit count of DihedralGroup n acting on colorings, via Mathlib's MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group, giving the general integral count for all odd n rather than case by case?",
+      "What is the even-n bracelet count, where reflections split into vertex-axis and edge-axis types with different fixed-point counts?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BurnsideCountingOQ03",
+      "Proofs.BurnsideCountingOQ05"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "BurnsideCountingOQ05OQ02",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 4,
+    "path": "Proofs/BurnsideCountingOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **oq-05 open question**: *"Can the reflection and rotation counts be assembled into a closed form for the number of inequivalent dihedral necklaces via Burnside's lemma?"*

For the dihedral group `D_n` (`n = 2m+1`) acting on `k`-colorings of a cycle, this assembles the rotation-fixed count `k^gcd(n,r)` (oq-03, divisor form `∑_{d|n} φ(n/d) k^d`) and the reflection-fixed count `k^((n+1)/2)` (oq-05) into the fixed-point total, and reads off the number of inequivalent **bracelets** as the Burnside average `total / |D_n|`, `|D_n| = 2n`:

```
dihedralTotal = ∑_{r<n} k^gcd(n,r) + n·k^(m+1)
             = ∑_{d|n} φ(n/d) k^d  + n·k^(m+1)
```

## Results

- `reflectionTotal_eq_card` — provenance: the reflection total is `n` copies of the oq-05 count.
- `dihedralTotal_divisor_form` — **general** (all odd `n`, all `k`) divisor-sum closed form, via the oq-03 Pólya identity.
- `n = 3`: total `k(k+1)(k+2)`, bracelet count the tetrahedral number `C(k+2,3)`.
- `n = 5`: total `k(k²+1)(k²+4)`, bracelet count `k(k²+1)(k²+4)/10`.
- Integrality (`|D_n| ∣ total`) by a residue check over `ZMod 6` / `ZMod 10` (`decide`) lifted with `ZMod.natCast_eq_zero_iff`.
- Numeric checks: `B(3,2)=4`, `B(3,3)=10`, `B(5,2)=8` (kernel `decide`).

## Verification

- Builds clean: `./proofs/scripts/docker-build.sh Proofs.BurnsideCountingOQ05OQ02` (7745 jobs, 0 errors). Gallery `pnpm build` passes.
- `#print axioms` on every theorem reports only `propext, Classical.choice, Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`** (kernel `decide`, not `native_decide`).
- **0 axioms, 0 sorries.** Builds on the sibling verified files `BurnsideCountingOQ03` and `BurnsideCountingOQ05`.

## Scope

The general fixed-point total is proved for all odd `n`; the exact integral bracelet count `total/(2n)` is proved for the worked cases `n = 3, 5`. Identifying `braceletCount` with the literal orbit count of `DihedralGroup n` (via Mathlib's `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`) is noted as the natural next child.

🤖 Generated with [Claude Code](https://claude.com/claude-code)