### PR TITLE
research(combinations-formula-oq-06-oq-03): polynomial closed forms of the hockey-stick partial sums [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ06OQ03.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ06OQ03.lean
@@ -1,0 +1,187 @@
+import Mathlib
+
+/-
+# Polynomial Closed Forms for the Hockey-Stick Partial Sums
+
+## Open Question (combinations-formula-oq-06, follow-up)
+
+The parent file `CombinationsFormulaOQ06` proves the hockey-stick identity
+`∑_{m≤n} C(m, k) = C(n+1, k+1)` and, at column `k = 1`, the triangular closed form
+`C(n+1, 2) = n(n+1)/2`.  It also proves that the sum of the first `n+1` triangular numbers
+is the tetrahedral number *as a binomial coefficient* (`sum_triangular_eq_tetrahedral`,
+`∑_{m≤n} C(m+1, 2) = C(n+2, 3)`), but leaves that running total in binomial form.
+
+The sibling `combinations-formula-oq-06-oq-02` supplies the *point* closed forms of the
+figurate numbers themselves — `C(n+2, 3) = n(n+1)(n+2)/6` and `C(n+3, 4) = …/24` — via the
+ascending factorial `S(k, n) = C(n+k-1, k)`.
+
+This entry closes the remaining gap: it gives the **hockey-stick partial sums their own
+polynomial closed forms**, and extends the running-total tower one rung further.
+
+  `sum_triangular_closed_form`  — `∑_{m≤n} T_m  = ∑_{m≤n} C(m+1, 2) = n(n+1)(n+2)/6`
+  `sum_tetrahedral_eq_pentatope`— `∑_{m≤n} Te_m = ∑_{m≤n} C(m+2, 3) = C(n+3, 4)`  (new rung)
+  `sum_tetrahedral_closed_form` — `∑_{m≤n} Te_m = n(n+1)(n+2)(n+3)/24`.
+
+So each simplicial layer is exhibited as the running total of the one beneath it *and* as a
+degree-`(k+1)` polynomial in `n`, making the Pythagorean "each layer sums to the next"
+picture literal at the level of closed forms.
+
+## Method: the descending factorial, a finite product rather than an induction
+
+The supporting point closed forms are obtained here through the **descending** factorial
+(the mirror of the sibling's ascending route), which packages the closed form of every
+binomial coefficient without induction on `n`:
+
+  `Nat.descFactorial_eq_factorial_mul_choose : n.descFactorial k = k! * C(n, k)`
+  `Nat.descFactorial_eq_prod_range          : n.descFactorial k = ∏_{i<k} (n - i)`.
+
+Chaining them gives, for every dimension `k` at once,
+
+  `k! * C(n+k, k) = ∏_{i<k} (n+k-i)`                        (`figurate_factorial_closed_form`)
+
+a finite product of `k` consecutive integers.  Specialising `k = 3, 4` and evaluating the
+short product yields `6·C(n+2, 3) = n(n+1)(n+2)` and `24·C(n+3, 4) = n(n+1)(n+2)(n+3)`; the
+partial-sum closed forms then follow by composing the hockey-stick sums with these.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ06OQ03
+
+open Finset
+
+/-! ### The hockey-stick identity (restated for self-containment) -/
+
+/-- **Hockey-stick identity (interval form).**  `∑_{m=k}^{n} C(m, k) = C(n+1, k+1)`.
+    This is `Nat.sum_Icc_choose`. -/
+theorem hockey_stick_Icc (n k : ℕ) :
+    ∑ m ∈ Finset.Icc k n, Nat.choose m k = Nat.choose (n + 1) (k + 1) :=
+  Nat.sum_Icc_choose n k
+
+/-- **Hockey-stick identity (range form).**  The same sum over `range (n+1)`; extending
+    the index range down to `0` changes nothing because `C(m, k) = 0` for `m < k`. -/
+theorem hockey_stick_range (n k : ℕ) :
+    ∑ m ∈ Finset.range (n + 1), Nat.choose m k = Nat.choose (n + 1) (k + 1) := by
+  rw [← hockey_stick_Icc n k]
+  refine (Finset.sum_subset ?_ ?_).symm
+  · intro x hx
+    rw [Finset.mem_Icc] at hx
+    rw [Finset.mem_range]
+    omega
+  · intro m hm hmIcc
+    rw [Finset.mem_range] at hm
+    rw [Finset.mem_Icc] at hmIcc
+    exact Nat.choose_eq_zero_of_lt (by omega)
+
+/-! ### The general induction-free figurate closed form (descending-factorial route) -/
+
+/-- **Figurate closed form (general, no induction).**  For the `k`-dimensional figurate
+    number `C(n+k, k)`,
+
+      `k! * C(n+k, k) = ∏_{i<k} (n+k-i)`,
+
+    a finite product of `k` consecutive integers.  Two rewrites from
+    `descFactorial = k!·choose` and `descFactorial = ∏ (n - i)`; no recursion on `n`. -/
+theorem figurate_factorial_closed_form (n k : ℕ) :
+    Nat.factorial k * Nat.choose (n + k) k = ∏ i ∈ Finset.range k, (n + k - i) := by
+  rw [← Nat.descFactorial_eq_factorial_mul_choose, Nat.descFactorial_eq_prod_range]
+
+/-! ### Evaluating the short descending factorials -/
+
+/-- The length-3 descending factorial `(n+2)·(n+1)·n`, written low-to-high. -/
+theorem descFactorial_three (n : ℕ) :
+    (n + 2).descFactorial 3 = n * (n + 1) * (n + 2) := by
+  simp only [Nat.descFactorial_eq_prod_range, Finset.prod_range_succ,
+    Finset.prod_range_zero, one_mul]
+  rw [show n + 2 - 0 = n + 2 from rfl, show n + 2 - 1 = n + 1 from rfl,
+    show n + 2 - 2 = n from rfl]
+  ring
+
+/-- The length-4 descending factorial `(n+3)·(n+2)·(n+1)·n`, written low-to-high. -/
+theorem descFactorial_four (n : ℕ) :
+    (n + 3).descFactorial 4 = n * (n + 1) * (n + 2) * (n + 3) := by
+  simp only [Nat.descFactorial_eq_prod_range, Finset.prod_range_succ,
+    Finset.prod_range_zero, one_mul]
+  rw [show n + 3 - 0 = n + 3 from rfl, show n + 3 - 1 = n + 2 from rfl,
+    show n + 3 - 2 = n + 1 from rfl, show n + 3 - 3 = n from rfl]
+  ring
+
+/-! ### Point closed forms of the tetrahedral and pentatope numbers
+
+These specialise the general identity; they coincide with the sibling entry
+`combinations-formula-oq-06-oq-02`'s `S_three_closed` / `S_four_closed` (there `S(k,n) =
+C(n+k-1,k)`), and are included here as the supporting lemmas for the partial-sum closed
+forms below. -/
+
+/-- `6 · C(n+2, 3) = n(n+1)(n+2)` (division-free), from `descFactorial = 3!·choose`. -/
+theorem tetrahedral_mul_closed_form (n : ℕ) :
+    6 * Nat.choose (n + 2) 3 = n * (n + 1) * (n + 2) := by
+  have h := Nat.descFactorial_eq_factorial_mul_choose (n + 2) 3
+  rw [descFactorial_three, (by decide : Nat.factorial 3 = 6)] at h
+  linarith [h]
+
+/-- `C(n+2, 3) = n(n+1)(n+2)/6`, the tetrahedral point closed form. -/
+theorem tetrahedral_closed_form (n : ℕ) :
+    Nat.choose (n + 2) 3 = n * (n + 1) * (n + 2) / 6 := by
+  have h := tetrahedral_mul_closed_form n
+  omega
+
+/-- `24 · C(n+3, 4) = n(n+1)(n+2)(n+3)` (division-free), from `descFactorial = 4!·choose`. -/
+theorem pentatope_mul_closed_form (n : ℕ) :
+    24 * Nat.choose (n + 3) 4 = n * (n + 1) * (n + 2) * (n + 3) := by
+  have h := Nat.descFactorial_eq_factorial_mul_choose (n + 3) 4
+  rw [descFactorial_four, (by decide : Nat.factorial 4 = 24)] at h
+  linarith [h]
+
+/-- `C(n+3, 4) = n(n+1)(n+2)(n+3)/24`, the pentatope point closed form. -/
+theorem pentatope_closed_form (n : ℕ) :
+    Nat.choose (n + 3) 4 = n * (n + 1) * (n + 2) * (n + 3) / 24 := by
+  have h := pentatope_mul_closed_form n
+  omega
+
+/-! ### The main results: polynomial closed forms of the hockey-stick partial sums -/
+
+/-- The sum of the first `n+1` triangular numbers `T_m = C(m+1, 2)` is the tetrahedral
+    number `C(n+2, 3)` (hockey-stick, column `2`, dropping the vanishing `C(0,2)` term).
+    Restated from the parent as the anchor for its closed form below. -/
+theorem sum_triangular_eq_tetrahedral (n : ℕ) :
+    ∑ m ∈ Finset.range (n + 1), Nat.choose (m + 1) 2 = Nat.choose (n + 2) 3 := by
+  have h := hockey_stick_range (n + 1) 2
+  rw [Finset.sum_range_succ'] at h
+  simpa using h
+
+/-- **Partial-sum closed form (triangular → tetrahedral).**  The running total of the
+    triangular numbers is a cubic polynomial in `n`:
+    `∑_{m≤n} T_m = n(n+1)(n+2)/6`. -/
+theorem sum_triangular_closed_form (n : ℕ) :
+    ∑ m ∈ Finset.range (n + 1), Nat.choose (m + 1) 2 = n * (n + 1) * (n + 2) / 6 := by
+  rw [sum_triangular_eq_tetrahedral, tetrahedral_closed_form]
+
+/-- **New rung.**  The sum of the first `n+1` tetrahedral numbers `Te_m = C(m+2, 3)` is the
+    pentatope number `C(n+3, 4)` (hockey-stick, column `3`, dropping the vanishing `C(0,3)`,
+    `C(1,3)` terms).  This is the running-total identity one dimension past the parent's. -/
+theorem sum_tetrahedral_eq_pentatope (n : ℕ) :
+    ∑ m ∈ Finset.range (n + 1), Nat.choose (m + 2) 3 = Nat.choose (n + 3) 4 := by
+  have h := hockey_stick_range (n + 2) 3
+  rw [Finset.sum_range_succ', Finset.sum_range_succ',
+    (by decide : Nat.choose 1 3 = 0), (by decide : Nat.choose 0 3 = 0)] at h
+  simpa using h
+
+/-- **Partial-sum closed form (tetrahedral → pentatope).**  The running total of the
+    tetrahedral numbers is a quartic polynomial in `n`:
+    `∑_{m≤n} Te_m = n(n+1)(n+2)(n+3)/24`. -/
+theorem sum_tetrahedral_closed_form (n : ℕ) :
+    ∑ m ∈ Finset.range (n + 1), Nat.choose (m + 2) 3
+      = n * (n + 1) * (n + 2) * (n + 3) / 24 := by
+  rw [sum_tetrahedral_eq_pentatope, pentatope_closed_form]
+
+/-! ### Concrete verifications -/
+
+/-- `T_0 + ⋯ + T_4 = 0+1+3+6+10 = 20 = 3·4·5/6`, the running total in closed form. -/
+example : ∑ m ∈ Finset.range 5, Nat.choose (m + 1) 2 = 3 * 4 * 5 / 6 := by decide
+/-- `Te_0 + ⋯ + Te_4 = 0+1+4+10+20 = 35 = C(7, 4) = 3·4·5·6/24`. -/
+example : ∑ m ∈ Finset.range 5, Nat.choose (m + 2) 3 = 3 * 4 * 5 * 6 / 24 := by decide
+/-- `∑_{m≤4} Te_m = 35 = C(7, 4)`, the running total as a binomial. -/
+example : ∑ m ∈ Finset.range 5, Nat.choose (m + 2) 3 = Nat.choose 7 4 := by decide
+
+end CombinationsFormulaOQ06OQ03

--- a/proofs/Proofs/CombinationsFormulaOQ06OQ03.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ06OQ03.lean
@@ -177,10 +177,10 @@ theorem sum_tetrahedral_closed_form (n : ℕ) :
 
 /-! ### Concrete verifications -/
 
-/-- `T_0 + ⋯ + T_4 = 0+1+3+6+10 = 20 = 3·4·5/6`, the running total in closed form. -/
-example : ∑ m ∈ Finset.range 5, Nat.choose (m + 1) 2 = 3 * 4 * 5 / 6 := by decide
-/-- `Te_0 + ⋯ + Te_4 = 0+1+4+10+20 = 35 = C(7, 4) = 3·4·5·6/24`. -/
-example : ∑ m ∈ Finset.range 5, Nat.choose (m + 2) 3 = 3 * 4 * 5 * 6 / 24 := by decide
+/-- `T_0 + ⋯ + T_4 = 0+1+3+6+10 = 20 = 4·5·6/6` (the `n = 4` triangular running total). -/
+example : ∑ m ∈ Finset.range 5, Nat.choose (m + 1) 2 = 4 * 5 * 6 / 6 := by decide
+/-- `Te_0 + ⋯ + Te_4 = 0+1+4+10+20 = 35 = C(7, 4) = 4·5·6·7/24`. -/
+example : ∑ m ∈ Finset.range 5, Nat.choose (m + 2) 3 = 4 * 5 * 6 * 7 / 24 := by decide
 /-- `∑_{m≤4} Te_m = 35 = C(7, 4)`, the running total as a binomial. -/
 example : ∑ m ∈ Finset.range 5, Nat.choose (m + 2) 3 = Nat.choose 7 4 := by decide
 

--- a/src/data/proofs/combinations-formula-oq-06-oq-03/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-06-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "partial-sum-context",
+    "proofId": "combinations-formula-oq-06-oq-03",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "Polynomial Closed Forms for the Figurate Running Totals",
+    "content": "The parent entry proves ∑_{m≤n} T_m = C(n+2,3) but leaves the running total in binomial form; the sibling oq-06-oq-02 supplies the point closed form C(n+2,3) = n(n+1)(n+2)/6. This entry composes the two — giving each hockey-stick partial sum an explicit polynomial in n — and extends the running-total tower one rung with ∑_{m≤n} Te_m = C(n+3,4). The supporting point closed forms are obtained through the descending factorial, the mirror of the sibling's ascending-factorial route.",
+    "mathContext": "$\\sum_{m=0}^{n} T_m = \\binom{n+2}{3} = \\tfrac{n(n+1)(n+2)}{6}$ and $\\sum_{m=0}^{n} Te_m = \\binom{n+3}{4} = \\tfrac{n(n+1)(n+2)(n+3)}{24}$: each simplicial layer is the running total of the one below, at both the binomial and polynomial levels.",
+    "significance": "key",
+    "prerequisites": ["hockey-stick identity", "binomial coefficients", "descending factorial"],
+    "relatedConcepts": ["figurate numbers", "partial sums", "tetrahedral numbers", "pentatope numbers", "closed form"]
+  },
+  {
+    "id": "hockey-stick-ann",
+    "proofId": "combinations-formula-oq-06-oq-03",
+    "range": { "startLine": 57, "endLine": 74 },
+    "type": "theorem",
+    "title": "Hockey-Stick Identity (Interval and Range Forms)",
+    "content": "hockey_stick_Icc restates Nat.sum_Icc_choose (∑_{m∈Icc k n} C(m,k) = C(n+1,k+1)); hockey_stick_range transports it to Finset.range (n+1) via Finset.sum_subset, the extra terms C(m,k) with m < k vanishing by Nat.choose_eq_zero_of_lt. These feed the partial-sum identities below.",
+    "mathContext": "$\\sum_{m=k}^{n}\\binom{m}{k} = \\binom{n+1}{k+1}$, extended to $\\sum_{m=0}^{n}$ at no cost since $\\binom{m}{k}=0$ for $m<k$.",
+    "significance": "supporting",
+    "prerequisites": ["Nat.sum_Icc_choose", "Finset.sum_subset"],
+    "relatedConcepts": ["hockey-stick identity", "binomial coefficients", "Finset sums"]
+  },
+  {
+    "id": "figurate-general-ann",
+    "proofId": "combinations-formula-oq-06-oq-03",
+    "range": { "startLine": 85, "endLine": 87 },
+    "type": "theorem",
+    "title": "Induction-Free Figurate Closed Form (Descending Factorial)",
+    "content": "figurate_factorial_closed_form: k!·C(n+k,k) = ∏_{i<k}(n+k-i) for every dimension k, proved in two rewrites from Nat.descFactorial_eq_factorial_mul_choose and Nat.descFactorial_eq_prod_range. This is the descending-factorial mirror of the sibling oq-06-oq-02's ascending-factorial identity; no induction on n.",
+    "mathContext": "$k!\\binom{n+k}{k} = (n+k)^{\\underline{k}} = \\prod_{i<k}(n+k-i)$.",
+    "significance": "supporting",
+    "prerequisites": ["Nat.descFactorial_eq_factorial_mul_choose", "Nat.descFactorial_eq_prod_range"],
+    "relatedConcepts": ["descending factorial", "figurate numbers", "closed form", "finite product"]
+  },
+  {
+    "id": "point-closed-forms-ann",
+    "proofId": "combinations-formula-oq-06-oq-03",
+    "range": { "startLine": 92, "endLine": 140 },
+    "type": "theorem",
+    "title": "Point Closed Forms of the Tetrahedral and Pentatope Numbers",
+    "content": "descFactorial_three/four evaluate the length-3/4 descending factorials as finite products; tetrahedral_mul_closed_form (6·C(n+2,3) = n(n+1)(n+2)) and pentatope_mul_closed_form (24·C(n+3,4) = n(n+1)(n+2)(n+3)) follow from descFactorial = k!·choose with 3! = 6, 4! = 24, and the division forms by omega. These supporting lemmas coincide with the sibling oq-06-oq-02's S_three_closed / S_four_closed, cross-checked here via the descending route.",
+    "mathContext": "$\\binom{n+2}{3} = \\tfrac{n(n+1)(n+2)}{6}$, $\\binom{n+3}{4} = \\tfrac{n(n+1)(n+2)(n+3)}{24}$.",
+    "significance": "supporting",
+    "prerequisites": ["Nat.descFactorial_eq_factorial_mul_choose", "Finset.prod_range_succ"],
+    "relatedConcepts": ["tetrahedral numbers", "pentatope numbers", "closed form"]
+  },
+  {
+    "id": "sum-triangular-closed-ann",
+    "proofId": "combinations-formula-oq-06-oq-03",
+    "range": { "startLine": 147, "endLine": 161 },
+    "type": "theorem",
+    "title": "Triangular Running Total as a Cubic Polynomial",
+    "content": "sum_triangular_eq_tetrahedral (∑_{m≤n} C(m+1,2) = C(n+2,3), from the column-2 hockey stick after Finset.sum_range_succ' drops the vanishing C(0,2) term) composed with the tetrahedral point closed form gives sum_triangular_closed_form: ∑_{m≤n} T_m = n(n+1)(n+2)/6. The parent's binomial running total becomes an explicit polynomial in n.",
+    "mathContext": "$\\sum_{m=0}^{n} T_m = \\binom{n+2}{3} = \\tfrac{n(n+1)(n+2)}{6}$.",
+    "significance": "key",
+    "prerequisites": ["Finset.sum_range_succ'", "hockey-stick identity"],
+    "relatedConcepts": ["triangular numbers", "tetrahedral numbers", "partial sums", "closed form"]
+  },
+  {
+    "id": "sum-tetrahedral-closed-ann",
+    "proofId": "combinations-formula-oq-06-oq-03",
+    "range": { "startLine": 163, "endLine": 176 },
+    "type": "theorem",
+    "title": "Tetrahedral Running Total: New Rung + Quartic Closed Form",
+    "content": "sum_tetrahedral_eq_pentatope: ∑_{m≤n} Te_m = ∑_{m≤n} C(m+2,3) = C(n+3,4) — the running-total identity one dimension past the parent, obtained by peeling TWO vanishing head terms C(0,3) = C(1,3) = 0 with Finset.sum_range_succ' applied twice. Composed with the pentatope point closed form it gives sum_tetrahedral_closed_form: ∑_{m≤n} Te_m = n(n+1)(n+2)(n+3)/24.",
+    "mathContext": "$\\sum_{m=0}^{n} Te_m = \\binom{n+3}{4} = \\tfrac{n(n+1)(n+2)(n+3)}{24}$.",
+    "significance": "key",
+    "prerequisites": ["Finset.sum_range_succ'", "hockey-stick identity"],
+    "relatedConcepts": ["tetrahedral numbers", "pentatope numbers", "partial sums", "figurate tower"]
+  },
+  {
+    "id": "verification-ann",
+    "proofId": "combinations-formula-oq-06-oq-03",
+    "range": { "startLine": 178, "endLine": 186 },
+    "type": "concept",
+    "title": "Worked Verifications",
+    "content": "Concrete kernel-decide checks: ∑_{m<5} T_m = 0+1+3+6+10 = 20 = 4·5·6/6, and ∑_{m<5} Te_m = 0+1+4+10+20 = 35 = 4·5·6·7/24 = C(7,4). Kernel `decide` (not native_decide) keeps the file free of the Lean.ofReduceBool axiom.",
+    "mathContext": "Small instances of the partial-sum closed forms, checked by kernel reduction.",
+    "significance": "supporting",
+    "prerequisites": ["decide"],
+    "relatedConcepts": ["triangular numbers", "tetrahedral numbers", "verification"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-06-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-06-oq-03/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "combinations-formula-oq-06-oq-03",
+  "title": "Polynomial Closed Forms for the Hockey-Stick Partial Sums",
+  "slug": "combinations-formula-oq-06-oq-03",
+  "description": "Gives the hockey-stick partial sums their own polynomial closed forms and extends the figurate running-total tower one rung further. The parent (combinations-formula-oq-06) proves ∑_{m≤n} C(m+1,2) = C(n+2,3) but leaves the running total in binomial form; the sibling oq-06-oq-02 supplies the point closed forms C(n+2,3) = n(n+1)(n+2)/6. This entry composes the two and adds the next rung: ∑_{m≤n} T_m = n(n+1)(n+2)/6, the new running-total identity ∑_{m≤n} Te_m = C(n+3,4) (sum of tetrahedral numbers = pentatope), and ∑_{m≤n} Te_m = n(n+1)(n+2)(n+3)/24. The supporting point closed forms are derived through the descending factorial (the mirror of the sibling's ascending route) via the induction-free identity k!·C(n+k,k) = ∏_{i<k}(n+k-i).",
+  "meta": {
+    "author": "Lean Genius researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ06OQ03.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 187,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "assumptions": "None. All identities hold for every natural number n and are fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms on sum_triangular_closed_form, sum_tetrahedral_closed_form, sum_tetrahedral_eq_pentatope, figurate_factorial_closed_form); the concrete checks use kernel `decide`, not `native_decide`, so there is no Lean.ofReduceBool dependency.",
+    "tags": [
+      "combinatorics",
+      "hockey-stick-identity",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "figurate-numbers",
+      "tetrahedral-numbers",
+      "pentatope-numbers",
+      "partial-sums",
+      "descending-factorial",
+      "closed-form",
+      "finset-sums"
+    ],
+    "dateAdded": "2026-06-30",
+    "originalContributions": [
+      "sum_triangular_closed_form: the running total of the triangular numbers as a cubic polynomial, ∑_{m≤n} T_m = ∑_{m≤n} C(m+1,2) = n(n+1)(n+2)/6 — the parent's ∑ T_m = C(n+2,3) composed with the tetrahedral point closed form, giving the partial sum its polynomial shape rather than leaving it as a binomial coefficient",
+      "sum_tetrahedral_eq_pentatope: the running-total identity one rung past the parent — the sum of the first n+1 tetrahedral numbers Te_m = C(m+2,3) is the pentatope number C(n+3,4), obtained from the column-3 hockey stick by dropping the two vanishing head terms C(0,3), C(1,3) via Finset.sum_range_succ' applied twice",
+      "sum_tetrahedral_closed_form: the running total of the tetrahedral numbers as a quartic polynomial, ∑_{m≤n} Te_m = n(n+1)(n+2)(n+3)/24",
+      "figurate_factorial_closed_form: the induction-free closed form of every simplicial figurate number via the DESCENDING factorial, k!·C(n+k,k) = ∏_{i<k}(n+k-i), a two-rewrite proof from Nat.descFactorial_eq_factorial_mul_choose and Nat.descFactorial_eq_prod_range — the mirror of the sibling oq-06-oq-02's ascending-factorial route, supplying the tetrahedral/pentatope point closed forms used above"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ06OQ03.lean",
+    "namespace": "CombinationsFormulaOQ06OQ03",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 187,
+    "theoremCount": 13,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "In the Pythagorean/Nicomachean picture of figurate numbers, each simplicial layer is the running total of the one beneath it: the natural numbers sum to the triangular numbers, the triangular to the tetrahedral, the tetrahedral to the pentatope. The hockey-stick identity ∑_{m≤n} C(m,k) = C(n+1,k+1) captures exactly this 'partial sums move one column right' phenomenon. Classically the running totals also have closed polynomial forms — 1+3+6+⋯ = n(n+1)(n+2)/6, etc. — but a formalization that anchors on the hockey stick tends to stop at the binomial coefficient. This entry supplies the missing polynomial shapes for the partial sums and adds the tetrahedral→pentatope rung.",
+    "problemStatement": "Follow-up to combinations-formula-oq-06: the parent proves the running total ∑_{m≤n} T_m equals the tetrahedral number C(n+2,3) but leaves it in binomial form, and stops the running-total tower at that single rung. Give the hockey-stick partial sums their explicit polynomial closed forms (∑ T_m = n(n+1)(n+2)/6, ∑ Te_m = n(n+1)(n+2)(n+3)/24) and extend the running-total identity one dimension further (∑ Te_m = C(n+3,4)).",
+    "proofStrategy": "Two ingredients. (1) The point closed forms of the figurate numbers, obtained through the descending factorial without induction: Nat.descFactorial_eq_factorial_mul_choose (descFactorial = k!·choose) chained with Nat.descFactorial_eq_prod_range (descFactorial = ∏(n-i)) gives k!·C(n+k,k) = ∏_{i<k}(n+k-i) for all k (figurate_factorial_closed_form); specializing to k=3,4 and evaluating the short products yields 6·C(n+2,3) = n(n+1)(n+2) and 24·C(n+3,4) = n(n+1)(n+2)(n+3), with the division forms following by omega. (2) The running-total identities: ∑_{m≤n} C(m+1,2) = C(n+2,3) and ∑_{m≤n} C(m+2,3) = C(n+3,4) come from the hockey stick over range (n+1) after Finset.sum_range_succ' peels the vanishing head terms (once for the triangular sum, twice for the tetrahedral sum). Composing (2) with (1) gives the partial-sum polynomial closed forms directly.",
+    "keyInsights": [
+      "The parent's ∑_{m≤n} T_m = C(n+2,3) becomes a genuine closed form only once the tetrahedral point value C(n+2,3) = n(n+1)(n+2)/6 is supplied; composing the hockey-stick sum with the point closed form is what turns the running total into a polynomial in n.",
+      "The running-total tower continues cleanly: peeling TWO vanishing head terms C(0,3) = C(1,3) = 0 with Finset.sum_range_succ' turns the column-3 hockey stick into ∑_{m≤n} Te_m = C(n+3,4), the sum of tetrahedral numbers equalling the pentatope number — the next rung the parent did not state.",
+      "The point closed forms come here from the DESCENDING factorial, the mirror of the sibling oq-06-oq-02's ascending-factorial route: descFactorial = k!·choose composed with descFactorial = ∏(n-i) gives k!·C(n+k,k) = ∏_{i<k}(n+k-i) with no induction, and the two routes cross-check the same tetrahedral and pentatope values.",
+      "Every partial sum is exhibited twice — as a binomial coefficient (the running-total identity) and as a degree-(k+1) polynomial (the closed form) — making the Pythagorean 'each layer is the running total of the next' literal at both levels."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Follow-Up Question and Method",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Header stating the follow-up to OQ-06: give the hockey-stick partial sums polynomial closed forms and extend the running-total tower one rung. Explains the descending-factorial route to the supporting point closed forms and cross-references sibling oq-06-oq-02 (ascending-factorial point forms) and the parent."
+    },
+    {
+      "id": "hockey-stick",
+      "title": "Hockey-Stick Identity (Interval and Range Forms)",
+      "startLine": 53,
+      "endLine": 74,
+      "summary": "hockey_stick_Icc and hockey_stick_range: ∑_{m=k}^{n} C(m,k) = C(n+1,k+1) from Nat.sum_Icc_choose, transported to Finset.range (n+1) via Finset.sum_subset and the vanishing of C(m,k) for m < k."
+    },
+    {
+      "id": "general-closed-form",
+      "title": "The Induction-Free Figurate Closed Form (Descending Factorial)",
+      "startLine": 76,
+      "endLine": 87,
+      "summary": "figurate_factorial_closed_form: k!·C(n+k,k) = ∏_{i<k}(n+k-i) for every dimension k, two rewrites from Nat.descFactorial_eq_factorial_mul_choose and Nat.descFactorial_eq_prod_range. The mirror of the sibling's ascending-factorial identity."
+    },
+    {
+      "id": "descending-factorials",
+      "title": "Evaluating the Short Descending Factorials",
+      "startLine": 89,
+      "endLine": 107,
+      "summary": "descFactorial_three: (n+2).descFactorial 3 = n(n+1)(n+2) and descFactorial_four: (n+3).descFactorial 4 = n(n+1)(n+2)(n+3), unfolding the finite product via Finset.prod_range_succ and closing by ring."
+    },
+    {
+      "id": "point-closed-forms",
+      "title": "Point Closed Forms (Tetrahedral and Pentatope)",
+      "startLine": 109,
+      "endLine": 140,
+      "summary": "tetrahedral_mul_closed_form / tetrahedral_closed_form (6·C(n+2,3) = n(n+1)(n+2); C(n+2,3) = n(n+1)(n+2)/6) and pentatope_mul_closed_form / pentatope_closed_form (24·C(n+3,4) = …; C(n+3,4) = …/24). Supporting lemmas coinciding with sibling oq-06-oq-02's S_three_closed / S_four_closed, obtained here via the descending factorial."
+    },
+    {
+      "id": "partial-sum-closed-forms",
+      "title": "Polynomial Closed Forms of the Hockey-Stick Partial Sums",
+      "startLine": 142,
+      "endLine": 176,
+      "summary": "The main results. sum_triangular_eq_tetrahedral (∑ T_m = C(n+2,3)) and its closed form sum_triangular_closed_form = n(n+1)(n+2)/6; the new rung sum_tetrahedral_eq_pentatope (∑ Te_m = C(n+3,4)) and its closed form sum_tetrahedral_closed_form = n(n+1)(n+2)(n+3)/24, via Finset.sum_range_succ' peeling vanishing head terms composed with the point closed forms."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 178,
+      "endLine": 186,
+      "summary": "Concrete kernel-decide checks: ∑_{m<5} T_m = 20 = 4·5·6/6; ∑_{m<5} Te_m = 35 = 4·5·6·7/24 = C(7,4)."
+    }
+  ],
+  "conclusion": {
+    "summary": "13 theorems, 0 sorries, 0 axioms. The hockey-stick partial sums are given polynomial closed forms — ∑_{m≤n} T_m = n(n+1)(n+2)/6 and ∑_{m≤n} Te_m = n(n+1)(n+2)(n+3)/24 — and the running-total tower is extended one rung with ∑_{m≤n} Te_m = C(n+3,4) (sum of tetrahedral numbers = pentatope). The supporting point closed forms are derived through the descending factorial, mirroring the sibling oq-06-oq-02's ascending-factorial route.",
+    "implications": "The parent's running-total identity ∑ T_m = C(n+2,3) and the sibling's point closed forms are here combined into the natural end product: each simplicial partial sum as an explicit polynomial in n, plus the next tower rung. The recipe — hockey stick over range (n+1), peel vanishing head terms with sum_range_succ', compose with the descending-factorial point closed form — extends verbatim to higher columns, giving ∑ (k-dim figurate) = ((k+1)-dim figurate) with its degree-(k+2) polynomial closed form for any k.",
+    "openQuestions": [
+      "Does the running-total-plus-closed-form pattern package uniformly in the column index k as a single Lean statement ∑_{m≤n} C(m+k-1,k) = C(n+k,k+1) = (∏_{i≤k}(n+i))/((k+1)!), rather than one rung at a time?",
+      "Do the alternating partial sums ∑_{m≤n} (-1)^m C(m+2,3) admit comparable closed forms, or does the sign break the hockey-stick telescoping that collapses the plain sums?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-06",
+      "relationship": "parent — proves the hockey-stick identity and ∑_{m≤n} T_m = C(n+2,3) in binomial form; this entry supplies the partial sums' polynomial closed forms and the next running-total rung"
+    },
+    {
+      "targetId": "combinations-formula-oq-06-oq-02",
+      "relationship": "sibling — supplies the figurate point closed forms C(n+2,3) = n(n+1)(n+2)/6 etc. via the ascending factorial; this entry re-derives them through the mirror descending factorial and uses them to close the partial sums"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **combinations-formula-oq-06-oq-03**: gives the hockey-stick partial sums their own **polynomial closed forms** and extends the figurate running-total tower one rung further.

- `proofs/Proofs/CombinationsFormulaOQ06OQ03.lean` — 187 lines, 13 theorems, **0 sorries, 0 axioms** (`#print axioms` reports only `propext, Classical.choice, Quot.sound`; concrete checks use kernel `decide`, not `native_decide`).
- `src/data/proofs/combinations-formula-oq-06-oq-03/` — meta.json + annotations.json.

## Context

- The **parent** (`combinations-formula-oq-06`) proves `∑_{m≤n} C(m+1,2) = C(n+2,3)` but leaves the running total in **binomial** form.
- The **sibling** `combinations-formula-oq-06-oq-02` (merged concurrently) supplies the figurate **point** closed forms `C(n+2,3) = n(n+1)(n+2)/6` etc. via the *ascending* factorial.

This entry closes the remaining gap by composing the two and adding the next rung. The hockey-stick partial-sum closed forms appear **nowhere else** in the gallery.

## New results

| Theorem | Statement |
|---|---|
| `sum_triangular_closed_form` | `∑_{m≤n} T_m = n(n+1)(n+2)/6` (cubic) |
| `sum_tetrahedral_eq_pentatope` | `∑_{m≤n} Te_m = C(n+3,4)` — **new running-total rung** |
| `sum_tetrahedral_closed_form` | `∑_{m≤n} Te_m = n(n+1)(n+2)(n+3)/24` (quartic) |
| `figurate_factorial_closed_form` | `k!·C(n+k,k) = ∏_{i<k}(n+k-i)` via the **descending** factorial (mirror of the sibling's ascending route) |

## Method

The point closed forms come from the descending factorial without induction on `n`: `Nat.descFactorial_eq_factorial_mul_choose` chained with `Nat.descFactorial_eq_prod_range`. The running-total identities come from the hockey stick over `range (n+1)` after `Finset.sum_range_succ'` peels the vanishing head terms (once for triangular, twice for tetrahedral). Composing gives the polynomial partial-sum closed forms.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CombinationsFormulaOQ06OQ03` — builds clean.
- `#print axioms` on the four headline theorems: `[propext, Classical.choice, Quot.sound]` only.
- `pnpm build` — gallery builds; entry validates with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)