### PR TITLE
Fix: erdos-1047 leanFile.path aligned to proofRepoPath (Main.lean)

### DIFF
--- a/src/data/proofs/erdos-1047/meta.json
+++ b/src/data/proofs/erdos-1047/meta.json
@@ -244,22 +244,18 @@
   ],
   "leanFile": {
     "imports": [
-      "Mathlib.Analysis.Complex.Polynomial.Basic",
-      "Mathlib.Analysis.Normed.Field.Basic",
-      "Mathlib.Topology.Connected.Basic",
-      "Mathlib.Topology.MetricSpace.Basic",
-      "Mathlib.Algebra.Polynomial.Eval.SMul"
+      "Proofs.Erdos1047OQ02Certificate"
     ],
     "opens": [
       "Polynomial",
       "Set"
     ],
     "namespace": "Erdos1047",
-    "lineCount": 265,
+    "lineCount": 70,
     "axiomCount": 0,
-    "theoremCount": 10,
-    "definitionCount": 13,
-    "path": "Proofs/Erdos1047Problem.lean",
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1047Main.lean",
     "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos1047Problem.lean",


### PR DESCRIPTION
## Fix

Realign the `leanFile` block in `erdos-1047/meta.json` to describe the entry's actual primary file `Erdos1047Main.lean`, matching the authoritative `meta.proofRepoPath`.

## Evidence

The entry was refactored into multiple files: the four headline theorems (`erdos_1047`, `grunskyConjecture_false`, `erdos_1047_counterexample`, `erdos_1047_answer`) were relocated into `Proofs/Erdos1047Main.lean` (the primary file, pointed to by `meta.proofRepoPath`), while `Erdos1047Problem.lean` became a supporting definitions file. The `meta` block was updated accordingly, but the top-level `leanFile` block was left describing the old single file.

**Before**: `leanFile.path = "Proofs/Erdos1047Problem.lean"` (contradicts `proofRepoPath = "Proofs/Erdos1047Main.lean"`), counts describe the old file (265 lines / 10 thms / 13 defs), and the path was redundantly self-listed in `leanFile.additionalFiles`.

**After**: `leanFile.path = "Proofs/Erdos1047Main.lean"` with matching per-file metadata (70 lines / 4 thms / 0 defs, imports `Proofs.Erdos1047OQ02Certificate`). `additionalFiles` now correctly lists only the four supporting files.

This restores the two invariants that hold for all other 460 multi-file gallery entries: `leanFile.path == proofRepoPath`, and the primary file is never self-listed in `additionalFiles`. erdos-1047 was the sole violator of both across all 4225 entries.

`leanFile.path` is consumed by `scripts/herald/post-mathstodon.sh` (source-file link/verification) and the auditor/peer-reviewer target scripts, so the corrected path points those tools at the primary file. Verified status is unaffected (Main.lean has 0 real sorries — the two `sorry` tokens are in comments — and 0 axioms).

Metadata-only change; no Lean source or build impact.

---
Automated fix by lean-mechanic agent.