### PR TITLE
Enrich 6 classic theorems: add references (batch 6)

### DIFF
--- a/src/data/proofs/circumference-via-differentiation/meta.json
+++ b/src/data/proofs/circumference-via-differentiation/meta.json
@@ -142,5 +142,34 @@
     "definitionCount": 2,
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Calculus, Volume I",
+      "year": 1967,
+      "venue": "Wiley, 2nd ed.",
+      "note": "Rigorous treatment of area, arc length, and the fundamental theorem of calculus underlying C(r) = dA/dr = 2πr."
+    },
+    {
+      "authors": "Michael Spivak",
+      "title": "Calculus",
+      "year": 2008,
+      "venue": "Publish or Perish, 4th ed.",
+      "note": "Careful development of differentiation and the geometric meaning of the derivative used in the area-circumference duality."
+    },
+    {
+      "authors": "Walter Rudin",
+      "title": "Principles of Mathematical Analysis",
+      "year": 1976,
+      "venue": "McGraw-Hill, 3rd ed.",
+      "note": "Foundational real analysis for differentiation and integration against which the derivation is machine-checked."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: deriv, integration, and Real.pi API",
+      "year": 2024,
+      "note": "Supplies the differentiation and integration infrastructure and the constant π used to verify C(r) = dA/dr."
+    }
+  ]
 }

--- a/src/data/proofs/ehrhart-cube-proven/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven/meta.json
@@ -215,5 +215,41 @@
       "significance": "Product formula for cube Ehrhart polynomials"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Eugène Ehrhart",
+      "title": "Sur les polyèdres rationnels homothétiques à n dimensions",
+      "year": 1962,
+      "venue": "Comptes Rendus de l'Académie des Sciences 254, 616–618",
+      "note": "Introduces the Ehrhart polynomial counting lattice points in dilates of a rational polytope; L([0,1]^d, n) = (n+1)^d is the paradigm case."
+    },
+    {
+      "authors": "Matthias Beck and Sinai Robins",
+      "title": "Computing the Continuous Discretely: Integer-Point Enumeration in Polyhedra",
+      "year": 2015,
+      "venue": "Springer, 2nd ed.",
+      "note": "Modern textbook on Ehrhart theory and Ehrhart–Macdonald reciprocity, both verified here for the unit cube."
+    },
+    {
+      "authors": "Ian G. Macdonald",
+      "title": "Polynomials Associated with Finite Cell-Complexes",
+      "year": 1971,
+      "venue": "Journal of the London Mathematical Society s2-4(1), 181–192",
+      "note": "Establishes Ehrhart–Macdonald reciprocity L(P, −n) = (−1)^d L(P°, n), the interior-count (n−1)^d identity proved algebraically here."
+    },
+    {
+      "authors": "Georg Alexander Pick",
+      "title": "Geometrisches zur Zahlenlehre",
+      "year": 1899,
+      "venue": "Sitzungsberichte des deutschen naturwissenschaftlich-medicinischen Vereines für Böhmen ‘Lotos’ 19, 311–319",
+      "note": "Pick's formula for lattice polygons, derived here as the d = 2 specialization of the cube Ehrhart polynomial."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Fintype cardinality and Finset.prod API",
+      "year": 2024,
+      "note": "Provides the lattice-point bijection Fin d → Fin(n+1) and the product-formula cardinality machinery used from first principles."
+    }
+  ]
 }

--- a/src/data/proofs/shannon-source-coding-wip-01/meta.json
+++ b/src/data/proofs/shannon-source-coding-wip-01/meta.json
@@ -124,5 +124,41 @@
       "significance": "Bridges to the gallery's definition; lets negMulLog_mul drive the proof"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Claude E. Shannon",
+      "title": "A Mathematical Theory of Communication",
+      "year": 1948,
+      "venue": "Bell System Technical Journal 27, 379–423 & 623–656",
+      "note": "Establishes entropy as the fundamental measure of information; additivity for independent sources is the basis of the source-coding theorem (n i.i.d. symbols carry n·H bits)."
+    },
+    {
+      "authors": "Thomas M. Cover and Joy A. Thomas",
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley, 2nd ed.",
+      "note": "Chapter 2: joint entropy, independence, and the equality case H(X,Y) = H(X) + H(Y) formalized here."
+    },
+    {
+      "authors": "Robert M. Gray",
+      "title": "Entropy and Information Theory",
+      "year": 2011,
+      "venue": "Springer, 2nd ed.",
+      "note": "Rigorous measure-theoretic development of entropy additivity for product measures."
+    },
+    {
+      "authors": "David J. C. MacKay",
+      "title": "Information Theory, Inference, and Learning Algorithms",
+      "year": 2003,
+      "venue": "Cambridge University Press",
+      "note": "Elementary derivation of entropy additivity and its role in typical-set source coding."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Real.negMulLog and finite-sum API",
+      "year": 2024,
+      "note": "Supplies negMulLog_mul and the symbol-by-symbol linearization that drives the additivity proof."
+    }
+  ]
 }

--- a/src/data/proofs/sperner-mathlib4/meta.json
+++ b/src/data/proofs/sperner-mathlib4/meta.json
@@ -128,5 +128,41 @@
       "Proofs/SpernerGridAristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Emanuel Sperner",
+      "title": "Neuer Beweis für die Invarianz der Dimensionszahl und des Gebietes",
+      "year": 1928,
+      "venue": "Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg 6, 265–272",
+      "note": "Original combinatorial lemma on labelings of triangulations, the door-counting core abstracted here."
+    },
+    {
+      "authors": "Martin Aigner and Günter M. Ziegler",
+      "title": "Proofs from THE BOOK",
+      "year": 2018,
+      "venue": "Springer, 6th ed.",
+      "note": "The elegant door-counting (parity) proof of Sperner's lemma that this abstract CellComplex formulation mirrors."
+    },
+    {
+      "authors": "Jiří Matoušek",
+      "title": "Using the Borsuk–Ulam Theorem",
+      "year": 2003,
+      "venue": "Springer",
+      "note": "Sperner's lemma, its equivalence with Brouwer's fixed-point theorem, and combinatorial-topology context."
+    },
+    {
+      "authors": "L. E. J. Brouwer",
+      "title": "Über Abbildung von Mannigfaltigkeiten",
+      "year": 1911,
+      "venue": "Mathematische Annalen 71, 97–115",
+      "note": "Brouwer's fixed-point theorem, the classical application of Sperner's lemma."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Finset, parity, and combinatorics API",
+      "year": 2024,
+      "note": "Supplies the finite-set door-counting infrastructure over which the abstract CellComplex adjacency axioms are stated; drafted in Yaël Dillies' suggested contribution style."
+    }
+  ]
 }

--- a/src/data/proofs/unit-distance-independence/meta.json
+++ b/src/data/proofs/unit-distance-independence/meta.json
@@ -267,5 +267,41 @@
       "mathContext": "Recap of the toolkit: $\\alpha(G)\\ge|V|/\\chi(G)$ (pigeonhole) and $\\alpha(G)\\ge|V|/(\\Delta+1)$ (greedy), feeding the still-open Hadwiger–Nelson window $5\\le\\chi(\\mathbb{R}^2)\\le 7$."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Hugo Hadwiger",
+      "title": "Ungelöste Probleme No. 40",
+      "year": 1961,
+      "venue": "Elemente der Mathematik 16, 103–104",
+      "note": "Popularizes the chromatic number of the plane problem, χ(ℝ²), whose bounds 4 ≤ χ ≤ 7 are studied here (lower bound later improved)."
+    },
+    {
+      "authors": "Aubrey D. N. J. de Grey",
+      "title": "The Chromatic Number of the Plane Is at Least 5",
+      "year": 2018,
+      "venue": "Geombinatorics 28, 18–31",
+      "note": "Breakthrough unit-distance construction raising the Hadwiger–Nelson lower bound to 5, matching the lower bound axiomatized in this entry."
+    },
+    {
+      "authors": "Alexander Soifer",
+      "title": "The Mathematical Coloring Book",
+      "year": 2009,
+      "venue": "Springer",
+      "note": "Comprehensive history of the Hadwiger–Nelson problem, unit-distance graphs, and the 7-coloring hexagonal upper bound."
+    },
+    {
+      "authors": "Paul Erdős",
+      "title": "On Sets of Distances of n Points",
+      "year": 1946,
+      "venue": "American Mathematical Monthly 53, 248–250",
+      "note": "Founding paper on unit-distance graphs and distance problems in the plane, the combinatorial setting of the independence numbers here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: SimpleGraph, independence, and chromatic-number API",
+      "year": 2024,
+      "note": "Provides the simple-graph, independent-set, and coloring infrastructure over which the unit-distance bounds are formalized."
+    }
+  ]
 }

--- a/src/data/proofs/zsqrtd-neg-two/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two/meta.json
@@ -159,5 +159,40 @@
       "significance": "Direct corollary: p = a² + b² + b²"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "David A. Cox",
+      "title": "Primes of the Form x² + ny²: Fermat, Class Field Theory, and Complex Multiplication",
+      "year": 2013,
+      "venue": "Wiley, 2nd ed.",
+      "note": "Definitive reference on representing primes by x² + 2y²; characterizes p ≡ 1, 3 (mod 8) as the represented primes."
+    },
+    {
+      "authors": "Kenneth Ireland and Michael Rosen",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": 1990,
+      "venue": "Springer GTM 84, 2nd ed.",
+      "note": "Quadratic reciprocity, Legendre symbols, and the arithmetic of quadratic rings such as ℤ[√−2]."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Sums of three squares and the classical representation p = x² + 2y² for suitable primes."
+    },
+    {
+      "authors": "Carl Friedrich Gauss",
+      "title": "Disquisitiones Arithmeticae",
+      "year": 1801,
+      "note": "Foundational theory of binary quadratic forms, including the form x² + 2y² and quadratic reciprocity."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Zsqrtd, Zsqrtd.norm, and EuclideanDomain API",
+      "year": 2024,
+      "note": "Provides ℤ[√d] as Zsqrtd, the norm z ↦ a² + 2b², and the Euclidean-domain structure used in the proof."
+    }
+  ]
 }


### PR DESCRIPTION
Adds curated `references` to 6 base-level named-theorem gallery entries that had empty reference lists.

Entries enriched:
- **shannon-source-coding-wip-01** — Shannon 1948, Cover–Thomas, Gray, MacKay (entropy additivity)
- **zsqrtd-neg-two** — Cox, Ireland–Rosen, Hardy–Wright, Gauss (x²+2y² representations)
- **sperner-mathlib4** — Sperner 1928, Aigner–Ziegler, Matoušek, Brouwer
- **ehrhart-cube-proven** — Ehrhart 1962, Beck–Robins, Macdonald 1971, Pick 1899
- **circumference-via-differentiation** — Apostol, Spivak, Rudin
- **unit-distance-independence** — Hadwiger 1961, de Grey 2018, Soifer, Erdős 1946

Each list cites the primary source plus standard references matching the entry's specific content, ending with the relevant Mathlib module. No fabricated citations.

Enrichment pass — references only; no source or proof changes.