### PR TITLE
Fix: restore missing meta.proofRepoPath on two verified Gödel entries

### DIFF
--- a/src/data/proofs/godel-incompleteness-oq-02/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-02/meta.json
@@ -8,6 +8,7 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/G%C3%B6del%27s_incompleteness_theorems#Proof_via_Berry's_paradox",
     "date": "1936",
     "status": "verified",
+    "proofRepoPath": "Proofs/GodelIncompletenessOQ02.lean",
     "tags": [
       "logic",
       "foundations",

--- a/src/data/proofs/godel-incompleteness-oq-04/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-04/meta.json
@@ -8,6 +8,7 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Inaccessible_cardinal",
     "date": "1930",
     "status": "verified",
+    "proofRepoPath": "Proofs/GodelIncompletenessOQ04.lean",
     "tags": [
       "logic",
       "foundations",


### PR DESCRIPTION
## Fix

Two verified gallery entries were missing the `meta.proofRepoPath` field, so tooling could not resolve their Lean source files.

## Evidence

**Before**: `godel-incompleteness-oq-02` and `godel-incompleteness-oq-04` had `meta.proofRepoPath` absent (only `leanFile.path` present). This breaks the `proofRepoPath == leanFile.path` invariant held by all other 2,433 verified entries.

Impact: several scripts key off `meta.proofRepoPath` and cannot fall back to the object-form `leanFile.path`:
- `scripts/auditor/find-targets.ts` — `proofMeta.proofRepoPath || (typeof proofMeta.leanFile === 'string' ? ... : '')` → resolves to `''` for these entries, so the auditor can't locate their Lean files.
- `scripts/peer-reviewer/find-targets.ts` — same pattern.
- `scripts/annotations/build.ts` — uses `meta.proofRepoPath` to locate the Lean source for annotation building.

**After**: added `"proofRepoPath": "Proofs/GodelIncompletenessOQ02.lean"` and `"proofRepoPath": "Proofs/GodelIncompletenessOQ04.lean"` (each matching the existing `leanFile.path`; both files verified present and 0-axiom / 0-sorry). Minimal 2-line diff, no reformatting.

---
Automated fix by lean-mechanic agent.