### PR TITLE
Enrich Rising/Falling Factorial Vandermonde (add references)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01",
+  "title": "Rising/Falling Factorial Vandermonde over a Commutative Ring",
+  "slug": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01",
+  "description": "Lifts the numerical falling-factorial Vandermonde identity (over ℕ) to genuine ring-element identities over an arbitrary commutative ring R: (x+y)^{(r)} = ∑_{j=0}^{r} C(r,j)·x^{(j)}·y^{(r-j)} for the rising factorial x^{(k)}=x(x+1)···(x+k-1), with the falling-factorial mirror obtained via the reflection x^{underline k}=(-1)^k(-x)^{(k)}. This is the binomial theorem for the finite-difference operator; Mathlib has ascPochhammer/descPochhammer but no such convolution lemma. 8 theorems, 2 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Vandermonde%27s_identity",
+    "date": "2026-06-30",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "umbral-calculus",
+      "rising-factorial",
+      "falling-factorial",
+      "vandermonde",
+      "commutative-ring",
+      "finite-differences"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-30",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified over an arbitrary CommRing.",
+    "mathlib_version": "4.26.0",
+    "lineCount": 185,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "prerequisites": [
+      "Nat.choose_succ_succ: Pascal's rule C(n+1,k+1)=C(n,k)+C(n,k+1)",
+      "Finset.sum_range_succ' and Finset.sum_range_succ: peel/reindex range sums",
+      "Nat.add_sub_cancel': j ≤ r ⇒ j + (r-j) = r, for the shift split (x+y+r)=(x+j)+(y+(r-j))"
+    ],
+    "originalContributions": [
+      "risingFactorial_add: (x+y)^{(r)} = ∑_j C(r,j)·x^{(j)}·y^{(r-j)} over any commutative ring, proved by induction on r mirroring add_pow (no ascPochhammer_add exists in Mathlib)",
+      "fallingFactorial_add: the falling-factorial mirror, derived cleanly via the reflection x^{underline k}=(-1)^k(-x)^{(k)}",
+      "fallingFactorial_eq_neg_one_pow_mul_risingFactorial: the rising↔falling reflection identity over a CommRing",
+      "risingFactorial_natCast: bridge risingFactorial (m:R) k = (Nat.ascFactorial m k : R) recovering the numerical parent"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule C(n+1,k+1) = C(n,k) + C(n,k+1), used to recombine the two shifted sums in the induction step",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "∑_{i<n+1} f i = (∑_{i<n} f(i+1)) + f 0: peels the bottom term and reindexes, matching the rising-factorial shift",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Nat.add_sub_cancel'",
+        "description": "j ≤ r ⇒ j + (r - j) = r: casts to give (j:R)+(r-j:R)=(r:R), the algebraic core of the shift split",
+        "module": "Mathlib.Data.Nat.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Chu-Vandermonde convolution $\\binom{m+n}{r}=\\sum_j\\binom{m}{j}\\binom{n}{r-j}$ (Chu Shih-Chieh 1303, Vandermonde 1772) has an exact analogue in the world of factorial powers, where the ordinary monomial $x^j$ is replaced by the rising factorial $x^{(j)}=x(x+1)\\cdots(x+j-1)$ or the falling factorial $x^{\\underline j}=x(x-1)\\cdots(x-j+1)$. In that world $(x+y)^{(r)}$ expands into $\\sum_j\\binom{r}{j}x^{(j)}y^{(r-j)}$ with the *same* binomial coefficients. This is the central identity of the umbral calculus (Blissard, Bell, and the Rota-Roman school of the 1970s) and of the classical finite-difference calculus: the rising/falling factorials are the analogues of monomials for the forward difference operator $\\Delta f(x)=f(x+1)-f(x)$, so this convolution is literally the binomial theorem for $\\Delta$. The parent gallery entry proved the identity for whole-number arguments $m,n$; the present entry lifts it to genuine polynomial identities valid for any elements $x,y$ of any commutative ring.",
+    "problemStatement": "Formalize the rising-factorial Vandermonde convolution $(x+y)^{(r)}=\\sum_{j=0}^{r}\\binom{r}{j}x^{(j)}y^{(r-j)}$ over an arbitrary commutative ring $R$ (with $x,y\\in R$), together with the falling-factorial mirror, recovering the numerical parent as the special case $x=m,y=n$.",
+    "text": "The rising factorial is defined recursively by risingFactorial x 0 = 1 and risingFactorial x (k+1) = risingFactorial x k * (x + k). The main theorem risingFactorial_add is proved by induction on r, mirroring Mathlib's add_pow: the successor step unfolds the outer factor, applies the inductive hypothesis, then splits the shift (x+y+r) = (x+j)+(y+(r-j)) — valid since j ≤ r forces (j:R)+(r-j:R)=(r:R) — producing two sums that recombine by Pascal's rule (Nat.choose_succ_succ) after reindexing with Finset.sum_range_succ'. The falling-factorial companion fallingFactorial_add is obtained from the rising form through the reflection x^{underline k} = (-1)^k (-x)^{(k)}, avoiding a second induction.",
+    "proofStrategy": "Induction on r following the architecture of Commute.add_pow. Base case r=0 is 1=1. In the successor step: (1) rewrite risingFactorial (x+y) (r+1) = risingFactorial (x+y) r * ((x+y)+r) and apply the inductive hypothesis; (2) distribute the shift over the sum and, term by term, split (x+y+r) into (x+j)+(y+(r-j)) using j ≤ r, turning each summand into risingFactorial x (j+1)·(...) + (...)·risingFactorial y (r-j+1); (3) peel the j=0 term of the target sum with Finset.sum_range_succ', apply Pascal's rule C(r+1,j+1)=C(r,j)+C(r,j+1) inside, and reindex so the two accumulated sums A and B match. The falling-factorial theorem reuses the rising result via the sign reflection, and a numerical bridge lemma identifies risingFactorial (m:R) k with the cast of Nat.ascFactorial m k.",
+    "keyInsights": [
+      "Over a general commutative ring the binomial coefficient C(r,j) is a natural number acting by Nat.cast; keeping casts coherent (Nat.cast_add, push_cast) is essential for the Pascal-rule recombination.",
+      "The shift split (x+y+r) = (x+j) + (y+(r-j)) is the ring-element analogue of the exponent bookkeeping n = j + (n-j) in the ordinary binomial theorem, and reduces to the ℕ fact j + (r-j) = r for j ≤ r.",
+      "Finset.sum_range_succ' (peel bottom + reindex) is the right tool for the rising-factorial shift, since the induction naturally produces summands indexed by j+1.",
+      "The reflection x^{underline k} = (-1)^k (-x)^{(k)} converts the falling-factorial identity into the rising one for free — the sign (-1)^r factors as (-1)^j·(-1)^{r-j} exactly matching the split of the summation index.",
+      "Mathlib has ascPochhammer/descPochhammer with a full succ/eval library but no ascPochhammer_add (binomial convolution), so this content is genuinely absent and must be proved, not merely rewritten."
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_succ: Pascal's rule",
+      "Finset.sum_range_succ' / Finset.sum_range_succ: range-sum peeling and reindexing",
+      "Nat.add_sub_cancel': j ≤ r ⇒ j + (r-j) = r"
+    ]
+  },
+  "conclusion": {
+    "summary": "A self-contained formalization of the Vandermonde convolution for rising and falling factorials over an arbitrary commutative ring: (x+y)^{(r)} = ∑_j C(r,j)·x^{(j)}·y^{(r-j)}, proved by an add_pow-style induction with an explicit Pascal-rule recombination, plus the falling-factorial mirror via the sign reflection and a numerical bridge to Nat.ascFactorial. 8 theorems, 2 definitions, 0 sorries, 0 axioms.",
+    "implications": "**Umbral calculus / finite differences**: This is the binomial theorem for the forward-difference operator Δf(x)=f(x+1)-f(x); every polynomial expands in the factorial-power basis, and this convolution is the product rule for that expansion. **Mathlib gap**: it supplies the missing ascPochhammer_add-style lemma at the level of evaluated ring elements. **Specialization**: setting x=m, y=n and applying the numerical bridge recovers the parent's ℕ-valued identity as a corollary.",
+    "openQuestions": [
+      "State and prove the identity at the polynomial level in R[X] for ascPochhammer R r, yielding a reusable Mathlib-shaped ascPochhammer_add lemma, and evaluate to recover the ring-element form.",
+      "Prove the q-analogue: the q-Vandermonde convolution for the q-rising factorial (x;q)_r over a commutative ring, deforming the Pascal recombination by the q-Pascal rule."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Graham, Ronald L.; Knuth, Donald E.; Patashnik, Oren",
+      "title": "Concrete Mathematics: A Foundation for Computer Science (2nd ed.), Ch. 2 (Sums) and Ch. 5 (Binomial Coefficients)",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "note": "Source of the falling/rising factorial power notation x^{underline k}, x^{overline k} and the Vandermonde convolution in finite calculus."
+    },
+    {
+      "authors": "Vandermonde, Alexandre-Théophile",
+      "title": "Mémoire sur des irrationnelles de différens ordres avec une application au cercle",
+      "year": "1772",
+      "venue": "Mémoires de l'Académie Royale des Sciences, Paris",
+      "note": "Classical Vandermonde convolution identity (anticipated by Chu Shih-Chieh, 1303)."
+    },
+    {
+      "authors": "Riordan, John",
+      "title": "Combinatorial Identities",
+      "year": "1968",
+      "venue": "Wiley",
+      "note": "Systematic treatment of Vandermonde-type convolutions and factorial-power identities."
+    },
+    {
+      "authors": "Comtet, Louis",
+      "title": "Advanced Combinatorics: The Art of Finite and Infinite Expansions",
+      "year": "1974",
+      "venue": "D. Reidel",
+      "note": "Rising/falling factorials (Pochhammer symbols) and their binomial convolutions."
+    },
+    {
+      "authors": "Roman, Steven",
+      "title": "The Umbral Calculus",
+      "year": "1984",
+      "venue": "Academic Press",
+      "note": "Finite-difference / umbral viewpoint: the identity is the binomial theorem for the forward-difference operator."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "ascPochhammer, descPochhammer, Nat.ascFactorial and Commute.add_pow (Mathlib.RingTheory.Polynomial.Pochhammer, Mathlib.Algebra.BigOperators)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Provides the Pochhammer polynomials and the ordinary binomial theorem this convolution generalizes; the falling/rising factorial Vandermonde convolution itself is not in Mathlib."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
+      "relationship": "parent",
+      "description": "Numerical falling-factorial Vandermonde over ℕ; this entry lifts it to arbitrary ring elements"
+    },
+    {
+      "targetId": "binomial-theorem-oq-03",
+      "relationship": "related",
+      "description": "Standard Vandermonde convolution vandermonde_range underlying the numerical parent"
+    },
+    {
+      "targetId": "arithmetic-series-oq-02-oq-01-oq-01",
+      "relationship": "related",
+      "description": "q-Vandermonde identity — q-deformation of this convolution"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "RisingFactorialVandermonde",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ01.lean",
+    "theoremCount": 8,
+    "definitionCount": 2
+  }
+}


### PR DESCRIPTION
## Enrichment pass

Verified entry `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-01` (rising/falling factorial Vandermonde convolution over a commutative ring) had a rich overview, conclusion, and 3 crossReferences but **no references**.

**Added** 6 targeted references (Concrete Mathematics for falling/rising factorial notation, Vandermonde 1772, Riordan, Comtet, Roman's umbral calculus, mathlib Pochhammer modules). meta.json 11.7 KB, within caps. No Lean source changed.