### PR TITLE
research(feuerbachs-theorem-oq-04): internal-tangency full tangent-point spec [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04.lean
@@ -545,4 +545,24 @@ theorem externallyTangent_tangent_point_spec {O₁ O₂ : E}
     (by rw [← Real.cos_sub, show ρ₁ - (ρ₁ + ρ₂) = -ρ₂ from by ring, Real.cos_neg])
     hρ₁0 (by linarith) hρ₂0 (by linarith)
 
+/-- **Tangent point — full specification (internal case).**  For two internally tangent
+spherical circles with `0 ≤ ρ₂`, `ρ₁ ≤ π`, `0 < ρ₁ − ρ₂` and `ρ₁ − ρ₂ < π`, the unique point
+of contact lies on the geodesic through the centres and is at spherical distance `ρ₁` from
+`O₁` and `ρ₂` from `O₂` — the internal analogue of `externallyTangent_tangent_point_spec`.
+Internal tangency puts the centres at spherical distance `ρ₁ − ρ₂` (the smaller circle sits
+inside the larger, touching from within), and the addition law degenerates to
+`cos ρ₂ = cos ρ₁ cos(ρ₁−ρ₂) + sin ρ₁ sin(ρ₁−ρ₂)` since `ρ₁ − (ρ₁−ρ₂) = ρ₂`.  The remaining
+range bounds `0 ≤ ρ₁` and `ρ₂ ≤ π` are automatic from `0 < ρ₁ − ρ₂` and `ρ₁ ≤ π`. -/
+theorem internallyTangent_tangent_point_spec {O₁ O₂ : E}
+    (h₁ : OnSphere O₁) (h₂ : OnSphere O₂) {ρ₁ ρ₂ : ℝ}
+    (htan : InternallyTangent O₁ ρ₁ O₂ ρ₂)
+    (hρ₂0 : 0 ≤ ρ₂) (hρ₁pi : ρ₁ ≤ Real.pi) (hpos : 0 < ρ₁ - ρ₂) (hlt : ρ₁ - ρ₂ < Real.pi) :
+    ∃ P : E, sCircle O₁ ρ₁ ∩ sCircle O₂ ρ₂ = {P} ∧
+      P ∈ Submodule.span ℝ ({O₁, O₂} : Set E) ∧
+      sdist P O₁ = ρ₁ ∧ sdist P O₂ = ρ₂ := by
+  have hd : sdist O₁ O₂ = ρ₁ - ρ₂ := by rw [htan]; exact abs_of_pos hpos
+  exact sphere_slerp_tangent_point_spec h₁ h₂ hd hpos hlt
+    (by rw [← Real.cos_sub, show ρ₁ - (ρ₁ - ρ₂) = ρ₂ from by ring])
+    (by linarith) hρ₁pi hρ₂0 (by linarith)
+
 end FeuerbachsTheoremOQ04

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -312,3 +312,30 @@ single commit. knowledge.md likewise a clean superset (append-only).
 3. Optional: tangent geodesic at P is ⊥ the centre geodesic (the metric "tangent line" fact).
 
 BLOCKER (hyperbolic side, unchanged): no Mathlib hyperbolic metric — spherical model only.
+
+## Session 2026-06-30 (researcher-2): internal-tangency full tangent-point spec [VERIFIED, 0-axiom]
+
+The metric layer is COMPLETE (`sdist_isMetric` at line ~195 now on main — the once-"hard frontier"
+spherical triangle inequality is done via Mathlib's `InnerProductGeometry.angle_le_angle_add_angle`,
+transported by `sdist_eq_angle`). Tangent-point theory has external+internal existence and uniqueness,
+plus the FULL external spec (`externallyTangent_tangent_point_spec`: contact point on the geodesic
+through the centres, at spherical distances ρ₁,ρ₂). The internal case stopped at
+`internallyTangent_unique_common_point` — no full spec. **Filled that symmetry gap.**
+
+- `internallyTangent_tangent_point_spec` (VERIFIED, docker `[7744/7744]`, `#print axioms` =
+  [propext,Classical.choice,Quot.sound], 0-axiom). Specializes `sphere_slerp_tangent_point_spec`
+  with d = ρ₁−ρ₂ (internal tangency ⟹ centres at spherical distance ρ₁−ρ₂ via `abs_of_pos`); the
+  addition law `cos ρ₂ = cos ρ₁ cos d + sin ρ₁ sin d` degenerates because ρ₁−(ρ₁−ρ₂)=ρ₂
+  (`rw [← Real.cos_sub, show ρ₁-(ρ₁-ρ₂)=ρ₂ from by ring]`, no `Real.cos_neg` unlike external's
+  ρ₁+ρ₂ case). Range bounds 0≤ρ₁ and ρ₂≤π auto from 0<ρ₁−ρ₂, ρ₁≤π via `linarith`.
+  Signature: `(hρ₂0 : 0≤ρ₂) (hρ₁pi : ρ₁≤π) (hpos : 0<ρ₁−ρ₂) (hlt : ρ₁−ρ₂<π)`.
+
+File now 568L/29thm/6def, 0-sorry/0-axiom. Shipped as PR (no gallery entry exists for this OQ-child;
+tracked via research json + this knowledge.md). GOTCHA: fresh /tmp worktree's `proofs/` got WIPED
+mid-session (empty dir, likely infra/concurrent cleanup after a failed git-128 mathlib-clone) losing an
+uncommitted edit — recreate worktree + COMMIT before building.
+
+### Next steps (unchanged, all hard/construction-heavy)
+1. Tangent-point uniqueness geodesic argument refinements.
+2. Spherical incircle + nine-point circle constructions, then the spherical Feuerbach tangency (the
+   genuine open target — multi-session).

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -92,7 +92,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.293Z",
-  "lastUpdate": "2026-06-28T11:55:00.000Z",
+  "lastUpdate": "2026-06-30",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -385,8 +385,8 @@
     {
       "path": "Proofs/FeuerbachsTheoremOQ04.lean",
       "filename": "FeuerbachsTheoremOQ04.lean",
-      "lineCount": 112,
-      "theoremCount": 9,
+      "lineCount": 568,
+      "theoremCount": 29,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Completes the internal/external symmetry of the spherical tangent-point theory in `FeuerbachsTheoremOQ04.lean`. The **external** case already had a full specification (`externallyTangent_tangent_point_spec`): the contact point of two externally tangent spherical circles lies on the geodesic through the centres and sits at spherical distances `ρ₁` and `ρ₂` from them. The **internal** case stopped at `internallyTangent_unique_common_point` — existence + uniqueness, but not the distance specification.

Adds `internallyTangent_tangent_point_spec`: for internally tangent circles (`0 ≤ ρ₂`, `ρ₁ ≤ π`, `0 < ρ₁ − ρ₂ < π`), the unique contact point lies on the line of centres at spherical distances `ρ₁` and `ρ₂`. It specializes the shared core `sphere_slerp_tangent_point_spec` with `d = ρ₁ − ρ₂` (internal tangency places the centres at spherical distance `ρ₁ − ρ₂`), the spherical addition law degenerating via `ρ₁ − (ρ₁ − ρ₂) = ρ₂`. The remaining range bounds `0 ≤ ρ₁`, `ρ₂ ≤ π` are automatic.

## Verification

- `docker-build.sh Proofs.FeuerbachsTheoremOQ04` → `✔ [7744/7744] Built`, exit 0.
- `#print axioms internallyTangent_tangent_point_spec` = `[propext, Classical.choice, Quot.sound]` — **0 counted axioms, 0 sorry.**
- No gallery entry exists for this OQ-child research problem; progress tracked in the research JSON + knowledge.md (both synced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)