### PR TITLE
Enrich Countability of Algebraic Elements (oq-05-oq-04): add annotations.json

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05-oq-04/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "algcount-ann-header",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04",
+    "range": { "startLine": 3, "endLine": 49 },
+    "type": "concept",
+    "title": "The Open Question and Why the Naive Generalization Fails",
+    "content": "The parent entry uses Cantor's 1874 height function to prove $\\{x \\in \\mathbb{R} \\mid \\text{IsAlgebraic } \\mathbb{Q}\\ x\\}$ countable. Its open question asks whether this extends to other base fields — e.g. $\\mathbb{Q}(\\sqrt 2)$ or 'algebraic $p$-adic numbers'. The header pins down the trap: the phrase *algebraic $p$-adic numbers* silently changes the base field to $\\mathbb{Q}_p$, which is **uncountable**, and every element of an uncountable field is trivially algebraic over itself (a root of $X - k$). So the honest statement is not an unconditional 'yes' but a biconditional: for a field extension $L/K$, the algebraic set $\\{x \\in L \\mid \\text{IsAlgebraic } K\\ x\\}$ is countable **iff** the base field $K$ is countable. The ambient field $L$ is irrelevant.",
+    "mathContext": "$\\{x \\in L \\mid \\text{IsAlgebraic } K\\ x\\}\\ \\text{countable} \\iff K\\ \\text{countable}.$ The algebraic elements are the roots of the polynomials in $K[X]$; there are $\\#K$-many such polynomials, so the count is governed entirely by $\\#K$.",
+    "significance": "context",
+    "relatedConcepts": ["algebraic numbers", "countability", "field extension", "p-adic numbers", "Cantor's theorem"],
+    "prerequisites": ["cardinality", "algebraic elements over a field"]
+  },
+  {
+    "id": "algcount-ann-sufficient",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04",
+    "range": { "startLine": 59, "endLine": 65 },
+    "type": "theorem",
+    "title": "Sufficient Direction: Countable Base ⟹ Countable Algebraic Set",
+    "content": "`algebraic_setOf_countable` is the parent's 'yes', now a one-liner. When `[Countable K]`, the set of elements of any extension `L` algebraic over `K` is countable — this is precisely Mathlib's `Algebraic.countable K L`, whose proof bounds the algebraic elements by the (countably many) roots of the (countably many) polynomials in `K[X]`. No Cantor height function is re-derived; the ambient `L` never enters the hypothesis. This is the easy half of the biconditional.",
+    "mathContext": "$K\\ \\text{countable} \\implies \\{x \\in L \\mid \\text{IsAlgebraic } K\\ x\\}\\ \\text{countable}.$ Bound: $\\#\\{\\text{algebraic elements}\\} \\le \\aleph_0 \\cdot \\#K[X] = \\#K$ when $\\#K \\ge \\aleph_0$.",
+    "significance": "key",
+    "relatedConcepts": ["Algebraic.countable", "countable union of finite sets", "polynomial roots"],
+    "prerequisites": ["countability is closed under countable unions", "a polynomial has finitely many roots"]
+  },
+  {
+    "id": "algcount-ann-embedding",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04",
+    "range": { "startLine": 69, "endLine": 73 },
+    "type": "theorem",
+    "title": "The Base Field Embeds Into Its Own Algebraic Set",
+    "content": "`algebraMap_mem_algebraic` records the elementary fact that every image `algebraMap K L k` is algebraic over `K` — it is a root of the linear polynomial `X - k` (Mathlib's `isAlgebraic_algebraMap`). Geometrically, the copy of `K` sitting inside `L` lies entirely within the algebraic set. This is the pivot for the converse direction: it lets us turn a hypothetical injection of `K` into a genuine map landing in the algebraic set.",
+    "mathContext": "$\\forall k \\in K,\\ \\text{algebraMap}_{K \\to L}(k) \\in \\{x \\in L \\mid \\text{IsAlgebraic } K\\ x\\}$, since $k$ is a root of $X - k \\in K[X]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["isAlgebraic_algebraMap", "algebra map", "minimal polynomial"],
+    "prerequisites": ["algebra structure K → L", "definition of IsAlgebraic"]
+  },
+  {
+    "id": "algcount-ann-necessary",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04",
+    "range": { "startLine": 77, "endLine": 90 },
+    "type": "theorem",
+    "title": "Necessary Direction: Countable Algebraic Set ⟹ Countable Base",
+    "content": "`countable_of_algebraic_setOf_countable` is the new content relative to Mathlib. If the algebraic set is countable, promote it to a countable subtype (`h.to_subtype`), then inject `K` into it by `k ↦ ⟨algebraMap K L k, isAlgebraic_algebraMap k⟩`. Injectivity comes from `FaithfulSMul.algebraMap_injective K L`: an algebra map out of a *field* into a *nontrivial* ring is injective (a field forces `NoZeroSMulDivisors`, hence `FaithfulSMul`). `Function.Injective.countable` then transfers countability back to `K`. No cardinal arithmetic is needed — just an injection into a countable set.",
+    "mathContext": "$\\{x \\in L \\mid \\text{IsAlgebraic } K\\ x\\}\\ \\text{countable} \\implies K\\ \\text{countable}$, via the injection $k \\mapsto \\langle \\text{algebraMap } K\\ L\\ k,\\ \\cdot\\rangle$ whose injectivity is $\\ker(\\text{algebraMap}) = 0$ for a field source.",
+    "significance": "key",
+    "relatedConcepts": ["FaithfulSMul.algebraMap_injective", "Function.Injective.countable", "Set.Countable.to_subtype", "NoZeroSMulDivisors"],
+    "prerequisites": ["injective map into a countable set has countable domain", "algebra maps from fields are injective"]
+  },
+  {
+    "id": "algcount-ann-characterization",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04",
+    "range": { "startLine": 94, "endLine": 109 },
+    "type": "theorem",
+    "title": "The Sharp Biconditional and the p-adic Obstruction",
+    "content": "`countable_algebraic_iff` assembles the two directions into `Set.Countable {x : L | IsAlgebraic K x} ↔ Countable K` — the sharp answer to the open question. Its contrapositive, `not_countable_algebraic_of_uncountable_base`, states the $p$-adic obstruction in general form: an uncountable base field yields uncountably many algebraic elements, because the base field alone already supplies them. Applying this with `K = ℚ_p` (uncountable) explains exactly why 'algebraic $p$-adic numbers' are *not* countable, while 'algebraic over $\\mathbb{Q}$' (inside $\\mathbb{Q}_p$ or anywhere) remains countable.",
+    "mathContext": "$\\text{Countable}\\,\\{x \\in L \\mid \\text{IsAlgebraic } K\\ x\\} \\iff \\text{Countable } K$; contrapositive: $\\neg\\,\\text{Countable } K \\implies \\neg\\,\\text{Countable}\\,\\{x \\mid \\text{IsAlgebraic } K\\ x\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["biconditional characterization", "contrapositive", "sharp boundary", "p-adic field ℚ_p"],
+    "prerequisites": ["the two directions above", "logical contrapositive"]
+  },
+  {
+    "id": "algcount-ann-examples",
+    "proofId": "algebraic-numbers-countable-oq-05-oq-04",
+    "range": { "startLine": 111, "endLine": 138 },
+    "type": "example",
+    "title": "Worked Instances on Both Sides",
+    "content": "Three one-line instances exercise the characterization. Over $\\mathbb{Q}$: the classical case, recovered without Cantor's height function. Over a finite field $\\mathbb{Z}/p\\mathbb{Z}$: countable because `ZMod p` is finite (the function-field analogue of the number-field case). Over $\\mathbb{R}$ inside $\\mathbb{C}$: **un**countable, since $\\mathbb{R}$ is uncountable and every complex number is algebraic over $\\mathbb{R}$ (degree $\\le 2$) — a concrete cautionary example that stands in for the $p$-adic case yet needs no $p$-adic imports. The three instances land on opposite sides of the boundary purely by the countability of the base.",
+    "mathContext": "$\\{x \\mid \\text{IsAlgebraic } \\mathbb{Q}\\ x\\},\\ \\{x \\mid \\text{IsAlgebraic } (\\mathbb{Z}/p)\\ x\\}$ countable; $\\{x \\in \\mathbb{C} \\mid \\text{IsAlgebraic } \\mathbb{R}\\ x\\} = \\mathbb{C}$ uncountable.",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod p", "finite fields", "Uncountable ℝ", "Cantor's transcendence argument"],
+    "prerequisites": ["ZMod p is finite", "ℝ is uncountable", "ℂ/ℝ is an algebraic extension"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass — algebraic-numbers-countable-oq-05-oq-04

This entry had a rich `meta.json` but **no `annotations.json`** (0 annotation coverage — a primary quality gap for a pass-0 entry).

Adds **6 inline annotations** covering the full Lean file, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`:
- Header — the open question and why 'algebraic $p$-adic numbers' breaks the naive generalization
- Sufficient direction (`algebraic_setOf_countable` / `Algebraic.countable`)
- Base-field embedding (`algebraMap_mem_algebraic`)
- Necessary direction (`countable_of_algebraic_setOf_countable` via `FaithfulSMul.algebraMap_injective`)
- The sharp biconditional + $p$-adic obstruction (`countable_algebraic_iff`, `not_countable_algebraic_of_uncountable_base`)
- Worked instances ($\mathbb{Q}$, $\mathbb{Z}/p$, $\mathbb{R}\subseteq\mathbb{C}$)

Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)