### PR TITLE
Enrich 8 classic theorems: add references (batch 5)

### DIFF
--- a/src/data/proofs/godel-first-incompleteness-oq01/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01/meta.json
@@ -188,5 +188,40 @@
     "path": "Proofs/GodelFirstIncompletenessOQ01.lean",
     "definitionCount": 7,
     "theoremCount": 5
-  }
+  },
+  "references": [
+    {
+      "authors": "Kurt Gödel",
+      "title": "Über formal unentscheidbare Sätze der Principia Mathematica und verwandter Systeme I",
+      "year": 1931,
+      "venue": "Monatshefte für Mathematik und Physik 38, 173–198",
+      "note": "The original paper establishing the First Incompleteness Theorem: any consistent, effectively axiomatized theory extending arithmetic is incomplete."
+    },
+    {
+      "authors": "Kurt Gödel (trans. Martin Hirzel)",
+      "title": "On Formally Undecidable Propositions of Principia Mathematica and Related Systems I",
+      "year": 1931,
+      "note": "Standard English translation of the 1931 paper; the source of the Gödel sentence construction formalized here."
+    },
+    {
+      "authors": "Peter Smith",
+      "title": "An Introduction to Gödel's Theorems",
+      "year": 2013,
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Modern textbook development of the diagonal lemma and the derivability conditions underlying this axiomatic presentation."
+    },
+    {
+      "authors": "Raymond M. Smullyan",
+      "title": "Gödel's Incompleteness Theorems",
+      "year": 1992,
+      "venue": "Oxford University Press",
+      "note": "Self-contained treatment of representability and the fixed-point construction; motivates the opaque Provable predicate used here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: logic and computability infrastructure",
+      "year": 2024,
+      "note": "Provides the propositional and classical-logic foundation over which the five explicit incompleteness axioms are stated and combined."
+    }
+  ]
 }

--- a/src/data/proofs/godel-second-incompleteness-oq02/meta.json
+++ b/src/data/proofs/godel-second-incompleteness-oq02/meta.json
@@ -199,5 +199,41 @@
         "description": "S2-α companion (OQ02-OQ-02): object-level implication impl_formula and HBL D2/D3 axiomatization. Defines impl_formula and proves Gödel-code distinctness lemmas (impl_formula_code/_ne_falsum/_ne_Prov). Axiomatizes impl_mp (modus ponens internalization), d2_distribution (□(φ→ψ) → □φ → □ψ), and d3_internal_necessitation (□φ → □□φ). Derives internal_K as the prototypical Hilbert-Bernays-Löb K-axiom."
       }
     ]
-  }
+  },
+  "references": [
+    {
+      "authors": "Kurt Gödel",
+      "title": "Über formal unentscheidbare Sätze der Principia Mathematica und verwandter Systeme I",
+      "year": 1931,
+      "venue": "Monatshefte für Mathematik und Physik 38, 173–198",
+      "note": "Sketches the Second Incompleteness Theorem: a consistent system cannot prove its own consistency (Con(T) is unprovable in T)."
+    },
+    {
+      "authors": "David Hilbert and Paul Bernays",
+      "title": "Grundlagen der Mathematik II",
+      "year": 1939,
+      "venue": "Springer",
+      "note": "Introduces the Hilbert–Bernays derivability conditions (HBL conditions) on the provability predicate that this proof assumes."
+    },
+    {
+      "authors": "Martin Hugo Löb",
+      "title": "Solution of a Problem of Leon Henkin",
+      "year": 1955,
+      "venue": "Journal of Symbolic Logic 20(2), 115–118",
+      "note": "Löb's theorem and the third derivability condition; the modal core of the Second Incompleteness argument."
+    },
+    {
+      "authors": "George Boolos",
+      "title": "The Logic of Provability",
+      "year": 1993,
+      "venue": "Cambridge University Press",
+      "note": "Provability logic (GL) treatment showing Second Incompleteness as a one-line consequence of Löb's theorem, matching the structure of this formalization."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: classical logic foundation",
+      "year": 2024,
+      "note": "Underlies the derivation of the second theorem from the formalized First Incompleteness axiom and the HBL conditions."
+    }
+  ]
 }

--- a/src/data/proofs/inverse-galois-d4/meta.json
+++ b/src/data/proofs/inverse-galois-d4/meta.json
@@ -117,5 +117,41 @@
       "Proofs.NthRootIrrationalOQ01"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "David S. Dummit and Richard M. Foote",
+      "title": "Abstract Algebra",
+      "year": 2004,
+      "venue": "Wiley, 3rd ed.",
+      "note": "Standard reference: X⁴−2 has splitting field ℚ(⁴√2, i) with Galois group the dihedral group D₄ of order 8 (§14.2)."
+    },
+    {
+      "authors": "Jean-Pierre Serre",
+      "title": "Topics in Galois Theory",
+      "year": 2008,
+      "venue": "A K Peters, 2nd ed.",
+      "note": "Systematic treatment of the inverse Galois problem and the realization of small groups such as D₄ over ℚ."
+    },
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra",
+      "year": 2002,
+      "venue": "Springer GTM 211, 3rd ed.",
+      "note": "Splitting fields, degree multiplicativity, and the embedding arguments used for the order-8 upper bound."
+    },
+    {
+      "authors": "Gunter Malle and B. Heinrich Matzat",
+      "title": "Inverse Galois Theory",
+      "year": 2018,
+      "venue": "Springer Monographs in Mathematics, 2nd ed.",
+      "note": "Comprehensive account of which finite groups are known to be Galois groups over ℚ, including dihedral realizations."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: AdjoinRoot, IsSplittingField, and Galois group API",
+      "year": 2024,
+      "note": "Supplies AdjoinRoot(X⁴−2), the ℝ-embedding obstruction, and the finite Galois-group cardinality machinery used in the proof."
+    }
+  ]
 }

--- a/src/data/proofs/inverse-galois-f20/meta.json
+++ b/src/data/proofs/inverse-galois-f20/meta.json
@@ -149,5 +149,41 @@
       "significance": "Combined with lower bound: |Gal| = 20 exactly"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "David S. Dummit and Richard M. Foote",
+      "title": "Abstract Algebra",
+      "year": 2004,
+      "venue": "Wiley, 3rd ed.",
+      "note": "The splitting field of X⁵−2 is ℚ(⁵√2, ζ₅) with Galois group the Frobenius group F₂₀ = ℤ/5 ⋊ ℤ/4 of order 20 (§14)."
+    },
+    {
+      "authors": "Jean-Pierre Serre",
+      "title": "Topics in Galois Theory",
+      "year": 2008,
+      "venue": "A K Peters, 2nd ed.",
+      "note": "Realizes solvable groups such as F₂₀ as Galois groups over ℚ via semidirect-product structure."
+    },
+    {
+      "authors": "Gunter Malle and B. Heinrich Matzat",
+      "title": "Inverse Galois Theory",
+      "year": 2018,
+      "venue": "Springer Monographs in Mathematics, 2nd ed.",
+      "note": "Background on Frobenius groups as Galois groups and the metacyclic realization pattern used here."
+    },
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra",
+      "year": 2002,
+      "venue": "Springer GTM 211, 3rd ed.",
+      "note": "Cyclotomic extensions ℚ(ζ₅), irreducibility of Φ₅, and the degree bound [ℚ(⁵√2, ζ₅):ℚ] ≤ 20."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: cyclotomic polynomials and splitting-field API",
+      "year": 2024,
+      "note": "Provides Φ₅ irreducibility, Eisenstein irreducibility of X⁵−2, and the Galois-group cardinality bounds combined in the proof."
+    }
+  ]
 }

--- a/src/data/proofs/ramsey-r4k-extensions/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions/meta.json
@@ -269,5 +269,48 @@
       "summary": "Part IX. Summary of extensions and recent frontier results stated as axioms: the Campos-Griffiths-Morris-Sahasrabudhe (CGMS) exponential improvement $R(k,k)\\le(4-\\varepsilon)^k$ with its $\\varepsilon$ estimate and book-algorithm structure, off-diagonal bounds, Bohman-Keevash $R(3,t)$, Mattheus-Verstraete $R(4,t)$, the Burr-Erdős conjecture, and Ramsey multiplicity."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Paul Erdős",
+      "title": "Some Remarks on the Theory of Graphs",
+      "year": 1947,
+      "venue": "Bulletin of the AMS 53, 292–294",
+      "note": "The founding probabilistic-method argument giving R(k,k) ≥ 2^(k/2), formalized here as the diagonal lower bound."
+    },
+    {
+      "authors": "Joel Spencer",
+      "title": "Ramsey's Theorem — A New Lower Bound",
+      "year": 1975,
+      "venue": "Journal of Combinatorial Theory, Series A 18, 108–115",
+      "note": "Lovász Local Lemma improvement of the Erdős bound, one of the extensions treated in this entry."
+    },
+    {
+      "authors": "David Conlon, Jacob Fox, and Benny Sudakov",
+      "title": "Recent Developments in Graph Ramsey Theory",
+      "year": 2015,
+      "venue": "Surveys in Combinatorics, LMS Lecture Notes 424, 49–118",
+      "note": "Survey containing the upper-bound techniques and state-of-the-art R(4,k) estimates axiomatized here."
+    },
+    {
+      "authors": "Miklós Ajtai, János Komlós, and Endre Szemerédi",
+      "title": "A Note on Ramsey Numbers",
+      "year": 1980,
+      "venue": "Journal of Combinatorial Theory, Series A 29, 354–360",
+      "note": "Establishes R(4,k) = O(k³/log²k) and the general R(s,k) upper bounds behind the quadratic-type lower-bound comparison."
+    },
+    {
+      "authors": "Noga Alon and Joel H. Spencer",
+      "title": "The Probabilistic Method",
+      "year": 2016,
+      "venue": "Wiley, 4th ed.",
+      "note": "Textbook development of the deletion method and alteration bounds underlying the R(4,k) ≥ Ω(k²/log k) lower bound."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Combinatorics.SimpleGraph and Ramsey-theoretic API",
+      "year": 2024,
+      "note": "Graph, clique, and independent-set infrastructure over which the Ramsey bounds are stated."
+    }
+  ]
 }

--- a/src/data/proofs/rh-consequences/meta.json
+++ b/src/data/proofs/rh-consequences/meta.json
@@ -264,5 +264,41 @@
       "mathContext": "Final consolidated summary of all formal statements, distinguishing the unconditionally proved theorems from the RH-conditional results and the remaining analytic axioms."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Bernhard Riemann",
+      "title": "Über die Anzahl der Primzahlen unter einer gegebenen Grösse",
+      "year": 1859,
+      "venue": "Monatsberichte der Berliner Akademie",
+      "note": "Original memoir stating the hypothesis on the zeros of ζ(s) whose consequences are formalized here."
+    },
+    {
+      "authors": "Edward Charles Titchmarsh (rev. D. R. Heath-Brown)",
+      "title": "The Theory of the Riemann Zeta-Function",
+      "year": 1986,
+      "venue": "Oxford University Press, 2nd ed.",
+      "note": "Standard reference for the equivalence between RH and the error-term bounds M(x) = O(√x·) on the Mertens function."
+    },
+    {
+      "authors": "Harold M. Edwards",
+      "title": "Riemann's Zeta Function",
+      "year": 1974,
+      "venue": "Academic Press",
+      "note": "Detailed exposition connecting RH to the Möbius/Mertens summatory functions and the Chebyshev ψ and θ functions used here."
+    },
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer",
+      "note": "Chebyshev functions, Möbius function identities, and the O(√x) consequences under RH."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: RiemannHypothesis, ArithmeticFunction.moebius, and ζ API",
+      "year": 2024,
+      "note": "Supplies the built-in RiemannHypothesis statement and Möbius/Chebyshev definitions on which the consequences are built."
+    }
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding-awgn/meta.json
+++ b/src/data/proofs/shannon-channel-coding-awgn/meta.json
@@ -1,186 +1,222 @@
 {
-    "id": "shannon-channel-coding-awgn",
-    "title": "AWGN Channel Capacity (C = ½ log(1 + P/N))",
-    "slug": "shannon-channel-coding-awgn",
-    "description": "Formalizes the additive white Gaussian noise (AWGN) channel capacity formula C(P, N) = ½ log(1 + P/N), the third and last named channel of the Shannon channel-coding goal (after BSC and BEC). The capacity is assembled axiom-free from the proven Gaussian differential-entropy theorems of ShannonEntropyOQ01: the noise entropy ½ log(2πe N), the capacity-achieving Gaussian output entropy ½ log(2πe (P+N)), their difference collapsing to ½ log(1 + P/N) (achievability), and a matching converse via the Gaussian maximum-entropy theorem for any output density of variance ≤ P + N. Includes the algebraic core identity and the structural properties of C(P, N) (non-negativity, vanishing at zero power, strict positivity, monotone increasing in signal power, decreasing in noise power). Scope: this is the entropy-difference assembly of the capacity; the operational continuous-alphabet mutual-information layer (defining I(X;Y) measure-theoretically and proving I = h(Y) - h(Z)) is described in prose but not formalized — the differential entropies are taken as the grounded quantities of ShannonEntropyOQ01 and the output-power relation E[Y²] ≤ P + N is the converse hypothesis.",
-    "meta": {
-        "author": "Claude Shannon (1948), formalized in Lean 4",
-        "sourceUrl": "https://en.wikipedia.org/wiki/Shannon%E2%80%93Hartley_theorem",
-        "date": "1948",
-        "status": "verified",
-        "proofRepoPath": "Proofs/ShannonChannelCodingAWGN.lean",
-        "tags": [
-            "information-theory",
-            "analysis",
-            "probability",
-            "measure-theory",
-            "coding-theory",
-            "channel-capacity",
-            "differential-entropy",
-            "advanced"
-        ],
-        "badge": "original",
-        "sorries": 0,
-        "mathlibDependencies": [
-            {
-                "theorem": "Analysis.SpecialFunctions.Log.Basic",
-                "description": "Real.log_div, Real.log_le_log, Real.log_nonneg, Real.log_pos for the entropy-difference identity and the capacity monotonicity",
-                "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
-            },
-            {
-                "theorem": "Analysis.SpecialFunctions.Sqrt",
-                "description": "Real.sqrt_pos and Real.sq_sqrt to instantiate the σ²-form Gaussian entropy theorems at σ = √N and σ = √(P+N)",
-                "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
-            }
-        ],
-        "originalContributions": [
-            "Axiom-free assembly of the AWGN capacity formula C(P, N) = ½ log(1 + P/N) from the proven Gaussian differential-entropy cornerstones of ShannonEntropyOQ01 — no new measure theory beyond what is already established there",
-            "awgn_log_identity: the algebraic core ½ log(2πe(P+N)) - ½ log(2πe N) = ½ log(1 + P/N), the entropy difference that defines the capacity",
-            "awgn_capacity_achieved: a Gaussian input of power P produces a Gaussian output of power P + N, whose differential entropy minus the noise entropy is exactly the capacity (achievability of the formula)",
-            "awgn_capacity_upper_bound: the converse — via the Gaussian maximum-entropy theorem, no output density whose variance is bounded by the output power P + N can beat the capacity",
-            "Structural properties of C(P, N): non-negativity, vanishing at zero signal power, strict positivity for P > 0, monotone increasing in signal power, and decreasing in noise power"
-        ],
-        "assumptions": "0 axioms, 0 sorries. The file imports ShannonEntropyOQ01 (itself 0 axioms, 0 sorries) and uses two of its theorems — gaussianDifferentialEntropy (h(N(μ,σ²)) = ½ log(2πe σ²)) and gaussian_max_entropy (the Gaussian maximizes differential entropy at fixed variance); neither lies on a path to any sorry. SCOPE: this entry formalizes the capacity FORMULA as an entropy difference — the achievability and converse are proven exactly as stated, in terms of the output differential entropy minus the noise differential entropy. The operational continuous-alphabet mutual-information layer (constructing the joint distribution of (X, Y) for the additive channel Y = X + Z, defining I(X;Y) measure-theoretically, and proving the chain-rule decomposition I(X;Y) = h(Y) - h(Z)) is described in the prose but is NOT formalized; the variance-of-a-sum relation E[Y²] = P + N for an independent additive noise appears as the converse hypothesis (hvar) rather than as a derived fact. The entry therefore proves the capacity-value assembly, not the full operational coding theorem.",
-        "dateAdded": "2026-06-18",
-        "axiomCount": 0,
-        "lineCount": 199,
-        "prerequisites": [
-            "Differential entropy and the Gaussian closed form h(N) = ½ log(2πe σ²) (ShannonEntropyOQ01.lean)",
-            "The Gaussian maximum-entropy theorem at fixed variance (ShannonEntropyOQ01.lean)",
-            "Discrete memoryless channels and channel capacity for the finite-alphabet siblings BSC/BEC (ShannonChannelCoding.lean)"
-        ],
-        "mathlib_version": "4.26.0",
-        "theoremCount": 10,
-        "definitionCount": 1
-    },
-    "overview": {
-        "historicalContext": "The additive white Gaussian noise channel is the continuous-alphabet counterpart of the BSC and BEC and the central model of physical communication — wireless, optical fiber, and deep-space links are all AWGN-limited. Shannon's 1948 capacity C = ½ log(1 + P/N) per channel use (equivalently the Shannon–Hartley law C = B log₂(1 + P/N) bits/s over bandwidth B) sets the ultimate rate for reliable communication at signal-to-noise ratio P/N, and modern capacity-approaching codes (turbo, LDPC, polar) are benchmarked against it.\n\nUnlike the discrete channels, the AWGN derivation runs through the differential entropy of continuous random variables. The key facts are that a Gaussian of variance σ² has differential entropy exactly ½ log(2πe σ²), and that the Gaussian maximizes differential entropy among all densities of a given variance. With additive independent noise Z ~ N(0, N) and an input of power ≤ P, the output Y = X + Z has variance ≤ P + N, and the capacity is the largest possible h(Y) - h(Z) = ½ log(2πe(P+N)) - ½ log(2πe N) = ½ log(1 + P/N), attained by a Gaussian input.",
-        "problemStatement": "**AWGN Capacity Formula**: For the additive white Gaussian noise channel $Y = X + Z$ with independent noise $Z \\sim N(0, N)$ and an average-power constraint $\\mathbb{E}[X^2] \\le P$,\n$$C(P, N) = \\tfrac{1}{2}\\,\\log\\!\\left(1 + \\frac{P}{N}\\right).$$\nThe capacity is the difference between the maximal output differential entropy $\\tfrac12\\log(2\\pi e (P+N))$ (achieved by a Gaussian input) and the noise differential entropy $\\tfrac12\\log(2\\pi e N)$.",
-        "text": "Assembles the AWGN capacity C = ½ log(1 + P/N) axiom-free from the proven Gaussian differential-entropy theorems: the capacity-achieving Gaussian output entropy minus the Gaussian noise entropy, with a maximum-entropy converse.",
-        "proofStrategy": "The capacity is built in four stages from the differential-entropy cornerstones of ShannonEntropyOQ01:\n\n1. **Algebraic core** (awgn_log_identity): the entropy difference ½ log(2πe(P+N)) - ½ log(2πe N) collapses, via Real.log_div, to ½ log((P+N)/N) = ½ log(1 + P/N).\n\n2. **Grounding the entropies** (awgn_noise_entropy, awgn_output_entropy): instantiate gaussianDifferentialEntropy at σ = √N and σ = √(P+N) — using Real.sq_sqrt to turn σ² back into N and P+N — to obtain the noise entropy ½ log(2πe N) and the capacity-achieving output entropy ½ log(2πe(P+N)).\n\n3. **Achievability** (awgn_capacity_achieved): a Gaussian input of power P gives a Gaussian output of power P + N; its differential entropy minus the noise entropy is exactly the capacity, by stages 1–2.\n\n4. **Converse** (awgn_capacity_upper_bound): apply gaussian_max_entropy at σ = √(P+N) to any output density f of variance ≤ P + N — no such density exceeds ½ log(2πe(P+N)), so h(f) - h(Z) ≤ ½ log(1 + P/N).\n\nThe structural lemmas (non-negativity, zero at P = 0, strict positivity, monotone in P, antitone in N) follow from elementary log monotonicity.",
-        "keyInsights": [
-            "The AWGN capacity needs no new measure theory beyond the differential-entropy package: gaussianDifferentialEntropy supplies both the noise entropy and the capacity-achieving output entropy, and gaussian_max_entropy supplies the converse directly.",
-            "The capacity is literally an entropy difference: ½ log(2πe(P+N)) - ½ log(2πe N) = ½ log(1 + P/N) — the 2πe factors cancel, leaving only the signal-to-noise ratio.",
-            "The σ²-form entropy theorems are instantiated at σ = √V via Real.sq_sqrt (√V ^ 2 = V), bridging the entropy lemmas (parameterized by standard deviation) and the channel (parameterized by powers/variances).",
-            "The Gaussian is doubly optimal here: it gives the noise its entropy AND, as the maximum-entropy distribution at fixed variance, it is the capacity-achieving input — the same theorem (gaussian_max_entropy) that proves the converse identifies the optimal input.",
-            "Scope honesty: this proves the capacity VALUE as an entropy difference; the operational mutual-information identity I(X;Y) = h(Y) - h(Z) for the continuous additive channel is the standard decomposition assumed in prose, not the formalized object."
-        ]
-    },
-    "sections": [
-        {
-            "id": "awgn-capacity-def",
-            "title": "The AWGN Capacity C(P, N)",
-            "startLine": 53,
-            "endLine": 58,
-            "description": "Defines awgnCapacity P N = ½ log(1 + P/N), the Shannon capacity of the additive white Gaussian noise channel as a function of signal power P and noise power N.",
-            "summary": "The capacity function C(P, N) = ½ log(1 + P/N)."
-        },
-        {
-            "id": "log-identity",
-            "title": "The Entropy-Difference Identity",
-            "startLine": 60,
-            "endLine": 81,
-            "description": "awgn_log_identity: the difference of the capacity-achieving output entropy and the noise entropy, ½ log(2πe(P+N)) - ½ log(2πe N), collapses to ½ log(1 + P/N) via Real.log_div and field arithmetic. This is the algebraic heart of the capacity.",
-            "summary": "½ log(2πe(P+N)) - ½ log(2πe N) = ½ log(1 + P/N) — the 2πe factors cancel."
-        },
-        {
-            "id": "grounded-entropies",
-            "title": "Grounding the Two Differential Entropies",
-            "startLine": 82,
-            "endLine": 101,
-            "description": "awgn_noise_entropy and awgn_output_entropy instantiate the proven gaussianDifferentialEntropy at σ = √N and σ = √(P+N), using Real.sq_sqrt to recover the variances, giving the noise entropy ½ log(2πe N) and the Gaussian output entropy ½ log(2πe(P+N)).",
-            "summary": "Noise entropy ½ log(2πe N) and capacity-achieving output entropy ½ log(2πe(P+N)) from the Gaussian closed form."
-        },
-        {
-            "id": "achievability",
-            "title": "Achievability",
-            "startLine": 102,
-            "endLine": 113,
-            "description": "awgn_capacity_achieved: a Gaussian input of power P yields a Gaussian output of power P + N; its differential entropy minus the noise entropy equals the capacity ½ log(1 + P/N), combining the grounded entropies with the log identity.",
-            "summary": "A Gaussian input realizes h(Y) - h(Z) = ½ log(1 + P/N)."
-        },
-        {
-            "id": "converse",
-            "title": "Converse via Maximum Entropy",
-            "startLine": 114,
-            "endLine": 141,
-            "description": "awgn_capacity_upper_bound: applying gaussian_max_entropy at σ = √(P+N), no output density f whose variance is bounded by the output power P + N can exceed ½ log(2πe(P+N)); subtracting the noise entropy gives h(f) - h(Z) ≤ ½ log(1 + P/N). The output-power constraint E[Y²] ≤ P + N is the hypothesis hvar.",
-            "summary": "No output density of variance ≤ P + N beats the capacity — the Gaussian max-entropy bound."
-        },
-        {
-            "id": "structural-properties",
-            "title": "Structural Properties of the Capacity",
-            "startLine": 142,
-            "endLine": 199,
-            "description": "Elementary properties of C(P, N): awgn_capacity_nonneg (≥ 0), awgn_capacity_zero_power (C(0, N) = 0), awgn_capacity_pos (> 0 for P > 0), awgn_capacity_mono_power (increasing in signal power), and awgn_capacity_antitone_noise (decreasing in noise power).",
-            "summary": "C(P, N) is non-negative, zero at P = 0, increasing in P, and decreasing in N."
-        }
+  "id": "shannon-channel-coding-awgn",
+  "title": "AWGN Channel Capacity (C = ½ log(1 + P/N))",
+  "slug": "shannon-channel-coding-awgn",
+  "description": "Formalizes the additive white Gaussian noise (AWGN) channel capacity formula C(P, N) = ½ log(1 + P/N), the third and last named channel of the Shannon channel-coding goal (after BSC and BEC). The capacity is assembled axiom-free from the proven Gaussian differential-entropy theorems of ShannonEntropyOQ01: the noise entropy ½ log(2πe N), the capacity-achieving Gaussian output entropy ½ log(2πe (P+N)), their difference collapsing to ½ log(1 + P/N) (achievability), and a matching converse via the Gaussian maximum-entropy theorem for any output density of variance ≤ P + N. Includes the algebraic core identity and the structural properties of C(P, N) (non-negativity, vanishing at zero power, strict positivity, monotone increasing in signal power, decreasing in noise power). Scope: this is the entropy-difference assembly of the capacity; the operational continuous-alphabet mutual-information layer (defining I(X;Y) measure-theoretically and proving I = h(Y) - h(Z)) is described in prose but not formalized — the differential entropies are taken as the grounded quantities of ShannonEntropyOQ01 and the output-power relation E[Y²] ≤ P + N is the converse hypothesis.",
+  "meta": {
+    "author": "Claude Shannon (1948), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Shannon%E2%80%93Hartley_theorem",
+    "date": "1948",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonChannelCodingAWGN.lean",
+    "tags": [
+      "information-theory",
+      "analysis",
+      "probability",
+      "measure-theory",
+      "coding-theory",
+      "channel-capacity",
+      "differential-entropy",
+      "advanced"
     ],
-    "crossReferences": [
-        {
-            "targetId": "shannon-channel-coding-bec",
-            "relationship": "sibling",
-            "description": "Companion concrete-capacity proof for the binary erasure channel C(BEC(p)) = (1 - p) log 2. With the BSC and the AWGN, these are the three named channels of the Shannon channel-coding goal; BEC and BSC are the finite-alphabet pair, AWGN the continuous one."
-        },
-        {
-            "targetId": "shannon-channel-coding-oq-02",
-            "relationship": "sibling",
-            "description": "Companion concrete-capacity proof for the binary symmetric channel C(BSC(p)) = log 2 - h(p). Together with BEC and AWGN it completes the three named channels."
-        },
-        {
-            "targetId": "shannon-entropy-oq-01",
-            "relationship": "uses",
-            "description": "Built directly on its proven Gaussian differential-entropy theorems: gaussianDifferentialEntropy (h(N(μ,σ²)) = ½ log(2πe σ²)) and gaussian_max_entropy (the Gaussian maximizes differential entropy at fixed variance)."
-        },
-        {
-            "targetId": "shannon-channel-coding",
-            "relationship": "extends",
-            "description": "Supplies the continuous-alphabet concrete capacity for the parent channel-coding scaffold, complementing the discrete BSC and BEC capacities."
-        }
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Analysis.SpecialFunctions.Log.Basic",
+        "description": "Real.log_div, Real.log_le_log, Real.log_nonneg, Real.log_pos for the entropy-difference identity and the capacity monotonicity",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Analysis.SpecialFunctions.Sqrt",
+        "description": "Real.sqrt_pos and Real.sq_sqrt to instantiate the σ²-form Gaussian entropy theorems at σ = √N and σ = √(P+N)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      }
     ],
-    "conclusion": {
-        "summary": "This formalization assembles the AWGN channel capacity C(P, N) = ½ log(1 + P/N) axiom-free, with 0 sorries, from the proven Gaussian differential-entropy theorems of ShannonEntropyOQ01. The capacity is the entropy difference ½ log(2πe(P+N)) - ½ log(2πe N): the capacity-achieving Gaussian output entropy minus the Gaussian noise entropy. Achievability is realized by a Gaussian input of power P, and the converse follows from the Gaussian maximum-entropy theorem applied to any output density of variance bounded by P + N. With the BSC and BEC capacities, all three named channels of the Shannon channel-coding goal now have concrete, machine-checked capacity results, replacing the original placeholder statements.",
-        "implications": "The Shannon–Hartley capacity is the design target of every modern physical-layer communication system; pinning C = ½ log(1 + P/N) to the proven Gaussian differential-entropy package shows the formula is a thin algebraic shell over two facts about Gaussians — their closed-form entropy and their entropy-maximality at fixed variance. The same maximum-entropy theorem that supplies the converse also identifies the capacity-achieving (Gaussian) input, unifying achievability and converse under one lemma.",
-        "openQuestions": [
-            "Formalize the operational continuous-alphabet mutual information I(X;Y) for the additive channel Y = X + Z and prove the chain-rule decomposition I(X;Y) = h(Y) - h(Z), upgrading the entropy-difference assembly to the full operational AWGN capacity theorem.",
-            "Derive the variance-of-a-sum relation E[Y²] = P + N for independent additive noise from Mathlib's variance/independence API, removing it as the converse hypothesis.",
-            "Extend to the bandlimited Shannon–Hartley form C = B log₂(1 + P/N) bits/s and to parallel Gaussian channels via water-filling (the capacity of a vector AWGN channel).",
-            "Establish the coding theorem operationally (random Gaussian codebooks, sphere-packing converse) connecting the information-theoretic capacity proved here to achievable rates."
-        ]
-    },
-    "mainTheorems": [
-        {
-            "name": "awgn_capacity_achieved",
-            "type": "core",
-            "description": "A Gaussian input of power P gives output entropy minus noise entropy equal to the capacity ½ log(1 + P/N) — achievability of the AWGN capacity formula.",
-            "leanType": "differentialEntropy (gaussianPDF 0 (Real.sqrt (P+N))) - differentialEntropy (gaussianPDF 0 (Real.sqrt N)) = awgnCapacity P N"
-        },
-        {
-            "name": "awgn_capacity_upper_bound",
-            "type": "core",
-            "description": "Converse: no output density of variance ≤ P + N beats the capacity, via the Gaussian maximum-entropy theorem.",
-            "leanType": "differentialEntropy f - differentialEntropy (gaussianPDF 0 (Real.sqrt N)) ≤ awgnCapacity P N"
-        },
-        {
-            "name": "awgn_log_identity",
-            "type": "supporting",
-            "description": "The algebraic core: the difference of output and noise entropies equals ½ log(1 + P/N).",
-            "leanType": "(1/2) * Real.log (2*π*e*(P+N)) - (1/2) * Real.log (2*π*e*N) = (1/2) * Real.log (1 + P/N)"
-        },
-        {
-            "name": "awgn_capacity_mono_power",
-            "type": "corollary",
-            "description": "The capacity is monotone increasing in the signal power P.",
-            "leanType": "awgnCapacity P₁ N ≤ awgnCapacity P₂ N"
-        }
+    "originalContributions": [
+      "Axiom-free assembly of the AWGN capacity formula C(P, N) = ½ log(1 + P/N) from the proven Gaussian differential-entropy cornerstones of ShannonEntropyOQ01 — no new measure theory beyond what is already established there",
+      "awgn_log_identity: the algebraic core ½ log(2πe(P+N)) - ½ log(2πe N) = ½ log(1 + P/N), the entropy difference that defines the capacity",
+      "awgn_capacity_achieved: a Gaussian input of power P produces a Gaussian output of power P + N, whose differential entropy minus the noise entropy is exactly the capacity (achievability of the formula)",
+      "awgn_capacity_upper_bound: the converse — via the Gaussian maximum-entropy theorem, no output density whose variance is bounded by the output power P + N can beat the capacity",
+      "Structural properties of C(P, N): non-negativity, vanishing at zero signal power, strict positivity for P > 0, monotone increasing in signal power, and decreasing in noise power"
     ],
-    "leanFile": {
-        "axiomCount": 0,
-        "lineCount": 199,
-        "path": "Proofs/ShannonChannelCodingAWGN.lean",
-        "sorries": 0,
-        "definitionCount": 1,
-        "theoremCount": 10
+    "assumptions": "0 axioms, 0 sorries. The file imports ShannonEntropyOQ01 (itself 0 axioms, 0 sorries) and uses two of its theorems — gaussianDifferentialEntropy (h(N(μ,σ²)) = ½ log(2πe σ²)) and gaussian_max_entropy (the Gaussian maximizes differential entropy at fixed variance); neither lies on a path to any sorry. SCOPE: this entry formalizes the capacity FORMULA as an entropy difference — the achievability and converse are proven exactly as stated, in terms of the output differential entropy minus the noise differential entropy. The operational continuous-alphabet mutual-information layer (constructing the joint distribution of (X, Y) for the additive channel Y = X + Z, defining I(X;Y) measure-theoretically, and proving the chain-rule decomposition I(X;Y) = h(Y) - h(Z)) is described in the prose but is NOT formalized; the variance-of-a-sum relation E[Y²] = P + N for an independent additive noise appears as the converse hypothesis (hvar) rather than as a derived fact. The entry therefore proves the capacity-value assembly, not the full operational coding theorem.",
+    "dateAdded": "2026-06-18",
+    "axiomCount": 0,
+    "lineCount": 199,
+    "prerequisites": [
+      "Differential entropy and the Gaussian closed form h(N) = ½ log(2πe σ²) (ShannonEntropyOQ01.lean)",
+      "The Gaussian maximum-entropy theorem at fixed variance (ShannonEntropyOQ01.lean)",
+      "Discrete memoryless channels and channel capacity for the finite-alphabet siblings BSC/BEC (ShannonChannelCoding.lean)"
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The additive white Gaussian noise channel is the continuous-alphabet counterpart of the BSC and BEC and the central model of physical communication — wireless, optical fiber, and deep-space links are all AWGN-limited. Shannon's 1948 capacity C = ½ log(1 + P/N) per channel use (equivalently the Shannon–Hartley law C = B log₂(1 + P/N) bits/s over bandwidth B) sets the ultimate rate for reliable communication at signal-to-noise ratio P/N, and modern capacity-approaching codes (turbo, LDPC, polar) are benchmarked against it.\n\nUnlike the discrete channels, the AWGN derivation runs through the differential entropy of continuous random variables. The key facts are that a Gaussian of variance σ² has differential entropy exactly ½ log(2πe σ²), and that the Gaussian maximizes differential entropy among all densities of a given variance. With additive independent noise Z ~ N(0, N) and an input of power ≤ P, the output Y = X + Z has variance ≤ P + N, and the capacity is the largest possible h(Y) - h(Z) = ½ log(2πe(P+N)) - ½ log(2πe N) = ½ log(1 + P/N), attained by a Gaussian input.",
+    "problemStatement": "**AWGN Capacity Formula**: For the additive white Gaussian noise channel $Y = X + Z$ with independent noise $Z \\sim N(0, N)$ and an average-power constraint $\\mathbb{E}[X^2] \\le P$,\n$$C(P, N) = \\tfrac{1}{2}\\,\\log\\!\\left(1 + \\frac{P}{N}\\right).$$\nThe capacity is the difference between the maximal output differential entropy $\\tfrac12\\log(2\\pi e (P+N))$ (achieved by a Gaussian input) and the noise differential entropy $\\tfrac12\\log(2\\pi e N)$.",
+    "text": "Assembles the AWGN capacity C = ½ log(1 + P/N) axiom-free from the proven Gaussian differential-entropy theorems: the capacity-achieving Gaussian output entropy minus the Gaussian noise entropy, with a maximum-entropy converse.",
+    "proofStrategy": "The capacity is built in four stages from the differential-entropy cornerstones of ShannonEntropyOQ01:\n\n1. **Algebraic core** (awgn_log_identity): the entropy difference ½ log(2πe(P+N)) - ½ log(2πe N) collapses, via Real.log_div, to ½ log((P+N)/N) = ½ log(1 + P/N).\n\n2. **Grounding the entropies** (awgn_noise_entropy, awgn_output_entropy): instantiate gaussianDifferentialEntropy at σ = √N and σ = √(P+N) — using Real.sq_sqrt to turn σ² back into N and P+N — to obtain the noise entropy ½ log(2πe N) and the capacity-achieving output entropy ½ log(2πe(P+N)).\n\n3. **Achievability** (awgn_capacity_achieved): a Gaussian input of power P gives a Gaussian output of power P + N; its differential entropy minus the noise entropy is exactly the capacity, by stages 1–2.\n\n4. **Converse** (awgn_capacity_upper_bound): apply gaussian_max_entropy at σ = √(P+N) to any output density f of variance ≤ P + N — no such density exceeds ½ log(2πe(P+N)), so h(f) - h(Z) ≤ ½ log(1 + P/N).\n\nThe structural lemmas (non-negativity, zero at P = 0, strict positivity, monotone in P, antitone in N) follow from elementary log monotonicity.",
+    "keyInsights": [
+      "The AWGN capacity needs no new measure theory beyond the differential-entropy package: gaussianDifferentialEntropy supplies both the noise entropy and the capacity-achieving output entropy, and gaussian_max_entropy supplies the converse directly.",
+      "The capacity is literally an entropy difference: ½ log(2πe(P+N)) - ½ log(2πe N) = ½ log(1 + P/N) — the 2πe factors cancel, leaving only the signal-to-noise ratio.",
+      "The σ²-form entropy theorems are instantiated at σ = √V via Real.sq_sqrt (√V ^ 2 = V), bridging the entropy lemmas (parameterized by standard deviation) and the channel (parameterized by powers/variances).",
+      "The Gaussian is doubly optimal here: it gives the noise its entropy AND, as the maximum-entropy distribution at fixed variance, it is the capacity-achieving input — the same theorem (gaussian_max_entropy) that proves the converse identifies the optimal input.",
+      "Scope honesty: this proves the capacity VALUE as an entropy difference; the operational mutual-information identity I(X;Y) = h(Y) - h(Z) for the continuous additive channel is the standard decomposition assumed in prose, not the formalized object."
+    ]
+  },
+  "sections": [
+    {
+      "id": "awgn-capacity-def",
+      "title": "The AWGN Capacity C(P, N)",
+      "startLine": 53,
+      "endLine": 58,
+      "description": "Defines awgnCapacity P N = ½ log(1 + P/N), the Shannon capacity of the additive white Gaussian noise channel as a function of signal power P and noise power N.",
+      "summary": "The capacity function C(P, N) = ½ log(1 + P/N)."
     },
-    "sorries": 0
+    {
+      "id": "log-identity",
+      "title": "The Entropy-Difference Identity",
+      "startLine": 60,
+      "endLine": 81,
+      "description": "awgn_log_identity: the difference of the capacity-achieving output entropy and the noise entropy, ½ log(2πe(P+N)) - ½ log(2πe N), collapses to ½ log(1 + P/N) via Real.log_div and field arithmetic. This is the algebraic heart of the capacity.",
+      "summary": "½ log(2πe(P+N)) - ½ log(2πe N) = ½ log(1 + P/N) — the 2πe factors cancel."
+    },
+    {
+      "id": "grounded-entropies",
+      "title": "Grounding the Two Differential Entropies",
+      "startLine": 82,
+      "endLine": 101,
+      "description": "awgn_noise_entropy and awgn_output_entropy instantiate the proven gaussianDifferentialEntropy at σ = √N and σ = √(P+N), using Real.sq_sqrt to recover the variances, giving the noise entropy ½ log(2πe N) and the Gaussian output entropy ½ log(2πe(P+N)).",
+      "summary": "Noise entropy ½ log(2πe N) and capacity-achieving output entropy ½ log(2πe(P+N)) from the Gaussian closed form."
+    },
+    {
+      "id": "achievability",
+      "title": "Achievability",
+      "startLine": 102,
+      "endLine": 113,
+      "description": "awgn_capacity_achieved: a Gaussian input of power P yields a Gaussian output of power P + N; its differential entropy minus the noise entropy equals the capacity ½ log(1 + P/N), combining the grounded entropies with the log identity.",
+      "summary": "A Gaussian input realizes h(Y) - h(Z) = ½ log(1 + P/N)."
+    },
+    {
+      "id": "converse",
+      "title": "Converse via Maximum Entropy",
+      "startLine": 114,
+      "endLine": 141,
+      "description": "awgn_capacity_upper_bound: applying gaussian_max_entropy at σ = √(P+N), no output density f whose variance is bounded by the output power P + N can exceed ½ log(2πe(P+N)); subtracting the noise entropy gives h(f) - h(Z) ≤ ½ log(1 + P/N). The output-power constraint E[Y²] ≤ P + N is the hypothesis hvar.",
+      "summary": "No output density of variance ≤ P + N beats the capacity — the Gaussian max-entropy bound."
+    },
+    {
+      "id": "structural-properties",
+      "title": "Structural Properties of the Capacity",
+      "startLine": 142,
+      "endLine": 199,
+      "description": "Elementary properties of C(P, N): awgn_capacity_nonneg (≥ 0), awgn_capacity_zero_power (C(0, N) = 0), awgn_capacity_pos (> 0 for P > 0), awgn_capacity_mono_power (increasing in signal power), and awgn_capacity_antitone_noise (decreasing in noise power).",
+      "summary": "C(P, N) is non-negative, zero at P = 0, increasing in P, and decreasing in N."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "shannon-channel-coding-bec",
+      "relationship": "sibling",
+      "description": "Companion concrete-capacity proof for the binary erasure channel C(BEC(p)) = (1 - p) log 2. With the BSC and the AWGN, these are the three named channels of the Shannon channel-coding goal; BEC and BSC are the finite-alphabet pair, AWGN the continuous one."
+    },
+    {
+      "targetId": "shannon-channel-coding-oq-02",
+      "relationship": "sibling",
+      "description": "Companion concrete-capacity proof for the binary symmetric channel C(BSC(p)) = log 2 - h(p). Together with BEC and AWGN it completes the three named channels."
+    },
+    {
+      "targetId": "shannon-entropy-oq-01",
+      "relationship": "uses",
+      "description": "Built directly on its proven Gaussian differential-entropy theorems: gaussianDifferentialEntropy (h(N(μ,σ²)) = ½ log(2πe σ²)) and gaussian_max_entropy (the Gaussian maximizes differential entropy at fixed variance)."
+    },
+    {
+      "targetId": "shannon-channel-coding",
+      "relationship": "extends",
+      "description": "Supplies the continuous-alphabet concrete capacity for the parent channel-coding scaffold, complementing the discrete BSC and BEC capacities."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization assembles the AWGN channel capacity C(P, N) = ½ log(1 + P/N) axiom-free, with 0 sorries, from the proven Gaussian differential-entropy theorems of ShannonEntropyOQ01. The capacity is the entropy difference ½ log(2πe(P+N)) - ½ log(2πe N): the capacity-achieving Gaussian output entropy minus the Gaussian noise entropy. Achievability is realized by a Gaussian input of power P, and the converse follows from the Gaussian maximum-entropy theorem applied to any output density of variance bounded by P + N. With the BSC and BEC capacities, all three named channels of the Shannon channel-coding goal now have concrete, machine-checked capacity results, replacing the original placeholder statements.",
+    "implications": "The Shannon–Hartley capacity is the design target of every modern physical-layer communication system; pinning C = ½ log(1 + P/N) to the proven Gaussian differential-entropy package shows the formula is a thin algebraic shell over two facts about Gaussians — their closed-form entropy and their entropy-maximality at fixed variance. The same maximum-entropy theorem that supplies the converse also identifies the capacity-achieving (Gaussian) input, unifying achievability and converse under one lemma.",
+    "openQuestions": [
+      "Formalize the operational continuous-alphabet mutual information I(X;Y) for the additive channel Y = X + Z and prove the chain-rule decomposition I(X;Y) = h(Y) - h(Z), upgrading the entropy-difference assembly to the full operational AWGN capacity theorem.",
+      "Derive the variance-of-a-sum relation E[Y²] = P + N for independent additive noise from Mathlib's variance/independence API, removing it as the converse hypothesis.",
+      "Extend to the bandlimited Shannon–Hartley form C = B log₂(1 + P/N) bits/s and to parallel Gaussian channels via water-filling (the capacity of a vector AWGN channel).",
+      "Establish the coding theorem operationally (random Gaussian codebooks, sphere-packing converse) connecting the information-theoretic capacity proved here to achievable rates."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "awgn_capacity_achieved",
+      "type": "core",
+      "description": "A Gaussian input of power P gives output entropy minus noise entropy equal to the capacity ½ log(1 + P/N) — achievability of the AWGN capacity formula.",
+      "leanType": "differentialEntropy (gaussianPDF 0 (Real.sqrt (P+N))) - differentialEntropy (gaussianPDF 0 (Real.sqrt N)) = awgnCapacity P N"
+    },
+    {
+      "name": "awgn_capacity_upper_bound",
+      "type": "core",
+      "description": "Converse: no output density of variance ≤ P + N beats the capacity, via the Gaussian maximum-entropy theorem.",
+      "leanType": "differentialEntropy f - differentialEntropy (gaussianPDF 0 (Real.sqrt N)) ≤ awgnCapacity P N"
+    },
+    {
+      "name": "awgn_log_identity",
+      "type": "supporting",
+      "description": "The algebraic core: the difference of output and noise entropies equals ½ log(1 + P/N).",
+      "leanType": "(1/2) * Real.log (2*π*e*(P+N)) - (1/2) * Real.log (2*π*e*N) = (1/2) * Real.log (1 + P/N)"
+    },
+    {
+      "name": "awgn_capacity_mono_power",
+      "type": "corollary",
+      "description": "The capacity is monotone increasing in the signal power P.",
+      "leanType": "awgnCapacity P₁ N ≤ awgnCapacity P₂ N"
+    }
+  ],
+  "leanFile": {
+    "axiomCount": 0,
+    "lineCount": 199,
+    "path": "Proofs/ShannonChannelCodingAWGN.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 10
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Claude E. Shannon",
+      "title": "A Mathematical Theory of Communication",
+      "year": 1948,
+      "venue": "Bell System Technical Journal 27, 379–423 & 623–656",
+      "note": "Introduces channel capacity and derives the AWGN formula C = ½ log(1 + P/N) for the band-limited Gaussian channel."
+    },
+    {
+      "authors": "Thomas M. Cover and Joy A. Thomas",
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley, 2nd ed.",
+      "note": "Chapter 9: Gaussian channel capacity via differential entropy, exactly the assembly used here (½ log(2πe·) terms)."
+    },
+    {
+      "authors": "Robert G. Gallager",
+      "title": "Information Theory and Reliable Communication",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Rigorous capacity theorems for continuous-alphabet channels and the maximizing Gaussian input distribution."
+    },
+    {
+      "authors": "Abbas El Gamal and Young-Han Kim",
+      "title": "Network Information Theory",
+      "year": 2011,
+      "venue": "Cambridge University Press",
+      "note": "Modern treatment of the Gaussian channel and its differential-entropy building blocks."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: measure theory and Gaussian differential entropy",
+      "year": 2024,
+      "note": "Underlies the proven noise and output entropies ½ log(2πe N) and ½ log(2πe (P+N)) combined into the capacity."
+    }
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding-bec/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec/meta.json
@@ -1,188 +1,224 @@
 {
-    "id": "shannon-channel-coding-bec",
-    "title": "BEC Capacity Proof (Binary Erasure Channel)",
-    "slug": "shannon-channel-coding-bec",
-    "description": "Proves the binary erasure channel capacity formula C(BEC(p)) = (1 - p) · log 2 from first principles. The BEC has input Bool and output Option Bool (none = erasure); each bit is erased with probability p. The proof rests on the erasure identity H(X|Y) = p · H(X) for any input distribution, giving I(X;Y) = (1 - p) · H(X) by the chain rule, with the uniform input achieving H(X) = log 2. Introduces no new axioms or sorries; inherits 2 axioms from the parent ShannonChannelCoding import.",
-    "meta": {
-        "author": "Claude Shannon (1948), formalized in Lean 4",
-        "sourceUrl": "https://en.wikipedia.org/wiki/Binary_erasure_channel",
-        "date": "1948",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/ShannonChannelCodingBEC.lean",
-        "tags": [
-            "information-theory",
-            "analysis",
-            "probability",
-            "coding-theory",
-            "channel-capacity",
-            "advanced"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "mathlibDependencies": [
-            {
-                "theorem": "Analysis.SpecialFunctions.Log.Basic",
-                "description": "Logarithm properties for entropy and mutual information computations",
-                "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
-            },
-            {
-                "theorem": "Order.ConditionallyCompleteLattice.Basic",
-                "description": "csSup/csSup_le and le_csSup for capacity as a supremum",
-                "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
-            }
-        ],
-        "originalContributions": [
-            "Complete from-first-principles proof that BEC(p) capacity = (1 - p) · log 2 nats (equivalently 1 - p bits)",
-            "The BEC erasure identity H(X|Y) = p · H(X) for any input distribution: un-erased outputs (probability 1 - p) determine the input exactly, erased outputs (probability p) leave the full input entropy",
-            "Mutual information identity I(X;Y) = (1 - p) · H(X) via the chain rule",
-            "Converse I(X;Y) ≤ (1 - p) · log 2 from H(X) ≤ log 2, and achievability via the uniform Bernoulli(1/2) input",
-            "Capacity-in-bits corollary, non-negativity, and the ≤ log 2 (one-bit) ceiling"
-        ],
-        "assumptions": "2 axioms inherited in scope from ShannonChannelCoding.lean: channel_coding_achievability, channel_coding_converse. (The parent's fano_inequality was discharged to a proven theorem via ShannonChannelCodingOQ02OQ01.fano_inequality_proved, and its former bsc_capacity_eq axiom was removed -- the BSC capacity bounds now follow from general capacity theorems and the exact value is proved in ShannonChannelCodingOQ02.) 0 sorries. The BEC capacity result itself is proved from first principles and does not invoke any of these axioms; they are carried in scope because the file imports the parent (and the BSC development in ShannonChannelCodingOQ02). Unlike the BSC, the BEC is not weakly symmetric (its erasure column sums to 2p, the others to 1 - p), so the parent's symmetric-channel machinery does not apply -- the H(X|Y) = p · H(X) identity is the engine instead.",
-        "dateAdded": "2026-06-18",
-        "axiomCount": 2,
-        "lineCount": 243,
-        "prerequisites": [
-            "Shannon entropy and mutual information (ShannonEntropy.lean)",
-            "Discrete memoryless channels and channel capacity (ShannonChannelCoding.lean)",
-            "BSC development: uniformBool, entropy_uniform_bool (ShannonChannelCodingOQ02.lean)",
-            "Binary entropy function h(p) (ShannonChannelCodingOQ04.lean)"
-        ],
-        "mathlib_version": "4.26.0",
-        "theoremCount": 12,
-        "definitionCount": 1
-    },
-    "overview": {
-        "historicalContext": "The binary erasure channel (BEC) is, with the BSC, one of the two canonical discrete memoryless channels. Each transmitted bit is either received correctly (probability 1 - p) or replaced by an erasure symbol (probability p); crucially, the receiver always knows when an erasure has occurred. This makes the BEC the simplest channel that models packet loss, and its capacity C = 1 - p bits has a transparent operational meaning: a fraction p of the transmissions are lost, and the remaining 1 - p carry one bit each.\n\nUnlike the BSC, the BEC is not weakly symmetric, so the symmetric-channel capacity machinery does not apply. Instead the clean route is the erasure identity H(X|Y) = p · H(X): conditioned on the output, the residual uncertainty about the input is zero when the symbol arrives un-erased and the full H(X) when it is erased. The capacity-achieving input is uniform, exactly as for the BSC, because erasure is symmetric in the input symbol.",
-        "problemStatement": "**BEC Capacity Formula**: For a binary erasure channel with erasure probability $0 < p < 1$:\n$$C(\\text{BEC}(p)) = (1 - p)\\,\\log 2 \\text{ nats} = 1 - p \\text{ bits}.$$\nThe channel has input alphabet $\\{0,1\\}$ and output alphabet $\\{0, 1, ?\\}$ where $?$ denotes an erasure, with $W(x \\mid ?) = p$ and $W(y \\mid x) = (1-p)\\,[x = y]$ for $y \\in \\{0,1\\}$.",
-        "text": "Proves the binary erasure channel capacity C(BEC(p)) = (1 - p) · log 2 from first principles, via the erasure identity H(X|Y) = p · H(X).",
-        "proofStrategy": "The capacity proof has five stages, mirroring the BSC development:\n\n1. **Channel and marginals**: Define bec : DMChannel Bool (Option Bool). Compute the output marginals: the erasure output has probability p for every input, and each un-erased symbol y has marginal p(y) · (1 - p).\n\n2. **Erasure identity** H(X|Y) = p · H(X): In the conditional entropy, the un-erased (some y) summands vanish -- off-diagonal joint probabilities are 0, and on the diagonal the conditional probability is 1 so log 1 = 0. Only the erasure (none) summand survives, and it reproduces the input entropy scaled by p.\n\n3. **Mutual information** I(X;Y) = (1 - p) · H(X): immediate from the chain rule I = H(X) - H(X|Y) and step 2.\n\n4. **Converse**: H(X) ≤ log|Bool| = log 2, so I(X;Y) ≤ (1 - p) · log 2 for every input.\n\n5. **Capacity**: The uniform Bernoulli(1/2) input gives H(X) = log 2 and hence achieves (1 - p) · log 2. The supremum (channel capacity) therefore equals (1 - p) · log 2.",
-        "keyInsights": [
-            "The erasure identity H(X|Y) = p · H(X) is the entire engine: it holds for ANY input distribution, not just the optimal one.",
-            "The BEC is not weakly symmetric (the erasure column sums to 2p while the others sum to 1 - p), so the parent's symmetric-channel capacity lemmas do not apply -- a separate development is genuinely needed.",
-            "Erasure is symmetric in the input symbol, so the capacity-achieving input is still uniform Bernoulli(1/2), exactly as for the BSC.",
-            "Capacity in bits is simply 1 - p: a clean operational reading as the surviving fraction of transmissions.",
-            "Erasures are strictly cheaper than errors: because the decoder knows *where* information was lost, C_BEC = 1 - p exceeds the binary symmetric channel's C_BSC = 1 - H₂(p) for every p ∈ (0, 1) (with equality only at the endpoints) -- quantifying the operational value of knowing the location of corruption."
-        ]
-    },
-    "sections": [
-        {
-            "id": "bec-channel",
-            "title": "The Binary Erasure Channel BEC(p)",
-            "startLine": 49,
-            "endLine": 72,
-            "description": "Defines bec : DMChannel Bool (Option Bool) where none is the erasure symbol: W x none = p and W x (some y) = (1 - p)·[x = y]. The simp lemmas bec_W_none / bec_W_some expose the transition probabilities, and the channel laws (non-negativity, rows sum to one) are discharged for 0 ≤ p ≤ 1.",
-            "summary": "Defines the BEC as a discrete memoryless channel from Bool to Option Bool, with each bit erased independently with probability p."
-        },
-        {
-            "id": "output-marginals",
-            "title": "Output Marginals",
-            "startLine": 74,
-            "endLine": 91,
-            "description": "Computes the output distribution induced by an arbitrary input. bec_ymarg_none: the erasure output has marginal p regardless of the input; bec_ymarg_some: each un-erased symbol y has marginal inp.p y · (1 - p).",
-            "summary": "The erasure output has probability p for every input; each un-erased symbol y has marginal p(y)·(1 - p)."
-        },
-        {
-            "id": "erasure-identity",
-            "title": "The Erasure Identity H(X|Y) = p · H(X)",
-            "startLine": 93,
-            "endLine": 163,
-            "description": "The engine of the proof (bec_conditional_entropy). For any input distribution the un-erased summands vanish — off-diagonal joints are 0 and on the diagonal the conditional probability is 1 (log 1 = 0) — leaving only the erasure term, which reproduces the input entropy scaled by p.",
-            "summary": "Proves that conditioning on the output leaves residual input uncertainty p·H(X): zero when the symbol arrives, full H(X) when erased."
-        },
-        {
-            "id": "mutual-information",
-            "title": "Mutual Information I(X;Y) = (1 - p) · H(X)",
-            "startLine": 165,
-            "endLine": 185,
-            "description": "bec_mi_eq derives the mutual information from the chain rule I = H(X) - H(X|Y) and the erasure identity, holding for every input distribution.",
-            "summary": "Immediate from the chain rule and the erasure identity: I(X;Y) = (1 - p)·H(X)."
-        },
-        {
-            "id": "achievability-converse",
-            "title": "Achievability and Converse",
-            "startLine": 186,
-            "endLine": 202,
-            "description": "bec_uniform_mi shows the uniform Bernoulli(1/2) input achieves I(X;Y) = (1 - p)·log 2 (since H(X) = log 2); bec_mi_le gives the matching converse I(X;Y) ≤ (1 - p)·log 2 for every input via H(X) ≤ log 2.",
-            "summary": "The uniform input attains (1 - p)·log 2, and the entropy bound H(X) ≤ log 2 caps every input at the same value."
-        },
-        {
-            "id": "capacity",
-            "title": "BEC Capacity = (1 - p) · log 2",
-            "startLine": 204,
-            "endLine": 227,
-            "description": "bec_capacity identifies the supremum of mutual information: the converse bounds it above and the uniform input meets the bound, so the capacity equals (1 - p)·log 2. bec_capacity_bits divides by log 2 to read the capacity as 1 - p bits.",
-            "summary": "Capacity is pinned to (1 - p)·log 2 nats, equivalently 1 - p bits — the surviving fraction of transmissions."
-        },
-        {
-            "id": "corollaries",
-            "title": "Corollaries: Non-negativity and the One-bit Ceiling",
-            "startLine": 229,
-            "endLine": 243,
-            "description": "bec_capacity_nonneg shows the capacity is ≥ 0, and bec_capacity_le_log_two bounds it above by log 2 (one bit), with equality only in the noiseless limit p → 0.",
-            "summary": "The capacity sits in [0, log 2]: never negative, never above one bit, approaching one bit as p → 0."
-        }
+  "id": "shannon-channel-coding-bec",
+  "title": "BEC Capacity Proof (Binary Erasure Channel)",
+  "slug": "shannon-channel-coding-bec",
+  "description": "Proves the binary erasure channel capacity formula C(BEC(p)) = (1 - p) · log 2 from first principles. The BEC has input Bool and output Option Bool (none = erasure); each bit is erased with probability p. The proof rests on the erasure identity H(X|Y) = p · H(X) for any input distribution, giving I(X;Y) = (1 - p) · H(X) by the chain rule, with the uniform input achieving H(X) = log 2. Introduces no new axioms or sorries; inherits 2 axioms from the parent ShannonChannelCoding import.",
+  "meta": {
+    "author": "Claude Shannon (1948), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_erasure_channel",
+    "date": "1948",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/ShannonChannelCodingBEC.lean",
+    "tags": [
+      "information-theory",
+      "analysis",
+      "probability",
+      "coding-theory",
+      "channel-capacity",
+      "advanced"
     ],
-    "crossReferences": [
-        {
-            "targetId": "shannon-channel-coding",
-            "relationship": "extends",
-            "description": "Built on the parent's DMChannel / InputDist / capacity (csSup) framework; supplies a concrete from-first-principles capacity for one of the two canonical channels."
-        },
-        {
-            "targetId": "shannon-channel-coding-oq-02",
-            "relationship": "sibling",
-            "description": "Companion capacity proof for the binary symmetric channel C(BSC(p)) = log 2 - h(p); reuses uniformBool and entropy_uniform_bool from the BSC development. Together the BEC and BSC are the two canonical discrete memoryless channels."
-        },
-        {
-            "targetId": "shannon-entropy",
-            "relationship": "uses",
-            "description": "Built on the Shannon entropy, conditional entropy, and mutual information definitions that the erasure identity and chain-rule step rely on."
-        }
+    "badge": "axiom",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Analysis.SpecialFunctions.Log.Basic",
+        "description": "Logarithm properties for entropy and mutual information computations",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Order.ConditionallyCompleteLattice.Basic",
+        "description": "csSup/csSup_le and le_csSup for capacity as a supremum",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      }
     ],
-    "conclusion": {
-        "summary": "This formalization proves the binary erasure channel capacity C(BEC(p)) = (1 - p)·log 2 nats (= 1 - p bits) entirely from first principles, introducing no new axioms and no sorries. The whole argument turns on a single identity, H(X|Y) = p·H(X), which holds for every input distribution; the chain rule then gives I(X;Y) = (1 - p)·H(X), the entropy bound H(X) ≤ log 2 supplies the converse, and the uniform Bernoulli(1/2) input meets it. Two axioms from the parent ShannonChannelCoding.lean (channel_coding_achievability, channel_coding_converse) remain in scope via import but are not invoked by the BEC result.",
-        "implications": "The BEC is the canonical model of packet loss and the foundational channel for erasure coding: its capacity 1 - p bits is the benchmark that maximum-distance-separable, fountain (LT, Raptor), and random linear network codes approach. Because the BEC is not weakly symmetric, the parent's symmetric-channel machinery does not apply, so this entry demonstrates that the erasure identity is an independent route to a capacity formula. Paired with the BSC capacity proof, it completes the two textbook discrete memoryless channels from a single shared Mathlib-backed framework.",
-        "openQuestions": [
-            "Generalize the erasure identity and capacity to the q-ary erasure channel, where C = (1 - p)·log q.",
-            "Establish an operational coding theorem for the BEC (e.g. via random linear codes and the peeling decoder), connecting the information-theoretic supremum proved here to achievable rates through the parent's channel_coding_achievability.",
-            "Formalize the converse for the BEC operationally via Fano's inequality, discharging it against the parent's channel_coding_converse axiom.",
-            "Extend to channels with both erasures and errors (the binary error-and-erasure channel) and recover the BEC and BSC as boundary cases."
-        ]
-    },
-    "mainTheorems": [
-        {
-            "name": "bec_capacity",
-            "type": "core",
-            "description": "The capacity of BEC(p) equals (1 - p)·log 2 for 0 < p < 1.",
-            "leanType": "channelCapacity (bec p ..) = (1 - p) * Real.log 2"
-        },
-        {
-            "name": "bec_conditional_entropy",
-            "type": "core",
-            "description": "The erasure identity H(X|Y) = p·H(X) holding for any input distribution — the engine of the proof.",
-            "leanType": "conditionalEntropy (bec p ..) inp = p * inputEntropy inp"
-        },
-        {
-            "name": "bec_mi_eq",
-            "type": "supporting",
-            "description": "Mutual information I(X;Y) = (1 - p)·H(X) for any input, via the chain rule and the erasure identity.",
-            "leanType": "mutualInformation (bec p ..) inp = (1 - p) * inputEntropy inp"
-        },
-        {
-            "name": "bec_capacity_bits",
-            "type": "corollary",
-            "description": "Capacity in bits: C₂(BEC(p)) = 1 - p.",
-            "leanType": "channelCapacity (bec p ..) / Real.log 2 = 1 - p"
-        }
+    "originalContributions": [
+      "Complete from-first-principles proof that BEC(p) capacity = (1 - p) · log 2 nats (equivalently 1 - p bits)",
+      "The BEC erasure identity H(X|Y) = p · H(X) for any input distribution: un-erased outputs (probability 1 - p) determine the input exactly, erased outputs (probability p) leave the full input entropy",
+      "Mutual information identity I(X;Y) = (1 - p) · H(X) via the chain rule",
+      "Converse I(X;Y) ≤ (1 - p) · log 2 from H(X) ≤ log 2, and achievability via the uniform Bernoulli(1/2) input",
+      "Capacity-in-bits corollary, non-negativity, and the ≤ log 2 (one-bit) ceiling"
     ],
-    "leanFile": {
-        "axiomCount": 0,
-        "lineCount": 243,
-        "path": "Proofs/ShannonChannelCodingBEC.lean",
-        "sorries": 0,
-        "definitionCount": 1,
-        "theoremCount": 12
+    "assumptions": "2 axioms inherited in scope from ShannonChannelCoding.lean: channel_coding_achievability, channel_coding_converse. (The parent's fano_inequality was discharged to a proven theorem via ShannonChannelCodingOQ02OQ01.fano_inequality_proved, and its former bsc_capacity_eq axiom was removed -- the BSC capacity bounds now follow from general capacity theorems and the exact value is proved in ShannonChannelCodingOQ02.) 0 sorries. The BEC capacity result itself is proved from first principles and does not invoke any of these axioms; they are carried in scope because the file imports the parent (and the BSC development in ShannonChannelCodingOQ02). Unlike the BSC, the BEC is not weakly symmetric (its erasure column sums to 2p, the others to 1 - p), so the parent's symmetric-channel machinery does not apply -- the H(X|Y) = p · H(X) identity is the engine instead.",
+    "dateAdded": "2026-06-18",
+    "axiomCount": 2,
+    "lineCount": 243,
+    "prerequisites": [
+      "Shannon entropy and mutual information (ShannonEntropy.lean)",
+      "Discrete memoryless channels and channel capacity (ShannonChannelCoding.lean)",
+      "BSC development: uniformBool, entropy_uniform_bool (ShannonChannelCodingOQ02.lean)",
+      "Binary entropy function h(p) (ShannonChannelCodingOQ04.lean)"
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The binary erasure channel (BEC) is, with the BSC, one of the two canonical discrete memoryless channels. Each transmitted bit is either received correctly (probability 1 - p) or replaced by an erasure symbol (probability p); crucially, the receiver always knows when an erasure has occurred. This makes the BEC the simplest channel that models packet loss, and its capacity C = 1 - p bits has a transparent operational meaning: a fraction p of the transmissions are lost, and the remaining 1 - p carry one bit each.\n\nUnlike the BSC, the BEC is not weakly symmetric, so the symmetric-channel capacity machinery does not apply. Instead the clean route is the erasure identity H(X|Y) = p · H(X): conditioned on the output, the residual uncertainty about the input is zero when the symbol arrives un-erased and the full H(X) when it is erased. The capacity-achieving input is uniform, exactly as for the BSC, because erasure is symmetric in the input symbol.",
+    "problemStatement": "**BEC Capacity Formula**: For a binary erasure channel with erasure probability $0 < p < 1$:\n$$C(\\text{BEC}(p)) = (1 - p)\\,\\log 2 \\text{ nats} = 1 - p \\text{ bits}.$$\nThe channel has input alphabet $\\{0,1\\}$ and output alphabet $\\{0, 1, ?\\}$ where $?$ denotes an erasure, with $W(x \\mid ?) = p$ and $W(y \\mid x) = (1-p)\\,[x = y]$ for $y \\in \\{0,1\\}$.",
+    "text": "Proves the binary erasure channel capacity C(BEC(p)) = (1 - p) · log 2 from first principles, via the erasure identity H(X|Y) = p · H(X).",
+    "proofStrategy": "The capacity proof has five stages, mirroring the BSC development:\n\n1. **Channel and marginals**: Define bec : DMChannel Bool (Option Bool). Compute the output marginals: the erasure output has probability p for every input, and each un-erased symbol y has marginal p(y) · (1 - p).\n\n2. **Erasure identity** H(X|Y) = p · H(X): In the conditional entropy, the un-erased (some y) summands vanish -- off-diagonal joint probabilities are 0, and on the diagonal the conditional probability is 1 so log 1 = 0. Only the erasure (none) summand survives, and it reproduces the input entropy scaled by p.\n\n3. **Mutual information** I(X;Y) = (1 - p) · H(X): immediate from the chain rule I = H(X) - H(X|Y) and step 2.\n\n4. **Converse**: H(X) ≤ log|Bool| = log 2, so I(X;Y) ≤ (1 - p) · log 2 for every input.\n\n5. **Capacity**: The uniform Bernoulli(1/2) input gives H(X) = log 2 and hence achieves (1 - p) · log 2. The supremum (channel capacity) therefore equals (1 - p) · log 2.",
+    "keyInsights": [
+      "The erasure identity H(X|Y) = p · H(X) is the entire engine: it holds for ANY input distribution, not just the optimal one.",
+      "The BEC is not weakly symmetric (the erasure column sums to 2p while the others sum to 1 - p), so the parent's symmetric-channel capacity lemmas do not apply -- a separate development is genuinely needed.",
+      "Erasure is symmetric in the input symbol, so the capacity-achieving input is still uniform Bernoulli(1/2), exactly as for the BSC.",
+      "Capacity in bits is simply 1 - p: a clean operational reading as the surviving fraction of transmissions.",
+      "Erasures are strictly cheaper than errors: because the decoder knows *where* information was lost, C_BEC = 1 - p exceeds the binary symmetric channel's C_BSC = 1 - H₂(p) for every p ∈ (0, 1) (with equality only at the endpoints) -- quantifying the operational value of knowing the location of corruption."
+    ]
+  },
+  "sections": [
+    {
+      "id": "bec-channel",
+      "title": "The Binary Erasure Channel BEC(p)",
+      "startLine": 49,
+      "endLine": 72,
+      "description": "Defines bec : DMChannel Bool (Option Bool) where none is the erasure symbol: W x none = p and W x (some y) = (1 - p)·[x = y]. The simp lemmas bec_W_none / bec_W_some expose the transition probabilities, and the channel laws (non-negativity, rows sum to one) are discharged for 0 ≤ p ≤ 1.",
+      "summary": "Defines the BEC as a discrete memoryless channel from Bool to Option Bool, with each bit erased independently with probability p."
     },
-    "sorries": 0
+    {
+      "id": "output-marginals",
+      "title": "Output Marginals",
+      "startLine": 74,
+      "endLine": 91,
+      "description": "Computes the output distribution induced by an arbitrary input. bec_ymarg_none: the erasure output has marginal p regardless of the input; bec_ymarg_some: each un-erased symbol y has marginal inp.p y · (1 - p).",
+      "summary": "The erasure output has probability p for every input; each un-erased symbol y has marginal p(y)·(1 - p)."
+    },
+    {
+      "id": "erasure-identity",
+      "title": "The Erasure Identity H(X|Y) = p · H(X)",
+      "startLine": 93,
+      "endLine": 163,
+      "description": "The engine of the proof (bec_conditional_entropy). For any input distribution the un-erased summands vanish — off-diagonal joints are 0 and on the diagonal the conditional probability is 1 (log 1 = 0) — leaving only the erasure term, which reproduces the input entropy scaled by p.",
+      "summary": "Proves that conditioning on the output leaves residual input uncertainty p·H(X): zero when the symbol arrives, full H(X) when erased."
+    },
+    {
+      "id": "mutual-information",
+      "title": "Mutual Information I(X;Y) = (1 - p) · H(X)",
+      "startLine": 165,
+      "endLine": 185,
+      "description": "bec_mi_eq derives the mutual information from the chain rule I = H(X) - H(X|Y) and the erasure identity, holding for every input distribution.",
+      "summary": "Immediate from the chain rule and the erasure identity: I(X;Y) = (1 - p)·H(X)."
+    },
+    {
+      "id": "achievability-converse",
+      "title": "Achievability and Converse",
+      "startLine": 186,
+      "endLine": 202,
+      "description": "bec_uniform_mi shows the uniform Bernoulli(1/2) input achieves I(X;Y) = (1 - p)·log 2 (since H(X) = log 2); bec_mi_le gives the matching converse I(X;Y) ≤ (1 - p)·log 2 for every input via H(X) ≤ log 2.",
+      "summary": "The uniform input attains (1 - p)·log 2, and the entropy bound H(X) ≤ log 2 caps every input at the same value."
+    },
+    {
+      "id": "capacity",
+      "title": "BEC Capacity = (1 - p) · log 2",
+      "startLine": 204,
+      "endLine": 227,
+      "description": "bec_capacity identifies the supremum of mutual information: the converse bounds it above and the uniform input meets the bound, so the capacity equals (1 - p)·log 2. bec_capacity_bits divides by log 2 to read the capacity as 1 - p bits.",
+      "summary": "Capacity is pinned to (1 - p)·log 2 nats, equivalently 1 - p bits — the surviving fraction of transmissions."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries: Non-negativity and the One-bit Ceiling",
+      "startLine": 229,
+      "endLine": 243,
+      "description": "bec_capacity_nonneg shows the capacity is ≥ 0, and bec_capacity_le_log_two bounds it above by log 2 (one bit), with equality only in the noiseless limit p → 0.",
+      "summary": "The capacity sits in [0, log 2]: never negative, never above one bit, approaching one bit as p → 0."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "shannon-channel-coding",
+      "relationship": "extends",
+      "description": "Built on the parent's DMChannel / InputDist / capacity (csSup) framework; supplies a concrete from-first-principles capacity for one of the two canonical channels."
+    },
+    {
+      "targetId": "shannon-channel-coding-oq-02",
+      "relationship": "sibling",
+      "description": "Companion capacity proof for the binary symmetric channel C(BSC(p)) = log 2 - h(p); reuses uniformBool and entropy_uniform_bool from the BSC development. Together the BEC and BSC are the two canonical discrete memoryless channels."
+    },
+    {
+      "targetId": "shannon-entropy",
+      "relationship": "uses",
+      "description": "Built on the Shannon entropy, conditional entropy, and mutual information definitions that the erasure identity and chain-rule step rely on."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves the binary erasure channel capacity C(BEC(p)) = (1 - p)·log 2 nats (= 1 - p bits) entirely from first principles, introducing no new axioms and no sorries. The whole argument turns on a single identity, H(X|Y) = p·H(X), which holds for every input distribution; the chain rule then gives I(X;Y) = (1 - p)·H(X), the entropy bound H(X) ≤ log 2 supplies the converse, and the uniform Bernoulli(1/2) input meets it. Two axioms from the parent ShannonChannelCoding.lean (channel_coding_achievability, channel_coding_converse) remain in scope via import but are not invoked by the BEC result.",
+    "implications": "The BEC is the canonical model of packet loss and the foundational channel for erasure coding: its capacity 1 - p bits is the benchmark that maximum-distance-separable, fountain (LT, Raptor), and random linear network codes approach. Because the BEC is not weakly symmetric, the parent's symmetric-channel machinery does not apply, so this entry demonstrates that the erasure identity is an independent route to a capacity formula. Paired with the BSC capacity proof, it completes the two textbook discrete memoryless channels from a single shared Mathlib-backed framework.",
+    "openQuestions": [
+      "Generalize the erasure identity and capacity to the q-ary erasure channel, where C = (1 - p)·log q.",
+      "Establish an operational coding theorem for the BEC (e.g. via random linear codes and the peeling decoder), connecting the information-theoretic supremum proved here to achievable rates through the parent's channel_coding_achievability.",
+      "Formalize the converse for the BEC operationally via Fano's inequality, discharging it against the parent's channel_coding_converse axiom.",
+      "Extend to channels with both erasures and errors (the binary error-and-erasure channel) and recover the BEC and BSC as boundary cases."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "bec_capacity",
+      "type": "core",
+      "description": "The capacity of BEC(p) equals (1 - p)·log 2 for 0 < p < 1.",
+      "leanType": "channelCapacity (bec p ..) = (1 - p) * Real.log 2"
+    },
+    {
+      "name": "bec_conditional_entropy",
+      "type": "core",
+      "description": "The erasure identity H(X|Y) = p·H(X) holding for any input distribution — the engine of the proof.",
+      "leanType": "conditionalEntropy (bec p ..) inp = p * inputEntropy inp"
+    },
+    {
+      "name": "bec_mi_eq",
+      "type": "supporting",
+      "description": "Mutual information I(X;Y) = (1 - p)·H(X) for any input, via the chain rule and the erasure identity.",
+      "leanType": "mutualInformation (bec p ..) inp = (1 - p) * inputEntropy inp"
+    },
+    {
+      "name": "bec_capacity_bits",
+      "type": "corollary",
+      "description": "Capacity in bits: C₂(BEC(p)) = 1 - p.",
+      "leanType": "channelCapacity (bec p ..) / Real.log 2 = 1 - p"
+    }
+  ],
+  "leanFile": {
+    "axiomCount": 0,
+    "lineCount": 243,
+    "path": "Proofs/ShannonChannelCodingBEC.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 12
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Claude E. Shannon",
+      "title": "A Mathematical Theory of Communication",
+      "year": 1948,
+      "venue": "Bell System Technical Journal 27, 379–423 & 623–656",
+      "note": "Founding paper defining channel capacity as the maximum mutual information, the framework for the BEC capacity here."
+    },
+    {
+      "authors": "Peter Elias",
+      "title": "Coding for Two Noisy Channels",
+      "year": 1955,
+      "venue": "Information Theory (3rd London Symposium), 61–76",
+      "note": "Introduces the binary erasure channel and its capacity C = 1 − p (in bits)."
+    },
+    {
+      "authors": "Thomas M. Cover and Joy A. Thomas",
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley, 2nd ed.",
+      "note": "Derives BEC capacity from the erasure identity H(X|Y) = p·H(X) and the chain rule, exactly as formalized."
+    },
+    {
+      "authors": "David J. C. MacKay",
+      "title": "Information Theory, Inference, and Learning Algorithms",
+      "year": 2003,
+      "venue": "Cambridge University Press",
+      "note": "Accessible treatment of the erasure channel and mutual information I(X;Y) = (1−p)·H(X)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: finite-type entropy and negMulLog API",
+      "year": 2024,
+      "note": "Provides the Shannon-entropy and conditional-entropy machinery over Bool/Option Bool used in the proof."
+    }
+  ]
 }


### PR DESCRIPTION
Adds curated `references` to 8 base-level named-theorem gallery entries that had empty reference lists.

Entries enriched:
- **godel-first-incompleteness-oq01** — Gödel 1931, Smith, Smullyan
- **godel-second-incompleteness-oq02** — Gödel 1931, Hilbert–Bernays, Löb 1955, Boolos
- **inverse-galois-d4** — Dummit–Foote, Serre, Malle–Matzat (D₄ via X⁴−2)
- **inverse-galois-f20** — Frobenius group F₂₀ via X⁵−2
- **ramsey-r4k-extensions** — Erdős 1947, Spencer 1975, Conlon–Fox–Sudakov, Ajtai–Komlós–Szemerédi
- **rh-consequences** — Riemann 1859, Titchmarsh, Edwards, Apostol
- **shannon-channel-coding-awgn** — Shannon 1948, Cover–Thomas, Gallager
- **shannon-channel-coding-bec** — Shannon 1948, Elias 1955, Cover–Thomas, MacKay

Each list cites the primary source plus standard references matching the entry's specific content, ending with the relevant Mathlib module. No fabricated citations.

Enrichment pass — references only; no source or proof changes.