### PR TITLE
research(lhopital-oq-04-oq-01): iterated L'Hôpital as ratio of n-th Taylor coefficients [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LHopitalOQ04OQ01.lean
+++ b/proofs/Proofs/LHopitalOQ04OQ01.lean
@@ -1,0 +1,201 @@
+import Mathlib
+
+/-
+# Iterated L'Hôpital via the n-th Taylor Coefficient (OQ-04 → OQ-01)
+
+The parent gallery entry `LHopitalOQ04` proves the **order-1** Taylor form of
+L'Hôpital's rule: if `f a = g a = 0` and `g'(a) ≠ 0`, then near `a` both functions
+behave like their linear Taylor terms, so
+
+    f(x)/g(x) → f'(a)/g'(a).
+
+This file generalizes that to **arbitrary order `n`**. Suppose `f` and `g` vanish at
+`a` together with all of their derivatives up to order `n - 1`, and `g^(n)(a) ≠ 0`.
+Then the ratio is governed by the first surviving Taylor coefficients:
+
+    f(x)/g(x) → f^(n)(a) / g^(n)(a).
+
+The engine is the **coefficient-extraction limit**
+
+    f^(k)(a) = 0  for k < n   ⟹   f(x)/(x-a)^n → f^(n)(a)/n!,
+
+which is Taylor's theorem with a little-o remainder (Mathlib's `Real.taylor_tendsto`)
+after collapsing the degree-`n` Taylor polynomial to its single surviving top monomial
+`(f^(n)(a)/n!)·(x-a)^n`. Dividing the two coefficient limits and cancelling the shared
+`(x-a)^n` gives the rule — exactly as the parent divides two order-1 limits and cancels
+`(x-a)`. No Mean Value Theorem is used; the deepest content of L'Hôpital's rule is made
+explicit: the `0/0` limit is a **ratio of Taylor coefficients**.
+
+At `n = 1` this recovers the parent statement. The `n = 2` example
+`(1 - cos x)/x² → 1/2` exhibits a genuinely second-order `0/0` form (numerator and
+denominator both vanish to order 2), where a single application of order-1 L'Hôpital is
+still indeterminate.
+
+Self-contained: imports only Mathlib.
+-/
+
+namespace LHopitalOQ04OQ01
+
+open Filter Topology Nat
+
+/-- **Collapse of the Taylor polynomial under vanishing lower derivatives.**
+If `f^(k)(a) = 0` for every `k < n`, then the degree-`n` Taylor polynomial of `f` based
+at `a` reduces to its single top monomial:
+
+    taylorWithinEval f n univ a x = (n!)⁻¹ · (x-a)^n · f^(n)(a).
+
+The proof expands `taylorWithinEval` into the finite sum `∑_{k≤n} (k!)⁻¹(x-a)^k f^(k)(a)`
+(`taylor_within_apply`, over `Set.univ` so `iteratedDerivWithin = iteratedDeriv`), splits
+off the `k = n` term, and observes every `k < n` term carries the vanishing factor
+`f^(k)(a) = 0`. -/
+theorem taylorWithinEval_collapse {f : ℝ → ℝ} {a x : ℝ} {n : ℕ}
+    (hvanish : ∀ k < n, iteratedDeriv k f a = 0) :
+    taylorWithinEval f n Set.univ a x
+      = (n ! : ℝ)⁻¹ * (x - a) ^ n * iteratedDeriv n f a := by
+  rw [taylor_within_apply, Finset.sum_range_succ, iteratedDerivWithin_univ, smul_eq_mul]
+  have hz : (∑ k ∈ Finset.range n,
+      ((k ! : ℝ)⁻¹ * (x - a) ^ k) • iteratedDerivWithin k f Set.univ a) = 0 :=
+    Finset.sum_eq_zero fun k hk => by
+      rw [iteratedDerivWithin_univ, hvanish k (Finset.mem_range.mp hk), smul_zero]
+  rw [hz, zero_add]
+
+/-- **The `n`-th Taylor coefficient as a limit.** If `f` is `n`-times continuously
+differentiable and `f^(k)(a) = 0` for every `k < n`, then
+
+    f(x)/(x-a)^n → f^(n)(a)/n!    as x → a  (x ≠ a).
+
+This is the heart of the iterated rule: it extracts the leading (order-`n`) Taylor
+coefficient of `f` at `a` as a genuine two-sided limit. Proof: Taylor's theorem gives
+`(f x - taylorWithinEval f n univ a x)/(x-a)^n → 0`; the polynomial collapses to
+`(f^(n)(a)/n!)(x-a)^n` (`taylorWithinEval_collapse`), which contributes exactly the
+constant `f^(n)(a)/n!` after dividing by `(x-a)^n`. -/
+theorem tendsto_div_pow_of_iteratedDeriv {f : ℝ → ℝ} {a : ℝ} {n : ℕ}
+    (hf : ContDiff ℝ n f) (hvanish : ∀ k < n, iteratedDeriv k f a = 0) :
+    Tendsto (fun x => f x / (x - a) ^ n) (𝓝[≠] a) (𝓝 (iteratedDeriv n f a / (n ! : ℝ))) := by
+  -- Taylor's theorem with little-o remainder, along `𝓝[univ] a = 𝓝 a`.
+  have htaylor := Real.taylor_tendsto (convex_univ) (Set.mem_univ a) hf.contDiffOn
+  rw [nhdsWithin_univ] at htaylor
+  -- Restrict the limit to the punctured neighbourhood `𝓝[≠] a ≤ 𝓝 a`.
+  have htaylor' : Tendsto
+      (fun x => (f x - taylorWithinEval f n Set.univ a x) / (x - a) ^ n)
+      (𝓝[≠] a) (𝓝 0) :=
+    htaylor.mono_left nhdsWithin_le_nhds
+  have hfact : (n ! : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_pos n).ne'
+  -- Add the constant `f^(n)(a)/n!`; the sum tends to `0 + f^(n)(a)/n!`.
+  have hlim : Tendsto
+      (fun x => (f x - taylorWithinEval f n Set.univ a x) / (x - a) ^ n
+        + iteratedDeriv n f a / (n ! : ℝ))
+      (𝓝[≠] a) (𝓝 (0 + iteratedDeriv n f a / (n ! : ℝ))) :=
+    htaylor'.add tendsto_const_nhds
+  rw [zero_add] at hlim
+  -- On `𝓝[≠] a` this sum equals `f(x)/(x-a)^n`.
+  apply hlim.congr'
+  filter_upwards [self_mem_nhdsWithin] with x hx
+  have hxa : x - a ≠ 0 := sub_ne_zero.mpr (by simpa using hx)
+  have hd : (x - a) ^ n ≠ 0 := pow_ne_zero n hxa
+  rw [taylorWithinEval_collapse hvanish]
+  field_simp
+  ring
+
+/-- **Iterated L'Hôpital's rule for `0/0`, as a ratio of `n`-th Taylor coefficients.**
+For `f, g` that are `n`-times continuously differentiable at `a`, with
+
+    f^(k)(a) = g^(k)(a) = 0   for all k < n,   g^(n)(a) ≠ 0,
+
+we have
+
+    f(x)/g(x) → f^(n)(a) / g^(n)(a)    as x → a.
+
+The proof divides the two coefficient limits `f(x)/(x-a)^n → f^(n)(a)/n!` and
+`g(x)/(x-a)^n → g^(n)(a)/n!` (both from `tendsto_div_pow_of_iteratedDeriv`) and cancels
+the common `(x-a)^n`, using `g^(n)(a) ≠ 0` for the nonzero denominator. The two `1/n!`
+factors cancel, leaving the pure ratio of `n`-th derivatives. This is the exact
+order-`n` analogue of the parent's `lhopital_zero_taylor`. -/
+theorem lhopital_zero_taylor_iterated {f g : ℝ → ℝ} {a : ℝ} {n : ℕ}
+    (hf : ContDiff ℝ n f) (hg : ContDiff ℝ n g)
+    (hfv : ∀ k < n, iteratedDeriv k f a = 0)
+    (hgv : ∀ k < n, iteratedDeriv k g a = 0)
+    (hgn : iteratedDeriv n g a ≠ 0) :
+    Tendsto (fun x => f x / g x) (𝓝[≠] a)
+      (𝓝 (iteratedDeriv n f a / iteratedDeriv n g a)) := by
+  have hF := tendsto_div_pow_of_iteratedDeriv hf hfv
+  have hG := tendsto_div_pow_of_iteratedDeriv hg hgv
+  have hfact : (n ! : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_pos n).ne'
+  have hgn' : iteratedDeriv n g a / (n ! : ℝ) ≠ 0 := div_ne_zero hgn hfact
+  have hdiv := hF.div hG hgn'
+  -- The limit value `(f^(n)/n!)/(g^(n)/n!)` collapses to `f^(n)/g^(n)`.
+  rw [div_div_div_cancel_right₀ hfact] at hdiv
+  apply hdiv.congr'
+  filter_upwards [self_mem_nhdsWithin] with x hx
+  have hxa : x - a ≠ 0 := sub_ne_zero.mpr (by simpa using hx)
+  simp only [Pi.div_apply]
+  rw [div_div_div_cancel_right₀ (pow_ne_zero n hxa)]
+
+/-- The same statement packaged so the limit is *named* by the ratio of `n`-th Taylor
+coefficients `f^(n)(a)/n!` and `g^(n)(a)/n!` — making explicit that order-`n` L'Hôpital
+*is* the ratio of the first surviving Taylor coefficients. -/
+theorem lhopital_zero_taylor_iterated_coeff {f g : ℝ → ℝ} {a : ℝ} {n : ℕ}
+    (hf : ContDiff ℝ n f) (hg : ContDiff ℝ n g)
+    (hfv : ∀ k < n, iteratedDeriv k f a = 0)
+    (hgv : ∀ k < n, iteratedDeriv k g a = 0)
+    (hgn : iteratedDeriv n g a ≠ 0) :
+    Tendsto (fun x => f x / g x) (𝓝[≠] a)
+      (𝓝 ((iteratedDeriv n f a / (n ! : ℝ)) / (iteratedDeriv n g a / (n ! : ℝ)))) := by
+  have hfact : (n ! : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_pos n).ne'
+  rw [div_div_div_cancel_right₀ hfact]
+  exact lhopital_zero_taylor_iterated hf hg hfv hgv hgn
+
+/-! ### Worked example: `(1 - cos x)/x² → 1/2` (a genuine `n = 2` case) -/
+
+/-- Derivative of the numerator `x ↦ 1 - cos x` is `x ↦ sin x`. -/
+private theorem deriv_one_sub_cos : deriv (fun x : ℝ => 1 - Real.cos x) = fun x => Real.sin x := by
+  funext x
+  have : HasDerivAt (fun x : ℝ => 1 - Real.cos x) (Real.sin x) x := by
+    simpa using (hasDerivAt_const x (1 : ℝ)).sub (Real.hasDerivAt_cos x)
+  exact this.deriv
+
+/-- Derivative of `x ↦ x²` is `x ↦ 2x`. -/
+private theorem deriv_sq : deriv (fun x : ℝ => x ^ 2) = fun x => 2 * x := by
+  funext x
+  have : HasDerivAt (fun x : ℝ => x ^ 2) (2 * x) x := by
+    simpa using hasDerivAt_pow 2 x
+  exact this.deriv
+
+/-- Worked example: `(1 - cos x)/x² → 1/2` as `x → 0`. Both numerator and denominator
+vanish to order 2 (`f(0) = f'(0) = 0`, `g(0) = g'(0) = 0`), so single-step L'Hôpital is
+still `0/0`; the second-order rule gives the limit `f''(0)/g''(0) = 1/2`. -/
+example : Tendsto (fun x => (1 - Real.cos x) / x ^ 2) (𝓝[≠] (0 : ℝ)) (𝓝 (1 / 2)) := by
+  set f : ℝ → ℝ := fun x => 1 - Real.cos x with hf_def
+  set g : ℝ → ℝ := fun x => x ^ 2 with hg_def
+  -- Smoothness.
+  have hf : ContDiff ℝ 2 f := contDiff_const.sub Real.contDiff_cos
+  have hg : ContDiff ℝ 2 g := contDiff_id.pow 2
+  -- Second derivatives at 0.
+  have hf2 : iteratedDeriv 2 f 0 = 1 := by
+    rw [iteratedDeriv_succ, iteratedDeriv_one, hf_def, deriv_one_sub_cos]
+    have : HasDerivAt (fun x : ℝ => Real.sin x) (Real.cos 0) 0 := Real.hasDerivAt_sin 0
+    rw [this.deriv, Real.cos_zero]
+  have hg2 : iteratedDeriv 2 g 0 = 2 := by
+    rw [iteratedDeriv_succ, iteratedDeriv_one, hg_def, deriv_sq]
+    have : HasDerivAt (fun x : ℝ => 2 * x) 2 0 := by
+      simpa using (hasDerivAt_id (0 : ℝ)).const_mul 2
+    rw [this.deriv]
+  -- Vanishing of the lower derivatives.
+  have hfv : ∀ k < 2, iteratedDeriv k f 0 = 0 := by
+    intro k hk
+    interval_cases k
+    · rw [iteratedDeriv_zero, hf_def]; simp
+    · rw [iteratedDeriv_one, hf_def, deriv_one_sub_cos]; simp
+  have hgv : ∀ k < 2, iteratedDeriv k g 0 = 0 := by
+    intro k hk
+    interval_cases k
+    · rw [iteratedDeriv_zero, hg_def]; simp
+    · rw [iteratedDeriv_one, hg_def, deriv_sq]; simp
+  have hgn : iteratedDeriv 2 g 0 ≠ 0 := by rw [hg2]; norm_num
+  have h := lhopital_zero_taylor_iterated hf hg hfv hgv hgn
+  rw [hf2, hg2] at h
+  simpa using h
+
+#check @lhopital_zero_taylor_iterated
+
+end LHopitalOQ04OQ01

--- a/research/problems/lhopital-oq-04-oq-01/knowledge.md
+++ b/research/problems/lhopital-oq-04-oq-01/knowledge.md
@@ -4,18 +4,45 @@ Insights accumulated during research on this problem.
 
 ---
 
-## Problem Understanding
+## Session 2026-06-30 (Session 1) — SOLVED (FRESH)
 
-[Initial observations about the problem will be recorded here]
+**Mode**: FRESH · **Outcome**: completed (0 sorries, 0 axioms, no native_decide)
+**File**: `proofs/Proofs/LHopitalOQ04OQ01.lean` (200 lines, 6 theorems)
+
+### What I Did
+Formalized iterated L'Hôpital as a ratio of n-th Taylor coefficients via the
+recommended little-o / `Real.taylor_tendsto` route (Approach 1 from problem.md).
+
+### Key Findings / Techniques
+- **`Real.taylor_tendsto (convex_univ) (Set.mem_univ a) hf.contDiffOn`** is the whole
+  analytic input: `(f x − taylorWithinEval f n univ a x)/(x−a)^n → 0` along `𝓝[univ] a`.
+  Rewrite `nhdsWithin_univ` then `.mono_left nhdsWithin_le_nhds` restricts to `𝓝[≠] a`.
+- **Polynomial collapse** (`taylorWithinEval_collapse`): `taylor_within_apply` +
+  `Finset.sum_range_succ` splits off the k=n term; the range-n remainder is
+  `Finset.sum_eq_zero` because each summand carries `iteratedDeriv k f a = 0`. Use
+  `iteratedDerivWithin_univ` to bridge within→plain derivatives, `smul_eq_mul` for ℝ.
+  Note: `rw [iteratedDerivWithin_univ]` after `sum_range_succ` only hits the *outer*
+  k=n term (the bound-variable occurrences inside the sum are shielded from rw).
+- **Coefficient limit** built by `htaylor'.add tendsto_const_nhds` then `Tendsto.congr'`;
+  pointwise `field_simp; ring` after `rw [taylorWithinEval_collapse]`.
+- **Ratio step** = parent template: `hF.div hG hgn'`, then `div_div_div_cancel_right₀`
+  cancels the shared `n!` in the limit value AND the shared `(x−a)^n` pointwise. Needed
+  `simp only [Pi.div_apply]` before the pointwise cancel (Tendsto.div gives a `Pi.div`,
+  not a beta-reduced `fun x => …/…`).
+- **Example** `(1−cos x)/x² → 1/2`: computed f''(0)=1, g''(0)=2 via `iteratedDeriv_succ`/
+  `iteratedDeriv_one` + `HasDerivAt.deriv` (deriv(1−cos)=sin, deriv(x²)=2x); vanishing of
+  order 0,1 by `interval_cases k`. All plain tactics → 0-axiom.
+
+### Gotchas
+- Factorial `!` notation is `scoped notation … => Nat.factorial` in namespace `Nat` →
+  **must `open Nat`** or `(n ! : ℝ)` fails to parse ("unexpected token ':'").
+- `Nat.factorial_pos n |>.ne'` for `(n! : ℝ) ≠ 0` via `Nat.cast_ne_zero.mpr`.
+
+### Status
+COMPLETE. Verified 0-axiom. PR pending.
 
 ---
 
-## Insights
-
-[Insights from research attempts will be accumulated here]
-
----
-
-## Dead Ends
-
-[Approaches known not to work will be documented here]
+## Follow-up open questions generated
+- One-sided Lagrange-remainder route (`taylor_mean_remainder_lagrange_iteratedDeriv`).
+- Mismatched vanishing orders: `g^(n)(a)=0` but `g^(m)(a)≠0`, m>n.

--- a/src/data/proofs/lhopital-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/lhopital-oq-04-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-lhoq0401-header",
+    "proofId": "lhopital-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "From order-1 to order-n L'Hôpital",
+    "content": "The parent entry proves the order-1 Taylor form of L'Hôpital: if f a = g a = 0 then f(x)/g(x) → f′(a)/g′(a), because near a each function equals its linear Taylor term. But when the first derivatives also vanish (say (1−cos x)/x², where both numerator and denominator vanish to order 2) a single L'Hôpital step is still 0/0. This file generalizes to arbitrary order n: if f and g vanish at a together with all derivatives up to order n−1 and g^(n)(a) ≠ 0, then f(x)/g(x) → f^(n)(a)/g^(n)(a). The whole generalization rests on one fact — the coefficient-extraction limit f(x)/(x−a)^n → f^(n)(a)/n! — obtained from Taylor's theorem with a little-o remainder. No Mean Value Theorem is used.",
+    "mathContext": "Order-n indeterminate $0/0$: $f^{(k)}(a)=g^{(k)}(a)=0$ for $k<n$, $g^{(n)}(a)\\neq 0$. Taylor: $f(x)=\\frac{f^{(n)}(a)}{n!}(x-a)^n+o((x-a)^n)$, so $\\frac{f(x)}{g(x)}\\to\\frac{f^{(n)}(a)}{g^{(n)}(a)}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["L'Hôpital's rule", "iterated derivative", "Taylor expansion", "little-o remainder", "indeterminate forms"],
+    "prerequisites": ["the 0/0 indeterminate form", "Taylor's theorem with remainder", "iterated derivatives"]
+  },
+  {
+    "id": "ann-lhoq0401-collapse",
+    "proofId": "lhopital-oq-04-oq-01",
+    "range": { "startLine": 41, "endLine": 60 },
+    "type": "insight",
+    "title": "Collapsing the Taylor polynomial to one monomial",
+    "content": "taylorWithinEval_collapse is the combinatorial core. The degree-n Taylor polynomial is the finite sum ∑_{k≤n} (k!)⁻¹(x−a)^k f^(k)(a) (Mathlib's taylor_within_apply, over Set.univ so iteratedDerivWithin = iteratedDeriv). Under the vanishing hypotheses f^(k)(a) = 0 for k < n, every term below order n dies; the k = n term is the polynomial's top degree. So the whole polynomial collapses to the single monomial (n!)⁻¹(x−a)^n f^(n)(a). The proof splits off the k = n term with Finset.sum_range_succ and discharges the remaining range-n sum with Finset.sum_eq_zero, each summand carrying the factor f^(k)(a) = 0.",
+    "mathContext": "$\\mathrm{taylorWithinEval}\\,f\\,n\\,\\mathbb{R}\\,a\\,x=\\sum_{k=0}^{n}\\frac{(x-a)^k}{k!}f^{(k)}(a)=\\frac{(x-a)^n}{n!}f^{(n)}(a)$ once $f^{(k)}(a)=0$ for $k<n$.",
+    "significance": "key",
+    "relatedConcepts": ["Taylor polynomial", "finite sums", "iteratedDerivWithin vs iteratedDeriv", "vanishing coefficients"],
+    "prerequisites": ["taylor_within_apply", "Finset.sum_range_succ", "iteratedDerivWithin_univ"]
+  },
+  {
+    "id": "ann-lhoq0401-coefflimit",
+    "proofId": "lhopital-oq-04-oq-01",
+    "range": { "startLine": 62, "endLine": 98 },
+    "type": "insight",
+    "title": "The heart: f(x)/(x−a)^n → f^(n)(a)/n!",
+    "content": "tendsto_div_pow_of_iteratedDeriv extracts the n-th Taylor coefficient as a genuine two-sided limit. Real.taylor_tendsto gives (f x − taylorWithinEval f n univ a x)/(x−a)^n → 0 along 𝓝[univ] a = 𝓝 a; restricting to the punctured filter 𝓝[≠] a (nhdsWithin_le_nhds) keeps it. Adding the constant f^(n)(a)/n! and transporting along the collapse identity — for x ≠ a, f(x)/(x−a)^n = (f x − taylorWithinEval …)/(x−a)^n + f^(n)(a)/n! (field_simp; ring) — turns the little-o statement into the coefficient limit. This lemma is the single fact the whole rule reduces to, and is reusable wherever a leading Taylor coefficient must be read off as a limit.",
+    "mathContext": "$\\dfrac{f(x)}{(x-a)^n}=\\dfrac{f(x)-P_n(x)}{(x-a)^n}+\\dfrac{f^{(n)}(a)}{n!}\\to 0+\\dfrac{f^{(n)}(a)}{n!}$, where $P_n$ is the collapsed Taylor polynomial.",
+    "significance": "critical",
+    "relatedConcepts": ["Taylor's theorem", "little-o", "punctured neighbourhood filter", "Tendsto.congr'", "coefficient extraction"],
+    "prerequisites": ["Real.taylor_tendsto", "nhdsWithin_le_nhds", "Filter.Tendsto.add"]
+  },
+  {
+    "id": "ann-lhoq0401-rule",
+    "proofId": "lhopital-oq-04-oq-01",
+    "range": { "startLine": 100, "endLine": 146 },
+    "type": "insight",
+    "title": "Dividing the two coefficient limits",
+    "content": "lhopital_zero_taylor_iterated divides the numerator and denominator coefficient limits. From hF : f(x)/(x−a)^n → f^(n)(a)/n! and hG : g(x)/(x−a)^n → g^(n)(a)/n!, the quotient hF.div hG (valid since g^(n)(a)/n! ≠ 0) tends to (f^(n)(a)/n!)/(g^(n)(a)/n!). The two 1/n! factors cancel by div_div_div_cancel_right₀, leaving the pure ratio f^(n)(a)/g^(n)(a). Transporting along f(x)/g(x) = (f(x)/(x−a)^n)/(g(x)/(x−a)^n) for x ≠ a (the same lemma with c = (x−a)^n) finishes it. This is the exact order-n analogue of the parent's lhopital_zero_taylor. The _coeff variant simply names the value as the ratio of n-th Taylor coefficients before the factorials cancel.",
+    "mathContext": "$\\dfrac{f(x)}{g(x)}=\\dfrac{f(x)/(x-a)^n}{g(x)/(x-a)^n}\\to\\dfrac{f^{(n)}(a)/n!}{g^{(n)}(a)/n!}=\\dfrac{f^{(n)}(a)}{g^{(n)}(a)}$.",
+    "significance": "key",
+    "relatedConcepts": ["Filter.Tendsto.div", "div_div_div_cancel_right₀", "ratio of Taylor coefficients", "Tendsto.congr'"],
+    "prerequisites": ["quotient of limits", "the coefficient-extraction limit"]
+  },
+  {
+    "id": "ann-lhoq0401-example",
+    "proofId": "lhopital-oq-04-oq-01",
+    "range": { "startLine": 148, "endLine": 198 },
+    "type": "example",
+    "title": "(1 − cos x)/x² → 1/2, a true second-order case",
+    "content": "The worked example instantiates the order-2 rule where single-step L'Hôpital is still indeterminate: f = 1 − cos x has f(0) = f′(0) = 0, and g = x² has g(0) = g′(0) = 0, so f(x)/g(x) is 0/0 even after one differentiation. The rule reads off the limit from the second derivatives: f″(0) = cos 0 = 1 and g″(0) = 2, giving 1/2. The second derivatives are computed explicitly — deriv_one_sub_cos (deriv (1 − cos x) = sin x) and deriv_sq (deriv (x²) = 2x) via HasDerivAt, then one more derivative through iteratedDeriv_succ. Vanishing of the order-0 and order-1 derivatives is handled by interval_cases. No native_decide, so the entry stays 0-axiom.",
+    "mathContext": "$\\lim_{x\\to 0}\\dfrac{1-\\cos x}{x^2}=\\dfrac{f''(0)}{g''(0)}=\\dfrac{1}{2}$; both vanish to order 2 so a single L'Hôpital step gives $0/0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["second derivative", "iteratedDeriv", "HasDerivAt", "worked example"],
+    "prerequisites": ["derivatives of sin and cos", "iterated derivatives of monomials"]
+  }
+]

--- a/src/data/proofs/lhopital-oq-04-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-04-oq-01/meta.json
@@ -1,0 +1,199 @@
+{
+  "id": "lhopital-oq-04-oq-01",
+  "title": "Iterated L'Hôpital as a Ratio of n-th Taylor Coefficients",
+  "slug": "lhopital-oq-04-oq-01",
+  "description": "Answers the parent Taylor-route L'Hôpital entry's OQ-01 — generalize the order-1 rule to arbitrary order n. If f and g vanish at a together with all derivatives up to order n-1 and g^(n)(a) ≠ 0, then f(x)/g(x) → f^(n)(a)/g^(n)(a). The engine is the coefficient-extraction limit f(x)/(x-a)^n → f^(n)(a)/n!, obtained from Taylor's theorem with little-o remainder (Real.taylor_tendsto) by collapsing the degree-n Taylor polynomial to its single surviving top monomial. Dividing the two coefficient limits and cancelling (x-a)^n gives the rule, exactly as the parent divides two order-1 limits. Worked n=2 example (1-cos x)/x² → 1/2. Verified, zero axioms, no native_decide.",
+  "meta": {
+    "author": "L'Hôpital / Bernoulli (1696); iterated Taylor route formalized in Lean 4",
+    "date": "1696",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LHopitalOQ04OQ01.lean",
+    "tags": [
+      "analysis",
+      "calculus",
+      "lhopital",
+      "taylor-series",
+      "limits",
+      "derivatives",
+      "iterated-derivative"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 200,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "originalContributions": [
+      "taylorWithinEval_collapse: under vanishing lower derivatives f^(k)(a)=0 for k<n, the degree-n Taylor polynomial collapses to its single top monomial (n!)⁻¹·(x-a)^n·f^(n)(a). Proved by expanding taylor_within_apply into a finite sum over Set.univ (iteratedDerivWithin = iteratedDeriv), splitting off the k=n term, and killing every k<n term with the vanishing factor.",
+      "tendsto_div_pow_of_iteratedDeriv: the n-th Taylor coefficient as a limit — f(x)/(x-a)^n → f^(n)(a)/n! from Taylor's theorem with little-o remainder (Real.taylor_tendsto) plus the polynomial collapse. This is the heart of the iterated rule and independently reusable for extracting leading coefficients in asymptotics.",
+      "lhopital_zero_taylor_iterated: iterated L'Hôpital for 0/0 as a ratio of n-th Taylor coefficients — f(x)/g(x) → f^(n)(a)/g^(n)(a), by dividing the two coefficient limits and cancelling (x-a)^n (div_div_div_cancel_right₀). No Mean Value Theorem, generalizing the parent's order-1 lhopital_zero_taylor.",
+      "lhopital_zero_taylor_iterated_coeff: the same limit named as the ratio (f^(n)(a)/n!)/(g^(n)(a)/n!), making explicit that order-n L'Hôpital is the ratio of the first surviving Taylor coefficients.",
+      "Worked n=2 example (1 - cos x)/x² → 1/2: a genuinely second-order 0/0 form where single-step L'Hôpital is still indeterminate; the second derivatives f''(0)=1, g''(0)=2 are computed via iterated deriv, giving the limit 1/2. No native_decide."
+    ],
+    "prerequisites": [
+      "Taylor's theorem with the little-o (Peano) remainder (Real.taylor_tendsto)",
+      "The Taylor polynomial taylorWithinEval and its finite-sum expansion (taylor_within_apply)",
+      "Iterated derivatives (iteratedDeriv) and their equality with iteratedDerivWithin on Set.univ",
+      "Limit arithmetic: Filter.Tendsto.div and Tendsto.add for combining limits",
+      "L'Hôpital's rule for the 0/0 indeterminate form (order-1 parent entry)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.taylor_tendsto",
+        "description": "Taylor's theorem as a limit: (f x - taylorWithinEval f n s x₀ x)/(x-x₀)^n → 0 along 𝓝[s] x₀, under Convex s, x₀ ∈ s, ContDiffOn ℝ n f s. The analytic input, used with s = Set.univ.",
+        "module": "Mathlib.Analysis.Calculus.Taylor"
+      },
+      {
+        "theorem": "taylor_within_apply",
+        "description": "Expands taylorWithinEval f n s x₀ x = ∑_{k≤n} (k!)⁻¹(x-x₀)^k • iteratedDerivWithin k f s x₀ — the finite sum whose lower terms vanish.",
+        "module": "Mathlib.Analysis.Calculus.Taylor"
+      },
+      {
+        "theorem": "iteratedDerivWithin_univ",
+        "description": "iteratedDerivWithin n f Set.univ = iteratedDeriv n f — bridges the within-derivatives of the Taylor lemmas to plain iterated derivatives.",
+        "module": "Mathlib.Analysis.Calculus.IteratedDeriv.Defs"
+      },
+      {
+        "theorem": "div_div_div_cancel_right₀",
+        "description": "(a/c)/(b/c) = a/b for c ≠ 0 — cancels the shared (x-a)^n across numerator and denominator, and the shared n! in the coefficient ratio.",
+        "module": "Mathlib.Algebra.GroupWithZero.Units.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "L'Hôpital's rule (1696, due to Johann Bernoulli) evaluates 0/0 limits by differentiating numerator and denominator. When the first derivatives also vanish, the classical procedure applies the rule repeatedly. The parent gallery entry gave the Taylor-series explanation of the single step: near a, f and g look like their linear Taylor terms, so f(x)/g(x) → f'(a)/g'(a). This entry closes that entry's own open question by explaining the iterated procedure in one clean statement: when f and g vanish to order n, the limit is the ratio of the first surviving Taylor coefficients f^(n)(a)/g^(n)(a). The mechanism is that near a each function behaves like (coefficient)·(x-a)^n, so the shared (x-a)^n cancels.",
+    "problemStatement": "**Open Question (parent lhopital-oq-04, OQ-01)**: iterated L'Hôpital — when f^(k)(a) = g^(k)(a) = 0 for k < n, prove the limit equals the ratio of n-th Taylor coefficients f^(n)(a)/g^(n)(a), via f(x)/(x-a)^n → f^(n)(a)/n! from Taylor's theorem with remainder.\n\n**This entry**: proves f(x)/g(x) → f^(n)(a)/g^(n)(a) (for f, g in ContDiff ℝ n, vanishing to order n-1, g^(n)(a) ≠ 0) via the coefficient-extraction limit, with zero axioms and no Mean Value Theorem.",
+    "text": "A 200-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing only Mathlib. Its core is tendsto_div_pow_of_iteratedDeriv: the coefficient-extraction limit f(x)/(x-a)^n → f^(n)(a)/n!, obtained from Real.taylor_tendsto after taylorWithinEval_collapse reduces the Taylor polynomial to its top monomial. lhopital_zero_taylor_iterated then divides the f- and g-limits and cancels (x-a)^n; lhopital_zero_taylor_iterated_coeff renames the value as a ratio of n-th coefficients. A worked n=2 example (1 - cos x)/x² → 1/2 instantiates the rule with genuinely second-order vanishing.",
+    "proofStrategy": "taylorWithinEval_collapse expands taylorWithinEval via taylor_within_apply into ∑_{k≤n} (k!)⁻¹(x-a)^k f^(k)(a) (using iteratedDerivWithin_univ), splits off the k=n term with Finset.sum_range_succ, and shows the remaining range-n sum is zero because each term carries the vanishing factor f^(k)(a) = 0. tendsto_div_pow_of_iteratedDeriv takes Real.taylor_tendsto along 𝓝[univ] a = 𝓝 a, restricts to 𝓝[≠] a (nhdsWithin_le_nhds), adds the constant f^(n)(a)/n!, and transports along the eventual equality f(x)/(x-a)^n = (f x - taylorWithinEval …)/(x-a)^n + f^(n)(a)/n! (from the collapse, valid for x ≠ a) via Tendsto.congr'. lhopital_zero_taylor_iterated forms hF.div hG using g^(n)(a)/n! ≠ 0, rewrites the limit value with div_div_div_cancel_right₀ (the two n! cancel), and transports along f(x)/g(x) = (f(x)/(x-a)^n)/(g(x)/(x-a)^n) for x ≠ a. No Mean Value Theorem appears.",
+    "keyInsights": [
+      "The whole iterated rule reduces to one fact, the coefficient-extraction limit f(x)/(x-a)^n → f^(n)(a)/n! — Taylor's theorem with little-o remainder, once the polynomial is collapsed to its top term.",
+      "Under the vanishing hypotheses the degree-n Taylor polynomial has exactly one surviving term (n!)⁻¹(x-a)^n f^(n)(a); everything below order n is killed by f^(k)(a) = 0, everything above is beyond the polynomial's degree.",
+      "The cancellation f(x)/g(x) = (f(x)/(x-a)^n)/(g(x)/(x-a)^n) for x ≠ a is the order-n analogue of the parent's (x-a) cancellation — the shared (x-a)^n factor is the common Taylor scale divided out of both.",
+      "The two 1/n! factors cancel in the ratio, so the limit is the pure ratio of n-th derivatives f^(n)(a)/g^(n)(a), not of Taylor coefficients — the factorials are an artifact of the extraction that disappears.",
+      "This is strictly more than an inductive chain of single-step L'Hôpital applications: it is one clean statement, and it makes explicit that a 0/0 limit of order n is a ratio of n-th Taylor coefficients — not an artifact of the Mean Value Theorem.",
+      "The example (1 - cos x)/x² → 1/2 is genuinely second order: both numerator and denominator vanish to order 2, so a single L'Hôpital step is still 0/0; the rule reads off f''(0)/g''(0) = 1/2 directly."
+    ]
+  },
+  "sections": [
+    {
+      "id": "polynomial-collapse",
+      "title": "Collapsing the Taylor Polynomial",
+      "startLine": 51,
+      "endLine": 60,
+      "summary": "taylorWithinEval_collapse: under f^(k)(a)=0 for k<n, the degree-n Taylor polynomial reduces to its single top monomial (n!)⁻¹(x-a)^n f^(n)(a).",
+      "mathContext": "Finite-sum expansion (taylor_within_apply) with all lower terms killed by the vanishing hypotheses."
+    },
+    {
+      "id": "coefficient-limit",
+      "title": "The n-th Taylor Coefficient as a Limit",
+      "startLine": 62,
+      "endLine": 98,
+      "summary": "tendsto_div_pow_of_iteratedDeriv: f(x)/(x-a)^n → f^(n)(a)/n! from Real.taylor_tendsto plus the polynomial collapse — the heart of the iterated rule.",
+      "mathContext": "Taylor's theorem with little-o remainder, restricted to 𝓝[≠] a and transported along the collapse identity."
+    },
+    {
+      "id": "iterated-rule",
+      "title": "Iterated L'Hôpital via Dividing Coefficient Limits",
+      "startLine": 100,
+      "endLine": 146,
+      "summary": "lhopital_zero_taylor_iterated divides the two coefficient limits and cancels (x-a)^n to get f(x)/g(x) → f^(n)(a)/g^(n)(a); the coeff variant names the value as a ratio of n-th coefficients.",
+      "mathContext": "f(x)/g(x) = (f(x)/(x-a)^n)/(g(x)/(x-a)^n) → f^(n)(a)/g^(n)(a), no MVT."
+    },
+    {
+      "id": "example",
+      "title": "Worked Example (1 - cos x)/x² → 1/2",
+      "startLine": 148,
+      "endLine": 198,
+      "summary": "A genuine n=2 case: numerator and denominator both vanish to order 2, second derivatives f''(0)=1 and g''(0)=2 computed via iterated deriv, limit 1/2.",
+      "mathContext": "Instantiating the order-2 rule where single-step L'Hôpital is still indeterminate."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the parent Taylor-route L'Hôpital entry's OQ-01 by generalizing the order-1 rule to arbitrary order n: when f and g vanish at a to order n-1 and g^(n)(a) ≠ 0, the limit f(x)/g(x) → f^(n)(a)/g^(n)(a) follows from the single coefficient-extraction fact f(x)/(x-a)^n → f^(n)(a)/n! divided across numerator and denominator, with zero axioms and no Mean Value Theorem.",
+    "implications": "The result gives a single clean statement in place of an inductive chain of single-step L'Hôpital applications, and isolates the deepest content of the rule: a 0/0 limit of order n is a ratio of n-th Taylor coefficients. The coefficient-extraction lemma tendsto_div_pow_of_iteratedDeriv is independently reusable wherever an n-th Taylor coefficient must be extracted as a limit — in asymptotics and singularity analysis.",
+    "openQuestions": [
+      "A one-sided Lagrange-remainder variant: derive the same limit from taylor_mean_remainder_lagrange_iteratedDeriv via an explicit intermediate point and continuity of f^(n), comparing the two routes.",
+      "Extend to the case g^(n)(a) = 0 but g^(m)(a) ≠ 0 for some m > n (mismatched vanishing orders), where the limit is 0 or ±∞ depending on the numerator's order."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lhopital-oq-04",
+      "relationship": "extends",
+      "description": "Parent entry: the order-1 Taylor derivation f(x)/g(x) → f'(a)/g'(a). This entry generalizes it to arbitrary order n, answering the parent's OQ-01 on iterated L'Hôpital."
+    },
+    {
+      "targetId": "lhopital",
+      "relationship": "related",
+      "description": "Grandparent entry: the Mean-Value-Theorem proof of L'Hôpital's 0/0 rule that this Taylor route deliberately avoids."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "Nat"
+    ],
+    "namespace": "LHopitalOQ04OQ01",
+    "lineCount": 200,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "lhopital_zero_taylor_iterated",
+        "type": "core",
+        "description": "Iterated L'Hôpital for 0/0 as a ratio of n-th Taylor coefficients (no MVT): f(x)/g(x) → f^(n)(a)/g^(n)(a) when f,g vanish to order n-1 and g^(n)(a) ≠ 0.",
+        "leanType": "{f g : ℝ → ℝ} → {a : ℝ} → {n : ℕ} → ContDiff ℝ n f → ContDiff ℝ n g → (∀ k < n, iteratedDeriv k f a = 0) → (∀ k < n, iteratedDeriv k g a = 0) → iteratedDeriv n g a ≠ 0 → Tendsto (fun x => f x / g x) (𝓝[≠] a) (𝓝 (iteratedDeriv n f a / iteratedDeriv n g a))"
+      },
+      {
+        "name": "tendsto_div_pow_of_iteratedDeriv",
+        "type": "key",
+        "description": "The n-th Taylor coefficient as a limit: f(x)/(x-a)^n → f^(n)(a)/n! when f^(k)(a)=0 for k<n. The heart of the iterated rule.",
+        "leanType": "{f : ℝ → ℝ} → {a : ℝ} → {n : ℕ} → ContDiff ℝ n f → (∀ k < n, iteratedDeriv k f a = 0) → Tendsto (fun x => f x / (x - a) ^ n) (𝓝[≠] a) (𝓝 (iteratedDeriv n f a / n !))"
+      },
+      {
+        "name": "taylorWithinEval_collapse",
+        "type": "supporting",
+        "description": "Under vanishing lower derivatives, the degree-n Taylor polynomial collapses to its top monomial (n!)⁻¹(x-a)^n f^(n)(a).",
+        "leanType": "{f : ℝ → ℝ} → {a x : ℝ} → {n : ℕ} → (∀ k < n, iteratedDeriv k f a = 0) → taylorWithinEval f n Set.univ a x = (n !)⁻¹ * (x - a) ^ n * iteratedDeriv n f a"
+      }
+    ],
+    "path": "Proofs/LHopitalOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "lhopital_zero_taylor_iterated",
+      "type": "core",
+      "description": "Iterated L'Hôpital 0/0 as a ratio of n-th Taylor coefficients, no Mean Value Theorem.",
+      "leanType": "{f g : ℝ → ℝ} → {a : ℝ} → {n : ℕ} → ContDiff ℝ n f → ContDiff ℝ n g → (∀ k < n, iteratedDeriv k f a = 0) → (∀ k < n, iteratedDeriv k g a = 0) → iteratedDeriv n g a ≠ 0 → Tendsto (fun x => f x / g x) (𝓝[≠] a) (𝓝 (iteratedDeriv n f a / iteratedDeriv n g a))"
+    },
+    {
+      "name": "tendsto_div_pow_of_iteratedDeriv",
+      "type": "key",
+      "description": "The n-th Taylor coefficient as a limit: f(x)/(x-a)^n → f^(n)(a)/n! under vanishing lower derivatives.",
+      "leanType": "{f : ℝ → ℝ} → {a : ℝ} → {n : ℕ} → ContDiff ℝ n f → (∀ k < n, iteratedDeriv k f a = 0) → Tendsto (fun x => f x / (x - a) ^ n) (𝓝[≠] a) (𝓝 (iteratedDeriv n f a / n !))"
+    }
+  ],
+  "references": [
+    {
+      "authors": "de l'Hôpital, Guillaume (after Johann Bernoulli)",
+      "title": "Analyse des Infiniment Petits pour l'Intelligence des Lignes Courbes",
+      "year": "1696",
+      "venue": "Paris",
+      "note": "The original publication of the rule"
+    },
+    {
+      "authors": "Rudin, Walter",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "venue": "McGraw-Hill (3rd ed.)",
+      "note": "Taylor's theorem with remainder and its relation to the iterated 0/0 form"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent Taylor-route L'Hôpital entry's **OQ-01**: generalize the order-1 rule to arbitrary order `n`. If `f` and `g` vanish at `a` together with all derivatives up to order `n−1` and `g^(n)(a) ≠ 0`, then
```
f(x)/g(x) → f^(n)(a) / g^(n)(a)   as x → a.
```

The engine is the **coefficient-extraction limit** `f(x)/(x−a)^n → f^(n)(a)/n!`, obtained from Taylor's theorem with a little-o remainder (`Real.taylor_tendsto`) by collapsing the degree-`n` Taylor polynomial to its single surviving top monomial. Dividing the two coefficient limits and cancelling the shared `(x−a)^n` gives the rule — exactly as the parent divides two order-1 limits. **No Mean Value Theorem.**

## Contents (`proofs/Proofs/LHopitalOQ04OQ01.lean`, 200 lines)
- `taylorWithinEval_collapse` — degree-n Taylor polynomial collapses to `(n!)⁻¹(x−a)^n f^(n)(a)` under vanishing lower derivatives.
- `tendsto_div_pow_of_iteratedDeriv` — the n-th Taylor coefficient as a limit (the heart).
- `lhopital_zero_taylor_iterated` — the iterated rule, ratio of n-th coefficients.
- `lhopital_zero_taylor_iterated_coeff` — same limit named by `(f^(n)/n!)/(g^(n)/n!)`.
- Worked **n=2** example `(1 − cos x)/x² → 1/2` (a genuine second-order 0/0, where single-step L'Hôpital is still indeterminate).

## Verification
- **0 sorries, 0 axioms, no native_decide.** Builds green (Docker, 7743 jobs).
- Imports only Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)