### PR TITLE
Enrich 8 classic theorems: add references (batch 4)

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge/meta.json
@@ -185,5 +185,35 @@
       "Finset"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "P. L. Chebyshev",
+      "title": "Mémoire sur les nombres premiers",
+      "year": 1852,
+      "venue": "J. Math. Pures Appl. (1) 17, 366–390",
+      "note": "Original elementary bounds on π(x)."
+    },
+    {
+      "authors": "T. M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer, ch. 4",
+      "note": "Chebyshev functions and π(x)·log(x)/x estimates."
+    },
+    {
+      "authors": "M. Aigner and G. M. Ziegler",
+      "title": "Proofs from THE BOOK",
+      "year": 2018,
+      "venue": "Springer, 6th ed.",
+      "note": "Central-binomial-coefficient bounds giving π(x) = Θ(x/log x)."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford Univ. Press, 6th ed., ch. XXII",
+      "note": "Elementary order-of-magnitude estimates for π(x)."
+    }
+  ]
 }

--- a/src/data/proofs/factor-remainder-nullstellensatz/meta.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz/meta.json
@@ -192,5 +192,35 @@
       "leanType": "(W : Set (σ → k)) → vanishingIdeal (zeroLocus ↑(vanishingIdeal W)) = vanishingIdeal W"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "D. Hilbert",
+      "title": "Über die vollen Invariantensysteme",
+      "year": 1893,
+      "venue": "Math. Ann. 42, 313–373",
+      "note": "Origin of the Nullstellensatz."
+    },
+    {
+      "authors": "D. Cox, J. Little and D. O'Shea",
+      "title": "Ideals, Varieties, and Algorithms",
+      "year": 2015,
+      "venue": "Springer, 4th ed.",
+      "note": "Factor theorem, vanishing ideals and the ideal–variety Galois connection."
+    },
+    {
+      "authors": "M. Atiyah and I. G. Macdonald",
+      "title": "Introduction to Commutative Algebra",
+      "year": 1969,
+      "venue": "Addison-Wesley",
+      "note": "Nullstellensatz and maximal ideals over algebraically closed fields."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: RingTheory.Polynomial and Nullstellensatz (MvPolynomial vanishing ideal)",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Factor theorem and zero-locus/vanishing-ideal API used here."
+    }
+  ]
 }

--- a/src/data/proofs/gauss-wilson-non-cyclic/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic/meta.json
@@ -131,5 +131,35 @@
       "Proofs/GaussWilsonNonCyclicOQ03.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "C. F. Gauss",
+      "title": "Disquisitiones Arithmeticae",
+      "year": 1801,
+      "venue": "Leipzig",
+      "note": "Generalized Wilson theorem and the structure of (ℤ/nℤ)×."
+    },
+    {
+      "authors": "K. Ireland and M. Rosen",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": 1990,
+      "venue": "Springer GTM 84, 2nd ed., ch. 4",
+      "note": "Structure of the unit group (ℤ/nℤ)× and its cyclicity criterion."
+    },
+    {
+      "authors": "D. S. Dummit and R. M. Foote",
+      "title": "Abstract Algebra",
+      "year": 2004,
+      "venue": "Wiley, 3rd ed.",
+      "note": "CRT decomposition and 2-torsion of finite abelian groups."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: ZMod.unitsMap, ZMod.chineseRemainder and IsCyclic",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Unit group, CRT and cyclicity API underlying the two-case proof."
+    }
+  ]
 }

--- a/src/data/proofs/inverse-galois-a5/meta.json
+++ b/src/data/proofs/inverse-galois-a5/meta.json
@@ -138,5 +138,35 @@
       "Formalize the Hilbert irreducibility theorem to give uniform realizations of S_n and A_n for all n"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "D. S. Dummit and R. M. Foote",
+      "title": "Abstract Algebra",
+      "year": 2004,
+      "venue": "Wiley, 3rd ed., ch. 14",
+      "note": "Galois theory, discriminants and the alternating-group criterion Gal ≤ A_n."
+    },
+    {
+      "authors": "J.-P. Serre",
+      "title": "Topics in Galois Theory",
+      "year": 2008,
+      "venue": "A K Peters, 2nd ed.",
+      "note": "The inverse Galois problem and realizations of specific groups over ℚ."
+    },
+    {
+      "authors": "H. Völklein",
+      "title": "Groups as Galois Groups: An Introduction",
+      "year": 1996,
+      "venue": "Cambridge Univ. Press",
+      "note": "Systematic constructions realizing groups as Galois groups."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: FieldTheory.Galois, Polynomial.Eisenstein and discriminant API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Eisenstein irreducibility and Galois-group machinery used in the realization."
+    }
+  ]
 }

--- a/src/data/proofs/ramsey-r4k/meta.json
+++ b/src/data/proofs/ramsey-r4k/meta.json
@@ -235,5 +235,42 @@
       "description": "Extensions of R(4,k) bounds beyond the classical binomial framework, including the AKS improvement O(k³/log²k) and probabilistic lower bounds Ω(k^{5/2}/log²k)"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "F. P. Ramsey",
+      "title": "On a problem of formal logic",
+      "year": 1930,
+      "venue": "Proc. London Math. Soc. (2) 30, 264–286",
+      "note": "Original Ramsey theorem."
+    },
+    {
+      "authors": "P. Erdős and G. Szekeres",
+      "title": "A combinatorial problem in geometry",
+      "year": 1935,
+      "venue": "Compositio Math. 2, 463–470",
+      "note": "Binomial upper bound R(r,s) ≤ C(r+s-2, r-1) and the Pascal recursion."
+    },
+    {
+      "authors": "P. Erdős",
+      "title": "Some remarks on the theory of graphs",
+      "year": 1947,
+      "venue": "Bull. Amer. Math. Soc. 53, 292–294",
+      "note": "Probabilistic lower bound for Ramsey numbers."
+    },
+    {
+      "authors": "J. H. Spencer",
+      "title": "Ten Lectures on the Probabilistic Method",
+      "year": 1994,
+      "venue": "SIAM, 2nd ed.",
+      "note": "Union-bound lower bounds for off-diagonal Ramsey numbers."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Combinatorics.SimpleGraph.Ramsey and Nat.choose",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Ramsey number bounds and binomial-coefficient API."
+    }
+  ]
 }

--- a/src/data/proofs/spherical-law-of-sines/meta.json
+++ b/src/data/proofs/spherical-law-of-sines/meta.json
@@ -153,5 +153,35 @@
   },
   "additionalFiles": [
     "Proofs/SphericalLawOfSinesOQ03.lean"
+  ],
+  "references": [
+    {
+      "authors": "I. Todhunter",
+      "title": "Spherical Trigonometry, for the Use of Colleges and Schools",
+      "year": 1886,
+      "venue": "Macmillan, 5th ed.",
+      "note": "Classical derivation of the spherical law of sines."
+    },
+    {
+      "authors": "M. do Carmo",
+      "title": "Differential Geometry of Curves and Surfaces",
+      "year": 2016,
+      "venue": "Dover, 2nd ed.",
+      "note": "Geodesic triangles on the sphere and their trigonometric relations."
+    },
+    {
+      "authors": "W. Gellert et al. (eds.)",
+      "title": "The VNR Concise Encyclopedia of Mathematics",
+      "year": 1989,
+      "venue": "Van Nostrand Reinhold, 2nd ed.",
+      "note": "Reference formulas of spherical trigonometry."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: InnerProductSpace, cross product and determinant API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Cross-product/determinant identities in ℝ³ used in the proof."
+    }
   ]
 }

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational/meta.json
@@ -138,5 +138,35 @@
       "endLine": 142,
       "summary": "irrational_sqrt2_plus_sqrt3_plus_sqrt5 (main). Assume α = (r : ℝ) for some r : ℚ. By alpha_pos we have α > 0, so r ≠ 0 and 8 · (r : ℝ) ≠ 0. Substituting r for α in the quartic identity and dividing by 8(r:ℝ) gives sqrt 30 = ((r:ℝ)⁴ − 20(r:ℝ)² − 24) / (8(r:ℝ)). The rational witness (r⁴ − 20r² − 24) / (8r) ∈ ℚ then contradicts irrational_sqrt_thirty via push_cast. Closely modelled on the parent's irrational_sqrt2_plus_sqrt3 proof structure."
     }
+  ],
+  "references": [
+    {
+      "authors": "I. Niven",
+      "title": "Irrational Numbers",
+      "year": 1956,
+      "venue": "Mathematical Association of America, Carus Monograph 11",
+      "note": "Irrationality of sums of square roots of distinct primes."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford Univ. Press, 6th ed., ch. IV",
+      "note": "Irrationality of surds via repeated squaring."
+    },
+    {
+      "authors": "R. Courant and H. Robbins",
+      "title": "What Is Mathematics?",
+      "year": 1996,
+      "venue": "Oxford Univ. Press, 2nd ed.",
+      "note": "Elementary irrationality arguments and field extensions of ℚ."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: irrational_sqrt_natCast_iff and Nat.Prime.irrational_sqrt",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Irrationality of √n for non-square n, used for √30."
+    }
   ]
 }

--- a/src/data/proofs/subset-count-multiset/meta.json
+++ b/src/data/proofs/subset-count-multiset/meta.json
@@ -156,5 +156,28 @@
       "leanType": "(s : Multiset α) → (k : ℕ) → card (powersetCard k s) = (card s).choose k"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "R. P. Stanley",
+      "title": "Enumerative Combinatorics, Vol. 1",
+      "year": 2011,
+      "venue": "Cambridge Univ. Press, 2nd ed.",
+      "note": "Submultiset counting and binomial identities."
+    },
+    {
+      "authors": "J. H. van Lint and R. M. Wilson",
+      "title": "A Course in Combinatorics",
+      "year": 2001,
+      "venue": "Cambridge Univ. Press, 2nd ed.",
+      "note": "Counting subsets and multisets bijectively."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Multiset, Finset.powerset and Nat.choose API",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Multiset powerset cardinality (2^n) and k-element counts used here."
+    }
+  ]
 }


### PR DESCRIPTION
Adds curated bibliographic references to eight gallery entries whose top-level `references` field was empty.

Entries enriched:
- **Spherical Law of Sines** — Todhunter, do Carmo, VNR Encyclopedia
- **Irrationality of √2+√3+√5** — Niven, Hardy–Wright, Courant–Robbins
- **Factor Theorem → Nullstellensatz** — Hilbert 1893, Cox–Little–O'Shea, Atiyah–Macdonald
- **Non-Cyclic 2-Torsion (Gauss–Wilson)** — Gauss, Ireland–Rosen, Dummit–Foote
- **Ramsey R(4,k)** — Ramsey 1930, Erdős–Szekeres 1935, Erdős 1947, Spencer
- **Submultiset Counting** — Stanley, van Lint–Wilson
- **A₅ Inverse-Galois** — Dummit–Foote, Serre, Völklein
- **Chebyshev–PNT Bridge** — Chebyshev 1852, Apostol, Aigner–Ziegler, Hardy–Wright

Each reference set is matched to the entry's specific content and ends with a mathlib pointer where relevant. Data-only change; no Lean sources touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)