### PR TITLE
Enrich 6 oq-child entries: add references (Jordan-Chevalley-Dunford, Skolem-Noether, Routh, Bertrand, Chebyshev, spherical Ceva)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-02/meta.json
@@ -3,6 +3,38 @@
   "title": "The Jordan–Chevalley–Dunford Decomposition",
   "slug": "cayley-hamilton-minpoly-oq-01-oq-02",
   "description": "Proves the Jordan–Chevalley–Dunford decomposition: every endomorphism f of a finite-dimensional vector space over a perfect field splits as f = s + n, where s is semisimple, n is nilpotent, s and n commute, and both are polynomial expressions in f. The decomposition is shown to be unique. This is the basis-free shadow of the Jordan canonical form studied in the parent entry, and unlike that entry it is fully machine-checked with no axioms, via Mathlib's Newton-iteration proof together with the fact that a difference of commuting semisimple operators is semisimple.",
+  "references": [
+    {
+      "authors": "Claude Chevalley",
+      "title": "Théorie des groupes de Lie, Tome II: Groupes algébriques",
+      "year": 1951,
+      "note": "Hermann. The Jordan–Chevalley decomposition of an endomorphism into commuting semisimple and nilpotent parts."
+    },
+    {
+      "authors": "Nelson Dunford",
+      "title": "Spectral Operators (Pacific Journal of Mathematics 4)",
+      "year": 1954,
+      "note": "The operator-theoretic (Dunford) form of the additive semisimple-plus-nilpotent decomposition."
+    },
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra (Revised 3rd ed.), GTM 211",
+      "year": 2002,
+      "note": "Springer. The Jordan–Chevalley decomposition over a perfect field and its uniqueness."
+    },
+    {
+      "authors": "Nicolas Bourbaki",
+      "title": "Algèbre, Chapitre 7: Modules sur les anneaux principaux",
+      "year": 1958,
+      "note": "Hermann. Semisimple and nilpotent parts and the structure of endomorphisms."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: LinearMap semisimple/nilpotent and minpoly (perfect field) infrastructure",
+      "year": 2024,
+      "note": "Semisimplicity, nilpotency, and commuting-decomposition machinery used to state f = s + n."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-21",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Skolem-Noether for Central Simple Algebras: General Case",
   "slug": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01",
   "description": "Formalizes the general Skolem-Noether theorem: any two K-algebra homomorphisms from a finite-dimensional simple K-algebra A into a central simple K-algebra B are conjugate by a unit of B. Extends the matrix-algebra case (SkolemNoetherMatrixAut.lean) to arbitrary CSAs. The proof architecture isolates the key step (module isomorphism via Wedderburn-Artin + isotypic decomposition) as 1 axiom, with all surrounding algebraic lemmas fully proved. 0 sorries, 1 axiom.",
+  "references": [
+    {
+      "authors": "Thoralf Skolem",
+      "title": "Zur Theorie der assoziativen Zahlensysteme (Skrifter Norske Vid.-Akad. Oslo)",
+      "year": 1927,
+      "note": "Skolem's half of the Skolem–Noether theorem on conjugacy of algebra homomorphisms."
+    },
+    {
+      "authors": "Emmy Noether",
+      "title": "Nichtkommutative Algebra (Mathematische Zeitschrift 37)",
+      "year": 1933,
+      "note": "Noether's general form of the theorem for central simple algebras, formalized here."
+    },
+    {
+      "authors": "Richard S. Pierce",
+      "title": "Associative Algebras, GTM 88",
+      "year": 1982,
+      "note": "Springer. The Skolem–Noether theorem and the structure of central simple algebras."
+    },
+    {
+      "authors": "Benson Farb and R. Keith Dennis",
+      "title": "Noncommutative Algebra, GTM 144",
+      "year": 1993,
+      "note": "Springer. Central simple algebras, conjugacy of embeddings, and the Skolem–Noether theorem."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: central simple algebra and AlgHom conjugacy infrastructure",
+      "year": 2024,
+      "note": "Simple/central-simple K-algebra structures underlying the general conjugacy statement."
+    }
+  ],
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Skolem%E2%80%93Noether_theorem",

--- a/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01-oq-03/meta.json
@@ -3,6 +3,38 @@
   "title": "Routh's Theorem: Area Formula for Non-Concurrent Cevians",
   "slug": "cevas-theorem-oq-01-oq-03",
   "description": "Proves Routh's theorem for general parameters d, e, f ∈ (0,1): the inner triangle formed by three non-concurrent cevians has signed area equal to routhRatio(d,e,f) = (def-(1-d)(1-e)(1-f))² / ((1-e+de)(1-f+ef)(1-d+fd)) times the original triangle area. Complete proof via coordinate intersection formulas and a single polynomial identity. 19 theorems, 0 axioms.",
+  "references": [
+    {
+      "authors": "Edward John Routh",
+      "title": "A Treatise on Analytical Statics, Volume 1",
+      "year": 1896,
+      "note": "Cambridge University Press. Routh's area ratio for the triangle formed by three non-concurrent cevians."
+    },
+    {
+      "authors": "H. S. M. Coxeter",
+      "title": "Introduction to Geometry (2nd ed.)",
+      "year": 1969,
+      "note": "Wiley. Routh's theorem and its relation to Ceva's and Menelaus's theorems."
+    },
+    {
+      "authors": "H. S. M. Coxeter and S. L. Greitzer",
+      "title": "Geometry Revisited",
+      "year": 1967,
+      "note": "Mathematical Association of America. Cevians, area ratios, and Routh's theorem."
+    },
+    {
+      "authors": "Roger A. Johnson",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": 1929,
+      "note": "Dover reprint. Signed area ratios for cevian triangles."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: affine combination and signed-area (determinant) infrastructure",
+      "year": 2024,
+      "note": "Barycentric/affine coordinates and signed-area computations giving the routhRatio formula."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-05-03",

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Ceva's Theorem: Spherical Ceva via Unit Vectors and Weight Balance",
   "slug": "cevas-theorem-oq-02-oq-01",
   "description": "The spherical Ceva theorem expressed concretely using unit vectors in an inner product space. Cevian points on arcs are defined by weight parameters (α, β) via normalization of α·B + β·C. The key results: sin(BD)/sin(DC) = β/α for a single cevian, the triple product of sin-ratios equals the weight-product ratio, and the spherical Ceva concurrency condition reduces to α_D·α_E·α_F = β_D·β_E·β_F.",
+  "references": [
+    {
+      "authors": "Giovanni Ceva",
+      "title": "De lineis rectis se invicem secantibus statica constructio",
+      "year": 1678,
+      "note": "Ceva's original concurrency theorem, here transported to the sphere via unit vectors."
+    },
+    {
+      "authors": "Isaac Todhunter",
+      "title": "Spherical Trigonometry (5th ed.)",
+      "year": 1886,
+      "note": "Macmillan. Spherical triangles, arc measures, and the sine relations behind spherical Ceva."
+    },
+    {
+      "authors": "H. S. M. Coxeter and S. L. Greitzer",
+      "title": "Geometry Revisited",
+      "year": 1967,
+      "note": "Mathematical Association of America. Ceva's theorem and its trigonometric (sine) form."
+    },
+    {
+      "authors": "Marcel Berger",
+      "title": "Geometry I",
+      "year": 1987,
+      "note": "Springer. Spherical geometry and the metric relations underlying spherical Ceva."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: EuclideanSpace unit vectors, inner product and normalization infrastructure",
+      "year": 2024,
+      "note": "Unit-vector cevian points α·B+β·C and inner-product/sine relations used in the weight-balance proof."
+    }
+  ],
   "meta": {
     "author": "Classical (Ceva 1678); unit-vector formulation original",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ceva%27s_theorem#Spherical_geometry",

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-03/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-03/meta.json
@@ -3,6 +3,38 @@
   "title": "Bertrand's Postulate and the Prime-Counting Function",
   "slug": "chebyshev-pnt-bridge-oq-03",
   "description": "Formalizes Bertrand's postulate (a prime in (n, 2n] for every n ≥ 1) in the Chebyshev-PNT bridge framework, then derives its quantitative consequences for π: π(2n) ≥ π(n) + 1 (each doubling adds a prime) and π(2^k) ≥ k (at least k primes below 2^k), a clean lower bound matching the Θ(x/log x) order. 0 axioms, 0 sorries.",
+  "references": [
+    {
+      "authors": "Joseph Bertrand",
+      "title": "Mémoire sur le nombre de valeurs que peut prendre une fonction (Journal de l'École Royale Polytechnique)",
+      "year": 1845,
+      "note": "Bertrand's postulate: a prime always lies in (n, 2n]."
+    },
+    {
+      "authors": "Pafnuty Chebyshev",
+      "title": "Mémoire sur les nombres premiers (Journal de mathématiques pures et appliquées)",
+      "year": 1852,
+      "note": "The first proof of Bertrand's postulate via the Chebyshev functions θ and ψ."
+    },
+    {
+      "authors": "Paul Erdős",
+      "title": "Beweis eines Satzes von Tschebyschef (Acta Litt. Sci. Szeged 5)",
+      "year": 1932,
+      "note": "Erdős's celebrated elementary proof of Bertrand's postulate using binomial coefficients."
+    },
+    {
+      "authors": "Martin Aigner and Günter M. Ziegler",
+      "title": "Proofs from THE BOOK (6th ed.)",
+      "year": 2018,
+      "note": "Springer. The Erdős proof of Bertrand's postulate and its consequences for π."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.bertrand and Chebyshev-function infrastructure",
+      "year": 2024,
+      "note": "Mathlib's formalized Bertrand postulate, bridged here to π(2n) ≥ π(n)+1."
+    }
+  ],
   "meta": {
     "author": "Joseph Bertrand / Pafnuty Chebyshev",
     "sourceUrl": "https://en.wikipedia.org/wiki/Bertrand%27s_postulate",

--- a/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
@@ -19,6 +19,38 @@
     "sorries": 0
   },
   "description": "The composition law T_{m·n} = T_m ∘ T_n for the Chebyshev polynomials of the first kind, over any commutative ring and for all integer indices. Mathlib proves the multiplicativity (Polynomial.Chebyshev.T_mul) but records none of its structural consequences. The headline original result is the one Mathlib omits — that the Chebyshev polynomials commute under composition, T_m ∘ T_n = T_n ∘ T_m — together with the surrounding monoid picture (X = T₁ as the compositional identity, associativity of the triple composite) and the trigonometric origin cos(m·n·θ) = T_m(T_n(cos θ)).",
+  "references": [
+    {
+      "authors": "Pafnuty Chebyshev",
+      "title": "Théorie des mécanismes connus sous le nom de parallélogrammes (Mém. Acad. Sci. St.-Pétersbourg)",
+      "year": 1854,
+      "note": "Introduces the Chebyshev polynomials whose composition law T_{mn}=T_m∘T_n is proved here."
+    },
+    {
+      "authors": "Theodore J. Rivlin",
+      "title": "Chebyshev Polynomials: From Approximation Theory to Algebra and Number Theory (2nd ed.)",
+      "year": 1990,
+      "note": "Wiley. Composition and semigroup properties of the Chebyshev polynomials T_n."
+    },
+    {
+      "authors": "J. C. Mason and D. C. Handscomb",
+      "title": "Chebyshev Polynomials",
+      "year": 2002,
+      "note": "Chapman & Hall/CRC. Identities for T_n including multiplicativity and composition of indices."
+    },
+    {
+      "authors": "Gábor Szegő",
+      "title": "Orthogonal Polynomials (4th ed.)",
+      "year": 1975,
+      "note": "American Mathematical Society. The Chebyshev polynomials among the classical orthogonal families."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Polynomial.Chebyshev.T_mul and T_complex_cos",
+      "year": 2024,
+      "note": "Mathlib's multiplicativity T_{m·n}=T_m(T_n) bridged to the general composition/commutation law."
+    }
+  ],
   "meta": {
     "author": "Pafnuty Chebyshev (1854)",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass adding accurate literature `references` to six oq-child entries whose only gap was empty references.

| Entry | References |
|-------|-----------|
| cayley-hamilton-minpoly-oq-01-oq-02 (Jordan-Chevalley-Dunford) | Chevalley, Dunford, Lang, Bourbaki, mathlib |
| cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01 (Skolem-Noether) | Skolem, Noether, Pierce, Farb-Dennis, mathlib |
| cevas-theorem-oq-01-oq-03 (Routh's theorem) | Routh, Coxeter, Coxeter-Greitzer, Johnson, mathlib |
| chebyshev-pnt-bridge-oq-03 (Bertrand's postulate) | Bertrand, Chebyshev, Erdős, Aigner-Ziegler, mathlib |
| chebyshev-polynomials-oq-01 (Chebyshev composition) | Chebyshev, Rivlin, Mason-Handscomb, Szegő, mathlib |
| cevas-theorem-oq-02-oq-01 (spherical Ceva) | Ceva, Todhunter, Coxeter-Greitzer, Berger, mathlib |

Each set matched to the entry's specific angle, ending with a mathlib Community citation. Minimal additive diffs.