### PR TITLE
research: companion matrix is nonderogatory (μ=χ=p) — cayley-hamilton-minpoly-oq-03-oq-03-oq-01 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ03OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ03OQ01.lean
@@ -1,0 +1,300 @@
+/-
+  The Companion Matrix is Nonderogatory: μ_C = χ_C = p
+  (cayley-hamilton-minpoly-oq-03-oq-03-oq-01)
+
+  Context: The parent entry `cayley-hamilton-minpoly-oq-03-oq-03`
+  (`CayleyHamiltonMinpolyOQ03OQ03.lean`) proves that a nonderogatory matrix `M`
+  with a cyclic vector is *similar* to the companion matrix of its minimal
+  polynomial: `P⁻¹ · M · P = C(μ_M)`, the rational canonical form as a single
+  companion block.  That statement takes for granted that `C(μ_M)` is the right
+  target — i.e. that the companion matrix of a monic polynomial `p` really does
+  have `p` as *both* its minimal and characteristic polynomial.  This grandchild
+  supplies exactly that missing converse, self-containedly.
+
+  Answer (formalized here): For a monic polynomial `p` of degree `n ≥ 1` over a
+  field `K`, we build the explicit **companion matrix** `C = companion p`, a
+  concrete `n × n` matrix, and prove:
+
+  1. **Krylov sequence = standard basis** (`companion_pow_mulVec_e0`):
+     the standard vector `e₀` is a *cyclic vector* for `C`, and its Krylov
+     sequence `{e₀, C·e₀, …, C^{n-1}·e₀}` is exactly the standard basis
+     `{e₀, e₁, …, e_{n-1}}`.  Thus `C` is already in the coordinates given by the
+     Krylov sequence — this is the sense in which "the Krylov sequence with a
+     cyclic vector produces the companion matrix."
+
+  2. **Krylov recurrence / annihilation** (`companion_aeval_eq_zero`):
+     `p(C) = 0`.  The top Krylov vector closes the ladder:
+     `C^n·e₀ = -∑_{i<n} p.coeff i • eᵢ`, which is precisely the last column of
+     the companion matrix.
+
+  3. **Minimal polynomial** (`companion_minpoly`): `μ_C = minpoly K C = p`.
+     Because `e₀` is cyclic, no polynomial of degree `< n` annihilates `C`, so
+     `p` is *the* minimal polynomial (not merely an annihilator).
+
+  4. **Characteristic polynomial** (`companion_charpoly`): `χ_C = p`.
+     Combining `μ_C = p` (degree `n`) with Cayley–Hamilton (`p ∣ χ_C`) and the
+     fact that `χ_C` is monic of degree `n` forces `χ_C = p`.
+
+  In particular `μ_C = χ_C = p`: the companion matrix is **nonderogatory**.  This
+  is the fact that makes `companion p` the canonical representative of the
+  rational canonical form — the target block that the parent entry's similarity
+  `P⁻¹ · M · P = C(μ_M)` conjugates into.
+
+  The determinant-free proof of `χ_C = p` is the point of interest: rather than
+  the usual cofactor expansion of `det(X·I − C)`, we obtain `χ_C = p` from the
+  cyclic-vector structure via the minimal polynomial and Mathlib's
+  Cayley–Hamilton theorem `Matrix.aeval_self_charpoly`.
+
+  This file is self-contained (imports only Mathlib): it re-derives the small
+  Krylov expansion lemma it needs rather than importing the parent chain, so it
+  stands alone.  Mathlib itself has no companion-matrix construction.
+
+  References:
+  - Horn & Johnson, "Matrix Analysis" §3.3 (companion matrices, RCF)
+  - Dummit & Foote, "Abstract Algebra" §12.2 (rational canonical form)
+  - Mathlib: LinearAlgebra.Matrix.Charpoly.Minpoly
+
+  Companion to (does not import):
+  - CayleyHamiltonMinpolyOQ03OQ03.lean   (parent: Krylov RCF similarity P⁻¹MP = C(μ_M))
+  - CayleyHamiltonMinpolyOQ03OQ01.lean   (Krylov expansion `aeval_mulVec_eq_krylov_sum`)
+-/
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+set_option linter.unusedSimpArgs false
+
+namespace MinpolyComplexity.RCF
+
+open Matrix Polynomial Finset
+
+variable {K : Type*} [Field K]
+
+/-! ## Krylov infrastructure (self-contained; mirrors OQ-03/OQ-03-OQ-01) -/
+
+/-- The `k`-th Krylov vector of `M` starting from `v`: `M^k · v`. -/
+def krylovVec {n : ℕ} (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K) (k : ℕ) : Fin n → K :=
+  (M ^ k).mulVec v
+
+/-- `mulVec` distributes over finite sums of matrices. -/
+private theorem sum_mulVec {n : ℕ} {ι : Type*} [DecidableEq ι] (s : Finset ι)
+    (f : ι → Matrix (Fin n) (Fin n) K) (v : Fin n → K) :
+    (∑ i ∈ s, f i).mulVec v = ∑ i ∈ s, (f i).mulVec v := by
+  induction s using Finset.induction_on with
+  | empty => simp [Matrix.zero_mulVec]
+  | @insert a s' has ih =>
+    rw [Finset.sum_insert has, Matrix.add_mulVec, ih, Finset.sum_insert has]
+
+/-- **Krylov expansion**: evaluating `p` at `M` and applying to `v` gives the
+    linear combination of Krylov vectors with the polynomial's coefficients. -/
+theorem aeval_mulVec_eq_krylov_sum {n : ℕ} (M : Matrix (Fin n) (Fin n) K)
+    (v : Fin n → K) (p : K[X]) :
+    (aeval M p).mulVec v =
+      ∑ i ∈ range (p.natDegree + 1), p.coeff i • krylovVec M v i := by
+  have haeval_expand : aeval M p =
+      ∑ i ∈ range (p.natDegree + 1), p.coeff i • M ^ i := by
+    simp only [aeval_def, Polynomial.eval₂_eq_sum, Polynomial.sum_def]
+    have hsub : p.support ⊆ range (p.natDegree + 1) := by
+      intro i hi
+      exact Finset.mem_range.mpr
+        (Nat.lt_succ_of_le (Polynomial.le_natDegree_of_mem_supp _ hi))
+    rw [Finset.sum_subset hsub]
+    · congr 1; ext i
+      rw [Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul]
+    · intro i _ hi
+      rw [Polynomial.notMem_support_iff.mp hi, map_zero, zero_mul]
+  rw [haeval_expand, sum_mulVec]
+  simp only [Matrix.smul_mulVec, krylovVec]
+
+/-! ## The companion matrix -/
+
+/-- The **companion matrix** of a polynomial `p` (dimension `p.natDegree`).
+    Column `j` (for `j < n-1`) is `e_{j+1}` (the sub-diagonal `1`s), and the
+    last column `j = n-1` holds the negated coefficients `-p.coeff i`.  Thus
+    `C · e_j = e_{j+1}` for `j < n-1` and `C · e_{n-1} = -∑_i p.coeff i • e_i`. -/
+def companion (p : K[X]) : Matrix (Fin p.natDegree) (Fin p.natDegree) K :=
+  fun i j =>
+    if (j : ℕ) = p.natDegree - 1 then - p.coeff (i : ℕ)
+    else if (i : ℕ) = (j : ℕ) + 1 then 1 else 0
+
+section Companion
+
+variable {p : K[X]}
+
+/-- The standard cyclic vector `e₀`. -/
+private def e0 (hn : 0 < p.natDegree) : Fin p.natDegree → K := Pi.single ⟨0, hn⟩ 1
+
+/-- Applying a matrix to a standard basis vector reads off a column. -/
+private theorem mulVec_single_entry
+    (M : Matrix (Fin p.natDegree) (Fin p.natDegree) K) (j i : Fin p.natDegree) :
+    (M *ᵥ Pi.single j 1) i = M i j := by
+  show ∑ x, M i x * (Pi.single j 1 : Fin p.natDegree → K) x = M i j
+  rw [Finset.sum_eq_single j (fun b _ hb => by simp [Pi.single_apply, hb])
+    (fun h => absurd (Finset.mem_univ j) h)]
+  simp
+
+/-- **Krylov sequence is the standard basis.** For `k < n`, `C^k · e₀ = e_k`. -/
+theorem companion_pow_mulVec_e0 (hn : 0 < p.natDegree) :
+    ∀ k : ℕ, (hk : k < p.natDegree) →
+      (companion p ^ k) *ᵥ e0 hn = Pi.single (⟨k, hk⟩ : Fin p.natDegree) 1 := by
+  intro k
+  induction k with
+  | zero =>
+    intro hk
+    rw [pow_zero, Matrix.one_mulVec]
+    rfl
+  | succ m ih =>
+    intro hk
+    have hm : m < p.natDegree := Nat.lt_of_succ_lt hk
+    have hmlt : m < p.natDegree - 1 := by omega
+    have hstep : companion p ^ (m + 1) = companion p * companion p ^ m := pow_succ' _ _
+    rw [hstep, ← Matrix.mulVec_mulVec, ih hm]
+    funext i
+    rw [mulVec_single_entry (companion p) ⟨m, hm⟩ i]
+    simp only [companion, Fin.val_mk, Pi.single_apply, Fin.ext_iff]
+    rw [if_neg (show ¬ (m = p.natDegree - 1) by omega)]
+
+/-- The **top Krylov vector** closes the ladder: `C^n · e₀ = -∑_i p.coeff i • e_i`
+    (the last column of the companion matrix). -/
+theorem companion_pow_natDegree_mulVec_e0 (hn : 0 < p.natDegree) :
+    (companion p ^ p.natDegree) *ᵥ e0 hn = fun (i : Fin p.natDegree) => - p.coeff (i : ℕ) := by
+  have hstep : companion p ^ p.natDegree
+      = companion p * companion p ^ (p.natDegree - 1) := by
+    rw [← pow_succ']
+    congr 1
+    omega
+  rw [hstep, ← Matrix.mulVec_mulVec, companion_pow_mulVec_e0 hn (p.natDegree - 1) (by omega)]
+  funext i
+  rw [mulVec_single_entry (companion p) ⟨p.natDegree - 1, by omega⟩ i]
+  simp [companion]
+
+/-- Coordinate form of the Krylov sequence: `(C^i · e₀) k = [k = i]` for `i < n`. -/
+private theorem krylov_coord (hn : 0 < p.natDegree) (i : ℕ) (hi : i < p.natDegree)
+    (k : Fin p.natDegree) :
+    krylovVec (companion p) (e0 hn) i k = if (k : ℕ) = i then 1 else 0 := by
+  show ((companion p ^ i) *ᵥ e0 hn) k = _
+  rw [companion_pow_mulVec_e0 hn i hi, Pi.single_apply]
+  simp [Fin.ext_iff]
+
+/-- `p(C) · e₀ = 0`: the defining Krylov recurrence of the companion matrix. -/
+private theorem companion_aeval_mulVec_e0 (hn : 0 < p.natDegree) (hp : p.Monic) :
+    (aeval (companion p) p) *ᵥ e0 hn = 0 := by
+  rw [aeval_mulVec_eq_krylov_sum]
+  funext k
+  simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul, Pi.zero_apply]
+  rw [Finset.sum_range_succ]
+  -- top term: p.coeff n • (C^n e₀) k = 1 • (-p.coeff k)
+  have htop : krylovVec (companion p) (e0 hn) p.natDegree k = - p.coeff (k : ℕ) :=
+    congrFun (companion_pow_natDegree_mulVec_e0 hn) k
+  rw [htop, hp.coeff_natDegree]
+  -- lower sum: ∑_{i<n} p.coeff i * [k = i] = p.coeff k
+  have hlow : (∑ i ∈ Finset.range p.natDegree,
+      p.coeff i * krylovVec (companion p) (e0 hn) i k) = p.coeff (k : ℕ) := by
+    rw [Finset.sum_congr rfl
+      (fun i hi => by rw [krylov_coord hn i (Finset.mem_range.mp hi) k])]
+    simp only [mul_ite, mul_one, mul_zero]
+    rw [Finset.sum_ite_eq (Finset.range p.natDegree) (k : ℕ) (fun i => p.coeff i)]
+    rw [if_pos (Finset.mem_range.mpr k.isLt)]
+  rw [hlow]
+  ring
+
+/-- A matrix that annihilates every standard basis vector is zero. -/
+private theorem matrix_eq_zero_of_mulVec_basis
+    (M : Matrix (Fin p.natDegree) (Fin p.natDegree) K)
+    (h : ∀ j, M *ᵥ Pi.single j 1 = 0) : M = 0 := by
+  ext i j
+  have := congrFun (h j) i
+  rw [mulVec_single_entry M j i] at this
+  simpa using this
+
+/-- **Krylov annihilation**: `p(C) = 0`. -/
+theorem companion_aeval_eq_zero (hn : 0 < p.natDegree) (hp : p.Monic) :
+    aeval (companion p) p = 0 := by
+  apply matrix_eq_zero_of_mulVec_basis
+  intro j
+  -- e_j = C^{j} · e₀ (Krylov sequence), and p(C) commutes with C^{j}
+  have hj : Pi.single j 1 = (companion p ^ (j : ℕ)) *ᵥ e0 hn := by
+    rw [companion_pow_mulVec_e0 hn (j : ℕ) j.isLt, Fin.eta]
+  have hcomm : Commute (aeval (companion p) p) (companion p) := by
+    have h := (Commute.all p X).map (aeval (companion p))
+    rwa [aeval_X] at h
+  rw [hj, Matrix.mulVec_mulVec, (hcomm.pow_right (j : ℕ)).eq,
+      ← Matrix.mulVec_mulVec, companion_aeval_mulVec_e0 hn hp, Matrix.mulVec_zero]
+
+/-! ## Minimal and characteristic polynomials -/
+
+/-- `C` is integral over `K` (finite-dimensional matrix algebra). -/
+private theorem companion_isIntegral : IsIntegral K (companion p) :=
+  Algebra.IsIntegral.isIntegral _
+
+/-- **Cyclic-vector degree bound**: any annihilating polynomial of `C` of degree
+    `< n` is zero (because `e₀` is a cyclic vector). -/
+private theorem companion_no_low_annihilator (hn : 0 < p.natDegree) (q : K[X])
+    (hq0 : aeval (companion p) q = 0) (hdeg : q.natDegree < p.natDegree) : q = 0 := by
+  -- q(C) · e₀ = ∑_{i ≤ deg q} q.coeff i • e_i, whose k-th coordinate is q.coeff k
+  have hvec : (aeval (companion p) q) *ᵥ e0 hn = fun (k : Fin p.natDegree) => q.coeff (k : ℕ) := by
+    rw [aeval_mulVec_eq_krylov_sum]
+    funext k
+    simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+    rw [Finset.sum_congr rfl
+      (fun i hi => by
+        rw [krylov_coord hn i (lt_of_le_of_lt
+          (Nat.lt_succ_iff.mp (Finset.mem_range.mp hi)) hdeg) k])]
+    simp only [mul_ite, mul_one, mul_zero]
+    rw [Finset.sum_ite_eq (Finset.range (q.natDegree + 1)) (k : ℕ) (fun i => q.coeff i)]
+    by_cases hk : (k : ℕ) < q.natDegree + 1
+    · rw [if_pos (Finset.mem_range.mpr hk)]
+    · rw [if_neg (fun h => hk (Finset.mem_range.mp h))]
+      exact (Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)).symm
+  rw [hq0] at hvec
+  -- every coefficient of q vanishes
+  ext i
+  by_cases hi : i < p.natDegree
+  · have := congrFun hvec.symm ⟨i, hi⟩
+    simpa using this
+  · exact Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)
+
+/-- **Minimal polynomial of the companion matrix**: `μ_C = p`. -/
+theorem companion_minpoly (hn : 0 < p.natDegree) (hp : p.Monic) :
+    minpoly K (companion p) = p := by
+  have hInt : IsIntegral K (companion p) := companion_isIntegral
+  have hdvd : minpoly K (companion p) ∣ p :=
+    minpoly.dvd K _ (companion_aeval_eq_zero hn hp)
+  -- degree ≥ n: minpoly is a nonzero annihilator, so has degree ≥ n
+  have hge : p.natDegree ≤ (minpoly K (companion p)).natDegree := by
+    by_contra hlt
+    push_neg at hlt
+    have := companion_no_low_annihilator hn (minpoly K (companion p))
+      (minpoly.aeval K _) hlt
+    exact minpoly.ne_zero hInt this
+  -- degree ≤ n from the divisibility
+  have hle : (minpoly K (companion p)).natDegree ≤ p.natDegree :=
+    Polynomial.natDegree_le_of_dvd hdvd hp.ne_zero
+  have hdeg : p.natDegree = (minpoly K (companion p)).natDegree := le_antisymm hge hle
+  -- equal monic polynomials of equal degree that divide each other
+  exact (Polynomial.eq_of_monic_of_dvd_of_natDegree_le (minpoly.monic hInt) hp hdvd
+    (by omega)).symm
+
+/-- **Characteristic polynomial of the companion matrix**: `χ_C = p`.
+    Determinant-free: via `μ_C = p` and Cayley–Hamilton. -/
+theorem companion_charpoly (hn : 0 < p.natDegree) (hp : p.Monic) :
+    (companion p).charpoly = p := by
+  -- p = μ_C divides χ_C
+  have hdvd : p ∣ (companion p).charpoly := by
+    have hmc := minpoly_dvd_charpoly (companion p)
+    rwa [companion_minpoly hn hp] at hmc
+  -- χ_C is monic of degree n
+  have hmonic : (companion p).charpoly.Monic := Matrix.charpoly_monic _
+  have hdim : (companion p).charpoly.natDegree = p.natDegree := by
+    rw [Matrix.charpoly_natDegree_eq_dim, Fintype.card_fin]
+  exact Polynomial.eq_of_monic_of_dvd_of_natDegree_le hp hmonic hdvd (by omega)
+
+/-- **Nonderogatory**: `μ_C = χ_C`, both equal to `p`. -/
+theorem companion_minpoly_eq_charpoly (hn : 0 < p.natDegree) (hp : p.Monic) :
+    minpoly K (companion p) = (companion p).charpoly := by
+  rw [companion_minpoly hn hp, companion_charpoly hn hp]
+
+end Companion
+
+end MinpolyComplexity.RCF

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03-oq-01/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-rcf-preamble",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 52
+    },
+    "type": "concept",
+    "title": "Krylov Sequences and the Rational Canonical Form: Problem Statement",
+    "content": "The module docstring frames the structural question raised by OQ-03: what is the formal relationship between the Krylov sequence and the rational canonical form? The answer built here is the explicit companion matrix C = companion p of a monic polynomial p of degree n ≥ 1. Four results are proved: (1) the standard vector e₀ is a cyclic vector whose Krylov sequence {e₀, C·e₀, …, C^{n-1}·e₀} is exactly the standard basis; (2) p(C) = 0; (3) μ_C = p; (4) χ_C = p. Hence C is nonderogatory and any cyclic operator with minimal polynomial p is similar to it. The notable point is that χ_C = p is proved determinant-free — via μ_C = p plus Cayley–Hamilton — rather than by cofactor expansion of det(X·I − C). Mathlib has no companion-matrix construction, so this fills a genuine gap.",
+    "mathContext": "Companion matrix of monic $p = X^n + \\sum_{i<n} c_i X^i$: $C e_j = e_{j+1}$ for $j<n-1$, $C e_{n-1} = -\\sum_i c_i e_i$. Goal: $\\mu_C = \\chi_C = p$ and $e_0$ cyclic with $C^k e_0 = e_k$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "rational canonical form",
+      "companion matrix",
+      "cyclic vector",
+      "nonderogatory matrix",
+      "Krylov subspace"
+    ],
+    "prerequisites": [
+      "minpoly and Matrix.charpoly in Mathlib",
+      "Cayley–Hamilton theorem",
+      "Matrix.mulVec"
+    ]
+  },
+  {
+    "id": "ann-rcf-krylov-expansion",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-03-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 102
+    },
+    "type": "technique",
+    "title": "Krylov Expansion: p(M)·v as a Linear Combination of Krylov Vectors",
+    "content": "The self-contained Krylov toolkit. krylovVec M v k = M^k·v is the Krylov sequence; sum_mulVec shows mulVec distributes over finite sums of matrices; and aeval_mulVec_eq_krylov_sum is the computational bridge: p(M)·v = ∑_{i} p.coeff i • krylovVec M v i. This rewrites the algebraic action of a polynomial at M on v into an explicit linear combination of Krylov vectors with the polynomial's coefficients — the identity that lets coordinate arguments about C^k·e₀ settle both p(C)·e₀ = 0 and the degree bound.",
+    "mathContext": "$p(M)v = \\sum_{i=0}^{\\deg p} p_i\\, M^i v$, expressed over $\\mathrm{range}(\\deg p + 1)$; proved by expanding $\\mathrm{aeval}\\,M\\,p$ as $\\sum_i p_i M^i$ and distributing mulVec across the sum.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Krylov sequence",
+      "aeval",
+      "polynomial evaluation at a matrix"
+    ],
+    "prerequisites": [
+      "Polynomial.aeval",
+      "Matrix.mulVec",
+      "Finset.sum"
+    ]
+  },
+  {
+    "id": "ann-rcf-companion-krylov-basis",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-03-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 163
+    },
+    "type": "key-step",
+    "title": "The Companion Matrix and its Krylov Sequence = Standard Basis",
+    "content": "companion p is defined concretely: column j is e_{j+1} (sub-diagonal 1s) for j < n-1, and the last column j = n-1 holds the negated coefficients -p.coeff i. The two theorems establish that e₀ is a cyclic vector: companion_pow_mulVec_e0 proves C^k·e₀ = e_k for k < n (the Krylov sequence IS the standard basis), by induction using the shift action; and companion_pow_natDegree_mulVec_e0 proves C^n·e₀ = -∑ p.coeff i • e_i, the last column that closes the Krylov ladder. This is the precise sense in which 'the Krylov sequence with a cyclic vector produces the companion matrix': in Krylov coordinates the operator is already C.",
+    "mathContext": "$C^k e_0 = e_k$ for $k<n$ (Krylov sequence = standard basis) and $C^n e_0 = -\\sum_{i<n} p_i e_i$ (top Krylov vector), the algebraic dependence certifying the minimal polynomial.",
+    "significance": "central",
+    "relatedConcepts": [
+      "cyclic vector",
+      "companion matrix",
+      "Krylov sequence",
+      "shift operator"
+    ],
+    "prerequisites": [
+      "Matrix.mulVec",
+      "matrix powers",
+      "induction on ℕ"
+    ]
+  },
+  {
+    "id": "ann-rcf-annihilation",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-03-oq-01",
+    "range": {
+      "startLine": 164,
+      "endLine": 216
+    },
+    "type": "key-step",
+    "title": "Krylov Recurrence: p(C) = 0",
+    "content": "companion_aeval_mulVec_e0 proves p(C)·e₀ = 0: expand p(C)·e₀ as a Krylov sum, note that for i < n the terms give ∑ p.coeff i • e_i, and the top term uses the monic leading coefficient p.coeff n = 1 with C^n·e₀ = -∑ p.coeff i • e_i, so the two cancel. companion_aeval_eq_zero then upgrades this to the matrix identity p(C) = 0 by commuting p(C) past each power C^j (polynomials in C commute) so that p(C)·e_j = C^j·(p(C)·e₀) = 0 on every basis vector.",
+    "mathContext": "$p(C)e_0 = \\sum_{i<n} p_i e_i + p_n(-\\sum_{i<n} p_i e_i) = 0$ since $p_n = 1$; then $p(C)e_j = p(C)C^j e_0 = C^j p(C) e_0 = 0$, so $p(C) = 0$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "annihilating polynomial",
+      "monic polynomial",
+      "commuting matrix powers"
+    ],
+    "prerequisites": [
+      "Monic.coeff_natDegree",
+      "Commute.map",
+      "Matrix.mulVec_mulVec"
+    ]
+  },
+  {
+    "id": "ann-rcf-minpoly-charpoly",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-03-oq-01",
+    "range": {
+      "startLine": 217,
+      "endLine": 293
+    },
+    "type": "key-step",
+    "title": "μ_C = χ_C = p: Determinant-Free Nonderogatory Identity",
+    "content": "companion_no_low_annihilator is the cyclic-vector degree bound: any q annihilating C with deg q < n forces q(C)·e₀ = ∑ q.coeff i • e_i = 0, so every coefficient of q vanishes and q = 0. Combined with p(C) = 0 (so μ_C | p) and minpoly | annihilator, this gives companion_minpoly: μ_C = p (both monic of degree n). Finally companion_charpoly derives χ_C = p WITHOUT a determinant: χ_C is monic of degree n (charpoly_monic, charpoly_natDegree_eq_dim) and μ_C = p divides χ_C by Cayley–Hamilton (minpoly_dvd_charpoly), so χ_C = p. companion_minpoly_eq_charpoly records that C is nonderogatory (μ_C = χ_C).",
+    "mathContext": "Cyclic $\\Rightarrow$ no annihilator of degree $<n$ $\\Rightarrow \\deg\\mu_C \\geq n$; with $\\mu_C \\mid p$ this gives $\\mu_C = p$. Then $\\chi_C$ monic of degree $n$ and $p = \\mu_C \\mid \\chi_C$ force $\\chi_C = p$ — no cofactor expansion of $\\det(XI-C)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "minimal polynomial",
+      "characteristic polynomial",
+      "Cayley–Hamilton",
+      "nonderogatory matrix"
+    ],
+    "prerequisites": [
+      "minpoly.dvd",
+      "Matrix.minpoly_dvd_charpoly",
+      "Matrix.charpoly_monic",
+      "Polynomial.eq_of_monic_of_dvd_of_natDegree_le"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03-oq-01/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-03-oq-03-oq-01",
+  "title": "The Companion Matrix is Nonderogatory: μ_C = χ_C = p",
+  "slug": "cayley-hamilton-minpoly-oq-03-oq-03-oq-01",
+  "description": "Complementary converse to the parent RCF entry (oq-03-oq-03): that entry shows a nonderogatory matrix M is SIMILAR to the companion matrix of its minimal polynomial (P⁻¹·M·P = C(μ_M)); this grandchild proves the companion matrix C = companion p of ANY monic p of degree n ≥ 1 is itself nonderogatory, with μ_C = χ_C = p. The standard vector e₀ is a cyclic vector whose Krylov sequence is exactly the standard basis, C^n·e₀ = -∑ p.coeff i • eᵢ closes the ladder, and χ_C = p is proved determinant-free via μ_C = p and Cayley–Hamilton (no cofactor expansion of det(X·I − C)). Self-contained.",
+  "meta": {
+    "author": "researcher-11",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Companion_matrix",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ03OQ03OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "matrices",
+      "minimal-polynomial",
+      "characteristic-polynomial",
+      "companion-matrix",
+      "rational-canonical-form",
+      "krylov-method",
+      "cyclic-vector"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 293,
+    "assumptions": "No axioms, no sorries. All theorems fully machine-checked over an arbitrary field K, for any monic polynomial of positive degree. Reuses the Krylov expansion lemma pattern from OQ-03-OQ-01. Determinant-free: χ_C = p is obtained from μ_C = p plus Mathlib's Matrix.aeval_self_charpoly (Cayley–Hamilton) and charpoly degree/monic lemmas.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 14,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The companion matrix is the concrete matrix realization of a cyclic (nonderogatory) linear operator, and the atomic building block of the rational canonical form (Frobenius normal form). Its defining property — that a single Krylov sequence starting from a cyclic vector spans the whole space and turns the operator into the shift-plus-last-column companion form — is exactly what makes the Krylov method (OQ-03) compute the minimal polynomial in n matrix-vector products. This entry closes the loop between the Krylov perspective and the structural/RCF perspective.",
+    "problemStatement": "What is the formal relationship between the Krylov sequence and the rational canonical form? Concretely: given a monic p of degree n ≥ 1 over a field K, build the companion matrix C and prove (1) e₀ is a cyclic vector whose Krylov sequence is the standard basis, (2) p(C) = 0, (3) μ_C = p, (4) χ_C = p — so C is nonderogatory and any cyclic operator with minimal polynomial p is similar to C.",
+    "proofStrategy": "Define C = companion p with C·e_j = e_{j+1} for j < n-1 and C·e_{n-1} = -∑ p.coeff i • e_i. By induction on the shift, C^k·e₀ = e_k for k < n (Krylov sequence = standard basis), and C^n·e₀ = -∑ p.coeff i • e_i. Expanding p(C)·e₀ as a Krylov sum and using monic p.coeff n = 1 gives p(C)·e₀ = 0; commuting p(C) past C^j (polynomials in C commute) extends this to p(C)·e_j = 0 for every basis vector, so p(C) = 0. Hence μ_C | p. Conversely, since {C^i·e₀ = e_i} is the standard basis, any annihilator of degree < n has all coefficients equal to the coordinates of q(C)·e₀ = 0, so q = 0; thus deg μ_C ≥ n, forcing μ_C = p (both monic of degree n, μ_C | p). Finally χ_C is monic of degree n (charpoly_monic, charpoly_natDegree_eq_dim) and μ_C = p | χ_C (minpoly_dvd_charpoly), so χ_C = p — no determinant expansion needed.",
+    "keyInsights": [
+      "The Krylov sequence with a cyclic vector IS the change of basis that puts a cyclic operator into companion form: C^k·e₀ = e_k means the standard basis already are the Krylov vectors, so C is literally 'the matrix of the operator in Krylov coordinates'.",
+      "The last column of the companion matrix is the algebraic content of the top Krylov vector: C^n·e₀ = -∑ p.coeff i • e_i is precisely the linear dependence certifying that the minimal polynomial is p.",
+      "χ_C = p is proved WITHOUT a determinant. The classical route computes det(X·I − C) by cofactor expansion; here χ_C = p falls out of μ_C = p (from the cyclic vector) together with Cayley–Hamilton (μ_C | χ_C) and the fact that χ_C is monic of degree n. This is both shorter and more structural.",
+      "Cyclicity gives the sharp degree bound: because the Krylov vectors {e₀,…,e_{n-1}} are a basis, a polynomial q of degree < n annihilating C would force q(C)·e₀ = ∑ q.coeff i • e_i = 0, i.e. every coefficient of q vanishes. This is the exact mechanism by which a cyclic vector makes μ_C reach full degree n = χ_C, i.e. makes C nonderogatory.",
+      "Everything is coordinate-explicit: the companion matrix is a concrete `Matrix (Fin n) (Fin n) K`, its powers acting on e₀ are computed directly, and the spectral identities μ_C = χ_C = p are derived from these computations rather than assumed — filling a genuine gap, since Mathlib has no companion-matrix construction."
+    ],
+    "prerequisites": [
+      "Minimal and characteristic polynomials of a matrix (Mathlib minpoly, Matrix.charpoly)",
+      "Cayley–Hamilton theorem (Matrix.aeval_self_charpoly, minpoly_dvd_charpoly)",
+      "Polynomial evaluation via aeval and the Krylov expansion aeval(M)·v = ∑ coeff i • Mⁱv",
+      "Rational canonical form / cyclic (nonderogatory) operators"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly",
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "MinpolyComplexity.RCF",
+    "lineCount": 293,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 3,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "part-i-krylov-infrastructure",
+      "title": "Part I: Krylov Infrastructure",
+      "startLine": 63,
+      "endLine": 100,
+      "summary": "Self-contained Krylov toolkit: krylovVec M v k = M^k·v, the sum_mulVec helper (mulVec distributes over finite matrix sums), and aeval_mulVec_eq_krylov_sum expressing polynomial evaluation p(M)·v as a Krylov linear combination ∑ p.coeff i • krylovVec M v i. Mirrors the OQ-03 infrastructure so the file stands alone."
+    },
+    {
+      "id": "part-ii-companion-matrix",
+      "title": "Part II: The Companion Matrix and its Krylov Sequence",
+      "startLine": 101,
+      "endLine": 163,
+      "summary": "Defines companion p (sub-diagonal 1s, last column = negated coefficients) and proves the Krylov sequence is the standard basis: companion_pow_mulVec_e0 (C^k·e₀ = e_k for k < n) by induction on the shift, and companion_pow_natDegree_mulVec_e0 (C^n·e₀ = -∑ p.coeff i • e_i), the last column that closes the Krylov ladder."
+    },
+    {
+      "id": "part-iii-annihilation",
+      "title": "Part III: Krylov Recurrence — p(C) = 0",
+      "startLine": 164,
+      "endLine": 216,
+      "summary": "krylov_coord (coordinatewise form of the Krylov sequence), companion_aeval_mulVec_e0 (p(C)·e₀ = 0 via the Krylov sum and monic leading coefficient), and companion_aeval_eq_zero (p(C) = 0), extended from e₀ to every basis vector by commuting p(C) past the powers of C."
+    },
+    {
+      "id": "part-iv-minpoly-charpoly",
+      "title": "Part IV: μ_C = χ_C = p (Nonderogatory)",
+      "startLine": 217,
+      "endLine": 293,
+      "summary": "companion_no_low_annihilator (cyclic-vector degree bound: no annihilator of degree < n), companion_minpoly (μ_C = p), companion_charpoly (χ_C = p, determinant-free via Cayley–Hamilton), and companion_minpoly_eq_charpoly (nonderogatory: μ_C = χ_C)."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For a monic polynomial p of degree n ≥ 1 over any field K, the explicit companion matrix C = companion p realizes the rational canonical form: the standard vector e₀ is a cyclic vector whose Krylov sequence {e₀, C·e₀, …, C^{n-1}·e₀} is exactly the standard basis, and μ_C = χ_C = p. The companion matrix is therefore nonderogatory, and any cyclic operator with minimal polynomial p is similar to it.",
+    "implications": "This closes the relationship between the Krylov sequence (OQ-03) and the rational canonical form: the Krylov sequence with a cyclic vector is literally the basis in which the operator becomes its companion matrix. The determinant-free derivation of χ_C = p (through μ_C = p and Cayley–Hamilton, avoiding the usual cofactor expansion of det(X·I − C)) is both shorter and more structural, and fills a gap since Mathlib has no companion-matrix construction. The results provide the atomic block for a future formalization of the full rational canonical form of an arbitrary operator as a direct sum of companion blocks.",
+    "openQuestions": [
+      "Can this companion-matrix construction be extended to the full rational canonical form — every finite-dimensional operator is similar to a block-diagonal sum of companion matrices of its invariant factors?",
+      "Is the similarity explicit: given any matrix M with a cyclic vector v, can one build the change-of-basis matrix (from the Krylov basis {v, Mv, …}) conjugating M to companion (minpoly K M) and verify it in Lean?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-03-oq-03",
+      "relationship": "extends",
+      "description": "The parent proves a nonderogatory M is similar to the companion matrix of μ_M (P⁻¹·M·P = C(μ_M)). This grandchild supplies the converse it presupposes: companion p is itself nonderogatory with μ = χ = p, so C(μ_M) is the correct RCF target block."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-03-oq-01",
+      "relationship": "uses",
+      "description": "Reuses the Krylov expansion pattern aeval(M)·v = ∑ coeff i • Mⁱv (re-derived here for self-containment), specialized to the cyclic vector e₀ of the companion matrix."
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "uses",
+      "description": "Cayley–Hamilton (minpoly ∣ charpoly) is the key step making χ_C = p follow from μ_C = p with no determinant computation."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Horn, Roger A. and Johnson, Charles R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, §3.3",
+      "note": "Companion matrices, cyclic/nonderogatory operators, and the rational canonical form"
+    },
+    {
+      "authors": "Dummit, David S. and Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, §12.2",
+      "note": "Rational canonical form as a direct sum of companion matrices of the invariant factors"
+    }
+  ]
+}

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-03-oq-01.json
@@ -1,0 +1,549 @@
+{
+  "slug": "cayley-hamilton-minpoly-oq-03-oq-03-oq-01",
+  "title": "Krylov Sequences and the Rational Canonical Form",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For a cyclic vector $v$ of $M \\in K^{n\\times n}$ with $d = \\deg\\mu_M$, the Krylov sequence $v, Mv, M^2v, \\ldots, M^{d-1}v$ is a basis of the Krylov subspace $\\mathcal{K}$, and in this ordered basis the restricted operator $M|_{\\mathcal{K}}$ has matrix equal to the companion matrix $C(\\mu_M)$ of the minimal polynomial: the subdiagonal is all $1$s and the last column is $(-a_0, -a_1, \\ldots, -a_{d-1})$ where $\\mu_M = X^d + a_{d-1}X^{d-1} + \\cdots + a_0$. When $M$ is nonderogatory ($\\mu_M = \\chi_M$, $d = n$), the Krylov matrix $P = (v \\mid Mv \\mid \\cdots \\mid M^{n-1}v)$ conjugates $M$ to its rational canonical form: $P^{-1}MP = C(\\mu_M)$.",
+    "plain": "Repeatedly multiplying a starting vector $v$ by a matrix $M$ gives the Krylov sequence $v, Mv, M^2v, \\ldots$, which the parent proof showed goes linearly dependent exactly at step $d = \\deg\\mu_M$. This problem asks what that basis reveals: written in the Krylov basis, $M$ takes the companion-matrix form of its minimal polynomial, whose last column stores the coefficients of $\\mu_M$. So Krylov iteration is not just a way to compute $\\mu_M$ but the constructive bridge to the rational canonical form, the field-independent normal form that classifies matrices up to similarity.",
+    "whyMatters": [
+      "Gives a constructive, algorithmic route to the rational canonical form via the already-formalized $O(n^3)$ Krylov iteration, rather than an abstract PID structure-theorem existence proof.",
+      "Upgrades the parent's nonderogatory-optimality theorem from counting independent vectors to an explicit similarity $P^{-1}MP = C(\\mu_M)$.",
+      "Supplies the base case for the cyclic decomposition $K^n = \\bigoplus_i K[X]\\cdot v_i$, the linear-algebra shadow of the structure theorem for finitely generated modules over a PID.",
+      "Unifies three gallery threads — Cayley-Hamilton, the minimal polynomial, and cyclic vectors — into one normal-form statement over an arbitrary field."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Krylov termination and dimension bound: the first $\\deg\\mu_M+1$ Krylov vectors are dependent, at most $\\deg\\mu_M$ are independent (cayley-hamilton-minpoly-oq-03).",
+      "Nonderogatory optimality: for $\\mu_M=\\chi_M$ and cyclic $v$, exactly $n$ Krylov vectors are independent (cayley-hamilton-minpoly-oq-03, Part VII).",
+      "Polynomial-Krylov expansion and M-invariance of the Krylov subspace (cayley-hamilton-minpoly-oq-03, Parts II, VIII-IX).",
+      "$\\mu_M \\mid \\chi_M$ and $\\deg\\chi_M = n$ (Mathlib Matrix.minpoly_dvd_charpoly, Matrix.charpoly_natDegree_eq_dim)."
+    ],
+    "open": [
+      "A Mathlib companion-matrix definition $C(p)$ with $\\chi_{C(p)} = \\mu_{C(p)} = p$ — no general companion-matrix API exists in Mathlib.",
+      "The explicit similarity $P^{-1}MP = C(\\mu_M)$ for a cyclic vector via the Krylov matrix.",
+      "The full rational canonical form / invariant-factor decomposition $M \\sim \\bigoplus_i C(f_i)$ and similarity classification."
+    ],
+    "goal": "Formalize the single-block statement: for a cyclic vector $v$, the Krylov sequence is a basis in which $M|_{\\mathcal{K}}$ has matrix $C(\\mu_M)$, and derive the nonderogatory corollary $P^{-1}MP = C(\\mu_M)$. The full multi-block rational canonical form is deferred as a stretch goal."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-30T21:27:31-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: companion matrix of a monic p built and verified — e₀ cyclic (Krylov sequence = standard basis), μ_C = χ_C = p, determinant-free. PR opened. 0 sorries, 0 axioms.",
+    "builtItems": [
+      "companion, krylovMatrix defs + krylov_companion_conjugation (M·P=P·C), krylov_rcf_similarity (P⁻¹MP=C), krylovMatrix_isUnit_of_cyclic, krylov_rcf_similarity_of_cyclic — Proofs/CayleyHamiltonMinpolyOQ03OQ03.lean (208L, 6 thm/2 def, 0 sorry/0 axiom)",
+      "CayleyHamiltonMinpolyOQ03OQ03.lean: companion (def), companion_pow_mulVec_e0 (Krylov = standard basis), companion_pow_natDegree_mulVec_e0 (top Krylov vector), companion_aeval_eq_zero (p(C)=0), companion_minpoly (μ_C=p), companion_charpoly (χ_C=p), companion_minpoly_eq_charpoly (nonderogatory) — 293 lines, 0 sorries, 0 axioms, builds on Mathlib 4.26.0."
+    ],
+    "insights": [
+      "The conjugation identity M·P = P·C(μ_M) holds for ANY starting vector v once M is nonderogatory (deg μ_M = n); cyclicity of v is needed only to promote conjugation to a genuine similarity P⁻¹MP = C.",
+      "The last column of the companion matrix IS the (negated) coefficient vector of μ_M, so reading M·P=P·C off the last column is exactly Cayley–Hamilton applied to v: M^n v = -∑_{k<n} a_k M^k v.",
+      "The Krylov sequence with a cyclic vector IS the change of basis to companion form: C^k·e₀ = e_k means the standard basis already are the Krylov vectors, so the companion matrix is the operator in Krylov coordinates.",
+      "χ_C = p can be proved determinant-free: from μ_C = p (cyclic vector) plus Cayley–Hamilton (μ_C | χ_C) and χ_C monic of degree n, avoiding cofactor expansion of det(X·I − C).",
+      "Cyclicity gives the sharp degree bound: since {C^i·e₀ = e_i} is a basis, any annihilator q with deg q < n forces q(C)·e₀ = ∑ q.coeff i • e_i = 0, so q = 0; hence deg μ_C ≥ n = deg χ_C (nonderogatory)."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no companion-matrix construction (no Matrix.companion, no charpoly-of-companion lemma); this entry builds it and its spectral identities from scratch."
+    ],
+    "nextSteps": [
+      "Extend to the full rational canonical form: every operator is similar to a block-diagonal sum of companion matrices of its invariant factors.",
+      "Make the similarity explicit: for a matrix M with cyclic vector v, build the change-of-basis matrix from the Krylov basis conjugating M to companion (minpoly K M)."
+    ],
+    "markdown": "# Knowledge Base: cayley-hamilton-minpoly-oq-03-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "linear-algebra",
+    "minimal-polynomial",
+    "companion-matrix",
+    "rational-canonical-form"
+  ],
+  "relatedProofs": [
+    "cayley-hamilton",
+    "cayley-hamilton-minpoly",
+    "cayley-hamilton-minpoly-oq-01",
+    "cayley-hamilton-minpoly-oq-01-oq-02",
+    "cayley-hamilton-minpoly-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-01",
+    "cayley-hamilton-minpoly-oq-02-oq-01-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
+    "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-03",
+    "cayley-hamilton-minpoly-oq-03",
+    "cayley-hamilton-minpoly-oq-03-oq-01",
+    "cayley-hamilton-minpoly-oq-03-oq-02",
+    "cayley-hamilton-minpoly-oq-04",
+    "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+    "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01",
+    "cayley-hamilton-minpoly-oq-04-oq-01",
+    "cayley-hamilton-minpoly-oq-05",
+    "cayley-hamilton-minpoly-oq-05-oq-01",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-01",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-02",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-03",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05",
+    "cayley-hamilton-minpoly-oq-05-oq-02",
+    "cayley-hamilton-minpoly-oq-05-oq-02-oq-03",
+    "cayley-hamilton-minpoly-oq-06",
+    "cayley-hamilton-minpoly-oq-06-oq-01",
+    "cayley-hamilton-minpoly-oq-07",
+    "cayley-hamilton-minpoly-oq-07-oq-01"
+  ],
+  "references": {
+    "papers": [
+      "Krylov, A. N., On the numerical solution of the equation..., 1931 — origin of the Krylov subspace iteration.",
+      "Keller-Gehrig, W., Fast algorithms for the characteristic polynomial, Theoretical Computer Science 36 (1985), 309-317 — blocked Krylov / companion-block viewpoint."
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Companion_matrix — companion matrix, its characteristic/minimal polynomial, cyclic/nonderogatory matrices.",
+      "https://en.wikipedia.org/wiki/Rational_canonical_form — Frobenius (rational) canonical form and invariant factors over a general field."
+    ],
+    "mathlib": [
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic — Matrix.charpoly, charpoly_natDegree_eq_dim.",
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly — Matrix.minpoly_dvd_charpoly.",
+      "Mathlib.FieldTheory.Minpoly.Basic — minpoly, minpoly.monic, minpoly.aeval.",
+      "Mathlib.LinearAlgebra.Matrix.ToLin — LinearMap.toMatrix, Matrix.toLin, basis change/similarity.",
+      "Mathlib.LinearAlgebra.Basis.Basic — Basis, submodule spans, endomorphism restriction (no companion-matrix / rational-canonical-form API exists as of 4.26.0)."
+    ]
+  },
+  "started": "2026-07-01T04:30:18.716Z",
+  "lastUpdate": "2026-07-01T04:30:18.763Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ01.lean",
+      "lineCount": 308,
+      "theoremCount": 20,
+      "axiomCount": 3,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ01OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ01OQ01.lean",
+      "lineCount": 329,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ01OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ01OQ02.lean",
+      "lineCount": 130,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02.lean",
+      "lineCount": 132,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ01.lean",
+      "lineCount": 218,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ01OQ02.lean",
+      "lineCount": 172,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ02.lean",
+      "lineCount": 391,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ02OQ01.lean",
+      "lineCount": 167,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ02OQ02.lean",
+      "lineCount": 269,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ03.lean",
+      "lineCount": 137,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03.lean",
+      "lineCount": 369,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03Aristotle.lean",
+      "lineCount": 115,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03OQ01.lean",
+      "lineCount": 266,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03OQ02.lean",
+      "lineCount": 384,
+      "theoremCount": 12,
+      "axiomCount": 3,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04.lean",
+      "lineCount": 317,
+      "theoremCount": 8,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04Backward.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04Backward.lean",
+      "lineCount": 481,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
+      "lineCount": 126,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04BackwardIncomplete01.lean",
+      "lineCount": 154,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ01.lean",
+      "lineCount": 87,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04OQ01.lean",
+      "lineCount": 239,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05.lean",
+      "lineCount": 233,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01.lean",
+      "lineCount": 271,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
+      "lineCount": 363,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
+      "lineCount": 271,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
+      "lineCount": 351,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
+      "lineCount": 288,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
+      "lineCount": 307,
+      "theoremCount": 5,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean",
+      "lineCount": 576,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean",
+      "lineCount": 254,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
+      "lineCount": 360,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean",
+      "lineCount": 191,
+      "theoremCount": 1,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ02.lean",
+      "lineCount": 263,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ02OQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ02OQ03.lean",
+      "lineCount": 245,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ06.lean",
+      "filename": "CayleyHamiltonMinpolyOQ06.lean",
+      "lineCount": 80,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ06.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ06OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ06OQ01.lean",
+      "lineCount": 162,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ06OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ07.lean",
+      "filename": "CayleyHamiltonMinpolyOQ07.lean",
+      "lineCount": 127,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ07.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ07OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ07OQ01.lean",
+      "lineCount": 185,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ07OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ07OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ07OQ02.lean",
+      "lineCount": 157,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ07OQ02.lean"
+    }
+  ],
+  "id": "cayley-hamilton-minpoly-oq-03-oq-03-oq-01"
+}


### PR DESCRIPTION
## Summary

New **verified, 0-axiom** gallery entry `cayley-hamilton-minpoly-oq-03-oq-03-oq-01`: **the companion matrix is nonderogatory**.

This is the complementary converse to the parent `cayley-hamilton-minpoly-oq-03-oq-03` (Krylov RCF *similarity*, merged as #—). The parent shows a nonderogatory matrix `M` with a cyclic vector is *similar* to the companion matrix of its minimal polynomial (`P⁻¹·M·P = C(μ_M)`). This grandchild supplies the fact that entry presupposes: for **any** monic `p` of degree `n ≥ 1` over a field `K`, the companion matrix `C = companion p` itself satisfies

- **μ_C = p**  (`companion_minpoly`)
- **χ_C = p**  (`companion_charpoly`)

so `C(μ_M)` really is the correct rational-canonical-form target block.

## What is proved
1. `companion_pow_mulVec_e0` — the standard vector `e₀` is a **cyclic vector**: its Krylov sequence `{e₀, C·e₀, …, C^{n-1}·e₀}` is exactly the standard basis.
2. `companion_pow_natDegree_mulVec_e0` — the top Krylov vector `C^n·e₀ = -∑ p.coeff i • eᵢ` closes the ladder (the last column of `C`).
3. `companion_aeval_eq_zero` — `p(C) = 0`.
4. `companion_minpoly` — `μ_C = p` (via the cyclic-vector degree bound).
5. `companion_charpoly` — `χ_C = p`, **determinant-free**: from `μ_C = p` + Cayley–Hamilton (`minpoly_dvd_charpoly`) + `χ_C` monic of degree `n`, avoiding any cofactor expansion of `det(X·I − C)`.
6. `companion_minpoly_eq_charpoly` — nonderogatory (`μ_C = χ_C`).

## Verification
- `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonMinpolyOQ03OQ03OQ01` → **Build succeeded** (3058 jobs).
- 0 sorries, 0 `axiom` declarations, no `native_decide` (all tactics: induction/omega/ring/simp/rw/congrFun) → genuinely 0-axiom.
- Self-contained (imports only Mathlib); Mathlib has no companion-matrix construction, so this builds it and its spectral identities from scratch.
- Mathlib 4.26.0.

## Files
- `proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ03OQ01.lean` (293 lines)
- `src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-03-oq-01/{meta,annotations}.json`
- `src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-03-oq-01.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)