### PR TITLE
research(bezout-identity-oq-01-oq-02): Bézout as a unimodular SL₂(ℤ) reduction [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ02.lean
@@ -1,0 +1,145 @@
+/-
+  Bézout's identity as a unimodular reduction — the matrix view of the extended Euclidean algorithm
+  Open Question: bezout-identity-oq-01-oq-02
+
+  The parent entry (bezout-identity-oq-01) formalizes the extended Euclidean algorithm as a
+  computable function `extGcd : ℕ → ℕ → ℤ × ℤ × ℕ` and proves Bézout correctness
+  `a·x + b·y = gcd(a,b)` together with the GCD and divisibility corollaries.  Its open question
+  asks to *connect the algorithm to matrix arithmetic: the sequence of division steps corresponds
+  to a unimodular change of basis.*
+
+  This entry answers that question in closed form.  For integers `a, b` set `g = gcd(a, b)` and let
+  `A = gcdA a b`, `B = gcdB a b` be the Bézout coefficients delivered by Mathlib's
+  `Int.gcd_eq_gcd_ab` (`g = a·A + b·B`).  Define the 2×2 integer matrix
+
+        U(a,b) = ⎡  A      B  ⎤
+                 ⎣ -b/g   a/g ⎦.
+
+  We prove the two facts that make `U` the "matrix form" of the Euclidean algorithm:
+
+    * **Reduction.**  `U ·ᵥ (a, b) = (g, 0)` for *all* `a, b`.  The algorithm's net effect —
+      collapsing the input pair to `(gcd, 0)` — is realized by a single linear map, whose top row
+      is precisely the Bézout coefficient pair.
+
+    * **Unimodularity.**  When `g ≠ 0`, `det U = 1`, so `U ∈ SL₂(ℤ)`.  Thus the reduction is an
+      invertible change of basis over `ℤ`, and the transition from `(a, b)` to `(gcd, 0)` loses no
+      information — exactly the structural content behind "the extended Euclidean algorithm is a
+      product of elementary unimodular matrices."
+
+  Specializing to a coprime pair (`g = 1`) recovers the classical statement that any primitive
+  vector `(a, b)` is carried to the standard basis vector `(1, 0)` by an element of `SL₂(ℤ)` —
+  the `n = 2` case of `SL_n(ℤ)` acting transitively on primitive vectors.  As a capstone we package
+  `U` as a genuine element of `Matrix.SpecialLinearGroup (Fin 2) ℤ` in the coprime case.
+
+  Everything is derived from Mathlib's `Int.gcdA/gcdB` machinery; no new axioms are introduced.
+
+  References:
+  - Bézout, "Théorie générale des équations algébriques" (1779).
+  - Mathlib.Data.Int.GCD (`Int.gcd_eq_gcd_ab`, `Int.gcdA`, `Int.gcdB`).
+  - Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup (`SL₂(ℤ)`).
+  - Parent: BezoutIdentityOQ01.lean (computable `extGcd`).
+-/
+
+import Mathlib
+
+namespace BezoutIdentityOQ01OQ02
+
+open Matrix
+
+/-- A convenient entrywise formula for the action of a 2×2 matrix on a length-2 vector. -/
+theorem mulVec_two (M : Matrix (Fin 2) (Fin 2) ℤ) (v : Fin 2 → ℤ) :
+    M *ᵥ v = ![M 0 0 * v 0 + M 0 1 * v 1, M 1 0 * v 0 + M 1 1 * v 1] := by
+  funext i
+  fin_cases i <;>
+    simp [Matrix.mulVec, dotProduct, Fin.sum_univ_two]
+
+/-- The unimodular reduction matrix attached to the extended Euclidean algorithm on `(a, b)`.
+Its top row `(gcdA a b, gcdB a b)` is the Bézout coefficient pair; its bottom row `(-b/g, a/g)`
+encodes the primitive direction of `(a, b)`. -/
+def bezoutMatrix (a b : ℤ) : Matrix (Fin 2) (Fin 2) ℤ :=
+  !![Int.gcdA a b, Int.gcdB a b; -(b / Int.gcd a b), a / Int.gcd a b]
+
+@[simp] theorem bezoutMatrix_zero_zero (a b : ℤ) : bezoutMatrix a b 0 0 = Int.gcdA a b := rfl
+@[simp] theorem bezoutMatrix_zero_one (a b : ℤ) : bezoutMatrix a b 0 1 = Int.gcdB a b := rfl
+@[simp] theorem bezoutMatrix_one_zero (a b : ℤ) :
+    bezoutMatrix a b 1 0 = -(b / Int.gcd a b) := rfl
+@[simp] theorem bezoutMatrix_one_one (a b : ℤ) :
+    bezoutMatrix a b 1 1 = a / Int.gcd a b := rfl
+
+/-- **Bézout, matrix form.**  The top row of `bezoutMatrix` pairs with `(a, b)` to give `gcd a b`:
+this is `Int.gcd_eq_gcd_ab` read off the first coordinate of the reduction. -/
+theorem topRow_bezout (a b : ℤ) :
+    a * bezoutMatrix a b 0 0 + b * bezoutMatrix a b 0 1 = (Int.gcd a b : ℤ) := by
+  simpa using (Int.gcd_eq_gcd_ab a b).symm
+
+/-- **Reduction.**  `U ·ᵥ (a, b) = (gcd a b, 0)` for all integers `a, b`. The extended Euclidean
+algorithm's collapse of the pair to `(gcd, 0)` is a single linear map. -/
+theorem bezoutMatrix_mulVec (a b : ℤ) :
+    bezoutMatrix a b *ᵥ ![a, b] = ![(Int.gcd a b : ℤ), 0] := by
+  have hbez : (Int.gcd a b : ℤ) = a * Int.gcdA a b + b * Int.gcdB a b := Int.gcd_eq_gcd_ab a b
+  have hda : a / (Int.gcd a b : ℤ) * (Int.gcd a b : ℤ) = a :=
+    Int.ediv_mul_cancel (Int.gcd_dvd_left a b)
+  have hdb : b / (Int.gcd a b : ℤ) * (Int.gcd a b : ℤ) = b :=
+    Int.ediv_mul_cancel (Int.gcd_dvd_right a b)
+  rw [mulVec_two]
+  simp only [bezoutMatrix_zero_zero, bezoutMatrix_zero_one, bezoutMatrix_one_zero,
+    bezoutMatrix_one_one, Matrix.cons_val_zero, Matrix.cons_val_one]
+  refine Matrix.vecCons_inj.mpr ⟨?_, Matrix.vecCons_inj.mpr ⟨?_, rfl⟩⟩
+  · -- first coordinate: A·a + B·b = g
+    linear_combination -hbez
+  · -- second coordinate: (-(b/g))·a + (a/g)·b = 0
+    linear_combination (b / (Int.gcd a b : ℤ)) * hda - (a / (Int.gcd a b : ℤ)) * hdb
+
+/-- **Unimodularity.**  When `gcd a b ≠ 0` the reduction matrix has determinant `1`, so it lies in
+`SL₂(ℤ)`: the Euclidean reduction is an invertible integral change of basis. -/
+theorem bezoutMatrix_det (a b : ℤ) (h : Int.gcd a b ≠ 0) :
+    (bezoutMatrix a b).det = 1 := by
+  have hg : (Int.gcd a b : ℤ) ≠ 0 := Int.natCast_ne_zero.mpr h
+  have hbez : (Int.gcd a b : ℤ) = a * Int.gcdA a b + b * Int.gcdB a b := Int.gcd_eq_gcd_ab a b
+  have hda : a / (Int.gcd a b : ℤ) * (Int.gcd a b : ℤ) = a :=
+    Int.ediv_mul_cancel (Int.gcd_dvd_left a b)
+  have hdb : b / (Int.gcd a b : ℤ) * (Int.gcd a b : ℤ) = b :=
+    Int.ediv_mul_cancel (Int.gcd_dvd_right a b)
+  -- det U = A·(a/g) + B·(b/g); multiply by g and use Bézout to get det U · g = g.
+  rw [bezoutMatrix, Matrix.det_fin_two_of]
+  have key : ((Int.gcdA a b * (a / (Int.gcd a b : ℤ))
+      - Int.gcdB a b * -(b / (Int.gcd a b : ℤ)))) * (Int.gcd a b : ℤ) = (Int.gcd a b : ℤ) := by
+    linear_combination Int.gcdA a b * hda + Int.gcdB a b * hdb - hbez
+  exact mul_right_cancel₀ hg (by rw [one_mul]; exact key)
+
+/-- The determinant of `bezoutMatrix` is a unit whenever `gcd a b ≠ 0`; equivalently `U` is an
+invertible matrix over `ℤ` (an element of `GL₂(ℤ)`). -/
+theorem isUnit_bezoutMatrix_det (a b : ℤ) (h : Int.gcd a b ≠ 0) :
+    IsUnit (bezoutMatrix a b).det := by
+  rw [bezoutMatrix_det a b h]; exact isUnit_one
+
+/-- **Coprime specialization.**  A primitive pair `(a, b)` (i.e. `IsCoprime a b`) is carried to the
+standard basis vector `(1, 0)` by the unimodular matrix `U` — the `n = 2` case of `SLₙ(ℤ)` acting
+transitively on primitive vectors. -/
+theorem bezoutMatrix_mulVec_coprime (a b : ℤ) (h : IsCoprime a b) :
+    bezoutMatrix a b *ᵥ ![a, b] = ![1, 0] := by
+  have hg : Int.gcd a b = 1 := Int.isCoprime_iff_gcd_eq_one.mp h
+  rw [bezoutMatrix_mulVec, hg]; norm_num
+
+theorem bezoutMatrix_det_coprime (a b : ℤ) (h : IsCoprime a b) :
+    (bezoutMatrix a b).det = 1 :=
+  bezoutMatrix_det a b (by rw [Int.isCoprime_iff_gcd_eq_one.mp h]; exact one_ne_zero)
+
+/-- **Capstone.**  For a coprime pair, `bezoutMatrix` is a genuine element of the special linear
+group `SL₂(ℤ)`, carrying `(a, b)` to `(1, 0)`. -/
+def bezoutSL (a b : ℤ) (h : IsCoprime a b) : Matrix.SpecialLinearGroup (Fin 2) ℤ :=
+  ⟨bezoutMatrix a b, bezoutMatrix_det_coprime a b h⟩
+
+theorem bezoutSL_mulVec (a b : ℤ) (h : IsCoprime a b) :
+    (bezoutSL a b h : Matrix (Fin 2) (Fin 2) ℤ) *ᵥ ![a, b] = ![1, 0] :=
+  bezoutMatrix_mulVec_coprime a b h
+
+/-- Sanity check: the reduction of `(12, 8)` is `(gcd 12 8, 0) = (4, 0)`. -/
+example : bezoutMatrix 12 8 *ᵥ ![12, 8] = ![4, 0] := by
+  rw [bezoutMatrix_mulVec]; norm_num
+
+/-- Sanity check: `(7, 5)` is coprime, so `U` sends it to `(1, 0)`. -/
+example : bezoutMatrix 7 5 *ᵥ ![7, 5] = ![1, 0] := by
+  rw [bezoutMatrix_mulVec]; norm_num
+
+end BezoutIdentityOQ01OQ02

--- a/src/data/proofs/bezout-identity-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-mulvec-two",
+    "proofId": "bezout-identity-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 54 },
+    "type": "theorem",
+    "title": "mulVec_two: Entrywise Action of a 2×2 Matrix",
+    "content": "A reusable helper that unfolds the matrix–vector product M ·ᵥ v of a 2×2 integer matrix on a length-2 vector into its two explicit dot-product components: ![M00·v0 + M01·v1, M10·v0 + M11·v1]. Proved by funext over Fin 2 and fin_cases, unfolding Matrix.mulVec and dotProduct and summing with Fin.sum_univ_two. This packages the fiddly indexing once, so the main reduction theorem can reason about the two output coordinates as ordinary scalars.",
+    "mathContext": "$M \\cdot_{\\mathrm v} v = \\begin{pmatrix} M_{00} v_0 + M_{01} v_1 \\\\ M_{10} v_0 + M_{11} v_1 \\end{pmatrix}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "matrix-vector multiplication",
+      "dot product",
+      "Fin.sum_univ_two"
+    ],
+    "prerequisites": [
+      "Matrix.mulVec",
+      "dotProduct",
+      "Fin.sum_univ_two"
+    ]
+  },
+  {
+    "id": "ann-bezout-matrix-def",
+    "proofId": "bezout-identity-oq-01-oq-02",
+    "range": { "startLine": 56, "endLine": 67 },
+    "type": "definition",
+    "title": "bezoutMatrix: the Unimodular Reduction Matrix",
+    "content": "The 2×2 integer matrix U(a,b) = !![gcdA a b, gcdB a b; -(b/g), a/g] attached to a pair (a,b), where g = gcd(a,b) and gcdA/gcdB are Mathlib's Bézout coefficients. Its top row is the Bézout coefficient pair; its bottom row (-b/g, a/g) encodes the primitive direction of (a,b). Four @[simp] accessor lemmas expose the four entries so later proofs can rewrite them by definition. The sign convention — minus on b/g rather than a/g — is chosen precisely so that the determinant comes out +1 rather than −1.",
+    "mathContext": "$U(a,b) = \\begin{pmatrix} \\gcd_A(a,b) & \\gcd_B(a,b) \\\\ -b/g & a/g \\end{pmatrix}, \\qquad g = \\gcd(a,b)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bézout coefficients",
+      "unimodular matrix",
+      "primitive vector"
+    ],
+    "prerequisites": [
+      "Int.gcdA / Int.gcdB",
+      "Int.gcd",
+      "2×2 matrix notation !![…]"
+    ]
+  },
+  {
+    "id": "ann-toprow-bezout",
+    "proofId": "bezout-identity-oq-01-oq-02",
+    "range": { "startLine": 69, "endLine": 73 },
+    "type": "theorem",
+    "title": "Bézout in Matrix Form: the Top Row",
+    "content": "topRow_bezout states that pairing the top row (gcdA, gcdB) of U with the input (a,b) reproduces gcd(a,b): a·gcdA + b·gcdB = g. This is Mathlib's Int.gcd_eq_gcd_ab read off the first coordinate of the reduction, making explicit that the Bézout coefficients are literally the top row of the change-of-basis matrix.",
+    "mathContext": "$a \\cdot \\gcd_A(a,b) + b \\cdot \\gcd_B(a,b) = \\gcd(a,b)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bézout's identity",
+      "Int.gcd_eq_gcd_ab"
+    ],
+    "prerequisites": [
+      "Int.gcd_eq_gcd_ab"
+    ]
+  },
+  {
+    "id": "ann-reduction",
+    "proofId": "bezout-identity-oq-01-oq-02",
+    "range": { "startLine": 75, "endLine": 91 },
+    "type": "theorem",
+    "title": "Reduction: U ·ᵥ (a,b) = (gcd, 0)",
+    "content": "The central theorem: for all integers a, b the reduction matrix collapses the input pair to (gcd a b, 0) as a single linear map — the matrix incarnation of the entire extended Euclidean algorithm. The proof rewrites with mulVec_two, then Matrix.vecCons_inj splits the vector equality into two scalar goals. The top coordinate a·gcdA + b·gcdB = g is Bézout; the bottom coordinate (-(b/g))·a + (a/g)·b = 0 is closed by linear_combination using the exact divisions a = (a/g)·g and b = (b/g)·g (Int.ediv_mul_cancel with Int.gcd_dvd_left/right). The identity holds even in the degenerate a = b = 0 case.",
+    "mathContext": "$U(a,b) \\cdot_{\\mathrm v} \\begin{pmatrix} a \\\\ b \\end{pmatrix} = \\begin{pmatrix} \\gcd(a,b) \\\\ 0 \\end{pmatrix}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "extended Euclidean algorithm",
+      "change of basis",
+      "Matrix.vecCons_inj",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "Int.gcd_eq_gcd_ab",
+      "Int.ediv_mul_cancel",
+      "Int.gcd_dvd_left / Int.gcd_dvd_right"
+    ]
+  },
+  {
+    "id": "ann-unimodular",
+    "proofId": "bezout-identity-oq-01-oq-02",
+    "range": { "startLine": 93, "endLine": 114 },
+    "type": "theorem",
+    "title": "Unimodularity: det U = 1, hence U ∈ SL₂(ℤ)",
+    "content": "bezoutMatrix_det proves det U = 1 whenever gcd(a,b) ≠ 0. Via Matrix.det_fin_two_of the determinant is gcdA·(a/g) + gcdB·(b/g); multiplying by g and applying Bézout gives (det U)·g = g, and mul_right_cancel₀ (with g ≠ 0) yields det U = 1. Thus the Euclidean reduction is an invertible integral change of basis — an element of SL₂(ℤ). The companion isUnit_bezoutMatrix_det records that the determinant is a unit, i.e. U ∈ GL₂(ℤ).",
+    "mathContext": "$\\det U(a,b) = \\gcd_A \\cdot \\tfrac{a}{g} + \\gcd_B \\cdot \\tfrac{b}{g} = 1 \\quad (g \\neq 0)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "special linear group SL₂(ℤ)",
+      "unimodular matrix",
+      "determinant of a 2×2 matrix"
+    ],
+    "prerequisites": [
+      "Matrix.det_fin_two_of",
+      "mul_right_cancel₀",
+      "Int.gcd_eq_gcd_ab"
+    ]
+  },
+  {
+    "id": "ann-coprime-sl",
+    "proofId": "bezout-identity-oq-01-oq-02",
+    "range": { "startLine": 116, "endLine": 135 },
+    "type": "theorem",
+    "title": "Coprime Pairs and SL₂(ℤ) Membership",
+    "content": "For a coprime pair (IsCoprime a b, equivalently gcd = 1 via Int.isCoprime_iff_gcd_eq_one), bezoutMatrix_mulVec_coprime shows U carries (a,b) to the standard basis vector (1,0), and bezoutMatrix_det_coprime gives det U = 1. The capstone bezoutSL packages U as a genuine element of Matrix.SpecialLinearGroup (Fin 2) ℤ, with bezoutSL_mulVec recording its action. This is the n=2 case of SLₙ(ℤ) acting transitively on primitive integer vectors — the arithmetic seed of the modular group.",
+    "mathContext": "$\\gcd(a,b)=1 \\;\\Rightarrow\\; U(a,b) \\in \\mathrm{SL}_2(\\mathbb Z), \\quad U(a,b)\\cdot_{\\mathrm v}(a,b) = (1,0)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "coprimality",
+      "primitive vectors",
+      "modular group SL₂(ℤ)",
+      "Matrix.SpecialLinearGroup"
+    ],
+    "prerequisites": [
+      "Int.isCoprime_iff_gcd_eq_one",
+      "Matrix.SpecialLinearGroup"
+    ]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "bezout-identity-oq-01-oq-02",
+    "range": { "startLine": 137, "endLine": 145 },
+    "type": "insight",
+    "title": "Concrete Sanity Checks",
+    "content": "Two examples confirm the construction on concrete inputs: the reduction of (12,8) is (gcd 12 8, 0) = (4,0), and the coprime pair (7,5) is carried to (1,0). Both are discharged by norm_num using its kernel-level GCD certificate rather than native_decide, keeping the entry genuinely 0-axiom.",
+    "mathContext": "$U(12,8)\\cdot_{\\mathrm v}(12,8) = (4,0), \\qquad U(7,5)\\cdot_{\\mathrm v}(7,5) = (1,0)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked example",
+      "norm_num GCD certificate"
+    ],
+    "prerequisites": [
+      "norm_num"
+    ]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "bezout-identity-oq-01-oq-02",
+  "title": "Bézout's Identity as a Unimodular SL₂(ℤ) Reduction",
+  "slug": "bezout-identity-oq-01-oq-02",
+  "description": "Answers the parent entry's open question — connect the extended Euclidean algorithm to matrix arithmetic. For integers a, b with g = gcd(a,b), the 2×2 integer matrix U = !![gcdA a b, gcdB a b; -(b/g), a/g] realizes the algorithm's net effect as a single linear map: U ·ᵥ (a,b) = (g, 0) for all a, b, and det U = 1 whenever g ≠ 0, so U ∈ SL₂(ℤ). The top row of U is exactly the Bézout coefficient pair. Specializing to coprime pairs recovers the n=2 case of SLₙ(ℤ) acting transitively on primitive vectors, packaged as a genuine element of Matrix.SpecialLinearGroup (Fin 2) ℤ. 12 theorems, 2 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "bezout-identity",
+      "euclidean-algorithm",
+      "linear-algebra",
+      "special-linear-group",
+      "unimodular-matrix",
+      "gcd",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified over Mathlib's Int.gcdA/Int.gcdB machinery; no new axioms and no native_decide.",
+    "lineCount": 145,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "originalContributions": [
+      "bezoutMatrix: the closed-form 2×2 integer reduction matrix !![gcdA, gcdB; -b/g, a/g] attached to a pair (a,b)",
+      "bezoutMatrix_mulVec: U ·ᵥ (a,b) = (gcd a b, 0) for all a, b — the Euclidean collapse as one linear map",
+      "bezoutMatrix_det: det U = 1 whenever gcd(a,b) ≠ 0, exhibiting U as an element of SL₂(ℤ)",
+      "bezoutSL: packages U as a genuine Matrix.SpecialLinearGroup (Fin 2) ℤ element for coprime pairs, the n=2 transitivity of SLₙ(ℤ) on primitive vectors"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Bézout's identity — that gcd(a,b) is an integer linear combination ax + by — was proved in full generality by Étienne Bézout (1779). Its algorithmic companion, the extended Euclidean algorithm, computes the coefficients x, y explicitly. The matrix viewpoint is standard folklore in computational number theory and the theory of continued fractions: each division step of the Euclidean algorithm is left-multiplication by an elementary matrix [[0,1],[1,-q]] of determinant −1, so the accumulated transition matrix is unimodular (determinant ±1) and carries the input column (a,b) to (gcd, 0). This is the concrete n=2 face of a deep structural fact: the group SLₙ(ℤ) acts transitively on primitive (coprime-coordinate) integer vectors, the starting point for the theory of the modular group SL₂(ℤ), Stern–Brocot / Farey fractions, and the reduction theory of binary quadratic forms. The parent gallery entry (bezout-identity-oq-01) formalized the extended Euclidean algorithm as a computable function and asked precisely for this matrix reduction; this entry supplies it in closed form.",
+    "problemStatement": "Exhibit, for every pair of integers a, b, an explicit unimodular 2×2 integer matrix U(a,b) whose action carries (a,b) to (gcd(a,b), 0), and prove det U = 1 when gcd(a,b) ≠ 0, so that U ∈ SL₂(ℤ) and the Euclidean reduction is an invertible integral change of basis.",
+    "text": "Set g = gcd(a,b) and let A = gcdA a b, B = gcdB a b be Mathlib's Bézout coefficients, so g = aA + bB. Define U = !![A, B; -(b/g), a/g]. Two facts make U the matrix form of the Euclidean algorithm. (1) Reduction: U ·ᵥ (a,b) = (g, 0). The top coordinate is aA + bB = g (Bézout), and the bottom coordinate is (-(b/g))·a + (a/g)·b = 0 after clearing the exact divisions a = (a/g)·g, b = (b/g)·g. (2) Unimodularity: det U = A·(a/g) − B·(−(b/g)) = A·(a/g) + B·(b/g). Multiplying by g and using Bézout gives (det U)·g = g, so det U = 1 whenever g ≠ 0. Hence U ∈ SL₂(ℤ). For a coprime pair g = 1, so U carries (a,b) to (1,0) — the standard basis vector — and is packaged as an element of Matrix.SpecialLinearGroup (Fin 2) ℤ.",
+    "proofStrategy": "All content is derived from Mathlib's Int.gcd_eq_gcd_ab (Bézout) together with the exact-division facts Int.ediv_mul_cancel (Int.gcd_dvd_left/right). The vector identity is proved entrywise via a local mulVec_two helper (unfolding a 2×2 mulVec into its two dot products) and Matrix.vecCons_inj to split the vector equality into scalar goals closed by linear_combination. The determinant is computed with Matrix.det_fin_two_of; multiplying the determinant expression by g and cancelling with mul_right_cancel₀ reduces det U = 1 to the Bézout relation. IsCoprime is bridged to g = 1 via Int.isCoprime_iff_gcd_eq_one.",
+    "keyInsights": [
+      "The Bézout coefficients are not just a solution to aX + bY = g; they are the top row of a unimodular change of basis. This upgrades the identity from an existence statement to a structural one: (a,b) and (gcd,0) are the same lattice vector viewed in two ℤ-bases.",
+      "The determinant equals 1 (not merely ±1) with the sign convention U = !![gcdA, gcdB; -b/g, a/g]. Placing the minus sign on b/g rather than a/g is exactly what makes det U = A·(a/g) + B·(b/g), which Bézout forces to be 1 after cancelling g.",
+      "The reduction identity U ·ᵥ (a,b) = (gcd,0) holds for ALL a,b — including the degenerate a = b = 0 where g = 0 — but unimodularity requires g ≠ 0. Separating the two claims keeps the reduction maximally general while confining the SL₂(ℤ) statement to its natural domain.",
+      "The coprime case is the n=2 instance of SLₙ(ℤ) acting transitively on primitive vectors: any coprime (a,b) extends to a ℤ-basis of ℤ², witnessed concretely by the second row (-b, a) (up to the g=1 normalization). This is the arithmetic seed of the modular group.",
+      "Working over Mathlib's Int.gcdA/Int.gcdB keeps the proof free of native_decide: the two concrete sanity checks (12,8)↦(4,0) and (7,5)↦(1,0) are discharged by norm_num's kernel-level GCD certificate, so the entry is genuinely 0-axiom."
+    ],
+    "prerequisites": [
+      "Bézout coefficients in Mathlib: Int.gcdA, Int.gcdB, Int.gcd_eq_gcd_ab",
+      "Exact integer division: Int.ediv_mul_cancel with Int.gcd_dvd_left / Int.gcd_dvd_right",
+      "2×2 matrix arithmetic: Matrix.det_fin_two_of, mulVec, Matrix.vecCons_inj",
+      "The special linear group Matrix.SpecialLinearGroup (Fin 2) ℤ"
+    ]
+  },
+  "conclusion": {
+    "summary": "The extended Euclidean algorithm's reduction of (a,b) to (gcd,0) is realized by an explicit unimodular matrix U = !![gcdA, gcdB; -b/g, a/g] with det U = 1 (for gcd ≠ 0), hence an element of SL₂(ℤ). Coprime pairs map to (1,0). 12 theorems, 2 definitions, 0 sorries, 0 axioms, 145 lines.",
+    "implications": "This closes the parent entry's open question, recasting Bézout's identity as a statement about SL₂(ℤ): the Bézout coefficients are the top row of a unimodular change of basis, and coprime integer pairs are exactly the primitive vectors that SL₂(ℤ) carries to the standard basis vector. The construction is the concrete arithmetic entry point to the modular group, continued fractions, and the reduction theory of binary quadratic forms.",
+    "openQuestions": [
+      "Realize U as an explicit product of the elementary step matrices [[0,1],[1,-qᵢ]] indexed by the Euclidean quotients qᵢ, connecting the closed-form matrix to the algorithm's per-step recursion.",
+      "Generalize to SLₙ(ℤ): construct a unimodular n×n matrix carrying an arbitrary primitive integer vector to the first standard basis vector, formalizing transitivity of SLₙ(ℤ) on primitive vectors."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "bezoutMatrix_mulVec",
+      "type": "core",
+      "description": "For all integers a, b, the reduction matrix satisfies U ·ᵥ (a,b) = (gcd a b, 0): the Euclidean algorithm's collapse of the pair to (gcd, 0) as a single linear map. Proved entrywise via Matrix.vecCons_inj and linear_combination over the Bézout relation and the exact-division facts."
+    },
+    {
+      "name": "bezoutMatrix_det",
+      "type": "core",
+      "description": "When gcd(a,b) ≠ 0, det U = 1, so U lies in SL₂(ℤ). The determinant expression A·(a/g) + B·(b/g), multiplied by g, equals g by Bézout; mul_right_cancel₀ then yields det U = 1."
+    },
+    {
+      "name": "bezoutSL",
+      "type": "core",
+      "description": "For a coprime pair, U is packaged as a genuine element of Matrix.SpecialLinearGroup (Fin 2) ℤ carrying (a,b) to (1,0) — the n=2 case of SLₙ(ℤ) acting transitively on primitive vectors."
+    },
+    {
+      "name": "topRow_bezout",
+      "type": "supporting",
+      "description": "The top row (gcdA a b, gcdB a b) of U pairs with (a,b) to give gcd a b — Int.gcd_eq_gcd_ab read off the first coordinate of the reduction."
+    },
+    {
+      "name": "bezoutMatrix_mulVec_coprime",
+      "type": "supporting",
+      "description": "A primitive pair (IsCoprime a b) is carried to the standard basis vector (1,0), obtained by specializing the reduction with Int.isCoprime_iff_gcd_eq_one."
+    }
+  ],
+  "leanFile": {
+    "namespace": "BezoutIdentityOQ01OQ02",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/BezoutIdentityOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-01",
+      "relationship": "parent",
+      "description": "Formalizes the extended Euclidean algorithm as a computable function and poses the open question — connect it to unimodular 2×2 integer matrices — answered here."
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "related",
+      "description": "The classical Bézout identity, here upgraded from an existence statement to a unimodular change-of-basis in SL₂(ℤ)."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Problem Statement",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module documentation states the parent's open question, defines the reduction matrix U = !![gcdA, gcdB; -b/g, a/g], and describes the two results (reduction U ·ᵥ (a,b) = (g,0) and unimodularity det U = 1) with references to Bézout and SL₂(ℤ)."
+    },
+    {
+      "id": "sec-mulvec-two",
+      "title": "Helper: Action of a 2×2 Matrix on a Length-2 Vector",
+      "startLine": 49,
+      "endLine": 54,
+      "summary": "mulVec_two unfolds M ·ᵥ v into its two explicit dot-product components ![M00·v0 + M01·v1, M10·v0 + M11·v1], the entrywise form used to prove the reduction identity."
+    },
+    {
+      "id": "sec-matrix-def",
+      "title": "Definition: The Bézout Reduction Matrix and Its Entries",
+      "startLine": 56,
+      "endLine": 67,
+      "summary": "Defines bezoutMatrix a b = !![gcdA a b, gcdB a b; -(b/gcd), a/gcd] and four @[simp] accessor lemmas exposing its entries."
+    },
+    {
+      "id": "sec-toprow",
+      "title": "Bézout in Matrix Form: the Top Row",
+      "startLine": 69,
+      "endLine": 73,
+      "summary": "topRow_bezout: pairing the top row of U with (a,b) yields gcd a b — Int.gcd_eq_gcd_ab read off the first coordinate."
+    },
+    {
+      "id": "sec-reduction",
+      "title": "Reduction: U ·ᵥ (a,b) = (gcd, 0)",
+      "startLine": 75,
+      "endLine": 91,
+      "summary": "bezoutMatrix_mulVec proves the reduction for all a,b. mulVec_two plus Matrix.vecCons_inj split the vector equality into two scalar goals: the top from Bézout, the bottom from the exact divisions a = (a/g)g, b = (b/g)g via linear_combination."
+    },
+    {
+      "id": "sec-unimodular",
+      "title": "Unimodularity: det U = 1 and Invertibility",
+      "startLine": 93,
+      "endLine": 114,
+      "summary": "bezoutMatrix_det computes det U via Matrix.det_fin_two_of; multiplying by g and using Bézout gives (det U)·g = g, so mul_right_cancel₀ yields det U = 1 when gcd ≠ 0. isUnit_bezoutMatrix_det records that the determinant is a unit (U ∈ GL₂(ℤ))."
+    },
+    {
+      "id": "sec-coprime",
+      "title": "Coprime Specialization and SL₂(ℤ) Membership",
+      "startLine": 116,
+      "endLine": 135,
+      "summary": "For coprime pairs, bezoutMatrix_mulVec_coprime sends (a,b) to (1,0) and bezoutMatrix_det_coprime gives det U = 1; bezoutSL packages U as an element of Matrix.SpecialLinearGroup (Fin 2) ℤ, with bezoutSL_mulVec recording its action."
+    },
+    {
+      "id": "sec-examples",
+      "title": "Concrete Sanity Checks",
+      "startLine": 137,
+      "endLine": 145,
+      "summary": "Two examples verify the reduction on (12,8) ↦ (gcd 12 8, 0) = (4,0) and on the coprime pair (7,5) ↦ (1,0), discharged by norm_num's kernel-level GCD certificate (no native_decide)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's (**bezout-identity-oq-01**) open question — *"Connect extGcd to matrix arithmetic: the algorithm corresponds to unimodular 2×2 integer matrices."*

For integers `a, b` with `g = gcd(a,b)` and Mathlib's Bézout coefficients `A = gcdA a b`, `B = gcdB a b`, define the reduction matrix

```
U(a,b) = !![ A,      B ;
             -(b/g), a/g ]
```

and prove the two facts that make `U` the matrix form of the extended Euclidean algorithm:

- **Reduction** (`bezoutMatrix_mulVec`): `U ·ᵥ (a,b) = (gcd a b, 0)` for **all** `a, b`. The algorithm's collapse of the pair to `(gcd, 0)` is realized by a single linear map whose top row is exactly the Bézout coefficient pair.
- **Unimodularity** (`bezoutMatrix_det`): `det U = 1` whenever `gcd(a,b) ≠ 0`, so `U ∈ SL₂(ℤ)` — the Euclidean reduction is an invertible integral change of basis.

Specializing to a coprime pair (`bezoutMatrix_mulVec_coprime`, `bezoutSL`) carries `(a,b)` to the standard basis vector `(1,0)`, packaged as a genuine element of `Matrix.SpecialLinearGroup (Fin 2) ℤ` — the `n = 2` case of `SLₙ(ℤ)` acting transitively on primitive vectors.

## Why this is genuine content

Mathlib has `Int.gcdA/gcdB` and `Int.gcd_eq_gcd_ab`, but **not** the unimodular 2×2 reduction of gcd (`TotallyUnimodular` is an unrelated concept). This entry upgrades Bézout's identity from an *existence* statement to a *structural* one: the Bézout coefficients are the top row of a unimodular change of basis, and coprime pairs are precisely the primitive vectors `SL₂(ℤ)` sends to `e₁`.

## Verification

- **Builds clean**: `./proofs/scripts/docker-build.sh Proofs.BezoutIdentityOQ01OQ02` → 7743 jobs, 0 errors.
- **0 sorries, 0 axioms**: all tactics are `simp`/`rw`/`refine`/`linear_combination`/`norm_num` — no `native_decide`, so no `Lean.ofReduceBool`. The two concrete sanity checks use `norm_num`'s kernel-level GCD certificate.
- 12 theorems, 2 definitions, 145 lines.

## Files

- `proofs/Proofs/BezoutIdentityOQ01OQ02.lean`
- `src/data/proofs/bezout-identity-oq-01-oq-02/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)