### PR TITLE
Enrich Nicomachus's Theorem (oq-01): add references

### DIFF
--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-01/meta.json
@@ -97,6 +97,24 @@
       "Can the squared-triangular identity be promoted to a bijective / combinatorial proof in Lean (counting ordered pairs in an n×n grid), matching the classic visual dissection?"
     ]
   },
+  "references": [
+    {
+      "title": "Squared triangular number (Nicomachus's theorem)",
+      "url": "https://en.wikipedia.org/wiki/Squared_triangular_number"
+    },
+    {
+      "title": "Nicomachus of Gerasa, Introduction to Arithmetic (c. 100 AD), trans. M. L. D'Ooge",
+      "url": "https://archive.org/details/nicomachusofgera00nicouoft"
+    },
+    {
+      "title": "Mathlib: Finset.sum_range_id_mul_two (division-free Gauss triangular-number identity)",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/BigOperators/Intervals.html"
+    },
+    {
+      "title": "R. B. Nelsen, Proofs Without Words: Exercises in Visual Thinking (MAA, 1993) — visual dissection proofs of ∑k³ = (∑k)²",
+      "url": "https://www.jstor.org/stable/10.4169/j.ctt5hh8mw"
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "nicomachus-sum-of-cubes-oq-02",


### PR DESCRIPTION
## Enrichment pass — nicomachus-sum-of-cubes-oq-01

The entry was comprehensive (annotations, keyInsights, sections, 4 crossReferences, conclusion) but had **no `references` array**. Adds 4 accurate sources:

- Wikipedia — Squared triangular number (Nicomachus's theorem)
- Nicomachus of Gerasa, *Introduction to Arithmetic* (c. 100 AD, D'Ooge translation)
- Mathlib `Finset.sum_range_id_mul_two` module (the Gauss identity reused in the proof)
- Nelsen, *Proofs Without Words* — the visual-dissection proofs

meta.json 10.5 KB (well under cap). Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)