### PR TITLE
Enrich Telescoping Product (oq-01): add cross-references

### DIFF
--- a/src/data/proofs/telescoping-product-oq-01/meta.json
+++ b/src/data/proofs/telescoping-product-oq-01/meta.json
@@ -104,6 +104,17 @@
       "Does the same peel-and-collapse template yield a closed form for the shifted family ∏_{k=2}^{n} (1 − 1/k^m) for m ≥ 2, where the factor (k^m − 1)/k^m factors through cyclotomic-style telescoping?"
     ]
   },
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "proofId": "factorial-telescoping-sum-oq-01",
+      "relationship": "Additive telescoping analogue",
+      "description": "The telescoping SUM ∑_{k=1}^{n} k·k! = (n+1)! − 1. This entry is the multiplicative counterpart — where the factorial identity collapses a sum of consecutive differences, ∏(1−1/k²) collapses a product of consecutive ratios (k−1)/k against (k+1)/k. Together they illustrate the telescoping technique in both the additive and multiplicative monoids."
+    },
+    {
+      "proofId": "basel-problem",
+      "relationship": "Same 1/k² terms, additive",
+      "description": "Euler's Basel problem ∑ 1/k² = π²/6. It sums the reciprocal squares that this entry instead multiplies as (1 − 1/k²); the finite product here telescopes to an elementary 1/2, in sharp contrast to the transcendental value of the additive series."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `telescoping-product-oq-01` (∏(1−1/k²) = (n+1)/(2n)).

**Gap addressed:** empty `crossReferences` array.

**Added 2 accurate cross-references:**
- `factorial-telescoping-sum-oq-01` — the additive telescoping analogue (∑ k·k! = (n+1)!−1), pairing the multiplicative and additive forms of the telescoping technique.
- `basel-problem` — ∑ 1/k² = π²/6, the additive series over the same reciprocal-square terms this entry multiplies (elementary 1/2 product vs. transcendental sum).

Pure JSON-valid crossReferences addition, matching the schema of the gallery's other cross-referenced entries.