### PR TITLE
Enrich Erdős #1040 oq-03 (EHP convex): add references + 4th key insight

### DIFF
--- a/src/data/proofs/erdos-1040-oq-03/meta.json
+++ b/src/data/proofs/erdos-1040-oq-03/meta.json
@@ -124,7 +124,8 @@
     "keyInsights": [
       "**Linear lemniscates are discs**: {|z - a| < 1} = B(a, 1) is the unique degree at which the sublevel set is itself convex and has a clean closed-form measure π",
       "**μ(F) is universally bounded above by π**: the degree-1 witness makes finiteness of μ(F) elementary and independent of the transfinite diameter — the easy counterpart to the open lower-bound conjecture μ(F) = 0 at capacity ≥ 1",
-      "**Convex roots do not give convex lemniscates**: already the quadratic z² - 1, with both roots in [-1, 1], has a non-convex sublevel set (the two lobes around ±1 pinch at the saddle 0), so the EHP-to-convex-sets program cannot proceed by convexity of sublevel sets"
+      "**Convex roots do not give convex lemniscates**: already the quadratic z² - 1, with both roots in [-1, 1], has a non-convex sublevel set (the two lobes around ±1 pinch at the saddle 0), so the EHP-to-convex-sets program cannot proceed by convexity of sublevel sets",
+      "**Non-convexity is organized by the critical points of f.** The lemniscate {|f| < 1} splits into a lobe around each root, and the lobes are separated at the critical points where f' = 0. For z² − 1 the critical point is 0, with |f(0)| = 1 — exactly the saddle on the boundary that the segment [−1, 1] must cross, forcing non-convexity. The obstruction is therefore generic to every degree ≥ 2 with separated roots, not special to this example, and it ties the failure of convexity to the count of connected components raised in the open questions."
     ],
     "prerequisites": [
       "The EHP quantity μ(F) and the sublevel (lemniscate) set {z : |f(z)| < 1}",
@@ -145,6 +146,24 @@
       "Determine sharpness of μ(F) ≤ π and the asymptotics of μ(F) as degree or root-spread grows?"
     ]
   },
+  "references": [
+    {
+      "title": "Erdős Problem #1040",
+      "url": "https://www.erdosproblems.com/1040"
+    },
+    {
+      "title": "P. Erdős, F. Herzog, G. Piranian, \"Metric properties of polynomials\" (J. Analyse Math. 6, 1958)",
+      "url": "https://link.springer.com/article/10.1007/BF02790232"
+    },
+    {
+      "title": "Transfinite diameter / logarithmic capacity",
+      "url": "https://en.wikipedia.org/wiki/Transfinite_diameter"
+    },
+    {
+      "title": "Polynomial lemniscate {z : |f(z)| < 1}",
+      "url": "https://en.wikipedia.org/wiki/Lemniscate"
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "erdos-1040",


### PR DESCRIPTION
## Enrichment pass — erdos-1040-oq-03

Two concrete gaps filled (entry already had sections, mathlibDependencies, crossReferences, conclusion):

- **Added `references`** (previously absent): Erdős Problem #1040, the Erdős–Herzog–Piranian (1958) paper, transfinite diameter/logarithmic capacity, and polynomial lemniscates.
- **Added a 4th key insight** (was 3): the degree-2 non-convexity is organized by the *critical points* of $f$ — the lobes of $\{|f|<1\}$ pinch where $f'=0$; for $z^2-1$ that saddle is $0$ with $|f(0)|=1$ — making the obstruction generic to every degree ≥ 2 with separated roots and tying it to the component-count open question.

meta.json 15.1 KB (well under cap). Build validated. (Note: this research entry's Lean kernel build is gated by the deployer per its own `assumptions` note; this PR only edits meta.json.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)