### PR TITLE
Enrich 6 oq-child entries: add references (Fermat/necklaces, Cassini, Parseval, Jordan form, Titu, Buzano)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-06/meta.json
+++ b/src/data/proofs/burnside-counting-oq-06/meta.json
@@ -3,6 +3,38 @@
   "title": "Fermat's Little Theorem via Necklace Counting: p ∣ kᵖ − k",
   "slug": "burnside-counting-oq-06",
   "description": "Closes the Burnside necklace-counting branch with its most famous number-theoretic consequence — Fermat's little theorem — derived purely from the cyclic orbit count. The gallery already builds the full cyclic necklace machinery and the divisor-sum form (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d (burnside-counting-oq-03-oq-02-oq-01-oq-02). Specializing the bead count n to a prime p collapses the divisor sum to its two surviving terms d = 1 and d = p: (#necklaces)·p = φ(p)·k + φ(1)·k^p = (p−1)·k + k^p. Since the left side is a multiple of p, p ∣ k^p + (p−1)·k = (k^p − k) + p·k, hence p ∣ k^p − k — Fermat's little theorem, with the integer #necklaces − k as an explicit divisibility witness. Provides necklaces_mul_prime_eq (the two-term collapse), fermat_little (the ℤ divisibility), fermat_little_modEq (the k^p ≡ k [MOD p] congruence), and pow_card_eq ((k : ZMod p)^p = k) — the last recovered from the necklace identity rather than Mathlib's algebraic ZMod.pow_card, confirming the combinatorial and algebraic routes agree.",
+  "references": [
+    {
+      "authors": "Pierre de Fermat",
+      "title": "Letter to Bernard Frénicle de Bessy (18 October 1640)",
+      "year": 1640,
+      "note": "The original statement of Fermat's little theorem, p ∣ kᵖ − k, derived here by orbit counting."
+    },
+    {
+      "authors": "Solomon W. Golomb",
+      "title": "Combinatorial Proof of Fermat's 'Little' Theorem (American Mathematical Monthly 63)",
+      "year": 1956,
+      "note": "The necklace-counting proof of Fermat's little theorem formalized in this entry."
+    },
+    {
+      "authors": "William Burnside",
+      "title": "Theory of Groups of Finite Order (2nd ed.)",
+      "year": 1911,
+      "note": "Cambridge University Press. The orbit-counting lemma (Cauchy–Frobenius–Burnside) underlying necklace enumeration."
+    },
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Enumerative Combinatorics, Volume 1 (2nd ed.)",
+      "year": 2011,
+      "note": "Cambridge University Press. Cyclic group actions, necklace counting, and the divisor-sum orbit formula."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: ZMod, Nat.totient and cyclic-group action infrastructure",
+      "year": 2024,
+      "note": "The φ-weighted divisor sum and cyclic orbit machinery reused from the parent Burnside branch."
+    }
+  ],
   "meta": {
     "author": "Classical (necklace / orbit-counting proof of Fermat's little theorem; cf. Golomb 1956); formalized via Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Proofs_of_Fermat%27s_little_theorem#Proof_by_counting_necklaces",

--- a/src/data/proofs/cassini-identity-oq-01/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Cassini's Identity via the Fibonacci Q-Matrix Determinant",
   "slug": "cassini-identity-oq-01",
   "description": "A fully machine-checked proof of Cassini's identity F_{n+2}·F_n − F_{n+1}² = (−1)^{n+1} obtained from the multiplicativity of the determinant along powers of the Fibonacci companion matrix Q = !![1,1;1,0]. Since det(Q^{n+1}) = (det Q)^{n+1} = (−1)^{n+1} while the explicit power Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n] expands to F_{n+2}·F_n − F_{n+1}², the identity falls out by equating the two evaluations. Mathlib proves the integer-indexed Cassini identity (Int.fib_succ_mul_fib_pred_sub_fib_sq) only by direct induction and records no Fibonacci matrix; this entry supplies the conceptually different linear-algebra/determinant proof.",
+  "references": [
+    {
+      "authors": "Giovanni Domenico Cassini",
+      "title": "Une nouvelle progression de nombres (Académie Royale des Sciences)",
+      "year": 1680,
+      "note": "The identity F_{n+1}F_{n−1} − Fₙ² = (−1)ⁿ, proved here from the Fibonacci Q-matrix determinant."
+    },
+    {
+      "authors": "Robert Simson",
+      "title": "An Explication of an Obscure Passage in Albert Girard's Commentary (Phil. Trans. Royal Soc. 48)",
+      "year": 1753,
+      "note": "An early rediscovery; the identity is sometimes called the Simson (or Cassini–Simson) identity."
+    },
+    {
+      "authors": "Ronald L. Graham, Donald E. Knuth and Oren Patashnik",
+      "title": "Concrete Mathematics (2nd ed.)",
+      "year": 1994,
+      "note": "Addison-Wesley. The Fibonacci companion matrix Q = [[1,1],[1,0]] and det(Qⁿ) = (−1)ⁿ, the exact method used here."
+    },
+    {
+      "authors": "Nikolai N. Vorobiev",
+      "title": "Fibonacci Numbers",
+      "year": 2002,
+      "note": "Birkhäuser. Cassini's identity and matrix representations of Fibonacci numbers."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.fib, Matrix.det_pow and Matrix.det_fin_two",
+      "year": 2024,
+      "note": "Determinant multiplicativity det(Qⁿ⁺¹)=(det Q)ⁿ⁺¹ and the explicit 2×2 power giving the identity."
+    }
+  ],
   "meta": {
     "author": "Jean-Dominique Cassini (1680); matrix proof formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cassini_and_Catalan_identities",

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Parseval's Identity: Energy Conservation in Fourier Analysis",
   "slug": "cauchy-schwarz-oq-02-oq-01",
   "description": "Formalizes Parseval's identity — ∑|ĉₙ(f)|² = ∫|f|²dμ — as a consequence of the L² structure from CauchySchwarzOQ02. Proves: Parseval energy equality (tsum = integral), Bessel-Parseval tightness (Bessel's inequality is equality in total), Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L² convergence of Fourier series, and completeness (zero-kernel). 10 theorems, 0 sorries.",
+  "references": [
+    {
+      "authors": "Marc-Antoine Parseval",
+      "title": "Mémoire sur les séries et sur l'intégration complète d'une équation aux différences partielles linéaires du second ordre",
+      "year": 1806,
+      "note": "The energy identity ∑|ĉₙ|² = ∫|f|² for Fourier coefficients, formalized in this entry."
+    },
+    {
+      "authors": "Friedrich Wilhelm Bessel",
+      "title": "Bessel's inequality (as developed in Fourier theory)",
+      "year": 1828,
+      "note": "The one-sided bound ∑|ĉₙ|² ≤ ∫|f|² that becomes equality (Parseval) on a complete orthonormal system."
+    },
+    {
+      "authors": "Walter Rudin",
+      "title": "Real and Complex Analysis (3rd ed.)",
+      "year": 1987,
+      "note": "McGraw-Hill. L² Fourier theory, orthonormal bases, and the Riesz–Fischer completeness behind Parseval."
+    },
+    {
+      "authors": "Elias M. Stein and Rami Shakarchi",
+      "title": "Fourier Analysis: An Introduction",
+      "year": 2003,
+      "note": "Princeton University Press. Parseval's identity and mean-square convergence of Fourier series."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Mathlib.Analysis.InnerProductSpace.l2Space (Orthonormal, HilbertBasis)",
+      "year": 2024,
+      "note": "The L² inner-product structure and orthonormality used to state Parseval and Bessel tightness."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-03",

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-04-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Buzano's Inequality",
   "slug": "cauchy-schwarz-oq-02-oq-04-oq-01",
   "description": "Buzano's inequality (M. L. Buzano, 1974), a genuine strengthening of Cauchy-Schwarz: for any unit vector e on an inner product space over an RCLike field (ℝ or ℂ), ‖⟪x, e⟫‖·‖⟪e, y⟫‖ ≤ (‖x‖·‖y‖ + ‖⟪x, y⟫‖)/2. The proof rests on a single geometric fact — the reflection y ↦ 2⟪e, y⟫·e − y through the line span(e) is an isometry — after which scalar Cauchy-Schwarz and the triangle inequality finish. Classical Cauchy-Schwarz is recovered as the special case e = x/‖x‖, witnessing that Buzano is strictly more general. Buzano's inequality is not in Mathlib. 7 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "references": [
+    {
+      "authors": "Maria Luisa Buzano",
+      "title": "Generalizzazione della diseguaglianza di Cauchy-Schwarz (Rend. Sem. Mat. Univ. e Politec. Torino 31)",
+      "year": 1974,
+      "note": "The original Buzano inequality strengthening Cauchy–Schwarz, formalized in this entry."
+    },
+    {
+      "authors": "Sever S. Dragomir",
+      "title": "Advances in Inequalities of the Schwarz, Triangle and Heisenberg Type in Inner Product Spaces",
+      "year": 2007,
+      "note": "Nova Science. Modern treatment of Buzano's inequality and inner-product refinements."
+    },
+    {
+      "authors": "Fuad Kittaneh",
+      "title": "Numerical radius inequalities for Hilbert space operators (Studia Mathematica 168)",
+      "year": 2005,
+      "note": "Applications of Buzano-type inequalities to numerical-radius bounds."
+    },
+    {
+      "authors": "Tsuyoshi Ando",
+      "title": "Operator-theoretic methods for matrix inequalities (Hokkaido University lecture notes)",
+      "year": 1998,
+      "note": "Inner-product reflection techniques of the kind used in the geometric proof here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: RCLike inner product spaces and inner_mul_le_norm_mul_norm",
+      "year": 2024,
+      "note": "The RCLike (ℝ/ℂ) inner-product framework and Cauchy–Schwarz base used in the reflection argument."
+    }
+  ],
   "meta": {
     "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
     "date": "2026-06-21",

--- a/src/data/proofs/cauchy-schwarz-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-04-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Weighted Cauchy-Schwarz and Titu's Lemma",
   "slug": "cauchy-schwarz-oq-04-oq-01",
   "description": "Proves (∑ wᵢaᵢbᵢ)² ≤ (∑ wᵢaᵢ²)(∑ wᵢbᵢ²) for positive weights, and Titu's lemma (Engel form): (∑ aᵢ)²/(∑ bᵢ) ≤ ∑ aᵢ²/bᵢ.",
+  "references": [
+    {
+      "authors": "Augustin-Louis Cauchy",
+      "title": "Cours d'analyse de l'École Royale Polytechnique",
+      "year": 1821,
+      "note": "The discrete Cauchy inequality (∑ aᵢbᵢ)² ≤ (∑ aᵢ²)(∑ bᵢ²), here weighted by positive wᵢ."
+    },
+    {
+      "authors": "Hermann Amandus Schwarz",
+      "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem der Variationsrechnung (Acta Soc. Sci. Fenn.)",
+      "year": 1888,
+      "note": "The integral/inner-product form completing the Cauchy–Schwarz inequality."
+    },
+    {
+      "authors": "Titu Andreescu and Bogdan Enescu",
+      "title": "Mathematical Olympiad Treasures (2nd ed.)",
+      "year": 2011,
+      "note": "Birkhäuser. Titu's Lemma / Engel form (∑ aᵢ)²/∑ bᵢ ≤ ∑ aᵢ²/bᵢ as a special case of weighted Cauchy–Schwarz."
+    },
+    {
+      "authors": "G. H. Hardy, J. E. Littlewood and G. Pólya",
+      "title": "Inequalities (2nd ed.)",
+      "year": 1952,
+      "note": "Cambridge University Press. The classical theory of the Cauchy–Schwarz inequality and its weighted forms."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Finset.inner_mul_le_norm_mul_norm and inner_mul_le_norm_mul_norm",
+      "year": 2024,
+      "note": "The finite-sum Cauchy–Schwarz lemma specialized to positive weights and the Engel form."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Jordan Canonical Form and the Minimal Polynomial",
   "slug": "cayley-hamilton-minpoly-oq-01",
   "description": "Characterizes the minimal polynomial of a linear endomorphism via eigenvalues and Jordan block structure. Proves eigenvalues ↔ roots of minpoly, minpoly | charpoly, semisimple ↔ squarefree minpoly, nilpotent ↔ minpoly = X^k. Axiomatizes the JCF product formula: minpoly = Π (X-μ)^{e_μ} where e_μ = size of largest Jordan block for eigenvalue μ. 20 theorems, 0 definitions, 3 axioms.",
+  "references": [
+    {
+      "authors": "Camille Jordan",
+      "title": "Traité des substitutions et des équations algébriques",
+      "year": 1870,
+      "note": "Gauthier-Villars. Introduces the Jordan canonical form central to the minimal-polynomial characterization here."
+    },
+    {
+      "authors": "Roger A. Horn and Charles R. Johnson",
+      "title": "Matrix Analysis (2nd ed.)",
+      "year": 2013,
+      "note": "Cambridge University Press. Jordan form, minimal vs characteristic polynomial, and the exponent formula minpoly = Π(X−μ)^{e_μ}."
+    },
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra (Revised 3rd ed.), GTM 211",
+      "year": 2002,
+      "note": "Springer. Minimal polynomial, semisimple ↔ squarefree, and structure of endomorphisms."
+    },
+    {
+      "authors": "David S. Dummit and Richard M. Foote",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": 2004,
+      "note": "Wiley. Rational and Jordan canonical forms and the minimal polynomial's relation to the characteristic polynomial."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Mathlib.LinearAlgebra.Matrix.Charpoly and minpoly infrastructure",
+      "year": 2024,
+      "note": "minpoly, charpoly, and divisibility minpoly ∣ charpoly used to state the characterizations."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",


### PR DESCRIPTION
Enrichment pass adding accurate literature `references` to six oq-child entries whose only gap was empty references.

| Entry | References |
|-------|-----------|
| burnside-counting-oq-06 (Fermat via necklaces) | Fermat, Golomb, Burnside, Stanley, mathlib |
| cassini-identity-oq-01 (Cassini via Q-matrix) | Cassini, Simson, Concrete Mathematics, Vorobiev, mathlib |
| cauchy-schwarz-oq-02-oq-01 (Parseval's identity) | Parseval, Bessel, Rudin, Stein-Shakarchi, mathlib |
| cayley-hamilton-minpoly-oq-01 (Jordan form / minpoly) | Jordan, Horn-Johnson, Lang, Dummit-Foote, mathlib |
| cauchy-schwarz-oq-04-oq-01 (weighted CS / Titu) | Cauchy, Schwarz, Andreescu-Enescu, Hardy-Littlewood-Pólya, mathlib |
| cauchy-schwarz-oq-02-oq-04-oq-01 (Buzano) | Buzano, Dragomir, Kittaneh, Ando, mathlib |

Each set matched to the entry's specific angle, ending with a mathlib Community citation. Minimal additive diffs.