### PR TITLE
chore(auditor): record clean audit of 3 verified OQ-child entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -26263,6 +26263,24 @@
       "lastAudited": "2026-07-01T06:24:40Z",
       "result": "clean",
       "issues": []
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T06:55:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T06:55:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "harmonic-divergence-oq-06-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-01T06:55:56Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited 3 never-audited verified entries. All **CLEAN** — mechanical checks pass (0 sorries, 0 `axiom` decls, no `native_decide`, no `True` stubs) and public narrative matches the Lean source.

| Entry | Status/Badge | Finding |
|-------|-------------|---------|
| `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01` | verified/original | Genuine Vandermonde addition theorem for rising/falling factorials over an arbitrary CommRing (Mathlib lacks `ascPochhammer_add`). Contributions accurately scoped. |
| `cayley-hamilton-minpoly-oq-03-oq-03` | verified/mathlib | Krylov/RCF similarity results. Mathlib reliance fully disclosed in `assumptions`; badge correctly `mathlib`. |
| `harmonic-divergence-oq-06-oq-02` | verified/original | Closes b=0 endpoint of Σ1/(a·n+b) via index-shift/scaling reduction. Mathlib engine `Real.not_summable_one_div_natCast` credited explicitly in `originalContributions` + `assumptions`. No delegation opacity. |

Notes:
- `bezout-identity-oq-01-oq-02` skipped — claimed by a concurrent auditor.
- `minkowski-theorem-oq-04-oq-02` appeared in the queue but its gallery dir does not exist (transient untracked researcher draft, absent on origin/main); claim released, no result recorded.

Updates `audit-tracker.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)