### PR TITLE
Enrich buffons-needle OQ-children cluster: add references (8 entries)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,90 +1,8 @@
 {
   "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
-  "slug": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
   "title": "Exponent-Swap Reflection Symmetry of the Half-Period Trigonometric Integral",
-  "overview": {
-    "historicalContext": "The Cauchy–Crofton chain reduces the angular average on S^{n-1} to one-dimensional trigonometric power integrals of the form ∫_0^{π/2} sinᵃθ cosᵇθ dθ. The parent entry (BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01) proved a single-power instance of the reflection symmetry — ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ — and flagged as its second open question whether that bespoke reflection packages into one clean, reusable lemma: that the half-period trig integral is invariant under swapping its two exponents. This file resolves that question.",
-    "problemStatement": "Prove the exponent-swap symmetry $\\int_0^{\\pi/2} \\sin^{a}\\theta\\,\\cos^{b}\\theta\\,d\\theta = \\int_0^{\\pi/2} \\sin^{b}\\theta\\,\\cos^{a}\\theta\\,d\\theta$ as a single reusable lemma, for natural-number exponents $a,b$ and — strictly more generally — for arbitrary real exponents (Real.rpow), and identify the Euler Beta symmetry $B(x,y)=B(y,x)$ as the immediate corollary.",
-    "proofStrategy": "The whole content is the reflection θ ↦ π/2 − θ, applied via intervalIntegral.integral_comp_sub_left with center π/2 on the self-fixed interval [0, π/2] (endpoints π/2−π/2 = 0 and π/2−0 = π/2, closed by sub_self and sub_zero). The unconditional identities Real.sin_pi_div_two_sub (sin(π/2−θ)=cos θ) and Real.cos_pi_div_two_sub (cos(π/2−θ)=sin θ) rewrite the reflected integrand sinᵃ(π/2−θ)·cosᵇ(π/2−θ) into cosᵃθ·sinᵇθ; a single intervalIntegral.integral_congr with mul_comm transposes the two factors to land on the swapped integrand. Because the rewrite acts only on the bases of the powers, the identical script proves the natural-number version (the powers are Monoid.npow) and the real-exponent version (Real.rpow) with no positivity or integrability hypothesis. The Beta symmetry corollary is the real-exponent lemma instantiated at exponents 2x−1, 2y−1; the parent's single-power identity is the natural-number lemma at a = 1 (using pow_one).",
-    "keyInsights": [
-      "The reflection symmetry is not really about FTC or antiderivatives at all — it is a pure change of variables. Stripping the parent's single-power statement down to its mechanism reveals a two-parameter lemma whose proof is three tactic lines: integral_comp_sub_left, simp with the two complementary-angle identities, and integral_congr with mul_comm.",
-      "Because the complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ are unconditional and act on the *bases* of the powers, the proof is completely insensitive to the exponent type. The natural-number and Real.rpow versions are literally the same script, so the general (real-exponent) lemma is obtained at no extra cost — and it is the form that meets the Euler Beta integral.",
-      "Euler's Beta symmetry B(x,y) = B(y,x), in the trigonometric representation B(x,y) = 2∫_0^{π/2} sin^{2x−1}θ cos^{2y−1}θ dθ, is exactly this exponent swap at exponents 2x−1, 2y−1. The reflection therefore gives a Gamma-free proof of Beta symmetry — the symmetry half of the Beta theory, cleanly separated from the (harder) evaluation half that needs the Gamma recurrence.",
-      "The parent's hand-rolled reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ is recovered verbatim as the a = 1 slice, confirming the new lemma is a genuine generalization rather than a restatement, and supplying the reusable bridge the open question asked for."
-    ]
-  },
+  "slug": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
   "description": "Packages the parent's bespoke single-power reflection into one clean, reusable lemma: the half-period trigonometric integral ∫_0^{π/2} sinᵃθ cosᵇθ dθ is invariant under swapping the exponents a ↔ b. The proof is the single reflection θ ↦ π/2 − θ (intervalIntegral.integral_comp_sub_left) together with the complementary-angle identities sin(π/2−θ)=cos θ, cos(π/2−θ)=sin θ; because these act on the bases of the powers, the identical script proves both the natural-number-exponent and the Real.rpow versions, with no positivity or integrability side conditions. As corollaries it gives the Euler Beta symmetry B(x,y)=B(y,x) in trigonometric form (a Gamma-free derivation) and recovers the parent's single-power identity as the a = 1 case. Axiom-free, 0 sorries.",
-  "assumptions": [],
-  "conclusion": {
-    "summary": "Gives a complete axiom-free Lean formalization of the exponent-swap reflection symmetry of the half-period trigonometric integral, for both natural-number and arbitrary real (Real.rpow) exponents, from the single reflection θ ↦ π/2 − θ. Includes the Euler Beta symmetry B(x,y)=B(y,x) in trigonometric form and the parent's single-power identity as corollaries. All results are machine-checked with 0 sorries and 0 axioms.",
-    "implications": "Supplies the reusable 'symmetry of the half-period trig integral under exponent swap' lemma requested by the parent's open question, in a form usable across the gallery's trigonometric-integral entries and one that meets the Beta function directly. By isolating the symmetry content as a pure reflection — independent of exponent type, positivity, and integrability — it cleanly separates the (easy) symmetry half of Beta theory from the (Gamma-dependent) evaluation half.",
-    "openQuestions": [
-      "Can the trigonometric Beta integral ∫_0^{π/2} sin^{2x−1}θ cos^{2y−1}θ dθ be connected to Mathlib's Real.betaIntegral via the half-angle substitution t = sin²θ, turning this trigonometric symmetry into a proof of the symmetry of Real.betaIntegral itself?",
-      "Does the same reflection give the Wallis recurrence relating ∫ sinᵃθ cosᵇθ to ∫ sin^{a−2}θ cosᵇθ (integration by parts in the reflected variable), completing an elementary evaluation route alongside the symmetry?"
-    ]
-  },
-  "sorries": 0,
-  "openQuestion": {
-    "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
-    "parentId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01",
-    "question": "Does the reflection-symmetry argument generalize to a clean Lean lemma 'symmetry of the half-period trig integral under exponent swap' usable across the gallery's trigonometric-integral entries?",
-    "answer": "Yes. The lemma integral_sin_pow_mul_cos_pow_swap states ∫_0^{π/2} sinᵃθ cosᵇθ dθ = ∫_0^{π/2} sinᵇθ cosᵃθ dθ for all a, b : ℕ, proved in three tactic steps from intervalIntegral.integral_comp_sub_left (the reflection θ ↦ π/2 − θ), the complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ, and a single integral_congr/mul_comm transposition. Because the identities act on the bases of the powers, the identical proof yields the strictly more general Real.rpow version integral_sin_rpow_mul_cos_rpow_swap for real exponents, with no positivity or integrability hypothesis. This real-exponent form instantiates to the Euler Beta symmetry B(x,y)=B(y,x) in its trigonometric guise (integral_beta_trig_symm), a Gamma-free derivation, and the natural-number form at a = 1 recovers the parent's single-power reflection identity (integral_sin_mul_cos_pow_eq_reflect). Connecting the trigonometric Beta integral to Mathlib's Real.betaIntegral via t = sin²θ remains the natural next step.",
-    "status": "answered"
-  },
-  "crossReferences": [
-    {
-      "targetId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01",
-      "relationship": "Parent: proved the single-power reflection ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ and flagged the general exponent-swap lemma as its second open question; this file proves that general lemma and recovers the parent's identity as the a = 1 case"
-    },
-    {
-      "targetId": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
-      "relationship": "Grandparent: defines the Cauchy–Crofton angular-average data whose trigonometric power integrals this symmetry governs"
-    },
-    {
-      "targetId": "buffons-needle",
-      "relationship": "Classical root: the Buffon needle crossing problem this integral-geometry chain formalizes"
-    }
-  ],
-  "highlights": [
-    {
-      "title": "One reflection, two exponent types",
-      "detail": "The reflection θ ↦ π/2 − θ rewrites the bases of the powers, so the same three-line proof covers natural-number and Real.rpow exponents alike — the general lemma costs nothing beyond the special case."
-    },
-    {
-      "title": "Beta symmetry without Gamma",
-      "detail": "Instantiated at exponents 2x−1, 2y−1, the lemma is Euler's Beta symmetry B(x,y)=B(y,x) in trigonometric form, derived purely from the reflection with no Gamma-function input."
-    },
-    {
-      "title": "No side conditions",
-      "detail": "The complementary-angle identities are unconditional, so the swap needs no positivity, no integrability, and no antiderivative — it is a pure change of variables."
-    },
-    {
-      "title": "Generalizes the parent verbatim",
-      "detail": "Setting a = 1 (using sin θ ^ 1 = sin θ) recovers the parent's hand-rolled reflection identity, confirming a genuine generalization."
-    },
-    {
-      "title": "Reusable across the gallery",
-      "detail": "Stated as a standalone two-parameter lemma, it is directly applicable to any half-period trigonometric power integral in the gallery, exactly as the open question requested."
-    }
-  ],
-  "sections": [
-    {
-      "title": "The exponent-swap lemma",
-      "content": "The headline lemma integral_sin_pow_mul_cos_pow_swap asserts ∫_0^{π/2} sinᵃθ cosᵇθ = ∫_0^{π/2} sinᵇθ cosᵃθ for a, b : ℕ. The proof applies intervalIntegral.integral_comp_sub_left with center π/2 and interval [0, π/2], which is fixed by the reflection (its endpoints map to π/2−π/2 = 0 and π/2−0 = π/2). The complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ rewrite the reflected integrand into cosᵃθ sinᵇθ, and one integral_congr with mul_comm transposes the factors onto the target."
-    },
-    {
-      "title": "Real exponents and the Beta function",
-      "content": "Because the reflection rewrites only the bases of the powers, the identical script proves integral_sin_rpow_mul_cos_rpow_swap for arbitrary real exponents (Real.rpow), with no positivity or integrability hypothesis. Instantiating the exponents at 2x−1 and 2y−1 yields integral_beta_trig_symm, the trigonometric form of Euler's Beta symmetry B(x,y)=B(y,x) — obtained without any Gamma-function machinery."
-    },
-    {
-      "title": "Recovering the parent",
-      "content": "The natural-number lemma at a = 1 (with sin θ ^ 1 = sin θ, cos θ ^ 1 = cos θ) is the parent's single-power reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ, re-proved here as integral_sin_mul_cos_pow_eq_reflect. This confirms the new statement strictly generalizes the parent and supplies the reusable bridge the open question asked for."
-    },
-    {
-      "title": "Scope and boundary",
-      "content": "This file isolates the symmetry content of the trigonometric power integrals. The complementary half — the evaluation of ∫ sin^{2x−1}θ cos^{2y−1}θ as a ratio of Gamma values, and the bridge to Mathlib's Real.betaIntegral via t = sin²θ — needs the Gamma recurrence and is left to the Beta/Gamma API, marking the boundary of the elementary reflection method."
-    }
-  ],
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Beta_function",
@@ -109,5 +27,116 @@
     "lineCount": 117,
     "theoremCount": 4,
     "definitionCount": 0
-  }
+  },
+  "overview": {
+    "historicalContext": "The Cauchy–Crofton chain reduces the angular average on S^{n-1} to one-dimensional trigonometric power integrals of the form ∫_0^{π/2} sinᵃθ cosᵇθ dθ. The parent entry (BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01) proved a single-power instance of the reflection symmetry — ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ — and flagged as its second open question whether that bespoke reflection packages into one clean, reusable lemma: that the half-period trig integral is invariant under swapping its two exponents. This file resolves that question.",
+    "problemStatement": "Prove the exponent-swap symmetry $\\int_0^{\\pi/2} \\sin^{a}\\theta\\,\\cos^{b}\\theta\\,d\\theta = \\int_0^{\\pi/2} \\sin^{b}\\theta\\,\\cos^{a}\\theta\\,d\\theta$ as a single reusable lemma, for natural-number exponents $a,b$ and — strictly more generally — for arbitrary real exponents (Real.rpow), and identify the Euler Beta symmetry $B(x,y)=B(y,x)$ as the immediate corollary.",
+    "proofStrategy": "The whole content is the reflection θ ↦ π/2 − θ, applied via intervalIntegral.integral_comp_sub_left with center π/2 on the self-fixed interval [0, π/2] (endpoints π/2−π/2 = 0 and π/2−0 = π/2, closed by sub_self and sub_zero). The unconditional identities Real.sin_pi_div_two_sub (sin(π/2−θ)=cos θ) and Real.cos_pi_div_two_sub (cos(π/2−θ)=sin θ) rewrite the reflected integrand sinᵃ(π/2−θ)·cosᵇ(π/2−θ) into cosᵃθ·sinᵇθ; a single intervalIntegral.integral_congr with mul_comm transposes the two factors to land on the swapped integrand. Because the rewrite acts only on the bases of the powers, the identical script proves the natural-number version (the powers are Monoid.npow) and the real-exponent version (Real.rpow) with no positivity or integrability hypothesis. The Beta symmetry corollary is the real-exponent lemma instantiated at exponents 2x−1, 2y−1; the parent's single-power identity is the natural-number lemma at a = 1 (using pow_one).",
+    "keyInsights": [
+      "The reflection symmetry is not really about FTC or antiderivatives at all — it is a pure change of variables. Stripping the parent's single-power statement down to its mechanism reveals a two-parameter lemma whose proof is three tactic lines: integral_comp_sub_left, simp with the two complementary-angle identities, and integral_congr with mul_comm.",
+      "Because the complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ are unconditional and act on the *bases* of the powers, the proof is completely insensitive to the exponent type. The natural-number and Real.rpow versions are literally the same script, so the general (real-exponent) lemma is obtained at no extra cost — and it is the form that meets the Euler Beta integral.",
+      "Euler's Beta symmetry B(x,y) = B(y,x), in the trigonometric representation B(x,y) = 2∫_0^{π/2} sin^{2x−1}θ cos^{2y−1}θ dθ, is exactly this exponent swap at exponents 2x−1, 2y−1. The reflection therefore gives a Gamma-free proof of Beta symmetry — the symmetry half of the Beta theory, cleanly separated from the (harder) evaluation half that needs the Gamma recurrence.",
+      "The parent's hand-rolled reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ is recovered verbatim as the a = 1 slice, confirming the new lemma is a genuine generalization rather than a restatement, and supplying the reusable bridge the open question asked for."
+    ]
+  },
+  "sections": [
+    {
+      "title": "The exponent-swap lemma",
+      "content": "The headline lemma integral_sin_pow_mul_cos_pow_swap asserts ∫_0^{π/2} sinᵃθ cosᵇθ = ∫_0^{π/2} sinᵇθ cosᵃθ for a, b : ℕ. The proof applies intervalIntegral.integral_comp_sub_left with center π/2 and interval [0, π/2], which is fixed by the reflection (its endpoints map to π/2−π/2 = 0 and π/2−0 = π/2). The complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ rewrite the reflected integrand into cosᵃθ sinᵇθ, and one integral_congr with mul_comm transposes the factors onto the target."
+    },
+    {
+      "title": "Real exponents and the Beta function",
+      "content": "Because the reflection rewrites only the bases of the powers, the identical script proves integral_sin_rpow_mul_cos_rpow_swap for arbitrary real exponents (Real.rpow), with no positivity or integrability hypothesis. Instantiating the exponents at 2x−1 and 2y−1 yields integral_beta_trig_symm, the trigonometric form of Euler's Beta symmetry B(x,y)=B(y,x) — obtained without any Gamma-function machinery."
+    },
+    {
+      "title": "Recovering the parent",
+      "content": "The natural-number lemma at a = 1 (with sin θ ^ 1 = sin θ, cos θ ^ 1 = cos θ) is the parent's single-power reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ, re-proved here as integral_sin_mul_cos_pow_eq_reflect. This confirms the new statement strictly generalizes the parent and supplies the reusable bridge the open question asked for."
+    },
+    {
+      "title": "Scope and boundary",
+      "content": "This file isolates the symmetry content of the trigonometric power integrals. The complementary half — the evaluation of ∫ sin^{2x−1}θ cos^{2y−1}θ as a ratio of Gamma values, and the bridge to Mathlib's Real.betaIntegral via t = sin²θ — needs the Gamma recurrence and is left to the Beta/Gamma API, marking the boundary of the elementary reflection method."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01",
+      "relationship": "Parent: proved the single-power reflection ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ and flagged the general exponent-swap lemma as its second open question; this file proves that general lemma and recovers the parent's identity as the a = 1 case"
+    },
+    {
+      "targetId": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
+      "relationship": "Grandparent: defines the Cauchy–Crofton angular-average data whose trigonometric power integrals this symmetry governs"
+    },
+    {
+      "targetId": "buffons-needle",
+      "relationship": "Classical root: the Buffon needle crossing problem this integral-geometry chain formalizes"
+    }
+  ],
+  "conclusion": {
+    "summary": "Gives a complete axiom-free Lean formalization of the exponent-swap reflection symmetry of the half-period trigonometric integral, for both natural-number and arbitrary real (Real.rpow) exponents, from the single reflection θ ↦ π/2 − θ. Includes the Euler Beta symmetry B(x,y)=B(y,x) in trigonometric form and the parent's single-power identity as corollaries. All results are machine-checked with 0 sorries and 0 axioms.",
+    "implications": "Supplies the reusable 'symmetry of the half-period trig integral under exponent swap' lemma requested by the parent's open question, in a form usable across the gallery's trigonometric-integral entries and one that meets the Beta function directly. By isolating the symmetry content as a pure reflection — independent of exponent type, positivity, and integrability — it cleanly separates the (easy) symmetry half of Beta theory from the (Gamma-dependent) evaluation half.",
+    "openQuestions": [
+      "Can the trigonometric Beta integral ∫_0^{π/2} sin^{2x−1}θ cos^{2y−1}θ dθ be connected to Mathlib's Real.betaIntegral via the half-angle substitution t = sin²θ, turning this trigonometric symmetry into a proof of the symmetry of Real.betaIntegral itself?",
+      "Does the same reflection give the Wallis recurrence relating ∫ sinᵃθ cosᵇθ to ∫ sin^{a−2}θ cosᵇθ (integration by parts in the reflected variable), completing an elementary evaluation route alongside the symmetry?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Wallis, John",
+      "title": "Arithmetica Infinitorum",
+      "year": "1656",
+      "venue": "Oxford",
+      "note": "Origin of the sin/cos power integrals underlying the angular Beta integral."
+    },
+    {
+      "authors": "Whittaker, E. T. and Watson, G. N.",
+      "title": "A Course of Modern Analysis (4th ed.)",
+      "year": "1927",
+      "venue": "Cambridge University Press",
+      "note": "Beta and Gamma function integrals ∫₀^{π/2} sin^a θ cos^b θ dθ."
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston",
+      "note": "Beta–Gamma relation B(x,y)=Γ(x)Γ(y)/Γ(x+y)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "integral_sin_pow, integral_cos_pow, Real.Gamma/Beta and sphere-measure lemmas (Mathlib.Analysis.SpecialFunctions.Integrals / .Gamma)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "sorries": 0,
+  "assumptions": [],
+  "openQuestion": {
+    "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "parentId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01",
+    "question": "Does the reflection-symmetry argument generalize to a clean Lean lemma 'symmetry of the half-period trig integral under exponent swap' usable across the gallery's trigonometric-integral entries?",
+    "answer": "Yes. The lemma integral_sin_pow_mul_cos_pow_swap states ∫_0^{π/2} sinᵃθ cosᵇθ dθ = ∫_0^{π/2} sinᵇθ cosᵃθ dθ for all a, b : ℕ, proved in three tactic steps from intervalIntegral.integral_comp_sub_left (the reflection θ ↦ π/2 − θ), the complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ, and a single integral_congr/mul_comm transposition. Because the identities act on the bases of the powers, the identical proof yields the strictly more general Real.rpow version integral_sin_rpow_mul_cos_rpow_swap for real exponents, with no positivity or integrability hypothesis. This real-exponent form instantiates to the Euler Beta symmetry B(x,y)=B(y,x) in its trigonometric guise (integral_beta_trig_symm), a Gamma-free derivation, and the natural-number form at a = 1 recovers the parent's single-power reflection identity (integral_sin_mul_cos_pow_eq_reflect). Connecting the trigonometric Beta integral to Mathlib's Real.betaIntegral via t = sin²θ remains the natural next step.",
+    "status": "answered"
+  },
+  "highlights": [
+    {
+      "title": "One reflection, two exponent types",
+      "detail": "The reflection θ ↦ π/2 − θ rewrites the bases of the powers, so the same three-line proof covers natural-number and Real.rpow exponents alike — the general lemma costs nothing beyond the special case."
+    },
+    {
+      "title": "Beta symmetry without Gamma",
+      "detail": "Instantiated at exponents 2x−1, 2y−1, the lemma is Euler's Beta symmetry B(x,y)=B(y,x) in trigonometric form, derived purely from the reflection with no Gamma-function input."
+    },
+    {
+      "title": "No side conditions",
+      "detail": "The complementary-angle identities are unconditional, so the swap needs no positivity, no integrability, and no antiderivative — it is a pure change of variables."
+    },
+    {
+      "title": "Generalizes the parent verbatim",
+      "detail": "Setting a = 1 (using sin θ ^ 1 = sin θ) recovers the parent's hand-rolled reflection identity, confirming a genuine generalization."
+    },
+    {
+      "title": "Reusable across the gallery",
+      "detail": "Stated as a standalone two-parameter lemma, it is directly applicable to any half-period trigonometric power integral in the gallery, exactly as the open question requested."
+    }
+  ]
 }

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -27,13 +27,6 @@
     "theoremCount": 3,
     "definitionCount": 0
   },
-  "openQuestion": {
-    "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01",
-    "parentId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
-    "question": "Can the companion integral ∫_0^{π/2} sin θ · cos^{n-2} θ dθ = 1/(n-1) (and more generally the full Beta function B(a,b) = ∫_0^{π/2} sin^{2a-1}θ cos^{2b-1}θ dθ) be formalized by the same FTC template? And does an independent proof exist?",
-    "answer": "Yes for the companion integral. The general lemma ∫_0^{π/2} sin θ · cosᵐ θ dθ = 1/(m+1) is proved for every m : ℕ by the fundamental theorem of calculus with the mirror antiderivative F(θ) = -cos^{m+1}(θ)/(m+1), whose derivative is sin θ · cosᵐ θ (the closed form of the substitution u = cos θ). Specializing m := n-2 gives the dimensional form 1/(n-1) for n ≥ 2. An independent derivation is also provided: the reflection θ ↦ π/2 − θ (intervalIntegral.integral_comp_sub_left with cos(π/2−θ)=sin θ, sin(π/2−θ)=cos θ) maps the companion integral exactly onto the parent integral ∫_0^{π/2} cos θ · sinᵐ θ dθ, so the value 1/(m+1) follows a second way without re-running the FTC. The full two-parameter Beta function B(a,b) for general real a,b is NOT reachable by this single-step FTC template — an elementary antiderivative closes the integral only when one factor is a first power; the general case requires the Gamma-function recurrence.",
-    "status": "answered"
-  },
   "overview": {
     "historicalContext": "The Cauchy–Crofton formula generalizes the 2D Buffon needle identity to higher dimensions, reducing the angular average on S^{n-1} to a one-dimensional Beta integral. The parent entry (BuffonsNeedleOQ01OQ01OQ04OQ01Beta) proved ∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1) by FTC and flagged two open questions: (1) whether the companion integral ∫_0^{π/2} sin θ · cos^{n-2} θ dθ = 1/(n-1) — and the full Beta function — can be handled by the same FTC template, and (2) whether an independent proof exists. This file resolves both.",
     "problemStatement": "For $n \\geq 2$, prove the companion Beta integral $\\int_0^{\\pi/2} \\sin\\theta \\cdot \\cos^{n-2}\\theta \\, d\\theta = \\frac{1}{n-1}$ (equivalently, for every $m : \\mathbb{N}$, $\\int_0^{\\pi/2} \\sin\\theta \\cdot \\cos^{m}\\theta \\, d\\theta = \\frac{1}{m+1}$), and give an independent derivation via the reflection $\\theta \\mapsto \\pi/2 - \\theta$.",
@@ -79,14 +72,6 @@
       "mathContext": "The reflection $\\theta\\mapsto\\pi/2-\\theta$ is an involution of $[0,\\pi/2]$ interchanging $\\sin$ and $\\cos$, so $\\int_0^{\\pi/2}\\sin\\theta\\cos^m\\theta = \\int_0^{\\pi/2}\\cos\\theta\\sin^m\\theta$."
     }
   ],
-  "conclusion": {
-    "summary": "This file gives a complete axiom-free Lean formalization of the companion Beta integral ∫_0^{π/2} sin θ · cos^{n-2} θ dθ = 1/(n-1) for n ≥ 2 (general form 1/(m+1)) by the fundamental theorem of calculus with the mirror antiderivative -cos^{m+1}(θ)/(m+1), and an independent derivation of the same value via the reflection θ ↦ π/2 − θ. All three theorems are machine-checked with 0 sorries and 0 axioms.",
-    "implications": "Together with the parent file, this closes the angular-averaging analytic core symmetrically in sin and cos, making the choice of polar axis provably immaterial. The reflection lemma is a reusable bridge between the two trigonometric power-integral templates, and the explicit scoping of the full Beta function marks the boundary of the single-step FTC method.",
-    "openQuestions": [
-      "Can the full two-parameter Beta function B(a,b) = ∫_0^{π/2} sin^{2a-1}θ cos^{2b-1}θ dθ for general real a,b be connected to Mathlib's Real.Gamma / betaIntegral API and the Wallis-type recurrence integral_sin_pow / integral_cos_pow?",
-      "Does the reflection-symmetry argument generalize to a clean Lean lemma 'symmetry of the half-period trig integral under exponent swap' usable across the gallery's trigonometric-integral entries?"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
@@ -101,14 +86,43 @@
       "relationship": "Classical root: the Buffon needle crossing problem this integral-geometry chain formalizes"
     }
   ],
-  "highlights": [
-    "Companion Beta integral ∫_0^{π/2} sin θ · cos^{n-2} θ dθ = 1/(n-1) proved axiom-free for n ≥ 2",
-    "Mirror FTC antiderivative F(θ) = -cos^{m+1}(θ)/(m+1) transfers the parent's template verbatim",
-    "Independent reflection derivation θ ↦ π/2 − θ shows the companion is the parent with sin ↔ cos swapped",
-    "Sharply scopes the full two-parameter Beta function out of the single-step FTC method",
-    "Self-contained: depends only on Mathlib, 0 sorries, 0 axioms"
+  "conclusion": {
+    "summary": "This file gives a complete axiom-free Lean formalization of the companion Beta integral ∫_0^{π/2} sin θ · cos^{n-2} θ dθ = 1/(n-1) for n ≥ 2 (general form 1/(m+1)) by the fundamental theorem of calculus with the mirror antiderivative -cos^{m+1}(θ)/(m+1), and an independent derivation of the same value via the reflection θ ↦ π/2 − θ. All three theorems are machine-checked with 0 sorries and 0 axioms.",
+    "implications": "Together with the parent file, this closes the angular-averaging analytic core symmetrically in sin and cos, making the choice of polar axis provably immaterial. The reflection lemma is a reusable bridge between the two trigonometric power-integral templates, and the explicit scoping of the full Beta function marks the boundary of the single-step FTC method.",
+    "openQuestions": [
+      "Can the full two-parameter Beta function B(a,b) = ∫_0^{π/2} sin^{2a-1}θ cos^{2b-1}θ dθ for general real a,b be connected to Mathlib's Real.Gamma / betaIntegral API and the Wallis-type recurrence integral_sin_pow / integral_cos_pow?",
+      "Does the reflection-symmetry argument generalize to a clean Lean lemma 'symmetry of the half-period trig integral under exponent swap' usable across the gallery's trigonometric-integral entries?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Wallis, John",
+      "title": "Arithmetica Infinitorum",
+      "year": "1656",
+      "venue": "Oxford",
+      "note": "Origin of the sin/cos power integrals underlying the angular Beta integral."
+    },
+    {
+      "authors": "Whittaker, E. T. and Watson, G. N.",
+      "title": "A Course of Modern Analysis (4th ed.)",
+      "year": "1927",
+      "venue": "Cambridge University Press",
+      "note": "Beta and Gamma function integrals ∫₀^{π/2} sin^a θ cos^b θ dθ."
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston",
+      "note": "Beta–Gamma relation B(x,y)=Γ(x)Γ(y)/Γ(x+y)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "integral_sin_pow, integral_cos_pow, Real.Gamma/Beta and sphere-measure lemmas (Mathlib.Analysis.SpecialFunctions.Integrals / .Gamma)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
   ],
-  "assumptions": [],
   "leanFile": {
     "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01.lean",
     "lineCount": 112,
@@ -126,5 +140,20 @@
     ],
     "namespace": "BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01"
   },
-  "sorries": 0
+  "sorries": 0,
+  "openQuestion": {
+    "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01",
+    "parentId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
+    "question": "Can the companion integral ∫_0^{π/2} sin θ · cos^{n-2} θ dθ = 1/(n-1) (and more generally the full Beta function B(a,b) = ∫_0^{π/2} sin^{2a-1}θ cos^{2b-1}θ dθ) be formalized by the same FTC template? And does an independent proof exist?",
+    "answer": "Yes for the companion integral. The general lemma ∫_0^{π/2} sin θ · cosᵐ θ dθ = 1/(m+1) is proved for every m : ℕ by the fundamental theorem of calculus with the mirror antiderivative F(θ) = -cos^{m+1}(θ)/(m+1), whose derivative is sin θ · cosᵐ θ (the closed form of the substitution u = cos θ). Specializing m := n-2 gives the dimensional form 1/(n-1) for n ≥ 2. An independent derivation is also provided: the reflection θ ↦ π/2 − θ (intervalIntegral.integral_comp_sub_left with cos(π/2−θ)=sin θ, sin(π/2−θ)=cos θ) maps the companion integral exactly onto the parent integral ∫_0^{π/2} cos θ · sinᵐ θ dθ, so the value 1/(m+1) follows a second way without re-running the FTC. The full two-parameter Beta function B(a,b) for general real a,b is NOT reachable by this single-step FTC template — an elementary antiderivative closes the integral only when one factor is a first power; the general case requires the Gamma-function recurrence.",
+    "status": "answered"
+  },
+  "highlights": [
+    "Companion Beta integral ∫_0^{π/2} sin θ · cos^{n-2} θ dθ = 1/(n-1) proved axiom-free for n ≥ 2",
+    "Mirror FTC antiderivative F(θ) = -cos^{m+1}(θ)/(m+1) transfers the parent's template verbatim",
+    "Independent reflection derivation θ ↦ π/2 − θ shows the companion is the parent with sin ↔ cos swapped",
+    "Sharply scopes the full two-parameter Beta function out of the single-step FTC method",
+    "Self-contained: depends only on Mathlib, 0 sorries, 0 axioms"
+  ],
+  "assumptions": []
 }

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01/meta.json
@@ -26,12 +26,6 @@
     "theoremCount": 2,
     "definitionCount": 0
   },
-  "openQuestion": {
-    "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
-    "parentId": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
-    "question": "Can the Beta integral identity ∫_0^{π/2} cos(θ)·sin^{n-2}(θ) dθ = 1/(n-1) be formalized in Lean 4 using Mathlib's integration lemmas?",
-    "answer": "Yes, axiom-free. The general lemma ∫_0^{π/2} cos θ · sinᵐ θ dθ = 1/(m+1) is proved for every m : ℕ by the fundamental theorem of calculus with antiderivative F(θ) = sin^{m+1}(θ)/(m+1), whose derivative is cos θ · sinᵐ θ (this is the closed form of the substitution u = sin θ, ∫_0^1 uᵐ du = 1/(m+1)). Specializing m := n-2 with the cast (n-2 : ℕ) + 1 = (n:ℝ) - 1 for n ≥ 2 yields the stated Beta integral. No measure-theoretic axioms beyond Mathlib's intervalIntegral.integral_eq_sub_of_hasDerivAt are required."
-  },
   "overview": {
     "historicalContext": "The Cauchy–Crofton formula generalizes the 2D Buffon needle crossing identity ∫_0^π |cos θ| dθ = 2 to higher dimensions, replacing it with the sphere integral ∫_{S^{n-1}} |⟨v, ω⟩| dσ(ω) = 2σ_{n-2}/(n-1) · ‖v‖. The parent proof established the angular averaging identity for all n ≥ 2 by constructing the AngularAverageData structure with the explicit linear factor σ_{n-2}/(n-1). The remaining analytic gap — flagged as the key missing piece — was to prove the one-dimensional Beta integral ∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1), which supplies that proportionality factor when the sphere integral is decomposed in polar coordinates.",
     "problemStatement": "For $n \\geq 2$, prove the Beta integral identity $\\int_0^{\\pi/2} \\cos\\theta \\cdot \\sin^{n-2}\\theta \\, d\\theta = \\frac{1}{n-1}$. Equivalently, for every natural number $m$, $\\int_0^{\\pi/2} \\cos\\theta \\cdot \\sin^{m}\\theta \\, d\\theta = \\frac{1}{m+1}$.",
@@ -86,14 +80,6 @@
       "mathContext": "With $m = n-2$ the value $\\tfrac{1}{m+1}$ becomes $\\tfrac{1}{n-1}$; the hypothesis $n \\ge 2$ is needed for the ℕ-subtraction cast $((n-2:\\mathbb{N}):\\mathbb{R}) + 1 = (n:\\mathbb{R}) - 1$."
     }
   ],
-  "conclusion": {
-    "summary": "This file gives a complete axiom-free Lean formalization of the Beta integral ∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1) for n ≥ 2, together with its general natural-exponent form 1/(m+1). Both theorems are machine-checked with 0 sorries and 0 axioms, using only the fundamental theorem of calculus.",
-    "implications": "The identity closes the last analytic gap in the parent Cauchy–Crofton angular averaging proof for n ≥ 3: it supplies the σ_{n-2}/(n-1) proportionality factor that the AngularAverageData construction requires. More broadly, it provides a reusable closed-form template for trigonometric power integrals of the shape ∫ cos θ · sinᵐ θ.",
-    "openQuestions": [
-      "Can the companion integral ∫_0^{π/2} sin θ · cos^{n-2} θ dθ = 1/(n-1) (and more generally the full Beta function B(a,b) = ∫_0^{π/2} sin^{2a-1}θ cos^{2b-1}θ dθ) be formalized by the same FTC template?",
-      "Does Mathlib's existing integral_sin_pow / integral_cos_pow recurrence machinery yield an independent proof, and is the FTC route strictly shorter?"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
@@ -108,13 +94,43 @@
       "relationship": "Classical root: the Buffon needle crossing problem this integral-geometry chain formalizes"
     }
   ],
-  "highlights": [
-    "Beta integral ∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1) proved axiom-free for n ≥ 2",
-    "General form ∫_0^{π/2} cos θ · sinᵐ θ dθ = 1/(m+1) via fundamental theorem of calculus",
-    "Closes the last analytic gap in the n ≥ 3 Cauchy–Crofton angular averaging argument",
-    "Self-contained: depends only on Mathlib, 0 sorries, 0 axioms"
+  "conclusion": {
+    "summary": "This file gives a complete axiom-free Lean formalization of the Beta integral ∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1) for n ≥ 2, together with its general natural-exponent form 1/(m+1). Both theorems are machine-checked with 0 sorries and 0 axioms, using only the fundamental theorem of calculus.",
+    "implications": "The identity closes the last analytic gap in the parent Cauchy–Crofton angular averaging proof for n ≥ 3: it supplies the σ_{n-2}/(n-1) proportionality factor that the AngularAverageData construction requires. More broadly, it provides a reusable closed-form template for trigonometric power integrals of the shape ∫ cos θ · sinᵐ θ.",
+    "openQuestions": [
+      "Can the companion integral ∫_0^{π/2} sin θ · cos^{n-2} θ dθ = 1/(n-1) (and more generally the full Beta function B(a,b) = ∫_0^{π/2} sin^{2a-1}θ cos^{2b-1}θ dθ) be formalized by the same FTC template?",
+      "Does Mathlib's existing integral_sin_pow / integral_cos_pow recurrence machinery yield an independent proof, and is the FTC route strictly shorter?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Wallis, John",
+      "title": "Arithmetica Infinitorum",
+      "year": "1656",
+      "venue": "Oxford",
+      "note": "Origin of the sin/cos power integrals underlying the angular Beta integral."
+    },
+    {
+      "authors": "Whittaker, E. T. and Watson, G. N.",
+      "title": "A Course of Modern Analysis (4th ed.)",
+      "year": "1927",
+      "venue": "Cambridge University Press",
+      "note": "Beta and Gamma function integrals ∫₀^{π/2} sin^a θ cos^b θ dθ."
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston",
+      "note": "Beta–Gamma relation B(x,y)=Γ(x)Γ(y)/Γ(x+y)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "integral_sin_pow, integral_cos_pow, Real.Gamma/Beta and sphere-measure lemmas (Mathlib.Analysis.SpecialFunctions.Integrals / .Gamma)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
   ],
-  "assumptions": [],
   "leanFile": {
     "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01Beta.lean",
     "lineCount": 74,
@@ -132,5 +148,18 @@
     ],
     "namespace": "BuffonsNeedleOQ01OQ01OQ04OQ01Beta"
   },
-  "sorries": 0
+  "sorries": 0,
+  "openQuestion": {
+    "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01",
+    "parentId": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
+    "question": "Can the Beta integral identity ∫_0^{π/2} cos(θ)·sin^{n-2}(θ) dθ = 1/(n-1) be formalized in Lean 4 using Mathlib's integration lemmas?",
+    "answer": "Yes, axiom-free. The general lemma ∫_0^{π/2} cos θ · sinᵐ θ dθ = 1/(m+1) is proved for every m : ℕ by the fundamental theorem of calculus with antiderivative F(θ) = sin^{m+1}(θ)/(m+1), whose derivative is cos θ · sinᵐ θ (this is the closed form of the substitution u = sin θ, ∫_0^1 uᵐ du = 1/(m+1)). Specializing m := n-2 with the cast (n-2 : ℕ) + 1 = (n:ℝ) - 1 for n ≥ 2 yields the stated Beta integral. No measure-theoretic axioms beyond Mathlib's intervalIntegral.integral_eq_sub_of_hasDerivAt are required."
+  },
+  "highlights": [
+    "Beta integral ∫_0^{π/2} cos θ · sin^{n-2} θ dθ = 1/(n-1) proved axiom-free for n ≥ 2",
+    "General form ∫_0^{π/2} cos θ · sinᵐ θ dθ = 1/(m+1) via fundamental theorem of calculus",
+    "Closes the last analytic gap in the n ≥ 3 Cauchy–Crofton angular averaging argument",
+    "Self-contained: depends only on Mathlib, 0 sorries, 0 axioms"
+  ],
+  "assumptions": []
 }

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
   "title": "Angular Averaging Identity from Sphere Measure Theory",
   "slug": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
-  "description": "Proves the angular averaging identity for all n \u2265 2 axiom-free. For n=2: constructs AngularAverageData 2 from \u222b_0^\u03c0 |cos \u03b8| d\u03b8 = 2 via interval integration. For n \u2265 3: constructs AngularAverageData n via the explicit linear function r \u21a6 sphereArea(n-2)/(n-1)\u00b7r, which satisfies the algebraic identity by definition. Derives the product formula c_n \u00b7 c_{n+1} = 2/(n\u00b7\u03c0) using the sphere area recurrence. The full Cauchy-Crofton framework is 0-axiom.",
+  "description": "Proves the angular averaging identity for all n ≥ 2 axiom-free. For n=2: constructs AngularAverageData 2 from ∫_0^π |cos θ| dθ = 2 via interval integration. For n ≥ 3: constructs AngularAverageData n via the explicit linear function r ↦ sphereArea(n-2)/(n-1)·r, which satisfies the algebraic identity by definition. Derives the product formula c_n · c_{n+1} = 2/(n·π) using the sphere area recurrence. The full Cauchy-Crofton framework is 0-axiom.",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cauchy%E2%80%93Crofton_formula",
@@ -25,22 +25,16 @@
     "theoremCount": 11,
     "definitionCount": 2
   },
-  "openQuestion": {
-    "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
-    "parentId": "buffons-needle-oq-01-oq-01-oq-04",
-    "question": "Can the angular averaging identity \u222b_{S^{n-1}} |\u27e8v, \u03c9\u27e9| d\u03c3(\u03c9) = 2\u03c3_{n-2}/(n-1) \u00b7 \u2016v\u2016 be proved from Mathlib's sphere measure theory?",
-    "answer": "Yes for n=2: proved via \u222b_0^\u03c0 |cos \u03b8| d\u03b8 = 2 (rotation of the known \u222b_0^\u03c0 |sin \u03b8| d\u03b8 = 2). For n \u2265 3: proved by constructing AngularAverageData n with the explicit linear function r \u21a6 sphereArea(n-2)/(n-1)\u00b7r, which trivially satisfies the algebraic identity required by the structure. This is axiom-free: non-negativity follows from sphereArea_pos and n \u2265 3 \u27f9 (n:\u211d)-1 \u2265 2 > 0."
-  },
   "overview": {
-    "historicalContext": "The Buffon needle problem (1777) was the first geometric probability result, asking for the probability that a dropped needle crosses a parallel line. Joseph-\u00c9mile Barbier extended this in 1860: for any convex curve of length L, the expected crossing count is E = 2L/(\u03c0d), where d is the line spacing. The key analytic factor is the angular averaging identity \u222b_0^\u03c0 |cos \u03b8| d\u03b8 = 2, which quantifies how a unit-length curve element at angle \u03b8 projects onto perpendicular lines. The n-dimensional generalization, the Cauchy-Crofton formula, replaces this with \u222b_{S^{n-1}} |\u27e8v, \u03c9\u27e9| d\u03c3(\u03c9) = 2\u03c3_{n-2}/(n-1) \u00b7 \u2016v\u2016 and was developed by Augustin-Louis Cauchy and Morgan Crofton in the 19th century as part of the foundations of integral geometry.",
+    "historicalContext": "The Buffon needle problem (1777) was the first geometric probability result, asking for the probability that a dropped needle crosses a parallel line. Joseph-Émile Barbier extended this in 1860: for any convex curve of length L, the expected crossing count is E = 2L/(πd), where d is the line spacing. The key analytic factor is the angular averaging identity ∫_0^π |cos θ| dθ = 2, which quantifies how a unit-length curve element at angle θ projects onto perpendicular lines. The n-dimensional generalization, the Cauchy-Crofton formula, replaces this with ∫_{S^{n-1}} |⟨v, ω⟩| dσ(ω) = 2σ_{n-2}/(n-1) · ‖v‖ and was developed by Augustin-Louis Cauchy and Morgan Crofton in the 19th century as part of the foundations of integral geometry.",
     "problemStatement": "Let $\\sigma_k$ denote the surface area of $S^k$. The **Cauchy-Crofton constant** $c_n = 2\\sigma_{n-2} / ((n-1)\\sigma_{n-1})$ governs the expected number of hyperplane crossings for a rectifiable curve in $\\mathbb{R}^n$. The 2D case $c_2 = 2/\\pi$ rests on the identity $\\int_0^\\pi |\\cos\\theta|\\,d\\theta = 2$. The file also proves the **product formula** $c_n \\cdot c_{n+1} = 2/(n\\pi)$ for $n \\geq 2$.",
-    "proofStrategy": "The proof proceeds in five parts. Part I reduces the cos integral to the known sin integral via the phase-shift identity |sin(\u03b8 + \u03c0/2)| = |cos \u03b8|, avoiding direct antiderivative computation. Part II packages this into an axiom-free AngularAverageData 2 instance by verifying the algebraic identity 2r = \u03c3_0/(2-1) \u00b7 r = 2r. Part III constructs AngularAverageData n for n \u2265 3 by defining angularAvg r := sphereArea(n-2)/(n-1)\u00b7r directly; the structure identity holds by rfl and non-negativity follows from sphereArea_pos and n \u2265 3 \u27f9 (n:\u211d)-1 \u2265 2. Part IV derives the product formula c_n \u00b7 c_{n+1} = 2/(n\u00b7\u03c0) by applying the sphere area recurrence \u03c3_n = 2\u03c0/(n-1) \u00b7 \u03c3_{n-2} to telescope the numerators and denominators. Part V establishes positivity and shows c_2 < 1, c_{n+1} = 2/(n\u00b7\u03c0\u00b7c_n).",
+    "proofStrategy": "The proof proceeds in five parts. Part I reduces the cos integral to the known sin integral via the phase-shift identity |sin(θ + π/2)| = |cos θ|, avoiding direct antiderivative computation. Part II packages this into an axiom-free AngularAverageData 2 instance by verifying the algebraic identity 2r = σ_0/(2-1) · r = 2r. Part III constructs AngularAverageData n for n ≥ 3 by defining angularAvg r := sphereArea(n-2)/(n-1)·r directly; the structure identity holds by rfl and non-negativity follows from sphereArea_pos and n ≥ 3 ⟹ (n:ℝ)-1 ≥ 2. Part IV derives the product formula c_n · c_{n+1} = 2/(n·π) by applying the sphere area recurrence σ_n = 2π/(n-1) · σ_{n-2} to telescope the numerators and denominators. Part V establishes positivity and shows c_2 < 1, c_{n+1} = 2/(n·π·c_n).",
     "keyInsights": [
-      "Rotation invariance of |sin| eliminates direct computation: |cos \u03b8| = |sin(\u03b8 + \u03c0/2)| converts the unfamiliar cos integral to the already-proved sin integral with a phase shift, a zero-computation proof technique.",
-      "The axiom-free AngularAverageData 2 instance means E[crossings] = 2L/(\u03c0d) is a theorem derivable from classical interval integration alone \u2014 no measure theory on sphere bundles is needed for the 2D case.",
-      "The sphere area recurrence \u03c3_n = 2\u03c0/(n-1) \u00b7 \u03c3_{n-2} creates an exact telescoping cancellation in the product c_n \u00b7 c_{n+1}, reducing an apparent six-term formula to the simple expression 2/(n\u00b7\u03c0).",
-      "The product formula reveals a hidden structure: the sequence (c_n \u00b7 c_{n+1}) = (2/(n\u00b7\u03c0)) is strictly decreasing, consistent with the well-known fact that the volume of the unit ball vanishes as n \u2192 \u221e.",
-      "The n \u2265 3 case is proved axiom-free by defining angularAvg r := sphereArea(n-2)/(n-1)\u00b7r directly. AngularAverageData only requires algebraic properties (the function equals this formula and is non-negative), not that the formula equals the sphere integral. Both are now machine-checked without any assumptions."
+      "Rotation invariance of |sin| eliminates direct computation: |cos θ| = |sin(θ + π/2)| converts the unfamiliar cos integral to the already-proved sin integral with a phase shift, a zero-computation proof technique.",
+      "The axiom-free AngularAverageData 2 instance means E[crossings] = 2L/(πd) is a theorem derivable from classical interval integration alone — no measure theory on sphere bundles is needed for the 2D case.",
+      "The sphere area recurrence σ_n = 2π/(n-1) · σ_{n-2} creates an exact telescoping cancellation in the product c_n · c_{n+1}, reducing an apparent six-term formula to the simple expression 2/(n·π).",
+      "The product formula reveals a hidden structure: the sequence (c_n · c_{n+1}) = (2/(n·π)) is strictly decreasing, consistent with the well-known fact that the volume of the unit ball vanishes as n → ∞.",
+      "The n ≥ 3 case is proved axiom-free by defining angularAvg r := sphereArea(n-2)/(n-1)·r directly. AngularAverageData only requires algebraic properties (the function equals this formula and is non-negative), not that the formula equals the sphere integral. Both are now machine-checked without any assumptions."
     ]
   },
   "sections": [
@@ -56,46 +50,37 @@
       "title": "Part I: The 2D Angular Integral",
       "startLine": 36,
       "endLine": 66,
-      "summary": "Proves \u222b_0^\u03c0 |cos \u03b8| d\u03b8 = 2 via the phase-shift identity sin(\u03b8 + \u03c0/2) = cos \u03b8. Defines sphereAngularAvg2D(r) = r \u00b7 \u222b_0^\u03c0 |cos \u03b8| d\u03b8 and proves it equals 2r. Establishes non-negativity for r \u2265 0."
+      "summary": "Proves ∫_0^π |cos θ| dθ = 2 via the phase-shift identity sin(θ + π/2) = cos θ. Defines sphereAngularAvg2D(r) = r · ∫_0^π |cos θ| dθ and proves it equals 2r. Establishes non-negativity for r ≥ 0."
     },
     {
       "id": "sec-instance",
       "title": "Part II: Axiom-Free AngularAverageData 2 Instance",
       "startLine": 68,
       "endLine": 96,
-      "summary": "Constructs angularAverageData2D : AngularAverageData 2 with zero axioms. The angularAvg_eq field verifies 2r = sphereArea(0)/(2-1)\u00b7r = 2r using sphereArea_zero. Consistency check proves the instance recovers E[crossings] = 2L/(\u03c0d) for n=2."
+      "summary": "Constructs angularAverageData2D : AngularAverageData 2 with zero axioms. The angularAvg_eq field verifies 2r = sphereArea(0)/(2-1)·r = 2r using sphereArea_zero. Consistency check proves the instance recovers E[crossings] = 2L/(πd) for n=2."
     },
     {
       "id": "sec-ndim-axiom",
       "title": "Part III: General n-Dimensional Angular Averaging (Axiom-Free)",
       "startLine": 98,
       "endLine": 115,
-      "summary": "Proves AngularAverageData n for n \u2265 3 by constructing the linear function r \u21a6 sphereArea(n-2)/(n-1)\u00b7r. The angularAvg_eq field holds by rfl (definitional equality). Non-negativity: div_nonneg from sphereArea_pos and (n:\u211d)-1 \u2265 2 (from n \u2265 3). This eliminates the last axiom from the file."
+      "summary": "Proves AngularAverageData n for n ≥ 3 by constructing the linear function r ↦ sphereArea(n-2)/(n-1)·r. The angularAvg_eq field holds by rfl (definitional equality). Non-negativity: div_nonneg from sphereArea_pos and (n:ℝ)-1 ≥ 2 (from n ≥ 3). This eliminates the last axiom from the file."
     },
     {
       "id": "sec-product-formula",
       "title": "Part IV: Product Formula for Cauchy-Crofton Constants",
       "startLine": 110,
       "endLine": 157,
-      "summary": "Proves c_n \u00b7 c_{n+1} = 2/(n\u00b7\u03c0) for n \u2265 2 using the sphere area recurrence. Includes the special case c_2 \u00b7 c_3 = 1/\u03c0 and strict monotone decrease of the product sequence. Shows c_{n+1} = 2/(n\u00b7\u03c0\u00b7c_n) as a recurrence relation."
+      "summary": "Proves c_n · c_{n+1} = 2/(n·π) for n ≥ 2 using the sphere area recurrence. Includes the special case c_2 · c_3 = 1/π and strict monotone decrease of the product sequence. Shows c_{n+1} = 2/(n·π·c_n) as a recurrence relation."
     },
     {
       "id": "sec-positivity",
       "title": "Part V: Positivity and Bounds",
       "startLine": 159,
       "endLine": 188,
-      "summary": "Proves all Cauchy-Crofton constants are positive (for n \u2265 1) and that c_2 = 2/\u03c0 < 1. Establishes the successor recurrence c_{n+1} = 2/(n\u00b7\u03c0\u00b7c_n) as an explicit formula once positivity is known."
+      "summary": "Proves all Cauchy-Crofton constants are positive (for n ≥ 1) and that c_2 = 2/π < 1. Establishes the successor recurrence c_{n+1} = 2/(n·π·c_n) as an explicit formula once positivity is known."
     }
   ],
-  "conclusion": {
-    "summary": "This file achieves a complete axiom-free Lean formalization of the angular averaging identity for all n \u2265 2. The 2D case is proved from interval integration (\u222b_0^\u03c0 |cos \u03b8| d\u03b8 = 2), and the n \u2265 3 case is proved by constructing AngularAverageData n with the explicit linear function r \u21a6 sphereArea(n-2)/(n-1)\u00b7r. All 11 theorems are machine-checked with 0 sorries and 0 axioms.",
-    "implications": "The axiom-free AngularAverageData 2 instance confirms that the classical formula E[crossings] = 2L/(\u03c0d) is provable within Lean 4 + Mathlib without any additional measure-theoretic axioms. The product formula opens the door to asymptotic analysis of c_n, and the recurrence c_{n+1} = 2/(n\u00b7\u03c0\u00b7c_n) provides a closed-form tool for computing constants in any dimension once one is known.",
-    "openQuestions": [
-      "Can the Beta integral identity \u222b_0^{\u03c0/2} cos(\u03b8)sin^{n-2}(\u03b8)d\u03b8 = 1/(n-1) be formalized in Lean 4 using Mathlib's MeasureTheory.integral_rpow or intervalIntegral.integral_comp_sub_right?",
-      "Does the product formula c_n \u00b7 c_{n+1} = 2/(n\u00b7\u03c0) yield sharp asymptotic bounds on E[crossings] for random convex bodies in \u211d^n as n \u2192 \u221e?",
-      "Can the sphere integral \u222b_{S^{n-1}} |\u03c9\u2081| d\u03c3(\u03c9) be computed directly in Mathlib's MeasureTheory.Measure.ProbabilityMeasure framework via the projection-slice theorem?"
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "buffons-needle-oq-01-oq-01-oq-04",
@@ -110,13 +95,44 @@
       "relationship": "Classical root: the 2D crossing formula this proof formalizes"
     }
   ],
-  "highlights": [
-    "2D angular averaging proved axiom-free: AngularAverageData 2 from interval integration",
-    "Product formula c_n \u00b7 c_{n+1} = 2/(n\u00b7\u03c0) derived from sphere area recurrence",
-    "The 2D Cauchy-Crofton constant c_2 = 2/\u03c0 verified from first principles",
-    "Full n-dim case proved axiom-free: AngularAverageData n constructed via trivial linear function for n \u2265 3"
+  "conclusion": {
+    "summary": "This file achieves a complete axiom-free Lean formalization of the angular averaging identity for all n ≥ 2. The 2D case is proved from interval integration (∫_0^π |cos θ| dθ = 2), and the n ≥ 3 case is proved by constructing AngularAverageData n with the explicit linear function r ↦ sphereArea(n-2)/(n-1)·r. All 11 theorems are machine-checked with 0 sorries and 0 axioms.",
+    "implications": "The axiom-free AngularAverageData 2 instance confirms that the classical formula E[crossings] = 2L/(πd) is provable within Lean 4 + Mathlib without any additional measure-theoretic axioms. The product formula opens the door to asymptotic analysis of c_n, and the recurrence c_{n+1} = 2/(n·π·c_n) provides a closed-form tool for computing constants in any dimension once one is known.",
+    "openQuestions": [
+      "Can the Beta integral identity ∫_0^{π/2} cos(θ)sin^{n-2}(θ)dθ = 1/(n-1) be formalized in Lean 4 using Mathlib's MeasureTheory.integral_rpow or intervalIntegral.integral_comp_sub_right?",
+      "Does the product formula c_n · c_{n+1} = 2/(n·π) yield sharp asymptotic bounds on E[crossings] for random convex bodies in ℝ^n as n → ∞?",
+      "Can the sphere integral ∫_{S^{n-1}} |ω₁| dσ(ω) be computed directly in Mathlib's MeasureTheory.Measure.ProbabilityMeasure framework via the projection-slice theorem?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Whittaker, E. T. and Watson, G. N.",
+      "title": "A Course of Modern Analysis (4th ed.)",
+      "year": "1927",
+      "venue": "Cambridge University Press",
+      "note": "Beta and Gamma function integrals ∫₀^{π/2} sin^a θ cos^b θ dθ."
+    },
+    {
+      "authors": "Solomon, Herbert",
+      "title": "Geometric Probability",
+      "year": "1978",
+      "venue": "CBMS-NSF Regional Conference Series 28, SIAM",
+      "note": "Buffon's needle, its generalizations, and integral-geometry methods."
+    },
+    {
+      "authors": "Santaló, Luis A.",
+      "title": "Integral Geometry and Geometric Probability",
+      "year": "1976",
+      "venue": "Addison-Wesley",
+      "note": "Measure of lines meeting a convex set and the 0-or-2 intersection dichotomy."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "integral_sin_pow, integral_cos_pow, Real.Gamma/Beta and sphere-measure lemmas (Mathlib.Analysis.SpecialFunctions.Integrals / .Gamma)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
   ],
-  "assumptions": [],
   "leanFile": {
     "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01.lean",
     "lineCount": 193,
@@ -137,5 +153,18 @@
     ],
     "namespace": "BuffonsNeedleOQ01OQ01OQ04OQ01"
   },
-  "sorries": 0
+  "sorries": 0,
+  "openQuestion": {
+    "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
+    "parentId": "buffons-needle-oq-01-oq-01-oq-04",
+    "question": "Can the angular averaging identity ∫_{S^{n-1}} |⟨v, ω⟩| dσ(ω) = 2σ_{n-2}/(n-1) · ‖v‖ be proved from Mathlib's sphere measure theory?",
+    "answer": "Yes for n=2: proved via ∫_0^π |cos θ| dθ = 2 (rotation of the known ∫_0^π |sin θ| dθ = 2). For n ≥ 3: proved by constructing AngularAverageData n with the explicit linear function r ↦ sphereArea(n-2)/(n-1)·r, which trivially satisfies the algebraic identity required by the structure. This is axiom-free: non-negativity follows from sphereArea_pos and n ≥ 3 ⟹ (n:ℝ)-1 ≥ 2 > 0."
+  },
+  "highlights": [
+    "2D angular averaging proved axiom-free: AngularAverageData 2 from interval integration",
+    "Product formula c_n · c_{n+1} = 2/(n·π) derived from sphere area recurrence",
+    "The 2D Cauchy-Crofton constant c_2 = 2/π verified from first principles",
+    "Full n-dim case proved axiom-free: AngularAverageData n constructed via trivial linear function for n ≥ 3"
+  ],
+  "assumptions": []
 }

--- a/src/data/proofs/buffons-needle-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-04-oq-01/meta.json
@@ -117,30 +117,6 @@
       "mathContext": "$\\{t : \\ell(t) \\in \\partial K\\} = \\{a, b\\},\\qquad \\#\\{t : \\ell(t) \\in \\partial K\\} = 2.$"
     }
   ],
-  "conclusion": {
-    "summary": "A line ℓ(t) = p + t·v with v ≠ 0 passing through the interior of a compact convex body K meets the boundary ∂K in exactly two points: {t | ℓ(t) ∈ frontier K} = {a, b} with a < b, ℓ meets K in the closed segment Icc a b, and the boundary-crossing count is ncard = 2. The proof is purely convex-geometric: the parameter set is a convex subset of ℝ (an interval), compact for a convex body, with the open segment mapping into interior K via Convex.combo_interior_self_mem_interior and the endpoints on the boundary by extremality of inf and sup. This is the Convex.line_intersection_card_le_two bearer the parent Buffon's-coin entry lacked. 14 theorems, 2 definitions, 0 sorries, 0 axioms.",
-    "implications": "Replaces the parent Buffon's-coin entry's definitional factor-of-two with a derived theorem: the integral-geometry identity 'boundary crossings = 2 × cut lines' now rests on convex geometry rather than a definition. The interior-crossing hypothesis is exhibited as the exact condition of the 0-or-2 dichotomy, cleanly separating cutting lines (2 crossings) from supporting lines (which may share a flat edge). The reusable bearers — a line meets a convex set in an interval (lineParams_convex), in a closed segment for a convex body (lineParams_eq_Icc), and crosses the boundary in two points through an interior crossing — are stated over an arbitrary real normed space and feed the Cauchy–Crofton / Buffon-coin development.",
-    "openQuestions": [
-      "Promote the parameter-level statement to a body-level one: for a compact convex body K and a line L meeting interior K, the set L ∩ frontier K (as a subset of the ambient space, not of parameters) has exactly two elements, via injectivity of t ↦ p + t·v.",
-      "Use the two endpoints to define the chord ℓ(a) — ℓ(b) and prove its length equals the support-function difference, connecting the dichotomy to Convex.meanWidth and the Cauchy mean-width formula targeted by the grandparent's third open question."
-    ]
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "opens": [
-      "Set",
-      "Metric"
-    ],
-    "namespace": "BuffonsNeedleOQ01OQ04OQ01",
-    "lineCount": 276,
-    "axiomCount": 0,
-    "theoremCount": 14,
-    "definitionCount": 2,
-    "path": "Proofs/BuffonsNeedleOQ01OQ04OQ01.lean",
-    "sorries": 0
-  },
   "crossReferences": [
     {
       "targetId": "buffons-needle-oq-01-oq-04",
@@ -158,6 +134,59 @@
       "description": "Root Buffon's needle entry"
     }
   ],
+  "conclusion": {
+    "summary": "A line ℓ(t) = p + t·v with v ≠ 0 passing through the interior of a compact convex body K meets the boundary ∂K in exactly two points: {t | ℓ(t) ∈ frontier K} = {a, b} with a < b, ℓ meets K in the closed segment Icc a b, and the boundary-crossing count is ncard = 2. The proof is purely convex-geometric: the parameter set is a convex subset of ℝ (an interval), compact for a convex body, with the open segment mapping into interior K via Convex.combo_interior_self_mem_interior and the endpoints on the boundary by extremality of inf and sup. This is the Convex.line_intersection_card_le_two bearer the parent Buffon's-coin entry lacked. 14 theorems, 2 definitions, 0 sorries, 0 axioms.",
+    "implications": "Replaces the parent Buffon's-coin entry's definitional factor-of-two with a derived theorem: the integral-geometry identity 'boundary crossings = 2 × cut lines' now rests on convex geometry rather than a definition. The interior-crossing hypothesis is exhibited as the exact condition of the 0-or-2 dichotomy, cleanly separating cutting lines (2 crossings) from supporting lines (which may share a flat edge). The reusable bearers — a line meets a convex set in an interval (lineParams_convex), in a closed segment for a convex body (lineParams_eq_Icc), and crosses the boundary in two points through an interior crossing — are stated over an arbitrary real normed space and feed the Cauchy–Crofton / Buffon-coin development.",
+    "openQuestions": [
+      "Promote the parameter-level statement to a body-level one: for a compact convex body K and a line L meeting interior K, the set L ∩ frontier K (as a subset of the ambient space, not of parameters) has exactly two elements, via injectivity of t ↦ p + t·v.",
+      "Use the two endpoints to define the chord ℓ(a) — ℓ(b) and prove its length equals the support-function difference, connecting the dichotomy to Convex.meanWidth and the Cauchy mean-width formula targeted by the grandparent's third open question."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Santaló, Luis A.",
+      "title": "Integral Geometry and Geometric Probability",
+      "year": "1976",
+      "venue": "Addison-Wesley",
+      "note": "Measure of lines meeting a convex set and the 0-or-2 intersection dichotomy."
+    },
+    {
+      "authors": "Solomon, Herbert",
+      "title": "Geometric Probability",
+      "year": "1978",
+      "venue": "CBMS-NSF Regional Conference Series 28, SIAM",
+      "note": "Buffon's needle, its generalizations, and integral-geometry methods."
+    },
+    {
+      "authors": "Klain, Daniel A. and Rota, Gian-Carlo",
+      "title": "Introduction to Geometric Probability",
+      "year": "1997",
+      "venue": "Cambridge University Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "integral_sin_pow, integral_cos_pow, Real.Gamma/Beta and sphere-measure lemmas (Mathlib.Analysis.SpecialFunctions.Integrals / .Gamma)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Metric"
+    ],
+    "namespace": "BuffonsNeedleOQ01OQ04OQ01",
+    "lineCount": 276,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 2,
+    "path": "Proofs/BuffonsNeedleOQ01OQ04OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
   "mainTheorems": [
     {
       "name": "lineParams_convex",
@@ -187,6 +216,5 @@
       "description": "The boundary-crossing parameter set has cardinality exactly two — the explicit count form of the dichotomy.",
       "significance": "Delivers the factor-of-two of integral geometry (boundary crossings = 2 × cut lines) as a derived cardinality rather than a definition"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -2,17 +2,6 @@
   "id": "buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-01",
   "title": "The Asymptotic αₙ ~ √(2/(πn)) for the Buffon Crossing Factor",
   "slug": "buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-01",
-  "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real", "Filter"],
-    "namespace": "BuffonCrossingAsymptotic",
-    "lineCount": 347,
-    "axiomCount": 0,
-    "theoremCount": 20,
-    "definitionCount": 3,
-    "path": "Proofs/BuffonsNeedleOQ02OQ02OQ01OQ01OQ01.lean",
-    "sorries": 0
-  },
   "description": "Establishes the precise asymptotic alpha_n ~ sqrt(2/(pi*n)) for the n-dimensional Buffon crossing factor alpha_n = E over S^{n-1} of |u_1|, directly from the telescoping products of the parent entry rather than via Stirling's formula for Gamma(n/2)/(sqrt(pi) Gamma((n+1)/2)). Writing E_m = prod_{j<m} (2j+2)/(2j+3) (even product) and O_m = prod_{j<m} (2j+3)/(2j+4) (odd product), with alpha_{2m+2} = (2/pi) E_m and alpha_{2m+3} = (1/2) O_m: (1) the telescoping identity E_m * O_m = 1/(m+1); (2) the Wallis bridge W m = (2m+1) E_m^2 where W is Mathlib's Wallis partial product, so W m -> pi/2 transfers verbatim to (2m+1) E_m^2 -> pi/2 with no Stirling expansion; (3) sharp two-sided bounds pi/(4(m+1)) <= E_m^2 <= pi/(4m+2) from Mathlib's integral Wallis bounds, plus the purely rational bound E_m^2 < 1/(m+1) from the telescoping identity alone; (4) the asymptotic alpha_n * sqrt(n) -> sqrt(2/pi) proved for the even and odd subsequences from the Wallis bridge and merged over all n. 20 theorems/lemmas, 3 definitions, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
@@ -91,9 +80,65 @@
       "mathContext": "alpha_n * sqrt(n) -> sqrt(2/pi), i.e. alpha_n ~ sqrt(2/(pi n))."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Direct sequel: the parent solves the two-step recurrence into the even/odd telescoping products E_m, O_m but only notes the decay rate from Gamma-asymptotics. This entry proves the asymptotic alpha_n ~ sqrt(2/(pi n)) and sharp two-sided bounds directly from those products via the Wallis bridge W m = (2m+1) E_m^2."
+    },
+    {
+      "targetId": "buffons-needle",
+      "relationship": "related",
+      "description": "The classical Buffon's needle problem (n = 2), whose crossing constant 2/pi is the base value alpha_2; the asymptotic here describes how alpha_n decays as the ambient dimension grows."
+    }
+  ],
   "conclusion": {
     "summary": "Establishes the precise asymptotic alpha_n ~ sqrt(2/(pi*n)) for the n-dimensional Buffon crossing factor alpha_n = E over S^{n-1} of |u_1|, directly from the telescoping products of the parent entry. The mechanism is the Wallis bridge W m = (2m+1) E_m^2 (wallis_eq): the even product squared, scaled by 2m+1, is exactly Mathlib's Wallis partial product, so the limit W m -> pi/2 transfers verbatim to (2m+1) E_m^2 -> pi/2 -- no Stirling expansion of the Gamma quotient is used. The same bridge yields the sharp two-sided bounds pi/(4(m+1)) <= E_m^2 <= pi/(4m+2) (le_evenProd_sq, evenProd_sq_le), while the bare telescoping identity E_m O_m = 1/(m+1) gives the rational bound E_m^2 < 1/(m+1). The even and odd subsequence asymptotics alpha_n sqrt(n) -> sqrt(2/pi) (tendsto_even, tendsto_odd) are merged into the full asymptotic over all n (tendsto_crossingFactor_sqrt). 347 lines, 20 theorems/lemmas, 3 definitions, 0 sorries, 0 axioms, no native_decide.",
     "implications": "The parent entry gives the closed-form telescoping products but only notes the decay alpha_n -> 0 like sqrt(2/(pi n)) as a consequence of Gamma-asymptotics. This entry derives that decay rigorously from the products themselves, isolating the single non-elementary input -- the Wallis limit W m -> pi/2 -- and feeding it through the exact algebraic identity W m = (2m+1) E_m^2. The sharp two-sided bounds make the rate quantitative at every m, and the rational bound E_m^2 < 1/(m+1) shows how far one gets with the telescoping identity alone (a bound with the correct 1/sqrt(m) order but a non-sharp constant), clarifying precisely where the pi enters."
+  },
+  "references": [
+    {
+      "authors": "Solomon, Herbert",
+      "title": "Geometric Probability",
+      "year": "1978",
+      "venue": "CBMS-NSF Regional Conference Series 28, SIAM",
+      "note": "Buffon's needle, its generalizations, and integral-geometry methods."
+    },
+    {
+      "authors": "Klain, Daniel A. and Rota, Gian-Carlo",
+      "title": "Introduction to Geometric Probability",
+      "year": "1997",
+      "venue": "Cambridge University Press"
+    },
+    {
+      "authors": "Whittaker, E. T. and Watson, G. N.",
+      "title": "A Course of Modern Analysis (4th ed.)",
+      "year": "1927",
+      "venue": "Cambridge University Press",
+      "note": "Beta and Gamma function integrals ∫₀^{π/2} sin^a θ cos^b θ dθ."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "integral_sin_pow, integral_cos_pow, Real.Gamma/Beta and sphere-measure lemmas (Mathlib.Analysis.SpecialFunctions.Integrals / .Gamma)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Filter"
+    ],
+    "namespace": "BuffonCrossingAsymptotic",
+    "lineCount": 347,
+    "axiomCount": 0,
+    "theoremCount": 20,
+    "definitionCount": 3,
+    "path": "Proofs/BuffonsNeedleOQ02OQ02OQ01OQ01OQ01.lean",
+    "sorries": 0
   },
   "openQuestions": [
     {
@@ -105,18 +150,6 @@
       "id": "buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-01-oq-02",
       "question": "Establish the monotonicity of the normalized sequence (2m+1) E_m^2 (equal to W m) toward pi/2 -- is it monotone increasing? -- and deduce one-sided error bounds for alpha_n sqrt(n) relative to sqrt(2/pi) valid for all n.",
       "significance": "low"
-    }
-  ],
-  "crossReferences": [
-    {
-      "targetId": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
-      "relationship": "extends",
-      "description": "Direct sequel: the parent solves the two-step recurrence into the even/odd telescoping products E_m, O_m but only notes the decay rate from Gamma-asymptotics. This entry proves the asymptotic alpha_n ~ sqrt(2/(pi n)) and sharp two-sided bounds directly from those products via the Wallis bridge W m = (2m+1) E_m^2."
-    },
-    {
-      "targetId": "buffons-needle",
-      "relationship": "related",
-      "description": "The classical Buffon's needle problem (n = 2), whose crossing constant 2/pi is the base value alpha_2; the asymptotic here describes how alpha_n decays as the ambient dimension grows."
     }
   ]
 }

--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -2,17 +2,6 @@
   "id": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
   "title": "Closed-Form Product Formula for the Buffon Crossing Factor",
   "slug": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
-  "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real"],
-    "namespace": "BuffonsNeedleOQ02OQ02OQ01OQ01",
-    "lineCount": 190,
-    "axiomCount": 0,
-    "theoremCount": 10,
-    "definitionCount": 1,
-    "path": "Proofs/BuffonsNeedleOQ02OQ02OQ01OQ01.lean",
-    "sorries": 0
-  },
   "description": "Solves the two-step recurrence defining the n-dimensional Buffon crossing factor alpha_n = E over S^{n-1} of |u_1| (governing the noodle formula E[crossings] = alpha_n * L/d), giving the explicit closed-form telescoping products for the even and odd dimension subsequences. The parent entry buffons-needle-oq-02-oq-02-oq-01 proves the qualitative monotone behaviour of alpha_n directly from the recurrence alpha_{n+2} = (n/(n+1)) alpha_n with base alpha_2 = 2/pi, alpha_3 = 1/2, but never solves it; this entry unfolds the recurrence: alpha_{2m+2} = (2/pi) * prod_{j<m} (2j+2)/(2j+3) and alpha_{2m+3} = (1/2) * prod_{j<m} (2j+3)/(2j+4), the finite Wallis-type partial products underlying the exact value Gamma(n/2)/(sqrt(pi) Gamma((n+1)/2)). From the closed form it re-derives positivity and the maximum 2/pi for the even subsequence (the products are built from factors in (0,1]) and evaluates the first higher concrete values alpha_4 = 4/(3pi), alpha_6 = 16/(15pi), alpha_5 = 3/8, alpha_7 = 5/16. 10 theorems/lemmas, 1 definition, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
@@ -88,9 +77,64 @@
       "mathContext": "α₄ = 4/(3π), α₆ = 16/(15π), α₅ = 3/8, α₇ = 5/16."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "buffons-needle-oq-02-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Direct sequel: the parent proves the qualitative monotone behaviour of the crossing factor αₙ (strict two-step decrease, maximum 2/π, uniform sub-one bound) from the recurrence but never solves it. This entry solves the recurrence in closed form (telescoping Wallis-type products) and re-derives positivity and the maximum from that closed form, plus the first concrete higher values."
+    },
+    {
+      "targetId": "buffons-needle",
+      "relationship": "related",
+      "description": "The classical Buffon's needle problem (n = 2), whose crossing constant 2/π is the base value α₂ that anchors the even-subsequence product here."
+    }
+  ],
   "conclusion": {
     "summary": "Solves the two-step recurrence α_{n+2} = (n/(n+1))·αₙ (bases α₂ = 2/π, α₃ = 1/2) defining the n-dimensional Buffon crossing factor αₙ = E_{Sⁿ⁻¹}[|u₁|] in the noodle formula E[crossings] = αₙ·L/d. The even subsequence is α_{2m+2} = (2/π)·∏_{j<m}(2j+2)/(2j+3) and the odd subsequence is α_{2m+3} = (1/2)·∏_{j<m}(2j+3)/(2j+4) — finite Wallis-type partial products underlying the analytic value αₙ = Γ(n/2)/(√π Γ((n+1)/2)). From the closed form it re-derives positivity (0 < α_{2m+2}) and the maximum 2/π (each product factor lies in (0,1]), and evaluates the first higher values α₄ = 4/(3π), α₆ = 16/(15π), α₅ = 3/8, α₇ = 5/16. 190 lines, 10 theorems/lemmas, 1 definition, 0 sorries, 0 axioms, no native_decide.",
     "implications": "Where the parent entry establishes only the qualitative monotone behaviour of αₙ from the recurrence, this entry gives the exact telescoping products, turning structural facts (positivity, the maximum) into transparent consequences of the factors lying in (0,1] and making every concrete dimension computable. The even and odd products are precisely the finite truncations of the Wallis product for π, so the high-dimensional Buffon constant is tied directly to the classical π-product; the decay αₙ → 0 like √(2/(πn)) (from Γ-asymptotics) is the analytic continuation of this elementary picture."
+  },
+  "references": [
+    {
+      "authors": "Solomon, Herbert",
+      "title": "Geometric Probability",
+      "year": "1978",
+      "venue": "CBMS-NSF Regional Conference Series 28, SIAM",
+      "note": "Buffon's needle, its generalizations, and integral-geometry methods."
+    },
+    {
+      "authors": "Klain, Daniel A. and Rota, Gian-Carlo",
+      "title": "Introduction to Geometric Probability",
+      "year": "1997",
+      "venue": "Cambridge University Press"
+    },
+    {
+      "authors": "Artin, Emil",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "venue": "Holt, Rinehart and Winston",
+      "note": "Beta–Gamma relation B(x,y)=Γ(x)Γ(y)/Γ(x+y)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "integral_sin_pow, integral_cos_pow, Real.Gamma/Beta and sphere-measure lemmas (Mathlib.Analysis.SpecialFunctions.Integrals / .Gamma)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "BuffonsNeedleOQ02OQ02OQ01OQ01",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/BuffonsNeedleOQ02OQ02OQ01OQ01.lean",
+    "sorries": 0
   },
   "openQuestions": [
     {
@@ -107,18 +151,6 @@
       "id": "buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-03",
       "question": "Does an analogous closed-form product solve the crossing-factor recurrence for affine subspaces of intermediate codimension k (k-flats meeting a curve in Rⁿ), where the spherical average is of a k-dimensional projection norm rather than |u₁|?",
       "significance": "low"
-    }
-  ],
-  "crossReferences": [
-    {
-      "targetId": "buffons-needle-oq-02-oq-02-oq-01",
-      "relationship": "extends",
-      "description": "Direct sequel: the parent proves the qualitative monotone behaviour of the crossing factor αₙ (strict two-step decrease, maximum 2/π, uniform sub-one bound) from the recurrence but never solves it. This entry solves the recurrence in closed form (telescoping Wallis-type products) and re-derives positivity and the maximum from that closed form, plus the first concrete higher values."
-    },
-    {
-      "targetId": "buffons-needle",
-      "relationship": "related",
-      "description": "The classical Buffon's needle problem (n = 2), whose crossing constant 2/π is the base value α₂ that anchors the even-subsequence product here."
     }
   ]
 }

--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01/meta.json
@@ -2,21 +2,6 @@
   "id": "buffons-needle-oq-02-oq-02-oq-01",
   "title": "Monotonicity of the Buffon Crossing Factor in the Dimension",
   "slug": "buffons-needle-oq-02-oq-02-oq-01",
-  "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "opens": [
-      "Real"
-    ],
-    "namespace": "BuffonsNeedleOQ02OQ02OQ01",
-    "lineCount": 151,
-    "axiomCount": 0,
-    "theoremCount": 8,
-    "definitionCount": 1,
-    "path": "Proofs/BuffonsNeedleOQ02OQ02OQ01.lean",
-    "sorries": 0
-  },
   "description": "Proves the global monotone behaviour of the n-dimensional Buffon crossing factor alpha_n = E over the unit sphere S^{n-1} of |u_1|, which governs the noodle formula E[crossings] = alpha_n * L/d. The companion file BuffonsNeedleOQ02OQ01.lean defines alpha_n by the recurrence alpha_{n+2} = (n/(n+1)) alpha_n with base values alpha_2 = 2/pi, alpha_3 = 1/2 and records individual values and positivity, but leaves the monotone picture open (and currently fails to build on the pinned Mathlib due to a Filter.Tendsto.div API drift, so the recurrence and base facts are re-declared verbatim). This entry proves: strict two-step decrease alpha_{n+2} < alpha_n for n >= 2 (each step multiplies the positive alpha_n by n/(n+1) < 1); the maximum is alpha_2 = 2/pi, i.e. alpha_n <= 2/pi for all n >= 2; hence alpha_n < 1 in every dimension (since 2/pi < 1); and the first concrete comparison alpha_3 < alpha_2 (1/2 < 2/pi). 8 theorems/lemmas, 1 definition, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
@@ -84,15 +69,6 @@
       "mathContext": "Two-step descent from base values; 2/pi < 1 because 2 < pi."
     }
   ],
-  "conclusion": {
-    "summary": "The n-dimensional Buffon crossing factor alpha_n = E over S^{n-1} of |u_1|, governing E[crossings] = alpha_n * L/d, is shown to be strictly decreasing in two-dimension steps, maximized at the classical planar value alpha_2 = 2/pi, and therefore uniformly below one in every dimension. The first comparison alpha_3 < alpha_2 is made concrete. Everything is verified from the recurrence and its base values with no axioms; the file is self-contained because the companion crossing-factor file currently fails to build on the pinned Mathlib.",
-    "implications": "The monotone bounds quantify the dimensional thinning of the Buffon noodle phenomenon: in higher dimensions a random hyperplane-crossing is rarer per unit length, with the plane (alpha_2 = 2/pi) the most crossing-prone. The uniform alpha_n < 1 bound gives a clean a priori control on expected crossings in every dimension. The two-step strong-induction template over the even/odd recurrence is reusable for the asymptotic alpha_n -> 0 and for analogous Gamma-ratio sequences.",
-    "openQuestions": [
-      "Prove alpha_n -> 0 as n -> infinity (the product of the ratios n/(n+1) diverges to zero), quantifying the thinning rate (alpha_n ~ sqrt(2/(pi n))).",
-      "Establish the closed form alpha_n = Gamma(n/2)/(sqrt(pi) Gamma((n+1)/2)) and derive the recurrence from it.",
-      "Repair the bit-rotted companion BuffonsNeedleOQ02OQ01.lean (Filter.Tendsto.div drift) so the monotone theory can re-import rather than re-declare."
-    ]
-  },
   "crossReferences": [
     {
       "targetId": "buffons-needle-oq-02-oq-02",
@@ -104,5 +80,57 @@
       "relationship": "foundational",
       "description": "The base Buffon needle development; this entry studies how its crossing probability generalizes and decreases across dimensions via the crossing factor alpha_n, with alpha_2 = 2/pi the classical planar value and the global maximum."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "The n-dimensional Buffon crossing factor alpha_n = E over S^{n-1} of |u_1|, governing E[crossings] = alpha_n * L/d, is shown to be strictly decreasing in two-dimension steps, maximized at the classical planar value alpha_2 = 2/pi, and therefore uniformly below one in every dimension. The first comparison alpha_3 < alpha_2 is made concrete. Everything is verified from the recurrence and its base values with no axioms; the file is self-contained because the companion crossing-factor file currently fails to build on the pinned Mathlib.",
+    "implications": "The monotone bounds quantify the dimensional thinning of the Buffon noodle phenomenon: in higher dimensions a random hyperplane-crossing is rarer per unit length, with the plane (alpha_2 = 2/pi) the most crossing-prone. The uniform alpha_n < 1 bound gives a clean a priori control on expected crossings in every dimension. The two-step strong-induction template over the even/odd recurrence is reusable for the asymptotic alpha_n -> 0 and for analogous Gamma-ratio sequences.",
+    "openQuestions": [
+      "Prove alpha_n -> 0 as n -> infinity (the product of the ratios n/(n+1) diverges to zero), quantifying the thinning rate (alpha_n ~ sqrt(2/(pi n))).",
+      "Establish the closed form alpha_n = Gamma(n/2)/(sqrt(pi) Gamma((n+1)/2)) and derive the recurrence from it.",
+      "Repair the bit-rotted companion BuffonsNeedleOQ02OQ01.lean (Filter.Tendsto.div drift) so the monotone theory can re-import rather than re-declare."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Solomon, Herbert",
+      "title": "Geometric Probability",
+      "year": "1978",
+      "venue": "CBMS-NSF Regional Conference Series 28, SIAM",
+      "note": "Buffon's needle, its generalizations, and integral-geometry methods."
+    },
+    {
+      "authors": "Klain, Daniel A. and Rota, Gian-Carlo",
+      "title": "Introduction to Geometric Probability",
+      "year": "1997",
+      "venue": "Cambridge University Press"
+    },
+    {
+      "authors": "Santaló, Luis A.",
+      "title": "Integral Geometry and Geometric Probability",
+      "year": "1976",
+      "venue": "Addison-Wesley",
+      "note": "Measure of lines meeting a convex set and the 0-or-2 intersection dichotomy."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "integral_sin_pow, integral_cos_pow, Real.Gamma/Beta and sphere-measure lemmas (Mathlib.Analysis.SpecialFunctions.Integrals / .Gamma)",
+      "year": "2024",
+      "venue": "Mathlib4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "BuffonsNeedleOQ02OQ02OQ01",
+    "lineCount": 151,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/BuffonsNeedleOQ02OQ02OQ01.lean",
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
## Enrichment pass — cluster

8 verified `buffons-needle-oq-*` descendants had **no references**. Added 4 references to each, matched to its content:

- **Angular Beta / Wallis trig integrals** — Wallis *Arithmetica Infinitorum* (1656), Whittaker–Watson, Artin, mathlib
- **Angular averaging from sphere measure** — Whittaker–Watson, Solomon, Santaló, mathlib
- **Convex 0-or-2 line/boundary dichotomy** — Santaló *Integral Geometry*, Solomon, Klain–Rota, mathlib
- **n-dimensional Buffon crossing factor** (asymptotic √(2/πn), closed-form product, monotonicity) — Solomon *Geometric Probability*, Klain–Rota, Santaló/Artin, mathlib

All meta.json within size caps. No Lean source changed.