### PR TITLE
Enrich 6 oq-child entries: add references (Euler partition recurrence, Ptolemy converse, De Gua, Simson, casus irreducibilis, Kakutani)

### DIFF
--- a/src/data/proofs/pentagonal-number-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01-oq-02/meta.json
@@ -22,6 +22,38 @@
     "sorries": 0
   },
   "description": "Answers the parent's second open question — derive Euler's partition recurrence for p(n) as a corollary — by isolating its true analytic engine: the formal power-series reciprocal identity P(X)·∏_{m≥1}(1−Xᵐ) = 1, where P(X)=∑ p(n)Xⁿ is the partition generating function (Mathlib's Nat.Partition.genFun with the trivial character). The proof multiplies the two convergent infinite products factor-by-factor (Multipliable.tprod_mul), each combined factor (∑_j X^{(i+1)j})·(1−X^{i+1}) collapsing to 1 by the geometric-series identity, so the whole product is 1. Reading off the n-th coefficient (PowerSeries.coeff_mul) gives Euler's recurrence in Cauchy-convolution form ∑_{a+b=n} p(a)·c_b = [n=0], and solving for p(n) yields the explicit recurrence p(n) = −∑_{k<n} p(k)·c_{n−k}. The Euler coefficients c_b = [Xᵇ]∏(1−Xᵐ) = ∑_{q∈distincts b}(−1)^{#parts} are supplied by the parent's verified coeff_tprod_pent. All 0-sorry, 0-axiom. The famous pentagonal indexing p(n)=∑(−1)^{k−1}(p(n−g_k)+p(n−g_{−k})) is the only conditional step, gated on the identity ∑_{q∈distincts b}(−1)^{#parts}=pentSeriesCoeff b — Franklin's involution, the parent entry's stated OPEN CORE and still absent from Mathlib.",
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "Introductio in analysin infinitorum, Vol. 1",
+      "year": 1748,
+      "note": "The pentagonal number theorem and the partition recurrence p(n)=Σ(−1)^{k−1}[p(n−g_k)+p(n−g_k')] derived here."
+    },
+    {
+      "authors": "George E. Andrews",
+      "title": "The Theory of Partitions",
+      "year": 1976,
+      "note": "Cambridge University Press. The generating function ∏(1−Xⁿ) and Euler's recurrence for p(n)."
+    },
+    {
+      "authors": "Herbert S. Wilf",
+      "title": "generatingfunctionology (3rd ed.)",
+      "year": 2006,
+      "note": "A K Peters. Formal power-series reciprocals P(X)·∏(1−Xᵐ)=1, the analytic engine isolated in this entry."
+    },
+    {
+      "authors": "G. H. Hardy and E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers (6th ed.)",
+      "year": 2008,
+      "note": "Oxford University Press. Partitions, generating functions, and the pentagonal number theorem."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: PowerSeries and Nat.Partition infrastructure",
+      "year": 2024,
+      "note": "Formal power series over ℤ and the partition function used to state P(X)·∏(1−Xᵐ)=1."
+    }
+  ],
   "meta": {
     "status": "verified",
     "tags": [

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Ptolemy's Theorem Converse: Equality Characterizes Cyclic Order",
   "slug": "ptolemys-theorem-oq-01-oq-01",
   "description": "Proves the converse of Ptolemy's theorem for unit-circle points: if the equality ‖z₁-z₃‖·‖z₂-z₄‖ = ‖z₁-z₂‖·‖z₃-z₄‖ + ‖z₂-z₃‖·‖z₁-z₄‖ holds for four distinct points on the unit circle, then they appear in counterclockwise or clockwise cyclic order. Combined with the forward direction from PtolemysTheoremOQ01, this gives the complete biconditional: Ptolemy equality ↔ CCW or CW order. The proof uses the equality case of the triangle inequality in the strictly convex space ℂ (via SameRay) to extract a positive proportionality constant, then axiomatizes the angular case analysis identifying positive sine-product ratios with cyclic orderings.",
+  "references": [
+    {
+      "authors": "Claudius Ptolemy",
+      "title": "Almagest (Mathēmatikē Syntaxis), Book I",
+      "year": 150,
+      "note": "The original relation among the sides and diagonals of a cyclic quadrilateral; this entry proves its converse."
+    },
+    {
+      "authors": "Roger A. Johnson",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": 1929,
+      "note": "Dover reprint. Ptolemy's theorem, the Ptolemy inequality, and the cyclic-quadrilateral characterization."
+    },
+    {
+      "authors": "H. S. M. Coxeter and S. L. Greitzer",
+      "title": "Geometry Revisited",
+      "year": 1967,
+      "note": "Mathematical Association of America. Ptolemy's theorem and its converse via the Ptolemy inequality."
+    },
+    {
+      "authors": "Nathan Altshiller-Court",
+      "title": "College Geometry (2nd ed.)",
+      "year": 1952,
+      "note": "Barnes & Noble. Cyclic quadrilaterals and equality conditions in Ptolemy's relation."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Complex.abs and EuclideanGeometry distance infrastructure",
+      "year": 2024,
+      "note": "Complex unit-circle coordinates and norm identities used to characterize cyclic order."
+    }
+  ],
   "meta": {
     "author": "Lean Genius Researcher",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ptolemy%27s_theorem",

--- a/src/data/proofs/pythagorean-theorem-oq-06/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-06/meta.json
@@ -3,6 +3,38 @@
   "title": "De Gua's Theorem: The 3-D Pythagorean Theorem",
   "slug": "pythagorean-theorem-oq-06",
   "description": "For a trirectangular tetrahedron — a tetrahedron with three mutually perpendicular edges meeting at one vertex — the square of the area of the face opposite that vertex equals the sum of the squares of the areas of the three right-angle faces: Area(ABC)² = Area(OAB)² + Area(OBC)² + Area(OCA)². This is the natural three-dimensional analogue of the Pythagorean theorem.",
+  "references": [
+    {
+      "authors": "Jean Paul de Gua de Malves",
+      "title": "Mémoire (presented to the Académie Royale des Sciences)",
+      "year": 1783,
+      "note": "The 3-D Pythagorean theorem for a trirectangular tetrahedron, formalized in this entry."
+    },
+    {
+      "authors": "René Descartes",
+      "title": "Progymnasmata de solidorum elementis (posthumous)",
+      "year": 1650,
+      "note": "An earlier appearance of the trirectangular-tetrahedron area relation (also known to Faulhaber)."
+    },
+    {
+      "authors": "H. S. M. Coxeter",
+      "title": "Introduction to Geometry (2nd ed.)",
+      "year": 1969,
+      "note": "Wiley. Areas and orthogonality in tetrahedra, including the De Gua relation."
+    },
+    {
+      "authors": "Marcel Berger",
+      "title": "Geometry I",
+      "year": 1987,
+      "note": "Springer. Metric relations for simplices generalizing the Pythagorean theorem."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: EuclideanSpace, inner product and area (Gram determinant) infrastructure",
+      "year": 2024,
+      "note": "Orthogonality and area-squared computations used to prove the sum-of-squares of face areas."
+    }
+  ],
   "meta": {
     "author": "Jean Paul de Gua de Malves (1783), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/De_Gua%27s_theorem",

--- a/src/data/proofs/schauder-fixed-point-oq-03/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03/meta.json
@@ -3,6 +3,38 @@
   "title": "Kakutani Fixed Point Theorem for Set-Valued Maps",
   "slug": "schauder-fixed-point-oq-03",
   "description": "Formalizes the Kakutani fixed point theorem framework: set-valued maps, upper hemicontinuity, and the main theorem for compact convex sets. Recovers Brouwer as a corollary.",
+  "references": [
+    {
+      "authors": "Shizuo Kakutani",
+      "title": "A Generalization of Brouwer's Fixed Point Theorem (Duke Mathematical Journal 8)",
+      "year": 1941,
+      "note": "The Kakutani fixed point theorem for upper-hemicontinuous set-valued maps, formalized here."
+    },
+    {
+      "authors": "L. E. J. Brouwer",
+      "title": "Über Abbildung von Mannigfaltigkeiten (Mathematische Annalen 71)",
+      "year": 1911,
+      "note": "Brouwer's fixed point theorem, recovered as a corollary of Kakutani's."
+    },
+    {
+      "authors": "John F. Nash",
+      "title": "Equilibrium Points in n-Person Games (Proc. National Academy of Sciences 36)",
+      "year": 1950,
+      "note": "The classic application of Kakutani's theorem to the existence of Nash equilibria."
+    },
+    {
+      "authors": "Kim C. Border",
+      "title": "Fixed Point Theorems with Applications to Economics and Game Theory",
+      "year": 1985,
+      "note": "Cambridge University Press. Set-valued maps, upper hemicontinuity, and Kakutani's theorem."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: convexity, compactness and set-valued map infrastructure",
+      "year": 2024,
+      "note": "Compact-convex sets and continuity structures underlying the Kakutani framework."
+    }
+  ],
   "meta": {
     "author": "Kakutani (1941)",
     "date": "2026",

--- a/src/data/proofs/simson-line-theorem-oq-01/meta.json
+++ b/src/data/proofs/simson-line-theorem-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Simson's Line Theorem",
   "slug": "simson-line-theorem-oq-01",
   "description": "Simson's theorem as a biconditional: the feet of the perpendiculars from a point P to the three side-lines of triangle ABC are collinear if and only if P lies on the circumcircle of ABC. Formalized in complex coordinates with the circumcircle normalised to the unit circle.",
+  "references": [
+    {
+      "authors": "William Wallace",
+      "title": "Contribution to Thomas Leybourn's Mathematical Repository",
+      "year": 1799,
+      "note": "The first known statement of the 'Simson line'; the result is historically misattributed to Robert Simson."
+    },
+    {
+      "authors": "Roger A. Johnson",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": 1929,
+      "note": "Dover reprint. The Simson line and its circumcircle characterization."
+    },
+    {
+      "authors": "H. S. M. Coxeter and S. L. Greitzer",
+      "title": "Geometry Revisited",
+      "year": 1967,
+      "note": "Mathematical Association of America. The Simson–Wallace line and pedal triangles."
+    },
+    {
+      "authors": "Liang-shin Hahn",
+      "title": "Complex Numbers and Geometry",
+      "year": 1994,
+      "note": "Mathematical Association of America. Complex-coordinate proofs of Simson's theorem, the method used here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Complex geometry, collinearity and circumcircle infrastructure",
+      "year": 2024,
+      "note": "Complex coordinates, foot-of-perpendicular, and collinearity predicates used for the biconditional."
+    }
+  ],
   "meta": {
     "author": "Robert Simson / William Wallace (attributed)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Simson_line",

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-02/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-02/meta.json
@@ -3,6 +3,38 @@
   "title": "Casus Irreducibilis: When Real Roots Require Complex Cube Roots",
   "slug": "solution-of-cubic-oq-03-oq-02",
   "description": "Formalizes the casus irreducibilis: when the depressed cubic x³+px+q=0 has three distinct real roots (Δ>0), Cardano's formula necessarily involves non-real complex cube roots. Proves D<0 implies non-real arguments, verifies a concrete example (x³-7x+6=0), and states Wantzel's impossibility theorem.",
+  "references": [
+    {
+      "authors": "Gerolamo Cardano",
+      "title": "Artis Magnae, sive de Regulis Algebraicis (Ars Magna)",
+      "year": 1545,
+      "note": "Cardano's formula for the cubic, whose casus irreducibilis is formalized here."
+    },
+    {
+      "authors": "Rafael Bombelli",
+      "title": "L'Algebra",
+      "year": 1572,
+      "note": "Introduces complex arithmetic precisely to handle the casus irreducibilis of Cardano's formula."
+    },
+    {
+      "authors": "Pierre Laurent Wantzel",
+      "title": "Classification des nombres incommensurables d'origine algébrique (Nouvelles Annales de Mathématiques)",
+      "year": 1843,
+      "note": "Proof that in the casus irreducibilis the real roots genuinely cannot be expressed by real radicals."
+    },
+    {
+      "authors": "David A. Cox",
+      "title": "Galois Theory (2nd ed.)",
+      "year": 2012,
+      "note": "Wiley. The casus irreducibilis theorem and its Galois-theoretic explanation."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Complex, Polynomial.discriminant and cube-root infrastructure",
+      "year": 2024,
+      "note": "Discriminant sign analysis and complex cube roots used to prove non-real arguments when Δ>0."
+    }
+  ],
   "meta": {
     "author": "Cardano (1545), Bombelli (1572), Wantzel (1843); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Casus_irreducibilis",


### PR DESCRIPTION
Enrichment pass adding accurate literature `references` to six oq-child entries whose only gap was empty references.

| Entry | References |
|-------|-----------|
| pentagonal-number-theorem-oq-01-oq-02 (Euler partition recurrence) | Euler, Andrews, Wilf, Hardy-Wright, mathlib |
| ptolemys-theorem-oq-01-oq-01 (Ptolemy converse) | Ptolemy, Johnson, Coxeter-Greitzer, Altshiller-Court, mathlib |
| pythagorean-theorem-oq-06 (De Gua's theorem) | de Gua, Descartes, Coxeter, Berger, mathlib |
| simson-line-theorem-oq-01 (Simson/Wallace line) | Wallace, Johnson, Coxeter-Greitzer, Hahn, mathlib |
| solution-of-cubic-oq-03-oq-02 (casus irreducibilis) | Cardano, Bombelli, Wantzel, Cox, mathlib |
| schauder-fixed-point-oq-03 (Kakutani FPT) | Kakutani, Brouwer, Nash, Border, mathlib |

Each set matched to the entry's specific angle, ending with a mathlib Community citation. Minimal additive diffs.