### PR TITLE
Enrich descartes-rule-of-signs OQ-children cluster: add references (9 entries)

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/meta.json
@@ -1,7 +1,7 @@
 {
-  "slug": "descartes-rule-of-signs-oq-01-oq-04-oq-02",
   "id": "descartes-rule-of-signs-oq-01-oq-04-oq-02",
   "title": "Descartes Boundary Exact Count: One Sign Variation Forces Exactly One Positive Root (via IVT, sidestepping parity)",
+  "slug": "descartes-rule-of-signs-oq-01-oq-04-oq-02",
   "description": "Addresses the parent's open question of whether the exact positive-root count can be pinned down in the boundary cases signVariations ∈ {0,1}. The textbook route is the parity refinement (#positive roots ≡ signVariations mod 2), but that is the hard FTA-flavoured content of Descartes' Rule and is unavailable in both Mathlib and the gallery (every gallery file takes the parity as a hypothesis). The key observation here is that the boundary cases need only root EXISTENCE, not the full odd-multiplicity parity: signVariations = 0 forces zero positive roots from Descartes' bound alone, and signVariations = 1 forces exactly one positive root because the bound gives ≤ 1 while the Intermediate Value Theorem supplies ≥ 1. The IVT existence argument — deflate by the largest power of X, then cross zero between the trailing-coefficient sign at 0 and the leading-coefficient sign near +∞ — is fully machine-checked. The single combinatorial fact that one sign variation forces opposite leading/trailing signs is taken as an explicit hypothesis (it carries no analytic content), so the entry reduces the open boundary-exact-count to that one bridge plus a verified IVT core, entirely bypassing the open parity refinement. Stated over ℝ, since over ℚ the exact count is false (X²−2 has one sign variation but no rational root).",
   "meta": {
     "author": "Lean Genius",
@@ -45,18 +45,6 @@
       }
     ],
     "definitionCount": 0
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "namespace": "DescartesExactCount",
-    "lineCount": 192,
-    "axiomCount": 0,
-    "theoremCount": 3,
-    "definitionCount": 0,
-    "path": "Proofs/DescartesRuleOfSignsOQ01OQ04OQ02.lean",
-    "sorries": 0
   },
   "overview": {
     "problemStatement": "Can the exact number of positive roots be determined in the boundary cases signVariations ∈ {0, 1}, lifting Descartes' bound from an inequality to an equality there — given that the textbook tool, the parity refinement #positive roots ≡ signVariations (mod 2), is unavailable in Mathlib and the gallery?",
@@ -145,6 +133,47 @@
       "Generalize the existence argument from sign-change endpoints to an arbitrary real-closed field, replacing the IVT with the order-completeness available there.",
       "Combine with a Sturm-style oddness count to extend the exact count beyond the boundary cases signVariations ∈ {0,1}."
     ]
+  },
+  "references": [
+    {
+      "authors": "Descartes, René",
+      "title": "La Géométrie (appendix to Discours de la méthode)",
+      "year": "1637",
+      "venue": "Jan Maire, Leiden",
+      "note": "Original statement of the rule of signs."
+    },
+    {
+      "authors": "Prasolov, Victor V.",
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "Modern reference for Descartes' rule, Budan–Fourier, Vincent's theorem, and root bounds."
+    },
+    {
+      "authors": "Basu, Saugata; Pollack, Richard; Roy, Marie-Françoise",
+      "title": "Algorithms in Real Algebraic Geometry (2nd ed.)",
+      "year": "2006",
+      "venue": "Springer",
+      "note": "Sign-variation counting and constructive real-root isolation over ordered fields."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Polynomial.signVariations, cauchyBound and root-counting lemmas (Mathlib.Analysis / Mathlib.RingTheory.Polynomial)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "DescartesExactCount",
+    "lineCount": 192,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/DescartesRuleOfSignsOQ01OQ04OQ02.lean",
+    "sorries": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/meta.json
@@ -1,7 +1,7 @@
 {
-  "slug": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
   "id": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
   "title": "Sign Variations over an Arbitrary Ordered Field, Invariant under Order Embeddings",
+  "slug": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
   "description": "Answers the parent's open question: generalize the computable sign-variation count signVarList from ℚ to any LinearOrderedField with decidable order (ℚ, computable algebraic reals, …), keeping the rfl bridge to Mathlib's abstract signVariations. The substantive new infrastructure is a theorem absent from Mathlib — signVariations is invariant under any strictly monotone ring homomorphism (signVariations_map) — because the count reads only the signs of the coefficient list, and a strict-mono ring hom preserves both signs and (being injective) the list length. As payoff this bridges ℚ to ℝ: the kernel-reducible ℚ-coefficient count equals the sign-variation count of the real polynomial, so it bounds the number of positive REAL roots (the genuine Descartes statement), not merely the rational ones the parent could reach.",
   "meta": {
     "author": "Lean Genius",
@@ -54,18 +54,6 @@
       }
     ],
     "definitionCount": 1
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "namespace": "DescartesConstructiveGeneral",
-    "lineCount": 202,
-    "axiomCount": 0,
-    "theoremCount": 8,
-    "definitionCount": 1,
-    "path": "Proofs/DescartesRuleOfSignsOQ01OQ04OQ03.lean",
-    "sorries": 0
   },
   "overview": {
     "problemStatement": "Can the constructive sign-variation count signVarList be generalized from ℚ to an arbitrary computable LinearOrderedField while keeping the rfl bridge to the abstract count — and does the resulting count actually see the real-root behaviour Descartes' Rule is about, rather than just the roots living in the coefficient field?",
@@ -169,6 +157,47 @@
       "Can map-invariance be strengthened to an order-reflecting equivalence, characterizing exactly which (not-necessarily-injective) ring homs preserve signVariations?",
       "Combined with a formalization of Sturm's theorem over ℚ, does the real-root bound realRoots_countP_pos_le_signVarList upgrade to an exact computable count of positive real roots?"
     ]
+  },
+  "references": [
+    {
+      "authors": "Basu, Saugata; Pollack, Richard; Roy, Marie-Françoise",
+      "title": "Algorithms in Real Algebraic Geometry (2nd ed.)",
+      "year": "2006",
+      "venue": "Springer",
+      "note": "Sign-variation counting and constructive real-root isolation over ordered fields."
+    },
+    {
+      "authors": "Prasolov, Victor V.",
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "Modern reference for Descartes' rule, Budan–Fourier, Vincent's theorem, and root bounds."
+    },
+    {
+      "authors": "Descartes, René",
+      "title": "La Géométrie (appendix to Discours de la méthode)",
+      "year": "1637",
+      "venue": "Jan Maire, Leiden",
+      "note": "Original statement of the rule of signs."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Polynomial.signVariations, cauchyBound and root-counting lemmas (Mathlib.Analysis / Mathlib.RingTheory.Polynomial)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "DescartesConstructiveGeneral",
+    "lineCount": 202,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/DescartesRuleOfSignsOQ01OQ04OQ03.lean",
+    "sorries": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04/meta.json
@@ -1,7 +1,7 @@
 {
-  "slug": "descartes-rule-of-signs-oq-01-oq-04",
   "id": "descartes-rule-of-signs-oq-01-oq-04",
   "title": "A Constructive (Computable) Sign-Variation Count for Descartes' Rule",
+  "slug": "descartes-rule-of-signs-oq-01-oq-04",
   "description": "Answers the open question of whether Descartes' Rule can be made constructive. Mathlib's Polynomial.signVariations is noncomputable as a function of the polynomial. This file isolates the genuinely computable core — a sign-variation count on an explicit list of rational coefficients — proves it agrees with the abstract Mathlib definition, transports Descartes' bound to the computable side, and derives a decidable sound certificate that a polynomial has no positive roots. Includes worked examples discharged by kernel decide (0 axioms).",
   "meta": {
     "author": "Lean Genius",
@@ -45,20 +45,6 @@
       }
     ],
     "definitionCount": 1
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib.Algebra.Polynomial.RuleOfSigns",
-      "Mathlib.Algebra.Polynomial.Roots",
-      "Mathlib.Tactic"
-    ],
-    "namespace": "DescartesConstructive",
-    "lineCount": 134,
-    "axiomCount": 0,
-    "theoremCount": 4,
-    "definitionCount": 1,
-    "path": "Proofs/DescartesRuleOfSignsOQ01OQ04.lean",
-    "sorries": 0
   },
   "overview": {
     "problemStatement": "Can Descartes' Rule of Signs be made constructive — can the sign-variation bound be turned into something a machine actually computes, with decidable instances — given that Mathlib's Polynomial.signVariations is noncomputable as a function of the polynomial?",
@@ -163,6 +149,49 @@
       "Does the parity refinement (signVariations ≡ positive roots mod 2, proved over ℝ in the parent chain) lift to give a computable exact count when signVarList returns 0 or 1?",
       "Can signVarList be generalized from ℚ to an arbitrary computable LinearOrderedField (e.g. computable algebraic reals) while keeping the rfl bridge?"
     ]
+  },
+  "references": [
+    {
+      "authors": "Basu, Saugata; Pollack, Richard; Roy, Marie-Françoise",
+      "title": "Algorithms in Real Algebraic Geometry (2nd ed.)",
+      "year": "2006",
+      "venue": "Springer",
+      "note": "Sign-variation counting and constructive real-root isolation over ordered fields."
+    },
+    {
+      "authors": "Prasolov, Victor V.",
+      "title": "Polynomials",
+      "year": "2004",
+      "venue": "Algorithms and Computation in Mathematics 11, Springer",
+      "note": "Modern reference for Descartes' rule, Budan–Fourier, Vincent's theorem, and root bounds."
+    },
+    {
+      "authors": "Descartes, René",
+      "title": "La Géométrie (appendix to Discours de la méthode)",
+      "year": "1637",
+      "venue": "Jan Maire, Leiden",
+      "note": "Original statement of the rule of signs."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Polynomial.signVariations, cauchyBound and root-counting lemmas (Mathlib.Analysis / Mathlib.RingTheory.Polynomial)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.Polynomial.RuleOfSigns",
+      "Mathlib.Algebra.Polynomial.Roots",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "DescartesConstructive",
+    "lineCount": 134,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/DescartesRuleOfSignsOQ01OQ04.lean",
+    "sorries": 0
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Enrichment pass — cluster

9 verified `descartes-rule-of-signs-oq-*` descendants had **no references**. Added 4 references to each, matched to the classical result it formalizes:

- **Budan–Fourier** (endpoint backbone, upper bound) — Fourier (1831), Budan (1807), Prasolov, mathlib
- **Descartes parity / conjugate roots** — Descartes *La Géométrie* (1637), Lang *Algebra*, Prasolov, mathlib
- **Constructive sign-variation count / arbitrary ordered field** — Basu–Pollack–Roy, Prasolov, mathlib
- **Vincent's bisection theorem** — Vincent (1836), Akritas (1986), Prasolov, mathlib
- **Cauchy root bound + localization** — Cauchy (1821), Prasolov, Basu–Pollack–Roy, mathlib

All meta.json within size caps. No Lean source changed.