### PR TITLE
Enrich Eisenstein/Hurwitz/Jacobi sums-of-squares entries: add references

### DIFF
--- a/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01-oq-03/meta.json
@@ -9,7 +9,13 @@
     "date": "2026",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/FermatTwoSquaresOQ01OQ03.lean",
-    "tags": ["number-theory", "quaternions", "four-squares", "euclidean-domain", "hurwitz"],
+    "tags": [
+      "number-theory",
+      "quaternions",
+      "four-squares",
+      "euclidean-domain",
+      "hurwitz"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
@@ -156,5 +162,31 @@
       "relationship": "Sibling open question exploring representation counts and the role of quaternion arithmetic in the four-squares problem."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Hurwitz, A.",
+      "title": "Vorlesungen über die Zahlentheorie der Quaternionen",
+      "year": "1919",
+      "note": "Springer, Berlin. Introduces the Hurwitz order (with ω=½(1+i+j+k)) and its Euclidean structure, the ring formalized in this entry."
+    },
+    {
+      "authors": "Conway, J. H.; Smith, D. A.",
+      "title": "On Quaternions and Octonions: Their Geometry, Arithmetic, and Symmetry",
+      "year": "2003",
+      "note": "A K Peters. Modern account of the Hurwitz quaternions, their unit group of order 24, and the four-squares theorem via norm multiplicativity."
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers (6th ed.)",
+      "year": "2008",
+      "note": "Oxford University Press. §20.11–20.12 prove Lagrange's four-square theorem, including the quaternion-based argument."
+    },
+    {
+      "authors": "Davidoff, G.; Sarnak, P.; Valette, A.",
+      "title": "Elementary Number Theory, Group Theory and Ramanujan Graphs",
+      "year": "2003",
+      "note": "Cambridge LMS Student Texts 55. Uses the arithmetic of Hurwitz (integer) quaternions and sums of four squares as the foundation for constructing Ramanujan graphs."
+    }
+  ]
 }

--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -366,5 +366,31 @@
       "relationship": "uses",
       "description": "Lagrange's four-square theorem (every n ≥ 0 is a sum of four integer squares). Lagrange gives existence; Jacobi's formula refines this by counting representations exactly. r₄(n) ≥ 1 for all n ≥ 0 from Lagrange, and Jacobi's r₄(n) = 8·σ*(n) > 0 confirms this for n ≥ 1."
     }
+  ],
+  "references": [
+    {
+      "authors": "Jacobi, C. G. J.",
+      "title": "Fundamenta Nova Theoriae Functionum Ellipticarum",
+      "year": "1829",
+      "note": "Königsberg. Derives the four-square formula r₄(n)=8·∑_{d|n,4∤d}d from theta-function (elliptic function) identities — the result this entry axiomatizes pending modular-form machinery."
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers (6th ed.)",
+      "year": "2008",
+      "note": "Oxford University Press. §20.12–20.13 state and prove Jacobi's formula r₄(n)=8σ*(n) for the number of representations as four squares."
+    },
+    {
+      "authors": "Grosswald, E.",
+      "title": "Representations of Integers as Sums of Squares",
+      "year": "1985",
+      "note": "Springer. A comprehensive reference for rₖ(n) formulas, including Jacobi's four-square theorem and its modular-form proofs."
+    },
+    {
+      "authors": "Hirschhorn, M. D.",
+      "title": "The Power of q: A Personal Journey",
+      "year": "2017",
+      "note": "Springer Developments in Mathematics 49. Gives elementary q-series proofs of Jacobi's two- and four-square theorems."
+    }
   ]
 }

--- a/src/data/proofs/zsqrtd-neg-two-oq-03/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-03/meta.json
@@ -205,5 +205,31 @@
       "relationship": "analogous",
       "description": "Lagrange's four-squares theorem $\\forall n \\in \\mathbb{N},\\ \\exists a,b,c,d \\in \\mathbb{Z},\\ n = a^2 + b^2 + c^2 + d^2$ uses the **Hurwitz quaternions** $\\mathcal{H}$ — a maximal-order construction in the non-commutative algebra $\\mathbb{H}$ over $\\mathbb{Q}$ — exactly as this file uses the **Eisenstein integers** $\\mathbb{Z}[\\omega]$ as the maximal order in the commutative algebra $\\mathbb{Q}(\\sqrt{-3})$. Both proofs share the same three-step skeleton: (i) build a maximal-order ring with a multiplicative norm; (ii) show that any prime factors in that ring (via a left-Euclidean or two-sided Euclidean argument with the norm); (iii) translate the norm equation $p = N(\\alpha)$ back to the target quadratic form. The norm-multiplicativity step (`norm_mul` in this file) is the analog of the Euler four-squares identity in the Hurwitz proof."
     }
+  ],
+  "references": [
+    {
+      "authors": "Cox, D. A.",
+      "title": "Primes of the Form x² + ny²: Fermat, Class Field Theory, and Complex Multiplication",
+      "year": "1989",
+      "note": "Wiley. The definitive treatment of which primes are represented by x²+ny²; the x²+3y² case handled here corresponds to the class-number-one order ℤ[ω] of Eisenstein integers."
+    },
+    {
+      "authors": "Ireland, K.; Rosen, M.",
+      "title": "A Classical Introduction to Modern Number Theory (2nd ed.)",
+      "year": "1990",
+      "note": "Springer GTM 84. Chapter 9 develops the ring of Eisenstein integers ℤ[ω] with ω²+ω+1=0, its norm N(a+bω)=a²−ab+b², units, and cubic reciprocity."
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers (6th ed.)",
+      "year": "2008",
+      "note": "Oxford University Press. §15.4 treats the Eisenstein (Jacobian) integers and their Euclidean structure."
+    },
+    {
+      "authors": "Stark, H. M.",
+      "title": "A complete determination of the complex quadratic fields of class-number one",
+      "year": "1967",
+      "note": "Michigan Mathematical Journal 14, 1–27. The nine Heegner numbers (including −3, giving ℤ[ω]) are exactly the imaginary quadratic fields with unique factorization — the class-number-one property this entry relies on."
+    }
   ]
 }


### PR DESCRIPTION
## Enrichment: references

Three rich sums-of-squares number-theory entries had empty `references`. Added authoritative, content-matched references:

**zsqrtd-neg-two-oq-03** — Eisenstein integers ℤ[ω], x²+3y² representation: Cox *Primes of the Form x²+ny²*, Ireland–Rosen, Hardy–Wright, Stark (class-number-one).

**fermat-two-squares-oq-01-oq-03** — Hurwitz quaternions & Lagrange four squares: Hurwitz (1919), Conway–Smith, Hardy–Wright, Davidoff–Sarnak–Valette.

**four-square-distribution-oq-01** — Jacobi's formula r₄(n)=8σ*(n): Jacobi (1829), Hardy–Wright, Grosswald, Hirschhorn.

All files remain well under the 60 KB / 25-reference caps. No other fields touched.