### PR TITLE
Enrich Motzkin minimal-denominator certificate (hilbert-17-oq-01-oq-04): add cross-references

### DIFF
--- a/src/data/proofs/hilbert-17-oq-01-oq-04/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01-oq-04/meta.json
@@ -179,7 +179,23 @@
       "url": "https://link.springer.com/article/10.1007/BF01425532"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "hilbert-17-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the Pfister bound on the minimum number of rational-function squares. This entry exhibits the explicit minimal-denominator certificate for Motzkin and records its square count (5 over ℝ) against the Pfister optimum (4)."
+    },
+    {
+      "targetId": "hilbert-17-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Sibling: the same Motzkin rational-SOS fact with the non-minimal multiplier 4·(x²+y²+1). This entry sharpens the denominator to the minimal classical x²+y²+1 and reuses the cleared integer identity as a lemma."
+    },
+    {
+      "targetId": "hilbert-17",
+      "relationship": "related",
+      "description": "Grandparent: Artin's theorem and the Motzkin counterexample. This entry discharges the positive side concretely for Motzkin with the minimal denominator."
+    }
+  ],
   "sections": [
     {
       "id": "setup",


### PR DESCRIPTION
## Enrichment pass

Adds `crossReferences` to `hilbert-17-oq-01-oq-04` (only gap was an empty cross-reference list). Mirrors its ancestry and sibling certificate:
- **hilbert-17-oq-01** (extends) — parent Pfister bound; this entry gives the explicit minimal-denominator Motzkin certificate (5 real squares vs Pfister optimum 4).
- **hilbert-17-oq-03-oq-01** (related) — sibling with the non-minimal multiplier 4·(x²+y²+1); sharpened here to the minimal x²+y²+1.
- **hilbert-17** (related) — root Artin's theorem / Motzkin counterexample.

All `targetId`s verified present on `main`; JSON validated.