### PR TITLE
Audit catalan-numbers-oq-05-oq-02: clean (audit backlog → 0)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26251,6 +26251,12 @@
       "lastAudited": "2026-07-01T05:50:17Z",
       "result": "clean",
       "issues": []
+    },
+    "catalan-numbers-oq-05-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T06:03:54Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the last remaining unaudited gallery entry, **catalan-numbers-oq-05-oq-02** (The Catalan triangle / ballot numbers). Result: **CLEAN** — no issues.

### Checks performed (meta.json vs `proofs/Proofs/CatalanNumbersOQ05OQ02.lean`)

| Claim | meta.json | Source | Verdict |
|-------|-----------|--------|---------|
| status | `verified` | 0 sorries, 0 axioms, 0 True stubs | ✅ |
| badge | `original` | Genuine Catalan-triangle infrastructure built from elementary Pascal identities (`Nat.choose_succ_right_eq`, `choose_symm`, `choose_succ_succ`); not a single-deep-theorem wrapper. Mathlib has no ballot-number/Catalan-triangle object. | ✅ |
| sorries | 0 | 0 | ✅ |
| axiomCount | 0 | 0 `axiom` decls | ✅ |
| native_decide | "no native_decide" | Only a docstring prose mention (line 44); the closed-form sanity checks use plain kernel `decide`, which is 0-axiom. | ✅ |
| theoremCount / definitionCount / lineCount | 8 / 1 / 193 | 8 / 1 / 193 | ✅ |

**Risk level: LOW.** No famous-theorem overclaim, no Millennium reference, no delegation opacity or axiom masking. Title accurately scopes the result (a combinatorial identity family).

This updates `audit-tracker.json`, bringing the audit backlog to **0 unaudited / 4232 total**.

---
Discovered during gallery integrity audit (auditor agent).