### PR TITLE
Enrich area-of-circle OQ-children cluster: add references (22 entries)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -142,15 +142,6 @@
       "mathContext": "$\\omega_{2k} = \\pi^k(k!)^{-1} \\sim (\\pi e/k)^k/\\sqrt{2\\pi k}$; ratio $\\to 1$."
     }
   ],
-  "conclusion": {
-    "summary": "The exact even-subsequence asymptotic of the unit-ball volumes is established and machine-checked (0 sorries, 0 axioms): ω_{2k} ~[atTop] (πe/k)^k/√(2πk), equivalently ω_n ~ (2πe/n)^(n/2)/√(πn). The proof leverages the exact even closed form ω_{2k} = π^k/k! to reduce everything to Mathlib's Stirling formula for k!, then transports it through the calculus of asymptotic equivalence. Along the way the originally-posed leading constant √(2π/n) is corrected to the true 1/√(πn).",
-    "implications": "This pins the precise rate of the curse of dimensionality on the even subsequence: the ball volume decays super-exponentially like (πe/k)^k — faster than any geometric rate once k > πe — with polynomial prefactor 1/√(2πk). The work also demonstrates a robust formalization pattern (exact closed form + equivalence calculus) for converting a 'tends to 0' statement into a sharp asymptotic, and records a careful correction of a mis-stated constant rather than silently proving a different claim.",
-    "openQuestions": [
-      "Extend the exact asymptotic to the full (including odd) subsequence ω_n, where the half-integer Gamma values require the duplication formula or a direct Stirling estimate of Γ(n/2+1).",
-      "Quantify the second-order term: an asymptotic expansion ω_{2k} = (πe/k)^k/√(2πk)·(1 + c/k + O(1/k²)) from the refined Stirling series.",
-      "Determine the dimension k maximizing ω_{2k} (the volume peaks near n ≈ 5 and then decays) directly from the closed form π^k/k!."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
@@ -161,6 +152,43 @@
       "targetId": "area-of-circle",
       "relationship": "related",
       "description": "Part of the area-of-circle / ball-volume lineage: the n-dimensional generalization of the circle-area computation, here analyzed asymptotically in high dimension."
+    }
+  ],
+  "conclusion": {
+    "summary": "The exact even-subsequence asymptotic of the unit-ball volumes is established and machine-checked (0 sorries, 0 axioms): ω_{2k} ~[atTop] (πe/k)^k/√(2πk), equivalently ω_n ~ (2πe/n)^(n/2)/√(πn). The proof leverages the exact even closed form ω_{2k} = π^k/k! to reduce everything to Mathlib's Stirling formula for k!, then transports it through the calculus of asymptotic equivalence. Along the way the originally-posed leading constant √(2π/n) is corrected to the true 1/√(πn).",
+    "implications": "This pins the precise rate of the curse of dimensionality on the even subsequence: the ball volume decays super-exponentially like (πe/k)^k — faster than any geometric rate once k > πe — with polynomial prefactor 1/√(2πk). The work also demonstrates a robust formalization pattern (exact closed form + equivalence calculus) for converting a 'tends to 0' statement into a sharp asymptotic, and records a careful correction of a mis-stated constant rather than silently proving a different claim.",
+    "openQuestions": [
+      "Extend the exact asymptotic to the full (including odd) subsequence ω_n, where the half-integer Gamma values require the duplication formula or a direct Stirling estimate of Γ(n/2+1).",
+      "Quantify the second-order term: an asymptotic expansion ω_{2k} = (πe/k)^k/√(2πk)·(1 + c/k + O(1/k²)) from the refined Stirling series.",
+      "Determine the dimension k maximizing ω_{2k} (the volume peaks near n ≈ 5 and then decays) directly from the closed form π^k/k!."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Robbins, Herbert",
+      "title": "A Remark on Stirling's Formula",
+      "year": "1955",
+      "venue": "American Mathematical Monthly 62(1), 26–29"
+    },
+    {
+      "authors": "Smith, David J. and Vamanamurthy, Mavina K.",
+      "title": "How Small Is a Unit Ball?",
+      "year": "1989",
+      "venue": "Mathematics Magazine 62(2), 101–107",
+      "note": "Growth-then-decay of unit n-ball volume, the n=5 maximum, and monotonicity/shape properties."
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Real.Gamma, EuclideanSpace.volume_ball, and Stirling's formula (Mathlib.Analysis.SpecialFunctions.Gamma / .Stirling)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ]
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -159,14 +159,6 @@
       "mathContext": "Follow by composition from omega_tendsto_zero"
     }
   ],
-  "conclusion": {
-    "summary": "We prove ω_n → 0 as n → ∞ using: (1) the exact formula ω_{2k} = π^k/k! from the recurrence, (2) the inductive bound ω_{2k+1} ≤ 2·ω_{2k}, and (3) a squeeze argument via the exp series.",
-    "implications": "**Geometric significance**: The unit ball in high dimensions has negligible volume. This is the mathematical basis of the 'curse of dimensionality' — in machine learning and statistics, high-dimensional balls are essentially hollow, which explains why distance-based algorithms fail in high dimensions.\n\n**Optimal dimension**: The maximum ω_n occurs at n=5 (proved in a sibling proof). After n=5, the volumes are strictly decreasing and tend to 0.",
-    "openQuestions": [
-      "What is the rate of decay? Is ω_n ~ C · n^{-1/2} · (2πe/n)^{n/2} (Stirling approximation)?",
-      "Prove the exact asymptotics ω_n ~ √(2π/n) · (2πe/n)^{n/2} from Stirling's formula in Mathlib"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
@@ -179,7 +171,43 @@
       "description": "Root of the ball volume chain: π·r² for the 2-ball"
     }
   ],
-  "sorries": 0,
+  "conclusion": {
+    "summary": "We prove ω_n → 0 as n → ∞ using: (1) the exact formula ω_{2k} = π^k/k! from the recurrence, (2) the inductive bound ω_{2k+1} ≤ 2·ω_{2k}, and (3) a squeeze argument via the exp series.",
+    "implications": "**Geometric significance**: The unit ball in high dimensions has negligible volume. This is the mathematical basis of the 'curse of dimensionality' — in machine learning and statistics, high-dimensional balls are essentially hollow, which explains why distance-based algorithms fail in high dimensions.\n\n**Optimal dimension**: The maximum ω_n occurs at n=5 (proved in a sibling proof). After n=5, the volumes are strictly decreasing and tend to 0.",
+    "openQuestions": [
+      "What is the rate of decay? Is ω_n ~ C · n^{-1/2} · (2πe/n)^{n/2} (Stirling approximation)?",
+      "Prove the exact asymptotics ω_n ~ √(2π/n) · (2πe/n)^{n/2} from Stirling's formula in Mathlib"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Smith, David J. and Vamanamurthy, Mavina K.",
+      "title": "How Small Is a Unit Ball?",
+      "year": "1989",
+      "venue": "Mathematics Magazine 62(2), 101–107",
+      "note": "Growth-then-decay of unit n-ball volume, the n=5 maximum, and monotonicity/shape properties."
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston",
+      "note": "Functional equation Γ(x+1)=x·Γ(x) and log-convexity."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Real.Gamma, EuclideanSpace.volume_ball, and Stirling's formula (Mathlib.Analysis.SpecialFunctions.Gamma / .Stirling)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Proofs.AreaOfCircleOQ01OQ02OQ01OQ01",
@@ -198,5 +226,6 @@
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean"
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -126,14 +126,6 @@
       "mathContext": "Each computation uses `omega_recurrence` then the previously computed value, with `push_cast; ring` for algebra."
     }
   ],
-  "conclusion": {
-    "summary": "Fully verified formalization (0 axioms, 0 sorries) proving the recurrence $\\omega_{n+2} = (2\\pi/(n+2))\\cdot\\omega_n$ for unit ball volumes. Together with base cases $\\omega_0 = 1$ and $\\omega_1 = 2$, this provides a complete recursive algorithm for computing all unit ball volumes.",
-    "implications": "The recurrence provides a purely algebraic computation of unit ball volumes, avoiding direct Gamma function evaluation. This answers the open question affirmatively: all $\\omega_n$ are recursively computable from elementary arithmetic operations and $\\pi$.",
-    "openQuestions": [
-      "Does $\\omega_n \\to 0$ as $n \\to \\infty$? (Yes, provable from the recurrence: the factor $2\\pi/(n+2) < 1$ for $n > 2\\pi - 2$)",
-      "At which dimension is $\\omega_n$ maximized? ($n = 5$ gives the maximum among integer dimensions)"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-01-oq-02-oq-01",
@@ -144,6 +136,43 @@
       "targetId": "area-of-circle",
       "relationship": "ancestor",
       "description": "Root proof: A = πr² for the circle, the starting point of this OQ chain"
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified formalization (0 axioms, 0 sorries) proving the recurrence $\\omega_{n+2} = (2\\pi/(n+2))\\cdot\\omega_n$ for unit ball volumes. Together with base cases $\\omega_0 = 1$ and $\\omega_1 = 2$, this provides a complete recursive algorithm for computing all unit ball volumes.",
+    "implications": "The recurrence provides a purely algebraic computation of unit ball volumes, avoiding direct Gamma function evaluation. This answers the open question affirmatively: all $\\omega_n$ are recursively computable from elementary arithmetic operations and $\\pi$.",
+    "openQuestions": [
+      "Does $\\omega_n \\to 0$ as $n \\to \\infty$? (Yes, provable from the recurrence: the factor $2\\pi/(n+2) < 1$ for $n > 2\\pi - 2$)",
+      "At which dimension is $\\omega_n$ maximized? ($n = 5$ gives the maximum among integer dimensions)"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston",
+      "note": "Functional equation Γ(x+1)=x·Γ(x) and log-convexity."
+    },
+    {
+      "authors": "Smith, David J. and Vamanamurthy, Mavina K.",
+      "title": "How Small Is a Unit Ball?",
+      "year": "1989",
+      "venue": "Mathematics Magazine 62(2), 101–107",
+      "note": "Growth-then-decay of unit n-ball volume, the n=5 maximum, and monotonicity/shape properties."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Real.Gamma, EuclideanSpace.volume_ball, and Stirling's formula (Mathlib.Analysis.SpecialFunctions.Gamma / .Stirling)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-02/meta.json
@@ -153,15 +153,6 @@
       "mathContext": "These are the classical isoperimetric equalities for the circle and sphere written in the monomial form $S^n = c_n V^{n-1}$."
     }
   ],
-  "conclusion": {
-    "summary": "Fully verified formalization (0 axioms, 0 sorries) of the equality case and scale invariance of the n-dimensional isoperimetric inequality. The n-ball saturates Sⁿ = (nⁿ·ω_n)·V^(n-1), and its dimensionless isoperimetric quotient equals the optimal constant nⁿ·ω_n independent of radius, recovering the classical 4π (planar) and 36π (spatial) constants.",
-    "implications": "This pins the optimal isoperimetric constant nⁿ·ω_n as the value of the dimensionless quotient on the extremal body. It answers the parent's second open question to the extent the elementary monomial definitions allow: the equality structure and scale invariance are fully formalized.",
-    "openQuestions": [
-      "Can the inequality direction Sⁿ ≥ nⁿ·ω_n·V^(n-1) be formalized for general bodies (not just balls)? This requires the Brunn–Minkowski inequality or spherical symmetrization from geometric measure theory.",
-      "Can uniqueness of the ball as the equality case be characterized within Mathlib's measure-theoretic framework?",
-      "Does the constant nⁿ·ω_n → 0 super-exponentially, mirroring the thin-shell behavior of ω_n?"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-01-oq-02-oq-01",
@@ -182,6 +173,43 @@
       "targetId": "area-of-circle",
       "relationship": "ancestor",
       "description": "Root proof: A = πr² for the circle, the starting point of this OQ chain"
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified formalization (0 axioms, 0 sorries) of the equality case and scale invariance of the n-dimensional isoperimetric inequality. The n-ball saturates Sⁿ = (nⁿ·ω_n)·V^(n-1), and its dimensionless isoperimetric quotient equals the optimal constant nⁿ·ω_n independent of radius, recovering the classical 4π (planar) and 36π (spatial) constants.",
+    "implications": "This pins the optimal isoperimetric constant nⁿ·ω_n as the value of the dimensionless quotient on the extremal body. It answers the parent's second open question to the extent the elementary monomial definitions allow: the equality structure and scale invariance are fully formalized.",
+    "openQuestions": [
+      "Can the inequality direction Sⁿ ≥ nⁿ·ω_n·V^(n-1) be formalized for general bodies (not just balls)? This requires the Brunn–Minkowski inequality or spherical symmetrization from geometric measure theory.",
+      "Can uniqueness of the ball as the equality case be characterized within Mathlib's measure-theoretic framework?",
+      "Does the constant nⁿ·ω_n → 0 super-exponentially, mirroring the thin-shell behavior of ω_n?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Osserman, Robert",
+      "title": "The Isoperimetric Inequality",
+      "year": "1978",
+      "venue": "Bulletin of the American Mathematical Society 84(6), 1182–1238"
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "Smith, David J. and Vamanamurthy, Mavina K.",
+      "title": "How Small Is a Unit Ball?",
+      "year": "1989",
+      "venue": "Mathematics Magazine 62(2), 101–107",
+      "note": "Growth-then-decay of unit n-ball volume, the n=5 maximum, and monotonicity/shape properties."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Real.Gamma, EuclideanSpace.volume_ball, and Stirling's formula (Mathlib.Analysis.SpecialFunctions.Gamma / .Stirling)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -150,15 +150,6 @@
       "mathContext": "$(1-\\varepsilon)^n \\to 0$ since $|1-\\varepsilon| < 1$, so the shell fraction $1 - (1-\\varepsilon)^n \\to 1$."
     }
   ],
-  "conclusion": {
-    "summary": "Fully verified formalization (0 axioms, 0 sorries) proving that the unit n-ball volume ω_n converges to 0 as n → ∞. The proof combines the two-step recurrence (from sibling OQ01) with a geometric decay bound to establish convergence via an explicit ε-δ argument.",
-    "implications": "This formalizes a fundamental fact in high-dimensional geometry: the 'curse of dimensionality' for ball volumes. The geometric decay rate $(2/3)^{n/2}$ gives a concrete, quantitative bound on how fast the volumes vanish. The result has practical consequences: in $\\mathbb{R}^{100}$, the unit ball has negligible volume compared to the circumscribing cube $[-1,1]^{100}$ (ratio $\\sim 10^{-70}$), which means uniform sampling in high-dimensional cubes almost never hits the ball. Combined with the thin shell concentration, it explains why high-dimensional phenomena are qualitatively different from low-dimensional intuition.",
-    "openQuestions": [
-      "What is the precise asymptotic rate? Stirling's approximation gives $\\omega_n \\sim \\sqrt{2\\pi e/n} \\cdot (2\\pi e/n)^{n/2} / \\sqrt{\\pi}$, showing super-exponential decay",
-      "Can we formalize concentration of measure on the sphere (Lévy's lemma) building on this?",
-      "What is the dimension $n^*$ at which $\\omega_n$ achieves its maximum? (The answer is $n^* = 5$, with $\\omega_5 = 8\\pi^2/15$)"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-01-oq-02-oq-01",
@@ -184,6 +175,44 @@
       "targetId": "area-of-circle-oq-01-oq-02-oq-02",
       "relationship": "sibling",
       "description": "Sibling exploring surface area of the n-sphere, complementing the volume result"
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified formalization (0 axioms, 0 sorries) proving that the unit n-ball volume ω_n converges to 0 as n → ∞. The proof combines the two-step recurrence (from sibling OQ01) with a geometric decay bound to establish convergence via an explicit ε-δ argument.",
+    "implications": "This formalizes a fundamental fact in high-dimensional geometry: the 'curse of dimensionality' for ball volumes. The geometric decay rate $(2/3)^{n/2}$ gives a concrete, quantitative bound on how fast the volumes vanish. The result has practical consequences: in $\\mathbb{R}^{100}$, the unit ball has negligible volume compared to the circumscribing cube $[-1,1]^{100}$ (ratio $\\sim 10^{-70}$), which means uniform sampling in high-dimensional cubes almost never hits the ball. Combined with the thin shell concentration, it explains why high-dimensional phenomena are qualitatively different from low-dimensional intuition.",
+    "openQuestions": [
+      "What is the precise asymptotic rate? Stirling's approximation gives $\\omega_n \\sim \\sqrt{2\\pi e/n} \\cdot (2\\pi e/n)^{n/2} / \\sqrt{\\pi}$, showing super-exponential decay",
+      "Can we formalize concentration of measure on the sphere (Lévy's lemma) building on this?",
+      "What is the dimension $n^*$ at which $\\omega_n$ achieves its maximum? (The answer is $n^* = 5$, with $\\omega_5 = 8\\pi^2/15$)"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Smith, David J. and Vamanamurthy, Mavina K.",
+      "title": "How Small Is a Unit Ball?",
+      "year": "1989",
+      "venue": "Mathematics Magazine 62(2), 101–107",
+      "note": "Growth-then-decay of unit n-ball volume, the n=5 maximum, and monotonicity/shape properties."
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston",
+      "note": "Functional equation Γ(x+1)=x·Γ(x) and log-convexity."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Real.Gamma, EuclideanSpace.volume_ball, and Stirling's formula (Mathlib.Analysis.SpecialFunctions.Gamma / .Stirling)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -137,6 +137,16 @@
       "summary": "first_harmonic_deriv, first_harmonic_mean_zero, first_harmonic_sq_integral and first_harmonic_wirtinger_equality exhibit the first harmonic explicitly: derivative b cos t − a sin t (HasDerivAt.const_mul on cos/sin), zero mean over a period, energy ∫f²=π(a²+b²) via integral_cos_sq / integral_sin_sq / integral_sin_mul_cos₁, and the attained equality ∫f²=∫(f')²=π(a²+b²) (the derivative is again a first harmonic, so the same energy formula applies)."
     }
   ],
+  "crossReferences": [
+    {
+      "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01",
+      "relationship": "Parent: proves Wirtinger's inequality ∫f²≤∫(f')² (all five analytic axioms discharged 0-axiom); this entry characterizes its equality case."
+    },
+    {
+      "proofId": "area-of-circle-oq-01-oq-03",
+      "relationship": "Grandparent: supplies the axiom-free Fourier decomposition (Parseval for f and f' via integration by parts) reused here as IsoperimetricOQ.fourier_decomposition."
+    }
+  ],
   "conclusion": {
     "summary": "A fully verified (0 sorries, 0 axioms) 224-line file with 7 theorems and 1 definition characterizing the equality case of Wirtinger's inequality: for a mean-zero 2π-periodic C¹ function, ∫f² = ∫(f')² holds iff the Fourier support is the first harmonic {−1,+1} (wirtinger_equality_iff_first_harmonic). The concrete extremiser f(t)=a cos t + b sin t is exhibited with zero mean, energy π(a²+b²), and attained equality. This discharges the rigidity half of the isoperimetric problem on top of the parent's axiom-free inequality.",
     "implications": "This supplies the analytic core of isoperimetric rigidity — the statement that the circle is the unique extremiser of C²=4πA. The proof is purely spectral: the gap ∫(f')²−∫f² = Σ(n²−1)cₙ² is a sum of non-negative terms, and rigidity is the elementary fact that a non-negative sum vanishes iff every term does. Forcing the first-harmonic condition in both coordinates of a constant-speed closed curve yields a circle, completing the geometric rigidity statement. The reusable engine is Summable.tsum_pos applied to a manifestly non-negative spectral gap.",
@@ -146,14 +156,32 @@
       "Quantify the stability/near-equality regime: bound the deficit ∫(f')²−∫f² below by the energy in harmonics |n|≥2, yielding a quantitative isoperimetric inequality (Bonnesen-type) measuring how far a near-extremiser is from a circle."
     ]
   },
-  "crossReferences": [
+  "references": [
     {
-      "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01",
-      "relationship": "Parent: proves Wirtinger's inequality ∫f²≤∫(f')² (all five analytic axioms discharged 0-axiom); this entry characterizes its equality case."
+      "authors": "Hurwitz, Adolf",
+      "title": "Sur quelques applications géométriques des séries de Fourier",
+      "year": "1902",
+      "venue": "Annales Scientifiques de l'École Normale Supérieure 19, 357–408",
+      "note": "Fourier-series proof of the isoperimetric inequality and its equality case."
     },
     {
-      "proofId": "area-of-circle-oq-01-oq-03",
-      "relationship": "Grandparent: supplies the axiom-free Fourier decomposition (Parseval for f and f' via integration by parts) reused here as IsoperimetricOQ.fourier_decomposition."
+      "authors": "do Carmo, Manfredo P.",
+      "title": "Differential Geometry of Curves and Surfaces",
+      "year": "1976",
+      "venue": "Prentice-Hall",
+      "note": "Wirtinger's inequality, arc-length reparametrization, and the isoperimetric inequality for plane curves."
+    },
+    {
+      "authors": "Osserman, Robert",
+      "title": "The Isoperimetric Inequality",
+      "year": "1978",
+      "venue": "Bulletin of the American Mathematical Society 84(6), 1182–1238"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Arc length, curve reparametrization and volume lemmas (Mathlib.Geometry / Mathlib.MeasureTheory)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ]
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -125,6 +125,13 @@
       "summary": "isoperimetric_inequality_regular is the capstone. It applies exists_nice_reparam_for_regular (IFT, 0-axiom) to get a constant-speed (c = L/2π) zero-mean reparametrization ρ of γ, names S = ∫√(x²+y²) and Sxy = ∫(x²+y²), invokes the Wirtinger sum bound (Sxy ≤ 2πc²) and both Cauchy–Schwarz bounds (S² ≤ 2π·Sxy and |∫(x·y'−y·x')| ≤ c·S) on ρ, bridges 2·ρ.area = |∫(ρ.x·ρ.y' − ρ.y·ρ.x')|, and feeds everything to the kernel. ρ's circumference/area preservation transports the bound back to γ — 4πA ≤ L² with #print axioms reporting only propext / Classical.choice / Quot.sound."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent isoperimetric entry, which proved 4πA ≤ L² for smooth closed curves from five disclosed analytic axioms (Fourier decomposition, constant-speed reparametrization, the Wirtinger sum bound, and two Cauchy–Schwarz bounds). This capstone replaces every one of those axioms with its independently-discharged 0-axiom companion and assembles them into a fully axiom-free proof on the regular locus — the maximal honest endpoint, since the reparametrization axiom is genuinely false at stationary points."
+    }
+  ],
   "conclusion": {
     "summary": "Completes the Hurwitz isoperimetric program in Lean: $4\\pi A \\le L^2$ holds for every regular $C^1$ closed plane curve with positive circumference, proved with zero axioms (`#print axioms` reports only `propext / Classical.choice / Quot.sound`). The proof is pure assembly — the constant-speed zero-mean reparametrization (inverse function theorem), the Wirtinger/Fourier sum bound, and the two Cauchy–Schwarz bounds were each discharged axiom-free in a companion file, and this capstone wires them into the self-contained algebraic kernel $4\\pi A \\le L^2$. The algebraic kernel is re-proved locally so the result survives the parent file's bit-rot on the current Mathlib pin.",
     "implications": "This is the maximal honest 0-axiom endpoint of the parent's five-axiom proof: regularity (nowhere-vanishing speed) is not a convenience but a necessity, since the arc-length reparametrization is genuinely false at stationary points (the arc-length map is not strictly monotone, so the inverse function theorem yields no $C^1$ inverse). The work demonstrates a reusable formalization pattern — isolate an analytic proof's hard analytic facts as named axioms, discharge each independently in a self-contained companion, then reassemble — that turns an axiomatized gallery entry into a fully machine-checked theorem without re-deriving the entire chain at once. It also resolves a Wiedijk-100-adjacent target (the isoperimetric inequality) axiom-free on the regular locus.",
@@ -134,11 +141,32 @@
       "Higher dimensions: extend to the $n$-dimensional isoperimetric inequality $\\mathrm{vol}(\\partial\\Omega)^n \\ge n^n \\omega_n \\mathrm{vol}(\\Omega)^{n-1}$, where the Fourier/Wirtinger machinery is replaced by Brunn–Minkowski or symmetrization, and assess how much can be made axiom-free in Mathlib."
     ]
   },
-  "crossReferences": [
+  "references": [
     {
-      "targetId": "area-of-circle-oq-01-oq-02-oq-02-oq-01",
-      "relationship": "extends",
-      "description": "Parent isoperimetric entry, which proved 4πA ≤ L² for smooth closed curves from five disclosed analytic axioms (Fourier decomposition, constant-speed reparametrization, the Wirtinger sum bound, and two Cauchy–Schwarz bounds). This capstone replaces every one of those axioms with its independently-discharged 0-axiom companion and assembles them into a fully axiom-free proof on the regular locus — the maximal honest endpoint, since the reparametrization axiom is genuinely false at stationary points."
+      "authors": "Hurwitz, Adolf",
+      "title": "Sur quelques applications géométriques des séries de Fourier",
+      "year": "1902",
+      "venue": "Annales Scientifiques de l'École Normale Supérieure 19, 357–408",
+      "note": "Fourier-series proof of the isoperimetric inequality and its equality case."
+    },
+    {
+      "authors": "Osserman, Robert",
+      "title": "The Isoperimetric Inequality",
+      "year": "1978",
+      "venue": "Bulletin of the American Mathematical Society 84(6), 1182–1238"
+    },
+    {
+      "authors": "do Carmo, Manfredo P.",
+      "title": "Differential Geometry of Curves and Surfaces",
+      "year": "1976",
+      "venue": "Prentice-Hall",
+      "note": "Wirtinger's inequality, arc-length reparametrization, and the isoperimetric inequality for plane curves."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Arc length, curve reparametrization and volume lemmas (Mathlib.Geometry / Mathlib.MeasureTheory)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ]
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03/meta.json
@@ -167,16 +167,6 @@
       "mathContext": "Key theorem: `two_methods_one_area` — if inscribedArea(n,r) → A for any A, then A = FTC integral. Proof: `tendsto_nhds_unique`. This formalizes Archimedes' implicit assumption that the circle area is unique: any consistent approximation scheme converges to the same value in ℝ (Hausdorff space)."
     }
   ],
-  "conclusion": {
-    "summary": "Both Archimedes' exhaustion method and the FTC integration proof converge to πr², and this file formally proves they compute the same value. The connection is `tendsto_nhds_unique` — Hausdorff uniqueness of limits — which formalizes the 2250-year-old implicit assumption that the circle has a unique well-defined area. 14 theorems, 0 sorries, 0 axioms.",
-    "implications": "This formalization shows that Archimedes was implicitly using the Hausdorff property of ℝ. His exhaustion argument shows that the area is simultaneously ≤ πr² (by inscribed polygons) and ≥ πr² (by circumscribed polygons), concluding that it equals πr² by completeness. The modern proof via FTC is more direct but makes the same fundamental use of the limit structure of ℝ. Formally, both are special cases of the general principle that limits in Hausdorff spaces are unique.",
-    "openQuestions": [
-      "Can the connection be extended to circumscribed polygon approximations, giving a two-sided squeeze theorem that matches Archimedes' original double exhaustion?",
-      "Does the convergence rate of inscribed n-gons (error ~ π²r²/n²) match what one gets from numerical integration error bounds on the FTC integral?",
-      "Can Steiner's formula — $\\frac{d}{dr}\\text{Vol}(B_r) = \\text{Area}(\\partial B_r)$ — be formalized in Lean for balls in ℝⁿ, unifying the circle result with sphere and hypersphere cases?",
-      "Can the convergence rate of inscribed polygons be sharpened to an exact error formula, analogous to the explicit O(1/n²) bound proved in OQ-01-OQ-02 for the chord approximation? Specifically, can `inscribedArea(n,r) = πr² - π³r²/(3n²) + O(1/n⁴)` be formalized using the Taylor expansion sin(h) = h - h³/6 + ...?"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-01-oq-02",
@@ -202,6 +192,44 @@
       "targetId": "area-of-circle-oq-01-oq-02-oq-01",
       "relationship": "related",
       "description": "Generalizes the A = ∫ C dρ pattern to n dimensions (Steiner's formula); the circle case proved here is the n=2 base case"
+    }
+  ],
+  "conclusion": {
+    "summary": "Both Archimedes' exhaustion method and the FTC integration proof converge to πr², and this file formally proves they compute the same value. The connection is `tendsto_nhds_unique` — Hausdorff uniqueness of limits — which formalizes the 2250-year-old implicit assumption that the circle has a unique well-defined area. 14 theorems, 0 sorries, 0 axioms.",
+    "implications": "This formalization shows that Archimedes was implicitly using the Hausdorff property of ℝ. His exhaustion argument shows that the area is simultaneously ≤ πr² (by inscribed polygons) and ≥ πr² (by circumscribed polygons), concluding that it equals πr² by completeness. The modern proof via FTC is more direct but makes the same fundamental use of the limit structure of ℝ. Formally, both are special cases of the general principle that limits in Hausdorff spaces are unique.",
+    "openQuestions": [
+      "Can the connection be extended to circumscribed polygon approximations, giving a two-sided squeeze theorem that matches Archimedes' original double exhaustion?",
+      "Does the convergence rate of inscribed n-gons (error ~ π²r²/n²) match what one gets from numerical integration error bounds on the FTC integral?",
+      "Can Steiner's formula — $\\frac{d}{dr}\\text{Vol}(B_r) = \\text{Area}(\\partial B_r)$ — be formalized in Lean for balls in ℝⁿ, unifying the circle result with sphere and hypersphere cases?",
+      "Can the convergence rate of inscribed polygons be sharpened to an exact error formula, analogous to the explicit O(1/n²) bound proved in OQ-01-OQ-02 for the chord approximation? Specifically, can `inscribedArea(n,r) = πr² - π³r²/(3n²) + O(1/n⁴)` be formalized using the Taylor expansion sin(h) = h - h³/6 + ...?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Archimedes",
+      "title": "Measurement of a Circle",
+      "year": "c. 250 BCE",
+      "venue": "in T. L. Heath (ed.), The Works of Archimedes, Cambridge University Press, 1897"
+    },
+    {
+      "authors": "Edwards, C. H.",
+      "title": "The Historical Development of the Calculus",
+      "year": "1979",
+      "venue": "Springer",
+      "note": "Method of exhaustion and its modern relation to the Fundamental Theorem of Calculus."
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Interval integration, MeasureTheory.integral_gaussian and change-of-variables lemmas (Mathlib.Analysis.SpecialFunctions.Gaussian / Mathlib.MeasureTheory.Integral)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-01/meta.json
@@ -146,16 +146,6 @@
       "mathContext": "With constant speed $c = L/(2\\pi)$, the Fourier series of $\\gamma'$ satisfies Parseval's equality in a form equivalent to the Wirtinger inequality $\\|f'\\|^2 \\ge \\|f\\|^2$, yielding the isoperimetric inequality $L^2 \\ge 4\\pi A$."
     }
   ],
-  "conclusion": {
-    "summary": "The arc-length reparametrization theorem is formalized with 0 sorries and 0 axioms. The key new result is the periodic integral shift ∫_t^{t+T} f = ∫_0^T f (proved from Mathlib's integral_comp_add_left), which gives quasi-periodicity of arc-length and completes the sorry in the parent isoperimetric inequality proof. Surjectivity is proved via IVT. All 4 originally axiomatized theorems (IFT inverse, IFT derivative, circumference and area change-of-variables) are now fully proved.",
-    "implications": "This file provides the missing analytic infrastructure for the isoperimetric inequality (area-of-circle-oq-01-oq-03). The periodic integral shift lemma has broad applicability: it underlies Parseval's theorem for periodic functions, the Poisson summation formula, and many other harmonic analysis results. The arc-length reparametrization is the standard tool for normalizing curve geometry in Riemannian geometry, where it enables the definition of geodesic curvature and the Gauss-Bonnet theorem.",
-    "openQuestions": [
-      "Remove arcLengthInv_contDiff axiom: apply Mathlib's ContDiff.hasStrictFDerivAt_of_hasStrictFDerivAt to get the global C¹ inverse",
-      "Remove arcLengthInv_hasDerivAt axiom: derive from the IFT applied pointwise using Real.hasStrictDerivAt_inv",
-      "Remove change-of-variables axioms: use MeasureTheory.integral_image_eq_integral_abs_deriv_smul for the circumference integral",
-      "Extend to Lipschitz curves: arc-length reparametrization holds for Lipschitz regular curves too, using absolutely continuous functions"
-    ]
-  },
   "crossReferences": [
     {
       "relationship": "child-of",
@@ -166,6 +156,44 @@
       "relationship": "sibling",
       "description": "OQ-02 (Fourier IBP) and OQ-01 (arc-length reparam) are the two analytic pillars of the isoperimetric proof",
       "targetId": "area-of-circle-oq-01-oq-02-oq-02"
+    }
+  ],
+  "conclusion": {
+    "summary": "The arc-length reparametrization theorem is formalized with 0 sorries and 0 axioms. The key new result is the periodic integral shift ∫_t^{t+T} f = ∫_0^T f (proved from Mathlib's integral_comp_add_left), which gives quasi-periodicity of arc-length and completes the sorry in the parent isoperimetric inequality proof. Surjectivity is proved via IVT. All 4 originally axiomatized theorems (IFT inverse, IFT derivative, circumference and area change-of-variables) are now fully proved.",
+    "implications": "This file provides the missing analytic infrastructure for the isoperimetric inequality (area-of-circle-oq-01-oq-03). The periodic integral shift lemma has broad applicability: it underlies Parseval's theorem for periodic functions, the Poisson summation formula, and many other harmonic analysis results. The arc-length reparametrization is the standard tool for normalizing curve geometry in Riemannian geometry, where it enables the definition of geodesic curvature and the Gauss-Bonnet theorem.",
+    "openQuestions": [
+      "Remove arcLengthInv_contDiff axiom: apply Mathlib's ContDiff.hasStrictFDerivAt_of_hasStrictFDerivAt to get the global C¹ inverse",
+      "Remove arcLengthInv_hasDerivAt axiom: derive from the IFT applied pointwise using Real.hasStrictDerivAt_inv",
+      "Remove change-of-variables axioms: use MeasureTheory.integral_image_eq_integral_abs_deriv_smul for the circumference integral",
+      "Extend to Lipschitz curves: arc-length reparametrization holds for Lipschitz regular curves too, using absolutely continuous functions"
+    ]
+  },
+  "references": [
+    {
+      "authors": "do Carmo, Manfredo P.",
+      "title": "Differential Geometry of Curves and Surfaces",
+      "year": "1976",
+      "venue": "Prentice-Hall",
+      "note": "Wirtinger's inequality, arc-length reparametrization, and the isoperimetric inequality for plane curves."
+    },
+    {
+      "authors": "Osserman, Robert",
+      "title": "The Isoperimetric Inequality",
+      "year": "1978",
+      "venue": "Bulletin of the American Mathematical Society 84(6), 1182–1238"
+    },
+    {
+      "authors": "Hurwitz, Adolf",
+      "title": "Sur quelques applications géométriques des séries de Fourier",
+      "year": "1902",
+      "venue": "Annales Scientifiques de l'École Normale Supérieure 19, 357–408",
+      "note": "Fourier-series proof of the isoperimetric inequality and its equality case."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Arc length, curve reparametrization and volume lemmas (Mathlib.Geometry / Mathlib.MeasureTheory)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
@@ -112,14 +112,6 @@
       "mathContext": "For $n=0, r=0$: $\\text{Vol}(\\emptyset) = 0$ but $r^0 \\cdot \\text{unitBallVolume}(0) = 1 \\cdot 1 = 1$. Bug: $0^0 = 1$ in $\\mathbb{R}$."
     }
   ],
-  "conclusion": {
-    "summary": "A fully verified (0 sorries, 0 axioms) proof that Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)) for n ≥ 1. The key bridge is (√π)^n = π^(n/2). Also uncovers a genuine bug in the parent axiom at n=0, r=0.",
-    "implications": "The parent entry (area-of-circle-oq-02) can reduce its axiom count to 0 by replacing the axiom with a theorem with hypothesis n ≥ 1. All practical uses of the parent (n=2 for circles, n=3 for spheres) are covered.",
-    "openQuestions": [
-      "Can the parent axiom be fixed to work for all n ≥ 0 by changing the hypothesis from `0 ≤ r` to `0 < r`? (Yes, with a separate n=0 argument.)",
-      "Is there a single unified Lean theorem for all n ≥ 0 that avoids the 0^0 = 1 vs vol(∅) = 0 conflict?"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-02",
@@ -130,6 +122,43 @@
       "targetId": "area-of-circle",
       "relationship": "generalizes",
       "description": "The n=2 case recovers the original area-of-circle result A = πr²."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) proof that Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)) for n ≥ 1. The key bridge is (√π)^n = π^(n/2). Also uncovers a genuine bug in the parent axiom at n=0, r=0.",
+    "implications": "The parent entry (area-of-circle-oq-02) can reduce its axiom count to 0 by replacing the axiom with a theorem with hypothesis n ≥ 1. All practical uses of the parent (n=2 for circles, n=3 for spheres) are covered.",
+    "openQuestions": [
+      "Can the parent axiom be fixed to work for all n ≥ 0 by changing the hypothesis from `0 ≤ r` to `0 < r`? (Yes, with a separate n=0 argument.)",
+      "Is there a single unified Lean theorem for all n ≥ 0 that avoids the 0^0 = 1 vs vol(∅) = 0 conflict?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston",
+      "note": "Functional equation Γ(x+1)=x·Γ(x) and log-convexity."
+    },
+    {
+      "authors": "Smith, David J. and Vamanamurthy, Mavina K.",
+      "title": "How Small Is a Unit Ball?",
+      "year": "1989",
+      "venue": "Mathematics Magazine 62(2), 101–107",
+      "note": "Growth-then-decay of unit n-ball volume, the n=5 maximum, and monotonicity/shape properties."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Real.Gamma, EuclideanSpace.volume_ball, and Stirling's formula (Mathlib.Analysis.SpecialFunctions.Gamma / .Stirling)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-02/meta.json
@@ -144,15 +144,6 @@
       "mathContext": "$\\mathrm{vol}(B^n(1)) \\to 0$ in $\\mathbb{R}$ as $n \\to \\infty$."
     }
   ],
-  "conclusion": {
-    "summary": "A fully verified (0 sorries, 0 axioms) proof that the unit n-ball volume Vₙ = π^(n/2)/Γ(n/2+1) vanishes as n → ∞, together with the corresponding statement for the genuine Lebesgue measure of the Euclidean unit ball. The argument is elementary: an exact even closed form πᵐ/m!, a uniform odd bound 2·πᵐ/m!, and an ε–N parity combination.",
-    "implications": "Formalizes the 'concentration of measure' fact that high-dimensional balls are negligible relative to their bounding cubes. The self-contained recurrence and scaling derivations make the entry independent of the parent file's axiom.",
-    "openQuestions": [
-      "Quantify the decay rate: prove Vₙ ~ (2πe/n)^(n/2)/√(nπ) (Stirling) and a clean exponential upper bound.",
-      "Locate the maximum rigorously: prove Vₙ is increasing for n ≤ 5 and decreasing for n ≥ 5 in one statement.",
-      "Extend to the ratio Vₙ/2ⁿ (ball vs. bounding cube), showing it tends to 0 super-exponentially."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-02",
@@ -163,6 +154,44 @@
       "targetId": "area-of-circle-oq-02-oq-01",
       "relationship": "related",
       "description": "Both derive the Euclidean scaling law from EuclideanSpace.volume_ball; this entry uses the n = 1 unit-ball case for its measure-theoretic corollary."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) proof that the unit n-ball volume Vₙ = π^(n/2)/Γ(n/2+1) vanishes as n → ∞, together with the corresponding statement for the genuine Lebesgue measure of the Euclidean unit ball. The argument is elementary: an exact even closed form πᵐ/m!, a uniform odd bound 2·πᵐ/m!, and an ε–N parity combination.",
+    "implications": "Formalizes the 'concentration of measure' fact that high-dimensional balls are negligible relative to their bounding cubes. The self-contained recurrence and scaling derivations make the entry independent of the parent file's axiom.",
+    "openQuestions": [
+      "Quantify the decay rate: prove Vₙ ~ (2πe/n)^(n/2)/√(nπ) (Stirling) and a clean exponential upper bound.",
+      "Locate the maximum rigorously: prove Vₙ is increasing for n ≤ 5 and decreasing for n ≥ 5 in one statement.",
+      "Extend to the ratio Vₙ/2ⁿ (ball vs. bounding cube), showing it tends to 0 super-exponentially."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Smith, David J. and Vamanamurthy, Mavina K.",
+      "title": "How Small Is a Unit Ball?",
+      "year": "1989",
+      "venue": "Mathematics Magazine 62(2), 101–107",
+      "note": "Growth-then-decay of unit n-ball volume, the n=5 maximum, and monotonicity/shape properties."
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston",
+      "note": "Functional equation Γ(x+1)=x·Γ(x) and log-convexity."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Real.Gamma, EuclideanSpace.volume_ball, and Stirling's formula (Mathlib.Analysis.SpecialFunctions.Gamma / .Stirling)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle-oq-02-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-03/meta.json
@@ -123,14 +123,6 @@
       "mathContext": "$S_1=2$ (two endpoints), $S_2=2\\pi$ (circumference), $S_3=4\\pi$ (sphere surface)."
     }
   ],
-  "conclusion": {
-    "summary": "A fully verified (0 sorries, 0 axioms) proof that the unit (n−1)-sphere surface measure Sₙ = 2π^(n/2)/Γ(n/2) equals n times the unit n-ball volume Vₙ = π^(n/2)/Γ(n/2+1). Defining surface area by its own Gamma closed form makes Sₙ=n·Vₙ a genuine theorem — a restatement of the Gamma functional equation Γ(n/2+1)=(n/2)·Γ(n/2) — rather than a definitional identity. Special values recover S₁=2, S₂=2π, S₃=4π.",
-    "implications": "Completes the volume–surface pair of Gamma closed forms for the n-ball/sphere, exhibiting the divergence-theorem scaling Sₙ=n·Vₙ at the level of the explicit formulas. The half-dimension shift Γ(n/2+1)↔Γ(n/2) is identified as the source of the proportionality constant n.",
-    "openQuestions": [
-      "Connect this algebraic identity to a measure-theoretic statement: that 2π^(n/2)/Γ(n/2) is the actual (n−1)-Hausdorff measure of the unit sphere in ℝⁿ, via Mathlib's surface-measure API.",
-      "Derive the radial-shell integral Vₙ = ∫₀¹ Sₙ rⁿ⁻¹ dr directly, recovering Sₙ=n·Vₙ from the Fundamental Theorem of Calculus rather than the Gamma recurrence."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-02",
@@ -141,6 +133,42 @@
       "targetId": "area-of-circle-oq-01-oq-02-oq-01",
       "relationship": "complements",
       "description": "That file defines surface area differentially (n·ωₙ·r^(n−1)); this file defines it via an independent Gamma closed form, so Sₙ=n·Vₙ becomes a theorem rather than a definition."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) proof that the unit (n−1)-sphere surface measure Sₙ = 2π^(n/2)/Γ(n/2) equals n times the unit n-ball volume Vₙ = π^(n/2)/Γ(n/2+1). Defining surface area by its own Gamma closed form makes Sₙ=n·Vₙ a genuine theorem — a restatement of the Gamma functional equation Γ(n/2+1)=(n/2)·Γ(n/2) — rather than a definitional identity. Special values recover S₁=2, S₂=2π, S₃=4π.",
+    "implications": "Completes the volume–surface pair of Gamma closed forms for the n-ball/sphere, exhibiting the divergence-theorem scaling Sₙ=n·Vₙ at the level of the explicit formulas. The half-dimension shift Γ(n/2+1)↔Γ(n/2) is identified as the source of the proportionality constant n.",
+    "openQuestions": [
+      "Connect this algebraic identity to a measure-theoretic statement: that 2π^(n/2)/Γ(n/2) is the actual (n−1)-Hausdorff measure of the unit sphere in ℝⁿ, via Mathlib's surface-measure API.",
+      "Derive the radial-shell integral Vₙ = ∫₀¹ Sₙ rⁿ⁻¹ dr directly, recovering Sₙ=n·Vₙ from the Fundamental Theorem of Calculus rather than the Gamma recurrence."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston",
+      "note": "Functional equation Γ(x+1)=x·Γ(x) and log-convexity."
+    },
+    {
+      "authors": "Osserman, Robert",
+      "title": "The Isoperimetric Inequality",
+      "year": "1978",
+      "venue": "Bulletin of the American Mathematical Society 84(6), 1182–1238"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Real.Gamma, EuclideanSpace.volume_ball, and Stirling's formula (Mathlib.Analysis.SpecialFunctions.Gamma / .Stirling)",
+      "year": "2024",
+      "venue": "Mathlib4"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/area-of-circle-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-01/meta.json
@@ -109,25 +109,6 @@
       "mathContext": "For $n \\geq 3$: $2\\pi/n > 0$, so $\\sin(2\\pi/n) < 2\\pi/n$ by `Real.sin_lt`. Then $A_n = nr^2/2 \\cdot \\sin(2\\pi/n) < nr^2/2 \\cdot 2\\pi/n = \\pi r^2$. Combined with the lower bound: $0 < \\pi r^2 - A_n \\leq 2\\pi^3 r^2/(3n^2)$ — the inscribed polygon is always below but within $O(1/n^2)$ of the circle area."
     }
   ],
-  "conclusion": {
-    "summary": "The convergence rate of inscribed polygon areas to $\\pi r^2$ is proved with an explicit $O(1/n^2)$ bound. The proof demonstrates the MVT-as-bootstrapping technique: use derivative bounds to establish function bounds without the explicit Taylor remainder formula. All 9 theorems are verified with 0 axioms and 0 sorries.",
-    "implications": "This formalization gives the first machine-verified, quantitative version of Archimedes' method for approximating $\\pi$ via inscribed polygons. The explicit bound $|A_n - \\pi r^2| \\leq 2\\pi^3r^2/(3n^2)$ shows the convergence is 'second-order': doubling the number of sides reduces the error by a factor of 4. For error tolerance $\\varepsilon$ (relative to $\\pi r^2$), one needs $n \\approx \\pi\\sqrt{2/(3\\varepsilon)}$ sides.",
-    "openQuestions": [
-      "Prove the circumscribed polygon bound: the area $A_n^{\\text{circ}}$ of the circumscribed $n$-gon satisfies $A_n^{\\text{circ}} - \\pi r^2 \\leq 2\\pi^3r^2/(3n^2)$ with a similar bound from the other side.",
-      "Prove the sharpness: $\\pi r^2 - A_n \\geq c/n^2$ for some $c > 0$. The leading term is exactly $2\\pi^3r^2/(3n^2)$, so the upper bound is tight to leading order.",
-      "Prove convergence of the polygon perimeter to $2\\pi r$: the perimeter of the inscribed $n$-gon is $P_n = 2nr\\sin(\\pi/n)$, and $P_n \\to 2\\pi r$ at rate $O(1/n^2)$ similarly.",
-      "Can the Viète product $2/\\pi = (\\sqrt{2}/2)(\\sqrt{2+\\sqrt{2}}/2)\\cdots$ be formalized in Lean as the limit of the inscribed polygon recursion? This would give the first machine-verified proof of Viète's formula."
-    ]
-  },
-  "leanFile": {
-    "namespace": "AreaOfCircleOQ03OQ01",
-    "lineCount": 232,
-    "axiomCount": 0,
-    "theoremCount": 9,
-    "definitionCount": 1,
-    "path": "Proofs/AreaOfCircleOQ03OQ01.lean",
-    "sorries": 0
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle",
@@ -155,5 +136,52 @@
       "description": "OQ-03-OQ-03 proves parabolic exhaustion has geometric convergence (ratio 1/4) — exponentially faster than this file's O(1/n²) polynomial rate for circle inscribed polygons"
     }
   ],
+  "conclusion": {
+    "summary": "The convergence rate of inscribed polygon areas to $\\pi r^2$ is proved with an explicit $O(1/n^2)$ bound. The proof demonstrates the MVT-as-bootstrapping technique: use derivative bounds to establish function bounds without the explicit Taylor remainder formula. All 9 theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "This formalization gives the first machine-verified, quantitative version of Archimedes' method for approximating $\\pi$ via inscribed polygons. The explicit bound $|A_n - \\pi r^2| \\leq 2\\pi^3r^2/(3n^2)$ shows the convergence is 'second-order': doubling the number of sides reduces the error by a factor of 4. For error tolerance $\\varepsilon$ (relative to $\\pi r^2$), one needs $n \\approx \\pi\\sqrt{2/(3\\varepsilon)}$ sides.",
+    "openQuestions": [
+      "Prove the circumscribed polygon bound: the area $A_n^{\\text{circ}}$ of the circumscribed $n$-gon satisfies $A_n^{\\text{circ}} - \\pi r^2 \\leq 2\\pi^3r^2/(3n^2)$ with a similar bound from the other side.",
+      "Prove the sharpness: $\\pi r^2 - A_n \\geq c/n^2$ for some $c > 0$. The leading term is exactly $2\\pi^3r^2/(3n^2)$, so the upper bound is tight to leading order.",
+      "Prove convergence of the polygon perimeter to $2\\pi r$: the perimeter of the inscribed $n$-gon is $P_n = 2nr\\sin(\\pi/n)$, and $P_n \\to 2\\pi r$ at rate $O(1/n^2)$ similarly.",
+      "Can the Viète product $2/\\pi = (\\sqrt{2}/2)(\\sqrt{2+\\sqrt{2}}/2)\\cdots$ be formalized in Lean as the limit of the inscribed polygon recursion? This would give the first machine-verified proof of Viète's formula."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Archimedes",
+      "title": "Measurement of a Circle",
+      "year": "c. 250 BCE",
+      "venue": "in T. L. Heath (ed.), The Works of Archimedes, Cambridge University Press, 1897"
+    },
+    {
+      "authors": "Edwards, C. H.",
+      "title": "The Historical Development of the Calculus",
+      "year": "1979",
+      "venue": "Springer",
+      "note": "Method of exhaustion and its modern relation to the Fundamental Theorem of Calculus."
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Interval integration, MeasureTheory.integral_gaussian and change-of-variables lemmas (Mathlib.Analysis.SpecialFunctions.Gaussian / Mathlib.MeasureTheory.Integral)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "namespace": "AreaOfCircleOQ03OQ01",
+    "lineCount": 232,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/AreaOfCircleOQ03OQ01.lean",
+    "sorries": 0
+  },
   "sorries": 0
 }

--- a/src/data/proofs/area-of-circle-oq-03-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-03-oq-02/meta.json
@@ -113,30 +113,6 @@
       "mathContext": "$\\frac{4}{3}T_0 - T_0 \\sum_{k=0}^{n-1}(1/4)^k = \\frac{4}{3}T_0 \\cdot (1/4)^n > 0$ for $T_0 > 0$. As $n \\to \\infty$, the gap vanishes, confirming the area of the parabolic segment is $\\frac{4}{3}T_0$."
     }
   ],
-  "conclusion": {
-    "summary": "Formalizes the missing geometric fact behind Archimedes' parabolic exhaustion: the sub-triangle area ratio is exactly 1/4. For y = x², the triangle area (b-a)³/8 is cubic in interval length, so halving gives 1/8 per sub-triangle and 1/4 total. This ratio generates the geometric series 1 + 1/4 + 1/16 + ... = 4/3 that Archimedes computed in the Quadrature of the Parabola. 12 theorems, 1 definition, 0 axioms, 0 sorries.",
-    "implications": "This fills a gap in the parent proof (AreaOfCircleOQ03OQ03), which proved the geometric series sum but noted as an open question that the 1/4 ratio itself was not formally justified. The cubic dependence on interval length also explains why the parabola is the unique conic section with ratio exactly 1/4.",
-    "openQuestions": [
-      "For the general power curve y = x^p, what is the sub-triangle area ratio? The area formula generalizes to expressions involving (b-a)^(p+1). For p = 3, the ratio would be different and the corresponding series would have a different sum.",
-      "Can this coordinate-free be proved without coordinates, as Archimedes did? A synthetic proof would use only the reflection property of parabolas and properties of tangent lines."
-    ]
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
-      "Mathlib.Tactic"
-    ],
-    "opens": [
-      "Real"
-    ],
-    "namespace": "AreaOfCircleOQ03OQ03OQ02",
-    "lineCount": 189,
-    "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 1,
-    "path": "Proofs/AreaOfCircleOQ03OQ03OQ02.lean",
-    "sorries": 0
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-03-oq-03",
@@ -154,5 +130,56 @@
       "description": "Root proof in the area-of-circle family"
     }
   ],
+  "conclusion": {
+    "summary": "Formalizes the missing geometric fact behind Archimedes' parabolic exhaustion: the sub-triangle area ratio is exactly 1/4. For y = x², the triangle area (b-a)³/8 is cubic in interval length, so halving gives 1/8 per sub-triangle and 1/4 total. This ratio generates the geometric series 1 + 1/4 + 1/16 + ... = 4/3 that Archimedes computed in the Quadrature of the Parabola. 12 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "This fills a gap in the parent proof (AreaOfCircleOQ03OQ03), which proved the geometric series sum but noted as an open question that the 1/4 ratio itself was not formally justified. The cubic dependence on interval length also explains why the parabola is the unique conic section with ratio exactly 1/4.",
+    "openQuestions": [
+      "For the general power curve y = x^p, what is the sub-triangle area ratio? The area formula generalizes to expressions involving (b-a)^(p+1). For p = 3, the ratio would be different and the corresponding series would have a different sum.",
+      "Can this coordinate-free be proved without coordinates, as Archimedes did? A synthetic proof would use only the reflection property of parabolas and properties of tangent lines."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Archimedes",
+      "title": "Quadrature of the Parabola",
+      "year": "c. 250 BCE",
+      "venue": "in T. L. Heath (ed.), The Works of Archimedes, Cambridge University Press, 1897"
+    },
+    {
+      "authors": "Edwards, C. H.",
+      "title": "The Historical Development of the Calculus",
+      "year": "1979",
+      "venue": "Springer",
+      "note": "Method of exhaustion and its modern relation to the Fundamental Theorem of Calculus."
+    },
+    {
+      "authors": "Archimedes",
+      "title": "Measurement of a Circle",
+      "year": "c. 250 BCE",
+      "venue": "in T. L. Heath (ed.), The Works of Archimedes, Cambridge University Press, 1897"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Interval integration, MeasureTheory.integral_gaussian and change-of-variables lemmas (Mathlib.Analysis.SpecialFunctions.Gaussian / Mathlib.MeasureTheory.Integral)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "AreaOfCircleOQ03OQ03OQ02",
+    "lineCount": 189,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "path": "Proofs/AreaOfCircleOQ03OQ03OQ02.lean",
+    "sorries": 0
+  },
   "sorries": 0
 }

--- a/src/data/proofs/area-of-circle-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-03/meta.json
@@ -116,35 +116,6 @@
       "mathContext": "The theorem `exhaustion_error_small` states: $\\forall \\varepsilon > 0, \\exists N, C \\cdot r^N < \\varepsilon$. Proof pipeline: `tendsto_pow_atTop_nhds_zero_of_lt_one` → `Filter.Tendsto` → `Metric.tendsto_atTop` → extract $N$ with $|r^N - 0| < \\varepsilon/C$ → multiply by $C$ via `mul_lt_mul_of_pos_left`. This is the $\\varepsilon$-$N$ formulation of geometric convergence, abstracting the specific base $r = 1/4$ (parabola) or polynomial $O(1/n^2)$ (circles)."
     }
   ],
-  "conclusion": {
-    "summary": "The method of exhaustion generalizes to ellipses (algebraically stated via scaling) and parabolas (fully formalized via Archimedes' geometric series $1 + 1/4 + \\cdots = 4/3$). The parabolic exhaustion gives explicit error bounds $(4/3)(1/4)^n$ with exponential convergence. The general exhaustion principle (geometric convergence $C \\cdot r^n \\to 0$) is proved using Mathlib's `tendsto_pow_atTop_nhds_zero_of_lt_one`. 14 theorems, 0 axioms, 0 sorries.",
-    "implications": "This formalizes one of the oldest infinite series computations in mathematics: Archimedes' *Quadrature of the Parabola* (c. 250 BCE). The convergence rate comparison illuminates why Archimedes' parabola proof is so elegant: the geometric series with ratio 1/4 converges exponentially, while the circle polygon approximation converges only polynomially ($O(1/n^2)$). The parabola is easier to exhaust than the circle.",
-    "openQuestions": [
-      "Prove the ellipse area formula rigorously using Mathlib's measure-theoretic change of variables. The `MeasureTheory.MeasurePreserving` API or `integral_comp_mul_right` may provide the right tools. The current proof is an algebraic placeholder.",
-      "Formalize Archimedes' proof that the sub-triangles in parabolic exhaustion have area exactly 1/4 of their parent. This requires showing that the vertex of the new triangle (the midpoint of the parabolic arc) achieves exactly 1/4 the parent area — a non-trivial geometric fact about parabolas.",
-      "Can Archimedes' spiral area computation ($A = \\pi r^2/3$ for the first turn of $r = \\theta$) be formalized? It requires integrating $r^2/2 \\cdot d\\theta = \\theta^2/2 \\cdot d\\theta$ in polar coordinates.",
-      "Prove the ellipsoid surface area formula via scaling from the sphere. Unlike the area formula, surface area under affine maps does not simply scale by the Jacobian — it requires the Gram determinant of the map restricted to the surface."
-    ]
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
-      "Mathlib.Analysis.SpecialFunctions.Integrals",
-      "Mathlib.MeasureTheory.Integral.IntervalIntegral",
-      "Mathlib.Tactic"
-    ],
-    "opens": [
-      "Real",
-      "MeasureTheory"
-    ],
-    "namespace": "AreaOfCircleOQ03OQ03",
-    "lineCount": 190,
-    "axiomCount": 0,
-    "theoremCount": 14,
-    "definitionCount": 0,
-    "path": "Proofs/AreaOfCircleOQ03OQ03.lean",
-    "sorries": 0
-  },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-03",
@@ -172,5 +143,61 @@
       "description": "Archimedes-FTC connection: proves inscribed polygons converge to πr²; the parabola's geometric convergence (ratio 1/4) contrasts with the polygon's polynomial convergence O(1/n²)"
     }
   ],
+  "conclusion": {
+    "summary": "The method of exhaustion generalizes to ellipses (algebraically stated via scaling) and parabolas (fully formalized via Archimedes' geometric series $1 + 1/4 + \\cdots = 4/3$). The parabolic exhaustion gives explicit error bounds $(4/3)(1/4)^n$ with exponential convergence. The general exhaustion principle (geometric convergence $C \\cdot r^n \\to 0$) is proved using Mathlib's `tendsto_pow_atTop_nhds_zero_of_lt_one`. 14 theorems, 0 axioms, 0 sorries.",
+    "implications": "This formalizes one of the oldest infinite series computations in mathematics: Archimedes' *Quadrature of the Parabola* (c. 250 BCE). The convergence rate comparison illuminates why Archimedes' parabola proof is so elegant: the geometric series with ratio 1/4 converges exponentially, while the circle polygon approximation converges only polynomially ($O(1/n^2)$). The parabola is easier to exhaust than the circle.",
+    "openQuestions": [
+      "Prove the ellipse area formula rigorously using Mathlib's measure-theoretic change of variables. The `MeasureTheory.MeasurePreserving` API or `integral_comp_mul_right` may provide the right tools. The current proof is an algebraic placeholder.",
+      "Formalize Archimedes' proof that the sub-triangles in parabolic exhaustion have area exactly 1/4 of their parent. This requires showing that the vertex of the new triangle (the midpoint of the parabolic arc) achieves exactly 1/4 the parent area — a non-trivial geometric fact about parabolas.",
+      "Can Archimedes' spiral area computation ($A = \\pi r^2/3$ for the first turn of $r = \\theta$) be formalized? It requires integrating $r^2/2 \\cdot d\\theta = \\theta^2/2 \\cdot d\\theta$ in polar coordinates.",
+      "Prove the ellipsoid surface area formula via scaling from the sphere. Unlike the area formula, surface area under affine maps does not simply scale by the Jacobian — it requires the Gram determinant of the map restricted to the surface."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Archimedes",
+      "title": "Quadrature of the Parabola",
+      "year": "c. 250 BCE",
+      "venue": "in T. L. Heath (ed.), The Works of Archimedes, Cambridge University Press, 1897"
+    },
+    {
+      "authors": "Archimedes",
+      "title": "Measurement of a Circle",
+      "year": "c. 250 BCE",
+      "venue": "in T. L. Heath (ed.), The Works of Archimedes, Cambridge University Press, 1897"
+    },
+    {
+      "authors": "Edwards, C. H.",
+      "title": "The Historical Development of the Calculus",
+      "year": "1979",
+      "venue": "Springer",
+      "note": "Method of exhaustion and its modern relation to the Fundamental Theorem of Calculus."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Interval integration, MeasureTheory.integral_gaussian and change-of-variables lemmas (Mathlib.Analysis.SpecialFunctions.Gaussian / Mathlib.MeasureTheory.Integral)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Integrals",
+      "Mathlib.MeasureTheory.Integral.IntervalIntegral",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "AreaOfCircleOQ03OQ03",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ03OQ03.lean",
+    "sorries": 0
+  },
   "sorries": 0
 }

--- a/src/data/proofs/area-of-circle-oq-05-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01-incomplete-01/meta.json
@@ -77,34 +77,6 @@
       "Mathlib polarCoord: PartialHomeomorph (ℝ×ℝ) (ℝ×ℝ)"
     ]
   },
-  "crossReferences": [
-    {
-      "targetId": "area-of-circle-oq-05-oq-01",
-      "relationship": "extends",
-      "description": "Generalizes the parent's explicit polar proof from the unit Gaussian (a = 1) to arbitrary a > 0, and reuses its verified angular_integral (∫_{-π}^π 1 dθ = 2π)"
-    },
-    {
-      "targetId": "area-of-circle-oq-05",
-      "relationship": "related",
-      "description": "AreaOfCircleOQ05.scaled_gaussian proves the same √(π/a) formula directly via Mathlib's integral_gaussian; this entry derives it through the explicit polar method instead"
-    }
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
-      "Mathlib.Analysis.SpecialFunctions.PolarCoord",
-      "Mathlib.Tactic",
-      "Proofs.AreaOfCircleOQ05",
-      "Proofs.AreaOfCircleOQ05OQ01"
-    ],
-    "namespace": "AreaOfCircleOQ05OQ01Incomplete01",
-    "lineCount": 203,
-    "axiomCount": 0,
-    "theoremCount": 9,
-    "definitionCount": 0,
-    "path": "Proofs/AreaOfCircleOQ05OQ01Incomplete01.lean",
-    "sorries": 0
-  },
   "sections": [
     {
       "id": "sec-fubini-scaled",
@@ -163,6 +135,18 @@
       "mathContext": "At $a = 1$: $\\int_{-\\infty}^\\infty e^{-x^2} dx = \\sqrt{\\pi/1} = \\sqrt{\\pi}$."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Generalizes the parent's explicit polar proof from the unit Gaussian (a = 1) to arbitrary a > 0, and reuses its verified angular_integral (∫_{-π}^π 1 dθ = 2π)"
+    },
+    {
+      "targetId": "area-of-circle-oq-05",
+      "relationship": "related",
+      "description": "AreaOfCircleOQ05.scaled_gaussian proves the same √(π/a) formula directly via Mathlib's integral_gaussian; this entry derives it through the explicit polar method instead"
+    }
+  ],
   "conclusion": {
     "summary": "Carries the explicit polar-coordinate derivation of the Gaussian integral through for an arbitrary scale a > 0, proving (∫ e^{-a x²})² = π/a and ∫ e^{-a x²} = √(π/a). The single a-dependent ingredient is the radial integral 1/(2a); the angular factor 2π is reused from the verified parent. All ten theorems compile with 0 sorries and 0 axioms.",
     "implications": "Closes the gap between the gallery's black-box scaled Gaussian (via integral_gaussian) and its explicit unit-case polar proof: the geometric polar derivation generalizes cleanly to every scale, with π/a arising as (radial 1/(2a)) × (angular 2π).",
@@ -170,6 +154,51 @@
       "Generalize further to anisotropic Gaussians ∫∫ e^{-(a x² + b y²)} = π/√(ab) via an elliptical change of variables",
       "Formalize the multivariate Gaussian ∫_{ℝⁿ} e^{-x·Ax} = π^{n/2}/√(det A) for positive-definite A"
     ]
+  },
+  "references": [
+    {
+      "authors": "Stein, Elias M. and Shakarchi, Rami",
+      "title": "Real Analysis: Measure Theory, Integration, and Hilbert Spaces",
+      "year": "2005",
+      "venue": "Princeton University Press",
+      "note": "Gaussian integral via the polar-coordinate (Poisson) trick and Fubini's theorem."
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston",
+      "note": "Functional equation Γ(x+1)=x·Γ(x) and log-convexity."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Interval integration, MeasureTheory.integral_gaussian and change-of-variables lemmas (Mathlib.Analysis.SpecialFunctions.Gaussian / Mathlib.MeasureTheory.Integral)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Analysis.SpecialFunctions.PolarCoord",
+      "Mathlib.Tactic",
+      "Proofs.AreaOfCircleOQ05",
+      "Proofs.AreaOfCircleOQ05OQ01"
+    ],
+    "namespace": "AreaOfCircleOQ05OQ01Incomplete01",
+    "lineCount": 203,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ05OQ01Incomplete01.lean",
+    "sorries": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -75,22 +75,6 @@
       "Positive-definite matrices (Mathlib.Analysis.Matrix.PosDef): PosDef, eigenvalues_pos"
     ]
   },
-  "crossReferences": [
-    {
-      "id": "xref-oq05-parent",
-      "targetId": "area-of-circle-oq-05",
-      "targetTitle": "The Gaussian Integral and the Area of a Circle",
-      "relationship": "parent",
-      "description": "Parent proof establishing the scalar Gaussian integral ∫ e^{-x²} = √π via Mathlib's integral_gaussian"
-    },
-    {
-      "id": "xref-oq05-oq01",
-      "targetId": "area-of-circle-oq-05-oq-01",
-      "targetTitle": "Polar-Coordinate Proof of the Gaussian Integral",
-      "relationship": "sibling",
-      "description": "Sibling open question about the polar coordinate proof of the same scalar Gaussian"
-    }
-  ],
   "sections": [
     {
       "id": "sec-preamble",
@@ -128,6 +112,22 @@
       "summary": "Main theorem: ∫ exp(-xᵀAx) = √(πⁿ/det A) for positive-definite A — fully proved via spectral decomposition and measure-preserving orthogonal change of variables"
     }
   ],
+  "crossReferences": [
+    {
+      "id": "xref-oq05-parent",
+      "targetId": "area-of-circle-oq-05",
+      "targetTitle": "The Gaussian Integral and the Area of a Circle",
+      "relationship": "parent",
+      "description": "Parent proof establishing the scalar Gaussian integral ∫ e^{-x²} = √π via Mathlib's integral_gaussian"
+    },
+    {
+      "id": "xref-oq05-oq01",
+      "targetId": "area-of-circle-oq-05-oq-01",
+      "targetTitle": "Polar-Coordinate Proof of the Gaussian Integral",
+      "relationship": "sibling",
+      "description": "Sibling open question about the polar coordinate proof of the same scalar Gaussian"
+    }
+  ],
   "conclusion": {
     "summary": "This entry formalizes the multivariate Gaussian integral in Lean 4 and is fully proved (0 sorries). The diagonal case (`diagonal_gaussian`) uses Fubini's theorem for product spaces and the scalar Gaussian from the parent proof. The general case (`multivariate_gaussian_integral`) reduces to diagonal via the spectral theorem and is fully proved via spectral decomposition + map_linearMap_volume_pi_eq_smul_volume_pi + integral_map.",
     "implications": "The diagonal case represents a substantial Lean 4 achievement: combining `Real.exp_sum`, Fubini for `Fin n → ℝ` product spaces, and the scalar Gaussian gives a clean sorry-free proof. The general case is also closed: the measure-preserving orthogonal change of variables is discharged via Mathlib's `map_linearMap_volume_pi_eq_smul_volume_pi` applied to the eigenvector unitary (|det Uᵀ| = 1). This formalization demonstrates the modular structure of the Lean Genius gallery: `AreaOfCircleOQ05 → AreaOfCircleOQ05OQ02` via the `scaled_gaussian` import.",
@@ -136,7 +136,35 @@
       "Can the result be extended to the complex case (Hermitian positive-definite matrices over ℂ)?"
     ]
   },
-  "sorries": 0,
+  "references": [
+    {
+      "authors": "Bilodeau, Martin and Brenner, David",
+      "title": "Theory of Multivariate Statistics",
+      "year": "1999",
+      "venue": "Springer",
+      "note": "Multivariate Gaussian normalization via orthogonal diagonalization of the quadratic form."
+    },
+    {
+      "authors": "Stein, Elias M. and Shakarchi, Rami",
+      "title": "Real Analysis: Measure Theory, Integration, and Hilbert Spaces",
+      "year": "2005",
+      "venue": "Princeton University Press",
+      "note": "Gaussian integral via the polar-coordinate (Poisson) trick and Fubini's theorem."
+    },
+    {
+      "authors": "Folland, Gerald B.",
+      "title": "Real Analysis: Modern Techniques and Their Applications (2nd ed.)",
+      "year": "1999",
+      "venue": "Wiley",
+      "note": "Volume of the n-ball via the Gamma function and spherical coordinates."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Interval integration, MeasureTheory.integral_gaussian and change-of-variables lemmas (Mathlib.Analysis.SpecialFunctions.Gaussian / Mathlib.MeasureTheory.Integral)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
   "leanFile": {
     "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
     "imports": [
@@ -147,5 +175,6 @@
     "definitionCount": 0,
     "axiomCount": 0,
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }


### PR DESCRIPTION
## Enrichment pass — cluster

22 verified `area-of-circle-oq-*` descendants had **no references**. Added 4 angle-matched references to each, grouped by sub-theme:

- **Unit n-ball volume / Gamma asymptotics** (Smith–Vamanamurthy *How Small Is a Unit Ball?*, Folland, Artin, Robbins on Stirling, mathlib Gamma): recurrence ω_{n+2}=(2π/(n+2))ω_n, ω_n→0, exact Stirling rate, n=5 argmax, unimodality, log-concavity, isoperimetric ratio, scaling law, sphere surface area.
- **Isoperimetric / Hurwitz / Wirtinger** (Hurwitz 1902, Osserman 1978, do Carmo, mathlib): reparametrization invariance, Wirtinger equality case, Hurwitz capstone, arc-length reparametrization.
- **Archimedes exhaustion** (*Measurement of a Circle*, *Quadrature of the Parabola*, Edwards, mathlib integration): exhaustion↔FTC, inscribed-polygon O(1/n²) rate, ellipse/parabola exhaustion, parabolic sub-triangle ratios.
- **π bounds** (Dalzell 1944, Lucas 2005): generalized Dalzell integral.
- **Gaussian integral** (Stein–Shakarchi, Bilodeau–Brenner): scaled and multivariate.

All entries verified to exist; all meta.json within size caps (`check-meta-size.ts` passes on all 4239). No Lean source changed.