### PR TITLE
seeker: fill 2 broken pool candidates + skip 1 moonshot

### DIFF
--- a/research/problems/feuerbachs-theorem-oq-02-murakami-oq-01/problem.md
+++ b/research/problems/feuerbachs-theorem-oq-02-murakami-oq-01/problem.md
@@ -1,0 +1,98 @@
+# Problem: Grace's Theorem Beyond the Trirectangular Tetrahedron
+
+**Slug**: feuerbachs-theorem-oq-02-murakami-oq-01
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The parent proof verifies **Grace's theorem (the 3D Feuerbach theorem)** for the
+**trirectangular** tetrahedron: there is a single sphere through the three
+vertices $A, B, C$ opposite the right-angle vertex $D$ that is internally
+tangent to both the insphere and the $D$-exsphere, with a rational centre
+$\Theta$ and rational radius $R$.
+
+This problem asks to **extend the tangency result beyond the trirectangular
+class** — to a broader family such as the **orthocentric** tetrahedra (those
+whose four altitudes are concurrent) or the **isodynamic** tetrahedra — and, in
+the fully general case, to characterize exactly which tetrahedra admit the
+Grace tangent sphere.
+
+### Plain Language
+
+For the special "corner" (trirectangular) tetrahedron, the gallery already
+proves a clean Feuerbach-type tangency with rational data. Real tetrahedra are
+more general. The question is how far the tangency survives: does an analogous
+sphere, tangent to both the insphere and an exsphere, exist for orthocentric
+tetrahedra? For general tetrahedra? Identifying the right hypothesis and proving
+(or formally refuting with a witness) the tangency for the next class up is the
+goal.
+
+### Why This Matters
+
+The planar Feuerbach theorem (the nine-point circle is tangent to the incircle
+and excircles) is a gem of classical geometry; its 3D analogue (Grace's theorem)
+is far less standard and barely formalized. Pushing the verified case from the
+trirectangular corner tetrahedron to a genuinely non-degenerate family is the
+natural next increment and probes how much of the elegant planar tangency
+persists in three dimensions.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `feuerbachs-theorem-oq-02-murakami`
+  (`Proofs/StatementOnly_FeuerbachOQ02Murakami_GraceTrirectangular.lean`):
+  for the trirectangular tetrahedron a single sphere through $A, B, C$ is
+  internally tangent to both the insphere and the $D$-exsphere, with rational
+  centre and radius despite the irrational radii of the tangent spheres
+  (0 sorry, 0 axiom).
+- Planar Feuerbach theorem and its supporting circle/tangency machinery live in
+  the `feuerbachs-theorem*` gallery family.
+
+### What's Still Open
+
+- An analogous tangency statement for **orthocentric** tetrahedra.
+- A characterization of which tetrahedra admit the Grace tangent sphere.
+- Whether rational centre/radius data persists outside the trirectangular case
+  (likely not — expect algebraic-number data).
+
+### Our Goal
+
+Formalize a Grace-type tangency for at least one class strictly larger than the
+trirectangular tetrahedra (target: orthocentric or isodynamic), or, failing a
+positive result, produce a concrete tetrahedron witnessing the **failure** of
+the tangency to sharpen the boundary of validity.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| feuerbachs-theorem-oq-02-murakami | Trirectangular Grace tangency (parent) | sphere tangency, coordinate geometry |
+| feuerbachs-theorem | Planar Feuerbach tangency, nine-point circle | incircle/excircle tangency |
+| feuerbachs-theorem-defs | Circle/sphere and tangency definitions | EuclideanGeometry, distances |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Coordinate computation for orthocentric tetrahedra**: Place an orthocentric
+   tetrahedron in coordinates, compute insphere / exsphere centres and radii,
+   and search for a sphere through one face internally tangent to both.
+   - Risk: The algebra is heavier than the trirectangular case; radii become
+     irrational and the tangent-sphere data may not be rational.
+2. **Invariant / reduction argument**: Identify the geometric invariant that made
+   the trirectangular case work (right-angle corner) and isolate the minimal
+   hypothesis it can be relaxed to.
+   - Risk: May reveal the tangency is special to the trirectangular class,
+     turning the problem into a sharp counterexample hunt.
+
+### Key Difficulties
+
+- 3D tangency computations are algebraically heavy and Mathlib's spherical
+  tangency API is thin compared to the planar circle API.
+- The rational-data phenomenon is likely special to the trirectangular case;
+  the general statement may need algebraic (non-rational) centres and radii.

--- a/research/problems/friendship-theorem-oq-01-oq-02/problem.md
+++ b/research/problems/friendship-theorem-oq-01-oq-02/problem.md
@@ -1,0 +1,100 @@
+# Problem: Complete the Friendship Theorem — the Non-Regular Case
+
+**Slug**: friendship-theorem-oq-01-oq-02
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let $G$ be a finite simple graph in which every two distinct vertices have
+**exactly one** common neighbour (the friendship condition). Then $G$ has a
+**universal vertex** (a vertex adjacent to all others), and hence $G$ is a
+windmill graph — a collection of triangles sharing one common vertex.
+
+The parent proof `FriendshipTheoremOQ01` already establishes the **regular
+case**: every $k$-regular friendship graph satisfies $k = 2$, so it is the
+triangle $K_3$. The remaining piece is:
+
+$$
+G \text{ friendship graph} \;\Longrightarrow\; G \text{ is regular} \ \text{OR}\ G \text{ has a universal vertex}.
+$$
+
+Combined with the parent, this yields the full Erdős–Rényi–Sós theorem.
+
+### Plain Language
+
+The classical proof of the Friendship Theorem splits into two parts. The hard
+spectral part — "if the graph is regular then $k=2$" — is already formalized in
+`FriendshipTheoremOQ01.lean`. This problem asks for the *combinatorial* part:
+show that a friendship graph is either regular or contains a vertex joined to
+everyone. The standard argument counts common neighbours to prove that any two
+**non-adjacent** vertices have the same degree; a short case analysis then forces
+either global regularity or the existence of a universal vertex. Assembling this
+with the parent gives a complete, axiom-free formal proof of the whole theorem.
+
+### Why This Matters
+
+The Friendship Theorem (Erdős–Rényi–Sós, 1966) is a landmark combinatorial
+result and a standard test case for formalization because its usual proof mixes
+spectral graph theory with elementary counting. The spectral half is already in
+the gallery with 0 axioms and 0 sorries; completing the combinatorial half
+closes the gap and delivers the full theorem, not just its regular case.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `friendship-theorem-oq-01` (`Proofs/FriendshipTheoremOQ01.lean`):
+  every $k$-regular friendship graph has $k = 2$ and is $K_3$, proved via
+  characteristic-polynomial identities, the Weinstein–Aronszajn formula, and a
+  prime-divisibility argument — **without** the spectral theorem for symmetric
+  matrices (0 axioms, 0 sorries, 84 theorems).
+- Base entry `friendship-theorem`: statement and definitions of the friendship
+  condition and the windmill/universal-vertex structure.
+
+### What's Still Open
+
+- The **non-regularity step**: two non-adjacent vertices in a friendship graph
+  have equal degree.
+- The case analysis assembling "regular or universal vertex".
+- The **combination**: chaining the non-regular reduction into the parent's
+  regular result to obtain the full theorem.
+
+### Our Goal
+
+Formalize the combinatorial non-regularity argument in Lean 4 and combine it
+with `FriendshipTheoremOQ01` to state and prove the full Friendship Theorem
+(existence of a universal vertex / windmill structure), keeping the proof
+axiom-free.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| friendship-theorem-oq-01 | Regular case $k=2$ (the spectral half) | char. polynomial, Weinstein–Aronszajn, UFD in ℤ[X] |
+| friendship-theorem | Base definitions of the friendship condition | SimpleGraph, common neighbours |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Equal-degree lemma via double counting**: For non-adjacent $u, v$, count
+   paths of length 2 to show $\deg u = \deg v$; propagate equality across the
+   graph.
+   - Risk: The "counting common friends" bijection needs care in Mathlib's
+     `SimpleGraph` API (neighbor finsets, `Finset.card` bijections).
+2. **Contrapositive / universal vertex extraction**: Assume no universal vertex,
+   derive regularity, then invoke the parent to force $k=2$ and a contradiction
+   with non-triviality.
+   - Risk: Bookkeeping the degree-equality graph (adjacency of "same degree")
+     and its connectivity.
+
+### Key Difficulties
+
+- Translating the classical "two non-adjacent vertices have the same degree"
+  counting argument into Mathlib's `SimpleGraph` neighbor-finset API.
+- Cleanly interfacing with the parent's regular-case theorem so the final
+  statement is the full theorem, not a restatement.


### PR DESCRIPTION
## Seeker pool remediation (2026-06-30)

Routine seeker cycle. Pool depth was nominally 24 available but a quality scan found the effective usable free pool was below threshold: 3 'available' candidates had **no problem.md** (a researcher claiming them gets nothing to work from), and one was a moonshot.

### Changes
- **Fill** `friendship-theorem-oq-01-oq-02/problem.md` — complete the Friendship Theorem via the combinatorial non-regularity / universal-vertex step (parent `friendship-theorem-oq-01` already proved the regular case ⟹ k=2). Significance 7.
- **Fill** `feuerbachs-theorem-oq-02-murakami-oq-01/problem.md` — extend Grace's 3D Feuerbach tangency beyond the trirectangular tetrahedron (parent verifies the trirectangular case).
- **Skip** `abel-ruffini-oq-08` (pool DB only, gitignored) — moonshot: formalizing the Arnold–Khovanskii topological/monodromy proof of Abel–Ruffini is not autonomous-tractable.

Both filled stubs pass `validate-seeker-stubs.ts` (no template placeholders). After remediation the effective free pool is 15 genuinely-usable problems, all with a filled problem.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)