### PR TITLE
Enrich 8 entries: add crossReferences (mirror relatedProblems)

### DIFF
--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-01/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-01/meta.json
@@ -192,7 +192,23 @@
       "url": "https://link.springer.com/book/10.1007/978-1-4612-4190-4"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "algebraic-reals-meager-dense-gdelta",
+      "relationship": "extends",
+      "description": "Parent: exhibits the transcendentals as a dense Gδ and the algebraic reals as not-Gδ; its first open question asks for the dual Fσ presentation of the algebraic reals and the full Gδ/Fσ classification, which this entry supplies"
+    },
+    {
+      "targetId": "algebraic-reals-meager",
+      "relationship": "related",
+      "description": "Grandparent: the algebraic reals are meagre and dense, the Baire-category half of the dichotomy this entry completes on the Borel-complexity side"
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "related",
+      "description": "The algebraic reals are countable — the countability input that drives the Fσ decomposition into singletons"
+    }
+  ],
   "sections": [
     {
       "id": "fsigma-predicate-duality",

--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-02/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-02/meta.json
@@ -205,7 +205,23 @@
       "url": "https://link.springer.com/book/10.1007/978-1-4612-4190-4"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "algebraic-reals-meager-dense-gdelta-oq-01",
+      "relationship": "extends",
+      "description": "Sibling: dualizes to the algebraic reals as an explicit Fσ; its own second open question asks for exactly this constructive enumeration of the algebraic reals and the resulting monotone sequence, which this entry supplies on the Gδ side"
+    },
+    {
+      "targetId": "algebraic-reals-meager-dense-gdelta",
+      "relationship": "related",
+      "description": "Parent: proves the transcendentals are a dense Gδ only abstractly (via IsGδ.biInter_of_isOpen over all singleton complements); this entry replaces that with an honest enumerable decreasing sequence and re-derives the Gδ property from it"
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "related",
+      "description": "The algebraic reals are countable — the countability that yields the enumeration algEnum driving the construction"
+    }
+  ],
   "sections": [
     {
       "id": "enumeration",

--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta/meta.json
@@ -188,7 +188,18 @@
       "url": "https://link.springer.com/book/10.1007/978-1-4684-9339-9"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "algebraic-reals-meager",
+      "relationship": "extends",
+      "description": "Parent: proves the transcendentals are residual and dense; its open question asks to exhibit them as an explicit dense Gδ, which this entry does"
+    },
+    {
+      "targetId": "algebraic-numbers-countable",
+      "relationship": "related",
+      "description": "Grandparent: the algebraic reals are countable (the countability input reused here)"
+    }
+  ],
   "sections": [
     {
       "id": "abstract-lemmas",

--- a/src/data/proofs/erdos-309-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-309-incomplete-01/meta.json
@@ -133,5 +133,12 @@
       "Reprove the deep Yokota lower bound F(N) ≥ log N − O(log log N) axiom-free, replacing the parent's axiom yokota_lower_bound_1997 and completing the F(N) = Θ(log N) result without assumptions.",
       "Sharpen the additive constant: the truth is F(N) = log N + γ + o(1) (γ the Euler–Mascheroni constant); formalize the refined asymptotic, not merely the +2 bound."
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-309",
+      "relationship": "extends",
+      "description": "Parent formalization (axiomatizes the hard Yokota lower bound; this file proves the easy upper direction axiom-free). The parent file no longer builds against Mathlib 4.26.0 due to removed imports, so this contribution is self-contained."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-441-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-441-incomplete-01/meta.json
@@ -112,5 +112,22 @@
       "Prove an unconditional upper bound g(N) ≤ C√N to make g(N) = Θ(√N) axiom-free in both directions, not just the lower half.",
       "Recover the sharp constant (9/8)^{1/2} elementarily by computing the exact cardinality of Erdős' construction, narrowing the gap to the axiomatized Chen–Dai asymptotic."
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-441",
+      "relationship": "extends",
+      "description": "Parent entry: records the full Chen–Dai answer g(N) ~ (9N/8)^{1/2} as three axioms (Chen 1998 asymptotic, Chen–Dai 2007 upper bound, Chen–Dai 2006 non-optimality) plus a sorry'd lower bound. This entry supplies an unconditional, axiom-free lower bound of the correct order."
+    },
+    {
+      "targetId": "erdos-440",
+      "relationship": "related",
+      "description": "Sibling LCM problem on the counting function of sets whose consecutive elements have small LCM."
+    },
+    {
+      "targetId": "gcd-algorithm",
+      "relationship": "related",
+      "description": "The lcm(a,b) ≤ a·b bound used here is the divisibility face of the gcd–lcm identity lcm(a,b) = ab/gcd(a,b)."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-57-oq-04/meta.json
+++ b/src/data/proofs/erdos-57-oq-04/meta.json
@@ -184,5 +184,12 @@
       "description": "A path that uses the edge joining its two endpoints is the single-edge path; rules out the degenerate `cons_isCycle_iff` failure mode for odd walks."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "crossReferences": [
+    {
+      "targetId": "erdos-57",
+      "relationship": "extends",
+      "description": "**Parent file.** Erdős #57 (Liu–Montgomery 2020): if χ(G) = ∞ then ∑ 1/aᵢ = ∞ over the odd cycle lengths. The parent's main result `erdos_57` remains an axiom (the genuinely deep theorem), but its bipartite-characterization scaffolding — `bipartite_iff_no_odd_cycles`, the foundational χ ≤ 2 ⟺ no odd cycles equivalence used throughout the hierarchy — had one remaining sorry in the reverse direction. This entry closes it by proving the crux lemma `exists_odd_cycle_of_odd_closed_walk`, dropping the parent from 1 sorry to 0 (it stays `axiomatized` solely because of the open `erdos_57` axiom)."
+    }
+  ]
 }

--- a/src/data/proofs/hilbert-17-oq-03-oq-02/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-02/meta.json
@@ -184,7 +184,18 @@
       "url": "https://www.ams.org/books/conm/253/"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "hilbert-17",
+      "relationship": "extends",
+      "description": "Parent: states Artin's theorem and the Motzkin counterexample but carries Motzkin's non-polynomial-SOS status as the axiom motzkin_not_sos_polynomial_aux. This entry proves exactly that statement with 0 axioms; the same definition of motzkin and IsSumOfSquaresMvPolynomial is used, so the axiom can be discharged by reference."
+    },
+    {
+      "targetId": "hilbert-17-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "Sibling (positive side): an explicit 0-axiom rational SOS certificate showing Motzkin IS a sum of squares of rational functions. Its listed open question — 'Discharge the companion axiom motzkin_not_sos_polynomial_aux (Motzkin is not a polynomial SOS) by the coefficient/degree argument' — is answered here, exactly by that coefficient/degree argument."
+    }
+  ],
   "sections": [
     {
       "id": "setup",

--- a/src/data/proofs/prob-method-applications-wip-01/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01/meta.json
@@ -151,5 +151,17 @@
       "note": "Original probabilistic lower bound on Ramsey numbers"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "crossReferences": [
+    {
+      "targetId": "prob-method-applications",
+      "relationship": "extends",
+      "description": "Completes the work-in-progress applications module by supplying the genuine first-moment engine its placeholder theorems stood in for"
+    },
+    {
+      "targetId": "prob-method-expectation",
+      "relationship": "related",
+      "description": "Provides the counting (cardinality) form of the first moment existence principle"
+    }
+  ]
 }


### PR DESCRIPTION
Gap-scan of origin/main found 8 gallery entries with a populated `meta.relatedProblems` but an **empty top-level `crossReferences`** — the field the gallery ProofPage actually renders as related-proof links. This pass mirrors each relatedProblem into a proper `{targetId, relationship, description}` cross-reference.

Entries enriched:
- algebraic-reals-meager-dense-gdelta (+2)
- algebraic-reals-meager-dense-gdelta-oq-01 (+3)
- algebraic-reals-meager-dense-gdelta-oq-02 (+3)
- erdos-309-incomplete-01 (+1)
- erdos-441-incomplete-01 (+3)
- erdos-57-oq-04 (+1)
- hilbert-17-oq-03-oq-02 (+2, dropped pageless `hilbert-17-oq-03`)
- prob-method-applications-wip-01 (+2)

**Every targetId was verified present in origin/main** (`git cat-file -e`); the one pageless conceptual parent (`hilbert-17-oq-03`) was dropped to avoid a dangling live link. Only `crossReferences` added — no other fields touched (re-dump is byte-identical apart from the new key).