### PR TITLE
Enrich 8 classic theorems: add references (batch 3)

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -199,5 +199,35 @@
       "description": "Polynomial annihilator characterization: cyclic iff not killed by any nonzero polynomial of degree < n."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "S. Roman",
+      "title": "Advanced Linear Algebra",
+      "year": 2008,
+      "venue": "Springer GTM 135, 3rd ed.",
+      "note": "Cyclic (nonderogatory) operators, minimal polynomial and primary decomposition."
+    },
+    {
+      "authors": "N. Jacobson",
+      "title": "Basic Algebra I",
+      "year": 1985,
+      "venue": "W. H. Freeman, 2nd ed.",
+      "note": "Rational canonical form and cyclic-vector existence via module theory."
+    },
+    {
+      "authors": "K. Hoffman and R. Kunze",
+      "title": "Linear Algebra",
+      "year": 1971,
+      "venue": "Prentice-Hall, 2nd ed., ch. 7",
+      "note": "Cyclic decomposition theorem and the primary decomposition used here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: LinearAlgebra.Matrix.Charpoly and minpoly, module primary decomposition",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Minimal/characteristic polynomial and CRT machinery over a general field."
+    }
+  ]
 }

--- a/src/data/proofs/cevas-theorem-non-euclidean/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean/meta.json
@@ -142,5 +142,35 @@
     "definitionCount": 11,
     "theoremCount": 18
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "G. Ceva",
+      "title": "De lineis rectis se invicem secantibus statica constructio",
+      "year": 1678,
+      "venue": "Milan",
+      "note": "Original Euclidean concurrency criterion for cevians."
+    },
+    {
+      "authors": "H. S. M. Coxeter and S. L. Greitzer",
+      "title": "Geometry Revisited",
+      "year": 1967,
+      "venue": "Mathematical Association of America",
+      "note": "Ceva's theorem and its ratio form."
+    },
+    {
+      "authors": "M. J. Greenberg",
+      "title": "Euclidean and Non-Euclidean Geometries: Development and History",
+      "year": 2008,
+      "venue": "W. H. Freeman, 4th ed.",
+      "note": "Spherical and hyperbolic trigonometry framing the non-Euclidean extensions."
+    },
+    {
+      "authors": "I. Todhunter",
+      "title": "Spherical Trigonometry",
+      "year": 1886,
+      "venue": "Macmillan, 5th ed.",
+      "note": "Sine-rule identities for the spherical version of Ceva's theorem."
+    }
+  ]
 }

--- a/src/data/proofs/divisibility-rules/meta.json
+++ b/src/data/proofs/divisibility-rules/meta.json
@@ -136,5 +136,35 @@
     "definitionCount": 3,
     "theoremCount": 38
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford Univ. Press, 6th ed., ch. IX",
+      "note": "Decimal representation of numbers and congruence-based divisibility tests."
+    },
+    {
+      "authors": "D. M. Burton",
+      "title": "Elementary Number Theory",
+      "year": 2010,
+      "venue": "McGraw-Hill, 7th ed., ch. 4",
+      "note": "Standard divisibility rules derived from modular arithmetic."
+    },
+    {
+      "authors": "O. Ore",
+      "title": "Number Theory and Its History",
+      "year": 1948,
+      "venue": "McGraw-Hill",
+      "note": "Historical development of casting-out-nines and digit-sum tests."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.modEq_digits_sum and Nat.digits API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Digit-sum congruence framework underlying the base-b divisibility rules."
+    }
+  ]
 }

--- a/src/data/proofs/frobenius-number/meta.json
+++ b/src/data/proofs/frobenius-number/meta.json
@@ -1,152 +1,182 @@
 {
-    "id": "frobenius-number",
-    "title": "Frobenius Number for Two Coprime Integers",
-    "slug": "frobenius-number",
-    "description": "A complete proof of Sylvester's 1884 theorem: for coprime positive integers a and b, the Frobenius number (largest non-representable integer) is g(a,b) = ab - a - b. Also known as the Chicken McNugget Theorem or Coin Problem. The proof establishes the representability structure via the Bezout identity and shows exactly (a-1)(b-1)/2 non-representable positive integers exist.",
-    "meta": {
-        "author": "Lean Genius",
-        "date": "2026-05-04",
-        "status": "verified",
-        "proofRepoPath": "Proofs/FrobeniusNumber.lean",
-        "tags": [
-            "number-theory",
-            "combinatorics",
-            "frobenius",
-            "coin-problem",
-            "coprime"
-        ],
-        "badge": "original",
-        "sorries": 0,
-        "axiomCount": 0,
-        "lineCount": 324,
-        "theoremCount": 15,
-        "definitionCount": 3,
-        "assumptions": ""
-    },
-    "overview": {
-        "historicalContext": "J.J. Sylvester posed the Frobenius coin problem in 1882 and solved the two-generator case in 1884: for coprime positive integers $a$ and $b$, the largest amount that cannot be made using only $a$-cent and $b$-cent coins is $ab - a - b$. The result was independently rediscovered multiple times (Frobenius discussed it in lectures, giving it his name). The popular 'Chicken McNugget Theorem' refers to the claim that with 6- and 9-piece boxes you can't make exactly 43 pieces, but since gcd(6,9)=3, the actual coprime example is {3,5} or {5,7}. The n-generator generalization ($n \\geq 3$) is NP-hard, making this two-generator formula doubly remarkable: it is both explicit and proves the maximum exists (a non-trivial fact — when gcd > 1 there is no largest non-representable number).",
-        "problemStatement": "For coprime positive integers $a, b$ (i.e., $\\gcd(a,b) = 1$), define $g(a,b) = ab - a - b$. Prove: (1) $g(a,b)$ is NOT representable as $ax + by$ with $x, y \\geq 0$; (2) every integer $n > g(a,b)$ IS representable. Additionally, there are exactly $(a-1)(b-1)/2$ positive non-representable integers.",
-        "proofStrategy": "The key is that the map $k \\mapsto kb \\bmod a$ is a bijection on $\\{0, 1, \\ldots, a-1\\}$ when $\\gcd(a,b) = 1$ (proved via injectivity → surjectivity on a finite set). Given $n > ab - a - b$, find $k < a$ with $kb \\equiv n \\pmod{a}$. Then $a \\mid (n - kb)$, giving $n - kb = aq$ for some $q \\geq 0$, so $n = aq + kb$. The bound $n > ab - a - b = (a-1)(b-1) - 1$ ensures $n \\geq (a-1)(b-1)$ which, combined with $k < a$, forces $q \\geq 0$. For the non-representability of $ab - a - b$: any representation $ax + by = ab - a - b$ leads to $a(x+1) + b(y+1) = ab$; coprimality then forces $a \\mid (y+1)$ and $b \\mid (x+1)$, giving $x+1 \\geq b$ and $y+1 \\geq a$, so $a(x+1) + b(y+1) \\geq 2ab > ab$, contradiction.",
-        "keyInsights": [
-            "The injectivity of $k \\mapsto kb \\bmod a$ on $\\{0, \\ldots, a-1\\}$ is the bridge between the number theory (coprimality) and the combinatorics (surjectivity needed to find representations). In Lean 4 this uses `Finite.injective_iff_surjective` on `Fin a`.",
-            "The bound $(a-1)(b-1) \\leq n$ is equivalent to $n > ab - a - b$ by a simple omega computation: $(a-1)(b-1) = ab - a - b + 1$. This rewriting is the key step connecting the theorem's two formulations.",
-            "The non-representability proof uses a `nlinarith`-friendly formulation: any representation $ax + by = ab - a - b$ would give $a(x+1) + b(y+1) = ab$ with $a \\mid (y+1)$ and $b \\mid (x+1)$, forcing both terms to be at least $ab$ — but their sum is $ab$. Contradiction by linear arithmetic.",
-            "Consecutive integers $(a, a+1)$ always have $\\gcd = 1$, giving the family $g(a, a+1) = a^2 - a - 1$. For $a = 2$: only 1 is non-representable in $\\{2, 3\\}$; for $a = 3$: only $\\{1, 2, 4, 5\\}$ are non-representable in $\\{3, 4\\}$ with max 5.",
-            "The count $(a-1)(b-1)/2$ of non-representable positive integers is proved implicitly via examples but not by a general theorem in this file — it is an open question whether this gallery proof can be extended to include the exact count."
-        ]
-    },
-    "sections": [
-        {
-            "id": "representability",
-            "title": "Representability: Definition and Closure Properties",
-            "startLine": 38,
-            "endLine": 68,
-            "summary": "Defines `Representable a b n := ∃ x y : ℕ, n = a*x + b*y` and proves closure: 0, a, b are representable; if n is representable so are n+a and n+b. These closure properties bootstrap the inductive structure used in the main theorem."
-        },
-        {
-            "id": "frobenius-def",
-            "title": "Frobenius Number and Count Definitions",
-            "startLine": 70,
-            "endLine": 89,
-            "summary": "Defines `frobeniusNumber a b := a*b - a - b` (the conjectured threshold) and `numNonRepresentable a b := (a-1)*(b-1)/2` (the count of non-representable positives). Proves the alternative form `frobeniusNumber = (a-1)*(b-1) - 1` for a,b ≥ 2."
-        },
-        {
-            "id": "key-lemma",
-            "title": "Key Lemma: Bijection k ↦ kb mod a on Fin a",
-            "startLine": 90,
-            "endLine": 132,
-            "summary": "The private lemma `mul_mod_injective` proves injectivity of k ↦ k*b mod a on Fin a (when gcd(a,b) = 1) via coprimality. Then `exists_mul_mod` inverts this: every residue r < a is achieved as k*b mod a for some k < a. This bijection is the number-theoretic engine of the Frobenius theorem."
-        },
-        {
-            "id": "main-theorem",
-            "title": "Main Theorem: Large Numbers Are Representable",
-            "startLine": 134,
-            "endLine": 233,
-            "summary": "Two key theorems: `large_representable` (every n ≥ (a-1)(b-1) is representable, proved by finding k < a with k*b ≡ n mod a) and `frobenius_not_representable` (ab-a-b is not representable, by coprimality forcing x+1 ≥ b and y+1 ≥ a). Combined in `sylvester_frobenius`."
-        },
-        {
-            "id": "examples",
-            "title": "Verified Numeric Examples",
-            "startLine": 235,
-            "endLine": 263,
-            "summary": "Concrete computations using native_decide: frobeniusNumber(3,5)=7, (3,7)=11, (5,8)=27. Explicit representations for 8 through 12 in {3,5}. numNonRepresentable(3,5)=4 (values: 1,2,4,7) and (3,7)=6."
-        },
-        {
-            "id": "corollaries",
-            "title": "Corollaries and Special Cases",
-            "startLine": 265,
-            "endLine": 316,
-            "summary": "eventually_all_representable (quantitative: all n ≥ (a-1)(b-1) work), closure theorems as one-line aliases, frobenius_consecutive (special case: g(a,a+1) = a²-a-1), and Chicken McNugget examples (g(2,3)=1, g(3,4)=5, g(4,5)=11)."
-        }
+  "id": "frobenius-number",
+  "title": "Frobenius Number for Two Coprime Integers",
+  "slug": "frobenius-number",
+  "description": "A complete proof of Sylvester's 1884 theorem: for coprime positive integers a and b, the Frobenius number (largest non-representable integer) is g(a,b) = ab - a - b. Also known as the Chicken McNugget Theorem or Coin Problem. The proof establishes the representability structure via the Bezout identity and shows exactly (a-1)(b-1)/2 non-representable positive integers exist.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-05-04",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FrobeniusNumber.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "frobenius",
+      "coin-problem",
+      "coprime"
     ],
-    "conclusion": {
-        "summary": "The Frobenius number formula g(a,b) = ab - a - b is machine-checked for all coprime positive integers a and b, with no axioms or sorries. The proof uses the bijection k ↦ kb mod a on Fin a as the key number-theoretic tool.",
-        "implications": "This is the complete two-variable solution to the Frobenius coin problem. The n-variable version (n ≥ 3 generators) is NP-hard in general, so this entry captures the full extent of what is computationally tractable. The bijection approach (injectivity → surjectivity on a finite set) is a pattern that reappears in many discrete math arguments: coprimality + finiteness → existence. The result also implies that the set of non-representable numbers is exactly a symmetric set: n is non-representable iff ab - a - b - n is non-representable (when 1 ≤ n ≤ ab - a - b - 1), a beautiful duality not proved here.",
-        "openQuestions": [
-            "Can the count of non-representable numbers ((a-1)(b-1)/2) be proved as a theorem in this framework, not just verified for examples?",
-            "The symmetry of non-representable numbers (n is non-representable iff g(a,b) - n is non-representable, when both are positive) — can this be formalized here?",
-            "Can the proof be extended to the 3-generator case g(a,b,c) with explicit formulas for specific families (arithmetic progressions, Fibonacci triples)?"
-        ]
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 324,
+    "theoremCount": 15,
+    "definitionCount": 3,
+    "assumptions": ""
+  },
+  "overview": {
+    "historicalContext": "J.J. Sylvester posed the Frobenius coin problem in 1882 and solved the two-generator case in 1884: for coprime positive integers $a$ and $b$, the largest amount that cannot be made using only $a$-cent and $b$-cent coins is $ab - a - b$. The result was independently rediscovered multiple times (Frobenius discussed it in lectures, giving it his name). The popular 'Chicken McNugget Theorem' refers to the claim that with 6- and 9-piece boxes you can't make exactly 43 pieces, but since gcd(6,9)=3, the actual coprime example is {3,5} or {5,7}. The n-generator generalization ($n \\geq 3$) is NP-hard, making this two-generator formula doubly remarkable: it is both explicit and proves the maximum exists (a non-trivial fact — when gcd > 1 there is no largest non-representable number).",
+    "problemStatement": "For coprime positive integers $a, b$ (i.e., $\\gcd(a,b) = 1$), define $g(a,b) = ab - a - b$. Prove: (1) $g(a,b)$ is NOT representable as $ax + by$ with $x, y \\geq 0$; (2) every integer $n > g(a,b)$ IS representable. Additionally, there are exactly $(a-1)(b-1)/2$ positive non-representable integers.",
+    "proofStrategy": "The key is that the map $k \\mapsto kb \\bmod a$ is a bijection on $\\{0, 1, \\ldots, a-1\\}$ when $\\gcd(a,b) = 1$ (proved via injectivity → surjectivity on a finite set). Given $n > ab - a - b$, find $k < a$ with $kb \\equiv n \\pmod{a}$. Then $a \\mid (n - kb)$, giving $n - kb = aq$ for some $q \\geq 0$, so $n = aq + kb$. The bound $n > ab - a - b = (a-1)(b-1) - 1$ ensures $n \\geq (a-1)(b-1)$ which, combined with $k < a$, forces $q \\geq 0$. For the non-representability of $ab - a - b$: any representation $ax + by = ab - a - b$ leads to $a(x+1) + b(y+1) = ab$; coprimality then forces $a \\mid (y+1)$ and $b \\mid (x+1)$, giving $x+1 \\geq b$ and $y+1 \\geq a$, so $a(x+1) + b(y+1) \\geq 2ab > ab$, contradiction.",
+    "keyInsights": [
+      "The injectivity of $k \\mapsto kb \\bmod a$ on $\\{0, \\ldots, a-1\\}$ is the bridge between the number theory (coprimality) and the combinatorics (surjectivity needed to find representations). In Lean 4 this uses `Finite.injective_iff_surjective` on `Fin a`.",
+      "The bound $(a-1)(b-1) \\leq n$ is equivalent to $n > ab - a - b$ by a simple omega computation: $(a-1)(b-1) = ab - a - b + 1$. This rewriting is the key step connecting the theorem's two formulations.",
+      "The non-representability proof uses a `nlinarith`-friendly formulation: any representation $ax + by = ab - a - b$ would give $a(x+1) + b(y+1) = ab$ with $a \\mid (y+1)$ and $b \\mid (x+1)$, forcing both terms to be at least $ab$ — but their sum is $ab$. Contradiction by linear arithmetic.",
+      "Consecutive integers $(a, a+1)$ always have $\\gcd = 1$, giving the family $g(a, a+1) = a^2 - a - 1$. For $a = 2$: only 1 is non-representable in $\\{2, 3\\}$; for $a = 3$: only $\\{1, 2, 4, 5\\}$ are non-representable in $\\{3, 4\\}$ with max 5.",
+      "The count $(a-1)(b-1)/2$ of non-representable positive integers is proved implicitly via examples but not by a general theorem in this file — it is an open question whether this gallery proof can be extended to include the exact count."
+    ]
+  },
+  "sections": [
+    {
+      "id": "representability",
+      "title": "Representability: Definition and Closure Properties",
+      "startLine": 38,
+      "endLine": 68,
+      "summary": "Defines `Representable a b n := ∃ x y : ℕ, n = a*x + b*y` and proves closure: 0, a, b are representable; if n is representable so are n+a and n+b. These closure properties bootstrap the inductive structure used in the main theorem."
     },
-    "crossReferences": [
-        {
-            "proofId": "bezout-identity",
-            "relationship": "foundational",
-            "description": "Bézout's identity is the algebraic engine behind Sylvester's proof. The Frobenius theorem reduces to: for coprime $a, b$ and $n > ab - a - b$, find $k \\in [0, a)$ with $kb \\equiv n \\pmod{a}$. Existence of such $k$ is *exactly* the surjectivity of $k \\mapsto kb \\bmod a$ on $\\{0, \\ldots, a-1\\}$, which is the multiplicative form of Bézout's identity in $\\mathbb{Z}/a$: $\\gcd(a, b) = 1$ implies $b$ is a unit modulo $a$, so $bk$ ranges over all residues. The Lean proof uses `Finite.injective_iff_surjective`, a categorical reformulation of the same fact."
-        },
-        {
-            "proofId": "gcd-algorithm",
-            "relationship": "foundational",
-            "description": "The Euclidean GCD algorithm is the computational engine that makes the coprimality hypothesis $\\gcd(a, b) = 1$ checkable. The Frobenius formula $g(a, b) = ab - a - b$ is meaningless when $\\gcd > 1$ — in fact there is no largest non-representable number in that case. The Lean file's `native_decide` examples (Chicken McNugget $g(2,3) = 1$, $g(3,4) = 5$, $g(4,5) = 11$, $g(3,5) = 7$) all rely on Mathlib's `Nat.gcd` decision procedure to verify coprimality before the formula applies."
-        },
-        {
-            "proofId": "binary-gcd",
-            "relationship": "related",
-            "description": "Stein's binary GCD — an alternative efficient algorithm for the coprimality test that underlies the Frobenius hypothesis. The conceptual link: both this entry and Stein's algorithm exploit the modular-arithmetic structure of $\\mathbb{Z}$ at coprime pairs. The bijection $k \\mapsto kb \\bmod a$ on $\\{0, \\ldots, a-1\\}$ used here is the discrete analogue of the shift/subtract loop in Stein: both transit through residue classes modulo $a$ using only operations that respect the coprime structure."
-        },
-        {
-            "proofId": "chinese-remainder-constructive",
-            "relationship": "related",
-            "description": "Chinese Remainder Theorem — the structural extension of the Frobenius bijection beyond two moduli. The Frobenius proof uses the case $(a, b)$ coprime $\\Rightarrow$ $\\mathbb{Z}/a \\times \\mathbb{Z}/b \\cong \\mathbb{Z}/(ab)$ implicitly: it asserts every residue $r \\pmod a$ has a unique representative in $[0, a)$ that equals $kb$ for some $k$. CRT generalises to $n$ pairwise coprime moduli, opening the door to the (NP-hard) $n$-generator Frobenius problem listed in this entry's open questions."
-        },
-        {
-            "proofId": "wilsons-theorem",
-            "relationship": "related",
-            "description": "Wilson's theorem ($(p-1)! \\equiv -1 \\pmod p$ for prime $p$) — another classical use of the bijection $k \\mapsto kb \\bmod p$ on $\\{1, \\ldots, p-1\\}$. Wilson's proof pairs each $k$ with its inverse $k^{-1} \\bmod p$, which exists by exactly the same coprimality argument used here in `mul_mod_injective`. Both proofs are instances of the meta-pattern *coprimality $\\Rightarrow$ permutation of residues*; the present Frobenius proof uses the permutation's *surjectivity*, while Wilson uses its *pairing structure*."
-        },
-        {
-            "proofId": "partition-theorem",
-            "relationship": "related",
-            "description": "Integer partitions — the closest combinatorial cousin to representability $n = ax + by$. Where partition theory counts *all* ways to express $n$ as a sum of positive parts, the Frobenius problem counts only those expressions using the restricted multiset $\\{a, a, \\ldots, b, b, \\ldots\\}$. The denumerant $r(n) := |\\{(x, y) \\in \\mathbb{N}^2 : ax + by = n\\}|$ studied in classical Frobenius theory connects directly to partition generating functions; this gallery entry's open question on the $(a-1)(b-1)/2$ count is the Frobenius analogue of partition-counting identities."
-        },
-        {
-            "proofId": "infinitude-primes",
-            "relationship": "context",
-            "description": "Euclid's infinitude of primes — the historical and conceptual root of the coprimality-as-tool methodology that drives this entry. Both proofs leverage the same Mathlib `Nat.GCD` infrastructure (`Nat.Coprime`, `Nat.gcd_eq_one`, etc.) and both arrive at existence results via Bézout-style arguments at the level of $\\mathbb{Z}$. Distantly related but conceptually adjacent."
-        },
-        {
-            "proofId": "mathematical-induction",
-            "relationship": "context",
-            "description": "Mathematical induction underlies the closure-based bootstrap in `Representable` (§I of this file): the base cases $0, a, b$ are representable, and the closure properties `n representable $\\Rightarrow$ n+a, n+b representable` propagate representability through induction on $\\mathbb{N}$. The Lean tactics `Nat.rec` and `induction'` are the syntactic surface of this principle in the proofs of `large_representable` and `eventually_all_representable`."
-        },
-        {
-            "targetId": "frobenius-number-oq-01",
-            "relationship": "extended-by",
-            "description": "The Sylvester count: exactly (a-1)(b-1)/2 positive integers are non-representable by two coprime generators."
-        },
-        {
-            "targetId": "frobenius-number-oq-02",
-            "relationship": "extended-by",
-            "description": "The Sylvester symmetry duality Rep(n) <-> not Rep(g-n) for the Frobenius number g of two coprime generators."
-        }
-    ],
-    "leanFile": {
-        "path": "Proofs/FrobeniusNumber.lean",
-        "axiomCount": 0,
-        "lineCount": 324,
-        "theoremCount": 15,
-        "definitionCount": 3,
-        "sorries": 0
+    {
+      "id": "frobenius-def",
+      "title": "Frobenius Number and Count Definitions",
+      "startLine": 70,
+      "endLine": 89,
+      "summary": "Defines `frobeniusNumber a b := a*b - a - b` (the conjectured threshold) and `numNonRepresentable a b := (a-1)*(b-1)/2` (the count of non-representable positives). Proves the alternative form `frobeniusNumber = (a-1)*(b-1) - 1` for a,b ≥ 2."
     },
+    {
+      "id": "key-lemma",
+      "title": "Key Lemma: Bijection k ↦ kb mod a on Fin a",
+      "startLine": 90,
+      "endLine": 132,
+      "summary": "The private lemma `mul_mod_injective` proves injectivity of k ↦ k*b mod a on Fin a (when gcd(a,b) = 1) via coprimality. Then `exists_mul_mod` inverts this: every residue r < a is achieved as k*b mod a for some k < a. This bijection is the number-theoretic engine of the Frobenius theorem."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: Large Numbers Are Representable",
+      "startLine": 134,
+      "endLine": 233,
+      "summary": "Two key theorems: `large_representable` (every n ≥ (a-1)(b-1) is representable, proved by finding k < a with k*b ≡ n mod a) and `frobenius_not_representable` (ab-a-b is not representable, by coprimality forcing x+1 ≥ b and y+1 ≥ a). Combined in `sylvester_frobenius`."
+    },
+    {
+      "id": "examples",
+      "title": "Verified Numeric Examples",
+      "startLine": 235,
+      "endLine": 263,
+      "summary": "Concrete computations using native_decide: frobeniusNumber(3,5)=7, (3,7)=11, (5,8)=27. Explicit representations for 8 through 12 in {3,5}. numNonRepresentable(3,5)=4 (values: 1,2,4,7) and (3,7)=6."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries and Special Cases",
+      "startLine": 265,
+      "endLine": 316,
+      "summary": "eventually_all_representable (quantitative: all n ≥ (a-1)(b-1) work), closure theorems as one-line aliases, frobenius_consecutive (special case: g(a,a+1) = a²-a-1), and Chicken McNugget examples (g(2,3)=1, g(3,4)=5, g(4,5)=11)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Frobenius number formula g(a,b) = ab - a - b is machine-checked for all coprime positive integers a and b, with no axioms or sorries. The proof uses the bijection k ↦ kb mod a on Fin a as the key number-theoretic tool.",
+    "implications": "This is the complete two-variable solution to the Frobenius coin problem. The n-variable version (n ≥ 3 generators) is NP-hard in general, so this entry captures the full extent of what is computationally tractable. The bijection approach (injectivity → surjectivity on a finite set) is a pattern that reappears in many discrete math arguments: coprimality + finiteness → existence. The result also implies that the set of non-representable numbers is exactly a symmetric set: n is non-representable iff ab - a - b - n is non-representable (when 1 ≤ n ≤ ab - a - b - 1), a beautiful duality not proved here.",
+    "openQuestions": [
+      "Can the count of non-representable numbers ((a-1)(b-1)/2) be proved as a theorem in this framework, not just verified for examples?",
+      "The symmetry of non-representable numbers (n is non-representable iff g(a,b) - n is non-representable, when both are positive) — can this be formalized here?",
+      "Can the proof be extended to the 3-generator case g(a,b,c) with explicit formulas for specific families (arithmetic progressions, Fibonacci triples)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "bezout-identity",
+      "relationship": "foundational",
+      "description": "Bézout's identity is the algebraic engine behind Sylvester's proof. The Frobenius theorem reduces to: for coprime $a, b$ and $n > ab - a - b$, find $k \\in [0, a)$ with $kb \\equiv n \\pmod{a}$. Existence of such $k$ is *exactly* the surjectivity of $k \\mapsto kb \\bmod a$ on $\\{0, \\ldots, a-1\\}$, which is the multiplicative form of Bézout's identity in $\\mathbb{Z}/a$: $\\gcd(a, b) = 1$ implies $b$ is a unit modulo $a$, so $bk$ ranges over all residues. The Lean proof uses `Finite.injective_iff_surjective`, a categorical reformulation of the same fact."
+    },
+    {
+      "proofId": "gcd-algorithm",
+      "relationship": "foundational",
+      "description": "The Euclidean GCD algorithm is the computational engine that makes the coprimality hypothesis $\\gcd(a, b) = 1$ checkable. The Frobenius formula $g(a, b) = ab - a - b$ is meaningless when $\\gcd > 1$ — in fact there is no largest non-representable number in that case. The Lean file's `native_decide` examples (Chicken McNugget $g(2,3) = 1$, $g(3,4) = 5$, $g(4,5) = 11$, $g(3,5) = 7$) all rely on Mathlib's `Nat.gcd` decision procedure to verify coprimality before the formula applies."
+    },
+    {
+      "proofId": "binary-gcd",
+      "relationship": "related",
+      "description": "Stein's binary GCD — an alternative efficient algorithm for the coprimality test that underlies the Frobenius hypothesis. The conceptual link: both this entry and Stein's algorithm exploit the modular-arithmetic structure of $\\mathbb{Z}$ at coprime pairs. The bijection $k \\mapsto kb \\bmod a$ on $\\{0, \\ldots, a-1\\}$ used here is the discrete analogue of the shift/subtract loop in Stein: both transit through residue classes modulo $a$ using only operations that respect the coprime structure."
+    },
+    {
+      "proofId": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "Chinese Remainder Theorem — the structural extension of the Frobenius bijection beyond two moduli. The Frobenius proof uses the case $(a, b)$ coprime $\\Rightarrow$ $\\mathbb{Z}/a \\times \\mathbb{Z}/b \\cong \\mathbb{Z}/(ab)$ implicitly: it asserts every residue $r \\pmod a$ has a unique representative in $[0, a)$ that equals $kb$ for some $k$. CRT generalises to $n$ pairwise coprime moduli, opening the door to the (NP-hard) $n$-generator Frobenius problem listed in this entry's open questions."
+    },
+    {
+      "proofId": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Wilson's theorem ($(p-1)! \\equiv -1 \\pmod p$ for prime $p$) — another classical use of the bijection $k \\mapsto kb \\bmod p$ on $\\{1, \\ldots, p-1\\}$. Wilson's proof pairs each $k$ with its inverse $k^{-1} \\bmod p$, which exists by exactly the same coprimality argument used here in `mul_mod_injective`. Both proofs are instances of the meta-pattern *coprimality $\\Rightarrow$ permutation of residues*; the present Frobenius proof uses the permutation's *surjectivity*, while Wilson uses its *pairing structure*."
+    },
+    {
+      "proofId": "partition-theorem",
+      "relationship": "related",
+      "description": "Integer partitions — the closest combinatorial cousin to representability $n = ax + by$. Where partition theory counts *all* ways to express $n$ as a sum of positive parts, the Frobenius problem counts only those expressions using the restricted multiset $\\{a, a, \\ldots, b, b, \\ldots\\}$. The denumerant $r(n) := |\\{(x, y) \\in \\mathbb{N}^2 : ax + by = n\\}|$ studied in classical Frobenius theory connects directly to partition generating functions; this gallery entry's open question on the $(a-1)(b-1)/2$ count is the Frobenius analogue of partition-counting identities."
+    },
+    {
+      "proofId": "infinitude-primes",
+      "relationship": "context",
+      "description": "Euclid's infinitude of primes — the historical and conceptual root of the coprimality-as-tool methodology that drives this entry. Both proofs leverage the same Mathlib `Nat.GCD` infrastructure (`Nat.Coprime`, `Nat.gcd_eq_one`, etc.) and both arrive at existence results via Bézout-style arguments at the level of $\\mathbb{Z}$. Distantly related but conceptually adjacent."
+    },
+    {
+      "proofId": "mathematical-induction",
+      "relationship": "context",
+      "description": "Mathematical induction underlies the closure-based bootstrap in `Representable` (§I of this file): the base cases $0, a, b$ are representable, and the closure properties `n representable $\\Rightarrow$ n+a, n+b representable` propagate representability through induction on $\\mathbb{N}$. The Lean tactics `Nat.rec` and `induction'` are the syntactic surface of this principle in the proofs of `large_representable` and `eventually_all_representable`."
+    },
+    {
+      "targetId": "frobenius-number-oq-01",
+      "relationship": "extended-by",
+      "description": "The Sylvester count: exactly (a-1)(b-1)/2 positive integers are non-representable by two coprime generators."
+    },
+    {
+      "targetId": "frobenius-number-oq-02",
+      "relationship": "extended-by",
+      "description": "The Sylvester symmetry duality Rep(n) <-> not Rep(g-n) for the Frobenius number g of two coprime generators."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/FrobeniusNumber.lean",
+    "axiomCount": 0,
+    "lineCount": 324,
+    "theoremCount": 15,
+    "definitionCount": 3,
     "sorries": 0
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "J. J. Sylvester",
+      "title": "Mathematical question 7382",
+      "year": 1884,
+      "venue": "Educational Times 41, 21",
+      "note": "Original statement that the largest non-representable integer is ab−a−b."
+    },
+    {
+      "authors": "J. L. Ramírez Alfonsín",
+      "title": "The Diophantine Frobenius Problem",
+      "year": 2005,
+      "venue": "Oxford Univ. Press",
+      "note": "Comprehensive monograph on the Frobenius/coin problem."
+    },
+    {
+      "authors": "A. Brauer",
+      "title": "On a problem of partitions",
+      "year": 1942,
+      "venue": "Amer. J. Math. 64, 299–312",
+      "note": "Early systematic study of the Frobenius number for several generators."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.gcd, Bezout identity (Nat.gcd_eq_gcd_ab)",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Bezout coefficients underlying the representability structure."
+    }
+  ]
 }

--- a/src/data/proofs/markov-equation/meta.json
+++ b/src/data/proofs/markov-equation/meta.json
@@ -38,53 +38,60 @@
   },
   "sections": [
     {
-      "id": "sec-header",
-      "title": "The Markov Equation and the Root (1,1,1)",
+      "id": "intro",
+      "title": "The Markov equation and the Markov tree",
       "startLine": 1,
-      "endLine": 37,
-      "summary": "Docstring introducing the Markov equation x² + y² + z² = 3xyz, the Markov tree rooted at (1,1,1), and the descent strategy (sign of the quadratic g(t) = t² − 3xy·t + (x²+y²)). Notes that the ternary equation is not in Mathlib. Imports Mathlib, opens the MarkovEquation namespace, defines IsMarkov as positivity plus the equation, and proves markov_one that (1,1,1) is a solution."
+      "endLine": 30,
+      "summary": "Docstring framing: positive solutions of x²+y²+z²=3xyz form a tree rooted at (1,1,1); the file proves the structural theorem by descent on the coordinate sum, mirroring negative-Pell descent. Defines IsMarkov.",
+      "mathContext": "$x^2+y^2+z^2=3xyz$; the Markov tree organizes all positive solutions."
     },
     {
-      "id": "sec-symmetry",
-      "title": "Symmetry of the Equation",
-      "startLine": 39,
+      "id": "singular-symmetry",
+      "title": "The singular solution and coordinate symmetry",
+      "startLine": 31,
       "endLine": 49,
-      "summary": "markov_swap12 and markov_swap23: the two adjacent coordinate transpositions preserve Markov triples (the equation is fully symmetric), each a one-line linear_combination carrying the positivity hypotheses. These generate the S₃ action used in the move relation."
+      "summary": "markov_one: (1,1,1) is a Markov triple. markov_swap12 / markov_swap23: transposing coordinates preserves Markov triples (the equation is symmetric).",
+      "mathContext": "The equation is symmetric in x,y,z; (1,1,1) is the singular root."
     },
     {
-      "id": "sec-vieta",
-      "title": "Vieta Jumping",
+      "id": "vieta-jump",
+      "title": "Vieta jumping",
       "startLine": 51,
       "endLine": 74,
-      "summary": "markov_root_prod (the two z-roots multiply to x²+y²), markov_vieta (the jump z ↦ 3xy − z sends a Markov triple to a Markov triple, with positivity of the new coordinate from z·z' = x²+y² > 0 and z > 0), and markov_vieta_involutive (the jump is an involution). This is the root-swapping move of the tree."
+      "summary": "markov_root_prod (z·z' = x²+y²), markov_vieta (the jump z ↦ 3xy−z preserves Markov triples with positivity), and markov_vieta_involutive (the jump is an involution).",
+      "mathContext": "Fixing x,y, the equation is a quadratic in z with roots z, z'=3xy−z (Vieta)."
     },
     {
-      "id": "sec-descent",
-      "title": "The Descent Inequality",
+      "id": "descent",
+      "title": "The descent inequality",
       "startLine": 76,
       "endLine": 112,
-      "summary": "markov_top_strict (a sorted triple with z ≥ 2 has a strict maximum y < z; a tie forces the impossible x² = z²(3x−2)) and markov_vieta_lt (the Vieta jump on the maximum strictly decreases it, 3xy − z < z), driven by the sign g(y) = (y−z)(y−z') = x² + y²(2−3x) ≤ 0 and the chain x²+y² = z·z' ≤ z·y < z². The engine of the descent."
+      "summary": "markov_top_strict (a sorted triple with z ≥ 2 has strict max y < z) and markov_vieta_lt (the descent 3xy − z < z via g(y) ≤ 0 and the root product), the arithmetic engine of the descent.",
+      "mathContext": "$g(y)=(y-z)(y-z')\\le 0$ forces $z'\\le y<z$, so the jump strictly decreases the sum."
     },
     {
-      "id": "sec-reachability",
-      "title": "Reachability in the Markov Tree",
+      "id": "reachability",
+      "title": "Reachability and sorting",
       "startLine": 114,
       "endLine": 167,
-      "summary": "The inductive Step relation (two transpositions + Vieta jump), Reachable as its reflexive-transitive closure, isMarkov_of_step (each move preserves IsMarkov), and sort_reachable (any triple reaches a sorted representative with the same sum via ≤ 3 transpositions, covering all six orderings)."
+      "summary": "Step (transpositions + Vieta jump) and its closure Reachable; isMarkov_of_step (moves preserve IsMarkov); sort_reachable (any triple reaches a sorted representative by ≤ 3 transpositions, same sum).",
+      "mathContext": "Reachable = ReflTransGen(Step); sorting preserves the coordinate sum."
     },
     {
-      "id": "sec-classification",
-      "title": "Main Classification Theorem",
+      "id": "classification",
+      "title": "The classification theorem",
       "startLine": 169,
       "endLine": 207,
-      "summary": "markov_reachable_one by strong induction on the coordinate sum (via Int.toNat): sort the triple, and if the top is ≥ 2, Vieta-jump it down to a strictly smaller sum and apply the induction hypothesis; otherwise it is (1,1,1). markov_classification packages this as: every positive Markov triple is reachable from the root."
+      "summary": "markov_reachable_one (strong induction on the sum: sort, then Vieta-jump the max to descend) and markov_classification (every positive Markov triple reaches (1,1,1)).",
+      "mathContext": "Descent terminates only at the root (1,1,1)."
     },
     {
-      "id": "sec-consequences",
-      "title": "Consequences and Small Triples",
+      "id": "consequences",
+      "title": "Consequences and small triples",
       "startLine": 209,
       "endLine": 237,
-      "summary": "markov_all_eq (the root (1,1,1) is the unique all-equal triple, since (t,t,t) Markov ⟺ t²(t−1) = 0 ⟺ t = 1), the concrete witnesses (1,1,2), (1,2,5), (2,5,29), and markov_step_root_to_112 exhibiting the first Vieta jump (1,1,1) ↦ (1,1,2)."
+      "summary": "markov_all_eq (uniqueness: (t,t,t) Markov iff t=1), concrete triples (1,1,2), (1,2,5), (2,5,29), and markov_step_root_to_112 (the first Vieta jump from the root).",
+      "mathContext": "$(t,t,t)$ Markov $\\iff t=1$; small triples ground the tree."
     }
   ],
   "crossReferences": [
@@ -160,63 +167,35 @@
       "leanType": "∀ {t : ℤ}, IsMarkov t t t → t = 1"
     }
   ],
-  "sections": [
+  "sorries": 0,
+  "references": [
     {
-      "id": "intro",
-      "title": "The Markov equation and the Markov tree",
-      "startLine": 1,
-      "endLine": 30,
-      "summary": "Docstring framing: positive solutions of x²+y²+z²=3xyz form a tree rooted at (1,1,1); the file proves the structural theorem by descent on the coordinate sum, mirroring negative-Pell descent. Defines IsMarkov.",
-      "mathContext": "$x^2+y^2+z^2=3xyz$; the Markov tree organizes all positive solutions."
+      "authors": "A. A. Markov",
+      "title": "Sur les formes quadratiques binaires indéfinies",
+      "year": 1880,
+      "venue": "Math. Ann. 17, 379–399",
+      "note": "Origin of the Markov equation x²+y²+z²=3xyz and its tree of solutions."
     },
     {
-      "id": "singular-symmetry",
-      "title": "The singular solution and coordinate symmetry",
-      "startLine": 31,
-      "endLine": 49,
-      "summary": "markov_one: (1,1,1) is a Markov triple. markov_swap12 / markov_swap23: transposing coordinates preserves Markov triples (the equation is symmetric).",
-      "mathContext": "The equation is symmetric in x,y,z; (1,1,1) is the singular root."
+      "authors": "M. Aigner",
+      "title": "Markov's Theorem and 100 Years of the Uniqueness Conjecture",
+      "year": 2013,
+      "venue": "Springer",
+      "note": "Modern monograph on the Markov tree, Vieta jumping and the uniqueness conjecture."
     },
     {
-      "id": "vieta-jump",
-      "title": "Vieta jumping",
-      "startLine": 51,
-      "endLine": 74,
-      "summary": "markov_root_prod (z·z' = x²+y²), markov_vieta (the jump z ↦ 3xy−z preserves Markov triples with positivity), and markov_vieta_involutive (the jump is an involution).",
-      "mathContext": "Fixing x,y, the equation is a quadratic in z with roots z, z'=3xy−z (Vieta)."
+      "authors": "J. W. S. Cassels",
+      "title": "An Introduction to Diophantine Approximation",
+      "year": 1957,
+      "venue": "Cambridge Univ. Press",
+      "note": "Markov spectrum and the arithmetic of the Markov equation."
     },
     {
-      "id": "descent",
-      "title": "The descent inequality",
-      "startLine": 76,
-      "endLine": 112,
-      "summary": "markov_top_strict (a sorted triple with z ≥ 2 has strict max y < z) and markov_vieta_lt (the descent 3xy − z < z via g(y) ≤ 0 and the root product), the arithmetic engine of the descent.",
-      "mathContext": "$g(y)=(y-z)(y-z')\\le 0$ forces $z'\\le y<z$, so the jump strictly decreases the sum."
-    },
-    {
-      "id": "reachability",
-      "title": "Reachability and sorting",
-      "startLine": 114,
-      "endLine": 167,
-      "summary": "Step (transpositions + Vieta jump) and its closure Reachable; isMarkov_of_step (moves preserve IsMarkov); sort_reachable (any triple reaches a sorted representative by ≤ 3 transpositions, same sum).",
-      "mathContext": "Reachable = ReflTransGen(Step); sorting preserves the coordinate sum."
-    },
-    {
-      "id": "classification",
-      "title": "The classification theorem",
-      "startLine": 169,
-      "endLine": 207,
-      "summary": "markov_reachable_one (strong induction on the sum: sort, then Vieta-jump the max to descend) and markov_classification (every positive Markov triple reaches (1,1,1)).",
-      "mathContext": "Descent terminates only at the root (1,1,1)."
-    },
-    {
-      "id": "consequences",
-      "title": "Consequences and small triples",
-      "startLine": 209,
-      "endLine": 237,
-      "summary": "markov_all_eq (uniqueness: (t,t,t) Markov iff t=1), concrete triples (1,1,2), (1,2,5), (2,5,29), and markov_step_root_to_112 (the first Vieta jump from the root).",
-      "mathContext": "$(t,t,t)$ Markov $\\iff t=1$; small triples ground the tree."
+      "authors": "T. Andreescu and B. Enescu",
+      "title": "Mathematical Olympiad Treasures",
+      "year": 2011,
+      "venue": "Birkhäuser, 2nd ed.",
+      "note": "Vieta jumping (root flipping) as an infinite-descent technique."
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/minpoly-charpoly/meta.json
+++ b/src/data/proofs/minpoly-charpoly/meta.json
@@ -205,5 +205,35 @@
       "significance": "The starting point for the divisibility proof"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "K. Hoffman and R. Kunze",
+      "title": "Linear Algebra",
+      "year": 1971,
+      "venue": "Prentice-Hall, 2nd ed., ch. 6",
+      "note": "Minimal and characteristic polynomials and their divisibility relation."
+    },
+    {
+      "authors": "S. Lang",
+      "title": "Algebra",
+      "year": 2002,
+      "venue": "Springer GTM 211, 3rd ed.",
+      "note": "Cayley–Hamilton theorem and minimal polynomial theory."
+    },
+    {
+      "authors": "D. S. Dummit and R. M. Foote",
+      "title": "Abstract Algebra",
+      "year": 2004,
+      "venue": "Wiley, 3rd ed., ch. 12",
+      "note": "Rational canonical form; minpoly divides charpoly with the same irreducible factors."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: LinearAlgebra.Matrix.Charpoly.Basic and FieldTheory.Minpoly",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "minpoly, charpoly, monicity and the aeval Cayley–Hamilton API."
+    }
+  ]
 }

--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -178,5 +178,42 @@
   "sorries": 0,
   "additionalFiles": [
     "Proofs/RothTheoremOQ02.lean"
+  ],
+  "references": [
+    {
+      "authors": "K. F. Roth",
+      "title": "On certain sets of integers",
+      "year": 1953,
+      "venue": "J. London Math. Soc. 28, 104–109",
+      "note": "Original theorem: sets with no 3-term AP have density o(1)."
+    },
+    {
+      "authors": "E. Szemerédi",
+      "title": "On sets of integers containing no k elements in arithmetic progression",
+      "year": 1975,
+      "venue": "Acta Arith. 27, 199–245",
+      "note": "Generalization to arbitrary-length progressions."
+    },
+    {
+      "authors": "H. Furstenberg and Y. Katznelson",
+      "title": "An ergodic Szemerédi theorem for commuting transformations",
+      "year": 1978,
+      "venue": "J. Analyse Math. 34, 275–291",
+      "note": "Corners theorem, the route used by Mathlib's Roth."
+    },
+    {
+      "authors": "B. Green and T. Tao",
+      "title": "An arithmetic regularity lemma, an associated counting lemma, and applications",
+      "year": 2010,
+      "venue": "An Irregular Mind, Bolyai Soc. Math. Stud. 21, 261–334",
+      "note": "Modern Fourier-analytic and regularity framework for AP counting."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Combinatorics.Additive.Corner and Roth",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Corners-theorem-based Roth invoked by the formalization."
+    }
   ]
 }

--- a/src/data/proofs/van-der-waerden-first-moment/meta.json
+++ b/src/data/proofs/van-der-waerden-first-moment/meta.json
@@ -123,5 +123,35 @@
       "relationship": "context — the probabilistic-method applications gallery whose vacuous ramsey/property-B placeholders are superseded by verified dedicated entries such as this one"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "B. L. van der Waerden",
+      "title": "Beweis einer Baudetschen Vermutung",
+      "year": 1927,
+      "venue": "Nieuw Arch. Wisk. 15, 212–216",
+      "note": "Original proof that any finite colouring of ℤ contains long monochromatic APs."
+    },
+    {
+      "authors": "N. Alon and J. H. Spencer",
+      "title": "The Probabilistic Method",
+      "year": 2016,
+      "venue": "Wiley, 4th ed., ch. 1",
+      "note": "First-moment/union-bound lower bounds for van der Waerden numbers."
+    },
+    {
+      "authors": "R. L. Graham, B. L. Rothschild and J. H. Spencer",
+      "title": "Ramsey Theory",
+      "year": 1990,
+      "venue": "Wiley, 2nd ed.",
+      "note": "Van der Waerden numbers and their bounds."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Combinatorics.Pigeonhole and probability API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Counting and union-bound machinery used in the first-moment argument."
+    }
+  ]
 }


### PR DESCRIPTION
Adds curated bibliographic references to eight gallery entries whose top-level `references` field was empty.

Entries enriched:
- **Markov Equation** — Markov 1880, Aigner monograph, Cassels, Vieta jumping
- **Frobenius Number** — Sylvester 1884, Ramírez Alfonsín, Brauer
- **Roth's Theorem** — Roth 1953, Szemerédi, Furstenberg–Katznelson, Green–Tao
- **van der Waerden First-Moment Bound** — van der Waerden 1927, Alon–Spencer, Graham–Rothschild–Spencer
- **Nonderogatory → Cyclic Vector** — Roman, Jacobson, Hoffman–Kunze
- **Minpoly vs Charpoly** — Hoffman–Kunze, Lang, Dummit–Foote
- **Divisibility Rules** — Hardy–Wright, Burton, Ore
- **Non-Euclidean Ceva** — Ceva 1678, Coxeter–Greitzer, Greenberg, Todhunter

Each reference set is matched to the entry's specific content and ends with a mathlib pointer where relevant. Data-only change; no Lean sources touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)