### PR TITLE
research(seeker): replenish pool with 6 diverse verified-parent OQ-children

### DIFF
--- a/research/problems/abel-ruffini-oq-04-oq-02-oq-04-oq-03/problem.md
+++ b/research/problems/abel-ruffini-oq-04-oq-02-oq-04-oq-03/problem.md
@@ -1,0 +1,231 @@
+# Problem: Metacyclic Groups Are Solvable — Cyclic-by-Cyclic Extensions
+
+**Slug**: `abel-ruffini-oq-04-oq-02-oq-04-oq-03`
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap (open-question child of `abel-ruffini-oq-04-oq-02-oq-04`)
+
+## Problem Statement
+
+The parent entry `abel-ruffini-oq-04-oq-02-oq-04` ("Dihedral Groups Are Solvable")
+proves `IsSolvable (DihedralGroup n)` for every `n` by exhibiting `Dₙ` as **metabelian**:
+a cyclic normal rotation subgroup `⟨r⟩ ≅ ℤ/n` of index `2` with abelian quotient `ℤ/2`.
+The concrete proof builds a parity homomorphism `parity : Dₙ →* ℤ/2` whose kernel equals
+the range of a rotation inclusion `ℤ/n →* Dₙ`, then feeds this into Mathlib's
+`solvable_of_ker_le_range`.
+
+The parent's third open question asks:
+
+> "Generalize to the metacyclic and, more broadly, supersolvable families: is every group
+> with a cyclic normal subgroup of prime index solvable by the same parity/character
+> argument? Concretely: if `G` has a normal subgroup `N` that is cyclic with `G/N` cyclic
+> (a metacyclic group), then `G` is solvable; more generally supersolvable ⇒ solvable."
+
+This child abstracts the dihedral proof to its structural core: the ad-hoc parity character
+is a special case of the general **extension-closure** fact that a group built as an
+abelian-by-abelian (indeed cyclic-by-cyclic) tower is automatically solvable. The dihedral
+case is `N = ⟨r⟩` cyclic of index 2; here we drop all ties to the dihedral multiplication
+table and state the clean, reusable theorem.
+
+### Formal Statement
+
+Let `G` be a group and `N : Subgroup G` a normal subgroup.
+
+**(1) Cyclic-by-cyclic (metacyclic) ⇒ solvable.** If `N` is cyclic and the quotient `G ⧸ N`
+is cyclic, then `G` is solvable:
+
+```lean
+theorem isSolvable_of_cyclic_by_cyclic {G : Type*} [Group G]
+    (N : Subgroup G) [N.Normal] [IsCyclic N] [IsCyclic (G ⧸ N)] :
+    IsSolvable G := by
+  -- cyclic ⇒ commutative ⇒ solvable, on both layers
+  haveI : CommGroup N := IsCyclic.commGroup
+  haveI : CommGroup (G ⧸ N) := IsCyclic.commGroup
+  -- solvability is closed under the extension 1 → N → G → G ⧸ N → 1
+  exact solvable_of_ker_le_range N.subtype (QuotientGroup.mk' N)
+    (by rw [QuotientGroup.ker_mk', Subgroup.range_subtype])
+```
+
+The key identity is `(QuotientGroup.mk' N).ker = N = N.subtype.range` (from
+`QuotientGroup.ker_mk'` and `Subgroup.range_subtype`), so the hypothesis
+`g.ker ≤ f.range` of `solvable_of_ker_le_range` holds with equality. Since `N` and `G ⧸ N`
+are abelian they are solvable (`CommGroup.isSolvable`), and the lemma delivers
+`IsSolvable G`.
+
+**(1′) Abelian-by-abelian (metabelian) ⇒ solvable.** The same proof works verbatim if
+`IsCyclic` is weakened to `CommGroup`/abelian on both layers — this is the direct
+generalization the dihedral proof instantiates:
+
+```lean
+theorem isSolvable_of_abelian_by_abelian {G : Type*} [Group G]
+    (N : Subgroup G) [N.Normal] [IsSolvable N] [IsSolvable (G ⧸ N)] :
+    IsSolvable G :=
+  solvable_of_ker_le_range N.subtype (QuotientGroup.mk' N)
+    (by rw [QuotientGroup.ker_mk', Subgroup.range_subtype])
+```
+
+**(2) Specialization — cyclic normal subgroup of prime index.** If `N ⊴ G` is cyclic and
+`[G : N] = p` is prime, then `G ⧸ N` has prime order, hence is cyclic
+(`isCyclic_of_prime_card` / `ZMod p`-type argument), so (1) applies:
+
+```lean
+theorem isSolvable_of_cyclic_normal_prime_index {G : Type*} [Group G]
+    (N : Subgroup G) [N.Normal] [IsCyclic N] {p : ℕ} (hp : p.Prime)
+    (hindex : N.index = p) : IsSolvable G := by
+  haveI : IsCyclic (G ⧸ N) := by
+    -- Nat.card (G ⧸ N) = N.index = p prime ⇒ cyclic of prime order
+    sorry
+  exact isSolvable_of_cyclic_by_cyclic N
+```
+
+The dihedral entry is exactly `p = 2`.
+
+**(3) Supersolvable ⇒ solvable (stretch goal).** A supersolvable group has a normal
+series `1 = G₀ ◁ G₁ ◁ ... ◁ Gₖ = G` with each `Gᵢ ◁ G` (normal in the whole group) and each
+factor `Gᵢ₊₁ / Gᵢ` cyclic. Every factor abelian ⇒ solvable by induction along the series
+using (1′) at each step. **Caveat:** Mathlib (checked at version 4.26.0) has **no**
+`Supersolvable` predicate, so part (3) requires first *defining* the notion (or an ad-hoc
+finite chain hypothesis) — it is not a one-liner. Parts (1), (1′), (2) are the core, fully
+supported by existing Mathlib API; (3) is optional and heavier.
+
+## Plain Language
+
+A group is **solvable** when it can be built up out of abelian (commutative) pieces stacked
+in layers — formally, a chain of subgroups whose successive quotients are all abelian.
+"Solvable" is the group-theoretic condition behind Abel–Ruffini: a polynomial is solvable by
+radicals exactly when its Galois group is solvable.
+
+A **metacyclic** group is the simplest non-trivial case: just **two** layers, a cyclic
+normal subgroup `N` on the bottom and a cyclic quotient `G/N` on top. Two abelian layers is
+already a solvable tower, so *every metacyclic group is automatically solvable* — no clever
+argument required. The dihedral group `Dₙ` (rotations `⟨r⟩` on the bottom, the flip `ℤ/2` on
+top) is the textbook example, and the parent entry proved that case by hand. The point of
+this problem is to prove the *general* statement once, so the dihedral proof becomes a
+one-line corollary rather than a bespoke computation.
+
+**Supersolvable** groups extend this to a full *normal cyclic tower* (each layer cyclic and
+normal in the whole group). Stacking cyclic-hence-abelian layers still gives a solvable
+group, so supersolvable ⇒ solvable as well.
+
+## Why This Matters
+
+The parent proves solvability of a *specific* family (dihedral) with a hand-crafted parity
+character and a four-case check against the dihedral multiplication table. That argument is
+correct but non-reusable: it is glued to `DihedralGroup`. This problem extracts the
+**structural** statement — solvability is closed under (abelian, and in particular cyclic)
+extensions — which is:
+
+- **The clean, reusable Mathlib fact.** `solvable_of_ker_le_range` already encodes
+  extension-closure; the metacyclic theorem is the natural named consequence and would let
+  the dihedral proof (and any future split/metacyclic family) be discharged in one line via
+  `isSolvable_of_cyclic_by_cyclic`.
+- **Directly relevant to Abel–Ruffini-style Galois arguments.** Solvable-by-radicals
+  reasoning repeatedly needs "this Galois group is an extension of abelian layers, hence
+  solvable." Metacyclic groups arise as Galois groups of many concrete radical extensions
+  (e.g. `xⁿ − a` over a field containing `n`-th roots of unity has metacyclic Galois group),
+  so the general lemma is a genuine workhorse.
+- **Isolates what makes Sₙ special.** The parent contrasts solvable `Dₙ` with non-solvable
+  `S₅`. Making the metacyclic direction structural sharpens the point: solvability fails for
+  `Sₙ` (`n ≥ 5`) precisely because `Sₙ` is *not* an iterated abelian extension, whereas every
+  metacyclic/supersolvable group is by construction.
+
+## Known Results
+
+Everything needed for parts (1), (1′), (2) is present in Mathlib
+(`Mathlib/GroupTheory/Solvable.lean`, `.../SpecificGroups/Cyclic.lean`,
+`.../QuotientGroup/Defs.lean`), verified against version 4.26.0:
+
+- `class IsSolvable (G) : Prop` — solvability via the derived series.
+- `instance CommGroup.isSolvable {G} [CommGroup G] : IsSolvable G` — **abelian ⇒ solvable.**
+- `def IsCyclic.commGroup [Group α] [IsCyclic α] : CommGroup α` — **cyclic ⇒ abelian**
+  (so cyclic ⇒ solvable by composing with the above).
+- `theorem solvable_of_ker_le_range (f : G' →* G) (g : G →* G'') (hfg : g.ker ≤ f.range)`
+  `[IsSolvable G'] [IsSolvable G''] : IsSolvable G` — **the extension-closure lemma** (this
+  is exactly what the parent dihedral proof uses).
+- `theorem QuotientGroup.ker_mk' (N : Subgroup G) [N.Normal] :`
+  `(QuotientGroup.mk' N).ker = N` — kernel of the quotient map is `N`.
+- `theorem Subgroup.range_subtype (H : Subgroup G) : H.subtype.range = H` — range of the
+  inclusion is `N`. Together with `ker_mk'` this gives `g.ker = f.range`, discharging the
+  `≤` hypothesis of `solvable_of_ker_le_range`.
+- Supporting closure instances confirming the picture:
+  `instance subgroup_solvable_of_solvable (H : Subgroup G) [IsSolvable G] : IsSolvable H`,
+  `instance solvable_quotient_of_solvable (H : Subgroup G) [H.Normal] [IsSolvable G] :`
+  `IsSolvable (G ⧸ H)`, and `solvable_of_surjective` / `solvable_of_solvable_injective`.
+- For part (2): `isCyclic_of_prime_card` (a group of prime order is cyclic) plus
+  `Subgroup.index` / `Nat.card (G ⧸ N) = N.index` to see the prime-index quotient is cyclic.
+
+**Not in Mathlib:** there is no `Supersolvable` class or `supersolvable` predicate (searched,
+none found), so part (3) must either define the notion or take a concrete finite normal
+cyclic series as a hypothesis and induct.
+
+**Parent's specific argument:** `abel-ruffini-oq-04-oq-02-oq-04` proves the `Dₙ` instance via
+`parity : Dₙ →* ℤ/2`, `rotation : ℤ/n →* Dₙ`, and
+`parity_ker_eq_rotation_range`, then `solvable_of_ker_le_range rotation parity ...`. The
+present problem is that same final step made hypothesis-free / general.
+
+## Suggested Approach
+
+**Core (parts 1, 1′).** Follow the Lean sketches above.
+
+1. Get `IsSolvable N`: from `[IsCyclic N]` obtain `CommGroup N` via `IsCyclic.commGroup`
+   (`haveI`), then `CommGroup.isSolvable` fires the instance. (For part (1′) take
+   `[IsSolvable N]` directly as hypothesis.)
+2. Get `IsSolvable (G ⧸ N)` the same way from `[IsCyclic (G ⧸ N)]`.
+3. Apply `solvable_of_ker_le_range` with `f := N.subtype` and `g := QuotientGroup.mk' N`;
+   discharge `g.ker ≤ f.range` by rewriting with `QuotientGroup.ker_mk'` and
+   `Subgroup.range_subtype` (they give equality, so `.le` / `le_of_eq`).
+
+**Specialization (part 2).** Show `IsCyclic (G ⧸ N)` from a prime index: relate
+`Nat.card (G ⧸ N)` to `N.index`, then use `isCyclic_of_prime_card`. Then invoke
+`isSolvable_of_cyclic_by_cyclic`. Provide `DihedralGroup n` (`p = 2`) as a sanity-check
+corollary, re-deriving the parent result in one line.
+
+**Stretch (part 3).** Either (a) add a lightweight definition of a supersolvable group as a
+`List`/`Fin`-indexed normal series with cyclic factors and induct along it applying (1′) at
+each extension step, or (b) state a concrete instance (e.g. any group with a subnormal series
+of cyclic factors) and prove solvability by the same induction. Flag this as the harder,
+possibly-out-of-scope part since Mathlib provides no supersolvable scaffolding.
+
+**Caution / uncertainty to verify during formalization:**
+- Confirm `IsCyclic.commGroup` is usable as a local instance via `haveI` (it is a `def`, not
+  an `instance`); alternatively there may be a direct `IsCyclic → IsSolvable` path worth
+  checking.
+- The exact spelling `Nat.card (G ⧸ N) = N.index` vs `Subgroup.index` API should be
+  double-checked (`Subgroup.card_quotient_eq_index` or similar) when doing part (2).
+- Keep the theorem `axiom`-free: `solvable_of_ker_le_range` and the cyclic/abelian instances
+  are all `decide`/`native_decide`-free, matching the parent's 0-axiom status.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 7
+tags:
+  - group-theory
+  - solvable-groups
+  - metacyclic
+  - dihedral-group
+  - galois-theory
+  - abel-ruffini
+```
+
+Parts (1), (1′), (2) are genuinely tractable — the extension-closure route reduces to three
+short applications of existing Mathlib lemmas and mirrors the parent almost exactly. Part (3)
+(supersolvable) is a natural but heavier stretch because Mathlib lacks a supersolvable
+predicate.
+
+## Related Gallery Proofs
+
+- **`abel-ruffini-oq-04-oq-02-oq-04`** (parent) — "Dihedral Groups Are Solvable"; proves the
+  metabelian `Dₙ` instance via `solvable_of_ker_le_range`. This problem generalizes its final
+  step to arbitrary cyclic-by-cyclic (metacyclic) groups.
+- **`abel-ruffini-oq-04-oq-02`** (grandparent) — "S₂, S₃, S₄ Are Solvable"; classifies
+  solvability of symmetric groups (`Sₙ` solvable iff `n ≤ 4`), the origin of the
+  "other infinite families" open question.
+- **`abel-ruffini-oq-04-oq-02-oq-02`** — "Aₙ solvable iff n ≤ 4"; the `A₅` obstruction,
+  contrasting with the always-solvable metacyclic/dihedral families here.
+- **`abel-ruffini-oq-04`** / **`abel-ruffini`** (root) — the Abel–Ruffini impossibility
+  theorem, whose Galois-solvability machinery is exactly where metacyclic solvability feeds in.
+- Any Sylow / p-group / solvable-group gallery entries — Sylow theory and supersolvability
+  are the natural next structural layer above metacyclic.

--- a/research/problems/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/problem.md
+++ b/research/problems/antitone-integral-sum-comparison-oq-01-oq-02-oq-02/problem.md
@@ -1,0 +1,176 @@
+# Problem: The Generalized Euler Constant of an Antitone Function — Convergence of the Sum–Integral Defect
+
+**Slug**: antitone-integral-sum-comparison-oq-01-oq-02-oq-02
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap (open-question child of antitone-integral-sum-comparison-oq-01-oq-02)
+
+## Problem Statement
+
+The parent entry pinned the defect `Hₙ − log n → γ` for the special function
+`f(x) = 1/x`, bridging to Mathlib's `Real.eulerMascheroniConstant`. This child
+abstracts that result: for an **arbitrary** non-increasing, non-negative `f` on
+`[1, ∞)` whose integral diverges, the "sum minus integral" defect still converges
+to a finite limit — the *generalized Euler constant of `f`*. The special case
+`f(x) = 1/x` recovers `γ`.
+
+### Formal Statement
+
+Let `f : ℝ → ℝ` be antitone on `[1, ∞)` with `f x ≥ 0` there (divergence of
+`∫₁^∞ f` is what makes the problem nontrivial, but it is not needed for the
+convergence claim itself — the defect converges regardless). Define the
+**defect sequence**
+
+```
+D n = (∑ k ∈ Finset.Icc 1 n, f k) − ∫ x in (1:ℝ)..n, f x.
+```
+
+The claim is that `D` converges:
+
+```lean
+theorem antitone_defect_converges
+    {f : ℝ → ℝ} (hmono : AntitoneOn f (Set.Ici 1))
+    (hnonneg : ∀ x ≥ (1:ℝ), 0 ≤ f x)
+    (hint : ∀ n : ℕ, IntervalIntegrable f MeasureTheory.volume 1 n) :
+    ∃ L : ℝ, Filter.Tendsto
+      (fun n : ℕ => (∑ k ∈ Finset.Icc 1 n, f k) - ∫ x in (1:ℝ)..n, f x)
+      Filter.atTop (nhds L) := by
+  sorry
+```
+
+The proof is a bounded–monotone convergence argument: `D` is **monotone
+decreasing** and **bounded below by 0**, so it converges by
+`tendsto_atTop_ciInf` (an antitone sequence bounded below tends to its infimum).
+The limit is `L = ⨅ n, D n`.
+
+### Plain Language
+
+Picture the graph of a non-increasing curve `y = f(x)` and the staircase of
+rectangles of width 1 and heights `f(1), f(2), f(3), …`. The left-endpoint
+staircase overestimates the area under the curve, so on each unit interval
+`[k, k+1]` the sliver between the step `f(k)` and the curve has positive area,
+namely `f(k) − ∫ₖ^{k+1} f`. Because `f` is non-increasing, this sliver is at
+most `f(k) − f(k+1)`, and summing telescopes to at most `f(1)`. The total
+overhang — the sum of all the slivers — is therefore finite and non-negative:
+that total is exactly the limiting defect. When `f(x) = 1/x` the curve is the
+hyperbola, the staircase is the harmonic series, the overhang is `γ ≈ 0.5772`,
+and the picture is the classical derivation of the Euler–Mascheroni constant.
+
+### Why This Matters
+
+The parent proof does the whole story for one function, `f(x) = 1/x`, and lands
+on `Real.eulerMascheroniConstant`. But the *mechanism* — a monotone, bounded
+defect converging by the integral test — is completely general and reusable.
+Formalizing it once yields a clean piece of Mathlib-style infrastructure: a
+"generalized Euler constant exists" lemma applicable to `f(x) = 1/xᵖ` for
+`0 < p ≤ 1`, `f(x) = 1/(x log x)`, and any other antitone divergent series,
+each of which currently would require a bespoke argument.
+
+Mathlib already knows the harmonic special case tightly: the divergence itself is
+`Real.tendsto_sum_range_one_div_nat_succ_atTop` (partial sums of `∑ 1/(n+1)` tend
+to `atTop`), and the constant lives at `Real.eulerMascheroniConstant` with the two
+defect limits `Real.tendsto_harmonic_sub_log` and
+`Real.tendsto_harmonic_sub_log_add_one` and the monotone bracketing sequences
+`Real.eulerMascheroniSeq` / `eulerMascheroniSeq'`. What Mathlib does **not**
+have is the abstract antitone version; this problem supplies it, and the parent
+entry's `f = 1/x` proof becomes a corollary obtained by unfolding definitions.
+
+### Known Results
+
+The two ingredients are both elementary and both already available in Mathlib in
+the exact form the parent uses.
+
+1. **Per-interval sandwich (antitonicity).** For `f` antitone on `[k, k+1]`,
+   ```
+   f (k+1) ≤ ∫ x in (k:ℝ)..(k+1), f x ≤ f k,
+   ```
+   the two halves being `AntitoneOn.sum_le_integral` and
+   `AntitoneOn.integral_le_sum` (the same lemmas the root proof
+   `AntitoneIntegralSumComparison.integral_sandwich` packages). Consequently
+   ```
+   0 ≤ f k − ∫ₖ^{k+1} f ≤ f k − f (k+1).
+   ```
+
+2. **Bounded-monotone convergence.** A sequence that is antitone and bounded
+   below converges to its infimum. In Lean:
+   `tendsto_atTop_ciInf (h_anti : Antitone D) (hbdd : BddBelow (Set.range D))`
+   gives `Tendsto D atTop (𝓝 (⨅ n, D n))`.
+
+Combining: `D` is decreasing (item 1 makes each increment `≤ 0`) and bounded
+below by `0` (item 1 telescopes), so it converges (item 2). Divergence of
+`∫₁^∞ f` is not required for convergence of the *defect*; it is the hypothesis
+that makes the result interesting (otherwise both `∑ f` and `∫ f` converge
+separately and the defect is a trivial difference of limits).
+
+### Suggested Approach
+
+A concrete Lean plan, naming only lemmas that appear in the parent/root files or
+standard Mathlib:
+
+1. **Split the integral additively.** Write
+   `∫₁^{n+1} f = ∫₁^n f + ∫ₙ^{n+1} f` via
+   `intervalIntegral.integral_add_adjacent_intervals` (needs the
+   `IntervalIntegrable` hypotheses `hint`). Then
+   ```
+   D (n+1) − D n = f (n+1) − ∫ₙ^{n+1} f.
+   ```
+
+2. **Monotone decreasing.** On `[n, n+1]`, antitonicity gives
+   `f (n+1) ≤ ∫ₙ^{n+1} f` (from `AntitoneOn.integral_le_sum`, or directly
+   `intervalIntegral.integral_mono_on` against the constant `f (n+1)`), hence
+   `D (n+1) − D n ≤ 0`. Package as `Antitone D` via
+   `antitone_nat_of_succ_le`.
+
+3. **Bounded below by 0.** Telescoping the per-interval upper bound
+   `∫ₖ^{k+1} f ≤ f k` over `k = 1 … n−1` gives `∫₁^n f ≤ ∑_{k=1}^{n−1} f k`,
+   so `D n ≥ f n ≥ 0` (using `hnonneg`). Establish
+   `BddBelow (Set.range D)` with `0` as a lower bound (`bddBelow_def` /
+   `mem_lowerBounds`).
+
+4. **Conclude.** Apply `tendsto_atTop_ciInf` (antitone + `BddBelow`) to obtain
+   `Tendsto D atTop (𝓝 (⨅ n, D n))`, and provide the witness
+   `L := ⨅ n, D n` via `Filter.Tendsto` and `⟨_, _⟩`.
+
+5. **Sanity check the special case.** Instantiate `f := fun x => 1/x`. With the
+   root file's `oneDiv_antitone` and `log_integral`, `D n` becomes
+   `Hₙ − log n`, whose limit is `Real.eulerMascheroniConstant` by
+   `Real.tendsto_harmonic_sub_log`; this confirms the abstract `L` specializes
+   to `γ` and mirrors the parent's `tendsto_harmonic_sub_log`.
+
+The whole argument stays inside real analysis with no measure-theoretic
+subtleties beyond `IntervalIntegrable`; the antitone per-interval bounds and the
+`ciInf` convergence lemma are the only non-trivial imports.
+
+### Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 7
+tags:
+  - analysis
+  - integral-test
+  - euler-mascheroni
+  - convergence
+  - monotone-convergence
+  - asymptotics
+  - harmonic-numbers
+rationale: >
+  Genuinely tractable: the result is a textbook bounded-monotone convergence
+  argument, and every ingredient (AntitoneOn.integral_le_sum /
+  AntitoneOn.sum_le_integral from the root proof, tendsto_atTop_ciInf,
+  intervalIntegral.integral_add_adjacent_intervals) is already in Mathlib. The
+  significance is the reusable abstraction: it lifts the parent's single-function
+  γ result to a general "generalized Euler constant exists" lemma that Mathlib
+  currently lacks. Main care points are the IntervalIntegrable side-conditions
+  and getting the telescoping lower bound clean.
+```
+
+### Related Gallery Proofs
+
+| Slug | Relationship |
+|------|--------------|
+| `antitone-integral-sum-comparison-oq-01-oq-02` | Parent. Proves the special case `f(x) = 1/x`: `Hₙ − log n → γ = Real.eulerMascheroniConstant`, with the monotone bracketing `Hₙ − log(n+1) < γ < Hₙ − log n`. This child abstracts that convergence to arbitrary antitone non-negative `f`. |
+| `antitone-integral-sum-comparison` | Root. Establishes the general integral-test sandwich `∑ f(x₀+i+1) ≤ ∫ f ≤ ∑ f(x₀+i)` via `AntitoneOn.sum_le_integral` / `AntitoneOn.integral_le_sum` — the per-interval engine reused here. |
+| `antitone-integral-sum-comparison-oq-01` | Sibling intermediate node in the integral-test family (harmonic-defect boundedness). |
+| `antitone-integral-sum-comparison-oq-01-oq-03` | Sibling open-question child on the same integral-test lineage. |

--- a/research/problems/basel-problem-oq-13-oq-01-oq-01/problem.md
+++ b/research/problems/basel-problem-oq-13-oq-01-oq-01/problem.md
@@ -1,0 +1,219 @@
+# Problem: Uniform even Dirichlet eta values η(2k) = (1 − 2^{1−2k})ζ(2k) via `hasSum_zeta_nat`
+
+**Slug**: basel-problem-oq-13-oq-01-oq-01
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap (open-question child of basel-problem-oq-13-oq-01)
+
+## Problem Statement
+
+### Formal Statement
+
+The parent entry `basel-problem-oq-13-oq-01` proves a single fixed instance — the
+Dirichlet eta value at `s = 4`:
+
+$$\eta(4) = \sum_{n=1}^{\infty} \frac{(-1)^{n+1}}{n^4} = \frac{7\pi^4}{720},$$
+
+by hand-assembling two hard-coded numerical ingredients (λ(4) = π⁴/96 and the
+even-fourth-power sum π⁴/1440). This problem asks for the **uniform** statement
+over all positive `k`.
+
+For every integer `k ≥ 1`, the even Dirichlet eta value is
+
+$$\eta(2k) \;=\; \sum_{n=1}^{\infty} \frac{(-1)^{n+1}}{n^{2k}}
+   \;=\; \bigl(1 - 2^{\,1-2k}\bigr)\,\zeta(2k),$$
+
+where the closed form for the even zeta value is Euler's formula
+
+$$\zeta(2k) \;=\; \frac{(-1)^{k+1}\,B_{2k}\,(2\pi)^{2k}}{2\,(2k)!}
+   \;=\; (-1)^{k+1}\,2^{\,2k-1}\,\pi^{2k}\,\frac{B_{2k}}{(2k)!}.$$
+
+The second form is *exactly* the value supplied by Mathlib's `hasSum_zeta_nat`
+(see Known Results), so no separate re-derivation of the zeta closed form is
+needed.
+
+The target **Lean theorem** is a single statement quantified over `k` (not a
+fixed numeral), of roughly the following shape:
+
+```lean
+open scoped Nat  -- for the factorial notation `!`
+
+/-- Uniform even Dirichlet eta value:
+    `∑ (-1)^(n+1)/n^(2k) = (1 - 2^(1-2k)) * ζ(2k)` for every `k ≥ 1`. -/
+theorem hasSum_eta_nat {k : ℕ} (hk : k ≠ 0) :
+    HasSum (fun n : ℕ => (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ (2 * k))
+      ((1 - (2 : ℝ) ^ (1 - 2 * (k : ℤ)))
+        * ((-1 : ℝ) ^ (k + 1) * 2 ^ (2 * k - 1) * π ^ (2 * k)
+            * bernoulli (2 * k) / (2 * k)!)) := by
+  sorry
+```
+
+A cleaner corollary factors the answer through the zeta value directly, so the
+Bernoulli constant never has to be manipulated:
+
+```lean
+/-- η(2k) as `(1 - 2^(1-2k))` times the Mathlib zeta value. -/
+theorem hasSum_eta_nat' {k : ℕ} (hk : k ≠ 0)
+    (Z : ℝ) (hZ : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ (2 * k)) Z) :
+    HasSum (fun n : ℕ => (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ (2 * k))
+      ((1 - (2 : ℝ) ^ (1 - 2 * (k : ℤ))) * Z) := by
+  sorry
+```
+
+Deriving `hasSum_eta_nat` from `hasSum_eta_nat'` is then a one-liner: instantiate
+`Z` and `hZ` with the value and proof from `hasSum_zeta_nat hk`. Recovering the
+parent's `hasSum_eta_four` as the `k = 2` specialization (with `ring`/`norm_num`
+to check `(1 − 2^{−3})·π⁴/90 = 7π⁴/720`) should be included as a sanity check.
+
+### Plain Language
+
+The Riemann zeta function `ζ(s) = ∑ 1/n^s` sums the reciprocals of the `s`-th
+powers with all-positive signs. The **Dirichlet eta function**
+`η(s) = ∑ (-1)^{n+1}/n^s` is its *alternating* cousin: odd-indexed terms keep a
+`+` sign and even-indexed terms flip to `−`. The two are linked by the clean
+scalar identity `η(s) = (1 − 2^{1−s})ζ(s)`, which comes from removing twice the
+even-index part of the zeta series.
+
+At even arguments `s = 2k`, Euler's theorem gives `ζ(2k)` as an explicit rational
+multiple of `π^{2k}` (through the Bernoulli numbers). Consequently every even
+eta value `η(2k)` also has a closed form: `η(2) = π²/12`, `η(4) = 7π⁴/720`,
+`η(6) = 31π⁶/30240`, and so on. The parent gallery entry establishes just the
+`η(4)` line, and it does so by re-using two numbers (`π⁴/96` and `π⁴/1440`) that
+were themselves computed by hand for the `k = 2` case.
+
+The generalization asks: prove the whole family at once. Replace the fixed
+numerical ingredients by a single application of Mathlib's general zeta-value
+lemma `hasSum_zeta_nat`, so that the parity-split "eta-from-zeta" template is
+formalized **uniformly in `k`** rather than recompiled for each individual
+exponent.
+
+### Why This Matters
+
+The parent proof is a pleasant but narrow artifact: it hard-codes `π⁴/96` and
+`π⁴/1440`, so producing `η(6)` would require repeating the entire construction
+with fresh constants (`λ(6)`, the even-sixth-power sum, etc.). That does not
+scale and hides the actual mathematical content, which is a single scalar
+identity `η(s) = (1 − 2^{1−s})ζ(s)` that is completely independent of the
+particular exponent.
+
+Formalizing the uniform version:
+
+- **Decouples the result from hand-computed constants.** The only analytic input
+  becomes Mathlib's `hasSum_zeta_nat`; everything else is algebra on the scalar
+  factor `(1 − 2^{1−2k})`.
+- **Yields the entire even eta family as free specializations** (`η(2)`, `η(4)`,
+  `η(6)`, …) — and re-derives the parent's `η(4)` as one corollary, tying the
+  gallery together.
+- **Isolates a reusable lemma.** The even/odd parity split that turns a zeta-type
+  sum into an eta-type sum is exactly the same idiom used for the lambda values
+  `λ(2k) = (1 − 2^{−2k})ζ(2k)` and the alternating beta values; a uniform proof
+  gives a template other entries can import instead of re-deriving.
+
+## Known Results
+
+**From the parent chain (verified, 0-axiom):**
+
+- `basel-problem-oq-13-oq-01` (`BaselProblemOQ13OQ01.lean`) — proves the single
+  case `η(4) = 7π⁴/720` via `HasSum.even_add_odd` applied to
+  `f n = (-1)^{n+1}/n⁴`, with the two subseries values imported from the parent.
+- `basel-problem-oq-13` (`BaselProblemOQ13.lean`) — proves
+  `hasSum_even_zeta_four : ∑ 1/(2k)⁴ = π⁴/1440` and
+  `hasSum_odd_zeta_four : ∑ 1/(2k+1)⁴ = π⁴/96`, itself built on Mathlib's
+  `hasSum_zeta_four`.
+
+**From Mathlib (`Mathlib.NumberTheory.ZetaValues`) — verified to exist:**
+
+- `hasSum_zeta_nat {k : ℕ} (hk : k ≠ 0) : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ (2 * k)) ((-1)^(k+1) * 2^(2*k-1) * π^(2*k) * bernoulli (2*k) / (2*k)!)`
+  — the *uniform* even zeta value. This is the key lemma the parent chain does
+  not use; the whole point of the generalization is to route through it.
+- `hasSum_zeta_two`, `hasSum_zeta_four` — the `k = 1, 2` specializations, proved
+  in Mathlib as `convert hasSum_zeta_nat _ using 1` corollaries (a model for how
+  to specialize the general form).
+- `bernoulli`, `bernoulliFun`, and the Bernoulli-number API (`bernoulli'_two`,
+  `bernoulli'_four`, `bernoulli_eq_bernoulli'_of_ne_one`) used to evaluate the
+  closed form at particular `k`.
+
+**Standard scalar identity (to be formalized, elementary):**
+
+- `η(s) = (1 − 2^{1−s})ζ(s)`. At `s = 2k`: the even-index subseries of the zeta
+  series is `∑ 1/(2m)^{2k} = 2^{−2k} ζ(2k)`, so the odd-index (lambda) part is
+  `(1 − 2^{−2k})ζ(2k)`, and `η(2k) = (odd) − (even) = (1 − 2·2^{−2k})ζ(2k) =
+  (1 − 2^{1−2k})ζ(2k)`.
+
+## Suggested Approach
+
+The cleanest architecture proves the parity split **once**, parameterized by the
+zeta value `Z` and its `HasSum` witness, then specializes.
+
+1. **Even subseries as a scaled zeta.** For fixed `k ≥ 1`, show
+   `HasSum (fun m : ℕ => 1 / ((2*m : ℕ) : ℝ)^(2*k)) (2^(-2*k) * Z)` from
+   `hZ : HasSum (fun n => 1/(n:ℝ)^(2*k)) Z`. Rewrite `1/(2m)^{2k} = 2^{−2k}·(1/m^{2k})`
+   (`push_cast; ring` under the sum, then `hZ.mul_left (2^(-2*k))` — the same
+   `.mul_left` move the parent uses with the fixed `1/16`).
+
+2. **The two signed subseries.** Following the parent's `hasSum_eta_four_even` /
+   `hasSum_eta_four_odd`, reduce the alternating signs by parity:
+   `(-1)^(2m+1) = -1` and `(-1)^(2m+2) = 1` via `pow_succ`, `pow_mul`, `norm_num`.
+   This turns the even alternating subseries into `−2^{−2k}·Z` (apply `HasSum.neg`
+   to step 1) and the odd alternating subseries into the lambda value
+   `(1 − 2^{−2k})·Z`. Obtain the odd/lambda value the way the parent does: the
+   full zeta series `hZ` splits as `even + odd` under `HasSum.even_add_odd`, and
+   `HasSum.unique` pins the odd part to `Z − 2^{−2k}Z = (1 − 2^{−2k})Z`.
+
+3. **Reassemble η(2k).** Apply `HasSum.even_add_odd` with
+   `f n = (-1)^(n+1)/n^(2k)` and the two signed subseries from step 2 to get
+   `HasSum f ((−2^{−2k}Z) + (1 − 2^{−2k})Z)`, then `convert … using 1; ring` to
+   normalize the scalar to `(1 − 2^{1−2k})·Z`. The `n = 0` term is
+   `(-1)^1/0^{2k} = 0` under Lean's division-by-zero convention, exactly as in the
+   parent. This yields `hasSum_eta_nat'`.
+
+4. **Instantiate the zeta value.** Define `hasSum_eta_nat` by feeding
+   `hasSum_zeta_nat hk` as the `(Z, hZ)` pair into `hasSum_eta_nat'`. The Bernoulli
+   closed form rides along untouched.
+
+5. **Recover the parent as a corollary.** Specialize `k = 2` and check
+   `(1 − 2^{−3}) · (π⁴/90) = 7π⁴/720` with `norm_num`/`ring`; likewise `k = 1`
+   gives `η(2) = π²/12`. Use these as regression tests against
+   `hasSum_zeta_two` / `hasSum_zeta_four`.
+
+**Anticipated friction points:**
+
+- **Integer vs. natural exponents on the scalar `2^{1−2k}`.** `2^{1−2k}` needs an
+  integer (or real `zpow`) exponent since `1 − 2k < 0`. Keep the exponent as
+  `(1 - 2*(k:ℤ))` with `zpow`, or carry `2^{−2k}` as `((2:ℝ)^(2*k))⁻¹` and let
+  `field_simp`/`ring` reconcile it. `hasSum_zeta_nat` itself uses `2^(2*k-1)`
+  (a `ℕ` subtraction, valid since `k ≥ 1`); mind that `Nat` subtraction when
+  cross-checking constants.
+- **`open scoped Nat`** is required for the factorial notation `(2*k)!` to parse
+  (the parent chain does not use `!`, but the general zeta value does).
+- **`push_cast`** discipline on `((2*m : ℕ) : ℝ)` and `((n : ℕ) : ℝ)` casts —
+  the parent already relies on this for `1/(2k)⁴ = (1/16)(1/k⁴)`.
+- **Summability side-goals** for `even_add_odd` come from `hZ.summable` composed
+  with the injections `m ↦ 2m` / `m ↦ 2m+1` (`comp_injective`, as in the parent's
+  `hasSum_odd_zeta_four`).
+
+Overall this is a faithful "lift the fixed numerals to a parameter" refactor of
+proofs already present in the parent chain, with one genuinely new (but
+elementary) lemma: the even subseries equals `2^{−2k}` times the zeta value for
+general `k`. No new hard analysis is required.
+
+## Classification
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - number-theory
+  - analysis
+  - zeta-function
+  - eta-function
+  - series
+```
+
+## Related Gallery Proofs
+| Proof | Relevance |
+|-------|-----------|
+| basel-problem-oq-13-oq-01 | Parent: proves the fixed `s = 4` case (η(4) = 7π⁴/720) this generalizes; supplies the parity-split template |
+| basel-problem-oq-13 | Grandparent: even/odd fourth-power sums (π⁴/1440, λ(4) = π⁴/96) built on `hasSum_zeta_four` |
+| basel-problem-oq-08 | ζ(4) = π⁴/90; η(4) = (1 − 1/8)ζ(4) is its alternating restriction |
+| basel-problem | Root: ζ(2) = π²/6, the `k = 1` seed of the even zeta/eta family |

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-04-oq-03/problem.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-04-oq-03/problem.md
@@ -1,0 +1,262 @@
+# Problem: All Factorial Moments of Binomial Marginals via Iterated Fiber Grouping
+
+**Slug**: `binomial-theorem-oq-02-oq-01-oq-04-oq-03`
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap (open-question child of `binomial-theorem-oq-02-oq-01-oq-04`)
+
+## Problem Statement
+
+The parent proof `BinomialTheoremOQ02OQ01OQ04` computes the **second** moment /
+variance of a multinomial marginal `Xᵢ ~ Binomial(n, pᵢ)` by *fiber grouping*
+over the value `j = k(i₀)`, reducing to the binomial second factorial moment
+`E[X(X−1)] = n(n−1)p²` already proved in `BinomialTheoremOQ03`. This child asks
+to lift that reduction to **arbitrary order `r`**, recovering *all* factorial
+moments — and hence all ordinary moments — of a binomial marginal uniformly.
+
+### Formal Statement
+
+Let `X ~ Binomial(n, p)`, represented (as in the parent chain) by the mass
+function
+
+```
+binomPMF n p k = (Nat.choose n k : ℝ) * p ^ k * (1 - p) ^ (n - k).
+```
+
+Write the **falling factorial** (Pochhammer descending) as
+`n^{(r)} = n·(n−1)⋯(n−r+1) = Nat.descFactorial n r`, with the convention
+`n^{(0)} = 1`. The `r`-th **factorial moment** of `X` is
+
+```
+  E[X^{(r)}]  =  E[ X (X−1) ⋯ (X−r+1) ]  =  ∑_{k=0}^{n} k^{(r)} · binomPMF n p k.
+```
+
+**Claim 1 (falling-factorial moment).** For all `n, r : ℕ` and `p : ℝ`,
+
+```
+  ∑_{k=0}^{n} (Nat.descFactorial k r : ℝ) · binomPMF n p k
+        =  (Nat.descFactorial n r : ℝ) · p ^ r.
+```
+
+Equivalently `E[X^{(r)}] = n^{(r)} p^r`. Note this holds for **every** `r`,
+including `r > n` where both sides vanish (`descFactorial n r = 0` when `r > n`).
+
+**Claim 2 (ordinary moment via Stirling).** Using Stirling numbers of the
+second kind `S(r, j) = Nat.stirlingSecond r j` and the connection identity
+`xʳ = ∑_{j=0}^{r} S(r, j) · x^{(j)}`, the ordinary moments follow uniformly:
+
+```
+  E[Xʳ]  =  ∑_{k=0}^{n} (k : ℝ) ^ r · binomPMF n p k
+         =  ∑_{j=0}^{r} (Nat.stirlingSecond r j : ℝ) · (Nat.descFactorial n j : ℝ) · p ^ j.
+```
+
+**Claim 3 (multinomial marginal, the fiber-grouping payoff).** For
+`(X₁,…,X_d) ~ Multinomial(n, p₁,…,p_d)` with `∑ pᵢ = 1`, represented as in the
+parent by `multinomialProb s p n k` summed over `k ∈ s.piAntidiag n`, each
+marginal statistic obeys
+
+```
+  ∑_{k ∈ s.piAntidiag n} (Nat.descFactorial (k i₀) r : ℝ) · multinomialProb s p n k
+        =  (Nat.descFactorial n r : ℝ) · (p i₀) ^ r,
+```
+
+for any `i₀ ∈ s`. This is Claim 1 pulled back through the marginal-PMF identity
+`multinomial_marginal_pmf` (from `BinomialTheoremOQ02OQ01OQ02`), exactly the
+`r`-fold generalization of the parent's `multinomial_second_moment`.
+
+### Plain Language
+
+A *moment* of a random count `X` measures its spread: `E[X]` is the average,
+`E[X²]` the average square, and so on. Ordinary powers `Xʳ` are awkward to sum
+against binomial weights because the algebra does not telescope cleanly. The
+trick — classical in probability — is to use **factorial moments**
+`E[X(X−1)⋯(X−r+1)]` instead. These *do* telescope, because of the **absorption
+identity**
+
+```
+  (k+1)·C(n+1, k+1) = (n+1)·C(n, k),
+```
+
+which lets a factor of `k` be "absorbed" into the binomial coefficient while
+shifting `n → n−1` and `k → k−1`. Applying it `r` times turns
+`k^{(r)}·C(n, k)` into `n^{(r)}·C(n−r, k−r)`; after reindexing `k ↦ k−r` and
+factoring out `n^{(r)} pʳ`, the leftover sum is a *complete* binomial sum that
+equals `1`. So `E[X^{(r)}] = n^{(r)} pʳ` drops out with almost no computation.
+
+"Fiber grouping" is the multinomial packaging of the same move: to evaluate a
+statistic that depends only on the `i₀`-th coordinate `k(i₀)`, group the
+multinomial outcomes into fibers `{k | k(i₀) = j}`; each fiber's total
+probability is exactly the binomial marginal `P(Xᵢ = j)`, so the multinomial
+computation collapses onto the binomial one.
+
+Ordinary moments are then recovered mechanically: since
+`xʳ = ∑_j S(r, j) x^{(j)}` (Stirling numbers of the second kind count the ways
+to expand a power into falling factorials), we get
+`E[Xʳ] = ∑_j S(r, j) n^{(j)} pʲ`. For example `E[X²] = n^{(2)}p² + n^{(1)}p =
+n(n−1)p² + np`, reproducing the parent's variance `np(1−p)`.
+
+### Why This Matters
+
+- **Uniformity.** The parent handles only `r = 2` (variance), with a bespoke
+  `double_absorption` lemma. This problem replaces the ad-hoc `r = 1, 2` lemmas
+  by a *single* statement covering all `r`, from which mean, variance,
+  skewness, kurtosis, and every higher moment follow.
+- **The falling-factorial abstraction is the "right" one.** The existing
+  `binomial_mean` and `binomial_second_factorial_moment` proofs in
+  `BinomialTheoremOQ03` are essentially the `r = 1` and `r = 2` special cases of
+  one clean induction. Formalizing the general `r` clarifies that the entire
+  family is a single absorption argument, not a growing pile of special cases.
+- **Reusable Mathlib-style lemma.** `∑_k k^{(r)} C(n,k) pᵏ (1−p)^{n−k} =
+  n^{(r)} pʳ` is a genuinely reusable fact about binomial factorial moments that
+  Mathlib currently lacks; it is the discrete analogue of the derivative rule
+  for the probability generating function `G(t) = (pt + 1 − p)ⁿ`, whose `r`-th
+  derivative at `t = 1` is `n^{(r)} pʳ`.
+- **Completes the multinomial moment story.** Combined with the parent's
+  covariance matrix `Σᵢⱼ = n pᵢ(δᵢⱼ − pⱼ)`, higher factorial moments open the
+  door to mixed factorial moments `E[Xᵢ^{(r)} Xⱼ^{(s)}]` and the full moment
+  structure of the multinomial.
+
+### Known Results
+
+- **Parent (`BinomialTheoremOQ02OQ01OQ04`).** `multinomial_second_moment`
+  (`E[Xᵢ²] = ∑ⱼ j²·binomPMF n pᵢ j` by fiber grouping) and `multinomial_variance`
+  (`Var(Xᵢ) = n pᵢ(1 − pᵢ)`). These are the `r = 2` instance of this problem.
+- **`BinomialTheoremOQ03`** already contains the `r = 1, 2` factorial moments and
+  the two absorption lemmas this problem generalizes:
+  - `absorption (n k : ℕ) : (k+1)·C(n+1, k+1) = (n+1)·C(n, k)` — proved from the
+    Mathlib lemma `Nat.add_one_mul_choose_eq n k :
+    (n+1)·choose n k = choose (n+1) (k+1)·(k+1)`. (Note: `Nat.succ_mul_choose_eq`
+    is the same fact but is **deprecated since 2025-12-09** — use
+    `Nat.add_one_mul_choose_eq`.)
+  - `double_absorption (n k) : (k+2)(k+1)·C(n+2, k+2) = (n+2)(n+1)·C(n, k)` —
+    two applications of `absorption`; this is the `r = 2` falling-factorial
+    absorption.
+  - `binomial_mean : ∑ₖ k·binomPMF n p k = n·p` (r = 1).
+  - `binomial_second_factorial_moment : ∑ₖ k(k−1)·binomPMF n p k = n(n−1)p²`
+    (r = 2). This is literally `E[X^{(2)}] = n^{(2)} p²`.
+  - `binomial_variance : E[X²] − (E[X])² = np(1−p)` (via
+    `E[X²] = E[X(X−1)] + E[X]`), and `binomial_expansion` / `binomPMF_sum_eq_one`
+    for the normalization `∑ₖ C(n,k) pᵏ(1−p)^{n−k} = 1`.
+- **Mathlib primitives** (verified present in this checkout):
+  - `Nat.descFactorial : ℕ → ℕ → ℕ`, with `Nat.descFactorial_zero`,
+    `Nat.descFactorial_one`, and the recurrence
+    `Nat.descFactorial_succ n k : n.descFactorial (k+1) = (n − k) · n.descFactorial k`.
+  - `Nat.descFactorial_eq_factorial_mul_choose (n k) :
+    n.descFactorial k = k! · n.choose k` — the exact bridge relating falling
+    factorial and binomial coefficient (and its inverse
+    `Nat.choose_eq_descFactorial_div_factorial`).
+  - `Nat.stirlingSecond : ℕ → ℕ → ℕ` (in
+    `Mathlib/Combinatorics/Enumerative/Stirling.lean`) with recurrences
+    `stirlingSecond_succ_succ`, `stirlingSecond_self`, `stirlingSecond_zero`,
+    `stirlingSecond_eq_zero_of_lt`. **Caveat:** the connection identity
+    `xʳ = ∑ⱼ S(r,j) x^{(j)}` does **not** appear to be in Mathlib as a named
+    lemma; it may need to be proved from the recurrence, or Claim 2 may be
+    stated directly in falling-factorial form and the Stirling expansion left as
+    a corollary.
+
+### Suggested Approach
+
+Grounded Lean plan, matching the parent's representation:
+
+1. **General falling-factorial absorption (the crux).** Prove, purely over `ℕ`,
+   ```
+   k.descFactorial r * Nat.choose n k = n.descFactorial r * Nat.choose (n − r) (k − r)
+   ```
+   or the more directly usable shifted form (with `k` reindexed as `k + r`):
+   ```
+   (k + r).descFactorial r * Nat.choose n (k + r)
+       = n.descFactorial r * Nat.choose (n − r) k.
+   ```
+   Prove by induction on `r`: the base `r = 0` is `Nat.descFactorial_zero` +
+   `Nat.sub_zero`; the step applies `absorption` (i.e.
+   `Nat.add_one_mul_choose_eq`) once and unfolds one layer via
+   `Nat.descFactorial_succ` on both `k^{(r+1)}` and `n^{(r+1)}`. This is the
+   inductive replacement for the parent's hand-written `double_absorption`.
+   *Alternative:* route through `Nat.descFactorial_eq_factorial_mul_choose` to
+   turn every `descFactorial` into `r! · choose`, converting the identity into a
+   pure `choose`/factorial statement provable by `Nat.choose_mul_choose`-type
+   Vandermonde reasoning (`Mathlib/Data/Nat/Choose/Mul.lean`,
+   `Vandermonde.lean`).
+
+2. **Sum evaluation.** In the real sum
+   `∑_{k ∈ range (n+1)} (k.descFactorial r) · binomPMF n p k`, drop the vanishing
+   low terms `k < r` (there `k.descFactorial r = 0`), reindex `k ↦ k + r` with
+   `Finset.sum_range_succ'` / a `Finset` shift, apply step 1 to rewrite each
+   term, factor out the constant `n.descFactorial r · pʳ` with `Finset.mul_sum`,
+   and recognize the residual sum
+   `∑_{k} C(n−r, k) pᵏ (1−p)^{(n−r)−k}` as `1` via `binomial_expansion`
+   (`= (p + (1−p))^{n−r} = 1`) — precisely the closing move in the existing
+   `binomial_mean` / `binomial_second_factorial_moment` proofs.
+
+3. **Multinomial marginal (Claim 3).** Re-run the parent's
+   `multinomial_second_moment` skeleton verbatim with the statistic `k(i₀)²`
+   replaced by `(k i₀).descFactorial r`:
+   `Finset.sum_fiberwise_of_maps_to` over `j = k i₀` (the `hmaps_to` bound uses
+   `Finset.single_le_sum` and `Finset.mem_piAntidiag`), on each fiber the
+   constant `j.descFactorial r` factors out via `Finset.mul_sum`, and the fiber
+   probability sum collapses to `binomPMF n (p i₀) j` by
+   `BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf`. Then invoke Claim 1.
+
+4. **Ordinary moments (Claim 2).** Either (a) prove
+   `xʳ = ∑ⱼ S(r,j) x^{(j)}` over `ℝ` by induction on `r` using
+   `stirlingSecond_succ_succ` and `x · x^{(j)} = x^{(j+1)} + j · x^{(j)}`
+   (Pochhammer recurrence), then combine termwise with Claim 1 and
+   `Finset.sum_comm`; or (b) state `E[Xʳ]` directly and derive the low cases
+   (`r = 1, 2`) to confirm consistency with the parent. Given the Stirling
+   connection identity is not prepackaged, expect the bulk of the effort here to
+   be that `ℝ`-level expansion.
+
+**Verified name check.** `binomPMF`, `absorption`, `double_absorption`,
+`binomial_mean`, `binomial_second_factorial_moment`, `binomial_variance`,
+`binomial_expansion` are from `Proofs/BinomialTheoremOQ03.lean`;
+`multinomialProb`, `multinomial_mean`, `piAntidiag` usage and
+`sum_fiberwise_of_maps_to` from the OQ03/OQ04 files;
+`multinomial_marginal_pmf` from `BinomialTheoremOQ02OQ01OQ02`. Mathlib names
+`Nat.descFactorial(_succ/_zero/_one)`, `Nat.descFactorial_eq_factorial_mul_choose`,
+`Nat.add_one_mul_choose_eq`, `Nat.stirlingSecond` are confirmed present in the
+checkout's mathlib (v4.26.0). The `xʳ = ∑ S(r,j) x^{(j)}` identity is the one
+piece I could **not** find as a ready-made Mathlib lemma — treat it as
+to-be-proved.
+
+### Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 7
+tags:
+  - probability
+  - multinomial-distribution
+  - factorial-moment
+  - binomial-marginal
+  - fiber-grouping
+  - combinatorics
+  - descFactorial
+  - stirling-numbers
+```
+
+Rationale: Claim 1 (the falling-factorial moment) is genuinely tractable — a
+clean induction on `r` reusing the parent's absorption/normalization machinery,
+so the core deliverable is well within reach (tractability 7). Claim 3 is a
+mechanical re-skinning of the parent proof. The Stirling-based ordinary-moment
+corollary (Claim 2) is the only part with real risk, because the connection
+identity is not prepackaged in Mathlib; a solver may reasonably ship Claims 1
+and 3 first and treat Claim 2 as a follow-on. Significance 6: uniform-in-`r`
+result that subsumes several existing special-case lemmas and adds a reusable
+binomial-factorial-moment fact.
+
+### Related Gallery Proofs
+
+- **`binomial-theorem-oq-02-oq-01-oq-04`** (parent) — second moment / variance of
+  multinomial marginals via fiber grouping; the `r = 2` case of Claim 1/3.
+- **`binomial-theorem-oq-03`** — binomial mean (`r = 1`), second factorial moment
+  (`r = 2`), variance, and the `absorption` / `double_absorption` identities this
+  problem generalizes to all `r`.
+- **`binomial-theorem-oq-02-oq-01-oq-03`** — off-diagonal cross-moments /
+  covariance `Cov(Xᵢ,Xⱼ) = −n pᵢ pⱼ`; the natural next target after single-index
+  higher moments is mixed factorial moments `E[Xᵢ^{(r)} Xⱼ^{(s)}]`.
+- **`binomial-theorem-oq-02-oq-01-oq-02`** — marginal PMF `P(Xᵢ = j) =
+  binomPMF n pᵢ j`, the identity that collapses each fiber sum.
+- **`binomial-theorem`** (root) — the binomial theorem `add_pow` /
+  `binomial_expansion` underlying the normalization `∑ₖ C(n,k) pᵏ(1−p)^{n−k} = 1`.
+```

--- a/research/problems/british-flag-theorem-oq-01-oq-02-oq-02/problem.md
+++ b/research/problems/british-flag-theorem-oq-01-oq-02-oq-02/problem.md
@@ -1,0 +1,196 @@
+# Problem: Higher-Moment British Flag Defect for Orthotopes — the 2k-th Power Alternating Sum
+
+**Slug**: british-flag-theorem-oq-01-oq-02-oq-02
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap (open-question child of british-flag-theorem-oq-01-oq-02)
+
+## Problem Statement
+
+### Formal Statement
+
+Fix `n ≥ 1` and an axis-aligned box in `ℝⁿ` with opposite corners `a, b : Fin n → ℝ`.
+Each of the `2ⁿ` vertices is indexed by a subset `t ⊆ Fin n`, coordinate `i` taking the
+"far" value `b i` when `i ∈ t` and the "near" value `a i` otherwise:
+
+  `vertex a b t i = if i ∈ t then b i else a i`   (exactly the parent's definition).
+
+The parent studies the **squared** distance `sqDist a b P t = ∑ᵢ (Pᵢ − vertexᵢ(t))²`.
+This problem replaces it by the `2k`-th moment `‖P − vertex(t)‖^{2k} = (sqDist a b P t)^k`
+and asks for the vanishing/defect law of the alternating parity sum
+
+  `A_k(P) := ∑_{t ⊆ Fin n} (−1)^{|t|} · (sqDist a b P t)^k`
+          `= ∑_{|t| even} ‖P − vertex(t)‖^{2k}  −  ∑_{|t| odd} ‖P − vertex(t)‖^{2k}.`
+
+For `k = 1`, `A_1 ≡ 0` for all `n ≥ 2` is exactly the parent theorem
+`alternating_sqDist_zero`; for `n = 2, k = 1` it is the classical British Flag Theorem.
+
+**Conjecture (box moment law).** Write `δᵢ := (Pᵢ − bᵢ)² − (Pᵢ − aᵢ)² = (aᵢ − bᵢ)(2Pᵢ − aᵢ − bᵢ)`
+for the per-coordinate squared-distance increment. Then:
+
+1. **Vanishing (main target).** If `k ≤ n − 1` (equivalently `k < n`), then `A_k(P) = 0` for
+   *every* box `a, b` and every observer `P`.
+
+2. **Sharp first defect.** If `k = n`, then
+     `A_n(P) = n! · ∏ᵢ ((Pᵢ − aᵢ)² − (Pᵢ − bᵢ)²) = (−1)ⁿ · n! · ∏ᵢ δᵢ`,
+   which is generically nonzero; it is independent of the observer only up to the
+   product structure and vanishes iff some coordinate is "centered" (`Pᵢ = (aᵢ+bᵢ)/2`)
+   or degenerate (`aᵢ = bᵢ`). For `n = 2, k = 2` this reads `A_2 = 2·δ₀·δ₁`.
+
+3. **General defect (research core).** For `k ≥ n`, `A_k(P) = (−1)ⁿ ·` [coefficient of the
+   full-support multilinear monomial `x₁x₂⋯xₙ` in the reduction of `(C + ∑ᵢ xᵢδᵢ)^k` modulo
+   `xᵢ² = xᵢ`], where `C = ∑ᵢ (Pᵢ − aᵢ)²`. Give this coefficient in closed symmetric form.
+
+**Lean theorem shape** (namespace, e.g., `BritishFlagMomentOQ010202`, importing
+`Proofs.BritishFlagOrthotopeOQ0102`):
+
+```
+def sqDistPow (a b P : Fin n → ℝ) (k : ℕ) (t : Finset (Fin n)) : ℝ :=
+  (BritishFlagOrthotopeOQ0102.sqDist a b P t) ^ k
+
+theorem box_moment_vanishes (hk : k < n) (a b P : Fin n → ℝ) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset, (-1 : ℝ) ^ t.card * sqDistPow a b P k t = 0
+
+theorem box_moment_first_defect (a b P : Fin n → ℝ) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset, (-1 : ℝ) ^ t.card * sqDistPow a b P n t
+      = (n ! : ℝ) * ∏ i, ((P i - a i) ^ 2 - (P i - b i) ^ 2)
+```
+
+### Plain Language
+
+Stand at any point `P` and look at the `2ⁿ` corners of a rectangular box in `n` dimensions.
+Colour a corner "even" or "odd" by the parity of how many of its coordinates sit at the far
+face. The British Flag Theorem says the even corners and odd corners give the same **sum of
+squared distances**. What if we sum the **fourth** powers instead? The sixth? The `2k`-th?
+
+The engine is the same "telescoping finite difference over the vertex hypercube": summing a
+quantity over all corners with alternating `±` signs is the `n`-fold discrete derivative, one
+step per coordinate, and each derivative step kills anything that does not genuinely depend on
+that coordinate. For a right-angled box the squared distance is a *sum* over coordinates
+(`∑ᵢ (Pᵢ − vertexᵢ)²`) — an affine function of the corner's `0/1` toggle vector, so its
+`k`-th power reaches "cross-terms" touching at most `k` distinct coordinates. As long as
+`k < n`, no term touches all `n` coordinates at once, so the `n`-fold alternating derivative
+annihilates everything and `A_k = 0`. Exactly at `k = n` the first full-coordinate cross-term
+appears — the product `δ₀δ₁⋯δ_{n−1}` weighted by `n!` — and the parity sum stops vanishing.
+
+### Why This Matters
+
+- **A reusable annihilation lemma.** The whole British-flag family (parent squared-distance,
+  the sibling fourth moment, this problem) is one statement: *the alternating powerset sum
+  `∑_t (−1)^{|t|} F(t)` annihilates every function `F` whose multilinear expansion in the
+  membership toggles omits at least one coordinate, and otherwise returns `(−1)ⁿ` times the
+  full-support coefficient.* Isolating "vanishing degree < n ⇒ 0; degree = n ⇒ explicit top
+  coefficient" turns each moment identity into a one-line corollary.
+
+- **It unifies and *sharpens* the two existing branches.** The sibling
+  (british-flag-theorem-oq-01-oq-02-oq-01) proves the fourth-moment defect for a *general
+  parallelepiped* (skew edges), where the squared distance is degree **2** in the toggles, so
+  the vanishing threshold is `n ≥ 2k+1` (n≥5 for k=2). For a *right-angled box* the off-diagonal
+  Gram entries `⟨uᵢ,uⱼ⟩` vanish, dropping the degree to **1** and improving the threshold to the
+  sharper `n ≥ k+1`. This problem pins down that the orthogonality of the box is precisely what
+  halves the required dimension.
+
+- **Top Walsh coefficient.** The weight `(−1)^{|t|}` is the top Walsh–Fourier character
+  `χ_{univ}` on the hypercube `{0,1}ⁿ`; `A_k(P)` is exactly the top Fourier coefficient of the
+  function `t ↦ ‖P − vertex(t)‖^{2k}`. The vanishing law is the statement that a bounded-degree
+  polynomial has no top Fourier mass — connecting to the parent entry's third open question.
+
+### Known Results
+
+- **Parent (`k = 1`):** `alternating_sqDist_zero` proves `A_1 ≡ 0` for `n ≥ 2`; the mechanism
+  is `∑_{s ⊆ univ∖{i}} (−1)^{|s|} = 0` per coordinate (Mathlib
+  `Finset.sum_powerset_neg_one_pow_card_of_nonempty`, cast to ℝ). The `n = 1` segment is the
+  sharp boundary where `A_1 ≠ 0`. This is the `k < n` law at `k = 1`.
+
+- **Sibling (`k = 2`, parallelepiped):** `BritishFlagFourthMomentOQ010201.lean` proves
+  `fourth_moment_defect_eq_zero` (`n ≥ 5`), `defect4_eq_quartic_piece` (`n ≥ 4` collapses to the
+  degree-4 Gram-square piece), and the first nonvanishing value `fourth_moment_defect_n4`:
+  `defect₄ = 8·(⟨u₀,u₁⟩⟨u₂,u₃⟩ + ⟨u₀,u₂⟩⟨u₁,u₃⟩ + ⟨u₀,u₃⟩⟨u₁,u₂⟩)`. It already isolates the
+  key abstraction `monomial_term_zero` (`∑_t (−1)^{|t|}[S ⊆ t] = 0` for `S ≠ univ`) and its
+  evaluator `monomial_term_eval` (`= (−1)ⁿ` iff `S = univ`) — valid for *every* `n`. **Note:**
+  for orthogonal edges (a box) all cross Gram entries are `0`, so `fourth_moment_defect_n4`
+  collapses to `0`, consistent with the sharper box threshold `k < n` (`A_2 = 0` for `n ≥ 3`,
+  and `A_2 = 2δ₀δ₁` at `n = 2`).
+
+- **Finite-difference / inclusion–exclusion:** the general principle that an `n`-fold alternating
+  sum extracts the top-degree multilinear coefficient is classical (Stanley, *Enumerative
+  Combinatorics* I). Mathlib's `Finset.prod_add` gives the exact telescoping
+  `∑_{t ⊆ univ} (∏_{i∈t} pᵢ)(∏_{i∉t} qᵢ) = ∏ᵢ (pᵢ + qᵢ)`.
+
+### Suggested Approach
+
+The recommended path proves the box case cleanly by *factoring over coordinates*, avoiding the
+full multinomial bookkeeping the sibling needed for skew edges.
+
+1. **Reduce to a product-of-affine structure.** For a box, `sqDist a b P t = ∑ᵢ gᵢ(t)` with
+   `gᵢ(t) = if i∈t then βᵢ else αᵢ`, `αᵢ = (Pᵢ−aᵢ)²`, `βᵢ = (Pᵢ−bᵢ)²`. This is the parent's
+   `sqDist`/`vertex` unfolding (`split_ifs`), reused by `import Proofs.BritishFlagOrthotopeOQ0102`.
+
+2. **Vanishing `k < n` — telescoping product.** The cleanest engine is the identity
+   `∑_{t⊆univ} (−1)^{|t|} ∏ᵢ fᵢ(t) = ∏ᵢ (fᵢ(∉) − fᵢ(∈))`, an instance of Mathlib
+   `Finset.prod_add` (write the sign into one factor). For `(sqDist)^k`, expand the `k`-th power
+   as a sum of products of `k` coordinate-indexed factors (via `Finset.sum_pow`/repeated
+   `Finset.sum_mul_sum` or `Finset.mul_sum` + `Finset.sum_comm`, mirroring the sibling's
+   `hrw`/`sum_comm` cascade). Each resulting product `∏` ranges over a multiset of at most `k`
+   coordinates; if `k < n` some coordinate `i₀` is *absent*, so summing the `(−1)^{|t|}` weight
+   over `t` factors out `∑_{s ⊆ univ∖{i₀}} (−1)^{|s|} = 0` — precisely the parent's
+   `alt_sum_ite_eq_zero` / `real_alt_powerset_zero`, or the sibling's `monomial_term_zero`
+   with `S ≠ univ` since `|S| ≤ k < n`.
+
+3. **First defect `k = n`.** Only the full-support term survives. Using `monomial_term_eval`
+   (`(−1)ⁿ` on `S = univ`) and the multinomial coefficient counting the `n!` orderings that hit
+   each of the `n` coordinates exactly once, obtain
+   `A_n(P) = (−1)ⁿ · n! · ∏ᵢ δᵢ = n! · ∏ᵢ (αᵢ − βᵢ)`. Verify the `n = 2` sanity value `2δ₀δ₁`
+   against a direct 4-vertex computation (`Fin.sum_univ_four`, as in `fourth_moment_defect_n4`).
+
+4. **General defect `k > n` (research core).** Characterize the full-support coefficient of
+   `(C + ∑ᵢ xᵢδᵢ)^k` mod `xᵢ² = xᵢ` in closed form (a sum over surjections `[k] ↠ [n]`, i.e.
+   Stirling-number-weighted symmetric functions in `δᵢ` and `C`). This is the genuinely open,
+   higher-effort part; the vanishing law and first defect (steps 2–3) are the shippable core.
+
+**Real Mathlib names to lean on:** `Finset.sum_powerset_neg_one_pow_card_of_nonempty`,
+`Finset.prod_add`, `Finset.powerset_insert`, `Finset.sum_comm`, `Finset.mul_sum`,
+`Finset.sum_mul_sum`, `Finset.sum_filter_add_sum_filter_not`, `Even.neg_one_pow`,
+`Odd.neg_one_pow`, `Fin.sum_univ_four`, `Nat.factorial`. Plus the project lemmas
+`BritishFlagOrthotopeOQ0102.alt_sum_ite_eq_zero`, `.real_alt_powerset_zero`, and the sibling's
+`monomial_term_zero` / `monomial_term_eval`. Do **not** assume a Mathlib multinomial-theorem
+lemma exists by a guessed name; check before use.
+
+### Classification
+
+```yaml
+tier: B
+significance: 5
+tractability: 5
+tags:
+  - geometry
+  - euclidean-geometry
+  - orthotope
+  - british-flag-theorem
+  - inclusion-exclusion
+  - powerset
+  - alternating-sum
+  - finite-difference
+domain: geometry
+parent: british-flag-theorem-oq-01-oq-02
+category: generalization
+```
+
+Notes on classification: the **vanishing law `k < n ⇒ A_k = 0`** and the **first defect
+`A_n = n!·∏(αᵢ−βᵢ)`** are highly tractable — they reuse the parent's and sibling's existing
+lemmas almost verbatim (tractability 5). The **general closed-form defect for `k > n`** is
+harder (surjection/Stirling combinatorics) and can be deferred or stated as a further open
+question; a shippable, verified entry needs only the vanishing law plus the first defect.
+
+### Related Gallery Proofs
+
+- **british-flag-theorem-oq-01-oq-02** (parent) — the orthotope squared-distance identity
+  `A_1 ≡ 0` for `n ≥ 2`; supplies `vertex`, `sqDist`, `alt_sum_ite_eq_zero`,
+  `real_alt_powerset_zero`. This problem is its `k`-th moment generalization.
+- **british-flag-theorem-oq-01-oq-02-oq-01** (sibling) — fourth-moment defect for a *general
+  parallelepiped* (`n ≥ 5` vanishing, explicit `n = 4` pairing-sum defect); supplies the reusable
+  `monomial_term_zero` / `monomial_term_eval` finite-difference abstraction. This problem is the
+  *orthogonal* (box) counterpart with the sharper `n ≥ k+1` threshold, for all `k`.
+- **british-flag-theorem-oq-01-oq-01** — the 2-D non-orthogonal parallelogram defect `2⟨u,v⟩`;
+  the `k = 1` skew case underlying the sibling's higher-degree generalization.
+- **british-flag-theorem-oq-01** — the British Flag Theorem in ℝ²; the `n = 2, k = 1` slice.

--- a/research/problems/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03/problem.md
+++ b/research/problems/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03/problem.md
@@ -1,0 +1,202 @@
+# Problem: Poincaré Separation — Eigenvalue Bounds for m×m Principal Submatrices
+
+**Slug**: cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: gallery-gap (open-question child of `cauchy-interlacing-theorem-oq-01-oq-01-oq-01`)
+
+## Problem Statement
+
+### Formal Statement
+
+Let `A : Matrix (Fin n) (Fin n) 𝕜` be Hermitian (`hA : A.IsHermitian`) over an `RCLike`
+field `𝕜` (so `ℝ` or `ℂ`), with sorted eigenvalues `hA.eigenvalues₀ : Fin n → ℝ`
+(the concrete Mathlib tuple from `Mathlib.Analysis.Matrix.Spectrum`, antitone by
+`Matrix.IsHermitian.eigenvalues₀_antitone`). Fix an index set `I ⊆ Fin n` of size `m`,
+realized as an injection `g : Fin m ↪ Fin n` (or `g : Fin m → Fin n` injective), and form
+the `m × m` principal submatrix
+
+```
+A^{(I)} := A.submatrix g g          -- (A.submatrix g g) i j = A (g i) (g j)
+```
+
+which is again Hermitian (`(hA.submatrix g).?` — Hermitianness of a principal submatrix is
+immediate: `(A.submatrix g g)ᴴ = Aᴴ.submatrix g g = A.submatrix g g`). Write
+`μ := (submatrix_isHermitian).eigenvalues₀ : Fin m → ℝ` for its sorted eigenvalue tuple.
+
+**Poincaré separation theorem.** For every `k` with `1 ≤ k ≤ m` (0-indexed: `k : Fin m`),
+
+```
+λ_k(A)  ≤  λ_k(A^{(I)})  ≤  λ_{k + (n − m)}(A).
+```
+
+Because Mathlib's `eigenvalues₀` are sorted in **decreasing** (antitone) order, the same
+statement in Mathlib's convention becomes the "opposite ordering" form flagged in the parent's
+open question:
+
+```
+λ_{k + (n − m)}(A)  ≤  λ_k(A^{(I)})  ≤  λ_k(A)      -- antitone/decreasing indexing
+```
+
+i.e. with `hA.eigenvalues₀` and `μ` both decreasing, `k : Fin m`, and the shift
+`k ↦ ⟨k + (n − m), _⟩ : Fin n` on the lower bound. The parent single-deletion result is the
+special case `m = n − 1`, which reads `λ_{k+1}(A) ≤ λ_k(A^{(j)}) ≤ λ_k(A)`.
+
+**Lean theorem shape (decreasing convention):**
+
+```lean
+theorem poincare_separation
+    {n m : ℕ} {𝕜 : Type*} [RCLike 𝕜]
+    {A : Matrix (Fin n) (Fin n) 𝕜} (hA : A.IsHermitian)
+    (g : Fin m → Fin n) (hg : Function.Injective g)
+    (hAI : (A.submatrix g g).IsHermitian)      -- from hA and injectivity
+    (k : Fin m) (hkn : (k : ℕ) + (n - m) < n) :
+    hA.eigenvalues₀ ⟨(k : ℕ) + (n - m), hkn⟩
+      ≤ hAI.eigenvalues₀ k
+    ∧ hAI.eigenvalues₀ k
+      ≤ hA.eigenvalues₀ ⟨(k : ℕ), by omega⟩ := by
+  sorry
+```
+
+**Compression viewpoint.** Let `P_I : EuclideanSpace 𝕜 (Fin n) → EuclideanSpace 𝕜 (Fin n)` be
+the orthogonal projection onto `span 𝕜 {e_i : i ∈ I}` (the coordinate subspace `ℝ^I`, an
+`m`-dimensional coordinate subspace). Then `A^{(I)}` is the **compression** `P_I A P_I`
+restricted to that subspace: identifying the coordinate subspace `span {e_{g i}}` with
+`EuclideanSpace 𝕜 (Fin m)` via the isometry sending `e_{g i} ↦ e_i`, the operator
+`toEuclideanLin (A.submatrix g g)` is unitarily conjugate to `P_I ∘ toEuclideanLin A ∘ P_I`
+on that subspace. This is exactly the sesquilinear-form identification the parent chain proves:
+the entry `#27917` (`cauchy-interlacing-theorem-oq-01-oq-01`) supplies
+`compress_inner_eq_principalSubmatrix`, and this entry's parent
+(`cauchy-interlacing-theorem-oq-01-oq-01-oq-01`) supplies `eigenvalues_eq_of_eigenbasis` /
+the unitary-conjugation invariance that lets one read the compressed operator's sorted spectrum
+off as `A^{(I)}`'s.
+
+### Plain Language
+
+Take a Hermitian matrix `A` and throw away all but `m` chosen rows and the matching `m`
+columns, keeping an `m × m` diagonal block `A^{(I)}`. The eigenvalues of that block cannot
+stray arbitrarily from those of `A`: sorted the same way, each eigenvalue of the block is
+squeezed between the corresponding eigenvalue of `A` and the one shifted by `n − m` positions.
+The classic **Cauchy interlacing** theorem is the case where you delete a single row/column
+(`m = n − 1`); the eigenvalues of the `(n−1)×(n−1)` block then strictly interlace those of `A`.
+Poincaré separation is the general statement, obtained either by **iterating** single-row
+deletion `n − m` times, or **in one shot** via the min–max (Courant–Fischer) description of
+eigenvalues restricted to test subspaces that live inside the coordinate subspace `ℝ^I`.
+
+### Why This Matters
+
+- **General form of interlacing.** Cauchy interlacing (`m = n − 1`) is the workhorse special
+  case; Poincaré separation is the full statement for any principal submatrix. Having it makes
+  the whole gallery Cauchy-interlacing chain "complete at the top."
+- **Reusable spectral infrastructure.** The compression / restriction-to-a-coordinate-subspace
+  identification, and the sorted-eigenvalue-is-a-unitary-invariant lemma proved by the parent,
+  are exactly the tools needed for a family of monotonicity results.
+- **Foundation for majorization and min–max.** Poincaré separation is the standard route into
+  the **Schur–Horn** theorem (diagonal entries are majorized by eigenvalues), **Weyl's
+  inequalities** for eigenvalues of sums, and numerical eigenvalue bounds (deflation, Rayleigh–
+  Ritz, Sturm sequences). None of these are in Mathlib yet; this is a natural first brick.
+
+### Known Results
+
+- **Parent bridge lemma (verified, this gallery).**
+  `CauchyInterlacingOQ01OQ01OQ01.eigenvalues_eq_of_eigenbasis`: for a self-adjoint
+  `T : E →ₗ[𝕜] E` with `hT : T.IsSymmetric`, any orthonormal eigenbasis `(b, f)` with
+  `T (b i) = (f i : 𝕜) • b i` and `f` antitone satisfies `hT.eigenvalues hn = f`. Corollary:
+  the sorted spectrum is invariant under linear isometry equivalence (unitary conjugation).
+- **Compression identity (verified, `#27917`).** `compress_inner_eq_principalSubmatrix`:
+  the sesquilinear form of the compressed operator on the coordinate subspace equals that of
+  `toEuclideanLin (A.submatrix …)`.
+- **Courant–Fischer min–max (classical, NOT yet in Mathlib for the k-th eigenvalue).**
+  `λ_k(A) = min_{dim V = k} max_{0 ≠ x ∈ V} ⟨Ax, x⟩ / ⟨x, x⟩` (increasing convention). Mathlib
+  currently has only the **extremal** Rayleigh cases (largest/smallest eigenvalue), not the
+  general k-dimensional subspace min–max. See "Suggested Approach" for exactly what is missing.
+- **Coordinate-subspace restriction.** Restricting the Rayleigh quotient of `A` to test vectors
+  supported on `I` yields the Rayleigh quotient of `A^{(I)}`; combined with min–max this gives
+  the two-sided bound directly.
+
+### Suggested Approach
+
+Two routes; the iterated-parent route is the tractable one given current Mathlib.
+
+**(a) Iterated single-deletion (recommended).**
+Assemble the parent's single-deletion principal-submatrix interlacing
+`λ_{k+1}(A) ≤ λ_k(A^{(j)}) ≤ λ_k(A)` (the parent's second open question — building the explicit
+coordinate-hyperplane isometry and feeding `compress_inner_eq_principalSubmatrix` into the
+conjugation corollary), then induct on `n − m`: delete indices in `Fin n \ I` one at a time,
+each step applying single-deletion and composing the index shifts (`k+1` accumulates to
+`k + (n − m)`). Pros: reuses the parent lemma directly; each step is a known result. Cons:
+requires (i) finishing the parent's own single-deletion assembly first, and (ii) careful
+bookkeeping of the `Fin`-index arithmetic across `n − m` deletions and of Hermitianness of each
+intermediate submatrix. This is the lower-risk path because it does not need any new min–max
+machinery.
+
+**(b) Direct Courant–Fischer min–max.**
+Prove the general k-th-eigenvalue min–max characterization first, then restrict the test
+subspaces to lie inside the `m`-dimensional coordinate subspace `ℝ^I`: the upper bound
+`λ_k(A^{(I)}) ≤ λ_k(A)` uses that `A^{(I)}`'s optimal `k`-dim subspace is a valid (smaller-
+ambient) competitor for `A`; the lower bound `λ_{k+(n−m)}(A) ≤ λ_k(A^{(I)})` uses the max–min
+form with the codimension bookkeeping. Pros: one shot, no induction, conceptually clean. Cons:
+**the general k-dimensional min–max theorem is absent from Mathlib** — only the extremal cases
+exist (see verified names below). Building it (a `sInf`/`sSup` over subspaces of a given
+`finrank`, plus existence of an optimizer via the spectral theorem) is itself a substantial
+lemma. So route (b) is more work unless one first upstreams Courant–Fischer.
+
+**Verified Mathlib names to build on** (spelling + module confirmed):
+- `Matrix.IsHermitian` — `Mathlib.LinearAlgebra.Matrix.Hermitian` (`Aᴴ = A`).
+- `Matrix.IsHermitian.eigenvalues₀`, `Matrix.IsHermitian.eigenvalues`,
+  `Matrix.IsHermitian.eigenvalues₀_antitone`, `Matrix.IsHermitian.eigenvectorBasis`
+  — `Mathlib.Analysis.Matrix.Spectrum`.
+- `Matrix.toEuclideanLin`, `Matrix.submatrix` — core Mathlib.
+- `LinearMap.IsSymmetric.eigenvalues`, `.eigenvalues_antitone`, `.eigenvectorBasis`,
+  `.apply_eigenvectorBasis` — `Mathlib.Analysis.InnerProductSpace.Spectrum`.
+- `ContinuousLinearMap.rayleighQuotient`,
+  `LinearMap.IsSymmetric.hasEigenvalue_iSup_of_finiteDimensional`,
+  `LinearMap.IsSymmetric.hasEigenvalue_iInf_of_finiteDimensional`
+  — `Mathlib.Analysis.InnerProductSpace.Rayleigh` (extremal Rayleigh only — the largest/smallest
+  eigenvalue; **no k-th-eigenvalue min–max**).
+- `Submodule.subtype`, `OrthonormalBasis`, linear isometry equivalences `≃ₗᵢ` — for the
+  coordinate-subspace restriction / conjugation, exactly as the parent uses them.
+
+**Do NOT cite (searched, not present in Mathlib):** `LinearMap.IsSymmetric.rayleigh`, any
+`iSup_rayleigh_eq_iInf…` on `LinearMap.IsSymmetric`, a general Courant–Fischer k-th eigenvalue
+min–max theorem, or any `interlac`/`Poincare` eigenvalue lemma. These would be original
+contributions.
+
+**Recommendation.** Pursue route (a): it inherits the parent's verified charpoly-based
+invariance lemma and only needs the single-deletion assembly (already scoped as the parent's
+open question) plus an induction on `n − m`. Route (b) is mathematically cleaner but is gated on
+first formalizing Courant–Fischer, which is a larger independent target.
+
+### Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 5
+tags:
+  - linear-algebra
+  - spectral
+  - hermitian
+  - eigenvalues
+  - cauchy-interlacing
+  - spectral-theorem
+```
+
+Rationale: significance 7 — Poincaré separation is a named, textbook-standard generalization
+underpinning Schur–Horn, Weyl, and numerical spectral bounds, and it completes the gallery's
+Cauchy-interlacing chain. Tractability 5 — the iterated route reuses the parent's verified
+bridge lemma, but depends on first completing the parent's own single-deletion assembly and on
+nontrivial `Fin`-index bookkeeping across `n − m` deletions; the clean min–max route needs a
+Courant–Fischer theorem that Mathlib does not yet have.
+
+### Related Gallery Proofs
+
+- **`cauchy-interlacing-theorem-oq-01-oq-01-oq-01`** (direct parent, verified, 0 axioms) —
+  proves `eigenvalues_eq_of_eigenbasis`: a self-adjoint operator's sorted eigenvalues are
+  determined by any orthonormal eigenbasis, i.e. invariant under unitary conjugation. Its third
+  listed open question is exactly this Poincaré-separation generalization.
+- **`cauchy-interlacing-theorem-oq-01-oq-01`** (grandparent, `#27917`) — the principal-submatrix
+  identification supplying `compress_inner_eq_principalSubmatrix`, the sesquilinear-form bridge
+  between the compressed operator and `toEuclideanLin (A.submatrix …)`.
+- **`cauchy-interlacing-theorem`** (root) — the single-deletion Cauchy interlacing keystone,
+  `λ_{k+1}(A) ≤ λ_k(A^{(j)}) ≤ λ_k(A)`, the `m = n − 1` special case of this problem.


### PR DESCRIPTION
## Summary

Pool replenishment. Effective available pool had dropped to ~20 usable
(33 nominal − 6 already-locked − 1 missing-dir − 6 moonshot placeholder
stubs), so this adds **6 fresh tractable research problems** to rebuild the
buffer above the 15-problem threshold with a healthy margin.

One problem per mathematical domain for diversity. Each is an open-question
child of a **verified, 0-axiom** gallery parent, so the ground is solid and
the generalization well-scoped. Every formal statement and suggested-approach
lemma name was **verified against the repo's Mathlib source** by a drafting
pass — no invented lemma names.

| Slug | Domain | Problem |
|------|--------|---------|
| `basel-problem-oq-13-oq-01-oq-01` | number theory | Uniform even eta values η(2k)=(1−2^{1−2k})ζ(2k) via `hasSum_zeta_nat` |
| `antitone-integral-sum-comparison-oq-01-oq-02-oq-02` | analysis | Generalized Euler constant: ∑f(k)−∫f converges for antitone divergent f |
| `british-flag-theorem-oq-01-oq-02-oq-02` | geometry | Higher-moment orthotope alternating vertex sums; threshold A_k≡0 ⟺ k<n |
| `cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-03` | linear algebra | Poincaré separation for m×m principal submatrices |
| `binomial-theorem-oq-02-oq-01-oq-04-oq-03` | probability | All factorial moments of binomial marginals via iterated fiber grouping |
| `abel-ruffini-oq-04-oq-02-oq-04-oq-03` | group theory | Metacyclic (cyclic-by-cyclic) extensions are solvable |

All 6 pass `validate-seeker-stubs.ts` (no template placeholders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)