### PR TITLE
Enrich Erdős 309 axiom-free upper bound (erdos-309-incomplete-01): add cross-references

### DIFF
--- a/src/data/proofs/erdos-309-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-309-incomplete-01/meta.json
@@ -133,5 +133,12 @@
       "Reprove the deep Yokota lower bound F(N) ≥ log N − O(log log N) axiom-free, replacing the parent's axiom yokota_lower_bound_1997 and completing the F(N) = Θ(log N) result without assumptions.",
       "Sharpen the additive constant: the truth is F(N) = log N + γ + o(1) (γ the Euler–Mascheroni constant); formalize the refined asymptotic, not merely the +2 bound."
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-309",
+      "relationship": "extends",
+      "description": "Parent formalization (axiomatizes the hard Yokota lower bound; this file proves the easy upper direction axiom-free). The parent file no longer builds against Mathlib 4.26.0 due to removed imports, so this contribution is self-contained."
+    }
+  ]
 }


### PR DESCRIPTION
## Enrichment pass

Adds `crossReferences` (only gap was an empty list), from the entry's `relatedProblems`:
- **erdos-309** (extends) — parent formalization axiomatizing the hard Yokota lower bound; this file proves the easy upper direction axiom-free and self-contained.

`targetId` verified present on `main`; JSON validated.