### PR TITLE
Enrich antitone integral-test family (4 entries): add references

### DIFF
--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -73,6 +73,36 @@
     "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01.lean",
     "sorries": 0
   },
+  "references": [
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Mathematical Analysis (2nd ed.)",
+      "year": "1974",
+      "venue": "Addison-Wesley",
+      "note": "Standard reference for the integral test (Theorem 8.23) comparing ∑f(n) with ∫f, and its application to the p-series ∑1/nᵖ — the comparison framework this family formalizes."
+    },
+    {
+      "authors": "Knopp, Konrad",
+      "title": "Theory and Application of Infinite Series",
+      "year": "1951",
+      "venue": "Blackie & Son / Dover reprint",
+      "note": "Classical treatment of the integral (Cauchy–Maclaurin) test and monotone series–integral comparisons, the historical source of the sandwich ∑f(x₀+i) ≤ ∫f ≤ ∑f(x₀+i+1)."
+    },
+    {
+      "authors": "Graham, R. L.; Knuth, D. E.; Patashnik, O.",
+      "title": "Concrete Mathematics: A Foundation for Computer Science (2nd ed.)",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "note": "§9.5 (Euler–Maclaurin summation) gives the matching upper and lower Riemann-sum estimates that this entry assembles into the two-sided p-series tail sandwich."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Analysis.PSeries and Mathlib.MeasureTheory.Integral.FundThmCalculus",
+      "year": "2024",
+      "venue": "Lean 4 mathematical library (mathlib4)",
+      "note": "Source of the monotone/antitone Riemann-sum bounds against the integral and the interval-integral machinery through which this entry's sandwich and p-series estimates are proved."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02",

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/meta.json
@@ -121,6 +121,36 @@
     "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02.lean",
     "sorries": 0
   },
+  "references": [
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Mathematical Analysis (2nd ed.)",
+      "year": "1974",
+      "venue": "Addison-Wesley",
+      "note": "Standard reference for the integral test (Theorem 8.23) comparing ∑f(n) with ∫f, and its application to the p-series ∑1/nᵖ — the comparison framework this family formalizes."
+    },
+    {
+      "authors": "Knopp, Konrad",
+      "title": "Theory and Application of Infinite Series",
+      "year": "1951",
+      "venue": "Blackie & Son / Dover reprint",
+      "note": "Classical treatment of the integral (Cauchy–Maclaurin) test and monotone series–integral comparisons, the historical source of the sandwich ∑f(x₀+i) ≤ ∫f ≤ ∑f(x₀+i+1)."
+    },
+    {
+      "authors": "Graham, R. L.; Knuth, D. E.; Patashnik, O.",
+      "title": "Concrete Mathematics: A Foundation for Computer Science (2nd ed.)",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "note": "§9.5 (Euler–Maclaurin summation) develops the integral-comparison remainder estimates that give the p-series tail bound ∑_{n>N}1/nᵖ ≤ N^{1−p}/(p−1) proved here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Analysis.PSeries and Mathlib.MeasureTheory.Integral.FundThmCalculus",
+      "year": "2024",
+      "venue": "Lean 4 mathematical library (mathlib4)",
+      "note": "Source of the monotone/antitone Riemann-sum bounds against the integral and the interval-integral machinery through which this entry's sandwich and p-series estimates are proved."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "antitone-integral-sum-comparison-oq-01-oq-01",

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01/meta.json
@@ -73,6 +73,36 @@
     "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01.lean",
     "sorries": 0
   },
+  "references": [
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Mathematical Analysis (2nd ed.)",
+      "year": "1974",
+      "venue": "Addison-Wesley",
+      "note": "Standard reference for the integral test (Theorem 8.23) comparing ∑f(n) with ∫f, and its application to the p-series ∑1/nᵖ — the comparison framework this family formalizes."
+    },
+    {
+      "authors": "Knopp, Konrad",
+      "title": "Theory and Application of Infinite Series",
+      "year": "1951",
+      "venue": "Blackie & Son / Dover reprint",
+      "note": "Classical treatment of the integral (Cauchy–Maclaurin) test and monotone series–integral comparisons, the historical source of the sandwich ∑f(x₀+i) ≤ ∫f ≤ ∑f(x₀+i+1)."
+    },
+    {
+      "authors": "Robbins, Herbert",
+      "title": "A Remark on Stirling's Formula",
+      "year": "1955",
+      "venue": "The American Mathematical Monthly, vol. 62, no. 1",
+      "note": "Sharp elementary two-sided bounds for log n! of the form used here, obtained by exactly the integral-comparison technique applied to log x."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Analysis.PSeries and Mathlib.MeasureTheory.Integral.FundThmCalculus",
+      "year": "2024",
+      "venue": "Lean 4 mathematical library (mathlib4)",
+      "note": "Source of the monotone/antitone Riemann-sum bounds against the integral and the interval-integral machinery through which this entry's sandwich and p-series estimates are proved."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "antitone-integral-sum-comparison-oq-01",

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02/meta.json
@@ -124,6 +124,36 @@
     ]
   },
   "references": null,
+  "references": [
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Mathematical Analysis (2nd ed.)",
+      "year": "1974",
+      "venue": "Addison-Wesley",
+      "note": "Standard reference for the integral test (Theorem 8.23) comparing ∑f(n) with ∫f, and its application to the p-series ∑1/nᵖ — the comparison framework this family formalizes."
+    },
+    {
+      "authors": "Knopp, Konrad",
+      "title": "Theory and Application of Infinite Series",
+      "year": "1951",
+      "venue": "Blackie & Son / Dover reprint",
+      "note": "Classical treatment of the integral (Cauchy–Maclaurin) test and monotone series–integral comparisons, the historical source of the sandwich ∑f(x₀+i) ≤ ∫f ≤ ∑f(x₀+i+1)."
+    },
+    {
+      "authors": "Havil, Julian",
+      "title": "Gamma: Exploring Euler's Constant",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "note": "Book-length account of the Euler–Mascheroni constant γ = lim(Hₙ − log n), including the monotone-defect convergence argument this entry formalizes."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Analysis.PSeries and Mathlib.MeasureTheory.Integral.FundThmCalculus",
+      "year": "2024",
+      "venue": "Lean 4 mathematical library (mathlib4)",
+      "note": "Source of the monotone/antitone Riemann-sum bounds against the integral and the interval-integral machinery through which this entry's sandwich and p-series estimates are proved."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "antitone-integral-sum-comparison-oq-01",


### PR DESCRIPTION
## Enrichment pass

Adds curated 4-item `references` arrays (previously missing) to the four antitone integral-test / p-series children:

- `…-oq-01-oq-01` (Stirling bounds for log n!) — + Robbins (1955, *Monthly*)
- `…-oq-01-oq-02` (Euler–Mascheroni harmonic defect) — + Havil, *Gamma*
- `…-oq-01-oq-01-oq-02` (p-series tail remainder) — + Concrete Mathematics §9.5
- `…-oq-01-oq-01-oq-02-oq-01` (two-sided tail sandwich) — + Concrete Mathematics §9.5

All share Apostol, Knopp, and the Mathlib PSeries/interval-integral modules. crossReferences already present on all four and untouched. Each meta.json well under the 60 KB cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)