### PR TITLE
Enrich 6 oq-child entries: add references (Euler OI², friendship theorem, four-color, Riemann-Lebesgue, Xⁿ−p, Horadam)

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02/meta.json
@@ -3,6 +3,38 @@
   "title": "Euler's Triangle Formula: OI² = R² − 2Rr and Euler's Inequality R ≥ 2r",
   "slug": "feuerbachs-theorem-defs-oq-02",
   "description": "Proves Euler's 1765 formula relating the circumcenter O and incenter I of a triangle: the squared distance OI² equals R² − 2Rr, where R is the circumradius and r the inradius. Since OI² ≥ 0 this forces Euler's inequality R ≥ 2r. Built from the coordinate API of FeuerbachsTheoremDefs.lean. 7 theorems (+ supporting lemmas), 0 axioms, 0 sorries.",
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "Solutio facilis problematum quorundam geometricorum difficillimorum (Novi Comment. Acad. Sci. Petrop. 11)",
+      "year": 1765,
+      "note": "Euler's formula OI² = R² − 2Rr and the resulting inequality R ≥ 2r, formalized here."
+    },
+    {
+      "authors": "Roger A. Johnson",
+      "title": "Advanced Euclidean Geometry (Modern Geometry)",
+      "year": 1929,
+      "note": "Dover reprint. The Euler triangle formula and distances among the classical triangle centers."
+    },
+    {
+      "authors": "H. S. M. Coxeter and S. L. Greitzer",
+      "title": "Geometry Revisited",
+      "year": 1967,
+      "note": "Mathematical Association of America. Euler's OI² = R² − 2Rr and Euler's inequality."
+    },
+    {
+      "authors": "Nathan Altshiller-Court",
+      "title": "College Geometry (2nd ed.)",
+      "year": 1952,
+      "note": "Barnes & Noble. Circumcenter–incenter distance and the tritangent circles."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: EuclideanGeometry circumradius/inradius and dist infrastructure",
+      "year": 2024,
+      "note": "Circumcenter, incenter, and squared-distance machinery used to prove OI² = R² − 2Rr."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-21",

--- a/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-02/meta.json
@@ -3,6 +3,38 @@
   "slug": "fibonacci-identities-oq-04-oq-01-oq-02",
   "title": "Cassini and d'Ocagne for the Full Horadam Recurrence — the Geometric Constant (−q)ⁿ",
   "description": "The parent entry (fibonacci-identities-oq-04-oq-01) proved Vajda's product identities for every solution of the *Fibonacci* recurrence G(n+2)=G(n+1)+G(n), replacing the Cassini sign (−1)ⁿ by the discriminant μ=a²−ab−b². Its second open question asks to push the constant to the full Horadam recurrence H(n+2)=p·H(n+1)+q·H(n) with arbitrary p,q∈ℤ, where the controlling constant is no longer a fixed sign but the geometric factor (−q)ⁿ. This entry supplies that generalization. Fix parameters p,q and seeds H(0)=a, H(1)=b. The headline result is the two-index d'Ocagne identity for Horadam sequences H(n+k+1)·H(n) − H(n+k)·H(n+1) = (−q)ⁿ·(H(k+1)·a − H(k)·b), proved by a single induction on n that applies the recurrence twice in the step. Cassini/Simson is the k=1 case H(n+2)·H(n) − H(n+1)² = (−q)ⁿ·(H(2)·a − b²), whose constant H(2)·a − b² = (p·b+q·a)·a − b² is the Horadam discriminant. For the Fibonacci numbers (p,q,a,b)=(1,1,0,1) the discriminant is −1 and (−q)ⁿ=(−1)ⁿ, recovering the textbook Cassini identity in the shifted form F(n+2)·F(n) − F(n+1)² = (−1)ⁿ⁺¹. The geometric factor (−q)ⁿ is exactly det(M)ⁿ for the companion matrix M=[[p,q],[1,0]] (det M=−q), the Horadam analogue of the Q=[[1,1],[1,0]] viewpoint of the parent hierarchy. Fully verified: 0 sorries, 0 axioms, no native_decide.",
+  "references": [
+    {
+      "authors": "Alwyn F. Horadam",
+      "title": "Basic Properties of a Certain Generalized Sequence of Numbers (Fibonacci Quarterly 3)",
+      "year": 1965,
+      "note": "Introduces the Horadam sequence generalizing Fibonacci/Lucas, the setting of these Cassini/d'Ocagne identities."
+    },
+    {
+      "authors": "Maurice d'Ocagne",
+      "title": "Sur une suite récurrente (Bulletin de la Société Mathématique de France 13)",
+      "year": 1885,
+      "note": "d'Ocagne's identity for recurrent sequences, generalized here to the Horadam recurrence."
+    },
+    {
+      "authors": "Steven Vajda",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": 1989,
+      "note": "Ellis Horwood. Vajda's product identities and the Cassini/d'Ocagne family."
+    },
+    {
+      "authors": "Thomas Koshy",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": 2001,
+      "note": "Wiley. Cassini, Catalan, and d'Ocagne identities and their generalizations."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: linear-recurrence and matrix-power (companion matrix) infrastructure",
+      "year": 2024,
+      "note": "Recurrence and determinant machinery yielding the geometric constant (−q)ⁿ in the general identities."
+    }
+  ],
   "meta": {
     "author": "A. F. Horadam (Horadam/Gibonacci sequences, 1965); J. D. d'Ocagne, J. B. Cassini, R. Simson (classical identities); formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Identities",

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -3,6 +3,38 @@
   "title": "Minimal Unavoidable Reducible Configurations",
   "slug": "four-color-theorem-oq-02",
   "description": "Formalizes the theory of unavoidable reducible configuration sets for the Four Color Theorem. Historical progression: Appel-Haken 1476 → RSST 633. Open: minimum size unknown.",
+  "references": [
+    {
+      "authors": "Kenneth Appel and Wolfgang Haken",
+      "title": "Every Planar Map Is Four Colorable (Illinois Journal of Mathematics 21)",
+      "year": 1977,
+      "note": "The original computer-assisted proof with 1476 unavoidable reducible configurations."
+    },
+    {
+      "authors": "Neil Robertson, Daniel P. Sanders, Paul Seymour and Robin Thomas",
+      "title": "The Four-Colour Theorem (Journal of Combinatorial Theory, Series B 70)",
+      "year": 1997,
+      "note": "The streamlined RSST proof reducing the configuration set to 633."
+    },
+    {
+      "authors": "Georges Gonthier",
+      "title": "Formal Proof—The Four-Color Theorem (Notices of the AMS 55)",
+      "year": 2008,
+      "note": "The full machine-checked Coq proof, the reference for formalizing unavoidability and reducibility."
+    },
+    {
+      "authors": "Robin Wilson",
+      "title": "Four Colors Suffice: How the Map Problem Was Solved",
+      "year": 2002,
+      "note": "Princeton University Press. History of unavoidable sets and reducible configurations."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: SimpleGraph planarity and coloring infrastructure",
+      "year": 2024,
+      "note": "Graph-coloring and configuration definitions used to formalize the unavoidable-reducible theory."
+    }
+  ],
   "meta": {
     "author": "Robertson-Sanders-Seymour-Thomas (1997)",
     "date": "1997",

--- a/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Riemann-Lebesgue via L²: Alternative Proof for Hölder Functions",
   "slug": "fourier-series-oq-02-oq-01",
   "description": "Proves that Fourier coefficients of Hölder-continuous functions tend to zero via the Parseval/L² route (Continuous → MemLp 2 → Summable ‖ĉ_n‖² → ĉ_n → 0), rather than via explicit quantitative decay bounds. 0 sorries, 0 axioms.",
+  "references": [
+    {
+      "authors": "Bernhard Riemann",
+      "title": "Über die Darstellbarkeit einer Function durch eine trigonometrische Reihe (Habilitationsschrift)",
+      "year": 1854,
+      "note": "Origin of the Riemann–Lebesgue lemma on the decay of Fourier coefficients."
+    },
+    {
+      "authors": "Henri Lebesgue",
+      "title": "Sur les séries trigonométriques (Annales Sci. École Norm. Sup. 20)",
+      "year": 1903,
+      "note": "The Lebesgue-integral form of the Riemann–Lebesgue lemma."
+    },
+    {
+      "authors": "Walter Rudin",
+      "title": "Real and Complex Analysis (3rd ed.)",
+      "year": 1987,
+      "note": "McGraw-Hill. L² Fourier theory, Bessel/Parseval, and the Riemann–Lebesgue lemma."
+    },
+    {
+      "authors": "Elias M. Stein and Rami Shakarchi",
+      "title": "Fourier Analysis: An Introduction",
+      "year": 2003,
+      "note": "Princeton University Press. Decay of Fourier coefficients and the mean-square (L²) approach used here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: MeasureTheory.MemLp, fourierCoeff and Summable infrastructure",
+      "year": 2024,
+      "note": "The Continuous → MemLp 2 → Summable ‖ĉ_n‖² → ĉ_n → 0 chain formalizing Riemann–Lebesgue for Hölder functions."
+    }
+  ],
   "meta": {
     "author": "Classical result; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Riemann%E2%80%93Lebesgue_lemma",

--- a/src/data/proofs/fourth-root-2-degree4-oq-02/meta.json
+++ b/src/data/proofs/fourth-root-2-degree4-oq-02/meta.json
@@ -3,6 +3,38 @@
   "slug": "fourth-root-2-degree4-oq-02",
   "title": "Xⁿ − p is irreducible for every prime p and every n ≥ 1: the Eisenstein-then-Gauss route packaged as a reusable lemma",
   "description": "Open-question generalization of the gallery proof ⁴√2-has-degree-4. The parent handled X⁴ − 2 (the case 4 = 2² that Mathlib's Kummer API explicitly cannot reach) by a hand-rolled Eisenstein-at-2 argument. This entry shows that argument was never special to the prime 2 or the exponent 4: Eisenstein's criterion at a prime p applies verbatim to Xⁿ − p for EVERY prime p and EVERY n ≥ 1, with no parity or p ≠ 2 restriction, because the only facts used are leadingCoeff = 1 ∉ (p), all lower coefficients ∈ (p), and constant term −p ∉ (p)². Gauss's lemma descends irreducibility from ℤ[X] to ℚ[X]. From the single packaged lemma we recover, as one-line corollaries, the minimal polynomial and field degree [ℚ(α):ℚ] = n of any root αⁿ = p, the previously TODO-blocked even cases X² − 2, X⁴ − 2, X⁸ − 2, X¹⁶ − 2, and odd-prime even-exponent cases X⁴ − 3, X⁶ − 7, plus the parent's [ℚ(√2):ℚ] = 2 and [ℚ(⁴√2):ℚ] = 4.",
+  "references": [
+    {
+      "authors": "Gotthold Eisenstein",
+      "title": "Über die Irreductibilität und einige andere Eigenschaften der Gleichung... (Journal für die reine und angewandte Mathematik 39)",
+      "year": 1850,
+      "note": "The Eisenstein irreducibility criterion, the core of the Xⁿ − p argument packaged here."
+    },
+    {
+      "authors": "Ernst Eduard Kummer",
+      "title": "Über die Zerlegung der aus Wurzeln der Einheit gebildeten complexen Zahlen (Journal für die reine und angewandte Mathematik 35)",
+      "year": 1847,
+      "note": "Kummer theory of Xⁿ − a, whose 4 = 2² gap Eisenstein-at-p fills."
+    },
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra (Revised 3rd ed.), GTM 211",
+      "year": 2002,
+      "note": "Springer. Eisenstein's criterion and Gauss's lemma for irreducibility over ℚ."
+    },
+    {
+      "authors": "David S. Dummit and Richard M. Foote",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": 2004,
+      "note": "Wiley. Eisenstein criterion and irreducibility of Xⁿ − p (§9.4)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Polynomial.irreducible_of_eisenstein_criterion and IsPrimitive.Int infrastructure",
+      "year": 2024,
+      "note": "The Eisenstein-then-Gauss lemmas assembled into the reusable Xⁿ − p irreducibility result."
+    }
+  ],
   "meta": {
     "author": "Lean Genius (Researcher)",
     "date": "2026-06-27",

--- a/src/data/proofs/friendship-theorem-oq-01/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-01/meta.json
@@ -3,6 +3,38 @@
   "title": "Friendship Theorem: Spectral Proof via Characteristic Polynomials",
   "slug": "friendship-theorem-oq-01",
   "description": "Axiom-free spectral proof that every k-regular friendship graph has k=2, using adjacency matrix characteristic polynomial techniques, the Weinstein-Aronszajn determinant identity, and UFD factorization in \u2124[X]. Proves the core regularity step: if no universal vertex exists, the friendship graph must be a triangle.",
+  "references": [
+    {
+      "authors": "Paul Erdős, Alfréd Rényi and Vera T. Sós",
+      "title": "On a Problem of Graph Theory (Studia Scientiarum Mathematicarum Hungarica 1)",
+      "year": 1966,
+      "note": "The original friendship theorem: a graph where every pair has exactly one common friend has a universal vertex."
+    },
+    {
+      "authors": "Herbert S. Wilf",
+      "title": "The Friendship Theorem (in Combinatorial Mathematics and Its Applications)",
+      "year": 1971,
+      "note": "Academic Press. The spectral / adjacency-matrix proof formalized in this entry."
+    },
+    {
+      "authors": "Martin Aigner and Günter M. Ziegler",
+      "title": "Proofs from THE BOOK (6th ed.)",
+      "year": 2018,
+      "note": "Springer. The eigenvalue proof of the friendship theorem."
+    },
+    {
+      "authors": "Chris Godsil and Gordon Royle",
+      "title": "Algebraic Graph Theory, GTM 207",
+      "year": 2001,
+      "note": "Springer. Adjacency-matrix spectra and strongly regular graphs behind the friendship theorem."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: SimpleGraph adjacency matrix, Matrix.charpoly and ℤ[X] UFD infrastructure",
+      "year": 2024,
+      "note": "Characteristic-polynomial and unique-factorization machinery driving the axiom-free spectral proof."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-02",


### PR DESCRIPTION
Enrichment pass adding accurate literature `references` to six oq-child entries whose only gap was empty references.

| Entry | References |
|-------|-----------|
| feuerbachs-theorem-defs-oq-02 (Euler OI²=R²−2Rr) | Euler, Johnson, Coxeter-Greitzer, Altshiller-Court, mathlib |
| friendship-theorem-oq-01 (spectral proof) | Erdős-Rényi-Sós, Wilf, Aigner-Ziegler, Godsil-Royle, mathlib |
| four-color-theorem-oq-02 (unavoidable configs) | Appel-Haken, RSST, Gonthier, Wilson, mathlib |
| fourier-series-oq-02-oq-01 (Riemann-Lebesgue via L²) | Riemann, Lebesgue, Rudin, Stein-Shakarchi, mathlib |
| fourth-root-2-degree4-oq-02 (Xⁿ−p irreducibility) | Eisenstein, Kummer, Lang, Dummit-Foote, mathlib |
| fibonacci-identities-oq-04-oq-01-oq-02 (Horadam Cassini/d'Ocagne) | Horadam, d'Ocagne, Vajda, Koshy, mathlib |

Each set matched to the entry's specific angle, ending with a mathlib Community citation. Minimal additive diffs.