### PR TITLE
Enrich 6 oq-child entries: add references (Sylow order-pq, van Aubel, Newton identities, telescoping product, Thue-Morse, x²+3y²)

### DIFF
--- a/src/data/proofs/sylow-theorems-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Classification of Groups of Order pq via Sylow Theorems",
   "slug": "sylow-theorems-oq-01",
   "description": "For distinct primes p < q: if p does not divide (q-1), the only group of order pq is cyclic. If p divides (q-1), there are exactly two groups (cyclic + non-abelian semidirect product). Proves the Sylow counting arguments (n_q = 1, n_p ∈ {1,q}), normality of unique Sylow subgroups, and states the classification theorem with concrete examples (orders 6, 15, 21, 35).",
+  "references": [
+    {
+      "authors": "Ludwig Sylow",
+      "title": "Théorèmes sur les groupes de substitutions (Mathematische Annalen 5)",
+      "year": 1872,
+      "note": "The Sylow theorems, whose counting arguments classify the groups of order pq here."
+    },
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra (Revised 3rd ed.), GTM 211",
+      "year": 2002,
+      "note": "Springer. Sylow theory and semidirect products in the classification of small-order groups."
+    },
+    {
+      "authors": "David S. Dummit and Richard M. Foote",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": 2004,
+      "note": "Wiley. §4.5 classifies groups of order pq via Sylow counting and semidirect products."
+    },
+    {
+      "authors": "Joseph J. Rotman",
+      "title": "An Introduction to the Theory of Groups (4th ed.)",
+      "year": 1995,
+      "note": "Springer GTM 148. Groups of order pq: cyclic when p∤(q−1), two groups when p∣(q−1)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Sylow, Subgroup.normal and semidirectProduct infrastructure",
+      "year": 2024,
+      "note": "Sylow subgroups and normality criteria used to enumerate the groups of order pq."
+    }
+  ],
   "meta": {
     "author": "Burnside (1911); Sylow (1872)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Sylow_theorems#Examples",

--- a/src/data/proofs/telescoping-product-oq-01/meta.json
+++ b/src/data/proofs/telescoping-product-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Telescoping Product ∏(1 − 1/k²) = (n+1)/(2n)",
   "slug": "telescoping-product-oq-01",
   "description": "Formalizes the canonical telescoping product ∏_{k=2}^{n} (1 − 1/k²) = (n+1)/(2n), the multiplicative analogue of a telescoping sum. Each factor collapses as 1 − 1/k² = (k−1)(k+1)/k², so the product of the (k−1)/k parts telescopes against the (k+1)/k parts, leaving only the endpoint contributions. The closed form is proved by induction over Finset.Icc with Finset.prod_Icc_succ_top, and the resulting limit (n+1)/(2n) → 1/2 shows the infinite product converges to 1/2. The closed form is not named in Mathlib.",
+  "references": [
+    {
+      "authors": "Konrad Knopp",
+      "title": "Theory and Application of Infinite Series (2nd English ed.)",
+      "year": 1990,
+      "note": "Dover. Telescoping (collapsing) products and their evaluation."
+    },
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Calculus, Volume 1 (2nd ed.)",
+      "year": 1967,
+      "note": "Wiley. Telescoping sums and products via partial-fraction / factor collapse."
+    },
+    {
+      "authors": "George Pólya and Gábor Szegő",
+      "title": "Problems and Theorems in Analysis I",
+      "year": 1972,
+      "note": "Springer. Finite product identities including ∏(1−1/k²) type telescopes."
+    },
+    {
+      "authors": "Ronald L. Graham, Donald E. Knuth and Oren Patashnik",
+      "title": "Concrete Mathematics (2nd ed.)",
+      "year": 1994,
+      "note": "Addison-Wesley. The perturbation/telescoping method for closed-form finite products."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Finset.prod_range_succ and factor-collapse infrastructure",
+      "year": 2024,
+      "note": "Finite-product lemmas used to collapse ∏(k−1)/k · ∏(k+1)/k to (n+1)/(2n)."
+    }
+  ],
   "meta": {
     "author": "Lean Genius researcher-2",
     "status": "verified",

--- a/src/data/proofs/thue-morse-oq-01/meta.json
+++ b/src/data/proofs/thue-morse-oq-01/meta.json
@@ -20,6 +20,38 @@
     "sorries": 0
   },
   "description": "The Thue-Morse sequence, defined as the parity of the binary digit sum, satisfies the bit-flip recurrences t(2n)=t(n), t(2n+1)=t(n)+1, takes value 1 at every power of two, and exhibits the four-term Prouhet-Tarry-Escott block structure t(4n)=t(4n+3), t(4n+1)=t(4n+2).",
+  "references": [
+    {
+      "authors": "Axel Thue",
+      "title": "Über unendliche Zeichenreihen (Norske Vid. Selsk. Skr.)",
+      "year": 1906,
+      "note": "Introduces the Thue–Morse sequence and its overlap-free / cube-free properties."
+    },
+    {
+      "authors": "Marston Morse",
+      "title": "Recurrent Geodesics on a Surface of Negative Curvature (Transactions of the AMS 22)",
+      "year": 1921,
+      "note": "Rediscovery of the sequence in symbolic dynamics; hence 'Thue–Morse'."
+    },
+    {
+      "authors": "Eugène Prouhet",
+      "title": "Mémoire sur quelques relations entre les puissances des nombres (C. R. Acad. Sci. Paris 33)",
+      "year": 1851,
+      "note": "The Prouhet–Tarry–Escott partition realized by the four-term Thue–Morse identity."
+    },
+    {
+      "authors": "Jean-Paul Allouche and Jeffrey Shallit",
+      "title": "Automatic Sequences: Theory, Applications, Generalizations",
+      "year": 2003,
+      "note": "Cambridge University Press. Definitive account of the Thue–Morse sequence and its recurrences."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.binaryRec and digit-sum parity infrastructure",
+      "year": 2024,
+      "note": "Binary digit-sum parity used to define t(n) and prove the bit-flip recurrences."
+    }
+  ],
   "meta": {
     "author": "Eugene Prouhet (1851), Axel Thue (1906), Marston Morse (1921)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Thue%E2%80%93Morse_sequence",

--- a/src/data/proofs/van-aubel-theorem-oq-01/meta.json
+++ b/src/data/proofs/van-aubel-theorem-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "van Aubel's Theorem via a Single Complex Identity",
   "slug": "van-aubel-theorem-oq-01",
   "description": "van Aubel's theorem: erect squares externally on the four sides of an arbitrary planar quadrilateral and join the centers of opposite squares. The two resulting segments are equal in length and perpendicular. Modelling the plane as ℂ, the entire theorem collapses to one algebraic identity R - P = i·(S - Q), from which equal length and perpendicularity follow because multiplication by i is a length-preserving 90° rotation. 3 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "references": [
+    {
+      "authors": "Henricus Hubertus van Aubel",
+      "title": "Note concernant les centres de carrés construits sur les côtés d'un polygone quelconque (Nouvelle Correspondance Mathématique 4)",
+      "year": 1878,
+      "note": "The original van Aubel theorem on squares erected on a quadrilateral, formalized here."
+    },
+    {
+      "authors": "Liang-shin Hahn",
+      "title": "Complex Numbers and Geometry",
+      "year": 1994,
+      "note": "Mathematical Association of America. Complex-identity proofs of van Aubel's and related square-on-side theorems."
+    },
+    {
+      "authors": "Roger A. Johnson",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": 1929,
+      "note": "Dover reprint. Squares on the sides of polygons and their center configurations."
+    },
+    {
+      "authors": "H. S. M. Coxeter and S. L. Greitzer",
+      "title": "Geometry Revisited",
+      "year": 1967,
+      "note": "Mathematical Association of America. Napoleon/van Aubel-type theorems and rotation arguments."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Complex multiplication (rotation by i) and distance infrastructure",
+      "year": 2024,
+      "note": "The single complex identity (multiplication by i for the right angle) modelling the two segments."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Van_Aubel%27s_theorem",

--- a/src/data/proofs/vietas-formulas-oq-02/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-02/meta.json
@@ -3,6 +3,38 @@
   "title": "Newton's Identities: Multivariate Vieta's Formulas",
   "slug": "vietas-formulas-oq-02",
   "description": "Formalizes Newton's identities relating power sums p_k = Σ x_i^k to elementary symmetric polynomials e_k for 2 and 3 variables. Proves all three Newton identities, the cube sum factorization, and the Vieta-Newton bridge connecting coefficients to power sums.",
+  "references": [
+    {
+      "authors": "Isaac Newton",
+      "title": "Arithmetica Universalis",
+      "year": 1707,
+      "note": "Newton's identities relating power sums to elementary symmetric polynomials, formalized here."
+    },
+    {
+      "authors": "Albert Girard",
+      "title": "Invention nouvelle en l'algèbre",
+      "year": 1629,
+      "note": "Early statement of the relations between roots and symmetric functions (Vieta–Girard)."
+    },
+    {
+      "authors": "Ian G. Macdonald",
+      "title": "Symmetric Functions and Hall Polynomials (2nd ed.)",
+      "year": 1995,
+      "note": "Oxford University Press. Power sums p_k, elementary symmetric e_k, and Newton's identities."
+    },
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Enumerative Combinatorics, Volume 2",
+      "year": 1999,
+      "note": "Cambridge University Press. Symmetric functions and the Newton–Girard identities."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: MvPolynomial.esymm and psum (power sum) infrastructure",
+      "year": 2024,
+      "note": "Elementary symmetric and power-sum polynomials used to state Newton's identities for 2 and 3 variables."
+    }
+  ],
   "meta": {
     "author": "Newton (1666), formalized in Lean 4",
     "date": "1666",

--- a/src/data/proofs/zsqrtd-neg-two-oq-03-oq-01/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-03-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Primes $p \\equiv 1 \\pmod 3$ are $x^2 + 3y^2$ (Euler/Fermat, $n = 3$)",
   "slug": "zsqrtd-neg-two-oq-03-oq-01",
   "description": "Completes the open question deferred by the parent `zsqrtd-neg-two-oq-03`: using the Eisenstein-integer infrastructure built there (the ring ℤ[ω], its multiplicative norm N(a + bω) = a² - ab + b², the EuclideanDomain instance, and the quadratic-reciprocity criterion (-3/p) = 1 ↔ p ≡ 1 mod 3), this file proves the classical n = 3 Heegner-number representation theorem `sq_add_three_sq_of_prime_one_mod_three : p.Prime → p % 3 = 1 → ∃ a b : ℤ, (p : ℤ) = a² + 3b²`. The argument has two independent parts. Part I (`eisenstein_form_to_x_sq_add_three_y_sq`, pure ℤ arithmetic) shows the Eisenstein norm form a² - ab + b² represents exactly the integers x² + 3y², via the identity 4(a² - ab + b²) = (2a - b)² + 3b² and a three-branch parity case split using the order-6 unit rotations of ℤ[ω]. Part II (`exists_eisenstein_norm_eq_prime`) is the splitting argument: for p ≡ 1 mod 3, (-3) is a square mod p (quadratic reciprocity), so p divides (c - θ)(c + θ) where θ = 1 + 2ω satisfies θ² = -3 but divides neither factor (their ω-coordinates are ∓2 and p ∤ 2); hence p is reducible in the UFD ℤ[ω], and norm-multiplicativity forces N(α) = p for some Eisenstein integer α. Combining the two parts gives p = a² + 3b². Fully machine-checked: 0 sorries, 0 axioms.",
+  "references": [
+    {
+      "authors": "Pierre de Fermat",
+      "title": "Correspondence (letters to Mersenne and Digby)",
+      "year": 1654,
+      "note": "Fermat's conjecture that primes p ≡ 1 (mod 3) are represented as x² + 3y²."
+    },
+    {
+      "authors": "Leonhard Euler",
+      "title": "Novi commentarii academiae scientiarum Petropolitanae (work on x²+3y²)",
+      "year": 1760,
+      "note": "Euler's proof of the p = x² + 3y² representation, completed formally in this entry."
+    },
+    {
+      "authors": "David A. Cox",
+      "title": "Primes of the Form x² + ny² (2nd ed.)",
+      "year": 2013,
+      "note": "Wiley. The definitive account of representations p = x² + 3y² via the ring of Eisenstein integers."
+    },
+    {
+      "authors": "Kenneth Ireland and Michael Rosen",
+      "title": "A Classical Introduction to Modern Number Theory (2nd ed.)",
+      "year": 1990,
+      "note": "Springer GTM 84. The Eisenstein integers ℤ[ω], their norm, and cubic residue theory."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Zsqrtd / Eisenstein-integer ring, norm and EuclideanDomain infrastructure",
+      "year": 2024,
+      "note": "The ring ℤ[ω] with norm N(a+bω)=a²−ab+b² and its Euclidean structure used in the proof."
+    }
+  ],
   "meta": {
     "author": "Euler (1763), Fermat (1640), Lagrange (1775)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Eisenstein_integer",


### PR DESCRIPTION
Enrichment pass adding accurate literature `references` to six oq-child entries whose only gap was empty references.

| Entry | References |
|-------|-----------|
| sylow-theorems-oq-01 (classification of order pq) | Sylow, Lang, Dummit-Foote, Rotman, mathlib |
| van-aubel-theorem-oq-01 (van Aubel) | van Aubel, Hahn, Johnson, Coxeter-Greitzer, mathlib |
| vietas-formulas-oq-02 (Newton's identities) | Newton, Girard, Macdonald, Stanley, mathlib |
| telescoping-product-oq-01 (∏(1−1/k²)) | Knopp, Apostol, Pólya-Szegő, Concrete Mathematics, mathlib |
| thue-morse-oq-01 (Thue-Morse sequence) | Thue, Morse, Prouhet, Allouche-Shallit, mathlib |
| zsqrtd-neg-two-oq-03-oq-01 (primes x²+3y²) | Fermat, Euler, Cox, Ireland-Rosen, mathlib |

Each set matched to the entry's specific angle, ending with a mathlib Community citation. Minimal additive diffs.