### PR TITLE
audit: mark 16 never-audited gallery entries clean (4231/4231)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26155,6 +26155,102 @@
       "lastAudited": "2026-07-01T03:20:14Z",
       "result": "clean",
       "issues": []
+    },
+    "algebraic-numbers-countable-oq-05-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "alternating-series-boole-summation-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "antitone-integral-sum-comparison-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-13-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "burnside-counting-oq-05-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-06-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-06-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cramers-rule-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cube-root-3-irrational-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-by-3-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fourth-root-2-degree4-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-08": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "markov-equation-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "platonic-solids-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T05:50:17Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Marked 16 previously never-audited entries as **clean** after full integrity checks.

### Checked (all CLEAN)
- `algebraic-numbers-countable-oq-05-oq-04` (verified/mathlib)
- `alternating-series-boole-summation-oq-01` (verified/original)
- `antitone-integral-sum-comparison-oq-01-oq-03` (verified/original)
- `basel-problem-oq-13-oq-02` (verified/mathlib)
- `burnside-counting-oq-05-oq-02` (verified/mathlib)
- `cauchy-schwarz-oq-04-oq-02` (verified/original)
- `combinations-formula-oq-06-oq-02` (verified/original)
- `combinations-formula-oq-06-oq-03` (verified/mathlib)
- `cramers-rule-oq-02-oq-01-oq-01-oq-01` (verified/original)
- `cube-root-3-irrational-oq-02-oq-04` (verified/original)
- `divisibility-by-3-oq-02-oq-02` (verified/mathlib)
- `factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01` (verified/original)
- `fourth-root-2-degree4-oq-02-oq-01` (verified/original)
- `lagrange-theorem-oq-08` (verified/original)
- `markov-equation-oq-05` (verified/original)
- `platonic-solids-oq-03-oq-01` (verified/original)

### Findings
For each: `sorries` field matches actual (0), `axiomCount` matches (0 axiom declarations, 0 structure-encoded assumptions), no `True`-stubs, badge/status consistent with Lean source.

**Only nuance:** `divisibility-by-3-oq-02-oq-02` contains 6 `native_decide` calls, but all are confined to anonymous `example` blocks (lines 148–209), not the presented named theorems. The verified/0-axiom claim is therefore correct; `assumptions` honestly discloses the Mathlib dependency.

Backlog after this: **4231/4231 audited, 0 with issues**.

---
Discovered during gallery integrity audit.