### PR TITLE
research(cayley-hamilton-minpoly-oq-03-oq-03): Krylov→companion RCF similarity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ03.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ03.lean
@@ -1,0 +1,208 @@
+/-
+# Krylov Sequences and the Rational Canonical Form
+
+This file is the structural follow-up to `CayleyHamiltonMinpolyOQ03.lean`
+(problem `cayley-hamilton-minpoly-oq-03`), which showed that the Krylov
+sequence `v, Mv, M²v, …` of a matrix `M` goes linearly dependent exactly at
+step `d = deg μ_M`.  Here we answer: *what does the Krylov basis reveal about
+`M` itself?*
+
+The answer is the **companion / rational-canonical-form** statement.  Assemble
+the first `n` Krylov vectors as the columns of a change-of-basis matrix
+
+    P = ( v ∣ Mv ∣ ⋯ ∣ M^{n-1}v ),   `krylovMatrix M v`,
+
+and let `C(μ_M)` be the companion matrix of the (monic, degree-`n`) minimal
+polynomial.  Then the Krylov iteration **intertwines** `M` with the companion
+matrix:
+
+    M · P  =  P · C(μ_M).                     (`krylov_companion_conjugation`)
+
+This holds for *every* starting vector `v` once `M` is nonderogatory
+(`deg μ_M = n`): the identity is a coordinate-free consequence of the two facts
+`M·(M^k v) = M^{k+1} v` and `μ_M(M)·v = 0`.  When in addition `v` is cyclic the
+Krylov vectors form a basis, `P` is invertible, and conjugation upgrades to a
+genuine **similarity**
+
+    P⁻¹ · M · P  =  C(μ_M),                    (`krylov_rcf_similarity`)
+
+exhibiting the rational canonical form of a nonderogatory matrix as a single
+companion block.  This is the constructive bridge — via the same `O(n³)` Krylov
+iteration already formalized — from numerical linear algebra to the
+module-theoretic normal form that classifies matrices up to similarity over an
+arbitrary field.
+
+## Main results
+
+* `krylovMatrix`, `companion` — the change-of-basis and companion matrices.
+* `krylov_companion_conjugation` — `M * P = P * C(μ_M)` (nonderogatory).
+* `krylov_rcf_similarity` — `P⁻¹ * M * P = C(μ_M)` when `P` is invertible.
+* `krylovMatrix_isUnit_of_cyclic` — a cyclic vector makes `P` invertible.
+* `krylov_rcf_similarity_of_cyclic` — the RCF similarity from a cyclic vector.
+
+All results are proved with `0` sorries and no additional axioms.
+-/
+import Proofs.CayleyHamiltonMinpolyOQ03
+
+namespace MinpolyComplexity
+
+open Matrix Polynomial Finset
+
+variable {K : Type*} [Field K] {n : ℕ}
+
+-- ============================================================
+-- PART I: The companion matrix and the Krylov change-of-basis
+-- ============================================================
+
+/-- The **companion matrix** of a polynomial `μ`, in the convention where the
+    coefficients occupy the last column and the subdiagonal carries `1`s:
+
+    ```
+    0 0 … 0 -a₀
+    1 0 … 0 -a₁
+    0 1 … 0 -a₂
+    ⋮       ⋮
+    0 0 … 1 -a_{n-1}
+    ```
+
+    For a monic `μ = Xⁿ + a_{n-1}Xⁿ⁻¹ + ⋯ + a₀` of degree `n`, this is exactly
+    the matrix of multiplication-by-`X` on `K[X]/(μ)` in the basis
+    `1, X, …, Xⁿ⁻¹`. -/
+def companion (μ : K[X]) : Matrix (Fin n) (Fin n) K :=
+  Matrix.of fun i j =>
+    if (j : ℕ) + 1 = n then -μ.coeff (i : ℕ)
+    else if (i : ℕ) = (j : ℕ) + 1 then 1 else 0
+
+/-- The **Krylov change-of-basis matrix**: column `j` is the `j`-th Krylov
+    vector `Mʲ v`.  When `v` is cyclic and `M` nonderogatory this is the
+    matrix `P = (v ∣ Mv ∣ ⋯ ∣ M^{n-1}v)` that conjugates `M` into rational
+    canonical form. -/
+def krylovMatrix (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K) :
+    Matrix (Fin n) (Fin n) K :=
+  Matrix.of fun i j => krylovVec M v (j : ℕ) i
+
+@[simp]
+theorem krylovMatrix_apply (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K)
+    (i j : Fin n) : krylovMatrix M v i j = krylovVec M v (j : ℕ) i := rfl
+
+-- ============================================================
+-- PART II: The conjugation identity  M · P = P · C(μ_M)
+-- ============================================================
+
+/-- **Krylov–companion conjugation.**  For a nonderogatory matrix `M`
+    (`deg μ_M = n`) and *any* starting vector `v`, the Krylov change-of-basis
+    matrix `P` intertwines `M` with the companion matrix of the minimal
+    polynomial:
+
+        `M * P = P * C(μ_M)`.
+
+    Columnwise this says `M·(Mʲv) = M^{j+1}v`, which for `j < n-1` is the
+    subdiagonal shift of `C`, and for `j = n-1` is `M^n v = -∑_{k<n} a_k M^k v`
+    (Cayley–Hamilton applied to `v`), the last column of `C`. -/
+theorem krylov_companion_conjugation [NeZero n]
+    (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K)
+    (hdeg : (minpoly K M).natDegree = n) :
+    M * krylovMatrix M v = krylovMatrix M v * companion (minpoly K M) := by
+  -- Cayley–Hamilton for `v`: `∑_{i≤n} aᵢ (Mⁱv) = 0`.
+  have hann : (∑ i ∈ range (n + 1), (minpoly K M).coeff i • krylovVec M v i) = 0 := by
+    have h1 := minpoly_annihilates_vec M v
+    rw [aeval_mulVec_eq_krylov_sum, hdeg] at h1
+    exact h1
+  -- Leading coefficient is `1`.
+  have hmonic : (minpoly K M).coeff n = 1 := by
+    have h := (minpoly.monic (isIntegral M)).coeff_natDegree
+    rwa [hdeg] at h
+  -- Peel the top term: `∑_{k<n} a_k (Mᵏv) = -(Mⁿv)`.
+  have hsplit : (∑ k ∈ range n, (minpoly K M).coeff k • krylovVec M v k)
+      = - krylovVec M v n := by
+    rw [Finset.sum_range_succ, hmonic, one_smul] at hann
+    exact eq_neg_of_add_eq_zero_left hann
+  ext i j
+  -- Left-hand column `j`:  `M·(Mʲv) = M^{j+1}v`.
+  have hL : (M * krylovMatrix M v) i j = krylovVec M v ((j : ℕ) + 1) i := by
+    rw [Matrix.mul_apply, krylovVec_succ]
+    simp only [krylovMatrix, Matrix.of_apply, Matrix.mulVec, dotProduct]
+  rw [hL, Matrix.mul_apply]
+  simp only [krylovMatrix, companion, Matrix.of_apply]
+  by_cases hjn : (j : ℕ) + 1 = n
+  · -- Last column: use Cayley–Hamilton to identify `M^{j+1}v = Mⁿv`.
+    simp only [if_pos hjn]
+    rw [hjn]
+    have key : (∑ k ∈ range n, krylovVec M v k i * (minpoly K M).coeff k)
+        = - krylovVec M v n i := by
+      have h := congrFun hsplit i
+      simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul, Pi.neg_apply] at h
+      rw [← h]
+      exact Finset.sum_congr rfl fun k _ => mul_comm _ _
+    rw [Fin.sum_univ_eq_sum_range
+      (fun k => krylovVec M v k i * -(minpoly K M).coeff k) n]
+    simp only [mul_neg, Finset.sum_neg_distrib]
+    rw [key]; ring
+  · -- Interior column `j`: only the `k = j+1` term survives (the subdiagonal `1`).
+    have hlt : (j : ℕ) + 1 < n :=
+      lt_of_le_of_ne (Nat.succ_le_of_lt j.isLt) hjn
+    have hj'val : ((⟨(j : ℕ) + 1, hlt⟩ : Fin n) : ℕ) = (j : ℕ) + 1 := rfl
+    simp only [if_neg hjn]
+    rw [Finset.sum_eq_single_of_mem (⟨(j : ℕ) + 1, hlt⟩ : Fin n)
+        (Finset.mem_univ _) (by
+          intro k _ hk
+          have hne : (k : ℕ) ≠ (j : ℕ) + 1 := fun hc =>
+            hk (Fin.ext (hc.trans hj'val.symm))
+          rw [if_neg hne, mul_zero])]
+    rw [hj'val, if_pos rfl, mul_one]
+
+-- ============================================================
+-- PART III: The similarity  P⁻¹ · M · P = C(μ_M)
+-- ============================================================
+
+/-- **Rational canonical form via Krylov.**  When the Krylov change-of-basis
+    matrix `P` is invertible, conjugation `M·P = P·C(μ_M)` upgrades to a
+    similarity `P⁻¹·M·P = C(μ_M)`: the matrix `M` is similar to the companion
+    matrix of its minimal polynomial, i.e. it is in rational canonical form
+    (a single companion block). -/
+theorem krylov_rcf_similarity [NeZero n]
+    (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K)
+    (hdeg : (minpoly K M).natDegree = n)
+    (hunit : IsUnit (krylovMatrix M v).det) :
+    (krylovMatrix M v)⁻¹ * M * krylovMatrix M v = companion (minpoly K M) := by
+  have hconj := krylov_companion_conjugation M v hdeg
+  rw [Matrix.mul_assoc, hconj, ← Matrix.mul_assoc, Matrix.nonsing_inv_mul _ hunit,
+    Matrix.one_mul]
+
+-- ============================================================
+-- PART IV: A cyclic vector makes the Krylov matrix invertible
+-- ============================================================
+
+/-- The columns of the Krylov matrix are precisely the Krylov vectors. -/
+theorem krylovMatrix_col (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K) :
+    (krylovMatrix M v).col = fun i : Fin n => krylovVec M v i := by
+  funext j i; rfl
+
+/-- **Invertibility from a cyclic vector.**  For a nonderogatory matrix
+    (`μ_M = χ_M`) with a cyclic vector `v`, the `n` Krylov vectors are linearly
+    independent (parent theorem `nonderogatory_krylov_optimal`), so the Krylov
+    change-of-basis matrix is invertible. -/
+theorem krylovMatrix_isUnit_of_cyclic [NeZero n]
+    (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K)
+    (hcyclic : ∀ p : K[X], p.natDegree < n → (aeval M p).mulVec v = 0 → p = 0)
+    (hnond : minpoly K M = M.charpoly) :
+    IsUnit (krylovMatrix M v).det := by
+  have hli := nonderogatory_krylov_optimal M v hcyclic hnond
+  rw [← Matrix.isUnit_iff_isUnit_det, ← Matrix.linearIndependent_cols_iff_isUnit,
+    krylovMatrix_col]
+  exact hli
+
+/-- **Rational canonical form of a nonderogatory matrix.**  Combining the
+    conjugation identity with invertibility of the Krylov matrix: a
+    nonderogatory matrix with a cyclic vector is conjugate to the companion
+    matrix of its minimal (= characteristic) polynomial via the explicit Krylov
+    change of basis `P = (v ∣ Mv ∣ ⋯ ∣ M^{n-1}v)`. -/
+theorem krylov_rcf_similarity_of_cyclic [NeZero n]
+    (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K)
+    (hcyclic : ∀ p : K[X], p.natDegree < n → (aeval M p).mulVec v = 0 → p = 0)
+    (hnond : minpoly K M = M.charpoly)
+    (hdeg : (minpoly K M).natDegree = n) :
+    (krylovMatrix M v)⁻¹ * M * krylovMatrix M v = companion (minpoly K M) :=
+  krylov_rcf_similarity M v hdeg (krylovMatrix_isUnit_of_cyclic M v hcyclic hnond)
+
+end MinpolyComplexity

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03/annotations.json
@@ -1,0 +1,124 @@
+[
+  {
+    "id": "ann-krylov-rcf-preamble",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "Krylov Sequences and the Rational Canonical Form: Problem Statement",
+    "content": "The module docstring frames the structural follow-up to the parent OQ-03 (Krylov termination and minimal-polynomial computation): what does the Krylov basis reveal about M itself? The answer is the rational canonical form. Collect the first n Krylov vectors v, Mv, ..., M^{n-1}v as the columns of a change-of-basis matrix P; then a nonderogatory matrix M intertwines with the companion matrix of its minimal polynomial, M·P = P·C(μ_M). When v is cyclic, P is invertible and this becomes a similarity P⁻¹·M·P = C(μ_M) — the field-independent normal form that classifies matrices up to similarity. This is the constructive bridge (via the same O(n³) Krylov iteration) from numerical to module-theoretic linear algebra.",
+    "mathContext": "$P = (v\\mid Mv\\mid\\cdots\\mid M^{n-1}v)$, $C(\\mu_M)$ the companion matrix. Nonderogatory ($\\deg\\mu_M = n$): $MP = PC(\\mu_M)$. Cyclic $v$: $P^{-1}MP = C(\\mu_M)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "rational canonical form",
+      "companion matrix",
+      "cyclic vector",
+      "Krylov subspace methods",
+      "invariant factors"
+    ],
+    "prerequisites": [
+      "Krylov sequences (parent OQ-03)",
+      "Companion matrix",
+      "Matrix.mulVec",
+      "Field typeclass"
+    ]
+  },
+  {
+    "id": "ann-companion-krylov-matrix",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-03",
+    "range": {
+      "startLine": 53,
+      "endLine": 86
+    },
+    "type": "definition",
+    "title": "The Companion Matrix and the Krylov Change-of-Basis Matrix",
+    "content": "companion μ is the companion matrix in the convention where the coefficients occupy the last column (entry -μ.coeff i in row i when j = n-1) and the subdiagonal carries 1s (entry 1 when i = j+1). For a monic μ = Xⁿ + a_{n-1}Xⁿ⁻¹ + ... + a₀ of degree n this is the matrix of multiplication-by-X on K[X]/(μ) in the basis 1, X, ..., Xⁿ⁻¹. krylovMatrix M v is the change-of-basis matrix whose column j is the j-th Krylov vector Mʲv, i.e. entry (i,j) = krylovVec M v j i. The condition for the last column is written (j:ℕ)+1 = n to avoid natural-number subtraction.",
+    "mathContext": "$C(\\mu)_{ij} = -\\mu_i$ if $j+1=n$, else $1$ if $i=j+1$, else $0$; $P_{ij} = (M^j v)_i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "companion matrix",
+      "multiplication by X on K[X]/(μ)",
+      "change of basis"
+    ],
+    "prerequisites": [
+      "Polynomial.coeff",
+      "krylovVec (parent OQ-03)",
+      "Matrix.of"
+    ]
+  },
+  {
+    "id": "ann-conjugation",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-03",
+    "range": {
+      "startLine": 88,
+      "endLine": 152
+    },
+    "type": "insight",
+    "title": "The Conjugation Identity M·P = P·C(μ_M)",
+    "content": "krylov_companion_conjugation is the structural heart. Entrywise, column j of M·P is M·(Mʲv) = M^{j+1}v (the Krylov recurrence krylovVec_succ, applied after unfolding the matrix product into a mulVec/dotProduct sum). Column j of P·C(μ_M) is ∑_k C(μ_M)_{kj}·(Mᵏv). For an interior column j < n-1 the companion's subdiagonal 1 (Finset.sum_eq_single_of_mem at k = j+1) selects the single term M^{j+1}v. For the last column j = n-1 the companion column is (-a₀,...,-a_{n-1}); Cayley–Hamilton for v (minpoly_annihilates_vec, expanded by the parent lemma aeval_mulVec_eq_krylov_sum, then Finset.sum_range_succ peels the monic top term with coeff n = 1 from Monic.coeff_natDegree) gives -∑_{k<n} a_k Mᵏv = Mⁿv. Both columns match, so M·P = P·C(μ_M). No invertibility of P is required — only deg μ_M = n.",
+    "mathContext": "Interior: $\\sum_k C_{kj}(M^k v) = M^{j+1}v$. Last: $-\\sum_{k<n} a_k M^k v = M^n v$ from $\\mu_M(M)v = 0$, $a_n = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cayley–Hamilton for a vector",
+      "Krylov recurrence",
+      "companion matrix",
+      "Finset.sum_neg_distrib",
+      "Fin.sum_univ_eq_sum_range"
+    ],
+    "prerequisites": [
+      "aeval_mulVec_eq_krylov_sum (parent)",
+      "minpoly_annihilates_vec (parent)",
+      "Monic.coeff_natDegree",
+      "Matrix.mul_apply"
+    ]
+  },
+  {
+    "id": "ann-similarity",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-03",
+    "range": {
+      "startLine": 154,
+      "endLine": 170
+    },
+    "type": "insight",
+    "title": "The Similarity P⁻¹·M·P = C(μ_M)",
+    "content": "krylov_rcf_similarity promotes conjugation to similarity: when the Krylov matrix P is invertible (IsUnit P.det), left-multiplying M·P = P·C(μ_M) by P⁻¹ yields P⁻¹·M·P = C(μ_M) via Matrix.mul_assoc and Matrix.nonsing_inv_mul. This exhibits the nonderogatory matrix M in rational canonical form — a single companion block, the coordinate-free normal form classifying M up to similarity over K.",
+    "mathContext": "$P^{-1}MP = P^{-1}(PC(\\mu_M)) = (P^{-1}P)C(\\mu_M) = C(\\mu_M)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "similarity of matrices",
+      "rational canonical form",
+      "matrix inverse over a field"
+    ],
+    "prerequisites": [
+      "Matrix.nonsing_inv_mul",
+      "Matrix.mul_assoc",
+      "IsUnit of determinant"
+    ]
+  },
+  {
+    "id": "ann-cyclic-invertibility",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-03",
+    "range": {
+      "startLine": 172,
+      "endLine": 208
+    },
+    "type": "insight",
+    "title": "A Cyclic Vector Makes the Krylov Matrix Invertible",
+    "content": "krylovMatrix_col identifies the columns of P (the transpose, Matrix.col = ᵀ) with the Krylov vectors fun i => krylovVec M v i. krylovMatrix_isUnit_of_cyclic then derives IsUnit P.det: the parent's nonderogatory_krylov_optimal gives linear independence of the n Krylov columns, which Matrix.linearIndependent_cols_iff_isUnit and Matrix.isUnit_iff_isUnit_det convert into invertibility of P. Finally krylov_rcf_similarity_of_cyclic assembles the full rational canonical form similarity for a nonderogatory matrix with a cyclic vector: P⁻¹·M·P = C(μ_M) with P the explicit Krylov change of basis.",
+    "mathContext": "$v$ cyclic $\\Rightarrow$ Krylov columns independent $\\Rightarrow \\mathrm{IsUnit}(P.\\det) \\Rightarrow P^{-1}MP = C(\\mu_M)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cyclic vector",
+      "linear independence of columns",
+      "nonderogatory matrix",
+      "invertibility"
+    ],
+    "prerequisites": [
+      "nonderogatory_krylov_optimal (parent)",
+      "Matrix.linearIndependent_cols_iff_isUnit",
+      "Matrix.isUnit_iff_isUnit_det"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-03-oq-03",
+  "title": "Krylov Sequences and the Rational Canonical Form",
+  "slug": "cayley-hamilton-minpoly-oq-03-oq-03",
+  "description": "Establishes the companion / rational-canonical-form content of the Krylov basis. Assembling the first n Krylov vectors as the columns of a change-of-basis matrix P = (v | Mv | ... | M^{n-1}v), a nonderogatory matrix M intertwines with the companion matrix of its minimal polynomial: M·P = P·C(μ_M). When v is cyclic, P is invertible and this upgrades to a similarity P⁻¹·M·P = C(μ_M), the rational canonical form as a single companion block. Verified, 0 axioms.",
+  "meta": {
+    "author": "researcher-10",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Rational_canonical_form",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ03OQ03.lean",
+    "tags": [
+      "linear-algebra",
+      "matrices",
+      "minimal-polynomial",
+      "krylov-method",
+      "companion-matrix",
+      "rational-canonical-form",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 208,
+    "assumptions": "No axioms, no sorries. All 6 theorems fully proved. Imports the parent Proofs.CayleyHamiltonMinpolyOQ03 (itself 0-axiom for the Krylov core) and uses only Mathlib lemmas (Matrix.mul_apply, Matrix.mulVec/dotProduct unfolding, Fin.sum_univ_eq_sum_range, Finset.sum_neg_distrib, Monic.coeff_natDegree, Matrix.linearIndependent_cols_iff_isUnit, Matrix.isUnit_iff_isUnit_det, Matrix.nonsing_inv_mul). No native_decide.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The rational canonical form (Frobenius normal form) is the field-independent analogue of Jordan form: two matrices over a field K are similar iff they share the same invariant factors, iff they have the same rational canonical form — no eigenvalues, no splitting field required. Classically it is obtained abstractly, from the structure theorem for finitely generated modules over the PID K[X], viewing K^n as a K[X]-module via X·w := Mw. The constructive route runs through Krylov sequences: for a cyclic vector v the powers v, Mv, ..., M^{n-1}v form a basis in which M becomes the companion matrix of its minimal polynomial, whose last column stores exactly the polynomial's coefficients. This is the same object A. N. Krylov introduced in 1931 for iterative eigenvalue computation, here read structurally rather than numerically. The companion matrix itself is the matrix of multiplication-by-X on K[X]/(μ) in the monomial basis 1, X, ..., X^{n-1}.",
+    "problemStatement": "Let K be a field and M an n×n matrix over K with minimal polynomial μ_M of degree d. For a starting vector v, assemble the Krylov vectors v, Mv, ..., M^{n-1}v as the columns of P. When M is nonderogatory (d = n), show that P intertwines M with the companion matrix C(μ_M): M·P = P·C(μ_M). When in addition v is cyclic (so P is invertible), conclude the similarity P⁻¹·M·P = C(μ_M) — the rational canonical form of M as a single companion block.",
+    "proofStrategy": "The conjugation identity M·P = P·C(μ_M) is proved entrywise. Column j of M·P is M·(M^j v) = M^{j+1}v (the Krylov recurrence krylovVec_succ). Column j of P·C(μ_M) is ∑_k C(μ_M)_{kj}·(M^k v). For an interior column j < n-1, the companion's subdiagonal 1 in row j+1 selects exactly the k = j+1 term, giving M^{j+1}v — matching. For the last column j = n-1, the companion column is (-a_0, ..., -a_{n-1}), so P·C's last column is -∑_{k<n} a_k M^k v; Cayley–Hamilton applied to v (μ_M(M)·v = 0, expanded via the parent lemma aeval_mulVec_eq_krylov_sum, peeling the monic top term with coeff n = 1) gives exactly -∑_{k<n} a_k M^k v = M^n v = M^{j+1}v — matching. The similarity then follows by left-multiplying by P⁻¹ (Matrix.nonsing_inv_mul), and invertibility of P for a cyclic v is obtained from the parent's nonderogatory_krylov_optimal (linear independence of the n Krylov columns) via Matrix.linearIndependent_cols_iff_isUnit.",
+    "keyInsights": [
+      "The Krylov iteration is not just a way to *find* the minimal polynomial (parent OQ-03); it is the constructive bridge to the *rational canonical form*. The single identity M·P = P·C(μ_M) packages both facts M·(M^j v) = M^{j+1}v and Cayley–Hamilton μ_M(M)·v = 0 into a change-of-basis statement.",
+      "The conjugation identity M·P = P·C(μ_M) needs *no* invertibility of P: it holds for every starting vector v once M is nonderogatory (deg μ_M = n). Cyclicity of v is used only to promote conjugation to a genuine similarity P⁻¹·M·P = C(μ_M).",
+      "Working with concrete column vectors (Fin n → K) and the raw matrix product, rather than the abstract Basis / LinearMap.toMatrix machinery, keeps the whole proof at the level of Finset.sum manipulation — the last column reduces to Cayley–Hamilton for v and the interior columns to a single-term subdiagonal sum.",
+      "The last column of the companion matrix literally *is* the coefficient vector of the minimal polynomial (negated). Reading M·P = P·C off the last column is precisely the statement M^n v = -∑_{k<n} a_k M^k v — Cayley–Hamilton, applied to a vector.",
+      "Invertibility of the Krylov change-of-basis matrix is exactly linear independence of its columns, which is the parent's nonderogatory optimality theorem. Matrix.linearIndependent_cols_iff_isUnit turns that linear-algebra fact into the units statement needed for the similarity."
+    ],
+    "prerequisites": [
+      "Cayley-Hamilton theorem and minimal polynomial theory",
+      "Companion matrix of a monic polynomial",
+      "Krylov sequence and the expansion aeval_mulVec_eq_krylov_sum (parent OQ-03)",
+      "Nonderogatory matrices and cyclic vectors (parent OQ-03 Part VII)",
+      "Matrix inverse over a field: linearIndependent_cols_iff_isUnit, nonsing_inv_mul"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.CayleyHamiltonMinpolyOQ03"
+    ],
+    "namespace": "MinpolyComplexity",
+    "lineCount": 208,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ03.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "part-i-companion-krylov-matrix",
+      "title": "Part I: The Companion Matrix and the Krylov Change-of-Basis",
+      "startLine": 53,
+      "endLine": 86,
+      "summary": "Defines the companion matrix C(μ) of a polynomial (coefficients in the last column, 1s on the subdiagonal — the matrix of multiplication-by-X on K[X]/(μ)) and the Krylov change-of-basis matrix P = krylovMatrix M v whose column j is the j-th Krylov vector M^j v. The simp lemma krylovMatrix_apply exposes the entries.",
+      "mathContext": "$C(\\mu)_{ij} = -\\mu.\\mathrm{coeff}\\,i$ if $j = n-1$, else $1$ if $i = j+1$, else $0$; $P_{ij} = (M^j v)_i$."
+    },
+    {
+      "id": "part-ii-conjugation",
+      "title": "Part II: The Conjugation Identity M·P = P·C(μ_M)",
+      "startLine": 88,
+      "endLine": 152,
+      "summary": "The main structural theorem krylov_companion_conjugation: for a nonderogatory matrix (deg μ_M = n) and any starting vector v, M·P = P·C(μ_M). Proved entrywise: interior columns via the Krylov recurrence and a single-term subdiagonal sum, the last column via Cayley–Hamilton for v (μ_M(M)·v = 0 expanded and split at the monic top term).",
+      "mathContext": "$M\\cdot(M^j v) = M^{j+1}v$; last column $-\\sum_{k<n} a_k M^k v = M^n v$ from $\\mu_M(M)v = 0$."
+    },
+    {
+      "id": "part-iii-similarity",
+      "title": "Part III: The Similarity P⁻¹·M·P = C(μ_M)",
+      "startLine": 154,
+      "endLine": 170,
+      "summary": "krylov_rcf_similarity: when the Krylov matrix P is invertible, conjugation upgrades to a similarity P⁻¹·M·P = C(μ_M), exhibiting the rational canonical form as a single companion block. Proved by left-multiplying the conjugation identity by P⁻¹ (Matrix.nonsing_inv_mul).",
+      "mathContext": "$P^{-1}MP = C(\\mu_M)$ from $MP = PC(\\mu_M)$ and $P^{-1}P = 1$."
+    },
+    {
+      "id": "part-iv-cyclic-invertibility",
+      "title": "Part IV: A Cyclic Vector Makes the Krylov Matrix Invertible",
+      "startLine": 172,
+      "endLine": 208,
+      "summary": "krylovMatrix_col identifies the columns of P with the Krylov vectors; krylovMatrix_isUnit_of_cyclic derives invertibility of P from the parent's nonderogatory_krylov_optimal (linear independence of the n Krylov columns) via linearIndependent_cols_iff_isUnit; and krylov_rcf_similarity_of_cyclic assembles the full RCF similarity for a nonderogatory matrix with a cyclic vector.",
+      "mathContext": "$v$ cyclic $\\Rightarrow$ columns of $P$ independent $\\Rightarrow \\mathrm{IsUnit}(P.\\det) \\Rightarrow P^{-1}MP = C(\\mu_M)$."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Six theorems establish the rational-canonical-form content of the Krylov basis. The structural core krylov_companion_conjugation shows that a nonderogatory matrix M intertwines with the companion matrix of its minimal polynomial through the explicit Krylov change of basis: M·P = P·C(μ_M), with the interior columns given by the Krylov recurrence and the last column by Cayley–Hamilton applied to the starting vector. krylov_rcf_similarity and krylov_rcf_similarity_of_cyclic promote this to a genuine similarity P⁻¹·M·P = C(μ_M) once P is invertible, which krylovMatrix_isUnit_of_cyclic guarantees for a cyclic vector.",
+    "implications": "This closes the loop between the numerical Krylov iteration formalized in the parent (OQ-03) and the module-theoretic rational canonical form: the same O(n³) sequence that computes the minimal polynomial also produces, constructively, the change of basis conjugating a nonderogatory matrix into a single companion block. The companion matrix's last column being the (negated) coefficient vector of μ_M makes the identity M^n v = -∑_{k<n} a_k M^k v — Cayley–Hamilton for a vector — the whole content of the last column, giving a self-contained, Basis-free formalization suitable as the cyclic base case for the general invariant-factor decomposition.",
+    "openQuestions": [
+      "Extend from the nonderogatory (single-block) case to the full invariant-factor decomposition: iterate the Krylov construction on complementary M-invariant subspaces to obtain the block-diagonal rational canonical form ⊕_i C(f_i) with f_1 | f_2 | ... | f_k = μ_M.",
+      "Derive the similarity classification corollary: two nonderogatory matrices are similar over K iff they have the same minimal polynomial (equivalently the same companion matrix), by transitivity of the Krylov similarity."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-03",
+      "relationship": "extends",
+      "description": "OQ-03 proves Krylov termination and nonderogatory optimality (n independent Krylov vectors). OQ-03-OQ-03 reads that basis structurally: in it M becomes the companion matrix of μ_M, giving the rational canonical form via the explicit change of basis M·P = P·C(μ_M)."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-04",
+      "relationship": "uses",
+      "description": "The cyclic-vector characterization of nonderogatory matrices supplies the hypothesis (cyclic v) under which the Krylov matrix is invertible and the conjugation becomes a similarity."
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "uses",
+      "description": "The last column of the conjugation identity is exactly Cayley–Hamilton applied to the starting vector: μ_M(M)·v = 0 gives M^n v = -∑_{k<n} a_k M^k v."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Krylov, Aleksei N.",
+      "title": "On the numerical solution of the equation by which the frequency of small oscillations is determined in technical problems",
+      "year": "1931",
+      "venue": "Izv. Akad. Nauk SSSR, Otd. Mat. Estest. Nauk, 7(4), 491–539",
+      "note": "Introduced Krylov subspace sequences for eigenvalue computation"
+    },
+    {
+      "authors": "Dummit, David S. and Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, 3rd edition, §12.2 (The Rational Canonical Form)",
+      "note": "Standard reference: cyclic vectors, companion matrices, and the invariant-factor form of the rational canonical form"
+    }
+  ]
+}


### PR DESCRIPTION
## Krylov Sequences and the Rational Canonical Form

Structural follow-up to **cayley-hamilton-minpoly-oq-03** (Krylov termination / minimal-polynomial computation). Answers: *what does the Krylov basis reveal about M itself?* — the **rational canonical form**.

Assemble the first `n` Krylov vectors as the columns of a change-of-basis matrix `P = (v | Mv | ... | M^{n-1}v)` and let `C(μ_M)` be the companion matrix of the minimal polynomial.

### Results (all VERIFIED, 0 axioms, 0 sorries)

| Theorem | Statement |
|---|---|
| `krylov_companion_conjugation` | `M * P = P * C(μ_M)` for nonderogatory `M` (`deg μ_M = n`), **any** `v` |
| `krylov_rcf_similarity` | `P⁻¹ * M * P = C(μ_M)` when `P` is invertible |
| `krylovMatrix_isUnit_of_cyclic` | cyclic `v` ⇒ `IsUnit P.det` |
| `krylov_rcf_similarity_of_cyclic` | full RCF similarity from a cyclic vector |

### Proof idea

The conjugation identity is proved **entrywise**, avoiding all `Basis`/`LinearMap.toMatrix` machinery:
- **interior column** `j < n-1`: `M·(Mʲv) = M^{j+1}v` (Krylov recurrence) matches the companion's subdiagonal `1` (single-term sum);
- **last column** `j = n-1`: `M^n v = -∑_{k<n} a_k M^k v` — **Cayley–Hamilton applied to `v`** (`μ_M(M)·v = 0`, expanded via the parent's `aeval_mulVec_eq_krylov_sum`, monic top term peeled with `Monic.coeff_natDegree`).

Invertibility for a cyclic vector comes from the parent's `nonderogatory_krylov_optimal` via `Matrix.linearIndependent_cols_iff_isUnit`.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonMinpolyOQ03OQ03` → **Build succeeded (3059 jobs)**
- 6 theorems, 2 defs, 208 lines, 0 sorries, 0 `axiom`, no `native_decide`.
- Imports only the 0-axiom parent `Proofs.CayleyHamiltonMinpolyOQ03` + Mathlib.

Gallery entry: `src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03/` (meta.json + annotations.json), status `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)