### PR TITLE
Enrich angle-trisection cluster: add references to 12 OQ-child entries

### DIFF
--- a/src/data/proofs/angle-trisection-oq-01-oq-04-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01-oq-04-oq-02/meta.json
@@ -64,6 +64,26 @@
     "definitionCount": 0,
     "trueStubs": 0
   },
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "venue": "Leipzig (English translation, Yale University Press, 1965), §365–366"
+    },
+    {
+      "authors": "Dummit, David S. and Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Nat.Prime, Fermat numbers and Nat.factorization; Mathlib.NumberTheory.LucasLehmer, Mathlib.Data.Nat.Prime",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "In 1796 the nineteen-year-old Gauss discovered that the regular 17-gon is constructible by ruler and compass, the first advance on the classical constructibility problem since antiquity. The full criterion — completed by Pierre Wantzel in 1837 — states that a regular n-gon is constructible if and only if n = 2^a times a product of distinct Fermat primes, where a Fermat prime is a prime of the form 2^(2^k) + 1. Fermat had conjectured in 1640 that every number 2^(2^k) + 1 is prime; Euler refuted this in 1732 by factoring 2^32 + 1 = 641 · 6700417. A basic structural fact underpins the whole theory: if 2^m + 1 is prime at all, the exponent m must itself be a power of two. The reason is elementary but constructive — any odd factor d > 1 of m exposes an explicit divisor 2^(m/d) + 1 of 2^m + 1. This entry formalizes that constructive obstruction and the exponent law it yields, the precise tool the parent Gauss–Wantzel entry flagged as missing.",
     "problemStatement": "Prove that if 2^m + 1 is prime (m ≠ 0) then m is a power of two. Equivalently, give a constructive criterion: whenever the exponent m has an odd factor d > 1, exhibit an explicit proper divisor of 2^m + 1 certifying that it is composite.",

--- a/src/data/proofs/angle-trisection-oq-01-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01-oq-04/meta.json
@@ -60,6 +60,32 @@
     "theoremCount": 22,
     "definitionCount": 1
   },
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "venue": "Leipzig (English translation, Yale University Press, 1965), §365–366"
+    },
+    {
+      "authors": "Wantzel, Pierre Laurent",
+      "title": "Recherches sur les moyens de reconnaître si un problème de géométrie peut se résoudre avec la règle et le compas",
+      "year": "1837",
+      "venue": "Journal de Mathématiques Pures et Appliquées 2, 366–372"
+    },
+    {
+      "authors": "Stewart, Ian",
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "4th ed., CRC Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Nat.totient and powers of two; Mathlib.NumberTheory.Divisors, Mathlib.Data.Nat.Totient",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "Gauss showed (1796, published in Disquisitiones Arithmeticae 1801) that the regular 17-gon is constructible, and stated that a regular n-gon is constructible exactly when n = 2^a·p₁⋯pₘ with the pᵢ distinct Fermat primes; Pierre Wantzel (1837) supplied the necessity proof. The criterion is equivalent to φ(n) being a power of 2, where φ is Euler's totient. The known Fermat primes are 3, 5, 17, 257, 65537; whether any others exist is a famous open problem. The parent file verifies the n ≤ 20 cases with native_decide; this entry develops the structural machinery to go further without trusting the compiler.",
     "problemStatement": "Extend the regular-polygon classification beyond n = 20 toward the general Gauss–Wantzel characterization n = 2^a·(distinct Fermat primes).",

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02/meta.json
@@ -65,6 +65,26 @@
     "theoremCount": 6,
     "definitionCount": 1
   },
+  "references": [
+    {
+      "authors": "Dummit, David S. and Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley"
+    },
+    {
+      "authors": "Cox, David A.",
+      "title": "Galois Theory",
+      "year": "2012",
+      "venue": "2nd ed., Wiley"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "IsGalois, IntermediateField and Field.Emb / separable degree; Mathlib.FieldTheory.Galois",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "leanFile": {
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02.lean",
     "axiomCount": 0,

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -52,6 +52,32 @@
       "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean"
     ]
   },
+  "references": [
+    {
+      "authors": "Wantzel, Pierre Laurent",
+      "title": "Recherches sur les moyens de reconnaître si un problème de géométrie peut se résoudre avec la règle et le compas",
+      "year": "1837",
+      "venue": "Journal de Mathématiques Pures et Appliquées 2, 366–372"
+    },
+    {
+      "authors": "Stewart, Ian",
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "4th ed., CRC Press"
+    },
+    {
+      "authors": "Martin, George E.",
+      "title": "Geometric Constructions",
+      "year": "1998",
+      "venue": "Undergraduate Texts in Mathematics, Springer"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "IntermediateField.adjoin and quadratic extensions; Mathlib.FieldTheory.Adjoin",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "parent": "angle-trisection-oq-02-oq-01-oq-02",
   "openQuestion": "How can the not_constructible_of_bad_degree sorry in the parent Wantzel-Galois formalization be proved?",
   "overview": {

--- a/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/meta.json
@@ -53,6 +53,32 @@
     "mathlib_version": "4.26.0",
     "definitionCount": 1
   },
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "venue": "Leipzig (English translation, Yale University Press, 1965), §365–366"
+    },
+    {
+      "authors": "Wantzel, Pierre Laurent",
+      "title": "Recherches sur les moyens de reconnaître si un problème de géométrie peut se résoudre avec la règle et le compas",
+      "year": "1837",
+      "venue": "Journal de Mathématiques Pures et Appliquées 2, 366–372"
+    },
+    {
+      "authors": "Stewart, Ian",
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "4th ed., CRC Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Nat.totient and Nat.factorization; Mathlib.Data.Nat.Totient",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.Totient",
@@ -61,7 +87,9 @@
       "Mathlib.Data.Nat.GCD.BigOperators",
       "Mathlib.Tactic.NormNum.Prime"
     ],
-    "opens": ["Nat"],
+    "opens": [
+      "Nat"
+    ],
     "namespace": "AngleTrisectionOQ02OQ02OQ02",
     "lineCount": 246,
     "axiomCount": 0,

--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -62,6 +62,26 @@
     "theoremCount": 12,
     "definitionCount": 1
   },
+  "references": [
+    {
+      "authors": "Cox, David A.",
+      "title": "Galois Theory",
+      "year": "2012",
+      "venue": "2nd ed., Wiley"
+    },
+    {
+      "authors": "Stewart, Ian",
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "4th ed., CRC Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "IsGalois, the Galois correspondence and 2-groups; Mathlib.FieldTheory.Galois, Mathlib.GroupTheory.PGroup",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "Wantzel (1837) proved that a number is constructible by compass and straightedge iff it lies in a tower of quadratic extensions over ℚ, finally resolving the ancient Greek impossibility questions (angle trisection, cube duplication, circle squaring). Galois theory, developed by Galois (1832) and systematized in the 19th century, recharacterizes this: constructibility is equivalent to the Galois group of the minimal polynomial being a 2-group (a group of order 2^n). The equivalence of these two formulations — quadratic tower criterion ↔ Galois 2-group criterion — is a fundamental result connecting classical constructibility with modern algebraic structure theory. Remarkably, Galois was killed in a duel at age 20 in 1832 before his work was published; it took 14 years for Liouville to recognize its importance.",
     "problemStatement": "Can the equivalence between the quadratic tower criterion and the Galois 2-group criterion for constructibility be proved using Mathlib's Galois correspondence?",

--- a/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-01/meta.json
@@ -90,6 +90,26 @@
     ],
     "definitionCount": 2
   },
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "venue": "Leipzig (English translation, Yale University Press, 1965), §365–366"
+    },
+    {
+      "authors": "Wantzel, Pierre Laurent",
+      "title": "Recherches sur les moyens de reconnaître si un problème de géométrie peut se résoudre avec la règle et le compas",
+      "year": "1837",
+      "venue": "Journal de Mathématiques Pures et Appliquées 2, 366–372"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Decidable instances and Nat.totient; Mathlib.Data.Nat.Totient, Mathlib.Logic.Decidable",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The question of which regular polygons are constructible by compass and straightedge was resolved by Gauss (1796) and Wantzel (1837): a regular n-gon is constructible iff Euler's totient φ(n) is a power of 2. While the decidability of this check was formalized in OQ03 (via `Decidable` typeclass instances), that formalization operated at the level of mathematical propositions (Prop). This file bridges the gap to computation: it implements an actual Bool-valued program, proves it correct, and uses it to enumerate constructible polygons.\n\nThe known Fermat primes are 3, 5, 17, 257, and 65537. It is unknown whether there are more. The 65537-gon was explicitly constructed by Hermes (1894) in a 200-page manuscript. Lean's `native_decide` tactic can verify that 65537 is a constructible polygon in seconds.",
     "problemStatement": "**From Decidability to Executable Program**:\n\nOQ03 showed that n-gon constructibility is decidable by providing `Decidable` typeclass instances. But a Lean `Decidable` instance is a proof object, not necessarily an efficient program. This file asks:\n\n1. Can we define a concrete `Bool`-valued function `ngonConstructible : ℕ → Bool`?\n2. Is it provably correct against `IsConstructibleNgon n` (Gauss-Wantzel)?\n3. Can we use it to compute a verified list of all constructible polygons up to n = 100?",

--- a/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-02/meta.json
@@ -25,6 +25,20 @@
     "theoremCount": 13,
     "definitionCount": 1
   },
+  "references": [
+    {
+      "authors": "Martin, George E.",
+      "title": "Geometric Constructions",
+      "year": "1998",
+      "venue": "Undergraduate Texts in Mathematics, Springer"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Nat.log and logarithmic step counts; Mathlib.Data.Nat.Log",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The impossibility of trisecting a general angle with compass and straightedge was proved by Pierre Wantzel in 1837 using Galois theory: an angle θ is trisectable iff 8x³ − 6x − cos θ has a rational root or splits into linear factors over the iterated quadratic extensions of ℚ. The OQ-03 companion entry formalizes an O(log d) algorithm to check whether a denominator d (determining the angle π/d) satisfies the constructibility conditions by counting halvings of d until it becomes odd. This entry (OQ-03-OQ-02) closes the complexity question: the O(log d) bound is not just an upper bound — it is tight. The halvings algorithm performs exactly Nat.log 2 (2^k) = k steps on inputs d = 2^k, and no algorithm can process these inputs in sub-logarithmic time. The proof connects the constructibility check to the 2-adic valuation v₂(d) — the exact power of 2 dividing d — which is the information-theoretically required number of halvings.",
     "problemStatement": "Let halvings : ℕ → ℕ count the number of divisions by 2 before d becomes odd. Prove: (1) halvings(2^k) = k for all k; (2) halvings(2^k) = Nat.log 2 (2^k); (3) the step count is unbounded (no O(1) bound suffices); (4) 2^k − 1 is rejected in 0 steps while 2^k requires k steps.",

--- a/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
@@ -35,6 +35,32 @@
     "mathlib_version": "4.26.0",
     "definitionCount": 2
   },
+  "references": [
+    {
+      "authors": "Gleason, Andrew M.",
+      "title": "Angle trisection, the heptagon, and the triskaidecagon",
+      "year": "1988",
+      "venue": "American Mathematical Monthly 95(3), 185–194"
+    },
+    {
+      "authors": "Videla, Carlos R.",
+      "title": "On points constructible from conics",
+      "year": "1997",
+      "venue": "The Mathematical Intelligencer 19(2), 53–57"
+    },
+    {
+      "authors": "Martin, George E.",
+      "title": "Geometric Constructions",
+      "year": "1998",
+      "venue": "Undergraduate Texts in Mathematics, Springer"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Nat.Prime and factorizations 2^a·3^b; Mathlib.Data.Nat.Prime, Mathlib.Data.Nat.Factorization",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The Gauss-Wantzel theorem (1801/1837) characterizes compass-and-straightedge constructible regular polygons via Fermat primes: n-gon constructible iff φ(n) = 2^k. Neusis (marked ruler) constructions were used in antiquity for angle trisection — the ancient Greeks knew that neusis can trisect any angle, while compass-straightedge cannot trisect 60°. The modern algebraic characterization of neusis-constructible polygons was worked out by Andrew Gleason in 'Angle Trisection, the Heptagon, and the Triskaidecagon' (American Mathematical Monthly, 1988): n-gon is neusis-constructible iff φ(n) = 2^u · 3^v, equivalently n = 2^a · 3^b × (distinct Pierpont primes > 3). Pierpont primes — primes p with p−1 = 2^u · 3^v — are the neusis analog of Fermat primes. Unlike Fermat primes (of which only 5 are known: 3, 5, 17, 257, 65537), infinitely many Pierpont primes are expected (OEIS A005109: 2, 3, 5, 7, 13, 17, 19, 37, 73, 97, 109, 163, 193, 257, ...). The key new polygon enabled by neusis: the regular 7-gon (heptagon), since φ(7)=6=2·3 is 3-smooth but not a power of 2.",
     "problemStatement": "Formalize the Pierpont prime criterion: define `IsPierpontPrime p` and `Is23Smooth`, verify examples, and prove the neusis-constructibility criterion for specific polygons.",

--- a/src/data/proofs/angle-trisection-oq-04-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-04/meta.json
@@ -80,6 +80,32 @@
     "parentProofId": "angle-trisection-oq-04",
     "definitionCount": 0
   },
+  "references": [
+    {
+      "authors": "Alperin, Roger C.",
+      "title": "A mathematical theory of origami constructions and numbers",
+      "year": "2000",
+      "venue": "New York Journal of Mathematics 6, 119–133"
+    },
+    {
+      "authors": "Alperin, Roger C. and Lang, Robert J.",
+      "title": "One-, two-, and multi-fold origami axioms",
+      "year": "2009",
+      "venue": "Origami^4 (4OSME), A K Peters, 371–393"
+    },
+    {
+      "authors": "Gleason, Andrew M.",
+      "title": "Angle trisection, the heptagon, and the triskaidecagon",
+      "year": "1988",
+      "venue": "American Mathematical Monthly 95(3), 185–194"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Nat.Prime and constructibility predicates; Mathlib.Data.Nat.Prime",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "sorries": 0,
   "overview": {
     "historicalContext": "The constructibility hierarchy for regular polygons has been progressively refined since Gauss (1796). The Gauss-Wantzel theorem (1837) characterizes compass-and-straightedge constructibility: an n-gon is constructible iff φ(n) = 2^k. Neusis (marked-ruler) construction, studied since antiquity (Archimedes trisection, Diocles cissoid), allows the Pierpont primes: n-gons with φ(n) | 2^a·3^b. The identification of single-fold origami (Huzita-Hatori axiom O6) with neusis was established by Alperin and Lang (2006). Multi-fold origami extends this further: k-fold origami with the p_{k+1}-smooth degree criterion was studied by Huzita, Alperin, and others in the 1980s–2000s. The strict gap between neusis and 2-fold origami, witnessed by the 11-gon (φ(11) = 10 = 2·5), is a concrete and computable consequence of this hierarchy.",

--- a/src/data/proofs/angle-trisection-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04/meta.json
@@ -34,6 +34,32 @@
       "five_not_two_three and eleven_not_pierpont: explicit failures of neusis-constructibility"
     ]
   },
+  "references": [
+    {
+      "authors": "Martin, George E.",
+      "title": "Geometric Constructions",
+      "year": "1998",
+      "venue": "Undergraduate Texts in Mathematics, Springer"
+    },
+    {
+      "authors": "Gleason, Andrew M.",
+      "title": "Angle trisection, the heptagon, and the triskaidecagon",
+      "year": "1988",
+      "venue": "American Mathematical Monthly 95(3), 185–194"
+    },
+    {
+      "authors": "Alperin, Roger C.",
+      "title": "A mathematical theory of origami constructions and numbers",
+      "year": "2000",
+      "venue": "New York Journal of Mathematics 6, 119–133"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "field extensions and constructibility degrees; Mathlib.FieldTheory.Adjoin",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The impossibility of angle trisection with compass and straightedge, proved by Pierre Wantzel in 1837, left open the natural question: what becomes possible with stronger tools?\n\n**Ancient neusis constructions**: The marked ruler (neusis) was known to the Greeks. Archimedes (c.287–212 BC) used neusis to trisect arbitrary angles. Nicomedes (c.280–210 BC) used it to duplicate the cube (construct ∛2). These constructions were considered 'mechanical' rather than 'geometric' — Pappus distinguished three categories: plane (compass+straightedge), solid (conic sections), and mechanical (neusis/spirals). The Greeks viewed compass-and-straightedge as the pure geometric standard, which is why Wantzel's 1837 proof was so philosophically significant.\n\n**19th century tool equivalences**: Georg Mohr (1672) and Lorenzo Mascheroni (1797) independently proved that a compass alone can do everything a compass-and-straightedge combination can — the straightedge adds nothing algebraically. Jean-Victor Poncelet and Jakob Steiner proved the Poncelet-Steiner theorem (1833): a straightedge together with one fixed circle (whose center is known) has the same constructive power as a full compass-and-straightedge. This completed the tool equivalences on the 'lower' side.\n\n**20th century algebraic characterization**: Andrew Gleason (1988) gave the precise algebraic condition for neusis-constructibility: a real number α is neusis-constructible iff [ℚ(α) : ℚ] divides some 2^a · 3^b. This exactly captures the ability to solve cubics (degree 3 extensions): since 3 = 2^0 · 3^1 is a 2-3 number, cos(20°) is neusis-constructible. The Pierpont primes (primes p = 2^a · 3^b + 1) play the role for neusis-constructible regular n-gons that Fermat primes play in the Gauss-Wantzel theorem.\n\n**Origami**: The Huzita-Justin axioms (1989/1991) for paper folding include HJ-6, which can solve cubic equations — making origami at least as powerful as neusis constructions.",
     "problemStatement": "Open question from angle-trisection: Are there natural generalizations to constructions with additional tools such as the marked ruler, origami, or compass-only? The answer is yes, and this formalization establishes the complete five-level hierarchy:\n\nstraightedge-only ⊊ {compass+straightedge = compass-only = straightedge+circle} ⊊ marked ruler ⊆ origami\n\nThe central algebraic fact is that neusis-constructibility corresponds exactly to the class of real numbers whose minimal polynomial degree over ℚ divides some 2^a · 3^b — the 2-3 numbers. Since cos(20°) satisfies a cubic (degree 3 = 2^0 · 3^1), it is neusis-constructible, in contrast to its non-constructibility by compass and straightedge.",

--- a/src/data/proofs/angle-trisection-oq-05-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-02/meta.json
@@ -36,6 +36,32 @@
       "Concrete examples: degrees 2, 3, 5, 7, 11, 100 are all omega-fold constructible"
     ]
   },
+  "references": [
+    {
+      "authors": "Alperin, Roger C.",
+      "title": "A mathematical theory of origami constructions and numbers",
+      "year": "2000",
+      "venue": "New York Journal of Mathematics 6, 119–133"
+    },
+    {
+      "authors": "Alperin, Roger C. and Lang, Robert J.",
+      "title": "One-, two-, and multi-fold origami axioms",
+      "year": "2009",
+      "venue": "Origami^4 (4OSME), A K Peters, 371–393"
+    },
+    {
+      "authors": "Martin, George E.",
+      "title": "Geometric Constructions",
+      "year": "1998",
+      "venue": "Undergraduate Texts in Mathematics, Springer"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "polynomial solvability and origami-constructible degrees; Mathlib.FieldTheory.Adjoin",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
   "overview": {
     "historicalContext": "The story of origami geometry begins with the classical Greek impossibility results. Gauss (1796) characterized ruler-and-compass constructible numbers as those in the tower of quadratic extensions of ℚ, and Wantzel (1837) proved rigorously that angle trisection and cube duplication are impossible with ruler and compass alone. The key obstruction: ruler-and-compass can only adjoin square roots, but trisection requires solving a cubic. Paper folding changes everything. A single Huzita-Hatori fold (1989–2001) simultaneously places two points onto two lines, solving systems of degree up to 3. Abe's 1980 method trisects any angle by origami. Beloch (1936) had already shown that single-fold origami can solve all cubic equations. The Huzita-Hatori axioms (H1–H7) give the full axiomatic foundation for single-fold origami, making the constructible numbers exactly the closure of ℚ under square roots and cube roots — strictly more powerful than ruler and compass. Alperin-Lang (2006) extended this to k simultaneous folds: k-fold origami corresponds to p_{k+1}-smooth degrees, where a degree is smooth if all its prime factors are at most p_{k+1} (the (k+1)-th prime). 1-fold gives the 3-smooth degrees (powers of 2 and 3); 2-fold gives the 5-smooth (regular numbers). For k ≥ 3, the sharp characterization is conjectured to be p_{k+1}-smooth. This file answers OQ-05-OQ-02: the existential question — does some fold level always work? Answer: YES, omega-fold origami (existential over all finite k) is algebraically complete, with degree 0 as the unique exception.",
     "problemStatement": "Can multi-fold origami solve ALL polynomial equations? More precisely, is omega-fold origami (allowing any finite number of simultaneous folds) algebraically complete — can it construct the roots of every polynomial of positive degree?",


### PR DESCRIPTION
Enrichment pass adding curated `references` to the 12 `angle-trisection-*` follow-up entries that had none.

Each entry gets 2–4 accurate references matched to its **specific** content on compass-and-straightedge (and generalized) constructibility, plus a Mathlib-module citation:

| Strand | Key references |
|--------|----------------|
| Gauss–Wantzel, Fermat primes, totient criteria | Gauss (*Disquisitiones*); Wantzel (1837); Stewart; Dummit–Foote |
| Galois-theoretic constructibility / 2-group criterion | Cox; Stewart; Dummit–Foote |
| neusis / Pierpont primes | Gleason (1988); Videla (1997); Martin |
| origami (multi-fold, ω-fold) | Alperin (2000); Alperin–Lang (2009); Martin |
| executable checker / log-step lower bound | Martin |

**Safety:** only the `references` key is added; all other meta.json keys verified deep-equal to origin/main for all 12 files. No Lean files touched.

Part of the references-gap cleanup.