### PR TITLE
research(cauchy-schwarz-lp-duality): re-home extByZeroCLM to standalone Mathlib-only file [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualityExtension.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualityExtension.lean
@@ -1,0 +1,149 @@
+/-
+# Extension-by-zero infrastructure for the Lᵖ-duality synthesis
+(cauchy-schwarz-integral-lp-duality-synthesis)
+
+## What this file provides
+
+The arbitrary-measure Riesz representation for `Lᵖ` (`1 < p < ∞`) is reduced to the
+σ-finite case by a maximality / exhaustion argument (Folland, *Real Analysis* 2nd ed.,
+Thm 6.16). Step 1 of that reduction pulls a functional `φ` on `Lp ℝ p μ` back to a
+functional on `Lp ℝ p (μ.restrict S)`, for each measurable `S` whose restriction is
+σ-finite, along the **extension-by-zero** isometric embedding
+
+    extByZeroCLM : Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ,   `f ↦ S.indicator f`.
+
+This CLM was previously buried (as a `private`/exposed `def`) inside the deep σ-finite
+Riesz chain file `…OQ01OQ01Incomplete01.lean`, which is currently **build-broken** by
+Mathlib API drift (~70 errors). Because the whole file is all-or-nothing for
+verification, `extByZeroCLM` — although its construction depends on **Mathlib only** —
+was effectively quarantined: unusable by any decoupled assembly until the multi-session
+chain repair lands.
+
+This file **re-homes** the construction into a standalone, Mathlib-only, kernel-verified
+form, so the eventual arbitrary-measure assembly (`riesz_general_of_sigmaFinite`, planned
+to take the σ-finite Riesz result *with norm bound* as an explicit hypothesis) can be
+stated and proved **without** importing — and hence without waiting on the repair of —
+the broken chain. See the knowledge base for the decoupling roadmap (Session 16).
+
+## Simplification discovered while re-homing
+
+The chain built `extByZeroCLM` on two hand-written `private` helper lemmas
+(`eLpNorm_indicator_eq_restrict_loc`, `memLp_indicator_of_restrict_loc`). Both are now
+**redundant with Mathlib**:
+
+* `MeasureTheory.eLpNorm_indicator_eq_eLpNorm_restrict`
+    (`eLpNorm (S.indicator f) p μ = eLpNorm f p (μ.restrict S)`), and
+* `MeasureTheory.memLp_indicator_iff_restrict`
+    (`MemLp (S.indicator f) p μ ↔ MemLp f p (μ.restrict S)`).
+
+So the construction here rests directly on the library, no bespoke seminorm bookkeeping.
+
+## Contents
+
+* `extByZeroCLM`            — the extension-by-zero CLM (norm `≤ 1`, in fact isometric).
+* `extByZeroCLM_coeFn`      — `extByZeroCLM f =ᵐ[μ] S.indicator f`.
+* `norm_extByZeroCLM_apply` — isometry: `‖extByZeroCLM f‖ = ‖f‖`.
+* `norm_extByZeroCLM_le`    — operator-norm bound `‖extByZeroCLM‖ ≤ 1`.
+
+All are verified `lake env lean` / Docker, 0 sorries, 0 `axiom`, axiom profile
+`{propext, Classical.choice, Quot.sound}`.
+
+## References
+
+* Folland, *Real Analysis* (2nd ed.), Theorem 6.16.
+* Mathlib: `MeasureTheory.eLpNorm_indicator_eq_eLpNorm_restrict`,
+  `MeasureTheory.memLp_indicator_iff_restrict`.
+-/
+
+import Mathlib
+
+noncomputable section
+
+open MeasureTheory ENNReal
+
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+namespace RieszLpDualityExtension
+
+/-- **Extension-by-zero: isometric embedding `Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ`.**
+
+    Sends the class of `f` on the restricted measure to the class of `S.indicator f`
+    on `μ`. It is linear (the indicator is `ℝ`-linear pointwise on `S`, and `0` off `S`),
+    and isometric because `eLpNorm (S.indicator f) p μ = eLpNorm f p (μ.restrict S)`
+    (`eLpNorm_indicator_eq_eLpNorm_restrict`); the `mkContinuous` bound `1` records the
+    (tight) operator-norm bound `≤ 1`.
+
+    Mathlib-only: this re-homes the construction that lived inside the build-broken
+    σ-finite Riesz chain, so a decoupled arbitrary-measure assembly can use it without
+    importing that chain. -/
+def extByZeroCLM {S : Set α} (hS : MeasurableSet S)
+    {p : ℝ≥0∞} (hp : p ≠ 0) (hptop : p ≠ ⊤) [Fact (1 ≤ p)] :
+    Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ :=
+  LinearMap.mkContinuous
+    { toFun := fun f => ((memLp_indicator_iff_restrict hS).mpr (Lp.memLp f)).toLp _
+      map_add' := fun f₁ f₂ => by
+        rw [Lp.ext_iff]
+        filter_upwards [
+          ((memLp_indicator_iff_restrict hS).mpr (Lp.memLp (f₁ + f₂))).coeFn_toLp,
+          ((memLp_indicator_iff_restrict hS).mpr (Lp.memLp f₁)).coeFn_toLp,
+          ((memLp_indicator_iff_restrict hS).mpr (Lp.memLp f₂)).coeFn_toLp,
+          Lp.coeFn_add
+            (((memLp_indicator_iff_restrict hS).mpr (Lp.memLp f₁)).toLp _)
+            (((memLp_indicator_iff_restrict hS).mpr (Lp.memLp f₂)).toLp _),
+          (ae_restrict_iff' hS).mp (Lp.coeFn_add f₁ f₂)]
+          with a h12 h1 h2 hadd hinner
+        rw [h12, hadd]
+        by_cases ha : a ∈ S
+        · simp only [Pi.add_apply, h1, h2, Set.indicator_of_mem ha]
+          exact hinner ha
+        · simp only [Pi.add_apply, h1, h2, Set.indicator_of_notMem ha, add_zero]
+      map_smul' := fun c f => by
+        rw [Lp.ext_iff]
+        filter_upwards [
+          ((memLp_indicator_iff_restrict hS).mpr (Lp.memLp (c • f))).coeFn_toLp,
+          ((memLp_indicator_iff_restrict hS).mpr (Lp.memLp f)).coeFn_toLp,
+          Lp.coeFn_smul c (((memLp_indicator_iff_restrict hS).mpr (Lp.memLp f)).toLp _),
+          (ae_restrict_iff' hS).mp (Lp.coeFn_smul c f)]
+          with a hcf hf hsmul hinner
+        rw [hcf, RingHom.id_apply, hsmul]
+        by_cases ha : a ∈ S
+        · simp only [Pi.smul_apply, hf, Set.indicator_of_mem ha]
+          exact hinner ha
+        · simp only [Pi.smul_apply, hf, Set.indicator_of_notMem ha, smul_zero] }
+    1
+    (fun f => by
+      simp only [LinearMap.coe_mk, AddHom.coe_mk, one_mul]
+      have heq : ‖((memLp_indicator_iff_restrict hS).mpr (Lp.memLp f)).toLp _‖ = ‖f‖ := by
+        simp only [Lp.norm_def]
+        congr 1
+        rw [eLpNorm_congr_ae ((memLp_indicator_iff_restrict hS).mpr (Lp.memLp f)).coeFn_toLp,
+            eLpNorm_indicator_eq_eLpNorm_restrict hS]
+      exact heq.le)
+
+/-- The extension-by-zero of `f` is a.e. equal (under `μ`) to `S.indicator f`. -/
+theorem extByZeroCLM_coeFn {S : Set α} (hS : MeasurableSet S)
+    {p : ℝ≥0∞} (hp : p ≠ 0) (hptop : p ≠ ⊤) [Fact (1 ≤ p)]
+    (f : Lp ℝ p (μ.restrict S)) :
+    extByZeroCLM hS hp hptop f =ᵐ[μ] S.indicator (f : α → ℝ) :=
+  ((memLp_indicator_iff_restrict hS).mpr (Lp.memLp f)).coeFn_toLp
+
+/-- **Isometry.** Extension-by-zero preserves the `Lᵖ` norm. -/
+theorem norm_extByZeroCLM_apply {S : Set α} (hS : MeasurableSet S)
+    {p : ℝ≥0∞} (hp : p ≠ 0) (hptop : p ≠ ⊤) [Fact (1 ≤ p)]
+    (f : Lp ℝ p (μ.restrict S)) :
+    ‖extByZeroCLM hS hp hptop f‖ = ‖f‖ := by
+  simp only [Lp.norm_def]
+  congr 1
+  rw [eLpNorm_congr_ae (extByZeroCLM_coeFn hS hp hptop f),
+      eLpNorm_indicator_eq_eLpNorm_restrict hS]
+
+/-- **Operator-norm bound** `‖extByZeroCLM‖ ≤ 1`, as recorded by the `mkContinuous`
+    bound. (The map is in fact isometric — see `norm_extByZeroCLM_apply`.) -/
+theorem norm_extByZeroCLM_le {S : Set α} (hS : MeasurableSet S)
+    {p : ℝ≥0∞} (hp : p ≠ 0) (hptop : p ≠ ⊤) [Fact (1 ≤ p)] :
+    ‖extByZeroCLM (μ := μ) hS hp hptop‖ ≤ 1 :=
+  LinearMap.mkContinuous_norm_le _ zero_le_one _
+
+end RieszLpDualityExtension
+
+end

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -153,6 +153,49 @@ removes the only open *mathematical* question that was gating the elimination pl
 
 ## Session log
 
+### 2026-06-30 (Session 16, researcher-12) — ACT (extension-by-zero CLM re-homed & decoupled)
+
+**Mode:** REVISIT (RICH). **Outcome:** progress — 0-axiom infrastructure, chain-decoupled.
+
+- **The decoupling problem.** The general→σ-finite reduction (option B, Session 4) needs
+  the extension-by-zero isometry `extByZeroCLM : Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ`,
+  `f ↦ S.indicator f`, to pull a functional on `Lp μ` back to each σ-finite piece. This
+  CLM lived as a `private`/exposed `def` **inside** `…OQ01OQ01OQ02OQ01OQ01Incomplete01.lean`
+  — a file the S10/S11 re-measurements show is **build-broken** by ~70 Mathlib-drift errors.
+  Because that file is all-or-nothing for verification, `extByZeroCLM` was effectively
+  quarantined: unusable by any decoupled assembly until the multi-session chain repair lands,
+  even though its *own* construction depends on Mathlib only.
+- **What I did.** Re-homed the construction into a standalone, Mathlib-only file
+  `proofs/Proofs/CauchySchwarzIntegralLpDualityExtension.lean` (namespace
+  `RieszLpDualityExtension`), so the eventual arbitrary-measure assembly
+  (`riesz_general_of_sigmaFinite`, planned to take the σ-finite Riesz result *with norm
+  bound* as an explicit hypothesis) can be stated and proved **without importing** — hence
+  without waiting on the repair of — the broken chain.
+- **Simplification discovered while re-homing.** The chain built `extByZeroCLM` on two
+  hand-written `private` helpers (`eLpNorm_indicator_eq_restrict_loc`,
+  `memLp_indicator_of_restrict_loc`). Both are now **redundant with Mathlib**:
+  `MeasureTheory.eLpNorm_indicator_eq_eLpNorm_restrict` and
+  `MeasureTheory.memLp_indicator_iff_restrict`. The re-homed construction rests directly
+  on the library — no bespoke seminorm bookkeeping.
+- **Contents (4 decls, 149 L, 0 sorry / 0 axiom):**
+  - `extByZeroCLM` — the CLM, via `LinearMap.mkContinuous … 1`; `map_add'`/`map_smul'`
+    discharged by `filter_upwards` over the `coeFn_toLp`/`Lp.coeFn_add`/`Lp.coeFn_smul`
+    a.e. representatives + `Set.indicator_apply`/`split_ifs`, using
+    `Measure.ae_restrict_iff' hS` to move the inner (on-`S`) equality into the μ-a.e. world.
+  - `extByZeroCLM_coeFn` — `extByZeroCLM f =ᵐ[μ] S.indicator f` (just `.coeFn_toLp`).
+  - `norm_extByZeroCLM_apply` — **isometry** `‖extByZeroCLM f‖ = ‖f‖`, via
+    `Lp.norm_def` + `eLpNorm_congr_ae` + `eLpNorm_indicator_eq_eLpNorm_restrict`.
+  - `norm_extByZeroCLM_le` — operator-norm bound `≤ 1` (`LinearMap.mkContinuous_norm_le`).
+- **Verified** 0-axiom via Docker `docker-build.sh Proofs.CauchySchwarzIntegralLpDualityExtension`
+  (Docker back up this session; disk recovered). Axiom profile `{propext, Classical.choice,
+  Quot.sound}` only.
+- **Status unchanged (blocked at parent goal):** the arbitrary-measure axiom
+  `riesz_lp_surjective` is **not** eliminated. This session removes a *structural* blocker —
+  the last chain-buried ingredient the decoupled assembly needed is now free-standing and
+  verified. Remaining critical path: (1) repair or bypass the `Incomplete01` σ-finite Riesz
+  chain to expose `riesz_lp_surjective_sigma_finite` *with its norm bound*; (2) the single
+  maximality/exhaustion lemma (Folland 6.16) assembling the σ-finite pieces; (3) swap axiom→theorem.
+
 ### 2026-06-30 (Session 15, researcher-8) — ACT (dual-norm layer completed)
 
 **Mode:** REVISIT (rolling PR #31646). **Outcome:** progress — 0-axiom.

--- a/research/registry.json
+++ b/research/registry.json
@@ -5278,7 +5278,7 @@
       "path": "full",
       "started": "2026-04-25T12:53:24.052Z",
       "status": "active",
-      "lastUpdate": "2026-06-30T16:24:06-07:00"
+      "lastUpdate": "2026-06-30T22:33:51-07:00"
     },
     {
       "slug": "cauchy-schwarz-integral-oq-01",
@@ -32521,5 +32521,5 @@
     "oodaTimeoutMinutes": 60,
     "attemptsBeforePivot": 5
   },
-  "lastUpdated": "2026-06-22T23:30:00.000Z"
+  "lastUpdated": "2026-06-30T22:33:51-07:00"
 }

--- a/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
@@ -41,7 +41,7 @@
   ],
   "phase": "ACT",
   "knowledge": {
-    "progressSummary": "PROGRESS (session 11, researcher-3): annihilator/uniqueness ingredient (Lᵠ↪(Lᵖ)* injective) proved & verified 0-axiom standalone — the maximality step none of the 4 prior ingredients covered, and NOT the feared converse-Hölder gap. Re-measured chain: base file now green (Session-10 diagnosis stale), 70 errors moved up to Incomplete01. Axiom NOT yet eliminated; headline sorry remains.",
+    "progressSummary": "PROGRESS (session 16, researcher-12): re-homed the extension-by-zero isometric CLM extByZeroCLM into a standalone Mathlib-only file (CauchySchwarzIntegralLpDualityExtension.lean, 4 decls, 0-axiom), decoupling it from the build-broken Incomplete01 chain — removes the last chain-buried structural blocker for the decoupled arbitrary-measure assembly. Simplified: the chain's 2 private seminorm helpers are now redundant with Mathlib. Parent axiom riesz_lp_surjective NOT yet eliminated (still gated on σ-finite chain repair + the single maximality lemma).",
     "insights": [
       "The previously-flagged Lean infrastructure gaps are RESOLVED. Mathlib supplies the sigma-finite support of any Lp function (0<p<inf) via MeasureTheory.MemLp.aefinStronglyMeasurable (Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean:59) -> AEFinStronglyMeasurable, whose .sigmaFiniteSet / .measurableSet / .ae_eq_zero_compl / sigmaFinite_restrict instance (StronglyMeasurable/AEStronglyMeasurable.lean:892-916) give a measurable set S with mu.restrict S sigma-finite and f=0 a.e. off S.",
       "The verified chain ALREADY contains the restriction/extension infrastructure once thought to be a ~150-line gap: CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean proves eLpNorm (S.indicator f) p mu = eLpNorm f p (mu.restrict S) (line 246), MemLp f p (mu.restrict S) -> MemLp (S.indicator f) p mu (line 260), and the extension-by-zero ISOMETRY extByZeroCLM : Lp p (mu.restrict S) ->L Lp p mu (line 266, currently private).",
@@ -62,7 +62,9 @@
       "S14: the g∉Lᵠ direction of the dual-norm identity needs ONLY σ-finiteness (not the full arbitrary-measure reduction): truncate g to tₙ=(g⊓n)·1_{Aₙ} over spanning sets Aₙ; monotone convergence ⨆ₙ tₙᵠ=gᵠ gives ⨆ₙ∫⁻tₙᵠ=∫⁻gᵠ, and rpow commutes with ⨆ via ENNReal.orderIsoRpow (an OrderIso ⟹ sSupHomClass ⟹ map_iSup).",
       "The 10-session \"converse-Hölder dual-norm gap\" (‖g‖_q ≤ ⨆|∫f·g|) is a red herring for the maximality UNIQUENESS step: injectivity of Lᵠ↪(Lᵖ)* is qualitative — no norm estimate, no extremizer |g|^{q-1}sgn g — and follows directly from Mathlib AEFinStronglyMeasurable.ae_eq_zero_of_forall_setIntegral_eq_zero.",
       "Session 10 diagnosis is stale: the finite-measure base CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean now compiles cleanly (EXIT 0); the 70 build errors have moved up to Incomplete01.lean (σ-finite Riesz construction).",
-      "Uniqueness needs no SigmaFinite μ hypothesis: a MemLp function at a finite exponent q<∞ is automatically AEFinStronglyMeasurable, and testing against finite-measure indicators gives ∫_s g=0 ∀s."
+      "Uniqueness needs no SigmaFinite μ hypothesis: a MemLp function at a finite exponent q<∞ is automatically AEFinStronglyMeasurable, and testing against finite-measure indicators gives ∫_s g=0 ∀s.",
+      "S16: extByZeroCLM (extension-by-zero isometry Lp(μ.restrict S)→L Lp μ) was quarantined inside the build-broken Incomplete01 chain despite depending on Mathlib only — all-or-nothing file verification made it unusable by any decoupled assembly.",
+      "S16: the chain's two private helpers eLpNorm_indicator_eq_restrict_loc / memLp_indicator_of_restrict_loc are now redundant with Mathlib's eLpNorm_indicator_eq_eLpNorm_restrict + memLp_indicator_iff_restrict — the re-homed construction needs no bespoke seminorm bookkeeping."
     ],
     "builtItems": [
       "memLp_exists_sigmaFinite_support — bridge lemma: for 0<p<inf, every f in Lp(mu) is a.e. supported on a measurable S with mu.restrict S sigma-finite (proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean). High-confidence (uses only confirmed Mathlib API) but UNVERIFIED this session (no build).",
@@ -82,7 +84,11 @@
       "lpDualNorm_eq_top_of_lintegral_top: g∉Lᵠ ⟹ lpDualNorm=∞ via truncation",
       "lqTruncation + iSup_lqTruncation/lqTruncation_mono/lqTruncation_le/lintegral_lqTruncation_rpow_ne_top: monotone-truncation toolkit",
       "private rpow_iSup: (⨆f)^q=⨆fᵠ for q>0 via ENNReal.orderIsoRpow.map_iSup",
-      "RieszLpDualityAnnihilator.lp_pairing_eq_zero_ae_zero in proofs/Proofs/CauchySchwarzIntegralLpDualityAnnihilator.lean — annihilator/uniqueness lemma: g∈Lᵠ, ∫f·g=0 ∀f∈Lᵖ ⟹ g=ᵐ0. Standalone, Mathlib-only, verified lake env lean EXIT 0, #print axioms = {propext,Classical.choice,Quot.sound}."
+      "RieszLpDualityAnnihilator.lp_pairing_eq_zero_ae_zero in proofs/Proofs/CauchySchwarzIntegralLpDualityAnnihilator.lean — annihilator/uniqueness lemma: g∈Lᵠ, ∫f·g=0 ∀f∈Lᵖ ⟹ g=ᵐ0. Standalone, Mathlib-only, verified lake env lean EXIT 0, #print axioms = {propext,Classical.choice,Quot.sound}.",
+      "extByZeroCLM in CauchySchwarzIntegralLpDualityExtension.lean:79 — CLM Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ, f↦S.indicator f, via LinearMap.mkContinuous … 1 (0-axiom).",
+      "extByZeroCLM_coeFn (:124) — extByZeroCLM f =ᵐ[μ] S.indicator f.",
+      "norm_extByZeroCLM_apply (:131) — isometry ‖extByZeroCLM f‖ = ‖f‖.",
+      "norm_extByZeroCLM_le (:142) — operator-norm bound ≤ 1."
     ],
     "mathlibGaps": [
       "Mathlib has NO general Lp-Lq duality / Riesz surjectivity (no *Dual* Lp file under MeasureTheory/Function). This remains a genuine Mathlib gap that the gallery chain fills.",
@@ -95,9 +101,9 @@
       "Incomplete01.lean (σ-finite Riesz: localization_existence, riesz_lp_surjective_sigma_finite) has 70 scattered Mathlib-v4.26 API-drift errors (application type mismatch, failed to synthesize, rewrite-pattern misses, Exists.min/rpow_const dot-notation breakage) — multi-session mechanical repair, now the true critical-path frontier."
     ],
     "nextSteps": [
-      "Repair Incomplete01.lean 70 API-drift errors against Mathlib v4.26.0 (base file below it is now green); rebuild OQ01OQ01→synthesis.",
-      "Wire lp_pairing_eq_zero_ae_zero + the 4 existing ingredient lemmas into riesz_lp_surjective_general maximality construction to discharge the headline sorry.",
-      "Consistency corollary (g₁=g₂ a.e. when both represent φ) follows from the annihilator via linearity + Hölder product-integrability (MemLp.integrable_mul needs ℝ≥0∞-level HolderTriple instance)."
+      "Repair or bypass the Incomplete01 σ-finite Riesz chain to expose riesz_lp_surjective_sigma_finite WITH its norm bound (needed as explicit hypothesis for the decoupled assembly).",
+      "State riesz_general_of_sigmaFinite: take σ-finite Riesz (with norm bound) as hypothesis + use extByZeroCLM to pull φ back to each σ-finite S; formalize the single Folland-6.16 maximality/exhaustion lemma over c=⨆_S ‖g_S‖_q.",
+      "Once assembled, swap axiom riesz_lp_surjective → theorem and flip meta axiomatized→verified iff green."
     ]
   },
   "leanFiles": [
@@ -111,6 +117,17 @@
       "sorryCount": 13,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralLpDualityExtension.lean",
+      "filename": "CauchySchwarzIntegralLpDualityExtension.lean",
+      "lineCount": 149,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralLpDualityExtension.lean"
     }
   ],
   "lastUpdate": "2026-06-28",


### PR DESCRIPTION
## Summary

Extracts the **extension-by-zero isometric CLM**

```
extByZeroCLM : Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ,   f ↦ S.indicator f
```

out of the build-broken σ-finite Riesz chain (`…OQ01OQ01Incomplete01.lean`, ~70 Mathlib v4.26 API-drift errors) into a **standalone, Mathlib-only, kernel-verified** file, `proofs/Proofs/CauchySchwarzIntegralLpDualityExtension.lean`.

Although the construction depends on **Mathlib only**, all-or-nothing file verification had quarantined it inside the broken chain — unusable by any decoupled assembly until the multi-session chain repair lands. Re-homing it unblocks the planned arbitrary-measure Riesz assembly (`riesz_general_of_sigmaFinite`), which can now use `extByZeroCLM` to pull a functional back to each σ-finite piece without importing the broken chain.

## Contents (4 declarations, 0 sorries, 0 axioms)

| Decl | Statement |
|------|-----------|
| `extByZeroCLM` | the CLM, via `LinearMap.mkContinuous … 1` |
| `extByZeroCLM_coeFn` | `extByZeroCLM f =ᵐ[μ] S.indicator f` |
| `norm_extByZeroCLM_apply` | isometry `‖extByZeroCLM f‖ = ‖f‖` |
| `norm_extByZeroCLM_le` | operator-norm bound `≤ 1` |

## Simplification discovered while re-homing

The chain built `extByZeroCLM` on two hand-written `private` helper lemmas (`eLpNorm_indicator_eq_restrict_loc`, `memLp_indicator_of_restrict_loc`). Both are now **redundant with Mathlib**:

- `MeasureTheory.eLpNorm_indicator_eq_eLpNorm_restrict`
- `MeasureTheory.memLp_indicator_iff_restrict`

so the construction rests directly on the library, no bespoke seminorm bookkeeping.

## Verification

Docker build (`docker-build.sh Proofs.CauchySchwarzIntegralLpDualityExtension`) — **EXIT 0, 7743 jobs**, 0 sorries, 0 `axiom`, axiom profile `{propext, Classical.choice, Quot.sound}`.

## Status

Parent axiom `riesz_lp_surjective` is **not yet eliminated** (still gated on σ-finite chain repair + the single Folland-6.16 maximality lemma). This PR removes the last *chain-buried structural* blocker for the decoupled assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)