### PR TITLE
Enrich Frobenius Number & Sperner's Lemma entries: add references

### DIFF
--- a/src/data/proofs/frobenius-number-oq-03/meta.json
+++ b/src/data/proofs/frobenius-number-oq-03/meta.json
@@ -185,5 +185,31 @@
       "relationship": "foundational",
       "description": "The Euclidean GCD algorithm makes the `Nat.Coprime a b` hypothesis checkable and decidable. This is essential for instantiating the Sylvester bound $(a-1)(b-1)$ on concrete numeric examples — without computable coprimality testing, the bound is purely abstract."
     }
+  ],
+  "references": [
+    {
+      "authors": "Sylvester, J. J.",
+      "title": "Question 7382",
+      "year": "1884",
+      "note": "Mathematical Questions from the Educational Times 41, 21. Gives the two-generator Frobenius number g(a,b)=ab−a−b, the base case the three-generator theory here generalizes."
+    },
+    {
+      "authors": "Brauer, A.",
+      "title": "On a problem of partitions",
+      "year": "1942",
+      "note": "American Journal of Mathematics 64, 299–312. Early systematic study of the Frobenius (coin) problem for several generators."
+    },
+    {
+      "authors": "Ramírez Alfonsín, J. L.",
+      "title": "The Diophantine Frobenius Problem",
+      "year": "2005",
+      "note": "Oxford Lecture Series in Mathematics and its Applications 30. The comprehensive monograph on the Frobenius number, including the NP-hardness and known formulas for three generators."
+    },
+    {
+      "authors": "Rosales, J. C.; García-Sánchez, P. A.",
+      "title": "Numerical Semigroups",
+      "year": "2009",
+      "note": "Springer Developments in Mathematics 20. Develops the numerical-semigroup framework ⟨a,b,c⟩ and the Frobenius number as its largest gap, matching this entry's Representable3 API."
+    }
   ]
 }

--- a/src/data/proofs/sperner-mathlib/meta.json
+++ b/src/data/proofs/sperner-mathlib/meta.json
@@ -112,5 +112,31 @@
     "additionalFiles": [
       "Proofs/SpernerMathlibHyper.lean"
     ]
-  }
+  },
+  "references": [
+    {
+      "authors": "Sperner, E.",
+      "title": "Neuer Beweis für die Invarianz der Dimensionszahl und des Gebietes",
+      "year": "1928",
+      "note": "Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg 6, 265–272. The original combinatorial lemma on panchromatic (fully labeled) simplices."
+    },
+    {
+      "authors": "Kuhn, H. W.",
+      "title": "Some combinatorial lemmas in topology",
+      "year": "1960",
+      "note": "IBM Journal of Research and Development 4(5), 518–524. The door / path-following parity argument for Sperner's lemma that this cell-complex proof formalizes."
+    },
+    {
+      "authors": "Su, F. E.",
+      "title": "Rental Harmony: Sperner's Lemma in Fair Division",
+      "year": "1999",
+      "note": "American Mathematical Monthly 106(10), 930–942. A widely cited exposition of the 'rooms and doors' counting proof used here."
+    },
+    {
+      "authors": "Aigner, M.; Ziegler, G. M.",
+      "title": "Proofs from THE BOOK (6th ed.)",
+      "year": "2018",
+      "note": "Springer. Presents Sperner's lemma and its parity proof alongside the Brouwer fixed-point application."
+    }
+  ]
 }

--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -180,5 +180,31 @@
   "sorries": 0,
   "additionalFiles": [
     "Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean"
+  ],
+  "references": [
+    {
+      "authors": "Sperner, E.",
+      "title": "Neuer Beweis für die Invarianz der Dimensionszahl und des Gebietes",
+      "year": "1928",
+      "note": "Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg 6, 265–272. The original statement of Sperner's lemma for triangulated simplices."
+    },
+    {
+      "authors": "Kuhn, H. W.",
+      "title": "Some combinatorial lemmas in topology",
+      "year": "1960",
+      "note": "IBM Journal of Research and Development 4(5), 518–524. Path-following proof; the pseudomanifold parity structure bridged here generalizes Kuhn's triangulation setting."
+    },
+    {
+      "authors": "Henle, M.",
+      "title": "A Combinatorial Introduction to Topology",
+      "year": "1994",
+      "note": "Dover. Treats simplicial complexes, pseudomanifolds, and Sperner's lemma with the boundary/interior door counting used in this bridge."
+    },
+    {
+      "authors": "Aigner, M.; Ziegler, G. M.",
+      "title": "Proofs from THE BOOK (6th ed.)",
+      "year": "2018",
+      "note": "Springer. Sperner's lemma and its role in Brouwer's fixed-point theorem via triangulations."
+    }
   ]
 }


### PR DESCRIPTION
## Enrichment: references

Three rich reference-less entries in combinatorics/number theory get authoritative, content-matched references:

**frobenius-number-oq-03** — three-generator Frobenius (coin) problem: Sylvester (two-generator base case), Brauer, Ramírez Alfonsín *The Diophantine Frobenius Problem*, Rosales–García-Sánchez *Numerical Semigroups*.

**sperner-mathlib** — Sperner's lemma via door counting: Sperner (1928), Kuhn (1960 path-following), Su (rooms-and-doors exposition), Aigner–Ziegler.

**sperner-simplicial-instance** — pseudomanifold bridge: Sperner, Kuhn, Henle, Aigner–Ziegler.

All files well under the 60 KB / 25-reference caps. No other fields touched.