### PR TITLE
Enrich 6 oq-child entries: add references (Gauss's lemma, Euler product, Cayley-Menger, Hurwitz, inclusion-exclusion, Euler-Mascheroni)

### DIFF
--- a/src/data/proofs/gauss-lemma-primitive-oq-01/meta.json
+++ b/src/data/proofs/gauss-lemma-primitive-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Gauss's Lemma: a primitive integer polynomial is irreducible over ℤ iff over ℚ",
   "slug": "gauss-lemma-primitive-oq-01",
   "description": "Gauss's Lemma (irreducibility form): a primitive polynomial p ∈ ℤ[X] is irreducible over ℤ if and only if its image in ℚ[X] is irreducible. Mathlib proves the biconditional (IsPrimitive.Int.irreducible_iff_irreducible_map_cast) but the gallery had no entry packaging it with the monic specialization (where primitivity is automatic) and a fully-formalized witness that primitivity is essential — the non-primitive polynomial 2X, reducible over ℤ yet irreducible over ℚ.",
+  "references": [
+    {
+      "authors": "Carl Friedrich Gauss",
+      "title": "Disquisitiones Arithmeticae (art. 42)",
+      "year": 1801,
+      "note": "The original Gauss's lemma: a product of primitive polynomials is primitive, yielding the ℤ↔ℚ irreducibility equivalence."
+    },
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra (Revised 3rd ed.), GTM 211",
+      "year": 2002,
+      "note": "Springer. Gauss's lemma and irreducibility over ℤ versus ℚ (Chapter IV)."
+    },
+    {
+      "authors": "David S. Dummit and Richard M. Foote",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": 2004,
+      "note": "Wiley. §9.3 proves Gauss's lemma and the primitive-polynomial irreducibility criterion."
+    },
+    {
+      "authors": "B. L. van der Waerden",
+      "title": "Algebra, Volume 1 (7th ed.)",
+      "year": 1991,
+      "note": "Springer. Content, primitive polynomials, and Gauss's lemma over a UFD."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
+      "year": 2024,
+      "note": "The Mathlib biconditional wrapped by this entry to give a gallery-friendly Gauss's lemma."
+    }
+  ],
   "meta": {
     "author": "Carl Friedrich Gauss (1801)",
     "status": "verified",

--- a/src/data/proofs/geometric-series-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-03/meta.json
@@ -3,6 +3,38 @@
   "title": "Euler Product Formula from Geometric Series",
   "slug": "geometric-series-oq-03",
   "description": "The Riemann zeta function's Euler product ζ(s) = ∏_p (1-p^{-s})^{-1} as an explicit product of geometric series, proved for Re(s) > 1.",
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "Variae observationes circa series infinitas (Comment. Acad. Sci. Petrop. 9)",
+      "year": 1737,
+      "note": "Euler's product ζ(s)=∏_p (1−p^{−s})^{−1}, derived here from geometric series."
+    },
+    {
+      "authors": "Bernhard Riemann",
+      "title": "Über die Anzahl der Primzahlen unter einer gegebenen Größe (Monatsber. Berlin Akad.)",
+      "year": 1859,
+      "note": "Uses the Euler product as the analytic bridge between ζ and the primes."
+    },
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "note": "Springer. The Euler product and Dirichlet series for Re(s) > 1."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers (6th ed.)",
+      "year": 2008,
+      "note": "Oxford University Press. Convergence of ∏_p (1−p^{−s})^{−1} and its equality with ζ(s)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: riemannZeta and Nat.Primes tprod (Euler product) infrastructure",
+      "year": 2024,
+      "note": "The geometric-series expansion (1−p^{−s})^{−1} = Σ p^{−ks} and the prime product used here."
+    }
+  ],
   "meta": {
     "author": "Leonhard Euler (1737), formalized via Mathlib",
     "sourceUrl": "https://github.com/leanprover-community/mathlib4",

--- a/src/data/proofs/harmonic-divergence-oq-01/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Euler-Mascheroni Constant: Bounds, Structure, and Connections",
   "slug": "harmonic-divergence-oq-01",
   "description": "A comprehensive formalization of the Euler-Mascheroni constant γ ≈ 0.5772: convergence and monotonicity of the defining sequences, log bounds on harmonic numbers, Theisinger's theorem that H_n is never an integer for n ≥ 2, sandwich sequence convergence rate, systematic rational exclusion (all p/q with denominator ≤ 4), conditional irrationality consequences, and connections to the p-series boundary.",
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "De progressionibus harmonicis observationes (Comment. Acad. Sci. Petrop. 7)",
+      "year": 1734,
+      "note": "Introduces the constant γ = lim (Hₙ − log n), the Euler–Mascheroni constant formalized here."
+    },
+    {
+      "authors": "Lorenzo Mascheroni",
+      "title": "Adnotationes ad calculum integralem Euleri",
+      "year": 1790,
+      "note": "Refines the numerical value of γ, giving the constant its second name."
+    },
+    {
+      "authors": "Julian Havil",
+      "title": "Gamma: Exploring Euler's Constant",
+      "year": 2003,
+      "note": "Princeton University Press. Comprehensive account of γ, its bounds, and connections."
+    },
+    {
+      "authors": "Leopold Theisinger",
+      "title": "Bemerkung über die harmonische Reihe (Monatshefte für Mathematik und Physik 26)",
+      "year": 1915,
+      "note": "Theisinger's theorem that Hₙ is never an integer for n ≥ 2, proved in this entry."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: harmonic, Real.log bounds and monotone-sequence convergence infrastructure",
+      "year": 2024,
+      "note": "Harmonic numbers, logarithmic sandwich bounds, and the convergence of the defining sequences for γ."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",

--- a/src/data/proofs/herons-formula-oq-05/meta.json
+++ b/src/data/proofs/herons-formula-oq-05/meta.json
@@ -3,6 +3,38 @@
   "title": "Heron's Formula via the Cayley–Menger Determinant",
   "slug": "herons-formula-oq-05",
   "description": "Generalizes Heron's formula to simplex content from squared edge lengths via the Cayley–Menger determinant. Proves two classical cases as explicit polynomial identities in the squared edge lengths: the triangle (n=2) gives 16·Area² = −cmDet3 (Heron's formula), and the tetrahedron (n=3) gives 288·V² = cmDet4. Includes realizability (cmDet4 ≥ 0) and a coplanarity/degeneracy criterion. 6 theorems, 0 axioms.",
+  "references": [
+    {
+      "authors": "Heron of Alexandria",
+      "title": "Metrica, Book I",
+      "year": 60,
+      "note": "The original area formula √(s(s−a)(s−b)(s−c)), generalized here to simplex content."
+    },
+    {
+      "authors": "Arthur Cayley",
+      "title": "On a Theorem in the Geometry of Position (Cambridge Mathematical Journal 2)",
+      "year": 1841,
+      "note": "The determinant of squared distances that became the Cayley–Menger determinant."
+    },
+    {
+      "authors": "Karl Menger",
+      "title": "Untersuchungen über allgemeine Metrik (Mathematische Annalen 100)",
+      "year": 1928,
+      "note": "The Cayley–Menger determinant characterizing metric embeddability and simplex volume."
+    },
+    {
+      "authors": "Marcel Berger",
+      "title": "Geometry I",
+      "year": 1987,
+      "note": "Springer. Cayley–Menger determinants and the metric geometry of simplices."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Matrix.det (det_fin_three) and EuclideanSpace distance infrastructure",
+      "year": 2024,
+      "note": "Determinant expansions used to prove 16·Area² = −cmDet3 and the higher-simplex identities."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-16",

--- a/src/data/proofs/hurwitz-theorem-oq-02/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-02/meta.json
@@ -3,6 +3,38 @@
   "title": "Hurwitz's Theorem: The Four Division Algebras and the Four Fundamental Forces",
   "slug": "hurwitz-theorem-oq-02",
   "description": "Formalizes the mathematical backbone of the Dixon–Furey–Baez–Huerta 'division algebras and physics' dictionary: a canonical bijection between the four normed division algebras (ℝ, ℂ, ℍ, 𝕆) classified by Hurwitz's theorem and the four fundamental forces (gravity, electromagnetism, weak, strong), under which every gauge-group dimension matches a dimension of the corresponding algebra — U(1)=1=Im ℂ, SU(2)=3=Im ℍ, SU(3)=8=dim 𝕆. Proves the unit quaternions Sp(1)≅SU(2) (weak gauge group) form a subgroup of ℍˣ and the unit complex numbers U(1) (electromagnetism) are closed, via multiplicativity of the quaternion/complex norm.",
+  "references": [
+    {
+      "authors": "Adolf Hurwitz",
+      "title": "Über die Composition der quadratischen Formen von beliebig vielen Variabeln (Nachr. Ges. Wiss. Göttingen)",
+      "year": 1898,
+      "note": "Hurwitz's theorem classifying the normed division algebras ℝ, ℂ, ℍ, 𝕆 via the 1,2,4,8-square identities."
+    },
+    {
+      "authors": "John C. Baez",
+      "title": "The Octonions (Bulletin of the American Mathematical Society 39)",
+      "year": 2002,
+      "note": "Definitive survey of ℝ, ℂ, ℍ, 𝕆 and their appearances in physics."
+    },
+    {
+      "authors": "John H. Conway and Derek A. Smith",
+      "title": "On Quaternions and Octonions: Their Geometry, Arithmetic, and Symmetry",
+      "year": 2003,
+      "note": "A K Peters. The four normed division algebras and their symmetry groups."
+    },
+    {
+      "authors": "Geoffrey M. Dixon",
+      "title": "Division Algebras: Octonions, Quaternions, Complex Numbers and the Algebraic Design of Physics",
+      "year": 1994,
+      "note": "Kluwer. The division-algebra dictionary underlying the four-forces correspondence formalized here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Quaternion, Octonion-style normed-algebra infrastructure",
+      "year": 2024,
+      "note": "Normed division algebra structures used to state the four-algebra bijection."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-27",

--- a/src/data/proofs/inclusion-exclusion-oq-01-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "General Inclusion-Exclusion for k Sets",
   "slug": "inclusion-exclusion-oq-01-oq-01",
   "description": "Proves the general inclusion-exclusion formula for k finite sets using Mathlib's Finset.inclusion_exclusion_card_biUnion. Establishes the inductive step (adding one more set to a union), the complementary counting form, explicit 2/3/4-set specializations, and the first Bonferroni inequality (union bound). 13 theorems, 0 definitions, 0 axioms.",
+  "references": [
+    {
+      "authors": "Abraham de Moivre",
+      "title": "The Doctrine of Chances",
+      "year": 1718,
+      "note": "An early appearance of the inclusion–exclusion principle in probability."
+    },
+    {
+      "authors": "Henri Poincaré",
+      "title": "Calcul des probabilités",
+      "year": 1896,
+      "note": "The general inclusion–exclusion (Poincaré) formula for the measure of a union."
+    },
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Enumerative Combinatorics, Volume 1 (2nd ed.)",
+      "year": 2011,
+      "note": "Cambridge University Press. Inclusion–exclusion, sieve methods, and Bonferroni inequalities (§2.1)."
+    },
+    {
+      "authors": "Jacobus H. van Lint and Richard M. Wilson",
+      "title": "A Course in Combinatorics (2nd ed.)",
+      "year": 2001,
+      "note": "Cambridge University Press. The k-set inclusion–exclusion formula and its number-theoretic applications."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Finset.inclusion_exclusion_card_biUnion",
+      "year": 2024,
+      "note": "The Mathlib inclusion–exclusion theorem specialized here to k sets and complementary counting."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-05",


### PR DESCRIPTION
Enrichment pass adding accurate literature `references` to six oq-child entries whose only gap was empty references.

| Entry | References |
|-------|-----------|
| gauss-lemma-primitive-oq-01 (Gauss's lemma) | Gauss, Lang, Dummit-Foote, van der Waerden, mathlib |
| geometric-series-oq-03 (Euler product) | Euler, Riemann, Apostol, Hardy-Wright, mathlib |
| herons-formula-oq-05 (Cayley-Menger / Heron) | Heron, Cayley, Menger, Berger, mathlib |
| hurwitz-theorem-oq-02 (four division algebras) | Hurwitz, Baez, Conway-Smith, Dixon, mathlib |
| inclusion-exclusion-oq-01-oq-01 (k-set I-E) | de Moivre, Poincaré, Stanley, van Lint-Wilson, mathlib |
| harmonic-divergence-oq-01 (Euler-Mascheroni γ) | Euler, Mascheroni, Havil, Theisinger, mathlib |

Each set matched to the entry's specific angle, ending with a mathlib Community citation. Minimal additive diffs.