### PR TITLE
Enrich Univariate Hilbert 17 Fejér–Riesz degree bound (oq-01-01): add cross-references

### DIFF
--- a/src/data/proofs/hilbert-17-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-01/meta.json
@@ -164,7 +164,23 @@
       "url": "https://www.ams.org/books/conm/253/"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "hilbert-17-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the Pfister bound on the minimum number of squares for PSD polynomials. The univariate case (n=1) is the base of that hierarchy; this entry adds the sharp degree bound on the two summands."
+    },
+    {
+      "targetId": "hilbert-17",
+      "relationship": "related",
+      "description": "Grandparent: Hilbert's 17th problem and Artin's theorem. Its univariate strand is discharged by Hilbert17UnivariatePSDSOS.lean; this entry sharpens that result with the Fejér–Riesz degree bound."
+    },
+    {
+      "targetId": "hilbert-17-oq-01-oq-04",
+      "relationship": "related",
+      "description": "Cousin: the multivariate minimal-denominator certificate for the Motzkin polynomial. Both entries concern the size/structure of SOS certificates rather than mere existence — degree of the summands here, denominator there."
+    }
+  ],
   "sections": [
     {
       "id": "setup",


### PR DESCRIPTION
## Enrichment pass

Adds `crossReferences` to `hilbert-17-oq-01-oq-01` — its only gap was an empty cross-reference list (meta, references, and `relatedProblems` were already rich). The three cross-references mirror the entry's ancestry and a cousin certificate:
- **hilbert-17-oq-01** (extends) — parent Pfister bound; this entry adds the sharp degree bound on the two univariate summands.
- **hilbert-17** (related) — root Hilbert 17 / Artin's theorem.
- **hilbert-17-oq-01-oq-04** (related) — cousin multivariate minimal-denominator certificate (Motzkin).

All `targetId`s verified present on `main`; JSON validated.