### PR TITLE
Enrich 8 classic theorems: add references

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem/meta.json
@@ -174,5 +174,42 @@
     "definitionCount": 2,
     "theoremCount": 6
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "G. L. Dirichlet",
+      "title": "Verallgemeinerung eines Satzes aus der Lehre von den Kettenbrüchen nebst einigen Anwendungen auf die Theorie der Zahlen",
+      "year": 1842,
+      "venue": "Bericht Königl. Preuss. Akad. Wiss., 93–95",
+      "note": "Original pigeonhole (Schubfachprinzip) approximation theorem."
+    },
+    {
+      "authors": "A. Ya. Khinchin",
+      "title": "Continued Fractions",
+      "year": 1964,
+      "venue": "Univ. of Chicago Press",
+      "note": "Continued-fraction context for best rational approximations."
+    },
+    {
+      "authors": "W. M. Schmidt",
+      "title": "Diophantine Approximation",
+      "year": 1980,
+      "venue": "Springer, Lecture Notes in Math. 785",
+      "note": "Modern account of Dirichlet's theorem and its higher-dimensional generalizations."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford Univ. Press, 6th ed., ch. XI",
+      "note": "Textbook proof via the pigeonhole principle."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: pigeonhole principle (Finset.exists_ne_map_eq_of_card_lt_of_maps_to)",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Pigeonhole lemma underlying the formal proof."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-ko-rado/meta.json
+++ b/src/data/proofs/erdos-ko-rado/meta.json
@@ -170,5 +170,49 @@
       "summary": "A closing block of `#check` commands, grouped by part, that elaborates the type of every named definition, axiom, and theorem across Parts II–VI. Acts as a lightweight compile-time regression guard documenting the file's public surface."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "P. Erdős, C. Ko and R. Rado",
+      "title": "Intersection theorems for systems of finite sets",
+      "year": 1961,
+      "venue": "Quart. J. Math. Oxford Ser. (2) 12, 313–320",
+      "note": "Original theorem: an intersecting family of k-subsets of [n] with n≥2k has at most C(n-1,k-1) members."
+    },
+    {
+      "authors": "G. O. H. Katona",
+      "title": "A simple proof of the Erdős–Ko–Rado theorem",
+      "year": 1972,
+      "venue": "J. Combin. Theory Ser. B 13, 183–184",
+      "note": "The cyclic-permutation averaging argument formalized here."
+    },
+    {
+      "authors": "A. J. W. Hilton and E. C. Milner",
+      "title": "Some intersection theorems for systems of finite sets",
+      "year": 1967,
+      "venue": "Quart. J. Math. Oxford Ser. (2) 18, 369–384",
+      "note": "Hilton–Milner refinement bounding non-star intersecting families."
+    },
+    {
+      "authors": "P. Frankl",
+      "title": "The Erdős–Ko–Rado theorem is true for n = ckt",
+      "year": 1978,
+      "venue": "Combinatorics (Keszthely 1976), Colloq. Math. Soc. János Bolyai 18, 365–375",
+      "note": "t-intersecting extension used in the generalizations."
+    },
+    {
+      "authors": "P. Erdős and R. Rado",
+      "title": "Intersection theorems for systems of sets",
+      "year": 1960,
+      "venue": "J. London Math. Soc. 35, 85–90",
+      "note": "Origin of the sunflower (Δ-system) lemma."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Combinatorics.SetFamily.KruskalKatona and intersecting families",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Finset-based set-family API supporting the formalization."
+    }
+  ]
 }

--- a/src/data/proofs/mantel-theorem/meta.json
+++ b/src/data/proofs/mantel-theorem/meta.json
@@ -156,5 +156,42 @@
     "card_edgeFinset_turanGraph_two",
     "mantel_bound_is_tight"
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "W. Mantel",
+      "title": "Problem 28 (solution by H. Gouwentak, W. Mantel, J. Teixeira de Mattes, F. Schuh and W. A. Wythoff)",
+      "year": 1907,
+      "venue": "Wiskundige Opgaven 10, 60–61",
+      "note": "Original statement and proof that a triangle-free graph on n vertices has at most ⌊n²/4⌋ edges."
+    },
+    {
+      "authors": "P. Turán",
+      "title": "On an extremal problem in graph theory (Hungarian)",
+      "year": 1941,
+      "venue": "Matematikai és Fizikai Lapok 48, 436–452",
+      "note": "Generalizes Mantel to K_{r+1}-free graphs; Mantel is the r=2 case."
+    },
+    {
+      "authors": "M. Aigner and G. M. Ziegler",
+      "title": "Proofs from THE BOOK",
+      "year": 2018,
+      "venue": "Springer, 6th ed., ch. 'Turán's graph theorem'",
+      "note": "Collects several short proofs of Mantel/Turán, including the weight-shifting and probabilistic arguments."
+    },
+    {
+      "authors": "B. Bollobás",
+      "title": "Extremal Graph Theory",
+      "year": 1978,
+      "venue": "Academic Press",
+      "note": "Standard reference placing Mantel's theorem at the origin of extremal graph theory."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Combinatorics.SimpleGraph and extremal graph theory API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Simple graph, edge-set cardinality and bipartite constructions underlying the formalization."
+    }
+  ]
 }

--- a/src/data/proofs/napoleons-theorem/meta.json
+++ b/src/data/proofs/napoleons-theorem/meta.json
@@ -201,5 +201,35 @@
     "definitionCount": 10,
     "sorries": 0,
     "path": "Proofs/NapoleonsTheorem.lean"
-  }
+  },
+  "references": [
+    {
+      "authors": "H. S. M. Coxeter and S. L. Greitzer",
+      "title": "Geometry Revisited",
+      "year": 1967,
+      "venue": "Mathematical Association of America, New Mathematical Library 19",
+      "note": "Classical exposition of Napoleon's theorem via rotations and complex numbers."
+    },
+    {
+      "authors": "J. E. Wetzel",
+      "title": "Converses of Napoleon's theorem",
+      "year": 1992,
+      "venue": "Amer. Math. Monthly 99(4), 339–351",
+      "note": "Survey of the theorem, its history, and converse statements."
+    },
+    {
+      "authors": "H. S. M. Coxeter",
+      "title": "Introduction to Geometry",
+      "year": 1969,
+      "venue": "Wiley, 2nd ed.",
+      "note": "Treats the centroid/isogonal structure underlying the equilateral outer triangle."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Geometry.Euclidean and complex-number rotation API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Euclidean geometry and rotation lemmas used in the formalization."
+    }
+  ]
 }

--- a/src/data/proofs/quadratic-reciprocity-algorithm/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm/meta.json
@@ -171,5 +171,35 @@
       "leanType": "{p q : ℕ} → [Fact p.Prime] → [Fact q.Prime] → p ≠ 2 → q ≠ 2 → legendreSym q p = (-1)^(p/2*(q/2)) * legendreSym p q"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "C. F. Gauss",
+      "title": "Disquisitiones Arithmeticae",
+      "year": 1801,
+      "venue": "Leipzig (English transl. A. A. Clarke, Yale Univ. Press, 1966)",
+      "note": "First complete proof of the law of quadratic reciprocity."
+    },
+    {
+      "authors": "K. Ireland and M. Rosen",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": 1990,
+      "venue": "Springer GTM 84, 2nd ed.",
+      "note": "Legendre/Jacobi symbols and reciprocity as a computational tool."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford Univ. Press, 6th ed.",
+      "note": "Elementary treatment of the Legendre symbol and reciprocity."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: NumberTheory.LegendreSymbol.QuadraticReciprocity",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Legendre symbol, its multiplicativity and the reciprocity law formalized in Lean."
+    }
+  ]
 }

--- a/src/data/proofs/sum-of-divisors/meta.json
+++ b/src/data/proofs/sum-of-divisors/meta.json
@@ -203,5 +203,35 @@
       "summary": "Proves not_abundant_lt_12 (∀ 0<n<12, ¬IsAbundant n) by interval_cases + native_decide, then twelve_smallest_abundant combining this with twelve_is_abundant."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "T. M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer, Undergraduate Texts in Mathematics, ch. 2",
+      "note": "Multiplicative arithmetic functions, σ(n) and the prime-power formula."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford Univ. Press, 6th ed.",
+      "note": "Divisor functions and perfect/abundant number classification."
+    },
+    {
+      "authors": "L. E. Dickson",
+      "title": "History of the Theory of Numbers, Vol. I: Divisibility and Primality",
+      "year": 1919,
+      "venue": "Carnegie Institution of Washington",
+      "note": "Historical account of perfect, abundant, deficient and amicable numbers."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: NumberTheory.Divisors and ArithmeticFunction.sigma",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "σ arithmetic function, multiplicativity and divisor-sum API used here."
+    }
+  ]
 }

--- a/src/data/proofs/sylow-theorem/meta.json
+++ b/src/data/proofs/sylow-theorem/meta.json
@@ -141,5 +141,42 @@
     "definitionCount": 1,
     "theoremCount": 10
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "L. Sylow",
+      "title": "Théorèmes sur les groupes de substitutions",
+      "year": 1872,
+      "venue": "Math. Ann. 5, 584–594",
+      "note": "Original statement of the three Sylow theorems."
+    },
+    {
+      "authors": "D. S. Dummit and R. M. Foote",
+      "title": "Abstract Algebra",
+      "year": 2004,
+      "venue": "Wiley, 3rd ed., ch. 4",
+      "note": "Standard textbook treatment of the Sylow theorems and their applications to classification."
+    },
+    {
+      "authors": "J. J. Rotman",
+      "title": "An Introduction to the Theory of Groups",
+      "year": 1995,
+      "venue": "Springer GTM 148, 4th ed.",
+      "note": "Group-action proof of existence, conjugacy and the n_p ≡ 1 (mod p) count."
+    },
+    {
+      "authors": "F. Wiedijk (ed.)",
+      "title": "Formalizing 100 Theorems — #72 Sylow's Theorem",
+      "year": 2023,
+      "venue": "cs.ru.nl/~freek/100/",
+      "note": "Tracks formal proofs of Sylow's theorems across proof assistants."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: GroupTheory.Sylow",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Provides Sylow p-subgroups, conjugacy and Cauchy's theorem used here."
+    }
+  ]
 }

--- a/src/data/proofs/weak-goldbach/meta.json
+++ b/src/data/proofs/weak-goldbach/meta.json
@@ -186,5 +186,42 @@
       "description": "Dirichlet's theorem on primes in arithmetic progressions is the analytic foundation underlying the singular series in the Goldbach circle method: the local factors Π_p (correction) are computed from the distribution of primes modulo small primes, exactly what Dirichlet L-functions govern."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "H. A. Helfgott",
+      "title": "The ternary Goldbach conjecture is true",
+      "year": 2013,
+      "venue": "arXiv:1312.7748",
+      "note": "Unconditional proof that every odd integer > 5 is a sum of three primes."
+    },
+    {
+      "authors": "I. M. Vinogradov",
+      "title": "Representation of an odd number as a sum of three primes",
+      "year": 1937,
+      "venue": "Dokl. Akad. Nauk SSSR 15, 291–294",
+      "note": "Circle-method proof for all sufficiently large odd integers."
+    },
+    {
+      "authors": "T. Tao",
+      "title": "Every odd number greater than 1 is the sum of at most five primes",
+      "year": 2014,
+      "venue": "Math. Comp. 83, 997–1038",
+      "note": "The 5-prime bound, superseded by Helfgott."
+    },
+    {
+      "authors": "O. Ramaré",
+      "title": "On Šnirel'man's constant",
+      "year": 1995,
+      "venue": "Ann. Scuola Norm. Sup. Pisa Cl. Sci. (4) 22, 645–706",
+      "note": "Six-prime bound and Schnirelmann-type additive-basis results."
+    },
+    {
+      "authors": "H. A. Helfgott",
+      "title": "Major arcs for Goldbach's problem",
+      "year": 2015,
+      "venue": "arXiv:1305.2897",
+      "note": "Companion paper supplying the major-arc estimates of the ternary proof."
+    }
+  ]
 }


### PR DESCRIPTION
Adds curated bibliographic references to eight gallery entries whose top-level `references` field was empty.

Entries enriched:
- **Mantel's Theorem** — Mantel 1907, Turán 1941, Aigner–Ziegler, Bollobás
- **Erdős–Ko–Rado** — EKR 1961, Katona 1972, Hilton–Milner, Frankl, sunflower lemma
- **Sylow's Theorems** — Sylow 1872, Dummit–Foote, Rotman, Wiedijk #72
- **Napoleon's Theorem** — Coxeter–Greitzer, Wetzel 1992, Coxeter
- **Quadratic Reciprocity Algorithm** — Gauss 1801, Ireland–Rosen, Hardy–Wright
- **Weak Goldbach** — Helfgott 2013/2015, Vinogradov 1937, Tao 2014, Ramaré 1995
- **Dirichlet's Approximation Theorem** — Dirichlet 1842, Khinchin, Schmidt, Hardy–Wright
- **Sum of Divisors** — Apostol, Hardy–Wright, Dickson, mathlib

Each reference set is matched to the entry's specific mathematical content and ends with a mathlib module pointer where relevant. Data-only change (meta.json `references` field); no Lean sources touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)