### PR TITLE
Enrich Univariate Hilbert 17 exact normalization (oq-01-01-01): add cross-references

### DIFF
--- a/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01-oq-01/meta.json
@@ -168,7 +168,23 @@
       "url": "https://www.ams.org/books/conm/253/"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "hilbert-17-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: the degree-sharp Fejér–Riesz upper bound 2·deg u ≤ deg p. This entry answers that file's first open question, sharpening the symmetric ≤ bound to the exact normalization deg v < deg u with 2·deg u = deg p, and adds the even-degree and positive-leading-coefficient corollaries."
+    },
+    {
+      "targetId": "hilbert-17-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent: the Pfister bound on the minimum number of squares. The univariate two-square strand is sharpened here from an existence/upper-bound statement to an exact-degree certificate."
+    },
+    {
+      "targetId": "hilbert-17",
+      "relationship": "related",
+      "description": "Root: Hilbert's 17th problem and Artin's theorem. The univariate case is the classical exceptional case in which polynomial (not merely rational) squares already suffice."
+    }
+  ],
   "sections": [
     {
       "id": "header",


### PR DESCRIPTION
## Enrichment pass

Adds `crossReferences` to `hilbert-17-oq-01-oq-01-oq-01`, whose sole gap was an empty cross-reference list (it already had rich meta, references, and `relatedProblems`).

Three cross-references mirror the entry's ancestry chain, with relationship types and descriptions:
- **hilbert-17-oq-01-oq-01** (extends) — direct parent; this entry answers its first open question by sharpening the symmetric 2·deg u ≤ deg p bound to the exact normalization deg v < deg u, 2·deg u = deg p, plus even-degree / positive-leading-coefficient corollaries.
- **hilbert-17-oq-01** (extends) — grandparent Pfister bound; univariate two-square strand sharpened from existence to exact-degree certificate.
- **hilbert-17** (related) — root Hilbert 17 / Artin's theorem.

All three `targetId`s verified to exist on `main`. JSON validated; data-enrichment build step processes the entry cleanly.