### PR TITLE
Fix: add missing meta.proofRepoPath to 2 verified Gödel entries

### DIFF
--- a/src/data/proofs/godel-incompleteness-oq-02/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-02/meta.json
@@ -38,7 +38,8 @@
       "no_decider_for_const_true: a concrete instance showing the obstruction is structural, not about the predicate being 'hard'"
     ],
     "dateAdded": "2026-06-25",
-    "axioms": []
+    "axioms": [],
+    "proofRepoPath": "Proofs/GodelIncompletenessOQ02.lean"
   },
   "overview": {
     "historicalContext": "In 1931 Gödel proved that any consistent, effectively axiomatized theory strong enough for arithmetic is incomplete, building a self-referential sentence by hand via the diagonal lemma. In 1936 Turing proved the halting problem undecidable. The two results are the same diagonal argument viewed from two angles: Turing's undecidability immediately yields incompleteness, because a complete sound theory whose theorems are recursively enumerable would decide the undecidable. Kleene's recursion-theoretic proofs of incompleteness (1936–1943) made this bridge canonical, and it is the form in which the theorem is usually taught in computability courses today. This file formalizes that bridge directly and constructively.",

--- a/src/data/proofs/godel-incompleteness-oq-04/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-04/meta.json
@@ -52,7 +52,8 @@
       "Explicit separation of which closures are inaccessible-specific: inaccessible_add_lt / inaccessible_mul_lt hold for ANY infinite cardinal and are recorded as such, isolating powerset (strong-limit) and replacement (regularity) as the load-bearing properties"
     ],
     "dateAdded": "2026-06-26",
-    "axioms": []
+    "axioms": [],
+    "proofRepoPath": "Proofs/GodelIncompletenessOQ04.lean"
   },
   "overview": {
     "historicalContext": "Gödel's second incompleteness theorem (1931) shows no consistent effective theory extending arithmetic proves its own consistency. The large-cardinal hierarchy is the canonical ladder that climbs the resulting tower of consistency strengths: Zermelo (1930) proved that if κ is strongly inaccessible then the rank-initial segment V_κ is a model of ZFC. Consequently the existence of an inaccessible proves Con(ZFC), so by Gödel 2 the statement 'an inaccessible cardinal exists' is not provable in ZFC (if ZFC is consistent) — the prototypical large-cardinal independence result. The mathematical content of 'V_κ ⊨ ZFC' is, at the level of cardinals, a package of arithmetic closure properties: V_κ must be closed under the ZFC set-builders (pairing, union, powerset, replacement). This file isolates and machine-checks that arithmetic core.",


### PR DESCRIPTION
## Fix

Two `verified` gallery entries — `godel-incompleteness-oq-02` and `godel-incompleteness-oq-04` — were missing `meta.proofRepoPath`. They were the only 2 of 4226 gallery metas lacking this field. Their top-level `leanFile.path` already pointed at the correct, existing Lean source; this PR sets `meta.proofRepoPath` to match.

## Evidence

**Before**: `meta.proofRepoPath` absent on both entries.
- `scripts/auditor/find-targets.ts` L290 and `scripts/peer-reviewer/find-targets.ts` L142 resolve the Lean file via `proofMeta.proofRepoPath || (typeof proofMeta.leanFile === 'string' ? proofMeta.leanFile : '')`. With `proofRepoPath` absent **and** `leanFile` an object, this yields an empty path — the auditor/peer-reviewer cannot locate the source.
- `scripts/annotations/build.ts` L148-149 also reads `meta.meta?.proofRepoPath` to locate the source.

**After**: both entries carry
- `godel-incompleteness-oq-02` → `Proofs/GodelIncompletenessOQ02.lean`
- `godel-incompleteness-oq-04` → `Proofs/GodelIncompletenessOQ04.lean`

matching the existing `leanFile.path` (both files present under `proofs/Proofs/`; sibling `godel-incompleteness-oq-03` already follows this `proofRepoPath == leanFile.path` convention). Minimal 2-line-per-file diff, no reformatting.

---
Automated fix by lean-mechanic agent.