### PR TITLE
research(basel-problem-oq-13-oq-02): higher even lambda values λ(6)=π⁶/960, λ(8)=17π⁸/161280 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BaselProblemOQ13OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ13OQ02.lean
@@ -86,17 +86,17 @@ Instantiate the general even-zeta formula `hasSum_zeta_nat` at `k = 3` and `k = 
 
 /-- **Sixth zeta value**: `∑_n 1/n⁶ = π⁶/945`. -/
 theorem hasSum_zeta_six : HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 6) (π ^ 6 / 945) := by
-  convert hasSum_zeta_nat (k := 3) (by norm_num) using 2
-  · norm_num
-  · rw [show (2 * 3 : ℕ) = 6 from rfl, bernoulli_six]
-    norm_num [Nat.factorial]
+  convert hasSum_zeta_nat (k := 3) (by norm_num) using 1
+  rw [bernoulli_six]
+  push_cast [Nat.factorial]
+  ring
 
 /-- **Eighth zeta value**: `∑_n 1/n⁸ = π⁸/9450`. -/
 theorem hasSum_zeta_eight : HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 8) (π ^ 8 / 9450) := by
-  convert hasSum_zeta_nat (k := 4) (by norm_num) using 2
-  · norm_num
-  · rw [show (2 * 4 : ℕ) = 8 from rfl, bernoulli_eight]
-    norm_num [Nat.factorial]
+  convert hasSum_zeta_nat (k := 4) (by norm_num) using 1
+  rw [bernoulli_eight]
+  push_cast [Nat.factorial]
+  ring
 
 /-! ## Step 3: the even parts, `2^(−s) ζ(s)` -/
 

--- a/proofs/Proofs/BaselProblemOQ13OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ13OQ02.lean
@@ -1,0 +1,199 @@
+/-
+  # Higher even lambda values: λ(6) = π⁶/960 and λ(8) = 17π⁸/161280
+  # (basel-problem-oq-13-oq-02)
+
+  ## The Open Question
+
+  The parent entry `basel-problem-oq-13` formalizes the *lambda value*
+  λ(4) = ∑_{k≥0} 1/(2k+1)⁴ = π⁴/96 by the parity split λ(s) = (1 − 2^(−s)) ζ(s),
+  reusing Mathlib's `hasSum_zeta_four` (ζ(4) = π⁴/90). The follow-up question asks to
+  **generalize the parity-split template to the full lambda value** λ(s) = (1 − 2^(−s)) ζ(s)
+  for higher even s, packaging λ(6) and λ(8) from Mathlib's general even-zeta formula
+  `hasSum_zeta_nat` by the *same* even/odd `HasSum` split.
+
+  ## What is new here
+
+  Mathlib provides ζ(2) and ζ(4) explicitly (`hasSum_zeta_two`, `hasSum_zeta_four`),
+  but nothing higher as a standalone `HasSum`. The general formula
+
+      ζ(2k) = ∑_n 1/n^(2k) = (−1)^(k+1) · 2^(2k−1) · π^(2k) · B_(2k) / (2k)!
+
+  is `hasSum_zeta_nat`, phrased through the Bernoulli numbers `bernoulli (2k)`.
+  Mathlib only computes the Bernoulli numbers up to `bernoulli' 4`, so to instantiate
+  the formula at k = 3 and k = 4 we first compute
+
+      bernoulli 6 = 1/42,   bernoulli 8 = −1/30
+
+  from the defining recurrence. These give
+
+      ζ(6) = π⁶/945,        ζ(8) = π⁸/9450.
+
+  ## The parity split
+
+  Splitting ζ(s) into even- and odd-indexed parts via `HasSum.even_add_odd`:
+
+    * even part:  ∑_k 1/(2k)ˢ = 2^(−s) ζ(s),
+    * odd part:   λ(s) = ∑_k 1/(2k+1)ˢ = ζ(s) − 2^(−s) ζ(s) = (1 − 2^(−s)) ζ(s).
+
+  For s = 6:  λ(6) = (1 − 1/64)(π⁶/945)  = (63/64)(π⁶/945) = π⁶/960.
+  For s = 8:  λ(8) = (1 − 1/256)(π⁸/9450) = (255/256)(π⁸/9450) = 17π⁸/161280.
+
+  Everything is built from `hasSum_zeta_nat` and the even/odd series split — no new
+  analytic input beyond the two Bernoulli-number computations.
+
+  ## Axiom count: 0
+-/
+
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.Tactic
+
+open Real Finset
+
+namespace BaselHigherLambda
+
+/-! ## Step 1: the Bernoulli numbers `B₆` and `B₈`
+
+Mathlib stops at `bernoulli' 4`; we extend the table to the two values we need,
+using the defining recurrence `bernoulli'_def` and the vanishing of odd Bernoulli
+numbers `bernoulli'_eq_zero_of_odd`. -/
+
+/-- `bernoulli' 6 = 1/42`. -/
+theorem bernoulli'_six : bernoulli' 6 = 1 / 42 := by
+  have h5 : bernoulli' 5 = 0 := bernoulli'_eq_zero_of_odd (by decide) (by decide)
+  rw [bernoulli'_def]
+  norm_num [sum_range_succ, sum_range_zero, bernoulli'_zero, bernoulli'_one, bernoulli'_two,
+    bernoulli'_three, bernoulli'_four, h5, Nat.choose]
+
+/-- `bernoulli' 8 = -1/30`. -/
+theorem bernoulli'_eight : bernoulli' 8 = -1 / 30 := by
+  have h5 : bernoulli' 5 = 0 := bernoulli'_eq_zero_of_odd (by decide) (by decide)
+  have h7 : bernoulli' 7 = 0 := bernoulli'_eq_zero_of_odd (by decide) (by decide)
+  rw [bernoulli'_def]
+  norm_num [sum_range_succ, sum_range_zero, bernoulli'_zero, bernoulli'_one, bernoulli'_two,
+    bernoulli'_three, bernoulli'_four, bernoulli'_six, h5, h7, Nat.choose]
+
+/-- `bernoulli 6 = 1/42` (the even-index sign is `+`). -/
+theorem bernoulli_six : bernoulli 6 = 1 / 42 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide), bernoulli'_six]
+
+/-- `bernoulli 8 = -1/30`. -/
+theorem bernoulli_eight : bernoulli 8 = -1 / 30 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide), bernoulli'_eight]
+
+/-! ## Step 2: the zeta values ζ(6) and ζ(8)
+
+Instantiate the general even-zeta formula `hasSum_zeta_nat` at `k = 3` and `k = 4`. -/
+
+/-- **Sixth zeta value**: `∑_n 1/n⁶ = π⁶/945`. -/
+theorem hasSum_zeta_six : HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 6) (π ^ 6 / 945) := by
+  convert hasSum_zeta_nat (k := 3) (by norm_num) using 2
+  · norm_num
+  · rw [show (2 * 3 : ℕ) = 6 from rfl, bernoulli_six]
+    norm_num [Nat.factorial]
+
+/-- **Eighth zeta value**: `∑_n 1/n⁸ = π⁸/9450`. -/
+theorem hasSum_zeta_eight : HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 8) (π ^ 8 / 9450) := by
+  convert hasSum_zeta_nat (k := 4) (by norm_num) using 2
+  · norm_num
+  · rw [show (2 * 4 : ℕ) = 8 from rfl, bernoulli_eight]
+    norm_num [Nat.factorial]
+
+/-! ## Step 3: the even parts, `2^(−s) ζ(s)` -/
+
+/-- Even-indexed sixth-power sum: `∑_k 1/(2k)⁶ = π⁶/60480` (a 64-th of ζ(6)). -/
+theorem hasSum_even_zeta_six :
+    HasSum (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ 6) (π ^ 6 / 60480) := by
+  have h64 := hasSum_zeta_six.mul_left (1 / 64 : ℝ)
+  have hfe : (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ 6)
+      = (fun k : ℕ => (1 / 64 : ℝ) * (1 / (k : ℝ) ^ 6)) := by
+    funext k; push_cast; ring
+  rw [hfe]
+  convert h64 using 1
+  ring
+
+/-- Even-indexed eighth-power sum: `∑_k 1/(2k)⁸ = π⁸/2419200` (a 256-th of ζ(8)). -/
+theorem hasSum_even_zeta_eight :
+    HasSum (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ 8) (π ^ 8 / 2419200) := by
+  have h256 := hasSum_zeta_eight.mul_left (1 / 256 : ℝ)
+  have hfe : (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ 8)
+      = (fun k : ℕ => (1 / 256 : ℝ) * (1 / (k : ℝ) ^ 8)) := by
+    funext k; push_cast; ring
+  rw [hfe]
+  convert h256 using 1
+  ring
+
+/-! ## Step 4: the odd parts — the lambda values λ(6) and λ(8) -/
+
+/-- **λ(6)**: `∑_k 1/(2k+1)⁶ = π⁶/960`. Derived from `hasSum_zeta_six` by the even/odd
+    split: ζ(6) = (even part π⁶/60480) + (odd part), so the odd part is
+    π⁶/945 − π⁶/60480 = π⁶/960. -/
+theorem hasSum_odd_zeta_six :
+    HasSum (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 6) (π ^ 6 / 960) := by
+  have hodd_summable : Summable (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 6) :=
+    hasSum_zeta_six.summable.comp_injective (fun a b h => by omega)
+  have hkey : HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 6)
+      (π ^ 6 / 60480 + ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 6) := by
+    refine HasSum.even_add_odd ?_ ?_
+    · exact hasSum_even_zeta_six
+    · exact hodd_summable.hasSum
+  have hsum_eq : π ^ 6 / 60480 + ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 6 = π ^ 6 / 945 :=
+    hkey.unique hasSum_zeta_six
+  have hval : ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 6 = π ^ 6 / 960 := by linarith
+  rw [← hval]
+  exact hodd_summable.hasSum
+
+/-- **λ(8)**: `∑_k 1/(2k+1)⁸ = 17π⁸/161280`. Derived from `hasSum_zeta_eight` by the
+    even/odd split: ζ(8) = (even part π⁸/2419200) + (odd part), so the odd part is
+    π⁸/9450 − π⁸/2419200 = 17π⁸/161280. -/
+theorem hasSum_odd_zeta_eight :
+    HasSum (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 8) (17 * π ^ 8 / 161280) := by
+  have hodd_summable : Summable (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 8) :=
+    hasSum_zeta_eight.summable.comp_injective (fun a b h => by omega)
+  have hkey : HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 8)
+      (π ^ 8 / 2419200 + ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 8) := by
+    refine HasSum.even_add_odd ?_ ?_
+    · exact hasSum_even_zeta_eight
+    · exact hodd_summable.hasSum
+  have hsum_eq : π ^ 8 / 2419200 + ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 8 = π ^ 8 / 9450 :=
+    hkey.unique hasSum_zeta_eight
+  have hval : ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 8 = 17 * π ^ 8 / 161280 := by linarith
+  rw [← hval]
+  exact hodd_summable.hasSum
+
+/-! ## Step 5: `tsum` forms -/
+
+/-- `∑' k, 1/(2k+1)⁶ = π⁶/960`. -/
+theorem tsum_odd_zeta_six :
+    ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 6 = π ^ 6 / 960 :=
+  hasSum_odd_zeta_six.tsum_eq
+
+/-- `∑' k, 1/(2k+1)⁸ = 17π⁸/161280`. -/
+theorem tsum_odd_zeta_eight :
+    ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 8 = 17 * π ^ 8 / 161280 :=
+  hasSum_odd_zeta_eight.tsum_eq
+
+end BaselHigherLambda
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `bernoulli_six`         | B₆ = 1/42 |
+  | `bernoulli_eight`       | B₈ = −1/30 |
+  | `hasSum_zeta_six`       | ∑ 1/n⁶ = π⁶/945 |
+  | `hasSum_zeta_eight`     | ∑ 1/n⁸ = π⁸/9450 |
+  | `hasSum_even_zeta_six`  | ∑ 1/(2k)⁶ = π⁶/60480 |
+  | `hasSum_even_zeta_eight`| ∑ 1/(2k)⁸ = π⁸/2419200 |
+  | `hasSum_odd_zeta_six`   | λ(6) = ∑ 1/(2k+1)⁶ = π⁶/960 |
+  | `hasSum_odd_zeta_eight` | λ(8) = ∑ 1/(2k+1)⁸ = 17π⁸/161280 |
+  | `tsum_odd_zeta_six`     | ∑' k, 1/(2k+1)⁶ = π⁶/960 |
+  | `tsum_odd_zeta_eight`   | ∑' k, 1/(2k+1)⁸ = 17π⁸/161280 |
+
+  Built entirely from Mathlib's general even-zeta formula `hasSum_zeta_nat`
+  (with `bernoulli 6 = 1/42`, `bernoulli 8 = −1/30` computed from the recurrence)
+  and the even/odd series split `HasSum.even_add_odd`.
+
+  **Sorries**: 0
+  **Axioms**: 0
+-/

--- a/src/data/proofs/basel-problem-oq-13-oq-02/annotations.json
+++ b/src/data/proofs/basel-problem-oq-13-oq-02/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "ann-basel-oq13-oq02-header",
+    "proofId": "basel-problem-oq-13-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 45
+    },
+    "type": "context",
+    "title": "λ(6) and λ(8): pushing the parity split past Mathlib's zeta table",
+    "content": "The parent entry formalized λ(4) = π⁴/96 by splitting Mathlib's ζ(4) = π⁴/90 into even- and odd-indexed parts. This follow-up asks for the same at s = 6 and s = 8. The obstruction is that Mathlib supplies ζ(2) and ζ(4) explicitly but nothing higher as a standalone HasSum. The header records the plan: obtain ζ(6) = π⁶/945 and ζ(8) = π⁸/9450 from the general even-zeta formula hasSum_zeta_nat (which needs the Bernoulli numbers B₆, B₈), then reuse the identical even/odd split λ(s) = (1 − 2^(−s))ζ(s).",
+    "mathContext": "$\\lambda(s)=\\sum_{k\\ge 0}\\frac{1}{(2k+1)^s}=(1-2^{-s})\\zeta(s)$; at $s=6,8$: $\\lambda(6)=\\tfrac{63}{64}\\cdot\\tfrac{\\pi^6}{945}=\\tfrac{\\pi^6}{960}$, $\\lambda(8)=\\tfrac{255}{256}\\cdot\\tfrac{\\pi^8}{9450}=\\tfrac{17\\pi^8}{161280}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Riemann zeta at even integers",
+      "Dirichlet lambda function",
+      "Bernoulli numbers",
+      "hasSum_zeta_nat"
+    ],
+    "prerequisites": [
+      "Riemann zeta function",
+      "infinite series (HasSum/tsum)"
+    ]
+  },
+  {
+    "id": "ann-basel-oq13-oq02-bernoulli",
+    "proofId": "basel-problem-oq-13-oq-02",
+    "range": {
+      "startLine": 60,
+      "endLine": 81
+    },
+    "type": "technique",
+    "title": "Step 1: Bernoulli numbers B₆ = 1/42, B₈ = −1/30 from the recurrence",
+    "content": "Mathlib evaluates bernoulli' only up to 4 (bernoulli'_four), so the two Bernoulli inputs to Euler's ζ(2k) formula must be computed here. bernoulli'_def unfolds B_n = 1 − ∑_{k<n} C(n,k)/(n−k+1)·B_k over range n; expanding with sum_range_succ and substituting the known lower values closes B₆ and B₈ by norm_num. The odd terms B₃ = B₅ = B₇ = 0 are supplied by bernoulli'_eq_zero_of_odd. The even-index sign lemma bernoulli_eq_bernoulli'_of_ne_one then gives bernoulli 6 = 1/42 and bernoulli 8 = −1/30 with a `+` sign.",
+    "mathContext": "$B_6=\\tfrac{1}{42},\\ B_8=-\\tfrac{1}{30}$, from $B_n = 1-\\sum_{k<n}\\binom{n}{k}\\tfrac{B_k}{n-k+1}$ with $B_3=B_5=B_7=0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "bernoulli'_def",
+      "bernoulli'_eq_zero_of_odd",
+      "Bernoulli recurrence",
+      "sum_range_succ"
+    ],
+    "prerequisites": [
+      "Bernoulli numbers",
+      "finite-sum recurrences"
+    ]
+  },
+  {
+    "id": "ann-basel-oq13-oq02-zeta",
+    "proofId": "basel-problem-oq-13-oq-02",
+    "range": {
+      "startLine": 87,
+      "endLine": 99
+    },
+    "type": "technique",
+    "title": "Step 2: ζ(6) = π⁶/945 and ζ(8) = π⁸/9450 via hasSum_zeta_nat",
+    "content": "The general formula hasSum_zeta_nat gives ζ(2k) = (−1)^(k+1) 2^(2k−1) π^(2k) B_(2k) / (2k)!. Instantiating at k = 3, 4 and matching against the target closed form is `convert hasSum_zeta_nat … using 1` (the summand functions unify definitionally once 2·k reduces), leaving a scalar equation closed by rewriting the Bernoulli value and `push_cast [Nat.factorial]; ring`: 2⁵·(1/42)/6! = 1/945 and −2⁷·(−1/30)/8! = 1/9450. These standalone HasSum lemmas for ζ(6), ζ(8) are not otherwise in Mathlib.",
+    "mathContext": "$\\zeta(6)=\\tfrac{2^{5}\\pi^{6}B_6}{6!}=\\tfrac{\\pi^6}{945}$, $\\ \\zeta(8)=\\tfrac{-2^{7}\\pi^{8}B_8}{8!}=\\tfrac{\\pi^8}{9450}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "hasSum_zeta_nat",
+      "Euler's even-zeta formula",
+      "convert tactic",
+      "push_cast"
+    ],
+    "prerequisites": [
+      "Bernoulli numbers",
+      "Riemann zeta at even integers"
+    ]
+  },
+  {
+    "id": "ann-basel-oq13-oq02-even",
+    "proofId": "basel-problem-oq-13-oq-02",
+    "range": {
+      "startLine": 103,
+      "endLine": 123
+    },
+    "type": "technique",
+    "title": "Step 3: even parts π⁶/60480 and π⁸/2419200 as scaled ζ",
+    "content": "Pulling the factor 2 out of (2k)^s gives 1/(2k)^s = 2^(−s)(1/k^s), so the even-indexed subseries is exactly 2^(−s)ζ(s): a 64-th of ζ(6) and a 256-th of ζ(8). Each is a one-line HasSum.mul_left after a `funext; push_cast; ring` rewrite of the summand (valid even at k = 0, where both sides are 0 in ℝ). This is the sixth/eighth-power analogue of the sixteenth-scaling used for λ(4).",
+    "mathContext": "$\\sum_k \\tfrac{1}{(2k)^6}=\\tfrac{1}{64}\\zeta(6)=\\tfrac{\\pi^6}{60480}$, $\\ \\sum_k\\tfrac{1}{(2k)^8}=\\tfrac{1}{256}\\zeta(8)=\\tfrac{\\pi^8}{2419200}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "HasSum.mul_left",
+      "even-indexed subseries",
+      "series rescaling"
+    ],
+    "prerequisites": [
+      "infinite series",
+      "scaling of convergent sums"
+    ]
+  },
+  {
+    "id": "ann-basel-oq13-oq02-odd",
+    "proofId": "basel-problem-oq-13-oq-02",
+    "range": {
+      "startLine": 127,
+      "endLine": 162
+    },
+    "type": "key-step",
+    "title": "Step 4: λ(6) = π⁶/960 and λ(8) = 17π⁸/161280 by uniqueness",
+    "content": "Each odd subseries is summable (Summable.comp_injective with k ↦ 2k+1), so reassembling ζ(s) = even + odd via HasSum.even_add_odd and applying HasSum.unique against the Step-2 zeta value forces the odd sum. No summand is evaluated directly. For s = 6: π⁶/945 − π⁶/60480 = π⁶/960. For s = 8: π⁸/9450 − π⁸/2419200 = 17π⁸/161280 — the numerator 17 survives because 255 = 3·5·17 shares only 15 with the denominator, unlike the clean unit fraction λ(6).",
+    "mathContext": "$\\lambda(6)=\\zeta(6)-\\tfrac{\\pi^6}{60480}=\\tfrac{\\pi^6}{960}$, $\\ \\lambda(8)=\\zeta(8)-\\tfrac{\\pi^8}{2419200}=\\tfrac{17\\pi^8}{161280}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "HasSum.even_add_odd",
+      "HasSum.unique",
+      "Summable.comp_injective",
+      "Dirichlet lambda function"
+    ],
+    "prerequisites": [
+      "even/odd decomposition of series",
+      "uniqueness of sums"
+    ]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-13-oq-02/index.ts
+++ b/src/data/proofs/basel-problem-oq-13-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BaselProblemOQ13OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const baselProblemOq13Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const baselProblemOq13Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const baselProblemOq13Oq02Data: ProofData = {
+  proof: baselProblemOq13Oq02Proof,
+  annotations: baselProblemOq13Oq02Annotations,
+}

--- a/src/data/proofs/basel-problem-oq-13-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-13-oq-02/meta.json
@@ -1,0 +1,190 @@
+{
+  "id": "basel-problem-oq-13-oq-02",
+  "title": "Higher even lambda values: λ(6) = π⁶/960 and λ(8) = 17π⁸/161280",
+  "slug": "basel-problem-oq-13-oq-02",
+  "description": "Generalizes the parity-split template of the parent entry (λ(4) = π⁴/96) to the higher even lambda values λ(6) = ∑_{k≥0} 1/(2k+1)⁶ = π⁶/960 and λ(8) = ∑_{k≥0} 1/(2k+1)⁸ = 17π⁸/161280. Mathlib provides ζ(2) and ζ(4) explicitly but nothing higher as a standalone HasSum, so the proof first instantiates the general even-zeta formula hasSum_zeta_nat at k = 3, 4 — which requires computing the Bernoulli numbers B₆ = 1/42 and B₈ = −1/30 from the defining recurrence (Mathlib stops at bernoulli' 4) — to obtain ζ(6) = π⁶/945 and ζ(8) = π⁸/9450, then applies the same even/odd split λ(s) = (1 − 2^(−s))ζ(s) via HasSum.even_add_odd. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ13OQ02.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "series",
+      "zeta-function",
+      "zeta-values",
+      "bernoulli-numbers",
+      "basel-problem",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 199,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-30",
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_nat",
+        "description": "The general even zeta value ζ(2k) = (−1)^(k+1) 2^(2k−1) π^(2k) B_(2k) / (2k)!",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "bernoulli'_def",
+        "description": "The defining recurrence for the Bernoulli numbers, used to compute B₆ and B₈",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli'_eq_zero_of_odd",
+        "description": "Odd Bernoulli numbers greater than one vanish, killing the B₅ and B₇ terms",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "HasSum.even_add_odd",
+        "description": "Combine the even- and odd-indexed subseries into the full sum",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "Summable.comp_injective",
+        "description": "Summability of the odd-indexed subseries from summability of ζ(2k)",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      }
+    ],
+    "originalContributions": [
+      "bernoulli_six / bernoulli_eight: B₆ = 1/42 and B₈ = −1/30, computed from the defining recurrence (Mathlib only supplies bernoulli' up to 4)",
+      "hasSum_zeta_six / hasSum_zeta_eight: the standalone HasSum forms ζ(6) = π⁶/945 and ζ(8) = π⁸/9450, instantiated from hasSum_zeta_nat at k = 3, 4",
+      "hasSum_even_zeta_six / hasSum_even_zeta_eight: the even-indexed parts π⁶/60480 = ζ(6)/64 and π⁸/2419200 = ζ(8)/256",
+      "hasSum_odd_zeta_six / hasSum_odd_zeta_eight: the lambda values λ(6) = π⁶/960 and λ(8) = 17π⁸/161280 via HasSum.even_add_odd + HasSum.unique",
+      "tsum_odd_zeta_six / tsum_odd_zeta_eight: the corresponding tsum forms"
+    ],
+    "prerequisites": [
+      "General even zeta value ζ(2k) in terms of Bernoulli numbers (Mathlib hasSum_zeta_nat)",
+      "The Bernoulli-number recurrence and vanishing of odd Bernoulli numbers",
+      "Even/odd splitting of an infinite sum (HasSum.even_add_odd)",
+      "Uniqueness of sums (HasSum.unique)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Finset"
+    ],
+    "namespace": "BaselHigherLambda",
+    "path": "Proofs/BaselProblemOQ13OQ02.lean",
+    "lineCount": 199,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "Euler's 1740 evaluation ζ(2k) = (−1)^(k+1) B_(2k) (2π)^(2k) / (2·(2k)!) expresses every even zeta value as a rational multiple of π^(2k) through the Bernoulli numbers B_(2k). The odd-indexed restriction λ(s) = ∑_{k≥0} 1/(2k+1)^s is the Dirichlet lambda function, tied to ζ by λ(s) = (1 − 2^(−s))ζ(s). The parent entry basel-problem-oq-13 formalized the case s = 4 (λ(4) = π⁴/96); this follow-up carries the same template up to s = 6 and s = 8, where Mathlib no longer supplies the underlying zeta value out of the box.",
+    "problemStatement": "Formalize, with 0 sorries and 0 axioms, the higher even lambda values\n\n$$\\lambda(6) = \\sum_{k=0}^{\\infty} \\frac{1}{(2k+1)^6} = \\frac{\\pi^6}{960}, \\qquad \\lambda(8) = \\sum_{k=0}^{\\infty} \\frac{1}{(2k+1)^8} = \\frac{17\\pi^8}{161280},$$\n\nby instantiating Mathlib's general even-zeta formula `hasSum_zeta_nat` at k = 3, 4 (computing B₆ = 1/42 and B₈ = −1/30) and reusing the parity split λ(s) = (1 − 2^(−s))ζ(s).",
+    "text": "The odd-indexed Basel-type sums at exponents 6 and 8: λ(6) = π⁶/960 and λ(8) = 17π⁸/161280, obtained from ζ(6) = π⁶/945 and ζ(8) = π⁸/9450 by separating even- and odd-indexed terms.",
+    "proofStrategy": "Four stages. (1) Compute the Bernoulli numbers B₆ = 1/42 and B₈ = −1/30 from bernoulli'_def, using bernoulli'_eq_zero_of_odd to drop the odd-index terms, then transfer to bernoulli via bernoulli_eq_bernoulli'_of_ne_one. (2) Instantiate hasSum_zeta_nat at k = 3 and k = 4 (convert … using 1; rw the Bernoulli value; push_cast [Nat.factorial]; ring) to get ζ(6) = π⁶/945 and ζ(8) = π⁸/9450 as standalone HasSum lemmas. (3) Evaluate the even parts by rewriting 1/(2k)^s = 2^(−s)(1/k^s) and scaling ζ(s): ζ(6)/64 = π⁶/60480 and ζ(8)/256 = π⁸/2419200. (4) Reassemble ζ(s) = even + odd with HasSum.even_add_odd and pin the odd part by HasSum.unique: λ(6) = π⁶/945 − π⁶/60480 = π⁶/960 and λ(8) = π⁸/9450 − π⁸/2419200 = 17π⁸/161280. tsum corollaries record the ∑' forms.",
+    "keyInsights": [
+      "**The bottleneck is the Bernoulli input, not the analysis.** Mathlib evaluates ζ(2) and ζ(4) explicitly but only computes bernoulli' up to 4, so pushing the parity-split template to s = 6, 8 first requires B₆ = 1/42 and B₈ = −1/30 — each obtained from the defining recurrence bernoulli'_def with the odd terms B₃ = B₅ = B₇ = 0 removed by bernoulli'_eq_zero_of_odd.",
+      "**hasSum_zeta_nat turns the whole even-zeta table into a one-line instantiation.** Once B_(2k) is known, ζ(2k) = (−1)^(k+1) 2^(2k−1) π^(2k) B_(2k)/(2k)! follows by `convert hasSum_zeta_nat … using 1` and a `push_cast [Nat.factorial]; ring` closing the scalar arithmetic 2^5·(1/42)/6! = 1/945 and −2^7·(1/30)/8! = 1/9450.",
+      "**The even-indexed subseries is again a scaled copy of ζ.** 1/(2k)^s = 2^(−s)(1/k^s), so the even part is 2^(−s)ζ(s): a 64-th of ζ(6) and a 256-th of ζ(8) — one HasSum.mul_left after a `ring` rewrite, valid even at k = 0.",
+      "**The odd sums fall out by uniqueness, identical to the s = 4 parent.** Reassemble ζ(s) from its even and odd halves and use HasSum.unique: no summand is evaluated directly; λ(s) = ζ(s) − 2^(−s)ζ(s) = (1 − 2^(−s))ζ(s) is realized constructively at s = 6, 8.",
+      "**λ(8) is not a unit fraction of π⁸.** (1 − 1/256)(π⁸/9450) = 255π⁸/2419200 = 17π⁸/161280 — the numerator 17 survives because 255 = 3·5·17 shares only 15 with the denominator, in contrast to the clean λ(6) = π⁶/960."
+    ],
+    "prerequisites": [
+      "Sixth and eighth zeta values ζ(6) = π⁶/945, ζ(8) = π⁸/9450",
+      "Bernoulli numbers and Euler's ζ(2k) formula",
+      "Dirichlet lambda function and λ(s) = (1 − 2^(−s))ζ(s)",
+      "Even/odd decomposition of infinite sums (HasSum.even_add_odd)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Documents the generalization of the λ(4) parity split to λ(6) and λ(8), the Bernoulli-number prerequisites, and the value computations; imports Mathlib's ZetaValues (for hasSum_zeta_nat) and Tactic.",
+      "mathContext": "λ(6), λ(8) are values of the Dirichlet lambda function, the odd-indexed restriction of ζ, computed from Euler's even-zeta formula."
+    },
+    {
+      "id": "bernoulli",
+      "title": "Step 1 — Bernoulli numbers B₆ = 1/42 and B₈ = −1/30",
+      "startLine": 54,
+      "endLine": 81,
+      "summary": "Computes bernoulli' 6 and bernoulli' 8 from the defining recurrence (odd terms killed by bernoulli'_eq_zero_of_odd), then transfers to bernoulli via the even-index sign lemma.",
+      "mathContext": "Mathlib supplies bernoulli' only up to 4; B₆ and B₈ are the missing inputs to Euler's ζ(2k) formula."
+    },
+    {
+      "id": "zeta-values",
+      "title": "Step 2 — ζ(6) = π⁶/945 and ζ(8) = π⁸/9450",
+      "startLine": 83,
+      "endLine": 99,
+      "summary": "Instantiates hasSum_zeta_nat at k = 3, 4, rewriting the Bernoulli value and discharging the scalar arithmetic with push_cast [Nat.factorial] and ring.",
+      "mathContext": "The standalone even zeta values at 6 and 8, not otherwise available in Mathlib as HasSum statements."
+    },
+    {
+      "id": "even-parts",
+      "title": "Step 3 — even parts π⁶/60480 and π⁸/2419200",
+      "startLine": 101,
+      "endLine": 123,
+      "summary": "Rewrites 1/(2k)^s = 2^(−s)(1/k^s) and scales ζ(s) by 1/64 and 1/256 (HasSum.mul_left + ring).",
+      "mathContext": "The even-indexed sixth- and eighth-power terms form 2^(−s)-scaled copies of ζ(s)."
+    },
+    {
+      "id": "odd-parts",
+      "title": "Step 4 — lambda values λ(6) = π⁶/960 and λ(8) = 17π⁸/161280",
+      "startLine": 125,
+      "endLine": 173,
+      "summary": "Each odd subseries is summable via comp_injective; reassemble ζ(s) = even + odd with HasSum.even_add_odd and use HasSum.unique to pin the odd sum, with tsum corollaries.",
+      "mathContext": "The lambda values λ(6), λ(8), recovered as ζ(s) minus its even part."
+    }
+  ],
+  "conclusion": {
+    "summary": "The higher even lambda values λ(6) = ∑ 1/(2k+1)⁶ = π⁶/960 and λ(8) = ∑ 1/(2k+1)⁸ = 17π⁸/161280 are formalized with 0 axioms and 0 sorries. The proof supplies the Bernoulli numbers B₆ = 1/42 and B₈ = −1/30 that Mathlib lacks, uses them to derive ζ(6) = π⁶/945 and ζ(8) = π⁸/9450 from hasSum_zeta_nat, and then reuses the parent's even/odd parity split to extract the odd-indexed lambda values, packaged as reusable HasSum and tsum lemmas.",
+    "implications": "Carries the HasSum.even_add_odd splitting idiom from exponent 4 up to 6 and 8, and demonstrates that the only obstruction to the full family λ(2k) = (1 − 2^(−2k))ζ(2k) is the Bernoulli-number computation — everything downstream is the same template. The intermediate ζ(6) and ζ(8) HasSum lemmas are independently reusable, e.g. for the Dirichlet eta values η(6), η(8).",
+    "openQuestions": [
+      "Package the Bernoulli-number step as a decision procedure `bernoulli_even n` that evaluates B_(2k) for arbitrary small k, removing the per-value recurrence unfolding and letting λ(2k) = (1 − 2^(−2k))ζ(2k) be generated uniformly.",
+      "Derive the Dirichlet eta values η(6) = 31π⁶/30240 and η(8) = 127π⁸/1209600 by combining these lambda values with the even-indexed sums, mirroring the η(4) construction from the parent's oq-01."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-13",
+      "relationship": "extends",
+      "description": "Parent entry establishing the λ(4) = π⁴/96 parity-split template; this entry generalizes it to λ(6) and λ(8) using Mathlib's general even-zeta formula."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "extends",
+      "description": "Root Basel entry ζ(2) = π²/6; these are the odd-indexed sixth- and eighth-power companions."
+    }
+  ],
+  "references": [
+    {
+      "title": "Introductio in analysin infinitorum",
+      "author": "Leonhard Euler",
+      "year": "1748",
+      "description": "Euler's evaluation of the even zeta values ζ(2k) = (−1)^(k+1) B_(2k)(2π)^(2k)/(2·(2k)!), giving ζ(6) = π⁶/945 and ζ(8) = π⁸/9450."
+    },
+    {
+      "title": "Riemann's Zeta Function",
+      "author": "Harold M. Edwards",
+      "year": "1974",
+      "venue": "Academic Press",
+      "description": "Develops the Dirichlet lambda and eta functions λ(s) = (1 − 2^(−s))ζ(s) and η(s) = (1 − 2^(1−s))ζ(s) as restrictions of the Riemann zeta function."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "basel-problem-oq-13-oq-02-oq-01",
+      "question": "Package the Bernoulli-number step as a reusable evaluator for B_(2k) so that λ(2k) = (1 − 2^(−2k))ζ(2k) can be generated uniformly for all small k rather than value-by-value.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent open question **basel-problem-oq-13** (oq-02): *generalize the parity-split template to the full lambda value λ(s) = (1 − 2^(−s))ζ(s) for higher even s, packaging λ(6) and λ(8) from Mathlib's `hasSum_zeta_nat` by the same even/odd HasSum split.*

Where the parent formalized λ(4) = π⁴/96 from Mathlib's explicit `hasSum_zeta_four`, Mathlib supplies **no** standalone HasSum for ζ(6) or higher. This entry:

1. **Computes the Bernoulli numbers** B₆ = 1/42 and B₈ = −1/30 from the defining recurrence `bernoulli'_def` (Mathlib stops at `bernoulli' 4`), killing the odd terms with `bernoulli'_eq_zero_of_odd`.
2. **Derives ζ(6) = π⁶/945 and ζ(8) = π⁸/9450** as standalone `HasSum` lemmas by instantiating the general even-zeta formula `hasSum_zeta_nat` at k = 3, 4.
3. **Reuses the parent's even/odd parity split** (`HasSum.even_add_odd` + `HasSum.unique`) to extract the lambda values:
   - **λ(6) = ∑ 1/(2k+1)⁶ = π⁶/960**
   - **λ(8) = ∑ 1/(2k+1)⁸ = 17π⁸/161280** (numerator 17 survives since 255 = 3·5·17 shares only 15 with the denominator)

## Verification

- `./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ13OQ02` — **builds, 0 sorries**
- **0 axioms**: no `axiom` declarations, no `native_decide`, no structure-encoded assumptions (`decide` is used only for small foundational ℕ facts). `status: verified`, `badge: mathlib`.
- `pnpm build` passes with the gallery entry (meta.json + annotations.json + index.ts).

## Content

12 theorems / 199 lines. New reusable lemmas: `bernoulli_six`, `bernoulli_eight`, `hasSum_zeta_six`, `hasSum_zeta_eight`, `hasSum_even_zeta_six/eight`, `hasSum_odd_zeta_six/eight`, `tsum_odd_zeta_six/eight`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)