### PR TITLE
Enrich 6 oq-child entries: add references (Menon, Möbius totient, Gauss sum, four-square, optional stopping, Nullstellensatz)

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Gauss Sum Squared Identity τ² = χ(-1)·p",
   "slug": "elementary-quadratic-reciprocity-oq-01-oq-01-oq-01",
   "description": "Proves the central identity in the Gauss sum proof of Quadratic Reciprocity: for odd prime p, the classical Gauss sum τ = Σ_a (a/p)·exp(2πia/p) satisfies τ² = (-1)^((p-1)/2)·p in ℂ. This fills the key gap in the Gauss pathway outlined in ElementaryQuadraticReciprocityOQ01OQ01, converting an axiomatized identity into a theorem. The proof uses Mathlib's gaussSum_sq with the quadratic character of ZMod p and the standard additive character, then computes χ(-1) via the first supplementary law.",
+  "references": [
+    {
+      "authors": "Carl Friedrich Gauss",
+      "title": "Disquisitiones Arithmeticae",
+      "year": 1801,
+      "note": "Origin of quadratic reciprocity and Gauss sums; τ² = (−1)^{(p−1)/2}p is the analytic heart of one proof."
+    },
+    {
+      "authors": "Kenneth Ireland and Michael Rosen",
+      "title": "A Classical Introduction to Modern Number Theory (2nd ed.)",
+      "year": 1990,
+      "note": "Springer GTM 84. Gauss sums, the identity τ² = χ(−1)p, and the Gauss-sum proof of reciprocity."
+    },
+    {
+      "authors": "Bruce C. Berndt, Ronald J. Evans and Kenneth S. Williams",
+      "title": "Gauss and Jacobi Sums",
+      "year": 1998,
+      "note": "Wiley. Definitive treatment of Gauss sums and their squared evaluation."
+    },
+    {
+      "authors": "Jean-Pierre Serre",
+      "title": "A Course in Arithmetic",
+      "year": 1973,
+      "note": "Springer GTM 7. Quadratic reciprocity via Gauss sums over finite fields."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: gaussSum, ZMod.quadraticChar and cyclotomic root-of-unity infrastructure",
+      "year": 2024,
+      "note": "The Gauss sum τ and quadratic character machinery used to prove τ² = χ(−1)p in ℂ."
+    }
+  ],
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-05-05",

--- a/src/data/proofs/euler-identity-oq-05/meta.json
+++ b/src/data/proofs/euler-identity-oq-05/meta.json
@@ -19,6 +19,38 @@
     "sorries": 0
   },
   "sorries": 0,
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "Letter to Christian Goldbach (12 April 1749)",
+      "year": 1749,
+      "note": "Euler's four-square identity expressing a product of two sums of four squares as a sum of four squares."
+    },
+    {
+      "authors": "Joseph-Louis Lagrange",
+      "title": "Démonstration d'un théorème d'arithmétique (Nouveaux Mémoires Acad. Berlin)",
+      "year": 1770,
+      "note": "The four-square theorem, for which Euler's identity supplies the multiplicative (closure) step."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers (6th ed.)",
+      "year": 2008,
+      "note": "Oxford University Press. Sums of four squares, Euler's identity, and quaternion norms."
+    },
+    {
+      "authors": "Kenneth Ireland and Michael Rosen",
+      "title": "A Classical Introduction to Modern Number Theory (2nd ed.)",
+      "year": 1990,
+      "note": "Springer GTM 84. The four-square identity as the norm multiplicativity of the Hurwitz quaternions."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: sum-of-four-squares and Quaternion norm infrastructure",
+      "year": 2024,
+      "note": "Ring identities underlying the four-square product formula and its multiplicative closure."
+    }
+  ],
   "meta": {
     "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_four-square_identity",

--- a/src/data/proofs/euler-totient-oq-04-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-04-oq-02/meta.json
@@ -3,6 +3,38 @@
   "title": "Möbius Inversion of the Totient: φ = μ ∗ id",
   "slug": "euler-totient-oq-04-oq-02",
   "description": "Proves the Möbius-inversion formula for Euler's totient, φ(n) = Σ_{d|n} μ(d)·(n/d), i.e. the totient is the Dirichlet convolution μ ∗ id (over ℤ). This is the inverse of the parent's Gauss identity n = Σ_{d|n} φ(d): instantiating Mathlib's abstract Möbius inversion with f = φ and g = id turns Gauss's forward sum into the signed divisor sum for φ. Also gives the antidiagonal-convolution form and the n/d↔d reflected form. 4 theorems, 0 axioms, 0 sorries.",
+  "references": [
+    {
+      "authors": "August Ferdinand Möbius",
+      "title": "Über eine besondere Art von Umkehrung der Reihen (Journal für die reine und angewandte Mathematik 9)",
+      "year": 1832,
+      "note": "Introduces the Möbius function and inversion formula used to invert Gauss's totient identity."
+    },
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "note": "Springer. Dirichlet convolution and the identity φ = μ ∗ id inverting n = Σ_{d|n} φ(d)."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers (6th ed.)",
+      "year": 2008,
+      "note": "Oxford University Press. Möbius inversion and the multiplicative structure of the totient."
+    },
+    {
+      "authors": "Harold Davenport",
+      "title": "Multiplicative Number Theory (3rd ed.)",
+      "year": 2000,
+      "note": "Springer. Dirichlet convolution and Möbius inversion in analytic number theory."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.ArithmeticFunction.moebius and the abstract Möbius inversion theorem",
+      "year": 2024,
+      "note": "Mathlib's Dirichlet-convolution Möbius inversion, instantiated to φ = μ ∗ id."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-24",

--- a/src/data/proofs/euler-totient-oq-10/meta.json
+++ b/src/data/proofs/euler-totient-oq-10/meta.json
@@ -3,6 +3,38 @@
   "title": "Menon's Identity: $\\sum_{\\gcd(k,n)=1}\\gcd(k-1,n)=\\varphi(n)\\,d(n)$",
   "slug": "euler-totient-oq-10",
   "description": "Formalizes Menon's identity (P. Kesava Menon, 1965), a classical arithmetic identity living over the unit group of ℤ/nℤ: summing gcd(k−1, n) over the residues k coprime to n yields φ(n)·d(n), where φ is Euler's totient and d(n) is the number of divisors of n. The proof is the slick counting argument, fully uniform in n with no factorization or multiplicativity bookkeeping. Indexing the sum by the units a ∈ (ℤ/nℤ)ˣ (so the summand is gcd((a−1).val, n)), three steps close it: (1) Divisor expansion — gcd(v, n) = ∑_{d∣n, d∣v} φ(d), obtained by applying Gauss's identity ∑_{e∣g} φ(e) = g to g = gcd(v,n), whose divisors are exactly the common divisors of v and n. (2) Swap of summation — Menon's sum becomes ∑_{d∣n} φ(d)·#{a ∈ (ℤ/nℤ)ˣ : d ∣ (a−1).val}. (3) Fibre count — the reduction homomorphism unitsMap : (ℤ/nℤ)ˣ → (ℤ/dℤ)ˣ is surjective (ZMod.unitsMap_surjective), and d ∣ (a−1).val ⟺ a ∈ ker(unitsMap); since for a surjective homomorphism of finite groups |G| = |H|·|ker| (Lagrange + first isomorphism theorem), each divisor d contributes φ(d)·|ker| = φ(n). Collapsing, ∑_{d∣n} φ(n) = φ(n)·d(n). This is genuinely new relative to Mathlib, which has Euler's totient and the unitsMap reduction but not Menon's identity. Fully machine-checked: 0 sorries, 0 axioms (only the foundational propext/Classical.choice/Quot.sound), no native_decide.",
+  "references": [
+    {
+      "authors": "P. Kesava Menon",
+      "title": "On the Sum Σ(a−1,n) with (a,n)=1 (Journal of the Indian Mathematical Society 29)",
+      "year": 1965,
+      "note": "The original Menon identity Σ_{gcd(k,n)=1} gcd(k−1,n) = φ(n)d(n), formalized in this entry."
+    },
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "note": "Springer. Euler's totient, the divisor function, and arithmetic identities over ℤ/nℤ."
+    },
+    {
+      "authors": "László Tóth",
+      "title": "Menon's Identity and Arithmetical Sums Representing Functions of Several Variables (Rendiconti Sem. Mat. Univ. Politec. Torino 69)",
+      "year": 2011,
+      "note": "Modern generalizations and group-theoretic interpretation of Menon's identity."
+    },
+    {
+      "authors": "Paul J. McCarthy",
+      "title": "Introduction to Arithmetical Functions",
+      "year": 1986,
+      "note": "Springer. Menon-type identities in the theory of arithmetical functions."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.totient, Nat.ArithmeticFunction.sigma and ZMod unit-group infrastructure",
+      "year": 2024,
+      "note": "Totient, divisor count, and the unit group (ℤ/nℤ)ˣ used to sum gcd(k−1,n) over coprime residues."
+    }
+  ],
   "meta": {
     "author": "P. Kesava Menon (1965); the counting proof formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Menon%27s_identity",

--- a/src/data/proofs/factor-remainder-nullstellensatz-oq-01/meta.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Strong Nullstellensatz I(V(J)) = √J via Mathlib",
   "slug": "factor-remainder-nullstellensatz-oq-01",
   "description": "Wraps Mathlib's MvPolynomial.vanishingIdeal_zeroLocus_eq_radical to deliver Hilbert's Nullstellensatz (1893) in a gallery-friendly API. Derives the weak Nullstellensatz, polynomial membership criterion, radical ideal correspondence, and the V-I Galois connection as corollaries—establishing the foundational algebra-geometry dictionary for algebraically closed fields.",
+  "references": [
+    {
+      "authors": "David Hilbert",
+      "title": "Über die vollen Invariantensysteme (Mathematische Annalen 42)",
+      "year": 1893,
+      "note": "Hilbert's Nullstellensatz, I(V(J)) = √J, delivered here via a gallery-friendly Mathlib API."
+    },
+    {
+      "authors": "David Eisenbud",
+      "title": "Commutative Algebra with a View Toward Algebraic Geometry",
+      "year": 1995,
+      "note": "Springer GTM 150. The strong and weak Nullstellensatz and the radical-ideal correspondence."
+    },
+    {
+      "authors": "Robin Hartshorne",
+      "title": "Algebraic Geometry",
+      "year": 1977,
+      "note": "Springer GTM 52. The Nullstellensatz and the V–I Galois connection between ideals and varieties."
+    },
+    {
+      "authors": "Michael Atiyah and Ian G. Macdonald",
+      "title": "Introduction to Commutative Algebra",
+      "year": 1969,
+      "note": "Addison-Wesley. Radical ideals and the algebra–geometry dictionary underlying the Nullstellensatz."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: MvPolynomial.vanishingIdeal_zeroLocus_eq_radical",
+      "year": 2024,
+      "note": "The Mathlib theorem wrapped here to expose the weak/strong Nullstellensatz and membership criteria."
+    }
+  ],
   "meta": {
     "author": "Hilbert (1893), formalized via Mathlib",
     "date": "1893",

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Doob's Optional Stopping Theorem: Standalone Formalization",
   "slug": "fair-games-theorem-oq-02-oq-01",
   "description": "Comprehensive formalization of Doob's Optional Stopping Theorem (1953) using Mathlib's probability library. Proves three forms of OST (bounded, submartingale inequality, two stopping times), the martingale convergence theorem, the submartingale characterization via OST, and Doob's maximal inequality. Answers the open question from FairGamesTheoremOQ02: Yes, Mathlib's martingale library is sufficient for a complete OST formalization. 10 theorems, 0 sorries, 621 lines.",
+  "references": [
+    {
+      "authors": "Joseph L. Doob",
+      "title": "Stochastic Processes",
+      "year": 1953,
+      "note": "Wiley. The optional stopping theorem and martingale theory formalized in this entry."
+    },
+    {
+      "authors": "David Williams",
+      "title": "Probability with Martingales",
+      "year": 1991,
+      "note": "Cambridge University Press. Optional stopping in bounded, submartingale, and two-stopping-time forms."
+    },
+    {
+      "authors": "Rick Durrett",
+      "title": "Probability: Theory and Examples (5th ed.)",
+      "year": 2019,
+      "note": "Cambridge University Press. Martingale convergence and optional stopping with applications to gambler's ruin."
+    },
+    {
+      "authors": "Jean-François Le Gall",
+      "title": "Measure Theory, Probability, and Stochastic Processes",
+      "year": 2022,
+      "note": "Springer GTM 295. Discrete-time martingales and the optional stopping theorem."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: MeasureTheory.Martingale and stopping-time infrastructure",
+      "year": 2024,
+      "note": "Mathlib's martingale/stopping-time library on which the standalone OST formalization is built."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-12",


### PR DESCRIPTION
Enrichment pass adding accurate literature `references` to six oq-child entries whose only gap was empty references.

| Entry | References |
|-------|-----------|
| euler-totient-oq-10 (Menon's identity) | Menon, Apostol, Tóth, McCarthy, mathlib |
| euler-totient-oq-04-oq-02 (Möbius inversion of totient) | Möbius, Apostol, Hardy-Wright, Davenport, mathlib |
| elementary-quadratic-reciprocity-oq-01-oq-01-oq-01 (Gauss sum τ²=χ(-1)p) | Gauss, Ireland-Rosen, Berndt-Evans-Williams, Serre, mathlib |
| euler-identity-oq-05 (Euler four-square identity) | Euler, Lagrange, Hardy-Wright, Ireland-Rosen, mathlib |
| fair-games-theorem-oq-02-oq-01 (Doob optional stopping) | Doob, Williams, Durrett, Le Gall, mathlib |
| factor-remainder-nullstellensatz-oq-01 (strong Nullstellensatz) | Hilbert, Eisenbud, Hartshorne, Atiyah-Macdonald, mathlib |

Each set matched to the entry's specific angle, ending with a mathlib Community citation. Minimal additive diffs.