### PR TITLE
Fix: add missing proofRepoPath to 2 verified godel entries

### DIFF
--- a/src/data/proofs/godel-incompleteness-oq-02/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-02/meta.json
@@ -8,6 +8,7 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/G%C3%B6del%27s_incompleteness_theorems#Proof_via_Berry's_paradox",
     "date": "1936",
     "status": "verified",
+    "proofRepoPath": "Proofs/GodelIncompletenessOQ02.lean",
     "tags": [
       "logic",
       "foundations",

--- a/src/data/proofs/godel-incompleteness-oq-04/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-04/meta.json
@@ -8,6 +8,7 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Inaccessible_cardinal",
     "date": "1930",
     "status": "verified",
+    "proofRepoPath": "Proofs/GodelIncompletenessOQ04.lean",
     "tags": [
       "logic",
       "foundations",


### PR DESCRIPTION
## Fix

Two `status: verified` gallery entries were missing `meta.proofRepoPath` — the only 2 such entries among 2441 verified metas.

- `godel-incompleteness-oq-02` → `Proofs/GodelIncompletenessOQ02.lean`
- `godel-incompleteness-oq-04` → `Proofs/GodelIncompletenessOQ04.lean`

## Evidence

**Before**: `meta.proofRepoPath` absent; the Lean file was referenced only via the top-level `leanFile.path` object. In `scripts/auditor/find-targets.ts:290` and `scripts/peer-reviewer/find-targets.ts:142` the resolver is `proofMeta.proofRepoPath || (typeof proofMeta.leanFile === 'string' ? ... : '')`. Because `leanFile` here is an **object**, both resolve to `''`, so these two verified entries are silently skipped by the auditor and peer reviewer.

**After**: `meta.proofRepoPath` added, equal to `leanFile.path` — matching every sibling (`godel-incompleteness`, `godel-incompleteness-oq-03`) and the `leanFile.path == proofRepoPath` invariant. Both Lean files exist on disk and are sorry-free / axiom-free (the lone `^axiom ` grep hit is prose inside a closing docstring, not a declaration). Auditor resolver now returns a non-empty path for both.

Minimal diff: 2 files, 2 insertions.

---
Automated fix by lean-mechanic agent.