### PR TITLE
seeker: replenish pool with 6 tractable OQ-child research problems

### DIFF
--- a/research/problems/derangements-oq-04-oq-01-oq-01/problem.md
+++ b/research/problems/derangements-oq-04-oq-01-oq-01/problem.md
@@ -1,0 +1,211 @@
+# Problem: Poisson(1) Limit of the Fixed-Point Distribution
+
+**Slug**: derangements-oq-04-oq-01-oq-01
+**Created**: 2026-06-30T22:49:26-07:00
+**Status**: Active
+**Source**: proof-suggestion
+
+## Problem Statement
+
+### Formal Statement
+
+Let $S(n,k)$ be the number of permutations of an $n$-element set with **exactly
+$k$ fixed points** (the rencontres / partial-derangement numbers). The parent entry
+proves the finite closed form, over any characteristic-zero field,
+$$
+\frac{S(n,k)}{n!} \;=\; \frac{1}{k!}\sum_{j=0}^{n-k}\frac{(-1)^j}{j!}.
+$$
+The goal is the $n \to \infty$ limit: for each fixed $k \in \mathbb{N}$,
+$$
+\lim_{n\to\infty}\frac{S(n,k)}{n!}
+  \;=\; \frac{1}{k!}\sum_{j=0}^{\infty}\frac{(-1)^j}{j!}
+  \;=\; \frac{e^{-1}}{k!}.
+$$
+In Lean, with the count realized as a cardinality over `Equiv.Perm (Fin n)`:
+$$
+\texttt{Filter.Tendsto}\Big(\lambda\, n \mapsto \tfrac{S(n,k)}{n!} : \mathbb{R}\Big)\ \texttt{atTop}\ \big(\mathcal{N}(\tfrac{e^{-1}}{k!})\big),
+$$
+i.e. the fixed-point-count distribution converges pointwise (in $k$) to the
+**Poisson(1)** probability mass function $p(k) = e^{-1}/k!$.
+
+### Plain Language
+
+Pick a permutation of $\{1,\dots,n\}$ uniformly at random and count how many
+elements it leaves fixed. The probability of seeing exactly $k$ fixed points is
+$S(n,k)/n!$. As $n$ grows, this probability settles down to $e^{-1}/k!$ — the
+probability of the value $k$ under a Poisson distribution with mean $1$. So the
+number of fixed points of a large random permutation behaves like a Poisson(1)
+random variable: on average one fixed point, with the classic $1/e \approx 0.3679$
+chance of a full derangement ($k = 0$).
+
+### Why This Matters
+
+- **Completes the rencontres story.** The parent gives the *finite* identity; this
+  entry gives its *asymptotic* payoff — the single most-quoted fact about the
+  distribution of fixed points.
+- **The canonical Poisson approximation.** Fixed points of a random permutation are
+  the textbook example where a sum of weakly dependent indicators converges to a
+  Poisson law; here it falls out of an exact closed form rather than a coupling or
+  Chen–Stein argument.
+- **Recovers $1/e$ at $k=0$.** The $k=0$ case is exactly the derangement limit
+  $D_n/n! \to 1/e$, tying this child to `derangements-oq-03` (the sharp rate) and to
+  the classical Montmort matching-problem answer.
+
+## Known Results
+
+### What's Already Proven
+
+- **Finite closed form** (parent `derangements-oq-04-oq-01`,
+  `card_perms_with_kfixed_closed_form`): over any characteristic-zero field
+  $\mathbb{K}$,
+  $S(n,k) = \dfrac{n!}{k!}\sum_{j=0}^{n-k}(-1)^j/j!$ for $k \le n$; with ℚ/ℝ
+  specializations `card_perms_with_kfixed_closed_form_rat` / `_real`.
+- **Truncated-exponential phrasing** (`card_perms_with_kfixed_eq_factorial_mul_trunc`):
+  the bracket is `DerangementsOQ04.truncExpNegOne 𝕜 (n-k+1)`, the order-$(n-k)$
+  truncation of the series for $e^{-1}$.
+- **Combinatorial count** (sibling `derangements-oq-02`,
+  `PartialDerangements.card_perms_with_kfixed`): $S(n,k) = \binom{n}{k}\,D_{n-k}$.
+- **Derangement closed form** (`DerangementsOQ04.numDerangements_closed_form`):
+  $(D_m : \mathbb{K}) = m!\sum_{j\le m}(-1)^j/j!$.
+- **Exponential series in Mathlib**: `Real.exp_eq_exp_ℝ` / `NormedSpace.expSeries`
+  and `Real.exp (-1) = ∑' j, (-1)^j / j!` give the target value of the infinite sum.
+
+### What's Still Open
+
+- The pointwise Poisson(1) limit stated above (this entry's goal).
+- Uniform / total-variation convergence of the whole distribution to Poisson(1)
+  (a strictly stronger, out-of-scope statement).
+- The bivariate exponential generating function $e^{(x-1)t}/(1-t)$ (the sibling
+  second open question, separate from this one).
+
+### Our Goal
+
+Prove, for each fixed $k$, that $\lambda\, n \mapsto S(n,k)/n! \to e^{-1}/k!$ as
+$n \to \infty$ over $\mathbb{R}$. The finite identity is already in hand, so the
+task is a **clean analytic limit**: show the truncated alternating sum
+$\sum_{j=0}^{n-k}(-1)^j/j!$ converges to $e^{-1}$ and divide by the constant $k!$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| derangements-oq-04-oq-01 | Parent: supplies the finite closed form $S(n,k)=(n!/k!)\sum(-1)^j/j!$ being taken to the limit | choose/factorial bridge, `linear_combination` |
+| derangements-oq-04 | Grandparent: field derangement closed form $D_m = m!\sum(-1)^j/j!$ and `truncExpNegOne` | induction, truncated exponential |
+| derangements-oq-03 | Sibling: sharp rate $|D_n/n! - 1/e| \le 1/(n+1)!$ — the $k=0$ instance with an explicit tail bound | alternating-series tail estimate |
+| derangements-oq-02 | Foundational: $S(n,k)=\binom{n}{k}D_{n-k}$ | support bijection to derangements |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — partial sums of `Real.exp (-1)`.**
+   $e^{-1} = \sum_{j=0}^{\infty}(-1)^j/j!$ via `Real.exp_eq_tsum` / `NormedSpace.expSeries`
+   at $x = -1$. The truncated sum $\sum_{j=0}^{n-k}(-1)^j/j!$ is exactly the
+   $(n-k+1)$-th partial sum. Since the exponential series is summable, its partial
+   sums tend to the tsum (`HasSum.tendsto_sum_nat`); reindex $n \mapsto n-k$ (a
+   `Filter.Tendsto` on `atTop`, cofinal shift) to get the truncation $\to e^{-1}$.
+   Then multiply by the constant $1/k!$ with `Filter.Tendsto.const_mul` /
+   `Tendsto.div_const`.
+   - Why it works: the hard combinatorics is already the finite identity; only a
+     summable-series limit remains, and Mathlib has the exact building block.
+   - Risk: index bookkeeping — the sum runs to $n-k$, the range is $n-k+1$, and the
+     $k \le n$ hypothesis must be threaded so the closed form applies eventually.
+
+2. **Approach B — explicit alternating-tail bound (reuse derangements-oq-03).**
+   For an alternating series with decreasing terms, $\big|\sum_{j=0}^{m}(-1)^j/j! - e^{-1}\big| \le 1/(m+1)!$.
+   The sibling `derangements-oq-03` already formalizes this tail estimate for the
+   $k=0$ case; lift it to a `Tendsto` via `squeeze_zero` / `tendsto_of_tendsto_of_tendsto_of_le_of_le`
+   using $1/(m+1)! \to 0$ (`Nat.factorial` grows, `tendsto_one_div_atTop` style).
+   - Why it works: gives an effective rate, mirrors an existing entry, avoids
+     `tsum` machinery.
+   - Risk: re-deriving the tail bound if the sibling lemma is not directly reusable.
+
+### Key Difficulties
+
+- Threading the eventual hypothesis $k \le n$: the closed form holds only for
+  $n \ge k$, so the limit must be argued on the cofinal tail (`Filter.eventually_atTop`).
+- Reindexing the sum bound $n-k$ against Mathlib's partial-sum lemmas, which are
+  phrased in terms of the summation range endpoint.
+- Casting: cardinalities are `ℕ`; the limit lives in `ℝ`; keep `push_cast` /
+  `Nat.cast` coercions clean.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `Real.exp (-1) = ∑' j, (-1)^j / j!` (from `Real.exp_eq_tsum` or
+  `NormedSpace.expSeries` summability) and `HasSum.tendsto_sum_nat`.
+- Key lemma 2: the finite identity `card_perms_with_kfixed_closed_form_real` divided
+  through by `n!`, valid eventually in `n`.
+- Key lemma 3: partial-sum reindexing on `atTop` (`Filter.tendsto_atTop` cofinal
+  shift by $k$) plus `Tendsto.const_mul` for the $1/k!$ factor.
+- Technical requirement: `Filter.Tendsto`, `tsum`, `HasSum`, `Nat.factorial`,
+  `Real.exp`, and eventual-equality of two sequences (`Filter.Tendsto.congr'`).
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The combinatorial and algebraic content is fully proven in the parent/siblings;
+  what remains is a standard limit of a convergent alternating series.
+- The exponential series, its summability, and partial-sum convergence are all in
+  Mathlib (`Real.exp_eq_tsum`, `NormedSpace.expSeries`, `HasSum.tendsto_sum_nat`).
+- The sibling `derangements-oq-03` already handles the $k=0$ tail bound, giving a
+  proven template to generalize.
+- The only real friction is index/eventual-hypothesis bookkeeping and casts, which
+  is fiddly but routine.
+
+**Estimated Effort**:
+- Exploration: 0.5–1 day
+- If tractable: 2–4 days
+- If hard: 1 week (only if the reindexing/eventual-equality plumbing proves stubborn)
+
+## References
+
+### Papers
+- Montmort, P. R., *Essay d'analyse sur les jeux de hasard*, 1708 — the problème des
+  rencontres; the matching problem whose limiting probability is $1/e$.
+- Euler, L., *Calcul de la probabilité dans le jeu de rencontre*, 1751 — establishes
+  $D_n = n!\sum_{k=0}^n(-1)^k/k!$, the $k=0$ case.
+- Riordan, J., *An Introduction to Combinatorial Analysis*, Wiley, 1958 — rencontres
+  numbers $S(n,k) = \binom{n}{k}D_{n-k}$ and their asymptotics.
+- Barbour, Holst, Janson, *Poisson Approximation*, Oxford, 1992 — fixed points of a
+  random permutation as the canonical Poisson(1) limit.
+- Feller, W., *An Introduction to Probability Theory and Its Applications, Vol. I*,
+  Wiley — the matching problem and its Poisson limit in the standard probability text.
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Rencontres_numbers — closed form and Poisson limit.
+- https://en.wikipedia.org/wiki/Random_permutation_statistics — fixed-point count and
+  its convergence to Poisson(1).
+
+### Mathlib
+- `Mathlib.Analysis.SpecialFunctions.Exp` — `Real.exp`, `Real.exp_eq_tsum`.
+- `Mathlib.Analysis.SpecialFunctions.Exponential` / `NormedSpace.expSeries` — the
+  exponential series and its summability.
+- `Mathlib.Topology.Algebra.InfiniteSum.Basic` — `tsum`, `HasSum`,
+  `HasSum.tendsto_sum_nat`.
+- `Mathlib.Order.Filter.AtTopBot` / `Mathlib.Topology.Algebra.Order` —
+  `Filter.Tendsto`, `Tendsto.const_mul`, cofinal shift and eventual equality.
+- `Mathlib.Data.Nat.Factorial.Basic` — `Nat.factorial`, `Nat.factorial_ne_zero`.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - analysis
+  - derangements
+  - rencontres-numbers
+  - poisson-distribution
+  - limit
+  - exponential-series
+  - random-permutations
+related_proofs:
+  - derangements-oq-04-oq-01
+  - derangements-oq-04
+  - derangements-oq-03
+  - derangements-oq-02
+difficulty: medium
+source: proof-suggestion
+created: 2026-06-30T22:49:26-07:00
+```

--- a/research/problems/harmonic-divergence-oq-06-oq-02/problem.md
+++ b/research/problems/harmonic-divergence-oq-06-oq-02/problem.md
@@ -1,0 +1,222 @@
+# Problem: Divergence of Σ 1/(a·n+b) for b ≥ 0 (including the b = 0 scaled-harmonic case)
+
+**Slug**: harmonic-divergence-oq-06-oq-02
+**Created**: 2026-06-30T22:49:26-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For real $a > 0$ and $b \ge 0$, the reciprocal series along the arithmetic
+progression $a\,n + b$ diverges:
+
+$$
+\forall\, a > 0,\ \forall\, b \ge 0,\qquad
+\sum_{n \ge 1} \frac{1}{a\,n + b} = +\infty
+\quad\Longleftrightarrow\quad
+\neg\,\text{Summable}\ \Bigl(n \mapsto \tfrac{1}{a\,n + b}\Bigr).
+$$
+
+The new content over the parent (which requires $b > 0$) is the endpoint
+$b = 0$, where the series is exactly the harmonic series rescaled by $1/a$:
+
+$$
+\sum_{n \ge 1} \frac{1}{a\,n} \;=\; \frac{1}{a}\sum_{n \ge 1} \frac{1}{n}
+\;=\; +\infty .
+$$
+
+Because $\tfrac{1}{a\cdot 0}=\tfrac{1}{0}$ is undefined, the $b=0$ series must be
+indexed from $n = 1$: the $n = 0$ term is excised. Equivalently, in Lean one
+either sums over `fun n : ℕ => 1/(a*(n+1))` or invokes the index-shift lemma so
+that only strictly positive multiples $a, 2a, 3a, \dots$ appear.
+
+### Plain Language
+
+The parent proof shows that the reciprocals of any arithmetic progression
+$b, a+b, 2a+b, \dots$ add up to infinity, **provided the progression starts at a
+strictly positive value** ($b > 0$). This open question closes the last gap:
+allow $b = 0$ as well.
+
+When $b = 0$ the progression is just $0, a, 2a, 3a, \dots$. The very first term
+$1/0$ makes no sense, so we throw it away and sum the reciprocals of the
+positive multiples of $a$: $\tfrac1a + \tfrac1{2a} + \tfrac1{3a} + \cdots$.
+Factoring out $1/a$ turns this into $\tfrac1a\,(1 + \tfrac12 + \tfrac13 + \cdots)$
+— exactly $1/a$ times the harmonic series. Since the harmonic series diverges,
+so does its constant multiple, and the whole family $\Sigma\,1/(a n + b)$ for
+$a > 0$, $b \ge 0$ is handled uniformly.
+
+### Why This Matters
+
+- **Completes the arithmetic-progression divergence family.** The parent settles
+  $b > 0$; this settles $b = 0$. Together they give one clean statement covering
+  every $a > 0$, $b \ge 0$ — including the pure "multiples of $a$" case that is
+  the most natural starting point and the one closest to the raw harmonic series.
+- **Uniform treatment of $\Sigma\,1/(a n + b)$.** Rather than special-casing the
+  endpoint, the whole progression family becomes a single theorem, ready to be
+  reused by any downstream result that needs "linear-density reciprocal series
+  diverge."
+- **Illustrates the scaling principle.** The $b = 0$ case is a textbook example
+  that summability is invariant under multiplication by a nonzero constant, and
+  that a divergent series stays divergent when rescaled. This is precisely the
+  content of Mathlib's `summable_mul_left_iff`.
+
+## Known Results
+
+### What's Already Proven
+
+- **Parent, `not_summable_one_div_arith`** (gallery `harmonic-divergence-oq-06`,
+  VERIFIED, 0-axiom): for $a > 0$, $b > 0$,
+  $\neg\,\text{Summable}\,(n \mapsto 1/(a n + b))$, by comparison with the
+  harmonic series via $a n + b \le (a+b)(n+1)$. — `Proofs/HarmonicDivergenceOQ06.lean`
+- **Corollaries in the parent**: `not_summable_one_div_odd` ($a=2,b=1$),
+  `not_summable_one_div_even` ($a=2,b=2$), and
+  `tendsto_sum_one_div_odd_atTop` (odd partial sums $\to +\infty$).
+- **Harmonic divergence**, `Real.not_summable_one_div_natCast`:
+  $\neg\,\text{Summable}\,(n \mapsto 1/(n:\mathbb{R}))$ — Mathlib
+  `Mathlib.Analysis.PSeries`. This is the engine everything reduces to.
+
+### What's Still Open
+
+- The $b = 0$ endpoint: $\neg\,\text{Summable}\,(n \mapsto 1/(a n))$ for $a > 0$,
+  handled by excising $n = 0$ (index from $1$) and factoring out $1/a$. **(This
+  problem.)**
+- Sibling OQ (oq-01): the explicit odd-harmonic asymptotic
+  $\Sigma_{i<n}\,1/(2i+1) = \tfrac12(\ln n + \gamma + \ln 4) + o(1)$.
+- Sibling OQ (oq-03): Cesàro / Abel summability and the contrast with the
+  conditionally convergent alternating series $\Sigma\,(-1)^n/(2n+1) = \pi/4$.
+
+### Our Goal
+
+Prove the $b \ge 0$ statement, i.e. extend the parent to admit $b = 0$. The core
+new lemma is the scaled-harmonic divergence
+
+$$
+\neg\,\text{Summable}\ \Bigl(n \mapsto \tfrac{1}{a\,(n+1)}\Bigr)\quad (a > 0),
+$$
+
+then package a single theorem `not_summable_one_div_arith'` with hypothesis
+`0 ≤ b` that dispatches to the parent when $b > 0$ and to the scaled-harmonic
+lemma when $b = 0$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| harmonic-divergence-oq-06 | Direct parent; supplies the $b>0$ case and the comparison machinery | comparison test, index shift, `nlinarith` |
+| harmonic-divergence | Divergence of $\Sigma\,1/n$, the ultimate engine | Oresme dyadic blocking / `PSeries` |
+| p-series | $\Sigma\,1/n^p$ converges iff $p>1$; here is the borderline $p=1$ linear case | `Real.summable_one_div_nat_rpow` |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — scaling reduction (recommended).**
+   For $b = 0$, write $1/(a(n+1)) = (1/a)\cdot 1/(n+1)$ and use
+   `summable_mul_left_iff` (needs $a \ne 0$, available from $a > 0$):
+   `Summable (fun n => 1/(a*(n+1)))` $\leftrightarrow$
+   `Summable (fun n => 1/(n+1))`. The right side fails by
+   `Real.not_summable_one_div_natCast` transported through `summable_nat_add_iff`.
+   - Why it might work: it is essentially the parent's endgame minus the
+     comparison inequality — the scaling makes the reduction *exact* rather than
+     by domination.
+   - Risk: aligning the `1/(a*(n+1))` shape with the `(1/a) * (1/(n+1))` shape
+     needs a `field_simp` / `mul_one_div` massage; and choosing whether to index
+     from `n+1` or apply `summable_nat_add_iff` on `fun n => 1/(a*n)`.
+
+2. **Approach B — comparison, reusing the parent verbatim.**
+   Keep the parent inequality but at $b = 0$: $a n \le a(n+1)$ trivially, and
+   $1/(n+1) \le a \cdot 1/(a n)$ for $n \ge 1$. This mirrors the parent's
+   `Summable.of_nonneg_of_le` structure and dominates the shifted harmonic
+   series directly, avoiding the iff lemma.
+   - Why it might work: maximal code reuse; the parent proof already establishes
+     every supporting lemma.
+   - Risk: the comparison bound must start at $n = 1$ (the excised term), so the
+     shift bookkeeping is slightly fussier than Approach A's clean iff.
+
+### Key Difficulties
+
+- **Excising $n = 0$.** The only genuine subtlety: at $b = 0$, $1/(a\cdot 0)$ is
+  the junk value $1/0 = 0$ in Lean's `ℝ`, which would silently *shrink* the tail
+  and could mask divergence if handled naively. Index from $n = 1$ (or use
+  `summable_nat_add_iff` with shift $1$) so only positive denominators occur.
+- **Shape matching.** Getting `1/(a*(n+1))` into the exact form consumed by
+  `summable_mul_left_iff` / `Summable.mul_left`.
+- **Unifying $b = 0$ and $b > 0$** into one hypothesis `0 ≤ b` via
+  `rcases eq_or_lt_of_le hb` (or `lt_or_eq`) without duplicating the whole proof.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `not_summable_one_div_scaled_harmonic (a : ℝ) (ha : 0 < a) :
+  ¬ Summable (fun n : ℕ => 1/(a*(n+1)))` — via `summable_mul_left_iff` (or
+  `Summable.mul_left` on the contrapositive) reducing to
+  `Real.not_summable_one_div_natCast`.
+- Key lemma 2 (packaging): `not_summable_one_div_arith' (a b : ℝ)
+  (ha : 0 < a) (hb : 0 ≤ b) : ¬ Summable (fun n : ℕ => 1/(a*n+b))` splitting on
+  `b = 0` vs `b > 0`.
+- Technical requirements: `summable_mul_left_iff`, `Summable.mul_left`,
+  `summable_nat_add_iff`, `Real.not_summable_one_div_natCast`, `mul_one_div`,
+  `field_simp`, and `ne_of_gt` for `a ≠ 0`.
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium
+
+**Justification**:
+- The $b = 0$ case is a near-mechanical reduction to the already-formalized
+  harmonic divergence via a single scaling step; no new mathematical idea beyond
+  "constant multiple of a divergent series diverges."
+- The parent proof already ships every supporting lemma (comparison, index
+  shift, harmonic non-summability), so most of the work is plumbing.
+- The one care point — excising $n = 0$ and matching the `mul_left` shape — is a
+  standard Mathlib manipulation with well-known lemmas.
+
+**Estimated Effort**:
+- Exploration: a few hours (confirm `summable_mul_left_iff` signature and the
+  cleanest index-shift path).
+- If tractable: 1–2 days for the scaled lemma plus the unified `0 ≤ b` wrapper
+  and a couple of corollaries (e.g. $\Sigma\,1/(3n)$).
+- If hard: unlikely; worst case is fiddly rewriting, not a genuine obstruction.
+
+## References
+
+### Papers
+- Nicole Oresme, *Quaestiones super Geometriam Euclidis*, c. 1350 — first proof
+  that the harmonic series diverges (dyadic blocking); the scaled series here is
+  an immediate corollary.
+- Leonhard Euler, *Variae observationes circa series infinitas*, 1737 — study of
+  reciprocal series, including $\Sigma\,1/p$ over primes.
+
+### Online Resources
+- Divergence of arithmetic-progression reciprocal series — the general fact that
+  $\Sigma\,1/n_k$ diverges when $n_k$ grows at most linearly.
+
+### Mathlib
+- `Mathlib.Analysis.PSeries` — `Real.not_summable_one_div_natCast` /
+  `Real.not_summable_nat_cast_inv`: divergence of the harmonic series.
+- `Mathlib.Topology.Algebra.InfiniteSum.*` — `Summable.mul_left`,
+  `summable_mul_left_iff` (scaling a series by a nonzero constant preserves
+  summability), `summable_nat_add_iff` (index-shift), and the comparison test
+  `Summable.of_nonneg_of_le` / `summable_of_nonneg`.
+- `Finset.sum` and `not_summable_iff_tendsto_nat_atTop_of_nonneg` — for phrasing
+  the divergence as partial sums $\to +\infty$.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - series
+  - harmonic-series
+  - summability
+  - arithmetic-progression
+  - comparison-test
+related_proofs:
+  - harmonic-divergence-oq-06
+  - harmonic-divergence
+  - p-series
+difficulty: medium
+source: gallery-gap
+created: 2026-06-30T22:49:26-07:00
+```

--- a/research/problems/konigsberg-oq-02-oq-01-oq-02/problem.md
+++ b/research/problems/konigsberg-oq-02-oq-01-oq-02/problem.md
@@ -1,0 +1,276 @@
+# Problem: Undirected Eulerian Circuit Theorem (Euler's Characterization)
+
+**Slug**: konigsberg-oq-02-oq-01-oq-02
+**Created**: 2026-06-30T22:49:26-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let $G = (V, E)$ be a finite, connected (multi)graph. Euler's theorem
+characterizes when $G$ admits an *Eulerian circuit* — a closed walk that
+traverses every edge exactly once — and an *Eulerian trail* — an open walk
+with the same edge-covering property:
+
+$$
+G \text{ has an Eulerian circuit} \iff G \text{ is connected and } \deg(v) \text{ is even for every } v \in V.
+$$
+
+$$
+G \text{ has an Eulerian trail} \iff G \text{ is connected and the number of odd-degree vertices is } 0 \text{ or } 2.
+$$
+
+Equivalently, writing $O = \{\, v \in V : \deg(v) \text{ is odd}\,\}$, a
+connected graph has an Eulerian trail iff $|O| \in \{0, 2\}$; the circuit case
+is exactly $|O| = 0$, and when $|O| = 2$ the trail must start at one odd-degree
+vertex and end at the other. (The handshake lemma forces $|O|$ to be even, so
+$|O| = 1$ is impossible.)
+
+In the Mathlib formulation the target existence theorem reads:
+
+$$
+\bigl(G.\mathrm{Connected}\bigr) \;\wedge\; \bigl(\forall v,\ \mathrm{Even}\,(G.\deg v)\bigr)
+\;\Longrightarrow\; \exists\, v_0\ (p : G.\mathrm{Walk}\ v_0\ v_0),\ p.\mathrm{IsEulerian} \wedge p.\mathrm{IsCircuit}.
+$$
+
+### Plain Language
+
+This is the theorem that started graph theory. In 1736 Leonhard Euler was asked
+whether one could stroll through Königsberg crossing each of its seven bridges
+exactly once and return home. He proved it impossible, and in doing so isolated
+the only thing that matters: the *parity of the degrees*. If you are going to
+enter and leave every landmass without repeating a bridge, then every time you
+arrive at a vertex you must also depart, so bridges get used up in pairs — every
+vertex needs an even number of them. Königsberg had four landmasses all of odd
+degree, so no such tour exists. Euler's insight is that this simple counting
+obstruction is the *only* obstruction: a connected graph in which every vertex
+has even degree can always be traced in one closed sweep.
+
+### Why This Matters
+
+This entry is the **undirected companion** to the parent gallery proof
+`konigsberg-oq-02-oq-01`, which fully formalizes Hierholzer's algorithm for the
+*directed* case (an Eulerian circuit exists iff the digraph is strongly
+connected and every vertex is balanced, $\mathrm{indeg} = \mathrm{outdeg}$).
+Completing the undirected characterization closes the classical Euler result in
+its original form — the form that answers the Königsberg bridges question that
+names this whole problem family. Together the directed and undirected theorems
+give the complete Euler/Hierholzer picture, and the undirected trail corollary
+($0$ or $2$ odd vertices) is what actually settles the historical puzzle.
+
+## Known Results
+
+### What's Already Proven
+
+- **Directed Eulerian circuit theorem (parent).** `konigsberg-oq-02-oq-01`
+  (`Proofs/KonigsbergOQ02OQ01.lean`, 0 sorries, 0 axioms) proves
+  `directed_euler_circuit_sufficient_corrected`: a strongly connected, balanced
+  finite digraph has an Eulerian circuit, via a full formalization of
+  Hierholzer's algorithm — maximal-trail-is-a-circuit, `Walk.splice`,
+  `removeArcList` residual-subgraph bookkeeping, and well-founded induction on
+  arc count.
+- **Necessary direction, undirected (Mathlib).** In
+  `Mathlib/Combinatorics/SimpleGraph/Trails.lean`:
+  - `SimpleGraph.Walk.IsEulerian` — the predicate that a trail covers every
+    edge exactly once (`p.IsTrail ∧ ∀ e ∈ G.edgeSet, e ∈ p.edges`).
+  - `SimpleGraph.Walk.IsEulerian.even_degree_iff` — for an Eulerian walk from
+    $u$ to $v$, vertex $x$ has even degree iff $x \notin \{u,v\}$. This is the
+    forward (necessity) half of the characterization.
+  - `SimpleGraph.Walk.IsEulerian.card_odd_degree` — a graph with an Eulerian
+    trail has $0$ or $2$ odd-degree vertices.
+  - `SimpleGraph.Walk.IsTrail.even_countP_edges_iff`, `IsEulerian.isTrail`,
+    `IsEulerian.edgeSet_eq`, `IsTrail.isEulerian_iff` — supporting lemmas.
+- **Handshake lemma (Mathlib).** `SimpleGraph.even_card_odd_degree_vertices`
+  (a.k.a. the sum-of-degrees / even-number-of-odd-vertices result) gives that
+  $|O|$ is even for free.
+
+### What's Still Open
+
+- **The sufficiency (existence) direction is NOT in Mathlib.** Mathlib supplies
+  only the "Eulerian $\Rightarrow$ even degrees" necessity lemmas. The
+  constructive converse — "connected + even degrees $\Rightarrow$ an Eulerian
+  circuit *exists*" — has no Mathlib proof and is the substance of this problem.
+- The **multigraph modelling** question (parallel edges / loops) is unresolved:
+  `SimpleGraph` cannot represent the actual seven-bridge Königsberg graph.
+
+### Our Goal
+
+Prove the sufficiency direction for `SimpleGraph`:
+
+> For a finite, connected `SimpleGraph G` with `∀ v, Even (G.degree v)`, there
+> exist `v₀` and a walk `p : G.Walk v₀ v₀` with `p.IsEulerian` (and hence
+> `p.IsCircuit`).
+
+Then derive the trail corollary ($0$ or $2$ odd vertices $\Rightarrow$ Eulerian
+trail) by adding a virtual edge between the two odd vertices, reducing to the
+even case, and deleting that edge. Combining this with Mathlib's necessity
+lemmas yields the full iff.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| konigsberg-oq-02-oq-01 | Directed analogue; supplies the Hierholzer construction to port | maximal-trail-is-circuit, `Walk.splice`, `removeArcList`, WF induction on arc count |
+| konigsberg-oq-02 | Grandparent; defines `Digraph`, `Walk`, `isEulerian`, degree theory | directed Euler framework |
+| konigsberg | Original undirected Königsberg bridges impossibility (the historical root) | degree-parity obstruction |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Port Hierholzer from the directed parent via darts.** Model
+   each undirected edge as a *matched pair of darts* (oriented half-edges), i.e.
+   apply the parent's directed machinery to the symmetric digraph where every
+   edge $\{a,b\}$ becomes both arcs $(a,b)$ and $(b,a)$. In that digraph
+   $\mathrm{indeg}(v) = \mathrm{outdeg}(v) = \deg_G(v)$ automatically (balance is
+   free), and connectivity of $G$ gives strong connectivity of the symmetrized
+   digraph. The parent's `directed_euler_circuit_sufficient_corrected` then
+   produces a directed circuit; the remaining work is to show it descends to an
+   *undirected* Eulerian circuit that uses each undirected edge once rather than
+   its two darts once each.
+   - Why it might work: reuses a fully verified, 0-sorry Hierholzer engine; the
+     dart correspondence is the standard textbook bridge between the cases.
+   - Risk: the "use each edge once, not each dart once" descent is subtle — the
+     directed circuit traverses $2|E|$ darts, and one must pair them so the
+     undirected walk is a genuine trail. Interfacing the parent's bespoke
+     `Digraph`/`Walk` types with Mathlib's `SimpleGraph.Walk` is glue work.
+
+2. **Approach B — Native Hierholzer on `SimpleGraph.Walk`.** Reprove the
+   algorithm directly for undirected walks: build a maximal trail from a
+   positive-degree vertex, show even degree forces it to close into a circuit,
+   splice in sub-circuits found in the edge-deleted residual graph, induct on
+   `G.edgeFinset.card`.
+   - Why it might work: stays entirely inside Mathlib's `SimpleGraph`,
+     `Walk.IsTrail`, `Walk.IsCircuit`, `edgeSet`, `degree` API; the resulting
+     theorem is stated in the idiomatic library types.
+   - Risk: essentially redoing the parent's substantial proof, now with the
+     added bookkeeping that deleting an *undirected* edge decrements *two*
+     degrees, and with `Sym2 V` edge handling instead of ordered arcs.
+
+3. **Approach C — Induction on the number of edges via cycle decomposition.**
+   Prove the classical lemma that a graph with all-even degrees decomposes into
+   edge-disjoint cycles, then stitch cycles together along shared vertices using
+   connectivity.
+   - Why it might work: the even-degree cycle-decomposition lemma is clean and
+     independently useful.
+   - Risk: "stitch along shared vertices" is again a splice argument; without
+     care the stitching order needs connectivity in a form that is itself work
+     to formalize.
+
+### Key Difficulties
+
+- **Multigraph modelling — the central wrinkle.** `SimpleGraph` forbids both
+  parallel edges and loops, but the real Königsberg graph has *parallel* bridges
+  between the same pair of landmasses. So the `SimpleGraph` theorem, while the
+  right first target, does **not** literally decide the historical puzzle. To
+  cover the genuine bridges instance one must model a multigraph: options are
+  (a) Mathlib's `Quiver`/incidence style with an explicit edge type and an
+  endpoint map $E \to \mathrm{Sym2}\,V$; (b) a `Multigraph` structure carrying
+  edge multiplicities; or (c) simulate multiplicity by subdividing each parallel
+  edge with a degree-2 dummy vertex (which preserves the parity of the original
+  vertices and reduces the multigraph to a `SimpleGraph`). The subdivision trick
+  (c) is the cheapest path to actually resolving Königsberg without new
+  infrastructure, but it changes $E$ and must be argued to preserve Eulerian
+  status.
+- **Directed → undirected descent (if Approach A).** Turning a dart circuit into
+  an edge trail requires a consistent pairing of the two darts of each edge and
+  a proof that the resulting undirected walk is `IsTrail`.
+- **Connectivity plumbing.** `SimpleGraph.Connected` / `Reachable` must be
+  converted into the concrete "there is a vertex of the current circuit with an
+  unused incident edge" statement that drives the splice step (the parent's
+  `vertex_with_unused_arc` lemma is the directed template).
+- **Even-degree residual bookkeeping.** Deleting a closed trail's edges must be
+  shown to preserve the all-even-degree invariant on the residual graph (the
+  undirected analogue of the parent's `removeArcList_balanced`).
+
+### What Would a Proof Need?
+
+- Key lemma 1: `maximal_trail_is_circuit` (undirected) — in an all-even-degree
+  graph, a maximal trail (no unused edge at its final vertex) is closed.
+- Key lemma 2: `Walk.splice` for `SimpleGraph.Walk` at a shared vertex, plus a
+  trail-preservation lemma for edge-disjoint splices (port of the parent's
+  `Walk.splice` / `splice_nodup`).
+- Key lemma 3: even-degree preservation under deletion of a circuit's edge set
+  (undirected `removeArcList_balanced`).
+- Key lemma 4: connectivity $\Rightarrow$ some circuit vertex has an incident
+  edge outside the circuit (undirected `vertex_with_unused_arc`).
+- Technical requirement: well-founded recursion on `G.edgeFinset.card` (or the
+  residual edge count), mirroring the parent's WF induction on `arcCount`.
+- Corollary: the $0$-or-$2$-odd-vertex trail theorem via the virtual-edge
+  reduction, and the multigraph statement via one of the modelling options.
+
+## Tractability Assessment
+
+**Difficulty**: Medium–High
+
+**Justification**:
+- The mathematics is completely classical and the *directed* version is already
+  fully formalized in the gallery (0 sorries, 0 axioms) — this is adaptation,
+  not invention. That is the strongest tractability signal.
+- Mathlib already supplies half the iff (`IsEulerian.even_degree_iff`,
+  `card_odd_degree`) and a rich `SimpleGraph.Walk`/`IsTrail`/`IsCircuit` API, so
+  the necessity direction and much scaffolding are free.
+- The remaining work is real: either porting the parent's ~950-line Hierholzer
+  proof to undirected walks (Approach B) or building the dart correspondence and
+  descent (Approach A). Neither is a one-liner.
+- The multigraph modelling is the genuine wrinkle: the clean `SimpleGraph`
+  theorem does not literally cover Königsberg's parallel bridges, so a faithful
+  statement needs a modelling decision (incidence structure or edge
+  subdivision) and its own preservation lemmas.
+
+**Estimated Effort**:
+- Exploration: 1–3 days (fix the model; decide Approach A vs B; inventory which
+  parent lemmas port directly).
+- If tractable: 1–2 weeks for the `SimpleGraph` sufficiency theorem plus the
+  trail corollary.
+- If hard: multigraph faithfulness and the directed→undirected descent could
+  extend this if the dart pairing resists formalization.
+
+## References
+
+### Papers
+- L. Euler, "Solutio problematis ad geometriam situs pertinentis,"
+  *Commentarii Academiae Scientiarum Petropolitanae* 8 (1736), 128–140 — the
+  Königsberg bridges paper; origin of graph theory and the degree-parity
+  argument.
+- C. Hierholzer, "Über die Möglichkeit, einen Linienzug ohne Wiederholung und
+  ohne Unterbrechung zu umfahren," *Mathematische Annalen* 6 (1873), 30–32 —
+  the constructive circuit-splicing algorithm (published posthumously).
+
+### Books
+- R. Diestel, *Graph Theory*, 5th ed., Springer GTM 173 — Chapter 1 covers
+  Eulerian tours and Euler's theorem for the undirected/multigraph case.
+- D. B. West, *Introduction to Graph Theory*, 2nd ed. — Theorem 1.2.26
+  (Eulerian circuit iff connected and all degrees even), with the trail variant.
+
+### Mathlib
+- `Mathlib.Combinatorics.SimpleGraph.Trails` — `Walk.IsEulerian`,
+  `IsEulerian.isTrail`, `IsEulerian.even_degree_iff` (necessity direction),
+  `IsEulerian.card_odd_degree`, `IsTrail.even_countP_edges_iff`,
+  `IsTrail.isEulerian_iff`.
+- `Mathlib.Combinatorics.SimpleGraph.Walk` / `.Path` — `Walk`, `IsTrail`,
+  `IsCircuit`, `edges`, `edgeSet`, walk append/concatenation API.
+- `Mathlib.Combinatorics.SimpleGraph.Connectivity` — `Connected`, `Reachable`,
+  `Preconnected` for the connectivity hypotheses.
+- `Mathlib.Combinatorics.SimpleGraph.DegreeSum` — degree sum / handshake lemma
+  giving that the number of odd-degree vertices is even.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - graph-theory
+  - euler-paths
+  - konigsberg
+  - hierholzer
+related_proofs:
+  - konigsberg-oq-02-oq-01
+  - konigsberg-oq-02
+  - konigsberg
+difficulty: high
+source: gallery-gap
+created: 2026-06-30T22:49:26-07:00
+```

--- a/research/problems/niven-theorem-oq-01-oq-02/problem.md
+++ b/research/problems/niven-theorem-oq-01-oq-02/problem.md
@@ -1,0 +1,233 @@
+# Problem: Unfold Niven's Algebraic-Integer Step into the Explicit Monic Chebyshev Recurrence
+
+**Slug**: niven-theorem-oq-01-oq-02
+**Created**: 2026-06-30T22:49:26-07:00
+**Status**: Active
+**Source**: gallery-gap <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+Let $C_n(x)$ be the sequence of monic integer polynomials ("Vieta–Lucas" /
+normalized Chebyshev-of-the-first-kind polynomials) defined by the recurrence
+
+$$
+C_0(x) = 2,\qquad C_1(x) = x,\qquad C_{n+1}(x) = x\,C_n(x) - C_{n-1}(x).
+$$
+
+The goal is to prove, fully from scratch, the fundamental cosine identity
+
+$$
+2\cos(n\theta) \;=\; C_n\!\bigl(2\cos\theta\bigr)\qquad\text{for all } n\in\mathbb{N},\ \theta\in\mathbb{R},
+$$
+
+and to use it to give a self-contained proof that $2\cos\theta$ is an **algebraic
+integer** whenever $\theta$ is a rational multiple of $\pi$. Concretely, if
+$\theta=(m/n)\pi$ then $n\theta=m\pi$ so $\cos(n\theta)=\pm 1\in\mathbb{Z}$, and
+
+$$
+C_n\!\bigl(2\cos\theta\bigr) - 2\cos(n\theta) \;=\; 0
+$$
+
+exhibits $2\cos\theta$ as a root of the **monic integer polynomial**
+$C_n(X) - 2\cos(n\theta) \in \mathbb{Z}[X]$. Hence
+
+$$
+\texttt{IsIntegral } \mathbb{Z}\ (2\cos\theta),
+$$
+
+replacing the current delegation to Mathlib's
+`Real.isIntegral_two_mul_cos_rat_mul_pi` with an explicit witness polynomial.
+
+### Plain Language
+
+The gallery entry `niven-theorem-oq-01` proves Niven's theorem — the only rational
+values of $\cos\theta$ at rational-multiple-of-$\pi$ angles are $0,\pm\tfrac12,\pm 1$.
+Its hard step ("$2\cos\theta$ is an algebraic integer") is currently handed off to a
+single Mathlib lemma, `Real.isIntegral_two_mul_cos_rat_mul_pi`, which is proved
+internally via roots of unity. That works, but it hides the classical mechanism.
+
+The classical argument is elementary and beautiful: there is a sequence of polynomials
+$C_n$ with **integer coefficients and leading coefficient $1$** such that plugging in
+$2\cos\theta$ gives exactly $2\cos(n\theta)$. For example
+$C_2(x)=x^2-2$ (so $2\cos 2\theta = (2\cos\theta)^2 - 2$), and
+$C_3(x)=x^3-3x$ (so $2\cos 3\theta = (2\cos\theta)^3 - 3(2\cos\theta)$). Because these
+polynomials are monic with integer coefficients, and because $2\cos(n\theta)=\pm2$ is
+an integer when $\theta=(m/n)\pi$, the number $2\cos\theta$ satisfies a monic integer
+equation — i.e. it is an algebraic integer. This task asks to build that ladder of
+polynomials in Lean and prove the identity by induction, so the Niven proof no longer
+rests on a Mathlib black box.
+
+### Why This Matters
+
+- **Self-contained proof.** It removes the last external dependency in the deep half of
+  Niven's theorem, turning the gallery entry from a "presentation citing Mathlib" into a
+  genuinely from-scratch formalization of the whole argument.
+- **Exposes the real mechanism.** The monic Chebyshev recurrence is *the* reason the
+  theorem is true; making it explicit is far more instructive than "roots of unity give
+  integrality."
+- **Reusable machinery.** The identity $2\cos(n\theta)=C_n(2\cos\theta)$ and the
+  "monic integer polynomial $\Rightarrow$ algebraic integer" packaging are exactly what
+  is needed for the sibling cyclotomic/irrationality results (e.g. irrationality of
+  $\cos(2\pi/n)$ for most $n$), so a clean statement pays dividends elsewhere.
+
+## Known Results
+
+### What's Already Proven
+
+- `Real.isIntegral_two_mul_cos_rat_mul_pi` — Mathlib's statement that $2\cos(q\pi)$ is
+  integral over $\mathbb{Z}$ for rational $q$ (currently cited by the parent entry). In
+  `Mathlib.NumberTheory.Niven`.
+- `Polynomial.Chebyshev.T` — Mathlib's Chebyshev polynomials of the first kind $T_n$
+  (defined over any commutative ring, including $\mathbb{Z}$), with the recurrence
+  $T_{n+1} = 2\,X\,T_n - T_{n-1}$, $T_0 = 1$, $T_1 = X$.
+- `Polynomial.Chebyshev.T_real_cos` / `T_complex_cos` (cosine evaluation) — the
+  defining trigonometric identity $T_n(\cos\theta) = \cos(n\theta)$. In
+  `Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev`.
+- `Polynomial.Monic`, `Polynomial.Monic.natDegree`, and the `IsIntegral` API
+  (`isIntegral_of_mem_of_fg`, root-of-monic constructors) — for packaging "root of a
+  monic integer polynomial" as `IsIntegral ℤ`.
+- The parent entry's enumeration tail (`niven`) and `IsIntegral.exists_int_iff_exists_rat`
+  are unaffected and can be reused verbatim once the core lemma is re-derived.
+
+### What's Still Open
+
+- No explicit *monic normalized* $C_n$ with the from-scratch induction is present in the
+  gallery; the parent simply cites the packaged Mathlib lemma.
+- The bridge $C_n(x) = 2\,T_n(x/2)$ between the monic normalization and Mathlib's $T_n$
+  (which has leading coefficient $2^{n-1}$, not $1$) is not spelled out anywhere in the
+  entry.
+
+### Our Goal
+
+Replace `two_cos_int_of_rational`'s appeal to
+`Real.isIntegral_two_mul_cos_rat_mul_pi` with an explicit construction:
+
+1. define the monic integer sequence $C_n$ by the recurrence above (either directly as a
+   `Polynomial ℤ` recursion or as $C_n := 2\,T_n(X/2)$ scaled back into $\mathbb{Z}[X]$);
+2. prove $2\cos(n\theta) = C_n(2\cos\theta)$ by two-step induction;
+3. prove `Monic (C n)` and conclude `IsIntegral ℤ (2 * Real.cos θ)` by exhibiting the
+   monic witness $C_n(X) - 2\cos(n\theta)$ with $2\cos(n\theta)\in\mathbb{Z}$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| niven-theorem-oq-01 | Parent entry; this task unfolds its delegated algebraic-integer step | `IsIntegral`, `interval_cases`, cosine bounds |
+| nth-root-irrational-oq-01-oq-01 | Sibling cyclotomic/Niven work resting on the same "2cos(qπ) is integral" fact | roots of unity, minimal polynomials |
+| sqrt2-minpoly-oq-01-oq-02-oq-01 | Another "rational algebraic integer is an ordinary integer" instance | minimal/monic integer polynomials, integrality |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Direct monic recursion in $\mathbb{Z}[X]$.** Define
+   `C : ℕ → Polynomial ℤ` by `C 0 = 2`, `C 1 = X`, `C (n+2) = X * C (n+1) - C n`. Prove
+   `(C n).Monic` by two-step induction (the leading term of $x\cdot C_{n+1}$ dominates
+   $C_{n-1}$ because $\deg C_{n+1} = n+1 > n-1 = \deg C_{n-1}$). Then prove the evaluation
+   identity `2*cos(n·θ) = eval (2*cos θ) (C n)` by induction using the addition formula.
+   - Why it might work: keeps everything over $\mathbb{Z}$, so `Monic`/`IsIntegral` are
+     immediate; the recurrence mirrors the cosine identity one-to-one.
+   - Risk: managing `natDegree`/`leadingCoeff` bookkeeping for the monic proof, and the
+     Lean `Nat.rec`/`Nat.strong_induction` plumbing for a two-step recurrence.
+
+2. **Approach B — Renormalize Mathlib's $T_n$.** Use `Polynomial.Chebyshev.T ℤ n` and set
+   $C_n(x) := 2\,T_n(x/2)$, i.e. work with $2\,T_n\!\big(\tfrac{X}{2}\big)$; equivalently
+   define the scaling so $C_n \in \mathbb{Z}[X]$ and derive its monicity and the cosine
+   identity from `T_real_cos` ($T_n(\cos\theta)=\cos(n\theta)$) by the substitution
+   $\theta \mapsto \theta$, $\cos\theta \mapsto \tfrac{2\cos\theta}{2}$.
+   - Why it might work: reuses Mathlib's already-proved $T_n(\cos\theta)=\cos(n\theta)$,
+     so only the *renormalization* (halving/doubling) and monicity need new work.
+   - Risk: the substitution $X\mapsto X/2$ leaves $\mathbb{Z}[X]$; must show
+     $2\,T_n(X/2)$ has integer coefficients (true — $T_n$'s coefficients are integers with
+     $2$-power denominators exactly cancelled) and is monic with leading coefficient $1$.
+
+### Key Difficulties
+
+- Proving `Monic (C n)` for the two-step recurrence: needs $\deg C_n = n$ and that the
+  subtraction $x\cdot C_{n+1} - C_{n-1}$ does not lower the top-degree coefficient.
+- The evaluation identity's induction step *is* the cosine addition/product-to-sum
+  identity $2\cos((n{+}1)\theta) = 2\cos\theta\cdot 2\cos(n\theta) - 2\cos((n{-}1)\theta)$;
+  formalizing this cleanly (`Real.cos_add`, `Real.cos_sub`, or `Real.cos_add_cos`) with a
+  two-step (strong / `Nat.le_induction`-style) induction.
+- Bridging to `IsIntegral ℤ (2*cos θ)`: assembling the monic witness polynomial
+  $C_n(X) - (2\cos(n\theta))$ and feeding it to the `IsIntegral` root constructor, with
+  $2\cos(n\theta)=\pm2$ pushed to a concrete integer.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `C_cos : ∀ n θ, 2 * Real.cos (n*θ) = Polynomial.eval (2*Real.cos θ) ((C n).map (Int.cast)) ` — the fundamental identity, by two-step induction from the cosine product-to-sum formula.
+- Key lemma 2: `C_monic : ∀ n, (C n).Monic` (equivalently `natDegree (C n) = n` plus leading coefficient $1$), by two-step induction on the recurrence.
+- Key lemma 3: at $\theta=(m/n)\pi$, `2*Real.cos (n*θ) = 2*Real.cos (m*π) = ±2 ∈ ℤ`, using `Real.cos_int_mul_two_pi` / `Real.cos_nat_mul_pi` style facts, so the constant term of the witness polynomial is an integer.
+- Technical requirement: connect the monic integer witness to `IsIntegral ℤ (2*Real.cos θ)` and then finish exactly as the parent does via `IsIntegral.exists_int_iff_exists_rat` and the `interval_cases` tail.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Mathlib already provides Chebyshev polynomials `Polynomial.Chebyshev.T` **and** the
+  cosine identity `T_real_cos` ($T_n(\cos\theta)=\cos(n\theta)$), so the deep
+  trigonometry is not re-derived from nothing — the work is the monic *renormalization*
+  $C_n(x)=2T_n(x/2)$ and the accompanying `Monic`/`IsIntegral` bookkeeping.
+- Two-step polynomial inductions with degree/leading-coefficient tracking are routine but
+  fiddly in Lean; the cosine product-to-sum step is a standard `Real.cos_add`/`cos_sub`
+  manipulation.
+- Similar "root of an explicit monic integer polynomial $\Rightarrow$ `IsIntegral ℤ`"
+  packaging has been done in sibling entries, so the final assembly has precedent.
+- The enumeration tail and the rational-algebraic-integer collapse are already proven in
+  the parent and reused unchanged.
+
+**Estimated Effort**:
+- Exploration: 0.5–1 day (decide Approach A vs B; check `T`'s degree/leadingCoeff API)
+- If tractable: 3–6 days (monicity induction + evaluation identity + `IsIntegral` bridge)
+- If hard: 1–2 weeks (if the monic-degree bookkeeping or the $X\mapsto X/2$ integrality
+  proof proves stubborn)
+
+## References
+
+### Papers
+- Ivan Niven, *Irrational Numbers*, Carus Mathematical Monographs 11, MAA, 1956 — the
+  original source of the theorem and of the "$2\cos\theta$ is an algebraic integer"
+  argument via the monic recurrence.
+- J. M. H. Olmsted, "Rational values of trigonometric functions", *Amer. Math. Monthly*
+  52 (1945) — an early exposition of the rational-cosine classification.
+- François Viète (Vieta), *Ad angulares sectiones* — origin of the "Vieta–Lucas"
+  polynomials $V_n$ satisfying $V_n(2\cos\theta)=2\cos(n\theta)$.
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Niven%27s_theorem — statement, history, sine/tangent
+  companions.
+- https://en.wikipedia.org/wiki/Chebyshev_polynomials — first-kind $T_n$, the monic
+  normalization, and the recurrence.
+- https://en.wikipedia.org/wiki/Lucas_sequence — the $V_n$ (Vieta–Lucas) family and its
+  monic recurrence $V_{n+1}=x V_n - V_{n-1}$.
+
+### Mathlib
+- `Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev` — `Polynomial.Chebyshev.T`
+  and `T_real_cos` / `T_complex_cos` giving $T_n(\cos\theta)=\cos(n\theta)$.
+- `Mathlib.RingTheory.Polynomial.Chebyshev` — the recurrence and degree facts for $T_n$
+  ($T_{n+1}=2X T_n - T_{n-1}$).
+- `Mathlib.RingTheory.IntegralClosure` / `IsIntegral` — root-of-monic constructors and
+  `IsIntegral.exists_int_iff_exists_rat` (ℤ integrally closed in ℚ).
+- `Mathlib.NumberTheory.Niven` — the existing `Real.isIntegral_two_mul_cos_rat_mul_pi`
+  being replaced.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - algebraic-integers
+  - chebyshev-polynomials
+  - trigonometry
+  - rational-multiples-of-pi
+related_proofs:
+  - niven-theorem-oq-01
+  - nth-root-irrational-oq-01-oq-01
+  - sqrt2-minpoly-oq-01-oq-02-oq-01
+difficulty: medium
+source: gallery-gap
+created: 2026-06-30T22:49:26-07:00
+```

--- a/research/problems/prob-method-second-moment-oq-01-oq-03/problem.md
+++ b/research/problems/prob-method-second-moment-oq-01-oq-03/problem.md
@@ -1,0 +1,270 @@
+# Problem: Paley-Zygmund Inequality in Mathlib's Measure-Theoretic Framework
+
+**Slug**: prob-method-second-moment-oq-01-oq-03
+**Created**: 2026-06-30T22:49:26-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The Paley-Zygmund inequality. Let $Z$ be a non-negative random variable on a
+probability space $(\Omega, \mathcal{F}, \mathbb{P})$ with finite variance
+(equivalently $Z \in L^2$), and let $0 \le \theta \le 1$. Then
+
+$$
+\mathbb{P}\bigl(Z > \theta \, \mathbb{E}[Z]\bigr) \;\ge\; (1 - \theta)^2 \, \frac{\mathbb{E}[Z]^2}{\mathbb{E}[Z^2]}.
+$$
+
+Equivalently, in terms of the variance $\operatorname{Var}(Z) = \mathbb{E}[Z^2] - \mathbb{E}[Z]^2$,
+
+$$
+\mathbb{P}\bigl(Z > \theta \, \mathbb{E}[Z]\bigr) \;\ge\; \frac{(1-\theta)^2 \, \mathbb{E}[Z]^2}{\operatorname{Var}(Z) + \mathbb{E}[Z]^2}.
+$$
+
+The target of this research problem is a Lean 4 statement over Mathlib's
+`MeasureTheory`/`ProbabilityTheory` API, roughly of the form:
+
+```
+theorem paley_zygmund
+    {Ω : Type*} {m : MeasurableSpace Ω} {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {Z : Ω → ℝ} (hZ : 0 ≤ᵐ[μ] Z) (hL2 : MemLp Z 2 μ) {θ : ℝ}
+    (hθ0 : 0 ≤ θ) (hθ1 : θ ≤ 1) :
+    (1 - θ)^2 * (∫ ω, Z ω ∂μ)^2
+      ≤ (μ {ω | θ * (∫ ω, Z ω ∂μ) < Z ω}).toReal * (∫ ω, (Z ω)^2 ∂μ)
+```
+
+with the classical ratio form recovered by dividing through by
+$\mathbb{E}[Z^2]$ (assuming it is positive).
+
+### Plain Language
+
+If $Z$ is a non-negative quantity that is random, the Paley-Zygmund
+inequality guarantees that $Z$ is not too concentrated near zero: with
+probability at least $(1-\theta)^2 \mathbb{E}[Z]^2 / \mathbb{E}[Z^2]$, the value
+of $Z$ exceeds the fraction $\theta$ of its average. Taking $\theta = 0$
+recovers the qualitative statement that $\mathbb{P}(Z > 0) \ge \mathbb{E}[Z]^2/\mathbb{E}[Z^2] > 0$
+whenever $\mathbb{E}[Z] > 0$ — a mean-square way of certifying that $Z$ is
+sometimes strictly positive.
+
+Where Markov's inequality bounds the *upper* tail ($\mathbb{P}(Z \ge a) \le
+\mathbb{E}[Z]/a$) and Chebyshev bounds deviations from the mean, Paley-Zygmund
+bounds the *lower* tail from below. It says that a random variable whose second
+moment is comparable to the square of its first moment cannot spend all its mass
+on being small.
+
+### Why This Matters
+
+Paley-Zygmund is the quantitative heart of the **second moment method** in
+probabilistic combinatorics:
+
+- **Lower-tail control.** It complements Chebyshev's inequality. Chebyshev
+  (`ProbabilityTheory.meas_ge_le_variance_div_sq`) says $Z$ concentrates near
+  its mean; Paley-Zygmund says $Z$ is bounded *away* from $0$ with definite
+  probability. Together they are the standard toolkit for showing a counting
+  random variable is positive with high probability.
+- **Random graphs and thresholds.** In $G(n,p)$, one lets $Z$ count the number
+  of copies of a fixed subgraph (or cliques, independent sets, perfect
+  matchings, etc.). Showing $\mathbb{E}[Z^2] = (1+o(1))\mathbb{E}[Z]^2$ and applying
+  Paley-Zygmund gives $\mathbb{P}(Z > 0) \to 1$, pinning down sharp threshold
+  functions for appearance of substructures.
+- **Ramsey lower bounds.** The probabilistic lower bounds on Ramsey numbers and
+  on clique/independence numbers in random graphs (Alon-Spencer, Chapter 4)
+  routinely invoke the second moment method / Paley-Zygmund.
+
+A measure-theoretic version stated over Mathlib's probability API would make all
+of these arguments expressible against the same infrastructure used for the
+strong law, Chebyshev, and concentration inequalities already in Mathlib — and
+it is a natural, self-contained candidate for an upstream mathlib4 contribution.
+
+## Known Results
+
+### What's Already Proven
+
+- **Parent gallery entry `prob-method-second-moment-oq-01`
+  (`Proofs/ProbMethodSecondMomentOQ01.lean`, verified, 0 axioms).** Proves the
+  quantitative Paley-Zygmund inequality in a *finite, discrete* setting: for
+  $f : \alpha \to \mathbb{Q}$ non-negative on a `Finset s` with positive sum and
+  $0 \le \theta < 1$,
+  $$(1-\theta)^2 \Bigl(\textstyle\sum_s f\Bigr)^2 \le \bigl|\{a \in s : f(a) > \theta \mu\}\bigr| \cdot \sum_s f^2,$$
+  where $\mu = (\sum_s f)/|s|$. It includes a private Cauchy-Schwarz lemma
+  `sq_sum_le` ($(\sum f)^2 \le |s| \sum f^2$, via $\sum_{i<j}(f_i-f_j)^2 \ge 0$),
+  a probability/ratio form `paley_zygmund_probability`, and the $\theta = 0$
+  recovery `paley_zygmund_at_zero`.
+- **The classical proof is completely standard** (Paley-Zygmund 1932;
+  Alon-Spencer). See "Our Goal" and "Initial Thoughts" below.
+- **Mathlib already has the surrounding machinery**: expectation as
+  `MeasureTheory.integral`, `ProbabilityTheory.variance` and
+  `ProbabilityTheory.evariance`, Chebyshev
+  (`ProbabilityTheory.meas_ge_le_variance_div_sq`), Markov/Chebyshev for the
+  integral (`MeasureTheory.mul_meas_ge_le_lintegral`), Hölder/Cauchy-Schwarz for
+  integrals (`MeasureTheory.integral_mul_le_Lp_mul_Lq` and the $L^2$
+  `inner_mul_le_norm_mul_norm`), and the `MemLp`/`Lp` framework for $L^2$
+  bookkeeping.
+
+### What's Still Open
+
+- No general **measure-theoretic** Paley-Zygmund inequality exists in Mathlib.
+- No version stated for arbitrary `IsProbabilityMeasure` spaces with an $L^2$
+  random variable exists in the gallery — only the finite `Finset`/`ℚ` version.
+- The finite version does not directly imply the continuous version; the
+  discrete counting argument must be re-cast in terms of integrals and measures
+  of measurable sets.
+
+### Our Goal
+
+Recast the parent's finite Paley-Zygmund result in Mathlib's
+measure-theoretic `ProbabilityTheory`/`MeasureTheory` framework, in a form
+suitable for **upstream contribution to mathlib4**. Concretely:
+
+1. State the inequality for a non-negative $L^2$ random variable $Z$ on a
+   probability space (hypotheses: `IsProbabilityMeasure μ`, `0 ≤ᵐ[μ] Z`,
+   `MemLp Z 2 μ`).
+2. Prove the **integral split** as the concrete first step: writing
+   $A = \{ \omega : Z(\omega) > \theta \, \mathbb{E}[Z]\}$ and its complement,
+   $$\mathbb{E}[Z] = \mathbb{E}[Z \cdot \mathbf{1}_A] + \mathbb{E}[Z \cdot \mathbf{1}_{A^c}],$$
+   and bound the second term by $\theta \, \mathbb{E}[Z]$ (since $Z \le \theta\mathbb{E}[Z]$
+   on $A^c$ and $\mathbb{P}$ is a probability measure).
+3. Apply Cauchy-Schwarz to the first term:
+   $\mathbb{E}[Z \cdot \mathbf{1}_A] \le \sqrt{\mathbb{E}[Z^2] \cdot \mathbb{P}(A)}$, then combine
+   with $\mathbb{E}[Z \cdot \mathbf{1}_A] \ge (1-\theta)\mathbb{E}[Z]$ and square.
+4. Provide the ratio (probability) form by dividing by $\mathbb{E}[Z^2]$, and the
+   variance form via $\mathbb{E}[Z^2] = \operatorname{Var}(Z) + \mathbb{E}[Z]^2$.
+
+If the statement and proof are clean, package as a mathlib4 PR (likely under
+`Mathlib/Probability/` alongside the moment inequalities).
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| prob-method-second-moment-oq-01 | Parent: finite/discrete Paley-Zygmund over `Finset`/`ℚ` — the result to lift | above/below split, Cauchy-Schwarz `sq_sum_le`, `sq_le_sq'` |
+| prob-method-second-moment | Grandparent: qualitative second moment method ($\mathbb{P}(Z>0)>0$) | first/second moment comparison |
+| cauchy-schwarz | Cauchy-Schwarz is the analytic bridge from first to second moment | inner-product / integral Hölder bound |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Indicator split + integral Cauchy-Schwarz (recommended).**
+   Set $A = \{Z > \theta \mathbb{E}[Z]\}$ (measurable since $Z$ is `AEMeasurable`
+   from `MemLp`). Write $Z = Z\mathbf{1}_A + Z\mathbf{1}_{A^c}$ and integrate.
+   - Why it might work: this is the textbook proof; every step has a direct
+     Mathlib counterpart (`integral_add`, `setIntegral`, `MeasureTheory.integral_mul_le_Lp_mul_Lq`
+     with $p=q=2$, or `inner_mul_le_norm_mul_norm` in `L²`).
+   - Risk: the friction is entirely in API/`MemLp` bookkeeping —
+     integrability of $Z\mathbf{1}_A$, measurability of the level set, converting
+     between `ENNReal` measures and `Real` integrals (`.toReal`,
+     `ENNReal.toReal_le_toReal`), and matching the exact hypotheses Mathlib's
+     Hölder lemma expects (`MemLp`, conjugate exponents).
+
+2. **Approach B — Discretize / transfer from the finite version.**
+   Approximate $Z$ by simple functions and pass the parent's `Finset` inequality
+   to the limit.
+   - Why it might work: reuses the already-verified finite result.
+   - Risk: limiting arguments over measures of level sets are delicate
+     (weak convergence, dominated convergence) and likely *more* work than
+     proving the continuous version directly; not recommended.
+
+### Key Difficulties
+
+- **`MemLp`/integrability plumbing**: establishing that $Z$, $Z^2$, and the
+  indicator-restricted products are integrable, and threading `MemLp Z 2 μ`
+  through Cauchy-Schwarz.
+- **`ENNReal` vs `Real`**: measures land in `ENNReal`; the inequality is stated
+  in `Real`. Careful use of `.toReal`, finiteness of measures on a probability
+  space, and monotonicity lemmas is required.
+- **Degenerate cases**: $\mathbb{E}[Z^2] = 0$ (i.e. $Z = 0$ a.e.) and $\theta = 1$
+  must be handled so the ratio form is well-defined.
+
+### What Would a Proof Need?
+
+- Key lemma 1: the additive split $\mathbb{E}[Z] = \mathbb{E}[Z\mathbf{1}_A] + \mathbb{E}[Z\mathbf{1}_{A^c}]$
+  with $A^c$-term $\le \theta\mathbb{E}[Z]$ (the **concrete first step** of this
+  problem).
+- Key lemma 2: Cauchy-Schwarz $\mathbb{E}[Z\mathbf{1}_A] \le \sqrt{\mathbb{E}[Z^2]\,\mathbb{P}(A)}$
+  via `MeasureTheory.integral_mul_le_Lp_mul_Lq` (or the $L^2$ inner-product
+  bound) applied to $Z$ and $\mathbf{1}_A$.
+- Technical requirements: measurability of the level set,
+  `MemLp`/integrability of the pieces, `ENNReal.toReal` conversions, and the
+  algebra to square $(1-\theta)\mathbb{E}[Z] \le \sqrt{\mathbb{E}[Z^2]\,\mathbb{P}(A)}$ into the
+  stated inequality.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The mathematics is short and classical — a two-line proof on paper — and the
+  finite version is already fully verified in the parent gallery entry.
+- The genuine work is engineering: fitting Mathlib's integration API,
+  discharging `MemLp`/integrability side conditions, and converting between
+  `ENNReal` and `Real`. This is well-trodden ground (Chebyshev, the moment
+  inequalities, and Hölder already live in Mathlib).
+- All required lemmas exist: `MeasureTheory.integral_mul_le_Lp_mul_Lq`,
+  `ProbabilityTheory.variance`, `ProbabilityTheory.meas_ge_le_variance_div_sq`,
+  `MemLp`/`Lp` API. No new deep theory is needed.
+- A clean statement + proof is a plausible **mathlib4 PR** target, which raises
+  the polish bar (naming, generality, docstrings) but not the mathematical
+  difficulty.
+
+**Estimated Effort**:
+- Exploration: 1-2 days (locating the exact Hölder/`MemLp` lemmas and the right
+  statement generality).
+- If tractable: 3-7 days for a gallery-quality proof; add time for an
+  upstream-ready mathlib4 PR (review iteration on naming and API fit).
+- If hard: unknown, only if the `MemLp` bookkeeping proves unexpectedly
+  stubborn.
+
+## References
+
+### Papers
+- Paley, R.E.A.C. and Zygmund, A., "On some series of functions (1)",
+  *Proceedings of the Cambridge Philosophical Society* 26 (1932), 337-357 —
+  original source of the inequality, in the study of lacunary trigonometric
+  series.
+- Alon, N. and Spencer, J.H., *The Probabilistic Method*, 4th ed., Wiley, 2016 —
+  Chapter 4, second moment method and Paley-Zygmund with random-graph and
+  Ramsey applications.
+- Kahane, J.-P., *Some Random Series of Functions*, 2nd ed., Cambridge
+  University Press, 1985 — modern treatment of Paley-Zygmund in the context of
+  random series.
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Paley%E2%80%93Zygmund_inequality — statement,
+  standard proof, and the variance form.
+- https://leanprover-community.github.io/mathlib4_docs/Mathlib/Probability/Variance.html —
+  Mathlib's variance and Chebyshev API.
+
+### Mathlib
+- `MeasureTheory.MeasureSpace` / `IsProbabilityMeasure` — probability space and
+  total-mass-one setting.
+- `MeasureTheory.integral` — expectation $\mathbb{E}[Z] = \int Z \, d\mu$.
+- `MeasureTheory.MemLp` / `MeasureTheory.Lp` — the $L^2$ hypothesis and
+  integrability bookkeeping.
+- `ProbabilityTheory.variance`, `ProbabilityTheory.evariance` — variance form.
+- `ProbabilityTheory.meas_ge_le_variance_div_sq` — Chebyshev's inequality
+  (the complementary upper/deviation bound).
+- `MeasureTheory.integral_mul_le_Lp_mul_Lq` (Hölder, $p=q=2$) and
+  `inner_mul_le_norm_mul_norm` ($L^2$ Cauchy-Schwarz) — the analytic core step.
+- `ENNReal` / `ENNReal.toReal` — measure-to-real conversions for the probability
+  of the level set.
+
+## Metadata
+
+```yaml
+tags:
+  - probability
+  - measure-theory
+  - second-moment-method
+  - paley-zygmund
+  - mathlib-contribution
+related_proofs:
+  - prob-method-second-moment-oq-01
+  - prob-method-second-moment
+  - cauchy-schwarz
+difficulty: medium
+source: gallery-gap
+created: 2026-06-30T22:49:26-07:00
+```

--- a/research/problems/wilsons-theorem-oq-04-oq-02-oq-01/problem.md
+++ b/research/problems/wilsons-theorem-oq-04-oq-02-oq-01/problem.md
@@ -1,0 +1,165 @@
+# Problem: Product of All Group Elements in the Non-Abelian Case (via Abelianization)
+
+**Slug**: wilsons-theorem-oq-04-oq-02-oq-01
+**Created**: 2026-06-30T22:49:26-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The parent proof establishes, for a finite **commutative** group $G$, that
+$$
+\prod_{g \in G} g \;=\; \tau \quad\text{when } \tau \text{ is the unique non-trivial involution, and } \prod_{g \in G} g = 1 \text{ otherwise.}
+$$
+
+The open question asks to generalize to **non-abelian** finite groups $G$. The first obstruction is that
+$$
+\prod_{g \in G} g
+$$
+is **not well-defined** when $G$ is non-abelian: the value depends on the chosen enumeration $g_1, g_2, \dots, g_n$ of the elements, since $g_i g_j \neq g_j g_i$ in general.
+
+The clean, tractable formalization pushes the product through the **abelianization** $G^{\mathrm{ab}} = G / [G,G]$, where $[G,G]$ is the commutator subgroup. Let $\pi = \mathrm{Abelianization.of} : G \to G^{\mathrm{ab}}$ be the canonical projection. Because $\pi$ is a group homomorphism and $G^{\mathrm{ab}}$ is abelian:
+
+**(a) Well-definedness of the image.** For *any* enumeration $g_1,\dots,g_n$ of the elements of $G$,
+$$
+\pi\!\left(\prod_{i=1}^{n} g_i\right) \;=\; \prod_{i=1}^{n} \pi(g_i) \;=\; \prod_{h \in G^{\mathrm{ab}}} h^{\,|\ker \pi \cap \pi^{-1}(h)|}
+\;=\; \prod_{y \in \mathrm{im}\,\pi} y^{\,[G:G^{\mathrm{ab}}\text{-fiber}]},
+$$
+and in particular the **coset** $\left(\prod_i g_i\right)\,[G,G] \in G^{\mathrm{ab}}$ is **independent of the enumeration**. Concretely,
+$$
+\pi\!\left(\prod_{g\in G} g\right) \text{ is well-defined and equals } \prod_{g \in G} \pi(g).
+$$
+
+**(b) Characterization via the parent's abelian result.** Since $G^{\mathrm{ab}}$ is a finite abelian group, apply the parent theorem to the multiset $\{\pi(g) : g \in G\}$. When $[G:G']$-multiplicity is accounted for, the well-defined image satisfies:
+$$
+\pi\!\left(\prod_{g\in G} g\right) =
+\begin{cases}
+\bar\tau, & \text{if } G^{\mathrm{ab}} \text{ has a unique involution } \bar\tau \text{ and each fiber has odd size (mod 2 survives)},\\[4pt]
+1, & \text{if } G^{\mathrm{ab}} \text{ has no unique involution (e.g. is trivial, odd order, or non-cyclic 2-part).}
+\end{cases}
+$$
+
+Equivalently: **there exists an enumeration with $\prod_i g_i = 1$ iff the well-defined image $\pi(\prod g) = 1$ in $G^{\mathrm{ab}}$** — because the set of achievable products of a fixed multiset is exactly one coset of $[G,G]$ (a theorem of the Dénes–Hermann / Ore circle), so an ordering yielding the identity exists precisely when that coset is $[G,G]$ itself.
+
+### Plain Language
+
+In an abelian group the notation $\prod_{g\in G} g$ is unambiguous — you can multiply the elements in any order and get the same answer. The parent proof pins that answer down: it is the unique element of order 2 if there is exactly one (the "$-1$" in Gauss's Wilson theorem), and the identity otherwise.
+
+In a non-abelian group this breaks immediately: reorder the factors and the product changes. So "$\prod G = e$?" has no answer as literally written. The rescue is the **abelianization** $G^{\mathrm{ab}} = G/[G,G]$: it is the largest abelian quotient of $G$, obtained by forcing all elements to commute. The projection $\pi$ is a homomorphism, so it sends products to products, and in the abelian target the order no longer matters. Therefore the *image* $\pi(\prod g)$ is a genuine, ordering-independent invariant of $G$ — and the parent theorem computes it. Moreover, the different orderings of $\prod g$ inside $G$ trace out exactly one coset of the commutator subgroup, so the image tells you whether you can order the factors to land on the identity.
+
+### Why This Matters
+
+- **Extends the Gauss–Wilson involution result beyond abelian groups.** The parent captures the classical "$(p-1)! \equiv -1$" phenomenon at the abelian level. This child gives the honest, well-posed statement for arbitrary finite groups, isolating exactly what survives (the commutator-quotient invariant).
+- **Connects to a genuine research thread.** The "product of all the elements of a finite group" was studied by G. A. Miller (1903), and the coset-of-$[G,G]$ characterization is the Dénes–Hermann theorem; it is the subject of the Herzog–Kaplan–Lev work on rearrangements and sequenceable/complete-mapping groups. The clean punchline "the achievable products form one coset of $[G,G]$" is exactly why the abelianization image is the right invariant.
+- **Illustrates a reusable formalization pattern.** "An ill-posed product becomes well-posed in the abelianization" is a technique that recurs (e.g. transfer maps, sign of a permutation as an abelianization). Formalizing it here builds a template.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `wilsons-theorem-oq-04-oq-02` (`WilsonsTheoremOQ04OQ02.lean`): for finite commutative $G$, `prod_univ_of_unique_involution` ($\prod G = \tau$ for the unique involution), `prod_cyclic_even_group`, and `prod_univ_odd_order` ($\prod G = 1$ for odd order). Also `prod_eq_prod_involutions`: $\prod G = \prod_{x^2=1} x$.
+- Classical Wilson `wilsons-theorem`: $(p-1)! \equiv -1 \pmod p$.
+- Mathlib provides the abelianization functor and the homomorphism-preserves-products machinery outright.
+
+### What's Still Open
+
+- The genuinely non-abelian refinement: the exact multiplicity/parity bookkeeping (fiber sizes of $\pi$) needed to compute $\pi(\prod g)$ purely from group invariants of $G$ (not $G^{\mathrm{ab}}$ alone), and the full Dénes–Hermann coset theorem inside $G$ (which orderings are achievable) — the latter is a substantial combinatorial result.
+- The complete determination for all non-cyclic 2-groups where $G^{\mathrm{ab}}$ has several involutions.
+
+### Our Goal
+
+Formalize the **well-posed** statement: define $\pi = \mathrm{Abelianization.of}$, prove $\pi(\prod_{g} g) = \prod_g \pi(g)$ (ordering-independent by construction), and then invoke the parent's abelian theorem on $G^{\mathrm{ab}}$ to characterize this image (equals the unique involution of $G^{\mathrm{ab}}$ if one exists with odd fibers, else $1$). We do **not** attempt the full achievable-orderings coset theorem inside $G$; the deliverable is the abelianization characterization plus a clear statement of why the raw $\prod G$ is ill-posed.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| wilsons-theorem-oq-04-oq-02 | Direct parent; supplies the abelian product-of-involutions theorem we transport | `Finset.prod_involution`, `IsCyclic.card_pow_eq_one_le`, `Finset.prod_pair` |
+| wilsons-theorem-oq-02 | Sibling instantiation for $(\mathbb Z/n\mathbb Z)^\times$ | modular units, cyclicity classification |
+| wilsons-theorem | Classical root $(p-1)!\equiv-1$ | pairing with inverses |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Push the product through `Abelianization.of` (recommended).**
+   - Concrete first step: `Abelianization.of` is a `MonoidHom`, so
+     `Abelianization.of (∏ g in Finset.univ, g) = ∏ g in Finset.univ, Abelianization.of g`
+     is exactly `map_prod Abelianization.of _ _` (or `MonoidHom.map_prod`).
+   - Then the RHS is a product over all elements of $G$ pushed into the abelian group $G^{\mathrm{ab}}$; regroup by fibers of $\pi$ and apply the parent theorem to $G^{\mathrm{ab}}$.
+   - Why it works: the target is abelian, so `Finset.prod` is reorder-invariant automatically; no ordering choice is ever made. This sidesteps the ill-posedness entirely.
+   - Risk: the fiber-multiplicity bookkeeping ($\prod_{g} \pi(g) = \prod_{h\in G^{\mathrm{ab}}} h^{|\text{fiber}|}$) needs `Finset.prod_fiberwise` / `Finset.prod_comp` and a parity argument; getting the exponents right is the main labor.
+
+2. **Approach B — State the coset invariant directly.**
+   - Prove the weaker but fully rigorous claim: the map `enumeration ↦ ∏ᵢ gᵢ` has image contained in a single coset of `commutator G`, i.e. all products agree modulo $[G,G]$. This is `Approach A` phrased without naming a canonical value.
+   - Why it works: it is exactly the well-definedness in $G^{\mathrm{ab}}$ restated in $G$; provable from `Approach A` since $\pi(x)=\pi(y) \iff x^{-1}y \in [G,G]$.
+   - Risk: quantifying over "all enumerations" (bijections `Fin n ≃ G`) and their ordered products is more setup than the `Finset.prod`-in-quotient formulation.
+
+### Key Difficulties
+
+- The literal $\prod_{g\in G} g$ cannot even be written in Lean for non-abelian $G$ without fixing an ordering (`List.prod` of some enumeration); the entire point is to avoid needing that.
+- Fiber multiplicities: $\prod_{g\in G}\pi(g)$ counts each $h\in\mathrm{im}\,\pi$ with multiplicity $|\pi^{-1}(h)|=|[G,G]|$ (constant, since fibers are cosets), so the image is $\big(\prod_{h}h\big)^{|[G,G]|}$ — the exponent's parity governs the outcome.
+- Determining when $G^{\mathrm{ab}}$ has a *unique* involution (its cyclic even-order 2-part) mirrors the parent's cyclic analysis.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `Abelianization.of` is a `MonoidHom`; `map_prod`/`MonoidHom.map_prod` transports `Finset.prod` — gives ordering-independence for free.
+- Key lemma 2: fiber decomposition $\prod_{g\in G}\pi(g) = \big(\prod_{h\in G^{\mathrm{ab}}} h\big)^{|[G,G]|}$ via `Finset.prod_fiberwise`/`Finset.prod_comp` (all fibers of $\pi$ are cosets of $[G,G]$, hence equinumerous).
+- Key lemma 3: apply the parent's `prod_univ_of_unique_involution` / `prod_univ_odd_order` to the finite abelian group $G^{\mathrm{ab}}$, then raise to the $|[G,G]|$ power and reduce mod the involution's order 2.
+- Technical requirements: `Fintype`/`DecidableEq` on $G$ (hence on $G^{\mathrm{ab}}$), `orderOf` bookkeeping for involutions.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The abelianization reduction is clean and every ingredient is in Mathlib: `Abelianization`, `Abelianization.of`, `map_prod`, `Finset.prod_fiberwise`, and the parent theorem itself is directly reusable on $G^{\mathrm{ab}}$.
+- The honest caveat is that a fully general "$\prod G = e$" statement is **ill-posed**, so we cannot state the literal generalization; the deliverable is the abelianization characterization plus the coset invariant. This reframing is standard and defensible.
+- Similar reorder-into-a-quotient arguments (sign of a permutation, transfer homomorphism) are already formalized, so the pattern is proven feasible.
+- The only real labor is the fiber-multiplicity/parity computation; everything else is `map_prod` plus citing the parent.
+
+**Estimated Effort**:
+- Exploration: 1–2 days
+- If tractable: 3–7 days
+- If hard (full Dénes–Hermann achievable-orderings coset theorem inside $G$): unknown / out of scope
+
+## References
+
+### Papers
+- G. A. Miller, "The product of the elements of a finite group," early group-theory studies (1903) — origin of the "product of all group elements" question.
+- J. Dénes, A. D. Keedwell, and work of Dénes–Hermann on the set of products of all elements — the achievable products form a single coset of the commutator subgroup.
+- M. Herzog, G. Kaplan, A. Lev, "Representation of permutations as products..." — modern treatment of orderings and complete mappings related to the product of all elements.
+- C. F. Gauss, *Disquisitiones Arithmeticae* (1801) — the abelian/Wilson root and the unique-involution idea.
+
+### Online Resources
+- Wikipedia, "Wilson's theorem" — classical statement and the involution-pairing proof.
+- Wikipedia, "Commutator subgroup" / "Abelianization" — the universal abelian quotient used to make $\prod G$ well-posed.
+
+### Mathlib
+- `Mathlib.GroupTheory.Abelianization` — `Abelianization`, `Abelianization.of` (the canonical `MonoidHom G → G^{ab}`), universal property.
+- `Mathlib.GroupTheory.Commutator` / `Subgroup.commutator`, `commutator G` — the commutator subgroup $[G,G]$ (kernel of `Abelianization.of`).
+- `Finset.prod`, `map_prod` / `MonoidHom.map_prod`, `Finset.prod_fiberwise`, `Finset.prod_comp` — transporting and regrouping products.
+- `IsCyclic`, `IsCyclic.card_pow_eq_one_le`, `orderOf`, `orderOf ... = 2` — locating the unique involution in $G^{\mathrm{ab}}$ (reuses parent machinery).
+- `Monoid.IsTorsionFree` — rules out involutions in the torsion-free / odd-order analysis.
+- Parent module `Proofs/WilsonsTheoremOQ04OQ02.lean` — `prod_univ_of_unique_involution`, `prod_univ_odd_order`, `prod_eq_prod_involutions` applied to $G^{\mathrm{ab}}$.
+
+## Metadata
+
+```yaml
+tags:
+  - group-theory
+  - abstract-algebra
+  - abelianization
+  - commutator-subgroup
+  - gauss-wilson
+  - involutions
+related_proofs:
+  - wilsons-theorem-oq-04-oq-02
+  - wilsons-theorem-oq-02
+  - wilsons-theorem
+difficulty: medium
+source: gallery-gap
+created: 2026-06-30T22:49:26-07:00
+```


### PR DESCRIPTION
## Summary

The candidate pool nominally showed 24 available problems, but 6 of those were placeholder-quality moonshot stubs (`kepler-conjecture-oq-03`, `godel-second-incompleteness`, `russell-1-plus-1-oq-02`, `fodor-pressing-down`, two Erdős complexity questions — all `(formal statement to be added)`, tractability 3–5) and 3 more were already claimed. Effective *tractable, well-specified* free pool sat right at the 15 threshold.

This PR adds 6 fresh open-question children, each spawned from a **verified, 0-axiom** gallery proof, diverse across 6 domains, each with a rich placeholder-free `problem.md` (formal statement, Mathlib support, concrete first step, tractability assessment, references):

| Slug | Domain | Question |
|------|--------|----------|
| `derangements-oq-04-oq-01-oq-01` | combinatorics | Poisson(1) limit of fixed-point distribution (n,k)/n! \to e^{-1}/k!$ |
| `niven-theorem-oq-01-oq-02` | number theory | explicit monic Vieta–Lucas/Chebyshev recurrence for \cos(n\theta)$ |
| `harmonic-divergence-oq-06-oq-02` | analysis | divergence of $\sum 1/(an)$ via excising =0$ |
| `prob-method-second-moment-oq-01-oq-03` | probability | measure-theoretic Paley–Zygmund for Mathlib |
| `konigsberg-oq-02-oq-01-oq-02` | graph theory | undirected Eulerian circuit theorem |
| `wilsons-theorem-oq-04-oq-02-oq-01` | group theory | product of all group elements, non-abelian (via abelianization) |

## Guards applied
- OQ-chain depth ≤ 3, no same-index re-spawn loops
- None already in gallery (`git cat-file` on origin/main) or with open WIP PRs
- All parents verified 0-axiom
- All 6 pass `validate-seeker-stubs.ts` (no template placeholders)

Database + `.lean/state/candidate-pool.json` updated separately (local state); this PR carries only the git-tracked `problem.md` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)