### PR TITLE
research(seeker): 7 diverse verified-parent OQ children to replenish pool

### DIFF
--- a/research/problems/algebraic-reals-meager-dense-gdelta-oq-03/problem.md
+++ b/research/problems/algebraic-reals-meager-dense-gdelta-oq-03/problem.md
@@ -1,0 +1,98 @@
+# Problem: Generically Liouville: A Comeagre Refinement Inside the Transcendental Gδ
+
+**Slug**: algebraic-reals-meager-dense-gdelta-oq-03
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: algebraic-reals-meager-dense-gdelta
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\{x:\mathrm{Liouville}\,x\}\ \text{is a dense }G_\delta \subseteq \{x:\neg\mathrm{IsAlgebraic}_\mathbb{Q}\,x\},\quad \{x:\neg\mathrm{IsAlgebraic}_\mathbb{Q} x \wedge \neg\mathrm{Liouville}\,x\}\ \text{is meagre}
+$$
+
+### Plain Language
+
+The parent shows the transcendentals are a dense Gδ (comeagre) in ℝ. Is this the sharpest such witness? No: the Liouville numbers form a strictly smaller dense Gδ contained in the transcendentals. Exhibit {x | Liouville x} as a comeagre subset of {x | ¬IsAlgebraic ℚ x}, and conclude the transcendental-but-not-Liouville reals are meagre — residually every real is not merely transcendental but Liouville.
+
+### Why This Matters
+
+Shows the transcendental dense-Gδ is NOT minimal: a strictly smaller natural comeagre set sits inside. Introduces Liouville numbers / Diophantine approximation and the non-minimality of the comeagre witness — untouched by oq-01 (Fσ dual) and oq-02 (constructive decreasing sequence).
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `algebraic-reals-meager-dense-gdelta` is verified (0-axiom) in the gallery and supplies the base result this question extends.
+- All Mathlib lemmas listed under References below were grep-confirmed to exist in the pinned Mathlib.
+
+### What's Still Open
+
+- The specific target theorems sketched below (currently `sorry`).
+
+### Our Goal
+
+Prove the target sketch below as a self-contained, verified (0-axiom) child of `algebraic-reals-meager-dense-gdelta`. Category: **extension**.
+
+## Target Lean Sketch
+
+```lean
+theorem liouville_comeagre_refines_transcendentals :
+    (IsGδ {x : ℝ | Liouville x} ∧ Dense {x : ℝ | Liouville x}) ∧
+    {x : ℝ | Liouville x} ⊆ {x : ℝ | ¬ IsAlgebraic ℚ x} ∧
+    IsMeagre {x : ℝ | ¬ IsAlgebraic ℚ x ∧ ¬ Liouville x} := by sorry
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `algebraic-reals-meager-dense-gdelta` | Parent: transcendentals are a dense Gδ / algebraics meagre | Baire category, residual sets |
+| `algebraic-reals-meager-dense-gdelta-oq-02` | Sibling: constructive decreasing sequence | explicit Gδ construction |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 7/10  |  **Tractability**: 9/10  |  **Tier**: B
+
+**Justification**: The required Mathlib primitives exist and the proof mirrors the parent's style; the sketch reduces to assembling named lemmas.
+
+### Suggested First Steps
+
+1. Gδ+dense clause: exact ⟨IsGδ.setOf_liouville, dense_liouville⟩.
+2. Inclusion: intro x hx; Liouville.transcendental gives Transcendental ℤ x; transport to ¬IsAlgebraic ℚ x via IsAlgebraic.transcendental_iff.
+3. Meagre clause: {¬alg ∧ ¬Liouville} ⊆ {¬Liouville} = {Liouville}ᶜ, meagre since {Liouville} ∈ residual (eventually_residual_liouville); close with IsMeagre.mono.
+
+## References
+
+### Mathlib
+
+- `IsGδ.setOf_liouville`, `dense_liouville`, `eventually_residual_liouville` — NumberTheory/Transcendental/Liouville/Residual.lean
+- `Liouville.transcendental : Transcendental ℤ x` — Liouville/Basic.lean
+- `IsAlgebraic.transcendental_iff` — RingTheory/Algebraic/Integral.lean (transfer ℤ ↔ ℚ)
+- `IsMeagre`, `IsMeagre.mono` — Topology/GDelta/Basic.lean
+- reuse parent `transcendentalReals_dense_isGδ` (import Proofs.AlgebraicRealsMeagerDenseGDelta)
+
+## Metadata
+
+```yaml
+tags:
+  - topology
+  - baire-category
+  - real-analysis
+  - descriptive-set-theory
+  - liouville-numbers
+  - transcendental-numbers
+  - comeagre-set
+  - diophantine-approximation
+related_proofs:
+  - algebraic-reals-meager-dense-gdelta
+  - algebraic-reals-meager-dense-gdelta-oq-02
+difficulty: low
+source: proof-suggestion
+created: 2026-06-30
+```

--- a/research/problems/alternating-series-boole-summation-oq-02/problem.md
+++ b/research/problems/alternating-series-boole-summation-oq-02/problem.md
@@ -1,0 +1,107 @@
+# Problem: Boole Summation in Normed Spaces: Finite Identity and Remainder Bound over Banach-Valued Sequences
+
+**Slug**: alternating-series-boole-summation-oq-02
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: alternating-series-boole-summation
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\Big\| \mathrm{altSum}\,a\,n\,m - \tfrac12\big((-1)^n a_n - (-1)^m a_m\big)\Big\| \le \tfrac12 \sum_{j=n}^{m-1} \|\Delta a_j\|,\qquad a:\mathbb{N}\to E
+$$
+
+### Plain Language
+
+The parent proves the finite Boole summation identity and total-variation bound only for real sequences. Generalize both to sequences a : ℕ → E valued in a normed ℝ-vector space E (e.g. E = ℂ, or a Banach space). Show the first-order identity altSum a n m = ½·((-1)^n·a_n − (-1)^m·a_m) − ½·altSum(Δa) n m over any ℝ-module, and the corresponding norm bound.
+
+### Why This Matters
+
+One engine then covers ℂ-valued, operator-valued, and Fourier/Dirichlet partial sums. The algebraic Boole identity is domain-agnostic; the honest scope is that the finite identity and remainder bound port, while the antitone/telescoping monotonicity bounds do NOT (E is unordered).
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `alternating-series-boole-summation` is verified (0-axiom) in the gallery and supplies the base result this question extends.
+- All Mathlib lemmas listed under References below were grep-confirmed to exist in the pinned Mathlib.
+
+### What's Still Open
+
+- The specific target theorems sketched below (currently `sorry`).
+
+### Our Goal
+
+Prove the target sketch below as a self-contained, verified (0-axiom) child of `alternating-series-boole-summation`. Category: **generalization**.
+
+## Target Lean Sketch
+
+```lean
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+def altSum (a : ℕ → E) (n m : ℕ) : E := ∑ j ∈ Finset.Ico n m, (-1:ℝ)^j • a j
+def fdiff (a : ℕ → E) (j : ℕ) : E := a (j+1) - a j
+
+theorem boole_first_normed (a : ℕ → E) {n m : ℕ} (h : n ≤ m) :
+    altSum a n m
+      = (1/2:ℝ) • ((-1:ℝ)^n • a n - (-1:ℝ)^m • a m) - (1/2:ℝ) • altSum (fdiff a) n m := by
+  sorry
+
+theorem altSum_sub_model_norm_le (a : ℕ → E) {n m : ℕ} (h : n ≤ m) :
+    ‖altSum a n m - (1/2:ℝ) • ((-1:ℝ)^n • a n - (-1:ℝ)^m • a m)‖
+      ≤ (1/2:ℝ) * ∑ j ∈ Finset.Ico n m, ‖fdiff a j‖ := by
+  sorry
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `alternating-series-boole-summation` | Parent: real Boole summation identity + bound | finite differences, summation by parts |
+| `alternating-series-boole-summation-oq-01` | Sibling: m→∞ limit passage (real case) | tsum, Filter.Tendsto |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 6/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: The required Mathlib primitives exist and the proof mirrors the parent's style; the sketch reduces to assembling named lemmas.
+
+### Suggested First Steps
+
+1. Port `altSum`/`fdiff`/`altSum_succ` to E, proving `altSum_succ` from `Finset.sum_Ico_succ_top`.
+2. Prove `boole_first_normed` by `Nat.le_induction`; in the successor step rewrite both altSums via altSum_succ, substitute the IH, close with `module` (handle (-1)^(m+1)•x via pow_succ/neg_smul).
+3. Derive the norm bound: rearrange to altSum − model = −½•altSum(Δa) n m, then chain `norm_smul`, `norm_sum_le`, and ‖(-1:ℝ)^j • Δaⱼ‖ = ‖Δaⱼ‖. Finish with a worked E = ℂ instantiation.
+
+## References
+
+### Mathlib
+
+- `Finset.sum_Ico_succ_top` — Algebra/BigOperators/Intervals.lean (drives the one-step recurrence; used by verified parent)
+- `Nat.le_induction` — induction on m ≥ n
+- `norm_sum_le` — Analysis/Normed/Group/Basic.lean (‖∑ f‖ ≤ ∑ ‖f‖)
+- `norm_smul` — Analysis/Normed/MulAction.lean (‖r • x‖ = ‖r‖ * ‖x‖)
+- `module` tactic — Tactic/Module.lean (closes the smul identity where the parent used `ring`)
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - series
+  - alternating-series
+  - boole-summation
+  - normed-space
+  - banach-space
+  - finite-difference
+  - remainder-bound
+related_proofs:
+  - alternating-series-boole-summation
+  - alternating-series-boole-summation-oq-01
+difficulty: low
+source: proof-suggestion
+created: 2026-06-30
+```

--- a/research/problems/factor-remainder-hasse-derivative-fq-oq-02/problem.md
+++ b/research/problems/factor-remainder-hasse-derivative-fq-oq-02/problem.md
@@ -1,0 +1,99 @@
+# Problem: The Global Kernel of the Ordinary-Derivative Test: derivative f = 0 ⇔ Frobenius expansion ⇔ p-th power over 𝔽_q
+
+**Slug**: factor-remainder-hasse-derivative-fq-oq-02
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: factor-remainder-hasse-derivative-fq
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{over }F,\ \mathrm{char}\,F=p:\quad D f = 0 \iff \exists g,\, f = \mathrm{expand}_p g;\qquad \text{over perfect }F:\quad D f = 0 \iff \exists h,\, f = h^p
+$$
+
+### Plain Language
+
+The parent shows the ordinary iterated-derivative test goes blind at order p; the sibling oq-01 quantifies the pointwise multiplicity gap. Which polynomials are globally invisible — killed by the first ordinary derivative? Over a characteristic-p field these are exactly the Frobenius expansions f = g(X^p), and over any perfect field (every 𝔽_q) exactly the p-th powers f = h^p. This pins down the ordinary derivative's kernel structurally, tying the parent's blindness to inseparability.
+
+### Why This Matters
+
+The classical inseparability ⇔ p-th-power criterion, freshly framed as the exact global kernel of the parent's ordinary-derivative test — blind at all orders ≥1 simultaneously — complementing the parent (pointwise multiplicity threshold) and oq-01 (overcounting gap).
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `factor-remainder-hasse-derivative-fq` is verified (0-axiom) in the gallery and supplies the base result this question extends.
+- All Mathlib lemmas listed under References below were grep-confirmed to exist in the pinned Mathlib.
+
+### What's Still Open
+
+- The specific target theorems sketched below (currently `sorry`).
+
+### Our Goal
+
+Prove the target sketch below as a self-contained, verified (0-axiom) child of `factor-remainder-hasse-derivative-fq`. Category: **extension**.
+
+## Target Lean Sketch
+
+```lean
+variable {F : Type*} [Field F] {p : ℕ} [Fact p.Prime] [CharP F p]
+
+theorem derivative_eq_zero_iff_expand (f : F[X]) :
+    Polynomial.derivative f = 0 ↔ ∃ g : F[X], f = Polynomial.expand F p g := by sorry
+
+theorem derivative_eq_zero_iff_pow (f : F[X]) [PerfectRing F p] :
+    Polynomial.derivative f = 0 ↔ ∃ h : F[X], f = h ^ p := by sorry
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `factor-remainder-hasse-derivative-fq` | Parent: Hasse derivative factor/remainder over 𝔽_q | Hasse derivative, Taylor expansion |
+| `factor-remainder-hasse-derivative-fq-oq-01` | Sibling: pointwise multiplicity overcounting gap | rootMultiplicity |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 7/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: The required Mathlib primitives exist and the proof mirrors the parent's style; the sketch reduces to assembling named lemmas.
+
+### Suggested First Steps
+
+1. derivative_eq_zero_iff_expand ⇐: rw derivative_expand, then (p:F)=0 via CharP.cast_eq_zero → mul_zero. ⇒: exact ⟨contract p f, (expand_contract p hf ‹p≠0›).symm⟩.
+2. Corollary ⇒: from f = expand p g, use surjective_frobenius + Polynomial.map_surjective to get h with map (frobenius F p) h = g; then f = expand p (map frob h) = map frob (expand p h) = h^p via map_expand + expand_char.
+3. Add concrete witnesses: X^p (blind, = expand p X) and a separable X − C a (not blind).
+
+## References
+
+### Mathlib
+
+- `Polynomial.derivative_expand` — Algebra/Polynomial/Expand.lean (derivative (expand R p f) = expand R p (derivative f) * (p * X^(p-1)); the (p:F)=0 factor kills the ⇐ direction)
+- `Polynomial.expand_contract` + `Polynomial.contract` — Expand.lean ([CharP R p][NoZeroDivisors R]) give ⇒ with g := contract p f
+- `Polynomial.map_expand`, `Polynomial.expand_char` — Expand.lean (map (frobenius R p)(expand R p f) = f^p) assemble the p-th-power corollary
+- `surjective_frobenius`; `PerfectRing.ofFiniteOfIsReduced` / `PerfectField.ofFinite` — FieldTheory/Perfect.lean (perfect-field instances for 𝔽_q)
+
+## Metadata
+
+```yaml
+tags:
+  - algebra
+  - polynomials
+  - hasse-derivative
+  - positive-characteristic
+  - finite-fields
+  - frobenius
+  - separability
+related_proofs:
+  - factor-remainder-hasse-derivative-fq
+  - factor-remainder-hasse-derivative-fq-oq-01
+difficulty: low
+source: proof-suggestion
+created: 2026-06-30
+```

--- a/research/problems/fourth-root-2-irrational-oq-03/problem.md
+++ b/research/problems/fourth-root-2-irrational-oq-03/problem.md
@@ -1,0 +1,100 @@
+# Problem: The Galois Closure of ℚ(⁴√2): [ℚ(⁴√2, i) : ℚ] = 8 via the Quadratic Step i ∉ ℝ ⊇ ℚ(⁴√2)
+
+**Slug**: fourth-root-2-irrational-oq-03
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: fourth-root-2-irrational
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+[\mathbb{Q}(\sqrt[4]{2},\, i) : \mathbb{Q}] = 8,\qquad \text{via }\ \mathbb{Q}\subset\mathbb{Q}(\sqrt[4]{2})\subset\mathbb{Q}(\sqrt[4]{2},i),\ 4\cdot 2=8
+$$
+
+### Plain Language
+
+The parent's OQ-01 asserts the splitting field of X⁴−2 is ℚ(⁴√2, i), of degree 8 with Galois group D₄. Formalize the degree half: model α = (⁴√2 : ℂ) via Complex.ofReal and prove [ℚ(α, i) : ℚ] = 8 by the tower ℚ ⊂ ℚ(α) ⊂ ℚ(α, i), where [ℚ(α):ℚ]=4 (reusing X⁴−2 irreducible) and [ℚ(α,i):ℚ(α)]=2 because i satisfies X²+1 but i ∉ ℚ(α) (that field is real).
+
+### Why This Matters
+
+Directly answers parent OQ-01's concrete degree claim [ℚ(⁴√2,i):ℚ]=8 and is distinct from oq-02, which stays inside ℝ with real radicals. The full D₄ Galois-group identification is left as the new downstream open question.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `fourth-root-2-irrational` is verified (0-axiom) in the gallery and supplies the base result this question extends.
+- All Mathlib lemmas listed under References below were grep-confirmed to exist in the pinned Mathlib.
+
+### What's Still Open
+
+- The specific target theorems sketched below (currently `sorry`).
+
+### Our Goal
+
+Prove the target sketch below as a self-contained, verified (0-axiom) child of `fourth-root-2-irrational`. Category: **extension**.
+
+## Target Lean Sketch
+
+```lean
+-- α : ℂ := ((2:ℝ) ^ ((1:ℝ)/4) : ℝ)  -- real fourth root, coerced to ℂ
+theorem i_notin_adjoin_fr2 : Complex.I ∉ ℚ⟮α⟯ := by sorry
+theorem finrank_adjoin_i_over_fr2 :
+    Module.finrank ℚ⟮α⟯ (ℚ⟮α⟯⟮Complex.I⟯) = 2 := by sorry
+theorem finrank_galois_closure :
+    Module.finrank ℚ ℚ⟮α, Complex.I⟯ = 8 := by sorry
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `fourth-root-2-irrational` | Parent: ⁴√2 irrational, X⁴−2 irreducible over ℚ | minimal polynomial, Eisenstein |
+| `fourth-root-2-irrational-oq-02` | Sibling: stays inside ℝ with real radicals | real subfield degrees |
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Significance**: 7/10  |  **Tractability**: 6/10  |  **Tier**: B
+
+**Justification**: The required Mathlib primitives exist and the proof mirrors the parent's style; the sketch reduces to assembling named lemmas.
+
+### Suggested First Steps
+
+1. Show ℚ⟮α⟯ ≤ (real subfield: Complex.ofReal's fieldRange as an IntermediateField ℚ ℂ) via adjoin_le_iff; conclude every z ∈ ℚ⟮α⟯ has z.im = 0, excluding i (I_im = 1).
+2. From i ∉ ℚ⟮α⟯ and i²+1=0, get X²+1 irreducible/monic over ℚ⟮α⟯ ⇒ minpoly = X²+1 ⇒ relative finrank 2.
+3. Combine [ℚ(α):ℚ]=4 (parent) with Module.finrank_mul_finrank; rewrite via adjoin_adjoin_left to reach 8.
+
+## References
+
+### Mathlib
+
+- `Module.finrank_mul_finrank` — LinearAlgebra/Dimension/Free.lean (tower 4·2=8)
+- `IntermediateField.adjoin.finrank` — FieldTheory/IntermediateField/Adjoin/Basic.lean
+- `IntermediateField.adjoin_adjoin_left` — Adjoin/Defs.lean (ℚ⟮α⟯⟮i⟯ = ℚ⟮{α,i}⟯)
+- `minpoly.eq_of_irreducible_of_monic` — FieldTheory/Minpoly/Field.lean (X²+1 = minpoly i)
+- `Complex.I_sq`, `Complex.ofReal_im`, `Complex.I_im` — Data/Complex/Basic.lean; `Subfield.fieldRange`
+- Reuse parent `irreducible_X4_sub_2_rat` via import Proofs.FourthRoot2Degree4
+
+## Metadata
+
+```yaml
+tags:
+  - irrationality
+  - field-theory
+  - galois-theory
+  - splitting-field
+  - minimal-polynomial
+  - number-theory
+  - nth-roots
+related_proofs:
+  - fourth-root-2-irrational
+  - fourth-root-2-irrational-oq-02
+difficulty: medium
+source: proof-suggestion
+created: 2026-06-30
+```

--- a/research/problems/halting-problem-oq-02/problem.md
+++ b/research/problems/halting-problem-oq-02/problem.md
@@ -1,0 +1,106 @@
+# Problem: Undecidability of the Totality Problem (Rice's Theorem Instance)
+
+**Slug**: halting-problem-oq-02
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: halting-problem
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\neg\,\mathrm{ComputablePred}\big(\lambda c.\ c\in\mathrm{TotalCodes}\big),\qquad \mathrm{TotalCodes}=\{c:\forall n,\ (\mathrm{eval}\ c\ n).\mathrm{Dom}\}
+$$
+
+### Plain Language
+
+The parent flags Rice's theorem as the universal generalization of halting undecidability. Instantiate it on a fresh, non-halting-set property: is the totality set — codes whose partial function is defined on every input — decidable? Prove it is not, by showing this class is extensional but neither empty nor everything.
+
+### Why This Matters
+
+A named classic — 'does a program halt on all inputs' — genuinely distinct from the parent's fixed-input halting question, sibling oq-01 (sound computable approximators + arithmetical hierarchy), and sibling oq-03 (relativized/oracle halting). Direct application of Mathlib's ComputablePred.rice₂ to a concrete extensional code-class.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `halting-problem` is verified (0-axiom) in the gallery and supplies the base result this question extends.
+- All Mathlib lemmas listed under References below were grep-confirmed to exist in the pinned Mathlib.
+
+### What's Still Open
+
+- The specific target theorems sketched below (currently `sorry`).
+
+### Our Goal
+
+Prove the target sketch below as a self-contained, verified (0-axiom) child of `halting-problem`. Category: **extension**.
+
+## Target Lean Sketch
+
+```lean
+open Nat.Partrec Nat.Partrec.Code ComputablePred
+
+def TotalCodes : Set Code := {c | ∀ n, (eval c n).Dom}
+
+theorem totalCodes_extensional (cf cg : Code) (h : eval cf = eval cg) :
+    cf ∈ TotalCodes ↔ cg ∈ TotalCodes := by
+  simp only [TotalCodes, Set.mem_setOf_eq, h]
+
+theorem totalCodes_ne_empty : TotalCodes ≠ ∅ := by sorry   -- witness: Code.const 0
+theorem totalCodes_ne_univ  : TotalCodes ≠ Set.univ := by sorry -- witness: exists_code of Nat.Partrec.none
+
+theorem totality_undecidable : ¬ ComputablePred (fun c : Code => c ∈ TotalCodes) := by
+  intro h
+  rcases (rice₂ TotalCodes totalCodes_extensional).1 h with he | hu
+  · exact totalCodes_ne_empty he
+  · exact totalCodes_ne_univ hu
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `halting-problem` | Parent: undecidability of the halting problem via diagonalization | diagonalization, ComputablePred |
+| `halting-problem-oq-01` | Sibling: sound computable approximators + arithmetical hierarchy | Nat.Partrec |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 7/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: The required Mathlib primitives exist and the proof mirrors the parent's style; the sketch reduces to assembling named lemmas.
+
+### Suggested First Steps
+
+1. totalCodes_ne_empty: Code.const 0 ∈ TotalCodes since eval_const makes every (eval (const 0) n).Dom hold → Set.nonempty_iff_ne_empty.
+2. totalCodes_ne_univ: get c from exists_code.mp Nat.Partrec.none; eval c 0 = Part.none is not Dom, so c ∉ TotalCodes, contradicting Set.univ.
+3. Assemble totality_undecidable via rice₂ + rcases; run #print axioms totality_undecidable to confirm 0-axiom.
+
+## References
+
+### Mathlib
+
+- `ComputablePred.rice₂` — Computability/Halting.lean (ComputablePred (·∈C) ↔ C = ∅ ∨ C = Set.univ for extensional C)
+- `Nat.Partrec.Code.eval_const` — PartrecCode.lean (total witness: eval (Code.const n) m = Part.some n)
+- `Nat.Partrec.Code.exists_code` + `Nat.Partrec.none` — PartrecCode.lean / Partrec.lean (nowhere-defined witness)
+- `Nat.Partrec.Code.instDenumerable` — PartrecCode.lean (Primcodable Code, so ComputablePred over Code typechecks)
+
+## Metadata
+
+```yaml
+tags:
+  - computability
+  - undecidability
+  - rice-theorem
+  - partial-recursive
+  - diagonalization
+related_proofs:
+  - halting-problem
+  - halting-problem-oq-01
+difficulty: low
+source: proof-suggestion
+created: 2026-06-30
+```

--- a/research/problems/shapley-folkman-oq-04/problem.md
+++ b/research/problems/shapley-folkman-oq-04/problem.md
@@ -1,0 +1,102 @@
+# Problem: Shapley-Folkman Refined: Excess Bounded by the Number of Non-Convex Summands
+
+**Slug**: shapley-folkman-oq-04
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: shapley-folkman
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\mathrm{excessIndices}(D)\subseteq \{i\in t : \neg\,\mathrm{Convex}\,\mathbb{R}\,(S\,i)\};\quad |\mathrm{excessIndices}\,D| \le \min\big(\dim_\mathbb{R} E,\ |\{i\in t : \neg\mathrm{Convex}\,(S i)\}|\big)
+$$
+
+### Plain Language
+
+The parent bounds the number of convexified summands by finrank ℝ E, independent of which sets are convex. But a convex S_i never needs convexification. Show the excess indices are contained in the non-convex indices, yielding the sharper bound excessIndices.card ≤ min(finrank ℝ E, #{i ∈ t : ¬Convex (S i)}). When only k of N ≫ k summands are non-convex, excess is bounded by k, not by dimension.
+
+### Why This Matters
+
+A standard, genuinely useful sharpening: the dimension bound is loose when few summands are non-convex, yet economically the truly non-convex agents are what matter. The core inclusion is a one-lemma consequence of Convex.convexHull_eq and reuses the parent's Decomposition/excessIndices directly.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `shapley-folkman` is verified (0-axiom) in the gallery and supplies the base result this question extends.
+- All Mathlib lemmas listed under References below were grep-confirmed to exist in the pinned Mathlib.
+
+### What's Still Open
+
+- The specific target theorems sketched below (currently `sorry`).
+
+### Our Goal
+
+Prove the target sketch below as a self-contained, verified (0-axiom) child of `shapley-folkman`. Category: **extension**.
+
+## Target Lean Sketch
+
+```lean
+import Proofs.ShapleyFolkman
+open ShapleyFolkman
+variable {E : Type*} [AddCommGroup E] [Module ℝ E]
+
+theorem excessIndices_subset_nonConvex {ι} {S : ι → Set E} {t : Finset ι} {x : E}
+    (D : Decomposition S t x) :
+    D.excessIndices ⊆ t.filter (fun i => ¬ Convex ℝ (S i)) := by sorry
+
+theorem shapley_folkman_nonConvex_bound [FiniteDimensional ℝ E]
+    {ι} {S : ι → Set E} {t : Finset ι} {x : E} (D : Decomposition S t x) :
+    D.excessIndices.card
+      ≤ min (Module.finrank ℝ E) (t.filter (fun i => ¬ Convex ℝ (S i))).card := by sorry
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `shapley-folkman` | Parent: Shapley-Folkman lemma, excess bounded by dimension | convex hull, Carathéodory, Minkowski sum |
+| `shapley-folkman-oq-03` | Sibling | convexification bounds |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 6/10  |  **Tractability**: 8/10  |  **Tier**: B
+
+**Justification**: The required Mathlib primitives exist and the proof mirrors the parent's style; the sketch reduces to assembling named lemmas.
+
+### Suggested First Steps
+
+1. Prove excessIndices_subset_nonConvex: take i ∈ excessIndices (i ∈ t, point i ∉ S i); by contradiction if Convex ℝ (S i) then Convex.convexHull_eq rewrites mem_convexHull to point i ∈ S i — contradiction. Membership via Finset.mem_filter.
+2. Get excessIndices.card ≤ (t.filter ¬Convex).card via Finset.card_le_card.
+3. Combine with parent shapley_folkman (card ≤ finrank) using le_min; add a corollary example (k non-convex among N ⇒ excess ≤ k).
+
+## References
+
+### Mathlib
+
+- `Convex.convexHull_eq` — Analysis/Convex/Hull.lean (Convex ℝ s → convexHull ℝ s = s)
+- `subset_convexHull` — Analysis/Convex/Hull.lean
+- parent `shapley_folkman` (Decomposition → excessIndices.card ≤ finrank) — proofs/Proofs/ShapleyFolkman.lean
+- `Finset.filter`, `Finset.card_le_card`, `le_min` — core/Mathlib
+
+## Metadata
+
+```yaml
+tags:
+  - convex-analysis
+  - combinatorics
+  - minkowski-sum
+  - economics
+  - caratheodory
+related_proofs:
+  - shapley-folkman
+  - shapley-folkman-oq-03
+difficulty: low
+source: proof-suggestion
+created: 2026-06-30
+```

--- a/research/problems/taylor-theorem-oq-04/problem.md
+++ b/research/problems/taylor-theorem-oq-04/problem.md
@@ -1,0 +1,112 @@
+# Problem: Taylor Series Convergence of sin and cos via the Uniform Derivative Bound
+
+**Slug**: taylor-theorem-oq-04
+**Created**: 2026-06-30
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: taylor-theorem
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+|\sin x - T_n(x)| \le \frac{|x|^{n+1}}{n!} \xrightarrow{n\to\infty} 0,\qquad T_n = \text{taylorWithinEval }\sin\, n\, [0,x]\, 0
+$$
+
+### Plain Language
+
+Prove that the Taylor series of sin and cos converges to the function at every real point, using the *bounded-derivatives* mechanism (distinct from the sibling children): because every iterated derivative of sin/cos is uniformly bounded by 1, the Lagrange/uniform remainder bound gives |f(x) - T_n(x)| <= |x|^{n+1}/n! -> 0. This is the classic 'entire function with uniformly bounded derivatives => everywhere-convergent Taylor series' argument.
+
+### Why This Matters
+
+The uniform-derivative-bound technique is a fundamentally different route to convergence than sibling oq-02 (abstract formal power series) or oq-03 (exp via NormedSpace.exp summability). It packages the recognizable alternating-series headline sin x = sum (-1)^k x^{2k+1}/(2k+1)! from a clean remainder estimate.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `taylor-theorem` is verified (0-axiom) in the gallery and supplies the base result this question extends.
+- All Mathlib lemmas listed under References below were grep-confirmed to exist in the pinned Mathlib.
+
+### What's Still Open
+
+- The specific target theorems sketched below (currently `sorry`).
+
+### Our Goal
+
+Prove the target sketch below as a self-contained, verified (0-axiom) child of `taylor-theorem`. Category: **extension**.
+
+## Target Lean Sketch
+
+```lean
+open Set Filter Topology Nat
+
+theorem sin_taylor_remainder_le (x : ℝ) (hx : 0 < x) (n : ℕ) :
+    |Real.sin x - taylorWithinEval Real.sin n (Icc 0 x) 0 x| ≤ x ^ (n + 1) / n ! := by
+  have hbound : ∀ y ∈ Icc (0:ℝ) x,
+      ‖iteratedDerivWithin (n + 1) Real.sin (Icc 0 x) y‖ ≤ 1 := by
+    intro y hy
+    rw [Real.iteratedDerivWithin_sin_Icc _ hx hy, Real.norm_eq_abs]
+    exact Real.abs_iteratedDeriv_sin_le_one _ y
+  have := taylor_mean_remainder_bound (f := Real.sin) (a := 0) (b := x) (C := 1)
+    hx.le Real.contDiff_sin.contDiffOn (right_mem_Icc.2 hx.le) hbound
+  simpa [Real.norm_eq_abs, abs_of_nonneg hx.le] using this
+
+theorem sin_taylor_remainder_tendsto_zero (x : ℝ) (hx : 0 < x) :
+    Tendsto (fun n => Real.sin x - taylorWithinEval Real.sin n (Icc 0 x) 0 x)
+      atTop (nhds 0) := by sorry   -- squeeze with x^{n+1}/n! → 0
+
+theorem cos_taylor_remainder_le (x : ℝ) (hx : 0 < x) (n : ℕ) :
+    |Real.cos x - taylorWithinEval Real.cos n (Icc 0 x) 0 x| ≤ x ^ (n + 1) / n ! := by sorry
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `taylor-theorem` | Parent: Taylor's theorem with Lagrange remainder | Taylor polynomial, iterated derivatives |
+| `taylor-theorem-oq-03` | Sibling: exp convergence via summability (different technique) | NormedSpace.exp |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 6/10  |  **Tractability**: 9/10  |  **Tier**: B
+
+**Justification**: The required Mathlib primitives exist and the proof mirrors the parent's style; the sketch reduces to assembling named lemmas.
+
+### Suggested First Steps
+
+1. Prove `sin_taylor_remainder_le` as sketched (`taylor_mean_remainder_bound` + `iteratedDerivWithin_sin_Icc` + `abs_iteratedDeriv_sin_le_one`).
+2. Prove x^{n+1}/n! → 0 from `summable_pow_div_factorial` (factor x·(x^n/n!)), then `squeeze_zero` against the bound for `_tendsto_zero`.
+3. Mirror for cos; add the coefficient-pattern corollary sin x = Σ (−1)^k x^{2k+1}/(2k+1)! via `taylor_within_apply` + odd/even iterated-derivative lemmas.
+
+## References
+
+### Mathlib
+
+- `Real.abs_iteratedDeriv_sin_le_one`, `Real.abs_iteratedDeriv_cos_le_one` — Analysis/SpecialFunctions/Trigonometric/Deriv.lean (the uniform bound |fⁿ| ≤ 1)
+- `Real.iteratedDerivWithin_sin_Icc`, `..._cos_Icc` — same file (bridge iteratedDerivWithin → iteratedDeriv on Icc)
+- `Real.contDiff_sin`, `Real.contDiff_cos` — same file
+- `taylor_mean_remainder_bound` — Analysis/Calculus/Taylor.lean (engine: ‖f x − Tₙ‖ ≤ C·(x−a)^{n+1}/n!)
+- `taylorWithinEval`, `taylor_within_apply` — Analysis/Calculus/Taylor.lean
+- `summable_pow_div_factorial` — Analysis/SpecificLimits/Normed.lean (gives x^{n+1}/n! → 0; squeeze via `squeeze_zero`)
+
+## Metadata
+
+```yaml
+tags:
+  - calculus
+  - analysis
+  - taylor-series
+  - trigonometric-functions
+  - convergence
+  - lagrange-remainder
+related_proofs:
+  - taylor-theorem
+  - taylor-theorem-oq-03
+difficulty: low
+source: proof-suggestion
+created: 2026-06-30
+```


### PR DESCRIPTION
## Summary

The Seeker's **effective** candidate pool had drained to ~1 usable problem. Nominal count read 45 available, but ~37 of those already have active `research/problems/<slug>/` directories (freshly populated today, 10–13 KB each) — i.e. researchers are already working them. This PR replenishes with **7 fresh depth-1 open-question children**, one per distinct domain, each spawned from a **verified 0-axiom** gallery parent.

Each child was designed by a dedicated subagent that read the parent + existing siblings (dedup) and **grep-confirmed every cited Mathlib lemma exists** in the pinned Mathlib before drafting.

| Slug | Domain | Question | Key Mathlib |
|------|--------|----------|-------------|
| `taylor-theorem-oq-04` | calculus | sin/cos Taylor convergence via the uniform derivative bound | `taylor_mean_remainder_bound`, `Real.abs_iteratedDeriv_sin_le_one` |
| `alternating-series-boole-summation-oq-02` | analysis | Boole summation over normed/Banach-valued sequences | `module` tactic, `norm_sum_le`, `Finset.sum_Ico_succ_top` |
| `factor-remainder-hasse-derivative-fq-oq-02` | algebra | global kernel of the ordinary-derivative test = Frobenius expansions / p-th powers | `Polynomial.derivative_expand`, `expand_contract`, `expand_char` |
| `fourth-root-2-irrational-oq-03` | irrationality | Galois-closure degree `[ℚ(⁴√2, i):ℚ] = 8` via the real-subfield quadratic step | `Module.finrank_mul_finrank`, `IntermediateField.adjoin.finrank` |
| `algebraic-reals-meager-dense-gdelta-oq-03` | topology | Liouville comeagre refinement inside the transcendental Gδ | `eventually_residual_liouville`, `Liouville.transcendental`, `IsMeagre.mono` |
| `shapley-folkman-oq-04` | convex-analysis | excess bounded by the number of non-convex summands | `Convex.convexHull_eq`, parent `shapley_folkman` |
| `halting-problem-oq-02` | computability | undecidability of the totality problem | `ComputablePred.rice₂`, `Code.eval_const`, `exists_code` |

## Guardrails

- All 7 slugs are **depth-1** (`-oq-NN` once) → OQ-chain depth/repeat guards pass trivially.
- Each verified distinct from existing siblings (no content dedup violations).
- `validate-seeker-stubs.ts` **PASS** for all 7 (no template placeholders).
- Registered in `research/db/knowledge.db` and synced to the candidate pool (local, gitignored — not in this diff).

## Notes

Only the git-tracked `problem.md` files are included. The DB and `candidate-pool.json` are local/gitignored and regenerated by the deployer; they were updated on the seeker host so researchers can claim these immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
