### PR TITLE
Enrich 21 OQ-child entries: add parent cross-references

### DIFF
--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -72,5 +72,12 @@
     "definitionCount": 0,
     "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01.lean",
     "sorries": 0
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry; this proves the matching LOWER bound for the p-series tail and assembles the two-sided sandwich the parent left open (it bounded the remainder from above only)."
+    }
+  ]
 }

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/meta.json
@@ -120,5 +120,12 @@
     "definitionCount": 0,
     "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02.lean",
     "sorries": 0
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "antitone-integral-sum-comparison-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry; this answers its second open question, turning the integral test into a quantitative convergence rate for the p-series tail (∑_{n>N} 1/nᵖ ≤ N^{1−p}/(p−1))."
+    }
+  ]
 }

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01/meta.json
@@ -72,5 +72,12 @@
     "definitionCount": 0,
     "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01.lean",
     "sorries": 0
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "antitone-integral-sum-comparison-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry; this builds the monotone (increasing) companion to the parent's antitone integral-test sandwich, answering its open question and applying it to showcase integrands."
+    }
+  ]
 }

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02/meta.json
@@ -124,6 +124,12 @@
     ]
   },
   "references": null,
-  "crossReferences": null,
+  "crossReferences": [
+    {
+      "targetId": "antitone-integral-sum-comparison-oq-01",
+      "relationship": "extends",
+      "description": "Parent integral-test entry; this continues the parent's harmonic-defect analysis (Hₙ − log(n+1) ∈ [0,1]) toward the open question on the limiting constant."
+    }
+  ],
   "sorries": null
 }

--- a/src/data/proofs/cassini-identity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-02/meta.json
@@ -147,5 +147,12 @@
       "Can d'Ocagne's identity $F_m F_{n+1} - F_{m+1}F_n = (-1)^n F_{m-n}$ be obtained from the off-diagonal entries of $Q^m Q^{-n}$ or from a determinant of a product, completing the entry-reading programme for the standard identity list?",
       "Does the Catalan identity $F_{n-r}F_{n+r} - F_n^2 = (-1)^{n-r+1}F_r^2$ follow from a determinant of $Q^{n-r}Q^{2r}$ as suggested in the parent entry, or does the off-diagonal mixing require a separate entry analysis?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "cassini-identity-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry; this answers its open question by reading the Fibonacci addition formula off the matrix law Q^{m+n}=Q^m·Q^n for the companion matrix Q=[[1,1],[1,0]]."
+    }
+  ]
 }

--- a/src/data/proofs/centered-hexagonal-sum-oq-01-oq-01/meta.json
+++ b/src/data/proofs/centered-hexagonal-sum-oq-01-oq-01/meta.json
@@ -109,5 +109,12 @@
       "Do the centered polygonal numbers themselves (not their partial sums) admit a clean closed form for ∑ C_{k,i}² or other power sums, again uniform in k?",
       "Is there an analogous single formula for the partial sums of the ordinary (non-centered) k-gonal numbers, and how does the special value of k that yields a pure power shift?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "centered-hexagonal-sum-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry; this answers its open question with a single uniform closed form for the centered k-gonal partial sums valid for all k at once."
+    }
+  ]
 }

--- a/src/data/proofs/chebyshev-bounds-oq-06/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06/meta.json
@@ -106,5 +106,12 @@
       "Can the upper bound be sharpened to the standard $\\binom{2n}{n}\\le 4^n/\\sqrt{\\pi n}$ (Stirling) within Mathlib, giving the matching asymptotic $\\binom{2n}{n}\\sim 4^n/\\sqrt{\\pi n}$?",
       "Does the central-binomial sandwich let the parent chebyshev-bounds discharge its remaining axiomatized $\\theta(n)\\le n\\log 4$ upper bound directly?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-bounds",
+      "relationship": "related",
+      "description": "Parent Chebyshev prime-counting entry; this packages the two-sided central-binomial estimate 4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ that is the combinatorial workhorse behind Chebyshev-type bounds."
+    }
+  ]
 }

--- a/src/data/proofs/chebyshev-polynomials-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01-oq-01/meta.json
@@ -4,8 +4,13 @@
   "title": "Chebyshev addition formulas: T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1}, and the second-kind companion",
   "description": "The angle-addition formula for Chebyshev polynomials, the polynomial shadow of cos(α+β) = cos α cos β − sin α sin β: T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1}, over any commutative ring and for all integer indices. Mathlib records only the product-to-sum identity T_mul_T (2·T_m·T_k = T_{m+k} + T_{m−k}), not this addition law. The entry also proves the matching subtraction formula T_{m−n} = T_m·T_n + (1−X²)·U_{m−1}·U_{n−1}, the second-kind addition formula U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1} (the sin(α+β) analog, likewise absent from Mathlib), and the Pell/Pythagorean identity Tₙ² + (1−X²)·U_{n−1}² = 1 obtained on the diagonal.",
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Polynomial", "Polynomial.Chebyshev"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Polynomial.Chebyshev"
+    ],
     "namespace": "ChebyshevPolynomialsOQ01OQ01",
     "lineCount": 135,
     "axiomCount": 0,
@@ -107,8 +112,13 @@
     "lineCount": 135,
     "theoremCount": 4,
     "definitionCount": 0,
-    "imports": ["Mathlib"],
-    "opens": ["Polynomial", "Polynomial.Chebyshev"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Polynomial.Chebyshev"
+    ],
     "namespace": "ChebyshevPolynomialsOQ01OQ01",
     "path": "Proofs/ChebyshevPolynomialsOQ01OQ01.lean"
   },
@@ -186,6 +196,13 @@
     {
       "title": "Mathlib.RingTheory.Polynomial.Chebyshev",
       "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/Polynomial/Chebyshev.html"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-polynomials-oq-01",
+      "relationship": "extends",
+      "description": "Parent Chebyshev-polynomial entry; this adds the angle-addition formula T_{m+n}=T_m·T_n − (1−X²)·U_{m−1}·U_{n−1} over any commutative ring, extending Mathlib's product-to-sum identity."
     }
   ]
 }

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-02-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-02-oq-01/meta.json
@@ -66,5 +66,12 @@
       "Add gcd_lcm_distrib and the Associates DistribLattice instance to Mathlib (the divisibility lattice of a UFD is distributive)",
       "Quantify the solution: an explicit representative modulo lcm(m₁,m₂,m₃) via iterated Bézout, with complexity bounds"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "chinese-remainder-non-coprime-oq-02",
+      "relationship": "extends",
+      "description": "Parent two-modulus non-coprime CRT; this extends the solvability criterion to three moduli in a PID/Bézout domain (pairwise gcd compatibility, solution unique mod lcm)."
+    }
+  ]
 }

--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
@@ -126,7 +126,13 @@
       "mathContext": "$Z(\\mathrm{Mult}(\\mathbb{Z}/4))$ is nontrivial."
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "conjugacy-class-equation-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry; this answers its second open question — a nontrivial finite p-group has nontrivial center — from per-class divisibility in the class equation."
+    }
+  ],
   "conclusion": {
     "summary": "Complete, fully verified (0 sorries, 0 axioms) class-equation proof that a nontrivial finite p-group has nontrivial center. The derivation lifts the parent's per-class divisibility to arbitrary classes, shows every noncentral class has size a positive power of p, and reads the numeric class equation |Z(G)| + Σ = |G| modulo p to get p ∣ |Z(G)|, hence 1 < |Z(G)|.",
     "implications": "Realizes the textbook class-equation proof of the p-group center theorem inside the gallery's conjugacy-class chain, distinct from Mathlib's fixed-point proof, and isolates the reusable lemma noncentral_class_card_eq_prime_pow (noncentral classes have prime-power size).",

--- a/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01-oq-01/meta.json
@@ -188,6 +188,12 @@
       "url": "https://en.wikipedia.org/wiki/Triangular_number"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "cramers-rule-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent flop-count entry; this refines the (n³−n)/3 elimination count into its cubic ∑j² part (the n³/3 term) and quadratic ∑j = C(n,2) part."
+    }
+  ],
   "sorries": []
 }

--- a/src/data/proofs/cramers-rule-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01/meta.json
@@ -202,6 +202,12 @@
       "url": "https://en.wikipedia.org/wiki/LU_decomposition#Theoretical_complexity"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "cramers-rule-oq-02",
+      "relationship": "extends",
+      "description": "Parent Cramer-vs-Gauss complexity entry; this tightens the loose n³ model to the exact (n³−n)/3 multiply/divide count of forward Gaussian elimination."
+    }
+  ],
   "sorries": []
 }

--- a/src/data/proofs/de-moivre-oq-05-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-02/meta.json
@@ -167,5 +167,12 @@
       "year": 2026,
       "note": "Primitive-root partition, geometric-sum vanishing, and Möbius inversion over a ring"
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-05",
+      "relationship": "extends",
+      "description": "Parent (all n-th roots of unity sum to 0 for n>1); this generalizes to the primitive-root sum = μ(n) via Möbius inversion over the divisor partition of the roots of unity."
+    }
   ]
 }

--- a/src/data/proofs/euler-totient-oq-05-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-05-oq-01/meta.json
@@ -113,5 +113,12 @@
       "Extend full correctness to squarefree moduli n = p_1 ⋯ p_k with k > 2 prime factors, iterating the CRT gluing over the prime factorization",
       "Characterize the exact set of messages recovered when n is NOT squarefree (e.g. n = p^2·q), where Fermat's fixed point fails for residues divisible by p but not by p^2"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-05",
+      "relationship": "extends",
+      "description": "Parent RSA-correctness entry; this drops the coprimality hypothesis, proving (m^e)^d ≡ m (mod p·q) for ALL messages m via the all-m fixed-point form of Fermat's little theorem."
+    }
+  ]
 }

--- a/src/data/proofs/euler-totient-oq-05/meta.json
+++ b/src/data/proofs/euler-totient-oq-05/meta.json
@@ -127,5 +127,12 @@
       "Prove RSA correctness without the coprimality hypothesis on m, via CRT over the prime factorization n = pq (the full RSA correctness theorem)",
       "Formalize the converse refinement: Carmichael's λ(n) is the exact (least) universal exponent, sharpening orderOf u | φ(n)"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient",
+      "relationship": "extends",
+      "description": "Parent Euler-totient entry; this develops the number-theoretic Nat.ModEq face — a^φ(n)≡1, exponent reduction a^k≡a^(k mod φ(n)), Fermat's little theorem, and RSA correctness."
+    }
+  ]
 }

--- a/src/data/proofs/four-square-distribution-oq-01-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01-oq-01/meta.json
@@ -122,5 +122,12 @@
       "Generalize the σ*-vs-σ split to the analogous modified divisor sums appearing in the r2, r6, r8 sum-of-squares formulas (e.g. the χ-twisted sums for r2 and the σ3-based formula for r8).",
       "Derive an explicit closed form for Σ_{d|n, 4|d} d = 4·σ(n/4) when 4 | n, turning the additive correction into a multiplicative recursion σ*(n) = σ(n) − 4σ(n/4)."
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "four-square-distribution-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry states Jacobi's four-square formula r4(n)=8·σ*(n) as `axiom jacobi_r4_formula`; this child develops that formula and its modified divisor sum σ*(n)=Σ_{d|n,4∤d} d."
+    }
+  ]
 }

--- a/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
@@ -103,5 +103,12 @@
       "Specialize to real quadratic fields, where ε is the classical fundamental unit, and produce explicit numerical witnesses of the rank-one regulator formula.",
       "Address the open effective-computation problem: exhibit, for a mixed-signature cubic field, the Stark unit generating the predicted abelian extension — the actual content of Hilbert's 12th problem here."
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "kroneckers-jugendtraum",
+      "relationship": "extends",
+      "description": "Parent Kronecker Jugendtraum / Stark entry; this treats the unit-rank-1 case where the regulator collapses from an r×r determinant to a single archimedean log of the fundamental (Stark) unit."
+    }
+  ]
 }

--- a/src/data/proofs/lagrange-four-squares-oq-03/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-03/meta.json
@@ -132,5 +132,12 @@
       "Generalize the Liouville-style identity to give elementary finite bounds for g(8) (eighth powers, where an analogous identity expresses a constant times a square of a four-square form as a sum of eighth powers) and other even exponents."
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "crossReferences": [
+    {
+      "targetId": "lagrange-four-squares",
+      "relationship": "extends",
+      "description": "Parent Lagrange four-square theorem; this derives an explicit Waring bound g(4) ≤ 53 (every natural is a sum of ≤53 fourth powers) by a Lagrange-type argument building on Nat.sum_four_squares."
+    }
+  ]
 }

--- a/src/data/proofs/sperner-ndim-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-01-oq-01/meta.json
@@ -116,5 +116,12 @@
       "Can `intermediate_sets_card_eq_two` be generalized to count k-element sets strictly between A and B when |B \\ A| = m, giving the binomial C(m, k−|A|) and connecting the door count to the face lattice of a simplex?",
       "Would upstreaming the reproved prefix-set infrastructure to Mathlib — as a general theory of prefix Finsets of nodup lists — prevent the recurring bit-rot that forced this re-derivation?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "sperner-ndim-oq-01",
+      "relationship": "extends",
+      "description": "Parent n-dimensional Sperner entry; this completes the door-counting parity fact (the count of simplices sharing a facet) underlying the combinatorial proof for the Freudenthal triangulation."
+    }
+  ]
 }

--- a/src/data/proofs/subset-count-oq-02-oq-02/meta.json
+++ b/src/data/proofs/subset-count-oq-02-oq-02/meta.json
@@ -83,5 +83,12 @@
       "Does the hockey-stick identity ∑_{i=r}^{n} i.choose r = (n+1).choose (r+1) admit a powerset-decomposition proof, classifying (r+1)-subsets by their largest element?",
       "Can the explicit bijection in choose_succ_succ_finset (insert x / erase x) be packaged as a reusable Equiv between the (k+1)-subsets of insert x s and the disjoint union, so the cardinality identity becomes a corollary of an equivalence rather than a card computation?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "subset-count-oq-02",
+      "relationship": "extends",
+      "description": "Parent subset-counting entry; this derives Pascal's rule and the companion binomial identity combinatorially by decomposing the powerset rather than unfolding Nat.choose."
+    }
+  ]
 }

--- a/src/data/proofs/twin-primes-special-oq-02/meta.json
+++ b/src/data/proofs/twin-primes-special-oq-02/meta.json
@@ -71,5 +71,12 @@
     "definitionCount": 1,
     "path": "Proofs/TwinPrimesSpecialOQ02.lean",
     "sorries": 0
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "twin-primes-special",
+      "relationship": "extends",
+      "description": "Parent twin-primes entry; this addresses its open question on the true growth rate π₂(N), stating the Hardy–Littlewood Conjecture B prediction π₂(N) ~ 2C₂N/(log N)²."
+    }
+  ]
 }


### PR DESCRIPTION
Gap-scan of origin/main found 21 open-question *child* entries (`…-oq-NN`) that had **no crossReferences and no relatedProblems**, yet whose parent gallery page exists — so their pages currently render zero related-proof links despite being direct answers to a parent's open question.

Each child gets one accurate `{targetId, relationship, description}` cross-reference to its parent, with the description grounded in the child's own `description` (how it extends / answers / tightens the parent) rather than generic filler. Examples:
- `cassini-identity-oq-01-oq-02` → `cassini-identity-oq-01` (matrix-law derivation of the Fibonacci addition formula)
- `euler-totient-oq-05-oq-01` → `euler-totient-oq-05` (RSA correctness without coprimality)
- `de-moivre-oq-05-oq-02` → `de-moivre-oq-05` (primitive-root sum = μ(n))
- `lagrange-four-squares-oq-03` → `lagrange-four-squares` (Waring bound g(4) ≤ 53)

All 21 parent targetIds verified present in origin/main (`git cat-file -e`). Only `crossReferences` added; re-dump is byte-identical apart from the new key.