### PR TITLE
Enrich ballot-problem cluster: add references to 16 OQ-child entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -33,6 +33,26 @@
       "Disjoint-pairs example: three pairs {2i, 2i+1} for i=0,1,2"
     ]
   },
+  "references": [
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Vol. 1",
+      "year": "2012",
+      "venue": "2nd ed., Cambridge University Press"
+    },
+    {
+      "authors": "Feller, William",
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. I",
+      "year": "1968",
+      "venue": "3rd ed., Wiley"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Set.ncard, Set.PairwiseDisjoint and Set.ncard_biUnion; Mathlib.Data.Set.Card",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The problem of counting a disjoint union of uniform sets arises across combinatorics, group theory, and probability. The classical result that a group $G$ has order $|G| = k \\cdot |G/H|$ when every coset $gH$ has exactly $k$ elements is the prototypical example. In Lean 4's Mathlib, `Set.ncard_biUnion` gives the general sum formula for disjoint unions, but as of Mathlib4 there is no direct corollary for the *uniform* case — the gap this entry fills. The ballot problem chain (initiated in this gallery) provided the immediate motivation: fiber counting under a multi-candidate permutation map reduces exactly to this uniform-union structure, and the extracted lemma is clean enough to stand on its own in Mathlib.",
     "problemStatement": "Given a finite index set $I$, a family of sets $s : \\iota \\to \\mathrm{Set}\\,\\alpha$ that is pairwise disjoint on $I$, with each $s(i)$ finite and $|s(i)| = k$, prove that $\\left|\\bigcup_{i \\in I} s(i)\\right| = k \\cdot |I|$. Equivalently: a disjoint union of $n$ sets each of size $k$ has total size $kn$.",

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-02/meta.json
@@ -37,6 +37,26 @@
       "uniformOn_union_transfer: transfer holds for P ∪ Q (union events)"
     ]
   },
+  "references": [
+    {
+      "authors": "Feller, William",
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. I",
+      "year": "1968",
+      "venue": "3rd ed., Wiley"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Vol. 1",
+      "year": "2012",
+      "venue": "2nd ed., Cambridge University Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "ProbabilityTheory.uniformOn and conditional probability on finite sets; Mathlib.Probability.UniformOn",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The classical ballot problem (Bertrand 1887, Désiré André 1887) asks for the probability that candidate A stays strictly ahead of B throughout the counting of a ballot. The modern treatment via Mathlib's `ProbabilityTheory.uniformOn` reformulates this combinatorially: ballot sequences form a finite set with a uniform measure, and the ballot theorem follows from a fiber-transfer argument showing that the projection onto final tallies preserves conditional probabilities.\n\nThe OQ chain ballot-problem-oq-01 through oq-01-oq-02-oq-01 progressively abstracted this argument: OQ-01 proved the classical result, OQ-01-OQ-02 proved the multi-candidate generalization, and OQ-01-OQ-02-OQ-01 extracted the key mechanism as `uniformOn_fiber_transfer` — showing that the ballot projection preserves uniformOn for one specific event. This final OQ-01-OQ-02-OQ-01-OQ-02 asks the natural mathematical question: is the fiber-transfer result for one event actually a *universal* property?\n\nThe answer YES places the ballot probability argument in the general theory of probability-preserving maps. In measure theory, a measure-preserving map between probability spaces satisfies $\\mu(f^{-1}(E)) = \\nu(E)$ for ALL measurable events E — not just some special one. The equal-fiber surjection condition is precisely the discrete-finite analog: $|A \\cap f^{-1}(\\{t\\})| = k$ for all $t \\in T$ is the condition that makes $f$ an isomorphism of discrete probability spaces (under `uniformOn`). The passage from singleton events to all events is enabled by Finset sum additivity: $|A \\cap f^{-1}(P)| = \\sum_{t \\in P} |A \\cap f^{-1}(\\{t\\})| = k|P|$, and dividing by $|A| = k|T|$ cancels the fiber-size factor $k$. This theorem is the discrete-finite-set instance of the general pushforward measure identity $f_* \\mu = \\nu$.",
     "problemStatement": "Can the uniformOn_fiber_transfer pattern be generalized: if a surjective map between finite probability spaces has uniform fibers, does it preserve all event probabilities (not just uniformOn)?",

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -34,6 +34,26 @@
       "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean"
     ]
   },
+  "references": [
+    {
+      "authors": "Feller, William",
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. I",
+      "year": "1968",
+      "venue": "3rd ed., Wiley"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Vol. 1",
+      "year": "2012",
+      "venue": "2nd ed., Cambridge University Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "ProbabilityTheory.uniformOn; fiber cardinality via Set.ncard; Mathlib.Probability.UniformOn",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The ballot problem originates with Joseph Bertrand (1887), who asked for the probability that a winning candidate leads throughout the count. The classical formula $(a-b)/(a+b)$ was proved elegantly by Désiré André using the reflection principle. The multi-candidate generalization asks: when one candidate faces $m-1$ opponents, does the same formula apply? The answer is yes, because only the total opponent vote count matters, not its distribution among opponents. The parent file (BallotProblemOQ01OQ02) established this reduction via a projection-and-fiber argument, proving that all fibers have equal cardinality through an explicit fiberSwap bijection. However, a gap remained: translating the combinatorial fact $|\\text{fiber}(t_1)| = |\\text{fiber}(t_2)|$ into the measure-theoretic statement $\\text{uniformOn}(\\text{MCS}, \\text{MSP}) = \\text{uniformOn}(\\text{CS}, \\text{SP})$. This file provides that bridge, using Set.ncard_biUnion for the cardinality decomposition and ENNReal.div_eq_div_iff for the ratio cancellation.",
     "problemStatement": "Prove uniformOn_fiber_transfer: the uniformOn probability of multiStaysPositive over multiCountedSequence equals the uniformOn probability of staysPositive over countedSequence.",

--- a/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
@@ -45,6 +45,32 @@
       }
     ]
   },
+  "references": [
+    {
+      "authors": "Bertrand, Joseph",
+      "title": "Solution d'un problème",
+      "year": "1887",
+      "venue": "Comptes Rendus de l'Académie des Sciences 105, 369"
+    },
+    {
+      "authors": "André, Désiré",
+      "title": "Solution directe du problème résolu par M. Bertrand",
+      "year": "1887",
+      "venue": "Comptes Rendus de l'Académie des Sciences 105, 436–437"
+    },
+    {
+      "authors": "Feller, William",
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. I",
+      "year": "1968",
+      "venue": "3rd ed., Wiley"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "the ballot problem, ProbabilityTheory.ballot; Mathlib.Probability.Ballot",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The ballot problem originated with Bertrand (1887) and Désiré André's reflection principle proof (also 1887). It is Wiedijk's Famous Theorems #30 and appears in Mathlib as Archive.Wiedijk100Theorems.BallotProblem. The problem: given a > b votes, the probability that candidate A leads throughout the counting is (a-b)/(a+b). This elegant formula was explained independently by the cycle lemma (Dvoretzky-Motzkin 1947): a random cyclic shift of the vote sequence has the leading property with probability exactly (a-b)/(a+b).\n\nThe multi-candidate extension asks: with m ≥ 2 candidates (candidate 0 has a votes, all others combined have b votes), does the probability of candidate 0 leading all opponents combined throughout still equal (a-b)/(a+b)? The answer is YES, proved via projection: the leading condition depends only on the ±1 pattern (who gets each vote, not which opponent gets it), and all fibers of this projection have equal size (the multinomial coefficient b!/(a₁!·...·aₘ₋₁!)), so uniform probability is preserved.\n\nThe harder question — full ordering probability for m candidates with fixed vote counts — involves non-intersecting lattice paths and the Lindström-Gessel-Viennot lemma (1973), giving a determinantal formula det||(aᵢ-aⱼ)/(aᵢ+aⱼ)||. This file states but does not prove the full ordering result.",
     "problemStatement": "In an election with m ≥ 2 candidates where candidate 0 receives a votes and candidates 1,...,m-1 collectively receive b votes (a > b), prove that P(candidate 0 leads all opponents combined throughout the count) = (a-b)/(a+b).",

--- a/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
@@ -44,6 +44,26 @@
     "definitionCount": 3,
     "mathlib_version": "4.26.0"
   },
+  "references": [
+    {
+      "authors": "Chung, Kai Lai and Feller, William",
+      "title": "On fluctuations in coin-tossing",
+      "year": "1949",
+      "venue": "Proceedings of the National Academy of Sciences 35(10), 605–608"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "venue": "Cambridge University Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Catalan numbers and Dyck paths; Mathlib.Combinatorics.Catalan",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The combinatorial setting traces to W. A. Whitworth's *Choice and Chance* (1879) and Joseph Bertrand's classical 1887 ballot problem: in how many ways can the votes for two candidates be counted so that one always leads? Désiré André's 1887 reflection-principle proof (the same year as Bertrand's note in *Comptes Rendus*) gave the modern $\\binom{2n}{n} - \\binom{2n}{n-1}$ formula. The *cycle lemma* — that exactly one cyclic rotation of any sequence with positive sum has all positive prefix sums — was first stated explicitly by Aryeh Dvoretzky and Theodore Motzkin in 1947 (\"A problem of arrangements\", *Duke Math. J.*) and is the structural backbone of every modern Catalan / ballot-style enumeration. The Chung-Feller theorem appeared in K. L. Chung and W. Feller's 1949 paper \"On fluctuations in coin-tossing\" (*Proc. Nat. Acad. Sci.*), strengthening the ballot result: among all balanced ±1 paths of length $2n$, those with exactly $k$ upsteps above the axis are *equinumerous* for every $k \\in \\{0,1,\\ldots,n\\}$, each class containing exactly $C_n = \\binom{2n}{n}/(n+1)$ paths. This gives a *combinatorial* — not just generating-function — proof that $|{\\text{Dyck paths}}| = C_n$, by counting balanced paths in two ways. The proof presented here mechanizes the explicit bijection (used by Stanley in *Catalan Numbers* §1.6.1; called the \"second proof\" on Wikipedia): prepend 1 to a balanced path $l$, rotate by the *rightmost minimum* position, take the tail. The rightmost-minimum choice is the unique rotation making the tail a Dyck path — exactly the cycle-lemma content. This entry answers OQ-01 of `ballot-problem-oq-01-oq-04` (\"Can we prove the bijection explicitly?\") with a complete, verified construction, eliminating the `chung_feller_uniform` axiom that the parent entry previously used.",
     "problemStatement": "**Chung-Feller theorem**: For any n ≥ 1 and any j, k ∈ {0,...,n}:\n|{balanced paths of length 2n and type j}| = |{balanced paths of length 2n and type k}|\n(where 'type j' means the path has exactly j upsteps above the horizontal axis).\n\nFormalized as: `chung_feller_uniform'`.",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -58,6 +58,32 @@
       "Suffix-as-`Sym` packaging (S35, this PR): one private def + one private lemma bundling the S34 `_drop_card` / `_drop_le` lemmas (PR #17695, merged) into a single `Sym (Fin n) (c - j)` value with built-in submultiset witness against `M.1`. `rotateSortedListSuffixSym M k j := ⟨((rotateSortedList M k).drop j : Multiset _), rotateSortedList_drop_card M k j⟩` carries the cardinality witness in the `.2` field; `rotateSortedListSuffixSym_le` re-exposes the `≤ M.1` submultiset witness via `.1` projection (one-line `rotateSortedList_drop_le M k j`). Symmetric counterpart of in-flight PR #17680 `rotateSortedListPrefixSym` (which packages the prefix half under `hj : j ≤ c`); together the two `Sym`-level packagings provide the forward direction of the 2B.4 refined-codomain bijection at the typed-cardinality level. No precondition needed here because `Sym (Fin n) 0` canonically handles the `j ≥ c` boundary (truncated `Nat` subtraction). Net sorry count unchanged at 2; 0 axioms; +1 def + 1 lemma (44 → 45 by the `@[simp]`-excluded canonical convention from PR #17518/PR #17569; 10 → 11 defs), +50 lines (2031 → 2081). Build-verification status: pending (parent OQ03OQ02 break per `feedback_researcher_ballot_oq03oq02_parent_break.md` 2026-05-09)."
     ]
   },
+  "references": [
+    {
+      "authors": "Macdonald, Ian G.",
+      "title": "Symmetric Functions and Hall Polynomials",
+      "year": "1995",
+      "venue": "2nd ed., Oxford University Press"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Vol. 2",
+      "year": "1999",
+      "venue": "Cambridge Studies in Advanced Mathematics 62, Cambridge University Press"
+    },
+    {
+      "authors": "Sagan, Bruce E.",
+      "title": "The Symmetric Group: Representations, Combinatorial Algorithms, and Symmetric Functions",
+      "year": "2001",
+      "venue": "2nd ed., Graduate Texts in Mathematics 203, Springer"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "MvPolynomial and symmetric functions; Mathlib.RingTheory.MvPolynomial.Symmetric",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "Carl Gustav Jacob Jacobi stated the identity bearing his name in 1841, and Nicola Trudi independently rediscovered it in 1864. The formula $s_\\lambda = \\det[h_{\\lambda_i - i + j}]$ expresses Schur polynomials as determinants of complete homogeneous symmetric polynomials $h_n$. Issai Schur (1901–1911) developed the systematic theory connecting these polynomials to the representation theory of GL(n): each $s_\\lambda$ is the character of the irreducible polynomial representation indexed by partition $\\lambda$. This dual algebraic/combinatorial nature — both a ring-theoretic determinant formula and a character — makes the Jacobi-Trudi identity central to modern algebraic combinatorics. The combinatorial proof via the Lindström-Gessel-Viennot (LGV) lemma was developed by Gessel and Viennot in 1985, completing the picture by showing semistandard Young tableaux (SSYT) biject with non-intersecting lattice path systems. Macdonald's 1979 book 'Symmetric Functions and Hall Polynomials' systematized these connections and remains the standard reference.",
     "problemStatement": "Formalize the definition of Schur polynomials via the Jacobi-Trudi determinant formula and prove their key properties: symmetry, base cases, and the connection to the LGV lemma infrastructure already formalized in the parent gallery proofs.",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01/meta.json
@@ -32,6 +32,32 @@
       "jacobi_trudi_interpretation: LGV interpretation of Jacobi-Trudi identity"
     ]
   },
+  "references": [
+    {
+      "authors": "Lindström, Bernt",
+      "title": "On the vector representations of induced matroids",
+      "year": "1973",
+      "venue": "Bulletin of the London Mathematical Society 5(1), 85–90"
+    },
+    {
+      "authors": "Gessel, Ira and Viennot, Gérard",
+      "title": "Binomial determinants, paths, and hook length formulae",
+      "year": "1985",
+      "venue": "Advances in Mathematics 58(3), 300–321"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Vol. 2",
+      "year": "1999",
+      "venue": "Cambridge Studies in Advanced Mathematics 62, Cambridge University Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Matrix.det and path-count matrices; Mathlib.LinearAlgebra.Matrix.Determinant",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The Lindström-Gessel-Viennot (LGV) lemma (Lindström 1973, Gessel-Viennot 1985) states that the number of non-intersecting path systems from r sources A₁,...,Aᵣ to r targets B₁,...,Bᵣ equals the determinant of the matrix M_{ij} = e(Aᵢ, Bⱼ) of individual path counts. The sign-reversing involution proof (Gessel-Viennot) uses a bijection that pairs all intersecting path tuples in sign-cancelling pairs. This is one of the most powerful tools in algebraic combinatorics, giving determinantal formulas for Schur polynomials (Jacobi-Trudi identity), binomial coefficient identities, and enumeration of standard Young tableaux. The parent proof (BallotProblemOQ03OQ02) established the full n×n result via the Gessel-Viennot involution; this proof provides the clean restatement and concrete instantiations.",
     "problemStatement": "For r source-target pairs satisfying the wellFormed condition (sources strictly increasing), prove |{non-intersecting r-tuples of lattice paths}| = det[e(Aᵢ, Bⱼ)].",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -55,6 +55,32 @@
       "hook_walk_identity_nineRow: hook walk identity proved for ALL exactly-9-row Young diagrams [a,b,c,d,e,f,g,h,i] via colLen zones, hookLen lemmas, arm product lemmas, field_simp+ring; 0 sorries (PART XXIII)"
     ]
   },
+  "references": [
+    {
+      "authors": "Frame, J. S., Robinson, G. de B. and Thrall, R. M.",
+      "title": "The hook graphs of the symmetric group",
+      "year": "1954",
+      "venue": "Canadian Journal of Mathematics 6, 316–324"
+    },
+    {
+      "authors": "Greene, Curtis, Nijenhuis, Albert and Wilf, Herbert S.",
+      "title": "A probabilistic proof of a formula for the number of Young tableaux of a given shape",
+      "year": "1979",
+      "venue": "Advances in Mathematics 31(1), 104–109"
+    },
+    {
+      "authors": "Sagan, Bruce E.",
+      "title": "The Symmetric Group: Representations, Combinatorial Algorithms, and Symmetric Functions",
+      "year": "2001",
+      "venue": "2nd ed., Graduate Texts in Mathematics 203, Springer"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Young diagrams and Nat.factorial; Mathlib.Combinatorics.YoungDiagram",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The hook-length formula (Frame-Robinson-Thrall 1954) states $f^\\lambda = n!/\\prod_{u \\in \\lambda} h(u)$ where $h(u) = \\text{arm}(u) + \\text{leg}(u) + 1$ is the hook length at cell $u$ of the Young diagram $\\lambda$. This is one of the most celebrated formulas in algebraic combinatorics, connecting enumerative combinatorics with representation theory ($f^\\lambda = \\dim S^\\lambda$, the dimension of the Specht module). The original 1954 proof by Frame, Robinson, and Thrall was a clever but not especially illuminating algebraic manipulation.\n\nThe most beautiful proof came in 1979 when **Greene, Nijenhuis, and Wilf** (GNW) gave a probabilistic proof via the **hook walk**: start at a random cell, randomly walk to a cell in the arm or leg, repeat until hitting a corner; the probability of stopping at each corner $c$ is exactly $\\text{hookProd}(\\mu \\setminus c)/\\text{hookProd}(\\mu)$, and these must sum to 1 — giving the hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu \\setminus c) = |\\mu|$. This probabilistic argument drives the corner induction in this file.\n\nThis formalization represents the most comprehensive Lean 4 treatment of the hook-length formula to date, with the formula proved for all shapes via a corner induction argument modulo one remaining sorry (the GNW probabilistic identity `gnwProb_key` for shapes with $\\geq 10$ rows and $\\geq 3$ columns).",
     "problemStatement": "Given the complete n×n LGV infrastructure in BallotProblemOQ03OQ02.lean, prove the hook-length formula f^λ = n!/∏_{u∈λ}h(u) using: (1) the bijection between SYT(λ) and non-intersecting lattice path tuples with LGV source/target encoding, and (2) the algebraic identity showing the LGV determinant equals n!/∏h(u).",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
@@ -38,6 +38,32 @@
       "Vandermonde identity via lattice path bijection"
     ]
   },
+  "references": [
+    {
+      "authors": "Lindström, Bernt",
+      "title": "On the vector representations of induced matroids",
+      "year": "1973",
+      "venue": "Bulletin of the London Mathematical Society 5(1), 85–90"
+    },
+    {
+      "authors": "Gessel, Ira and Viennot, Gérard",
+      "title": "Binomial determinants, paths, and hook length formulae",
+      "year": "1985",
+      "venue": "Advances in Mathematics 58(3), 300–321"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Vol. 2",
+      "year": "1999",
+      "venue": "Cambridge Studies in Advanced Mathematics 62, Cambridge University Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Matrix.det_fin_two and involution bijections; Mathlib.LinearAlgebra.Matrix.Determinant",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The Lindström-Gessel-Viennot (LGV) Lemma (Lindström 1973, Gessel-Viennot 1985) is a fundamental tool in combinatorics that counts non-intersecting lattice path systems using determinants. The 2×2 case states: given sources A₁, A₂ and targets B₁, B₂, the number of non-intersecting path pairs (A₁→B₁, A₂→B₂) equals e(A₁,B₁)·e(A₂,B₂) - e(A₁,B₂)·e(A₂,B₁), where e(A,B) is the number of monotone lattice paths from A to B. This file provides a complete formal proof with a novel crossing lemma via column entry order analysis.",
     "problemStatement": "Prove the 2×2 LGV Lemma: for source points A₁=(0,a₁), A₂=(0,a₂) with a₁<a₂ and target points B₁=(m,b₁), B₂=(m,b₂) with b₁<b₂, the number of non-intersecting path pairs (P₁:A₁→B₁, P₂:A₂→B₂) equals C(m+b₁-a₁, m)·C(m+b₂-a₂, m) - C(m+b₂-a₁, m)·C(m+b₁-a₂, m).",

--- a/src/data/proofs/ballot-problem-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02-oq-01/meta.json
@@ -41,6 +41,32 @@
       "det_comp_signed_family_sum (VERIFIED 0-axiom): bridge to the sibling's algebraic core — combining multiplicativity with the sibling's Leibniz/family expansion det_matrix_eq_signed_family_sum, the composite determinant is the PRODUCT of two signed family sums, making explicit that each layer contributes its own signed sum over path families."
     ]
   },
+  "references": [
+    {
+      "authors": "Gessel, Ira and Viennot, Gérard",
+      "title": "Binomial determinants, paths, and hook length formulae",
+      "year": "1985",
+      "venue": "Advances in Mathematics 58(3), 300–321"
+    },
+    {
+      "authors": "Lindström, Bernt",
+      "title": "On the vector representations of induced matroids",
+      "year": "1973",
+      "venue": "Bulletin of the London Mathematical Society 5(1), 85–90"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Vol. 2",
+      "year": "1999",
+      "venue": "Cambridge Studies in Advanced Mathematics 62, Cambridge University Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Matrix.det multiplicativity (det_mul); Mathlib.LinearAlgebra.Matrix.Determinant",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The Lindström–Gessel–Viennot lemma (Lindström 1973; Gessel–Viennot 1985) expresses a determinant of path counts as a signed sum over families of lattice paths that collapses, via a sign-reversing involution, to the non-intersecting families. Its applications in algebraic combinatorics — Jacobi–Trudi identities for Schur functions, MacMahon's box formula for plane partitions, dimer models and the Aztec diamond — almost always invoke the WEIGHTED (generating-function) form AND the fact that LGV determinants MULTIPLY when path systems are stacked in layers. The parent entry ballot-problem-oq-03-oq-02 formalises the unweighted general r×r lemma; the weighted sibling ballot-problem-oq-03-oq-02-oq-03 supplies the algebraic core (det H as a signed sum over all path families). Both leave open the 'product structure' connecting LGV to its applications. This entry closes that gap: it proves the LGV determinant is multiplicative under path-system composition, the single algebraic fact behind the LGV product formulas.",
     "problemStatement": "Establish the product structure of LGV determinants: define composition of weighted path systems (concatenating paths through an intermediate layer with multiplicative weights) and prove that the generating-function matrix of the composite is the matrix product of the two layers' matrices, hence — by Cauchy–Binet — that the composite LGV determinant is the product of the two layers' determinants. Extend to an arbitrary stack of layers and bridge to the sibling's signed family-sum expansion.",

--- a/src/data/proofs/ballot-problem-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02-oq-03/meta.json
@@ -38,6 +38,32 @@
       "WeightedLGVConjecture (open goal, stated not proved): the full weighted LGV lemma det H = Σ_{non-intersecting identity families} ∏ w, reduced by the algebraic core to weight-invariance of the Gessel–Viennot tail-swap involution (already proved unweighted in the parent's gv_involution_cancellation / lgv_lemma_rxr)."
     ]
   },
+  "references": [
+    {
+      "authors": "Gessel, Ira and Viennot, Gérard",
+      "title": "Binomial determinants, paths, and hook length formulae",
+      "year": "1985",
+      "venue": "Advances in Mathematics 58(3), 300–321"
+    },
+    {
+      "authors": "Lindström, Bernt",
+      "title": "On the vector representations of induced matroids",
+      "year": "1973",
+      "venue": "Bulletin of the London Mathematical Society 5(1), 85–90"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Vol. 2",
+      "year": "1999",
+      "venue": "Cambridge Studies in Advanced Mathematics 62, Cambridge University Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "generating functions over CommRing and Matrix.det; Mathlib.LinearAlgebra.Matrix.Determinant",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The Lindström–Gessel–Viennot lemma (Lindström 1973; Gessel–Viennot 1985) expresses a determinant of path counts as a signed sum over families of lattice paths that collapses, via a sign-reversing involution, to the non-intersecting families. Its WEIGHTED form — where each path carries a monomial weight and counts become generating functions — is the version actually used in algebraic combinatorics (Jacobi–Trudi identities for Schur functions, plane partitions, the Aztec diamond). The parent entry `ballot-problem-oq-03-oq-02` formalises the unweighted general r×r lemma; its open-question list asks to extend it to the weighted/generating-function setting. This entry supplies the algebraic core of that extension over an arbitrary commutative ring.",
     "problemStatement": "Formalise the weighted (generating-function) LGV lemma: over a commutative ring R with path weights w(P), det[Σ_{P:Aᵢ→Bⱼ} w(P)] = Σ over non-intersecting r-tuples of products of weights. This file proves the unconditional algebraic half (the signed sum over ALL path families) and states the full lemma (collapse to non-intersecting families) as the open goal.",

--- a/src/data/proofs/ballot-problem-oq-03-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-03/meta.json
@@ -55,6 +55,32 @@
     "dateAdded": "2026-05-04",
     "mathlib_version": "4.26.0"
   },
+  "references": [
+    {
+      "authors": "Frame, J. S., Robinson, G. de B. and Thrall, R. M.",
+      "title": "The hook graphs of the symmetric group",
+      "year": "1954",
+      "venue": "Canadian Journal of Mathematics 6, 316–324"
+    },
+    {
+      "authors": "Greene, Curtis, Nijenhuis, Albert and Wilf, Herbert S.",
+      "title": "A probabilistic proof of a formula for the number of Young tableaux of a given shape",
+      "year": "1979",
+      "venue": "Advances in Mathematics 31(1), 104–109"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Vol. 2",
+      "year": "1999",
+      "venue": "Cambridge Studies in Advanced Mathematics 62, Cambridge University Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Catalan numbers and Nat.factorial identities; Mathlib.Combinatorics.Catalan",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "leanFile": {
     "path": "Proofs/BallotProblemOQ03OQ03.lean",
     "lineCount": 280,

--- a/src/data/proofs/ballot-problem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-01/meta.json
@@ -52,6 +52,32 @@
     "theoremCount": 4,
     "definitionCount": 1
   },
+  "references": [
+    {
+      "authors": "Kreweras, Germain",
+      "title": "Sur les partitions non croisées d'un cycle",
+      "year": "1972",
+      "venue": "Discrete Mathematics 1(4), 333–350"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "venue": "Cambridge University Press"
+    },
+    {
+      "authors": "Simion, Rodica",
+      "title": "Noncrossing partitions",
+      "year": "2000",
+      "venue": "Discrete Mathematics 217(1–3), 367–409"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Setoid (Fin n) and partitions; Mathlib.Data.Setoid.Partition",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "Non-crossing partitions, introduced by Germain Kreweras in 1972, are the partitions of points on a circle whose blocks can be drawn without crossing chords. They are counted by the Catalan numbers and form one of the largest families of Catalan objects, in bijection with Dyck paths, ballot sequences, binary trees, and triangulations. The smallest case where they differ from arbitrary (Bell-counted) partitions is n = 4: the partition pairing the two diagonals of a square, {{0, 2}, {1, 3}}, is the unique partition of four points whose blocks must cross, so the non-crossing partitions of a 4-set number 15 − 1 = 14 = catalan 4.",
     "problemStatement": "Exhibit, with a machine-checked proof, the unique crossing partition of Fin 4 — the n = 4 discriminator that separates the Bell number B₄ = 15 from catalan 4 = 14 — and prove it fails the non-crossing predicate IsNonCrossing.",

--- a/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json
@@ -77,6 +77,26 @@
       "nonCrossingCount_recurrence (statement): nonCrossingCount (n+1) = ∑ ij ∈ antidiagonal n, nonCrossingCount ij.1 * nonCrossingCount ij.2 — the Catalan convolution for the Finpartition model, stated to match catalan_succ' so the reduction is purely formal. Its proof (the block/first-return decomposition) is the single outstanding sorry and the entire remaining combinatorial content."
     ]
   },
+  "references": [
+    {
+      "authors": "Kreweras, Germain",
+      "title": "Sur les partitions non croisées d'un cycle",
+      "year": "1972",
+      "venue": "Discrete Mathematics 1(4), 333–350"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "venue": "Cambridge University Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Finpartition and Catalan recurrence; Mathlib.Order.Partition.Finpartition, Mathlib.Combinatorics.Catalan",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "Non-crossing partitions of a linearly ordered n-element set (Kreweras 1972) are one of the canonical Catalan families, alongside Dyck words and ballot sequences. The grandparent entry ballot-problem-oq-04 introduced them to Lean as a setoid predicate; the parent ballot-problem-oq-04-oq-02 ported them to Mathlib's Fintype-bearing Finpartition, defined the count nonCrossingCount n, and proved n = 4 is the first point where the count drops below the Bell number (catalan 4 = 14 < 15 = Bell 4). The exact enumeration nonCrossingCount n = catalan n was left as the parent's openQuestion[2], to be proved either by the explicit Dyck-word bijection (sibling oq-04-oq-01) or by establishing the Catalan recurrence directly on the Finpartition model. This entry takes the latter route and carries it as far as a single combinatorial lemma.",
     "problemStatement": "Prove nonCrossingCount n = catalan n. Reduce it, with full rigour, to the single recurrence nonCrossingCount (n+1) = ∑ (i,j) ∈ antidiagonal n, nonCrossingCount i · nonCrossingCount j, matching Mathlib's catalan recurrence.",

--- a/src/data/proofs/ballot-problem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-02/meta.json
@@ -69,6 +69,32 @@
       "crossing4 / crossing4Fp and nonCrossingCount_four_lt: the parity partition {{0,2},{1,3}} on Fin 4 (kernel of ·%2) crosses, yielding the strict drop nonCrossingCount 4 < Fintype.card (Finpartition univ) — n=4 as the first point where non-crossing partitions become a proper subfamily, the catalan 4 = 14 < 15 = Bell 4 discriminator as a theorem"
     ]
   },
+  "references": [
+    {
+      "authors": "Kreweras, Germain",
+      "title": "Sur les partitions non croisées d'un cycle",
+      "year": "1972",
+      "venue": "Discrete Mathematics 1(4), 333–350"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "venue": "Cambridge University Press"
+    },
+    {
+      "authors": "Simion, Rodica",
+      "title": "Noncrossing partitions",
+      "year": "2000",
+      "venue": "Discrete Mathematics 217(1–3), 367–409"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Finpartition and Fintype.card of decidable subtypes; Mathlib.Order.Partition.Finpartition",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "Non-crossing partitions of a linearly ordered n-element set, introduced by Kreweras (1972), are counted by the Catalan numbers and form one of the canonical Catalan families alongside Dyck words and ballot sequences. The parent gallery entry ballot-problem-oq-04 introduced them to Lean as a predicate on the same-block setoid and developed their structural theory, explicitly flagging (openQuestion[2]) that the setoid presentation cannot be counted directly: an arbitrary Setoid (Fin n) is a Prop-valued relation, hence not a Fintype. Mathlib's Finpartition, by contrast, is a genuine Fintype, and Finpartition.ofSetoid bridges the two presentations. This entry uses that bridge to give non-crossing partitions a countable model and to locate, as a theorem, the first n at which the non-crossing count falls below the total partition (Bell) count: n = 4, where catalan 4 = 14 while Bell 4 = 15.",
     "problemStatement": "Define non-crossing partitions of Fin n as Finpartitions, prove the setoid and Finpartition formulations agree, equip the non-crossing partitions with a Fintype/cardinality, and exhibit the first n at which the non-crossing count discriminates from the total partition count (n = 4).",

--- a/src/data/proofs/ballot-problem-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04/meta.json
@@ -52,6 +52,32 @@
       "dyck_side_card: re-exposes Mathlib's card_dyckWord_semilength_eq_catalan (catalan n Dyck words of semilength n) as the Catalan-counted ballot/Dyck domain of the OQ-04 bijection, alongside the now-formalized non-crossing codomain"
     ]
   },
+  "references": [
+    {
+      "authors": "Kreweras, Germain",
+      "title": "Sur les partitions non croisées d'un cycle",
+      "year": "1972",
+      "venue": "Discrete Mathematics 1(4), 333–350"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "venue": "Cambridge University Press"
+    },
+    {
+      "authors": "Simion, Rodica",
+      "title": "Noncrossing partitions",
+      "year": "2000",
+      "venue": "Discrete Mathematics 217(1–3), 367–409"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Setoid (Fin n), Dyck paths and Catalan numbers; Mathlib.Combinatorics.Catalan",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The Catalan numbers C_n = (1/(n+1)) binom(2n,n) count an enormous family of combinatorial objects, among them Dyck paths / ballot sequences (lattice paths staying weakly ahead) and the non-crossing partitions of {1,...,n} introduced by Kreweras (1972). Non-crossing partitions are central to free probability (Speicher's theory of free cumulants), the combinatorics of the symmetric and reflection groups, and cluster algebras. The classical fact that ballot/Dyck objects biject with non-crossing partitions is a cornerstone Catalan bijection. Mathlib formalizes the ballot/Dyck side completely (DyckWord with a proof that there are catalan n Dyck words of semilength n) but has no notion of non-crossing partition, so the bijection's target object did not exist in the library.",
     "problemStatement": "OQ-04 — Ballot Sequences and Non-Crossing Partition Bijection: ballot sequences (Dyck words) and non-crossing partitions of an n-element ordered set are both counted by catalan n; exhibit the explicit bijection. As a prerequisite, the non-crossing-partition side must first be defined and given its structural theory in Lean.",


### PR DESCRIPTION
Enrichment pass adding curated `references` to the 16 `ballot-problem-*` follow-up entries that had none.

Each entry gets 3–4 accurate references matched to its **specific** content, plus a Mathlib-module citation:

| Strand | Key references |
|--------|----------------|
| Bertrand ballot / multi-candidate / uniform-fiber | Bertrand (1887); André (1887, reflection principle); Feller Vol. I |
| Chung–Feller theorem | Chung & Feller (1949); Stanley, *Catalan Numbers* |
| Lindström–Gessel–Viennot lemma (2×2, n×n, weighted) | Lindström (1973); Gessel–Viennot (1985); Stanley EC2 |
| Jacobi–Trudi / Schur polynomials | Macdonald; Stanley EC2; Sagan |
| Hook-length formula | Frame–Robinson–Thrall (1954); Greene–Nijenhuis–Wilf (1979) |
| Non-crossing partitions / Catalan | Kreweras (1972); Stanley, *Catalan Numbers*; Simion (2000) |

**Safety:** only the `references` key is added; all other meta.json keys verified byte-for-byte deep-equal to origin/main for all 16 files. No Lean files touched.

Part of the references-gap cleanup.