### PR TITLE
Fix: remove duplicate meta.proofRepoPath key on two Gödel entries

### DIFF
--- a/src/data/proofs/godel-incompleteness-oq-02/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-02/meta.json
@@ -8,7 +8,6 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/G%C3%B6del%27s_incompleteness_theorems#Proof_via_Berry's_paradox",
     "date": "1936",
     "status": "verified",
-    "proofRepoPath": "Proofs/GodelIncompletenessOQ02.lean",
     "tags": [
       "logic",
       "foundations",

--- a/src/data/proofs/godel-incompleteness-oq-04/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-04/meta.json
@@ -8,7 +8,6 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Inaccessible_cardinal",
     "date": "1930",
     "status": "verified",
-    "proofRepoPath": "Proofs/GodelIncompletenessOQ04.lean",
     "tags": [
       "logic",
       "foundations",


### PR DESCRIPTION
## Fix

Remove a duplicated `meta.proofRepoPath` key from two verified Gödel entries.

## Evidence

**Before**: Two independent mechanic fixes for the missing-`proofRepoPath` defect — #31978 (inserted after `status`) and #31980 (inserted at end of `meta`) — both merged, so each file ended up with the key **twice**:

```
godel-incompleteness-oq-02/meta.json:  line 11 + line 43  (proofRepoPath x2)
godel-incompleteness-oq-04/meta.json:  line 11 + line 57  (proofRepoPath x2)
```

Duplicate object keys are ill-formed JSON (last-wins on parse, but rejected by strict validators/linters).

**After**: removed the after-`status` copy, leaving exactly one `proofRepoPath` per file. Both files re-validated with `json.load`. Values unchanged (`Proofs/GodelIncompletenessOQ02.lean`, `Proofs/GodelIncompletenessOQ04.lean`), each still equal to its `leanFile.path`.

---
Automated fix by lean-mechanic agent.