### PR TITLE
Enrich 6 oq-child entries: add references (Lamé, Smith normal form, Vandermonde, birthday, exp limit, equivariant Borsuk-Ulam)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03/meta.json
@@ -140,6 +140,38 @@
       "relationship": "related"
     }
   ],
+  "references": [
+    {
+      "authors": "Gabriel Lamé",
+      "title": "Note sur la limite du nombre des divisions dans la recherche du plus grand commun diviseur entre deux nombres entiers (Comptes Rendus Acad. Sci. 19)",
+      "year": 1844,
+      "note": "The original O(log) bound on the number of division steps in the Euclidean algorithm, formalized here."
+    },
+    {
+      "authors": "Donald E. Knuth",
+      "title": "The Art of Computer Programming, Vol. 2: Seminumerical Algorithms (3rd ed.)",
+      "year": 1997,
+      "note": "Addison-Wesley. §4.5.3 analyzes the Euclidean algorithm; the Fibonacci worst case matches the tight lower bound."
+    },
+    {
+      "authors": "John D. Dixon",
+      "title": "The number of steps in the Euclidean algorithm (Journal of Number Theory 2)",
+      "year": 1970,
+      "note": "Sharp average- and worst-case step counts, complementing the Θ(log) characterization."
+    },
+    {
+      "authors": "Eric Bach and Jeffrey Shallit",
+      "title": "Algorithmic Number Theory, Vol. 1: Efficient Algorithms",
+      "year": 1996,
+      "note": "MIT Press. GCD algorithm complexity and the Fibonacci extremal input."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.log and Nat.gcd recursion infrastructure",
+      "year": 2024,
+      "note": "⌊log₂⌋ bounds and well-founded gcd recursion used to state and prove the step-count characterization."
+    }
+  ],
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-06-27",

--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Smith Normal Form over PIDs: GCD Characterization via Mathlib",
   "slug": "bezout-identity-oq-04-oq-01-oq-01",
   "description": "Generalizes the Smith Normal Form theory from ℤ to arbitrary Principal Ideal Domains. The 1×2 invariant factor equals gcd(a,b) up to associates in any GCDMonoid. Unimodularity becomes IsUnit det. The key technique replaces the ±1 case split with a unit.inv_val cancellation argument.",
+  "references": [
+    {
+      "authors": "Henry J. S. Smith",
+      "title": "On systems of linear indeterminate equations and congruences (Phil. Trans. Royal Soc. 151)",
+      "year": 1861,
+      "note": "Introduces the Smith normal form and its invariant factors, generalized here from ℤ to arbitrary PIDs."
+    },
+    {
+      "authors": "Nathan Jacobson",
+      "title": "Basic Algebra I (2nd ed.)",
+      "year": 1985,
+      "note": "W. H. Freeman. Smith normal form and the structure theorem for modules over a PID."
+    },
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra (Revised 3rd ed.), GTM 211",
+      "year": 2002,
+      "note": "Springer. Modules over principal ideal domains and invariant factors."
+    },
+    {
+      "authors": "David S. Dummit and Richard M. Foote",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": 2004,
+      "note": "Wiley. Smith normal form and the associated GCD characterization of invariant factors."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: GCDMonoid, IsPrincipalIdealRing and Matrix.SpecialLinearGroup",
+      "year": 2024,
+      "note": "The GCDMonoid abstraction and IsUnit det condition replacing the ℤ-specific ±1 case split."
+    }
+  ],
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Smith_normal_form",

--- a/src/data/proofs/binomial-theorem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02/meta.json
@@ -3,6 +3,38 @@
   "title": "The Classical Limit (1+x/n)^n → exp(x)",
   "slug": "binomial-theorem-oq-03-oq-02",
   "description": "The fundamental limit characterization of the exponential function, proved from first principles: log'(1) = 1, so n·log(1+x/n) → x, and continuity of exp gives (1+x/n)^n → exp(x). Includes Euler's number as (1+1/n)^n → e, the reciprocal limit, and the compounding inequality.",
+  "references": [
+    {
+      "authors": "Jacob Bernoulli",
+      "title": "Quaestiones nonnullae de usuris (Acta Eruditorum)",
+      "year": 1683,
+      "note": "The compound-interest limit (1+1/n)^n underlying the constant e."
+    },
+    {
+      "authors": "Leonhard Euler",
+      "title": "Introductio in analysin infinitorum",
+      "year": 1748,
+      "note": "Develops e and the exponential function as a limit of (1+x/n)^n."
+    },
+    {
+      "authors": "Walter Rudin",
+      "title": "Principles of Mathematical Analysis (3rd ed.)",
+      "year": 1976,
+      "note": "McGraw-Hill. The exponential function and its limit and derivative characterizations."
+    },
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Calculus, Volume 1 (2nd ed.)",
+      "year": 1967,
+      "note": "Wiley. log'(1)=1 and the continuity argument turning n·log(1+x/n)→x into (1+x/n)^n→e^x."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Real.hasDerivAt_log, Real.exp_log and Filter.Tendsto machinery",
+      "year": 2024,
+      "note": "HasDerivAt(log,1,1) and continuity of exp, the three Mathlib ingredients of the proof."
+    }
+  ],
   "meta": {
     "author": "Euler (1748); limit definition formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Characterizations_of_the_exponential_function",

--- a/src/data/proofs/binomial-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Vandermonde's Identity: Combinatorial Bijection Proof",
   "slug": "binomial-theorem-oq-04-oq-01",
   "description": "Proves Vandermonde's convolution identity C(m+n,r) = Σ_k C(m,k)·C(n,r-k) via an explicit bijection rather than algebraic/generating function methods. Constructs the bijection between r-subsets of {0,...,m+n-1} and pairs (k-subsets of {0,...,m-1}) × ((r-k)-subsets of {0,...,n-1}), using a 'split by threshold m' map. Proves forward and inverse maps and bijectivity. 14 theorems, 4 definitions, 0 axioms.",
+  "references": [
+    {
+      "authors": "Zhu Shijie (Chu Shih-Chieh)",
+      "title": "Siyuan yujian (Jade Mirror of the Four Unknowns)",
+      "year": 1303,
+      "note": "Earliest known statement of the convolution now called the Chu–Vandermonde identity."
+    },
+    {
+      "authors": "Alexandre-Théophile Vandermonde",
+      "title": "Mémoire sur des irrationnelles de différents ordres (Hist. Acad. Roy. Sci.)",
+      "year": 1772,
+      "note": "The European statement of the convolution C(m+n,r)=Σ C(m,k)C(n,r−k)."
+    },
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Enumerative Combinatorics, Volume 1 (2nd ed.)",
+      "year": 2011,
+      "note": "Cambridge University Press. Bijective proofs of binomial convolutions, the method used in this entry."
+    },
+    {
+      "authors": "Ronald L. Graham, Donald E. Knuth and Oren Patashnik",
+      "title": "Concrete Mathematics (2nd ed.)",
+      "year": 1994,
+      "note": "Addison-Wesley. §5.1 develops Vandermonde's convolution and its combinatorial meaning."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Finset.card and explicit bijection (Equiv) infrastructure",
+      "year": 2024,
+      "note": "Finset cardinality and bijection lemmas supporting the split-by-threshold-m map."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",

--- a/src/data/proofs/birthday-problem-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Birthday Problem OQ01: Expected Number of Shared Birthday Pairs",
   "slug": "birthday-problem-oq-01",
   "description": "The expected number of shared birthday pairs among n people with d equally likely birthdays is C(n,2)/d = n(n-1)/(2d). Proved: formula, monotonicity, variance bounds, threshold computations (n=28 first exceeds 1 pair for d=365), and general threshold criterion. The concrete triple/quad threshold values and the thresholds_summary record are discharged by native_decide (relies on Lean.ofReduceBool).",
+  "references": [
+    {
+      "authors": "Richard von Mises",
+      "title": "Über Aufteilungs- und Besetzungswahrscheinlichkeiten (Revue de la Faculté des Sciences, Istanbul)",
+      "year": 1939,
+      "note": "An early formulation of the birthday problem and coincidence counting."
+    },
+    {
+      "authors": "William Feller",
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. 1 (3rd ed.)",
+      "year": 1968,
+      "note": "Wiley. Occupancy problems and expected coincidences via indicator variables."
+    },
+    {
+      "authors": "Sheldon Ross",
+      "title": "A First Course in Probability (8th ed.)",
+      "year": 2010,
+      "note": "Pearson. Linearity of expectation over pair-indicators gives E[X]=C(n,2)/d directly."
+    },
+    {
+      "authors": "Persi Diaconis and Frederick Mosteller",
+      "title": "Methods for Studying Coincidences (Journal of the American Statistical Association 84)",
+      "year": 1989,
+      "note": "Systematic treatment of birthday-type coincidence expectations and thresholds."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Finset.sum, Nat.choose and probability-mass infrastructure",
+      "year": 2024,
+      "note": "Summation over pair-indicators and the C(n,2) count used in the expectation formula."
+    }
+  ],
   "meta": {
     "author": "Lean Genius OQ-01",
     "status": "axiomatized",

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
@@ -3,6 +3,38 @@
   "title": "Equivariant Borsuk-Ulam for Compact Lie Groups",
   "slug": "borsuk-ulam-oq-02-oq-02",
   "description": "Survey of equivariant Borsuk-Ulam for compact Lie groups (SO(n), U(n)). Formalizes equivariant map definitions, fixed-point subspace properties, and identifies ~2000 lines of infrastructure needed for the full theorem.",
+  "references": [
+    {
+      "authors": "Karol Borsuk",
+      "title": "Drei Sätze über die n-dimensionale euklidische Sphäre (Fundamenta Mathematicae 20)",
+      "year": 1933,
+      "note": "The original Borsuk–Ulam theorem, whose equivariant generalization to compact Lie groups is surveyed here."
+    },
+    {
+      "authors": "Tammo tom Dieck",
+      "title": "Transformation Groups",
+      "year": 1987,
+      "note": "de Gruyter Studies in Mathematics 8. Equivariant maps, fixed-point subspaces, and G-representation theory for compact Lie groups."
+    },
+    {
+      "authors": "Glen E. Bredon",
+      "title": "Introduction to Compact Transformation Groups",
+      "year": 1972,
+      "note": "Academic Press. Fixed-point sets and representation spheres for compact Lie group actions."
+    },
+    {
+      "authors": "Jiří Matoušek",
+      "title": "Using the Borsuk–Ulam Theorem",
+      "year": 2003,
+      "note": "Springer. Modern account of Borsuk–Ulam and its equivariant/topological-combinatorial generalizations."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Representation, MulAction fixed points, and topology infrastructure",
+      "year": 2024,
+      "note": "G-representation and fixed-point subspace definitions underlying the ~2000-line infrastructure this entry scopes."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "axiomatized",


### PR DESCRIPTION
Enrichment pass adding accurate literature `references` to six oq-child gallery entries whose only gap was empty references.

| Entry | References added |
|-------|------------------|
| bezout-identity-oq-02-oq-02-oq-01-oq-03 (Lamé's Theorem, Euclidean complexity) | Lamé, Knuth TAOCP2, Dixon, Bach-Shallit, mathlib |
| bezout-identity-oq-04-oq-01-oq-01 (Smith Normal Form over PIDs) | Smith, Jacobson, Lang, Dummit-Foote, mathlib |
| binomial-theorem-oq-04-oq-01 (Vandermonde, combinatorial) | Zhu Shijie, Vandermonde, Stanley, Concrete Mathematics, mathlib |
| birthday-problem-oq-01 (expected shared pairs) | von Mises, Feller, Ross, Diaconis-Mosteller, mathlib |
| binomial-theorem-oq-03-oq-02 ((1+x/n)^n → exp) | Bernoulli, Euler, Rudin, Apostol, mathlib |
| borsuk-ulam-oq-02-oq-02 (equivariant Borsuk-Ulam) | Borsuk, tom Dieck, Bredon, Matoušek, mathlib |

Each set matched to the entry's specific angle (read from description/problemStatement), ending with a mathlib Community citation naming reused modules. Minimal additive diffs.