### PR TITLE
Enrich jensen-inequality OQ cluster: add references to 11 entries

### DIFF
--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -98,6 +98,37 @@
       "mathContext": "$A(q)^{r-p}=A(p)^{r-q}A(r)^{q-p}\\iff x\\ \\text{constant}$, $a=\\tfrac{r-q}{r-p},\\ b=\\tfrac{q-p}{r-p}$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Lyapunov, A.M."
+      ],
+      "title": "Nouvelle forme du théorème sur la limite de probabilité",
+      "year": "1901",
+      "venue": "Mémoires de l'Académie Impériale des Sciences de St.-Pétersbourg (8), vol. 12, no. 5",
+      "note": "Source of Lyapunov's moment inequality, i.e. the log-convexity of the moment function."
+    },
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "The canonical reference for AM–GM, power means, Young, Hölder, Minkowski and Jensen inequalities, including their equality cases."
+    },
+    {
+      "authors": [
+        "Bullen, P.S."
+      ],
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Mathematics and Its Applications 560, Kluwer/Springer",
+      "note": "Encyclopaedic treatment of weighted power means and the comparison inequalities between them."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified 216-line file (0 sorries, 0 axioms, no native_decide; all theorems depend only on propext/Classical.choice/Quot.sound) settles the equality case of Lyapunov's inequality: for distinct exponents p ≠ r, the interpolation bound A(a·p+b·r) ≤ A(p)^a·A(r)^b is an equality iff the data x is constant. It also delivers the strict inequality for non-constant data and the equality case of the symmetric three-exponent form. The single equality input is the two-variable weighted AM–GM equality case, applied pointwise to normalised moment families and summed, with the rigidity packaged in the reusable abstract lemma normalized_amgm_sum_eq_one_iff.",
     "implications": "The result completes the rigidity picture for the discrete Lyapunov inequality: log-convexity of moments is strict precisely off the single-point locus, so the gallery's power-mean monotonicity and power-mean equality entries are exposed as first- and second-order shadows of one convexity phenomenon. The abstract core (a summed AM–GM is an equality iff termwise) is a reusable template for the equality case of any inequality obtained by summing pointwise weighted AM–GM, including discrete Hölder and Minkowski.",

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -100,6 +100,47 @@
       "mathContext": "$A(q)^{r-p}\\le \\big(A(p)^a A(r)^b\\big)^{r-p}=A(p)^{r-q}A(r)^{q-p}$ with $a=\\tfrac{r-q}{r-p},\\ b=\\tfrac{q-p}{r-p}$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Lyapunov, A.M."
+      ],
+      "title": "Nouvelle forme du théorème sur la limite de probabilité",
+      "year": "1901",
+      "venue": "Mémoires de l'Académie Impériale des Sciences de St.-Pétersbourg (8), vol. 12, no. 5",
+      "note": "Source of Lyapunov's moment inequality, i.e. the log-convexity of the moment function."
+    },
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "The canonical reference for AM–GM, power means, Young, Hölder, Minkowski and Jensen inequalities, including their equality cases."
+    },
+    {
+      "authors": [
+        "Bullen, P.S."
+      ],
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Mathematics and Its Applications 560, Kluwer/Springer",
+      "note": "Encyclopaedic treatment of weighted power means and the comparison inequalities between them."
+    },
+    {
+      "authors": [
+        "The mathlib community"
+      ],
+      "title": "Mathlib.Analysis.MeanInequalities",
+      "year": "2020",
+      "venue": "Mathlib4, Lean 4 mathematical library",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/MeanInequalities.html",
+      "note": "Mathlib's weighted AM–GM (Real.geom_mean_le_arith_mean_weighted) and single-exponent Jensen bounds, the engines these entries build on."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified 170-line file (0 sorries, 0 axioms, no native_decide; all theorems depend only on propext/Classical.choice/Quot.sound) proves Lyapunov's inequality for the weighted moment function A(t) = ∑_i w_i·x_i^t in three faces: the interpolation inequality A(a·p+b·r) ≤ A(p)^a·A(r)^b, the log-convexity of t ↦ log A(t) on ℝ, and the symmetric three-exponent form A(q)^{r-p} ≤ A(p)^{r-q}·A(r)^{q-p}. The entire argument is a single application of the two-function discrete Hölder inequality from the parent generalized-Hölder entry.",
     "implications": "Log-convexity of moments is the discrete, elementary core of the interpolation theory of Lᵖ spaces and a structural refinement of the power-mean inequality. It exposes that the monotonicity of power means is the first-order shadow of a second-order convexity phenomenon, and it is the finite-sum prototype of the Lyapunov / Riesz–Thorin interpolation inequalities.",

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -90,6 +90,46 @@
       "mathContext": "$\\sum_i u_i v_i \\le \\big(\\sum_i u_i^p\\big)^{1/p}\\big(\\sum_i v_i^q\\big)^{1/q}$ for $p,q>0$ with $p^{-1}+q^{-1}=1$, evaluated via $\\mathrm{Fin.prod\\_univ\\_two}$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hölder, O."
+      ],
+      "title": "Über einen Mittelwertsatz",
+      "year": "1889",
+      "venue": "Nachrichten von der Königl. Gesellschaft der Wissenschaften zu Göttingen, pp. 38–47",
+      "note": "Classical source of Hölder's inequality (anticipated by Rogers, 1888)."
+    },
+    {
+      "authors": [
+        "Rogers, L.J."
+      ],
+      "title": "An extension of a certain theorem in inequalities",
+      "year": "1888",
+      "venue": "Messenger of Mathematics 17, pp. 145–150",
+      "note": "Earliest form of what is now called Hölder's inequality."
+    },
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "The canonical reference for AM–GM, power means, Young, Hölder, Minkowski and Jensen inequalities, including their equality cases."
+    },
+    {
+      "authors": [
+        "Steele, J.M."
+      ],
+      "title": "The Cauchy–Schwarz Master Class: An Introduction to the Art of Mathematical Inequalities",
+      "year": "2004",
+      "venue": "Cambridge University Press / MAA",
+      "note": "Modern exposition emphasising Young, Hölder and the AM–GM equality (saturation) conditions."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified 134-line file (0 sorries, 0 axioms, no native_decide) supplies the generalized n-fold Hölder inequality for finite sums, which Mathlib does not provide. The proof factors through the n-variable Young product inequality (young_product), itself a one-line consequence of Mathlib's weighted AM–GM, and the standard normalization-by-Lᵖ-norm argument. The classical two-function Hölder inequality is recovered as a Fin 2 specialization.",
     "implications": "Together with the parent entries this completes the AM–GM → Young → Hölder ladder for finite sums: weighted AM–GM gives the pointwise Young product inequality, and normalization lifts it to the n-fold Hölder bound. The generalized form is the tool for estimating sums of products of more than two factors (e.g. interpolation inequalities and products of Lᵖ functions), where the two-exponent Hölder inequality does not directly apply.",

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -105,6 +105,37 @@
       "mathContext": "If $\\exists j\\,k,\\ x_j \\ne x_k$ then $(\\sum_i w_i x_i^{-1})^{-1} < \\sum_i w_i x_i$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "The canonical reference for AM–GM, power means, Young, Hölder, Minkowski and Jensen inequalities, including their equality cases."
+    },
+    {
+      "authors": [
+        "Bullen, P.S."
+      ],
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Mathematics and Its Applications 560, Kluwer/Springer",
+      "note": "Encyclopaedic treatment of weighted power means and the comparison inequalities between them."
+    },
+    {
+      "authors": [
+        "Cauchy, A.-L."
+      ],
+      "title": "Cours d'analyse de l'École Royale Polytechnique, I: Analyse algébrique",
+      "year": "1821",
+      "venue": "Paris (Note II)",
+      "note": "Cauchy's forward–backward induction proof of the arithmetic–geometric mean inequality."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified 124-line file (0 sorries, 0 axioms, no native_decide) supplies the weighted arithmetic–harmonic mean inequality and its equality case — the M₋₁ ≤ M₁ rung of the weighted power-mean ladder — which Mathlib does not separately provide. The proof is a clean double application of the gallery parent's weighted AM–GM inequality and its equality case, bracketing the weighted geometric mean between the harmonic and arithmetic means.",
     "implications": "Together with the parent entries this completes the base H ≤ G ≤ A of the weighted power-mean chain: weighted AM–GM gives both G ≤ A and (read through reciprocals) H ≤ G. The same bracketing makes the equality cases uniform — all three means coincide exactly when the data are constant.",

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -90,6 +90,37 @@
       "mathContext": "$\\|\\textstyle\\sum_j c_j\\,h\\|_p = \\|(\\sum_j c_j)\\,h\\|_p = (\\sum_j c_j)\\|h\\|_p = \\sum_j c_j\\|h\\|_p = \\sum_j \\|c_j\\,h\\|_p$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Minkowski, H."
+      ],
+      "title": "Geometrie der Zahlen",
+      "year": "1896",
+      "venue": "B.G. Teubner, Leipzig",
+      "note": "Origin of Minkowski's inequality, the triangle inequality for the ℓᵖ norm; collinearity is its equality case."
+    },
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "The canonical reference for AM–GM, power means, Young, Hölder, Minkowski and Jensen inequalities, including their equality cases."
+    },
+    {
+      "authors": [
+        "Steele, J.M."
+      ],
+      "title": "The Cauchy–Schwarz Master Class: An Introduction to the Art of Mathematical Inequalities",
+      "year": "2004",
+      "venue": "Cambridge University Press / MAA",
+      "note": "Modern exposition emphasising Young, Hölder and the AM–GM equality (saturation) conditions."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified 95-line file (0 sorries, 0 axioms, no native_decide) establishes the positive homogeneity and definiteness of the discrete ℓᵖ norm and the saturation case of the finite-family Minkowski inequality: equality holds on a common ray F_j = c_j·h for every p > 0. The saturation proof needs no inequality — collinearity collapses both sides to (∑_j c_j)·‖h‖_p by homogeneity. None of these elementary closed-form facts are in Mathlib.",
     "implications": "Together with the sibling subadditivity entry, this assembles all three seminorm/norm axioms for the discrete ℓᵖ norm — homogeneity, definiteness, and the triangle inequality — in elementary form, and pins the extremal configurations of the ℓᵖ triangle inequality. The saturation-on-rays result is the forward half of the Minkowski equality case and the natural foundation for the converse rigidity statement.",

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01/meta.json
@@ -80,6 +80,37 @@
       "id": "am-qm-corollaries"
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Jensen, J.L.W.V."
+      ],
+      "title": "Sur les fonctions convexes et les inégalités entre les valeurs moyennes",
+      "year": "1906",
+      "venue": "Acta Mathematica 30, pp. 175–193",
+      "note": "Origin of Jensen's inequality; the strict-convexity equality case underlies this entry."
+    },
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "The canonical reference for AM–GM, power means, Young, Hölder, Minkowski and Jensen inequalities, including their equality cases."
+    },
+    {
+      "authors": [
+        "Bullen, P.S."
+      ],
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Mathematics and Its Applications 560, Kluwer/Springer",
+      "note": "Encyclopaedic treatment of weighted power means and the comparison inequalities between them."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified 176-line file (0 sorries, 0 axioms, no native_decide) determines the equality case of the power-mean inequality: for 0 < r < t with strictly positive weights summing to 1 and strictly positive data, M_r(z) = M_t(z) if and only if all the data z_i are equal, hence M_r < M_t strictly off the constant diagonal. The engine is a single application of the equality case of strict Jensen (jensen_eq_iff) to the strictly convex map x ↦ x^{t/r} on the powered data z_i^r, with the two translations between the means and the data both supplied by injectivity of x ↦ x^c on the nonnegative reals. Neither the power mean nor its equality case is in Mathlib.",
     "implications": "This sharpens the parent's non-strict power-mean monotonicity into a strict characterization, pinning the extremal (constant-data) configuration of the entire positive-exponent mean hierarchy. The r=1, t=2 instance is the strict QM–AM inequality — the algebraic statement that the quadratic mean strictly exceeds the arithmetic mean for any non-constant family, i.e. strict positivity of variance. It mirrors, for power functions, the AM–GM equality case the grandparent obtains from the same jensen_eq_iff applied to exp.",

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04/meta.json
@@ -90,6 +90,38 @@
       "mathContext": "$\\sum_i w_i x_i \\le M_p$ for $p\\ge1$; QM–AM: $\\sum_i w_i x_i \\le \\big(\\sum_i w_i x_i^2\\big)^{1/2}$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "The canonical reference for AM–GM, power means, Young, Hölder, Minkowski and Jensen inequalities, including their equality cases."
+    },
+    {
+      "authors": [
+        "Bullen, P.S."
+      ],
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Mathematics and Its Applications 560, Kluwer/Springer",
+      "note": "Encyclopaedic treatment of weighted power means and the comparison inequalities between them."
+    },
+    {
+      "authors": [
+        "Mitrinović, D.S.",
+        "Vasić, P.M."
+      ],
+      "title": "Analytic Inequalities",
+      "year": "1970",
+      "venue": "Grundlehren der mathematischen Wissenschaften 165, Springer",
+      "note": "Systematic development of the classical mean and convexity inequalities."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified file (0 sorries, 0 axioms, no native_decide) supplies the classical power-mean inequality — monotonicity of the weighted power mean M_p(x) = (∑ w_i x_i^p)^{1/p} in the exponent p on the positive reals — which Mathlib does not provide. The proof is a single application of Mathlib's single-exponent Jensen bound rpow_arith_mean_le_arith_mean_rpow to the powered data x_i^p with exponent q/p, followed by rpow-monotonicity. The weighted arithmetic-mean lower bound and the QM–AM (root-mean-square) inequality are recovered as specializations.",
     "implications": "The power-mean inequality is the unifying statement behind the elementary mean inequalities on positive exponents: AM ≤ QM (root-mean-square), and more generally M_p ≤ M_q for 0 < p ≤ q. Combined with the parent Young/AM–GM entry and the sibling Hölder entry, it rounds out the Jensen-driven family of finite-sum inequalities, all of which descend from convexity of a single elementary function.",

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/meta.json
@@ -83,6 +83,46 @@
       "mathContext": "$\\prod_i a_i = \\sum_i a_i^{p_i}/p_i \\iff \\forall j,k,\\ a_j^{p_j}=a_k^{p_k}$. Apply weighted AM–GM with $w_i=p_i^{-1}$, $z_i=a_i^{p_i}$; rewrite $\\prod z_i^{w_i}=\\prod a_i$ and $\\sum w_i z_i=\\sum a_i^{p_i}/p_i$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Young, W.H."
+      ],
+      "title": "On classes of summable functions and their Fourier series",
+      "year": "1912",
+      "venue": "Proceedings of the Royal Society A 87 (594), pp. 225–229",
+      "note": "Original source of Young's product inequality ab ≤ aᵖ/p + bᵍ/q."
+    },
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "The canonical reference for AM–GM, power means, Young, Hölder, Minkowski and Jensen inequalities, including their equality cases."
+    },
+    {
+      "authors": [
+        "Bullen, P.S."
+      ],
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Mathematics and Its Applications 560, Kluwer/Springer",
+      "note": "Encyclopaedic treatment of weighted power means and the comparison inequalities between them."
+    },
+    {
+      "authors": [
+        "Steele, J.M."
+      ],
+      "title": "The Cauchy–Schwarz Master Class: An Introduction to the Art of Mathematical Inequalities",
+      "year": "2004",
+      "venue": "Cambridge University Press / MAA",
+      "note": "Modern exposition emphasising Young, Hölder and the AM–GM equality (saturation) conditions."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified 95-line file (0 sorries, 0 axioms, no native_decide) adds the general n-variable Young product inequality ∏ aᵢ ≤ ∑ aᵢ^{pᵢ}/pᵢ (for ∑ 1/pᵢ = 1) together with its equality case — equality iff all the aᵢ^{pᵢ} are equal — neither of which Mathlib provides beyond the two-variable Young inequality. Both descend from the grandparent entry's general weighted AM–GM inequality and equality characterization, applied with weights 1/pᵢ and data aᵢ^{pᵢ}. The strict form young_prod_lt_of_ne rounds out the entry. It directly answers the parent entry's listed open question on the n-fold generalized Young equality case.",
     "implications": "The general product form is the pointwise engine behind the generalized Hölder inequality for n functions, and its equality case identifies exactly when that bound is tight (all aᵢ^{pᵢ} proportional pointwise), making it a rigidity tool. Deriving it as a corollary of weighted AM–GM exhibits the uniform mechanism — apply the AM–GM equality case in the coordinates wᵢ = 1/pᵢ, zᵢ = aᵢ^{pᵢ} — that yields the equality cases throughout the Young–Hölder family, with the two-variable Young inequality recovered as the n = 2 case.",

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01/meta.json
@@ -78,6 +78,47 @@
       "mathContext": "$ab=a^p/p+b^q/q\\iff a^p=b^q$. Apply amgm_two_weighted_eq_iff with $w_x=p^{-1}$, $w_y=q^{-1}$, $x=a^p$, $y=b^q$; $(a^p)^{p^{-1}}=a$ via $a^{p\\cdot p^{-1}}=a^1$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Young, W.H."
+      ],
+      "title": "On classes of summable functions and their Fourier series",
+      "year": "1912",
+      "venue": "Proceedings of the Royal Society A 87 (594), pp. 225–229",
+      "note": "Original source of Young's product inequality ab ≤ aᵖ/p + bᵍ/q."
+    },
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "The canonical reference for AM–GM, power means, Young, Hölder, Minkowski and Jensen inequalities, including their equality cases."
+    },
+    {
+      "authors": [
+        "Bullen, P.S."
+      ],
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Mathematics and Its Applications 560, Kluwer/Springer",
+      "note": "Encyclopaedic treatment of weighted power means and the comparison inequalities between them."
+    },
+    {
+      "authors": [
+        "The mathlib community"
+      ],
+      "title": "Mathlib.Analysis.MeanInequalities",
+      "year": "2020",
+      "venue": "Mathlib4, Lean 4 mathematical library",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/MeanInequalities.html",
+      "note": "Mathlib's weighted AM–GM (Real.geom_mean_le_arith_mean_weighted) and single-exponent Jensen bounds, the engines these entries build on."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified 89-line file (0 sorries, 0 axioms, no native_decide) adds the equality case of Young's inequality — a·b = aᵖ/p + bᵍ/q ↔ aᵖ = bᵍ — which Mathlib's library does not provide. It is obtained by recognizing Young's inequality as the two-term weighted AM–GM inequality (weights 1/p, 1/q on data aᵖ, bᵍ) and inheriting the equality characterization from the parent entry's weighted_amgm_eq_iff. The strict form young_lt_of_ne and a re-export young_le of the inequality itself round out the entry.",
     "implications": "The equality case is what makes Young's inequality usable as a rigidity tool: it identifies exactly when the pointwise bound underlying Hölder's inequality is tight, hence the extremizers of Hölder (proportional |f|ᵖ and |g|ᵍ). Recording Young as a corollary of weighted AM–GM also shows the uniform mechanism — apply the AM–GM equality case in the right coordinates — that yields the equality cases of the whole Hölder–Minkowski family.",

--- a/src/data/proofs/jensen-inequality-oq-01-oq-02/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-02/meta.json
@@ -79,6 +79,38 @@
       "mathContext": "$\\sum_i w_i z_i \\le \\left(\\sum_i w_i z_i^2\\right)^{1/2}$, the weighted AM–QM inequality."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "The canonical reference for AM–GM, power means, Young, Hölder, Minkowski and Jensen inequalities, including their equality cases."
+    },
+    {
+      "authors": [
+        "Bullen, P.S."
+      ],
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Mathematics and Its Applications 560, Kluwer/Springer",
+      "note": "Encyclopaedic treatment of weighted power means and the comparison inequalities between them."
+    },
+    {
+      "authors": [
+        "Mitrinović, D.S.",
+        "Vasić, P.M."
+      ],
+      "title": "Analytic Inequalities",
+      "year": "1970",
+      "venue": "Grundlehren der mathematischen Wissenschaften 165, Springer",
+      "note": "Systematic development of the classical mean and convexity inequalities."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified 87-line file (0 sorries, 0 axioms, no native_decide) proves weighted power-mean monotonicity over positive exponents — 0 < p ≤ q ⟹ M_p ≤ M_q — which Mathlib does not package, and recovers the weighted arithmetic-mean ≤ quadratic-mean inequality as a specialization. The proof is a single change of variable on Mathlib's rpow Jensen inequality.",
     "implications": "This answers, over the positive range, the open question posed by the AM–HM sibling entry: the full power-mean ladder M_r is monotone in r. The same change-of-variable template would extend to negative exponents (with the inequality direction tracked through the sign of the ratio) and, in the limit, to the geometric-mean rung M_r → G as r → 0.",

--- a/src/data/proofs/jensen-inequality-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01/meta.json
@@ -86,6 +86,47 @@
       "mathContext": "The $n=2$ unweighted case: $\\sqrt{ab}=\\tfrac{a+b}{2}\\iff a=b$. Writing $u=\\sqrt a$, $v=\\sqrt b$, equality reads $uv=\\tfrac{u^2+v^2}{2}$, i.e. $(u-v)^2=0$, so $u=v$ and $a=b$."
     }
   ],
+  "references": [
+    {
+      "authors": [
+        "Jensen, J.L.W.V."
+      ],
+      "title": "Sur les fonctions convexes et les inégalités entre les valeurs moyennes",
+      "year": "1906",
+      "venue": "Acta Mathematica 30, pp. 175–193",
+      "note": "Origin of Jensen's inequality; the strict-convexity equality case underlies this entry."
+    },
+    {
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
+      "title": "Inequalities",
+      "year": "1952",
+      "venue": "2nd ed., Cambridge University Press",
+      "note": "The canonical reference for AM–GM, power means, Young, Hölder, Minkowski and Jensen inequalities, including their equality cases."
+    },
+    {
+      "authors": [
+        "Steele, J.M."
+      ],
+      "title": "The Cauchy–Schwarz Master Class: An Introduction to the Art of Mathematical Inequalities",
+      "year": "2004",
+      "venue": "Cambridge University Press / MAA",
+      "note": "Modern exposition emphasising Young, Hölder and the AM–GM equality (saturation) conditions."
+    },
+    {
+      "authors": [
+        "The mathlib community"
+      ],
+      "title": "Mathlib.Analysis.MeanInequalities",
+      "year": "2020",
+      "venue": "Mathlib4, Lean 4 mathematical library",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/MeanInequalities.html",
+      "note": "Mathlib's weighted AM–GM (Real.geom_mean_le_arith_mean_weighted) and single-exponent Jensen bounds, the engines these entries build on."
+    }
+  ],
   "conclusion": {
     "summary": "This fully verified 124-line file (0 sorries, 0 axioms, no native_decide) packages the equality case of strict Jensen and its specialization to the sharp weighted AM–GM equality. The headline characterization weighted_amgm_eq_iff states that the weighted geometric and arithmetic means of positive data coincide iff all the data are equal, and weighted_amgm_lt_of_ne derives the strict gap directly from the strict convexity of exp, making the Jensen → AM–GM bridge explicit. The classic two-variable instance √(ab) = (a+b)/2 ↔ a = b is included as a concrete corollary.",
     "implications": "Equality characterizations are what make mean inequalities usable in optimization and probability: knowing AM–GM is tight exactly on constant data turns a bound into a rigidity statement (e.g. extremizers of geometric-vs-arithmetic-mean ratios are forced to be balanced). Recording the convexity bridge as named lemmas — jensen_eq_iff, weighted_amgm_eq_iff, weighted_amgm_lt_of_ne — makes the standard 'apply exp-Jensen' argument reusable for the other classical inequalities (Hölder, Young) that descend from convexity.",


### PR DESCRIPTION
Adds a top-level `references` array to all 11 open-question descendants of the **jensen-inequality** cluster, none of which previously carried any references.

## Entries enriched
`jensen-inequality-oq-01` and its OQ tree — equality case of strict Jensen & sharp AM–GM, Young's inequality + equality case, n-variable Young, generalized n-fold Hölder, Lyapunov's inequality (log-convexity of the moment function) + its equality case, weighted AM–HM inequality, sharpness of generalized Minkowski, monotonicity of the weighted power mean + its equality case, and the sibling power-mean monotonicity entry.

## Method
Each entry receives the canonical classical sources for its specific result:
- **Shared core:** Hardy–Littlewood–Pólya, *Inequalities* (1952); Bullen, *Handbook of Means and Their Inequalities* (2003); Mitrinović, *Analytic Inequalities* (1970); Steele, *The Cauchy–Schwarz Master Class* (2004).
- **Angle-specific primary sources:** Jensen (1906), Young (1912), Hölder (1889) / Rogers (1888), Minkowski (1896), Lyapunov (1901), Cauchy (1821), plus the relevant Mathlib `MeanInequalities` module where the entry builds directly on it.

Citations were matched to each entry's `description` (3–4 per entry, well under the 25-item cap).

## Verification
References-only change: a canonicalization check confirms **no non-`references` key of any `meta.json` was altered** vs `origin/main`. Gallery data generation (`pnpm build`) enriched all 2220 problems successfully.