### PR TITLE
research(antitone-integral-sum-comparison-oq-01-oq-03): general integral test as a convergence criterion [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/AntitoneIntegralTest.lean
+++ b/proofs/Proofs/AntitoneIntegralTest.lean
@@ -1,0 +1,141 @@
+import Mathlib
+
+/-
+# The Integral Test: a Convergence Criterion for Antitone Series
+
+The parent entry `AntitoneIntegralSumComparison` packaged the two-sided sandwich
+
+  ∑_{i<n} f(x₀ + i + 1)  ≤  ∫_{x₀}^{x₀+n} f  ≤  ∑_{i<n} f(x₀ + i)
+
+for an antitone `f`, and applied it to the single function `f(x) = 1/x`.  This
+entry promotes that sandwich into the **general integral test**: for an
+antitone, nonnegative `f` on `[1, ∞)`, the series `∑ₙ f(n+1)` converges **iff**
+the sequence of definite integrals `∫₁^{1+n} f` is bounded above.
+
+Mathlib supplies the one-step comparisons `AntitoneOn.sum_le_integral` and
+`AntitoneOn.integral_le_sum`, but packages them into no convergence dichotomy;
+this entry fills that gap.  We then recover, purely through the test, the
+classical **divergence of the harmonic series**: the integrals
+`∫₁^{1+n} 1/x = log(n+1)` are unbounded, so `∑ 1/(n+1)` cannot converge.
+
+All results are fully machine-verified: 0 sorries, 0 axioms.
+-/
+
+namespace AntitoneIntegralTest
+
+open scoped BigOperators
+open Finset intervalIntegral
+
+variable {f : ℝ → ℝ}
+
+/-! ## Part I — Windowed antitonicity -/
+
+/-- Restrict antitonicity from `[1, ∞)` to each finite window `[1, 1+n]`. -/
+private theorem antitoneOn_window (hmono : AntitoneOn f (Set.Ici (1 : ℝ))) (n : ℕ) :
+    AntitoneOn f (Set.Icc 1 (1 + (n : ℝ))) :=
+  hmono.mono Set.Icc_subset_Ici_self
+
+/-! ## Part II — The two comparisons, indexed by the series `n ↦ f(n+1)` -/
+
+/-- **Upper comparison.** The integral over `[1, 1+n]` is at most the `n`-term
+partial sum `∑_{i<n} f(i+1)` (the left Riemann sum). -/
+theorem integral_le_partialSum (hmono : AntitoneOn f (Set.Ici (1 : ℝ))) (n : ℕ) :
+    (∫ x in (1 : ℝ)..(1 + n), f x) ≤ ∑ i ∈ Finset.range n, f ((i : ℝ) + 1) := by
+  refine ((antitoneOn_window hmono n).integral_le_sum).trans_eq ?_
+  apply Finset.sum_congr rfl
+  intro i _
+  congr 1
+  ring
+
+/-- **Lower comparison.** The `(n+1)`-term partial sum `∑_{i<n+1} f(i+1)` is at
+most `f 1 + ∫₁^{1+n} f` (the right Riemann sum, shifted by the first term). -/
+theorem partialSum_succ_le (hmono : AntitoneOn f (Set.Ici (1 : ℝ))) (n : ℕ) :
+    (∑ i ∈ Finset.range (n + 1), f ((i : ℝ) + 1)) ≤ f 1 + ∫ x in (1 : ℝ)..(1 + n), f x := by
+  have h := (antitoneOn_window hmono n).sum_le_integral
+  -- h : (∑ i ∈ range n, f (1 + ↑(i+1))) ≤ ∫ x in 1..1+↑n, f x
+  rw [Finset.sum_range_succ']
+  simp only [Nat.cast_zero, zero_add]
+  -- goal : (∑ i ∈ range n, f (↑(i+1) + 1)) + f 1 ≤ f 1 + ∫ ...
+  have e : (∑ i ∈ Finset.range n, f (((i + 1 : ℕ) : ℝ) + 1))
+      = ∑ i ∈ Finset.range n, f (1 + ((i + 1 : ℕ) : ℝ)) := by
+    apply Finset.sum_congr rfl
+    intro i _
+    congr 1
+    ring
+  rw [e]
+  linarith [h]
+
+/-! ## Part III — The integral test -/
+
+/-- **The integral test.** For an antitone, nonnegative `f` on `[1, ∞)`, the
+series `∑ₙ f(n+1)` is summable **iff** the sequence of integrals `∫₁^{1+n} f` is
+bounded above.  This is the convergence dichotomy underlying every application
+of the sum–integral sandwich. -/
+theorem integral_test (hmono : AntitoneOn f (Set.Ici (1 : ℝ)))
+    (hnonneg : ∀ x : ℝ, 1 ≤ x → 0 ≤ f x) :
+    Summable (fun n : ℕ => f ((n : ℝ) + 1)) ↔
+      BddAbove (Set.range fun n : ℕ => ∫ x in (1 : ℝ)..(1 + n), f x) := by
+  have hgnn : ∀ n : ℕ, 0 ≤ f ((n : ℝ) + 1) := fun n =>
+    hnonneg _ (le_add_of_nonneg_left (Nat.cast_nonneg n))
+  constructor
+  · -- Summable ⟹ integrals bounded (by the total sum)
+    intro hsum
+    refine ⟨∑' n, f ((n : ℝ) + 1), ?_⟩
+    rintro _ ⟨n, rfl⟩
+    refine (integral_le_partialSum hmono n).trans ?_
+    exact sum_le_hasSum (Finset.range n) (fun i _ => hgnn i) hsum.hasSum
+  · -- integrals bounded ⟹ Summable (bounded partial sums of a nonneg series)
+    rintro ⟨B, hB⟩
+    have hBmem : ∀ n : ℕ, (∫ x in (1 : ℝ)..(1 + n), f x) ≤ B := fun n =>
+      hB ⟨n, rfl⟩
+    refine summable_of_sum_range_le hgnn (c := f 1 + B) ?_
+    intro n
+    cases n with
+    | zero =>
+      simp only [Finset.range_zero, Finset.sum_empty]
+      have h1 : (0 : ℝ) ≤ f 1 := hnonneg 1 le_rfl
+      have hB0 : (0 : ℝ) ≤ B := by simpa using hBmem 0
+      linarith
+    | succ m =>
+      refine (partialSum_succ_le hmono m).trans ?_
+      linarith [hBmem m]
+
+/-! ## Part IV — Application: divergence of the harmonic series -/
+
+/-- `x ↦ 1/x` is antitone on `[1, ∞)`. -/
+private theorem oneDiv_antitone : AntitoneOn (fun x : ℝ => 1 / x) (Set.Ici (1 : ℝ)) := by
+  intro x hx y _ hxy
+  have hx1 : (1 : ℝ) ≤ x := hx
+  exact one_div_le_one_div_of_le (by linarith) hxy
+
+/-- `∫₁^{1+n} 1/x dx = log(n + 1)`. -/
+private theorem log_integral (n : ℕ) :
+    (∫ x in (1 : ℝ)..(1 + (n : ℝ)), 1 / x) = Real.log ((n : ℝ) + 1) := by
+  have h0 : (0 : ℝ) ∉ Set.uIcc (1 : ℝ) (1 + (n : ℝ)) :=
+    Set.notMem_uIcc_of_lt one_pos (by positivity)
+  rw [integral_one_div h0, div_one]
+  congr 1
+  ring
+
+/-- **The harmonic series diverges.** Applying the integral test to `f(x) = 1/x`:
+the integrals `∫₁^{1+n} 1/x = log(n+1)` are unbounded (`log → ∞`), so the series
+`∑ₙ 1/(n+1)` is not summable. -/
+theorem not_summable_one_div_harmonic :
+    ¬ Summable (fun n : ℕ => 1 / ((n : ℝ) + 1)) := by
+  intro hs
+  have hbdd :=
+    (integral_test oneDiv_antitone (fun x hx => div_nonneg zero_le_one (by linarith))).mp hs
+  obtain ⟨B, hB⟩ := hbdd
+  -- the integrals `log(n+1)` grow without bound
+  have hlim : Filter.Tendsto (fun n : ℕ => Real.log ((n : ℝ) + 1)) Filter.atTop Filter.atTop :=
+    Real.tendsto_log_atTop.comp
+      (Filter.tendsto_atTop_add_const_right _ 1 tendsto_natCast_atTop_atTop)
+  obtain ⟨N, hN⟩ := (hlim.eventually_gt_atTop B).exists
+  have hval : (∫ x in (1 : ℝ)..(1 + (N : ℝ)), (fun x : ℝ => 1 / x) x) = Real.log ((N : ℝ) + 1) :=
+    log_integral N
+  have hle : (∫ x in (1 : ℝ)..(1 + (N : ℝ)), (fun x : ℝ => 1 / x) x) ≤ B :=
+    hB (Set.mem_range_self N)
+  rw [hval] at hle
+  linarith [hN, hle]
+
+end AntitoneIntegralTest

--- a/proofs/Proofs/AntitoneIntegralTest.lean
+++ b/proofs/Proofs/AntitoneIntegralTest.lean
@@ -80,7 +80,7 @@ theorem integral_test (hmono : AntitoneOn f (Set.Ici (1 : ℝ)))
   constructor
   · -- Summable ⟹ integrals bounded (by the total sum)
     intro hsum
-    refine ⟨∑' n, f ((n : ℝ) + 1), ?_⟩
+    refine ⟨∑' n : ℕ, f ((n : ℝ) + 1), ?_⟩
     rintro _ ⟨n, rfl⟩
     refine (integral_le_partialSum hmono n).trans ?_
     exact sum_le_hasSum (Finset.range n) (fun i _ => hgnn i) hsum.hasSum

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/annotations.json
@@ -1,0 +1,106 @@
+[
+  {
+    "id": "ann-ait-integral-le-partialsum",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-03",
+    "range": {
+      "startLine": 40,
+      "endLine": 48
+    },
+    "type": "theorem",
+    "title": "Upper Comparison: Integral ≤ Left Riemann Sum",
+    "content": "integral_le_partialSum specialises the parent's AntitoneOn.integral_le_sum to x₀ = 1 and reindexes the resulting left Riemann sum ∑_{i<n} f(1+i) into ∑_{i<n} f(i+1), the n-term partial sum of the series n ↦ f(n+1). The only work is add_comm inside Finset.sum_congr to line up the summand.",
+    "mathContext": "\\int_1^{1+n} f \\;\\le\\; \\sum_{i<n} f(i+1)",
+    "significance": "key",
+    "relatedConcepts": [
+      "integral test",
+      "left Riemann sum",
+      "antitone functions"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-ait-partialsum-succ-le",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-03",
+    "range": {
+      "startLine": 50,
+      "endLine": 66
+    },
+    "type": "theorem",
+    "title": "Lower Comparison: (n+1)-Partial Sum ≤ f(1) + Integral",
+    "content": "partialSum_succ_le specialises AntitoneOn.sum_le_integral, whose right Riemann sum ∑_{i<n} f(i+2) equals the (n+1)-term partial sum minus its leading term f(1). Finset.sum_range_succ' peels that first term, giving ∑_{i<n+1} f(i+1) ≤ f(1) + ∫₁^{1+n} f. Together with the upper comparison this traps the integrals and partial sums within a constant of each other.",
+    "mathContext": "\\sum_{i<n+1} f(i+1) \\;\\le\\; f(1) + \\int_1^{1+n} f",
+    "significance": "key",
+    "relatedConcepts": [
+      "right Riemann sum",
+      "Finset.sum_range_succ'",
+      "reindexing"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-ait-integral-test",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-03",
+    "range": {
+      "startLine": 70,
+      "endLine": 101
+    },
+    "type": "theorem",
+    "title": "The Integral Test (Summable ↔ BddAbove Integrals)",
+    "content": "The main result: for an antitone, nonnegative f on [1,∞), the series ∑ₙ f(n+1) is summable iff the integrals ∫₁^{1+n} f are bounded above. Forward, each integral is ≤ the total sum ∑' f(n+1) via sum_le_hasSum. Reverse, an upper bound B on the integrals yields the uniform partial-sum bound f(1)+B (the n=0 case is pure nonnegativity), and summable_of_sum_range_le concludes. This convergence dichotomy is the reusable engine the parent entry only instantiated for 1/x, and it is absent from Mathlib.",
+    "mathContext": "\\text{Summable}\\,(n \\mapsto f(n+1)) \\iff \\text{BddAbove}\\,\\Big\\{\\int_1^{1+n} f : n \\in \\mathbb{N}\\Big\\}",
+    "significance": "critical",
+    "relatedConcepts": [
+      "integral test",
+      "summable",
+      "BddAbove",
+      "convergence tests",
+      "tsum"
+    ],
+    "prerequisites": [
+      "ann-ait-integral-le-partialsum",
+      "ann-ait-partialsum-succ-le"
+    ]
+  },
+  {
+    "id": "ann-ait-log-integral",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-03",
+    "range": {
+      "startLine": 111,
+      "endLine": 118
+    },
+    "type": "theorem",
+    "title": "The Logarithmic Integral ∫₁^{1+n} 1/x = log(n+1)",
+    "content": "log_integral evaluates the exact integral driving the harmonic application: integral_one_div gives ∫ₐᵇ 1/x = log(b/a) when 0 ∉ uIcc a b, and here 0 < 1 discharges the side condition while div_one simplifies log((1+n)/1) to log(n+1). It is this unbounded family of integrals that the test converts into non-summability.",
+    "mathContext": "\\int_1^{1+n} \\frac{1}{x}\\,dx = \\log(n+1)",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "natural logarithm",
+      "interval integral",
+      "integral_one_div"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-ait-harmonic-divergence",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-03",
+    "range": {
+      "startLine": 120,
+      "endLine": 141
+    },
+    "type": "theorem",
+    "title": "The Harmonic Series Diverges (via the Integral Test)",
+    "content": "not_summable_one_div_harmonic applies integral_test to f(x) = 1/x. The integrals are log(n+1), and because log → ∞ (Real.tendsto_log_atTop composed with ℕ → ℝ) they are not bounded above; the test then forces ∑ 1/(n+1) to be non-summable. This recovers the classical divergence of the harmonic series purely from the integral side, showcasing the criterion in action.",
+    "mathContext": "\\neg\\,\\text{Summable}\\,\\Big(n \\mapsto \\tfrac{1}{n+1}\\Big) \\quad\\text{since}\\quad \\int_1^{1+n}\\tfrac1x = \\log(n+1) \\to \\infty",
+    "significance": "key",
+    "relatedConcepts": [
+      "harmonic series",
+      "divergence",
+      "log growth",
+      "integral test"
+    ],
+    "prerequisites": [
+      "ann-ait-integral-test",
+      "ann-ait-log-integral"
+    ]
+  }
+]

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-03/meta.json
@@ -1,0 +1,74 @@
+{
+  "id": "antitone-integral-sum-comparison-oq-01-oq-03",
+  "title": "The Integral Test as a Convergence Criterion for Antitone Series",
+  "slug": "antitone-integral-sum-comparison-oq-01-oq-03",
+  "description": "The parent entry packaged the two-sided sum–integral sandwich for an antitone f and applied it to the single function 1/x. This follow-up promotes that sandwich into the general integral test: for an antitone, nonnegative f on [1,∞), the series ∑ₙ f(n+1) is summable if and only if the sequence of definite integrals ∫₁^{1+n} f is bounded above. Mathlib supplies the one-step comparisons AntitoneOn.sum_le_integral and AntitoneOn.integral_le_sum but no convergence dichotomy, and the gallery had none; this fills that gap with a reusable Summable ↔ BddAbove criterion. As a worked application the test is turned back on 1/x to reprove the classical divergence of the harmonic series purely through the integral side: ∫₁^{1+n} 1/x = log(n+1) is unbounded, so ∑ 1/(n+1) cannot be summable. 7 theorems, 0 definitions, 141 lines, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Integral_test_for_convergence",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AntitoneIntegralTest.lean",
+    "tags": [
+      "analysis",
+      "integral-test",
+      "convergence",
+      "harmonic-series",
+      "summable",
+      "antitone",
+      "riemann-sums"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified; the only axioms are the standard propext / Classical.choice / Quot.sound.",
+    "lineCount": 141,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "originalContributions": [
+      "integral_test: the convergence dichotomy Summable (n ↦ f(n+1)) ↔ BddAbove {∫₁^{1+n} f} for an antitone nonnegative f on [1,∞) — the general integral test, absent from both Mathlib and the gallery",
+      "integral_le_partialSum: ∫₁^{1+n} f ≤ ∑_{i<n} f(i+1), the upper comparison reindexed to the series n ↦ f(n+1)",
+      "partialSum_succ_le: ∑_{i<n+1} f(i+1) ≤ f(1) + ∫₁^{1+n} f, the lower comparison shifted by the first term via Finset.sum_range_succ'",
+      "not_summable_one_div_harmonic: the harmonic series ∑ 1/(n+1) diverges, obtained by feeding the unbounded integrals ∫₁^{1+n} 1/x = log(n+1) into the general test",
+      "oneDiv_antitone / log_integral: the 1/x antitonicity and the exact integral log(n+1) that instantiate the test"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The integral test (Cauchy, early 19th century) decides the convergence of a series ∑ f(n) with monotone terms by comparing it to the improper integral ∫ f: because an antitone graph is trapped between the left and right Riemann staircases, the partial sums and the integral are bounded by one another, so they converge or diverge together. Its archetypal consequence is that the harmonic series diverges — but only logarithmically, since ∑_{k≤n} 1/k grows like ∫₁ⁿ 1/x = log n. The parent gallery entry built the two-sided Riemann-sum sandwich and read off the harmonic bounds; the natural next step, and the reusable heart of the test, is the convergence dichotomy itself.",
+    "problemStatement": "Promote the parent's sum–integral sandwich from a one-off inequality about 1/x into the general integral test: state and prove, for an antitone nonnegative f on [1,∞), that ∑ₙ f(n+1) is summable exactly when the definite integrals ∫₁^{1+n} f stay bounded, and demonstrate the criterion by recovering the divergence of the harmonic series from the integral side alone.",
+    "text": "For an antitone f the parent sandwich gives, at x₀ = 1, both ∫₁^{1+n} f ≤ ∑_{i<n} f(i+1) (left Riemann sum, an upper bound for the integral) and ∑_{i<n} f(i+2) ≤ ∫₁^{1+n} f (right Riemann sum, a lower bound). Writing Σₙ = ∑_{i<n} f(i+1) for the n-th partial sum of the series n ↦ f(n+1), these read Σ_{n+1} − f(1) ≤ ∫₁^{1+n} f ≤ Σₙ. Hence the integrals are bounded above precisely when the partial sums are. Since the terms are nonnegative the partial sums are monotone, so bounded partial sums ⇔ summable (summable_of_sum_range_le one way, sum_le_hasSum the other). Chaining the two equivalences yields Summable (n ↦ f(n+1)) ↔ BddAbove {∫₁^{1+n} f}.",
+    "proofStrategy": "Part I restricts antitonicity from [1,∞) to each finite window [1,1+n] (Set.Icc_subset_Ici_self). Part II records the two comparisons in the exact indexing of the series n ↦ f(n+1): integral_le_partialSum is AntitoneOn.integral_le_sum with the left sum reindexed by add_comm, and partialSum_succ_le is AntitoneOn.sum_le_integral with the right sum peeled by Finset.sum_range_succ' to expose the leading term f(1). Part III proves integral_test: the forward direction bounds each integral by the total sum ∑' f(n+1) using sum_le_hasSum; the reverse direction turns an upper bound B on the integrals into the uniform partial-sum bound f(1)+B (with the n=0 case handled by nonnegativity) and applies summable_of_sum_range_le. Part IV instantiates f = 1/x: oneDiv_antitone gives antitonicity, log_integral evaluates ∫₁^{1+n} 1/x = log(n+1), and since log(n+1) → ∞ the integrals are not bounded above (not_bddAbove), so not_summable_one_div_harmonic follows directly from the test.",
+    "keyInsights": [
+      "The whole test is two boundedness equivalences stitched together: integrals bounded ⇔ partial sums bounded (from the sandwich), and partial sums bounded ⇔ summable (from nonnegativity)",
+      "Reindexing matters: writing the series as n ↦ f(n+1) makes the parent's left Riemann sum literally the partial sum, and Finset.sum_range_succ' converts the right Riemann sum into 'partial sum minus the first term'",
+      "The BddAbove formulation sidesteps improper integrals entirely — one only ever compares the monotone sequence of proper integrals ∫₁^{1+n} f against the partial sums",
+      "Divergence and convergence come from the same statement: an unbounded integral (log(n+1) for 1/x) forces non-summability, while a bounded one would force summability",
+      "This is the reusable engine the parent's implications pointed to — the 1/x specialization there and the harmonic divergence here are two instances of one criterion"
+    ],
+    "prerequisites": [
+      "Antitone / AntitoneOn functions and the sum–integral sandwich of the parent entry",
+      "Summable and tsum for nonnegative real series; summable ⇔ bounded partial sums",
+      "Interval integrals and the evaluation ∫ 1/x = log",
+      "BddAbove, upper bounds, and the divergence of log at infinity"
+    ]
+  },
+  "conclusion": {
+    "summary": "The parent's sum–integral sandwich is promoted to the general integral test: for an antitone nonnegative f on [1,∞), ∑ₙ f(n+1) is summable iff the integrals ∫₁^{1+n} f are bounded above. The criterion is then applied to 1/x to reprove that the harmonic series diverges, its integrals log(n+1) being unbounded. 7 theorems, 141 lines, 0 sorries, 0 axioms.",
+    "implications": "Adds the missing convergence dichotomy to the gallery's integral-test infrastructure in reusable form: integral_test applies verbatim to any antitone nonnegative summand, so a p-series result (∑ 1/(n+1)^p convergent iff p > 1) reduces to bounding ∫₁^{1+n} x^{-p}, and the harmonic divergence recovered here is the p = 1 instance. The Summable ↔ BddAbove shape is exactly what downstream comparison-test arguments consume.",
+    "openQuestions": [
+      "Instantiate integral_test at f(x) = 1/x^p to obtain the full p-series dichotomy ∑ 1/(n+1)^p convergent iff p > 1, using ∫₁^{1+n} x^{-p} = (1 − (1+n)^{1−p})/(p−1)",
+      "Derive the tsum comparison ∫₁^∞ f ≤ ∑ f(n) ≤ f(1) + ∫₁^∞ f for a summable antitone f, upgrading the BddAbove criterion to a two-sided bound on the sum",
+      "State the monotone (increasing-function) analogue of the test from MonotoneOn.sum_le_integral / integral_le_sum for divergent comparison"
+    ]
+  },
+  "leanFile": {
+    "namespace": "AntitoneIntegralTest",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/AntitoneIntegralTest.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up child of **antitone-integral-sum-comparison-oq-01** ("The Integral Test: Sum–Integral Comparison for Antitone Functions"). The parent built the two-sided Riemann-sum sandwich and applied it to the single function `1/x`; its own *implications* note called that sandwich "the template for p-series and other comparison-test results." This entry supplies the missing template itself — the **general integral test** as a convergence dichotomy:

> For an antitone, nonnegative `f` on `[1, ∞)`,
> `Summable (n ↦ f(n+1))  ↔  BddAbove { ∫₁^{1+n} f : n ∈ ℕ }`.

Mathlib provides the one-step comparisons `AntitoneOn.sum_le_integral` / `AntitoneOn.integral_le_sum` but **no convergence criterion**, and the gallery had none. As a worked application the test is turned back on `1/x` to reprove the classical **divergence of the harmonic series** purely from the integral side: `∫₁^{1+n} 1/x = log(n+1)` is unbounded, so `∑ 1/(n+1)` cannot be summable.

## Contents (`Proofs/AntitoneIntegralTest.lean`, namespace `AntitoneIntegralTest`)

- `integral_le_partialSum` / `partialSum_succ_le` — the two comparisons reindexed to the series `n ↦ f(n+1)`, trapping the integrals and partial sums within `f(1)` of each other.
- `integral_test` — the main dichotomy `Summable ↔ BddAbove`. Forward via `sum_le_hasSum`; reverse via `summable_of_sum_range_le` (bounded partial sums of a nonnegative series).
- `not_summable_one_div_harmonic` — the harmonic series diverges, obtained by feeding the unbounded `log(n+1)` integrals into the test.

## Verification

- **0 sorries, 0 axioms.** `#print axioms` on all main theorems lists only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- Docker build succeeds (`7743/7743` jobs).
- 141 lines, 7 theorems, 0 definitions.

## Relation to existing work

The result is genuinely absent from Mathlib (its Euler–Mascheroni / p-series files provide specific limits, not the antitone convergence dichotomy). Harmonic divergence appears elsewhere in the gallery, but here it is only a *demonstration* of the general criterion — the contribution is the reusable `Summable ↔ BddAbove` engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)