### PR TITLE
research(pentagonal-number-theorem-oq-01): sync meta counts to merged Part 16 [1589L/91thm]

### DIFF
--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -13,9 +13,9 @@
       "PowerSeries.WithPiTopology"
     ],
     "namespace": "PentagonalNumberTheoremOQ01",
-    "lineCount": 1559,
+    "lineCount": 1589,
     "axiomCount": 0,
-    "theoremCount": 90,
+    "theoremCount": 91,
     "definitionCount": 12,
     "path": "Proofs/PentagonalNumberTheoremOQ01.lean",
     "sorries": 0
@@ -90,9 +90,9 @@
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,
-    "lineCount": 1559,
+    "lineCount": 1589,
     "assumptions": "None counted: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. pentSeriesCoeff is a noncomputable def using Classical.choice (a foundational axiom that the project's axiom policy does not count toward axiomCount). The genFun bridges genFun_pent_eq_tprod, coeff_genFun_pent and the two composed tprod headlines coeff_tprod_pent, coeff_tprod_pent_eq_evenOdd_diff each #print axioms to [propext, Classical.choice, Quot.sound] \u2014 only the standard foundational axioms, none counted. Machine-verified \u2014 the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, 7743 jobs, exit 0).",
-    "theoremCount": 90,
+    "theoremCount": 91,
     "definitionCount": 12
   },
   "overview": {


### PR DESCRIPTION
## Summary

Small metadata sync. PR #31885 merged Parts 15–16 into the parent Lean file (`Proofs/PentagonalNumberTheoremOQ01.lean` is now **1589 lines / 91 theorems**, including `franklinMoveA_franklinMoveB_canonical`), but `meta.json` still recorded the pre-Part-16 counts (1559 / 90). This aligns both count blocks (`meta` and `leanFile`) with the merged source.

**Part 16** (`franklinMoveA_franklinMoveB_canonical`) proves the Move-B branch of Franklin's involution is self-inverse when its reverse-move parameters are read **canonically** off the image as `min'` (Part 15) and `max'` (Part 14) — the first branch of the involution's bijectivity, docker-build verified `✔ Built ...OQ01` (7743 jobs), 0-axiom / 0-sorry / no `native_decide`.

No `.lean` changes — the file already on `main` is the verified source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)