### PR TITLE
Enrich Modulus Decay in Roth's Density Increment

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-01-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "roth-theorem-k3-oq-01-oq-01",
+  "title": "Modulus Decay in Roth's Density Increment",
+  "slug": "roth-theorem-k3-oq-01-oq-01",
+  "description": "Formalizes the analytic core of the modulus-decay bound M ≥ M^θ (Roth's case θ = 2/3) in Roth's density-increment argument, and derives the log-log iteration barrier it produces. Answers affirmatively the feasibility question: the M ≥ N^{2/3} decay is expressible and provable in Mathlib via Real.rpow/Real.log.",
+  "meta": {
+    "author": "Roth (1953)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Roth%27s_theorem_on_arithmetic_progressions",
+    "date": "1953",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RothTheoremQuantitativeOQ01.lean",
+    "tags": [
+      "additive-combinatorics",
+      "szemeredi",
+      "arithmetic-progressions",
+      "quantitative-bounds",
+      "roth-number",
+      "density-increment"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Fully machine-checked. The modulus sequence and its per-step decay bound M(i+1) ≥ (M i)^θ are taken as hypotheses on an abstract sequence M : ℕ → ℝ (the analytic skeleton of one density-increment step); this file does not re-derive the Fourier-analytic increment itself.",
+    "dateAdded": "2026-06-28",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.rpow_mul",
+        "description": "(x^y)^z = x^(y*z) for x ≥ 0, used to collapse iterated powers N^(θ^k)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "Monotonicity of rpow in the base, drives the induction lower envelope",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_def_of_pos",
+        "description": "x^y = exp(log x * y), used to compare T with N^(θ^k) via logs",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.exp_log",
+        "description": "exp(log x) = x for x > 0, threshold comparison",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "modulus_ge_rpow: from M(i+1) ≥ (M i)^θ and M 0 = N, proves M k ≥ N^(θ^k) by induction (the modulus never collapses)",
+      "modulus_ge_rpow_roth: the Roth case θ = 2/3, giving M k ≥ N^((2/3)^k)",
+      "modulus_ge_threshold: the modulus stays ≥ T while the log-budget log T ≤ θ^k · log N holds",
+      "modulus_exhaust_log: contrapositive — dropping below T forces θ^k · log N < log T",
+      "modulus_exhaust_loglog: rearranged to log N < log T · (1/θ)^k, exhibiting the double-exponential (log log N) survival barrier without any logb machinery",
+      "modulus_exhaust_loglog_roth: Roth case log N < log T · (3/2)^k, so exhausting the modulus needs k = Ω(log log N) iterations"
+    ],
+    "lineCount": 166,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Roth's 1953 proof that 3-AP-free subsets of [N] have density o(1) introduced the density-increment method: if a set has no 3-term arithmetic progression, its Fourier transform must have a large non-trivial coefficient, which yields a longer AP (a sub-progression) on which the set has strictly greater relative density. Iterating this increment must terminate, because density cannot exceed 1. The quantitative strength of Roth's bound r_3(N) = O(N / log log N) is governed entirely by how fast the modulus of the ambient progression shrinks at each step. Bourgain (1999), Sanders (2011), Bloom (2016), Bloom-Sisask (2020) and finally Kelley-Meka (2023) progressively sharpened this decay analysis; the last reached the near-Behrend bound N·exp(-c(log N)^{1/12}).",
+    "problemStatement": "The parent entry (Quantitative Bounds for Roth's Theorem) asks whether the analytic heart of the density-increment iteration — the per-step modulus-decay inequality M(i+1) ≥ (M i)^θ and the resulting number of surviving iterations — can be stated and machine-checked in Mathlib using only Real.rpow and Real.log. This entry answers that feasibility question affirmatively for the Roth exponent θ = 2/3.",
+    "text": "Working with an abstract modulus sequence M : ℕ → ℝ subject to M 0 = N and the one-step decay bound M(i+1) ≥ (M i)^θ, the file proves the closed-form lower envelope M k ≥ N^(θ^k) by induction, instantiates the Roth case θ = 2/3, and derives the iteration barrier: the modulus stays above a threshold T until roughly k = Ω(log log N) steps have elapsed. This isolates the double-exponential structure that limits how many density-increment steps are available before the ambient progression is exhausted.",
+    "proofStrategy": "The lower envelope M k ≥ N^(θ^k) follows by induction on k: the base case is M 0 = N = N^(θ^0), and the step composes the hypothesis M(k+1) ≥ (M k)^θ with monotonicity of rpow (Real.rpow_le_rpow) and the power law (M k)^θ ≥ (N^(θ^k))^θ = N^(θ^{k+1}) via Real.rpow_mul. The survival barrier is obtained by taking logarithms: M k ≥ T holds as long as log T ≤ θ^k · log N; the contrapositive rearranges (dividing by θ^k > 0) to log N < log T · (1/θ)^k, exhibiting the (1/θ)^k = (3/2)^k double-exponential growth that forces k = Ω(log log N). No logb machinery is needed — everything is phrased through Real.log and Real.rpow_def_of_pos.",
+    "keyInsights": [
+      "The entire quantitative content of Roth's density increment is captured by a single scalar recurrence M(i+1) ≥ (M i)^θ; the Fourier analysis only serves to produce this inequality with a specific θ.",
+      "Iterating a power-law decay gives M k ≥ N^(θ^k), a stretched-exponential envelope — the modulus does not collapse geometrically, it collapses through iterated exponentiation.",
+      "Because the surviving exponent is θ^k, the number of usable iterations before dropping below a fixed threshold T is only Ω(log log N): the log-log loss in Roth's bound r_3(N) = O(N/log log N) is a direct fingerprint of this double-exponential barrier.",
+      "The barrier is expressible entirely with Real.rpow and Real.log — no specialized additive-combinatorics library is required to formalize the analytic skeleton, only careful monotonicity and logarithm lemmas.",
+      "Isolating the recurrence as an abstract hypothesis on M cleanly separates the 'soft' iteration bookkeeping (formalized here, 0 axioms) from the 'hard' Fourier-analytic increment step (not re-derived)."
+    ],
+    "prerequisites": [
+      "Real powers Real.rpow and their algebra (rpow_mul, rpow_le_rpow monotonicity)",
+      "The natural logarithm Real.log and the identity x^y = exp(log x · y) for x > 0",
+      "Induction on ℕ and basic inequality manipulation",
+      "Conceptual familiarity with Roth's density-increment argument (not required for the formal proof itself)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "roth-theorem-k3-oq-01",
+      "relationship": "parent",
+      "description": "Direct parent: formalizes the Roth number r_3(N) and states the quantitative bounds from Roth (1953) through Kelley-Meka (2023). This entry answers its open question of whether the modulus-decay analytic core is expressible and provable in Mathlib."
+    },
+    {
+      "targetId": "roth-theorem-k3",
+      "relationship": "foundational",
+      "description": "The verified k=3 case of Szemerédi's theorem via Fourier analysis — the qualitative statement (3-AP-free sets have size o(N)) whose quantitative refinement this entry's modulus-decay barrier governs."
+    },
+    {
+      "targetId": "roth-theorem",
+      "relationship": "related",
+      "description": "The full Fourier-analytic development of Roth's density-increment argument; this entry isolates and machine-checks the scalar modulus-decay recurrence that argument produces."
+    },
+    {
+      "targetId": "roth-theorem-k3-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling generalization of the density increment to k-term APs via Gowers uniformity norms; shares the iterate-until-density-saturates structure but with higher-order Fourier analysis."
+    },
+    {
+      "targetId": "roth-theorem-k3-oq-02",
+      "relationship": "sibling",
+      "description": "An alternative route to Roth's theorem via the Ruzsa-Szemerédi triangle removal lemma, contrasting the density-increment method quantified here."
+    }
+  ],
+  "conclusion": {
+    "summary": "The modulus-decay lower envelope M k ≥ N^(θ^k) and its log-log iteration barrier are fully formalized in Mathlib with 0 axioms and 0 sorries for the Roth exponent θ = 2/3, confirming that the analytic skeleton of Roth's density increment — the part that dictates the O(N/log log N) bound — is expressible using only Real.rpow and Real.log on an abstract modulus sequence.",
+    "implications": [
+      "Provides a reusable, axiom-free scaffold for the iteration bookkeeping in density-increment arguments, decoupled from the Fourier-analytic increment step.",
+      "Makes explicit, in machine-checked form, why Roth's original bound loses a log-log factor: the surviving modulus exponent decays like θ^k, so only Ω(log log N) iterations are available.",
+      "Demonstrates that quantitative additive-combinatorics bounds can be captured through elementary real-analytic lemmas, lowering the barrier to formalizing later improvements (Bourgain, Bloom-Sisask, Kelley-Meka)."
+    ],
+    "openQuestions": [
+      "Formalize the Fourier-analytic increment step itself, deriving the decay inequality M(i+1) ≥ (M i)^θ rather than assuming it, to obtain an end-to-end machine-checked quantitative Roth bound.",
+      "Instantiate sharper exponents/decay profiles corresponding to the Bloom-Sisask and Kelley-Meka improvements and derive their (log N)^c-type barriers in the same framework.",
+      "Connect the abstract modulus sequence to a concrete formalized notion of an ambient arithmetic progression and its shrinking modulus."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Roth, Klaus",
+      "title": "On certain sets of integers",
+      "year": "1953",
+      "venue": "Journal of the London Mathematical Society 28, 104–109"
+    },
+    {
+      "authors": "Behrend, Felix A.",
+      "title": "On sets of integers which contain no three terms in arithmetical progression",
+      "year": "1946",
+      "venue": "Proceedings of the National Academy of Sciences 32(12), 331–332"
+    },
+    {
+      "authors": "Heath-Brown, D. R.",
+      "title": "Integer sets containing no arithmetic progressions",
+      "year": "1987",
+      "venue": "Journal of the London Mathematical Society 35(3), 385–394"
+    },
+    {
+      "authors": "Szemerédi, Endre",
+      "title": "Integer sets containing no arithmetic progressions",
+      "year": "1990",
+      "venue": "Acta Mathematica Hungarica 56(1–2), 155–158"
+    },
+    {
+      "authors": "Bourgain, Jean",
+      "title": "On triples in arithmetic progression",
+      "year": "1999",
+      "venue": "Geometric and Functional Analysis 9(5), 968–984"
+    },
+    {
+      "authors": "Bloom, Thomas F. and Sisask, Olof",
+      "title": "Breaking the logarithmic barrier in Roth's theorem on arithmetic progressions",
+      "year": "2020",
+      "venue": "arXiv:2007.03528"
+    },
+    {
+      "authors": "Kelley, Zander and Meka, Raghu",
+      "title": "Strong bounds for 3-progressions",
+      "year": "2023",
+      "venue": "Proc. 64th IEEE FOCS; arXiv:2302.05537"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Real.rpow, Real.log and special-function power/logarithm lemmas (Mathlib.Analysis.SpecialFunctions.Pow.Real, .Log.Basic)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "Szemeredi.Roth.ModulusDecay",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/RothTheoremQuantitativeOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Enrichment pass

Quality-0/passes-0 entry `roth-theorem-k3-oq-01-oq-01` (analytic core of Roth's modulus-decay bound). Previously only description + meta + one reference.

**Added:** overview (historicalContext, proofStrategy, 5 keyInsights, prerequisites), 5 crossReferences to the Roth k=3 family (all targetIds verified), conclusion (summary/implications/openQuestions), and references expanded 1 → 8 (Behrend, Heath-Brown, Szemerédi, Bourgain, Bloom-Sisask, Kelley-Meka, mathlib).

meta.json 12 KB, within all size caps. No Lean source changed.