### PR TITLE
research(harmonic-divergence-oq-06-oq-02): b=0 endpoint of arithmetic-progression reciprocal divergence [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/HarmonicDivergenceOQ06OQ02.lean
+++ b/proofs/Proofs/HarmonicDivergenceOQ06OQ02.lean
@@ -1,0 +1,95 @@
+/-
+  Divergence of Σ 1/(a·n + b) for a > 0, b ≥ 0 — the b = 0 endpoint
+  Open Question: harmonic-divergence-oq-06-oq-02
+
+  The parent `harmonic-divergence-oq-06` proves, for real a > 0 and *b > 0*,
+  that Σ 1/(a·n + b) diverges (comparison with the shifted harmonic series via
+  a·n + b ≤ (a + b)·(n + 1)). That comparison genuinely needs b > 0: at n = 0
+  with b = 0 the term 1/(a·0 + 0) = 1/0 is 0 by Lean's junk-value convention, so
+  the pointwise bound 1/(n+1) ≤ (a+b)·1/(a·n+b) fails (1 ≤ 0).
+
+  This entry closes the last gap, b = 0. When b = 0 the series is the harmonic
+  series rescaled by 1/a:
+
+      Σ_{n ≥ 1} 1/(a·n) = (1/a) · Σ_{n ≥ 1} 1/n = +∞.
+
+  The n = 0 term is excised by an index shift; the rest factors as (1/a)·(1/n)
+  and reduces to `Real.not_summable_one_div_natCast`.
+
+  ## Main results
+
+  `not_summable_one_div_scaled` (a > 0):
+      ¬ Summable (fun n => 1 / (a · n))                    -- the b = 0 core
+
+  `not_summable_one_div_arith'` (a > 0, 0 ≤ b):
+      ¬ Summable (fun n => 1 / (a · n + b))                -- unified b ≥ 0 statement
+
+  ## Corollaries
+
+  `not_summable_one_div_multiples`      : reciprocals of positive multiples of a
+  `not_summable_harmonic`               : a = 1, b = 0 recovers the raw harmonic series
+  `tendsto_sum_one_div_scaled_atTop`    : partial sums of Σ 1/(a·(n+1)) → ∞
+-/
+
+import Mathlib
+import Proofs.HarmonicDivergenceOQ06
+
+open Filter Topology
+
+namespace HarmonicDivergenceOQ06OQ02
+
+/-- **Scaled-harmonic divergence (the b = 0 endpoint).** For real `a > 0`, the
+    reciprocals of the multiples of `a` are not summable:
+    `¬ Summable (fun n => 1 / (a · n))`.
+
+    The `n = 0` term is `1/0 = 0`; discarding it via an index shift leaves
+    `(1/a)·Σ 1/(n+1)`, which diverges because the harmonic series does. -/
+theorem not_summable_one_div_scaled (a : ℝ) (ha : 0 < a) :
+    ¬ Summable (fun n : ℕ => 1 / (a * (n : ℝ))) := by
+  intro hsum
+  have hane : a ≠ 0 := ha.ne'
+  -- Discard the n = 0 term (`1/0 = 0`) by shifting the index up by one.
+  have hsum1 : Summable (fun n : ℕ => 1 / (a * ((n : ℝ) + 1))) := by
+    have h := (summable_nat_add_iff (f := fun n : ℕ => 1 / (a * (n : ℝ))) 1).mpr hsum
+    simpa using h
+  -- Multiply by `a`: the constant multiple reduces to the shifted harmonic series.
+  have hharm : Summable (fun n : ℕ => 1 / ((n : ℝ) + 1)) := by
+    refine (hsum1.mul_left a).congr (fun n => ?_)
+    rw [one_div, mul_inv, ← mul_assoc, mul_inv_cancel₀ hane, one_mul, one_div]
+  -- But the shifted harmonic series is not summable.
+  exact Real.not_summable_one_div_natCast
+    ((summable_nat_add_iff (f := fun n : ℕ => 1 / (n : ℝ)) 1).mp (by simpa using hharm))
+
+/-- **Unified arithmetic-progression divergence, `b ≥ 0`.** For real `a > 0` and
+    `b ≥ 0`, the reciprocals along `a·n + b` are not summable. This subsumes the
+    parent (`b > 0`) and the scaled-harmonic endpoint (`b = 0`) in one statement. -/
+theorem not_summable_one_div_arith' (a b : ℝ) (ha : 0 < a) (hb : 0 ≤ b) :
+    ¬ Summable (fun n : ℕ => 1 / (a * n + b)) := by
+  rcases hb.lt_or_eq with hpos | hzero
+  · -- b > 0 : this is exactly the parent theorem.
+    exact HarmonicDivergenceOQ06.not_summable_one_div_arith a b ha hpos
+  · -- b = 0 : the series is `1/(a·n)`, handled by the scaled-harmonic lemma.
+    subst hzero
+    simpa using not_summable_one_div_scaled a ha
+
+/-- Reciprocals of the positive multiples of `a` diverge (index shifted so the
+    first term is `1/a`): `¬ Summable (fun n => 1 / (a·(n+1)))`. -/
+theorem not_summable_one_div_multiples (a : ℝ) (ha : 0 < a) :
+    ¬ Summable (fun n : ℕ => 1 / (a * ((n : ℝ) + 1))) := by
+  intro hsum
+  exact not_summable_one_div_scaled a ha
+    ((summable_nat_add_iff (f := fun n : ℕ => 1 / (a * (n : ℝ))) 1).mp (by simpa using hsum))
+
+/-- The raw harmonic series is the `a = 1, b = 0` instance. -/
+theorem not_summable_harmonic :
+    ¬ Summable (fun n : ℕ => 1 / (n : ℝ)) := by
+  simpa using not_summable_one_div_scaled 1 (by norm_num)
+
+/-- The partial sums of the scaled-harmonic series `Σ_{i<n} 1/(a·(i+1))` tend to
+    `+∞`, the explicit divergence statement (terms are nonnegative). -/
+theorem tendsto_sum_one_div_scaled_atTop (a : ℝ) (ha : 0 < a) :
+    Tendsto (fun n => ∑ i ∈ Finset.range n, 1 / (a * ((i : ℝ) + 1))) atTop atTop := by
+  rw [← not_summable_iff_tendsto_nat_atTop_of_nonneg (fun i => by positivity)]
+  exact not_summable_one_div_multiples a ha
+
+end HarmonicDivergenceOQ06OQ02

--- a/research/problems/harmonic-divergence-oq-06-oq-02/knowledge.md
+++ b/research/problems/harmonic-divergence-oq-06-oq-02/knowledge.md
@@ -1,0 +1,52 @@
+# Knowledge Base: harmonic-divergence-oq-06-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]
+
+## Session 2026-06-30 (Session 1) - b=0 endpoint SOLVED
+
+**Mode**: FRESH
+**Outcome**: completed (VERIFIED, 0-axiom)
+
+### What I Did
+- Proved `not_summable_one_div_scaled` (a>0): ¬Summable(1/(a·n)), the b=0 core, by
+  shifting the index (summable_nat_add_iff) to discard the 1/0=0 junk term, then
+  factoring out 1/a (Summable.mul_left + Summable.congr) to reduce to
+  Real.not_summable_one_div_natCast.
+- Packaged the unified `not_summable_one_div_arith'` (a>0, 0≤b) via a case split:
+  b>0 → parent, b=0 → scaled lemma.
+- Corollaries: not_summable_one_div_multiples, not_summable_harmonic (a=1,b=0),
+  tendsto_sum_one_div_scaled_atTop.
+- Docker build: 7744 jobs, success, 0 sorries, no native_decide → 0-axiom.
+- Created gallery entry src/data/proofs/harmonic-divergence-oq-06-oq-02/.
+
+### Key Findings
+- The b=0 obstruction is purely formal (1/0=0 junk value breaks the parent's
+  n=0 comparison term); the index shift is the exact fix.
+- Once n=0 is excised, the series is literally (1/a)·(harmonic), so divergence
+  reduces to one Mathlib fact.
+
+### Files Modified
+- proofs/Proofs/HarmonicDivergenceOQ06OQ02.lean (new, 95L, 5 thm)
+- src/data/proofs/harmonic-divergence-oq-06-oq-02/{meta,annotations}.json (new)
+
+### Next Steps
+- Quantitative asymptotic Σ_{i<n} 1/(a·(i+1)) = (1/a)(ln n + γ) + o(1).
+- Two-sided logarithmic bound uniform over a>0, b≥0.

--- a/src/data/proofs/harmonic-divergence-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-06-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-hdoq06oq02-header",
+    "proofId": "harmonic-divergence-oq-06-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 39
+    },
+    "type": "concept",
+    "title": "Module Overview: The b = 0 Endpoint",
+    "content": "This module extends the parent (harmonic-divergence-oq-06) from b > 0 to b ≥ 0. The parent proves Σ 1/(a·n+b) diverges for a > 0, b > 0 by comparison with the harmonic series, but that comparison genuinely needs b > 0: at n = 0 with b = 0 the term 1/(a·0+0) = 1/0 is 0 (Lean's junk value), so the pointwise bound 1/(n+1) ≤ (a+b)·1/(a·n+b) would assert 1 ≤ 0. This entry closes the endpoint b = 0. It imports Mathlib and the parent module and opens Filter, Topology.",
+    "mathContext": "For $b=0$ the series is $\\sum 1/(a n) = (1/a)\\sum 1/n$, the harmonic series rescaled by $1/a$, once the $n=0$ term is excised.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Summable",
+      "harmonic series",
+      "junk value 1/0",
+      "index shift",
+      "scaling"
+    ],
+    "prerequisites": [
+      "Real.not_summable_one_div_natCast (harmonic divergence)",
+      "summable_nat_add_iff (index shift)",
+      "not_summable_one_div_arith (parent, b > 0 case)"
+    ]
+  },
+  {
+    "id": "ann-hdoq06oq02-scaled",
+    "proofId": "harmonic-divergence-oq-06-oq-02",
+    "range": {
+      "startLine": 41,
+      "endLine": 61
+    },
+    "type": "theorem",
+    "title": "The b = 0 Core: Scaled-Harmonic Divergence",
+    "content": "not_summable_one_div_scaled (a : ℝ) (ha : 0 < a): ¬ Summable (fun n => 1/(a·n)). Proof by contradiction. Since the n = 0 term is 1/0 = 0, summability is preserved by shifting the index up by one (summable_nat_add_iff), giving Summable (fun n => 1/(a·(n+1))). Multiplying by a (Summable.mul_left) and simplifying a·(1/(a·(n+1))) = 1/(n+1) via Summable.congr — using a ≠ 0 from a > 0 through the rewrite one_div, mul_inv, mul_inv_cancel₀ — yields Summable (fun n => 1/(n+1)). Shifting back with summable_nat_add_iff contradicts Real.not_summable_one_div_natCast.",
+    "mathContext": "The key algebraic step is $a \\cdot \\frac{1}{a(n+1)} = \\frac{1}{n+1}$, valid because $a \\neq 0$; the two index shifts bracket the reduction to Mathlib's $\\sum 1/n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "index shift",
+      "constant-multiple stability",
+      "Summable.mul_left",
+      "Summable.congr"
+    ],
+    "prerequisites": [
+      "summable_nat_add_iff",
+      "Summable.mul_left",
+      "Real.not_summable_one_div_natCast"
+    ]
+  },
+  {
+    "id": "ann-hdoq06oq02-unified",
+    "proofId": "harmonic-divergence-oq-06-oq-02",
+    "range": {
+      "startLine": 63,
+      "endLine": 95
+    },
+    "type": "theorem",
+    "title": "Unified b ≥ 0 Statement and Corollaries",
+    "content": "not_summable_one_div_arith' (a b : ℝ) (ha : 0 < a) (hb : 0 ≤ b): ¬ Summable (fun n => 1/(a·n+b)). The proof splits 0 ≤ b into b > 0 (dispatched to the parent not_summable_one_div_arith) and b = 0 (dispatched to not_summable_one_div_scaled after simplifying a·n+0 = a·n). Three corollaries follow: not_summable_one_div_multiples (reciprocals of positive multiples of a, index-shifted); not_summable_harmonic (a = 1, b = 0 recovers Σ 1/n); and tendsto_sum_one_div_scaled_atTop (partial sums Σ_{i<n} 1/(a·(i+1)) → +∞ via not_summable_iff_tendsto_nat_atTop_of_nonneg).",
+    "mathContext": "A single case split unifies the family $a>0,\\ b\\ge 0$; the endpoint $b=0$ is the pure 'multiples of $a$' series, and $a=1,b=0$ is the raw harmonic series.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "case split",
+      "arithmetic progression",
+      "partial sums",
+      "divergence to infinity"
+    ],
+    "prerequisites": [
+      "not_summable_one_div_arith (parent)",
+      "not_summable_iff_tendsto_nat_atTop_of_nonneg"
+    ]
+  }
+]

--- a/src/data/proofs/harmonic-divergence-oq-06-oq-02/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-06-oq-02/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "harmonic-divergence-oq-06-oq-02",
+  "title": "Divergence of Σ 1/(a·n+b) at the Endpoint b = 0",
+  "slug": "harmonic-divergence-oq-06-oq-02",
+  "description": "Closes the b = 0 endpoint of the arithmetic-progression reciprocal divergence family. The parent (harmonic-divergence-oq-06) proves Σ 1/(a·n+b) diverges for a > 0, b > 0 by comparison with the harmonic series; that comparison breaks at n = 0 when b = 0 because 1/(a·0+0) = 1/0 = 0 (Lean's junk value). This entry handles b = 0 by an index shift that discards the n = 0 term, leaving (1/a)·Σ 1/(n+1) — the harmonic series rescaled — and packages a single unified theorem valid for all a > 0, b ≥ 0.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HarmonicDivergenceOQ06OQ02.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "harmonic-series",
+      "summability",
+      "arithmetic-progression",
+      "index-shift",
+      "scaling",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. All theorems are fully machine-checked. The b = 0 core reduces to the divergence of the harmonic series (Real.not_summable_one_div_natCast) via the index-shift lemma summable_nat_add_iff and the constant-multiple stability Summable.mul_left / Summable.congr; the unified theorem dispatches the b > 0 case to the parent. Only the foundational axioms propext, Classical.choice, Quot.sound are used.",
+    "dateAdded": "2026-06-30",
+    "lineCount": 95,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "not_summable_one_div_scaled (PROVED, MAIN new content): for a > 0, ¬ Summable (fun n => 1/(a·n)) — the b = 0 endpoint, proved by shifting the index to discard the junk n = 0 term and factoring out 1/a",
+      "not_summable_one_div_arith' (PROVED, unified): for a > 0, 0 ≤ b, ¬ Summable (fun n => 1/(a·n+b)) — a single statement subsuming the parent (b > 0) and the scaled-harmonic endpoint (b = 0)",
+      "not_summable_one_div_multiples (PROVED): for a > 0, ¬ Summable (fun n => 1/(a·(n+1))) — reciprocals of the positive multiples of a, index-shifted so the first term is 1/a",
+      "not_summable_harmonic (PROVED): ¬ Summable (fun n => 1/n) recovered as the a = 1, b = 0 instance",
+      "tendsto_sum_one_div_scaled_atTop (PROVED): the partial sums Σ_{i<n} 1/(a·(i+1)) → +∞"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.not_summable_one_div_natCast",
+        "description": "¬ Summable (fun n : ℕ => 1/(n:ℝ)) — divergence of the harmonic series, the engine everything reduces to",
+        "module": "Mathlib.Analysis.PSeries"
+      },
+      {
+        "theorem": "summable_nat_add_iff",
+        "description": "Summable (fun n => f (n+k)) ↔ Summable f — the index shift that excises the n = 0 junk term 1/0 = 0",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "Summable.mul_left",
+        "description": "Summable f ⟹ Summable (fun n => c · f n) — multiplying by a keeps the scaled-harmonic series summable, reducing it to Σ 1/(n+1)",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Ring"
+      },
+      {
+        "theorem": "not_summable_iff_tendsto_nat_atTop_of_nonneg",
+        "description": "For nonnegative terms, ¬Summable f ↔ partial sums tend to +∞ — converts non-summability to the explicit divergence statement",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Real"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The divergence of the harmonic series Σ 1/n was first established by Nicole Oresme (c. 1350) via dyadic blocking. Its rescalings Σ 1/(a·n) = (1/a)·Σ 1/n are the simplest divergent series after the harmonic series itself, and the b = 0 progression 0, a, 2a, 3a, … is the most natural 'multiples of a' starting point. The subtlety here is purely formal: in a proof assistant 1/0 is assigned the junk value 0, so the b = 0 series must be indexed from n = 1 (or its n = 0 term excised) before the classical scaling argument applies. This entry records that excision explicitly, completing the arithmetic-progression divergence family begun in the parent.",
+    "problemStatement": "**OQ-02 of harmonic-divergence-oq-06.**\n\nExtend the parent's arithmetic-progression divergence to admit b = 0:\n\n  ∀ a > 0, ∀ b ≥ 0, ¬ Summable (fun n : ℕ => 1/(a·n+b)),\n\nthe new content being the endpoint b = 0, where Σ 1/(a·n) is the harmonic series rescaled by 1/a and the n = 0 term 1/0 must be discarded.",
+    "text": "For a > 0 and b ≥ 0, ¬ Summable (fun n => 1/(a·n+b)); in particular the scaled-harmonic endpoint ¬ Summable (fun n => 1/(a·n)).",
+    "proofStrategy": "**The b = 0 core (not_summable_one_div_scaled).** Suppose Σ 1/(a·n) were summable. The n = 0 term is 1/0 = 0, so summability is unchanged by shifting the index up by one (`summable_nat_add_iff`), giving Summable (fun n => 1/(a·(n+1))). Multiplying by a (`Summable.mul_left`) and simplifying a·(1/(a·(n+1))) = 1/(n+1) (`Summable.congr`, using a ≠ 0) yields Summable (fun n => 1/(n+1)). Shifting back identifies this with Σ 1/n, contradicting `Real.not_summable_one_div_natCast`.\n\n**The unified statement (not_summable_one_div_arith').** For 0 ≤ b, split on b = 0 versus b > 0: the positive case is exactly the parent theorem `not_summable_one_div_arith`, and the b = 0 case is the scaled-harmonic lemma above (after simplifying a·n+0 = a·n).\n\n**Corollaries.** The reciprocals of the positive multiples of a diverge (index-shifted form); the raw harmonic series is recovered at a = 1, b = 0; and the partial sums Σ_{i<n} 1/(a·(i+1)) tend to +∞ via `not_summable_iff_tendsto_nat_atTop_of_nonneg`.",
+    "keyInsights": [
+      "The only obstruction to b = 0 is formal, not mathematical: 1/(a·0+0) = 1/0 = 0 is a junk value, so the parent's pointwise comparison 1/(n+1) ≤ (a+b)·1/(a·n+b) fails at n = 0 (it would assert 1 ≤ 0). Excising that single term via an index shift removes the obstruction.",
+      "Once the n = 0 term is gone, Σ 1/(a·(n+1)) is literally a constant multiple of the harmonic series: dividing out 1/a via Summable.mul_left / Summable.congr reduces divergence of the whole b = 0 family to the one fact Real.not_summable_one_div_natCast.",
+      "The unified hypothesis 0 ≤ b is dispatched by a single case split — b > 0 to the parent, b = 0 to the scaled lemma — so the entire family a > 0, b ≥ 0 becomes one reusable theorem rather than two special cases.",
+      "Summability is invariant under multiplication by the nonzero constant a: this is the textbook 'a divergent series stays divergent when rescaled', made precise by Summable.mul_left together with the a ≠ 0 obtained from a > 0.",
+      "The two index shifts (summable_nat_add_iff, applied to excise n = 0 and then to compare with Σ 1/n) are the workhorse: Mathlib's harmonic divergence is phrased for 1/n, so all bookkeeping is about matching that shape."
+    ],
+    "prerequisites": [
+      "Real.not_summable_one_div_natCast (divergence of the harmonic series) from Mathlib",
+      "The index-shift lemma summable_nat_add_iff",
+      "Constant-multiple stability of summability: Summable.mul_left, Summable.congr",
+      "The parent theorem not_summable_one_div_arith (a > 0, b > 0 case)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring explaining why the parent needs b > 0 (the 1/0 junk value at n = 0 breaks the comparison) and how the b = 0 endpoint is recovered by an index shift plus scaling. Imports Mathlib and the parent module Proofs.HarmonicDivergenceOQ06, opens Filter and Topology, namespace HarmonicDivergenceOQ06OQ02.",
+      "mathContext": "The engine is $\\neg\\,\\text{Summable}\\,(n \\mapsto 1/n)$; the b = 0 case is $(1/a)$ times it after discarding the $n = 0$ term."
+    },
+    {
+      "id": "sec-scaled",
+      "title": "The b = 0 Core: Scaled-Harmonic Divergence",
+      "startLine": 41,
+      "endLine": 61,
+      "summary": "not_summable_one_div_scaled (a : ℝ) (ha : 0 < a): assume Σ 1/(a·n) summable, shift the index by one via summable_nat_add_iff to drop the n = 0 junk term, multiply by a with Summable.mul_left and simplify a·(1/(a·(n+1))) = 1/(n+1) via Summable.congr, then contradict Real.not_summable_one_div_natCast after shifting back.",
+      "mathContext": "$\\sum_{n\\ge 1} 1/(a n) = (1/a)\\sum_{n\\ge 1} 1/n = +\\infty$; the $n=0$ term $1/0$ is excised, not summed."
+    },
+    {
+      "id": "sec-unified",
+      "title": "Unified b ≥ 0 Statement and Corollaries",
+      "startLine": 63,
+      "endLine": 95,
+      "summary": "not_summable_one_div_arith' (a b : ℝ) (ha : 0 < a) (hb : 0 ≤ b): case split on b, dispatching b > 0 to the parent not_summable_one_div_arith and b = 0 to not_summable_one_div_scaled. Then not_summable_one_div_multiples (index-shifted multiples of a), not_summable_harmonic (a = 1, b = 0 recovers Σ 1/n), and tendsto_sum_one_div_scaled_atTop (partial sums → +∞).",
+      "mathContext": "One theorem covers every $a>0,\\ b\\ge 0$; the endpoint $b=0$ is the pure 'multiples of $a$' case closest to the raw harmonic series."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "harmonic-divergence-oq-06",
+      "relationship": "extends",
+      "description": "Direct parent: proves Σ 1/(a·n+b) diverges for a > 0, b > 0 via comparison with the harmonic series. This entry answers its open question 'Generalise to b ≥ 0 (allowing b = 0)' by excising the n = 0 term."
+    },
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "extends",
+      "description": "Grandparent: divergence of Σ 1/n, recovered here as the a = 1, b = 0 instance (not_summable_harmonic). The whole b = 0 family is a constant multiple of it."
+    },
+    {
+      "targetId": "p-series",
+      "relationship": "related",
+      "description": "Σ 1/n^p converges iff p > 1; the scaled-harmonic series Σ 1/(a·n) is the borderline linear case p = 1 and diverges for every a > 0."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified: for every a > 0 and b ≥ 0, the arithmetic-progression reciprocal series Σ 1/(a·n+b) diverges. The new content over the parent is the endpoint b = 0, where Σ 1/(a·n) is the harmonic series rescaled by 1/a; the n = 0 junk term 1/0 is excised by an index shift. A single unified theorem now covers the full family a > 0, b ≥ 0. Zero sorries, zero extra axioms.",
+    "implications": "**Completes the arithmetic-progression divergence family.** Parent (b > 0) and this entry (b = 0) combine into one statement covering all a > 0, b ≥ 0, ready to be reused by any result needing 'linear-density reciprocal series diverge'.\\n\\n**Isolates a formalization subtlety.** The endpoint is mathematically trivial (scaling) but formally requires excising the junk value 1/0 = 0 — a clean illustration of how proof assistants handle division by zero and why an index shift is the right tool.",
+    "openQuestions": [
+      "Prove the quantitative rescaling Σ_{i<n} 1/(a·(i+1)) = (1/a)(ln n + γ) + o(1), making the 1/a factor and the Euler–Mascheroni constant explicit for the scaled series.",
+      "Formalize the two-sided bound c₁·ln n ≤ Σ_{i<n} 1/(a·i+b) ≤ c₂·ln n for a > 0, b ≥ 0, capturing the logarithmic growth rate uniformly across the whole progression family."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "not_summable_one_div_scaled",
+      "type": "core",
+      "description": "The b = 0 endpoint: for a > 0, the reciprocals of the multiples of a diverge.",
+      "leanType": "(a : ℝ) → 0 < a → ¬ Summable (fun n : ℕ => 1 / (a * n))"
+    },
+    {
+      "name": "not_summable_one_div_arith'",
+      "type": "core",
+      "description": "Unified statement: for a > 0 and b ≥ 0, the arithmetic-progression reciprocal series diverges.",
+      "leanType": "(a b : ℝ) → 0 < a → 0 ≤ b → ¬ Summable (fun n : ℕ => 1 / (a * n + b))"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.HarmonicDivergenceOQ06"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "HarmonicDivergenceOQ06OQ02",
+    "lineCount": 95,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 2,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/HarmonicDivergenceOQ06OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Nicole Oresme",
+      "title": "Quaestiones super Geometriam Euclidis",
+      "year": "c. 1350",
+      "venue": "manuscript",
+      "note": "First proof that the harmonic series diverges. The scaled-harmonic endpoint Σ 1/(a·n) = (1/a)·Σ 1/n proved here is an immediate constant-multiple consequence."
+    },
+    {
+      "authors": "Konrad Knopp",
+      "title": "Theory and Application of Infinite Series",
+      "year": "1951",
+      "venue": "Blackie & Son, 2nd English ed.",
+      "note": "Standard reference for the elementary theory of series, including the invariance of divergence under nonzero scaling and under alteration of finitely many terms — precisely the two facts (Summable.mul_left, summable_nat_add_iff) used here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "The Lean Mathematical Library — Real.not_summable_one_div_natCast, summable_nat_add_iff, Summable.mul_left",
+      "year": "2020",
+      "venue": "Proceedings of CPP 2020, pp. 367–381",
+      "note": "Supplies the harmonic-divergence engine, the index-shift equivalence used to excise the n = 0 junk term, and the constant-multiple stability of summability reused in this entry."
+    }
+  ]
+}

--- a/src/data/research/problems/harmonic-divergence-oq-06-oq-02.json
+++ b/src/data/research/problems/harmonic-divergence-oq-06-oq-02.json
@@ -1,0 +1,189 @@
+{
+  "slug": "harmonic-divergence-oq-06-oq-02",
+  "title": "Divergence of Σ 1/(a·n+b) for b ≥ 0 (including the b = 0 scaled-harmonic case)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\forall\\, a > 0,\\ \\forall\\, b \\ge 0,\\qquad\n\\sum_{n \\ge 1} \\frac{1}{a\\,n + b} = +\\infty\n\\quad\\Longleftrightarrow\\quad\n\\neg\\,\\text{Summable}\\ \\Bigl(n \\mapsto \\tfrac{1}{a\\,n + b}\\Bigr).",
+    "plain": "The parent proof shows that the reciprocals of any arithmetic progression",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-30T22:49:26-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: b=0 endpoint proved, VERIFIED 0-axiom (5 thm/95L). Unified b>=0 theorem packages parent+endpoint. Gallery entry created.",
+    "builtItems": [
+      "not_summable_one_div_scaled (a>0): not Summable(1/(a*n)) - Proofs/HarmonicDivergenceOQ06OQ02.lean:47",
+      "not_summable_one_div_arith' (a>0,0<=b): unified not Summable(1/(a*n+b)) - HarmonicDivergenceOQ06OQ02.lean:66",
+      "not_summable_one_div_multiples, not_summable_harmonic, tendsto_sum_one_div_scaled_atTop corollaries"
+    ],
+    "insights": [
+      "The b=0 obstruction is purely formal: 1/(a*0+0)=1/0=0 (Lean junk value) breaks the parent's pointwise comparison 1/(n+1) <= (a+b)*1/(a*n+b) at n=0 (asserts 1<=0). Excising the n=0 term via summable_nat_add_iff removes it.",
+      "After the index shift, Sum 1/(a*(n+1)) is a constant multiple of the harmonic series; Summable.mul_left + Summable.congr divide out 1/a, reducing to Real.not_summable_one_div_natCast.",
+      "Unified 0<=b handled by a single case split: b>0 -> parent not_summable_one_div_arith, b=0 -> scaled-harmonic lemma."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Quantitative: Sum_{i<n} 1/(a*(i+1)) = (1/a)(ln n + gamma) + o(1), making 1/a and Euler-Mascheroni explicit",
+      "Two-sided log bound c1*ln n <= Sum_{i<n} 1/(a*i+b) <= c2*ln n uniform over a>0,b>=0"
+    ],
+    "markdown": "# Knowledge Base: harmonic-divergence-oq-06-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "analysis",
+    "series",
+    "harmonic-series",
+    "summability",
+    "arithmetic-progression",
+    "comparison-test"
+  ],
+  "relatedProofs": [
+    "harmonic-divergence",
+    "harmonic-divergence-oq-01",
+    "harmonic-divergence-oq-02",
+    "harmonic-divergence-oq-02-oq-01",
+    "harmonic-divergence-oq-03",
+    "harmonic-divergence-oq-04",
+    "harmonic-divergence-oq-05",
+    "harmonic-divergence-oq-05-oq-01",
+    "harmonic-divergence-oq-05-oq-02",
+    "harmonic-divergence-oq-06"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-01T05:59:00.178Z",
+  "lastUpdate": "2026-07-01T05:59:00.261Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/HarmonicDivergence.lean",
+      "filename": "HarmonicDivergence.lean",
+      "lineCount": 182,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergence.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ01.lean",
+      "filename": "HarmonicDivergenceOQ01.lean",
+      "lineCount": 254,
+      "theoremCount": 52,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ01.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ02.lean",
+      "filename": "HarmonicDivergenceOQ02.lean",
+      "lineCount": 290,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ02.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ02OQ01.lean",
+      "filename": "HarmonicDivergenceOQ02OQ01.lean",
+      "lineCount": 214,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ03.lean",
+      "filename": "HarmonicDivergenceOQ03.lean",
+      "lineCount": 154,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ03.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ04.lean",
+      "filename": "HarmonicDivergenceOQ04.lean",
+      "lineCount": 107,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ04.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ05.lean",
+      "filename": "HarmonicDivergenceOQ05.lean",
+      "lineCount": 146,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ05.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ05OQ01.lean",
+      "filename": "HarmonicDivergenceOQ05OQ01.lean",
+      "lineCount": 123,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ05OQ02.lean",
+      "filename": "HarmonicDivergenceOQ05OQ02.lean",
+      "lineCount": 243,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ05OQ02.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ06.lean",
+      "filename": "HarmonicDivergenceOQ06.lean",
+      "lineCount": 85,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ06.lean"
+    }
+  ]
+}


### PR DESCRIPTION
Closes the **b = 0 endpoint** of the arithmetic-progression reciprocal divergence family, answering the parent (`harmonic-divergence-oq-06`) open question *"Generalise to b ≥ 0 (allowing b = 0, i.e. Σ 1/(a·n))."*

## The subtlety
The parent proves `¬ Summable (fun n => 1/(a·n+b))` for `a > 0, b > 0` by comparison with the harmonic series. That comparison **genuinely needs `b > 0`**: at `n = 0` with `b = 0` the term `1/(a·0+0) = 1/0 = 0` (Lean junk value), so the pointwise bound `1/(n+1) ≤ (a+b)·1/(a·n+b)` would assert `1 ≤ 0`. The obstruction is purely formal, not mathematical.

## What is proved
- **`not_summable_one_div_scaled`** `(a > 0)`: `¬ Summable (fun n => 1/(a·n))` — the b = 0 core. Index-shift (`summable_nat_add_iff`) to discard the `n = 0` junk term, factor out `1/a` (`Summable.mul_left` + `Summable.congr`), reduce to `Real.not_summable_one_div_natCast`.
- **`not_summable_one_div_arith'`** `(a > 0, 0 ≤ b)`: unified statement, case split `b > 0` → parent, `b = 0` → scaled lemma.
- Corollaries: `not_summable_one_div_multiples`, `not_summable_harmonic` (a=1,b=0 recovers Σ 1/n), `tendsto_sum_one_div_scaled_atTop`.

## Verification
- Docker build `Proofs.HarmonicDivergenceOQ06OQ02`: **7744 jobs, success**.
- 5 theorems / 95 lines, **0 sorries**, no `native_decide`/`axiom` → **verified, 0-axiom** (only `propext`/`Classical.choice`/`Quot.sound`).
- Gallery entry added (`meta.json` + `annotations.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
