### PR TITLE
Enrich 8 more classic theorems: add references

### DIFF
--- a/src/data/proofs/binary-gcd/meta.json
+++ b/src/data/proofs/binary-gcd/meta.json
@@ -140,5 +140,35 @@
       "description": "Correctness: binaryGcd a b = Nat.gcd a b"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "J. Stein",
+      "title": "Computational problems associated with Racah algebra",
+      "year": 1967,
+      "venue": "J. Comput. Phys. 1(3), 397–405",
+      "note": "Original binary GCD algorithm using only subtraction and shifts."
+    },
+    {
+      "authors": "D. E. Knuth",
+      "title": "The Art of Computer Programming, Vol. 2: Seminumerical Algorithms",
+      "year": 1997,
+      "venue": "Addison-Wesley, 3rd ed., §4.5.2",
+      "note": "Analysis of the binary GCD algorithm and comparison with Euclid's."
+    },
+    {
+      "authors": "R. P. Brent",
+      "title": "Analysis of the binary Euclidean algorithm",
+      "year": 1976,
+      "venue": "Algorithms and Complexity (J. F. Traub, ed.), Academic Press, 321–355",
+      "note": "Average-case complexity of Stein's algorithm."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.gcd and divisibility lemmas",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "gcd properties used to prove correctness of the binary variant."
+    }
+  ]
 }

--- a/src/data/proofs/chebyshev-bounds/meta.json
+++ b/src/data/proofs/chebyshev-bounds/meta.json
@@ -149,7 +149,47 @@
       "Mathlib.Analysis.SpecialFunctions.Log.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": ["Nat", "Finset"]
+    "opens": [
+      "Nat",
+      "Finset"
+    ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "P. L. Chebyshev",
+      "title": "Mémoire sur les nombres premiers",
+      "year": 1852,
+      "venue": "J. Math. Pures Appl. (1) 17, 366–390",
+      "note": "Original elementary bounds showing π(x) is of order x/log x."
+    },
+    {
+      "authors": "M. Aigner and G. M. Ziegler",
+      "title": "Proofs from THE BOOK",
+      "year": 2018,
+      "venue": "Springer, 6th ed., ch. 'Bertrand's postulate'",
+      "note": "Erdős's central-binomial-coefficient proof of Bertrand's postulate and Chebyshev-type bounds."
+    },
+    {
+      "authors": "T. M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer, ch. 4",
+      "note": "Chebyshev functions θ(x), ψ(x) and their elementary estimates."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford Univ. Press, 6th ed., ch. XXII",
+      "note": "Order-of-magnitude of π(n) and Bertrand's postulate."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: NumberTheory.Bertrand and central binomial coefficient API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Bertrand's postulate and Nat.centralBinom used in the bounds."
+    }
+  ]
 }

--- a/src/data/proofs/infinitude-primes-4k1/meta.json
+++ b/src/data/proofs/infinitude-primes-4k1/meta.json
@@ -136,5 +136,35 @@
       "summary": "Proves by decide that 5, 13, 17, 29, 37 are all prime and ≡ 1 (mod 4). These are the first five elements of OEIS A002144 (primes ≡ 1 mod 4), all expressible as sums of two squares: 5=1²+2², 13=2²+3², 17=1²+4², 29=2²+5², 37=1²+6²."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "L. Euler",
+      "title": "Observations on a theorem of Fermat and others concerning prime numbers",
+      "year": 1758,
+      "venue": "Novi Comm. Acad. Sci. Petrop.",
+      "note": "Euler's criterion and sums-of-two-squares background."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford Univ. Press, 6th ed., ch. II & VI",
+      "note": "Primes in arithmetic progressions mod 4 and Fermat's two-squares theorem."
+    },
+    {
+      "authors": "K. Ireland and M. Rosen",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": 1990,
+      "venue": "Springer GTM 84, 2nd ed.",
+      "note": "Euler's criterion for -1 being a quadratic residue mod p."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Key lemma constraining odd prime factors of n²+1 to be ≡ 1 (mod 4)."
+    }
+  ]
 }

--- a/src/data/proofs/infinitude-primes-4k3/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3/meta.json
@@ -156,5 +156,35 @@
       "summary": "Five `example` statements verifying 3, 7, 11, 19, 23 are primes = 3 (mod 4), each by `decide`/`Nat.prime_three`, plus #check exports of the main results."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Euclid",
+      "title": "Elements, Book IX, Proposition 20",
+      "year": -300,
+      "venue": "Alexandria",
+      "note": "The prototype infinitude-of-primes argument adapted to the 4k+3 progression."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford Univ. Press, 6th ed., ch. II",
+      "note": "Elementary proof of infinitely many primes ≡ 3 (mod 4)."
+    },
+    {
+      "authors": "D. M. Burton",
+      "title": "Elementary Number Theory",
+      "year": 2010,
+      "venue": "McGraw-Hill, 7th ed.",
+      "note": "Euclid-style constructions for primes in special residue classes."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.Prime and ZMod residue API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Prime factorization and mod-4 residue reasoning used here."
+    }
+  ]
 }

--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -294,5 +294,35 @@
       "significance": "Confirms G(2) = g(2) = 4"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "J.-L. Lagrange",
+      "title": "Démonstration d'un théorème d'arithmétique",
+      "year": 1770,
+      "venue": "Nouv. Mém. Acad. Berlin",
+      "note": "Every natural number is a sum of four squares."
+    },
+    {
+      "authors": "C. F. Gauss",
+      "title": "Disquisitiones Arithmeticae",
+      "year": 1801,
+      "venue": "Leipzig, art. 291–293",
+      "note": "Three-squares theorem: n is a sum of three squares iff n ≠ 4^a(8b+7)."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford Univ. Press, 6th ed., ch. XX–XXI",
+      "note": "Sums of squares and Waring's problem, including g(2)=4."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: NumberTheory.SumFourSquares and SumTwoSquares",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Lagrange's four-square theorem formalized in Lean."
+    }
+  ]
 }

--- a/src/data/proofs/spherical-law-of-cosines/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines/meta.json
@@ -150,5 +150,35 @@
     "definitionCount": 9,
     "theoremCount": 24
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "I. Todhunter",
+      "title": "Spherical Trigonometry, for the Use of Colleges and Schools",
+      "year": 1886,
+      "venue": "Macmillan, 5th ed.",
+      "note": "Classical derivation of the spherical law of cosines."
+    },
+    {
+      "authors": "M. do Carmo",
+      "title": "Differential Geometry of Curves and Surfaces",
+      "year": 2016,
+      "venue": "Dover, 2nd ed.",
+      "note": "Geodesic triangles on the sphere and inner-product formulation."
+    },
+    {
+      "authors": "W. Gellert et al. (eds.)",
+      "title": "The VNR Concise Encyclopedia of Mathematics",
+      "year": 1989,
+      "venue": "Van Nostrand Reinhold, 2nd ed.",
+      "note": "Reference formulas of spherical trigonometry."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: InnerProductSpace and EuclideanSpace API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Inner products and orthogonal projections in ℝ³ used in the proof."
+    }
+  ]
 }

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
@@ -133,5 +133,35 @@
       "summary": "The second half of irrational_sqrt2_plus_sqrt3. From hsq : (r:ℝ)² = 5 + 2√6, `linarith` isolates h6 : √6 = ((r:ℝ)² - 5)/2. The witness hrat : ∃ q : ℚ, (q:ℝ) = √6 is built with q = (r²-5)/2, using `simp only [Rat.cast_div, Rat.cast_sub, Rat.cast_pow, Rat.cast_natCast]` to align ℚ→ℝ casts with h6.symm. Then `exact irrational_sqrt_six hrat` feeds the rational witness into the auxiliary lemma, contradicting Irrational (√6) and discharging the goal. Line 54 closes the namespace."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford Univ. Press, 6th ed., ch. IV",
+      "note": "Irrationality of surds and elementary irrationality arguments."
+    },
+    {
+      "authors": "I. Niven",
+      "title": "Irrational Numbers",
+      "year": 1956,
+      "venue": "Mathematical Association of America, Carus Monograph 11",
+      "note": "Systematic treatment of irrationality proofs including sums of square roots."
+    },
+    {
+      "authors": "M. Aigner and G. M. Ziegler",
+      "title": "Proofs from THE BOOK",
+      "year": 2018,
+      "venue": "Springer, 6th ed.",
+      "note": "Classic short irrationality proofs by contradiction."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: irrational_sqrt_natCast_iff and Irrational API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Irrationality of √n for non-square n, used directly for √6."
+    }
+  ]
 }

--- a/src/data/proofs/stars-and-bars-weak-compositions/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions/meta.json
@@ -128,5 +128,35 @@
   "crossReferences": [
     "composition-parts-choose-oq-01",
     "composition-card-2pow-oq-01"
+  ],
+  "references": [
+    {
+      "authors": "W. Feller",
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. I",
+      "year": 1968,
+      "venue": "Wiley, 3rd ed., ch. II",
+      "note": "The stars-and-bars occupancy model and its counting formula."
+    },
+    {
+      "authors": "R. P. Stanley",
+      "title": "Enumerative Combinatorics, Vol. 1",
+      "year": 2011,
+      "venue": "Cambridge Univ. Press, 2nd ed.",
+      "note": "Weak compositions and multiset coefficients C(n+k-1, n)."
+    },
+    {
+      "authors": "J. H. van Lint and R. M. Wilson",
+      "title": "A Course in Combinatorics",
+      "year": 2001,
+      "venue": "Cambridge Univ. Press, 2nd ed.",
+      "note": "Bijective proof of the multiset/composition count."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Sym, Finset and Nat.multichoose API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Multiset and cardinality machinery underlying the formalization."
+    }
   ]
 }


### PR DESCRIPTION
Adds curated bibliographic references to eight gallery entries whose top-level `references` field was empty.

Entries enriched:
- **Chebyshev's Prime Bounds** — Chebyshev 1852, Aigner–Ziegler, Apostol, Hardy–Wright
- **Binary GCD (Stein)** — Stein 1967, Knuth TAOCP, Brent 1976
- **Irrationality of √2+√3** — Hardy–Wright, Niven, Aigner–Ziegler
- **Primes ≡ 1 (mod 4)** — Euler, Ireland–Rosen, Hardy–Wright
- **Primes ≡ 3 (mod 4)** — Euclid, Hardy–Wright, Burton
- **Stars and Bars** — Feller, Stanley, van Lint–Wilson
- **Waring g(2)=4 (Lagrange four squares)** — Lagrange 1770, Gauss, Hardy–Wright
- **Spherical Law of Cosines** — Todhunter, do Carmo, VNR Encyclopedia

Each reference set is matched to the entry's specific mathematical content and ends with a mathlib module pointer where relevant. Data-only change; no Lean sources touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)