### PR TITLE
research(seeker): replenish pool with 6 tractable OQ-child problems

### DIFF
--- a/research/problems/amgm-inequality-oq-05-oq-02-oq-01/knowledge.md
+++ b/research/problems/amgm-inequality-oq-05-oq-02-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: amgm-inequality-oq-05-oq-02-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/amgm-inequality-oq-05-oq-02-oq-01/literature/README.md
+++ b/research/problems/amgm-inequality-oq-05-oq-02-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for amgm-inequality-oq-05-oq-02-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/amgm-inequality-oq-05-oq-02-oq-01/problem.md
+++ b/research/problems/amgm-inequality-oq-05-oq-02-oq-01/problem.md
@@ -1,0 +1,248 @@
+# Problem: The Classical AM-GM Equality Case at Uniform Weights (Indexed over `Fin n`)
+
+**Slug**: amgm-inequality-oq-05-oq-02-oq-01
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Specialise the parent's **weighted** AM-GM equality characterisation to **equal
+weights** $w_i = 1/n$, recovering the classical statement that the geometric mean
+of $n$ nonnegative reals equals their arithmetic mean iff all the reals coincide.
+Concretely, for $n \ge 1$ and $x : \operatorname{Fin} n \to \mathbb{R}$ strictly
+positive, prove
+
+$$
+\Bigl(\prod_{i} x_i\Bigr)^{1/n} \;=\; \frac{1}{n}\sum_{i} x_i
+\qquad\Longleftrightarrow\qquad
+\forall\, i\, j,\; x_i = x_j .
+$$
+
+A Lean-flavoured target signature (the researcher may adjust names and the exact
+rpow / `n`-th-root spelling):
+
+```lean
+theorem amgm_uniform_eq_iff {n : ℕ} (hn : 0 < n) {x : Fin n → ℝ}
+    (hx : ∀ i, 0 < x i) :
+    ((∏ i, x i) ^ ((1 : ℝ) / n) = (∑ i, x i) / n) ↔ (∀ i j, x i = x j) := by
+  sorry
+```
+
+This is obtained by instantiating the parent theorem
+`AmgmInequalityOQ05OQ02.weighted_amgm_eq_iff_pairwise` (and/or
+`weighted_amgm_eq_iff`) at the index set `t = Finset.univ : Finset (Fin n)` and the
+constant weight function `w i = 1 / n`. Two small translation steps convert the
+parent's shape $\prod_i x_i^{w_i} = \sum_i w_i x_i$ into the familiar
+$n$-th-root/average shape above:
+
+- the **geometric side** $\prod_i x_i^{1/n} = \bigl(\prod_i x_i\bigr)^{1/n}$ by a
+  lemma of the form "`Real.rpow` distributes over a finite product of positive
+  factors" (i.e. $(\prod_i x_i)^{r} = \prod_i x_i^{r}$);
+- the **arithmetic side** $\sum_i (1/n)\,x_i = \bigl(\sum_i x_i\bigr)/n$ by
+  `Finset.mul_sum` / `Finset.sum_div`.
+
+The weight hypotheses of the parent are discharged immediately at $w_i = 1/n$:
+positivity $0 < 1/n$ from `hn`, and the normalisation
+$\sum_{i \in \operatorname{univ}} 1/n = n \cdot (1/n) = 1$ from
+`Finset.sum_const`, `Finset.card_univ`, `Fintype.card_fin`, and cancellation using
+$n \ne 0$.
+
+### Plain Language
+
+The arithmetic mean of $n$ positive numbers is always at least their geometric
+mean; the two are *equal* exactly when the numbers are all the same. The parent
+gallery entry proved the general **weighted** version of this equality case — for
+arbitrary positive weights summing to $1$ — using the strict concavity of the
+logarithm. This problem asks for the single most-used consequence: plug in the
+uniform weights $1/n$ and restate the result in its textbook form, "the $n$-th
+root of a product equals the average iff all the terms are equal," cleanly indexed
+over `Fin n` so it reads as the classical AM-GM equality case with no weight
+bookkeeping visible.
+
+### Why This Matters
+
+The equal-weight AM-GM equality case is the version quoted in virtually every
+textbook and used throughout olympiad-style and analysis arguments; the weighted
+form, while strictly more general, is less convenient to apply directly. Packaging
+the `Fin n` corollary turns the parent's research result into a plug-and-play
+library lemma: any argument that invokes AM-GM and needs to know *when* it is tight
+can cite this one statement. It also completes the pedagogical arc of the entry
+family — from the two-variable Young equality case (`amgm-inequality-oq-05`), to the
+general weighted $n$-term equality case (`amgm-inequality-oq-05-oq-02`), down to the
+classical uniform corollary here — and demonstrates the standard
+"specialise weighted → uniform" pattern that recurs across the inequality
+literature.
+
+## Known Results
+
+### What's Already Proven
+
+- **Weighted AM-GM equality case, `n` terms** (`amgm-inequality-oq-05-oq-02`,
+  parent, verified, 0 axioms): for strictly positive weights $w$ summing to $1$
+  and strictly positive $x$ over a finite index set,
+  $\prod_i x_i^{w_i} = \sum_i w_i x_i$ iff every $x_j$ equals the common mean
+  (`weighted_amgm_eq_iff`), equivalently iff all $x_j$ are equal
+  (`weighted_amgm_eq_iff_pairwise`); the trivial converse is
+  `weighted_amgm_eq_of_const`. Proved via strict concavity of `Real.log`
+  (`strictConcaveOn_log_Ioi`) fed to `StrictConcaveOn.map_sum_eq_iff`, with the
+  multiplicative equality transported through `log` via `Real.log_injOn_pos`.
+- **Two-variable Young equality case** (`amgm-inequality-oq-05`, grandparent):
+  the weights $(1/p, 1/q)$ pointwise Young equality case from strict convexity of
+  `exp`.
+- **The AM-GM inequality itself** (`amgm-inequality`): the underlying inequality
+  the equality case sharpens. Mathlib carries the weighted inequality
+  (`Real.inner_le_weight_mul_Lp`, the `Real.geom_mean_le_arith_mean*_weighted`
+  family, and the `Real.pow_arith_mean_le_arith_mean_pow` / `Real.rpow` AM-GM
+  lemmas), but not the equality characterisation the parent supplies.
+
+### What's Still Open
+
+- No standalone `Fin n`, uniform-weight statement of the classical AM-GM equality
+  case exists in Mathlib or the gallery — only the general weighted version proved
+  by the parent. This is the gap to fill.
+
+### Our Goal
+
+Prove the classical AM-GM equality case at uniform weights as a **standalone
+corollary** by instantiating the parent's weighted equality theorem at
+$w_i = 1/n$ over `Finset.univ : Finset (Fin n)`. The mathematical content is
+entirely inherited from the parent; the work is the (small) translation from the
+weighted shape $\prod x_i^{w_i} = \sum w_i x_i$ to the textbook shape
+$(\prod x_i)^{1/n} = (\sum x_i)/n$, plus discharging the uniform-weight hypotheses.
+Deliver a 0-axiom Lean file with the `Fin n` iff-statement as the headline theorem,
+and optionally the two convenience directions (constant $\Rightarrow$ equality, and
+the pairwise phrasing).
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| amgm-inequality-oq-05-oq-02 | Direct parent: the weighted `n`-term equality case this specialises at $w_i = 1/n$ | Strict concavity of `log`, `StrictConcaveOn.map_sum_eq_iff`, `Real.log_injOn_pos` |
+| amgm-inequality-oq-05 | Grandparent: two-variable Young equality case (weights $1/p, 1/q$) | Strict convexity of `exp` |
+| amgm-inequality | The base inequality being sharpened; uniform-weight AM-GM is its classical face | Jensen / convexity |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Instantiate the parent, then normalise the shapes (recommended).**
+   Apply `weighted_amgm_eq_iff_pairwise` with `t := Finset.univ`,
+   `w := fun _ => (1 : ℝ)/n`, `x := x`. Discharge `hw` (each $1/n > 0$ from `hn`),
+   `hsum` ($\sum_{\operatorname{univ}} 1/n = 1$ via `Finset.sum_const`,
+   `Finset.card_univ`, `Fintype.card_fin`, and $n \cdot (1/n) = 1$), and `hx`. This
+   yields $\prod_i x_i^{1/n} = \sum_i (1/n) x_i \iff \forall i j,\, x_i = x_j$. Then
+   rewrite the geometric side to $(\prod_i x_i)^{1/n}$ (pull the common exponent out
+   of the product of positive factors) and the arithmetic side to
+   $(\sum_i x_i)/n$ (`Finset.mul_sum` / `Finset.sum_div`). Done.
+   - Why it works: no new mathematics; the equivalence is exactly the parent's,
+     re-expressed. Very likely 0 axioms.
+   - Risk: only the rpow-of-product bookkeeping (see difficulties).
+
+2. **Approach B — Reprove directly at uniform weights.** Skip the general parent and
+   run the log / strict-concavity argument specialised to $1/n$. Not recommended:
+   duplicates the parent's proof for no benefit and is strictly more work.
+
+### Key Difficulties
+
+- **Collecting the common exponent out of a product.** The parent's geometric side
+  is $\prod_i x_i^{1/n}$; the textbook side is $(\prod_i x_i)^{1/n}$. These agree for
+  positive $x_i$ by a lemma of the form $(\prod_i x_i)^{r} = \prod_i x_i^{r}$
+  (`Real.rpow` distributing over a finite product of nonnegative/positive factors).
+  Confirm the exact Mathlib name and orientation, and that positivity of the factors
+  is available.
+- **The `1/n` normalisation.** $\sum_{i \in \operatorname{univ}} 1/n = 1$ needs
+  `card (univ : Finset (Fin n)) = n` and $n \cdot (1/n) = 1$, which requires
+  $n \ne 0$ — hence the `0 < n` hypothesis. The $n = 0$ case is genuinely excluded
+  (empty product is $1$, empty sum is $0$, and $1/0$ conventions make the statement
+  degenerate), so carry `hn : 0 < n` explicitly.
+- **`n`-th root vs. rpow spelling.** "$n$-th root" is cleanest as
+  `(·) ^ ((1 : ℝ) / n)` with `Real.rpow`; keep exponents real throughout (matching
+  the parent, which uses `Real.rpow`) rather than mixing in `Real.sqrt` / `NNReal`
+  roots.
+
+### What Would a Proof Need?
+
+- Key lemma 1: the parent instantiation `weighted_amgm_eq_iff_pairwise` (or
+  `weighted_amgm_eq_iff`) at `t = univ`, `w = fun _ => 1/n`.
+- Key lemma 2: `∑ i, (1:ℝ)/n = 1` over `Fin n` (via `Finset.sum_const` + cardinality).
+- Key lemma 3: geometric-side rewrite $\prod_i x_i^{1/n} = (\prod_i x_i)^{1/n}$
+  (rpow over a positive product) and arithmetic-side rewrite
+  $\sum_i (1/n) x_i = (\sum_i x_i)/n$ (`Finset.mul_sum`).
+- Technical requirements: `Fintype (Fin n)` instances (automatic), positivity facts
+  `Real.rpow_pos_of_pos`, and `0 < n` to license the normalisation.
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Justification**:
+- This is a **direct corollary** of a fully verified, 0-axiom parent theorem. The
+  hard part — the strict-concavity equality argument — is already done and imported.
+- The only genuine work is cosmetic algebra: normalising the uniform weights to sum
+  to $1$ and reshaping $\prod x_i^{1/n}$ / $\sum (1/n)x_i$ into $(\prod x_i)^{1/n}$ /
+  $(\sum x_i)/n$. All tools (`Finset.sum_const`, `Finset.mul_sum`,
+  `Finset.card_univ`, `Fintype.card_fin`, `Real.rpow` product/positivity lemmas) are
+  standard Mathlib.
+- Comparable specialisations (weighted → uniform) are routine one-file ports; the
+  parent even names this exact task as its first open question.
+- Main residual risk is the naming/orientation of the rpow-over-product lemma,
+  resolvable by a short Mathlib search.
+
+**Estimated Effort**:
+- Exploration: a few hours (pin the rpow-product lemma name and root spelling).
+- If tractable: **~1 day** for a 0-axiom file with the headline `Fin n` iff and a
+  couple of convenience corollaries.
+- If hard: n/a — this is not expected to be hard.
+
+## References
+
+### Papers
+- Hardy, G. H.; Littlewood, J. E.; Pólya, G., *Inequalities*, Cambridge University
+  Press, 1934 — the classical treatment of AM-GM and its equality case (the
+  equal-weight statement is the canonical Theorem 9 form).
+- Steele, J. Michael, *The Cauchy–Schwarz Master Class*, Cambridge University Press,
+  2004 — AM-GM, Jensen, and the role of strict convexity in equality cases.
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Inequality_of_arithmetic_and_geometric_means —
+  statement of AM-GM, the equal-weight equality case, and the convexity proof.
+
+### Mathlib
+- `Mathlib.Analysis.MeanInequalities` — the weighted AM-GM inequality and the
+  `Real.geom_mean_le_arith_mean*_weighted` / `Real.inner_le_weight_mul_Lp` family the
+  parent builds on.
+- `Mathlib.Analysis.Convex.SpecificFunctions.Basic` — `strictConcaveOn_log_Ioi`
+  (imported transitively through the parent's equality characterisation).
+- `Mathlib.Analysis.SpecialFunctions.Pow.Real` /
+  `Mathlib.Analysis.SpecialFunctions.Pow.NNRpow` — `Real.rpow`,
+  `Real.rpow_pos_of_pos`, and the lemma of the form $(\prod_i x_i)^r = \prod_i x_i^r$
+  for the geometric-side rewrite.
+- `Mathlib.Algebra.BigOperators.Ring.Finset` (`Finset.mul_sum`, `Finset.sum_div`) —
+  reshaping $\sum (1/n) x_i$ into $(\sum x_i)/n$.
+- `Mathlib.Algebra.BigOperators.Basic` (`Finset.sum_const`, `Finset.card_univ`) plus
+  `Fintype.card_fin` — the $\sum 1/n = 1$ normalisation.
+- The parent file `Proofs/AmgmInequalityOQ05OQ02.lean`
+  (`weighted_amgm_eq_iff`, `weighted_amgm_eq_iff_pairwise`) — imported directly and
+  instantiated at `w i = 1/n`.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - inequalities
+  - amgm
+  - equality-case
+  - convexity
+  - jensen
+related_proofs:
+  - amgm-inequality-oq-05-oq-02
+  - amgm-inequality-oq-05
+  - amgm-inequality
+difficulty: low
+source: gallery-gap
+created: 2026-06-30
+```

--- a/research/problems/amgm-inequality-oq-05-oq-02-oq-01/state.md
+++ b/research/problems/amgm-inequality-oq-05-oq-02-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: amgm-inequality-oq-05-oq-02-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-30T23:06:21-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/knowledge.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/literature/README.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/problem.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/problem.md
@@ -1,0 +1,266 @@
+# Problem: Vandermonde Convolution for Rising/Falling Factorials over a Commutative Ring
+
+**Slug**: arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The parent entry proved the numerical falling-factorial Vandermonde identity over
+$\mathbb{N}$:
+$(m+n)^{\underline{r}} = \sum_{j=0}^{r} \binom{r}{j}\, m^{\underline{j}}\, n^{\underline{r-j}}$.
+This child asks for the **umbral / polynomial generalization** to an arbitrary
+commutative ring $R$ with two *ring elements* $x, y \in R$ (not just natural numbers).
+
+Let the **rising factorial** of $x \in R$ at $k$ be
+$$
+x^{(k)} \;=\; \prod_{i=0}^{k-1} (x + i) \;=\; x\,(x+1)\cdots(x+k-1),
+\qquad x^{(0)} = 1 .
+$$
+The claim to formalize is the rising-factorial Vandermonde (umbral binomial theorem):
+$$
+(x+y)^{(r)} \;=\; \sum_{j=0}^{r} \binom{r}{j}\; x^{(j)}\; y^{(r-j)}
+\qquad\text{for all } x, y \in R,\ r \in \mathbb{N},
+$$
+where $\binom{r}{j} \in \mathbb{N}$ acts on the ring element by the natural
+`nsmul`/`Nat.cast` scalar action.
+
+A concrete Lean theorem signature (self-contained rising-factorial definition):
+
+```lean
+open Finset
+
+/-- Rising factorial of a ring element: x^{(k)} = x·(x+1)···(x+k-1). -/
+def risingFactorial {R : Type*} [CommRing R] (x : R) : ℕ → R
+  | 0     => 1
+  | k + 1 => risingFactorial x k * (x + k)
+
+/-- Vandermonde convolution for rising factorials over any commutative ring. -/
+theorem risingFactorial_add {R : Type*} [CommRing R] (x y : R) (r : ℕ) :
+    risingFactorial (x + y) r
+      = ∑ j ∈ Finset.range (r + 1),
+          (r.choose j : R) * risingFactorial x j * risingFactorial y (r - j) := by
+  sorry
+```
+
+The **falling-factorial variant** is the mirror statement with
+$x^{\underline{k}} = x(x-1)\cdots(x-k+1)$:
+$$
+(x+y)^{\underline{r}} \;=\; \sum_{j=0}^{r} \binom{r}{j}\; x^{\underline{j}}\; y^{\underline{r-j}} ,
+$$
+which follows from the rising form by the reflection $x^{\underline{k}} = (-1)^k (-x)^{(k)}$,
+or is proved by the identical induction.
+
+### Plain Language
+
+The ordinary binomial theorem expands $(x+y)^r$ into a sum of $\binom{r}{j} x^j y^{r-j}$.
+There is an exact analogue where the *ordinary powers* $x^j$ are replaced by
+**factorial powers** — the rising factorial $x^{(j)} = x(x+1)\cdots(x+j-1)$ or the falling
+factorial $x^{\underline{j}} = x(x-1)\cdots(x-j+1)$. In that world $(x+y)^{(r)}$ expands
+into $\sum_j \binom{r}{j} x^{(j)} y^{(r-j)}$ with the *same* binomial coefficients. The
+parent gallery entry proved this for whole-number arguments $m, n$; here we lift it to
+genuine polynomial identities valid for any elements $x, y$ of any commutative ring, which
+is the version used in umbral calculus and finite-difference theory.
+
+### Why This Matters
+
+The numerical form over $\mathbb{N}$ is a corollary of the polynomial form, so this
+generalization is the "real" theorem: it is the binomial theorem for the **finite
+difference operator** $\Delta f(x) = f(x+1) - f(x)$, for which the rising/falling
+factorials are the analogue of monomials. Formalizing it gives Mathlib a genuinely missing
+result: while Mathlib has `ascPochhammer R n : R[X]` and `descPochhammer R n : R[X]` with a
+full library of `succ`/`eval`/`ascFactorial` lemmas, it has **no** `ascPochhammer_add`
+(Vandermonde/binomial-convolution) lemma. Supplying it — either as an identity of
+polynomials in `R[X]` or, as above, of evaluated ring elements — closes a concrete gap and
+provides the "product rule" for expanding polynomials in the factorial basis.
+
+## Known Results
+
+### What's Already Proven
+
+- **Falling-factorial Vandermonde over $\mathbb{N}$** — parent gallery entry
+  `arithmetic-series-oq-02-oq-04-oq-01-oq-03` (verified, 0 axioms):
+  $(m+n)^{\underline{r}} = \sum_j \binom{r}{j} m^{\underline{j}} n^{\underline{r-j}}$ for
+  $m,n,r \in \mathbb{N}$, derived from the standard Vandermonde convolution by multiplying
+  through by $r!$ and using `Nat.descFactorial_eq_factorial_mul_choose`.
+- **Standard Vandermonde convolution** $\binom{m+n}{r} = \sum_j \binom{m}{j}\binom{n}{r-j}$
+  — gallery entry `binomial-theorem-oq-03` (`vandermonde_range`).
+- **Ordinary binomial theorem in a commutative (semi)ring** — Mathlib
+  `Commute.add_pow` / `add_pow` (`Mathlib.Data.Nat.Choose.Sum`):
+  $(x+y)^r = \sum_j \binom{r}{j} x^j y^{r-j}$, the exact structural template for the
+  factorial-power version.
+- **Pochhammer infrastructure** — `ascPochhammer`, `descPochhammer`,
+  `ascPochhammer_succ_right`, `ascPochhammer_succ_left`,
+  `ascPochhammer_nat_eq_ascFactorial`, `ascPochhammer_nat_eq_descFactorial`,
+  `Nat.factorial_mul_ascFactorial`, `Nat.add_descFactorial_eq_ascFactorial'`
+  (`Mathlib.RingTheory.Polynomial.Pochhammer`, `Mathlib.Data.Nat.Factorial.Basic`).
+
+### What's Still Open
+
+- No Mathlib lemma of the form `ascPochhammer_add` — the binomial convolution for factorial
+  powers is absent from the pochhammer file (only `succ_left`/`succ_right`/`eval` lemmas
+  exist).
+- No commutative-ring-level statement `(x+y)^{(r)} = ∑ j, C(r,j) x^{(j)} y^{(r-j)}` for ring
+  elements $x, y$ (only the $\mathbb{N}$-valued numerical special case in the parent).
+- No unified rising-vs-falling packaging tying the two forms together through the
+  reflection $x^{\underline{k}} = (-1)^k(-x)^{(k)}$.
+
+### Our Goal
+
+Formalize the rising-factorial Vandermonde `risingFactorial_add` over an arbitrary
+`CommRing R` (statement above), with the falling-factorial mirror `fallingFactorial_add` as
+a companion. Recover the parent's $\mathbb{N}$ result as a corollary by specializing
+$x = m$, $y = n$ and matching `risingFactorial (m : R) k` with the `Nat.ascFactorial`/
+`Nat.descFactorial` numerics. Optionally state the same identity at the polynomial level in
+`R[X]` using `ascPochhammer` to plug the concrete Mathlib gap.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| arithmetic-series-oq-02-oq-04-oq-01-oq-03 | Direct parent: numerical falling-factorial Vandermonde over $\mathbb{N}$; this problem lifts it to ring elements | `Nat.descFactorial_eq_factorial_mul_choose`, `Finset.sum_congr`, `vandermonde_range` |
+| binomial-theorem-oq-03 | Supplies `vandermonde_range`, the standard convolution underlying the numerical corollary | Coefficient extraction, `Finset.range` sums |
+| binomial-theorem | Ordinary $(x+y)^r$ theorem; structural template (`Commute.add_pow`) for the factorial-power version | Pascal's rule, induction on $r$, `Finset.mul_sum` |
+| arithmetic-series-oq-02-oq-04 | Rising-factorial power-sum identity $S_k(n)\cdot k! = (n+1)^{\overline{k}}$ | `Nat.ascFactorial`, factorial bookkeeping |
+| arithmetic-series-oq-02-oq-01-oq-01 | $q$-Vandermonde identity — $q$-deformation of the same convolution | $q$-binomial coefficients |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Induction on $r$ with Pascal's rule (recommended).**
+   Mirror the proof of `Commute.add_pow`. Base case $r = 0$ is $1 = 1$. For the step, use
+   the rising-factorial recurrence $x^{(r+1)} = x^{(r)}\,(x+r)$ and its shifted companion
+   $(x+y)^{(r+1)} = (x+y)^{(r)}\,(x+y+r)$; expand the inductive hypothesis, split
+   $(x+y+r)$ appropriately, and re-index so that the two resulting sums recombine via
+   Pascal's rule $\binom{r}{j-1} + \binom{r}{j} = \binom{r+1}{j}$ (`Nat.choose_succ_succ` /
+   `Finset.sum_range_succ'`).
+   - Why it might work: it is the exact architecture of the verified ordinary binomial
+     theorem, with $x^j \mapsto x^{(j)}$; the algebraic identities needed are all present.
+   - Risk: the friction is the rising-factorial *product-shift* bookkeeping
+     ($x^{(j)}\cdot(\dots)$ recombining across the two shifted sums) and the
+     $\mathbb{N}$-subtraction in `r - j`, which must be handled with `Finset.range`
+     re-indexing (`Finset.sum_range_succ`, `Finset.sum_range_succ'`).
+
+2. **Approach B — Derive from the numerical parent by polynomial identity.**
+   Because both sides are polynomials in $x, y$ of bounded degree, an identity holding for
+   all natural-number substitutions $x = m, y = n$ holds identically (a polynomial vanishing
+   on all of $\mathbb{N}^2$ is the zero polynomial over an infinite integral domain, then
+   transfer via a ring hom $\mathbb{Z}[X,Y] \to R$).
+   - Why it might work: reuses the already-verified parent as a black box.
+   - Risk: setting up the "agrees on $\mathbb{N}$ $\Rightarrow$ equal as polynomials
+     $\Rightarrow$ equal in every $R$" transfer is heavier in Lean than a direct induction,
+     and needs `MvPolynomial` eval machinery; likely more work than Approach A.
+
+3. **Approach C — Polynomial-level `ascPochhammer` statement.**
+   Prove the convolution directly in `R[X]` for `ascPochhammer R r`, using
+   `ascPochhammer_succ_right`/`_left` and `ascPochhammer_succ_comp_X_add_one`, then evaluate.
+   - Why it might work: yields a reusable Mathlib-shaped `ascPochhammer_add` lemma.
+   - Risk: composition/`.comp (X + C ·)` bookkeeping on polynomials is fiddlier than the
+     elementwise recurrence.
+
+### Key Difficulties
+
+- **Rising-vs-falling and index bookkeeping.** The summand is
+  $\binom{r}{j}\,x^{(j)}\,y^{(r-j)}$ with $\mathbb{N}$-subtraction `r - j`; the induction
+  step multiplies by a *shifted* linear factor $(x+y+r)$ that must be routed into either the
+  $x$-factor or the $y$-factor, forcing careful `Finset.range` re-indexing — the same
+  friction that makes `Commute.add_pow` a nontrivial proof.
+- **Scalar action of $\binom{r}{j}$.** Over a general `CommRing`, $\binom{r}{j}$ is a
+  natural number acting by `Nat.cast`/`nsmul`; the algebra must keep casts and `•` coherent
+  (`nsmul_eq_mul`, `Nat.cast_mul`, `push_cast`).
+- **No off-the-shelf `ascPochhammer_add`.** The would-be one-line reuse does not exist in
+  Mathlib, so the content really has to be proved, not merely rewritten.
+
+### What Would a Proof Need?
+
+- Key lemma 1: the rising-factorial recurrence
+  `risingFactorial x (k+1) = risingFactorial x k * (x + k)` (definitional) plus a shifted
+  form suitable for splitting $(x+y+r)$.
+- Key lemma 2: Pascal's rule re-indexing combining $\sum_j \binom{r}{j}(\cdots)$ shifted by
+  one into $\sum_j \binom{r+1}{j}(\cdots)$ via `Finset.sum_range_succ'` and
+  `Nat.choose_succ_succ`.
+- Key lemma 3: the numerical corollary bridge
+  `risingFactorial (m : R) k = (Nat.ascFactorial m k : R)` (and the descFactorial mirror),
+  used to recover the parent identity.
+- Technical requirements: `Finset.mul_sum`, `Finset.sum_congr`, `push_cast`/`nsmul_eq_mul`,
+  and — for Approach C — `ascPochhammer_succ_right`, `ascPochhammer_nat_eq_ascFactorial`.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The **rising-factorial induction (Approach A) is Medium**: it is a faithful port of the
+  verified `Commute.add_pow` / binomial theorem with $x^j$ replaced by $x^{(j)}$, and all
+  supporting recurrences and Pascal-rule lemmas already exist in Mathlib. The main effort is
+  the product-shift and `range`-reindex bookkeeping, not new mathematics.
+- The **falling-factorial variant** is either an independent identical induction or a short
+  corollary via $x^{\underline{k}} = (-1)^k(-x)^{(k)}$.
+- Similar solved problems: the parent numerical entry and Mathlib's own `add_pow` show the
+  technique closes end-to-end with 0 axioms.
+- Risk factors: $\mathbb{N}$-subtraction in `r - j` and cast/`nsmul` coherence are the usual
+  sources of iteration; the polynomial-`ascPochhammer` route (Approach C) is higher-friction.
+
+**Estimated Effort**:
+- Exploration: 0.5–1 day (fix the `risingFactorial` interface, confirm the induction plan).
+- If tractable (Approach A, rising + falling + numerical corollary): 2–4 days for a 0-axiom
+  file.
+- If hard (polynomial `ascPochhammer_add` in `R[X]`, Approach C): +1–2 days.
+
+## References
+
+### Papers
+- Graham, R. L., Knuth, D. E., & Patashnik, O. (1994). *Concrete Mathematics*, 2nd ed.,
+  Addison-Wesley — §2.6 and §5.1 on rising/falling factorial powers and the factorial-power
+  (Vandermonde) binomial theorem.
+- Roman, S. (1984). *The Umbral Calculus*, Academic Press — binomial-type polynomial
+  sequences and the binomial theorem for the lower/upper factorial bases.
+- Rota, G.-C., Kahaner, D., & Odlyzko, A. (1973). On the Foundations of Combinatorial
+  Theory VIII: Finite Operator Calculus. *J. Math. Anal. Appl.* 42(3), 684–760.
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Vandermonde%27s_identity — Vandermonde/Chu convolution and
+  its factorial-power form.
+- https://en.wikipedia.org/wiki/Falling_and_rising_factorials — identities including the
+  binomial theorem for rising/falling factorials.
+- https://en.wikipedia.org/wiki/Umbral_calculus — the operator-calculus viewpoint.
+
+### Mathlib
+- `Mathlib.RingTheory.Polynomial.Pochhammer` — `ascPochhammer`, `descPochhammer`,
+  `ascPochhammer_succ_right`, `ascPochhammer_succ_left`,
+  `ascPochhammer_nat_eq_ascFactorial`, `ascPochhammer_nat_eq_descFactorial` (the polynomial
+  factorial-power infrastructure; note: no `ascPochhammer_add` exists — the gap this problem
+  fills).
+- `Mathlib.Data.Nat.Choose.Sum` — `Commute.add_pow` / `add_pow` (the ordinary binomial
+  theorem; structural template for the induction).
+- `Mathlib.Data.Nat.Choose.Basic` — `Nat.choose_succ_succ` (Pascal's rule),
+  `Nat.choose_mul_factorial_mul_factorial`.
+- `Mathlib.Data.Nat.Factorial.Basic` — `Nat.ascFactorial`, `Nat.descFactorial`,
+  `Nat.descFactorial_eq_factorial_mul_choose`, `Nat.factorial_mul_ascFactorial`,
+  `Nat.add_descFactorial_eq_ascFactorial'` (numerical-corollary bridge).
+- `Mathlib.Algebra.BigOperators.Ring.Finset` — `Finset.mul_sum`, `Finset.sum_range_succ'`
+  (constant-factoring and re-indexing in the induction step).
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - rising-factorial
+  - falling-factorial
+  - vandermonde
+  - pochhammer
+  - umbral-calculus
+related_proofs:
+  - arithmetic-series-oq-02-oq-04-oq-01-oq-03
+  - binomial-theorem-oq-03
+  - binomial-theorem
+  - arithmetic-series-oq-02-oq-04
+difficulty: medium
+source: gallery-gap
+created: 2026-06-30
+```

--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/state.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-30T23:06:21-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/automorphic-number-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/automorphic-number-oq-01-oq-02-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: automorphic-number-oq-01-oq-02-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/automorphic-number-oq-01-oq-02-oq-01/literature/README.md
+++ b/research/problems/automorphic-number-oq-01-oq-02-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for automorphic-number-oq-01-oq-02-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/automorphic-number-oq-01-oq-02-oq-01/problem.md
+++ b/research/problems/automorphic-number-oq-01-oq-02-oq-01/problem.md
@@ -1,0 +1,272 @@
+# Problem: Idempotents of ℤ/mᵏ — Counting, Complementation, and the Boolean Algebra of Rank ω(m)
+
+**Slug**: automorphic-number-oq-01-oq-02-oq-01
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The parent entry pins down the idempotents of `ZMod (10 ^ k)` — the automorphic residues
+`n² ≡ n (mod 10^k)` — proving there are exactly four and that they split into two
+complementary pairs `{0, 1}` and `{…5, …6}`. This problem removes the base `10` entirely
+and describes the idempotent structure of `ZMod (m ^ k)` for **arbitrary** `m ≥ 2`.
+
+Let `m ≥ 2` and `k ≥ 1`. The claim is that the number of idempotents of the ring
+`ZMod (m ^ k)` depends only on the number of **distinct primes** of `m` (not on `k`):
+
+$$
+\#\{\, e \in \mathbb{Z}/m^k \mathbb{Z} : e^2 = e \,\} \;=\; 2^{\omega(m)},
+\qquad \omega(m) = \#\{\text{distinct primes dividing } m\}.
+$$
+
+Concretely, the target Lean statement is:
+
+```lean
+theorem card_idempotents_eq_two_pow_omega (m k : ℕ) (hm : 2 ≤ m) (hk : 1 ≤ k) :
+    Fintype.card {e : ZMod (m ^ k) // IsIdempotentElem e}
+      = 2 ^ m.primeFactors.card
+```
+
+where `m.primeFactors.card = ω(m)` (Mathlib's `ArithmeticFunction.cardDistinctFactors`,
+notation `ω`, satisfies `ω m = m.primeFactorsList.dedup.length = m.primeFactors.card`).
+
+Two structural refinements accompany the count:
+
+1. **Complementation involution (primary secondary goal).** The map `e ↦ 1 - e` sends
+   idempotents to idempotents (`IsIdempotentElem.one_sub`), is an involution
+   (`1 - (1 - e) = e`), and pairs the `2^ω(m)` idempotents by orthogonal complementation
+   `e ↔ 1 - e` with `e + (1 - e) = 1` and `e · (1 - e) = 0`:
+
+   ```lean
+   theorem compl_involutive (m k : ℕ) :
+       Function.Involutive
+         (fun e : {e : ZMod (m ^ k) // IsIdempotentElem e} => eᶜ)
+   ```
+
+   (Mathlib already provides `HasCompl {a // IsIdempotentElem a}` with `↑aᶜ = 1 - ↑a` and
+   `compl_compl`, so this refinement is largely a repackaging.)
+
+2. **Boolean algebra of rank ω(m) (stretch goal).** The idempotents form a Boolean
+   algebra under meet `a ∧ b := a · b`, join `a ∨ b := a + b − a·b`, and complement
+   `¬a := 1 − a`; as a Boolean algebra it is isomorphic to the power set
+   `𝒫(primeFactors m) ≅ (Bool)^{ω(m)}`, hence has rank `ω(m)` and `2^{ω(m)}` elements.
+
+### Plain Language
+
+An "automorphic" number is one whose square ends in the same digits as itself
+(`76² = 5776`). Working base `10`, these are exactly the residues `e` mod `10^k` with
+`e² = e` — the idempotents of the ring `ℤ/10^k`. There are always four of them, and the
+parent entry showed they come in two complementary pairs. But `10 = 2·5` has two prime
+factors, and *that* is the real reason there are `4 = 2²` of them. Replace `10` by any
+`m`: the number of idempotents of `ℤ/mᵏ` is `2` raised to the number of *distinct primes*
+of `m`. So `ℤ/12ᵏ` (with `12 = 2²·3`, two primes) also has `4` idempotents, `ℤ/30ᵏ`
+(`30 = 2·3·5`, three primes) has `8`, and `ℤ/pᵏ` for a prime power has only the boring two
+(`0` and `1`). The exponent `k` never matters. Moreover these idempotents form a Boolean
+algebra — a "power set in disguise" — of the set of primes of `m`, and the pairing
+`e ↔ 1 − e` is exactly set-complementation.
+
+### Why This Matters
+
+This is the *correct* level of generality for the automorphic-number phenomenon: the count
+`2^ω(m)` and the complementary-pairing structure are consequences of the Chinese Remainder
+Theorem and the fact that a finite local ring has only the two trivial idempotents, and
+have nothing to do with the specific base `10`. Formalizing it converts the parent's
+concrete `{0, 1, …5, …6}` computation into the structural statement it is a shadow of, and
+exhibits the idempotents of `ZMod (m^k)` as the Boolean algebra `𝒫(primeFactors m)`. It
+also exercises a reusable pattern — decompose a `ZMod` via CRT into a product of local
+rings, then count/structure a ring-theoretic invariant factor by factor — that recurs
+throughout elementary number theory (units, nilpotents, zero-divisors, idempotents).
+
+## Known Results
+
+### What's Already Proven
+
+- **Complementary pairing mod 10^k** (`0` axioms) — gallery parent
+  `automorphic-number-oq-01-oq-02`: the four idempotents of `ZMod (10^k)` are exactly
+  `{0, 1, a, 1-a}`, orthogonal complements, with last-digit uniqueness. The `m = 10`
+  case of this problem, done by hand.
+- **The count is 2^ω(n)** — gallery entry `automorphic-number-oq-01` (first follow-up),
+  which already frames the mod-`10^k` count `4` as `2^ω(10) = 2²`.
+- **Idempotent algebra in a commutative ring** — Mathlib `Mathlib.Algebra.Ring.Idempotent`:
+  `IsIdempotentElem.one_sub`, `one_sub_iff`, `mul_one_sub_self` (`a·(1-a)=0`),
+  `HasCompl {a // IsIdempotentElem a}` with `coe_compl : ↑aᶜ = 1 - ↑a`, `compl_compl`,
+  `zero_compl`, `one_compl`, and the Boolean-operation lemma `add_sub_mul`
+  (`IsIdempotentElem (a + b - a*b)`).
+- **CRT for ZMod** — `ZMod.chineseRemainder : m.Coprime n → ZMod (m*n) ≃+* ZMod m × ZMod n`.
+- **Complete orthogonal idempotents and the product decomposition** —
+  `Mathlib.RingTheory.Idempotents`: `CompleteOrthogonalIdempotents`, `bijective_pi`, and
+  `pair_iffₛ : CompleteOrthogonalIdempotents ![x, y] ↔ x*y = 0 ∧ x + y = 1`.
+- **ω is additive on coprime products** — `ArithmeticFunction.cardDistinctFactors_mul`,
+  `cardDistinctFactors_apply_prime_pow (hp : p.Prime) (hk : k ≠ 0) : ω (p^k) = 1`.
+
+### What's Still Open
+
+- No Lean statement of `#{e : ZMod (m^k) // e² = e} = 2^ω(m)` for general `m`.
+- No formal identification of the idempotents of `ZMod (m^k)` with subsets of
+  `primeFactors m`, nor of the Boolean-algebra isomorphism to `𝒫(primeFactors m)`.
+- No general "local ring / prime-power `ZMod` has only trivial idempotents" bridge wired
+  to the count (the parent proves this only implicitly for `10^k` via its `4`-count).
+
+### Our Goal
+
+Prove `card_idempotents_eq_two_pow_omega` with `0` axioms: the idempotent count of
+`ZMod (m^k)` is `2^ω(m)`, independent of `k`. Then upgrade to the complementation
+involution `e ↦ 1 - e` (largely a repackaging of Mathlib's `HasCompl`/`compl_compl`), and,
+as a stretch goal, the full Boolean-algebra isomorphism with `𝒫(primeFactors m)`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| automorphic-number-oq-01-oq-02 | Direct parent: the `m = 10` complementary-pairing case, done concretely | `IsNilpotent`, tripotent identity, `Finset.card`, `decide` |
+| automorphic-number-oq-01 | First follow-up: frames the mod-`10^k` count as `2^ω(10)` | CRT count, `Nat.factorization` |
+| automorphic-number | Base entry: automorphic numbers `n² ≡ n (mod 10^k)` as idempotents | `ZMod`, idempotency |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — CRT into local factors, count idempotents in the product (recommended).**
+   Write `m^k = ∏_{p ∈ primeFactors m} p^{k·v_p(m)}`; the factors are pairwise coprime, so
+   iterating `ZMod.chineseRemainder` gives a ring isomorphism
+   `ZMod (m^k) ≃+* ∏_{p ∈ primeFactors m} ZMod (p^{k·v_p(m)})`. Idempotents transport
+   across a ring isomorphism, and an idempotent of a product ring is exactly a tuple of
+   idempotents of the factors (`IsIdempotentElem` in `R × S` ↔ a pair of idempotents —
+   provable directly from `Prod.ext` / componentwise multiplication). Each factor
+   `ZMod (p^a)` (with `a ≥ 1`) is a **local ring**, so its only idempotents are `0` and
+   `1`. Hence idempotents of `ZMod (m^k)` correspond bijectively to functions
+   `primeFactors m → {0,1}`, i.e. to `Finset.powerset (primeFactors m)`, giving the count
+   `2^{ω(m)}` and, simultaneously, the Boolean structure and the `e ↦ 1-e` = set-complement
+   pairing.
+   - Why it might work: every ingredient exists in Mathlib — `ZMod.chineseRemainder`,
+     `Fintype.card_congr` for the idempotent-subtype equivalence, `Finset.card_powerset`,
+     and `cardDistinctFactors_apply_prime_pow`.
+   - Risk: the CRT bookkeeping is over a `Finset` (`Finset.prod`), so the product-ring
+     decomposition is an iterated / dependent product `∀ p ∈ s, ZMod (…)`; managing the
+     coprimality side conditions and the dependent `Fintype.card` of the idempotent
+     subtype of a `Π`-type is the main labor.
+
+2. **Approach B — Prove the two-idempotent lemma for `ZMod (p^a)` first, then induct on
+   `primeFactors m`.**
+   Establish `Fintype.card {e : ZMod (p^a) // IsIdempotentElem e} = 2` for prime `p`,
+   `a ≥ 1` (local ring), then peel one prime at a time using
+   `ZMod.chineseRemainder` and the product rule
+   `card_idem(R × S) = card_idem(R) · card_idem(S)`, accumulating the factor `2` per prime.
+   `cardDistinctFactors_mul` gives `ω(m·m') = ω(m)+ω(m')` on coprime pieces, matching the
+   doubling.
+   - Why it might work: reduces the whole problem to a clean single-prime lemma plus a
+     coprime-multiplicativity induction; avoids a global dependent product.
+   - Risk: setting up the coprime factorization `m = ∏ p^{v_p(m)}` and threading the
+     induction over `Finset` still needs care; the `Fintype.card` product lemma for the
+     idempotent subtype of `R × S` must be proved from scratch.
+
+### Key Difficulties
+
+- **`ZMod (p^a)` has exactly two idempotents.** This needs a "local ring / no nontrivial
+  idempotents" argument. Two routes: (i) `ZMod (p^a)` is local (`IsLocalRing`), and a
+  local ring has only trivial idempotents; or (ii) reuse the parent's engine —
+  the maximal ideal `(p)` is nil, two idempotents with nilpotent difference coincide, and
+  modulo `p` the ring is the field `ZMod p` with only `0, 1`. A clean Lean lemma of the
+  form `IsIdempotentElem e → e = 0 ∨ e = 1` for `ZMod (p^a)` is the crux.
+- **Product-ring idempotents.** `IsIdempotentElem (x, y) ↔ IsIdempotentElem x ∧
+  IsIdempotentElem y`, and the corresponding `Fintype.card` factorization
+  `card {e : R×S // IsIdempotentElem e} = card{·:R//·} · card{·:S//·}`. Straightforward but
+  must be built (via `Equiv` to a sigma/product of subtypes), then iterated over a `Finset`.
+- **CRT indexing over `primeFactors`.** Assembling `ZMod (m^k) ≃+* Π p ∈ primeFactors m,
+  ZMod (p^{k·v_p(m)})` from binary `ZMod.chineseRemainder` requires an induction on the
+  prime factorization with pairwise-coprimality obligations (`Nat.Coprime.pow`,
+  `Nat.coprime`-of-distinct-primes facts).
+- **`k` must genuinely drop out.** The exponent `k·v_p(m) ≥ 1` keeps each factor a
+  nontrivial local ring with exactly two idempotents; the count `2` per prime is
+  independent of that exponent, which is why `k` never appears in `2^ω(m)` — this needs to
+  be visible in the proof, not accidental.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `∀ p a, p.Prime → 1 ≤ a → Fintype.card {e : ZMod (p^a) // IsIdempotentElem e}
+  = 2` (local / prime-power ring has only trivial idempotents).
+- Key lemma 2: idempotent-subtype cardinality is multiplicative across a ring product /
+  `ZMod.chineseRemainder`, i.e. `card_idem (ZMod (m*n)) = card_idem (ZMod m) · card_idem
+  (ZMod n)` for `m.Coprime n`.
+- Key lemma 3: `m = ∏ p ∈ primeFactors m, p^{v_p(m)}` with pairwise coprime factors
+  (`Nat.factorization` / `Nat.prod_primeFactors`), lifted to the `k`-th power.
+- Assembly: fold lemmas 1–3 to get `2^{ω(m)}` via `Finset.card_powerset` /
+  `cardDistinctFactors_mul`, then attach the `e ↦ 1-e` involution (`IsIdempotentElem.one_sub`,
+  `compl_compl`) and, for the stretch goal, the Boolean-algebra isomorphism to
+  `𝒫(primeFactors m)` using `add_sub_mul` for the join.
+
+## Tractability Assessment
+
+**Difficulty**: Moderate
+
+**Justification**:
+- The **count `2^ω(m)` is Moderate**: all the Mathlib pieces exist
+  (`ZMod.chineseRemainder`, `Fintype.card_congr`, `Finset.card_powerset`,
+  `cardDistinctFactors_apply_prime_pow` / `_mul`), and the parent already demonstrates the
+  local-ring idempotent-uniqueness engine (`IsNilpotent`, tripotent identity) in the
+  `10^k` case. The two genuinely new sub-lemmas are (i) `ZMod (p^a)` has exactly two
+  idempotents and (ii) idempotent-count multiplicativity over a coprime product / CRT.
+- The **CRT-over-`primeFactors` indexing is the main labor**: assembling the binary CRT
+  isomorphism into a `Finset`-indexed product and computing the `Fintype.card` of the
+  idempotent subtype of that dependent product is fiddly but standard.
+- The **Boolean-algebra isomorphism to `𝒫(primeFactors m)` is a stretch goal**: Mathlib
+  supplies the operations (`add_sub_mul`, `HasCompl`), but packaging them into a
+  `BooleanAlgebra` instance and proving the iso to `Finset.powerset` is extra work beyond
+  the count.
+- Similar solved problems: the parent `automorphic-number-oq-01-oq-02` (hand proof for
+  `m=10`) and Mathlib's `CompleteOrthogonalIdempotents.bijective_pi` (product-ring
+  idempotent decomposition) show the technique is in reach.
+
+**Estimated Effort**:
+- Exploration: 1–2 days (fix the two-idempotent local-ring lemma and the CRT product form).
+- If tractable (count + involution): 4–7 days for a `0`-axiom file.
+- If hard (full Boolean-algebra iso to `𝒫(primeFactors m)`): +3–5 days.
+
+## References
+
+### Books
+- Ireland, K. and Rosen, M., *A Classical Introduction to Modern Number Theory*, 2nd ed.,
+  Springer GTM 84, 1990 — CRT for `ℤ/nℤ`, structure of `ℤ/p^kℤ` as a local ring, and
+  idempotents / the number of solutions of `x² = x`.
+- Atiyah, M. F. and Macdonald, I. G., *Introduction to Commutative Algebra*, 1969 —
+  idempotents, local rings, and the product decomposition of a ring via a complete set of
+  orthogonal idempotents.
+
+### Mathlib
+- `Mathlib.Data.ZMod.Basic` (`ZMod.chineseRemainder`, `ZMod.natCast_self`) — the CRT ring
+  isomorphism `ZMod (m*n) ≃+* ZMod m × ZMod n` and the nilpotency of the residue.
+- `Mathlib.Algebra.Ring.Idempotent` (`IsIdempotentElem`, `one_sub`, `mul_one_sub_self`,
+  `HasCompl` on the idempotent subtype, `compl_compl`, `add_sub_mul`) — the complement and
+  Boolean operations.
+- `Mathlib.RingTheory.Idempotents` (`CompleteOrthogonalIdempotents`, `bijective_pi`,
+  `pair_iffₛ`) — the product-ring idempotent decomposition machinery.
+- `Mathlib.NumberTheory.ArithmeticFunction.Misc`
+  (`ArithmeticFunction.cardDistinctFactors`, notation `ω`, `cardDistinctFactors_apply`,
+  `cardDistinctFactors_apply_prime_pow`, `cardDistinctFactors_mul`) — `ω(m)` and its
+  values on prime powers and coprime products.
+- `Mathlib.Data.Nat.Factorization.Basic` (`Nat.factorization`, `Nat.primeFactors`,
+  `Nat.prod_primeFactors`) — the coprime prime-power factorization `m = ∏ p^{v_p(m)}`.
+- `Mathlib.Data.Finset.Powerset` (`Finset.card_powerset : (s.powerset).card = 2 ^ s.card`)
+  — the final `2^{ω(m)}` count.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - idempotents
+  - zmod
+  - chinese-remainder-theorem
+  - boolean-algebra
+  - automorphic-numbers
+related_proofs:
+  - automorphic-number-oq-01-oq-02
+  - automorphic-number-oq-01
+  - automorphic-number
+difficulty: moderate
+source: gallery-gap
+created: 2026-06-30
+```

--- a/research/problems/automorphic-number-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/automorphic-number-oq-01-oq-02-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: automorphic-number-oq-01-oq-02-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-30T23:06:21-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/knowledge.md
+++ b/research/problems/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: cauchy-schwarz-oq-01-oq-02-oq-01-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/literature/README.md
+++ b/research/problems/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for cauchy-schwarz-oq-01-oq-02-oq-01-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/problem.md
+++ b/research/problems/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/problem.md
@@ -1,0 +1,285 @@
+# Problem: From Rank-One to Finite-Rank — Projection onto a Subspace as a Sum of Rank-One Projectors
+
+**Slug**: cauchy-schwarz-oq-01-oq-02-oq-01-oq-03
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let $\mathbb{K}$ be $\mathbb{R}$ or $\mathbb{C}$ (an `RCLike` field) and let $E$ be an
+inner product space over $\mathbb{K}$. Let $e : \mathrm{Fin}\,k \to E$ be an
+**orthonormal family**, i.e. $\langle e_i, e_j\rangle = \delta_{ij}$, and let
+$S = \operatorname{span}_{\mathbb{K}}(\operatorname{range} e)$ be the
+$k$-dimensional subspace it spans. Write $P_S$ for the orthogonal projection onto
+$S$. The claim is the finite-rank generalization of the parent's rank-one projector:
+
+$$
+P_S\,x \;=\; \sum_{i=1}^{k} \langle e_i, x\rangle \, e_i
+\qquad\text{for every } x \in E,
+$$
+
+that is, $P_S$ is the **sum of the rank-one orthogonal projectors**
+$x \mapsto \langle e_i, x\rangle\,e_i$ over the orthonormal family, together with the
+**Parseval / Bessel equality on $S$**:
+
+$$
+\lVert P_S\,x\rVert^{2} \;=\; \sum_{i=1}^{k} \bigl\lvert \langle e_i, x\rangle\bigr\rvert^{2}
+\qquad\text{for every } x \in E.
+$$
+
+For $k = 1$ (a single unit vector $e_0 = v/\lVert v\rVert$) both statements collapse to
+the parent entry's rank-one facts $P_{\{v\}}x = \langle e_0,x\rangle\,e_0$ and
+$\lVert P_{\{v\}}x\rVert = \lvert\langle e_0,x\rangle\rvert$.
+
+A concrete Lean signature (real scalars shown; the file will be stated over an
+arbitrary `RCLike` field) reads:
+
+```lean
+open scoped InnerProductSpace RealInnerProductSpace
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+/-- Orthogonal projection onto the span of a finite orthonormal family equals the
+    sum of the rank-one projectors over that family. -/
+theorem orthogonalProjection_eq_sum_rank_one
+    {k : ℕ} (e : Fin k → E) (he : Orthonormal 𝕜 e) (x : E) :
+    (orthogonalProjection (Submodule.span 𝕜 (Set.range e)) x : E)
+      = ∑ i, ⟪e i, x⟫_𝕜 • e i := by
+  sorry
+
+/-- Parseval / Bessel equality on the subspace: the squared norm of the projection
+    is the sum of squared coordinate moduli. -/
+theorem norm_orthogonalProjection_sq_eq_sum
+    {k : ℕ} (e : Fin k → E) (he : Orthonormal 𝕜 e) (x : E) :
+    ‖(orthogonalProjection (Submodule.span 𝕜 (Set.range e)) x : E)‖ ^ 2
+      = ∑ i, ‖⟪e i, x⟫_𝕜‖ ^ 2 := by
+  sorry
+```
+
+Equivalently, one packages the family as an `OrthonormalBasis (Fin k) 𝕜 S` for the
+subspace `S` (a finite-dimensional inner product space) and uses
+`OrthonormalBasis.sum_repr` transported back to `E` via the isometry `S ↪ E`.
+
+### Plain Language
+
+The parent proved that projecting a vector onto a single line is given by one simple
+formula, $x \mapsto \langle e, x\rangle\,e$, and that this map is a genuine projector
+(idempotent, complementary residual, exact norm). This problem asks the natural next
+question: what if we project onto a whole $k$-dimensional subspace rather than a single
+line? The answer is that the projection is just the **sum** of the one-line projections,
+one for each vector in an orthonormal basis of the subspace:
+$P_S x = \sum_i \langle e_i, x\rangle\,e_i$. Moreover the length-squared of the
+projection is exactly the sum of the squares of the coordinates $|\langle e_i,x\rangle|^2$
+— this is the finite-dimensional **Parseval identity** (equality form of **Bessel's
+inequality**) restricted to the subspace $S$.
+
+### Why This Matters
+
+This is the exact step that turns the rank-one Gram–Schmidt/Cauchy–Schwarz picture into
+the general theory of orthogonal projection. The sum-of-rank-one-projectors formula is
+the operator identity $P_S = \sum_i e_i e_i^{*}$ (a finite-rank resolution-of-the-identity
+statement), and the Parseval equality on $S$ is the sharp, attained form of Bessel's
+inequality. Concretely, it is the analytic backbone of the **QR decomposition** and of
+least-squares approximation: the best approximation of $x$ from $S$ is
+$\sum_i \langle e_i, x\rangle\,e_i$, and its error norm is controlled by
+$\lVert x\rVert^2 - \sum_i |\langle e_i,x\rangle|^2$. It closes the third open question
+left by the parent entry ("Does the projector identity extend to projection onto a
+finite-dimensional subspace, expressed as a sum of rank-one projectors over an orthonormal
+basis?") and provides a reusable, fully verified bridge between Mathlib's
+`orthogonalProjection` API and the coordinate/`OrthonormalBasis` API.
+
+## Known Results
+
+### What's Already Proven
+
+- **One Gram–Schmidt step is an orthogonal projector** ($P = \mathrm{orthProj}\,v$ onto
+  $\operatorname{span}\{v\}$: $P^2=P$, $(1-P)^2=1-P$, $P+(1-P)=\mathrm{id}$, exact norm
+  $\lVert Px\rVert = \lvert\langle v,x\rangle\rvert/\lVert v\rVert$, $0$ axioms) — gallery
+  entry `cauchy-schwarz-oq-01-oq-02-oq-01` (parent), the $k=1$ rank-one case of this
+  problem.
+- **Gram–Schmidt via Cauchy–Schwarz** (boundedness of the projection coefficient,
+  orthogonal residual, Pythagoras) — gallery entry `cauchy-schwarz-oq-01-oq-02`
+  (grandparent).
+- **Mathlib orthogonal projection API.** `orthogonalProjection (K : Submodule 𝕜 E)` for a
+  complete subspace `K`, with `orthogonalProjection_mem`, `orthogonalProjection_inner_eq_zero`
+  (the defining orthogonality of the residual), `orthogonalProjection_eq_self_iff`, and
+  `inner_orthogonalProjection_eq_of_mem_right` / `_left` — in
+  `Mathlib.Analysis.InnerProductSpace.Projection`.
+- **Orthonormal-basis coordinate expansion.** `OrthonormalBasis.sum_repr`
+  ($x = \sum_i \langle b_i,x\rangle\,b_i$ over a full basis) and
+  `Orthonormal.inner_products` in `Mathlib.Analysis.InnerProductSpace.PiL2`.
+- **Bessel's inequality** `Orthonormal.sum_inner_products_le`
+  ($\sum_i |\langle e_i,x\rangle|^2 \le \lVert x\rVert^2$) and
+  `Orthonormal.inner_products_le` in `Mathlib.Analysis.InnerProductSpace.Basic`.
+
+### What's Still Open
+
+- No gallery entry assembles the **sum-of-rank-one-projectors** identity
+  $P_S x = \sum_i \langle e_i,x\rangle\,e_i$ for a finite orthonormal family in an
+  ambient space $E$ (as opposed to the full-space `OrthonormalBasis.sum_repr`).
+- No gallery entry states the **Parseval equality on the subspace**
+  $\lVert P_S x\rVert^2 = \sum_i |\langle e_i,x\rangle|^2$ as the attained case of Bessel
+  restricted to $S$ (Mathlib has the inequality, not this subspace-equality packaging).
+- The clean reduction to the parent's $k=1$ rank-one statement, exhibiting the parent as
+  the one-term sum.
+
+### Our Goal
+
+Produce a `0`-axiom, `0`-sorry Lean file that proves, over an arbitrary `RCLike` field:
+(1) $P_S x = \sum_i \langle e_i, x\rangle\,e_i$ where $S = \operatorname{span}(\mathrm{range}\,e)$;
+(2) $\lVert P_S x\rVert^2 = \sum_i |\langle e_i,x\rangle|^2$;
+(3) the residual $x - P_S x$ is orthogonal to every $e_i$ (hence to $S$);
+(4) idempotency $P_S(P_S x) = P_S x$ on $S$ and reconstruction $P_S + (1 - P_S) = \mathrm{id}$;
+and (5) the $k=1$ specialization recovering the parent. The subspace $S$ is
+finite-dimensional, hence complete, so `orthogonalProjection` is well defined without any
+completeness hypothesis on $E$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| cauchy-schwarz-oq-01-oq-02-oq-01 | Direct parent: rank-one ($k=1$) projector onto a line; this problem sums $k$ of them | `inner_smul_right`, `div_self`, idempotency, exact norm |
+| cauchy-schwarz-oq-01-oq-02 | Grandparent: Gram–Schmidt via Cauchy–Schwarz (bound, residual, Pythagoras) | Cauchy–Schwarz, orthogonal residual |
+| cauchy-schwarz | Base inner-product inequality underlying Bessel/Parseval | `norm_inner_le_norm`, inner-product algebra |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — `OrthonormalBasis` of the subspace $S$ (recommended idiomatic route).**
+   The family $e$ restricts to an orthonormal basis of $S = \operatorname{span}(\mathrm{range}\,e)$.
+   Build `b : OrthonormalBasis (Fin k) 𝕜 S` from `he` and the span construction, use
+   `OrthonormalBasis.sum_repr` inside $S$ to expand
+   $P_S x = \sum_i \langle b_i, P_S x\rangle\,b_i$, and rewrite
+   $\langle b_i, P_S x\rangle = \langle e_i, x\rangle$ using the residual orthogonality of
+   the projector (a lemma of the form `inner_orthogonalProjection_eq_of_mem_left`, since
+   $e_i \in S$). Transport along the isometry `S ↪ E` (`Submodule.subtypeₗᵢ`) to land the
+   sum in $E$. Parseval then follows from the orthonormal `norm_sum` computation.
+   - Why it might work: every ingredient is a named Mathlib lemma; the work is glue and
+     the $S \hookrightarrow E$ transport.
+   - Risk: bookkeeping between $E$-inner-products and $S$-inner-products; managing the
+     isometry coercion cleanly.
+
+2. **Approach B — Direct verification via the projection characterization (recommended for a self-contained file).**
+   Define $Q x := \sum_i \langle e_i, x\rangle\,e_i$ directly and prove
+   $Q x = P_S x$ using the uniqueness of orthogonal projection: show
+   (i) $Q x \in S$ (a sum of scalar multiples of the $e_i$), and
+   (ii) $x - Q x \perp e_j$ for all $j$, i.e. $\langle e_j, x - Q x\rangle = 0$, which by
+   orthonormality is $\langle e_j, x\rangle - \sum_i \langle e_i,x\rangle\langle e_j,e_i\rangle
+   = \langle e_j,x\rangle - \langle e_j,x\rangle = 0$. Then invoke a uniqueness lemma of the
+   form `eq_orthogonalProjection_of_mem_of_inner_eq_zero` ("if $y \in K$ and $x - y \perp K$
+   then $y = P_K x$").
+   - Why it might work: avoids the $S \hookrightarrow E$ transport entirely; the residual
+     computation is a one-line `Finset.sum` manipulation using $\langle e_i,e_j\rangle=\delta_{ij}$.
+   - Risk: need to supply orthogonality against all of $S$ (spanning suffices via linearity),
+     and the Parseval norm still needs the orthonormal `norm_sum` computation.
+
+Approach B is likely the cleaner path to a self-contained `0`-axiom file, mirroring the
+parent's direct style; Approach A is the more idiomatic "assemble existing API" route.
+
+### Key Difficulties
+
+- **Two inner-product worlds.** `orthogonalProjection` has values in the subspace `↥S`, so
+  statements comparing $P_S x$ (an element of $E$ after coercion) with a sum in $E$ require
+  careful handling of the `Submodule.subtype` coercion and possibly `OrthonormalBasis`
+  transport.
+- **Orthogonality against a span.** The residual must be shown orthogonal to all of $S$,
+  not just to each $e_i$; use that orthogonality to a spanning set extends by linearity
+  (a lemma of the form `Submodule.inner_right_of_mem_span`, or reduce via `Submodule.span_induction`).
+- **Parseval cross terms.** Expanding $\lVert \sum_i c_i e_i\rVert^2 = \langle \sum_i c_i e_i,
+  \sum_j c_j e_j\rangle$ into $\sum_{i,j} \overline{c_i} c_j \langle e_i, e_j\rangle$ and
+  collapsing the double sum to the diagonal via $\langle e_i,e_j\rangle = \delta_{ij}$
+  (`inner_sum`, `sum_inner`, `Finset.sum_ite_eq`, `Orthonormal`); the standard but slightly
+  fiddly orthonormal `norm_sum` computation.
+- **`RCLike` vs `ℝ`.** Over $\mathbb{C}$ the coefficients are $\langle e_i, x\rangle \in
+  \mathbb{C}$ and the squared modulus is $\lVert\langle e_i,x\rangle\rVert^2$; keep the
+  statement `RCLike`-general as the parent did.
+
+### What Would a Proof Need?
+
+- Key lemma 1: $x - \sum_i \langle e_i,x\rangle\,e_i \perp e_j$ for every $j$
+  (residual orthogonality), from orthonormality and `Finset` linearity of the inner product.
+- Key lemma 2: $\sum_i \langle e_i,x\rangle\,e_i \in S = \operatorname{span}(\mathrm{range}\,e)$.
+- Key lemma 3: uniqueness of orthogonal projection
+  (`eq_orthogonalProjection_of_mem_of_inner_eq_zero`-style) to identify the sum with $P_S x$.
+- Key lemma 4: orthonormal `norm_sum`,
+  $\lVert \sum_i c_i e_i\rVert^2 = \sum_i \lVert c_i\rVert^2$, for the Parseval equality.
+- Technical requirements: finite-dimensionality of $S$ (so `orthogonalProjection` exists),
+  the `S ↪ E` isometry if following Approach A, and `Finset.sum`/`Fintype` bookkeeping.
+
+## Tractability Assessment
+
+**Difficulty**: Moderate-High (assembly of existing Mathlib projection/orthonormal API)
+
+**Justification**:
+- The result is a **standard, fully classical theorem** (finite-dimensional Parseval /
+  resolution of the identity) with **substantial Mathlib support already in place**:
+  `orthogonalProjection`, `Orthonormal`, `OrthonormalBasis.sum_repr`,
+  `Orthonormal.sum_inner_products_le` (Bessel). The main work is *assembly* and the
+  sum-of-projectors bookkeeping, not new mathematics.
+- The **residual-orthogonality + uniqueness** route (Approach B) is a direct, low-risk port
+  of the parent's style to a `Finset.sum` of terms and is very likely to close with
+  `0` axioms.
+- The only genuine friction is the coercion/transport between the ambient space $E$ and the
+  subspace $S = \uparrow(\operatorname{span}\,e)$, and the orthonormal `norm_sum`
+  double-sum collapse — both are exercised elsewhere in Mathlib.
+- Similar solved work: the parent rank-one entry (this is its $k$-fold sum) and Mathlib's
+  own `OrthonormalBasis` expansion lemmas demonstrate the toolkit end-to-end.
+
+**Estimated Effort**:
+- Exploration: 0.5–1 day (choose Approach A vs B; confirm the exact
+  `eq_orthogonalProjection_of_mem_of_inner_eq_zero` and orthonormal `norm_sum` lemma names).
+- If tractable (expected): 1–3 days for a `0`-axiom file with the sum-of-projectors
+  identity, the Parseval equality, residual orthogonality, idempotency, and the $k=1$
+  recovery of the parent.
+
+## References
+
+### Books
+- Conway, J. B., *A Course in Functional Analysis*, 2nd ed., Springer GTM 96, 1990 —
+  orthogonal projections, orthonormal bases, Bessel's inequality and Parseval's identity
+  (Chapter I).
+- Halmos, P. R., *Finite-Dimensional Vector Spaces*, 2nd ed., Springer, 1958 — orthogonal
+  projection onto a subspace, resolution of the identity, and the projector calculus in
+  finite dimension.
+- Axler, S., *Linear Algebra Done Right*, 3rd ed., Springer, 2015 — orthonormal bases,
+  orthogonal projections, and best approximation (least squares).
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Parseval%27s_identity — Parseval / Bessel equality.
+- https://en.wikipedia.org/wiki/Projection_(linear_algebra) — orthogonal projection as a
+  sum of rank-one projectors.
+
+### Mathlib
+- `Mathlib.Analysis.InnerProductSpace.Projection` — `orthogonalProjection`,
+  `orthogonalProjection_inner_eq_zero`, `orthogonalProjection_mem`, and a uniqueness lemma
+  of the form `eq_orthogonalProjection_of_mem_of_inner_eq_zero`.
+- `Mathlib.Analysis.InnerProductSpace.PiL2` — `OrthonormalBasis`, `OrthonormalBasis.sum_repr`,
+  and orthonormal-basis coordinate/projection expansions.
+- `Mathlib.Analysis.InnerProductSpace.Basic` — `Orthonormal`, `Orthonormal.inner_products`,
+  `Orthonormal.sum_inner_products_le` (Bessel's inequality), `inner_sum`, `sum_inner`.
+- `Mathlib.LinearAlgebra.Span` — `Submodule.span`, `Submodule.mem_span_range` and
+  span-induction principles for extending orthogonality from a spanning set to all of $S$.
+
+## Metadata
+
+```yaml
+tags:
+  - linear-algebra
+  - inner-product-spaces
+  - orthogonal-projection
+  - parseval
+  - bessel
+  - gram-schmidt
+related_proofs:
+  - cauchy-schwarz-oq-01-oq-02-oq-01
+  - cauchy-schwarz-oq-01-oq-02
+  - cauchy-schwarz
+difficulty: moderate-high
+source: gallery-gap
+created: 2026-06-30
+```

--- a/research/problems/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/state.md
+++ b/research/problems/cauchy-schwarz-oq-01-oq-02-oq-01-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: cauchy-schwarz-oq-01-oq-02-oq-01-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-30T23:06:21-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/lagrange-theorem-oq-02-oq-03/knowledge.md
+++ b/research/problems/lagrange-theorem-oq-02-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: lagrange-theorem-oq-02-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/lagrange-theorem-oq-02-oq-03/literature/README.md
+++ b/research/problems/lagrange-theorem-oq-02-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for lagrange-theorem-oq-02-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/lagrange-theorem-oq-02-oq-03/problem.md
+++ b/research/problems/lagrange-theorem-oq-02-oq-03/problem.md
@@ -1,0 +1,294 @@
+# Problem: Orbit–Stabilizer Without Finiteness — The Bijection and its Cardinal Corollary
+
+**Slug**: lagrange-theorem-oq-02-oq-03
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let $G$ be an *arbitrary* group (no finiteness hypothesis) acting on a set $X$,
+and fix $x \in X$. The orbit–stabilizer correspondence is the natural bijection
+
+$$
+\operatorname{Orb}_G(x) \;\simeq\; G \,/\, \operatorname{Stab}_G(x),
+\qquad
+g \cdot x \;\longmapsto\; g\,\operatorname{Stab}_G(x),
+$$
+
+between the orbit of $x$ and the *left coset space* of the stabilizer. This map
+is a well-defined bijection with **no** cardinality assumption on $G$, $X$, or the
+orbit: $g_1 \cdot x = g_2 \cdot x \iff g_1^{-1} g_2 \in \operatorname{Stab}_G(x)
+\iff g_1 \operatorname{Stab}_G(x) = g_2 \operatorname{Stab}_G(x)$.
+
+Taking cardinalities of both sides yields the *infinite-general* cardinal identity
+
+$$
+\#\,\operatorname{Orb}_G(x)
+   \;=\;
+   \#\bigl(G / \operatorname{Stab}_G(x)\bigr)
+   \;=\;
+   [\,G : \operatorname{Stab}_G(x)\,]
+$$
+
+as `Cardinal.mk`, where the index $[G : H]$ is read as the cardinal $\#(G/H)$.
+Restricting to a finite group recovers the multiplicative form
+$\#\operatorname{Orb}_G(x)\cdot\#\operatorname{Stab}_G(x) = \#G$ as natural
+numbers.
+
+A concrete target theorem signature (Lean 4 / Mathlib):
+
+```lean
+/-- Orbit–stabilizer bijection, no finiteness hypothesis. -/
+theorem orbit_equiv_quotient_stabilizer_general
+    {G : Type*} [Group G] {X : Type*} [MulAction G X] (x : X) :
+    MulAction.orbit G x ≃ G ⧸ MulAction.stabilizer G x :=
+  MulAction.orbitEquivQuotientStabilizer G x
+
+/-- Cardinal orbit–stabilizer: `#(orbit) = #(G ⧸ Stab)` as cardinals,
+    for an arbitrary (possibly infinite) group. -/
+theorem mk_orbit_eq_mk_quotient_stabilizer_general
+    {G : Type*} [Group G] {X : Type*} [MulAction G X] (x : X) :
+    Cardinal.mk (MulAction.orbit G x)
+      = Cardinal.mk (G ⧸ MulAction.stabilizer G x) :=
+  Cardinal.mk_congr (MulAction.orbitEquivQuotientStabilizer G x)
+
+/-- Finite specialization: the product form as natural numbers,
+    needing only local finiteness of the stabilizer. -/
+theorem card_orbit_mul_card_stabilizer_general
+    {G : Type*} [Group G] [Finite G] {X : Type*} [MulAction G X] (x : X) :
+    Nat.card (MulAction.orbit G x) * Nat.card (MulAction.stabilizer G x)
+      = Nat.card G := by
+  rw [Nat.card_congr (MulAction.orbitEquivQuotientStabilizer G x), mul_comm]
+  exact Subgroup.card_mul_index (MulAction.stabilizer G x)
+```
+
+### Plain Language
+
+The orbit–stabilizer theorem is usually stated for *finite* groups:
+"orbit size times stabilizer size equals group order." But the *reason* it is
+true has nothing to do with finiteness — it is a genuine one-to-one
+correspondence between the points you can reach from $x$ (the orbit) and the
+cosets of the subgroup that pins $x$ in place (the stabilizer). The parent
+gallery entry proved the finite version. This child asks: state and package the
+correspondence itself, valid for *any* group — infinite groups included — and
+then read off the size statement as an equation of **cardinals**, so that
+"orbit size $=$ stabilizer index" makes sense even when everything in sight is
+infinite. The finite product formula then drops out as a corollary.
+
+### Why This Matters
+
+The finite orbit–stabilizer theorem is the workhorse of finite group theory, but
+its structural core — the bijection $\operatorname{Orb}(x) \simeq G/\operatorname{Stab}(x)$ —
+is a statement about *arbitrary* group actions and is exactly how Mathlib already
+packages it. Making the infinite-general statement explicit in the gallery does
+three things: (1) it separates the *bijective content* (finiteness-free) from the
+*arithmetic content* (a corollary needing only local finiteness), which is the
+honest conceptual decomposition; (2) it exhibits the correct home for the size
+statement in the infinite case — the cardinal $\#(G/\operatorname{Stab})$, i.e.
+the subgroup *index* as a cardinal — rather than a natural-number product; and
+(3) it directly answers the parent's own open question about extending
+orbit–stabilizer beyond finite groups. This is the same move that upgrades
+Lagrange's theorem from "$|H|$ divides $|G|$" to "$|G| = |H|\cdot[G:H]$ as
+cardinals," and it is the natural launching point for infinite-index arguments
+(e.g. finitely generated groups acting on trees, transitive actions on infinite
+sets).
+
+## Known Results
+
+### What's Already Proven
+
+- **Orbit–Stabilizer for finite groups** ($\#\operatorname{Orb}(x)\cdot\#\operatorname{Stab}(x)=\#G$,
+  plus divisibility, Lagrange recovery, $p$-group corollaries; $0$ axioms,
+  $0$ sorries) — parent gallery entry `lagrange-theorem-oq-02`.
+- **Lagrange's theorem** — grandparent gallery entry `lagrange-theorem`:
+  $\#H \mid \#G$ for a subgroup $H$ of a finite group.
+- **The orbit–stabilizer bijection is already fully general in Mathlib.**
+  `MulAction.orbitEquivQuotientStabilizer G x : orbit G x ≃ G ⧸ stabilizer G x`
+  carries *no* finiteness typeclass — it is the honest infinite-general
+  equivalence. The genuine content of this child is *exposing* it without
+  finiteness and deriving the cardinal corollary, not re-deriving the map.
+- **Index as a cardinal / product formula.** Mathlib's `Subgroup.index` and the
+  relations `Subgroup.card_mul_index`, `Subgroup.index_eq_card`, together with
+  `Cardinal.mk_congr` and `Nat.card_congr`, connect the equivalence to both the
+  cardinal and the finite natural-number statements.
+
+### What's Still Open
+
+- No gallery entry states the orbit–stabilizer *bijection* and its *cardinal*
+  corollary in full generality (no `Fintype`/`Finite` on $G$ or $X$).
+- The clean packaging "$\#\operatorname{Orb}(x) = [G:\operatorname{Stab}(x)]$
+  as `Cardinal.mk`" — the infinite-general size statement — is not presented,
+  even though every ingredient exists in Mathlib.
+- The precise *minimal* finiteness hypotheses for the natural-number product form
+  (`Finite (stabilizer G x)` combined with `Finite (orbit G x)`, versus the usual
+  blanket `Finite G`) deserve to be stated and separated cleanly.
+
+### Our Goal
+
+Present, in a self-contained verified file, the finiteness-free backbone:
+
+1. The bijection $\operatorname{Orb}_G(x) \simeq G/\operatorname{Stab}_G(x)$ for
+   an arbitrary group $G$ acting on an arbitrary set $X$ (restating
+   `MulAction.orbitEquivQuotientStabilizer`).
+2. The cardinal identity $\#\operatorname{Orb}_G(x) = \#(G/\operatorname{Stab}_G(x))
+   = [G:\operatorname{Stab}_G(x)]$ via `Cardinal.mk_congr`, with the index read as
+   a cardinal.
+3. The finite-group corollary $\#\operatorname{Orb}(x)\cdot\#\operatorname{Stab}(x)=\#G$
+   recovered from (1) under a finiteness hypothesis, so the parent's headline
+   theorem becomes a *special case*.
+4. Structural corollaries that survive to the infinite setting: transitive
+   actions give $\operatorname{Orb}(x) = X$ hence $\#X = \#(G/\operatorname{Stab}(x))$;
+   a free/faithful transitive (regular) action gives $\#X = \#G$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| lagrange-theorem-oq-02 | Direct parent: the finite orbit–stabilizer theorem this generalizes; its headline becomes our finite corollary | `MulAction.orbitEquivQuotientStabilizer`, `Subgroup.card_mul_index`, `Nat.card_congr` |
+| lagrange-theorem | Grandparent: $\#H \mid \#G$; the transitive $G$-action on $G/H$ is the model example, now stated as cardinals | Coset partition, index formula |
+| lagrange-theorem-oq-03 | Sibling: Hall/converse-flavored subgroup existence; shares the coset/index machinery | `Subgroup.index`, coset spaces |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Restate the Mathlib equivalence, then push through cardinals (recommended).**
+   The map is `MulAction.orbitEquivQuotientStabilizer G x`, which is already
+   finiteness-free. Apply `Cardinal.mk_congr` to obtain
+   $\#\operatorname{Orb}(x) = \#(G/\operatorname{Stab}(x))$. Identify the RHS with
+   the index either definitionally (Mathlib's `Subgroup.index H` is
+   `Nat.card (G ⧸ H)`; for the cardinal version use `Cardinal.mk (G ⧸ H)` directly,
+   or a lemma of the form bridging index and coset cardinality). For the finite
+   corollary, feed the equivalence to `Nat.card_congr` and combine with
+   `Subgroup.card_mul_index`.
+   - Why it works: it is the exact architecture of the verified parent with the
+     `[Fintype G] [Fintype X]` instances *removed* from the bijection and confined
+     to the corollary; a near-mechanical, low-risk port.
+   - Risk: minimal. The only care needed is choosing the honest home for the index
+     in the infinite case (`Cardinal.mk (G ⧸ H)` vs. the `Nat`-valued
+     `Subgroup.index`, which is `0` when the coset space is infinite).
+
+2. **Approach B — Work directly with `Cardinal.mk` and cardinal coset decomposition.**
+   Build the cardinal statement from the ground up: $\#(G/H) \cdot \#H = \#G$ as a
+   cardinal product (the cardinal Lagrange, of the form
+   `Cardinal.mk_eq_mk_mul …` for the coset partition), then substitute
+   $H = \operatorname{Stab}(x)$ and $\#(G/H) = \#\operatorname{Orb}(x)$.
+   - Why it might help: gives the fully infinite multiplicative identity
+     $\#\operatorname{Orb}(x)\cdot\#\operatorname{Stab}(x) = \#G$ as cardinals,
+     stronger than the `Nat` corollary.
+   - Risk: cardinal multiplication lemmas for coset decompositions may need to be
+     assembled by hand; more moving parts than Approach A, though still
+     finiteness-free.
+
+### Key Difficulties
+
+- **Where does the index live in the infinite case?** `Subgroup.index` is
+  `Nat`-valued and *collapses to `0`* for infinite coset spaces, so the honest
+  infinite statement must use `Cardinal.mk (G ⧸ stabilizer G x)` (or a cardinal
+  index), not `Subgroup.index`. Stating the corollary with the right object is the
+  main conceptual choice.
+- **Separating hypotheses cleanly.** The bijection needs nothing; the `Nat` product
+  needs finiteness. Exposing the *minimal* hypothesis for the product corollary
+  (finiteness of the coset space / stabilizer via `Subgroup.card_mul_index`, rather
+  than a blanket `Fintype G`) is a small but worthwhile piece of hygiene.
+- **Honesty about novelty.** The core equivalence is a one-line wrapper around an
+  existing Mathlib lemma; the *value added* is the finiteness-free framing, the
+  cardinal corollary, and the clean exhibition of the parent's theorem as a special
+  case. The file should say so plainly.
+
+### What Would a Proof Need?
+
+- Key lemma 1: the equivalence `orbit G x ≃ G ⧸ stabilizer G x` with no finiteness
+  instances (restate `MulAction.orbitEquivQuotientStabilizer`).
+- Key lemma 2: `Cardinal.mk (orbit G x) = Cardinal.mk (G ⧸ stabilizer G x)` via
+  `Cardinal.mk_congr` applied to Key lemma 1.
+- Key lemma 3: finite corollary
+  `Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G` via
+  `Nat.card_congr` + `Subgroup.card_mul_index`, under a finiteness hypothesis.
+- Key lemma 4 (structural): transitive action $\Rightarrow$ `orbit G x = Set.univ`
+  (`MulAction.orbit_eq_univ`) hence $\#X = \#(G/\operatorname{Stab}(x))$; regular
+  action $\Rightarrow \#X = \#G$.
+- Technical requirements: `MulAction.orbitEquivQuotientStabilizer`,
+  `Cardinal.mk_congr`, `Nat.card_congr`, `Subgroup.card_mul_index`,
+  `Subgroup.index_eq_card`, and the `Subgroup.index` / `Cardinal.mk` bridging — all
+  present in current Mathlib.
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium (High tractability)
+
+**Justification**:
+- The **bijection is already infinite-general in Mathlib**
+  (`MulAction.orbitEquivQuotientStabilizer` carries no finiteness typeclass), so
+  Key lemma 1 is a one-line restatement and Key lemma 2 is a single
+  `Cardinal.mk_congr`. This is very likely to close with $0$ axioms.
+- The **finite corollary is a verbatim port of the parent's headline theorem**
+  (`Nat.card_congr` + `Subgroup.card_mul_index`), already known to compile in
+  `lagrange-theorem-oq-02`.
+- The only genuine design decision is the **honest home for the index in the
+  infinite case** (`Cardinal.mk (G ⧸ H)` vs. the `Nat`-collapsing
+  `Subgroup.index`), which is a framing choice, not a proof obstacle.
+- Techniques available in Mathlib: `MulAction.orbitEquivQuotientStabilizer`,
+  `Cardinal.mk_congr`, `Nat.card_congr`, `Subgroup.card_mul_index`,
+  `MulAction.orbit_eq_univ`.
+
+**Estimated Effort**:
+- Exploration: a few hours (confirm the cardinal-index framing and lemma names).
+- If tractable (backbone + finite corollary + structural corollaries): 1–2 days
+  for a $0$-axiom file of roughly 100–160 lines.
+- Stretch (fully infinite cardinal product $\#\operatorname{Orb}\cdot\#\operatorname{Stab}=\#G$
+  via Approach B): additional 1–2 days assembling cardinal coset-decomposition lemmas.
+
+## References
+
+### Papers / Books
+
+- Dummit, D. S. and Foote, R. M., *Abstract Algebra*, 3rd ed., Wiley, 2004 —
+  Section 4.1 develops the orbit–stabilizer theorem via the coset bijection; the
+  argument is stated without essential use of finiteness.
+- Rotman, J. J., *An Introduction to the Theory of Groups*, 4th ed., Springer
+  (GTM 148), 1995 — Chapter 3 presents group actions, orbits, stabilizers, and the
+  orbit–stabilizer correspondence as a bijection of coset spaces, the natural home
+  for the infinite-general statement.
+- Lang, S., *Algebra*, 3rd ed., Springer, 2002 — Chapter I.5 on group actions,
+  orbits, and the counting formula.
+
+### Online Resources
+
+- https://en.wikipedia.org/wiki/Group_action — the orbit–stabilizer bijection and
+  its cardinal (index) form.
+
+### Mathlib
+
+- `Mathlib.GroupTheory.GroupAction.Basic` — `MulAction.orbit`,
+  `MulAction.stabilizer`, `MulAction.orbit_eq_univ` (transitive actions).
+- `Mathlib.GroupTheory.GroupAction.Quotient` —
+  `MulAction.orbitEquivQuotientStabilizer` (the finiteness-free bijection at the
+  heart of this problem).
+- `Mathlib.GroupTheory.Index` — `Subgroup.index`, `Subgroup.card_mul_index`,
+  `Subgroup.index_eq_card` (index as coset cardinality; the finite product form).
+- `Mathlib.SetTheory.Cardinal.Finite` — `Nat.card`, `Nat.card_congr` (transporting
+  cardinalities along `Equiv`, for the finite corollary).
+- `Mathlib.SetTheory.Cardinal.Basic` — `Cardinal.mk`, `Cardinal.mk_congr` (the
+  infinite-general cardinal identity).
+
+## Metadata
+
+```yaml
+tags:
+  - group-theory
+  - group-actions
+  - algebra
+  - cardinal-arithmetic
+  - orbit-stabilizer
+related_proofs:
+  - lagrange-theorem-oq-02
+  - lagrange-theorem
+  - lagrange-theorem-oq-03
+difficulty: low
+source: gallery-gap
+created: 2026-06-30
+```

--- a/research/problems/lagrange-theorem-oq-02-oq-03/state.md
+++ b/research/problems/lagrange-theorem-oq-02-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: lagrange-theorem-oq-02-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-30T23:06:21-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/mantel-theorem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/mantel-theorem-oq-03-oq-01-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: mantel-theorem-oq-03-oq-01-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/mantel-theorem-oq-03-oq-01-oq-02/literature/README.md
+++ b/research/problems/mantel-theorem-oq-03-oq-01-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for mantel-theorem-oq-03-oq-01-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/mantel-theorem-oq-03-oq-01-oq-02/problem.md
+++ b/research/problems/mantel-theorem-oq-03-oq-01-oq-02/problem.md
@@ -1,0 +1,280 @@
+# Problem: Minimum Degree of the General Turán Graph `turanGraph n r` is Exactly `n − ⌈n/r⌉`
+
+**Slug**: mantel-theorem-oq-03-oq-01-oq-02
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The parent entry `mantel-theorem-oq-03-oq-01` proved the $r = 2$ sharpness certificate
+for Mantel's minimum-degree bound: the balanced complete bipartite graph
+`turanGraph n 2` is triangle-free and has minimum degree exactly $\lfloor n/2\rfloor$.
+This problem lifts that computation to **every** $r \ge 1$, certifying sharpness of the
+Turán minimum-degree bound $(1 - 1/r)\,n$ for $K_{r+1}$-free graphs (the parent's third
+open question).
+
+Recall Mathlib's definition (`Mathlib.Combinatorics.SimpleGraph.Extremal.Turan`):
+$$
+\texttt{turanGraph } n\ r \;:\; \text{SimpleGraph }(\mathrm{Fin}\,n),
+\qquad
+v \sim w \iff (v : \mathbb{N}) \bmod r \;\ne\; (w : \mathbb{N}) \bmod r .
+$$
+So `turanGraph n r` is the complete $r$-partite graph whose parts are the residue classes
+$\{v : v \bmod r = j\}$ for $j = 0, \dots, r-1$ inside $\mathrm{Fin}\,n$. A vertex $v$ is
+adjacent to **every** vertex outside its own residue class, hence
+$$
+\deg v \;=\; n \;-\; \bigl|\{\,k < n : k \bmod r = v \bmod r\,\}\bigr|
+\;=\; n - c_r(v \bmod r, n),
+$$
+where $c_r(j, n) = \#\{k < n : k \bmod r = j\} = \lceil (n - j)/r\rceil$ is the size of the
+$j$-th residue class. The class sizes decrease weakly in $j$, so the **largest** class is
+$j = 0$ with size $\lceil n/r\rceil$; the minimum degree is attained there:
+$$
+\boxed{\;(\texttt{turanGraph } n\ r).\mathrm{minDegree} \;=\; n - \lceil n/r\rceil
+\;=\; n - \tfrac{n + r - 1}{r}\ \ (\text{Nat division}).\;}
+$$
+
+**Target Lean theorem** (signature to formalize):
+
+```lean
+open SimpleGraph
+
+/-- The exact per-vertex degree of the general Turán graph: `n` minus the size of the
+own residue class of `v` modulo `r`. -/
+theorem turanGraph_degree (n r : ℕ) (hr : 0 < r) (v : Fin n) :
+    (turanGraph n r).degree v
+      = n - Nat.count (fun k => k % r = v.val % r) n := by
+  sorry
+
+/-- **Sharpness, minimum degree, general `r`.** For `n ≥ 1` and `r ≥ 1`, the Turán graph
+`turanGraph n r` has minimum degree exactly `n − ⌈n/r⌉`, attained on the residue class 0. -/
+theorem turanGraph_minDegree (n r : ℕ) (hn : 0 < n) (hr : 0 < r) :
+    (turanGraph n r).minDegree = n - (n + r - 1) / r := by
+  sorry
+
+/-- **Sharpness certificate for the parent's third open question.** `turanGraph n r` is
+`K_{r+1}`-free and its minimum degree `n − ⌈n/r⌉` witnesses that the `(1 − 1/r)·n`
+minimum-degree bound for `K_{r+1}`-free graphs cannot be improved. -/
+theorem turanGraph_minDegree_sharp (n r : ℕ) (hn : 0 < n) (hr : 0 < r) :
+    (turanGraph n r).CliqueFree (r + 1)
+      ∧ (turanGraph n r).minDegree = n - (n + r - 1) / r :=
+  ⟨turanGraph_cliqueFree hr, turanGraph_minDegree n r hn hr⟩
+```
+
+Here $(n + r - 1)/r$ is the `Nat`-division encoding of $\lceil n/r\rceil$. Specializing to
+$r = 2$ recovers the parent: $n - \lceil n/2\rceil = \lfloor n/2\rfloor = n/2$, so
+`turanGraph_minDegree n 2 hn (by norm_num)` reduces to the parent's `turanTwo_minDegree`.
+
+### Plain Language
+
+The Turán graph splits $n$ labelled vertices into $r$ groups as evenly as possible (group
+$j$ is "everything with remainder $j$ when divided by $r$"), and joins two vertices exactly
+when they are in different groups. Each vertex is therefore connected to everyone outside
+its own group, so its degree is $n$ minus the size of its own group. The vertex with the
+*fewest* neighbours lives in the *largest* group; because the groups are as balanced as the
+division allows, the largest group has $\lceil n/r\rceil$ members, so the smallest degree in
+the whole graph is $n - \lceil n/r\rceil$. The parent proved this for two groups
+($r = 2$, the triangle-free / bipartite case); here we prove it for any number of groups,
+which is exactly the extremal construction behind Turán's theorem.
+
+### Why This Matters
+
+Turán's theorem says a $K_{r+1}$-free graph on $n$ vertices has at most as many edges as
+`turanGraph n r`. Its *local* companion — the minimum-degree version — states that a
+$K_{r+1}$-free graph must contain a vertex of degree at most $(1 - 1/r)\,n$. Such an upper
+bound is only meaningful once one exhibits a graph attaining it, and the natural witness is
+the Turán graph itself. Computing `(turanGraph n r).minDegree = n − ⌈n/r⌉` supplies exactly
+that witness for every $r$, closing the loop opened by the parent's third open question in
+one uniform statement. It also produces, as a byproduct, the full minimum-degree data of the
+extremal graph in Turán's theorem — a clean, reusable Mathlib-level fact — and demonstrates
+that the parent's residue-counting technique scales from the parity ($r = 2$) case to
+arbitrary moduli.
+
+## Known Results
+
+### What's Already Proven
+
+- **Parent, $r = 2$ sharpness** — gallery entry `mantel-theorem-oq-03-oq-01`
+  (`turanTwo_minDegree`, `turanTwo_sharp`): `turanGraph n 2` is triangle-free and has
+  minimum degree exactly $\lfloor n/2\rfloor$, verified, $0$ axioms. This is the $r = 2$
+  specialization of the present target.
+- **Mantel minimum-degree corollary** — grandparent `mantel-theorem-oq-03`: every
+  triangle-free graph on $n \ge 1$ vertices has a vertex of degree $\le \lfloor n/2\rfloor$.
+- **Mantel's theorem** (edge bound $\lfloor n^2/4\rfloor$) — gallery entry `mantel-theorem`.
+- **Turán graph API in Mathlib** — `SimpleGraph.turanGraph`, `turanGraph_adj`,
+  `turanGraph_cliqueFree (hr : 0 < r) : (turanGraph n r).CliqueFree (r + 1)`,
+  `turanGraph_eq_top`, and the exact edge-count `card_edgeFinset_turanGraph`
+  (`Mathlib.Combinatorics.SimpleGraph.Extremal.Turan`).
+- **Reusable residue-counting lemmas from the parent** — `card_fin_filter_val`
+  (bridging a `Fin n` filter to `Nat.count` over `range n`) and the closed forms
+  `count_mod_two_eq_zero/one`. The $r = 2$ closed forms are the base cases of the general
+  residue-class-size count needed here.
+
+### What's Still Open
+
+- No Lean statement of the general degree formula
+  $\deg v = n - c_r(v \bmod r, n)$ for `turanGraph n r`.
+- No Lean closed form for the residue-class size
+  $c_r(j, n) = \#\{k < n : k \bmod r = j\} = \lceil (n - j)/r\rceil$, nor the monotonicity
+  $c_r(0,n) \ge c_r(j,n)$ that pins the minimum-degree vertex to residue class $0$.
+- No Lean statement `(turanGraph n r).minDegree = n − ⌈n/r⌉` for general $r$, and hence no
+  formal certificate that the $K_{r+1}$-free minimum-degree bound $(1 - 1/r)\,n$ is sharp.
+
+### Our Goal
+
+Prove, with $0$ axioms, the three theorems above: the exact per-vertex degree
+$\deg v = n - \mathrm{count}(\cdot \bmod r = v \bmod r)\,n$, the closed-form minimum degree
+$n - \lceil n/r\rceil$, and the packaged sharpness certificate combining it with
+`turanGraph_cliqueFree`. Confirm the $r = 2$ specialization reproduces the parent's
+`turanTwo_minDegree`, and record the corollary that $n - \lceil n/r\rceil \le (1 - 1/r)\,n$
+(with equality when $r \mid n$), certifying the parent's third open question.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| mantel-theorem-oq-03-oq-01 | Direct parent: the $r = 2$ case; this problem generalizes its `turanTwo_minDegree` to all $r$ | `turanGraph_cliqueFree`, `card_fin_filter_val`, `Nat.count` closed forms, `minDegree` antisymmetry |
+| mantel-theorem-oq-03 | Grandparent: the triangle-free minimum-degree bound this construction shows is sharp | Degree double counting, `exists_degree_le_card_div_two` |
+| mantel-theorem | The global edge bound $\lfloor n^2/4\rfloor$; `turanGraph n 2` is its extremal example | Extremal edge counting, complete bipartite witness |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Port the parent's residue-count architecture from mod 2 to mod r (recommended).**
+   The parent computes $\deg v$ as a `Nat.count` over `range n` of a residue predicate via
+   `card_fin_filter_val`, then evaluates the count in closed form by induction using
+   `Nat.count_succ`. Reuse `card_fin_filter_val` verbatim; it is stated for a general
+   `Q : ℕ → Prop`. The neighbour set of $v$ in `turanGraph n r` is
+   $\{w : v \bmod r \ne w \bmod r\}$, so
+   $\deg v = n - \#\{w : v \bmod r = w \bmod r\}$ (complement within `Fin n`), and the
+   subtracted count is `Nat.count (fun k => k % r = v.val % r) n`.
+   - Why it might work: the $r = 2$ file is a fully verified template; the only genuinely
+     new lemma is the general residue-class-size count.
+   - Risk: `Nat`-division / ceiling bookkeeping for $\lceil (n-j)/r\rceil$ is fiddlier than
+     the two-way `omega` split that sufficed for parity.
+
+2. **Approach B — General residue-class-size lemma, then minimize over $j$.**
+   Prove a standalone lemma
+   $\#\{k < n : k \bmod r = j\} = \lceil (n - j)/r\rceil$ for $j < r$ (e.g. by induction on
+   $n$ with `Nat.count_succ`, or via a division argument), then show
+   $j \mapsto \lceil (n-j)/r\rceil$ is antitone so the max class size is $\lceil n/r\rceil$ at
+   $j = 0$. Feed both into the `minDegree` antisymmetry the parent used
+   (`minDegree_le_degree` at vertex $0$ for the upper bound;
+   `le_minDegree_of_forall_le_degree` with $n - \lceil n/r\rceil \le \deg v$ for the lower).
+   - Why it might work: cleanly separates the arithmetic (class-size closed form) from the
+     graph theory (minDegree antisymmetry).
+   - Risk: needs an honest antitonicity proof and careful handling of $n < r$ (empty classes
+     for $j \ge n$, where the graph is complete $K_n$ and every degree is $n - 1$; note
+     $n - \lceil n/r\rceil = n - 1$ there, so the formula still holds).
+
+### Key Difficulties
+
+- **Ceiling / floor `Nat`-division bookkeeping.** The class size $\lceil (n-j)/r\rceil$ and
+  the target $n - (n + r - 1)/r$ mix subtraction, ceiling division and the identity
+  $\lceil n/r\rceil = (n + r - 1)/r$. `omega` handles linear `Nat` goals but not division in
+  general; expect to introduce division lemmas of the form `Nat.add_div_right` /
+  `Nat.succ_div` or an explicit `⌈a/b⌉ = (a + b - 1)/b` rewrite, then close residual linear
+  goals with `omega`.
+- **Identifying the minimizing vertex.** Unlike $r = 2$ (only two class sizes differing by
+  at most one), for general $r$ one must prove the class-size function is antitone in $j$ to
+  justify that residue $0$ minimizes the degree. Vertex $0 \in \mathrm{Fin}\,n$ (needs
+  $n \ge 1$) is the concrete witness whose degree realizes the minimum.
+- **Degenerate ranges.** For $n \le r$ some residue classes are empty; the graph is complete
+  and every vertex has degree $n - 1$. The formula $n - \lceil n/r\rceil = n - 1$ must be
+  checked to survive this regime rather than special-casing it.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `card_fin_filter_val` (reuse from parent) to move the neighbour count to
+  `Nat.count` over `range n`.
+- Key lemma 2: the general residue-class-size closed form
+  $\mathrm{count}(\cdot \bmod r = j)\,n = \lceil (n - j)/r\rceil$, by induction on $n$ with
+  `Nat.count_succ` (a lemma of the form `count_mod_eq_size` — verify the exact name/shape in
+  `Mathlib.Data.Nat.Count`, do not assume a ready-made one exists).
+- Key lemma 3: antitonicity of class size in the residue $j$, giving max size
+  $\lceil n/r\rceil$ at $j = 0$.
+- Key lemma 4: `minDegree` antisymmetry via `minDegree_le_degree` and
+  `le_minDegree_of_forall_le_degree` (`Mathlib.Combinatorics.SimpleGraph.Finite`), exactly
+  as in `turanTwo_minDegree`.
+- Technical requirements: `Nonempty (Fin n)` from $n \ge 1$; `turanGraph_adj` to unfold
+  adjacency; `SimpleGraph.neighborFinset_eq_filter`; `Nat` ceiling-division lemmas plus
+  `omega` for the arithmetic residue.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The **graph-theoretic scaffolding is a verified template**: `turanTwo_degree`,
+  `turanTwo_minDegree` and `turanTwo_sharp` in the parent already exhibit the entire
+  `card_fin_filter_val` → `Nat.count` → `minDegree`-antisymmetry pipeline. Generalizing the
+  modulus from $2$ to $r$ keeps every structural step.
+- The **only new mathematical content** is the closed-form size of a residue class mod $r$
+  in $\mathrm{Fin}\,n$ and its antitonicity in the residue — an elementary `Nat.count`
+  induction, but with real ceiling/floor `Nat`-division friction that the parity case dodged
+  with a two-branch `omega`.
+- Similar solved problems: the parent ($r = 2$) is $0$-axiom and verified; Mathlib already
+  proves `card_edgeFinset_turanGraph` by the same residue-filtering style, confirming the
+  approach is library-supported.
+- Techniques available in Mathlib: `Nat.count_succ`, `Nat.count_eq_card_filter_range`,
+  `turanGraph_cliqueFree`, `minDegree_le_degree`, `le_minDegree_of_forall_le_degree`,
+  `omega`, and `Nat` division lemmas.
+
+**Estimated Effort**:
+- Exploration: 0.5–1 day (nail the residue-class-size closed form and its `Nat`-division
+  normal form).
+- If tractable: 1–2 days for a $0$-axiom file with all three target theorems plus the
+  $r = 2$ specialization check.
+- If hard: overrun would come entirely from the ceiling-division algebra, not the graph
+  theory.
+
+## References
+
+### Papers
+- Turán, P., *On an extremal problem in graph theory* (Hungarian),
+  *Matematikai és Fizikai Lapok* **48** (1941), 436–452 — the theorem whose extremal graph
+  is `turanGraph n r`.
+- Mantel, W., *Problem 28*, *Wiskundige Opgaven* **10** (1907), 60–61 — the $r = 2$ base
+  case (triangle-free edge bound).
+
+### Online Resources
+- https://en.wikipedia.org/wiki/Tur%C3%A1n_graph — the Turán graph $T(n,r)$, its part sizes,
+  and its degree sequence.
+- https://en.wikipedia.org/wiki/Tur%C3%A1n%27s_theorem — statement of Turán's theorem and the
+  extremal graph.
+
+### Mathlib
+- `Mathlib.Combinatorics.SimpleGraph.Extremal.Turan` — `SimpleGraph.turanGraph`,
+  `turanGraph_adj`, `turanGraph_cliqueFree`, `turanGraph_eq_top`,
+  `card_edgeFinset_turanGraph`.
+- `Mathlib.Combinatorics.SimpleGraph.Finite` — `SimpleGraph.degree`,
+  `SimpleGraph.neighborFinset_eq_filter`, `SimpleGraph.minDegree`,
+  `SimpleGraph.minDegree_le_degree`, `SimpleGraph.le_minDegree_of_forall_le_degree`.
+- `Mathlib.Data.Nat.Count` — `Nat.count`, `Nat.count_eq_card_filter_range`,
+  `Nat.count_succ` (the residue-class-size induction engine).
+- Parent file `Proofs/MantelTheoremOQ03OQ01.lean` — `card_fin_filter_val` and the
+  `count_mod_two_eq_zero/one` closed forms to be generalized.
+
+## Metadata
+
+```yaml
+tags:
+  - graph-theory
+  - combinatorics
+  - extremal-graph-theory
+  - turan-graph
+  - turan-theorem
+  - minimum-degree
+  - sharpness
+related_proofs:
+  - mantel-theorem-oq-03-oq-01
+  - mantel-theorem-oq-03
+  - mantel-theorem
+difficulty: medium
+source: gallery-gap
+created: 2026-06-30
+```

--- a/research/problems/mantel-theorem-oq-03-oq-01-oq-02/state.md
+++ b/research/problems/mantel-theorem-oq-03-oq-01-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: mantel-theorem-oq-03-oq-01-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-30T23:06:21-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.


### PR DESCRIPTION
## Summary

Seeker replenishment: the effective free candidate pool had dropped to ~16 usable problems (nominal 30 "available", but 7 were locked by active researchers and 7 were dead moonshot/missing placeholder stubs). This adds **6 new tractable open-question child problems**, each derived from a **VERIFIED, 0-axiom parent**, spanning 6 distinct domains for diversity.

| Child slug | Domain | Parent | Goal |
|---|---|---|---|
| `amgm-inequality-oq-05-oq-02-oq-01` | analysis | amgm-inequality-oq-05-oq-02 | Uniform-weight AM-GM equality case as a standalone `Fin n` corollary |
| `lagrange-theorem-oq-02-oq-03` | group theory | lagrange-theorem-oq-02 | Orbit-stabilizer for infinite groups (Cardinal.mk) |
| `cauchy-schwarz-oq-01-oq-02-oq-01-oq-03` | linear algebra | cauchy-schwarz-oq-01-oq-02-oq-01 | Sum-of-rank-one-projectors / Parseval equality on a finite-dim subspace |
| `mantel-theorem-oq-03-oq-01-oq-02` | graph theory | mantel-theorem-oq-03-oq-01 | turanGraph n r min degree = n - ceil(n/r) (sharpness witness) |
| `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01` | combinatorics | arithmetic-series-oq-02-oq-04-oq-01-oq-03 | Vandermonde convolution for rising factorials over a comm. ring |
| `automorphic-number-oq-01-oq-02-oq-01` | number theory | automorphic-number-oq-01-oq-02 | Idempotents of Z/m^k count 2^omega(m), Boolean algebra via CRT |

## Quality

- Each `problem.md` (~180-290 lines) is grounded in the parent's Lean source and cites **verified Mathlib lemma names** (drafters checked against the vendored Mathlib; uncertain lemmas phrased as "a lemma of the form ...", no fabricated APIs).
- All 6 pass `validate-seeker-stubs.ts` (no template placeholders).
- All parents independently confirmed `status: verified`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)